### PR TITLE
Fix legacy save-load regression from contract/cap normalization rollout

### DIFF
--- a/src/core/__tests__/realisticContracts.test.js
+++ b/src/core/__tests__/realisticContracts.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   normalizeContractDetails,
+  repairLegacyPlayerContract,
   calculateContractCapHit,
   estimateHoldoutRisk,
   calculateTeamPayroll,
@@ -18,6 +19,43 @@ describe('realistic contract normalization', () => {
   it('includes likely incentives in cap hit', () => {
     const capHit = calculateContractCapHit({ yearsTotal: 4, baseAnnual: 24, signingBonus: 8, incentives: [{ amount: 2, capTreatment: 'likely' }, { amount: 3, capTreatment: 'unlikely' }] });
     expect(capHit).toBe(28);
+  });
+
+  it('repairs legacy flat-contract players without inflating annual salary', () => {
+    const repaired = repairLegacyPlayerContract({
+      id: 1,
+      years: 4,
+      yearsTotal: 4,
+      salary: 88, // legacy total-deal value
+      signingBonus: 8,
+    });
+    expect(repaired.contract.baseAnnual).toBe(22);
+    expect(calculateContractCapHit(repaired.contract)).toBe(24);
+  });
+
+  it('prefers canonical nested contract and avoids double counting signing bonus', () => {
+    const repaired = repairLegacyPlayerContract({
+      id: 2,
+      years: 4,
+      yearsTotal: 4,
+      baseAnnual: 18,
+      signingBonus: 12,
+      contract: { yearsTotal: 4, baseAnnual: 26, signingBonus: 8 },
+    });
+    expect(repaired.contract.baseAnnual).toBe(26);
+    expect(repaired.contract.signingBonus).toBe(8);
+    expect(calculateContractCapHit(repaired.contract)).toBe(28);
+  });
+
+  it('repairs corrupted contract values with conservative defaults', () => {
+    const repaired = repairLegacyPlayerContract({
+      id: 3,
+      contract: { yearsTotal: -9, yearsRemaining: 99, baseAnnual: 'bad', signingBonus: -20 },
+    });
+    expect(repaired.contract.yearsTotal).toBe(1);
+    expect(repaired.contract.yearsRemaining).toBe(1);
+    expect(repaired.contract.baseAnnual).toBe(0);
+    expect(repaired.contract.signingBonus).toBe(0);
   });
 });
 
@@ -43,6 +81,21 @@ describe('holdout and payroll rules', () => {
     });
     expect(payroll.overCap).toBe(true);
     expect(payroll.belowFloor).toBe(false);
+  });
+
+  it('includes staff payroll and dead cap exactly once', () => {
+    const payroll = calculateTeamPayroll({
+      roster: [
+        { contract: { yearsTotal: 4, baseAnnual: 20, signingBonus: 8 } }, // 22
+        { contract: { yearsTotal: 2, baseAnnual: 10, signingBonus: 0 } }, // 10
+      ],
+      staffPayroll: 15,
+      deadCap: 5,
+      capLimit: 80,
+    });
+    expect(payroll.playerPayroll).toBe(32);
+    expect(payroll.totalPayroll).toBe(52);
+    expect(payroll.capSpace).toBe(28);
   });
 });
 

--- a/src/core/__tests__/teamValidation.load.test.js
+++ b/src/core/__tests__/teamValidation.load.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { validateLeagueTeamLegality } from '../teamValidation.js';
+
+describe('team validation load-time cap behavior', () => {
+  it('reports cap violations as warnings when requested', () => {
+    const result = validateLeagueTeamLegality({
+      teams: [{ id: 1, abbr: 'BUF', deadCap: 0 }],
+      players: [{ id: 10, teamId: 1, contract: { yearsTotal: 4, baseAnnual: 100, signingBonus: 0 } }],
+      hardCap: 50,
+      capViolationSeverity: 'warn',
+    });
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].code).toBe('cap_limit');
+    expect(result.issues[0].severity).toBe('warn');
+  });
+});
+

--- a/src/core/contracts/realisticContracts.js
+++ b/src/core/contracts/realisticContracts.js
@@ -61,6 +61,11 @@ function clamp(v, min, max) {
   return Math.max(min, Math.min(max, v));
 }
 
+function hasFinite(v) {
+  return Number.isFinite(Number(v));
+}
+
+
 function normalizeIncentives(incentives = []) {
   if (!Array.isArray(incentives)) return [];
   return incentives
@@ -102,6 +107,78 @@ export function normalizeContractDetails(contract = {}, player = {}) {
     fifthYearOptionExercised: !!contract?.fifthYearOptionExercised,
     restrictedFreeAgent: !!contract?.restrictedFreeAgent,
     incentives: normalizeIncentives(contract?.incentives),
+  };
+}
+
+function scoreContractSource(source = {}) {
+  let score = 0;
+  if (hasFinite(source?.baseAnnual)) score += 4;
+  if (hasFinite(source?.signingBonus)) score += 2;
+  if (hasFinite(source?.yearsTotal ?? source?.years)) score += 2;
+  if (hasFinite(source?.yearsRemaining)) score += 1;
+  if (Array.isArray(source?.incentives) && source.incentives.length > 0) score += 1;
+  return score;
+}
+
+function deriveAnnualFromLegacy(rawAnnual, yearsTotal) {
+  const annual = Math.max(0, n(rawAnnual, 0));
+  if (annual <= 80) return annual;
+  if (yearsTotal > 1) {
+    // Older saves sometimes persisted total value into "salary/amount".
+    // If the value is implausibly large for one year, conservatively treat
+    // it as a total deal value and convert to annual.
+    return annual / yearsTotal;
+  }
+  return annual;
+}
+
+export function repairLegacyPlayerContract(player = {}) {
+  const nested = (player?.contract && typeof player.contract === 'object') ? player.contract : {};
+  const inferredYearsTotal = Math.max(1, Math.round(n(
+    nested?.yearsTotal ?? nested?.years ?? player?.yearsTotal ?? player?.years ?? 1,
+    1,
+  )));
+
+  const nestedAnnualCandidate = nested?.baseAnnual ?? nested?.salary ?? nested?.amount ?? nested?.capHit;
+  const flatAnnualCandidate = player?.baseAnnual ?? player?.salary ?? player?.amount ?? player?.capHit;
+
+  const flat = {
+    yearsTotal: player?.yearsTotal ?? player?.years ?? inferredYearsTotal,
+    yearsRemaining: player?.yearsRemaining ?? player?.years,
+    baseAnnual: deriveAnnualFromLegacy(flatAnnualCandidate, inferredYearsTotal),
+    signingBonus: player?.signingBonus ?? player?.bonus ?? 0,
+    guaranteedPct: player?.guaranteedPct,
+  };
+
+  const nestedForScore = {
+    ...nested,
+    baseAnnual: deriveAnnualFromLegacy(nestedAnnualCandidate, inferredYearsTotal),
+  };
+
+  const nestedScore = scoreContractSource(nestedForScore);
+  const flatScore = scoreContractSource(flat);
+  const nestedHasCore = hasFinite(nestedForScore?.baseAnnual) || hasFinite(nestedForScore?.salary) || hasFinite(nestedForScore?.amount);
+  const useNested = nestedHasCore ? nestedScore >= (flatScore - 1) : nestedScore >= flatScore;
+  const source = useNested ? nestedForScore : flat;
+  const normalized = normalizeContractDetails(source, player);
+
+  return {
+    ...player,
+    contract: normalized,
+    // Keep legacy flat fields in sync for backward compatibility with old paths.
+    baseAnnual: normalized.baseAnnual,
+    signingBonus: normalized.signingBonus,
+    years: normalized.yearsRemaining,
+    yearsTotal: normalized.yearsTotal,
+    guaranteedPct: normalized.guaranteedPct,
+  };
+}
+
+export function normalizeLoadedLeagueContracts(league = {}) {
+  const players = Array.isArray(league?.players) ? league.players : [];
+  return {
+    ...league,
+    players: players.map((player) => repairLegacyPlayerContract(player)),
   };
 }
 

--- a/src/core/teamValidation.js
+++ b/src/core/teamValidation.js
@@ -28,7 +28,13 @@ function buildTeamPlayerMap(players = []) {
   return byTeam;
 }
 
-export function validateLeagueTeamLegality({ teams = [], players = [], phase = 'regular', hardCap = Constants.SALARY_CAP.HARD_CAP } = {}) {
+export function validateLeagueTeamLegality({
+  teams = [],
+  players = [],
+  phase = 'regular',
+  hardCap = Constants.SALARY_CAP.HARD_CAP,
+  capViolationSeverity = 'error',
+} = {}) {
   const byTeam = buildTeamPlayerMap(players);
   const rosterLimit = getRosterLimitForPhase(phase);
   const issues = [];
@@ -45,7 +51,12 @@ export function validateLeagueTeamLegality({ teams = [], players = [], phase = '
 
     const projectedCap = roster.reduce((sum, p) => sum + getPlayerCapHit(p), 0) + Number(team?.deadCap ?? 0);
     if (projectedCap > Number(hardCap)) {
-      issues.push({ severity: 'error', teamId, code: 'cap_limit', message: `${team?.abbr ?? team?.name ?? `Team ${teamId}`} is over cap (${projectedCap.toFixed(1)}M / ${Number(hardCap).toFixed(1)}M).` });
+      issues.push({
+        severity: capViolationSeverity === 'warn' ? 'warn' : 'error',
+        teamId,
+        code: 'cap_limit',
+        message: `${team?.abbr ?? team?.name ?? `Team ${teamId}`} is over cap (${projectedCap.toFixed(1)}M / ${Number(hardCap).toFixed(1)}M).`,
+      });
     }
 
     if (uniqueIds.size !== rosterIds.length) {

--- a/src/worker/__tests__/loadPipelineRegression.test.js
+++ b/src/worker/__tests__/loadPipelineRegression.test.js
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('load pipeline regression guards', () => {
+  it('does not reference removed contract normalization helper in load path', () => {
+    const workerSource = readFileSync(resolve(process.cwd(), 'src/worker/worker.js'), 'utf8');
+    expect(workerSource.includes('normalizeContract(p)')).toBe(false);
+    expect(workerSource.includes('normalizeContractLoading')).toBe(false);
+  });
+});
+

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -82,7 +82,14 @@ import {
 import { getTeamContextForNegotiation } from '../core/teamContext/negotiationContext.js';
 import { evaluateContractOffer, summarizeNegotiationStance } from '../core/contracts/negotiation.js';
 import { computeRestructureOutcome, shouldPreserveChemistryOnReturn, isContractRestructureEligible } from '../core/contracts/restructure.js';
-import { normalizeContractDetails, calculateContractCapHit, calculateTeamPayroll, estimateHoldoutRisk, projectTeamFinancials } from '../core/contracts/realisticContracts.js';
+import {
+  normalizeContractDetails,
+  repairLegacyPlayerContract,
+  calculateContractCapHit,
+  calculateTeamPayroll,
+  estimateHoldoutRisk,
+  projectTeamFinancials,
+} from '../core/contracts/realisticContracts.js';
 import { summarizePlayerMood } from '../core/mood/playerMood.js';
 import { getFreeAgencyDecisionState } from '../core/freeAgency/decisionState.js';
 import {
@@ -256,7 +263,7 @@ function validateLeagueFlowState({ stage = 'runtime', requireDraftState = false 
       issues.push(`[${stage}] player ${p?.id} has invalid status/team linkage`);
       break;
     }
-    const c = normalizeContract(p);
+    const c = normalizeContractDetails(p?.contract ?? {}, p);
     if (![c.baseAnnual, c.signingBonus, c.yearsTotal].every(Number.isFinite)) {
       issues.push(`[${stage}] player ${p?.id} has invalid contract numbers`);
       break;
@@ -268,6 +275,7 @@ function validateLeagueFlowState({ stage = 'runtime', requireDraftState = false 
     players,
     phase: meta?.phase,
     hardCap: Number(getLeagueSetting('salaryCap', Constants.SALARY_CAP.HARD_CAP)),
+    capViolationSeverity: stage === 'load-save' || stage === 'post-load' ? 'warn' : 'error',
   });
   for (const issue of legality.issues.slice(0, 6)) issues.push(`[${stage}] ${issue.message}`);
 
@@ -458,6 +466,49 @@ function repairRosterAndTeamLinks({ reason = 'load' } = {}) {
       level: 'info',
       message: `Repaired roster links for ${repairedTeams} team${repairedTeams === 1 ? '' : 's'} (${reason}).`,
     });
+  }
+}
+
+function repairLegacyPlayerContractsOnLoad({ userTeamId = null } = {}) {
+  const userTeamNum = Number(userTeamId);
+  let repairedCount = 0;
+  let userTeamExampleBefore = null;
+  let userTeamExampleAfter = null;
+
+  for (const player of cache.getAllPlayers()) {
+    const before = {
+      baseAnnual: player?.baseAnnual,
+      signingBonus: player?.signingBonus,
+      years: player?.years,
+      yearsTotal: player?.yearsTotal,
+      contract: player?.contract ?? null,
+    };
+    const repaired = repairLegacyPlayerContract(player);
+    const after = {
+      baseAnnual: repaired?.baseAnnual,
+      signingBonus: repaired?.signingBonus,
+      years: repaired?.years,
+      yearsTotal: repaired?.yearsTotal,
+      contract: repaired?.contract ?? null,
+    };
+    const changed = JSON.stringify(before) !== JSON.stringify(after);
+    if (changed) {
+      repairedCount += 1;
+      cache.updatePlayer(player.id, repaired);
+    }
+
+    if (Number(player?.teamId) === userTeamNum && !userTeamExampleBefore) {
+      userTeamExampleBefore = before;
+      userTeamExampleAfter = after;
+    }
+  }
+
+  if (isDev) {
+    console.info(`[load-save] repaired legacy contracts: ${repairedCount}`);
+    if (userTeamExampleBefore) {
+      console.info('[load-save] user team contract sample (before)', userTeamExampleBefore);
+      console.info('[load-save] user team contract sample (after)', userTeamExampleAfter);
+    }
   }
 }
 
@@ -1411,12 +1462,13 @@ async function handleLoadSave({ leagueId }, id) {
       // salary as flat fields rather than inside a contract object) display
       // the correct Cap Used / Cap Room values immediately on load.
       repairRosterAndTeamLinks({ reason: 'load-save' });
+      repairLegacyPlayerContractsOnLoad({ userTeamId: meta?.userTeamId });
       for (const team of cache.getAllTeams()) {
-        recalculateTeamCap(team.id);
+        recalculateTeamCap(team.id, { debugReason: 'load-save' });
         const normalizedStaff = ensureTeamStaff(team, { year: Number(meta?.year ?? 2025) });
         cache.updateTeam(team.id, { staff: normalizedStaff, ...deriveTeamUnitRatings(team.id) });
       }
-      runLegalityValidation({ stage: 'load-save', notify: true });
+      const loadLegality = runLegalityValidation({ stage: 'load-save', notify: true });
 
       // Migration/defaulting for league customization + commissioner metadata.
       const normalizedEconomy = normalizeLeagueEconomy(meta?.economy ?? {}, { year: meta?.year });
@@ -1462,7 +1514,17 @@ async function handleLoadSave({ leagueId }, id) {
         cache.setMeta({ schedule: meta.schedule });
       }
 
-      validateLeagueFlowState({ stage: 'post-load', requireDraftState: meta?.phase === 'draft' });
+      const flowValidation = validateLeagueFlowState({ stage: 'post-load', requireDraftState: meta?.phase === 'draft' });
+      const blockingIssues = [
+        ...(loadLegality?.issues ?? []),
+        ...(flowValidation?.issues ?? []),
+      ].filter((issue) => {
+        if (typeof issue === 'string') return true;
+        return issue?.severity === 'error' && issue?.code !== 'cap_limit';
+      });
+      if (blockingIssues.length > 0) {
+        throw new Error(`Save load aborted: ${String(blockingIssues[0]?.message ?? blockingIssues[0])}`);
+      }
 
       // Auto-generate draft class if save is in draft phase but prospects are missing.
       // This guards against iOS saves where the worker restarted mid-draft.
@@ -1487,11 +1549,13 @@ async function handleLoadSave({ leagueId }, id) {
       // a different format; the Schedule tab handles missing data gracefully so
       // we must NOT block the UI in an infinite spinner waiting for it.
       const viewState = buildViewState();
-      const isComplete = viewState.seasonId != null && viewState.teams.length > 0;
+      const isComplete = viewState.seasonId != null
+        && viewState.teams.length > 0
+        && viewState.userTeamId != null
+        && viewState.teams.some((t) => Number(t?.id) === Number(viewState.userTeamId));
 
       if (!isComplete) {
-        console.warn('[Worker] LOAD_SAVE: view state incomplete after hydration', viewState);
-        post(toUI.NOTIFICATION, { level: 'warn', message: 'Save data partially loaded — some features may be unavailable.' });
+        throw new Error('Save load aborted: playable league state is incomplete after validation.');
       }
 
       post(toUI.FULL_STATE, viewState, id);
@@ -5942,7 +6006,7 @@ async function handleUpdateStrategy({ offPlanId, defPlanId, riskId, starTargetId
 
 // ── Cap helper ────────────────────────────────────────────────────────────────
 
-function recalculateTeamCap(teamId) {
+function recalculateTeamCap(teamId, { debugReason = '' } = {}) {
   const players = cache.getPlayersByTeam(teamId);
   const team = cache.getTeam(teamId);
   if (!team) return;
@@ -5996,6 +6060,16 @@ function recalculateTeamCap(teamId) {
     deadMoneyNextYear: Math.round(deadMoneyNextYear * 100) / 100,
     financials,
   });
+
+  if (isDev && debugReason === 'load-save') {
+    console.info(`[load-save] ${team?.abbr ?? team?.name ?? teamId} payroll`, {
+      playerPayroll: payroll.playerPayroll,
+      staffPayroll: payroll.staffPayroll,
+      deadCap: payroll.deadCap,
+      totalPayroll: payroll.totalPayroll,
+      capTotal,
+    });
+  }
 }
 
 // Alias for backward compatibility if needed, but we should replace calls.
@@ -6012,6 +6086,7 @@ function runLegalityValidation({ stage = 'action', teamIds = null, notify = fals
     players: cache.getAllPlayers(),
     phase: meta?.phase,
     hardCap: Number(getLeagueSetting('salaryCap', Constants.SALARY_CAP.HARD_CAP)),
+    capViolationSeverity: stage === 'load-save' ? 'warn' : 'error',
   });
   if (notify && result.issues.length > 0) {
     const first = result.issues[0];


### PR DESCRIPTION
### Motivation
- Recent realistic contracts / cap changes caused legacy saves to be mis-hydrated (flat vs nested salary shapes), inflating payroll and triggering load-time cap errors and an undefined helper reference in the worker load path. 
- The load pipeline currently published a partial dashboard even when validation failed, leaving the UI stuck in a half-hydrated state.

### Description
- Add canonical repair helpers in `src/core/contracts/realisticContracts.js`: `repairLegacyPlayerContract(player)` and `normalizeLoadedLeagueContracts(league)` to merge mixed legacy flat/nested shapes, derive annual from legacy total values conservatively, clamp `yearsRemaining`, and avoid double-counting signing bonuses.
- Integrate load-time repair in the worker (`src/worker/worker.js`): `repairLegacyPlayerContractsOnLoad()` runs after roster links repair and before cap recalculation; cap is recalculated from repaired contracts; worker now gates publishing `FULL_STATE` behind deterministic validation so partial dashboards are not shown on unrecoverable errors.
- Replace stale/missing helper usage in validation path by using `normalizeContractDetails(...)` directly and remove references to `normalizeContract(...)`/`normalizeContractLoading` in the load path to eliminate the undefined-reference error.
- Make cap-limit findings load-safe by adding `capViolationSeverity` to `validateLeagueTeamLegality` (`src/core/teamValidation.js`) and surfacing cap violations as `warn` during load while keeping hard `error` behavior for normal gameplay stages.
- Add temporary dev debug logs for load triage: repaired contract count and a user-team before/after sample, plus per-team payroll breakdown during load; and minor refactors to `recalculateTeamCap` to accept a `debugReason`.
- Added/updated unit tests to cover the regression scenarios in `src/core/__tests__/realisticContracts.test.js`, `src/core/__tests__/teamValidation.load.test.js`, and `src/worker/__tests__/loadPipelineRegression.test.js`.

### Testing
- Ran targeted unit tests with `npm run test:unit -- src/core/__tests__/realisticContracts.test.js src/core/__tests__/teamValidation.load.test.js src/worker/__tests__/loadPipelineRegression.test.js` and all tests passed (11 tests across the three files).
- Added tests that assert legacy flat-contract repair does not inflate annual salary, nested+flat preference avoids double-counting, corrupted-contract conservative defaults, staff/dead-cap payroll composition, load-time cap warnings, and that the worker load path contains no removed helper references.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddd219430c832da231867e0edf3029)