### PR TITLE
Normalize box score player stats for archived game payloads

### DIFF
--- a/src/core/game-simulator.js
+++ b/src/core/game-simulator.js
@@ -3072,14 +3072,59 @@ function transformStatsForBoxScore(playerStatsMap, roster) {
         }
 
         if (p) {
+            const normalizedStats = normalizeGameStatsForBoxScore(playerStatsMap[pid]);
             box[pid] = {
                 name: p.name,
                 pos: p.pos,
-                stats: playerStatsMap[pid]
+                stats: normalizedStats
             };
         }
     }
     return box;
+}
+
+function normalizeGameStatsForBoxScore(rawStats = {}) {
+    const stats = { ...(rawStats || {}) };
+
+    const alias = (canonicalKey, ...keys) => {
+        if (stats[canonicalKey] == null) {
+            for (const key of keys) {
+                if (stats[key] != null) {
+                    stats[canonicalKey] = stats[key];
+                    break;
+                }
+            }
+        }
+    };
+
+    alias('passYd', 'passYds');
+    alias('passTD', 'passTDs');
+    alias('rushYd', 'rushYds');
+    alias('rushTD', 'rushTDs');
+    alias('recYd', 'recYds');
+    alias('recTD', 'recTDs');
+    alias('interceptions', 'INT', 'ints');
+    alias('fumblesLost', 'fumbles');
+
+    if (stats.completionPct == null) {
+        const att = Number(stats.passAtt ?? 0);
+        const comp = Number(stats.passComp ?? 0);
+        stats.completionPct = att > 0 ? Math.round((comp / att) * 1000) / 10 : 0;
+    }
+
+    if (stats.ypc == null) {
+        const rushAtt = Number(stats.rushAtt ?? 0);
+        const rushYd = Number(stats.rushYd ?? 0);
+        stats.ypc = rushAtt > 0 ? Math.round((rushYd / rushAtt) * 100) / 100 : 0;
+    }
+
+    if (stats.ypr == null) {
+        const rec = Number(stats.receptions ?? 0);
+        const recYd = Number(stats.recYd ?? 0);
+        stats.ypr = rec > 0 ? Math.round((recYd / rec) * 100) / 100 : 0;
+    }
+
+    return stats;
 }
 
 /**
@@ -3238,10 +3283,11 @@ export function simulateBatch(games, options = {}) {
                     for (let i = 0; i < roster.length; i++) {
                         const player = roster[i];
                         if (player && player.stats && player.stats.game) {
+                            const normalizedStats = normalizeGameStatsForBoxScore(player.stats.game);
                             playerStats[String(player.id)] = {
                                 name: player.name,
                                 pos: player.pos,
-                                ...player.stats.game
+                                ...normalizedStats
                             };
                         }
                     }


### PR DESCRIPTION
### Motivation
- Ensure archived box score payloads contain a stable, canonical stat shape so UI box score, recap, and leader/feat derivation logic render correctly with legacy or variant simulator outputs.
- Handle legacy/alternate stat keys (e.g. `passYds`, `passTDs`, `rushYds`, `recYds`, `INT`, `fumbles`) and fill commonly derived efficiency fields so downstream presentation is consistent.

### Description
- Added `normalizeGameStatsForBoxScore(rawStats)` to `src/core/game-simulator.js` to map common aliases into canonical keys and derive fallback efficiency metrics like `completionPct`, `ypc`, and `ypr`.
- Updated `transformStatsForBoxScore` to call `normalizeGameStatsForBoxScore` before persisting each player’s `stats` into the archived `boxScore` object.
- Updated the in-simulation capture path (`capturePlayerStats`) to normalize `player.stats.game` with the same function, so simulated results and override flows produce consistent stat shapes.
- Normalizations include aliases: `passYds -> passYd`, `passTDs -> passTD`, `rushYds -> rushYd`, `rushTDs -> rushTD`, `recYds -> recYd`, `recTDs -> recTD`, `INT/ints -> interceptions`, and `fumbles -> fumblesLost`.

### Testing
- Ran unit tests: `npm run test:unit -- tests/unit/box_score_presentation.test.js src/core/__tests__/gameSummary.test.js`.
- Result: both test files ran and all tests passed (`2 files, 10 tests` passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3e60d280832d9dd86e8ca86e0192)