### PR TITLE
Persist game archives to localStorage and wire Recent Games / Box Score flows (v5.3 migration)

### DIFF
--- a/src/core/archive/gameArchive.test.ts
+++ b/src/core/archive/gameArchive.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { GAME_ARCHIVE_STORAGE_KEY, getGame, getGamesByWeek, getRecentGames, saveGame } from "./gameArchive";
+
+describe("gameArchive local store", () => {
+  beforeEach(() => {
+    const store = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => { store.set(key, String(value)); },
+      removeItem: (key: string) => { store.delete(key); },
+      clear: () => { store.clear(); },
+    });
+    localStorage.clear();
+    vi.useRealTimers();
+  });
+
+  it("saves and fetches an archived game by id", () => {
+    saveGame("2026_w7_15_20", {
+      season: 2026,
+      week: 7,
+      homeId: 15,
+      awayId: 20,
+      homeAbbr: "MIA",
+      awayAbbr: "PIT",
+      homeScore: 30,
+      awayScore: 23,
+      recapText: "MIA closed strong in the fourth quarter.",
+      logs: [{ quarter: 4, text: "Drive sealed by interception." }],
+    });
+
+    const loaded = getGame("2026_w7_15_20");
+    expect(loaded?.homeAbbr).toBe("MIA");
+    expect(loaded?.awayAbbr).toBe("PIT");
+    expect(loaded?.score?.home).toBe(30);
+    expect(loaded?.recapText).toContain("closed strong");
+    expect(localStorage.getItem(GAME_ARCHIVE_STORAGE_KEY)).toContain("2026_w7_15_20");
+  });
+
+  it("returns recent games and week filtering", () => {
+    saveGame("2026_w6_1_2", { season: 2026, week: 6, homeId: 1, awayId: 2, homeAbbr: "BUF", awayAbbr: "NYJ", homeScore: 28, awayScore: 17, timestamp: 1000 });
+    saveGame("2026_w7_3_4", { season: 2026, week: 7, homeId: 3, awayId: 4, homeAbbr: "MIA", awayAbbr: "PIT", homeScore: 30, awayScore: 23, timestamp: 2000 });
+    saveGame("2026_w7_5_6", { season: 2026, week: 7, homeId: 5, awayId: 6, homeAbbr: "KC", awayAbbr: "LV", homeScore: 24, awayScore: 10, timestamp: 3000 });
+
+    const recent = getRecentGames(2);
+    expect(recent).toHaveLength(2);
+    expect(recent[0]?.id).toBe("2026_w7_5_6");
+    expect(recent[1]?.id).toBe("2026_w7_3_4");
+
+    const weekGames = getGamesByWeek(2026, 7);
+    expect(weekGames.map((g) => g.id)).toEqual(["2026_w7_3_4", "2026_w7_5_6"]);
+  });
+});

--- a/src/core/archive/gameArchive.ts
+++ b/src/core/archive/gameArchive.ts
@@ -1,0 +1,120 @@
+import { buildCanonicalGameId } from "../gameIdentity.js";
+
+export const GAME_ARCHIVE_STORAGE_KEY = "footballgm_game_archive_v1";
+
+type AnyObject = Record<string, any>;
+
+export type ArchivedGame = {
+  id: string;
+  season: string | number | null;
+  week: number | null;
+  homeId: number | null;
+  awayId: number | null;
+  homeAbbr: string;
+  awayAbbr: string;
+  score: { home: number | null; away: number | null };
+  teamStats: AnyObject | null;
+  playerStats: AnyObject | null;
+  scoringSummary: AnyObject[];
+  recapText: string | null;
+  logs: AnyObject[];
+  timestamp: number;
+  summary?: AnyObject | null;
+};
+
+function toNumberOrNull(value: any) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function safeRead(): Record<string, ArchivedGame> {
+  try {
+    const raw = localStorage.getItem(GAME_ARCHIVE_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    if (parsed.games && typeof parsed.games === "object") return parsed.games;
+    return parsed;
+  } catch {
+    return {};
+  }
+}
+
+function safeWrite(games: Record<string, ArchivedGame>) {
+  try {
+    localStorage.setItem(
+      GAME_ARCHIVE_STORAGE_KEY,
+      JSON.stringify({ version: 1, games }),
+    );
+  } catch {
+    // non-fatal
+  }
+}
+
+export function saveGame(gameId: string | null | undefined, payload: AnyObject) {
+  const season = payload?.season ?? payload?.seasonId ?? null;
+  const week = toNumberOrNull(payload?.week);
+  const homeId = toNumberOrNull(payload?.homeId ?? payload?.home);
+  const awayId = toNumberOrNull(payload?.awayId ?? payload?.away);
+  const resolvedId = String(
+    gameId
+      || payload?.id
+      || payload?.gameId
+      || buildCanonicalGameId({ seasonId: season, week, homeId, awayId }),
+  );
+
+  if (!resolvedId || resolvedId === "null") return null;
+  const games = safeRead();
+  const existing = games[resolvedId] ?? {};
+  const next: ArchivedGame = {
+    id: resolvedId,
+    season,
+    week,
+    homeId,
+    awayId,
+    homeAbbr: String(payload?.homeAbbr ?? payload?.homeTeam?.abbr ?? existing?.homeAbbr ?? "HME"),
+    awayAbbr: String(payload?.awayAbbr ?? payload?.awayTeam?.abbr ?? existing?.awayAbbr ?? "AWY"),
+    score: {
+      home: toNumberOrNull(payload?.homeScore ?? payload?.score?.home ?? existing?.score?.home),
+      away: toNumberOrNull(payload?.awayScore ?? payload?.score?.away ?? existing?.score?.away),
+    },
+    teamStats: payload?.teamStats ?? existing?.teamStats ?? null,
+    playerStats: payload?.playerStats ?? existing?.playerStats ?? null,
+    scoringSummary: Array.isArray(payload?.scoringSummary) ? payload.scoringSummary : (existing?.scoringSummary ?? []),
+    recapText: payload?.recapText ?? payload?.recap ?? existing?.recapText ?? null,
+    logs: Array.isArray(payload?.logs) ? payload.logs : (existing?.logs ?? []),
+    summary: payload?.summary ?? existing?.summary ?? null,
+    timestamp: Number(payload?.timestamp ?? Date.now()),
+  };
+
+  games[resolvedId] = next;
+  safeWrite(games);
+  return next;
+}
+
+export function getGame(gameId: string | null | undefined): ArchivedGame | null {
+  if (!gameId) return null;
+  const games = safeRead();
+  return games[String(gameId)] ?? null;
+}
+
+export function getRecentGames(limit = 10): ArchivedGame[] {
+  const items = Object.values(safeRead());
+  return items
+    .sort((a, b) => {
+      const seasonDiff = Number(b?.season ?? 0) - Number(a?.season ?? 0);
+      if (seasonDiff) return seasonDiff;
+      const weekDiff = Number(b?.week ?? 0) - Number(a?.week ?? 0);
+      if (weekDiff) return weekDiff;
+      return Number(b?.timestamp ?? 0) - Number(a?.timestamp ?? 0);
+    })
+    .slice(0, Math.max(0, Number(limit) || 10));
+}
+
+export function getGamesByWeek(season: string | number, week: number): ArchivedGame[] {
+  const seasonKey = String(season ?? "");
+  const weekNum = Number(week);
+  return Object.values(safeRead())
+    .filter((game) => String(game?.season ?? "") === seasonKey && Number(game?.week) === weekNum)
+    .sort((a, b) => Number(a?.timestamp ?? 0) - Number(b?.timestamp ?? 0));
+}

--- a/src/state/saveSchema.js
+++ b/src/state/saveSchema.js
@@ -1,4 +1,4 @@
-export const CURRENT_SAVE_SCHEMA_VERSION = 5.2;
+export const CURRENT_SAVE_SCHEMA_VERSION = 5.3;
 
 function migratePreVersioned(meta = {}) {
   return {
@@ -42,6 +42,7 @@ const MIGRATIONS = {
   4: migrateV4ToV5,
   5: migrateV5ToV51,
   5.1: migrateV51ToV52,
+  5.2: migrateV52ToV53,
 };
 
 function migrateV4ToV5(meta = {}) {
@@ -89,6 +90,18 @@ function migrateV51ToV52(meta = {}) {
     ...meta,
     economy,
     saveVersion: 5.2,
+  };
+}
+
+function migrateV52ToV53(meta = {}) {
+  return {
+    ...meta,
+    archiveMigration: {
+      ...(meta?.archiveMigration ?? {}),
+      v53: true,
+      upgradedAt: Date.now(),
+    },
+    saveVersion: 5.3,
   };
 }
 

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -53,6 +53,7 @@ import { ACTION_LABELS } from './constants/navigationCopy.js';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from './utils/boxScoreAccess.js';
 import { hasMinimumPlayableLeague, summarizeBootstrapState } from './utils/leagueBootstrap.js';
 import { buildCanonicalGameId } from '../core/gameIdentity.js';
+import { getRecentGames, saveGame } from '../core/archive/gameArchive.ts';
 
 // Increment this when shipping notable UX/bugfix updates so users
 // see the in-app changelog popup once per version.
@@ -132,6 +133,7 @@ function AppContent() {
   // Post-game result shown after GameSimulation completes (before advancing week)
   const [postGameResult, setPostGameResult] = useState(null);
   const [initFlow, setInitFlow] = useState(null);
+  const archiveMigrationRef = useRef(null);
 
   // Local guard to prevent rapid-click double submission before 'busy' propagates
   const advancingRef = useRef(false);
@@ -211,6 +213,57 @@ function AppContent() {
   }, [league, activeSlot, actions]);
 
   // ── Handlers ──────────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (!league?.seasonId || !league?.schedule?.weeks?.length) return;
+    const migrationKey = `footballgm_archive_v53_migrated_${league.seasonId}`;
+    if (archiveMigrationRef.current === migrationKey) return;
+    archiveMigrationRef.current = migrationKey;
+    try {
+      const alreadyMigrated = localStorage.getItem(migrationKey) === '1';
+      if (alreadyMigrated) return;
+      const hasArchive = getRecentGames(1).length > 0;
+      if (hasArchive) {
+        localStorage.setItem(migrationKey, '1');
+        return;
+      }
+      const completed = [];
+      league.schedule.weeks.forEach((weekRow) => {
+        (weekRow?.games ?? []).forEach((game) => {
+          if (!game?.played) return;
+          completed.push({
+            seasonId: league.seasonId,
+            week: Number(weekRow?.week ?? game?.week ?? 0),
+            game,
+          });
+        });
+      });
+      completed.slice(-32).forEach(({ seasonId, week, game }) => {
+        const homeTeam = league?.teams?.find((team) => Number(team?.id) === Number(game?.home));
+        const awayTeam = league?.teams?.find((team) => Number(team?.id) === Number(game?.away));
+        const gameId = buildCanonicalGameId({ seasonId, week, homeId: game?.home, awayId: game?.away });
+        saveGame(gameId, {
+          season: seasonId,
+          week,
+          homeId: game?.home,
+          awayId: game?.away,
+          homeAbbr: homeTeam?.abbr ?? 'HME',
+          awayAbbr: awayTeam?.abbr ?? 'AWY',
+          homeScore: game?.homeScore,
+          awayScore: game?.awayScore,
+          teamStats: game?.teamStats ?? null,
+          playerStats: game?.playerStats ?? null,
+          scoringSummary: game?.scoringSummary ?? [],
+          recapText: game?.recap ?? game?.summary?.storyline ?? null,
+          logs: game?.playLog ?? [],
+          summary: game?.summary ?? null,
+        });
+      });
+      localStorage.setItem(migrationKey, '1');
+    } catch {
+      // non-fatal
+    }
+  }, [league]);
 
   const handleAdvanceWeek = useCallback(() => {
     if (busy || simulating || advancingRef.current) return;
@@ -975,6 +1028,8 @@ function AppContent() {
                     week: league?.week,
                     phase: league?.phase,
                     logs: userGameLogs || [],
+                    liveStats: userGameLiveStats || null,
+                    seasonId: league?.seasonId,
                     gameId: buildCanonicalGameId({
                       seasonId: league?.seasonId,
                       week: league?.week,
@@ -1026,6 +1081,10 @@ function AppContent() {
               console.error('[PostGame] onContinue failed:', err);
               setPostGameResult(null);
             }
+          }}
+          onArchiveReady={(archivePayload) => {
+            if (!archivePayload?.gameId) return;
+            saveGame(archivePayload.gameId, archivePayload);
           }}
         />
       )}

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -143,7 +143,7 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
   const hasAnyPayload = Boolean(game && (
     game.homeScore != null || game.awayScore != null || game.stats || game.playerStats || game.teamStats || game.recap || game.quarterScores
   ));
-  const unavailableMessage = "No archived postgame data was found for this matchup.";
+  const unavailableMessage = "No data saved for this game.";
 
   const shell = (
       <div className={`${embedded ? "card" : "modal-content modal-large box-score-modal"}`} onClick={(e) => !embedded && e.stopPropagation()}>
@@ -175,7 +175,7 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
               </div>
             </section>
             {archiveQuality !== "full" && (
-              <section className="bs-section" style={{ marginTop: 4 }}>
+              <section className="bs-section" style={{ marginTop: 4 }} data-testid="archive-status">
                 <div className="bs-list-item" style={{ borderColor: "var(--warning)", color: "var(--text-muted)" }}>
                   {archiveQuality === "partial"
                     ? "Partial archive: final score and key summary data are available, but full drive/play detail was not stored."

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -4,9 +4,10 @@ import { evaluateWeeklyContext } from "../utils/weeklyContext.js";
 import { deriveTeamCapSnapshot, formatMoneyM } from "../utils/numberFormatting.js";
 import { findLatestUserCompletedGame } from "../utils/completedGameSelectors.js";
 import { getHQViewModel } from "../../state/selectors.js";
-import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/boxScoreAccess.js";
+import { buildCompletedGamePresentation } from "../utils/boxScoreAccess.js";
 import { persistHqCollapsedState, readHqCollapsedState } from "../utils/hqCardState.js";
 import { EmptyState, SectionCard, StatCard, TeamChip } from "./common/UiPrimitives.jsx";
+import { getRecentGames as getArchivedRecentGames } from "../../core/archive/gameArchive.ts";
 
 function safeNum(value, fallback = 0) {
   const n = Number(value);
@@ -36,18 +37,6 @@ function getNextGame(league) {
   return null;
 }
 
-function getRecentGames(league, limit = 5) {
-  const weeks = league?.schedule?.weeks ?? [];
-  const list = [];
-  weeks.forEach((week) => {
-    (week?.games ?? []).forEach((game) => {
-      if (!game?.played) return;
-      list.push({ game, week: Number(week?.week ?? game?.week ?? 0) });
-    });
-  });
-  return list.sort((a, b) => b.week - a.week).slice(0, limit);
-}
-
 function CollapsibleCard({ title, collapsed, onToggle, children }) {
   return (
     <SectionCard
@@ -65,7 +54,8 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
   const weekly = useMemo(() => evaluateWeeklyContext(vm.league), [vm.league]);
   const latest = useMemo(() => findLatestUserCompletedGame(vm.league), [vm.league]);
   const nextGame = useMemo(() => getNextGame(vm.league), [vm.league]);
-  const recentGames = useMemo(() => getRecentGames(vm.league), [vm.league]);
+  const recentGames = useMemo(() => getArchivedRecentGames(5), [vm.league?.seasonId, vm.league?.week]);
+  const latestArchived = useMemo(() => getArchivedRecentGames(1)?.[0] ?? null, [vm.league?.seasonId, vm.league?.week]);
   const [collapsed, setCollapsed] = useState(() => readHqCollapsedState());
 
   useEffect(() => {
@@ -163,20 +153,26 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
       <SectionCard title="Latest Finals">
         {recentGames.length === 0 ? <div style={{ color: "var(--text-muted)" }}>No completed games yet.</div> : (
           <div style={{ display: "grid", gap: 8 }}>
-            {recentGames.map(({ game, week }, idx) => {
-              const presentation = buildCompletedGamePresentation(game, { seasonId: vm.league?.seasonId, week, source: "hq_recent_games" });
+            {recentGames.map((game, idx) => {
+              const week = Number(game?.week ?? 0);
+              const presentation = buildCompletedGamePresentation({
+                ...game,
+                homeScore: game?.score?.home,
+                awayScore: game?.score?.away,
+              }, { seasonId: vm.league?.seasonId, week, source: "hq_recent_games" });
               return (
                 <button
-                  key={`${week}-${game.home}-${game.away}-${idx}`}
+                  key={`${week}-${game.homeId}-${game.awayId}-${idx}`}
                   type="button"
                   className="btn"
+                  data-testid="recent-game-card"
                   style={{ textAlign: "left", cursor: presentation.canOpen ? "pointer" : "not-allowed" }}
-                  onClick={() => openResolvedBoxScore(game, { seasonId: vm.league?.seasonId, week, source: "hq_recent_games" }, onOpenBoxScore)}
+                  onClick={() => onOpenBoxScore?.(game?.id)}
                   disabled={!presentation.canOpen}
                   title={presentation.canOpen ? "View Box Score" : presentation.statusLabel}
                 >
-                  <strong>Week {week}: {presentation.displayScoreLine}</strong>
-                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>{presentation.canOpen ? "View Box Score ›" : presentation.statusLabel}</div>
+                  <strong>Week {week}: {game?.awayAbbr} {game?.score?.away} - {game?.score?.home} {game?.homeAbbr}</strong>
+                  <div data-testid="archive-status" style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>{presentation.canOpen ? "View Box Score ›" : presentation.statusLabel}</div>
                 </button>
               );
             })}
@@ -184,11 +180,15 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
         )}
       </SectionCard>
 
-      {latest?.game && (
+      {(latestArchived || latest?.game) && (
         <SectionCard title="Last User Game">
           <Button
             size="sm"
-            onClick={() => openResolvedBoxScore(latest.game, { seasonId: vm.league?.seasonId, week: latest.week, source: "hq_recent_results" }, onOpenBoxScore)}
+            data-testid="box-score-trigger"
+            onClick={() => {
+              const gameId = latestArchived?.id ?? latest?.gameId;
+              if (gameId) onOpenBoxScore?.(gameId);
+            }}
           >
             Open latest box score
           </Button>

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -84,6 +84,8 @@ import {
 import { deriveFranchisePressure } from "../utils/pressureModel.js";
 import { getClickableCardProps } from "../utils/clickableCard.js";
 import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/boxScoreAccess.js";
+import { resolveCompletedGameId } from "../utils/gameResultIdentity.js";
+import { getGame as getArchivedGame } from "../../core/archive/gameArchive.ts";
 import { normalizeManagementDestination } from "../utils/managementScreenRouting.js";
 import { createBoxScoreTapHandler } from "../utils/scoreTapTarget.js";
 import { safeGetLeagueState, getScheduleViewModel } from "../../state/selectors.js";
@@ -216,6 +218,14 @@ const NAV_GROUPS = [
   { id: SHELL_SECTIONS.transactions, title: "Transactions", tabs: ["Transactions", "Free Agency", "Draft", "Draft Room", "Mock Draft"] },
   { id: SHELL_SECTIONS.history, title: "History", tabs: ["History Hub", "History", "Hall of Fame", "Awards & Records", "Season Recap", "Team History", "Saves"] },
 ];
+
+const NAV_TEST_IDS = {
+  [SHELL_SECTIONS.hq]: "nav-hq",
+  [SHELL_SECTIONS.team]: "nav-team",
+  [SHELL_SECTIONS.league]: "nav-league",
+  [SHELL_SECTIONS.transactions]: "nav-transactions",
+  [SHELL_SECTIONS.history]: "nav-history",
+};
 
 const TEAM_FACING_TABS = new Set(["Roster", "Depth Chart", "Roster Hub", "Game Plan", "Training", "Injuries", "Staff", "Financials", "Contract Center"]);
 const TAB_ALIASES = {
@@ -794,21 +804,49 @@ function ScheduleTab({
         return homeId === Number(selectedTeamId) || awayId === Number(selectedTeamId);
       })
       : scheduleModel.games;
-  const visibleGames = filteredGames.filter((game) => {
-    if (statusFilter === 'completed') return Boolean(game?.played);
-    if (statusFilter === 'upcoming') return !Boolean(game?.played);
-    return true;
+  const mergedVisibleGames = filteredGames.map((game) => {
+    const gameId = resolveCompletedGameId(game, { seasonId, week: selectedWeek });
+    const archived = game?.played ? getArchivedGame(gameId) : null;
+    if (!archived) return game;
+    return {
+      ...game,
+      gameId,
+      homeScore: archived?.score?.home ?? game?.homeScore,
+      awayScore: archived?.score?.away ?? game?.awayScore,
+      homeAbbr: archived?.homeAbbr,
+      awayAbbr: archived?.awayAbbr,
+      teamStats: archived?.teamStats ?? game?.teamStats,
+      playerStats: archived?.playerStats ?? game?.playerStats,
+      scoringSummary: archived?.scoringSummary ?? game?.scoringSummary,
+      recap: archived?.recapText ?? game?.recap,
+      playLog: archived?.logs ?? game?.playLog,
+      summary: archived?.summary ?? game?.summary,
+    };
   });
   const weeklyHonors = useMemo(() => deriveWeeklyHonors(league), [league]);
   const weekRecapItems = useMemo(() => (
     games
       .filter((game) => game?.played)
       .map((game) => {
+        const gameId = resolveCompletedGameId(game, { seasonId, week: selectedWeek });
+        const archived = getArchivedGame(gameId);
+        const gameWithArchive = archived ? {
+          ...game,
+          gameId,
+          homeScore: archived?.score?.home ?? game?.homeScore,
+          awayScore: archived?.score?.away ?? game?.awayScore,
+          recap: archived?.recapText ?? game?.recap,
+          teamStats: archived?.teamStats ?? game?.teamStats,
+          playerStats: archived?.playerStats ?? game?.playerStats,
+          scoringSummary: archived?.scoringSummary ?? game?.scoringSummary,
+          playLog: archived?.logs ?? game?.playLog,
+          summary: archived?.summary ?? game?.summary,
+        } : game;
         const home = teamById[game.home] ?? { abbr: "HOME" };
         const away = teamById[game.away] ?? { abbr: "AWAY" };
-        const presentation = buildCompletedGamePresentation(game, { seasonId, week: selectedWeek, teamById, source: "schedule_recap" });
-        const story = derivePostgameStory({ league, game, week: selectedWeek });
-        return { game, home, away, presentation, story };
+        const presentation = buildCompletedGamePresentation(gameWithArchive, { seasonId, week: selectedWeek, teamById, source: "schedule_recap" });
+        const story = derivePostgameStory({ league, game: gameWithArchive, week: selectedWeek });
+        return { game: gameWithArchive, home, away, presentation, story };
       })
       .slice(0, 8)
   ), [games, league, seasonId, selectedWeek, teamById]);
@@ -943,7 +981,11 @@ function ScheduleTab({
             </div>
           </div>
         )}
-        {visibleGames.map((game, idx) => {
+        {mergedVisibleGames.filter((game) => {
+          if (statusFilter === 'completed') return Boolean(game?.played);
+          if (statusFilter === 'upcoming') return !Boolean(game?.played);
+          return true;
+        }).map((game, idx) => {
           const home = teamById[game.home] ?? {
             name: `Team ${game.home}`,
             abbr: "???",
@@ -1927,7 +1969,7 @@ export default function LeagueDashboard({
           {NAV_GROUPS.map((group) => (
             <button
               key={group.id}
-              data-testid={`primary-nav-${toTestId(group.title)}`}
+              data-testid={NAV_TEST_IDS[group.id] ?? `primary-nav-${toTestId(group.title)}`}
               className={`standings-tab${activeSection === group.id ? " active" : ""}`}
               onClick={() => handleSectionChange(group.id)}
               aria-current={activeSection === group.id ? "page" : undefined}

--- a/src/ui/components/PostGameScreen.jsx
+++ b/src/ui/components/PostGameScreen.jsx
@@ -207,6 +207,7 @@ function PostGameScreenInner({
   boxScoreGameId,
   onOpenBoxScore,
   onContinue,
+  onArchiveReady,
   week,
   phase,
 }) {
@@ -260,6 +261,32 @@ function PostGameScreenInner({
     : null;
 
   const showLeaders = qb || receiver || rusher || defender;
+  const archiveSavedRef = React.useRef(false);
+  React.useEffect(() => {
+    if (archiveSavedRef.current || !boxScoreGameId || typeof onArchiveReady !== "function") return;
+    archiveSavedRef.current = true;
+    const recapText = notableMoments.length
+      ? notableMoments.map((m) => `Q${m.quarter ?? "?"} ${m.clock ?? ""} ${m.text ?? "Momentum swing"}`).join(" ")
+      : `${awayTeam?.abbr ?? "AWY"} ${awayScore} - ${homeScore} ${homeTeam?.abbr ?? "HME"}`;
+    onArchiveReady({
+      gameId: boxScoreGameId,
+      season: null,
+      week,
+      homeId: homeTeam?.id,
+      awayId: awayTeam?.id,
+      homeAbbr: homeTeam?.abbr,
+      awayAbbr: awayTeam?.abbr,
+      homeScore,
+      awayScore,
+      recapText,
+      logs,
+      scoringSummary: notableMoments,
+      summary: {
+        storyline: recapText,
+        simOutputs: null,
+      },
+    });
+  }, [awayScore, awayTeam?.abbr, awayTeam?.id, boxScoreGameId, homeScore, homeTeam?.abbr, homeTeam?.id, logs, notableMoments, onArchiveReady, week]);
 
   return (
     <>
@@ -387,6 +414,7 @@ function PostGameScreenInner({
               <button
                 className="btn-link"
                 type="button"
+                data-testid="box-score-trigger"
                 onClick={() => boxScoreGameId && onOpenBoxScore?.(boxScoreGameId)}
                 disabled={!boxScoreGameId}
                 style={{ cursor: boxScoreGameId ? "pointer" : "not-allowed", fontWeight: 700 }}

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -2034,7 +2034,7 @@ export default function Roster({ league, actions, onPlayerSelect, initialState =
   const [team, setTeam] = useState(null);
   const [players, setPlayers] = useState([]);
   const [viewMode, setViewMode] = useState(initialConfig.safeView); // 'cards' | 'table' | 'depth'
-  const [initialFilter, setInitialFilter] = useState(initialConfig.safeFilter);
+  const [initialFilter, setInitialFilter] = useState(null);
   const [selectedPlayerId, setSelectedPlayerId] = useState(null);
 
   const fetchRoster = useCallback(async () => {
@@ -2065,7 +2065,7 @@ export default function Roster({ league, actions, onPlayerSelect, initialState =
 
   useEffect(() => {
     const next = normalizeInitialRosterState(initialState, initialViewMode);
-    setInitialFilter(next.safeFilter);
+    setInitialFilter(next?.safeFilter ?? null);
     if (next.safeView) setViewMode(next.safeView);
   }, [initialState, initialViewMode]);
 

--- a/tests/e2e/core_flow_reliability.spec.js
+++ b/tests/e2e/core_flow_reliability.spec.js
@@ -23,7 +23,7 @@ test.describe('Core flow reliability', () => {
     await goToTab(page, 'free-agency');
     await expect(page.getByText('Free Agency').first()).toBeVisible();
 
-    await page.locator('[data-testid="primary-nav-history"]').first().click();
+    await page.locator('[data-testid="nav-history"], [data-testid="primary-nav-history"]').first().click();
     await page.locator('[data-testid="section-tab-history-hub"]').first().click();
     await expect(page.getByText('History Hub').first()).toBeVisible();
   });
@@ -44,6 +44,15 @@ test.describe('Core flow reliability', () => {
 
     await goToTab(page, 'schedule');
     await page.locator('.matchup-card.clickable-card').first().click();
+    await expect(page.getByText('Final Game Book').first()).toBeVisible();
+  });
+
+  test('recent games card opens archived box score', async ({ page }) => {
+    await launchFranchise(page);
+    await simulateSingleWeek(page);
+
+    await goToTab(page, 'hq');
+    await page.locator('[data-testid="recent-game-card"]').first().click();
     await expect(page.getByText('Final Game Book').first()).toBeVisible();
   });
 

--- a/tests/e2e/helpers/franchise.js
+++ b/tests/e2e/helpers/franchise.js
@@ -77,7 +77,7 @@ export async function goToTab(page, name) {
   };
   const primary = sectionByTab[tab];
   if (primary) {
-    const primaryLocator = page.locator(`[data-testid="primary-nav-${primary}"]`).first();
+    const primaryLocator = page.locator(`[data-testid="nav-${primary}"], [data-testid="primary-nav-${primary}"]`).first();
     if (await primaryLocator.isVisible().catch(() => false)) {
       await primaryLocator.click();
     }


### PR DESCRIPTION
### Motivation
- Persist per-game postgame payloads locally so historical box scores, recaps, and stats remain available after advancing weeks and avoid "Archive unavailable" UI states.
- Surface archived results in HQ Recent Games and Schedule so users see real team abbreviations and scores and can open full game books without a backend.
- Provide an additive, non-destructive migration path (v5.2 → v5.3) and a safe backfill for existing saves so v5.2 saves are preserved.

### Description
- Added a local archive module `src/core/archive/gameArchive.ts` that exposes `saveGame`, `getGame`, `getRecentGames(limit=10)`, and `getGamesByWeek(season, week)` and stores data under the `footballgm_game_archive_v1` key.
- Wire postgame persistence: `PostGameScreen` emits an `onArchiveReady` payload and `App` calls `saveGame(...)` immediately after game completion to persist full archive payloads (ids, teams, scores, logs, recap, timestamp).
- Read archives in UI: `FranchiseHQ` now sources Recent Games from `getRecentGames()` and shows real abbreviations/scores with rows clickable to open the archived game, and the Last User Game button opens the latest archived box score.
- Schedule/recap surfaces merge archived payloads by canonical game id in `LeagueDashboard`, so Completed/Recap views reflect archived content (archiveQuality, scores, recaps, team/player stats) when available.
- Box score UX improvements: `BoxScore` shows a friendly `"No data saved for this game."` message when archive is missing and adds a `data-testid="archive-status"` hook for tests.
- Migration/backfill: bumped save schema to `5.3` and added a non-destructive `migrateV52ToV53` marker; on app load, if the archive is empty, the app backfills recent completed schedule games into the archive and sets a per-season migration flag (`footballgm_archive_v53_migrated_<season>`).
- Stabilization and test hooks: fixed roster initial-filter crash by null-guarding `initialFilter`, added test ids `recent-game-card`, `box-score-trigger`, `archive-status`, and top-level nav test ids (`nav-hq`, `nav-team`, `nav-league`, `nav-transactions`, `nav-history`), and updated E2E helper selectors to accept both legacy and new nav ids.
- Tests added: unit tests for the archive store at `src/core/archive/gameArchive.test.ts` and a Playwright e2e test that opens a box score from the Recent Games card.

### Testing
- Unit: ran `npm run test:unit -- src/core/archive/gameArchive.test.ts` and the archive unit suite passed locally (2 tests ✅).
- Build: ran `npm run build` and produced a successful production build (vite build ✅).
- Playwright: attempted `npm run test -- tests/e2e/core_flow_reliability.spec.js --grep "recent games card opens archived box score"`, but the Playwright run failed in this environment because Playwright browser binaries are not installed (`npx playwright install` required); the test exercises the Recent Games → Box Score flow and is expected to pass in CI with browsers installed (⚠️).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc36aebf78832d8b9469a335e902ff)