### PR TITLE
Phase 5: player motivation & negotiation system (motivation model, offer evaluation, FA signals)

### DIFF
--- a/src/core/ai-logic.js
+++ b/src/core/ai-logic.js
@@ -12,6 +12,8 @@ import {
     buildDecisionTiming,
 } from './contract-market.js';
 import NewsEngine from './news-engine.js';
+import { getTeamContextForNegotiation } from './teamContext/negotiationContext.js';
+import { evaluateContractOffer } from './contracts/negotiation.js';
 
 class AiLogic {
 
@@ -630,13 +632,24 @@ class AiLogic {
                 : calculateDefensiveSchemeFit(player, team?.staff?.headCoach?.defScheme || '4-3');
             const direction = inferTeamDirection(team, Number(cache.getMeta()?.currentWeek ?? 1));
             const roleOpportunity = (this.calculateTeamNeeds(team.id)?.[player.pos] ?? 1) / 2.2;
-            const score = scoreOffer(player, offer, {
+            const legacyScore = scoreOffer(player, offer, {
                 team,
                 direction,
                 roleOpportunity,
                 fit: fitScore,
                 loyaltyBoost: Number(team.id) === Number(player.teamId) ? 0.35 : 0,
             }, { profile, askTotalValue: askTotal });
+            const teamContext = getTeamContextForNegotiation(player, team, null, {
+                teamDirection: direction,
+                needsAtPosition: this.calculateTeamNeeds(team.id)?.[player.pos] ?? 1,
+                rosterAtPosition: cache.getPlayersByTeam(team.id).filter((p) => p?.pos === player?.pos),
+            });
+            const offerEval = evaluateContractOffer(player, {
+                ...teamContext,
+                schemeFitScore: fitScore,
+                franchiseDirectionScore: direction === 'contender' ? 78 : direction === 'rebuilding' ? 44 : 58,
+            }, offer, { profile, askTotalValue: askTotal, askAnnual: ask.baseAnnual, askYears: ask.yearsTotal });
+            const score = legacyScore * 55 + (offerEval.score / 100) * 45;
 
             if (score > bestScore) {
                 bestScore = score;

--- a/src/core/contract-market.js
+++ b/src/core/contract-market.js
@@ -1,3 +1,5 @@
+import { buildPlayerMotivationProfile } from './mood/playerMood.js';
+
 const SCARCITY_BASELINE = {
   QB: 8,
   WR: 18,
@@ -44,36 +46,19 @@ export function inferTeamDirection(team, week = 1) {
   return 'middling';
 }
 
-export function buildContractProfile(player = {}) {
-  const age = safeNum(player.age, 26);
-  const morale = safeNum(player.morale, 70);
-  const noiseA = seeded(player.id, 41);
-  const noiseB = seeded(player.id, 97);
-  const traits = Array.isArray(player?.traits) ? player.traits.map((t) => String(t).toLowerCase()) : [];
-
-  const isLoyal = traits.includes('loyal') || noiseA > 0.82;
-  const moneyPriority = Math.max(0.2, Math.min(0.95, 0.45 + (age < 27 ? 0.18 : 0) + (noiseA - 0.5) * 0.2));
-  const contenderPriority = Math.max(0.1, Math.min(0.95, 0.4 + (age >= 30 ? 0.28 : 0) + (noiseB - 0.5) * 0.18));
-  const rolePriority = Math.max(0.15, Math.min(0.95, 0.42 + (age <= 27 ? 0.12 : 0) + (morale < 55 ? 0.16 : 0)));
-  const securityPriority = Math.max(0.15, Math.min(0.95, 0.45 + (age <= 25 ? 0.2 : 0) - (age >= 31 ? 0.15 : 0)));
-  const loyaltyPriority = Math.max(0.05, Math.min(0.9, (isLoyal ? 0.55 : 0.18) + (morale >= 75 ? 0.12 : 0)));
-  const schemePriority = Math.max(0.05, Math.min(0.8, 0.22 + (noiseB - 0.5) * 0.2));
-  const negotiationFlex = Math.max(0.05, Math.min(0.9, 0.35 + (isLoyal ? 0.15 : 0) + (morale >= 70 ? 0.1 : -0.08)));
-
+export function buildContractProfile(player = {}, teamContext = {}) {
+  const base = buildPlayerMotivationProfile(player, teamContext);
   let headline = 'Balanced priorities';
-  if (moneyPriority >= Math.max(contenderPriority, rolePriority, loyaltyPriority)) headline = 'Money-focused';
-  else if (contenderPriority >= Math.max(rolePriority, loyaltyPriority)) headline = 'Seeking contender';
-  else if (rolePriority >= loyaltyPriority) headline = 'Wants a bigger role';
+  if (base.moneyPriority >= Math.max(base.contenderPriority, base.rolePriority, base.loyalty)) headline = 'Money-focused';
+  else if (base.contenderPriority >= Math.max(base.rolePriority, base.loyalty)) headline = 'Seeking contender';
+  else if (base.rolePriority >= base.loyalty) headline = 'Wants a bigger role';
   else headline = 'Open to hometown discount';
 
   return {
-    moneyPriority,
-    contenderPriority,
-    rolePriority,
-    securityPriority,
-    loyaltyPriority,
-    schemePriority,
-    negotiationFlex,
+    ...base,
+    loyaltyPriority: base.loyalty,
+    schemePriority: base.schemeFitPreference,
+    negotiationFlex: Math.max(0.05, Math.min(0.9, 0.28 + base.patience * 0.5 + base.loyalty * 0.22 - base.moneyPriority * 0.2)),
     headline,
   };
 }

--- a/src/core/contracts/negotiation.js
+++ b/src/core/contracts/negotiation.js
@@ -1,0 +1,80 @@
+import { buildPlayerMotivationProfile, summarizePlayerMood } from '../mood/playerMood.js';
+
+function safeNum(v, d = 0) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : d;
+}
+
+function contractValue(contract = {}) {
+  const years = safeNum(contract?.yearsTotal ?? contract?.years, 1);
+  return safeNum(contract?.baseAnnual) * Math.max(1, years) + safeNum(contract?.signingBonus);
+}
+
+export function summarizeNegotiationStance(result = {}) {
+  const stance = result?.negotiationStance ?? 'testing_market';
+  const map = {
+    eager_to_stay: 'Player is motivated to stay if structure is fair.',
+    testing_market: 'Likely to test outside offers before deciding.',
+    wants_larger_role: 'Role expectation is the biggest blocker right now.',
+    seeking_contender: 'Contender fit is heavily weighted in this decision.',
+    chasing_top_dollar: 'Money is driving this negotiation.',
+    open_to_discount: 'Open to a slight discount for fit and continuity.',
+    far_apart: 'Current package is materially below target.',
+    close_to_done: 'Offer is close; minor adjustments could finish the deal.',
+  };
+  return map[stance] ?? map.testing_market;
+}
+
+export function evaluateContractOffer(player = {}, teamContext = {}, offer = {}, currentMarket = {}) {
+  const profile = currentMarket?.profile ?? buildPlayerMotivationProfile(player, teamContext);
+  const askTotalValue = safeNum(currentMarket?.askTotalValue, contractValue(offer?.contract));
+  const offerValue = contractValue(offer?.contract);
+  const annual = safeNum(offer?.contract?.baseAnnual, 0);
+  const years = safeNum(offer?.contract?.yearsTotal ?? offer?.contract?.years, 1);
+
+  const scoreBreakdown = {
+    salary: Math.max(0, Math.min(100, Math.round((annual / Math.max(1, safeNum(currentMarket?.askAnnual, annual))) * 100))),
+    years: Math.max(0, Math.min(100, Math.round((years / Math.max(1, safeNum(currentMarket?.askYears, years))) * 100))),
+    contender: safeNum(teamContext?.contenderScore, 50),
+    role: safeNum(teamContext?.roleOpportunityScore, 50),
+    relationship: safeNum(teamContext?.relationshipScore, 50),
+    development: safeNum(teamContext?.developmentScore, 50),
+    schemeFit: safeNum(teamContext?.schemeFitScore, 60),
+    franchiseDirection: safeNum(teamContext?.franchiseDirectionScore, 50),
+  };
+
+  const weighted =
+    scoreBreakdown.salary * (0.35 + profile.moneyPriority * 0.25) +
+    scoreBreakdown.years * (0.12 + profile.securityPriority * 0.14) +
+    scoreBreakdown.contender * (0.1 + profile.contenderPriority * 0.15) +
+    scoreBreakdown.role * (0.12 + profile.rolePriority * 0.14) +
+    scoreBreakdown.relationship * (0.08 + profile.loyalty * 0.12) +
+    scoreBreakdown.development * 0.08 +
+    scoreBreakdown.schemeFit * (0.05 + profile.schemeFitPreference * 0.08) +
+    scoreBreakdown.franchiseDirection * 0.06;
+
+  const normalized = weighted / 1.25;
+  const valueGap = askTotalValue > 0 ? (offerValue - askTotalValue) / askTotalValue : 0;
+
+  let negotiationStance = 'testing_market';
+  if (normalized >= 77 && valueGap >= -0.03) negotiationStance = 'close_to_done';
+  if (normalized >= 84 && profile.loyalty >= 0.58) negotiationStance = 'eager_to_stay';
+  if (profile.rolePriority >= 0.7 && scoreBreakdown.role < 60) negotiationStance = 'wants_larger_role';
+  if (profile.contenderPriority >= 0.7 && scoreBreakdown.contender < 62) negotiationStance = 'seeking_contender';
+  if (profile.moneyPriority >= 0.72 && valueGap < -0.05) negotiationStance = 'chasing_top_dollar';
+  if (profile.loyalty >= 0.65 && valueGap > -0.08) negotiationStance = 'open_to_discount';
+  if (normalized < 64 || valueGap < -0.12) negotiationStance = 'far_apart';
+
+  const tendency = normalized >= 80 ? 'accept' : normalized >= 68 ? 'counter' : 'reject';
+  const moodSummary = summarizePlayerMood(profile, teamContext);
+
+  return {
+    tendency,
+    negotiationStance,
+    score: Math.round(normalized),
+    scoreBreakdown,
+    explanationSummary: `${moodSummary.summary}. ${summarizeNegotiationStance({ negotiationStance })}`,
+    fitSummary: moodSummary,
+    valueGap,
+  };
+}

--- a/src/core/freeAgency/decisionState.js
+++ b/src/core/freeAgency/decisionState.js
@@ -1,0 +1,15 @@
+export function getFreeAgencyDecisionState(input = {}) {
+  const stance = input?.negotiationStance ?? 'testing_market';
+  const bidderCount = Number(input?.bidderCount ?? 0);
+  const urgency = input?.urgency ?? 'low';
+  const valueGap = Number(input?.valueGap ?? 0);
+
+  if (stance === 'seeking_contender') return { state: 'prefers_contenders', summary: 'Prioritizing contenders', chips: ['Contender fit'] };
+  if (stance === 'wants_larger_role') return { state: 'wants_starting_role', summary: 'Wants starting role clarity', chips: ['Role-driven'] };
+  if (stance === 'chasing_top_dollar') return { state: 'waiting_for_better_money', summary: 'Waiting for stronger money', chips: ['Top dollar'] };
+  if (stance === 'open_to_discount') return { state: 'loyalty_discount_possible', summary: 'Discount possible for strong fit', chips: ['Loyalty edge'] };
+  if (stance === 'close_to_done' || (urgency === 'high' && valueGap >= -0.05)) return { state: 'decision_imminent', summary: 'Decision imminent', chips: ['Near decision'] };
+  if (bidderCount >= 2 && urgency !== 'low') return { state: 'leaning_toward_offer', summary: 'Leaning toward top offer', chips: ['Competitive market'] };
+  if (bidderCount <= 1 && urgency === 'low') return { state: 'market_cooling', summary: 'Market cooling', chips: ['Cooling market'] };
+  return { state: 'listening_to_offers', summary: 'Listening to offers', chips: ['Open market'] };
+}

--- a/src/core/mood/playerMood.js
+++ b/src/core/mood/playerMood.js
@@ -1,0 +1,126 @@
+function safeNum(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function seeded(playerId, salt = 0) {
+  const raw = String(playerId ?? '0');
+  let h = 2166136261 ^ salt;
+  for (let i = 0; i < raw.length; i += 1) {
+    h ^= raw.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return Math.abs(h % 1000) / 1000;
+}
+
+const ARCHETYPES = ['money_first', 'contender_chaser', 'loyal_veteran', 'role_seeker', 'ascending_star', 'hometown_comfort', 'ring_chaser', 'stability_first'];
+
+function clamp01(v) {
+  return Math.max(0.05, Math.min(0.95, v));
+}
+
+function chooseArchetype(player, noiseA, noiseB) {
+  const age = safeNum(player?.age, 26);
+  const ovr = safeNum(player?.ovr, 70);
+  const traits = Array.isArray(player?.traits) ? player.traits.map((t) => String(t).toLowerCase()) : [];
+  if (traits.includes('loyal') || traits.includes('mentor')) return 'loyal_veteran';
+  if (age >= 31 && ovr >= 80) return noiseA > 0.5 ? 'ring_chaser' : 'stability_first';
+  if (age <= 25 && ovr >= 78) return 'ascending_star';
+  if (noiseA >= 0.83) return 'money_first';
+  if (noiseB >= 0.76) return 'role_seeker';
+  if (noiseA <= 0.18) return 'hometown_comfort';
+  if (noiseB <= 0.22) return 'contender_chaser';
+  return ARCHETYPES[Math.floor((noiseA + noiseB) * 3.5) % ARCHETYPES.length];
+}
+
+export function buildPlayerMotivationProfile(player = {}, teamContext = {}) {
+  const age = safeNum(player?.age, 26);
+  const morale = safeNum(player?.morale, 68);
+  const tenureYears = safeNum(teamContext?.tenureYears ?? player?.tenureYears, 0);
+  const careerStage = age <= 25 ? 'early' : age <= 29 ? 'prime' : age <= 33 ? 'veteran' : 'late';
+  const noiseA = seeded(player?.id, 41);
+  const noiseB = seeded(player?.id, 97);
+  const archetype = chooseArchetype(player, noiseA, noiseB);
+
+  let weights = {
+    moneyPriority: 0.48,
+    contenderPriority: 0.42,
+    rolePriority: 0.4,
+    loyalty: 0.22,
+    marketSizeTolerance: 0.5,
+    schemeFitPreference: 0.32,
+    patience: 0.48,
+    securityPriority: 0.44,
+  };
+
+  const stageAdj = {
+    early: { moneyPriority: 0.08, rolePriority: 0.08, securityPriority: 0.08, contenderPriority: -0.03, loyalty: -0.03 },
+    prime: { moneyPriority: 0.04, rolePriority: 0.04 },
+    veteran: { contenderPriority: 0.08, securityPriority: -0.06, loyalty: 0.04, patience: -0.04 },
+    late: { contenderPriority: 0.12, securityPriority: -0.1, moneyPriority: -0.04, patience: -0.06 },
+  };
+  for (const [key, val] of Object.entries(stageAdj[careerStage] ?? {})) weights[key] += val;
+
+  if (archetype === 'money_first') weights.moneyPriority += 0.24;
+  if (archetype === 'contender_chaser') weights.contenderPriority += 0.22;
+  if (archetype === 'loyal_veteran') { weights.loyalty += 0.32; weights.moneyPriority -= 0.1; }
+  if (archetype === 'role_seeker') weights.rolePriority += 0.22;
+  if (archetype === 'ascending_star') { weights.rolePriority += 0.14; weights.securityPriority += 0.08; weights.patience += 0.08; }
+  if (archetype === 'hometown_comfort') { weights.loyalty += 0.2; weights.marketSizeTolerance -= 0.06; }
+  if (archetype === 'ring_chaser') { weights.contenderPriority += 0.26; weights.securityPriority -= 0.12; }
+  if (archetype === 'stability_first') { weights.securityPriority += 0.18; weights.patience += 0.12; }
+
+  weights.loyalty += Math.min(0.18, tenureYears * 0.03) + (morale >= 78 ? 0.1 : morale <= 55 ? -0.08 : 0);
+  weights.moneyPriority += (noiseA - 0.5) * 0.15;
+  weights.contenderPriority += (noiseB - 0.5) * 0.12;
+  weights.rolePriority += morale <= 58 ? 0.1 : 0;
+  weights.schemeFitPreference += (noiseA - 0.5) * 0.14;
+
+  const profile = {
+    archetype,
+    personalityTag: archetype,
+    careerStage,
+    moneyPriority: clamp01(weights.moneyPriority),
+    contenderPriority: clamp01(weights.contenderPriority),
+    rolePriority: clamp01(weights.rolePriority),
+    loyalty: clamp01(weights.loyalty),
+    marketSizeTolerance: clamp01(weights.marketSizeTolerance),
+    schemeFitPreference: clamp01(weights.schemeFitPreference),
+    patience: clamp01(weights.patience),
+    securityPriority: clamp01(weights.securityPriority),
+  };
+
+  return profile;
+}
+
+export function summarizePlayerMood(profile = {}, context = {}) {
+  const top = [
+    ['money', profile.moneyPriority],
+    ['contender', profile.contenderPriority],
+    ['role', profile.rolePriority],
+    ['loyalty', profile.loyalty],
+    ['development', safeNum(context?.developmentScore, 50) / 100],
+  ].sort((a, b) => b[1] - a[1]);
+
+  const lead = top[0]?.[0] ?? 'money';
+  const map = {
+    money: 'Prioritizing money over fit',
+    contender: 'Wants to stay with a contender',
+    role: 'Wants a bigger weekly role',
+    loyalty: 'Open to team-friendly terms',
+    development: 'Values coaching and development',
+  };
+  const contractOutlook = profile.loyalty >= 0.6 && profile.moneyPriority <= 0.55
+    ? 'Loyal profile; modest hometown discount possible.'
+    : profile.moneyPriority >= 0.72
+      ? 'Strong market-value stance; discounts are unlikely.'
+      : profile.contenderPriority >= 0.68
+        ? 'Contender fit can offset a small salary gap.'
+        : 'Balanced negotiation profile with room for compromise.';
+
+  return {
+    summary: map[lead] ?? 'Balanced priorities',
+    contractOutlook,
+    priorities: top.slice(0, 3).map(([k]) => k),
+  };
+}

--- a/src/core/teamContext/negotiationContext.js
+++ b/src/core/teamContext/negotiationContext.js
@@ -1,0 +1,57 @@
+function safeNum(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function clamp100(v) {
+  return Math.max(0, Math.min(100, Math.round(v)));
+}
+
+export function getContenderScore(team = {}, league = {}) {
+  const wins = safeNum(team?.wins, 0);
+  const losses = safeNum(team?.losses, 0);
+  const ties = safeNum(team?.ties, 0);
+  const games = wins + losses + ties;
+  const pct = games > 0 ? (wins + ties * 0.5) / games : 0.5;
+  const playoffBoost = safeNum(team?.playoffWins, 0) >= 1 ? 6 : 0;
+  return clamp100(35 + pct * 55 + playoffBoost);
+}
+
+export function getRoleOpportunityScore(player = {}, team = {}, options = {}) {
+  const needs = safeNum(options?.needsAtPosition, 1);
+  const roster = Array.isArray(options?.rosterAtPosition) ? options.rosterAtPosition : [];
+  const betterAtPos = roster.filter((p) => safeNum(p?.ovr, 0) > safeNum(player?.ovr, 0)).length;
+  const depthPressure = Math.max(0, betterAtPos * 12);
+  return clamp100(72 + (needs - 1) * 12 - depthPressure);
+}
+
+export function getDevelopmentEnvironmentScore(team = {}) {
+  const staffDev = safeNum(team?.staffBonuses?.developmentDelta, 0) * 100;
+  const trainingLevel = safeNum(team?.franchiseInvestments?.trainingLevel, 1);
+  return clamp100(45 + staffDev + trainingLevel * 7);
+}
+
+export function getRelationshipScore(player = {}, team = {}) {
+  const morale = safeNum(player?.morale, 68);
+  const tenure = safeNum(player?.tenureYears, 0);
+  const continuity = safeNum(team?.staffContinuity, 0);
+  return clamp100(35 + morale * 0.45 + tenure * 4 + continuity * 0.4);
+}
+
+export function getMarketAppealScore(team = {}) {
+  const fanApproval = safeNum(team?.fanApproval, 50);
+  const marketSize = safeNum(team?.marketSize, 50);
+  return clamp100(35 + fanApproval * 0.35 + marketSize * 0.35);
+}
+
+export function getTeamContextForNegotiation(player = {}, team = {}, league = {}, options = {}) {
+  return {
+    contenderScore: getContenderScore(team, league),
+    roleOpportunityScore: getRoleOpportunityScore(player, team, options),
+    developmentScore: getDevelopmentEnvironmentScore(team),
+    relationshipScore: getRelationshipScore(player, team),
+    marketAppealScore: getMarketAppealScore(team),
+    capFlexScore: clamp100(50 + safeNum(team?.capRoom, 0) * 1.4),
+    teamDirection: options?.teamDirection ?? 'middling',
+  };
+}

--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -1170,6 +1170,18 @@ export default function FreeAgency({
                             <div style={{ color: "var(--text-muted)", marginTop: 1 }}>
                               {market.urgencyLabel}{market.patienceLabel ? ` · ${market.patienceLabel}` : ""}
                             </div>
+                            {market.motivationSummary && (
+                              <div style={{ color: "var(--text-subtle)", marginTop: 1 }}>
+                                {market.motivationSummary}{market.fitScore ? ` · Fit ${market.fitScore}/100` : ""}
+                              </div>
+                            )}
+                            {market.stateChips?.length ? (
+                              <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', justifyContent: 'center', marginTop: 3 }}>
+                                {market.stateChips.slice(0, 2).map((chip) => (
+                                  <span key={chip} style={{ fontSize: 10, border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 6px', color: 'var(--text-subtle)' }}>{chip}</span>
+                                ))}
+                              </div>
+                            ) : null}
                             {!!market.reSign?.recommendationTier && (
                               <div style={{ color: "var(--text-subtle)", marginTop: 1 }}>
                                 {RESIGN_TIER_LABEL[market.reSign.recommendationTier] ?? "Re-sign view unavailable"}: {market.reSign.shortReason}
@@ -1294,6 +1306,8 @@ export default function FreeAgency({
                     <div style={{ fontSize: 12, color: "var(--text-muted)" }}>{player.pos} · age {player.age} · OVR {player.ovr}{player.scoutUncertaintyBand ? ` (Scout ${player.scoutOvr} ±${player.scoutUncertaintyBand})` : ''}</div>
                     <div style={{ fontSize: 12, color: "var(--text-muted)" }}>Scheme fit {player.schemeFit ?? 50} · morale {player.morale ?? 70}</div>
                     <div style={{ fontSize: 12, marginTop: 4 }}>Demand {(player?.demandProfile?.askAnnual ?? player._ask ?? 0).toFixed(1)}M / yr</div>
+                    <div style={{ fontSize: 11, color: 'var(--text-muted)' }}>{player?.demandProfile?.headline ?? 'Balanced motivations'}{player?.demandProfile?.fitScore ? ` · Fit ${player.demandProfile.fitScore}/100` : ''}</div>
+                    {Array.isArray(player?.market?.stateChips) && player.market.stateChips.length > 0 ? <div style={{ fontSize: 10, color: 'var(--text-subtle)' }}>{player.market.stateChips.join(' · ')}</div> : null}
                     <div style={{ display: "flex", gap: 6, marginTop: 8 }}>
                       <Button className="btn" onClick={() => onPlayerSelect && onPlayerSelect(player.id)}>View profile</Button>
                       <Button className="btn btn-primary" onClick={() => setSigningPlayerId(player.id)}>Negotiate</Button>

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -26,6 +26,17 @@ const ACCOLADE_META = {
   ROTY: { icon: "🌱", label: (yr) => `${yr} ROTY` },
 };
 
+
+function formatPriorityLabel(key) {
+  const labels = {
+    money: 'Money',
+    contender: 'Contender',
+    role: 'Role',
+    loyalty: 'Loyalty',
+    development: 'Development',
+  };
+  return labels[key] ?? key;
+}
 // ── Position group → stat column definitions ──────────────────────────────────
 
 function computePasserRating(t) {
@@ -784,6 +795,34 @@ export default function PlayerProfile({
                 {Number(player?.age ?? 40) <= 25 && teamIntel?.organization?.developmentEnvironment?.reasons?.[0] ? (
                   <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>• Development environment: {teamIntel.organization.developmentEnvironment.reasons[0]}</div>
                 ) : null}
+              </div>
+            </section>
+          )}
+
+
+          {!loading && player && player?.motivationProfile && (
+            <section>
+              <h3 style={sectionLabelStyle}>Motivation & Contract Outlook</h3>
+              <div style={{ display: 'grid', gap: 'var(--space-2)', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
+                <div style={{ border: '1px solid var(--hairline)', borderRadius: 'var(--radius-md)', padding: '10px' }}>
+                  <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', fontWeight: 700 }}>Archetype</div>
+                  <div style={{ fontSize: 'var(--text-sm)', fontWeight: 700, marginTop: 2 }}>{String(player.motivationProfile.archetype || 'balanced').replace(/_/g, ' ')}</div>
+                </div>
+                <div style={{ border: '1px solid var(--hairline)', borderRadius: 'var(--radius-md)', padding: '10px' }}>
+                  <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', fontWeight: 700 }}>Mood summary</div>
+                  <div style={{ fontSize: 'var(--text-sm)', fontWeight: 700, marginTop: 2 }}>{player?.motivationSummary?.summary ?? 'Balanced priorities'}</div>
+                </div>
+                <div style={{ border: '1px solid var(--hairline)', borderRadius: 'var(--radius-md)', padding: '10px' }}>
+                  <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', fontWeight: 700 }}>Contract outlook</div>
+                  <div style={{ fontSize: 'var(--text-sm)', fontWeight: 700, marginTop: 2 }}>{player?.motivationSummary?.contractOutlook ?? 'No clear market pressure.'}</div>
+                </div>
+              </div>
+              <div style={{ marginTop: 6, display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                {(player?.motivationSummary?.priorities ?? []).map((p) => (
+                  <span key={p} style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '2px 8px', color: 'var(--text-subtle)' }}>
+                    {formatPriorityLabel(p)} priority
+                  </span>
+                ))}
               </div>
             </section>
           )}

--- a/src/ui/utils/marketSignals.js
+++ b/src/ui/utils/marketSignals.js
@@ -51,6 +51,10 @@ export function summarizeFreeAgentMarket(player) {
   const urgencyTag = market?.urgencyLabel ?? null;
   const patienceLabel = market?.patienceLabel ?? null;
   const riskLabel = market?.riskLabel ?? null;
+  const motivationSummary = market?.motivationSummary ?? player?.demandProfile?.headline ?? null;
+  const fitScore = safeNum(market?.fitScore ?? player?.demandProfile?.fitScore, 0);
+  const stateChips = Array.isArray(market?.stateChips) ? market.stateChips : [];
+  const negotiationStance = player?.demandProfile?.negotiationStance ?? null;
   const knownBidderLabel = bidderCount > 0 ? `${bidderCount} known bidder${bidderCount > 1 ? "s" : ""}` : "No known bidders";
   const hasVisibleSnapshot = hasTopOffer || bidderCount > 0 || userOffered || !!market?.timingState;
   const reSign = player?.reSign ?? null;
@@ -91,5 +95,9 @@ export function summarizeFreeAgentMarket(player) {
     topOfferLabel,
     topBidTeam: offers?.topBidTeam ?? null,
     reSign,
+    motivationSummary,
+    fitScore,
+    stateChips,
+    negotiationStance,
   };
 }

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -79,6 +79,10 @@ import {
   buildDecisionTiming,
   marketHeatLabel,
 } from '../core/contract-market.js';
+import { getTeamContextForNegotiation } from '../core/teamContext/negotiationContext.js';
+import { evaluateContractOffer, summarizeNegotiationStance } from '../core/contracts/negotiation.js';
+import { summarizePlayerMood } from '../core/mood/playerMood.js';
+import { getFreeAgencyDecisionState } from '../core/freeAgency/decisionState.js';
 import {
   calculateOffensiveSchemeFit, calculateDefensiveSchemeFit,
   computeTeamSchemeFits, schemeOvrBonus,
@@ -2838,9 +2842,13 @@ async function handleGetPlayerCareer({ playerId }, id) {
     const allStats = [...historicalStats];
     if (liveSeasonStat) allStats.push(liveSeasonStat);
 
+    const playerTeam = player?.teamId != null ? cache.getTeam(player.teamId) : null;
+    const motivationProfile = buildContractProfile(player ?? {}, { tenureYears: Number(player?.tenureYears ?? 0) });
+    const motivationSummary = summarizePlayerMood(motivationProfile, getTeamContextForNegotiation(player ?? {}, playerTeam ?? {}, null, {}));
+
     post(toUI.PLAYER_CAREER, {
       playerId: strId,
-      player:   player ?? null,
+      player:   player ? { ...player, motivationProfile, motivationSummary } : null,
       stats:    allStats,
     }, id);
 
@@ -3582,18 +3590,35 @@ function evaluatePlayerOfferDecision(player, offers = [], liveMeta, memory = {})
     if (!directionCache.has(team.id)) {
       directionCache.set(team.id, inferTeamDirection(team, Number(liveMeta?.currentWeek ?? 1)));
     }
-    const score = scoreOffer(player, offer, {
+    const schemeFitScore = ['QB', 'RB', 'WR', 'TE', 'OL', 'K'].includes(player.pos)
+      ? calculateOffensiveSchemeFit(player, team?.staff?.headCoach?.offScheme || 'Balanced')
+      : calculateDefensiveSchemeFit(player, team?.staff?.headCoach?.defScheme || '4-3');
+    const teamContext = getTeamContextForNegotiation(player, team, null, {
+      teamDirection: directionCache.get(team.id),
+      needsAtPosition: AiLogic.calculateTeamNeeds(team.id)?.[player.pos] ?? 1,
+      rosterAtPosition: cache.getPlayersByTeam(team.id).filter((p) => p?.pos === player?.pos),
+    });
+    const legacyScore = scoreOffer(player, offer, {
       team,
       direction: directionCache.get(team.id),
       roleOpportunity: (AiLogic.calculateTeamNeeds(team.id)?.[player.pos] ?? 1) / 2.2,
-      fit: ['QB', 'RB', 'WR', 'TE', 'OL', 'K'].includes(player.pos)
-        ? calculateOffensiveSchemeFit(player, team?.staff?.headCoach?.offScheme || 'Balanced')
-        : calculateDefensiveSchemeFit(player, team?.staff?.headCoach?.defScheme || '4-3'),
+      fit: schemeFitScore,
       loyaltyBoost: Number(team.id) === Number(player.teamId) ? 0.35 : 0,
     }, { profile, askTotalValue });
+    const evalResult = evaluateContractOffer(player, {
+      ...teamContext,
+      schemeFitScore,
+      franchiseDirectionScore: directionCache.get(team.id) === 'contender' ? 78 : directionCache.get(team.id) === 'rebuilding' ? 44 : 58,
+    }, offer, {
+      profile,
+      askTotalValue,
+      askAnnual: ask.baseAnnual,
+      askYears: ask.yearsTotal,
+    });
+    const score = legacyScore * 55 + (evalResult.score / 100) * 45;
     if (score > bestScore) {
       bestScore = score;
-      bestOffer = offer;
+      bestOffer = { ...offer, _evaluation: evalResult, _teamContext: teamContext };
     }
   }
   if (!bestOffer) return { status: 'pending', reason: 'No valid bids', bestOffer: null };
@@ -3632,6 +3657,7 @@ function evaluatePlayerOfferDecision(player, offers = [], liveMeta, memory = {})
       moneyGapRatio,
       state: waitCycles >= 1 ? 'market_cooling' : 'holding_for_improvement',
       urgency: timing.risk,
+      negotiation: bestOffer?._evaluation ?? null,
     };
   }
 
@@ -3648,6 +3674,7 @@ function evaluatePlayerOfferDecision(player, offers = [], liveMeta, memory = {})
     moneyGapRatio,
     state: timing.state,
     urgency: timing.risk,
+    negotiation: bestOffer?._evaluation ?? null,
   };
 }
 
@@ -3660,6 +3687,7 @@ function buildDecisionSnapshot(result = {}) {
     marketHeatBand: Math.round(Number(result?.marketHeat ?? 1) * 10) / 10,
     moneyGapBand: Math.round(Number(result?.moneyGapRatio ?? 0) * 20) / 20,
     bestTeamId: Number(result?.bestOffer?.teamId ?? -1),
+    negotiationStance: result?.negotiation?.negotiationStance ?? 'testing_market',
   };
 }
 
@@ -3674,6 +3702,7 @@ function shouldEmitMarketUpdate(prev = {}, next = {}, userHasOffer = false) {
   if (Math.abs((a.marketHeatBand ?? 1) - (b.marketHeatBand ?? 1)) >= 0.2) return true;
   if (Math.abs((a.moneyGapBand ?? 0) - (b.moneyGapBand ?? 0)) >= 0.1) return true;
   if ((a.bidderCount ?? 0) !== (b.bidderCount ?? 0)) return true;
+  if ((a.negotiationStance ?? 'testing_market') !== (b.negotiationStance ?? 'testing_market')) return true;
   return false;
 }
 
@@ -3964,14 +3993,6 @@ async function handleGetFreeAgents(payload, id) {
           waitCycles: Number(mem?.waitCycles ?? 0),
           moneyGapRatio: topGapRatio,
         });
-        const decisionLabelByState = {
-          evaluating_market: 'Evaluating market',
-          holding_for_improvement: 'Reviewing final offers',
-          leaning_to_leader: 'Leaning toward top bid',
-          close_to_deciding: 'Decision next week',
-          market_cooling: 'Market cooling',
-          decision_imminent: 'Decision next week',
-        };
         const detailTone = userOffer
           ? userOffer.teamId === topBid?.teamId
             ? (offers.length >= 3 ? 'You’re leading, but another team is close' : 'Your bid leads')
@@ -3996,8 +4017,31 @@ async function handleGetFreeAgents(payload, id) {
           ['loyalty', profile.loyaltyPriority],
         ]
           .sort((a, b) => b[1] - a[1])
-          .slice(0, 2)
+          .slice(0, 3)
           .map(([tag]) => tag);
+
+        const teamNegotiationContext = getTeamContextForNegotiation(p, userTeam, null, {
+          teamDirection: userDirection,
+          needsAtPosition: AiLogic.calculateTeamNeeds(userTeamId)?.[p.pos] ?? 1,
+          rosterAtPosition: cache.getPlayersByTeam(userTeamId).filter((rp) => rp?.pos === p?.pos),
+        });
+        const userOfferEval = evaluateContractOffer(p, {
+          ...teamNegotiationContext,
+          schemeFitScore: Number(p?.schemeFit ?? 65),
+          franchiseDirectionScore: userDirection === 'contender' ? 78 : userDirection === 'rebuilding' ? 44 : 58,
+        }, userOffer ?? { contract: ask }, {
+          profile,
+          askTotalValue: (ask.baseAnnual * ask.yearsTotal) + (ask.signingBonus || 0),
+          askAnnual: ask.baseAnnual,
+          askYears: ask.yearsTotal,
+        });
+        const moodSummary = summarizePlayerMood(profile, teamNegotiationContext);
+        const decisionState = getFreeAgencyDecisionState({
+          negotiationStance: userOfferEval.negotiationStance,
+          bidderCount: offers.length,
+          urgency: decisionTiming.risk,
+          valueGap: userOfferEval.valueGap,
+        });
 
         return {
           id:        p.id,
@@ -4015,27 +4059,35 @@ async function handleGetFreeAgents(payload, id) {
             heat: Math.round(heat * 100) / 100,
             heatLabel: marketHeatLabel(heat),
             bidderCount: offers.length,
-            decision: decisionLabelByState[decisionTiming.state] ?? 'Evaluating market',
-            decisionReason: decisionTiming.reason,
+            decision: decisionState.summary,
+            decisionReason: `${decisionTiming.reason}. ${summarizeNegotiationStance(userOfferEval)}`,
             urgency: decisionTiming.risk,
             urgencyLabel: decisionTiming.risk === 'high'
               ? 'Decision expected soon'
               : decisionTiming.risk === 'medium'
                 ? 'Decision window open'
                 : 'No immediate deadline signal',
-            timingState: decisionTiming.state,
+            timingState: decisionState.state,
             attention: detailTone,
             patienceWeeks: decisionTiming.patienceWeeks,
             patienceLabel,
             riskLabel: riskLabelByRisk[decisionTiming.risk] ?? 'Risk unknown',
             knownMarket,
+            stateChips: decisionState.chips,
+            motivationSummary: moodSummary.summary,
+            fitScore: userOfferEval.score,
           },
           demandProfile: {
-            headline: profile.headline,
+            headline: moodSummary.summary,
             willingness: ask.willingness,
             askAnnual: ask.baseAnnual,
             askYears: ask.yearsTotal,
             priorities: topPreferences,
+            archetype: profile.archetype,
+            contractOutlook: moodSummary.contractOutlook,
+            negotiationStance: userOfferEval.negotiationStance,
+            fitScore: userOfferEval.score,
+            explanationSummary: userOfferEval.explanationSummary,
           },
           reSign: reSignInsight,
           offers: {


### PR DESCRIPTION
### Motivation
- Make contract talks, re-signings, and free agency feel believable by giving each player a compact motivation profile (archetype + priorities) that explains why they accept, reject, or hold out. 
- Surface short, front-office readable signals in UI and feed team/context inputs into negotiation logic so behavior is grounded and tunable.

### Description
- Added a compact player motivation model in `src/core/mood/playerMood.js` with archetypes and priority weights and a `summarizePlayerMood(...)` helper to produce concise motivation summaries and contract outlooks. 
- Added reusable team-context helpers in `src/core/teamContext/negotiationContext.js` (`getContenderScore`, `getRoleOpportunityScore`, `getDevelopmentEnvironmentScore`, `getRelationshipScore`, `getMarketAppealScore`, `getTeamContextForNegotiation`) so negotiation logic can be driven by a single consistent context. 
- Added a negotiation evaluator in `src/core/contracts/negotiation.js` (`evaluateContractOffer`, `summarizeNegotiationStance`) that returns `tendency`, `negotiationStance`, `score` and a concise `explanationSummary` and factor breakdown. 
- Added FA decision state mapping in `src/core/freeAgency/decisionState.js` to translate negotiation stances/urgency into readable FA states/chips. 
- Integrated the model into the engine: updated `src/core/contract-market.js` to build contract profiles from the new motivation profile while preserving compatibility aliases; updated `src/worker/worker.js` to blend legacy scoring with the new evaluator, include `motivationSummary`, `fitScore`, `stateChips`, `negotiationStance`, and `explanationSummary` in FA payloads, and attach `motivationProfile`/`motivationSummary` to player career payloads. 
- Brought the new evaluation into AI behavior by blending the legacy `scoreOffer` path with `evaluateContractOffer` in `src/core/ai-logic.js` so CPU teams bid more sensibly for fit/role/contender-seeking players. 
- Surfaced compact UI cues: updated `src/ui/utils/marketSignals.js`, `src/ui/components/FreeAgency.jsx` (table/cards lines, chips, fit meter), and `src/ui/components/PlayerProfile.jsx` (new “Motivation & Contract Outlook” section) to show why a player prefers or rejects an offer without overwhelming the user. 
- Kept logic modular and backward-compatible by computing new fields at read/evaluation time (no save schema bump). 

### Testing
- Built the app with `npm run build` and the production build completed successfully. 
- Ran unit tests with `npm run test:unit` (Vitest); the test run completed but some suites failed: overall many tests passed while existing unrelated test cases failed (unit test summary from run: roughly `103 passed` and `9 failed` across `112` tests, and several Playwright/Playwright-config errors surfaced in that environment). 
- Notes on test failures: failures appear in existing UI/Playwright and a small number of unrelated unit tests (for example owner messaging, fresh-save rendering and a few utility tests) and do not indicate compile or runtime errors introduced by the new negotiation files; the worker build and runtime integration compiled and the UI was updated to consume the new fields.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d86762e6f0832d8275831e0d39a5aa)