### PR TITLE
Daily Regression Pass & Tension Messaging Update

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -2,9 +2,9 @@
 > dev
 > vite
 
-Port 3000 is in use, trying another one...
 
-  VITE v7.3.1  ready in 376 ms
+  VITE v7.3.1  ready in 346 ms
 
-  ➜  Local:   http://localhost:3001/
+  ➜  Local:   http://localhost:3000/
   ➜  Network: use --host to expose
+5:40:52 PM [vite] (client) page reload src/core/game-simulator.js

--- a/src/core/game-simulator.js
+++ b/src/core/game-simulator.js
@@ -619,11 +619,25 @@ export function generatePostGameCallbacks(context, stats, homeScore, awayScore) 
     }
 
     // 7. Stakes Callbacks
-    if (stakes && stakes > 50) {
-        if (won) {
-            callbacks.push(`${stakes >= 90 ? 'Season-defining' : 'Clutch'} performance when it mattered most — ${userScore}-${oppScore}.`);
-        } else {
-            callbacks.push(`Crushing ${scoreDiff}-point defeat when the stakes couldn't be higher.`);
+    if (stakes) {
+        if (stakes >= 90) {
+            if (won) {
+                callbacks.push(`A legendary, season-defining victory under immense pressure (${userScore}-${oppScore}).`);
+            } else {
+                callbacks.push(`Heartbreaking loss on the biggest stage. The locker room is devastated.`);
+            }
+        } else if (stakes >= 75) {
+            if (won) {
+                callbacks.push(`Clutch performance when the lights were brightest, securing a crucial ${userScore}-${oppScore} win.`);
+            } else {
+                callbacks.push(`A crushing ${scoreDiff}-point defeat in a must-win situation.`);
+            }
+        } else if (stakes >= 50) {
+            if (won) {
+                callbacks.push(`A gritty, important win to keep the momentum going (${userScore}-${oppScore}).`);
+            } else {
+                callbacks.push(`A frustrating setback at a critical point in the season.`);
+            }
         }
     }
 


### PR DESCRIPTION
This commit acts as the daily regression pass. It verifies the functionality for basic tasks (smoke test, persistence, scrolling, free agency). Furthermore, it introduces a requested small enhancement by enriching the emotional engagement in game simulation post-game recaps. Stakes logic is more granular, providing varied tension levels depending on how crucial the game was (>= 90 stakes vs > 75 or >= 50).

---
*PR created automatically by Jules for task [4868868254953044886](https://jules.google.com/task/4868868254953044886) started by @rbcati*