### PR TITLE
League economy inflation tuning and veteran restructure guardrails

### DIFF
--- a/src/core/__tests__/economy.test.js
+++ b/src/core/__tests__/economy.test.js
@@ -15,4 +15,14 @@ describe('league economy progression', () => {
     expect(contract.baseAnnual).toBe(22);
     expect(contract.signingBonus).toBe(11);
   });
+
+  it('uses tracked season inflation so long saves increase asks even with modest cap drift', () => {
+    const mult = getSalaryInflationMultiplier({
+      baseSalaryCap: 300,
+      currentSalaryCap: 320,
+      annualSalaryInflationRate: 0.03,
+      economyHistory: [{ season: 2026, salaryCap: 300 }, { season: 2027, salaryCap: 309 }, { season: 2028, salaryCap: 318 }],
+    });
+    expect(mult).toBeCloseTo(1.0667, 4);
+  });
 });

--- a/src/core/__tests__/restructure.test.js
+++ b/src/core/__tests__/restructure.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeRestructureOutcome, shouldPreserveChemistryOnReturn } from '../contracts/restructure.js';
+import { computeRestructureOutcome, isContractRestructureEligible, shouldPreserveChemistryOnReturn } from '../contracts/restructure.js';
 
 describe('contract restructure baseline', () => {
   it('reduces current cap hit and increases future prorated burden', () => {
@@ -17,5 +17,16 @@ describe('offseason chemistry continuity', () => {
     expect(shouldPreserveChemistryOnReturn({ releaseRecord, signingTeamId: 4, currentSeason: 2028 })).toBe(true);
     expect(shouldPreserveChemistryOnReturn({ releaseRecord, signingTeamId: 5, currentSeason: 2028 })).toBe(false);
     expect(shouldPreserveChemistryOnReturn({ releaseRecord, signingTeamId: 4, currentSeason: 2029 })).toBe(false);
+  });
+});
+
+describe('restructure eligibility guardrails', () => {
+  it('requires veteran profile and available restructure slots', () => {
+    const vet = { age: 30, contract: { years: 3, baseAnnual: 16, restructureCount: 1 } };
+    expect(isContractRestructureEligible(vet, { currentSeason: 2028 })).toBe(true);
+    const nonVet = { age: 24, accruedSeasons: 2, contract: { years: 3, baseAnnual: 16 } };
+    expect(isContractRestructureEligible(nonVet, { currentSeason: 2028 })).toBe(false);
+    const exhausted = { age: 31, contract: { years: 3, baseAnnual: 16, restructureCount: 2 } };
+    expect(isContractRestructureEligible(exhausted, { currentSeason: 2028 })).toBe(false);
   });
 });

--- a/src/core/contracts/restructure.js
+++ b/src/core/contracts/restructure.js
@@ -24,6 +24,23 @@ export function computeRestructureOutcome(contract = {}, maxConvertPct = 0.5) {
   };
 }
 
+export function isContractRestructureEligible(player = {}, { currentSeason = null } = {}) {
+  const contract = player?.contract ?? player ?? {};
+  const yearsRemaining = Math.max(0, n(contract?.years ?? contract?.yearsRemaining ?? 0));
+  const baseAnnual = n(contract?.baseAnnual ?? player?.baseAnnual, 0);
+  const restructureCount = n(contract?.restructureCount, 0);
+  const lastRestructureSeason = n(contract?.lastRestructureSeason, -1);
+  const age = n(player?.age, 0);
+  const accruedSeasons = n(player?.accruedSeasons ?? player?.serviceYears, 0);
+  const veteranEligible = age >= 27 || accruedSeasons >= 4;
+  const alreadyRestructuredThisSeason = currentSeason != null && lastRestructureSeason === Number(currentSeason);
+  return yearsRemaining >= 2
+    && baseAnnual > 0
+    && veteranEligible
+    && !alreadyRestructuredThisSeason
+    && restructureCount < 2;
+}
+
 export function shouldPreserveChemistryOnReturn({ releaseRecord, signingTeamId, currentSeason }) {
   if (!releaseRecord) return false;
   if (Number(releaseRecord.teamId) !== Number(signingTeamId)) return false;

--- a/src/core/economy.js
+++ b/src/core/economy.js
@@ -65,7 +65,10 @@ export function projectNextSeasonEconomy(economy = {}, nextSeason) {
 
 export function getSalaryInflationMultiplier(economy = {}) {
   const normalized = normalizeLeagueEconomy(economy);
-  return Math.max(0.85, normalized.currentSalaryCap / Math.max(1, normalized.baseSalaryCap));
+  const capMultiplier = normalized.currentSalaryCap / Math.max(1, normalized.baseSalaryCap);
+  const seasonsTracked = Math.max(0, (normalized.economyHistory?.length ?? 1) - 1);
+  const inflationMultiplier = Math.pow(1 + normalized.annualSalaryInflationRate, seasonsTracked);
+  return Math.max(0.85, Math.min(3, Math.max(capMultiplier, inflationMultiplier)));
 }
 
 export function inflateContract(contract = {}, multiplier = 1) {

--- a/src/ui/components/FinancialsView.jsx
+++ b/src/ui/components/FinancialsView.jsx
@@ -24,6 +24,7 @@ import FranchiseInvestmentsPanel from "./FranchiseInvestmentsPanel.jsx";
 import { classifyTeamDirection, evaluateResignRecommendation } from "../utils/contractInsights.js";
 import { CONTRACT_PLAN_LABELS, normalizeManagement } from "../utils/playerManagement.js";
 import InfoTip from "./InfoTip.jsx";
+import { computeRestructureOutcome, isContractRestructureEligible } from "../../core/contracts/restructure.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -210,11 +211,9 @@ export default function FinancialsView({ league, actions }) {
         baseAnnual: p.contract?.baseAnnual ?? p.baseAnnual ?? 0,
         signingBonus: p.contract?.signingBonus ?? 0,
         yearsTotal: p.contract?.yearsTotal ?? 1,
-        canRestructure:
-          (p.contract?.years ?? 1) >= 2 &&
-          (p.contract?.baseAnnual ?? p.baseAnnual ?? 0) > 0,
+        canRestructure: isContractRestructureEligible(p, { currentSeason: league?.year }),
       })),
-    [players],
+    [players, league?.year],
   );
 
   // Sorted player list
@@ -329,13 +328,9 @@ export default function FinancialsView({ league, actions }) {
 
   const handleRestructure = async (player) => {
     if (!actions?.restructureContract) return;
-    const currentCapHit = capHitOf(player);
-    const years = Math.max(1, Number(player?.contract?.years ?? player?.contract?.yearsRemaining ?? 1));
-    const convertAmount = Number(player?.contract?.baseAnnual ?? 0) * 0.5;
-    const projectedBonus = Number(player?.contract?.signingBonus ?? 0) + convertAmount;
-    const projectedCapHit = (Number(player?.contract?.baseAnnual ?? 0) - convertAmount) + (projectedBonus / years);
+    const outcome = computeRestructureOutcome(player?.contract ?? {}, 0.5);
     const proceed = window.confirm(
-      `Restructure ${player.name}?\nCurrent cap hit: ${fmt(currentCapHit)}\nNew cap hit: ${fmt(projectedCapHit)}\nFuture bonus impact: +${fmt(convertAmount / years)} per remaining year.`
+      `Restructure ${player.name}?\nCurrent cap hit: ${fmt(outcome.oldCapHit)}\nNew cap hit: ${fmt(outcome.newCapHit)}\nCap savings this year: ${fmt(outcome.capSavingsThisYear)}\nFuture dead-cap exposure: +${fmt(outcome.futureAnnualBonusDelta)} per remaining season if released.`
     );
     if (!proceed) return;
     setRestructuring(player.id);

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -81,7 +81,7 @@ import {
 } from '../core/contract-market.js';
 import { getTeamContextForNegotiation } from '../core/teamContext/negotiationContext.js';
 import { evaluateContractOffer, summarizeNegotiationStance } from '../core/contracts/negotiation.js';
-import { computeRestructureOutcome, shouldPreserveChemistryOnReturn } from '../core/contracts/restructure.js';
+import { computeRestructureOutcome, shouldPreserveChemistryOnReturn, isContractRestructureEligible } from '../core/contracts/restructure.js';
 import { summarizePlayerMood } from '../core/mood/playerMood.js';
 import { getFreeAgencyDecisionState } from '../core/freeAgency/decisionState.js';
 import {
@@ -5548,17 +5548,12 @@ async function handleRestructureContract({ playerId, teamId }, id) {
     guaranteedPct:player.guaranteedPct ?? 0.5,
   };
 
-  const yearsRemaining = contract.years ?? 1;
-  if (yearsRemaining < 2) {
-    post(toUI.ERROR, { message: 'Cannot restructure: player must have at least 2 years remaining.' }, id);
+  const eligible = isContractRestructureEligible({ ...player, contract }, { currentSeason: meta?.year });
+  if (!eligible) {
+    post(toUI.ERROR, { message: 'Cannot restructure: requires veteran player, 2+ years remaining, and unused restructure slots.' }, id);
     return;
   }
   const restructureCount = Number(contract?.restructureCount ?? 0);
-  const sameSeason = Number(contract?.lastRestructureSeason ?? 0) === Number(meta?.year ?? 0);
-  if (sameSeason || restructureCount >= 2) {
-    post(toUI.ERROR, { message: 'Cannot restructure: limit reached for this contract this offseason.' }, id);
-    return;
-  }
 
   const maxConvertPct = Constants.SALARY_CAP.RESTRUCTURE_MAX_CONVERT_PCT;
   const outcome = computeRestructureOutcome(contract, maxConvertPct);

--- a/tests/unit/saveSchemaEconomy.test.js
+++ b/tests/unit/saveSchemaEconomy.test.js
@@ -8,4 +8,12 @@ describe('save schema v5.2 economy migration', () => {
     expect(migrated.economy.currentSalaryCap).toBe(312.5);
     expect(migrated.economy.baseSalaryCap).toBe(312.5);
   });
+
+  it('migrates pre-economy saves with safe defaults when salary cap setting is absent', () => {
+    const { migrated } = migrateSaveMetaToCurrent({ saveVersion: 4, settings: {} });
+    expect(migrated.saveVersion).toBe(CURRENT_SAVE_SCHEMA_VERSION);
+    expect(migrated.economy.currentSalaryCap).toBe(301.2);
+    expect(migrated.economy.annualCapGrowthRate).toBe(0.035);
+    expect(migrated.economy.annualSalaryInflationRate).toBe(0.025);
+  });
 });


### PR DESCRIPTION
### Motivation
- Make long-term contracts and cap progression more meaningful by having contract asks reflect both cap growth and tracked inflation over multiple seasons while keeping saves backward-compatible.
- Provide a safe, first-version contract restructure flow with clear limits and pre-confirmation impact info to avoid exploitative or spammy restructures.
- Preserve same-offseason chemistry continuity and surface free-agent playbook familiarity for better signing decisions without changing save schemas destructively.

### Description
- Add `isContractRestructureEligible(...)` to `src/core/contracts/restructure.js` to centralize veteran + anti-spam guardrails for restructures.
- Expand `getSalaryInflationMultiplier` in `src/core/economy.js` to consider both cap-relative drift and tracked-season inflation (via `economyHistory`) and bound the multiplier (min 0.85, max 3.0) to prevent runaway inflation.
- Enforce the new eligibility guard in `handleRestructureContract` in `src/worker/worker.js`, and keep restructure bookkeeping (`restructureCount`, `lastRestructureSeason`) unchanged but validated server-side.
- Update `src/ui/components/FinancialsView.jsx` to reuse `computeRestructureOutcome` for the pre-confirmation dialog and show clearer before/after cap impact and future dead-cap exposure.
- Add/adjust tests: long-save inflation behavior, restructure eligibility guardrails, and migration defaults for older saves; keep migrations additive/backfill-safe.
- Intentionally defer more advanced restructure mechanics (custom conversion sliders, void years, revised guarantees) to follow-up work.

### Testing
- Ran targeted unit tests with Vitest: `src/core/__tests__/economy.test.js`, `src/core/__tests__/restructure.test.js`, `tests/unit/saveSchemaEconomy.test.js`, and `src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx`; all tests passed (9/9).
- Performed a production build with `npm run build`; build completed successfully and bundles were produced.
- Added migration/backfill test validating safe defaults for pre-economy saves to ensure backward compatibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc39719fcc832db890aea27a8fb02f)