### PR TITLE
PR 3.5: shell, schedule, and trade workflow cleanup

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -4,6 +4,7 @@ import { evaluateWeeklyContext } from "../utils/weeklyContext.js";
 import { deriveTeamCapSnapshot, formatMoneyM } from "../utils/numberFormatting.js";
 import { findLatestUserCompletedGame } from "../utils/completedGameSelectors.js";
 import { getHQViewModel } from "../../state/selectors.js";
+import { getHQPrimaryAction } from "../utils/hqPrimaryAction.js";
 import { EmptyState, SectionCard, StatCard, TeamChip, TrendBadge } from "./common/UiPrimitives.jsx";
 
 function safeNum(value, fallback = 0) {
@@ -45,7 +46,19 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore }) {
   const recent = Array.isArray(team?.recentResults) ? team.recentResults.slice(-5) : [];
   const trend = recent.length ? (recent.filter((r) => r === "W").length >= Math.ceil(recent.length / 2) ? "up" : "down") : "steady";
 
-  const storylines = (weekly?.storylineCards ?? []).slice(0, 4);
+  const storylines = (weekly?.storylineCards ?? []).slice(0, 3);
+  const primaryAction = getHQPrimaryAction(vm.league);
+
+  const handlePrimaryAction = () => {
+    if (!primaryAction?.action) return;
+    if (primaryAction.action.type === 'box_score' && primaryAction.action.gameId) {
+      onOpenBoxScore?.(primaryAction.action.gameId);
+      return;
+    }
+    if (primaryAction.action.type === 'navigate' && primaryAction.action.tab) {
+      onNavigate?.(primaryAction.action.tab);
+    }
+  };
 
   return (
     <div className="app-screen-stack franchise-hq" style={{ display: "grid", gap: "var(--space-3)" }}>
@@ -55,6 +68,10 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore }) {
       >
         <div style={{ display: "grid", gap: 8 }}>
           <div><strong>{vm.league?.year}</strong> · Week {vm.league?.week ?? 1} · {vm.league?.phase ?? "regular"}</div>
+          <button className="btn btn-primary" style={{ textAlign: 'left', minHeight: 46 }} onClick={handlePrimaryAction}>
+            <div style={{ fontWeight: 800 }}>{primaryAction?.label ?? 'Review weekly priorities'}</div>
+            <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{primaryAction?.detail}</div>
+          </button>
           <div>Next opponent: {nextGame ? <>Week {nextGame.week} {nextGame.isHome ? "vs" : "@"} <TeamChip team={nextGame.opp} /></> : "No game scheduled"}</div>
           <div>Record context: <strong>{record}</strong></div>
           <div>Availability: {safeNum(weekly?.pressurePoints?.injuriesCount) > 0 ? `${safeNum(weekly?.pressurePoints?.injuriesCount)} injury flags` : "No major injuries"}</div>
@@ -79,9 +96,10 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore }) {
       <SectionCard title="Front Office">
         <div style={{ display: "grid", gap: 8 }}>
           <StatCard label="Cap Space" value={formatMoneyM(cap.capRoom)} note={`Used ${formatMoneyM(cap.capUsed)} / ${formatMoneyM(cap.capTotal)}`} />
-          <div>Roster/contracts: {safeNum(weekly?.pressurePoints?.expiringCount) > 0 ? `${safeNum(weekly?.pressurePoints?.expiringCount)} expiring players.` : "No immediate contract issue."}</div>
+          {safeNum(weekly?.pressurePoints?.expiringCount) > 0 ? <div>Contracts: <strong>{safeNum(weekly?.pressurePoints?.expiringCount)} expiring players.</strong></div> : null}
+          {safeNum(weekly?.pressurePoints?.injuriesCount) > 0 ? <div>Injuries: <strong>{safeNum(weekly?.pressurePoints?.injuriesCount)} players need coverage.</strong></div> : null}
           <div>Trade deadline: {deadline?.isLocked ? "Closed" : `Week ${deadline?.deadlineWeek ?? "—"}${deadline?.isFinalWindow ? " (approaching)" : ""}`}</div>
-          <div>Draft picks: {(team?.picks ?? []).length} currently held.</div>
+          {(team?.picks ?? []).length === 0 ? <div>Draft capital: no picks currently held.</div> : <div>Draft picks: {(team?.picks ?? []).length} currently held.</div>}
         </div>
       </SectionCard>
 
@@ -91,7 +109,7 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore }) {
         ) : (
           <div style={{ display: "grid", gap: 8 }}>
             {storylines.map((item) => (
-              <div key={item?.id ?? item?.title} className="card" style={{ padding: "var(--space-2) var(--space-3)" }}>
+              <div key={item?.id ?? item?.title} className="card franchise-story-item" style={{ padding: "var(--space-2) var(--space-3)" }}>
                 <strong>{item?.title ?? "League note"}</strong>
                 <div style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)" }}>{item?.detail ?? item?.why ?? "No detail"}</div>
               </div>

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -62,6 +62,8 @@ import CapManager from "./CapManager.jsx";
 import DraftBigBoard from "./DraftBigBoard.jsx";
 import CoachingScreen from "./CoachingScreen.jsx";
 import { buildLatestResultsSummary } from "../utils/lastResultSummary.js";
+import { getAppShellContext } from "../utils/appShellContext.js";
+import { getScheduleFiltersState, persistScheduleFiltersState } from "../utils/scheduleFiltersState.js";
 import {
   clampPercent,
   deriveTeamCapSnapshot,
@@ -749,9 +751,16 @@ function ScheduleTab({
   league,
   onPlayerSelect,
 }) {
-  const [selectedWeek, setSelectedWeek] = useState(currentWeek);
-  const [viewMode, setViewMode] = useState("my_team");
-  const [selectedTeamId, setSelectedTeamId] = useState(userTeamId);
+  const initialFilters = useMemo(() => getScheduleFiltersState({
+    selectedWeek: Number(currentWeek ?? 1),
+    viewMode: 'my_team',
+    selectedTeamId: Number(userTeamId ?? 0),
+    statusFilter: 'all',
+  }), [currentWeek, userTeamId]);
+  const [selectedWeek, setSelectedWeek] = useState(initialFilters.selectedWeek);
+  const [viewMode, setViewMode] = useState(initialFilters.viewMode);
+  const [selectedTeamId, setSelectedTeamId] = useState(initialFilters.selectedTeamId);
+  const [statusFilter, setStatusFilter] = useState(initialFilters.statusFilter);
 
   const teamById = useMemo(() => {
     const map = {};
@@ -800,8 +809,12 @@ function ScheduleTab({
     week: selectedWeek,
     teamId: selectedTeamId,
     mode: viewMode === 'selected_team' || viewMode === 'my_team' ? 'team' : 'league',
-    status: viewMode === 'completed_only' ? 'completed' : viewMode === 'upcoming_only' ? 'upcoming' : 'all',
+    status: statusFilter,
   });
+  useEffect(() => {
+    persistScheduleFiltersState({ selectedWeek, viewMode, selectedTeamId, statusFilter });
+  }, [selectedWeek, viewMode, selectedTeamId, statusFilter]);
+
   const filteredGames = (viewMode === 'my_team')
     ? games.filter((game) => {
       const homeId = Number(game?.home?.id ?? game?.home);
@@ -815,6 +828,11 @@ function ScheduleTab({
         return homeId === Number(selectedTeamId) || awayId === Number(selectedTeamId);
       })
       : scheduleModel.games;
+  const visibleGames = filteredGames.filter((game) => {
+    if (statusFilter === 'completed') return Boolean(game?.played);
+    if (statusFilter === 'upcoming') return !Boolean(game?.played);
+    return true;
+  });
   const weeklyHonors = useMemo(() => deriveWeeklyHonors(league), [league]);
   const weekRecapItems = useMemo(() => (
     games
@@ -851,9 +869,9 @@ function ScheduleTab({
       >
         <strong style={{ fontSize: "var(--text-xs)", letterSpacing: ".4px", textTransform: "uppercase", color: "var(--text-muted)" }}>Filters</strong>
         <div style={{ display: "flex", gap: "var(--space-2)", alignItems: "center", flexWrap: "wrap" }}>
-          <Button size="sm" variant={viewMode === "completed_only" ? "default" : "outline"} onClick={() => setViewMode("completed_only")}>Completed</Button>
-          <Button size="sm" variant={viewMode === "upcoming_only" ? "default" : "outline"} onClick={() => setViewMode("upcoming_only")}>Upcoming</Button>
-          <Button size="sm" variant={viewMode === "all_week" ? "default" : "outline"} onClick={() => setViewMode("all_week")}>All</Button>
+          <Button size="sm" variant={statusFilter === "completed" ? "default" : "outline"} onClick={() => setStatusFilter("completed")}>Completed</Button>
+          <Button size="sm" variant={statusFilter === "upcoming" ? "default" : "outline"} onClick={() => setStatusFilter("upcoming")}>Upcoming</Button>
+          <Button size="sm" variant={statusFilter === "all" ? "default" : "outline"} onClick={() => setStatusFilter("all")}>All</Button>
         </div>
       </div>
       <div
@@ -889,10 +907,9 @@ function ScheduleTab({
         <select value={viewMode} onChange={(e) => setViewMode(e.target.value)} style={{ minHeight: 34 }}>
           <option value="my_team">My team schedule</option>
           <option value="selected_team">Selected team</option>
-          <option value="all_week">All games this week</option>
-          <option value="completed_only">Completed only</option>
-          <option value="upcoming_only">Upcoming only</option>
+          <option value="all_week">League view (week slate)</option>
         </select>
+        <span className="badge">{viewMode === 'my_team' ? 'My Team View' : viewMode === 'selected_team' ? 'Selected Team View' : 'League View'}</span>
         {viewMode === "selected_team" && (
           <select value={selectedTeamId ?? ""} onChange={(e) => setSelectedTeamId(Number(e.target.value))} style={{ minHeight: 34 }}>
             {(teams ?? []).map((team) => <option key={team.id} value={team.id}>{team.name}</option>)}
@@ -961,7 +978,7 @@ function ScheduleTab({
             </div>
           </div>
         )}
-        {filteredGames.map((game, idx) => {
+        {visibleGames.map((game, idx) => {
           const home = teamById[game.home] ?? {
             name: `Team ${game.home}`,
             abbr: "???",
@@ -1291,7 +1308,7 @@ function ScheduleTab({
           );
         })}
 
-        {games.length === 0 && (
+        {visibleGames.length === 0 && (
           <p
             style={{
               color: "var(--text-muted)",
@@ -1563,6 +1580,7 @@ export default function LeagueDashboard({
   );
   const ownerApprovalText = formatPercent(ownerApproval, "—");
   const pressure = deriveFranchisePressure(league);
+  const shell = getAppShellContext(league);
   const teamSummaryNav = () => setActiveTab("Roster Hub");
   const openGameDetail = (gameId, sourceTab = activeTab) => {
     if (!gameId) return;
@@ -1573,15 +1591,8 @@ export default function LeagueDashboard({
 
   return (
     <div>
-      {/* ── Hub Header — compact single row ── */}
-      <div style={{
-        display: "flex",
-        alignItems: "center",
-        gap: "var(--space-3)",
-        padding: "var(--space-3) 0",
-        marginBottom: "var(--space-2)",
-        borderBottom: "1px solid var(--hairline)",
-      }}>
+      {/* ── Franchise shell status bar ── */}
+      <div className="franchise-status-bar">
         <button
           type="button"
           className="team-summary-nav-card clickable-card"
@@ -1620,6 +1631,13 @@ export default function LeagueDashboard({
             }}
           />
         </div>
+        <div className="franchise-status-bar__meta">
+          <span><strong>{shell.teamAbbr}</strong> {shell.teamName}</span>
+          <span>{shell.year}</span>
+          <span>Week {shell.week}</span>
+          <span style={{ textTransform: 'capitalize' }}>{shell.phase}</span>
+          <span>Cap {shell.capSummary}</span>
+        </div>
       </div>
 
       {/* ── Contextual Action Banners (compact) ── */}
@@ -1647,6 +1665,12 @@ export default function LeagueDashboard({
           🏈 <strong>Draft Board is Open</strong> — click to make picks
         </div>
       )}
+
+      <div className="franchise-primary-nav">
+        {["HQ","Roster","Schedule","Transactions","Standings"].map((tab) => (
+          <button key={`shell-${tab}`} className={`standings-tab${activeTab === tab ? ' active' : ''}`} onClick={() => setActiveTab(tab)}>{tab}</button>
+        ))}
+      </div>
 
       {/* ── Status Grid — hidden during Draft to create a cleaner "War Room" view ── */}
       {activeTab !== "Home" && activeTab !== "HQ" && league.phase !== "draft" && <div

--- a/src/ui/components/TradeCenter.jsx
+++ b/src/ui/components/TradeCenter.jsx
@@ -17,6 +17,8 @@ import { buildIncomingOfferPresentation, getOfferIdentity } from "../utils/trade
 import { ScreenHeader, EmptyState, StickySubnav } from "./ScreenSystem.jsx";
 import { isTradeWindowOpen, getTradeWindowSnapshot } from "../../core/tradeWindow.js";
 import { DeadlineBanner } from "./common/UiPrimitives.jsx";
+import { buildTradeAssetDisplay } from "../utils/tradeAssetDisplay.js";
+import { getTradeLockReason } from "../utils/tradeLockReason.js";
 
 // ── Original helpers (kept exactly as you had) ─────────────────────────────────
 
@@ -56,13 +58,17 @@ function OvrBadge({ ovr }) {
 }
 
 function PlayerCheckRow({ player, checked, onChange, onNameClick }) {
+  const asset = buildTradeAssetDisplay(player, { type: 'player' });
   return (
     <label className={`trade-asset-row ${checked ? "is-selected" : ""}`}>
-      <input type="checkbox" checked={checked} onChange={(e) => onChange(player.id, e.target.checked)} style={{ accentColor: "var(--accent)", width: 15, height: 15 }} />
+      <input type="checkbox" checked={checked} onChange={(e) => onChange(player.id, e.target.checked)} style={{ accentColor: "var(--accent)", width: 16, height: 16 }} />
       <OvrBadge ovr={player.ovr} />
       <span className="trade-asset-row__pos">{player.pos}</span>
-      <span onClick={(e) => { e.preventDefault(); onNameClick?.(player.id); }} className="trade-asset-row__name">{player.name}</span>
-      <span className="trade-asset-row__salary">{fmtSalary(player.contract?.baseAnnual)}</span>
+      <span className="trade-asset-row__name" onClick={(e) => { e.preventDefault(); onNameClick?.(player.id); }}>
+        <strong>{asset.title}</strong>
+        <small>{asset.subtitle}</small>
+      </span>
+      <span className="trade-asset-row__salary">{asset.meta}</span>
     </label>
   );
 }
@@ -114,7 +120,8 @@ function CapImpact({ myTeam, theirTeam, myCapAfter, theirCapAfter }) {
 }
 
 function pickLabel(pk) {
-  return `${pk?.season ?? pk?.year ?? "Future"} R${pk?.round ?? "?"}${pk?.isCompensatory ? " COMP" : ""}`;
+  const display = buildTradeAssetDisplay(pk, { type: 'pick' });
+  return `${display.title}${display.subtitle ? ` · ${display.subtitle}` : ''}`;
 }
 
 function PickSelector({ side, picks, onChange, availablePicks = [] }) {
@@ -144,7 +151,7 @@ function PickSelector({ side, picks, onChange, availablePicks = [] }) {
         <div className="trade-pick-controls__chips">
           {picks.map(pk => (
             <span key={pk.id} className="trade-pick-chip">
-              {pickLabel(pk)}
+              🏷️ {pickLabel(pk)}
               <Button style={{ background: "none", border: "none", color: "inherit", padding: 0, fontSize: 12, minHeight: 0 }} onClick={() => onChange(side, pk, true)}>×</Button>
             </span>
           ))}
@@ -411,6 +418,8 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
     }
   }, [initialTradeContext, myAvailablePicks]);
 
+  const lockReason = getTradeLockReason({ tradeLocked, tradeDeadline, phase: league?.phase });
+
   useEffect(() => {
     onTradeContextChange?.({
       partnerTeamId: targetId,
@@ -501,6 +510,12 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
         </div>
       )}
       {/* Header + propose button (original) */}
+      {lockReason ? (
+        <div className="card" style={{ padding: 'var(--space-3)', borderColor: 'var(--danger)', background: 'rgba(255,69,58,0.08)', marginBottom: 'var(--space-2)' }}>
+          <strong style={{ display: 'block', marginBottom: 4 }}>Trading actions are locked</strong>
+          <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{lockReason}</span>
+        </div>
+      ) : null}
       {incomingOffers.length > 0 && (
         <div className="card" style={{ marginBottom: "var(--space-4)", padding: "var(--space-4) var(--space-5)" }}>
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
@@ -569,9 +584,9 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
                       </div>
                     ) : null}
                     <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-                      <Button size="sm" onClick={() => actions?.acceptIncomingTrade?.(offer.id)}>Accept</Button>
-                      <Button size="sm" variant="secondary" onClick={() => actions?.rejectIncomingTrade?.(offer.id)}>Reject</Button>
-                      <Button size="sm" variant="outline" onClick={() => startCounterOffer(offer)}>Counter</Button>
+                      <Button size="sm" disabled={tradeLocked} onClick={() => actions?.acceptIncomingTrade?.(offer.id)}>Accept</Button>
+                      <Button size="sm" variant="secondary" disabled={tradeLocked} onClick={() => actions?.rejectIncomingTrade?.(offer.id)}>Reject</Button>
+                      <Button size="sm" variant="outline" disabled={tradeLocked} onClick={() => startCounterOffer(offer)}>Counter</Button>
                       <Button size="sm" variant="outline" onClick={() => setTargetId(Number(offer.offeringTeamId))}>Open Team</Button>
                     </div>
                   </div>
@@ -674,6 +689,31 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
           </div>
 
           {/* Trade block summary (original) */}
+          <div className="trade-offer-review">
+            <div className="trade-offer-review__col">
+              <h4>You Give</h4>
+              {[...offering].map((id) => myRosterMap.get(id)).filter(Boolean).map((player) => {
+                const display = buildTradeAssetDisplay(player, { type: 'player' });
+                return <div key={`give-${player.id}`} className="trade-offer-review__item"><strong>{display.title}</strong><span>{display.subtitle}</span></div>;
+              })}
+              {myPicks.map((pick) => {
+                const display = buildTradeAssetDisplay(pick, { type: 'pick' });
+                return <div key={`give-p-${pick.id}`} className="trade-offer-review__item pick"><strong>{display.title}</strong><span>{display.subtitle || 'Draft pick'}</span></div>;
+              })}
+            </div>
+            <div className="trade-offer-review__col">
+              <h4>You Receive</h4>
+              {[...receiving].map((id) => theirRosterMap.get(id)).filter(Boolean).map((player) => {
+                const display = buildTradeAssetDisplay(player, { type: 'player' });
+                return <div key={`recv-${player.id}`} className="trade-offer-review__item"><strong>{display.title}</strong><span>{display.subtitle}</span></div>;
+              })}
+              {theirPicks.map((pick) => {
+                const display = buildTradeAssetDisplay(pick, { type: 'pick' });
+                return <div key={`recv-p-${pick.id}`} className="trade-offer-review__item pick"><strong>{display.title}</strong><span>{display.subtitle || 'Draft pick'}</span></div>;
+              })}
+            </div>
+          </div>
+
           <TradeBlockSummary myRosterMap={myRosterMap} theirRosterMap={theirRosterMap} offering={offering} receiving={receiving} myPicks={myPicks} theirPicks={theirPicks} />
 
           {/* Player preview sheet (original) */}

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -1023,3 +1023,89 @@ label {
 @media (max-width: 760px) {
   .franchise-hq-flow { grid-template-columns: 1fr; }
 }
+
+/* PR 3.5 shell/schedule/trade cleanup */
+.franchise-status-bar {
+  position: sticky;
+  top: calc(env(safe-area-inset-top) + 0px);
+  z-index: 30;
+  display: grid;
+  gap: 8px;
+  padding: 8px 0 10px;
+  background: var(--bg);
+  border-bottom: 1px solid var(--hairline);
+  margin-bottom: var(--space-2);
+}
+.franchise-status-bar__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.franchise-status-bar__meta span {
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-pill);
+  padding: 2px 8px;
+  font-size: 11px;
+  color: var(--text-muted);
+  background: rgba(255,255,255,0.03);
+}
+.franchise-primary-nav {
+  display: flex;
+  gap: 6px;
+  overflow-x: auto;
+  padding-bottom: 8px;
+  margin-bottom: var(--space-2);
+}
+
+.trade-asset-row__name {
+  display: grid;
+  gap: 2px;
+}
+.trade-asset-row__name small {
+  font-size: 10px;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+.trade-offer-review {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+  margin-top: var(--space-3);
+}
+.trade-offer-review__col {
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+  padding: 10px;
+  background: rgba(255,255,255,0.02);
+  display: grid;
+  gap: 6px;
+}
+.trade-offer-review__col h4 {
+  margin: 0;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  color: var(--text-subtle);
+}
+.trade-offer-review__item {
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-sm);
+  padding: 6px 8px;
+  display: grid;
+  gap: 2px;
+  background: rgba(255,255,255,0.015);
+}
+.trade-offer-review__item.pick {
+  border-color: rgba(245,158,11,0.5);
+  background: rgba(245,158,11,0.10);
+}
+.trade-offer-review__item span {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+@media (min-width: 900px) {
+  .trade-offer-review {
+    grid-template-columns: 1fr 1fr;
+  }
+}

--- a/src/ui/utils/appShellContext.js
+++ b/src/ui/utils/appShellContext.js
@@ -1,0 +1,17 @@
+import { deriveTeamCapSnapshot, formatMoneyM } from './numberFormatting.js';
+
+export function getAppShellContext(league) {
+  const teams = Array.isArray(league?.teams) ? league.teams : [];
+  const userTeam = teams.find((team) => Number(team?.id) === Number(league?.userTeamId)) ?? teams[0] ?? null;
+  const cap = deriveTeamCapSnapshot(userTeam, { fallbackCapTotal: 255 });
+
+  return {
+    teamName: userTeam?.name ?? 'No Team',
+    teamAbbr: userTeam?.abbr ?? '---',
+    year: Number(league?.year ?? 0) || '—',
+    week: Number(league?.week ?? 1),
+    phase: String(league?.phase ?? 'regular').replaceAll('_', ' '),
+    capRoom: cap.capRoom,
+    capSummary: `${formatMoneyM(cap.capRoom)} room`,
+  };
+}

--- a/src/ui/utils/hqPrimaryAction.js
+++ b/src/ui/utils/hqPrimaryAction.js
@@ -1,0 +1,42 @@
+import { findLatestUserCompletedGame } from './completedGameSelectors.js';
+
+export function getHQPrimaryAction(league) {
+  const latest = findLatestUserCompletedGame(league);
+  const userTeam = (league?.teams ?? []).find((team) => Number(team?.id) === Number(league?.userTeamId));
+  const injuries = Number(userTeam?.roster?.filter?.((p) => p?.injury?.gamesRemaining > 0)?.length ?? 0);
+  const expiring = Number(userTeam?.roster?.filter?.((p) => Number(p?.contract?.yearsRemaining ?? p?.contract?.years ?? 0) <= 1)?.length ?? 0);
+
+  if (latest?.gameId) {
+    return {
+      key: 'review_box_score',
+      label: 'Review last box score',
+      detail: latest?.story?.headline ?? 'Break down your most recent game before setting this week.',
+      action: { type: 'box_score', gameId: latest.gameId },
+    };
+  }
+
+  if (injuries > 0) {
+    return {
+      key: 'fix_injuries',
+      label: 'Address injury depth',
+      detail: `${injuries} injured player${injuries === 1 ? '' : 's'} need depth chart coverage.`,
+      action: { type: 'navigate', tab: 'Injuries' },
+    };
+  }
+
+  if (expiring > 0) {
+    return {
+      key: 'expiring_contracts',
+      label: 'Handle expiring contracts',
+      detail: `${expiring} expiring deal${expiring === 1 ? '' : 's'} could impact this offseason.`,
+      action: { type: 'navigate', tab: 'Roster' },
+    };
+  }
+
+  return {
+    key: 'prepare_next_opponent',
+    label: 'Prepare next opponent',
+    detail: 'Set your plan and review the next matchup slate.',
+    action: { type: 'navigate', tab: 'Schedule' },
+  };
+}

--- a/src/ui/utils/scheduleFiltersState.js
+++ b/src/ui/utils/scheduleFiltersState.js
@@ -1,0 +1,27 @@
+const KEY = 'gmsim_schedule_filters_v2';
+
+export function getScheduleFiltersState(defaults) {
+  if (typeof window === 'undefined') return { ...defaults };
+  try {
+    const raw = window.sessionStorage.getItem(KEY);
+    if (!raw) return { ...defaults };
+    const parsed = JSON.parse(raw);
+    return {
+      ...defaults,
+      ...parsed,
+      selectedWeek: Number(parsed?.selectedWeek ?? defaults.selectedWeek),
+      selectedTeamId: parsed?.selectedTeamId != null ? Number(parsed.selectedTeamId) : defaults.selectedTeamId,
+    };
+  } catch {
+    return { ...defaults };
+  }
+}
+
+export function persistScheduleFiltersState(state) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(KEY, JSON.stringify(state));
+  } catch {
+    // ignore session storage failures
+  }
+}

--- a/src/ui/utils/tradeAssetDisplay.js
+++ b/src/ui/utils/tradeAssetDisplay.js
@@ -1,0 +1,25 @@
+export function buildTradeAssetDisplay(asset, { type = 'player' } = {}) {
+  if (!asset) return { title: 'Unknown asset', subtitle: 'Missing data', type };
+
+  if (type === 'pick') {
+    const season = asset?.season ?? asset?.year ?? 'Future';
+    const round = asset?.round ?? '?';
+    const origin = asset?.originalTeamAbbr ?? asset?.originalTeam ?? asset?.fromTeamAbbr;
+    const comp = asset?.isCompensatory ? 'Compensatory' : null;
+    return {
+      type: 'pick',
+      title: `${season} Round ${round}`,
+      subtitle: [origin ? `via ${origin}` : null, comp].filter(Boolean).join(' · ') || 'Draft pick',
+      badge: 'Pick',
+    };
+  }
+
+  const ovr = Number(asset?.ovr ?? asset?.overall ?? 0);
+  return {
+    type: 'player',
+    title: asset?.name ?? 'Unnamed player',
+    subtitle: `${asset?.pos ?? 'POS'} · Age ${asset?.age ?? '--'} · OVR ${ovr || '--'}`,
+    meta: asset?.contract?.baseAnnual != null ? `$${Number(asset.contract.baseAnnual).toFixed(1)}M/yr` : 'No contract data',
+    badge: 'Player',
+  };
+}

--- a/src/ui/utils/tradeLockReason.js
+++ b/src/ui/utils/tradeLockReason.js
@@ -1,0 +1,11 @@
+export function getTradeLockReason({ tradeLocked, tradeDeadline, phase }) {
+  if (!tradeLocked) return null;
+  const week = tradeDeadline?.deadlineWeek;
+  if (phase === 'offseason' || phase === 'offseason_resign' || phase === 'free_agency') {
+    return 'Trading is disabled during this offseason phase. Trading reopens during preseason.';
+  }
+  if (week != null) {
+    return `The trade deadline passed after Week ${week}. Trading reopens in the offseason/preseason window.`;
+  }
+  return 'Trading is currently locked by league rules.';
+}


### PR DESCRIPTION
### Motivation
- Finish the incomplete UX/workflow work from recent reliability refactors so franchise mode feels cohesive and predictable. 
- Keep HQ concise but actionable and ensure core franchise context is always visible while browsing major screens. 
- Stabilize schedule and trade flows so users can browse games, open box scores, and construct/accept offers without confusing or silent behavior.

### Description
- App shell: added a sticky franchise status bar and compact primary nav, centralized context formatting with `getAppShellContext`, and updated shell CSS to improve spacing and mobile readability. (mod: `src/ui/components/LeagueDashboard.jsx`, add: `src/ui/utils/appShellContext.js`, mod: `src/ui/styles/components.css`).
- HQ: introduced a single weekly primary recommended action via `getHQPrimaryAction`, surfaced it as a prominent CTA, and tightened Front Office signals for cap/expiries/injuries while keeping the HQ compact. (mod: `src/ui/components/FranchiseHQ.jsx`, add: `src/ui/utils/hqPrimaryAction.js`).
- Schedule: separated viewing mode from completion status, added persistent in-session schedule filters via `getScheduleFiltersState` and `persistScheduleFiltersState`, and made completed-game entries consistently route to shared box score handlers. (mod: `src/ui/components/LeagueDashboard.jsx`, add: `src/ui/utils/scheduleFiltersState.js`).
- Trade workflow: improved asset presentation with `buildTradeAssetDisplay`, made picks visually distinct, added a two-column offer review (`You Give` / `You Receive`), surfaced explicit trade lock reasons via `getTradeLockReason`, and disabled incoming-offer actions when the trade window is locked. (mod: `src/ui/components/TradeCenter.jsx`, add: `src/ui/utils/tradeAssetDisplay.js`, `src/ui/utils/tradeLockReason.js`, mod: `src/ui/styles/components.css`).

### Testing
- Ran targeted unit tests with `npm run test:unit -- src/ui/utils/tradeWorkspaceState.test.js src/ui/utils/weeklyContext.test.js src/ui/utils/boxScorePresentation.test.js` and all tests passed. 
- Ran core unit suites with `npm run test:unit -- src/core/__tests__/trade-logic.test.js src/core/__tests__/schedule.test.js` and all tests passed. 
- Built production bundle with `npm run build`, which completed successfully (Vite emitted a non-blocking chunk-size warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8281d5c78832d84454e30085d9eda)