### PR TITLE
Improve Franchise HQ grounding, prioritization, and regression coverage

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -8,7 +8,13 @@ import { EmptyState, SectionCard, StatCard } from "./common/UiPrimitives.jsx";
 import { StatusChip, CompactListRow } from "./ScreenSystem.jsx";
 import { getRecentGames as getArchivedRecentGames } from "../../core/archive/gameArchive.ts";
 import { autoBuildDepthChart, depthWarnings } from "../../core/depthChart.js";
-import { getTeamStatusLine, getActionContext } from "../utils/hqHelpers.js";
+import {
+  getTeamStatusLine,
+  getActionContext,
+  getActionDestination,
+  rankHqPriorityItems,
+  getTeamSnapshotNotes,
+} from "../utils/hqHelpers.js";
 
 function safeNum(value, fallback = 0) {
   const n = Number(value);
@@ -55,27 +61,8 @@ function getPrevGame(league) {
 
 function getSeverityTone(level) {
   if (level === "urgent" || level === "blocker") return "danger";
-  if (level === "recommended" || level === "warning") return "warning";
+  if (level === "recommended" || level === "warning" || level === "recommendation") return "warning";
   return "info";
-}
-
-function ovrTier(ovr) {
-  const value = safeNum(ovr);
-  if (value >= 84) return "Contender";
-  if (value >= 77) return "Playoff bubble";
-  return "Rebuilding";
-}
-
-function capTier(room) {
-  if (room < 0) return "Overcommitted";
-  if (room < 6) return "Tight";
-  return "Healthy";
-}
-
-function rosterTier(rosterSize, injuries) {
-  if (injuries >= 5) return "Thin";
-  if (rosterSize > 53) return "Cutdown needed";
-  return "Healthy";
 }
 
 const HQHero = ({ team, league, record, statusLine, nextGame, onAdvanceWeek, onNavigate, busy, simulating }) => (
@@ -137,7 +124,10 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
   const cap = deriveTeamCapSnapshot(team, { fallbackCapTotal: 255 });
   const record = formatRecord(team);
   const statusLine = getTeamStatusLine(team, vm.league, weekly);
-  const urgentItems = (weekly?.urgentItems ?? []).slice(0, 6);
+  const rankedPriorities = rankHqPriorityItems(team, vm.league, weekly, nextGame);
+  const featuredPriority = rankedPriorities.featured;
+  const secondaryPriorities = rankedPriorities.secondary;
+  const snapshotNotes = getTeamSnapshotNotes(team, weekly, cap.capRoom);
 
   const teamDevelopments = (vm.league?.newsItems ?? [])
     .filter((item) => item?.teamId == null || Number(item?.teamId) === Number(vm.league?.userTeamId))
@@ -166,15 +156,12 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
 
   const commandCenterActions = [
     { label: "Set lineup", type: "lineup", onClick: handleSetLineup },
-    { label: "Game plan", type: "gameplan", onClick: () => onNavigate?.("Game Plan") },
-    { label: "News & injuries", type: "news", onClick: () => onNavigate?.("News") },
-    { label: "Preview opponent", type: "opponent", onClick: () => onNavigate?.("Schedule") },
+    { label: "Game plan", type: "gameplan", onClick: () => onNavigate?.(getActionDestination("gameplan", nextGame)) },
+    { label: "News & injuries", type: "news", onClick: () => onNavigate?.(getActionDestination("news", nextGame)) },
+    { label: "Scout opponent", type: "opponent", onClick: () => onNavigate?.(getActionDestination("opponent", nextGame)) },
   ]
     .map((a) => ({ ...a, context: getActionContext(a.type, weekly, nextGame) }))
     .slice(0, 4);
-
-  const featuredPriority = urgentItems[0] ?? null;
-  const secondaryPriorities = urgentItems.slice(1, 4);
 
   const latestGamePresentation = latestArchived
     ? buildCompletedGamePresentation(
@@ -213,6 +200,9 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
     if (margin >= 14) return "Lopsided outcome; trench and turnover battles tilted early.";
     return "Momentum swung in the second half and decided the final margin.";
   })();
+  const recapCtaLabel = latestGamePresentation?.canOpen
+    ? (latestGamePresentation?.ctaLabel?.toLowerCase().includes("tactical") ? "Tactical Recap" : "Box Score")
+    : "View Result";
 
   const leagueLeadersSnapshot = (() => {
     const teams = Array.isArray(vm.league?.teams) ? vm.league.teams : [];
@@ -228,6 +218,8 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
   })();
 
   const matchupGap = nextGame?.opp ? safeNum(team?.ovr) - safeNum(nextGame.opp?.ovr) : null;
+  const offenseGap = nextGame?.opp ? safeNum(team?.offenseRating ?? team?.offRating ?? team?.offense) - safeNum(nextGame.opp?.offenseRating ?? nextGame.opp?.offRating ?? nextGame.opp?.offense) : null;
+  const defenseGap = nextGame?.opp ? safeNum(team?.defenseRating ?? team?.defRating ?? team?.defense) - safeNum(nextGame.opp?.defenseRating ?? nextGame.opp?.defRating ?? nextGame.opp?.defense) : null;
   const matchupNote =
     matchupGap == null
       ? "Use schedule + game plan to prep your next checkpoint."
@@ -307,13 +299,13 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
 
       <SectionCard title="Team Snapshot" subtitle="Interpretive status for roster, cap, and window.">
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(130px, 1fr))", gap: 8 }}>
-          <StatCard label="OVR" value={`${safeNum(team?.ovr, 0)}`} note={ovrTier(team?.ovr)} />
-          <StatCard label="Cap room" value={formatMoneyM(cap.capRoom)} note={capTier(cap.capRoom)} />
-          <StatCard label="Roster" value={`${(team?.roster ?? []).length} active`} note={rosterTier((team?.roster ?? []).length, safeNum(weekly?.pressurePoints?.injuriesCount))} />
+          <StatCard label="OVR" value={`${safeNum(team?.ovr, 0)}`} note={snapshotNotes.ovrNote} />
+          <StatCard label="Cap room" value={formatMoneyM(cap.capRoom)} note={snapshotNotes.capNote} />
+          <StatCard label="Roster" value={`${(team?.roster ?? []).length} active`} note={snapshotNotes.rosterNote} />
           <StatCard
             label="Expiring deals"
             value={`${safeNum(weekly?.pressurePoints?.expiringCount)}`}
-            note={safeNum(weekly?.pressurePoints?.expiringCount) > 2 ? "Key starters at risk" : "Stable core"}
+            note={snapshotNotes.expiringNote}
           />
         </div>
       </SectionCard>
@@ -327,9 +319,14 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
               <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
                 {nextGame?.opp ? `Opponent record: ${formatRecord(nextGame.opp)} · OVR ${safeNum(nextGame.opp?.ovr, 0)}` : "Schedule or playoff bracket context will appear here."}
               </div>
+              {nextGame?.opp ? (
+                <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
+                  OVR edge: {matchupGap > 0 ? "+" : ""}{safeNum(matchupGap)} · Offense: {offenseGap > 0 ? "+" : ""}{safeNum(offenseGap)} · Defense: {defenseGap > 0 ? "+" : ""}{safeNum(defenseGap)}
+                </div>
+              ) : null}
               <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>Matchup note: {matchupNote}</div>
               <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-                <Button size="sm" variant="outline" onClick={() => onNavigate?.("Schedule")}>Preview Matchup</Button>
+                <Button size="sm" variant="outline" onClick={() => onNavigate?.(getActionDestination("opponent", nextGame))}>Scout Matchup</Button>
                 <Button size="sm" variant="outline" onClick={() => onNavigate?.("Game Plan")}>Prepare Game</Button>
               </div>
             </div>
@@ -353,7 +350,7 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
                       onClick={() => onOpenBoxScore?.(latestArchived?.id ?? lastGame?.id)}
                       disabled={latestArchived ? !latestGamePresentation?.canOpen : false}
                     >
-                      {latestGamePresentation?.ctaLabel ?? "Tactical Recap"}
+                      {recapCtaLabel}
                     </Button>
                   </div>
                 </>

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import FranchiseHQ from '../FranchiseHQ.jsx';
+
+const baseLeague = {
+  year: 2026,
+  week: 10,
+  seasonId: 's10',
+  phase: 'regular',
+  userTeamId: 10,
+  ownerApproval: 58,
+  teams: [
+    {
+      id: 10,
+      city: 'Chicago',
+      name: 'Bears',
+      abbr: 'CHI',
+      conf: 1,
+      div: 0,
+      wins: 6,
+      losses: 3,
+      ties: 0,
+      ovr: 84,
+      offenseRating: 82,
+      defenseRating: 83,
+      capRoom: 7,
+      roster: [
+        { id: 1, contract: { yearsRemaining: 1 } },
+        { id: 2, contract: { yearsRemaining: 1 }, injury: 'Ankle', injuredWeeks: 1 },
+      ],
+      recentResults: ['W', 'W', 'L', 'W'],
+    },
+    {
+      id: 11,
+      city: 'Detroit',
+      name: 'Lions',
+      abbr: 'DET',
+      conf: 1,
+      div: 0,
+      wins: 5,
+      losses: 4,
+      ties: 0,
+      ovr: 83,
+      offenseRating: 86,
+      defenseRating: 80,
+      capRoom: 11,
+      roster: [],
+    },
+  ],
+  schedule: {
+    weeks: [
+      { week: 9, games: [{ id: 'g-9', home: { id: 11, abbr: 'DET' }, away: { id: 10, abbr: 'CHI' }, homeScore: 20, awayScore: 23, played: true }] },
+      { week: 10, games: [{ id: 'g-10', home: { id: 10, abbr: 'CHI' }, away: { id: 11, abbr: 'DET' }, played: false }] },
+    ],
+  },
+  incomingTradeOffers: [],
+  newsItems: [{ id: 'n1', teamId: 10, headline: 'Starter upgraded to probable status.' }],
+};
+
+describe('FranchiseHQ', () => {
+  it('renders command center, ranked priorities, and matchup/recap cards', () => {
+    const html = renderToString(
+      <FranchiseHQ
+        league={baseLeague}
+        onNavigate={() => {}}
+        onOpenBoxScore={() => {}}
+        onAdvanceWeek={() => {}}
+        busy={false}
+        simulating={false}
+      />,
+    );
+
+    expect(html).toContain('This Week');
+    expect(html).toContain('Scout opponent');
+    expect(html).toContain('Priority Queue');
+    expect(html).toContain('Next Game');
+    expect(html).toContain('Last Game');
+    expect(html).toContain('Matchup note');
+  });
+
+  it('is safe with partial/older save payloads', () => {
+    expect(() => renderToString(
+      <FranchiseHQ
+        league={{
+          year: 2026,
+          week: 2,
+          phase: 'regular',
+          userTeamId: 1,
+          teams: [{ id: 1, name: 'Legacy Team', city: 'Legacy', conf: 0, div: 0 }],
+          schedule: { weeks: [] },
+        }}
+        onNavigate={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        onAdvanceWeek={vi.fn()}
+        busy={false}
+        simulating={false}
+      />,
+    )).not.toThrow();
+  });
+});

--- a/src/ui/utils/hqHelpers.js
+++ b/src/ui/utils/hqHelpers.js
@@ -1,50 +1,255 @@
+function safeNum(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function getWinPct(team) {
+  const wins = safeNum(team?.wins);
+  const losses = safeNum(team?.losses);
+  const ties = safeNum(team?.ties);
+  const games = wins + losses + ties;
+  if (games <= 0) return 0.5;
+  return (wins + 0.5 * ties) / games;
+}
+
+function getDivisionPosition(team, league) {
+  const teams = Array.isArray(league?.teams) ? league.teams : [];
+  const sameDivision = teams.filter((candidate) => candidate?.conf === team?.conf && candidate?.div === team?.div);
+  if (sameDivision.length <= 1) return { rank: 1, teams: sameDivision };
+  const sorted = [...sameDivision].sort((a, b) => getWinPct(b) - getWinPct(a));
+  const index = sorted.findIndex((candidate) => Number(candidate?.id) === Number(team?.id));
+  return { rank: index >= 0 ? index + 1 : null, teams: sorted };
+}
+
+function getPlayoffSeed(team, league) {
+  const standings = Array.isArray(league?.standings) ? league.standings : [];
+  const userStanding = standings.find((row) => Number(row?.id) === Number(team?.id));
+  const fromStanding = safeNum(userStanding?.seed ?? userStanding?.playoffSeed, null);
+  if (fromStanding != null) return fromStanding;
+  const fromTeam = safeNum(team?.seed ?? team?.playoffSeed, null);
+  return fromTeam;
+}
+
+function ownerPressureState(league, weekly) {
+  const pressureState = weekly?.ownerContext?.pressureState;
+  if (pressureState === 'urgent_demand') return 'urgent';
+  if (pressureState === 'warning') return 'warning';
+  const approval = safeNum(weekly?.pressurePoints?.ownerApproval ?? league?.ownerApproval ?? league?.ownerMood, null);
+  if (approval == null) return 'stable';
+  if (approval < 40) return 'urgent';
+  if (approval < 55) return 'warning';
+  return 'stable';
+}
+
 export function getTeamStatusLine(team, league, weekly) {
-  if (!team || !league) return "Season in progress";
+  if (!team || !league) return 'Season in progress';
 
-  const phase = league.phase;
-  const wins = Number(team.wins || 0);
-  const losses = Number(team.losses || 0);
-  const totalGames = wins + losses;
-
-  if (phase === 'preseason') return "Finalizing roster for Week 1";
-  if (phase === 'playoffs') return "Postseason pursuit";
-  if (phase === 'offseason' || phase === 'draft' || phase === 'free_agency') return "Building for next season";
-
-  if (weekly?.pressurePoints?.ownerApproval < 40) return "Owner pressure rising";
-  if (totalGames > 12) {
-    if (team.isPlayoffSeed) return "Playoff push"; // Assuming this might be in state
-    if (wins > losses) return "Wildcard race";
+  const phase = String(league?.phase ?? 'regular');
+  if (phase === 'preseason') return 'Finalize depth chart before Week 1';
+  if (phase === 'playoffs') return 'Win-or-go-home postseason football';
+  if (phase === 'offseason' || phase === 'draft' || phase === 'free_agency' || phase === 'offseason_resign') {
+    return 'Build next season\'s core';
   }
 
-  if (team.ovr > 85 && wins < losses) return "Underachieving season";
-  if (team.ovr < 75 && wins > losses) return "Exceeding expectations";
+  const pressure = ownerPressureState(league, weekly);
+  const winPct = getWinPct(team);
+  const week = safeNum(league?.week, 1);
+  const ovr = safeNum(team?.ovr, 0);
+  const seed = getPlayoffSeed(team, league);
+  const { rank: divisionRank, teams: divisionTeams } = getDivisionPosition(team, league);
+  const gamesBackDivision = divisionTeams.length > 1 ? getWinPct(divisionTeams[0]) - winPct : 0;
 
-  return "Must-win week ahead";
+  if (pressure === 'urgent' && week >= 8) return 'Owner pressure: results needed now';
+
+  const lateSeason = week >= 13;
+  const inPlayoffPosition = seed != null ? seed <= 7 : winPct >= 0.58;
+  const bubbleRecord = winPct >= 0.45 && winPct < 0.58;
+
+  if (lateSeason && !inPlayoffPosition && bubbleRecord) return 'Must-win stretch to stay alive';
+  if (inPlayoffPosition && (divisionRank === 1 || winPct >= 0.64)) return 'Contender track: protect playoff seed';
+  if (divisionRank != null && divisionRank <= 2 && gamesBackDivision <= 0.08 && week >= 6) return 'Division race tightening';
+  if (bubbleRecord && week >= 7) return 'Playoff bubble: every week swings odds';
+  if (ovr >= 84 && winPct < 0.45 && week >= 5) return 'Underachieving relative to roster talent';
+  if ((weekly?.direction === 'rebuilding' || ovr < 77) && week >= 5) return 'Rebuild lane: prioritize long-term value';
+  if (pressure === 'warning') return 'Owner expectations rising';
+
+  return 'Weekly prep window is open';
 }
 
 export function getActionContext(type, weekly, nextGame) {
+  const injuries = safeNum(weekly?.pressurePoints?.injuriesCount, 0);
+  const offers = safeNum(weekly?.pressurePoints?.incomingTradeCount ?? weekly?.incomingOffers?.length, 0);
+  const opp = nextGame?.opp ?? null;
+
   switch (type) {
     case 'lineup':
-      if (weekly?.pressurePoints?.injuriesCount > 0) {
-        return `${weekly.pressurePoints.injuriesCount} active injury impacts`;
-      }
-      return "Ensure depth is set";
+      if (injuries >= 4) return `${injuries} injuries active — re-balance depth chart now`;
+      if (injuries > 0) return `${injuries} injury impact${injuries > 1 ? 's' : ''} to cover`;
+      return 'Confirm starters and situational packages';
     case 'gameplan':
-      if (nextGame?.opp) {
-        const opp = nextGame.opp;
-        if (opp.offenseRating > 85) return "Facing elite offense";
-        if (opp.defenseRating > 85) return "Heavy defensive test";
-        return `Prepare for ${opp.abbr}`;
+      if (opp) {
+        const offense = safeNum(opp?.offenseRating ?? opp?.offRating ?? opp?.offense);
+        const defense = safeNum(opp?.defenseRating ?? opp?.defRating ?? opp?.defense);
+        if (offense >= 85) return `Limit ${opp.abbr ?? opp.name} explosive offense`;
+        if (defense >= 85) return `Attack ${opp.abbr ?? opp.name} elite defense with matchup calls`;
+        return `Install plan for ${opp.abbr ?? opp.name}`;
       }
-      return "Optimize strategy";
+      return 'Set weekly strategy and tempo';
     case 'news':
-      return "Review league developments";
+      if (injuries > 0) return `Injury report updated (${injuries} active)`;
+      if (offers > 0) return `${offers} trade conversation${offers > 1 ? 's' : ''} needs review`;
+      return 'Review team headlines and health updates';
     case 'opponent':
-      if (nextGame?.opp) {
-        return `Matchup vs ${nextGame.opp.abbr}`;
+      if (opp) {
+        return `${nextGame?.isHome ? 'Home' : 'Road'} matchup vs ${opp.abbr ?? opp.name}`;
       }
-      return "Scout upcoming games";
+      return 'Scout upcoming matchup windows';
     default:
       return null;
   }
+}
+
+export function getActionDestination(type, nextGame) {
+  switch (type) {
+    case 'lineup':
+      return 'Roster:depth|ALL';
+    case 'gameplan':
+      return 'Game Plan';
+    case 'news':
+      return nextGame ? 'Injuries' : 'News';
+    case 'opponent':
+      return nextGame ? 'Game Plan' : 'Schedule';
+    default:
+      return 'HQ';
+  }
+}
+
+export function rankHqPriorityItems(team, league, weekly, nextGame) {
+  const items = [];
+  const pressure = ownerPressureState(league, weekly);
+  const injuries = safeNum(weekly?.pressurePoints?.injuriesCount, 0);
+  const expiring = safeNum(weekly?.pressurePoints?.expiringCount, 0);
+  const capRoom = safeNum(team?.capRoom ?? team?.capSpace, 0);
+  const week = safeNum(league?.week, 1);
+
+  if (pressure === 'urgent') {
+    items.push({ level: 'urgent', rank: 97, label: 'Owner mandate active', detail: 'Franchise confidence is falling — deliver a result this week.', verb: 'Address pressure', tab: '🤖 GM Advisor' });
+  } else if (pressure === 'warning') {
+    items.push({ level: 'recommended', rank: 82, label: 'Owner confidence slipping', detail: 'Recent trend has increased scrutiny on weekly decisions.', verb: 'Review priorities', tab: '🤖 GM Advisor' });
+  }
+
+  if (injuries >= 4) {
+    items.push({ level: 'urgent', rank: 95, label: 'Depth chart stress test', detail: `${injuries} injuries are impacting lineup stability.`, verb: 'Set emergency lineup', tab: 'Roster:depth|ALL' });
+  } else if (injuries >= 2) {
+    items.push({ level: 'recommended', rank: 74, label: 'Injury coverage needed', detail: `${injuries} active injuries require role adjustments.`, verb: 'Reassign roles', tab: 'Injuries' });
+  }
+
+  if (expiring >= 4 && week >= 8) {
+    items.push({ level: 'recommended', rank: 84, label: 'Core contracts nearing expiry', detail: `${expiring} rotation players are in contract-year windows.`, verb: 'Start extension talks', tab: 'Financials' });
+  }
+
+  if (capRoom < 0) {
+    items.push({ level: 'urgent', rank: 92, label: 'Cap overage risk', detail: `Current cap room is ${capRoom.toFixed(1)}M.`, verb: 'Open cap view', tab: 'Financials' });
+  } else if (capRoom < 3) {
+    items.push({ level: 'recommended', rank: 72, label: 'Cap flexibility is tight', detail: `Only ${capRoom.toFixed(1)}M available for emergency moves.`, verb: 'Protect flexibility', tab: 'Financials' });
+  }
+
+  if (league?.phase === 'preseason') {
+    const rosterCount = Array.isArray(team?.roster) ? team.roster.length : safeNum(team?.rosterCount, 0);
+    if (rosterCount > 53) {
+      items.push({ level: 'urgent', rank: 93, label: 'Roster cutdown required', detail: `${rosterCount} players rostered before regular-season limit.`, verb: 'Complete cuts', tab: 'Roster Hub' });
+    }
+  }
+
+  const deadlineWeek = safeNum(league?.tradeDeadline, null);
+  if (deadlineWeek != null && league?.phase === 'regular') {
+    const weeksLeft = deadlineWeek - week;
+    if (weeksLeft >= 0 && weeksLeft <= 2) {
+      items.push({ level: weeksLeft === 0 ? 'urgent' : 'recommended', rank: weeksLeft === 0 ? 91 : 79, label: 'Trade deadline pressure', detail: weeksLeft === 0 ? 'Deadline closes after this week.' : `Deadline closes in ${weeksLeft} week${weeksLeft > 1 ? 's' : ''}.`, verb: 'Review trade options', tab: 'Trades' });
+    }
+  }
+
+  if (nextGame?.opp) {
+    const ovrGap = safeNum(team?.ovr) - safeNum(nextGame.opp?.ovr);
+    if (ovrGap <= -4) {
+      items.push({ level: 'recommended', rank: 76, label: 'Upset prep opportunity', detail: `Underdog matchup vs ${nextGame.opp?.abbr ?? nextGame.opp?.name}.`, verb: 'Tune game plan', tab: 'Game Plan' });
+    } else if (ovrGap >= 5) {
+      items.push({ level: 'info', rank: 58, label: 'Execution week', detail: 'Talent edge exists — avoid turnovers and penalties.', verb: 'Lock focus points', tab: 'Game Plan' });
+    }
+  }
+
+  const merged = [...items, ...((weekly?.urgentItems ?? []).map((item) => ({
+    ...item,
+    level: item?.level === 'blocker' ? 'urgent' : item?.level === 'recommendation' ? 'recommended' : (item?.level ?? 'info'),
+  })))];
+
+  const deduped = [];
+  const seen = new Set();
+  for (const item of merged) {
+    const key = `${item?.label}|${item?.tab}`;
+    if (!item?.label || seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(item);
+  }
+
+  const ranked = deduped
+    .sort((a, b) => {
+      const rankDiff = safeNum(b?.rank, 0) - safeNum(a?.rank, 0);
+      if (rankDiff !== 0) return rankDiff;
+      return String(a?.label ?? '').localeCompare(String(b?.label ?? ''));
+    })
+    .slice(0, 4);
+
+  return {
+    featured: ranked[0] ?? null,
+    secondary: ranked.slice(1, 4),
+  };
+}
+
+export function getTeamSnapshotNotes(team, weekly, capRoom) {
+  const injuries = safeNum(weekly?.pressurePoints?.injuriesCount, 0);
+  const expiring = safeNum(weekly?.pressurePoints?.expiringCount, 0);
+  const rosterSize = Array.isArray(team?.roster) ? team.roster.length : safeNum(team?.rosterCount, 0);
+  const ovr = safeNum(team?.ovr, 0);
+
+  const ovrNote = weekly?.direction === 'rebuilding'
+    ? 'Rebuild phase'
+    : ovr >= 86
+      ? 'Championship-caliber'
+      : ovr >= 80
+        ? 'Playoff-caliber'
+        : ovr >= 74
+          ? 'Transitioning roster'
+          : 'Long-term build';
+
+  const capNote = capRoom < 0
+    ? 'Over cap pressure'
+    : capRoom < 5
+      ? 'Near cap ceiling'
+      : capRoom < 14
+        ? 'Manageable room'
+        : 'Flexible cap outlook';
+
+  const rosterNote = injuries >= 5
+    ? 'Injury-strained depth'
+    : injuries >= 2
+      ? 'Minor injury stress'
+      : rosterSize > 53
+        ? 'Cutdown required'
+        : rosterSize < 48
+          ? 'Thin active roster'
+          : 'Depth in healthy range';
+
+  const expiringNote = expiring >= 5
+    ? 'Multiple core contracts expiring'
+    : expiring >= 2
+      ? 'Several rotation deals expiring'
+      : 'Core contracts relatively stable';
+
+  return {
+    ovrNote,
+    capNote,
+    rosterNote,
+    expiringNote,
+  };
 }

--- a/src/ui/utils/hqHelpers.test.js
+++ b/src/ui/utils/hqHelpers.test.js
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getTeamStatusLine,
+  getActionContext,
+  getActionDestination,
+  rankHqPriorityItems,
+  getTeamSnapshotNotes,
+} from './hqHelpers.js';
+
+const team = {
+  id: 1,
+  conf: 0,
+  div: 0,
+  wins: 5,
+  losses: 6,
+  ovr: 86,
+  capRoom: -2,
+  roster: [{ id: 11 }, { id: 12 }],
+};
+
+const league = {
+  phase: 'regular',
+  week: 14,
+  userTeamId: 1,
+  tradeDeadline: 14,
+  teams: [
+    team,
+    { id: 2, conf: 0, div: 0, wins: 6, losses: 5, ovr: 84 },
+    { id: 3, conf: 0, div: 0, wins: 9, losses: 2, ovr: 90 },
+  ],
+};
+
+describe('hqHelpers', () => {
+  it('builds grounded status for must-win and owner pressure scenarios', () => {
+    const status = getTeamStatusLine(team, league, {
+      pressurePoints: { ownerApproval: 35 },
+      ownerContext: { pressureState: 'urgent_demand' },
+    });
+    expect(status).toContain('Owner pressure');
+  });
+
+  it('generates action contexts and destinations with matchup awareness', () => {
+    const nextGame = { isHome: false, opp: { abbr: 'DET', offenseRating: 88, defenseRating: 79, ovr: 89 } };
+    const weekly = { pressurePoints: { injuriesCount: 3, incomingTradeCount: 2 } };
+
+    expect(getActionContext('lineup', weekly, nextGame)).toContain('3 injury');
+    expect(getActionContext('gameplan', weekly, nextGame)).toContain('explosive offense');
+    expect(getActionDestination('lineup', nextGame)).toBe('Roster:depth|ALL');
+    expect(getActionDestination('opponent', nextGame)).toBe('Game Plan');
+  });
+
+  it('ranks a featured urgent item and limits secondary items', () => {
+    const ranked = rankHqPriorityItems(team, league, {
+      pressurePoints: { injuriesCount: 5, expiringCount: 6, ownerApproval: 32 },
+      urgentItems: [{ label: 'Legacy Alert', tab: 'News', rank: 50, level: 'recommendation' }],
+    }, { opp: { abbr: 'GB', ovr: 92 } });
+
+    expect(ranked.featured).toBeTruthy();
+    expect(['urgent', 'recommended', 'info']).toContain(ranked.featured.level);
+    expect(ranked.secondary.length).toBeLessThanOrEqual(3);
+  });
+
+  it('handles partial or missing state safely', () => {
+    expect(getTeamStatusLine(null, null, null)).toBe('Season in progress');
+    expect(getActionContext('news', null, null)).toContain('Review');
+    const ranked = rankHqPriorityItems({ roster: null }, { week: 1, phase: 'regular' }, null, null);
+    expect(ranked).toHaveProperty('featured');
+    expect(Array.isArray(ranked.secondary)).toBe(true);
+    expect(ranked.secondary.length).toBeLessThanOrEqual(3);
+  });
+
+  it('derives team snapshot notes from cap, injuries, and expiring context', () => {
+    const notes = getTeamSnapshotNotes({ ovr: 88, roster: new Array(54).fill({}) }, { direction: 'balanced', pressurePoints: { injuriesCount: 1, expiringCount: 5 } }, -4);
+    expect(notes.ovrNote).toContain('Championship');
+    expect(notes.capNote).toContain('Over cap');
+    expect(notes.rosterNote).toContain('Cutdown');
+    expect(notes.expiringNote).toContain('core');
+  });
+});


### PR DESCRIPTION
### Motivation
- Make the new HQ layout genuinely intelligence-driven by grounding status messages and actions in deeper franchise state (owner pressure, standings/seed, division race, playoff odds, cap/roster pressure). 
- Replace presentation-heavy heuristics with safer, inspectable helpers so HQ behaves predictably on older/partial saves.
- Ensure the Command Center routes players to the most relevant screens and that the Priority Queue is meaningfully ranked.
- Add regression tests to prevent future heuristic regressions.

### Description
- Reworked HQ helpers in `src/ui/utils/hqHelpers.js`: replaced `getTeamStatusLine` with a grounded implementation (owner pressure, win%, seed/division position, phase/week timing), and added `getActionDestination`, `rankHqPriorityItems`, and `getTeamSnapshotNotes` to centralize routing, priority ranking, and snapshot interpretation.
- Improved action context and routing so command center actions use `getActionContext` and `getActionDestination` to produce matchup-aware context copy and route to appropriate destinations (e.g. lineup -> `Roster:depth|ALL`, news -> `Injuries` when relevant, opponent -> `Game Plan` or `Schedule`).
- Implemented a ranked Priority Queue with one featured item plus up to three secondary items, severity-aware ordering, deduping, and clearer CTA verbs/labels (owner mandates, injury depth, cap risk, cutdowns, trade-deadline, matchup prep).
- Tightened Team Snapshot semantics using `getTeamSnapshotNotes` so OVR/cap/roster/expiring notes reflect actual pressure inputs and safe fallbacks.
- Expanded Next Game and Last Game cards in `src/ui/components/FranchiseHQ.jsx` with OVR/offense/defense deltas, a more specific matchup note, and normalized recap CTA labels (`Tactical Recap` / `Box Score` / `View Result`).
- Added defensive guards throughout helpers and the HQ component for missing arrays/fields (roster, schedule, weekly pressure, legacy saves) so HQ rendering is robust.
- Added unit tests: `src/ui/utils/hqHelpers.test.js` (helpers/ranking/context/safety) and `src/ui/components/__tests__/FranchiseHQ.test.jsx` (rendering and partial-save safety); kept existing `freshSaveScreens` coverage.

### Testing
- Ran unit tests with `npm run test:unit -- src/ui/utils/hqHelpers.test.js src/ui/components/__tests__/FranchiseHQ.test.jsx src/ui/components/__tests__/freshSaveScreens.test.jsx`, and all tests passed (3 test files, 12 tests total passed).
- Verified helper-level assertions for `getTeamStatusLine`, `getActionContext`, `getActionDestination`, `rankHqPriorityItems`, and `getTeamSnapshotNotes` in `src/ui/utils/hqHelpers.test.js` succeeded.
- Render tests for `FranchiseHQ` and existing fresh-save screens in `src/ui/components/__tests__` completed without throwing and validated the new labels/CTAs and partial-state safety.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1b90b0e64832da0ddc78af73fe76c)