### PR TITLE
Add League Leaders, Career Stats tab, and app SettingsContext

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -48,7 +48,7 @@ import { toWorker }        from '../worker/protocol.js';
 import { DEFAULT_TEAMS }   from '../data/default-teams.js';
 import MilestoneModal      from './components/MilestoneModal.jsx';
 import ThemeToggle         from './components/ThemeToggle.jsx';
-import { SettingsProvider, useSettings } from '../context/SettingsContext.jsx';
+import { SettingsProvider, useSettings } from './context/SettingsContext.jsx';
 import { ACTION_LABELS } from './constants/navigationCopy.js';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from './utils/boxScoreAccess.js';
 import { hasMinimumPlayableLeague, summarizeBootstrapState } from './utils/leagueBootstrap.js';
@@ -123,7 +123,8 @@ function AppContent() {
   const [watchMode, setWatchMode] = useState('watch');
   const [externalBoxScoreId, setExternalBoxScoreId] = useState(null);
   const [showChangelog, setShowChangelog] = useState(false);
-  const { soundEnabled, toggleSound } = useSettings();
+  const { settings, updateSetting } = useSettings();
+  const soundEnabled = settings?.soundEnabled ?? true;
   const isWeeklyResultPhase = league?.phase === 'preseason' || league?.phase === 'regular' || league?.phase === 'playoffs';
   const authoritativeResults = useMemo(
     () => (isWeeklyResultPhase && Array.isArray(lastResults) ? lastResults : []),
@@ -640,7 +641,13 @@ function AppContent() {
         </div>
 
         <div className="app-header-actions">
-          <button className="btn app-icon-btn" onClick={toggleSound} title={soundEnabled ? "Mute sound" : "Unmute sound"}>
+          <button
+            className="btn app-icon-btn"
+            onClick={() => updateSetting("soundEnabled", !soundEnabled)}
+            title="Toggle sound effects"
+            aria-label="Toggle sound effects"
+            style={{ minWidth: 44, minHeight: 44 }}
+          >
             {soundEnabled ? "🔊" : "🔇"}
           </button>
           <ThemeToggle compact />

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -213,7 +213,7 @@ const BASE_TABS = [
 const NAV_GROUPS = [
   { id: SHELL_SECTIONS.hq, title: "HQ", tabs: ["HQ"] },
   { id: SHELL_SECTIONS.team, title: "Team", tabs: ["Team", "Roster", "Depth Chart", "Game Plan", "Training", "Injuries", "Staff", "Financials", "Contract Center"] },
-  { id: SHELL_SECTIONS.league, title: "League", tabs: ["League", "Schedule", "Standings", "Stats", "Transactions", "History Hub", "History", "Awards & Records", "Season Recap"] },
+  { id: SHELL_SECTIONS.league, title: "League", tabs: ["League", "Schedule", "Standings", "Stats", "League Leaders", "Transactions", "History Hub", "History", "Awards & Records", "Season Recap"] },
   { id: SHELL_SECTIONS.news, title: "News", tabs: ["News"] },
 ];
 
@@ -228,6 +228,14 @@ const TEAM_FACING_TABS = new Set(["Roster", "Depth Chart", "Roster Hub", "Game P
 const TAB_ALIASES = {
   Trades: "Transactions",
 };
+
+const MOBILE_TAB_MAP = Object.freeze({
+  "League Leaders": "league-leaders",
+});
+
+const REVERSE_TAB_MAP = Object.freeze(
+  Object.fromEntries(Object.entries(MOBILE_TAB_MAP).map(([tab, slug]) => [slug, tab])),
+);
 
 // Division display labels and their numeric indices (from App.jsx DEFAULT_TEAMS).
 // div: 0=East  1=North  2=South  3=West
@@ -286,6 +294,11 @@ function toTestId(value = "") {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
+}
+
+function canonicalizeMobileTab(tab) {
+  if (!tab) return tab;
+  return REVERSE_TAB_MAP[tab] ?? tab;
 }
 
 // ── Sub-components ─────────────────────────────────────────────────────────────
@@ -1719,7 +1732,11 @@ export default function LeagueDashboard({
         )}
         {isInitialized && activeTab === "League Leaders" && (
           <TabErrorBoundary label="League Leaders">
-            <LeagueLeaders league={league} actions={actions} />
+            <LeagueLeaders
+              league={league}
+              onPlayerSelect={(player) => setSelectedPlayerId(player?.id ?? player)}
+              onNavigate={setActiveTab}
+            />
           </TabErrorBoundary>
         )}
         {activeTab === "Award Races" && (
@@ -1997,7 +2014,7 @@ export default function LeagueDashboard({
       <MobileNav
         activeSection={activeSection}
         onSectionChange={handleSectionChange}
-        onDestinationChange={(tab) => setActiveTab(tab)}
+        onDestinationChange={(tab) => setActiveTab(canonicalizeMobileTab(tab))}
         onAdvance={onAdvanceWeek}
         advanceLabel={advanceLabel}
         advanceDisabled={advanceDisabled}

--- a/src/ui/components/LeagueLeaders.jsx
+++ b/src/ui/components/LeagueLeaders.jsx
@@ -1,121 +1,165 @@
-import React, { useEffect, useMemo, useState } from "react";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { getTeamIdentity } from "../../data/team-utils.js";
-import { toFiniteNumber } from "../utils/numberFormatting.js";
+import React, { useMemo, useState } from "react";
 
-function rankBadge(rank) {
-  if (rank === 1) return "🥇";
-  if (rank === 2) return "🥈";
-  if (rank === 3) return "🥉";
-  return `#${rank}`;
+const TABS = ["Passing", "Rushing", "Receiving", "Tackles", "Sacks", "Interceptions"];
+
+const CATEGORY_CONFIG = {
+  Passing: {
+    primaryLabel: "Pass Yds",
+    secondaryLabel: "TD / Cmp%",
+    getPrimary: (player) => stat(player, ["passingYards", "passYd"]),
+    getSecondary: (player) => {
+      const td = stat(player, ["touchdowns", "passTD", "passTDs"]);
+      const comp = stat(player, ["completions", "passComp"]);
+      const att = stat(player, ["attempts", "passAtt"]);
+      const pct = att > 0 ? (comp / att) * 100 : 0;
+      return `${displayNumber(td)} / ${displayNumber(pct, 1, "%")}`;
+    },
+  },
+  Rushing: {
+    primaryLabel: "Rush Yds",
+    secondaryLabel: "TD / YPC",
+    getPrimary: (player) => stat(player, ["rushingYards", "rushYd", "rushYds"]),
+    getSecondary: (player) => {
+      const td = stat(player, ["rushingTDs", "rushTD", "rushTDs"]);
+      const yds = stat(player, ["rushingYards", "rushYd", "rushYds"]);
+      const att = stat(player, ["rushingAttempts", "rushAtt"]);
+      const ypc = att > 0 ? yds / att : 0;
+      return `${displayNumber(td)} / ${displayNumber(ypc, 1)}`;
+    },
+  },
+  Receiving: {
+    primaryLabel: "Rec Yds",
+    secondaryLabel: "Rec / TD",
+    getPrimary: (player) => stat(player, ["receivingYards", "recYd", "recYds"]),
+    getSecondary: (player) => {
+      const rec = stat(player, ["receptions"]);
+      const td = stat(player, ["receivingTDs", "recTD", "recTDs"]);
+      return `${displayNumber(rec)} / ${displayNumber(td)}`;
+    },
+  },
+  Tackles: {
+    primaryLabel: "Total Tkl",
+    secondaryLabel: "Solo / Ast",
+    getPrimary: (player) => {
+      const solo = stat(player, ["soloTackles"]);
+      const assist = stat(player, ["assistTackles"]);
+      const tackles = stat(player, ["totalTackles", "tackles"]);
+      return Math.max(tackles, solo + assist);
+    },
+    getSecondary: (player) => `${displayNumber(stat(player, ["soloTackles"]))} / ${displayNumber(stat(player, ["assistTackles"]))}`,
+  },
+  Sacks: {
+    primaryLabel: "Sacks",
+    secondaryLabel: "TFL / FF",
+    getPrimary: (player) => stat(player, ["sacks"]),
+    getSecondary: (player) => `${displayNumber(stat(player, ["tacklesForLoss", "tfl"]))} / ${displayNumber(stat(player, ["forcedFumbles", "ffum"]))}`,
+  },
+  Interceptions: {
+    primaryLabel: "INT",
+    secondaryLabel: "PD / Tkl",
+    getPrimary: (player) => stat(player, ["interceptions", "ints"]),
+    getSecondary: (player) => `${displayNumber(stat(player, ["passesDefended"]))} / ${displayNumber(stat(player, ["tackles", "totalTackles"]))}`,
+  },
+};
+
+function stat(player, keys) {
+  const source = player?.stats ?? player?.seasonStats ?? player?.totals ?? {};
+  const fromSource = keys.reduce((value, key) => (value != null ? value : source?.[key]), null);
+  const fromPlayer = keys.reduce((value, key) => (value != null ? value : player?.[key]), null);
+  return Number(fromSource ?? fromPlayer ?? 0) || 0;
 }
 
-function LeaderList({ title, statLabel, rows }) {
-  return (
-    <Card className="card-premium">
-      <CardHeader className="py-2 px-3 border-b border-[color:var(--hairline)]" style={{ background: "var(--surface-strong)" }}>
-        <CardTitle className="text-xs font-bold uppercase tracking-widest text-[color:var(--text-muted)]">{title}</CardTitle>
-      </CardHeader>
-      <CardContent className="p-0">
-        {rows.map((row, idx) => (
-          <div key={`${row.id}-${idx}`} style={{ display: "grid", gridTemplateColumns: "40px 1fr auto", gap: 10, alignItems: "center", padding: "10px 12px", borderBottom: idx < rows.length - 1 ? "1px solid var(--hairline)" : "none" }}>
-            <div style={{ fontSize: 12, fontWeight: 800, color: idx < 3 ? "#FFD60A" : "var(--text-subtle)" }}>{rankBadge(idx + 1)}</div>
-            <div style={{ minWidth: 0 }}>
-              <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
-                <span style={{ fontWeight: 700, color: "var(--text)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{row.name ?? "Unknown"}</span>
-                <Badge variant="outline" style={{ fontSize: 10, padding: "0 6px", background: "var(--surface)", borderColor: "var(--hairline)" }}>{row.pos ?? "?"}</Badge>
-                <span style={{ fontSize: 11, color: "var(--text-muted)", fontWeight: 700 }}>{row.teamAbbr ?? "—"}</span>
-              </div>
-              <div style={{ fontSize: 10, color: "var(--text-subtle)", marginTop: 2 }}>{statLabel}</div>
-            </div>
-            <div style={{ fontWeight: 900, fontVariantNumeric: "tabular-nums", color: "var(--text)" }}>{(toFiniteNumber(row.value, 0)).toLocaleString()}</div>
-          </div>
-        ))}
-      </CardContent>
-    </Card>
+function displayNumber(value, decimals = 0, suffix = "") {
+  const safe = Number(value ?? 0) || 0;
+  if (safe === 0) return "—";
+  return `${safe.toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals })}${suffix}`;
+}
+
+export default function LeagueLeaders({ league, onPlayerSelect, onNavigate }) {
+  const [activeTab, setActiveTab] = useState("Passing");
+  const teams = Array.isArray(league?.teams) ? league.teams : [];
+
+  const allPlayers = useMemo(
+    () =>
+      teams.flatMap((team) =>
+        (Array.isArray(team?.roster) ? team.roster : []).map((p) => ({
+          ...p,
+          teamName: team?.name ?? "—",
+          teamId: team?.id ?? null,
+          isUserTeam: team?.isUserTeam ?? Number(team?.id) === Number(league?.userTeamId),
+        })),
+      ),
+    [teams, league?.userTeamId],
   );
-}
 
-export default function LeagueLeaders({ league, actions }) {
-  const [rostersByTeam, setRostersByTeam] = useState({});
-  const currentSeason = league?.year ?? league?.seasonId;
-  const isReady = Boolean(league && currentSeason && Array.isArray(league?.teams));
-  const teams = league?.teams ?? [];
-  const getStat = (player, key) => toFiniteNumber(player?.seasonLog?.[currentSeason]?.[key], 0);
+  const rows = useMemo(() => {
+    const config = CATEGORY_CONFIG[activeTab] ?? CATEGORY_CONFIG.Passing;
+    return allPlayers
+      .map((player) => ({
+        player,
+        primary: config.getPrimary(player) ?? 0,
+        secondary: config.getSecondary(player),
+      }))
+      .sort((a, b) => (b.primary ?? 0) - (a.primary ?? 0))
+      .slice(0, 10);
+  }, [allPlayers, activeTab]);
 
-  useEffect(() => {
-    let mounted = true;
-    const load = async () => {
-      if (!league?.teams?.length || !actions?.getRoster) return;
-      const responses = await Promise.all(
-        league.teams.map(async (team) => {
-          try {
-            const resp = await actions.getRoster(team.id);
-            return [team.id, resp?.payload?.players ?? []];
-          } catch {
-            return [team.id, []];
-          }
-        }),
-      );
-      if (mounted) setRostersByTeam(Object.fromEntries(responses));
-    };
-    load();
-    return () => {
-      mounted = false;
-    };
-  }, [league?.teams, actions]);
-
-  const allPlayers = useMemo(() => {
-    const aggregated = [];
-    teams.forEach((team) => {
-      const loadedRoster = rostersByTeam?.[team?.id];
-      const roster = Array.isArray(loadedRoster) ? loadedRoster : (team?.roster ?? []);
-      roster.forEach((player) => {
-        if (player) aggregated.push({ ...player, teamId: Number(team?.id) });
-      });
-    });
-    return aggregated;
-  }, [rostersByTeam, teams]);
-
-  const topPassing = useMemo(() => allPlayers
-    .map((player) => {
-      const team = getTeamIdentity(player.teamId, teams);
-      return { id: player.id, name: player.name, pos: player.pos, teamAbbr: team.abbr, value: getStat(player, "passYd") };
-    })
-    .sort((a, b) => b.value - a.value)
-    .slice(0, 10), [allPlayers, currentSeason, teams]);
-
-  const topRushing = useMemo(() => allPlayers
-    .map((player) => {
-      const team = getTeamIdentity(player.teamId, teams);
-      return { id: player.id, name: player.name, pos: player.pos, teamAbbr: team.abbr, value: getStat(player, "rushYd") };
-    })
-    .sort((a, b) => b.value - a.value)
-    .slice(0, 10), [allPlayers, currentSeason, teams]);
-
-  const topDefense = useMemo(() => allPlayers
-    .map((player) => {
-      const team = getTeamIdentity(player.teamId, teams);
-      const combined = getStat(player, "tackles") + getStat(player, "sacks");
-      return { id: player.id, name: player.name, pos: player.pos, teamAbbr: team.abbr, value: combined };
-    })
-    .sort((a, b) => b.value - a.value)
-    .slice(0, 10), [allPlayers, currentSeason, teams]);
-
-  if (!isReady) {
-    return (
-      <div className="leaders-empty">
-        <p>Stats will appear after Week 1.</p>
-      </div>
-    );
-  }
+  const config = CATEGORY_CONFIG[activeTab] ?? CATEGORY_CONFIG.Passing;
 
   return (
-    <div style={{ display: "grid", gap: "var(--space-4)" }}>
-      <LeaderList title="Top 10 Passing" statLabel="Pass Yards" rows={topPassing} />
-      <LeaderList title="Top 10 Rushing" statLabel="Rush Yards" rows={topRushing} />
-      <LeaderList title="Top 10 Defense" statLabel="Tackles + Sacks" rows={topDefense} />
+    <div style={{ display: "grid", gap: "var(--space-3)" }}>
+      <div className="standings-tabs" style={{ flexWrap: "wrap", gap: 6 }}>
+        {TABS.map((tab) => (
+          <button key={tab} className={`standings-tab${activeTab === tab ? " active" : ""}`} onClick={() => setActiveTab(tab)}>
+            {tab}
+          </button>
+        ))}
+      </div>
+      <div className="table-wrapper" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
+        <table className="standings-table" style={{ width: "100%", minWidth: 680 }}>
+          <thead>
+            <tr>
+              <th style={{ width: 70 }}>Rank</th>
+              <th>Player</th>
+              <th>Team</th>
+              <th style={{ textAlign: "right" }}>{config.primaryLabel}</th>
+              <th style={{ textAlign: "right" }}>{config.secondaryLabel}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((entry, index) => (
+              <tr
+                key={`${entry.player?.id ?? entry.player?.name ?? "player"}-${index}`}
+                style={entry.player?.isUserTeam ? { background: "color-mix(in srgb, var(--accent) 10%, transparent)" } : undefined}
+              >
+                <td>{index + 1}</td>
+                <td>
+                  <button
+                    className="btn btn-link"
+                    style={{ padding: 0, minHeight: 0 }}
+                    onClick={() => onPlayerSelect?.(entry.player)}
+                  >
+                    {entry.player?.name ?? "—"}
+                  </button>
+                </td>
+                <td>{entry.player?.teamName ?? "—"}</td>
+                <td style={{ textAlign: "right" }}>{displayNumber(entry.primary)}</td>
+                <td style={{ textAlign: "right" }}>{entry.secondary ?? "—"}</td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={5} style={{ textAlign: "center", color: "var(--text-muted)", padding: "var(--space-4)" }}>
+                  No player stats available yet.{" "}
+                  <button className="btn btn-link" onClick={() => onNavigate?.("League")} style={{ padding: 0, minHeight: 0 }}>
+                    Return to League
+                  </button>
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/src/ui/components/MobileNav.jsx
+++ b/src/ui/components/MobileNav.jsx
@@ -24,6 +24,7 @@ const MORE_GROUPS = [
   {
     title: 'League + History',
     items: [
+      { id: 'league-leaders', label: 'League Leaders', icon: StandingsIcon },
       { id: 'History Hub', label: 'History', icon: HomeIcon },
       { id: 'Analytics', label: 'Analytics', icon: AnalyticsIcon },
       { id: 'Saves', label: 'Saves', icon: SaveIcon },

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -197,6 +197,12 @@ const POS_COLUMNS = {
   ],
 };
 
+const PASS_POSITIONS = ["QB"];
+const RUSH_POSITIONS = ["RB", "FB"];
+const REC_POSITIONS = ["WR", "TE"];
+const DEF_POSITIONS = ["CB", "S", "SS", "FS", "LB", "MLB", "OLB", "DE", "DT", "NT"];
+const SPEC_POSITIONS = ["K", "P", "LS"];
+
 function getColumns(pos) {
   if (!pos) return POS_COLUMNS.QB;
   const p = pos.toUpperCase();
@@ -318,6 +324,7 @@ export default function PlayerProfile({
   const [loading, setLoading] = useState(true);
   const [extending, setExtending] = useState(false);
   const [showProjections, setShowProjections] = useState(false);
+  const [activeProfileTab, setActiveProfileTab] = useState("Overview");
 
   const fetchProfile = React.useCallback(() => {
     if (!playerId) return;
@@ -462,6 +469,30 @@ export default function PlayerProfile({
       { label: 'Kicking', data: devHistory.map((d) => d.kicking ?? null), borderColor: '#14b8a6', backgroundColor: 'transparent' },
     ],
   }), [devHistory]);
+
+  const careerRows = useMemo(
+    () => (Array.isArray(player?.careerStats) ? [...player.careerStats] : []),
+    [player?.careerStats],
+  );
+  const careerTotals = useMemo(
+    () =>
+      careerRows.reduce((totals, line) => ({
+        gamesPlayed: totals.gamesPlayed + Number(line?.gamesPlayed ?? line?.gp ?? 0),
+        passYds: totals.passYds + Number(line?.passYds ?? line?.passingYards ?? 0),
+        passTDs: totals.passTDs + Number(line?.passTDs ?? line?.touchdowns ?? 0),
+        rushYds: totals.rushYds + Number(line?.rushYds ?? line?.rushingYards ?? 0),
+        rushTDs: totals.rushTDs + Number(line?.rushTDs ?? line?.rushingTDs ?? 0),
+        receptions: totals.receptions + Number(line?.receptions ?? 0),
+        recYds: totals.recYds + Number(line?.recYds ?? line?.receivingYards ?? 0),
+        recTDs: totals.recTDs + Number(line?.recTDs ?? line?.receivingTDs ?? 0),
+        tackles: totals.tackles + Number(line?.tackles ?? line?.totalTackles ?? 0),
+        sacks: totals.sacks + Number(line?.sacks ?? 0),
+        interceptions: totals.interceptions + Number(line?.interceptions ?? line?.ints ?? 0),
+      }), {
+        gamesPlayed: 0, passYds: 0, passTDs: 0, rushYds: 0, rushTDs: 0, receptions: 0, recYds: 0, recTDs: 0, tackles: 0, sacks: 0, interceptions: 0,
+      }),
+    [careerRows],
+  );
 
   return (
     <div
@@ -765,6 +796,19 @@ export default function PlayerProfile({
 
         {/* ── Body ── */}
         <div style={{ padding: "var(--space-4)", flex: 1, display: "grid", gap: "var(--space-4)" }}>
+          <div className="standings-tabs" style={{ gap: 6, flexWrap: "wrap" }}>
+            {["Overview", "Career Stats"].map((tab) => (
+              <button
+                key={tab}
+                className={`standings-tab${activeProfileTab === tab ? " active" : ""}`}
+                onClick={() => setActiveProfileTab(tab)}
+              >
+                {tab}
+              </button>
+            ))}
+          </div>
+          {activeProfileTab === "Overview" && (
+            <>
           {!loading && player && (
             <section>
               <h3 style={sectionLabelStyle}>Development Tab</h3>
@@ -1402,6 +1446,58 @@ export default function PlayerProfile({
                   </TableBody>
                 </Table>
               </div>
+            </section>
+          )}
+            </>
+          )}
+          {activeProfileTab === "Career Stats" && (
+            <section>
+              {careerRows.length === 0 ? (
+                <p style={{ color: "var(--text-muted)" }}>
+                  No career stats recorded yet. Stats accumulate after each completed season.
+                </p>
+              ) : (
+                <div className="table-wrapper" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
+                  <Table className="standings-table" style={{ width: "100%", minWidth: 760 }}>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Season</TableHead>
+                        <TableHead>Team</TableHead>
+                        <TableHead style={{ textAlign: "center" }}>Games</TableHead>
+                        {PASS_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableHead style={{ textAlign: "right" }}>Pass Yds</TableHead><TableHead style={{ textAlign: "right" }}>Pass TD</TableHead></>)}
+                        {RUSH_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableHead style={{ textAlign: "right" }}>Rush Yds</TableHead><TableHead style={{ textAlign: "right" }}>Rush TD</TableHead></>)}
+                        {REC_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableHead style={{ textAlign: "right" }}>Rec</TableHead><TableHead style={{ textAlign: "right" }}>Rec Yds</TableHead><TableHead style={{ textAlign: "right" }}>Rec TD</TableHead></>)}
+                        {DEF_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableHead style={{ textAlign: "right" }}>Tackles</TableHead><TableHead style={{ textAlign: "right" }}>Sacks</TableHead><TableHead style={{ textAlign: "right" }}>INT</TableHead></>)}
+                        {SPEC_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableHead style={{ textAlign: "right" }}>FGM</TableHead><TableHead style={{ textAlign: "right" }}>XPM</TableHead></>)}
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {careerRows.map((line, index) => (
+                        <TableRow key={`${line?.season ?? "season"}-${line?.team ?? "team"}-${index}`}>
+                          <TableCell>{line?.season ?? line?.seasonId ?? "—"}</TableCell>
+                          <TableCell>{line?.team ?? "—"}</TableCell>
+                          <TableCell style={{ textAlign: "center" }}>{line?.gamesPlayed ?? line?.gp ?? "—"}</TableCell>
+                          {PASS_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableCell style={{ textAlign: "right" }}>{Number(line?.passYds ?? line?.passingYards ?? 0) > 0 ? Number(line?.passYds ?? line?.passingYards ?? 0).toLocaleString() : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{Number(line?.passTDs ?? line?.touchdowns ?? 0) > 0 ? Number(line?.passTDs ?? line?.touchdowns ?? 0) : "—"}</TableCell></>)}
+                          {RUSH_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableCell style={{ textAlign: "right" }}>{Number(line?.rushYds ?? line?.rushingYards ?? 0) > 0 ? Number(line?.rushYds ?? line?.rushingYards ?? 0).toLocaleString() : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{Number(line?.rushTDs ?? line?.rushingTDs ?? 0) > 0 ? Number(line?.rushTDs ?? line?.rushingTDs ?? 0) : "—"}</TableCell></>)}
+                          {REC_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableCell style={{ textAlign: "right" }}>{Number(line?.receptions ?? 0) > 0 ? Number(line?.receptions ?? 0) : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{Number(line?.recYds ?? line?.receivingYards ?? 0) > 0 ? Number(line?.recYds ?? line?.receivingYards ?? 0).toLocaleString() : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{Number(line?.recTDs ?? line?.receivingTDs ?? 0) > 0 ? Number(line?.recTDs ?? line?.receivingTDs ?? 0) : "—"}</TableCell></>)}
+                          {DEF_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableCell style={{ textAlign: "right" }}>{Number(line?.tackles ?? line?.totalTackles ?? 0) > 0 ? Number(line?.tackles ?? line?.totalTackles ?? 0) : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{Number(line?.sacks ?? 0) > 0 ? Number(line?.sacks ?? 0) : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{Number(line?.interceptions ?? line?.ints ?? 0) > 0 ? Number(line?.interceptions ?? line?.ints ?? 0) : "—"}</TableCell></>)}
+                          {SPEC_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableCell style={{ textAlign: "right" }}>{line?.fgMade || 0 ? line?.fgMade ?? 0 : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{line?.xpMade || 0 ? line?.xpMade ?? 0 : "—"}</TableCell></>)}
+                        </TableRow>
+                      ))}
+                      <TableRow style={{ fontWeight: 800, background: "var(--surface-strong)" }}>
+                        <TableCell>Career Totals</TableCell>
+                        <TableCell>—</TableCell>
+                        <TableCell style={{ textAlign: "center" }}>{careerTotals.gamesPlayed || "—"}</TableCell>
+                        {PASS_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableCell style={{ textAlign: "right" }}>{careerTotals.passYds ? careerTotals.passYds.toLocaleString() : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{careerTotals.passTDs || "—"}</TableCell></>)}
+                        {RUSH_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableCell style={{ textAlign: "right" }}>{careerTotals.rushYds ? careerTotals.rushYds.toLocaleString() : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{careerTotals.rushTDs || "—"}</TableCell></>)}
+                        {REC_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableCell style={{ textAlign: "right" }}>{careerTotals.receptions || "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{careerTotals.recYds ? careerTotals.recYds.toLocaleString() : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{careerTotals.recTDs || "—"}</TableCell></>)}
+                        {DEF_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableCell style={{ textAlign: "right" }}>{careerTotals.tackles || "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{careerTotals.sacks || "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{careerTotals.interceptions || "—"}</TableCell></>)}
+                        {SPEC_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableCell style={{ textAlign: "right" }}>—</TableCell><TableCell style={{ textAlign: "right" }}>—</TableCell></>)}
+                      </TableRow>
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
             </section>
           )}
         </div>

--- a/src/ui/components/ThemeToggle.jsx
+++ b/src/ui/components/ThemeToggle.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { useSettings } from "../../context/SettingsContext.jsx";
+import { useSettings } from "../context/SettingsContext.jsx";
 
 /**
  * ThemeToggle — Dark/Light/System theme switcher
@@ -16,7 +16,8 @@ const THEMES = {
 };
 
 export default function ThemeToggle({ compact = false }) {
-  const { theme: savedTheme = "system", setTheme: setSavedTheme } = useSettings();
+  const { settings, updateSetting } = useSettings();
+  const savedTheme = settings?.theme ?? "system";
   const [theme, setTheme] = useState(() => {
     return savedTheme || "system";
   });
@@ -43,8 +44,8 @@ export default function ThemeToggle({ compact = false }) {
 
   useEffect(() => {
     applyTheme(theme);
-    setSavedTheme?.(theme);
-  }, [theme, applyTheme]);
+    updateSetting?.("theme", theme);
+  }, [theme, applyTheme, updateSetting]);
 
   const cycle = useCallback(() => {
     setTheme(prev => {

--- a/src/ui/context/SettingsContext.jsx
+++ b/src/ui/context/SettingsContext.jsx
@@ -1,0 +1,41 @@
+import React, { createContext, useContext, useState, useEffect, useMemo } from 'react';
+
+const STORAGE_KEY = 'fgmsim_settings_v1';
+
+const defaultSettings = {
+  soundEnabled: true,
+  theme: 'system',
+  // future: animationsEnabled, etc.
+};
+
+const SettingsContext = createContext({
+  settings: defaultSettings,
+  updateSetting: () => {},
+});
+
+export function SettingsProvider({ children }) {
+  const [settings, setSettings] = useState(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      return saved ? { ...defaultSettings, ...JSON.parse(saved) } : defaultSettings;
+    } catch {
+      return defaultSettings;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+    } catch {
+      // best-effort persistence
+    }
+  }, [settings]);
+
+  const updateSetting = (key, value) => setSettings((prev) => ({ ...prev, [key]: value }));
+
+  const value = useMemo(() => ({ settings, updateSetting }), [settings]);
+
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
+}
+
+export const useSettings = () => useContext(SettingsContext);


### PR DESCRIPTION
### Motivation
- Provide a full League Leaders surface to surface Top-10 leaderboards across all teams and close a high-impact ZenGM parity gap. 
- Expose season-by-season career history inside the player profile so users can inspect career totals and per-season production. 
- Add a minimal app-level settings context to persist toggles (starting with sound/theme) and enable future global settings features.

### Description
- Implemented a tabbed `LeagueLeaders` view at `src/ui/components/LeagueLeaders.jsx` that aggregates rostered players across all teams (guards array/stat access with safe fallbacks) and provides Passing, Rushing, Receiving, Tackles, Sacks, and Interceptions Top-10 lists with clickable player rows and user-team row highlighting. 
- Wired the new screen into `LeagueDashboard` by adding the `"League Leaders"` tab to the League nav group, passing `league`, `onPlayerSelect`, and `onNavigate` into `LeagueLeaders`, and adding mobile canonicalization via `MOBILE_TAB_MAP` / `REVERSE_TAB_MAP` plus `canonicalizeMobileTab`. 
- Added mobile menu entry for League Leaders in `MobileNav` so it is reachable from the mobile drawer/bottom nav. 
- Extended `PlayerProfile.jsx` to include a small tab strip and a new `Career Stats` tab that renders a position-aware season-by-season table from `player.careerStats` and a bolded `Career Totals` summary row, with an empty-state message when no career stats exist. 
- Introduced an app-level `SettingsContext` at `src/ui/context/SettingsContext.jsx` (persisted to `localStorage`) and updated `src/ui/App.jsx` to consume it for a header sound toggle (`🔊/🔇`) with a 44px touch target and `aria-label="Toggle sound effects"`, and updated `ThemeToggle` to use the new context shape.

### Testing
- Ran a production build via `npm run build`, addressed an initial transform error caused by mixed `||`/`??` expressions in `PlayerProfile.jsx`, and re-ran `npm run build` successfully, producing the app bundle without build-time errors. 
- No additional automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0550b3ae8832da83841b73944609c)