### PR TITLE
Implement Runtime Route-Detail Cache Invalidation

### DIFF
--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -15,7 +15,7 @@ import { buildCompletedGamePresentation, getGameDetailPayload } from "../utils/b
 import { normalizeArchivedGamePayload } from "../../core/gameArchive.js";
 import { buildTeamComparisonRows, PLAYER_STATS_TABLES } from "../../core/footballMeta";
 import GameDetailV2 from "./game/GameDetailV2.tsx";
-import { buildRouteRequestKey } from "../utils/requestLoopGuard.js";
+import { buildRouteRequestKey, buildLeagueCacheScopeKey } from "../utils/requestLoopGuard.js";
 import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 
 function TeamButton({ team, onSelect }) {
@@ -196,10 +196,7 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
   const [playerTeamFilter, setPlayerTeamFilter] = useState("all");
   const sectionRefs = useRef({});
   const requestKey = useMemo(() => buildRouteRequestKey("game", gameId), [gameId]);
-  const cacheScopeKey = useMemo(
-    () => `${league?.seasonId ?? league?.year ?? 'season'}:${league?.week ?? 0}`,
-    [league?.seasonId, league?.week, league?.year],
-  );
+  const cacheScopeKey = useMemo(() => buildLeagueCacheScopeKey(league), [league]);
   const fetchBoxScore = React.useCallback(async () => {
     const res = await actions?.getBoxScore?.(gameId);
     const payload = normalizeArchivedGamePayload(res?.game ?? getGameDetailPayload(gameId, league));

--- a/src/ui/components/ContractCenter.jsx
+++ b/src/ui/components/ContractCenter.jsx
@@ -1,3 +1,4 @@
+import { buildLeagueCacheScopeKey } from "../utils/requestLoopGuard.js";
 import React, { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import ExtensionNegotiationModal from './ExtensionNegotiationModal.jsx';
@@ -437,7 +438,7 @@ export default function ContractCenter({ league, actions, compact = false, onNav
           player={extensionPlayer}
           teamId={team?.id}
           actions={actions}
-          cacheScopeKey={`${league?.seasonId ?? league?.year ?? 'season'}:${league?.week ?? 0}`}
+          cacheScopeKey={buildLeagueCacheScopeKey(league)}
           onClose={() => setExtensionPlayer(null)}
           onComplete={() => {
             setStatusMessage(`${extensionPlayer.name} extension signed.`);

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -335,8 +335,6 @@ function getTeamName(teamId, teams) {
 }
 
 export default function PlayerProfile({
-  const [localData, setLocalData] = useState(null);
-
   playerId,
   onClose,
   actions,

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -23,7 +23,7 @@ import { PERSONALITY_TOOLTIPS } from '../../core/development/personalitySystem.j
 import { buildDevelopmentNotes, classifyDevelopmentTrend, getPlayerReadiness, getSchemeFitSignal, getAgeCurveContext, getDevelopmentSnapshot, getDevelopmentDrivers } from '../utils/playerDevelopmentSignals.js';
 import { ToneChip, DevelopmentSignalRow, DevelopmentStatCard } from './PlayerDevelopmentUI.jsx';
 import EmptyState from './EmptyState.jsx';
-import { buildRouteRequestKey } from "../utils/requestLoopGuard.js";
+import { buildRouteRequestKey, buildLeagueCacheScopeKey } from "../utils/requestLoopGuard.js";
 import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
@@ -335,6 +335,8 @@ function getTeamName(teamId, teams) {
 }
 
 export default function PlayerProfile({
+  const [localData, setLocalData] = useState(null);
+
   playerId,
   onClose,
   actions,
@@ -344,22 +346,20 @@ export default function PlayerProfile({
   isUserOnClock = false,
   onDraftPlayer = null,
 }) {
+
   const [data, setData] = useState(null);
-  const [loading, setLoading] = useState(true);
+  const [loadingLocal, setLoadingLocal] = useState(true);
   const [extending, setExtending] = useState(false);
   const [showProjections, setShowProjections] = useState(false);
   const [activeProfileTab, setActiveProfileTab] = useState("Overview");
   const requestKey = useMemo(() => buildRouteRequestKey("player", playerId), [playerId]);
-  const cacheScopeKey = useMemo(
-    () => `${league?.seasonId ?? league?.year ?? 'season'}:${league?.week ?? 0}`,
-    [league?.seasonId, league?.week, league?.year],
-  );
+  const cacheScopeKey = useMemo(() => buildLeagueCacheScopeKey(league), [league]);
   const fetchProfileData = React.useCallback(async () => {
     const response = await actions?.getPlayerCareer?.(playerId);
     return response?.payload ?? response ?? null;
   }, [actions, playerId]);
   const {
-    data,
+    data: fetchedData,
     loading,
     error: requestError,
     refresh: fetchProfile,
@@ -378,6 +378,10 @@ export default function PlayerProfile({
     }
   }, [requestError]);
 
+
+  useEffect(() => {
+    if (fetchedData) setData(fetchedData);
+  }, [fetchedData]);
   const player = data?.player;
   const userTeam = useMemo(() => teams.find((t) => t.id === data?.meta?.userTeamId || t.id === player?.teamId), [teams, data?.meta?.userTeamId, player?.teamId]);
   const teamIntel = useMemo(() => buildTeamIntelligence(userTeam, { week: data?.meta?.week ?? 1 }), [userTeam, data?.meta?.week]);

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -1,3 +1,4 @@
+import { buildLeagueCacheScopeKey } from "../utils/requestLoopGuard.js";
 /**
  * Roster.jsx
  *
@@ -619,7 +620,7 @@ function RosterTable({
           player={extending}
           actions={actions}
           teamId={teamId}
-          cacheScopeKey={`${league?.seasonId ?? league?.year ?? 'season'}:${league?.week ?? 0}`}
+          cacheScopeKey={buildLeagueCacheScopeKey(league)}
           statusNode={<StatusBadge injuryWeeks={extending.injuryWeeksRemaining} />}
           onClose={() => setExtending(null)}
           onComplete={() => {

--- a/src/ui/components/TeamProfile.jsx
+++ b/src/ui/components/TeamProfile.jsx
@@ -16,7 +16,7 @@ import { buildTeamIntelligence } from "../utils/teamIntelligence.js";
 import { deriveTeamCoachingIdentity } from "../utils/coachingIdentity.js";
 import { buildTeamChemistrySummary } from "../utils/teamChemistry.js";
 import { franchiseInvestmentSummary } from "../utils/franchiseInvestments.js";
-import { buildRouteRequestKey } from "../utils/requestLoopGuard.js";
+import { buildRouteRequestKey, buildLeagueCacheScopeKey } from "../utils/requestLoopGuard.js";
 import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -115,10 +115,7 @@ function StatBox({ label, value, sub }) {
 export default function TeamProfile({ teamId, onClose, onPlayerSelect, actions, onNavigate = null, league = null }) {
   const [showRelocate, setShowRelocate] = useState(false);
   const requestKey = useMemo(() => buildRouteRequestKey("team", teamId), [teamId]);
-  const cacheScopeKey = useMemo(
-    () => `${league?.seasonId ?? league?.year ?? 'season'}:${league?.week ?? 0}`,
-    [league?.seasonId, league?.week, league?.year],
-  );
+  const cacheScopeKey = useMemo(() => buildLeagueCacheScopeKey(league), [league]);
   const fetchTeamProfile = React.useCallback(async () => {
     const resp = await actions?.getTeamProfile?.(teamId);
     return resp?.payload ?? resp ?? null;

--- a/src/ui/hooks/useStableRouteRequest.test.jsx
+++ b/src/ui/hooks/useStableRouteRequest.test.jsx
@@ -196,4 +196,69 @@ describe('useStableRouteRequest controller behavior', () => {
 
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
+
+  it("invalidates same-scope cache when __invalidateStableRouteRequestCache is called with matching scope", async () => {
+    const controller = createStableRouteRequestController();
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce({ player: { id: 1, ver: 1 } })
+      .mockResolvedValueOnce({ player: { id: 1, ver: 2 } });
+
+    const scope = "season:2024:week:1";
+
+    // First request
+    await controller.request({
+      requestKey: buildRouteRequestKey("player", 1),
+      cacheScopeKey: scope,
+      fetcher,
+    });
+
+    // Invalidate the scope
+    __invalidateStableRouteRequestCache(scope);
+
+    // Second request with same key and scope
+    await controller.request({
+      requestKey: buildRouteRequestKey("player", 1),
+      cacheScopeKey: scope,
+      fetcher,
+    });
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not invalidate other scopes when __invalidateStableRouteRequestCache is called with specific scope", async () => {
+    const controller = createStableRouteRequestController();
+    const fetcher = vi.fn()
+      .mockResolvedValue({ player: { id: 1 } });
+
+    await controller.request({
+      requestKey: buildRouteRequestKey("player", 1),
+      cacheScopeKey: "scope-a",
+      fetcher,
+    });
+    await controller.request({
+      requestKey: buildRouteRequestKey("player", 1),
+      cacheScopeKey: "scope-b",
+      fetcher,
+    });
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    __invalidateStableRouteRequestCache("scope-a");
+
+    // Request scope-a again -> should fetch
+    await controller.request({
+      requestKey: buildRouteRequestKey("player", 1),
+      cacheScopeKey: "scope-a",
+      fetcher,
+    });
+    expect(fetcher).toHaveBeenCalledTimes(3);
+
+    // Request scope-b again -> should NOT fetch (still cached)
+    await controller.request({
+      requestKey: buildRouteRequestKey("player", 1),
+      cacheScopeKey: "scope-b",
+      fetcher,
+    });
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
 });

--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -17,6 +17,8 @@
  */
 
 import { useEffect, useRef, useCallback, useReducer, useMemo } from 'react';
+import { __invalidateStableRouteRequestCache } from "./useStableRouteRequest.js";
+import { buildLeagueCacheScopeKey } from "../utils/requestLoopGuard.js";
 import { toWorker, toUI, send as buildMsg } from '../../worker/protocol.js';
 
 const WORKER_REQUEST_TIMEOUT_MS = 20000;
@@ -184,6 +186,10 @@ function reducer(state, action) {
 
 export function useWorker() {
   const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
+  const leagueRef = useRef(null);
+  useEffect(() => {
+    leagueRef.current = state.league;
+  }, [state.league]);
 
   /** Ref to the worker instance so it can be used inside callbacks without re-renders. */
   const workerRef = useRef(null);
@@ -209,6 +215,19 @@ export function useWorker() {
 
     worker.onmessage = (event) => {
       const { type, payload = {}, id } = event.data;
+      // Invalidate route-detail cache on material changes
+      if (type === toUI.READY || type === toUI.FULL_STATE) {
+        __invalidateStableRouteRequestCache(); // Full wipe for new saves/reset
+      } else if (
+        type === toUI.STATE_UPDATE ||
+        type === toUI.WEEK_COMPLETE ||
+        type === toUI.SEASON_START ||
+        type === toUI.OFFSEASON_PHASE
+      ) {
+        const currentScope = buildLeagueCacheScopeKey(leagueRef.current);
+        __invalidateStableRouteRequestCache(currentScope);
+      }
+
 
       // Resolve/reject any waiting promise first.
       // Silent requests (getRoster, getFreeAgents, history lookups) never set

--- a/src/ui/utils/requestLoopGuard.js
+++ b/src/ui/utils/requestLoopGuard.js
@@ -1,3 +1,8 @@
+export function buildLeagueCacheScopeKey(league) {
+  if (!league) return "global";
+  return `${league.seasonId ?? league.year ?? "season"}:${league.week ?? 0}`;
+}
+
 export function buildRouteRequestKey(prefix, id) {
   if (id == null || id === '') return null;
   return `${prefix}:${String(id)}`;


### PR DESCRIPTION
This PR addresses a stale-data gap in the route-detail caching system. Previously, while cache entries were scoped by week/season, mutations within the same week would still hit the stale cache.

Key changes:
1. Centralized the logic for building cache scope keys into a reusable helper `buildLeagueCacheScopeKey`.
2. Updated all consumers of `useStableRouteRequest` to use this helper.
3. Integrated `__invalidateStableRouteRequestCache` into the central `useWorker` hook.
4. Triggered invalidation on material state changes (`STATE_UPDATE`, `WEEK_COMPLETE`, `FULL_STATE`, etc.).
5. Added unit tests proving that invalidation works correctly and that cross-scope isolation is maintained.
6. Cleaned up a duplicate state bug in `PlayerProfile.jsx` discovered during testing.

---
*PR created automatically by Jules for task [13131236086623319007](https://jules.google.com/task/13131236086623319007) started by @rbcati*