### PR TITLE
Stabilize season-phase dashboards (draft, standings, league leaders)

### DIFF
--- a/src/state/selectors.js
+++ b/src/state/selectors.js
@@ -70,3 +70,52 @@ export function getScheduleViewModel(league, filters = {}) {
     games: filtered,
   };
 }
+
+export function getSafeStandingsRows(league) {
+  const safe = safeGetLeagueState(league);
+  const rows = Array.isArray(safe?.standings) ? safe.standings : safe.teams;
+  return (Array.isArray(rows) ? rows : []).map((team) => ({
+    id: team?.id ?? null,
+    name: team?.name ?? 'Unknown Team',
+    abbr: team?.abbr ?? '---',
+    conf: team?.conf ?? 0,
+    div: team?.div ?? 0,
+    wins: Number(team?.wins ?? 0),
+    losses: Number(team?.losses ?? 0),
+    ties: Number(team?.ties ?? 0),
+    ptsFor: Number(team?.ptsFor ?? 0),
+    ptsAgainst: Number(team?.ptsAgainst ?? 0),
+    ovr: Number(team?.ovr ?? 0),
+    capRoom: Number(team?.capRoom ?? team?.capSpace ?? 0),
+    recentResults: Array.isArray(team?.recentResults) ? team.recentResults : [],
+    tiebreakers: team?.tiebreakers ?? {},
+  }));
+}
+
+export function getSafePhaseContext(league) {
+  const safe = safeGetLeagueState(league);
+  return {
+    phase: safe?.phase ?? 'regular',
+    year: Number(safe?.year ?? 0),
+    week: Number(safe?.week ?? 1),
+    userTeamId: safe?.userTeamId ?? null,
+    seasonId: safe?.seasonId ?? null,
+    hasSchedule: Array.isArray(safe?.schedule?.weeks) && safe.schedule.weeks.length > 0,
+  };
+}
+
+export function getSafeLeagueLeaderCategories(categories) {
+  const safeCategories = categories && typeof categories === 'object' ? categories : {};
+  const normalizeBucket = (bucket) => {
+    const safeBucket = bucket && typeof bucket === 'object' ? bucket : {};
+    return Object.fromEntries(
+      Object.entries(safeBucket).map(([key, value]) => [key, Array.isArray(value) ? value : []]),
+    );
+  };
+  return {
+    passing: normalizeBucket(safeCategories.passing),
+    rushing: normalizeBucket(safeCategories.rushing),
+    receiving: normalizeBucket(safeCategories.receiving),
+    defense: normalizeBucket(safeCategories.defense),
+  };
+}

--- a/src/state/selectors.test.js
+++ b/src/state/selectors.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getSafeLeagueLeaderCategories,
+  getSafePhaseContext,
+  getSafeStandingsRows,
+  safeGetLeagueState,
+} from './selectors.js';
+
+describe('state selectors safety', () => {
+  it('normalizes partial league payloads', () => {
+    const safe = safeGetLeagueState({ phase: null, teams: null, schedule: null });
+    expect(Array.isArray(safe.teams)).toBe(true);
+    expect(Array.isArray(safe.schedule.weeks)).toBe(true);
+    expect(safe.phase).toBe('regular');
+  });
+
+  it('returns default standings rows without throwing on missing stats', () => {
+    const rows = getSafeStandingsRows({
+      teams: [{ id: 1, name: 'Test', abbr: 'TST', conf: 'AFC', div: 'East' }],
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].wins).toBe(0);
+    expect(rows[0].recentResults).toEqual([]);
+  });
+
+  it('returns phase-safe context defaults', () => {
+    const context = getSafePhaseContext(null);
+    expect(context.phase).toBe('regular');
+    expect(context.hasSchedule).toBe(false);
+  });
+
+  it('normalizes missing leader categories into empty arrays', () => {
+    const categories = getSafeLeagueLeaderCategories({ passing: { passYards: null } });
+    expect(Array.isArray(categories.passing.passYards)).toBe(true);
+    expect(categories.passing.passYards).toEqual([]);
+  });
+});

--- a/src/ui/components/Draft.jsx
+++ b/src/ui/components/Draft.jsx
@@ -1029,7 +1029,7 @@ function PreDraftPanel({ league, actions, onDraftStarted }) {
 export function filterDraftProspectsForView(prospects, { filterPos, nameFilter, advancedFilters }) {
   let list = [...(prospects ?? [])];
   if (filterPos) list = list.filter((p) => p.pos === filterPos);
-  if (nameFilter) list = list.filter((p) => p.name.toLowerCase().includes(nameFilter.toLowerCase()));
+  if (nameFilter) list = list.filter((p) => String(p?.name ?? "").toLowerCase().includes(nameFilter.toLowerCase()));
   return applyAdvancedPlayerFilters(list, advancedFilters);
 }
 
@@ -2230,6 +2230,12 @@ export default function Draft({ league, actions, onNavigate = null }) {
   const normalizeDraftState = useCallback((incoming) => normalizeIncomingDraftState(incoming), []);
 
   const loadDraftState = useCallback(async () => {
+    if (!actions?.getDraftState) {
+      setLoading(false);
+      setError("Draft service unavailable for this save.");
+      setDraftState(null);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -2417,12 +2423,30 @@ export default function Draft({ league, actions, onNavigate = null }) {
       )}
 
       {/* Pre-draft: no draft started yet */}
-      {!loading && !draftState && (
+      {!loading && !draftState && league?.phase !== "draft" && (
         <PreDraftPanel
           league={league}
           actions={actions}
           onDraftStarted={handleDraftStarted}
         />
+      )}
+
+      {/* Draft phase recovery: entered draft but state is missing/unhydrated */}
+      {!loading && !draftState && league?.phase === "draft" && (
+        <Card className="card-premium">
+          <CardHeader>
+            <CardTitle>Draft data is still initializing</CardTitle>
+          </CardHeader>
+          <CardContent style={{ display: "grid", gap: "var(--space-3)" }}>
+            <div style={{ color: "var(--text-muted)", fontSize: "var(--text-sm)" }}>
+              The draft is active, but board data has not been hydrated yet. Retry loading or return to League HQ.
+            </div>
+            <div style={{ display: "flex", gap: "var(--space-2)" }}>
+              <Button className="btn" onClick={loadDraftState}>Retry Draft Load</Button>
+              <Button className="btn btn-secondary" onClick={() => onNavigate?.("League")}>Return to League</Button>
+            </div>
+          </CardContent>
+        </Card>
       )}
 
       {/* Draft board: draft in progress */}

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -87,7 +87,7 @@ import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/b
 import { resolveCompletedGameId } from "../utils/gameResultIdentity.js";
 import { getGame as getArchivedGame } from "../../core/archive/gameArchive.ts";
 import { normalizeManagementDestination } from "../utils/managementScreenRouting.js";
-import { safeGetLeagueState, getScheduleViewModel } from "../../state/selectors.js";
+import { safeGetLeagueState, getSafePhaseContext, getSafeStandingsRows, getScheduleViewModel } from "../../state/selectors.js";
 import {
   SHELL_SECTIONS,
   getShellSectionForDashboardTab,
@@ -124,6 +124,7 @@ class TabErrorBoundary extends Component {
     if (!this.state.hasError) return this.props.children;
 
     const label = this.props.label ?? "This tab";
+    const fallbackTab = this.props.fallbackTab ?? "HQ";
     return (
       <div
         style={{
@@ -158,6 +159,16 @@ class TabErrorBoundary extends Component {
           onClick={() => this.setState({ hasError: false, error: null })}
         >
           Retry
+        </button>
+        <button
+          className="btn btn-secondary"
+          style={{ marginLeft: "var(--space-2)" }}
+          onClick={() => {
+            this.setState({ hasError: false, error: null });
+            this.props.onNavigate?.(fallbackTab);
+          }}
+        >
+          Return to {fallbackTab}
         </button>
       </div>
     );
@@ -1391,8 +1402,10 @@ export default function LeagueDashboard({
       </div>
     );
   }
-  const safeTeams = Array.isArray(league?.teams) ? league.teams : [];
-  const safeLeague = { ...league, teams: safeTeams, week: Number(league?.week ?? 1) };
+  const safeLeague = safeGetLeagueState(league);
+  const safeTeams = safeLeague.teams;
+  const phaseContext = getSafePhaseContext(safeLeague);
+  const safeStandingsRows = useMemo(() => getSafeStandingsRows(safeLeague), [safeLeague]);
   const isInitialized = safeTeams.length > 0;
 
   // NOTE: a missing schedule only affects the Schedule tab.
@@ -1497,12 +1510,12 @@ export default function LeagueDashboard({
       </div>
 
       {/* ── Contextual Action Banners (compact) ── */}
-      {activeTab !== "HQ" && league.phase === "offseason_resign" && (
+      {activeTab !== "HQ" && phaseContext.phase === "offseason_resign" && (
         <div onClick={() => setActiveTab("Roster")} className="action-banner action-banner-success">
           ✍️ <strong>Expiring Contracts</strong> — review before Free Agency
         </div>
       )}
-      {activeTab !== "HQ" && league.phase === "preseason" && (
+      {activeTab !== "HQ" && phaseContext.phase === "preseason" && (
         <div className="action-banner action-banner-warning">
           ⚠️ <strong>Roster Cutdown:</strong>{" "}
           <span style={{ color: (userTeam?.rosterCount ?? 0) > 53 ? "var(--danger)" : "var(--success)" }}>
@@ -1511,12 +1524,12 @@ export default function LeagueDashboard({
           {" "}/ 53 — must release {Math.max(0, (userTeam?.rosterCount ?? 0) - 53)} players
         </div>
       )}
-      {activeTab !== "HQ" && league.phase === "playoffs" && activeTab !== "Postseason" && (
+      {activeTab !== "HQ" && phaseContext.phase === "playoffs" && activeTab !== "Postseason" && (
         <div onClick={() => setActiveTab("Postseason")} className="action-banner action-banner-gold">
           🏆 <strong>PLAYOFFS</strong> — click to view bracket
         </div>
       )}
-      {activeTab !== "HQ" && league.phase === "draft" && activeTab !== "Draft" && (
+      {activeTab !== "HQ" && phaseContext.phase === "draft" && activeTab !== "Draft" && (
         <div onClick={() => setActiveTab("Draft")} className="action-banner action-banner-accent">
           🏈 <strong>Draft Board is Open</strong> — click to make picks
         </div>
@@ -1573,7 +1586,7 @@ export default function LeagueDashboard({
       <div className="fade-in" key={activeTab}>
         {TEAM_FACING_TABS.has(activeTab) ? <FranchiseSummaryPanel league={league} compact className="" /> : null}
         {(activeTab === "HQ" || activeTab === "Weekly Hub" || activeTab === "Home") && (
-          <TabErrorBoundary label="Franchise HQ">
+          <TabErrorBoundary label="Franchise HQ" onNavigate={setActiveTab}>
               <FranchiseHQ
                 league={safeLeague}
                 onNavigate={(tab) => {
@@ -1604,7 +1617,7 @@ export default function LeagueDashboard({
           </TabErrorBoundary>
         )}
         {activeTab === "Team" && (
-          <TabErrorBoundary label="Team">
+          <TabErrorBoundary label="Team" onNavigate={setActiveTab}>
             <TeamHub
               league={league}
               actions={actions}
@@ -1634,7 +1647,7 @@ export default function LeagueDashboard({
           </TabErrorBoundary>
         )}
         {activeTab === "League" && (
-          <TabErrorBoundary label="League">
+          <TabErrorBoundary label="League" onNavigate={setActiveTab}>
             <LeagueHub
               league={league}
               actions={actions}
@@ -1663,7 +1676,7 @@ export default function LeagueDashboard({
               )}
               renderStandings={() => (
                 <StandingsTab
-                  teams={league.teams}
+                  teams={safeStandingsRows}
                   userTeamId={league.userTeamId}
                   onTeamSelect={setSelectedTeamId}
                   leagueSettings={league.settings}
@@ -1673,7 +1686,7 @@ export default function LeagueDashboard({
           </TabErrorBoundary>
         )}
         {activeTab === "News" && (
-          <TabErrorBoundary label="News">
+          <TabErrorBoundary label="News" onNavigate={setActiveTab}>
             <SectionSubnav items={["All", "Team", "League", "Transactions"]} activeItem={newsSubtab} onChange={setNewsSubtab} />
             <NewsFeed
               league={league}
@@ -1687,9 +1700,9 @@ export default function LeagueDashboard({
           </TabErrorBoundary>
         )}
         {activeTab === "Standings" && (
-          <TabErrorBoundary label="Standings">
+          <TabErrorBoundary label="Standings" onNavigate={setActiveTab} fallbackTab="League">
             <StandingsTab
-              teams={league.teams}
+              teams={safeStandingsRows}
               userTeamId={league.userTeamId}
               onTeamSelect={setSelectedTeamId}
               leagueSettings={league.settings}
@@ -1697,7 +1710,7 @@ export default function LeagueDashboard({
           </TabErrorBoundary>
         )}
         {activeTab === "Schedule" && (
-          <TabErrorBoundary label="Schedule">
+          <TabErrorBoundary label="Schedule" onNavigate={setActiveTab}>
             <ScheduleTab
               schedule={league.schedule}
               teams={league.teams}
@@ -1716,7 +1729,7 @@ export default function LeagueDashboard({
           </TabErrorBoundary>
         )}
         {activeTab === "Stats" && (
-          <TabErrorBoundary label="Stats">
+          <TabErrorBoundary label="Stats" onNavigate={setActiveTab}>
             <PlayerStats
               actions={actions}
               league={league}
@@ -1726,7 +1739,7 @@ export default function LeagueDashboard({
           </TabErrorBoundary>
         )}
         {activeTab === "Leaders" && (
-          <TabErrorBoundary label="Leaders">
+          <TabErrorBoundary label="Leaders" onNavigate={setActiveTab}>
             <Leaders
               onPlayerSelect={setSelectedPlayerId}
               userTeamId={league.userTeamId}
@@ -1737,7 +1750,7 @@ export default function LeagueDashboard({
           </TabErrorBoundary>
         )}
         {isInitialized && activeTab === "League Leaders" && (
-          <TabErrorBoundary label="League Leaders">
+          <TabErrorBoundary label="League Leaders" onNavigate={setActiveTab} fallbackTab="League">
             <LeagueLeaders
               league={league}
               actions={actions}
@@ -1747,7 +1760,7 @@ export default function LeagueDashboard({
           </TabErrorBoundary>
         )}
         {activeTab === "Award Races" && (
-          <TabErrorBoundary label="Award Races">
+          <TabErrorBoundary label="Award Races" onNavigate={setActiveTab}>
             <AwardRaces
               actions={actions}
               onPlayerSelect={setSelectedPlayerId}
@@ -1755,17 +1768,17 @@ export default function LeagueDashboard({
           </TabErrorBoundary>
         )}
         {activeTab === "Strategy" && (
-          <TabErrorBoundary label="Strategy">
+          <TabErrorBoundary label="Strategy" onNavigate={setActiveTab}>
             <StrategyPanel league={league} actions={actions} />
           </TabErrorBoundary>
         )}
         {activeTab === "Game Plan" && (
-          <TabErrorBoundary label="Game Plan">
+          <TabErrorBoundary label="Game Plan" onNavigate={setActiveTab}>
             <GamePlanScreen league={league} actions={actions} />
           </TabErrorBoundary>
         )}
         {activeTab === "Roster" && (
-          <TabErrorBoundary label="Roster">
+          <TabErrorBoundary label="Roster" onNavigate={setActiveTab}>
             <Roster
               league={league}
               actions={actions}
@@ -1777,7 +1790,7 @@ export default function LeagueDashboard({
           </TabErrorBoundary>
         )}
         {activeTab === "Depth Chart" && (
-          <TabErrorBoundary label="Depth Chart">
+          <TabErrorBoundary label="Depth Chart" onNavigate={setActiveTab}>
             <DragAndDropDepthChart
               league={league}
               actions={actions}
@@ -1787,7 +1800,7 @@ export default function LeagueDashboard({
           </TabErrorBoundary>
         )}
         {activeTab === "Roster Hub" && (
-          <TabErrorBoundary label="Roster Hub">
+          <TabErrorBoundary label="Roster Hub" onNavigate={setActiveTab}>
             <RosterHub
               league={league}
               actions={actions}
@@ -1796,17 +1809,17 @@ export default function LeagueDashboard({
           </TabErrorBoundary>
         )}
         {activeTab === "Financials" && (
-          <TabErrorBoundary label="Financials">
+          <TabErrorBoundary label="Financials" onNavigate={setActiveTab}>
             <FinancialsView league={league} actions={actions} />
           </TabErrorBoundary>
         )}
         {activeTab === "Contract Center" && (
-          <TabErrorBoundary label="Contract Center">
+          <TabErrorBoundary label="Contract Center" onNavigate={setActiveTab}>
             <ContractCenter league={league} actions={actions} onNavigate={setActiveTab} />
           </TabErrorBoundary>
         )}
         {activeTab === "Draft" && (
-          <TabErrorBoundary label="Draft">
+          <TabErrorBoundary label="Draft" onNavigate={setActiveTab} fallbackTab="League">
             <Draft
               league={league}
               actions={actions}

--- a/src/ui/components/LeagueLeaders.jsx
+++ b/src/ui/components/LeagueLeaders.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import EmptyState from "./EmptyState.jsx";
+import { getSafeLeagueLeaderCategories } from "../../state/selectors.js";
 
 const TABS = ["Passing", "Rushing", "Receiving", "Tackles", "Sacks", "Interceptions"];
 
@@ -88,12 +89,12 @@ function normalizeLeaderRows(rawRows = []) {
 }
 
 const API_TAB_MAP = Object.freeze({
-  Passing: { category: "passing", statKeys: ["passYards", "passTDs", "completions"] },
-  Rushing: { category: "rushing", statKeys: ["rushYards", "rushTDs", "rushAttempts"] },
-  Receiving: { category: "receiving", statKeys: ["recYards", "recTDs", "receptions"] },
-  Tackles: { category: "defense", statKeys: ["tackles"] },
-  Sacks: { category: "defense", statKeys: ["sacks"] },
-  Interceptions: { category: "defense", statKeys: ["interceptions"] },
+  Passing: { category: "passing", primaryKey: "passYards", secondaryKey: "passTDs" },
+  Rushing: { category: "rushing", primaryKey: "rushYards", secondaryKey: "rushTDs" },
+  Receiving: { category: "receiving", primaryKey: "recYards", secondaryKey: "receptions" },
+  Tackles: { category: "defense", primaryKey: "tackles", secondaryKey: "sacks" },
+  Sacks: { category: "defense", primaryKey: "sacks", secondaryKey: "pressures" },
+  Interceptions: { category: "defense", primaryKey: "interceptions", secondaryKey: "passesDefended" },
 });
 
 export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavigate }) {
@@ -136,10 +137,14 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
   const rows = useMemo(() => {
     const apiConfig = API_TAB_MAP[activeTab];
     if (remoteCategories && apiConfig) {
-      const bucket = remoteCategories?.[apiConfig.category] ?? {};
-      const statKey = apiConfig.statKeys.find((key) => Array.isArray(bucket?.[key]) && bucket[key].length > 0);
-      if (statKey) {
-        return normalizeLeaderRows(bucket[statKey]).slice(0, 10).map((row) => ({
+      const safeCategories = getSafeLeagueLeaderCategories(remoteCategories);
+      const bucket = safeCategories?.[apiConfig.category] ?? {};
+      const primaryRows = normalizeLeaderRows(bucket?.[apiConfig.primaryKey]).slice(0, 10);
+      const secondaryMap = new Map(
+        normalizeLeaderRows(bucket?.[apiConfig.secondaryKey]).map((row) => [String(row.id), row.value]),
+      );
+      if (primaryRows.length > 0) {
+        return primaryRows.map((row) => ({
           player: {
             ...row.raw,
             id: row.id,
@@ -149,7 +154,7 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
             isUserTeam: Number(row.teamId) === Number(league?.userTeamId),
           },
           primary: row.value,
-          secondary: "—",
+          secondary: displayNumber(secondaryMap.get(String(row.id))),
         }));
       }
     }
@@ -163,7 +168,7 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
       }))
       .sort((a, b) => (b.primary ?? 0) - (a.primary ?? 0))
       .slice(0, 10);
-  }, [allPlayers, activeTab]);
+  }, [allPlayers, activeTab, league?.userTeamId, remoteCategories]);
 
   const config = CATEGORY_CONFIG[activeTab] ?? CATEGORY_CONFIG.Passing;
 

--- a/src/ui/components/__tests__/draftFilters.test.jsx
+++ b/src/ui/components/__tests__/draftFilters.test.jsx
@@ -17,4 +17,14 @@ describe('draft advanced filter integration', () => {
 
     expect(result.map((p) => p.id)).toEqual([1]);
   });
+
+  it('handles prospects without names during draft state hydration', () => {
+    const prospects = [{ id: 4, pos: 'QB', potential: 81 }, { id: 5, name: 'Chris Clean', pos: 'QB', potential: 79 }];
+    const result = filterDraftProspectsForView(prospects, {
+      filterPos: 'QB',
+      nameFilter: 'ch',
+      advancedFilters: [],
+    });
+    expect(result.map((p) => p.id)).toEqual([5]);
+  });
 });


### PR DESCRIPTION
### Motivation
- The Draft route was crashing when the app transitioned into `draft` with unhydrated state, blocking the core game loop (season → offseason → draft). 
- Several league screens (Standings, League Leaders) were brittle during phase transitions and could render blank or throw when expected payloads were missing. 
- The UI needs phase-safe guards and localized error containment so pages survive delayed or missing worker data instead of crashing. 

### Description
- Added phase-safe selector helpers in `src/state/selectors.js`: `getSafeStandingsRows`, `getSafePhaseContext`, and `getSafeLeagueLeaderCategories` to always return sensible defaults for standings, phase context, and leader buckets. 
- Hardened the Draft flow in `src/ui/components/Draft.jsx` by guarding `actions.getDraftState`, making the name filter resilient to missing `name` fields, and adding a recoverable empty-state panel when the app is in the `draft` phase but the board data is not yet hydrated (includes `Retry` and `Return to League` controls). 
- Improved league dashboard containment in `src/ui/components/LeagueDashboard.jsx` by using the safe selectors, replacing direct league assumptions with `safeLeague`/`phaseContext`, and extending `TabErrorBoundary` with a `Return to <fallback>` action so crashed tabs are recoverable without dead-ends. 
- Fixed League Leaders mapping in `src/ui/components/LeagueLeaders.jsx` to consume normalized category buckets and paired primary/secondary keys from the worker payload to avoid blank or misaligned stat columns. 
- Added/updated unit tests: `src/state/selectors.test.js` and expanded `src/ui/components/__tests__/draftFilters.test.jsx` to cover partial hydration cases and ensure the new guards behave as expected. 
- No save schema changes or new runtime dependencies were introduced; all changes are additive guards and UI fallbacks to preserve compatibility. 

### Testing
- Ran unit tests for selector and draft filter regressions with `npm run test:unit -- src/state/selectors.test.js src/ui/components/__tests__/draftFilters.test.jsx`, and all tests passed. 
- Ran the existing dashboard smoke test `npm run test:unit -- src/ui/components/__tests__/freshSaveScreens.test.jsx`, and it passed. 
- These automated checks confirm the selectors and draft filtering logic are resilient to partially-initialized data and that core dashboard screens render without throwing in the covered scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1267f7a6c832da4175ac2b4495916)