### PR TITLE
Stabilize Draft/Standings, fix League Leaders and improve navigation & accessibility

### DIFF
--- a/src/context/SettingsContext.jsx
+++ b/src/context/SettingsContext.jsx
@@ -3,14 +3,17 @@ import React, { createContext, useContext, useEffect, useMemo, useState } from "
 const STORAGE_KEY = "footballgm_settings";
 
 const SettingsContext = createContext({
+  settings: { soundEnabled: true, theme: "system", contrastMode: "standard" },
   soundEnabled: true,
   theme: "system",
+  contrastMode: "standard",
   toggleSound: () => {},
   setTheme: () => {},
+  updateSetting: () => {},
 });
 
 export function SettingsProvider({ children }) {
-  const [settings, setSettings] = useState({ soundEnabled: true, theme: "system" });
+  const [settings, setSettings] = useState({ soundEnabled: true, theme: "system", contrastMode: "standard" });
 
   useEffect(() => {
     try {
@@ -21,9 +24,10 @@ export function SettingsProvider({ children }) {
         ...prev,
         soundEnabled: typeof parsed?.soundEnabled === "boolean" ? parsed.soundEnabled : prev.soundEnabled,
         theme: typeof parsed?.theme === "string" ? parsed.theme : prev.theme,
+        contrastMode: parsed?.contrastMode === "high" ? "high" : "standard",
       }));
     } catch {
-      setSettings({ soundEnabled: true, theme: "system" });
+      setSettings({ soundEnabled: true, theme: "system", contrastMode: "standard" });
     }
   }, []);
 
@@ -32,11 +36,14 @@ export function SettingsProvider({ children }) {
   }, [settings]);
 
   const value = useMemo(() => ({
+    settings,
     soundEnabled: settings.soundEnabled,
     theme: settings.theme,
+    contrastMode: settings.contrastMode,
     toggleSound: () => setSettings((prev) => ({ ...prev, soundEnabled: !prev.soundEnabled })),
     setTheme: (theme) => setSettings((prev) => ({ ...prev, theme })),
-  }), [settings.soundEnabled, settings.theme]);
+    updateSetting: (key, val) => setSettings((prev) => ({ ...prev, [key]: val })),
+  }), [settings]);
 
   return (
     <SettingsContext.Provider value={value}>

--- a/src/ui/components/Draft.jsx
+++ b/src/ui/components/Draft.jsx
@@ -1033,6 +1033,17 @@ export function filterDraftProspectsForView(prospects, { filterPos, nameFilter, 
   return applyAdvancedPlayerFilters(list, advancedFilters);
 }
 
+export function normalizeIncomingDraftState(incoming) {
+  if (!incoming || typeof incoming !== "object" || incoming.notStarted) return null;
+  return {
+    ...incoming,
+    prospects: Array.isArray(incoming.prospects) ? incoming.prospects : [],
+    completedPicks: Array.isArray(incoming.completedPicks) ? incoming.completedPicks : [],
+    upcomingPicks: Array.isArray(incoming.upcomingPicks) ? incoming.upcomingPicks : [],
+    totalPicks: Number(incoming.totalPicks ?? 0),
+  };
+}
+
 function DraftBoard({
   draftState,
   userTeamId,
@@ -2216,18 +2227,20 @@ export default function Draft({ league, actions, onNavigate = null }) {
   const [profilePlayerId, setProfilePlayerId] = useState(null);
   const [pickGrade, setPickGrade] = useState(null); // { pick, grade }
 
+  const normalizeDraftState = useCallback((incoming) => normalizeIncomingDraftState(incoming), []);
+
   const loadDraftState = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
       const res = await actions.getDraftState();
-      if (res?.payload) setDraftState(res.payload.notStarted ? null : res.payload);
+      setDraftState(normalizeDraftState(res?.payload));
     } catch (err) {
       setError(err?.message ?? 'Unable to load draft state');
     } finally {
       setLoading(false);
     }
-  }, [actions]);
+  }, [actions, normalizeDraftState]);
 
   // Enrich each pick with isUser flag for the completed-picks panel
   const enrichedDraftState = useMemo(() => {
@@ -2254,21 +2267,21 @@ export default function Draft({ league, actions, onNavigate = null }) {
   }, [loadDraftState]);
 
   const handleDraftStarted = useCallback((state) => {
-    setDraftState(state);
-  }, []);
+      setDraftState(normalizeDraftState(state));
+  }, [normalizeDraftState]);
 
   const handleSimToMyPick = useCallback(async () => {
     setSimming(true);
     setError(null);
     try {
       const res = await actions.simDraftPick();
-      if (res?.payload) setDraftState(res.payload);
+      if (res?.payload) setDraftState(normalizeDraftState(res.payload));
     } catch (err) {
       setError(err.message);
     } finally {
       setSimming(false);
     }
-  }, [actions]);
+  }, [actions, normalizeDraftState]);
 
   const handleDraftPlayer = useCallback(
     async (playerId) => {
@@ -2276,7 +2289,7 @@ export default function Draft({ league, actions, onNavigate = null }) {
       try {
         const res = await actions.makeDraftPick(playerId);
         if (res?.payload) {
-          setDraftState(res.payload);
+          setDraftState(normalizeDraftState(res.payload));
 
           // Show pick grade for the user's pick
           const picks = res.payload.completedPicks ?? [];
@@ -2298,7 +2311,7 @@ export default function Draft({ league, actions, onNavigate = null }) {
         setError(err.message);
       }
     },
-    [actions, league?.userTeamId],
+    [actions, league?.userTeamId, normalizeDraftState],
   );
 
   // ── Render ─────────────────────────────────────────────────────────────────

--- a/src/ui/components/Draft.test.jsx
+++ b/src/ui/components/Draft.test.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { renderToString } from "react-dom/server";
+import Draft, { normalizeIncomingDraftState } from "./Draft.jsx";
+
+describe("Draft safeguards", () => {
+  it("normalizes incomplete draft payloads", () => {
+    const normalized = normalizeIncomingDraftState({ currentPickIndex: 1, notStarted: false });
+    expect(normalized.prospects).toEqual([]);
+    expect(normalized.completedPicks).toEqual([]);
+    expect(normalized.upcomingPicks).toEqual([]);
+    expect(normalized.totalPicks).toBe(0);
+  });
+
+  it("renders draft shell without crashing for offseason flow", () => {
+    const html = renderToString(
+      <Draft
+        league={{ year: 2026, userTeamId: 1, teams: [] }}
+        actions={{ getDraftState: async () => ({ payload: null }) }}
+        onNavigate={() => {}}
+      />,
+    );
+    expect(html).toContain("NFL Draft");
+  });
+});

--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -815,6 +815,7 @@ export default function FreeAgency({
           <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
             <Badge variant="outline">{formatNeedsLine(needsSummary)}</Badge>
             <Badge variant="outline">Direction: {teamIntel.direction}</Badge>
+            <Button size="sm" variant="outline" onClick={() => onNavigate?.("Team")}>Return to team overview</Button>
             <Button size="sm" variant="secondary" onClick={() => onNavigate?.("FA Hub")}>Open FA Hub Overview</Button>
           </div>
           <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>{buildDirectionGuidance(teamIntel)}</div>

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -498,7 +498,7 @@ function PlayoffPictureView({ teams, activeConf, userTeamId, onTeamSelect }) {
   );
 }
 
-function StandingsTab({ teams, userTeamId, onTeamSelect, leagueSettings }) {
+function StandingsTab({ teams = [], userTeamId, onTeamSelect, leagueSettings }) {
   const confNames = Array.isArray(leagueSettings?.conferenceNames) && leagueSettings.conferenceNames.length
     ? leagueSettings.conferenceNames
     : CONFS;
@@ -508,11 +508,17 @@ function StandingsTab({ teams, userTeamId, onTeamSelect, leagueSettings }) {
   const [activeConf, setActiveConf] = useState(confNames[0] || "AFC");
   const [viewMode, setViewMode] = useState("division"); // "division" | "playoff"
 
+  useEffect(() => {
+    if (!confNames.includes(activeConf)) {
+      setActiveConf(confNames[0] || "AFC");
+    }
+  }, [confNames, activeConf]);
+
   // Normalise activeConf label → numeric index for comparison
   const activeConfIdx = Math.max(0, confNames.indexOf(activeConf));
 
   const grouped = useMemo(() => {
-    const confTeams = teams.filter((t) => confIdx(t.conf) === activeConfIdx);
+    const confTeams = (Array.isArray(teams) ? teams : []).filter((t) => confIdx(t.conf) === activeConfIdx);
     const groups = divNames.map((name, idx) => ({
       div: name,
       teams: confTeams
@@ -1734,6 +1740,7 @@ export default function LeagueDashboard({
           <TabErrorBoundary label="League Leaders">
             <LeagueLeaders
               league={league}
+              actions={actions}
               onPlayerSelect={(player) => setSelectedPlayerId(player?.id ?? player)}
               onNavigate={setActiveTab}
             />
@@ -1855,6 +1862,7 @@ export default function LeagueDashboard({
               league={league}
               actions={actions}
               onPlayerSelect={setSelectedPlayerId}
+              onNavigate={setActiveTab}
               initialView={tradeInitialView}
               initialPartnerTeamId={tradeSeedPartnerId}
             />

--- a/src/ui/components/LeagueLeaders.jsx
+++ b/src/ui/components/LeagueLeaders.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import EmptyState from "./EmptyState.jsx";
 
 const TABS = ["Passing", "Rushing", "Receiving", "Tackles", "Sacks", "Interceptions"];
@@ -76,9 +76,49 @@ function displayNumber(value, decimals = 0, suffix = "") {
   return `${safe.toLocaleString(undefined, { minimumFractionDigits: decimals, maximumFractionDigits: decimals })}${suffix}`;
 }
 
-export default function LeagueLeaders({ league, onPlayerSelect, onNavigate }) {
+function normalizeLeaderRows(rawRows = []) {
+  return (Array.isArray(rawRows) ? rawRows : []).map((row) => ({
+    id: row?.playerId ?? row?.id ?? row?.pid ?? row?.player?.id ?? null,
+    name: row?.name ?? row?.playerName ?? row?.player?.name ?? "—",
+    teamAbbr: row?.teamAbbr ?? row?.abbr ?? row?.team ?? "—",
+    teamId: row?.teamId ?? row?.tid ?? row?.team?.id ?? null,
+    value: Number(row?.value ?? row?.stat ?? row?.amount ?? 0) || 0,
+    raw: row,
+  }));
+}
+
+const API_TAB_MAP = Object.freeze({
+  Passing: { category: "passing", statKeys: ["passYards", "passTDs", "completions"] },
+  Rushing: { category: "rushing", statKeys: ["rushYards", "rushTDs", "rushAttempts"] },
+  Receiving: { category: "receiving", statKeys: ["recYards", "recTDs", "receptions"] },
+  Tackles: { category: "defense", statKeys: ["tackles"] },
+  Sacks: { category: "defense", statKeys: ["sacks"] },
+  Interceptions: { category: "defense", statKeys: ["interceptions"] },
+});
+
+export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavigate }) {
   const [activeTab, setActiveTab] = useState("Passing");
+  const [remoteCategories, setRemoteCategories] = useState(null);
+  const firstTabRef = useRef(null);
   const teams = Array.isArray(league?.teams) ? league.teams : [];
+
+  useEffect(() => {
+    firstTabRef.current?.focus?.();
+  }, []);
+
+  useEffect(() => {
+    let alive = true;
+    actions?.getLeagueLeaders?.("season")
+      .then((resp) => {
+        if (!alive) return;
+        setRemoteCategories(resp?.payload?.categories ?? null);
+      })
+      .catch(() => {
+        if (!alive) return;
+        setRemoteCategories(null);
+      });
+    return () => { alive = false; };
+  }, [actions]);
 
   const allPlayers = useMemo(
     () =>
@@ -94,6 +134,26 @@ export default function LeagueLeaders({ league, onPlayerSelect, onNavigate }) {
   );
 
   const rows = useMemo(() => {
+    const apiConfig = API_TAB_MAP[activeTab];
+    if (remoteCategories && apiConfig) {
+      const bucket = remoteCategories?.[apiConfig.category] ?? {};
+      const statKey = apiConfig.statKeys.find((key) => Array.isArray(bucket?.[key]) && bucket[key].length > 0);
+      if (statKey) {
+        return normalizeLeaderRows(bucket[statKey]).slice(0, 10).map((row) => ({
+          player: {
+            ...row.raw,
+            id: row.id,
+            name: row.name,
+            teamName: row.teamAbbr,
+            teamId: row.teamId,
+            isUserTeam: Number(row.teamId) === Number(league?.userTeamId),
+          },
+          primary: row.value,
+          secondary: "—",
+        }));
+      }
+    }
+
     const config = CATEGORY_CONFIG[activeTab] ?? CATEGORY_CONFIG.Passing;
     return allPlayers
       .map((player) => ({
@@ -109,9 +169,16 @@ export default function LeagueLeaders({ league, onPlayerSelect, onNavigate }) {
 
   return (
     <div style={{ display: "grid", gap: "var(--space-3)" }}>
-      <div className="standings-tabs profile-tab-row" style={{ flexWrap: "nowrap", gap: 6 }}>
-        {TABS.map((tab) => (
-          <button key={tab} className={`standings-tab${activeTab === tab ? " active" : ""}`} onClick={() => setActiveTab(tab)}>
+      <div className="standings-tabs profile-tab-row" role="tablist" aria-label="League leader categories" style={{ flexWrap: "nowrap", gap: 6, alignItems: "center" }}>
+        {TABS.map((tab, index) => (
+          <button
+            key={tab}
+            ref={index === 0 ? firstTabRef : null}
+            role="tab"
+            aria-selected={activeTab === tab}
+            className={`standings-tab${activeTab === tab ? " active" : ""}`}
+            onClick={() => setActiveTab(tab)}
+          >
             {tab}
           </button>
         ))}

--- a/src/ui/components/NewLeagueSetup.jsx
+++ b/src/ui/components/NewLeagueSetup.jsx
@@ -315,6 +315,8 @@ export default function NewLeagueSetup({ actions, onCancel, onStartCreate }) {
             {/* Advanced Settings Toggle */}
             <Button
               onClick={() => setShowAdvanced(!showAdvanced)}
+              aria-expanded={showAdvanced}
+              aria-controls="advanced-settings-panel"
               style={{
                 width: "100%", padding: "var(--space-3) var(--space-4)",
                 background: "transparent",
@@ -338,7 +340,7 @@ export default function NewLeagueSetup({ actions, onCancel, onStartCreate }) {
 
             {/* Advanced Settings Panel */}
             {showAdvanced && (
-              <div className="fade-in" style={{ display: "flex", flexDirection: "column", gap: "var(--space-5)" }}>
+              <div id="advanced-settings-panel" className="fade-in" style={{ display: "flex", flexDirection: "column", gap: "var(--space-5)" }}>
                 {/* Playoff Format */}
                 <div className="settings-group">
                   <label className="settings-label">Playoff Format</label>

--- a/src/ui/components/StandingsTable.jsx
+++ b/src/ui/components/StandingsTable.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from "@/components/ui/table";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+function safeWinPct(wins = 0, losses = 0, ties = 0) {
+  const games = Number(wins) + Number(losses) + Number(ties);
+  if (games <= 0) return ".000";
+  return ((Number(wins) + Number(ties) * 0.5) / games).toFixed(3).replace(/^0/, "");
+}
+
+export default function StandingsTable({ teams = [], userTeamId = null, onTeamSelect = null }) {
+  const safeTeams = Array.isArray(teams) ? teams : [];
+
+  return (
+    <ScrollArea className="h-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead style={{ paddingLeft: "var(--space-5)" }}>Team</TableHead>
+            <TableHead style={{ textAlign: "center" }}>W</TableHead>
+            <TableHead style={{ textAlign: "center" }}>L</TableHead>
+            <TableHead style={{ textAlign: "center" }}>T</TableHead>
+            <TableHead style={{ textAlign: "center" }}>PCT</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {safeTeams.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={5} style={{ textAlign: "center", color: "var(--text-muted)" }}>
+                No standings data available.
+              </TableCell>
+            </TableRow>
+          )}
+          {safeTeams.map((team, idx) => {
+            const wins = Number(team?.wins ?? 0);
+            const losses = Number(team?.losses ?? 0);
+            const ties = Number(team?.ties ?? 0);
+            const isUser = Number(team?.id) === Number(userTeamId);
+            return (
+              <TableRow key={team?.id ?? `${team?.abbr ?? "team"}-${idx}`} className={isUser ? "user-team-row" : ""}>
+                <TableCell style={{ paddingLeft: "var(--space-4)" }}>
+                  <button className="btn btn-link" onClick={() => onTeamSelect?.(team?.id)}>
+                    {team?.name ?? team?.abbr ?? "Unknown"}
+                  </button>
+                </TableCell>
+                <TableCell style={{ textAlign: "center" }}>{wins}</TableCell>
+                <TableCell style={{ textAlign: "center" }}>{losses}</TableCell>
+                <TableCell style={{ textAlign: "center" }}>{ties}</TableCell>
+                <TableCell style={{ textAlign: "center" }}>{safeWinPct(wins, losses, ties)}</TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </ScrollArea>
+  );
+}

--- a/src/ui/components/StandingsTable.test.jsx
+++ b/src/ui/components/StandingsTable.test.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { renderToString } from "react-dom/server";
+import StandingsTable from "./StandingsTable.jsx";
+
+describe("StandingsTable", () => {
+  it("renders empty-state copy when standings are missing", () => {
+    const html = renderToString(<StandingsTable teams={[]} />);
+    expect(html).toContain("No standings data available.");
+  });
+
+  it("renders partial team rows without crashing", () => {
+    const html = renderToString(
+      <StandingsTable
+        userTeamId={7}
+        teams={[
+          { id: 7, abbr: "BUF", wins: 10, losses: 7 },
+          { id: 11, name: "Jets", wins: 6, losses: 11, ties: 0 },
+        ]}
+      />,
+    );
+    expect(html).toContain("BUF");
+    expect(html).toContain("Jets");
+    expect(html).toContain(".588");
+  });
+});

--- a/src/ui/components/ThemeToggle.jsx
+++ b/src/ui/components/ThemeToggle.jsx
@@ -13,6 +13,7 @@ const THEMES = {
   system: { label: "System", icon: SunMoonIcon },
   dark: { label: "Dark", icon: MoonIcon },
   light: { label: "Light", icon: SunIcon },
+  high: { label: "High Contrast", icon: ContrastIcon },
 };
 
 export default function ThemeToggle({ compact = false }) {
@@ -32,12 +33,15 @@ export default function ThemeToggle({ compact = false }) {
 
     // Clear all theme classes
     root.classList.remove("force-dark");
+    root.classList.remove("theme-high-contrast");
     body.classList.remove("theme-light");
 
     if (t === "dark") {
       root.classList.add("force-dark");
     } else if (t === "light") {
       body.classList.add("theme-light");
+    } else if (t === "high") {
+      root.classList.add("theme-high-contrast");
     }
     // "system" — let @media (prefers-color-scheme) handle it
   }, []);
@@ -51,6 +55,7 @@ export default function ThemeToggle({ compact = false }) {
     setTheme(prev => {
       if (prev === "system") return "dark";
       if (prev === "dark") return "light";
+      if (prev === "light") return "high";
       return "system";
     });
   }, []);
@@ -138,6 +143,15 @@ function SunMoonIcon({ size = 18 }) {
       <path d="M20 12h2" />
       <path d="M6.34 17.66l-1.41 1.41" />
       <path d="M19.07 4.93l-1.41 1.41" />
+    </svg>
+  );
+}
+
+function ContrastIcon({ size = 18 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 3a9 9 0 0 1 0 18z" />
     </svg>
   );
 }

--- a/src/ui/components/TradeWorkspace.jsx
+++ b/src/ui/components/TradeWorkspace.jsx
@@ -13,7 +13,7 @@ import { buildNewsDeskModel } from '../utils/newsDesk.js';
 
 const VIEWS = ['Block', 'Finder', 'Builder', 'Offers', 'Summary'];
 
-export default function TradeWorkspace({ league, actions, onPlayerSelect, initialView = 'Finder', initialPartnerTeamId = null }) {
+export default function TradeWorkspace({ league, actions, onPlayerSelect, onNavigate = null, initialView = 'Finder', initialPartnerTeamId = null }) {
   const normalizedInitialView = typeof initialView === 'string' && initialView.includes(':')
     ? (initialView.split(':')[1] || 'Finder')
     : initialView;
@@ -71,6 +71,7 @@ export default function TradeWorkspace({ league, actions, onPlayerSelect, initia
       />
       <StickySubnav title="Trade views">
         <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          <button className="btn btn-secondary" onClick={() => onNavigate?.('Team')}>Back to Team</button>
           {VIEWS.map((v) => (
             <button key={v} className={`standings-tab${view === v ? ' active' : ''}`} onClick={() => setView(v)}>{v}</button>
           ))}

--- a/src/ui/styles/base.css
+++ b/src/ui/styles/base.css
@@ -175,6 +175,25 @@ body.theme-light {
   --ring: 221 83% 53%;
 }
 
+:root.theme-high-contrast {
+  --bg: #000000;
+  --bg-secondary: #050505;
+  --surface: #000000;
+  --surface-strong: #0a0a0a;
+  --surface-elevated: #101010;
+  --hairline: rgba(255, 255, 255, 0.4);
+  --hairline-strong: rgba(255, 255, 255, 0.7);
+  --text: #ffffff;
+  --text-muted: #f5f5f5;
+  --text-subtle: #d4d4d4;
+  --accent: #00a2ff;
+  --accent-hover: #45b9ff;
+  --accent-muted: rgba(0, 162, 255, 0.3);
+  --danger: #ff6464;
+  --success: #5cf58a;
+  --warning: #ffd166;
+}
+
 /* ============================================================================
    BASE STYLES
    ============================================================================ */


### PR DESCRIPTION
### Motivation
- Prevent fatal render crashes and blank UI in Draft and Standings when worker/view-model payloads are incomplete or missing. 
- Ensure League Leaders shows numeric stats (not just names) by using worker-provided leaderboard categories where available and make category tabs accessible. 
- Improve navigation and accessibility for key screens (Free Agency, Trade Workspace, New League setup) and add a high-contrast theme option.

### Description
- Hardened draft handling by normalizing incoming draft payloads and wiring all draft load/update flows through `normalizeIncomingDraftState`, ensuring `prospects`, `completedPicks`, `upcomingPicks` and `totalPicks` are defined before rendering (changes in `src/ui/components/Draft.jsx`).
- Made Standings resilient to missing/malformed inputs and reset invalid conference selection when league settings change, and added a reusable `StandingsTable` component that safely renders empty/partial data (`src/ui/components/LeagueDashboard.jsx`, `src/ui/components/StandingsTable.jsx`).
- Fixed League Leaders by preferring worker-provided categories when present, normalizing rows from the API, and adding accessible tab semantics (`role="tablist"`/`role="tab"`) with initial focus on the first tab (`src/ui/components/LeagueLeaders.jsx`).
- Improved navigation UX by adding explicit return actions: a “Return to team overview” button in Free Agency and a “Back to Team” button in the Trade Workspace, and passed `onNavigate` where needed (`src/ui/components/FreeAgency.jsx`, `src/ui/components/TradeWorkspace.jsx`, `src/ui/components/LeagueDashboard.jsx`).
- Improved New League Setup accordion accessibility by adding `aria-expanded` and `aria-controls` to the advanced toggle (`src/ui/components/NewLeagueSetup.jsx`).
- Extended settings/theme API to provide `settings` and `updateSetting`, added a high-contrast mode and CSS variables for it, and updated the theme toggle to persist and apply the new mode (`src/context/SettingsContext.jsx`, `src/ui/components/ThemeToggle.jsx`, `src/ui/styles/base.css`).
- Added lightweight unit tests to cover draft normalization and standings empty/partial rendering, and a small normalization export to support testing (`src/ui/components/Draft.test.jsx`, `src/ui/components/StandingsTable.test.jsx`).

### Testing
- Ran unit tests: `npm run test:unit -- src/ui/components/Draft.test.jsx src/ui/components/StandingsTable.test.jsx src/ui/components/BoxScore.test.jsx` and all tests passed (3 files, 7 tests) ✅.
- Built production bundle with `npm run build` which completed successfully (bundle warnings only) ✅.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e12460cd30832d81ab9549906d237b)