### PR TITLE
Fix franchise roster legality, cap enforcement, and contract rendering consistency

### DIFF
--- a/src/core/depthChart.js
+++ b/src/core/depthChart.js
@@ -28,6 +28,20 @@ function rowForPosition(pos, preferredRowKey = null) {
   return DEPTH_CHART_ROWS.find((r) => r.match.includes(pos));
 }
 
+function getPlayerFallbackPositions(player = {}) {
+  if (Array.isArray(player?.secondaryPositions)) return player.secondaryPositions;
+  if (Array.isArray(player?.positions)) return player.positions.slice(1);
+  return [];
+}
+
+function playerMatchTier(player, row) {
+  const primary = String(player?.pos ?? '');
+  if (row.match.includes(primary)) return 0;
+  const secondary = getPlayerFallbackPositions(player).map((p) => String(p));
+  if (secondary.some((pos) => row.match.includes(pos))) return 1;
+  return 2;
+}
+
 function scorePlayerForRow(player, rowKey, scheme = {}) {
   const injuryPenalty = (player?.injuryWeeksRemaining ?? 0) > 0 ? 18 : 0;
   const fatiguePenalty = Math.max(0, Math.min(12, Math.round((player?.fatigue ?? 0) / 9)));
@@ -39,28 +53,30 @@ function scorePlayerForRow(player, rowKey, scheme = {}) {
   if ((rowKey === 'EDGE') && /rush|power/.test(archetype)) archetypeBonus = 5;
   if ((rowKey === 'IDL') && /run|anchor/.test(archetype)) archetypeBonus = 5;
 
-  return (player?.ovr ?? 0) + schemeFitBonus + archetypeBonus - injuryPenalty - fatiguePenalty;
+  const roleFit = Number(player?.roleFit?.[rowKey] ?? player?.roleFitScore ?? 0);
+  const row = DEPTH_CHART_ROWS.find((entry) => entry.key === rowKey);
+  const tier = row ? playerMatchTier(player, row) : 2;
+  const tierPenalty = tier === 0 ? 0 : tier === 1 ? 7 : 24;
+
+  return (player?.ovr ?? 0) + schemeFitBonus + archetypeBonus + Math.round(roleFit / 12) - injuryPenalty - fatiguePenalty - tierPenalty;
 }
 
 export function autoBuildDepthChart(players = [], existingAssignments = {}) {
-  const byRow = {};
-  for (const row of DEPTH_CHART_ROWS) byRow[row.key] = [];
-
-  for (const player of players) {
-    if (!player || player.teamId == null || player.status === 'free_agent') continue;
-    const preferred = player?.depthChart?.rowKey;
-    const row = rowForPosition(player.pos, preferred);
-    if (!row) continue;
-    byRow[row.key].push(player);
-  }
-
   const assignments = {};
+  const availablePlayers = players.filter((player) => player && player.teamId != null && player.status !== 'free_agent');
+  const assignedPlayerIds = new Set();
+
   for (const row of DEPTH_CHART_ROWS) {
     const currentIds = Array.isArray(existingAssignments?.[row.key])
       ? existingAssignments[row.key].map((x) => Number(x)).filter(Number.isFinite)
       : [];
 
-    const pool = byRow[row.key] ?? [];
+    const pool = availablePlayers.filter((player) => {
+      if (assignedPlayerIds.has(Number(player.id))) return false;
+      const tier = playerMatchTier(player, row);
+      return tier <= 1;
+    });
+
     const ranked = [...pool].sort((a, b) => {
       const idxA = currentIds.indexOf(Number(a.id));
       const idxB = currentIds.indexOf(Number(b.id));
@@ -70,7 +86,21 @@ export function autoBuildDepthChart(players = [], existingAssignments = {}) {
       return scorePlayerForRow(b, row.key) - scorePlayerForRow(a, row.key);
     });
 
-    assignments[row.key] = ranked.map((p) => Number(p.id));
+    const chosen = ranked.slice(0, row.slots).map((p) => Number(p.id));
+    assignments[row.key] = chosen;
+    chosen.forEach((id) => assignedPlayerIds.add(id));
+  }
+
+  // Fill any still-empty rows with best available fallback player to keep chart complete.
+  for (const row of DEPTH_CHART_ROWS) {
+    if ((assignments[row.key] ?? []).length > 0) continue;
+    const fallback = availablePlayers
+      .filter((player) => !assignedPlayerIds.has(Number(player.id)))
+      .sort((a, b) => scorePlayerForRow(b, row.key) - scorePlayerForRow(a, row.key))[0];
+    if (fallback) {
+      assignments[row.key] = [Number(fallback.id)];
+      assignedPlayerIds.add(Number(fallback.id));
+    }
   }
 
   return assignments;

--- a/src/core/teamValidation.js
+++ b/src/core/teamValidation.js
@@ -1,0 +1,103 @@
+import { Constants } from './constants.js';
+import { DEPTH_CHART_ROWS } from './depthChart.js';
+
+export function normalizeContract(player = {}) {
+  const contract = player?.contract ?? {};
+  const yearsTotal = Number(contract?.yearsTotal ?? contract?.years ?? player?.yearsTotal ?? player?.years ?? 1) || 1;
+  const baseAnnual = Number(contract?.baseAnnual ?? player?.baseAnnual ?? contract?.salary ?? player?.salary ?? 0) || 0;
+  const signingBonus = Number(contract?.signingBonus ?? player?.signingBonus ?? 0) || 0;
+  const guaranteedPct = Number(contract?.guaranteedPct ?? player?.guaranteedPct ?? 0) || 0;
+  return {
+    yearsTotal: Math.max(1, yearsTotal),
+    baseAnnual: Math.max(0, baseAnnual),
+    signingBonus: Math.max(0, signingBonus),
+    guaranteedPct: Math.max(0, guaranteedPct),
+  };
+}
+
+export function getPlayerCapHit(player = {}) {
+  const c = normalizeContract(player);
+  return c.baseAnnual + (c.signingBonus / c.yearsTotal);
+}
+
+export function getRosterLimitForPhase(phase) {
+  return ['offseason_resign', 'free_agency', 'draft', 'offseason', 'preseason'].includes(phase)
+    ? Constants.ROSTER_LIMITS.OFFSEASON
+    : Constants.ROSTER_LIMITS.REGULAR_SEASON;
+}
+
+function buildTeamPlayerMap(players = []) {
+  const byTeam = new Map();
+  for (const player of players) {
+    if (player?.teamId == null || player?.status === 'free_agent') continue;
+    const teamId = Number(player.teamId);
+    if (!Number.isFinite(teamId)) continue;
+    if (!byTeam.has(teamId)) byTeam.set(teamId, []);
+    byTeam.get(teamId).push(player);
+  }
+  return byTeam;
+}
+
+export function validateLeagueTeamLegality({ teams = [], players = [], phase = 'regular', hardCap = Constants.SALARY_CAP.HARD_CAP } = {}) {
+  const byTeam = buildTeamPlayerMap(players);
+  const rosterLimit = getRosterLimitForPhase(phase);
+  const issues = [];
+
+  for (const team of teams) {
+    const teamId = Number(team?.id);
+    const roster = byTeam.get(teamId) ?? [];
+    const rosterIds = roster.map((p) => Number(p?.id)).filter(Number.isFinite);
+    const uniqueIds = new Set(rosterIds);
+
+    if (roster.length > rosterLimit) {
+      issues.push({ severity: 'error', teamId, code: 'roster_limit', message: `${team?.abbr ?? team?.name ?? `Team ${teamId}`} has ${roster.length}/${rosterLimit} players. Cut roster before continuing.` });
+    }
+
+    const projectedCap = roster.reduce((sum, p) => sum + getPlayerCapHit(p), 0) + Number(team?.deadCap ?? 0);
+    if (projectedCap > Number(hardCap)) {
+      issues.push({ severity: 'error', teamId, code: 'cap_limit', message: `${team?.abbr ?? team?.name ?? `Team ${teamId}`} is over cap (${projectedCap.toFixed(1)}M / ${Number(hardCap).toFixed(1)}M).` });
+    }
+
+    if (uniqueIds.size !== rosterIds.length) {
+      issues.push({ severity: 'error', teamId, code: 'duplicate_player_refs', message: `${team?.abbr ?? team?.name ?? `Team ${teamId}`} has duplicate player references.` });
+    }
+
+    for (const player of roster) {
+      const hasContract = !!player?.contract || Number.isFinite(Number(player?.baseAnnual));
+      if (!hasContract) {
+        issues.push({ severity: 'error', teamId, code: 'missing_contract', message: `${team?.abbr ?? team?.name ?? `Team ${teamId}`} has active player ${player?.name ?? player?.id} without a contract.` });
+        break;
+      }
+    }
+
+    const depthByRow = new Map();
+    for (const p of roster) {
+      const rowKey = p?.depthChart?.rowKey;
+      if (!rowKey) continue;
+      if (!depthByRow.has(rowKey)) depthByRow.set(rowKey, []);
+      depthByRow.get(rowKey).push(p);
+    }
+
+    for (const p of roster) {
+      const rowKey = p?.depthChart?.rowKey;
+      if (!rowKey) continue;
+      const row = DEPTH_CHART_ROWS.find((r) => r.key === rowKey);
+      if (!row) {
+        issues.push({ severity: 'warn', teamId, code: 'invalid_depth_row', message: `${team?.abbr ?? team?.name ?? `Team ${teamId}`} has unknown depth row ${rowKey}.` });
+      }
+    }
+
+    for (const row of DEPTH_CHART_ROWS) {
+      const assigned = depthByRow.get(row.key) ?? [];
+      const eligible = roster.filter((p) => row.match.includes(p?.pos));
+      if (assigned.length > 0 && assigned.some((p) => Number(p?.teamId) !== teamId)) {
+        issues.push({ severity: 'error', teamId, code: 'depth_non_roster', message: `${team?.abbr ?? team?.name ?? `Team ${teamId}`} depth chart references non-roster players.` });
+      }
+      if (eligible.length > 0 && assigned.length === 0) {
+        issues.push({ severity: 'warn', teamId, code: 'invalid_starter_counts', message: `${team?.abbr ?? team?.name ?? `Team ${teamId}`} has no ${row.label} assignments.` });
+      }
+    }
+  }
+
+  return { issues, rosterLimit };
+}

--- a/src/ui/components/DragAndDropDepthChart.jsx
+++ b/src/ui/components/DragAndDropDepthChart.jsx
@@ -11,6 +11,7 @@
  */
 
 import React, { useState, useCallback, useMemo, useRef } from "react";
+import { derivePlayerContractFinancials, formatContractMoney } from "../utils/contractFormatting.js";
 
 // Position groups definition
 const POSITION_GROUPS = [
@@ -70,6 +71,7 @@ function PlayerRow({
   const inj = player.injury || (player.injuredWeeks > 0 ? {} : null);
   const pc = posColor(player.pos);
   const oc = ovrColor(player.ovr ?? 70);
+  const contract = derivePlayerContractFinancials(player);
 
   return (
     <div
@@ -170,9 +172,9 @@ function PlayerRow({
       )}
 
       {/* Salary */}
-      {player.contract?.salary != null && (
+      {contract.annualSalary != null && (
         <span style={{ fontSize: "0.65rem", color: "var(--text-subtle)", flexShrink: 0 }}>
-          ${(player.contract.salary / 1e6).toFixed(1)}M
+          {formatContractMoney(contract.annualSalary)}
         </span>
       )}
     </div>

--- a/src/ui/components/PlayerCardGrid.jsx
+++ b/src/ui/components/PlayerCardGrid.jsx
@@ -14,6 +14,7 @@
  */
 
 import React, { useState, useMemo } from "react";
+import { derivePlayerContractFinancials, formatContractMoney } from "../utils/contractFormatting.js";
 
 // ── Colour maps ────────────────────────────────────────────────────────────────
 
@@ -140,19 +141,16 @@ function RosterCard({ player, onSelect }) {
   const ovr       = player.ovr ?? player.displayOvr ?? 50;
   const { color: ovrColor, bg: ovrBg, glow: ovrGlow } = ovrStyle(ovr);
 
-  const salary    = player.baseAnnual ?? player.contract?.baseAnnual ?? player.contract?.salary ?? 0;
-  const years     = player.years ?? player.contract?.years ?? 0;
+  const contractFinancials = derivePlayerContractFinancials(player);
+  const salary = contractFinancials.annualSalary ?? 0;
+  const years     = player.years ?? player.contract?.years ?? contractFinancials.yearsTotal ?? 0;
   const isInjured = (player.injuryWeeksRemaining ?? 0) > 0 || !!player.injury;
   const isExpiring = years <= 1 && years > 0;
   const isElitePot = (player.potential ?? 0) >= 88 && (player.potential ?? 0) > ovr + 5;
 
   const attrs = getCardKeyAttrs(pos);
 
-  const salaryStr = salary >= 1
-    ? `$${salary.toFixed(1)}M`
-    : salary > 0
-      ? `$${Math.round(salary * 1000)}K`
-      : "—";
+  const salaryStr = salary > 0 ? formatContractMoney(salary) : "—";
 
   return (
     <div
@@ -281,8 +279,8 @@ export default function PlayerCardGrid({ roster = [], onPlayerSelect }) {
           vb = b.ovr ?? b.displayOvr ?? 0;
           break;
         case "salary":
-          va = a.baseAnnual ?? a.contract?.baseAnnual ?? a.contract?.salary ?? 0;
-          vb = b.baseAnnual ?? b.contract?.baseAnnual ?? b.contract?.salary ?? 0;
+          va = derivePlayerContractFinancials(a).annualSalary ?? 0;
+          vb = derivePlayerContractFinancials(b).annualSalary ?? 0;
           break;
         case "age":
           va = a.age ?? 0;

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -11,6 +11,7 @@ import { getTeamIdentity } from "../../data/team-utils.js";
 import { Button } from "@/components/ui/button";
 import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from "@/components/ui/table";
 import { formatMoneyM, safeRound, toFiniteNumber } from "../utils/numberFormatting.js";
+import { derivePlayerContractFinancials } from "../utils/contractFormatting.js";
 import { buildTeamIntelligence, classifyNeedFitForProspect, describeProspectProfile, describeRookieOnboarding } from "../utils/teamIntelligence.js";
 import { buildTeamChemistrySummary, describePlayerMoraleContext } from "../utils/teamChemistry.js";
 import { normalizeManagement, TRADE_STATUS_LABELS, TRADE_STATUS_TOOLTIPS, TRADE_STATUSES, CONTRACT_PLAN_FLAGS, CONTRACT_PLAN_LABELS, toggleContractPlan } from "../utils/playerManagement.js";
@@ -249,7 +250,7 @@ function getSeasonProductionSummary(player) {
 function getPlayerSummaryChips(player, ringCount, nonRing) {
   const chips = [];
   const contractYears = toFiniteNumber(player?.contract?.years, null);
-  const contractAnnual = toFiniteNumber(player?.contract?.baseAnnual, null);
+  const contractAnnual = derivePlayerContractFinancials(player).annualSalary;
   if (contractYears != null || contractAnnual != null) {
     chips.push({
       label: "Contract",

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -47,6 +47,7 @@ import {
 import { buildDirectionGuidance, buildTeamIntelligence } from "../utils/teamIntelligence.js";
 import { normalizeManagement, TRADE_STATUSES, TRADE_STATUS_LABELS, CONTRACT_PLAN_LABELS, toggleContractPlan } from "../utils/playerManagement.js";
 import { deriveTeamCapSnapshot, formatMoneyM, toFiniteNumber } from "../utils/numberFormatting.js";
+import { derivePlayerContractFinancials } from "../utils/contractFormatting.js";
 import { describePlayerMoraleContext } from "../utils/teamChemistry.js";
 import { getDepthRows, autoBuildDepthChart, depthWarnings } from "../../core/depthChart.js";
 import AdvancedPlayerSearch from "./AdvancedPlayerSearch.jsx";
@@ -233,8 +234,8 @@ function sortPlayers(players, sortKey, sortDir) {
         vb = b.age ?? 0;
         break;
       case "salary":
-        va = a.contract?.baseAnnual ?? 0;
-        vb = b.contract?.baseAnnual ?? 0;
+        va = derivePlayerContractFinancials(a).annualSalary ?? 0;
+        vb = derivePlayerContractFinancials(b).annualSalary ?? 0;
         break;
       case "fit":
         va = a.schemeFit ?? 50;
@@ -982,7 +983,7 @@ function RosterTable({
                         fontVariantNumeric: "tabular-nums",
                       }}
                     >
-                      {fmtSalary(player.contract?.baseAnnual)}
+                      {fmtSalary(derivePlayerContractFinancials(player).annualSalary)}
                     </TableCell>
                     {/* Years */}
                     <TableCell
@@ -1638,8 +1639,7 @@ function PlayerCard({ player, onSelect, showDecisionContext = false, decisionCon
     ovr >= 70 ? "#0A84FF" :
     ovr >= 60 ? "#FF9F0A" : "#FF453A";
 
-  const salary =
-    player.contract?.baseAnnual ?? player.baseAnnual ?? 0;
+  const salary = derivePlayerContractFinancials(player).annualSalary ?? 0;
   const yearsLeft =
     player.contract?.yearsLeft ??
     player.contract?.yearsRemaining ??

--- a/src/ui/components/RosterHub.jsx
+++ b/src/ui/components/RosterHub.jsx
@@ -16,6 +16,7 @@ import PlayerCardGrid from "./PlayerCardGrid.jsx";
 import DragAndDropDepthChart from "./DragAndDropDepthChart.jsx";
 import { ScreenHeader, SectionCard, EmptyState, StickySubnav } from "./ScreenSystem.jsx";
 import { applyRangeFilter, inTier, cycleSort } from "../utils/managementList.js";
+import { derivePlayerContractFinancials, formatContractMoney } from "../utils/contractFormatting.js";
 
 // ── Position color map (matches stadium-theme.css pos-badge classes) ──
 const POS_COLORS = {
@@ -116,7 +117,7 @@ function PlayerRow({ player, isUser, onSelect, schemeName }) {
   const devBadge = getDevTraitBadge(player.devTrait);
   const pos = player.pos || player.position;
   const posColor = POS_COLORS[pos] || "#9ca3af";
-  const salary = player.baseAnnual || player.contract?.baseAnnual || 0;
+  const salary = derivePlayerContractFinancials(player).annualSalary ?? 0;
   const yearsLeft = player.years ?? player.contract?.years ?? 0;
   const isInjured = (player.injuryWeeksRemaining || 0) > 0;
   const isExpiring = yearsLeft <= 1;
@@ -215,7 +216,7 @@ function PlayerRow({ player, isUser, onSelect, schemeName }) {
           color: salary > 15 ? "var(--warning)" : "var(--text)",
           fontVariantNumeric: "tabular-nums",
         }}>
-          ${salary.toFixed(1)}M
+          {formatContractMoney(salary)}
         </div>
         <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
           {yearsLeft}yr
@@ -320,8 +321,8 @@ export default function RosterHub({ league, actions, onPlayerSelect, teamId }) {
           vb = b.age || 0;
           break;
         case "salary":
-          va = a.baseAnnual || a.contract?.baseAnnual || 0;
-          vb = b.baseAnnual || b.contract?.baseAnnual || 0;
+          va = derivePlayerContractFinancials(a).annualSalary ?? 0;
+          vb = derivePlayerContractFinancials(b).annualSalary ?? 0;
           break;
         case "name":
           va = (a.name || "").toLowerCase();
@@ -349,7 +350,7 @@ export default function RosterHub({ league, actions, onPlayerSelect, teamId }) {
   // Roster summary stats
   const rosterSize = roster.length;
   const avgOvr = rosterSize > 0 ? Math.round(roster.reduce((s, p) => s + (p.ovr || 0), 0) / rosterSize) : 0;
-  const totalSalary = roster.reduce((s, p) => s + (p.baseAnnual || p.contract?.baseAnnual || 0), 0);
+  const totalSalary = roster.reduce((s, p) => s + (derivePlayerContractFinancials(p).annualSalary ?? 0), 0);
   const injuredCount = roster.filter(p => (p.injuryWeeksRemaining || 0) > 0).length;
   const schemeName = team?.strategies?.offScheme || team?.strategies?.offPlanId || "";
   const avgFit = rosterSize > 0
@@ -526,7 +527,7 @@ export default function RosterHub({ league, actions, onPlayerSelect, teamId }) {
               <tbody>
                 {filtered.map((player) => {
                   const fit = computeSchemeFit(player, schemeName);
-                  const salary = player.baseAnnual || player.contract?.baseAnnual || 0;
+                  const salary = derivePlayerContractFinancials(player).annualSalary ?? 0;
                   const yearsLeft = player.years ?? player.contract?.years ?? 0;
                   const injuryWeeks = player.injuryWeeksRemaining || 0;
                   return (
@@ -538,9 +539,9 @@ export default function RosterHub({ league, actions, onPlayerSelect, teamId }) {
                       <td>{player.potential || "—"}</td>
                       <td>{Math.round(player.morale ?? 70)}</td>
                       <td>{injuryWeeks > 0 ? `${injuryWeeks}w` : "—"}</td>
-                      <td>${salary.toFixed(1)}M</td>
+                      <td>{formatContractMoney(salary)}</td>
                       <td>{yearsLeft}</td>
-                      <td>${salary.toFixed(1)}M</td>
+                      <td>{formatContractMoney(salary)}</td>
                       <td style={{ color: schemeFitColor(fit) }}>{fit ?? "—"}</td>
                       <td>{yearsLeft <= 1 ? "EXP " : ""}{injuryWeeks > 0 ? "INJ" : ""}</td>
                       <td><button className="btn" onClick={() => onPlayerSelect?.(player.id)}>View</button></td>

--- a/src/ui/utils/contractFormatting.js
+++ b/src/ui/utils/contractFormatting.js
@@ -1,0 +1,30 @@
+import { formatMoneyM, toFiniteNumber } from './numberFormatting.js';
+
+function normalizeSalaryUnit(value) {
+  const raw = toFiniteNumber(value, null);
+  if (raw == null) return null;
+  if (Math.abs(raw) >= 1000) return raw / 1e6;
+  return raw;
+}
+
+export function derivePlayerContractFinancials(player = {}) {
+  const contract = player?.contract ?? {};
+  const yearsTotal = Math.max(1, toFiniteNumber(contract?.yearsTotal ?? contract?.years ?? player?.yearsTotal ?? player?.years, 1));
+  const annualSalary = normalizeSalaryUnit(contract?.baseAnnual ?? player?.baseAnnual ?? contract?.salary ?? player?.salary);
+  const signingBonus = Math.max(0, normalizeSalaryUnit(contract?.signingBonus ?? player?.signingBonus) ?? 0);
+  const guaranteedPct = Math.max(0, toFiniteNumber(contract?.guaranteedPct ?? player?.guaranteedPct, 0));
+  const capHit = annualSalary != null ? annualSalary + (signingBonus / yearsTotal) : null;
+  const guaranteedMoney = annualSalary != null ? (annualSalary * yearsTotal + signingBonus) * guaranteedPct : null;
+  return {
+    yearsTotal,
+    annualSalary,
+    signingBonus,
+    capHit,
+    guaranteedMoney,
+    deadMoney: null,
+  };
+}
+
+export function formatContractMoney(value, fallback = '—') {
+  return formatMoneyM(value, fallback);
+}

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -101,6 +101,7 @@ import { ensureLeagueMemoryMeta, buildSeasonArchiveSummary, updateFranchiseHisto
 import { ensureDynastyMeta, generateOwnerGoals, applyGameFanApproval, updateGoalsForWin } from '../core/dynasty-story.js';
 import { isValidSaveId, sanitizeSaveList } from './saveIntegrity.js';
 import { autoBuildDepthChart, applyDepthChartToPlayers } from '../core/depthChart.js';
+import { getPlayerCapHit, getRosterLimitForPhase, validateLeagueTeamLegality } from '../core/teamValidation.js';
 import { DEFAULT_LEAGUE_SETTINGS, normalizeLeagueSettings, getRuleEditType } from '../core/leagueSettings.js';
 import { migrateSaveMetaToCurrent, CURRENT_SAVE_SCHEMA_VERSION } from '../state/saveSchema.js';
 import { getTradeWindowSnapshot, isTradeWindowOpen } from '../core/tradeWindow.js';
@@ -1274,6 +1275,7 @@ async function handleLoadSave({ leagueId }, id) {
         const normalizedStaff = ensureTeamStaff(team, { year: Number(meta?.year ?? 2025) });
         cache.updateTeam(team.id, { staff: normalizedStaff, ...deriveTeamUnitRatings(team.id) });
       }
+      runLegalityValidation({ stage: 'load-save', notify: true });
 
       // Migration/defaulting for league customization + commissioner metadata.
       const normalizedEconomy = normalizeLeagueEconomy(meta?.economy ?? {}, { year: meta?.year });
@@ -1820,6 +1822,11 @@ async function handleAdvanceWeek(payload, id) {
   if (!['regular', 'playoffs', 'preseason'].includes(meta.phase)) {
       post(toUI.ERROR, { message: `Cannot advance week in phase "${meta.phase}". Use the correct action.` }, id);
       return;
+  }
+  const legality = runLegalityValidation({ stage: 'pre-advance' }).issues.filter((issue) => issue.severity === 'error');
+  if (legality.length > 0) {
+    post(toUI.ERROR, { message: legality[0].message }, id);
+    return;
   }
 
   // Ensure depth chart integrity before every simulation step.
@@ -3677,9 +3684,7 @@ async function handleSignPlayer({ playerId, teamId, contract }, id) {
   if (!teamCtx.ok) { post(toUI.ERROR, { message: teamCtx.message }, id); return; }
   const { meta, teamId: resolvedTeamId, team } = teamCtx;
 
-  const limit = (['offseason_resign', 'free_agency', 'draft', 'offseason', 'preseason'].includes(meta.phase))
-      ? Constants.ROSTER_LIMITS.OFFSEASON
-      : Constants.ROSTER_LIMITS.REGULAR_SEASON;
+  const limit = getRosterLimitForPhase(meta.phase);
 
   const roster = cache.getPlayersByTeam(resolvedTeamId);
   if (roster.length >= limit) {
@@ -3690,6 +3695,12 @@ async function handleSignPlayer({ playerId, teamId, contract }, id) {
   // Normalize the incoming playerId.
   let player = cache.getPlayer(playerId);
   if (!player) { post(toUI.ERROR, { message: 'Player not found' }, id); return; }
+
+  const preIssues = runLegalityValidation({ stage: 'pre-sign', teamIds: [resolvedTeamId] }).issues.filter((issue) => issue.severity === 'error');
+  if (preIssues.length > 0) {
+    post(toUI.ERROR, { message: preIssues[0].message }, id);
+    return;
+  }
 
   // ── Hard Cap Check ($301.2M) ────────────────────────────────────────────────
   if (team && contract) {
@@ -3730,6 +3741,11 @@ async function handleSignPlayer({ playerId, teamId, contract }, id) {
   // Update cap
   recalculateTeamCap(resolvedTeamId);
   if (oldTeamId != null && oldTeamId !== resolvedTeamId) recalculateTeamCap(oldTeamId);
+  const postIssues = runLegalityValidation({ stage: 'post-sign', teamIds: [resolvedTeamId, oldTeamId].filter((x) => x != null) }).issues.filter((issue) => issue.severity === 'error');
+  if (postIssues.length > 0) {
+    post(toUI.ERROR, { message: postIssues[0].message }, id);
+    return;
+  }
 
   const txDetails = { playerId, contract };
   await Transactions.add({
@@ -3826,6 +3842,11 @@ async function finalizeFreeAgencySigning(player, offer, liveMeta) {
   if (!signingTeam) return null;
 
   const capHit = (offer?.contract?.baseAnnual ?? 0) + ((offer?.contract?.signingBonus ?? 0) / (offer?.contract?.yearsTotal || 1));
+  const rosterLimit = getRosterLimitForPhase(liveMeta?.phase);
+  const rosterCount = cache.getPlayersByTeam(signingTeamId).length;
+  if (rosterCount >= rosterLimit) {
+    return null;
+  }
   if ((signingTeam.capRoom ?? 0) < capHit) {
     const nextOffers = (player.offers ?? []).filter((o) => Number(o?.teamId) !== signingTeamId);
     cache.updatePlayer(player.id, { offers: nextOffers });
@@ -4953,6 +4974,31 @@ function tradePackagePositions(playerIds = []) {
   return [...positions];
 }
 
+function evaluateTradeLegality({ fromTeamId, toTeamId, offering = {}, receiving = {}, phase }) {
+  const hardCap = Number(getLeagueSetting('salaryCap', Constants.SALARY_CAP.HARD_CAP));
+  const rosterLimit = getRosterLimitForPhase(phase);
+  const fromTeam = cache.getTeam(Number(fromTeamId));
+  const toTeam = cache.getTeam(Number(toTeamId));
+  if (!fromTeam || !toTeam) return { ok: false, reason: 'Trade blocked: invalid team context.' };
+
+  const capHitOf = (pids = []) => pids.reduce((sum, pid) => {
+    const p = cache.getPlayer(Number(pid));
+    return sum + (p ? getPlayerCapHit(p) : 0);
+  }, 0);
+
+  const fromProjectedCap = (fromTeam?.capUsed ?? 0) - capHitOf(offering.playerIds) + capHitOf(receiving.playerIds);
+  const toProjectedCap = (toTeam?.capUsed ?? 0) - capHitOf(receiving.playerIds) + capHitOf(offering.playerIds);
+  if (fromProjectedCap > hardCap) return { ok: false, reason: `Trade blocked: ${fromTeam.name} would exceed the $${hardCap}M hard cap.` };
+  if (toProjectedCap > hardCap) return { ok: false, reason: `Trade blocked: ${toTeam.name} would exceed the $${hardCap}M hard cap.` };
+
+  const fromCount = cache.getPlayersByTeam(Number(fromTeamId)).length - (offering?.playerIds?.length ?? 0) + (receiving?.playerIds?.length ?? 0);
+  const toCount = cache.getPlayersByTeam(Number(toTeamId)).length - (receiving?.playerIds?.length ?? 0) + (offering?.playerIds?.length ?? 0);
+  if (fromCount > rosterLimit) return { ok: false, reason: `Trade blocked: ${fromTeam.name} would exceed roster limit (${fromCount}/${rosterLimit}).` };
+  if (toCount > rosterLimit) return { ok: false, reason: `Trade blocked: ${toTeam.name} would exceed roster limit (${toCount}/${rosterLimit}).` };
+
+  return { ok: true };
+}
+
 async function handleTradeOffer({ fromTeamId, toTeamId, offering, receiving }, id) {
   // offering  = { playerIds: [], pickIds: [] }  (what fromTeam gives)
   // receiving = { playerIds: [], pickIds: [] }  (what fromTeam gets back)
@@ -5067,59 +5113,27 @@ async function handleTradeOffer({ fromTeamId, toTeamId, offering, receiving }, i
   }
   const accepted = offerVal >= threshold;
 
-  // ── Hard Cap Trade Validation ────────────────────────────────────────────────
-  // Before executing an accepted trade, verify neither team would breach the
-  // $301.2M hard cap after swapping players.
   if (accepted) {
-    const hardCap = Number(getLeagueSetting('salaryCap', Constants.SALARY_CAP.HARD_CAP));
-
-    // Helper: sum cap hit for a list of player IDs
-    const capHitOf = (pids = []) => pids.reduce((sum, pid) => {
-      const p = cache.getPlayer(Number(pid));
-      if (!p) return sum;
-      const base  = p.contract?.baseAnnual  ?? p.baseAnnual  ?? 0;
-      const bonus = p.contract?.signingBonus ?? p.signingBonus ?? 0;
-      const yrs   = p.contract?.yearsTotal   ?? p.yearsTotal  ?? 1;
-      return sum + base + bonus / (yrs || 1);
-    }, 0);
-
-    const fromTeamObj = cache.getTeam(Number(fromTeamId));
-    const toTeamObj   = cache.getTeam(Number(toTeamId));
-
-    // fromTeam loses offering players, gains receiving players
-    const fromProjected = (fromTeamObj?.capUsed ?? 0)
-      - capHitOf(offering.playerIds)
-      + capHitOf(receiving.playerIds);
-
-    // toTeam loses receiving players, gains offering players
-    const toProjected = (toTeamObj?.capUsed ?? 0)
-      - capHitOf(receiving.playerIds)
-      + capHitOf(offering.playerIds);
-
-    if (fromProjected > hardCap) {
+    const tradeLegality = evaluateTradeLegality({ fromTeamId, toTeamId, offering, receiving, phase: meta?.phase });
+    if (!tradeLegality.ok) {
       post(toUI.TRADE_RESPONSE, {
         accepted: false,
         offerValue: Math.round(offerVal),
         receiveValue: Math.round(receiveVal),
         rejectionType: 'cap',
-        reason: `Trade blocked: ${from.name} would exceed the $${hardCap}M hard cap ($${fromProjected.toFixed(1)}M projected).`,
-      }, id);
-      return;
-    }
-    if (toProjected > hardCap) {
-      post(toUI.TRADE_RESPONSE, {
-        accepted: false,
-        offerValue: Math.round(offerVal),
-        receiveValue: Math.round(receiveVal),
-        rejectionType: 'cap',
-        reason: `Trade blocked: ${to.name} would exceed the $${hardCap}M hard cap ($${toProjected.toFixed(1)}M projected).`,
+        reason: tradeLegality.reason,
       }, id);
       return;
     }
   }
 
   if (accepted) {
-    await executeAcceptedTrade({ fromTeamId, toTeamId, offering, receiving });
+    try {
+      await executeAcceptedTrade({ fromTeamId, toTeamId, offering, receiving });
+    } catch (tradeErr) {
+      post(toUI.TRADE_RESPONSE, { accepted: false, rejectionType: 'validation', reason: tradeErr?.message ?? 'Trade blocked by validation.' }, id);
+      return;
+    }
   }
 
   const rejectionType = accepted ? null : (
@@ -5188,6 +5202,10 @@ async function executeAcceptedTrade({ fromTeamId, toTeamId, offering, receiving 
 
   recalculateTeamCap(Number(fromTeamId));
   recalculateTeamCap(Number(toTeamId));
+  const tradeIssues = runLegalityValidation({ stage: 'post-trade', teamIds: [Number(fromTeamId), Number(toTeamId)] }).issues.filter((issue) => issue.severity === 'error');
+  if (tradeIssues.length > 0) {
+    throw new Error(tradeIssues[0].message);
+  }
 
   const latestMeta = ensureDynastyMeta(cache.getMeta());
   const tradeRecord = {
@@ -5216,12 +5234,29 @@ async function handleAcceptIncomingTrade({ offerId }, id) {
     return;
   }
 
-  await executeAcceptedTrade({
+  const legality = evaluateTradeLegality({
     fromTeamId: Number(latestMeta?.userTeamId),
     toTeamId: Number(offer.offeringTeamId),
     offering: offer.receiving ?? { playerIds: [offer.receivingPlayerId], pickIds: [] },
     receiving: offer.offering ?? { playerIds: [offer.offeringPlayerId], pickIds: [] },
+    phase: latestMeta?.phase,
   });
+  if (!legality.ok) {
+    post(toUI.TRADE_RESPONSE, { accepted: false, rejectionType: 'cap', reason: legality.reason }, id);
+    return;
+  }
+
+  try {
+    await executeAcceptedTrade({
+      fromTeamId: Number(latestMeta?.userTeamId),
+      toTeamId: Number(offer.offeringTeamId),
+      offering: offer.receiving ?? { playerIds: [offer.receivingPlayerId], pickIds: [] },
+      receiving: offer.offering ?? { playerIds: [offer.offeringPlayerId], pickIds: [] },
+    });
+  } catch (tradeErr) {
+    post(toUI.TRADE_RESPONSE, { accepted: false, rejectionType: 'validation', reason: tradeErr?.message ?? 'Trade blocked by validation.' }, id);
+    return;
+  }
 
   const remaining = offers.filter((o) => o?.id !== offerId);
   cache.setMeta({ incomingTradeOffers: remaining, lastTradeActivityWeek: Number(latestMeta?.currentWeek ?? 1) });
@@ -5571,6 +5606,25 @@ function recalculateTeamCap(teamId) {
 // Alias for backward compatibility if needed, but we should replace calls.
 const _updateTeamCap = recalculateTeamCap;
 
+function runLegalityValidation({ stage = 'action', teamIds = null, notify = false } = {}) {
+  const meta = ensureDynastyMeta(cache.getMeta());
+  const allTeams = cache.getAllTeams();
+  const scopedTeams = Array.isArray(teamIds) && teamIds.length > 0
+    ? allTeams.filter((team) => teamIds.includes(Number(team?.id)))
+    : allTeams;
+  const result = validateLeagueTeamLegality({
+    teams: scopedTeams,
+    players: cache.getAllPlayers(),
+    phase: meta?.phase,
+    hardCap: Number(getLeagueSetting('salaryCap', Constants.SALARY_CAP.HARD_CAP)),
+  });
+  if (notify && result.issues.length > 0) {
+    const first = result.issues[0];
+    post(toUI.NOTIFICATION, { level: first?.severity === 'error' ? 'warn' : 'info', message: `[${stage}] ${first?.message}` });
+  }
+  return result;
+}
+
 // ── Handler: RESTRUCTURE_CONTRACT ────────────────────────────────────────────
 //
 // Converts a portion of a player's base salary into a prorated signing bonus,
@@ -5779,6 +5833,8 @@ function _executeDraftPick(pickIndex, playerId, teamId) {
   // Normalize the ID.
   let player = cache.getPlayer(playerId);
   if (!player) return;
+  const rosterLimit = getRosterLimitForPhase(meta?.phase);
+  if (cache.getPlayersByTeam(teamId).length >= rosterLimit) return;
 
   const pk = draftState.picks[pickIndex];
   pk.playerId   = playerId;
@@ -6094,6 +6150,7 @@ async function handleMakeDraftPick({ playerId }, id) {
     postPickMeta.draftState &&
     postPickMeta.draftState.currentPickIndex >= postPickMeta.draftState.picks.length
   ) {
+    runLegalityValidation({ stage: 'post-draft', notify: true });
     return await handleStartNewSeason({}, id);
   }
 
@@ -6168,6 +6225,7 @@ async function handleSimDraftPick(payload, id) {
     postSimMeta.draftState &&
     postSimMeta.draftState.currentPickIndex >= postSimMeta.draftState.picks.length
   ) {
+    runLegalityValidation({ stage: 'post-draft', notify: true });
     return await handleStartNewSeason({}, id);
   }
 


### PR DESCRIPTION
### Motivation
- Fix inconsistent salary/contract rendering and unit mismatches that caused `$0.0M` in cards/depth/table views. 
- Prevent silent illegal team states after signings, trades, and draft picks by centralizing roster/cap/contract validation. 
- Make depth-chart auto-sort deterministic and avoid off-position starters when suitable players exist. 

### Description
- Introduced a centralized team legality validator in `src/core/teamValidation.js` that normalizes contracts and reports actionable issues (roster limit, cap projection, duplicate refs, missing contracts, depth-chart problems). 
- Added shared contract normalization/formatting helpers in `src/ui/utils/contractFormatting.js` and replaced duplicated UI formatting with `derivePlayerContractFinancials` / `formatContractMoney` across roster, card, depth-chart, profile, and hub components so all views agree on annual salary/cap hit units. 
- Hardened worker flows (`src/worker/worker.js`) to call the validator at key lifecycle points: after save load, pre-advance-week, pre/post sign, during FA offer finalization, preflight and acceptance paths for trades (including incoming-trade accept), and post-draft; blocked or surfaced clear messages when actions would produce illegal states. 
- Improved depth-chart auto-sort in `src/core/depthChart.js` to use primary/secondary position tiers, role-fit, scheme/OVR scoring, deterministic slot assignment, and a controlled fallback fill strategy to avoid absurd placements. 
- Small UI touches only where required: salary text now uses the shared formatting helper and table/card rows were updated to preserve existing layout while fixing unit mismatches. 

### Testing
- Ran unit tests: `npm run test:unit -- src/core/__tests__/depth-chart.test.js src/worker/__tests__/saveIntegrity.test.js` — all tests passed locally (5 tests total). 
- Performed production build: `npm run build` — build completed successfully. 
- Added defensive runtime checks (idempotent, non-destructive) so existing saves are audited at load and only produce notifications/errors when real issues are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc60b2acec832dbce499ab9232c4f7)