### PR TITLE
Fix v5.1 save integrity: roster hydration, cap & ratings repair, and news dedupe

### DIFF
--- a/src/db/cache.js
+++ b/src/db/cache.js
@@ -152,7 +152,16 @@ export const cache = {
 
   getPlayer:    (id)     => (id != null) ? (_players.get(String(id)) ?? null) : null,
   getAllPlayers: ()       => [..._players.values()],
-  getPlayersByTeam: (teamId) => [..._players.values()].filter(p => p.teamId === teamId),
+  getPlayersByTeam: (teamId) => {
+    const targetNum = Number(teamId);
+    const targetStr = String(teamId);
+    return [..._players.values()].filter((p) => {
+      if (p?.teamId == null) return false;
+      if (p.teamId === teamId) return true;
+      if (String(p.teamId) === targetStr) return true;
+      return Number.isFinite(targetNum) && Number(p.teamId) === targetNum;
+    });
+  },
   setPlayer:    (player) => {
     if (!player || player.id == null) return;
     _players.set(String(player.id), player);

--- a/src/state/saveSchema.js
+++ b/src/state/saveSchema.js
@@ -1,4 +1,4 @@
-export const CURRENT_SAVE_SCHEMA_VERSION = 5;
+export const CURRENT_SAVE_SCHEMA_VERSION = 5.1;
 
 function migratePreVersioned(meta = {}) {
   return {
@@ -40,6 +40,7 @@ const MIGRATIONS = {
   2: migrateV2ToV3,
   3: migrateV3ToV4,
   4: migrateV4ToV5,
+  5: migrateV5ToV51,
 };
 
 function migrateV4ToV5(meta = {}) {
@@ -61,6 +62,15 @@ function migrateV4ToV5(meta = {}) {
     ...meta,
     resultsByWeek: normalizedResultsByWeek,
     saveVersion: 5,
+  };
+}
+
+function migrateV5ToV51(meta = {}) {
+  return {
+    ...meta,
+    // v5.1 is a non-destructive repair marker. Actual repair work (roster/cap
+    // hydration) runs in the worker at load-time so no user data is wiped.
+    saveVersion: 5.1,
   };
 }
 

--- a/src/ui/components/LeagueHub.jsx
+++ b/src/ui/components/LeagueHub.jsx
@@ -44,9 +44,15 @@ export default function LeagueHub({ league, actions, onOpenGameDetail, onPlayerS
   }, [teams]);
 
   const featuredGames = useMemo(() => {
-    const games = Array.isArray(league?.schedule) ? league.schedule : [];
-    return [...games].reverse().filter((g) => Number(g.homeScore ?? -1) >= 0 && Number(g.awayScore ?? -1) >= 0).slice(0, 3);
-  }, [league?.schedule]);
+    const weeks = Array.isArray(league?.schedule?.weeks) ? league.schedule.weeks : [];
+    const allGames = weeks.flatMap((weekRow) => (
+      (weekRow?.games ?? []).map((g) => ({ ...g, week: Number(weekRow?.week ?? g?.week ?? 0) }))
+    ));
+    return allGames
+      .filter((g) => g?.played || (Number(g.homeScore ?? -1) >= 0 && Number(g.awayScore ?? -1) >= 0))
+      .sort((a, b) => Number(b.week ?? 0) - Number(a.week ?? 0))
+      .slice(0, 3);
+  }, [league?.schedule?.weeks]);
 
   return (
     <div>

--- a/src/ui/utils/coachingIdentity.js
+++ b/src/ui/utils/coachingIdentity.js
@@ -240,9 +240,10 @@ export function buildCoachingNarrativeCards(league, { limit = 4 } = {}) {
     const tenure = toTenureYears(hc);
 
     if (!hc) {
+      const record = `${wins}-${losses}${ties ? `-${ties}` : ''}`;
       cards.push({
         id: `coach-vacant-${team.id}`,
-        title: `${team.abbr ?? team.name} still searching for sideline identity`,
+        title: `${team.abbr ?? team.name} (${record}) still searching for sideline identity`,
         detail: 'Head-coach seat is unsettled and coordinators are operating under interim pressure.',
         priority: 92,
         tone: 'danger',

--- a/src/ui/utils/completedGameSelectors.js
+++ b/src/ui/utils/completedGameSelectors.js
@@ -2,21 +2,47 @@ import { resolveCompletedGameId } from './gameResultIdentity.js';
 import { deriveBoxScoreImmersion, derivePostgameStory, normalizeTeamId } from './gamePresentation.js';
 
 export function findLatestUserCompletedGame(league) {
-  const targetWeek = Number(league?.week ?? 1) - 1;
-  if (!league?.seasonId || targetWeek < 1) return null;
-  const weekData = league?.schedule?.weeks?.find((w) => Number(w?.week) === targetWeek);
-  const game = (weekData?.games ?? []).find((g) => {
-    const homeId = normalizeTeamId(g?.home);
-    const awayId = normalizeTeamId(g?.away);
-    return g?.played && (homeId === league?.userTeamId || awayId === league?.userTeamId);
-  });
-  if (!game) return null;
-  const gameId = resolveCompletedGameId(game, { seasonId: league.seasonId, week: targetWeek });
+  const currentWeek = Number(league?.week ?? 1);
+  if (!league?.seasonId || currentWeek < 1) return null;
+  const userTeamId = Number(league?.userTeamId);
+  const weeks = Array.isArray(league?.schedule?.weeks) ? league.schedule.weeks : [];
+
+  let chosenWeek = null;
+  let game = null;
+  for (let week = currentWeek - 1; week >= 1; week -= 1) {
+    const weekData = weeks.find((w) => Number(w?.week) === week);
+    const userGame = (weekData?.games ?? []).find((g) => {
+      const homeId = Number(normalizeTeamId(g?.home));
+      const awayId = Number(normalizeTeamId(g?.away));
+      return g?.played && (homeId === userTeamId || awayId === userTeamId);
+    });
+    if (userGame) {
+      chosenWeek = week;
+      game = userGame;
+      break;
+    }
+  }
+
+  // Fallback: latest league result if the user's latest week had a bye.
+  if (!game) {
+    for (let week = currentWeek - 1; week >= 1; week -= 1) {
+      const weekData = weeks.find((w) => Number(w?.week) === week);
+      const latestGame = (weekData?.games ?? []).find((g) => g?.played);
+      if (latestGame) {
+        chosenWeek = week;
+        game = latestGame;
+        break;
+      }
+    }
+  }
+
+  if (!game || chosenWeek == null) return null;
+  const gameId = resolveCompletedGameId(game, { seasonId: league.seasonId, week: chosenWeek });
   return {
-    week: targetWeek,
+    week: chosenWeek,
     game,
     gameId,
-    story: derivePostgameStory({ league, game, week: targetWeek }),
-    immersion: deriveBoxScoreImmersion({ league, game, week: targetWeek }),
+    story: derivePostgameStory({ league, game, week: chosenWeek }),
+    immersion: deriveBoxScoreImmersion({ league, game, week: chosenWeek }),
   };
 }

--- a/src/ui/utils/leagueNarratives.js
+++ b/src/ui/utils/leagueNarratives.js
@@ -340,7 +340,7 @@ export function buildStorylineCards(league) {
       category: 'major_result',
       priority: 91,
       tone: 'warning',
-      title: `Statement win from Week ${honors.week}`,
+      title: `Statement win (Week ${honors.week}): ${honors.statementWin.headline}`,
       detail: honors.statementWin.detail,
       tab: 'Schedule',
     });
@@ -393,6 +393,14 @@ export function buildStorylineCards(league) {
 
 export function buildNarrativeNewsItems(league) {
   const stories = buildStorylineCards(league);
+  const seenHeadlinesByWeek = new Set();
+  const keepUniqueHeadline = (item) => {
+    const key = `${Number(item?.week ?? league?.week ?? 0)}::${String(item?.headline ?? '').trim().toLowerCase()}`;
+    if (!item?.headline || seenHeadlinesByWeek.has(key)) return false;
+    seenHeadlinesByWeek.add(key);
+    return true;
+  };
+
   const storyItems = stories.map((s, idx) => ({
     id: `story-${s.id}`,
     headline: s.title,
@@ -406,7 +414,7 @@ export function buildNarrativeNewsItems(league) {
     category: s.category,
     sortWeight: 500 - idx,
     tab: s.tab,
-  }));
+  })).filter(keepUniqueHeadline);
 
   const weekly = deriveWeeklyHonors(league);
   const weeklyItems = [];
@@ -446,5 +454,5 @@ export function buildNarrativeNewsItems(league) {
     });
   }
 
-  return [...weeklyItems, ...storyItems];
+  return [...weeklyItems, ...storyItems].filter(keepUniqueHeadline);
 }

--- a/src/ui/utils/weeklyContext.js
+++ b/src/ui/utils/weeklyContext.js
@@ -118,10 +118,17 @@ export function evaluateWeeklyContext(league) {
   const direction = classifyDirection(userTeam, week);
   const intel = buildTeamIntelligence(userTeam, { week });
   const contractMarket = league?.contractMarket ?? null;
-  const storylineCards = [
+  const rawStorylineCards = [
     ...buildStorylineCards(league),
     ...(Array.isArray(league?.seasonStorylines) ? league.seasonStorylines : []),
-  ].slice(0, 8);
+  ];
+  const seenStoryHeadlines = new Set();
+  const storylineCards = rawStorylineCards.filter((card) => {
+    const headline = String(card?.title ?? '').trim().toLowerCase();
+    if (!headline || seenStoryHeadlines.has(headline)) return false;
+    seenStoryHeadlines.add(headline);
+    return true;
+  }).slice(0, 8);
   const chemistry = intel?.chemistry;
   const investments = franchiseInvestmentSummary(userTeam);
 

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -221,6 +221,103 @@ function getTeamRosterDepth(teamId) {
   return depth;
 }
 
+function resolvePlayerTeamId(player) {
+  const num = Number(player?.teamId);
+  if (Number.isFinite(num)) return num;
+  if (typeof player?.teamId === 'string' && player.teamId.trim()) return player.teamId.trim();
+  return null;
+}
+
+function averageOvr(players = []) {
+  const rows = players.filter((p) => Number.isFinite(Number(p?.ovr)));
+  if (!rows.length) return 0;
+  return Math.round(rows.reduce((sum, p) => sum + Number(p.ovr), 0) / rows.length);
+}
+
+function deriveTeamUnitRatings(teamId) {
+  const roster = cache.getPlayersByTeam(teamId);
+  const posBuckets = {
+    QB: [], RB: [], WR: [], TE: [], OL: [],
+    DL: [], LB: [], DB: [],
+  };
+  for (const p of roster) {
+    const pos = String(p?.pos ?? '').toUpperCase();
+    if (pos === 'QB') posBuckets.QB.push(p);
+    else if (['RB', 'HB', 'FB'].includes(pos)) posBuckets.RB.push(p);
+    else if (['WR', 'FL', 'SE'].includes(pos)) posBuckets.WR.push(p);
+    else if (pos === 'TE') posBuckets.TE.push(p);
+    else if (['OL', 'OT', 'LT', 'RT', 'OG', 'LG', 'RG', 'C', 'T', 'G'].includes(pos)) posBuckets.OL.push(p);
+    else if (['DL', 'DE', 'DT', 'EDGE', 'NT', 'IDL'].includes(pos)) posBuckets.DL.push(p);
+    else if (['LB', 'MLB', 'OLB', 'ILB'].includes(pos)) posBuckets.LB.push(p);
+    else if (['DB', 'CB', 'S', 'SS', 'FS', 'NCB'].includes(pos)) posBuckets.DB.push(p);
+  }
+
+  const pickTop = (rows, count) => [...rows].sort((a, b) => Number(b?.ovr ?? 0) - Number(a?.ovr ?? 0)).slice(0, count);
+  const offenseStarters = [
+    ...pickTop(posBuckets.QB, 1),
+    ...pickTop(posBuckets.RB, 1),
+    ...pickTop(posBuckets.WR, 3),
+    ...pickTop(posBuckets.TE, 1),
+    ...pickTop(posBuckets.OL, 5),
+  ];
+  const defenseStarters = [
+    ...pickTop(posBuckets.DL, 4),
+    ...pickTop(posBuckets.LB, 3),
+    ...pickTop(posBuckets.DB, 4),
+  ];
+
+  const off = averageOvr(offenseStarters);
+  const def = averageOvr(defenseStarters);
+  return {
+    offenseRating: off,
+    defenseRating: def,
+    offRating: off,
+    defRating: def,
+    offOvr: off,
+    defOvr: def,
+  };
+}
+
+function repairRosterAndTeamLinks({ reason = 'load' } = {}) {
+  let repairedTeams = 0;
+  const teams = cache.getAllTeams();
+  for (const team of teams) {
+    const teamId = Number(team?.id);
+    if (!Number.isFinite(teamId)) continue;
+
+    const rosterFromPool = cache.getPlayersByTeam(teamId);
+    const rosterIds = Array.isArray(team?.rosterIds) ? team.rosterIds : [];
+    if (!rosterFromPool.length && rosterIds.length) {
+      for (const pid of rosterIds) {
+        const player = cache.getPlayer(pid);
+        if (!player) continue;
+        if (resolvePlayerTeamId(player) !== teamId) cache.updatePlayer(player.id, { teamId });
+      }
+    }
+
+    const repairedRoster = cache.getPlayersByTeam(teamId);
+    const shouldRepair = (team?.roster ?? []).length === 0 && (Number(team?.rosterCount ?? 0) >= 53 || repairedRoster.length >= 53);
+    if (shouldRepair || repairedRoster.length !== (team?.roster ?? []).length) {
+      cache.updateTeam(teamId, {
+        roster: repairedRoster,
+        rosterIds: repairedRoster.map((p) => p.id),
+        rosterCount: repairedRoster.length,
+        ...deriveTeamUnitRatings(teamId),
+      });
+      repairedTeams += 1;
+    } else {
+      cache.updateTeam(teamId, deriveTeamUnitRatings(teamId));
+    }
+  }
+
+  if (repairedTeams > 0) {
+    post(toUI.NOTIFICATION, {
+      level: 'info',
+      message: `Repaired roster links for ${repairedTeams} team${repairedTeams === 1 ? '' : 's'} (${reason}).`,
+    });
+  }
+}
+
 function buildTeamContractSnapshot(teamId) {
   const team = cache.getTeam(teamId);
   const roster = cache.getPlayersByTeam(teamId);
@@ -315,7 +412,9 @@ let meta = getSafeMeta();
 function buildViewState() {
   const meta = getSafeMeta();
   const tradeDeadline = getTradeDeadlineSnapshot(meta);
-  const teams = cache.getAllTeams().map(t => ({
+  const teams = cache.getAllTeams().map(t => {
+    const roster = cache.getPlayersByTeam(t.id);
+    return ({
     id:        t.id,
     name:      t.name,
     abbr:      t.abbr,
@@ -330,7 +429,14 @@ function buildViewState() {
     capRoom:   t.capRoom   ?? 0,
     capTotal:  t.capTotal  ?? Constants.SALARY_CAP.HARD_CAP,
     ovr:       t.ovr       ?? 75,
-    rosterCount: cache.getPlayersByTeam(t.id).length,
+    offenseRating: t.offenseRating ?? t.offRating ?? t.offOvr ?? 0,
+    defenseRating: t.defenseRating ?? t.defRating ?? t.defOvr ?? 0,
+    offRating: t.offRating ?? t.offenseRating ?? t.offOvr ?? 0,
+    defRating: t.defRating ?? t.defenseRating ?? t.defOvr ?? 0,
+    offOvr: t.offOvr ?? t.offenseRating ?? t.offRating ?? 0,
+    defOvr: t.defOvr ?? t.defenseRating ?? t.defRating ?? 0,
+    rosterCount: roster.length,
+    roster,
     fanApproval: t?.fanApproval ?? 50,
     franchiseInvestments: normalizeFranchiseInvestments(t?.franchiseInvestments),
     rivalTeamId: t?.rivalTeamId ?? null,
@@ -345,7 +451,8 @@ function buildViewState() {
         compensatoryForName: pk?.compensatoryForName ?? null,
       }))
       : [],
-  }));
+  });
+  });
 
   // Calculate tension/stakes for the user's next game
   let nextGameStakes = 0;
@@ -1120,10 +1227,11 @@ async function handleLoadSave({ leagueId }, id) {
       // Recalculate cap for every team so legacy saves (where players stored
       // salary as flat fields rather than inside a contract object) display
       // the correct Cap Used / Cap Room values immediately on load.
+      repairRosterAndTeamLinks({ reason: 'load-save' });
       for (const team of cache.getAllTeams()) {
         recalculateTeamCap(team.id);
         const normalizedStaff = ensureTeamStaff(team, { year: Number(meta?.year ?? 2025) });
-        cache.updateTeam(team.id, { staff: normalizedStaff });
+        cache.updateTeam(team.id, { staff: normalizedStaff, ...deriveTeamUnitRatings(team.id) });
       }
 
       // Migration/defaulting for league customization + commissioner metadata.
@@ -3399,6 +3507,12 @@ async function handleImportSave({ data, saveName }, id) {
       news: await News.latest(200),
       availableCoaches: meta?.availableCoaches ?? [],
     });
+    repairRosterAndTeamLinks({ reason: 'import-save' });
+    for (const team of cache.getAllTeams()) {
+      recalculateTeamCap(team.id);
+      cache.updateTeam(team.id, deriveTeamUnitRatings(team.id));
+    }
+    await flushDirty();
     const userTeam = cache.getTeam(meta?.userTeamId);
     await Saves.save({
       id: leagueId,


### PR DESCRIPTION
### Motivation
- Repair migrated saves where team `roster` was empty while `rosterCount`/spots remained (caused roster cards to show 0 players) and cap/rating fields diverged between UI cards. 
- Ensure Off/Def unit ratings are derived from starters and surfaced to the UI so `OVR / OFF / DEF` readouts are meaningful. 
- Reduce repeated weekly headlines and make generated narratives reference specific game/team context to avoid duplicate news items.

### Description
- Bumped save schema to `v5.1` (non-destructive marker) and added load-time repair flow to run without wiping user data (`src/state/saveSchema.js`).
- Make `cache.getPlayersByTeam()` tolerant of string/number `teamId` mismatches so player→team lookups succeed across save versions (`src/db/cache.js`).
- Add a worker-side repair routine `repairRosterAndTeamLinks()` that repopulates `team.roster`, `team.rosterIds`, and `rosterCount` from the canonical player pool (using saved `rosterIds` as a fallback) and run it on save `load` and `import` (`src/worker/worker.js`).
- Unify cap bookkeeping by recalculating each team via existing `recalculateTeamCap()` after repair so `capUsed`/`capRoom` come from active contracts (worker changes in `src/worker/worker.js`).
- Derive OFF/DEF unit ratings from starter buckets (QB/RB/WR/TE/OL and DL/LB/DB), persist on team objects, and include them in the view-state payload so HQ/Summary show consistent `OFF/DEF` values (`src/worker/worker.js`).
- Hydrate view-state `teams` with `roster` and rating fields so `Team Snapshot` shows the real roster and ratings (`src/worker/worker.js`).
- Fix latest result selection to scan backward by week and fallback to the latest league game if user had a bye so `Last Game`/featured games show recent results (`src/ui/utils/completedGameSelectors.js` and `src/ui/components/LeagueHub.jsx`).
- Add per-week headline dedupe and headline enrichment (unique record in coaching vacancy headline and richer statement-win headline) to stop verbatim duplicates and make templates distinct (`src/ui/utils/leagueNarratives.js`, `src/ui/utils/weeklyContext.js`, `src/ui/utils/coachingIdentity.js`).
- Files changed (why in one line each): `src/state/saveSchema.js` (bump schema v5.1 marker), `src/db/cache.js` (teamId lookup tolerance), `src/worker/worker.js` (repair hydration, ratings, view-state hydration, run-on-load/import), `src/ui/utils/completedGameSelectors.js` (robust last-game selector), `src/ui/components/LeagueHub.jsx` (featured games from schedule weeks), `src/ui/utils/leagueNarratives.js` (news dedupe + enriched headlines), `src/ui/utils/weeklyContext.js` (storyline dedupe), `src/ui/utils/coachingIdentity.js` (vary sideline identity headline).

### Testing
- Ran production build with `npm run build` and it completed successfully (`vite build` passed). 
- Ran unit suite with `npm run test:unit` (`vitest run`) and observed multiple pre-existing unrelated failures (Playwright-spec vs Vitest execution collisions and several baseline unit expectation mismatches) which are not introduced by this patch; the test run demonstrates the repository has unrelated failing suites. 
- Attempted `npm run test:unit -- --runInBand` and the `--runInBand` flag is unsupported by `vitest` resulting in an immediate error; the correct `vitest` invocation was used above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db0614ce50832db296b6e576fe1c35)