### PR TITLE
Add realistic contracts, salary-cap & financial systems with migration and UI updates

### DIFF
--- a/src/core/__tests__/realisticContracts.test.js
+++ b/src/core/__tests__/realisticContracts.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeContractDetails,
+  calculateContractCapHit,
+  estimateHoldoutRisk,
+  calculateTeamPayroll,
+  projectTeamFinancials,
+} from '../contracts/realisticContracts.js';
+
+describe('realistic contract normalization', () => {
+  it('hydrates legacy/partial contracts with safe defaults', () => {
+    const normalized = normalizeContractDetails({ baseAnnual: 20, incentives: [{ amount: 2 }] }, { years: 3 });
+    expect(normalized.yearsTotal).toBe(3);
+    expect(normalized.incentives).toHaveLength(1);
+    expect(normalized.tagType).toBe('none');
+  });
+
+  it('includes likely incentives in cap hit', () => {
+    const capHit = calculateContractCapHit({ yearsTotal: 4, baseAnnual: 24, signingBonus: 8, incentives: [{ amount: 2, capTreatment: 'likely' }, { amount: 3, capTreatment: 'unlikely' }] });
+    expect(capHit).toBe(28);
+  });
+});
+
+describe('holdout and payroll rules', () => {
+  it('flags holdout risk for underpaid volatile stars', () => {
+    const risk = estimateHoldoutRisk({
+      contract: { baseAnnual: 8, years: 2 },
+      extensionAsk: { baseAnnual: 18 },
+      morale: 42,
+      personalityProfile: { holdoutRisk: 88 },
+    }, { wins: 12 });
+    expect(risk.tier).toBe('high');
+    expect(risk.shouldHoldout).toBe(true);
+  });
+
+  it('computes hard cap and floor status', () => {
+    const payroll = calculateTeamPayroll({
+      roster: [{ contract: { years: 4, baseAnnual: 30, signingBonus: 16 } }],
+      staffPayroll: 24,
+      deadCap: 10,
+      capFloor: 60,
+      capLimit: 67,
+    });
+    expect(payroll.overCap).toBe(true);
+    expect(payroll.belowFloor).toBe(false);
+  });
+});
+
+describe('financial projections', () => {
+  it('projects positive income for winning franchises in strong markets', () => {
+    const f = projectTeamFinancials({ marketSize: 1.25, wins: 13, fanApproval: 82, payroll: 220, facilityLevels: { trainingLevel: 4, medicalLevel: 4, scoutingLevel: 3 } });
+    expect(f.ticketSales).toBeGreaterThan(80);
+    expect(f.facilityUpgrades).toHaveLength(3);
+  });
+});

--- a/src/core/contracts/realisticContracts.js
+++ b/src/core/contracts/realisticContracts.js
@@ -1,0 +1,188 @@
+const TAG_TYPES = ['none', 'franchise', 'transition'];
+
+/**
+ * @typedef {Object} ContractIncentive
+ * @property {string} key
+ * @property {string} label
+ * @property {number} amount
+ * @property {'likely'|'unlikely'} capTreatment
+ * @property {number} target
+ * @property {string} metric
+ */
+
+/**
+ * @typedef {Object} ContractDetails
+ * @property {number} years
+ * @property {number} yearsTotal
+ * @property {number} yearsRemaining
+ * @property {number} baseAnnual
+ * @property {number} signingBonus
+ * @property {number} guaranteedPct
+ * @property {number} guaranteedMoney
+ * @property {number} optionBonus
+ * @property {number} optionYear
+ * @property {boolean} hasNoTradeClause
+ * @property {'none'|'franchise'|'transition'} tagType
+ * @property {boolean} rookieScale
+ * @property {boolean} fifthYearOptionEligible
+ * @property {boolean} fifthYearOptionExercised
+ * @property {boolean} restrictedFreeAgent
+ * @property {ContractIncentive[]} incentives
+ */
+
+/**
+ * @typedef {Object} FacilityUpgrade
+ * @property {'training'|'medical'|'scouting'} key
+ * @property {number} level
+ * @property {number} annualCost
+ * @property {number} projectedReturn
+ */
+
+/**
+ * @typedef {Object} Financials
+ * @property {number} ticketSales
+ * @property {number} merchandise
+ * @property {number} broadcasting
+ * @property {number} sponsorships
+ * @property {number} facilities
+ * @property {number} staffPayroll
+ * @property {number} playerPayroll
+ * @property {number} deadCap
+ * @property {number} netCashFlow
+ * @property {FacilityUpgrade[]} facilityUpgrades
+ */
+
+function n(v, fb = 0) {
+  const num = Number(v);
+  return Number.isFinite(num) ? num : fb;
+}
+
+function clamp(v, min, max) {
+  return Math.max(min, Math.min(max, v));
+}
+
+function normalizeIncentives(incentives = []) {
+  if (!Array.isArray(incentives)) return [];
+  return incentives
+    .map((row, idx) => ({
+      key: String(row?.key ?? `inc_${idx}`),
+      label: String(row?.label ?? 'Performance milestone'),
+      amount: Math.max(0, n(row?.amount, 0)),
+      capTreatment: row?.capTreatment === 'unlikely' ? 'unlikely' : 'likely',
+      target: Math.max(0, n(row?.target, 0)),
+      metric: String(row?.metric ?? 'season_award'),
+    }))
+    .slice(0, 8);
+}
+
+export function normalizeContractDetails(contract = {}, player = {}) {
+  const yearsTotal = Math.max(1, Math.round(n(contract?.yearsTotal ?? contract?.years ?? player?.yearsTotal ?? player?.years, 1)));
+  const yearsRemaining = clamp(Math.round(n(contract?.yearsRemaining ?? contract?.years ?? player?.years ?? yearsTotal, yearsTotal)), 1, yearsTotal);
+  const baseAnnual = Math.max(0, n(contract?.baseAnnual ?? player?.baseAnnual ?? contract?.salary ?? player?.salary, 0));
+  const signingBonus = Math.max(0, n(contract?.signingBonus ?? player?.signingBonus, 0));
+  const guaranteedPct = clamp(n(contract?.guaranteedPct ?? player?.guaranteedPct, 0), 0, 1);
+  const guaranteedMoney = Math.max(0, n(contract?.guaranteedMoney, (baseAnnual * yearsTotal + signingBonus) * guaranteedPct));
+  const optionYear = clamp(Math.round(n(contract?.optionYear, 0)), 0, yearsTotal);
+  const tagType = TAG_TYPES.includes(contract?.tagType) ? contract.tagType : (player?.isTagged ? 'franchise' : 'none');
+
+  return {
+    years: yearsRemaining,
+    yearsTotal,
+    yearsRemaining,
+    baseAnnual,
+    signingBonus,
+    guaranteedPct,
+    guaranteedMoney,
+    optionBonus: Math.max(0, n(contract?.optionBonus, 0)),
+    optionYear,
+    hasNoTradeClause: !!contract?.hasNoTradeClause,
+    tagType,
+    rookieScale: !!contract?.rookieScale,
+    fifthYearOptionEligible: !!contract?.fifthYearOptionEligible,
+    fifthYearOptionExercised: !!contract?.fifthYearOptionExercised,
+    restrictedFreeAgent: !!contract?.restrictedFreeAgent,
+    incentives: normalizeIncentives(contract?.incentives),
+  };
+}
+
+export function calculateContractCapHit(contract = {}, { includeLikelyIncentives = true } = {}) {
+  const c = normalizeContractDetails(contract);
+  const proratedBonus = c.signingBonus / Math.max(1, c.yearsTotal);
+  const likelyIncentives = c.incentives
+    .filter((inc) => inc.capTreatment === 'likely')
+    .reduce((sum, inc) => sum + inc.amount, 0);
+  return Math.round((c.baseAnnual + proratedBonus + (includeLikelyIncentives ? likelyIncentives : 0)) * 100) / 100;
+}
+
+export function estimateHoldoutRisk(player = {}, teamContext = {}) {
+  const c = normalizeContractDetails(player?.contract ?? {}, player);
+  const personalityRisk = n(player?.personalityProfile?.holdoutRisk ?? player?.personality?.holdoutRisk, 20);
+  const morale = clamp(n(player?.morale, 60), 0, 100);
+  const marketValue = Math.max(c.baseAnnual, n(player?.extensionAsk?.baseAnnual, c.baseAnnual));
+  const underpaidGap = Math.max(0, marketValue - c.baseAnnual);
+  const successPressure = clamp(n(teamContext?.wins, 8) / 17, 0, 1);
+  const score = clamp(
+    personalityRisk * 0.6 +
+    underpaidGap * 3.6 +
+    (100 - morale) * 0.35 +
+    successPressure * 12,
+    0,
+    100,
+  );
+  return {
+    score: Math.round(score),
+    tier: score >= 75 ? 'high' : score >= 45 ? 'medium' : 'low',
+    shouldHoldout: score >= 78 && underpaidGap >= 3,
+  };
+}
+
+export function calculateTeamPayroll({ roster = [], staffPayroll = 0, deadCap = 0, capFloor = 0, capLimit = 0 } = {}) {
+  const playerPayroll = roster.reduce((sum, p) => sum + calculateContractCapHit(p?.contract ?? p, { includeLikelyIncentives: true }), 0);
+  const totalPayroll = playerPayroll + Math.max(0, n(staffPayroll, 0)) + Math.max(0, n(deadCap, 0));
+  return {
+    playerPayroll: Math.round(playerPayroll * 100) / 100,
+    staffPayroll: Math.max(0, n(staffPayroll, 0)),
+    deadCap: Math.max(0, n(deadCap, 0)),
+    totalPayroll: Math.round(totalPayroll * 100) / 100,
+    overCap: capLimit > 0 ? totalPayroll > capLimit : false,
+    belowFloor: capFloor > 0 ? totalPayroll < capFloor : false,
+    capSpace: capLimit > 0 ? Math.round((capLimit - totalPayroll) * 100) / 100 : 0,
+  };
+}
+
+export function projectTeamFinancials({ marketSize = 1, wins = 8, fanApproval = 50, payroll = 0, facilityLevels = {} } = {}) {
+  const market = clamp(n(marketSize, 1), 0.7, 1.4);
+  const winBoost = clamp(n(wins, 8) / 17, 0, 1.1);
+  const fanBoost = clamp(n(fanApproval, 50) / 100, 0.4, 1.2);
+  const training = clamp(n(facilityLevels?.trainingLevel, 1), 1, 5);
+  const medical = clamp(n(facilityLevels?.medicalLevel ?? facilityLevels?.trainingLevel, 1), 1, 5);
+  const scouting = clamp(n(facilityLevels?.scoutingLevel, 1), 1, 5);
+
+  const ticketSales = (95 * market) * (0.7 + winBoost * 0.45) * fanBoost;
+  const merchandise = (38 * market) * (0.6 + winBoost * 0.5) * fanBoost;
+  const broadcasting = 120 * (0.95 + market * 0.08);
+  const sponsorships = (44 * market) * (0.8 + fanBoost * 0.4);
+  const facilities = 6 + training * 2.2 + medical * 2 + scouting * 1.8;
+  const netCashFlow = ticketSales + merchandise + broadcasting + sponsorships - payroll - facilities;
+
+  return {
+    ticketSales: round2(ticketSales),
+    merchandise: round2(merchandise),
+    broadcasting: round2(broadcasting),
+    sponsorships: round2(sponsorships),
+    facilities: round2(facilities),
+    staffPayroll: 0,
+    playerPayroll: round2(payroll),
+    deadCap: 0,
+    netCashFlow: round2(netCashFlow),
+    facilityUpgrades: [
+      { key: 'training', level: training, annualCost: round2(training * 2.2), projectedReturn: round2(training * 1.5) },
+      { key: 'medical', level: medical, annualCost: round2(medical * 2), projectedReturn: round2(medical * 1.3) },
+      { key: 'scouting', level: scouting, annualCost: round2(scouting * 1.8), projectedReturn: round2(scouting * 1.2) },
+    ],
+  };
+}
+
+function round2(v) {
+  return Math.round(n(v, 0) * 100) / 100;
+}

--- a/src/core/teamValidation.js
+++ b/src/core/teamValidation.js
@@ -1,23 +1,13 @@
 import { Constants } from './constants.js';
 import { DEPTH_CHART_ROWS } from './depthChart.js';
+import { normalizeContractDetails, calculateContractCapHit } from './contracts/realisticContracts.js';
 
 export function normalizeContract(player = {}) {
-  const contract = player?.contract ?? {};
-  const yearsTotal = Number(contract?.yearsTotal ?? contract?.years ?? player?.yearsTotal ?? player?.years ?? 1) || 1;
-  const baseAnnual = Number(contract?.baseAnnual ?? player?.baseAnnual ?? contract?.salary ?? player?.salary ?? 0) || 0;
-  const signingBonus = Number(contract?.signingBonus ?? player?.signingBonus ?? 0) || 0;
-  const guaranteedPct = Number(contract?.guaranteedPct ?? player?.guaranteedPct ?? 0) || 0;
-  return {
-    yearsTotal: Math.max(1, yearsTotal),
-    baseAnnual: Math.max(0, baseAnnual),
-    signingBonus: Math.max(0, signingBonus),
-    guaranteedPct: Math.max(0, guaranteedPct),
-  };
+  return normalizeContractDetails(player?.contract ?? {}, player);
 }
 
 export function getPlayerCapHit(player = {}) {
-  const c = normalizeContract(player);
-  return c.baseAnnual + (c.signingBonus / c.yearsTotal);
+  return calculateContractCapHit(player?.contract ?? player);
 }
 
 export function getRosterLimitForPhase(phase) {

--- a/src/state/saveSchema.js
+++ b/src/state/saveSchema.js
@@ -1,4 +1,4 @@
-export const CURRENT_SAVE_SCHEMA_VERSION = 5.4;
+export const CURRENT_SAVE_SCHEMA_VERSION = 5.5;
 
 function migratePreVersioned(meta = {}) {
   return {
@@ -44,6 +44,7 @@ const MIGRATIONS = {
   5.1: migrateV51ToV52,
   5.2: migrateV52ToV53,
   5.3: migrateV53ToV54,
+  5.4: migrateV54ToV55,
 };
 
 function migrateV4ToV5(meta = {}) {
@@ -118,6 +119,37 @@ function migrateV53ToV54(meta = {}) {
     saveVersion: 5.4,
   };
 }
+
+
+function migrateV54ToV55(meta = {}) {
+  const financialSystem = {
+    salaryCapModel: 'hard_cap',
+    capFloorEnforced: true,
+    rookieWageScaleEnabled: true,
+    fifthYearOptionEnabled: true,
+    restrictedFreeAgencyEnabled: true,
+    ownerGoalStyle: meta?.financialSystem?.ownerGoalStyle ?? 'balanced',
+    upgradedAt: Date.now(),
+    ...(meta?.financialSystem ?? {}),
+  };
+
+  const baselineRevenue = {
+    ticketSales: 86,
+    merchandise: 34,
+    broadcasting: 120,
+    sponsorships: 39,
+    facilityCost: 12,
+    ...(meta?.baselineRevenue ?? {}),
+  };
+
+  return {
+    ...meta,
+    financialSystem,
+    baselineRevenue,
+    saveVersion: 5.5,
+  };
+}
+
 export function migrateSaveMetaToCurrent(meta = {}) {
   const startVersion = Number(meta?.saveVersion ?? 0);
   if (!Number.isFinite(startVersion) || startVersion < 0) {

--- a/src/ui/components/ContractNegotiation.jsx
+++ b/src/ui/components/ContractNegotiation.jsx
@@ -82,6 +82,10 @@ export default function ContractNegotiation({
   const [annual, setAnnual] = useState(Math.max(0.8, Math.round((player.baseAnnual || 4) * 10) / 10));
   const [guaranteePct, setGuaranteePct] = useState(50);
   const [bonus, setBonus] = useState(0);
+  const [hasNoTradeClause, setHasNoTradeClause] = useState(false);
+  const [optionYear, setOptionYear] = useState(0);
+  const [tagType, setTagType] = useState("none");
+  const [incentives, setIncentives] = useState({ mvp: false, allPro: false, yards: false });
 
   const totalValue = useMemo(() => annual * years, [annual, years]);
   const capHitThisYear = useMemo(() => {
@@ -207,6 +211,33 @@ export default function ContractNegotiation({
           </div>
         </div>
 
+
+          {/* Clauses */}
+          <div style={{ borderTop: '1px solid var(--hairline)', paddingTop: 'var(--space-3)' }}>
+            <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', marginBottom: 8, fontWeight: 700 }}>Clauses & Options</div>
+            <label style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+              <input type="checkbox" checked={hasNoTradeClause} onChange={(e) => setHasNoTradeClause(e.target.checked)} />
+              <span style={{ fontSize: 'var(--text-xs)' }}>No-trade clause</span>
+            </label>
+            <label style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+              <input type="checkbox" checked={optionYear > 0} onChange={(e) => setOptionYear(e.target.checked ? years : 0)} />
+              <span style={{ fontSize: 'var(--text-xs)' }}>Option year ({optionYear > 0 ? `Year ${optionYear}` : 'Off'})</span>
+            </label>
+            <div style={{ display: 'flex', gap: 8, marginBottom: 6 }}>
+              <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>Tag</span>
+              <select value={tagType} onChange={(e) => setTagType(e.target.value)} style={{ fontSize: 'var(--text-xs)' }}>
+                <option value="none">None</option>
+                <option value="franchise">Franchise</option>
+                <option value="transition">Transition</option>
+              </select>
+            </div>
+            <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginTop: 8 }}>
+              <label style={{ fontSize: 'var(--text-xs)' }}><input type="checkbox" checked={incentives.mvp} onChange={(e) => setIncentives((v) => ({ ...v, mvp: e.target.checked }))} /> MVP bonus</label>
+              <label style={{ fontSize: 'var(--text-xs)' }}><input type="checkbox" checked={incentives.allPro} onChange={(e) => setIncentives((v) => ({ ...v, allPro: e.target.checked }))} /> All-Pro bonus</label>
+              <label style={{ fontSize: 'var(--text-xs)' }}><input type="checkbox" checked={incentives.yards} onChange={(e) => setIncentives((v) => ({ ...v, yards: e.target.checked }))} /> Yardage bonus</label>
+            </div>
+          </div>
+
         {/* Live preview */}
         <div style={{ background: "var(--glass-bg)", border: "1px solid var(--glass-border)", borderRadius: "var(--radius-md)", padding: "var(--space-3)", marginTop: "var(--space-5)" }}>
           <div style={{ display: "flex", justifyContent: "space-between", fontSize: "var(--text-xs)", marginBottom: 6 }}>
@@ -242,7 +273,7 @@ export default function ContractNegotiation({
           </button>
           <button
             className="btn-premium btn-primary-premium"
-            onClick={() => onOffer({ years, annual, guaranteePct, bonus })}
+            onClick={() => onOffer({ years, annual, guaranteePct, bonus, hasNoTradeClause, optionYear, tagType, incentives })}
             style={{ flex: 2 }}
           >
             Submit Offer

--- a/src/ui/components/FinancialsView.jsx
+++ b/src/ui/components/FinancialsView.jsx
@@ -200,6 +200,9 @@ export default function FinancialsView({ league, actions }) {
   const capRoom = Math.round((hardCap - capUsedTotal) * 100) / 100;
   const isOverCap = capUsedTotal > hardCap;
   const june1 = june1Label(phase);
+  const capFloor = Number(team?.capFloor ?? league?.settings?.capFloor ?? 210);
+  const capStatus = team?.capStatus ?? (capUsedTotal > hardCap ? 'over' : capUsedTotal < capFloor ? 'below_floor' : 'healthy');
+  const financials = team?.financials ?? null;
 
   // Enrich players with computed cap hit
   const enriched = useMemo(
@@ -547,7 +550,38 @@ export default function FinancialsView({ league, actions }) {
           sub={`vs. $${hardCap}M hard cap`}
           danger={isOverCap}
         />
+        <StatBox
+          label="Cap Floor"
+          value={fmt(capFloor)}
+          sub={capStatus === 'below_floor' ? 'Below floor: spend required' : 'Floor target healthy'}
+          danger={capStatus === 'below_floor'}
+        />
+        <StatBox
+          label="Net Cash Flow"
+          value={financials ? fmt(financials.netCashFlow) : '—'}
+          sub={financials ? 'Revenue - payroll - facilities' : 'Projection pending'}
+          danger={Number(financials?.netCashFlow ?? 0) < 0}
+        />
       </div>
+
+
+      <Card className="card-premium" style={{ marginBottom: "var(--space-5)" }}>
+        <CardHeader><CardTitle>Revenue & Expense Projection</CardTitle></CardHeader>
+        <CardContent style={{ display: 'grid', gap: 10 }}>
+          {!financials ? <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>No financial projection yet for this team.</div> : (
+            <>
+              <div style={{ display: 'grid', gap: 8, gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))' }}>
+                <StatBox label="Ticket sales" value={fmt(financials.ticketSales)} />
+                <StatBox label="Merchandise" value={fmt(financials.merchandise)} />
+                <StatBox label="Broadcasting" value={fmt(financials.broadcasting)} />
+                <StatBox label="Sponsorships" value={fmt(financials.sponsorships)} />
+                <StatBox label="Facilities cost" value={fmt(financials.facilities)} danger />
+              </div>
+              <div style={{ fontSize: 11, color: 'var(--text-subtle)' }}>Facility upgrades directly affect long-term development, injury recovery and scouting confidence.</div>
+            </>
+          )}
+        </CardContent>
+      </Card>
 
       <Card className="card-premium" style={{ marginBottom: "var(--space-5)" }}>
         <CardHeader><CardTitle>Cap Commitments & Allocation</CardTitle></CardHeader>

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -82,6 +82,7 @@ import {
 import { getTeamContextForNegotiation } from '../core/teamContext/negotiationContext.js';
 import { evaluateContractOffer, summarizeNegotiationStance } from '../core/contracts/negotiation.js';
 import { computeRestructureOutcome, shouldPreserveChemistryOnReturn, isContractRestructureEligible } from '../core/contracts/restructure.js';
+import { normalizeContractDetails, calculateContractCapHit, calculateTeamPayroll, estimateHoldoutRisk, projectTeamFinancials } from '../core/contracts/realisticContracts.js';
 import { summarizePlayerMood } from '../core/mood/playerMood.js';
 import { getFreeAgencyDecisionState } from '../core/freeAgency/decisionState.js';
 import {
@@ -1041,16 +1042,9 @@ function buildRosterView(teamId) {
     // inside p.contract, but makePlayer() during league init writes those fields
     // directly on the player object (legacy flat format).  Merge both so the UI
     // always receives a properly-shaped contract object.
-    const contract = p.contract ?? (
-      p.baseAnnual != null ? {
-        years:        p.years        ?? 1,
-        yearsTotal:   p.yearsTotal   ?? p.years ?? 1,
-        yearsRemaining: p.years      ?? 1,
-        baseAnnual:   p.baseAnnual,
-        signingBonus: p.signingBonus ?? 0,
-        guaranteedPct:p.guaranteedPct ?? 0.5,
-      } : null
-    );
+    const contract = p.contract || p.baseAnnual != null
+      ? normalizeContractDetails(p.contract ?? {}, p)
+      : null;
 
     return {
         id:       p.id,
@@ -2311,11 +2305,16 @@ if (res.injuries && res.injuries.length > 0) {
           const isDivisive = p.personality?.traits?.includes('Divisive');
           const holdoutProb = isDivisive ? 0.03 : 0.01;
           const conductProb = isDivisive ? 0.02 : 0.005;
+          const holdout = estimateHoldoutRisk(p, { wins: team?.wins ?? 0 });
 
-          // chance per week for low morale players to holdout
-          if (p.morale < 30 && p.ovr > 80 && Math.random() < holdoutProb) {
+          // chance per week for low morale / underpaid stars to holdout
+          if ((holdout.shouldHoldout || (p.morale < 30 && p.ovr > 80)) && Math.random() < Math.max(holdoutProb, holdout.score / 4000)) {
               await NewsEngine.logNarrative(p, 'HOLDOUT', team?.abbr || 'FA');
-              // Could also apply a temporary OVR penalty or status change here
+              cache.updatePlayer(p.id, {
+                morale: Math.max(0, Number(p?.morale ?? 50) - 6),
+                holdoutRisk: holdout.score,
+                holdoutStatus: 'active',
+              });
           }
           // chance per week for any player to get a conduct fine
           if (Math.random() < conductProb) {
@@ -5825,19 +5824,9 @@ async function handleUpdateStrategy({ offPlanId, defPlanId, riskId, starTargetId
 
 function recalculateTeamCap(teamId) {
   const players = cache.getPlayersByTeam(teamId);
-  const activeCap = players.reduce((sum, p) => {
-    // Support both nested contract object (p.contract.baseAnnual) produced by
-    // worker transactions (signPlayer, draftPick, etc.) AND legacy flat fields
-    // (p.baseAnnual, p.signingBonus) written by makePlayer() during league init.
-    const baseAnnual   = p.contract?.baseAnnual   ?? p.baseAnnual   ?? 0;
-    const signingBonus = p.contract?.signingBonus  ?? p.signingBonus ?? 0;
-    const yearsTotal   = p.contract?.yearsTotal    ?? p.yearsTotal   ?? 1;
-    // Cap hit = Base + Prorated Bonus
-    return sum + baseAnnual + (signingBonus / (yearsTotal || 1));
-  }, 0);
-
   const team = cache.getTeam(teamId);
   if (!team) return;
+
   const staff = ensureTeamStaff(team, { year: Number(getSafeMeta()?.year ?? 2025) });
   const staffCap = Object.keys(staff).reduce((sum, key) => {
     const member = staff?.[key];
@@ -5845,19 +5834,50 @@ function recalculateTeamCap(teamId) {
     return sum + Number(member?.contract?.annualSalary ?? member?.annualSalary ?? 0);
   }, 0);
 
-  const deadCap          = team.deadCap         || 0;
-  const deadMoneyNextYear = team.deadMoneyNextYear || 0;
+  const deadCap = Number(team.deadCap || 0);
+  const deadMoneyNextYear = Number(team.deadMoneyNextYear || 0);
   const leagueCap = Number(getSafeMeta()?.economy?.currentSalaryCap ?? getLeagueSetting('salaryCap', Constants.SALARY_CAP.HARD_CAP));
-  const capTotal          = team.capTotal         ?? leagueCap;
-  const totalCapUsed      = activeCap + deadCap + staffCap;
+  const capTotal = Number(team.capTotal ?? leagueCap);
+  const capFloor = Number(getLeagueSetting('capFloor', 210));
+
+  const payroll = calculateTeamPayroll({
+    roster: players.map((p) => ({
+      ...p,
+      contract: normalizeContractDetails(p?.contract ?? {}, p),
+    })),
+    staffPayroll: staffCap,
+    deadCap,
+    capFloor,
+    capLimit: capTotal,
+  });
+
+  const marketSize = Number(team?.marketSize ?? team?.market?.score ?? 1);
+  const financials = projectTeamFinancials({
+    marketSize,
+    wins: Number(team?.wins ?? 0),
+    fanApproval: Number(team?.fanApproval ?? 50),
+    payroll: payroll.totalPayroll,
+    facilityLevels: {
+      trainingLevel: Number(team?.franchiseInvestments?.trainingLevel ?? 1),
+      scoutingLevel: Number(team?.franchiseInvestments?.scoutingLevel ?? 1),
+      medicalLevel: Number(team?.franchiseInvestments?.trainingLevel ?? 1),
+    },
+  });
 
   cache.updateTeam(teamId, {
-    capUsed:         Math.round(totalCapUsed * 100)        / 100,
-    capRoom:         Math.round((capTotal - totalCapUsed) * 100) / 100,
-    deadCap:         Math.round(deadCap * 100)             / 100,
+    capUsed: payroll.totalPayroll,
+    capRoom: payroll.capSpace,
+    capFloor,
+    capTotal,
+    capStatus: payroll.overCap ? 'over' : payroll.belowFloor ? 'below_floor' : 'healthy',
+    playerPayroll: payroll.playerPayroll,
+    staffPayroll: payroll.staffPayroll,
+    deadCap: Math.round(deadCap * 100) / 100,
     deadMoneyNextYear: Math.round(deadMoneyNextYear * 100) / 100,
+    financials,
   });
 }
+
 // Alias for backward compatibility if needed, but we should replace calls.
 const _updateTeamCap = recalculateTeamCap;
 


### PR DESCRIPTION
### Motivation
- Provide a richer, more realistic contract model (bonuses, incentives, option years, tags, rookie scale, holdout risk) so roster decisions have long-term financial consequences.  
- Move cap math, payroll enforcement (hard cap + cap floor) and revenue/expense projections into the worker to ensure accuracy and deterministic simulation behavior.  
- Surface financial state in the UI (negotiation controls + Financials dashboard) and add a safe save-schema migration so older saves continue to work.

### Description
- Introduced a new core engine `src/core/contracts/realisticContracts.js` that normalizes contract details, computes cap hits (including likely incentives), estimates personality-driven holdout risk, computes team payroll (player/staff/dead money) and projects team financials/facility ROI.  
- Wired the new engine into runtime code: `src/worker/worker.js` now imports and uses `normalizeContractDetails`, `calculateContractCapHit`, `calculateTeamPayroll`, `estimateHoldoutRisk`, and `projectTeamFinancials` to hydrate roster views, run weekly holdout narratives, and recalculate team cap/financial fields.  
- Replaced legacy contract helpers in `src/core/teamValidation.js` to use the normalized contract model so validation and cap math are consistent.  
- Save migration bump: `src/state/saveSchema.js` updated from `5.4` → `5.5` and added `migrateV54ToV55` to supply non-destructive defaults for the new financial system and baseline revenues.  
- UI updates: `src/ui/components/ContractNegotiation.jsx` adds clause controls (no-trade, option-year, franchise/transition tag, incentive toggles) and passes them with `onOffer`; `src/ui/components/FinancialsView.jsx` now shows cap floor, `capStatus`, net cash flow and a Revenue & Expense projection card driven by worker-provided team financials.  
- Added unit tests `src/core/__tests__/realisticContracts.test.js` that cover normalization, cap-hit math with incentives, holdout scoring, payroll enforcement, and financial projection behavior.

### Testing
- Ran unit tests `npm run test:unit` for the new tests and related contract tests: `src/core/__tests__/realisticContracts.test.js` and `src/core/__tests__/restructure.test.js`; initial expectation mismatch was corrected and the final run had all tests passing.  
- Commands run: `npm run test:unit -- --run src/core/__tests__/realisticContracts.test.js src/core/__tests__/restructure.test.js` (final result: all tests passed).  
- Production build validated with `npm run build` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddc2361d8c832dbd715dba3c1a0b18)