### PR TITLE
Phase 4: Staff, scouting, and development foundation

### DIFF
--- a/src/core/development/developmentSystem.js
+++ b/src/core/development/developmentSystem.js
@@ -1,0 +1,14 @@
+export const TRAINING_FOCUS_OPTIONS = ['balanced', 'youth_development', 'win_now', 'rehab_recovery', 'strength_conditioning'];
+
+export function computePlayerDevelopmentDelta({ player, focus = 'balanced', staffImpact = {}, trainingLevel = 1, playingTimeFactor = 0, variance = 0 } = {}) {
+  const age = Number(player?.age ?? 24);
+  const baseAgeCurve = age <= 23 ? 0.9 : age <= 26 ? 0.45 : age <= 29 ? 0.1 : -0.55;
+  const focusMod = focus === 'youth_development' ? (age <= 24 ? 0.35 : -0.1) : focus === 'win_now' ? (age <= 24 ? -0.15 : 0.12) : focus === 'rehab_recovery' ? 0.02 : focus === 'strength_conditioning' ? 0.08 : 0;
+  const levelMod = (Math.max(1, Math.min(5, Number(trainingLevel) || 1)) - 1) * 0.05;
+  const coachBonus = (Number(staffImpact?.developmentDelta ?? 0) * 2.8) + (age <= 24 ? Number(staffImpact?.offensiveDevDelta ?? 0) * 0.8 + Number(staffImpact?.defensiveDevDelta ?? 0) * 0.8 : 0);
+  const delta = baseAgeCurve + focusMod + levelMod + coachBonus + Number(playingTimeFactor || 0) + Number(variance || 0);
+  return {
+    developmentDelta: delta,
+    explanation: { baseAgeCurve, trainingFocusModifier: focusMod + levelMod, staffDevelopmentModifier: coachBonus, playingTimeModifier: Number(playingTimeFactor || 0), variance: Number(variance || 0) },
+  };
+}

--- a/src/core/league.js
+++ b/src/core/league.js
@@ -223,6 +223,7 @@ function makeLeague(teams, options = {}, dependencies = {}) {
                   scoutingRegion: 'national',
                   ownerCapacity: 10,
                   usedCapacity: 4,
+                  trainingFocus: 'balanced',
                   history: [],
                 },
                 rivalTeamId: null

--- a/src/core/progression-logic.js
+++ b/src/core/progression-logic.js
@@ -302,8 +302,15 @@ export function processPlayerProgression(players, options = {}) {
     const ovrAfter         = calculateOvr(player.pos, player.ratings);
     const progressionDelta = ovrAfter - ovrBefore;
 
-    player.ovr              = ovrAfter;
+    player.ovr = ovrAfter;
     player.progressionDelta = progressionDelta;
+    player.developmentContext = {
+      baseAgeCurve: age <= 25 ? 'growth' : age <= 29 ? 'prime' : 'decline',
+      trainingFocus: org?.trainingFocus ?? 'balanced',
+      staffDevelopmentModifier: Math.round((Number(org?.staffDevelopmentModifier ?? 0) || 0) * 1000) / 10,
+      playingTimeModifier: player.depthRole === 'starter' ? '+ starter reps' : player.depthRole === 'bench' ? '- limited reps' : 'neutral reps',
+      varianceTag: breakoutEvent ? 'breakout variance' : bustEvent ? 'bust variance' : wallEvent ? 'wall variance' : 'normal variance',
+    };
 
     // ── Classify for news ──────────────────────────────────────────────────
     if (progressionDelta >= 4) {

--- a/src/core/scouting/scoutingSystem.js
+++ b/src/core/scouting/scoutingSystem.js
@@ -1,0 +1,11 @@
+const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, Number(v) || 0));
+
+export function getScoutingConfidence({ staffImpact = {}, fogStrength = 50, scoutingLevel = 1, scoutProgress = 0 } = {}) {
+  const fog = clamp(fogStrength, 0, 100) / 100;
+  const level = Math.max(1, Math.min(5, Math.round(Number(scoutingLevel) || 1)));
+  const base = 0.52 + Number(staffImpact?.scoutingAccuracy ?? 0) * 0.36 + (level - 1) * 0.04;
+  const confidence = clamp(base - fog * 0.22 + (Number(scoutProgress) / 100) * 0.35, 0.28, 0.96);
+  const uncertainty = Math.round(clamp((1 - confidence) * 20 + fog * 7, 2, 24));
+  const label = confidence >= 0.83 ? 'High confidence' : confidence >= 0.68 ? 'Medium confidence' : 'Low confidence';
+  return { confidence, uncertainty, label };
+}

--- a/src/core/staff-system.js
+++ b/src/core/staff-system.js
@@ -1,134 +1,83 @@
-import { Utils } from './utils.js';
+import { CORE_STAFF_ROLES, evaluateStaffImpact, generateStaffCandidate, getStaffMarketViewModel, summarizeStaffEffects } from './staff/staffFoundation.js';
+import { getScoutingConfidence } from './scouting/scoutingSystem.js';
 
-export const STAFF_ROLE_DEFS = Object.freeze({
-  headCoach: { key: 'headCoach', title: 'Head Coach', roleType: 'coach' },
-  offCoordinator: { key: 'offCoordinator', title: 'Offensive Coordinator', roleType: 'coach' },
-  defCoordinator: { key: 'defCoordinator', title: 'Defensive Coordinator', roleType: 'coach' },
-  leadScout: { key: 'leadScout', title: 'College Scouting Director', roleType: 'scout_college' },
-  proScout: { key: 'proScout', title: 'Pro Personnel Director', roleType: 'scout_pro' },
-  headTrainer: { key: 'headTrainer', title: 'Head Trainer', roleType: 'medical' },
-  capAdvisor: { key: 'capAdvisor', title: 'Cap & Contracts Advisor', roleType: 'contracts' },
+const LEGACY_ROLE_ALIASES = Object.freeze({
+  offCoord: 'offCoordinator',
+  defCoord: 'defCoordinator',
+  leadScout: 'scoutDirector',
+  proScout: 'scoutDirector',
+  capAdvisor: 'headTrainer',
 });
 
-const ARCHETYPES = {
-  coach: ['Strategist', 'Developer', 'Culture Builder', 'Aggressive Playcaller'],
-  scout_college: ['Traits Evaluator', 'Projection Specialist', 'Regional Networker'],
-  scout_pro: ['Veteran Evaluator', 'Scheme Matcher', 'Trade Intelligence'],
-  medical: ['Prevention Focused', 'Recovery Focused', 'Sports Science'],
-  contracts: ['Value Hunter', 'Retention Focused', 'Hardline Negotiator'],
-};
+export const STAFF_ROLE_DEFS = CORE_STAFF_ROLES;
 
-const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, Number(v) || 0));
-
-export function createStaffMember(roleKey, { year = 2025, teamId = 0 } = {}) {
-  const def = STAFF_ROLE_DEFS[roleKey] ?? STAFF_ROLE_DEFS.headCoach;
-  const roleType = def.roleType;
-  const level = Utils.weightedChoice ? Utils.weightedChoice([1, 2, 3, 4, 5], [12, 28, 34, 18, 8]) : Utils.rand(1, 5);
-  const base = 38 + level * 11;
-  const attrs = {
-    development: clamp(base + Utils.rand(-8, 10), 25, 95),
-    schemeFlex: clamp(base + Utils.rand(-10, 8), 25, 95),
-    collegeScouting: clamp(base + Utils.rand(-12, 12), 20, 98),
-    proScouting: clamp(base + Utils.rand(-12, 12), 20, 98),
-    injuryPrevention: clamp(base + Utils.rand(-12, 10), 20, 98),
-    recovery: clamp(base + Utils.rand(-12, 10), 20, 98),
-    morale: clamp(base + Utils.rand(-10, 10), 20, 98),
-    contractLeverage: clamp(base + Utils.rand(-12, 12), 20, 98),
-    aggression: clamp(base + Utils.rand(-15, 15), 15, 95),
-  };
-  if (roleType === 'scout_college') attrs.collegeScouting = clamp(attrs.collegeScouting + 10, 20, 99);
-  if (roleType === 'scout_pro') attrs.proScouting = clamp(attrs.proScouting + 10, 20, 99);
-  if (roleType === 'medical') {
-    attrs.injuryPrevention = clamp(attrs.injuryPrevention + 10, 25, 99);
-    attrs.recovery = clamp(attrs.recovery + 10, 25, 99);
-  }
-  if (roleType === 'contracts') attrs.contractLeverage = clamp(attrs.contractLeverage + 12, 20, 99);
-  if (roleType === 'coach') attrs.development = clamp(attrs.development + 6, 25, 99);
-
-  const archetypePool = ARCHETYPES[roleType] ?? ['Generalist'];
-  return {
-    id: Utils.id(),
-    role: def.title,
-    roleKey,
-    roleType,
-    name: `${Utils.choice(['Alex', 'Jordan', 'Casey', 'Taylor', 'Drew', 'Riley', 'Sam'])} ${Utils.choice(['Harper', 'Mason', 'Reed', 'Quinn', 'Parker', 'Shaw'])}`,
-    age: Utils.rand(33, 66),
-    years: Utils.rand(1, 4),
-    salary: Math.round((0.5 + level * 0.45 + (roleKey === 'headCoach' ? 2 : 0)) * 10) / 10,
-    level,
-    rating: clamp(Math.round(base + Utils.rand(-5, 7)), 35, 98),
-    archetype: Utils.choice(archetypePool),
-    attrs,
-    continuity: { teamId, sinceYear: year, tenureYears: 0 },
-  };
+export function createStaffMember(roleKey, options = {}) {
+  const normalized = LEGACY_ROLE_ALIASES[roleKey] ?? roleKey;
+  return generateStaffCandidate(normalized, options);
 }
 
 export function ensureTeamStaff(team, { year = 2025 } = {}) {
-  const existing = team?.staff ?? {};
-  const next = { ...existing };
-  for (const key of Object.keys(STAFF_ROLE_DEFS)) {
-    if (!next[key]) next[key] = createStaffMember(key, { year, teamId: team?.id ?? 0 });
+  const existing = { ...(team?.staff ?? {}) };
+  for (const [legacyKey, mapped] of Object.entries(LEGACY_ROLE_ALIASES)) {
+    if (!existing[mapped] && existing[legacyKey]) existing[mapped] = { ...existing[legacyKey], roleKey: mapped };
   }
-  if (!Array.isArray(next.marketHistory)) next.marketHistory = [];
-  return next;
+  for (const key of Object.keys(CORE_STAFF_ROLES)) {
+    if (!existing[key]) existing[key] = createStaffMember(key, { year, teamId: team?.id ?? 0 });
+  }
+
+  // Backward-compatible mirror keys for older systems/tests.
+  existing.leadScout = existing.scoutDirector;
+  existing.proScout = existing.scoutDirector;
+  existing.capAdvisor = existing.headTrainer;
+  if (!Array.isArray(existing.marketHistory)) existing.marketHistory = [];
+  return existing;
 }
+
+const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, Number(v) || 0));
 
 export function computeStaffTeamBonuses(team, leagueSettings = {}) {
   const staff = ensureTeamStaff(team, { year: leagueSettings?.year ?? 2025 });
   const impactStrength = clamp(leagueSettings?.staffImpactStrength ?? 50, 0, 100) / 100;
-  const wt = 0.55 + impactStrength * 0.9;
-  const avg = (vals) => vals.reduce((s, v) => s + (Number(v) || 0), 0) / Math.max(1, vals.length);
-
-  const coachCore = [staff.headCoach, staff.offCoordinator, staff.defCoordinator].filter(Boolean);
-  const dev = avg(coachCore.map((s) => s.attrs?.development));
-  const scheme = avg(coachCore.map((s) => s.attrs?.schemeFlex));
-  const morale = avg(coachCore.map((s) => s.attrs?.morale));
-  const injury = avg([staff.headTrainer?.attrs?.injuryPrevention, staff.headTrainer?.attrs?.recovery]);
-  const college = avg([staff.leadScout?.attrs?.collegeScouting, staff.leadScout?.attrs?.development]);
-  const pro = avg([staff.proScout?.attrs?.proScouting, staff.proScout?.attrs?.schemeFlex]);
-  const cap = avg([staff.capAdvisor?.attrs?.contractLeverage, staff.capAdvisor?.attrs?.morale]);
-
+  const impact = evaluateStaffImpact(staff);
+  const scale = 0.65 + impactStrength * 0.7;
   return {
-    developmentDelta: clamp(((dev - 55) / 240) * wt, -0.16, 0.18),
-    rookieAdaptationDelta: clamp(((dev + morale - 110) / 340) * wt, -0.15, 0.15),
-    injuryRateDelta: clamp(((injury - 55) / 280) * wt, -0.18, 0.12),
-    recoveryDelta: clamp(((injury - 55) / 220) * wt, -0.14, 0.14),
-    collegeScoutAccuracy: clamp(0.52 + (college / 180) * wt, 0.45, 0.93),
-    proScoutAccuracy: clamp(0.52 + (pro / 180) * wt, 0.45, 0.93),
-    moraleStabilityDelta: clamp(((morale - 55) / 280) * wt, -0.12, 0.12),
-    contractSupportDelta: clamp(((cap - 55) / 260) * wt, -0.1, 0.12),
-    schemeFlexDelta: clamp(((scheme - 55) / 260) * wt, -0.1, 0.12),
+    developmentDelta: clamp((impact.developmentDelta || 0) * scale, -0.2, 0.24),
+    offensiveDevelopmentDelta: clamp((impact.offensiveDevDelta || 0) * scale, -0.18, 0.24),
+    defensiveDevelopmentDelta: clamp((impact.defensiveDevDelta || 0) * scale, -0.18, 0.24),
+    rookieAdaptationDelta: clamp(((impact.cultureDelta || 0) + (impact.readinessDelta || 0)) * scale * 0.75, -0.15, 0.15),
+    readinessDelta: clamp((impact.readinessDelta || 0) * scale, -0.12, 0.16),
+    injuryRateDelta: clamp((impact.injuryRiskDelta || 0) * scale, -0.16, 0.1),
+    recoveryDelta: clamp((impact.recoveryDelta || 0) * scale, -0.12, 0.14),
+    collegeScoutAccuracy: clamp(0.5 + ((impact.scoutingAccuracy || 0.6) - 0.56) * 0.95, 0.45, 0.93),
+    proScoutAccuracy: clamp(0.5 + ((impact.scoutingAccuracy || 0.6) - 0.56) * 1.02, 0.45, 0.94),
+    moraleStabilityDelta: clamp((impact.cultureDelta || 0) * scale * 0.7, -0.1, 0.12),
+    summary: summarizeStaffEffects(staff),
   };
 }
 
 export function buildStaffMarket(teams = [], { year = 2025, size = 40 } = {}) {
-  const market = [];
-  for (let i = 0; i < size; i++) {
-    const roleKey = Utils.choice(Object.keys(STAFF_ROLE_DEFS));
-    market.push(createStaffMember(roleKey, { year, teamId: -1 }));
-  }
-  const incumbents = teams.flatMap((t) => Object.values(t?.staff ?? {}).filter((s) => s && s.roleKey));
-  return [...market, ...incumbents.slice(0, 20)].sort((a, b) => (b.rating ?? 0) - (a.rating ?? 0));
+  return getStaffMarketViewModel(teams, { year, size });
 }
 
 export function buildScoutingSnapshot(player, team, { fogStrength = 50, commissionerMode = false } = {}) {
   if (!player) return null;
-  const bonuses = computeStaffTeamBonuses(team, { staffImpactStrength: team?.staffImpactStrength ?? 50 });
+  if (commissionerMode) {
+    return { estimatedOvr: Number(player.ovr ?? 50), estimatedPotential: Number(player.potential ?? player.pot ?? 50), confidence: 1, uncertainty: 0, confidenceLabel: 'High confidence', hidden: false };
+  }
+  const staff = ensureTeamStaff(team, { year: Number(team?.year ?? 2025) });
+  const bonuses = computeStaffTeamBonuses({ ...team, staff }, { staffImpactStrength: team?.staffImpactStrength ?? 50 });
+  const scoutingLevel = Number(team?.franchiseInvestments?.scoutingLevel ?? 1);
+  const confidenceProfile = getScoutingConfidence({ staffImpact: { scoutingAccuracy: (bonuses.collegeScoutAccuracy + bonuses.proScoutAccuracy) / 2 }, fogStrength, scoutingLevel, scoutProgress: Number(player?.scoutProgress ?? 0) });
+  const band = confidenceProfile.uncertainty;
+  const noise = Math.round((Math.random() * 2 - 1) * band);
   const trueOvr = Number(player.ovr ?? 50);
   const truePot = Number(player.potential ?? player.pot ?? trueOvr + 4);
-  if (commissionerMode) {
-    return { estimatedOvr: trueOvr, estimatedPotential: truePot, confidence: 1, uncertainty: 0, hidden: false };
-  }
-  const fog = clamp(fogStrength, 0, 100) / 100;
-  const accuracy = clamp((bonuses.collegeScoutAccuracy + bonuses.proScoutAccuracy) / 2, 0.45, 0.95);
-  const confidence = clamp(accuracy - fog * 0.35 + ((player.scoutProgress ?? 0) / 100) * 0.5, 0.25, 0.95);
-  const band = Math.round(clamp((1 - confidence) * 18 + fog * 8, 2, 22));
-  const noise = Math.round((Math.random() * 2 - 1) * band);
   return {
     estimatedOvr: clamp(Math.round(trueOvr + noise), 35, 99),
-    estimatedPotential: clamp(Math.round(truePot + noise * 0.75), 35, 99),
-    confidence,
+    estimatedPotential: clamp(Math.round(truePot + noise * 0.7), 35, 99),
+    confidence: confidenceProfile.confidence,
     uncertainty: band,
+    confidenceLabel: confidenceProfile.label,
     hidden: true,
   };
 }

--- a/src/core/staff/staffFoundation.js
+++ b/src/core/staff/staffFoundation.js
@@ -1,0 +1,80 @@
+import { Utils } from '../utils.js';
+
+export const CORE_STAFF_ROLES = Object.freeze({
+  headCoach: { key: 'headCoach', title: 'Head Coach', domain: 'leadership' },
+  offCoordinator: { key: 'offCoordinator', title: 'Offensive Coordinator', domain: 'offense' },
+  defCoordinator: { key: 'defCoordinator', title: 'Defensive Coordinator', domain: 'defense' },
+  scoutDirector: { key: 'scoutDirector', title: 'Scout Director', domain: 'scouting' },
+  headTrainer: { key: 'headTrainer', title: 'Head Trainer', domain: 'medical' },
+});
+const TIERS = ['Local', 'Regional', 'National', 'Elite'];
+const FIRST = ['Alex', 'Jordan', 'Taylor', 'Riley', 'Sam', 'Morgan', 'Casey', 'Drew', 'Avery', 'Parker'];
+const LAST = ['Reed', 'Mason', 'Shaw', 'Harper', 'Quinn', 'Pryor', 'Bennett', 'Hayes', 'Vaughn', 'Collins'];
+const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, Math.round(Number(v) || 0)));
+
+function buildSpecialties(roleKey, base) {
+  if (roleKey === 'headCoach') return { leadership: clamp(base + Utils.rand(-8, 10), 25, 99), gameManagement: clamp(base + Utils.rand(-10, 8), 25, 99), culture: clamp(base + Utils.rand(-12, 10), 25, 99), playerDevelopment: clamp(base + Utils.rand(-10, 12), 25, 99) };
+  if (roleKey === 'offCoordinator') return { passScheme: clamp(base + Utils.rand(-10, 12), 25, 99), runScheme: clamp(base + Utils.rand(-10, 12), 25, 99), qbDevelopment: clamp(base + Utils.rand(-8, 12), 25, 99), skillPlayerDevelopment: clamp(base + Utils.rand(-8, 12), 25, 99) };
+  if (roleKey === 'defCoordinator') return { frontSeven: clamp(base + Utils.rand(-10, 12), 25, 99), coverage: clamp(base + Utils.rand(-10, 12), 25, 99), passRush: clamp(base + Utils.rand(-10, 12), 25, 99), defensiveDevelopment: clamp(base + Utils.rand(-8, 12), 25, 99) };
+  if (roleKey === 'scoutDirector') return { collegeScouting: clamp(base + Utils.rand(-8, 14), 25, 99), proScouting: clamp(base + Utils.rand(-8, 14), 25, 99), potentialEvaluation: clamp(base + Utils.rand(-10, 12), 25, 99), positionalAccuracy: clamp(base + Utils.rand(-10, 12), 25, 99) };
+  return { injuryPrevention: clamp(base + Utils.rand(-8, 12), 25, 99), recovery: clamp(base + Utils.rand(-8, 12), 25, 99), conditioning: clamp(base + Utils.rand(-8, 12), 25, 99) };
+}
+
+function buildStyleTags(roleKey, sp) {
+  if (roleKey === 'offCoordinator') return [sp.passScheme >= sp.runScheme ? 'pass-first' : 'run-first', sp.qbDevelopment >= 75 ? 'qb-whisperer' : 'balanced-dev'];
+  if (roleKey === 'defCoordinator') return [sp.coverage >= sp.frontSeven ? 'coverage-shell' : 'front-pressure', sp.passRush >= 75 ? 'pressure-heavy' : 'contain-first'];
+  if (roleKey === 'headCoach') return [sp.culture >= 75 ? 'culture-builder' : 'results-first'];
+  if (roleKey === 'scoutDirector') return [sp.collegeScouting >= sp.proScouting ? 'college-focus' : 'pro-focus'];
+  return [sp.conditioning >= 75 ? 'conditioning-first' : 'recovery-first'];
+}
+
+function buildModifiers(roleKey, sp) {
+  if (roleKey === 'headCoach') return { dev: (sp.playerDevelopment - 60) / 300, readiness: (sp.gameManagement - 60) / 360, culture: (sp.culture - 60) / 260 };
+  if (roleKey === 'offCoordinator') return { offDev: (sp.qbDevelopment + sp.skillPlayerDevelopment - 120) / 420 };
+  if (roleKey === 'defCoordinator') return { defDev: (sp.defensiveDevelopment + sp.frontSeven - 120) / 420 };
+  if (roleKey === 'scoutDirector') return { scout: (sp.collegeScouting + sp.proScouting + sp.potentialEvaluation - 180) / 420 };
+  return { injuryPrevention: (sp.injuryPrevention - 60) / 360, recovery: (sp.recovery - 60) / 320 };
+}
+
+export function generateStaffCandidate(roleKey, { year = 2025, teamId = -1 } = {}) {
+  const role = CORE_STAFF_ROLES[roleKey] ?? CORE_STAFF_ROLES.headCoach;
+  const overall = clamp(48 + Utils.rand(0, 45), 35, 97);
+  const specialties = buildSpecialties(role.key, overall);
+  const repIndex = overall >= 89 ? 3 : overall >= 77 ? 2 : overall >= 64 ? 1 : 0;
+  return { id: Utils.id(), name: `${Utils.choice(FIRST)} ${Utils.choice(LAST)}`, age: Utils.rand(34, 67), role: role.title, roleKey: role.key, overall, specialtyRatings: specialties, contractYears: overall >= 85 ? Utils.rand(3, 5) : Utils.rand(2, 4), annualSalary: Math.round((1.1 + (overall - 50) * 0.08 + (roleKey === 'headCoach' ? 1.5 : 0)) * 10) / 10, reputationTier: TIERS[repIndex], styleTags: buildStyleTags(role.key, specialties), modifiers: buildModifiers(role.key, specialties), continuity: { teamId, sinceYear: year, tenureYears: 0 } };
+}
+
+export function evaluateStaffImpact(staff = {}) {
+  const hc = staff.headCoach;
+  const oc = staff.offCoordinator;
+  const dc = staff.defCoordinator;
+  const scout = staff.scoutDirector;
+  const trainer = staff.headTrainer;
+  return {
+    developmentDelta: (hc?.modifiers?.dev ?? 0) + (oc?.modifiers?.offDev ?? 0) * 0.7 + (dc?.modifiers?.defDev ?? 0) * 0.7,
+    offensiveDevDelta: (hc?.modifiers?.dev ?? 0) * 0.35 + (oc?.modifiers?.offDev ?? 0),
+    defensiveDevDelta: (hc?.modifiers?.dev ?? 0) * 0.35 + (dc?.modifiers?.defDev ?? 0),
+    readinessDelta: hc?.modifiers?.readiness ?? 0,
+    cultureDelta: hc?.modifiers?.culture ?? 0,
+    scoutingAccuracy: 0.56 + (scout?.modifiers?.scout ?? 0),
+    injuryRiskDelta: -((trainer?.modifiers?.injuryPrevention ?? 0) * 0.85),
+    recoveryDelta: trainer?.modifiers?.recovery ?? 0,
+  };
+}
+
+export function summarizeStaffEffects(staff = {}) {
+  const impact = evaluateStaffImpact(staff);
+  return [
+    impact.offensiveDevDelta >= 0.04 ? 'QB and skill development boosted' : 'Offensive development is average',
+    impact.defensiveDevDelta >= 0.04 ? 'Defensive development strong' : 'Defensive development is steady',
+    impact.scoutingAccuracy >= 0.75 ? 'Scouting confidence above average' : impact.scoutingAccuracy <= 0.62 ? 'Scouting confidence is limited' : 'Scouting confidence is balanced',
+    impact.injuryRiskDelta <= -0.04 ? 'Injury prevention strong' : 'Injury prevention weak',
+  ];
+}
+
+export function getStaffMarketViewModel(teams = [], { year = 2025, size = 55 } = {}) {
+  const market = [];
+  for (let i = 0; i < size; i += 1) market.push(generateStaffCandidate(Utils.choice(Object.keys(CORE_STAFF_ROLES)), { year, teamId: -1 }));
+  const incumbents = teams.flatMap((team) => Object.values(team?.staff ?? {}).filter((m) => m?.roleKey));
+  return [...market, ...incumbents.slice(0, 20)].sort((a, b) => (b.overall ?? 0) - (a.overall ?? 0));
+}

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -449,6 +449,7 @@ export const State = {
         scoutingRegion: 'national',
         ownerCapacity: 10,
         usedCapacity: 4,
+        trainingFocus: 'balanced',
         history: [],
       };
       migratedTeam.rivalTeamId = migratedTeam?.rivalTeamId ?? null;

--- a/src/ui/components/FranchiseInvestmentsPanel.jsx
+++ b/src/ui/components/FranchiseInvestmentsPanel.jsx
@@ -60,6 +60,23 @@ export default function FranchiseInvestmentsPanel({ team, actions, compact = fal
           </div>
         </div>
 
+
+        <div style={CARD_STYLE}>
+          <div style={{ fontWeight: 700 }}>Development focus</div>
+          <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>Sets franchise-wide progression emphasis used in offseason development calculations.</div>
+          <div style={{ marginTop: 6, display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            {[
+              ['balanced', 'Balanced'],
+              ['youth_development', 'Youth Development'],
+              ['win_now', 'Win Now'],
+              ['rehab_recovery', 'Rehab / Recovery'],
+              ['strength_conditioning', 'Strength & Conditioning'],
+            ].map(([key, label]) => (
+              <Button key={key} size="sm" variant={inv.trainingFocus === key ? 'default' : 'outline'} onClick={() => applyUpdate({ trainingFocus: key })}>{label}</Button>
+            ))}
+          </div>
+        </div>
+
         <div style={CARD_STYLE}>
           <div style={{ fontWeight: 700 }}>Scouting department · {inv.scoutingLevel}/5</div>
           <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>Higher quality tightens prospect confidence and improves sleeper visibility without perfect information.</div>
@@ -77,6 +94,7 @@ export default function FranchiseInvestmentsPanel({ team, actions, compact = fal
       </div>
 
       <div style={{ fontSize: 12, color: 'var(--text-muted)', display: 'grid', gap: 3 }}>
+        <div>Training focus: <strong>{summary.trainingFocusLabel}</strong>.</div>
         <div>Effects now: Fans {summary.fanSentimentDelta >= 0 ? '+' : ''}{summary.fanSentimentDelta}, Owner business {summary.ownerBusinessDelta >= 0 ? '+' : ''}{summary.ownerBusinessDelta}, FA appeal {summary.freeAgentAppealDelta >= 0 ? '+' : ''}{summary.freeAgentAppealDelta}.</div>
         <div>Scouting confidence {summary.scoutingConfidenceDelta >= 0 ? '+' : ''}{summary.scoutingConfidenceDelta} with <strong>{summary.scoutingRegionLabel}</strong> emphasis and readable uncertainty.</div>
       </div>

--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -1215,7 +1215,7 @@ export default function FreeAgency({
                             <TableCell style={{ whiteSpace: "nowrap" }}>
                               {(player.traits || []).map((t) => <TraitBadge key={t} traitId={t} />)}
                             </TableCell>
-                            <TableCell><OvrBadge ovr={player.ovr} /></TableCell>
+                            <TableCell><OvrBadge ovr={player.ovr} />{player.scoutUncertaintyBand ? <div style={{fontSize:11,color:'var(--text-muted)'}}>{player.scoutConfidenceLabel} · ±{player.scoutUncertaintyBand}</div> : null}</TableCell>
                             <TableCell style={{ color: "var(--text-muted)" }}>{player.age}</TableCell>
                             <TableCell style={{ textAlign: "center" }}>
                               <PipBar value={player.schemeFit ?? 50} color="var(--accent)" />
@@ -1291,7 +1291,7 @@ export default function FreeAgency({
                 {sortedAgents.slice(0, 80).map((player, idx) => (
                   <Card key={player.id} className="card-premium" style={{ padding: "var(--space-3)" }}>
                     <div style={{ fontWeight: 700 }}>{idx + 1}. {player.name}</div>
-                    <div style={{ fontSize: 12, color: "var(--text-muted)" }}>{player.pos} · age {player.age} · OVR {player.ovr}</div>
+                    <div style={{ fontSize: 12, color: "var(--text-muted)" }}>{player.pos} · age {player.age} · OVR {player.ovr}{player.scoutUncertaintyBand ? ` (Scout ${player.scoutOvr} ±${player.scoutUncertaintyBand})` : ''}</div>
                     <div style={{ fontSize: 12, color: "var(--text-muted)" }}>Scheme fit {player.schemeFit ?? 50} · morale {player.morale ?? 70}</div>
                     <div style={{ fontSize: 12, marginTop: 4 }}>Demand {(player?.demandProfile?.askAnnual ?? player._ask ?? 0).toFixed(1)}M / yr</div>
                     <div style={{ display: "flex", gap: 6, marginTop: 8 }}>

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -578,6 +578,13 @@ export default function PlayerProfile({
                   )}
                 </div>
 
+
+                {player.developmentContext && (
+                  <div style={{ marginTop: 6, fontSize: 'var(--text-xs)', color: 'var(--text-subtle)' }}>
+                    Dev path: {player.developmentContext.baseAgeCurve} · Focus {String(player.developmentContext.trainingFocus || 'balanced').replace('_', ' ')} · Staff mod {player.developmentContext.staffDevelopmentModifier >= 0 ? '+' : ''}{player.developmentContext.staffDevelopmentModifier}% · {player.developmentContext.playingTimeModifier}
+                  </div>
+                )}
+
                 {/* Traits */}
                 {player.traits?.length > 0 && (
                   <div

--- a/src/ui/components/StaffManagement.jsx
+++ b/src/ui/components/StaffManagement.jsx
@@ -1,877 +1,152 @@
-/**
- * StaffManagement.jsx — Unified staff management screen for Coaches, Scouts, and Medical Staff.
- * Extends the existing coaching system with scouting department and physio staff.
- * Generates staff data client-side using a seeded random based on league year.
- *
- * Props:
- *  - league: league view-model from worker
- *  - actions: worker action dispatchers
- */
+import React, { useCallback, useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { ScreenHeader, SectionCard, EmptyState } from './ScreenSystem.jsx';
+import FranchiseInvestmentsPanel from './FranchiseInvestmentsPanel.jsx';
 
-import React, { useState, useMemo, useCallback } from "react";
-import { deriveFranchisePressure } from "../utils/pressureModel.js";
-import { buildTeamIntelligence } from "../utils/teamIntelligence.js";
-import { deriveTeamCoachingIdentity } from "../utils/coachingIdentity.js";
-import FranchiseInvestmentsPanel from "./FranchiseInvestmentsPanel.jsx";
-import { ScreenHeader, SectionCard, EmptyState, StickySubnav } from "./ScreenSystem.jsx";
+const ROLE_ORDER = ['headCoach', 'offCoordinator', 'defCoordinator', 'scoutDirector', 'headTrainer'];
+const ROLE_LABELS = {
+  headCoach: 'Head Coach',
+  offCoordinator: 'Offensive Coordinator',
+  defCoordinator: 'Defensive Coordinator',
+  scoutDirector: 'Scout Director',
+  headTrainer: 'Head Trainer',
+};
 
-// ── Seeded RNG ──────────────────────────────────────────────────────────────
-
-function createRng(seed) {
-  let s = seed | 0;
-  return () => {
-    s = (s * 1664525 + 1013904223) | 0;
-    return ((s >>> 0) / 0x100000000);
-  };
+function fmtMoney(value) {
+  return `$${Number(value || 0).toFixed(1)}M`;
 }
 
-function pick(rng, arr) {
-  return arr[Math.floor(rng() * arr.length)];
+function effectSummary(roleKey, member) {
+  const s = member?.specialtyRatings ?? {};
+  if (roleKey === 'headCoach') return `Leadership ${s.leadership ?? 0} · Development ${s.playerDevelopment ?? 0}`;
+  if (roleKey === 'offCoordinator') return `QB dev ${s.qbDevelopment ?? 0} · Skill dev ${s.skillPlayerDevelopment ?? 0}`;
+  if (roleKey === 'defCoordinator') return `Front seven ${s.frontSeven ?? 0} · Coverage ${s.coverage ?? 0}`;
+  if (roleKey === 'scoutDirector') return `College ${s.collegeScouting ?? 0} · Pro ${s.proScouting ?? 0} · Potential ${s.potentialEvaluation ?? 0}`;
+  return `Injury prevention ${s.injuryPrevention ?? 0} · Recovery ${s.recovery ?? 0}`;
 }
 
-function randInt(rng, min, max) {
-  return min + Math.floor(rng() * (max - min + 1));
+function valueScore(candidate) {
+  const specialty = Object.values(candidate?.specialtyRatings ?? {}).reduce((sum, n) => sum + Number(n || 0), 0);
+  return Math.round((specialty / Math.max(1, Object.keys(candidate?.specialtyRatings ?? {}).length)) - (Number(candidate?.annualSalary || 0) * 2));
 }
-
-function randFloat(rng, min, max, decimals = 1) {
-  return +(min + rng() * (max - min)).toFixed(decimals);
-}
-
-// ── Name pools ──────────────────────────────────────────────────────────────
-
-const FIRST_NAMES = [
-  "James", "Mike", "David", "Chris", "Steve", "Mark", "Tom", "Dan",
-  "Rick", "Brian", "Tony", "Bill", "Greg", "Jeff", "Paul", "Scott",
-  "Kevin", "Eric", "Jason", "Ryan", "Matt", "John", "Tim", "Rob",
-  "Pete", "Frank", "Ray", "Ken", "Joe", "Ed", "Ben", "Sam",
-];
-
-const LAST_NAMES = [
-  "Johnson", "Williams", "Brown", "Davis", "Miller", "Wilson", "Moore",
-  "Taylor", "Anderson", "Thomas", "Jackson", "White", "Harris", "Martin",
-  "Thompson", "Robinson", "Clark", "Lewis", "Lee", "Walker", "Hall",
-  "Allen", "Young", "King", "Wright", "Scott", "Green", "Baker",
-  "Adams", "Nelson", "Carter", "Mitchell", "Perez", "Roberts", "Turner",
-  "Phillips", "Campbell", "Parker", "Evans", "Edwards", "Collins", "Stewart",
-];
-
-// ── Trait definitions ───────────────────────────────────────────────────────
-
-const SCOUT_TRAITS = [
-  {
-    id: "eye_for_talent",
-    name: "Eye for Talent",
-    icon: "👁️",
-    color: "#a855f7",
-    bg: "rgba(168,85,247,0.12)",
-    description: "More accurate prospect overall ratings. Draft board grades within ±2 of true value.",
-  },
-  {
-    id: "combine_guru",
-    name: "Combine Guru",
-    icon: "🏋️",
-    color: "#ef4444",
-    bg: "rgba(239,68,68,0.12)",
-    description: "Better athletic measurables analysis. Identifies combine risers/fallers earlier.",
-  },
-  {
-    id: "interview_expert",
-    name: "Interview Expert",
-    icon: "🗣️",
-    color: "#3b82f6",
-    bg: "rgba(59,130,246,0.12)",
-    description: "Reveals character and leadership traits before the draft. Avoids bust personalities.",
-  },
-  {
-    id: "film_junkie",
-    name: "Film Junkie",
-    icon: "🎬",
-    color: "#22c55e",
-    bg: "rgba(34,197,94,0.12)",
-    description: "Uncovers hidden potential through game film. Reveals prospect potential earlier.",
-  },
-  {
-    id: "regional_specialist",
-    name: "Regional Specialist",
-    icon: "🗺️",
-    color: "#f59e0b",
-    bg: "rgba(245,158,11,0.12)",
-    description: "Deep contacts in specific conference. Discovers small-school gems others miss.",
-  },
-];
-
-const PHYSIO_TRAITS = [
-  {
-    id: "injury_prevention",
-    name: "Injury Prevention",
-    icon: "🛡️",
-    color: "#22c55e",
-    bg: "rgba(34,197,94,0.12)",
-    description: "Reduces team injury rate by up to 15%. Proactive load management protocols.",
-  },
-  {
-    id: "fast_recovery",
-    name: "Fast Recovery",
-    icon: "⚡",
-    color: "#f59e0b",
-    bg: "rgba(245,158,11,0.12)",
-    description: "Players return from injury 20% faster. Advanced rehabilitation techniques.",
-  },
-  {
-    id: "conditioning_expert",
-    name: "Conditioning Expert",
-    icon: "💪",
-    color: "#ef4444",
-    bg: "rgba(239,68,68,0.12)",
-    description: "Improved stamina and durability ratings. Players maintain peak performance longer.",
-  },
-  {
-    id: "sports_science",
-    name: "Sports Science",
-    icon: "🔬",
-    color: "#3b82f6",
-    bg: "rgba(59,130,246,0.12)",
-    description: "Data-driven training optimization. Slows age-related decline by 1-2 seasons.",
-  },
-  {
-    id: "rehab_specialist",
-    name: "Rehab Specialist",
-    icon: "🏥",
-    color: "#a855f7",
-    bg: "rgba(168,85,247,0.12)",
-    description: "Players return from major injuries at higher capacity. Reduces re-injury risk.",
-  },
-];
-
-const COACH_ROLES = ["Head Coach", "Offensive Coordinator", "Defensive Coordinator"];
-
-const SCOUT_ROLES = [
-  "Director of Scouting", "National Scout", "Area Scout",
-  "Pro Scout", "College Scout",
-];
-
-const PHYSIO_ROLES = [
-  "Head Athletic Trainer", "Physical Therapist", "Strength & Conditioning Coach",
-  "Team Physician", "Recovery Specialist",
-];
-
-// ── Staff generator ─────────────────────────────────────────────────────────
-
-function generateStaffPool(leagueYear, teamId) {
-  const baseSeed = (leagueYear || 2024) * 10000 + (teamId || 0);
-
-  function buildMember(rng, role, traitPool, idx) {
-    const firstName = pick(rng, FIRST_NAMES);
-    const lastName = pick(rng, LAST_NAMES);
-    const numTraits = randInt(rng, 1, 3);
-    const shuffled = [...traitPool].sort(() => rng() - 0.5);
-    const traits = shuffled.slice(0, numTraits);
-    const rating = randInt(rng, 1, 5);
-    const age = randInt(rng, 32, 65);
-    const experience = randInt(rng, 1, Math.min(30, age - 25));
-    const salary = randFloat(rng, 0.5, 3.5 + rating * 0.8, 1);
-    const contractYears = randInt(rng, 1, 4);
-
-    // Performance metrics seeded from rating + random variance
-    const perfBase = rating * 18 + randInt(rng, -8, 8);
-    const performance = Math.max(10, Math.min(99, perfBase));
-
-    return {
-      id: `staff_${role.replace(/\s+/g, "_").toLowerCase()}_${idx}_${baseSeed}`,
-      name: `${firstName} ${lastName}`,
-      role,
-      age,
-      experience,
-      salary,
-      contractYears,
-      traits,
-      rating,
-      performance,
-    };
-  }
-
-  // Current staff (hired)
-  const rngCurrent = createRng(baseSeed);
-  const coaches = COACH_ROLES.map((role, i) => buildMember(rngCurrent, role, [], i));
-  const scouts = SCOUT_ROLES.slice(0, 3).map((role, i) => buildMember(rngCurrent, role, SCOUT_TRAITS, i));
-  const medStaff = PHYSIO_ROLES.slice(0, 2).map((role, i) => buildMember(rngCurrent, role, PHYSIO_TRAITS, i));
-
-  // Candidate pools
-  const rngCand = createRng(baseSeed + 777);
-  const scoutCandidates = SCOUT_ROLES.map((role, i) => buildMember(rngCand, role, SCOUT_TRAITS, i + 100));
-  const physioCandidates = PHYSIO_ROLES.map((role, i) => buildMember(rngCand, role, PHYSIO_TRAITS, i + 200));
-
-  return { coaches, scouts, medStaff, scoutCandidates, physioCandidates };
-}
-
-// ── Budget defaults ─────────────────────────────────────────────────────────
-
-const STAFF_BUDGET_TOTAL = 25.0; // $25M staff budget
-
-// ── Sub-components ──────────────────────────────────────────────────────────
-
-function StarRating({ rating }) {
-  return (
-    <span style={{ display: "inline-flex", gap: 1, fontSize: 14 }} aria-label={`${rating} out of 5 stars`}>
-      {[1, 2, 3, 4, 5].map(i => (
-        <span
-          key={i}
-          style={{ color: i <= rating ? "#f59e0b" : "var(--hairline)", transition: "color 0.2s" }}
-        >
-          ★
-        </span>
-      ))}
-    </span>
-  );
-}
-
-function StaffTraitBadge({ trait }) {
-  return (
-    <span
-      title={`${trait.name}\n${trait.description}`}
-      style={{
-        display: "inline-flex",
-        alignItems: "center",
-        gap: 4,
-        padding: "2px 8px",
-        borderRadius: 999,
-        background: trait.bg,
-        color: trait.color,
-        fontSize: "var(--text-xs, 11px)",
-        fontWeight: 600,
-        cursor: "help",
-        whiteSpace: "nowrap",
-        border: `1px solid ${trait.color}33`,
-        transition: "transform 0.15s",
-      }}
-    >
-      <span>{trait.icon}</span>
-      {trait.name}
-    </span>
-  );
-}
-
-function PersonIcon({ name, accentColor }) {
-  const initials = (name || "")
-    .split(" ")
-    .map(n => n[0])
-    .join("")
-    .slice(0, 2)
-    .toUpperCase();
-
-  return (
-    <div
-      style={{
-        width: 48,
-        height: 48,
-        borderRadius: "50%",
-        background: `${accentColor}18`,
-        border: `2px solid ${accentColor}`,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        fontWeight: 900,
-        fontSize: 14,
-        color: accentColor,
-        flexShrink: 0,
-      }}
-    >
-      {initials}
-    </div>
-  );
-}
-
-function PerformanceMeter({ value, label }) {
-  const color = value >= 75 ? "var(--success, #22c55e)" : value >= 50 ? "var(--warning, #f59e0b)" : "var(--danger, #ef4444)";
-  return (
-    <div style={{ flex: 1, minWidth: 80 }}>
-      <div style={{ fontSize: "var(--text-xs, 11px)", color: "var(--text-muted)", marginBottom: 3, fontWeight: 600 }}>
-        {label}
-      </div>
-      <div style={{
-        width: "100%",
-        height: 6,
-        borderRadius: 3,
-        background: "var(--hairline, #333)",
-        overflow: "hidden",
-      }}>
-        <div style={{
-          width: `${value}%`,
-          height: "100%",
-          borderRadius: 3,
-          background: color,
-          transition: "width 0.6s ease",
-        }} />
-      </div>
-      <div style={{ fontSize: "var(--text-xs, 11px)", fontWeight: 700, color, marginTop: 2 }}>
-        {value}
-      </div>
-    </div>
-  );
-}
-
-function BudgetBar({ used, total }) {
-  const pct = Math.min(100, (used / total) * 100);
-  const remaining = Math.max(0, total - used);
-  const barColor = pct > 90 ? "var(--danger, #ef4444)" : pct > 70 ? "var(--warning, #f59e0b)" : "var(--success, #22c55e)";
-
-  return (
-    <div
-      className="card fade-in"
-      style={{ padding: "var(--space-4, 16px)", marginBottom: "var(--space-4, 16px)" }}
-    >
-      <div style={{
-        display: "flex",
-        justifyContent: "space-between",
-        alignItems: "center",
-        marginBottom: "var(--space-3, 12px)",
-        flexWrap: "wrap",
-        gap: 8,
-      }}>
-        <div>
-          <div style={{ fontWeight: 800, fontSize: "var(--text-lg, 18px)" }}>Staff Budget</div>
-          <div style={{ fontSize: "var(--text-sm, 13px)", color: "var(--text-muted)" }}>
-            Separate from salary cap
-          </div>
-        </div>
-        <div style={{ display: "flex", gap: "var(--space-4, 16px)", flexWrap: "wrap" }}>
-          <div className="stat-box" style={{
-            background: "var(--surface)",
-            padding: "6px 14px",
-            borderRadius: "var(--radius-sm, 6px)",
-            textAlign: "center",
-          }}>
-            <div style={{ fontSize: "var(--text-xs, 11px)", color: "var(--text-muted)", fontWeight: 600, textTransform: "uppercase" }}>
-              Used
-            </div>
-            <div style={{ fontWeight: 800, color: "var(--text)" }}>
-              ${used.toFixed(1)}M
-            </div>
-          </div>
-          <div className="stat-box" style={{
-            background: "var(--surface)",
-            padding: "6px 14px",
-            borderRadius: "var(--radius-sm, 6px)",
-            textAlign: "center",
-          }}>
-            <div style={{ fontSize: "var(--text-xs, 11px)", color: "var(--text-muted)", fontWeight: 600, textTransform: "uppercase" }}>
-              Remaining
-            </div>
-            <div style={{ fontWeight: 800, color: remaining < 3 ? "var(--danger, #ef4444)" : "var(--success, #22c55e)" }}>
-              ${remaining.toFixed(1)}M
-            </div>
-          </div>
-          <div className="stat-box" style={{
-            background: "var(--surface)",
-            padding: "6px 14px",
-            borderRadius: "var(--radius-sm, 6px)",
-            textAlign: "center",
-          }}>
-            <div style={{ fontSize: "var(--text-xs, 11px)", color: "var(--text-muted)", fontWeight: 600, textTransform: "uppercase" }}>
-              Total
-            </div>
-            <div style={{ fontWeight: 800, color: "var(--text)" }}>
-              ${total.toFixed(1)}M
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Progress bar */}
-      <div style={{
-        width: "100%",
-        height: 10,
-        borderRadius: 5,
-        background: "var(--hairline, #333)",
-        overflow: "hidden",
-      }}>
-        <div style={{
-          width: `${pct}%`,
-          height: "100%",
-          borderRadius: 5,
-          background: barColor,
-          transition: "width 0.6s ease",
-        }} />
-      </div>
-      <div style={{
-        display: "flex",
-        justifyContent: "space-between",
-        fontSize: "var(--text-xs, 11px)",
-        color: "var(--text-muted)",
-        marginTop: 4,
-      }}>
-        <span>{pct.toFixed(0)}% allocated</span>
-        <span>${total.toFixed(1)}M cap</span>
-      </div>
-    </div>
-  );
-}
-
-function StaffCard({ member, accentColor, onFire, type }) {
-  return (
-    <div
-      className="card fade-in"
-      style={{
-        padding: "var(--space-4, 16px)",
-        borderLeft: `3px solid ${accentColor}`,
-        transition: "box-shadow 0.2s",
-      }}
-    >
-      {/* Header row */}
-      <div style={{ display: "flex", gap: "var(--space-3, 12px)", alignItems: "flex-start" }}>
-        <PersonIcon name={member.name} accentColor={accentColor} />
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", flexWrap: "wrap", gap: 4 }}>
-            <div>
-              <div style={{ fontWeight: 800, fontSize: "var(--text-base, 15px)" }}>
-                {member.name}
-              </div>
-              <div style={{ fontSize: "var(--text-sm, 13px)", color: "var(--text-muted)", marginTop: 1 }}>
-                {member.role} · Age {member.age} · {member.experience}yr exp
-              </div>
-            </div>
-            <div style={{ textAlign: "right", flexShrink: 0 }}>
-              <StarRating rating={member.rating} />
-              <div style={{ fontSize: "var(--text-xs, 11px)", color: "var(--text-muted)", marginTop: 1 }}>
-                ${member.salary}M / {member.contractYears}yr
-              </div>
-            </div>
-          </div>
-
-          {/* Traits */}
-          {member.traits && member.traits.length > 0 && (
-            <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: "var(--space-2, 8px)" }}>
-              {member.traits.map(t => (
-                <StaffTraitBadge key={t.id} trait={t} />
-              ))}
-            </div>
-          )}
-
-          {/* Performance */}
-          <div style={{ display: "flex", gap: "var(--space-3, 12px)", marginTop: "var(--space-3, 12px)", flexWrap: "wrap" }}>
-            <PerformanceMeter value={member.performance} label="Performance" />
-            {type === "scout" && (
-              <>
-                <PerformanceMeter value={Math.min(99, member.performance + randInt(createRng(member.id?.length || 5), -10, 15))} label="Accuracy" />
-                <PerformanceMeter value={Math.min(99, member.performance + randInt(createRng((member.id?.length || 5) + 1), -12, 10))} label="Network" />
-              </>
-            )}
-            {type === "physio" && (
-              <>
-                <PerformanceMeter value={Math.min(99, member.performance + randInt(createRng(member.id?.length || 5), -10, 15))} label="Prevention" />
-                <PerformanceMeter value={Math.min(99, member.performance + randInt(createRng((member.id?.length || 5) + 1), -12, 10))} label="Recovery" />
-              </>
-            )}
-          </div>
-        </div>
-      </div>
-
-      {/* Fire button */}
-      {onFire && (
-        <div style={{ marginTop: "var(--space-3, 12px)", textAlign: "right" }}>
-          <button
-            className="btn"
-            onClick={() => onFire(member)}
-            style={{
-              background: "transparent",
-              color: "var(--danger, #ef4444)",
-              border: "1px solid var(--danger, #ef4444)",
-              fontSize: "var(--text-xs, 11px)",
-              padding: "4px 12px",
-              borderRadius: "var(--radius-sm, 6px)",
-              cursor: "pointer",
-              fontWeight: 600,
-            }}
-          >
-            Fire
-          </button>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function CandidateRow({ candidate, accentColor, onHire, budgetRemaining }) {
-  const canAfford = candidate.salary <= budgetRemaining;
-
-  return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: "var(--space-3, 12px)",
-        padding: "var(--space-3, 12px)",
-        borderBottom: "1px solid var(--hairline, #333)",
-        flexWrap: "wrap",
-      }}
-    >
-      <PersonIcon name={candidate.name} accentColor={accentColor} />
-      <div style={{ flex: 1, minWidth: 140 }}>
-        <div style={{ fontWeight: 700, fontSize: "var(--text-sm, 13px)" }}>{candidate.name}</div>
-        <div style={{ fontSize: "var(--text-xs, 11px)", color: "var(--text-muted)" }}>
-          {candidate.role} · Age {candidate.age} · {candidate.experience}yr exp
-        </div>
-        {candidate.traits && candidate.traits.length > 0 && (
-          <div style={{ display: "flex", flexWrap: "wrap", gap: 3, marginTop: 4 }}>
-            {candidate.traits.map(t => (
-              <StaffTraitBadge key={t.id} trait={t} />
-            ))}
-          </div>
-        )}
-      </div>
-      <div style={{ textAlign: "center", flexShrink: 0 }}>
-        <StarRating rating={candidate.rating} />
-        <div style={{ fontSize: "var(--text-xs, 11px)", color: "var(--text-muted)", marginTop: 2 }}>
-          ${candidate.salary}M / {candidate.contractYears}yr
-        </div>
-      </div>
-      <button
-        className="btn"
-        disabled={!canAfford}
-        onClick={() => onHire(candidate)}
-        style={{
-          background: canAfford ? "var(--accent)" : "var(--hairline, #333)",
-          color: canAfford ? "#fff" : "var(--text-muted)",
-          border: "none",
-          fontSize: "var(--text-xs, 11px)",
-          padding: "6px 14px",
-          borderRadius: "var(--radius-sm, 6px)",
-          cursor: canAfford ? "pointer" : "not-allowed",
-          fontWeight: 700,
-          flexShrink: 0,
-          opacity: canAfford ? 1 : 0.5,
-        }}
-      >
-        Hire
-      </button>
-    </div>
-  );
-}
-
-function CollapsibleSection({ title, subtitle, count, accentColor, defaultOpen, children }) {
-  const [open, setOpen] = useState(defaultOpen ?? true);
-
-  return (
-    <div style={{ marginBottom: "var(--space-4, 16px)" }}>
-      <button
-        onClick={() => setOpen(o => !o)}
-        style={{
-          width: "100%",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          padding: "var(--space-3, 12px) var(--space-4, 16px)",
-          background: "var(--surface)",
-          border: "1px solid var(--hairline, #333)",
-          borderRadius: "var(--radius-sm, 6px)",
-          cursor: "pointer",
-          color: "var(--text)",
-          transition: "background 0.15s",
-        }}
-      >
-        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-3, 12px)" }}>
-          <div style={{
-            width: 8,
-            height: 8,
-            borderRadius: "50%",
-            background: accentColor,
-            flexShrink: 0,
-          }} />
-          <div style={{ textAlign: "left" }}>
-            <div style={{ fontWeight: 800, fontSize: "var(--text-base, 15px)" }}>{title}</div>
-            {subtitle && (
-              <div style={{ fontSize: "var(--text-xs, 11px)", color: "var(--text-muted)", marginTop: 1 }}>
-                {subtitle}
-              </div>
-            )}
-          </div>
-        </div>
-        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2, 8px)" }}>
-          {count !== undefined && (
-            <span className="ovr-pill" style={{
-              background: `${accentColor}22`,
-              color: accentColor,
-              fontWeight: 700,
-              fontSize: "var(--text-xs, 11px)",
-              padding: "2px 8px",
-              borderRadius: 999,
-            }}>
-              {count}
-            </span>
-          )}
-          <span style={{
-            fontSize: 16,
-            transform: open ? "rotate(180deg)" : "rotate(0deg)",
-            transition: "transform 0.2s",
-            lineHeight: 1,
-          }}>
-            ▼
-          </span>
-        </div>
-      </button>
-
-      {open && (
-        <div className="fade-in" style={{ marginTop: "var(--space-3, 12px)" }}>
-          {children}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function ConfirmDialog({ message, onConfirm, onCancel }) {
-  return (
-    <div
-      onClick={onCancel}
-      style={{
-        position: "fixed",
-        inset: 0,
-        zIndex: 9200,
-        background: "rgba(0,0,0,0.7)",
-        backdropFilter: "blur(8px)",
-        WebkitBackdropFilter: "blur(8px)",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: "var(--space-4, 16px)",
-      }}
-    >
-      <div
-        onClick={e => e.stopPropagation()}
-        className="card fade-in"
-        style={{
-          width: "100%",
-          maxWidth: 360,
-          padding: "var(--space-5, 20px)",
-          textAlign: "center",
-        }}
-      >
-        <div style={{ fontSize: 32, marginBottom: "var(--space-3, 12px)" }}>⚠️</div>
-        <div style={{ fontWeight: 700, fontSize: "var(--text-base, 15px)", marginBottom: "var(--space-4, 16px)" }}>
-          {message}
-        </div>
-        <div style={{ display: "flex", gap: "var(--space-3, 12px)", justifyContent: "center" }}>
-          <button
-            className="btn"
-            onClick={onCancel}
-            style={{
-              background: "var(--surface)",
-              color: "var(--text)",
-              border: "1px solid var(--hairline, #333)",
-              padding: "8px 20px",
-              borderRadius: "var(--radius-sm, 6px)",
-              cursor: "pointer",
-              fontWeight: 600,
-            }}
-          >
-            Cancel
-          </button>
-          <button
-            className="btn"
-            onClick={onConfirm}
-            style={{
-              background: "var(--danger, #ef4444)",
-              color: "#fff",
-              border: "none",
-              padding: "8px 20px",
-              borderRadius: "var(--radius-sm, 6px)",
-              cursor: "pointer",
-              fontWeight: 700,
-            }}
-          >
-            Confirm
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function HiringPanel({ title, candidates, accentColor, onHire, budgetRemaining, onClose }) {
-  return (
-    <div
-      onClick={onClose}
-      style={{
-        position: "fixed",
-        inset: 0,
-        zIndex: 9100,
-        background: "rgba(0,0,0,0.7)",
-        backdropFilter: "blur(8px)",
-        WebkitBackdropFilter: "blur(8px)",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: "var(--space-4, 16px)",
-      }}
-    >
-      <div
-        onClick={e => e.stopPropagation()}
-        className="card fade-in"
-        style={{
-          width: "100%",
-          maxWidth: 560,
-          maxHeight: "80vh",
-          display: "flex",
-          flexDirection: "column",
-          overflow: "hidden",
-          borderTop: `3px solid ${accentColor}`,
-        }}
-      >
-        <div style={{
-          padding: "var(--space-4, 16px)",
-          borderBottom: "1px solid var(--hairline, #333)",
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-        }}>
-          <div>
-            <div style={{ fontWeight: 800, fontSize: "var(--text-lg, 18px)" }}>{title}</div>
-            <div style={{ fontSize: "var(--text-xs, 11px)", color: "var(--text-muted)", marginTop: 2 }}>
-              Budget remaining: ${budgetRemaining.toFixed(1)}M
-            </div>
-          </div>
-          <button
-            onClick={onClose}
-            style={{
-              background: "none",
-              border: "none",
-              color: "var(--text-muted)",
-              fontSize: 20,
-              cursor: "pointer",
-              lineHeight: 1,
-              padding: 4,
-            }}
-          >
-            ✕
-          </button>
-        </div>
-        <div style={{ overflowY: "auto", flex: 1 }}>
-          {candidates.length === 0 ? (
-            <div style={{ padding: "var(--space-5, 20px)", textAlign: "center", color: "var(--text-muted)" }}>
-              No candidates available.
-            </div>
-          ) : (
-            candidates.map(c => (
-              <CandidateRow
-                key={c.id}
-                candidate={c}
-                accentColor={accentColor}
-                onHire={onHire}
-                budgetRemaining={budgetRemaining}
-              />
-            ))
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ── Main Component ──────────────────────────────────────────────────────────
 
 export default function StaffManagement({ league, actions }) {
   const teamId = league?.userTeamId ?? 0;
   const [staffState, setStaffState] = useState(null);
-  const [hiringPanel, setHiringPanel] = useState(null);
+  const [selectedRole, setSelectedRole] = useState('all');
+  const [sortBy, setSortBy] = useState('overall');
 
   const refresh = useCallback(async () => {
-    if (!actions?.getStaffState) return;
-    const res = await actions.getStaffState();
+    const res = await actions?.getStaffState?.();
     if (res?.payload) setStaffState(res.payload);
   }, [actions]);
 
   React.useEffect(() => { refresh(); }, [refresh]);
 
-  const userTeam = useMemo(() => (league?.teams ?? []).find((t) => t.id === teamId) ?? null, [league?.teams, teamId]);
-  const teamIntel = useMemo(() => buildTeamIntelligence(userTeam, { week: league?.week ?? 1 }), [userTeam, league?.week]);
-  const direction = teamIntel?.direction ?? "balanced";
-  const pressure = useMemo(() => deriveFranchisePressure(league, { intel: teamIntel, direction }), [league, teamIntel, direction]);
-  const coachingIdentity = useMemo(() => deriveTeamCoachingIdentity(userTeam, { pressure, intel: teamIntel, direction }), [userTeam, pressure, teamIntel, direction]);
-
+  const userTeam = useMemo(() => (league?.teams ?? []).find((t) => Number(t.id) === Number(teamId)) ?? null, [league?.teams, teamId]);
   const staff = staffState?.staff ?? {};
-  const market = staffState?.market ?? [];
-  const draftBoard = staffState?.draftBoard ?? { shortlist: [], avoid: [] };
+  const market = Array.isArray(staffState?.market) ? staffState.market : [];
+  const bonuses = staffState?.bonuses ?? {};
 
-  const roles = {
-    coach: ['headCoach', 'offCoordinator', 'defCoordinator'],
-    scout: ['leadScout', 'proScout'],
-    physio: ['headTrainer', 'capAdvisor'],
-  };
+  const currentStaffRows = ROLE_ORDER.map((roleKey) => ({ roleKey, member: staff?.[roleKey] ?? null }));
+  const staffSalaryTotal = currentStaffRows.reduce((sum, row) => sum + Number(row.member?.annualSalary ?? 0), 0);
 
-  const staffListFor = (keys) => keys.map((key) => ({ ...(staff?.[key] ?? {}), roleKey: key, role: staff?.[key]?.role ?? key })).filter((m) => m?.id);
+  const filteredMarket = useMemo(() => {
+    const base = market.filter((candidate) => selectedRole === 'all' || candidate?.roleKey === selectedRole);
+    return [...base].sort((a, b) => {
+      if (sortBy === 'salary') return Number(a?.annualSalary ?? 0) - Number(b?.annualSalary ?? 0);
+      if (sortBy === 'development') {
+        const aDev = Number(a?.specialtyRatings?.playerDevelopment ?? a?.specialtyRatings?.qbDevelopment ?? a?.specialtyRatings?.defensiveDevelopment ?? 0);
+        const bDev = Number(b?.specialtyRatings?.playerDevelopment ?? b?.specialtyRatings?.qbDevelopment ?? b?.specialtyRatings?.defensiveDevelopment ?? 0);
+        return bDev - aDev;
+      }
+      if (sortBy === 'scouting') {
+        const aScout = Number(a?.specialtyRatings?.collegeScouting ?? 0) + Number(a?.specialtyRatings?.proScouting ?? 0);
+        const bScout = Number(b?.specialtyRatings?.collegeScouting ?? 0) + Number(b?.specialtyRatings?.proScouting ?? 0);
+        return bScout - aScout;
+      }
+      return Number(b?.overall ?? 0) - Number(a?.overall ?? 0);
+    });
+  }, [market, selectedRole, sortBy]);
 
-  const coaches = staffListFor(roles.coach);
-  const scouts = staffListFor(roles.scout);
-  const medStaff = staffListFor(roles.physio);
-
-  const totalUsed = useMemo(() => [...coaches, ...scouts, ...medStaff].reduce((s, c) => s + Number(c?.salary ?? 0), 0), [coaches, scouts, medStaff]);
-  const budgetRemaining = +(STAFF_BUDGET_TOTAL - totalUsed).toFixed(1);
-
-  const handleFire = async (member) => {
-    await actions?.fireStaffMember?.({ teamId, roleKey: member.roleKey });
+  const hire = async (candidate) => {
+    await actions?.hireStaffMember?.({ teamId, roleKey: candidate?.roleKey, candidate });
     await refresh();
   };
 
-  const handleHire = async (candidate) => {
-    await actions?.hireStaffMember?.({ teamId, roleKey: candidate.roleKey, candidate });
-    setHiringPanel(null);
+  const fire = async (roleKey) => {
+    await actions?.fireStaffMember?.({ teamId, roleKey });
     await refresh();
   };
-
-  const enrich = (m) => ({ ...m, performance: m?.rating ?? 60, traits: Object.entries(m?.attrs ?? {}).slice(0, 3).map(([k,v]) => ({ id:k, name:`${k}: ${Math.round(v)}`, icon:'•', color:'#60a5fa', bg:'rgba(96,165,250,0.15)', description:k })) });
 
   return (
-    <div style={{ maxWidth: 900, margin: "0 auto" }} className="app-screen-stack">
+    <div className="app-screen-stack" style={{ maxWidth: 1000, margin: '0 auto' }}>
       <ScreenHeader
         eyebrow="Operations"
-        title="Staff Management"
-        subtitle="Run coaching, scouting, and support hiring from one workflow."
+        title="Staff & Development"
+        subtitle="Hire coaches and department heads, manage contracts, and see exactly what each role improves."
         metadata={[
-          { label: "Budget Used", value: `$${totalUsed.toFixed(1)}M` },
-          { label: "Remaining", value: `$${budgetRemaining.toFixed(1)}M` },
-          { label: "Direction", value: direction },
+          { label: 'Staff payroll', value: fmtMoney(staffSalaryTotal) },
+          { label: 'Dev impact', value: `${((bonuses.developmentDelta ?? 0) * 100).toFixed(1)}%` },
+          { label: 'Scouting confidence', value: bonuses.summary?.[2] ?? 'Balanced' },
         ]}
       />
-      <StickySubnav title="Quick actions">
-        <button className="btn" onClick={() => setHiringPanel('scout')}>Hire Scout</button>
-        <button className="btn" onClick={() => setHiringPanel('support')}>Hire Support</button>
-      </StickySubnav>
-      <SectionCard title="Budget">
-        <BudgetBar used={totalUsed} total={STAFF_BUDGET_TOTAL} />
+
+      <SectionCard title="Current staff" subtitle="One core role per franchise layer. Replace or fire from here.">
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(230px,1fr))', gap: 10 }}>
+          {currentStaffRows.map(({ roleKey, member }) => (
+            <div key={roleKey} className="card" style={{ padding: 10 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
+                <strong>{ROLE_LABELS[roleKey]}</strong>
+                <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>OVR {member?.overall ?? '--'}</span>
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4 }}>{member?.name ?? 'Vacant'} · {member?.age ?? '--'} · {member?.reputationTier ?? 'Unproven'}</div>
+              <div style={{ fontSize: 12, marginTop: 4 }}>{effectSummary(roleKey, member)}</div>
+              <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4 }}>Contract: {member?.contractYears ?? 0} yrs · {fmtMoney(member?.annualSalary)}</div>
+              <div style={{ display: 'flex', gap: 6, marginTop: 8 }}>
+                <Button size="sm" variant="outline" onClick={() => setSelectedRole(roleKey)}>Replace</Button>
+                <Button size="sm" variant="ghost" onClick={() => fire(roleKey)}>Fire</Button>
+              </div>
+            </div>
+          ))}
+        </div>
       </SectionCard>
-      {staffState?.bonuses && <div className="card" style={{ padding: 10, marginBottom: 12, fontSize: 12, color: 'var(--text-muted)' }}>
-        Development {staffState.bonuses.developmentDelta >= 0 ? '+' : ''}{(staffState.bonuses.developmentDelta*100).toFixed(1)}% · Rookie adaptation {staffState.bonuses.rookieAdaptationDelta >= 0 ? '+' : ''}{(staffState.bonuses.rookieAdaptationDelta*100).toFixed(1)}% · Injury volatility {(staffState.bonuses.injuryRateDelta*100).toFixed(1)}%
-      </div>}
 
-      <CollapsibleSection title="Coaching Staff" count={coaches.length} accentColor="#f59e0b" defaultOpen>
-        <div style={{ display: 'grid', gap: 10 }}>{coaches.map((c) => <StaffCard key={c.id} member={enrich(c)} accentColor="#f59e0b" onFire={handleFire} type="coach" />)}</div>
-      </CollapsibleSection>
+      <SectionCard title="Team impact summary" subtitle="How your current staff affects development, scouting, and injury areas.">
+        <div style={{ display: 'grid', gap: 6, fontSize: 13 }}>
+          {(bonuses.summary ?? []).map((line) => <div key={line}>• {line}</div>)}
+        </div>
+      </SectionCard>
 
-      <CollapsibleSection title="Scouting Department" count={scouts.length} accentColor="#3b82f6" defaultOpen>
-        <div style={{ display: 'grid', gap: 10 }}>{scouts.map((c) => <StaffCard key={c.id} member={enrich(c)} accentColor="#3b82f6" onFire={handleFire} type="scout" />)}</div>
-        <button className="btn" onClick={() => setHiringPanel('scout')}>Hire Scout Staff</button>
-      </CollapsibleSection>
+      <SectionCard title="Candidate market" subtitle="Filter and sort by role, overall, development, scouting, and salary demand.">
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 10 }}>
+          <select value={selectedRole} onChange={(e) => setSelectedRole(e.target.value)}><option value="all">All roles</option>{ROLE_ORDER.map((r) => <option key={r} value={r}>{ROLE_LABELS[r]}</option>)}</select>
+          <select value={sortBy} onChange={(e) => setSortBy(e.target.value)}>
+            <option value="overall">Sort: Overall</option>
+            <option value="development">Sort: Development</option>
+            <option value="scouting">Sort: Scouting</option>
+            <option value="salary">Sort: Salary demand</option>
+          </select>
+        </div>
+        <div style={{ display: 'grid', gap: 8 }}>
+          {filteredMarket.slice(0, 24).map((candidate) => (
+            <div key={candidate.id} className="card" style={{ padding: 10 }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>
+                <div>
+                  <strong>{candidate.name}</strong>
+                  <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{ROLE_LABELS[candidate.roleKey] ?? candidate.role}</div>
+                </div>
+                <div style={{ fontSize: 12, textAlign: 'right' }}>OVR {candidate.overall} · {candidate.reputationTier}<br />Demand {fmtMoney(candidate.annualSalary)} / {candidate.contractYears}y</div>
+              </div>
+              <div style={{ fontSize: 12, marginTop: 4 }}>{effectSummary(candidate.roleKey, candidate)}</div>
+              <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>Value score: {valueScore(candidate)} · Tags: {(candidate.styleTags ?? []).join(', ') || 'none'}</div>
+              <div style={{ marginTop: 8 }}><Button size="sm" onClick={() => hire(candidate)}>Hire / Replace</Button></div>
+            </div>
+          ))}
+        </div>
+      </SectionCard>
 
-      <CollapsibleSection title="Medical + Contracts" count={medStaff.length} accentColor="#22c55e" defaultOpen>
-        <div style={{ display: 'grid', gap: 10 }}>{medStaff.map((c) => <StaffCard key={c.id} member={enrich(c)} accentColor="#22c55e" onFire={handleFire} type="physio" />)}</div>
-        <button className="btn" onClick={() => setHiringPanel('support')}>Hire Support Staff</button>
-      </CollapsibleSection>
-
-      <div className="card" style={{ padding: 10, marginTop: 10 }}>
-        <div style={{ fontSize: 12, fontWeight: 700 }}>Draft board watchlist</div>
-        <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>Shortlist: {draftBoard.shortlist?.length ?? 0} · Avoid: {draftBoard.avoid?.length ?? 0}</div>
-      </div>
-
-      {hiringPanel && (
-        <HiringPanel
-          title="Staff Market"
-          candidates={market.filter((m) => hiringPanel === 'scout' ? ['leadScout','proScout'].includes(m.roleKey) : ['headTrainer','capAdvisor'].includes(m.roleKey))}
-          accentColor={hiringPanel === 'scout' ? '#3b82f6' : '#22c55e'}
-          onHire={handleHire}
-          budgetRemaining={budgetRemaining}
-          onClose={() => setHiringPanel(null)}
-        />
-      )}
+      <FranchiseInvestmentsPanel team={userTeam} actions={actions} />
       {!staffState && <EmptyState title="No staff state yet" body="Load a save with staff data to unlock hiring and firing actions." />}
     </div>
   );

--- a/src/ui/utils/franchiseInvestments.js
+++ b/src/ui/utils/franchiseInvestments.js
@@ -6,6 +6,7 @@ const DEFAULT_INVESTMENTS = Object.freeze({
   scoutingRegion: 'national',
   ownerCapacity: 10,
   usedCapacity: 4,
+  trainingFocus: 'balanced',
   history: [],
 });
 
@@ -26,6 +27,7 @@ export function normalizeFranchiseInvestments(raw = {}) {
   merged.usedCapacity = clampInt(merged.usedCapacity, 0, merged.ownerCapacity);
   merged.concessionsStrategy = ['fan_friendly', 'balanced', 'premium'].includes(merged.concessionsStrategy) ? merged.concessionsStrategy : 'balanced';
   merged.scoutingRegion = REGION_OPTIONS.some((r) => r.key === merged.scoutingRegion) ? merged.scoutingRegion : 'national';
+  merged.trainingFocus = ['balanced','youth_development','win_now','rehab_recovery','strength_conditioning'].includes(merged.trainingFocus) ? merged.trainingFocus : 'balanced';
   merged.history = Array.isArray(merged.history) ? merged.history.slice(0, 20) : [];
   return merged;
 }
@@ -83,6 +85,7 @@ export function franchiseInvestmentSummary(team) {
     stadiumLabel: `Fan experience ${inv.stadiumLevel}/5`,
     trainingLabel: `Training complex ${inv.trainingLevel}/5`,
     scoutingLabel: `Scouting department ${inv.scoutingLevel}/5`,
+    trainingFocusLabel: inv.trainingFocus === 'youth_development' ? 'Youth Development' : inv.trainingFocus === 'win_now' ? 'Win Now' : inv.trainingFocus === 'rehab_recovery' ? 'Rehab / Recovery' : inv.trainingFocus === 'strength_conditioning' ? 'Strength & Conditioning' : 'Balanced',
     concessionsLabel: inv.concessionsStrategy === 'fan_friendly' ? 'Fan-friendly pricing' : inv.concessionsStrategy === 'premium' ? 'Premium pricing' : 'Balanced pricing',
     scoutingRegionLabel: REGION_OPTIONS.find((r) => r.key === inv.scoutingRegion)?.label ?? 'National balanced',
   };

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -153,6 +153,7 @@ function normalizeFranchiseInvestments(raw = {}) {
     scoutingRegion: 'national',
     ownerCapacity: 10,
     usedCapacity: 4,
+    trainingFocus: 'balanced',
     history: [],
   };
   const merged = { ...base, ...(raw || {}) };
@@ -163,6 +164,7 @@ function normalizeFranchiseInvestments(raw = {}) {
   merged.usedCapacity = Math.max(0, Math.min(merged.ownerCapacity, Math.round(Number(merged.usedCapacity) || 4)));
   if (!['fan_friendly', 'balanced', 'premium'].includes(merged.concessionsStrategy)) merged.concessionsStrategy = 'balanced';
   if (!['national', 'southeast', 'southwest', 'midwest', 'west'].includes(merged.scoutingRegion)) merged.scoutingRegion = 'national';
+  if (!['balanced','youth_development','win_now','rehab_recovery','strength_conditioning'].includes(merged.trainingFocus)) merged.trainingFocus = 'balanced';
   merged.history = Array.isArray(merged.history) ? merged.history.slice(0, 20) : [];
   return merged;
 }
@@ -3909,6 +3911,7 @@ async function handleGetFreeAgents(payload, id) {
 
   const freeAgents = allFreeAgents
     .map(p => {
+        const scoutingView = buildScoutingSnapshot(p, userTeam, { fogStrength: Number(getLeagueSetting('scoutingFogStrength', 50)), commissionerMode: !!meta?.commissionerMode });
         // Summarize offers for UI — bidding war edition
         const offers = p.offers || [];
         const userOffer = offers.find(o => o.teamId === userTeamId);
@@ -4002,6 +4005,9 @@ async function handleGetFreeAgents(payload, id) {
           pos:       p.pos,
           age:       p.age,
           ovr:       p.ovr,
+          scoutOvr: scoutingView?.estimatedOvr ?? p.ovr,
+          scoutUncertaintyBand: scoutingView?.uncertainty ?? 0,
+          scoutConfidenceLabel: scoutingView?.confidenceLabel ?? 'Medium confidence',
           potential: p.potential ?? null,
           contract:  p.contract ?? null,
           traits:    p.traits ?? [],
@@ -6077,15 +6083,17 @@ function runAiStaffCarousel(meta, teams) {
     const staff = ensureTeamStaff(team, { year: Number(meta?.year ?? 2025) });
     const winPct = ((team?.wins ?? 0) + 0.5 * (team?.ties ?? 0)) / Math.max(1, (team?.wins ?? 0) + (team?.losses ?? 0) + (team?.ties ?? 0));
     const direction = winPct >= 0.62 ? 'contender' : winPct <= 0.42 ? 'rebuild' : 'balanced';
-    const roles = ['headCoach', 'offCoordinator', 'defCoordinator', 'leadScout', 'proScout', 'headTrainer', 'capAdvisor'];
+    const roles = ['headCoach', 'offCoordinator', 'defCoordinator', 'scoutDirector', 'headTrainer'];
     for (const roleKey of roles) {
       const current = staff?.[roleKey];
-      const stayBias = direction === 'contender' ? 0.78 : direction === 'rebuild' ? 0.58 : 0.66;
-      if (current && Math.random() < stayBias) continue;
-      const pool = market.filter((m) => m.roleKey === roleKey);
+      const currentScore = Number(current?.overall ?? 55);
+      const stayBias = direction === 'contender' ? 0.8 : direction === 'rebuild' ? 0.58 : 0.68;
+      if (current && currentScore >= 75 && Math.random() < stayBias) continue;
+      const pool = market.filter((m) => m.roleKey === roleKey).sort((a, b) => Number(b?.overall ?? 0) - Number(a?.overall ?? 0));
       if (!pool.length) continue;
-      const candidate = pool[Math.floor(Math.random() * Math.min(6, pool.length))];
-      if (!candidate) continue;
+      const shortlist = pool.slice(0, 12);
+      const candidate = shortlist[Math.floor(Math.random() * Math.max(2, shortlist.length / 2))] ?? shortlist[0];
+      if (!candidate || Number(candidate?.overall ?? 0) < currentScore + (direction === 'rebuild' ? -3 : 2)) continue;
       staff[roleKey] = { ...candidate, continuity: { teamId: team.id, sinceYear: Number(meta?.year ?? 2025), tenureYears: 0 } };
     }
     cache.updateTeam(team.id, { staff });
@@ -6138,6 +6146,7 @@ async function handleAdvanceOffseason(payload, id) {
   for (const team of allTeams) {
     const inv = team?.franchiseInvestments ?? {};
     const trainingLevel = Math.max(1, Math.min(5, Math.round(Number(inv?.trainingLevel ?? 1) || 1)));
+    const trainingFocus = String(inv?.trainingFocus ?? 'balanced');
     const roster = Array.isArray(team?.roster) ? team.roster : allPlayers.filter((p) => Number(p?.teamId) === Number(team?.id));
     const moraleAvg = roster.length ? roster.reduce((sum, p) => sum + (Number(p?.morale ?? 70) || 70), 0) / roster.length : 70;
     const stableMorale = moraleAvg >= 74 ? 1 : moraleAvg <= 60 ? -1 : 0;
@@ -6148,10 +6157,13 @@ async function handleAdvanceOffseason(payload, id) {
       .filter(Boolean)
       .reduce((sum, member) => sum + (Number(member?.yearsWithTeam ?? member?.tenure ?? 0) >= 2 ? 1 : 0), 0);
     const continuitySignal = continuityCount >= 2 ? 1 : continuityCount === 0 ? -1 : 0;
-    const youngGrowthBonus = ((trainingLevel >= 4 ? 0.12 : trainingLevel >= 3 ? 0.06 : trainingLevel <= 2 ? -0.04 : 0) + (staffBonuses.developmentDelta ?? 0)) * envScale;
-    const volatilityDampener = ((continuitySignal > 0 ? 0.08 : continuitySignal < 0 ? -0.05 : 0) + (staffBonuses.moraleStabilityDelta ?? 0)) * staffScale;
-    const rookieAdaptation = ((trainingLevel >= 4 ? 0.08 : 0) + (stableMorale > 0 ? 0.07 : stableMorale < 0 ? -0.07 : 0) + (staffBonuses.rookieAdaptationDelta ?? 0)) * envScale;
-    teamEnvironments[team.id] = { youngGrowthBonus, volatilityDampener, rookieAdaptation };
+    const focusGrowth = trainingFocus === 'youth_development' ? 0.08 : trainingFocus === 'win_now' ? -0.03 : trainingFocus === 'strength_conditioning' ? 0.04 : 0;
+    const focusReadiness = trainingFocus === 'win_now' ? 0.05 : trainingFocus === 'rehab_recovery' ? -0.02 : 0;
+    const focusRecovery = trainingFocus === 'rehab_recovery' ? 0.06 : trainingFocus === 'strength_conditioning' ? 0.03 : 0;
+    const youngGrowthBonus = ((trainingLevel >= 4 ? 0.12 : trainingLevel >= 3 ? 0.06 : trainingLevel <= 2 ? -0.04 : 0) + focusGrowth + (staffBonuses.developmentDelta ?? 0)) * envScale;
+    const volatilityDampener = ((continuitySignal > 0 ? 0.08 : continuitySignal < 0 ? -0.05 : 0) + (staffBonuses.moraleStabilityDelta ?? 0) + focusReadiness) * staffScale;
+    const rookieAdaptation = ((trainingLevel >= 4 ? 0.08 : 0) + (stableMorale > 0 ? 0.07 : stableMorale < 0 ? -0.07 : 0) + (staffBonuses.rookieAdaptationDelta ?? 0) + focusRecovery) * envScale;
+    teamEnvironments[team.id] = { youngGrowthBonus, volatilityDampener, rookieAdaptation, trainingFocus, staffDevelopmentModifier: staffBonuses.developmentDelta ?? 0 };
   }
   const { gainers, regressors, breakouts, wallHits } = processPlayerProgression(allPlayers, { teamEnvironments });
 
@@ -6163,6 +6175,7 @@ async function handleAdvanceOffseason(payload, id) {
       ovr:              player.ovr,
       potential:        player.potential,
       progressionDelta: player.progressionDelta ?? null,
+      developmentContext: player.developmentContext ?? null,
     });
   }
 


### PR DESCRIPTION
### Motivation
- Provide a clear, extensible staff layer (coaches, scouting, medical) that meaningfully affects player development, scouting confidence, and injury/recovery without adding unrelated systems. 
- Make hiring/firing, contracts, and staff market visible and mobile-friendly so players can understand staff value and choices. 
- Wire franchise-level training focus into the offseason progression pass so training + staff visibly influence player growth. 

### Description
- Added a reusable staff foundation with five core roles and role-specific attributes, market generation, impact evaluation, and human-friendly summary strings in `src/core/staff/staffFoundation.js` and reworked `src/core/staff-system.js` to use it with backward-compatible aliases. 
- Implemented lightweight scouting confidence helpers in `src/core/scouting/scoutingSystem.js` and integrated staff + franchise scouting into player snapshots and free-agent views (worker and UI wiring). 
- Introduced a development helper and franchise `trainingFocus` (options: `balanced`, `youth_development`, `win_now`, `rehab_recovery`, `strength_conditioning`) and surfaced a `developmentContext` on players to explain progression in `src/core/development/developmentSystem.js`, `src/core/progression-logic.js`, and `src/ui/components/PlayerProfile.jsx`. 
- Replaced/rewrote the Staff UI to a card-based `StaffManagement` screen with current staff, candidate market filtering/sorting, contract visibility, and hire/fire actions, and added training-focus controls to `FranchiseInvestmentsPanel`. 
- Updated worker-side logic to provide `STAFF_STATE`, to persist hires/fires (`handleHireStaffMember`/`handleFireStaffMember`), to include scouting snapshot fields for free agents, and to run a simple AI staff carousel that fills/upgrades core roles. 

### Testing
- Ran `npm run build` and produced a successful production build (`vite build`) ✅. 
- Ran the focused unit suite for staff changes with `npx vitest run tests/unit/staff_system.test.js` and it passed ✅. 
- Ran full unit tests with `npm run test:unit`; the command completed but the repository contains multiple unrelated, pre-existing failing suites outside the scope of this PR (failures noted but not caused by the staff changes) ⚠️.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d863f12230832d85c91d8cc04f427a)