### PR TITLE
Improve player development & morale UX: chips, profile cards, and roster intelligence

### DIFF
--- a/src/ui/components/PlayerDevelopmentUI.jsx
+++ b/src/ui/components/PlayerDevelopmentUI.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+
+const TONE_CONFIG = {
+  good: { color: "var(--success)", bg: "rgba(52,199,89,0.14)", border: "rgba(52,199,89,0.35)" },
+  warn: { color: "var(--warning)", bg: "rgba(255,159,10,0.14)", border: "rgba(255,159,10,0.35)" },
+  bad: { color: "var(--danger)", bg: "rgba(255,69,58,0.14)", border: "rgba(255,69,58,0.35)" },
+  neutral: { color: "var(--text-subtle)", bg: "var(--surface-strong)", border: "var(--hairline)" },
+};
+
+export function ToneChip({ label, tone = "neutral", title = "" }) {
+  const cfg = TONE_CONFIG[tone] ?? TONE_CONFIG.neutral;
+  return (
+    <span
+      title={title}
+      style={{
+        fontSize: 9,
+        fontWeight: 800,
+        borderRadius: "var(--radius-pill)",
+        padding: "1px 6px",
+        color: cfg.color,
+        background: cfg.bg,
+        border: `1px solid ${cfg.border}`,
+        letterSpacing: ".03em",
+        textTransform: "uppercase",
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+export function DevelopmentStatCard({ label, value, detail, tone = "neutral" }) {
+  const cfg = TONE_CONFIG[tone] ?? TONE_CONFIG.neutral;
+  return (
+    <div style={{ border: `1px solid ${cfg.border}`, borderRadius: "var(--radius-md)", padding: "10px", background: cfg.bg }}>
+      <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>{label}</div>
+      <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2, color: cfg.color }}>{value}</div>
+      {detail ? <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)", marginTop: 2 }}>{detail}</div> : null}
+    </div>
+  );
+}
+
+export function DevelopmentSignalRow({ items = [] }) {
+  if (!items.length) return null;
+  return (
+    <div style={{ marginTop: 6, display: "flex", gap: 6, flexWrap: "wrap" }}>
+      {items.map((item) => (
+        <ToneChip
+          key={`${item.label}-${item.title ?? ""}`}
+          label={item.label}
+          tone={item.tone}
+          title={item.title}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -20,7 +20,8 @@ import FaceAvatar from './FaceAvatar.jsx';
 import { Line } from 'react-chartjs-2';
 import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend } from 'chart.js';
 import { PERSONALITY_TOOLTIPS } from '../../core/development/personalitySystem.js';
-import { buildDevelopmentNotes, classifyDevelopmentTrend, getPlayerReadiness, getSchemeFitSignal } from '../utils/playerDevelopmentSignals.js';
+import { buildDevelopmentNotes, classifyDevelopmentTrend, getPlayerReadiness, getSchemeFitSignal, getAgeCurveContext, getDevelopmentSnapshot, getDevelopmentDrivers } from '../utils/playerDevelopmentSignals.js';
+import { ToneChip, DevelopmentSignalRow, DevelopmentStatCard } from './PlayerDevelopmentUI.jsx';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
@@ -369,6 +370,9 @@ export default function PlayerProfile({
   const readinessSignal = useMemo(() => getPlayerReadiness(player), [player]);
   const fitSignal = useMemo(() => getSchemeFitSignal(player), [player]);
   const developmentNotes = useMemo(() => buildDevelopmentNotes(player, moraleContext), [player, moraleContext]);
+  const ageCurve = useMemo(() => getAgeCurveContext(player), [player]);
+  const developmentSnapshot = useMemo(() => getDevelopmentSnapshot(player), [player]);
+  const developmentDrivers = useMemo(() => getDevelopmentDrivers(player, moraleContext), [player, moraleContext]);
 
   const management = useMemo(() => normalizeManagement(player), [player]);
   const updateManagement = async (updates) => {
@@ -635,6 +639,14 @@ export default function PlayerProfile({
                 <div style={{ marginTop: 6, fontSize: 'var(--text-xs)', color: 'var(--text-subtle)' }}>
                   Trend: {developmentSignal.label} · Readiness: {readinessSignal.label} · Scheme: {fitSignal.label}
                 </div>
+                <DevelopmentSignalRow
+                  items={[
+                    { label: developmentSignal.label, tone: developmentSignal.tone },
+                    { label: readinessSignal.label, tone: readinessSignal.tone },
+                    { label: `${fitSignal.label} (${player?.schemeFit ?? 50})`, tone: fitSignal.tone },
+                    { label: ageCurve.label, tone: ageCurve.tone },
+                  ]}
+                />
 
                 {/* Traits */}
                 {player.traits?.length > 0 && (
@@ -848,34 +860,49 @@ export default function PlayerProfile({
             <section>
               <h3 style={sectionLabelStyle}>Development Intelligence</h3>
               <div style={{ display: "grid", gap: "var(--space-2)", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" }}>
-                <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
-                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Trajectory</div>
-                  <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>{developmentSignal.label}</div>
-                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>OVR change: {player.progressionDelta > 0 ? "+" : ""}{player.progressionDelta ?? 0}</div>
-                </div>
-                <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
-                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Short-term readiness</div>
-                  <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>{readinessSignal.label}</div>
-                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>{readinessSignal.detail}</div>
-                </div>
-                <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
-                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Scheme fit context</div>
-                  <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>{fitSignal.label} · {player?.schemeFit ?? 50}</div>
-                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>Best role is tied to current scheme and depth usage.</div>
-                </div>
-                <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
-                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Age curve</div>
-                  <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>
-                    {Number(player?.age ?? 30) <= 24 ? "Early growth window" : Number(player?.age ?? 30) >= 30 ? "Late-career window" : "Prime window"}
-                  </div>
-                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>Age {player?.age ?? "—"} · Potential {player?.potential ?? "—"}.</div>
-                </div>
+                <DevelopmentStatCard
+                  label="Trajectory"
+                  value={`${developmentSignal.icon} ${developmentSignal.label}`}
+                  detail={`OVR change: ${player.progressionDelta > 0 ? "+" : ""}${player.progressionDelta ?? 0}`}
+                  tone={developmentSignal.tone}
+                />
+                <DevelopmentStatCard
+                  label="Short-term readiness"
+                  value={readinessSignal.label}
+                  detail={readinessSignal.detail}
+                  tone={readinessSignal.tone}
+                />
+                <DevelopmentStatCard
+                  label="Scheme fit context"
+                  value={`${fitSignal.label} · ${player?.schemeFit ?? 50}`}
+                  detail="Best role is tied to current scheme and depth usage."
+                  tone={fitSignal.tone}
+                />
+                <DevelopmentStatCard
+                  label="Age curve"
+                  value={ageCurve.label}
+                  detail={`Age ${player?.age ?? "—"} · Potential ${player?.potential ?? "—"}. ${ageCurve.detail}`}
+                  tone={ageCurve.tone}
+                />
               </div>
               <div style={{ marginTop: 8, display: "grid", gap: 4 }}>
                 {developmentNotes.notes.slice(0, 4).map((note, idx) => (
                   <div key={`dev-note-${idx}`} style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>• {note}</div>
                 ))}
+                {developmentDrivers.slice(0, 3).map((driver, idx) => (
+                  <div key={`driver-${idx}`} style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>↳ {driver}</div>
+                ))}
               </div>
+              {developmentSnapshot ? (
+                <div style={{ marginTop: 8, border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px", background: "var(--surface-strong)" }}>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Recent development snapshot</div>
+                  <div style={{ marginTop: 4, display: "flex", gap: 8, flexWrap: "wrap" }}>
+                    {developmentSnapshot.topGain ? <ToneChip label={`Top gain: ${developmentSnapshot.topGain.label} +${developmentSnapshot.topGain.delta}`} tone="good" /> : null}
+                    {developmentSnapshot.topDrop && developmentSnapshot.topDrop.delta < 0 ? <ToneChip label={`Top drop: ${developmentSnapshot.topDrop.label} ${developmentSnapshot.topDrop.delta}`} tone="bad" /> : null}
+                    {!developmentSnapshot.topGain && !developmentSnapshot.topDrop ? <span style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>No category-level change in latest snapshot.</span> : null}
+                  </div>
+                </div>
+              ) : null}
               <div style={{ marginTop: 8, display: "flex", gap: 6, flexWrap: "wrap" }}>
                 <Button size="sm" variant="outline" onClick={() => onNavigate?.("Roster")}>Review depth role</Button>
                 <Button size="sm" variant="outline" onClick={() => onNavigate?.("Contract Center")}>Review extension decision</Button>

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -59,6 +59,7 @@ import { applyAdvancedPlayerFilters } from "../../core/footballAdvancedFilters";
 import { usePlayerCompare } from "../utils/playerCompare.js";
 import SocialFeed from "./SocialFeed.jsx";
 import { TeamWorkspaceHeader, TeamCapSummaryStrip } from "./TeamWorkspacePrimitives.jsx";
+import { ToneChip, DevelopmentSignalRow } from "./PlayerDevelopmentUI.jsx";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -429,32 +430,6 @@ function StatusBadge({ injuryWeeks }) {
       }}
     >
       {isIR ? "IR" : "OUT"}
-    </span>
-  );
-}
-
-function DevelopmentTag({ label, tone = "neutral" }) {
-  const tones = {
-    good: { color: "var(--success)", bg: "rgba(52,199,89,0.14)" },
-    warn: { color: "var(--warning)", bg: "rgba(255,159,10,0.14)" },
-    bad: { color: "var(--danger)", bg: "rgba(255,69,58,0.14)" },
-    neutral: { color: "var(--text-subtle)", bg: "var(--surface-strong)" },
-  };
-  const cfg = tones[tone] ?? tones.neutral;
-  return (
-    <span
-      style={{
-        fontSize: 9,
-        fontWeight: 800,
-        borderRadius: "var(--radius-pill)",
-        padding: "1px 6px",
-        color: cfg.color,
-        background: cfg.bg,
-        letterSpacing: ".03em",
-        textTransform: "uppercase",
-      }}
-    >
-      {label}
     </span>
   );
 }
@@ -927,8 +902,9 @@ function RosterTable({
                         {player.name}
                         <div style={{ fontSize: 10, color: "var(--text-subtle)" }}>{TRADE_STATUS_LABELS[normalizeManagement(player).tradeStatus]}{normalizeManagement(player).contractPlan[0] ? ` · ${CONTRACT_PLAN_LABELS[normalizeManagement(player).contractPlan[0]]}` : ""}</div>
                         <div style={{ marginTop: 2, display: "flex", gap: 4, flexWrap: "wrap" }}>
-                          <DevelopmentTag label={devContext.trend.label} tone={devContext.trend.tone} />
-                          <DevelopmentTag label={devContext.readiness.label} tone={devContext.readiness.tone} />
+                          <ToneChip label={devContext.trend.label} tone={devContext.trend.tone} />
+                          <ToneChip label={devContext.readiness.label} tone={devContext.readiness.tone} />
+                          <ToneChip label={devContext.fit.label} tone={devContext.fit.tone} />
                         </div>
                       </button>
                       {isResignPhase && isZeroYears && (
@@ -2247,13 +2223,23 @@ export default function Roster({ league, actions, onPlayerSelect, onNavigate = n
             <Badge variant={developmentSummary.slipping.length > 0 ? "destructive" : "outline"}>📉 Slipping: {developmentSummary.slipping.length}</Badge>
             <Badge variant={developmentSummary.moraleRisk.length > 0 ? "destructive" : "outline"}>😕 Morale risk: {developmentSummary.moraleRisk.length}</Badge>
             <Badge variant={developmentSummary.mismatch.length > 0 ? "destructive" : "secondary"}>🧩 Scheme mismatch: {developmentSummary.mismatch.length}</Badge>
+            <Badge variant={developmentSummary.blocked.length > 0 ? "secondary" : "outline"}>🚧 Blocked dev: {developmentSummary.blocked.length}</Badge>
+            <Badge variant={developmentSummary.contractPressure.length > 0 ? "secondary" : "outline"}>⏱ Contract pressure: {developmentSummary.contractPressure.length}</Badge>
             <Badge variant="secondary">🌱 Rookie watch: {developmentSummary.rookieWatch.length}</Badge>
           </div>
           <div style={{ display: "grid", gap: 4, fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>
             {developmentSummary.rising[0] ? <div>Best current development bet: <strong style={{ color: "var(--text)" }}>{developmentSummary.rising[0].name}</strong> ({developmentSummary.rising[0].progressionDelta > 0 ? "+" : ""}{developmentSummary.rising[0].progressionDelta ?? 0} OVR).</div> : null}
             {developmentSummary.slipping[0] ? <div>Regression watch: <strong style={{ color: "var(--text)" }}>{developmentSummary.slipping[0].name}</strong> ({developmentSummary.slipping[0].progressionDelta ?? 0} OVR) — review role, usage, and contract timeline.</div> : null}
             {developmentSummary.mismatch[0] ? <div>Top scheme mismatch: <strong style={{ color: "var(--text)" }}>{developmentSummary.mismatch[0].name}</strong> (fit {developmentSummary.mismatch[0].schemeFit ?? 50}) — consider package changes or depth-chart adjustment.</div> : null}
+            {developmentSummary.blocked[0] ? <div>Blocked prospect: <strong style={{ color: "var(--text)" }}>{developmentSummary.blocked[0].name}</strong> is depth-clamped — consider role/package changes.</div> : null}
+            {developmentSummary.contractPressure[0] ? <div>Trajectory + contract decision: <strong style={{ color: "var(--text)" }}>{developmentSummary.contractPressure[0].name}</strong> is up for a near-term call.</div> : null}
           </div>
+          <DevelopmentSignalRow items={[
+            developmentSummary.rising[0] ? { label: `Rising: ${developmentSummary.rising[0].name}`, tone: 'good' } : null,
+            developmentSummary.slipping[0] ? { label: `Slipping: ${developmentSummary.slipping[0].name}`, tone: 'bad' } : null,
+            developmentSummary.moraleRisk[0] ? { label: `Morale risk: ${developmentSummary.moraleRisk[0].name}`, tone: 'warn' } : null,
+            developmentSummary.blocked[0] ? { label: `Blocked: ${developmentSummary.blocked[0].name}`, tone: 'warn' } : null,
+          ].filter(Boolean)} />
           <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
             <Button variant="outline" size="sm" onClick={() => { setViewMode("table"); setInitialFilter("DEVELOPMENT"); }}>Open young/development group</Button>
             <Button variant="outline" size="sm" onClick={() => { setViewMode("depth"); setInitialFilter("DEPTH"); }}>Adjust depth chart</Button>

--- a/src/ui/utils/playerDevelopmentSignals.js
+++ b/src/ui/utils/playerDevelopmentSignals.js
@@ -84,6 +84,59 @@ export function getSchemeFitSignal(player) {
   return { key: 'neutral_fit', label: 'Neutral fit', tone: 'neutral' };
 }
 
+export function getAgeCurveContext(player) {
+  const age = safeNumber(player?.age, 30);
+  if (age <= 23) return { key: 'early_growth', label: 'Early growth window', detail: 'High variance development stage.', tone: 'good' };
+  if (age <= 28) return { key: 'prime', label: 'Prime growth/stability window', detail: 'Expect steadier week-to-week outcomes.', tone: 'neutral' };
+  if (age <= 31) return { key: 'maintenance', label: 'Maintenance window', detail: 'Role and health management matter most.', tone: 'warn' };
+  return { key: 'late_curve', label: 'Late-career curve', detail: 'Regression risk rises without ideal usage/health.', tone: 'bad' };
+}
+
+export function getDevelopmentDrivers(player, moraleContext = null) {
+  const reasons = [];
+  const ageContext = getAgeCurveContext(player);
+  reasons.push(ageContext.label);
+
+  const fit = safeNumber(player?.schemeFit, 50);
+  if (fit >= 75) reasons.push('Scheme alignment supporting growth');
+  else if (fit <= 45) reasons.push('Scheme mismatch suppressing output');
+
+  const injuryWeeks = safeNumber(player?.injuryWeeksRemaining ?? player?.injury?.weeksRemaining, 0);
+  if (injuryWeeks > 0) reasons.push(`Injury recovery (${injuryWeeks}w)`);
+
+  const depthOrder = normalizeDepthOrder(player);
+  if (depthOrder >= 3 && safeNumber(player?.age, 30) <= 25) reasons.push('Depth role may be limiting reps');
+
+  const topMoraleReason = moraleContext?.reasons?.[0];
+  if (topMoraleReason) reasons.push(topMoraleReason);
+
+  return reasons.slice(0, 4);
+}
+
+export function getDevelopmentSnapshot(player) {
+  const history = Array.isArray(player?.developmentHistory) ? player.developmentHistory : [];
+  if (history.length < 2) return null;
+  const latest = history[history.length - 1] ?? {};
+  const prev = history[history.length - 2] ?? {};
+  const keys = [
+    ['physical', 'Physical'],
+    ['passing', 'Passing'],
+    ['rushingReceiving', 'Rush/Rec'],
+    ['blocking', 'Blocking'],
+    ['defense', 'Defense'],
+    ['kicking', 'Kicking'],
+  ];
+  const deltas = keys.map(([key, label]) => ({
+    key,
+    label,
+    delta: safeNumber(latest?.[key], 0) - safeNumber(prev?.[key], 0),
+  })).filter((entry) => entry.delta !== 0);
+
+  const topGain = [...deltas].sort((a, b) => b.delta - a.delta)[0] ?? null;
+  const topDrop = [...deltas].sort((a, b) => a.delta - b.delta)[0] ?? null;
+  return { topGain, topDrop, deltas };
+}
+
 export function buildDevelopmentNotes(player, moraleContext = null) {
   const trend = classifyDevelopmentTrend(player);
   const readiness = getPlayerReadiness(player);
@@ -96,10 +149,11 @@ export function buildDevelopmentNotes(player, moraleContext = null) {
   if (moraleContext?.state) {
     notes.push(`Morale: ${moraleContext.state}`);
   }
-  const topReason = moraleContext?.reasons?.[0];
-  if (topReason) notes.push(topReason);
-  return { trend, readiness, fit, notes };
+  const drivers = getDevelopmentDrivers(player, moraleContext);
+  notes.push(...drivers);
+  return { trend, readiness, fit, notes: [...new Set(notes)].slice(0, 6) };
 }
+
 
 export function summarizeRosterDevelopment(players = [], moraleById = new Map()) {
   const list = Array.isArray(players) ? players : [];
@@ -108,6 +162,8 @@ export function summarizeRosterDevelopment(players = [], moraleById = new Map())
   const moraleRisk = [];
   const mismatch = [];
   const rookiesWatch = [];
+  const blocked = [];
+  const contractPressure = [];
 
   for (const player of list) {
     const trend = classifyDevelopmentTrend(player);
@@ -121,6 +177,8 @@ export function summarizeRosterDevelopment(players = [], moraleById = new Map())
     if (moraleScore <= 62 || String(moraleState).toLowerCase().includes('friction') || String(moraleState).toLowerCase().includes('frustrated')) moraleRisk.push(player);
     if (fit <= 45) mismatch.push(player);
     if (age <= 24) rookiesWatch.push(player);
+    if (normalizeDepthOrder(player) >= 3 && age <= 25 && safeNumber(player?.ovr, 0) >= 68) blocked.push(player);
+    if (safeNumber(player?.contract?.yearsRemaining ?? player?.contract?.years, 0) <= 1 && ['breakout_candidate','trending_up','trending_down','regression_risk'].includes(trend.key)) contractPressure.push(player);
   }
 
   const sortByDelta = (a, b) => safeNumber(b?.progressionDelta, 0) - safeNumber(a?.progressionDelta, 0);
@@ -132,5 +190,8 @@ export function summarizeRosterDevelopment(players = [], moraleById = new Map())
     moraleRisk: moraleRisk.sort((a, b) => safeNumber(a?.morale, 100) - safeNumber(b?.morale, 100)),
     mismatch: mismatch.sort((a, b) => safeNumber(a?.schemeFit, 100) - safeNumber(b?.schemeFit, 100)),
     rookieWatch: rookiesWatch.sort((a, b) => safeNumber(a?.age, 99) - safeNumber(b?.age, 99)),
+    blocked: blocked.sort((a, b) => safeNumber(a?.age, 99) - safeNumber(b?.age, 99)),
+    contractPressure: contractPressure.sort((a, b) => safeNumber(a?.contract?.yearsRemaining ?? a?.contract?.years, 9) - safeNumber(b?.contract?.yearsRemaining ?? b?.contract?.years, 9)),
   };
 }
+


### PR DESCRIPTION
### Motivation
- Player progression, morale, and readiness signals were scattered and sometimes opaque, making roster decisions feel disconnected from visible data. 
- The goal is to surface who is improving or declining and why, so users can act (depth, contract, trade) without digging through raw numbers.

### Description
- Added a small reusable UI module `src/ui/components/PlayerDevelopmentUI.jsx` exposing `ToneChip`, `DevelopmentStatCard`, and `DevelopmentSignalRow` for consistent, compact development/morale/rendiness presentation. 
- Extended `src/ui/utils/playerDevelopmentSignals.js` with age-curve context, `getDevelopmentDrivers`, `getDevelopmentSnapshot`, and added roster-level buckets `blocked` and `contractPressure`, and updated `buildDevelopmentNotes` to include drivers. 
- Updated `src/ui/components/Roster.jsx` to show compact development chips (trend/readiness/fit) on each player row and to enhance the development intelligence strip with blocked/contract-pressure counts and a compact `DevelopmentSignalRow` for quick triage. 
- Enhanced `src/ui/components/PlayerProfile.jsx` to include header-level development chips, tone-coded stat cards for Trajectory/Readiness/Scheme-Fit/Age-Curve, explicit development drivers, and a recent snapshot area showing top category gains/drops. 

### Testing
- Ran unit tests with `npm run test:unit -- src/ui/components/coreManagementScreens.test.jsx src/ui/components/__tests__/rosterInitialState.test.js` and all tests passed. 
- Built the production bundle with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e031b1b970832da7414145822f3177)