### PR TITLE
Live Gameday Viewer and Watch Mode Foundation

### DIFF
--- a/src/core/liveGame/liveGameEvents.js
+++ b/src/core/liveGame/liveGameEvents.js
@@ -1,0 +1,102 @@
+const EVENT_TYPE_TO_TAG = {
+  kickoff: 'routine',
+  first_down: 'key_play',
+  explosive_play: 'key_play',
+  touchdown: 'score',
+  field_goal: 'score',
+  turnover: 'turnover',
+  sack: 'key_play',
+  red_zone_entry: 'red_zone',
+  failed_conversion: 'key_play',
+  injury: 'key_play',
+  quarter_end: 'routine',
+  halftime: 'swing',
+  game_end: 'swing',
+  turning_point: 'swing',
+};
+
+function normalizeEventType(log = {}) {
+  const text = String(log.text || log.playText || '').toLowerCase();
+  if (log.type === 'touchdown' || text.includes('touchdown')) return 'touchdown';
+  if (log.type === 'field_goal' || text.includes('field goal')) return 'field_goal';
+  if (log.type === 'interception' || log.type === 'fumble' || text.includes('interception') || text.includes('fumble')) return 'turnover';
+  if (log.type === 'sack' || text.includes('sack')) return 'sack';
+  if (text.includes('first down')) return 'first_down';
+  if (text.includes('injur')) return 'injury';
+  if ((log.yards || 0) >= 20) return 'explosive_play';
+  if ((log.fieldPosition || log.yardLine || 50) >= 80) return 'red_zone_entry';
+  return 'routine';
+}
+
+export function buildLiveGameEvent(log = {}, index = 0, context = {}) {
+  const eventType = normalizeEventType(log);
+  const home = Number(log.homeScore ?? log.scoreHome ?? 0);
+  const away = Number(log.awayScore ?? log.scoreAway ?? 0);
+  return {
+    id: `${context.gameId || 'game'}-${index}`,
+    gameId: context.gameId || 'game',
+    quarter: Number(log.quarter || 1),
+    clock: log.clock || log.timeLeft || '15:00',
+    offenseTeamId: log.possession === 'home' ? context.homeTeamId : context.awayTeamId,
+    defenseTeamId: log.possession === 'home' ? context.awayTeamId : context.homeTeamId,
+    eventType,
+    headline: String(log.text || log.playText || 'Drive develops').trim(),
+    detail: log.description || undefined,
+    score: { home, away },
+    possessionTeamId: log.possession === 'home' ? context.homeTeamId : context.awayTeamId,
+    fieldPosition: log.fieldPosition ?? log.yardLine,
+    down: log.down,
+    distance: log.distance,
+    raw: log,
+    impactTag: EVENT_TYPE_TO_TAG[eventType] || 'routine',
+  };
+}
+
+export function mapArchiveEventsToLiveFeed(playLogs = [], context = {}) {
+  const base = Array.isArray(playLogs) ? playLogs : [];
+  const events = base.map((log, index) => buildLiveGameEvent(log, index, context));
+  if (!events.length) return [];
+
+  const withMarkers = [];
+  for (let i = 0; i < events.length; i += 1) {
+    const event = events[i];
+    withMarkers.push(event);
+    const next = events[i + 1];
+    if (next && next.quarter !== event.quarter) {
+      withMarkers.push({
+        ...event,
+        id: `${event.id}-q-end`,
+        eventType: event.quarter === 2 ? 'halftime' : 'quarter_end',
+        headline: event.quarter === 2 ? 'Halftime adjustments on deck.' : `End of Q${event.quarter}`,
+        impactTag: event.quarter === 2 ? 'swing' : 'routine',
+      });
+    }
+  }
+
+  const last = withMarkers[withMarkers.length - 1];
+  withMarkers.push({
+    ...last,
+    id: `${last.id}-final`,
+    eventType: 'game_end',
+    headline: 'Final whistle. Game Book is ready.',
+    impactTag: 'swing',
+  });
+
+  return withMarkers;
+}
+
+export function getNextImportantEvent(events = [], startIndex = 0, filter = 'score') {
+  const important = {
+    score: (event) => event.eventType === 'touchdown' || event.eventType === 'field_goal',
+    redZone: (event) => event.eventType === 'red_zone_entry',
+    turnover: (event) => event.eventType === 'turnover',
+    keyPlay: (event) => ['turnover', 'touchdown', 'field_goal', 'sack', 'explosive_play', 'turning_point'].includes(event.eventType),
+    finalMinutes: (event) => event.quarter >= 4 && /^([0-4]):/.test(String(event.clock || '')),
+    end: (event) => event.eventType === 'game_end',
+  };
+  const matcher = important[filter] || important.keyPlay;
+  for (let i = Math.max(0, startIndex + 1); i < events.length; i += 1) {
+    if (matcher(events[i])) return i;
+  }
+  return events.length - 1;
+}

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -40,7 +40,7 @@ import React, { useEffect, useCallback, useRef, useState, Component, useMemo } f
 import { useWorker }       from './hooks/useWorker.js';
 import LeagueDashboard     from './components/LeagueDashboard.jsx';
 import LiveGame            from './components/LiveGame.jsx';
-import GameSimulation      from './components/GameSimulation.jsx';
+import LiveGameViewer      from './components/LiveGameViewer.jsx';
 import PostGameScreen      from './components/PostGameScreen.jsx';
 import SaveSlotManager     from './components/SaveSlotManager.jsx';
 import NewLeagueSetup      from './components/NewLeagueSetup.jsx';
@@ -118,6 +118,7 @@ function AppContent() {
   const [activeView, setActiveView] = useState('saves');
   const [activeSlot, setActiveSlot] = useState(null);
   const [pendingNewSlot, setPendingNewSlot] = useState(null);
+  const [watchMode, setWatchMode] = useState('watch');
   const [externalBoxScoreId, setExternalBoxScoreId] = useState(null);
   const [showChangelog, setShowChangelog] = useState(false);
   const { soundEnabled, toggleSound } = useSettings();
@@ -868,7 +869,10 @@ function AppContent() {
               <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
                 <button
                   className="btn btn-primary"
-                  onClick={() => actions.watchGame()}
+                  onClick={() => {
+                    setWatchMode('watch');
+                    actions.watchGame();
+                  }}
                   disabled={busy}
                   style={{
                     width: '100%', minHeight: 52,
@@ -878,6 +882,38 @@ function AppContent() {
                   }}
                 >
                   {busy ? 'Loading...' : '🏈 Watch Game'}
+                </button>
+                <button
+                  className="btn"
+                  onClick={() => {
+                    setWatchMode('fast');
+                    actions.watchGame();
+                  }}
+                  disabled={busy}
+                  style={{
+                    width: '100%', minHeight: 48,
+                    fontSize: 'var(--text-sm)', fontWeight: 700,
+                    cursor: 'pointer',
+                    borderRadius: 'var(--radius-md)',
+                  }}
+                >
+                  ⚡ Fast Watch
+                </button>
+                <button
+                  className="btn"
+                  onClick={() => {
+                    setWatchMode('instant');
+                    actions.watchGame();
+                  }}
+                  disabled={busy}
+                  style={{
+                    width: '100%', minHeight: 48,
+                    fontSize: 'var(--text-sm)', fontWeight: 700,
+                    cursor: 'pointer',
+                    borderRadius: 'var(--radius-md)',
+                  }}
+                >
+                  ⏭️ Sim to End
                 </button>
                 <button
                   className="btn"
@@ -901,7 +937,7 @@ function AppContent() {
         );
       })()}
 
-      {/* ── Live Game Viewer (premium GameSimulation) ── */}
+      {/* ── Live Game Viewer (watch mode foundation) ── */}
       {userGameLogs && (() => {
         // Determine actual home/away from the latest game event for the user's team
         const userEvent = gameEvents?.find(e => e.homeId === league?.userTeamId || e.awayId === league?.userTeamId);
@@ -917,11 +953,11 @@ function AppContent() {
             actions.clearUserGame();
             setTimeout(() => actions.advanceWeek({ skipUserGame: true }), 200);
           }}>
-            <GameSimulation
+            <LiveGameViewer
               logs={userGameLogs}
               homeTeam={homeTeam}
               awayTeam={awayTeam}
-              userTeamId={league?.userTeamId}
+              initialMode={watchMode}
               onComplete={(scores) => {
                 try {
                   // Belt-and-suspenders save immediately on game completion
@@ -937,9 +973,11 @@ function AppContent() {
                     phase: league?.phase,
                     logs: userGameLogs || [],
                   });
+                  setWatchMode('watch');
                   actions.clearUserGame();
                 } catch (err) {
                   console.error('[App] onComplete failed:', err);
+                  setWatchMode('watch');
                   actions.clearUserGame();
                 }
               }}

--- a/src/ui/components/GameEventFeed/GameEventFeed.jsx
+++ b/src/ui/components/GameEventFeed/GameEventFeed.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { getEventTags } from '../../utils/liveGamePresentation.js';
+
+export default function GameEventFeed({ events = [], activeIndex = 0 }) {
+  const visible = events.slice(Math.max(0, activeIndex - 20), activeIndex + 1);
+  return (
+    <div className="live-feed">
+      {visible.map((event, idx) => {
+        const tags = getEventTags(event);
+        return (
+          <article key={event.id || idx} className={`feed-row ${idx === visible.length - 1 ? 'latest' : ''}`}>
+            <div className="feed-time">Q{event.quarter} {event.clock}</div>
+            <div className="feed-body">
+              <div className="feed-headline">{event.headline}</div>
+              <div className="feed-meta">
+                <span>{event.score ? `${event.score.away}-${event.score.home}` : ''}</span>
+                {tags.map((tag) => <span key={tag} className="feed-tag">{tag}</span>)}
+              </div>
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/ui/components/LiveGameViewer.jsx
+++ b/src/ui/components/LiveGameViewer.jsx
@@ -1,440 +1,143 @@
-/**
- * LiveGameViewer.jsx — Full-screen play-by-play game viewer
- *
- * Renders as a fixed overlay so it properly blocks underlying UI.
- * Handles empty logs, auto-advance with configurable speed, and
- * bulletproof touch handling for mobile.
- */
+import React, { useMemo, useState, useEffect } from 'react';
+import Scorebug from './Scorebug/Scorebug.jsx';
+import GameEventFeed from './GameEventFeed/GameEventFeed.jsx';
+import { mapArchiveEventsToLiveFeed, getNextImportantEvent } from '../../core/liveGame/liveGameEvents.js';
+import { getCurrentStandoutPlayers, summarizeGameSwing } from '../utils/liveGamePresentation.js';
 
-import React, { useState, useEffect, useRef, useCallback } from "react";
-
-function teamColor(abbr = "") {
-  const palette = [
-    "#0A84FF", "#34C759", "#FF9F0A", "#FF453A", "#5E5CE6",
-    "#64D2FF", "#FFD60A", "#30D158", "#FF6961", "#AEC6CF",
-    "#FF6B35", "#B4A0E5",
-  ];
-  let hash = 0;
-  for (let i = 0; i < abbr.length; i++) hash = abbr.charCodeAt(i) + ((hash << 5) - hash);
-  return palette[Math.abs(hash) % palette.length];
-}
-
-const SPEEDS = [
-  { label: "Slow", ms: 2500 },
-  { label: "Normal", ms: 1200 },
-  { label: "Fast", ms: 400 },
-  { label: "Instant", ms: 0 },
+const SPEED_STEPS = [
+  { key: 'slow', label: 'Slow', ms: 1400 },
+  { key: 'normal', label: 'Normal', ms: 850 },
+  { key: 'fast', label: 'Fast', ms: 350 },
+  { key: 'veryFast', label: 'Very Fast', ms: 140 },
 ];
 
-export default function LiveGameViewer({ logs, homeTeam, awayTeam, onComplete }) {
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [speedIdx, setSpeedIdx] = useState(1); // Normal
-  const [finished, setFinished] = useState(false);
-  const [paused, setPaused] = useState(false);
-  const logContainerRef = useRef(null);
-  const completedRef = useRef(false);
+export default function LiveGameViewer({ logs = [], homeTeam, awayTeam, onComplete, initialMode = 'watch' }) {
+  const events = useMemo(() => mapArchiveEventsToLiveFeed(logs, {
+    gameId: `${homeTeam?.id || 'h'}-${awayTeam?.id || 'a'}`,
+    homeTeamId: homeTeam?.id,
+    awayTeamId: awayTeam?.id,
+  }), [logs, homeTeam?.id, awayTeam?.id]);
 
-  const speed = SPEEDS[speedIdx].ms;
-  const safeLogs = Array.isArray(logs) && logs.length > 0 ? logs : null;
+  const [index, setIndex] = useState(0);
+  const [paused, setPaused] = useState(initialMode === 'pause');
+  const [speed, setSpeed] = useState(initialMode === 'fast' ? 'fast' : 'normal');
 
-  // Handle empty logs — auto-complete after short delay
   useEffect(() => {
-    if (!safeLogs && !completedRef.current) {
-      completedRef.current = true;
-      const timer = setTimeout(() => {
-        if (onComplete) onComplete();
-      }, 1500);
-      return () => clearTimeout(timer);
+    if (initialMode === 'instant') {
+      setIndex(Math.max(0, events.length - 1));
+      setPaused(true);
+    } else if (initialMode === 'fast') {
+      setSpeed('veryFast');
+      setPaused(false);
     }
-  }, [safeLogs, onComplete]);
+  }, [initialMode, events.length]);
 
-  // Auto-advance play index
   useEffect(() => {
-    if (!safeLogs || finished || paused) return;
+    if (paused || index >= events.length - 1) return;
+    const delay = SPEED_STEPS.find((step) => step.key === speed)?.ms ?? 850;
+    const timer = setTimeout(() => setIndex((prev) => Math.min(events.length - 1, prev + 1)), delay);
+    return () => clearTimeout(timer);
+  }, [paused, speed, index, events.length]);
 
-    if (speed === 0) {
-      // Instant — jump to end
-      setCurrentIndex(safeLogs.length - 1);
-      setFinished(true);
-      return;
-    }
+  const currentEvent = events[index] || {};
+  const standout = useMemo(() => getCurrentStandoutPlayers(events, index + 1), [events, index]);
+  const swing = useMemo(() => summarizeGameSwing(events, index + 1), [events, index]);
 
-    if (currentIndex >= safeLogs.length - 1) {
-      setFinished(true);
-      return;
-    }
+  const scoreState = {
+    score: currentEvent.score || { home: 0, away: 0 },
+    quarter: currentEvent.quarter || 1,
+    clock: currentEvent.clock || '15:00',
+    downDistance: currentEvent.down ? `${currentEvent.down}${ordinal(currentEvent.down)} & ${currentEvent.distance || 10}` : 'Drive update',
+    ballSpot: currentEvent.fieldPosition != null ? `Ball on ${Math.round(Number(currentEvent.fieldPosition) || 50)}` : 'Ball spot --',
+    possessionTeamId: currentEvent.possessionTeamId,
+  };
 
-    const timer = setInterval(() => {
-      setCurrentIndex((prev) => {
-        const next = prev + 1;
-        if (next >= safeLogs.length - 1) {
-          setFinished(true);
-        }
-        return Math.min(next, safeLogs.length - 1);
-      });
-    }, speed);
-
-    return () => clearInterval(timer);
-  }, [currentIndex, safeLogs, speed, finished, paused]);
-
-  // Auto-scroll play log
-  useEffect(() => {
-    if (logContainerRef.current) {
-      logContainerRef.current.scrollTop = logContainerRef.current.scrollHeight;
-    }
-  }, [currentIndex]);
-
-  // Handle game completion
-  const handleComplete = useCallback(() => {
-    if (completedRef.current) return;
-    completedRef.current = true;
-    if (onComplete) onComplete();
-  }, [onComplete]);
-
-  // Auto-proceed after game ends
-  useEffect(() => {
-    if (finished && !completedRef.current) {
-      const timer = setTimeout(handleComplete, 2500);
-      return () => clearTimeout(timer);
-    }
-  }, [finished, handleComplete]);
-
-  if (!safeLogs) {
-    return (
-      <div className="lgv-overlay">
-        <div className="lgv-empty-state">
-          <div className="lgv-empty-icon">🏈</div>
-          <p>No play-by-play data available for this game.</p>
-          <button className="lgv-btn lgv-btn-primary" onClick={handleComplete}>
-            Continue
-          </button>
-        </div>
-        <style>{lgvStyles}</style>
-      </div>
-    );
-  }
-
-  const currentLog = safeLogs[currentIndex] || safeLogs[0];
-  const visibleLogs = safeLogs.slice(0, currentIndex + 1).slice(-25);
-
-  const homeColor = teamColor(homeTeam?.abbr);
-  const awayColor = teamColor(awayTeam?.abbr);
-  const isHomePoss = currentLog.possession === 'home';
-
-  const progress = safeLogs.length > 1
-    ? Math.round((currentIndex / (safeLogs.length - 1)) * 100)
-    : 100;
+  const finished = index >= events.length - 1;
 
   return (
-    <div className="lgv-overlay">
-      <style>{lgvStyles}</style>
+    <div className="watch-overlay">
+      <style>{styles}</style>
+      <header className="watch-header">
+        <Scorebug homeTeam={homeTeam} awayTeam={awayTeam} state={scoreState} />
+      </header>
 
-      <div className="lgv-game-container">
-        {/* Scorebug */}
-        <div className="lgv-scorebug">
-          <div className={`lgv-team-block ${!isHomePoss ? 'lgv-has-poss' : ''}`}>
-            <div className="lgv-team-name" style={{ color: awayColor }}>
-              {awayTeam?.abbr || 'AWAY'}
-            </div>
-            <div className="lgv-team-score">{currentLog.scoreAway || 0}</div>
+      <main className="watch-main">
+        <section className="watch-panel">
+          <div className={`momentum ${swing.tone}`}>Momentum: {swing.label}</div>
+          <div className="jump-row">
+            <JumpBtn label="Scoring Plays" onClick={() => setIndex(getNextImportantEvent(events, index, 'score'))} />
+            <JumpBtn label="Red Zone" onClick={() => setIndex(getNextImportantEvent(events, index, 'redZone'))} />
+            <JumpBtn label="Turnovers" onClick={() => setIndex(getNextImportantEvent(events, index, 'turnover'))} />
+            <JumpBtn label="Final Minutes" onClick={() => setIndex(getNextImportantEvent(events, index, 'finalMinutes'))} />
+            <JumpBtn label="End" onClick={() => setIndex(events.length - 1)} />
           </div>
+          <GameEventFeed events={events} activeIndex={index} />
+        </section>
 
-          <div className="lgv-game-info">
-            <div className="lgv-quarter">Q{currentLog.quarter || 1}</div>
-            <div className="lgv-clock">{currentLog.clock || '15:00'}</div>
-            <div className="lgv-down-dist">
-              {currentLog.down || 1}{ordinalSuffix(currentLog.down || 1)} & {currentLog.distance || 10}
-            </div>
-          </div>
-
-          <div className={`lgv-team-block ${isHomePoss ? 'lgv-has-poss' : ''}`}>
-            <div className="lgv-team-name" style={{ color: homeColor }}>
-              {homeTeam?.abbr || 'HOME'}
-            </div>
-            <div className="lgv-team-score">{currentLog.scoreHome || 0}</div>
-          </div>
-        </div>
-
-        {/* Field */}
-        <div className="lgv-field-wrap">
-          <div className="lgv-field">
-            {Array.from({ length: 9 }).map((_, i) => (
-              <div key={i} className="lgv-yard-line" style={{ left: `${(i + 1) * 10}%` }}>
-                <span className="lgv-yard-num">{i < 5 ? (i + 1) * 10 : (9 - i) * 10}</span>
-              </div>
+        <aside className="watch-side">
+          <h3>Standouts</h3>
+          <ul>
+            <li>QB: {formatQb(standout.qb)}</li>
+            <li>Rush: {formatRush(standout.rusher)}</li>
+            <li>Rec: {formatRec(standout.receiver)}</li>
+            <li>Sacks: {standout.sacks ? `${standout.sacks.player} (${standout.sacks.sacks})` : '—'}</li>
+            <li>INT: {standout.picks ? `${standout.picks.player} (${standout.picks.picks})` : '—'}</li>
+          </ul>
+          <div className="controls">
+            <button onClick={() => setPaused((prev) => !prev)}>{paused ? 'Resume' : 'Pause'}</button>
+            {SPEED_STEPS.map((step) => (
+              <button key={step.key} className={speed === step.key ? 'active' : ''} onClick={() => { setSpeed(step.key); setPaused(false); }}>{step.label}</button>
             ))}
-            <div
-              className="lgv-los"
-              style={{ left: `${Math.max(2, Math.min(98, currentLog.yardLine || 50))}%` }}
-            />
-            <div
-              className="lgv-first-down-marker"
-              style={{ left: `${Math.max(2, Math.min(98, (currentLog.yardLine || 50) + (currentLog.distance || 10)))}%` }}
-            />
+            <button onClick={() => setIndex(getNextImportantEvent(events, index, 'score'))}>Skip to Next Score</button>
+            <button onClick={() => setIndex(getNextImportantEvent(events, index, 'keyPlay'))}>Skip to Key Play</button>
+            <button onClick={() => setIndex(events.length - 1)}>Sim to End</button>
           </div>
-          {/* Progress bar */}
-          <div className="lgv-progress-bar">
-            <div className="lgv-progress-fill" style={{ width: `${progress}%` }} />
-          </div>
-        </div>
-
-        {/* Play-by-play */}
-        <div ref={logContainerRef} className="lgv-plays">
-          {visibleLogs.map((log, idx) => (
-            <div
-              key={idx}
-              className={`lgv-play ${idx === visibleLogs.length - 1 ? 'lgv-play-latest' : ''}`}
-              style={{
-                borderLeftColor: log.possession === 'home' ? homeColor : awayColor,
-              }}
-            >
-              <span className="lgv-play-info">
-                Q{log.quarter || 1} {log.clock || ''} &middot; {log.down || 1}&{log.distance || 10}
-              </span>
-              <span className="lgv-play-text">{log.playText}</span>
-            </div>
-          ))}
-        </div>
-
-        {/* Controls */}
-        <div className="lgv-controls">
-          <div className="lgv-speed-btns">
-            {!finished && (
-              <button
-                className={`lgv-btn ${paused ? 'lgv-btn-primary' : ''}`}
-                onClick={() => setPaused(!paused)}
-              >
-                {paused ? '▶ Play' : '⏸ Pause'}
-              </button>
-            )}
-            {SPEEDS.map((s, i) => (
-              <button
-                key={s.label}
-                className={`lgv-btn ${speedIdx === i && !finished ? 'lgv-btn-active' : ''}`}
-                onClick={() => {
-                  setSpeedIdx(i);
-                  setPaused(false);
-                  if (s.ms === 0) {
-                    setCurrentIndex(safeLogs.length - 1);
-                    setFinished(true);
-                  }
-                }}
-              >
-                {s.label}
-              </button>
-            ))}
-          </div>
-          {finished && (
-            <button className="lgv-btn lgv-btn-primary lgv-btn-continue" onClick={handleComplete}>
-              Continue &rarr;
-            </button>
-          )}
-        </div>
-      </div>
+          {finished ? <button className="finish" onClick={() => onComplete?.({ homeScore: scoreState.score.home, awayScore: scoreState.score.away })}>Open Final Game Book</button> : null}
+        </aside>
+      </main>
     </div>
   );
 }
 
-function ordinalSuffix(n) {
-  const s = ['th', 'st', 'nd', 'rd'];
-  const v = n % 100;
-  return (s[(v - 20) % 10] || s[v] || s[0]);
+function JumpBtn({ label, onClick }) {
+  return <button className="jump-btn" onClick={onClick}>{label}</button>;
 }
 
-const lgvStyles = `
-  .lgv-overlay {
-    position: fixed; inset: 0;
-    z-index: 5000;
-    background: var(--bg, #0a0c10);
-    display: flex; flex-direction: column;
-    align-items: center; justify-content: center;
-    padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
-    pointer-events: auto;
-    touch-action: manipulation;
-  }
+function ordinal(n) {
+  if (n === 1) return 'st';
+  if (n === 2) return 'nd';
+  if (n === 3) return 'rd';
+  return 'th';
+}
 
-  .lgv-game-container {
-    width: 100%; max-width: 600px;
-    display: flex; flex-direction: column;
-    height: 100%; max-height: 100dvh;
-    padding: var(--space-3);
-    gap: var(--space-3);
-  }
+function formatQb(v) { return v ? `${v.player} ${v.comp}/${v.att} ${v.yds}y ${v.td}TD` : '—'; }
+function formatRush(v) { return v ? `${v.player} ${v.yds}y (${v.att} att)` : '—'; }
+function formatRec(v) { return v ? `${v.player} ${v.rec} rec, ${v.yds}y` : '—'; }
 
-  /* Scorebug */
-  .lgv-scorebug {
-    display: flex; align-items: center; justify-content: space-between;
-    background: var(--surface);
-    border: 1px solid var(--hairline);
-    border-radius: var(--radius-lg);
-    padding: var(--space-3) var(--space-4);
-    flex-shrink: 0;
-  }
-  .lgv-team-block {
-    display: flex; flex-direction: column; align-items: center;
-    gap: 2px; min-width: 60px;
-    position: relative;
-  }
-  .lgv-team-block.lgv-has-poss::after {
-    content: ''; position: absolute; bottom: -6px; left: 50%;
-    transform: translateX(-50%);
-    width: 6px; height: 6px; border-radius: 50%;
-    background: var(--accent);
-  }
-  .lgv-team-name {
-    font-size: var(--text-sm); font-weight: 800;
-    letter-spacing: 1px; text-transform: uppercase;
-  }
-  .lgv-team-score {
-    font-size: var(--text-3xl); font-weight: 900;
-    color: var(--text); line-height: 1;
-  }
-  .lgv-game-info {
-    text-align: center; flex: 1;
-  }
-  .lgv-quarter {
-    font-size: var(--text-xs); font-weight: 700;
-    color: var(--accent); text-transform: uppercase;
-    letter-spacing: 1px;
-  }
-  .lgv-clock {
-    font-size: var(--text-xl); font-weight: 800;
-    color: var(--text); font-variant-numeric: tabular-nums;
-  }
-  .lgv-down-dist {
-    font-size: var(--text-xs); color: var(--text-muted); font-weight: 600;
-  }
-
-  /* Field */
-  .lgv-field-wrap { flex-shrink: 0; }
-  .lgv-field {
-    height: 40px; border-radius: var(--radius-md);
-    background: linear-gradient(90deg, #1a472a, #2d7a4a 50%, #1a472a);
-    position: relative; overflow: hidden;
-    border: 2px solid rgba(255,255,255,0.1);
-  }
-  .lgv-yard-line {
-    position: absolute; top: 0; bottom: 0; width: 1px;
-    background: rgba(255,255,255,0.15);
-  }
-  .lgv-yard-num {
-    position: absolute; top: 2px; left: 50%;
-    transform: translateX(-50%);
-    font-size: 8px; color: rgba(255,255,255,0.35);
-    font-weight: 700;
-  }
-  .lgv-los {
-    position: absolute; top: 0; bottom: 0; width: 3px;
-    background: var(--accent);
-    box-shadow: 0 0 8px rgba(10,132,255,0.5);
-    transition: left 300ms ease;
-  }
-  .lgv-first-down-marker {
-    position: absolute; top: 0; bottom: 0; width: 2px;
-    background: var(--warning);
-    opacity: 0.7;
-    transition: left 300ms ease;
-  }
-  .lgv-progress-bar {
-    height: 3px; background: var(--hairline);
-    border-radius: 2px; margin-top: var(--space-1);
-    overflow: hidden;
-  }
-  .lgv-progress-fill {
-    height: 100%; background: var(--accent);
-    border-radius: 2px;
-    transition: width 300ms ease;
-  }
-
-  /* Plays */
-  .lgv-plays {
-    flex: 1; overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
-    display: flex; flex-direction: column;
-    gap: var(--space-1);
-    padding: var(--space-1) 0;
-    min-height: 0;
-  }
-  .lgv-play {
-    padding: var(--space-2) var(--space-3);
-    border-left: 3px solid var(--hairline);
-    background: var(--surface);
-    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
-    font-size: var(--text-sm);
-    display: flex; flex-direction: column; gap: 2px;
-    opacity: 0.7;
-  }
-  .lgv-play.lgv-play-latest {
-    opacity: 1;
-    background: var(--surface-strong);
-    animation: lgvFadeIn 0.25s ease-out;
-  }
-  .lgv-play-info {
-    font-size: 10px; color: var(--text-subtle);
-    font-weight: 600; font-variant-numeric: tabular-nums;
-  }
-  .lgv-play-text {
-    color: var(--text); font-weight: 500;
-  }
-
-  /* Controls */
-  .lgv-controls {
-    flex-shrink: 0;
-    display: flex; flex-direction: column; gap: var(--space-2);
-    padding-top: var(--space-2);
-    border-top: 1px solid var(--hairline);
-  }
-  .lgv-speed-btns {
-    display: flex; gap: var(--space-2);
-    flex-wrap: wrap; justify-content: center;
-  }
-  .lgv-btn {
-    padding: var(--space-2) var(--space-3);
-    border: 1px solid var(--hairline);
-    background: var(--surface);
-    color: var(--text-muted);
-    border-radius: var(--radius-md);
-    font-size: var(--text-xs); font-weight: 700;
-    cursor: pointer;
-    min-height: 40px; min-width: 40px;
-    touch-action: manipulation;
-    -webkit-tap-highlight-color: transparent;
-    transition: all 150ms ease;
-  }
-  .lgv-btn:hover { background: var(--surface-strong); color: var(--text); }
-  .lgv-btn.lgv-btn-active {
-    background: var(--accent); color: #fff;
-    border-color: var(--accent);
-  }
-  .lgv-btn.lgv-btn-primary {
-    background: var(--accent); color: #fff;
-    border-color: var(--accent);
-  }
-  .lgv-btn.lgv-btn-primary:hover {
-    background: var(--accent-hover);
-  }
-  .lgv-btn-continue {
-    width: 100%; min-height: 48px;
-    font-size: var(--text-base); font-weight: 800;
-  }
-
-  /* Empty state */
-  .lgv-empty-state {
-    text-align: center;
-    display: flex; flex-direction: column;
-    align-items: center; gap: var(--space-4);
-    color: var(--text-muted);
-  }
-  .lgv-empty-icon { font-size: 48px; }
-
-  @keyframes lgvFadeIn {
-    from { opacity: 0; transform: translateY(6px); }
-    to { opacity: 1; transform: translateY(0); }
-  }
-
-  @media (max-width: 480px) {
-    .lgv-scorebug { padding: var(--space-2) var(--space-3); }
-    .lgv-team-score { font-size: var(--text-2xl); }
-    .lgv-clock { font-size: var(--text-lg); }
-  }
+const styles = `
+.watch-overlay { position: fixed; inset: 0; background: #071021; color: #f3f6ff; z-index: 7000; display:flex; flex-direction:column; }
+.watch-header { position: sticky; top: 0; z-index: 2; padding: 10px; background: #071021; border-bottom: 1px solid #253149; }
+.live-scorebug { display:grid; grid-template-columns: 1fr auto 1fr; gap: 8px; align-items:center; }
+.sb-team { display:flex; justify-content:space-between; align-items:center; background:#111c33; border:1px solid #30405f; padding:8px 10px; border-radius:10px; }
+.sb-team.has-ball { border-color:#fbbf24; box-shadow: inset 0 0 0 1px #fbbf24; }
+.sb-center { text-align:center; font-size:12px; color:#d0dbf5; }
+.watch-main { display:grid; grid-template-columns: minmax(0, 1fr); gap: 10px; padding: 10px; height: 100%; overflow: hidden; }
+.watch-panel, .watch-side { background:#0f172b; border:1px solid #2d3a55; border-radius:12px; padding:10px; overflow:auto; }
+.momentum { font-size:12px; margin-bottom:8px; padding:6px 8px; border-radius:8px; font-weight:700; }
+.momentum.offense { background:#173b2f; } .momentum.defense { background:#3d2527; } .momentum.swing { background:#3b2f18; } .momentum.neutral { background:#253149; }
+.jump-row { display:flex; gap:6px; overflow:auto; padding-bottom:6px; }
+.jump-btn { white-space:nowrap; background:#182741; color:#d8e6ff; border:1px solid #37527d; border-radius:999px; padding:6px 10px; font-size:12px; }
+.live-feed { display:grid; gap:8px; }
+.feed-row { display:grid; grid-template-columns:auto 1fr; gap:8px; border-left:2px solid #344766; padding:4px 0 4px 8px; }
+.feed-row.latest { border-left-color:#7cc4ff; background:#13213a; border-radius:6px; }
+.feed-time { font-size:11px; color:#9fb4d8; }
+.feed-headline { font-size:13px; }
+.feed-meta { display:flex; gap:6px; flex-wrap:wrap; font-size:11px; color:#9fb4d8; }
+.feed-tag { background:#1b2f4f; border:1px solid #415d89; border-radius:999px; padding:1px 6px; }
+.watch-side ul { margin: 0; padding-left: 16px; display:grid; gap:4px; }
+.controls { display:grid; gap:6px; margin-top:10px; }
+.controls button, .finish { background:#1c2e4d; color:white; border:1px solid #456596; border-radius:8px; padding:8px; }
+.controls .active { border-color:#7cc4ff; }
+.finish { margin-top:10px; width:100%; background:#1d4ed8; }
+@media (min-width: 960px) { .watch-main { grid-template-columns: 2fr 1fr; } }
 `;

--- a/src/ui/components/Scorebug/Scorebug.jsx
+++ b/src/ui/components/Scorebug/Scorebug.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function Scorebug({ homeTeam, awayTeam, state }) {
+  const possession = state?.possessionTeamId;
+  return (
+    <div className="live-scorebug">
+      <div className={`sb-team ${possession === awayTeam?.id ? 'has-ball' : ''}`}>
+        <span>{awayTeam?.abbr || 'AWY'}</span>
+        <strong>{state?.score?.away ?? 0}</strong>
+      </div>
+      <div className="sb-center">
+        <div>Q{state?.quarter ?? 1} · {state?.clock ?? '15:00'}</div>
+        <div>{state?.downDistance || '—'} · {state?.ballSpot || 'Ball on --'}</div>
+      </div>
+      <div className={`sb-team ${possession === homeTeam?.id ? 'has-ball' : ''}`}>
+        <span>{homeTeam?.abbr || 'HME'}</span>
+        <strong>{state?.score?.home ?? 0}</strong>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/utils/liveGamePresentation.js
+++ b/src/ui/utils/liveGamePresentation.js
@@ -1,0 +1,97 @@
+function playerName(player) {
+  return player?.name || 'Unknown';
+}
+
+export function getCurrentStandoutPlayers(events = [], visibleCount = events.length) {
+  const totals = {
+    qb: new Map(),
+    rusher: new Map(),
+    receiver: new Map(),
+    sacks: new Map(),
+    picks: new Map(),
+  };
+
+  for (let i = 0; i < visibleCount && i < events.length; i += 1) {
+    const log = events[i]?.raw || {};
+    const passer = log.passer;
+    const runner = (log.type === 'run' ? log.player : null);
+    const receiver = (log.type === 'pass' ? log.player : null);
+    const defender = log.player;
+
+    if (passer) {
+      const key = playerName(passer);
+      const prev = totals.qb.get(key) || { player: key, yds: 0, td: 0, att: 0, comp: 0 };
+      prev.yds += Number(log.passYds || 0);
+      prev.td += log.type === 'touchdown' && log.tdType === 'pass' ? 1 : 0;
+      prev.att += Number(log.passAtt || 1);
+      prev.comp += log.completed ? 1 : 0;
+      totals.qb.set(key, prev);
+    }
+    if (runner) {
+      const key = playerName(runner);
+      const prev = totals.rusher.get(key) || { player: key, yds: 0, att: 0, td: 0 };
+      prev.yds += Number(log.rushYds || 0);
+      prev.att += 1;
+      prev.td += log.type === 'touchdown' && log.tdType === 'rush' ? 1 : 0;
+      totals.rusher.set(key, prev);
+    }
+    if (receiver) {
+      const key = playerName(receiver);
+      const prev = totals.receiver.get(key) || { player: key, yds: 0, rec: 0, td: 0 };
+      prev.yds += Number(log.passYds || 0);
+      prev.rec += log.completed ? 1 : 0;
+      prev.td += log.type === 'touchdown' && log.tdType === 'pass' ? 1 : 0;
+      totals.receiver.set(key, prev);
+    }
+    if (log.type === 'sack' && defender) {
+      const key = playerName(defender);
+      totals.sacks.set(key, (totals.sacks.get(key) || 0) + 1);
+    }
+    if (log.type === 'interception' && defender) {
+      const key = playerName(defender);
+      totals.picks.set(key, (totals.picks.get(key) || 0) + 1);
+    }
+  }
+
+  const top = (map, valueKey) => {
+    const entries = Array.from(map.values());
+    if (!entries.length) return null;
+    entries.sort((a, b) => ((b[valueKey] || b) - (a[valueKey] || a)));
+    return entries[0];
+  };
+
+  return {
+    qb: top(totals.qb, 'yds'),
+    rusher: top(totals.rusher, 'yds'),
+    receiver: top(totals.receiver, 'yds'),
+    sacks: top(new Map(Array.from(totals.sacks.entries()).map(([player, sacks]) => [player, { player, sacks }])), 'sacks'),
+    picks: top(new Map(Array.from(totals.picks.entries()).map(([player, picks]) => [player, { player, picks }])), 'picks'),
+  };
+}
+
+export function summarizeGameSwing(events = [], visibleCount = events.length) {
+  const recent = events.slice(Math.max(0, visibleCount - 6), visibleCount);
+  const scores = recent.filter((event) => ['touchdown', 'field_goal'].includes(event.eventType)).length;
+  const turnovers = recent.filter((event) => event.eventType === 'turnover').length;
+  const explosive = recent.filter((event) => event.eventType === 'explosive_play').length;
+
+  if (turnovers >= 2) return { label: 'Defense taking control', tone: 'defense' };
+  if (scores >= 3) return { label: 'Offense in rhythm', tone: 'offense' };
+  if (scores >= 2 && explosive >= 1) return { label: 'Momentum swing building', tone: 'swing' };
+  if (explosive >= 2) return { label: 'Field position flipped', tone: 'swing' };
+  return { label: 'Game still in balance', tone: 'neutral' };
+}
+
+export function getEventTags(event = {}) {
+  const tags = [];
+  if (event.eventType === 'touchdown') tags.push('TD');
+  if (event.eventType === 'turnover') {
+    const text = String(event.headline || '').toLowerCase();
+    tags.push(text.includes('interception') ? 'INT' : 'FUM');
+  }
+  if (event.eventType === 'sack') tags.push('SACK');
+  if (event.eventType === 'explosive_play') tags.push('BIG PLAY');
+  if (event.eventType === 'red_zone_entry') tags.push('RED ZONE');
+  if (event.impactTag === 'swing') tags.push('CLUTCH');
+  return tags;
+}


### PR DESCRIPTION
### Motivation
- Provide a mobile-first, modular watch-mode so users can watch or fast-forward a game using the existing simulation/event outputs without rebuilding archive plumbing or adding finance/business systems. 
- Surface live score, possession, momentum, standout players and jump/skip controls so in-progress games feel like a live match center rather than raw logs. 

### Description
- Introduced a normalized live event model and mapping layer via `src/core/liveGame/liveGameEvents.js` with `buildLiveGameEvent`, `mapArchiveEventsToLiveFeed`, and `getNextImportantEvent` to convert simulation/play logs into timeline events (including quarter/halftime/game-end markers). 
- Added presentation helpers in `src/ui/utils/liveGamePresentation.js` to derive standout players, lightweight momentum/swing labels, and readable event tags (TD/INT/FUM/SACK/BIG PLAY/RED ZONE/CLUTCH). 
- Built UI components: compact sticky scorebug (`src/ui/components/Scorebug/Scorebug.jsx`), scrolling event feed (`src/ui/components/GameEventFeed/GameEventFeed.jsx`), and a mobile-friendly `LiveGameViewer` (`src/ui/components/LiveGameViewer.jsx`) that orchestrates playback, speed controls, jump-to-key-moment actions, momentum banner, and standouts panel. 
- Hooked into the app flow in `src/ui/App.jsx` to present pre-watch choices (Watch, Fast Watch, Sim to End), pass `userGameLogs` into the new viewer, and cleanly transition to the PostGame screen once the viewer finishes, while preserving the instant-sim path.

### Testing
- `npm run build` completed successfully (production build generated). 
- `npm run test:unit` was executed but the test run failed; the repository shows pre-existing unrelated test failures across multiple suites (unit + Playwright collection conflicts), resulting in failing tests in this environment (summary: test run produced failing suites and tests unrelated to the new watch-mode files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d88947f8c8832da5fccd9a541981c8)