### PR TITLE
Add shared football advanced player search/filter engine and UI

### DIFF
--- a/src/core/__tests__/footballAdvancedFilters.test.ts
+++ b/src/core/__tests__/footballAdvancedFilters.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  allFilters,
+  applyAdvancedPlayerFilters,
+  getExtraStatTypeKeys,
+  getStats,
+  getStatsTableByType,
+} from '../footballAdvancedFilters';
+
+describe('footballAdvancedFilters', () => {
+  it('builds catalog from football metadata tables', () => {
+    expect(allFilters.some((f) => f.key === 'age')).toBe(true);
+    expect(allFilters.some((f) => f.key === 'ovr')).toBe(true);
+    expect(allFilters.some((f) => f.key === 'passing:passYd')).toBe(true);
+  });
+
+  it('resolves stat tables and stat keys', () => {
+    expect(getStatsTableByType('passing')?.sortBy).toBe('passYd');
+    expect(getStats('receiving')).toContain('recYd');
+    expect(getStatsTableByType('missing')).toBeNull();
+  });
+
+  it('collects extra worker field requirements', () => {
+    const required = getExtraStatTypeKeys([
+      { id: '1', fieldKey: 'age', operator: 'gte', value: 23 },
+      { id: '2', fieldKey: 'tha', operator: 'gte', value: 70 },
+      { id: '3', fieldKey: 'passing:passYd', operator: 'gte', value: 2500 },
+    ]);
+
+    expect(required.attrs).toContain('age');
+    expect(required.ratings).toContain('tha');
+    expect(required.stats).toContain('passYd');
+  });
+
+  it('supports numeric, string, and AND logic', () => {
+    const players = [
+      { id: 1, name: 'Alex One', pos: 'QB', age: 24, ovr: 81, potential: 87 },
+      { id: 2, name: 'Brian Two', pos: 'WR', age: 29, ovr: 77, potential: 78 },
+      { id: 3, name: 'Chris Three', pos: 'QB', age: 31, ovr: 70, potential: 72 },
+    ];
+
+    const filtered = applyAdvancedPlayerFilters(players, [
+      { id: 'a', fieldKey: 'name', operator: 'contains', value: 'alex' },
+      { id: 'b', fieldKey: 'ovr', operator: 'gte', value: 80 },
+      { id: 'c', fieldKey: 'pos', operator: 'eq', value: 'QB' },
+    ]);
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].id).toBe(1);
+  });
+});

--- a/src/core/footballAdvancedFilters.ts
+++ b/src/core/footballAdvancedFilters.ts
@@ -1,0 +1,219 @@
+import { LEGACY_TO_CANONICAL_RATING_KEY } from './footballRatings';
+import { PLAYER_STATS_TABLES, PRIMARY_POSITIONS } from './footballMeta';
+import type { RatingKey } from './footballTypes';
+
+export type FootballFilterCategory = 'bio' | 'ratings' | 'stats';
+export type FootballFilterValueType = 'numeric' | 'string';
+export type FootballFilterOperator = 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'contains';
+
+export type FootballAdvancedFilterField = {
+  category: FootballFilterCategory;
+  key: string;
+  label: string;
+  colKey: string;
+  valueType: FootballFilterValueType;
+  statGroup?: string;
+  workerFieldOverride?: 'attrs' | 'ratings' | 'stats';
+  getter: (player: any) => string | number | null;
+};
+
+export type FootballAdvancedFilter = {
+  id: string;
+  fieldKey: string;
+  operator: FootballFilterOperator;
+  value: string | number;
+};
+
+const RATING_LABELS: Record<string, string> = {
+  ovr: 'OVR',
+  potential: 'Potential',
+  tha: 'Throw Accuracy',
+  thp: 'Throw Power',
+  spd: 'Speed',
+  acc: 'Acceleration',
+  awr: 'Awareness',
+  cth: 'Catching',
+  cit: 'Catch In Traffic',
+  rbk: 'Run Blocking',
+  pbk: 'Pass Blocking',
+  prs: 'Pass Rush Speed',
+  prp: 'Pass Rush Power',
+  rns: 'Run Stop',
+  cov: 'Coverage',
+  kpw: 'Kick Power',
+  kac: 'Kick Accuracy',
+  trk: 'Trucking',
+  jkm: 'Juking',
+};
+
+const numericGetter = (path: (string | number)[]) => (player: any) => {
+  let value = player;
+  for (const key of path) {
+    value = value?.[key];
+  }
+  return typeof value === 'number' ? value : value == null ? null : Number(value);
+};
+
+const stringGetter = (fn: (player: any) => unknown) => (player: any) => {
+  const raw = fn(player);
+  if (raw == null) return null;
+  return String(raw);
+};
+
+const bioFields: FootballAdvancedFilterField[] = [
+  { category: 'bio', key: 'name', label: 'Name', colKey: 'name', valueType: 'string', workerFieldOverride: 'attrs', getter: stringGetter((p) => p?.name) },
+  { category: 'bio', key: 'pos', label: 'Position', colKey: 'pos', valueType: 'string', workerFieldOverride: 'attrs', getter: stringGetter((p) => p?.pos) },
+  { category: 'bio', key: 'teamAbbrev', label: 'Team', colKey: 'abbrev', valueType: 'string', workerFieldOverride: 'attrs', getter: stringGetter((p) => p?.teamAbbrev ?? p?.team?.abbr ?? p?.team?.abbrev) },
+  { category: 'bio', key: 'age', label: 'Age', colKey: 'age', valueType: 'numeric', workerFieldOverride: 'attrs', getter: numericGetter(['age']) },
+  { category: 'bio', key: 'contractAmount', label: 'Contract Amount', colKey: 'contractAmount', valueType: 'numeric', workerFieldOverride: 'attrs', getter: (p) => Number(p?.contract?.baseAnnual ?? p?.contractAmount ?? p?.askingPrice ?? p?.ask ?? 0) },
+  { category: 'bio', key: 'contractExp', label: 'Contract Exp Year', colKey: 'contractExp', valueType: 'numeric', workerFieldOverride: 'attrs', getter: (p) => Number(p?.contract?.exp ?? p?.contract?.expYear ?? 0) || null },
+  { category: 'bio', key: 'college', label: 'College', colKey: 'college', valueType: 'string', workerFieldOverride: 'attrs', getter: stringGetter((p) => p?.college) },
+  { category: 'bio', key: 'draftYear', label: 'Draft Year', colKey: 'draftYear', valueType: 'numeric', workerFieldOverride: 'attrs', getter: (p) => Number(p?.draft?.year ?? p?.draftYear ?? 0) || null },
+  { category: 'bio', key: 'draftRound', label: 'Draft Round', colKey: 'draftRound', valueType: 'numeric', workerFieldOverride: 'attrs', getter: (p) => Number(p?.draft?.round ?? p?.draftRound ?? 0) || null },
+  { category: 'bio', key: 'draftPick', label: 'Draft Pick', colKey: 'draftPick', valueType: 'numeric', workerFieldOverride: 'attrs', getter: (p) => Number(p?.draft?.pick ?? p?.draftPick ?? 0) || null },
+  { category: 'bio', key: 'experience', label: 'Experience', colKey: 'experience', valueType: 'numeric', workerFieldOverride: 'attrs', getter: (p) => Number(p?.experience ?? p?.exp ?? 0) || null },
+];
+
+const canonicalRatings = Object.values(LEGACY_TO_CANONICAL_RATING_KEY);
+
+const ratingFields: FootballAdvancedFilterField[] = [
+  { category: 'ratings', key: 'ovr', label: RATING_LABELS.ovr, colKey: 'ovr', valueType: 'numeric', workerFieldOverride: 'attrs', getter: numericGetter(['ovr']) },
+  { category: 'ratings', key: 'potential', label: RATING_LABELS.potential, colKey: 'pot', valueType: 'numeric', workerFieldOverride: 'attrs', getter: (p) => Number(p?.potential ?? p?.pot ?? 0) || null },
+  ...canonicalRatings.map((key) => ({
+    category: 'ratings' as const,
+    key,
+    label: RATING_LABELS[key] ?? key.toUpperCase(),
+    colKey: key,
+    valueType: 'numeric' as const,
+    workerFieldOverride: 'ratings' as const,
+    getter: (p: any) => {
+      const canonical = p?.ratings?.[key as RatingKey];
+      if (typeof canonical === 'number') return canonical;
+      const legacyKey = Object.keys(LEGACY_TO_CANONICAL_RATING_KEY).find((legacy) => LEGACY_TO_CANONICAL_RATING_KEY[legacy as keyof typeof LEGACY_TO_CANONICAL_RATING_KEY] === key);
+      const legacy = legacyKey ? p?.ratings?.[legacyKey] : undefined;
+      return typeof legacy === 'number' ? legacy : null;
+    },
+  })),
+];
+
+export function getStatsTableByType(statType: string) {
+  return PLAYER_STATS_TABLES[statType] ?? null;
+}
+
+export function getStats(statType: string): string[] {
+  const table = getStatsTableByType(statType);
+  if (!table) return [];
+  return table.columns.map((column) => column.key);
+}
+
+const statFields: FootballAdvancedFilterField[] = Object.entries(PLAYER_STATS_TABLES).flatMap(([groupKey, table]) =>
+  table.columns.map((column) => ({
+    category: 'stats' as const,
+    key: `${groupKey}:${column.key}`,
+    label: `${table.title.replace(/ leaders$/i, '')} ${column.label}`,
+    colKey: column.key,
+    statGroup: groupKey,
+    valueType: 'numeric' as const,
+    workerFieldOverride: 'stats' as const,
+    getter: (p: any) => {
+      const direct = p?.stats?.[column.key] ?? p?.[column.key];
+      if (typeof direct === 'number') return direct;
+      const season = p?.stats?.season?.[column.key];
+      if (typeof season === 'number') return season;
+      return null;
+    },
+  })),
+);
+
+export const allFilters: FootballAdvancedFilterField[] = [...bioFields, ...ratingFields, ...statFields];
+
+export const filtersByCategory: Record<FootballFilterCategory, FootballAdvancedFilterField[]> = {
+  bio: allFilters.filter((f) => f.category === 'bio'),
+  ratings: allFilters.filter((f) => f.category === 'ratings'),
+  stats: allFilters.filter((f) => f.category === 'stats'),
+};
+
+export function addPrefixForStat(field: FootballAdvancedFilterField) {
+  if (field.category === 'bio') return `Bio: ${field.label}`;
+  if (field.category === 'ratings') return `Ratings: ${field.label}`;
+  return `Stats: ${field.label}`;
+}
+
+export function getExtraStatTypeKeys(filters: FootballAdvancedFilter[] = []) {
+  const attrs = new Set<string>();
+  const ratings = new Set<string>();
+  const stats = new Set<string>();
+
+  for (const filter of filters) {
+    const field = allFilters.find((f) => f.key === filter.fieldKey);
+    if (!field) continue;
+    if (field.workerFieldOverride === 'ratings') ratings.add(field.colKey);
+    else if (field.workerFieldOverride === 'stats') stats.add(field.colKey);
+    else attrs.add(field.colKey);
+  }
+
+  if (attrs.has('pos')) {
+    PRIMARY_POSITIONS.forEach((pos) => attrs.add(`pos:${pos}`));
+  }
+
+  return {
+    attrs: Array.from(attrs),
+    ratings: Array.from(ratings),
+    stats: Array.from(stats),
+  };
+}
+
+export function applyAdvancedPlayerFilters(players: any[], filters: FootballAdvancedFilter[] = []) {
+  if (!Array.isArray(filters) || filters.length === 0) return players;
+  return players.filter((player) => filters.every((filter) => matchesFilter(player, filter)));
+}
+
+function matchesFilter(player: any, filter: FootballAdvancedFilter) {
+  const field = allFilters.find((entry) => entry.key === filter.fieldKey);
+  if (!field) return true;
+
+  const left = field.getter(player);
+  if (left == null || filter.value == null || filter.value === '') return true;
+
+  if (field.valueType === 'numeric') {
+    const leftNum = Number(left);
+    const rightNum = Number(filter.value);
+    if (!Number.isFinite(leftNum) || !Number.isFinite(rightNum)) return false;
+    switch (filter.operator) {
+      case 'eq': return leftNum === rightNum;
+      case 'neq': return leftNum !== rightNum;
+      case 'gt': return leftNum > rightNum;
+      case 'gte': return leftNum >= rightNum;
+      case 'lt': return leftNum < rightNum;
+      case 'lte': return leftNum <= rightNum;
+      default: return true;
+    }
+  }
+
+  const leftStr = String(left).toLowerCase();
+  const rightStr = String(filter.value).toLowerCase();
+  switch (filter.operator) {
+    case 'eq': return leftStr === rightStr;
+    case 'neq': return leftStr !== rightStr;
+    case 'contains': return leftStr.includes(rightStr);
+    default: return true;
+  }
+}
+
+export const ADVANCED_FILTER_PRESETS: Record<string, FootballAdvancedFilter[]> = {
+  youngHighPotential: [
+    { id: 'preset-age', fieldKey: 'age', operator: 'lte', value: 24 },
+    { id: 'preset-pot', fieldKey: 'potential', operator: 'gte', value: 80 },
+  ],
+  cheapStarters: [
+    { id: 'preset-ovr', fieldKey: 'ovr', operator: 'gte', value: 70 },
+    { id: 'preset-contract', fieldKey: 'contractAmount', operator: 'lte', value: 6 },
+  ],
+  expiringContracts: [
+    { id: 'preset-exp', fieldKey: 'contractExp', operator: 'eq', value: 1 },
+  ],
+  draftSteals: [
+    { id: 'preset-draft-round', fieldKey: 'draftRound', operator: 'gte', value: 3 },
+    { id: 'preset-draft-ovr', fieldKey: 'ovr', operator: 'gte', value: 70 },
+  ],
+};

--- a/src/ui/components/AdvancedPlayerSearch.jsx
+++ b/src/ui/components/AdvancedPlayerSearch.jsx
@@ -1,0 +1,125 @@
+import React, { useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  ADVANCED_FILTER_PRESETS,
+  addPrefixForStat,
+  allFilters,
+  filtersByCategory,
+} from '../../core/footballAdvancedFilters';
+
+const CATEGORY_OPTIONS = [
+  { value: 'bio', label: 'Bio' },
+  { value: 'ratings', label: 'Ratings' },
+  { value: 'stats', label: 'Stats' },
+];
+
+const OPERATORS = {
+  numeric: [
+    { value: 'eq', label: '=' },
+    { value: 'neq', label: '≠' },
+    { value: 'gt', label: '>' },
+    { value: 'gte', label: '≥' },
+    { value: 'lt', label: '<' },
+    { value: 'lte', label: '≤' },
+  ],
+  string: [
+    { value: 'contains', label: 'contains' },
+    { value: 'eq', label: '=' },
+    { value: 'neq', label: '≠' },
+  ],
+};
+
+const firstFieldInCategory = (category) => filtersByCategory[category]?.[0]?.key ?? allFilters[0]?.key ?? 'name';
+
+export default function AdvancedPlayerSearch({ filters, onChange, title = 'Advanced filters' }) {
+  const activeFilters = filters ?? [];
+  const hasFilters = activeFilters.length > 0;
+
+  const chips = useMemo(() => activeFilters
+    .map((filter) => {
+      const field = allFilters.find((entry) => entry.key === filter.fieldKey);
+      if (!field) return null;
+      const operatorLabel = (OPERATORS[field.valueType] ?? []).find((op) => op.value === filter.operator)?.label ?? filter.operator;
+      return `${field.label} ${operatorLabel} ${filter.value}`;
+    })
+    .filter(Boolean), [activeFilters]);
+
+  const addRow = () => {
+    const fieldKey = firstFieldInCategory('bio');
+    onChange([
+      ...activeFilters,
+      { id: `f-${Date.now()}-${Math.random()}`, fieldKey, operator: 'contains', value: '' },
+    ]);
+  };
+
+  const updateRow = (id, changes) => {
+    onChange(activeFilters.map((row) => (row.id === id ? { ...row, ...changes } : row)));
+  };
+
+  const removeRow = (id) => onChange(activeFilters.filter((row) => row.id !== id));
+
+  const applyPreset = (key) => {
+    const preset = ADVANCED_FILTER_PRESETS[key] ?? [];
+    onChange(preset.map((row, idx) => ({ ...row, id: `${row.id}-${idx}-${Date.now()}` })));
+  };
+
+  return (
+    <div style={{ border: '1px solid var(--hairline)', borderRadius: 'var(--radius-md)', padding: 'var(--space-3)', marginBottom: 'var(--space-4)' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 'var(--space-2)', flexWrap: 'wrap' }}>
+        <strong style={{ fontSize: 'var(--text-sm)' }}>{title}</strong>
+        <div style={{ display: 'flex', gap: 'var(--space-2)', flexWrap: 'wrap' }}>
+          <Button variant="ghost" onClick={() => applyPreset('youngHighPotential')}>Young high-potential</Button>
+          <Button variant="ghost" onClick={() => applyPreset('cheapStarters')}>Cheap starters</Button>
+          <Button variant="ghost" onClick={() => applyPreset('expiringContracts')}>Expiring</Button>
+          <Button variant="ghost" onClick={() => applyPreset('draftSteals')}>Draft steals</Button>
+          <Button variant="ghost" onClick={() => onChange([])} disabled={!hasFilters}>Clear all</Button>
+          <Button variant="default" onClick={addRow}>+ Add filter</Button>
+        </div>
+      </div>
+
+      {activeFilters.map((row) => {
+        const selectedField = allFilters.find((entry) => entry.key === row.fieldKey) ?? allFilters[0];
+        const fieldOptions = filtersByCategory[selectedField.category] ?? [];
+        const operatorOptions = OPERATORS[selectedField.valueType] ?? OPERATORS.string;
+
+        return (
+          <div key={row.id} style={{ display: 'grid', gridTemplateColumns: '140px 1fr 120px 1fr auto', gap: 'var(--space-2)', marginTop: 'var(--space-2)' }}>
+            <select
+              value={selectedField.category}
+              onChange={(event) => {
+                const category = event.target.value;
+                const nextField = firstFieldInCategory(category);
+                const nextMeta = allFilters.find((entry) => entry.key === nextField);
+                updateRow(row.id, { fieldKey: nextField, operator: nextMeta?.valueType === 'numeric' ? 'gte' : 'contains', value: '' });
+              }}
+            >
+              {CATEGORY_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+            </select>
+            <select value={row.fieldKey} onChange={(event) => updateRow(row.id, { fieldKey: event.target.value, value: '' })}>
+              {fieldOptions.map((field) => <option key={field.key} value={field.key}>{addPrefixForStat(field)}</option>)}
+            </select>
+            <select value={row.operator} onChange={(event) => updateRow(row.id, { operator: event.target.value })}>
+              {operatorOptions.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+            </select>
+            <Input
+              type={selectedField.valueType === 'numeric' ? 'number' : 'text'}
+              value={row.value}
+              onChange={(event) => updateRow(row.id, { value: event.target.value })}
+              placeholder={selectedField.valueType === 'numeric' ? 'Value' : 'Text'}
+            />
+            <Button variant="ghost" onClick={() => removeRow(row.id)}>✕</Button>
+          </div>
+        );
+      })}
+
+      {chips.length > 0 && (
+        <div style={{ marginTop: 'var(--space-3)', display: 'flex', gap: 'var(--space-2)', flexWrap: 'wrap' }}>
+          {chips.map((chip) => (
+            <span key={chip} style={{ fontSize: 'var(--text-xs)', padding: '2px 8px', borderRadius: 999, background: 'var(--surface-strong)' }}>{chip}</span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -42,6 +42,8 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { computeTeamNeedsSummary, formatNeedsLine, summarizeFreeAgentMarket } from "../utils/marketSignals.js";
 import { buildDirectionGuidance, buildTeamIntelligence, scoreFreeAgentForTeam } from "../utils/teamIntelligence.js";
 import { ScreenHeader, EmptyState, StickySubnav } from "./ScreenSystem.jsx";
+import AdvancedPlayerSearch from "./AdvancedPlayerSearch.jsx";
+import { applyAdvancedPlayerFilters } from "../../core/footballAdvancedFilters";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -124,6 +126,17 @@ const RESIGN_TIER_LABEL = {
 
 export function formatPlaybookKnowledge(playbookKnowledge) {
   return `${playbookKnowledge?.label ?? "None"} (${playbookKnowledge?.score ?? 0})`;
+}
+
+export function filterFreeAgentsForView(faPool, { signedIds, posFilter, minOvr, nameFilter, advancedFilters }) {
+  const baseFiltered = faPool.filter((p) => {
+    if (signedIds?.has?.(p.id)) return false;
+    if (posFilter !== "ALL" && p.pos !== posFilter) return false;
+    if (minOvr > 0 && p.ovr < minOvr) return false;
+    if (nameFilter && !p.name.toLowerCase().includes(nameFilter.toLowerCase())) return false;
+    return true;
+  });
+  return applyAdvancedPlayerFilters(baseFiltered, advancedFilters);
 }
 
 // ── Shared sub-components (identical signature & appearance to Roster.jsx) ────
@@ -593,6 +606,7 @@ export default function FreeAgency({
   const [posFilter, setPosFilter] = useState("ALL");
   const [nameFilter, setNameFilter] = useState("");
   const [minOvr, setMinOvr] = useState(60);
+  const [advancedFilters, setAdvancedFilters] = useState([]);
 
   // Sorting
   const [sortKey, setSortKey] = useState("ovr");
@@ -657,19 +671,8 @@ export default function FreeAgency({
   }, [faState]);
 
   const displayed = useMemo(() => {
-    return faPool.filter((p) => {
-      if (signedIds.has(p.id)) return false; // Hide players we just signed
-      if (posFilter !== "ALL" && p.pos !== posFilter) return false;
-      if (minOvr > 0 && p.ovr < minOvr) return false;
-      if (
-        nameFilter &&
-        !p.name.toLowerCase().includes(nameFilter.toLowerCase())
-      ) {
-        return false;
-      }
-      return true;
-    });
-  }, [faPool, signedIds, posFilter, nameFilter, minOvr]);
+    return filterFreeAgentsForView(faPool, { signedIds, posFilter, minOvr, nameFilter, advancedFilters });
+  }, [faPool, signedIds, posFilter, nameFilter, minOvr, advancedFilters]);
 
   const sortedAgents = useMemo(() => {
     const arr = [...displayed];
@@ -1012,6 +1015,11 @@ export default function FreeAgency({
           </div>
         </CardContent>
       </Card>
+      <AdvancedPlayerSearch
+        filters={advancedFilters}
+        onChange={setAdvancedFilters}
+        title="Advanced player search (AND)"
+      />
 
       {showCapPreview && (
         <Card className="card-premium" style={{ marginBottom: "var(--space-4)", borderColor: "var(--accent-gold)" }}>

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -48,6 +48,8 @@ import { normalizeManagement, TRADE_STATUSES, TRADE_STATUS_LABELS, CONTRACT_PLAN
 import { deriveTeamCapSnapshot, formatMoneyM, toFiniteNumber } from "../utils/numberFormatting.js";
 import { describePlayerMoraleContext } from "../utils/teamChemistry.js";
 import { getDepthRows, autoBuildDepthChart, depthWarnings } from "../../core/depthChart.js";
+import AdvancedPlayerSearch from "./AdvancedPlayerSearch.jsx";
+import { applyAdvancedPlayerFilters } from "../../core/footballAdvancedFilters";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -267,6 +269,32 @@ function isStarterPlayer(player) {
   return Number.isFinite(depthOrder) && depthOrder === 1;
 }
 
+function applyRosterQuickFilter(players, posFilter) {
+  if (posFilter === "EXPIRING") {
+    return players.filter((p) => getContractYearsLeft(p) <= 1);
+  }
+  if (posFilter === "STARTERS") {
+    return players.filter((p) => isStarterPlayer(p));
+  }
+  if (posFilter === "DEPTH") {
+    return players.filter((p) => !isStarterPlayer(p));
+  }
+  if (posFilter === "INJURED") {
+    return players.filter((p) => isInjuredPlayer(p));
+  }
+  if (posFilter === "DEVELOPMENT") {
+    return players.filter((p) => Number(p?.age ?? 40) <= 24 || Number(p?.potential ?? 0) >= 80);
+  }
+  if (posFilter !== "ALL") {
+    return players.filter(
+      (p) =>
+        p.pos === posFilter ||
+        DEPTH_ROWS.find((r) => r.key === posFilter)?.match.includes(p.pos),
+    );
+  }
+  return players;
+}
+
 // ── Sub-components ────────────────────────────────────────────────────────────
 
 function CapBar({ capUsed, capTotal, deadCap = 0 }) {
@@ -461,6 +489,7 @@ function RosterTable({
   const [sortDir, setSortDir] = useState("desc");
   const [releasing, setReleasing] = useState(null);
   const [extending, setExtending] = useState(null);
+  const [advancedFilters, setAdvancedFilters] = useState([]);
   // Compare mode: up to 2 players selected for side-by-side comparison
   const [compareIds, setCompareIds] = useState([]);
   const [showComparison, setShowComparison] = useState(false);
@@ -474,26 +503,10 @@ function RosterTable({
   };
 
   const displayed = useMemo(() => {
-    let filtered = players;
-    if (posFilter === "EXPIRING") {
-      filtered = players.filter((p) => getContractYearsLeft(p) <= 1);
-    } else if (posFilter === "STARTERS") {
-      filtered = players.filter((p) => isStarterPlayer(p));
-    } else if (posFilter === "DEPTH") {
-      filtered = players.filter((p) => !isStarterPlayer(p));
-    } else if (posFilter === "INJURED") {
-      filtered = players.filter((p) => isInjuredPlayer(p));
-    } else if (posFilter === "DEVELOPMENT") {
-      filtered = players.filter((p) => Number(p?.age ?? 40) <= 24 || Number(p?.potential ?? 0) >= 80);
-    } else if (posFilter !== "ALL") {
-      filtered = players.filter(
-        (p) =>
-          p.pos === posFilter ||
-          DEPTH_ROWS.find((r) => r.key === posFilter)?.match.includes(p.pos),
-      );
-    }
+    const quickFiltered = applyRosterQuickFilter(players, posFilter);
+    const filtered = applyAdvancedPlayerFilters(quickFiltered, advancedFilters);
     return sortPlayers(filtered, sortKey, sortDir);
-  }, [players, posFilter, sortKey, sortDir]);
+  }, [players, posFilter, sortKey, sortDir, advancedFilters]);
   const teamDirection = useMemo(() => classifyTeamDirection(team, week), [team, week]);
   const decisionSummary = useMemo(
     () => buildExpiringDecisionSummary(players, { team, roster: players, direction: teamDirection }),
@@ -691,6 +704,11 @@ function RosterTable({
           </Button>
         ))}
       </div>
+      <AdvancedPlayerSearch
+        filters={advancedFilters}
+        onChange={setAdvancedFilters}
+        title="Advanced player search (AND)"
+      />
 
       {/* Table */}
       <Card className="card-premium" style={{ padding: 0, overflow: "hidden" }}><CardContent style={{ padding: 0 }}>
@@ -1835,31 +1853,15 @@ function PlayerCardGrid({ players, onPlayerSelect, phase, team, week, initialFil
   const [posFilter, setPosFilter] = useState(initialFilter || (isResignPhase ? "EXPIRING" : "ALL"));
   const [sortKey, setSortKey] = useState("ovr");
   const [sortDir, setSortDir] = useState("desc");
+  const [advancedFilters, setAdvancedFilters] = useState([]);
 
   const activeFilters = isResignPhase ? ["EXPIRING", "STARTERS", "DEPTH", "INJURED", "DEVELOPMENT", ...POSITIONS] : ["STARTERS", "DEPTH", "INJURED", "EXPIRING", "DEVELOPMENT", ...POSITIONS];
 
   const displayed = useMemo(() => {
-    let filtered = players;
-    if (posFilter === "EXPIRING") {
-      filtered = players.filter(
-        (p) => getContractYearsLeft(p) <= 1,
-      );
-    } else if (posFilter === "STARTERS") {
-      filtered = players.filter((p) => isStarterPlayer(p));
-    } else if (posFilter === "DEPTH") {
-      filtered = players.filter((p) => !isStarterPlayer(p));
-    } else if (posFilter === "INJURED") {
-      filtered = players.filter((p) => isInjuredPlayer(p));
-    } else if (posFilter === "DEVELOPMENT") {
-      filtered = players.filter((p) => Number(p?.age ?? 40) <= 24 || Number(p?.potential ?? 0) >= 80);
-    } else if (posFilter !== "ALL") {
-      filtered = players.filter(
-        (p) => p.pos === posFilter ||
-          DEPTH_ROWS.find((r) => r.key === posFilter)?.match.includes(p.pos),
-      );
-    }
+    const quickFiltered = applyRosterQuickFilter(players, posFilter);
+    const filtered = applyAdvancedPlayerFilters(quickFiltered, advancedFilters);
     return sortPlayers(filtered, sortKey, sortDir);
-  }, [players, posFilter, sortKey, sortDir]);
+  }, [players, posFilter, sortKey, sortDir, advancedFilters]);
   const direction = useMemo(() => classifyTeamDirection(team, week), [team, week]);
   const decisionSummary = useMemo(
     () => buildExpiringDecisionSummary(players, { team, roster: players, direction }),
@@ -1895,6 +1897,11 @@ function PlayerCardGrid({ players, onPlayerSelect, phase, team, week, initialFil
         flexDirection: "column",
         gap: "var(--space-3)",
       }}>
+        <AdvancedPlayerSearch
+          filters={advancedFilters}
+          onChange={setAdvancedFilters}
+          title="Advanced player search (AND)"
+        />
         {isResignPhase && (
           <div style={{
             display: "flex",

--- a/src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx
+++ b/src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx
@@ -1,9 +1,25 @@
 import { describe, it, expect } from 'vitest';
-import { formatPlaybookKnowledge } from '../FreeAgency.jsx';
+import { filterFreeAgentsForView, formatPlaybookKnowledge } from '../FreeAgency.jsx';
 
 describe('free agency playbook knowledge display', () => {
   it('formats label and score for UI rows/cards', () => {
     expect(formatPlaybookKnowledge({ label: 'High', score: 88 })).toBe('High (88)');
     expect(formatPlaybookKnowledge(null)).toBe('None (0)');
+  });
+
+  it('applies advanced filters on top of baseline FA filters', () => {
+    const pool = [
+      { id: 1, name: 'Alex QB', pos: 'QB', ovr: 82, age: 24, potential: 88 },
+      { id: 2, name: 'Brett WR', pos: 'WR', ovr: 79, age: 28, potential: 80 },
+      { id: 3, name: 'Chris QB', pos: 'QB', ovr: 68, age: 31, potential: 69 },
+    ];
+    const result = filterFreeAgentsForView(pool, {
+      signedIds: new Set(),
+      posFilter: 'QB',
+      minOvr: 60,
+      nameFilter: '',
+      advancedFilters: [{ id: 'a', fieldKey: 'age', operator: 'lte', value: 25 }],
+    });
+    expect(result.map((p) => p.id)).toEqual([1]);
   });
 });


### PR DESCRIPTION
### Motivation
- Audit showed existing per-screen filter logic and that stat/rating metadata is available in `src/core/footballMeta.ts` and `src/core/footballRatings.ts`, so a shared football-only filter layer was needed. 
- Implement a reusable, metadata-driven advanced filter catalog so roster, free agency, and later draft screens can share consistent bio/ratings/stats filters without introducing a second football schema. 
- Keep the first version safe and compatible by doing client-side evaluation and not requiring any save migration or fake stat fields. 

### Description
- Added a new core module `src/core/footballAdvancedFilters.ts` that builds the filter catalog from `PLAYER_STATS_TABLES` and canonical ratings and exports `allFilters`, `addPrefixForStat`, `getStatsTableByType`, `getStats`, `getExtraStatTypeKeys`, `applyAdvancedPlayerFilters`, and `ADVANCED_FILTER_PRESETS`.
- Implemented field metadata for Bio, Ratings (canonical + legacy fallback), and Stats (derived from `PLAYER_STATS_TABLES`) with per-field `getter`, `valueType`, `workerFieldOverride`, and `statGroup` where appropriate.
- Added a lightweight `AdvancedPlayerSearch` UI component at `src/ui/components/AdvancedPlayerSearch.jsx` that supports multiple filter rows (category, field, operator, value), presets, chips, and clear functionality, supporting numeric and string operators including `contains` and range comparisons.
- Integrated advanced filters into Roster and Free Agency screens by adding `AdvancedPlayerSearch` components and wiring the shared `applyAdvancedPlayerFilters` evaluator, plus a helper `filterFreeAgentsForView` to keep FA logic testable and modular.
- Preserved existing quick filters, sorting, and UI behavior; kept filtering client-side in v1 to avoid changing worker payloads or requiring migrations, and deferred draft-screen wiring and worker-side selective fetches for a follow-up.

### Testing
- Ran unit tests for the new catalog and FA integration with: `npm run test:unit -- src/core/__tests__/footballAdvancedFilters.test.ts src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx` and all tests passed (2 files, 6 tests).
- Tests cover filter catalog generation, `getStatsTableByType` / `getStats`, `getExtraStatTypeKeys`, numeric/string matching, AND semantics, and a Free Agency filter integration sanity check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc4a259174832d899223027ca47c92)