### PR TITLE
Add NFL 32-team schedule templates and integrate with scheduler

### DIFF
--- a/src/core/__tests__/schedule.test.js
+++ b/src/core/__tests__/schedule.test.js
@@ -1,10 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { makeAccurateSchedule } from '../schedule.js';
 
-function createTeams(n) {
+function createTeams(n, withStructure = true) {
   return Array.from({ length: n }, (_, i) => ({
     id: i + 1,
     name: `Team ${i + 1}`,
+    ...(withStructure
+      ? {
+          conf: Math.floor(i / 16),
+          div: Math.floor((i % 16) / 4),
+        }
+      : {}),
   }));
 }
 
@@ -32,6 +38,7 @@ describe('makeAccurateSchedule', () => {
   it('builds an 18 week schedule for a 32-team league', () => {
     const schedule = makeAccurateSchedule(createTeams(32));
     expect(schedule.weeks).toHaveLength(18);
+    expect(schedule.metadata.type).toBe('nfl-template');
   });
 
   it('ensures each team gets exactly 17 games and 1 bye in 32-team mode', () => {
@@ -49,5 +56,21 @@ describe('makeAccurateSchedule', () => {
     const schedule = makeAccurateSchedule(createTeams(8));
     expect(schedule.metadata.type).toBe('simple-fallback');
     expect(schedule.weeks).toHaveLength(18);
+  });
+
+  it('falls back safely when league structure is not NFL-style', () => {
+    const schedule = makeAccurateSchedule(createTeams(32, false));
+    expect(schedule.weeks).toHaveLength(18);
+    expect(schedule.metadata.type).toBe('nfl-style');
+  });
+
+  it('rotates template deterministically by season', () => {
+    const teams = createTeams(32);
+    const season0 = makeAccurateSchedule(teams, 0);
+    const season1 = makeAccurateSchedule(teams, 1);
+    const season4 = makeAccurateSchedule(teams, 4);
+
+    expect(season0.weeks[0].games).toEqual(season4.weeks[0].games);
+    expect(season0.weeks[0].games).not.toEqual(season1.weeks[0].games);
   });
 });

--- a/src/core/schedule.js
+++ b/src/core/schedule.js
@@ -1,17 +1,22 @@
 import { Utils } from './utils.js';
+import {
+    canUseNfl32Templates,
+    materializeTemplateSchedule,
+    validateMaterializedTemplateSchedule
+} from '../data/nflScheduleTemplates.js';
 
 /**
  * Main function to create the schedule.
  * @param {Array} teams - Array of team objects
  * @returns {Object} Schedule object with weeks array
  */
-function makeAccurateSchedule(teams) {
+function makeAccurateSchedule(teams, season = 0) {
     if (!teams || teams.length !== 32) {
         console.warn('Expected 32 teams, got', teams?.length, '. Using simple schedule as fallback.');
         return createSimpleSchedule(teams || []);
     }
     try {
-        return createNFLStyleSchedule(teams);
+        return createNFLStyleSchedule(teams, season);
     } catch (error) {
         console.error('Error creating NFL schedule, falling back to simple schedule:', error);
         return createSimpleSchedule(teams);
@@ -23,12 +28,22 @@ function makeAccurateSchedule(teams) {
  * @param {Array} teams - Array of team objects
  * @returns {Object} Schedule object
  */
-function createNFLStyleSchedule(teams) {
+function createNFLStyleSchedule(teams, season = 0) {
 
 
     if (!teams || teams.length !== 32) {
         console.error('Invalid teams array for NFL schedule');
         return createSimpleSchedule(teams);
+    }
+
+    if (canUseNfl32Templates(teams)) {
+        try {
+            const templateWeeks = materializeTemplateSchedule(teams, season);
+            validateMaterializedTemplateSchedule(templateWeeks, teams.length);
+            return buildTemplateBackedSchedule(teams, templateWeeks);
+        } catch (error) {
+            console.error('NFL template generation failed, falling back to procedural generator:', error);
+        }
     }
 
     const schedule = {
@@ -80,6 +95,42 @@ function createNFLStyleSchedule(teams) {
 
     logScheduleStats(schedule, teams);
     return schedule;
+}
+
+function buildTemplateBackedSchedule(teams, templateWeeks) {
+    return {
+        weeks: templateWeeks.map((week) => {
+            const teamsInWeek = new Set();
+            const games = week.games.map((game) => {
+                teamsInWeek.add(game.homeTid);
+                teamsInWeek.add(game.awayTid);
+                return {
+                    home: game.homeTid,
+                    away: game.awayTid,
+                    week: week.week
+                };
+            });
+            const teamsWithBye = teams
+                .map((team) => team.id)
+                .filter((teamId) => !teamsInWeek.has(teamId));
+
+            if (teamsWithBye.length > 0) {
+                games.unshift({ bye: teamsWithBye });
+            }
+
+            return {
+                weekNumber: week.week,
+                week: week.week,
+                games,
+                teamsWithBye
+            };
+        }),
+        teams,
+        metadata: {
+            generated: new Date().toISOString(),
+            type: 'nfl-template'
+        }
+    };
 }
 
 /**

--- a/src/data/nflScheduleTemplates.js
+++ b/src/data/nflScheduleTemplates.js
@@ -1,0 +1,237 @@
+const TEAM_INFOS = {
+  0: [0, 0, 0], 1: [0, 0, 1], 2: [0, 0, 2], 3: [0, 0, 3],
+  4: [0, 1, 0], 5: [0, 1, 1], 6: [0, 1, 2], 7: [0, 1, 3],
+  8: [0, 2, 0], 9: [0, 2, 1], 10: [0, 2, 2], 11: [0, 2, 3],
+  12: [0, 3, 0], 13: [0, 3, 1], 14: [0, 3, 2], 15: [0, 3, 3],
+  16: [1, 0, 0], 17: [1, 0, 1], 18: [1, 0, 2], 19: [1, 0, 3],
+  20: [1, 1, 0], 21: [1, 1, 1], 22: [1, 1, 2], 23: [1, 1, 3],
+  24: [1, 2, 0], 25: [1, 2, 1], 26: [1, 2, 2], 27: [1, 2, 3],
+  28: [1, 3, 0], 29: [1, 3, 1], 30: [1, 3, 2], 31: [1, 3, 3],
+};
+
+const TEMPLATE_TEAM_IDS = Array.from({ length: 32 }, (_, i) => i);
+// Matchup tuple order is [homeTemplateTeamId, awayTemplateTeamId].
+// If a caller needs [away, home], adapt in one place during materialization.
+
+function rotateArray(values, offset) {
+  const size = values.length;
+  if (size === 0) return [];
+  const normalized = ((offset % size) + size) % size;
+  return [...values.slice(normalized), ...values.slice(0, normalized)];
+}
+
+function buildGeneratedTemplate(seed) {
+  const weeks = [];
+
+  for (let week = 1; week <= 18; week++) {
+    const byeWeekIndex = week >= 5 && week <= 12 ? week - 5 : -1;
+    const byeTeams = byeWeekIndex >= 0
+      ? TEMPLATE_TEAM_IDS.filter(teamId => ((teamId + seed) % 8) === byeWeekIndex)
+      : [];
+
+    const activeTeams = TEMPLATE_TEAM_IDS.filter(teamId => !byeTeams.includes(teamId));
+    const rotated = rotateArray(activeTeams, week * (seed + 1));
+    const half = rotated.length / 2;
+    const matchups = [];
+
+    for (let i = 0; i < half; i++) {
+      const teamA = rotated[i];
+      const teamB = rotated[i + half];
+      const shouldFlip = (week + i + seed) % 2 === 0;
+      matchups.push(shouldFlip ? [teamB, teamA] : [teamA, teamB]);
+    }
+
+    weeks.push({ day: week, matchups });
+  }
+
+  return weeks;
+}
+
+export const NFL_32_TEMPLATE_PACK = {
+  schedules: [0, 1, 2, 3].map(buildGeneratedTemplate),
+  teamInfos: TEAM_INFOS,
+};
+
+function getTeamConferenceId(team) {
+  return team.cid ?? team.conf ?? team.conferenceId ?? team.conference ?? null;
+}
+
+function getTeamDivisionId(team) {
+  return team.did ?? team.div ?? team.divisionId ?? team.division ?? null;
+}
+
+export function getTemplateIndexForSeason(season) {
+  const count = NFL_32_TEMPLATE_PACK.schedules.length;
+  if (count === 0) {
+    throw new Error('NFL_32_TEMPLATE_PACK.schedules is empty');
+  }
+
+  return Math.abs(Number(season) || 0) % count;
+}
+
+export function canUseNfl32Templates(teams) {
+  if (!Array.isArray(teams) || teams.length !== 32) {
+    return false;
+  }
+
+  const conferenceDivisionCounts = new Map();
+
+  for (const team of teams) {
+    const cid = getTeamConferenceId(team);
+    const did = getTeamDivisionId(team);
+
+    if (cid == null || did == null) {
+      return false;
+    }
+
+    const key = `${cid}:${did}`;
+    conferenceDivisionCounts.set(key, (conferenceDivisionCounts.get(key) ?? 0) + 1);
+  }
+
+  if (conferenceDivisionCounts.size !== 8) {
+    return false;
+  }
+
+  const conferences = new Set();
+  const divisionsByConference = new Map();
+
+  for (const key of conferenceDivisionCounts.keys()) {
+    const [cidRaw, didRaw] = key.split(':');
+    const cid = Number(cidRaw);
+    const did = Number(didRaw);
+    conferences.add(cid);
+    const divSet = divisionsByConference.get(cid) ?? new Set();
+    divSet.add(did);
+    divisionsByConference.set(cid, divSet);
+  }
+
+  if (conferences.size !== 2) {
+    return false;
+  }
+
+  for (const count of conferenceDivisionCounts.values()) {
+    if (count !== 4) {
+      return false;
+    }
+  }
+
+  for (const divSet of divisionsByConference.values()) {
+    if (divSet.size !== 4) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function buildTemplateSlotToTidMap(teams) {
+  const grouped = new Map();
+
+  for (const team of teams) {
+    const cid = getTeamConferenceId(team);
+    const did = getTeamDivisionId(team);
+    const tid = team.tid ?? team.id;
+
+    if (cid == null || did == null || tid == null) {
+      throw new Error('Cannot map teams without conference, division, and team id values');
+    }
+
+    const key = `${cid}:${did}`;
+    const bucket = grouped.get(key) ?? [];
+    bucket.push({ tid, cid, did });
+    grouped.set(key, bucket);
+  }
+
+  for (const bucket of grouped.values()) {
+    bucket.sort((a, b) => a.tid - b.tid);
+  }
+
+  const slotToTid = new Map();
+
+  for (const [templateTidRaw, info] of Object.entries(NFL_32_TEMPLATE_PACK.teamInfos)) {
+    const templateTid = Number(templateTidRaw);
+    const [cid, did, slot] = info;
+    const bucketKey = `${cid}:${did}`;
+    const realTeam = grouped.get(bucketKey)?.[slot];
+
+    if (!realTeam) {
+      throw new Error(
+        `Missing real team for template slot ${templateTid} (cid=${cid}, did=${did}, slot=${slot})`,
+      );
+    }
+
+    slotToTid.set(templateTid, realTeam.tid);
+  }
+
+  return slotToTid;
+}
+
+export function materializeTemplateSchedule(teams, season) {
+  if (!canUseNfl32Templates(teams)) {
+    throw new Error('League does not match the 32-team NFL template structure');
+  }
+
+  const templateIndex = getTemplateIndexForSeason(season);
+  const template = NFL_32_TEMPLATE_PACK.schedules[templateIndex];
+  const slotToTid = buildTemplateSlotToTidMap(teams);
+
+  return template.map((week) => ({
+    week: week.day,
+    games: week.matchups.map(([homeTemplateTid, awayTemplateTid]) => {
+      const homeTid = slotToTid.get(homeTemplateTid);
+      const awayTid = slotToTid.get(awayTemplateTid);
+
+      if (homeTid == null || awayTid == null) {
+        throw new Error(
+          `Failed to materialize matchup [${homeTemplateTid}, ${awayTemplateTid}] for week ${week.day}`,
+        );
+      }
+
+      return {
+        week: week.day,
+        homeTid,
+        awayTid,
+      };
+    }),
+  }));
+}
+
+export function validateMaterializedTemplateSchedule(weeks, expectedTeamCount = 32) {
+  if (weeks.length !== 18) {
+    throw new Error(`Expected 18 weeks, got ${weeks.length}`);
+  }
+
+  const gamesPlayed = new Map();
+
+  for (const week of weeks) {
+    const seen = new Set();
+
+    for (const game of week.games) {
+      if (game.homeTid === game.awayTid) {
+        throw new Error(`Week ${week.week} has self-matchup for team ${game.homeTid}`);
+      }
+
+      if (seen.has(game.homeTid) || seen.has(game.awayTid)) {
+        throw new Error(`Week ${week.week} has a duplicate team assignment`);
+      }
+
+      seen.add(game.homeTid);
+      seen.add(game.awayTid);
+
+      gamesPlayed.set(game.homeTid, (gamesPlayed.get(game.homeTid) ?? 0) + 1);
+      gamesPlayed.set(game.awayTid, (gamesPlayed.get(game.awayTid) ?? 0) + 1);
+    }
+  }
+
+  if (gamesPlayed.size !== expectedTeamCount) {
+    throw new Error(
+      `Expected ${expectedTeamCount} teams in schedule, got ${gamesPlayed.size}`,
+    );
+  }
+
+  for (const [tid, count] of gamesPlayed.entries()) {
+    if (count !== 17) {
+      throw new Error(`Expected team ${tid} to have 17 games, got ${count}`);
+    }
+  }
+}

--- a/src/data/nflScheduleTemplates.test.js
+++ b/src/data/nflScheduleTemplates.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildTemplateSlotToTidMap,
+  canUseNfl32Templates,
+  materializeTemplateSchedule,
+  validateMaterializedTemplateSchedule,
+} from './nflScheduleTemplates.js';
+
+function createLeagueTeams() {
+  return Array.from({ length: 32 }, (_, i) => ({
+    tid: i + 100,
+    cid: Math.floor(i / 16),
+    did: Math.floor((i % 16) / 4),
+  }));
+}
+
+describe('nflScheduleTemplates', () => {
+  it('maps template slots to sorted team ids inside each division', () => {
+    const teams = createLeagueTeams().reverse();
+    const map = buildTemplateSlotToTidMap(teams);
+
+    expect(map.get(0)).toBe(100);
+    expect(map.get(3)).toBe(103);
+    expect(map.get(16)).toBe(116);
+    expect(map.get(31)).toBe(131);
+  });
+
+  it('materializes and validates a full 18-week / 17-game schedule', () => {
+    const teams = createLeagueTeams();
+    expect(canUseNfl32Templates(teams)).toBe(true);
+
+    const weeks = materializeTemplateSchedule(teams, 2026);
+    expect(weeks).toHaveLength(18);
+
+    expect(() => validateMaterializedTemplateSchedule(weeks)).not.toThrow();
+  });
+
+  it('rejects non-standard conference/division layouts', () => {
+    const teams = createLeagueTeams().map((team) => ({ ...team, did: 0 }));
+    expect(canUseNfl32Templates(teams)).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a deterministic, rotating NFL-style schedule pack for standard 32-team leagues while preserving the existing procedural generator as a safe fallback.
- Allow the engine to map template team slots to real in-game team IDs using conference/division/slot metadata so templates can be reused across saves and seasons.
- Validate template-generated schedules to avoid introducing invalid schedules or breaking existing UI and save formats.

### Description

- Add a reusable template module `src/data/nflScheduleTemplates.js` that contains 32-slot `teamInfos`, deterministic rotating `schedules`, and helper functions `getTemplateIndexForSeason`, `canUseNfl32Templates`, `buildTemplateSlotToTidMap`, `materializeTemplateSchedule`, and `validateMaterializedTemplateSchedule`, and document the matchup tuple order as `[homeTemplateTeamId, awayTemplateTeamId]`. 
- Integrate templates into the scheduler by updating `src/core/schedule.js` so `makeAccurateSchedule(teams, season)` accepts an optional `season`, checks `canUseNfl32Templates`, attempts to materialize and validate the template schedule, and falls back to the existing procedural generator on any failure. 
- Add `buildTemplateBackedSchedule` in `src/core/schedule.js` to adapt materialized template weeks into the codebase’s existing schedule shape (including `home`/`away`, `week`, `bye` entries, and `teamsWithBye`).
- Add and update tests: extend `src/core/__tests__/schedule.test.js` to assert template usage, deterministic rotation by season, and fallback behavior, and add `src/data/nflScheduleTemplates.test.js` to verify slot-to-tid mapping, materialization/validation of 18-week schedules, and non-standard-structure rejection.

### Testing

- Ran the focused Vitest suite with `npx vitest run src/core/__tests__/schedule.test.js src/data/nflScheduleTemplates.test.js`, and all tests passed (2 test files, 8 tests total passed). 
- An attempt to run `npm test` with Playwright arguments did not locate the Vitest files because the project `npm test` script is wired to Playwright, so `npx vitest` was used instead and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3d0f9b28832da44ff17d03c9a2a4)