### PR TITLE
Polish HQ, News and League surfaces; compact schedule row readability

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -35,6 +35,12 @@ function getNextGame(league) {
   return null;
 }
 
+function toneAccent(tone) {
+  if (tone === "danger") return "var(--danger)";
+  if (tone === "warning") return "var(--warning)";
+  return "var(--accent)";
+}
+
 export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeamSelect, onAdvanceWeek, busy, simulating }) {
   const vm = useMemo(() => getHQViewModel(league), [league]);
   const weekly = useMemo(() => evaluateWeeklyContext(vm.league), [vm.league]);
@@ -48,11 +54,40 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
   const team = vm.userTeam;
   const cap = deriveTeamCapSnapshot(team, { fallbackCapTotal: 255 });
   const record = formatRecord(team);
-  const urgentItems = (weekly?.urgentItems ?? []).slice(0, 5);
+  const urgentItems = (weekly?.urgentItems ?? []).slice(0, 6);
   const pressureSummary = `Owner ${weekly?.pressure?.owner?.state ?? "Stable"} · Fans ${weekly?.pressure?.fans?.state ?? "Steady"} · Media ${weekly?.pressure?.media?.state ?? "Steady"}`;
   const teamDevelopments = (vm.league?.newsItems ?? [])
     .filter((item) => item?.teamId == null || Number(item?.teamId) === Number(vm.league?.userTeamId))
-    .slice(0, 3);
+    .slice(0, 2);
+  const scheduleWeeks = vm.league?.schedule?.weeks ?? [];
+  const remainingRegularSeasonGames = scheduleWeeks
+    .flatMap((w) => w?.games ?? [])
+    .filter((game) => {
+      const homeId = Number(game?.home?.id ?? game?.home);
+      const awayId = Number(game?.away?.id ?? game?.away);
+      const involvesUser = homeId === Number(vm.league?.userTeamId) || awayId === Number(vm.league?.userTeamId);
+      return involvesUser && !game?.played;
+    }).length;
+  const phasePriorityQueue = useMemo(() => {
+    const queue = [...urgentItems];
+    if (vm.league?.phase === "preseason" && (team?.roster?.length ?? 0) > 53) {
+      queue.unshift({
+        label: "Roster cutdown required",
+        detail: `${team.roster.length} players on roster — trim to regular-season limits.`,
+        tab: "Roster",
+        tone: "danger",
+      });
+    }
+    if (vm.league?.phase === "regular" && remainingRegularSeasonGames <= 3) {
+      queue.unshift({
+        label: "Trade window is closing",
+        detail: `${remainingRegularSeasonGames} regular-season game${remainingRegularSeasonGames === 1 ? "" : "s"} left. Resolve pending market moves now.`,
+        tab: "Transactions",
+        tone: "warning",
+      });
+    }
+    return queue.slice(0, 5);
+  }, [urgentItems, vm.league?.phase, team?.roster?.length, remainingRegularSeasonGames]);
   const latestGamePresentation = latestArchived
     ? buildCompletedGamePresentation({
       ...latestArchived,
@@ -70,6 +105,24 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
           <div style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)" }}>{pressureSummary}</div>
           <Button size="sm" onClick={onAdvanceWeek} disabled={busy || simulating}>Advance Week</Button>
         </div>
+      </SectionCard>
+
+      <SectionCard title="Priority Queue" actions={<Button size="sm" variant="outline" onClick={() => onNavigate?.("Team")}>Team</Button>}>
+        {phasePriorityQueue.length === 0 ? <div style={{ color: "var(--text-muted)" }}>No immediate blockers.</div> : (
+          <div style={{ display: "grid", gap: 8 }}>
+            {phasePriorityQueue.map((item) => (
+              <button
+                key={`${item.label}-${item.tab}`}
+                className="btn"
+                style={{ textAlign: "left", borderLeft: `3px solid ${toneAccent(item.tone)}` }}
+                onClick={() => onNavigate?.(item?.tab ?? "Team")}
+              >
+                <div style={{ fontWeight: 700 }}>{item.label}</div>
+                <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>{item.detail}</div>
+              </button>
+            ))}
+          </div>
+        )}
       </SectionCard>
 
       <SectionCard title="Next Game">
@@ -104,19 +157,6 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
         )}
       </SectionCard>
 
-      <SectionCard title="Urgent Actions" actions={<Button size="sm" variant="outline" onClick={() => onNavigate?.("Team")}>Team Hub</Button>}>
-        {urgentItems.length === 0 ? <div style={{ color: "var(--text-muted)" }}>No immediate blockers.</div> : (
-          <div style={{ display: "grid", gap: 8 }}>
-            {urgentItems.map((item) => (
-              <button key={`${item.label}-${item.tab}`} className="btn" style={{ textAlign: "left" }} onClick={() => onNavigate?.(item?.tab ?? "Team")}>
-                <div style={{ fontWeight: 700 }}>{item.label}</div>
-                <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>{item.detail}</div>
-              </button>
-            ))}
-          </div>
-        )}
-      </SectionCard>
-
       <SectionCard title="Team Snapshot">
         <div style={{ display: "grid", gridTemplateColumns: "repeat(2, minmax(0, 1fr))", gap: 8 }}>
           <StatCard label="OVR / OFF / DEF" value={`${safeNum(team?.ovr, 0)} / ${safeNum(team?.offenseRating, team?.offRating)} / ${safeNum(team?.defenseRating, team?.defRating)}`} />
@@ -126,7 +166,7 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
         </div>
       </SectionCard>
 
-      <SectionCard title="Team Developments" actions={<Button size="sm" variant="outline" onClick={() => onNavigate?.("News")}>Open News</Button>}>
+      <SectionCard title="News Desk Preview" actions={<Button size="sm" variant="outline" onClick={() => onNavigate?.("News")}>Open News</Button>}>
         <div style={{ display: "grid", gap: 8 }}>
           {teamDevelopments.map((item, idx) => (
             <button
@@ -139,6 +179,7 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
               }}
             >
               <div style={{ fontWeight: 700 }}>{item?.headline ?? "League update"}</div>
+              <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>Read full context in News</div>
             </button>
           ))}
           {teamDevelopments.length === 0 ? <div style={{ color: "var(--text-muted)" }}>No major updates this week.</div> : null}

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -1042,12 +1042,17 @@ function ScheduleTab({
                 padding: "10px 12px",
                 border: "1px solid var(--hairline)",
                 borderColor: isUserGame ? "var(--accent)" : "var(--hairline)",
+                borderLeft: `3px solid ${game.played ? "color-mix(in oklab, var(--text-muted) 70%, transparent)" : "color-mix(in oklab, var(--accent) 65%, transparent)"}`,
+                background: "color-mix(in oklab, var(--surface) 90%, black 10%)",
                 ...(isClickable ? { cursor: "pointer" } : {}),
               }}
             >
               <div style={{ display: "flex", justifyContent: "space-between", gap: 10, alignItems: "center", marginBottom: 6 }}>
-                <div style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)" }}>
-                  Week {selectedWeek} · {away.abbr} @ {home.abbr}
+                <div style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)", display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                  <span style={{ fontWeight: 700, color: "var(--text-subtle)" }}>W{selectedWeek}</span>
+                  <span style={{ border: "1px solid var(--hairline)", borderRadius: 999, padding: "1px 7px", fontSize: "var(--text-xs)" }}>AWAY {away.abbr}</span>
+                  <span style={{ color: "var(--text-subtle)", fontSize: "var(--text-xs)" }}>@</span>
+                  <span style={{ border: "1px solid var(--hairline)", borderRadius: 999, padding: "1px 7px", fontSize: "var(--text-xs)" }}>HOME {home.abbr}</span>
                 </div>
                 <span className="badge">{game.played ? "Final" : "Upcoming"}</span>
               </div>
@@ -1128,7 +1133,7 @@ function ScheduleTab({
               )}
               {!game.played && (
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
-                  <div style={{ fontWeight: 700 }}>{away.abbr} at {home.abbr}</div>
+                  <div style={{ fontWeight: 700 }}>{away.abbr} @ {home.abbr}</div>
                   <Button size="sm" variant="outline" onClick={() => canOpenGameDetail && onGameSelect?.(upcomingGameId)} disabled={!canOpenGameDetail}>
                     {canOpenGameDetail ? "Game Details" : "Scheduled"}
                   </Button>
@@ -1153,8 +1158,8 @@ function ScheduleTab({
                 </div>
               )}
               <div style={{ display: "flex", gap: 8, marginTop: 6 }}>
-                <button className="btn btn-sm" onClick={(e) => { e.stopPropagation(); onTeamRoster?.(away.id); }}>{away.abbr}</button>
-                <button className="btn btn-sm" onClick={(e) => { e.stopPropagation(); onTeamRoster?.(home.id); }}>{home.abbr}</button>
+                <button className="btn btn-sm" onClick={(e) => { e.stopPropagation(); onTeamRoster?.(away.id); }}>Away roster</button>
+                <button className="btn btn-sm" onClick={(e) => { e.stopPropagation(); onTeamRoster?.(home.id); }}>Home roster</button>
                 {showStakes ? <span className="badge">{nextGameStakes > 80 ? "Rivalry" : "Stakes"}</span> : null}
                 {isTopWeekTeam ? <span className="badge">Team of Week</span> : null}
               </div>

--- a/src/ui/components/LeagueHub.jsx
+++ b/src/ui/components/LeagueHub.jsx
@@ -2,9 +2,9 @@ import React, { useMemo, useState } from 'react';
 import RecordBook from './RecordBook.jsx';
 import PostseasonHub from './PostseasonHub.jsx';
 import PlayerStats from './PlayerStats.jsx';
-import NewsFeed from './NewsFeed.jsx';
 import SectionHeader from './SectionHeader.jsx';
 import SectionSubnav from './SectionSubnav.jsx';
+import { buildNewsDeskModel } from '../utils/newsDesk.js';
 
 const LEAGUE_SUBNAV = ['Schedule', 'Standings', 'Stats', 'Transactions', 'History'];
 
@@ -44,16 +44,28 @@ export default function LeagueHub({ league, actions, onOpenGameDetail, onPlayerS
     ];
   }, [teams]);
 
-  const featuredGames = useMemo(() => {
-    const weeks = Array.isArray(league?.schedule?.weeks) ? league.schedule.weeks : [];
-    const allGames = weeks.flatMap((weekRow) => (
-      (weekRow?.games ?? []).map((g) => ({ ...g, week: Number(weekRow?.week ?? g?.week ?? 0) }))
-    ));
-    return allGames
-      .filter((g) => g?.played || (Number(g.homeScore ?? -1) >= 0 && Number(g.awayScore ?? -1) >= 0))
-      .sort((a, b) => Number(b.week ?? 0) - Number(a.week ?? 0))
-      .slice(0, 3);
-  }, [league?.schedule?.weeks]);
+  const newsDesk = useMemo(() => buildNewsDeskModel(league, { segment: 'all', limit: 120 }), [league]);
+  const transactionRows = useMemo(() => {
+    return (newsDesk.transactions ?? []).slice(0, 14).map((item) => {
+      const raw = `${item?.headline ?? ''} ${item?.body ?? ''}`.toLowerCase();
+      const type = raw.includes('trade')
+        ? 'Trade'
+        : raw.includes('release') || raw.includes('waive')
+          ? 'Release'
+          : raw.includes('draft')
+            ? 'Draft'
+            : 'Signing';
+      return { ...item, _txType: type };
+    });
+  }, [newsDesk.transactions]);
+  const transactionTotals = useMemo(() => (
+    transactionRows.reduce((acc, row) => {
+      acc[row._txType] = (acc[row._txType] ?? 0) + 1;
+      return acc;
+    }, {})
+  ), [transactionRows]);
+  const champions = Array.isArray(league?.history?.champions) ? league.history.champions : [];
+  const recentWinners = champions.slice(-3).reverse();
 
   return (
     <div>
@@ -75,27 +87,57 @@ export default function LeagueHub({ league, actions, onOpenGameDetail, onPlayerS
       {subtab === 'Transactions' && (
         <div style={{ display: 'grid', gap: 'var(--space-3)' }}>
           <div className="card" style={{ padding: 'var(--space-3)' }}>
-            <div style={{ fontWeight: 700, marginBottom: 8 }}>Latest featured games</div>
-            <div style={{ display: 'grid', gap: 6 }}>
-              {featuredGames.map((game, idx) => (
-                <button key={`${game.week}-${idx}`} className="btn" onClick={() => onOpenGameDetail?.(game.id ?? game.gameId, 'League')}>
-                  W{game.week ?? '—'} · {game.awayAbbr ?? game.away} {game.awayScore} - {game.homeScore} {game.homeAbbr ?? game.home}
-                </button>
+            <div style={{ fontWeight: 700, marginBottom: 8 }}>League activity center</div>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(110px, 1fr))', gap: 8 }}>
+              {['Trade', 'Signing', 'Release', 'Draft'].map((label) => (
+                <div key={label} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: '8px 10px', background: 'var(--surface-2)' }}>
+                  <div style={{ fontSize: 11, color: 'var(--text-subtle)', textTransform: 'uppercase' }}>{label}</div>
+                  <div style={{ fontWeight: 800, fontSize: 18 }}>{transactionTotals[label] ?? 0}</div>
+                </div>
               ))}
-              {featuredGames.length === 0 ? <div style={{ color: 'var(--text-muted)' }}>No recent results yet.</div> : null}
             </div>
           </div>
-          <NewsFeed
-            league={league}
-            mode="full"
-            segment="transactions"
-            onPlayerSelect={onPlayerSelect}
-            onOpenBoxScore={(gameId) => onOpenGameDetail?.(gameId, 'League')}
-          />
+
+          <div className="card" style={{ padding: 'var(--space-3)' }}>
+            <div style={{ fontWeight: 700, marginBottom: 8 }}>Recent transactions</div>
+            <div style={{ display: 'grid', gap: 7 }}>
+              {transactionRows.map((item, idx) => (
+                <div key={item?.id ?? `tx-${idx}`} style={{ border: '1px solid var(--hairline)', borderRadius: 9, padding: '8px 10px', display: 'grid', gap: 4 }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'center' }}>
+                    <strong style={{ fontSize: 13 }}>{item?.headline ?? 'League transaction'}</strong>
+                    <span className="badge">{item?._txType}</span>
+                  </div>
+                  <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{item?.body ?? 'No detail available.'}</div>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                    <span style={{ fontSize: 11, color: 'var(--text-subtle)' }}>W{item?.week ?? '-'} · {item?.phase ?? 'season'}</span>
+                    <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                      {item?.playerId != null ? <button className="btn btn-sm" onClick={() => onPlayerSelect?.(item.playerId)}>Player</button> : null}
+                      {item?.gameId ? <button className="btn btn-sm" onClick={() => onOpenGameDetail?.(item.gameId, 'League')}>Box</button> : null}
+                    </div>
+                  </div>
+                </div>
+              ))}
+              {transactionRows.length === 0 ? <div style={{ color: 'var(--text-muted)' }}>No transaction activity yet.</div> : null}
+            </div>
+          </div>
         </div>
       )}
       {subtab === 'History' && (
         <div style={{ display: 'grid', gap: 'var(--space-3)' }}>
+          <div className="card" style={{ padding: 'var(--space-3)' }}>
+            <div style={{ fontWeight: 700 }}>History spotlight</div>
+            <div style={{ marginTop: 6, fontSize: 13, color: 'var(--text-muted)' }}>
+              Defending champion: <strong style={{ color: 'var(--text)' }}>{league?.championAbbr ?? recentWinners?.[0]?.champion ?? 'TBD'}</strong>
+            </div>
+            <div style={{ display: 'grid', gap: 4, marginTop: 8 }}>
+              {recentWinners.map((entry, idx) => (
+                <div key={`winner-${idx}`} style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+                  {entry?.year ?? '—'}: <strong style={{ color: 'var(--text)' }}>{entry?.champion ?? 'Champion TBD'}</strong>
+                </div>
+              ))}
+              {recentWinners.length === 0 ? <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>Play more seasons to unlock dynasty arcs.</div> : null}
+            </div>
+          </div>
           <PostseasonHub league={league} onOpenBoxScore={(gameId) => onOpenGameDetail?.(gameId, 'League')} />
           <RecordBook league={league} />
         </div>

--- a/src/ui/components/NewsFeed.jsx
+++ b/src/ui/components/NewsFeed.jsx
@@ -36,12 +36,50 @@ function StoryCard({ item, onTeamSelect, onOpenBoxScore, onPlayerSelect }) {
   );
 }
 
-function SectionBlock({ title, stories, ...handlers }) {
+function CompactStoryRow({ item, onTeamSelect, onOpenBoxScore, onPlayerSelect }) {
+  if (!item) return null;
+  return (
+    <div
+      style={{
+        border: '1px solid var(--hairline)',
+        borderRadius: 10,
+        padding: '10px 12px',
+        background: 'color-mix(in oklab, var(--surface) 88%, black 12%)',
+        display: 'grid',
+        gap: 6,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+        <div style={{ fontWeight: 700, fontSize: 13 }}>{item?.headline}</div>
+        <span style={{ fontSize: 10, color: 'var(--text-subtle)', border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 6px' }}>
+          {item?._categoryLabel}
+        </span>
+      </div>
+      {item?.body ? <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{item.body}</div> : null}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>
+        <div style={{ fontSize: 11, color: 'var(--text-subtle)' }}>
+          W{item?.week ?? '-'} · {item?.phase ?? 'season'}{item?._teamRelevant ? ' · Team' : ''}
+        </div>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          {item?.gameId ? <button className="btn btn-sm" onClick={() => onOpenBoxScore?.(item.gameId)}>Box</button> : null}
+          {item?.teamId != null ? <button className="btn btn-sm" onClick={() => onTeamSelect?.(item.teamId)}>Team</button> : null}
+          {item?.playerId != null ? <button className="btn btn-sm" onClick={() => onPlayerSelect?.(item.playerId)}>Player</button> : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SectionBlock({ title, stories, compact = false, ...handlers }) {
   if (!stories?.length) return null;
   return (
     <section style={{ display: 'grid', gap: 8 }}>
       <h3 style={{ margin: 0, fontSize: 'var(--text-sm)', textTransform: 'uppercase', letterSpacing: '.04em', color: 'var(--text-subtle)' }}>{title}</h3>
-      {stories.map((item, idx) => <StoryCard key={item?.id ?? `${title}-${idx}`} item={item} {...handlers} />)}
+      {stories.map((item, idx) => (
+        compact
+          ? <CompactStoryRow key={item?.id ?? `${title}-${idx}`} item={item} {...handlers} />
+          : <StoryCard key={item?.id ?? `${title}-${idx}`} item={item} {...handlers} />
+      ))}
     </section>
   );
 }
@@ -94,7 +132,16 @@ export default function NewsFeed({ league, mode = 'full', segment = 'all', onTea
           ['league', 'LEAGUE'],
           ['transactions', 'TRANSACTIONS'],
         ].map(([value, label]) => (
-          <button key={value} className="btn" onClick={() => setFilter(value)} style={{ opacity: filter === value ? 1 : 0.7 }}>
+          <button
+            key={value}
+            className="btn"
+            onClick={() => setFilter(value)}
+            style={{
+              opacity: filter === value ? 1 : 0.72,
+              fontWeight: filter === value ? 700 : 500,
+              borderColor: filter === value ? 'var(--accent)' : undefined,
+            }}
+          >
             {label}
           </button>
         ))}
@@ -107,18 +154,28 @@ export default function NewsFeed({ league, mode = 'full', segment = 'all', onTea
         </section>
       ) : <div style={{ color: 'var(--text-subtle)' }}>No news yet.</div>}
 
-      <SectionBlock title="Top Stories" stories={desk.topStories} onTeamSelect={onTeamSelect} onOpenBoxScore={onOpenBoxScore} onPlayerSelect={onPlayerSelect} />
-      <SectionBlock title="Your Team Desk" stories={desk.teamStories} onTeamSelect={onTeamSelect} onOpenBoxScore={onOpenBoxScore} onPlayerSelect={onPlayerSelect} />
-      <SectionBlock title="League Wide" stories={desk.leagueStories} onTeamSelect={onTeamSelect} onOpenBoxScore={onOpenBoxScore} onPlayerSelect={onPlayerSelect} />
-      <SectionBlock title="Transactions Wire" stories={desk.transactions} onTeamSelect={onTeamSelect} onOpenBoxScore={onOpenBoxScore} onPlayerSelect={onPlayerSelect} />
-      <SectionBlock title="This Week in the League" stories={desk.recap} onTeamSelect={onTeamSelect} onOpenBoxScore={onOpenBoxScore} onPlayerSelect={onPlayerSelect} />
+      <SectionBlock
+        title={`News Feed (${desk.filtered.length})`}
+        stories={desk.filtered.slice(1, 13)}
+        compact
+        onTeamSelect={onTeamSelect}
+        onOpenBoxScore={onOpenBoxScore}
+        onPlayerSelect={onPlayerSelect}
+      />
+      {filter === 'all' ? (
+        <>
+          <SectionBlock title="Team Desk" stories={desk.teamStories.slice(0, 2)} compact onTeamSelect={onTeamSelect} onOpenBoxScore={onOpenBoxScore} onPlayerSelect={onPlayerSelect} />
+          <SectionBlock title="League Pulse" stories={desk.recap.slice(0, 2)} compact onTeamSelect={onTeamSelect} onOpenBoxScore={onOpenBoxScore} onPlayerSelect={onPlayerSelect} />
+        </>
+      ) : null}
 
-      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-        <button className="btn" onClick={() => onNavigate?.('Team')}>Team</button>
-        <button className="btn" onClick={() => onNavigate?.('League')}>League</button>
-        <button className="btn" onClick={() => onNavigate?.('Schedule')}>Schedule</button>
-        <button className="btn" onClick={() => onNavigate?.('Contract Center')}>Contracts</button>
-        <button className="btn" onClick={() => onNavigate?.('💰 Cap')}>Cap</button>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+        <div style={{ fontSize: 12, color: 'var(--text-subtle)' }}>Use filters to keep this desk focused by context.</div>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          <button className="btn btn-sm" onClick={() => onNavigate?.('Team')}>Team</button>
+          <button className="btn btn-sm" onClick={() => onNavigate?.('League')}>League</button>
+          <button className="btn btn-sm" onClick={() => onNavigate?.('Schedule')}>Schedule</button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Strengthen the newly merged HQ / Team / League / News shell so News feels like a first-class destination, HQ is an actionable weekly agenda, League does exploration not narrative dumping, and the schedule remains compact but clearer. 
- Reduce content duplication across HQ/News/League and increase mobile scanability without adding visual bloat or backend changes.

### Description
- News: rewrote the News feed body to emphasize a single featured lead then compact, mobile-friendly story rows with preserved deep links (box score, team, player) and stronger active filter styling (All / Team / League / Transactions). (src/ui/components/NewsFeed.jsx)
- HQ: added a ranked, phase-aware "Priority Queue" with severity accents and direct navigation targets (Roster, Transactions, Injuries, etc.), trimmed the HQ team-news preview into a short "News Desk Preview" that points users into News for full context, and surfaced a few phase prompts (roster cutdown, closing trade window). (src/ui/components/FranchiseHQ.jsx)
- League: tightened the League hub so Transactions is a focused activity center with type summaries and compact transaction rows, and History begins with a lightweight spotlight (defending champion + recent winners) before deeper archive screens. This reduces narrative overlap with News. (src/ui/components/LeagueHub.jsx)
- Schedule rows: improved compact schedule row readability by adding subtle left accents, clearer AWAY/HOME identity chips, intentional roster-link labels, preserving tappable final scores and existing box-score handlers while keeping density. (src/ui/components/LeagueDashboard.jsx)
- Files changed: src/ui/components/NewsFeed.jsx, src/ui/components/FranchiseHQ.jsx, src/ui/components/LeagueHub.jsx, src/ui/components/LeagueDashboard.jsx.
- Follow-ups suggested: add a reusable `ActivityRow`/`FeedRow` component to unify compact rows across News and Transactions, add phase-aware empty states for Transactions/History, and a small visual spacing/token pass to reduce same-box syndrome.

### Testing
- Unit tests: `vitest run src/ui/utils/newsDesk.test.js src/ui/utils/weeklyContext.test.js src/ui/components/WeeklyHub.test.jsx` — all tests passed (3 files, 5 tests passed).
- Production build: `npm run build` completed successfully (build produced bundles; noted chunk-size warnings from Vite but no failures).
- No backend or new dependencies were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd8db4eff0832d920e1de4ed5ff988)