### PR TITLE
Polish schedule/results flow and standardize game entry actions

### DIFF
--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -396,7 +396,14 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
       </div>
 
       {loading && <div className="box-score-container"><EmptyState title="Loading box score…" body="Pulling archived game detail and postgame context." /></div>}
-      {!loading && error && !hasAnyPayload && <div className="box-score-container"><EmptyState title="Game archive unavailable" body={`${unavailableMessage} (${availability.statusLabel ?? "Archive unavailable"})`} /></div>}
+      {!loading && error && !hasAnyPayload && (
+        <div className="box-score-container">
+          <EmptyState
+            title="Result recorded · detailed archive unavailable"
+            body={`The final result is saved, but this game's full box score data is not available in the archive. ${unavailableMessage} (${availability.statusLabel ?? "Archive unavailable"})`}
+          />
+        </div>
+      )}
 
       {!loading && hasAnyPayload && game && (
         <div className="box-score-container">
@@ -421,8 +428,8 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
             <section className="bs-section" style={{ marginTop: 4 }} data-testid="archive-status">
               <div className="bs-list-item" style={{ borderColor: "var(--warning)", color: "var(--text-muted)" }}>
                 {archiveQuality === "partial"
-                  ? "Partial archive: final score and key summary data are available, but full drive/play detail was not stored."
-                  : "Legacy archive: only limited matchup context could be recovered for this game."}
+                  ? "Result recorded. Partial archive: final score and summary are available, but complete drive/play detail was not stored."
+                  : "Result recorded. Detailed box score is unavailable for this game, but any recap and context below are still shown."}
               </div>
             </section>
           )}

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -174,7 +174,7 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
               Week {latestArchived?.week ?? vm.league?.week}: {latestArchived?.awayAbbr} {latestArchived?.score?.away} - {latestArchived?.score?.home} {latestArchived?.homeAbbr}
             </strong>
             <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>
-              {latestGamePresentation?.canOpen ? "Tap score to open box score ›" : latestGamePresentation?.statusLabel}
+              {latestGamePresentation?.canOpen ? "Open box score" : "View result unavailable"}
             </div>
           </button>
         )}

--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -8,7 +8,7 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
       <div className="app-screen-stack">
         <ScreenHeader
           title="Game Detail"
-          subtitle="Select any completed game to view full postgame data."
+          subtitle="Open any game to view score context, recap, and box score details when available."
           onBack={onBack}
           backLabel="Back"
           metadata={[{ label: 'Season', value: league?.seasonId ?? '—' }]}
@@ -25,7 +25,7 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
     <div className="app-screen-stack">
       <ScreenHeader
         title="Game Book"
-        subtitle="Final score, recap, box score stats, and archived game detail."
+        subtitle="Final score hierarchy, recap context, and archived game details."
         onBack={onBack}
         backLabel="Back"
         metadata={[{ label: 'Game ID', value: gameId }]}

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -857,6 +857,16 @@ function ScheduleTab({
   ), [games, league, seasonId, selectedWeek, teamById]);
   const completedVisibleGames = mergedVisibleGames.filter((game) => Boolean(game?.played));
   const upcomingVisibleGames = mergedVisibleGames.filter((game) => !Boolean(game?.played));
+  const scheduleSummary = {
+    total: mergedVisibleGames.length,
+    completed: completedVisibleGames.length,
+    upcoming: upcomingVisibleGames.length,
+    myGames: mergedVisibleGames.filter((game) => {
+      const homeId = Number(game?.home?.id ?? game?.home);
+      const awayId = Number(game?.away?.id ?? game?.away);
+      return homeId === Number(userTeamId) || awayId === Number(userTeamId);
+    }).length,
+  };
 
   return (
     <div>
@@ -923,6 +933,12 @@ function ScheduleTab({
         <select value={selectedTeamId ?? ""} onChange={(e) => setSelectedTeamId(Number(e.target.value))} style={{ minHeight: 34 }}>
           {(teams ?? []).map((team) => <option key={team.id} value={team.id}>{team.name}</option>)}
         </select>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          <span className="badge">Week slate: {scheduleSummary.total}</span>
+          <span className="badge">My games: {scheduleSummary.myGames}</span>
+          <span className="badge">Upcoming: {scheduleSummary.upcoming}</span>
+          <span className="badge">Completed: {scheduleSummary.completed}</span>
+        </div>
       </div>
 
       {weekRecapItems.length > 0 && (
@@ -932,13 +948,22 @@ function ScheduleTab({
             <span style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>Scores + storylines at a glance</span>
           </div>
           <div style={{ display: "grid", gap: 6 }}>
-            {weekRecapItems.map(({ game, away, home, presentation, story }, idx) => (
+            {weekRecapItems.map(({ game, away, home, presentation, story }, idx) => {
+              const canViewResult = Boolean(presentation.resolvedGameId && onGameSelect);
+              const recapActionLabel = presentation.canOpen ? "Open box score" : (canViewResult ? "View result" : "Unavailable");
+              return (
               <button
                 key={`${game.home}-${game.away}-${idx}`}
-                className={`btn-link ${presentation.canOpen ? "" : "disabled"}`}
-                onClick={() => openResolvedBoxScore(game, { seasonId, week: selectedWeek, source: "schedule_recap" }, onGameSelect)}
+                className={`btn-link ${presentation.canOpen || canViewResult ? "" : "disabled"}`}
+                onClick={() => {
+                  if (presentation.canOpen) {
+                    openResolvedBoxScore(game, { seasonId, week: selectedWeek, source: "schedule_recap" }, onGameSelect);
+                  } else if (canViewResult) {
+                    onGameSelect?.(String(presentation.resolvedGameId));
+                  }
+                }}
                 style={{ textAlign: "left", fontSize: "var(--text-sm)", color: "var(--text-muted)" }}
-                title={presentation.canOpen ? presentation.ctaLabel : presentation.statusLabel}
+                title={presentation.canOpen ? "Open box score" : recapActionLabel}
               >
                 <strong style={{ color: "var(--text)" }}>{away.abbr} {game.awayScore} @ {home.abbr} {game.homeScore}</strong>
                 {" · "}
@@ -948,7 +973,7 @@ function ScheduleTab({
                   {presentation.statusLabel}
                 </span>
               </button>
-            ))}
+            )})}
           </div>
         </div>
       )}
@@ -1020,7 +1045,9 @@ function ScheduleTab({
           const presentation = game.played ? buildCompletedGamePresentation(game, { seasonId, week: selectedWeek, teamById, source: "schedule_card" }) : null;
           const resolvedGameId = presentation?.resolvedGameId ?? null;
           const archiveQuality = presentation?.archiveQuality ?? "missing";
-          const isClickable = Boolean(presentation?.canOpen && onGameSelect);
+          const canOpenBoxScore = Boolean(presentation?.canOpen && onGameSelect);
+          const canOpenResultOnly = Boolean(game.played && !presentation?.canOpen && presentation?.resolvedGameId && onGameSelect);
+          const isClickable = canOpenBoxScore || canOpenResultOnly;
           const pregameAngles = !game.played ? derivePregameAngles({ league, game, week: selectedWeek }) : [];
           const postgame = game.played ? derivePostgameStory({ league, game, week: selectedWeek }) : null;
           const immersion = game.played ? deriveBoxScoreImmersion({ league, game, week: selectedWeek }) : null;
@@ -1036,7 +1063,13 @@ function ScheduleTab({
             return null;
           })();
           const handleCardClick = isClickable
-            ? () => openResolvedBoxScore(game, { seasonId, week: selectedWeek, source: "schedule_card" }, onGameSelect)
+            ? () => {
+              if (canOpenBoxScore) {
+                openResolvedBoxScore(game, { seasonId, week: selectedWeek, source: "schedule_card" }, onGameSelect);
+              } else if (canOpenResultOnly) {
+                onGameSelect?.(String(presentation?.resolvedGameId));
+              }
+            }
             : undefined;
           const scoreTapHandler = createBoxScoreTapHandler({
             gameId: resolvedGameId,
@@ -1072,8 +1105,12 @@ function ScheduleTab({
                   <span style={{ color: "var(--text-subtle)", fontSize: "var(--text-xs)" }}>@</span>
                   <span style={{ border: "1px solid var(--hairline)", borderRadius: 999, padding: "1px 7px", fontSize: "var(--text-xs)" }}>HOME {home.abbr}</span>
                 </div>
-                <span className="badge">{game.played ? "Final" : "Upcoming"}</span>
-              </div>
+                  <span className="badge">
+                    {game.played
+                      ? (isUserGame ? "Final · User game" : "Final · League game")
+                      : (isUserGame ? "Upcoming · User game" : "Upcoming · League game")}
+                  </span>
+                </div>
 
               {game.played && game.homeScore !== undefined && (
                 <>
@@ -1117,16 +1154,24 @@ function ScheduleTab({
                         : ""}
                     </span>
                   </button>
-                  {isClickable && (
+                  {canOpenBoxScore && (
                     <div
                       style={{ textAlign: "center", fontSize: "var(--text-xs)", color: "var(--accent)", marginBottom: "var(--space-1)" }}
                     >
-                      {presentation?.ctaLabel ?? "View Box Score"} →
+                      Open box score →
                     </div>
                   )}
-                  {!isClickable && (
-                    <div style={{ textAlign: "center", fontSize: "var(--text-xs)", color: "var(--text-subtle)", marginBottom: "var(--space-1)" }}>
-                      {presentation?.statusLabel ?? "Archive unavailable for this game."}
+                  {canOpenResultOnly && (
+                    <div
+                      style={{ textAlign: "center", fontSize: "var(--text-xs)", color: "var(--accent)", marginBottom: "var(--space-1)" }}
+                    >
+                      View result →
+                    </div>
+                  )}
+                  {!canOpenBoxScore && !canOpenResultOnly && (
+                    <div style={{ textAlign: "center", fontSize: "var(--text-xs)", color: "var(--warning)", marginBottom: "var(--space-1)", border: "1px solid color-mix(in oklab, var(--warning) 50%, transparent)", borderRadius: "var(--radius-sm)", padding: "6px 8px", background: "color-mix(in oklab, var(--warning) 9%, transparent)" }}>
+                      Result recorded. Detailed box score archive unavailable.
+                      {postgame?.headline ? <div style={{ marginTop: 4, color: "var(--text-muted)" }}>{postgame.headline}</div> : null}
                     </div>
                   )}
                   {postgame && (
@@ -1158,7 +1203,7 @@ function ScheduleTab({
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
                   <div style={{ fontWeight: 700 }}>{away.abbr} @ {home.abbr}</div>
                   <Button size="sm" variant="outline" onClick={() => canOpenGameDetail && onGameSelect?.(upcomingGameId)} disabled={!canOpenGameDetail}>
-                    {canOpenGameDetail ? "Game Details" : "Scheduled"}
+                    {canOpenGameDetail ? "Open game" : "Scheduled"}
                   </Button>
                 </div>
               )}

--- a/src/ui/components/NewsFeed.jsx
+++ b/src/ui/components/NewsFeed.jsx
@@ -65,7 +65,7 @@ function CompactStoryRow({ item, onTeamSelect, onOpenBoxScore, onPlayerSelect })
           W{item?.week ?? '-'} · {item?.phase ?? 'season'}{item?._teamRelevant ? ' · Team' : ''}
         </div>
         <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-          {item?.gameId ? <button className="btn btn-sm" onClick={() => onOpenBoxScore?.(item.gameId)}>Open box</button> : null}
+          {item?.gameId ? <button className="btn btn-sm" onClick={() => onOpenBoxScore?.(item.gameId)}>Open box score</button> : null}
           {item?.teamId != null ? <button className="btn btn-sm" onClick={() => onTeamSelect?.(item.teamId)}>Open team</button> : null}
           {item?.playerId != null ? <button className="btn btn-sm" onClick={() => onPlayerSelect?.(item.playerId)}>Open player</button> : null}
         </div>

--- a/src/ui/utils/boxScoreAccess.js
+++ b/src/ui/utils/boxScoreAccess.js
@@ -73,8 +73,8 @@ export function buildCompletedGamePresentation(game, context = {}) {
   return {
     ...availability,
     ctaLabel: availability.canOpen
-      ? (availability.archiveQuality === "partial" ? "View Partial Archive" : "View Box Score")
-      : "Archive Unavailable",
+      ? (availability.archiveQuality === "partial" ? "Open box score (partial archive)" : "Open box score")
+      : "View result",
     statusLabel: getArchiveQualityLabel(availability.archiveQuality),
     displayScoreLine,
     away,


### PR DESCRIPTION
### Motivation
- Improve the schedule → result → box score flow so upcoming and completed games are easier to scan and act on. 
- Make completed-game cards clearly show whether a box score can be opened, and provide an intentional fallback when archives are missing. 
- Standardize action labels and entry behaviour across HQ, Schedule, News and Game Detail so users move naturally between surfaces.

### Description
- Introduced concise schedule slate badges and week summary counts in the Schedule tab and strengthened card status labels to show `Final · User game` / `Upcoming · League game`. (`src/ui/components/LeagueDashboard.jsx`).
- Consolidated presentation behaviour for completed games by updating `buildCompletedGamePresentation` to return consistent CTA text (`Open box score`, `Open box score (partial archive)`, or `View result`) and `statusLabel`. (`src/ui/utils/boxScoreAccess.js`).
- Made completed-game cards and week-recap rows use the presentation to either open the archived box score or fall back to a result-only view when archive identity exists but full archive is missing, and made card click targets visually and functionally consistent. (`src/ui/components/LeagueDashboard.jsx`).
- Reworked game-detail / box score messaging and empty states to be deliberate and explanatory when detailed archives are partial or missing, while still surfacing recaps and summary context. (`src/ui/components/BoxScore.jsx`, `src/ui/components/GameDetailScreen.jsx`).
- Standardized button labels across HQ and News to use the unified convention (`Open box score`, `Open game`) and clarified HQ last-game copy when a box score is unavailable. (`src/ui/components/FranchiseHQ.jsx`, `src/ui/components/NewsFeed.jsx`).

### Testing
- Ran unit tests: `npm run test:unit -- src/ui/utils/boxScoreAccess.test.js src/ui/utils/boxScorePresentation.test.js src/ui/utils/scheduleFiltersState.js`, and all included tests passed. 
- Performed a production build with `npm run build`, which completed successfully (vite build completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df1a4333f0832da4e9bea7ccb006df)