### PR TITLE
Polish transaction workflow UX: FA affordability tags, cap/roster previews, and trade consequence strip

### DIFF
--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -43,6 +43,7 @@ import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { computeTeamNeedsSummary, formatNeedsLine, summarizeFreeAgentMarket } from "../utils/marketSignals.js";
 import { buildDirectionGuidance, buildTeamIntelligence, scoreFreeAgentForTeam } from "../utils/teamIntelligence.js";
+import { getBudgetLabel, getMarketPlayerTags, toneToCssColor } from "../utils/transactionMarket.js";
 import { ScreenHeader, EmptyState, StickySubnav } from "./ScreenSystem.jsx";
 import AdvancedPlayerSearch from "./AdvancedPlayerSearch.jsx";
 import { applyAdvancedPlayerFilters } from "../../core/footballAdvancedFilters";
@@ -322,7 +323,7 @@ function CapBanner({ userTeam }) {
 // Renders as a full-width <td colSpan=7> in its own table row, appearing
 // directly below the highlighted player row (two-row pattern from Roster.jsx).
 
-function SignInlineForm({ player, capRoom, onSubmit, onCancel, asDiv }) {
+function SignInlineForm({ player, capRoom, rosterCount = 53, rosterLimit = 53, onSubmit, onCancel, asDiv }) {
   const defaultSalary = suggestedSalary(player.ovr, player.pos, player.age);
   const defaultYears = suggestedYears(player.age);
   const [annual, setAnnual] = useState(defaultSalary);
@@ -349,6 +350,8 @@ function SignInlineForm({ player, capRoom, onSubmit, onCancel, asDiv }) {
 
   const Wrapper = asDiv ? 'div' : 'td';
   const props = asDiv ? {} : { colSpan: 9 };
+  const postMoveCap = Number(capRoom) - Number(annual || 0);
+  const postMoveRoster = Number(rosterCount) + 1;
 
   return (
     <Wrapper
@@ -386,6 +389,14 @@ function SignInlineForm({ player, capRoom, onSubmit, onCancel, asDiv }) {
           >
             ${(player._ask ?? 0).toFixed(1)}M / yr · {suggestedYears(player.age)}{" "}
             years
+          </div>
+        </div>
+        <div style={{ display: "grid", gap: 2, marginLeft: "auto", minWidth: 170 }}>
+          <div style={{ fontSize: "10px", color: "var(--text-muted)" }}>
+            Cap after bid: <strong style={{ color: postMoveCap < 0 ? "var(--danger)" : "var(--text)" }}>${postMoveCap.toFixed(1)}M</strong>
+          </div>
+          <div style={{ fontSize: "10px", color: "var(--text-muted)" }}>
+            Roster after signing: <strong style={{ color: postMoveRoster > rosterLimit ? "var(--warning)" : "var(--text)" }}>{postMoveRoster}/{rosterLimit}</strong>
           </div>
         </div>
 
@@ -662,6 +673,8 @@ export default function FreeAgency({
   const capUsed = userTeam?.capUsed ?? 0;
   const deadCap = userTeam?.deadCap ?? 0;
   const capRoom = userTeam?.capRoom ?? (capTotal - capUsed - deadCap);
+  const rosterCount = Array.isArray(userTeam?.roster) ? userTeam.roster.length : 0;
+  const rosterLimit = 53;
   const needsSummary = useMemo(() => computeTeamNeedsSummary(userTeam), [userTeam]);
   const teamIntel = useMemo(() => buildTeamIntelligence(userTeam, { week: league?.week ?? 1 }), [userTeam, league?.week]);
 
@@ -1289,6 +1302,8 @@ export default function FreeAgency({
                             <SignInlineForm
                               player={player}
                               capRoom={capRoom}
+                              rosterCount={rosterCount}
+                              rosterLimit={rosterLimit}
                               onCancel={() => setSigningPlayerId(null)}
                               onSubmit={(c) => handleSign(player.id, c)}
                             />
@@ -1324,6 +1339,12 @@ export default function FreeAgency({
                           <div style={{ fontSize: "10px", color: "var(--text-muted)", marginBottom: 4 }}>
                             {player?.demandProfile?.headline ?? "Balanced priorities"}{market.riskLabel ? ` · ${market.riskLabel}` : ""}
                           </div>
+                          <div style={{ marginBottom: 4 }}>
+                            {(() => {
+                              const budget = getBudgetLabel({ askAnnual: player?.demandProfile?.askAnnual ?? player._ask ?? 0, capRoom });
+                              return <span style={{ fontSize: "10px", color: toneToCssColor(budget.tone), fontWeight: 700 }}>{budget.label}</span>;
+                            })()}
+                          </div>
                           <div style={{ fontSize: "10px", color: "var(--text-muted)", marginBottom: 4 }}>
                             Playbook: {formatPlaybookKnowledge(player?.playbookKnowledge)}
                           </div>
@@ -1350,6 +1371,14 @@ export default function FreeAgency({
 
             {viewMode === "cards" && (
               <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: "var(--space-3)", padding: "var(--space-3)" }}>
+                {sortedAgents.length === 0 ? (
+                  <EmptyState
+                    title={faState?.phase === "offseason_resign" ? "No re-sign targets in this filter" : "No free agents match"}
+                    body={faState?.phase === "offseason_resign"
+                      ? "Try broadening position filters or lower minimum OVR to find affordable retention options."
+                      : "Adjust filters or open FA Hub to scout position pressure before returning here."}
+                  />
+                ) : null}
                 {sortedAgents.slice(0, 80).map((player, idx) => (
                   <Card key={player.id} className="card-premium" style={{ padding: "var(--space-3)" }}>
                     <div style={{ fontWeight: 700 }}>{idx + 1}. {player.name}</div>
@@ -1357,6 +1386,11 @@ export default function FreeAgency({
                     <div style={{ fontSize: 12, color: "var(--text-muted)" }}>Scheme fit {player.schemeFit ?? 50} · morale {player.morale ?? 70}</div>
                     <div style={{ fontSize: 12, color: "var(--text-muted)" }}>Playbook {formatPlaybookKnowledge(player?.playbookKnowledge)}</div>
                     <div style={{ fontSize: 12, marginTop: 4 }}>Demand {(player?.demandProfile?.askAnnual ?? player._ask ?? 0).toFixed(1)}M / yr</div>
+                    <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: 4 }}>
+                      {getMarketPlayerTags(player, { capRoom, needs: needsSummary?.needs ?? [], surplus: needsSummary?.surplus ?? [] }).map((tag) => (
+                        <span key={`${player.id}-${tag.label}`} style={{ fontSize: 10, border: "1px solid var(--hairline)", padding: "1px 6px", borderRadius: 999, color: toneToCssColor(tag.tone) }}>{tag.label}</span>
+                      ))}
+                    </div>
                     <div style={{ fontSize: 11, color: 'var(--text-muted)' }}>{player?.demandProfile?.headline ?? 'Balanced motivations'}{player?.demandProfile?.fitScore ? ` · Fit ${player.demandProfile.fitScore}/100` : ''}</div>
                     {Array.isArray(player?.market?.stateChips) && player.market.stateChips.length > 0 ? <div style={{ fontSize: 10, color: 'var(--text-subtle)' }}>{player.market.stateChips.join(' · ')}</div> : null}
                     <div style={{ display: "flex", gap: 6, marginTop: 8 }}>
@@ -1372,7 +1406,12 @@ export default function FreeAgency({
             {/* Mobile Card Layout */}
             <div className="mobile-only" style={{ display: "none", flexDirection: "column", gap: "var(--space-3)", padding: "var(--space-3)" }}>
                {sortedAgents.length === 0 && (
-                  <EmptyState title="No free agents match" body="Adjust filters, minimum OVR, or search criteria." />
+                  <EmptyState
+                    title={faState?.phase === "offseason_resign" ? "No re-sign targets in this filter" : "No free agents match"}
+                    body={faState?.phase === "offseason_resign"
+                      ? "Try broadening position filters or lower minimum OVR to find affordable retention options."
+                      : "Adjust filters, minimum OVR, or search criteria."}
+                  />
                )}
                {sortedAgents.slice(0, 100).map((player, idx) => {
                   const isSigningThis = signingPlayerId === player.id;
@@ -1435,12 +1474,17 @@ export default function FreeAgency({
                                <div style={{ marginTop: "var(--space-2)" }}>
                                   {(player.traits || []).map((t) => <TraitBadge key={t} traitId={t} />)}
                                </div>
+                               <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: 4 }}>
+                                 {getMarketPlayerTags(player, { capRoom, needs: needsSummary?.needs ?? [], surplus: needsSummary?.surplus ?? [] }).map((tag) => (
+                                   <span key={`${player.id}-m-${tag.label}`} style={{ fontSize: 10, border: "1px solid var(--hairline)", padding: "1px 6px", borderRadius: 999, color: toneToCssColor(tag.tone) }}>{tag.label}</span>
+                                 ))}
+                               </div>
                            </div>
                         </div>
 
                         {isSigningThis ? (
                             <div style={{ borderTop: "1px solid var(--hairline)", paddingTop: "var(--space-3)", marginTop: "var(--space-2)" }}>
-                               <SignInlineForm player={player} capRoom={capRoom} asDiv onCancel={() => setSigningPlayerId(null)} onSubmit={(c) => handleSign(player.id, c)} />
+                               <SignInlineForm player={player} capRoom={capRoom} rosterCount={rosterCount} rosterLimit={rosterLimit} asDiv onCancel={() => setSigningPlayerId(null)} onSubmit={(c) => handleSign(player.id, c)} />
                             </div>
                         ) : (
                             <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>

--- a/src/ui/components/TeamHub.jsx
+++ b/src/ui/components/TeamHub.jsx
@@ -73,12 +73,12 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
           { label: 'Phase', value: league?.phase ?? 'regular' },
         ]}
         actions={[
-          { label: 'Roster', primary: true, onClick: () => setSubtab('Roster') },
+          { label: 'View roster details', primary: true, onClick: () => setSubtab('Roster') },
           { label: 'Depth Chart', onClick: () => setSubtab('Depth Chart') },
-          { label: 'Contracts', onClick: () => setSubtab('Contracts') },
+          { label: 'Review contracts', onClick: () => setSubtab('Contracts') },
           { label: 'Financials', onClick: () => setSubtab('Financials') },
-          { label: 'Free Agency', onClick: () => onNavigate?.('Free Agency') },
-          { label: 'Transactions', onClick: () => onNavigate?.('Transactions') },
+          { label: 'Explore free agents', onClick: () => onNavigate?.('Free Agency') },
+          { label: 'Shop trade market', onClick: () => onNavigate?.('Transactions') },
         ]}
         quickContext={[
           { label: `Cap ${formatMoneyM(capSnapshot.capRoom)} room`, tone: capSnapshot.capRoom <= 10 ? 'warning' : 'ok' },
@@ -140,12 +140,12 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
 
           <SectionCard title="Team workflow" subtitle="Move through the full roster management loop.">
             <CtaRow actions={[
-              { label: 'Review roster', compact: true, onClick: () => setSubtab('Roster') },
+              { label: 'View player details', compact: true, onClick: () => setSubtab('Roster') },
               { label: 'Set depth', compact: true, onClick: () => setSubtab('Depth Chart') },
-              { label: 'Handle contracts', compact: true, onClick: () => setSubtab('Contracts') },
+              { label: 'Review contracts', compact: true, onClick: () => setSubtab('Contracts') },
               { label: 'Cap outlook', compact: true, onClick: () => setSubtab('Financials') },
-              { label: 'Enter free agency', compact: true, onClick: () => onNavigate?.('Free Agency') },
-              { label: 'Open trade desk', compact: true, onClick: () => onNavigate?.('Transactions') },
+              { label: 'Explore free agents', compact: true, onClick: () => onNavigate?.('Free Agency') },
+              { label: 'Shop trade market', compact: true, onClick: () => onNavigate?.('Transactions') },
             ]} />
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
               <StatusChip label="Connected team workspace" tone="team" />

--- a/src/ui/components/TradeCenter.jsx
+++ b/src/ui/components/TradeCenter.jsx
@@ -19,6 +19,7 @@ import { isTradeWindowOpen, getTradeWindowSnapshot } from "../../core/tradeWindo
 import { DeadlineBanner } from "./common/UiPrimitives.jsx";
 import { buildTradeAssetDisplay } from "../utils/tradeAssetDisplay.js";
 import { getTradeLockReason } from "../utils/tradeLockReason.js";
+import { getBudgetLabel, toneToCssColor } from "../utils/transactionMarket.js";
 
 // ── Original helpers (kept exactly as you had) ─────────────────────────────────
 
@@ -281,6 +282,24 @@ function TradeSubmissionSummary({
       </div>
       <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
         Roster/fit: {tradeImpact.needHits.length ? `addresses ${tradeImpact.needHits.join(", ")}` : "no top-need hit yet"} · {tradeImpact.timeline}
+      </div>
+    </div>
+  );
+}
+
+function TradeConsequenceStrip({ myTeam, offeringCount, receivingCount, myCapAfter, tradeImpact }) {
+  const rosterBefore = Array.isArray(myTeam?.roster) ? myTeam.roster.length : 0;
+  const rosterAfter = rosterBefore - offeringCount + receivingCount;
+  const budget = getBudgetLabel({ askAnnual: Math.max(0, (myTeam?.capRoom ?? 0) - myCapAfter), capRoom: myTeam?.capRoom ?? 0 });
+  return (
+    <div className="card" style={{ marginBottom: "var(--space-3)", padding: "10px 12px", display: "grid", gap: 5 }}>
+      <div style={{ fontSize: "11px", textTransform: "uppercase", letterSpacing: ".08em", color: "var(--text-subtle)", fontWeight: 700 }}>Roster impact preview</div>
+      <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
+        Cap room: <strong style={{ color: myCapAfter < 0 ? "var(--danger)" : "var(--text)" }}>${Number(myTeam?.capRoom ?? 0).toFixed(1)}M → ${Number(myCapAfter).toFixed(1)}M</strong> ·
+        Roster spots: <strong style={{ color: rosterAfter > 53 ? "var(--warning)" : "var(--text)" }}> {rosterBefore}/53 → {rosterAfter}/53</strong>
+      </div>
+      <div style={{ fontSize: "var(--text-xs)", color: toneToCssColor(budget.tone) }}>
+        {budget.label} cap movement · {tradeImpact.needHits.length ? `Need coverage: ${tradeImpact.needHits.join(", ")}` : "No top need addressed yet"}
       </div>
     </div>
   );
@@ -645,14 +664,17 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
       <div className="card trade-header-card" style={{ marginBottom: "var(--space-4)", padding: "var(--space-4) var(--space-5)" }}>
         <div style={{ display: "flex", alignItems: "flex-end", gap: "var(--space-4)", flexWrap: "wrap" }}>
           <div>
-            <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: "0.5px", marginBottom: 4 }}>Trade Partner</div>
+          <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: "0.5px", marginBottom: 4 }}>Trade Partner</div>
             <select value={targetId ?? ""} onChange={e => {
               setTargetId(e.target.value ? Number(e.target.value) : null);
               setCounterOfferId(null);
               setOffering(new Set()); setReceiving(new Set()); setMyPicks([]); setTheirPicks([]); setTradeResult(null);
             }} style={{ background: "var(--surface)", border: "1px solid var(--hairline)", color: "var(--text)", borderRadius: "var(--radius-md)", padding: "var(--space-2) var(--space-3)", minWidth: 220, width: "100%" }}>
               <option value="">Select a team…</option>
-              {otherTeams.map(t => <option key={t.id} value={t.id}>{t.name} ({t.wins}–{t.losses})</option>)}
+              {otherTeams.map(t => {
+                const intel = buildTeamIntelligence(t, { week: league?.week ?? 1 });
+                return <option key={t.id} value={t.id}>{t.name} ({t.wins}–{t.losses}) · {intel.direction}</option>;
+              })}
             </select>
           </div>
           {targetId && liveTheirTeam && (
@@ -668,6 +690,11 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
           <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>{liveMyTeam?.abbr ?? "You"} · {formatNeedsLine(myNeedsSummary)}</div>
           {liveTheirTeam && <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>{liveTheirTeam?.abbr ?? "Them"} · {formatNeedsLine(theirNeedsSummary)}</div>}
           {liveTheirTeam && <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>Direction: {buildTeamIntelligence(liveTheirTeam, { week: league?.week ?? 1 }).direction} · Preferred package based on needs/age curve.</div>}
+          {!incomingOffers.length && (
+            <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>
+              No offers yet. Tip: start with teams showing a complementary need/surplus profile.
+            </div>
+          )}
         </div>
       </div>
       {counterOfferId && (
@@ -709,6 +736,15 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
                 <div>{tradeImpact.timeline}</div>
               </div>
             </div>
+          )}
+          {hasSelection && (
+            <TradeConsequenceStrip
+              myTeam={liveMyTeam}
+              offeringCount={offering.size}
+              receivingCount={receiving.size}
+              myCapAfter={myCapAfter}
+              tradeImpact={tradeImpact}
+            />
           )}
           {hasSelection && (
             <TradeSubmissionSummary

--- a/src/ui/utils/transactionMarket.js
+++ b/src/ui/utils/transactionMarket.js
@@ -1,0 +1,39 @@
+function safeNum(v, fallback = 0) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export function getBudgetLabel({ askAnnual = 0, capRoom = 0 }) {
+  const ask = safeNum(askAnnual);
+  const cap = safeNum(capRoom);
+  if (ask <= Math.max(0, cap) * 0.45) return { label: 'Affordable', tone: 'ok' };
+  if (ask <= cap) return { label: 'Stretch', tone: 'warning' };
+  return { label: 'Over budget', tone: 'danger' };
+}
+
+export function getMarketPlayerTags(player, { capRoom = 0, needs = [], surplus = [] } = {}) {
+  const tags = [];
+  const yearsLeft = safeNum(player?.contract?.yearsRemaining ?? player?.contract?.years ?? player?.years ?? 0);
+  const askAnnual = safeNum(player?.demandProfile?.askAnnual ?? player?._ask ?? player?.contract?.baseAnnual ?? 0);
+  const budgetTag = getBudgetLabel({ askAnnual, capRoom });
+  tags.push({ label: budgetTag.label, tone: budgetTag.tone });
+
+  if (yearsLeft > 0 && yearsLeft <= 1) tags.push({ label: 'Expiring', tone: 'warning' });
+  if (askAnnual >= 18) tags.push({ label: 'Expensive', tone: 'danger' });
+  if (safeNum(player?.ovr) >= 78) tags.push({ label: 'Starter upgrade', tone: 'ok' });
+  else if (safeNum(player?.ovr) >= 68) tags.push({ label: 'Depth upgrade', tone: 'league' });
+
+  const pos = player?.pos ?? player?.position;
+  if (pos && needs.includes(pos)) tags.push({ label: 'Need fit', tone: 'ok' });
+  if (pos && surplus.includes(pos)) tags.push({ label: 'Low priority', tone: 'neutral' });
+
+  return tags.slice(0, 4);
+}
+
+export function toneToCssColor(tone) {
+  if (tone === 'ok') return 'var(--success)';
+  if (tone === 'warning') return 'var(--warning)';
+  if (tone === 'danger') return 'var(--danger)';
+  if (tone === 'league') return 'var(--accent)';
+  return 'var(--text-subtle)';
+}


### PR DESCRIPTION
### Motivation
- Improve the transactions experience so free agency and trade workflows feel like a coherent market where users can quickly scan, compare, and act with cap/roster context.  
- Surface compact decision-support (affordability tags, cap/roster consequences, need-fit hints) without changing core sim/trade logic.  

### Description
- Added `src/ui/utils/transactionMarket.js` to centralize lightweight market helpers: budget labels (`Affordable` / `Stretch` / `Over budget`), market player tags, and tone→CSS mapping used by UI.  
- FreeAgency UI changes in `src/ui/components/FreeAgency.jsx`: inline sign form now shows projected cap room and roster count after the bid (table + mobile), cards/rows include standardized market tags and a budget label, and empty states distinguish FA vs re-sign flows for clearer next actions.  
- Trade UX changes in `src/ui/components/TradeCenter.jsx`: partner selector now annotates teams with their direction, added a small guidance hint when there are no incoming offers, and introduced a compact `TradeConsequenceStrip` that summarizes cap/roster impact and whether needs are addressed while building a package.  
- Team entry points in `src/ui/components/TeamHub.jsx` updated CTA labels to better connect Team → Contracts → Free Agency → Trades.  
- All UI changes are presentation-only and reuse existing derived values; no core simulator or trade engine logic was rewritten.  

### Testing
- `npm run build` completed successfully (production build produced).  
- `npm run test:unit` for `src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx` passed.  
- Targeted unit test run for three modules (`freeAgencyPlaybookKnowledge`, `tradeWorkspaceState`, `tradeFinderOffers`) showed one failing assertion in `tradeFinderOffers.test.js` where the expected `status: "empty"` was `"ok"` in the current baseline; this appears to be an existing signal-level mismatch and not caused by sim-core changes from this PR.  
- Quick smoke: ran the partial unit builds above and the production build; both succeeded except for the noted unit assertion mismatch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc1657f14832dae9ff8835fb174cd)