### PR TITLE
Mobile-first shell reset with HQ/Team/League/News hubs and canonical routing

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -791,6 +791,8 @@ function AppContent() {
           onDismissNotification={actions.dismissNotification}
           externalBoxScoreId={externalBoxScoreId}
           onConsumeExternalBoxScore={() => setExternalBoxScoreId(null)}
+          advanceLabel={getAdvanceLabel()}
+          advanceDisabled={busy || simulating || isCutdownRequired || !!batchSim || !!promptUserGame}
         />
       </ErrorBoundary>
 

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -84,6 +84,12 @@ import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/b
 import { normalizeManagementDestination } from "../utils/managementScreenRouting.js";
 import { createBoxScoreTapHandler } from "../utils/scoreTapTarget.js";
 import { safeGetLeagueState, getScheduleViewModel } from "../../state/selectors.js";
+import {
+  SHELL_SECTIONS,
+  getShellSectionForDashboardTab,
+  normalizeDashboardTab,
+  normalizeShellSectionId,
+} from "../utils/shellNavigation.js";
 
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from "@/components/ui/table";
@@ -91,56 +97,6 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { ScrollArea } from "@/components/ui/scroll-area";
-
-// Map MobileNav tab IDs → LeagueDashboard tab names
-const MOBILE_TAB_MAP = {
-  weekly: "HQ",
-  home: "HQ",
-  history: "History Hub",
-  standings: "Standings",
-  schedule: "Schedule",
-  roster: "Roster",
-  leaders: "Leaders",
-  freeagency: "Free Agency",
-  trade: "Trades",
-  draft: "Draft",
-  mockdraft: "Mock Draft",
-  coaches: "Coaches",
-  staff: "Staff",
-  training: "Training",
-  injuries: "Injuries",
-  cap: "💰 Cap",
-  advisor: "🤖 GM Advisor",
-
-  // Legacy aliases kept for compatibility with any older callers.
-  hub: "HQ",
-  free_agency: "Free Agency",
-  trades: "Trades",
-  mock_draft: "Mock Draft",
-  financials: "Financials",
-};
-
-// Reverse map: dashboard tab → MobileNav tab ID (canonical IDs only).
-const REVERSE_TAB_MAP = {
-  HQ: "weekly",
-  "Weekly Hub": "weekly",
-  Home: "weekly",
-  "History Hub": "history",
-  Standings: "standings",
-  Schedule: "schedule",
-  Roster: "roster",
-  Leaders: "leaders",
-  "Free Agency": "freeagency",
-  Trades: "trade",
-  Draft: "draft",
-  "Mock Draft": "mockdraft",
-  Coaches: "coaches",
-  Staff: "staff",
-  Training: "training",
-  Injuries: "injuries",
-  "💰 Cap": "cap",
-  "🤖 GM Advisor": "advisor",
-};
 
 // ── TabErrorBoundary ─────────────────────────────────────────────────────────
 // Catches render-phase exceptions inside individual tabs.  A crash in one tab
@@ -208,6 +164,9 @@ class TabErrorBoundary extends Component {
 
 const BASE_TABS = [
   "HQ",
+  "Team",
+  "League",
+  "News",
   "Standings",
   "Schedule",
   "Stats",
@@ -258,12 +217,7 @@ const NAV_GROUPS = [
 
 const TEAM_FACING_TABS = new Set(["Roster", "Depth Chart", "Roster Hub", "Game Plan", "Training", "Injuries", "Staff", "Financials", "Contract Center"]);
 const TAB_ALIASES = {
-  "Weekly Hub": "HQ",
-  Home: "HQ",
-  "Trade Center": "Transactions",
-  "Trade Finder": "Transactions",
   Trades: "Transactions",
-  "FA Hub": "Free Agency",
 };
 
 // Division display labels and their numeric indices (from App.jsx DEFAULT_TEAMS).
@@ -1462,6 +1416,26 @@ function getPhasePriorityTabs(phase) {
   return ["HQ", "Game Plan", "Roster", "Transactions"];
 }
 
+const TEAM_SUBNAV = ["Overview", "Roster", "Contracts / Cap", "Stats", "Schedule", "History"];
+const LEAGUE_SUBNAV = ["Standings", "Schedule", "Team Stats", "Player Stats", "Records", "Playoffs"];
+
+function SectionSubnav({ items, activeItem, onChange }) {
+  return (
+    <div className="standings-tabs" style={{ marginBottom: "var(--space-3)", gap: 6, flexWrap: "nowrap", overflowX: "auto" }}>
+      {items.map((item) => (
+        <button
+          key={item}
+          className={`standings-tab${activeItem === item ? " active" : ""}`}
+          onClick={() => onChange(item)}
+          style={{ flexShrink: 0 }}
+        >
+          {item}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 export default function LeagueDashboard({
   league,
   lastResults = [],
@@ -1474,6 +1448,8 @@ export default function LeagueDashboard({
   onDismissNotification,
   externalBoxScoreId,
   onConsumeExternalBoxScore,
+  advanceLabel = "Advance",
+  advanceDisabled = false,
 }) {
   const [activeTab, setActiveTab] = useState("HQ");
   const [selectedGameId, setSelectedGameId] = useState(null);
@@ -1485,6 +1461,10 @@ export default function LeagueDashboard({
   const [rosterInitialState, setRosterInitialState] = useState({ view: "table", filter: "ALL" });
   const [rosterInitialView, setRosterInitialView] = useState("table");
   const [statsInitialFamily, setStatsInitialFamily] = useState("passing");
+  const [teamSubtab, setTeamSubtab] = useState("Overview");
+  const [leagueSubtab, setLeagueSubtab] = useState("Standings");
+  const [newsSubtab, setNewsSubtab] = useState("All");
+  const [isMobile, setIsMobile] = useState(() => (typeof window !== "undefined" ? window.innerWidth <= 767 : false));
 
   // Track the previous phase so we can detect transitions.
   const prevPhaseRef = React.useRef(null);
@@ -1508,10 +1488,24 @@ export default function LeagueDashboard({
   //                    DraftComplete panel no longer shows.
   //  playoffs    → auto-switch to Postseason tab on first entry
   useEffect(() => {
-    if (TAB_ALIASES[activeTab]) {
-      setActiveTab(TAB_ALIASES[activeTab]);
+    const normalized = normalizeDashboardTab(activeTab);
+    if (TAB_ALIASES[normalized]) {
+      setActiveTab(TAB_ALIASES[normalized]);
+      return;
+    }
+    if (normalized !== activeTab) {
+      setActiveTab(normalized);
     }
   }, [activeTab]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    const mql = window.matchMedia("(max-width: 767px)");
+    const onChange = (e) => setIsMobile(e.matches);
+    setIsMobile(mql.matches);
+    mql.addEventListener?.("change", onChange);
+    return () => mql.removeEventListener?.("change", onChange);
+  }, []);
 
   useEffect(() => {
     const prevPhase = prevPhaseRef.current;
@@ -1588,6 +1582,23 @@ export default function LeagueDashboard({
     setLastGameTab(sourceTab);
     setSelectedGameId(gameId);
     setActiveTab("Game Detail");
+  };
+  const activeSection = getShellSectionForDashboardTab(activeTab);
+  const handleSectionChange = (sectionId) => {
+    const normalizedSection = normalizeShellSectionId(sectionId);
+    if (normalizedSection === SHELL_SECTIONS.team) {
+      setActiveTab("Team");
+      return;
+    }
+    if (normalizedSection === SHELL_SECTIONS.league) {
+      setActiveTab("League");
+      return;
+    }
+    if (normalizedSection === SHELL_SECTIONS.news) {
+      setActiveTab("News");
+      return;
+    }
+    setActiveTab("HQ");
   };
 
   return (
@@ -1667,11 +1678,11 @@ export default function LeagueDashboard({
         </div>
       )}
 
-      <div className="franchise-primary-nav">
+      {!isMobile && <div className="franchise-primary-nav">
         {["HQ","Roster","Schedule","Transactions","Standings"].map((tab) => (
           <button key={`shell-${tab}`} className={`standings-tab${activeTab === tab ? ' active' : ''}`} onClick={() => setActiveTab(tab)}>{tab}</button>
         ))}
-      </div>
+      </div>}
 
       {/* ── Status Grid — hidden during Draft to create a cleaner "War Room" view ── */}
       {activeTab !== "Home" && activeTab !== "HQ" && league.phase !== "draft" && <div
@@ -1924,7 +1935,7 @@ export default function LeagueDashboard({
 
       </div>}
 
-      <div className="standings-tabs" style={{ marginBottom: "var(--space-2)", gap: 6, flexWrap: "nowrap", overflowX: "auto" }}>
+      {!isMobile && <div className="standings-tabs" style={{ marginBottom: "var(--space-2)", gap: 6, flexWrap: "nowrap", overflowX: "auto" }}>
         {getPhasePriorityTabs(league.phase).filter((tab) => TABS.includes(tab)).map((tab) => (
           <button
             key={`priority-${tab}`}
@@ -1940,10 +1951,10 @@ export default function LeagueDashboard({
             {tab}
           </button>
         ))}
-      </div>
+      </div>}
 
       {/* ── Grouped Navigation ── */}
-      <div
+      {!isMobile && <div
         className="standings-tabs dashboard-main-tabs"
         style={{
           marginBottom: "var(--space-4)",
@@ -1980,7 +1991,7 @@ export default function LeagueDashboard({
             </div>
           </div>
         ))}
-      </div>
+      </div>}
 
       {/* ── Tab Content — each tab is independently error-bounded ── */}
       <div className="fade-in" key={activeTab}>
@@ -2013,6 +2024,51 @@ export default function LeagueDashboard({
                 <StatLeadersWidget onPlayerSelect={setSelectedPlayerId} actions={actions} />
               </div>
             )}
+          </TabErrorBoundary>
+        )}
+        {activeTab === "Team" && (
+          <TabErrorBoundary label="Team">
+            <SectionSubnav items={TEAM_SUBNAV} activeItem={teamSubtab} onChange={setTeamSubtab} />
+            {teamSubtab === "Overview" && (
+              <div style={{ display: "grid", gap: "var(--space-3)" }}>
+                <div className="card" style={{ padding: "var(--space-4)" }}>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>Team Identity</div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 8 }}>
+                    <TeamLogo abbr={userAbbr} size={48} isUser />
+                    <div>
+                      <div style={{ fontSize: "var(--text-lg)", fontWeight: 800 }}>{userTeam?.name ?? "Your Team"}</div>
+                      <div style={{ color: "var(--text-muted)", fontSize: "var(--text-sm)" }}>{userRecord} · OFF {userTeam?.off ?? "—"} · DEF {userTeam?.def ?? "—"} · OVR {userTeam?.ovr ?? "—"}</div>
+                    </div>
+                  </div>
+                </div>
+                <FranchiseSummaryPanel league={league} compact />
+                <div className="card" style={{ padding: "var(--space-4)", color: "var(--text-muted)" }}>
+                  Cap snapshot: <strong style={{ color: "var(--text)" }}>{formatMoneyM(capRoom)}</strong> room · Used {formatMoneyM(capUsed)} / {formatMoneyM(capTotal)}.
+                </div>
+              </div>
+            )}
+            {teamSubtab === "Roster" && <Roster league={league} actions={actions} onPlayerSelect={setSelectedPlayerId} initialState={rosterInitialState} initialViewMode={rosterInitialView} />}
+            {teamSubtab === "Contracts / Cap" && <ContractCenter league={league} actions={actions} />}
+            {teamSubtab === "Stats" && <PlayerStats actions={actions} league={league} onPlayerSelect={setSelectedPlayerId} initialFamily={statsInitialFamily} />}
+            {teamSubtab === "Schedule" && <ScheduleTab schedule={league.schedule} teams={league.teams} currentWeek={league.week} userTeamId={league.userTeamId} nextGameStakes={league.nextGameStakes} seasonId={league.seasonId} onGameSelect={(gameId) => openGameDetail(gameId, "Team")} playoffSeeds={league.playoffSeeds} onTeamRoster={setSelectedTeamId} league={league} onPlayerSelect={setSelectedPlayerId} />}
+            {teamSubtab === "History" && <TeamHistoryScreen league={league} actions={actions} onPlayerSelect={setSelectedPlayerId} onBack={() => setTeamSubtab("Overview")} teamId={league?.userTeamId} onOpenBoxScore={(gameId) => openGameDetail(gameId, "Team")} />}
+          </TabErrorBoundary>
+        )}
+        {activeTab === "League" && (
+          <TabErrorBoundary label="League">
+            <SectionSubnav items={LEAGUE_SUBNAV} activeItem={leagueSubtab} onChange={setLeagueSubtab} />
+            {leagueSubtab === "Standings" && <StandingsTab teams={league.teams} userTeamId={league.userTeamId} onTeamSelect={setSelectedTeamId} leagueSettings={league.settings} />}
+            {leagueSubtab === "Schedule" && <ScheduleTab schedule={league.schedule} teams={league.teams} currentWeek={league.week} userTeamId={league.userTeamId} nextGameStakes={league.nextGameStakes} seasonId={league.seasonId} onGameSelect={(gameId) => openGameDetail(gameId, "League")} playoffSeeds={league.playoffSeeds} onTeamRoster={setSelectedTeamId} league={league} onPlayerSelect={setSelectedPlayerId} />}
+            {leagueSubtab === "Team Stats" && <AnalyticsHub league={league} actions={actions} onPlayerSelect={setSelectedPlayerId} onTeamSelect={setSelectedTeamId} onNavigate={setActiveTab} />}
+            {leagueSubtab === "Player Stats" && <Leaders onPlayerSelect={setSelectedPlayerId} userTeamId={league.userTeamId} actions={actions} onNavigate={setActiveTab} league={league} />}
+            {leagueSubtab === "Records" && <RecordBook league={league} />}
+            {leagueSubtab === "Playoffs" && <PostseasonHub league={league} onOpenBoxScore={(gameId) => openGameDetail(gameId, "League")} />}
+          </TabErrorBoundary>
+        )}
+        {activeTab === "News" && (
+          <TabErrorBoundary label="News">
+            <SectionSubnav items={["All", "Team", "League", "Transactions"]} activeItem={newsSubtab} onChange={setNewsSubtab} />
+            <NewsFeed league={league} mode="full" segment={newsSubtab.toLowerCase()} />
           </TabErrorBoundary>
         )}
         {activeTab === "Standings" && (
@@ -2184,7 +2240,6 @@ export default function LeagueDashboard({
                 {isInitialized && activeTab === "📰 News" && (
           <TabErrorBoundary label="News">
             <NewsFeed league={league} mode="full" />
-            <RecordBook league={league} />
           </TabErrorBoundary>
         )}
 
@@ -2323,15 +2378,16 @@ export default function LeagueDashboard({
       </div>
 
       {/* ── Quick-Jump FAB (mobile) ── */}
-      <QuickJumpFab onNavigate={setActiveTab} />
+      {!isMobile && <QuickJumpFab onNavigate={setActiveTab} />}
 
       {/* ── Mobile Navigation (bottom bar + slide-in) ── */}
       <MobileNav
-        activeTab={REVERSE_TAB_MAP[activeTab] || "weekly"}
-        onTabChange={(mobileTabId) => {
-          const dashTab = MOBILE_TAB_MAP[mobileTabId];
-          if (dashTab) setActiveTab(dashTab);
-        }}
+        activeSection={activeSection}
+        onSectionChange={handleSectionChange}
+        onDestinationChange={(tab) => setActiveTab(tab)}
+        onAdvance={onAdvanceWeek}
+        advanceLabel={advanceLabel}
+        advanceDisabled={advanceDisabled}
         league={league}
       />
 

--- a/src/ui/components/MobileNav.jsx
+++ b/src/ui/components/MobileNav.jsx
@@ -1,64 +1,49 @@
 import React, { useState, useEffect } from 'react';
 import { NAV_LABELS } from '../constants/navigationCopy.js';
+import { SHELL_SECTIONS } from '../utils/shellNavigation.js';
 
-const NAV_GROUPS = [
-  {
-    title: 'HQ',
-    items: [
-      { id: 'weekly', label: 'Franchise HQ', icon: WeeklyHubIcon },
-    ],
-  },
-  {
-    title: 'Team',
-    items: [
-      { id: 'roster', label: 'Roster', icon: RosterIcon },
-      { id: 'staff', label: 'Staff', icon: StaffIcon },
-      { id: 'training', label: 'Training', icon: TrainingIcon },
-      { id: 'injuries', label: 'Injuries', icon: InjuryIcon },
-      { id: 'cap', label: 'Finances', icon: FinancesIcon },
-    ],
-  },
+const MORE_GROUPS = [
   {
     title: 'Transactions',
     items: [
-      { id: 'trade', label: 'Trades', icon: TradesIcon },
-      { id: 'freeagency', label: 'Free Agency', icon: FAIcon },
-      { id: 'draft', label: 'Draft', icon: DraftIcon },
+      { id: 'Transactions', label: 'Trades', icon: TradesIcon },
+      { id: 'Free Agency', label: 'Free Agency', icon: FAIcon },
+      { id: 'Draft', label: 'Draft', icon: DraftIcon },
     ],
   },
   {
-    title: 'League',
+    title: 'Team Ops',
     items: [
-      { id: 'standings', label: 'Standings', icon: StandingsIcon },
-      { id: 'schedule', label: 'Schedule', icon: ScheduleIcon },
-      { id: 'leaders', label: 'Leaders', icon: LeadersIcon },
+      { id: 'Staff', label: 'Staff', icon: StaffIcon },
+      { id: 'Training', label: 'Training', icon: TrainingIcon },
+      { id: 'Injuries', label: 'Injuries', icon: InjuryIcon },
+      { id: '💰 Cap', label: 'Cap / Financials', icon: FinancesIcon },
+      { id: 'Contract Center', label: 'Contracts', icon: ContractIcon },
     ],
   },
   {
-    title: 'History',
+    title: 'League Office',
     items: [
-      { id: 'history', label: 'History Hub', icon: HomeIcon },
-    ],
-  },
-  {
-    title: 'Tools',
-    items: [
-      { id: 'advisor', label: 'GM Advisor', icon: AdvisorIcon },
+      { id: 'History Hub', label: 'History', icon: HomeIcon },
+      { id: 'Analytics', label: 'Analytics', icon: AnalyticsIcon },
+      { id: 'Saves', label: 'Saves', icon: SaveIcon },
+      { id: '🤖 GM Advisor', label: 'GM Advisor', icon: AdvisorIcon },
+      { id: 'God Mode', label: 'God Mode', icon: GodModeIcon },
     ],
   },
 ];
 
 const BOTTOM_TABS = [
-  { id: 'weekly', label: NAV_LABELS.weekly, icon: WeeklyHubIcon },
-  { id: 'roster', label: NAV_LABELS.roster, icon: RosterIcon },
-  { id: 'standings', label: NAV_LABELS.standings, icon: StandingsIcon },
-  { id: 'trade', label: NAV_LABELS.trades, icon: TradesIcon },
+  { id: SHELL_SECTIONS.hq, label: NAV_LABELS.hq, icon: HomeIcon },
+  { id: SHELL_SECTIONS.team, label: NAV_LABELS.team, icon: RosterIcon },
+  { id: SHELL_SECTIONS.league, label: NAV_LABELS.league, icon: StandingsIcon },
+  { id: SHELL_SECTIONS.news, label: NAV_LABELS.news, icon: NewsIcon },
 ];
 
-export default function MobileNav({ activeTab, onTabChange, league }) {
+export default function MobileNav({ activeSection, onSectionChange, onDestinationChange, onAdvance, advanceLabel, advanceDisabled, league }) {
   const [menuOpen, setMenuOpen] = useState(false);
 
-  useEffect(() => setMenuOpen(false), [activeTab]);
+  useEffect(() => setMenuOpen(false), [activeSection]);
 
   useEffect(() => {
     const handleKey = (e) => e.key === 'Escape' && setMenuOpen(false);
@@ -72,8 +57,14 @@ export default function MobileNav({ activeTab, onTabChange, league }) {
     };
   }, [menuOpen]);
 
-  const handleNavClick = (tabKey) => {
-    onTabChange?.(tabKey);
+  const handleSectionClick = (sectionId) => {
+    onSectionChange?.(sectionId);
+    setMenuOpen(false);
+    window.scrollTo(0, 0);
+  };
+
+  const handleDestinationClick = (tab) => {
+    onDestinationChange?.(tab);
     setMenuOpen(false);
     window.scrollTo(0, 0);
   };
@@ -88,21 +79,20 @@ export default function MobileNav({ activeTab, onTabChange, league }) {
 
       {menuOpen && <div className="mobile-nav-backdrop" onClick={() => setMenuOpen(false)} aria-hidden="true" />}
 
-      <nav className={`mobile-nav-panel ${menuOpen ? 'open' : ''}`} aria-label="Main navigation">
+      <nav className={`mobile-nav-panel ${menuOpen ? 'open' : ''}`} aria-label="More navigation">
         <div className="mobile-nav-header">
-          <h2 className="mobile-nav-title">Franchise HQ</h2>
+          <h2 className="mobile-nav-title">More</h2>
           {league && <p className="mobile-nav-subtitle">{league.year ?? league.seasonId} · {league.phase}</p>}
         </div>
 
         <div className="mobile-nav-items grouped">
-          {NAV_GROUPS.map((group) => (
+          {MORE_GROUPS.map((group) => (
             <section key={group.title} className="mobile-nav-group">
               <h3 className="mobile-nav-group-title">{group.title}</h3>
               {group.items.map((item) => {
                 const Icon = item.icon;
-                const isActive = activeTab === item.id;
                 return (
-                  <button key={item.id} className={`mobile-nav-item ${isActive ? 'active' : ''}`} onClick={() => handleNavClick(item.id)}>
+                  <button key={item.id} className="mobile-nav-item" onClick={() => handleDestinationClick(item.id)}>
                     <Icon size={20} />
                     <span>{item.label}</span>
                   </button>
@@ -114,16 +104,38 @@ export default function MobileNav({ activeTab, onTabChange, league }) {
       </nav>
 
       <div className="mobile-bottom-bar">
-        {BOTTOM_TABS.map((tab) => {
+        {BOTTOM_TABS.slice(0, 2).map((tab) => {
           const Icon = tab.icon;
-          const isActive = activeTab === tab.id;
+          const isActive = activeSection === tab.id;
           return (
-            <button key={tab.id} className={`mobile-bottom-tab ${isActive ? 'active' : ''}`} onClick={() => handleNavClick(tab.id)} aria-label={tab.label}>
+            <button key={tab.id} className={`mobile-bottom-tab ${isActive ? 'active' : ''}`} onClick={() => handleSectionClick(tab.id)} aria-label={tab.label}>
               <Icon size={20} />
               <span className="mobile-bottom-label">{tab.label}</span>
             </button>
           );
         })}
+
+        <button
+          className="mobile-bottom-tab mobile-bottom-tab-advance"
+          onClick={onAdvance}
+          disabled={advanceDisabled}
+          aria-label={advanceLabel || 'Advance'}
+        >
+          <PlayIcon size={22} />
+          <span className="mobile-bottom-label">{advanceLabel || 'Advance'}</span>
+        </button>
+
+        {BOTTOM_TABS.slice(2).map((tab) => {
+          const Icon = tab.icon;
+          const isActive = activeSection === tab.id;
+          return (
+            <button key={tab.id} className={`mobile-bottom-tab ${isActive ? 'active' : ''}`} onClick={() => handleSectionClick(tab.id)} aria-label={tab.label}>
+              <Icon size={20} />
+              <span className="mobile-bottom-label">{tab.label}</span>
+            </button>
+          );
+        })}
+
         <button className={`mobile-bottom-tab ${menuOpen ? 'active' : ''}`} onClick={() => setMenuOpen(!menuOpen)} aria-label="Open more menu">
           <MoreIcon size={20} />
           <span className="mobile-bottom-label">{NAV_LABELS.more}</span>
@@ -133,11 +145,11 @@ export default function MobileNav({ activeTab, onTabChange, league }) {
   );
 }
 
-function WeeklyHubIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="12" r="10" /><path d="M12 7v5l3 2" /></svg>; }
 function HomeIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M3 10.5 12 3l9 7.5V21H3z" /><path d="M9 21v-6h6v6" /></svg>; }
 function StandingsIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M5 6h14M5 12h14M5 18h14" /></svg>; }
 function RosterIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="9" cy="7" r="4" /><path d="M2 21v-2a5 5 0 0 1 5-5h4a5 5 0 0 1 5 5v2" /></svg>; }
-function LeadersIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="m3 17 6-6 4 4 8-8" /></svg>; }
+function NewsIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M4 5h14a2 2 0 0 1 2 2v12H6a2 2 0 0 1-2-2z" /><path d="M8 9h8M8 13h8M8 17h5" /></svg>; }
+function PlayIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor"><path d="m8 5 11 7-11 7z" /></svg>; }
 function FAIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M16 4v8M20 8h-8" /><circle cx="8" cy="8" r="4" /><path d="M2 21v-1a5 5 0 0 1 5-5h2" /></svg>; }
 function TradesIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="m17 1 4 4-4 4" /><path d="M3 11V9a4 4 0 0 1 4-4h14" /><path d="m7 23-4-4 4-4" /><path d="M21 13v2a4 4 0 0 1-4 4H3" /></svg>; }
 function DraftIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M14 2H6a2 2 0 0 0-2 2v16h16V8z" /><path d="M14 2v6h6" /></svg>; }
@@ -146,5 +158,8 @@ function TrainingIcon({ size = 24 }) { return <svg width={size} height={size} vi
 function InjuryIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M10 2v7l-2 2 8 8 2-2-8-8 2-2h7" /></svg>; }
 function FinancesIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M12 2v20" /><path d="M17 6H9a3 3 0 1 0 0 6h6a3 3 0 1 1 0 6H6" /></svg>; }
 function AdvisorIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="3" y="4" width="18" height="13" rx="2" /><path d="M8 21h8M12 17v4" /></svg>; }
+function ContractIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M8 3h8l5 5v13H3V3z" /><path d="M8 3v5h5" /></svg>; }
+function SaveIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" /><path d="M17 21v-8H7v8" /></svg>; }
+function GodModeIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M12 2 4 7v10l8 5 8-5V7z" /><path d="M12 22V12" /></svg>; }
+function AnalyticsIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M3 3v18h18" /><path d="m7 15 4-4 3 3 5-6" /></svg>; }
 function MoreIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="5" cy="12" r="1.5" /><circle cx="12" cy="12" r="1.5" /><circle cx="19" cy="12" r="1.5" /></svg>; }
-function ScheduleIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="3" y="4" width="18" height="17" rx="2" /><path d="M8 2v4M16 2v4M3 10h18" /></svg>; }

--- a/src/ui/components/NewsFeed.jsx
+++ b/src/ui/components/NewsFeed.jsx
@@ -57,9 +57,9 @@ function sortWeight(item, idx) {
   return (item?.sortWeight ?? 0) + priorityBase + sourceBoost + recency;
 }
 
-export default function NewsFeed({ league, mode = 'full' }) {
+export default function NewsFeed({ league, mode = 'full', segment = 'all' }) {
   const [activeIndex, setActiveIndex] = useState(0);
-  const [filter, setFilter] = useState('all');
+  const [filter, setFilter] = useState(segment);
 
   const allNews = useMemo(() => (Array.isArray(league?.newsItems) ? league.newsItems : []), [league?.newsItems]);
   const userTeamId = league?.userTeamId;
@@ -87,6 +87,10 @@ export default function NewsFeed({ league, mode = 'full' }) {
     }, 4000);
     return () => clearInterval(timer);
   }, [mode, latestFive.length]);
+
+  useEffect(() => {
+    setFilter(segment);
+  }, [segment]);
 
   if (mode === 'ticker') {
     if (!Array.isArray(latestFive) || latestFive.length === 0) return null;
@@ -117,7 +121,7 @@ export default function NewsFeed({ league, mode = 'full' }) {
     if (filter === 'league') return item?.teamId == null;
     if (filter === 'high') return item?.priority === 'high';
     if (filter === 'race') return /playoff|award|standing|rival/i.test(item?._categoryLabel ?? '');
-    if (filter === 'moves') return /trade|agency|draft/i.test(item?._categoryLabel ?? '');
+    if (filter === 'moves' || filter === 'transactions') return /trade|agency|draft|transaction/i.test(item?._categoryLabel ?? '');
     return true;
   }).slice(0, 50);
 
@@ -152,11 +156,10 @@ export default function NewsFeed({ league, mode = 'full' }) {
       <div style={{ display: 'flex', gap: 8, marginBottom: 12, flexWrap: 'wrap' }}>
         {[
           ['all', 'ALL'],
-          ['high', 'MAJOR'],
-          ['race', 'RACES'],
-          ['moves', 'MOVES'],
-          ['team', 'YOUR TEAM'],
+          ['team', 'TEAM'],
           ['league', 'LEAGUE'],
+          ['transactions', 'TRANSACTIONS'],
+          ['high', 'MAJOR'],
         ].map(([value, label]) => (
           <button key={value} className="btn" onClick={() => setFilter(value)} style={{ opacity: filter === value ? 1 : 0.7 }}>
             {label}

--- a/src/ui/constants/navigationCopy.js
+++ b/src/ui/constants/navigationCopy.js
@@ -1,17 +1,17 @@
 export const NAV_LABELS = Object.freeze({
-  weekly: "Weekly",
-  roster: "Roster",
-  standings: "League",
-  trades: "Trades",
-  more: "More",
-  overflow: "More",
+  hq: 'HQ',
+  team: 'Team',
+  league: 'League',
+  news: 'News',
+  more: 'More',
+  overflow: 'More',
 });
 
 export const ACTION_LABELS = Object.freeze({
-  advanceWeek: "Advance Week",
-  advanceFranchise: "Advance Franchise",
-  readyToAdvance: "Ready to Advance",
-  simulating: "Simulating...",
-  working: "Working...",
-  more: "More",
+  advanceWeek: 'Advance Week',
+  advanceFranchise: 'Advance Franchise',
+  readyToAdvance: 'Ready to Advance',
+  simulating: 'Simulating...',
+  working: 'Working...',
+  more: 'More',
 });

--- a/src/ui/styles/app-mobile.css
+++ b/src/ui/styles/app-mobile.css
@@ -862,6 +862,22 @@
   color: var(--accent);
 }
 
+.mobile-bottom-tab-advance {
+  background: var(--accent);
+  color: #111;
+  border-radius: 999px;
+  min-width: 84px;
+  padding: 8px 10px;
+  font-weight: 700;
+  transform: translateY(-12px);
+  box-shadow: 0 8px 22px rgba(255, 183, 3, 0.35);
+}
+
+.mobile-bottom-tab-advance:disabled {
+  opacity: 0.6;
+  transform: translateY(-8px);
+}
+
 .mobile-bottom-label {
   font-size: 10px;
   line-height: 1.2;

--- a/src/ui/utils/shellNavigation.js
+++ b/src/ui/utils/shellNavigation.js
@@ -1,0 +1,78 @@
+export const SHELL_SECTIONS = Object.freeze({
+  hq: 'hq',
+  team: 'team',
+  league: 'league',
+  news: 'news',
+  more: 'more',
+});
+
+export const SECTION_DEFAULT_TAB = Object.freeze({
+  [SHELL_SECTIONS.hq]: 'HQ',
+  [SHELL_SECTIONS.team]: 'Team',
+  [SHELL_SECTIONS.league]: 'League',
+  [SHELL_SECTIONS.news]: 'News',
+});
+
+const DASHBOARD_TAB_ALIASES = Object.freeze({
+  'Weekly Hub': 'HQ',
+  Home: 'HQ',
+  'Trade Center': 'Transactions',
+  'Trade Finder': 'Transactions',
+  Trades: 'Transactions',
+  'FA Hub': 'Free Agency',
+  '📰 News': 'News',
+});
+
+const TAB_TO_SECTION = Object.freeze({
+  HQ: SHELL_SECTIONS.hq,
+  Team: SHELL_SECTIONS.team,
+  Roster: SHELL_SECTIONS.team,
+  'Depth Chart': SHELL_SECTIONS.team,
+  'Roster Hub': SHELL_SECTIONS.team,
+  'Game Plan': SHELL_SECTIONS.team,
+  Training: SHELL_SECTIONS.team,
+  Injuries: SHELL_SECTIONS.team,
+  Staff: SHELL_SECTIONS.team,
+  Financials: SHELL_SECTIONS.team,
+  'Contract Center': SHELL_SECTIONS.team,
+  '💰 Cap': SHELL_SECTIONS.team,
+  League: SHELL_SECTIONS.league,
+  Standings: SHELL_SECTIONS.league,
+  Schedule: SHELL_SECTIONS.league,
+  Stats: SHELL_SECTIONS.league,
+  Leaders: SHELL_SECTIONS.league,
+  Analytics: SHELL_SECTIONS.league,
+  'Award Races': SHELL_SECTIONS.league,
+  'League Leaders': SHELL_SECTIONS.league,
+  Postseason: SHELL_SECTIONS.league,
+  'Awards & Records': SHELL_SECTIONS.league,
+  News: SHELL_SECTIONS.news,
+});
+
+const LEGACY_MOBILE_ID_TO_SECTION = Object.freeze({
+  weekly: SHELL_SECTIONS.hq,
+  home: SHELL_SECTIONS.hq,
+  roster: SHELL_SECTIONS.team,
+  standings: SHELL_SECTIONS.league,
+  schedule: SHELL_SECTIONS.league,
+  leaders: SHELL_SECTIONS.league,
+  trade: SHELL_SECTIONS.more,
+  freeagency: SHELL_SECTIONS.more,
+  history: SHELL_SECTIONS.more,
+  news: SHELL_SECTIONS.news,
+});
+
+export function normalizeDashboardTab(tab) {
+  return DASHBOARD_TAB_ALIASES[tab] ?? tab;
+}
+
+export function getShellSectionForDashboardTab(tab) {
+  const normalized = normalizeDashboardTab(tab);
+  return TAB_TO_SECTION[normalized] ?? SHELL_SECTIONS.more;
+}
+
+export function normalizeShellSectionId(input) {
+  if (!input) return SHELL_SECTIONS.hq;
+  if (Object.values(SHELL_SECTIONS).includes(input)) return input;
+  return LEGACY_MOBILE_ID_TO_SECTION[input] ?? SHELL_SECTIONS.hq;
+}

--- a/src/ui/utils/shellNavigation.test.js
+++ b/src/ui/utils/shellNavigation.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { getShellSectionForDashboardTab, normalizeDashboardTab, normalizeShellSectionId } from './shellNavigation.js';
+
+describe('shell navigation mapping', () => {
+  it('normalizes legacy aliases to canonical dashboard tabs', () => {
+    expect(normalizeDashboardTab('Weekly Hub')).toBe('HQ');
+    expect(normalizeDashboardTab('📰 News')).toBe('News');
+  });
+
+  it('maps dashboard tabs into shell sections', () => {
+    expect(getShellSectionForDashboardTab('Roster')).toBe('team');
+    expect(getShellSectionForDashboardTab('Standings')).toBe('league');
+    expect(getShellSectionForDashboardTab('News')).toBe('news');
+    expect(getShellSectionForDashboardTab('Transactions')).toBe('more');
+  });
+
+  it('accepts legacy mobile ids as section inputs', () => {
+    expect(normalizeShellSectionId('weekly')).toBe('hq');
+    expect(normalizeShellSectionId('trade')).toBe('more');
+    expect(normalizeShellSectionId('league')).toBe('league');
+  });
+});


### PR DESCRIPTION
### Motivation
- The mobile UI had too many competing navigation layers and developer-oriented labels causing mobile clutter and confusing hierarchy. The shell needed a simple game-first structure matching Pocket GM / Pro Football GM expectations.
- Make News a first-class destination and turn Team/League into real hubs instead of shallow shortcuts, without changing simulation systems or core flows.
- Centralize routing aliases so navigation no longer depends on scattered label strings and legacy emoji labels.

### Description
- Introduced a canonical shell mapping layer in `src/ui/utils/shellNavigation.js` with section ids `hq`, `team`, `league`, `news`, `more` and compatibility aliases to preserve older callers.
- Rewrote the mobile navigation in `src/ui/components/MobileNav.jsx` to a five-item persistent bottom bar: `HQ` / `Team` / center Advance CTA / `League` / `News`, with secondary destinations moved into a `More` drawer.
- Built lightweight in-place hubs inside `src/ui/components/LeagueDashboard.jsx` for `Team`, `League`, and `News` with local subnavs and overview content; suppressed redundant desktop/tab rails and the quick-jump FAB on mobile widths to reduce clutter.
- Made News a proper section and added segment-driven filtering to `src/ui/components/NewsFeed.jsx` (supports `all`, `team`, `league`, `transactions`), updated navigation copy in `src/ui/constants/navigationCopy.js`, and added mobile styles for the raised center advance CTA in `src/ui/styles/app-mobile.css`.

### Testing
- Ran a production build with `npm run build` which completed successfully (vite build finished without fatal errors). (success)
- Added and executed a small unit test suite `src/ui/utils/shellNavigation.test.js` with `npm run test:unit -- src/ui/utils/shellNavigation.test.js` and all tests passed (3 tests). (success)
- No automated UI/browser tests were added in this PR; visual/responsive validation should be performed in a follow-up QA pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d96e04d03c832da34e28d7d96a37b4)