### PR TITLE
Hotfix: prevent route-level request loops in Player Profile and Game Detail

### DIFF
--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -15,6 +15,7 @@ import { buildCompletedGamePresentation, getGameDetailPayload } from "../utils/b
 import { normalizeArchivedGamePayload } from "../../core/gameArchive.js";
 import { buildTeamComparisonRows, PLAYER_STATS_TABLES } from "../../core/footballMeta";
 import GameDetailV2 from "./game/GameDetailV2.tsx";
+import { buildRouteRequestKey, shouldStartRouteRequest, shouldWarnRepeatedRouteRequest } from "../utils/requestLoopGuard.js";
 
 function TeamButton({ team, onSelect }) {
   if (!team) return <span>—</span>;
@@ -196,30 +197,61 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
   const [activeSection, setActiveSection] = useState("summary");
   const [playerTeamFilter, setPlayerTeamFilter] = useState("all");
   const sectionRefs = useRef({});
+  const getBoxScoreRef = useRef(actions?.getBoxScore);
+  const leagueRef = useRef(league);
+  const requestStateRef = useRef({ inFlightKey: null, lastCompletedKey: null, repeatCount: 0, previousKey: null });
 
   useEffect(() => {
+    getBoxScoreRef.current = actions?.getBoxScore;
+  }, [actions?.getBoxScore]);
+
+  useEffect(() => {
+    leagueRef.current = league;
+  }, [league]);
+
+  useEffect(() => {
+    const requestKey = buildRouteRequestKey("game", gameId);
+    const requestState = requestStateRef.current;
+    if (!shouldStartRouteRequest({ requestKey, inFlightKey: requestState.inFlightKey, lastCompletedKey: requestState.lastCompletedKey })) {
+      return;
+    }
+    const getBoxScore = getBoxScoreRef.current;
+    if (!requestKey || !getBoxScore) return;
+
+    const nextRepeatCount = requestState.previousKey === requestKey ? requestState.repeatCount + 1 : 1;
+    if (import.meta.env.DEV && shouldWarnRepeatedRouteRequest({ requestKey, previousKey: requestState.previousKey, repeatCount: requestState.repeatCount })) {
+      console.warn("[BoxScore] repeated box score request for same game", { gameId, repeatCount: nextRepeatCount });
+    }
+    requestState.previousKey = requestKey;
+    requestState.repeatCount = nextRepeatCount;
+    requestState.inFlightKey = requestKey;
+
     let alive = true;
     setLoading(true);
     setError("");
     setGame(null);
 
-    actions?.getBoxScore?.(gameId)
+    getBoxScore(gameId)
       .then((res) => {
         if (!alive) return;
-        const payload = normalizeArchivedGamePayload(res?.game ?? getGameDetailPayload(gameId, league));
+        const payload = normalizeArchivedGamePayload(res?.game ?? getGameDetailPayload(gameId, leagueRef.current));
         setGame(payload ?? null);
         if (!payload) setError(res?.error ?? "Box score unavailable for this game.");
+        requestState.lastCompletedKey = requestKey;
       })
       .catch((err) => {
         if (!alive) return;
         setError(err?.message ?? "Unable to load box score.");
       })
       .finally(() => {
+        if (requestStateRef.current.inFlightKey === requestKey) {
+          requestStateRef.current.inFlightKey = null;
+        }
         if (alive) setLoading(false);
       });
 
     return () => { alive = false; };
-  }, [actions, gameId, league]);
+  }, [gameId]);
 
   useEffect(() => {
     if (!game) return undefined;

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -3,7 +3,7 @@
  *
  * Modal: accolades/legacy badges + position-aware career stats table.
  */
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import TraitBadge from "./TraitBadge";
 import RadarChart from "./RadarChart";
 import ExtensionNegotiationModal from "./ExtensionNegotiationModal.jsx";
@@ -23,6 +23,7 @@ import { PERSONALITY_TOOLTIPS } from '../../core/development/personalitySystem.j
 import { buildDevelopmentNotes, classifyDevelopmentTrend, getPlayerReadiness, getSchemeFitSignal, getAgeCurveContext, getDevelopmentSnapshot, getDevelopmentDrivers } from '../utils/playerDevelopmentSignals.js';
 import { ToneChip, DevelopmentSignalRow, DevelopmentStatCard } from './PlayerDevelopmentUI.jsx';
 import EmptyState from './EmptyState.jsx';
+import { buildRouteRequestKey, shouldStartRouteRequest, shouldWarnRepeatedRouteRequest } from "../utils/requestLoopGuard.js";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
@@ -346,44 +347,56 @@ export default function PlayerProfile({
   const [extending, setExtending] = useState(false);
   const [showProjections, setShowProjections] = useState(false);
   const [activeProfileTab, setActiveProfileTab] = useState("Overview");
+  const getPlayerCareerRef = useRef(actions?.getPlayerCareer);
+  const requestStateRef = useRef({ inFlightKey: null, lastCompletedKey: null, repeatCount: 0, previousKey: null });
 
-  const fetchProfile = React.useCallback(() => {
-    if (!playerId) return;
+  useEffect(() => {
+    getPlayerCareerRef.current = actions?.getPlayerCareer;
+  }, [actions?.getPlayerCareer]);
+
+  const loadProfile = React.useCallback((force = false) => {
+    const requestKey = buildRouteRequestKey("player", playerId);
+    const requestState = requestStateRef.current;
+    if (!shouldStartRouteRequest({ requestKey, inFlightKey: requestState.inFlightKey, lastCompletedKey: requestState.lastCompletedKey, force })) {
+      return Promise.resolve(null);
+    }
+    const getPlayerCareer = getPlayerCareerRef.current;
+    if (!getPlayerCareer) return Promise.resolve(null);
+
+    const nextRepeatCount = requestState.previousKey === requestKey ? requestState.repeatCount + 1 : 1;
+    if (import.meta.env.DEV && shouldWarnRepeatedRouteRequest({ requestKey, previousKey: requestState.previousKey, repeatCount: requestState.repeatCount })) {
+      console.warn("[PlayerProfile] repeated profile request for same player", { playerId, repeatCount: nextRepeatCount });
+    }
+    requestState.previousKey = requestKey;
+    requestState.repeatCount = nextRepeatCount;
+    requestState.inFlightKey = requestKey;
+
     setLoading(true);
-    actions
-      .getPlayerCareer(playerId)
+    return getPlayerCareer(playerId)
       .then((response) => {
-        setData(response.payload ?? response);
-        setLoading(false);
+        setData(response?.payload ?? response);
+        requestState.lastCompletedKey = requestKey;
       })
       .catch((err) => {
         console.error("Failed to load player profile:", err);
+      })
+      .finally(() => {
+        if (requestStateRef.current.inFlightKey === requestKey) {
+          requestStateRef.current.inFlightKey = null;
+        }
         setLoading(false);
       });
-  }, [playerId, actions]);
+  }, [playerId]);
+
+  const fetchProfile = React.useCallback(() => {
+    requestStateRef.current.lastCompletedKey = null;
+    return loadProfile(true);
+  }, [loadProfile]);
 
   useEffect(() => {
-    let stale = false;
     if (!playerId) return;
-    setLoading(true);
-    actions
-      .getPlayerCareer(playerId)
-      .then((response) => {
-        if (!stale) {
-          setData(response.payload ?? response);
-          setLoading(false);
-        }
-      })
-      .catch((err) => {
-        if (!stale) {
-          console.error("Failed to load player profile:", err);
-          setLoading(false);
-        }
-      });
-    return () => {
-      stale = true;
-    };
-  }, [playerId, actions]);
+    loadProfile(false);
+  }, [playerId, loadProfile]);
 
   const player = data?.player;
   const userTeam = useMemo(() => teams.find((t) => t.id === data?.meta?.userTeamId || t.id === player?.teamId), [teams, data?.meta?.userTeamId, player?.teamId]);

--- a/src/ui/components/game/GameDetailV2.test.tsx
+++ b/src/ui/components/game/GameDetailV2.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import GameDetailV2 from './GameDetailV2';
+
+describe('GameDetailV2 tactical recap stability', () => {
+  const teams = {
+    awayTeam: { id: 1, abbr: 'AWY' },
+    homeTeam: { id: 2, abbr: 'HME' },
+  };
+
+  it('renders rich tactical recap payloads', () => {
+    const html = renderToString(
+      <GameDetailV2
+        game={{
+          eventDigest: [{ quarter: 2, clockSec: 201, team: 'away', type: 'explosive_play', text: 'Deep shot sets up score', awayScore: 10, homeScore: 7 }],
+          summary: {
+            headlineMoments: ['QB scramble flips field position'],
+            teamStats: {
+              away: { successRate: 0.48, explosivePlays: 5, redZoneScores: 2, redZoneTrips: 3, passYd: 260, rushYd: 110, plays: 65, sacksMade: 2, turnovers: 1 },
+              home: { successRate: 0.44, explosivePlays: 3, redZoneScores: 1, redZoneTrips: 3, passYd: 215, rushYd: 102, plays: 63, sacksMade: 1, turnovers: 2 },
+            },
+          },
+          topReason1: 'Controlled early-down efficiency',
+        }}
+        {...teams}
+      />,
+    );
+
+    expect(html).toContain('Tactical recap');
+    expect(html).toContain('Controlled early-down efficiency');
+  });
+
+  it('fails safely (returns empty output) for partial/malformed detail payloads', () => {
+    const html = renderToString(
+      <GameDetailV2
+        game={{
+          eventDigest: { not: 'an array' },
+          summary: { headlineMoments: null, teamStats: {} },
+          topReason1: null,
+        }}
+        {...teams}
+      />,
+    );
+
+    expect(html).toBe('');
+  });
+});

--- a/src/ui/utils/requestLoopGuard.js
+++ b/src/ui/utils/requestLoopGuard.js
@@ -1,0 +1,16 @@
+export function buildRouteRequestKey(prefix, id) {
+  if (id == null || id === '') return null;
+  return `${prefix}:${String(id)}`;
+}
+
+export function shouldStartRouteRequest({ requestKey, inFlightKey, lastCompletedKey, force = false }) {
+  if (!requestKey) return false;
+  if (force) return requestKey !== inFlightKey;
+  return requestKey !== inFlightKey && requestKey !== lastCompletedKey;
+}
+
+export function shouldWarnRepeatedRouteRequest({ requestKey, previousKey, repeatCount, threshold = 4 }) {
+  if (!requestKey) return false;
+  const nextCount = previousKey === requestKey ? repeatCount + 1 : 1;
+  return nextCount >= threshold;
+}

--- a/src/ui/utils/requestLoopGuard.test.js
+++ b/src/ui/utils/requestLoopGuard.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { buildRouteRequestKey, shouldStartRouteRequest, shouldWarnRepeatedRouteRequest } from './requestLoopGuard.js';
+
+describe('requestLoopGuard', () => {
+  it('builds stable route keys for primitive ids', () => {
+    expect(buildRouteRequestKey('player', 42)).toBe('player:42');
+    expect(buildRouteRequestKey('game', 'abc')).toBe('game:abc');
+    expect(buildRouteRequestKey('game', null)).toBeNull();
+  });
+
+  it('dedupes in-flight and completed requests for unchanged route ids', () => {
+    const requestKey = buildRouteRequestKey('player', 99);
+    expect(shouldStartRouteRequest({ requestKey, inFlightKey: null, lastCompletedKey: null })).toBe(true);
+    expect(shouldStartRouteRequest({ requestKey, inFlightKey: requestKey, lastCompletedKey: null })).toBe(false);
+    expect(shouldStartRouteRequest({ requestKey, inFlightKey: null, lastCompletedKey: requestKey })).toBe(false);
+    expect(shouldStartRouteRequest({ requestKey, inFlightKey: requestKey, lastCompletedKey: requestKey, force: true })).toBe(false);
+    expect(shouldStartRouteRequest({ requestKey, inFlightKey: null, lastCompletedKey: requestKey, force: true })).toBe(true);
+  });
+
+  it('flags repeated same-id request cycles for dev diagnostics', () => {
+    expect(shouldWarnRepeatedRouteRequest({ requestKey: 'game:4', previousKey: 'game:4', repeatCount: 3 })).toBe(true);
+    expect(shouldWarnRepeatedRouteRequest({ requestKey: 'game:4', previousKey: 'game:5', repeatCount: 20 })).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Recent richer derived-state and worker-driven refreshes caused render → request → setState → render feedback loops in detail routes (React Error #185), often triggered by effects depending on unstable object/function identities.
- The immediate goal is to stop same-ID refetch churn (mount/effect triggering worker requests which update store and re-trigger the same effect) without removing recent tactical/roster functionality.

### Description
- Add a small `requestLoopGuard` utility with `buildRouteRequestKey`, `shouldStartRouteRequest`, and `shouldWarnRepeatedRouteRequest` to produce stable route keys and dedupe requests by logical id. (`src/ui/utils/requestLoopGuard.js`)
- Refactor `PlayerProfile` to use a stable method ref for `actions.getPlayerCareer`, gate effect-triggered requests by the stable `player:<id>` key, and preserve a forced refresh via `fetchProfile`. (`src/ui/components/PlayerProfile.jsx`)
- Refactor `BoxScore` loading to use a stable `getBoxScore` ref and gate requests by a `game:<id>` key, avoiding re-requests from unstable parent props while keeping fallback payload behavior. (`src/ui/components/BoxScore.jsx`)
- Add regression tests: `requestLoopGuard.test.js` for the dedupe/force/repeat-warning behavior and `GameDetailV2.test.tsx` to assert stable rendering for rich and malformed tactical recap payloads. (`src/ui/utils/requestLoopGuard.test.js`, `src/ui/components/game/GameDetailV2.test.tsx`)

### Testing
- Ran unit tests for the new helpers and tactical recap: `npm run test:unit -- src/ui/utils/requestLoopGuard.test.js src/ui/components/game/GameDetailV2.test.tsx`, which passed (`2 files, 5 tests` all green).
- Ran additional existing unit tests touching game detail presentation: `npm run test:unit -- src/ui/components/GameDetailScreen.test.jsx src/ui/utils/boxScorePresentation.test.js`, which also passed (`2 files, 6 tests` all green).
- No tests failed; local unit test suite validated the new guard logic and safe rendering for malformed tactical payloads.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e26441152c832db9178d3e9aa63f7f)