### PR TITLE
Canonical archived game normalization and honest box score quality

### DIFF
--- a/src/core/__tests__/gameArchive.test.js
+++ b/src/core/__tests__/gameArchive.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyArchiveQuality,
+  normalizeArchivedGamePayload,
+  recoverArchivedGameFromSchedule,
+  summarizeArchiveDefects,
+} from '../gameArchive.js';
+
+describe('gameArchive helpers', () => {
+  it('classifies full archives only when core sections exist', () => {
+    const game = normalizeArchivedGamePayload({
+      id: '2030_w3_1_2',
+      seasonId: '2030',
+      week: 3,
+      homeId: 1,
+      awayId: 2,
+      homeScore: 28,
+      awayScore: 17,
+      teamStats: { home: { totalYards: 380 }, away: { totalYards: 301 } },
+      playerStats: { home: { p1: { stats: { passYd: 280 } } }, away: { p2: { stats: { passYd: 245 } } } },
+      scoringSummary: [{ quarter: 1, teamId: 1, text: 'TD' }],
+      playLog: [{ quarter: 1, teamId: 1, text: 'TD pass' }],
+    });
+    expect(classifyArchiveQuality(game)).toBe('full');
+  });
+
+  it('keeps missing team stats as unavailable instead of fake zeros', () => {
+    const game = normalizeArchivedGamePayload({
+      id: '2030_w4_3_8',
+      seasonId: '2030',
+      week: 4,
+      homeId: 3,
+      awayId: 8,
+      homeScore: 21,
+      awayScore: 20,
+      recap: 'Legacy row only',
+    });
+    expect(game.teamStats?.home).toBeNull();
+    expect(game.archiveQuality).toBe('partial');
+  });
+
+  it('recovers schedule fallback as partial archive', () => {
+    const recovered = recoverArchivedGameFromSchedule('2031_w7_5_6', {
+      schedule: { weeks: [{ week: 7, games: [{ home: 5, away: 6, homeScore: 14, awayScore: 10, played: true }] }] },
+    });
+    expect(recovered?.archiveQuality).toBe('partial');
+    expect(recovered?.homeScore).toBe(14);
+  });
+
+  it('flags contradictory full markers on validation summaries', () => {
+    const defects = summarizeArchiveDefects({
+      id: 'x',
+      seasonId: '2030',
+      week: 2,
+      homeId: 1,
+      awayId: 2,
+      homeScore: 10,
+      awayScore: 7,
+      archiveQuality: 'full',
+    });
+    expect(defects.some((d) => d.includes('full_without_team_stats'))).toBe(true);
+  });
+});

--- a/src/core/__tests__/gameIdentity.test.js
+++ b/src/core/__tests__/gameIdentity.test.js
@@ -11,7 +11,7 @@ describe('game identity helpers', () => {
     expect(archived.id).toBe('2030_w3_8_2');
     expect(archived.stats).toBe(null);
     expect(archived.homeScore).toBe(24);
-    expect(archived.archiveQuality).toBe('partial');
+    expect(archived.archiveQuality).toBe('missing');
   });
 
   it('marks archives with play logs as full detail payloads', () => {

--- a/src/core/gameArchive.js
+++ b/src/core/gameArchive.js
@@ -1,0 +1,180 @@
+import { buildCanonicalGameId, toTeamId } from './gameIdentity.js';
+
+const QUALITY = {
+  full: 'full',
+  partial: 'partial',
+  missing: 'missing',
+};
+
+const asNumberOrNull = (value) => {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+};
+
+const hasValues = (obj) => Boolean(obj && typeof obj === 'object' && Object.keys(obj).length > 0);
+
+function normalizeQuarterScores(input) {
+  if (!input || typeof input !== 'object') return null;
+  const home = Array.isArray(input.home) ? input.home : Array.isArray(input.h) ? input.h : null;
+  const away = Array.isArray(input.away) ? input.away : Array.isArray(input.a) ? input.a : null;
+  if (!home && !away) return null;
+  const normalizeSide = (rows) => [0, 1, 2, 3].map((idx) => {
+    if (!rows) return null;
+    const val = asNumberOrNull(rows[idx]);
+    return val == null ? null : val;
+  });
+  return { home: normalizeSide(home), away: normalizeSide(away) };
+}
+
+export function deriveTeamStatsFromPlayerRows(playerRows = {}) {
+  const rows = Object.values(playerRows ?? {});
+  if (!rows.length) return null;
+  const sum = (key) => rows.reduce((acc, row) => acc + (Number(row?.stats?.[key]) || 0), 0);
+  const hasAnyStat = rows.some((row) => hasValues(row?.stats));
+  if (!hasAnyStat) return null;
+  const passYards = sum('passYd');
+  const rushYards = sum('rushYd');
+  return {
+    totalYards: passYards + rushYards,
+    passYards,
+    rushYards,
+    turnovers: sum('interceptions') + sum('fumblesLost'),
+    sacks: sum('sacks'),
+    firstDowns: sum('firstDowns'),
+    thirdDownMade: sum('thirdDownMade'),
+    thirdDownAtt: sum('thirdDownAtt'),
+    redZoneMade: sum('redZoneMade'),
+    redZoneAtt: sum('redZoneAtt'),
+    penalties: sum('penalties'),
+  };
+}
+
+export function classifyArchiveQuality(rawGame) {
+  if (!rawGame || typeof rawGame !== 'object') return QUALITY.missing;
+  const hasFinal = Number.isFinite(Number(rawGame?.homeScore)) && Number.isFinite(Number(rawGame?.awayScore));
+  const hasTeamStats = hasValues(rawGame?.teamStats?.home) && hasValues(rawGame?.teamStats?.away);
+  const hasPlayerStats = hasValues(rawGame?.playerStats?.home) && hasValues(rawGame?.playerStats?.away);
+  const hasSections = (rawGame?.scoringSummary?.length ?? 0) > 0
+    || (rawGame?.driveSummary?.length ?? 0) > 0
+    || (rawGame?.playLog?.length ?? 0) > 0
+    || (rawGame?.eventLog?.length ?? 0) > 0;
+  if (hasFinal && hasTeamStats && hasPlayerStats && hasSections) return QUALITY.full;
+  if (hasFinal && (hasTeamStats || hasPlayerStats || hasSections || rawGame?.summary || rawGame?.recap || rawGame?.quarterScores)) return QUALITY.partial;
+  return QUALITY.missing;
+}
+
+export function summarizeArchiveDefects(rawGame) {
+  const g = normalizeArchivedGamePayload(rawGame);
+  const defects = [];
+  const declaredQuality = rawGame?.archiveQuality;
+  if (!g?.id) defects.push('missing_id');
+  if (!Number.isFinite(Number(g?.homeId))) defects.push('missing_home_id');
+  if (!Number.isFinite(Number(g?.awayId))) defects.push('missing_away_id');
+  if (!Number.isFinite(Number(g?.homeScore)) || !Number.isFinite(Number(g?.awayScore))) defects.push('missing_final_score');
+  const classified = classifyArchiveQuality(g);
+  if (declaredQuality === QUALITY.full) {
+    if (!(hasValues(g?.teamStats?.home) && hasValues(g?.teamStats?.away))) defects.push('full_without_team_stats');
+    if (!(hasValues(g?.playerStats?.home) && hasValues(g?.playerStats?.away))) defects.push('full_without_player_stats');
+  }
+  if (declaredQuality && declaredQuality !== classified) defects.push(`quality_mismatch:${declaredQuality}->${classified}`);
+  return defects;
+}
+
+export function validateArchivedGame(rawGame) {
+  const defects = summarizeArchiveDefects(rawGame);
+  return { valid: defects.length === 0, defects };
+}
+
+export function normalizeArchivedGamePayload(rawGame) {
+  if (!rawGame || typeof rawGame !== 'object') return null;
+  const seasonId = rawGame?.seasonId ?? null;
+  const week = asNumberOrNull(rawGame?.week);
+  const homeId = toTeamId(rawGame?.homeId ?? rawGame?.home);
+  const awayId = toTeamId(rawGame?.awayId ?? rawGame?.away);
+  const id = rawGame?.id ?? rawGame?.gameId ?? buildCanonicalGameId({ seasonId, week, homeId, awayId });
+
+  const legacyStats = rawGame?.stats ?? null;
+  const playerStats = rawGame?.playerStats ?? (legacyStats ? {
+    home: legacyStats.home ?? null,
+    away: legacyStats.away ?? null,
+  } : null);
+
+  const playLog = Array.isArray(rawGame?.playLog)
+    ? rawGame.playLog
+    : Array.isArray(rawGame?.eventLog)
+      ? rawGame.eventLog
+      : Array.isArray(legacyStats?.playLogs)
+        ? legacyStats.playLogs
+        : [];
+
+  const scoringSummary = Array.isArray(rawGame?.scoringSummary)
+    ? rawGame.scoringSummary
+    : [];
+
+  const teamStats = rawGame?.teamStats ?? {
+    home: deriveTeamStatsFromPlayerRows(playerStats?.home ?? {}),
+    away: deriveTeamStatsFromPlayerRows(playerStats?.away ?? {}),
+  };
+
+  const normalized = {
+    id,
+    gameId: id,
+    seasonId,
+    week,
+    phase: rawGame?.phase ?? null,
+    homeId,
+    awayId,
+    homeScore: asNumberOrNull(rawGame?.homeScore),
+    awayScore: asNumberOrNull(rawGame?.awayScore),
+    quarterScores: normalizeQuarterScores(rawGame?.quarterScores ?? rawGame?.linescore),
+    recap: rawGame?.recap ?? null,
+    summary: rawGame?.summary ?? null,
+    teamStats,
+    playerStats,
+    scoringSummary,
+    driveSummary: Array.isArray(rawGame?.driveSummary) ? rawGame.driveSummary : (Array.isArray(rawGame?.drives) ? rawGame.drives : []),
+    turningPoints: Array.isArray(rawGame?.turningPoints) ? rawGame.turningPoints : [],
+    playLog,
+    eventLog: Array.isArray(rawGame?.eventLog) ? rawGame.eventLog : playLog,
+    notablePerformances: Array.isArray(rawGame?.notablePerformances) ? rawGame.notablePerformances : [],
+    injuries: Array.isArray(rawGame?.injuries) ? rawGame.injuries : [],
+    archiveQuality: rawGame?.archiveQuality,
+    // legacy compatibility fields
+    stats: legacyStats ?? (playerStats ? { ...playerStats, playLogs: playLog } : null),
+    drives: Array.isArray(rawGame?.drives) ? rawGame.drives : (Array.isArray(rawGame?.driveSummary) ? rawGame.driveSummary : []),
+  };
+
+  normalized.archiveQuality = classifyArchiveQuality(normalized);
+  return normalized;
+}
+
+export function recoverArchivedGameFromSchedule(gameId, leagueState) {
+  if (!gameId || !leagueState?.schedule?.weeks) return null;
+  const parsed = String(gameId).match(/(.+)_w(\d+)_(\d+)_(\d+)$/);
+  if (!parsed) return null;
+  const [, seasonId, weekValue, homeValue, awayValue] = parsed;
+  const weekNumber = Number(weekValue);
+  for (const weekRow of leagueState.schedule.weeks) {
+    if (Number(weekRow?.week) !== weekNumber) continue;
+    for (const row of weekRow?.games ?? []) {
+      const rowHome = toTeamId(row?.homeId ?? row?.home?.id ?? row?.home);
+      const rowAway = toTeamId(row?.awayId ?? row?.away?.id ?? row?.away);
+      if (rowHome !== Number(homeValue) || rowAway !== Number(awayValue)) continue;
+      if (row?.homeScore == null && row?.awayScore == null) continue;
+      return normalizeArchivedGamePayload({
+        id: gameId,
+        seasonId: row?.seasonId ?? seasonId,
+        week: row?.week ?? weekNumber,
+        homeId: rowHome,
+        awayId: rowAway,
+        homeScore: row?.homeScore,
+        awayScore: row?.awayScore,
+        quarterScores: row?.quarterScores ?? null,
+        recap: row?.recap ?? 'Legacy result restored from schedule final score.',
+        summary: row?.summary ?? null,
+        archiveQuality: 'partial',
+      });
+    }
+  }
+  return null;
+}

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -10,6 +10,7 @@ import {
   toPlayerArray,
 } from "../utils/boxScorePresentation.js";
 import { buildCompletedGamePresentation, getGameDetailPayload } from "../utils/boxScoreAccess.js";
+import { normalizeArchivedGamePayload } from "../../core/gameArchive.js";
 
 function TeamButton({ team, onSelect }) {
   if (!team) return <span>—</span>;
@@ -88,7 +89,7 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
     actions?.getBoxScore?.(gameId)
       .then((res) => {
         if (!alive) return;
-        const payload = res?.game ?? getGameDetailPayload(gameId, league);
+        const payload = normalizeArchivedGamePayload(res?.game ?? getGameDetailPayload(gameId, league));
         setGame(payload ?? null);
         if (!payload) setError(res?.error ?? "Box score unavailable for this game.");
       })
@@ -114,18 +115,18 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
   const awayTeam = teamsById[game?.awayId] ?? { id: game?.awayId, abbr: game?.awayAbbr ?? "AWAY", wins: 0, losses: 0, ties: 0 };
 
   const leaders = useMemo(() => deriveLeaders(game), [game]);
-  const scoring = useMemo(() => deriveScoringSummary(game?.stats?.playLogs ?? [], teamsById), [game, teamsById]);
-  const momentumNotes = useMemo(() => deriveMomentumNotes(game?.stats?.playLogs ?? []), [game]);
-  const quarterScores = useMemo(() => deriveQuarterScores(game, game?.stats?.playLogs ?? []), [game]);
-  const driveSummary = Array.isArray(game?.drives) ? game.drives : [];
-  const playLog = Array.isArray(game?.stats?.playLogs) ? game.stats.playLogs : [];
+  const scoring = useMemo(() => (game?.scoringSummary?.length ? game.scoringSummary : deriveScoringSummary(game?.playLog ?? game?.stats?.playLogs ?? [], teamsById)), [game, teamsById]);
+  const momentumNotes = useMemo(() => (Array.isArray(game?.turningPoints) && game.turningPoints.length ? game.turningPoints : deriveMomentumNotes(game?.playLog ?? game?.stats?.playLogs ?? [])), [game]);
+  const quarterScores = useMemo(() => deriveQuarterScores(game, game?.playLog ?? game?.stats?.playLogs ?? []), [game]);
+  const driveSummary = Array.isArray(game?.driveSummary) ? game.driveSummary : (Array.isArray(game?.drives) ? game.drives : []);
+  const playLog = Array.isArray(game?.playLog) ? game.playLog : (Array.isArray(game?.stats?.playLogs) ? game.stats.playLogs : []);
 
-  const awayPlayers = useMemo(() => toPlayerArray(game?.stats?.away, game?.awayId), [game]);
-  const homePlayers = useMemo(() => toPlayerArray(game?.stats?.home, game?.homeId), [game]);
+  const awayPlayers = useMemo(() => toPlayerArray(game?.playerStats?.away ?? game?.stats?.away, game?.awayId), [game]);
+  const homePlayers = useMemo(() => toPlayerArray(game?.playerStats?.home ?? game?.stats?.home, game?.homeId), [game]);
   const playerRows = useMemo(() => [...awayPlayers, ...homePlayers], [awayPlayers, homePlayers]);
   const teamTotals = useMemo(() => ({
-    home: deriveTeamTotals(game?.stats?.home),
-    away: deriveTeamTotals(game?.stats?.away),
+    home: game?.teamStats?.home ?? deriveTeamTotals(game?.playerStats?.home ?? game?.stats?.home),
+    away: game?.teamStats?.away ?? deriveTeamTotals(game?.playerStats?.away ?? game?.stats?.away),
   }), [game]);
 
   const topPassers = playerRows.filter((p) => (p.stats?.passAtt ?? 0) > 0).sort((a, b) => (b.stats?.passYd ?? 0) - (a.stats?.passYd ?? 0)).slice(0, 6);
@@ -138,7 +139,7 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
   const availability = buildCompletedGamePresentation(game ?? { gameId }, { source: "game_detail_screen" });
   const archiveQuality = availability.archiveQuality;
   const hasAnyPayload = Boolean(game && (
-    game.homeScore != null || game.awayScore != null || game.stats || game.recap || game.quarterScores
+    game.homeScore != null || game.awayScore != null || game.stats || game.playerStats || game.teamStats || game.recap || game.quarterScores
   ));
   const unavailableMessage = "No archived postgame data was found for this matchup.";
 
@@ -200,12 +201,12 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
             <section className="bs-section">
               <h4>Team comparison</h4>
               <div className="bs-compare-grid">
-                <StatCompareRow label="Total Yards" awayValue={teamTotals.away.totalYards} homeValue={teamTotals.home.totalYards} />
-                <StatCompareRow label="Pass Yards" awayValue={teamTotals.away.passYards} homeValue={teamTotals.home.passYards} />
-                <StatCompareRow label="Rush Yards" awayValue={teamTotals.away.rushYards} homeValue={teamTotals.home.rushYards} />
-                <StatCompareRow label="Turnovers" awayValue={teamTotals.away.turnovers} homeValue={teamTotals.home.turnovers} />
-                <StatCompareRow label="Sacks" awayValue={teamTotals.away.sacks} homeValue={teamTotals.home.sacks} />
-                <StatCompareRow label="3rd Down" awayValue={`${teamTotals.away.thirdDownMade}/${teamTotals.away.thirdDownAtt}`} homeValue={`${teamTotals.home.thirdDownMade}/${teamTotals.home.thirdDownAtt}`} />
+                <StatCompareRow label="Total Yards" awayValue={teamTotals.away.totalYards ?? "Unavailable"} homeValue={teamTotals.home.totalYards ?? "Unavailable"} />
+                <StatCompareRow label="Pass Yards" awayValue={teamTotals.away.passYards ?? "Unavailable"} homeValue={teamTotals.home.passYards ?? "Unavailable"} />
+                <StatCompareRow label="Rush Yards" awayValue={teamTotals.away.rushYards ?? "Unavailable"} homeValue={teamTotals.home.rushYards ?? "Unavailable"} />
+                <StatCompareRow label="Turnovers" awayValue={teamTotals.away.turnovers ?? "Unavailable"} homeValue={teamTotals.home.turnovers ?? "Unavailable"} />
+                <StatCompareRow label="Sacks" awayValue={teamTotals.away.sacks ?? "Unavailable"} homeValue={teamTotals.home.sacks ?? "Unavailable"} />
+                <StatCompareRow label="3rd Down" awayValue={teamTotals.away.thirdDownAtt != null ? `${teamTotals.away.thirdDownMade ?? 0}/${teamTotals.away.thirdDownAtt}` : "Unavailable"} homeValue={teamTotals.home.thirdDownAtt != null ? `${teamTotals.home.thirdDownMade ?? 0}/${teamTotals.home.thirdDownAtt}` : "Unavailable"} />
               </div>
             </section>
 

--- a/src/ui/utils/boxScoreAccess.js
+++ b/src/ui/utils/boxScoreAccess.js
@@ -1,4 +1,5 @@
 import { buildCanonicalGameId, toTeamId } from "../../core/gameIdentity.js";
+import { classifyArchiveQuality, normalizeArchivedGamePayload, recoverArchivedGameFromSchedule } from "../../core/gameArchive.js";
 
 const ARCHIVE_QUALITY_LABELS = {
   full: "Full box score",
@@ -7,12 +8,7 @@ const ARCHIVE_QUALITY_LABELS = {
 };
 
 function detectArchiveQuality(game) {
-  if (game?.archiveQuality === "full" || game?.archiveQuality === "partial" || game?.archiveQuality === "missing") {
-    return game.archiveQuality;
-  }
-  if (Array.isArray(game?.stats?.playLogs) && game.stats.playLogs.length > 0) return "full";
-  if (game?.stats || game?.summary || game?.recap || game?.drives || game?.quarterScores) return "partial";
-  return "missing";
+  return classifyArchiveQuality(game);
 }
 
 function hasFinalScore(game) {
@@ -53,7 +49,7 @@ export function resolveBoxScoreGameId(game, context = {}) {
 }
 
 export function getBoxScoreAvailability(game, context = {}) {
-  const normalized = normalizeCompletedGameRecord(game, context);
+  const normalized = normalizeArchivedGamePayload(normalizeCompletedGameRecord(game, context) ?? game);
   const resolvedGameId = resolveBoxScoreGameId(normalized, context);
   const archiveQuality = detectArchiveQuality(normalized);
   const isCompleted = hasFinalScore(normalized);
@@ -107,13 +103,15 @@ export function openResolvedBoxScore(game, context = {}, onOpen) {
 
 export function getGameDetailPayload(gameId, leagueState) {
   if (!gameId || !leagueState?.schedule?.weeks) return null;
+  const recovered = recoverArchivedGameFromSchedule(gameId, leagueState);
+  if (recovered) return recovered;
   const [seasonPart, weekPart, homePart, awayPart] = String(gameId).split("_");
   const week = Number((weekPart ?? "").replace("w", ""));
   const awayId = Number(awayPart);
   const homeId = Number(homePart);
   for (const weekRow of leagueState.schedule.weeks) {
     for (const game of weekRow?.games ?? []) {
-      const normalized = normalizeCompletedGameRecord(game, { seasonId: seasonPart, week: Number(weekRow?.week ?? week) });
+      const normalized = normalizeArchivedGamePayload(normalizeCompletedGameRecord(game, { seasonId: seasonPart, week: Number(weekRow?.week ?? week) }));
       if (inferCompletedGameIdentity(normalized, { seasonId: seasonPart, week: weekRow?.week }) === gameId) return normalized;
       if (
         Number(weekRow?.week) === week

--- a/src/ui/utils/boxScorePresentation.js
+++ b/src/ui/utils/boxScorePresentation.js
@@ -70,6 +70,21 @@ export function deriveLeaders(game) {
 
 export function deriveTeamTotals(sideStats) {
   const players = toPlayerArray(sideStats, null);
+  const hasAnyStats = players.some((p) => p?.stats && Object.keys(p.stats).length > 0);
+  if (!hasAnyStats) {
+    return {
+      passYards: null,
+      rushYards: null,
+      turnovers: null,
+      sacks: null,
+      penalties: null,
+      firstDowns: null,
+      totalYards: null,
+      thirdDownMade: null,
+      thirdDownAtt: null,
+      timePossession: null,
+    };
+  }
   return {
     passYards: sum(players.map((p) => p.stats?.passYd)),
     rushYards: sum(players.map((p) => p.stats?.rushYd)),

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -104,6 +104,7 @@ import { DEFAULT_LEAGUE_SETTINGS, normalizeLeagueSettings, getRuleEditType } fro
 import { migrateSaveMetaToCurrent, CURRENT_SAVE_SCHEMA_VERSION } from '../state/saveSchema.js';
 import { getTradeWindowSnapshot, isTradeWindowOpen } from '../core/tradeWindow.js';
 import { buildCanonicalGameId, buildArchivedGame, toTeamId } from '../core/gameIdentity.js';
+import { normalizeArchivedGamePayload, classifyArchiveQuality, validateArchivedGame, recoverArchivedGameFromSchedule } from '../core/gameArchive.js';
 
 // ── DB Reload Guard ───────────────────────────────────────────────────────────
 // Register a callback with db/index.js so that when IDB fires onblocked or
@@ -2268,9 +2269,22 @@ function applyGameResultToCache(result, week, seasonId) {
   const scoreHome = result.scoreHome ?? result.homeScore ?? 0;
   const scoreAway = result.scoreAway ?? result.awayScore ?? 0;
   const margin = Math.abs(Number(scoreHome) - Number(scoreAway));
-  const archiveQuality = Array.isArray(result.playLogs) && result.playLogs.length > 0
-    ? 'full'
-    : (result.boxScore || result.recap || result.quarterScores || result.linescore ? 'partial' : 'partial');
+  const derivedQualityInput = normalizeArchivedGamePayload({
+    seasonId,
+    week,
+    homeId: hId,
+    awayId: aId,
+    homeScore: scoreHome,
+    awayScore: scoreAway,
+    quarterScores: result.quarterScores ?? result.linescore ?? null,
+    summary: result.summary ?? null,
+    recap: result.recap ?? null,
+    playerStats: result.boxScore ? { home: result.boxScore.home ?? {}, away: result.boxScore.away ?? {} } : null,
+    playLog: Array.isArray(result.playLogs) ? result.playLogs : [],
+    driveSummary: Array.isArray(result.drives) ? result.drives : null,
+    injuries: Array.isArray(result.injuries) ? result.injuries : [],
+  });
+  const archiveQuality = classifyArchiveQuality(derivedQualityInput);
 
   const homeWin = scoreHome > scoreAway;
   const tie     = scoreHome === scoreAway;
@@ -2356,7 +2370,7 @@ function applyGameResultToCache(result, week, seasonId) {
     }
   }
 
-  const archivedGame = buildArchivedGame({
+  const archivedGame = normalizeArchivedGamePayload(buildArchivedGame({
     seasonId,
     week,
     homeId: hId,
@@ -2383,7 +2397,11 @@ function applyGameResultToCache(result, week, seasonId) {
           : 'Balanced game that swung on a few decisive drives.'),
     },
     archiveQuality,
-  });
+  }));
+  const archiveValidation = validateArchivedGame(archivedGame);
+  if (!archiveValidation.valid) {
+    console.warn('[Worker] Archived game validation defects', archivedGame?.id, archiveValidation.defects);
+  }
   cache.addGame(archivedGame);
 }
 
@@ -2949,52 +2967,7 @@ async function handleGetBoxScore({ gameId }, id) {
 
   try {
     const parsedCanonical = String(gameId).match(/(.+)_w(\d+)_(\d+)_(\d+)$/);
-    const buildScheduleFallback = () => {
-      if (!parsedCanonical) return null;
-      const [, seasonKey, weekValue, homeValue, awayValue] = parsedCanonical;
-      const weekNum = Number(weekValue);
-      const seasonVariants = new Set([String(seasonKey), Number(seasonKey)]);
-      const scheduleWeeks = cache.getMeta()?.schedule?.weeks ?? [];
-      for (const weekRow of scheduleWeeks) {
-        const rowWeek = Number(weekRow?.week);
-        if (Number.isFinite(weekNum) && Number.isFinite(rowWeek) && rowWeek !== weekNum) continue;
-        for (const row of weekRow?.games ?? []) {
-          const rowHome = Number(row?.home?.id ?? row?.home ?? row?.homeId);
-          const rowAway = Number(row?.away?.id ?? row?.away ?? row?.awayId);
-          if (
-            !((rowHome === Number(homeValue) && rowAway === Number(awayValue))
-            || (rowHome === Number(awayValue) && rowAway === Number(homeValue)))
-          ) continue;
-          const rowSeason = row?.seasonId ?? cache.getMeta()?.currentSeasonId ?? seasonKey;
-          if (rowSeason != null && seasonVariants.size > 0 && !seasonVariants.has(rowSeason) && !seasonVariants.has(String(rowSeason))) continue;
-          const homeScore = Number(row?.homeScore ?? 0);
-          const awayScore = Number(row?.awayScore ?? 0);
-          const hasFinal = row?.played || row?.homeScore != null || row?.awayScore != null;
-          if (!hasFinal) continue;
-          return {
-            id: gameId,
-            seasonId: rowSeason,
-            week: rowWeek || weekNum,
-            homeId: rowHome,
-            awayId: rowAway,
-            homeScore,
-            awayScore,
-            quarterScores: row?.quarterScores ?? null,
-            recap: row?.recap ?? 'Legacy result restored from schedule final score. Detailed drive/play logs were not archived for this game.',
-            summary: {
-              winnerId: homeScore >= awayScore ? rowHome : rowAway,
-              margin: Math.abs(homeScore - awayScore),
-              storyline: 'Partial archive restored from schedule data. Final score and matchup metadata are available.',
-              leaders: row?.summary?.leaders ?? null,
-            },
-            stats: row?.stats ?? null,
-            drives: row?.drives ?? null,
-            archiveQuality: 'partial',
-          };
-        }
-      }
-      return null;
-    };
+    const buildScheduleFallback = () => recoverArchivedGameFromSchedule(gameId, cache.getMeta());
 
     // Look for the game in the current week's hot cache first
     const hotGame = cache.getWeekGames().find(g => g.id === gameId || g.gameId === gameId);
@@ -3028,6 +3001,8 @@ async function handleGetBoxScore({ gameId }, id) {
 
     if (!game) game = buildScheduleFallback();
 
+    game = normalizeArchivedGamePayload(game);
+
     if (!game) {
       post(toUI.BOX_SCORE, { gameId, game: null, error: 'Game not found' }, id);
       return;
@@ -3051,6 +3026,14 @@ async function handleGetBoxScore({ gameId }, id) {
         awayName:  awayTeam?.name ?? '?',
         awayAbbr:  awayTeam?.abbr ?? '???',
         stats:     game.stats ?? null,
+        teamStats: game.teamStats ?? null,
+        playerStats: game.playerStats ?? null,
+        scoringSummary: game.scoringSummary ?? [],
+        driveSummary: game.driveSummary ?? [],
+        turningPoints: game.turningPoints ?? [],
+        playLog: game.playLog ?? [],
+        notablePerformances: game.notablePerformances ?? [],
+        injuries: game.injuries ?? [],
         recap:     game.recap ?? null,
         summary: game.summary ?? {
           winnerId: (Number(game?.homeScore ?? 0) >= Number(game?.awayScore ?? 0)) ? game.homeId : game.awayId,
@@ -3059,7 +3042,7 @@ async function handleGetBoxScore({ gameId }, id) {
         },
         quarterScores: game.quarterScores ?? null,
         drives: game.drives ?? null,
-        archiveQuality: game.archiveQuality ?? (game?.stats?.playLogs?.length ? 'full' : (game?.stats || game?.summary || game?.recap ? 'partial' : 'missing')),
+        archiveQuality: classifyArchiveQuality(game),
       },
     }, id);
   } catch (err) {

--- a/tests/unit/box_score_presentation.test.js
+++ b/tests/unit/box_score_presentation.test.js
@@ -33,7 +33,7 @@ describe("box score presentation helpers", () => {
 
   it("handles partial/missing stat data safely", () => {
     expect(toPlayerArray(null, 1)).toEqual([]);
-    expect(deriveTeamTotals(undefined).totalYards).toBe(0);
+    expect(deriveTeamTotals(undefined).totalYards).toBeNull();
   });
 
   it("builds scoring and quarter views from logs when quarter arrays are missing", () => {


### PR DESCRIPTION
### Motivation
- Box score data and archive quality were inconsistent because multiple layers reconstructed archives differently, leading to zero-filled or contradictory UI states. 
- The sim/worker/UI paths needed a single canonical archived-game shape and an authoritative archive-quality classifier to stop fabricating detail and to surface honest availability. 
- The goal was to ensure completed games produce, persist, retrieve, and render truthful postgame payloads without changing click-path UX.

### Description
- Added a new canonical archive module `src/core/gameArchive.js` that normalizes legacy/current payloads, derives team totals from player rows (without fabricating zeros), classifies archive quality (`full|partial|missing`), validates archives, and recovers honest partial archives from schedule rows. 
- Updated the worker archiving flow to build normalized archives via `normalizeArchivedGamePayload(...)`, to compute quality via `classifyArchiveQuality(...)`, to run `validateArchivedGame(...)`, and to persist the normalized record (worker changes in `src/worker/worker.js`). 
- Repaired retrieval/fallback: `GET_BOX_SCORE` now normalizes loaded DB/hot-cache/fallback rows and returns canonical sections (`teamStats`, `playerStats`, `scoringSummary`, `driveSummary`, `turningPoints`, `playLog`, etc.) with a single authoritative quality. 
- UI changes: `src/ui/utils/boxScoreAccess.js` now delegates to the canonical normalizer/classifier and schedule recovery; `src/ui/components/BoxScore.jsx` consumes normalized fields (via `normalizeArchivedGamePayload`) and avoids rendering missing stats as zeros by showing `Unavailable` where appropriate; `src/ui/utils/boxScorePresentation.js` updated `deriveTeamTotals` to return `null` when no true stats exist. 
- Tests: added `src/core/__tests__/gameArchive.test.js` and updated existing tests to assert missing-vs-zero semantics and canonical behavior; small test adjustments for legacy expectations and presentation helpers.

### Testing
- Ran unit tests with `npm run test:unit -- src/core/__tests__/gameIdentity.test.js src/core/__tests__/gameArchive.test.js tests/unit/box_score_presentation.test.js src/ui/utils/boxScoreAccess.test.js`. 
- All exercised unit tests passed after the changes (14 tests across the updated files passed).
- Archive validation logging is emitted in development when `validateArchivedGame(...)` finds defects (no runtime test failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d879805990832da73c7ba668c7f965)