### PR TITLE
Add Weekly Results Game Center and wire Game Book entry points

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { evaluateWeeklyContext } from "../utils/weeklyContext.js";
 import { deriveTeamCapSnapshot, formatMoneyM } from "../utils/numberFormatting.js";
 import { getHQViewModel } from "../../state/selectors.js";
-import { buildCompletedGamePresentation } from "../utils/boxScoreAccess.js";
+import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/boxScoreAccess.js";
 import { EmptyState, SectionCard, StatCard } from "./common/UiPrimitives.jsx";
 import { StatusChip, CompactListRow } from "./ScreenSystem.jsx";
 import { getRecentGames as getArchivedRecentGames } from "../../core/archive/gameArchive.ts";
@@ -345,10 +345,23 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
                     <Button
                       size="sm"
                       variant="outline"
-                      onClick={() => onOpenBoxScore?.(latestArchived?.id ?? lastGame?.id)}
+                      onClick={() => openResolvedBoxScore(
+                        {
+                          ...latestArchived,
+                          id: latestArchived?.id ?? lastGame?.id,
+                          week: latestArchived?.week ?? lastGame?.week,
+                          homeScore: latestArchived?.score?.home ?? lastGame?.score?.home,
+                          awayScore: latestArchived?.score?.away ?? lastGame?.score?.away,
+                        },
+                        { seasonId: vm.league?.seasonId, week: Number(latestArchived?.week ?? lastGame?.week ?? vm.league?.week ?? 1), source: "hq_last_game" },
+                        onOpenBoxScore,
+                      )}
                       disabled={latestArchived ? !latestGamePresentation?.canOpen : false}
                     >
                       {recapCtaLabel}
+                    </Button>
+                    <Button size="sm" variant="ghost" onClick={() => onNavigate?.("Weekly Results")} style={{ marginLeft: 6 }}>
+                      Weekly Results
                     </Button>
                   </div>
                 </>
@@ -359,6 +372,7 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
                   meta={<StatusChip label="Info" tone="info" />}
                 >
                   <Button size="sm" variant="outline" onClick={() => onNavigate?.("Schedule")}>Open Schedule</Button>
+                  <Button size="sm" variant="ghost" onClick={() => onNavigate?.("Weekly Results")}>Weekly Results</Button>
                 </CompactListRow>
               )}
             </div>

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -41,6 +41,7 @@ import PlayerStats from "./PlayerStats.jsx";
 import StrategyPanel from "./StrategyPanel.jsx";
 import GamePlanScreen from "./GamePlanScreen.jsx";
 import WeeklyPrepScreen from "./WeeklyPrepScreen.jsx";
+import WeeklyResultsCenter from "./WeeklyResultsCenter.jsx";
 import NewsFeed from "./NewsFeed.jsx";
 import RecordBook from "./RecordBook.jsx";
 import StatLeadersWidget from "./StatLeadersWidget.jsx";
@@ -186,6 +187,7 @@ const BASE_TABS = [
   "News",
   "Standings",
   "Schedule",
+  "Weekly Results",
   "Stats",
   "Leaders",
   "League Leaders",
@@ -227,7 +229,7 @@ const BASE_TABS = [
 const NAV_GROUPS = [
   { id: SHELL_SECTIONS.hq, title: "HQ", tabs: ["HQ"] },
   { id: SHELL_SECTIONS.team, title: "Team", tabs: ["Team", "Roster", "Depth Chart", "Weekly Prep", "Game Plan", "Training", "Injuries", "Staff", "Financials", "Contract Center"] },
-  { id: SHELL_SECTIONS.league, title: "League", tabs: ["League", "Schedule", "Standings", "Stats", "League Leaders", "Transactions", "History Hub", "History", "Awards & Records", "Season Recap"] },
+  { id: SHELL_SECTIONS.league, title: "League", tabs: ["League", "Weekly Results", "Schedule", "Standings", "Stats", "League Leaders", "Transactions", "History Hub", "History", "Awards & Records", "Season Recap"] },
   { id: SHELL_SECTIONS.news, title: "News", tabs: ["News"] },
 ];
 
@@ -1684,6 +1686,13 @@ export default function LeagueDashboard({
                   onPlayerSelect={setSelectedPlayerId}
                 />
               )}
+              renderResults={() => (
+                <WeeklyResultsCenter
+                  league={league}
+                  initialWeek={league?.week}
+                  onGameSelect={(gameId) => openGameDetail(gameId, "League")}
+                />
+              )}
               renderStandings={() => (
                 <StandingsTab
                   teams={safeStandingsRows}
@@ -1737,6 +1746,15 @@ export default function LeagueDashboard({
               }}
               league={league}
               onPlayerSelect={setSelectedPlayerId}
+            />
+          </TabErrorBoundary>
+        )}
+        {activeTab === "Weekly Results" && (
+          <TabErrorBoundary label="Weekly Results" onNavigate={setActiveTab} fallbackTab="League">
+            <WeeklyResultsCenter
+              league={league}
+              initialWeek={league?.week}
+              onGameSelect={(gameId) => openGameDetail(gameId, "Weekly Results")}
             />
           </TabErrorBoundary>
         )}

--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -353,13 +353,13 @@ function SeasonExplorer({ seasons, onPlayerSelect, onOpenBoxScore, league }) {
             <h4 className="text-sm font-bold mb-2">Completed game archive</h4>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm">
               {(selected?.gameIndex ?? []).slice(-12).reverse().map((game) => {
-                const presentation = buildCompletedGamePresentation(game, { seasonId: selected?.year, source: "league_history" });
+                const presentation = buildCompletedGamePresentation(game, { seasonId: selected?.year, week: game?.week, source: "league_history" });
                 const clickable = Boolean(presentation.canOpen && onOpenBoxScore);
                 return (
                   <button
                     key={game.id}
                     className="rounded-md border border-[color:var(--hairline)] px-3 py-2 text-left"
-                    onClick={() => openResolvedBoxScore(game, { seasonId: selected?.year, source: "league_history" }, onOpenBoxScore)}
+                    onClick={() => openResolvedBoxScore(game, { seasonId: selected?.year, week: game?.week, source: "league_history" }, onOpenBoxScore)}
                     style={{ cursor: clickable ? "pointer" : "default", opacity: clickable ? 1 : 0.75 }}
                     title={clickable ? presentation.ctaLabel : presentation.statusLabel}
                   >

--- a/src/ui/components/LeagueHub.jsx
+++ b/src/ui/components/LeagueHub.jsx
@@ -7,7 +7,7 @@ import { buildNewsDeskModel } from '../utils/newsDesk.js';
 import SocialFeed from './SocialFeed.jsx';
 import { CompactListRow, ScreenHeader, StatusChip } from './ScreenSystem.jsx';
 
-const LEAGUE_SUBNAV = ['Schedule', 'Standings', 'Stats', 'Transactions', 'History'];
+const LEAGUE_SUBNAV = ['Results', 'Schedule', 'Standings', 'Stats', 'Transactions', 'History'];
 
 function TeamComparison({ teams = [] }) {
   const rows = [...teams]
@@ -32,7 +32,7 @@ function TeamComparison({ teams = [] }) {
   );
 }
 
-export default function LeagueHub({ league, actions, onOpenGameDetail, onPlayerSelect, onNavigateTrade, renderStandings, renderSchedule }) {
+export default function LeagueHub({ league, actions, onOpenGameDetail, onPlayerSelect, onNavigateTrade, renderStandings, renderSchedule, renderResults }) {
   const [subtab, setSubtab] = useState('Schedule');
   const teams = Array.isArray(league?.teams) ? league.teams : [];
 
@@ -78,6 +78,7 @@ export default function LeagueHub({ league, actions, onOpenGameDetail, onPlayerS
       <SectionSubnav items={LEAGUE_SUBNAV} activeItem={subtab} onChange={setSubtab} />
       <SocialFeed league={league} defaultFilter="league" maxItems={8} onPlayerSelect={onPlayerSelect} />
 
+      {subtab === 'Results' && renderResults?.('League')}
       {subtab === 'Standings' && renderStandings?.()}
       {subtab === 'Schedule' && renderSchedule?.('League')}
       {subtab === 'Stats' && (

--- a/src/ui/components/WeeklyHub.jsx
+++ b/src/ui/components/WeeklyHub.jsx
@@ -221,6 +221,9 @@ export default function WeeklyHub({ league, onNavigate, onAdvanceWeek, busy, sim
             >
               {latestCompletedGame?.gameId ? (latestResultPresentation?.ctaLabel ?? "View result") : "Open schedule"}
             </Button>
+            <Button size="sm" variant="ghost" onClick={() => onNavigate?.("Weekly Results")}>
+              Weekly Results
+            </Button>
           </CardContent>
         </Card>
       </section>

--- a/src/ui/components/WeeklyResultsCenter.jsx
+++ b/src/ui/components/WeeklyResultsCenter.jsx
@@ -1,0 +1,138 @@
+import React, { useMemo, useState } from 'react';
+import { buildCompletedGamePresentation, openResolvedBoxScore } from '../utils/boxScoreAccess.js';
+import { deriveCompactResultRecap, getGameLifecycleBucket, selectWeekGames } from '../utils/gameCenterResults.js';
+
+function normalizeTeam(team) {
+  if (!team || typeof team !== 'object') return { abbr: '—', name: 'Unknown' };
+  return { abbr: team.abbr ?? team.name ?? '—', name: team.name ?? team.abbr ?? 'Unknown' };
+}
+
+function formatPeriodLabel(game) {
+  const quarterCount = Number(game?.quarterScores?.home?.length ?? game?.quarterScores?.away?.length ?? 0);
+  if (quarterCount > 4) return `Final/OT${quarterCount - 4 > 1 ? quarterCount - 4 : ''}`;
+  return 'Final';
+}
+
+function ResultRow({ row, seasonId, onGameSelect }) {
+  const presentation = buildCompletedGamePresentation(row.game, { seasonId, week: row.week, teamById: row.teamById, source: 'weekly_results_center' });
+  const clickable = Boolean(presentation.canOpen && onGameSelect);
+
+  return (
+    <article className="premium-game-card is-completed" style={{ padding: 'var(--space-3)' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'center' }}>
+        <strong>Week {row.week}</strong>
+        <span className="badge">{formatPeriodLabel(row.game)}</span>
+      </div>
+      <div style={{ marginTop: 6, fontWeight: 700 }}>
+        {row.away.abbr} {row.game?.awayScore ?? '—'} @ {row.home.abbr} {row.game?.homeScore ?? '—'}
+      </div>
+      <div style={{ marginTop: 4, fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{row.recap}</div>
+      <div style={{ marginTop: 8 }}>
+        <button
+          type="button"
+          className="btn btn-sm"
+          onClick={clickable ? () => openResolvedBoxScore(row.game, { seasonId, week: row.week, source: 'weekly_results_center' }, onGameSelect) : undefined}
+          disabled={!clickable}
+          title={clickable ? (presentation?.ctaLabel ?? 'Open Game Book') : (presentation?.statusLabel ?? 'Archive unavailable')}
+        >
+          {clickable ? 'Open Game Book' : (presentation?.statusLabel ?? 'Archive unavailable')}
+        </button>
+      </div>
+    </article>
+  );
+}
+
+export default function WeeklyResultsCenter({ league, initialWeek, onGameSelect }) {
+  const totalWeeks = Number(league?.schedule?.weeks?.length ?? 0);
+  const currentWeek = Number(initialWeek ?? league?.week ?? 1);
+  const [selectedWeek, setSelectedWeek] = useState(currentWeek);
+
+  const teamById = useMemo(() => {
+    const out = {};
+    for (const team of league?.teams ?? []) out[Number(team?.id)] = team;
+    return out;
+  }, [league?.teams]);
+
+  const selectedWeekGames = useMemo(() => {
+    return selectWeekGames(league?.schedule, selectedWeek);
+  }, [league?.schedule, selectedWeek]);
+
+  const rows = useMemo(() => selectedWeekGames.map((game, idx) => {
+    const homeId = Number(game?.home?.id ?? game?.home);
+    const awayId = Number(game?.away?.id ?? game?.away);
+    return {
+      key: game?.id ?? game?.gameId ?? `${selectedWeek}-${homeId}-${awayId}-${idx}`,
+      week: selectedWeek,
+      game,
+      away: normalizeTeam(teamById[awayId]),
+      home: normalizeTeam(teamById[homeId]),
+      recap: deriveCompactResultRecap(game, { awayTeam: teamById[awayId], homeTeam: teamById[homeId] }),
+      bucket: getGameLifecycleBucket(game),
+      teamById,
+    };
+  }), [selectedWeekGames, selectedWeek, teamById]);
+
+  const completed = rows.filter((row) => row.bucket === 'completed');
+  const live = rows.filter((row) => row.bucket === 'live');
+  const upcoming = rows.filter((row) => row.bucket === 'upcoming');
+
+  if (!totalWeeks) {
+    return <div className="card" style={{ padding: 'var(--space-4)' }}>No schedule data available for weekly results.</div>;
+  }
+
+  return (
+    <div className="app-screen-stack">
+      <section className="card" style={{ padding: 'var(--space-3)', display: 'grid', gap: 8 }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+          <div>
+            <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}>Game Center</div>
+            <h2 style={{ margin: 0 }}>Weekly Results</h2>
+          </div>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <button type="button" className="btn btn-sm" onClick={() => setSelectedWeek((w) => Math.max(1, w - 1))} disabled={selectedWeek <= 1}>Prev</button>
+            <span className="badge">Week {selectedWeek}</span>
+            <button type="button" className="btn btn-sm" onClick={() => setSelectedWeek((w) => Math.min(totalWeeks, w + 1))} disabled={selectedWeek >= totalWeeks}>Next</button>
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          <span className="badge">Completed {completed.length}</span>
+          <span className="badge">Live {live.length}</span>
+          <span className="badge">Upcoming {upcoming.length}</span>
+        </div>
+      </section>
+
+      {completed.length > 0 && (
+        <section style={{ display: 'grid', gap: 8 }}>
+          <h3 style={{ margin: 0 }}>Completed</h3>
+          {completed.map((row) => <ResultRow key={row.key} row={row} seasonId={league?.seasonId} onGameSelect={onGameSelect} />)}
+        </section>
+      )}
+
+      {live.length > 0 && (
+        <section style={{ display: 'grid', gap: 8 }}>
+          <h3 style={{ margin: 0 }}>In progress</h3>
+          {live.map((row) => (
+            <article key={row.key} className="card" style={{ padding: 'var(--space-3)' }}>
+              <strong>{row.away.abbr} @ {row.home.abbr}</strong>
+              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{row.recap}</div>
+            </article>
+          ))}
+        </section>
+      )}
+
+      {upcoming.length > 0 && (
+        <section style={{ display: 'grid', gap: 8 }}>
+          <h3 style={{ margin: 0 }}>Upcoming</h3>
+          {upcoming.map((row) => (
+            <article key={row.key} className="card" style={{ padding: 'var(--space-3)' }}>
+              <strong>{row.away.abbr} @ {row.home.abbr}</strong>
+              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{row.recap}</div>
+            </article>
+          ))}
+        </section>
+      )}
+
+      {rows.length === 0 ? <div className="card" style={{ padding: 'var(--space-4)' }}>No games scheduled for week {selectedWeek}.</div> : null}
+    </div>
+  );
+}

--- a/src/ui/components/WeeklyResultsCenter.test.jsx
+++ b/src/ui/components/WeeklyResultsCenter.test.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import WeeklyResultsCenter from './WeeklyResultsCenter.jsx';
+
+const league = {
+  seasonId: '2026',
+  week: 2,
+  teams: [
+    { id: 1, abbr: 'DAL', name: 'Dallas' },
+    { id: 2, abbr: 'PHI', name: 'Philadelphia' },
+    { id: 3, abbr: 'NYG', name: 'New York' },
+  ],
+  schedule: {
+    weeks: [
+      { week: 1, games: [{ gameId: '2026_w1_1_2', home: 1, away: 2, played: true, homeScore: 21, awayScore: 17, summary: { storyline: 'Turnovers decided it.' } }] },
+      { week: 2, games: [
+        { gameId: '2026_w2_2_3', home: 2, away: 3, played: true, homeScore: 14, awayScore: 10, summary: { headline: 'Red zone defense sealed it.' } },
+        { gameId: '2026_w2_1_3', home: 1, away: 3, status: 'live' },
+        { gameId: '2026_w2_1_2', home: 1, away: 2, played: false },
+      ] },
+    ],
+  },
+};
+
+describe('WeeklyResultsCenter', () => {
+  it('renders completed/live/upcoming groupings and game book affordance', () => {
+    const html = renderToString(<WeeklyResultsCenter league={league} initialWeek={2} onGameSelect={() => {}} />);
+    expect(html).toContain('Completed');
+    expect(html).toContain('In progress');
+    expect(html).toContain('Upcoming');
+    expect(html).toContain('Open Game Book');
+  });
+
+  it('is safe for older partial payloads with score-only games', () => {
+    const legacyLeague = {
+      ...league,
+      schedule: { weeks: [{ week: 3, games: [{ gameId: '2026_w3_1_2', home: 1, away: 2, played: true, homeScore: 7, awayScore: 3 }] }] },
+    };
+    const html = renderToString(<WeeklyResultsCenter league={legacyLeague} initialWeek={3} onGameSelect={() => {}} />);
+    expect(html).toContain('DAL won by 4 (3-7).');
+    expect(html).toContain('Archive unavailable');
+  });
+});

--- a/src/ui/utils/gameCenterResults.js
+++ b/src/ui/utils/gameCenterResults.js
@@ -1,0 +1,43 @@
+function safeNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function getGameLifecycleBucket(game) {
+  if (!game || typeof game !== 'object') return 'upcoming';
+  if (game.played || safeNumber(game?.homeScore) != null || safeNumber(game?.awayScore) != null) return 'completed';
+  if (game?.inProgress || game?.status === 'live' || game?.status === 'in_progress') return 'live';
+  return 'upcoming';
+}
+
+export function deriveCompactResultRecap(game, { awayTeam, homeTeam } = {}) {
+  const awayAbbr = awayTeam?.abbr ?? 'AWY';
+  const homeAbbr = homeTeam?.abbr ?? 'HME';
+  const richStoryline = game?.summary?.storyline
+    ?? game?.summary?.headline
+    ?? game?.summary?.standout
+    ?? game?.recap
+    ?? game?.topReason1
+    ?? game?.headline;
+  if (typeof richStoryline === 'string' && richStoryline.trim()) return richStoryline.trim();
+
+  const awayScore = safeNumber(game?.awayScore);
+  const homeScore = safeNumber(game?.homeScore);
+  if (awayScore == null || homeScore == null) {
+    return `${awayAbbr} at ${homeAbbr} is upcoming.`;
+  }
+
+  if (awayScore === homeScore) {
+    return `${awayAbbr} and ${homeAbbr} finished level at ${awayScore}-${homeScore}.`;
+  }
+
+  const winnerAbbr = awayScore > homeScore ? awayAbbr : homeAbbr;
+  const margin = Math.abs(awayScore - homeScore);
+  return `${winnerAbbr} won by ${margin} (${awayScore}-${homeScore}).`;
+}
+
+export function selectWeekGames(schedule, week) {
+  if (!Array.isArray(schedule?.weeks)) return [];
+  const row = schedule.weeks.find((entry) => Number(entry?.week) === Number(week));
+  return Array.isArray(row?.games) ? row.games : [];
+}

--- a/src/ui/utils/gameCenterResults.test.js
+++ b/src/ui/utils/gameCenterResults.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { deriveCompactResultRecap, getGameLifecycleBucket, selectWeekGames } from './gameCenterResults.js';
+
+describe('gameCenterResults helpers', () => {
+  it('creates deterministic recap text for the same payload', () => {
+    const payload = {
+      awayScore: 24,
+      homeScore: 20,
+      summary: { storyline: 'Defense closed the final drive.' },
+    };
+
+    const first = deriveCompactResultRecap(payload, { awayTeam: { abbr: 'DAL' }, homeTeam: { abbr: 'PHI' } });
+    const second = deriveCompactResultRecap(payload, { awayTeam: { abbr: 'DAL' }, homeTeam: { abbr: 'PHI' } });
+
+    expect(first).toBe('Defense closed the final drive.');
+    expect(second).toBe(first);
+  });
+
+  it('falls back to score-only text when archive detail is missing', () => {
+    expect(deriveCompactResultRecap({ awayScore: 17, homeScore: 21 }, { awayTeam: { abbr: 'NYG' }, homeTeam: { abbr: 'WAS' } }))
+      .toBe('WAS won by 4 (17-21).');
+  });
+
+  it('classifies completed, live, and upcoming games', () => {
+    expect(getGameLifecycleBucket({ played: true })).toBe('completed');
+    expect(getGameLifecycleBucket({ status: 'live' })).toBe('live');
+    expect(getGameLifecycleBucket({})).toBe('upcoming');
+  });
+
+  it('loads games for the requested week when browsing results history', () => {
+    const schedule = {
+      weeks: [
+        { week: 1, games: [{ gameId: '2026_w1_1_2' }] },
+        { week: 2, games: [{ gameId: '2026_w2_2_3' }, { gameId: '2026_w2_1_3' }] },
+      ],
+    };
+    expect(selectWeekGames(schedule, 1)).toHaveLength(1);
+    expect(selectWeekGames(schedule, 2)).toHaveLength(2);
+    expect(selectWeekGames(schedule, 3)).toHaveLength(0);
+  });
+});

--- a/src/ui/utils/shellNavigation.js
+++ b/src/ui/utils/shellNavigation.js
@@ -41,6 +41,7 @@ const TAB_TO_SECTION = Object.freeze({
   League: SHELL_SECTIONS.league,
   Standings: SHELL_SECTIONS.league,
   Schedule: SHELL_SECTIONS.league,
+  'Weekly Results': SHELL_SECTIONS.league,
   Stats: SHELL_SECTIONS.league,
   Leaders: SHELL_SECTIONS.league,
   Analytics: SHELL_SECTIONS.league,


### PR DESCRIPTION
### Motivation
- Provide a lightweight Game Center / Weekly Results surface so completed games are easy to discover and open. 
- Surface the stronger Box Score / Game Book already added to completed games across HQ, League, and History flows. 
- Keep the change focused and surgical by reusing the existing box score access helpers and avoiding new routing/state plumbing. 

### Description
- Add a new `WeeklyResultsCenter` React screen that shows all games for a selected week and separates Completed / In progress / Upcoming, with compact recaps and an Open Game Book affordance. 
- Add `src/ui/utils/gameCenterResults.js` with `deriveCompactResultRecap`, `getGameLifecycleBucket`, and `selectWeekGames` to produce deterministic recaps, lifecycle bucketing, and week browsing. 
- Wire the results surface into navigation by adding `Weekly Results` as a dashboard/league tab and exposing it via `LeagueHub` (new `Results` subtab), `LeagueDashboard`, `FranchiseHQ`, and `WeeklyHub` quick links. 
- Reuse the existing Box Book access flow by routing completed game clicks to `openResolvedBoxScore`/existing BoxScore destination; update HQ last-game click to call `openResolvedBoxScore` and pass safer archive context. 
- Improve archive clickthrough safety by passing `week` context when opening archived season games from `LeagueHistory`. 
- Keep visual and behavioral fallbacks for partial/older archived payloads (score-only rows and archive-unavailable UI). 
- Add focused unit tests for the new helpers and UI surface and include a small set of integration points to ensure click-through behavior remains stable. 

### Testing
- Ran unit tests: `vitest` targeted runs for the new helpers and components via `npm run test:unit -- src/ui/utils/gameCenterResults.test.js src/ui/components/WeeklyResultsCenter.test.jsx src/ui/utils/boxScoreAccess.test.js` and all targeted tests passed. 
- Ran existing HQ smoke tests via `npm run test:unit -- src/ui/components/__tests__/FranchiseHQ.test.jsx` and those tests passed. 
- New tests added: `src/ui/utils/gameCenterResults.test.js` and `src/ui/components/WeeklyResultsCenter.test.jsx`, both passing in the final test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2a77a78e8832d8428374360cfd895)