### PR TITLE
Trade Center: Finder market signals, targets browser, and clearer proposal UX

### DIFF
--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -1337,6 +1337,7 @@ export default function LeagueDashboard({
   const [selectedTeamId, setSelectedTeamId] = useState(null);
   const [comparePlayerId, setComparePlayerId] = useState(null);
   const [tradeInitialView, setTradeInitialView] = useState("Finder");
+  const [tradeSeedPartnerId, setTradeSeedPartnerId] = useState(null);
   const [rosterInitialState, setRosterInitialState] = useState({ view: "table", filter: "ALL" });
   const [rosterInitialView, setRosterInitialView] = useState("table");
   const [statsInitialFamily, setStatsInitialFamily] = useState("passing");
@@ -1662,6 +1663,11 @@ export default function LeagueDashboard({
               actions={actions}
               onPlayerSelect={setSelectedPlayerId}
               onTeamSelect={setSelectedTeamId}
+              onNavigateTrade={(teamId = null) => {
+                setTradeInitialView("Finder");
+                setTradeSeedPartnerId(teamId != null ? Number(teamId) : null);
+                setActiveTab("Transactions");
+              }}
               onOpenGameDetail={openGameDetail}
               renderSchedule={(sourceTab = "League") => (
                 <ScheduleTab
@@ -1864,9 +1870,15 @@ export default function LeagueDashboard({
             />
           </TabErrorBoundary>
         )}
-                {(activeTab === "Transactions" || activeTab === "Trades") && (
+        {(activeTab === "Transactions" || activeTab === "Trades") && (
           <TabErrorBoundary label="Transactions">
-            <TradeWorkspace league={league} actions={actions} onPlayerSelect={setSelectedPlayerId} initialView={tradeInitialView} />
+            <TradeWorkspace
+              league={league}
+              actions={actions}
+              onPlayerSelect={setSelectedPlayerId}
+              initialView={tradeInitialView}
+              initialPartnerTeamId={tradeSeedPartnerId}
+            />
           </TabErrorBoundary>
         )}
                 {isInitialized && activeTab === "📰 News" && (

--- a/src/ui/components/LeagueHub.jsx
+++ b/src/ui/components/LeagueHub.jsx
@@ -31,7 +31,7 @@ function TeamComparison({ teams = [] }) {
   );
 }
 
-export default function LeagueHub({ league, actions, onOpenGameDetail, onPlayerSelect, renderStandings, renderSchedule }) {
+export default function LeagueHub({ league, actions, onOpenGameDetail, onPlayerSelect, onNavigateTrade, renderStandings, renderSchedule }) {
   const [subtab, setSubtab] = useState('Schedule');
   const teams = Array.isArray(league?.teams) ? league.teams : [];
 
@@ -112,6 +112,7 @@ export default function LeagueHub({ league, actions, onOpenGameDetail, onPlayerS
                     <span style={{ fontSize: 11, color: 'var(--text-subtle)' }}>W{item?.week ?? '-'} · {item?.phase ?? 'season'}</span>
                     <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
                       {item?.playerId != null ? <button className="btn btn-sm" onClick={() => onPlayerSelect?.(item.playerId)}>Player</button> : null}
+                      {item?._txType === 'Trade' ? <button className="btn btn-sm" onClick={() => onNavigateTrade?.(item?.teamId ?? null)}>Scout Market</button> : null}
                       {item?.gameId ? <button className="btn btn-sm" onClick={() => onOpenGameDetail?.(item.gameId, 'League')}>Box</button> : null}
                     </div>
                   </div>

--- a/src/ui/components/TradeCenter.jsx
+++ b/src/ui/components/TradeCenter.jsx
@@ -164,7 +164,15 @@ function PickSelector({ side, picks, onChange, availablePicks = [] }) {
 function TradeResult({ result, onDismiss }) {
   if (!result) return null;
   const valueDiff = (result.receiveValue ?? 0) - (result.offerValue ?? 0);
-  const reasonType = result?.rejectionType ?? (String(result?.reason ?? "").toLowerCase().includes("cap") ? "cap" : "value");
+  const reasonText = String(result?.reason ?? "").toLowerCase();
+  const reasonType = result?.rejectionType
+    ?? (reasonText.includes("cap")
+      ? "cap"
+      : reasonText.includes("need") || reasonText.includes("position")
+        ? "fit"
+        : reasonText.includes("timeline") || reasonText.includes("rebuild") || reasonText.includes("contend")
+          ? "direction"
+          : "value");
   const askHint = result?.askHint;
   const reasonDetail = result?.reasonDetail ?? null;
   const counterHint = !result.accepted
@@ -245,6 +253,34 @@ function TradeBlockSummary({ myRosterMap, theirRosterMap, offering, receiving, m
             {theirPicks.map(pk => <span key={pk.id} style={{ padding: "2px 8px", borderRadius: "var(--radius-pill)", background: "var(--accent)11", color: "var(--accent)" }}>{pickLabel(pk)}</span>)}
           </div>
         </div>
+      </div>
+    </div>
+  );
+}
+
+function TradeSubmissionSummary({
+  liveMyTeam,
+  liveTheirTeam,
+  outgoingCount,
+  incomingCount,
+  myPicksCount,
+  theirPicksCount,
+  myCapAfter,
+  theirCapAfter,
+  tradeImpact,
+}) {
+  return (
+    <div className="card" style={{ padding: "var(--space-3)", display: "grid", gap: 6 }}>
+      <div style={{ fontSize: "11px", textTransform: "uppercase", letterSpacing: ".08em", color: "var(--text-subtle)", fontWeight: 700 }}>Trade Summary Before Submit</div>
+      <div style={{ fontSize: "var(--text-xs)" }}>
+        <strong>{liveMyTeam?.abbr ?? "You"} send:</strong> {outgoingCount} player(s), {myPicksCount} pick(s) ·
+        <strong> receive:</strong> {incomingCount} player(s), {theirPicksCount} pick(s)
+      </div>
+      <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
+        Cap after trade: {liveMyTeam?.abbr ?? "You"} ${myCapAfter.toFixed(1)}M · {liveTheirTeam?.abbr ?? "Them"} ${theirCapAfter.toFixed(1)}M
+      </div>
+      <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
+        Roster/fit: {tradeImpact.needHits.length ? `addresses ${tradeImpact.needHits.join(", ")}` : "no top-need hit yet"} · {tradeImpact.timeline}
       </div>
     </div>
   );
@@ -385,6 +421,8 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
   };
 
   const hasSelection = offering.size > 0 || receiving.size > 0 || myPicks.length > 0 || theirPicks.length > 0;
+  const outgoingCount = offering.size;
+  const incomingCount = receiving.size;
   const tradeDeadline = getTradeWindowSnapshot({
     week: league?.week,
     phase: league?.phase,
@@ -397,6 +435,16 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
     settings: league?.settings,
     commissionerMode: league?.commissionerMode,
   });
+  const lockReason = getTradeLockReason({ tradeLocked, tradeDeadline, phase: league?.phase });
+  const tradeBlockers = useMemo(() => {
+    const blockers = [];
+    if (targetId == null) blockers.push("Choose a trade partner.");
+    if (!hasSelection) blockers.push("Add at least one asset on either side.");
+    if (tradeLocked) blockers.push(lockReason || "Trading is locked for this phase.");
+    if (myCapAfter < 0) blockers.push("Your team would be over the cap after this package.");
+    if (theirCapAfter < 0) blockers.push("Their team would be over the cap after this package.");
+    return blockers;
+  }, [targetId, hasSelection, tradeLocked, lockReason, myCapAfter, theirCapAfter]);
 
 
   useEffect(() => {
@@ -417,8 +465,6 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
       setMyPicks(initialTradeContext.outgoingPickIds.map((id) => myAvailablePicks.find((pk) => String(pk.id) === String(id)) ?? { id }));
     }
   }, [initialTradeContext, myAvailablePicks]);
-
-  const lockReason = getTradeLockReason({ tradeLocked, tradeDeadline, phase: league?.phase });
 
   useEffect(() => {
     onTradeContextChange?.({
@@ -633,6 +679,14 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
 
       {/* Trade result (original) */}
       {tradeResult && <TradeResult result={tradeResult} onDismiss={() => setTradeResult(null)} />}
+      {tradeBlockers.length > 0 && (
+        <div className="card" style={{ padding: "var(--space-3)", borderColor: "rgba(255,159,10,.45)", background: "rgba(255,159,10,.08)", display: "grid", gap: 4 }}>
+          <strong style={{ fontSize: "var(--text-xs)" }}>Before you submit</strong>
+          <ul style={{ margin: 0, paddingLeft: 16, fontSize: "var(--text-xs)", color: "var(--text-muted)", display: "grid", gap: 3 }}>
+            {tradeBlockers.slice(0, 4).map((reason) => <li key={reason}>{reason}</li>)}
+          </ul>
+        </div>
+      )}
 
       {targetId == null ? (
         <EmptyState title="Select a trade partner" body="Choose another team to load available assets and package controls." />
@@ -655,6 +709,19 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
                 <div>{tradeImpact.timeline}</div>
               </div>
             </div>
+          )}
+          {hasSelection && (
+            <TradeSubmissionSummary
+              liveMyTeam={liveMyTeam}
+              liveTheirTeam={liveTheirTeam}
+              outgoingCount={outgoingCount}
+              incomingCount={incomingCount}
+              myPicksCount={myPicks.length}
+              theirPicksCount={theirPicks.length}
+              myCapAfter={myCapAfter}
+              theirCapAfter={theirCapAfter}
+              tradeImpact={tradeImpact}
+            />
           )}
 
           {/* Drag-and-drop panels */}

--- a/src/ui/components/TradeFinder.jsx
+++ b/src/ui/components/TradeFinder.jsx
@@ -32,6 +32,15 @@ function PlayerAssetRow({ p, selected, onToggle }) {
   );
 }
 
+function classifyContractType(player) {
+  const years = Number(player?.contract?.yearsRemaining ?? player?.contract?.years ?? 0);
+  const annual = Number(player?.contract?.baseAnnual ?? 0);
+  if (years <= 1) return 'expiring';
+  if (annual >= 16) return 'premium';
+  if (annual <= 4) return 'cheap';
+  return 'mid';
+}
+
 export default function TradeFinder({ league, actions, onPlayerSelect, onOpenTradeCenter, workspace, onWorkspaceChange }) {
   const teams = league?.teams ?? [];
   const userTeam = teams.find((t) => Number(t.id) === Number(league?.userTeamId));
@@ -43,6 +52,12 @@ export default function TradeFinder({ league, actions, onPlayerSelect, onOpenTra
   const [incomingPlayers, setIncomingPlayers] = useState(workspace?.incomingPlayerIds ?? []);
   const [helperReason, setHelperReason] = useState(workspace?.helperReason ?? '');
   const [helperContext, setHelperContext] = useState(workspace?.helperContext ?? null);
+  const [targetPosFilter, setTargetPosFilter] = useState('ALL');
+  const [targetTeamFilter, setTargetTeamFilter] = useState('ALL');
+  const [targetContractFilter, setTargetContractFilter] = useState('ALL');
+  const [targetAvailabilityFilter, setTargetAvailabilityFilter] = useState('ALL');
+  const [targetAgeMin, setTargetAgeMin] = useState(21);
+  const [targetAgeMax, setTargetAgeMax] = useState(35);
 
   useEffect(() => {
     if (workspace?.partnerTeamId !== undefined && Number(workspace?.partnerTeamId) !== Number(selectedPartnerId)) {
@@ -100,6 +115,64 @@ export default function TradeFinder({ league, actions, onPlayerSelect, onOpenTra
 
   const outgoingValue = selectedOutgoingPlayers.reduce((sum, p) => sum + playerAssetValue(p, { direction: 'balanced' }), 0)
     + selectedOutgoingPicks.reduce((sum, p) => sum + pickAssetValue(p, { week, direction: 'balanced' }), 0);
+  const marketSignals = useMemo(() => {
+    const needs = {};
+    const buyers = [];
+    const sellers = [];
+    for (const team of teamsWithIntel) {
+      const intel = team?.teamIntel ?? {};
+      const topNeed = intel?.needsNow?.[0]?.pos;
+      if (topNeed) needs[topNeed] = (needs[topNeed] ?? 0) + 1;
+      if (intel?.direction === 'contender' && Number(team?.capRoom ?? 0) >= 6) buyers.push(team);
+      if (intel?.direction === 'rebuilding' || Number(team?.capRoom ?? 0) < 0) sellers.push(team);
+    }
+    const hotNeeds = Object.entries(needs).sort((a, b) => b[1] - a[1]).slice(0, 6);
+    return { hotNeeds, buyers: buyers.slice(0, 8), sellers: sellers.slice(0, 8) };
+  }, [teamsWithIntel]);
+
+  const tradeTargets = useMemo(() => {
+    const rows = [];
+    for (const team of teamsWithIntel) {
+      if (Number(team.id) === Number(league?.userTeamId)) continue;
+      const intel = team?.teamIntel ?? {};
+      const needText = (intel?.needsNow ?? []).slice(0, 2).map((n) => n.pos).join(', ') || 'No urgent needs';
+      for (const player of (team?.roster ?? [])) {
+        const management = normalizeManagement(player);
+        const availability = management.tradeStatus === 'actively_shopping'
+          ? 'block'
+          : management.tradeStatus === 'available'
+            ? 'available'
+            : (management.contractPlan ?? []).includes('trade_candidate')
+              ? 'expendable'
+              : 'normal';
+        rows.push({
+          id: `${team.id}-${player.id}`,
+          teamId: team.id,
+          teamAbbr: team.abbr,
+          teamName: team.name,
+          name: player.name,
+          pos: player.pos,
+          age: player.age ?? 0,
+          ovr: player.ovr ?? 0,
+          pot: player.potential ?? player.ovr ?? 0,
+          annual: Number(player?.contract?.baseAnnual ?? 0),
+          years: Number(player?.contract?.yearsRemaining ?? player?.contract?.years ?? 0),
+          contractType: classifyContractType(player),
+          availability,
+          fitHint: `${intel.direction ?? 'balanced'} · Need: ${needText}`,
+          playerId: player.id,
+        });
+      }
+    }
+    return rows.sort((a, b) => (b.ovr - a.ovr) || (a.age - b.age));
+  }, [teamsWithIntel, league?.userTeamId]);
+
+  const filteredTargets = useMemo(() => tradeTargets
+    .filter((row) => targetPosFilter === 'ALL' ? true : row.pos === targetPosFilter)
+    .filter((row) => targetTeamFilter === 'ALL' ? true : String(row.teamId) === targetTeamFilter)
+    .filter((row) => targetContractFilter === 'ALL' ? true : row.contractType === targetContractFilter)
+    .filter((row) => targetAvailabilityFilter === 'ALL' ? true : row.availability === targetAvailabilityFilter)
+    .filter((row) => row.age >= targetAgeMin && row.age <= targetAgeMax), [tradeTargets, targetPosFilter, targetTeamFilter, targetContractFilter, targetAvailabilityFilter, targetAgeMin, targetAgeMax]);
 
   const askWhatTheyOffer = useCallback((partnerId = selectedPartnerId) => {
     const partner = teams.find((t) => Number(t.id) === Number(partnerId));
@@ -185,6 +258,81 @@ export default function TradeFinder({ league, actions, onPlayerSelect, onOpenTra
               </div>
             </div>
           ))}
+        </CardContent>
+      </Card>
+
+      <Card className="card-premium">
+        <CardHeader><CardTitle>Market Signals</CardTitle></CardHeader>
+        <CardContent style={{ display: 'grid', gap: 8 }}>
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            {marketSignals.hotNeeds.map(([pos, count]) => <Badge key={pos} variant="outline">{pos} need: {count} teams</Badge>)}
+            {!marketSignals.hotNeeds.length ? <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>No strong need cluster yet.</span> : null}
+          </div>
+          <div style={{ fontSize: 12 }}>
+            <strong>Buyers:</strong> {marketSignals.buyers.map((t) => t.abbr).join(', ') || 'none flagged'} · <strong>Sellers:</strong> {marketSignals.sellers.map((t) => t.abbr).join(', ') || 'none flagged'}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="card-premium">
+        <CardHeader><CardTitle>Trade Targets Browser</CardTitle></CardHeader>
+        <CardContent style={{ display: 'grid', gap: 8 }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(130px,1fr))', gap: 6 }}>
+            <select value={targetPosFilter} onChange={(e) => setTargetPosFilter(e.target.value)}>
+              <option value="ALL">All positions</option>
+              {Array.from(new Set(tradeTargets.map((r) => r.pos))).sort().map((pos) => <option key={pos} value={pos}>{pos}</option>)}
+            </select>
+            <select value={targetTeamFilter} onChange={(e) => setTargetTeamFilter(e.target.value)}>
+              <option value="ALL">All teams</option>
+              {Array.from(new Set(tradeTargets.map((r) => `${r.teamId}|${r.teamAbbr}`))).map((key) => {
+                const [teamId, abbr] = key.split('|');
+                return <option key={key} value={teamId}>{abbr}</option>;
+              })}
+            </select>
+            <select value={targetContractFilter} onChange={(e) => setTargetContractFilter(e.target.value)}>
+              <option value="ALL">All contracts</option>
+              <option value="expiring">Expiring</option>
+              <option value="cheap">Cheap</option>
+              <option value="mid">Mid</option>
+              <option value="premium">Premium</option>
+            </select>
+            <select value={targetAvailabilityFilter} onChange={(e) => setTargetAvailabilityFilter(e.target.value)}>
+              <option value="ALL">All availability</option>
+              <option value="block">Trade block</option>
+              <option value="available">Available</option>
+              <option value="expendable">Expendable</option>
+              <option value="normal">Normal</option>
+            </select>
+            <label style={{ fontSize: 11, color: 'var(--text-muted)' }}>Age min
+              <input type="number" min={20} max={38} value={targetAgeMin} onChange={(e) => setTargetAgeMin(Number(e.target.value || 20))} style={{ width: '100%' }} />
+            </label>
+            <label style={{ fontSize: 11, color: 'var(--text-muted)' }}>Age max
+              <input type="number" min={20} max={40} value={targetAgeMax} onChange={(e) => setTargetAgeMax(Number(e.target.value || 40))} style={{ width: '100%' }} />
+            </label>
+          </div>
+          <div style={{ maxHeight: 320, overflow: 'auto', display: 'grid', gap: 6 }}>
+            {filteredTargets.slice(0, 80).map((row) => (
+              <div key={row.id} style={{ border: '1px solid var(--hairline)', borderRadius: 8, padding: '7px 8px', display: 'grid', gap: 3 }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', gap: 6, alignItems: 'center' }}>
+                  <strong style={{ fontSize: 13 }}>{row.pos} {row.name}</strong>
+                  <Badge variant="outline">{row.teamAbbr}</Badge>
+                </div>
+                <div style={{ fontSize: 11, color: 'var(--text-muted)' }}>
+                  Age {row.age} · OVR {row.ovr} / POT {row.pot} · ${row.annual.toFixed(1)}M · {row.years}y · {row.availability}
+                </div>
+                <div style={{ fontSize: 11, color: 'var(--text-muted)' }}>{row.fitHint}</div>
+                <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                  <Button className="btn" onClick={() => {
+                    setSelectedPartnerId(row.teamId);
+                    setIncomingPlayers((prev) => prev.includes(row.playerId) ? prev : [...prev, row.playerId]);
+                    onOpenTradeCenter?.();
+                  }}>Prefill in Builder</Button>
+                  <Button className="btn" onClick={() => onPlayerSelect?.(row.playerId)}>Player</Button>
+                </div>
+              </div>
+            ))}
+            {!filteredTargets.length ? <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>No targets match these filters.</div> : null}
+          </div>
         </CardContent>
       </Card>
 

--- a/src/ui/components/TradeWorkspace.jsx
+++ b/src/ui/components/TradeWorkspace.jsx
@@ -9,10 +9,11 @@ import { ScreenHeader, SectionCard, StickySubnav } from './ScreenSystem.jsx';
 import { getStickyTopOffset } from '../utils/screenSystem.js';
 import { Badge } from '@/components/ui/badge';
 import { buildIncomingOfferPresentation } from '../utils/tradeOfferPresentation.js';
+import { buildNewsDeskModel } from '../utils/newsDesk.js';
 
 const VIEWS = ['Block', 'Finder', 'Builder', 'Offers', 'Summary'];
 
-export default function TradeWorkspace({ league, actions, onPlayerSelect, initialView = 'Finder' }) {
+export default function TradeWorkspace({ league, actions, onPlayerSelect, initialView = 'Finder', initialPartnerTeamId = null }) {
   const normalizedInitialView = typeof initialView === 'string' && initialView.includes(':')
     ? (initialView.split(':')[1] || 'Finder')
     : initialView;
@@ -42,11 +43,20 @@ export default function TradeWorkspace({ league, actions, onPlayerSelect, initia
     () => incomingOffers.map((offer) => ({ offer, summary: buildIncomingOfferPresentation({ offer, league, userTeamId: league?.userTeamId }) })),
     [incomingOffers, league],
   );
+  const marketTransactions = useMemo(() => {
+    const desk = buildNewsDeskModel(league, { segment: 'transactions', limit: 80 });
+    return (desk.transactions ?? []).slice(0, 6);
+  }, [league]);
 
   useEffect(() => {
     if (!safeInitialView) return;
     setView(safeInitialView);
   }, [safeInitialView]);
+
+  useEffect(() => {
+    if (initialPartnerTeamId == null) return;
+    setWorkspace((prev) => mergeTradeWorkspaceState(prev, { partnerTeamId: Number(initialPartnerTeamId) }));
+  }, [initialPartnerTeamId]);
 
   return (
     <div className="trade-workspace app-screen-stack" style={{ '--screen-sticky-top': getStickyTopOffset('default') }}>
@@ -76,14 +86,30 @@ export default function TradeWorkspace({ league, actions, onPlayerSelect, initia
       </SectionCard>
 
       {view === 'Finder' && (
-        <TradeFinder
-          league={league}
-          actions={actions}
-          onPlayerSelect={onPlayerSelect}
-          workspace={workspace}
-          onWorkspaceChange={(patch) => setWorkspace((prev) => mergeTradeWorkspaceState(prev, patch))}
-          onOpenTradeCenter={() => setView('Builder')}
-        />
+        <>
+          <TradeFinder
+            league={league}
+            actions={actions}
+            onPlayerSelect={onPlayerSelect}
+            workspace={workspace}
+            onWorkspaceChange={(patch) => setWorkspace((prev) => mergeTradeWorkspaceState(prev, patch))}
+            onOpenTradeCenter={() => setView('Builder')}
+          />
+          <SectionCard title="Recent Market Activity" subtitle="Use live league deals to pick your next call list.">
+            <div style={{ display: 'grid', gap: 7 }}>
+              {marketTransactions.map((item, idx) => (
+                <div key={item?.id ?? idx} style={{ border: '1px solid var(--hairline)', borderRadius: 8, padding: '8px 10px', display: 'grid', gap: 4 }}>
+                  <strong style={{ fontSize: 13 }}>{item?.headline ?? 'League move'}</strong>
+                  <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{item?.body ?? 'No detail available.'}</div>
+                  <div style={{ display: 'flex', gap: 6 }}>
+                    <button className="btn btn-sm" onClick={() => setView('Builder')}>Open Builder</button>
+                  </div>
+                </div>
+              ))}
+              {!marketTransactions.length ? <div style={{ color: 'var(--text-muted)', fontSize: 12 }}>No recent transaction signals yet.</div> : null}
+            </div>
+          </SectionCard>
+        </>
       )}
 
       {view === 'Builder' && (
@@ -166,8 +192,8 @@ export default function TradeWorkspace({ league, actions, onPlayerSelect, initia
               <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
                 {partnerTeam.wins ?? 0}-{partnerTeam.losses ?? 0}{partnerTeam.ties ? `-${partnerTeam.ties}` : ''} · {partnerIntel?.direction ?? 'balanced'} · cap ${Number(partnerTeam.capRoom ?? 0).toFixed(1)}M
               </div>
-              <div style={{ fontSize: 'var(--text-xs)' }}>Needs now: {(partnerNeeds?.needNow?.slice(0, 3) ?? []).map((n) => n.pos).join(', ') || 'No urgent needs flagged'}.</div>
-              <div style={{ fontSize: 'var(--text-xs)' }}>Future needs: {(partnerNeeds?.needSoon?.slice(0, 3) ?? []).map((n) => n.pos).join(', ') || 'No future needs flagged'}.</div>
+              <div style={{ fontSize: 'var(--text-xs)' }}>Needs now: {(partnerIntel?.needsNow?.slice(0, 3) ?? []).map((n) => n.pos).join(', ') || 'No urgent needs flagged'}.</div>
+              <div style={{ fontSize: 'var(--text-xs)' }}>Surplus groups: {(partnerNeeds?.surplus?.slice(0, 3) ?? []).join(', ') || 'No surplus flagged'}.</div>
             </div>
           )}
         </SectionCard>


### PR DESCRIPTION
### Motivation
- Trading flows felt clunky and needed a focused Trade Center that helps identify partners, browse realistic targets, and explain package impact without changing the engine.
- Users need faster ways to find partners and jump from market signals into a seeded Builder flow while keeping mobile-first density and scanability.
- Improve the feedback and explanation layer so rejections and cap/roster impacts read like front-office logic rather than opaque yes/no messages.

### Description
- Trade Finder: added a lightweight market signals layer, a filterable Trade Targets Browser (position/team/age/contract/availability), and one-tap “Prefill in Builder” to seed Builder context; new code in `src/ui/components/TradeFinder.jsx`.
- Trade Center: added a compact pre-submit `TradeSummary` card and an explicit “Before you submit” blockers list, refined rejection categorization (cap/fit/direction/value), and preserved existing engine calls and legality checks; changes in `src/ui/components/TradeCenter.jsx`.
- Workspace & transactions linkage: added `initialPartnerTeamId` seeding, surfaced recent market activity in Finder, and wired League transaction rows with a “Scout Market” action that seeds the Trade Workspace; updates in `src/ui/components/TradeWorkspace.jsx`, `src/ui/components/LeagueHub.jsx`, and `src/ui/components/LeagueDashboard.jsx`.
- Surface/UX polish: improved partner context summaries to use `teamIntel` and needs/surplus signals, kept mobile-first compact rows and existing drag/drop and pick controls.
- Changed files: `src/ui/components/TradeFinder.jsx`, `src/ui/components/TradeCenter.jsx`, `src/ui/components/TradeWorkspace.jsx`, `src/ui/components/LeagueHub.jsx`, `src/ui/components/LeagueDashboard.jsx`.
- Follow-ups recommended: add a Recent Trades intelligence panel aggregated from transaction logs, saved partner/target shortlists persisted to localStorage, and targeted unit tests for Finder filtering and seeded navigation.

### Testing
- `npm run build` completed successfully and produced a production build (`vite build` completed). 
- `npm run test:unit` was executed; the run surfaced existing repository test failures (summary from the run: ~16 failed suites / 9 failing tests across unrelated Playwright/e2e and domain tests), and failures appear to be pre-existing rather than obviously introduced by these UI-focused edits.
- No backend or runtime trade engine changes were made; runtime trade calls (`submitTrade` / `counterIncomingTrade`) and trade-window/cap validations were preserved and exercised by the existing test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd9b7d9760832d937305293ac23aac)