### PR TITLE
Polish shell UX across HQ, Team, League, News, and Schedule

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -5,6 +5,7 @@ import { deriveTeamCapSnapshot, formatMoneyM } from "../utils/numberFormatting.j
 import { getHQViewModel } from "../../state/selectors.js";
 import { buildCompletedGamePresentation } from "../utils/boxScoreAccess.js";
 import { EmptyState, SectionCard, StatCard, TeamChip } from "./common/UiPrimitives.jsx";
+import { CtaRow, CompactListRow, StatusChip } from "./ScreenSystem.jsx";
 import { getRecentGames as getArchivedRecentGames } from "../../core/archive/gameArchive.ts";
 import { autoBuildDepthChart, depthWarnings } from "../../core/depthChart.js";
 
@@ -118,41 +119,42 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
 
   return (
     <div className="app-screen-stack franchise-hq" style={{ display: "grid", gap: "var(--space-3)" }}>
-      <SectionCard title="This Week" actions={<Button size="sm" variant="outline" onClick={() => onNavigate?.("Schedule")}>Schedule</Button>}>
+      <SectionCard title="This Week" actions={<StatusChip label={vm.league?.phase ?? "season"} tone="league" />}>
         <div style={{ display: "grid", gap: 6 }}>
           <div style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)" }}>{vm.league?.year} · Week {vm.league?.week ?? 1} · {vm.league?.phase ?? "regular"}</div>
           <div style={{ fontSize: "var(--text-lg)", fontWeight: 800 }}>{record} · {team?.conf ?? ""} {team?.div ?? ""}</div>
           <div style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)" }}>{pressureSummary}</div>
-          <Button size="sm" onClick={onAdvanceWeek} disabled={busy || simulating}>Advance Week</Button>
+          <CtaRow actions={[
+            { label: busy || simulating ? "Working…" : "Advance Week", onClick: onAdvanceWeek, disabled: busy || simulating },
+            { label: "Set lineup", onClick: handleSetLineup, compact: true },
+            { label: "Game plan", onClick: () => onNavigate?.("Game Plan"), compact: true },
+            { label: "Schedule", onClick: () => onNavigate?.("Schedule"), compact: true },
+            { label: "Open news", onClick: () => onNavigate?.("News"), compact: true },
+          ]} />
         </div>
       </SectionCard>
 
-      <SectionCard title="Priority Queue" actions={<Button size="sm" variant="outline" onClick={() => onNavigate?.("Team")}>Team</Button>}>
+      <SectionCard title="Priority Queue" subtitle="Only the highest-impact franchise actions for this week." actions={<Button size="sm" variant="outline" onClick={() => onNavigate?.("Team")}>Open Team</Button>}>
         {phasePriorityQueue.length === 0 ? <div style={{ color: "var(--text-muted)" }}>No immediate blockers.</div> : (
           <div style={{ display: "grid", gap: 8 }}>
             {phasePriorityQueue.map((item) => (
-              <button
+              <CompactListRow
                 key={`${item.label}-${item.tab}`}
-                className="btn"
-                style={{ textAlign: "left", borderLeft: `3px solid ${toneAccent(item.tone)}` }}
-                onClick={() => onNavigate?.(item?.tab ?? "Team")}
+                title={item.label}
+                subtitle={item.detail}
+                meta={<StatusChip label={item.tone ?? "info"} tone={item.tone === "danger" ? "warning" : "league"} />}
               >
-                <div style={{ fontWeight: 700 }}>{item.label}</div>
-                <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>{item.detail}</div>
-              </button>
+                <button className="btn btn-sm" onClick={() => onNavigate?.(item?.tab ?? "Team")}>Open</button>
+              </CompactListRow>
             ))}
           </div>
         )}
       </SectionCard>
 
-      <SectionCard title="Next Game">
+      <SectionCard title="Next Game" actions={nextGame ? <StatusChip label={`Week ${nextGame.week}`} tone="team" /> : null}>
         {nextGame ? (
           <div style={{ display: "grid", gap: 8 }}>
             <div style={{ fontSize: "var(--text-lg)", fontWeight: 800 }}>Week {nextGame.week} · {nextGame.isHome ? "vs" : "@"} <TeamChip team={nextGame.opp} /></div>
-            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-              <Button size="sm" onClick={handleSetLineup}>Set lineup</Button>
-              <Button size="sm" variant="outline" onClick={() => onNavigate?.("Game Plan")}>Game plan</Button>
-            </div>
             {lineupToast ? <div style={{ fontSize: "var(--text-xs)", color: "var(--accent)" }}>{lineupToast}</div> : null}
           </div>
         ) : <div style={{ color: "var(--text-muted)" }}>No upcoming game found.</div>}
@@ -178,7 +180,7 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
         )}
       </SectionCard>
 
-      <SectionCard title="Team Snapshot">
+      <SectionCard title="Team Snapshot" subtitle="Quick health and cap context. Open Team for full management tools.">
         <div style={{ display: "grid", gridTemplateColumns: "repeat(2, minmax(0, 1fr))", gap: 8 }}>
           <StatCard label="OVR / OFF / DEF" value={`${safeNum(team?.ovr, 0)} / ${safeNum(team?.offenseRating, team?.offRating)} / ${safeNum(team?.defenseRating, team?.defRating)}`} />
           <StatCard label="Cap Room" value={formatMoneyM(cap.capRoom)} note={`Used ${formatMoneyM(cap.capUsed)}`} />
@@ -187,21 +189,25 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
         </div>
       </SectionCard>
 
-      <SectionCard title="News Desk Preview" actions={<Button size="sm" variant="outline" onClick={() => onNavigate?.("News")}>Open News</Button>}>
+      <SectionCard title="News Desk Preview" subtitle="Recent stories tied to your team and league context." actions={<Button size="sm" variant="outline" onClick={() => onNavigate?.("News")}>Open News</Button>}>
         <div style={{ display: "grid", gap: 8 }}>
           {teamDevelopments.map((item, idx) => (
-            <button
+            <CompactListRow
               key={item?.id ?? `preview-${idx}`}
-              className="btn"
-              style={{ textAlign: "left" }}
-              onClick={() => {
-                if (item?.teamId != null) onTeamSelect?.(item.teamId);
-                onNavigate?.(item?.teamId != null ? "Team" : "News");
-              }}
+              title={item?.headline ?? "League update"}
+              subtitle={item?.body ?? "Read full context in News"}
+              meta={<StatusChip label={item?.teamId != null ? "Team story" : "League story"} tone={item?.teamId != null ? "team" : "league"} />}
             >
-              <div style={{ fontWeight: 700 }}>{item?.headline ?? "League update"}</div>
-              <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>Read full context in News</div>
-            </button>
+              <button
+                className="btn btn-sm"
+                onClick={() => {
+                  if (item?.teamId != null) onTeamSelect?.(item.teamId);
+                  onNavigate?.(item?.teamId != null ? "Team" : "News");
+                }}
+              >
+                Open
+              </button>
+            </CompactListRow>
           ))}
           {teamDevelopments.length === 0 ? <div style={{ color: "var(--text-muted)" }}>No major updates this week.</div> : null}
         </div>

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -855,6 +855,8 @@ function ScheduleTab({
       })
       .slice(0, 8)
   ), [games, league, seasonId, selectedWeek, teamById]);
+  const completedVisibleGames = mergedVisibleGames.filter((game) => Boolean(game?.played));
+  const upcomingVisibleGames = mergedVisibleGames.filter((game) => !Boolean(game?.played));
 
   return (
     <div>
@@ -983,9 +985,18 @@ function ScheduleTab({
           if (statusFilter === 'upcoming') return !Boolean(game?.played);
           return true;
         });
+        const sectionedVisibleGames = statusFilter === 'all'
+          ? [
+            { key: 'upcoming', title: 'Upcoming games', games: upcomingVisibleGames },
+            { key: 'completed', title: 'Completed games', games: completedVisibleGames },
+          ]
+          : [{ key: statusFilter, title: statusFilter === 'completed' ? 'Completed games' : 'Upcoming games', games: visibleGames }];
         return (
           <div style={{ display: "grid", gap: 8 }}>
-            {visibleGames.map((game, idx) => {
+            {sectionedVisibleGames.map((bucket) => (
+              <section key={bucket.key} style={{ display: "grid", gap: 8 }}>
+                <div style={{ fontSize: "var(--text-xs)", fontWeight: 800, textTransform: "uppercase", letterSpacing: ".08em", color: "var(--text-subtle)" }}>{bucket.title}</div>
+                {bucket.games.map((game, idx) => {
           const home = teamById[game.home] ?? {
             name: `Team ${game.home}`,
             abbr: "???",
@@ -1113,6 +1124,11 @@ function ScheduleTab({
                       {presentation?.ctaLabel ?? "View Box Score"} →
                     </div>
                   )}
+                  {!isClickable && (
+                    <div style={{ textAlign: "center", fontSize: "var(--text-xs)", color: "var(--text-subtle)", marginBottom: "var(--space-1)" }}>
+                      {presentation?.statusLabel ?? "Archive unavailable for this game."}
+                    </div>
+                  )}
                   {postgame && (
                     <div style={{ marginBottom: "var(--space-2)", fontSize: "var(--text-xs)", color: "var(--text-muted)", textAlign: "center" }}>
                       <strong style={{ color: "var(--text)" }}>{postgame.headline}</strong>
@@ -1173,6 +1189,8 @@ function ScheduleTab({
             </div>
           );
         })}
+              </section>
+            ))}
 
             {visibleGames.length === 0 && (
               <p style={{ color: "var(--text-muted)", textAlign: "center", padding: "var(--space-8)" }}>

--- a/src/ui/components/LeagueHub.jsx
+++ b/src/ui/components/LeagueHub.jsx
@@ -2,10 +2,10 @@ import React, { useMemo, useState } from 'react';
 import RecordBook from './RecordBook.jsx';
 import PostseasonHub from './PostseasonHub.jsx';
 import PlayerStats from './PlayerStats.jsx';
-import SectionHeader from './SectionHeader.jsx';
 import SectionSubnav from './SectionSubnav.jsx';
 import { buildNewsDeskModel } from '../utils/newsDesk.js';
 import SocialFeed from './SocialFeed.jsx';
+import { CompactListRow, ScreenHeader, StatusChip } from './ScreenSystem.jsx';
 
 const LEAGUE_SUBNAV = ['Schedule', 'Standings', 'Stats', 'Transactions', 'History'];
 
@@ -69,8 +69,12 @@ export default function LeagueHub({ league, actions, onOpenGameDetail, onPlayerS
   const recentWinners = champions.slice(-3).reverse();
 
   return (
-    <div>
-      <SectionHeader title="League" subtitle="League command center" />
+    <div className="app-screen-stack">
+      <ScreenHeader
+        title="League Hub"
+        subtitle="Schedule, standings, stats, transactions, and history."
+        eyebrow={`${league?.year ?? "Season"} · Week ${league?.week ?? 1}`}
+      />
       <SectionSubnav items={LEAGUE_SUBNAV} activeItem={subtab} onChange={setSubtab} />
       <SocialFeed league={league} defaultFilter="league" maxItems={8} onPlayerSelect={onPlayerSelect} />
 
@@ -104,21 +108,16 @@ export default function LeagueHub({ league, actions, onOpenGameDetail, onPlayerS
             <div style={{ fontWeight: 700, marginBottom: 8 }}>Recent transactions</div>
             <div style={{ display: 'grid', gap: 7 }}>
               {transactionRows.map((item, idx) => (
-                <div key={item?.id ?? `tx-${idx}`} style={{ border: '1px solid var(--hairline)', borderRadius: 9, padding: '8px 10px', display: 'grid', gap: 4 }}>
-                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'center' }}>
-                    <strong style={{ fontSize: 13 }}>{item?.headline ?? 'League transaction'}</strong>
-                    <span className="badge">{item?._txType}</span>
-                  </div>
-                  <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{item?.body ?? 'No detail available.'}</div>
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-                    <span style={{ fontSize: 11, color: 'var(--text-subtle)' }}>W{item?.week ?? '-'} · {item?.phase ?? 'season'}</span>
-                    <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-                      {item?.playerId != null ? <button className="btn btn-sm" onClick={() => onPlayerSelect?.(item.playerId)}>Player</button> : null}
-                      {item?._txType === 'Trade' ? <button className="btn btn-sm" onClick={() => onNavigateTrade?.(item?.teamId ?? null)}>Scout Market</button> : null}
-                      {item?.gameId ? <button className="btn btn-sm" onClick={() => onOpenGameDetail?.(item.gameId, 'League')}>Box</button> : null}
-                    </div>
-                  </div>
-                </div>
+                <CompactListRow
+                  key={item?.id ?? `tx-${idx}`}
+                  title={item?.headline ?? 'League transaction'}
+                  subtitle={item?.body ?? 'No detail available.'}
+                  meta={<><StatusChip label={item?._txType} tone="league" /> <span style={{ marginLeft: 6 }}>W{item?.week ?? '-'} · {item?.phase ?? 'season'}</span></>}
+                >
+                  {item?.playerId != null ? <button className="btn btn-sm" onClick={() => onPlayerSelect?.(item.playerId)}>Player</button> : null}
+                  {item?._txType === 'Trade' ? <button className="btn btn-sm" onClick={() => onNavigateTrade?.(item?.teamId ?? null)}>Scout market</button> : null}
+                  {item?.gameId ? <button className="btn btn-sm" onClick={() => onOpenGameDetail?.(item.gameId, 'League')}>Open box</button> : null}
+                </CompactListRow>
               ))}
               {transactionRows.length === 0 ? <div style={{ color: 'var(--text-muted)' }}>No transaction activity yet.</div> : null}
             </div>

--- a/src/ui/components/NewsFeed.jsx
+++ b/src/ui/components/NewsFeed.jsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState, useEffect } from 'react';
 import { deriveFranchisePressure } from '../utils/pressureModel.js';
 import { buildTeamIntelligence } from '../utils/teamIntelligence.js';
 import { buildNewsDeskModel } from '../utils/newsDesk.js';
+import { StatusChip } from './ScreenSystem.jsx';
 
 const tickerColor = {
   high: '#f59e0b',
@@ -21,16 +22,19 @@ function StoryCard({ item, onTeamSelect, onOpenBoxScore, onPlayerSelect }) {
     <div style={{ borderLeft: `4px solid ${priorityColor[item?.priority] ?? '#334155'}`, padding: '10px 12px', background: 'var(--surface)', borderRadius: 10 }}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>
         <div style={{ fontWeight: 700 }}>{item?.headline}</div>
-        <span style={{ fontSize: 11, color: 'var(--text-subtle)', border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 6px' }}>{item?._categoryLabel}</span>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          <StatusChip label={item?._teamRelevant ? 'Team' : 'League'} tone={item?._teamRelevant ? 'team' : 'league'} />
+          <span style={{ fontSize: 11, color: 'var(--text-subtle)', border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 6px' }}>{item?._categoryLabel}</span>
+        </div>
       </div>
       <div style={{ color: 'var(--text-muted)', marginTop: 2 }}>{item?.body}</div>
       <div style={{ fontSize: 11, color: 'var(--text-subtle)', marginTop: 4 }}>
         Week {item?.week ?? '-'} · {item?.phase ?? 'season'}{item?._teamRelevant ? ' · Your team' : ''}
       </div>
       <div style={{ display: 'flex', gap: 6, marginTop: 8, flexWrap: 'wrap' }}>
-        {item?.gameId ? <button className="btn" onClick={() => onOpenBoxScore?.(item.gameId)}>Box Score</button> : null}
-        {item?.teamId != null ? <button className="btn" onClick={() => onTeamSelect?.(item.teamId)}>Team Profile</button> : null}
-        {item?.playerId != null ? <button className="btn" onClick={() => onPlayerSelect?.(item.playerId)}>Player</button> : null}
+        {item?.gameId ? <button className="btn" onClick={() => onOpenBoxScore?.(item.gameId)}>Open box score</button> : null}
+        {item?.teamId != null ? <button className="btn" onClick={() => onTeamSelect?.(item.teamId)}>Open team</button> : null}
+        {item?.playerId != null ? <button className="btn" onClick={() => onPlayerSelect?.(item.playerId)}>Open player</button> : null}
       </div>
     </div>
   );
@@ -61,9 +65,9 @@ function CompactStoryRow({ item, onTeamSelect, onOpenBoxScore, onPlayerSelect })
           W{item?.week ?? '-'} · {item?.phase ?? 'season'}{item?._teamRelevant ? ' · Team' : ''}
         </div>
         <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-          {item?.gameId ? <button className="btn btn-sm" onClick={() => onOpenBoxScore?.(item.gameId)}>Box</button> : null}
-          {item?.teamId != null ? <button className="btn btn-sm" onClick={() => onTeamSelect?.(item.teamId)}>Team</button> : null}
-          {item?.playerId != null ? <button className="btn btn-sm" onClick={() => onPlayerSelect?.(item.playerId)}>Player</button> : null}
+          {item?.gameId ? <button className="btn btn-sm" onClick={() => onOpenBoxScore?.(item.gameId)}>Open box</button> : null}
+          {item?.teamId != null ? <button className="btn btn-sm" onClick={() => onTeamSelect?.(item.teamId)}>Open team</button> : null}
+          {item?.playerId != null ? <button className="btn btn-sm" onClick={() => onPlayerSelect?.(item.playerId)}>Open player</button> : null}
         </div>
       </div>
     </div>

--- a/src/ui/components/ScreenSystem.jsx
+++ b/src/ui/components/ScreenSystem.jsx
@@ -62,6 +62,47 @@ export function EmptyState({ title, body }) {
   );
 }
 
+export function StatusChip({ label, tone = "neutral" }) {
+  return <span className={`app-status-chip tone-${tone}`}>{label}</span>;
+}
+
+export function CtaRow({ actions = [] }) {
+  if (!actions.length) return null;
+  return (
+    <div className="app-cta-row">
+      {actions.map((action) => (
+        <button
+          key={`${action.label}-${action.href ?? action.variant ?? "default"}`}
+          type="button"
+          className={`btn ${action.compact ? "btn-sm" : ""}`}
+          onClick={action.onClick}
+          disabled={action.disabled}
+        >
+          {action.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function CardActionFooter({ children }) {
+  if (!children) return null;
+  return <div className="app-card-action-footer">{children}</div>;
+}
+
+export function CompactListRow({ title, subtitle, meta, children }) {
+  return (
+    <div className="app-compact-list-row">
+      <div className="app-compact-list-row__main">
+        <strong>{title}</strong>
+        {subtitle ? <span>{subtitle}</span> : null}
+      </div>
+      {meta ? <div className="app-compact-list-row__meta">{meta}</div> : null}
+      {children ? <div className="app-compact-list-row__actions">{children}</div> : null}
+    </div>
+  );
+}
+
 export function StickySubnav({ title, children }) {
   return (
     <div className="app-sticky-subnav card">

--- a/src/ui/components/SectionSubnav.jsx
+++ b/src/ui/components/SectionSubnav.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 export default function SectionSubnav({ items, activeItem, onChange, sticky = false }) {
   return (
     <div
-      className="standings-tabs"
+      className={`standings-tabs app-section-subnav ${sticky ? 'is-sticky' : ''}`}
       style={{
         marginBottom: 'var(--space-3)',
         gap: 6,
@@ -19,8 +19,9 @@ export default function SectionSubnav({ items, activeItem, onChange, sticky = fa
       {items.map((item) => (
         <button
           key={item}
-          className={`standings-tab${activeItem === item ? ' active' : ''}`}
+          className={`standings-tab app-section-subnav__tab${activeItem === item ? ' active' : ''}`}
           onClick={() => onChange(item)}
+          aria-current={activeItem === item ? 'page' : undefined}
           style={{ flexShrink: 0 }}
         >
           {item}

--- a/src/ui/components/SocialFeed.jsx
+++ b/src/ui/components/SocialFeed.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { EVENT_TOOLTIPS } from '../../core/events/eventSystem.js';
+import { StatusChip } from './ScreenSystem.jsx';
 
 const FILTERS = [
   { key: 'all', label: 'All' },
@@ -47,17 +48,22 @@ export default function SocialFeed({ league, onPlayerSelect, onTeamSelect, defau
 
       {entries.map((entry, idx) => {
         const tooltip = entry?.tooltip ?? EVENT_TOOLTIPS[entry?.type] ?? 'League update.';
+        const isTeamStory = Number(entry?.teamId) === userTeamId;
         return (
           <div key={entry?.id ?? `${entry?.headline ?? 'entry'}-${idx}`} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: '8px 10px', display: 'grid', gap: 4 }} title={tooltip}>
             <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'baseline' }}>
               <strong style={{ fontSize: 13 }}>{entry?.headline ?? entry?.text ?? 'Update'}</strong>
-              <span style={{ fontSize: 11, color: 'var(--text-subtle)' }}>{formatDate(entry)}</span>
+              <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                <StatusChip label={isTeamStory ? 'Team' : 'League'} tone={isTeamStory ? 'team' : 'league'} />
+                <span style={{ fontSize: 11, color: 'var(--text-subtle)' }}>{formatDate(entry)}</span>
+              </div>
             </div>
             {entry?.body || entry?.description ? <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{entry?.body ?? entry?.description}</div> : null}
             <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
               {entry?.actionLabel && entry?.actionTarget ? <span className="badge" title={`Suggested action: ${entry.actionTarget}`}>{entry.actionLabel}</span> : null}
               {entry?.playerId != null ? <button className="btn btn-sm" onClick={() => onPlayerSelect?.(entry.playerId)}>View Profile</button> : null}
-              {entry?.teamId != null ? <button className="btn btn-sm" onClick={() => onTeamSelect?.(entry.teamId)}>Team</button> : null}
+              {entry?.teamId != null ? <button className="btn btn-sm" onClick={() => onTeamSelect?.(entry.teamId)}>Open team</button> : null}
+              {entry?.gameId != null ? <span className="badge">Game linked</span> : null}
             </div>
           </div>
         );

--- a/src/ui/components/TeamHub.jsx
+++ b/src/ui/components/TeamHub.jsx
@@ -2,9 +2,9 @@ import React, { useMemo, useState } from 'react';
 import Roster from './Roster.jsx';
 import ContractCenter from './ContractCenter.jsx';
 import StaffManagement from './StaffManagement.jsx';
-import SectionHeader from './SectionHeader.jsx';
 import SectionSubnav from './SectionSubnav.jsx';
 import SocialFeed from './SocialFeed.jsx';
+import { CardActionFooter, CtaRow, ScreenHeader, StatusChip } from './ScreenSystem.jsx';
 import { derivePlayerContractFinancials } from '../utils/contractFormatting.js';
 import { deriveTeamCapSnapshot, formatMoneyM } from '../utils/numberFormatting.js';
 
@@ -221,8 +221,17 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
   ];
 
   return (
-    <div>
-      <SectionHeader title="Team" subtitle="Front-office workspace" />
+    <div className="app-screen-stack">
+      <ScreenHeader
+        title="Team Hub"
+        subtitle="Roster, depth chart, contracts, and staff in one operations workspace."
+        eyebrow={team?.name ?? 'Team'}
+        metadata={[
+          { label: 'Record', value: `${team?.wins ?? 0}-${team?.losses ?? 0}${team?.ties ? `-${team.ties}` : ''}` },
+          { label: 'Cap Room', value: formatMoneyM(capSnapshot.capRoom) },
+          { label: 'Roster', value: `${roster.length}/53` },
+        ]}
+      />
       <SectionSubnav items={TEAM_SUBNAV} activeItem={subtab} onChange={setSubtab} sticky />
 
       {subtab === 'Overview' && (
@@ -290,18 +299,14 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
 
           <div className="card" style={{ padding: '10px' }}>
             <div style={{ fontWeight: 700, fontSize: 13, marginBottom: 6 }}>Quick actions</div>
-            <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-              {quickActions.map((item) => (
-                <button
-                  key={item.tab}
-                  className="btn"
-                  onClick={() => (item.tab === 'Analytics' ? onNavigate?.('Analytics') : setSubtab(item.tab))}
-                  aria-label={item.label}
-                >
-                  {item.label}
-                </button>
-              ))}
-            </div>
+            <CtaRow actions={quickActions.map((item) => ({
+              label: item.label,
+              compact: true,
+              onClick: () => (item.tab === 'Analytics' ? onNavigate?.('Analytics') : setSubtab(item.tab)),
+            }))} />
+            <CardActionFooter>
+              <StatusChip label="Team workspace" tone="team" />
+            </CardActionFooter>
           </div>
         </div>
       )}

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -766,6 +766,17 @@ label {
 .leaders-footnote { display: flex; justify-content: space-between; align-items: center; color: var(--text-subtle); font-size: var(--text-xs); gap: 8px; }
 .leaders-empty { text-align: center; color: var(--text-muted); padding: var(--space-6); border: 1px dashed var(--hairline); border-radius: var(--radius-md); }
 
+.app-section-subnav {
+  padding: 4px;
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklab, var(--surface) 92%, black 8%);
+}
+.app-section-subnav__tab.active {
+  border-color: color-mix(in srgb, var(--accent) 65%, var(--hairline));
+  box-shadow: inset 0 -2px 0 var(--accent);
+}
+
 
 .trade-center-v2 { display: grid; gap: var(--space-3); }
 .trade-header-card { border: 1px solid var(--hairline-strong); }

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -36,6 +36,41 @@
 
 .app-empty-state { border: 1px dashed var(--hairline); border-radius: var(--radius-md); padding: var(--space-3); color: var(--text-muted); }
 .app-empty-state p { margin: 4px 0 0; font-size: var(--text-sm); }
+.app-status-chip {
+  border: 1px solid var(--hairline);
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.app-status-chip.tone-team { border-color: rgba(10,132,255,.45); color: var(--accent); background: rgba(10,132,255,.1); }
+.app-status-chip.tone-league { border-color: rgba(180,180,190,.4); color: var(--text-subtle); background: rgba(180,180,190,.08); }
+.app-status-chip.tone-warning { border-color: rgba(255,159,10,.45); color: var(--warning); background: rgba(255,159,10,.12); }
+
+.app-cta-row { display: flex; flex-wrap: wrap; gap: 8px; }
+.app-card-action-footer {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--hairline);
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.app-compact-list-row {
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+  padding: 8px 10px;
+  display: grid;
+  gap: 6px;
+  background: color-mix(in oklab, var(--surface) 90%, black 10%);
+}
+.app-compact-list-row__main { display: grid; gap: 2px; min-width: 0; }
+.app-compact-list-row__main strong { font-size: var(--text-sm); }
+.app-compact-list-row__main span { font-size: var(--text-xs); color: var(--text-muted); }
+.app-compact-list-row__meta { font-size: var(--text-xs); color: var(--text-subtle); }
+.app-compact-list-row__actions { display: flex; gap: 6px; flex-wrap: wrap; }
 
 .app-sticky-subnav {
   position: sticky;


### PR DESCRIPTION
### Motivation
- Reduce clutter and improve scanability across the top-level shells (HQ, Team, League, News, Schedule) so the app reads like a coherent football GM product. 
- Standardize small UI patterns (headers, chips, compact rows, CTA rows) to improve visual hierarchy and discoverability without changing core simulation logic. 
- Make the schedule/results and news flows more clearly actionable and consistent with team/league boundaries.

### Description
- Introduced small reusable UI primitives: `StatusChip`, `CtaRow`, `CardActionFooter`, and `CompactListRow` and corresponding styles to unify cards, CTAs, and list rows (`src/ui/components/ScreenSystem.jsx`, `src/ui/styles/screen-system.css`, `src/ui/styles/components.css`).
- Streamlined HQ (`FranchiseHQ.jsx`) to emphasize week/phase, next opponent, core CTAs and a compact priority/news snapshot; consolidated duplicate actions and moved less-urgent items behind clearer “Open” actions. 
- Standardized Team and League hubs to use the unified `ScreenHeader` and the new primitives for quick actions and transaction/news rows to improve consistency and reduce one-off layouts (`TeamHub.jsx`, `LeagueHub.jsx`).
- Polished News and Social feeds to show Team vs League relevance with chips, standardized action labels ("Open player / Open team / Open box"), and made related actions more discoverable (`NewsFeed.jsx`, `SocialFeed.jsx`).
- Improved Schedule/Results UX by sectioning week view into "Upcoming games" and "Completed games" (when viewing all) and showing an intentional archive/unavailable fallback on completed game cards; preserved existing navigation hooks and box-score opening behavior (`LeagueDashboard.jsx`).
- Minor subnav and styling tweaks to make active states and spacing more consistent (`SectionSubnav.jsx`, styles). No gameplay or simulation logic was altered and no new production dependencies were added.

### Testing
- Ran the focused UI unit test: `npx vitest run src/ui/components/__tests__/SocialFeed.test.jsx` which passed for the updated SocialFeed output. (passed)
- Built the production bundle with `npm run build` to validate runtime bundling and styles; build completed successfully. (passed)
- Ran the repository unit suite `npm run test:unit`; this run surfaced multiple unrelated, pre-existing failing suites in non-UI areas (reported in run output) which appear independent of these UI changes. (failed — failures unrelated to UI changes)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df170a3754832d8e41615b5bf5d9e3)