### PR TITLE
Stabilize route detail requests with shared hook for profile and box score views

### DIFF
--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -15,7 +15,8 @@ import { buildCompletedGamePresentation, getGameDetailPayload } from "../utils/b
 import { normalizeArchivedGamePayload } from "../../core/gameArchive.js";
 import { buildTeamComparisonRows, PLAYER_STATS_TABLES } from "../../core/footballMeta";
 import GameDetailV2 from "./game/GameDetailV2.tsx";
-import { buildRouteRequestKey, shouldStartRouteRequest, shouldWarnRepeatedRouteRequest } from "../utils/requestLoopGuard.js";
+import { buildRouteRequestKey } from "../utils/requestLoopGuard.js";
+import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 
 function TeamButton({ team, onSelect }) {
   if (!team) return <span>—</span>;
@@ -190,68 +191,28 @@ export function GameBookQuickNav({ activeSection, onJump }) {
 }
 
 export default function BoxScore({ gameId, actions, league, onClose, onBack, onPlayerSelect, onTeamSelect, embedded = false }) {
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
-  const [game, setGame] = useState(null);
   const [expanded, setExpanded] = useState(false);
   const [activeSection, setActiveSection] = useState("summary");
   const [playerTeamFilter, setPlayerTeamFilter] = useState("all");
   const sectionRefs = useRef({});
-  const getBoxScoreRef = useRef(actions?.getBoxScore);
-  const leagueRef = useRef(league);
-  const requestStateRef = useRef({ inFlightKey: null, lastCompletedKey: null, repeatCount: 0, previousKey: null });
-
-  useEffect(() => {
-    getBoxScoreRef.current = actions?.getBoxScore;
-  }, [actions?.getBoxScore]);
-
-  useEffect(() => {
-    leagueRef.current = league;
-  }, [league]);
-
-  useEffect(() => {
-    const requestKey = buildRouteRequestKey("game", gameId);
-    const requestState = requestStateRef.current;
-    if (!shouldStartRouteRequest({ requestKey, inFlightKey: requestState.inFlightKey, lastCompletedKey: requestState.lastCompletedKey })) {
-      return;
-    }
-    const getBoxScore = getBoxScoreRef.current;
-    if (!requestKey || !getBoxScore) return;
-
-    const nextRepeatCount = requestState.previousKey === requestKey ? requestState.repeatCount + 1 : 1;
-    if (import.meta.env.DEV && shouldWarnRepeatedRouteRequest({ requestKey, previousKey: requestState.previousKey, repeatCount: requestState.repeatCount })) {
-      console.warn("[BoxScore] repeated box score request for same game", { gameId, repeatCount: nextRepeatCount });
-    }
-    requestState.previousKey = requestKey;
-    requestState.repeatCount = nextRepeatCount;
-    requestState.inFlightKey = requestKey;
-
-    let alive = true;
-    setLoading(true);
-    setError("");
-    setGame(null);
-
-    getBoxScore(gameId)
-      .then((res) => {
-        if (!alive) return;
-        const payload = normalizeArchivedGamePayload(res?.game ?? getGameDetailPayload(gameId, leagueRef.current));
-        setGame(payload ?? null);
-        if (!payload) setError(res?.error ?? "Box score unavailable for this game.");
-        requestState.lastCompletedKey = requestKey;
-      })
-      .catch((err) => {
-        if (!alive) return;
-        setError(err?.message ?? "Unable to load box score.");
-      })
-      .finally(() => {
-        if (requestStateRef.current.inFlightKey === requestKey) {
-          requestStateRef.current.inFlightKey = null;
-        }
-        if (alive) setLoading(false);
-      });
-
-    return () => { alive = false; };
-  }, [gameId]);
+  const requestKey = useMemo(() => buildRouteRequestKey("game", gameId), [gameId]);
+  const fetchBoxScore = React.useCallback(async () => {
+    const res = await actions?.getBoxScore?.(gameId);
+    const payload = normalizeArchivedGamePayload(res?.game ?? getGameDetailPayload(gameId, league));
+    return {
+      payload: payload ?? null,
+      errorMessage: payload ? null : (res?.error ?? "Box score unavailable for this game."),
+    };
+  }, [actions, gameId, league]);
+  const { data: requestData, loading, error: requestError } = useStableRouteRequest({
+    requestKey,
+    enabled: gameId != null,
+    fetcher: fetchBoxScore,
+    warnLabel: "BoxScore",
+    clearDataOnLoad: true,
+  });
+  const game = requestData?.payload ?? null;
+  const error = requestError?.message ?? requestData?.errorMessage ?? "";
 
   useEffect(() => {
     if (!game) return undefined;

--- a/src/ui/components/ExtensionNegotiationModal.jsx
+++ b/src/ui/components/ExtensionNegotiationModal.jsx
@@ -2,6 +2,8 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { formatMoneyM, safeRound, toFiniteNumber } from "../utils/numberFormatting.js";
+import { buildRouteRequestKey } from "../utils/requestLoopGuard.js";
+import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 
 export default function ExtensionNegotiationModal({
   player,
@@ -12,28 +14,26 @@ export default function ExtensionNegotiationModal({
   statusNode = null,
 }) {
   const [ask, setAsk] = useState(null);
-  const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [offer, setOffer] = useState(null);
   const [response, setResponse] = useState(null);
+  const requestKey = useMemo(() => buildRouteRequestKey("extension-ask", player?.id), [player?.id]);
+  const fetchExtensionAsk = React.useCallback(async () => {
+    const resp = await actions?.getExtensionAsk?.(player?.id);
+    return resp?.payload?.ask ?? null;
+  }, [actions, player?.id]);
+  const { data: askData, loading } = useStableRouteRequest({
+    requestKey,
+    enabled: player?.id != null,
+    fetcher: fetchExtensionAsk,
+    warnLabel: "ExtensionNegotiationModal",
+    clearDataOnLoad: true,
+  });
 
   useEffect(() => {
-    let stale = false;
-    setLoading(true);
-    actions
-      .getExtensionAsk(player.id)
-      .then((resp) => {
-        if (stale) return;
-        if (resp?.payload?.ask) { setAsk(resp.payload.ask); setOffer(resp.payload.ask); }
-        setLoading(false);
-      })
-      .catch(() => {
-        if (!stale) setLoading(false);
-      });
-    return () => {
-      stale = true;
-    };
-  }, [player.id, actions]);
+    setAsk(askData ?? null);
+    setOffer(askData ?? null);
+  }, [askData]);
 
   const askYears = toFiniteNumber(ask?.years, null);
   const askBaseAnnual = toFiniteNumber(ask?.baseAnnual, null);

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -23,7 +23,8 @@ import { PERSONALITY_TOOLTIPS } from '../../core/development/personalitySystem.j
 import { buildDevelopmentNotes, classifyDevelopmentTrend, getPlayerReadiness, getSchemeFitSignal, getAgeCurveContext, getDevelopmentSnapshot, getDevelopmentDrivers } from '../utils/playerDevelopmentSignals.js';
 import { ToneChip, DevelopmentSignalRow, DevelopmentStatCard } from './PlayerDevelopmentUI.jsx';
 import EmptyState from './EmptyState.jsx';
-import { buildRouteRequestKey, shouldStartRouteRequest, shouldWarnRepeatedRouteRequest } from "../utils/requestLoopGuard.js";
+import { buildRouteRequestKey } from "../utils/requestLoopGuard.js";
+import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
@@ -347,56 +348,29 @@ export default function PlayerProfile({
   const [extending, setExtending] = useState(false);
   const [showProjections, setShowProjections] = useState(false);
   const [activeProfileTab, setActiveProfileTab] = useState("Overview");
-  const getPlayerCareerRef = useRef(actions?.getPlayerCareer);
-  const requestStateRef = useRef({ inFlightKey: null, lastCompletedKey: null, repeatCount: 0, previousKey: null });
+  const requestKey = useMemo(() => buildRouteRequestKey("player", playerId), [playerId]);
+  const fetchProfileData = React.useCallback(async () => {
+    const response = await actions?.getPlayerCareer?.(playerId);
+    return response?.payload ?? response ?? null;
+  }, [actions, playerId]);
+  const {
+    data,
+    loading,
+    error: requestError,
+    refresh: fetchProfile,
+  } = useStableRouteRequest({
+    requestKey,
+    enabled: playerId != null,
+    fetcher: fetchProfileData,
+    warnLabel: 'PlayerProfile',
+    clearDataOnLoad: false,
+  });
 
   useEffect(() => {
-    getPlayerCareerRef.current = actions?.getPlayerCareer;
-  }, [actions?.getPlayerCareer]);
-
-  const loadProfile = React.useCallback((force = false) => {
-    const requestKey = buildRouteRequestKey("player", playerId);
-    const requestState = requestStateRef.current;
-    if (!shouldStartRouteRequest({ requestKey, inFlightKey: requestState.inFlightKey, lastCompletedKey: requestState.lastCompletedKey, force })) {
-      return Promise.resolve(null);
+    if (requestError) {
+      console.error("Failed to load player profile:", requestError);
     }
-    const getPlayerCareer = getPlayerCareerRef.current;
-    if (!getPlayerCareer) return Promise.resolve(null);
-
-    const nextRepeatCount = requestState.previousKey === requestKey ? requestState.repeatCount + 1 : 1;
-    if (import.meta.env.DEV && shouldWarnRepeatedRouteRequest({ requestKey, previousKey: requestState.previousKey, repeatCount: requestState.repeatCount })) {
-      console.warn("[PlayerProfile] repeated profile request for same player", { playerId, repeatCount: nextRepeatCount });
-    }
-    requestState.previousKey = requestKey;
-    requestState.repeatCount = nextRepeatCount;
-    requestState.inFlightKey = requestKey;
-
-    setLoading(true);
-    return getPlayerCareer(playerId)
-      .then((response) => {
-        setData(response?.payload ?? response);
-        requestState.lastCompletedKey = requestKey;
-      })
-      .catch((err) => {
-        console.error("Failed to load player profile:", err);
-      })
-      .finally(() => {
-        if (requestStateRef.current.inFlightKey === requestKey) {
-          requestStateRef.current.inFlightKey = null;
-        }
-        setLoading(false);
-      });
-  }, [playerId]);
-
-  const fetchProfile = React.useCallback(() => {
-    requestStateRef.current.lastCompletedKey = null;
-    return loadProfile(true);
-  }, [loadProfile]);
-
-  useEffect(() => {
-    if (!playerId) return;
-    loadProfile(false);
-  }, [playerId, loadProfile]);
+  }, [requestError]);
 
   const player = data?.player;
   const userTeam = useMemo(() => teams.find((t) => t.id === data?.meta?.userTeamId || t.id === player?.teamId), [teams, data?.meta?.userTeamId, player?.teamId]);

--- a/src/ui/components/TeamProfile.jsx
+++ b/src/ui/components/TeamProfile.jsx
@@ -16,6 +16,8 @@ import { buildTeamIntelligence } from "../utils/teamIntelligence.js";
 import { deriveTeamCoachingIdentity } from "../utils/coachingIdentity.js";
 import { buildTeamChemistrySummary } from "../utils/teamChemistry.js";
 import { franchiseInvestmentSummary } from "../utils/franchiseInvestments.js";
+import { buildRouteRequestKey } from "../utils/requestLoopGuard.js";
+import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -111,25 +113,25 @@ function StatBox({ label, value, sub }) {
 // ── Main component ────────────────────────────────────────────────────────────
 
 export default function TeamProfile({ teamId, onClose, onPlayerSelect, actions, onNavigate = null }) {
-  const [data, setData] = useState(null);
-  const [loading, setLoading] = useState(true);
   const [showRelocate, setShowRelocate] = useState(false);
+  const requestKey = useMemo(() => buildRouteRequestKey("team", teamId), [teamId]);
+  const fetchTeamProfile = React.useCallback(async () => {
+    const resp = await actions?.getTeamProfile?.(teamId);
+    return resp?.payload ?? resp ?? null;
+  }, [actions, teamId]);
+  const { data, loading, error } = useStableRouteRequest({
+    requestKey,
+    enabled: teamId != null,
+    fetcher: fetchTeamProfile,
+    warnLabel: "TeamProfile",
+    clearDataOnLoad: true,
+  });
 
   useEffect(() => {
-    if (!teamId && teamId !== 0) return;
-    setLoading(true);
-    setData(null);
-    actions
-      .getTeamProfile(teamId)
-      .then((resp) => {
-        setData(resp.payload ?? resp);
-        setLoading(false);
-      })
-      .catch((err) => {
-        console.error("TeamProfile fetch failed:", err);
-        setLoading(false);
-      });
-  }, [teamId]);
+    if (error) {
+      console.error("TeamProfile fetch failed:", error);
+    }
+  }, [error]);
 
   if (teamId == null) return null;
 

--- a/src/ui/hooks/useStableRouteRequest.js
+++ b/src/ui/hooks/useStableRouteRequest.js
@@ -1,0 +1,198 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { shouldWarnRepeatedRouteRequest } from '../utils/requestLoopGuard.js';
+
+const inFlightRequests = new Map();
+const completedRequestCache = new Map();
+export function __resetStableRouteRequestCache() {
+  inFlightRequests.clear();
+  completedRequestCache.clear();
+}
+
+function normalizeError(error, fallbackMessage) {
+  if (error instanceof Error) return error;
+  return new Error(error?.message ?? fallbackMessage);
+}
+
+export function createStableRouteRequestController({
+  warnLabel = 'RouteRequest',
+  warnThreshold = 4,
+  onStateChange = null,
+} = {}) {
+  const state = { data: null, loading: false, error: null };
+  let activeToken = 0;
+  let previousKey = null;
+  let repeatCount = 0;
+
+  const emit = () => {
+    onStateChange?.({ ...state });
+  };
+
+  const request = async ({
+    requestKey,
+    fetcher,
+    enabled = true,
+    force = false,
+    clearDataOnLoad = true,
+  }) => {
+    if (!enabled || !requestKey || !fetcher) {
+      state.loading = false;
+      emit();
+      return null;
+    }
+
+    if (!force && completedRequestCache.has(requestKey)) {
+      state.data = completedRequestCache.get(requestKey);
+      state.error = null;
+      state.loading = false;
+      emit();
+      return state.data;
+    }
+
+    const token = activeToken + 1;
+    activeToken = token;
+
+    const existingInFlight = inFlightRequests.get(requestKey);
+    if (existingInFlight) {
+      state.loading = true;
+      state.error = null;
+      emit();
+      return existingInFlight
+        .then((result) => {
+          if (activeToken !== token) return result ?? null;
+          state.data = result ?? null;
+          state.error = null;
+          emit();
+          return result ?? null;
+        })
+        .catch((err) => {
+          const normalized = normalizeError(err, 'Unable to load route data.');
+          if (activeToken === token) {
+            state.error = normalized;
+            emit();
+          }
+          throw normalized;
+        })
+        .finally(() => {
+          if (activeToken === token) {
+            state.loading = false;
+            emit();
+          }
+        });
+    }
+
+    const nextRepeatCount = previousKey === requestKey ? repeatCount + 1 : 1;
+    if (
+      import.meta.env.DEV
+      && shouldWarnRepeatedRouteRequest({ requestKey, previousKey, repeatCount, threshold: warnThreshold })
+    ) {
+      console.warn(`[${warnLabel}] repeated request for key`, { requestKey, repeatCount: nextRepeatCount });
+    }
+    previousKey = requestKey;
+    repeatCount = nextRepeatCount;
+
+    state.loading = true;
+    state.error = null;
+    if (clearDataOnLoad) state.data = null;
+    emit();
+
+    const pendingRequest = Promise.resolve()
+      .then(() => fetcher())
+      .then((result) => {
+        completedRequestCache.set(requestKey, result ?? null);
+        if (activeToken !== token) return result ?? null;
+        state.data = result ?? null;
+        state.error = null;
+        emit();
+        return result ?? null;
+      })
+      .catch((err) => {
+        const normalized = normalizeError(err, 'Unable to load route data.');
+        if (activeToken === token) {
+          state.error = normalized;
+          emit();
+        }
+        throw normalized;
+      })
+      .finally(() => {
+        if (inFlightRequests.get(requestKey) === pendingRequest) {
+          inFlightRequests.delete(requestKey);
+        }
+        if (activeToken === token) {
+          state.loading = false;
+          emit();
+        }
+      });
+
+    inFlightRequests.set(requestKey, pendingRequest);
+    return pendingRequest;
+  };
+
+  const refresh = ({ requestKey, fetcher, enabled = true, clearDataOnLoad = true }) => {
+    if (!requestKey) return Promise.resolve(null);
+    completedRequestCache.delete(requestKey);
+    return request({ requestKey, fetcher, enabled, force: true, clearDataOnLoad });
+  };
+
+  return { request, refresh };
+}
+
+export default function useStableRouteRequest({
+  requestKey,
+  fetcher,
+  enabled = true,
+  warnLabel = 'RouteRequest',
+  warnThreshold = 4,
+  clearDataOnLoad = true,
+}) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetcherRef = useRef(fetcher);
+  const controllerRef = useRef(null);
+
+  if (!controllerRef.current) {
+    controllerRef.current = createStableRouteRequestController({
+      warnLabel,
+      warnThreshold,
+      onStateChange: ({ data: nextData, loading: nextLoading, error: nextError }) => {
+        setData(nextData);
+        setLoading(nextLoading);
+        setError(nextError);
+      },
+    });
+  }
+
+  useEffect(() => {
+    fetcherRef.current = fetcher;
+  }, [fetcher]);
+
+  const startRequest = useCallback((force = false) => controllerRef.current.request({
+    requestKey,
+    fetcher: fetcherRef.current,
+    enabled,
+    force,
+    clearDataOnLoad,
+  }), [clearDataOnLoad, enabled, requestKey]);
+
+  useEffect(() => {
+    if (!enabled || !requestKey) {
+      setLoading(false);
+      setError(null);
+      setData(null);
+      return;
+    }
+    startRequest(false).catch(() => {});
+  }, [enabled, requestKey, startRequest]);
+
+  const refresh = useCallback(() => {
+    return controllerRef.current.refresh({
+      requestKey,
+      fetcher: fetcherRef.current,
+      enabled,
+      clearDataOnLoad,
+    });
+  }, [clearDataOnLoad, enabled, requestKey]);
+
+  return { data, loading, error, refresh };
+}

--- a/src/ui/hooks/useStableRouteRequest.test.jsx
+++ b/src/ui/hooks/useStableRouteRequest.test.jsx
@@ -1,0 +1,125 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { buildRouteRequestKey } from '../utils/requestLoopGuard.js';
+import {
+  __resetStableRouteRequestCache,
+  createStableRouteRequestController,
+} from './useStableRouteRequest.js';
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('useStableRouteRequest controller behavior', () => {
+  beforeEach(() => {
+    __resetStableRouteRequestCache();
+  });
+
+  it('suppresses stale player responses when route id changes rapidly', async () => {
+    const snapshots = [];
+    const requests = new Map();
+    const fetcher = vi.fn((id) => {
+      const d = deferred();
+      requests.set(id, d);
+      return d.promise;
+    });
+    const controller = createStableRouteRequestController({
+      onStateChange: (state) => snapshots.push(state),
+    });
+
+    const requestA = controller.request({
+      requestKey: buildRouteRequestKey('player', 1),
+      fetcher: () => fetcher(1),
+    });
+    const requestB = controller.request({
+      requestKey: buildRouteRequestKey('player', 2),
+      fetcher: () => fetcher(2),
+    });
+    await Promise.resolve();
+
+    requests.get(2).resolve({ player: { id: 2 } });
+    await requestB;
+    requests.get(1).resolve({ player: { id: 1 } });
+    await requestA;
+
+    const latest = snapshots.at(-1);
+    expect(latest.data.player.id).toBe(2);
+    expect(latest.error).toBeNull();
+    expect(latest.loading).toBe(false);
+  });
+
+  it('prevents stale team request errors from replacing newer successes', async () => {
+    const snapshots = [];
+    const requests = new Map();
+    const fetcher = vi.fn((id) => {
+      const d = deferred();
+      requests.set(id, d);
+      return d.promise;
+    });
+    const controller = createStableRouteRequestController({
+      onStateChange: (state) => snapshots.push(state),
+    });
+
+    const oldReq = controller.request({
+      requestKey: buildRouteRequestKey('team', 10),
+      fetcher: () => fetcher(10),
+    }).catch(() => {});
+    const newReq = controller.request({
+      requestKey: buildRouteRequestKey('team', 20),
+      fetcher: () => fetcher(20),
+    });
+    await Promise.resolve();
+
+    requests.get(20).resolve({ team: { id: 20 } });
+    await newReq;
+    requests.get(10).reject(new Error('old failed'));
+    await oldReq;
+
+    const latest = snapshots.at(-1);
+    expect(latest.data.team.id).toBe(20);
+    expect(latest.error).toBeNull();
+    expect(latest.loading).toBe(false);
+  });
+
+  it('dedupes same-key requests and only re-fetches on forced refresh', async () => {
+    const snapshots = [];
+    const requestA = deferred();
+    const fetcher = vi.fn(() => requestA.promise);
+    const controller = createStableRouteRequestController({
+      onStateChange: (state) => snapshots.push(state),
+    });
+
+    const one = controller.request({
+      requestKey: buildRouteRequestKey('game', 'g1'),
+      fetcher,
+    });
+    const two = controller.request({
+      requestKey: buildRouteRequestKey('game', 'g1'),
+      fetcher,
+    });
+
+    requestA.resolve({ game: { id: 'g1' } });
+    await one;
+    await two;
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    const refreshRequest = deferred();
+    fetcher.mockImplementationOnce(() => refreshRequest.promise);
+    const refreshPromise = controller.refresh({
+      requestKey: buildRouteRequestKey('game', 'g1'),
+      fetcher,
+    });
+    refreshRequest.resolve({ game: { id: 'g1', rev: 2 } });
+    await refreshPromise;
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    const latest = snapshots.at(-1);
+    expect(latest.data.game.rev).toBe(2);
+    expect(latest.loading).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Rapid route switching could allow stale async worker responses (or errors) to overwrite newer selections and repeated same-id renders could spam worker requests; the existing `requestLoopGuard` was a partial fix but request logic remained duplicated across detail components.
- Centralize and harden route/detail fetch behavior to prevent stale-response overwrites, repeated same-id churn, and loading/error state drift while keeping the current worker protocol and visible UI unchanged.

### Description
- Added a reusable hook `src/ui/hooks/useStableRouteRequest.js` that provides stable logical keys, in-flight same-key dedupe, completed-key caching (no auto-refetch unless forced), stale-response/error suppression via token gating, an explicit `refresh()` API, and optional dev-only repeated-request warnings; also exported a controller (`createStableRouteRequestController`) and a test helper `__resetStableRouteRequestCache()` for deterministic tests.
- Migrated detail views to the shared hook with minimal changes: `src/ui/components/PlayerProfile.jsx` now uses `player:<id>`, `src/ui/components/TeamProfile.jsx` uses `team:<id>`, `src/ui/components/BoxScore.jsx` uses `game:<id>`, and the modal `src/ui/components/ExtensionNegotiationModal.jsx` was also migrated to the same pattern (`extension-ask:<playerId>`), preserving existing normalization and fallback behavior.
- Kept object/function references stable and avoided redesigning UI or changing worker message shapes; added small console error reporting where components previously logged failures.

### Testing
- Added targeted controller tests `src/ui/hooks/useStableRouteRequest.test.jsx` covering stale-response suppression, stale error suppression, same-key dedupe, and forced refresh, and ran the related unit tests along with existing guard/box score tests with Vitest using `npm run test:unit` for the files below; all tests passed.
  - Executed tests: `src/ui/hooks/useStableRouteRequest.test.jsx`, `src/ui/utils/requestLoopGuard.test.js`, `src/ui/components/BoxScore.test.jsx`, `src/ui/components/game/GameDetailV2.test.tsx` and they passed (11 tests total).
- Tests exercise the new controller directly to validate token-based stale suppression and dedupe logic; no UI behavior changes beyond eliminating race flashes were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e26cefccb8832d90d3f54d082b9f7a)