### PR TITLE
Connect Weekly Prep to deterministic rich-sim modifiers

### DIFF
--- a/src/core/__tests__/gamePlanMultipliers.test.ts
+++ b/src/core/__tests__/gamePlanMultipliers.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { deriveGamePlanMultipliers, getGamePlanSynergySummary } from '../sim/gamePlanMultipliers.ts';
+
+describe('gamePlanMultipliers', () => {
+  it('applies pass synergy for weak secondary with pass-heavy plan', () => {
+    const multipliers = deriveGamePlanMultipliers({
+      weeklyPrepState: {
+        insights: { weakSecondary: true },
+        completion: { lineupChecked: true, injuriesReviewed: true, opponentScouted: true, planReviewed: true },
+        hasTracking: true,
+      },
+      gamePlan: { runPassBalance: 70, deepShortBalance: 58, aggressionLevel: 55 },
+      teamContext: { hasBlockingLineupIssue: false, majorInjuryStress: false },
+    });
+
+    expect(multipliers.passSuccessDelta).toBeGreaterThan(0);
+    expect(multipliers.rushSuccessDelta).toBe(0);
+    expect(multipliers.activeReasons.join(' ')).toContain('Pass Attack Edge');
+  });
+
+  it('does not grant pass synergy when weak secondary meets run-heavy plan', () => {
+    const multipliers = deriveGamePlanMultipliers({
+      weeklyPrepState: {
+        insights: { weakSecondary: true },
+        completion: { lineupChecked: true, injuriesReviewed: true, opponentScouted: true, planReviewed: true },
+        hasTracking: true,
+      },
+      gamePlan: { runPassBalance: 30 },
+      teamContext: { hasBlockingLineupIssue: false, majorInjuryStress: false },
+    });
+
+    expect(multipliers.passSuccessDelta).toBe(0);
+    expect(multipliers.activeReasons.join(' ')).not.toContain('Pass Attack Edge');
+  });
+
+  it('penalizes skipped injury review when injury stress is active', () => {
+    const multipliers = deriveGamePlanMultipliers({
+      weeklyPrepState: {
+        insights: {},
+        completion: { injuriesReviewed: false, lineupChecked: true, opponentScouted: true, planReviewed: true },
+        hasTracking: true,
+      },
+      gamePlan: { runPassBalance: 50 },
+      teamContext: { hasBlockingLineupIssue: false, majorInjuryStress: true },
+    });
+
+    expect(multipliers.turnoverAvoidanceDelta).toBeLessThan(0);
+    expect(multipliers.chemistryPenalty).toBeLessThan(0);
+    expect(multipliers.activeReasons.join(' ')).toContain('Injury Review Missing');
+  });
+
+  it('penalizes invalid lineup more than missed checkbox-only prep', () => {
+    const checkboxOnly = deriveGamePlanMultipliers({
+      weeklyPrepState: {
+        insights: {},
+        completion: { lineupChecked: false, injuriesReviewed: true, opponentScouted: true, planReviewed: true },
+        hasTracking: true,
+      },
+      teamContext: { hasBlockingLineupIssue: false, majorInjuryStress: false },
+    });
+
+    const invalidLineup = deriveGamePlanMultipliers({
+      weeklyPrepState: {
+        insights: {},
+        completion: { lineupChecked: true, injuriesReviewed: true, opponentScouted: true, planReviewed: true },
+        hasTracking: true,
+      },
+      teamContext: { hasBlockingLineupIssue: true, majorInjuryStress: false },
+    });
+
+    expect(Math.abs(invalidLineup.netImpact)).toBeGreaterThan(Math.abs(checkboxOnly.netImpact));
+  });
+
+  it('is deterministic and safe with partial missing state', () => {
+    const input = {
+      weeklyPrepState: {
+        insights: { balancedMatchup: true },
+      },
+      gamePlan: { runPassBalance: 80 },
+      teamContext: {},
+    };
+
+    const one = deriveGamePlanMultipliers(input);
+    const two = deriveGamePlanMultipliers(input);
+
+    expect(one).toEqual(two);
+
+    const summary = getGamePlanSynergySummary(one);
+    expect(['Ready', 'Minor risk', 'Major risk']).toContain(summary.status);
+  });
+});

--- a/src/core/__tests__/richGameSimulator.test.ts
+++ b/src/core/__tests__/richGameSimulator.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it } from 'vitest';
 import { mapOverallToAttributesV2 } from '../migration/attributeMigrator.ts';
 import { simulateRichGame } from '../sim/richGameSimulator.ts';
+import type { DerivedGamePlanMultipliers } from '../sim/gamePlanMultipliers.ts';
+
+const PREP_EDGE: DerivedGamePlanMultipliers = {
+  passSuccessDelta: 0.03,
+  rushSuccessDelta: 0,
+  explosivePlayDelta: 0.01,
+  turnoverAvoidanceDelta: 0.01,
+  redZoneDelta: 0.005,
+  fatigueDisciplineDelta: 0.01,
+  chemistryPenalty: 0,
+  score: 0.065,
+  netImpact: 0.065,
+  severity: 'ready',
+  activeReasons: ['Test prep edge'],
+};
 
 function buildPayload(seed = 7) {
   return {
@@ -33,6 +48,7 @@ function buildPayload(seed = 7) {
       { id: 'a-lb', name: 'Away LB', pos: 'LB', ovr: 80 },
       { id: 'a-cb', name: 'Away CB', pos: 'CB', ovr: 81 },
     ],
+    homePrepMultipliers: PREP_EDGE,
   };
 }
 
@@ -73,5 +89,11 @@ describe('simulateRichGame', () => {
     expect(homePassRate).toBeLessThan(0.85);
     expect(awayPassRate).toBeGreaterThan(0.25);
     expect(awayPassRate).toBeLessThan(0.85);
+  });
+
+  it('accepts prep multipliers and keeps deterministic behavior for same inputs', () => {
+    const one = simulateRichGame(buildPayload(455));
+    const two = simulateRichGame(buildPayload(455));
+    expect(one).toEqual(two);
   });
 });

--- a/src/core/sim/gamePlanMultipliers.ts
+++ b/src/core/sim/gamePlanMultipliers.ts
@@ -1,0 +1,276 @@
+export interface PrepInsightFlags {
+  weakSecondary?: boolean;
+  weakRunDefense?: boolean;
+  elitePassRush?: boolean;
+  explosiveOpponentOffense?: boolean;
+  balancedMatchup?: boolean;
+}
+
+export interface PrepCompletionState {
+  lineupChecked?: boolean;
+  injuriesReviewed?: boolean;
+  opponentScouted?: boolean;
+  planReviewed?: boolean;
+}
+
+export interface WeeklyPrepStateLike {
+  insights?: PrepInsightFlags;
+  completion?: PrepCompletionState;
+  hasTracking?: boolean;
+}
+
+export interface GamePlanLike {
+  runPassBalance?: number;
+  aggressionLevel?: number;
+  deepShortBalance?: number;
+}
+
+export interface TeamReadinessContext {
+  hasBlockingLineupIssue?: boolean;
+  majorInjuryStress?: boolean;
+}
+
+export interface DerivedGamePlanMultipliers {
+  passSuccessDelta: number;
+  rushSuccessDelta: number;
+  explosivePlayDelta: number;
+  turnoverAvoidanceDelta: number;
+  redZoneDelta: number;
+  fatigueDisciplineDelta: number;
+  chemistryPenalty: number;
+  score: number;
+  netImpact: number;
+  severity: 'ready' | 'minor_risk' | 'major_risk';
+  activeReasons: string[];
+}
+
+const TUNING = Object.freeze({
+  PASS_SYNERGY_BONUS: 0.03,
+  PASS_EXPLOSIVE_BONUS: 0.012,
+  RUN_SYNERGY_BONUS: 0.03,
+  PROTECTION_PASS_BONUS: 0.015,
+  PROTECTION_TURNOVER_BONUS: 0.02,
+  TEMPO_CONTROL_TURNOVER_BONUS: 0.016,
+  TEMPO_CONTROL_DISCIPLINE_BONUS: 0.016,
+  RED_ZONE_EXECUTION_BONUS: 0.01,
+
+  PLAN_REVIEW_MISS_PENALTY: 0.008,
+  LINEUP_REVIEW_MISS_PENALTY: 0.012,
+  INJURY_REVIEW_MISS_PENALTY: 0.015,
+  INJURY_REVIEW_MISS_CHEMISTRY: 0.02,
+  UNCHECKED_OPPONENT_SCOUT_PENALTY: 0.006,
+
+  INJURY_STRESS_PENALTY: 0.012,
+  INVALID_LINEUP_PENALTY: 0.024,
+  INVALID_LINEUP_CHEMISTRY_PENALTY: 0.055,
+
+  EXTREME_UNSUPPORTED_PLAN_PENALTY: 0.01,
+
+  MAX_TOTAL_PREP_BONUS: 0.06,
+  MAX_TOTAL_PREP_PENALTY: 0.08,
+});
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function toNumber(value: unknown, fallback: number): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function capPositive(value: number): number {
+  return clamp(value, 0, TUNING.MAX_TOTAL_PREP_BONUS);
+}
+
+function capNegative(value: number): number {
+  return clamp(value, -TUNING.MAX_TOTAL_PREP_PENALTY, 0);
+}
+
+function pushReason(reasons: string[], reason: string): void {
+  if (!reason || reasons.includes(reason)) return;
+  reasons.push(reason);
+}
+
+export function deriveGamePlanMultipliers({
+  weeklyPrepState,
+  gamePlan,
+  teamContext,
+}: {
+  weeklyPrepState?: WeeklyPrepStateLike | null;
+  gamePlan?: GamePlanLike | null;
+  teamContext?: TeamReadinessContext | null;
+  opponentContext?: TeamReadinessContext | null;
+}): DerivedGamePlanMultipliers {
+  const prep = weeklyPrepState ?? {};
+  const insights = prep.insights ?? {};
+  const completion = prep.completion ?? {};
+  const hasTracking = Boolean(prep.hasTracking);
+
+  const runPassBalance = toNumber(gamePlan?.runPassBalance, 50);
+  const aggressionLevel = toNumber(gamePlan?.aggressionLevel, 50);
+  const deepShortBalance = toNumber(gamePlan?.deepShortBalance, 50);
+
+  const passHeavy = runPassBalance >= 60;
+  const runHeavy = runPassBalance <= 40;
+  const quickGame = deepShortBalance <= 42;
+  const conservativeTempo = aggressionLevel <= 45;
+  const extremePlan = Math.abs(runPassBalance - 50) >= 30;
+
+  let passSuccessDelta = 0;
+  let rushSuccessDelta = 0;
+  let explosivePlayDelta = 0;
+  let turnoverAvoidanceDelta = 0;
+  let redZoneDelta = 0;
+  let fatigueDisciplineDelta = 0;
+  let chemistryPenalty = 0;
+
+  const reasons: string[] = [];
+  let synergyApplied = false;
+
+  // --- Matchup synergy family: scouting report aligned with chosen game plan ---
+  if (insights.weakSecondary && passHeavy) {
+    synergyApplied = true;
+    passSuccessDelta += TUNING.PASS_SYNERGY_BONUS;
+    explosivePlayDelta += TUNING.PASS_EXPLOSIVE_BONUS;
+    pushReason(reasons, 'Pass Attack Edge: pass-heavy plan aligns with opponent weak secondary.');
+  }
+
+  if (insights.weakRunDefense && runHeavy) {
+    synergyApplied = true;
+    rushSuccessDelta += TUNING.RUN_SYNERGY_BONUS;
+    redZoneDelta += TUNING.RED_ZONE_EXECUTION_BONUS;
+    pushReason(reasons, 'Run Matchup Advantage: run-heavy script targets a soft front.');
+  }
+
+  if (insights.elitePassRush && quickGame) {
+    synergyApplied = true;
+    passSuccessDelta += TUNING.PROTECTION_PASS_BONUS;
+    turnoverAvoidanceDelta += TUNING.PROTECTION_TURNOVER_BONUS;
+    fatigueDisciplineDelta += TUNING.PROTECTION_PASS_BONUS;
+    pushReason(reasons, 'Protection Plan Active: quick-game focus offsets elite pass rush pressure.');
+  }
+
+  if (insights.explosiveOpponentOffense && conservativeTempo && runPassBalance <= 55) {
+    synergyApplied = true;
+    turnoverAvoidanceDelta += TUNING.TEMPO_CONTROL_TURNOVER_BONUS;
+    fatigueDisciplineDelta += TUNING.TEMPO_CONTROL_DISCIPLINE_BONUS;
+    pushReason(reasons, 'Strategy Synergy: lower-variance tempo helps contain an explosive opponent offense.');
+  }
+
+  if (insights.balancedMatchup && extremePlan && !synergyApplied) {
+    chemistryPenalty -= TUNING.EXTREME_UNSUPPORTED_PLAN_PENALTY;
+    pushReason(reasons, 'No scouting support for an extreme plan in a balanced matchup.');
+  }
+
+  // --- Readiness penalty family: skipped workflow checks and lineup stress ---
+  if (hasTracking && completion.planReviewed === false) {
+    passSuccessDelta -= TUNING.PLAN_REVIEW_MISS_PENALTY;
+    rushSuccessDelta -= TUNING.PLAN_REVIEW_MISS_PENALTY;
+    pushReason(reasons, 'Readiness Penalty Active: game plan review not completed.');
+  }
+
+  if (hasTracking && completion.lineupChecked === false) {
+    chemistryPenalty -= TUNING.LINEUP_REVIEW_MISS_PENALTY;
+    pushReason(reasons, 'Lineup Risk: lineup readiness check was skipped.');
+  }
+
+  if (hasTracking && completion.opponentScouted === false) {
+    passSuccessDelta -= TUNING.UNCHECKED_OPPONENT_SCOUT_PENALTY;
+    rushSuccessDelta -= TUNING.UNCHECKED_OPPONENT_SCOUT_PENALTY;
+    pushReason(reasons, 'Scouting gap: opponent tendencies were not reviewed this week.');
+  }
+
+  if (teamContext?.majorInjuryStress) {
+    fatigueDisciplineDelta -= TUNING.INJURY_STRESS_PENALTY;
+    pushReason(reasons, 'Injury stress is active in key position groups.');
+    if (hasTracking && completion.injuriesReviewed === false) {
+      turnoverAvoidanceDelta -= TUNING.INJURY_REVIEW_MISS_PENALTY;
+      chemistryPenalty -= TUNING.INJURY_REVIEW_MISS_CHEMISTRY;
+      pushReason(reasons, 'Injury Review Missing: key injury impacts were not reviewed.');
+    }
+  }
+
+  if (teamContext?.hasBlockingLineupIssue) {
+    passSuccessDelta -= TUNING.INVALID_LINEUP_PENALTY;
+    rushSuccessDelta -= TUNING.INVALID_LINEUP_PENALTY;
+    chemistryPenalty -= TUNING.INVALID_LINEUP_CHEMISTRY_PENALTY;
+    pushReason(reasons, 'Major Lineup Risk: depth chart blockers are unresolved.');
+  }
+
+  passSuccessDelta = capNegative(passSuccessDelta) + capPositive(passSuccessDelta);
+  rushSuccessDelta = capNegative(rushSuccessDelta) + capPositive(rushSuccessDelta);
+  explosivePlayDelta = capNegative(explosivePlayDelta) + capPositive(explosivePlayDelta);
+  turnoverAvoidanceDelta = capNegative(turnoverAvoidanceDelta) + capPositive(turnoverAvoidanceDelta);
+  redZoneDelta = capNegative(redZoneDelta) + capPositive(redZoneDelta);
+  fatigueDisciplineDelta = capNegative(fatigueDisciplineDelta) + capPositive(fatigueDisciplineDelta);
+  chemistryPenalty = capNegative(chemistryPenalty);
+
+  const score = Number((
+    passSuccessDelta
+    + rushSuccessDelta
+    + explosivePlayDelta
+    + turnoverAvoidanceDelta
+    + redZoneDelta
+    + fatigueDisciplineDelta
+    + chemistryPenalty
+  ).toFixed(4));
+
+  const severity: DerivedGamePlanMultipliers['severity'] = score <= -0.055
+    ? 'major_risk'
+    : score <= -0.015
+      ? 'minor_risk'
+      : 'ready';
+
+  return {
+    passSuccessDelta: Number(passSuccessDelta.toFixed(4)),
+    rushSuccessDelta: Number(rushSuccessDelta.toFixed(4)),
+    explosivePlayDelta: Number(explosivePlayDelta.toFixed(4)),
+    turnoverAvoidanceDelta: Number(turnoverAvoidanceDelta.toFixed(4)),
+    redZoneDelta: Number(redZoneDelta.toFixed(4)),
+    fatigueDisciplineDelta: Number(fatigueDisciplineDelta.toFixed(4)),
+    chemistryPenalty: Number(chemistryPenalty.toFixed(4)),
+    score,
+    netImpact: score,
+    severity,
+    activeReasons: reasons,
+  };
+}
+
+export function getGamePlanSynergySummary(multipliers: DerivedGamePlanMultipliers | null | undefined) {
+  const safe = multipliers ?? deriveGamePlanMultipliers({});
+  const positive = [
+    safe.passSuccessDelta,
+    safe.rushSuccessDelta,
+    safe.explosivePlayDelta,
+    safe.turnoverAvoidanceDelta,
+    safe.redZoneDelta,
+    safe.fatigueDisciplineDelta,
+  ].reduce((sum, value) => sum + Math.max(0, value), 0);
+  const negative = Math.abs(
+    [
+      safe.passSuccessDelta,
+      safe.rushSuccessDelta,
+      safe.explosivePlayDelta,
+      safe.turnoverAvoidanceDelta,
+      safe.redZoneDelta,
+      safe.fatigueDisciplineDelta,
+      safe.chemistryPenalty,
+    ].reduce((sum, value) => sum + Math.min(0, value), 0),
+  );
+
+  const status = safe.severity === 'major_risk'
+    ? 'Major risk'
+    : safe.severity === 'minor_risk'
+      ? 'Minor risk'
+      : 'Ready';
+
+  return {
+    status,
+    severity: safe.severity,
+    positive: Number(positive.toFixed(4)),
+    negative: Number(negative.toFixed(4)),
+    netImpact: safe.netImpact,
+    reasons: safe.activeReasons,
+  };
+}

--- a/src/core/sim/richGameSimulator.ts
+++ b/src/core/sim/richGameSimulator.ts
@@ -1,5 +1,6 @@
 import { resolveMatchup, DEFAULT_NORMALIZATION_CONSTANT } from './matchupEngine.ts';
 import type { AttributesV2 } from '../../types/player.ts';
+import type { DerivedGamePlanMultipliers } from './gamePlanMultipliers.ts';
 
 export interface SimPlayerRef {
   id: number | string;
@@ -86,10 +87,59 @@ export interface RichMatchupPayload {
   awayDefense: AttributesV2;
   homePlayers?: SimPlayerRef[];
   awayPlayers?: SimPlayerRef[];
+  homePrepMultipliers?: DerivedGamePlanMultipliers;
+  awayPrepMultipliers?: DerivedGamePlanMultipliers;
 }
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
+}
+
+const NEUTRAL_PREP: DerivedGamePlanMultipliers = {
+  passSuccessDelta: 0,
+  rushSuccessDelta: 0,
+  explosivePlayDelta: 0,
+  turnoverAvoidanceDelta: 0,
+  redZoneDelta: 0,
+  fatigueDisciplineDelta: 0,
+  chemistryPenalty: 0,
+  score: 0,
+  netImpact: 0,
+  severity: 'ready',
+  activeReasons: [],
+};
+
+function applyPrepToOffenseAttributes(
+  offense: AttributesV2,
+  prep: DerivedGamePlanMultipliers,
+  playType: 'pass' | 'run',
+  isRedZone: boolean,
+): AttributesV2 {
+  const passDelta = prep.passSuccessDelta + prep.chemistryPenalty;
+  const rushDelta = prep.rushSuccessDelta + prep.chemistryPenalty;
+  const explosiveDelta = prep.explosivePlayDelta;
+  const disciplineDelta = prep.turnoverAvoidanceDelta + prep.fatigueDisciplineDelta;
+  const redZoneDelta = isRedZone ? prep.redZoneDelta : 0;
+
+  const passBoost = playType === 'pass' ? passDelta : 0;
+  const runBoost = playType === 'run' ? rushDelta : 0;
+
+  const point = (value: number, delta: number, scale = 42) => clamp(value + (delta * scale), 25, 99);
+  return {
+    ...offense,
+    throwAccuracyShort: point(offense.throwAccuracyShort, passBoost + disciplineDelta * 0.35 + redZoneDelta * 0.25),
+    throwAccuracyDeep: point(offense.throwAccuracyDeep, passBoost * 0.85 + explosiveDelta + redZoneDelta * 0.2),
+    throwPower: point(offense.throwPower, explosiveDelta * 0.75 + passBoost * 0.3),
+    release: point(offense.release, passBoost * 0.8 + disciplineDelta * 0.25),
+    routeRunning: point(offense.routeRunning, passBoost * 0.75 + explosiveDelta * 0.4),
+    separation: point(offense.separation, passBoost * 0.7 + explosiveDelta * 0.5),
+    catchInTraffic: point(offense.catchInTraffic, disciplineDelta * 0.65 + redZoneDelta * 0.4),
+    ballTracking: point(offense.ballTracking, explosiveDelta * 0.7 + passBoost * 0.25),
+    decisionMaking: point(offense.decisionMaking, disciplineDelta * 0.9 + passBoost * 0.2 + runBoost * 0.2),
+    pocketPresence: point(offense.pocketPresence, disciplineDelta * 0.75 + passBoost * 0.2),
+    passBlockFootwork: point(offense.passBlockFootwork, passBoost * 0.3 + runBoost * 0.45 + disciplineDelta * 0.25),
+    passBlockStrength: point(offense.passBlockStrength, runBoost * 0.65 + disciplineDelta * 0.4 + redZoneDelta * 0.2),
+  };
 }
 
 function makeRng(seed = 1): () => number {
@@ -102,7 +152,11 @@ function makeRng(seed = 1): () => number {
   };
 }
 
-function getPlayType(state: { down: number; distance: number; quarter: number; clockSec: number; homeScore: number; awayScore: number; possession: 'home' | 'away' }, rng: () => number): 'pass' | 'run' {
+function getPlayType(
+  state: { down: number; distance: number; quarter: number; clockSec: number; homeScore: number; awayScore: number; possession: 'home' | 'away' },
+  rng: () => number,
+  prep: DerivedGamePlanMultipliers,
+): 'pass' | 'run' {
   const offenseLead = state.possession === 'home' ? state.homeScore - state.awayScore : state.awayScore - state.homeScore;
   let passProb = 0.49;
   if (state.down === 1) passProb -= 0.06;
@@ -116,7 +170,8 @@ function getPlayType(state: { down: number; distance: number; quarter: number; c
   if (state.quarter >= 3 && offenseLead >= 10) passProb -= 0.08;
   if (state.quarter >= 3 && offenseLead <= -10) passProb += 0.08;
 
-  passProb = clamp(passProb + (rng() - 0.5) * 0.1, 0.25, 0.82);
+  const prepPassBias = clamp((prep.passSuccessDelta - prep.rushSuccessDelta) * 1.4, -0.05, 0.05);
+  passProb = clamp(passProb + prepPassBias + (rng() - 0.5) * 0.1, 0.25, 0.82);
   return rng() <= passProb ? 'pass' : 'run';
 }
 
@@ -211,6 +266,8 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
   const quarterScores = { home: [0, 0, 0, 0], away: [0, 0, 0, 0] };
   const digest: GameEventDigestItem[] = [];
   const reasonMap = new Map<string, number>();
+  const homePrep = payload.homePrepMultipliers ?? NEUTRAL_PREP;
+  const awayPrep = payload.awayPrepMultipliers ?? NEUTRAL_PREP;
 
   const stats = {
     home: { plays: 0, passAtt: 0, passComp: 0, passYd: 0, passTD: 0, rushAtt: 0, rushYd: 0, rushTD: 0, firstDowns: 0, turnovers: 0, sacksAllowed: 0, sacksMade: 0, interceptions: 0, redZoneTrips: 0, redZoneScores: 0, explosivePlays: 0, success: 0 },
@@ -226,8 +283,11 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
     const wasRedZone = state.yardLine >= 80;
     const wasFourthDown = state.down === 4;
 
-    const playType = getPlayType(state, rng);
-    const result = resolveMatchup(offense, defense, {
+    const offensePrep = state.possession === 'home' ? homePrep : awayPrep;
+    const playType = getPlayType(state, rng, offensePrep);
+    const tunedOffense = applyPrepToOffenseAttributes(offense, offensePrep, playType, state.yardLine >= 80);
+    const fatigueBaseline = (stats.home.plays + stats.away.plays) / 220;
+    const result = resolveMatchup(tunedOffense, defense, {
       down: state.down,
       distance: state.distance,
       yardLine: state.yardLine,
@@ -235,7 +295,7 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
       clockSec: state.clockSec,
       weather: payload.weather,
       normalizationConstant: state.normalizationConstant,
-      fatigueFactor: (stats.home.plays + stats.away.plays) / 220,
+      fatigueFactor: clamp(fatigueBaseline - offensePrep.fatigueDisciplineDelta * 0.35, 0, 0.95),
       playType,
     }, rng);
 

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -53,6 +53,7 @@ import { ACTION_LABELS } from './constants/navigationCopy.js';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from './utils/boxScoreAccess.js';
 import { buildOffseasonActionCenter } from './utils/offseasonActionCenter.js';
 import { hasMinimumPlayableLeague, summarizeBootstrapState } from './utils/leagueBootstrap.js';
+import { clearWeeklyPrepForWeek, pruneWeeklyPrepStorage } from './utils/weeklyPrep.js';
 import { buildCanonicalGameId } from '../core/gameIdentity.js';
 import { getRecentGames, saveGame } from '../core/archive/gameArchive.ts';
 
@@ -383,6 +384,23 @@ function AppContent() {
     };
     localStorage.setItem(`footballgm_slot_${slotNum}_meta`, JSON.stringify(nextMeta));
   }, [league, activeSlot]);
+
+  useEffect(() => {
+    if (!league) return;
+    pruneWeeklyPrepStorage(league);
+  }, [league?.seasonId, league?.year]);
+
+  const previousWeekRef = useRef(null);
+  useEffect(() => {
+    if (!league) return;
+    const marker = `${league?.seasonId ?? league?.year}:${league?.week ?? 0}:${league?.userTeamId ?? 'user'}`;
+    const prior = previousWeekRef.current;
+    if (prior && prior !== marker) {
+      const [seasonId, week, userTeamId] = String(prior).split(':');
+      clearWeeklyPrepForWeek({ seasonId, week: Number(week), userTeamId });
+    }
+    previousWeekRef.current = marker;
+  }, [league?.seasonId, league?.year, league?.week, league?.userTeamId]);
 
   useEffect(() => {
     if (!league || !pendingNewSlot) return;

--- a/src/ui/components/WeeklyPrepScreen.jsx
+++ b/src/ui/components/WeeklyPrepScreen.jsx
@@ -39,7 +39,7 @@ export default function WeeklyPrepScreen({ league, onNavigate }) {
       <SectionCard
         title={`Week ${prep.nextGame.week} Prep · ${prep.nextGame.isHome ? 'vs' : '@'} ${prep.opponent.abbr ?? prep.opponent.name}`}
         subtitle={`Opponent ${prep.opponentSnapshot.record} · ${prep.opponentSnapshot.homeAway} game`}
-        actions={<TonePill tone={prep.remaining === 0 ? 'success' : 'warning'} label={prep.readinessLabel} />}
+        actions={<TonePill tone={prep.prepSummary?.severity === 'major_risk' ? 'danger' : prep.remaining === 0 ? 'success' : 'warning'} label={prep.prepSummary?.status ?? prep.readinessLabel} />}
       >
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: 8 }}>
           <div style={{ fontSize: 'var(--text-xs)' }}><strong>You:</strong> OVR {prep.teamSnapshot.overall} · OFF {prep.teamSnapshot.offense} · DEF {prep.teamSnapshot.defense}</div>
@@ -101,6 +101,20 @@ export default function WeeklyPrepScreen({ league, onNavigate }) {
               <Button size="sm" variant="outline" style={{ marginTop: 8 }} onClick={() => openAction(card.actionTab, 'planReviewed')}>
                 {card.actionLabel}
               </Button>
+            </div>
+          ))}
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Active effects" subtitle="Strategy synergy and readiness impacts for this week.">
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 8 }}>
+          <TonePill tone={prep.prepSummary?.severity === 'major_risk' ? 'danger' : prep.prepSummary?.severity === 'minor_risk' ? 'warning' : 'success'} label={`Prep state: ${prep.prepSummary?.status ?? 'Ready'}`} />
+          <TonePill tone={prep.prepSummary?.netImpact >= 0 ? 'success' : 'warning'} label={`Net impact ${prep.prepSummary?.netImpact >= 0 ? '+' : ''}${Number(prep.prepSummary?.netImpact ?? 0).toFixed(3)}`} />
+        </div>
+        <div style={{ display: 'grid', gap: 6 }}>
+          {(prep.prepSummary?.reasons?.length ? prep.prepSummary.reasons : ['No active matchup synergy or readiness penalties.']).map((reason) => (
+            <div key={reason} style={{ fontSize: 'var(--text-sm)', border: '1px solid var(--hairline)', borderRadius: 'var(--radius-md)', padding: 8 }}>
+              {reason}
             </div>
           ))}
         </div>

--- a/src/ui/components/__tests__/WeeklyPrepScreen.test.jsx
+++ b/src/ui/components/__tests__/WeeklyPrepScreen.test.jsx
@@ -46,6 +46,7 @@ describe('WeeklyPrepScreen', () => {
     expect(html).toContain('Opponent scout');
     expect(html).toContain('Lineup readiness');
     expect(html).toContain('Game plan recommendations');
+    expect(html).toContain('Active effects');
     expect(html).toContain('Prep completion');
   });
 

--- a/src/ui/utils/weeklyPrep.js
+++ b/src/ui/utils/weeklyPrep.js
@@ -1,6 +1,8 @@
 import { autoBuildDepthChart, depthWarnings, DEPTH_CHART_ROWS } from '../../core/depthChart.js';
+import { deriveGamePlanMultipliers, getGamePlanSynergySummary } from '../../core/sim/gamePlanMultipliers.ts';
 
 const PREP_STORAGE_KEY = 'footballgm_weekly_prep_v1';
+const GAME_PLAN_STORAGE_KEY = 'footballgm_gameplan_v1';
 
 function safeNum(value, fallback = 0) {
   const parsed = Number(value);
@@ -254,6 +256,16 @@ function prepProgressKey(league) {
   return `${league?.seasonId ?? league?.year ?? 'season'}:${league?.week ?? 1}:${league?.userTeamId ?? 'user'}`;
 }
 
+function readStoredGamePlan() {
+  if (typeof window === 'undefined') return {};
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(GAME_PLAN_STORAGE_KEY) ?? '{}');
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
 function writeStoredPrepProgress(allProgress) {
   if (typeof window === 'undefined') return;
   try {
@@ -290,6 +302,28 @@ export function markWeeklyPrepStep(league, step, value = true) {
   writeStoredPrepProgress(all);
 }
 
+export function clearWeeklyPrepForWeek(league) {
+  if (typeof window === 'undefined') return;
+  const key = prepProgressKey(league);
+  const all = readStoredPrepProgress();
+  if (!all || typeof all !== 'object' || !all[key]) return;
+  delete all[key];
+  writeStoredPrepProgress(all);
+}
+
+export function pruneWeeklyPrepStorage(activeLeague) {
+  if (typeof window === 'undefined') return;
+  const all = readStoredPrepProgress();
+  const activeSeason = String(activeLeague?.seasonId ?? activeLeague?.year ?? 'season');
+  const keepPrefix = `${activeSeason}:`;
+  const next = Object.fromEntries(
+    Object.entries(all).filter(([key]) => key.startsWith(keepPrefix)),
+  );
+  if (Object.keys(next).length !== Object.keys(all).length) {
+    writeStoredPrepProgress(next);
+  }
+}
+
 export function deriveWeeklyPrepState(league) {
   const userTeam = getTeam(league, league?.userTeamId);
   const nextGame = getNextGame(league);
@@ -304,6 +338,7 @@ export function deriveWeeklyPrepState(league) {
     offenseGap: userOff - oppDef,
     defenseGap: userDef - oppOff,
   };
+  const matchupAbsGap = Math.max(Math.abs(matchup.ovrGap), Math.abs(matchup.offenseGap), Math.abs(matchup.defenseGap));
 
   const opponentStrengths = [];
   if (oppOff >= 84) opponentStrengths.push(`Top-tier offense (${oppOff}) can create explosive drives.`);
@@ -317,6 +352,19 @@ export function deriveWeeklyPrepState(league) {
 
   const lineupIssues = buildLineupReadiness(userTeam, league);
   const recommendations = createRecommendationCards({ userTeam, opponent, matchup });
+  const gamePlan = {
+    ...(userTeam?.strategies?.gamePlan ?? {}),
+    ...readStoredGamePlan(),
+  };
+  const insights = {
+    weakSecondary: oppDef <= 76 || matchup.offenseGap >= 6,
+    weakRunDefense: oppDef <= 78 || matchup.offenseGap >= 4,
+    elitePassRush: oppDef >= 85 || (oppDef - userOff) >= 5,
+    explosiveOpponentOffense: oppOff >= 84,
+    balancedMatchup: matchupAbsGap <= 4,
+  };
+  const hasBlockingLineupIssue = lineupIssues.some((issue) => issue.level === 'urgent' && String(issue.label).toLowerCase().includes('depth chart blocker'));
+  const majorInjuryStress = lineupIssues.some((issue) => String(issue.label).toLowerCase().includes('injury stack'));
 
   const pressurePoints = [];
   if (matchup.defenseGap <= -4) pressurePoints.push('Defensive front must limit explosive passing downs.');
@@ -333,6 +381,19 @@ export function deriveWeeklyPrepState(league) {
 
   const remaining = Object.values(completion).filter((done) => !done).length;
   const readinessLabel = remaining === 0 ? 'Ready for kickoff' : `${remaining} prep item${remaining > 1 ? 's' : ''} remaining`;
+  const prepMultipliers = deriveGamePlanMultipliers({
+    weeklyPrepState: {
+      insights,
+      completion,
+      hasTracking: true,
+    },
+    gamePlan,
+    teamContext: {
+      hasBlockingLineupIssue,
+      majorInjuryStress,
+    },
+  });
+  const prepSummary = getGamePlanSynergySummary(prepMultipliers);
 
   return {
     userTeam,
@@ -366,6 +427,11 @@ export function deriveWeeklyPrepState(league) {
     completion,
     remaining,
     readinessLabel,
+    gamePlan,
+    insights,
+    prepMultipliers,
+    prepSummary,
+    readinessTier: prepSummary.severity,
     keyMatchupNote: recommendations?.[0]?.title ?? 'No clear tactical edge identified yet.',
   };
 }

--- a/src/ui/utils/weeklyPrep.test.js
+++ b/src/ui/utils/weeklyPrep.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { deriveWeeklyPrepState } from './weeklyPrep.js';
+import { deriveWeeklyPrepState, getWeeklyPrepProgress, markWeeklyPrepStep, clearWeeklyPrepForWeek } from './weeklyPrep.js';
 
 const league = {
   year: 2028,
@@ -49,6 +49,23 @@ const league = {
 };
 
 describe('weeklyPrep', () => {
+  it('resets weekly prep progress when week advances', () => {
+    const bucket = new Map();
+    global.window = {
+      localStorage: {
+        getItem: (key) => bucket.get(key) ?? null,
+        setItem: (key, value) => bucket.set(key, String(value)),
+        removeItem: (key) => bucket.delete(key),
+      },
+    };
+    const scopedLeague = { seasonId: 's-reset', week: 3, userTeamId: 1 };
+    markWeeklyPrepStep(scopedLeague, 'planReviewed', true);
+    expect(getWeeklyPrepProgress(scopedLeague).planReviewed).toBe(true);
+    clearWeeklyPrepForWeek(scopedLeague);
+    expect(getWeeklyPrepProgress(scopedLeague).planReviewed).toBe(false);
+    delete global.window;
+  });
+
   it('builds opponent scout/readiness model from league context', () => {
     const prep = deriveWeeklyPrepState(league);
     expect(prep.opponentSnapshot.record).toBe('2-3');
@@ -57,6 +74,8 @@ describe('weeklyPrep', () => {
     expect(prep.lineupIssues.length).toBeGreaterThan(0);
     expect(prep.recommendations.length).toBeGreaterThan(0);
     expect(prep.readinessLabel).toContain('remaining');
+    expect(prep.prepMultipliers).toBeTruthy();
+    expect(Array.isArray(prep.prepSummary.reasons)).toBe(true);
   });
 
   it('is safe with partial saves and missing opponent data', () => {
@@ -72,5 +91,6 @@ describe('weeklyPrep', () => {
     expect(prep.recommendations).toEqual([]);
     expect(Array.isArray(prep.lineupIssues)).toBe(true);
     expect(prep.readinessLabel).toContain('remaining');
+    expect(prep.prepSummary).toBeTruthy();
   });
 });

--- a/src/worker/WorkerPool.ts
+++ b/src/worker/WorkerPool.ts
@@ -4,6 +4,7 @@ import {
   type RichGameSummary,
   type SimPlayerRef,
 } from '../core/sim/richGameSimulator.ts';
+import type { DerivedGamePlanMultipliers } from '../core/sim/gamePlanMultipliers.ts';
 
 export interface Matchup {
   gameId: number | string;
@@ -18,6 +19,8 @@ export interface Matchup {
   awayDefense: AttributesV2;
   homePlayers?: SimPlayerRef[];
   awayPlayers?: SimPlayerRef[];
+  homePrepMultipliers?: DerivedGamePlanMultipliers;
+  awayPrepMultipliers?: DerivedGamePlanMultipliers;
 }
 
 export type GameSummary = RichGameSummary;

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -144,6 +144,7 @@ import {
   buildDeterministicSeed,
   simulateWithOptionalNewEngine,
 } from '../core/sim/weekSimulationBridge.ts';
+import { deriveGamePlanMultipliers } from '../core/sim/gamePlanMultipliers.ts';
 
 // ── DB Reload Guard ───────────────────────────────────────────────────────────
 // Register a callback with db/index.js so that when IDB fires onblocked or
@@ -2712,6 +2713,18 @@ function buildWeekMatchupsFromLeague(league, meta, week) {
   const matchups = [];
   const migratedPlayers = [];
 
+  const getRating = (team, key) => Number(team?.[key] ?? team?.[`${key}Rating`] ?? team?.[`${key}Ovr`] ?? team?.ovr ?? 0);
+  const countInjured = (roster = []) => roster.filter((player) => {
+    const weeks = Number(player?.injuryWeeksRemaining ?? player?.injuredWeeks ?? player?.injuryDuration ?? 0);
+    const status = String(player?.status ?? '').toLowerCase();
+    return weeks > 0 || status === 'injured' || status === 'ir';
+  }).length;
+  const blockingLineupIssue = (roster = []) => {
+    const starters = roster.filter((p) => Number(p?.depthOrder ?? 0) === 1 || Number(p?.depthChart?.order ?? 0) === 1);
+    const startersWithInjury = starters.filter((p) => Number(p?.injuryWeeksRemaining ?? p?.injuredWeeks ?? 0) > 0).length;
+    return starters.length > 0 && startersWithInjury >= 2;
+  };
+
   for (const game of (league?._weekGames ?? [])) {
     const homeRoster = Array.isArray(game?.home?.roster) ? game.home.roster : [];
     const awayRoster = Array.isArray(game?.away?.roster) ? game.away.roster : [];
@@ -2719,6 +2732,31 @@ function buildWeekMatchupsFromLeague(league, meta, week) {
     const homeUnits = aggregateTeamUnitsFromRoster(homeRoster);
     const awayUnits = aggregateTeamUnitsFromRoster(awayRoster);
     migratedPlayers.push(...homeUnits.migratedPlayers, ...awayUnits.migratedPlayers);
+
+    const homePlan = game?.home?.strategies?.gamePlan ?? {};
+    const awayPlan = game?.away?.strategies?.gamePlan ?? {};
+    const homeGap = getRating(game?.home, 'ovr') - getRating(game?.away, 'ovr');
+
+    const buildPrep = ({ team, opp, plan, isHome }) => deriveGamePlanMultipliers({
+      weeklyPrepState: {
+        insights: {
+          weakSecondary: getRating(opp, 'defense') <= 76 || (getRating(team, 'offense') - getRating(opp, 'defense')) >= 6,
+          weakRunDefense: getRating(opp, 'defense') <= 78 || (getRating(team, 'offense') - getRating(opp, 'defense')) >= 4,
+          elitePassRush: getRating(opp, 'defense') >= 85,
+          explosiveOpponentOffense: getRating(opp, 'offense') >= 84,
+          balancedMatchup: Math.abs(homeGap * (isHome ? 1 : -1)) <= 4,
+        },
+        hasTracking: false,
+      },
+      gamePlan: plan,
+      teamContext: {
+        majorInjuryStress: countInjured(team?.roster ?? []) >= 3,
+        hasBlockingLineupIssue: blockingLineupIssue(team?.roster ?? []),
+      },
+    });
+
+    const homePrepMultipliers = buildPrep({ team: game?.home, opp: game?.away, plan: homePlan, isHome: true });
+    const awayPrepMultipliers = buildPrep({ team: game?.away, opp: game?.home, plan: awayPlan, isHome: false });
 
     matchups.push({
       gameId: buildCanonicalGameId({
@@ -2733,6 +2771,8 @@ function buildWeekMatchupsFromLeague(league, meta, week) {
       homeDefense: homeUnits.defense,
       awayOffense: awayUnits.offense,
       awayDefense: awayUnits.defense,
+      homePrepMultipliers,
+      awayPrepMultipliers,
       homePlayers: homeRoster.map((player) => ({
         id: player.id,
         name: player.name,


### PR DESCRIPTION
### Motivation
- Make Weekly Prep decisions (scouting, lineup readiness, game plan) meaningfully affect the rich simulation in small, explainable, deterministic ways.
- Close the loop so scouting + readiness + plan choices produce modest, tunable synergy bonuses or readiness penalties. 
- Preserve deterministic RNG behavior and keep modifiers capped, transparent, and easy to tune.

### Description
- Introduced a central, inspectable tuning engine at `src/core/sim/gamePlanMultipliers.ts` that exports `deriveGamePlanMultipliers(...)` and `getGamePlanSynergySummary(...)` and encodes compact, tunable rules (synergy rules, readiness penalties, caps, and human-readable reasons). 
- Wired prep multipliers into the rich sim path by extending `RichMatchupPayload` to accept `homePrepMultipliers`/`awayPrepMultipliers` and applying them inside `src/core/sim/richGameSimulator.ts` to (a) bias play-call pass/run mix deterministically and (b) slightly tune offense attributes, fatigue/discipline, and red-zone execution without touching RNG sequencing. 
- Generated deterministic per-team multipliers at matchup construction in the worker (`src/worker/worker.js`) from plan + matchup + roster context and attached them to matchups so the sim receives consistent inputs. 
- Surface the same derived state in the UI by updating `deriveWeeklyPrepState` (`src/ui/utils/weeklyPrep.js`) to compute insights, read saved game-plan context, and expose `prepMultipliers` and `prepSummary`. 
- Added an "Active effects" area to `src/ui/components/WeeklyPrepScreen.jsx` that displays prep state, net impact, and human-readable reasons driven by the central engine. 
- Added persistence hygiene utilities (`clearWeeklyPrepForWeek`, `pruneWeeklyPrepStorage`) and integrated automatic clearing of prior-week prep state in `src/ui/App.jsx` so stale prep does not leak across weeks. 
- Kept all tuning constants centralized and modest in magnitude with caps to avoid stacked runaway impacts.

### Testing
- Ran the unit test suite for the modified areas with: `npm run test:unit -- src/core/__tests__/gamePlanMultipliers.test.ts src/core/__tests__/richGameSimulator.test.ts src/ui/utils/weeklyPrep.test.js src/ui/components/__tests__/WeeklyPrepScreen.test.jsx`. All tests passed. 
- New/updated tests added: `src/core/__tests__/gamePlanMultipliers.test.ts` (synergy & penalties & determinism), updates to `src/core/__tests__/richGameSimulator.test.ts` (accepts prep multipliers, deterministic behavior), `src/ui/utils/weeklyPrep.test.js` (derived multipliers + weekly reset), and `src/ui/components/__tests__/WeeklyPrepScreen.test.jsx` (renders Active effects).
- Verified deterministic behavior: same inputs (seed + multipliers) produce identical rich-sim outputs and multiplier derivation is deterministic for identical inputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e23cc50550832d9662f0dc761013d5)