### PR TITLE
Add Weekly Prep opponent scouting workflow linked from HQ

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -15,6 +15,7 @@ import {
   rankHqPriorityItems,
   getTeamSnapshotNotes,
 } from "../utils/hqHelpers.js";
+import { deriveWeeklyPrepState, markWeeklyPrepStep } from "../utils/weeklyPrep.js";
 
 function safeNum(value, fallback = 0) {
   const n = Number(value);
@@ -99,7 +100,7 @@ const HQHero = ({ team, league, record, statusLine, nextGame, onAdvanceWeek, onN
         </div>
       </div>
       <div style={{ display: "flex", gap: 6, flexWrap: "wrap", justifyContent: "flex-end" }}>
-        <Button size="sm" variant="outline" onClick={() => onNavigate?.("Game Plan")}>Prepare Game</Button>
+        <Button size="sm" variant="outline" onClick={() => onNavigate?.("Weekly Prep")}>Prepare Game</Button>
         <Button size="sm" className="app-advance-btn" onClick={onAdvanceWeek} disabled={busy || simulating}>
           {busy || simulating ? "Working…" : "Advance Week"}
         </Button>
@@ -112,6 +113,7 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
   const vm = useMemo(() => getHQViewModel(league), [league]);
   const [lineupToast, setLineupToast] = useState(null);
   const weekly = useMemo(() => evaluateWeeklyContext(vm.league), [vm.league]);
+  const prep = useMemo(() => deriveWeeklyPrepState(vm.league), [vm.league]);
   const nextGame = useMemo(() => getNextGame(vm.league), [vm.league]);
   const previousScheduledGame = useMemo(() => getPrevGame(vm.league), [vm.league]);
   const latestArchived = useMemo(() => getArchivedRecentGames(1)?.[0] ?? null, [vm.league?.seasonId, vm.league?.week]);
@@ -145,6 +147,7 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
     const assignments = autoBuildDepthChart(roster, existingAssignments);
     const warnings = depthWarnings(assignments, roster);
     const hasBlockingLineupIssue = warnings.some((warning) => warning.level === "error");
+    if (!hasBlockingLineupIssue) markWeeklyPrepStep(vm.league, "lineupChecked", true);
     setLineupToast(
       hasBlockingLineupIssue
         ? "Depth chart still has missing starters. Fix red-warning rows to finalize lineup."
@@ -156,9 +159,9 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
 
   const commandCenterActions = [
     { label: "Set lineup", type: "lineup", onClick: handleSetLineup },
-    { label: "Game plan", type: "gameplan", onClick: () => onNavigate?.(getActionDestination("gameplan", nextGame)) },
-    { label: "News & injuries", type: "news", onClick: () => onNavigate?.(getActionDestination("news", nextGame)) },
-    { label: "Scout opponent", type: "opponent", onClick: () => onNavigate?.(getActionDestination("opponent", nextGame)) },
+    { label: "Game plan", type: "gameplan", onClick: () => { markWeeklyPrepStep(vm.league, "planReviewed", true); onNavigate?.(getActionDestination("gameplan", nextGame)); } },
+    { label: "News & injuries", type: "news", onClick: () => { markWeeklyPrepStep(vm.league, "injuriesReviewed", true); onNavigate?.(getActionDestination("news", nextGame)); } },
+    { label: "Scout opponent", type: "opponent", onClick: () => { markWeeklyPrepStep(vm.league, "opponentScouted", true); onNavigate?.(getActionDestination("opponent", nextGame)); } },
   ]
     .map((a) => ({ ...a, context: getActionContext(a.type, weekly, nextGame) }))
     .slice(0, 4);
@@ -220,14 +223,8 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
   const matchupGap = nextGame?.opp ? safeNum(team?.ovr) - safeNum(nextGame.opp?.ovr) : null;
   const offenseGap = nextGame?.opp ? safeNum(team?.offenseRating ?? team?.offRating ?? team?.offense) - safeNum(nextGame.opp?.offenseRating ?? nextGame.opp?.offRating ?? nextGame.opp?.offense) : null;
   const defenseGap = nextGame?.opp ? safeNum(team?.defenseRating ?? team?.defRating ?? team?.defense) - safeNum(nextGame.opp?.defenseRating ?? nextGame.opp?.defRating ?? nextGame.opp?.defense) : null;
-  const matchupNote =
-    matchupGap == null
-      ? "Use schedule + game plan to prep your next checkpoint."
-      : matchupGap >= 5
-        ? "You hold the OVR edge—avoid self-inflicted mistakes."
-        : matchupGap <= -5
-          ? "Talent deficit on paper—scheme and turnovers become critical."
-          : "Even matchup—situational football and depth should swing it.";
+  const matchupNote = prep?.keyMatchupNote ?? "Use Weekly Prep to scout your next opponent.";
+  const prepStatus = prep?.readinessLabel ?? "Prep status unavailable";
 
   return (
     <div className="app-screen-stack franchise-hq" style={{ display: "grid", gap: "var(--space-2)" }}>
@@ -325,9 +322,10 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
                 </div>
               ) : null}
               <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>Matchup note: {matchupNote}</div>
+              <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>Prep status: {prepStatus}</div>
               <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
                 <Button size="sm" variant="outline" onClick={() => onNavigate?.(getActionDestination("opponent", nextGame))}>Scout Matchup</Button>
-                <Button size="sm" variant="outline" onClick={() => onNavigate?.("Game Plan")}>Prepare Game</Button>
+                <Button size="sm" variant="outline" onClick={() => onNavigate?.("Weekly Prep")}>Prepare Game</Button>
               </div>
             </div>
           </SectionCard>

--- a/src/ui/components/GamePlanScreen.jsx
+++ b/src/ui/components/GamePlanScreen.jsx
@@ -19,6 +19,7 @@ import { OFFENSIVE_SCHEMES, DEFENSIVE_SCHEMES } from "../../core/scheme-core.js"
 import { OFFENSIVE_PLANS, DEFENSIVE_PLANS } from "../../core/strategy.js";
 import { buildTeamIntelligence } from "../utils/teamIntelligence.js";
 import { deriveTeamCoachingIdentity } from "../utils/coachingIdentity.js";
+import { markWeeklyPrepStep } from '../utils/weeklyPrep.js';
 
 // ── Local-storage key for game plan sliders ───────────────────────────────────
 const GP_STORAGE_KEY = "footballgm_gameplan_v1";
@@ -294,6 +295,10 @@ export default function GamePlanScreen({ league, actions }) {
   // ── Toast state ──
   const [toastVisible, setToastVisible] = useState(false);
   const toastTimer = useRef(null);
+
+  useEffect(() => {
+    markWeeklyPrepStep(league, 'planReviewed', true);
+  }, [league?.seasonId, league?.week, league?.userTeamId]);
 
   // Sync scheme from server if it updates
   useEffect(() => {

--- a/src/ui/components/InjuryReport.jsx
+++ b/src/ui/components/InjuryReport.jsx
@@ -9,13 +9,14 @@
  *  - onPlayerSelect: (playerId) => void
  */
 
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from "@/components/ui/table";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { markWeeklyPrepStep } from "../utils/weeklyPrep.js";
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -384,7 +385,13 @@ function InjuryHistoryLog({ league }) {
 
 // ── Main Component ───────────────────────────────────────────────────────────
 
-export default function InjuryReport({ league, onPlayerSelect }) {
+export default function InjuryReport({
+  league, onPlayerSelect,
+}) {
+  useEffect(() => {
+    markWeeklyPrepStep(league, 'injuriesReviewed', true);
+  }, [league?.seasonId, league?.week, league?.userTeamId]);
+
   const [posFilter, setPosFilter] = useState("ALL");
   const [sevFilter, setSevFilter] = useState("ALL");
   const [teamFilter, setTeamFilter] = useState("ALL");

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -40,6 +40,7 @@ import AwardRaces from "./AwardRaces.jsx";
 import PlayerStats from "./PlayerStats.jsx";
 import StrategyPanel from "./StrategyPanel.jsx";
 import GamePlanScreen from "./GamePlanScreen.jsx";
+import WeeklyPrepScreen from "./WeeklyPrepScreen.jsx";
 import NewsFeed from "./NewsFeed.jsx";
 import RecordBook from "./RecordBook.jsx";
 import StatLeadersWidget from "./StatLeadersWidget.jsx";
@@ -190,6 +191,7 @@ const BASE_TABS = [
   "League Leaders",
   "Award Races",
   "Analytics",
+  "Weekly Prep",
   "Game Plan",
   "Roster",
   "Depth Chart",
@@ -224,7 +226,7 @@ const BASE_TABS = [
 
 const NAV_GROUPS = [
   { id: SHELL_SECTIONS.hq, title: "HQ", tabs: ["HQ"] },
-  { id: SHELL_SECTIONS.team, title: "Team", tabs: ["Team", "Roster", "Depth Chart", "Game Plan", "Training", "Injuries", "Staff", "Financials", "Contract Center"] },
+  { id: SHELL_SECTIONS.team, title: "Team", tabs: ["Team", "Roster", "Depth Chart", "Weekly Prep", "Game Plan", "Training", "Injuries", "Staff", "Financials", "Contract Center"] },
   { id: SHELL_SECTIONS.league, title: "League", tabs: ["League", "Schedule", "Standings", "Stats", "League Leaders", "Transactions", "History Hub", "History", "Awards & Records", "Season Recap"] },
   { id: SHELL_SECTIONS.news, title: "News", tabs: ["News"] },
 ];
@@ -236,7 +238,7 @@ const NAV_TEST_IDS = {
   [SHELL_SECTIONS.news]: "nav-news",
 };
 
-const TEAM_FACING_TABS = new Set(["Roster", "Depth Chart", "Roster Hub", "Game Plan", "Training", "Injuries", "Staff", "Financials", "Contract Center"]);
+const TEAM_FACING_TABS = new Set(["Roster", "Depth Chart", "Roster Hub", "Weekly Prep", "Game Plan", "Training", "Injuries", "Staff", "Financials", "Contract Center"]);
 const TAB_ALIASES = {
   Trades: "Transactions",
 };
@@ -1304,8 +1306,8 @@ function getPhasePriorityTabs(phase) {
   if (phase === "free_agency") return ["HQ", "Free Agency", "Trades", "Draft"];
   if (phase === "draft") return ["HQ", "Draft", "Mock Draft", "Transactions"];
   if (phase === "preseason") return ["HQ", "Roster Hub", "Depth Chart", "Training"];
-  if (phase === "playoffs") return ["HQ", "Postseason", "Game Plan", "Injuries"];
-  return ["HQ", "Game Plan", "Roster", "Transactions"];
+  if (phase === "playoffs") return ["HQ", "Postseason", "Weekly Prep", "Game Plan", "Injuries"];
+  return ["HQ", "Weekly Prep", "Game Plan", "Roster", "Transactions"];
 }
 
 export default function LeagueDashboard({
@@ -1780,6 +1782,11 @@ export default function LeagueDashboard({
         {activeTab === "Strategy" && (
           <TabErrorBoundary label="Strategy" onNavigate={setActiveTab}>
             <StrategyPanel league={league} actions={actions} />
+          </TabErrorBoundary>
+        )}
+        {activeTab === "Weekly Prep" && (
+          <TabErrorBoundary label="Weekly Prep" onNavigate={setActiveTab}>
+            <WeeklyPrepScreen league={league} onNavigate={setActiveTab} />
           </TabErrorBoundary>
         )}
         {activeTab === "Game Plan" && (

--- a/src/ui/components/WeeklyPrepScreen.jsx
+++ b/src/ui/components/WeeklyPrepScreen.jsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import { EmptyState, SectionCard } from './common/UiPrimitives.jsx';
+import { markWeeklyPrepStep, deriveWeeklyPrepState } from '../utils/weeklyPrep.js';
+
+function TonePill({ tone = 'info', label }) {
+  const palette = {
+    success: { border: 'var(--success)', bg: 'color-mix(in srgb, var(--success) 12%, var(--surface))' },
+    warning: { border: 'var(--warning)', bg: 'color-mix(in srgb, var(--warning) 12%, var(--surface))' },
+    danger: { border: 'var(--danger)', bg: 'color-mix(in srgb, var(--danger) 12%, var(--surface))' },
+    info: { border: 'var(--hairline)', bg: 'var(--surface)' },
+  };
+  const active = palette[tone] ?? palette.info;
+  return (
+    <span style={{ fontSize: 'var(--text-xs)', border: `1px solid ${active.border}`, background: active.bg, borderRadius: 999, padding: '2px 8px' }}>
+      {label}
+    </span>
+  );
+}
+
+export default function WeeklyPrepScreen({ league, onNavigate }) {
+  const prep = useMemo(() => deriveWeeklyPrepState(league), [league]);
+
+  useEffect(() => {
+    markWeeklyPrepStep(league, 'opponentScouted', true);
+  }, [league?.seasonId, league?.week, league?.userTeamId]);
+
+  if (!prep?.nextGame || !prep?.opponent) {
+    return <EmptyState title="Weekly prep unavailable" body="No upcoming opponent found. Open Schedule for next matchup details." />;
+  }
+
+  const openAction = (tab, completionStep = null) => {
+    if (completionStep) markWeeklyPrepStep(league, completionStep, true);
+    onNavigate?.(tab);
+  };
+
+  return (
+    <div className="app-screen-stack" style={{ display: 'grid', gap: 'var(--space-2)' }}>
+      <SectionCard
+        title={`Week ${prep.nextGame.week} Prep · ${prep.nextGame.isHome ? 'vs' : '@'} ${prep.opponent.abbr ?? prep.opponent.name}`}
+        subtitle={`Opponent ${prep.opponentSnapshot.record} · ${prep.opponentSnapshot.homeAway} game`}
+        actions={<TonePill tone={prep.remaining === 0 ? 'success' : 'warning'} label={prep.readinessLabel} />}
+      >
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: 8 }}>
+          <div style={{ fontSize: 'var(--text-xs)' }}><strong>You:</strong> OVR {prep.teamSnapshot.overall} · OFF {prep.teamSnapshot.offense} · DEF {prep.teamSnapshot.defense}</div>
+          <div style={{ fontSize: 'var(--text-xs)' }}><strong>Opp:</strong> OVR {prep.opponentSnapshot.overall} · OFF {prep.opponentSnapshot.offense} · DEF {prep.opponentSnapshot.defense}</div>
+          <div style={{ fontSize: 'var(--text-xs)' }}><strong>Form:</strong> You {prep.teamSnapshot.recentForm.summary} · Opp {prep.opponentSnapshot.recentForm.summary}</div>
+        </div>
+      </SectionCard>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(290px, 1fr))', gap: 'var(--space-2)' }}>
+        <SectionCard title="Opponent scout" subtitle="Football-specific matchup context.">
+          <div style={{ display: 'grid', gap: 8 }}>
+            <div>
+              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}>Strengths</div>
+              <ul style={{ margin: '4px 0 0', paddingLeft: 16 }}>
+                {(prep.opponentStrengths.length ? prep.opponentStrengths : ['No clear dominant opponent edge identified yet.']).map((item) => <li key={item} style={{ fontSize: 'var(--text-sm)' }}>{item}</li>)}
+              </ul>
+            </div>
+            <div>
+              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}>Exploitable weaknesses</div>
+              <ul style={{ margin: '4px 0 0', paddingLeft: 16 }}>
+                {(prep.opponentWeaknesses.length ? prep.opponentWeaknesses : ['No obvious weakness — game script and execution will decide this one.']).map((item) => <li key={item} style={{ fontSize: 'var(--text-sm)' }}>{item}</li>)}
+              </ul>
+            </div>
+            <div>
+              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}>Pressure points</div>
+              <ul style={{ margin: '4px 0 0', paddingLeft: 16 }}>
+                {(prep.pressurePoints.length ? prep.pressurePoints : ['No major pressure point flagged.']).map((item) => <li key={item} style={{ fontSize: 'var(--text-sm)' }}>{item}</li>)}
+              </ul>
+            </div>
+          </div>
+        </SectionCard>
+
+        <SectionCard title="Lineup readiness" subtitle="Depth/injury blockers before kickoff.">
+          <div style={{ display: 'grid', gap: 8 }}>
+            {prep.lineupIssues.length === 0 ? (
+              <div style={{ fontSize: 'var(--text-sm)' }}>No lineup blockers detected. Depth chart and injury coverage look stable.</div>
+            ) : prep.lineupIssues.map((issue) => (
+              <div key={issue.id} style={{ border: '1px solid var(--hairline)', borderRadius: 'var(--radius-md)', padding: 8 }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
+                  <strong style={{ fontSize: 'var(--text-sm)' }}>{issue.label}</strong>
+                  <TonePill tone={issue.level === 'urgent' ? 'danger' : 'warning'} label={issue.level} />
+                </div>
+                <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', marginTop: 2 }}>{issue.detail}</div>
+                <Button size="sm" variant="outline" style={{ marginTop: 6 }} onClick={() => openAction(issue.actionTab, issue.actionTab === 'Injuries' ? 'injuriesReviewed' : 'lineupChecked')}>
+                  {issue.actionLabel}
+                </Button>
+              </div>
+            ))}
+          </div>
+        </SectionCard>
+      </div>
+
+      <SectionCard title="Game plan recommendations" subtitle="Data-driven weekly suggestions.">
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 8 }}>
+          {prep.recommendations.map((card) => (
+            <div key={card.title} style={{ border: '1px solid var(--hairline)', borderRadius: 'var(--radius-md)', padding: 10 }}>
+              <div style={{ fontWeight: 700, fontSize: 'var(--text-sm)' }}>{card.title}</div>
+              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', marginTop: 4 }}>{card.reason}</div>
+              <Button size="sm" variant="outline" style={{ marginTop: 8 }} onClick={() => openAction(card.actionTab, 'planReviewed')}>
+                {card.actionLabel}
+              </Button>
+            </div>
+          ))}
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Prep completion" subtitle="Lightweight weekly readiness checklist.">
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+          <TonePill tone={prep.completion.lineupChecked ? 'success' : 'warning'} label={`Lineup ${prep.completion.lineupChecked ? 'checked' : 'pending'}`} />
+          <TonePill tone={prep.completion.injuriesReviewed ? 'success' : 'warning'} label={`Injuries ${prep.completion.injuriesReviewed ? 'reviewed' : 'pending'}`} />
+          <TonePill tone={prep.completion.opponentScouted ? 'success' : 'warning'} label={`Opponent ${prep.completion.opponentScouted ? 'scouted' : 'pending'}`} />
+          <TonePill tone={prep.completion.planReviewed ? 'success' : 'warning'} label={`Plan ${prep.completion.planReviewed ? 'reviewed' : 'pending'}`} />
+        </div>
+      </SectionCard>
+    </div>
+  );
+}

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -77,6 +77,7 @@ describe('FranchiseHQ', () => {
     expect(html).toContain('Next Game');
     expect(html).toContain('Last Game');
     expect(html).toContain('Matchup note');
+    expect(html).toContain('Prep status');
   });
 
   it('is safe with partial/older save payloads', () => {

--- a/src/ui/components/__tests__/WeeklyPrepScreen.test.jsx
+++ b/src/ui/components/__tests__/WeeklyPrepScreen.test.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import WeeklyPrepScreen from '../WeeklyPrepScreen.jsx';
+
+const league = {
+  year: 2027,
+  week: 8,
+  seasonId: 's8',
+  phase: 'regular',
+  userTeamId: 1,
+  teams: [
+    {
+      id: 1,
+      name: 'Bears',
+      abbr: 'CHI',
+      wins: 5,
+      losses: 2,
+      ovr: 84,
+      offenseRating: 82,
+      defenseRating: 83,
+      recentResults: ['W', 'W', 'L', 'W'],
+      roster: [{ id: 11, pos: 'QB', ovr: 80, teamId: 1 }],
+    },
+    {
+      id: 2,
+      name: 'Lions',
+      abbr: 'DET',
+      wins: 4,
+      losses: 3,
+      ovr: 81,
+      offenseRating: 85,
+      defenseRating: 76,
+      recentResults: ['L', 'W', 'W', 'L'],
+      roster: [],
+    },
+  ],
+  schedule: {
+    weeks: [{ week: 8, games: [{ id: 'g8', home: { id: 1 }, away: { id: 2 }, played: false }] }],
+  },
+};
+
+describe('WeeklyPrepScreen', () => {
+  it('renders prep workflow sections for an upcoming game', () => {
+    const html = renderToString(<WeeklyPrepScreen league={league} onNavigate={vi.fn()} />);
+    expect(html).toContain('Opponent scout');
+    expect(html).toContain('Lineup readiness');
+    expect(html).toContain('Game plan recommendations');
+    expect(html).toContain('Prep completion');
+  });
+
+  it('handles missing matchup data safely', () => {
+    const html = renderToString(
+      <WeeklyPrepScreen
+        league={{ year: 2027, week: 1, userTeamId: 1, teams: [{ id: 1, name: 'Legacy', roster: [] }], schedule: { weeks: [] } }}
+        onNavigate={vi.fn()}
+      />,
+    );
+    expect(html).toContain('Weekly prep unavailable');
+  });
+});

--- a/src/ui/utils/hqHelpers.js
+++ b/src/ui/utils/hqHelpers.js
@@ -118,7 +118,7 @@ export function getActionDestination(type, nextGame) {
     case 'news':
       return nextGame ? 'Injuries' : 'News';
     case 'opponent':
-      return nextGame ? 'Game Plan' : 'Schedule';
+      return nextGame ? 'Weekly Prep' : 'Schedule';
     default:
       return 'HQ';
   }

--- a/src/ui/utils/hqHelpers.test.js
+++ b/src/ui/utils/hqHelpers.test.js
@@ -46,7 +46,7 @@ describe('hqHelpers', () => {
     expect(getActionContext('lineup', weekly, nextGame)).toContain('3 injury');
     expect(getActionContext('gameplan', weekly, nextGame)).toContain('explosive offense');
     expect(getActionDestination('lineup', nextGame)).toBe('Roster:depth|ALL');
-    expect(getActionDestination('opponent', nextGame)).toBe('Game Plan');
+    expect(getActionDestination('opponent', nextGame)).toBe('Weekly Prep');
   });
 
   it('ranks a featured urgent item and limits secondary items', () => {

--- a/src/ui/utils/shellNavigation.js
+++ b/src/ui/utils/shellNavigation.js
@@ -29,6 +29,7 @@ const TAB_TO_SECTION = Object.freeze({
   Roster: SHELL_SECTIONS.team,
   'Depth Chart': SHELL_SECTIONS.team,
   'Roster Hub': SHELL_SECTIONS.team,
+  'Weekly Prep': SHELL_SECTIONS.team,
   'Game Plan': SHELL_SECTIONS.team,
   Training: SHELL_SECTIONS.team,
   Injuries: SHELL_SECTIONS.team,

--- a/src/ui/utils/weeklyPrep.js
+++ b/src/ui/utils/weeklyPrep.js
@@ -1,0 +1,371 @@
+import { autoBuildDepthChart, depthWarnings, DEPTH_CHART_ROWS } from '../../core/depthChart.js';
+
+const PREP_STORAGE_KEY = 'footballgm_weekly_prep_v1';
+
+function safeNum(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function getTeam(league, teamId) {
+  const teams = Array.isArray(league?.teams) ? league.teams : [];
+  return teams.find((team) => Number(team?.id) === Number(teamId)) ?? null;
+}
+
+export function getNextGame(league) {
+  const uid = Number(league?.userTeamId);
+  for (const week of league?.schedule?.weeks ?? []) {
+    for (const game of week?.games ?? []) {
+      if (game?.played) continue;
+      const homeId = Number(game?.home?.id ?? game?.home);
+      const awayId = Number(game?.away?.id ?? game?.away);
+      if (homeId !== uid && awayId !== uid) continue;
+      const isHome = homeId === uid;
+      const oppId = isHome ? awayId : homeId;
+      return {
+        week: safeNum(week?.week, safeNum(league?.week, 1)),
+        isHome,
+        oppId,
+        opp: getTeam(league, oppId),
+        game,
+      };
+    }
+  }
+  return null;
+}
+
+function getTeamRating(team, type = 'ovr') {
+  if (type === 'offense') return safeNum(team?.offenseRating ?? team?.offRating ?? team?.offense ?? team?.offOvr);
+  if (type === 'defense') return safeNum(team?.defenseRating ?? team?.defRating ?? team?.defense ?? team?.defOvr);
+  return safeNum(team?.ovr);
+}
+
+function getRecord(team) {
+  const wins = safeNum(team?.wins);
+  const losses = safeNum(team?.losses);
+  const ties = safeNum(team?.ties);
+  return `${wins}-${losses}${ties ? `-${ties}` : ''}`;
+}
+
+function getRecentForm(team, league) {
+  const explicit = Array.isArray(team?.recentResults)
+    ? team.recentResults.filter((value) => typeof value === 'string' && value.trim()).map((value) => value.trim().charAt(0).toUpperCase())
+    : [];
+  const sample = explicit.slice(-5);
+  if (sample.length > 0) {
+    const wins = sample.filter((value) => value === 'W').length;
+    const losses = sample.filter((value) => value === 'L').length;
+    return { sample, summary: `${wins}-${losses} in last ${sample.length}` };
+  }
+
+  const uid = Number(team?.id);
+  const results = [];
+  for (const week of [...(league?.schedule?.weeks ?? [])].sort((a, b) => safeNum(a?.week) - safeNum(b?.week))) {
+    for (const game of week?.games ?? []) {
+      if (!game?.played) continue;
+      const homeId = Number(game?.home?.id ?? game?.home);
+      const awayId = Number(game?.away?.id ?? game?.away);
+      if (homeId !== uid && awayId !== uid) continue;
+      const homeScore = safeNum(game?.homeScore ?? game?.score?.home);
+      const awayScore = safeNum(game?.awayScore ?? game?.score?.away);
+      if (homeScore === awayScore) results.push('T');
+      else if ((homeId === uid && homeScore > awayScore) || (awayId === uid && awayScore > homeScore)) results.push('W');
+      else results.push('L');
+    }
+  }
+  const tail = results.slice(-5);
+  if (!tail.length) return { sample: [], summary: 'No form sample yet' };
+  const wins = tail.filter((value) => value === 'W').length;
+  const losses = tail.filter((value) => value === 'L').length;
+  return { sample: tail, summary: `${wins}-${losses} in last ${tail.length}` };
+}
+
+function isPlayerInjured(player) {
+  return safeNum(player?.injuryWeeksRemaining ?? player?.injuredWeeks ?? player?.injuryDuration ?? 0) > 0
+    || ['injured', 'ir'].includes(String(player?.status ?? '').toLowerCase());
+}
+
+function getExistingAssignments(roster) {
+  const assignments = {};
+  for (const player of roster) {
+    const rowKey = player?.depthChart?.rowKey;
+    if (!rowKey) continue;
+    if (!assignments[rowKey]) assignments[rowKey] = [];
+    assignments[rowKey].push(Number(player.id));
+  }
+  return assignments;
+}
+
+function getPositionGroup(pos) {
+  const normalized = String(pos ?? '').toUpperCase();
+  const row = DEPTH_CHART_ROWS.find((entry) => entry.match.includes(normalized));
+  return row?.key ?? normalized;
+}
+
+function buildLineupReadiness(userTeam, league) {
+  const roster = Array.isArray(userTeam?.roster) ? userTeam.roster : [];
+  const assignments = autoBuildDepthChart(roster, getExistingAssignments(roster));
+  const issues = [];
+
+  for (const warning of depthWarnings(assignments, roster)) {
+    issues.push({
+      id: `depth-${warning.rowKey}-${warning.message}`,
+      level: warning.severity === 'error' ? 'urgent' : 'warning',
+      label: warning.severity === 'error' ? 'Depth chart blocker' : 'Depth risk',
+      detail: warning.message,
+      actionLabel: 'Fix depth chart',
+      actionTab: 'Roster:depth|ALL',
+    });
+  }
+
+  const byId = new Map(roster.map((player) => [Number(player.id), player]));
+  for (const row of DEPTH_CHART_ROWS) {
+    const starterId = assignments?.[row.key]?.[0];
+    const starter = byId.get(Number(starterId));
+    if (!starter) continue;
+    if (safeNum(starter?.ovr, 99) <= 62) {
+      issues.push({
+        id: `starter-low-${row.key}`,
+        level: 'warning',
+        label: 'Low-rated starter in key slot',
+        detail: `${row.label} is led by a low-rated starter (${safeNum(starter?.ovr)} OVR).`,
+        actionLabel: 'Adjust lineup',
+        actionTab: 'Roster:depth|ALL',
+      });
+    }
+  }
+
+  const injured = roster.filter(isPlayerInjured);
+  const injuredByGroup = injured.reduce((acc, player) => {
+    const group = getPositionGroup(player?.pos);
+    acc[group] = (acc[group] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  for (const [group, count] of Object.entries(injuredByGroup)) {
+    if (count < 2) continue;
+    const row = DEPTH_CHART_ROWS.find((entry) => entry.key === group);
+    issues.push({
+      id: `inj-group-${group}`,
+      level: count >= 3 ? 'urgent' : 'warning',
+      label: 'Position group injury stack',
+      detail: `${count} injuries in ${row?.label ?? group} this week.`,
+      actionLabel: 'Review injuries',
+      actionTab: 'Injuries',
+    });
+  }
+
+  if (String(league?.phase) === 'preseason' && roster.length > 53) {
+    issues.push({
+      id: 'roster-cutdown',
+      level: 'urgent',
+      label: 'Roster cutdown required',
+      detail: `${roster.length} players rostered before regular-season cap.`,
+      actionLabel: 'Open roster',
+      actionTab: 'Roster Hub',
+    });
+  }
+
+  const seen = new Set();
+  return issues.filter((issue) => {
+    const key = `${issue.label}|${issue.detail}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  }).slice(0, 6);
+}
+
+function createRecommendationCards({ userTeam, opponent, matchup }) {
+  if (!userTeam || !opponent) return [];
+  const cards = [];
+  const userOff = getTeamRating(userTeam, 'offense');
+  const userDef = getTeamRating(userTeam, 'defense');
+  const oppOff = getTeamRating(opponent, 'offense');
+  const oppDef = getTeamRating(opponent, 'defense');
+
+  if (oppDef >= 85) {
+    cards.push({
+      title: 'Protect against elite pass rush',
+      reason: `${opponent.abbr ?? opponent.name} grades ${oppDef} on defense; limit long-developing dropbacks.`,
+      actionLabel: 'Tune game plan',
+      actionTab: 'Game Plan',
+    });
+  }
+
+  if (oppDef <= 76 || userOff - oppDef >= 6) {
+    cards.push({
+      title: 'Attack weak secondary',
+      reason: `Your offense (${userOff}) has a favorable efficiency window against their defense (${oppDef}).`,
+      actionLabel: 'Open game plan',
+      actionTab: 'Game Plan',
+    });
+  }
+
+  if (oppOff >= 84 && userDef - oppOff <= -2) {
+    cards.push({
+      title: 'Contain explosive offense',
+      reason: `${opponent.abbr ?? opponent.name} offense (${oppOff}) can force shootouts if tempo gets loose.`,
+      actionLabel: 'Adjust defense',
+      actionTab: 'Game Plan',
+    });
+  }
+
+  if (matchup.ovrGap <= -5) {
+    cards.push({
+      title: 'Shorten the game',
+      reason: `You are an underdog by ${Math.abs(matchup.ovrGap)} OVR. Reduce possessions and avoid variance spikes.`,
+      actionLabel: 'Set conservative plan',
+      actionTab: 'Game Plan',
+    });
+  }
+
+  if (matchup.ovrGap >= 5) {
+    cards.push({
+      title: 'Stay aggressive with talent edge',
+      reason: `You hold a +${matchup.ovrGap} OVR edge. Press advantages instead of playing passive.`,
+      actionLabel: 'Lock plan',
+      actionTab: 'Game Plan',
+    });
+  }
+
+  if (!cards.length) {
+    cards.push({
+      title: 'Balanced script recommended',
+      reason: 'Ratings are close. Win with situational football and clean execution.',
+      actionLabel: 'Review game plan',
+      actionTab: 'Game Plan',
+    });
+  }
+
+  return cards.slice(0, 3);
+}
+
+function readStoredPrepProgress() {
+  if (typeof window === 'undefined') return {};
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(PREP_STORAGE_KEY) ?? '{}');
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function prepProgressKey(league) {
+  return `${league?.seasonId ?? league?.year ?? 'season'}:${league?.week ?? 1}:${league?.userTeamId ?? 'user'}`;
+}
+
+function writeStoredPrepProgress(allProgress) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(PREP_STORAGE_KEY, JSON.stringify(allProgress));
+  } catch {
+    // no-op on quota/permission issues
+  }
+}
+
+export function getWeeklyPrepProgress(league) {
+  const all = readStoredPrepProgress();
+  const key = prepProgressKey(league);
+  return {
+    lineupChecked: false,
+    injuriesReviewed: false,
+    opponentScouted: false,
+    planReviewed: false,
+    ...(all?.[key] ?? {}),
+  };
+}
+
+export function markWeeklyPrepStep(league, step, value = true) {
+  if (!league || !step) return;
+  const key = prepProgressKey(league);
+  const all = readStoredPrepProgress();
+  all[key] = {
+    lineupChecked: false,
+    injuriesReviewed: false,
+    opponentScouted: false,
+    planReviewed: false,
+    ...(all?.[key] ?? {}),
+    [step]: value,
+  };
+  writeStoredPrepProgress(all);
+}
+
+export function deriveWeeklyPrepState(league) {
+  const userTeam = getTeam(league, league?.userTeamId);
+  const nextGame = getNextGame(league);
+  const opponent = nextGame?.opp ?? null;
+  const userOff = getTeamRating(userTeam, 'offense');
+  const userDef = getTeamRating(userTeam, 'defense');
+  const oppOff = getTeamRating(opponent, 'offense');
+  const oppDef = getTeamRating(opponent, 'defense');
+
+  const matchup = {
+    ovrGap: getTeamRating(userTeam, 'ovr') - getTeamRating(opponent, 'ovr'),
+    offenseGap: userOff - oppDef,
+    defenseGap: userDef - oppOff,
+  };
+
+  const opponentStrengths = [];
+  if (oppOff >= 84) opponentStrengths.push(`Top-tier offense (${oppOff}) can create explosive drives.`);
+  if (oppDef >= 84) opponentStrengths.push(`Defensive unit (${oppDef}) forces difficult down-and-distance situations.`);
+  if (safeNum(opponent?.wins) - safeNum(opponent?.losses) >= 3) opponentStrengths.push(`Winning profile (${getRecord(opponent)}) indicates consistent execution.`);
+
+  const opponentWeaknesses = [];
+  if (oppDef <= 76) opponentWeaknesses.push(`Defense rating (${oppDef}) is vulnerable to sustained drives.`);
+  if (oppOff <= 76) opponentWeaknesses.push(`Offense rating (${oppOff}) struggles to finish possessions.`);
+  if (safeNum(opponent?.ptsAgainst) - safeNum(opponent?.ptsFor) >= 20) opponentWeaknesses.push('Point differential trend suggests late-game leakage.');
+
+  const lineupIssues = buildLineupReadiness(userTeam, league);
+  const recommendations = createRecommendationCards({ userTeam, opponent, matchup });
+
+  const pressurePoints = [];
+  if (matchup.defenseGap <= -4) pressurePoints.push('Defensive front must limit explosive passing downs.');
+  if (matchup.offenseGap <= -4) pressurePoints.push('Offense needs efficient early-down execution to avoid third-and-long.');
+  if (lineupIssues.some((issue) => issue.level === 'urgent')) pressurePoints.push('Current lineup issues can materially swing this matchup.');
+
+  const progress = getWeeklyPrepProgress(league);
+  const completion = {
+    lineupChecked: progress.lineupChecked || lineupIssues.length === 0,
+    injuriesReviewed: progress.injuriesReviewed || !lineupIssues.some((issue) => issue.actionTab === 'Injuries'),
+    opponentScouted: progress.opponentScouted,
+    planReviewed: progress.planReviewed,
+  };
+
+  const remaining = Object.values(completion).filter((done) => !done).length;
+  const readinessLabel = remaining === 0 ? 'Ready for kickoff' : `${remaining} prep item${remaining > 1 ? 's' : ''} remaining`;
+
+  return {
+    userTeam,
+    nextGame,
+    opponent,
+    matchup,
+    opponentSnapshot: opponent
+      ? {
+        record: getRecord(opponent),
+        homeAway: nextGame?.isHome ? 'Home' : 'Away',
+        overall: getTeamRating(opponent, 'ovr'),
+        offense: oppOff,
+        defense: oppDef,
+        recentForm: getRecentForm(opponent, league),
+      }
+      : null,
+    teamSnapshot: userTeam
+      ? {
+        record: getRecord(userTeam),
+        overall: getTeamRating(userTeam, 'ovr'),
+        offense: userOff,
+        defense: userDef,
+        recentForm: getRecentForm(userTeam, league),
+      }
+      : null,
+    opponentStrengths: opponentStrengths.slice(0, 2),
+    opponentWeaknesses: opponentWeaknesses.slice(0, 2),
+    pressurePoints: pressurePoints.slice(0, 2),
+    lineupIssues,
+    recommendations,
+    completion,
+    remaining,
+    readinessLabel,
+    keyMatchupNote: recommendations?.[0]?.title ?? 'No clear tactical edge identified yet.',
+  };
+}

--- a/src/ui/utils/weeklyPrep.test.js
+++ b/src/ui/utils/weeklyPrep.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { deriveWeeklyPrepState } from './weeklyPrep.js';
+
+const league = {
+  year: 2028,
+  week: 6,
+  seasonId: 's-2028',
+  phase: 'regular',
+  userTeamId: 1,
+  teams: [
+    {
+      id: 1,
+      name: 'Bears',
+      abbr: 'CHI',
+      wins: 4,
+      losses: 1,
+      ovr: 85,
+      offenseRating: 84,
+      defenseRating: 82,
+      recentResults: ['W', 'W', 'L', 'W', 'W'],
+      roster: [
+        { id: 11, pos: 'QB', ovr: 86, teamId: 1, depthChart: { rowKey: 'QB' } },
+        { id: 12, pos: 'RB', ovr: 80, teamId: 1, injuredWeeks: 3, depthChart: { rowKey: 'RB' } },
+        { id: 13, pos: 'RB', ovr: 67, teamId: 1 },
+        { id: 14, pos: 'WR', ovr: 78, teamId: 1 },
+      ],
+      strategies: { offSchemeId: 'WEST_COAST' },
+    },
+    {
+      id: 2,
+      name: 'Lions',
+      abbr: 'DET',
+      wins: 2,
+      losses: 3,
+      ovr: 80,
+      offenseRating: 87,
+      defenseRating: 74,
+      recentResults: ['L', 'L', 'W', 'L', 'W'],
+      ptsFor: 110,
+      ptsAgainst: 145,
+      roster: [],
+    },
+  ],
+  schedule: {
+    weeks: [
+      { week: 6, games: [{ id: 'g6', home: { id: 1 }, away: { id: 2 }, played: false }] },
+    ],
+  },
+};
+
+describe('weeklyPrep', () => {
+  it('builds opponent scout/readiness model from league context', () => {
+    const prep = deriveWeeklyPrepState(league);
+    expect(prep.opponentSnapshot.record).toBe('2-3');
+    expect(prep.opponentStrengths.length).toBeGreaterThan(0);
+    expect(prep.opponentWeaknesses.length).toBeGreaterThan(0);
+    expect(prep.lineupIssues.length).toBeGreaterThan(0);
+    expect(prep.recommendations.length).toBeGreaterThan(0);
+    expect(prep.readinessLabel).toContain('remaining');
+  });
+
+  it('is safe with partial saves and missing opponent data', () => {
+    const prep = deriveWeeklyPrepState({
+      year: 2028,
+      week: 1,
+      userTeamId: 1,
+      teams: [{ id: 1, name: 'Legacy', roster: [] }],
+      schedule: { weeks: [] },
+    });
+
+    expect(prep.nextGame).toBeNull();
+    expect(prep.recommendations).toEqual([]);
+    expect(Array.isArray(prep.lineupIssues)).toBe(true);
+    expect(prep.readinessLabel).toContain('remaining');
+  });
+});


### PR DESCRIPTION
### Motivation
- HQ needed a dedicated, football-specific weekly preparation surface so “Prepare Game” leads into meaningful, actionable weekly work rather than generic screens. 
- The workflow must surface opponent scouting, lineup readiness, injury/depth impacts, and game-plan recommendations driven by real team/game data. 
- A lightweight completion model helps players understand readiness before advancing the week.

### Description
- Add a data-driven prep model in `src/ui/utils/weeklyPrep.js` that derives matchup context from schedule, team ratings, recent form, depth-chart warnings, and injuries, and persists simple prep progress to `localStorage` via `markWeeklyPrepStep` and `getWeeklyPrepProgress`.
- Introduce `WeeklyPrepScreen` (`src/ui/components/WeeklyPrepScreen.jsx`) which renders opponent strengths/weaknesses, pressure points, lineup readiness issues with direct navigation actions, game-plan recommendation cards, and a prep-completion checklist.
- Wire Weekly Prep into the UI and routing by adding it to the dashboard tabs and shell mapping (`src/ui/components/LeagueDashboard.jsx`, `src/ui/utils/shellNavigation.js`), and update HQ so “Prepare Game” and “Scout opponent” route into Weekly Prep and surface a concise prep status and key matchup note (`src/ui/components/FranchiseHQ.jsx`, `src/ui/utils/hqHelpers.js`).
- Mark downstream actions to contribute to prep completion: opening Game Plan sets `planReviewed` (`src/ui/components/GamePlanScreen.jsx`) and opening Injuries sets `injuriesReviewed` (`src/ui/components/InjuryReport.jsx`), and setting a valid lineup marks `lineupChecked`.
- Add tests covering the new model and UI: `src/ui/utils/weeklyPrep.test.js`, `src/ui/components/__tests__/WeeklyPrepScreen.test.jsx`, and update HQ-related assertions (`src/ui/components/__tests__/FranchiseHQ.test.jsx`, `src/ui/utils/hqHelpers.test.js`).

### Testing
- Ran the targeted unit suite with `npx vitest run src/ui/utils/hqHelpers.test.js src/ui/utils/weeklyPrep.test.js src/ui/components/__tests__/WeeklyPrepScreen.test.jsx src/ui/components/__tests__/FranchiseHQ.test.jsx` and all tests passed (11 tests across 4 files).
- Added regression tests for the prep derivation (`deriveWeeklyPrepState`) and screen rendering for both full and missing opponent data, and updated HQ routing/label assertions; these tests succeeded under the vitest run. 
- Manual safety: new code uses existing depth-chart and rating helpers and includes defensive fallbacks for partial/legacy saves to avoid render crashes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1f500e678832d82d3c2932d21a45a)