### PR TITLE
Scope stable route request cache to active league context

### DIFF
--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -196,6 +196,10 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
   const [playerTeamFilter, setPlayerTeamFilter] = useState("all");
   const sectionRefs = useRef({});
   const requestKey = useMemo(() => buildRouteRequestKey("game", gameId), [gameId]);
+  const cacheScopeKey = useMemo(
+    () => `${league?.seasonId ?? league?.year ?? 'season'}:${league?.week ?? 0}`,
+    [league?.seasonId, league?.week, league?.year],
+  );
   const fetchBoxScore = React.useCallback(async () => {
     const res = await actions?.getBoxScore?.(gameId);
     const payload = normalizeArchivedGamePayload(res?.game ?? getGameDetailPayload(gameId, league));
@@ -206,6 +210,7 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
   }, [actions, gameId, league]);
   const { data: requestData, loading, error: requestError } = useStableRouteRequest({
     requestKey,
+    cacheScopeKey,
     enabled: gameId != null,
     fetcher: fetchBoxScore,
     warnLabel: "BoxScore",

--- a/src/ui/components/ContractCenter.jsx
+++ b/src/ui/components/ContractCenter.jsx
@@ -437,6 +437,7 @@ export default function ContractCenter({ league, actions, compact = false, onNav
           player={extensionPlayer}
           teamId={team?.id}
           actions={actions}
+          cacheScopeKey={`${league?.seasonId ?? league?.year ?? 'season'}:${league?.week ?? 0}`}
           onClose={() => setExtensionPlayer(null)}
           onComplete={() => {
             setStatusMessage(`${extensionPlayer.name} extension signed.`);

--- a/src/ui/components/Draft.jsx
+++ b/src/ui/components/Draft.jsx
@@ -2490,6 +2490,7 @@ export default function Draft({ league, actions, onNavigate = null }) {
           playerId={profilePlayerId}
           onClose={() => setProfilePlayerId(null)}
           actions={actions}
+          league={league}
           isUserOnClock={
             enrichedDraftState?.isUserPick &&
             !enrichedDraftState?.isDraftComplete

--- a/src/ui/components/ExtensionNegotiationModal.jsx
+++ b/src/ui/components/ExtensionNegotiationModal.jsx
@@ -9,6 +9,7 @@ export default function ExtensionNegotiationModal({
   player,
   actions,
   teamId,
+  cacheScopeKey = "global",
   onClose,
   onComplete,
   statusNode = null,
@@ -24,6 +25,7 @@ export default function ExtensionNegotiationModal({
   }, [actions, player?.id]);
   const { data: askData, loading } = useStableRouteRequest({
     requestKey,
+    cacheScopeKey,
     enabled: player?.id != null,
     fetcher: fetchExtensionAsk,
     warnLabel: "ExtensionNegotiationModal",

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -2067,6 +2067,7 @@ export default function LeagueDashboard({
             onClose={() => setSelectedPlayerId(null)}
             actions={actions}
             teams={league.teams}
+            league={league}
             onNavigate={setActiveTab}
           />
         </TabErrorBoundary>
@@ -2083,6 +2084,7 @@ export default function LeagueDashboard({
               setSelectedPlayerId(id);
             }}
             actions={actions}
+            league={league}
             onNavigate={setActiveTab}
           />
         </TabErrorBoundary>

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -339,6 +339,7 @@ export default function PlayerProfile({
   onClose,
   actions,
   teams = [],
+  league = null,
   onNavigate = null,
   isUserOnClock = false,
   onDraftPlayer = null,
@@ -349,6 +350,10 @@ export default function PlayerProfile({
   const [showProjections, setShowProjections] = useState(false);
   const [activeProfileTab, setActiveProfileTab] = useState("Overview");
   const requestKey = useMemo(() => buildRouteRequestKey("player", playerId), [playerId]);
+  const cacheScopeKey = useMemo(
+    () => `${league?.seasonId ?? league?.year ?? 'season'}:${league?.week ?? 0}`,
+    [league?.seasonId, league?.week, league?.year],
+  );
   const fetchProfileData = React.useCallback(async () => {
     const response = await actions?.getPlayerCareer?.(playerId);
     return response?.payload ?? response ?? null;
@@ -360,6 +365,7 @@ export default function PlayerProfile({
     refresh: fetchProfile,
   } = useStableRouteRequest({
     requestKey,
+    cacheScopeKey,
     enabled: playerId != null,
     fetcher: fetchProfileData,
     warnLabel: 'PlayerProfile',
@@ -1529,6 +1535,7 @@ export default function PlayerProfile({
           player={player}
           actions={actions}
           teamId={player.teamId}
+          cacheScopeKey={cacheScopeKey}
           onClose={() => setExtending(false)}
           onComplete={() => {
             setExtending(false);

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -619,6 +619,7 @@ function RosterTable({
           player={extending}
           actions={actions}
           teamId={teamId}
+          cacheScopeKey={`${league?.seasonId ?? league?.year ?? 'season'}:${league?.week ?? 0}`}
           statusNode={<StatusBadge injuryWeeks={extending.injuryWeeksRemaining} />}
           onClose={() => setExtending(null)}
           onComplete={() => {
@@ -2422,6 +2423,7 @@ export default function Roster({ league, actions, onPlayerSelect, onNavigate = n
           playerId={selectedPlayerId}
           actions={actions}
           teams={league?.teams ?? []}
+          league={league}
           onClose={() => setSelectedPlayerId(null)}
         />
       )}

--- a/src/ui/components/TeamProfile.jsx
+++ b/src/ui/components/TeamProfile.jsx
@@ -112,15 +112,20 @@ function StatBox({ label, value, sub }) {
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export default function TeamProfile({ teamId, onClose, onPlayerSelect, actions, onNavigate = null }) {
+export default function TeamProfile({ teamId, onClose, onPlayerSelect, actions, onNavigate = null, league = null }) {
   const [showRelocate, setShowRelocate] = useState(false);
   const requestKey = useMemo(() => buildRouteRequestKey("team", teamId), [teamId]);
+  const cacheScopeKey = useMemo(
+    () => `${league?.seasonId ?? league?.year ?? 'season'}:${league?.week ?? 0}`,
+    [league?.seasonId, league?.week, league?.year],
+  );
   const fetchTeamProfile = React.useCallback(async () => {
     const resp = await actions?.getTeamProfile?.(teamId);
     return resp?.payload ?? resp ?? null;
   }, [actions, teamId]);
   const { data, loading, error } = useStableRouteRequest({
     requestKey,
+    cacheScopeKey,
     enabled: teamId != null,
     fetcher: fetchTeamProfile,
     warnLabel: "TeamProfile",

--- a/src/ui/hooks/useStableRouteRequest.js
+++ b/src/ui/hooks/useStableRouteRequest.js
@@ -3,9 +3,29 @@ import { shouldWarnRepeatedRouteRequest } from '../utils/requestLoopGuard.js';
 
 const inFlightRequests = new Map();
 const completedRequestCache = new Map();
+
+function buildScopedRequestKey(requestKey, cacheScopeKey) {
+  const scope = cacheScopeKey == null || cacheScopeKey === '' ? 'global' : String(cacheScopeKey);
+  return `${scope}::${requestKey}`;
+}
+
 export function __resetStableRouteRequestCache() {
   inFlightRequests.clear();
   completedRequestCache.clear();
+}
+
+export function __invalidateStableRouteRequestCache(cacheScopeKey = null) {
+  if (cacheScopeKey == null) {
+    __resetStableRouteRequestCache();
+    return;
+  }
+  const scopePrefix = `${String(cacheScopeKey)}::`;
+  for (const key of inFlightRequests.keys()) {
+    if (key.startsWith(scopePrefix)) inFlightRequests.delete(key);
+  }
+  for (const key of completedRequestCache.keys()) {
+    if (key.startsWith(scopePrefix)) completedRequestCache.delete(key);
+  }
 }
 
 function normalizeError(error, fallbackMessage) {
@@ -30,6 +50,7 @@ export function createStableRouteRequestController({
   const request = async ({
     requestKey,
     fetcher,
+    cacheScopeKey = 'global',
     enabled = true,
     force = false,
     clearDataOnLoad = true,
@@ -40,8 +61,10 @@ export function createStableRouteRequestController({
       return null;
     }
 
-    if (!force && completedRequestCache.has(requestKey)) {
-      state.data = completedRequestCache.get(requestKey);
+    const scopedRequestKey = buildScopedRequestKey(requestKey, cacheScopeKey);
+
+    if (!force && completedRequestCache.has(scopedRequestKey)) {
+      state.data = completedRequestCache.get(scopedRequestKey);
       state.error = null;
       state.loading = false;
       emit();
@@ -51,7 +74,7 @@ export function createStableRouteRequestController({
     const token = activeToken + 1;
     activeToken = token;
 
-    const existingInFlight = inFlightRequests.get(requestKey);
+    const existingInFlight = inFlightRequests.get(scopedRequestKey);
     if (existingInFlight) {
       state.loading = true;
       state.error = null;
@@ -98,7 +121,7 @@ export function createStableRouteRequestController({
     const pendingRequest = Promise.resolve()
       .then(() => fetcher())
       .then((result) => {
-        completedRequestCache.set(requestKey, result ?? null);
+        completedRequestCache.set(scopedRequestKey, result ?? null);
         if (activeToken !== token) return result ?? null;
         state.data = result ?? null;
         state.error = null;
@@ -114,8 +137,8 @@ export function createStableRouteRequestController({
         throw normalized;
       })
       .finally(() => {
-        if (inFlightRequests.get(requestKey) === pendingRequest) {
-          inFlightRequests.delete(requestKey);
+        if (inFlightRequests.get(scopedRequestKey) === pendingRequest) {
+          inFlightRequests.delete(scopedRequestKey);
         }
         if (activeToken === token) {
           state.loading = false;
@@ -123,14 +146,14 @@ export function createStableRouteRequestController({
         }
       });
 
-    inFlightRequests.set(requestKey, pendingRequest);
+    inFlightRequests.set(scopedRequestKey, pendingRequest);
     return pendingRequest;
   };
 
-  const refresh = ({ requestKey, fetcher, enabled = true, clearDataOnLoad = true }) => {
+  const refresh = ({ requestKey, fetcher, cacheScopeKey = 'global', enabled = true, clearDataOnLoad = true }) => {
     if (!requestKey) return Promise.resolve(null);
-    completedRequestCache.delete(requestKey);
-    return request({ requestKey, fetcher, enabled, force: true, clearDataOnLoad });
+    completedRequestCache.delete(buildScopedRequestKey(requestKey, cacheScopeKey));
+    return request({ requestKey, fetcher, cacheScopeKey, enabled, force: true, clearDataOnLoad });
   };
 
   return { request, refresh };
@@ -139,6 +162,7 @@ export function createStableRouteRequestController({
 export default function useStableRouteRequest({
   requestKey,
   fetcher,
+  cacheScopeKey = 'global',
   enabled = true,
   warnLabel = 'RouteRequest',
   warnThreshold = 4,
@@ -170,10 +194,11 @@ export default function useStableRouteRequest({
   const startRequest = useCallback((force = false) => controllerRef.current.request({
     requestKey,
     fetcher: fetcherRef.current,
+    cacheScopeKey,
     enabled,
     force,
     clearDataOnLoad,
-  }), [clearDataOnLoad, enabled, requestKey]);
+  }), [cacheScopeKey, clearDataOnLoad, enabled, requestKey]);
 
   useEffect(() => {
     if (!enabled || !requestKey) {
@@ -183,16 +208,17 @@ export default function useStableRouteRequest({
       return;
     }
     startRequest(false).catch(() => {});
-  }, [enabled, requestKey, startRequest]);
+  }, [cacheScopeKey, enabled, requestKey, startRequest]);
 
   const refresh = useCallback(() => {
     return controllerRef.current.refresh({
       requestKey,
       fetcher: fetcherRef.current,
+      cacheScopeKey,
       enabled,
       clearDataOnLoad,
     });
-  }, [clearDataOnLoad, enabled, requestKey]);
+  }, [cacheScopeKey, clearDataOnLoad, enabled, requestKey]);
 
   return { data, loading, error, refresh };
 }

--- a/src/ui/hooks/useStableRouteRequest.test.jsx
+++ b/src/ui/hooks/useStableRouteRequest.test.jsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import { buildRouteRequestKey } from '../utils/requestLoopGuard.js';
 import {
+  __invalidateStableRouteRequestCache,
   __resetStableRouteRequestCache,
   createStableRouteRequestController,
 } from './useStableRouteRequest.js';
@@ -96,10 +97,12 @@ describe('useStableRouteRequest controller behavior', () => {
 
     const one = controller.request({
       requestKey: buildRouteRequestKey('game', 'g1'),
+      cacheScopeKey: 'scope-a',
       fetcher,
     });
     const two = controller.request({
       requestKey: buildRouteRequestKey('game', 'g1'),
+      cacheScopeKey: 'scope-a',
       fetcher,
     });
 
@@ -112,6 +115,7 @@ describe('useStableRouteRequest controller behavior', () => {
     fetcher.mockImplementationOnce(() => refreshRequest.promise);
     const refreshPromise = controller.refresh({
       requestKey: buildRouteRequestKey('game', 'g1'),
+      cacheScopeKey: 'scope-a',
       fetcher,
     });
     refreshRequest.resolve({ game: { id: 'g1', rev: 2 } });
@@ -121,5 +125,75 @@ describe('useStableRouteRequest controller behavior', () => {
     const latest = snapshots.at(-1);
     expect(latest.data.game.rev).toBe(2);
     expect(latest.loading).toBe(false);
+  });
+
+  it('isolates completed cache entries by scope', async () => {
+    const controller = createStableRouteRequestController();
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce({ player: { id: 1, scope: 'A' } })
+      .mockResolvedValueOnce({ player: { id: 1, scope: 'B' } });
+
+    await controller.request({
+      requestKey: buildRouteRequestKey('player', 1),
+      cacheScopeKey: 'scope-a',
+      fetcher,
+    });
+    await controller.request({
+      requestKey: buildRouteRequestKey('player', 1),
+      cacheScopeKey: 'scope-b',
+      fetcher,
+    });
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps in-flight dedupe isolated by scope', async () => {
+    const controller = createStableRouteRequestController();
+    const scopedA = deferred();
+    const scopedB = deferred();
+    const fetcher = vi.fn((scope) => (scope === 'scope-a' ? scopedA.promise : scopedB.promise));
+
+    const reqA1 = controller.request({
+      requestKey: buildRouteRequestKey('team', 5),
+      cacheScopeKey: 'scope-a',
+      fetcher: () => fetcher('scope-a'),
+    });
+    const reqA2 = controller.request({
+      requestKey: buildRouteRequestKey('team', 5),
+      cacheScopeKey: 'scope-a',
+      fetcher: () => fetcher('scope-a'),
+    });
+    const reqB = controller.request({
+      requestKey: buildRouteRequestKey('team', 5),
+      cacheScopeKey: 'scope-b',
+      fetcher: () => fetcher('scope-b'),
+    });
+
+    scopedA.resolve({ team: { id: 5, scope: 'A' } });
+    scopedB.resolve({ team: { id: 5, scope: 'B' } });
+    await Promise.all([reqA1, reqA2, reqB]);
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidates completed cache by scope when requested', async () => {
+    const controller = createStableRouteRequestController();
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce({ game: { id: 'g1', rev: 1 } })
+      .mockResolvedValueOnce({ game: { id: 'g1', rev: 2 } });
+
+    await controller.request({
+      requestKey: buildRouteRequestKey('game', 'g1'),
+      cacheScopeKey: 'scope-a',
+      fetcher,
+    });
+    __invalidateStableRouteRequestCache('scope-a');
+    await controller.request({
+      requestKey: buildRouteRequestKey('game', 'g1'),
+      cacheScopeKey: 'scope-a',
+      fetcher,
+    });
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent completed-request cache entries from leaking across different saves/leagues (stale detail views) while keeping the existing dedupe, stale-response suppression, and manual refresh semantics.
- Make the smallest, surgical change to avoid a large refactor and rely on an explicit, reliable scope key derived from existing league context.

### Description
- Added scoped cache keys to `useStableRouteRequest` by introducing `cacheScopeKey` and internal `buildScopedRequestKey` so completed/in-flight entries are keyed by scope + request key rather than globally. (F: `src/ui/hooks/useStableRouteRequest.js`)
- Exposed `__invalidateStableRouteRequestCache(cacheScopeKey)` to allow targeted invalidation of completed/in-flight entries for a scope (or full reset when called with no arg). (F: `src/ui/hooks/useStableRouteRequest.js`)
- Preserved previous controller behavior (in-flight dedupe, stale token suppression, forced refresh) by applying scoping only to cache/in-flight map keys and threading `cacheScopeKey` through `request` / `refresh` APIs.
- Plumbed the smallest reliable scope into consumers by passing a `cacheScopeKey` derived from existing `league` state (`seasonId || year` + `week`) to route-detail components: `PlayerProfile`, `TeamProfile`, `BoxScore`, and `ExtensionNegotiationModal`; added minimal prop plumbing where needed (e.g., `LeagueDashboard`, `Roster`, `Draft`, `ContractCenter`).
- Tests were added/updated to validate scope isolation and the existing behaviors (see test file). (F: `src/ui/hooks/useStableRouteRequest.test.jsx`)

### Testing
- Unit tests: `npm run test:unit -- src/ui/hooks/useStableRouteRequest.test.jsx` were run and all tests passed; output: "1 passed (6 tests)".
- The updated test suite covers scope-isolated completed cache behavior, same-scope in-flight dedupe, manual refresh in scope, stale-response suppression, and explicit scope invalidation (F: `src/ui/hooks/useStableRouteRequest.test.jsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e275688294832d9af4b719b2c1537e)