### PR TITLE
Integrate facesjs avatars: persistent player & staff faces + UI components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "chart.js": "^4.4.7",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "facesjs": "^5.0.2",
         "localforage": "^1.10.0",
         "lucide-react": "^1.6.0",
         "react": "^19.2.4",
@@ -2625,6 +2626,21 @@
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "license": "MIT"
+    },
+    "node_modules/dset": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
@@ -2721,6 +2737,32 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/facesjs": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/facesjs/-/facesjs-5.0.2.tgz",
+      "integrity": "sha512-uRHsfVXbCxk6kxuAnVzah0c0VZpAFNruESJky2xhOvwKkLgMpCSWg2Keb6JQukO59SzFiYndwvCwuD90+r6KYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dlv": "^1.1.3",
+        "dset": "^3.1.4",
+        "svg-path-bbox": "^2.0.0"
+      },
+      "bin": {
+        "facesjs": "build/cli.js"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fdir": {
@@ -3465,6 +3507,30 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/svg-path-bbox": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/svg-path-bbox/-/svg-path-bbox-2.1.0.tgz",
+      "integrity": "sha512-PEoSQFbBvL7FOCE4cN8Knej6L7bXdNkjPcUYsfMMpq0HpnqiO0sE2mcXTd7LX160aOyh5HbaeN/SoY8thMk5Kg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "svgpath": "^2.6.0"
+      },
+      "bin": {
+        "svg-path-bbox": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=6.17.1"
+      }
+    },
+    "node_modules/svgpath": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/svgpath/-/svgpath-2.6.0.tgz",
+      "integrity": "sha512-OIWR6bKzXvdXYyO4DK/UWa1VA1JeKq8E+0ug2DG98Y/vOmMpfZNj+TIG988HjfYSqtcy/hFOtZq/n/j5GSESNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/fontello/svg2ttf?sponsor=1"
+      }
     },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "chart.js": "^4.4.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "facesjs": "^5.0.2",
     "localforage": "^1.10.0",
     "lucide-react": "^1.6.0",
     "react": "^19.2.4",

--- a/src/core/__tests__/face.test.js
+++ b/src/core/__tests__/face.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { ensureFaceConfig, generateFaceConfig } from '../face.js';
+
+describe('face config helpers', () => {
+  it('generates a valid face payload', () => {
+    const face = generateFaceConfig('player-123');
+    expect(face).toBeTruthy();
+    expect(typeof face).toBe('object');
+    expect(face.body).toBeTruthy();
+  });
+
+  it('adds missing face to entity without replacing existing face', () => {
+    const player = { id: 'p1', name: 'Test Player' };
+    const withFace = ensureFaceConfig(player, 'player');
+    expect(withFace.face).toBeTruthy();
+    const same = ensureFaceConfig(withFace, 'player');
+    expect(same.face).toEqual(withFace.face);
+  });
+});

--- a/src/core/face.js
+++ b/src/core/face.js
@@ -1,0 +1,33 @@
+import { generate } from 'facesjs';
+
+const RACES = ['white', 'black', 'asian', 'brown'];
+
+function hashSeed(value) {
+  const text = String(value ?? 'seed');
+  let h = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    h = ((h << 5) - h + text.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
+function buildFaceOptions(seed, role = 'player') {
+  return {
+    gender: (seed % 3 === 0 || role === 'staff') ? 'female' : 'male',
+    race: RACES[seed % RACES.length],
+  };
+}
+
+export function generateFaceConfig(seedInput, role = 'player') {
+  const seed = hashSeed(seedInput);
+  return generate(undefined, buildFaceOptions(seed, role));
+}
+
+export function ensureFaceConfig(entity, role = 'player') {
+  if (!entity || typeof entity !== 'object') return entity;
+  if (entity.face && typeof entity.face === 'object') return entity;
+  return {
+    ...entity,
+    face: generateFaceConfig(entity.id ?? entity.name ?? Date.now(), role),
+  };
+}

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -5,6 +5,7 @@ import { Utils as U } from './utils.js';
 import { Constants as C } from './constants.js';
 import { calculateWAR as calculateWARImpl } from './war-calculator.js';
 import { generateTraits } from './traits.js';
+import { generateFaceConfig } from './face.js';
 
 const CONTRACT_DEFAULT = {
   salary: 2,
@@ -416,6 +417,7 @@ traits: generateTraits(pos, playerOvr),
         onTradeBlock: false,
         awards: [],
         personality: generatePersonality(),
+        face: generateFaceConfig(`player-${pos}-${playerAge}-${Date.now()}-${Math.random()}`),
         stats: {
           game: getZeroStats(),
           season: getZeroStats(),

--- a/src/core/staff-system.js
+++ b/src/core/staff-system.js
@@ -1,4 +1,5 @@
 import { CORE_STAFF_ROLES, evaluateStaffImpact, generateStaffCandidate, getStaffMarketViewModel, summarizeStaffEffects } from './staff/staffFoundation.js';
+import { ensureFaceConfig } from './face.js';
 import { getScoutingConfidence } from './scouting/scoutingSystem.js';
 
 const LEGACY_ROLE_ALIASES = Object.freeze({
@@ -23,6 +24,7 @@ export function ensureTeamStaff(team, { year = 2025 } = {}) {
   }
   for (const key of Object.keys(CORE_STAFF_ROLES)) {
     if (!existing[key]) existing[key] = createStaffMember(key, { year, teamId: team?.id ?? 0 });
+    existing[key] = ensureFaceConfig(existing[key], 'staff');
   }
 
   // Backward-compatible mirror keys for older systems/tests.

--- a/src/core/staff/staffFoundation.js
+++ b/src/core/staff/staffFoundation.js
@@ -1,4 +1,5 @@
 import { Utils } from '../utils.js';
+import { generateFaceConfig } from '../face.js';
 
 export const CORE_STAFF_ROLES = Object.freeze({
   headCoach: { key: 'headCoach', title: 'Head Coach', domain: 'leadership' },
@@ -41,7 +42,9 @@ export function generateStaffCandidate(roleKey, { year = 2025, teamId = -1 } = {
   const overall = clamp(48 + Utils.rand(0, 45), 35, 97);
   const specialties = buildSpecialties(role.key, overall);
   const repIndex = overall >= 89 ? 3 : overall >= 77 ? 2 : overall >= 64 ? 1 : 0;
-  return { id: Utils.id(), name: `${Utils.choice(FIRST)} ${Utils.choice(LAST)}`, age: Utils.rand(34, 67), role: role.title, roleKey: role.key, overall, specialtyRatings: specialties, contractYears: overall >= 85 ? Utils.rand(3, 5) : Utils.rand(2, 4), annualSalary: Math.round((1.1 + (overall - 50) * 0.08 + (roleKey === 'headCoach' ? 1.5 : 0)) * 10) / 10, reputationTier: TIERS[repIndex], styleTags: buildStyleTags(role.key, specialties), modifiers: buildModifiers(role.key, specialties), continuity: { teamId, sinceYear: year, tenureYears: 0 } };
+  const id = Utils.id();
+  const name = `${Utils.choice(FIRST)} ${Utils.choice(LAST)}`;
+  return { id, name, age: Utils.rand(34, 67), role: role.title, roleKey: role.key, overall, specialtyRatings: specialties, contractYears: overall >= 85 ? Utils.rand(3, 5) : Utils.rand(2, 4), annualSalary: Math.round((1.1 + (overall - 50) * 0.08 + (roleKey === 'headCoach' ? 1.5 : 0)) * 10) / 10, reputationTier: TIERS[repIndex], styleTags: buildStyleTags(role.key, specialties), modifiers: buildModifiers(role.key, specialties), continuity: { teamId, sinceYear: year, tenureYears: 0 }, face: generateFaceConfig(`staff-${id}-${name}`, 'staff') };
 }
 
 export function evaluateStaffImpact(staff = {}) {

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -3,6 +3,7 @@
 
 // Import dependencies
 import { Constants } from './constants.js';
+import { ensureFaceConfig } from './face.js';
 
 export let state = null;
 
@@ -453,6 +454,13 @@ export const State = {
         history: [],
       };
       migratedTeam.rivalTeamId = migratedTeam?.rivalTeamId ?? null;
+      if (migratedTeam.staff && typeof migratedTeam.staff === 'object') {
+        Object.keys(migratedTeam.staff).forEach((key) => {
+          if (migratedTeam.staff[key] && typeof migratedTeam.staff[key] === 'object') {
+            migratedTeam.staff[key] = ensureFaceConfig(migratedTeam.staff[key], 'staff');
+          }
+        });
+      }
 
       // Ensure team stats are initialized
       if (!migratedTeam.stats) {
@@ -486,7 +494,7 @@ export const State = {
           else if (Object.keys(migratedPlayer.stats.career).length === 0) migratedPlayer.stats.career = getZeroStats();
         }
         
-        return migratedPlayer;
+        return ensureFaceConfig(migratedPlayer, 'player');
       }).filter(p => p !== null);
       
       return migratedTeam;

--- a/src/ui/components/FaceAvatar.jsx
+++ b/src/ui/components/FaceAvatar.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Face } from 'facesjs/react';
+import { generateFaceConfig } from '../../core/face.js';
+
+export default function FaceAvatar({ face, seed, size = 52, className = '', style = {} }) {
+  const safeFace = React.useMemo(() => face ?? generateFaceConfig(seed ?? 'fallback-avatar'), [face, seed]);
+
+  return (
+    <Face
+      face={safeFace}
+      lazy
+      ignoreDisplayErrors
+      className={className}
+      style={{
+        width: size,
+        height: size,
+        borderRadius: 12,
+        overflow: 'hidden',
+        background: 'var(--surface-sunken)',
+        ...style,
+      }}
+    />
+  );
+}

--- a/src/ui/components/PlayerCardGrid.jsx
+++ b/src/ui/components/PlayerCardGrid.jsx
@@ -15,6 +15,7 @@
 
 import React, { useState, useMemo } from "react";
 import { derivePlayerContractFinancials, formatContractMoney } from "../utils/contractFormatting.js";
+import FaceAvatar from "./FaceAvatar.jsx";
 
 // ── Colour maps ────────────────────────────────────────────────────────────────
 
@@ -211,14 +212,13 @@ function RosterCard({ player, onSelect }) {
 
       {/* ── OVR badge + name / contract ── */}
       <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10 }}>
-        <div style={{
-          width: 46, height: 46, borderRadius: "50%", flexShrink: 0,
-          background: ovrBg, border: `2px solid ${ovrColor}`,
-          display: "flex", alignItems: "center", justifyContent: "center",
-          fontSize: "1rem", fontWeight: 900, color: ovrColor,
-          boxShadow: ovr >= 88 ? `0 0 12px ${ovrGlow}` : "none",
-        }}>
-          {ovr}
+        <div style={{ position: "relative", width: 46, height: 46, flexShrink: 0 }}>
+          <FaceAvatar face={player.face} seed={player.id ?? player.name} size={46} style={{ borderRadius: "50%", border: `2px solid ${ovrColor}`, boxShadow: ovr >= 88 ? `0 0 12px ${ovrGlow}` : "none" }} />
+          <div style={{
+            position: "absolute", right: -3, bottom: -3, minWidth: 20, height: 20, borderRadius: 10,
+            background: ovrBg, border: `1px solid ${ovrColor}`, display: "flex", alignItems: "center", justifyContent: "center",
+            fontSize: "0.62rem", fontWeight: 900, color: ovrColor, padding: "0 4px"
+          }}>{ovr}</div>
         </div>
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -16,6 +16,7 @@ import { buildTeamIntelligence, classifyNeedFitForProspect, describeProspectProf
 import { buildTeamChemistrySummary, describePlayerMoraleContext } from "../utils/teamChemistry.js";
 import { normalizeManagement, TRADE_STATUS_LABELS, TRADE_STATUS_TOOLTIPS, TRADE_STATUSES, CONTRACT_PLAN_FLAGS, CONTRACT_PLAN_LABELS, toggleContractPlan } from "../utils/playerManagement.js";
 import { evaluateReSigningPriority, summarizeRetentionPlan } from "../../core/retention/reSigning.js";
+import FaceAvatar from './FaceAvatar.jsx';
 
 // ── Accolade badge config ─────────────────────────────────────────────────────
 
@@ -508,23 +509,12 @@ export default function PlayerProfile({
               }}
             >
               {/* Avatar */}
-              <div
-                style={{
-                  width: 54,
-                  height: 54,
-                  borderRadius: "14px",
-                  background: "var(--surface-sunken)",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  fontSize: "1.3rem",
-                  fontWeight: 700,
-                  color: "var(--text-muted)",
-                  flexShrink: 0,
-                }}
-              >
-                {player.pos}
-              </div>
+              <FaceAvatar
+                face={player.face}
+                seed={player.id ?? player.name}
+                size={54}
+                style={{ flexShrink: 0 }}
+              />
               <div style={{ flex: 1, minWidth: 0 }}>
                 <h2
                   style={{

--- a/src/ui/components/StaffManagement.jsx
+++ b/src/ui/components/StaffManagement.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { ScreenHeader, SectionCard, EmptyState } from './ScreenSystem.jsx';
 import FranchiseInvestmentsPanel from './FranchiseInvestmentsPanel.jsx';
+import FaceAvatar from './FaceAvatar.jsx';
 
 const ROLE_ORDER = ['headCoach', 'offCoordinator', 'defCoordinator', 'scoutDirector', 'headTrainer'];
 const ROLE_LABELS = {
@@ -105,7 +106,7 @@ export default function StaffManagement({ league, actions, compact = false }) {
           {currentStaffRows.map(({ roleKey, member }) => (
             <div key={roleKey} className="card" style={{ padding: 10 }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
-                <strong>{ROLE_LABELS[roleKey]}</strong>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}><FaceAvatar face={member?.face} seed={member?.id ?? member?.name} size={30} /><strong>{ROLE_LABELS[roleKey]}</strong></div>
                 <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>OVR {member?.overall ?? '--'}</span>
               </div>
               <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4 }}>{member?.name ?? 'Vacant'} · {member?.age ?? '--'} · {member?.reputationTier ?? 'Unproven'}</div>
@@ -140,9 +141,9 @@ export default function StaffManagement({ league, actions, compact = false }) {
           {filteredMarket.slice(0, 24).map((candidate) => (
             <div key={candidate.id} className="card" style={{ padding: 10 }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>
-                <div>
-                  <strong>{candidate.name}</strong>
-                  <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{ROLE_LABELS[candidate.roleKey] ?? candidate.role}</div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <FaceAvatar face={candidate?.face} seed={candidate?.id ?? candidate?.name} size={32} />
+                  <div><strong>{candidate.name}</strong><div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{ROLE_LABELS[candidate.roleKey] ?? candidate.role}</div></div>
                 </div>
                 <div style={{ fontSize: 12, textAlign: 'right' }}>OVR {candidate.overall} · {candidate.reputationTier}<br />Demand {fmtMoney(candidate.annualSalary)} / {candidate.contractYears}y</div>
               </div>


### PR DESCRIPTION
### Motivation
- Add unique, persistent cartoon avatars for players and staff using the open-source `facesjs` library so avatars can be stored in saves and rendered across the UI.
- Keep the integration low-risk and backwards-compatible by generating face configs in shared core logic and hydrating legacy saves on load.

### Description
- Added `facesjs` to `package.json` and introduced `src/core/face.js` with `generateFaceConfig` and `ensureFaceConfig` helpers for deterministic/random face generation and hydration.
- Persist face configs when creating entities by injecting `face` on player creation in `src/core/player.js` and on staff candidates in `src/core/staff/staffFoundation.js`.
- Hydrate legacy data so migrated teams, roster players and staff receive face configs in `src/core/state.js` and `src/core/staff-system.js` to preserve backward compatibility.
- Added a reusable React `FaceAvatar` component (`src/ui/components/FaceAvatar.jsx`) and wired it into `PlayerProfile.jsx`, `PlayerCardGrid.jsx` and `StaffManagement.jsx` to render stored avatars in profile headers, roster cards and staff market/rows.
- Included a small unit test (`src/core/__tests__/face.test.js`) covering face generation and hydration behavior.

### Testing
- Ran unit tests with `npm run test:unit -- src/core/__tests__/face.test.js`, and the test file passed (2 tests) successfully.
- Built the app with `npm run build` (Vite production build) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddb3d56874832dace07d5235572afb)