### PR TITLE
Stabilize roster init state and deterministic onboarding/navigation e2e

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -504,7 +504,7 @@ function AppContent() {
   const themeClass = league?.phase ? `theme-${league.phase}` : 'theme-default';
 
   return (
-    <div className={`app-shell ${isPostseason ? 'postseason' : ''} ${themeClass}`} key="league_dashboard">
+    <div className={`app-shell ${isPostseason ? 'postseason' : ''} ${themeClass}`} key="league_dashboard" data-testid="app-shell-ready">
 
       {/* Phase-based Theming */}
       <style>{`
@@ -529,7 +529,7 @@ function AppContent() {
       {isPostseason && <div className="postseason-glow" />}
 
       {/* ── Top bar ────────────────────────────────────────────────────── */}
-      <header className="app-header">
+      <header className="app-header" data-testid="app-shell-header">
         <div className="app-header-left">
           <h1 className="app-title">Football GM</h1>
           <div className="app-season-info">

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -273,6 +273,14 @@ function divIdx(val) {
   return map[val] ?? 0;
 }
 
+function toTestId(value = "") {
+  return String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
 // ── Sub-components ─────────────────────────────────────────────────────────────
 
 /** Circular team "logo" placeholder with first 3 chars of abbreviation. */
@@ -1073,6 +1081,7 @@ function ScheduleTab({
                 <>
                   <button
                     type="button"
+                    data-testid={idx === 0 ? "recent-game-box-score-trigger" : undefined}
                     className={`score-tap-target ${scoreTapHandler ? "score-tap-target-clickable" : "score-tap-target-static"}`}
                     onClick={scoreTapHandler}
                     aria-label={scoreTapHandler ? `Open box score for ${away.abbr} at ${home.abbr}` : undefined}
@@ -1918,6 +1927,7 @@ export default function LeagueDashboard({
           {NAV_GROUPS.map((group) => (
             <button
               key={group.id}
+              data-testid={`primary-nav-${toTestId(group.title)}`}
               className={`standings-tab${activeSection === group.id ? " active" : ""}`}
               onClick={() => handleSectionChange(group.id)}
               aria-current={activeSection === group.id ? "page" : undefined}
@@ -1933,6 +1943,7 @@ export default function LeagueDashboard({
             .map((tab) => (
               <button
                 key={tab}
+                data-testid={`section-tab-${toTestId(tab)}`}
                 className={`standings-tab${activeTab === tab ? " active" : ""}`}
                 onClick={() => setActiveTab(tab)}
                 aria-current={activeTab === tab ? "page" : undefined}

--- a/src/ui/components/NewLeagueSetup.jsx
+++ b/src/ui/components/NewLeagueSetup.jsx
@@ -199,7 +199,7 @@ export default function NewLeagueSetup({ actions, onCancel, onStartCreate }) {
           </div>
 
           {/* Team grid */}
-          <div className="team-grid">
+          <div className="team-grid" data-testid="team-selection-flow">
             {filteredTeams.map((team, idx) => {
               const color = teamColor(team.abbr);
               return (
@@ -606,6 +606,7 @@ export default function NewLeagueSetup({ actions, onCancel, onStartCreate }) {
           </Button>
           <Button
             id="start-career-btn"
+            data-testid={step < 2 ? "onboarding-continue-button" : "start-dynasty-button"}
             className="btn-premium btn-primary-premium"
             onClick={() => {
               if (step < 2) setStep(step + 1);

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -1636,6 +1636,17 @@ function buildExpiringDecisionSummary(players = [], context = {}) {
   return summarizeExpiring(players, context);
 }
 
+export function normalizeInitialRosterState(initialState, initialViewMode = "table") {
+  const safeState = initialState && typeof initialState === "object" ? initialState : {};
+  const safeView = ["cards", "table", "depth"].includes(safeState.view)
+    ? safeState.view
+    : (["cards", "table", "depth"].includes(initialViewMode) ? initialViewMode : "table");
+  const safeFilter = typeof safeState.filter === "string" && safeState.filter.trim()
+    ? safeState.filter.trim().toUpperCase()
+    : "ALL";
+  return { safeView, safeFilter };
+}
+
 /**
  * Single player card — tappable, opens the PlayerProfile modal via onSelect(id).
  *
@@ -2014,11 +2025,16 @@ function PlayerCardGrid({ players, onPlayerSelect, phase, team, week, initialFil
 
 export default function Roster({ league, actions, onPlayerSelect, initialState = null, initialViewMode = "table" }) {
   const teamId = league?.userTeamId;
+  const initialConfig = useMemo(
+    () => normalizeInitialRosterState(initialState, initialViewMode),
+    [initialState, initialViewMode],
+  );
 
   const [loading, setLoading] = useState(false);
   const [team, setTeam] = useState(null);
   const [players, setPlayers] = useState([]);
-  const [viewMode, setViewMode] = useState(initialViewMode); // 'cards' | 'table' | 'depth'
+  const [viewMode, setViewMode] = useState(initialConfig.safeView); // 'cards' | 'table' | 'depth'
+  const [initialFilter, setInitialFilter] = useState(initialConfig.safeFilter);
   const [selectedPlayerId, setSelectedPlayerId] = useState(null);
 
   const fetchRoster = useCallback(async () => {
@@ -2048,10 +2064,10 @@ export default function Roster({ league, actions, onPlayerSelect, initialState =
   }, [fetchRoster]);
 
   useEffect(() => {
-    if (!initialState) return;
-    if (initialState.view) setViewMode(initialState.view);
-    if (initialState.filter) setInitialFilter(initialState.filter);
-  }, [initialState]);
+    const next = normalizeInitialRosterState(initialState, initialViewMode);
+    setInitialFilter(next.safeFilter);
+    if (next.safeView) setViewMode(next.safeView);
+  }, [initialState, initialViewMode]);
 
   useEffect(() => {
     if (["cards", "table", "depth"].includes(initialViewMode)) {

--- a/src/ui/components/SaveSlotManager.jsx
+++ b/src/ui/components/SaveSlotManager.jsx
@@ -97,7 +97,7 @@ export default function SaveSlotManager({ activeSlot, onLoad, onSave, onDelete, 
               {isEmpty ? (
                 <div className="save-slot-v2__empty">
                   <p>No franchise started yet. Create a new career in this slot.</p>
-                  <Button onClick={() => onNew?.(slot.key)}>Start New Franchise</Button>
+                  <Button data-testid="start-new-franchise-cta" onClick={() => onNew?.(slot.key)}>Start New Franchise</Button>
                 </div>
               ) : (
                 <>

--- a/src/ui/components/__tests__/rosterInitialState.test.js
+++ b/src/ui/components/__tests__/rosterInitialState.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { normalizeInitialRosterState } from "../Roster.jsx";
+
+describe("normalizeInitialRosterState", () => {
+  it("falls back safely for null/partial state", () => {
+    expect(normalizeInitialRosterState(null, "table")).toEqual({ safeView: "table", safeFilter: "ALL" });
+    expect(normalizeInitialRosterState({ view: "cards" }, "table")).toEqual({ safeView: "cards", safeFilter: "ALL" });
+    expect(normalizeInitialRosterState({ filter: "injured" }, "table")).toEqual({ safeView: "table", safeFilter: "INJURED" });
+  });
+
+  it("guards invalid view values", () => {
+    expect(normalizeInitialRosterState({ view: "grid" }, "depth")).toEqual({ safeView: "depth", safeFilter: "ALL" });
+    expect(normalizeInitialRosterState({ view: "grid" }, "oops")).toEqual({ safeView: "table", safeFilter: "ALL" });
+  });
+});

--- a/tests/e2e/box_score_clickthrough.spec.js
+++ b/tests/e2e/box_score_clickthrough.spec.js
@@ -1,13 +1,12 @@
 import { test, expect } from '@playwright/test';
-import { launchFranchise, simulateSingleWeek } from './helpers/franchise.js';
+import { launchFranchise, simulateSingleWeek, goToTab } from './helpers/franchise.js';
 
 test.describe('Shared box score detail', () => {
   test('schedule score row opens Game Detail box score', async ({ page }) => {
     await launchFranchise(page);
     await simulateSingleWeek(page);
 
-    await page.getByRole('button', { name: 'Schedule' }).first().click();
-    await page.waitForTimeout(500);
+    await goToTab(page, 'schedule');
 
     await page.locator('.schedule-game-card.played, .schedule-game-card').first().click();
     await expect(page.getByText('Final Game Book').first()).toBeVisible();
@@ -18,15 +17,13 @@ test.describe('Shared box score detail', () => {
     await launchFranchise(page);
     await simulateSingleWeek(page);
 
-    await page.getByRole('button', { name: 'Schedule' }).first().click();
-    await page.waitForTimeout(400);
+    await goToTab(page, 'schedule');
     await page.locator('.schedule-game-card.played, .schedule-game-card').first().click();
     await expect(page.getByText('Final Game Book').first()).toBeVisible();
 
     await page.reload();
     await launchFranchise(page);
-    await page.getByRole('button', { name: 'Schedule' }).first().click();
-    await page.waitForTimeout(400);
+    await goToTab(page, 'schedule');
     await page.locator('.schedule-game-card.played, .schedule-game-card').first().click();
     await expect(page.getByText('Final Game Book').first()).toBeVisible();
   });

--- a/tests/e2e/core_flow_reliability.spec.js
+++ b/tests/e2e/core_flow_reliability.spec.js
@@ -1,13 +1,39 @@
 import { test, expect } from '@playwright/test';
-import { launchFranchise, simulateSingleWeek } from './helpers/franchise.js';
+import { launchFranchise, simulateSingleWeek, goToTab } from './helpers/franchise.js';
 
 test.describe('Core flow reliability', () => {
+  test('refactored shell navigation paths remain reachable', async ({ page }) => {
+    await launchFranchise(page);
+
+    await goToTab(page, 'hq');
+    await expect(page.locator('[data-testid="section-tab-hq"][aria-current="page"]')).toBeVisible();
+
+    await goToTab(page, 'roster');
+    await expect(page.getByText('Roster').first()).toBeVisible();
+
+    await goToTab(page, 'game-plan');
+    await expect(page.getByText('Game Plan').first()).toBeVisible();
+
+    await goToTab(page, 'standings');
+    await expect(page.getByText('Standings').first()).toBeVisible();
+
+    await goToTab(page, 'stats');
+    await expect(page.getByText('Player Stats').first()).toBeVisible();
+
+    await goToTab(page, 'free-agency');
+    await expect(page.getByText('Free Agency').first()).toBeVisible();
+
+    await page.locator('[data-testid="primary-nav-history"]').first().click();
+    await page.locator('[data-testid="section-tab-history-hub"]').first().click();
+    await expect(page.getByText('History Hub').first()).toBeVisible();
+  });
+
   test('weekly hub completed game opens working box score', async ({ page }) => {
     await launchFranchise(page);
     await simulateSingleWeek(page);
 
-    await page.getByRole('button', { name: 'Weekly Hub' }).first().click();
-    await page.getByRole('button', { name: /Review box score/i }).first().click();
+    await goToTab(page, 'hq');
+    await page.locator('[data-testid="recent-game-box-score-trigger"]').first().click();
     await expect(page.getByText('Final Game Book').first()).toBeVisible();
     await expect(page.getByText('Team comparison').first()).toBeVisible();
   });
@@ -16,7 +42,7 @@ test.describe('Core flow reliability', () => {
     await launchFranchise(page);
     await simulateSingleWeek(page);
 
-    await page.getByRole('button', { name: 'Schedule' }).first().click();
+    await goToTab(page, 'schedule');
     await page.locator('.matchup-card.clickable-card').first().click();
     await expect(page.getByText('Final Game Book').first()).toBeVisible();
   });
@@ -29,7 +55,7 @@ test.describe('Core flow reliability', () => {
     await page.getByRole('button', { name: /^Delete$/ }).first().click();
 
     await expect(page.getByText('This franchise slot is ready for a new dynasty.').first()).toBeVisible();
-    await page.getByRole('button', { name: /Start New Franchise/i }).first().click();
+    await page.locator('[data-testid="start-new-franchise-cta"]').first().click();
     await expect(page.getByText(/Choose your franchise/i).first()).toBeVisible();
   });
 
@@ -42,7 +68,7 @@ test.describe('Core flow reliability', () => {
     await page.waitForFunction(() => Number(window?.state?.league?.tradeDeadline?.deadlineWeek) === 1);
 
     await simulateSingleWeek(page);
-    await page.getByRole('button', { name: 'Trades' }).first().click();
+    await goToTab(page, 'transactions');
 
     await expect(page.getByText(/trade market is locked/i).first()).toBeVisible();
   });

--- a/tests/e2e/fresh_franchise_bootstrap_smoke.spec.js
+++ b/tests/e2e/fresh_franchise_bootstrap_smoke.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { launchFranchise } from './helpers/franchise.js';
+import { launchFranchise, goToTab } from './helpers/franchise.js';
 
 test('fresh franchise setup lands in playable HQ without render boundary', async ({ page }) => {
   const pageErrors = [];
@@ -17,14 +17,14 @@ test('fresh franchise setup lands in playable HQ without render boundary', async
   });
   expect(leagueReady).toBeTruthy();
 
-  await page.click('button:has-text("Transactions")').catch(() => {});
+  await goToTab(page, 'transactions');
   await expect(page.locator('text=Trade Workspace')).toBeVisible({ timeout: 10000 });
   await expect(page.locator('text=No offers right now')).toBeVisible();
 
-  await page.click('button:has-text("Roster")').catch(() => {});
+  await goToTab(page, 'roster');
   await expect(page.locator('text=Roster')).toBeVisible({ timeout: 10000 });
 
-  await page.click('button:has-text("Stats")').catch(() => {});
+  await goToTab(page, 'stats');
   await expect(page.locator('text=Player Stats')).toBeVisible({ timeout: 10000 });
 
   expect(pageErrors.join('\n')).not.toContain('leagueReady is not defined');

--- a/tests/e2e/helpers/franchise.js
+++ b/tests/e2e/helpers/franchise.js
@@ -1,32 +1,88 @@
 import { expect } from '@playwright/test';
 
+const APP_READY = '[data-testid="app-shell-ready"]';
+const SAVE_HUB_CTA = '[data-testid="start-new-franchise-cta"]';
+const ONBOARDING_CONTINUE = '[data-testid="onboarding-continue-button"]';
+const START_DYNASTY = '[data-testid="start-dynasty-button"]';
+const TEAM_SELECT = '[data-testid="team-selection-flow"]';
+
+async function detectBootstrapState(page) {
+  if (await page.locator(APP_READY).first().isVisible().catch(() => false)) return 'app_ready';
+  if (await page.locator(SAVE_HUB_CTA).first().isVisible().catch(() => false)) return 'save_hub';
+  if (await page.locator(START_DYNASTY).first().isVisible().catch(() => false)) return 'start_dynasty';
+  if (await page.locator(TEAM_SELECT).first().isVisible().catch(() => false)) return 'team_select';
+  if (await page.locator(ONBOARDING_CONTINUE).first().isVisible().catch(() => false)) return 'onboarding_continue';
+  return 'unknown';
+}
+
+export async function ensureLeagueLoaded(page) {
+  // Deterministic boot gate: wait for one known state, then branch.
+  await page.waitForFunction(() => {
+    const selectors = [
+      '[data-testid="app-shell-ready"]',
+      '[data-testid="start-new-franchise-cta"]',
+      '[data-testid="onboarding-continue-button"]',
+      '[data-testid="start-dynasty-button"]',
+      '[data-testid="team-selection-flow"]',
+    ];
+    return selectors.some((selector) => document.querySelector(selector));
+  }, { timeout: 60000 });
+
+  let state = await detectBootstrapState(page);
+  if (state === 'app_ready') {
+    await expect(page.locator(APP_READY)).toBeVisible();
+    return;
+  }
+
+  if (state === 'save_hub') {
+    await page.locator(SAVE_HUB_CTA).first().click();
+    state = await detectBootstrapState(page);
+  }
+
+  if (state === 'team_select') {
+    await page.locator(`${TEAM_SELECT} .team-card`).first().click();
+    state = await detectBootstrapState(page);
+  }
+
+  while (state === 'onboarding_continue') {
+    await page.locator(ONBOARDING_CONTINUE).first().click();
+    state = await detectBootstrapState(page);
+  }
+
+  if (state === 'start_dynasty') {
+    await page.locator(START_DYNASTY).first().click();
+  }
+
+  await expect(page.locator(APP_READY)).toBeVisible({ timeout: 60000 });
+}
+
 export async function launchFranchise(page) {
   await page.goto('http://localhost:5173');
-  await page.waitForTimeout(1000);
+  await ensureLeagueLoaded(page);
+}
 
-  const hasHeader = await page.locator('.app-header').first().isVisible().catch(() => false);
-  if (hasHeader) return;
-
-  const createVisible = await page.isVisible('.btn-primary:has-text("New Career"), .sm-create-btn').catch(() => false);
-  if (createVisible) {
-    await page.click('.btn-primary:has-text("New Career"), .sm-create-btn');
-  }
-
-  const teamCard = page.locator('.team-select-btn, .team-card').first();
-  if (await teamCard.isVisible().catch(() => false)) {
-    await teamCard.click();
-    const continueBtn = page.locator('button:has-text("Continue")');
-    const continueCount = await continueBtn.count();
-    for (let i = 0; i < Math.min(2, continueCount); i += 1) {
-      await continueBtn.nth(0).click();
-      await page.waitForTimeout(350);
+export async function goToTab(page, name) {
+  const tab = String(name).toLowerCase();
+  const sectionByTab = {
+    hq: 'hq',
+    team: 'team',
+    roster: 'team',
+    'game-plan': 'team',
+    standings: 'league',
+    schedule: 'league',
+    stats: 'league',
+    transactions: 'transactions',
+    'free-agency': 'transactions',
+    'history-hub': 'history',
+  };
+  const primary = sectionByTab[tab];
+  if (primary) {
+    const primaryLocator = page.locator(`[data-testid="primary-nav-${primary}"]`).first();
+    if (await primaryLocator.isVisible().catch(() => false)) {
+      await primaryLocator.click();
     }
-    const startBtn = page.locator('button:has-text("Start Dynasty")').first();
-    if (await startBtn.isVisible().catch(() => false)) await startBtn.click();
   }
-
-  await page.waitForSelector('.app-header', { state: 'visible', timeout: 60000 });
-  await expect(page.locator('.app-header')).toBeVisible();
+  await page.locator(`[data-testid="section-tab-${tab}"]`).first().click();
 }
 
 export async function simulateSingleWeek(page) {
@@ -36,10 +92,13 @@ export async function simulateSingleWeek(page) {
     if (btn) btn.click();
     else if (window.handleGlobalAdvance) window.handleGlobalAdvance();
   });
-  await page.waitForTimeout(900);
-  await page.evaluate(() => {
-    const skip = Array.from(document.querySelectorAll('button')).find((b) => b.innerText?.includes('Simulate (Skip)'));
-    if (skip) skip.click();
-  });
-  await page.waitForFunction((baseline) => (window?.state?.league?.week ?? baseline) > baseline, startWeek, { timeout: 90000 });
+  await page.waitForFunction(
+    (baseline) => {
+      const week = window?.state?.league?.week ?? baseline;
+      const phase = window?.state?.league?.phase;
+      return week > baseline || phase === 'offseason' || phase === 'free_agency' || phase === 'draft';
+    },
+    startWeek,
+    { timeout: 90000 },
+  );
 }


### PR DESCRIPTION
### Motivation
- Post-refactor shell/navigation changes introduced a runtime crash in the Roster flows from an undefined `setInitialFilter`/missing initial filter state and made Playwright onboarding/navigation tests flaky. 
- Tests relied on broad text selectors and fixed sleeps that are brittle after the HQ/save-hub/navigation refactor. 
- The goal is to harden the roster initialization path, add deterministic e2e bootstrapping, and provide stable selectors for navigation and onboarding without changing save behavior or project dependencies. 

### Description
- Added a safe normalizer `normalizeInitialRosterState(initialState, initialViewMode)` and wired `initialFilter` into `Roster` so `initialState` can be null/partial and view/filter values are validated; exported the helper for unit tests (`src/ui/components/Roster.jsx`).
- Added a unit test for the normalizer covering null, partial, and invalid view fallbacks (`src/ui/components/__tests__/rosterInitialState.test.js`).
- Introduced deterministic Playwright helpers `ensureLeagueLoaded`, `launchFranchise`, `goToTab`, and a refined `simulateSingleWeek` that wait for explicit app states and avoid arbitrary sleeps (`tests/e2e/helpers/franchise.js`).
- Added stable `data-testid` hooks for critical anchors: app shell ready/header, start new franchise CTA, onboarding continue / start dynasty buttons, team selection flow, primary nav groups, section tabs, and recent-game box score trigger (`src/ui/App.jsx`, `src/ui/components/SaveSlotManager.jsx`, `src/ui/components/NewLeagueSetup.jsx`, `src/ui/components/LeagueDashboard.jsx`).
- Updated e2e specs to use the new helpers and stable test ids instead of generic text/button searches and fixed waits (`tests/e2e/core_flow_reliability.spec.js`, `tests/e2e/fresh_franchise_bootstrap_smoke.spec.js`, `tests/e2e/box_score_clickthrough.spec.js`).
- Kept changes focused to test hooks, guards, and small UI test attributes; no architecture or dependency upgrades were performed to preserve existing saves and behavior. 

### Testing
- Ran unit tests: `npm run test:unit -- src/ui/components/__tests__/rosterInitialState.test.js src/ui/components/__tests__/freshSaveScreens.test.jsx` and all tests passed (2 files, 7 tests total) ✅.
- Attempted Playwright run: `npx playwright test tests/e2e/core_flow_reliability.spec.js --reporter=line` but the environment lacked installed Playwright browser binaries so the run failed with a missing executable error (please run `npx playwright install` in CI / local environment to execute e2e) ⚠️.
- The patch is narrowly scoped to make e2e flows deterministic and to prevent the `setInitialFilter` crash; manual/CI Playwright validation is required in an environment with browser binaries installed to confirm full e2e pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc307fc384832d85f9eec6fc938fde)