### PR TITLE
feat(roster): migrate depth chart reordering to @dnd-kit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "football-gm-sim",
       "version": "2.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-select": "^2.2.6",
@@ -324,6 +327,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "test:unit": "vitest run"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.2.6",

--- a/src/ui/components/DragAndDropDepthChart.jsx
+++ b/src/ui/components/DragAndDropDepthChart.jsx
@@ -2,45 +2,52 @@
  * DragAndDropDepthChart.jsx — Drag-and-drop position depth chart
  *
  * Displays position groups in starters / depth / special-teams rows.
- * Players can be dragged up/down within or across position groups.
- *
- * Props:
- *  - league: league object (has userTeam.roster)
- *  - actions: { updateDepthChart(positions) }
- *  - onPlayerSelect(playerId)
+ * Players can be dragged and reordered within each position group.
  */
 
-import React, { useState, useCallback, useMemo, useRef } from "react";
+import React, { useState, useCallback, useMemo, useEffect } from "react";
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { derivePlayerContractFinancials, formatContractMoney } from "../utils/contractFormatting.js";
 
-// Position groups definition
 const POSITION_GROUPS = [
-  { key: "QB",  label: "QB Room",       positions: ["QB"] },
-  { key: "RB",  label: "Backfield",     positions: ["RB", "FB"] },
-  { key: "WR",  label: "Wide Receivers",positions: ["WR"] },
-  { key: "TE",  label: "Tight Ends",    positions: ["TE"] },
-  { key: "OL",  label: "Offensive Line",positions: ["LT","LG","C","RG","RT","OL"] },
-  { key: "DL",  label: "D-Line",        positions: ["DE","DT","NT","DL"] },
-  { key: "LB",  label: "Linebackers",   positions: ["OLB","MLB","ILB","LB"] },
-  { key: "DB",  label: "Secondary",     positions: ["CB","FS","SS","S"] },
-  { key: "ST",  label: "Special Teams", positions: ["K","P","LS"] },
+  { key: "QB", label: "QB Room", positions: ["QB"] },
+  { key: "RB", label: "Backfield", positions: ["RB", "FB"] },
+  { key: "WR", label: "Wide Receivers", positions: ["WR"] },
+  { key: "TE", label: "Tight Ends", positions: ["TE"] },
+  { key: "OL", label: "Offensive Line", positions: ["LT", "LG", "C", "RG", "RT", "OL"] },
+  { key: "DL", label: "D-Line", positions: ["DE", "DT", "NT", "DL"] },
+  { key: "LB", label: "Linebackers", positions: ["OLB", "MLB", "ILB", "LB"] },
+  { key: "DB", label: "Secondary", positions: ["CB", "FS", "SS", "S"] },
+  { key: "ST", label: "Special Teams", positions: ["K", "P", "LS"] },
 ];
 
 const STARTERS = { QB: 1, RB: 2, WR: 3, TE: 2, OL: 5, DL: 4, LB: 3, DB: 4, ST: 3 };
 
-// Scheme fit colour thresholds
 function schemeFitColor(fit) {
   if (fit == null) return "#636366";
-  if (fit >= 70) return "#34C759";  // green
-  if (fit >= 50) return "#FF9F0A";  // yellow
-  return "#FF453A";                  // red
+  if (fit >= 70) return "#34C759";
+  if (fit >= 50) return "#FF9F0A";
+  return "#FF453A";
 }
 
 function posColor(pos = "") {
   const map = {
     QB: "#FF9F0A", RB: "#34C759", WR: "#0A84FF", TE: "#5E5CE6",
     OL: "#64D2FF", DL: "#FF453A", LB: "#FF6B35", CB: "#FFD60A",
-    S:  "#30D158", K: "#AEC6CF", P: "#AEC6CF",
+    S: "#30D158", K: "#AEC6CF", P: "#AEC6CF",
   };
   const key = Object.keys(map).find(k => pos.startsWith(k));
   return map[key] || "#9FB0C2";
@@ -54,235 +61,154 @@ function ovrColor(ovr = 70) {
   return "#636366";
 }
 
-// ── Player Row ─────────────────────────────────────────────────────────────────
+function inGroup(group, player) {
+  return group.positions.some(pos => player?.pos === pos || player?.pos?.startsWith(pos));
+}
 
-function PlayerRow({
-  player,
-  depth,           // 1-based index within group
-  groupKey,
-  isDragging,
-  isDragOver,
-  onDragStart,
-  onDragOver,
-  onDrop,
-  onPlayerSelect,
-  injuryColor,
-}) {
+function buildChartOrder(roster) {
+  const init = {};
+  for (const g of POSITION_GROUPS) {
+    const players = roster
+      .filter((p) => inGroup(g, p))
+      .sort((a, b) => {
+        const aOrder = a?.depthChart?.order ?? a?.depthOrder ?? 999;
+        const bOrder = b?.depthChart?.order ?? b?.depthOrder ?? 999;
+        if (aOrder !== bOrder) return aOrder - bOrder;
+        return (b.ovr ?? 0) - (a.ovr ?? 0);
+      });
+    init[g.key] = players.map((p) => p.id);
+  }
+  return init;
+}
+
+function mergeRosterIntoOrder(prevOrder, roster) {
+  const playerById = new Map(roster.map((p) => [p.id, p]));
+  const next = {};
+  for (const g of POSITION_GROUPS) {
+    const validIds = new Set(roster.filter((p) => inGroup(g, p)).map((p) => p.id));
+    const carried = (prevOrder[g.key] || []).filter((id) => validIds.has(id) && playerById.has(id));
+    const missing = [...validIds].filter((id) => !carried.includes(id));
+    next[g.key] = [...carried, ...missing];
+  }
+  return next;
+}
+
+function sortableId(groupKey, playerId) {
+  return `${groupKey}::${playerId}`;
+}
+
+function parseSortableId(id) {
+  const [groupKey, rawPlayerId] = String(id).split("::");
+  return { groupKey, playerId: rawPlayerId };
+}
+
+function PlayerRow({ player, depth, groupKey, onPlayerSelect, recentlyMoved }) {
+  const id = sortableId(groupKey, player.id);
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+    padding: "7px 10px",
+    background: isDragging ? "rgba(255,255,255,0.04)" : "transparent",
+    borderRadius: 8,
+    cursor: "grab",
+    border: "1px solid transparent",
+    opacity: isDragging ? 0.45 : 1,
+    userSelect: "none",
+    WebkitUserSelect: "none",
+    boxShadow: recentlyMoved ? "0 0 0 2px rgba(52,199,89,0.45) inset" : "none",
+    animation: recentlyMoved ? "depth-row-flash 480ms ease-out" : "none",
+  };
+
   const inj = player.injury || (player.injuredWeeks > 0 ? {} : null);
   const pc = posColor(player.pos);
   const oc = ovrColor(player.ovr ?? 70);
   const contract = derivePlayerContractFinancials(player);
 
   return (
-    <div
-      draggable
-      onDragStart={(e) => onDragStart(e, groupKey, player.id)}
-      onDragOver={(e) => { e.preventDefault(); onDragOver(groupKey, player.id); }}
-      onDrop={(e) => onDrop(e, groupKey, player.id)}
-      onClick={() => onPlayerSelect?.(player.id)}
-      style={{
-        display: "flex", alignItems: "center", gap: 8,
-        padding: "7px 10px",
-        background: isDragOver
-          ? "rgba(10,132,255,0.12)"
-          : isDragging
-            ? "rgba(255,255,255,0.04)"
-            : "transparent",
-        borderRadius: 8,
-        cursor: "grab",
-        border: `1px solid ${isDragOver ? "var(--accent)" : "transparent"}`,
-        transition: "background 0.12s, border-color 0.12s",
-        opacity: isDragging ? 0.45 : 1,
-        userSelect: "none",
-        WebkitUserSelect: "none",
-      }}
-    >
-      {/* Depth number */}
-      <span style={{
-        fontSize: "0.65rem", fontWeight: 800,
-        color: depth === 1 ? "var(--accent)" : "var(--text-subtle)",
-        minWidth: 16, textAlign: "center",
-      }}>
-        {depth}
-      </span>
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners} onClick={() => onPlayerSelect?.(player.id)}>
+      <span style={{ fontSize: "0.65rem", fontWeight: 800, color: depth === 1 ? "var(--accent)" : "var(--text-subtle)", minWidth: 16, textAlign: "center" }}>{depth}</span>
+      <span style={{ fontSize: "0.75rem", color: "var(--text-subtle)", cursor: "grab", flexShrink: 0 }}>⠿</span>
 
-      {/* Drag handle */}
-      <span style={{
-        fontSize: "0.75rem", color: "var(--text-subtle)",
-        cursor: "grab", flexShrink: 0,
-      }}>
-        ⠿
-      </span>
-
-      {/* OVR badge */}
-      <div style={{
-        width: 32, height: 32, borderRadius: "50%", flexShrink: 0,
-        background: `${oc}20`, border: `2px solid ${oc}`,
-        display: "flex", alignItems: "center", justifyContent: "center",
-        fontSize: "0.65rem", fontWeight: 900, color: oc,
-      }}>
+      <div style={{ width: 32, height: 32, borderRadius: "50%", flexShrink: 0, background: `${oc}20`, border: `2px solid ${oc}`, display: "flex", alignItems: "center", justifyContent: "center", fontSize: "0.65rem", fontWeight: 900, color: oc }}>
         {player.ovr ?? "?"}
       </div>
 
-      {/* Player info */}
       <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{
-          fontSize: "0.8rem", fontWeight: 700, color: "var(--text)",
-          overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
-        }}>
+        <div style={{ fontSize: "0.8rem", fontWeight: 700, color: "var(--text)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
           {player.name || "Unknown"}
           {inj && (
-            <span style={{
-              marginLeft: 6, fontSize: "0.6rem",
-              background: "#FF453A22", color: "#FF453A",
-              border: "1px solid #FF453A44",
-              borderRadius: 4, padding: "1px 4px", fontWeight: 800,
-            }}>
+            <span style={{ marginLeft: 6, fontSize: "0.6rem", background: "#FF453A22", color: "#FF453A", border: "1px solid #FF453A44", borderRadius: 4, padding: "1px 4px", fontWeight: 800 }}>
               INJ
             </span>
           )}
         </div>
         <div style={{ display: "flex", gap: 5, marginTop: 2 }}>
-          <span style={{
-            fontSize: "0.6rem", fontWeight: 800, color: pc,
-            background: `${pc}18`, border: `1px solid ${pc}33`,
-            borderRadius: 4, padding: "1px 5px",
-          }}>
+          <span style={{ fontSize: "0.6rem", fontWeight: 800, color: pc, background: `${pc}18`, border: `1px solid ${pc}33`, borderRadius: 4, padding: "1px 5px" }}>
             {player.pos}
           </span>
-          <span style={{ fontSize: "0.62rem", color: "var(--text-muted)" }}>
-            Age {player.age ?? "?"}
-          </span>
+          <span style={{ fontSize: "0.62rem", color: "var(--text-muted)" }}>Age {player.age ?? "?"}</span>
         </div>
       </div>
 
-      {/* Scheme fit % pill */}
       {player.schemeFit != null && (
-        <div style={{
-          flexShrink: 0,
-          fontSize: "0.58rem", fontWeight: 800,
-          color: schemeFitColor(player.schemeFit),
-          background: `${schemeFitColor(player.schemeFit)}18`,
-          border: `1px solid ${schemeFitColor(player.schemeFit)}44`,
-          borderRadius: 4, padding: "1px 5px",
-          minWidth: 30, textAlign: "center",
-        }} title={`Scheme fit: ${Math.round(player.schemeFit)}%`}>
+        <div style={{ flexShrink: 0, fontSize: "0.58rem", fontWeight: 800, color: schemeFitColor(player.schemeFit), background: `${schemeFitColor(player.schemeFit)}18`, border: `1px solid ${schemeFitColor(player.schemeFit)}44`, borderRadius: 4, padding: "1px 5px", minWidth: 30, textAlign: "center" }} title={`Scheme fit: ${Math.round(player.schemeFit)}%`}>
           {Math.round(player.schemeFit)}%
         </div>
       )}
 
-      {/* Salary */}
       {contract.annualSalary != null && (
-        <span style={{ fontSize: "0.65rem", color: "var(--text-subtle)", flexShrink: 0 }}>
-          {formatContractMoney(contract.annualSalary)}
-        </span>
+        <span style={{ fontSize: "0.65rem", color: "var(--text-subtle)", flexShrink: 0 }}>{formatContractMoney(contract.annualSalary)}</span>
       )}
     </div>
   );
 }
 
-// ── Position Group ─────────────────────────────────────────────────────────────
-
-function PositionGroup({
-  group,
-  players,
-  dragState,
-  onDragStart,
-  onDragOver,
-  onDrop,
-  onDragEnd,
-  onPlayerSelect,
-}) {
+function PositionGroup({ group, players, onPlayerSelect, recentlyMovedId }) {
   const starterCount = STARTERS[group.key] ?? 1;
   const starters = players.slice(0, starterCount);
   const depth = players.slice(starterCount);
 
   return (
-    <div style={{
-      background: "var(--surface)",
-      border: "1.5px solid var(--hairline)",
-      borderRadius: 12,
-      overflow: "hidden",
-      marginBottom: 10,
-    }}>
-      {/* Header */}
-      <div style={{
-        padding: "8px 12px",
-        background: "var(--surface-strong, rgba(255,255,255,0.04))",
-        borderBottom: "1px solid var(--hairline)",
-        display: "flex", alignItems: "center", justifyContent: "space-between",
-      }}>
-        <span style={{ fontSize: "0.75rem", fontWeight: 800, color: "var(--text)",
-          textTransform: "uppercase", letterSpacing: "0.8px" }}>
-          {group.label}
-        </span>
-        <span style={{ fontSize: "0.62rem", color: "var(--text-subtle)" }}>
-          {players.length} player{players.length !== 1 ? "s" : ""}
-        </span>
+    <div style={{ background: "var(--surface)", border: "1.5px solid var(--hairline)", borderRadius: 12, overflow: "hidden", marginBottom: 10 }}>
+      <div style={{ padding: "8px 12px", background: "var(--surface-strong, rgba(255,255,255,0.04))", borderBottom: "1px solid var(--hairline)", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+        <span style={{ fontSize: "0.75rem", fontWeight: 800, color: "var(--text)", textTransform: "uppercase", letterSpacing: "0.8px" }}>{group.label}</span>
+        <span style={{ fontSize: "0.62rem", color: "var(--text-subtle)" }}>{players.length} player{players.length !== 1 ? "s" : ""}</span>
       </div>
 
-      {/* Starters section */}
-      {starters.length > 0 && (
-        <div style={{ padding: "4px 6px" }}>
-          <div style={{
-            fontSize: "0.58rem", fontWeight: 800, color: "#34C759",
-            textTransform: "uppercase", letterSpacing: "0.8px",
-            padding: "4px 6px 2px",
-          }}>
-            Starters
+      <SortableContext items={players.map((p) => sortableId(group.key, p.id))} strategy={verticalListSortingStrategy}>
+        {starters.length > 0 && (
+          <div style={{ padding: "4px 6px" }}>
+            <div style={{ fontSize: "0.58rem", fontWeight: 800, color: "#34C759", textTransform: "uppercase", letterSpacing: "0.8px", padding: "4px 6px 2px" }}>Starters</div>
+            {starters.map((p, i) => (
+              <PlayerRow key={p.id} player={p} depth={i + 1} groupKey={group.key} onPlayerSelect={onPlayerSelect} recentlyMoved={recentlyMovedId === p.id} />
+            ))}
           </div>
-          {starters.map((p, i) => (
-            <PlayerRow
-              key={p.id}
-              player={p}
-              depth={i + 1}
-              groupKey={group.key}
-              isDragging={dragState.dragging?.playerId === p.id}
-              isDragOver={dragState.over?.groupKey === group.key && dragState.over?.playerId === p.id}
-              onDragStart={onDragStart}
-              onDragOver={onDragOver}
-              onDrop={onDrop}
-              onPlayerSelect={onPlayerSelect}
-            />
-          ))}
-        </div>
-      )}
+        )}
 
-      {/* Depth section */}
-      {depth.length > 0 && (
-        <div style={{
-          padding: "4px 6px",
-          borderTop: starters.length > 0 ? "1px solid rgba(255,255,255,0.04)" : "none",
-        }}>
-          <div style={{
-            fontSize: "0.58rem", fontWeight: 800, color: "var(--text-subtle)",
-            textTransform: "uppercase", letterSpacing: "0.8px",
-            padding: "4px 6px 2px",
-          }}>
-            Depth
+        {depth.length > 0 && (
+          <div style={{ padding: "4px 6px", borderTop: starters.length > 0 ? "1px solid rgba(255,255,255,0.04)" : "none" }}>
+            <div style={{ fontSize: "0.58rem", fontWeight: 800, color: "var(--text-subtle)", textTransform: "uppercase", letterSpacing: "0.8px", padding: "4px 6px 2px" }}>Depth</div>
+            {depth.map((p, i) => (
+              <PlayerRow key={p.id} player={p} depth={starterCount + i + 1} groupKey={group.key} onPlayerSelect={onPlayerSelect} recentlyMoved={recentlyMovedId === p.id} />
+            ))}
           </div>
-          {depth.map((p, i) => (
-            <PlayerRow
-              key={p.id}
-              player={p}
-              depth={starterCount + i + 1}
-              groupKey={group.key}
-              isDragging={dragState.dragging?.playerId === p.id}
-              isDragOver={dragState.over?.groupKey === group.key && dragState.over?.playerId === p.id}
-              onDragStart={onDragStart}
-              onDragOver={onDragOver}
-              onDrop={onDrop}
-              onPlayerSelect={onPlayerSelect}
-            />
-          ))}
-        </div>
-      )}
+        )}
+      </SortableContext>
 
       {players.length === 0 && (
-        <div style={{
-          padding: "14px 12px", textAlign: "center",
-          color: "var(--text-subtle)", fontSize: "0.75rem",
-        }}>
+        <div style={{ padding: "14px 12px", textAlign: "center", color: "var(--text-subtle)", fontSize: "0.75rem" }}>
           No players at this position
         </div>
       )}
@@ -290,113 +216,66 @@ function PositionGroup({
   );
 }
 
-// ── Main Component ─────────────────────────────────────────────────────────────
-
 export default function DragAndDropDepthChart({ league, actions, onPlayerSelect }) {
-  const userTeam = league?.teams?.find(t => t.id === league.userTeamId);
+  const userTeam = league?.teams?.find((t) => t.id === league.userTeamId);
   const roster = userTeam?.roster ?? [];
 
-  // Local chart state (ordering per group)
-  const [chartOrder, setChartOrder] = useState(() => {
-    const init = {};
-    for (const g of POSITION_GROUPS) {
-      const players = roster
-        .filter(p => g.positions.some(pos => p.pos === pos || p.pos?.startsWith(pos)))
-        .sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0));
-      init[g.key] = players.map(p => p.id);
-    }
-    return init;
-  });
+  const [chartOrder, setChartOrder] = useState(() => buildChartOrder(roster));
+  const [activeGroup, setActiveGroup] = useState(null);
+  const [recentlyMovedId, setRecentlyMovedId] = useState(null);
 
-  const [dragState, setDragState] = useState({ dragging: null, over: null });
-  const [activeGroup, setActiveGroup] = useState(null); // null = show all
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
 
-  // Rebuild player list from chart order
+  useEffect(() => {
+    setChartOrder((prev) => mergeRosterIntoOrder(prev, roster));
+  }, [roster]);
+
   const groupedPlayers = useMemo(() => {
-    const playerById = Object.fromEntries(roster.map(p => [p.id, p]));
+    const playerById = Object.fromEntries(roster.map((p) => [p.id, p]));
     const result = {};
     for (const g of POSITION_GROUPS) {
-      const ids = chartOrder[g.key] || [];
-      result[g.key] = ids.map(id => playerById[id]).filter(Boolean);
+      result[g.key] = (chartOrder[g.key] || []).map((id) => playerById[id]).filter(Boolean);
     }
     return result;
   }, [chartOrder, roster]);
 
-  const handleDragStart = useCallback((e, groupKey, playerId) => {
-    setDragState(s => ({ ...s, dragging: { groupKey, playerId } }));
-    e.dataTransfer.effectAllowed = "move";
-    e.dataTransfer.setData("text/plain", JSON.stringify({ groupKey, playerId }));
-  }, []);
+  const persistOrder = useCallback((nextOrder) => {
+    if (!actions?.updateDepthChart) return;
+    actions.updateDepthChart(nextOrder).catch(() => {});
+  }, [actions]);
 
-  const handleDragOver = useCallback((groupKey, playerId) => {
-    setDragState(s => ({ ...s, over: { groupKey, playerId } }));
-  }, []);
+  const handleDragEnd = useCallback((event) => {
+    const { active, over } = event;
+    if (!active || !over) return;
 
-  const handleDrop = useCallback((e, targetGroupKey, targetPlayerId) => {
-    e.preventDefault();
-    let src;
-    try {
-      src = JSON.parse(e.dataTransfer.getData("text/plain"));
-    } catch {
-      src = dragState.dragging;
-    }
-    if (!src) { setDragState({ dragging: null, over: null }); return; }
+    const from = parseSortableId(active.id);
+    const to = parseSortableId(over.id);
+    if (from.groupKey !== to.groupKey || from.playerId === to.playerId) return;
 
-    const { groupKey: srcGroupKey, playerId: srcPlayerId } = src;
-
-    setChartOrder(prev => {
-      const newOrder = { ...prev };
-
-      // Remove from source
-      const srcList = [...(newOrder[srcGroupKey] || [])].filter(id => id !== srcPlayerId);
-
-      if (srcGroupKey === targetGroupKey) {
-        // Reorder within same group
-        const targetIdx = srcList.indexOf(targetPlayerId);
-        const insertAt = targetIdx === -1 ? srcList.length : targetIdx;
-        srcList.splice(insertAt, 0, srcPlayerId);
-        newOrder[srcGroupKey] = srcList;
-      } else {
-        // Move to different group (if compatible) — just append
-        newOrder[srcGroupKey] = srcList;
-        const dstList = [...(newOrder[targetGroupKey] || [])];
-        const targetIdx = dstList.indexOf(targetPlayerId);
-        const insertAt = targetIdx === -1 ? dstList.length : targetIdx;
-        dstList.splice(insertAt, 0, srcPlayerId);
-        newOrder[targetGroupKey] = dstList;
-      }
-
-      // Persist to worker if action available
-      if (actions?.updateDepthChart) {
-        const positions = {};
-        for (const [gk, ids] of Object.entries(newOrder)) {
-          positions[gk] = ids;
-        }
-        actions.updateDepthChart(positions).catch(() => {});
-      }
-
-      return newOrder;
+    setChartOrder((prev) => {
+      const list = [...(prev[from.groupKey] || [])];
+      const oldIndex = list.findIndex((id) => String(id) === from.playerId);
+      const newIndex = list.findIndex((id) => String(id) === to.playerId);
+      if (oldIndex < 0 || newIndex < 0) return prev;
+      const reordered = arrayMove(list, oldIndex, newIndex);
+      const next = { ...prev, [from.groupKey]: reordered };
+      persistOrder(next);
+      return next;
     });
 
-    setDragState({ dragging: null, over: null });
-  }, [dragState.dragging, actions]);
+    const movedId = roster.find((p) => String(p.id) === from.playerId)?.id ?? null;
+    setRecentlyMovedId(movedId);
+    window.setTimeout(() => setRecentlyMovedId(null), 550);
+  }, [persistOrder, roster]);
 
-  const handleDragEnd = useCallback(() => {
-    setDragState({ dragging: null, over: null });
-  }, []);
+  const visibleGroups = activeGroup ? POSITION_GROUPS.filter((g) => g.key === activeGroup) : POSITION_GROUPS;
 
-  const visibleGroups = activeGroup
-    ? POSITION_GROUPS.filter(g => g.key === activeGroup)
-    : POSITION_GROUPS;
-
-  // Auto-sort: order each group by schemeAdjustedOVR desc, then OVR desc
   const handleAutoSort = useCallback(() => {
-    const playerById = Object.fromEntries(roster.map(p => [p.id, p]));
-    setChartOrder(prev => {
-      const newOrder = {};
+    const playerById = Object.fromEntries(roster.map((p) => [p.id, p]));
+    setChartOrder((prev) => {
+      const next = {};
       for (const g of POSITION_GROUPS) {
-        const ids = prev[g.key] || [];
-        newOrder[g.key] = [...ids].sort((a, b) => {
+        next[g.key] = [...(prev[g.key] || [])].sort((a, b) => {
           const pa = playerById[a];
           const pb = playerById[b];
           const ovrA = pa?.schemeAdjustedOVR ?? pa?.ovr ?? 0;
@@ -404,35 +283,27 @@ export default function DragAndDropDepthChart({ league, actions, onPlayerSelect 
           return ovrB - ovrA;
         });
       }
-      if (actions?.updateDepthChart) {
-        actions.updateDepthChart(newOrder).catch(() => {});
-      }
-      return newOrder;
+      persistOrder(next);
+      return next;
     });
-  }, [roster, actions]);
+    setRecentlyMovedId(-1);
+    window.setTimeout(() => setRecentlyMovedId(null), 450);
+  }, [roster, persistOrder]);
 
-  // Compute team average scheme fit for display
   const avgSchemeFit = useMemo(() => {
-    const fits = roster.map(p => p.schemeFit).filter(f => f != null);
+    const fits = roster.map((p) => p.schemeFit).filter((f) => f != null);
     if (!fits.length) return null;
     return Math.round(fits.reduce((s, f) => s + f, 0) / fits.length);
   }, [roster]);
 
   return (
     <div style={{ maxWidth: 640, margin: "0 auto", paddingBottom: 40 }}>
-      {/* Header bar: auto-sort + avg fit */}
-      <div style={{
-        display: "flex", alignItems: "center", justifyContent: "space-between",
-        marginBottom: 10, gap: 8,
-      }}>
+      <style>{`@keyframes depth-row-flash { 0% { background: rgba(52,199,89,0.24);} 100% { background: transparent; } }`}</style>
+
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10, gap: 8 }}>
         <button
           onClick={handleAutoSort}
-          style={{
-            padding: "5px 14px", borderRadius: 8, border: "1px solid var(--accent)",
-            background: "var(--accent-muted, rgba(10,132,255,0.12))",
-            color: "var(--accent)", fontSize: "0.72rem", fontWeight: 700,
-            cursor: "pointer", display: "flex", alignItems: "center", gap: 6,
-          }}
+          style={{ padding: "5px 14px", borderRadius: 8, border: "1px solid var(--accent)", background: "var(--accent-muted, rgba(10,132,255,0.12))", color: "var(--accent)", fontSize: "0.72rem", fontWeight: 700, cursor: "pointer", display: "flex", alignItems: "center", gap: 6 }}
           title="Sort each position group by scheme-adjusted OVR"
         >
           ⚡ Auto-Sort by Fit
@@ -440,70 +311,34 @@ export default function DragAndDropDepthChart({ league, actions, onPlayerSelect 
         {avgSchemeFit != null && (
           <div style={{ display: "flex", alignItems: "center", gap: 5 }}>
             <span style={{ fontSize: "0.65rem", color: "var(--text-subtle)" }}>Avg Fit</span>
-            <span style={{
-              fontSize: "0.75rem", fontWeight: 800,
-              color: schemeFitColor(avgSchemeFit),
-            }}>{avgSchemeFit}%</span>
+            <span style={{ fontSize: "0.75rem", fontWeight: 800, color: schemeFitColor(avgSchemeFit) }}>{avgSchemeFit}%</span>
           </div>
         )}
       </div>
 
-      {/* Position group filter tabs */}
-      <div style={{
-        display: "flex", gap: 6, flexWrap: "wrap", marginBottom: 14,
-      }}>
-        <button
-          onClick={() => setActiveGroup(null)}
-          style={{
-            padding: "5px 12px", borderRadius: 8, border: "none",
-            background: !activeGroup ? "var(--accent)" : "var(--surface)",
-            color: !activeGroup ? "#fff" : "var(--text-muted)",
-            fontSize: "0.72rem", fontWeight: 700, cursor: "pointer",
-          }}
-        >
-          All
-        </button>
-        {POSITION_GROUPS.map(g => (
-          <button
-            key={g.key}
-            onClick={() => setActiveGroup(g.key === activeGroup ? null : g.key)}
-            style={{
-              padding: "5px 12px", borderRadius: 8, border: "none",
-              background: activeGroup === g.key ? "var(--accent)" : "var(--surface)",
-              color: activeGroup === g.key ? "#fff" : "var(--text-muted)",
-              fontSize: "0.72rem", fontWeight: 700, cursor: "pointer",
-            }}
-          >
-            {g.key}
-          </button>
+      <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: 14 }}>
+        <button onClick={() => setActiveGroup(null)} style={{ padding: "5px 12px", borderRadius: 8, border: "none", background: !activeGroup ? "var(--accent)" : "var(--surface)", color: !activeGroup ? "#fff" : "var(--text-muted)", fontSize: "0.72rem", fontWeight: 700, cursor: "pointer" }}>All</button>
+        {POSITION_GROUPS.map((g) => (
+          <button key={g.key} onClick={() => setActiveGroup(g.key === activeGroup ? null : g.key)} style={{ padding: "5px 12px", borderRadius: 8, border: "none", background: activeGroup === g.key ? "var(--accent)" : "var(--surface)", color: activeGroup === g.key ? "#fff" : "var(--text-muted)", fontSize: "0.72rem", fontWeight: 700, cursor: "pointer" }}>{g.key}</button>
         ))}
       </div>
 
-      {/* Hint */}
-      <div style={{
-        fontSize: "0.68rem", color: "var(--text-subtle)",
-        marginBottom: 12, display: "flex", alignItems: "center", gap: 6,
-      }}>
+      <div style={{ fontSize: "0.68rem", color: "var(--text-subtle)", marginBottom: 12, display: "flex", alignItems: "center", gap: 6 }}>
         <span>⠿</span>
-        <span>Drag players to reorder depth chart</span>
+        <span>Drag players to reorder depth chart inside each position group</span>
       </div>
 
-      {/* Groups */}
-      <div onDragEnd={handleDragEnd}>
-        {visibleGroups.map(g => (
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        {visibleGroups.map((g) => (
           <PositionGroup
             key={g.key}
             group={g}
             players={groupedPlayers[g.key] ?? []}
-            dragState={dragState}
-            onDragStart={handleDragStart}
-            onDragOver={handleDragOver}
-            onDrop={handleDrop}
-            onDragEnd={handleDragEnd}
             onPlayerSelect={onPlayerSelect}
+            recentlyMovedId={recentlyMovedId}
           />
         ))}
-      </div>
+      </DndContext>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Replace fragile HTML5 drag handlers with a robust sortable DnD solution so player rows are fully draggable and reorder smoothly within position groups.
- Preserve the existing UX: instant persistence via the debounced `UPDATE_DEPTH_CHART` path, Auto-Sort by Fit, filters, depth warnings/red-state, and the Cards/Table/Depth view toggle.

### Description
- Rewrote `DragAndDropDepthChart.jsx` to use `@dnd-kit` (`DndContext`, `SortableContext`, `useSortable`, `arrayMove`) for intra-group row sorting and drag handles, and added small utilities (`sortableId`, `parseSortableId`, `buildChartOrder`, `mergeRosterIntoOrder`) to maintain stable local order state and sync with roster updates.
- Kept persistence via the existing action: calls `actions.updateDepthChart(...)` after a reorder so the debounced `UPDATE_DEPTH_CHART` flow is used unchanged.
- Preserved Auto-Sort behavior and wired it to call the same `updateDepthChart` flow after sorting each group by `schemeAdjustedOVR`/OVR.
- Added immediate visual drop feedback (short green flash animation on the moved row and smooth reordering) and a small roster/order merge so the depth display refreshes from the worker-backed roster without a full page reload.
- Added `@dnd-kit/core`, `@dnd-kit/sortable`, and `@dnd-kit/utilities` to `package.json` and updated `package-lock.json`.
- Scope limited to the depth-chart editing experience; no changes were made outside that area.

### Testing
- Ran the focused unit suites: `npx vitest run src/core/__tests__/depth-chart.test.js src/ui/components/__tests__/rosterInitialState.test.js` — both suites passed.
- Ran the repository-wide unit command `npm run test:unit` and observed multiple pre-existing unrelated failures in other suites; those failures are existing in the branch and not introduced by this change.
- Changes were committed with the message `feat(roster): switch depth chart reordering to dnd-kit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5c96069c832dae20bcb00a3335a3)