### PR TITLE
Add Re-signing Center and wire Offseason Action Center to real flows

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -51,6 +51,7 @@ import ThemeToggle         from './components/ThemeToggle.jsx';
 import { SettingsProvider, useSettings } from './context/SettingsContext.jsx';
 import { ACTION_LABELS } from './constants/navigationCopy.js';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from './utils/boxScoreAccess.js';
+import { buildOffseasonActionCenter } from './utils/offseasonActionCenter.js';
 import { hasMinimumPlayableLeague, summarizeBootstrapState } from './utils/leagueBootstrap.js';
 import { buildCanonicalGameId } from '../core/gameIdentity.js';
 import { getRecentGames, saveGame } from '../core/archive/gameArchive.ts';
@@ -278,6 +279,14 @@ function AppContent() {
       advancingRef.current = true;
       actions.advanceWeek();
     } else if (['offseason_resign', 'offseason'].includes(league.phase)) {
+      if (league.phase === 'offseason_resign') {
+        const actionCenter = buildOffseasonActionCenter(league);
+        const unresolvedKey = Number(actionCenter?.unresolved?.keyExpiringContracts ?? 0);
+        if (unresolvedKey > 0) {
+          const proceed = window.confirm(`You still have ${unresolvedKey} unresolved key re-signing decisions. Advance anyway?`);
+          if (!proceed) return;
+        }
+      }
       advancingRef.current = true;
       actions.advanceOffseason();
     } else if (league.phase === 'free_agency') {

--- a/src/ui/components/ContractCenter.jsx
+++ b/src/ui/components/ContractCenter.jsx
@@ -10,11 +10,27 @@ import {
 import { summarizeNegotiationStance } from '../../core/contracts/negotiation.js';
 import { derivePlayerContractFinancials } from '../utils/contractFormatting.js';
 import { deriveTeamCapSnapshot } from '../utils/numberFormatting.js';
+import { evaluateResignRecommendation } from '../utils/contractInsights.js';
+
+const PREMIUM_POSITIONS = new Set(['QB', 'LT', 'EDGE', 'CB']);
+const SORT_PRESETS = [
+  { id: 'priority', label: 'Highest priority' },
+  { id: 'young_core', label: 'Youngest core piece' },
+  { id: 'cheap_keep', label: 'Cheapest to keep' },
+  { id: 'expensive', label: 'Most expensive' },
+  { id: 'replaceability', label: 'Hardest to replace' },
+  { id: 'premium_pos', label: 'Premium position first' },
+];
 
 function money(v) {
   const n = Number(v);
   if (!Number.isFinite(n)) return '—';
   return `$${n.toFixed(1)}M`;
+}
+
+function toNumber(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
 }
 
 function toneForRecommendation(key) {
@@ -36,6 +52,51 @@ function groupRows(board = []) {
     'Extension candidates': board.filter((r) => ['extension_candidate', 'strong_keep', 'cornerstone_priority'].includes(r.section) || ['cornerstone_priority', 'strong_keep'].includes(r.priority.recommendation)),
     'Move on / restructure': board.filter((r) => ['let_walk_candidate', 'depth_low_urgency'].includes(r.section) || ['let_walk', 'move_on'].includes(r.priority.recommendation)),
   };
+}
+
+function estimateDemand(player) {
+  const baseAnnual = toNumber(
+    player?.extensionAsk?.baseAnnual,
+    Math.max(
+      toNumber(player?.contract?.baseAnnual, 2) * 1.15,
+      (toNumber(player?.ovr, 68) - 58) * 0.38 + (PREMIUM_POSITIONS.has(String(player?.pos ?? '').toUpperCase()) ? 3 : 0),
+    ),
+  );
+  const yearsTotal = toNumber(player?.extensionAsk?.yearsTotal ?? player?.extensionAsk?.years, player?.age <= 27 ? 4 : 3);
+  const signingBonus = toNumber(player?.extensionAsk?.signingBonus, Math.max(1, baseAnnual * 0.35));
+  return {
+    baseAnnual: Math.max(1, Math.round(baseAnnual * 10) / 10),
+    yearsTotal: Math.max(1, Math.round(yearsTotal)),
+    signingBonus: Math.round(signingBonus * 10) / 10,
+    guaranteedPct: Math.min(0.95, Math.max(0.45, toNumber(player?.extensionAsk?.guaranteedPct, 0.55))),
+  };
+}
+
+function decisionLabel(decision) {
+  if (decision === 'extended') return 'Extended';
+  if (decision === 'let_walk') return 'Let Walk';
+  if (decision === 'deferred') return 'Decide Later';
+  if (decision === 'tagged') return 'Tagged';
+  return 'Pending';
+}
+
+function isKeyPlayer(player) {
+  const pos = String(player?.pos ?? '').toUpperCase();
+  return PREMIUM_POSITIONS.has(pos) || toNumber(player?.ovr, 0) >= 82;
+}
+
+function replacementHint(player, roster) {
+  const pos = String(player?.pos ?? '').toUpperCase();
+  const samePos = (roster ?? []).filter((p) => String(p?.pos ?? '').toUpperCase() === pos).length;
+  if (isKeyPlayer(player) && samePos <= 2) return 'Hard to replace';
+  if (samePos <= 3) return 'Thin depth';
+  return 'Replaceable';
+}
+
+function starterHint(player) {
+  if (player?.depthOrder === 1) return 'Starter';
+  if (player?.depthOrder === 2) return 'Rotation';
+  return 'Depth';
 }
 
 function PlayerRow({ row, onOpenTalks, onTag }) {
@@ -79,6 +140,208 @@ function PlayerRow({ row, onOpenTalks, onTag }) {
   );
 }
 
+function ReSigningCenter({ league, team, actions, onNavigate, setStatusMessage }) {
+  const [sortPreset, setSortPreset] = useState('priority');
+  const [previewPlayerId, setPreviewPlayerId] = useState(null);
+  const [busyPlayerId, setBusyPlayerId] = useState(null);
+
+  const capSnapshot = useMemo(() => deriveTeamCapSnapshot(team ?? {}, { fallbackCapTotal: 255 }), [team]);
+  const roster = Array.isArray(team?.roster) ? team.roster : [];
+  const expiringPlayers = useMemo(() => roster.filter((p) => toNumber(p?.contract?.years, 0) <= 1), [roster]);
+
+  const rows = useMemo(() => {
+    return expiringPlayers.map((player) => {
+      const demand = estimateDemand(player);
+      const currentCapHit = toNumber(player?.contract?.baseAnnual, 0) + (toNumber(player?.contract?.signingBonus, 0) / Math.max(1, toNumber(player?.contract?.yearsTotal, toNumber(player?.contract?.years, 1))));
+      const projectedCapHit = demand.baseAnnual + (demand.signingBonus / Math.max(1, demand.yearsTotal));
+      const rec = evaluateResignRecommendation(player, { team, roster });
+      const decision = String(player?.extensionDecision ?? 'pending');
+      const premium = PREMIUM_POSITIONS.has(String(player?.pos ?? '').toUpperCase());
+      const unresolved = !['extended', 'let_walk', 'tagged'].includes(decision);
+      return {
+        player,
+        demand,
+        decision,
+        decisionLabel: decisionLabel(decision),
+        currentCapHit,
+        projectedCapHit,
+        rec,
+        premium,
+        unresolved,
+        starter: starterHint(player),
+        replaceability: replacementHint(player, roster),
+        sortPriorityScore: (isKeyPlayer(player) ? 150 : 0) + (rec.tier === 'priority_resign' ? 80 : rec.tier === 'resign_if_price' ? 40 : 0) + (unresolved ? 20 : -15) + toNumber(player?.ovr, 60),
+      };
+    });
+  }, [expiringPlayers, roster, team]);
+
+  const sortedRows = useMemo(() => {
+    const clone = [...rows];
+    const byReplaceability = (row) => row.replaceability === 'Hard to replace' ? 3 : row.replaceability === 'Thin depth' ? 2 : 1;
+    clone.sort((a, b) => {
+      if (sortPreset === 'young_core') return (a.player.age - b.player.age) || (b.player.ovr - a.player.ovr);
+      if (sortPreset === 'cheap_keep') return (a.demand.baseAnnual - b.demand.baseAnnual) || (b.player.ovr - a.player.ovr);
+      if (sortPreset === 'expensive') return (b.demand.baseAnnual - a.demand.baseAnnual) || (b.player.ovr - a.player.ovr);
+      if (sortPreset === 'replaceability') return (byReplaceability(b) - byReplaceability(a)) || (b.player.ovr - a.player.ovr);
+      if (sortPreset === 'premium_pos') return (Number(b.premium) - Number(a.premium)) || (b.player.ovr - a.player.ovr);
+      return (b.sortPriorityScore - a.sortPriorityScore);
+    });
+    return clone;
+  }, [rows, sortPreset]);
+
+  const unresolvedKey = rows.filter((row) => row.unresolved && isKeyPlayer(row.player)).length;
+  const premiumAtRisk = rows.filter((row) => row.premium && row.decision !== 'extended' && row.decision !== 'tagged').length;
+  const projectedCapRoom = capSnapshot.capRoom - rows
+    .filter((row) => row.decision === 'deferred')
+    .reduce((sum, row) => sum + Math.max(0, row.projectedCapHit - row.currentCapHit), 0);
+  const recommendedNextMove = sortedRows.find((row) => row.unresolved)
+    ? `Decide ${sortedRows.find((row) => row.unresolved)?.player?.name} (${sortedRows.find((row) => row.unresolved)?.player?.pos})`
+    : 'All expiring decisions are resolved.';
+
+  const previewRow = sortedRows.find((row) => Number(row.player.id) === Number(previewPlayerId)) ?? null;
+
+  const applyDecision = async (row, decision) => {
+    if (!actions?.updatePlayerManagement || !team?.id) return;
+    setBusyPlayerId(row.player.id);
+    try {
+      await actions.updatePlayerManagement(row.player.id, team.id, { extensionDecision: decision });
+      setStatusMessage(`${row.player.name}: ${decisionLabel(decision)}.`);
+    } catch (err) {
+      setStatusMessage(err?.message ?? 'Unable to update contract decision.');
+    } finally {
+      setBusyPlayerId(null);
+    }
+  };
+
+  const confirmExtension = async () => {
+    if (!previewRow || !actions?.extendContract || !team?.id) return;
+    setBusyPlayerId(previewRow.player.id);
+    try {
+      const response = await actions.extendContract(previewRow.player.id, team.id, {
+        years: previewRow.demand.yearsTotal,
+        yearsTotal: previewRow.demand.yearsTotal,
+        baseAnnual: previewRow.demand.baseAnnual,
+        signingBonus: previewRow.demand.signingBonus,
+        guaranteedPct: previewRow.demand.guaranteedPct,
+      });
+      const status = response?.payload?.status;
+      if (status === 'accepted') {
+        await actions.updatePlayerManagement(previewRow.player.id, team.id, { extensionDecision: 'extended' });
+        setStatusMessage(`${previewRow.player.name} extension accepted.`);
+      } else if (status === 'counter') {
+        setStatusMessage(`${previewRow.player.name} countered. Ask increased to ${money(response?.payload?.counter?.baseAnnual)}.`);
+      } else {
+        setStatusMessage(response?.payload?.reason || `${previewRow.player.name} declined extension.`);
+      }
+    } catch (err) {
+      setStatusMessage(err?.message ?? 'Extension attempt failed.');
+    } finally {
+      setBusyPlayerId(null);
+    }
+  };
+
+  return (
+    <div className="app-screen-stack" style={{ display: 'grid', gap: 'var(--space-3)' }}>
+      <TeamWorkspaceHeader
+        title="Re-signing Center"
+        subtitle="Lock in core players with clear cap and roster impact before free agency opens."
+        eyebrow={team?.name ?? 'Contract Center'}
+        metadata={[
+          { label: 'Total expirings', value: rows.length },
+          { label: 'Key unresolved', value: unresolvedKey },
+          { label: 'Cap room', value: money(capSnapshot.capRoom) },
+        ]}
+        actions={[
+          { label: 'Financials', onClick: () => onNavigate?.('Financials') },
+          { label: 'Roster', onClick: () => onNavigate?.('Roster:EXPIRING') },
+          { label: 'Free Agency', onClick: () => onNavigate?.('Free Agency') },
+        ]}
+      />
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 8 }}>
+        <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Total expirings</div><div style={{ fontWeight: 800 }}>{rows.length}</div></div>
+        <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Unresolved key expirings</div><div style={{ fontWeight: 800, color: unresolvedKey ? 'var(--warning)' : 'var(--success)' }}>{unresolvedKey}</div></div>
+        <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Projected cap room (pending)</div><div style={{ fontWeight: 800, color: projectedCapRoom < 8 ? 'var(--warning)' : 'var(--text)' }}>{money(projectedCapRoom)}</div></div>
+        <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Premium positions at risk</div><div style={{ fontWeight: 800, color: premiumAtRisk ? 'var(--warning)' : 'var(--success)' }}>{premiumAtRisk}</div></div>
+      </div>
+
+      <section className="card" style={{ padding: 10, display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 8 }}>
+        <div style={{ fontSize: 12 }}><strong>Recommended next move:</strong> {recommendedNextMove}</div>
+        <label style={{ fontSize: 12, display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+          Sort:
+          <select value={sortPreset} onChange={(e) => setSortPreset(e.target.value)} style={{ padding: '4px 6px' }}>
+            {SORT_PRESETS.map((preset) => <option key={preset.id} value={preset.id}>{preset.label}</option>)}
+          </select>
+        </label>
+      </section>
+
+      {previewRow ? (
+        <section className="card" style={{ padding: 12 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>
+            <div style={{ fontWeight: 800 }}>Extension preview · {previewRow.player.name}</div>
+            <div style={{ fontSize: 12, color: projectedCapRoom < 5 ? 'var(--danger)' : 'var(--text-muted)' }}>
+              Cap room after signing: {money(capSnapshot.capRoom - Math.max(0, previewRow.projectedCapHit - previewRow.currentCapHit))}
+            </div>
+          </div>
+          <div style={{ marginTop: 6, fontSize: 12, color: 'var(--text-muted)' }}>
+            {money(previewRow.demand.baseAnnual)} AAV · {previewRow.demand.yearsTotal} years · Total {money(previewRow.demand.baseAnnual * previewRow.demand.yearsTotal)}.
+          </div>
+          {capSnapshot.capRoom - Math.max(0, previewRow.projectedCapHit - previewRow.currentCapHit) < 5 ? (
+            <div style={{ marginTop: 6, fontSize: 12, color: 'var(--warning)' }}>Warning: this creates cap stress heading into free agency.</div>
+          ) : null}
+          {isKeyPlayer(previewRow.player) ? null : (
+            <div style={{ marginTop: 4, fontSize: 12, color: 'var(--warning)' }}>Warning: letting this player walk could create a depth hole at {previewRow.player.pos}.</div>
+          )}
+          <div style={{ marginTop: 8, display: 'flex', gap: 6 }}>
+            <Button size="sm" disabled={busyPlayerId === previewRow.player.id} onClick={confirmExtension}>Confirm extension</Button>
+            <Button size="sm" variant="outline" onClick={() => setPreviewPlayerId(null)}>Close preview</Button>
+          </div>
+        </section>
+      ) : null}
+
+      <section className="card" style={{ padding: 0, overflowX: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
+          <thead>
+            <tr style={{ background: 'var(--surface)', textAlign: 'left' }}>
+              <th style={{ padding: 8 }}>Player</th><th style={{ padding: 8 }}>Age</th><th style={{ padding: 8 }}>OVR</th><th style={{ padding: 8 }}>Status</th><th style={{ padding: 8 }}>Ask</th><th style={{ padding: 8 }}>Current hit</th><th style={{ padding: 8 }}>Projected hit</th><th style={{ padding: 8 }}>Scheme</th><th style={{ padding: 8 }}>Role</th><th style={{ padding: 8 }}>Replaceability</th><th style={{ padding: 8 }}>Decision</th><th style={{ padding: 8 }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedRows.map((row) => (
+              <tr key={row.player.id} style={{ borderTop: '1px solid var(--hairline)' }}>
+                <td style={{ padding: 8, fontWeight: 700 }}>
+                  {row.player.name} <span style={{ color: 'var(--text-muted)' }}>({row.player.pos})</span>
+                  {row.premium ? <span style={{ marginLeft: 6, fontSize: 10, border: '1px solid var(--warning)', borderRadius: 10, padding: '1px 6px', color: 'var(--warning)' }}>Key</span> : null}
+                </td>
+                <td style={{ padding: 8 }}>{row.player.age ?? '—'}</td>
+                <td style={{ padding: 8 }}>{row.player.ovr ?? '—'}</td>
+                <td style={{ padding: 8 }}>{toNumber(row.player?.contract?.years, 0)}y remaining</td>
+                <td style={{ padding: 8 }}>{money(row.demand.baseAnnual)}</td>
+                <td style={{ padding: 8 }}>{money(row.currentCapHit)}</td>
+                <td style={{ padding: 8 }}>{money(row.projectedCapHit)}</td>
+                <td style={{ padding: 8 }}>{row.player.schemeFit == null ? '—' : `${Math.round(toNumber(row.player.schemeFit, 0))}%`}</td>
+                <td style={{ padding: 8 }}>{row.starter}</td>
+                <td style={{ padding: 8 }}>{row.replaceability}</td>
+                <td style={{ padding: 8 }}>{row.decisionLabel}</td>
+                <td style={{ padding: 8 }}>
+                  <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+                    <Button size="sm" variant="outline" disabled={busyPlayerId === row.player.id} onClick={() => setPreviewPlayerId(row.player.id)}>Extend</Button>
+                    <Button size="sm" variant="outline" disabled={busyPlayerId === row.player.id} onClick={() => applyDecision(row, 'let_walk')}>Let Walk</Button>
+                    <Button size="sm" variant="outline" disabled={busyPlayerId === row.player.id} onClick={() => applyDecision(row, 'deferred')}>Defer</Button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+            {sortedRows.length === 0 ? (
+              <tr><td style={{ padding: 10, color: 'var(--text-muted)' }} colSpan={12}>No expiring players found.</td></tr>
+            ) : null}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  );
+}
+
 export default function ContractCenter({ league, actions, compact = false, onNavigate = null }) {
   const [extensionPlayer, setExtensionPlayer] = useState(null);
   const [statusMessage, setStatusMessage] = useState('');
@@ -102,11 +365,16 @@ export default function ContractCenter({ league, actions, compact = false, onNav
     }
     try {
       await actions.applyFranchiseTag(player.id, team.id);
+      await actions.updatePlayerManagement?.(player.id, team.id, { extensionDecision: 'tagged' });
       setStatusMessage(`Tagged ${player.name}.`);
     } catch (err) {
       setStatusMessage(err?.message || 'Special retention tool not yet available.');
     }
   };
+
+  if (league?.phase === 'offseason_resign') {
+    return <ReSigningCenter league={league} team={team} actions={actions} onNavigate={onNavigate} setStatusMessage={setStatusMessage} />;
+  }
 
   return (
     <div className="app-screen-stack" style={{ display: 'grid', gap: compact ? 'var(--space-2)' : 'var(--space-3)' }}>

--- a/src/ui/components/ContractCenter.test.jsx
+++ b/src/ui/components/ContractCenter.test.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import ContractCenter from './ContractCenter.jsx';
+
+const league = {
+  phase: 'offseason_resign',
+  userTeamId: 1,
+  teams: [
+    {
+      id: 1,
+      name: 'User Team',
+      abbr: 'USR',
+      capTotal: 255,
+      capUsed: 230,
+      capRoom: 25,
+      roster: [
+        { id: 1, name: 'Core QB', pos: 'QB', age: 27, ovr: 88, schemeFit: 81, depthOrder: 1, contract: { years: 1, baseAnnual: 22, signingBonus: 10, yearsTotal: 4 }, extensionDecision: 'pending' },
+        { id: 2, name: 'Slot WR', pos: 'WR', age: 25, ovr: 77, schemeFit: 72, depthOrder: 1, contract: { years: 1, baseAnnual: 8, signingBonus: 2, yearsTotal: 3 }, extensionDecision: 'deferred' },
+      ],
+    },
+  ],
+};
+
+describe('ContractCenter re-signing mode', () => {
+  it('renders dedicated re-signing management table during offseason_resign', () => {
+    const html = renderToString(<ContractCenter league={league} actions={{}} onNavigate={() => {}} />);
+    expect(html).toContain('Re-signing Center');
+    expect(html).toContain('Projected cap room (pending)');
+    expect(html).toContain('Premium positions at risk');
+    expect(html).toContain('Core QB');
+    expect(html).toContain('Let Walk');
+    expect(html).toContain('Defer');
+  });
+});

--- a/src/ui/components/OffseasonHub.jsx
+++ b/src/ui/components/OffseasonHub.jsx
@@ -32,7 +32,7 @@ const PHASES = [
       "Players with >90 OVR may demand near max deals.",
     ],
     actions: [
-      { label: "View FA Hub", tab: "FA Hub" },
+      { label: "Re-signing Center", tab: "Contract Center" },
       { label: "Check Roster", tab: "Roster" },
       { label: "Financials", tab: "Financials" },
     ],
@@ -49,8 +49,8 @@ const PHASES = [
       "Look for scheme-fit free agents (green 70%+) for instant impact.",
     ],
     actions: [
-      { label: "FA Hub", tab: "FA Hub" },
       { label: "Free Agency", tab: "Free Agency" },
+      { label: "Contract Center", tab: "Contract Center" },
       { label: "Financials", tab: "Financials" },
     ],
   },

--- a/src/ui/components/coreManagementScreens.test.jsx
+++ b/src/ui/components/coreManagementScreens.test.jsx
@@ -59,6 +59,6 @@ describe("core management screens", () => {
     const html = renderToString(<OffseasonHub league={offseasonLeague} onNavigate={() => {}} />);
     expect(html).toContain("Offseason Action Center");
     expect(html).toContain("Blocking tasks remain");
-    expect(html).toContain("Open Re-sign table");
+    expect(html).toContain("Open Re-signing Center");
   });
 });

--- a/src/ui/utils/offseasonActionCenter.js
+++ b/src/ui/utils/offseasonActionCenter.js
@@ -11,15 +11,15 @@ const PHASE_LABELS = {
 
 const PHASE_ACTIONS = {
   offseason_resign: [
-    { label: 'Open Re-sign table', tab: 'Free Agency' },
+    { label: 'Open Re-signing Center', tab: 'Contract Center' },
     { label: 'Review cap outlook', tab: 'Financials' },
   ],
   free_agency: [
     { label: 'Open market board', tab: 'Free Agency' },
-    { label: 'Open FA Hub', tab: 'FA Hub' },
+    { label: 'Review roster needs', tab: 'Roster:EXPIRING' },
   ],
   trades: [
-    { label: 'Open Trade Workspace', tab: 'Trades' },
+    { label: 'Open Trade Workspace', tab: 'Transactions:Builder' },
     { label: 'Review roster surplus', tab: 'Roster' },
   ],
   draft: [
@@ -64,13 +64,19 @@ function summarizePerformanceNeeds(userTeam) {
 }
 
 function deriveExpiringPriority(expiring = []) {
-  const key = expiring
-    .filter((p) => toNumber(p?.ovr, 0) >= 74 || ['QB', 'LT', 'EDGE', 'CB'].includes(String(p?.pos ?? '').toUpperCase()))
-    .filter((p) => !p?.extensionDecision || p.extensionDecision === 'pending');
+  const unresolved = expiring.filter((p) => !['extended', 'let_walk', 'tagged'].includes(String(p?.extensionDecision ?? 'pending')));
+  const key = unresolved
+    .filter((p) => toNumber(p?.ovr, 0) >= 74 || ['QB', 'LT', 'EDGE', 'CB'].includes(String(p?.pos ?? '').toUpperCase()));
+  const premiumUnresolved = unresolved.filter((p) => ['QB', 'LT', 'EDGE', 'CB'].includes(String(p?.pos ?? '').toUpperCase()));
+  const projectedCapDelta = unresolved
+    .filter((p) => String(p?.extensionDecision ?? '') === 'deferred')
+    .reduce((sum, p) => sum + Math.max(0, toNumber(p?.extensionAsk?.baseAnnual, toNumber(p?.contract?.baseAnnual, 0) * 1.15) - toNumber(p?.contract?.baseAnnual, 0)), 0);
   return {
     total: expiring.length,
-    unresolved: expiring.filter((p) => !p?.extensionDecision || p.extensionDecision === 'pending').length,
+    unresolved: unresolved.length,
     keyUnresolved: key.length,
+    premiumUnresolved: premiumUnresolved.length,
+    projectedCapDelta,
   };
 }
 
@@ -110,8 +116,14 @@ export function buildOffseasonActionCenter(league) {
     blockers.push(`${expiringPriority.keyUnresolved} key expiring contracts still unresolved.`);
     priorities.push('Resolve core re-sign decisions before market opens.');
   }
+  if (phase === 'offseason_resign' && expiringPriority.premiumUnresolved > 0) {
+    blockers.push(`${expiringPriority.premiumUnresolved} premium position decisions are still pending.`);
+  }
   if (phase === 'free_agency' && capRoom <= 0) {
     blockers.push('No cap room remaining for competitive offers.');
+  }
+  if (capRoom < 5) {
+    blockers.push('Cap room is below safe operating threshold ($5M).');
   }
   if (phase === 'draft' && !Array.isArray(league?.draftClass)) {
     blockers.push('Draft board is not hydrated yet.');
@@ -119,6 +131,28 @@ export function buildOffseasonActionCenter(league) {
   if (phase === 'preseason' && rosterCount > 53) {
     blockers.push(`Roster cutdown required (${rosterCount}/53).`);
   }
+
+  if (phase === 'offseason_resign') {
+    const premiumShortages = ['QB', 'LT', 'EDGE', 'CB'].filter((pos) => !expiring.some((p) => String(p?.pos ?? '').toUpperCase() === pos && ['extended', 'tagged', 'deferred', 'pending'].includes(String(p?.extensionDecision ?? 'pending'))) && !(userTeam?.roster ?? []).some((p) => String(p?.pos ?? '').toUpperCase() === pos && toNumber(p?.contract?.years, 0) > 1));
+    if (premiumShortages.length > 0) {
+      blockers.push(`No starter security at premium spots: ${premiumShortages.join(', ')}.`);
+    }
+  }
+
+  const depthByPos = (userTeam?.roster ?? []).reduce((acc, p) => {
+    const pos = String(p?.pos ?? '').toUpperCase();
+    if (!pos) return acc;
+    acc[pos] = (acc[pos] ?? 0) + 1;
+    return acc;
+  }, {});
+  const thinGroups = ['OL', 'CB', 'DL', 'LB']
+    .filter((group) => {
+      const count = Object.entries(depthByPos)
+        .filter(([pos]) => pos.includes(group) || (group === 'OL' && ['LT', 'LG', 'C', 'RG', 'RT'].includes(pos)) || (group === 'DL' && ['DT', 'DE', 'EDGE'].includes(pos)))
+        .reduce((sum, [, count]) => sum + count, 0);
+      return count > 0 && count < 4;
+    });
+  if (thinGroups.length > 0) priorities.push(`Depth is thin in ${thinGroups.join(', ')}.`);
 
   if (capRoom < 8) priorities.push('Cap flexibility is thin; focus on value signings or restructures.');
   if (draftPickCount < 5) priorities.push('Limited draft capital; prioritize trade-back opportunities.');
@@ -138,6 +172,7 @@ export function buildOffseasonActionCenter(league) {
     },
     metrics: {
       capRoom,
+      projectedCapRoom: Math.round((capRoom - expiringPriority.projectedCapDelta) * 10) / 10,
       rosterCount,
       draftPickCount,
       expiringContracts: expiringPriority.total,

--- a/src/ui/utils/offseasonActionCenter.test.js
+++ b/src/ui/utils/offseasonActionCenter.test.js
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { buildOffseasonActionCenter } from './offseasonActionCenter.js';
 
-function makePlayer(id, { pos = 'WR', ovr = 70, years = 1, decision = 'pending' } = {}) {
-  return { id, pos, ovr, contract: { years }, extensionDecision: decision };
+function makePlayer(id, { pos = 'WR', ovr = 70, years = 1, decision = 'pending', baseAnnual = 6 } = {}) {
+  return { id, pos, ovr, contract: { years, baseAnnual }, extensionDecision: decision };
 }
 
 describe('buildOffseasonActionCenter', () => {
@@ -32,9 +32,19 @@ describe('buildOffseasonActionCenter', () => {
 
     const resignCenter = buildOffseasonActionCenter(league);
     expect(resignCenter.blockers.join(' ')).toContain('key expiring contracts');
+    expect(resignCenter.actions.map((a) => a.tab)).toContain('Contract Center');
     expect(resignCenter.metrics.expiringContracts).toBe(2);
+    expect(resignCenter.unresolved.keyExpiringContracts).toBe(2);
+
+    team.roster[0].extensionDecision = 'deferred';
+    const withDeferred = buildOffseasonActionCenter(league);
+    expect(withDeferred.metrics.projectedCapRoom).toBeLessThan(withDeferred.metrics.capRoom);
 
     team.roster[0].extensionDecision = 'extended';
+    team.roster[1].extensionDecision = 'let_walk';
+    const resolved = buildOffseasonActionCenter(league);
+    expect(resolved.unresolved.expiringContracts).toBe(0);
+
     team.capRoom = 10;
     league.phase = 'free_agency';
     const faCenter = buildOffseasonActionCenter(league);
@@ -46,12 +56,13 @@ describe('buildOffseasonActionCenter', () => {
     league.phase = 'trades';
     const tradeCenter = buildOffseasonActionCenter(league);
     expect(tradeCenter.phaseLabel).toBe('Trades');
+    expect(tradeCenter.actions.map((a) => a.tab)).toContain('Transactions:Builder');
     expect(tradeCenter.metrics.rosterCount).toBe(4);
 
     league.phase = 'draft';
     league.draftClass = [{ id: 90, name: 'Prospect One', pos: 'OT' }];
     const draftCenter = buildOffseasonActionCenter(league);
-    expect(draftCenter.blockers).toEqual([]);
+    expect(draftCenter.blockers).not.toContain('Draft board is not hydrated yet.');
 
     team.roster.push(makePlayer(5, { pos: 'OT', ovr: 72, years: 4, decision: 'none' }));
     league.phase = 'post_draft';

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -3668,7 +3668,7 @@ async function handleApplyFranchiseTag({ playerId, teamId }, id) {
       guaranteedPct: 100, // Fully guaranteed
   };
 
-  cache.updatePlayer(playerId, { contract, isTagged: true });
+  cache.updatePlayer(playerId, { contract, isTagged: true, extensionDecision: 'tagged' });
   recalculateTeamCap(resolvedTeamId);
 
   await Transactions.add({
@@ -5393,7 +5393,7 @@ async function handleExtendContract({ playerId, teamId, contract }, id) {
       return;
     }
 
-    cache.updatePlayer(playerId, { contract, negotiationStatus: 'SIGNED' });
+    cache.updatePlayer(playerId, { contract, negotiationStatus: 'SIGNED', extensionDecision: 'extended' });
     recalculateTeamCap(resolvedTeamId);
     await Transactions.add({
       type: 'EXTEND',
@@ -6725,6 +6725,7 @@ async function handleUpdatePlayerManagement({ playerId, teamId, updates = {} }, 
 
   const validTradeStatuses = new Set(['untouchable', 'soft_block', 'available', 'actively_shopping', 'not_available']);
   const validPlanFlags = new Set(['shortlist_extension', 'trade_candidate', 'defer_offseason', 'prioritize_deadline']);
+  const validExtensionDecisions = new Set(['pending', 'deferred', 'let_walk', 'extended', 'tagged']);
 
   const patch = {};
   if (typeof updates.tradeStatus === 'string' && validTradeStatuses.has(updates.tradeStatus)) {
@@ -6733,6 +6734,9 @@ async function handleUpdatePlayerManagement({ playerId, teamId, updates = {} }, 
   }
   if (Array.isArray(updates.contractPlan)) {
     patch.contractPlan = updates.contractPlan.filter((flag) => validPlanFlags.has(flag));
+  }
+  if (typeof updates.extensionDecision === 'string' && validExtensionDecisions.has(updates.extensionDecision)) {
+    patch.extensionDecision = updates.extensionDecision;
   }
 
   if (Object.keys(patch).length === 0) {


### PR DESCRIPTION
### Motivation
- The offseason guidance previously produced by the Offseason Action Center pointed to generic surfaces (Free Agency / placeholder tabs) rather than to a first-class re-signing management surface.  The goal is to make the `offseason_resign` phase a usable, actionable re-signing experience.
- Decisions made during re-signing must persist, change cap projections, reduce blockers, and integrate tightly with phase progression logic.

### Description
- Implemented a dedicated Re-signing Center inside `ContractCenter` that renders in `offseason_resign` mode and provides a management table of expiring players with name, pos, age, OVR, contract years, estimated ask, current/projected cap hits, scheme fit, role, replaceability hints, and a key-player badge for premium positions; added sorting presets and compact summary cards at the top. (`src/ui/components/ContractCenter.jsx`)
- Added decision actions for each expiring player: `Extend` (with lightweight contract preview and confirm flow), `Let Walk`, and `Defer/Decide Later`; decisions are persisted via the worker-backed `UPDATE_PLAYER_MANAGEMENT` path and shown in the UI immediately. (`src/ui/components/ContractCenter.jsx`, `src/worker/worker.js`)
- Worker-side changes: stamped `extensionDecision` when an extension is accepted and when a franchise tag is applied, and allowed `UPDATE_PLAYER_MANAGEMENT` to accept `extensionDecision` updates so UI decisions persist to state and trigger `STATE_UPDATE`. (`src/worker/worker.js`)
- Revised `buildOffseasonActionCenter()` to: route phase action buttons to real destinations (e.g., `Contract Center`, `Transactions:Builder`, `Roster:EXPIRING`), compute better blocker/priority intelligence (unresolved key expirings, premium-position risk, cap safety threshold, thin depth signals), and expose a `projectedCapRoom` metric that accounts for deferred/asked demands. (`src/ui/utils/offseasonActionCenter.js`)
- Offseason UX polish: Offseason Hub quick-actions now point to supported screens (re-signing action label updated), and `App` will prompt when advancing out of `offseason_resign` if key re-signing decisions remain unresolved. (`src/ui/components/OffseasonHub.jsx`, `src/ui/App.jsx`)
- Tests and small test-helpers added/updated to validate the new flows and blocking logic, and a focused unit test for the Contract/Resign center render was added. (`src/ui/utils/offseasonActionCenter.test.js`, `src/ui/components/ContractCenter.test.jsx`, `src/ui/components/coreManagementScreens.test.jsx`)

### Testing
- Ran unit tests covering the modified scenarios: `npm run test:unit -- src/ui/utils/offseasonActionCenter.test.js src/ui/components/coreManagementScreens.test.jsx src/ui/components/ContractCenter.test.jsx`, and all tests passed (3 files, 6 tests).
- Verified that extension acceptance and franchise tag flows set `extensionDecision` and that `buildOffseasonActionCenter()` reports updated unresolved counts and projected cap room after simulated decision changes via tests.
- Note: visual/manual browser QA was not performed in this automation run (no browser screenshots captured).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e13a338950832dab8ade1898e71481)