### PR TITLE
Fix Playwright Regression Test Suite and Roster Component Crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "vite": "^7.3.2"
       },
       "devDependencies": {
-        "@playwright/test": "^1.58.2",
+        "@playwright/test": "^1.59.1",
         "@vitejs/plugin-react": "^5.1.4",
         "playwright": "^1.58.2",
         "vitest": "^3.2.4"
@@ -831,13 +831,13 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3187,13 +3187,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3206,9 +3206,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "vite": "^7.3.2"
   },
   "devDependencies": {
-    "@playwright/test": "^1.58.2",
+    "@playwright/test": "^1.59.1",
     "@vitejs/plugin-react": "^5.1.4",
     "playwright": "^1.58.2",
     "vitest": "^3.2.4"

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -2013,6 +2013,8 @@ function PlayerCardGrid({ players, onPlayerSelect, phase, team, week, initialFil
 // ── Main Component ────────────────────────────────────────────────────────────
 
 export default function Roster({ league, actions, onPlayerSelect, initialState = null, initialViewMode = "table" }) {
+  const [initialFilter, setInitialFilter] = useState(initialState?.filter || "ALL");
+
   const teamId = league?.userTeamId;
 
   const [loading, setLoading] = useState(false);

--- a/tests/daily_regression.spec.js
+++ b/tests/daily_regression.spec.js
@@ -13,33 +13,33 @@ test.describe('Daily Regression Pass', () => {
         await page.waitForTimeout(1000);
 
         // Handle Onboarding / Dashboard
-        const createBtn = await page.isVisible('.btn-primary:has-text("New Career"), .sm-create-btn');
-        if (createBtn) {
-            await page.click('.btn-primary:has-text("New Career"), .sm-create-btn');
-            await page.waitForSelector('.team-select-btn, .team-card', { state: 'visible' });
-            await page.locator('.team-select-btn, .team-card').first().click();
-            await page.click('button:has-text("Continue")');
+        await page.waitForTimeout(2000);
+        const startBtns = await page.locator('button:has-text("Start New Franchise")').all();
+        if(startBtns.length > 0) {
+            console.log('Clicking Start New Franchise');
+            await startBtns[0].click();
+            await page.waitForTimeout(1000);
+
+            console.log('Clicking BUF');
+            await page.locator('text=Buffalo Bills').click();
             await page.waitForTimeout(500);
-            await page.click('button:has-text("Continue")');
-            await page.waitForTimeout(500);
-            await page.click('button:has-text("Start Dynasty")');
-        } else if (await page.isVisible('button:has-text("Start Dynasty")')) {
-             // Already in setup
-            await page.click('button:has-text("Start Dynasty")');
-        } else if (await page.isVisible('.team-select-btn, .team-card')) {
-             // Already in setup
-            await page.locator('.team-select-btn, .team-card').first().click();
-            await page.click('button:has-text("Continue")');
-            await page.waitForTimeout(500);
-            await page.click('button:has-text("Continue")');
-            await page.waitForTimeout(500);
-            await page.click('button:has-text("Start Dynasty")');
+
+            console.log('Clicking Continue 1');
+            await page.locator('button:has-text("Continue")').click();
+            await page.waitForTimeout(1000);
+
+            console.log('Clicking Continue 2');
+            await page.locator('button:has-text("Continue")').click();
+            await page.waitForTimeout(1000);
+
+            console.log('Clicking Start Dynasty');
+            await page.locator('button:has-text("Start Dynasty")').click();
+            await page.waitForTimeout(2000);
         } else {
-            // Assuming already in game or hub
             console.log('Assuming game already loaded...');
         }
 
-        await page.waitForFunction(() => document.querySelector('.app-header') !== null, null, { timeout: 60000 });
+        await page.waitForSelector('.app-header', { state: 'visible', timeout: 30000 });
         const hubVisible = await page.isVisible('.app-header');
         expect(hubVisible).toBeTruthy();
 
@@ -89,16 +89,25 @@ test.describe('Daily Regression Pass', () => {
 
         // Ensure game loaded
         await page.waitForFunction(() => window.gameController !== undefined);
-        await page.evaluate(async () => {
-            if (!window.state?.league) {
-                await window.gameController.startNewLeague();
-            }
-        });
+        await page.waitForTimeout(2000);
+        const startBtns = await page.locator('button:has-text("Start New Franchise")').all();
+        if(startBtns.length > 0) {
+            await startBtns[0].click();
+            await page.waitForTimeout(1000);
+            await page.locator('text=Buffalo Bills').click();
+            await page.waitForTimeout(500);
+            await page.locator('button:has-text("Continue")').click();
+            await page.waitForTimeout(1000);
+            await page.locator('button:has-text("Continue")').click();
+            await page.waitForTimeout(1000);
+            await page.locator('button:has-text("Start Dynasty")').click();
+            await page.waitForTimeout(2000);
+        }
         await page.waitForSelector('.app-header', { state: 'visible', timeout: 30000 });
 
         // 1. Test Strategy Persistence
         // Switch to the Strategy tab
-        await page.click('.dashboard-main-tabs button.standings-tab:has-text("Strategy")', { force: true });
+        await page.click('button:has-text("Game Plan")', { force: true });
         await page.waitForTimeout(500); // wait for tab render
 
         // The first <select> on the Strategy panel is typically the Offensive Scheme
@@ -157,11 +166,20 @@ test.describe('Daily Regression Pass', () => {
         // Ensure game is loaded (helper)
         await page.waitForTimeout(1000);
         await page.waitForFunction(() => window.gameController !== undefined);
-        await page.evaluate(async () => {
-            if (!window.state?.league) {
-                await window.gameController.startNewLeague();
-            }
-        });
+        await page.waitForTimeout(2000);
+        const startBtns = await page.locator('button:has-text("Start New Franchise")').all();
+        if(startBtns.length > 0) {
+            await startBtns[0].click();
+            await page.waitForTimeout(1000);
+            await page.locator('text=Buffalo Bills').click();
+            await page.waitForTimeout(500);
+            await page.locator('button:has-text("Continue")').click();
+            await page.waitForTimeout(1000);
+            await page.locator('button:has-text("Continue")').click();
+            await page.waitForTimeout(1000);
+            await page.locator('button:has-text("Start Dynasty")').click();
+            await page.waitForTimeout(2000);
+        }
         await page.waitForFunction(() => window.state && window.state.league);
         try {
             await page.waitForSelector('.app-header', { state: 'visible', timeout: 60000 });
@@ -173,7 +191,7 @@ test.describe('Daily Regression Pass', () => {
 
         // Check Power Rankings Scroll (Standings Tab)
         await page.evaluate(() => {
-            const btn = Array.from(document.querySelectorAll('.dashboard-main-tabs button.standings-tab')).find(b => b.innerText.trim() === 'Standings');
+            const btn = Array.from(document.querySelectorAll('button')).find(b => b.innerText.trim() === 'Standings');
             if (btn) btn.click();
         });
         await page.waitForTimeout(500);
@@ -187,7 +205,7 @@ test.describe('Daily Regression Pass', () => {
 
         // Check League Stats Scroll (Stats Tab)
         await page.evaluate(() => {
-            const btn = Array.from(document.querySelectorAll('.dashboard-main-tabs button.standings-tab')).find(b => b.innerText.trim() === 'Stats');
+            const btn = Array.from(document.querySelectorAll('button')).find(b => b.innerText.trim() === 'Stats');
             if (btn) btn.click();
         });
         await page.waitForTimeout(500);
@@ -201,7 +219,7 @@ test.describe('Daily Regression Pass', () => {
 
         // Check Roster Scroll
         await page.evaluate(() => {
-            const btn = Array.from(document.querySelectorAll('.dashboard-main-tabs button.standings-tab')).find(b => b.innerText.trim() === 'Roster');
+            const btn = Array.from(document.querySelectorAll('button')).find(b => b.innerText.trim() === 'Roster');
             if (btn) btn.click();
         });
         await page.waitForTimeout(500);
@@ -225,17 +243,26 @@ test.describe('Daily Regression Pass', () => {
         // Force new league to ensure cap space
         await page.waitForTimeout(1000);
         await page.waitForFunction(() => window.gameController !== undefined);
-        await page.evaluate(async () => {
-            if (!window.state?.league) {
-                await window.gameController.startNewLeague();
-            }
-        });
+        await page.waitForTimeout(2000);
+        const startBtns = await page.locator('button:has-text("Start New Franchise")').all();
+        if(startBtns.length > 0) {
+            await startBtns[0].click();
+            await page.waitForTimeout(1000);
+            await page.locator('text=Buffalo Bills').click();
+            await page.waitForTimeout(500);
+            await page.locator('button:has-text("Continue")').click();
+            await page.waitForTimeout(1000);
+            await page.locator('button:has-text("Continue")').click();
+            await page.waitForTimeout(1000);
+            await page.locator('button:has-text("Start Dynasty")').click();
+            await page.waitForTimeout(2000);
+        }
         await page.waitForFunction(() => window.state && window.state.league);
         await page.waitForSelector('.app-header', { state: 'visible', timeout: 20000 });
 
         // Release a player to ensure roster spot
         await page.evaluate(() => {
-            const btn = Array.from(document.querySelectorAll('.dashboard-main-tabs button.standings-tab')).find(b => b.innerText.trim() === 'Roster');
+            const btn = Array.from(document.querySelectorAll('button')).find(b => b.innerText.trim() === 'Roster');
             if (btn) btn.click();
         });
         await page.waitForTimeout(1000);
@@ -288,7 +315,7 @@ test.describe('Daily Regression Pass', () => {
 
         // Go to FA
         await page.evaluate(() => {
-            const btn = Array.from(document.querySelectorAll('.dashboard-main-tabs button.standings-tab')).find(b => b.innerText.trim() === 'Free Agency');
+            const btn = Array.from(document.querySelectorAll('button')).find(b => b.innerText.trim() === 'Free Agency');
             if (btn) btn.click();
         });
         await page.waitForTimeout(1000);
@@ -362,11 +389,20 @@ test.describe('Daily Regression Pass', () => {
         // Force state with a finalized game
         await page.waitForTimeout(1000);
         await page.waitForFunction(() => window.gameController !== undefined);
-        await page.evaluate(async () => {
-            if (!window.state?.league) {
-                await window.gameController.startNewLeague();
-            }
-        });
+        await page.waitForTimeout(2000);
+        const startBtns = await page.locator('button:has-text("Start New Franchise")').all();
+        if(startBtns.length > 0) {
+            await startBtns[0].click();
+            await page.waitForTimeout(1000);
+            await page.locator('text=Buffalo Bills').click();
+            await page.waitForTimeout(500);
+            await page.locator('button:has-text("Continue")').click();
+            await page.waitForTimeout(1000);
+            await page.locator('button:has-text("Continue")').click();
+            await page.waitForTimeout(1000);
+            await page.locator('button:has-text("Start Dynasty")').click();
+            await page.waitForTimeout(2000);
+        }
         await page.waitForFunction(() => window.state && window.state.league);
 
         await page.evaluate(async () => {


### PR DESCRIPTION
Addresses blockers in the Daily Regression Pass suite by fixing Playwright locators for the recent UI refactoring changes (specifically around the New Franchise initialization flow and outdated CSS class usages). Also resolves a critical `ReferenceError: setInitialFilter is not defined` bug that was breaking the table view tab within the Roster. All tests pass, ensuring game state persistence and cap logic remain trusted.

---
*PR created automatically by Jules for task [934937337025460276](https://jules.google.com/task/934937337025460276) started by @rbcati*