### PR TITLE
Box Score Reliability: centralize game-id resolution and archive availability

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -50,7 +50,7 @@ import MilestoneModal      from './components/MilestoneModal.jsx';
 import ThemeToggle         from './components/ThemeToggle.jsx';
 import { SettingsProvider, useSettings } from '../context/SettingsContext.jsx';
 import { ACTION_LABELS } from './constants/navigationCopy.js';
-import { resolveCompletedGameId } from './utils/gameResultIdentity.js';
+import { buildCompletedGamePresentation, openResolvedBoxScore } from './utils/boxScoreAccess.js';
 import { hasMinimumPlayableLeague, summarizeBootstrapState } from './utils/leagueBootstrap.js';
 
 // Increment this when shipping notable UX/bugfix updates so users
@@ -741,17 +741,23 @@ function AppContent() {
           {authoritativeResults.map((r, i) => {
             const homeWin = r.homeScore > r.awayScore;
             const isUserGame = r.homeId === league.userTeamId || r.awayId === league.userTeamId;
-            const gameId = resolveCompletedGameId(r, {
+            const gamePresentation = buildCompletedGamePresentation(r, {
               seasonId: league?.seasonId,
               week: lastSimWeek ?? Math.max(1, (league?.week ?? 1) - 1),
+              source: 'app_results_ticker',
             });
             return (
               <button
                 key={i}
                 type="button"
-                className={`app-result-item ${isUserGame ? 'app-result-user' : ''} ${gameId ? 'app-result-item-clickable' : ''}`}
-                onClick={gameId ? () => setExternalBoxScoreId(gameId) : undefined}
-                title={gameId ? "Open box score" : undefined}
+                className={`app-result-item ${isUserGame ? 'app-result-user' : ''} ${gamePresentation.canOpen ? 'app-result-item-clickable' : ''}`}
+                onClick={() => openResolvedBoxScore(r, {
+                  seasonId: league?.seasonId,
+                  week: lastSimWeek ?? Math.max(1, (league?.week ?? 1) - 1),
+                  source: 'app_results_ticker',
+                }, setExternalBoxScoreId)}
+                aria-disabled={!gamePresentation.canOpen}
+                title={gamePresentation.canOpen ? gamePresentation.ctaLabel : gamePresentation.statusLabel}
               >
                 <span style={{ fontWeight: homeWin ? 700 : 400, color: homeWin ? 'var(--text)' : 'var(--text-muted)' }}>
                   {r.homeName}

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -9,6 +9,7 @@ import {
   describeStatLine,
   toPlayerArray,
 } from "../utils/boxScorePresentation.js";
+import { buildCompletedGamePresentation, getGameDetailPayload } from "../utils/boxScoreAccess.js";
 
 function TeamButton({ team, onSelect }) {
   if (!team) return <span>—</span>;
@@ -87,8 +88,9 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
     actions?.getBoxScore?.(gameId)
       .then((res) => {
         if (!alive) return;
-        setGame(res?.game ?? null);
-        if (!res?.game) setError(res?.error ?? "Box score unavailable for this game.");
+        const payload = res?.game ?? getGameDetailPayload(gameId, league);
+        setGame(payload ?? null);
+        if (!payload) setError(res?.error ?? "Box score unavailable for this game.");
       })
       .catch((err) => {
         if (!alive) return;
@@ -133,7 +135,8 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
 
   const headerWeek = game?.week ?? gameId?.match(/_w(\d+)_/)?.[1] ?? "—";
   const headerSeason = game?.seasonId ?? gameId?.split('_w')?.[0] ?? "";
-  const archiveQuality = game?.archiveQuality ?? (game?.stats?.playLogs?.length ? "full" : (game?.stats || game?.summary || game?.recap ? "partial" : "missing"));
+  const availability = buildCompletedGamePresentation(game ?? { gameId }, { source: "game_detail_screen" });
+  const archiveQuality = availability.archiveQuality;
   const hasAnyPayload = Boolean(game && (
     game.homeScore != null || game.awayScore != null || game.stats || game.recap || game.quarterScores
   ));
@@ -153,7 +156,7 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
         </div>
 
         {loading && <div className="box-score-container"><EmptyState title="Loading box score…" body="Pulling archived game detail and postgame context." /></div>}
-        {!loading && error && !hasAnyPayload && <div className="box-score-container"><EmptyState title="Game archive unavailable" body={unavailableMessage} /></div>}
+        {!loading && error && !hasAnyPayload && <div className="box-score-container"><EmptyState title="Game archive unavailable" body={`${unavailableMessage} (${availability.statusLabel ?? "Archive unavailable"})`} /></div>}
 
         {!loading && hasAnyPayload && game && (
           <div className="box-score-container">

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -5,6 +5,7 @@ import { deriveTeamCapSnapshot, formatMoneyM } from "../utils/numberFormatting.j
 import { findLatestUserCompletedGame } from "../utils/completedGameSelectors.js";
 import { getHQViewModel } from "../../state/selectors.js";
 import { getHQPrimaryAction } from "../utils/hqPrimaryAction.js";
+import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/boxScoreAccess.js";
 import { EmptyState, SectionCard, StatCard, TeamChip, TrendBadge } from "./common/UiPrimitives.jsx";
 
 function safeNum(value, fallback = 0) {
@@ -34,6 +35,9 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore }) {
   const weekly = useMemo(() => evaluateWeeklyContext(vm.league), [vm.league]);
   const latest = useMemo(() => findLatestUserCompletedGame(vm.league), [vm.league]);
   const nextGame = useMemo(() => getNextGame(vm.league), [vm.league]);
+  const latestPresentation = useMemo(() => (
+    latest ? buildCompletedGamePresentation(latest.game, { seasonId: vm.league?.seasonId, week: latest.week, source: "hq_recent_results" }) : null
+  ), [latest, vm.league?.seasonId]);
 
   if (!vm.userTeam) {
     return <EmptyState title="HQ loading" body="Team context is still loading or this save is missing team ownership metadata." />;
@@ -86,8 +90,13 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore }) {
           <div>Next game: {nextGame ? `Week ${nextGame.week} ${nextGame.isHome ? "vs" : "@"} ${nextGame?.opp?.name ?? "TBD"}` : "TBD"}</div>
           <div>Trend: <TrendBadge trend={trend} /> {recent.length ? recent.join(" ") : "No trend yet"}</div>
           <div>
-            <Button size="sm" disabled={!latest?.gameId} onClick={() => latest?.gameId && onOpenBoxScore?.(latest.gameId)}>
-              Open Last Box Score
+            <Button
+              size="sm"
+              disabled={!latestPresentation?.canOpen}
+              onClick={() => latest && openResolvedBoxScore(latest.game, { seasonId: vm.league?.seasonId, week: latest.week, source: "hq_recent_results" }, onOpenBoxScore)}
+              title={latestPresentation?.statusLabel}
+            >
+              {latestPresentation?.ctaLabel ?? "Open Last Box Score"}
             </Button>
           </div>
         </div>

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -80,10 +80,10 @@ import {
 } from "../utils/gamePresentation.js";
 import { deriveFranchisePressure } from "../utils/pressureModel.js";
 import { getClickableCardProps } from "../utils/clickableCard.js";
-import { resolveCompletedGameId } from "../utils/gameResultIdentity.js";
+import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/boxScoreAccess.js";
 import { normalizeManagementDestination } from "../utils/managementScreenRouting.js";
 import { createBoxScoreTapHandler } from "../utils/scoreTapTarget.js";
-import { safeGetLeagueState, canOpenBoxScore, getScheduleViewModel } from "../../state/selectors.js";
+import { safeGetLeagueState, getScheduleViewModel } from "../../state/selectors.js";
 
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from "@/components/ui/table";
@@ -842,10 +842,9 @@ function ScheduleTab({
       .map((game) => {
         const home = teamById[game.home] ?? { abbr: "HOME" };
         const away = teamById[game.away] ?? { abbr: "AWAY" };
-        const gameId = resolveCompletedGameId(game, { seasonId, week: selectedWeek });
-        const archiveQuality = game?.archiveQuality ?? (game?.gameId ? "full" : (gameId ? "partial" : "missing"));
+        const presentation = buildCompletedGamePresentation(game, { seasonId, week: selectedWeek, teamById, source: "schedule_recap" });
         const story = derivePostgameStory({ league, game, week: selectedWeek });
-        return { game, home, away, gameId, archiveQuality, story };
+        return { game, home, away, presentation, story };
       })
       .slice(0, 8)
   ), [games, league, seasonId, selectedWeek, teamById]);
@@ -926,20 +925,20 @@ function ScheduleTab({
             <span style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>Scores + storylines at a glance</span>
           </div>
           <div style={{ display: "grid", gap: 6 }}>
-            {weekRecapItems.map(({ game, away, home, gameId, archiveQuality, story }, idx) => (
+            {weekRecapItems.map(({ game, away, home, presentation, story }, idx) => (
               <button
                 key={`${game.home}-${game.away}-${idx}`}
-                className={`btn-link ${gameId ? "" : "disabled"}`}
-                onClick={gameId ? () => onGameSelect?.(gameId) : undefined}
+                className={`btn-link ${presentation.canOpen ? "" : "disabled"}`}
+                onClick={() => openResolvedBoxScore(game, { seasonId, week: selectedWeek, source: "schedule_recap" }, onGameSelect)}
                 style={{ textAlign: "left", fontSize: "var(--text-sm)", color: "var(--text-muted)" }}
-                title={gameId ? "View box score" : "Archive unavailable"}
+                title={presentation.canOpen ? presentation.ctaLabel : presentation.statusLabel}
               >
                 <strong style={{ color: "var(--text)" }}>{away.abbr} {game.awayScore} @ {home.abbr} {game.homeScore}</strong>
                 {" · "}
                 {story?.headline ?? "Final"}
                 {" · "}
-                <span style={{ color: archiveQuality === "full" ? "var(--success)" : archiveQuality === "partial" ? "var(--warning)" : "var(--text-subtle)" }}>
-                  {archiveQuality === "full" ? "Full archive" : archiveQuality === "partial" ? "Partial archive" : "Archive unavailable"}
+                <span style={{ color: presentation.archiveQuality === "full" ? "var(--success)" : presentation.archiveQuality === "partial" ? "var(--warning)" : "var(--text-subtle)" }}>
+                  {presentation.statusLabel}
                 </span>
               </button>
             ))}
@@ -1001,9 +1000,10 @@ function ScheduleTab({
             !game.played &&
             nextGameStakes > 50 &&
             selectedWeek === currentWeek;
-          const resolvedGameId = game.played ? resolveCompletedGameId(game, { seasonId, week: selectedWeek }) : null;
-          const archiveQuality = game?.archiveQuality ?? (game?.gameId ? "full" : (resolvedGameId ? "partial" : "missing"));
-          const isClickable = Boolean(canOpenBoxScore({ ...game, gameId: resolvedGameId }) && onGameSelect && archiveQuality !== "missing");
+          const presentation = game.played ? buildCompletedGamePresentation(game, { seasonId, week: selectedWeek, teamById, source: "schedule_card" }) : null;
+          const resolvedGameId = presentation?.resolvedGameId ?? null;
+          const archiveQuality = presentation?.archiveQuality ?? "missing";
+          const isClickable = Boolean(presentation?.canOpen && onGameSelect);
           const pregameAngles = !game.played ? derivePregameAngles({ league, game, week: selectedWeek }) : [];
           const postgame = game.played ? derivePostgameStory({ league, game, week: selectedWeek }) : null;
           const immersion = game.played ? deriveBoxScoreImmersion({ league, game, week: selectedWeek }) : null;
@@ -1019,8 +1019,7 @@ function ScheduleTab({
             return null;
           })();
           const handleCardClick = isClickable
-            ? () =>
-                onGameSelect(resolvedGameId)
+            ? () => openResolvedBoxScore(game, { seasonId, week: selectedWeek, source: "schedule_card" }, onGameSelect)
             : undefined;
           const scoreTapHandler = createBoxScoreTapHandler({
             gameId: resolvedGameId,
@@ -1122,7 +1121,7 @@ function ScheduleTab({
                     onClick={scoreTapHandler}
                     aria-label={scoreTapHandler ? `Open box score for ${away.abbr} at ${home.abbr}` : undefined}
                     aria-disabled={!scoreTapHandler}
-                    title={scoreTapHandler ? "View box score" : undefined}
+                    title={scoreTapHandler ? presentation?.ctaLabel ?? "View box score" : presentation?.statusLabel}
                   >
                     <span
                       style={{
@@ -1169,7 +1168,7 @@ function ScheduleTab({
                         marginBottom: "var(--space-1)",
                       }}
                     >
-                      View Box Score →
+                      {presentation?.ctaLabel ?? "View Box Score"} →
                     </div>
                   )}
                   {postgame && (
@@ -1848,25 +1847,26 @@ export default function LeagueDashboard({
                         const aId = toId(g.awayId);
                         const hA = teamById[hId]?.abbr ?? "?";
                         const aA = teamById[aId]?.abbr ?? "?";
-                        const gId = resolveCompletedGameId(g, { seasonId: league.seasonId, week: prevWeek });
+                        const compactPresentation = buildCompletedGamePresentation(g, { seasonId: league.seasonId, week: prevWeek, source: "weekly_hub_compact_scores" });
+                        const gId = compactPresentation.resolvedGameId;
                         const compactScoreTapHandler = createBoxScoreTapHandler({
                           gameId: gId,
-                          onOpenBoxScore: (id) => openGameDetail(id, "Weekly Hub"),
+                          onOpenBoxScore: () => openResolvedBoxScore(g, { seasonId: league.seasonId, week: prevWeek, source: "weekly_hub_compact_scores" }, (id) => openGameDetail(id, "Weekly Hub")),
                         });
                         return (
                           <React.Fragment key={i}>
-                            {gId ? (
+                            {compactPresentation.canOpen ? (
                               <button
                                 type="button"
                                 className="compact-score-link"
                                 onClick={compactScoreTapHandler}
                                 aria-label={`Open box score for ${aA} at ${hA}`}
-                                title="View box score"
+                                title={compactPresentation.ctaLabel}
                               >
                                 {aA} {g.awayScore}-{g.homeScore} {hA}
                               </button>
                             ) : (
-                              <span>{aA} {g.awayScore}-{g.homeScore} {hA}</span>
+                              <span title={compactPresentation.statusLabel}>{aA} {g.awayScore}-{g.homeScore} {hA}</span>
                             )}
                             {i < arr.length - 1 ? " · " : ""}
                           </React.Fragment>

--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -4,6 +4,7 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/boxScoreAccess.js";
 
 const RECORD_LABELS = {
   passYd: "Passing Yards",
@@ -271,17 +272,18 @@ function SeasonExplorer({ seasons, onPlayerSelect, onOpenBoxScore }) {
             <h4 className="text-sm font-bold mb-2">Completed game archive</h4>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm">
               {(selected?.gameIndex ?? []).slice(-12).reverse().map((game) => {
-                const clickable = Boolean(game?.id && onOpenBoxScore);
+                const presentation = buildCompletedGamePresentation(game, { seasonId: selected?.year, source: "league_history" });
+                const clickable = Boolean(presentation.canOpen && onOpenBoxScore);
                 return (
                   <button
                     key={game.id}
                     className="rounded-md border border-[color:var(--hairline)] px-3 py-2 text-left"
-                    onClick={() => clickable ? onOpenBoxScore?.(game.id) : null}
+                    onClick={() => openResolvedBoxScore(game, { seasonId: selected?.year, source: "league_history" }, onOpenBoxScore)}
                     style={{ cursor: clickable ? "pointer" : "default", opacity: clickable ? 1 : 0.75 }}
-                    title={clickable ? "View box score" : undefined}
+                    title={clickable ? presentation.ctaLabel : presentation.statusLabel}
                   >
                     <strong>Week {game.week}: {game.awayScore ?? "—"} - {game.homeScore ?? "—"}</strong>
-                    <div className="text-xs text-[color:var(--text-muted)]">{clickable ? "Open shared game detail" : "Archived index row only"}</div>
+                    <div className="text-xs text-[color:var(--text-muted)]">{clickable ? presentation.ctaLabel : presentation.statusLabel}</div>
                   </button>
                 );
               })}

--- a/src/ui/components/LiveGame.jsx
+++ b/src/ui/components/LiveGame.jsx
@@ -33,6 +33,7 @@ import React, {
   useCallback,
 } from "react";
 import { getClickableCardProps } from "../utils/clickableCard.js";
+import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/boxScoreAccess.js";
 
 // ── Momentum Bar ───────────────────────────────────────────────────────────────
 // Shows which team has the momentum based on recent plays.
@@ -209,11 +210,9 @@ function MatchupCard({ event, userTeamId, pending, onOpenBoxScore }) {
   const { homeId, awayId, homeAbbr, awayAbbr, homeScore, awayScore } = event;
   const isUser = homeId === userTeamId || awayId === userTeamId;
   const finished = !pending;
-  const handleClick = () => {
-    if (!finished || !onOpenBoxScore || !event?.gameId) return;
-    onOpenBoxScore(event.gameId);
-  };
-  const interactive = finished && onOpenBoxScore && event?.gameId;
+  const presentation = buildCompletedGamePresentation(event, { source: "live_game_matchup" });
+  const handleClick = () => openResolvedBoxScore(event, { source: "live_game_matchup" }, onOpenBoxScore);
+  const interactive = finished && Boolean(onOpenBoxScore && presentation.canOpen);
   const interactiveProps = getClickableCardProps({
     onOpen: handleClick,
     disabled: !interactive,

--- a/src/ui/components/PostseasonHub.jsx
+++ b/src/ui/components/PostseasonHub.jsx
@@ -11,7 +11,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from "@/components/ui/table";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { resolveCompletedGameId } from "../utils/gameResultIdentity.js";
+import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/boxScoreAccess.js";
 
 function teamColor(abbr = "") {
   const palette = [
@@ -51,15 +51,15 @@ function MatchupCard({ game, teams, userTeamId, seedByTeam, onOpenBoxScore, seas
 
   const homeWon = game.played && game.homeScore > game.awayScore;
   const awayWon = game.played && game.awayScore > game.homeScore;
-  const gameId = game?.played ? resolveCompletedGameId(game, { seasonId, week }) : null;
-  const clickable = Boolean(gameId && onOpenBoxScore);
+  const presentation = game?.played ? buildCompletedGamePresentation(game, { seasonId, week, source: "postseason_hub" }) : null;
+  const clickable = Boolean(presentation?.canOpen && onOpenBoxScore);
 
   return (
     <div
       role={clickable ? "button" : undefined}
       tabIndex={clickable ? 0 : undefined}
-      onClick={clickable ? () => onOpenBoxScore?.(gameId) : undefined}
-      onKeyDown={clickable ? (e) => ((e.key === "Enter" || e.key === " ") ? onOpenBoxScore?.(gameId) : null) : undefined}
+      onClick={clickable ? () => openResolvedBoxScore(game, { seasonId, week, source: "postseason_hub" }, onOpenBoxScore) : undefined}
+      onKeyDown={clickable ? (e) => ((e.key === "Enter" || e.key === " ") ? openResolvedBoxScore(game, { seasonId, week, source: "postseason_hub" }, onOpenBoxScore) : null) : undefined}
       style={{
         background: "var(--surface)",
         border: `2px solid ${isUserGame ? "var(--accent)" : "var(--hairline)"}`,
@@ -195,6 +195,11 @@ function MatchupCard({ game, teams, userTeamId, seedByTeam, onOpenBoxScore, seas
         >
           {game.played ? "FINAL" : "UPCOMING"}
         </Badge>
+        {game.played && (
+          <div style={{ fontSize: 10, color: "var(--text-muted)", marginTop: 2 }}>
+            {presentation?.statusLabel ?? "Archive unavailable"}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/ui/components/SeasonRecap.jsx
+++ b/src/ui/components/SeasonRecap.jsx
@@ -10,7 +10,7 @@ import { deriveFranchisePressure } from "../utils/pressureModel.js";
 import { buildTeamIntelligence } from "../utils/teamIntelligence.js";
 import { deriveTeamCoachingIdentity, buildCoachingNarrativeCards } from "../utils/coachingIdentity.js";
 import { franchiseInvestmentSummary } from "../utils/franchiseInvestments.js";
-import { resolveCompletedGameId } from "../utils/gameResultIdentity.js";
+import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/boxScoreAccess.js";
 
 function AnimatedSection({ delay = 0, children, title, icon }) {
   const [visible, setVisible] = useState(false);
@@ -206,7 +206,7 @@ export default function SeasonRecap({ league, onPlayerSelect, onTeamSelect, onNa
         rows.push({
           game,
           week: Number(week?.week ?? league?.week ?? 1),
-          gameId: resolveCompletedGameId(game, { seasonId, week: Number(week?.week ?? 1) }),
+          presentation: buildCompletedGamePresentation(game, { seasonId, week: Number(week?.week ?? 1), source: "season_recap" }),
         });
       }
     }
@@ -395,10 +395,11 @@ export default function SeasonRecap({ league, onPlayerSelect, onTeamSelect, onNa
           ) : completedGames.map((row) => {
             const homeTeam = teams.find((t) => Number(t.id) === Number(row.game.home));
             const awayTeam = teams.find((t) => Number(t.id) === Number(row.game.away));
+            const clickable = Boolean(row.presentation?.canOpen && onOpenBoxScore);
             return (
               <button
-                key={row.gameId}
-                onClick={() => row.gameId ? onOpenBoxScore?.(row.gameId) : null}
+                key={row.presentation?.resolvedGameId ?? `${row.week}-${row.game?.home}-${row.game?.away}`}
+                onClick={() => openResolvedBoxScore(row.game, { seasonId: league?.seasonId, week: row.week, source: "season_recap" }, onOpenBoxScore)}
                 style={{
                   textAlign: "left",
                   border: "1px solid var(--hairline)",
@@ -406,11 +407,13 @@ export default function SeasonRecap({ league, onPlayerSelect, onTeamSelect, onNa
                   padding: "10px 12px",
                   background: "var(--surface-strong, #1a1a2e)",
                   color: "var(--text)",
-                  cursor: row.gameId ? "pointer" : "default",
+                  cursor: clickable ? "pointer" : "default",
+                  opacity: clickable ? 1 : 0.75,
                 }}
+                title={clickable ? row.presentation?.ctaLabel : row.presentation?.statusLabel}
               >
                 <strong>Week {row.week} · {awayTeam?.abbr ?? "AWY"} {row.game.awayScore ?? "—"} - {row.game.homeScore ?? "—"} {homeTeam?.abbr ?? "HME"}</strong>
-                <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>{row.gameId ? "Open universal box score" : "Game detail unavailable"}</div>
+                <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>{clickable ? row.presentation?.ctaLabel : row.presentation?.statusLabel}</div>
               </button>
             );
           })}

--- a/src/ui/components/TeamHistoryScreen.jsx
+++ b/src/ui/components/TeamHistoryScreen.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { ScreenHeader, SectionCard, EmptyState } from './ScreenSystem.jsx';
+import { buildCompletedGamePresentation, openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 
 function buildSeasonTeamMap(season) {
   const map = {};
@@ -59,8 +60,11 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
         if (homeId !== targetTeamId && awayId !== targetTeamId) continue;
         rows.push({
           gameId: game?.id,
+          id: game?.id,
           year: season?.year,
           week: game?.week,
+          homeId,
+          awayId,
           home: teamMap[homeId],
           away: teamMap[awayId],
           homeScore: game?.homeScore,
@@ -133,17 +137,18 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
           {completedGameRows.length === 0 ? (
             <EmptyState title="No archived results yet" body="Completed game links appear here as season history builds." />
           ) : completedGameRows.map((row) => {
-            const clickable = Boolean(row.gameId && onOpenBoxScore);
+            const presentation = buildCompletedGamePresentation(row, { seasonId: row.year, week: row.week, source: 'team_history' });
+            const clickable = Boolean(presentation.canOpen && onOpenBoxScore);
             return (
               <button
                 key={`${row.gameId}-${row.year}-${row.week}`}
                 className="btn"
-                onClick={() => clickable ? onOpenBoxScore?.(row.gameId) : null}
+                onClick={() => openResolvedBoxScore(row, { seasonId: row.year, week: row.week, source: 'team_history' }, onOpenBoxScore)}
                 style={{ textAlign: 'left', opacity: clickable ? 1 : 0.7, cursor: clickable ? 'pointer' : 'default' }}
-                title={clickable ? 'View box score' : undefined}
+                title={clickable ? presentation.ctaLabel : presentation.statusLabel}
               >
                 <strong>{row.year} · Week {row.week} · {row.away?.abbr ?? 'AWY'} {row.awayScore ?? '—'}-{row.homeScore ?? '—'} {row.home?.abbr ?? 'HME'}</strong>
-                <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4 }}>{clickable ? 'Open shared game detail' : 'Game detail unavailable for this row'}</div>
+                <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4 }}>{clickable ? presentation.ctaLabel : presentation.statusLabel}</div>
               </button>
             );
           })}

--- a/src/ui/features/boxScoreActions.js
+++ b/src/ui/features/boxScoreActions.js
@@ -1,4 +1,4 @@
-import { canOpenBoxScore } from '../../state/selectors.js';
+import { openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 
 export function openBoxScore(gameOrId, onOpen) {
   if (typeof onOpen !== 'function') return false;
@@ -6,7 +6,5 @@ export function openBoxScore(gameOrId, onOpen) {
     onOpen(String(gameOrId));
     return true;
   }
-  if (!canOpenBoxScore(gameOrId)) return false;
-  onOpen(String(gameOrId.gameId ?? gameOrId.id));
-  return true;
+  return openResolvedBoxScore(gameOrId, { source: 'openBoxScore' }, onOpen);
 }

--- a/src/ui/utils/boxScoreAccess.js
+++ b/src/ui/utils/boxScoreAccess.js
@@ -1,0 +1,126 @@
+import { buildCanonicalGameId, toTeamId } from "../../core/gameIdentity.js";
+
+const ARCHIVE_QUALITY_LABELS = {
+  full: "Full box score",
+  partial: "Partial archive",
+  missing: "Archive unavailable",
+};
+
+function detectArchiveQuality(game) {
+  if (game?.archiveQuality === "full" || game?.archiveQuality === "partial" || game?.archiveQuality === "missing") {
+    return game.archiveQuality;
+  }
+  if (Array.isArray(game?.stats?.playLogs) && game.stats.playLogs.length > 0) return "full";
+  if (game?.stats || game?.summary || game?.recap || game?.drives || game?.quarterScores) return "partial";
+  return "missing";
+}
+
+function hasFinalScore(game) {
+  return Boolean(
+    game?.played
+      || Number.isFinite(Number(game?.homeScore))
+      || Number.isFinite(Number(game?.awayScore)),
+  );
+}
+
+export function inferCompletedGameIdentity(game, context = {}) {
+  if (!game || typeof game !== "object") return null;
+  if (typeof game.gameId === "string" && game.gameId) return game.gameId;
+  if (typeof game.id === "string" && /_w\d+_\d+_\d+/.test(game.id)) return game.id;
+  return buildCanonicalGameId({
+    seasonId: game?.seasonId ?? context?.seasonId,
+    week: game?.week ?? context?.week,
+    homeId: game?.homeId ?? game?.home,
+    awayId: game?.awayId ?? game?.away,
+  });
+}
+
+export function normalizeCompletedGameRecord(game, context = {}) {
+  if (!game || typeof game !== "object") return null;
+  return {
+    ...game,
+    homeId: toTeamId(game?.homeId ?? game?.home),
+    awayId: toTeamId(game?.awayId ?? game?.away),
+    seasonId: game?.seasonId ?? context?.seasonId ?? null,
+    week: Number(game?.week ?? context?.week ?? null),
+  };
+}
+
+export function resolveBoxScoreGameId(game, context = {}) {
+  const normalized = normalizeCompletedGameRecord(game, context);
+  if (!normalized) return null;
+  return inferCompletedGameIdentity(normalized, context);
+}
+
+export function getBoxScoreAvailability(game, context = {}) {
+  const normalized = normalizeCompletedGameRecord(game, context);
+  const resolvedGameId = resolveBoxScoreGameId(normalized, context);
+  const archiveQuality = detectArchiveQuality(normalized);
+  const isCompleted = hasFinalScore(normalized);
+  const canOpen = Boolean(isCompleted && resolvedGameId && archiveQuality !== "missing");
+  let fallbackReason = null;
+  if (!isCompleted) fallbackReason = "Game not completed";
+  else if (!resolvedGameId) fallbackReason = "Missing game identity";
+  else if (archiveQuality === "missing") fallbackReason = "Archive unavailable";
+  return { resolvedGameId, archiveQuality, canOpen, fallbackReason, isCompleted };
+}
+
+export function getArchiveQualityLabel(archiveQuality) {
+  return ARCHIVE_QUALITY_LABELS[archiveQuality] ?? ARCHIVE_QUALITY_LABELS.missing;
+}
+
+export function buildCompletedGamePresentation(game, context = {}) {
+  const availability = getBoxScoreAvailability(game, context);
+  const away = context?.teamById?.[toTeamId(game?.awayId ?? game?.away)] ?? null;
+  const home = context?.teamById?.[toTeamId(game?.homeId ?? game?.home)] ?? null;
+  const displayScoreLine = `${away?.abbr ?? "AWY"} ${game?.awayScore ?? "—"} - ${game?.homeScore ?? "—"} ${home?.abbr ?? "HME"}`;
+  return {
+    ...availability,
+    ctaLabel: availability.canOpen
+      ? (availability.archiveQuality === "partial" ? "View Partial Archive" : "View Box Score")
+      : "Archive Unavailable",
+    statusLabel: getArchiveQualityLabel(availability.archiveQuality),
+    displayScoreLine,
+    away,
+    home,
+  };
+}
+
+export function openResolvedBoxScore(game, context = {}, onOpen) {
+  const presentation = buildCompletedGamePresentation(game, context);
+  if (!presentation.canOpen || typeof onOpen !== "function") {
+    if (import.meta.env?.DEV) {
+      // eslint-disable-next-line no-console
+      console.warn("[boxscore] open blocked", {
+        source: context?.source ?? "unknown",
+        resolvedGameId: presentation.resolvedGameId,
+        archiveQuality: presentation.archiveQuality,
+        fallbackReason: presentation.fallbackReason,
+        game,
+      });
+    }
+    return false;
+  }
+  onOpen(String(presentation.resolvedGameId));
+  return true;
+}
+
+export function getGameDetailPayload(gameId, leagueState) {
+  if (!gameId || !leagueState?.schedule?.weeks) return null;
+  const [seasonPart, weekPart, homePart, awayPart] = String(gameId).split("_");
+  const week = Number((weekPart ?? "").replace("w", ""));
+  const awayId = Number(awayPart);
+  const homeId = Number(homePart);
+  for (const weekRow of leagueState.schedule.weeks) {
+    for (const game of weekRow?.games ?? []) {
+      const normalized = normalizeCompletedGameRecord(game, { seasonId: seasonPart, week: Number(weekRow?.week ?? week) });
+      if (inferCompletedGameIdentity(normalized, { seasonId: seasonPart, week: weekRow?.week }) === gameId) return normalized;
+      if (
+        Number(weekRow?.week) === week
+        && Number(normalized?.homeId) === homeId
+        && Number(normalized?.awayId) === awayId
+      ) return normalized;
+    }
+  }
+  return null;
+}

--- a/src/ui/utils/boxScoreAccess.test.js
+++ b/src/ui/utils/boxScoreAccess.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildCompletedGamePresentation,
+  getBoxScoreAvailability,
+  openResolvedBoxScore,
+  resolveBoxScoreGameId,
+} from "./boxScoreAccess.js";
+
+describe("boxScoreAccess", () => {
+  it("resolves canonical ids from legacy-shaped game rows", () => {
+    expect(resolveBoxScoreGameId({ seasonId: "2030", week: 5, home: 1, away: 4 })).toBe("2030_w5_1_4");
+  });
+
+  it("marks missing archive games as not openable", () => {
+    const availability = getBoxScoreAvailability({ seasonId: "2030", week: 4, home: 3, away: 8, homeScore: 20, awayScore: 17 });
+    expect(availability.archiveQuality).toBe("missing");
+    expect(availability.canOpen).toBe(false);
+  });
+
+  it("builds partial archive CTA labels", () => {
+    const vm = buildCompletedGamePresentation({
+      seasonId: "2030",
+      week: 9,
+      home: 2,
+      away: 6,
+      homeScore: 27,
+      awayScore: 24,
+      recap: "Legacy recap only",
+    });
+    expect(vm.archiveQuality).toBe("partial");
+    expect(vm.ctaLabel).toBe("View Partial Archive");
+  });
+
+  it("opens resolved game IDs through shared flow", () => {
+    const onOpen = vi.fn();
+    const opened = openResolvedBoxScore({
+      seasonId: "2030",
+      week: 9,
+      home: 2,
+      away: 6,
+      homeScore: 27,
+      awayScore: 24,
+      recap: "Legacy recap only",
+    }, {}, onOpen);
+    expect(opened).toBe(true);
+    expect(onOpen).toHaveBeenCalledWith("2030_w9_2_6");
+  });
+});

--- a/src/ui/utils/gameResultIdentity.js
+++ b/src/ui/utils/gameResultIdentity.js
@@ -1,12 +1,5 @@
-import { buildCanonicalGameId } from '../../core/gameIdentity.js';
+import { resolveBoxScoreGameId } from './boxScoreAccess.js';
 
 export function resolveCompletedGameId(result, context = {}) {
-  if (result?.gameId) return result.gameId;
-  if (result?.id && String(result.id).includes('_w')) return result.id;
-  return buildCanonicalGameId({
-    seasonId: result?.seasonId ?? context?.seasonId,
-    week: result?.week ?? context?.week,
-    homeId: result?.homeId ?? result?.home,
-    awayId: result?.awayId ?? result?.away,
-  });
+  return resolveBoxScoreGameId(result, context);
 }


### PR DESCRIPTION
### Motivation
- Resolve inconsistent completed-game identity and false-positive box-score CTAs by introducing a single trusted access pipeline. 
- Make every entry point (HQ, Schedule, Weekly Hub, Postseason, History, Team History, LiveGame, and ticker) use the same logic so completed games open reliably. 
- Provide clear fallback behavior for partial/missing archives and avoid hard failures in `GameDetailScreen` when deep payload fields are absent. 

### Description
- Added a centralized helper module `src/ui/utils/boxScoreAccess.js` with helpers `resolveBoxScoreGameId`, `normalizeCompletedGameRecord`, `inferCompletedGameIdentity`, `getBoxScoreAvailability`/`getArchiveQualityLabel`, `buildCompletedGamePresentation`, `openResolvedBoxScore`, and `getGameDetailPayload` to normalize legacy rows, infer canonical IDs, and decide archive quality and openability. 
- Rewired box-score entry points to use the shared flow and availability metadata, including `src/ui/App.jsx` (results ticker), `src/ui/components/LeagueDashboard.jsx` (schedule, recap, compact scores), `src/ui/components/FranchiseHQ.jsx`, `src/ui/components/LiveGame.jsx`, `src/ui/components/PostseasonHub.jsx`, `src/ui/components/LeagueHistory.jsx`, `src/ui/components/TeamHistoryScreen.jsx`, and `src/ui/components/SeasonRecap.jsx`, so CTAs and click handlers only appear when a game can actually open. 
- Updated the core helpers `src/ui/features/boxScoreActions.js` and `src/ui/utils/gameResultIdentity.js` to route through the centralized resolution and open logic. 
- Hardened `GameDetailScreen`/`BoxScore` loading path to fall back to a schedule-derived payload via `getGameDetailPayload` when the archive fetch returns no game, and surface archive-aware messages instead of crashing. 
- Added unit tests `src/ui/utils/boxScoreAccess.test.js` covering canonical id resolution, archive availability detection, partial-archive CTA labeling, and the shared open flow. 

### Testing
- Ran unit tests via `npm run test:unit` for the new and related spec files and all targeted tests passed (`11` tests passed). 
- Built production assets with `npm run build` and the build completed successfully. 
- Verified the main UI flows were updated to call the shared helper (static analysis and smoke validation during the build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d874e36910832d942b47ffefbfd807)