### PR TITLE
Add SimulationManager worker-pool and AttributesV2 migration utilities

### DIFF
--- a/src/core/__tests__/attributeMigrator.test.ts
+++ b/src/core/__tests__/attributeMigrator.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { ensureAttributesV2, mapOverallToAttributesV2 } from '../migration/attributeMigrator.ts';
+
+describe('attributeMigrator', () => {
+  it('maps a legacy overall rating to varied attributes', () => {
+    const attrs = mapOverallToAttributesV2(90, 5.5, 'seed-90');
+    const uniqueValues = new Set(Object.values(attrs));
+
+    expect(Object.values(attrs).every((value) => value >= 25 && value <= 99)).toBe(true);
+    expect(uniqueValues.size).toBeGreaterThan(8);
+  });
+
+  it('is idempotent when attributesV2 already exists', () => {
+    const player = {
+      id: 12,
+      name: 'Existing Player',
+      ovr: 88,
+      attributesV2: mapOverallToAttributesV2(88, 5.5, 'existing'),
+    };
+
+    const migrated = ensureAttributesV2(player);
+
+    expect(migrated.attributesV2).toEqual(player.attributesV2);
+  });
+});

--- a/src/core/migration/attributeMigrator.ts
+++ b/src/core/migration/attributeMigrator.ts
@@ -1,0 +1,101 @@
+import type { AttributesV2 } from '../../types/player.ts';
+
+const ATTRIBUTE_KEYS: Array<keyof AttributesV2> = [
+  'release',
+  'routeRunning',
+  'separation',
+  'catchInTraffic',
+  'ballTracking',
+  'throwAccuracyShort',
+  'throwAccuracyDeep',
+  'throwPower',
+  'decisionMaking',
+  'pocketPresence',
+  'passBlockFootwork',
+  'passBlockStrength',
+  'passRush',
+  'pressCoverage',
+  'zoneCoverage',
+];
+
+const GAUSSIAN_OFFSETS = [
+  -1.55,
+  -1.2,
+  -0.95,
+  -0.7,
+  -0.45,
+  -0.2,
+  0,
+  0.2,
+  0.45,
+  0.7,
+  0.95,
+  1.2,
+  1.55,
+  -0.1,
+  0.1,
+];
+
+function clampRating(value: number): number {
+  return Math.max(25, Math.min(99, Math.round(value)));
+}
+
+function normalizeOverall(overall?: number): number {
+  const numericOverall = Number.isFinite(overall) ? Number(overall) : 60;
+  const normalized = numericOverall <= 1 ? numericOverall * 100 : numericOverall;
+  return Math.max(30, Math.min(99, normalized));
+}
+
+function seededJitter(seed: string, index: number): number {
+  let hash = 2166136261;
+  const input = `${seed}:${index}`;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return ((hash >>> 0) / 4294967295) * 2 - 1;
+}
+
+export function mapOverallToAttributesV2(overall?: number, varianceScale = 5.5, seed = 'legacy-player'): AttributesV2 {
+  const base = normalizeOverall(overall);
+
+  const migrated = ATTRIBUTE_KEYS.reduce((acc, key, idx) => {
+    const gaussian = GAUSSIAN_OFFSETS[idx % GAUSSIAN_OFFSETS.length] * varianceScale;
+    const jitter = seededJitter(seed, idx) * 1.75;
+    acc[key] = clampRating(base + gaussian + jitter);
+    return acc;
+  }, {} as Record<keyof AttributesV2, number>);
+
+  return migrated as AttributesV2;
+}
+
+export interface LegacyPlayerLike {
+  id?: number | string;
+  name?: string;
+  ovr?: number;
+  ratings?: {
+    overall?: number;
+    ovr?: number;
+    [key: string]: number | undefined;
+  };
+  attributesV2?: AttributesV2;
+  [key: string]: unknown;
+}
+
+export function ensureAttributesV2<T extends LegacyPlayerLike>(player: T): T & { attributesV2: AttributesV2 } {
+  if (player.attributesV2) {
+    return player as T & { attributesV2: AttributesV2 };
+  }
+
+  const legacyOverall = player.ratings?.overall ?? player.ratings?.ovr ?? player.ovr;
+  const seed = `${player.id ?? 'na'}:${player.name ?? 'unknown'}`;
+
+  return {
+    ...player,
+    attributesV2: mapOverallToAttributesV2(legacyOverall, 5.5, seed),
+  };
+}
+
+export function migratePlayersToAttributesV2<T extends LegacyPlayerLike>(players: T[]): Array<T & { attributesV2: AttributesV2 }> {
+  return players.map((player) => ensureAttributesV2(player));
+}

--- a/src/store/leagueStore.ts
+++ b/src/store/leagueStore.ts
@@ -1,0 +1,30 @@
+import type { Matchup, WeekSummary } from '../worker/WorkerPool.ts';
+import { simulationManager } from '../worker/WorkerPool.ts';
+import { ensureAttributesV2, type LegacyPlayerLike } from '../core/migration/attributeMigrator.ts';
+
+export interface LeagueState {
+  players: LegacyPlayerLike[];
+  simLoading: {
+    active: boolean;
+    done: number;
+    total: number;
+  };
+}
+
+export function migrateLeaguePlayers(players: LegacyPlayerLike[]): LegacyPlayerLike[] {
+  return players.map((player) => ensureAttributesV2(player));
+}
+
+export async function simWeek(
+  matchups: Matchup[],
+  setLoading: (loading: LeagueState['simLoading']) => void,
+): Promise<WeekSummary> {
+  setLoading({ active: true, done: 0, total: matchups.length });
+
+  const weekSummary = await simulationManager.simWeekParallel(matchups, ({ done, total }) => {
+    setLoading({ active: true, done, total });
+  });
+
+  setLoading({ active: false, done: weekSummary.completedGames, total: weekSummary.totalGames });
+  return weekSummary;
+}

--- a/src/types/player.ts
+++ b/src/types/player.ts
@@ -24,5 +24,5 @@ export interface Player {
   age?: number;
   ovr?: number;
   ratings?: Record<string, number>;
-  attributesV2: AttributesV2;
+  attributesV2?: AttributesV2;
 }

--- a/src/worker/WorkerPool.ts
+++ b/src/worker/WorkerPool.ts
@@ -1,0 +1,287 @@
+import { resolveMatchup, DEFAULT_NORMALIZATION_CONSTANT } from '../core/sim/matchupEngine.ts';
+import type { AttributesV2 } from '../types/player.ts';
+
+export interface Matchup {
+  gameId: number | string;
+  seed?: number;
+  weather?: 'clear' | 'rain' | 'snow' | 'wind';
+  normalizationConstant?: number;
+  homeTeamId: number;
+  awayTeamId: number;
+  homeOffense: AttributesV2;
+  awayOffense: AttributesV2;
+  homeDefense: AttributesV2;
+  awayDefense: AttributesV2;
+}
+
+export interface GameSummary {
+  gameId: number | string;
+  homeTeamId: number;
+  awayTeamId: number;
+  homeScore: number;
+  awayScore: number;
+  totalPlays: number;
+  homePassYards: number;
+  awayPassYards: number;
+  homeSuccessRate: number;
+  awaySuccessRate: number;
+  normalizationConstant: number;
+  topReason1: string | null;
+  topReason2: string | null;
+}
+
+export interface WeekSummary {
+  totalGames: number;
+  completedGames: number;
+  results: GameSummary[];
+}
+
+type ProgressListener = (progress: { done: number; total: number; currentGameId?: Matchup['gameId'] }) => void;
+type WorkerFactory = () => Worker;
+
+interface WorkerSlot {
+  worker: Worker;
+  busy: boolean;
+}
+
+function makeRng(seed = 1): () => number {
+  let t = seed >>> 0;
+  return () => {
+    t = (t + 0x6D2B79F5) | 0;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function runSingleGameInline(payload: Matchup): GameSummary {
+  const rng = makeRng(payload.seed ?? 1);
+  let state = {
+    homeScore: 0,
+    awayScore: 0,
+    quarter: 1,
+    clockSec: 900,
+    down: 1,
+    distance: 10,
+    yardLine: 25,
+    possession: 'home' as 'home' | 'away',
+    normalizationConstant: payload.normalizationConstant ?? DEFAULT_NORMALIZATION_CONSTANT,
+  };
+
+  const totals = {
+    plays: 0,
+    homePlays: 0,
+    awayPlays: 0,
+    homePassYards: 0,
+    awayPassYards: 0,
+    homeSuccess: 0,
+    awaySuccess: 0,
+    normalizationConstant: state.normalizationConstant,
+  };
+  const reasonsMap = new Map<string, number>();
+
+  while (state.quarter <= 4 && totals.plays < 180) {
+    const offense = state.possession === 'home' ? payload.homeOffense : payload.awayOffense;
+    const defense = state.possession === 'home' ? payload.awayDefense : payload.homeDefense;
+
+    const result = resolveMatchup(
+      offense,
+      defense,
+      {
+        down: state.down,
+        distance: state.distance,
+        yardLine: state.yardLine,
+        quarter: state.quarter,
+        clockSec: state.clockSec,
+        weather: payload.weather,
+        playType: 'pass',
+        normalizationConstant: state.normalizationConstant,
+        fatigueFactor: totals.plays / 220,
+      },
+      rng,
+    );
+
+    totals.plays += 1;
+    reasonsMap.set(result.reason, (reasonsMap.get(result.reason) ?? 0) + 1);
+
+    if (state.possession === 'home') {
+      totals.homePlays += 1;
+      totals.homePassYards += result.yardsGained;
+      totals.homeSuccess += result.success ? 1 : 0;
+    } else {
+      totals.awayPlays += 1;
+      totals.awayPassYards += result.yardsGained;
+      totals.awaySuccess += result.success ? 1 : 0;
+    }
+
+    const nextState = {
+      ...state,
+      clockSec: Math.max(0, state.clockSec - result.clockElapsedSec),
+      down: result.nextDown,
+      distance: result.nextDistance,
+      yardLine: result.nextYardLine,
+    };
+
+    const points = result.nextYardLine >= 99 ? 7 : 0;
+    if (state.possession === 'home') nextState.homeScore += points;
+    else nextState.awayScore += points;
+
+    if (nextState.down >= 4 && !result.success) {
+      nextState.possession = state.possession === 'home' ? 'away' : 'home';
+      nextState.down = 1;
+      nextState.distance = 10;
+      nextState.yardLine = Math.max(20, 100 - nextState.yardLine);
+    }
+
+    if (nextState.clockSec <= 0 && nextState.quarter < 4) {
+      nextState.quarter += 1;
+      nextState.clockSec = 900;
+    }
+
+    state = nextState;
+  }
+
+  const reasons = [...reasonsMap.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([reason]) => reason)
+    .slice(0, 2);
+
+  return {
+    gameId: payload.gameId,
+    homeTeamId: payload.homeTeamId,
+    awayTeamId: payload.awayTeamId,
+    homeScore: state.homeScore,
+    awayScore: state.awayScore,
+    totalPlays: totals.plays,
+    homePassYards: totals.homePassYards,
+    awayPassYards: totals.awayPassYards,
+    homeSuccessRate: totals.homePlays ? Number((totals.homeSuccess / totals.homePlays).toFixed(3)) : 0,
+    awaySuccessRate: totals.awayPlays ? Number((totals.awaySuccess / totals.awayPlays).toFixed(3)) : 0,
+    normalizationConstant: totals.normalizationConstant,
+    topReason1: reasons[0] ?? null,
+    topReason2: reasons[1] ?? null,
+  };
+}
+
+export class SimulationManager {
+  private readonly workerFactory?: WorkerFactory;
+
+  private readonly poolSize: number;
+
+  private readonly workerPool: WorkerSlot[] = [];
+
+  private nextMessageId = 1;
+
+  private initialized = false;
+
+  constructor({ poolSize, workerFactory }: { poolSize?: number; workerFactory?: WorkerFactory } = {}) {
+    this.poolSize = Math.max(1, poolSize ?? Math.min(8, Math.max(2, Math.floor((globalThis.navigator?.hardwareConcurrency ?? 4) / 2))));
+    this.workerFactory = workerFactory;
+  }
+
+  private supportsWorkers(): boolean {
+    return typeof globalThis.Worker !== 'undefined' || Boolean(this.workerFactory);
+  }
+
+  initialize(): void {
+    if (this.initialized || !this.supportsWorkers()) return;
+
+    for (let i = 0; i < this.poolSize; i += 1) {
+      const worker = this.workerFactory
+        ? this.workerFactory()
+        : new Worker(new URL('./SimWorker.js', import.meta.url), { type: 'module' });
+      this.workerPool.push({ worker, busy: false });
+    }
+
+    this.initialized = true;
+  }
+
+  dispose(): void {
+    for (const slot of this.workerPool) {
+      slot.worker.terminate();
+    }
+    this.workerPool.length = 0;
+    this.initialized = false;
+  }
+
+  async simWeekParallel(matchups: Matchup[], onProgress?: ProgressListener): Promise<WeekSummary> {
+    const total = matchups.length;
+    if (total === 0) {
+      return { totalGames: 0, completedGames: 0, results: [] };
+    }
+
+    if (!this.supportsWorkers()) {
+      const results = matchups.map((matchup, index) => {
+        const result = runSingleGameInline(matchup);
+        onProgress?.({ done: index + 1, total, currentGameId: matchup.gameId });
+        return result;
+      });
+      return { totalGames: total, completedGames: total, results };
+    }
+
+    this.initialize();
+
+    const queue = [...matchups];
+    const results: GameSummary[] = [];
+    let done = 0;
+
+    const runOnWorker = (slot: WorkerSlot, matchup: Matchup): Promise<void> => {
+      slot.busy = true;
+      const id = this.nextMessageId++;
+
+      return new Promise((resolve, reject) => {
+        const handleMessage = (event: MessageEvent) => {
+          const data = event.data ?? {};
+          if (data.id !== id) return;
+
+          slot.worker.removeEventListener('message', handleMessage);
+          slot.worker.removeEventListener('error', handleError);
+          slot.busy = false;
+
+          if (data.type === 'SIM_WORKER_ERROR') {
+            reject(new Error(data.payload?.message ?? 'Simulation worker error'));
+            return;
+          }
+
+          results.push(data.payload as GameSummary);
+          done += 1;
+          onProgress?.({ done, total, currentGameId: matchup.gameId });
+          resolve();
+        };
+
+        const handleError = (event: ErrorEvent) => {
+          slot.worker.removeEventListener('message', handleMessage);
+          slot.worker.removeEventListener('error', handleError);
+          slot.busy = false;
+          reject(event.error ?? new Error(event.message));
+        };
+
+        slot.worker.addEventListener('message', handleMessage);
+        slot.worker.addEventListener('error', handleError);
+        slot.worker.postMessage({
+          type: 'SIM_SINGLE_GAME',
+          id,
+          payload: matchup,
+        });
+      });
+    };
+
+    const consumeQueue = async (slot: WorkerSlot): Promise<void> => {
+      while (queue.length > 0) {
+        const next = queue.shift();
+        if (!next) return;
+        await runOnWorker(slot, next);
+      }
+    };
+
+    await Promise.all(this.workerPool.map((slot) => consumeQueue(slot)));
+
+    return {
+      totalGames: total,
+      completedGames: done,
+      results,
+    };
+  }
+}
+
+export const simulationManager = new SimulationManager();

--- a/src/worker/__tests__/WorkerPool.test.ts
+++ b/src/worker/__tests__/WorkerPool.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { SimulationManager, type Matchup } from '../WorkerPool.ts';
+import { mapOverallToAttributesV2 } from '../../core/migration/attributeMigrator.ts';
+
+function buildMatchup(gameId: number): Matchup {
+  return {
+    gameId,
+    homeTeamId: gameId,
+    awayTeamId: gameId + 100,
+    seed: gameId,
+    homeOffense: mapOverallToAttributesV2(86, 5.5, `h-off-${gameId}`),
+    awayOffense: mapOverallToAttributesV2(83, 5.5, `a-off-${gameId}`),
+    homeDefense: mapOverallToAttributesV2(84, 5.5, `h-def-${gameId}`),
+    awayDefense: mapOverallToAttributesV2(82, 5.5, `a-def-${gameId}`),
+  };
+}
+
+describe('SimulationManager', () => {
+  it('simulates a full week with main-thread fallback and emits progress', async () => {
+    const manager = new SimulationManager();
+    const progress: Array<string> = [];
+    const matchups = Array.from({ length: 16 }, (_, idx) => buildMatchup(idx + 1));
+
+    const summary = await manager.simWeekParallel(matchups, ({ done, total }) => {
+      progress.push(`${done}/${total}`);
+    });
+
+    expect(summary.totalGames).toBe(16);
+    expect(summary.completedGames).toBe(16);
+    expect(summary.results).toHaveLength(16);
+    expect(progress.at(-1)).toBe('16/16');
+  });
+});


### PR DESCRIPTION
### Motivation
- Enable parallel, deterministic weekly simulation (16 games) by orchestrating the existing single-game worker core and providing a main-thread fallback for environments without `Worker` support.
- Provide a safe, idempotent migration path from legacy 0–100 `Overall` ratings into the new `AttributesV2` schema so old saves remain compatible.
- Surface progress for the UI (e.g., "8/16 games completed") and centralize orchestration for performance and stability.

### Description
- Implemented `SimulationManager` in `src/worker/WorkerPool.ts` with a reusable worker pool, `initialize`/`dispose` lifecycle, and `simWeekParallel(matchups, onProgress)` that distributes matchups to workers and falls back to an inline main-thread runner when `Worker` is unavailable; the module exports a `simulationManager` singleton.
- Added deterministic seeded RNG and message correlation to keep simulations reproducible and debuggable; inline runner reuses the same `resolveMatchup` logic from `src/core/sim/matchupEngine.ts` for parity with the worker implementation.
- Added migration utilities in `src/core/migration/attributeMigrator.ts`: `mapOverallToAttributesV2` (bell-curve offsets + seeded jitter), `ensureAttributesV2` (idempotent), and `migratePlayersToAttributesV2` for batch migration.
- Added store integration helpers in `src/store/leagueStore.ts`: `migrateLeaguePlayers` and `simWeek` which delegates to `SimulationManager.simWeekParallel` and reports progress via a `setLoading` callback suitable for UI feedback.
- Made `attributesV2` optional in `src/types/player.ts` to preserve backward compatibility with legacy saves until migration runs.
- New unit tests: `src/core/__tests__/attributeMigrator.test.ts` and `src/worker/__tests__/WorkerPool.test.ts` to validate mapping behavior and week-level orchestration/fallback.

### Testing
- Ran `npm run test:unit -- src/core/__tests__/attributeMigrator.test.ts src/worker/__tests__/WorkerPool.test.ts` and both test files passed.
- Unit test summary: 2 test files, 3 tests total; all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e105ca9f30832da5abd482ff969259)