### PR TITLE
Turn Team into a Command Center and route HQ team actions into Team sections

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -150,7 +150,7 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
         : "Lineup is valid. Opening depth chart.",
     );
     window.setTimeout(() => setLineupToast(null), 2200);
-    onNavigate?.("Roster:depth|ALL");
+    onNavigate?.("Team:Roster / Depth");
   };
 
   const commandCenterActions = [
@@ -229,26 +229,14 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
       destination: "🤖 GM Advisor",
     },
     {
-      key: "injuries",
-      title: "Injury pressure",
-      subtitle: injuriesCount > 0
-        ? `${injuriesCount} active injury impact${injuriesCount > 1 ? "s" : ""} on depth chart decisions.`
-        : "No major injury blockers this week.",
-      tone: injuriesCount >= 3 ? "danger" : injuriesCount > 0 ? "warning" : "info",
-      cta: "Injury report",
-      destination: "Injuries",
-    },
-    {
-      key: "roster",
-      title: "Roster pressure",
+      key: "team",
+      title: "Team Command Center",
       subtitle: rosterCount > 53
-        ? `Roster at ${rosterCount}; cutdown action required.`
-        : expiringCount >= 3
-          ? `${expiringCount} rotation contracts are expiring soon.`
-          : "Core roster pressure is currently manageable.",
-      tone: rosterCount > 53 ? "danger" : expiringCount >= 3 ? "warning" : "info",
-      cta: rosterCount > 53 ? "Open roster hub" : "Contract center",
-      destination: rosterCount > 53 ? "Roster Hub" : "Contract Center",
+        ? `Roster at ${rosterCount}; cutdown and depth decisions now live in Team.`
+        : `${injuriesCount} injuries, ${expiringCount} expirings, and development signals are tracked in Team.`,
+      tone: rosterCount > 53 || injuriesCount >= 3 ? "warning" : "info",
+      cta: "Open Team",
+      destination: "Team:Overview",
     },
   ];
 
@@ -410,7 +398,7 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
             />
           </div>
         </SectionCard>
-        <SectionCard title="Team Context" subtitle="Owner mandate, injuries, and roster pressure.">
+        <SectionCard title="Team Context" subtitle="HQ links into Team-owned roster, injury, and contract context.">
           <div style={{ display: "grid", gap: 6 }}>
             {teamContextRows.map((row) => (
               <CompactListRow

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -1339,6 +1339,7 @@ export default function LeagueDashboard({
   const [rosterInitialView, setRosterInitialView] = useState("table");
   const [statsInitialFamily, setStatsInitialFamily] = useState("passing");
   const [leagueInitialSection, setLeagueInitialSection] = useState("Overview");
+  const [teamInitialSection, setTeamInitialSection] = useState("Overview");
   const [newsSubtab, setNewsSubtab] = useState("All");
   const [isMobile, setIsMobile] = useState(() => (typeof window !== "undefined" ? window.innerWidth <= 767 : false));
 
@@ -1617,6 +1618,9 @@ export default function LeagueDashboard({
                   if (destination.leagueSection) {
                     setLeagueInitialSection(destination.leagueSection);
                   }
+                  if (destination.teamSection) {
+                    setTeamInitialSection(destination.teamSection);
+                  }
                   setActiveTab(destination.tab && TABS.includes(destination.tab) ? destination.tab : "HQ");
                 }}
                 onAdvanceWeek={onAdvanceWeek}
@@ -1641,6 +1645,7 @@ export default function LeagueDashboard({
               onTeamSelect={setSelectedTeamId}
               onOpenGameDetail={openGameDetail}
               onNavigate={setActiveTab}
+              initialSection={teamInitialSection}
               rosterInitialState={rosterInitialState}
               rosterInitialView={rosterInitialView}
               statsInitialFamily={statsInitialFamily}

--- a/src/ui/components/TeamHub.jsx
+++ b/src/ui/components/TeamHub.jsx
@@ -1,16 +1,21 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import Roster from './Roster.jsx';
 import ContractCenter from './ContractCenter.jsx';
-import StaffManagement from './StaffManagement.jsx';
 import SectionSubnav from './SectionSubnav.jsx';
-import SocialFeed from './SocialFeed.jsx';
-import FinancialsView from './FinancialsView.jsx';
-import { SectionCard, CtaRow, StatusChip } from './ScreenSystem.jsx';
+import InjuryReport from './InjuryReport.jsx';
+import { SectionCard, CtaRow, StatusChip, CompactListRow } from './ScreenSystem.jsx';
 import { TeamWorkspaceHeader, TeamCapSummaryStrip } from './TeamWorkspacePrimitives.jsx';
 import { derivePlayerContractFinancials } from '../utils/contractFormatting.js';
 import { deriveTeamCapSnapshot, formatMoneyM } from '../utils/numberFormatting.js';
+import { summarizeRosterDevelopment } from '../utils/playerDevelopmentSignals.js';
 
-const TEAM_SUBNAV = ['Overview', 'Roster', 'Depth Chart', 'Contracts', 'Financials', 'Staff'];
+const TEAM_SECTIONS = ['Overview', 'Roster / Depth', 'Contracts', 'Development', 'Injuries'];
+const CRITICAL_POSITION_MIN = { QB: 2, RB: 3, WR: 5, TE: 3, OL: 8, DL: 8, LB: 6, CB: 5, S: 4, K: 1, P: 1 };
+
+function normalizeSection(section) {
+  if (typeof section !== 'string') return 'Overview';
+  return TEAM_SECTIONS.find((entry) => entry.toLowerCase() === section.toLowerCase()) ?? 'Overview';
+}
 
 function getGameId(game) {
   return game?.id ?? game?.gameId ?? game?.gid ?? null;
@@ -24,6 +29,32 @@ function getStarterHealth(team) {
   return `${healthy}/${starters.length} healthy`;
 }
 
+function getPositionGroupPressure(roster = []) {
+  const byPos = new Map();
+  for (const player of roster) {
+    const pos = String(player?.pos ?? player?.position ?? 'UNK').toUpperCase();
+    if (!byPos.has(pos)) byPos.set(pos, { pos, total: 0, injured: 0, starterHealthy: false });
+    const row = byPos.get(pos);
+    row.total += 1;
+    const injured = Number(player?.injury?.gamesRemaining ?? player?.injuryWeeksRemaining ?? 0) > 0;
+    if (injured) row.injured += 1;
+    const depthOrder = Number(player?.depthChart?.order ?? player?.depthOrder ?? 99);
+    if (depthOrder === 1 && !injured) row.starterHealthy = true;
+  }
+  return [...byPos.values()]
+    .map((row) => {
+      const min = CRITICAL_POSITION_MIN[row.pos] ?? 2;
+      const healthy = row.total - row.injured;
+      const thin = healthy < min;
+      const starterGap = !row.starterHealthy && row.total > 0;
+      const severity = thin && starterGap ? 3 : thin ? 2 : starterGap ? 1 : 0;
+      return { ...row, healthy, thin, starterGap, severity };
+    })
+    .filter((row) => row.severity > 0)
+    .sort((a, b) => b.severity - a.severity || a.healthy - b.healthy)
+    .slice(0, 4);
+}
+
 function makeMatchupLabel(game, team) {
   if (!game || !team) return '—';
   const homeId = Number(game.homeId ?? game.home);
@@ -33,14 +64,25 @@ function makeMatchupLabel(game, team) {
   return `${isHome ? 'vs' : '@'} ${oppAbbr} · Week ${game.week ?? '—'}`;
 }
 
-export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSelect, onNavigate = null }) {
-  const [subtab, setSubtab] = useState('Overview');
+export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSelect, onNavigate = null, initialSection = 'Overview' }) {
+  const [subtab, setSubtab] = useState(() => normalizeSection(initialSection));
+  const [rosterMode, setRosterMode] = useState('roster');
   const team = useMemo(() => (league?.teams ?? []).find((t) => Number(t.id) === Number(league?.userTeamId)) ?? null, [league]);
   const roster = Array.isArray(team?.roster) ? team.roster : [];
   const capSnapshot = deriveTeamCapSnapshot(team, { fallbackCapTotal: 255 });
+  const avgSchemeFit = useMemo(() => {
+    if (!roster.length) return 50;
+    return Math.round(roster.reduce((sum, player) => sum + Number(player?.schemeFit ?? 50), 0) / roster.length);
+  }, [roster]);
 
   const expiringPlayers = useMemo(() => roster.filter((p) => Number(derivePlayerContractFinancials(p).yearsRemaining ?? 0) <= 1), [roster]);
   const injuredPlayers = useMemo(() => roster.filter((p) => Number(p?.injury?.gamesRemaining ?? p?.injuryWeeksRemaining ?? 0) > 0), [roster]);
+  const developmentSummary = useMemo(() => summarizeRosterDevelopment(roster, new Map()), [roster]);
+  const pressureGroups = useMemo(() => getPositionGroupPressure(roster), [roster]);
+
+  useEffect(() => {
+    setSubtab(normalizeSection(initialSection));
+  }, [initialSection]);
 
   const latestGame = useMemo(() => {
     const games = Array.isArray(league?.schedule) ? league.schedule : [];
@@ -56,16 +98,17 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
     const flags = [];
     if (capSnapshot.capRoom < 10) flags.push({ tone: 'danger', label: `Cap room low (${formatMoneyM(capSnapshot.capRoom)})`, target: 'Financials' });
     if (expiringPlayers.length > 8) flags.push({ tone: 'warning', label: `${expiringPlayers.length} contracts need attention`, target: 'Contracts' });
-    if (injuredPlayers.length > 0) flags.push({ tone: 'warning', label: `${injuredPlayers.length} injured players impact depth`, target: 'Depth Chart' });
-    if (roster.length > 53 && league?.phase === 'preseason') flags.push({ tone: 'danger', label: `Roster cutdown required (${roster.length}/53)`, target: 'Roster' });
+    if (injuredPlayers.length > 0) flags.push({ tone: 'warning', label: `${injuredPlayers.length} injured players impact depth`, target: 'Injuries' });
+    if (pressureGroups.length > 0) flags.push({ tone: 'warning', label: `${pressureGroups.length} position groups under pressure`, target: 'Roster / Depth' });
+    if (roster.length > 53 && league?.phase === 'preseason') flags.push({ tone: 'danger', label: `Roster cutdown required (${roster.length}/53)`, target: 'Roster / Depth' });
     return flags;
-  }, [capSnapshot.capRoom, expiringPlayers.length, injuredPlayers.length, roster.length, league?.phase]);
+  }, [capSnapshot.capRoom, expiringPlayers.length, injuredPlayers.length, pressureGroups.length, roster.length, league?.phase]);
 
   return (
     <div className="app-screen-stack">
       <TeamWorkspaceHeader
-        title="Team Operations"
-        subtitle="Command center for roster, contracts, cap pressure, and transactions."
+        title="Team Command Center"
+        subtitle="State of your roster, depth, contracts, development, and availability."
         eyebrow={team?.name ?? 'Team'}
         metadata={[
           { label: 'Record', value: `${team?.wins ?? 0}-${team?.losses ?? 0}${team?.ties ? `-${team.ties}` : ''}` },
@@ -73,12 +116,11 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
           { label: 'Phase', value: league?.phase ?? 'regular' },
         ]}
         actions={[
-          { label: 'View roster details', primary: true, onClick: () => setSubtab('Roster') },
-          { label: 'Depth Chart', onClick: () => setSubtab('Depth Chart') },
-          { label: 'Review contracts', onClick: () => setSubtab('Contracts') },
-          { label: 'Financials', onClick: () => setSubtab('Financials') },
-          { label: 'Explore free agents', onClick: () => onNavigate?.('Free Agency') },
-          { label: 'Shop trade market', onClick: () => onNavigate?.('Transactions') },
+          { label: 'Overview', primary: true, onClick: () => setSubtab('Overview') },
+          { label: 'Roster / Depth', onClick: () => setSubtab('Roster / Depth') },
+          { label: 'Contracts', onClick: () => setSubtab('Contracts') },
+          { label: 'Development', onClick: () => setSubtab('Development') },
+          { label: 'Injuries', onClick: () => setSubtab('Injuries') },
         ]}
         quickContext={[
           { label: `Cap ${formatMoneyM(capSnapshot.capRoom)} room`, tone: capSnapshot.capRoom <= 10 ? 'warning' : 'ok' },
@@ -87,7 +129,7 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
         ]}
       />
 
-      <SectionSubnav items={TEAM_SUBNAV} activeItem={subtab} onChange={setSubtab} sticky />
+      <SectionSubnav items={TEAM_SECTIONS} activeItem={subtab} onChange={setSubtab} sticky />
 
       {subtab === 'Overview' && (
         <div className="app-screen-stack" style={{ gap: 'var(--space-2)' }}>
@@ -119,6 +161,28 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
             )) : <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>No urgent team issues right now.</div>}
           </SectionCard>
 
+          <SectionCard title="Position group pressure" subtitle="Where the current depth chart is stressed.">
+            <div style={{ display: 'grid', gap: 6 }}>
+              {pressureGroups.length === 0 ? <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>No major weak spots detected from current healthy depth.</div> : pressureGroups.map((group) => (
+                <CompactListRow
+                  key={group.pos}
+                  title={group.pos}
+                  subtitle={`${group.healthy}/${group.total} healthy · ${group.starterGap ? 'starter unavailable' : 'starter active'}`}
+                  meta={<StatusChip label={group.thin ? 'Thin' : 'Watch'} tone={group.thin ? 'warning' : 'info'} />}
+                >
+                  <button type="button" className="btn btn-sm btn-secondary" onClick={() => setSubtab('Roster / Depth')}>Open depth</button>
+                </CompactListRow>
+              ))}
+            </div>
+          </SectionCard>
+
+          <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: 8 }}>
+            <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Availability</div><div style={{ fontWeight: 800 }}>{injuredPlayers.length} out</div></div>
+            <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Expiring deals</div><div style={{ fontWeight: 800 }}>{expiringPlayers.length}</div></div>
+            <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Development</div><div style={{ fontWeight: 800 }}>+{developmentSummary.rising.length} / -{developmentSummary.slipping.length}</div></div>
+            <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Avg scheme fit</div><div style={{ fontWeight: 800 }}>{avgSchemeFit}</div></div>
+          </section>
+
           <SectionCard title="Game context" subtitle="Quick links back to game flow without leaving team ops.">
             <div style={{ display: 'grid', gap: 8 }}>
               <button className="card" style={{ padding: '10px', textAlign: 'left' }} onClick={() => {
@@ -140,37 +204,68 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
 
           <SectionCard title="Team workflow" subtitle="Move through the full roster management loop.">
             <CtaRow actions={[
-              { label: 'View player details', compact: true, onClick: () => setSubtab('Roster') },
-              { label: 'Set depth', compact: true, onClick: () => setSubtab('Depth Chart') },
+              { label: 'Open roster/depth', compact: true, onClick: () => setSubtab('Roster / Depth') },
               { label: 'Review contracts', compact: true, onClick: () => setSubtab('Contracts') },
-              { label: 'Cap outlook', compact: true, onClick: () => setSubtab('Financials') },
+              { label: 'Development watchlist', compact: true, onClick: () => setSubtab('Development') },
+              { label: 'Injury impact', compact: true, onClick: () => setSubtab('Injuries') },
               { label: 'Explore free agents', compact: true, onClick: () => onNavigate?.('Free Agency') },
-              { label: 'Shop trade market', compact: true, onClick: () => onNavigate?.('Transactions') },
             ]} />
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
               <StatusChip label="Connected team workspace" tone="team" />
               <StatusChip label="Transactions linked" tone="league" />
             </div>
           </SectionCard>
-
-          <SocialFeed league={league} defaultFilter="team" maxItems={5} onPlayerSelect={onPlayerSelect} />
         </div>
       )}
 
-      {subtab === 'Roster' && <Roster league={league} actions={actions} onPlayerSelect={onPlayerSelect} onNavigate={onNavigate} />}
-      {subtab === 'Depth Chart' && (
-        <Roster
-          league={league}
-          actions={actions}
-          onPlayerSelect={onPlayerSelect}
-          onNavigate={onNavigate}
-          initialState={{ viewMode: 'depth', initialFilter: 'ALL' }}
-          initialViewMode="depth"
-        />
+      {subtab === 'Roster / Depth' && (
+        <div className="app-screen-stack" style={{ gap: 'var(--space-2)' }}>
+          <SectionCard title="Roster and depth ownership" subtitle="Set roles, identify thin spots, and keep the lineup game-ready.">
+            <CtaRow actions={[
+              { label: 'Roster table', compact: true, onClick: () => setRosterMode('roster') },
+              { label: 'Depth chart', compact: true, onClick: () => setRosterMode('depth') },
+              { label: 'Injured filter', compact: true, onClick: () => {
+                setSubtab('Injuries');
+              } },
+            ]} />
+          </SectionCard>
+          <Roster
+            league={league}
+            actions={actions}
+            onPlayerSelect={onPlayerSelect}
+            onNavigate={onNavigate}
+            initialState={{ viewMode: rosterMode === 'depth' ? 'depth' : 'table', initialFilter: 'ALL' }}
+            initialViewMode={rosterMode === 'depth' ? 'depth' : 'table'}
+          />
+        </div>
       )}
       {subtab === 'Contracts' && <ContractCenter league={league} actions={actions} compact onNavigate={onNavigate} />}
-      {subtab === 'Financials' && <FinancialsView league={league} actions={actions} />}
-      {subtab === 'Staff' && <StaffManagement league={league} actions={actions} compact />}
+      {subtab === 'Development' && (
+        <div className="app-screen-stack" style={{ gap: 'var(--space-2)' }}>
+          <SectionCard title="Development board" subtitle="Track risers, fallers, and prospects blocked by current depth roles.">
+            <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: 8 }}>
+              <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Rising</div><div style={{ fontWeight: 800 }}>{developmentSummary.rising.length}</div></div>
+              <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Slipping</div><div style={{ fontWeight: 800 }}>{developmentSummary.slipping.length}</div></div>
+              <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Blocked</div><div style={{ fontWeight: 800 }}>{developmentSummary.blocked.length}</div></div>
+              <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Contract pressure</div><div style={{ fontWeight: 800 }}>{developmentSummary.contractPressure.length}</div></div>
+            </section>
+            <div style={{ display: 'grid', gap: 6 }}>
+              {developmentSummary.rising[0] ? <div style={{ fontSize: 12 }}>Top riser: <strong>{developmentSummary.rising[0].name}</strong>.</div> : null}
+              {developmentSummary.slipping[0] ? <div style={{ fontSize: 12 }}>Top faller: <strong>{developmentSummary.slipping[0].name}</strong>.</div> : null}
+              {developmentSummary.blocked[0] ? <div style={{ fontSize: 12 }}>Blocked depth concern: <strong>{developmentSummary.blocked[0].name}</strong>.</div> : null}
+            </div>
+          </SectionCard>
+          <Roster
+            league={league}
+            actions={actions}
+            onPlayerSelect={onPlayerSelect}
+            onNavigate={onNavigate}
+            initialState={{ viewMode: 'table', initialFilter: 'DEVELOPMENT' }}
+            initialViewMode="table"
+          />
+        </div>
+      )}
+      {subtab === 'Injuries' && <InjuryReport league={league} onPlayerSelect={onPlayerSelect} />}
     </div>
   );
 }

--- a/src/ui/components/TeamHub.test.jsx
+++ b/src/ui/components/TeamHub.test.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import TeamHub from './TeamHub.jsx';
+
+const league = {
+  year: 2026,
+  week: 5,
+  phase: 'regular',
+  userTeamId: 7,
+  teams: [
+    {
+      id: 7,
+      name: 'Seattle Orcas',
+      wins: 3,
+      losses: 2,
+      ties: 0,
+      capRoom: 9,
+      roster: [
+        { id: 1, name: 'Starter QB', pos: 'QB', schemeFit: 72, progressionDelta: 2, depthChart: { order: 1 }, contract: { yearsRemaining: 1 } },
+        { id: 2, name: 'Backup QB', pos: 'QB', schemeFit: 63, progressionDelta: 0, depthChart: { order: 2 }, contract: { yearsRemaining: 2 } },
+        { id: 3, name: 'WR1', pos: 'WR', schemeFit: 80, progressionDelta: -1, depthChart: { order: 1 }, contract: { yearsRemaining: 1 }, injury: { gamesRemaining: 2 } },
+        { id: 4, name: 'WR2', pos: 'WR', schemeFit: 65, progressionDelta: 1, depthChart: { order: 2 }, contract: { yearsRemaining: 3 } },
+      ],
+    },
+  ],
+  schedule: [
+    { id: 'g1', week: 4, homeId: 7, awayId: 10, homeAbbr: 'SEA', awayAbbr: 'LAR', homeScore: 21, awayScore: 24 },
+    { id: 'g2', week: 5, homeId: 11, awayId: 7, homeAbbr: 'SF', awayAbbr: 'SEA', homeScore: null, awayScore: null },
+  ],
+};
+
+describe('TeamHub', () => {
+  it('renders command center section tabs and useful overview summaries', () => {
+    const html = renderToString(
+      <TeamHub
+        league={league}
+        actions={{}}
+        onOpenGameDetail={vi.fn()}
+        onPlayerSelect={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('Team Command Center');
+    expect(html).toContain('Overview');
+    expect(html).toContain('Roster / Depth');
+    expect(html).toContain('Contracts');
+    expect(html).toContain('Development');
+    expect(html).toContain('Injuries');
+    expect(html).toContain('Position group pressure');
+    expect(html).toContain('Expiring deals');
+    expect(html).toContain('Avg scheme fit');
+  });
+
+  it('supports direct section entry for team-context deep links', () => {
+    const html = renderToString(
+      <TeamHub
+        league={league}
+        actions={{}}
+        initialSection="Contracts"
+        onOpenGameDetail={vi.fn()}
+        onPlayerSelect={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('Contract Operations');
+    expect(html).not.toContain('Position group pressure');
+  });
+
+  it('fails safe for partial/legacy saves', () => {
+    expect(() => renderToString(
+      <TeamHub
+        league={{ year: 2026, week: 1, userTeamId: 1, teams: [{ id: 1, name: 'Legacy Team' }] }}
+        actions={{}}
+        onOpenGameDetail={vi.fn()}
+        onPlayerSelect={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+    )).not.toThrow();
+  });
+});

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -86,8 +86,8 @@ describe('FranchiseHQ', () => {
     expect(html).toContain('Matchup note');
     expect(html).toContain('Prep status');
     expect(html).toContain('Owner mandate');
-    expect(html).toContain('Injury pressure');
-    expect(html).toContain('Roster pressure');
+    expect(html).toContain('Team Command Center');
+    expect(html).not.toContain('Injury pressure');
     expect(html).toContain('League Watch (Teasers)');
     expect(html).toContain('Open Results');
     expect(html).toContain('Open League');

--- a/src/ui/utils/hqHelpers.js
+++ b/src/ui/utils/hqHelpers.js
@@ -112,11 +112,11 @@ export function getActionContext(type, weekly, nextGame) {
 export function getActionDestination(type, nextGame) {
   switch (type) {
     case 'lineup':
-      return 'Roster:depth|ALL';
+      return 'Team:Roster / Depth';
     case 'gameplan':
       return 'Game Plan';
     case 'news':
-      return nextGame ? 'Injuries' : 'News';
+      return nextGame ? 'Team:Injuries' : 'News';
     case 'opponent':
       return nextGame ? 'Weekly Prep' : 'Schedule';
     default:
@@ -139,13 +139,13 @@ export function rankHqPriorityItems(team, league, weekly, nextGame) {
   }
 
   if (injuries >= 4) {
-    items.push({ level: 'urgent', rank: 95, label: 'Depth chart stress test', detail: `${injuries} injuries are impacting lineup stability.`, verb: 'Set emergency lineup', tab: 'Roster:depth|ALL' });
+    items.push({ level: 'urgent', rank: 95, label: 'Depth chart stress test', detail: `${injuries} injuries are impacting lineup stability.`, verb: 'Set emergency lineup', tab: 'Team:Roster / Depth' });
   } else if (injuries >= 2) {
-    items.push({ level: 'recommended', rank: 74, label: 'Injury coverage needed', detail: `${injuries} active injuries require role adjustments.`, verb: 'Reassign roles', tab: 'Injuries' });
+    items.push({ level: 'recommended', rank: 74, label: 'Injury coverage needed', detail: `${injuries} active injuries require role adjustments.`, verb: 'Reassign roles', tab: 'Team:Injuries' });
   }
 
   if (expiring >= 4 && week >= 8) {
-    items.push({ level: 'recommended', rank: 84, label: 'Core contracts nearing expiry', detail: `${expiring} rotation players are in contract-year windows.`, verb: 'Start extension talks', tab: 'Financials' });
+    items.push({ level: 'recommended', rank: 84, label: 'Core contracts nearing expiry', detail: `${expiring} rotation players are in contract-year windows.`, verb: 'Start extension talks', tab: 'Team:Contracts' });
   }
 
   if (capRoom < 0) {

--- a/src/ui/utils/hqHelpers.test.js
+++ b/src/ui/utils/hqHelpers.test.js
@@ -45,7 +45,7 @@ describe('hqHelpers', () => {
 
     expect(getActionContext('lineup', weekly, nextGame)).toContain('3 injury');
     expect(getActionContext('gameplan', weekly, nextGame)).toContain('explosive offense');
-    expect(getActionDestination('lineup', nextGame)).toBe('Roster:depth|ALL');
+    expect(getActionDestination('lineup', nextGame)).toBe('Team:Roster / Depth');
     expect(getActionDestination('opponent', nextGame)).toBe('Weekly Prep');
   });
 

--- a/src/ui/utils/managementScreenRouting.js
+++ b/src/ui/utils/managementScreenRouting.js
@@ -3,6 +3,7 @@ const ROSTER_VIEWS = new Set(["table", "cards", "depth"]);
 const ROSTER_FILTERS = new Set(["ALL", "EXPIRING", "STARTERS", "DEPTH", "INJURED", "DEVELOPMENT"]);
 const STAT_FAMILIES = new Set(["passing", "rushing", "receiving", "defense"]);
 const LEAGUE_SECTIONS = new Set(["Overview", "Results", "Standings", "News", "Leaders"]);
+const TEAM_SECTIONS = new Set(["Overview", "Roster / Depth", "Contracts", "Development", "Injuries"]);
 
 export function normalizeManagementDestination(tabToken) {
   const normalized = {
@@ -11,6 +12,7 @@ export function normalizeManagementDestination(tabToken) {
     rosterState: null,
     statsFamily: null,
     leagueSection: null,
+    teamSection: null,
   };
   if (typeof tabToken !== "string") return normalized;
 
@@ -48,6 +50,13 @@ export function normalizeManagementDestination(tabToken) {
     normalized.tab = "League";
     const canonicalSection = [...LEAGUE_SECTIONS].find((v) => v.toLowerCase() === state.toLowerCase());
     normalized.leagueSection = canonicalSection ?? "Overview";
+    return normalized;
+  }
+
+  if (tab === "Team") {
+    normalized.tab = "Team";
+    const canonicalSection = [...TEAM_SECTIONS].find((v) => v.toLowerCase() === state.toLowerCase());
+    normalized.teamSection = canonicalSection ?? "Overview";
     return normalized;
   }
 

--- a/src/ui/utils/managementScreenRouting.test.js
+++ b/src/ui/utils/managementScreenRouting.test.js
@@ -46,6 +46,17 @@ describe("normalizeManagementDestination", () => {
     });
   });
 
+  it("supports team command center section deep links with default", () => {
+    expect(normalizeManagementDestination("Team:Contracts")).toMatchObject({
+      tab: "Team",
+      teamSection: "Contracts",
+    });
+    expect(normalizeManagementDestination("Team:unknown")).toMatchObject({
+      tab: "Team",
+      teamSection: "Overview",
+    });
+  });
+
   it("leaves unknown tabs untouched", () => {
     expect(normalizeManagementDestination("Financials")).toMatchObject({
       tab: "Financials",
@@ -53,6 +64,7 @@ describe("normalizeManagementDestination", () => {
       rosterState: null,
       statsFamily: null,
       leagueSection: null,
+      teamSection: null,
     });
   });
 });


### PR DESCRIPTION
### Motivation
- Make the Team area the canonical home for roster/organizational decisions so team-building context (depth, contracts, development, injuries) is owned by Team rather than duplicated in HQ. 
- Surface compact, high-value signals (position-group pressure, availability, expiring contracts, development snapshot, scheme-fit) so mobile-first scans answer "what is the state of my team right now?". 
- Keep the change surgical by reusing existing roster/contract/development/injury components and wiring HQ→Team navigation rather than redesigning app shell or adding backend/state changes.

### Description
- Refactor `TeamHub` into a Team Command Center with explicit sections `Overview`, `Roster / Depth`, `Contracts`, `Development`, and `Injuries`, and a compact overview that surfaces position-group pressure, availability, expiring deals, development risers/fallers, and avg scheme fit. 
- Reuse existing screens and utilities by composing `Roster`, `ContractCenter`, and `InjuryReport` inside Team sections and by using `summarizeRosterDevelopment` and existing cap/contract helpers for snapshots. 
- Add light heuristics for position-group pressure and a small `rosterMode` switch for depth/table views to preserve existing roster logic and avoid duplication. 
- Add routing support for `Team:<section>` in `normalizeManagementDestination` and thread `teamInitialSection` through `LeagueDashboard` so HQ actions deep-link into the correct Team-owned section. 
- Update HQ handoffs (`hqHelpers`) to point lineup/news/contract pressure CTAs at Team-owned destinations and reduce duplicate HQ team cards by adding a single Team handoff row. 
- Add unit tests covering Team sections, deep-link routing, HQ→Team destinations, overview safety with partial/legacy saves, and the adjusted HQ summary expectations.

### Testing
- Ran targeted unit tests with `npm run test:unit -- src/ui/utils/managementScreenRouting.test.js src/ui/utils/hqHelpers.test.js src/ui/components/TeamHub.test.jsx src/ui/components/__tests__/FranchiseHQ.test.jsx`. 
- All specified unit tests passed (16 tests in those files passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2ffec4670832d819178df5dc35770)