### PR TITLE
Box Score UI 2.0: mobile-first Game Book with quick-nav and richer stats

### DIFF
--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { EmptyState } from "./ScreenSystem.jsx";
 import {
   deriveLeaders,
@@ -8,6 +8,7 @@ import {
   deriveTeamTotals,
   describeStatLine,
   getGameDetailSections,
+  groupScoringByPeriod,
   toPlayerArray,
 } from "../utils/boxScorePresentation.js";
 import { buildCompletedGamePresentation, getGameDetailPayload } from "../utils/boxScoreAccess.js";
@@ -22,7 +23,7 @@ function TeamButton({ team, onSelect }) {
 
 function PlayerButton({ player, onSelect }) {
   if (!player) return <span>—</span>;
-  if (!onSelect) return <span>{player.name}</span>;
+  if (!onSelect || !player.playerId) return <span>{player.name}</span>;
   return <button className="btn-link" onClick={() => onSelect(player.playerId)}>{player.name}</button>;
 }
 
@@ -37,33 +38,125 @@ function LeaderCard({ label, player, line, onPlayerSelect }) {
   );
 }
 
-function StatCompareRow({ label, homeValue, awayValue }) {
+function StatCompareRow({ label, homeValue, awayValue, homeWins, awayWins }) {
   return (
     <div className="bs-compare-row">
-      <span>{awayValue ?? "—"}</span>
+      <span className={awayWins ? "bs-compare-value bs-compare-value--winner" : "bs-compare-value"}>{awayValue ?? "—"}</span>
       <span className="bs-compare-label">{label}</span>
-      <span>{homeValue ?? "—"}</span>
+      <span className={homeWins ? "bs-compare-value bs-compare-value--winner" : "bs-compare-value"}>{homeValue ?? "—"}</span>
     </div>
   );
 }
 
-function PlayerTable({ title, players, cols, onPlayerSelect, emptyText }) {
-  if (!players.length) return (<section className="bs-section"><h4>{title}</h4><EmptyState title={`${title} unavailable`} body={emptyText ?? `No ${title.toLowerCase()} available.`} /></section>);
+const SECTION_LINKS = [
+  { key: "summary", label: "Summary" },
+  { key: "team", label: "Team Stats" },
+  { key: "players", label: "Players" },
+  { key: "scoring", label: "Scoring" },
+  { key: "drives", label: "Drives" },
+  { key: "plays", label: "Plays" },
+];
+
+function compareNumeric(awayValue, homeValue) {
+  if (awayValue == null || homeValue == null || Number.isNaN(Number(awayValue)) || Number.isNaN(Number(homeValue))) {
+    return { awayWins: false, homeWins: false };
+  }
+  const awayNum = Number(awayValue);
+  const homeNum = Number(homeValue);
+  if (awayNum === homeNum) return { awayWins: false, homeWins: false };
+  return { awayWins: awayNum > homeNum, homeWins: homeNum > awayNum };
+}
+
+function formatRecord(team) {
+  return `${team.wins ?? 0}-${team.losses ?? 0}${team.ties ? `-${team.ties}` : ""}`;
+}
+
+function TeamStatsSection({ rows }) {
+  const grouped = useMemo(() => ([
+    { title: "Overview", keys: ["Total Yards", "First Downs"] },
+    { title: "Passing & Rushing", keys: ["Pass Yards", "Rush Yards", "Rush YPC"] },
+    { title: "Efficiency", keys: ["3rd Down", "Time of Possession"] },
+    { title: "Turnovers & Defense", keys: ["Turnovers", "Sacks"] },
+  ].map((g) => ({ ...g, rows: rows.filter((row) => g.keys.includes(row.label)) })).filter((g) => g.rows.length > 0)), [rows]);
+
+  if (!rows.length) {
+    return <EmptyState title="Team stats unavailable" body="Team totals were not archived for this game." />;
+  }
+
   return (
-    <section className="bs-section">
-      <h4>{title}</h4>
+    <div className="bs-team-groups">
+      {grouped.map((group) => (
+        <div key={group.title} className="bs-team-group">
+          <h5>{group.title}</h5>
+          <div className="bs-compare-grid">
+            {group.rows.map((row) => {
+              const outcome = compareNumeric(row.awayRaw, row.homeRaw);
+              return (
+                <StatCompareRow
+                  key={row.label}
+                  label={row.label}
+                  awayValue={row.awayValue}
+                  homeValue={row.homeValue}
+                  awayWins={outcome.awayWins}
+                  homeWins={outcome.homeWins}
+                />
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function sortPlayers(players, sortKey, direction) {
+  return [...players].sort((a, b) => {
+    const av = Number(a.stats?.[sortKey] ?? 0);
+    const bv = Number(b.stats?.[sortKey] ?? 0);
+    return direction === "desc" ? bv - av : av - bv;
+  });
+}
+
+function PlayerCategoryTable({ title, players, cols, onPlayerSelect, emptyText, defaultSort }) {
+  const [sort, setSort] = useState({ key: defaultSort ?? cols[0]?.key, direction: "desc" });
+  const sortedPlayers = useMemo(() => sortPlayers(players, sort.key, sort.direction), [players, sort]);
+
+  const handleSort = (key) => {
+    setSort((prev) => (prev.key === key
+      ? { key, direction: prev.direction === "desc" ? "asc" : "desc" }
+      : { key, direction: "desc" }));
+  };
+
+  if (!players.length) {
+    return (
+      <section className="bs-subsection">
+        <h5>{title}</h5>
+        <EmptyState title={`${title} unavailable`} body={emptyText ?? `No ${title.toLowerCase()} available.`} />
+      </section>
+    );
+  }
+
+  return (
+    <section className="bs-subsection">
+      <h5>{title}</h5>
       <div className="bs-table-wrap">
         <table className="box-score-table">
           <thead>
             <tr>
               <th>Player</th>
               <th>Pos</th>
-              {cols.map((col) => <th key={col.key}>{col.label}</th>)}
+              {cols.map((col) => (
+                <th key={col.key}>
+                  <button className="bs-sort-btn" onClick={() => handleSort(col.key)}>
+                    {col.label}{sort.key === col.key ? (sort.direction === "desc" ? " ↓" : " ↑") : ""}
+                  </button>
+                </th>
+              ))}
             </tr>
           </thead>
           <tbody>
-            {players.map((p) => (
-              <tr key={`${p.teamId}-${p.playerId}`}>
+            {sortedPlayers.map((p) => (
+              <tr key={`${p.teamId}-${p.playerId}-${title}`}>
                 <td><PlayerButton player={p} onSelect={onPlayerSelect} /></td>
                 <td>{p.pos}</td>
                 {cols.map((col) => <td key={col.key}>{p.stats?.[col.key] ?? "—"}</td>)}
@@ -76,11 +169,31 @@ function PlayerTable({ title, players, cols, onPlayerSelect, emptyText }) {
   );
 }
 
+export function GameBookQuickNav({ activeSection, onJump }) {
+  return (
+    <nav className="bs-quick-nav" aria-label="Game Book sections" data-testid="gamebook-quick-nav">
+      {SECTION_LINKS.map((section) => (
+        <button
+          key={section.key}
+          className={activeSection === section.key ? "bs-nav-pill is-active" : "bs-nav-pill"}
+          onClick={() => onJump(section.key)}
+          type="button"
+        >
+          {section.label}
+        </button>
+      ))}
+    </nav>
+  );
+}
+
 export default function BoxScore({ gameId, actions, league, onClose, onBack, onPlayerSelect, onTeamSelect, embedded = false }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [game, setGame] = useState(null);
   const [expanded, setExpanded] = useState(false);
+  const [activeSection, setActiveSection] = useState("summary");
+  const [playerTeamFilter, setPlayerTeamFilter] = useState("all");
+  const sectionRefs = useRef({});
 
   useEffect(() => {
     let alive = true;
@@ -104,7 +217,30 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
       });
 
     return () => { alive = false; };
-  }, [actions, gameId]);
+  }, [actions, gameId, league]);
+
+  useEffect(() => {
+    if (!game) return undefined;
+    const observer = new IntersectionObserver((entries) => {
+      const visible = entries.filter((entry) => entry.isIntersecting)
+        .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+      if (visible?.target?.dataset?.section) {
+        setActiveSection(visible.target.dataset.section);
+      }
+    }, { rootMargin: "-20% 0px -60% 0px", threshold: [0.1, 0.3, 0.6] });
+
+    SECTION_LINKS.forEach((section) => {
+      const node = sectionRefs.current[section.key];
+      if (node) observer.observe(node);
+    });
+
+    return () => observer.disconnect();
+  }, [game]);
+
+  const jumpToSection = (sectionKey) => {
+    setActiveSection(sectionKey);
+    sectionRefs.current[sectionKey]?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
 
   const teamsById = useMemo(() => {
     const map = {};
@@ -118,12 +254,13 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
 
   const leaders = useMemo(() => deriveLeaders(game), [game]);
   const scoring = useMemo(() => (game?.scoringSummary?.length ? game.scoringSummary : deriveScoringSummary(game?.playLog ?? game?.stats?.playLogs ?? [], teamsById)), [game, teamsById]);
+  const scoringGroups = useMemo(() => groupScoringByPeriod(scoring), [scoring]);
   const momentumNotes = useMemo(() => (Array.isArray(game?.turningPoints) && game.turningPoints.length ? game.turningPoints : deriveMomentumNotes(game?.playLog ?? game?.stats?.playLogs ?? [])), [game]);
   const quarterScores = useMemo(() => deriveQuarterScores(game, game?.playLog ?? game?.stats?.playLogs ?? []), [game]);
   const driveSummary = Array.isArray(game?.driveSummary) ? game.driveSummary : (Array.isArray(game?.drives) ? game.drives : []);
   const playLog = Array.isArray(game?.playLog) ? game.playLog : (Array.isArray(game?.stats?.playLogs) ? game.stats.playLogs : []);
   const hasQuarterData = quarterScores.home.some((value) => value != null) || quarterScores.away.some((value) => value != null);
-  const canExpandDetails = scoring.length > 6 || driveSummary.length > 8 || playLog.length > 20;
+  const canExpandDetails = scoring.length > 8 || driveSummary.length > 10 || playLog.length > 24;
   const quarterHeaders = useMemo(
     () => Array.from({ length: Math.max(quarterScores.home.length, quarterScores.away.length, 4) }, (_, idx) => (idx < 4 ? `Q${idx + 1}` : `OT${idx - 3}`)),
     [quarterScores],
@@ -133,16 +270,108 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
   const awayPlayers = useMemo(() => toPlayerArray(game?.playerStats?.away ?? game?.stats?.away, game?.awayId), [game]);
   const homePlayers = useMemo(() => toPlayerArray(game?.playerStats?.home ?? game?.stats?.home, game?.homeId), [game]);
   const playerRows = useMemo(() => [...awayPlayers, ...homePlayers], [awayPlayers, homePlayers]);
+
+  const filteredPlayers = useMemo(() => {
+    if (playerTeamFilter === "away") return awayPlayers;
+    if (playerTeamFilter === "home") return homePlayers;
+    return playerRows;
+  }, [awayPlayers, homePlayers, playerRows, playerTeamFilter]);
+
   const teamTotals = useMemo(() => ({
     home: game?.teamStats?.home ?? deriveTeamTotals(game?.playerStats?.home ?? game?.stats?.home),
     away: game?.teamStats?.away ?? deriveTeamTotals(game?.playerStats?.away ?? game?.stats?.away),
   }), [game]);
 
-  const topPassers = playerRows.filter((p) => (p.stats?.passAtt ?? 0) > 0).sort((a, b) => (b.stats?.passYd ?? 0) - (a.stats?.passYd ?? 0)).slice(0, 6);
-  const topRushers = playerRows.filter((p) => (p.stats?.rushAtt ?? 0) > 0).sort((a, b) => (b.stats?.rushYd ?? 0) - (a.stats?.rushYd ?? 0)).slice(0, 6);
-  const topReceivers = playerRows.filter((p) => (p.stats?.receptions ?? 0) > 0).sort((a, b) => (b.stats?.recYd ?? 0) - (a.stats?.recYd ?? 0)).slice(0, 6);
-  const topDefenders = playerRows.filter((p) => (p.stats?.tackles ?? 0) + (p.stats?.sacks ?? 0) + (p.stats?.interceptions ?? 0) > 0).sort((a, b) => ((b.stats?.tackles ?? 0) + (b.stats?.sacks ?? 0) * 2 + (b.stats?.interceptions ?? 0) * 2) - ((a.stats?.tackles ?? 0) + (a.stats?.sacks ?? 0) * 2 + (a.stats?.interceptions ?? 0) * 2)).slice(0, 8);
-  const teamComparisonRows = buildTeamComparisonRows(teamTotals);
+  const simOutputs = game?.summary?.simOutputs;
+  const rushingYpcAway = simOutputs?.away?.rushingYpc ?? ((teamTotals.away?.rushAtt ?? 0) > 0 ? (teamTotals.away?.rushYards ?? 0) / teamTotals.away.rushAtt : null);
+  const rushingYpcHome = simOutputs?.home?.rushingYpc ?? ((teamTotals.home?.rushAtt ?? 0) > 0 ? (teamTotals.home?.rushYards ?? 0) / teamTotals.home.rushAtt : null);
+  const teamComparisonRows = useMemo(() => {
+    const baseRows = buildTeamComparisonRows(teamTotals).map((row) => ({ ...row, awayRaw: null, homeRaw: null }));
+    return [
+      ...baseRows,
+      {
+        label: "First Downs",
+        awayValue: teamTotals.away?.firstDowns ?? "Unavailable",
+        homeValue: teamTotals.home?.firstDowns ?? "Unavailable",
+        awayRaw: teamTotals.away?.firstDowns,
+        homeRaw: teamTotals.home?.firstDowns,
+      },
+      {
+        label: "Rush YPC",
+        awayValue: rushingYpcAway != null ? Number(rushingYpcAway).toFixed(2) : "Unavailable",
+        homeValue: rushingYpcHome != null ? Number(rushingYpcHome).toFixed(2) : "Unavailable",
+        awayRaw: rushingYpcAway,
+        homeRaw: rushingYpcHome,
+      },
+      {
+        label: "Time of Possession",
+        awayValue: teamTotals.away?.timePossession ?? "Unavailable",
+        homeValue: teamTotals.home?.timePossession ?? "Unavailable",
+        awayRaw: teamTotals.away?.timePossession,
+        homeRaw: teamTotals.home?.timePossession,
+      },
+    ];
+  }, [rushingYpcAway, rushingYpcHome, teamTotals]);
+
+  const topFacts = useMemo(() => {
+    const totalYardEdge = (teamTotals.home?.totalYards ?? 0) - (teamTotals.away?.totalYards ?? 0);
+    const turnoverMargin = (teamTotals.away?.turnovers ?? 0) - (teamTotals.home?.turnovers ?? 0);
+    const sackEdge = (teamTotals.home?.sacks ?? 0) - (teamTotals.away?.sacks ?? 0);
+    return [
+      game?.summary?.playerOfGame?.name ? { label: "Player of the Game", value: game.summary.playerOfGame.name } : null,
+      momentumNotes[0]?.text ? { label: "Biggest Swing", value: momentumNotes[0].text } : null,
+      { label: "Yards Edge", value: totalYardEdge === 0 ? "Even" : `${totalYardEdge > 0 ? homeTeam.abbr : awayTeam.abbr} +${Math.abs(totalYardEdge)}` },
+      { label: "Turnover Margin", value: turnoverMargin === 0 ? "Even" : `${turnoverMargin > 0 ? awayTeam.abbr : homeTeam.abbr} +${Math.abs(turnoverMargin)}` },
+      { label: "Sacks Edge", value: sackEdge === 0 ? "Even" : `${sackEdge > 0 ? homeTeam.abbr : awayTeam.abbr} +${Math.abs(sackEdge)}` },
+    ].filter(Boolean);
+  }, [game?.summary?.playerOfGame?.name, homeTeam.abbr, awayTeam.abbr, momentumNotes, teamTotals]);
+
+  const playerTables = useMemo(() => {
+    const categories = Object.entries(PLAYER_STATS_TABLES).map(([key, table]) => {
+      const rows = filteredPlayers
+        .filter((p) => Number(p.stats?.[table.sortBy] ?? 0) > 0 || key === "defense" && ((p.stats?.tackles ?? 0) + (p.stats?.sacks ?? 0) + (p.stats?.interceptions ?? 0) > 0));
+      return { key, table, rows };
+    });
+
+    const hasKicking = filteredPlayers.some((p) => (p.stats?.fieldGoalsAttempted ?? 0) > 0 || (p.stats?.extraPointsAttempted ?? 0) > 0);
+    const hasPunting = filteredPlayers.some((p) => (p.stats?.punts ?? 0) > 0);
+
+    if (hasKicking) {
+      categories.push({
+        key: "kicking",
+        table: {
+          title: "Kicking",
+          emptyText: "No kicking stats archived for this game.",
+          sortBy: "fieldGoalsMade",
+          columns: [
+            { key: "fieldGoalsMade", label: "FGM" },
+            { key: "fieldGoalsAttempted", label: "FGA" },
+            { key: "extraPointsMade", label: "XPM" },
+            { key: "extraPointsAttempted", label: "XPA" },
+          ],
+        },
+        rows: filteredPlayers.filter((p) => (p.stats?.fieldGoalsAttempted ?? 0) > 0 || (p.stats?.extraPointsAttempted ?? 0) > 0),
+      });
+    }
+
+    if (hasPunting) {
+      categories.push({
+        key: "punting",
+        table: {
+          title: "Punting",
+          emptyText: "No punting stats archived for this game.",
+          sortBy: "puntYards",
+          columns: [
+            { key: "punts", label: "Punts" },
+            { key: "puntYards", label: "Punt Yds" },
+          ],
+        },
+        rows: filteredPlayers.filter((p) => (p.stats?.punts ?? 0) > 0),
+      });
+    }
+
+    return categories;
+  }, [filteredPlayers]);
 
   const headerWeek = game?.week ?? gameId?.match(/_w(\d+)_/)?.[1] ?? "—";
   const headerSeason = game?.seasonId ?? gameId?.split('_w')?.[0] ?? "";
@@ -154,210 +383,207 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
   const unavailableMessage = "No data saved for this game.";
 
   const shell = (
-      <div className={`${embedded ? "card" : "modal-content modal-large box-score-modal"}`} onClick={(e) => !embedded && e.stopPropagation()}>
-        <div className="box-score-header bs-header-sticky">
-          <div>
-            <div className="muted" style={{ fontSize: 12 }}>Week {headerWeek} · {headerSeason}</div>
-            <h2 style={{ margin: "2px 0 8px" }}>Game Book</h2>
-          </div>
-          <div style={{ display: "flex", gap: 8 }}>
-            {onBack && <button className="btn" onClick={onBack}>Back</button>}
-            {!embedded && <button className="btn" onClick={onClose}>Close</button>}
-          </div>
+    <div className={`${embedded ? "card" : "modal-content modal-large box-score-modal"}`} onClick={(e) => !embedded && e.stopPropagation()}>
+      <div className="box-score-header bs-header-sticky">
+        <div>
+          <div className="muted" style={{ fontSize: 12 }}>Week {headerWeek} · {headerSeason}</div>
+          <h2 style={{ margin: "2px 0 8px" }}>Game Book</h2>
         </div>
+        <div style={{ display: "flex", gap: 8 }}>
+          {onBack && <button className="btn" onClick={onBack}>Back</button>}
+          {!embedded && <button className="btn" onClick={onClose}>Close</button>}
+        </div>
+      </div>
 
-        {loading && <div className="box-score-container"><EmptyState title="Loading box score…" body="Pulling archived game detail and postgame context." /></div>}
-        {!loading && error && !hasAnyPayload && <div className="box-score-container"><EmptyState title="Game archive unavailable" body={`${unavailableMessage} (${availability.statusLabel ?? "Archive unavailable"})`} /></div>}
+      {loading && <div className="box-score-container"><EmptyState title="Loading box score…" body="Pulling archived game detail and postgame context." /></div>}
+      {!loading && error && !hasAnyPayload && <div className="box-score-container"><EmptyState title="Game archive unavailable" body={`${unavailableMessage} (${availability.statusLabel ?? "Archive unavailable"})`} /></div>}
 
-        {!loading && hasAnyPayload && game && (
-          <div className="box-score-container">
-            <section className="bs-score-hero">
-              <div>
-                <TeamButton team={awayTeam} onSelect={onTeamSelect} />
-                <div className="bs-record">{awayTeam.wins ?? 0}-{awayTeam.losses ?? 0}{awayTeam.ties ? `-${awayTeam.ties}` : ""}</div>
-              </div>
+      {!loading && hasAnyPayload && game && (
+        <div className="box-score-container">
+          <section className="bs-score-hero">
+            <div className="bs-team-col">
+              <div className="bs-team-label">Away</div>
+              <TeamButton team={awayTeam} onSelect={onTeamSelect} />
+              <div className="bs-record">{formatRecord(awayTeam)}</div>
+            </div>
+            <div className="bs-scoreline-wrap">
+              <div className="bs-final-pill">Final</div>
               <div className="bs-scoreline">{game.awayScore} - {game.homeScore}</div>
-              <div>
-                <TeamButton team={homeTeam} onSelect={onTeamSelect} />
-                <div className="bs-record">{homeTeam.wins ?? 0}-{homeTeam.losses ?? 0}{homeTeam.ties ? `-${homeTeam.ties}` : ""}</div>
+            </div>
+            <div className="bs-team-col">
+              <div className="bs-team-label">Home</div>
+              <TeamButton team={homeTeam} onSelect={onTeamSelect} />
+              <div className="bs-record">{formatRecord(homeTeam)}</div>
+            </div>
+          </section>
+
+          {archiveQuality !== "full" && (
+            <section className="bs-section" style={{ marginTop: 4 }} data-testid="archive-status">
+              <div className="bs-list-item" style={{ borderColor: "var(--warning)", color: "var(--text-muted)" }}>
+                {archiveQuality === "partial"
+                  ? "Partial archive: final score and key summary data are available, but full drive/play detail was not stored."
+                  : "Legacy archive: only limited matchup context could be recovered for this game."}
               </div>
             </section>
-            {archiveQuality !== "full" && (
-              <section className="bs-section" style={{ marginTop: 4 }} data-testid="archive-status">
-                <div className="bs-list-item" style={{ borderColor: "var(--warning)", color: "var(--text-muted)" }}>
-                  {archiveQuality === "partial"
-                    ? "Partial archive: final score and key summary data are available, but full drive/play detail was not stored."
-                    : "Archive missing: only limited matchup context could be recovered for this game."}
-                </div>
-              </section>
-            )}
+          )}
 
-            <section className="bs-section">
-              <div className="bs-section-header">
-                <h4>Game recap</h4>
-                {canExpandDetails ? <button className="btn" onClick={() => setExpanded((v) => !v)}>{expanded ? "Compact" : "Expand details"}</button> : null}
-              </div>
-              <div className="bs-list-item" style={{ marginBottom: 10 }}>
-                {game?.summary?.storyline ?? game?.recap ?? "A complete box score was archived for this matchup."}
-              </div>
-              {game?.summary?.simOutputs && (
-                <div className="bs-compare-grid" style={{ marginBottom: 10 }}>
-                  <StatCompareRow
-                    label="QB Rating"
-                    awayValue={game.summary.simOutputs?.away?.qbRating?.toFixed?.(1) ?? game.summary.simOutputs?.away?.qbRating ?? "—"}
-                    homeValue={game.summary.simOutputs?.home?.qbRating?.toFixed?.(1) ?? game.summary.simOutputs?.home?.qbRating ?? "—"}
-                  />
-                  <StatCompareRow
-                    label="Rush YPC"
-                    awayValue={game.summary.simOutputs?.away?.rushingYpc?.toFixed?.(2) ?? game.summary.simOutputs?.away?.rushingYpc ?? "—"}
-                    homeValue={game.summary.simOutputs?.home?.rushingYpc?.toFixed?.(2) ?? game.summary.simOutputs?.home?.rushingYpc ?? "—"}
-                  />
-                  <StatCompareRow
-                    label="Turnovers"
-                    awayValue={game.summary.simOutputs?.away?.turnovers ?? "—"}
-                    homeValue={game.summary.simOutputs?.home?.turnovers ?? "—"}
-                  />
-                  <StatCompareRow
-                    label="Sacks"
-                    awayValue={game.summary.simOutputs?.away?.sacks ?? "—"}
-                    homeValue={game.summary.simOutputs?.home?.sacks ?? "—"}
-                  />
-                </div>
-              )}
-              {game?.summary?.playerOfGame?.name && (
-                <div className="bs-list-item" style={{ marginBottom: 10 }}>
-                  <strong>Player of the game:</strong> <PlayerButton player={game.summary.playerOfGame} onSelect={onPlayerSelect} />
-                </div>
-              )}
-              <div className="bs-leaders-grid">
-                <LeaderCard label="Passing leader" player={leaders.pass} line={describeStatLine(leaders.pass, ["passComp", "passAtt", "passYd", "passTD", "interceptions"])} onPlayerSelect={onPlayerSelect} />
-                <LeaderCard label="Rushing leader" player={leaders.rush} line={describeStatLine(leaders.rush, ["rushAtt", "rushYd", "rushTD"])} onPlayerSelect={onPlayerSelect} />
-                <LeaderCard label="Receiving leader" player={leaders.receive} line={describeStatLine(leaders.receive, ["receptions", "recYd", "recTD"])} onPlayerSelect={onPlayerSelect} />
-                <LeaderCard label="Defensive leader" player={leaders.defense} line={describeStatLine(leaders.defense, ["tackles", "sacks", "interceptions", "forcedFumbles"])} onPlayerSelect={onPlayerSelect} />
-              </div>
-              {!leaders.pass && !leaders.rush && !leaders.receive && !leaders.defense ? (
-                <EmptyState title="Player leaders not archived" body="This legacy game has a final score and recap, but player leader rows were not saved." />
-              ) : null}
-            </section>
+          <GameBookQuickNav activeSection={activeSection} onJump={jumpToSection} />
 
-            {sections.teamComparison && <section className="bs-section">
-              <h4>Team comparison</h4>
-              <div className="bs-compare-grid">
-                {teamComparisonRows.map((row) => (
-                  <StatCompareRow key={row.label} label={row.label} awayValue={row.awayValue} homeValue={row.homeValue} />
-                ))}
-              </div>
-            </section>}
-
-            <PlayerTable
-              title={PLAYER_STATS_TABLES.passing.title}
-              players={topPassers}
-              cols={PLAYER_STATS_TABLES.passing.columns}
-              onPlayerSelect={onPlayerSelect}
-              emptyText={PLAYER_STATS_TABLES.passing.emptyText}
-            />
-            <PlayerTable
-              title={PLAYER_STATS_TABLES.rushing.title}
-              players={topRushers}
-              cols={PLAYER_STATS_TABLES.rushing.columns}
-              onPlayerSelect={onPlayerSelect}
-              emptyText={PLAYER_STATS_TABLES.rushing.emptyText}
-            />
-            <PlayerTable
-              title={PLAYER_STATS_TABLES.receiving.title}
-              players={topReceivers}
-              cols={PLAYER_STATS_TABLES.receiving.columns}
-              onPlayerSelect={onPlayerSelect}
-              emptyText={PLAYER_STATS_TABLES.receiving.emptyText}
-            />
-            {topDefenders.length > 0 ? (
-              <PlayerTable
-                title={PLAYER_STATS_TABLES.defense.title}
-                players={topDefenders}
-                cols={PLAYER_STATS_TABLES.defense.columns}
-                onPlayerSelect={onPlayerSelect}
-              />
+          <section className="bs-section" ref={(node) => { sectionRefs.current.summary = node; }} data-section="summary">
+            <div className="bs-section-header">
+              <h4>Quick summary</h4>
+              {canExpandDetails ? <button className="btn" onClick={() => setExpanded((v) => !v)}>{expanded ? "Compact" : "Expand details"}</button> : null}
+            </div>
+            <div className="bs-list-item" style={{ marginBottom: 10 }}>
+              {game?.summary?.storyline ?? game?.recap ?? "A complete box score was archived for this matchup."}
+            </div>
+            <div className="bs-facts-grid">
+              {topFacts.map((fact) => (
+                <div key={fact.label} className="bs-fact-chip">
+                  <span>{fact.label}</span>
+                  <strong>{fact.value}</strong>
+                </div>
+              ))}
+            </div>
+            <div className="bs-leaders-grid">
+              <LeaderCard label="Passing leader" player={leaders.pass} line={describeStatLine(leaders.pass, ["passComp", "passAtt", "passYd", "passTD", "interceptions"])} onPlayerSelect={onPlayerSelect} />
+              <LeaderCard label="Rushing leader" player={leaders.rush} line={describeStatLine(leaders.rush, ["rushAtt", "rushYd", "rushTD"])} onPlayerSelect={onPlayerSelect} />
+              <LeaderCard label="Receiving leader" player={leaders.receive} line={describeStatLine(leaders.receive, ["receptions", "recYd", "recTD"])} onPlayerSelect={onPlayerSelect} />
+              <LeaderCard label="Defensive leader" player={leaders.defense} line={describeStatLine(leaders.defense, ["tackles", "sacks", "interceptions", "forcedFumbles"])} onPlayerSelect={onPlayerSelect} />
+            </div>
+            {!leaders.pass && !leaders.rush && !leaders.receive && !leaders.defense ? (
+              <EmptyState title="Player leaders not archived" body="This legacy game has a final score and recap, but player leader rows were not saved." />
             ) : null}
-            {sections.scoringSummary && <section className="bs-section">
+          </section>
+
+          {sections.teamComparison && (
+            <section className="bs-section" ref={(node) => { sectionRefs.current.team = node; }} data-section="team">
+              <h4>Team stats</h4>
+              <TeamStatsSection rows={teamComparisonRows} />
+            </section>
+          )}
+
+          <section className="bs-section" ref={(node) => { sectionRefs.current.players = node; }} data-section="players">
+            <div className="bs-section-header">
+              <h4>Player stats</h4>
+              <div className="bs-segmented" data-testid="player-team-filter">
+                <button className={playerTeamFilter === "all" ? "is-active" : ""} onClick={() => setPlayerTeamFilter("all")}>All Players</button>
+                <button className={playerTeamFilter === "away" ? "is-active" : ""} onClick={() => setPlayerTeamFilter("away")}>{awayTeam.abbr}</button>
+                <button className={playerTeamFilter === "home" ? "is-active" : ""} onClick={() => setPlayerTeamFilter("home")}>{homeTeam.abbr}</button>
+              </div>
+            </div>
+            {playerTables.map((category) => (
+              <PlayerCategoryTable
+                key={category.key}
+                title={category.table.title}
+                players={expanded ? category.rows : category.rows.slice(0, 14)}
+                cols={category.table.columns}
+                onPlayerSelect={onPlayerSelect}
+                emptyText={category.table.emptyText}
+                defaultSort={category.table.sortBy}
+              />
+            ))}
+          </section>
+
+          {sections.scoringSummary && (
+            <section className="bs-section" ref={(node) => { sectionRefs.current.scoring = node; }} data-section="scoring">
               <h4>Scoring summary</h4>
               {!!scoring.length ? (
-                <div className="bs-list">
-                  {scoring.slice(expanded ? 0 : 6).map((item) => (
-                    <div key={item.id} className="bs-list-item">
-                      <span>Q{item.quarter} {item.clock}</span>
-                      <span><strong>{item.teamAbbr}</strong> · {item.type}</span>
-                      <span>{item.text}</span>
+                <div className="bs-scoring-groups">
+                  {scoringGroups.map((group) => (
+                    <div key={group.period} className="bs-scoring-group">
+                      <h5>{group.period}</h5>
+                      <div className="bs-list">
+                        {group.items.slice(expanded ? 0 : 8).map((item) => (
+                          <div key={item.id} className={`bs-list-item bs-score-item bs-score-${String(item.type).toLowerCase()}`}>
+                            <span>Q{item.quarter} · {item.clock}</span>
+                            <span><strong>{item.teamAbbr}</strong> · {item.type}</span>
+                            <span>{item.runningScore ? `Score ${item.runningScore} · ` : ""}{item.text}</span>
+                          </div>
+                        ))}
+                      </div>
                     </div>
                   ))}
                 </div>
               ) : <EmptyState title="No scoring log available" body="Scoring-play logs were not archived for this matchup." />}
-            </section>}
+            </section>
+          )}
 
-            {sections.quarterByQuarter && <section className="bs-section">
+          {sections.quarterByQuarter && (
+            <section className="bs-section">
               <h4>Quarter-by-quarter</h4>
               {hasQuarterData ? (
                 <div className="bs-table-wrap">
                   <table className="box-score-table">
-                    <thead><tr><th>Team</th>{quarterHeaders.map((label) => <th key={label}>{label}</th>)}<th>Final</th></tr></thead>
+                    <thead><tr><th>Team</th>{quarterHeaders.map((label) => <th key={label}>{label}</th>)}<th className="bs-final-col">Final</th></tr></thead>
                     <tbody>
-                      <tr><td><TeamButton team={awayTeam} onSelect={onTeamSelect} /></td>{quarterHeaders.map((_, idx) => <td key={`away-q-${idx}`}>{quarterScores.away[idx] ?? "Not archived"}</td>)}<td>{game.awayScore}</td></tr>
-                      <tr><td><TeamButton team={homeTeam} onSelect={onTeamSelect} /></td>{quarterHeaders.map((_, idx) => <td key={`home-q-${idx}`}>{quarterScores.home[idx] ?? "Not archived"}</td>)}<td>{game.homeScore}</td></tr>
+                      <tr className={Number(game.awayScore) > Number(game.homeScore) ? "bs-winning-row" : ""}><td><TeamButton team={awayTeam} onSelect={onTeamSelect} /></td>{quarterHeaders.map((_, idx) => <td key={`away-q-${idx}`}>{quarterScores.away[idx] ?? "Not archived"}</td>)}<td className="bs-final-col">{game.awayScore}</td></tr>
+                      <tr className={Number(game.homeScore) > Number(game.awayScore) ? "bs-winning-row" : ""}><td><TeamButton team={homeTeam} onSelect={onTeamSelect} /></td>{quarterHeaders.map((_, idx) => <td key={`home-q-${idx}`}>{quarterScores.home[idx] ?? "Not archived"}</td>)}<td className="bs-final-col">{game.homeScore}</td></tr>
                     </tbody>
                   </table>
                 </div>
               ) : (
                 <EmptyState title="Quarter scores not archived" body="Only the final score was saved for this game." />
               )}
-            </section>}
-            {sections.driveSummary && <section className="bs-section">
+            </section>
+          )}
+
+          {sections.driveSummary && (
+            <section className="bs-section" ref={(node) => { sectionRefs.current.drives = node; }} data-section="drives">
               <h4>Drive summary</h4>
               {!!driveSummary.length ? (
                 <div className="bs-list">
-                  {driveSummary.slice(expanded ? 0 : 8).map((drive, idx) => (
-                    <div key={`drive-${idx}`} className="bs-list-item">
-                      <span>Q{drive.quarter ?? "—"} {drive.startClock ?? drive.clock ?? ""}</span>
-                      <span>{drive.teamAbbr ?? teamsById?.[Number(drive.teamId)]?.abbr ?? "Drive"}</span>
-                      <span>{drive.result ?? drive.summary ?? `${drive.plays ?? 0} plays · ${drive.yards ?? 0} yds`}</span>
+                  {driveSummary.slice(expanded ? 0 : 12).map((drive, idx) => (
+                    <div key={`drive-${idx}`} className="bs-list-item bs-drive-item">
+                      <span>Q{drive.quarter ?? "—"} · {drive.startClock ?? drive.clock ?? ""}</span>
+                      <span><strong>{drive.teamAbbr ?? teamsById?.[Number(drive.teamId)]?.abbr ?? "Drive"}</strong> <em className="bs-drive-badge">{drive.result ?? "Result"}</em></span>
+                      <span>{drive.summary ?? `${drive.plays ?? 0} plays · ${drive.yards ?? 0} yds`}</span>
                     </div>
                   ))}
                 </div>
               ) : <EmptyState title="No drive chart available" body="This game was simulated with summary-only detail." />}
-            </section>}
+            </section>
+          )}
 
-            {sections.turningPoints && <section className="bs-section">
-                <h4>Turning points</h4>
-                {!!momentumNotes.length ?
+          {sections.turningPoints && (
+            <section className="bs-section">
+              <h4>Turning points</h4>
+              {!!momentumNotes.length ?
                 <div className="bs-list">
                   {momentumNotes.map((note) => (
                     <div key={note.id} className="bs-list-item"><span>Q{note.quarter}</span><span>{note.text}</span></div>
                   ))}
                 </div>
-              : <EmptyState title="No turning points available" body="Turning-point annotations are unavailable for this game." />}
-              </section>}
-            {sections.playLog && <section className="bs-section">
+                : <EmptyState title="No turning points available" body="Turning-point annotations are unavailable for this game." />}
+            </section>
+          )}
+
+          {sections.playLog && (
+            <section className="bs-section" ref={(node) => { sectionRefs.current.plays = node; }} data-section="plays">
               <h4>Play log</h4>
               {!!playLog.length ? (
                 <div className="bs-list">
-                  {playLog.slice(expanded ? 0 : 20).map((play, idx) => (
-                    <div key={`play-${idx}`} className="bs-list-item">
-                      <span>Q{play.quarter ?? "—"} {play.clock ?? play.time ?? ""}</span>
-                      <span>{teamsById?.[Number(play.teamId)]?.abbr ?? "—"}</span>
+                  {playLog.slice(expanded ? 0 : 24).map((play, idx) => (
+                    <div key={`play-${idx}`} className="bs-list-item bs-play-item">
+                      <span>Q{play.quarter ?? "—"} · {play.clock ?? play.time ?? ""}</span>
+                      <span><strong>{teamsById?.[Number(play.teamId)]?.abbr ?? "—"}</strong></span>
                       <span>{play.text ?? "Play event"}</span>
                     </div>
                   ))}
                 </div>
               ) : <EmptyState title="No play log archived" body="Full event-by-event tracking was not available for this game." />}
-            </section>}
+            </section>
+          )}
 
-            {game?.recap && (
-              <section className="bs-section">
-                <h4>Recap</h4>
-                <div className="bs-list-item">{game.recap}</div>
-              </section>
-            )}
-          </div>
-        )}
-      </div>
+          {game?.recap && (
+            <section className="bs-section">
+              <h4>Recap</h4>
+              <div className="bs-list-item">{game.recap}</div>
+            </section>
+          )}
+        </div>
+      )}
+    </div>
   );
 
   if (embedded) return shell;

--- a/src/ui/components/BoxScore.test.jsx
+++ b/src/ui/components/BoxScore.test.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import { GameBookQuickNav } from './BoxScore.jsx';
+import { PLAYER_STATS_TABLES, buildTeamComparisonRows } from '../../core/footballMeta';
+
+describe('BoxScore UI 2.0 structure helpers', () => {
+  it('renders the quick section nav with key tabs', () => {
+    const html = renderToString(<GameBookQuickNav activeSection="summary" onJump={() => {}} />);
+    expect(html).toContain('Summary');
+    expect(html).toContain('Team Stats');
+    expect(html).toContain('Players');
+    expect(html).toContain('gamebook-quick-nav');
+  });
+
+  it('uses shared player stat metadata categories', () => {
+    expect(Object.keys(PLAYER_STATS_TABLES)).toEqual(expect.arrayContaining(['passing', 'rushing', 'receiving', 'defense']));
+    expect(PLAYER_STATS_TABLES.passing.columns.map((col) => col.key)).toContain('passYd');
+  });
+
+  it('renders team comparison rows from metadata config', () => {
+    const rows = buildTeamComparisonRows({
+      away: { totalYards: 380, passYards: 240, rushYards: 140, turnovers: 1, sacks: 3, thirdDownMade: 5, thirdDownAtt: 11 },
+      home: { totalYards: 320, passYards: 210, rushYards: 110, turnovers: 2, sacks: 1, thirdDownMade: 4, thirdDownAtt: 12 },
+    });
+    expect(rows.find((row) => row.label === 'Total Yards')?.awayValue).toBe(380);
+    expect(rows.find((row) => row.label === '3rd Down')?.homeValue).toBe('4/12');
+  });
+});

--- a/src/ui/styles/style.css
+++ b/src/ui/styles/style.css
@@ -7559,6 +7559,10 @@ details[open] .nav-summary::after {
 }
 
 .bs-scoreline { font-size: 1.8rem; font-weight: 900; letter-spacing: -0.02em; }
+.bs-scoreline-wrap { display: grid; gap: 4px; justify-items: center; }
+.bs-final-pill { font-size: 10px; text-transform: uppercase; letter-spacing: .08em; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--hairline); }
+.bs-team-col { display: grid; gap: 3px; justify-items: center; }
+.bs-team-label { font-size: 10px; text-transform: uppercase; color: var(--text-subtle); }
 .bs-record { color: var(--text-muted); font-size: var(--text-xs); margin-top: 4px; }
 .bs-section { margin-bottom: 12px; background: var(--surface); border: 1px solid var(--hairline); border-radius: 12px; padding: 12px; }
 .bs-section-header { display: flex; justify-content: space-between; align-items: center; gap: 8px; margin-bottom: 8px; }
@@ -7569,10 +7573,35 @@ details[open] .nav-summary::after {
 .bs-leader-line { font-size: 12px; color: var(--text-muted); }
 .bs-compare-grid { display: grid; gap: 6px; }
 .bs-compare-row { display: grid; grid-template-columns: 1fr auto 1fr; text-align: center; gap: 8px; padding: 8px; background: var(--surface-strong); border-radius: 8px; }
+.bs-compare-value--winner { font-weight: 700; color: var(--accent, var(--text-primary)); }
 .bs-compare-label { font-size: 11px; color: var(--text-subtle); text-transform: uppercase; letter-spacing: .06em; }
 .bs-table-wrap { overflow-x: auto; }
 .bs-list { display: grid; gap: 6px; }
 .bs-list-item { display: grid; gap: 4px; background: var(--surface-strong); border-radius: 8px; padding: 8px; font-size: 12px; }
+.bs-quick-nav { position: sticky; top: 66px; z-index: 1; display: flex; gap: 8px; overflow-x: auto; padding: 4px 0 10px; margin-bottom: 8px; }
+.bs-nav-pill { border: 1px solid var(--hairline); background: var(--surface-strong); color: var(--text-muted); border-radius: 999px; padding: 8px 12px; white-space: nowrap; font-size: 12px; }
+.bs-nav-pill.is-active { color: var(--text-primary); border-color: var(--accent, var(--text-primary)); }
+.bs-facts-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 8px; margin-bottom: 10px; }
+.bs-fact-chip { border: 1px solid var(--hairline); border-radius: 10px; padding: 8px; background: var(--surface-strong); display: grid; gap: 3px; }
+.bs-fact-chip span { font-size: 10px; text-transform: uppercase; color: var(--text-subtle); letter-spacing: .08em; }
+.bs-team-groups { display: grid; gap: 10px; }
+.bs-team-group h5 { margin: 0 0 6px; font-size: 12px; text-transform: uppercase; letter-spacing: .07em; color: var(--text-subtle); }
+.bs-subsection { margin-top: 10px; }
+.bs-subsection h5 { margin: 0 0 6px; }
+.bs-segmented { display: inline-flex; border: 1px solid var(--hairline); border-radius: 10px; overflow: hidden; }
+.bs-segmented button { border: 0; background: transparent; padding: 6px 10px; font-size: 12px; color: var(--text-muted); }
+.bs-segmented button.is-active { background: var(--surface-strong); color: var(--text-primary); }
+.bs-sort-btn { border: 0; background: transparent; color: inherit; font: inherit; padding: 0; cursor: pointer; }
+.bs-scoring-groups { display: grid; gap: 8px; }
+.bs-scoring-group h5 { margin: 0 0 6px; font-size: 12px; }
+.bs-score-item { border-left: 3px solid var(--hairline); }
+.bs-score-td { border-left-color: #16a34a; }
+.bs-score-fg { border-left-color: #2563eb; }
+.bs-score-safety { border-left-color: #f59e0b; }
+.bs-drive-badge { font-style: normal; font-size: 11px; border: 1px solid var(--hairline); border-radius: 999px; padding: 1px 7px; margin-left: 6px; }
+.bs-play-item, .bs-drive-item { grid-template-columns: minmax(78px, auto) minmax(70px, auto) 1fr; align-items: start; }
+.bs-final-col { font-weight: 800; }
+.bs-winning-row { background: color-mix(in srgb, var(--surface-strong) 80%, #16a34a 20%); }
 
 @media (max-width: 768px) {
   .weekly-hero__actions .btn,
@@ -7606,6 +7635,8 @@ details[open] .nav-summary::after {
     grid-template-columns: 1fr;
     gap: 6px;
   }
+  .bs-quick-nav { top: 58px; }
+  .bs-facts-grid { grid-template-columns: 1fr 1fr; }
 
   .bs-leaders-grid {
     grid-template-columns: 1fr;
@@ -7631,6 +7662,9 @@ details[open] .nav-summary::after {
 @media (max-width: 760px) {
   .bs-section { padding: 10px; }
   .bs-list-item { padding: 10px; font-size: 13px; }
+  .bs-play-item, .bs-drive-item { grid-template-columns: 1fr; }
+  .bs-segmented { width: 100%; }
+  .bs-segmented button { flex: 1; }
   .trade-workspace-nav { top: calc(env(safe-area-inset-top) + 48px) !important; }
   .trade-asset-row__name { min-width: 0; }
 }

--- a/src/ui/utils/boxScorePresentation.js
+++ b/src/ui/utils/boxScorePresentation.js
@@ -121,11 +121,22 @@ export function deriveScoringSummary(logs = [], teamsById = {}) {
         teamId,
         teamAbbr: team?.abbr ?? "—",
         type: parseScoreType(log.text),
+        runningScore: log.score ?? (log.awayScore != null && log.homeScore != null ? `${log.awayScore}-${log.homeScore}` : null),
         text: log.text ?? "Scoring play",
       };
     });
 
   return scoring;
+}
+
+export function groupScoringByPeriod(scoring = []) {
+  const groups = new Map();
+  scoring.forEach((row) => {
+    const period = Number(row.quarter) > 4 ? `OT${Number(row.quarter) - 4}` : `Q${row.quarter ?? "—"}`;
+    if (!groups.has(period)) groups.set(period, []);
+    groups.get(period).push(row);
+  });
+  return Array.from(groups.entries()).map(([period, items]) => ({ period, items }));
 }
 
 export function deriveQuarterScores(game, logs = []) {

--- a/src/ui/utils/boxScorePresentation.test.js
+++ b/src/ui/utils/boxScorePresentation.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { deriveLeaders, deriveQuarterScores, deriveScoringSummary } from './boxScorePresentation.js';
+import { deriveLeaders, deriveQuarterScores, deriveScoringSummary, getGameDetailSections, groupScoringByPeriod } from './boxScorePresentation.js';
 
 describe('box score presentation fallback', () => {
   it('builds quarter scores from logs when quarterScores missing', () => {
@@ -22,6 +22,17 @@ describe('box score presentation fallback', () => {
     expect(rows[0].type).toBe('TD');
   });
 
+  it('groups scoring rows by quarter for section rendering', () => {
+    const groups = groupScoringByPeriod([
+      { id: '1', quarter: 1, text: 'TD' },
+      { id: '2', quarter: 1, text: 'FG' },
+      { id: '3', quarter: 5, text: 'OT FG' },
+    ]);
+    expect(groups[0].period).toBe('Q1');
+    expect(groups[0].items).toHaveLength(2);
+    expect(groups[1].period).toBe('OT1');
+  });
+
   it('uses archived summary leaders when detailed box stats are missing', () => {
     const leaders = deriveLeaders({
       summary: {
@@ -32,5 +43,10 @@ describe('box score presentation fallback', () => {
     });
     expect(leaders.pass?.name).toBe('A. QB');
     expect(leaders.pass?.stats?.passYd).toBe(278);
+  });
+
+  it('handles missing optional archive fields without crashing', () => {
+    expect(getGameDetailSections({ homeScore: 10, awayScore: 7 }).quarterByQuarter).toBe(true);
+    expect(getGameDetailSections({}).playLog).toBe(false);
   });
 });


### PR DESCRIPTION
### Motivation
- Turn the long, utilitarian Game Book into a polished, mobile-first postgame hub with clearer hierarchy and faster scanning without touching simulator or archive shapes. 
- Surface higher-value insights (player-of-game, key comparison chips, winner emphasis) while preserving graceful legacy/partial fallbacks.

### Description
- Reworked `BoxScore.jsx` to present the page in information zones (Score Header, Quick Summary, Analysis sections) and added small internal subcomponents: `GameBookQuickNav`, `TeamStatsSection`, and `PlayerCategoryTable` to keep the component cohesive and modular. 
- Added an in-page sticky quick-nav with section active-state (via `IntersectionObserver`) and jump behavior for Summary / Team Stats / Players / Scoring / Drives / Plays. 
- Upgraded player/team/stat presentation: category-first player tables driven by shared `PLAYER_STATS_TABLES`, team filter segmented control, sortable columns, conditional kicking/punting sections, grouped team stat buckets and winner emphasis, and compact defaults with expand behavior. 
- Improved scoring/quarter/drive/play presentation by adding `runningScore` support and `groupScoringByPeriod` in `boxScorePresentation.js`, stronger quarter-by-quarter final emphasis, cleaner drive/play rows, and targeted styles in `src/ui/styles/style.css`; all legacy fallbacks retained.
- Files changed: `src/ui/components/BoxScore.jsx`, `src/ui/styles/style.css`, `src/ui/utils/boxScorePresentation.js`, plus tests `src/ui/utils/boxScorePresentation.test.js` and new `src/ui/components/BoxScore.test.jsx`.

### Testing
- Targeted unit tests for this PR were run with `npx vitest run src/ui/components/BoxScore.test.jsx src/ui/utils/boxScorePresentation.test.js` and both test files passed. 
- The repository’s full `npm run test:unit` run surfaced unrelated existing failures in other suites (including Playwright spec collection issues and some unrelated unit assertions) that are outside the scope of these UI changes. 
- Smoke verification confirming Box Score-related tests and presentation helpers succeed: `GameBookQuickNav` rendering, metadata-driven player categories/team comparison rows, scoring grouping behavior, and safe handling of missing optional archive fields all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc463315a4832daf99447be5eb70e3)