### PR TITLE
Add centralized player evaluation model and tactical roster/FA insights

### DIFF
--- a/src/core/__tests__/playerEvaluation.test.js
+++ b/src/core/__tests__/playerEvaluation.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPlayerEvaluation,
+  derivePlayerArchetype,
+  derivePlayerRoleProjection,
+  deriveSchemeFit,
+} from '../playerEvaluation.js';
+
+describe('playerEvaluation', () => {
+  it('derives archetype for deep threat profile', () => {
+    const player = { pos: 'WR', ovr: 82, ratings: { speed: 91, ballTracking: 78, catching: 72 } };
+    const archetype = derivePlayerArchetype(player, 'RECEIVER');
+    expect(archetype.archetype).toBe('Deep Threat');
+  });
+
+  it('scheme fit responds to team need and game plan tendencies', () => {
+    const qb = { pos: 'QB', ovr: 80, schemeFit: 55, ratings: { throwAccuracy: 80, throwPower: 80 } };
+    const fit = deriveSchemeFit(qb, { needsNow: [{ pos: 'QB' }] }, { passRate: 62 }, ['QB']);
+    expect(fit.score).toBeGreaterThan(65);
+    expect(['Strong', 'Excellent']).toContain(fit.tier);
+  });
+
+  it('role projection is safe for older save structures', () => {
+    const role = derivePlayerRoleProjection({ pos: 'CB', ovr: 68, age: 24, potential: 78 }, { roster: undefined });
+    expect(role.role).toBeTypeOf('string');
+    expect(role.replaceContext).toBeTypeOf('string');
+  });
+
+  it('buildPlayerEvaluation returns grouped output', () => {
+    const evalData = buildPlayerEvaluation({ pos: 'LB', ovr: 75, age: 25, ratings: { passRush: 81, runStop: 79, speed: 78 } }, { rosterContext: { roster: [] } });
+    expect(evalData.archetype.archetype).toBeTruthy();
+    expect(evalData.schemeFit.score).toBeGreaterThanOrEqual(0);
+    expect(evalData.attributeBuckets.focus.length).toBeGreaterThan(0);
+  });
+});

--- a/src/core/playerEvaluation.js
+++ b/src/core/playerEvaluation.js
@@ -1,0 +1,216 @@
+const POSITION_ALIAS = {
+  HB: 'RB', FB: 'RB', FL: 'WR', SE: 'WR',
+  OT: 'OL', LT: 'OL', RT: 'OL', OG: 'OL', LG: 'OL', RG: 'OL', C: 'OL',
+  DE: 'DL', DT: 'DL', NT: 'DL', IDL: 'DL', EDGE: 'DL',
+  MLB: 'LB', OLB: 'LB', ILB: 'LB',
+  DB: 'CB', NCB: 'CB', FS: 'S', SS: 'S',
+};
+
+function toNum(v, fallback = 50) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function clamp(n, lo = 0, hi = 100) {
+  return Math.max(lo, Math.min(hi, n));
+}
+
+function canonicalPos(player) {
+  const raw = String(player?.pos ?? player?.position ?? '').toUpperCase();
+  return POSITION_ALIAS[raw] ?? raw;
+}
+
+function readRating(player, key, fallback = 50) {
+  return toNum(player?.attributesV2?.[key] ?? player?.ratings?.[key], fallback);
+}
+
+export function getPositionGroup(playerOrPos) {
+  const pos = typeof playerOrPos === 'string' ? playerOrPos : canonicalPos(playerOrPos);
+  if (['QB'].includes(pos)) return 'QB';
+  if (['RB'].includes(pos)) return 'RB';
+  if (['WR', 'TE'].includes(pos)) return 'RECEIVER';
+  if (['OL'].includes(pos)) return 'OL';
+  if (['DL'].includes(pos)) return 'FRONT7';
+  if (['LB'].includes(pos)) return 'FRONT7';
+  if (['CB', 'S'].includes(pos)) return 'SECONDARY';
+  return 'GENERAL';
+}
+
+export function deriveAttributeBuckets(player, positionGroup = getPositionGroup(player)) {
+  const speed = readRating(player, 'speed');
+  const acceleration = readRating(player, 'acceleration');
+  const awareness = readRating(player, 'awareness');
+  const intelligence = readRating(player, 'intelligence');
+
+  const base = {
+    athleticism: Math.round((speed + acceleration) / 2),
+    technique: Math.round((readRating(player, 'catchInTraffic') + readRating(player, 'passBlockFootwork')) / 2),
+    playmaking: Math.round((readRating(player, 'catching') + readRating(player, 'juking') + readRating(player, 'trucking')) / 3),
+    processingIQ: Math.round((awareness + intelligence + readRating(player, 'decisionMaking')) / 3),
+    trenchSkills: Math.round((readRating(player, 'passBlock') + readRating(player, 'runBlock') + readRating(player, 'passRushPower') + readRating(player, 'runStop')) / 4),
+    ballSkills: Math.round((readRating(player, 'catching') + readRating(player, 'catchInTraffic') + readRating(player, 'ballTracking')) / 3),
+    qbMechanics: Math.round((readRating(player, 'throwAccuracy') + readRating(player, 'throwAccuracyShort') + readRating(player, 'throwAccuracyDeep') + readRating(player, 'throwPower') + readRating(player, 'pocketPresence')) / 5),
+    frontSevenImpact: Math.round((readRating(player, 'passRush') + readRating(player, 'passRushSpeed') + readRating(player, 'passRushPower') + readRating(player, 'runStop')) / 4),
+    coverage: Math.round((readRating(player, 'coverage') + readRating(player, 'pressCoverage') + readRating(player, 'zoneCoverage')) / 3),
+  };
+
+  const relevance = {
+    QB: ['processingIQ', 'qbMechanics', 'athleticism'],
+    RB: ['athleticism', 'playmaking', 'processingIQ'],
+    RECEIVER: ['athleticism', 'ballSkills', 'technique', 'playmaking'],
+    OL: ['trenchSkills', 'processingIQ', 'technique'],
+    FRONT7: ['frontSevenImpact', 'trenchSkills', 'athleticism'],
+    SECONDARY: ['coverage', 'athleticism', 'processingIQ', 'ballSkills'],
+    GENERAL: ['athleticism', 'processingIQ', 'playmaking'],
+  };
+
+  return {
+    values: base,
+    focus: relevance[positionGroup] ?? relevance.GENERAL,
+  };
+}
+
+export function derivePlayerArchetype(player, positionGroup = getPositionGroup(player)) {
+  const ovr = toNum(player?.ovr, 60);
+  const spd = readRating(player, 'speed');
+  const cth = readRating(player, 'catching');
+  const cit = readRating(player, 'catchInTraffic');
+  const trk = readRating(player, 'trucking');
+  const jkm = readRating(player, 'juking');
+  const cov = readRating(player, 'coverage');
+  const prs = Math.max(readRating(player, 'passRush'), readRating(player, 'passRushSpeed'));
+  const tha = Math.max(readRating(player, 'throwAccuracy'), readRating(player, 'throwAccuracyDeep'));
+  const awr = readRating(player, 'awareness');
+
+  let archetype = 'Balanced Contributor';
+  if (positionGroup === 'QB') {
+    if (tha >= 78 && readRating(player, 'throwPower') >= 76) archetype = 'Vertical Field General';
+    else if (awr >= 76 && readRating(player, 'throwAccuracyShort') >= 74) archetype = 'Timing Distributor';
+    else archetype = 'Developmental QB';
+  } else if (positionGroup === 'RB') {
+    archetype = trk >= jkm + 8 ? 'Power Runner' : jkm >= trk + 8 ? 'Space Creator' : 'Balanced Runner';
+  } else if (positionGroup === 'RECEIVER') {
+    if (spd >= 84 && readRating(player, 'ballTracking') >= 70) archetype = 'Deep Threat';
+    else if (cit >= 78) archetype = 'Possession Target';
+    else archetype = 'Route Separator';
+  } else if (positionGroup === 'OL') {
+    archetype = readRating(player, 'runBlock') >= readRating(player, 'passBlock') + 6 ? 'Road Grader' : 'Pass Protector';
+  } else if (positionGroup === 'FRONT7') {
+    archetype = prs >= 80 ? 'Edge Speed Rusher' : readRating(player, 'runStop') >= 78 ? 'Run Anchor' : 'Hybrid Front Defender';
+  } else if (positionGroup === 'SECONDARY') {
+    archetype = cov >= 80 && spd >= 78 ? 'Coverage Corner' : awr >= 78 ? 'Field Communicator' : 'Developmental DB';
+  }
+
+  const confidence = clamp(Math.round((ovr * 0.6) + (awr * 0.25) + 15), 35, 97);
+  return { archetype, confidence };
+}
+
+function fitTier(score) {
+  if (score >= 80) return 'Excellent';
+  if (score >= 68) return 'Strong';
+  if (score >= 55) return 'Neutral';
+  return 'Poor';
+}
+
+export function deriveSchemeFit(player, teamContext = {}, gamePlan = {}, depthChartNeeds = []) {
+  const position = canonicalPos(player);
+  const group = getPositionGroup(position);
+  const baseFit = toNum(player?.schemeFit, 50);
+  const tendencies = {
+    passRate: toNum(gamePlan?.passRate ?? gamePlan?.passRatio ?? teamContext?.passRate, 50),
+    runRate: toNum(gamePlan?.runRate ?? (100 - toNum(gamePlan?.passRate ?? gamePlan?.passRatio, 50)), 50),
+    blitzRate: toNum(gamePlan?.blitzRate, 50),
+    manCoverageRate: toNum(gamePlan?.manCoverageRate, 50),
+  };
+
+  const archetype = derivePlayerArchetype(player, group).archetype;
+  let score = baseFit;
+  if (group === 'QB' || group === 'RECEIVER') score += tendencies.passRate >= 55 ? 8 : -2;
+  if (group === 'RB' || group === 'OL') score += tendencies.runRate >= 52 ? 7 : -2;
+  if (group === 'FRONT7') score += tendencies.blitzRate >= 55 ? 6 : 1;
+  if (group === 'SECONDARY') score += tendencies.manCoverageRate >= 55 ? 6 : 1;
+
+  if (Array.isArray(depthChartNeeds) && depthChartNeeds.includes(position)) score += 10;
+  const teamNeedList = teamContext?.needs ?? teamContext?.needsNow ?? [];
+  if (Array.isArray(teamNeedList) && teamNeedList.some((n) => (n?.pos ?? n) === position)) score += 8;
+
+  const strengths = [];
+  const weaknesses = [];
+  const buckets = deriveAttributeBuckets(player, group);
+  buckets.focus.forEach((key) => {
+    const v = buckets.values[key] ?? 50;
+    if (v >= 76) strengths.push(key);
+    else if (v <= 58) weaknesses.push(key);
+  });
+
+  score = clamp(Math.round(score));
+  return {
+    score,
+    tier: fitTier(score),
+    strengths: strengths.slice(0, 3),
+    weaknesses: weaknesses.slice(0, 2),
+    archetype,
+    tendencies,
+  };
+}
+
+export function derivePlayerRoleProjection(player, rosterContext = {}) {
+  const ovr = toNum(player?.ovr, 60);
+  const age = toNum(player?.age, 27);
+  const position = canonicalPos(player);
+  const roster = Array.isArray(rosterContext?.roster) ? rosterContext.roster : [];
+  const peers = roster.filter((p) => canonicalPos(p) === position).sort((a, b) => toNum(b?.ovr, 0) - toNum(a?.ovr, 0));
+  const starter = peers[0];
+  const backup = peers[1];
+  const starterOvr = toNum(starter?.ovr, 0);
+  const backupOvr = toNum(backup?.ovr, 0);
+
+  let role = 'Depth';
+  let replaceContext = 'Redundant depth';
+  if (ovr >= starterOvr + 2 || !starter) {
+    role = 'Starter';
+    replaceContext = starter ? `Upgrades current starter by +${Math.max(1, Math.round(ovr - starterOvr))} OVR` : 'Fills starter vacancy';
+  } else if (ovr >= backupOvr + 2 || !backup) {
+    role = 'Rotation';
+    replaceContext = backup ? 'Upgrades rotation unit' : 'Fills injury/backup gap';
+  } else if (age <= 24 && (toNum(player?.potential, ovr + 4) - ovr) >= 5) {
+    role = 'Development';
+    replaceContext = 'Long-term development candidate';
+  }
+
+  return {
+    role,
+    replaceContext,
+    starterDelta: Math.round(ovr - starterOvr),
+    backupDelta: Math.round(ovr - backupOvr),
+  };
+}
+
+export function derivePlayerSimImpactSummary(player, positionGroup = getPositionGroup(player)) {
+  const ovr = toNum(player?.ovr, 60);
+  const fit = toNum(player?.schemeFit, 50);
+  const readiness = toNum(player?.readinessScore ?? player?.morale, 72);
+  const impact = clamp(Math.round((ovr * 0.52) + (fit * 0.28) + (readiness * 0.2)));
+  const lane = impact >= 78 ? 'high-leverage' : impact >= 64 ? 'situational' : 'depth-only';
+  return {
+    impactScore: impact,
+    summary: `${lane} ${positionGroup.toLowerCase()} contributor with ${fit >= 70 ? 'clean' : 'volatile'} scheme translation`,
+  };
+}
+
+export function buildPlayerEvaluation(player, context = {}) {
+  const positionGroup = getPositionGroup(player);
+  const archetype = derivePlayerArchetype(player, positionGroup);
+  const schemeFit = deriveSchemeFit(player, context.teamContext, context.gamePlan, context.depthChartNeeds);
+  const roleProjection = derivePlayerRoleProjection(player, context.rosterContext);
+  const simImpact = derivePlayerSimImpactSummary(player, positionGroup);
+  const buckets = deriveAttributeBuckets(player, positionGroup);
+  return {
+    positionGroup,
+    archetype,
+    schemeFit,
+    roleProjection,
+    simImpact,
+    attributeBuckets: buckets,
+  };
+}

--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -47,6 +47,7 @@ import { getBudgetLabel, getMarketPlayerTags, toneToCssColor } from "../utils/tr
 import { ScreenHeader, EmptyState, StickySubnav } from "./ScreenSystem.jsx";
 import AdvancedPlayerSearch from "./AdvancedPlayerSearch.jsx";
 import { applyAdvancedPlayerFilters } from "../../core/footballAdvancedFilters";
+import { buildPlayerEvaluation } from "../../core/playerEvaluation.js";
 import { usePlayerCompare } from "../utils/playerCompare.js";
 import { formatDemandTier } from "../utils/offseasonActionCenter.js";
 
@@ -133,15 +134,56 @@ export function formatPlaybookKnowledge(playbookKnowledge) {
   return `${playbookKnowledge?.label ?? "None"} (${playbookKnowledge?.score ?? 0})`;
 }
 
-export function filterFreeAgentsForView(faPool, { signedIds, posFilter, minOvr, nameFilter, advancedFilters }) {
+export function filterFreeAgentsForView(faPool, { signedIds, posFilter, minOvr, nameFilter, advancedFilters, archetypeFilter = "ALL", fitTierFilter = "ALL", roleFilter = "ALL", positionNeedOnly = false, needs = [] }) {
   const baseFiltered = faPool.filter((p) => {
     if (signedIds?.has?.(p.id)) return false;
     if (posFilter !== "ALL" && p.pos !== posFilter) return false;
     if (minOvr > 0 && p.ovr < minOvr) return false;
     if (nameFilter && !p.name.toLowerCase().includes(nameFilter.toLowerCase())) return false;
+    if (archetypeFilter !== "ALL" && p?._eval?.archetype?.archetype !== archetypeFilter) return false;
+    if (fitTierFilter !== "ALL" && p?._eval?.schemeFit?.tier !== fitTierFilter) return false;
+    if (roleFilter !== "ALL" && p?._eval?.roleProjection?.role !== roleFilter) return false;
+    if (positionNeedOnly && !new Set(needs).has(p.pos)) return false;
     return true;
   });
   return applyAdvancedPlayerFilters(baseFiltered, advancedFilters);
+}
+
+export function sortFreeAgentsForView(displayed, { sortPreset, sortKey, sortDir, needs = [] }) {
+  const arr = [...displayed];
+  if (sortPreset === "best_available") {
+    arr.sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0));
+    return arr;
+  }
+  if (sortPreset === "cheapest_value") {
+    arr.sort((a, b) => ((b.ovr ?? 0) / Math.max(0.2, b._ask ?? 1)) - ((a.ovr ?? 0) / Math.max(0.2, a._ask ?? 1)));
+    return arr;
+  }
+  if (sortPreset === "youngest") {
+    arr.sort((a, b) => (a.age ?? 99) - (b.age ?? 99));
+    return arr;
+  }
+  if (sortPreset === "position_need") {
+    const needSet = new Set(needs);
+    arr.sort((a, b) => Number(needSet.has(b.pos)) - Number(needSet.has(a.pos)) || (b.ovr ?? 0) - (a.ovr ?? 0));
+    return arr;
+  }
+  if (sortPreset === "tactical_fit") {
+    arr.sort((a, b) => (b?._eval?.schemeFit?.score ?? 0) - (a?._eval?.schemeFit?.score ?? 0) || (b.ovr ?? 0) - (a.ovr ?? 0));
+    return arr;
+  }
+  arr.sort((a, b) => {
+    let va = a[sortKey];
+    let vb = b[sortKey];
+    if (sortKey === "ask") {
+      va = a._ask;
+      vb = b._ask;
+    }
+    if (va === vb) return 0;
+    if (sortDir === "asc") return va > vb ? 1 : -1;
+    return va < vb ? 1 : -1;
+  });
+  return arr;
 }
 
 // ── Shared sub-components (identical signature & appearance to Roster.jsx) ────
@@ -626,6 +668,10 @@ export default function FreeAgency({
   const [minSchemeFit, setMinSchemeFit] = useState(0);
   const [demandTier, setDemandTier] = useState("ALL");
   const [watchOnly, setWatchOnly] = useState(false);
+  const [archetypeFilter, setArchetypeFilter] = useState("ALL");
+  const [fitTierFilter, setFitTierFilter] = useState("ALL");
+  const [roleFilter, setRoleFilter] = useState("ALL");
+  const [positionNeedOnly, setPositionNeedOnly] = useState(false);
   const [watchlistIds, setWatchlistIds] = useState(new Set());
   const [sortPreset, setSortPreset] = useState("best_available");
 
@@ -692,50 +738,37 @@ export default function FreeAgency({
       _ask: resolveDemandAnnual(p),
     }));
   }, [faState]);
+  const evaluatedFaPool = useMemo(() => faPool.map((p) => ({
+    ...p,
+    _eval: buildPlayerEvaluation(p, {
+      teamContext: teamIntel,
+      rosterContext: { roster: userTeam?.roster ?? [] },
+      depthChartNeeds: (needsSummary?.needs ?? []).slice(0, 4),
+      gamePlan: userTeam?.gamePlan ?? {},
+    }),
+  })), [faPool, teamIntel, userTeam?.roster, userTeam?.gamePlan, needsSummary?.needs]);
+  const topNeeds = useMemo(() => (needsSummary?.needs ?? []).slice(0, 4), [needsSummary?.needs]);
 
   const displayed = useMemo(() => {
-    const base = filterFreeAgentsForView(faPool, { signedIds, posFilter, minOvr, nameFilter, advancedFilters });
+    const base = filterFreeAgentsForView(evaluatedFaPool, {
+      signedIds, posFilter, minOvr, nameFilter, advancedFilters, archetypeFilter, fitTierFilter, roleFilter, positionNeedOnly, needs: topNeeds,
+    });
     return base.filter((player) => {
       if ((player.age ?? 99) > maxAge) return false;
-      if ((player.schemeFit ?? 0) < minSchemeFit) return false;
+      if ((player._eval?.schemeFit?.score ?? player.schemeFit ?? 0) < minSchemeFit) return false;
       if (demandTier !== "ALL" && formatDemandTier(player) !== demandTier) return false;
       if (watchOnly && !watchlistIds.has(player.id)) return false;
       return true;
     });
-  }, [faPool, signedIds, posFilter, nameFilter, minOvr, advancedFilters, maxAge, minSchemeFit, demandTier, watchOnly, watchlistIds]);
+  }, [evaluatedFaPool, signedIds, posFilter, nameFilter, minOvr, advancedFilters, archetypeFilter, fitTierFilter, roleFilter, positionNeedOnly, topNeeds, maxAge, minSchemeFit, demandTier, watchOnly, watchlistIds]);
 
   const sortedAgents = useMemo(() => {
-    const arr = [...displayed];
-    if (sortPreset === "best_available") {
-      arr.sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0));
-      return arr;
-    }
-    if (sortPreset === "cheapest_value") {
-      arr.sort((a, b) => ((b.ovr ?? 0) / Math.max(0.2, b._ask ?? 1)) - ((a.ovr ?? 0) / Math.max(0.2, a._ask ?? 1)));
-      return arr;
-    }
-    if (sortPreset === "youngest") {
-      arr.sort((a, b) => (a.age ?? 99) - (b.age ?? 99));
-      return arr;
-    }
-    if (sortPreset === "position_need") {
-      const needs = new Set((needsSummary?.needs ?? []).slice(0, 4));
-      arr.sort((a, b) => Number(needs.has(b.pos)) - Number(needs.has(a.pos)) || (b.ovr ?? 0) - (a.ovr ?? 0));
-      return arr;
-    }
-    arr.sort((a, b) => {
-      let va = a[sortKey];
-      let vb = b[sortKey];
-      if (sortKey === "ask") {
-        va = a._ask;
-        vb = b._ask;
-      }
-      if (va === vb) return 0;
-      if (sortDir === "asc") return va > vb ? 1 : -1;
-      return va < vb ? 1 : -1;
-    });
-    return arr;
+    return sortFreeAgentsForView(displayed, { sortPreset, sortKey, sortDir, needs: (needsSummary?.needs ?? []).slice(0, 4) });
   }, [displayed, sortKey, sortDir, sortPreset, needsSummary?.needs]);
+  const archetypeOptions = useMemo(
+    () => Array.from(new Set(evaluatedFaPool.map((p) => p?._eval?.archetype?.archetype).filter(Boolean))).slice(0, 24),
+    [evaluatedFaPool],
+  );
 
 
   const {
@@ -1051,8 +1084,30 @@ export default function FreeAgency({
               <option value="cheapest_value">Sort: Cheapest value</option>
               <option value="youngest">Sort: Youngest</option>
               <option value="position_need">Sort: Position need</option>
+              <option value="tactical_fit">Sort: Tactical fit</option>
               <option value="manual">Sort: Manual columns</option>
             </select>
+            <select value={fitTierFilter} onChange={(e) => setFitTierFilter(e.target.value)} style={{ height: 30, borderRadius: 8, background: "var(--surface-strong)", border: "1px solid var(--hairline)", color: "var(--text)", fontSize: 12 }}>
+              <option value="ALL">Fit tier: All</option>
+              <option value="Excellent">Excellent</option>
+              <option value="Strong">Strong</option>
+              <option value="Neutral">Neutral</option>
+              <option value="Poor">Poor</option>
+            </select>
+            <select value={archetypeFilter} onChange={(e) => setArchetypeFilter(e.target.value)} style={{ height: 30, borderRadius: 8, background: "var(--surface-strong)", border: "1px solid var(--hairline)", color: "var(--text)", fontSize: 12, maxWidth: 220 }}>
+              <option value="ALL">Archetype: All</option>
+              {archetypeOptions.map((arch) => <option key={arch} value={arch}>{arch}</option>)}
+            </select>
+            <select value={roleFilter} onChange={(e) => setRoleFilter(e.target.value)} style={{ height: 30, borderRadius: 8, background: "var(--surface-strong)", border: "1px solid var(--hairline)", color: "var(--text)", fontSize: 12 }}>
+              <option value="ALL">Role: All</option>
+              <option value="Starter">Starter</option>
+              <option value="Rotation">Rotation</option>
+              <option value="Depth">Depth</option>
+              <option value="Development">Development</option>
+            </select>
+            <Button className="btn" onClick={() => setPositionNeedOnly((v) => !v)} style={{ whiteSpace: "nowrap", opacity: positionNeedOnly ? 1 : 0.8 }}>
+              {positionNeedOnly ? "Need positions only" : "All positions"}
+            </Button>
             <Button className="btn" onClick={() => setWatchOnly((prev) => !prev)} style={{ whiteSpace: "nowrap" }}>
               {watchOnly ? "Showing watchlist" : `Watchlist (${watchlistIds.size})`}
             </Button>
@@ -1093,6 +1148,9 @@ export default function FreeAgency({
               </Button>
             ))}
             <div style={{ marginLeft: "auto", display: "flex", gap: 6 }} />
+          </div>
+          <div style={{ fontSize: 11, color: "var(--text-subtle)" }}>
+            Top needs: {topNeeds.join(", ") || "No urgent positional needs"}.
           </div>
         </CardContent>
       </Card>
@@ -1338,6 +1396,9 @@ export default function FreeAgency({
                             <TableCell><PosBadge pos={player.pos} /></TableCell>
                             <TableCell onClick={() => setPreviewPlayer(player)} style={{ fontWeight: 600, color: "var(--text)", cursor: "pointer" }}>
                               <span style={{ borderBottom: "1px dotted var(--text-muted)" }}>{player.name}</span>
+                              <div style={{ fontSize: 10, color: "var(--text-subtle)", marginTop: 2 }}>
+                                {player?._eval?.archetype?.archetype ?? "Balanced"} · {player?._eval?.roleProjection?.role ?? "Depth"} · {player?._eval?.simImpact?.summary}
+                              </div>
                             </TableCell>
                             <TableCell style={{ whiteSpace: "nowrap" }}>
                               {(player.traits || []).map((t) => <TraitBadge key={t} traitId={t} />)}
@@ -1347,7 +1408,8 @@ export default function FreeAgency({
                             <TableCell style={{ textAlign: "center" }}><Button title={compareIds.includes(player.id) ? "Remove from compare" : "Add to compare"} onClick={() => toggleCompare(player)} style={{ width: 22, height: 22, borderRadius: "var(--radius-sm)", border: `1.5px solid ${compareIds.includes(player.id) ? "var(--accent)" : "var(--hairline)"}`, background: compareIds.includes(player.id) ? "var(--accent-muted)" : "transparent", fontSize: 12, color: compareIds.includes(player.id) ? "var(--accent)" : "var(--text-subtle)" }}>{compareIds.includes(player.id) ? "✓" : "⊕"}</Button></TableCell>
                             <TableCell style={{ textAlign: "center" }}><Button title={watchlistIds.has(player.id) ? "Remove from watchlist" : "Add to watchlist"} onClick={() => setWatchlistIds((prev) => { const next = new Set(prev); if (next.has(player.id)) next.delete(player.id); else next.add(player.id); return next; })} style={{ width: 22, height: 22, borderRadius: "var(--radius-sm)", border: `1.5px solid ${watchlistIds.has(player.id) ? "var(--warning)" : "var(--hairline)"}`, background: watchlistIds.has(player.id) ? "rgba(255,159,10,0.16)" : "transparent", fontSize: 12, color: watchlistIds.has(player.id) ? "var(--warning)" : "var(--text-subtle)" }}>{watchlistIds.has(player.id) ? "★" : "☆"}</Button></TableCell>
                             <TableCell style={{ textAlign: "center" }}>
-                              <PipBar value={player.schemeFit ?? 50} color="var(--accent)" />
+                              <PipBar value={player?._eval?.schemeFit?.score ?? player.schemeFit ?? 50} color="var(--accent)" />
+                              <div style={{ fontSize: 10, color: "var(--text-subtle)" }}>{player?._eval?.schemeFit?.tier ?? "Neutral"}</div>
                             </TableCell>
                             {topBidCell}
                             <TableCell style={{ textAlign: "right", paddingRight: "var(--space-5)" }}>
@@ -1378,6 +1440,9 @@ export default function FreeAgency({
                         <TableCell><PosBadge pos={player.pos} /></TableCell>
                         <TableCell onClick={() => onPlayerSelect && onPlayerSelect(player.id)} style={{ fontWeight: 600, color: "var(--text)", cursor: onPlayerSelect ? "pointer" : "default" }}>
                           <span style={{ borderBottom: onPlayerSelect ? "1px dotted var(--text-muted)" : "none" }}>{player.name}</span>
+                          <div style={{ fontSize: 10, color: "var(--text-subtle)", marginTop: 2 }}>
+                            {player?._eval?.archetype?.archetype ?? "Balanced"} · {player?._eval?.roleProjection?.replaceContext ?? "Depth option"}
+                          </div>
                         </TableCell>
                         <TableCell style={{ whiteSpace: "nowrap" }}>
                           {(player.traits || []).map((t) => <TraitBadge key={t} traitId={t} />)}
@@ -1387,7 +1452,8 @@ export default function FreeAgency({
                         <TableCell style={{ textAlign: "center" }}><Button title={compareIds.includes(player.id) ? "Remove from compare" : "Add to compare"} onClick={() => toggleCompare(player)} style={{ width: 22, height: 22, borderRadius: "var(--radius-sm)", border: `1.5px solid ${compareIds.includes(player.id) ? "var(--accent)" : "var(--hairline)"}`, background: compareIds.includes(player.id) ? "var(--accent-muted)" : "transparent", fontSize: 12, color: compareIds.includes(player.id) ? "var(--accent)" : "var(--text-subtle)" }}>{compareIds.includes(player.id) ? "✓" : "⊕"}</Button></TableCell>
                         <TableCell style={{ textAlign: "center" }}><Button title={watchlistIds.has(player.id) ? "Remove from watchlist" : "Add to watchlist"} onClick={() => setWatchlistIds((prev) => { const next = new Set(prev); if (next.has(player.id)) next.delete(player.id); else next.add(player.id); return next; })} style={{ width: 22, height: 22, borderRadius: "var(--radius-sm)", border: `1.5px solid ${watchlistIds.has(player.id) ? "var(--warning)" : "var(--hairline)"}`, background: watchlistIds.has(player.id) ? "rgba(255,159,10,0.16)" : "transparent", fontSize: 12, color: watchlistIds.has(player.id) ? "var(--warning)" : "var(--text-subtle)" }}>{watchlistIds.has(player.id) ? "★" : "☆"}</Button></TableCell>
                         <TableCell style={{ textAlign: "center" }}>
-                          <PipBar value={player.schemeFit ?? 50} color="var(--accent)" />
+                          <PipBar value={player?._eval?.schemeFit?.score ?? player.schemeFit ?? 50} color="var(--accent)" />
+                          <div style={{ fontSize: 10, color: "var(--text-subtle)" }}>{player?._eval?.schemeFit?.tier ?? "Neutral"}</div>
                         </TableCell>
                         {topBidCell}
                         <TableCell style={{ textAlign: "right", paddingRight: "var(--space-5)", whiteSpace: "nowrap" }}>
@@ -1442,7 +1508,8 @@ export default function FreeAgency({
                   <Card key={player.id} className="card-premium" style={{ padding: "var(--space-3)" }}>
                     <div style={{ fontWeight: 700 }}>{idx + 1}. {player.name}</div>
                     <div style={{ fontSize: 12, color: "var(--text-muted)" }}>{player.pos} · age {player.age} · OVR {player.ovr}{player.scoutUncertaintyBand ? ` (Scout ${player.scoutOvr} ±${player.scoutUncertaintyBand})` : ''}</div>
-                    <div style={{ fontSize: 12, color: "var(--text-muted)" }}>Scheme fit {player.schemeFit ?? 50} · morale {player.morale ?? 70}</div>
+                    <div style={{ fontSize: 12, color: "var(--text-muted)" }}>{player?._eval?.archetype?.archetype ?? "Balanced"} · Fit {player?._eval?.schemeFit?.score ?? player.schemeFit ?? 50} ({player?._eval?.schemeFit?.tier ?? "Neutral"})</div>
+                    <div style={{ fontSize: 12, color: "var(--text-muted)" }}>{player?._eval?.roleProjection?.replaceContext ?? "Depth option"} · {player?._eval?.simImpact?.summary}</div>
                     <div style={{ fontSize: 12, color: "var(--text-muted)" }}>Playbook {formatPlaybookKnowledge(player?.playbookKnowledge)}</div>
                     <div style={{ fontSize: 12, marginTop: 4 }}>Demand {(player?.demandProfile?.askAnnual ?? player._ask ?? 0).toFixed(1)}M / yr</div>
                     <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: 4 }}>
@@ -1490,9 +1557,12 @@ export default function FreeAgency({
                                    <span onClick={() => setPreviewPlayer(player)} style={{ cursor: "pointer", borderBottom: "1px dotted" }}>{idx + 1}. {player.name}</span>
                                    <OvrBadge ovr={player.ovr} />
                                </div>
-                               <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginTop: 2 }}>
+                                <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginTop: 2 }}>
                                    Age {player.age} · Ask: ${(player?.demandProfile?.askAnnual ?? player._ask ?? 0).toFixed(1)}M/yr ({askYrs} yr)
                                 </div>
+                               <div style={{ fontSize: 10, color: "var(--text-subtle)", marginTop: 2 }}>
+                                  {player?._eval?.archetype?.archetype ?? "Balanced"} · Fit {player?._eval?.schemeFit?.score ?? player.schemeFit ?? 50} ({player?._eval?.schemeFit?.tier ?? "Neutral"}) · {player?._eval?.roleProjection?.role ?? "Depth"}
+                               </div>
                                <div style={{ fontSize: "10px", color: "var(--text-muted)", marginTop: 2 }}>
                                    {player?.demandProfile?.headline ?? "Balanced priorities"} · {mMarket.attention ?? `${mMarket.heatLabel ?? "No market heat signal"} market`} · {mMarket.knownBidderLabel}
                                 </div>

--- a/src/ui/components/PlayerComparison.jsx
+++ b/src/ui/components/PlayerComparison.jsx
@@ -8,6 +8,7 @@ import {
   resolveCompareStatSections,
   shouldShowGroupForPosition,
 } from '../../core/footballCompare';
+import { buildPlayerEvaluation, deriveAttributeBuckets, getPositionGroup } from '../../core/playerEvaluation.js';
 
 function formatContract(player) {
   const amount = Number(player?.contract?.baseAnnual ?? player?.contractAmount ?? player?.askingPrice ?? 0);
@@ -39,6 +40,23 @@ function Row({ label, a, b, lowerIsBetter = false }) {
   );
 }
 
+export function buildComparisonViewModel(playerA, playerB) {
+  if (!playerA || !playerB) return null;
+  const evalA = buildPlayerEvaluation(playerA, { rosterContext: { roster: [] } });
+  const evalB = buildPlayerEvaluation(playerB, { rosterContext: { roster: [] } });
+  const groupA = deriveAttributeBuckets(playerA, getPositionGroup(playerA));
+  const groupB = deriveAttributeBuckets(playerB, getPositionGroup(playerB));
+  return {
+    evalA,
+    evalB,
+    groupedRows: Array.from(new Set([...(groupA.focus ?? []), ...(groupB.focus ?? [])])).map((key) => ({
+      key,
+      a: groupA.values?.[key] ?? null,
+      b: groupB.values?.[key] ?? null,
+    })),
+  };
+}
+
 export default function PlayerComparison({ playerA, playerB, onClose }) {
   const [showAllStats, setShowAllStats] = useState(false);
 
@@ -52,6 +70,7 @@ export default function PlayerComparison({ playerA, playerB, onClose }) {
       b: getPlayerRatingValue(playerB, key),
     }))
     .filter((row) => row.a != null || row.b != null), [playerA, playerB]);
+  const evalModel = useMemo(() => buildComparisonViewModel(playerA, playerB), [playerA, playerB]);
 
   if (!playerA || !playerB) return null;
 
@@ -77,6 +96,18 @@ export default function PlayerComparison({ playerA, playerB, onClose }) {
           <h4 style={{ margin: '14px 0 8px 0' }}>Ratings</h4>
           {ratings.map((rating) => (
             <Row key={rating.key} label={rating.label} a={rating.a ?? '—'} b={rating.b ?? '—'} />
+          ))}
+
+          <h4 style={{ margin: '14px 0 8px 0' }}>Tactical Comparison</h4>
+          <Row label="Archetype" a={evalModel?.evalA?.archetype?.archetype ?? '—'} b={evalModel?.evalB?.archetype?.archetype ?? '—'} />
+          <Row label="Scheme Fit" a={`${evalModel?.evalA?.schemeFit?.score ?? '—'} (${evalModel?.evalA?.schemeFit?.tier ?? '—'})`} b={`${evalModel?.evalB?.schemeFit?.score ?? '—'} (${evalModel?.evalB?.schemeFit?.tier ?? '—'})`} />
+          <Row label="Projected Role" a={evalModel?.evalA?.roleProjection?.role ?? '—'} b={evalModel?.evalB?.roleProjection?.role ?? '—'} />
+          <Row label="Starter Context" a={evalModel?.evalA?.roleProjection?.replaceContext ?? '—'} b={evalModel?.evalB?.roleProjection?.replaceContext ?? '—'} />
+          <Row label="Sim Impact" a={evalModel?.evalA?.simImpact?.summary ?? '—'} b={evalModel?.evalB?.simImpact?.summary ?? '—'} />
+
+          <h4 style={{ margin: '14px 0 8px 0' }}>Attribute Buckets</h4>
+          {evalModel?.groupedRows?.map((row) => (
+            <Row key={row.key} label={row.key} a={row.a ?? '—'} b={row.b ?? '—'} />
           ))}
 
           <h4 style={{ margin: '14px 0 8px 0', display: 'flex', justifyContent: 'space-between' }}>

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -56,6 +56,7 @@ import { buildDevelopmentNotes, summarizeRosterDevelopment } from "../utils/play
 import { getDepthRows, autoBuildDepthChart, depthWarnings } from "../../core/depthChart.js";
 import AdvancedPlayerSearch from "./AdvancedPlayerSearch.jsx";
 import { applyAdvancedPlayerFilters } from "../../core/footballAdvancedFilters";
+import { buildPlayerEvaluation } from "../../core/playerEvaluation.js";
 import { usePlayerCompare } from "../utils/playerCompare.js";
 import SocialFeed from "./SocialFeed.jsx";
 import { TeamWorkspaceHeader, TeamCapSummaryStrip } from "./TeamWorkspacePrimitives.jsx";
@@ -505,6 +506,7 @@ function RosterTable({
   const [releasing, setReleasing] = useState(null);
   const [extending, setExtending] = useState(null);
   const [advancedFilters, setAdvancedFilters] = useState([]);
+  const [evaluationMode, setEvaluationMode] = useState(true);
   const {
     compareIds,
     setCompareIds,
@@ -520,6 +522,15 @@ function RosterTable({
     const filtered = applyAdvancedPlayerFilters(quickFiltered, advancedFilters);
     return sortPlayers(filtered, sortKey, sortDir);
   }, [players, posFilter, sortKey, sortDir, advancedFilters]);
+  const evaluatedDisplayed = useMemo(() => displayed.map((player) => ({
+    player,
+    eval: buildPlayerEvaluation(player, {
+      teamContext: team,
+      rosterContext: { roster: players },
+      depthChartNeeds: (team?.needsNow ?? []).map((n) => n?.pos ?? n),
+      gamePlan: team?.gamePlan ?? {},
+    }),
+  })), [displayed, team, players]);
   const teamDirection = useMemo(() => classifyTeamDirection(team, week), [team, week]);
   const decisionSummary = useMemo(
     () => buildExpiringDecisionSummary(players, { team, roster: players, direction: teamDirection }),
@@ -673,6 +684,11 @@ function RosterTable({
         onChange={setAdvancedFilters}
         title="Advanced player search (AND)"
       />
+      <div style={{ marginBottom: 8 }}>
+        <Button variant={evaluationMode ? "default" : "outline"} onClick={() => setEvaluationMode((v) => !v)}>
+          {evaluationMode ? "Evaluation view on" : "Evaluation view off"}
+        </Button>
+      </div>
 
       {/* Table */}
       <Card className="card-premium" style={{ padding: 0, overflow: "hidden" }}><CardContent style={{ padding: 0 }}>
@@ -834,7 +850,7 @@ function RosterTable({
                   </TableCell>
                 </TableRow>
               )}
-              {displayed.map((player, idx) => {
+                  {evaluatedDisplayed.map(({ player, eval: playerEval }, idx) => {
                 const isReleasing = releasing === player.id;
                 const isExpiring = (player.contract?.years || 0) <= 1;
                 const yearsLeft =
@@ -904,6 +920,16 @@ function RosterTable({
                           <ToneChip label={devContext.readiness.label} tone={devContext.readiness.tone} />
                           <ToneChip label={devContext.fit.label} tone={devContext.fit.tone} />
                         </div>
+                        {evaluationMode && (
+                          <div style={{ marginTop: 4, display: "grid", gap: 2 }}>
+                            <div style={{ fontSize: 10, color: "var(--text-subtle)" }}>
+                              <strong style={{ color: "var(--text)" }}>{playerEval?.archetype?.archetype}</strong> · Fit {playerEval?.schemeFit?.score} ({playerEval?.schemeFit?.tier}) · {playerEval?.roleProjection?.role}
+                            </div>
+                            <div style={{ fontSize: 10, color: "var(--text-subtle)" }}>
+                              {playerEval?.simImpact?.summary}
+                            </div>
+                          </div>
+                        )}
                       </button>
                       {(() => {
                         const salary = Number(derivePlayerContractFinancials(player)?.annualSalary ?? 0);

--- a/src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx
+++ b/src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { filterFreeAgentsForView, formatPlaybookKnowledge } from '../FreeAgency.jsx';
+import { filterFreeAgentsForView, formatPlaybookKnowledge, sortFreeAgentsForView } from '../FreeAgency.jsx';
 
 describe('free agency playbook knowledge display', () => {
   it('formats label and score for UI rows/cards', () => {
@@ -21,5 +21,34 @@ describe('free agency playbook knowledge display', () => {
       advancedFilters: [{ id: 'a', fieldKey: 'age', operator: 'lte', value: 25 }],
     });
     expect(result.map((p) => p.id)).toEqual([1]);
+  });
+
+  it('supports tactical evaluation filters', () => {
+    const pool = [
+      { id: 1, name: 'Alex QB', pos: 'QB', ovr: 82, _eval: { archetype: { archetype: 'Timing Distributor' }, schemeFit: { tier: 'Strong' }, roleProjection: { role: 'Starter' } } },
+      { id: 2, name: 'Brett WR', pos: 'WR', ovr: 79, _eval: { archetype: { archetype: 'Deep Threat' }, schemeFit: { tier: 'Poor' }, roleProjection: { role: 'Depth' } } },
+    ];
+    const result = filterFreeAgentsForView(pool, {
+      signedIds: new Set(),
+      posFilter: 'ALL',
+      minOvr: 60,
+      nameFilter: '',
+      advancedFilters: [],
+      fitTierFilter: 'Strong',
+      roleFilter: 'Starter',
+      archetypeFilter: 'Timing Distributor',
+      positionNeedOnly: true,
+      needs: ['QB'],
+    });
+    expect(result.map((p) => p.id)).toEqual([1]);
+  });
+
+  it('sorts by tactical fit using evaluation score', () => {
+    const sorted = sortFreeAgentsForView([
+      { id: 1, ovr: 80, _eval: { schemeFit: { score: 66 } } },
+      { id: 2, ovr: 77, _eval: { schemeFit: { score: 83 } } },
+      { id: 3, ovr: 82, _eval: { schemeFit: { score: 74 } } },
+    ], { sortPreset: 'tactical_fit', sortKey: 'ovr', sortDir: 'desc', needs: [] });
+    expect(sorted.map((p) => p.id)).toEqual([2, 3, 1]);
   });
 });

--- a/src/ui/components/__tests__/playerComparison.test.jsx
+++ b/src/ui/components/__tests__/playerComparison.test.jsx
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import PlayerComparison, { buildComparisonViewModel } from '../PlayerComparison.jsx';
+
+const playerA = {
+  id: 1,
+  name: 'A QB',
+  pos: 'QB',
+  ovr: 83,
+  age: 26,
+  contract: { baseAnnual: 21, yearsRemaining: 3 },
+  ratings: { throwAccuracy: 84, throwPower: 82, awareness: 79 },
+};
+const playerB = {
+  id: 2,
+  name: 'B QB',
+  pos: 'QB',
+  ovr: 79,
+  age: 30,
+  contract: { baseAnnual: 17, yearsRemaining: 2 },
+  ratings: { throwAccuracy: 78, throwPower: 80, awareness: 75 },
+};
+
+describe('PlayerComparison evaluation rendering', () => {
+  it('builds tactical comparison model', () => {
+    const model = buildComparisonViewModel(playerA, playerB);
+    expect(model.evalA.archetype.archetype).toBeTruthy();
+    expect(model.groupedRows.length).toBeGreaterThan(0);
+  });
+
+  it('renders tactical sections in markup', () => {
+    const html = renderToStaticMarkup(<PlayerComparison playerA={playerA} playerB={playerB} onClose={() => {}} />);
+    expect(html).toContain('Tactical Comparison');
+    expect(html).toContain('Attribute Buckets');
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a centralized, reusable evaluation layer that derives football-meaningful outputs (archetype, scheme fit, strengths/weaknesses, role projection, sim-impact) from existing player ratings and AttributesV2 so UI and AI can make tactical decisions beyond raw OVR. 
- Surface tactical context in Roster and Free Agency so roster building and sign/compare workflows answer “what kind of player is this?” and “will he upgrade my starter?” without scattering logic in components. 
- Make Free Agency filtering/sorting and player comparison decision-friendly for lineup planning and scheme fit prioritization.

### Description
- Added `src/core/playerEvaluation.js` implementing: position-group mapping, `deriveAttributeBuckets`, `derivePlayerArchetype`, `deriveSchemeFit`, `derivePlayerRoleProjection`, `derivePlayerSimImpactSummary`, and `buildPlayerEvaluation` that safely handle missing/legacy fields. 
- Integrated evaluation into Roster with an Evaluation view toggle and per-row compact summary showing archetype, fit score/tier, projected role, and sim-impact preview (keeps logic out of UI components). 
- Upgraded Free Agency to compute evaluations for the FA pool and added evaluation-aware features: archetype/fit/role filters, position-need-only filter, a `tactical_fit` sort preset, and visible archetype/fit/role/sim-impact in table/cards/mobile rows. 
- Enhanced Player Comparison to include a tactical section and grouped attribute-bucket comparisons via an exported `buildComparisonViewModel` for testability. 
- Added unit tests covering archetype derivation, scheme fit logic, role-projection safety with partial/older save shapes, comparison view/model rendering, and FA tactical filters/sorting; refactored FA sort/filter helpers into testable functions.

### Testing
- Ran unit tests: `npm run test:unit -- src/core/__tests__/playerEvaluation.test.js src/ui/components/__tests__/playerComparison.test.jsx src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx` and all tests passed (10 tests total). 
- New tests added: `src/core/__tests__/playerEvaluation.test.js`, `src/ui/components/__tests__/playerComparison.test.jsx`, and updates to `src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx`, which validate evaluation and FA filtering/sorting behavior. 
- Evaluation is computed at runtime with safe fallbacks so no save-schema or backend changes were required and tests confirm backward-compatible behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e240890974832dbcaf8709325f979e)