### PR TITLE
Integrate AttributesV2 worker-pool sim into advance-week (feature-flagged)

### DIFF
--- a/src/core/__tests__/weekSimulationBridge.test.ts
+++ b/src/core/__tests__/weekSimulationBridge.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mapOverallToAttributesV2 } from '../migration/attributeMigrator.ts';
+import {
+  aggregateTeamUnitsFromRoster,
+  buildDeterministicSeed,
+  mapGameSummaryToLegacyResult,
+  simulateWithOptionalNewEngine,
+} from '../sim/weekSimulationBridge.ts';
+
+describe('weekSimulationBridge', () => {
+  it('aggregates offense/defense units from roster players and migrates missing attributesV2', () => {
+    const roster = [
+      { id: 1, name: 'QB1', pos: 'QB', ovr: 90 },
+      { id: 2, name: 'WR1', pos: 'WR', ovr: 88 },
+      { id: 3, name: 'WR2', pos: 'WR', ovr: 84 },
+      { id: 4, name: 'CB1', pos: 'CB', ovr: 85, attributesV2: mapOverallToAttributesV2(85, 5.5, 'cb1') },
+      { id: 5, name: 'EDGE1', pos: 'EDGE', ovr: 86 },
+    ];
+
+    const units = aggregateTeamUnitsFromRoster(roster as any);
+
+    expect(units.migratedPlayers.length).toBe(4);
+    expect(units.offense.throwAccuracyShort).toBeGreaterThan(40);
+    expect(units.defense.passRush).toBeGreaterThan(40);
+  });
+
+  it('keeps migration idempotent when attributesV2 already exists', () => {
+    const attrs = mapOverallToAttributesV2(82, 5.5, 'existing-player');
+    const roster = [{ id: 7, name: 'Existing', pos: 'LB', attributesV2: attrs }];
+
+    const units = aggregateTeamUnitsFromRoster(roster as any);
+
+    expect(units.migratedPlayers).toHaveLength(0);
+    expect(units.defense.zoneCoverage).toBeGreaterThan(0);
+  });
+
+  it('falls back to legacy simulation when new path throws', async () => {
+    const legacySimulate = vi.fn(async () => [{ scoreHome: 14, scoreAway: 10 }]);
+    const manager = {
+      simWeekParallel: vi.fn(async () => {
+        throw new Error('worker unavailable');
+      }),
+    };
+
+    const result = await simulateWithOptionalNewEngine({
+      enabled: true,
+      matchups: [],
+      manager: manager as any,
+      legacySimulate,
+    });
+
+    expect(result.mode).toBe('legacy');
+    expect(legacySimulate).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps game summaries into existing result shape', () => {
+    const mapped = mapGameSummaryToLegacyResult({
+      gameId: 'g1',
+      homeTeamId: 1,
+      awayTeamId: 2,
+      homeScore: 28,
+      awayScore: 21,
+      totalPlays: 120,
+      homePassYards: 260,
+      awayPassYards: 230,
+      homeSuccessRate: 0.58,
+      awaySuccessRate: 0.53,
+      normalizationConstant: 0.74,
+      topReason1: 'Pocket survived pressure',
+      topReason2: 'Route leverage over zone',
+    });
+
+    expect(mapped.scoreHome).toBe(28);
+    expect(mapped.summary.storyline).toContain('Key edge');
+  });
+
+  it('builds deterministic seeds', () => {
+    expect(buildDeterministicSeed('2026:4:1:2')).toBe(buildDeterministicSeed('2026:4:1:2'));
+  });
+});

--- a/src/core/leagueSettings.js
+++ b/src/core/leagueSettings.js
@@ -36,6 +36,7 @@ export const DEFAULT_LEAGUE_SETTINGS = Object.freeze({
   progressionEnvironmentStrength: 50,
   draftClassStrength: 50,
   staffImpactStrength: 50,
+  useNewSimulationEngine: false,
   revenueSharing: true,
   luxuryTaxRate: 20,
   revealHiddenRatingsForCommissioner: true,
@@ -95,6 +96,7 @@ export function normalizeLeagueSettings(partial = {}) {
   if (!['nfl', 'college'].includes(String(out.overtimeFormat))) out.overtimeFormat = 'nfl';
   if (!['reverse_standings', 'lottery', 'random'].includes(String(out.draftOrderLogic))) out.draftOrderLogic = 'reverse_standings';
   if (!['fictional', 'historical'].includes(String(out.leagueUniverse))) out.leagueUniverse = 'fictional';
+  out.useNewSimulationEngine = Boolean(out.useNewSimulationEngine);
 
   if (!Array.isArray(out.conferenceNames) || out.conferenceNames.length === 0) {
     out.conferenceNames = [...DEFAULT_LEAGUE_SETTINGS.conferenceNames];

--- a/src/core/sim/weekSimulationBridge.ts
+++ b/src/core/sim/weekSimulationBridge.ts
@@ -1,0 +1,143 @@
+import type { AttributesV2, Player } from '../../types/player.ts';
+import { ensureAttributesV2 } from '../migration/attributeMigrator.ts';
+import type { GameSummary, Matchup, SimulationManager } from '../../worker/WorkerPool.ts';
+
+const OFFENSE_KEYS: Array<keyof AttributesV2> = [
+  'throwAccuracyShort', 'throwAccuracyDeep', 'throwPower', 'release', 'routeRunning', 'separation',
+  'catchInTraffic', 'ballTracking', 'decisionMaking', 'pocketPresence', 'passBlockFootwork', 'passBlockStrength',
+];
+const DEFENSE_KEYS: Array<keyof AttributesV2> = ['passRush', 'pressCoverage', 'zoneCoverage'];
+
+const OFFENSE_PRIORITY = ['QB', 'WR', 'TE', 'RB', 'OL', 'LT', 'LG', 'C', 'RG', 'RT'];
+const DEFENSE_PRIORITY = ['EDGE', 'DE', 'DT', 'LB', 'CB', 'S', 'FS', 'SS'];
+
+export interface AggregatedTeamUnits {
+  offense: AttributesV2;
+  defense: AttributesV2;
+  migratedPlayers: Array<{ id: number | string; attributesV2: AttributesV2 }>;
+}
+
+function stablePlayerSort(a: Player, b: Player): number {
+  const ovrDelta = Number(b?.ovr ?? b?.ratings?.overall ?? b?.ratings?.ovr ?? 0)
+    - Number(a?.ovr ?? a?.ratings?.overall ?? a?.ratings?.ovr ?? 0);
+  if (ovrDelta !== 0) return ovrDelta;
+  return String(a?.id ?? '').localeCompare(String(b?.id ?? ''));
+}
+
+function aggregateForKeys(players: Array<Player & { attributesV2: AttributesV2 }>, keys: Array<keyof AttributesV2>): AttributesV2 {
+  const base = players.length > 0 ? players : [{ attributesV2: ensureAttributesV2({ id: 'fallback', ovr: 60 }).attributesV2 } as Player & { attributesV2: AttributesV2 }];
+  const values = {} as Record<keyof AttributesV2, number>;
+
+  const allKeys: Array<keyof AttributesV2> = [...new Set([...OFFENSE_KEYS, ...DEFENSE_KEYS])];
+  for (const key of allKeys) {
+    if (!keys.includes(key)) {
+      values[key] = 50;
+      continue;
+    }
+    const sum = base.reduce((acc, player) => acc + Number(player.attributesV2[key] ?? 50), 0);
+    values[key] = Math.round(sum / base.length);
+  }
+
+  return values as AttributesV2;
+}
+
+function pickUnitPlayers(
+  roster: Array<Player & { attributesV2: AttributesV2 }>,
+  priority: string[],
+  targetSize = 11,
+): Array<Player & { attributesV2: AttributesV2 }> {
+  const picked: Array<Player & { attributesV2: AttributesV2 }> = [];
+  for (const pos of priority) {
+    const slice = roster.filter((player) => String(player.pos ?? '').toUpperCase() === pos).sort(stablePlayerSort);
+    picked.push(...slice.slice(0, pos === 'QB' ? 1 : 3));
+    if (picked.length >= targetSize) break;
+  }
+
+  if (picked.length < targetSize) {
+    const pickedIds = new Set(picked.map((player) => String(player.id)));
+    const fillers = roster
+      .filter((player) => !pickedIds.has(String(player.id)))
+      .sort(stablePlayerSort)
+      .slice(0, targetSize - picked.length);
+    picked.push(...fillers);
+  }
+
+  return picked.slice(0, targetSize);
+}
+
+export function aggregateTeamUnitsFromRoster(roster: Player[] = []): AggregatedTeamUnits {
+  const migratedPlayers: Array<{ id: number | string; attributesV2: AttributesV2 }> = [];
+  const upgradedRoster = roster
+    .map((player) => {
+      const upgraded = ensureAttributesV2(player);
+      if (!player.attributesV2 && player.id != null) {
+        migratedPlayers.push({ id: player.id, attributesV2: upgraded.attributesV2 });
+      }
+      return upgraded as Player & { attributesV2: AttributesV2 };
+    })
+    .sort(stablePlayerSort);
+
+  const offensePlayers = pickUnitPlayers(upgradedRoster, OFFENSE_PRIORITY, 11);
+  const defensePlayers = pickUnitPlayers(upgradedRoster, DEFENSE_PRIORITY, 11);
+
+  return {
+    offense: aggregateForKeys(offensePlayers, OFFENSE_KEYS),
+    defense: aggregateForKeys(defensePlayers, DEFENSE_KEYS),
+    migratedPlayers,
+  };
+}
+
+export function buildDeterministicSeed(input: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+export function mapGameSummaryToLegacyResult(summary: GameSummary) {
+  return {
+    gameId: summary.gameId,
+    home: summary.homeTeamId,
+    away: summary.awayTeamId,
+    scoreHome: summary.homeScore,
+    scoreAway: summary.awayScore,
+    recapText: summary.topReason1 ? `${summary.topReason1}. ${summary.topReason2 ?? ''}`.trim() : null,
+    summary: {
+      storyline: summary.topReason1 ? `Key edge: ${summary.topReason1}` : 'Simulation complete.',
+    },
+    simFactors: {
+      home: { qbRating: Math.round(summary.homeSuccessRate * 100), rushYpc: Number((summary.homePassYards / Math.max(1, summary.totalPlays / 2)).toFixed(2)) },
+      away: { qbRating: Math.round(summary.awaySuccessRate * 100), rushYpc: Number((summary.awayPassYards / Math.max(1, summary.totalPlays / 2)).toFixed(2)) },
+    },
+  };
+}
+
+export async function simulateWithOptionalNewEngine({
+  enabled,
+  matchups,
+  manager,
+  legacySimulate,
+  onProgress,
+  onError,
+}: {
+  enabled: boolean;
+  matchups: Matchup[];
+  manager: Pick<SimulationManager, 'simWeekParallel'>;
+  legacySimulate: () => Promise<any[]>;
+  onProgress?: (p: { done: number; total: number; currentGameId?: Matchup['gameId'] }) => void;
+  onError?: (error: unknown) => void;
+}) {
+  if (!enabled) {
+    return { mode: 'legacy' as const, results: await legacySimulate() };
+  }
+
+  try {
+    const summary = await manager.simWeekParallel(matchups, onProgress);
+    return { mode: 'new' as const, results: summary.results.map((result) => mapGameSummaryToLegacyResult(result)) };
+  } catch (error) {
+    onError?.(error);
+    return { mode: 'legacy' as const, results: await legacySimulate() };
+  }
+}

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -138,6 +138,12 @@ import { getScoutingRangeFromProfile, scoreDraftBoardEntry } from '../core/draft
 import { generateDynamicEvents, calculateSeasonAwards } from '../core/events/eventSystem.js';
 import { validateCustomRoster, validateDraftClass, validateLeagueFile, validateLeagueSettingsPayload, summarizeValidationErrors } from './modding/schemaValidation.js';
 import { buildDraftOrder } from './modding/ruleEngine.js';
+import { simulationManager } from './WorkerPool.ts';
+import {
+  aggregateTeamUnitsFromRoster,
+  buildDeterministicSeed,
+  simulateWithOptionalNewEngine,
+} from '../core/sim/weekSimulationBridge.ts';
 
 // ── DB Reload Guard ───────────────────────────────────────────────────────────
 // Register a callback with db/index.js so that when IDB fires onblocked or
@@ -2256,105 +2262,95 @@ async function handleAdvanceWeek(payload, id) {
   }
 
   post(toUI.SIM_PROGRESS, { done: 0, total: league._weekGames.length }, id);
-
-  // --- Simulate ---
-  // Run in small batches so we can yield between them.
-  // v2: Reduced from 4→2 so yieldFrame() fires every 2 games max,
-  // keeping each tick well under 30ms on mobile Safari/Chrome.
-  const BATCH_SIZE = 2;
   const gamesToSim = [...league._weekGames];
-  const results    = [];
-  const injuryFactor = Math.max(0, Number(getLeagueSetting('injuryFrequency', 50)) / 50);
+  const { matchups, migratedPlayers } = buildWeekMatchupsFromLeague(league, meta, week);
+  const useNewSimulationEngine = Boolean(getLeagueSetting('useNewSimulationEngine', false)) && matchups.length === gamesToSim.length;
 
-  for (let i = 0; i < gamesToSim.length; i += BATCH_SIZE) {
-    const batch = gamesToSim.slice(i, i + BATCH_SIZE);
-    let batchResults;
-    try {
-      batchResults = simulateBatch(batch, {
-        league,
-        isPlayoff: meta.phase === 'playoffs',
-        injuryFactor,
-        overtimeFormat: getLeagueSetting('overtimeFormat', 'nfl'),
+  if (migratedPlayers.length > 0) {
+    for (const migrated of migratedPlayers) {
+      const player = cache.getPlayer(migrated.id);
+      if (!player?.attributesV2) {
+        cache.updatePlayer(migrated.id, { attributesV2: migrated.attributesV2 });
+      }
+    }
+  }
+
+  const { mode: simulationMode, results } = await simulateWithOptionalNewEngine({
+    enabled: useNewSimulationEngine,
+    matchups,
+    manager: simulationManager,
+    onProgress: ({ done, total }) => post(toUI.SIM_PROGRESS, { done, total }, id),
+    onError: (error) => {
+      console.warn('[Worker] New simulation path failed, reverting to legacy simulation.', error);
+      post(toUI.NOTIFICATION, {
+        level: 'warn',
+        message: 'New simulation engine failed this week. The legacy simulator completed the week safely.',
       });
-    } catch (simErr) {
-      console.error(`[Worker] simulateBatch crashed for batch starting at game ${i}:`, simErr);
-      batchResults = [];
+    },
+    legacySimulate: () => simulateWeekLegacy({ gamesToSim, league, meta, id }),
+  });
+
+  if (simulationMode === 'new') {
+    post(toUI.NOTIFICATION, { level: 'info', message: 'Weekly simulation ran on the AttributesV2 engine.' });
+  }
+
+  // Apply each game result to cache and emit GAME_EVENT per game
+  for (const res of results) {
+    applyGameResultToCache(res, week, seasonId);
+
+    // Mark injured players as dirty so changes persist
+    if (res.injuries) {
+      for (const inj of res.injuries) {
+        const p = cache.getPlayer(inj.playerId);
+        if (p) {
+          cache.updatePlayer(p.id, {
+            injuries: p.injuries,
+            injured: p.injured,
+            injuryWeeksRemaining: p.injuryWeeksRemaining,
+            seasonEndingInjury: p.seasonEndingInjury
+          });
+        }
+      }
     }
-    if (batchResults.length === 0 && batch.length > 0) {
-      console.warn(`[Worker] simulateBatch returned 0 results for ${batch.length} games (batch at index ${i}). Games:`,
-        batch.map(g => `${g.home?.abbr ?? g.home?.id ?? '?'} vs ${g.away?.abbr ?? g.away?.id ?? '?'}`).join(', '));
-    }
-    results.push(...batchResults);
 
-    // Apply each game result to cache and emit GAME_EVENT per game
-    for (const res of batchResults) {
-      applyGameResultToCache(res, week, seasonId);
-
-      // Log significant injuries to News
-
-      // Mark injured players as dirty so changes persist
-      if (res.injuries) {
-          for (const inj of res.injuries) {
-             // We just need to trigger a dirty flag. Passing current state works.
-             const p = cache.getPlayer(inj.playerId);
-             if (p) {
-                 cache.updatePlayer(p.id, {
-                     injuries: p.injuries,
-                     injured: p.injured,
-                     injuryWeeksRemaining: p.injuryWeeksRemaining,
-                     seasonEndingInjury: p.seasonEndingInjury
-                 });
-             }
+    if (res.injuries && res.injuries.length > 0) {
+      for (const inj of res.injuries) {
+        if (inj.duration > 2 || inj.seasonEnding) {
+          const p = cache.getPlayer(inj.playerId);
+          if (p) {
+            await NewsEngine.logInjury(p, inj.type, inj.duration);
+            const injuryNews = createNewsItem('injury', { playerName: p?.name, position: p?.pos, weeks: inj?.duration, teamName: cache.getTeam(p?.teamId)?.name, teamId: p?.teamId ?? null }, week, meta?.season);
+            cache.setMeta(addNewsItem(cache.getMeta(), injuryNews));
           }
-      }
-
-if (res.injuries && res.injuries.length > 0) {
-          for (const inj of res.injuries) {
-              // Log only if duration > 2 weeks to reduce noise, or if season ending
-              if (inj.duration > 2 || inj.seasonEnding) {
-                  const p = cache.getPlayer(inj.playerId);
-                  if (p) {
-                      // Fire and forget (don't await to keep sim speed up, or await if consistency needed)
-                      // Since IDB ops are async, we should await or at least trigger.
-                      // Since we are inside an async function, let's await to be safe.
-                      await NewsEngine.logInjury(p, inj.type, inj.duration);
-                      const injuryNews = createNewsItem('injury', { playerName: p?.name, position: p?.pos, weeks: inj?.duration, teamName: cache.getTeam(p?.teamId)?.name, teamId: p?.teamId ?? null }, week, meta?.season);
-                      cache.setMeta(addNewsItem(cache.getMeta(), injuryNews));
-                  }
-              }
-          }
-      }
-
-      // Emit GAME_EVENT so the LiveGame viewer can update the scoreboard in real-time
-      const rawH   = res.home      ?? res.homeTeamId;
-      const rawA   = res.away      ?? res.awayTeamId;
-      const homeId = Number(typeof rawH === 'object' ? rawH?.id : rawH);
-      const awayId = Number(typeof rawA === 'object' ? rawA?.id : rawA);
-      if (!isNaN(homeId) && !isNaN(awayId)) {
-        post(toUI.GAME_EVENT, {
-          gameId:    buildCanonicalGameId({ seasonId, week, homeId, awayId }),
-          week,
-          homeId,
-          awayId,
-          homeName:  res.homeTeamName ?? cache.getTeam(homeId)?.name ?? '?',
-          awayName:  res.awayTeamName ?? cache.getTeam(awayId)?.name ?? '?',
-          homeAbbr:  res.homeTeamAbbr ?? cache.getTeam(homeId)?.abbr ?? '???',
-          awayAbbr:  res.awayTeamAbbr ?? cache.getTeam(awayId)?.abbr ?? '???',
-          homeScore: res.scoreHome ?? res.homeScore ?? 0,
-          awayScore: res.scoreAway ?? res.awayScore ?? 0,
-          recapText: res.recapText ?? null,
-          teamDriveStats: res.teamDriveStats ?? null,
-        });
+        }
       }
     }
 
-    post(toUI.SIM_PROGRESS, { done: i + batch.length, total: gamesToSim.length }, id);
-    await yieldFrame();
+    const rawH   = res.home      ?? res.homeTeamId;
+    const rawA   = res.away      ?? res.awayTeamId;
+    const homeId = Number(typeof rawH === 'object' ? rawH?.id : rawH);
+    const awayId = Number(typeof rawA === 'object' ? rawA?.id : rawA);
+    if (!isNaN(homeId) && !isNaN(awayId)) {
+      post(toUI.GAME_EVENT, {
+        gameId:    buildCanonicalGameId({ seasonId, week, homeId, awayId }),
+        week,
+        homeId,
+        awayId,
+        homeName:  res.homeTeamName ?? cache.getTeam(homeId)?.name ?? '?',
+        awayName:  res.awayTeamName ?? cache.getTeam(awayId)?.name ?? '?',
+        homeAbbr:  res.homeTeamAbbr ?? cache.getTeam(homeId)?.abbr ?? '???',
+        awayAbbr:  res.awayTeamAbbr ?? cache.getTeam(awayId)?.abbr ?? '???',
+        homeScore: res.scoreHome ?? res.homeScore ?? 0,
+        awayScore: res.scoreAway ?? res.awayScore ?? 0,
+        recapText: res.recapText ?? null,
+        teamDriveStats: res.teamDriveStats ?? null,
+      });
+    }
   }
 
   // SAFETY: If simulation produced 0 results, don't advance the week
   if (results.length === 0) {
-    console.error(`[Worker] ADVANCE_WEEK: simulateBatch returned 0 results for week ${week} (${gamesToSim.length} games attempted) — aborting advance.`);
+    console.error(`[Worker] ADVANCE_WEEK: simulation returned 0 results for week ${week} (${gamesToSim.length} games attempted) — aborting advance.`);
     post(toUI.WEEK_COMPLETE, {
       week,
       results:    [],
@@ -2661,6 +2657,70 @@ function buildLeagueForSim(schedule, week, seasonId) {
   };
 
   return leagueObj;
+}
+
+function buildWeekMatchupsFromLeague(league, meta, week) {
+  const matchups = [];
+  const migratedPlayers = [];
+
+  for (const game of (league?._weekGames ?? [])) {
+    const homeRoster = Array.isArray(game?.home?.roster) ? game.home.roster : [];
+    const awayRoster = Array.isArray(game?.away?.roster) ? game.away.roster : [];
+
+    const homeUnits = aggregateTeamUnitsFromRoster(homeRoster);
+    const awayUnits = aggregateTeamUnitsFromRoster(awayRoster);
+    migratedPlayers.push(...homeUnits.migratedPlayers, ...awayUnits.migratedPlayers);
+
+    matchups.push({
+      gameId: buildCanonicalGameId({
+        seasonId: Number(meta?.currentSeasonId ?? meta?.season ?? 1),
+        week: Number(week),
+        homeId: Number(game?.home?.id),
+        awayId: Number(game?.away?.id),
+      }),
+      homeTeamId: Number(game?.home?.id),
+      awayTeamId: Number(game?.away?.id),
+      homeOffense: homeUnits.offense,
+      homeDefense: homeUnits.defense,
+      awayOffense: awayUnits.offense,
+      awayDefense: awayUnits.defense,
+      seed: buildDeterministicSeed(`${meta?.currentSeasonId ?? 1}:${week}:${game?.home?.id}:${game?.away?.id}`),
+      weather: 'clear',
+    });
+  }
+
+  return { matchups, migratedPlayers };
+}
+
+async function simulateWeekLegacy({ gamesToSim, league, meta, id }) {
+  const BATCH_SIZE = 2;
+  const results = [];
+  const injuryFactor = Math.max(0, Number(getLeagueSetting('injuryFrequency', 50)) / 50);
+
+  for (let i = 0; i < gamesToSim.length; i += BATCH_SIZE) {
+    const batch = gamesToSim.slice(i, i + BATCH_SIZE);
+    let batchResults;
+    try {
+      batchResults = simulateBatch(batch, {
+        league,
+        isPlayoff: meta.phase === 'playoffs',
+        injuryFactor,
+        overtimeFormat: getLeagueSetting('overtimeFormat', 'nfl'),
+      });
+    } catch (simErr) {
+      console.error(`[Worker] simulateBatch crashed for batch starting at game ${i}:`, simErr);
+      batchResults = [];
+    }
+    if (batchResults.length === 0 && batch.length > 0) {
+      console.warn(`[Worker] simulateBatch returned 0 results for ${batch.length} games (batch at index ${i}). Games:`,
+        batch.map(g => `${g.home?.abbr ?? g.home?.id ?? '?'} vs ${g.away?.abbr ?? g.away?.id ?? '?'}`).join(', '));
+    }
+    results.push(...batchResults);
+    post(toUI.SIM_PROGRESS, { done: i + batch.length, total: gamesToSim.length }, id);
+    await yieldFrame();
+  }
+
+  return results;
 }
 
 function roundStat(value, decimals = 1) {


### PR DESCRIPTION
### Motivation
- Enable the new AttributesV2 matchup engine and worker-pool to power real weekly gameplay while preserving a safe, opt-in rollout and legacy fallback. 
- Provide a deterministic bridge from real roster/player data into the new engine's offense/defense unit inputs and keep migration idempotent.

### Description
- Added a new bridge module `src/core/sim/weekSimulationBridge.ts` that: derives offense/defense `AttributesV2` unit inputs from a real roster using explicit positional priority buckets, idempotently migrates missing `attributesV2`, builds deterministic seeds, maps `GameSummary` → legacy-compatible result objects, and exposes `simulateWithOptionalNewEngine` orchestration with fallback semantics.
- Wired the new path into the existing weekly flow inside the worker `ADVANCE_WEEK` handler (`src/worker/worker.js`) so weekly simulation will call `simulationManager.simWeekParallel(...)` when enabled, relay per-game progress to the UI (`toUI.SIM_PROGRESS` / `toUI.GAME_EVENT`), persist any migrated `attributesV2` back into the cache, and feed results through `applyGameResultToCache` so schedule/results/archive/news/game-detail flows are preserved.
- Added `useNewSimulationEngine` league setting (default `false`) and normalization to `normalizeLeagueSettings` so rollout is controlled by a clear flag and existing saves keep legacy behaviour.
- Preserved robust fallback: if the new engine is disabled or throws, the bridge runs the legacy `simulateBatch` path and reports a warning notification; migration is applied only when players lack `attributesV2` (idempotent).
- Added integration-focused tests `src/core/__tests__/weekSimulationBridge.test.ts` covering aggregation/migration, idempotence, fallback-on-error, deterministic seed, and summary→legacy mapping.

### Testing
- Ran unit/integration tests with `npm run test:unit -- src/core/__tests__/weekSimulationBridge.test.ts src/worker/__tests__/WorkerPool.test.ts src/core/__tests__/attributeMigrator.test.ts` and all tests passed: 3 files, 8 tests total (green).
- Verified `WorkerPool` main-thread fallback test still passes and the new `weekSimulationBridge` tests exercise migration, aggregation, fallback, deterministic seeding, and result mapping (all succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e109c10c10832daa63310a47cf8691)