### PR TITLE
Redesign Franchise HQ into ranked, contextual command center

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -5,8 +5,7 @@ import { deriveTeamCapSnapshot, formatMoneyM } from "../utils/numberFormatting.j
 import { getHQViewModel } from "../../state/selectors.js";
 import { buildCompletedGamePresentation } from "../utils/boxScoreAccess.js";
 import { EmptyState, SectionCard, StatCard } from "./common/UiPrimitives.jsx";
-import { LinkedGameSummaryCard } from "./common/GameResultCards.jsx";
-import { CtaRow, CompactListRow, StatusChip } from "./ScreenSystem.jsx";
+import { StatusChip, CompactListRow } from "./ScreenSystem.jsx";
 import { getRecentGames as getArchivedRecentGames } from "../../core/archive/gameArchive.ts";
 import { autoBuildDepthChart, depthWarnings } from "../../core/depthChart.js";
 import { getTeamStatusLine, getActionContext } from "../utils/hqHelpers.js";
@@ -39,71 +38,95 @@ function getNextGame(league) {
   return null;
 }
 
-const HQHero = ({ team, league, record, statusLine, nextGame, onAdvanceWeek, onNavigate, busy, simulating }) => {
-  return (
-    <div className="hq-hero-section card" style={{
-      padding: 'var(--space-4)',
-      background: 'linear-gradient(135deg, var(--surface) 0%, color-mix(in srgb, var(--surface) 95%, var(--accent)) 100%)',
-      border: '1px solid var(--hairline)',
-      display: 'grid',
-      gap: 'var(--space-3)'
-    }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-        <div>
-          <div style={{ fontSize: 'var(--text-xs)', textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-muted)', marginBottom: 4 }}>
-            {league.year} · Week {league.week} · {league.phase}
-          </div>
-          <h1 style={{ margin: 0, fontSize: 'var(--text-xl)', fontWeight: 900, lineHeight: 1 }}>
-            {team.city} {team.name}
-          </h1>
-          <div style={{ fontSize: 'var(--text-lg)', fontWeight: 600, color: 'var(--accent)' }}>
-            {record} · {team.conf} {team.div}
-          </div>
+function getPrevGame(league) {
+  const weeks = [...(league?.schedule?.weeks ?? [])].sort((a, b) => Number(b?.week ?? 0) - Number(a?.week ?? 0));
+  for (const week of weeks) {
+    const games = [...(week?.games ?? [])].reverse();
+    for (const game of games) {
+      if (!game?.played) continue;
+      const homeId = Number(game?.home?.id ?? game?.home);
+      const awayId = Number(game?.away?.id ?? game?.away);
+      if (homeId !== Number(league?.userTeamId) && awayId !== Number(league?.userTeamId)) continue;
+      return { ...game, week: Number(week?.week ?? league?.week ?? 1), homeId, awayId };
+    }
+  }
+  return null;
+}
+
+function getSeverityTone(level) {
+  if (level === "urgent" || level === "blocker") return "danger";
+  if (level === "recommended" || level === "warning") return "warning";
+  return "info";
+}
+
+function ovrTier(ovr) {
+  const value = safeNum(ovr);
+  if (value >= 84) return "Contender";
+  if (value >= 77) return "Playoff bubble";
+  return "Rebuilding";
+}
+
+function capTier(room) {
+  if (room < 0) return "Overcommitted";
+  if (room < 6) return "Tight";
+  return "Healthy";
+}
+
+function rosterTier(rosterSize, injuries) {
+  if (injuries >= 5) return "Thin";
+  if (rosterSize > 53) return "Cutdown needed";
+  return "Healthy";
+}
+
+const HQHero = ({ team, league, record, statusLine, nextGame, onAdvanceWeek, onNavigate, busy, simulating }) => (
+  <section
+    className="card"
+    style={{
+      padding: "var(--space-3)",
+      border: "1px solid color-mix(in srgb, var(--accent) 25%, var(--hairline))",
+      background: "linear-gradient(145deg, color-mix(in srgb, var(--surface) 94%, var(--accent) 6%) 0%, var(--surface) 100%)",
+      display: "grid",
+      gap: "var(--space-2)",
+    }}
+  >
+    <div style={{ display: "flex", justifyContent: "space-between", gap: 10, alignItems: "flex-start", flexWrap: "wrap" }}>
+      <div>
+        <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: ".05em" }}>
+          {league?.year} · Week {league?.week} · {String(league?.phase ?? "regular").replaceAll("_", " ")}
         </div>
-        <div style={{ textAlign: 'right' }}>
-           <StatusChip label={statusLine} tone="team" />
+        <h1 style={{ margin: "2px 0 0", fontSize: "clamp(1.1rem, 4.8vw, 1.5rem)", lineHeight: 1.1 }}>
+          {team?.city} {team?.name}
+        </h1>
+        <div style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)", marginTop: 2 }}>
+          {record} · {team?.conf} {team?.div}
         </div>
       </div>
+      <StatusChip label={statusLine} tone="team" />
+    </div>
 
-      <div style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 'var(--space-3)',
-        padding: 'var(--space-3)',
-        background: 'rgba(0,0,0,0.1)',
-        borderRadius: 'var(--radius-md)'
-      }}>
-        <div style={{ flex: 1 }}>
-          <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>Next Opponent</div>
-          <div style={{ fontWeight: 700 }}>{nextGame ? `${nextGame.isHome ? 'vs' : '@'} ${nextGame.opp?.name}` : 'No upcoming game'}</div>
+    <div style={{ display: "grid", gridTemplateColumns: "1fr auto", gap: "var(--space-2)", alignItems: "center" }}>
+      <div style={{ minWidth: 0 }}>
+        <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", textTransform: "uppercase" }}>Next opponent</div>
+        <div style={{ fontWeight: 700, fontSize: "var(--text-sm)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+          {nextGame ? `${nextGame.isHome ? "vs" : "@"} ${nextGame.opp?.name ?? "TBD"} (${formatRecord(nextGame.opp)})` : "Open week / schedule TBD"}
         </div>
-        <div style={{ display: 'flex', gap: 8 }}>
-          <Button
-            onClick={() => onNavigate?.("Game Plan")}
-            variant="outline"
-            size="sm"
-          >
-            Prepare
-          </Button>
-          <Button
-            onClick={onAdvanceWeek}
-            disabled={busy || simulating}
-            size="sm"
-            className="app-advance-btn"
-          >
-            {busy || simulating ? "Working…" : "Advance Week"}
-          </Button>
-        </div>
+      </div>
+      <div style={{ display: "flex", gap: 6, flexWrap: "wrap", justifyContent: "flex-end" }}>
+        <Button size="sm" variant="outline" onClick={() => onNavigate?.("Game Plan")}>Prepare Game</Button>
+        <Button size="sm" className="app-advance-btn" onClick={onAdvanceWeek} disabled={busy || simulating}>
+          {busy || simulating ? "Working…" : "Advance Week"}
+        </Button>
       </div>
     </div>
-  );
-};
+  </section>
+);
 
 export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeamSelect, onAdvanceWeek, busy, simulating }) {
   const vm = useMemo(() => getHQViewModel(league), [league]);
   const [lineupToast, setLineupToast] = useState(null);
   const weekly = useMemo(() => evaluateWeeklyContext(vm.league), [vm.league]);
   const nextGame = useMemo(() => getNextGame(vm.league), [vm.league]);
+  const previousScheduledGame = useMemo(() => getPrevGame(vm.league), [vm.league]);
   const latestArchived = useMemo(() => getArchivedRecentGames(1)?.[0] ?? null, [vm.league?.seasonId, vm.league?.week]);
 
   if (!vm.userTeam) {
@@ -113,53 +136,12 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
   const team = vm.userTeam;
   const cap = deriveTeamCapSnapshot(team, { fallbackCapTotal: 255 });
   const record = formatRecord(team);
-  const statusLine = useMemo(() => getTeamStatusLine(team, vm.league, weekly), [team, vm.league, weekly]);
+  const statusLine = getTeamStatusLine(team, vm.league, weekly);
   const urgentItems = (weekly?.urgentItems ?? []).slice(0, 6);
 
   const teamDevelopments = (vm.league?.newsItems ?? [])
     .filter((item) => item?.teamId == null || Number(item?.teamId) === Number(vm.league?.userTeamId))
-    .slice(0, 2);
-
-  const scheduleWeeks = vm.league?.schedule?.weeks ?? [];
-  const remainingRegularSeasonGames = scheduleWeeks
-    .flatMap((w) => w?.games ?? [])
-    .filter((game) => {
-      const homeId = Number(game?.home?.id ?? game?.home);
-      const awayId = Number(game?.away?.id ?? game?.away);
-      const involvesUser = homeId === Number(vm.league?.userTeamId) || awayId === Number(vm.league?.userTeamId);
-      return involvesUser && !game?.played;
-    }).length;
-
-  const phasePriorityQueue = useMemo(() => {
-    const queue = [...urgentItems];
-    if (vm.league?.phase === "preseason" && (team?.roster?.length ?? 0) > 53) {
-      queue.unshift({
-        label: "Roster cutdown required",
-        detail: `${team.roster.length} players on roster — trim to regular-season limits.`,
-        tab: "Roster",
-        tone: "danger",
-        verb: "Fix lineup"
-      });
-    }
-    if (vm.league?.phase === "regular" && remainingRegularSeasonGames <= 3) {
-      queue.unshift({
-        label: "Trade window is closing",
-        detail: `${remainingRegularSeasonGames} regular-season game${remainingRegularSeasonGames === 1 ? "" : "s"} left.`,
-        tab: "Transactions",
-        tone: "warning",
-        verb: "Review market"
-      });
-    }
-    return queue.slice(0, 4);
-  }, [urgentItems, vm.league?.phase, team?.roster?.length, remainingRegularSeasonGames]);
-
-  const latestGamePresentation = latestArchived
-    ? buildCompletedGamePresentation({
-      ...latestArchived,
-      homeScore: latestArchived?.score?.home,
-      awayScore: latestArchived?.score?.away,
-    }, { seasonId: vm.league?.seasonId, week: Number(latestArchived?.week ?? vm.league?.week ?? 1), source: "hq_last_game" })
-    : null;
+    .slice(0, 3);
 
   const handleSetLineup = () => {
     const roster = Array.isArray(team?.roster) ? team.roster : [];
@@ -173,35 +155,90 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
     const assignments = autoBuildDepthChart(roster, existingAssignments);
     const warnings = depthWarnings(assignments, roster);
     const hasBlockingLineupIssue = warnings.some((warning) => warning.level === "error");
-    setLineupToast(hasBlockingLineupIssue
-      ? "Depth chart still has missing starters. Fix red-warning rows to finalize lineup."
-      : "Lineup is valid. Opening depth chart.");
+    setLineupToast(
+      hasBlockingLineupIssue
+        ? "Depth chart still has missing starters. Fix red-warning rows to finalize lineup."
+        : "Lineup is valid. Opening depth chart.",
+    );
     window.setTimeout(() => setLineupToast(null), 2200);
     onNavigate?.("Roster:depth|ALL");
   };
 
   const commandCenterActions = [
-    { label: "Set Lineup", type: 'lineup', onClick: handleSetLineup },
-    { label: "Game Plan", type: 'gameplan', onClick: () => onNavigate?.("Game Plan") },
-    { label: "News & Injuries", type: 'news', onClick: () => onNavigate?.("News") },
-    { label: "Matchup", type: 'opponent', onClick: () => onNavigate?.("Schedule") },
-  ].map(a => ({ ...a, context: getActionContext(a.type, weekly, nextGame) }));
+    { label: "Set lineup", type: "lineup", onClick: handleSetLineup },
+    { label: "Game plan", type: "gameplan", onClick: () => onNavigate?.("Game Plan") },
+    { label: "News & injuries", type: "news", onClick: () => onNavigate?.("News") },
+    { label: "Preview opponent", type: "opponent", onClick: () => onNavigate?.("Schedule") },
+  ]
+    .map((a) => ({ ...a, context: getActionContext(a.type, weekly, nextGame) }))
+    .slice(0, 4);
 
-  const getCapStatus = (capRoom) => {
-     if (capRoom < 2) return "Tight";
-     if (capRoom < 10) return "Healthy";
-     return "Flexible";
-  };
+  const featuredPriority = urgentItems[0] ?? null;
+  const secondaryPriorities = urgentItems.slice(1, 4);
 
-  const getRosterStatus = (roster, injuries) => {
-     if (injuries > 4) return "Thin (Injuries)";
-     if (roster.length < 50) return "Incomplete";
-     return "Healthy";
-  };
+  const latestGamePresentation = latestArchived
+    ? buildCompletedGamePresentation(
+      {
+        ...latestArchived,
+        homeScore: latestArchived?.score?.home,
+        awayScore: latestArchived?.score?.away,
+      },
+      { seasonId: vm.league?.seasonId, week: Number(latestArchived?.week ?? vm.league?.week ?? 1), source: "hq_last_game" },
+    )
+    : null;
+
+  const fallbackLastGame = previousScheduledGame
+    ? {
+      id: previousScheduledGame?.id,
+      homeAbbr: previousScheduledGame?.home?.abbr ?? "HOME",
+      awayAbbr: previousScheduledGame?.away?.abbr ?? "AWAY",
+      score: {
+        home: safeNum(previousScheduledGame?.homeScore),
+        away: safeNum(previousScheduledGame?.awayScore),
+      },
+      week: previousScheduledGame?.week,
+      userWon:
+          (previousScheduledGame?.homeId === Number(vm.league?.userTeamId)
+            && safeNum(previousScheduledGame?.homeScore) > safeNum(previousScheduledGame?.awayScore))
+          || (previousScheduledGame?.awayId === Number(vm.league?.userTeamId)
+            && safeNum(previousScheduledGame?.awayScore) > safeNum(previousScheduledGame?.homeScore)),
+    }
+    : null;
+
+  const lastGame = latestArchived ?? fallbackLastGame;
+  const lastGameStory = (() => {
+    if (!lastGame) return "Play your next game to unlock recap context.";
+    const margin = Math.abs(safeNum(lastGame?.score?.home) - safeNum(lastGame?.score?.away));
+    if (margin <= 3) return "One-possession finish; late-game execution decided it.";
+    if (margin >= 14) return "Lopsided outcome; trench and turnover battles tilted early.";
+    return "Momentum swung in the second half and decided the final margin.";
+  })();
+
+  const leagueLeadersSnapshot = (() => {
+    const teams = Array.isArray(vm.league?.teams) ? vm.league.teams : [];
+    if (!teams.length) return [];
+    const bestRecord = [...teams].sort((a, b) => (safeNum(b.wins) - safeNum(b.losses)) - (safeNum(a.wins) - safeNum(a.losses)))[0];
+    const topOffense = [...teams].sort((a, b) => safeNum(b.ptsFor) - safeNum(a.ptsFor))[0];
+    const topDefense = [...teams].sort((a, b) => safeNum(a.ptsAgainst) - safeNum(b.ptsAgainst))[0];
+    return [
+      { label: "Best record", value: bestRecord?.abbr ?? bestRecord?.name ?? "—" },
+      { label: "Top offense", value: topOffense?.abbr ?? topOffense?.name ?? "—" },
+      { label: "Top defense", value: topDefense?.abbr ?? topDefense?.name ?? "—" },
+    ];
+  })();
+
+  const matchupGap = nextGame?.opp ? safeNum(team?.ovr) - safeNum(nextGame.opp?.ovr) : null;
+  const matchupNote =
+    matchupGap == null
+      ? "Use schedule + game plan to prep your next checkpoint."
+      : matchupGap >= 5
+        ? "You hold the OVR edge—avoid self-inflicted mistakes."
+        : matchupGap <= -5
+          ? "Talent deficit on paper—scheme and turnovers become critical."
+          : "Even matchup—situational football and depth should swing it.";
 
   return (
-    <div className="app-screen-stack franchise-hq" style={{ display: "grid", gap: "var(--space-3)" }}>
-
+    <div className="app-screen-stack franchise-hq" style={{ display: "grid", gap: "var(--space-2)" }}>
       <HQHero
         team={team}
         league={vm.league}
@@ -214,127 +251,150 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
         simulating={simulating}
       />
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: 'var(--space-3)' }}>
-
-        <SectionCard title="Command Center" subtitle="Contextual preparation for the current week.">
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 8 }}>
-            {commandCenterActions.map(action => (
-              <button
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(270px, 1fr))", gap: "var(--space-2)" }}>
+        <SectionCard title="This Week" subtitle="Contextual prep actions before kickoff.">
+          <div style={{ display: "grid", gap: 6 }}>
+            {commandCenterActions.map((action) => (
+              <CompactListRow
                 key={action.label}
-                className="btn btn-outline"
-                onClick={action.onClick}
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'flex-start',
-                  padding: '10px',
-                  height: 'auto',
-                  textAlign: 'left'
-                }}
+                title={action.label}
+                subtitle={action.context}
+                meta={<StatusChip label="Prep" tone="team" />}
               >
-                <span style={{ fontWeight: 700, fontSize: 'var(--text-sm)' }}>{action.label}</span>
-                <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', fontWeight: 400 }}>{action.context}</span>
-              </button>
+                <Button size="sm" variant="outline" onClick={action.onClick}>{action.label}</Button>
+              </CompactListRow>
             ))}
           </div>
-          {lineupToast ? <div style={{ fontSize: "var(--text-xs)", color: "var(--accent)", marginTop: 4 }}>{lineupToast}</div> : null}
+          {lineupToast ? <div style={{ fontSize: "var(--text-xs)", color: "var(--accent)", marginTop: 6 }}>{lineupToast}</div> : null}
         </SectionCard>
 
-        <SectionCard title="Priority Queue">
-          {phasePriorityQueue.length === 0 ? <div style={{ color: "var(--text-muted)", padding: 8 }}>No immediate blockers.</div> : (
-            <div style={{ display: "grid", gap: 6 }}>
-              {phasePriorityQueue.map((item, idx) => (
-                <div
-                  key={`${item.label}-${idx}`}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 10,
-                    padding: '8px 10px',
-                    background: idx === 0 ? 'rgba(var(--accent-rgb, 10, 132, 255), 0.1)' : 'var(--surface-muted)',
-                    border: idx === 0 ? '1px solid var(--accent)' : '1px solid var(--hairline)',
-                    borderRadius: 'var(--radius-md)'
-                  }}
-                >
-                  <div style={{ flex: 1 }}>
-                    <div style={{ fontWeight: 700, fontSize: 'var(--text-sm)' }}>{item.label}</div>
-                    <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{item.detail}</div>
+        <SectionCard title="Priority Queue" subtitle="Ranked by urgency and impact.">
+          {featuredPriority ? (
+            <div style={{ display: "grid", gap: 8 }}>
+              <div style={{ border: "1px solid var(--danger)", borderRadius: "var(--radius-md)", padding: "10px", background: "color-mix(in srgb, var(--danger) 10%, var(--surface))" }}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "start" }}>
+                  <div>
+                    <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", textTransform: "uppercase" }}>Urgent</div>
+                    <div style={{ fontWeight: 700, fontSize: "var(--text-sm)" }}>{featuredPriority.label}</div>
+                    <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginTop: 2 }}>{featuredPriority.detail}</div>
                   </div>
-                  <Button size="sm" onClick={() => onNavigate?.(item?.tab ?? "Team")}>
-                    {item.verb || "Open"}
-                  </Button>
+                  <Button size="sm" onClick={() => onNavigate?.(featuredPriority?.tab ?? "Team")}>{featuredPriority.verb || "Review now"}</Button>
                 </div>
+              </div>
+
+              {secondaryPriorities.map((item, idx) => (
+                <CompactListRow
+                  key={`${item.label}-${idx}`}
+                  title={item.label}
+                  subtitle={item.detail}
+                  meta={<StatusChip label={item.level === "blocker" ? "Urgent" : item.level === "recommendation" ? "Recommended" : "Info"} tone={getSeverityTone(item.level)} />}
+                >
+                  <Button size="sm" variant="outline" onClick={() => onNavigate?.(item?.tab ?? "Team")}>{item.verb || "Review"}</Button>
+                </CompactListRow>
               ))}
             </div>
+          ) : (
+            <CompactListRow
+              title="No urgent blockers"
+              subtitle="Use this week to improve cap, depth, and scouting position."
+              meta={<StatusChip label="Info" tone="info" />}
+            >
+              <Button size="sm" variant="outline" onClick={() => onNavigate?.("Financials")}>Upgrade facility</Button>
+            </CompactListRow>
           )}
         </SectionCard>
-
       </div>
 
-      <SectionCard title="Team Snapshot">
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 8 }}>
+      <SectionCard title="Team Snapshot" subtitle="Interpretive status for roster, cap, and window.">
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(130px, 1fr))", gap: 8 }}>
+          <StatCard label="OVR" value={`${safeNum(team?.ovr, 0)}`} note={ovrTier(team?.ovr)} />
+          <StatCard label="Cap room" value={formatMoneyM(cap.capRoom)} note={capTier(cap.capRoom)} />
+          <StatCard label="Roster" value={`${(team?.roster ?? []).length} active`} note={rosterTier((team?.roster ?? []).length, safeNum(weekly?.pressurePoints?.injuriesCount))} />
           <StatCard
-            label="OVR Rating"
-            value={`${safeNum(team?.ovr, 0)}`}
-            note={team.ovr > 80 ? 'Contender' : 'Building'}
-          />
-          <StatCard
-            label="Cap Space"
-            value={formatMoneyM(cap.capRoom)}
-            note={getCapStatus(cap.capRoom)}
-          />
-          <StatCard
-            label="Roster Health"
-            value={`${(team?.roster ?? []).length} active`}
-            note={getRosterStatus(team.roster, safeNum(weekly?.pressurePoints?.injuriesCount))}
-          />
-          <StatCard
-            label="Expiring"
+            label="Expiring deals"
             value={`${safeNum(weekly?.pressurePoints?.expiringCount)}`}
-            note={weekly?.pressurePoints?.expiringCount > 3 ? 'Action needed' : 'Stable'}
+            note={safeNum(weekly?.pressurePoints?.expiringCount) > 2 ? "Key starters at risk" : "Stable core"}
           />
         </div>
       </SectionCard>
 
-      <div className="league-pulse-section" style={{ display: 'grid', gap: 'var(--space-3)' }}>
-        <h3 style={{ margin: 'var(--space-2) 0 0', fontSize: 'var(--text-base)', opacity: 0.8 }}>League Pulse</h3>
-
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: 'var(--space-3)' }}>
+      <section style={{ display: "grid", gap: "var(--space-2)" }}>
+        <h3 style={{ margin: 0, fontSize: "var(--text-base)", opacity: 0.9 }}>League Pulse</h3>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))", gap: "var(--space-2)" }}>
           <SectionCard title="Next Game" actions={nextGame ? <StatusChip label={`Week ${nextGame.week}`} tone="team" /> : null}>
-            {nextGame ? (
-              <LinkedGameSummaryCard
-                label="Upcoming Matchup"
-                title={`${nextGame.isHome ? "vs" : "@"} ${nextGame.opp?.abbr ?? "TBD"} (${formatRecord(nextGame.opp)})`}
-                subtitle="View Preview"
-                onOpen={() => onNavigate?.("Schedule")}
-              />
-            ) : <div style={{ color: "var(--text-muted)" }}>No upcoming game.</div>}
+            <div style={{ display: "grid", gap: 5 }}>
+              <div style={{ fontWeight: 700 }}>{nextGame ? `${nextGame.isHome ? "vs" : "@"} ${nextGame.opp?.name ?? "TBD"}` : "No scheduled matchup"}</div>
+              <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
+                {nextGame?.opp ? `Opponent record: ${formatRecord(nextGame.opp)} · OVR ${safeNum(nextGame.opp?.ovr, 0)}` : "Schedule or playoff bracket context will appear here."}
+              </div>
+              <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>Matchup note: {matchupNote}</div>
+              <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+                <Button size="sm" variant="outline" onClick={() => onNavigate?.("Schedule")}>Preview Matchup</Button>
+                <Button size="sm" variant="outline" onClick={() => onNavigate?.("Game Plan")}>Prepare Game</Button>
+              </div>
+            </div>
           </SectionCard>
 
           <SectionCard title="Last Game">
-            {!latestArchived ? <div style={{ color: "var(--text-muted)" }}>No results yet.</div> : (
-              <LinkedGameSummaryCard
-                label={`Week ${latestArchived?.week ?? vm.league?.week} Final`}
-                title={`${latestArchived?.awayAbbr} ${latestArchived?.score?.away} @ ${latestArchived?.homeAbbr} ${latestArchived?.score?.home}`}
-                subtitle={latestGamePresentation?.ctaLabel ?? "View result"}
-                onOpen={() => onOpenBoxScore?.(latestArchived?.id)}
-                disabled={!latestGamePresentation?.canOpen}
-              />
-            )}
-          </SectionCard>
-
-          <SectionCard title="News Desk" actions={<Button size="sm" variant="ghost" onClick={() => onNavigate?.("News")}>View All</Button>}>
-             <div style={{ display: "grid", gap: 4 }}>
-              {teamDevelopments.map((item, idx) => (
-                <div key={item?.id || idx} style={{ fontSize: 'var(--text-sm)', borderBottom: '1px solid var(--hairline)', paddingBottom: 4 }}>
-                  <strong>{item.headline}</strong>
-                </div>
-              ))}
-              {teamDevelopments.length === 0 && <div style={{ color: "var(--text-muted)", fontSize: 'var(--text-sm)' }}>No major stories.</div>}
+            <div style={{ display: "grid", gap: 5 }}>
+              {lastGame ? (
+                <>
+                  <div style={{ fontWeight: 700 }}>
+                    {lastGame.userWon ? "W" : "L"} · {lastGame.awayAbbr} {safeNum(lastGame?.score?.away)} @ {lastGame.homeAbbr} {safeNum(lastGame?.score?.home)}
+                  </div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>{lastGameStory}</div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
+                    Top performer: {latestGamePresentation?.spotlightPlayer?.name ?? latestGamePresentation?.headline ?? "Team effort carried the result."}
+                  </div>
+                  <div>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => onOpenBoxScore?.(latestArchived?.id ?? lastGame?.id)}
+                      disabled={latestArchived ? !latestGamePresentation?.canOpen : false}
+                    >
+                      {latestGamePresentation?.ctaLabel ?? "Tactical Recap"}
+                    </Button>
+                  </div>
+                </>
+              ) : (
+                <CompactListRow
+                  title="No final yet"
+                  subtitle="Your first completed game will unlock recap context and tactical takeaways."
+                  meta={<StatusChip label="Info" tone="info" />}
+                >
+                  <Button size="sm" variant="outline" onClick={() => onNavigate?.("Schedule")}>Open Schedule</Button>
+                </CompactListRow>
+              )}
             </div>
           </SectionCard>
+
+          <SectionCard title="News & Leaders" actions={<Button size="sm" variant="ghost" onClick={() => onNavigate?.("News")}>News Desk</Button>}>
+            {teamDevelopments.length > 0 ? (
+              <div style={{ display: "grid", gap: 6 }}>
+                {teamDevelopments.map((item, idx) => (
+                  <div key={item?.id || idx} style={{ fontSize: "var(--text-sm)", borderBottom: "1px solid var(--hairline)", paddingBottom: 5 }}>
+                    <strong>{item.headline}</strong>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div style={{ display: "grid", gap: 6 }}>
+                <CompactListRow
+                  title="News Desk quiet"
+                  subtitle="No major team storylines this week."
+                  meta={<StatusChip label="League Pulse" tone="info" />}
+                />
+                {leagueLeadersSnapshot.map((item) => (
+                  <div key={item.label} style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
+                    {item.label}: <strong style={{ color: "var(--text)" }}>{item.value}</strong>
+                  </div>
+                ))}
+              </div>
+            )}
+          </SectionCard>
         </div>
-      </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- The HQ felt like a stacked-card dashboard with duplicated CTAs and low-information strips, lacking a clear focal point and contextual actions.
- The goal was to turn HQ into a compact command center with a single prominent advance action, contextual prep tasks, ranked priorities, and denser mobile-friendly spacing.

### Description
- Rewrote `src/ui/components/FranchiseHQ.jsx` to introduce a hero-led top module showing team identity, record, week/phase, status chip, next-opponent summary, and one primary in-page `Advance Week` CTA paired with a `Prepare Game` CTA.
- Replaced the old This Week layout with a compact contextual command center exposing up to 4 actions (`Set lineup`, `Game plan`, `News & injuries`, `Preview opponent`) and state-driven short reasons via `getActionContext`.
- Rebuilt Priority Queue into a ranked view with one featured urgent card and up to three secondary compact rows using severity tiers and action-oriented verbs instead of generic “Open” labels.
- Improved Next Game and Last Game presentations to always surface useful matchup or recap context (matchup notes, opponent record/OVR, short recap story, top performer and tactical recap CTA), collapsed quiet News into a compact row, and added a mini league-leaders snapshot; also made Team Snapshot interpretive (OVR / cap / roster / expiring deals tiers).

### Testing
- Ran the unit test file `npm run test:unit -- src/ui/components/__tests__/freshSaveScreens.test.jsx` and it passed (5 tests). 
- Built the production bundle with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1b7e0e0bc832dbe522fc09847ea0f)