### PR TITLE
Upgrade Weekly Results, News Desk, and Game Book to ScreenSystem UI

### DIFF
--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -1,21 +1,24 @@
 import React from 'react';
 import BoxScorePanel from './BoxScorePanel.jsx';
-import { ScreenHeader, EmptyState } from './ScreenSystem.jsx';
+import { EmptyState, ScreenHeader, SectionCard, StatusChip } from './ScreenSystem.jsx';
 
 export default function GameDetailScreen({ gameId, league, actions, onBack, onPlayerSelect, onTeamSelect }) {
+  const weekFromId = typeof gameId === 'string' ? gameId.match(/_w(\d+)_/i)?.[1] : null;
+
   if (!gameId) {
     return (
       <div className="app-screen-stack">
         <ScreenHeader
-          title="Game Detail"
+          eyebrow="Game Book"
+          title="Game Book"
           subtitle="Open any game to view score context, recap, and box score details when available."
           onBack={onBack}
           backLabel="Back"
-          metadata={[{ label: 'Season', value: league?.seasonId ?? '—' }]}
+          metadata={[{ label: 'Season', value: league?.seasonId ?? '—' }, { label: 'Status', value: 'No game selected' }]}
         />
         <EmptyState
           title="No completed game selected yet."
-          body="Open a final score from Schedule, Weekly Hub, or recent results to load the full game book."
+          body="Open a final score from Schedule, Weekly Results, or recent surfaces to load the full Game Book."
         />
       </div>
     );
@@ -24,20 +27,28 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
   return (
     <div className="app-screen-stack">
       <ScreenHeader
+        eyebrow="Game Book"
         title="Game Book"
         subtitle="Final score, recap narrative, team comparison, and player box score in one place."
         onBack={onBack}
         backLabel="Back"
-        metadata={[{ label: 'Game ID', value: gameId }, { label: 'Season', value: league?.seasonId ?? '—' }]}
+        primaryAction={<StatusChip label="Command View" tone="info" />}
+        metadata={[
+          { label: 'Game ID', value: gameId },
+          { label: 'Season', value: league?.seasonId ?? '—' },
+          { label: 'Week', value: weekFromId ?? '—' },
+        ]}
       />
-      <BoxScorePanel
-        gameId={gameId}
-        actions={actions}
-        league={league}
-        onBack={onBack}
-        onPlayerSelect={onPlayerSelect}
-        onTeamSelect={onTeamSelect}
-      />
+      <SectionCard variant="info" title="Game Book Detail" subtitle="Box score, recap, and player-level logs.">
+        <BoxScorePanel
+          gameId={gameId}
+          actions={actions}
+          league={league}
+          onBack={onBack}
+          onPlayerSelect={onPlayerSelect}
+          onTeamSelect={onTeamSelect}
+        />
+      </SectionCard>
     </div>
   );
 }

--- a/src/ui/components/GameDetailScreen.test.jsx
+++ b/src/ui/components/GameDetailScreen.test.jsx
@@ -14,6 +14,20 @@ describe('GameDetailScreen canonical title', () => {
     );
 
     expect(html).toContain('Game Book');
+    expect(html).toContain('Week');
     expect(html).not.toContain('Completed Game Detail');
+  });
+
+  it('renders an explicit empty state when no game is selected', () => {
+    const html = renderToString(
+      <GameDetailScreen
+        gameId={null}
+        league={{ seasonId: '2031' }}
+        actions={{}}
+      />,
+    );
+
+    expect(html).toContain('No completed game selected yet.');
+    expect(html).toContain('No game selected');
   });
 });

--- a/src/ui/components/NewsFeed.jsx
+++ b/src/ui/components/NewsFeed.jsx
@@ -2,7 +2,16 @@ import React, { useMemo, useState, useEffect } from 'react';
 import { deriveFranchisePressure } from '../utils/pressureModel.js';
 import { buildTeamIntelligence } from '../utils/teamIntelligence.js';
 import { buildNewsDeskModel } from '../utils/newsDesk.js';
-import { StatusChip } from './ScreenSystem.jsx';
+import {
+  CompactInsightCard,
+  CompactListRow,
+  CtaRow,
+  EmptyState,
+  HeroCard,
+  SectionCard,
+  SectionHeader,
+  StatusChip,
+} from './ScreenSystem.jsx';
 
 const tickerColor = {
   high: '#f59e0b',
@@ -10,81 +19,73 @@ const tickerColor = {
   low: '#94a3b8',
 };
 
-const priorityColor = {
-  high: '#ef4444',
-  medium: '#f59e0b',
-  low: '#334155',
+const priorityTone = {
+  high: 'danger',
+  medium: 'warning',
+  low: 'league',
 };
 
-function StoryCard({ item, onTeamSelect, onOpenBoxScore, onPlayerSelect }) {
+function StoryActions({ item, onTeamSelect, onOpenBoxScore, onPlayerSelect, compact = false }) {
+  return (
+    <CtaRow
+      actions={[
+        item?.gameId ? { label: 'Open game', compact, onClick: () => onOpenBoxScore?.(item.gameId) } : null,
+        item?.teamId != null ? { label: 'Open team', compact, onClick: () => onTeamSelect?.(item.teamId) } : null,
+        item?.playerId != null ? { label: 'Open player', compact, onClick: () => onPlayerSelect?.(item.playerId) } : null,
+      ].filter(Boolean)}
+    />
+  );
+}
+
+function LeadStory({ item, onTeamSelect, onOpenBoxScore, onPlayerSelect }) {
   if (!item) return null;
   return (
-    <div style={{ borderLeft: `4px solid ${priorityColor[item?.priority] ?? '#334155'}`, padding: '10px 12px', background: 'var(--surface)', borderRadius: 10 }}>
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>
-        <div style={{ fontWeight: 700 }}>{item?.headline}</div>
-        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+    <SectionCard
+      title={item?.headline}
+      subtitle={`Week ${item?.week ?? '-'} · ${item?.phase ?? 'season'}${item?._teamRelevant ? ' · Your team context' : ''}`}
+      variant="info"
+      actions={(
+        <div className="app-news-row-chips">
           <StatusChip label={item?._teamRelevant ? 'Team' : 'League'} tone={item?._teamRelevant ? 'team' : 'league'} />
-          <span style={{ fontSize: 11, color: 'var(--text-subtle)', border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 6px' }}>{item?._categoryLabel}</span>
+          <StatusChip label={item?._categoryLabel} tone={priorityTone[item?.priority] ?? 'league'} />
         </div>
-      </div>
-      <div style={{ color: 'var(--text-muted)', marginTop: 2 }}>{item?.body}</div>
-      <div style={{ fontSize: 11, color: 'var(--text-subtle)', marginTop: 4 }}>
-        Week {item?.week ?? '-'} · {item?.phase ?? 'season'}{item?._teamRelevant ? ' · Your team' : ''}
-      </div>
-      <div style={{ display: 'flex', gap: 6, marginTop: 8, flexWrap: 'wrap' }}>
-        {item?.gameId ? <button className="btn" onClick={() => onOpenBoxScore?.(item.gameId)}>Open game</button> : null}
-        {item?.teamId != null ? <button className="btn" onClick={() => onTeamSelect?.(item.teamId)}>Open team</button> : null}
-        {item?.playerId != null ? <button className="btn" onClick={() => onPlayerSelect?.(item.playerId)}>Open player</button> : null}
-      </div>
-    </div>
+      )}
+    >
+      <p className="app-news-story-body">{item?.body}</p>
+      <StoryActions item={item} onTeamSelect={onTeamSelect} onOpenBoxScore={onOpenBoxScore} onPlayerSelect={onPlayerSelect} />
+    </SectionCard>
   );
 }
 
-function CompactStoryRow({ item, onTeamSelect, onOpenBoxScore, onPlayerSelect }) {
+function StoryRow({ item, onTeamSelect, onOpenBoxScore, onPlayerSelect }) {
   if (!item) return null;
   return (
-    <div
-      style={{
-        border: '1px solid var(--hairline)',
-        borderRadius: 10,
-        padding: '10px 12px',
-        background: 'color-mix(in oklab, var(--surface) 88%, black 12%)',
-        display: 'grid',
-        gap: 6,
-      }}
+    <CompactListRow
+      title={item?.headline}
+      subtitle={item?.body}
+      meta={(
+        <div className="app-news-row-meta">
+          <span>W{item?.week ?? '-'} · {item?.phase ?? 'season'}{item?._teamRelevant ? ' · Team' : ''}</span>
+          <div className="app-news-row-chips">
+            <StatusChip label={item?._categoryLabel} tone="league" />
+            <StatusChip label={item?.priority ?? 'low'} tone={priorityTone[item?.priority] ?? 'league'} />
+          </div>
+        </div>
+      )}
     >
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
-        <div style={{ fontWeight: 700, fontSize: 13 }}>{item?.headline}</div>
-        <span style={{ fontSize: 10, color: 'var(--text-subtle)', border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 6px' }}>
-          {item?._categoryLabel}
-        </span>
-      </div>
-      {item?.body ? <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{item.body}</div> : null}
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>
-        <div style={{ fontSize: 11, color: 'var(--text-subtle)' }}>
-          W{item?.week ?? '-'} · {item?.phase ?? 'season'}{item?._teamRelevant ? ' · Team' : ''}
-        </div>
-        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-          {item?.gameId ? <button className="btn btn-sm" onClick={() => onOpenBoxScore?.(item.gameId)}>Open game</button> : null}
-          {item?.teamId != null ? <button className="btn btn-sm" onClick={() => onTeamSelect?.(item.teamId)}>Open team</button> : null}
-          {item?.playerId != null ? <button className="btn btn-sm" onClick={() => onPlayerSelect?.(item.playerId)}>Open player</button> : null}
-        </div>
-      </div>
-    </div>
+      <StoryActions item={item} onTeamSelect={onTeamSelect} onOpenBoxScore={onOpenBoxScore} onPlayerSelect={onPlayerSelect} compact />
+    </CompactListRow>
   );
 }
 
-function SectionBlock({ title, stories, compact = false, ...handlers }) {
+function NewsSection({ title, subtitle, stories, ...handlers }) {
   if (!stories?.length) return null;
   return (
-    <section style={{ display: 'grid', gap: 8 }}>
-      <h3 style={{ margin: 0, fontSize: 'var(--text-sm)', textTransform: 'uppercase', letterSpacing: '.04em', color: 'var(--text-subtle)' }}>{title}</h3>
-      {stories.map((item, idx) => (
-        compact
-          ? <CompactStoryRow key={item?.id ?? `${title}-${idx}`} item={item} {...handlers} />
-          : <StoryCard key={item?.id ?? `${title}-${idx}`} item={item} {...handlers} />
-      ))}
-    </section>
+    <SectionCard title={title} subtitle={subtitle} variant="compact">
+      <div className="app-screen-stack">
+        {stories.map((item, idx) => <StoryRow key={item?.id ?? `${title}-${idx}`} item={item} {...handlers} />)}
+      </div>
+    </SectionCard>
   );
 }
 
@@ -122,65 +123,73 @@ export default function NewsFeed({ league, mode = 'full', segment = 'all', onTea
   }
 
   return (
-    <div className="card" style={{ padding: 'var(--space-4)', display: 'grid', gap: 12 }}>
-      {pressure ? (
-        <div style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: '8px 10px', background: 'var(--surface-strong)', fontSize: 12 }}>
-          <strong>Local Pressure Briefing:</strong> Fans {pressure.fans.state} · Media {pressure.media.state}
+    <div className="app-screen-stack">
+      <HeroCard
+        eyebrow="News Desk"
+        title="Desk View"
+        subtitle="Curated league intelligence with team-priority context and actionable links."
+      >
+        {pressure ? (
+          <CompactInsightCard
+            title="Local Pressure Briefing"
+            subtitle={`Fans ${pressure.fans.state} · Media ${pressure.media.state}`}
+            tone="warning"
+          />
+        ) : null}
+        <div className="app-news-filter-row" role="tablist" aria-label="News segment filters">
+          {[
+            ['all', 'ALL'],
+            ['team', 'TEAM'],
+            ['league', 'LEAGUE'],
+            ['transactions', 'TRANSACTIONS'],
+          ].map(([value, label]) => (
+            <button
+              key={value}
+              className={`btn btn-sm ${filter === value ? 'is-active' : ''}`}
+              onClick={() => setFilter(value)}
+              aria-pressed={filter === value}
+            >
+              {label}
+            </button>
+          ))}
         </div>
-      ) : null}
-
-      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-        {[
-          ['all', 'ALL'],
-          ['team', 'TEAM'],
-          ['league', 'LEAGUE'],
-          ['transactions', 'TRANSACTIONS'],
-        ].map(([value, label]) => (
-          <button
-            key={value}
-            className="btn"
-            onClick={() => setFilter(value)}
-            style={{
-              opacity: filter === value ? 1 : 0.72,
-              fontWeight: filter === value ? 700 : 500,
-              borderColor: filter === value ? 'var(--accent)' : undefined,
-            }}
-          >
-            {label}
-          </button>
-        ))}
-      </div>
+      </HeroCard>
 
       {desk.featured ? (
-        <section style={{ display: 'grid', gap: 8 }}>
-          <h2 style={{ margin: 0 }}>Featured Lead Story</h2>
-          <StoryCard item={desk.featured} onTeamSelect={onTeamSelect} onOpenBoxScore={onOpenBoxScore} onPlayerSelect={onPlayerSelect} />
+        <section className="app-screen-stack">
+          <SectionHeader title="Featured Lead Story" subtitle="Highest leverage headline for this segment." />
+          <LeadStory item={desk.featured} onTeamSelect={onTeamSelect} onOpenBoxScore={onOpenBoxScore} onPlayerSelect={onPlayerSelect} />
         </section>
-      ) : <div style={{ color: 'var(--text-subtle)' }}>No news yet.</div>}
+      ) : <EmptyState title="No news yet." body="Stories will appear as league updates and narratives are generated." />}
 
-      <SectionBlock
+      <NewsSection
         title={`News Feed (${desk.filtered.length})`}
+        subtitle="Live story wire for this desk segment."
         stories={desk.filtered.slice(1, 13)}
-        compact
         onTeamSelect={onTeamSelect}
         onOpenBoxScore={onOpenBoxScore}
         onPlayerSelect={onPlayerSelect}
       />
+
       {filter === 'all' ? (
-        <>
-          <SectionBlock title="Team Desk" stories={desk.teamStories.slice(0, 2)} compact onTeamSelect={onTeamSelect} onOpenBoxScore={onOpenBoxScore} onPlayerSelect={onPlayerSelect} />
-          <SectionBlock title="League Pulse" stories={desk.recap.slice(0, 2)} compact onTeamSelect={onTeamSelect} onOpenBoxScore={onOpenBoxScore} onPlayerSelect={onPlayerSelect} />
-        </>
+        <div className="app-news-aux-grid">
+          <NewsSection title="Team Desk" subtitle="Your-team relevant stories" stories={desk.teamStories.slice(0, 3)} onTeamSelect={onTeamSelect} onOpenBoxScore={onOpenBoxScore} onPlayerSelect={onPlayerSelect} />
+          <NewsSection title="League Pulse" subtitle="Race and result context" stories={desk.recap.slice(0, 3)} onTeamSelect={onTeamSelect} onOpenBoxScore={onOpenBoxScore} onPlayerSelect={onPlayerSelect} />
+        </div>
       ) : null}
 
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
-        <div style={{ fontSize: 12, color: 'var(--text-subtle)' }}>Use filters to keep this desk focused by context.</div>
-        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-          <button className="btn btn-sm" onClick={() => onNavigate?.('Team')}>Team</button>
-          <button className="btn btn-sm" onClick={() => onNavigate?.('League')}>League</button>
-          <button className="btn btn-sm" onClick={() => onNavigate?.('Schedule')}>Schedule</button>
+      <SectionCard variant="compact">
+        <div className="app-news-cta-bar">
+          <div className="app-news-cta-copy">Use filters to keep this desk focused by context.</div>
+          <CtaRow
+            actions={[
+              { label: 'Team', compact: true, onClick: () => onNavigate?.('Team') },
+              { label: 'League', compact: true, onClick: () => onNavigate?.('League') },
+              { label: 'Schedule', compact: true, onClick: () => onNavigate?.('Schedule') },
+            ]}
+          />
         </div>
-      </div>
+      </SectionCard>
     </div>
   );
 }

--- a/src/ui/components/NewsFeed.test.jsx
+++ b/src/ui/components/NewsFeed.test.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import NewsFeed from './NewsFeed.jsx';
+
+const league = {
+  week: 7,
+  userTeamId: 10,
+  teams: [{ id: 10, name: 'Portland', wins: 4, losses: 2 }],
+  standings: [{ id: 10, wins: 4, losses: 2, ties: 0, pointsFor: 150, pointsAgainst: 140 }],
+  newsItems: [
+    { id: 'n1', headline: 'Big upset in prime time', body: 'The underdog won late.', priority: 'high', week: 7, phase: 'regular', gameId: '2026_w7_1_2', category: 'major_result' },
+    { id: 'n2', headline: 'Team extends star receiver', body: 'New contract secures target share.', priority: 'medium', week: 7, phase: 'regular', teamId: 10, category: 'team' },
+    { id: 'n3', headline: 'Veteran traded for picks', body: 'Deadline move shakes standings.', priority: 'medium', week: 7, phase: 'regular', teamId: 8, category: 'trade_completed' },
+    { id: 'n4', headline: 'Rookie on injury report', body: 'Day-to-day with hamstring tightness.', priority: 'low', week: 7, phase: 'regular', playerId: 55, category: 'injury' },
+  ],
+};
+
+describe('NewsFeed', () => {
+  it('renders premium desk sections with featured story and CTA buttons', () => {
+    const html = renderToString(
+      <NewsFeed
+        league={league}
+        onTeamSelect={() => {}}
+        onOpenBoxScore={() => {}}
+        onPlayerSelect={() => {}}
+        onNavigate={() => {}}
+      />,
+    );
+
+    expect(html).toContain('News Desk');
+    expect(html).toContain('Desk View');
+    expect(html).toContain('Featured Lead Story');
+    expect(html).toContain('Open game');
+    expect(html).toContain('Open team');
+    expect(html).toContain('Open player');
+    expect(html).toContain('Team Desk');
+    expect(html).toContain('League Pulse');
+    expect(html).toContain('Use filters to keep this desk focused by context.');
+  });
+
+  it('renders an empty state safely when there are no stories', () => {
+    const html = renderToString(
+      <NewsFeed
+        league={{ ...league, newsItems: [] }}
+        onTeamSelect={() => {}}
+        onOpenBoxScore={() => {}}
+        onPlayerSelect={() => {}}
+        onNavigate={() => {}}
+      />,
+    );
+
+    expect(html).toContain('No news yet.');
+  });
+});

--- a/src/ui/components/WeeklyResultsCenter.jsx
+++ b/src/ui/components/WeeklyResultsCenter.jsx
@@ -2,6 +2,15 @@ import React, { useMemo, useState } from 'react';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 import { deriveCompactResultRecap, getGameLifecycleBucket, selectWeekGames } from '../utils/gameCenterResults.js';
 import { buildWeeklyLeagueRecap } from '../utils/weeklyLeagueRecap.js';
+import {
+  CompactInsightCard,
+  EmptyState,
+  HeroCard,
+  SectionCard,
+  SectionHeader,
+  StatStrip,
+  StatusChip,
+} from './ScreenSystem.jsx';
 
 function normalizeTeam(team) {
   if (!team || typeof team !== 'object') return { abbr: '—', name: 'Unknown' };
@@ -14,25 +23,25 @@ function formatPeriodLabel(game) {
   return 'Final';
 }
 
-function ResultRow({ row, seasonId, onGameSelect }) {
-  const presentation = buildCompletedGamePresentation(row.game, { seasonId, week: row.week, teamById: row.teamById, source: 'weekly_results_center' });
+function ResultRow({ row, seasonId, onGameSelect, source = 'weekly_results_center' }) {
+  const presentation = buildCompletedGamePresentation(row.game, { seasonId, week: row.week, teamById: row.teamById, source });
   const clickable = Boolean(presentation.canOpen && onGameSelect);
 
   return (
-    <article className="premium-game-card is-completed" style={{ padding: 'var(--space-3)' }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'center' }}>
+    <article className="app-game-center-card card">
+      <div className="app-game-center-card__top">
         <strong>Week {row.week}</strong>
-        <span className="badge">{formatPeriodLabel(row.game)}</span>
+        <StatusChip label={formatPeriodLabel(row.game)} tone="ok" />
       </div>
-      <div style={{ marginTop: 6, fontWeight: 700 }}>
+      <div className="app-game-center-card__scoreline">
         {row.away.abbr} {row.game?.awayScore ?? '—'} @ {row.home.abbr} {row.game?.homeScore ?? '—'}
       </div>
-      <div style={{ marginTop: 4, fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{row.recap}</div>
-      <div style={{ marginTop: 8 }}>
+      <p className="app-game-center-card__summary">{row.recap}</p>
+      <div className="app-game-center-card__footer">
         <button
           type="button"
           className="btn btn-sm"
-          onClick={clickable ? () => openResolvedBoxScore(row.game, { seasonId, week: row.week, source: 'weekly_results_center' }, onGameSelect) : undefined}
+          onClick={clickable ? () => openResolvedBoxScore(row.game, { seasonId, week: row.week, source }, onGameSelect) : undefined}
           disabled={!clickable}
           title={clickable ? (presentation?.ctaLabel ?? 'Open Game Book') : (presentation?.statusLabel ?? 'Archive unavailable')}
         >
@@ -43,7 +52,20 @@ function ResultRow({ row, seasonId, onGameSelect }) {
   );
 }
 
-
+function LiveOrUpcomingRow({ row, label, tone = 'info' }) {
+  return (
+    <article className="app-game-center-card card is-compact">
+      <div className="app-game-center-card__top">
+        <strong>Week {row.week}</strong>
+        <StatusChip label={label} tone={tone} />
+      </div>
+      <div className="app-game-center-card__scoreline">
+        {row.away.abbr} @ {row.home.abbr}
+      </div>
+      <p className="app-game-center-card__summary">{row.recap}</p>
+    </article>
+  );
+}
 
 function SpotlightCard({ row, seasonId, onGameSelect }) {
   const presentation = buildCompletedGamePresentation(row.game, { seasonId, week: row.week, source: 'weekly_results_spotlight' });
@@ -52,16 +74,16 @@ function SpotlightCard({ row, seasonId, onGameSelect }) {
   const homeId = Number(row?.game?.home?.id ?? row?.game?.home);
 
   return (
-    <article className="card" style={{ padding: 'var(--space-3)' }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'center' }}>
+    <article className="app-game-center-card card is-spotlight">
+      <div className="app-game-center-card__top">
         <strong>Spotlight game</strong>
-        <span className="badge">Score {row.score}</span>
+        <StatusChip label={`Score ${row.score}`} tone="warning" />
       </div>
-      <div style={{ marginTop: 6, fontWeight: 700 }}>
+      <div className="app-game-center-card__scoreline">
         {row.teamById[awayId]?.abbr ?? 'AWY'} {row.game?.awayScore ?? '—'} @ {row.teamById[homeId]?.abbr ?? 'HME'} {row.game?.homeScore ?? '—'}
       </div>
-      <div style={{ marginTop: 4, fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{row.reason}</div>
-      <div style={{ marginTop: 8 }}>
+      <p className="app-game-center-card__summary">{row.reason}</p>
+      <div className="app-game-center-card__footer">
         <button
           type="button"
           className="btn btn-sm"
@@ -113,104 +135,119 @@ export default function WeeklyResultsCenter({ league, initialWeek, onGameSelect 
   const spotlightRows = useMemo(() => leagueRecap.spotlights.map((spotlight) => ({ ...spotlight, teamById })), [leagueRecap.spotlights, teamById]);
 
   if (!totalWeeks) {
-    return <div className="card" style={{ padding: 'var(--space-4)' }}>No schedule data available for weekly results.</div>;
+    return <EmptyState title="No schedule data available for weekly results." body="Weekly game center will populate when league schedule weeks are present." />;
   }
 
   return (
     <div className="app-screen-stack">
-      <section className="card" style={{ padding: 'var(--space-3)', display: 'grid', gap: 8 }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-          <div>
-            <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}>Game Center</div>
-            <h2 style={{ margin: 0 }}>Weekly Results</h2>
-          </div>
-          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+      <HeroCard
+        eyebrow="Game Center"
+        title="Weekly Results"
+        subtitle="Track finals, live windows, and upcoming slates from one command view."
+        rightMeta={<StatusChip label={`Week ${selectedWeek}`} tone="info" />}
+        actions={(
+          <div className="app-weekly-results-nav">
             <button type="button" className="btn btn-sm" onClick={() => setSelectedWeek((w) => Math.max(1, w - 1))} disabled={selectedWeek <= 1}>Prev</button>
-            <span className="badge">Week {selectedWeek}</span>
             <button type="button" className="btn btn-sm" onClick={() => setSelectedWeek((w) => Math.min(totalWeeks, w + 1))} disabled={selectedWeek >= totalWeeks}>Next</button>
           </div>
-        </div>
-        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-          <span className="badge">Completed {completed.length}</span>
-          <span className="badge">Live {live.length}</span>
-          <span className="badge">Upcoming {upcoming.length}</span>
-        </div>
-      </section>
-
+        )}
+      >
+        <StatStrip
+          items={[
+            { label: 'Completed', value: completed.length, tone: 'ok' },
+            { label: 'Live', value: live.length, tone: live.length ? 'warning' : 'neutral' },
+            { label: 'Upcoming', value: upcoming.length, tone: 'info' },
+            { label: 'Games', value: rows.length, tone: 'neutral' },
+          ]}
+        />
+        {leagueRecap.bullets[0] ? (
+          <CompactInsightCard
+            title="Featured weekly recap"
+            subtitle={leagueRecap.bullets[0]}
+            tone="info"
+          />
+        ) : null}
+      </HeroCard>
 
       {leagueRecap.bullets.length > 0 && (
-        <section className="card" style={{ padding: 'var(--space-3)', display: 'grid', gap: 10 }}>
-          <h3 style={{ margin: 0 }}>Weekly League Recap</h3>
-          <ul style={{ margin: 0, paddingLeft: 18, display: 'grid', gap: 4 }}>
-            {leagueRecap.bullets.map((bullet, idx) => <li key={`bullet-${idx}`} style={{ fontSize: 'var(--text-sm)' }}>{bullet}</li>)}
-          </ul>
-          <div style={{ display: 'grid', gap: 6, gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
-            <div className="card" style={{ padding: 'var(--space-2)' }}>
-              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}>Race center</div>
-              <div style={{ fontSize: 'var(--text-sm)' }}>
-                <strong>Hottest:</strong> {leagueRecap.raceCenter.hottest[0] ? `${leagueRecap.raceCenter.hottest[0].team?.abbr ?? leagueRecap.raceCenter.hottest[0].team?.name} (${leagueRecap.raceCenter.hottest[0].streak.length}W)` : '—'}
-              </div>
-              <div style={{ fontSize: 'var(--text-sm)' }}>
-                <strong>Coldest:</strong> {leagueRecap.raceCenter.coldest[0] ? `${leagueRecap.raceCenter.coldest[0].team?.abbr ?? leagueRecap.raceCenter.coldest[0].team?.name} (${leagueRecap.raceCenter.coldest[0].streak.length}L)` : '—'}
-              </div>
-              <div style={{ fontSize: 'var(--text-sm)' }}>
-                <strong>Mover:</strong> {leagueRecap.raceCenter.biggestMover?.change > 0 ? `${leagueRecap.raceCenter.biggestMover.team?.abbr ?? leagueRecap.raceCenter.biggestMover.team?.name} (+${leagueRecap.raceCenter.biggestMover.change})` : 'No major move'}
-              </div>
-              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
-                {leagueRecap.raceCenter.bubble ? `Bubble: ${(leagueRecap.raceCenter.bubble.gap * 100).toFixed(1)} pct gap` : 'Bubble context unlocks as standings deepen.'}
-              </div>
+        <SectionCard
+          title="Weekly League Recap"
+          subtitle="Race center trends, movement, and macro context from this week."
+          variant="info"
+        >
+          <div className="app-weekly-results-recap-grid">
+            <div className="app-weekly-results-bullets">
+              {leagueRecap.bullets.map((bullet, idx) => (
+                <CompactInsightCard key={`bullet-${idx}`} title={bullet} tone="info" />
+              ))}
             </div>
-            <div className="card" style={{ padding: 'var(--space-2)' }}>
-              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}>Team trajectories</div>
-              <div style={{ display: 'grid', gap: 4 }}>
-                {leagueRecap.trajectories.slice(0, 3).map((team) => (
-                  <div key={team.teamId ?? team.label} style={{ fontSize: 'var(--text-xs)' }}><strong>{team.label}:</strong> {team.snippet}</div>
-                ))}
-              </div>
+            <div className="app-weekly-results-bullets">
+              <CompactInsightCard
+                title="Race center"
+                subtitle={`Hottest: ${leagueRecap.raceCenter.hottest[0] ? `${leagueRecap.raceCenter.hottest[0].team?.abbr ?? leagueRecap.raceCenter.hottest[0].team?.name} (${leagueRecap.raceCenter.hottest[0].streak.length}W)` : '—'}`}
+                tone="ok"
+              />
+              <CompactInsightCard
+                title="Playoff pressure"
+                subtitle={`Coldest: ${leagueRecap.raceCenter.coldest[0] ? `${leagueRecap.raceCenter.coldest[0].team?.abbr ?? leagueRecap.raceCenter.coldest[0].team?.name} (${leagueRecap.raceCenter.coldest[0].streak.length}L)` : '—'}`}
+                tone="warning"
+              />
+              <CompactInsightCard
+                title="Biggest mover"
+                subtitle={leagueRecap.raceCenter.biggestMover?.change > 0
+                  ? `${leagueRecap.raceCenter.biggestMover.team?.abbr ?? leagueRecap.raceCenter.biggestMover.team?.name} (+${leagueRecap.raceCenter.biggestMover.change})`
+                  : 'No major move'}
+                tone="info"
+              />
+              <CompactInsightCard
+                title="Bubble context"
+                subtitle={leagueRecap.raceCenter.bubble
+                  ? `${(leagueRecap.raceCenter.bubble.gap * 100).toFixed(1)} pct gap`
+                  : 'Bubble context unlocks as standings deepen.'}
+                tone="info"
+              />
             </div>
           </div>
-        </section>
+        </SectionCard>
       )}
 
       {spotlightRows.length > 0 && (
-        <section style={{ display: 'grid', gap: 8 }}>
-          <h3 style={{ margin: 0 }}>Weekly Spotlight</h3>
-          {spotlightRows.map((row) => <SpotlightCard key={row.key} row={row} seasonId={league?.seasonId} onGameSelect={onGameSelect} />)}
+        <section className="app-screen-stack">
+          <SectionHeader title="Weekly Spotlight" subtitle="High-leverage finals and headline outcomes." />
+          <div className="app-weekly-results-grid">
+            {spotlightRows.map((row) => <SpotlightCard key={row.key} row={row} seasonId={league?.seasonId} onGameSelect={onGameSelect} />)}
+          </div>
         </section>
       )}
 
       {completed.length > 0 && (
-        <section style={{ display: 'grid', gap: 8 }}>
-          <h3 style={{ margin: 0 }}>Completed</h3>
-          {completed.map((row) => <ResultRow key={row.key} row={row} seasonId={league?.seasonId} onGameSelect={onGameSelect} />)}
+        <section className="app-screen-stack">
+          <SectionHeader title="Completed" subtitle="Finals available to open in Game Book." />
+          <div className="app-weekly-results-grid">
+            {completed.map((row) => <ResultRow key={row.key} row={row} seasonId={league?.seasonId} onGameSelect={onGameSelect} />)}
+          </div>
         </section>
       )}
 
       {live.length > 0 && (
-        <section style={{ display: 'grid', gap: 8 }}>
-          <h3 style={{ margin: 0 }}>In progress</h3>
-          {live.map((row) => (
-            <article key={row.key} className="card" style={{ padding: 'var(--space-3)' }}>
-              <strong>{row.away.abbr} @ {row.home.abbr}</strong>
-              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{row.recap}</div>
-            </article>
-          ))}
+        <section className="app-screen-stack">
+          <SectionHeader title="In progress" subtitle="Live windows and in-flight game scripts." />
+          <div className="app-weekly-results-grid">
+            {live.map((row) => <LiveOrUpcomingRow key={row.key} row={row} label="Live" tone="warning" />)}
+          </div>
         </section>
       )}
 
       {upcoming.length > 0 && (
-        <section style={{ display: 'grid', gap: 8 }}>
-          <h3 style={{ margin: 0 }}>Upcoming</h3>
-          {upcoming.map((row) => (
-            <article key={row.key} className="card" style={{ padding: 'var(--space-3)' }}>
-              <strong>{row.away.abbr} @ {row.home.abbr}</strong>
-              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{row.recap}</div>
-            </article>
-          ))}
+        <section className="app-screen-stack">
+          <SectionHeader title="Upcoming" subtitle="Scheduled matchups waiting to kick off." />
+          <div className="app-weekly-results-grid">
+            {upcoming.map((row) => <LiveOrUpcomingRow key={row.key} row={row} label="Upcoming" tone="info" />)}
+          </div>
         </section>
       )}
 
-      {rows.length === 0 ? <div className="card" style={{ padding: 'var(--space-4)' }}>No games scheduled for week {selectedWeek}.</div> : null}
+      {rows.length === 0 ? <EmptyState title={`No games scheduled for week ${selectedWeek}.`} body="Try another week to view slate and recap context." /> : null}
     </div>
   );
 }

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -146,3 +146,35 @@
   .app-section-card { padding: var(--space-3); }
   .app-hero-summary-grid { grid-template-columns: 1fr; }
 }
+
+.app-weekly-results-nav { display: flex; gap: 8px; flex-wrap: wrap; }
+.app-weekly-results-grid { display: grid; gap: 8px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+.app-weekly-results-recap-grid { display: grid; gap: 8px; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
+.app-weekly-results-bullets { display: grid; gap: 6px; }
+
+.app-game-center-card {
+  padding: var(--space-3);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface) 93%, black 7%);
+  display: grid;
+  gap: 8px;
+}
+.app-game-center-card.is-spotlight {
+  border-color: color-mix(in srgb, var(--warning) 35%, var(--hairline));
+  background: linear-gradient(140deg, color-mix(in srgb, var(--surface) 92%, var(--warning) 8%), var(--surface));
+}
+.app-game-center-card.is-compact { padding: var(--space-2) var(--space-3); }
+.app-game-center-card__top { display: flex; justify-content: space-between; align-items: center; gap: 8px; }
+.app-game-center-card__scoreline { font-size: var(--text-base); font-weight: 700; letter-spacing: -0.01em; }
+.app-game-center-card__summary { margin: 0; font-size: var(--text-xs); color: var(--text-muted); }
+.app-game-center-card__footer { display: flex; justify-content: flex-start; gap: 8px; }
+
+.app-news-filter-row { display: flex; gap: 8px; flex-wrap: wrap; }
+.app-news-filter-row .btn.is-active { border-color: var(--accent); box-shadow: 0 0 0 1px rgba(var(--accent-rgb), .38) inset; }
+.app-news-story-body { margin: 0; color: var(--text-muted); font-size: var(--text-sm); }
+.app-news-row-meta { display: flex; justify-content: space-between; align-items: center; gap: 8px; flex-wrap: wrap; }
+.app-news-row-chips { display: flex; gap: 6px; flex-wrap: wrap; }
+.app-news-aux-grid { display: grid; gap: 8px; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
+.app-news-cta-bar { display: flex; justify-content: space-between; align-items: center; gap: 10px; flex-wrap: wrap; }
+.app-news-cta-copy { font-size: var(--text-xs); color: var(--text-subtle); }


### PR DESCRIPTION
### Motivation
- Bring Weekly Results, News Feed, and Game Detail screens into the shared premium command-center visual language introduced earlier to make high-traffic surfaces feel consistent with HQ/Team/League.
- Remove ad-hoc inline card styling in favor of shared ScreenSystem primitives to reduce duplication and improve maintainability.
- Preserve all existing behavior (game open, archive access, routing, simulation and save semantics) and keep older/partial data safe.

### Description
- Weekly Results: refactored `WeeklyResultsCenter.jsx` to use `HeroCard`, `StatStrip`, `CompactInsightCard`, `SectionCard`, `SectionHeader`, `StatusChip`, and `EmptyState`, introduced reusable `app-game-center-card` markup and preserved `openResolvedBoxScore` calls for spotlight/completed games.
- News Desk: rebuilt `NewsFeed.jsx` as a “Desk View” using `HeroCard`, `SectionCard`, `SectionHeader`, `CompactListRow`, `CtaRow`, `CompactInsightCard`, and `StatusChip`, added a featured lead story layout, reusable story rows, and filter controls while keeping all CTAs intact (`open game`, `open team`, `open player`, and navigation hooks).
- Game Book: upgraded `GameDetailScreen.jsx` wrapper to use `ScreenHeader` metadata, `StatusChip`, and a `SectionCard` shell for `BoxScorePanel`, and added an explicit empty-state header showing game/season metadata when no game is selected.
- Styling and primitives: added focused layout and card styles to `screen-system.css` (`app-weekly-results-*`, `app-game-center-card`, news desk helpers) to replace new inline styles and harmonize spacing/touch targets with the existing premium look.
- Tests: added `NewsFeed.test.jsx` and updated `GameDetailScreen.test.jsx` and left `WeeklyResultsCenter.test.jsx` assertions aligned to the new structure without weakening coverage.

### Testing
- Ran targeted unit tests with Vitest: `npx vitest run src/ui/components/WeeklyResultsCenter.test.jsx src/ui/components/NewsFeed.test.jsx src/ui/components/GameDetailScreen.test.jsx`, and all tests passed (3 files, 7 tests passed).
- Attempted `npm test` invocation that uses a Playwright-based runner in this environment; that command failed due to runner mismatch (TypeError and no matching tests), but it did not affect the Vitest unit test results above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e31688d9ac832d8f5b33760efaafc9)