### PR TITLE
Implement Matchup Vector Engine prototype with normalized play resolution

### DIFF
--- a/src/core/__tests__/matchupEngine.test.ts
+++ b/src/core/__tests__/matchupEngine.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { resolveMatchup, DEFAULT_NORMALIZATION_CONSTANT } from '../sim/matchupEngine.ts';
+
+const eliteOffense = {
+  release: 92,
+  routeRunning: 90,
+  separation: 91,
+  catchInTraffic: 88,
+  ballTracking: 90,
+  throwAccuracyShort: 94,
+  throwAccuracyDeep: 90,
+  throwPower: 93,
+  decisionMaking: 92,
+  pocketPresence: 90,
+  passBlockFootwork: 86,
+  passBlockStrength: 84,
+  passRush: 40,
+  pressCoverage: 35,
+  zoneCoverage: 38,
+};
+
+const strongDefense = {
+  release: 40,
+  routeRunning: 45,
+  separation: 42,
+  catchInTraffic: 44,
+  ballTracking: 46,
+  throwAccuracyShort: 40,
+  throwAccuracyDeep: 38,
+  throwPower: 42,
+  decisionMaking: 45,
+  pocketPresence: 42,
+  passBlockFootwork: 52,
+  passBlockStrength: 57,
+  passRush: 90,
+  pressCoverage: 87,
+  zoneCoverage: 89,
+};
+
+describe('resolveMatchup', () => {
+  it('keeps probability in bounds and returns deterministic state fields', () => {
+    const result = resolveMatchup(eliteOffense, strongDefense, {
+      down: 2,
+      distance: 7,
+      yardLine: 35,
+      quarter: 1,
+      clockSec: 625,
+      normalizationConstant: DEFAULT_NORMALIZATION_CONSTANT,
+      playType: 'pass',
+    }, () => 0.32);
+
+    expect(result.successProbability).toBeGreaterThanOrEqual(0.03);
+    expect(result.successProbability).toBeLessThanOrEqual(0.97);
+    expect(result.nextDown).toBeGreaterThanOrEqual(1);
+    expect(result.nextDown).toBeLessThanOrEqual(4);
+    expect(result.nextYardLine).toBeGreaterThanOrEqual(0);
+    expect(result.nextYardLine).toBeLessThanOrEqual(100);
+    expect(typeof result.reason).toBe('string');
+  });
+
+  it('normalization constant scales outcome probability to prevent drift', () => {
+    const lowNorm = resolveMatchup(eliteOffense, strongDefense, {
+      down: 1,
+      distance: 10,
+      yardLine: 25,
+      quarter: 1,
+      clockSec: 840,
+      normalizationConstant: 0.4,
+      playType: 'pass',
+    }, () => 0.2);
+
+    const highNorm = resolveMatchup(eliteOffense, strongDefense, {
+      down: 1,
+      distance: 10,
+      yardLine: 25,
+      quarter: 1,
+      clockSec: 840,
+      normalizationConstant: 1.2,
+      playType: 'pass',
+    }, () => 0.2);
+
+    expect(highNorm.successProbability).toBeGreaterThan(lowNorm.successProbability);
+  });
+});

--- a/src/core/sim/matchupEngine.ts
+++ b/src/core/sim/matchupEngine.ts
@@ -1,0 +1,165 @@
+import type { AttributesV2 } from '../../types/player.ts';
+
+export interface PlayContext {
+  down: number;
+  distance: number;
+  yardLine: number;
+  quarter: number;
+  clockSec: number;
+  weather?: 'clear' | 'rain' | 'snow' | 'wind';
+  fatigueFactor?: number;
+  normalizationConstant?: number;
+  playType?: 'pass' | 'run';
+}
+
+export interface PlayResult {
+  success: boolean;
+  successProbability: number;
+  yardsGained: number;
+  clockElapsedSec: number;
+  nextDown: number;
+  nextDistance: number;
+  nextYardLine: number;
+  reason: string;
+}
+
+const OFFENSE_WEIGHTS: ReadonlyArray<[keyof AttributesV2, number]> = Object.freeze([
+  ['throwAccuracyShort', 0.14],
+  ['throwAccuracyDeep', 0.07],
+  ['throwPower', 0.07],
+  ['release', 0.1],
+  ['routeRunning', 0.12],
+  ['separation', 0.12],
+  ['catchInTraffic', 0.09],
+  ['ballTracking', 0.08],
+  ['decisionMaking', 0.09],
+  ['pocketPresence', 0.07],
+  ['passBlockFootwork', 0.03],
+  ['passBlockStrength', 0.02],
+]);
+
+const DEFENSE_WEIGHTS: ReadonlyArray<[keyof AttributesV2, number]> = Object.freeze([
+  ['passRush', 0.3],
+  ['pressCoverage', 0.36],
+  ['zoneCoverage', 0.34],
+]);
+
+export const DEFAULT_NORMALIZATION_CONSTANT = 0.74;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function sigmoid(input: number): number {
+  if (input <= -35) return 0;
+  if (input >= 35) return 1;
+  return 1 / (1 + Math.exp(-input));
+}
+
+function weightedScore(attributes: AttributesV2, weights: ReadonlyArray<[keyof AttributesV2, number]>): number {
+  let total = 0;
+  for (let i = 0; i < weights.length; i += 1) {
+    const [key, weight] = weights[i];
+    total += (attributes[key] ?? 50) * weight;
+  }
+  return total;
+}
+
+function weatherAdjustment(weather: PlayContext['weather']): number {
+  switch (weather) {
+    case 'rain':
+      return -0.06;
+    case 'snow':
+      return -0.09;
+    case 'wind':
+      return -0.04;
+    default:
+      return 0;
+  }
+}
+
+function explainWinningVector(offense: AttributesV2, defense: AttributesV2): string {
+  const signals = [
+    { label: 'Win on the Release', value: offense.release - defense.pressCoverage },
+    { label: 'Route leverage over zone', value: offense.routeRunning - defense.zoneCoverage },
+    { label: 'Pocket survived pressure', value: offense.passBlockFootwork - defense.passRush },
+    { label: 'Ball tracked through contact', value: offense.ballTracking - defense.pressCoverage },
+    { label: 'Decision beat disguise', value: offense.decisionMaking - defense.zoneCoverage },
+  ];
+
+  signals.sort((a, b) => b.value - a.value);
+  return signals[0].label;
+}
+
+function estimateYards({
+  successProb,
+  offenseScore,
+  defenseScore,
+  rng,
+}: {
+  successProb: number;
+  offenseScore: number;
+  defenseScore: number;
+  rng: () => number;
+}): number {
+  const delta = (offenseScore - defenseScore) / 100;
+  const base = 4.2 + delta * 2.4;
+  const volatility = 6 * successProb;
+  const sampled = base + (rng() - 0.5) * volatility;
+  return Math.round(clamp(sampled, -8, 45));
+}
+
+function nextDownState(ctx: PlayContext, yardsGained: number): Pick<PlayResult, 'nextDown' | 'nextDistance' | 'nextYardLine'> {
+  const nextYardLine = clamp(ctx.yardLine + yardsGained, 0, 100);
+  const earnedFirstDown = yardsGained >= ctx.distance;
+
+  if (nextYardLine >= 100) {
+    return { nextDown: 1, nextDistance: 10, nextYardLine: 75 };
+  }
+
+  if (earnedFirstDown) {
+    return { nextDown: 1, nextDistance: 10, nextYardLine };
+  }
+
+  return {
+    nextDown: clamp(ctx.down + 1, 1, 4),
+    nextDistance: clamp(ctx.distance - yardsGained, 1, 20),
+    nextYardLine,
+  };
+}
+
+export function resolveMatchup(
+  offense: AttributesV2,
+  defense: AttributesV2,
+  ctx: PlayContext,
+  rng: () => number = Math.random,
+): PlayResult {
+  const normalization = clamp(ctx.normalizationConstant ?? DEFAULT_NORMALIZATION_CONSTANT, 0.35, 1.35);
+  const offenseScore = weightedScore(offense, OFFENSE_WEIGHTS);
+  const defenseScore = weightedScore(defense, DEFENSE_WEIGHTS);
+
+  const matchupDelta = (offenseScore - defenseScore) / 100;
+  const pressurePenalty = (defense.passRush - offense.passBlockFootwork) / 400;
+  const fatiguePenalty = clamp((ctx.fatigueFactor ?? 0) * 0.12, 0, 0.12);
+  const downDistancePenalty = ctx.down >= 3 ? Math.min(0.06, Math.max(0, (ctx.distance - 5) * 0.006)) : 0;
+
+  const base = (ctx.playType ?? 'pass') === 'pass' ? -0.22 : -0.08;
+  const input = base + (matchupDelta * 2.25 * normalization) - pressurePenalty - fatiguePenalty - downDistancePenalty + weatherAdjustment(ctx.weather);
+  const successProbability = clamp(sigmoid(input), 0.03, 0.97);
+
+  const success = rng() <= successProbability;
+  const yardsGained = success
+    ? estimateYards({ successProb: successProbability, offenseScore, defenseScore, rng })
+    : -Math.round(clamp((defense.passRush - offense.pocketPresence) / 24, -1, 8));
+
+  const clockElapsedSec = Math.round(clamp(23 + rng() * 17 + (success ? 2 : 0), 18, 42));
+
+  return {
+    success,
+    successProbability,
+    yardsGained,
+    clockElapsedSec,
+    reason: explainWinningVector(offense, defense),
+    ...nextDownState(ctx, yardsGained),
+  };
+}

--- a/src/types/player.ts
+++ b/src/types/player.ts
@@ -1,0 +1,28 @@
+export interface AttributesV2 {
+  release: number;
+  routeRunning: number;
+  separation: number;
+  catchInTraffic: number;
+  ballTracking: number;
+  throwAccuracyShort: number;
+  throwAccuracyDeep: number;
+  throwPower: number;
+  decisionMaking: number;
+  pocketPresence: number;
+  passBlockFootwork: number;
+  passBlockStrength: number;
+  passRush: number;
+  pressCoverage: number;
+  zoneCoverage: number;
+}
+
+export interface Player {
+  id: number;
+  name: string;
+  pos: string;
+  teamId?: number | null;
+  age?: number;
+  ovr?: number;
+  ratings?: Record<string, number>;
+  attributesV2: AttributesV2;
+}

--- a/src/worker/SimWorker.js
+++ b/src/worker/SimWorker.js
@@ -1,0 +1,155 @@
+import { resolveMatchup, DEFAULT_NORMALIZATION_CONSTANT } from '../core/sim/matchupEngine.ts';
+
+function makeRng(seed = 1) {
+  let t = seed >>> 0;
+  return () => {
+    t = (t + 0x6D2B79F5) | 0;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function buildInitialGameState(payload = {}) {
+  return {
+    homeScore: 0,
+    awayScore: 0,
+    quarter: 1,
+    clockSec: 900,
+    down: 1,
+    distance: 10,
+    yardLine: 25,
+    possession: 'home',
+    normalizationConstant: payload.normalizationConstant ?? DEFAULT_NORMALIZATION_CONSTANT,
+  };
+}
+
+function applyResultToState(state, result) {
+  const nextState = {
+    ...state,
+    clockSec: Math.max(0, state.clockSec - result.clockElapsedSec),
+    down: result.nextDown,
+    distance: result.nextDistance,
+    yardLine: result.nextYardLine,
+  };
+
+  const points = result.nextYardLine >= 99 ? 7 : 0;
+  if (state.possession === 'home') nextState.homeScore += points;
+  else nextState.awayScore += points;
+
+  if (nextState.down >= 4 && !result.success) {
+    nextState.possession = state.possession === 'home' ? 'away' : 'home';
+    nextState.down = 1;
+    nextState.distance = 10;
+    nextState.yardLine = Math.max(20, 100 - nextState.yardLine);
+  }
+
+  if (nextState.clockSec <= 0 && nextState.quarter < 4) {
+    nextState.quarter += 1;
+    nextState.clockSec = 900;
+  }
+
+  return nextState;
+}
+
+function summarizeFlatGame({ gameId, homeTeamId, awayTeamId, state, totals, reasons }) {
+  return {
+    gameId,
+    homeTeamId,
+    awayTeamId,
+    homeScore: state.homeScore,
+    awayScore: state.awayScore,
+    totalPlays: totals.plays,
+    homePassYards: totals.homePassYards,
+    awayPassYards: totals.awayPassYards,
+    homeSuccessRate: totals.homePlays ? Number((totals.homeSuccess / totals.homePlays).toFixed(3)) : 0,
+    awaySuccessRate: totals.awayPlays ? Number((totals.awaySuccess / totals.awayPlays).toFixed(3)) : 0,
+    normalizationConstant: totals.normalizationConstant,
+    topReason1: reasons[0] ?? null,
+    topReason2: reasons[1] ?? null,
+  };
+}
+
+function runSingleGame(payload = {}) {
+  const rng = makeRng(payload.seed ?? 1);
+  let state = buildInitialGameState(payload);
+
+  const totals = {
+    plays: 0,
+    homePlays: 0,
+    awayPlays: 0,
+    homePassYards: 0,
+    awayPassYards: 0,
+    homeSuccess: 0,
+    awaySuccess: 0,
+    normalizationConstant: state.normalizationConstant,
+  };
+  const reasonsMap = new Map();
+
+  while (state.quarter <= 4 && totals.plays < 180) {
+    const offense = state.possession === 'home' ? payload.homeOffense : payload.awayOffense;
+    const defense = state.possession === 'home' ? payload.awayDefense : payload.homeDefense;
+    if (!offense || !defense) break;
+
+    const result = resolveMatchup(offense, defense, {
+      down: state.down,
+      distance: state.distance,
+      yardLine: state.yardLine,
+      quarter: state.quarter,
+      clockSec: state.clockSec,
+      weather: payload.weather,
+      playType: 'pass',
+      normalizationConstant: state.normalizationConstant,
+      fatigueFactor: totals.plays / 220,
+    }, rng);
+
+    totals.plays += 1;
+    reasonsMap.set(result.reason, (reasonsMap.get(result.reason) ?? 0) + 1);
+
+    if (state.possession === 'home') {
+      totals.homePlays += 1;
+      totals.homePassYards += result.yardsGained;
+      totals.homeSuccess += result.success ? 1 : 0;
+    } else {
+      totals.awayPlays += 1;
+      totals.awayPassYards += result.yardsGained;
+      totals.awaySuccess += result.success ? 1 : 0;
+    }
+
+    state = applyResultToState(state, result);
+  }
+
+  const reasons = [...reasonsMap.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([reason]) => reason)
+    .slice(0, 2);
+
+  return summarizeFlatGame({
+    gameId: payload.gameId,
+    homeTeamId: payload.homeTeamId,
+    awayTeamId: payload.awayTeamId,
+    state,
+    totals,
+    reasons,
+  });
+}
+
+self.onmessage = (event) => {
+  const { type, payload = {}, id } = event.data ?? {};
+
+  if (type !== 'SIM_SINGLE_GAME') {
+    self.postMessage({
+      type: 'SIM_WORKER_ERROR',
+      id,
+      payload: { message: `Unsupported message type: ${type}` },
+    });
+    return;
+  }
+
+  const summary = runSingleGame(payload);
+  self.postMessage({
+    type: 'SIM_SINGLE_GAME_COMPLETE',
+    id,
+    payload: summary,
+  });
+};


### PR DESCRIPTION
### Motivation
- Provide a concrete prototype for the Technical Refactor Roadmap by turning the theoretical sub-attribute taxonomy into a working matchup resolver so the simulation can avoid statistical drift. 
- Introduce a tunable `normalizationConstant` calibration layer so per-play probabilities remain league-calibrated when using many sub-attributes. 
- Add a minimal worker orchestration example to demonstrate deterministic, low-bandwidth worker-to-main-thread simulation flow suitable for later pool orchestration.

### Description
- Add `AttributesV2` and a lightweight `Player` type to `src/types/player.ts` to represent the 15 sub-attributes required by the roadmap and enable incremental migration. 
- Implement the core matchup calculator in `src/core/sim/matchupEngine.ts`, including weighted offense/defense vectors, a bounded `sigmoid` probability function, `normalizationConstant` guardrails, weather/fatigue/down-distance modifiers, a deterministic `PlayResult` shape, and human-readable tactical reason strings for UI explainability. 
- Add a focused single-game simulation worker `src/worker/SimWorker.js` that uses a seeded RNG, repeatedly calls `resolveMatchup`, tracks compact per-side totals, and returns a flat/minimized `GameSummary` payload to avoid large transfer overhead. 
- Add unit tests `src/core/__tests__/matchupEngine.test.ts` that validate probability bounds and the effect of the normalization constant on outcome probabilities.

### Testing
- Ran the unit test suite for the new engine with `npm run test:unit -- src/core/__tests__/matchupEngine.test.ts` and the test file completed successfully. 
- Test summary: `1 file` executed, `2 tests` passed (Vitest v3.2.4). 
- No additional automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e102ae68e4832d926547af1abffa78)