### PR TITLE
Add player Compare feature and wire advanced draft filters

### DIFF
--- a/src/core/__tests__/footballCompare.test.ts
+++ b/src/core/__tests__/footballCompare.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { compareNumbers, getPlayerRatingValue, resolveCompareStatSections } from '../footballCompare';
+
+describe('footballCompare helpers', () => {
+  it('highlights better values correctly', () => {
+    expect(compareNumbers(82, 79)).toBe('a');
+    expect(compareNumbers(70, 91)).toBe('b');
+    expect(compareNumbers(4, 2, true)).toBe('b');
+    expect(compareNumbers(null, 2)).toBe('tie');
+  });
+
+  it('supports canonical and legacy rating access', () => {
+    expect(getPlayerRatingValue({ ratings: { tha: 78 } }, 'tha')).toBe(78);
+    expect(getPlayerRatingValue({ ratings: { throwAccuracy: 74 } }, 'tha')).toBe(74);
+  });
+
+  it('filters empty stat sections for mismatched players', () => {
+    const sections = resolveCompareStatSections(
+      { pos: 'QB', stats: { passYd: 4100 } },
+      { pos: 'WR', stats: { recYd: 1200 } },
+      false,
+    );
+    expect(sections.some((s) => s.key === 'passing')).toBe(true);
+    expect(sections.some((s) => s.key === 'receiving')).toBe(true);
+  });
+});

--- a/src/core/footballAdvancedFilters.ts
+++ b/src/core/footballAdvancedFilters.ts
@@ -216,4 +216,30 @@ export const ADVANCED_FILTER_PRESETS: Record<string, FootballAdvancedFilter[]> =
     { id: 'preset-draft-round', fieldKey: 'draftRound', operator: 'gte', value: 3 },
     { id: 'preset-draft-ovr', fieldKey: 'ovr', operator: 'gte', value: 70 },
   ],
+  day1Starters: [
+    { id: 'preset-day1-ovr', fieldKey: 'ovr', operator: 'gte', value: 75 },
+    { id: 'preset-day1-pot', fieldKey: 'potential', operator: 'gte', value: 78 },
+  ],
+  developmentalUpside: [
+    { id: 'preset-dev-age', fieldKey: 'age', operator: 'lte', value: 22 },
+    { id: 'preset-dev-pot', fieldKey: 'potential', operator: 'gte', value: 82 },
+  ],
+  bestAthletes: [
+    { id: 'preset-ath-spd', fieldKey: 'spd', operator: 'gte', value: 82 },
+    { id: 'preset-ath-acc', fieldKey: 'acc', operator: 'gte', value: 80 },
+  ],
+  valuePicks: [
+    { id: 'preset-value-ovr', fieldKey: 'ovr', operator: 'gte', value: 68 },
+    { id: 'preset-value-pot', fieldKey: 'potential', operator: 'gte', value: 80 },
+  ],
+  qbUpside: [
+    { id: 'preset-qb-pos', fieldKey: 'pos', operator: 'eq', value: 'QB' },
+    { id: 'preset-qb-tha', fieldKey: 'tha', operator: 'gte', value: 74 },
+    { id: 'preset-qb-thp', fieldKey: 'thp', operator: 'gte', value: 78 },
+  ],
+  skillUpside: [
+    { id: 'preset-skill-pos-wr', fieldKey: 'pos', operator: 'contains', value: 'W' },
+    { id: 'preset-skill-speed', fieldKey: 'spd', operator: 'gte', value: 80 },
+    { id: 'preset-skill-pot', fieldKey: 'potential', operator: 'gte', value: 80 },
+  ],
 };

--- a/src/core/footballCompare.ts
+++ b/src/core/footballCompare.ts
@@ -1,0 +1,156 @@
+import { PLAYER_STATS_TABLES } from './footballMeta';
+import { LEGACY_TO_CANONICAL_RATING_KEY } from './footballRatings';
+import type { RatingKey } from './footballTypes';
+
+export type CompareStatRow = { key: string; label: string; lowerIsBetter?: boolean };
+export type CompareSection = { key: string; title: string; rows: CompareStatRow[]; optional?: boolean };
+
+const RATING_LABELS: Record<string, string> = {
+  ovr: 'OVR',
+  potential: 'Potential',
+  tha: 'Throw Accuracy',
+  thp: 'Throw Power',
+  spd: 'Speed',
+  acc: 'Acceleration',
+  awr: 'Awareness',
+  cth: 'Catching',
+  cit: 'Catch In Traffic',
+  rbk: 'Run Blocking',
+  pbk: 'Pass Blocking',
+  prs: 'Pass Rush Speed',
+  prp: 'Pass Rush Power',
+  rns: 'Run Stop',
+  cov: 'Coverage',
+  kpw: 'Kick Power',
+  kac: 'Kick Accuracy',
+  trk: 'Trucking',
+  jkm: 'Juking',
+};
+
+const PASS_POS = new Set(['QB']);
+const RUSH_POS = new Set(['RB', 'QB']);
+const RECEIVE_POS = new Set(['WR', 'TE', 'RB']);
+const DEF_POS = new Set(['DL', 'LB', 'CB', 'S']);
+const KICK_POS = new Set(['K', 'P']);
+
+const POSITION_GROUP_PRIORITIES: Record<string, string[]> = {
+  QB: ['passing', 'rushing', 'receiving'],
+  RB: ['rushing', 'receiving', 'passing'],
+  WR: ['receiving', 'rushing'],
+  TE: ['receiving', 'rushing'],
+  OL: [],
+  DL: ['defense'],
+  LB: ['defense'],
+  CB: ['defense'],
+  S: ['defense'],
+  K: ['kicking'],
+  P: ['kicking'],
+};
+
+export const COMPARE_RATING_KEYS: Array<'ovr' | 'potential' | RatingKey> = [
+  'ovr',
+  'potential',
+  ...Object.values(LEGACY_TO_CANONICAL_RATING_KEY),
+];
+
+export function getCompareRatingLabel(key: string) {
+  return RATING_LABELS[key] ?? key.toUpperCase();
+}
+
+export function getPlayerRatingValue(player: any, key: string): number | null {
+  if (key === 'ovr') return toNumber(player?.ovr);
+  if (key === 'potential') return toNumber(player?.potential ?? player?.pot);
+
+  const canonical = toNumber(player?.ratings?.[key]);
+  if (canonical != null) return canonical;
+
+  const legacyKey = Object.keys(LEGACY_TO_CANONICAL_RATING_KEY)
+    .find((legacy) => LEGACY_TO_CANONICAL_RATING_KEY[legacy as keyof typeof LEGACY_TO_CANONICAL_RATING_KEY] === key);
+  return legacyKey ? toNumber(player?.ratings?.[legacyKey]) : null;
+}
+
+export function getPlayerStatValue(player: any, key: string): number | null {
+  const direct = toNumber(player?.stats?.[key] ?? player?.[key]);
+  if (direct != null) return direct;
+  return toNumber(player?.stats?.season?.[key]);
+}
+
+export function resolveCompareStatSections(playerA: any, playerB: any, showAll = false): CompareSection[] {
+  const posA = playerA?.pos;
+  const posB = playerB?.pos;
+  const ordered = dedupe([
+    ...(POSITION_GROUP_PRIORITIES[posA] ?? []),
+    ...(POSITION_GROUP_PRIORITIES[posB] ?? []),
+    'passing',
+    'rushing',
+    'receiving',
+    'defense',
+    'kicking',
+  ]);
+
+  const baseSections = ordered.map((groupKey) => {
+    if (groupKey === 'kicking') {
+      return {
+        key: 'kicking',
+        title: 'Kicking / Punting',
+        rows: [
+          { key: 'fgMade', label: 'FG Made' },
+          { key: 'fgAttempts', label: 'FG Att' },
+          { key: 'xpMade', label: 'XP Made' },
+          { key: 'xpAttempts', label: 'XP Att' },
+          { key: 'punts', label: 'Punts' },
+          { key: 'puntYards', label: 'Punt Yards' },
+        ],
+        optional: true,
+      } as CompareSection;
+    }
+
+    const table = PLAYER_STATS_TABLES[groupKey];
+    if (!table) return null;
+    return {
+      key: groupKey,
+      title: table.title.replace(/ leaders$/i, ''),
+      rows: table.columns.map((column) => ({ key: column.key, label: column.label })),
+    } as CompareSection;
+  }).filter(Boolean) as CompareSection[];
+
+  const filtered = baseSections
+    .map((section) => ({
+      ...section,
+      rows: section.rows.filter((row) => {
+        if (showAll) return true;
+        return getPlayerStatValue(playerA, row.key) != null || getPlayerStatValue(playerB, row.key) != null;
+      }),
+    }))
+    .filter((section) => section.rows.length > 0);
+
+  return showAll ? baseSections : filtered;
+}
+
+export function compareNumbers(a: number | null, b: number | null, lowerIsBetter = false) {
+  if (a == null || b == null) return 'tie';
+  if (a === b) return 'tie';
+  if (lowerIsBetter) return a < b ? 'a' : 'b';
+  return a > b ? 'a' : 'b';
+}
+
+export function shouldShowGroupForPosition(group: string, pos?: string) {
+  if (!pos) return true;
+  if (group === 'passing') return PASS_POS.has(pos);
+  if (group === 'rushing') return RUSH_POS.has(pos);
+  if (group === 'receiving') return RECEIVE_POS.has(pos);
+  if (group === 'defense') return DEF_POS.has(pos);
+  if (group === 'kicking') return KICK_POS.has(pos);
+  return true;
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (value == null || value === '') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function dedupe(values: string[]) {
+  return Array.from(new Set(values));
+}

--- a/src/ui/components/AdvancedPlayerSearch.jsx
+++ b/src/ui/components/AdvancedPlayerSearch.jsx
@@ -30,23 +30,30 @@ const OPERATORS = {
   ],
 };
 
-const firstFieldInCategory = (category) => filtersByCategory[category]?.[0]?.key ?? allFilters[0]?.key ?? 'name';
+const firstFieldInCategory = (category, byCategory = filtersByCategory, fallback = allFilters) => byCategory[category]?.[0]?.key ?? fallback[0]?.key ?? 'name';
 
-export default function AdvancedPlayerSearch({ filters, onChange, title = 'Advanced filters' }) {
+export default function AdvancedPlayerSearch({ filters, onChange, title = 'Advanced filters', allowedFields, presetKeys }) {
+  const availableFields = useMemo(() => (Array.isArray(allowedFields) && allowedFields.length > 0 ? allowedFields : allFilters), [allowedFields]);
+  const availableByCategory = useMemo(() => ({
+    bio: availableFields.filter((f) => f.category === 'bio'),
+    ratings: availableFields.filter((f) => f.category === 'ratings'),
+    stats: availableFields.filter((f) => f.category === 'stats'),
+  }), [availableFields]);
+
   const activeFilters = filters ?? [];
   const hasFilters = activeFilters.length > 0;
 
   const chips = useMemo(() => activeFilters
     .map((filter) => {
-      const field = allFilters.find((entry) => entry.key === filter.fieldKey);
+      const field = availableFields.find((entry) => entry.key === filter.fieldKey);
       if (!field) return null;
       const operatorLabel = (OPERATORS[field.valueType] ?? []).find((op) => op.value === filter.operator)?.label ?? filter.operator;
       return `${field.label} ${operatorLabel} ${filter.value}`;
     })
-    .filter(Boolean), [activeFilters]);
+    .filter(Boolean), [activeFilters, availableFields]);
 
   const addRow = () => {
-    const fieldKey = firstFieldInCategory('bio');
+    const fieldKey = firstFieldInCategory('bio', availableByCategory, availableFields);
     onChange([
       ...activeFilters,
       { id: `f-${Date.now()}-${Math.random()}`, fieldKey, operator: 'contains', value: '' },
@@ -59,28 +66,33 @@ export default function AdvancedPlayerSearch({ filters, onChange, title = 'Advan
 
   const removeRow = (id) => onChange(activeFilters.filter((row) => row.id !== id));
 
+  const visiblePresetKeys = presetKeys ?? ['youngHighPotential', 'cheapStarters', 'expiringContracts', 'draftSteals'];
+
   const applyPreset = (key) => {
     const preset = ADVANCED_FILTER_PRESETS[key] ?? [];
-    onChange(preset.map((row, idx) => ({ ...row, id: `${row.id}-${idx}-${Date.now()}` })));
+    const allowedKeySet = new Set(availableFields.map((f) => f.key));
+    const filteredPreset = preset.filter((row) => allowedKeySet.has(row.fieldKey));
+    onChange(filteredPreset.map((row, idx) => ({ ...row, id: `${row.id}-${idx}-${Date.now()}` })));
   };
+
+  if (!availableFields.length) return null;
 
   return (
     <div style={{ border: '1px solid var(--hairline)', borderRadius: 'var(--radius-md)', padding: 'var(--space-3)', marginBottom: 'var(--space-4)' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 'var(--space-2)', flexWrap: 'wrap' }}>
         <strong style={{ fontSize: 'var(--text-sm)' }}>{title}</strong>
         <div style={{ display: 'flex', gap: 'var(--space-2)', flexWrap: 'wrap' }}>
-          <Button variant="ghost" onClick={() => applyPreset('youngHighPotential')}>Young high-potential</Button>
-          <Button variant="ghost" onClick={() => applyPreset('cheapStarters')}>Cheap starters</Button>
-          <Button variant="ghost" onClick={() => applyPreset('expiringContracts')}>Expiring</Button>
-          <Button variant="ghost" onClick={() => applyPreset('draftSteals')}>Draft steals</Button>
+          {visiblePresetKeys.map((key) => (
+            <Button key={key} variant="ghost" onClick={() => applyPreset(key)}>{key.replace(/([A-Z])/g, ' $1').trim()}</Button>
+          ))}
           <Button variant="ghost" onClick={() => onChange([])} disabled={!hasFilters}>Clear all</Button>
           <Button variant="default" onClick={addRow}>+ Add filter</Button>
         </div>
       </div>
 
       {activeFilters.map((row) => {
-        const selectedField = allFilters.find((entry) => entry.key === row.fieldKey) ?? allFilters[0];
-        const fieldOptions = filtersByCategory[selectedField.category] ?? [];
+        const selectedField = availableFields.find((entry) => entry.key === row.fieldKey) ?? availableFields[0];
+        const fieldOptions = availableByCategory[selectedField?.category] ?? [];
         const operatorOptions = OPERATORS[selectedField.valueType] ?? OPERATORS.string;
 
         return (
@@ -89,8 +101,8 @@ export default function AdvancedPlayerSearch({ filters, onChange, title = 'Advan
               value={selectedField.category}
               onChange={(event) => {
                 const category = event.target.value;
-                const nextField = firstFieldInCategory(category);
-                const nextMeta = allFilters.find((entry) => entry.key === nextField);
+                const nextField = firstFieldInCategory(category, availableByCategory, availableFields);
+                const nextMeta = availableFields.find((entry) => entry.key === nextField);
                 updateRow(row.id, { fieldKey: nextField, operator: nextMeta?.valueType === 'numeric' ? 'gte' : 'contains', value: '' });
               }}
             >

--- a/src/ui/components/Draft.jsx
+++ b/src/ui/components/Draft.jsx
@@ -27,6 +27,11 @@ import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { getProspectRegionTag, getScoutingConfidenceProfile } from "../utils/franchiseInvestments.js";
+import AdvancedPlayerSearch from "./AdvancedPlayerSearch.jsx";
+import PlayerComparison from "./PlayerComparison.jsx";
+import PlayerCompareTray from "./PlayerCompareTray.jsx";
+import { applyAdvancedPlayerFilters, allFilters } from "../../core/footballAdvancedFilters";
+import { usePlayerCompare } from "../utils/playerCompare.js";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -999,6 +1004,13 @@ function PreDraftPanel({ league, actions, onDraftStarted }) {
   );
 }
 
+export function filterDraftProspectsForView(prospects, { filterPos, nameFilter, advancedFilters }) {
+  let list = [...(prospects ?? [])];
+  if (filterPos) list = list.filter((p) => p.pos === filterPos);
+  if (nameFilter) list = list.filter((p) => p.name.toLowerCase().includes(nameFilter.toLowerCase()));
+  return applyAdvancedPlayerFilters(list, advancedFilters);
+}
+
 function DraftBoard({
   draftState,
   userTeamId,
@@ -1013,6 +1025,8 @@ function DraftBoard({
   const [sortDir, setSortDir] = useState(-1); // -1 = descending
   const [filterPos, setFilterPos] = useState("");
   const [nameFilter, setNameFilter] = useState("");
+  const [advancedFilters, setAdvancedFilters] = useState([]);
+  const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
   const [showTradeUp, setShowTradeUp] = useState(false);
   const [showTradeDown, setShowTradeDown] = useState(false);
   const [tradeDownProcessing, setTradeDownProcessing] = useState(false);
@@ -1035,13 +1049,19 @@ function DraftBoard({
     }
   };
 
+  const draftAdvancedFields = useMemo(() => allFilters.filter((field) => {
+    if (field.category === 'bio') {
+      return !['contractAmount', 'contractExp'].includes(field.key);
+    }
+    if (field.category === 'stats') {
+      return ['passing', 'rushing', 'receiving', 'defense'].includes(field.statGroup ?? '');
+    }
+    return true;
+  }), []);
+
   const sortedProspects = useMemo(() => {
-    let list = [...prospects];
-    if (filterPos) list = list.filter((p) => p.pos === filterPos);
-    if (nameFilter)
-      list = list.filter((p) =>
-        p.name.toLowerCase().includes(nameFilter.toLowerCase()),
-      );
+    const filtered = filterDraftProspectsForView(prospects, { filterPos, nameFilter, advancedFilters });
+    const list = [...filtered];
     list.sort((a, b) => {
       const av = a[sortKey] ?? 0;
       const bv = b[sortKey] ?? 0;
@@ -1049,7 +1069,17 @@ function DraftBoard({
       return sortDir * ((bv ?? 0) - (av ?? 0));
     });
     return list;
-  }, [prospects, filterPos, nameFilter, sortKey, sortDir]);
+  }, [prospects, filterPos, nameFilter, sortKey, sortDir, advancedFilters]);
+
+  const {
+    compareIds,
+    setCompareIds,
+    showComparison,
+    setShowComparison,
+    toggleCompare,
+    comparePlayerA,
+    comparePlayerB,
+  } = usePlayerCompare(sortedProspects, 2);
 
   const posOptions = useMemo(
     () => [...new Set(prospects.map((p) => p.pos))].sort(),
@@ -1610,6 +1640,31 @@ function DraftBoard({
             </span>
           </div>
 
+          <div style={{ marginTop: 8, marginBottom: 8 }}>
+            <Button className="btn" onClick={() => setShowAdvancedFilters((v) => !v)} style={{ fontSize: 'var(--text-xs)' }}>
+              {showAdvancedFilters ? 'Hide advanced filters' : 'Show advanced filters'}
+            </Button>
+          </div>
+          {showAdvancedFilters && (
+            <AdvancedPlayerSearch
+              filters={advancedFilters}
+              onChange={setAdvancedFilters}
+              title="Draft advanced search"
+              allowedFields={draftAdvancedFields}
+              presetKeys={["youngHighPotential", "day1Starters", "developmentalUpside", "bestAthletes", "valuePicks", "qbUpside", "skillUpside"]}
+            />
+          )}
+          {showComparison && comparePlayerA && comparePlayerB && (
+            <PlayerComparison playerA={comparePlayerA} playerB={comparePlayerB} onClose={() => setShowComparison(false)} />
+          )}
+          <PlayerCompareTray
+            compareIds={compareIds}
+            resolvePlayer={(id) => sortedProspects.find((p) => p.id === id)}
+            onRemove={toggleCompare}
+            onOpenCompare={() => setShowComparison(true)}
+            onClear={() => setCompareIds([])}
+          />
+
           {/* Prospects table */}
           <Card className="card-premium" style={{ padding: 0, overflow: "hidden" }}>
             <CardContent style={{ padding: 0 }}>
@@ -1634,6 +1689,7 @@ function DraftBoard({
                       { key: "name", label: "NAME" },
                       { key: "traits", label: "TRAITS" },
                       { key: "age", label: "AGE" },
+                      { key: "compare", label: "CMP" },
                       { key: "ovr", label: isDraftComplete ? "OVR" : "GRADE" },
                       { key: "potential", label: isDraftComplete ? "POT" : "???" },
                       { key: "college", label: "COLLEGE" },
@@ -1667,7 +1723,7 @@ function DraftBoard({
                   {sortedProspects.length === 0 && (
                     <TableRow>
                       <TableCell
-                        colSpan={isUserPick ? 8 : 7}
+                        colSpan={isUserPick ? 9 : 8}
                         style={{
                           textAlign: "center",
                           padding: "var(--space-6)",
@@ -1740,6 +1796,7 @@ function DraftBoard({
                         ))}
                       </TableCell>
                       <TableCell style={{ color: "var(--text-muted)" }}>{p.age}</TableCell>
+                      <TableCell style={{ textAlign: "center" }}><Button title={compareIds.includes(p.id) ? "Remove from compare" : "Add to compare"} onClick={() => toggleCompare(p)} style={{ width: 22, height: 22, borderRadius: "var(--radius-sm)", border: `1.5px solid ${compareIds.includes(p.id) ? "var(--accent)" : "var(--hairline)"}`, background: compareIds.includes(p.id) ? "var(--accent-muted)" : "transparent", fontSize: 12, color: compareIds.includes(p.id) ? "var(--accent)" : "var(--text-subtle)" }}>{compareIds.includes(p.id) ? "✓" : "⊕"}</Button></TableCell>
                       <TableCell>
                         {/* Fog of War: show scout grade before drafted, true OVR after */}
                         {isDraftComplete

--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -33,6 +33,8 @@ import TraitBadge from "./TraitBadge";
 import PlayerAvatar from "./PlayerAvatar";
 import DonutChart from "./DonutChart";
 import PlayerCard from "./PlayerCard.jsx";
+import PlayerComparison from "./PlayerComparison.jsx";
+import PlayerCompareTray from "./PlayerCompareTray.jsx";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
@@ -44,6 +46,7 @@ import { buildDirectionGuidance, buildTeamIntelligence, scoreFreeAgentForTeam } 
 import { ScreenHeader, EmptyState, StickySubnav } from "./ScreenSystem.jsx";
 import AdvancedPlayerSearch from "./AdvancedPlayerSearch.jsx";
 import { applyAdvancedPlayerFilters } from "../../core/footballAdvancedFilters";
+import { usePlayerCompare } from "../utils/playerCompare.js";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -690,6 +693,17 @@ export default function FreeAgency({
     return arr;
   }, [displayed, sortKey, sortDir]);
 
+
+  const {
+    compareIds,
+    setCompareIds,
+    showComparison,
+    setShowComparison,
+    toggleCompare,
+    comparePlayerA,
+    comparePlayerB,
+  } = usePlayerCompare(sortedAgents, 2);
+
   const isResignPhase = faState?.phase === "offseason_resign";
   const priorityTargets = useMemo(() => {
     if (isResignPhase) {
@@ -1020,6 +1034,16 @@ export default function FreeAgency({
         onChange={setAdvancedFilters}
         title="Advanced player search (AND)"
       />
+      {showComparison && comparePlayerA && comparePlayerB && (
+        <PlayerComparison playerA={comparePlayerA} playerB={comparePlayerB} onClose={() => setShowComparison(false)} />
+      )}
+      <PlayerCompareTray
+        compareIds={compareIds}
+        resolvePlayer={(id) => sortedAgents.find((p) => p.id === id)}
+        onRemove={toggleCompare}
+        onOpenCompare={() => setShowComparison(true)}
+        onClear={() => setCompareIds([])}
+      />
 
       {showCapPreview && (
         <Card className="card-premium" style={{ marginBottom: "var(--space-4)", borderColor: "var(--accent-gold)" }}>
@@ -1100,6 +1124,9 @@ export default function FreeAgency({
                       dir={sortDir}
                       onSort={handleSort}
                     />
+                    <TableHead style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 600, textAlign: "center" }}>
+                      CMP
+                    </TableHead>
                     <TableHead
                       style={{
                         fontSize: "var(--text-xs)",
@@ -1134,7 +1161,7 @@ export default function FreeAgency({
                   {sortedAgents.length === 0 && (
                     <TableRow>
                       <TableCell
-                        colSpan={9}
+                        colSpan={10}
                         style={{
                           textAlign: "center",
                           padding: "var(--space-8)",
@@ -1247,6 +1274,7 @@ export default function FreeAgency({
                             </TableCell>
                             <TableCell><OvrBadge ovr={player.ovr} />{player.scoutUncertaintyBand ? <div style={{fontSize:11,color:'var(--text-muted)'}}>{player.scoutConfidenceLabel} · ±{player.scoutUncertaintyBand}</div> : null}</TableCell>
                             <TableCell style={{ color: "var(--text-muted)" }}>{player.age}</TableCell>
+                            <TableCell style={{ textAlign: "center" }}><Button title={compareIds.includes(player.id) ? "Remove from compare" : "Add to compare"} onClick={() => toggleCompare(player)} style={{ width: 22, height: 22, borderRadius: "var(--radius-sm)", border: `1.5px solid ${compareIds.includes(player.id) ? "var(--accent)" : "var(--hairline)"}`, background: compareIds.includes(player.id) ? "var(--accent-muted)" : "transparent", fontSize: 12, color: compareIds.includes(player.id) ? "var(--accent)" : "var(--text-subtle)" }}>{compareIds.includes(player.id) ? "✓" : "⊕"}</Button></TableCell>
                             <TableCell style={{ textAlign: "center" }}>
                               <PipBar value={player.schemeFit ?? 50} color="var(--accent)" />
                             </TableCell>
@@ -1283,6 +1311,7 @@ export default function FreeAgency({
                         </TableCell>
                         <TableCell><OvrBadge ovr={player.ovr} /></TableCell>
                         <TableCell style={{ color: "var(--text-muted)" }}>{player.age}</TableCell>
+                        <TableCell style={{ textAlign: "center" }}><Button title={compareIds.includes(player.id) ? "Remove from compare" : "Add to compare"} onClick={() => toggleCompare(player)} style={{ width: 22, height: 22, borderRadius: "var(--radius-sm)", border: `1.5px solid ${compareIds.includes(player.id) ? "var(--accent)" : "var(--hairline)"}`, background: compareIds.includes(player.id) ? "var(--accent-muted)" : "transparent", fontSize: 12, color: compareIds.includes(player.id) ? "var(--accent)" : "var(--text-subtle)" }}>{compareIds.includes(player.id) ? "✓" : "⊕"}</Button></TableCell>
                         <TableCell style={{ textAlign: "center" }}>
                           <PipBar value={player.schemeFit ?? 50} color="var(--accent)" />
                         </TableCell>
@@ -1332,6 +1361,7 @@ export default function FreeAgency({
                     {Array.isArray(player?.market?.stateChips) && player.market.stateChips.length > 0 ? <div style={{ fontSize: 10, color: 'var(--text-subtle)' }}>{player.market.stateChips.join(' · ')}</div> : null}
                     <div style={{ display: "flex", gap: 6, marginTop: 8 }}>
                       <Button className="btn" onClick={() => onPlayerSelect && onPlayerSelect(player.id)}>View profile</Button>
+                      <Button className="btn" onClick={() => toggleCompare(player)}>{compareIds.includes(player.id) ? "Uncompare" : "Compare"}</Button>
                       <Button className="btn btn-primary" onClick={() => setSigningPlayerId(player.id)}>Negotiate</Button>
                     </div>
                   </Card>

--- a/src/ui/components/PlayerCompareTray.jsx
+++ b/src/ui/components/PlayerCompareTray.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+
+export default function PlayerCompareTray({ compareIds, resolvePlayer, onRemove, onOpenCompare, onClear, max = 2 }) {
+  if (!compareIds?.length) return null;
+
+  return (
+    <div style={{ position: 'sticky', bottom: 8, zIndex: 40, padding: 'var(--space-3) var(--space-4)', background: 'rgba(10,132,255,0.08)', border: '1px solid var(--accent)', borderRadius: 'var(--radius-md)', marginBottom: 'var(--space-3)', display: 'flex', alignItems: 'center', gap: 'var(--space-3)', flexWrap: 'wrap' }}>
+      <span style={{ fontSize: 'var(--text-xs)', fontWeight: 700, color: 'var(--accent)' }}>Compare ({compareIds.length}/{max})</span>
+      {compareIds.map((id) => {
+        const player = resolvePlayer(id);
+        if (!player) return null;
+        return (
+          <span key={id} style={{ padding: '2px 10px', borderRadius: 'var(--radius-pill)', background: 'var(--accent-muted)', color: 'var(--accent)', fontSize: 'var(--text-xs)', fontWeight: 600, display: 'flex', alignItems: 'center', gap: 4 }}>
+            {player.name}
+            <Button onClick={() => onRemove(player)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--accent)', fontSize: 14, lineHeight: 1, padding: 0 }}>×</Button>
+          </span>
+        );
+      })}
+      {compareIds.length === max && (
+        <Button className="btn" onClick={onOpenCompare} style={{ marginLeft: 'auto', fontSize: 'var(--text-xs)', padding: '4px 14px', background: 'var(--accent)', color: '#fff', border: 'none' }}>
+          Compare →
+        </Button>
+      )}
+      <Button onClick={onClear} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-muted)', fontSize: 'var(--text-xs)' }}>Clear</Button>
+    </div>
+  );
+}

--- a/src/ui/components/PlayerComparison.jsx
+++ b/src/ui/components/PlayerComparison.jsx
@@ -1,365 +1,103 @@
-/**
- * PlayerComparison.jsx
- *
- * Side-by-side player comparison modal.
- * Shows OVR, attributes, contract, age, career stats in a dual-panel layout
- * with attribute bars that visually show the difference between two players.
- *
- * Usage: open with two player objects and call onClose to dismiss.
- */
+import React, { useMemo, useState } from 'react';
+import {
+  compareNumbers,
+  COMPARE_RATING_KEYS,
+  getCompareRatingLabel,
+  getPlayerRatingValue,
+  getPlayerStatValue,
+  resolveCompareStatSections,
+  shouldShowGroupForPosition,
+} from '../../core/footballCompare';
 
-import React, { useMemo } from "react";
-
-// ── Helpers ────────────────────────────────────────────────────────────────────
-
-function teamColor(abbr = "") {
-  const palette = [
-    "#0A84FF","#34C759","#FF9F0A","#FF453A","#5E5CE6",
-    "#64D2FF","#FFD60A","#30D158","#FF6961","#AEC6CF",
-    "#FF6B35","#B4A0E5",
-  ];
-  let hash = 0;
-  for (let i = 0; i < abbr.length; i++)
-    hash = abbr.charCodeAt(i) + ((hash << 5) - hash);
-  return palette[Math.abs(hash) % palette.length];
+function formatContract(player) {
+  const amount = Number(player?.contract?.baseAnnual ?? player?.contractAmount ?? player?.askingPrice ?? 0);
+  const years = player?.contract?.yearsRemaining ?? player?.contract?.years ?? player?.contract?.yearsTotal;
+  if (!amount && !years) return '—';
+  return `$${amount.toFixed(1)}M${years ? ` · ${years}y` : ''}`;
 }
 
-function ovrClass(ovr) {
-  if (ovr >= 95) return "rating-color-goat";
-  if (ovr >= 88) return "rating-color-elite";
-  if (ovr >= 78) return "rating-color-star";
-  if (ovr >= 68) return "rating-color-good";
-  if (ovr >= 58) return "rating-color-avg";
-  return "rating-color-bad";
+function getDisplayName(player) {
+  return player?.name ?? `${player?.firstName ?? ''} ${player?.lastName ?? ''}`.trim() ?? 'Unknown';
 }
 
-// Position-specific attribute groups to compare
-const POS_ATTRS = {
-  QB:  ["throwPower","throwAccuracy","speed","agility","awareness","intelligence"],
-  RB:  ["speed","acceleration","trucking","juking","catching","awareness"],
-  WR:  ["speed","catching","catchInTraffic","agility","awareness","runBlock"],
-  TE:  ["catching","runBlock","passBlock","speed","awareness","agility"],
-  OL:  ["passBlock","runBlock","strength","awareness","agility","intelligence"],
-  DL:  ["passRushSpeed","passRushPower","runStop","strength","speed","awareness"],
-  LB:  ["coverage","runStop","passRushSpeed","speed","awareness","intelligence"],
-  CB:  ["coverage","speed","agility","awareness","runStop","intelligence"],
-  S:   ["coverage","runStop","speed","awareness","agility","intelligence"],
-  K:   ["kickPower","kickAccuracy","awareness","intelligence","speed","agility"],
-  P:   ["kickPower","kickAccuracy","awareness","intelligence","speed","agility"],
-};
-
-const ATTR_LABELS = {
-  throwPower: "Throw Power",
-  throwAccuracy: "Accuracy",
-  speed: "Speed",
-  acceleration: "Acceleration",
-  agility: "Agility",
-  awareness: "Awareness",
-  intelligence: "Intelligence",
-  trucking: "Trucking",
-  juking: "Juke",
-  catching: "Catching",
-  catchInTraffic: "Catch (Traffic)",
-  passBlock: "Pass Block",
-  runBlock: "Run Block",
-  strength: "Strength",
-  passRushSpeed: "Pass Rush Spd",
-  passRushPower: "Pass Rush Pwr",
-  runStop: "Run Stop",
-  coverage: "Coverage",
-  kickPower: "Kick Power",
-  kickAccuracy: "Kick Accuracy",
-};
-
-// ── Sub-components ─────────────────────────────────────────────────────────────
-
-function PlayerHeader({ player, color }) {
-  const isA = color === "var(--accent)";
+function ValueCell({ value, winner }) {
   return (
-    <div style={{
-      display: "flex",
-      flexDirection: "column",
-      alignItems: "center",
-      gap: "var(--space-2)",
-      padding: "var(--space-4)",
-      background: `${color}0a`,
-      borderBottom: "1px solid var(--hairline)",
-    }}>
-      {/* Avatar circle */}
-      <div style={{
-        width: 56, height: 56, borderRadius: "50%",
-        background: `${color}22`,
-        border: `3px solid ${color}`,
-        display: "flex", alignItems: "center", justifyContent: "center",
-        fontWeight: 900, fontSize: "1.1rem", color,
-      }}>
-        {(player.firstName?.[0] ?? "") + (player.lastName?.[0] ?? player.pos?.[0] ?? "?")}
-      </div>
-
-      {/* Name + Position */}
-      <div style={{ textAlign: "center" }}>
-        <div style={{ fontWeight: 700, fontSize: "var(--text-base)", color: "var(--text)", lineHeight: 1.2 }}>
-          {player.firstName} {player.lastName}
-        </div>
-        <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginTop: 2 }}>
-          {player.pos} · Age {player.age}
-        </div>
-      </div>
-
-      {/* OVR badge */}
-      <div style={{
-        display: "flex", alignItems: "center", gap: "var(--space-2)",
-      }}>
-        <span className={`ovr-pill ${ovrClass(player.ovr)}`} style={{ minWidth: 42, fontSize: "var(--text-sm)", padding: "3px 8px" }}>
-          {player.ovr}
-        </span>
-        {player.devTrait && player.devTrait !== "normal" && (
-          <span style={{
-            fontSize: 10, fontWeight: 700, padding: "2px 6px",
-            borderRadius: "var(--radius-pill)",
-            background: player.devTrait === "xfactor" ? "rgba(255,215,0,0.2)" : player.devTrait === "superstar" ? "rgba(191,90,242,0.2)" : "rgba(10,132,255,0.2)",
-            color: player.devTrait === "xfactor" ? "#FFD700" : player.devTrait === "superstar" ? "#BF5AF2" : "var(--accent)",
-          }}>
-            {player.devTrait === "xfactor" ? "X-Factor" : player.devTrait === "superstar" ? "Superstar" : "Star"}
-          </span>
-        )}
-      </div>
-
-      {/* Contract */}
-      {player.contract && (
-        <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)", textAlign: "center" }}>
-          ${(player.contract.salary ?? 0).toFixed(1)}M · {player.contract.years ?? 0}yr
-        </div>
-      )}
+    <div style={{ fontWeight: winner ? 800 : 500, color: winner ? 'var(--accent)' : 'var(--text-muted)' }}>
+      {value ?? '—'}
     </div>
   );
 }
 
-function AttributeBar({ label, valueA, valueB }) {
-  const max = 99;
-  const pctA = (valueA ?? 0) / max * 100;
-  const pctB = (valueB ?? 0) / max * 100;
-  const aWins = (valueA ?? 0) > (valueB ?? 0);
-  const bWins = (valueB ?? 0) > (valueA ?? 0);
-
+function Row({ label, a, b, lowerIsBetter = false }) {
+  const outcome = compareNumbers(typeof a === 'number' ? a : null, typeof b === 'number' ? b : null, lowerIsBetter);
   return (
-    <div style={{ marginBottom: "var(--space-2)" }}>
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 4 }}>
-        <span style={{
-          fontSize: "var(--text-xs)", fontWeight: aWins ? 700 : 400,
-          color: aWins ? "var(--accent)" : "var(--text-muted)",
-          minWidth: 28, textAlign: "right",
-        }}>
-          {valueA ?? "—"}
-        </span>
-        <span style={{ fontSize: 10, color: "var(--text-subtle)", flex: 1, textAlign: "center", textTransform: "uppercase", letterSpacing: "0.3px" }}>
-          {label}
-        </span>
-        <span style={{
-          fontSize: "var(--text-xs)", fontWeight: bWins ? 700 : 400,
-          color: bWins ? "#FF9F0A" : "var(--text-muted)",
-          minWidth: 28,
-        }}>
-          {valueB ?? "—"}
-        </span>
-      </div>
-      {/* Dual bar: left = player A (blue), right = player B (orange), meet in center */}
-      <div style={{ display: "flex", height: 6, gap: 2 }}>
-        {/* Player A bar (right-aligned) */}
-        <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
-          <div style={{
-            width: `${pctA}%`, height: "100%",
-            background: aWins ? "var(--accent)" : "rgba(10,132,255,0.4)",
-            borderRadius: "var(--radius-pill)",
-            transition: "width 0.5s var(--ease)",
-          }} />
-        </div>
-        {/* Center divider */}
-        <div style={{ width: 2, background: "var(--hairline-strong)", borderRadius: 1, flexShrink: 0 }} />
-        {/* Player B bar (left-aligned) */}
-        <div style={{ flex: 1 }}>
-          <div style={{
-            width: `${pctB}%`, height: "100%",
-            background: bWins ? "#FF9F0A" : "rgba(255,159,10,0.4)",
-            borderRadius: "var(--radius-pill)",
-            transition: "width 0.5s var(--ease)",
-          }} />
-        </div>
-      </div>
+    <div style={{ display: 'grid', gridTemplateColumns: '1fr auto 1fr', gap: 10, padding: '6px 0', borderBottom: '1px solid var(--hairline)' }}>
+      <ValueCell value={a} winner={outcome === 'a'} />
+      <div style={{ color: 'var(--text-subtle)', fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.5px' }}>{label}</div>
+      <div style={{ textAlign: 'right' }}><ValueCell value={b} winner={outcome === 'b'} /></div>
     </div>
   );
 }
-
-// ── Main Export ────────────────────────────────────────────────────────────────
 
 export default function PlayerComparison({ playerA, playerB, onClose }) {
-  // Determine which attribute group to show based on position
-  const pos = playerA?.pos ?? playerB?.pos ?? "QB";
-  const normalizedPos = Object.keys(POS_ATTRS).find(p => pos.startsWith(p)) ?? "QB";
-  const attrs = POS_ATTRS[normalizedPos] ?? POS_ATTRS.QB;
+  const [showAllStats, setShowAllStats] = useState(false);
 
-  const sharedAttrs = useMemo(() => {
-    // Show attrs that at least one player has a value for
-    return attrs.filter(attr =>
-      (playerA?.ratings?.[attr] != null) || (playerB?.ratings?.[attr] != null)
-    );
-  }, [attrs, playerA, playerB]);
+  const sections = useMemo(() => resolveCompareStatSections(playerA, playerB, showAllStats), [playerA, playerB, showAllStats]);
 
-  // Summary comparison
-  const wins = useMemo(() => {
-    let a = 0, b = 0;
-    sharedAttrs.forEach(attr => {
-      const va = playerA?.ratings?.[attr] ?? 0;
-      const vb = playerB?.ratings?.[attr] ?? 0;
-      if (va > vb) a++;
-      else if (vb > va) b++;
-    });
-    return { a, b };
-  }, [sharedAttrs, playerA, playerB]);
+  const ratings = useMemo(() => COMPARE_RATING_KEYS
+    .map((key) => ({
+      key,
+      label: getCompareRatingLabel(key),
+      a: getPlayerRatingValue(playerA, key),
+      b: getPlayerRatingValue(playerB, key),
+    }))
+    .filter((row) => row.a != null || row.b != null), [playerA, playerB]);
 
   if (!playerA || !playerB) return null;
 
   return (
-    <div
-      style={{
-        position: "fixed", inset: 0, zIndex: 1000,
-        background: "rgba(0,0,0,0.75)",
-        display: "flex", alignItems: "center", justifyContent: "center",
-        padding: "var(--space-4)",
-        backdropFilter: "blur(8px)",
-        WebkitBackdropFilter: "blur(8px)",
-      }}
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
-    >
-      <div style={{
-        background: "var(--bg-secondary)",
-        border: "1px solid var(--hairline-strong)",
-        borderRadius: "var(--radius-xl)",
-        overflow: "hidden",
-        width: "100%", maxWidth: 680,
-        maxHeight: "90vh",
-        display: "flex", flexDirection: "column",
-        boxShadow: "var(--shadow-xl)",
-      }}>
-        {/* Modal header */}
-        <div style={{
-          padding: "var(--space-3) var(--space-5)",
-          borderBottom: "1px solid var(--hairline)",
-          background: "var(--surface-strong)",
-          display: "flex", alignItems: "center", justifyContent: "space-between",
-        }}>
-          <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
-            <span style={{ fontSize: "1rem" }}>⚖️</span>
-            <span style={{ fontWeight: 700, fontSize: "var(--text-sm)", color: "var(--text)" }}>
-              Player Comparison
-            </span>
-            <span style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>
-              · {normalizedPos}
-            </span>
-          </div>
-          <button
-            onClick={onClose}
-            style={{
-              background: "none", border: "none", cursor: "pointer",
-              fontSize: 22, color: "var(--text-muted)", lineHeight: 1,
-              padding: "0 var(--space-1)",
-            }}
-            aria-label="Close comparison"
-          >
-            ×
-          </button>
+    <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.68)', zIndex: 1200, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 12 }} onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <div style={{ width: 'min(980px, 100%)', maxHeight: '90vh', overflowY: 'auto', background: 'var(--surface)', borderRadius: 'var(--radius-lg)', border: '1px solid var(--hairline)' }}>
+        <div style={{ position: 'sticky', top: 0, background: 'var(--surface-strong)', zIndex: 2, borderBottom: '1px solid var(--hairline)', padding: '10px 14px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <strong>Compare Players</strong>
+          <button onClick={onClose} style={{ border: 'none', background: 'transparent', fontSize: 18, cursor: 'pointer', color: 'var(--text-muted)' }}>✕</button>
         </div>
 
-        <div style={{ overflowY: "auto", flex: 1 }}>
-          {/* Player headers side-by-side */}
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 0 }}>
-            <PlayerHeader player={playerA} color="var(--accent)" />
-            <div style={{ borderLeft: "1px solid var(--hairline)" }}>
-              <PlayerHeader player={playerB} color="#FF9F0A" />
-            </div>
-          </div>
+        <div style={{ padding: 14 }}>
+          <h4 style={{ margin: '0 0 8px 0' }}>Bio</h4>
+          <Row label="Name" a={getDisplayName(playerA)} b={getDisplayName(playerB)} />
+          <Row label="Team" a={playerA?.teamAbbrev ?? playerA?.team?.abbr ?? 'FA'} b={playerB?.teamAbbrev ?? playerB?.team?.abbr ?? 'FA'} />
+          <Row label="Position" a={playerA?.pos ?? '—'} b={playerB?.pos ?? '—'} />
+          <Row label="Age" a={playerA?.age ?? '—'} b={playerB?.age ?? '—'} lowerIsBetter />
+          <Row label="College" a={playerA?.college ?? '—'} b={playerB?.college ?? '—'} />
+          <Row label="Experience" a={playerA?.experience ?? playerA?.exp ?? '—'} b={playerB?.experience ?? playerB?.exp ?? '—'} />
+          <Row label="Contract" a={formatContract(playerA)} b={formatContract(playerB)} />
+          <Row label="Draft" a={playerA?.draft?.year ? `${playerA.draft.year} R${playerA.draft.round ?? '?'} P${playerA.draft.pick ?? '?'}` : '—'} b={playerB?.draft?.year ? `${playerB.draft.year} R${playerB.draft.round ?? '?'} P${playerB.draft.pick ?? '?'}` : '—'} />
 
-          {/* Win count summary */}
-          <div style={{
-            padding: "var(--space-3) var(--space-5)",
-            background: "var(--surface)",
-            borderBottom: "1px solid var(--hairline)",
-            display: "flex", justifyContent: "space-between", alignItems: "center",
-          }}>
-            <span style={{ fontSize: "var(--text-xs)", color: wins.a > wins.b ? "var(--accent)" : "var(--text-subtle)", fontWeight: wins.a > wins.b ? 700 : 400 }}>
-              {playerA.firstName} wins {wins.a} / {sharedAttrs.length} attrs
-            </span>
-            <span style={{ fontSize: 10, color: "var(--text-subtle)", textTransform: "uppercase", letterSpacing: "0.5px" }}>
-              Head-to-Head
-            </span>
-            <span style={{ fontSize: "var(--text-xs)", color: wins.b > wins.a ? "#FF9F0A" : "var(--text-subtle)", fontWeight: wins.b > wins.a ? 700 : 400 }}>
-              {playerB.firstName} wins {wins.b} / {sharedAttrs.length} attrs
-            </span>
-          </div>
+          <h4 style={{ margin: '14px 0 8px 0' }}>Ratings</h4>
+          {ratings.map((rating) => (
+            <Row key={rating.key} label={rating.label} a={rating.a ?? '—'} b={rating.b ?? '—'} />
+          ))}
 
-          {/* Attribute bars */}
-          <div style={{ padding: "var(--space-4) var(--space-5)" }}>
-            <div style={{ fontSize: "var(--text-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.8px", color: "var(--text-subtle)", marginBottom: "var(--space-3)" }}>
-              Attributes
+          <h4 style={{ margin: '14px 0 8px 0', display: 'flex', justifyContent: 'space-between' }}>
+            <span>Production</span>
+            <button className="btn" onClick={() => setShowAllStats((v) => !v)} style={{ fontSize: 11 }}>{showAllStats ? 'Position-focused' : 'All stats'}</button>
+          </h4>
+          {sections.filter((section) => showAllStats || shouldShowGroupForPosition(section.key, playerA?.pos) || shouldShowGroupForPosition(section.key, playerB?.pos)).map((section) => (
+            <div key={section.key} style={{ marginBottom: 10, padding: 10, border: '1px solid var(--hairline)', borderRadius: 'var(--radius-md)' }}>
+              <div style={{ fontWeight: 700, marginBottom: 6 }}>{section.title}</div>
+              {section.rows.map((row) => (
+                <Row
+                  key={`${section.key}-${row.key}`}
+                  label={row.label}
+                  a={getPlayerStatValue(playerA, row.key) ?? '—'}
+                  b={getPlayerStatValue(playerB, row.key) ?? '—'}
+                  lowerIsBetter={row.lowerIsBetter}
+                />
+              ))}
             </div>
-            {sharedAttrs.map(attr => (
-              <AttributeBar
-                key={attr}
-                label={ATTR_LABELS[attr] ?? attr}
-                valueA={playerA.ratings?.[attr]}
-                valueB={playerB.ratings?.[attr]}
-              />
-            ))}
-          </div>
-
-          {/* OVR comparison big display */}
-          <div style={{
-            padding: "var(--space-4) var(--space-5)",
-            borderTop: "1px solid var(--hairline)",
-            display: "grid", gridTemplateColumns: "1fr auto 1fr",
-            alignItems: "center", gap: "var(--space-4)",
-          }}>
-            <div style={{ textAlign: "center" }}>
-              <div style={{ fontSize: 36, fontWeight: 900, color: playerA.ovr >= playerB.ovr ? "var(--accent)" : "var(--text-muted)" }}>
-                {playerA.ovr}
-              </div>
-              <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>Overall</div>
-            </div>
-            <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)", fontWeight: 700 }}>OVR</div>
-            <div style={{ textAlign: "center" }}>
-              <div style={{ fontSize: 36, fontWeight: 900, color: playerB.ovr >= playerA.ovr ? "#FF9F0A" : "var(--text-muted)" }}>
-                {playerB.ovr}
-              </div>
-              <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>Overall</div>
-            </div>
-          </div>
-
-          {/* Age & contract comparison */}
-          <div style={{
-            padding: "var(--space-3) var(--space-5)",
-            borderTop: "1px solid var(--hairline)",
-            display: "grid", gridTemplateColumns: "1fr auto 1fr",
-            gap: "var(--space-2)",
-            fontSize: "var(--text-xs)",
-          }}>
-            {[
-              { label: "Age", a: playerA.age, b: playerB.age, lowerIsBetter: true },
-              { label: "Salary", a: `$${(playerA.contract?.salary ?? 0).toFixed(1)}M`, b: `$${(playerB.contract?.salary ?? 0).toFixed(1)}M`, raw: { a: playerA.contract?.salary ?? 0, b: playerB.contract?.salary ?? 0 }, lowerIsBetter: true },
-              { label: "Contract", a: `${playerA.contract?.years ?? 0}yr`, b: `${playerB.contract?.years ?? 0}yr`, raw: null },
-            ].map(({ label, a, b, raw, lowerIsBetter }) => {
-              const ra = raw?.a ?? (typeof a === "number" ? a : null);
-              const rb = raw?.b ?? (typeof b === "number" ? b : null);
-              const aWins = ra != null && rb != null ? (lowerIsBetter ? ra < rb : ra > rb) : false;
-              const bWins = ra != null && rb != null ? (lowerIsBetter ? rb < ra : rb > ra) : false;
-              return (
-                <React.Fragment key={label}>
-                  <div style={{ textAlign: "right", fontWeight: aWins ? 700 : 400, color: aWins ? "var(--accent)" : "var(--text-muted)" }}>{a}</div>
-                  <div style={{ textAlign: "center", color: "var(--text-subtle)", textTransform: "uppercase", letterSpacing: "0.3px" }}>{label}</div>
-                  <div style={{ fontWeight: bWins ? 700 : 400, color: bWins ? "#FF9F0A" : "var(--text-muted)" }}>{b}</div>
-                </React.Fragment>
-              );
-            })}
-          </div>
+          ))}
+          {sections.length === 0 && <div style={{ color: 'var(--text-muted)' }}>No shared stat history available for this pairing yet.</div>}
         </div>
       </div>
     </div>

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -27,6 +27,7 @@
 import React, { useState, useEffect, useMemo, useCallback } from "react";
 import TraitBadge from "./TraitBadge";
 import PlayerComparison from "./PlayerComparison.jsx";
+import PlayerCompareTray from "./PlayerCompareTray.jsx";
 import PlayerProfile from "./PlayerProfile.jsx";
 import ExtensionNegotiationModal from "./ExtensionNegotiationModal.jsx";
 import { teamColor } from "../../data/team-utils.js";
@@ -50,6 +51,7 @@ import { describePlayerMoraleContext } from "../utils/teamChemistry.js";
 import { getDepthRows, autoBuildDepthChart, depthWarnings } from "../../core/depthChart.js";
 import AdvancedPlayerSearch from "./AdvancedPlayerSearch.jsx";
 import { applyAdvancedPlayerFilters } from "../../core/footballAdvancedFilters";
+import { usePlayerCompare } from "../utils/playerCompare.js";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -490,17 +492,15 @@ function RosterTable({
   const [releasing, setReleasing] = useState(null);
   const [extending, setExtending] = useState(null);
   const [advancedFilters, setAdvancedFilters] = useState([]);
-  // Compare mode: up to 2 players selected for side-by-side comparison
-  const [compareIds, setCompareIds] = useState([]);
-  const [showComparison, setShowComparison] = useState(false);
-
-  const toggleCompare = (player) => {
-    setCompareIds(prev => {
-      if (prev.includes(player.id)) return prev.filter(id => id !== player.id);
-      if (prev.length >= 2) return [prev[1], player.id]; // replace oldest
-      return [...prev, player.id];
-    });
-  };
+  const {
+    compareIds,
+    setCompareIds,
+    showComparison,
+    setShowComparison,
+    toggleCompare,
+    comparePlayerA,
+    comparePlayerB,
+  } = usePlayerCompare(players, 2);
 
   const displayed = useMemo(() => {
     const quickFiltered = applyRosterQuickFilter(players, posFilter);
@@ -587,8 +587,6 @@ function RosterTable({
   };
 
 
-  const comparePlayerA = players.find(p => p.id === compareIds[0]);
-  const comparePlayerB = players.find(p => p.id === compareIds[1]);
 
   return (
     <>
@@ -613,54 +611,13 @@ function RosterTable({
           onClose={() => setShowComparison(false)}
         />
       )}
-      {/* Compare bar — shown when 1-2 players are selected for comparison */}
-      {compareIds.length > 0 && (
-        <div style={{
-          padding: "var(--space-3) var(--space-4)",
-          background: "rgba(10,132,255,0.08)",
-          border: "1px solid var(--accent)",
-          borderRadius: "var(--radius-md)",
-          marginBottom: "var(--space-3)",
-          display: "flex", alignItems: "center", gap: "var(--space-3)",
-          flexWrap: "wrap",
-        }}>
-          <span style={{ fontSize: "var(--text-xs)", fontWeight: 700, color: "var(--accent)" }}>
-            Compare ({compareIds.length}/2):
-          </span>
-          {compareIds.map(id => {
-            const p = players.find(pl => pl.id === id);
-            return p ? (
-              <span key={id} style={{
-                padding: "2px 10px", borderRadius: "var(--radius-pill)",
-                background: "var(--accent-muted)", color: "var(--accent)",
-                fontSize: "var(--text-xs)", fontWeight: 600,
-                display: "flex", alignItems: "center", gap: 4,
-              }}>
-                {p.name}
-                <Button
-                  onClick={() => toggleCompare(p)}
-                  style={{ background: "none", border: "none", cursor: "pointer", color: "var(--accent)", fontSize: 14, lineHeight: 1, padding: 0 }}
-                >×</Button>
-              </span>
-            ) : null;
-          })}
-          {compareIds.length === 2 && (
-            <Button
-              className="btn"
-              onClick={() => setShowComparison(true)}
-              style={{ marginLeft: "auto", fontSize: "var(--text-xs)", padding: "4px 14px", background: "var(--accent)", color: "#fff", border: "none" }}
-            >
-              Compare →
-            </Button>
-          )}
-          <Button
-            onClick={() => setCompareIds([])}
-            style={{ background: "none", border: "none", cursor: "pointer", color: "var(--text-muted)", fontSize: "var(--text-xs)" }}
-          >
-            Clear
-          </Button>
-        </div>
-      )}
+      <PlayerCompareTray
+        compareIds={compareIds}
+        resolvePlayer={(id) => players.find((pl) => pl.id === id)}
+        onRemove={toggleCompare}
+        onOpenCompare={() => setShowComparison(true)}
+        onClear={() => setCompareIds([])}
+      />
       {/* Position filter pills */}
       {isResignPhase && (
         <div style={{

--- a/src/ui/components/__tests__/draftFilters.test.jsx
+++ b/src/ui/components/__tests__/draftFilters.test.jsx
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { filterDraftProspectsForView } from '../Draft.jsx';
+
+describe('draft advanced filter integration', () => {
+  it('applies position/name baseline plus advanced filters', () => {
+    const prospects = [
+      { id: 1, name: 'Aaron Ace', pos: 'QB', age: 22, ovr: 77, potential: 88, ratings: { tha: 79 } },
+      { id: 2, name: 'Ben Bolt', pos: 'QB', age: 24, ovr: 71, potential: 75, ratings: { tha: 68 } },
+      { id: 3, name: 'Will Wideout', pos: 'WR', age: 22, ovr: 74, potential: 86, ratings: { spd: 85 } },
+    ];
+
+    const result = filterDraftProspectsForView(prospects, {
+      filterPos: 'QB',
+      nameFilter: 'a',
+      advancedFilters: [{ id: 'f1', fieldKey: 'potential', operator: 'gte', value: 80 }],
+    });
+
+    expect(result.map((p) => p.id)).toEqual([1]);
+  });
+});

--- a/src/ui/utils/playerCompare.js
+++ b/src/ui/utils/playerCompare.js
@@ -1,0 +1,30 @@
+import { useMemo, useState } from 'react';
+
+export function nextCompareIds(prev, playerId, max = 2) {
+  if (prev.includes(playerId)) return prev.filter((id) => id !== playerId);
+  if (prev.length >= max) return [...prev.slice(1), playerId];
+  return [...prev, playerId];
+}
+
+export function usePlayerCompare(players = [], max = 2) {
+  const [compareIds, setCompareIds] = useState([]);
+  const [showComparison, setShowComparison] = useState(false);
+
+  const toggleCompare = (player) => {
+    if (!player?.id) return;
+    setCompareIds((prev) => nextCompareIds(prev, player.id, max));
+  };
+
+  const comparePlayerA = useMemo(() => players.find((p) => p.id === compareIds[0]), [players, compareIds]);
+  const comparePlayerB = useMemo(() => players.find((p) => p.id === compareIds[1]), [players, compareIds]);
+
+  return {
+    compareIds,
+    setCompareIds,
+    showComparison,
+    setShowComparison,
+    toggleCompare,
+    comparePlayerA,
+    comparePlayerB,
+  };
+}

--- a/src/ui/utils/playerCompare.test.js
+++ b/src/ui/utils/playerCompare.test.js
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { nextCompareIds } from './playerCompare';
+
+describe('playerCompare selection', () => {
+  it('adds/removes and caps compare list at two players', () => {
+    expect(nextCompareIds([], 10, 2)).toEqual([10]);
+    expect(nextCompareIds([10], 22, 2)).toEqual([10, 22]);
+    expect(nextCompareIds([10, 22], 35, 2)).toEqual([22, 35]);
+    expect(nextCompareIds([22, 35], 22, 2)).toEqual([35]);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a lightweight, reusable Compare Players experience across roster, free agency, and draft without changing the football schema or save format. 
- Surface a premium, position-aware side-by-side player evaluation that reuses existing canonical metadata, rating compatibility, and stat table definitions. 
- Integrate the previously-built advanced player search into the Draft flow so scouting/prospect filtering can reuse the same engine.

### Description
- Added a shared compare helper layer `src/core/footballCompare.ts` that reuses `PLAYER_STATS_TABLES` and rating mappings to drive rating labels, stat lookups, position-aware sections, and winner/highlight logic. 
- Rebuilt the compare UI into a metadata-driven `PlayerComparison` component that shows Bio, Ratings (OVR/POT + canonical ratings), and position-prioritized stat sections with an "All stats" toggle and per-row better-value highlighting. 
- Introduced selection primitives: `usePlayerCompare` (`src/ui/utils/playerCompare.js`) and a sticky `PlayerCompareTray` (`src/ui/components/PlayerCompareTray.jsx`) and wired compare entry points into `Roster`, `FreeAgency`, and `Draft` list/card views so players can be added/removed and opened into the compare modal. 
- Extended `AdvancedPlayerSearch` to accept scoped `allowedFields` and `presetKeys` so the same UI can be safely reused in draft context, added draft-safe presets (e.g., `day1Starters`, `developmentalUpside`, `qbUpside`), and added `filterDraftProspectsForView` to combine baseline prospect filters with advanced filters. 
- Kept runtime/data safety: no new schema, no fake stats, no sim engine changes, and compare falls back gracefully when ratings/stats are missing. 
- Added unit tests for compare helpers and selection and for draft filter integration and updated `ADVANCED_FILTER_PRESETS` to include draft-focused presets.

### Testing
- Ran unit tests with `npm run test:unit` for the new/modified tests: `src/core/__tests__/footballCompare.test.ts`, `src/ui/utils/playerCompare.test.js`, `src/ui/components/__tests__/draftFilters.test.jsx`, `src/core/__tests__/footballAdvancedFilters.test.ts`, and `src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx`, and all tests passed. 
- Built a production bundle with `npm run build` and the Vite build completed successfully. 
- Notes: advanced draft filters intentionally hide contract fields and limit stat groups for prospects because prospect data can be sparse; UI compare logic only displays rows when runtime/archive fields exist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc4db5a594832dade05b2e42caa14c)