### PR TITLE
Guided Offseason Action Center, Free Agency UX upgrades, and loop tests

### DIFF
--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -48,6 +48,7 @@ import { ScreenHeader, EmptyState, StickySubnav } from "./ScreenSystem.jsx";
 import AdvancedPlayerSearch from "./AdvancedPlayerSearch.jsx";
 import { applyAdvancedPlayerFilters } from "../../core/footballAdvancedFilters";
 import { usePlayerCompare } from "../utils/playerCompare.js";
+import { formatDemandTier } from "../utils/offseasonActionCenter.js";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -621,6 +622,12 @@ export default function FreeAgency({
   const [nameFilter, setNameFilter] = useState("");
   const [minOvr, setMinOvr] = useState(60);
   const [advancedFilters, setAdvancedFilters] = useState([]);
+  const [maxAge, setMaxAge] = useState(40);
+  const [minSchemeFit, setMinSchemeFit] = useState(0);
+  const [demandTier, setDemandTier] = useState("ALL");
+  const [watchOnly, setWatchOnly] = useState(false);
+  const [watchlistIds, setWatchlistIds] = useState(new Set());
+  const [sortPreset, setSortPreset] = useState("best_available");
 
   // Sorting
   const [sortKey, setSortKey] = useState("ovr");
@@ -687,11 +694,35 @@ export default function FreeAgency({
   }, [faState]);
 
   const displayed = useMemo(() => {
-    return filterFreeAgentsForView(faPool, { signedIds, posFilter, minOvr, nameFilter, advancedFilters });
-  }, [faPool, signedIds, posFilter, nameFilter, minOvr, advancedFilters]);
+    const base = filterFreeAgentsForView(faPool, { signedIds, posFilter, minOvr, nameFilter, advancedFilters });
+    return base.filter((player) => {
+      if ((player.age ?? 99) > maxAge) return false;
+      if ((player.schemeFit ?? 0) < minSchemeFit) return false;
+      if (demandTier !== "ALL" && formatDemandTier(player) !== demandTier) return false;
+      if (watchOnly && !watchlistIds.has(player.id)) return false;
+      return true;
+    });
+  }, [faPool, signedIds, posFilter, nameFilter, minOvr, advancedFilters, maxAge, minSchemeFit, demandTier, watchOnly, watchlistIds]);
 
   const sortedAgents = useMemo(() => {
     const arr = [...displayed];
+    if (sortPreset === "best_available") {
+      arr.sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0));
+      return arr;
+    }
+    if (sortPreset === "cheapest_value") {
+      arr.sort((a, b) => ((b.ovr ?? 0) / Math.max(0.2, b._ask ?? 1)) - ((a.ovr ?? 0) / Math.max(0.2, a._ask ?? 1)));
+      return arr;
+    }
+    if (sortPreset === "youngest") {
+      arr.sort((a, b) => (a.age ?? 99) - (b.age ?? 99));
+      return arr;
+    }
+    if (sortPreset === "position_need") {
+      const needs = new Set((needsSummary?.needs ?? []).slice(0, 4));
+      arr.sort((a, b) => Number(needs.has(b.pos)) - Number(needs.has(a.pos)) || (b.ovr ?? 0) - (a.ovr ?? 0));
+      return arr;
+    }
     arr.sort((a, b) => {
       let va = a[sortKey];
       let vb = b[sortKey];
@@ -704,7 +735,7 @@ export default function FreeAgency({
       return va < vb ? 1 : -1;
     });
     return arr;
-  }, [displayed, sortKey, sortDir]);
+  }, [displayed, sortKey, sortDir, sortPreset, needsSummary?.needs]);
 
 
   const {
@@ -1003,6 +1034,28 @@ export default function FreeAgency({
                 }}
               />
             </div>
+            <label style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>Max Age
+              <Input type="number" min="21" max="45" value={maxAge} onChange={(e) => setMaxAge(Number(e.target.value) || 40)} style={{ width: 62, marginLeft: 6 }} />
+            </label>
+            <label style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>Min Fit
+              <Input type="number" min="0" max="100" value={minSchemeFit} onChange={(e) => setMinSchemeFit(Number(e.target.value) || 0)} style={{ width: 62, marginLeft: 6 }} />
+            </label>
+            <select value={demandTier} onChange={(e) => setDemandTier(e.target.value)} style={{ height: 30, borderRadius: 8, background: "var(--surface-strong)", border: "1px solid var(--hairline)", color: "var(--text)", fontSize: 12 }}>
+              <option value="ALL">Demand: All</option>
+              <option value="value">Demand: Value</option>
+              <option value="starter">Demand: Starter</option>
+              <option value="premium">Demand: Premium</option>
+            </select>
+            <select value={sortPreset} onChange={(e) => setSortPreset(e.target.value)} style={{ height: 30, borderRadius: 8, background: "var(--surface-strong)", border: "1px solid var(--hairline)", color: "var(--text)", fontSize: 12 }}>
+              <option value="best_available">Sort: Best available</option>
+              <option value="cheapest_value">Sort: Cheapest value</option>
+              <option value="youngest">Sort: Youngest</option>
+              <option value="position_need">Sort: Position need</option>
+              <option value="manual">Sort: Manual columns</option>
+            </select>
+            <Button className="btn" onClick={() => setWatchOnly((prev) => !prev)} style={{ whiteSpace: "nowrap" }}>
+              {watchOnly ? "Showing watchlist" : `Watchlist (${watchlistIds.size})`}
+            </Button>
             {isResignPhase ? (
               <Button className="btn btn-primary" onClick={handleQuickFilterPriorities} style={{ whiteSpace: "nowrap" }}>
                 Quick Filter: Re-sign Priorities
@@ -1141,6 +1194,9 @@ export default function FreeAgency({
                     <TableHead style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 600, textAlign: "center" }}>
                       CMP
                     </TableHead>
+                    <TableHead style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 600, textAlign: "center" }}>
+                      WL
+                    </TableHead>
                     <TableHead
                       style={{
                         fontSize: "var(--text-xs)",
@@ -1175,7 +1231,7 @@ export default function FreeAgency({
                   {sortedAgents.length === 0 && (
                     <TableRow>
                       <TableCell
-                        colSpan={10}
+                        colSpan={11}
                         style={{
                           textAlign: "center",
                           padding: "var(--space-8)",
@@ -1289,6 +1345,7 @@ export default function FreeAgency({
                             <TableCell><OvrBadge ovr={player.ovr} />{player.scoutUncertaintyBand ? <div style={{fontSize:11,color:'var(--text-muted)'}}>{player.scoutConfidenceLabel} · ±{player.scoutUncertaintyBand}</div> : null}</TableCell>
                             <TableCell style={{ color: "var(--text-muted)" }}>{player.age}</TableCell>
                             <TableCell style={{ textAlign: "center" }}><Button title={compareIds.includes(player.id) ? "Remove from compare" : "Add to compare"} onClick={() => toggleCompare(player)} style={{ width: 22, height: 22, borderRadius: "var(--radius-sm)", border: `1.5px solid ${compareIds.includes(player.id) ? "var(--accent)" : "var(--hairline)"}`, background: compareIds.includes(player.id) ? "var(--accent-muted)" : "transparent", fontSize: 12, color: compareIds.includes(player.id) ? "var(--accent)" : "var(--text-subtle)" }}>{compareIds.includes(player.id) ? "✓" : "⊕"}</Button></TableCell>
+                            <TableCell style={{ textAlign: "center" }}><Button title={watchlistIds.has(player.id) ? "Remove from watchlist" : "Add to watchlist"} onClick={() => setWatchlistIds((prev) => { const next = new Set(prev); if (next.has(player.id)) next.delete(player.id); else next.add(player.id); return next; })} style={{ width: 22, height: 22, borderRadius: "var(--radius-sm)", border: `1.5px solid ${watchlistIds.has(player.id) ? "var(--warning)" : "var(--hairline)"}`, background: watchlistIds.has(player.id) ? "rgba(255,159,10,0.16)" : "transparent", fontSize: 12, color: watchlistIds.has(player.id) ? "var(--warning)" : "var(--text-subtle)" }}>{watchlistIds.has(player.id) ? "★" : "☆"}</Button></TableCell>
                             <TableCell style={{ textAlign: "center" }}>
                               <PipBar value={player.schemeFit ?? 50} color="var(--accent)" />
                             </TableCell>
@@ -1328,6 +1385,7 @@ export default function FreeAgency({
                         <TableCell><OvrBadge ovr={player.ovr} /></TableCell>
                         <TableCell style={{ color: "var(--text-muted)" }}>{player.age}</TableCell>
                         <TableCell style={{ textAlign: "center" }}><Button title={compareIds.includes(player.id) ? "Remove from compare" : "Add to compare"} onClick={() => toggleCompare(player)} style={{ width: 22, height: 22, borderRadius: "var(--radius-sm)", border: `1.5px solid ${compareIds.includes(player.id) ? "var(--accent)" : "var(--hairline)"}`, background: compareIds.includes(player.id) ? "var(--accent-muted)" : "transparent", fontSize: 12, color: compareIds.includes(player.id) ? "var(--accent)" : "var(--text-subtle)" }}>{compareIds.includes(player.id) ? "✓" : "⊕"}</Button></TableCell>
+                        <TableCell style={{ textAlign: "center" }}><Button title={watchlistIds.has(player.id) ? "Remove from watchlist" : "Add to watchlist"} onClick={() => setWatchlistIds((prev) => { const next = new Set(prev); if (next.has(player.id)) next.delete(player.id); else next.add(player.id); return next; })} style={{ width: 22, height: 22, borderRadius: "var(--radius-sm)", border: `1.5px solid ${watchlistIds.has(player.id) ? "var(--warning)" : "var(--hairline)"}`, background: watchlistIds.has(player.id) ? "rgba(255,159,10,0.16)" : "transparent", fontSize: 12, color: watchlistIds.has(player.id) ? "var(--warning)" : "var(--text-subtle)" }}>{watchlistIds.has(player.id) ? "★" : "☆"}</Button></TableCell>
                         <TableCell style={{ textAlign: "center" }}>
                           <PipBar value={player.schemeFit ?? 50} color="var(--accent)" />
                         </TableCell>

--- a/src/ui/components/OffseasonHub.jsx
+++ b/src/ui/components/OffseasonHub.jsx
@@ -17,6 +17,7 @@ import {
   toFiniteNumber,
 } from "../utils/numberFormatting.js";
 import { deriveFranchisePressure } from "../utils/pressureModel.js";
+import { buildOffseasonActionCenter } from "../utils/offseasonActionCenter.js";
 
 const PHASES = [
   {
@@ -309,6 +310,7 @@ function OffseasonStatsCard({ league, onNavigate }) {
 
 export default function OffseasonHub({ league, onNavigate }) {
   const currentPhase = league?.phase ?? "regular";
+  const actionCenter = useMemo(() => buildOffseasonActionCenter(league), [league]);
 
   const phaseOrder = PHASES.map(p => p.id);
   const currentIdx = phaseOrder.indexOf(currentPhase);
@@ -343,6 +345,41 @@ export default function OffseasonHub({ league, onNavigate }) {
       </div>
 
       <OffseasonStatsCard league={league} onNavigate={onNavigate} />
+
+      <div className="rounded-xl border border-white/10 bg-slate-950/65 p-3.5 shadow-xl">
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 8, flexWrap: "wrap", marginBottom: 8 }}>
+          <div>
+            <div style={{ fontSize: "0.62rem", textTransform: "uppercase", letterSpacing: "1px", color: "var(--text-muted)", fontWeight: 800 }}>Offseason Action Center</div>
+            <div style={{ fontSize: "0.9rem", fontWeight: 800 }}>{actionCenter.phaseLabel} · Next: {actionCenter.nextPhaseLabel}</div>
+          </div>
+          <div style={{ fontSize: "0.72rem", color: actionCenter.canSkipPhase ? "var(--success)" : "var(--warning)", fontWeight: 700 }}>
+            {actionCenter.canSkipPhase ? "No blockers — phase can be skipped." : "Blocking tasks remain."}
+          </div>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit,minmax(140px,1fr))", gap: 8, marginBottom: 10 }}>
+          <div className="rounded-lg border border-white/10 bg-white/5 p-2"><div style={{ fontSize: 10, color: "var(--text-muted)" }}>Cap Room</div><div style={{ fontWeight: 800 }}>${actionCenter.metrics.capRoom.toFixed(1)}M</div></div>
+          <div className="rounded-lg border border-white/10 bg-white/5 p-2"><div style={{ fontSize: 10, color: "var(--text-muted)" }}>Roster</div><div style={{ fontWeight: 800 }}>{actionCenter.metrics.rosterCount} players</div></div>
+          <div className="rounded-lg border border-white/10 bg-white/5 p-2"><div style={{ fontSize: 10, color: "var(--text-muted)" }}>Expiring</div><div style={{ fontWeight: 800 }}>{actionCenter.metrics.expiringContracts} ({actionCenter.unresolved?.keyExpiringContracts ?? 0} key)</div></div>
+          <div className="rounded-lg border border-white/10 bg-white/5 p-2"><div style={{ fontSize: 10, color: "var(--text-muted)" }}>Owned Picks</div><div style={{ fontWeight: 800 }}>{actionCenter.metrics.draftPickCount}</div></div>
+        </div>
+        {!!actionCenter.blockers?.length && (
+          <div style={{ marginBottom: 8 }}>
+            <div style={{ fontSize: "0.66rem", textTransform: "uppercase", color: "var(--warning)", fontWeight: 800 }}>Blockers</div>
+            {actionCenter.blockers.map((item) => <div key={item} style={{ fontSize: "0.75rem" }}>• {item}</div>)}
+          </div>
+        )}
+        {!!actionCenter.priorities?.length && (
+          <div style={{ marginBottom: 10 }}>
+            <div style={{ fontSize: "0.66rem", textTransform: "uppercase", color: "var(--accent)", fontWeight: 800 }}>Unresolved Priorities</div>
+            {actionCenter.priorities.map((item) => <div key={item} style={{ fontSize: "0.75rem", color: "var(--text-muted)" }}>• {item}</div>)}
+          </div>
+        )}
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+          {(actionCenter.actions ?? []).map((action) => (
+            <button key={action.label} className="btn btn-sm" onClick={() => onNavigate?.(action.tab)}>{action.label}</button>
+          ))}
+        </div>
+      </div>
 
       {/* Phase timeline */}
       <div className="rounded-xl border border-white/10 bg-slate-900/60 p-3 backdrop-blur-md">

--- a/src/ui/components/coreManagementScreens.test.jsx
+++ b/src/ui/components/coreManagementScreens.test.jsx
@@ -4,6 +4,7 @@ import { renderToString } from "react-dom/server";
 import TradeWorkspace from "./TradeWorkspace.jsx";
 import Roster from "./Roster.jsx";
 import PlayerStats from "./PlayerStats.jsx";
+import OffseasonHub from "./OffseasonHub.jsx";
 
 const baseLeague = {
   week: 1,
@@ -37,5 +38,27 @@ describe("core management screens", () => {
   it("renders stats with empty data and deep-linked family", () => {
     const html = renderToString(<PlayerStats actions={{}} initialFamily="defense" />);
     expect(html).toContain("Player Stats");
+  });
+
+  it("renders offseason action center with blockers and guided actions", () => {
+    const offseasonLeague = {
+      ...baseLeague,
+      phase: "offseason_resign",
+      teams: [
+        {
+          ...baseLeague.teams[0],
+          capRoom: 6,
+          roster: [
+            { id: 1, pos: "QB", ovr: 86, contract: { years: 1 }, extensionDecision: "pending" },
+            { id: 2, pos: "WR", ovr: 72, contract: { years: 1 }, extensionDecision: "pending" },
+          ],
+          picks: [{ id: "1-1" }, { id: "2-1" }],
+        },
+      ],
+    };
+    const html = renderToString(<OffseasonHub league={offseasonLeague} onNavigate={() => {}} />);
+    expect(html).toContain("Offseason Action Center");
+    expect(html).toContain("Blocking tasks remain");
+    expect(html).toContain("Open Re-sign table");
   });
 });

--- a/src/ui/utils/offseasonActionCenter.js
+++ b/src/ui/utils/offseasonActionCenter.js
@@ -1,0 +1,156 @@
+const PHASE_SEQUENCE = ['offseason_resign', 'free_agency', 'trades', 'draft', 'post_draft', 'preseason'];
+
+const PHASE_LABELS = {
+  offseason_resign: 'Re-signing',
+  free_agency: 'Free Agency',
+  trades: 'Trades',
+  draft: 'Draft',
+  post_draft: 'Post-Draft',
+  preseason: 'Preseason',
+};
+
+const PHASE_ACTIONS = {
+  offseason_resign: [
+    { label: 'Open Re-sign table', tab: 'Free Agency' },
+    { label: 'Review cap outlook', tab: 'Financials' },
+  ],
+  free_agency: [
+    { label: 'Open market board', tab: 'Free Agency' },
+    { label: 'Open FA Hub', tab: 'FA Hub' },
+  ],
+  trades: [
+    { label: 'Open Trade Workspace', tab: 'Trades' },
+    { label: 'Review roster surplus', tab: 'Roster' },
+  ],
+  draft: [
+    { label: 'Open Draft Room', tab: 'Draft Room' },
+    { label: 'Open Mock Draft', tab: 'Mock Draft' },
+  ],
+  post_draft: [
+    { label: 'Review Draft Class', tab: '🎓 Draft' },
+    { label: 'Open Roster', tab: 'Roster' },
+    { label: 'Open Depth Chart', tab: 'Roster:depth|ALL' },
+  ],
+  preseason: [
+    { label: 'Run final cuts', tab: 'Roster' },
+    { label: 'Set depth chart', tab: 'Roster:depth|ALL' },
+  ],
+};
+
+function toNumber(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function summarizePerformanceNeeds(userTeam) {
+  const summary = [];
+  const offense = toNumber(userTeam?.seasonTeamStats?.offenseYardsPerPlay ?? userTeam?.offenseYardsPerPlay, 0);
+  const defense = toNumber(userTeam?.seasonTeamStats?.defenseYardsPerPlayAllowed ?? userTeam?.defenseYardsPerPlayAllowed, 0);
+  const rushRate = toNumber(userTeam?.seasonTeamStats?.rushRate, 0);
+  const passSuccess = toNumber(userTeam?.seasonTeamStats?.passSuccessRate, 0);
+
+  if (offense > 0 && offense < 5.2) summary.push('Offense lacked efficient drive production');
+  if (defense > 6.0) summary.push('Defense allowed explosive drives');
+  if (rushRate > 0 && rushRate < 0.38) summary.push('Rushing identity was too one-dimensional');
+  if (passSuccess > 0 && passSuccess < 0.45) summary.push('Passing game efficiency lagged league pace');
+
+  const digest = Array.isArray(userTeam?.seasonEventDigest) ? userTeam.seasonEventDigest : [];
+  if (digest.length) {
+    const weakness = digest.find((item) => String(item?.tone ?? '').toLowerCase() === 'warning' || /allowed|struggled|weak/i.test(String(item?.summary ?? '')));
+    if (weakness?.summary) summary.push(String(weakness.summary));
+  }
+
+  return summary.slice(0, 3);
+}
+
+function deriveExpiringPriority(expiring = []) {
+  const key = expiring
+    .filter((p) => toNumber(p?.ovr, 0) >= 74 || ['QB', 'LT', 'EDGE', 'CB'].includes(String(p?.pos ?? '').toUpperCase()))
+    .filter((p) => !p?.extensionDecision || p.extensionDecision === 'pending');
+  return {
+    total: expiring.length,
+    unresolved: expiring.filter((p) => !p?.extensionDecision || p.extensionDecision === 'pending').length,
+    keyUnresolved: key.length,
+  };
+}
+
+function deriveDraftPickCount(userTeam) {
+  const picks = userTeam?.picksOwned ?? userTeam?.draftPicks ?? userTeam?.picks ?? [];
+  return Array.isArray(picks) ? picks.length : toNumber(userTeam?.numDraftPicks, 0);
+}
+
+export function buildOffseasonActionCenter(league) {
+  const phase = String(league?.phase ?? 'regular');
+  const userTeam = (league?.teams ?? []).find((team) => Number(team?.id) === Number(league?.userTeamId));
+  if (!userTeam) {
+    return {
+      phase,
+      phaseLabel: PHASE_LABELS[phase] ?? phase,
+      isOffseasonLoop: false,
+      blockers: ['User team context is still loading.'],
+      priorities: [],
+      actions: [],
+      metrics: { capRoom: 0, rosterCount: 0, draftPickCount: 0, expiringContracts: 0 },
+    };
+  }
+
+  const capRoom = toNumber(userTeam?.capRoom, toNumber(userTeam?.capTotal, 255) - toNumber(userTeam?.capUsed, 0) - toNumber(userTeam?.deadCap, 0));
+  const rosterCount = Array.isArray(userTeam?.roster) ? userTeam.roster.length : toNumber(userTeam?.rosterCount, 0);
+  const expiring = Array.isArray(userTeam?.roster)
+    ? userTeam.roster.filter((p) => toNumber(p?.contract?.years, 0) <= 1)
+    : [];
+  const expiringPriority = deriveExpiringPriority(expiring);
+  const draftPickCount = deriveDraftPickCount(userTeam);
+  const phaseIndex = PHASE_SEQUENCE.indexOf(phase);
+
+  const priorities = [];
+  const blockers = [];
+
+  if (phase === 'offseason_resign' && expiringPriority.keyUnresolved > 0) {
+    blockers.push(`${expiringPriority.keyUnresolved} key expiring contracts still unresolved.`);
+    priorities.push('Resolve core re-sign decisions before market opens.');
+  }
+  if (phase === 'free_agency' && capRoom <= 0) {
+    blockers.push('No cap room remaining for competitive offers.');
+  }
+  if (phase === 'draft' && !Array.isArray(league?.draftClass)) {
+    blockers.push('Draft board is not hydrated yet.');
+  }
+  if (phase === 'preseason' && rosterCount > 53) {
+    blockers.push(`Roster cutdown required (${rosterCount}/53).`);
+  }
+
+  if (capRoom < 8) priorities.push('Cap flexibility is thin; focus on value signings or restructures.');
+  if (draftPickCount < 5) priorities.push('Limited draft capital; prioritize trade-back opportunities.');
+
+  const productionNeeds = summarizePerformanceNeeds(userTeam);
+  for (const need of productionNeeds) priorities.push(need);
+
+  return {
+    phase,
+    phaseLabel: PHASE_LABELS[phase] ?? phase,
+    isOffseasonLoop: phaseIndex >= 0,
+    blockers,
+    priorities: priorities.slice(0, 6),
+    unresolved: {
+      expiringContracts: expiringPriority.unresolved,
+      keyExpiringContracts: expiringPriority.keyUnresolved,
+    },
+    metrics: {
+      capRoom,
+      rosterCount,
+      draftPickCount,
+      expiringContracts: expiringPriority.total,
+    },
+    actions: PHASE_ACTIONS[phase] ?? [],
+    canSkipPhase: blockers.length === 0,
+    nextPhaseLabel: PHASE_LABELS[PHASE_SEQUENCE[phaseIndex + 1]] ?? 'Regular Season',
+  };
+}
+
+export function formatDemandTier(player) {
+  const ask = toNumber(player?.demandProfile?.askAnnual ?? player?.askingPrice, 0);
+  if (ask >= 18) return 'premium';
+  if (ask >= 8) return 'starter';
+  return 'value';
+}

--- a/src/ui/utils/offseasonActionCenter.test.js
+++ b/src/ui/utils/offseasonActionCenter.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { buildOffseasonActionCenter } from './offseasonActionCenter.js';
+
+function makePlayer(id, { pos = 'WR', ovr = 70, years = 1, decision = 'pending' } = {}) {
+  return { id, pos, ovr, contract: { years }, extensionDecision: decision };
+}
+
+describe('buildOffseasonActionCenter', () => {
+  it('guides the full season-end to preseason management loop with updated cap and roster context', () => {
+    const team = {
+      id: 1,
+      abbr: 'USR',
+      capTotal: 255,
+      capUsed: 236,
+      deadCap: 2,
+      capRoom: 17,
+      picks: [{ id: '1-1' }, { id: '2-1' }, { id: '3-1' }, { id: '4-1' }, { id: '5-1' }, { id: '6-1' }, { id: '7-1' }],
+      roster: [
+        makePlayer(1, { pos: 'QB', ovr: 86, years: 1, decision: 'pending' }),
+        makePlayer(2, { pos: 'WR', ovr: 79, years: 1, decision: 'pending' }),
+        makePlayer(3, { pos: 'LB', ovr: 74, years: 2, decision: 'none' }),
+      ],
+      seasonTeamStats: {
+        offenseYardsPerPlay: 4.9,
+        defenseYardsPerPlayAllowed: 6.2,
+        passSuccessRate: 0.42,
+      },
+      seasonEventDigest: [{ tone: 'warning', summary: 'Allowed explosive passes in late downs.' }],
+    };
+
+    const league = { year: 2028, phase: 'offseason_resign', userTeamId: 1, teams: [team], draftClass: null };
+
+    const resignCenter = buildOffseasonActionCenter(league);
+    expect(resignCenter.blockers.join(' ')).toContain('key expiring contracts');
+    expect(resignCenter.metrics.expiringContracts).toBe(2);
+
+    team.roster[0].extensionDecision = 'extended';
+    team.capRoom = 10;
+    league.phase = 'free_agency';
+    const faCenter = buildOffseasonActionCenter(league);
+    expect(faCenter.metrics.capRoom).toBe(10);
+    expect(faCenter.actions.map((a) => a.tab)).toContain('Free Agency');
+
+    team.capRoom = 4;
+    team.roster.push(makePlayer(4, { pos: 'CB', ovr: 77, years: 3, decision: 'none' }));
+    league.phase = 'trades';
+    const tradeCenter = buildOffseasonActionCenter(league);
+    expect(tradeCenter.phaseLabel).toBe('Trades');
+    expect(tradeCenter.metrics.rosterCount).toBe(4);
+
+    league.phase = 'draft';
+    league.draftClass = [{ id: 90, name: 'Prospect One', pos: 'OT' }];
+    const draftCenter = buildOffseasonActionCenter(league);
+    expect(draftCenter.blockers).toEqual([]);
+
+    team.roster.push(makePlayer(5, { pos: 'OT', ovr: 72, years: 4, decision: 'none' }));
+    league.phase = 'post_draft';
+    const postDraft = buildOffseasonActionCenter(league);
+    expect(postDraft.actions.map((a) => a.tab)).toContain('Roster:depth|ALL');
+
+    league.phase = 'preseason';
+    team.roster = Array.from({ length: 56 }, (_, idx) => makePlayer(100 + idx));
+    const preseason = buildOffseasonActionCenter(league);
+    expect(preseason.blockers.join(' ')).toContain('Roster cutdown required');
+    expect(preseason.metrics.rosterCount).toBe(56);
+  });
+});


### PR DESCRIPTION
### Motivation
- Offseason progression was fragmented and relied on hunting through tabs, so add a single guided surface that tells the user what to do next and what is blocking advancement. 
- Re-signing and free agency flows needed deeper management controls (filters, watchlist, sort presets) so decisions feel strategic rather than shallow. 
- The full season-end → preseason loop requires end-to-end integration coverage to ensure phase transitions, cap, and roster counts update correctly.

### Description
- Added `src/ui/utils/offseasonActionCenter.js` which exposes `buildOffseasonActionCenter(league)` and `formatDemandTier(player)` to summarize phase, blockers, unresolved priorities, metrics (cap/roster/picks/expiring), production-based needs, phase actions, and next-phase guidance. 
- Wired the action model into the UI by adding an "Offseason Action Center" panel to `src/ui/components/OffseasonHub.jsx` that surfaces current phase, next phase, can-skip status, metrics, blockers, priorities, and phase-aware quick actions. 
- Enhanced Free Agency management in `src/ui/components/FreeAgency.jsx` with front-office filters and controls: `maxAge`, `minSchemeFit`, `demandTier` filter, watchlist toggle + per-player star, and `sortPreset` options (`best_available`, `cheapest_value`, `youngest`, `position_need`) plus small table/layout adjustments. 
- Added integration-oriented tests `src/ui/utils/offseasonActionCenter.test.js` and extended `src/ui/components/coreManagementScreens.test.jsx` to validate the loop behavior across phases and that the new guidance UI renders expected blockers/actions.

### Testing
- Ran unit tests for the new and impacted suites: `npm run test:unit -- src/ui/utils/offseasonActionCenter.test.js src/ui/components/coreManagementScreens.test.jsx` and both passed. 
- Also ran `npm run test:unit -- src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx` to ensure Free Agency changes did not regress existing behavior and that test passed. 
- All automated tests executed in this change succeeded (Vitest v3.2.4).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e12be49cec832d97e293908982b77b)