### PR TITLE
Add deterministic Weekly League Recap & Race Center to Weekly Results

### DIFF
--- a/src/ui/components/WeeklyResultsCenter.jsx
+++ b/src/ui/components/WeeklyResultsCenter.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 import { deriveCompactResultRecap, getGameLifecycleBucket, selectWeekGames } from '../utils/gameCenterResults.js';
+import { buildWeeklyLeagueRecap } from '../utils/weeklyLeagueRecap.js';
 
 function normalizeTeam(team) {
   if (!team || typeof team !== 'object') return { abbr: '—', name: 'Unknown' };
@@ -42,6 +43,38 @@ function ResultRow({ row, seasonId, onGameSelect }) {
   );
 }
 
+
+
+function SpotlightCard({ row, seasonId, onGameSelect }) {
+  const presentation = buildCompletedGamePresentation(row.game, { seasonId, week: row.week, source: 'weekly_results_spotlight' });
+  const clickable = Boolean(presentation.canOpen && onGameSelect);
+  const awayId = Number(row?.game?.away?.id ?? row?.game?.away);
+  const homeId = Number(row?.game?.home?.id ?? row?.game?.home);
+
+  return (
+    <article className="card" style={{ padding: 'var(--space-3)' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'center' }}>
+        <strong>Spotlight game</strong>
+        <span className="badge">Score {row.score}</span>
+      </div>
+      <div style={{ marginTop: 6, fontWeight: 700 }}>
+        {row.teamById[awayId]?.abbr ?? 'AWY'} {row.game?.awayScore ?? '—'} @ {row.teamById[homeId]?.abbr ?? 'HME'} {row.game?.homeScore ?? '—'}
+      </div>
+      <div style={{ marginTop: 4, fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{row.reason}</div>
+      <div style={{ marginTop: 8 }}>
+        <button
+          type="button"
+          className="btn btn-sm"
+          onClick={clickable ? () => openResolvedBoxScore(row.game, { seasonId, week: row.week, source: 'weekly_results_spotlight' }, onGameSelect) : undefined}
+          disabled={!clickable}
+        >
+          {clickable ? 'Open spotlight' : (presentation?.statusLabel ?? 'Archive unavailable')}
+        </button>
+      </div>
+    </article>
+  );
+}
+
 export default function WeeklyResultsCenter({ league, initialWeek, onGameSelect }) {
   const totalWeeks = Number(league?.schedule?.weeks?.length ?? 0);
   const currentWeek = Number(initialWeek ?? league?.week ?? 1);
@@ -76,6 +109,9 @@ export default function WeeklyResultsCenter({ league, initialWeek, onGameSelect 
   const live = rows.filter((row) => row.bucket === 'live');
   const upcoming = rows.filter((row) => row.bucket === 'upcoming');
 
+  const leagueRecap = useMemo(() => buildWeeklyLeagueRecap(league, { week: selectedWeek }), [league, selectedWeek]);
+  const spotlightRows = useMemo(() => leagueRecap.spotlights.map((spotlight) => ({ ...spotlight, teamById })), [leagueRecap.spotlights, teamById]);
+
   if (!totalWeeks) {
     return <div className="card" style={{ padding: 'var(--space-4)' }}>No schedule data available for weekly results.</div>;
   }
@@ -100,6 +136,48 @@ export default function WeeklyResultsCenter({ league, initialWeek, onGameSelect 
           <span className="badge">Upcoming {upcoming.length}</span>
         </div>
       </section>
+
+
+      {leagueRecap.bullets.length > 0 && (
+        <section className="card" style={{ padding: 'var(--space-3)', display: 'grid', gap: 10 }}>
+          <h3 style={{ margin: 0 }}>Weekly League Recap</h3>
+          <ul style={{ margin: 0, paddingLeft: 18, display: 'grid', gap: 4 }}>
+            {leagueRecap.bullets.map((bullet, idx) => <li key={`bullet-${idx}`} style={{ fontSize: 'var(--text-sm)' }}>{bullet}</li>)}
+          </ul>
+          <div style={{ display: 'grid', gap: 6, gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
+            <div className="card" style={{ padding: 'var(--space-2)' }}>
+              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}>Race center</div>
+              <div style={{ fontSize: 'var(--text-sm)' }}>
+                <strong>Hottest:</strong> {leagueRecap.raceCenter.hottest[0] ? `${leagueRecap.raceCenter.hottest[0].team?.abbr ?? leagueRecap.raceCenter.hottest[0].team?.name} (${leagueRecap.raceCenter.hottest[0].streak.length}W)` : '—'}
+              </div>
+              <div style={{ fontSize: 'var(--text-sm)' }}>
+                <strong>Coldest:</strong> {leagueRecap.raceCenter.coldest[0] ? `${leagueRecap.raceCenter.coldest[0].team?.abbr ?? leagueRecap.raceCenter.coldest[0].team?.name} (${leagueRecap.raceCenter.coldest[0].streak.length}L)` : '—'}
+              </div>
+              <div style={{ fontSize: 'var(--text-sm)' }}>
+                <strong>Mover:</strong> {leagueRecap.raceCenter.biggestMover?.change > 0 ? `${leagueRecap.raceCenter.biggestMover.team?.abbr ?? leagueRecap.raceCenter.biggestMover.team?.name} (+${leagueRecap.raceCenter.biggestMover.change})` : 'No major move'}
+              </div>
+              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+                {leagueRecap.raceCenter.bubble ? `Bubble: ${(leagueRecap.raceCenter.bubble.gap * 100).toFixed(1)} pct gap` : 'Bubble context unlocks as standings deepen.'}
+              </div>
+            </div>
+            <div className="card" style={{ padding: 'var(--space-2)' }}>
+              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}>Team trajectories</div>
+              <div style={{ display: 'grid', gap: 4 }}>
+                {leagueRecap.trajectories.slice(0, 3).map((team) => (
+                  <div key={team.teamId ?? team.label} style={{ fontSize: 'var(--text-xs)' }}><strong>{team.label}:</strong> {team.snippet}</div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {spotlightRows.length > 0 && (
+        <section style={{ display: 'grid', gap: 8 }}>
+          <h3 style={{ margin: 0 }}>Weekly Spotlight</h3>
+          {spotlightRows.map((row) => <SpotlightCard key={row.key} row={row} seasonId={league?.seasonId} onGameSelect={onGameSelect} />)}
+        </section>
+      )}
 
       {completed.length > 0 && (
         <section style={{ display: 'grid', gap: 8 }}>

--- a/src/ui/components/WeeklyResultsCenter.test.jsx
+++ b/src/ui/components/WeeklyResultsCenter.test.jsx
@@ -1,22 +1,36 @@
 import React from 'react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { renderToString } from 'react-dom/server';
 import WeeklyResultsCenter from './WeeklyResultsCenter.jsx';
+import { buildWeeklyLeagueRecap } from '../utils/weeklyLeagueRecap.js';
+import { openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 
 const league = {
   seasonId: '2026',
   week: 2,
   teams: [
-    { id: 1, abbr: 'DAL', name: 'Dallas' },
-    { id: 2, abbr: 'PHI', name: 'Philadelphia' },
-    { id: 3, abbr: 'NYG', name: 'New York' },
+    { id: 1, abbr: 'DAL', name: 'Dallas', conf: 1, div: 0 },
+    { id: 2, abbr: 'PHI', name: 'Philadelphia', conf: 1, div: 0 },
+    { id: 3, abbr: 'NYG', name: 'New York', conf: 1, div: 0 },
+    { id: 4, abbr: 'WSH', name: 'Washington', conf: 1, div: 0 },
+    { id: 5, abbr: 'BUF', name: 'Buffalo', conf: 0, div: 0 },
+    { id: 6, abbr: 'KC', name: 'Kansas City', conf: 0, div: 1 },
+    { id: 7, abbr: 'MIA', name: 'Miami', conf: 0, div: 0 },
+    { id: 8, abbr: 'NE', name: 'New England', conf: 0, div: 0 },
   ],
   schedule: {
     weeks: [
-      { week: 1, games: [{ gameId: '2026_w1_1_2', home: 1, away: 2, played: true, homeScore: 21, awayScore: 17, summary: { storyline: 'Turnovers decided it.' } }] },
+      { week: 1, games: [
+        { gameId: '2026_w1_1_2', home: 1, away: 2, played: true, homeScore: 21, awayScore: 17, summary: { storyline: 'Turnovers decided it.' } },
+        { gameId: '2026_w1_3_4', home: 3, away: 4, played: true, homeScore: 24, awayScore: 14 },
+        { gameId: '2026_w1_5_6', home: 5, away: 6, played: true, homeScore: 20, awayScore: 23 },
+        { gameId: '2026_w1_7_8', home: 7, away: 8, played: true, homeScore: 13, awayScore: 10 },
+      ] },
       { week: 2, games: [
-        { gameId: '2026_w2_2_3', home: 2, away: 3, played: true, homeScore: 14, awayScore: 10, summary: { headline: 'Red zone defense sealed it.' } },
-        { gameId: '2026_w2_1_3', home: 1, away: 3, status: 'live' },
+        { gameId: '2026_w2_2_3', home: 2, away: 3, played: true, homeScore: 14, awayScore: 10, summary: { headline: 'Red zone defense sealed it.' }, quarterScores: { home: [0, 7, 0, 7], away: [3, 0, 7, 0] } },
+        { gameId: '2026_w2_1_4', home: 1, away: 4, played: true, homeScore: 20, awayScore: 21, summary: { storyline: 'Game-winning drive in final minute.' }, quarterScores: { home: [7, 3, 7, 3], away: [7, 7, 0, 7] } },
+        { gameId: '2026_w2_5_7', home: 5, away: 7, played: true, homeScore: 27, awayScore: 17 },
+        { gameId: '2026_w2_6_8', home: 6, away: 8, status: 'live' },
         { gameId: '2026_w2_1_2', home: 1, away: 2, played: false },
       ] },
     ],
@@ -24,12 +38,15 @@ const league = {
 };
 
 describe('WeeklyResultsCenter', () => {
-  it('renders completed/live/upcoming groupings and game book affordance', () => {
+  it('renders weekly recap, race center, spotlight, and game groupings', () => {
     const html = renderToString(<WeeklyResultsCenter league={league} initialWeek={2} onGameSelect={() => {}} />);
+    expect(html).toContain('Weekly League Recap');
+    expect(html).toContain('Race center');
+    expect(html).toContain('Weekly Spotlight');
     expect(html).toContain('Completed');
     expect(html).toContain('In progress');
     expect(html).toContain('Upcoming');
-    expect(html).toContain('Open Game Book');
+    expect(html).toContain('Open spotlight');
   });
 
   it('is safe for older partial payloads with score-only games', () => {
@@ -40,5 +57,15 @@ describe('WeeklyResultsCenter', () => {
     const html = renderToString(<WeeklyResultsCenter league={legacyLeague} initialWeek={3} onGameSelect={() => {}} />);
     expect(html).toContain('DAL won by 4 (3-7).');
     expect(html).toContain('Archive unavailable');
+  });
+
+  it('routes spotlight game records through current game book open helper', () => {
+    const recap = buildWeeklyLeagueRecap(league, { week: 2 });
+    const onGameSelect = vi.fn();
+    const opened = openResolvedBoxScore(recap.spotlights[0].game, { seasonId: league.seasonId, week: 2, source: 'test_spotlight' }, onGameSelect);
+
+    expect(opened).toBe(true);
+    expect(onGameSelect).toHaveBeenCalledTimes(1);
+    expect(onGameSelect.mock.calls[0][0]).toMatch(/2026_w2_/);
   });
 });

--- a/src/ui/utils/weeklyLeagueRecap.js
+++ b/src/ui/utils/weeklyLeagueRecap.js
@@ -1,0 +1,277 @@
+import { deriveCompactResultRecap, selectWeekGames } from './gameCenterResults.js';
+
+function safeNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function teamIdOf(side) {
+  if (side && typeof side === 'object') return safeNumber(side.id);
+  return safeNumber(side);
+}
+
+function toTeamMap(teams = []) {
+  const map = new Map();
+  for (const team of teams) {
+    const id = safeNumber(team?.id);
+    if (id != null) map.set(id, team);
+  }
+  return map;
+}
+
+function teamLabel(team, fallback = 'Team') {
+  return team?.abbr ?? team?.name ?? fallback;
+}
+
+function gameKey(game, idx = 0) {
+  return game?.id ?? game?.gameId ?? `${teamIdOf(game?.away) ?? 'a'}-${teamIdOf(game?.home) ?? 'h'}-${idx}`;
+}
+
+function isCompleted(game) {
+  return Boolean(game?.played || (safeNumber(game?.homeScore) != null && safeNumber(game?.awayScore) != null));
+}
+
+function getCompletedGamesForWeek(league, week) {
+  return selectWeekGames(league?.schedule, week).filter(isCompleted);
+}
+
+function buildSeasonStatsToWeek(league, week) {
+  const stats = new Map();
+  const ensure = (teamId) => {
+    if (teamId == null) return null;
+    if (!stats.has(teamId)) {
+      stats.set(teamId, { wins: 0, losses: 0, ties: 0, pf: 0, pa: 0, results: [] });
+    }
+    return stats.get(teamId);
+  };
+  for (const weekRow of league?.schedule?.weeks ?? []) {
+    if (safeNumber(weekRow?.week) == null || Number(weekRow.week) > Number(week)) continue;
+    for (const game of weekRow?.games ?? []) {
+      if (!isCompleted(game)) continue;
+      const homeId = teamIdOf(game?.home);
+      const awayId = teamIdOf(game?.away);
+      const homeScore = safeNumber(game?.homeScore);
+      const awayScore = safeNumber(game?.awayScore);
+      if (homeId == null || awayId == null || homeScore == null || awayScore == null) continue;
+      const home = ensure(homeId);
+      const away = ensure(awayId);
+      home.pf += homeScore; home.pa += awayScore;
+      away.pf += awayScore; away.pa += homeScore;
+      if (homeScore > awayScore) {
+        home.wins += 1; away.losses += 1; home.results.push('W'); away.results.push('L');
+      } else if (homeScore < awayScore) {
+        away.wins += 1; home.losses += 1; away.results.push('W'); home.results.push('L');
+      } else {
+        home.ties += 1; away.ties += 1; home.results.push('T'); away.results.push('T');
+      }
+    }
+  }
+  return stats;
+}
+
+function winPct(row) {
+  const games = (row?.wins ?? 0) + (row?.losses ?? 0) + (row?.ties ?? 0);
+  if (!games) return 0;
+  return ((row?.wins ?? 0) + 0.5 * (row?.ties ?? 0)) / games;
+}
+
+function streakFromResults(results = []) {
+  if (!results.length) return { type: null, length: 0 };
+  const last = results[results.length - 1];
+  if (last === 'T') return { type: 'T', length: 1 };
+  let length = 0;
+  for (let i = results.length - 1; i >= 0; i -= 1) {
+    if (results[i] !== last) break;
+    length += 1;
+  }
+  return { type: last, length };
+}
+
+function rankConference(teams, stats, conf) {
+  return teams
+    .filter((t) => safeNumber(t?.conf) === conf)
+    .map((t) => ({ team: t, stat: stats.get(safeNumber(t?.id)) ?? { wins: 0, losses: 0, ties: 0, pf: 0, pa: 0, results: [] } }))
+    .sort((a, b) => {
+      const pctDiff = winPct(b.stat) - winPct(a.stat);
+      if (Math.abs(pctDiff) > 1e-9) return pctDiff;
+      const pdDiff = (b.stat.pf - b.stat.pa) - (a.stat.pf - a.stat.pa);
+      if (pdDiff !== 0) return pdDiff;
+      return teamLabel(a.team).localeCompare(teamLabel(b.team));
+    });
+}
+
+function calculateSpotlightScore(game, teamMap, weekStats) {
+  const home = teamMap.get(teamIdOf(game?.home));
+  const away = teamMap.get(teamIdOf(game?.away));
+  const homeScore = safeNumber(game?.homeScore);
+  const awayScore = safeNumber(game?.awayScore);
+  if (homeScore == null || awayScore == null) return -1;
+  const margin = Math.abs(homeScore - awayScore);
+  let score = 0;
+  score += Math.max(0, 14 - margin) * 3;
+  const quarters = safeNumber(game?.quarterScores?.home?.length ?? game?.quarterScores?.away?.length) ?? 0;
+  if (quarters > 4 || game?.wentToOT || game?.overtime) score += 14;
+  const winnerId = homeScore > awayScore ? teamIdOf(game?.home) : (awayScore > homeScore ? teamIdOf(game?.away) : null);
+  const loserId = winnerId === teamIdOf(game?.home) ? teamIdOf(game?.away) : teamIdOf(game?.home);
+  const winnerPct = winPct(weekStats.get(winnerId));
+  const loserPct = winPct(weekStats.get(loserId));
+  if (winnerId != null && loserId != null && winnerPct + 0.2 < loserPct) score += 12;
+  if (winnerPct >= 0.65 || loserPct >= 0.65) score += 5;
+  if (typeof game?.summary?.storyline === 'string' && game.summary.storyline.trim()) score += 4;
+  if ((home?.wins ?? 0) + (away?.wins ?? 0) >= 10) score += 2;
+  return score;
+}
+
+function buildTrajectory(team, stat) {
+  const results = stat?.results ?? [];
+  const streak = streakFromResults(results);
+  const shortStreak = streak.type === 'W' ? `${streak.length}W streak` : streak.type === 'L' ? `${streak.length}L skid` : 'mixed form';
+  const pd = (stat?.pf ?? 0) - (stat?.pa ?? 0);
+  const tail = results.slice(-3);
+  const winsLast3 = tail.filter((r) => r === 'W').length;
+  const form = winsLast3 >= 2 ? 'trending up' : winsLast3 === 0 && tail.length === 3 ? 'under pressure' : 'holding steady';
+  const pdLabel = pd >= 0 ? `+${pd}` : `${pd}`;
+  return `${shortStreak}; point diff ${pdLabel}; ${form}.`;
+}
+
+export function buildWeeklyLeagueRecap(league, { week, maxBullets = 6 } = {}) {
+  const selectedWeek = Number(week ?? league?.week ?? 1);
+  const teams = Array.isArray(league?.teams) ? league.teams : [];
+  const teamMap = toTeamMap(teams);
+  const completedGames = getCompletedGamesForWeek(league, selectedWeek);
+  const weekStats = buildSeasonStatsToWeek(league, selectedWeek);
+  const prevStats = buildSeasonStatsToWeek(league, selectedWeek - 1);
+
+  const ranked = teams
+    .map((team) => ({ team, stat: weekStats.get(safeNumber(team?.id)) ?? { wins: 0, losses: 0, ties: 0, pf: 0, pa: 0, results: [] } }))
+    .sort((a, b) => {
+      const pctDiff = winPct(b.stat) - winPct(a.stat);
+      if (Math.abs(pctDiff) > 1e-9) return pctDiff;
+      return ((b.stat.pf - b.stat.pa) - (a.stat.pf - a.stat.pa)) || teamLabel(a.team).localeCompare(teamLabel(b.team));
+    });
+
+  const bullets = [];
+  if (ranked[0]) {
+    const leader = ranked[0];
+    bullets.push(`${teamLabel(leader.team)} stayed on top at ${leader.stat.wins}-${leader.stat.losses}${leader.stat.ties ? `-${leader.stat.ties}` : ''}.`);
+  }
+
+  if (completedGames.length > 0) {
+    const biggestUpset = completedGames
+      .map((game, idx) => {
+        const homeId = teamIdOf(game?.home);
+        const awayId = teamIdOf(game?.away);
+        const homeScore = safeNumber(game?.homeScore);
+        const awayScore = safeNumber(game?.awayScore);
+        if (homeId == null || awayId == null || homeScore == null || awayScore == null) return null;
+        const winnerId = homeScore > awayScore ? homeId : awayId;
+        const loserId = winnerId === homeId ? awayId : homeId;
+        const winnerPct = winPct(prevStats.get(winnerId));
+        const loserPct = winPct(prevStats.get(loserId));
+        return { game, idx, delta: loserPct - winnerPct, winnerId, loserId };
+      })
+      .filter(Boolean)
+      .sort((a, b) => (b.delta - a.delta) || gameKey(a.game, a.idx).localeCompare(gameKey(b.game, b.idx)))[0];
+    if (biggestUpset && biggestUpset.delta > 0.15) {
+      const winner = teamLabel(teamMap.get(biggestUpset.winnerId));
+      const loser = teamLabel(teamMap.get(biggestUpset.loserId));
+      bullets.push(`Biggest upset: ${winner} knocked off ${loser}.`);
+    }
+
+    const closest = completedGames
+      .map((game, idx) => ({ game, idx, margin: Math.abs((safeNumber(game?.homeScore) ?? 0) - (safeNumber(game?.awayScore) ?? 0)) }))
+      .sort((a, b) => (a.margin - b.margin) || gameKey(a.game, a.idx).localeCompare(gameKey(b.game, b.idx)))[0];
+    if (closest && Number.isFinite(closest.margin)) {
+      const home = teamLabel(teamMap.get(teamIdOf(closest.game?.home)), 'Home');
+      const away = teamLabel(teamMap.get(teamIdOf(closest.game?.away)), 'Away');
+      bullets.push(`${away} vs ${home} was the tightest finish (${closest.margin}-point margin).`);
+    }
+  }
+
+  const streakRows = ranked
+    .map(({ team, stat }) => ({ team, streak: streakFromResults(stat.results) }))
+    .filter((row) => row.streak.length >= 3 && (row.streak.type === 'W' || row.streak.type === 'L'))
+    .sort((a, b) => (b.streak.length - a.streak.length) || teamLabel(a.team).localeCompare(teamLabel(b.team)));
+  if (streakRows[0]) {
+    const s = streakRows[0];
+    bullets.push(`${teamLabel(s.team)} is on a ${s.streak.length}-game ${s.streak.type === 'W' ? 'winning streak' : 'slide'}.`);
+  }
+
+  const movers = ranked
+    .map((row, idx) => {
+      const id = safeNumber(row.team?.id);
+      const prevRank = teams
+        .map((team) => ({ team, stat: prevStats.get(safeNumber(team?.id)) ?? { wins: 0, losses: 0, ties: 0, pf: 0, pa: 0 } }))
+        .sort((a, b) => (winPct(b.stat) - winPct(a.stat)) || ((b.stat.pf - b.stat.pa) - (a.stat.pf - a.stat.pa)) || teamLabel(a.team).localeCompare(teamLabel(b.team)))
+        .findIndex((entry) => safeNumber(entry.team?.id) === id);
+      return { team: row.team, change: (prevRank + 1) - (idx + 1) };
+    })
+    .sort((a, b) => (b.change - a.change) || teamLabel(a.team).localeCompare(teamLabel(b.team)));
+  if (movers[0]?.change > 0) bullets.push(`${teamLabel(movers[0].team)} climbed ${movers[0].change} spot${movers[0].change > 1 ? 's' : ''} in league order.`);
+
+  const conf0 = rankConference(teams, weekStats, 0);
+  const conf1 = rankConference(teams, weekStats, 1);
+  const bubbleLine = [conf0, conf1]
+    .map((conf) => {
+      if (conf.length < 8) return null;
+      const line = conf[6];
+      const chaser = conf[7];
+      const gap = winPct(line.stat) - winPct(chaser.stat);
+      return { line, chaser, gap };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.gap - b.gap)[0];
+  if (bubbleLine && selectedWeek >= 5) {
+    bullets.push(`Playoff bubble watch: ${teamLabel(bubbleLine.line.team)} leads ${teamLabel(bubbleLine.chaser.team)} by ${(bubbleLine.gap * 100).toFixed(1)} pct points.`);
+  }
+
+  const hottest = ranked
+    .map(({ team, stat }) => ({ team, streak: streakFromResults(stat.results), pct: winPct(stat) }))
+    .sort((a, b) => {
+      const streakDiff = ((b.streak.type === 'W') ? b.streak.length : -b.streak.length) - ((a.streak.type === 'W') ? a.streak.length : -a.streak.length);
+      if (streakDiff !== 0) return streakDiff;
+      return b.pct - a.pct;
+    });
+
+  const coldest = [...hottest].reverse();
+
+  const spotlights = completedGames
+    .map((game, idx) => {
+      const score = calculateSpotlightScore(game, teamMap, prevStats);
+      return {
+        key: gameKey(game, idx),
+        game,
+        week: selectedWeek,
+        reason: deriveCompactResultRecap(game, {
+          awayTeam: teamMap.get(teamIdOf(game?.away)),
+          homeTeam: teamMap.get(teamIdOf(game?.home)),
+        }),
+        score,
+      };
+    })
+    .sort((a, b) => (b.score - a.score) || a.key.localeCompare(b.key))
+    .slice(0, 3);
+
+  const trajectories = ranked.slice(0, 2).concat(ranked.slice(-2))
+    .filter((entry, idx, arr) => arr.findIndex((r) => safeNumber(r.team?.id) === safeNumber(entry.team?.id)) === idx)
+    .slice(0, 4)
+    .map(({ team, stat }) => ({
+      teamId: safeNumber(team?.id),
+      label: teamLabel(team),
+      snippet: buildTrajectory(team, stat),
+    }));
+
+  return {
+    bullets: bullets.filter(Boolean).slice(0, Math.max(3, maxBullets)),
+    raceCenter: {
+      hottest: hottest.filter((entry) => entry.streak.type === 'W' && entry.streak.length >= 2).slice(0, 3),
+      coldest: coldest.filter((entry) => entry.streak.type === 'L' && entry.streak.length >= 2).slice(0, 3),
+      longestWinning: hottest.find((entry) => entry.streak.type === 'W') ?? null,
+      longestLosing: coldest.find((entry) => entry.streak.type === 'L') ?? null,
+      biggestMover: movers[0] ?? null,
+      bubble: bubbleLine,
+    },
+    spotlights,
+    trajectories,
+  };
+}

--- a/src/ui/utils/weeklyLeagueRecap.test.js
+++ b/src/ui/utils/weeklyLeagueRecap.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { buildWeeklyLeagueRecap } from './weeklyLeagueRecap.js';
+
+const league = {
+  seasonId: '2026',
+  week: 6,
+  teams: [
+    { id: 1, abbr: 'BUF', conf: 0, div: 0 },
+    { id: 2, abbr: 'KC', conf: 0, div: 1 },
+    { id: 3, abbr: 'MIA', conf: 0, div: 0 },
+    { id: 4, abbr: 'NE', conf: 0, div: 0 },
+    { id: 5, abbr: 'DAL', conf: 1, div: 0 },
+    { id: 6, abbr: 'PHI', conf: 1, div: 0 },
+    { id: 7, abbr: 'SF', conf: 1, div: 1 },
+    { id: 8, abbr: 'DET', conf: 1, div: 1 },
+  ],
+  schedule: {
+    weeks: [
+      { week: 1, games: [
+        { gameId: '2026_w1_1_2', home: 1, away: 2, played: true, homeScore: 24, awayScore: 21 },
+        { gameId: '2026_w1_3_4', home: 3, away: 4, played: true, homeScore: 20, awayScore: 10 },
+        { gameId: '2026_w1_5_6', home: 5, away: 6, played: true, homeScore: 28, awayScore: 17 },
+        { gameId: '2026_w1_7_8', home: 7, away: 8, played: true, homeScore: 27, awayScore: 24 },
+      ] },
+      { week: 2, games: [
+        { gameId: '2026_w2_2_3', home: 2, away: 3, played: true, homeScore: 17, awayScore: 14 },
+        { gameId: '2026_w2_1_4', home: 1, away: 4, played: true, homeScore: 31, awayScore: 13 },
+        { gameId: '2026_w2_6_7', home: 6, away: 7, played: true, homeScore: 30, awayScore: 27 },
+        { gameId: '2026_w2_8_5', home: 8, away: 5, played: true, homeScore: 21, awayScore: 20 },
+      ] },
+      { week: 6, games: [
+        { gameId: '2026_w6_2_1', home: 2, away: 1, played: true, homeScore: 20, awayScore: 21, summary: { storyline: 'Late fourth-down stop.' }, quarterScores: { home: [7, 3, 7, 3], away: [3, 7, 7, 4] } },
+        { gameId: '2026_w6_3_4', home: 3, away: 4, played: true, homeScore: 28, awayScore: 10 },
+        { gameId: '2026_w6_6_5', home: 6, away: 5, played: true, homeScore: 24, awayScore: 27, quarterScores: { home: [3, 7, 7, 7, 0], away: [7, 3, 10, 4, 3] } },
+        { gameId: '2026_w6_8_7', home: 8, away: 7, played: true, homeScore: 23, awayScore: 17 },
+      ] },
+    ],
+  },
+};
+
+describe('weeklyLeagueRecap', () => {
+  it('generates deterministic league bullets and spotlight ordering', () => {
+    const a = buildWeeklyLeagueRecap(league, { week: 6 });
+    const b = buildWeeklyLeagueRecap(league, { week: 6 });
+
+    expect(a.bullets.length).toBeGreaterThanOrEqual(3);
+    expect(a.bullets).toEqual(b.bullets);
+    expect(a.spotlights.map((row) => row.key)).toEqual(b.spotlights.map((row) => row.key));
+  });
+
+  it('handles partial season payloads without crashing', () => {
+    const partial = buildWeeklyLeagueRecap({ teams: [{ id: 1, abbr: 'BUF', conf: 0 }], schedule: { weeks: [{ week: 1, games: [{ home: 1, away: 2, played: true, homeScore: 10, awayScore: 7 }] }] } }, { week: 1 });
+    expect(partial.bullets.length).toBeGreaterThan(0);
+    expect(Array.isArray(partial.trajectories)).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a compact, deterministic league-level recap layer that explains why a week mattered (standings movement, streaks, upsets) using only existing UI-layer schedule/team data.
- Keep integration surgical and backward-safe so no backend/state changes are required and older/partial saves render safely.
- Surface a small set of must-open games (spotlights) and reuse the existing Game Book / BoxScore open flow rather than creating new navigation.

### Description
- Added `buildWeeklyLeagueRecap` (`src/ui/utils/weeklyLeagueRecap.js`) which derives deterministic recap `bullets`, a `raceCenter` snapshot, ordered `spotlights`, and compact `trajectories` from the schedule and teams.
- Integrated the recap into `WeeklyResultsCenter` (`src/ui/components/WeeklyResultsCenter.jsx`) by adding a `Weekly League Recap` section, a compact `Race center` panel, `Team trajectories` snippets, and a `Weekly Spotlight` card list without changing existing groupings or navigation.
- Added a `SpotlightCard` component in `WeeklyResultsCenter` which routes to the current Game Book pathway via the existing `openResolvedBoxScore` / `buildCompletedGamePresentation` helpers, preserving archive availability logic.
- Added tests and test coverage scaffolding: `src/ui/utils/weeklyLeagueRecap.test.js` for utility determinism/partial-data safety and updated `src/ui/components/WeeklyResultsCenter.test.jsx` to assert recap/race center/spotlight rendering and safe operation with legacy payloads.

### Testing
- Ran unit tests with `npm run test:unit -- src/ui/utils/weeklyLeagueRecap.test.js src/ui/components/WeeklyResultsCenter.test.jsx src/ui/utils/gameCenterResults.test.js`.
- All unit tests passed in the final run: 3 test files, 9 tests, all green.
- Tests validate deterministic bullet generation, spotlight ordering stability, safe handling of partial/older payloads, and that spotlight records route through the current box score open helper.
- No runtime changes to backend/state were required and component changes are guarded for missing/partial data to avoid regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2c1600884832d9c3046d538945d7d)