### PR TITLE
Step 1: Drive-based sim outputs and 3-sentence recap (QB rating, YPC, turnovers, sacks)

### DIFF
--- a/src/core/game-simulator.js
+++ b/src/core/game-simulator.js
@@ -1531,6 +1531,54 @@ export function simGameStats(home, away, options = {}) {
       weather = WEATHER_TYPES[U.weightedChoice(weatherWeights)];
     }
 
+    const computeTeamEfficiencyProfile = (groups = {}) => {
+        const starterQB = (groups['QB'] || [])[0] || null;
+        const leadRB = (groups['RB'] || [])[0] || null;
+        const ol = groups['OL'] || [];
+        const passRush = [...(groups['DL'] || []), ...(groups['LB'] || [])];
+        const dbs = [...(groups['CB'] || []), ...(groups['S'] || [])];
+
+        const qbRating = (() => {
+            if (!starterQB) return 78;
+            const r = starterQB.ratings || {};
+            const awareness = r.awareness || 70;
+            const accuracy = r.throwAccuracy || 70;
+            const power = r.throwPower || 70;
+            return U.clamp(35 + (accuracy * 0.44) + (awareness * 0.33) + (power * 0.2), 55, 125);
+        })();
+
+        const rushYpc = (() => {
+            const rbOvr = leadRB?.ovr || 68;
+            const rbRatings = leadRB?.ratings || {};
+            const runSkill = ((rbRatings.speed || 70) * 0.35) + ((rbRatings.trucking || 70) * 0.3) + ((rbRatings.juking || 70) * 0.35);
+            const olRun = ol.length
+                ? ol.reduce((sum, p) => sum + ((p.ratings?.runBlock || p.ovr || 70)), 0) / ol.length
+                : 70;
+            return U.clamp(2.7 + ((rbOvr - 70) * 0.02) + ((runSkill - 70) * 0.015) + ((olRun - 70) * 0.014), 2.8, 6.5);
+        })();
+
+        const passBlock = ol.length
+            ? ol.reduce((sum, p) => sum + ((p.ratings?.passBlock || p.ovr || 70)), 0) / ol.length
+            : 70;
+        const passRushStrength = passRush.length
+            ? passRush.reduce((sum, p) => sum + (p.ovr || 70), 0) / passRush.length
+            : 70;
+        const coverageStrength = dbs.length
+            ? dbs.reduce((sum, p) => sum + (p.ovr || 70), 0) / dbs.length
+            : 70;
+
+        return {
+            qbRating: U.round(qbRating, 1),
+            rushYpc: U.round(rushYpc, 2),
+            passBlock: U.round(passBlock, 1),
+            passRushStrength: U.round(passRushStrength, 1),
+            coverageStrength: U.round(coverageStrength, 1),
+        };
+    };
+
+    const homeProfile = computeTeamEfficiencyProfile(homeGroups);
+    const awayProfile = computeTeamEfficiencyProfile(awayGroups);
+
     /**
      * Full game simulation with alternating possessions, momentum, and
      * defensive/special teams scoring.
@@ -1681,7 +1729,11 @@ export function simGameStats(home, away, options = {}) {
 
             const offFactor = (offStr - 50) / 40;
             const defFactor = (defStr - 50) / 40;
-            const netQuality = offFactor - defFactor + (advantage / 50);
+            const offProfile = isHome ? homeProfile : awayProfile;
+            const defProfile = isHome ? awayProfile : homeProfile;
+            const qbEfficiencyEdge = (offProfile.qbRating - defProfile.coverageStrength) / 160;
+            const rushEfficiencyEdge = (offProfile.rushYpc - 4.2) * 0.13;
+            const netQuality = offFactor - defFactor + (advantage / 50) + qbEfficiencyEdge + rushEfficiencyEdge;
 
             // Momentum modifier: ±5% scoring probability
             const momentumMod = isHome
@@ -1923,6 +1975,7 @@ export function simGameStats(home, away, options = {}) {
                 // Check for turnover (fumble, INT)
                 const baseTurnoverRate = 0.14 * weather.turnoverMod;
                 let turnoverChance = baseTurnoverRate;
+                turnoverChance *= (1 + U.clamp((defProfile.passRushStrength - offProfile.passBlock) / 220, -0.12, 0.18));
                 if (mods.intChance) turnoverChance *= (mods.intChance - 1) * 0.3 + 1;
                 if (defMods.defIntChance) turnoverChance *= (defMods.defIntChance - 1) * 0.3 + 1;
                 if (defMods.defPressure) turnoverChance *= 1 + (defMods.defPressure - 1) * 0.15;
@@ -2565,6 +2618,14 @@ export function simGameStats(home, away, options = {}) {
       awaySafeties: awayRes.safeties || 0,
       homeTurnoversForced: homeRes.turnoversForced || 0,
       awayTurnoversForced: awayRes.turnoversForced || 0,
+      simFactors: {
+        home: homeProfile,
+        away: awayProfile,
+        matchup: {
+          ovrDelta: U.round(homeStrength - awayStrength, 2),
+          homeFieldAdvantage: HOME_ADVANTAGE,
+        },
+      },
       playLogs: fullGameResult.playLogs || [],
       liveStats: fullGameResult.liveStats || {},
     };
@@ -2792,6 +2853,7 @@ export function commitGameResult(league, gameData, options = { persist: true }) 
         year: league.year,
         isPlayoff: isPlayoff,
         weather: gameData.weather || null,
+        simFactors: gameData.simFactors || null,
         defensiveTDs: {
             home: gameData.homeDefTDs || 0,
             away: gameData.awayDefTDs || 0
@@ -2988,6 +3050,7 @@ export function simulateBatch(games, options = {}) {
 
             let schemeNote = null;
             let gameInjuries = [];
+            let simFactors = null;
             // Declared here (not inside else) so it's accessible when building gameData below
             let gameScores = null;
 
@@ -3016,6 +3079,7 @@ export function simulateBatch(games, options = {}) {
                 sA = gameScores.awayScore;
                 schemeNote = gameScores.schemeNote;
                 if (gameScores.injuries) gameInjuries = gameScores.injuries;
+                simFactors = gameScores.simFactors || null;
 
                 // Store weather and defensive scoring data for the result
                 pair._weather = gameScores.weather || null;
@@ -3127,6 +3191,7 @@ export function simulateBatch(games, options = {}) {
                 weather: pair._weather,
                 homeDefTDs: pair._homeDefTDs || 0,
                 awayDefTDs: pair._awayDefTDs || 0,
+                simFactors,
                 playLogs: gameScores?.playLogs || [],
                 liveStats: pair._liveStats || {},
             };
@@ -3153,6 +3218,7 @@ export function simulateBatch(games, options = {}) {
                     week: league.week,
                     year: league.year,
                     isPlayoff: options.isPlayoff || false,
+                    simFactors,
                     playLogs: gameScores?.playLogs || [],
                     liveStats: pair._liveStats || {},
                 };

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -192,6 +192,30 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
               <div className="bs-list-item" style={{ marginBottom: 10 }}>
                 {game?.summary?.storyline ?? game?.recap ?? "A complete box score was archived for this matchup."}
               </div>
+              {game?.summary?.simOutputs && (
+                <div className="bs-compare-grid" style={{ marginBottom: 10 }}>
+                  <StatCompareRow
+                    label="QB Rating"
+                    awayValue={game.summary.simOutputs?.away?.qbRating?.toFixed?.(1) ?? game.summary.simOutputs?.away?.qbRating ?? "—"}
+                    homeValue={game.summary.simOutputs?.home?.qbRating?.toFixed?.(1) ?? game.summary.simOutputs?.home?.qbRating ?? "—"}
+                  />
+                  <StatCompareRow
+                    label="Rush YPC"
+                    awayValue={game.summary.simOutputs?.away?.rushingYpc?.toFixed?.(2) ?? game.summary.simOutputs?.away?.rushingYpc ?? "—"}
+                    homeValue={game.summary.simOutputs?.home?.rushingYpc?.toFixed?.(2) ?? game.summary.simOutputs?.home?.rushingYpc ?? "—"}
+                  />
+                  <StatCompareRow
+                    label="Turnovers"
+                    awayValue={game.summary.simOutputs?.away?.turnovers ?? "—"}
+                    homeValue={game.summary.simOutputs?.home?.turnovers ?? "—"}
+                  />
+                  <StatCompareRow
+                    label="Sacks"
+                    awayValue={game.summary.simOutputs?.away?.sacks ?? "—"}
+                    homeValue={game.summary.simOutputs?.home?.sacks ?? "—"}
+                  />
+                </div>
+              )}
               {game?.summary?.playerOfGame?.name && (
                 <div className="bs-list-item" style={{ marginBottom: 10 }}>
                   <strong>Player of the game:</strong> <PlayerButton player={game.summary.playerOfGame} onSelect={onPlayerSelect} />

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -2214,6 +2214,55 @@ function buildLeagueForSim(schedule, week, seasonId) {
   return leagueObj;
 }
 
+function roundStat(value, decimals = 1) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return 0;
+  const p = 10 ** decimals;
+  return Math.round(n * p) / p;
+}
+
+function buildTeamSimOutputs(boxSide = {}, simSide = {}) {
+  const rows = Object.values(boxSide || {});
+  const offenseRows = rows.filter((row) => ['QB', 'RB', 'WR', 'TE'].includes(String(row?.pos ?? '')));
+  const qbs = rows.filter((row) => (row?.pos === 'QB') && Number(row?.stats?.passAtt ?? 0) > 0);
+  const rushers = rows.filter((row) => Number(row?.stats?.rushAtt ?? 0) > 0);
+  const qbAttempts = qbs.reduce((sum, row) => sum + Number(row?.stats?.passAtt ?? 0), 0);
+  const qbCompletions = qbs.reduce((sum, row) => sum + Number(row?.stats?.passComp ?? 0), 0);
+  const qbYards = qbs.reduce((sum, row) => sum + Number(row?.stats?.passYd ?? 0), 0);
+  const qbTds = qbs.reduce((sum, row) => sum + Number(row?.stats?.passTD ?? 0), 0);
+  const qbInts = qbs.reduce((sum, row) => sum + Number(row?.stats?.interceptions ?? 0), 0);
+  const rushAttempts = rushers.reduce((sum, row) => sum + Number(row?.stats?.rushAtt ?? 0), 0);
+  const rushYards = rushers.reduce((sum, row) => sum + Number(row?.stats?.rushYd ?? 0), 0);
+  const turnovers = qbs.reduce((sum, row) => sum + Number(row?.stats?.interceptions ?? 0), 0)
+    + offenseRows.reduce((sum, row) => sum + Number(row?.stats?.fumblesLost ?? 0), 0);
+  const sacks = rows.reduce((sum, row) => sum + Number(row?.stats?.sacks ?? 0), 0);
+
+  const completionPct = qbAttempts > 0 ? qbCompletions / qbAttempts : 0;
+  const yardsPerAttempt = qbAttempts > 0 ? qbYards / qbAttempts : 0;
+  const tdRate = qbAttempts > 0 ? qbTds / qbAttempts : 0;
+  const intRate = qbAttempts > 0 ? qbInts / qbAttempts : 0;
+  const qbRating = qbAttempts > 0
+    ? (((completionPct - 0.3) * 5 + (yardsPerAttempt - 3) * 0.25 + tdRate * 20 + 2.375 - intRate * 25) / 6) * 100
+    : Number(simSide?.qbRating ?? 78);
+
+  return {
+    qbRating: roundStat(qbRating, 1),
+    rushingYpc: roundStat(rushAttempts > 0 ? rushYards / rushAttempts : Number(simSide?.rushYpc ?? 4.0), 2),
+    turnovers: Math.max(0, Math.round(turnovers)),
+    sacks: Math.max(0, roundStat(sacks, 1)),
+  };
+}
+
+function buildThreeSentenceRecap({ winnerAbbr, loserAbbr, winnerMetrics, loserMetrics, scoreHome, scoreAway, homeAbbr }) {
+  const margin = Math.abs(Number(scoreHome) - Number(scoreAway));
+  const winnerScore = winnerAbbr === homeAbbr ? scoreHome : scoreAway;
+  const loserScore = winnerAbbr === homeAbbr ? scoreAway : scoreHome;
+  const pointsLine = `${winnerAbbr} beat ${loserAbbr} ${winnerScore}-${loserScore}${margin <= 7 ? ' in a one-score finish' : ''}.`;
+  const efficiencyLine = `${winnerAbbr} won the efficiency battle with a ${winnerMetrics.qbRating.toFixed(1)} QB rating and ${winnerMetrics.rushingYpc.toFixed(2)} yards per carry.`;
+  const pressureLine = `${winnerAbbr} protected the ball (${winnerMetrics.turnovers} turnovers) while ${loserAbbr} coughed it up ${loserMetrics.turnovers} times and allowed ${winnerMetrics.sacks.toFixed(1)} sacks.`;
+  return `${pointsLine} ${efficiencyLine} ${pressureLine}`;
+}
+
 /**
  * Apply a game result coming from simulateBatch back to the cache.
  * Updates team win/loss records, writes scores into the slim schedule,
@@ -2282,6 +2331,21 @@ function applyGameResultToCache(result, week, seasonId) {
     wasUpset: false,
   });
   const winnerId = scoreHome >= scoreAway ? hId : aId;
+  const simOutputs = {
+    home: buildTeamSimOutputs(result.boxScore?.home ?? {}, result?.simFactors?.home ?? {}),
+    away: buildTeamSimOutputs(result.boxScore?.away ?? {}, result?.simFactors?.away ?? {}),
+  };
+  const winnerMetrics = winnerId === hId ? simOutputs.home : simOutputs.away;
+  const loserMetrics = winnerId === hId ? simOutputs.away : simOutputs.home;
+  const recapThreeSentence = buildThreeSentenceRecap({
+    winnerAbbr: winnerId === hId ? archiveContext.homeAbbr : archiveContext.awayAbbr,
+    loserAbbr: winnerId === hId ? archiveContext.awayAbbr : archiveContext.homeAbbr,
+    winnerMetrics,
+    loserMetrics,
+    scoreHome,
+    scoreAway,
+    homeAbbr: archiveContext.homeAbbr,
+  });
   const whyWon = summarizeWhyTeamWon({
     winnerAbbr: winnerId === hId ? archiveContext.homeAbbr : archiveContext.awayAbbr,
     loserAbbr: winnerId === hId ? archiveContext.awayAbbr : archiveContext.homeAbbr,
@@ -2290,7 +2354,7 @@ function applyGameResultToCache(result, week, seasonId) {
     awayId: aId,
     winnerId,
   });
-  const storyline = result.storyline ?? buildGameNarrativeSummary({
+  const storyline = result.storyline ?? recapThreeSentence ?? buildGameNarrativeSummary({
     homeTeam: { id: hId, abbr: archiveContext.homeAbbr },
     awayTeam: { id: aId, abbr: archiveContext.awayAbbr },
     homeScore: scoreHome,
@@ -2404,6 +2468,8 @@ function applyGameResultToCache(result, week, seasonId) {
       margin,
       gameScript,
       whyWon,
+      simOutputs,
+      recapThreeSentence,
       leaders: playerLeaders?.categories ?? null,
       playerOfGame: playerLeaders?.playerOfGame ?? null,
       standoutPerformances: playerLeaders?.standouts ?? [],


### PR DESCRIPTION
### Motivation
- Provide a lightweight drive-based pseudo play-by-play engine that produces richer, explainable results while keeping the sim fast and deterministic. 
- Surface a small set of actionable metrics (QB rating, rushing YPC, turnovers, sacks) and a short recap so UI and archives can explain why a team won without adding snap-by-snap complexity.

### Description
- Extended the drive engine in `src/core/game-simulator.js` by adding `computeTeamEfficiencyProfile` and integrating QB efficiency, rushing efficiency, and pass-rush vs pass-block effects into per-drive scoring and turnover weighting, and added a `simFactors` payload to game results. 
- Added worker-side aggregation in `src/worker/worker.js` that computes per-team `simOutputs` (QB rating, rushing YPC, turnovers, sacks), builds a deterministic 3-sentence recap (`recapThreeSentence`) and stores both under the archived game `summary`. 
- Updated `src/ui/components/BoxScore.jsx` to show a compact comparison of the new sim outputs in the game recap area with null-safe access so older archives render unchanged. 
- Preserved compatibility by making all fields additive (`simFactors`, `summary.simOutputs`, `summary.recapThreeSentence`) and keeping existing routes and schedule/result flows intact.

### Testing
- Ran unit tests via `npm run test:unit -- src/core/__tests__/game-simulator.test.js src/core/__tests__/gameSummary.test.js` and all tests passed (12/12). 
- Ran a production build with `npm run build` which completed successfully. 
- Performed seeded smoke simulations locally to validate determinism and that the new `simFactors`/`simOutputs` propagate into archived summaries and the Box Score UI; no automated test failures occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dafda8a564832d99553907e5805560)