### PR TITLE
Add canonical football metadata/types and shared box score-awards config

### DIFF
--- a/src/core/__tests__/footballMeta.test.ts
+++ b/src/core/__tests__/footballMeta.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { AWARD_DISPLAY_NAMES, buildTeamComparisonRows, PLAYER_GAME_STATS, PLAYER_STATS_TABLES, TEAM_STATS_TABLES, FOOTBALL_POSITIONS } from '../footballMeta';
+
+describe('footballMeta', () => {
+  it('uses game stats that exist in box score/stat flows', () => {
+    expect(PLAYER_GAME_STATS).toContain('passYd');
+    expect(PLAYER_GAME_STATS).toContain('rushYd');
+    expect(PLAYER_GAME_STATS).toContain('recYd');
+    expect(PLAYER_GAME_STATS).toContain('tackles');
+  });
+
+  it('defines player stat tables used by box score', () => {
+    expect(PLAYER_STATS_TABLES.passing.columns.map((c) => c.key)).toEqual(['passComp', 'passAtt', 'passYd', 'passTD', 'interceptions']);
+    expect(PLAYER_STATS_TABLES.defense.columns.map((c) => c.key)).toContain('passesDefended');
+  });
+
+  it('defines team comparison rows with third-down formatter', () => {
+    const rows = buildTeamComparisonRows({
+      away: { totalYards: 301, thirdDownMade: 3, thirdDownAtt: 9 },
+      home: { totalYards: 355, thirdDownMade: 6, thirdDownAtt: 12 },
+    });
+    expect(rows.find((row) => row.label === 'Total Yards')?.awayValue).toBe(301);
+    expect(rows.find((row) => row.label === '3rd Down')?.homeValue).toBe('6/12');
+  });
+
+  it('includes metadata-only return specialist positions', () => {
+    expect(FOOTBALL_POSITIONS.KR.runtimeSupported).toBe(false);
+    expect(FOOTBALL_POSITIONS.PR.runtimeSupported).toBe(false);
+  });
+
+  it('maps known awards to display names', () => {
+    expect(AWARD_DISPLAY_NAMES.mvp).toBe('Most Valuable Player');
+    expect(AWARD_DISPLAY_NAMES.sbMvp).toBe('Finals MVP');
+  });
+});

--- a/src/core/__tests__/footballRatings.test.ts
+++ b/src/core/__tests__/footballRatings.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { mapFootballRatingsToLegacyRatings, mapLegacyRatingsToFootballRatings } from '../footballRatings';
+
+describe('footballRatings adapters', () => {
+  it('maps legacy ratings into canonical shorthand keys', () => {
+    expect(
+      mapLegacyRatingsToFootballRatings({ throwAccuracy: 88, throwPower: 92, coverage: 77 }),
+    ).toEqual({ tha: 88, thp: 92, cov: 77 });
+  });
+
+  it('maps canonical shorthand keys back to legacy ratings', () => {
+    expect(
+      mapFootballRatingsToLegacyRatings({ tha: 85, prs: 79, rbk: 72 }),
+    ).toEqual({ throwAccuracy: 85, passRushSpeed: 79, runBlock: 72 });
+  });
+});

--- a/src/core/footballMeta.ts
+++ b/src/core/footballMeta.ts
@@ -1,0 +1,136 @@
+import type { AwardKey, Position, PrimaryPosition, TeamStatAttr } from './footballTypes';
+
+export type FootballStatColumn = {
+  key: string;
+  label: string;
+};
+
+export const PLAYER_GAME_STATS = [
+  'passComp',
+  'passAtt',
+  'passYd',
+  'passTD',
+  'interceptions',
+  'rushAtt',
+  'rushYd',
+  'rushTD',
+  'fumblesLost',
+  'targets',
+  'receptions',
+  'recYd',
+  'recTD',
+  'tackles',
+  'sacks',
+  'passesDefended',
+  'forcedFumbles',
+] as const;
+
+export const PLAYER_STATS_TABLES: Record<string, { title: string; emptyText: string; sortBy: string; columns: FootballStatColumn[] }> = {
+  passing: {
+    title: 'Passing leaders',
+    emptyText: 'No passing stats archived for this game.',
+    sortBy: 'passYd',
+    columns: [
+      { key: 'passComp', label: 'Comp' },
+      { key: 'passAtt', label: 'Att' },
+      { key: 'passYd', label: 'Yds' },
+      { key: 'passTD', label: 'TD' },
+      { key: 'interceptions', label: 'INT' },
+    ],
+  },
+  rushing: {
+    title: 'Rushing leaders',
+    emptyText: 'No rushing stats archived for this game.',
+    sortBy: 'rushYd',
+    columns: [
+      { key: 'rushAtt', label: 'Att' },
+      { key: 'rushYd', label: 'Yds' },
+      { key: 'rushTD', label: 'TD' },
+      { key: 'fumblesLost', label: 'FUM' },
+    ],
+  },
+  receiving: {
+    title: 'Receiving leaders',
+    emptyText: 'No receiving stats archived for this game.',
+    sortBy: 'recYd',
+    columns: [
+      { key: 'targets', label: 'Tgt' },
+      { key: 'receptions', label: 'Rec' },
+      { key: 'recYd', label: 'Yds' },
+      { key: 'recTD', label: 'TD' },
+    ],
+  },
+  defense: {
+    title: 'Defensive leaders',
+    emptyText: 'No defensive stats archived for this game.',
+    sortBy: 'impact',
+    columns: [
+      { key: 'tackles', label: 'Tkl' },
+      { key: 'sacks', label: 'Sacks' },
+      { key: 'interceptions', label: 'INT' },
+      { key: 'passesDefended', label: 'PD' },
+      { key: 'forcedFumbles', label: 'FF' },
+    ],
+  },
+};
+
+export const TEAM_STATS_TABLES: { comparison: { key: TeamStatAttr; label: string; formatter?: (value: any, side?: any) => string }[] } = {
+  comparison: [
+    { key: 'totalYards', label: 'Total Yards' },
+    { key: 'passYards', label: 'Pass Yards' },
+    { key: 'rushYards', label: 'Rush Yards' },
+    { key: 'turnovers', label: 'Turnovers' },
+    { key: 'sacks', label: 'Sacks' },
+    {
+      key: 'thirdDownAtt',
+      label: '3rd Down',
+      formatter: (_value, side) => (side?.thirdDownAtt != null ? `${side?.thirdDownMade ?? 0}/${side.thirdDownAtt}` : 'Unavailable'),
+    },
+  ],
+};
+
+export const FOOTBALL_POSITIONS: Record<Position, { label: string; primary: boolean; runtimeSupported: boolean }> = {
+  QB: { label: 'Quarterback', primary: true, runtimeSupported: true },
+  RB: { label: 'Running Back', primary: true, runtimeSupported: true },
+  WR: { label: 'Wide Receiver', primary: true, runtimeSupported: true },
+  TE: { label: 'Tight End', primary: true, runtimeSupported: true },
+  OL: { label: 'Offensive Line', primary: true, runtimeSupported: true },
+  DL: { label: 'Defensive Line', primary: true, runtimeSupported: true },
+  LB: { label: 'Linebacker', primary: true, runtimeSupported: true },
+  CB: { label: 'Cornerback', primary: true, runtimeSupported: true },
+  S: { label: 'Safety', primary: true, runtimeSupported: true },
+  K: { label: 'Kicker', primary: true, runtimeSupported: true },
+  P: { label: 'Punter', primary: true, runtimeSupported: true },
+  KR: { label: 'Kick Returner', primary: false, runtimeSupported: false },
+  PR: { label: 'Punt Returner', primary: false, runtimeSupported: false },
+};
+
+export const PRIMARY_POSITIONS = Object.keys(FOOTBALL_POSITIONS).filter((pos) => FOOTBALL_POSITIONS[pos as Position].primary) as PrimaryPosition[];
+
+export const AWARD_DISPLAY_NAMES: Record<AwardKey, string> = {
+  mvp: 'Most Valuable Player',
+  opoy: 'Offensive Player of the Year',
+  dpoy: 'Defensive Player of the Year',
+  oroy: 'Offensive Rookie of the Year',
+  droy: 'Defensive Rookie of the Year',
+  roty: 'Rookie of the Year',
+  sbMvp: 'Finals MVP',
+  allLeague: 'All-League',
+  allRookie: 'All-Rookie',
+};
+
+export const AWARDS_HISTORY_ORDER: AwardKey[] = ['mvp', 'opoy', 'dpoy', 'roty', 'sbMvp'];
+
+export function buildTeamComparisonRows(teamTotals: { away: Record<string, any>; home: Record<string, any> }) {
+  return TEAM_STATS_TABLES.comparison.map((row) => ({
+    label: row.label,
+    awayValue: row.formatter ? row.formatter(teamTotals.away?.[row.key], teamTotals.away) : (teamTotals.away?.[row.key] ?? 'Unavailable'),
+    homeValue: row.formatter ? row.formatter(teamTotals.home?.[row.key], teamTotals.home) : (teamTotals.home?.[row.key] ?? 'Unavailable'),
+  }));
+}
+
+export const FUTURE_COMPOSITE_WEIGHTS = {
+  // Metadata-only placeholder for future scouting/summary UI. Not wired into sim logic.
+  qbPocketPassing: { tha: 0.45, thp: 0.25, awr: 0.2, pbk: 0.1 },
+  edgePressure: { prs: 0.4, prp: 0.35, awr: 0.15, spd: 0.1 },
+};

--- a/src/core/footballRatings.ts
+++ b/src/core/footballRatings.ts
@@ -1,0 +1,49 @@
+import type { LegacyPlayerRatings, PlayerRatings, RatingKey, LegacyRatingKey } from './footballTypes';
+
+export const LEGACY_TO_CANONICAL_RATING_KEY: Record<LegacyRatingKey, RatingKey> = {
+  throwAccuracy: 'tha',
+  throwPower: 'thp',
+  speed: 'spd',
+  acceleration: 'acc',
+  awareness: 'awr',
+  catching: 'cth',
+  catchInTraffic: 'cit',
+  runBlock: 'rbk',
+  passBlock: 'pbk',
+  passRushSpeed: 'prs',
+  passRushPower: 'prp',
+  runStop: 'rns',
+  coverage: 'cov',
+  kickPower: 'kpw',
+  kickAccuracy: 'kac',
+  trucking: 'trk',
+  juking: 'jkm',
+};
+
+export const CANONICAL_TO_LEGACY_RATING_KEY: Record<RatingKey, LegacyRatingKey> = Object.entries(LEGACY_TO_CANONICAL_RATING_KEY)
+  .reduce((acc, [legacyKey, canonicalKey]) => {
+    acc[canonicalKey as RatingKey] = legacyKey as LegacyRatingKey;
+    return acc;
+  }, {} as Record<RatingKey, LegacyRatingKey>);
+
+export function mapLegacyRatingsToFootballRatings(ratings: LegacyPlayerRatings = {}): PlayerRatings {
+  const mapped: PlayerRatings = {};
+  for (const [legacyKey, canonicalKey] of Object.entries(LEGACY_TO_CANONICAL_RATING_KEY)) {
+    const value = ratings[legacyKey as LegacyRatingKey];
+    if (typeof value === 'number') {
+      mapped[canonicalKey] = value;
+    }
+  }
+  return mapped;
+}
+
+export function mapFootballRatingsToLegacyRatings(ratings: PlayerRatings = {}): LegacyPlayerRatings {
+  const mapped: LegacyPlayerRatings = {};
+  for (const [canonicalKey, legacyKey] of Object.entries(CANONICAL_TO_LEGACY_RATING_KEY)) {
+    const value = ratings[canonicalKey as RatingKey];
+    if (typeof value === 'number') {
+      mapped[legacyKey] = value;
+    }
+  }
+  return mapped;
+}

--- a/src/core/footballTypes.ts
+++ b/src/core/footballTypes.ts
@@ -1,0 +1,75 @@
+export type TeamStatAttr =
+  | 'totalYards'
+  | 'passYards'
+  | 'rushYards'
+  | 'turnovers'
+  | 'sacks'
+  | 'firstDowns'
+  | 'thirdDownMade'
+  | 'thirdDownAtt'
+  | 'redZoneMade'
+  | 'redZoneAtt'
+  | 'penalties';
+
+export type PrimaryPosition = 'QB' | 'RB' | 'WR' | 'TE' | 'OL' | 'DL' | 'LB' | 'CB' | 'S' | 'K' | 'P';
+
+export type Position = PrimaryPosition | 'KR' | 'PR';
+
+export type AwardKey = 'mvp' | 'opoy' | 'dpoy' | 'oroy' | 'droy' | 'roty' | 'sbMvp' | 'allLeague' | 'allRookie';
+
+export interface AwardPlayer {
+  playerId: number | null;
+  name: string;
+  teamId?: number | null;
+  pos?: string;
+  value?: number;
+}
+
+export interface AwardTeam {
+  teamId: number | null;
+  name: string;
+  abbr?: string;
+}
+
+export type Awards = Partial<Record<AwardKey, AwardPlayer | AwardPlayer[] | null>>;
+
+export type RatingKey =
+  | 'tha'
+  | 'thp'
+  | 'spd'
+  | 'acc'
+  | 'awr'
+  | 'cth'
+  | 'cit'
+  | 'rbk'
+  | 'pbk'
+  | 'prs'
+  | 'prp'
+  | 'rns'
+  | 'cov'
+  | 'kpw'
+  | 'kac'
+  | 'trk'
+  | 'jkm';
+
+export type LegacyRatingKey =
+  | 'throwAccuracy'
+  | 'throwPower'
+  | 'speed'
+  | 'acceleration'
+  | 'awareness'
+  | 'catching'
+  | 'catchInTraffic'
+  | 'runBlock'
+  | 'passBlock'
+  | 'passRushSpeed'
+  | 'passRushPower'
+  | 'runStop'
+  | 'coverage'
+  | 'kickPower'
+  | 'kickAccuracy'
+  | 'trucking'
+  | 'juking';
+
+export type PlayerRatings = Partial<Record<RatingKey, number>>;
+export type LegacyPlayerRatings = Partial<Record<LegacyRatingKey, number>>;

--- a/src/ui/components/AwardsRecordsScreen.jsx
+++ b/src/ui/components/AwardsRecordsScreen.jsx
@@ -2,8 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { filterAwardRows } from '../utils/historyDestinations.js';
 import { ScreenHeader, SectionCard, StickySubnav, EmptyState } from './ScreenSystem.jsx';
 import { getStickyTopOffset } from '../utils/screenSystem.js';
-
-const AWARD_KEYS = ['mvp', 'opoy', 'dpoy', 'roty'];
+import { AWARD_DISPLAY_NAMES, AWARDS_HISTORY_ORDER } from '../../core/footballMeta';
 
 export default function AwardsRecordsScreen({ actions, league, onPlayerSelect, onBack }) {
   const [seasons, setSeasons] = useState([]);
@@ -20,9 +19,9 @@ export default function AwardsRecordsScreen({ actions, league, onPlayerSelect, o
     });
   }, [actions]);
 
-  const awardRows = useMemo(() => (seasons ?? []).flatMap((s) => AWARD_KEYS.map((k) => ({
+  const awardRows = useMemo(() => (seasons ?? []).flatMap((s) => AWARDS_HISTORY_ORDER.map((k) => ({
     season: s.year,
-    award: k.toUpperCase(),
+    award: AWARD_DISPLAY_NAMES[k] ?? k.toUpperCase(),
     ...s?.awards?.[k],
   }))).filter((r) => r?.name), [seasons]);
 

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -12,6 +12,7 @@ import {
 } from "../utils/boxScorePresentation.js";
 import { buildCompletedGamePresentation, getGameDetailPayload } from "../utils/boxScoreAccess.js";
 import { normalizeArchivedGamePayload } from "../../core/gameArchive.js";
+import { buildTeamComparisonRows, PLAYER_STATS_TABLES } from "../../core/footballMeta";
 
 function TeamButton({ team, onSelect }) {
   if (!team) return <span>—</span>;
@@ -139,6 +140,7 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
   const topRushers = playerRows.filter((p) => (p.stats?.rushAtt ?? 0) > 0).sort((a, b) => (b.stats?.rushYd ?? 0) - (a.stats?.rushYd ?? 0)).slice(0, 6);
   const topReceivers = playerRows.filter((p) => (p.stats?.receptions ?? 0) > 0).sort((a, b) => (b.stats?.recYd ?? 0) - (a.stats?.recYd ?? 0)).slice(0, 6);
   const topDefenders = playerRows.filter((p) => (p.stats?.tackles ?? 0) + (p.stats?.sacks ?? 0) + (p.stats?.interceptions ?? 0) > 0).sort((a, b) => ((b.stats?.tackles ?? 0) + (b.stats?.sacks ?? 0) * 2 + (b.stats?.interceptions ?? 0) * 2) - ((a.stats?.tackles ?? 0) + (a.stats?.sacks ?? 0) * 2 + (a.stats?.interceptions ?? 0) * 2)).slice(0, 8);
+  const teamComparisonRows = buildTeamComparisonRows(teamTotals);
 
   const headerWeek = game?.week ?? gameId?.match(/_w(\d+)_/)?.[1] ?? "—";
   const headerSeason = game?.seasonId ?? gameId?.split('_w')?.[0] ?? "";
@@ -236,41 +238,38 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
             {sections.teamComparison && <section className="bs-section">
               <h4>Team comparison</h4>
               <div className="bs-compare-grid">
-                <StatCompareRow label="Total Yards" awayValue={teamTotals.away.totalYards ?? "Unavailable"} homeValue={teamTotals.home.totalYards ?? "Unavailable"} />
-                <StatCompareRow label="Pass Yards" awayValue={teamTotals.away.passYards ?? "Unavailable"} homeValue={teamTotals.home.passYards ?? "Unavailable"} />
-                <StatCompareRow label="Rush Yards" awayValue={teamTotals.away.rushYards ?? "Unavailable"} homeValue={teamTotals.home.rushYards ?? "Unavailable"} />
-                <StatCompareRow label="Turnovers" awayValue={teamTotals.away.turnovers ?? "Unavailable"} homeValue={teamTotals.home.turnovers ?? "Unavailable"} />
-                <StatCompareRow label="Sacks" awayValue={teamTotals.away.sacks ?? "Unavailable"} homeValue={teamTotals.home.sacks ?? "Unavailable"} />
-                <StatCompareRow label="3rd Down" awayValue={teamTotals.away.thirdDownAtt != null ? `${teamTotals.away.thirdDownMade ?? 0}/${teamTotals.away.thirdDownAtt}` : "Unavailable"} homeValue={teamTotals.home.thirdDownAtt != null ? `${teamTotals.home.thirdDownMade ?? 0}/${teamTotals.home.thirdDownAtt}` : "Unavailable"} />
+                {teamComparisonRows.map((row) => (
+                  <StatCompareRow key={row.label} label={row.label} awayValue={row.awayValue} homeValue={row.homeValue} />
+                ))}
               </div>
             </section>}
 
             <PlayerTable
-              title="Passing leaders"
+              title={PLAYER_STATS_TABLES.passing.title}
               players={topPassers}
-              cols={[{ key: "passComp", label: "Comp" }, { key: "passAtt", label: "Att" }, { key: "passYd", label: "Yds" }, { key: "passTD", label: "TD" }, { key: "interceptions", label: "INT" }]}
+              cols={PLAYER_STATS_TABLES.passing.columns}
               onPlayerSelect={onPlayerSelect}
-              emptyText="No passing stats archived for this game."
+              emptyText={PLAYER_STATS_TABLES.passing.emptyText}
             />
             <PlayerTable
-              title="Rushing leaders"
+              title={PLAYER_STATS_TABLES.rushing.title}
               players={topRushers}
-              cols={[{ key: "rushAtt", label: "Att" }, { key: "rushYd", label: "Yds" }, { key: "rushTD", label: "TD" }, { key: "fumblesLost", label: "FUM" }]}
+              cols={PLAYER_STATS_TABLES.rushing.columns}
               onPlayerSelect={onPlayerSelect}
-              emptyText="No rushing stats archived for this game."
+              emptyText={PLAYER_STATS_TABLES.rushing.emptyText}
             />
             <PlayerTable
-              title="Receiving leaders"
+              title={PLAYER_STATS_TABLES.receiving.title}
               players={topReceivers}
-              cols={[{ key: "targets", label: "Tgt" }, { key: "receptions", label: "Rec" }, { key: "recYd", label: "Yds" }, { key: "recTD", label: "TD" }]}
+              cols={PLAYER_STATS_TABLES.receiving.columns}
               onPlayerSelect={onPlayerSelect}
-              emptyText="No receiving stats archived for this game."
+              emptyText={PLAYER_STATS_TABLES.receiving.emptyText}
             />
             {topDefenders.length > 0 ? (
               <PlayerTable
-                title="Defensive leaders"
+                title={PLAYER_STATS_TABLES.defense.title}
                 players={topDefenders}
-                cols={[{ key: "tackles", label: "Tkl" }, { key: "sacks", label: "Sacks" }, { key: "interceptions", label: "INT" }, { key: "passesDefended", label: "PD" }, { key: "forcedFumbles", label: "FF" }]}
+                cols={PLAYER_STATS_TABLES.defense.columns}
                 onPlayerSelect={onPlayerSelect}
               />
             ) : null}

--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -5,6 +5,7 @@ import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from "@
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/boxScoreAccess.js";
+import { AWARD_DISPLAY_NAMES } from '../../core/footballMeta';
 
 const RECORD_LABELS = {
   passYd: "Passing Yards",
@@ -260,9 +261,9 @@ function SeasonExplorer({ seasons, onPlayerSelect, onOpenBoxScore }) {
             <h4 className="text-sm font-bold mb-2">Awards & Leaders</h4>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
               <AwardLine label="MVP" award={selected?.awards?.mvp} onPlayerSelect={onPlayerSelect} />
-              <AwardLine label="OPOY" award={selected?.awards?.opoy} onPlayerSelect={onPlayerSelect} />
-              <AwardLine label="DPOY" award={selected?.awards?.dpoy} onPlayerSelect={onPlayerSelect} />
-              <AwardLine label="ROTY" award={selected?.awards?.roty} onPlayerSelect={onPlayerSelect} />
+              <AwardLine label={AWARD_DISPLAY_NAMES.opoy} award={selected?.awards?.opoy} onPlayerSelect={onPlayerSelect} />
+              <AwardLine label={AWARD_DISPLAY_NAMES.dpoy} award={selected?.awards?.dpoy} onPlayerSelect={onPlayerSelect} />
+              <AwardLine label={AWARD_DISPLAY_NAMES.roty} award={selected?.awards?.roty} onPlayerSelect={onPlayerSelect} />
             </div>
             <div className="text-xs text-[color:var(--text-muted)] mt-2">
               Playoff bracket/path is not currently stored in archived season summaries.
@@ -393,9 +394,9 @@ function AwardsHistory({ seasons, onPlayerSelect }) {
                 <TableHead className="pl-5">Year</TableHead>
                 <TableHead>Champion</TableHead>
                 <TableHead>MVP</TableHead>
-                <TableHead>OPOY</TableHead>
-                <TableHead>DPOY</TableHead>
-                <TableHead>ROTY</TableHead>
+                <TableHead>{AWARD_DISPLAY_NAMES.opoy}</TableHead>
+                <TableHead>{AWARD_DISPLAY_NAMES.dpoy}</TableHead>
+                <TableHead>{AWARD_DISPLAY_NAMES.roty}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>


### PR DESCRIPTION
### Motivation
- Provide a single, typed football metadata/config layer to drive stat tables, awards naming, positions metadata and future rating UI without changing runtime save shapes or the simulator.
- Align UI table definitions and awards display with the actual stat keys used across box score, archives, and awards logic to prevent duplication and drift.
- Offer a safe, additive place for future-facing composite weights and shorthand rating types while avoiding any mass migration or sim wiring in this change.

### Description
- Added a typed metadata module `src/core/footballMeta.ts` that centralizes `PLAYER_GAME_STATS`, `PLAYER_STATS_TABLES`, `TEAM_STATS_TABLES`, position metadata (including metadata-only `KR`/`PR`), award display names and ordering, and a metadata-only `FUTURE_COMPOSITE_WEIGHTS` placeholder.
- Added types in `src/core/footballTypes.ts` for `TeamStatAttr`, awards/team/player shapes, `PrimaryPosition`/`Position`, `RatingKey` and legacy rating key unions and rating shapes to improve compile-time safety.
- Added a compatibility adapter `src/core/footballRatings.ts` implementing `mapLegacyRatingsToFootballRatings` and `mapFootballRatingsToLegacyRatings` so shorthand rating keys can coexist with the current verbose runtime keys without migrating saves.
- Refactored `src/ui/components/BoxScore.jsx` to consume `PLAYER_STATS_TABLES` and `buildTeamComparisonRows` from the shared metadata instead of hardcoded table definitions, and updated `src/ui/components/AwardsRecordsScreen.jsx` and `src/ui/components/LeagueHistory.jsx` to use `AWARD_DISPLAY_NAMES` / `AWARDS_HISTORY_ORDER` for display text.
- Added unit tests: `src/core/__tests__/footballMeta.test.ts` and `src/core/__tests__/footballRatings.test.ts` that validate metadata shape, comparison formatter behavior, and rating adapter correctness, and retained existing box score presentation tests.
- Audit notes: keys and table columns were chosen to match existing runtime/archive keys (e.g. `passYd`, `rushYd`, `recYd`, `interceptions`, `tackles`, `sacks`, `totalYards`, `thirdDownMade/thirdDownAtt`); unsupported or speculative fields were omitted or kept as metadata-only placeholders.
- Deferred intentionally: no simulator engine rewrite, no save-schema migration to shorthand ratings, no changes to roster/depth-chart runtime logic, and no wiring of composite weights into simulation logic.

### Testing
- Ran unit tests: `npm run test:unit -- src/core/__tests__/footballMeta.test.ts src/core/__tests__/footballRatings.test.ts src/ui/utils/boxScorePresentation.test.js` and all tests passed.
- Test summary: 3 test files executed, total 10 tests, all passing (green).
- The change preserves existing box score/tests behavior while verifying the new metadata and rating adapters behave as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc41af1fb0832d90a037894248f6e8)