### PR TITLE
Enhance league memory UX: history archive, recaps, HOF, records, and player career arcs

### DIFF
--- a/src/ui/components/AwardsRecordsScreen.jsx
+++ b/src/ui/components/AwardsRecordsScreen.jsx
@@ -8,6 +8,7 @@ export default function AwardsRecordsScreen({ actions, league, onPlayerSelect, o
   const [seasons, setSeasons] = useState([]);
   const [records, setRecords] = useState(null);
   const [scope, setScope] = useState('all');
+  const [recordScope, setRecordScope] = useState('singleSeason');
 
   useEffect(() => {
     Promise.all([
@@ -26,7 +27,10 @@ export default function AwardsRecordsScreen({ actions, league, onPlayerSelect, o
   }))).filter((r) => r?.name), [seasons]);
 
   const filteredAwardRows = filterAwardRows(awardRows.slice().reverse(), scope);
-  const recordRows = useMemo(() => Object.entries(records?.singleSeason ?? {}).map(([k, rec]) => ({ key: k, ...rec })), [records]);
+  const recordRows = useMemo(() => {
+    const source = recordScope === 'singleSeason' ? (records?.singleSeason ?? {}) : (records?.allTime ?? {});
+    return Object.entries(source).map(([k, rec]) => ({ key: k, ...rec }));
+  }, [records, recordScope]);
 
   return (
     <div className="app-screen-stack" style={{ '--screen-sticky-top': getStickyTopOffset('compact') }}>
@@ -40,6 +44,7 @@ export default function AwardsRecordsScreen({ actions, league, onPlayerSelect, o
       <StickySubnav title="Filter">
         <button className={`standings-tab ${scope === 'all' ? 'active' : ''}`} onClick={() => setScope('all')}>All awards</button>
         <button className={`standings-tab ${scope === 'recent' ? 'active' : ''}`} onClick={() => setScope('recent')}>Recent awards</button>
+        <button className={`standings-tab ${scope === 'mvp' ? 'active' : ''}`} onClick={() => setScope('mvp')}>MVP history</button>
       </StickySubnav>
 
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(260px,1fr))', gap: 10 }}>
@@ -56,6 +61,10 @@ export default function AwardsRecordsScreen({ actions, league, onPlayerSelect, o
         </SectionCard>
 
         <SectionCard title="League records">
+          <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+            <button className={`standings-tab ${recordScope === 'singleSeason' ? 'active' : ''}`} onClick={() => setRecordScope('singleSeason')}>Single-season</button>
+            <button className={`standings-tab ${recordScope === 'career' ? 'active' : ''}`} onClick={() => setRecordScope('career')}>Career</button>
+          </div>
           <div style={{ display: 'grid', gap: 8, maxHeight: 420, overflow: 'auto' }}>
             {recordRows.length === 0 ? <EmptyState title="No records yet." body="Record tables appear once this save archives statistical leaders." /> : recordRows.map((rec) => (
               <div key={rec.key} style={{ border: '1px solid var(--hairline)', borderRadius: 8, padding: 8 }}>

--- a/src/ui/components/HallOfFame.jsx
+++ b/src/ui/components/HallOfFame.jsx
@@ -15,6 +15,7 @@ export default function HallOfFame({ onPlayerSelect, actions }) {
   const [positionFilter, setPositionFilter] = useState("ALL");
   const [search, setSearch] = useState("");
   const [sortKey, setSortKey] = useState("legacy");
+  const [classFilter, setClassFilter] = useState("ALL");
 
   useEffect(() => {
     let mounted = true;
@@ -46,6 +47,7 @@ export default function HallOfFame({ onPlayerSelect, actions }) {
   const filteredPlayers = useMemo(() => {
     const list = (players ?? []).filter((p) => {
       if (positionFilter !== "ALL" && p.pos !== positionFilter) return false;
+      if (classFilter !== "ALL" && String(p.inductionYear ?? "Unknown") !== classFilter) return false;
       const q = search.trim().toLowerCase();
       if (!q) return true;
       return [p.name, p.pos, p.primaryTeam]
@@ -53,7 +55,15 @@ export default function HallOfFame({ onPlayerSelect, actions }) {
         .some((value) => String(value).toLowerCase().includes(q));
     });
     return [...list].sort((a, b) => sortHallPlayers(a, b, sortKey));
-  }, [players, positionFilter, search, sortKey]);
+  }, [players, positionFilter, classFilter, search, sortKey]);
+  const classOptions = useMemo(() => {
+    const years = [...new Set((players ?? []).map((p) => String(p.inductionYear ?? "Unknown")))];
+    return ["ALL", ...years.sort((a, b) => Number(b) - Number(a))];
+  }, [players]);
+  const latestClass = useMemo(() => {
+    const yr = classOptions.find((value) => value !== "ALL" && value !== "Unknown");
+    return yr ? filteredPlayers.filter((p) => String(p.inductionYear) === yr).slice(0, 3) : filteredPlayers.slice(0, 3);
+  }, [classOptions, filteredPlayers]);
 
   if (loading) {
     return (
@@ -79,6 +89,21 @@ export default function HallOfFame({ onPlayerSelect, actions }) {
         subtitle="Explore inductions, teams, awards, and peak greatness."
         metadata={[{ label: "Legends", value: `${filteredPlayers.length}/${players.length}` }]}
       />
+      {latestClass.length > 0 && (
+        <Card className="card-premium">
+          <CardContent className="p-4 space-y-2">
+            <div className="text-xs uppercase tracking-wide text-[color:var(--text-muted)]">Class spotlight</div>
+            <div className="text-sm font-semibold">Latest class standouts</div>
+            <div className="flex flex-wrap gap-2">
+              {latestClass.map((p) => (
+                <button key={`spot-${p.id}`} className="rounded-full border border-[color:var(--hairline)] px-3 py-1 text-xs" onClick={() => onPlayerSelect?.(p.id)}>
+                  {p.inductionYear ?? "—"} · {p.name}
+                </button>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       <Card className="card-premium">
         <CardContent className="p-3 sm:p-4">
@@ -97,6 +122,15 @@ export default function HallOfFame({ onPlayerSelect, actions }) {
             >
               {positions.map((pos) => (
                 <option key={pos} value={pos}>{pos === "ALL" ? "All positions" : pos}</option>
+              ))}
+            </select>
+            <select
+              value={classFilter}
+              onChange={(e) => setClassFilter(e.target.value)}
+              className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-sm"
+            >
+              {classOptions.map((option) => (
+                <option key={option} value={option}>{option === "ALL" ? "All classes" : `Class of ${option}`}</option>
               ))}
             </select>
             <select

--- a/src/ui/components/HistoryHub.jsx
+++ b/src/ui/components/HistoryHub.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { ScreenHeader, SectionCard } from './ScreenSystem.jsx';
 
 const DESTINATIONS = [
-  { key: 'History', title: 'League History', body: 'Season timelines, champions, and franchise arcs.' },
-  { key: 'Team History', title: 'Team History', body: 'Team-specific milestones and legacy context.' },
-  { key: 'Hall of Fame', title: 'Hall of Fame', body: 'Career achievement archive and notable classes.' },
-  { key: 'Awards & Records', title: 'Awards & Records', body: 'Record book, award races, and all-time leaders.' },
+  { key: 'History', title: 'League Archive', body: 'Champions, season snapshots, and year-to-year memory.' },
+  { key: 'Team History', title: 'Franchise Timeline', body: 'Highs/lows, droughts, and long-run identity by club.' },
+  { key: 'Hall of Fame', title: 'Hall of Fame', body: 'All-time greats, induction classes, and legacy scoreboards.' },
+  { key: 'Awards & Records', title: 'Awards & Records', body: 'Who defined each season and who owns the book.' },
 ];
 
 export default function HistoryHub({ onNavigate }) {
@@ -13,7 +13,7 @@ export default function HistoryHub({ onNavigate }) {
     <div className="app-screen-stack">
       <ScreenHeader
         title="History Hub"
-        subtitle="League archives, team legacy paths, and record books in one destination."
+        subtitle="Your save-file memory center: archives, honors, records, and franchise timelines."
       />
       <SectionCard title="Choose a history destination" subtitle="Consistent archive routes with clear destination naming.">
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(220px,1fr))', gap: 'var(--space-3)' }}>

--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -47,6 +47,42 @@ const STAT_LABELS = {
   passesDefended: "PD",
 };
 const NOOP_ACTIONS = {};
+const AWARD_KEYS = ["mvp", "opoy", "dpoy", "roty", "sbMvp"];
+
+function pct(row) {
+  const wins = Number(row?.wins ?? 0);
+  const losses = Number(row?.losses ?? 0);
+  const ties = Number(row?.ties ?? 0);
+  const games = wins + losses + ties;
+  if (!games) return 0;
+  return (wins + ties * 0.5) / games;
+}
+
+function buildChampionMap(seasons = []) {
+  const map = new Map();
+  for (const season of seasons) {
+    const abbr = season?.champion?.abbr;
+    if (!abbr) continue;
+    map.set(abbr, (map.get(abbr) ?? 0) + 1);
+  }
+  return [...map.entries()].sort((a, b) => b[1] - a[1]);
+}
+
+function summarizeSeasonStoryline(season, userTeamId) {
+  if (!season) return "Season summary is not yet archived.";
+  const champion = season?.champion?.name ?? season?.champion?.abbr ?? "Unknown champion";
+  const runnerUp = season?.runnerUp?.name ?? season?.runnerUp?.abbr;
+  const userRow = (season?.standings ?? []).find((row) => Number(row?.id) === Number(userTeamId));
+  const mvp = season?.awards?.mvp?.name;
+  const lines = [
+    `${season.year}: ${champion}${runnerUp ? ` defeated ${runnerUp}` : ""}.`,
+    mvp ? `${mvp} defined the regular season as MVP.` : "Award winners were recorded for this season archive.",
+  ];
+  if (userRow) {
+    lines.push(`Your franchise finished ${userRow.wins}-${userRow.losses}${userRow.ties ? `-${userRow.ties}` : ""}.`);
+  }
+  return lines.join(" ");
+}
 
 export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenBoxScore }) {
   const api = actions ?? NOOP_ACTIONS;
@@ -93,6 +129,7 @@ export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenB
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-2">
         <Badge variant="secondary">{seasons.length} archived seasons</Badge>
+        <Badge variant="outline">{buildChampionMap(seasons)[0] ? `${buildChampionMap(seasons)[0][0]} leads titles (${buildChampionMap(seasons)[0][1]})` : "No champions yet"}</Badge>
         <Badge variant="outline">{allPlayers.length.toLocaleString()} active player rows available for compare</Badge>
       </div>
 
@@ -107,7 +144,7 @@ export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenB
         </TabsList>
 
         <TabsContent value="seasons">
-          <SeasonExplorer seasons={seasons} onPlayerSelect={onPlayerSelect} onOpenBoxScore={onOpenBoxScore} />
+          <SeasonExplorer seasons={seasons} onPlayerSelect={onPlayerSelect} onOpenBoxScore={onOpenBoxScore} league={league} />
         </TabsContent>
 
         <TabsContent value="records">
@@ -198,7 +235,7 @@ function DraftHistoryExplorer({ seasons, league, onPlayerSelect }) {
   );
 }
 
-function SeasonExplorer({ seasons, onPlayerSelect, onOpenBoxScore }) {
+function SeasonExplorer({ seasons, onPlayerSelect, onOpenBoxScore, league }) {
   const [selectedSeasonId, setSelectedSeasonId] = useState(seasons?.[0]?.id ?? null);
 
   useEffect(() => {
@@ -206,11 +243,25 @@ function SeasonExplorer({ seasons, onPlayerSelect, onOpenBoxScore }) {
   }, [seasons, selectedSeasonId]);
 
   if (!seasons?.length) {
-    return <div className="py-8 text-center text-[color:var(--text-muted)]">No archived seasons yet.</div>;
+    return (
+      <Card className="card-premium">
+        <CardContent className="py-10 text-center text-[color:var(--text-muted)]">
+          <div className="font-semibold text-[color:var(--text)]">No archived seasons yet.</div>
+          <div className="mt-2 text-sm">Finish your first season to start a living archive with champions, awards, and records.</div>
+        </CardContent>
+      </Card>
+    );
   }
 
   const selected = seasons.find((s) => s.id === selectedSeasonId) ?? seasons[0];
-  const sortedStandings = [...(selected?.standings ?? [])].sort((a, b) => b.pct - a.pct).slice(0, 8);
+  const sortedStandings = [...(selected?.standings ?? [])].sort((a, b) => pct(b) - pct(a)).slice(0, 8);
+  const championBoard = buildChampionMap(seasons).slice(0, 5);
+  const playoffMentions = (selected?.standings ?? []).filter((row) => Number(row?.wins ?? 0) >= 10).slice(0, 6);
+  const seasonStoryline = summarizeSeasonStoryline(selected, league?.userTeamId);
+  const awardLeaders = AWARD_KEYS
+    .map((key) => ({ key, label: AWARD_DISPLAY_NAMES[key] ?? key.toUpperCase(), award: selected?.awards?.[key] }))
+    .filter((entry) => entry.award?.name);
+  const selectedSeasonIndex = seasons.findIndex((s) => s.id === selected?.id);
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[260px_1fr] gap-4">
@@ -239,11 +290,30 @@ function SeasonExplorer({ seasons, onPlayerSelect, onOpenBoxScore }) {
           <CardTitle>{selected?.year} League Snapshot</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <button className="btn" onClick={() => selectedSeasonIndex > 0 && setSelectedSeasonId(seasons[selectedSeasonIndex - 1].id)} disabled={selectedSeasonIndex <= 0}>Previous season</button>
+            <button className="btn" onClick={() => selectedSeasonIndex < seasons.length - 1 && setSelectedSeasonId(seasons[selectedSeasonIndex + 1].id)} disabled={selectedSeasonIndex >= seasons.length - 1}>Next season</button>
+          </div>
+          <div className="rounded-md border border-[color:var(--hairline)] px-3 py-2 text-sm text-[color:var(--text-muted)]">{seasonStoryline}</div>
+
           <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
             <SummaryBox label="Champion" value={selected?.champion?.name ?? "TBD"} />
             <SummaryBox label="Runner-up" value={selected?.runnerUp?.name ?? "—"} muted={!selected?.runnerUp} />
             <SummaryBox label="MVP" value={selected?.awards?.mvp?.name ?? "—"} onClick={selected?.awards?.mvp?.playerId != null ? () => onPlayerSelect?.(selected.awards.mvp.playerId) : undefined} />
           </div>
+
+          <section>
+            <h4 className="text-sm font-bold mb-2">League memory board</h4>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm">
+              {championBoard.map(([abbr, count]) => (
+                <div key={abbr} className="rounded-md border border-[color:var(--hairline)] px-3 py-2 flex justify-between">
+                  <span>{abbr} championships</span>
+                  <span className="font-semibold">{count}</span>
+                </div>
+              ))}
+              {championBoard.length === 0 && <div className="text-[color:var(--text-muted)]">Champion leaderboard will appear after completed seasons.</div>}
+            </div>
+          </section>
 
           <section>
             <h4 className="text-sm font-bold mb-2">Standings Snapshot</h4>
@@ -255,6 +325,9 @@ function SeasonExplorer({ seasons, onPlayerSelect, onOpenBoxScore }) {
                 </div>
               ))}
             </div>
+            <div className="text-xs text-[color:var(--text-muted)] mt-2">
+              Playoff-caliber clubs (10+ wins): {playoffMentions.length ? playoffMentions.map((team) => `${team.abbr ?? team.name} ${team.wins}-${team.losses}`).join(" · ") : "none archived"}
+            </div>
           </section>
 
           <section>
@@ -264,6 +337,13 @@ function SeasonExplorer({ seasons, onPlayerSelect, onOpenBoxScore }) {
               <AwardLine label={AWARD_DISPLAY_NAMES.opoy} award={selected?.awards?.opoy} onPlayerSelect={onPlayerSelect} />
               <AwardLine label={AWARD_DISPLAY_NAMES.dpoy} award={selected?.awards?.dpoy} onPlayerSelect={onPlayerSelect} />
               <AwardLine label={AWARD_DISPLAY_NAMES.roty} award={selected?.awards?.roty} onPlayerSelect={onPlayerSelect} />
+            </div>
+            <div className="flex flex-wrap gap-2 mt-2">
+              {awardLeaders.map((entry) => (
+                <button key={entry.key} className="rounded-full border border-[color:var(--hairline)] px-2 py-1 text-xs" onClick={() => entry.award?.playerId != null ? onPlayerSelect?.(entry.award.playerId) : null}>
+                  {entry.label}: {entry.award?.name}
+                </button>
+              ))}
             </div>
             <div className="text-xs text-[color:var(--text-muted)] mt-2">
               Playoff bracket/path is not currently stored in archived season summaries.
@@ -304,7 +384,11 @@ function RecordsExplorer({ records, recordBook, seasons, onPlayerSelect }) {
 
   if (!records) return <div className="py-8 text-center text-[color:var(--text-muted)]">No records tracked yet.</div>;
 
-  const source = scope === "singleSeason" ? (recordBook?.singleSeason ?? records.singleSeason) : (recordBook?.career ?? records.allTime);
+  const source = scope === "singleSeason"
+    ? (recordBook?.singleSeason ?? records.singleSeason)
+    : scope === "game"
+      ? (recordBook?.singleGame ?? records.singleGame)
+      : (recordBook?.career ?? records.allTime);
 
   const teamSeasonRecords = useMemo(() => {
     const bestWins = { year: null, team: null, value: -1 };
@@ -328,13 +412,18 @@ function RecordsExplorer({ records, recordBook, seasons, onPlayerSelect }) {
     <div className="space-y-4">
       <Tabs value={scope} onValueChange={setScope}>
         <TabsList>
+          <TabsTrigger value="game">Single-game</TabsTrigger>
           <TabsTrigger value="singleSeason">Single-season</TabsTrigger>
           <TabsTrigger value="allTime">Career</TabsTrigger>
         </TabsList>
       </Tabs>
 
+      <div className="text-xs text-[color:var(--text-muted)]">
+        {scope === "game" ? "Highest one-game outputs in archive." : scope === "singleSeason" ? "Best one-season marks and team highs." : "All-time career records and long-run leaders."}
+      </div>
+
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-        {Object.entries(recordBook?.singleSeason ?? RECORD_LABELS).map(([key, raw]) => {
+        {Object.entries(scope === "singleSeason" ? (recordBook?.singleSeason ?? RECORD_LABELS) : (source ?? {})).map(([key, raw]) => {
           const label = typeof raw === "string" ? raw : RECORD_LABELS[key] ?? key;
           const rec = source?.[key];
           if (!rec?.playerId) return null;

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -386,6 +386,22 @@ export default function PlayerProfile({
   const summaryChips = getPlayerSummaryChips(player, ringCount, nonRing);
   const accoladesByYear = [...accolades].sort((a, b) => (a.year ?? 0) - (b.year ?? 0));
   const teamJourney = [...new Set((player?.careerStats ?? []).map((line) => line.team).filter(Boolean))];
+  const careerArcRows = useMemo(() => {
+    const seasonRows = (player?.careerStats ?? []).map((line) => ({
+      year: Number(line?.season ?? 0),
+      label: `Season ${line?.season ?? "—"}`,
+      detail: `${line?.team ?? "FA"} · OVR ${line?.ovr ?? "—"}`,
+    }));
+    const awardRows = accoladesByYear.map((acc) => ({
+      year: Number(acc?.year ?? 0),
+      label: String(acc?.type ?? "Award").replaceAll("_", " "),
+      detail: acc?.type === "SB_RING" ? "Championship ring earned" : "Career accolade",
+    }));
+    return [...seasonRows, ...awardRows]
+      .filter((row) => Number.isFinite(row.year) && row.year > 0)
+      .sort((a, b) => b.year - a.year)
+      .slice(0, 12);
+  }, [player?.careerStats, accoladesByYear]);
   const keyColumns = columns.filter((c) => !c.fmt && c.key !== "gamesPlayed").slice(0, 4);
   const careerHighs = keyColumns
     .map((col) => {
@@ -973,6 +989,20 @@ export default function PlayerProfile({
                 {accoladesByYear.slice(-12).map((acc, idx) => (
                   <div key={`${acc.type}-${acc.year}-${idx}`} style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
                     <strong style={{ color: "var(--text)" }}>{acc.year ?? "—"}</strong> · {acc.type}
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {careerArcRows.length > 0 && (
+            <section>
+              <h3 style={sectionLabelStyle}>Career Arc</h3>
+              <div style={{ display: "grid", gap: 4 }}>
+                {careerArcRows.map((row, idx) => (
+                  <div key={`${row.year}-${row.label}-${idx}`} style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", display: "flex", justifyContent: "space-between", gap: 8 }}>
+                    <span><strong style={{ color: "var(--text)" }}>{row.year}</strong> · {row.label}</span>
+                    <span>{row.detail}</span>
                   </div>
                 ))}
               </div>

--- a/src/ui/components/SeasonRecap.jsx
+++ b/src/ui/components/SeasonRecap.jsx
@@ -221,6 +221,15 @@ export default function SeasonRecap({ league, onPlayerSelect, onTeamSelect, onNa
   const seasonReview = archivedReview?.seasonReview ?? null;
   const playerCards = Array.isArray(archivedReview?.playerReportCards) ? archivedReview.playerReportCards : [];
   const offseasonPlan = archivedReview?.offseasonPlan ?? null;
+  const seasonMemory = useMemo(() => {
+    if (!archivedReview) return [];
+    const rows = [];
+    if (champion?.name) rows.push({ label: "Champion", value: champion.name, action: () => onNavigate?.("History") });
+    if (archivedReview?.awards?.mvp?.name) rows.push({ label: "MVP", value: archivedReview.awards.mvp.name, playerId: archivedReview.awards.mvp.playerId });
+    if (archivedReview?.runnerUp?.name) rows.push({ label: "Runner-up", value: archivedReview.runnerUp.name, action: () => onNavigate?.("History") });
+    if (archivedReview?.storylineSnapshots?.[0]?.headline) rows.push({ label: "Headline", value: archivedReview.storylineSnapshots[0].headline, action: () => onNavigate?.("📰 News") });
+    return rows.slice(0, 4);
+  }, [archivedReview, champion?.name, onNavigate]);
 
   return (
     <div style={{ maxWidth: 700, margin: "0 auto", position: "relative" }}>
@@ -348,6 +357,25 @@ export default function SeasonRecap({ league, onPlayerSelect, onTeamSelect, onNa
                 </div>
               ))}
             </div>
+          </div>
+        </AnimatedSection>
+      )}
+
+      {seasonMemory.length > 0 && (
+        <AnimatedSection delay={590} title="Season memory capsule" icon="🕰️">
+          <div style={{ display: "grid", gap: 8 }}>
+            {seasonMemory.map((row) => (
+              <button
+                key={row.label}
+                onClick={() => {
+                  if (row.playerId != null) onPlayerSelect?.(row.playerId);
+                  else row.action?.();
+                }}
+                style={{ textAlign: "left", border: "1px solid var(--hairline)", borderRadius: 8, padding: "8px 10px", background: "var(--surface-strong, #1a1a2e)", color: "var(--text)", cursor: "pointer" }}
+              >
+                <strong>{row.label}:</strong> <span style={{ color: "var(--text-muted)" }}>{row.value}</span>
+              </button>
+            ))}
           </div>
         </AnimatedSection>
       )}
@@ -633,7 +661,9 @@ export default function SeasonRecap({ league, onPlayerSelect, onTeamSelect, onNa
             📋 Copy Season Summary
           </button>
           <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-            <button onClick={() => onNavigate?.("History")} style={secondaryBtnStyle}>Open season archive</button>
+            <button onClick={() => onNavigate?.("History")} style={secondaryBtnStyle}>Open league archive</button>
+            <button onClick={() => onNavigate?.("Team History")} style={secondaryBtnStyle}>Open franchise timeline</button>
+            <button onClick={() => onNavigate?.("Awards & Records")} style={secondaryBtnStyle}>Open awards & records</button>
             <button onClick={() => onNavigate?.("Hall of Fame")} style={secondaryBtnStyle}>View Hall of Fame</button>
             <button onClick={() => onNavigate?.("Leaders")} style={secondaryBtnStyle}>See league leaders</button>
           </div>

--- a/src/ui/components/TeamHistoryScreen.jsx
+++ b/src/ui/components/TeamHistoryScreen.jsx
@@ -47,6 +47,12 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
   const best = [...timeline].sort((a, b) => b.wins - a.wins)[0];
   const worst = [...timeline].sort((a, b) => a.wins - b.wins)[0];
   const drought = [...timeline].reverse().findIndex((t) => t.champion);
+  const recentFive = timeline.slice(-5);
+  const recentTrend = recentFive.length ? (recentFive.reduce((sum, row) => sum + Number(row.wins ?? 0), 0) / recentFive.length).toFixed(1) : "0.0";
+  const avgDiff = timeline.length ? (timeline.reduce((sum, row) => sum + (Number(row.pf ?? 0) - Number(row.pa ?? 0)), 0) / timeline.length).toFixed(1) : "0.0";
+  const timelineStory = timeline.length
+    ? `${activeTeam?.abbr ?? activeTeam?.name ?? "Team"} posted ${titles} title${titles === 1 ? "" : "s"} and ${playoffYears} playoff-caliber seasons across ${timeline.length} archived years.`
+    : "Franchise history starts once completed seasons are archived.";
   const completedGameRows = useMemo(() => {
     const rows = [];
     const targetTeamId = Number(activeTeam?.id);
@@ -93,7 +99,15 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
         <div className="stat-box"><div className="stat-label">Titles</div><div className="stat-value-large">{titles}</div></div>
         <div className="stat-box"><div className="stat-label">Playoff-caliber years</div><div className="stat-value-large">{playoffYears}</div></div>
         <div className="stat-box"><div className="stat-label">Current drought</div><div className="stat-value-large">{drought < 0 ? 'No title yet' : `${drought} seasons`}</div></div>
+        <div className="stat-box"><div className="stat-label">Recent avg wins (5y)</div><div className="stat-value-large">{recentTrend}</div></div>
       </div>
+
+      <SectionCard title="Franchise memory capsule">
+        <div style={{ fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}>{timelineStory}</div>
+        <div style={{ marginTop: 8, fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+          Average point differential across archived seasons: <strong style={{ color: 'var(--text)' }}>{avgDiff}</strong>
+        </div>
+      </SectionCard>
 
       <SectionCard title="Best and worst seasons">
         <div style={{ fontSize: 'var(--text-sm)' }}>Best: {best ? `${best.year} (${best.wins}-${best.losses}${best.ties ? `-${best.ties}` : ''})` : '—'}</div>
@@ -126,6 +140,11 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
                 <span>{s.wins}-{s.losses}{s.ties ? `-${s.ties}` : ''}{s.champion ? ' · 🏆 Champion' : ''}</span>
               </div>
               <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>PF {s.pf} · PA {s.pa}</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 4 }}>
+                {s.champion ? <span style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 8px' }}>Title season</span> : null}
+                {s.wins >= 12 ? <span style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 8px' }}>Elite year</span> : null}
+                {s.wins <= 4 ? <span style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 8px' }}>Rebuild low</span> : null}
+              </div>
               {s.mvp?.playerId != null ? <button className="btn-link" onClick={() => onPlayerSelect?.(s.mvp.playerId)}>League MVP: {s.mvp.name}</button> : null}
             </div>
           ))}


### PR DESCRIPTION
### Motivation
- Make long-term saves feel more meaningful by turning fragmented history screens into a coherent "league memory" layer with clearer navigation and story-focused presentation.
- Surface season-level headlines, award winners, champions, and team milestones so users can quickly understand what defined a season and a franchise over time.
- Improve discoverability and scanability of records, awards, Hall of Fame, and player career context without changing simulation logic.

### Description
- Reworked History Hub wording and destination tiles to emphasize an archive-first flow and clearer destination names (History/League Archive, Franchise Timeline, Hall of Fame, Awards & Records). (updated `HistoryHub.jsx`)
- Upgraded League History with a season storyline summary, champion leaderboard, previous/next season navigation, playoff-caliber highlights, award quick-link chips, and an improved empty state; also added a champion badge in the header to surface dominant franchises. (updated `LeagueHistory.jsx`)
- Enhanced Records UI to support browsing scopes for single-game, single-season, and career records with context copy and an added tab trigger for single-game records. (updated `LeagueHistory.jsx`)
- Strengthened Team History with a franchise memory capsule (summary sentence), recent 5-year average wins metric, average point-differential, and season tags (Title / Elite / Rebuild low) to make franchise highs/lows obvious. (updated `TeamHistoryScreen.jsx`)
- Improved Awards & Records screen with an MVP filter and a toggle for record scope (single-season vs career) for faster filtering. (updated `AwardsRecordsScreen.jsx`)
- Made Hall of Fame browsing more useful by adding induction class filtering and a latest-class spotlight to surface recent inductees. (updated `HallOfFame.jsx`)
- Added a Season Memory Capsule to `SeasonRecap.jsx` summarizing headline outcomes (champion, MVP, runner-up, notable storyline) and added cross-navigation buttons into archive, franchise timeline, awards/records, and Hall of Fame to tie recap → memory → detail flows.
- Improved player legacy framing with a structured "Career Arc" timeline that combines season markers and accolade events for clearer career storytelling in `PlayerProfile.jsx`.
- Small UI helper functions and non-invasive presentation helpers added (season summary, champion map, small sorting/filters); no simulation or persistence logic was rewritten.

### Testing
- `npm run build` completed successfully and produced a production bundle. (passed)
- Ran targeted unit tests: `npx vitest run src/ui/utils/historyDestinations.test.js src/ui/utils/playerCompare.test.js` and they passed. (passed)
- Ran full unit suite `npm run test:unit`; the run surfaced existing unrelated failures (Playwright spec loading issues and several pre-existing unit test expectations) that are not caused by these UI-only edits — the changed history/storytelling files do not appear in the failing traces. (CI: partial, unrelated failures present)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfcb9e02ac832daa1f9fddd9a9a716)