### PR TITLE
Dynamic Events + Social Feed, season awards, and standings tiebreaks

### DIFF
--- a/src/core/__tests__/eventSystem.test.js
+++ b/src/core/__tests__/eventSystem.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { generateDynamicEvents, calculateSeasonAwards } from '../events/eventSystem.js';
+
+function makePlayer(overrides = {}) {
+  return {
+    id: overrides.id ?? 1,
+    name: overrides.name ?? 'Player',
+    pos: overrides.pos ?? 'WR',
+    teamId: overrides.teamId ?? 1,
+    status: 'active',
+    morale: 42,
+    contract: { baseAnnual: 6, years: 2 },
+    extensionAsk: { baseAnnual: 18 },
+    personalityProfile: { holdoutRisk: 92, diva: 85, discipline: 30, offFieldRisk: 70 },
+    ...overrides,
+  };
+}
+
+describe('eventSystem dynamic event generation', () => {
+  it('generates holdout/trade pressure for volatile underpaid stars', () => {
+    const players = [makePlayer()];
+    const teams = [{ id: 1, abbr: 'USR', wins: 2, losses: 7 }];
+    const events = generateDynamicEvents({ players, teams, week: 8, phase: 'regular', rng: () => 0.01 });
+    const types = events.map((e) => e.type);
+    expect(types).toContain('holdout');
+    expect(types).toContain('trade_demand');
+  });
+
+  it('emits draft rumor events in draft phase', () => {
+    const events = generateDynamicEvents({ players: [makePlayer()], teams: [{ id: 1, name: 'User', abbr: 'USR' }], phase: 'draft', rng: () => 0.1 });
+    expect(events.some((e) => e.type === 'draft_rumor')).toBe(true);
+  });
+});
+
+describe('season awards', () => {
+  it('computes MVP/ROTY/COY and all-pro teams', () => {
+    const stats = [
+      { playerId: 1, name: 'Veteran QB', pos: 'QB', age: 29, teamId: 1, totals: { passYd: 4800, passTD: 42 } },
+      { playerId: 2, name: 'Rookie WR', pos: 'WR', age: 22, teamId: 2, totals: { recYd: 1400, recTD: 12 } },
+    ];
+    const teams = [{ id: 1, wins: 13, abbr: 'AAA' }, { id: 2, wins: 11, abbr: 'BBB' }];
+    const awards = calculateSeasonAwards({ stats, teams, year: 2030, coaches: [{ teamId: 1, name: 'Coach One' }] });
+    expect(awards.mvp?.playerId).toBe(1);
+    expect(awards.roty?.playerId).toBe(2);
+    expect(awards.coachOfTheYear?.teamId).toBe(1);
+    expect(awards.allPro.firstTeamOffense.length).toBeGreaterThan(0);
+  });
+});

--- a/src/core/dynasty-story.js
+++ b/src/core/dynasty-story.js
@@ -3,6 +3,7 @@ import { ensureLeagueMemoryMeta } from './league-memory.js';
 export const ensureDynastyMeta = (meta) => ensureLeagueMemoryMeta({
   ...meta,
   newsItems: Array.isArray(meta?.newsItems) ? meta.newsItems : [],
+  socialFeedEntries: Array.isArray(meta?.socialFeedEntries) ? meta.socialFeedEntries : [],
   ownerGoals: Array.isArray(meta?.ownerGoals) ? meta.ownerGoals : [],
   retiredPlayers: Array.isArray(meta?.retiredPlayers) ? meta.retiredPlayers : [],
   records: meta?.records ?? {

--- a/src/core/events/eventSystem.js
+++ b/src/core/events/eventSystem.js
@@ -1,0 +1,206 @@
+import { estimateHoldoutRisk } from '../contracts/realisticContracts.js';
+
+const EVENT_TYPES = Object.freeze({
+  HOLDOUT: 'holdout',
+  TRADE_DEMAND: 'trade_demand',
+  SUSPENSION: 'suspension',
+  RETIREMENT: 'retirement',
+  INJURY: 'injury',
+  MILESTONE: 'milestone',
+  AWARD: 'award',
+  DRAFT_RUMOR: 'draft_rumor',
+  OFF_FIELD: 'off_field_storyline',
+});
+
+export const EVENT_TOOLTIPS = Object.freeze({
+  [EVENT_TYPES.HOLDOUT]: 'Contract leverage standoff. High diva/holdout-risk players push for better terms.',
+  [EVENT_TYPES.TRADE_DEMAND]: 'A player is requesting a move due to fit, morale, or team direction.',
+  [EVENT_TYPES.SUSPENSION]: 'Discipline issue that temporarily removes the player from active games.',
+  [EVENT_TYPES.RETIREMENT]: 'Career decision triggered by age, injuries, or personal motivation.',
+  [EVENT_TYPES.INJURY]: 'Medical event affecting availability and short-term team planning.',
+  [EVENT_TYPES.MILESTONE]: 'Notable statistical achievement that boosts profile and morale.',
+  [EVENT_TYPES.AWARD]: 'End-of-season recognition for individual or coaching excellence.',
+  [EVENT_TYPES.DRAFT_RUMOR]: 'Pre-draft buzz that changes expectations and fan sentiment.',
+  [EVENT_TYPES.OFF_FIELD]: 'Narrative event (charity, controversy, mentoring) that impacts morale/popularity.',
+});
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function randomOf(rng, list = []) {
+  if (!list.length) return null;
+  return list[Math.floor(rng() * list.length)] ?? null;
+}
+
+function scorePlayer(player, team, context = {}) {
+  const wins = Number(team?.wins ?? 0);
+  const losses = Number(team?.losses ?? 0);
+  const poorRecord = losses > wins ? 1 : 0;
+  const profile = player?.personalityProfile ?? {};
+  const holdoutRisk = estimateHoldoutRisk(player, { wins });
+  return {
+    player,
+    team,
+    holdoutRisk,
+    volatility: Number(profile?.diva ?? 35) + Number(profile?.offFieldRisk ?? 25) + poorRecord * 12,
+    motivation: Number(player?.motivation ?? team?.staff?.headCoach?.motivation ?? 60),
+    discipline: Number(profile?.discipline ?? 50),
+    week: Number(context?.week ?? 1),
+    phase: String(context?.phase ?? 'regular'),
+  };
+}
+
+export function createEventEntry(type, payload, context = {}) {
+  return {
+    id: `evt_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    type,
+    category: type,
+    headline: payload.headline,
+    body: payload.body,
+    description: payload.description ?? payload.body,
+    playerId: payload.playerId ?? null,
+    teamId: payload.teamId ?? null,
+    staffId: payload.staffId ?? null,
+    actionLabel: payload.actionLabel ?? null,
+    actionTarget: payload.actionTarget ?? null,
+    effects: payload.effects ?? null,
+    priority: payload.priority ?? 'medium',
+    scope: payload.scope ?? (payload.teamId != null ? 'team' : 'league'),
+    phase: context.phase ?? 'regular',
+    week: context.week ?? 1,
+    year: context.year ?? null,
+    timestamp: Date.now(),
+    tooltip: EVENT_TOOLTIPS[type] ?? '',
+  };
+}
+
+export function generateDynamicEvents({ players = [], teams = [], userTeamId = null, week = 1, year = null, phase = 'regular', rng = Math.random } = {}) {
+  const teamById = Object.fromEntries((teams || []).map((t) => [Number(t.id), t]));
+  const candidates = players
+    .filter((p) => Number(p?.teamId) >= 0 && p?.status !== 'retired' && p?.status !== 'draft_eligible')
+    .map((p) => scorePlayer(p, teamById[Number(p.teamId)], { week, phase }))
+    .sort((a, b) => b.volatility - a.volatility)
+    .slice(0, 80);
+
+  const events = [];
+  for (const row of candidates) {
+    const { player, team, volatility, holdoutRisk, discipline, motivation } = row;
+    const profile = player?.personalityProfile ?? {};
+
+    if (phase === 'regular' && holdoutRisk?.shouldHoldout && rng() < clamp((holdoutRisk.score ?? 0) / 1300, 0.01, 0.22)) {
+      events.push(createEventEntry(EVENT_TYPES.HOLDOUT, {
+        headline: `${player.name} skips workouts over contract dispute`,
+        body: `${player.pos} ${player.name} is holding out while talks with ${team?.abbr ?? 'the team'} stall.`,
+        playerId: player.id,
+        teamId: player.teamId,
+        actionLabel: 'Negotiate',
+        actionTarget: 'Contract Center',
+        effects: { morale: -5, negotiationLeverage: 6 },
+        priority: 'high',
+      }, { week, year, phase }));
+    }
+
+    if (phase === 'regular' && rng() < clamp((volatility - discipline) / 5000, 0, 0.08)) {
+      events.push(createEventEntry(EVENT_TYPES.TRADE_DEMAND, {
+        headline: `${player.name} requests a trade`,
+        body: `${player.name} wants a fresh start after mounting frustration with role and results.`,
+        playerId: player.id,
+        teamId: player.teamId,
+        actionLabel: 'View Profile',
+        actionTarget: 'Player',
+        effects: { morale: -4, popularity: -2 },
+      }, { week, year, phase }));
+    }
+
+    if (rng() < clamp((Number(profile?.offFieldRisk ?? 20) - discipline) / 4000, 0, 0.04)) {
+      events.push(createEventEntry(EVENT_TYPES.SUSPENSION, {
+        headline: `${player.name} suspended by league office`,
+        body: `League discipline will sideline ${player.name} for conduct policy violations.`,
+        playerId: player.id,
+        teamId: player.teamId,
+        effects: { morale: -8, popularity: -6 },
+        priority: 'high',
+      }, { week, year, phase }));
+    }
+
+    if (phase === 'regular' && rng() < 0.025) {
+      const storyline = randomOf(rng, ['charity', 'controversy', 'mentoring']);
+      const body = storyline === 'charity'
+        ? `${player.name} funded a local youth football initiative, boosting community support.`
+        : storyline === 'mentoring'
+          ? `${player.name} has become a key mentor in the locker room for younger teammates.`
+          : `${player.name} drew headlines after a controversial media appearance.`;
+      const effects = storyline === 'charity'
+        ? { morale: 2, popularity: 6, negotiationLeverage: -2 }
+        : storyline === 'mentoring'
+          ? { morale: 3, popularity: 2, negotiationLeverage: -1 }
+          : { morale: -3, popularity: -5, negotiationLeverage: 3 };
+      events.push(createEventEntry(EVENT_TYPES.OFF_FIELD, {
+        headline: `${player.name} off-field update`,
+        body,
+        playerId: player.id,
+        teamId: player.teamId,
+        effects,
+        priority: storyline === 'controversy' ? 'medium' : 'low',
+      }, { week, year, phase }));
+    }
+
+    if (events.length >= 10) break;
+  }
+
+  if (phase === 'draft' && rng() < 0.8) {
+    const rumorTeam = randomOf(rng, teams);
+    if (rumorTeam) {
+      events.push(createEventEntry(EVENT_TYPES.DRAFT_RUMOR, {
+        headline: `Draft rumor: ${rumorTeam.abbr} considering aggressive move up`,
+        body: `${rumorTeam.name} is reportedly exploring a trade-up package for a premium prospect.`,
+        teamId: rumorTeam.id,
+        scope: Number(rumorTeam.id) === Number(userTeamId) ? 'team' : 'league',
+      }, { week, year, phase }));
+    }
+  }
+
+  return events.sort((a, b) => b.timestamp - a.timestamp);
+}
+
+function sum(totals = {}, keys = []) {
+  return keys.reduce((acc, key) => acc + Number(totals?.[key] ?? 0), 0);
+}
+
+export function calculateSeasonAwards({ stats = [], teams = [], year = null, coaches = [] } = {}) {
+  const teamById = Object.fromEntries(teams.map((t) => [Number(t.id), t]));
+  const score = (s) => {
+    const wins = Number(teamById[Number(s.teamId)]?.wins ?? 0);
+    return sum(s.totals, ['passYd', 'rushYd', 'recYd']) / 45
+      + sum(s.totals, ['passTD', 'rushTD', 'recTD']) * 7
+      + Number(s.totals?.sacks ?? 0) * 5
+      + Number(s.totals?.interceptions ?? 0) * 6
+      + wins * 2.2;
+  };
+  const sorted = [...stats].sort((a, b) => score(b) - score(a));
+  const best = (arr) => (arr.length ? arr[0] : null);
+
+  const mvp = best(sorted);
+  const roty = best(sorted.filter((row) => Number(row?.age ?? 99) <= 23));
+  const coy = [...teams].sort((a, b) => Number(b.wins ?? 0) - Number(a.wins ?? 0))[0] ?? null;
+
+  const allProOffense = sorted
+    .filter((s) => ['QB', 'RB', 'WR', 'TE', 'LT', 'LG', 'C', 'RG', 'RT'].includes(String(s.pos)))
+    .slice(0, 11)
+    .map((s) => ({ playerId: s.playerId, name: s.name, pos: s.pos, teamId: s.teamId }));
+  const allProDefense = sorted
+    .filter((s) => ['DL', 'DE', 'DT', 'LB', 'CB', 'S'].includes(String(s.pos)))
+    .slice(0, 11)
+    .map((s) => ({ playerId: s.playerId, name: s.name, pos: s.pos, teamId: s.teamId }));
+
+  return {
+    mvp: mvp ? { playerId: mvp.playerId, name: mvp.name, pos: mvp.pos, teamId: mvp.teamId, year } : null,
+    roty: roty ? { playerId: roty.playerId, name: roty.name, pos: roty.pos, teamId: roty.teamId, year } : null,
+    coachOfTheYear: coy ? { coachName: coaches.find((c) => Number(c?.teamId) === Number(coy.id))?.name ?? `${coy.abbr} Staff`, teamId: coy.id, year } : null,
+    allPro: {
+      firstTeamOffense: allProOffense,
+      firstTeamDefense: allProDefense,
+    },
+  };
+}

--- a/src/types/socialFeed.ts
+++ b/src/types/socialFeed.ts
@@ -1,0 +1,42 @@
+export interface EventEffect {
+  morale?: number;
+  popularity?: number;
+  negotiationLeverage?: number;
+}
+
+export interface Event {
+  id: string;
+  type: string;
+  category: string;
+  headline: string;
+  body: string;
+  description: string;
+  playerId: number | null;
+  teamId: number | null;
+  staffId: number | null;
+  actionLabel?: string | null;
+  actionTarget?: string | null;
+  effects?: EventEffect | null;
+  priority: 'high' | 'medium' | 'low';
+  scope: 'team' | 'league';
+  phase: string;
+  week: number;
+  year: number | null;
+  timestamp: number;
+  tooltip?: string;
+}
+
+export interface Award {
+  key: string;
+  season: number;
+  playerId?: number | null;
+  coachName?: string | null;
+  teamId?: number | null;
+  label: string;
+}
+
+export interface SocialFeedEntry extends Event {
+  dateLabel: string;
+  linkedEntityType?: 'player' | 'team' | 'staff' | null;
+  linkedEntityId?: number | null;
+}

--- a/src/ui/components/HomeDashboard.jsx
+++ b/src/ui/components/HomeDashboard.jsx
@@ -11,6 +11,7 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import NewsFeed from './NewsFeed.jsx';
+import SocialFeed from './SocialFeed.jsx';
 import OwnerGoalsPanel from './OwnerGoalsPanel.jsx';
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -1488,6 +1489,7 @@ export default function HomeDashboard({ league, onTeamSelect, onPlayerSelect, on
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
       <NewsFeed league={league} mode="ticker" />
+      <SocialFeed league={league} maxItems={8} onPlayerSelect={(playerId) => onTabChange?.("Roster", { playerId })} />
 
       {/* ── NEW SAVE: Full welcome hero replaces phase banner for first load ── */}
       {isNewSave ? (

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -364,11 +364,7 @@ function getConferenceRankings(teams, confVal) {
   const ci = typeof confVal === "string" ? (confVal === "AFC" ? 0 : 1) : confVal;
   const confTeams = teams
     .filter(t => confIdx(t.conf) === ci)
-    .sort((a, b) => {
-      const pa = parseFloat(winPct(a.wins, a.losses, a.ties));
-      const pb = parseFloat(winPct(b.wins, b.losses, b.ties));
-      return pb - pa || b.wins - a.wins;
-    });
+    .sort(compareStandingRows);
 
   // 7 teams make playoffs: 4 division winners (seeds 1-4) + 3 wild cards (seeds 5-7)
   // For simplicity: top team from each division gets a div seed, rest sorted for WC
@@ -384,6 +380,19 @@ function getConferenceRankings(teams, confVal) {
   const wildcards = confTeams.filter(t => !divWinners.has(t.id));
 
   return { divWinnerList, wildcards, divWinners, confTeams };
+}
+
+function compareStandingRows(a, b) {
+  const pa = parseFloat(winPct(a.wins, a.losses, a.ties));
+  const pb = parseFloat(winPct(b.wins, b.losses, b.ties));
+  if (pb !== pa) return pb - pa;
+  const h2hA = Number(a?.tiebreakers?.headToHeadWinPct ?? a?.headToHeadWinPct ?? 0);
+  const h2hB = Number(b?.tiebreakers?.headToHeadWinPct ?? b?.headToHeadWinPct ?? 0);
+  if (h2hB !== h2hA) return h2hB - h2hA;
+  const divA = Number(a?.tiebreakers?.divisionWinPct ?? a?.divisionWinPct ?? 0);
+  const divB = Number(b?.tiebreakers?.divisionWinPct ?? b?.divisionWinPct ?? 0);
+  if (divB !== divA) return divB - divA;
+  return Number(b?.wins ?? 0) - Number(a?.wins ?? 0);
 }
 
 function PlayoffPictureView({ teams, activeConf, userTeamId, onTeamSelect }) {
@@ -497,9 +506,7 @@ function StandingsTab({ teams, userTeamId, onTeamSelect, leagueSettings }) {
       teams: confTeams
         .filter((t) => divIdx(t.div) === idx)
         .sort((a, b) => {
-          const pa = winPct(a.wins, a.losses, a.ties);
-          const pb = winPct(b.wins, b.losses, b.ties);
-          return pb - pa || b.wins - a.wins;
+          return compareStandingRows(a, b);
         }),
     })).filter((g) => g.teams.length > 0);
 
@@ -704,7 +711,7 @@ function StandingsTab({ teams, userTeamId, onTeamSelect, leagueSettings }) {
       </div>
       )} {/* end playoff/division ternary */}
       <div style={{ marginTop: "var(--space-2)", fontSize: "0.66rem", color: "var(--text-subtle)" }}>
-        PF/PA values are season aggregates and may appear compressed early in the season.
+        Tiebreakers: head-to-head, then division record, then total wins. PF/PA values are season aggregates and may appear compressed early.
       </div>
     </div>
   );

--- a/src/ui/components/LeagueHub.jsx
+++ b/src/ui/components/LeagueHub.jsx
@@ -5,6 +5,7 @@ import PlayerStats from './PlayerStats.jsx';
 import SectionHeader from './SectionHeader.jsx';
 import SectionSubnav from './SectionSubnav.jsx';
 import { buildNewsDeskModel } from '../utils/newsDesk.js';
+import SocialFeed from './SocialFeed.jsx';
 
 const LEAGUE_SUBNAV = ['Schedule', 'Standings', 'Stats', 'Transactions', 'History'];
 
@@ -71,6 +72,7 @@ export default function LeagueHub({ league, actions, onOpenGameDetail, onPlayerS
     <div>
       <SectionHeader title="League" subtitle="League command center" />
       <SectionSubnav items={LEAGUE_SUBNAV} activeItem={subtab} onChange={setSubtab} />
+      <SocialFeed league={league} defaultFilter="league" maxItems={8} onPlayerSelect={onPlayerSelect} />
 
       {subtab === 'Standings' && renderStandings?.()}
       {subtab === 'Schedule' && renderSchedule?.('League')}

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -53,6 +53,7 @@ import { getDepthRows, autoBuildDepthChart, depthWarnings } from "../../core/dep
 import AdvancedPlayerSearch from "./AdvancedPlayerSearch.jsx";
 import { applyAdvancedPlayerFilters } from "../../core/footballAdvancedFilters";
 import { usePlayerCompare } from "../utils/playerCompare.js";
+import SocialFeed from "./SocialFeed.jsx";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -2296,6 +2297,7 @@ export default function Roster({ league, actions, onPlayerSelect, initialState =
           </span>
         </div>
       </CardContent></Card>
+      <SocialFeed league={league} defaultFilter="team" maxItems={5} onPlayerSelect={onPlayerSelect} />
 
       {/* ── Loading state ── */}
       {loading && (

--- a/src/ui/components/SocialFeed.jsx
+++ b/src/ui/components/SocialFeed.jsx
@@ -1,0 +1,67 @@
+import React, { useMemo, useState } from 'react';
+import { EVENT_TOOLTIPS } from '../../core/events/eventSystem.js';
+
+const FILTERS = [
+  { key: 'all', label: 'All' },
+  { key: 'team', label: 'Team' },
+  { key: 'league', label: 'League' },
+];
+
+function formatDate(entry) {
+  if (entry?.year && entry?.week) return `Y${entry.year} · W${entry.week}`;
+  if (entry?.week) return `W${entry.week}`;
+  return 'Now';
+}
+
+export default function SocialFeed({ league, onPlayerSelect, onTeamSelect, defaultFilter = 'all', maxItems = 40 }) {
+  const [filter, setFilter] = useState(defaultFilter);
+  const userTeamId = Number(league?.userTeamId);
+
+  const entries = useMemo(() => {
+    const rows = Array.isArray(league?.newsItems) ? league.newsItems : [];
+    return [...rows]
+      .map((entry) => ({ ...entry, timestamp: Number(entry?.timestamp ?? 0) }))
+      .sort((a, b) => b.timestamp - a.timestamp)
+      .filter((entry) => {
+        if (filter === 'team') return Number(entry?.teamId) === userTeamId;
+        if (filter === 'league') return Number(entry?.teamId) !== userTeamId;
+        return true;
+      })
+      .slice(0, maxItems);
+  }, [league?.newsItems, filter, userTeamId, maxItems]);
+
+  return (
+    <div className="card" style={{ padding: '10px', display: 'grid', gap: 8, maxHeight: 320, overflowY: 'auto' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+        <strong>Social Feed</strong>
+        <div style={{ display: 'flex', gap: 6 }}>
+          {FILTERS.map((item) => (
+            <button key={item.key} className="btn btn-sm" onClick={() => setFilter(item.key)} style={{ opacity: filter === item.key ? 1 : 0.7 }}>
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {entries.length === 0 ? <div style={{ color: 'var(--text-muted)', fontSize: 12 }}>No social stories yet for this save.</div> : null}
+
+      {entries.map((entry, idx) => {
+        const tooltip = entry?.tooltip ?? EVENT_TOOLTIPS[entry?.type] ?? 'League update.';
+        return (
+          <div key={entry?.id ?? `${entry?.headline ?? 'entry'}-${idx}`} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: '8px 10px', display: 'grid', gap: 4 }} title={tooltip}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'baseline' }}>
+              <strong style={{ fontSize: 13 }}>{entry?.headline ?? entry?.text ?? 'Update'}</strong>
+              <span style={{ fontSize: 11, color: 'var(--text-subtle)' }}>{formatDate(entry)}</span>
+            </div>
+            {entry?.body || entry?.description ? <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{entry?.body ?? entry?.description}</div> : null}
+            <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+              {entry?.actionLabel && entry?.actionTarget ? <span className="badge" title={`Suggested action: ${entry.actionTarget}`}>{entry.actionLabel}</span> : null}
+              {entry?.playerId != null ? <button className="btn btn-sm" onClick={() => onPlayerSelect?.(entry.playerId)}>View Profile</button> : null}
+              {entry?.teamId != null ? <button className="btn btn-sm" onClick={() => onTeamSelect?.(entry.teamId)}>Team</button> : null}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/ui/components/TeamHub.jsx
+++ b/src/ui/components/TeamHub.jsx
@@ -4,6 +4,7 @@ import ContractCenter from './ContractCenter.jsx';
 import StaffManagement from './StaffManagement.jsx';
 import SectionHeader from './SectionHeader.jsx';
 import SectionSubnav from './SectionSubnav.jsx';
+import SocialFeed from './SocialFeed.jsx';
 import { derivePlayerContractFinancials } from '../utils/contractFormatting.js';
 import { deriveTeamCapSnapshot, formatMoneyM } from '../utils/numberFormatting.js';
 
@@ -225,6 +226,7 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
 
       {subtab === 'Overview' && (
         <div style={{ display: 'grid', gap: 'var(--space-2)' }}>
+          <SocialFeed league={league} defaultFilter="team" maxItems={6} onPlayerSelect={onPlayerSelect} />
           <div className="card" style={{ padding: '10px' }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'baseline', flexWrap: 'wrap' }}>
               <div style={{ fontSize: 11, color: 'var(--text-muted)' }}>TEAM SNAPSHOT</div>

--- a/src/ui/components/__tests__/SocialFeed.test.jsx
+++ b/src/ui/components/__tests__/SocialFeed.test.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import SocialFeed from '../SocialFeed.jsx';
+
+describe('SocialFeed', () => {
+  it('renders feed entries and action buttons', () => {
+    const html = renderToString(
+      <SocialFeed
+        league={{
+          userTeamId: 1,
+          newsItems: [{
+            id: 'evt-1',
+            type: 'holdout',
+            headline: 'Star WR skips workouts',
+            body: 'Negotiations stalled.',
+            teamId: 1,
+            playerId: 7,
+            actionLabel: 'Negotiate',
+            actionTarget: 'Contract Center',
+            week: 5,
+            year: 2027,
+            timestamp: Date.now(),
+          }],
+        }}
+      />,
+    );
+
+    expect(html).toContain('Social Feed');
+    expect(html).toContain('Star WR skips workouts');
+    expect(html).toContain('View Profile');
+  });
+});

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -127,6 +127,7 @@ import {
   summarizeWhyTeamWon,
 } from '../core/gameSummary.js';
 import { getScoutingRangeFromProfile, scoreDraftBoardEntry } from '../core/draft/draftScouting.js';
+import { generateDynamicEvents, calculateSeasonAwards } from '../core/events/eventSystem.js';
 
 // ── DB Reload Guard ───────────────────────────────────────────────────────────
 // Register a callback with db/index.js so that when IDB fires onblocked or
@@ -176,6 +177,26 @@ function getLeagueSetting(key, fallback = null) {
   const meta = getSafeMeta();
   const settings = normalizeLeagueSettings(meta?.settings ?? {});
   return settings?.[key] ?? fallback;
+}
+
+function applyDynamicEventEffects(events = []) {
+  for (const evt of events) {
+    const playerId = evt?.playerId;
+    if (playerId == null) continue;
+    const player = cache.getPlayer(playerId);
+    if (!player) continue;
+    const effects = evt?.effects ?? {};
+    const moraleDelta = Number(effects?.morale ?? 0);
+    const popularityDelta = Number(effects?.popularity ?? 0);
+    const negotiationDelta = Number(effects?.negotiationLeverage ?? 0);
+    cache.updatePlayer(playerId, {
+      morale: Math.max(0, Math.min(100, Number(player?.morale ?? 50) + moraleDelta)),
+      popularity: Math.max(0, Math.min(100, Number(player?.popularity ?? 50) + popularityDelta)),
+      contractMoodModifier: Number(player?.contractMoodModifier ?? 0) + negotiationDelta,
+      holdoutStatus: evt?.type === 'holdout' ? 'active' : player?.holdoutStatus ?? null,
+      tradeRequestActive: evt?.type === 'trade_demand' ? true : player?.tradeRequestActive ?? false,
+    });
+  }
 }
 
 const SIM_SESSION_STAGES = Object.freeze([
@@ -2297,32 +2318,22 @@ if (res.injuries && res.injuries.length > 0) {
     cache.setMeta({ currentWeek: nextWeekNum });
   }
 
-  // Phase 4 Opus: Narrative Events
-  if (meta.phase === 'regular' || meta.phase === 'preseason') {
-      const userRoster = cache.getPlayersByTeam(meta.userTeamId);
-      const team = cache.getTeam(meta.userTeamId);
-      for (const p of userRoster) {
-          const isDivisive = p.personality?.traits?.includes('Divisive');
-          const holdoutProb = isDivisive ? 0.03 : 0.01;
-          const conductProb = isDivisive ? 0.02 : 0.005;
-          const holdout = estimateHoldoutRisk(p, { wins: team?.wins ?? 0 });
-
-          // chance per week for low morale / underpaid stars to holdout
-          if ((holdout.shouldHoldout || (p.morale < 30 && p.ovr > 80)) && Math.random() < Math.max(holdoutProb, holdout.score / 4000)) {
-              await NewsEngine.logNarrative(p, 'HOLDOUT', team?.abbr || 'FA');
-              cache.updatePlayer(p.id, {
-                morale: Math.max(0, Number(p?.morale ?? 50) - 6),
-                holdoutRisk: holdout.score,
-                holdoutStatus: 'active',
-              });
-          }
-          // chance per week for any player to get a conduct fine
-          if (Math.random() < conductProb) {
-              await NewsEngine.logNarrative(p, 'CONDUCT', team?.abbr || 'FA');
-              // Apply morale hit
-              cache.updatePlayer(p.id, { morale: Math.max(0, p.morale - 10) });
-          }
-      }
+  // Dynamic event engine: contextual stories and contract friction.
+  if (meta.phase === 'regular' || meta.phase === 'preseason' || meta.phase === 'draft') {
+    const dynamicEvents = generateDynamicEvents({
+      players: cache.getAllPlayers(),
+      teams: cache.getAllTeams(),
+      userTeamId: meta?.userTeamId,
+      week,
+      year: meta?.year,
+      phase: meta?.phase,
+    });
+    applyDynamicEventEffects(dynamicEvents);
+    let currentMeta = cache.getMeta();
+    for (const event of dynamicEvents) {
+      currentMeta = addNewsItem(currentMeta, event);
+    }
+    cache.setMeta({ newsItems: currentMeta.newsItems });
   }
 
   // --- AI-to-AI Trades (regular season only) ---
@@ -7180,6 +7191,20 @@ async function handleAdvanceFreeAgencyDay(payload, id) {
 
     // Process Day
     await AiLogic.processFreeAgencyDay(day);
+    const faEvents = generateDynamicEvents({
+      players: cache.getAllPlayers(),
+      teams: cache.getAllTeams(),
+      userTeamId: meta?.userTeamId,
+      week: meta?.currentWeek ?? 1,
+      year: meta?.year,
+      phase: 'free_agency',
+    });
+    applyDynamicEventEffects(faEvents);
+    let faMeta = cache.getMeta();
+    for (const event of faEvents) {
+      faMeta = addNewsItem(faMeta, event);
+    }
+    cache.setMeta({ newsItems: faMeta.newsItems });
 
     // Increment Day
     const nextDay = day + 1;
@@ -7323,7 +7348,15 @@ async function archiveSeason(seasonId) {
     const leaders = calculateLeaders(populatedStats);
 
     // 7. Awards
-    const awards = calculateAwards(populatedStats, teams);
+    const legacyAwards = calculateAwards(populatedStats, teams);
+    const staffRows = teams.map((t) => ({ teamId: t.id, name: t?.staff?.headCoach?.name ?? `${t?.abbr ?? 'Team'} HC` }));
+    const seasonAwards = calculateSeasonAwards({ stats: populatedStats, teams, year, coaches: staffRows });
+    const awards = {
+      ...legacyAwards,
+      ...seasonAwards,
+      roty: seasonAwards?.roty ?? legacyAwards?.roty ?? null,
+      allPro: seasonAwards?.allPro ?? { firstTeamOffense: [], firstTeamDefense: [] },
+    };
 
     // 8. Write accolades to player objects
     const year = meta.year;
@@ -7341,6 +7374,15 @@ async function archiveSeason(seasonId) {
     }
     if (awards.roty?.playerId != null) {
       await grantAccolade(awards.roty.playerId, { type: 'ROTY', year, seasonId });
+    }
+    if (awards.coachOfTheYear?.teamId != null) {
+      const coachTeam = cache.getTeam(awards.coachOfTheYear.teamId);
+      await NewsEngine.logNews(
+        'AWARD',
+        `${awards.coachOfTheYear.coachName} wins Coach of the Year after leading ${coachTeam?.abbr ?? 'their team'} to ${coachTeam?.wins ?? 0} wins.`,
+        awards.coachOfTheYear.teamId,
+        { category: 'award', awardType: 'coach_of_the_year' },
+      );
     }
 
     // SB Rings: all players on champion team


### PR DESCRIPTION
### Motivation
- Provide an ongoing narrative layer so each season produces contextual stories (holdouts, trade demands, suspensions, off-field moments, draft rumours) tied to player traits and team context.
- Surface those stories to the player via a persistent, filterable social feed and optional CTA actions to increase engagement without blocking the UI.
- Compute richer end-of-season awards and Hall-of-Fame inputs in the worker so historical records and leaderboards are complete and consistent.

### Description
- Added a worker-side dynamic event engine at `src/core/events/eventSystem.js` that generates contextual events (holdouts, trade demands, suspensions, off-field storylines, draft rumors) and exports `generateDynamicEvents` and `calculateSeasonAwards` along with tooltip metadata and deterministic RNG hooks.  New TS interfaces added in `src/types/socialFeed.ts`.
- Integrated event generation into the Shared Worker: weekly advance and free-agency day paths call `generateDynamicEvents`, effects are applied to players via `applyDynamicEventEffects` (morale/popularity/contract mood/holdout/trade flags), and generated events are merged into persistent `newsItems` via `addNewsItem` (`src/worker/worker.js`).
- Extended end-of-season processing to run `calculateSeasonAwards` (MVP, ROTY, Coach of the Year, All-Pro teams) and merged those results with the existing awards flow so accolades are persisted and news items are logged.
- Added a new UI component `SocialFeed` (`src/ui/components/SocialFeed.jsx`) with chronological ordering, filters (All/Team/League), date labels, contextual tooltips, linked entity buttons (View Profile / Team) and optional action chips; wired it into `HomeDashboard`, `TeamHub`, `LeagueHub`, and `Roster` so the feed is visible across the main surfaces.
- Kept all UI/worker separation: event logic and award computation run in the Shared Worker while `SocialFeed` reads `newsItems` from the league view-model; existing saves default to empty feed arrays via `ensureDynastyMeta` changes.
- Minor UX and rules polish: added explicit tiebreaker ordering (head-to-head → division record → total wins) and explanatory text in the standings component (`src/ui/components/LeagueDashboard.jsx`).
- Tests and scaffolding: unit tests added for event generation and season award calculations (`src/core/__tests__/eventSystem.test.js`) and for SocialFeed rendering (`src/ui/components/__tests__/SocialFeed.test.jsx`).

### Testing
- Ran targeted unit tests with Vitest: `npm run test:unit -- src/core/__tests__/eventSystem.test.js src/ui/components/__tests__/SocialFeed.test.jsx src/ui/utils/newsDesk.test.js` and all tests passed.
- Ran additional contract-related unit tests: `npm run test:unit -- src/core/__tests__/realisticContracts.test.js` which also passed.
- No new production dependencies were introduced; changes preserve backward compatibility by defaulting missing feed/history fields to empty arrays.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddc40567e4832d8091999376ad2005)