### PR TITLE
Stabilize sim-to-phase flow with cancellable batch-sim, status events, and draft timeout hardening

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -267,6 +267,8 @@ function AppContent() {
     }
   }, [league]);
 
+  const isBatchSimBlocking = !!batchSim && !['cancelled', 'completed', 'idle'].includes(batchSim?.status);
+
   const handleAdvanceWeek = useCallback(() => {
     if (busy || simulating || advancingRef.current) return;
     if (!league?.phase) return;
@@ -288,10 +290,20 @@ function AppContent() {
   }, [busy, simulating, actions, league]);
 
   const handleSimToPhase = useCallback((targetPhase) => {
-    if (busy || simulating || advancingRef.current || batchSim) return;
+    if (busy || simulating || advancingRef.current || isBatchSimBlocking) return;
     advancingRef.current = true;
     actions.simToPhase(targetPhase);
-  }, [busy, simulating, batchSim, actions]);
+  }, [busy, simulating, isBatchSimBlocking, actions]);
+
+  const handleCancelBatchSim = useCallback(() => {
+    actions.cancelSimToPhase();
+  }, [actions]);
+
+  const handleRetryBatchSim = useCallback(() => {
+    const target = batchSim?.targetPhase;
+    if (!target) return;
+    actions.retrySimToPhase(target);
+  }, [actions, batchSim]);
 
   const handleReset = useCallback(() => {
     if (window.confirm('Reset/Delete your active save? This cannot be undone.')) {
@@ -405,7 +417,7 @@ function AppContent() {
   };
 
   const safePhase = league?.phase ?? null;
-  const canUseTopActions = !!safePhase && !(busy || simulating || !!batchSim);
+  const canUseTopActions = !!safePhase && !(busy || simulating || isBatchSimBlocking);
 
   const topSecondaryAction = useMemo(() => {
     if (!safePhase) return null;
@@ -457,13 +469,13 @@ function AppContent() {
     }
 
     items.push(
-      { label: 'Save Game', onClick: () => activeSlot && actions.saveSlot(activeSlot), disabled: !activeSlot || busy || !!batchSim },
-      { label: 'Save Slots', onClick: () => setActiveSlot(null), disabled: busy || !!batchSim },
-      { label: 'Reset Franchise', onClick: handleReset, disabled: busy || !!batchSim, danger: true },
+      { label: 'Save Game', onClick: () => activeSlot && actions.saveSlot(activeSlot), disabled: !activeSlot || busy || isBatchSimBlocking },
+      { label: 'Save Slots', onClick: () => setActiveSlot(null), disabled: busy || isBatchSimBlocking },
+      { label: 'Reset Franchise', onClick: handleReset, disabled: busy || isBatchSimBlocking, danger: true },
     );
 
     return items;
-  }, [safePhase, canUseTopActions, activeSlot, actions, busy, batchSim, handleReset, handleSimToPhase]);
+  }, [safePhase, canUseTopActions, activeSlot, actions, busy, isBatchSimBlocking, handleReset, handleSimToPhase]);
 
   // ── Render ────────────────────────────────────────────────────────────────
 
@@ -621,12 +633,12 @@ function AppContent() {
           <button
             className="btn btn-primary app-advance-btn app-action-primary"
             onClick={handleAdvanceWeek}
-            disabled={busy || simulating || isCutdownRequired || !!batchSim || !!promptUserGame}
+            disabled={busy || simulating || isCutdownRequired || isBatchSimBlocking || !!promptUserGame}
             title={isCutdownRequired ? "You must cut your roster to 53 players before advancing." : ""}
           >
             {getAdvanceLabel()}
           </button>
-          {topSecondaryAction && !batchSim && (
+          {topSecondaryAction && !isBatchSimBlocking && (
             <button
               className="btn app-sim-btn app-action-secondary"
               onClick={topSecondaryAction.onClick}
@@ -678,8 +690,27 @@ function AppContent() {
              batchSim.phase === 'playoffs' ? `Playoffs Week ${batchSim.currentWeek}` :
              batchSim.phase || 'Initializing...'}
           </div>
+          <div className="app-batch-detail" style={{ opacity: 0.85, fontSize: 12 }}>
+            Status: {batchSim.status || 'running'}
+          </div>
           <div className="app-batch-bar">
             <div className="app-batch-bar-fill" />
+          </div>
+          <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+            <button
+              className="btn"
+              onClick={handleRetryBatchSim}
+              disabled={!['cancelled', 'completed'].includes(batchSim.status)}
+            >
+              Retry
+            </button>
+            <button
+              className="btn btn-danger"
+              onClick={handleCancelBatchSim}
+              disabled={batchSim.status === 'cancelled' || batchSim.status === 'completed'}
+            >
+              Cancel
+            </button>
           </div>
           <style>{`
             @keyframes batchSimPulse {
@@ -848,7 +879,7 @@ function AppContent() {
           externalBoxScoreId={externalBoxScoreId}
           onConsumeExternalBoxScore={() => setExternalBoxScoreId(null)}
           advanceLabel={getAdvanceLabel()}
-          advanceDisabled={busy || simulating || isCutdownRequired || !!batchSim || !!promptUserGame}
+          advanceDisabled={busy || simulating || isCutdownRequired || isBatchSimBlocking || !!promptUserGame}
         />
       </ErrorBoundary>
 
@@ -858,7 +889,7 @@ function AppContent() {
       )}
 
       {/* ── Simulation Progress Spinner (CSS-only, prevents frozen-UI appearance) ── */}
-      {(simulating || busy) && !promptUserGame && !userGameLogs && !batchSim && (
+      {(simulating || busy) && !promptUserGame && !userGameLogs && !isBatchSimBlocking && (
         <div className="app-sim-spinner-overlay">
           <div className="app-sim-spinner" />
           <p className="app-sim-spinner-text">

--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -20,6 +20,9 @@ import { useEffect, useRef, useCallback, useReducer, useMemo } from 'react';
 import { toWorker, toUI, send as buildMsg } from '../../worker/protocol.js';
 
 const WORKER_REQUEST_TIMEOUT_MS = 20000;
+const WORKER_TIMEOUT_BY_TYPE = Object.freeze({
+  [toWorker.GET_DRAFT_STATE]: 120000,
+});
 
 // ── State shape ───────────────────────────────────────────────────────────────
 
@@ -99,9 +102,22 @@ function reducer(state, action) {
     case 'SIM_START':
       return { ...state, simulating: true, simProgress: 0, gameEvents: [], promptUserGame: false, userGameLogs: null };
     case 'BATCH_SIM_START':
-      return { ...state, busy: true, batchSim: { currentWeek: 0, phase: '', targetPhase: action.targetPhase } };
+      return { ...state, busy: true, batchSim: { currentWeek: 0, phase: '', targetPhase: action.targetPhase, status: 'running' } };
     case 'BATCH_SIM_PROGRESS':
       return { ...state, batchSim: { ...state.batchSim, currentWeek: action.currentWeek, phase: action.phase } };
+    case 'BATCH_SIM_STATUS':
+      return {
+        ...state,
+        busy: action.status === 'running' || action.status === 'cancelling',
+        batchSim: action.status === 'idle'
+          ? null
+          : {
+              ...(state.batchSim ?? {}),
+              targetPhase: action.targetPhase ?? state.batchSim?.targetPhase ?? null,
+              phase: action.stage ?? state.batchSim?.phase ?? '',
+              status: action.status,
+            },
+      };
     case 'BATCH_SIM_DONE':
       return { ...state, busy: false, batchSim: null };
     case 'SIM_PROGRESS':
@@ -271,6 +287,9 @@ export function useWorker() {
         case toUI.SIM_BATCH_PROGRESS:
           dispatch({ type: 'BATCH_SIM_PROGRESS', currentWeek: payload.currentWeek, phase: payload.phase });
           break;
+        case toUI.SIM_BATCH_STATUS:
+          dispatch({ type: 'BATCH_SIM_STATUS', status: payload.status, targetPhase: payload.targetPhase, stage: payload.stage });
+          break;
         case toUI.GAME_EVENT:
           dispatch({ type: 'GAME_EVENT', event: payload });
           break;
@@ -346,19 +365,20 @@ export function useWorker() {
   // ── request (returns a Promise resolved on worker reply) ──────────────────
   // Pass { silent: true } for read-only fetches (getRoster, getFreeAgents,
   // history queries) so they do NOT set busy=true and lock the Advance button.
-  const request = useCallback((type, payload = {}, { silent = false } = {}) => {
+  const request = useCallback((type, payload = {}, { silent = false, timeoutMs } = {}) => {
     return new Promise((resolve, reject) => {
       if (!workerRef.current) {
         reject(new Error('Worker not ready'));
         return;
       }
       const msg = buildMsg(type, payload);
+      const effectiveTimeout = Number(timeoutMs) || WORKER_TIMEOUT_BY_TYPE[type] || WORKER_REQUEST_TIMEOUT_MS;
       const timeoutId = setTimeout(() => {
         if (!pendingRef.current.has(msg.id)) return;
         pendingRef.current.delete(msg.id);
         reject(new Error(`Worker timeout while handling ${type}`));
         dispatch({ type: 'ERROR', message: `Request timed out: ${type}. Please retry.` });
-      }, WORKER_REQUEST_TIMEOUT_MS);
+      }, effectiveTimeout);
       pendingRef.current.set(msg.id, { resolve, reject, silent, timeoutId });
       if (!silent) dispatch({ type: 'BUSY' });
       workerRef.current.postMessage(msg);
@@ -418,6 +438,11 @@ export function useWorker() {
 
     /** Batch sim to a target phase (playoffs, offseason, preseason/regular). */
     simToPhase: (targetPhase)  => {
+      dispatch({ type: 'BATCH_SIM_START', targetPhase });
+      send(toWorker.SIM_TO_PHASE, { targetPhase });
+    },
+    cancelSimToPhase: ()       => send(toWorker.CANCEL_SIM_TO_PHASE),
+    retrySimToPhase: (targetPhase) => {
       dispatch({ type: 'BATCH_SIM_START', targetPhase });
       send(toWorker.SIM_TO_PHASE, { targetPhase });
     },

--- a/src/worker/protocol.js
+++ b/src/worker/protocol.js
@@ -33,6 +33,7 @@ export const toWorker = Object.freeze({
 
   /** Batch simulation to a target phase */
   SIM_TO_PHASE:       'SIM_TO_PHASE',      // { targetPhase: 'playoffs'|'offseason'|'preseason' }
+  CANCEL_SIM_TO_PHASE:'CANCEL_SIM_TO_PHASE', // { }
 
   /** Playoffs */
   ADVANCE_PLAYOFFS:   'ADVANCE_PLAYOFFS',  // simulate the next playoff round
@@ -160,6 +161,7 @@ export const toUI = Object.freeze({
 
   /** Batch sim progress (Sim to... operations) */
   SIM_BATCH_PROGRESS: 'SIM_BATCH_PROGRESS',   // { currentWeek, targetPhase, phase }
+  SIM_BATCH_STATUS:   'SIM_BATCH_STATUS',     // { status: 'running'|'cancelled'|'completed', targetPhase, stage }
 
   /** A single game result (live ticker feed) */
   GAME_EVENT:         'GAME_EVENT',           // { gameId, event }

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -2740,57 +2740,95 @@ async function handleSimToPhase({ targetPhase }, id) {
   // Safety: max iterations to prevent infinite loops
   const MAX_ITERATIONS = 200;
   let iterations = 0;
+  batchSimControl = {
+    running: true,
+    cancelRequested: false,
+    targetPhase,
+    stage: meta.phase,
+  };
+  post(toUI.SIM_BATCH_STATUS, { status: 'running', targetPhase, stage: meta.phase });
 
-  while (iterations < MAX_ITERATIONS) {
-    const currentMeta = cache.getMeta();
+  try {
+    while (iterations < MAX_ITERATIONS) {
+      const currentMeta = cache.getMeta();
+      batchSimControl.stage = currentMeta?.phase ?? null;
 
-    // Check if we've reached the target
-    if (isTarget(currentMeta)) break;
-
-    // Send progress to UI
-    post(toUI.SIM_BATCH_PROGRESS, {
-      currentWeek: currentMeta.currentWeek ?? 0,
-      phase: currentMeta.phase,
-      targetPhase,
-    });
-
-    // Advance based on current phase
-    // Pass skipUserGame:true during batch sim to avoid prompting the user
-    if (['regular', 'playoffs', 'preseason'].includes(currentMeta.phase)) {
-      await handleAdvanceWeek({ skipUserGame: true }, null);
-    } else if (['offseason_resign', 'offseason'].includes(currentMeta.phase)) {
-      await handleAdvanceOffseason({}, null);
-    } else if (currentMeta.phase === 'free_agency') {
-      await handleAdvanceFreeAgencyDay({}, null);
-    } else if (currentMeta.phase === 'draft') {
-      // Auto-sim all draft picks. The draft pipeline itself is responsible
-      // for transitioning into the next season (handleSimDraftPick and
-      // handleMakeDraftPick both call handleStartNewSeason once all picks
-      // are made), so we deliberately do NOT call handleAdvanceOffseason here.
-      await handleStartDraft({}, null);
-      let draftDone = false;
-      let draftGuard = 0;
-      while (!draftDone && draftGuard < 500) {
-        const draftMeta = cache.getMeta();
-        const ds = draftMeta.draftState;
-        if (!ds || ds.currentPickIndex >= (ds.picks?.length ?? 0)) {
-          draftDone = true;
-        } else {
-          await handleSimDraftPick({}, null);
-        }
-        draftGuard++;
+      // Check if we've reached the target
+      if (isTarget(currentMeta)) break;
+      if (batchSimControl.cancelRequested) {
+        post(toUI.SIM_BATCH_STATUS, {
+          status: 'cancelled',
+          targetPhase,
+          stage: currentMeta.phase,
+        });
+        post(toUI.FULL_STATE, buildViewState(), id);
+        return;
       }
-    } else {
-      // Unknown phase — break to prevent infinite loop
-      break;
+
+      // Send progress to UI
+      post(toUI.SIM_BATCH_PROGRESS, {
+        currentWeek: currentMeta.currentWeek ?? 0,
+        phase: currentMeta.phase,
+        targetPhase,
+      });
+
+      // Advance based on current phase
+      // Pass skipUserGame:true during batch sim to avoid prompting the user
+      if (['regular', 'playoffs', 'preseason'].includes(currentMeta.phase)) {
+        await handleAdvanceWeek({ skipUserGame: true }, null);
+      } else if (['offseason_resign', 'offseason'].includes(currentMeta.phase)) {
+        await handleAdvanceOffseason({}, null);
+      } else if (currentMeta.phase === 'free_agency') {
+        await handleAdvanceFreeAgencyDay({}, null);
+      } else if (currentMeta.phase === 'draft') {
+        // Auto-sim all draft picks. The draft pipeline itself is responsible
+        // for transitioning into the next season (handleSimDraftPick and
+        // handleMakeDraftPick both call handleStartNewSeason once all picks
+        // are made), so we deliberately do NOT call handleAdvanceOffseason here.
+        await handleStartDraft({}, null);
+        let draftDone = false;
+        let draftGuard = 0;
+        while (!draftDone && draftGuard < 500) {
+          if (batchSimControl.cancelRequested) break;
+          const draftMeta = cache.getMeta();
+          const ds = draftMeta.draftState;
+          if (!ds || ds.currentPickIndex >= (ds.picks?.length ?? 0)) {
+            draftDone = true;
+          } else {
+            await handleSimDraftPick({}, null);
+          }
+          draftGuard++;
+          await yieldFrame();
+        }
+        if (batchSimControl.cancelRequested) {
+          post(toUI.SIM_BATCH_STATUS, {
+            status: 'cancelled',
+            targetPhase,
+            stage: 'draft',
+          });
+          post(toUI.FULL_STATE, buildViewState(), id);
+          return;
+        }
+      } else {
+        // Unknown phase — break to prevent infinite loop
+        break;
+      }
+
+      iterations++;
+      await yieldFrame();
     }
 
-    iterations++;
-    await yieldFrame();
+    // Final state broadcast
+    post(toUI.SIM_BATCH_STATUS, { status: 'completed', targetPhase, stage: cache.getMeta()?.phase ?? null });
+    post(toUI.FULL_STATE, buildViewState(), id);
+  } finally {
+    batchSimControl = {
+      running: false,
+      cancelRequested: false,
+      targetPhase: null,
+      stage: null,
+    };
   }
-
-  // Final state broadcast
-  post(toUI.FULL_STATE, buildViewState(), id);
 }
 
 // ── Handler: GET_SEASON_HISTORY ───────────────────────────────────────────────
@@ -7586,8 +7624,29 @@ async function handleGetAwardRaces(_payload, id) {
  */
 let messageQueue = Promise.resolve();
 let _queueProcessing = false;
+let batchSimControl = {
+  running: false,
+  cancelRequested: false,
+  targetPhase: null,
+  stage: null,
+};
 
 self.onmessage = (event) => {
+  const { type } = event?.data ?? {};
+  // High-priority cancellation path: do not queue behind long-running sim loops.
+  if (type === toWorker.CANCEL_SIM_TO_PHASE) {
+    if (batchSimControl.running) {
+      batchSimControl.cancelRequested = true;
+      post(toUI.SIM_BATCH_STATUS, {
+        status: 'cancelling',
+        targetPhase: batchSimControl.targetPhase,
+        stage: batchSimControl.stage,
+      });
+    } else {
+      post(toUI.SIM_BATCH_STATUS, { status: 'idle', targetPhase: null, stage: null });
+    }
+    return;
+  }
   // v2: Chain with guaranteed recovery — catch inside the .then so the
   // resolved chain is never broken by an unhandled rejection.
   messageQueue = messageQueue.then(async () => {


### PR DESCRIPTION
### Motivation
- The sim-to-season/offseason pipeline could freeze during draft (UI shows “Simulating to preseason…” and the UI reports `Request timed out: GET_DRAFT_STATE`) and leave the overlay stuck with no retry/cancel options. This change directly targets that class of freeze by making batch sims cancellable, observable, and more tolerant of long draft work.
- Make long-running simulation work non-blocking for the UI and avoid request timeouts caused by long-running draft/offseason processing.

### Description
- Added new worker protocol message types `CANCEL_SIM_TO_PHASE` and `SIM_BATCH_STATUS` so the UI can request cancellation and receive lifecycle status updates for batch simulations (running / cancelling / cancelled / completed). (`src/worker/protocol.js`)
- Introduced a cooperative `batchSimControl` object inside the worker and hardened `SIM_TO_PHASE` with: (a) explicit `running`/`cancelRequested` state, (b) status emissions via `SIM_BATCH_STATUS`, and (c) cooperative cancellation checks inside long loops (including the draft auto-pick loop) so cancellation is processed quickly and safely without corrupting save state. (`src/worker/worker.js`)
- Added a high-priority cancel path in `self.onmessage` so cancel messages are handled immediately instead of being queued behind long-running tasks in the worker message queue. (`src/worker/worker.js`)
- Extended the UI-side worker request mechanism to support per-message timeout overrides and increased the timeout for `GET_DRAFT_STATE` to reduce false timeouts during heavy draft/offseason work. (`src/ui/hooks/useWorker.js`)
- Exposed new actions `cancelSimToPhase` and `retrySimToPhase` from `useWorker` and hooked up `SIM_BATCH_STATUS` → `BATCH_SIM_STATUS` so React state tracks batch lifecycle and status. (`src/ui/hooks/useWorker.js`)
- Updated the main app shell to show batch-sim status in the overlay and provide Retry and Cancel controls, and refined action disabling rules so UI controls are blocked only while the batch sim is actively running/cancelling (not after terminal states). (`src/ui/App.jsx`)

### Testing
- Built the production bundle with `npm run build` and the build succeeded (no bundling errors). (result: success)
- Ran the unit/test suite with `npm run test:unit`; the majority of tests passed, but there are existing baseline test failures and Playwright/Vitest collection conflicts present in this repository that are unrelated to these changes (summary from run: ~173 passed, 6 failed across suites; some Playwright E2E suites report collection errors under the Vitest runner). The failures observed do not show regressions tied to the batch-sim cancellation/status logic introduced here. (result: partial — build OK, unit test run produced pre-existing unrelated failures)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc5d7084dc832dbb86cd08e4c69a5d)