### PR TITLE
League economy + contract realism: cap growth, inflation, restructures, FA playbook continuity

### DIFF
--- a/src/core/__tests__/economy.test.js
+++ b/src/core/__tests__/economy.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeLeagueEconomy, projectNextSeasonEconomy, getSalaryInflationMultiplier, inflateContract } from '../economy.js';
+
+describe('league economy progression', () => {
+  it('grows salary cap each season with deterministic defaults', () => {
+    const e1 = normalizeLeagueEconomy({ baseSalaryCap: 300, currentSalaryCap: 300, annualCapGrowthRate: 0.03 }, { year: 2026 });
+    const e2 = projectNextSeasonEconomy(e1, 2027);
+    expect(e2.currentSalaryCap).toBe(309);
+    expect(e2.economyHistory.some((r) => r.season === 2027 && r.salaryCap === 309)).toBe(true);
+  });
+
+  it('inflates newly generated contracts using cap multiplier', () => {
+    const mult = getSalaryInflationMultiplier({ baseSalaryCap: 300, currentSalaryCap: 330 });
+    const contract = inflateContract({ baseAnnual: 20, signingBonus: 10 }, mult);
+    expect(contract.baseAnnual).toBe(22);
+    expect(contract.signingBonus).toBe(11);
+  });
+});

--- a/src/core/__tests__/restructure.test.js
+++ b/src/core/__tests__/restructure.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { computeRestructureOutcome, shouldPreserveChemistryOnReturn } from '../contracts/restructure.js';
+
+describe('contract restructure baseline', () => {
+  it('reduces current cap hit and increases future prorated burden', () => {
+    const out = computeRestructureOutcome({ years: 3, yearsTotal: 3, baseAnnual: 18, signingBonus: 6 }, 0.5);
+    expect(out.oldCapHit).toBe(20);
+    expect(out.newCapHit).toBe(14);
+    expect(out.capSavingsThisYear).toBe(6);
+    expect(out.futureAnnualBonusDelta).toBe(3);
+  });
+});
+
+describe('offseason chemistry continuity', () => {
+  it('preserves continuity only for same team and same offseason season', () => {
+    const releaseRecord = { teamId: 4, season: 2028 };
+    expect(shouldPreserveChemistryOnReturn({ releaseRecord, signingTeamId: 4, currentSeason: 2028 })).toBe(true);
+    expect(shouldPreserveChemistryOnReturn({ releaseRecord, signingTeamId: 5, currentSeason: 2028 })).toBe(false);
+    expect(shouldPreserveChemistryOnReturn({ releaseRecord, signingTeamId: 4, currentSeason: 2029 })).toBe(false);
+  });
+});

--- a/src/core/contracts/restructure.js
+++ b/src/core/contracts/restructure.js
@@ -1,0 +1,32 @@
+function n(v, d = 0) {
+  const x = Number(v);
+  return Number.isFinite(x) ? x : d;
+}
+
+export function computeRestructureOutcome(contract = {}, maxConvertPct = 0.5) {
+  const yearsRemaining = Math.max(1, n(contract?.years ?? contract?.yearsRemaining ?? 1));
+  const yearsTotal = Math.max(1, n(contract?.yearsTotal, yearsRemaining));
+  const baseAnnual = n(contract?.baseAnnual, 0);
+  const signingBonus = n(contract?.signingBonus, 0);
+  const convertAmount = Math.round(baseAnnual * Math.max(0, Math.min(0.9, maxConvertPct)) * 100) / 100;
+  const newBase = Math.round((baseAnnual - convertAmount) * 100) / 100;
+  const newSigningBonus = Math.round((signingBonus + convertAmount) * 100) / 100;
+  const oldCapHit = baseAnnual + (signingBonus / yearsTotal);
+  const newCapHit = newBase + (newSigningBonus / yearsTotal);
+  return {
+    convertAmount,
+    newBase,
+    newSigningBonus,
+    oldCapHit: Math.round(oldCapHit * 100) / 100,
+    newCapHit: Math.round(newCapHit * 100) / 100,
+    capSavingsThisYear: Math.round((oldCapHit - newCapHit) * 100) / 100,
+    futureAnnualBonusDelta: Math.round((convertAmount / yearsRemaining) * 100) / 100,
+  };
+}
+
+export function shouldPreserveChemistryOnReturn({ releaseRecord, signingTeamId, currentSeason }) {
+  if (!releaseRecord) return false;
+  if (Number(releaseRecord.teamId) !== Number(signingTeamId)) return false;
+  if (Number(releaseRecord.season) !== Number(currentSeason)) return false;
+  return true;
+}

--- a/src/core/economy.js
+++ b/src/core/economy.js
@@ -1,0 +1,78 @@
+export const DEFAULT_LEAGUE_ECONOMY = Object.freeze({
+  baseSalaryCap: 301.2,
+  currentSalaryCap: 301.2,
+  annualCapGrowthRate: 0.035,
+  annualSalaryInflationRate: 0.025,
+  economyHistory: [],
+});
+
+function num(v, d = 0) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : d;
+}
+
+export function normalizeLeagueEconomy(raw = {}, { year = null } = {}) {
+  const base = num(raw?.baseSalaryCap, DEFAULT_LEAGUE_ECONOMY.baseSalaryCap);
+  const current = num(raw?.currentSalaryCap, base);
+  const annualCapGrowthRate = Math.max(0, Math.min(0.12, num(raw?.annualCapGrowthRate, DEFAULT_LEAGUE_ECONOMY.annualCapGrowthRate)));
+  const annualSalaryInflationRate = Math.max(0, Math.min(0.1, num(raw?.annualSalaryInflationRate, DEFAULT_LEAGUE_ECONOMY.annualSalaryInflationRate)));
+  const existingHistory = Array.isArray(raw?.economyHistory) ? raw.economyHistory : [];
+  const economyHistory = existingHistory
+    .map((row) => ({
+      season: Number(row?.season ?? row?.year ?? 0),
+      salaryCap: Math.max(50, num(row?.salaryCap, current)),
+      capGrowthRate: num(row?.capGrowthRate, annualCapGrowthRate),
+      inflationRate: num(row?.inflationRate, annualSalaryInflationRate),
+    }))
+    .filter((row) => Number.isFinite(row.season) && row.season > 0)
+    .slice(-80);
+
+  if (year != null && !economyHistory.some((row) => Number(row.season) === Number(year))) {
+    economyHistory.push({
+      season: Number(year),
+      salaryCap: Math.max(50, current),
+      capGrowthRate: annualCapGrowthRate,
+      inflationRate: annualSalaryInflationRate,
+    });
+  }
+
+  return {
+    baseSalaryCap: Math.max(50, base),
+    currentSalaryCap: Math.max(50, current),
+    annualCapGrowthRate,
+    annualSalaryInflationRate,
+    economyHistory: economyHistory.sort((a, b) => a.season - b.season).slice(-80),
+  };
+}
+
+export function projectNextSeasonEconomy(economy = {}, nextSeason) {
+  const normalized = normalizeLeagueEconomy(economy);
+  const nextCap = Math.round((normalized.currentSalaryCap * (1 + normalized.annualCapGrowthRate)) * 100) / 100;
+  return normalizeLeagueEconomy({
+    ...normalized,
+    currentSalaryCap: nextCap,
+    economyHistory: [
+      ...normalized.economyHistory,
+      {
+        season: Number(nextSeason),
+        salaryCap: nextCap,
+        capGrowthRate: normalized.annualCapGrowthRate,
+        inflationRate: normalized.annualSalaryInflationRate,
+      },
+    ],
+  });
+}
+
+export function getSalaryInflationMultiplier(economy = {}) {
+  const normalized = normalizeLeagueEconomy(economy);
+  return Math.max(0.85, normalized.currentSalaryCap / Math.max(1, normalized.baseSalaryCap));
+}
+
+export function inflateContract(contract = {}, multiplier = 1) {
+  const m = Math.max(0.85, Number(multiplier) || 1);
+  return {
+    ...contract,
+    baseAnnual: Math.round((num(contract?.baseAnnual, 0) * m) * 10) / 10,
+    signingBonus: Math.round((num(contract?.signingBonus, 0) * m) * 10) / 10,
+  };
+}

--- a/src/state/saveSchema.js
+++ b/src/state/saveSchema.js
@@ -1,4 +1,4 @@
-export const CURRENT_SAVE_SCHEMA_VERSION = 5.1;
+export const CURRENT_SAVE_SCHEMA_VERSION = 5.2;
 
 function migratePreVersioned(meta = {}) {
   return {
@@ -41,6 +41,7 @@ const MIGRATIONS = {
   3: migrateV3ToV4,
   4: migrateV4ToV5,
   5: migrateV5ToV51,
+  5.1: migrateV51ToV52,
 };
 
 function migrateV4ToV5(meta = {}) {
@@ -71,6 +72,23 @@ function migrateV5ToV51(meta = {}) {
     // v5.1 is a non-destructive repair marker. Actual repair work (roster/cap
     // hydration) runs in the worker at load-time so no user data is wiped.
     saveVersion: 5.1,
+  };
+}
+
+function migrateV51ToV52(meta = {}) {
+  const salaryCap = Number(meta?.settings?.salaryCap ?? 301.2);
+  const economy = {
+    baseSalaryCap: salaryCap,
+    currentSalaryCap: salaryCap,
+    annualCapGrowthRate: 0.035,
+    annualSalaryInflationRate: 0.025,
+    economyHistory: Array.isArray(meta?.economy?.economyHistory) ? meta.economy.economyHistory : [],
+    ...(meta?.economy ?? {}),
+  };
+  return {
+    ...meta,
+    economy,
+    saveVersion: 5.2,
   };
 }
 

--- a/src/ui/components/FinancialsView.jsx
+++ b/src/ui/components/FinancialsView.jsx
@@ -329,6 +329,15 @@ export default function FinancialsView({ league, actions }) {
 
   const handleRestructure = async (player) => {
     if (!actions?.restructureContract) return;
+    const currentCapHit = capHitOf(player);
+    const years = Math.max(1, Number(player?.contract?.years ?? player?.contract?.yearsRemaining ?? 1));
+    const convertAmount = Number(player?.contract?.baseAnnual ?? 0) * 0.5;
+    const projectedBonus = Number(player?.contract?.signingBonus ?? 0) + convertAmount;
+    const projectedCapHit = (Number(player?.contract?.baseAnnual ?? 0) - convertAmount) + (projectedBonus / years);
+    const proceed = window.confirm(
+      `Restructure ${player.name}?\nCurrent cap hit: ${fmt(currentCapHit)}\nNew cap hit: ${fmt(projectedCapHit)}\nFuture bonus impact: +${fmt(convertAmount / years)} per remaining year.`
+    );
+    if (!proceed) return;
     setRestructuring(player.id);
     setNotification(null);
     try {
@@ -337,7 +346,7 @@ export default function FinancialsView({ league, actions }) {
         const r = resp.payload.restructureResult;
         setNotification({
           type: "success",
-          message: `Restructured ${r.playerName}: converted $${r.convertAmount?.toFixed(2)}M → saves $${r.capSavingsThisYear?.toFixed(2)}M this year.`,
+          message: `Restructured ${r.playerName}: ${fmt(r.oldCapHit)} → ${fmt(r.newCapHit)} (saves $${r.capSavingsThisYear?.toFixed(2)}M this year, future +$${(r.futureAnnualBonusDelta ?? 0).toFixed(2)}M/yr).`,
         });
       } else {
         setNotification({ type: "success", message: "Contract restructured." });
@@ -404,6 +413,9 @@ export default function FinancialsView({ league, actions }) {
       </div>
     );
 
+  const economy = league?.economy ?? null;
+  const economyHistory = Array.isArray(economy?.economyHistory) ? [...economy.economyHistory].slice(-8).reverse() : [];
+
   return (
     <div style={{ padding: "var(--space-4)", maxWidth: 900, margin: "0 auto" }}>
       {/* ── Header ── */}
@@ -426,6 +438,22 @@ export default function FinancialsView({ league, actions }) {
           Hard Cap: ${hardCap.toFixed(1)}M
         </Badge>
       </div>
+      {economy && (
+        <Card style={{ marginBottom: "var(--space-4)" }}>
+          <CardHeader><CardTitle>League Economy</CardTitle></CardHeader>
+          <CardContent>
+            <div style={{ fontSize: 13, color: "var(--text-muted)", marginBottom: 8 }}>
+              Current cap: {fmt(economy.currentSalaryCap)} · Growth: {(Number(economy.annualCapGrowthRate ?? 0) * 100).toFixed(1)}%/yr · Salary inflation: {(Number(economy.annualSalaryInflationRate ?? 0) * 100).toFixed(1)}%/yr
+            </div>
+            {economyHistory.map((row) => (
+              <div key={row.season} style={{ display: "flex", justifyContent: "space-between", fontSize: 12, color: "var(--text-muted)" }}>
+                <span>{row.season}</span>
+                <span>{fmt(row.salaryCap)}</span>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
 
       {/* ── Notification ── */}
       {notification && (

--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -122,6 +122,10 @@ const RESIGN_TIER_LABEL = {
   trade_or_tag: "Trade/Tag candidate",
 };
 
+export function formatPlaybookKnowledge(playbookKnowledge) {
+  return `${playbookKnowledge?.label ?? "None"} (${playbookKnowledge?.score ?? 0})`;
+}
+
 // ── Shared sub-components (identical signature & appearance to Roster.jsx) ────
 
 function OvrBadge({ ovr }) {
@@ -502,6 +506,9 @@ function PlayerPreviewSheet({ player, capRoom, onClose, onSubmitBid }) {
         <div style={{ padding: "0 16px" }}>
           {/* PlayerCard hero */}
           <PlayerCard player={player} variant="hero" onClose={onClose} />
+          <div style={{ marginTop: 10, fontSize: "0.8rem", color: "var(--text-muted)" }}>
+            Team playbook knowledge: <strong style={{ color: "var(--text)" }}>{formatPlaybookKnowledge(player?.playbookKnowledge)}</strong>
+          </div>
 
           {/* Bid form or trigger */}
           <div style={{ marginTop: 16 }}>
@@ -1170,6 +1177,9 @@ export default function FreeAgency({
                             <div style={{ color: "var(--text-muted)", marginTop: 1 }}>
                               {market.urgencyLabel}{market.patienceLabel ? ` · ${market.patienceLabel}` : ""}
                             </div>
+                            <div style={{ color: "var(--text-muted)", marginTop: 1 }}>
+                              Playbook knowledge: {formatPlaybookKnowledge(player?.playbookKnowledge)}
+                            </div>
                             {market.motivationSummary && (
                               <div style={{ color: "var(--text-subtle)", marginTop: 1 }}>
                                 {market.motivationSummary}{market.fitScore ? ` · Fit ${market.fitScore}/100` : ""}
@@ -1277,6 +1287,9 @@ export default function FreeAgency({
                           <div style={{ fontSize: "10px", color: "var(--text-muted)", marginBottom: 4 }}>
                             {player?.demandProfile?.headline ?? "Balanced priorities"}{market.riskLabel ? ` · ${market.riskLabel}` : ""}
                           </div>
+                          <div style={{ fontSize: "10px", color: "var(--text-muted)", marginBottom: 4 }}>
+                            Playbook: {formatPlaybookKnowledge(player?.playbookKnowledge)}
+                          </div>
                           {!canAfford ? (
                             <span style={{ color: "var(--danger)", fontSize: "var(--text-xs)" }}>
                               Cannot Afford
@@ -1305,6 +1318,7 @@ export default function FreeAgency({
                     <div style={{ fontWeight: 700 }}>{idx + 1}. {player.name}</div>
                     <div style={{ fontSize: 12, color: "var(--text-muted)" }}>{player.pos} · age {player.age} · OVR {player.ovr}{player.scoutUncertaintyBand ? ` (Scout ${player.scoutOvr} ±${player.scoutUncertaintyBand})` : ''}</div>
                     <div style={{ fontSize: 12, color: "var(--text-muted)" }}>Scheme fit {player.schemeFit ?? 50} · morale {player.morale ?? 70}</div>
+                    <div style={{ fontSize: 12, color: "var(--text-muted)" }}>Playbook {formatPlaybookKnowledge(player?.playbookKnowledge)}</div>
                     <div style={{ fontSize: 12, marginTop: 4 }}>Demand {(player?.demandProfile?.askAnnual ?? player._ask ?? 0).toFixed(1)}M / yr</div>
                     <div style={{ fontSize: 11, color: 'var(--text-muted)' }}>{player?.demandProfile?.headline ?? 'Balanced motivations'}{player?.demandProfile?.fitScore ? ` · Fit ${player.demandProfile.fitScore}/100` : ''}</div>
                     {Array.isArray(player?.market?.stateChips) && player.market.stateChips.length > 0 ? <div style={{ fontSize: 10, color: 'var(--text-subtle)' }}>{player.market.stateChips.join(' · ')}</div> : null}
@@ -1348,6 +1362,9 @@ export default function FreeAgency({
                                 </div>
                                 <div style={{ fontSize: "10px", color: "var(--text-muted)", marginTop: 2 }}>
                                    {mMarket.decision} · {mMarket.urgencyLabel}{mMarket.patienceLabel ? ` · ${mMarket.patienceLabel}` : ""}
+                                </div>
+                                <div style={{ fontSize: "10px", color: "var(--text-muted)", marginTop: 2 }}>
+                                   Playbook: {formatPlaybookKnowledge(player?.playbookKnowledge)}
                                 </div>
                                 {mMarket.decisionReason && (
                                   <div style={{ fontSize: "10px", color: "var(--text-subtle)", marginTop: 2 }}>

--- a/src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx
+++ b/src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { formatPlaybookKnowledge } from '../FreeAgency.jsx';
+
+describe('free agency playbook knowledge display', () => {
+  it('formats label and score for UI rows/cards', () => {
+    expect(formatPlaybookKnowledge({ label: 'High', score: 88 })).toBe('High (88)');
+    expect(formatPlaybookKnowledge(null)).toBe('None (0)');
+  });
+});

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -81,6 +81,7 @@ import {
 } from '../core/contract-market.js';
 import { getTeamContextForNegotiation } from '../core/teamContext/negotiationContext.js';
 import { evaluateContractOffer, summarizeNegotiationStance } from '../core/contracts/negotiation.js';
+import { computeRestructureOutcome, shouldPreserveChemistryOnReturn } from '../core/contracts/restructure.js';
 import { summarizePlayerMood } from '../core/mood/playerMood.js';
 import { getFreeAgencyDecisionState } from '../core/freeAgency/decisionState.js';
 import {
@@ -105,6 +106,13 @@ import { migrateSaveMetaToCurrent, CURRENT_SAVE_SCHEMA_VERSION } from '../state/
 import { getTradeWindowSnapshot, isTradeWindowOpen } from '../core/tradeWindow.js';
 import { buildCanonicalGameId, buildArchivedGame, toTeamId } from '../core/gameIdentity.js';
 import { normalizeArchivedGamePayload, classifyArchiveQuality, validateArchivedGame, recoverArchivedGameFromSchedule } from '../core/gameArchive.js';
+import {
+  DEFAULT_LEAGUE_ECONOMY,
+  normalizeLeagueEconomy,
+  projectNextSeasonEconomy,
+  getSalaryInflationMultiplier,
+  inflateContract,
+} from '../core/economy.js';
 import {
   buildDriveSummaryFromSimulation,
   buildGameNarrativeSummary,
@@ -144,9 +152,15 @@ function yieldFrame() {
  */
 function getSafeMeta() {
   const safe = ensureDynastyMeta(cache.getMeta() ?? {});
+  const economy = normalizeLeagueEconomy(safe?.economy ?? {}, { year: safe?.year });
+  const settings = normalizeLeagueSettings({
+    ...(safe?.settings ?? {}),
+    salaryCap: economy.currentSalaryCap,
+  });
   return {
     ...safe,
-    settings: normalizeLeagueSettings(safe?.settings ?? {}),
+    settings,
+    economy,
     commissionerMode: !!safe?.commissionerMode,
     commissionerEverEnabled: !!safe?.commissionerEverEnabled,
     commissionerLog: Array.isArray(safe?.commissionerLog) ? safe.commissionerLog : [],
@@ -537,6 +551,7 @@ function buildViewState() {
     seasonStorylines: Array.isArray(meta?.seasonStorylines) ? meta.seasonStorylines : [],
     hallOfFameClasses: Array.isArray(meta?.hallOfFame?.classes) ? meta.hallOfFame.classes.slice(0, 20) : [],
     settings: normalizeLeagueSettings(meta?.settings ?? {}),
+    economy: normalizeLeagueEconomy(meta?.economy ?? {}, { year: meta?.year }),
     tradeDeadline,
     godMode: !!meta?.commissionerMode,
     commissionerMode: !!meta?.commissionerMode,
@@ -660,6 +675,32 @@ function ensureCompMeta(metaObj = ensureDynastyMeta(cache.getMeta())) {
     compPicksGeneratedForSeason: Array.isArray(metaObj?.compPicksGeneratedForSeason) ? metaObj.compPicksGeneratedForSeason : [],
     compPickAwardsHistory: Array.isArray(metaObj?.compPickAwardsHistory) ? metaObj.compPickAwardsHistory : [],
   };
+}
+
+function markOffseasonRelease(player, teamId, metaObj = ensureDynastyMeta(cache.getMeta())) {
+  if (!player || teamId == null) return;
+  if (!['offseason_resign', 'free_agency', 'draft', 'offseason', 'preseason'].includes(metaObj?.phase)) return;
+  const key = `${metaObj?.year ?? 0}:${player.id}`;
+  const history = {
+    ...(metaObj?.offseasonReleaseMap ?? {}),
+    [key]: {
+      playerId: Number(player.id),
+      teamId: Number(teamId),
+      season: Number(metaObj?.year ?? 0),
+      schemeFit: Number(player?.schemeFit ?? 65),
+      morale: Number(player?.morale ?? 70),
+      releasedAtWeek: Number(metaObj?.currentWeek ?? 1),
+    },
+  };
+  cache.setMeta({ offseasonReleaseMap: history });
+}
+
+function getOffseasonReturnSnapshot(playerId, teamId, metaObj = ensureDynastyMeta(cache.getMeta())) {
+  const key = `${metaObj?.year ?? 0}:${playerId}`;
+  const snapshot = metaObj?.offseasonReleaseMap?.[key];
+  if (!snapshot) return null;
+  if (!shouldPreserveChemistryOnReturn({ releaseRecord: snapshot, signingTeamId: teamId, currentSeason: metaObj?.year })) return null;
+  return snapshot;
 }
 
 function getContractAav(contract = {}) {
@@ -1235,8 +1276,10 @@ async function handleLoadSave({ leagueId }, id) {
       }
 
       // Migration/defaulting for league customization + commissioner metadata.
+      const normalizedEconomy = normalizeLeagueEconomy(meta?.economy ?? {}, { year: meta?.year });
       cache.setMeta({
-        settings: normalizeLeagueSettings(meta?.settings ?? {}),
+        settings: normalizeLeagueSettings({ ...(meta?.settings ?? {}), salaryCap: normalizedEconomy.currentSalaryCap }),
+        economy: normalizedEconomy,
         commissionerMode: !!meta?.commissionerMode,
         commissionerEverEnabled: !!meta?.commissionerEverEnabled,
         commissionerLog: Array.isArray(meta?.commissionerLog) ? meta.commissionerLog : [],
@@ -1445,6 +1488,11 @@ async function handleNewLeague(payload, id) {
     }
 
     const seasonId = `s${league.season ?? 1}`;
+    const economy = normalizeLeagueEconomy({
+      ...DEFAULT_LEAGUE_ECONOMY,
+      baseSalaryCap: resolvedSettings.salaryCap,
+      currentSalaryCap: resolvedSettings.salaryCap,
+    }, { year: league.year });
     const meta = ensureLeagueMemoryMeta({
       id:              'league',
       name:            String(options.name || resolvedSettings.leagueName || `League ${leagueId}`).slice(0, 80),
@@ -1457,10 +1505,12 @@ async function handleNewLeague(payload, id) {
       difficulty:      options.difficulty ?? 'Normal',
       settings:        normalizeLeagueSettings({
         ...resolvedSettings,
+        salaryCap: economy.currentSalaryCap,
         conferenceNames,
         divisionNames,
         leagueSize: configuredTeams.length,
       }),
+      economy,
       commissionerMode: !!options.godMode,
       commissionerEverEnabled: !!options.godMode,
       commissionerLog: [],
@@ -1485,9 +1535,9 @@ async function handleNewLeague(payload, id) {
         ...teamWithoutRoster,
         staff: normalizedStaff,
         draftBoard: teamWithoutRoster?.draftBoard ?? { ranks: {}, notes: {}, tags: {}, shortlist: [], avoid: [] },
-        capTotal: resolvedSettings.salaryCap,
-        capRoom: resolvedSettings.salaryCap,
-        capSpace: resolvedSettings.salaryCap,
+        capTotal: economy.currentSalaryCap,
+        capRoom: economy.currentSalaryCap,
+        capSpace: economy.currentSalaryCap,
         wins:       0,
         losses:     0,
         ties:       0,
@@ -3512,6 +3562,11 @@ async function handleImportSave({ data, saveName }, id) {
       recalculateTeamCap(team.id);
       cache.updateTeam(team.id, deriveTeamUnitRatings(team.id));
     }
+    const importedEconomy = normalizeLeagueEconomy(meta?.economy ?? {}, { year: meta?.year });
+    cache.setMeta({
+      economy: importedEconomy,
+      settings: normalizeLeagueSettings({ ...(meta?.settings ?? {}), salaryCap: importedEconomy.currentSalaryCap }),
+    });
     await flushDirty();
     const userTeam = cache.getTeam(meta?.userTeamId);
     await Saves.save({
@@ -3598,7 +3653,20 @@ async function handleSignPlayer({ playerId, teamId, contract }, id) {
   }
 
   const oldTeamId = player.teamId;
-  cache.updatePlayer(player.id, { teamId: resolvedTeamId, contract, status: 'active', offers: [] });
+  const continuity = getOffseasonReturnSnapshot(player.id, resolvedTeamId, meta);
+  cache.updatePlayer(player.id, {
+    teamId: resolvedTeamId,
+    contract,
+    status: 'active',
+    offers: [],
+    schemeFit: continuity ? Math.max(Number(player?.schemeFit ?? 65), Number(continuity?.schemeFit ?? 65)) : player?.schemeFit,
+    morale: continuity ? Math.max(Number(player?.morale ?? 70), Number(continuity?.morale ?? 70) - 3) : player?.morale,
+    chemistryContinuity: continuity ? {
+      preserved: true,
+      teamId: Number(resolvedTeamId),
+      season: Number(meta?.year ?? 0),
+    } : player?.chemistryContinuity,
+  });
   recordOffseasonFaMovement({
     player,
     oldTeamId,
@@ -3719,11 +3787,15 @@ async function finalizeFreeAgencySigning(player, offer, liveMeta) {
   }
 
   const oldTeamId = player.teamId;
+  const continuity = getOffseasonReturnSnapshot(player.id, signingTeamId, liveMeta);
   cache.updatePlayer(player.id, {
     teamId: signingTeamId,
     status: 'active',
     contract: offer.contract,
     offers: [],
+    schemeFit: continuity ? Math.max(Number(player?.schemeFit ?? 65), Number(continuity?.schemeFit ?? 65)) : player?.schemeFit,
+    morale: continuity ? Math.max(Number(player?.morale ?? 70), Number(continuity?.morale ?? 70) - 3) : player?.morale,
+    chemistryContinuity: continuity ? { preserved: true, teamId: signingTeamId, season: Number(liveMeta?.year ?? 0) } : player?.chemistryContinuity,
   });
   recordOffseasonFaMovement({
     player,
@@ -4029,6 +4101,7 @@ async function handleReleasePlayer({ playerId, teamId }, id) {
   }
 
   // Use player.id (the canonical key from the cache) for all subsequent writes.
+  markOffseasonRelease(player, teamId, meta);
   cache.updatePlayer(player.id, { teamId: null, status: 'free_agent', offers: [] });
   recalculateTeamCap(teamId);
 
@@ -4111,6 +4184,7 @@ async function handleGetRoster({ teamId }, id) {
 
 async function handleGetFreeAgents(payload, id) {
   const meta = ensureDynastyMeta(cache.getMeta());
+  const inflationMult = getSalaryInflationMultiplier(meta?.economy ?? {});
   const userTeamId = meta.userTeamId;
   const allFreeAgents = cache.getAllPlayers().filter((p) => !p.teamId || p.status === 'free_agent');
   const userTeam = cache.getTeam(userTeamId);
@@ -4125,18 +4199,27 @@ async function handleGetFreeAgents(payload, id) {
 
   const freeAgents = allFreeAgents
     .map(p => {
+        const continuity = getOffseasonReturnSnapshot(p.id, userTeamId, meta);
+        const playbookKnowledgeScore = Math.max(0, Math.min(100, continuity ? Number(continuity?.schemeFit ?? p?.schemeFit ?? 50) : Number(p?.schemeFit ?? 50)));
+        const playbookKnowledgeLabel = playbookKnowledgeScore >= 80
+          ? 'High'
+          : playbookKnowledgeScore >= 60
+            ? 'Moderate'
+            : playbookKnowledgeScore >= 35
+              ? 'Low'
+              : 'None';
         const scoutingView = buildScoutingSnapshot(p, userTeam, { fogStrength: Number(getLeagueSetting('scoutingFogStrength', 50)), commissionerMode: !!meta?.commissionerMode });
         // Summarize offers for UI — bidding war edition
         const offers = p.offers || [];
         const userOffer = offers.find(o => o.teamId === userTeamId);
         const profile = buildContractProfile(p);
         const heat = computeMarketHeat(p.pos, allFreeAgents);
-        const ask = buildDemandFromProfile(p, profile, {
+        const ask = inflateContract(buildDemandFromProfile(p, profile, {
           marketHeat: heat,
           morale: p.morale ?? 68,
           fit: Number(p?.schemeFit ?? 65),
           teamSuccess: userWinPct,
-        });
+        }), inflationMult);
         const reSignInsight = evaluateReSignPriority(p, {
           marketHeat: heat,
           teamDirection: userDirection,
@@ -4273,6 +4356,10 @@ async function handleGetFreeAgents(payload, id) {
             negotiationStance: userOfferEval.negotiationStance,
             fitScore: userOfferEval.score,
             explanationSummary: userOfferEval.explanationSummary,
+          },
+          playbookKnowledge: {
+            score: Math.round(playbookKnowledgeScore),
+            label: playbookKnowledgeLabel,
           },
           reSign: reSignInsight,
           offers: {
@@ -4557,18 +4644,19 @@ async function handleUpdateFranchiseInvestments({ teamId, updates }, id) {
 
 async function handleGetExtensionAsk({ playerId }, id) {
   const meta = ensureDynastyMeta(cache.getMeta());
+  const inflationMult = getSalaryInflationMultiplier(meta?.economy ?? {});
   const player = cache.getPlayer(playerId);
   if (!player) { post(toUI.ERROR, { message: 'Player not found' }, id); return; }
   const team = cache.getTeam(player.teamId ?? meta.userTeamId);
   const profile = buildContractProfile(player);
   const marketHeat = computeMarketHeat(player.pos, cache.getAllPlayers().filter((p) => !p.teamId || p.status === 'free_agent'));
-  const demandFromProfile = buildDemandFromProfile(player, profile, {
+  const demandFromProfile = inflateContract(buildDemandFromProfile(player, profile, {
     marketHeat,
     morale: calculateMorale(player, team, true),
     fit: player.schemeFit ?? 65,
     teamSuccess: ((team?.wins ?? 0) + (team?.ties ?? 0) * 0.5) / Math.max(1, (team?.wins ?? 0) + (team?.losses ?? 0) + (team?.ties ?? 0)),
-  });
-  const baselineAsk = calculateExtensionDemand(player, meta?.difficulty ?? 'Normal');
+  }), inflationMult);
+  const baselineAsk = inflateContract(calculateExtensionDemand(player, meta?.difficulty ?? 'Normal') ?? {}, inflationMult);
   const ask = {
     ...baselineAsk,
     baseAnnual: Math.max(baselineAsk?.baseAnnual ?? 0, demandFromProfile.baseAnnual),
@@ -4592,7 +4680,9 @@ async function handleExtendContract({ playerId, teamId, contract }, id) {
   const player = cache.getPlayer(playerId);
   if (!player) { post(toUI.ERROR, { message: 'Player not found' }, id); return; }
 
-  const requested = calculateExtensionDemand(player, ensureDynastyMeta(cache.getMeta())?.difficulty ?? 'Normal');
+  const meta = ensureDynastyMeta(cache.getMeta());
+  const inflationMult = getSalaryInflationMultiplier(meta?.economy ?? {});
+  const requested = inflateContract(calculateExtensionDemand(player, meta?.difficulty ?? 'Normal') ?? {}, inflationMult);
   const offeredAnnual = Number(contract?.baseAnnual ?? 0);
   const offeredYears = Number(contract?.yearsTotal ?? contract?.years ?? 0);
   const offeredGuarantee = Number(contract?.guaranteedPct ?? 0);
@@ -4622,7 +4712,6 @@ async function handleExtendContract({ playerId, teamId, contract }, id) {
 
     cache.updatePlayer(playerId, { contract, negotiationStatus: 'SIGNED' });
     recalculateTeamCap(resolvedTeamId);
-    const meta = ensureDynastyMeta(cache.getMeta());
     await Transactions.add({
       type: 'EXTEND',
       seasonId: meta.currentSeasonId,
@@ -5416,7 +5505,8 @@ function recalculateTeamCap(teamId) {
 
   const deadCap          = team.deadCap         || 0;
   const deadMoneyNextYear = team.deadMoneyNextYear || 0;
-  const capTotal          = team.capTotal         ?? Constants.SALARY_CAP.HARD_CAP;
+  const leagueCap = Number(getSafeMeta()?.economy?.currentSalaryCap ?? getLeagueSetting('salaryCap', Constants.SALARY_CAP.HARD_CAP));
+  const capTotal          = team.capTotal         ?? leagueCap;
   const totalCapUsed      = activeCap + deadCap;
 
   cache.updateTeam(teamId, {
@@ -5463,10 +5553,16 @@ async function handleRestructureContract({ playerId, teamId }, id) {
     post(toUI.ERROR, { message: 'Cannot restructure: player must have at least 2 years remaining.' }, id);
     return;
   }
+  const restructureCount = Number(contract?.restructureCount ?? 0);
+  const sameSeason = Number(contract?.lastRestructureSeason ?? 0) === Number(meta?.year ?? 0);
+  if (sameSeason || restructureCount >= 2) {
+    post(toUI.ERROR, { message: 'Cannot restructure: limit reached for this contract this offseason.' }, id);
+    return;
+  }
 
   const maxConvertPct = Constants.SALARY_CAP.RESTRUCTURE_MAX_CONVERT_PCT;
-  const baseAnnual    = contract.baseAnnual ?? 0;
-  const convertAmount = Math.round(baseAnnual * maxConvertPct * 100) / 100;
+  const outcome = computeRestructureOutcome(contract, maxConvertPct);
+  const convertAmount = outcome.convertAmount;
 
   if (convertAmount <= 0) {
     post(toUI.ERROR, { message: 'Cannot restructure: no base salary to convert.' }, id);
@@ -5474,15 +5570,15 @@ async function handleRestructureContract({ playerId, teamId }, id) {
   }
 
   // New contract values after restructure
-  const newBase         = Math.round((baseAnnual - convertAmount) * 100) / 100;
-  const addedBonusTotal = convertAmount * yearsRemaining; // spread over remaining years
-  const existingBonus   = contract.signingBonus ?? 0;
-  const newSigningBonus = Math.round((existingBonus + addedBonusTotal) * 100) / 100;
+  const newBase = outcome.newBase;
+  const newSigningBonus = outcome.newSigningBonus;
 
   const newContract = {
     ...contract,
     baseAnnual:   newBase,
     signingBonus: newSigningBonus,
+    restructureCount: restructureCount + 1,
+    lastRestructureSeason: Number(meta?.year ?? 0),
   };
 
   cache.updatePlayer(player.id, { contract: newContract });
@@ -5505,7 +5601,11 @@ async function handleRestructureContract({ playerId, teamId }, id) {
       convertAmount,
       newBase,
       newSigningBonus,
-      capSavingsThisYear: Math.round((convertAmount - convertAmount / yearsRemaining) * 100) / 100,
+      oldCapHit: outcome.oldCapHit,
+      newCapHit: outcome.newCapHit,
+      capSavingsThisYear: outcome.capSavingsThisYear,
+      futureAnnualBonusDelta: outcome.futureAnnualBonusDelta,
+      restructureCount: restructureCount + 1,
     },
   }, id);
 }
@@ -6839,6 +6939,7 @@ async function handleStartNewSeason(payload, id) {
   const newYear     = (meta.year   ?? 2025) + 1;
   const newSeason   = (meta.season ?? 1)    + 1;
   const newSeasonId = `s${newSeason}`;
+  const nextEconomy = projectNextSeasonEconomy(meta?.economy ?? {}, newYear);
 
   // Reset team records and roll dead money forward
   for (const team of cache.getAllTeams()) {
@@ -6849,7 +6950,7 @@ async function handleStartNewSeason(payload, id) {
       wins: 0, losses: 0, ties: 0, ptsFor: 0, ptsAgainst: 0,
       deadCap:          rolledDeadCap,
       deadMoneyNextYear: 0,
-      capTotal:          Constants.SALARY_CAP.HARD_CAP,
+      capTotal:          nextEconomy.currentSalaryCap,
       fanApproval:        team?.fanApproval ?? 50,
       fanApprovalWinBoostUsed: 0,
       lossStreak: 0,
@@ -6879,6 +6980,12 @@ async function handleStartNewSeason(payload, id) {
     championTeamId:          null,
     offseasonProgressionDone:false,
     ownerGoals: generateOwnerGoals(),
+    offseasonReleaseMap: {},
+    economy: nextEconomy,
+    settings: normalizeLeagueSettings({
+      ...(meta?.settings ?? {}),
+      salaryCap: nextEconomy.currentSalaryCap,
+    }),
   });
 
   await flushDirty(); // AUTO-SAVE: phase transition — new season initialized to preseason.

--- a/tests/unit/saveSchemaEconomy.test.js
+++ b/tests/unit/saveSchemaEconomy.test.js
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { migrateSaveMetaToCurrent, CURRENT_SAVE_SCHEMA_VERSION } from '../../src/state/saveSchema.js';
+
+describe('save schema v5.2 economy migration', () => {
+  it('adds safe economy defaults to older saves', () => {
+    const { migrated } = migrateSaveMetaToCurrent({ saveVersion: 5.1, settings: { salaryCap: 312.5 } });
+    expect(migrated.saveVersion).toBe(CURRENT_SAVE_SCHEMA_VERSION);
+    expect(migrated.economy.currentSalaryCap).toBe(312.5);
+    expect(migrated.economy.baseSalaryCap).toBe(312.5);
+  });
+});


### PR DESCRIPTION
### Motivation
- Introduce a safe, additive league economy so salary caps and contract generation can evolve over many seasons without breaking existing saves.
- Make long-term contracts and simple restructures meaningful while keeping changes low-risk and backward-compatible.
- Improve offseason realism by preserving chemistry for players who briefly leave and return in the same offseason and by surfacing free-agent playbook knowledge to the UI.

### Description
- Added a dedicated economy module `src/core/economy.js` that defines `baseSalaryCap`, `currentSalaryCap`, `annualCapGrowthRate`, `annualSalaryInflationRate`, and lightweight `economyHistory`, plus helpers `projectNextSeasonEconomy`, `getSalaryInflationMultiplier`, and `inflateContract` to deterministically scale values over time.
- Wires economy into worker lifecycle (`src/worker/worker.js`) by seeding `meta.economy` on new league creation, advancing the economy on `START_NEW_SEASON`, exposing `economy` in view state, and using `economy.currentSalaryCap` as the league cap fallback when recalculating team cap totals.
- Applied inflation multiplier to contract demand generation and extension logic so newly generated asks and AI valuation scale with the league economy, and kept defaults modest and tunable (`~3.5%` cap growth, `~2.5%` salary inflation).
- Implemented restructure groundwork: a pure calculator `src/core/contracts/restructure.js`, off-season limits per contract, corrected conversion/proration math, richer restructure result payload, and UI confirmation text in `FinancialsView` showing `oldCapHit`, `newCapHit`, yearly savings, and future bonus impact.
- Added defensive chemistry continuity tracking: record offseason releases to `meta.offseasonReleaseMap` and preserve scheme-fit/morale continuity only when the same player re-signs with the same team in the same offseason (worker-side logic in `worker.js`).
- Exposed free-agent “playbook knowledge” (score + label) in worker free-agent payloads and surfaced it in the Free Agency list, card views, and preview sheet (`src/ui/components/FreeAgency.jsx`).
- Added a compact League Economy panel in the Financials view showing current cap, growth/inflation rates, and recent season cap values.
- Migration: bumped save schema to `5.2` and added a non-destructive migration that backfills `meta.economy` from existing `settings.salaryCap` with safe defaults.
- Kept changes additive and modular to preserve save compatibility and make future iterations (advanced restructures, owner cash systems, agent-driven inflation) straightforward.

### Testing
- Unit tests added and executed: `src/core/__tests__/economy.test.js`, `src/core/__tests__/restructure.test.js`, `src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx`, and `tests/unit/saveSchemaEconomy.test.js`; all tests passed locally with `vitest`.
- Performed a production build (`vite build`) to validate bundling and UI changes; build completed successfully.
- Migration/backfill exercised during save load paths in the worker to ensure older saves receive safe economy defaults without destructive edits.

Notes: advanced restructure variants (void years, June-1 acceleration modeling), agent-driven inflation variation, and a full owner/cash subsystem are intentionally deferred to keep this PR focused and low-risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc33a37b1c832d820fda9f527a1459)