### PR TITLE
Introduce new ScreenSystem primitives and refactor HQ/League/Team UIs to use hero/stat/insight components

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -4,8 +4,17 @@ import { evaluateWeeklyContext } from "../utils/weeklyContext.js";
 import { deriveTeamCapSnapshot, formatMoneyM } from "../utils/numberFormatting.js";
 import { getHQViewModel } from "../../state/selectors.js";
 import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/boxScoreAccess.js";
-import { EmptyState, SectionCard, StatCard } from "./common/UiPrimitives.jsx";
-import { StatusChip, CompactListRow } from "./ScreenSystem.jsx";
+import {
+  EmptyState,
+  StatusChip,
+  HeroCard,
+  ActionTile,
+  StatStrip,
+  SectionCard,
+  CompactInsightCard,
+  CompactListRow,
+  SectionHeader,
+} from "./ScreenSystem.jsx";
 import { getRecentGames as getArchivedRecentGames } from "../../core/archive/gameArchive.ts";
 import { autoBuildDepthChart, depthWarnings } from "../../core/depthChart.js";
 import {
@@ -13,7 +22,6 @@ import {
   getActionContext,
   getActionDestination,
   rankHqPriorityItems,
-  getTeamSnapshotNotes,
 } from "../utils/hqHelpers.js";
 import { deriveWeeklyPrepState, markWeeklyPrepStep } from "../utils/weeklyPrep.js";
 
@@ -66,50 +74,7 @@ function getSeverityTone(level) {
   return "info";
 }
 
-const HQHero = ({ team, league, record, statusLine, nextGame, onAdvanceWeek, onNavigate, busy, simulating }) => (
-  <section
-    className="card"
-    style={{
-      padding: "var(--space-3)",
-      border: "1px solid color-mix(in srgb, var(--accent) 25%, var(--hairline))",
-      background: "linear-gradient(145deg, color-mix(in srgb, var(--surface) 94%, var(--accent) 6%) 0%, var(--surface) 100%)",
-      display: "grid",
-      gap: "var(--space-2)",
-    }}
-  >
-    <div style={{ display: "flex", justifyContent: "space-between", gap: 10, alignItems: "flex-start", flexWrap: "wrap" }}>
-      <div>
-        <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: ".05em" }}>
-          {league?.year} · Week {league?.week} · {String(league?.phase ?? "regular").replaceAll("_", " ")}
-        </div>
-        <h1 style={{ margin: "2px 0 0", fontSize: "clamp(1.1rem, 4.8vw, 1.5rem)", lineHeight: 1.1 }}>
-          {team?.city} {team?.name}
-        </h1>
-        <div style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)", marginTop: 2 }}>
-          {record} · {team?.conf} {team?.div}
-        </div>
-      </div>
-      <StatusChip label={statusLine} tone="team" />
-    </div>
-
-    <div style={{ display: "grid", gridTemplateColumns: "1fr auto", gap: "var(--space-2)", alignItems: "center" }}>
-      <div style={{ minWidth: 0 }}>
-        <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", textTransform: "uppercase" }}>Next opponent</div>
-        <div style={{ fontWeight: 700, fontSize: "var(--text-sm)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-          {nextGame ? `${nextGame.isHome ? "vs" : "@"} ${nextGame.opp?.name ?? "TBD"} (${formatRecord(nextGame.opp)})` : "Open week / schedule TBD"}
-        </div>
-      </div>
-      <div style={{ display: "flex", gap: 6, flexWrap: "wrap", justifyContent: "flex-end" }}>
-        <Button size="sm" variant="outline" onClick={() => onNavigate?.("Weekly Prep")}>Prepare Game</Button>
-        <Button size="sm" className="app-advance-btn" onClick={onAdvanceWeek} disabled={busy || simulating}>
-          {busy || simulating ? "Working…" : "Advance Week"}
-        </Button>
-      </div>
-    </div>
-  </section>
-);
-
-export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeamSelect, onAdvanceWeek, busy, simulating }) {
+export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdvanceWeek, busy, simulating }) {
   const vm = useMemo(() => getHQViewModel(league), [league]);
   const [lineupToast, setLineupToast] = useState(null);
   const weekly = useMemo(() => evaluateWeeklyContext(vm.league), [vm.league]);
@@ -127,40 +92,6 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
   const record = formatRecord(team);
   const statusLine = getTeamStatusLine(team, vm.league, weekly);
   const rankedPriorities = rankHqPriorityItems(team, vm.league, weekly, nextGame);
-  const featuredPriority = rankedPriorities.featured;
-  const secondaryPriorities = rankedPriorities.secondary;
-  const snapshotNotes = getTeamSnapshotNotes(team, weekly, cap.capRoom);
-
-  const handleSetLineup = () => {
-    const roster = Array.isArray(team?.roster) ? team.roster : [];
-    const existingAssignments = {};
-    for (const player of roster) {
-      const rowKey = player?.depthChart?.rowKey;
-      if (!rowKey) continue;
-      if (!existingAssignments[rowKey]) existingAssignments[rowKey] = [];
-      existingAssignments[rowKey].push(player.id);
-    }
-    const assignments = autoBuildDepthChart(roster, existingAssignments);
-    const warnings = depthWarnings(assignments, roster);
-    const hasBlockingLineupIssue = warnings.some((warning) => warning.level === "error");
-    if (!hasBlockingLineupIssue) markWeeklyPrepStep(vm.league, "lineupChecked", true);
-    setLineupToast(
-      hasBlockingLineupIssue
-        ? "Depth chart still has missing starters. Fix red-warning rows to finalize lineup."
-        : "Lineup is valid. Opening depth chart.",
-    );
-    window.setTimeout(() => setLineupToast(null), 2200);
-    onNavigate?.("Team:Roster / Depth");
-  };
-
-  const commandCenterActions = [
-    { label: "Set lineup", type: "lineup", onClick: handleSetLineup },
-    { label: "Game plan", type: "gameplan", onClick: () => { markWeeklyPrepStep(vm.league, "planReviewed", true); onNavigate?.(getActionDestination("gameplan", nextGame)); } },
-    { label: "News & injuries", type: "news", onClick: () => { markWeeklyPrepStep(vm.league, "injuriesReviewed", true); onNavigate?.(getActionDestination("news", nextGame)); } },
-    { label: "Scout opponent", type: "opponent", onClick: () => { markWeeklyPrepStep(vm.league, "opponentScouted", true); onNavigate?.(getActionDestination("opponent", nextGame)); } },
-  ]
-    .map((a) => ({ ...a, context: getActionContext(a.type, weekly, nextGame) }))
-    .slice(0, 4);
 
   const latestGamePresentation = latestArchived
     ? buildCompletedGamePresentation(
@@ -192,253 +123,142 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onTeam
     : null;
 
   const lastGame = latestArchived ?? fallbackLastGame;
-  const lastGameStory = (() => {
-    if (!lastGame) return "Play your next game to unlock recap context.";
-    const margin = Math.abs(safeNum(lastGame?.score?.home) - safeNum(lastGame?.score?.away));
-    if (margin <= 3) return "One-possession finish; late-game execution decided it.";
-    if (margin >= 14) return "Lopsided outcome; trench and turnover battles tilted early.";
-    return "Momentum swung in the second half and decided the final margin.";
-  })();
   const recapCtaLabel = latestGamePresentation?.canOpen
     ? (latestGamePresentation?.ctaLabel?.toLowerCase().includes("tactical") ? "Tactical Recap" : "Box Score")
     : "View Result";
 
-  const matchupGap = nextGame?.opp ? safeNum(team?.ovr) - safeNum(nextGame.opp?.ovr) : null;
-  const offenseGap = nextGame?.opp ? safeNum(team?.offenseRating ?? team?.offRating ?? team?.offense) - safeNum(nextGame.opp?.offenseRating ?? nextGame.opp?.offRating ?? nextGame.opp?.offense) : null;
-  const defenseGap = nextGame?.opp ? safeNum(team?.defenseRating ?? team?.defRating ?? team?.defense) - safeNum(nextGame.opp?.defenseRating ?? nextGame.opp?.defRating ?? nextGame.opp?.defense) : null;
-  const matchupNote = prep?.keyMatchupNote ?? "Use Weekly Prep to scout your next opponent.";
-  const prepStatus = prep?.readinessLabel ?? "Prep status unavailable";
+  const handleSetLineup = () => {
+    const roster = Array.isArray(team?.roster) ? team.roster : [];
+    const existingAssignments = {};
+    for (const player of roster) {
+      const rowKey = player?.depthChart?.rowKey;
+      if (!rowKey) continue;
+      if (!existingAssignments[rowKey]) existingAssignments[rowKey] = [];
+      existingAssignments[rowKey].push(player.id);
+    }
+    const assignments = autoBuildDepthChart(roster, existingAssignments);
+    const warnings = depthWarnings(assignments, roster);
+    const hasBlockingLineupIssue = warnings.some((warning) => warning.level === "error");
+    if (!hasBlockingLineupIssue) markWeeklyPrepStep(vm.league, "lineupChecked", true);
+    setLineupToast(hasBlockingLineupIssue ? "Depth chart still has missing starters." : "Lineup is valid. Opening depth chart.");
+    window.setTimeout(() => setLineupToast(null), 2200);
+    onNavigate?.("Team:Roster / Depth");
+  };
+
+  const commandCenterActions = [
+    { label: "Set Lineup", type: "lineup", onClick: handleSetLineup },
+    { label: "Game Plan", type: "gameplan", onClick: () => { markWeeklyPrepStep(vm.league, "planReviewed", true); onNavigate?.(getActionDestination("gameplan", nextGame)); } },
+    { label: "Scout Opponent", type: "opponent", onClick: () => { markWeeklyPrepStep(vm.league, "opponentScouted", true); onNavigate?.(getActionDestination("opponent", nextGame)); } },
+    { label: "News & Injuries", type: "news", onClick: () => { markWeeklyPrepStep(vm.league, "injuriesReviewed", true); onNavigate?.(getActionDestination("news", nextGame)); } },
+  ].map((a) => ({ ...a, context: getActionContext(a.type, weekly, nextGame) }));
+
+  const previewPriorities = [rankedPriorities.featured, ...(rankedPriorities.secondary ?? [])].filter(Boolean).slice(0, 3);
+
   const ownerApproval = safeNum(weekly?.pressurePoints?.ownerApproval ?? vm.league?.ownerApproval ?? vm.league?.ownerMood, null);
-  const injuriesCount = safeNum(weekly?.pressurePoints?.injuriesCount, 0);
-  const expiringCount = safeNum(weekly?.pressurePoints?.expiringCount, 0);
+  const expiringCount = safeNum(weekly?.pressurePoints?.expiringCount);
   const rosterCount = Array.isArray(team?.roster) ? team.roster.length : safeNum(team?.rosterCount, 0);
-  const ownerMandateTone = ownerApproval != null && ownerApproval < 40
-    ? "danger"
-    : ownerApproval != null && ownerApproval < 55
-      ? "warning"
-      : "info";
-  const teamContextRows = [
-    {
-      key: "owner",
-      title: "Owner mandate",
-      subtitle: ownerApproval == null
-        ? "Owner approval data unavailable in this save."
-        : `Approval ${ownerApproval} — ${ownerApproval < 40 ? "results required immediately" : ownerApproval < 55 ? "expectations rising this month" : "mandate on track"}`,
-      tone: ownerMandateTone,
-      cta: ownerApproval != null && ownerApproval < 55 ? "Open Advisor" : "Review goals",
-      destination: "🤖 GM Advisor",
-    },
-    {
-      key: "team",
-      title: "Team Command Center",
-      subtitle: rosterCount > 53
-        ? `Roster at ${rosterCount}; cutdown and depth decisions now live in Team.`
-        : `${injuriesCount} injuries, ${expiringCount} expirings, and development signals are tracked in Team.`,
-      tone: rosterCount > 53 || injuriesCount >= 3 ? "warning" : "info",
-      cta: "Open Team",
-      destination: "Team:Overview",
-    },
-  ];
 
   return (
-    <div className="app-screen-stack franchise-hq" style={{ display: "grid", gap: "var(--space-2)" }}>
-      <HQHero
-        team={team}
-        league={vm.league}
-        record={record}
-        statusLine={statusLine}
-        nextGame={nextGame}
-        onAdvanceWeek={onAdvanceWeek}
-        onNavigate={onNavigate}
-        busy={busy}
-        simulating={simulating}
-      />
-
-      <section style={{ display: "grid", gap: 8 }}>
-        <h3 style={{ margin: 0, fontSize: "var(--text-sm)", textTransform: "uppercase", letterSpacing: ".05em", color: "var(--text-muted)" }}>Act Now</h3>
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(270px, 1fr))", gap: "var(--space-2)" }}>
-          <SectionCard title="This Week" subtitle="Must-do franchise actions before kickoff.">
-            <div style={{ display: "grid", gap: 6 }}>
-              {commandCenterActions.map((action) => (
-                <CompactListRow
-                  key={action.label}
-                  title={action.label}
-                  subtitle={action.context}
-                  meta={<StatusChip label="Prep" tone="team" />}
-                >
-                  <Button size="sm" variant="outline" onClick={action.onClick}>{action.label}</Button>
-                </CompactListRow>
-              ))}
-            </div>
-            {lineupToast ? <div style={{ fontSize: "var(--text-xs)", color: "var(--accent)", marginTop: 6 }}>{lineupToast}</div> : null}
-          </SectionCard>
-
-          <SectionCard title="Priority Queue" subtitle="Critical blockers and high-impact calls.">
-            {featuredPriority ? (
-              <div style={{ display: "grid", gap: 8 }}>
-                <div style={{ border: "1px solid var(--danger)", borderRadius: "var(--radius-md)", padding: "10px", background: "color-mix(in srgb, var(--danger) 10%, var(--surface))" }}>
-                  <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "start" }}>
-                    <div>
-                      <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", textTransform: "uppercase" }}>Urgent</div>
-                      <div style={{ fontWeight: 700, fontSize: "var(--text-sm)" }}>{featuredPriority.label}</div>
-                      <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginTop: 2 }}>{featuredPriority.detail}</div>
-                    </div>
-                    <Button size="sm" onClick={() => onNavigate?.(featuredPriority?.tab ?? "Team")}>{featuredPriority.verb || "Review now"}</Button>
-                  </div>
-                </div>
-
-                {secondaryPriorities.map((item, idx) => (
-                  <CompactListRow
-                    key={`${item.label}-${idx}`}
-                    title={item.label}
-                    subtitle={item.detail}
-                    meta={<StatusChip label={item.level === "blocker" ? "Urgent" : item.level === "recommendation" ? "Recommended" : "Info"} tone={getSeverityTone(item.level)} />}
-                  >
-                    <Button size="sm" variant="outline" onClick={() => onNavigate?.(item?.tab ?? "Team")}>{item.verb || "Review"}</Button>
-                  </CompactListRow>
-                ))}
-              </div>
-            ) : (
-              <CompactListRow
-                title="No urgent blockers"
-                subtitle="Use this week to improve cap, depth, and scouting position."
-                meta={<StatusChip label="Info" tone="info" />}
-              >
-                <Button size="sm" variant="outline" onClick={() => onNavigate?.("Financials")}>Upgrade facility</Button>
-              </CompactListRow>
-            )}
-          </SectionCard>
+    <div className="app-screen-stack franchise-hq">
+      <HeroCard
+        eyebrow={`${league?.year ?? "Season"} · Week ${league?.week ?? 1} · ${String(league?.phase ?? "regular").replaceAll("_", " ")}`}
+        title={`${team?.city ?? ""} ${team?.name ?? "Team"}`}
+        subtitle={`${record} · ${nextGame ? `${nextGame.isHome ? "vs" : "@"} ${nextGame.opp?.name ?? "TBD"} (${formatRecord(nextGame.opp)})` : "No upcoming opponent"}`}
+        rightMeta={<StatusChip label={statusLine} tone="team" />}
+        actions={(
+          <>
+            <Button size="sm" variant="outline" onClick={() => onNavigate?.("Weekly Prep")}>Prepare Game</Button>
+            <Button size="sm" className="app-advance-btn" onClick={onAdvanceWeek} disabled={busy || simulating}>{busy || simulating ? "Working…" : "Advance Week"}</Button>
+          </>
+        )}
+      >
+        <div className="app-hero-summary-grid">
+          <div>
+            <span>Last result</span>
+            <strong>
+              {lastGame
+                ? `${lastGame.userWon ? "W" : "L"} · ${lastGame.awayAbbr} ${safeNum(lastGame?.score?.away)} @ ${lastGame.homeAbbr} ${safeNum(lastGame?.score?.home)}`
+                : "No completed game yet"}
+            </strong>
+          </div>
+          <div>
+            <span>Prep status</span>
+            <strong>{prep?.readinessLabel ?? "Prep status unavailable"}</strong>
+          </div>
         </div>
-      </section>
+      </HeroCard>
 
-      <section style={{ display: "grid", gap: 8 }}>
-        <h3 style={{ margin: 0, fontSize: "var(--text-sm)", textTransform: "uppercase", letterSpacing: ".05em", color: "var(--text-muted)" }}>This Week</h3>
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))", gap: "var(--space-2)" }}>
-          <SectionCard title="Next Opponent" actions={nextGame ? <StatusChip label={`Week ${nextGame.week}`} tone="team" /> : null}>
-            <div style={{ display: "grid", gap: 5 }}>
-              <div style={{ fontWeight: 700 }}>{nextGame ? `${nextGame.isHome ? "vs" : "@"} ${nextGame.opp?.name ?? "TBD"}` : "No scheduled matchup"}</div>
-              <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
-                {nextGame?.opp ? `Opponent record: ${formatRecord(nextGame.opp)} · OVR ${safeNum(nextGame.opp?.ovr, 0)}` : "Schedule or playoff bracket context will appear here."}
-              </div>
-              {nextGame?.opp ? (
-                <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
-                  OVR edge: {matchupGap > 0 ? "+" : ""}{safeNum(matchupGap)} · Offense: {offenseGap > 0 ? "+" : ""}{safeNum(offenseGap)} · Defense: {defenseGap > 0 ? "+" : ""}{safeNum(defenseGap)}
-                </div>
-              ) : null}
-              <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>Matchup note: {matchupNote}</div>
-              <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>Prep status: {prepStatus}</div>
-              <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-                <Button size="sm" variant="outline" onClick={() => onNavigate?.(getActionDestination("opponent", nextGame))}>Scout Matchup</Button>
-                <Button size="sm" variant="outline" onClick={() => onNavigate?.("Weekly Prep")}>Prepare Game</Button>
-              </div>
-            </div>
-          </SectionCard>
+      <div className="app-action-grid-2x2">
+        {commandCenterActions.map((action) => (
+          <ActionTile key={action.label} title={action.label} subtitle={action.context} onClick={action.onClick} tone="info" />
+        ))}
+      </div>
+      {lineupToast ? <p className="app-inline-toast">{lineupToast}</p> : null}
 
-          <SectionCard title="Latest Team Result">
-            <div style={{ display: "grid", gap: 5 }}>
-              {lastGame ? (
-                <>
-                  <div style={{ fontWeight: 700 }}>
-                    {lastGame.userWon ? "W" : "L"} · {lastGame.awayAbbr} {safeNum(lastGame?.score?.away)} @ {lastGame.homeAbbr} {safeNum(lastGame?.score?.home)}
-                  </div>
-                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>{lastGameStory}</div>
-                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
-                    Top performer: {latestGamePresentation?.spotlightPlayer?.name ?? latestGamePresentation?.headline ?? "Team effort carried the result."}
-                  </div>
-                  <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={() => openResolvedBoxScore(
-                        {
-                          ...latestArchived,
-                          id: latestArchived?.id ?? lastGame?.id,
-                          week: latestArchived?.week ?? lastGame?.week,
-                          homeScore: latestArchived?.score?.home ?? lastGame?.score?.home,
-                          awayScore: latestArchived?.score?.away ?? lastGame?.score?.away,
-                        },
-                        { seasonId: vm.league?.seasonId, week: Number(latestArchived?.week ?? lastGame?.week ?? vm.league?.week ?? 1), source: "hq_last_game" },
-                        onOpenBoxScore,
-                      )}
-                      disabled={latestArchived ? !latestGamePresentation?.canOpen : false}
-                    >
-                      {recapCtaLabel}
-                    </Button>
-                    <Button size="sm" variant="ghost" onClick={() => onNavigate?.("Weekly Results")}>
-                      Full Weekly Results
-                    </Button>
-                  </div>
-                </>
-              ) : (
-                <CompactListRow
-                  title="No final yet"
-                  subtitle="Your first completed game will unlock recap context and tactical takeaways."
-                  meta={<StatusChip label="Info" tone="info" />}
-                >
-                  <Button size="sm" variant="outline" onClick={() => onNavigate?.("Schedule")}>Open Schedule</Button>
-                  <Button size="sm" variant="ghost" onClick={() => onNavigate?.("Weekly Results")}>Weekly Results</Button>
-                </CompactListRow>
-              )}
-            </div>
-          </SectionCard>
-        </div>
-      </section>
-
-      <section style={{ display: "grid", gap: 8 }}>
-        <h3 style={{ margin: 0, fontSize: "var(--text-sm)", textTransform: "uppercase", letterSpacing: ".05em", color: "var(--text-muted)" }}>Team Status</h3>
-        <SectionCard title="Team Snapshot" subtitle="Roster, cap, and pressure at a glance.">
-          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(125px, 1fr))", gap: 8 }}>
-            <StatCard label="OVR" value={`${safeNum(team?.ovr, 0)}`} note={snapshotNotes.ovrNote} />
-            <StatCard label="Cap room" value={formatMoneyM(cap.capRoom)} note={snapshotNotes.capNote} />
-            <StatCard label="Roster" value={`${(team?.roster ?? []).length} active`} note={snapshotNotes.rosterNote} />
-            <StatCard
-              label="Expiring deals"
-              value={`${safeNum(weekly?.pressurePoints?.expiringCount)}`}
-              note={snapshotNotes.expiringNote}
+      <SectionCard title="Priority Rail" subtitle="Top front-office actions this week." variant="compact">
+        <div className="app-priority-rail">
+          {previewPriorities.length > 0 ? previewPriorities.map((item, idx) => (
+            <CompactInsightCard
+              key={`${item.label}-${idx}`}
+              title={item.label}
+              subtitle={item.detail}
+              tone={getSeverityTone(item.level)}
+              ctaLabel={item.verb || "Review"}
+              onCta={() => onNavigate?.(item?.tab ?? "Team")}
             />
-          </div>
-        </SectionCard>
-        <SectionCard title="Team Context" subtitle="HQ links into Team-owned roster, injury, and contract context.">
-          <div style={{ display: "grid", gap: 6 }}>
-            {teamContextRows.map((row) => (
-              <CompactListRow
-                key={row.key}
-                title={row.title}
-                subtitle={row.subtitle}
-                meta={<StatusChip label={row.tone === "danger" ? "Critical" : row.tone === "warning" ? "Watch" : "Stable"} tone={row.tone} />}
-              >
-                <Button size="sm" variant="outline" onClick={() => onNavigate?.(row.destination)}>{row.cta}</Button>
-              </CompactListRow>
-            ))}
-          </div>
-        </SectionCard>
-      </section>
-
-      <SectionCard title="League Watch (Teasers)" subtitle="League-wide context now lives in League and Weekly Results.">
-        <div style={{ display: "grid", gap: 6 }}>
-          <CompactListRow
-            title="Weekly League Recap"
-            subtitle="Open full recap, race center, and spotlight games in Weekly Results."
-            meta={<StatusChip label="Results" tone="league" />}
-          >
-            <Button size="sm" variant="ghost" onClick={() => onNavigate?.("League:Results")}>Open Results</Button>
-          </CompactListRow>
-          <CompactListRow
-            title="League Pulse"
-            subtitle="League activity, standings context, and social pulse moved to League."
-            meta={<StatusChip label="League" tone="league" />}
-          >
-            <Button size="sm" variant="ghost" onClick={() => onNavigate?.("League:Overview")}>Open League</Button>
-          </CompactListRow>
-          <CompactListRow
-            title="League Leaders"
-            subtitle="Team and player leaders now live in the League command center."
-            meta={<StatusChip label="Leaders" tone="info" />}
-          >
-            <Button size="sm" variant="ghost" onClick={() => onNavigate?.("League:Leaders")}>Open Leaders</Button>
-          </CompactListRow>
+          )) : (
+            <CompactInsightCard title="No urgent blockers" subtitle="Use this week to gain edges in prep and depth." tone="info" ctaLabel="Open Team" onCta={() => onNavigate?.("Team:Overview")} />
+          )}
         </div>
       </SectionCard>
+
+      <SectionHeader eyebrow="Team status" title="Snapshot" subtitle="Roster and cap in one line." />
+      <StatStrip items={[
+        { label: "OVR", value: `${safeNum(team?.ovr, 0)}`, tone: "team" },
+        { label: "Cap Room", value: formatMoneyM(cap.capRoom), tone: cap.capRoom < 10 ? "warning" : "ok" },
+        { label: "Roster", value: `${rosterCount}/53`, tone: rosterCount > 53 ? "danger" : "neutral" },
+        { label: "Expiring", value: `${expiringCount}`, tone: expiringCount >= 8 ? "warning" : "neutral" },
+      ]} />
+
+      <SectionCard title="Last Result" variant="compact">
+        {lastGame ? (
+          <CompactListRow
+            title={`${lastGame.userWon ? "Win" : "Loss"} · Week ${lastGame.week ?? vm.league?.week ?? 1}`}
+            subtitle={`${lastGame.awayAbbr} ${safeNum(lastGame?.score?.away)} @ ${lastGame.homeAbbr} ${safeNum(lastGame?.score?.home)}`}
+            meta={<StatusChip label="Recap" tone="league" />}
+          >
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => openResolvedBoxScore(
+                {
+                  ...latestArchived,
+                  id: latestArchived?.id ?? lastGame?.id,
+                  week: latestArchived?.week ?? lastGame?.week,
+                  homeScore: latestArchived?.score?.home ?? lastGame?.score?.home,
+                  awayScore: latestArchived?.score?.away ?? lastGame?.score?.away,
+                },
+                { seasonId: vm.league?.seasonId, week: Number(latestArchived?.week ?? lastGame?.week ?? vm.league?.week ?? 1), source: "hq_last_game" },
+                onOpenBoxScore,
+              )}
+              disabled={latestArchived ? !latestGamePresentation?.canOpen : false}
+            >
+              {recapCtaLabel}
+            </Button>
+          </CompactListRow>
+        ) : (
+          <CompactInsightCard title="No final yet" subtitle="Play your next game to unlock full recap context." tone="info" ctaLabel="Open Schedule" onCta={() => onNavigate?.("Schedule")} />
+        )}
+      </SectionCard>
+
+      <section className="app-teaser-strip card">
+        <CompactListRow title="League Results" subtitle="Open full recap and spotlight games." meta={<StatusChip label="League" tone="league" />}>
+          <Button size="sm" variant="ghost" onClick={() => onNavigate?.("League:Results")}>Open Results</Button>
+        </CompactListRow>
+        <CompactListRow title="Owner Mandate" subtitle={ownerApproval == null ? "Approval unavailable" : `Approval ${ownerApproval}`} meta={<StatusChip label="HQ" tone={ownerApproval != null && ownerApproval < 55 ? "warning" : "info"} />}>
+          <Button size="sm" variant="ghost" onClick={() => onNavigate?.("🤖 GM Advisor")}>Open Advisor</Button>
+        </CompactListRow>
+      </section>
     </div>
   );
 }

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -1514,12 +1514,11 @@ export default function LeagueDashboard({
             }}
           />
         </div>
-        <div className="franchise-status-bar__meta">
-          <span><strong>{shell.teamAbbr}</strong> {shell.teamName}</span>
-          <span>{shell.year}</span>
-          <span>Week {shell.week}</span>
-          <span style={{ textTransform: 'capitalize' }}>{shell.phase}</span>
-          <span>Cap {shell.capSummary}</span>
+        <div className="franchise-status-pill-row">
+          <span className="app-status-chip tone-team"><strong>{shell.teamAbbr}</strong></span>
+          <span className="app-status-chip tone-league">Week {shell.week}</span>
+          <span className="app-status-chip tone-info" style={{ textTransform: 'capitalize' }}>{shell.phase}</span>
+          <span className="app-status-chip">Cap {shell.capSummary}</span>
         </div>
       </div>
 

--- a/src/ui/components/LeagueHub.jsx
+++ b/src/ui/components/LeagueHub.jsx
@@ -4,7 +4,7 @@ import SocialFeed from './SocialFeed.jsx';
 import LeagueLeaders from './LeagueLeaders.jsx';
 import { buildNewsDeskModel } from '../utils/newsDesk.js';
 import { buildWeeklyLeagueRecap } from '../utils/weeklyLeagueRecap.js';
-import { CompactListRow, ScreenHeader, StatusChip } from './ScreenSystem.jsx';
+import { CompactListRow, StatusChip, HeroCard, SectionCard, StatStrip, CompactInsightCard } from './ScreenSystem.jsx';
 import { openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 
 const LEAGUE_SECTIONS = ['Overview', 'Results', 'Standings', 'News', 'Leaders'];
@@ -50,63 +50,61 @@ export default function LeagueHub({
 
   return (
     <div className="app-screen-stack">
-      <ScreenHeader
-        title="League Command Center"
-        subtitle="League-wide overview, results, standings pressure, news, and leaders."
+      <HeroCard
         eyebrow={`${league?.year ?? 'Season'} · Week ${league?.week ?? 1}`}
-      />
+        title="League Command Center"
+        subtitle="Results, standings pressure, league activity, and leaders."
+        rightMeta={<StatusChip label={section} tone="league" />}
+      >
+        <StatStrip items={[
+          { label: 'Spotlights', value: `${spotlightRows.length}`, tone: 'league' },
+          { label: 'Trades', value: `${transactionRows.filter((row) => row?._txType === 'Trade').length}`, tone: 'info' },
+          { label: 'Signings', value: `${transactionRows.filter((row) => row?._txType === 'Signing').length}`, tone: 'neutral' },
+          { label: 'Releases', value: `${transactionRows.filter((row) => row?._txType === 'Release').length}`, tone: transactionRows.some((row) => row?._txType === 'Release') ? 'warning' : 'neutral' },
+        ]} />
+      </HeroCard>
+
       <SectionSubnav items={LEAGUE_SECTIONS} activeItem={section} onChange={setSection} />
 
       {section === 'Overview' && (
-        <div style={{ display: 'grid', gap: 'var(--space-3)' }}>
-          <section className="card" style={{ padding: 'var(--space-3)', display: 'grid', gap: 8 }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-              <h3 style={{ margin: 0 }}>League Pulse</h3>
-              <StatusChip label="Overview" tone="league" />
+        <div className="app-screen-stack">
+          <SectionCard title="League pulse" subtitle="What changed this week." variant="compact">
+            <div className="app-row-stack">
+              {(recap?.bullets ?? []).slice(0, 3).map((bullet, idx) => (
+                <CompactInsightCard key={`overview-bullet-${idx}`} title={bullet} tone="info" />
+              ))}
+              {(recap?.bullets ?? []).length === 0 ? <CompactInsightCard title="Pulse unlocks after results" subtitle="Complete games to populate weekly pulse and race context." tone="info" /> : null}
             </div>
-            <ul style={{ margin: 0, paddingLeft: 18, display: 'grid', gap: 4 }}>
-              {(recap?.bullets ?? []).slice(0, 3).map((bullet, idx) => <li key={`overview-bullet-${idx}`}>{bullet}</li>)}
-            </ul>
-            {(recap?.bullets ?? []).length === 0 ? (
-              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
-                Weekly pulse unlocks once completed game results are available.
-              </div>
-            ) : null}
-          </section>
+          </SectionCard>
 
-          <section className="card" style={{ padding: 'var(--space-3)', display: 'grid', gap: 6 }}>
-            <h3 style={{ margin: 0 }}>Standings pressure</h3>
-            <div style={{ display: 'grid', gap: 4, gridTemplateColumns: 'repeat(auto-fit, minmax(170px, 1fr))' }}>
-              <div>
-                <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}>Hottest</div>
-                <div style={{ fontWeight: 700 }}>
-                  {recap?.raceCenter?.hottest?.[0]
-                    ? `${recap.raceCenter.hottest[0].team?.abbr ?? recap.raceCenter.hottest[0].team?.name} (${recap.raceCenter.hottest[0].streak.length}W)`
-                    : '—'}
-                </div>
-              </div>
-              <div>
-                <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}>Coldest</div>
-                <div style={{ fontWeight: 700 }}>
-                  {recap?.raceCenter?.coldest?.[0]
-                    ? `${recap.raceCenter.coldest[0].team?.abbr ?? recap.raceCenter.coldest[0].team?.name} (${recap.raceCenter.coldest[0].streak.length}L)`
-                    : '—'}
-                </div>
-              </div>
-              <div>
-                <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}>Mover</div>
-                <div style={{ fontWeight: 700 }}>
-                  {recap?.raceCenter?.biggestMover?.change > 0
-                    ? `${recap.raceCenter.biggestMover.team?.abbr ?? recap.raceCenter.biggestMover.team?.name} (+${recap.raceCenter.biggestMover.change})`
-                    : 'No major move'}
-                </div>
-              </div>
-            </div>
-          </section>
+          <SectionCard title="Standings pressure" variant="compact">
+            <StatStrip items={[
+              {
+                label: 'Hottest',
+                value: recap?.raceCenter?.hottest?.[0]
+                  ? `${recap.raceCenter.hottest[0].team?.abbr ?? recap.raceCenter.hottest[0].team?.name} (${recap.raceCenter.hottest[0].streak.length}W)`
+                  : '—',
+                tone: 'ok',
+              },
+              {
+                label: 'Coldest',
+                value: recap?.raceCenter?.coldest?.[0]
+                  ? `${recap.raceCenter.coldest[0].team?.abbr ?? recap.raceCenter.coldest[0].team?.name} (${recap.raceCenter.coldest[0].streak.length}L)`
+                  : '—',
+                tone: 'warning',
+              },
+              {
+                label: 'Mover',
+                value: recap?.raceCenter?.biggestMover?.change > 0
+                  ? `${recap.raceCenter.biggestMover.team?.abbr ?? recap.raceCenter.biggestMover.team?.name} (+${recap.raceCenter.biggestMover.change})`
+                  : 'No major move',
+                tone: 'league',
+              },
+            ]} />
+          </SectionCard>
 
           {spotlightRows.length > 0 && (
-            <section style={{ display: 'grid', gap: 6 }}>
-              <h3 style={{ margin: 0 }}>Spotlight games</h3>
+            <SectionCard title="Spotlight games" variant="compact">
               {spotlightRows.slice(0, 2).map((spotlight, idx) => (
                 <CompactListRow
                   key={spotlight.key ?? `spotlight-${idx}`}
@@ -123,7 +121,7 @@ export default function LeagueHub({
                   </button>
                 </CompactListRow>
               ))}
-            </section>
+            </SectionCard>
           )}
         </div>
       )}
@@ -132,30 +130,21 @@ export default function LeagueHub({
       {section === 'Standings' && renderStandings?.()}
 
       {section === 'News' && (
-        <div style={{ display: 'grid', gap: 'var(--space-3)' }}>
-          <section className="card" style={{ padding: 'var(--space-3)' }}>
-            <div style={{ fontWeight: 700, marginBottom: 8 }}>League activity center</div>
-            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(110px, 1fr))', gap: 8 }}>
-              {['Trade', 'Signing', 'Release', 'Draft'].map((label) => (
-                <div key={label} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: '8px 10px', background: 'var(--surface-2)' }}>
-                  <div style={{ fontSize: 11, color: 'var(--text-subtle)', textTransform: 'uppercase' }}>{label}</div>
-                  <div style={{ fontWeight: 800, fontSize: 18 }}>{transactionRows.filter((row) => row?._txType === label).length}</div>
-                </div>
-              ))}
-            </div>
-          </section>
+        <div className="app-screen-stack">
+          <SectionCard title="League activity" subtitle="Transaction mix this week." variant="compact">
+            <StatStrip items={['Trade', 'Signing', 'Release', 'Draft'].map((label) => ({
+              label,
+              value: `${transactionRows.filter((row) => row?._txType === label).length}`,
+              tone: label === 'Release' ? 'warning' : 'league',
+            }))} />
+          </SectionCard>
           <SocialFeed league={league} defaultFilter="league" maxItems={12} onPlayerSelect={onPlayerSelect} />
         </div>
       )}
 
       {section === 'Leaders' && (
-        <div style={{ display: 'grid', gap: 'var(--space-3)' }}>
-          <section className="card" style={{ padding: 'var(--space-3)' }}>
-            <h3 style={{ margin: 0 }}>League leaders</h3>
-            <div style={{ marginTop: 4, fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
-              Season production leaders and race snapshots across the league.
-            </div>
-          </section>
+        <div className="app-screen-stack">
+          <SectionCard title="League leaders" subtitle="Season production and race snapshots." variant="compact" />
           <LeagueLeaders league={league} actions={actions} onPlayerSelect={onPlayerSelect} />
         </div>
       )}

--- a/src/ui/components/LeagueHub.test.jsx
+++ b/src/ui/components/LeagueHub.test.jsx
@@ -45,7 +45,7 @@ describe('LeagueHub', () => {
     expect(html).toContain('Standings');
     expect(html).toContain('News');
     expect(html).toContain('Leaders');
-    expect(html).toContain('League Pulse');
+    expect(html).toContain('League pulse');
     expect(html).not.toContain('Weekly Results Stub');
   });
 

--- a/src/ui/components/MobileNav.jsx
+++ b/src/ui/components/MobileNav.jsx
@@ -80,9 +80,9 @@ export default function MobileNav({ activeSection, onSectionChange, onDestinatio
 
       {menuOpen && <div className="mobile-nav-backdrop" onClick={() => setMenuOpen(false)} aria-hidden="true" />}
 
-      <nav className={`mobile-nav-panel ${menuOpen ? 'open' : ''}`} aria-label="More navigation">
+      <nav className={`mobile-nav-panel mobile-nav-panel-premium ${menuOpen ? 'open' : ''}`} aria-label="More navigation">
         <div className="mobile-nav-header">
-          <h2 className="mobile-nav-title">More</h2>
+          <h2 className="mobile-nav-title">Command Menu</h2>
           {league && <p className="mobile-nav-subtitle">{league.year ?? league.seasonId} · {league.phase}</p>}
         </div>
 
@@ -93,7 +93,7 @@ export default function MobileNav({ activeSection, onSectionChange, onDestinatio
               {group.items.map((item) => {
                 const Icon = item.icon;
                 return (
-                  <button key={item.id} className="mobile-nav-item" onClick={() => handleDestinationClick(item.id)}>
+                  <button key={item.id} className="mobile-nav-item mobile-nav-item-premium" onClick={() => handleDestinationClick(item.id)}>
                     <Icon size={20} />
                     <span>{item.label}</span>
                   </button>
@@ -104,12 +104,12 @@ export default function MobileNav({ activeSection, onSectionChange, onDestinatio
         </div>
       </nav>
 
-      <div className="mobile-bottom-bar">
+      <div className="mobile-bottom-bar premium-bottom-nav">
         {BOTTOM_TABS.map((tab) => {
           const Icon = tab.icon;
           const isActive = activeSection === tab.id;
           return (
-            <button key={tab.id} className={`mobile-bottom-tab ${isActive ? 'active' : ''}`} onClick={() => handleSectionClick(tab.id)} aria-label={tab.label}>
+            <button key={tab.id} className={`mobile-bottom-tab premium-bottom-tab ${isActive ? 'active' : ''}`} onClick={() => handleSectionClick(tab.id)} aria-label={tab.label}>
               <Icon size={20} />
               <span className="mobile-bottom-label">{tab.label}</span>
             </button>
@@ -117,7 +117,7 @@ export default function MobileNav({ activeSection, onSectionChange, onDestinatio
         })}
 
         <button
-          className="mobile-bottom-tab mobile-bottom-tab-advance"
+          className="mobile-bottom-tab premium-bottom-tab mobile-bottom-tab-advance"
           onClick={onAdvance}
           disabled={advanceDisabled}
           aria-label={advanceLabel || 'Advance'}
@@ -126,7 +126,7 @@ export default function MobileNav({ activeSection, onSectionChange, onDestinatio
           <span className="mobile-bottom-label">{advanceLabel || 'Advance'}</span>
         </button>
 
-        <button className={`mobile-bottom-tab ${menuOpen ? 'active' : ''}`} onClick={() => setMenuOpen(!menuOpen)} aria-label="Open more menu">
+        <button className={`mobile-bottom-tab premium-bottom-tab ${menuOpen ? 'active' : ''}`} onClick={() => setMenuOpen(!menuOpen)} aria-label="Open more menu">
           <MoreIcon size={20} />
           <span className="mobile-bottom-label">{NAV_LABELS.more}</span>
         </button>

--- a/src/ui/components/MobileNav.test.jsx
+++ b/src/ui/components/MobileNav.test.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import MobileNav from './MobileNav.jsx';
+import { SHELL_SECTIONS } from '../utils/shellNavigation.js';
+
+describe('MobileNav', () => {
+  it('renders premium bottom nav and marks the active shell tab', () => {
+    const html = renderToString(
+      <MobileNav
+        activeSection={SHELL_SECTIONS.team}
+        onSectionChange={vi.fn()}
+        onDestinationChange={vi.fn()}
+        onAdvance={vi.fn()}
+        advanceLabel="Advance Week"
+        advanceDisabled={false}
+        league={{ year: 2026, phase: 'regular' }}
+      />,
+    );
+
+    expect(html).toContain('premium-bottom-nav');
+    expect(html).toContain('premium-bottom-tab active');
+    expect(html).toContain('Team');
+    expect(html).toContain('Advance Week');
+  });
+
+  it('keeps command menu destinations wired for more drawer entries', () => {
+    const html = renderToString(
+      <MobileNav
+        activeSection={SHELL_SECTIONS.hq}
+        onSectionChange={vi.fn()}
+        onDestinationChange={vi.fn()}
+        onAdvance={vi.fn()}
+        advanceLabel="Advance"
+        advanceDisabled={false}
+        league={{ year: 2026, phase: 'regular' }}
+      />,
+    );
+
+    expect(html).toContain('Command Menu');
+    expect(html).toContain('Trades');
+    expect(html).toContain('Free Agency');
+    expect(html).toContain('League Leaders');
+  });
+});

--- a/src/ui/components/ScreenSystem.jsx
+++ b/src/ui/components/ScreenSystem.jsx
@@ -36,9 +36,22 @@ export function ScreenHeader({
   );
 }
 
-export function SectionCard({ title, subtitle, actions = null, children }) {
+export function SectionHeader({ eyebrow, title, subtitle, actions = null }) {
   return (
-    <section className="app-section-card card">
+    <div className="app-section-header">
+      <div>
+        {eyebrow ? <div className="app-section-header__eyebrow">{eyebrow}</div> : null}
+        <h2 className="app-section-header__title">{title}</h2>
+        {subtitle ? <p className="app-section-header__subtitle">{subtitle}</p> : null}
+      </div>
+      {actions ? <div className="app-section-header__actions">{actions}</div> : null}
+    </div>
+  );
+}
+
+export function SectionCard({ title, subtitle, actions = null, children, variant = 'elevated' }) {
+  return (
+    <section className={`app-section-card card variant-${variant}`}>
       {(title || subtitle || actions) ? (
         <div className="app-section-card__header">
           <div>
@@ -53,6 +66,67 @@ export function SectionCard({ title, subtitle, actions = null, children }) {
   );
 }
 
+export function HeroCard({ eyebrow, title, subtitle, rightMeta = null, children, actions = null }) {
+  return (
+    <section className="app-hero-card card">
+      <div className="app-hero-card__top">
+        <div>
+          {eyebrow ? <div className="app-hero-card__eyebrow">{eyebrow}</div> : null}
+          <h1 className="app-hero-card__title">{title}</h1>
+          {subtitle ? <p className="app-hero-card__subtitle">{subtitle}</p> : null}
+        </div>
+        {rightMeta ? <div className="app-hero-card__meta">{rightMeta}</div> : null}
+      </div>
+      {children ? <div className="app-hero-card__body">{children}</div> : null}
+      {actions ? <div className="app-hero-card__actions">{actions}</div> : null}
+    </section>
+  );
+}
+
+export function ActionTile({ title, subtitle, badge = null, onClick, tone = 'info' }) {
+  return (
+    <button type="button" className={`app-action-tile tone-${tone}`} onClick={onClick}>
+      <div className="app-action-tile__title-row">
+        <strong>{title}</strong>
+        {badge}
+      </div>
+      {subtitle ? <span className="app-action-tile__subtitle">{subtitle}</span> : null}
+    </button>
+  );
+}
+
+export function StatPill({ label, value, tone = 'neutral' }) {
+  return (
+    <div className={`app-stat-pill tone-${tone}`}>
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+export function StatStrip({ items = [] }) {
+  if (!items.length) return null;
+  return (
+    <section className="app-stat-strip card">
+      {items.map((item) => (
+        <StatPill key={`${item.label}-${item.value}`} label={item.label} value={item.value} tone={item.tone ?? 'neutral'} />
+      ))}
+    </section>
+  );
+}
+
+export function CompactInsightCard({ title, subtitle, tone = 'info', ctaLabel, onCta }) {
+  return (
+    <div className={`app-compact-insight tone-${tone}`}>
+      <div className="app-compact-insight__text">
+        <strong>{title}</strong>
+        {subtitle ? <span>{subtitle}</span> : null}
+      </div>
+      {ctaLabel ? <button type="button" className="btn btn-sm" onClick={onCta}>{ctaLabel}</button> : null}
+    </div>
+  );
+}
+
 export function EmptyState({ title, body }) {
   return (
     <div className="app-empty-state">
@@ -62,7 +136,7 @@ export function EmptyState({ title, body }) {
   );
 }
 
-export function StatusChip({ label, tone = "neutral" }) {
+export function StatusChip({ label, tone = 'neutral' }) {
   return <span className={`app-status-chip tone-${tone}`}>{label}</span>;
 }
 
@@ -72,9 +146,9 @@ export function CtaRow({ actions = [] }) {
     <div className="app-cta-row">
       {actions.map((action) => (
         <button
-          key={`${action.label}-${action.href ?? action.variant ?? "default"}`}
+          key={`${action.label}-${action.href ?? action.variant ?? 'default'}`}
           type="button"
-          className={`btn ${action.compact ? "btn-sm" : ""}`}
+          className={`btn ${action.compact ? 'btn-sm' : ''}`}
           onClick={action.onClick}
           disabled={action.disabled}
         >

--- a/src/ui/components/TeamHub.jsx
+++ b/src/ui/components/TeamHub.jsx
@@ -3,8 +3,7 @@ import Roster from './Roster.jsx';
 import ContractCenter from './ContractCenter.jsx';
 import SectionSubnav from './SectionSubnav.jsx';
 import InjuryReport from './InjuryReport.jsx';
-import { SectionCard, CtaRow, StatusChip, CompactListRow } from './ScreenSystem.jsx';
-import { TeamWorkspaceHeader, TeamCapSummaryStrip } from './TeamWorkspacePrimitives.jsx';
+import { SectionCard, CtaRow, StatusChip, CompactListRow, HeroCard, StatStrip, SectionHeader, CompactInsightCard } from './ScreenSystem.jsx';
 import { derivePlayerContractFinancials } from '../utils/contractFormatting.js';
 import { deriveTeamCapSnapshot, formatMoneyM } from '../utils/numberFormatting.js';
 import { summarizeRosterDevelopment } from '../utils/playerDevelopmentSignals.js';
@@ -19,14 +18,6 @@ function normalizeSection(section) {
 
 function getGameId(game) {
   return game?.id ?? game?.gameId ?? game?.gid ?? null;
-}
-
-function getStarterHealth(team) {
-  const roster = Array.isArray(team?.roster) ? team.roster : [];
-  const starters = roster.filter((p) => Number(p?.depthChart?.order ?? p?.depthOrder ?? 999) === 1);
-  if (!starters.length) return 'Unset';
-  const healthy = starters.filter((p) => Number(p?.injury?.gamesRemaining ?? p?.injuryWeeksRemaining ?? 0) <= 0).length;
-  return `${healthy}/${starters.length} healthy`;
 }
 
 function getPositionGroupPressure(roster = []) {
@@ -52,15 +43,14 @@ function getPositionGroupPressure(roster = []) {
     })
     .filter((row) => row.severity > 0)
     .sort((a, b) => b.severity - a.severity || a.healthy - b.healthy)
-    .slice(0, 4);
+    .slice(0, 3);
 }
 
 function makeMatchupLabel(game, team) {
   if (!game || !team) return '—';
   const homeId = Number(game.homeId ?? game.home);
-  const awayId = Number(game.awayId ?? game.away);
   const isHome = homeId === Number(team.id);
-  const oppAbbr = isHome ? (game.awayAbbr ?? `Team ${awayId}`) : (game.homeAbbr ?? `Team ${homeId}`);
+  const oppAbbr = isHome ? (game.awayAbbr ?? `Team`) : (game.homeAbbr ?? `Team`);
   return `${isHome ? 'vs' : '@'} ${oppAbbr} · Week ${game.week ?? '—'}`;
 }
 
@@ -70,10 +60,6 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
   const team = useMemo(() => (league?.teams ?? []).find((t) => Number(t.id) === Number(league?.userTeamId)) ?? null, [league]);
   const roster = Array.isArray(team?.roster) ? team.roster : [];
   const capSnapshot = deriveTeamCapSnapshot(team, { fallbackCapTotal: 255 });
-  const avgSchemeFit = useMemo(() => {
-    if (!roster.length) return 50;
-    return Math.round(roster.reduce((sum, player) => sum + Number(player?.schemeFit ?? 50), 0) / roster.length);
-  }, [roster]);
 
   const expiringPlayers = useMemo(() => roster.filter((p) => Number(derivePlayerContractFinancials(p).yearsRemaining ?? 0) <= 1), [roster]);
   const injuredPlayers = useMemo(() => roster.filter((p) => Number(p?.injury?.gamesRemaining ?? p?.injuryWeeksRemaining ?? 0) > 0), [roster]);
@@ -101,69 +87,50 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
     if (injuredPlayers.length > 0) flags.push({ tone: 'warning', label: `${injuredPlayers.length} injured players impact depth`, target: 'Injuries' });
     if (pressureGroups.length > 0) flags.push({ tone: 'warning', label: `${pressureGroups.length} position groups under pressure`, target: 'Roster / Depth' });
     if (roster.length > 53 && league?.phase === 'preseason') flags.push({ tone: 'danger', label: `Roster cutdown required (${roster.length}/53)`, target: 'Roster / Depth' });
-    return flags;
+    return flags.slice(0, 3);
   }, [capSnapshot.capRoom, expiringPlayers.length, injuredPlayers.length, pressureGroups.length, roster.length, league?.phase]);
 
   return (
     <div className="app-screen-stack">
-      <TeamWorkspaceHeader
+      <HeroCard
+        eyebrow={`${league?.year ?? 'Season'} · Week ${league?.week ?? '—'} · ${league?.phase ?? 'regular'}`}
         title="Team Command Center"
-        subtitle="State of your roster, depth, contracts, development, and availability."
-        eyebrow={team?.name ?? 'Team'}
-        metadata={[
-          { label: 'Record', value: `${team?.wins ?? 0}-${team?.losses ?? 0}${team?.ties ? `-${team.ties}` : ''}` },
-          { label: 'Week', value: league?.week ?? '—' },
-          { label: 'Phase', value: league?.phase ?? 'regular' },
-        ]}
-        actions={[
-          { label: 'Overview', primary: true, onClick: () => setSubtab('Overview') },
-          { label: 'Roster / Depth', onClick: () => setSubtab('Roster / Depth') },
-          { label: 'Contracts', onClick: () => setSubtab('Contracts') },
-          { label: 'Development', onClick: () => setSubtab('Development') },
-          { label: 'Injuries', onClick: () => setSubtab('Injuries') },
-        ]}
-        quickContext={[
-          { label: `Cap ${formatMoneyM(capSnapshot.capRoom)} room`, tone: capSnapshot.capRoom <= 10 ? 'warning' : 'ok' },
-          { label: `${expiringPlayers.length} expiring deals`, tone: expiringPlayers.length >= 8 ? 'warning' : 'league' },
-          { label: `${injuredPlayers.length} injuries`, tone: injuredPlayers.length > 0 ? 'warning' : 'ok' },
-        ]}
-      />
+        subtitle={`${team?.name ?? 'Team'} · ${team?.wins ?? 0}-${team?.losses ?? 0}${team?.ties ? `-${team.ties}` : ''}`}
+        rightMeta={<StatusChip label={`${injuredPlayers.length} injuries`} tone={injuredPlayers.length ? 'warning' : 'ok'} />}
+      >
+        <div className="app-hero-summary-grid">
+          <div><span>Last game</span><strong>{latestGame ? makeMatchupLabel(latestGame, team) : 'No completed game yet'}</strong></div>
+          <div><span>Next game</span><strong>{upcomingGame ? makeMatchupLabel(upcomingGame, team) : 'No upcoming matchup'}</strong></div>
+        </div>
+      </HeroCard>
 
       <SectionSubnav items={TEAM_SECTIONS} activeItem={subtab} onChange={setSubtab} sticky />
 
       {subtab === 'Overview' && (
-        <div className="app-screen-stack" style={{ gap: 'var(--space-2)' }}>
-          <TeamCapSummaryStrip
-            capSnapshot={capSnapshot}
-            rosterCount={roster.length}
-            starterHealth={getStarterHealth(team)}
-            expiringCount={expiringPlayers.length}
-          />
+        <div className="app-screen-stack">
+          <SectionHeader eyebrow="Operations" title="Roster Status" subtitle="High-impact team signals." />
+          <StatStrip items={[
+            { label: 'Cap Room', value: formatMoneyM(capSnapshot.capRoom), tone: capSnapshot.capRoom < 10 ? 'warning' : 'ok' },
+            { label: 'Roster', value: `${roster.length}/53`, tone: roster.length > 53 ? 'danger' : 'neutral' },
+            { label: 'Expiring', value: `${expiringPlayers.length}`, tone: expiringPlayers.length > 8 ? 'warning' : 'neutral' },
+            { label: 'Development', value: `+${developmentSummary.rising.length} / -${developmentSummary.slipping.length}`, tone: 'team' },
+          ]} />
 
-          <SectionCard title="Priority queue" subtitle="Most important front-office actions this week.">
+          <SectionCard title="Priority queue" subtitle="Top actions to keep operations healthy." variant="compact">
             {urgentActions.length > 0 ? urgentActions.map((item) => (
-              <button
+              <CompactInsightCard
                 key={item.label}
-                onClick={() => setSubtab(item.target)}
-                style={{
-                  width: '100%',
-                  border: '1px solid var(--hairline)',
-                  borderRadius: 8,
-                  background: 'transparent',
-                  textAlign: 'left',
-                  padding: '8px 10px',
-                  fontSize: 12,
-                  color: item.tone === 'danger' ? 'var(--danger)' : 'var(--warning)',
-                }}
-              >
-                {item.label} →
-              </button>
-            )) : <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>No urgent team issues right now.</div>}
+                title={item.label}
+                tone={item.tone}
+                ctaLabel="Open"
+                onCta={() => setSubtab(item.target)}
+              />
+            )) : <CompactInsightCard title="No urgent team issues" subtitle="Use this week to improve depth and scouting." tone="info" ctaLabel="Open Roster" onCta={() => setSubtab('Roster / Depth')} />}
           </SectionCard>
 
-          <SectionCard title="Position group pressure" subtitle="Where the current depth chart is stressed.">
-            <div style={{ display: 'grid', gap: 6 }}>
-              {pressureGroups.length === 0 ? <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>No major weak spots detected from current healthy depth.</div> : pressureGroups.map((group) => (
+          <SectionCard title="Position pressure" subtitle="Where your depth chart is currently stressed." variant="compact">
+            <div className="app-row-stack">
+              {pressureGroups.length === 0 ? <CompactInsightCard title="No major weak spots" subtitle="Current healthy depth clears critical thresholds." tone="ok" /> : pressureGroups.map((group) => (
                 <CompactListRow
                   key={group.pos}
                   title={group.pos}
@@ -176,57 +143,23 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
             </div>
           </SectionCard>
 
-          <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: 8 }}>
-            <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Availability</div><div style={{ fontWeight: 800 }}>{injuredPlayers.length} out</div></div>
-            <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Expiring deals</div><div style={{ fontWeight: 800 }}>{expiringPlayers.length}</div></div>
-            <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Development</div><div style={{ fontWeight: 800 }}>+{developmentSummary.rising.length} / -{developmentSummary.slipping.length}</div></div>
-            <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Avg scheme fit</div><div style={{ fontWeight: 800 }}>{avgSchemeFit}</div></div>
-          </section>
-
-          <SectionCard title="Game context" subtitle="Quick links back to game flow without leaving team ops.">
-            <div style={{ display: 'grid', gap: 8 }}>
-              <button className="card" style={{ padding: '10px', textAlign: 'left' }} onClick={() => {
-                const gameId = getGameId(latestGame);
-                if (gameId != null) onOpenGameDetail?.(gameId, 'Team');
-              }}>
-                <div style={{ fontSize: 11, color: 'var(--text-muted)' }}>LAST RESULT</div>
-                <div style={{ fontWeight: 700, fontSize: 13 }}>{latestGame ? makeMatchupLabel(latestGame, team) : 'No completed game yet'}</div>
-              </button>
-              <button className="card" style={{ padding: '10px', textAlign: 'left' }} onClick={() => {
-                const gameId = getGameId(upcomingGame);
-                if (gameId != null) onOpenGameDetail?.(gameId, 'Team');
-              }}>
-                <div style={{ fontSize: 11, color: 'var(--text-muted)' }}>NEXT MATCHUP</div>
-                <div style={{ fontWeight: 700, fontSize: 13 }}>{upcomingGame ? makeMatchupLabel(upcomingGame, team) : 'No upcoming matchup found'}</div>
-              </button>
-            </div>
-          </SectionCard>
-
-          <SectionCard title="Team workflow" subtitle="Move through the full roster management loop.">
+          <SectionCard title="Game context" variant="compact">
             <CtaRow actions={[
-              { label: 'Open roster/depth', compact: true, onClick: () => setSubtab('Roster / Depth') },
-              { label: 'Review contracts', compact: true, onClick: () => setSubtab('Contracts') },
-              { label: 'Development watchlist', compact: true, onClick: () => setSubtab('Development') },
-              { label: 'Injury impact', compact: true, onClick: () => setSubtab('Injuries') },
-              { label: 'Explore free agents', compact: true, onClick: () => onNavigate?.('Free Agency') },
+              { label: 'Open last result', compact: true, onClick: () => { const gameId = getGameId(latestGame); if (gameId != null) onOpenGameDetail?.(gameId, 'Team'); } },
+              { label: 'Open next matchup', compact: true, onClick: () => { const gameId = getGameId(upcomingGame); if (gameId != null) onOpenGameDetail?.(gameId, 'Team'); } },
+              { label: 'Free Agency', compact: true, onClick: () => onNavigate?.('Free Agency') },
             ]} />
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
-              <StatusChip label="Connected team workspace" tone="team" />
-              <StatusChip label="Transactions linked" tone="league" />
-            </div>
           </SectionCard>
         </div>
       )}
 
       {subtab === 'Roster / Depth' && (
-        <div className="app-screen-stack" style={{ gap: 'var(--space-2)' }}>
-          <SectionCard title="Roster and depth ownership" subtitle="Set roles, identify thin spots, and keep the lineup game-ready.">
+        <div className="app-screen-stack">
+          <SectionCard title="Roster and depth" subtitle="Set roles and keep the lineup game-ready." variant="compact">
             <CtaRow actions={[
               { label: 'Roster table', compact: true, onClick: () => setRosterMode('roster') },
               { label: 'Depth chart', compact: true, onClick: () => setRosterMode('depth') },
-              { label: 'Injured filter', compact: true, onClick: () => {
-                setSubtab('Injuries');
-              } },
+              { label: 'Injured filter', compact: true, onClick: () => setSubtab('Injuries') },
             ]} />
           </SectionCard>
           <Roster
@@ -241,19 +174,14 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
       )}
       {subtab === 'Contracts' && <ContractCenter league={league} actions={actions} compact onNavigate={onNavigate} />}
       {subtab === 'Development' && (
-        <div className="app-screen-stack" style={{ gap: 'var(--space-2)' }}>
-          <SectionCard title="Development board" subtitle="Track risers, fallers, and prospects blocked by current depth roles.">
-            <section style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: 8 }}>
-              <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Rising</div><div style={{ fontWeight: 800 }}>{developmentSummary.rising.length}</div></div>
-              <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Slipping</div><div style={{ fontWeight: 800 }}>{developmentSummary.slipping.length}</div></div>
-              <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Blocked</div><div style={{ fontWeight: 800 }}>{developmentSummary.blocked.length}</div></div>
-              <div className="card" style={{ padding: 10 }}><div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Contract pressure</div><div style={{ fontWeight: 800 }}>{developmentSummary.contractPressure.length}</div></div>
-            </section>
-            <div style={{ display: 'grid', gap: 6 }}>
-              {developmentSummary.rising[0] ? <div style={{ fontSize: 12 }}>Top riser: <strong>{developmentSummary.rising[0].name}</strong>.</div> : null}
-              {developmentSummary.slipping[0] ? <div style={{ fontSize: 12 }}>Top faller: <strong>{developmentSummary.slipping[0].name}</strong>.</div> : null}
-              {developmentSummary.blocked[0] ? <div style={{ fontSize: 12 }}>Blocked depth concern: <strong>{developmentSummary.blocked[0].name}</strong>.</div> : null}
-            </div>
+        <div className="app-screen-stack">
+          <SectionCard title="Development board" subtitle="Risers, fallers, and blocked prospects." variant="compact">
+            <StatStrip items={[
+              { label: 'Rising', value: `${developmentSummary.rising.length}`, tone: 'ok' },
+              { label: 'Slipping', value: `${developmentSummary.slipping.length}`, tone: developmentSummary.slipping.length ? 'warning' : 'neutral' },
+              { label: 'Blocked', value: `${developmentSummary.blocked.length}`, tone: developmentSummary.blocked.length ? 'warning' : 'neutral' },
+              { label: 'Contract Pressure', value: `${developmentSummary.contractPressure.length}`, tone: 'info' },
+            ]} />
           </SectionCard>
           <Roster
             league={league}

--- a/src/ui/components/TeamHub.test.jsx
+++ b/src/ui/components/TeamHub.test.jsx
@@ -48,9 +48,9 @@ describe('TeamHub', () => {
     expect(html).toContain('Contracts');
     expect(html).toContain('Development');
     expect(html).toContain('Injuries');
-    expect(html).toContain('Position group pressure');
-    expect(html).toContain('Expiring deals');
-    expect(html).toContain('Avg scheme fit');
+    expect(html).toContain('Position pressure');
+    expect(html).toContain('Expiring');
+    expect(html).toContain('Development');
   });
 
   it('supports direct section entry for team-context deep links', () => {

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -59,7 +59,7 @@ const baseLeague = {
 };
 
 describe('FranchiseHQ', () => {
-  it('renders action-first grouped sections in the intended order', () => {
+  it('renders premium hero + action grid + compact rails', () => {
     const html = renderToString(
       <FranchiseHQ
         league={baseLeague}
@@ -71,28 +71,16 @@ describe('FranchiseHQ', () => {
       />,
     );
 
-    const actNowIdx = html.indexOf('Act Now');
-    const thisWeekIdx = html.indexOf('This Week');
-    const teamStatusIdx = html.indexOf('Team Status');
-    expect(actNowIdx).toBeGreaterThan(-1);
-    expect(thisWeekIdx).toBeGreaterThan(actNowIdx);
-    expect(teamStatusIdx).toBeGreaterThan(thisWeekIdx);
-
-    expect(html).toContain('This Week');
-    expect(html).toContain('Scout opponent');
-    expect(html).toContain('Priority Queue');
-    expect(html).toContain('Next Opponent');
-    expect(html).toContain('Latest Team Result');
-    expect(html).toContain('Matchup note');
-    expect(html).toContain('Prep status');
-    expect(html).toContain('Owner mandate');
-    expect(html).toContain('Team Command Center');
-    expect(html).not.toContain('Injury pressure');
-    expect(html).toContain('League Watch (Teasers)');
+    expect(html).toContain('Advance Week');
+    expect(html).toContain('Prepare Game');
+    expect(html).toContain('Set Lineup');
+    expect(html).toContain('Game Plan');
+    expect(html).toContain('Scout Opponent');
+    expect(html).toContain('News &amp; Injuries');
+    expect(html).toContain('Priority Rail');
+    expect(html).toContain('Snapshot');
+    expect(html).toContain('Owner Mandate');
     expect(html).toContain('Open Results');
-    expect(html).toContain('Open League');
-    expect(html).toContain('Open Leaders');
-    expect(html).not.toContain('News & Leaders');
   });
 
   it('is safe with partial/older save payloads', () => {

--- a/src/ui/styles/app-mobile.css
+++ b/src/ui/styles/app-mobile.css
@@ -1434,3 +1434,50 @@
   border-color: var(--hairline);
   transform: translateX(2px);
 }
+
+/* ── Premium shell/nav treatment ───────────────────────────────────────────── */
+.franchise-status-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.mobile-nav-panel-premium {
+  border-left: 1px solid var(--hairline-strong);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--surface-elevated) 94%, black 6%), var(--surface));
+}
+
+.mobile-nav-item-premium {
+  min-height: 46px;
+  border-radius: 12px;
+}
+
+.premium-bottom-nav {
+  border: 1px solid var(--hairline-strong);
+  border-radius: 18px;
+  left: max(10px, env(safe-area-inset-left));
+  right: max(10px, env(safe-area-inset-right));
+  bottom: max(10px, env(safe-area-inset-bottom));
+  width: auto;
+  max-width: 680px;
+  margin-inline: auto;
+  background: color-mix(in srgb, var(--surface-elevated) 92%, black 8%);
+  box-shadow: 0 20px 36px rgba(0, 0, 0, 0.42);
+}
+
+.premium-bottom-tab {
+  border-radius: 12px;
+  min-height: 48px;
+}
+
+.premium-bottom-tab.active {
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
+  color: var(--accent);
+}
+
+.mobile-bottom-tab-advance {
+  border-radius: 999px;
+  border: 1px solid rgba(var(--accent-rgb), 0.55);
+  background: linear-gradient(160deg, rgba(var(--accent-rgb), 0.3), rgba(var(--accent-rgb), 0.16));
+  color: var(--text);
+}

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -1,45 +1,108 @@
-.app-screen-stack {
-  display: grid;
-  gap: var(--space-3);
-}
+.app-screen-stack { display: grid; gap: var(--space-3); }
 
 .app-screen-header {
   border: 1px solid var(--hairline);
-  border-radius: var(--radius-lg);
+  border-radius: calc(var(--radius-lg) + 2px);
   padding: var(--space-3) var(--space-4);
-  background: linear-gradient(180deg, color-mix(in srgb, var(--surface) 90%, transparent), var(--surface));
+  background: linear-gradient(180deg, color-mix(in srgb, var(--surface) 92%, #0a111c 8%), var(--surface));
   display: grid;
   gap: var(--space-2);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
 }
-.app-screen-header__top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
-}
-.app-screen-header__eyebrow {
+.app-screen-header__top { display: flex; align-items: center; justify-content: space-between; gap: var(--space-2); }
+.app-screen-header__eyebrow,
+.app-section-header__eyebrow,
+.app-hero-card__eyebrow {
   font-size: var(--text-xs);
-  color: var(--text-muted);
+  color: var(--text-subtle);
   text-transform: uppercase;
-  letter-spacing: .04em;
+  letter-spacing: .09em;
 }
-.app-screen-header__title { margin: 0; font-size: clamp(1.05rem, 3.6vw, 1.45rem); }
-.app-screen-header__subtitle { margin: 0; color: var(--text-muted); font-size: var(--text-sm); }
+.app-screen-header__title { margin: 0; font-size: clamp(1.1rem, 4.2vw, 1.55rem); letter-spacing: -0.02em; }
+.app-screen-header__subtitle { margin: 0; color: var(--text-muted); font-size: var(--text-xs); }
 .app-screen-header__meta { display: flex; gap: 6px; flex-wrap: wrap; }
-.app-screen-meta-pill { border: 1px solid var(--hairline); border-radius: 999px; padding: 2px 8px; font-size: var(--text-xs); color: var(--text-muted); }
+.app-screen-meta-pill { border: 1px solid var(--hairline); border-radius: 999px; padding: 4px 10px; font-size: var(--text-xs); color: var(--text-muted); }
+
+.app-section-header { display: flex; justify-content: space-between; align-items: end; gap: 8px; }
+.app-section-header__title { margin: 2px 0 0; font-size: clamp(1rem, 3.5vw, 1.2rem); }
+.app-section-header__subtitle { margin: 3px 0 0; color: var(--text-muted); font-size: var(--text-xs); }
 
 .app-section-card { padding: var(--space-3) var(--space-4); display: grid; gap: var(--space-2); }
+.app-section-card.variant-compact { padding: var(--space-2) var(--space-3); }
+.app-section-card.variant-danger { border-color: color-mix(in srgb, var(--danger) 35%, var(--hairline)); }
+.app-section-card.variant-warning { border-color: color-mix(in srgb, var(--warning) 35%, var(--hairline)); }
+.app-section-card.variant-info { border-color: color-mix(in srgb, var(--accent) 28%, var(--hairline)); }
 .app-section-card__header { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--space-2); }
-.app-section-card__title { margin: 0; font-size: var(--text-base); }
+.app-section-card__title { margin: 0; font-size: var(--text-base); letter-spacing: -0.01em; }
 .app-section-card__subtitle { margin: 2px 0 0; font-size: var(--text-xs); color: var(--text-muted); }
 .app-section-card__body { display: grid; gap: var(--space-2); }
 
+.app-hero-card {
+  padding: var(--space-3);
+  border: 1px solid color-mix(in srgb, var(--accent) 22%, var(--hairline));
+  background: linear-gradient(140deg, color-mix(in srgb, var(--surface) 90%, var(--accent) 10%), var(--surface));
+  border-radius: calc(var(--radius-lg) + 2px);
+  display: grid;
+  gap: var(--space-2);
+}
+.app-hero-card__top { display: flex; justify-content: space-between; gap: 8px; align-items: flex-start; }
+.app-hero-card__title { margin: 2px 0 0; font-size: clamp(1.15rem, 5vw, 1.6rem); line-height: 1.1; }
+.app-hero-card__subtitle { margin: 4px 0 0; color: var(--text-muted); font-size: var(--text-sm); }
+.app-hero-card__body { display: grid; gap: 8px; }
+.app-hero-card__actions { display: flex; gap: 8px; flex-wrap: wrap; }
+
+.app-action-grid-2x2 { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+.app-action-tile {
+  min-height: 44px;
+  border: 1px solid var(--hairline-strong);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface-2) 92%, black 8%);
+  color: var(--text);
+  padding: 10px;
+  text-align: left;
+  display: grid;
+  gap: 4px;
+}
+.app-action-tile__title-row { display: flex; justify-content: space-between; align-items: center; gap: 8px; }
+.app-action-tile__subtitle { color: var(--text-muted); font-size: var(--text-xs); }
+.app-action-tile.tone-warning { border-color: rgba(255,159,10,.45); }
+.app-action-tile.tone-danger { border-color: rgba(255,69,58,.45); }
+
+.app-stat-strip {
+  padding: var(--space-2);
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.app-stat-pill { border: 1px solid var(--hairline); border-radius: 10px; padding: 8px; display: grid; gap: 3px; background: color-mix(in srgb, var(--surface) 92%, black 8%); }
+.app-stat-pill span { font-size: var(--text-xs); color: var(--text-muted); text-transform: uppercase; letter-spacing: .04em; }
+.app-stat-pill strong { font-size: var(--text-sm); }
+
+.app-compact-insight {
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+  padding: 8px 10px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  background: color-mix(in srgb, var(--surface) 95%, black 5%);
+}
+.app-compact-insight__text { display: grid; gap: 2px; }
+.app-compact-insight__text strong { font-size: var(--text-sm); }
+.app-compact-insight__text span { color: var(--text-muted); font-size: var(--text-xs); }
+.app-compact-insight.tone-warning { border-color: rgba(255,159,10,.45); }
+.app-compact-insight.tone-danger { border-color: rgba(255,69,58,.45); }
+.app-compact-insight.tone-ok { border-color: rgba(52,199,89,.45); }
+
 .app-empty-state { border: 1px dashed var(--hairline); border-radius: var(--radius-md); padding: var(--space-3); color: var(--text-muted); }
 .app-empty-state p { margin: 4px 0 0; font-size: var(--text-sm); }
+
 .app-status-chip {
   border: 1px solid var(--hairline);
   border-radius: 999px;
-  padding: 2px 8px;
+  padding: 4px 10px;
   font-size: var(--text-xs);
   color: var(--text-muted);
   white-space: nowrap;
@@ -47,30 +110,24 @@
 .app-status-chip.tone-team { border-color: rgba(10,132,255,.45); color: var(--accent); background: rgba(10,132,255,.1); }
 .app-status-chip.tone-league { border-color: rgba(180,180,190,.4); color: var(--text-subtle); background: rgba(180,180,190,.08); }
 .app-status-chip.tone-warning { border-color: rgba(255,159,10,.45); color: var(--warning); background: rgba(255,159,10,.12); }
+.app-status-chip.tone-danger { border-color: rgba(255,69,58,.45); color: var(--danger); background: rgba(255,69,58,.12); }
+.app-status-chip.tone-ok { border-color: rgba(52,199,89,.45); color: var(--success); background: rgba(52,199,89,.1); }
+.app-status-chip.tone-info { border-color: rgba(var(--accent-rgb), .4); color: var(--accent); background: rgba(var(--accent-rgb), .08); }
 
 .app-cta-row { display: flex; flex-wrap: wrap; gap: 8px; }
-.app-card-action-footer {
-  margin-top: 8px;
-  padding-top: 8px;
-  border-top: 1px solid var(--hairline);
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-.app-compact-list-row {
-  border: 1px solid var(--hairline);
-  border-radius: var(--radius-md);
-  padding: 8px 10px;
-  display: grid;
-  gap: 6px;
-  background: color-mix(in oklab, var(--surface) 90%, black 10%);
-}
+.app-card-action-footer { margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--hairline); display: flex; justify-content: flex-end; gap: 8px; flex-wrap: wrap; }
+.app-compact-list-row { border: 1px solid var(--hairline); border-radius: var(--radius-md); padding: 8px 10px; display: grid; gap: 6px; background: color-mix(in oklab, var(--surface) 90%, black 10%); }
 .app-compact-list-row__main { display: grid; gap: 2px; min-width: 0; }
 .app-compact-list-row__main strong { font-size: var(--text-sm); }
 .app-compact-list-row__main span { font-size: var(--text-xs); color: var(--text-muted); }
 .app-compact-list-row__meta { font-size: var(--text-xs); color: var(--text-subtle); }
 .app-compact-list-row__actions { display: flex; gap: 6px; flex-wrap: wrap; }
+
+.app-row-stack, .app-priority-rail, .app-teaser-strip { display: grid; gap: 8px; }
+.app-inline-toast { margin: 0; font-size: var(--text-xs); color: var(--accent); }
+.app-hero-summary-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+.app-hero-summary-grid span { display: block; font-size: var(--text-xs); color: var(--text-muted); text-transform: uppercase; letter-spacing: .06em; }
+.app-hero-summary-grid strong { font-size: var(--text-sm); }
 
 .app-sticky-subnav {
   position: sticky;
@@ -87,78 +144,5 @@
 @media (max-width: 768px) {
   .app-screen-stack { gap: var(--space-2); }
   .app-section-card { padding: var(--space-3); }
-}
-
-.app-status-chip.tone-danger { border-color: rgba(255,69,58,.45); color: var(--danger); background: rgba(255,69,58,.12); }
-.app-status-chip.tone-ok { border-color: rgba(52,199,89,.45); color: var(--success); background: rgba(52,199,89,.1); }
-
-.team-cap-summary-strip {
-  padding: var(--space-2) var(--space-3);
-  display: grid;
-  gap: 8px;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-}
-.team-cap-summary-strip__item {
-  border: 1px solid var(--hairline);
-  border-radius: var(--radius-md);
-  padding: 8px;
-  display: grid;
-  gap: 3px;
-}
-.team-cap-summary-strip__item span {
-  font-size: var(--text-xs);
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: .03em;
-}
-.team-cap-summary-strip__item strong {
-  font-size: var(--text-sm);
-}
-.team-cap-summary-strip__item strong.tone-danger { color: var(--danger); }
-.team-cap-summary-strip__item strong.tone-warning { color: var(--warning); }
-.team-cap-summary-strip__item strong.tone-ok { color: var(--success); }
-
-/* HQ Hero Section Styles */
-.hq-hero-section {
-  position: relative;
-  overflow: hidden;
-}
-
-.hq-hero-section h1 {
-  letter-spacing: -0.02em;
-}
-
-/* Mobile Adjustments for HQ */
-@media (max-width: 768px) {
-  .franchise-hq {
-    padding-bottom: 80px; /* Room for bottom nav */
-  }
-
-  .hq-hero-section {
-    padding: var(--space-3) !important;
-  }
-
-  .hq-hero-section h1 {
-    font-size: var(--text-lg) !important;
-  }
-
-  .app-section-card {
-    padding: var(--space-3) !important;
-  }
-
-  .app-section-card__header {
-    margin-bottom: var(--space-2) !important;
-  }
-
-  .app-section-card__title {
-    font-size: var(--text-sm) !important;
-  }
-
-  .app-section-card__body {
-    gap: 4px !important;
-  }
-
-  .btn-outline {
-    padding: 8px !important;
-  }
+  .app-hero-summary-grid { grid-template-columns: 1fr; }
 }


### PR DESCRIPTION
### Motivation

- Modernize and consolidate UI primitives to provide a consistent hero/section/stat/insight surface across HQ, League, and Team command centers.
- Replace bespoke inline hero and card markup with reusable components to simplify layout, surface consistency, and theming.
- Improve mobile navigation UX with a premium-styled bottom nav and a clearer command menu.

### Description

- Add new screen primitives in `ScreenSystem.jsx`: `HeroCard`, `SectionHeader`, `ActionTile`, `StatStrip`/`StatPill`, `CompactInsightCard`, and related CSS classes and refinements in `screen-system.css` and `app-mobile.css`.
- Refactor `FranchiseHQ.jsx`, `LeagueHub.jsx`, and `TeamHub.jsx` to use the new primitives instead of ad-hoc hero/section markup and to simplify action grids, priority rails, and stat strips.
- Update `MobileNav.jsx` to adjust labels, add premium styling classes, and wire in the command-menu/drawer style changes.
- Update tests and snapshots to reflect the new copy and structure: adjust expectations in `LeagueHub.test.jsx`, `TeamHub.test.jsx`, and `FranchiseHQ.test.jsx`, and add a new `MobileNav.test.jsx` that asserts the premium nav and menu render.
- Misc: small logic/formatting cleanups retained (e.g. `handleSetLineup` messaging tweak and limiting some lists for compact presentation).

### Testing

- Ran component unit tests with `vitest` for impacted modules: `LeagueHub.test.jsx`, `TeamHub.test.jsx`, `FranchiseHQ.test.jsx`, and new `MobileNav.test.jsx`.
- All updated and new tests executed successfully and passed.
- Also exercised server-side render checks via `renderToString` assertions in the tests to verify markup and copy changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3097d8890832da5aa28082506f08c)