### PR TITLE
Fix Week 1 simulation gating and debounce depth-chart saves; add HQ Set Lineup shortcut

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { evaluateWeeklyContext } from "../utils/weeklyContext.js";
 import { deriveTeamCapSnapshot, formatMoneyM } from "../utils/numberFormatting.js";
@@ -6,6 +6,7 @@ import { getHQViewModel } from "../../state/selectors.js";
 import { buildCompletedGamePresentation } from "../utils/boxScoreAccess.js";
 import { EmptyState, SectionCard, StatCard, TeamChip } from "./common/UiPrimitives.jsx";
 import { getRecentGames as getArchivedRecentGames } from "../../core/archive/gameArchive.ts";
+import { autoBuildDepthChart, depthWarnings } from "../../core/depthChart.js";
 
 function safeNum(value, fallback = 0) {
   const n = Number(value);
@@ -43,6 +44,7 @@ function toneAccent(tone) {
 
 export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeamSelect, onAdvanceWeek, busy, simulating }) {
   const vm = useMemo(() => getHQViewModel(league), [league]);
+  const [lineupToast, setLineupToast] = useState(null);
   const weekly = useMemo(() => evaluateWeeklyContext(vm.league), [vm.league]);
   const nextGame = useMemo(() => getNextGame(vm.league), [vm.league]);
   const latestArchived = useMemo(() => getArchivedRecentGames(1)?.[0] ?? null, [vm.league?.seasonId, vm.league?.week]);
@@ -95,6 +97,24 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
       awayScore: latestArchived?.score?.away,
     }, { seasonId: vm.league?.seasonId, week: Number(latestArchived?.week ?? vm.league?.week ?? 1), source: "hq_last_game" })
     : null;
+  const handleSetLineup = () => {
+    const roster = Array.isArray(team?.roster) ? team.roster : [];
+    const existingAssignments = {};
+    for (const player of roster) {
+      const rowKey = player?.depthChart?.rowKey;
+      if (!rowKey) continue;
+      if (!existingAssignments[rowKey]) existingAssignments[rowKey] = [];
+      existingAssignments[rowKey].push(player.id);
+    }
+    const assignments = autoBuildDepthChart(roster, existingAssignments);
+    const warnings = depthWarnings(assignments, roster);
+    const hasBlockingLineupIssue = warnings.some((warning) => warning.level === "error");
+    setLineupToast(hasBlockingLineupIssue
+      ? "Depth chart still has missing starters. Fix red-warning rows to finalize lineup."
+      : "Lineup is valid. Opening depth chart.");
+    window.setTimeout(() => setLineupToast(null), 2200);
+    onNavigate?.("Roster:depth|ALL");
+  };
 
   return (
     <div className="app-screen-stack franchise-hq" style={{ display: "grid", gap: "var(--space-3)" }}>
@@ -130,9 +150,10 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
           <div style={{ display: "grid", gap: 8 }}>
             <div style={{ fontSize: "var(--text-lg)", fontWeight: 800 }}>Week {nextGame.week} · {nextGame.isHome ? "vs" : "@"} <TeamChip team={nextGame.opp} /></div>
             <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-              <Button size="sm" onClick={() => onNavigate?.("Team")}>Set lineup</Button>
+              <Button size="sm" onClick={handleSetLineup}>Set lineup</Button>
               <Button size="sm" variant="outline" onClick={() => onNavigate?.("Game Plan")}>Game plan</Button>
             </div>
+            {lineupToast ? <div style={{ fontSize: "var(--text-xs)", color: "var(--accent)" }}>{lineupToast}</div> : null}
           </div>
         ) : <div style={{ color: "var(--text-muted)" }}>No upcoming game found.</div>}
       </SectionCard>

--- a/src/ui/components/LiveGame.jsx
+++ b/src/ui/components/LiveGame.jsx
@@ -208,7 +208,8 @@ function TeamBadge({ abbr, size = 36, isUser = false }) {
 
 function MatchupCard({ event, userTeamId, pending, onOpenBoxScore }) {
   const { homeId, awayId, homeAbbr, awayAbbr, homeScore, awayScore } = event;
-  const isUser = homeId === userTeamId || awayId === userTeamId;
+  const numericUserTeamId = Number(userTeamId);
+  const isUser = Number(homeId) === numericUserTeamId || Number(awayId) === numericUserTeamId;
   const finished = !pending;
   const presentation = buildCompletedGamePresentation(event, { source: "live_game_matchup" });
   const handleClick = () => openResolvedBoxScore(event, { source: "live_game_matchup" }, onOpenBoxScore);
@@ -239,14 +240,14 @@ function MatchupCard({ event, userTeamId, pending, onOpenBoxScore }) {
       {...interactiveProps}
     >
       {/* Away team */}
-      <TeamBadge abbr={awayAbbr} size={32} isUser={awayId === userTeamId} />
+      <TeamBadge abbr={awayAbbr} size={32} isUser={Number(awayId) === numericUserTeamId} />
       <div style={{ flex: 1, minWidth: 0 }}>
         <div
           style={{
             fontSize: "var(--text-xs)",
             fontWeight: 700,
             color:
-              awayId === userTeamId ? "var(--accent)" : "var(--text-muted)",
+              Number(awayId) === numericUserTeamId ? "var(--accent)" : "var(--text-muted)",
             overflow: "hidden",
             textOverflow: "ellipsis",
             whiteSpace: "nowrap",
@@ -300,7 +301,7 @@ function MatchupCard({ event, userTeamId, pending, onOpenBoxScore }) {
             fontSize: "var(--text-xs)",
             fontWeight: 700,
             color:
-              homeId === userTeamId ? "var(--accent)" : "var(--text-muted)",
+              Number(homeId) === numericUserTeamId ? "var(--accent)" : "var(--text-muted)",
             overflow: "hidden",
             textOverflow: "ellipsis",
             whiteSpace: "nowrap",
@@ -322,7 +323,7 @@ function MatchupCard({ event, userTeamId, pending, onOpenBoxScore }) {
           {homeScore}
         </div>
       </div>
-      <TeamBadge abbr={homeAbbr} size={32} isUser={homeId === userTeamId} />
+      <TeamBadge abbr={homeAbbr} size={32} isUser={Number(homeId) === numericUserTeamId} />
       {interactive ? <span className="clickable-card__chevron" aria-hidden="true">›</span> : null}
     </div>
   );
@@ -333,7 +334,8 @@ function MatchupCard({ event, userTeamId, pending, onOpenBoxScore }) {
 function PendingCard({ game, teamById, userTeamId }) {
   const home = teamById[game.home] ?? { abbr: "???", id: game.home };
   const away = teamById[game.away] ?? { abbr: "???", id: game.away };
-  const isUser = home.id === userTeamId || away.id === userTeamId;
+  const numericUserTeamId = Number(userTeamId);
+  const isUser = Number(home.id) === numericUserTeamId || Number(away.id) === numericUserTeamId;
   return (
     <div
       className={`matchup-card pending ${isUser ? "user-game" : ""}`}
@@ -346,7 +348,7 @@ function PendingCard({ game, teamById, userTeamId }) {
         ...(isUser ? { borderColor: "var(--accent)" } : {}),
       }}
     >
-      <TeamBadge abbr={away.abbr} size={32} isUser={away.id === userTeamId} />
+      <TeamBadge abbr={away.abbr} size={32} isUser={Number(away.id) === numericUserTeamId} />
       <div
         style={{
           flex: 1,
@@ -357,7 +359,7 @@ function PendingCard({ game, teamById, userTeamId }) {
       >
         {away.abbr} @ {home.abbr}
       </div>
-      <TeamBadge abbr={home.abbr} size={32} isUser={home.id === userTeamId} />
+      <TeamBadge abbr={home.abbr} size={32} isUser={Number(home.id) === numericUserTeamId} />
     </div>
   );
 }
@@ -612,11 +614,12 @@ export default function LiveGame({
   // ── Build scoreboard data ────────────────────────────────────────────────
 
   const userTeamId = league?.userTeamId;
+  const numericUserTeamId = Number(userTeamId);
 
   // All resolved game events — then filtered to user's game only for the scoreboard.
   const resolvedEvents = gameEvents ?? [];
   const userResolvedEvents = resolvedEvents.filter(
-    (e) => e.homeId === userTeamId || e.awayId === userTeamId,
+    (e) => Number(e.homeId) === numericUserTeamId || Number(e.awayId) === numericUserTeamId,
   );
 
   // Games still pending (not yet in gameEvents) — show only user's game.
@@ -656,7 +659,7 @@ export default function LiveGame({
       return "Dead even at the final whistle. Tough one to split.";
     }
     const homeWin = (recapGame.homeScore ?? 0) > (recapGame.awayScore ?? 0);
-    const userIsHome = recapGame.homeId === userTeamId;
+    const userIsHome = Number(recapGame.homeId) === numericUserTeamId;
     const userWon = userIsHome ? homeWin : !homeWin;
     const margin = Math.abs(homeScore - awayScore);
     if (userWon) {

--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -193,6 +193,11 @@ export function useWorker() {
    * Map<id, { resolve, reject }>
    */
   const pendingRef = useRef(new Map());
+  const depthChartSaveRef = useRef({
+    timerId: null,
+    latestUpdates: null,
+    waiters: [],
+  });
 
   // ── Spawn worker once ──────────────────────────────────────────────────────
   useEffect(() => {
@@ -350,6 +355,8 @@ export function useWorker() {
     worker.postMessage(buildMsg(toWorker.INIT));
 
     return () => {
+      const depthSave = depthChartSaveRef.current;
+      if (depthSave?.timerId) clearTimeout(depthSave.timerId);
       for (const pending of pendingRef.current.values()) {
         if (pending?.timeoutId) clearTimeout(pending.timeoutId);
       }
@@ -645,7 +652,27 @@ export function useWorker() {
 
     /** Update depth chart order for the user's team. */
     updateDepthChart: (updates) =>
-      request(toWorker.UPDATE_DEPTH_CHART, { updates }),
+      new Promise((resolve, reject) => {
+        if (!updates) {
+          resolve(null);
+          return;
+        }
+        const depthSave = depthChartSaveRef.current;
+        depthSave.latestUpdates = updates;
+        depthSave.waiters.push({ resolve, reject });
+
+        if (depthSave.timerId) clearTimeout(depthSave.timerId);
+        depthSave.timerId = setTimeout(() => {
+          const payloadToSend = depthSave.latestUpdates;
+          const waiters = depthSave.waiters.splice(0);
+          depthSave.latestUpdates = null;
+          depthSave.timerId = null;
+
+          request(toWorker.UPDATE_DEPTH_CHART, { updates: payloadToSend })
+            .then((result) => waiters.forEach(({ resolve: done }) => done(result)))
+            .catch((err) => waiters.forEach(({ reject: fail }) => fail(err)));
+        }, 120);
+      }),
 
     /** Update team strategy / GM decisions (fire-and-forget, non-blocking). */
     updateStrategy: (payload) =>

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -2179,10 +2179,11 @@ async function handleAdvanceWeek(payload, id) {
   // ── 0. Check for User Game to Prompt ────────────────────────────────────
   const userTeamId = meta.userTeamId;
   if (userTeamId != null && !payload.skipUserGame && ['regular', 'playoffs'].includes(meta.phase)) {
+      const numericUserTeamId = Number(userTeamId);
       const scheduleWeeks = meta.schedule?.weeks || [];
       const currentWeekData = scheduleWeeks.find(w => w.week === meta.currentWeek);
       if (currentWeekData) {
-          const userGame = currentWeekData.games.find(g => (Number(g.home) === userTeamId || Number(g.away) === userTeamId) && !g.played);
+          const userGame = currentWeekData.games.find(g => (Number(g.home) === numericUserTeamId || Number(g.away) === numericUserTeamId) && !g.played);
           if (userGame) {
               // Pause simulation and prompt the UI
               post(toUI.PROMPT_USER_GAME, {}, id);
@@ -8659,7 +8660,10 @@ async function handleWatchGame(payload, id) {
   const userTeamId = meta.userTeamId;
 
   const league = buildLeagueForSim(schedule, week, seasonId);
-  const userGameIndex = league._weekGames.findIndex(g => g.home.id === userTeamId || g.away.id === userTeamId);
+  const numericUserTeamId = Number(userTeamId);
+  const userGameIndex = league._weekGames.findIndex(
+    g => Number(g.home.id) === numericUserTeamId || Number(g.away.id) === numericUserTeamId,
+  );
 
   if (userGameIndex === -1) {
       post(toUI.ERROR, { message: 'No user game found this week' }, id);


### PR DESCRIPTION
### Motivation
- Prevent franchises (e.g. Bears) from hitting a Week 1 "No games to display"/missing user-game flow caused by string/number ID mismatches when detecting the user's game and emitting GAME_EVENTs. 
- Reduce `UPDATE_DEPTH_CHART` timeouts and excessive worker traffic from rapid depth-chart reorder/autosort operations.
- Provide an immediate, discoverable "Set lineup" action from HQ that navigates to the depth-chart and gives a quick validity confirmation.

### Description
- Normalize user/team ID comparisons to numeric values before schedule and event matching in the worker and UI to fix Week 1 gating and ensure user games are detected properly by `handleAdvanceWeek` and `handleWatchGame` (`src/worker/worker.js`).
- Debounce/batch depth-chart persistence in the hook by adding a small trailing debounce (120ms) that coalesces rapid `UPDATE_DEPTH_CHART` calls and resolves all waiters when the single request completes (`src/ui/hooks/useWorker.js`).
- Add an HQ-level `Set lineup` shortcut that builds a proposed depth assignment, runs `autoBuildDepthChart` and `depthWarnings`, routes to `Roster:depth|ALL`, and shows a short inline confirmation/toast indicating whether the lineup has blocking issues (`src/ui/components/FranchiseHQ.jsx`).
- Harden Live Game rendering and filters to use numeric comparisons for `userTeamId` and event/game IDs so the scoreboard/recap displays reliably (`src/ui/components/LiveGame.jsx`).
- Files changed: `src/worker/worker.js`, `src/ui/hooks/useWorker.js`, `src/ui/components/FranchiseHQ.jsx`, `src/ui/components/LiveGame.jsx`.

### Testing
- Ran a focused unit test run with Vitest: `npm run test:unit -- src/ui/utils/managementScreenRouting.test.js src/ui/utils/boxScorePresentation.test.js src/core/__tests__/depth-chart.test.js`; the `boxScorePresentation` and `depth-chart` tests passed but one pre-existing assertion in `managementScreenRouting.test.js` failed (expected different `Roster:Depth` filter behavior). 
- Verified production build: `npm run build` completed successfully.
- No new automated test failures were introduced by the changes beyond the existing assertion mismatch noted above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5881b81c832da504cc1d75ecbffb)