### PR TITLE
Immersive Live Game View + Simulation helper APIs

### DIFF
--- a/src/core/__tests__/game-simulator.test.js
+++ b/src/core/__tests__/game-simulator.test.js
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { applyResult, commitGameResult, groupPlayersByPosition, initializePlayerStats, updateTeamStandings } from '../game-simulator.js';
+import {
+  applyResult,
+  calculateMomentumSwing,
+  commitGameResult,
+  decideLateGameSequence,
+  getSimulationSpeedDelay,
+  groupPlayersByPosition,
+  initializePlayerStats,
+  updateTeamStandings,
+} from '../game-simulator.js';
 
 describe('groupPlayersByPosition', () => {
   it('sorts by depthOrder first, then ovr descending', () => {
@@ -100,5 +109,50 @@ describe('commitGameResult archive shape', () => {
     expect(result.scoringSummary).toHaveLength(1);
     expect(result.driveSummary).toHaveLength(1);
     expect(result.quarterScores.home[0]).toBe(7);
+  });
+});
+
+describe('immersive play helpers', () => {
+  it('maps simulation speed options to expected delay values', () => {
+    expect(getSimulationSpeedDelay('slow')).toBe(1400);
+    expect(getSimulationSpeedDelay('medium')).toBe(800);
+    expect(getSimulationSpeedDelay('instant')).toBe(0);
+    expect(getSimulationSpeedDelay('unknown')).toBe(800);
+  });
+
+  it('calculates momentum swings with turnover and scoring context', () => {
+    const tdSwing = calculateMomentumSwing({ yards: 18, isScoringPlay: true, offenseIsHome: true });
+    const turnoverSwing = calculateMomentumSwing({ yards: 4, turnover: true, offenseIsHome: true });
+    const awayExplosive = calculateMomentumSwing({ yards: 24, isExplosive: true, offenseIsHome: false });
+
+    expect(tdSwing).toBeGreaterThan(10);
+    expect(turnoverSwing).toBeLessThan(0);
+    expect(awayExplosive).toBeLessThan(0);
+  });
+
+  it('returns realistic late-game decision hints', () => {
+    const trailingFourthDown = decideLateGameSequence({
+      quarter: 4,
+      clockSeconds: 95,
+      scoreDiff: -6,
+      down: 4,
+      distance: 1,
+      yardLine: 63,
+      timeouts: 1,
+    });
+    expect(trailingFourthDown.fourthDownChoice).toBe('go');
+    expect(trailingFourthDown.useTimeout).toBe(true);
+    expect(trailingFourthDown.goForTwo).toBe(false);
+
+    const tieBreaker = decideLateGameSequence({
+      quarter: 4,
+      clockSeconds: 105,
+      scoreDiff: -1,
+      down: 3,
+      distance: 5,
+      yardLine: 70,
+      timeouts: 2,
+    });
+    expect(tieBreaker.goForTwo).toBe(true);
   });
 });

--- a/src/core/game-simulator.js
+++ b/src/core/game-simulator.js
@@ -46,6 +46,66 @@ function computePasserRating({ comp = 0, att = 0, yds = 0, td = 0, ints = 0 } = 
   return U.round(((a + b + c + d) / 6) * 100, 1);
 }
 
+const SIM_SPEED_TO_MS = {
+  slow: 1400,
+  medium: 800,
+  instant: 0,
+};
+
+export function getSimulationSpeedDelay(speed = 'medium') {
+  return SIM_SPEED_TO_MS[speed] ?? SIM_SPEED_TO_MS.medium;
+}
+
+export function calculateMomentumSwing({
+  yards = 0,
+  isScoringPlay = false,
+  turnover = false,
+  isExplosive = false,
+  offenseIsHome = true,
+}) {
+  let swing = Math.max(-12, Math.min(12, yards * 0.45));
+  if (isExplosive) swing += 6;
+  if (isScoringPlay) swing += 10;
+  if (turnover) swing -= 16;
+  if (!offenseIsHome) swing *= -1;
+  return U.clamp(Math.round(swing), -24, 24);
+}
+
+export function decideLateGameSequence({
+  quarter = 1,
+  clockSeconds = 900,
+  scoreDiff = 0, // offense score - defense score
+  down = 1,
+  distance = 10,
+  yardLine = 50,
+  timeouts = 3,
+}) {
+  const inLateGame = quarter >= 4;
+  const insideTwoMinutes = quarter >= 4 && clockSeconds <= 120;
+  const trailing = scoreDiff < 0;
+  const leading = scoreDiff > 0;
+
+  const goForTwo = inLateGame && ((scoreDiff === -2 && clockSeconds < 600) || (insideTwoMinutes && Math.abs(scoreDiff) === 1));
+  const conservativeTimeout = timeouts > 0 && leading && quarter >= 4 && clockSeconds < 80;
+  const aggressiveTimeout = timeouts > 0 && trailing && quarter >= 4 && clockSeconds < 180;
+
+  let fourthDownChoice = 'normal';
+  if (down === 4) {
+    const short = distance <= 2;
+    const inFgRange = yardLine >= 65;
+    if (trailing && (insideTwoMinutes || scoreDiff <= -9) && (short || yardLine >= 55)) fourthDownChoice = 'go';
+    else if (leading && inFgRange && clockSeconds < 240) fourthDownChoice = 'field_goal';
+    else if (!inFgRange && yardLine < 60) fourthDownChoice = 'punt';
+    else fourthDownChoice = short ? 'go' : 'field_goal';
+  }
+
+  return {
+    goForTwo,
+    useTimeout: conservativeTimeout || aggressiveTimeout,
+    fourthDownChoice,
+  };
+}
+
 function buildDriveBasedSummary({
   season = 0,
   week = 1,

--- a/src/types/gameSimulation.ts
+++ b/src/types/gameSimulation.ts
@@ -1,0 +1,29 @@
+export interface PlayResult {
+  quarter: number;
+  clock: string;
+  down: number;
+  distance: number;
+  fieldPosition: number;
+  yards: number;
+  type: 'run' | 'pass' | 'sack' | 'field_goal' | 'touchdown' | 'punt' | 'turnover' | 'play';
+  text: string;
+  homeScore: number;
+  awayScore: number;
+  momentum: number;
+}
+
+export interface GameState {
+  quarter: number;
+  clockSeconds: number;
+  possession: 'home' | 'away';
+  down: number;
+  distance: number;
+  fieldPosition: number;
+  homeScore: number;
+  awayScore: number;
+  momentum: number;
+  timeouts: {
+    home: number;
+    away: number;
+  };
+}

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -40,7 +40,7 @@ import React, { useEffect, useCallback, useRef, useState, Component, useMemo } f
 import { useWorker }       from './hooks/useWorker.js';
 import LeagueDashboard     from './components/LeagueDashboard.jsx';
 import LiveGame            from './components/LiveGame.jsx';
-import LiveGameViewer      from './components/LiveGameViewer.jsx';
+import LiveGameView        from './components/LiveGameView.jsx';
 import PostGameScreen      from './components/PostGameScreen.jsx';
 import SaveSlotManager     from './components/SaveSlotManager.jsx';
 import NewLeagueSetup      from './components/NewLeagueSetup.jsx';
@@ -1042,7 +1042,7 @@ function AppContent() {
             actions.clearUserGame();
             setTimeout(() => actions.advanceWeek({ skipUserGame: true }), 200);
           }}>
-            <LiveGameViewer
+            <LiveGameView
               logs={userGameLogs}
               homeTeam={homeTeam}
               awayTeam={awayTeam}

--- a/src/ui/components/LiveGameView.jsx
+++ b/src/ui/components/LiveGameView.jsx
@@ -1,0 +1,70 @@
+import React, { useMemo, useState } from 'react';
+import LiveGameViewer from './LiveGameViewer.jsx';
+import AnimatedField from './AnimatedField.jsx';
+import { mapArchiveEventsToLiveFeed } from '../../core/liveGame/liveGameEvents.js';
+
+function FieldPositionBar({ fieldPosition = 50, homeAbbr = 'HOME', awayAbbr = 'AWAY' }) {
+  const clamped = Math.max(1, Math.min(99, Number(fieldPosition) || 50));
+  return (
+    <div style={{ marginBottom: 10 }} title="Shows current field position based on last play.">
+      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11, color: 'var(--text-muted)' }}>
+        <span>{awayAbbr} Endzone</span>
+        <span>Ball: {Math.round(clamped)}</span>
+        <span>{homeAbbr} Endzone</span>
+      </div>
+      <div style={{ height: 8, borderRadius: 999, background: 'var(--surface-strong)', overflow: 'hidden' }}>
+        <div style={{ width: `${clamped}%`, height: '100%', background: 'var(--accent)', transition: 'width 0.35s ease' }} />
+      </div>
+    </div>
+  );
+}
+
+export default function LiveGameView(props) {
+  const { logs = [], homeTeam, awayTeam } = props;
+  const events = useMemo(() => mapArchiveEventsToLiveFeed(logs, {
+    gameId: `${homeTeam?.id || 'h'}-${awayTeam?.id || 'a'}`,
+    homeTeamId: homeTeam?.id,
+    awayTeamId: awayTeam?.id,
+  }), [logs, homeTeam?.id, awayTeam?.id]);
+
+  const [animationEnabled, setAnimationEnabled] = useState(true);
+  const latest = events[events.length - 1] || null;
+  const possession = latest?.possessionTeamId === homeTeam?.id ? 'home' : 'away';
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+        <strong style={{ fontSize: 13 }}>Live Game View</strong>
+        <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 12 }} title="Disable if you prefer fastest simulation.">
+          <input type="checkbox" checked={animationEnabled} onChange={(e) => setAnimationEnabled(e.target.checked)} />
+          2D Animation
+        </label>
+      </div>
+
+      <FieldPositionBar fieldPosition={latest?.fieldPosition} homeAbbr={homeTeam?.abbr} awayAbbr={awayTeam?.abbr} />
+
+      {animationEnabled && latest ? (
+        <div style={{ marginBottom: 10 }}>
+          <AnimatedField
+            play={{
+              ballOn: latest?.fieldPosition ?? 50,
+              distance: latest?.distance ?? 10,
+              type: latest?.type,
+              yards: latest?.yards ?? 0,
+              description: latest?.headline || latest?.playText || latest?.text || '',
+              isTouchdown: latest?.isTouchdown,
+              isTurnover: latest?.isTurnover,
+            }}
+            homeTeam={homeTeam}
+            awayTeam={awayTeam}
+            possession={possession}
+            momentum={0}
+            speed={1}
+          />
+        </div>
+      ) : null}
+
+      <LiveGameViewer {...props} />
+    </div>
+  );
+}

--- a/src/ui/components/LiveGameViewer.jsx
+++ b/src/ui/components/LiveGameViewer.jsx
@@ -11,7 +11,7 @@ const SPEED_STEPS = [
   { key: 'veryFast', label: 'Very Fast', ms: 140 },
 ];
 
-export default function LiveGameViewer({ logs = [], homeTeam, awayTeam, onComplete, initialMode = 'watch' }) {
+export default function LiveGameViewer({ logs = [], homeTeam, awayTeam, onComplete, initialMode = 'watch', onPlaycallOverride }) {
   const events = useMemo(() => mapArchiveEventsToLiveFeed(logs, {
     gameId: `${homeTeam?.id || 'h'}-${awayTeam?.id || 'a'}`,
     homeTeamId: homeTeam?.id,
@@ -88,6 +88,9 @@ export default function LiveGameViewer({ logs = [], homeTeam, awayTeam, onComple
             {SPEED_STEPS.map((step) => (
               <button key={step.key} className={speed === step.key ? 'active' : ''} onClick={() => { setSpeed(step.key); setPaused(false); }}>{step.label}</button>
             ))}
+            <button title="Lean run on next drive." onClick={() => onPlaycallOverride?.({ type: 'run_heavy' })}>Run Heavy</button>
+            <button title="Lean pass on next drive." onClick={() => onPlaycallOverride?.({ type: 'pass_heavy' })}>Pass Heavy</button>
+            <button title="Request a timeout for your team." onClick={() => onPlaycallOverride?.({ type: 'timeout' })}>Timeout</button>
             <button onClick={() => setIndex(getNextImportantEvent(events, index, 'score'))}>Skip to Next Score</button>
             <button onClick={() => setIndex(getNextImportantEvent(events, index, 'keyPlay'))}>Skip to Key Play</button>
             <button onClick={() => setIndex(events.length - 1)}>Sim to End</button>


### PR DESCRIPTION
### Motivation
- Provide a minimal, backwards-compatible foundation for immersive play-by-play watching by exposing small simulation helper APIs and a UI wrapper that layers a field-position bar and optional animated field on top of the existing live feed. 
- Give the UI / worker a stable contract for pacing, momentum calculation, and late-game decision hints so the Shared Worker and front-end can coordinate pacing and simple user overrides.

### Description
- Added new helper APIs to `src/core/game-simulator.js`: `getSimulationSpeedDelay`, `calculateMomentumSwing`, and `decideLateGameSequence` to support speed mapping, contextual momentum deltas, and 4th-down / 2-pt / timeout decision hints. 
- Introduced TypeScript interfaces in `src/types/gameSimulation.ts` for `PlayResult` and `GameState` to formalize live-play payload shapes. 
- Added a new UI wrapper `src/ui/components/LiveGameView.jsx` that shows a horizontal `FieldPositionBar`, a 2D animation toggle and optional `AnimatedField`, and then renders the existing sequential `LiveGameViewer` beneath it. 
- Enhanced `src/ui/components/LiveGameViewer.jsx` to accept an optional `onPlaycallOverride` callback and added three simple override buttons (`Run Heavy`, `Pass Heavy`, `Timeout`) while preserving existing behavior when the prop is not provided. 
- Wired the app to render `LiveGameView` in the user watch-game flow by replacing the previous direct `LiveGameViewer` usage in `src/ui/App.jsx`. 
- Expanded `src/core/__tests__/game-simulator.test.js` with unit tests exercising `getSimulationSpeedDelay`, `calculateMomentumSwing`, and `decideLateGameSequence` to cover the new logic.

### Testing
- Ran the unit test subset with `npm run test:unit -- src/core/__tests__/game-simulator.test.js` and all tests passed (`10 tests` passed). 
- Performed a production build with `npm run build` and the build completed successfully. 
- `npm install` was run during validation to ensure test/build dependencies were present and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddbd944038832da6637b94b59f9873)