### PR TITLE
Add player development intelligence layer: trend/readiness/fit signals on roster and profile

### DIFF
--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -20,6 +20,7 @@ import FaceAvatar from './FaceAvatar.jsx';
 import { Line } from 'react-chartjs-2';
 import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend } from 'chart.js';
 import { PERSONALITY_TOOLTIPS } from '../../core/development/personalitySystem.js';
+import { buildDevelopmentNotes, classifyDevelopmentTrend, getPlayerReadiness, getSchemeFitSignal } from '../utils/playerDevelopmentSignals.js';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
@@ -364,6 +365,10 @@ export default function PlayerProfile({
   const chemistry = useMemo(() => buildTeamChemistrySummary(userTeam, { week: data?.meta?.week ?? 1, direction: teamIntel?.direction }), [userTeam, data?.meta?.week, teamIntel]);
   const moraleContext = useMemo(() => describePlayerMoraleContext(player, { team: userTeam, chemistry, week: data?.meta?.week ?? 1 }), [player, userTeam, chemistry, data?.meta?.week]);
   const onboardingContext = useMemo(() => ((isProspect || Number(player?.age ?? 30) <= 24) ? describeRookieOnboarding(player, teamIntel) : null), [isProspect, player, teamIntel]);
+  const developmentSignal = useMemo(() => classifyDevelopmentTrend(player), [player]);
+  const readinessSignal = useMemo(() => getPlayerReadiness(player), [player]);
+  const fitSignal = useMemo(() => getSchemeFitSignal(player), [player]);
+  const developmentNotes = useMemo(() => buildDevelopmentNotes(player, moraleContext), [player, moraleContext]);
 
   const management = useMemo(() => normalizeManagement(player), [player]);
   const updateManagement = async (updates) => {
@@ -627,6 +632,9 @@ export default function PlayerProfile({
                     Dev path: {player.developmentContext.baseAgeCurve} · Focus {String(player.developmentContext.trainingFocus || 'balanced').replace('_', ' ')} · Staff mod {player.developmentContext.staffDevelopmentModifier >= 0 ? '+' : ''}{player.developmentContext.staffDevelopmentModifier}% · {player.developmentContext.playingTimeModifier}
                   </div>
                 )}
+                <div style={{ marginTop: 6, fontSize: 'var(--text-xs)', color: 'var(--text-subtle)' }}>
+                  Trend: {developmentSignal.label} · Readiness: {readinessSignal.label} · Scheme: {fitSignal.label}
+                </div>
 
                 {/* Traits */}
                 {player.traits?.length > 0 && (
@@ -835,6 +843,46 @@ export default function PlayerProfile({
             </section>
           )}
 
+
+          {!loading && player && (
+            <section>
+              <h3 style={sectionLabelStyle}>Development Intelligence</h3>
+              <div style={{ display: "grid", gap: "var(--space-2)", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" }}>
+                <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Trajectory</div>
+                  <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>{developmentSignal.label}</div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>OVR change: {player.progressionDelta > 0 ? "+" : ""}{player.progressionDelta ?? 0}</div>
+                </div>
+                <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Short-term readiness</div>
+                  <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>{readinessSignal.label}</div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>{readinessSignal.detail}</div>
+                </div>
+                <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Scheme fit context</div>
+                  <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>{fitSignal.label} · {player?.schemeFit ?? 50}</div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>Best role is tied to current scheme and depth usage.</div>
+                </div>
+                <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Age curve</div>
+                  <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>
+                    {Number(player?.age ?? 30) <= 24 ? "Early growth window" : Number(player?.age ?? 30) >= 30 ? "Late-career window" : "Prime window"}
+                  </div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>Age {player?.age ?? "—"} · Potential {player?.potential ?? "—"}.</div>
+                </div>
+              </div>
+              <div style={{ marginTop: 8, display: "grid", gap: 4 }}>
+                {developmentNotes.notes.slice(0, 4).map((note, idx) => (
+                  <div key={`dev-note-${idx}`} style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>• {note}</div>
+                ))}
+              </div>
+              <div style={{ marginTop: 8, display: "flex", gap: 6, flexWrap: "wrap" }}>
+                <Button size="sm" variant="outline" onClick={() => onNavigate?.("Roster")}>Review depth role</Button>
+                <Button size="sm" variant="outline" onClick={() => onNavigate?.("Contract Center")}>Review extension decision</Button>
+                <Button size="sm" variant="outline" onClick={() => onNavigate?.("Trade Center")}>Check trade value</Button>
+              </div>
+            </section>
+          )}
 
           {!loading && player && (
             <section>

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -52,6 +52,7 @@ import { normalizeManagement, TRADE_STATUSES, TRADE_STATUS_LABELS, CONTRACT_PLAN
 import { deriveTeamCapSnapshot, formatMoneyM, toFiniteNumber } from "../utils/numberFormatting.js";
 import { derivePlayerContractFinancials } from "../utils/contractFormatting.js";
 import { describePlayerMoraleContext } from "../utils/teamChemistry.js";
+import { buildDevelopmentNotes, summarizeRosterDevelopment } from "../utils/playerDevelopmentSignals.js";
 import { getDepthRows, autoBuildDepthChart, depthWarnings } from "../../core/depthChart.js";
 import AdvancedPlayerSearch from "./AdvancedPlayerSearch.jsx";
 import { applyAdvancedPlayerFilters } from "../../core/footballAdvancedFilters";
@@ -428,6 +429,32 @@ function StatusBadge({ injuryWeeks }) {
       }}
     >
       {isIR ? "IR" : "OUT"}
+    </span>
+  );
+}
+
+function DevelopmentTag({ label, tone = "neutral" }) {
+  const tones = {
+    good: { color: "var(--success)", bg: "rgba(52,199,89,0.14)" },
+    warn: { color: "var(--warning)", bg: "rgba(255,159,10,0.14)" },
+    bad: { color: "var(--danger)", bg: "rgba(255,69,58,0.14)" },
+    neutral: { color: "var(--text-subtle)", bg: "var(--surface-strong)" },
+  };
+  const cfg = tones[tone] ?? tones.neutral;
+  return (
+    <span
+      style={{
+        fontSize: 9,
+        fontWeight: 800,
+        borderRadius: "var(--radius-pill)",
+        padding: "1px 6px",
+        color: cfg.color,
+        background: cfg.bg,
+        letterSpacing: ".03em",
+        textTransform: "uppercase",
+      }}
+    >
+      {label}
     </span>
   );
 }
@@ -848,6 +875,7 @@ function RosterTable({
                 const fitCol = indicatorColor(fit);
                 const moraleCol = indicatorColor(morale);
                 const moraleContext = describePlayerMoraleContext(player, { team, chemistry, week });
+                const devContext = buildDevelopmentNotes(player, moraleContext);
                 const expiringDecision = isResignPhase && isExpiring
                   ? classifyExpiringDecision(player, { team, roster: players, direction: teamDirection })
                   : null;
@@ -898,6 +926,10 @@ function RosterTable({
                       >
                         {player.name}
                         <div style={{ fontSize: 10, color: "var(--text-subtle)" }}>{TRADE_STATUS_LABELS[normalizeManagement(player).tradeStatus]}{normalizeManagement(player).contractPlan[0] ? ` · ${CONTRACT_PLAN_LABELS[normalizeManagement(player).contractPlan[0]]}` : ""}</div>
+                        <div style={{ marginTop: 2, display: "flex", gap: 4, flexWrap: "wrap" }}>
+                          <DevelopmentTag label={devContext.trend.label} tone={devContext.trend.tone} />
+                          <DevelopmentTag label={devContext.readiness.label} tone={devContext.readiness.tone} />
+                        </div>
                       </button>
                       {isResignPhase && isZeroYears && (
                         <span
@@ -2162,6 +2194,14 @@ export default function Roster({ league, actions, onPlayerSelect, onNavigate = n
   );
   const directionGuidance = useMemo(() => buildDirectionGuidance(teamIntel), [teamIntel]);
   const chemistry = teamIntel?.chemistry;
+  const moraleById = useMemo(() => {
+    const map = new Map();
+    players.forEach((p) => {
+      map.set(p.id, describePlayerMoraleContext(p, { team, chemistry, week: league?.week }));
+    });
+    return map;
+  }, [players, team, chemistry, league?.week]);
+  const developmentSummary = useMemo(() => summarizeRosterDevelopment(players, moraleById), [players, moraleById]);
 
   return (
     <div>
@@ -2197,6 +2237,31 @@ export default function Roster({ league, actions, onPlayerSelect, onNavigate = n
         starterHealth={`${Math.max(0, starterCount - injuredCount)}/${starterCount || 0} available`}
         expiringCount={expiringCount}
       />
+      <Card className="card-premium" style={{ marginBottom: "var(--space-2)", padding: "var(--space-3) var(--space-4)" }}>
+        <CardContent style={{ display: "grid", gap: 8 }}>
+          <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 800, textTransform: "uppercase", letterSpacing: ".08em" }}>
+            Development intelligence
+          </div>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <Badge variant="outline">📈 Rising: {developmentSummary.rising.length}</Badge>
+            <Badge variant={developmentSummary.slipping.length > 0 ? "destructive" : "outline"}>📉 Slipping: {developmentSummary.slipping.length}</Badge>
+            <Badge variant={developmentSummary.moraleRisk.length > 0 ? "destructive" : "outline"}>😕 Morale risk: {developmentSummary.moraleRisk.length}</Badge>
+            <Badge variant={developmentSummary.mismatch.length > 0 ? "destructive" : "secondary"}>🧩 Scheme mismatch: {developmentSummary.mismatch.length}</Badge>
+            <Badge variant="secondary">🌱 Rookie watch: {developmentSummary.rookieWatch.length}</Badge>
+          </div>
+          <div style={{ display: "grid", gap: 4, fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>
+            {developmentSummary.rising[0] ? <div>Best current development bet: <strong style={{ color: "var(--text)" }}>{developmentSummary.rising[0].name}</strong> ({developmentSummary.rising[0].progressionDelta > 0 ? "+" : ""}{developmentSummary.rising[0].progressionDelta ?? 0} OVR).</div> : null}
+            {developmentSummary.slipping[0] ? <div>Regression watch: <strong style={{ color: "var(--text)" }}>{developmentSummary.slipping[0].name}</strong> ({developmentSummary.slipping[0].progressionDelta ?? 0} OVR) — review role, usage, and contract timeline.</div> : null}
+            {developmentSummary.mismatch[0] ? <div>Top scheme mismatch: <strong style={{ color: "var(--text)" }}>{developmentSummary.mismatch[0].name}</strong> (fit {developmentSummary.mismatch[0].schemeFit ?? 50}) — consider package changes or depth-chart adjustment.</div> : null}
+          </div>
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+            <Button variant="outline" size="sm" onClick={() => { setViewMode("table"); setInitialFilter("DEVELOPMENT"); }}>Open young/development group</Button>
+            <Button variant="outline" size="sm" onClick={() => { setViewMode("depth"); setInitialFilter("DEPTH"); }}>Adjust depth chart</Button>
+            <Button variant="outline" size="sm" onClick={() => onNavigate?.("Contract Center")}>Review contract calls</Button>
+            <Button variant="outline" size="sm" onClick={() => onNavigate?.("Trade Center")}>Check trade market</Button>
+          </div>
+        </CardContent>
+      </Card>
 
       <Card
         className="card-premium"

--- a/src/ui/utils/playerDevelopmentSignals.js
+++ b/src/ui/utils/playerDevelopmentSignals.js
@@ -1,0 +1,136 @@
+const safeNumber = (value, fallback = 0) => {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+};
+
+const normalizeDepthOrder = (player) => safeNumber(player?.depthChart?.order ?? player?.depthOrder ?? 99, 99);
+
+export function classifyDevelopmentTrend(player) {
+  const age = safeNumber(player?.age, 30);
+  const delta = safeNumber(player?.progressionDelta, 0);
+  const potential = safeNumber(player?.potential, safeNumber(player?.ovr, 70));
+  const ovr = safeNumber(player?.ovr, 70);
+  const upsideGap = potential - ovr;
+  const injuryWeeks = safeNumber(player?.injuryWeeksRemaining ?? player?.injury?.weeksRemaining, 0);
+
+  if (delta >= 3 && age <= 26) {
+    return { key: 'breakout_candidate', label: 'Breakout candidate', tone: 'good', icon: '🚀' };
+  }
+  if (delta >= 1) {
+    return { key: 'trending_up', label: 'Trending up', tone: 'good', icon: '📈' };
+  }
+  if (delta <= -2 && age >= 29) {
+    return { key: 'regression_risk', label: 'Regression risk', tone: 'bad', icon: '⚠️' };
+  }
+  if (age >= 30 && Math.abs(delta) <= 1) {
+    return { key: 'stable_veteran', label: 'Stable veteran', tone: 'neutral', icon: '🧭' };
+  }
+  if (age <= 24 && delta <= 0 && upsideGap >= 6) {
+    return {
+      key: injuryWeeks > 0 ? 'slowed_prospect' : 'stagnating_prospect',
+      label: injuryWeeks > 0 ? 'Slowed prospect' : 'Stagnating prospect',
+      tone: 'warn',
+      icon: injuryWeeks > 0 ? '🩹' : '⏳',
+    };
+  }
+  if (delta <= -1) {
+    return { key: 'trending_down', label: 'Trending down', tone: 'bad', icon: '📉' };
+  }
+  return { key: 'holding_pattern', label: 'Holding pattern', tone: 'neutral', icon: '➖' };
+}
+
+export function getPlayerReadiness(player) {
+  const age = safeNumber(player?.age, 30);
+  const ovr = safeNumber(player?.ovr, 0);
+  const injuryWeeks = safeNumber(player?.injuryWeeksRemaining ?? player?.injury?.weeksRemaining, 0);
+  const depthOrder = normalizeDepthOrder(player);
+
+  if (injuryWeeks > 0) {
+    return {
+      key: 'injured',
+      label: `Injured (${injuryWeeks}w)`,
+      detail: 'Short-term readiness is limited by injury recovery.',
+      tone: 'bad',
+    };
+  }
+  if (depthOrder >= 3 && age <= 25 && ovr >= 68) {
+    return {
+      key: 'blocked',
+      label: 'Blocked by depth',
+      detail: 'Long-term upside exists, but current role limits snaps.',
+      tone: 'warn',
+    };
+  }
+  if (ovr >= 75 || depthOrder <= 2) {
+    return {
+      key: 'game_ready',
+      label: 'Game ready',
+      detail: 'Can contribute now in current rotation.',
+      tone: 'good',
+    };
+  }
+  return {
+    key: 'developing',
+    label: 'Developing',
+    detail: 'Needs reps to translate upside into week-to-week impact.',
+    tone: 'neutral',
+  };
+}
+
+export function getSchemeFitSignal(player) {
+  const fit = safeNumber(player?.schemeFit, 50);
+  if (fit >= 75) return { key: 'strong_fit', label: 'Strong fit', tone: 'good' };
+  if (fit <= 45) return { key: 'weak_fit', label: 'Weak fit', tone: 'bad' };
+  return { key: 'neutral_fit', label: 'Neutral fit', tone: 'neutral' };
+}
+
+export function buildDevelopmentNotes(player, moraleContext = null) {
+  const trend = classifyDevelopmentTrend(player);
+  const readiness = getPlayerReadiness(player);
+  const fit = getSchemeFitSignal(player);
+  const notes = [
+    `${trend.icon} ${trend.label}`,
+    `${fit.label} (${safeNumber(player?.schemeFit, 50)})`,
+    readiness.label,
+  ];
+  if (moraleContext?.state) {
+    notes.push(`Morale: ${moraleContext.state}`);
+  }
+  const topReason = moraleContext?.reasons?.[0];
+  if (topReason) notes.push(topReason);
+  return { trend, readiness, fit, notes };
+}
+
+export function summarizeRosterDevelopment(players = [], moraleById = new Map()) {
+  const list = Array.isArray(players) ? players : [];
+  const rising = [];
+  const slipping = [];
+  const moraleRisk = [];
+  const mismatch = [];
+  const rookiesWatch = [];
+
+  for (const player of list) {
+    const trend = classifyDevelopmentTrend(player);
+    const moraleState = moraleById.get(player?.id)?.state ?? '';
+    const moraleScore = safeNumber(player?.morale, 70);
+    const fit = safeNumber(player?.schemeFit, 50);
+    const age = safeNumber(player?.age, 30);
+
+    if (['breakout_candidate', 'trending_up'].includes(trend.key)) rising.push(player);
+    if (['regression_risk', 'trending_down'].includes(trend.key)) slipping.push(player);
+    if (moraleScore <= 62 || String(moraleState).toLowerCase().includes('friction') || String(moraleState).toLowerCase().includes('frustrated')) moraleRisk.push(player);
+    if (fit <= 45) mismatch.push(player);
+    if (age <= 24) rookiesWatch.push(player);
+  }
+
+  const sortByDelta = (a, b) => safeNumber(b?.progressionDelta, 0) - safeNumber(a?.progressionDelta, 0);
+  const sortByNegativeDelta = (a, b) => safeNumber(a?.progressionDelta, 0) - safeNumber(b?.progressionDelta, 0);
+
+  return {
+    rising: rising.sort(sortByDelta),
+    slipping: slipping.sort(sortByNegativeDelta),
+    moraleRisk: moraleRisk.sort((a, b) => safeNumber(a?.morale, 100) - safeNumber(b?.morale, 100)),
+    mismatch: mismatch.sort((a, b) => safeNumber(a?.schemeFit, 100) - safeNumber(b?.schemeFit, 100)),
+    rookieWatch: rookiesWatch.sort((a, b) => safeNumber(a?.age, 99) - safeNumber(b?.age, 99)),
+  };
+}


### PR DESCRIPTION
### Motivation
- Make player progression, morale, and readiness easier to scan and act on without changing core sim progression logic. 
- Surface why players are improving or declining (age, injuries, usage, scheme fit, morale) and link signals into team actions. 

### Description
- Added a new reusable utility `src/ui/utils/playerDevelopmentSignals.js` that classifies development `trend`, `readiness`, and `scheme fit`, builds compact development notes, and summarizes roster-level signals (rising/slipping/morale risk/mismatch/rookie watch). 
- Surface per-player development/readiness chips in the roster table by integrating `buildDevelopmentNotes` so rows show a compact trajectory and readiness tag for quick scanning. 
- Added a team-level “Development intelligence” strip to the Roster view that shows counts (rising/slipping/morale risk/scheme mismatch/rookie watch), highlights top watch names, and provides quick action buttons into depth/development/contracts/trade flows. 
- Enhanced `PlayerProfile` with a concise header line (`Trend · Readiness · Scheme`) and a new `Development Intelligence` section that explains trajectory, short-term readiness, scheme-fit context, age-curve context, development notes, and direct action buttons (depth/contract/trade). 
- Changes are presentation-only and intentionally reuse existing data (ratings history, `progressionDelta`, `morale`, `schemeFit`, `age`, `injuryWeeksRemaining`, `potential`, etc.) without modifying core sim progression logic. 

### Testing
- Ran unit tests with `npm run test:unit -- src/ui/components/coreManagementScreens.test.jsx` and the suite passed. 
- Built the production bundle with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e00abb269c832d8dcf050145901227)