### PR TITLE
Contract Center and re-signings workflow with retention intelligence

### DIFF
--- a/src/core/__tests__/retention-board.test.js
+++ b/src/core/__tests__/retention-board.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildRetentionBoard,
+  evaluateReSigningPriority,
+  getExtensionReadiness,
+} from '../retention/reSigning.js';
+
+describe('retention workflow helpers', () => {
+  it('marks expiring core players as high-priority keeps', () => {
+    const team = { id: 1, wins: 11, losses: 6, ties: 0, capRoom: 45 };
+    const player = {
+      id: 'p1', teamId: 1, status: 'active', pos: 'QB', ovr: 90, potential: 93,
+      age: 27, morale: 80, schemeFit: 86, contract: { years: 1, baseAnnual: 18 },
+    };
+    const league = { players: [player], week: 12, phase: 'offseason_resign' };
+    const res = evaluateReSigningPriority(player, team, league);
+    expect(['cornerstone_priority', 'strong_keep']).toContain(res.recommendation);
+  });
+
+  it('builds cap outlook and retention board rows', () => {
+    const team = { id: 1, wins: 8, losses: 9, ties: 0, capRoom: 20 };
+    const players = [
+      { id: 'a', name: 'A', teamId: 1, status: 'active', pos: 'WR', ovr: 84, potential: 85, age: 26, morale: 72, schemeFit: 80, contract: { years: 1, baseAnnual: 15 } },
+      { id: 'b', name: 'B', teamId: 1, status: 'active', pos: 'WR', ovr: 70, potential: 71, age: 30, morale: 63, schemeFit: 62, contract: { years: 1, baseAnnual: 8 } },
+    ];
+    const out = buildRetentionBoard(team, { players, week: 5, phase: 'regular' });
+    expect(out.board.length).toBe(2);
+    expect(out.capOutlook).toHaveProperty('summary');
+  });
+
+  it('returns early extension state labels', () => {
+    const state = getExtensionReadiness({ contract: { years: 2 } }, { profile: { moneyPriority: 0.8, loyalty: 0.4, securityPriority: 0.4 }, phase: 'regular' });
+    expect(['prefers_to_wait', 'wants_market_reset', 'likely_to_test_free_agency']).toContain(state);
+  });
+});

--- a/src/core/ai-logic.js
+++ b/src/core/ai-logic.js
@@ -14,6 +14,7 @@ import {
 import NewsEngine from './news-engine.js';
 import { getTeamContextForNegotiation } from './teamContext/negotiationContext.js';
 import { evaluateContractOffer } from './contracts/negotiation.js';
+import { evaluateReSigningPriority } from './retention/reSigning.js';
 
 class AiLogic {
 
@@ -325,7 +326,10 @@ class AiLogic {
             const isQB = p.pos === 'QB';
             const maxAge = isQB ? 32 : 30;
 
-            if ((p.ovr ?? 0) >= 80 && (p.age ?? 25) <= maxAge) {
+            const retention = evaluateReSigningPriority(p, team, { players: roster, phase: cache.getMeta()?.phase, week: cache.getMeta()?.currentWeek });
+            const shouldPrioritize = ['cornerstone_priority', 'strong_keep', 'extension_candidate'].includes(retention.recommendation);
+
+            if ((p.ovr ?? 0) >= 76 && (p.age ?? 25) <= maxAge && shouldPrioritize) {
                 const demand = calculateExtensionDemand(p);
                 if (!demand) continue;
 

--- a/src/core/retention/reSigning.js
+++ b/src/core/retention/reSigning.js
@@ -1,0 +1,224 @@
+import { buildContractProfile, buildDemandFromProfile, computeMarketHeat, inferTeamDirection } from '../contract-market.js';
+import { evaluateContractOffer } from '../contracts/negotiation.js';
+import { getTeamContextForNegotiation } from '../teamContext/negotiationContext.js';
+
+function safeNum(v, d = 0) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : d;
+}
+
+function contractYearsLeft(player = {}) {
+  return safeNum(player?.contract?.years ?? player?.contract?.yearsRemaining ?? player?.contract?.yearsLeft, 0);
+}
+
+function demandValue(demand = {}) {
+  const years = Math.max(1, safeNum(demand?.yearsTotal ?? demand?.years, 1));
+  return safeNum(demand?.baseAnnual) * years + safeNum(demand?.signingBonus);
+}
+
+function replacementDifficulty(pos, roster = []) {
+  const atPos = roster.filter((p) => p?.pos === pos && (p?.status ?? 'active') === 'active').length;
+  if (atPos <= 2) return 'high';
+  if (atPos <= 4) return 'medium';
+  return 'low';
+}
+
+function recommendationFromScore(score = 0, { expiring = false, star = false, expensive = false } = {}) {
+  if (score >= 88 && expiring) return 'cornerstone_priority';
+  if (score >= 82) return expiring ? 'strong_keep' : 'extension_candidate';
+  if (score >= 70) return 'keep_if_price_is_right';
+  if (expensive && star) return 'franchise_tag_candidate';
+  if (score >= 58) return 'replaceable_depth';
+  if (expiring && score < 46) return 'likely_to_walk';
+  return 'move_on';
+}
+
+export function getExtensionReadiness(player = {}, context = {}) {
+  const yearsLeft = contractYearsLeft(player);
+  const profile = context.profile ?? buildContractProfile(player, context.teamContext ?? {});
+  const inSeason = ['regular', 'playoffs', 'preseason'].includes(String(context.phase ?? ''));
+  const relationship = safeNum(context.relationshipScore, 60);
+
+  if (yearsLeft <= 1) return 'open_to_extension_now';
+  if (inSeason && profile.moneyPriority >= 0.72) return 'prefers_to_wait';
+  if (profile.moneyPriority >= 0.76 && yearsLeft >= 2) return 'wants_market_reset';
+  if (profile.loyalty >= 0.66 && profile.securityPriority >= 0.58) return 'willing_to_discount_for_security';
+  if (profile.moneyPriority >= 0.68 && relationship < 58) return 'likely_to_test_free_agency';
+  return yearsLeft <= 2 ? 'open_to_extension_now' : 'prefers_to_wait';
+}
+
+export function evaluateReSigningPriority(player = {}, team = {}, league = {}) {
+  const roster = (league?.players ?? []).filter((p) => Number(p?.teamId) === Number(team?.id));
+  const freeAgents = (league?.players ?? []).filter((p) => !p?.teamId || p?.status === 'free_agent');
+  const teamDirection = inferTeamDirection(team, Number(league?.week ?? 1));
+  const profile = buildContractProfile(player, { tenureYears: safeNum(player?.tenureYears, 0) });
+  const marketHeat = computeMarketHeat(player?.pos, freeAgents);
+  const demand = buildDemandFromProfile(player, profile, {
+    marketHeat,
+    morale: safeNum(player?.morale, 68),
+    fit: safeNum(player?.schemeFit, 65),
+    teamSuccess: ((team?.wins ?? 0) + (team?.ties ?? 0) * 0.5) / Math.max(1, (team?.wins ?? 0) + (team?.losses ?? 0) + (team?.ties ?? 0)),
+  });
+
+  const yearsLeft = contractYearsLeft(player);
+  const expiring = yearsLeft <= 1;
+  const replacement = replacementDifficulty(player?.pos, roster);
+  const ovr = safeNum(player?.ovr, 65);
+  const pot = safeNum(player?.potential, ovr);
+  const age = safeNum(player?.age, 26);
+
+  const developmentOutlook = pot - ovr >= 4 && age <= 25 ? 'ascending' : age >= 30 ? 'declining' : 'stable';
+  const roleImportance = ovr >= 84 ? 'core_starter' : ovr >= 75 ? 'starter' : ovr >= 70 ? 'rotation' : 'depth';
+  const askAnnual = safeNum(demand?.baseAnnual, safeNum(player?.contract?.baseAnnual, 4));
+  const capRoom = safeNum(team?.capRoom, 0);
+
+  let score =
+    ovr * 0.9 +
+    (pot - ovr) * 1.2 +
+    (safeNum(player?.schemeFit, 65) - 60) * 0.5 +
+    (safeNum(player?.morale, 68) - 60) * 0.4 +
+    (marketHeat - 1) * 13;
+
+  if (replacement === 'high') score += 12;
+  if (replacement === 'medium') score += 6;
+  if (teamDirection === 'contender' && ovr >= 78) score += 8;
+  if (teamDirection === 'rebuilding' && age <= 26) score += 8;
+  if (age >= 31) score -= (age - 30) * 6;
+  if (askAnnual > Math.max(6, capRoom * 0.55)) score -= 10;
+
+  const recommendation = recommendationFromScore(score, {
+    expiring,
+    star: ovr >= 84,
+    expensive: askAnnual >= Math.max(14, capRoom * 0.6),
+  });
+
+  return {
+    recommendation,
+    score: Math.round(score),
+    roleImportance,
+    developmentOutlook,
+    replacementDifficulty: replacement,
+    expectedMarketDifficulty: marketHeat >= 1.35 ? 'high' : marketHeat >= 1.12 ? 'medium' : 'low',
+    teamDirection,
+    profile,
+    demand,
+    yearsLeft,
+    expiring,
+    extensionReadiness: getExtensionReadiness(player, { profile, phase: league?.phase }),
+  };
+}
+
+export function classifyContractDecision(player = {}, context = {}) {
+  const recommendation = context?.recommendation ?? 'keep_if_price_is_right';
+  if (recommendation === 'cornerstone_priority' || recommendation === 'strong_keep') return 'priority_re_signing';
+  if (recommendation === 'extension_candidate') return 'extension_candidate';
+  if (recommendation === 'franchise_tag_candidate') return 'franchise_tag_candidate';
+  if (recommendation === 'likely_to_walk' || recommendation === 'move_on') return 'let_walk_candidate';
+  if (context?.expiring && safeNum(player?.ovr, 0) >= 76) return 'expiring_starter';
+  return 'depth_low_urgency';
+}
+
+export function summarizeRetentionRecommendation(recommendation = '') {
+  const map = {
+    cornerstone_priority: 'Cornerstone priority. Keep at almost any reasonable price.',
+    strong_keep: 'Strong keep. Important starter with manageable risk.',
+    keep_if_price_is_right: 'Keep if price is right. Useful, but avoid overpay.',
+    extension_candidate: 'Extension candidate before leverage increases.',
+    franchise_tag_candidate: 'Tag candidate if long-term talks stall.',
+    replaceable_depth: 'Replaceable depth. Retain only on team-friendly terms.',
+    likely_to_walk: 'Likely to walk unless market-level offer is made now.',
+    move_on: 'Move on. Reallocate resources to replacements.',
+  };
+  return map[recommendation] ?? 'Evaluate with market context.';
+}
+
+export function summarizeContractRisk(player = {}, team = {}, league = {}, priority = null) {
+  const p = priority ?? evaluateReSigningPriority(player, team, league);
+  const riskScore =
+    (p.expectedMarketDifficulty === 'high' ? 35 : p.expectedMarketDifficulty === 'medium' ? 22 : 10) +
+    (p.replacementDifficulty === 'high' ? 22 : p.replacementDifficulty === 'medium' ? 12 : 4) +
+    (p.extensionReadiness === 'likely_to_test_free_agency' ? 25 : p.extensionReadiness === 'prefers_to_wait' ? 14 : 6);
+
+  return {
+    riskScore,
+    riskBand: riskScore >= 70 ? 'high' : riskScore >= 46 ? 'medium' : 'low',
+    summary: `${p.profile.headline}. ${summarizeRetentionRecommendation(p.recommendation)}`,
+  };
+}
+
+export function summarizeRetentionPlan(player = {}, context = {}) {
+  const priority = context.priority ?? evaluateReSigningPriority(player, context.team, context.league);
+  const decisionClass = classifyContractDecision(player, { ...priority, recommendation: priority.recommendation, expiring: priority.expiring });
+  const risk = summarizeContractRisk(player, context.team, context.league, priority);
+
+  return {
+    decisionClass,
+    recommendation: priority.recommendation,
+    recommendationSummary: summarizeRetentionRecommendation(priority.recommendation),
+    risk,
+    extensionReadiness: priority.extensionReadiness,
+    expectedMarketBehavior: priority.profile.headline,
+  };
+}
+
+export function getCapOutlookForRetention(team = {}, board = []) {
+  const capRoom = safeNum(team?.capRoom, 0);
+  const nextYearCapRoom = safeNum(team?.projectedCapRoomNextYear, capRoom);
+  const priorityRows = board.filter((r) => ['cornerstone_priority', 'strong_keep', 'extension_candidate'].includes(r.priority.recommendation));
+  const projectedPriorityCost = priorityRows.reduce((sum, row) => sum + safeNum(row.priority?.demand?.baseAnnual, 0), 0);
+  let running = 0;
+  let affordableCount = 0;
+  priorityRows.forEach((row) => {
+    running += safeNum(row.priority?.demand?.baseAnnual, 0);
+    if (running <= capRoom) affordableCount += 1;
+  });
+
+  let summary = 'Cap runway is healthy enough to retain your core.';
+  if (projectedPriorityCost > capRoom * 1.35) summary = `You can likely retain ${Math.max(0, affordableCount)} of your top ${priorityRows.length} priorities.`;
+  else if (priorityRows.some((r) => safeNum(r.priority?.demand?.baseAnnual, 0) >= capRoom * 0.55)) summary = 'One star extension will tighten your flexibility.';
+
+  return {
+    capRoom,
+    projectedCapRoomNextYear: nextYearCapRoom,
+    projectedPriorityCost: Math.round(projectedPriorityCost * 10) / 10,
+    likelyRetentionCount: affordableCount,
+    summary,
+  };
+}
+
+export function buildRetentionBoard(team = {}, league = {}) {
+  const roster = (league?.players ?? []).filter((p) => Number(p?.teamId) === Number(team?.id) && (p?.status ?? 'active') === 'active');
+  const board = roster.map((player) => {
+    const priority = evaluateReSigningPriority(player, team, league);
+    const teamContext = getTeamContextForNegotiation(player, team, null, {
+      teamDirection: priority.teamDirection,
+      rosterAtPosition: roster.filter((p) => p?.pos === player?.pos),
+      needsAtPosition: priority.replacementDifficulty === 'high' ? 1.7 : priority.replacementDifficulty === 'medium' ? 1.2 : 0.8,
+    });
+    const offerPreview = { contract: priority.demand };
+    const negotiation = evaluateContractOffer(player, {
+      ...teamContext,
+      contenderScore: priority.teamDirection === 'contender' ? 78 : priority.teamDirection === 'rebuilding' ? 45 : 60,
+      roleOpportunityScore: priority.roleImportance === 'core_starter' ? 83 : priority.roleImportance === 'starter' ? 72 : 58,
+    }, offerPreview, {
+      profile: priority.profile,
+      askTotalValue: demandValue(priority.demand),
+      askAnnual: safeNum(priority.demand?.baseAnnual, 0),
+      askYears: safeNum(priority.demand?.yearsTotal ?? priority.demand?.years, 1),
+    });
+
+    const plan = summarizeRetentionPlan(player, { team, league, priority });
+    return {
+      player,
+      priority,
+      plan,
+      negotiation,
+      section: classifyContractDecision(player, { recommendation: priority.recommendation, expiring: priority.expiring }),
+    };
+  });
+
+  board.sort((a, b) => (b.priority.score - a.priority.score) || ((b.player?.ovr ?? 0) - (a.player?.ovr ?? 0)));
+  const capOutlook = getCapOutlookForRetention(team, board);
+
+  return { board, capOutlook };
+}

--- a/src/ui/components/ContractCenter.jsx
+++ b/src/ui/components/ContractCenter.jsx
@@ -1,0 +1,163 @@
+import React, { useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import ExtensionNegotiationModal from './ExtensionNegotiationModal.jsx';
+import {
+  buildRetentionBoard,
+  summarizeRetentionRecommendation,
+} from '../../core/retention/reSigning.js';
+import { summarizeNegotiationStance } from '../../core/contracts/negotiation.js';
+
+function money(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return '—';
+  return `$${n.toFixed(1)}M`;
+}
+
+function toneForRecommendation(key) {
+  if (['cornerstone_priority', 'strong_keep', 'extension_candidate'].includes(key)) return 'var(--success)';
+  if (['keep_if_price_is_right', 'franchise_tag_candidate'].includes(key)) return 'var(--warning)';
+  return 'var(--danger)';
+}
+
+function prettify(v = '') {
+  return String(v).replace(/_/g, ' ');
+}
+
+function groupRows(board = []) {
+  return {
+    PriorityReSignings: board.filter((r) => ['cornerstone_priority', 'strong_keep'].includes(r.priority.recommendation) && r.priority.expiring),
+    ExtensionCandidates: board.filter((r) => r.section === 'extension_candidate'),
+    ExpiringStarters: board.filter((r) => r.priority.expiring && (r.player?.ovr ?? 0) >= 75),
+    LetWalkCandidates: board.filter((r) => r.section === 'let_walk_candidate'),
+    DepthLowUrgencyDeals: board.filter((r) => r.section === 'depth_low_urgency'),
+  };
+}
+
+function PlayerRow({ row, onOpenTalks, onTag }) {
+  const { player, priority, plan, negotiation } = row;
+  return (
+    <div style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: 10, background: 'var(--surface-strong)' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 10 }}>
+        <div>
+          <div style={{ fontWeight: 800 }}>{player.name} · {player.pos}</div>
+          <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>Age {player.age} · OVR {player.ovr} · {priority.expiring ? 'Expiring' : `${priority.yearsLeft}y left`}</div>
+        </div>
+        <div style={{ textAlign: 'right' }}>
+          <div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Recommendation</div>
+          <div style={{ fontWeight: 700, color: toneForRecommendation(priority.recommendation) }}>{prettify(priority.recommendation)}</div>
+        </div>
+      </div>
+      <div style={{ marginTop: 8, display: 'grid', gap: 4, gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', fontSize: 12 }}>
+        <div><strong>Motivation:</strong> {priority.profile.headline}</div>
+        <div><strong>Stance:</strong> {prettify(negotiation.negotiationStance)}</div>
+        <div><strong>Team fit:</strong> {Math.round(negotiation.scoreBreakdown.schemeFit)}/100</div>
+        <div><strong>Market difficulty:</strong> {priority.expectedMarketDifficulty}</div>
+        <div><strong>Extension readiness:</strong> {prettify(priority.extensionReadiness)}</div>
+        <div><strong>Likely ask:</strong> {money(priority.demand.baseAnnual)} / yr</div>
+      </div>
+      <div style={{ fontSize: 12, marginTop: 6, color: 'var(--text-subtle)' }}>
+        {summarizeRetentionRecommendation(priority.recommendation)}
+      </div>
+      <div style={{ fontSize: 12, marginTop: 4, color: 'var(--text-subtle)' }}>
+        {summarizeNegotiationStance({ negotiationStance: negotiation.negotiationStance })}
+      </div>
+      <div style={{ display: 'flex', gap: 6, marginTop: 8, flexWrap: 'wrap' }}>
+        <Button size="sm" variant="outline" onClick={() => onOpenTalks(player)}>Open talks</Button>
+        {priority.expiring ? <Button size="sm" variant="outline" onClick={() => onTag(player)}>Franchise tag</Button> : null}
+        <span style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--text-muted)' }}>Offer closeness: {negotiation.score}/100</span>
+      </div>
+      {plan?.risk?.summary ? <div style={{ marginTop: 5, fontSize: 11, color: 'var(--text-muted)' }}>{plan.risk.summary}</div> : null}
+    </div>
+  );
+}
+
+export default function ContractCenter({ league, actions }) {
+  const [extensionPlayer, setExtensionPlayer] = useState(null);
+  const [statusMessage, setStatusMessage] = useState('');
+
+  const team = useMemo(() => (league?.teams ?? []).find((t) => Number(t.id) === Number(league?.userTeamId)) ?? null, [league]);
+  const { board, capOutlook } = useMemo(() => buildRetentionBoard(team ?? {}, league ?? {}), [team, league]);
+  const grouped = useMemo(() => groupRows(board), [board]);
+
+  const recentActivity = useMemo(() => {
+    return board
+      .filter((r) => ['counter', 'reject'].includes(r.negotiation.tendency) || r.priority.expiring)
+      .slice(0, 6)
+      .map((r) => `${r.player.name}: ${summarizeNegotiationStance({ negotiationStance: r.negotiation.negotiationStance })}`);
+  }, [board]);
+
+  const handleTag = async (player) => {
+    if (!actions?.applyFranchiseTag || !team?.id) {
+      setStatusMessage('Special retention tool not yet available in this build.');
+      return;
+    }
+    try {
+      await actions.applyFranchiseTag(player.id, team.id);
+      setStatusMessage(`Tagged ${player.name}.`);
+    } catch (err) {
+      setStatusMessage(err?.message || 'Special retention tool not yet available.');
+    }
+  };
+
+  return (
+    <div className="app-screen-stack" style={{ display: 'grid', gap: 'var(--space-4)' }}>
+      <section className="card" style={{ padding: 'var(--space-4)' }}>
+        <h2 style={{ marginTop: 0 }}>Contract Center</h2>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 10, fontSize: 13 }}>
+          <div><strong>Cap room now:</strong> {money(capOutlook.capRoom)}</div>
+          <div><strong>Projected next year:</strong> {money(capOutlook.projectedCapRoomNextYear)}</div>
+          <div><strong>Top-priority cost:</strong> {money(capOutlook.projectedPriorityCost)}</div>
+          <div><strong>Likely keeps:</strong> {capOutlook.likelyRetentionCount}</div>
+        </div>
+        <div style={{ marginTop: 8, color: 'var(--text-subtle)', fontSize: 13 }}>{capOutlook.summary}</div>
+        {statusMessage ? <div style={{ marginTop: 6, fontSize: 12, color: 'var(--accent)' }}>{statusMessage}</div> : null}
+      </section>
+
+      {Object.entries(grouped).map(([title, rows]) => (
+        <section key={title} className="card" style={{ padding: 'var(--space-4)' }}>
+          <h3 style={{ marginTop: 0 }}>{title.replace(/([A-Z])/g, ' $1').trim()} ({rows.length})</h3>
+          <div style={{ display: 'grid', gap: 8 }}>
+            {rows.slice(0, 8).map((row) => (
+              <PlayerRow
+                key={row.player.id}
+                row={row}
+                onOpenTalks={(player) => setExtensionPlayer(player)}
+                onTag={handleTag}
+              />
+            ))}
+            {rows.length === 0 ? <div style={{ color: 'var(--text-muted)', fontSize: 12 }}>No players in this bucket.</div> : null}
+          </div>
+        </section>
+      ))}
+
+      <section className="card" style={{ padding: 'var(--space-4)' }}>
+        <h3 style={{ marginTop: 0 }}>Offseason Retention Board</h3>
+        <ul style={{ margin: 0, paddingLeft: 18, color: 'var(--text-subtle)' }}>
+          {board.slice(0, 5).map((row) => <li key={row.player.id}>{row.player.name} · {prettify(row.priority.recommendation)} · {row.priority.expectedMarketDifficulty} market</li>)}
+        </ul>
+      </section>
+
+      <section className="card" style={{ padding: 'var(--space-4)' }}>
+        <h3 style={{ marginTop: 0 }}>Recent Negotiation Activity</h3>
+        <ul style={{ margin: 0, paddingLeft: 18, color: 'var(--text-subtle)' }}>
+          {recentActivity.map((line, idx) => <li key={`${line}-${idx}`}>{line}</li>)}
+          {recentActivity.length === 0 ? <li>No active internal negotiation signals this week.</li> : null}
+        </ul>
+      </section>
+
+      {extensionPlayer ? (
+        <ExtensionNegotiationModal
+          player={extensionPlayer}
+          teamId={team?.id}
+          actions={actions}
+          onClose={() => setExtensionPlayer(null)}
+          onComplete={() => {
+            setStatusMessage(`${extensionPlayer.name} extension signed.`);
+            setExtensionPlayer(null);
+          }}
+          statusNode={<div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 6 }}>Front-office read: {board.find((r) => r.player.id === extensionPlayer.id)?.plan?.recommendationSummary}</div>}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -44,6 +44,7 @@ import NewsFeed from "./NewsFeed.jsx";
 import RecordBook from "./RecordBook.jsx";
 import StatLeadersWidget from "./StatLeadersWidget.jsx";
 import FinancialsView from "./FinancialsView.jsx";
+import ContractCenter from "./ContractCenter.jsx";
 import PostseasonHub from "./PostseasonHub.jsx";
 import TrainingCamp from "./TrainingCamp.jsx";
 import StaffManagement from "./StaffManagement.jsx";
@@ -221,6 +222,7 @@ const BASE_TABS = [
   "Training",
   "Injuries",
   "Financials",
+  "Contract Center",
   "Coaches",
   "Staff",
   "Transactions",
@@ -247,14 +249,14 @@ const BASE_TABS = [
 
 const NAV_GROUPS = [
   { title: "HQ", tabs: ["HQ"] },
-  { title: "Team", tabs: ["Roster", "Depth Chart", "Game Plan", "Training", "Injuries", "Staff", "Financials"] },
+  { title: "Team", tabs: ["Roster", "Depth Chart", "Game Plan", "Training", "Injuries", "Staff", "Financials", "Contract Center"] },
   { title: "League", tabs: ["Standings", "Schedule", "Stats", "Leaders", "Award Races", "Analytics"] },
   { title: "Transactions", tabs: ["Transactions", "Free Agency", "Draft", "Draft Room", "Mock Draft"] },
   { title: "History", tabs: ["History Hub", "History", "Hall of Fame", "Awards & Records", "Season Recap"] },
   { title: "Tools", tabs: ["Saves", "God Mode", "🤖 GM Advisor"] },
 ];
 
-const TEAM_FACING_TABS = new Set(["Roster", "Depth Chart", "Roster Hub", "Game Plan", "Training", "Injuries", "Staff", "Financials"]);
+const TEAM_FACING_TABS = new Set(["Roster", "Depth Chart", "Roster Hub", "Game Plan", "Training", "Injuries", "Staff", "Financials", "Contract Center"]);
 const TAB_ALIASES = {
   "Weekly Hub": "HQ",
   Home: "HQ",
@@ -1453,7 +1455,7 @@ function QuickJumpFab({ onNavigate }) {
 }
 
 function getPhasePriorityTabs(phase) {
-  if (phase === "offseason_resign") return ["HQ", "Roster", "Free Agency", "Financials"];
+  if (phase === "offseason_resign") return ["HQ", "Contract Center", "Roster", "Free Agency", "Financials"];
   if (phase === "free_agency") return ["HQ", "Free Agency", "Trades", "Draft"];
   if (phase === "draft") return ["HQ", "Draft", "Mock Draft", "Transactions"];
   if (phase === "preseason") return ["HQ", "Roster Hub", "Depth Chart", "Training"];
@@ -2118,6 +2120,11 @@ export default function LeagueDashboard({
         {activeTab === "Financials" && (
           <TabErrorBoundary label="Financials">
             <FinancialsView league={league} actions={actions} />
+          </TabErrorBoundary>
+        )}
+        {activeTab === "Contract Center" && (
+          <TabErrorBoundary label="Contract Center">
+            <ContractCenter league={league} actions={actions} />
           </TabErrorBoundary>
         )}
         {activeTab === "Draft" && (

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -14,6 +14,7 @@ import { formatMoneyM, safeRound, toFiniteNumber } from "../utils/numberFormatti
 import { buildTeamIntelligence, classifyNeedFitForProspect, describeProspectProfile, describeRookieOnboarding } from "../utils/teamIntelligence.js";
 import { buildTeamChemistrySummary, describePlayerMoraleContext } from "../utils/teamChemistry.js";
 import { normalizeManagement, TRADE_STATUS_LABELS, TRADE_STATUS_TOOLTIPS, TRADE_STATUSES, CONTRACT_PLAN_FLAGS, CONTRACT_PLAN_LABELS, toggleContractPlan } from "../utils/playerManagement.js";
+import { evaluateReSigningPriority, summarizeRetentionPlan } from "../../core/retention/reSigning.js";
 
 // ── Accolade badge config ─────────────────────────────────────────────────────
 
@@ -824,6 +825,42 @@ export default function PlayerProfile({
                   </span>
                 ))}
               </div>
+            </section>
+          )}
+
+
+          {!loading && player && (
+            <section>
+              <h3 style={sectionLabelStyle}>Contract Retention Panel</h3>
+              {(() => {
+                const userTeam = teams.find((t) => Number(t.id) === Number(player?.teamId)) || {};
+                const leagueCtx = { players: [], week: 1, phase: '' };
+                const priority = evaluateReSigningPriority(player, userTeam, leagueCtx);
+                const plan = summarizeRetentionPlan(player, { team: userTeam, league: leagueCtx, priority });
+                return (
+                  <>
+                    <div style={{ display: "grid", gap: "var(--space-2)", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" }}>
+                      <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
+                        <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Contract status</div>
+                        <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>{priority.expiring ? 'Expiring now' : `${priority.yearsLeft} years remaining`}</div>
+                      </div>
+                      <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
+                        <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Extension eligibility</div>
+                        <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>{String(priority.extensionReadiness).replace(/_/g, ' ')}</div>
+                      </div>
+                      <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
+                        <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Expected market behavior</div>
+                        <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>{priority.profile.headline}</div>
+                      </div>
+                      <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
+                        <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Retention recommendation</div>
+                        <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>{String(plan.recommendation).replace(/_/g, ' ')}</div>
+                      </div>
+                    </div>
+                    <div style={{ marginTop: 6, fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>{plan.recommendationSummary}</div>
+                  </>
+                );
+              })()}
             </section>
           )}
 


### PR DESCRIPTION
### Motivation
- Surface internal contract planning and re-signing decisions using the existing motivation and negotiation systems without adding full finance simulation.  
- Make re-signing feel strategic by giving the front office clear priorities, extension readiness, negotiation context, and a light cap outlook.  
- Provide reusable retention helpers so UI and AI logic can share consistent recommendations and risk signals.  

### Description
- Add a modular retention engine at `src/core/retention/reSigning.js` with helpers `evaluateReSigningPriority`, `getExtensionReadiness`, `summarizeContractRisk`, `summarizeRetentionPlan`, `classifyContractDecision`, `getCapOutlookForRetention`, and `buildRetentionBoard` to compute priority tiers, demand estimates, and cap outlook.  
- Add a new `ContractCenter` UI at `src/ui/components/ContractCenter.jsx` that groups players into Priority Re-Signings, Extension Candidates, Expiring Starters, Let-Walk Candidates, Depth/Low-Urgency deals, and shows Recent Negotiation Activity plus a lightweight cap summary and actions to open extension talks or apply franchise tag (with fallback messaging).  
- Wire the new Contract Center into the dashboard tabs and phase prioritization (e.g. `offseason_resign`) and add a Contract Retention panel to `PlayerProfile.jsx` that surfaces urgency, extension eligibility, motivation headline, and a concise recommendation.  
- Make AI extension processing retention-aware by consulting the new `evaluateReSigningPriority` output when deciding which expiring players to prioritize for extensions.  
- Add unit tests for the retention helpers in `src/core/__tests__/retention-board.test.js` and keep changes additive so no save-schema migration is required.  

### Testing
- Ran `npx vitest run src/core/__tests__/retention-board.test.js` which executed the new test file and reported all tests passing.  
- Performed a production build with `npm run -s build` which completed successfully (build warnings about chunk size only).  
- An earlier attempt using `npm run -s test -- <file>` produced a runner-argument error in this environment, but the direct `npx vitest` invocation validated the new tests successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d871b9f53c832d84a2dd5a4da2edaa)