### PR TITLE
Deterministic weekly player evolution engine + worker integration

### DIFF
--- a/src/core/__tests__/evolutionEngine.test.ts
+++ b/src/core/__tests__/evolutionEngine.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { processWeeklyEvolution } from '../progression/evolutionEngine.ts';
+
+function makeAttrs(value: number) {
+  return {
+    release: value,
+    routeRunning: value,
+    separation: value,
+    catchInTraffic: value,
+    ballTracking: value,
+    throwAccuracyShort: value,
+    throwAccuracyDeep: value,
+    throwPower: value,
+    decisionMaking: value,
+    pocketPresence: value,
+    passBlockFootwork: value,
+    passBlockStrength: value,
+    passRush: value,
+    pressCoverage: value,
+    zoneCoverage: value,
+  };
+}
+
+describe('processWeeklyEvolution', () => {
+  it('grows a 22-year-old starter more than a bench peer with similar talent', () => {
+    const sharedAttrs = makeAttrs(74);
+    const result = processWeeklyEvolution({
+      week: 4,
+      seasonId: 2031,
+      seed: 99,
+      players: [
+        { id: 'starter-qb', pos: 'QB', age: 22, teamId: 1, attributesV2: sharedAttrs },
+        { id: 'bench-qb', pos: 'QB', age: 22, teamId: 1, attributesV2: sharedAttrs },
+      ],
+      results: [
+        {
+          home: 1,
+          away: 2,
+          teamDriveStats: { home: { explosivePlays: 6 }, away: {} },
+          boxScore: {
+            home: {
+              'starter-qb': {
+                pos: 'QB',
+                stats: { passAtt: 36, passComp: 27, passYd: 318, passTD: 3, interceptions: 0, sacks: 1 },
+              },
+              'bench-qb': {
+                pos: 'QB',
+                stats: { passAtt: 3, passComp: 1, passYd: 8, passTD: 0, interceptions: 0, sacks: 0 },
+              },
+            },
+            away: {},
+          },
+        },
+      ],
+    });
+
+    const starter = result.updates.find((row) => row.playerId === 'starter-qb');
+    const bench = result.updates.find((row) => row.playerId === 'bench-qb');
+    const starterGain = Object.values(starter?.growthHistoryEntry.deltas ?? {}).reduce((sum, delta) => sum + Math.max(0, Number(delta ?? 0)), 0);
+    const benchGain = Object.values(bench?.growthHistoryEntry.deltas ?? {}).reduce((sum, delta) => sum + Math.max(0, Number(delta ?? 0)), 0);
+
+    expect(starterGain).toBeGreaterThan(benchGain);
+  });
+
+  it('keeps strong older production near maintenance and can include regression pressure', () => {
+    const result = processWeeklyEvolution({
+      week: 8,
+      seasonId: 2031,
+      seed: 77,
+      players: [
+        { id: 'veteran-qb', pos: 'QB', age: 35, teamId: 1, attributesV2: makeAttrs(84) },
+      ],
+      results: [
+        {
+          home: 1,
+          away: 2,
+          teamDriveStats: { home: { explosivePlays: 5 }, away: {} },
+          boxScore: {
+            home: {
+              'veteran-qb': {
+                pos: 'QB',
+                stats: { passAtt: 34, passComp: 23, passYd: 274, passTD: 2, interceptions: 1, sacks: 3 },
+              },
+            },
+            away: {},
+          },
+        },
+      ],
+    });
+
+    const vet = result.updates[0];
+    expect(vet).toBeTruthy();
+    expect(Math.abs(vet.growthHistoryEntry.totalDelta)).toBeLessThanOrEqual(4);
+    const hasRegression = Object.values(vet.growthHistoryEntry.deltas).some((delta) => Number(delta ?? 0) < 0);
+    expect(hasRegression).toBe(true);
+  });
+
+  it('is deterministic for same seed and same statline', () => {
+    const payload = {
+      week: 5,
+      seasonId: 2031,
+      seed: 1337,
+      players: [{ id: 'wr1', pos: 'WR', age: 24, teamId: 1, attributesV2: makeAttrs(79) }],
+      results: [{ home: 1, away: 2, boxScore: { home: { wr1: { pos: 'WR', stats: { targets: 12, receptions: 8, recYd: 118, recTD: 1 } } }, away: {} }, teamDriveStats: { home: { explosivePlays: 4 }, away: {} } }],
+    };
+
+    const first = processWeeklyEvolution(payload);
+    const second = processWeeklyEvolution(payload);
+    expect(first).toEqual(second);
+  });
+
+  it('applies a league-wide inflation guardrail in one weekly run', () => {
+    const players = Array.from({ length: 64 }).map((_, idx) => ({
+      id: `wr-${idx}`,
+      pos: 'WR',
+      age: 22,
+      teamId: idx % 8,
+      attributesV2: makeAttrs(70),
+    }));
+    const boxHome = Object.fromEntries(players.slice(0, 32).map((p) => [p.id, { pos: 'WR', stats: { targets: 14, receptions: 10, recYd: 140, recTD: 1 } }]));
+    const boxAway = Object.fromEntries(players.slice(32).map((p) => [p.id, { pos: 'WR', stats: { targets: 14, receptions: 10, recYd: 140, recTD: 1 } }]));
+
+    const result = processWeeklyEvolution({
+      week: 11,
+      seasonId: 2031,
+      seed: 4,
+      players,
+      results: [{ home: 1, away: 2, boxScore: { home: boxHome, away: boxAway }, teamDriveStats: { home: { explosivePlays: 10 }, away: { explosivePlays: 10 } } }],
+    });
+
+    expect(result.summary.netDelta).toBeLessThanOrEqual(Math.max(5, Math.floor(players.length * 0.12)));
+  });
+});

--- a/src/core/progression/evolutionEngine.ts
+++ b/src/core/progression/evolutionEngine.ts
@@ -1,0 +1,431 @@
+import type { AttributesV2 } from '../../types/player.ts';
+
+export interface EvolutionPlayer {
+  id: string | number;
+  name?: string;
+  pos?: string;
+  age?: number;
+  teamId?: number | string | null;
+  attributesV2?: AttributesV2;
+  attributeXp?: Partial<Record<keyof AttributesV2, number>>;
+  growthHistory?: Array<Record<string, unknown>>;
+  lastEvolutionWeek?: string | null;
+}
+
+export interface EvolutionGameResult {
+  home?: number | string;
+  away?: number | string;
+  boxScore?: {
+    home?: Record<string, { pos?: string; stats?: Record<string, number> }>;
+    away?: Record<string, { pos?: string; stats?: Record<string, number> }>;
+  };
+  teamDriveStats?: {
+    home?: Record<string, number>;
+    away?: Record<string, number>;
+  };
+}
+
+export interface TeamDevelopmentFocus {
+  trainingFocus?: string;
+  intensity?: 'light' | 'normal' | 'hard' | string;
+  drillType?: 'technique' | 'conditioning' | 'teamwork' | 'film' | string;
+  positionGroups?: string[];
+}
+
+interface PlayerDevelopmentAccumulator {
+  xp: Partial<Record<keyof AttributesV2, number>>;
+  production: number;
+}
+
+export interface WeeklyEvolutionInput {
+  players: EvolutionPlayer[];
+  results: EvolutionGameResult[];
+  week: number;
+  seasonId: number;
+  seed: number;
+  teamFocusByTeamId?: Record<string, TeamDevelopmentFocus>;
+}
+
+export interface PlayerEvolutionUpdate {
+  playerId: string;
+  attributesV2: AttributesV2;
+  attributeXp: Partial<Record<keyof AttributesV2, number>>;
+  growthHistoryEntry: {
+    seasonId: number;
+    week: number;
+    deltas: Partial<Record<keyof AttributesV2, number>>;
+    totalDelta: number;
+    notes: string[];
+  };
+  notableNote?: string;
+}
+
+export interface WeeklyEvolutionResult {
+  updates: PlayerEvolutionUpdate[];
+  developmentEvents: Array<{
+    playerId: string;
+    teamId: number | string | null;
+    week: number;
+    seasonId: number;
+    note: string;
+  }>;
+  stamp: string;
+  summary: {
+    processedPlayers: number;
+    totalPositiveDelta: number;
+    totalNegativeDelta: number;
+    netDelta: number;
+  };
+}
+
+const ATTRIBUTE_KEYS: Array<keyof AttributesV2> = [
+  'release', 'routeRunning', 'separation', 'catchInTraffic', 'ballTracking',
+  'throwAccuracyShort', 'throwAccuracyDeep', 'throwPower', 'decisionMaking',
+  'pocketPresence', 'passBlockFootwork', 'passBlockStrength', 'passRush',
+  'pressCoverage', 'zoneCoverage',
+];
+
+const POSITION_GROUPS: Record<string, string[]> = {
+  qb: ['QB'],
+  rb: ['RB', 'FB'],
+  wr: ['WR'],
+  te: ['TE'],
+  ol: ['OL', 'C', 'G', 'T'],
+  dl: ['DL', 'DE', 'DT', 'NT', 'EDGE'],
+  lb: ['LB', 'MLB', 'OLB'],
+  db: ['CB', 'S', 'FS', 'SS'],
+};
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function num(v: unknown) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function makeStamp(seasonId: number, week: number) {
+  return `${seasonId}:${week}`;
+}
+
+function emptyXp(): Partial<Record<keyof AttributesV2, number>> {
+  return ATTRIBUTE_KEYS.reduce((acc, key) => {
+    acc[key] = 0;
+    return acc;
+  }, {} as Partial<Record<keyof AttributesV2, number>>);
+}
+
+function getAgeCurve(ageRaw: unknown) {
+  const age = Math.round(num(ageRaw) || 25);
+  if (age <= 23) return { growth: 1.3, maintenancePressure: 0.02 };
+  if (age <= 25) return { growth: 1.15, maintenancePressure: 0.05 };
+  if (age <= 28) return { growth: 0.95, maintenancePressure: 0.11 };
+  if (age <= 30) return { growth: 0.82, maintenancePressure: 0.19 };
+  if (age <= 33) return { growth: 0.68, maintenancePressure: 0.3 };
+  return { growth: 0.55, maintenancePressure: 0.4 };
+}
+
+function addXp(acc: PlayerDevelopmentAccumulator, attribute: keyof AttributesV2, value: number) {
+  if (!Number.isFinite(value) || value === 0) return;
+  const current = num(acc.xp[attribute]);
+  acc.xp[attribute] = current + value;
+}
+
+function deriveFocusMultiplier(playerPos: string, teamFocus?: TeamDevelopmentFocus) {
+  if (!teamFocus) return 1;
+  const trainingFocus = String(teamFocus.trainingFocus ?? 'balanced');
+  const intensity = String(teamFocus.intensity ?? 'normal');
+  const drillType = String(teamFocus.drillType ?? 'technique');
+  const focusGroups = new Set((teamFocus.positionGroups ?? []).map((g) => String(g).toLowerCase()));
+
+  let multiplier = 1;
+  if (intensity === 'light') multiplier *= 0.94;
+  if (intensity === 'hard') multiplier *= 1.06;
+
+  if (drillType === 'film' && ['QB', 'WR', 'TE', 'CB', 'S', 'LB'].includes(playerPos)) multiplier *= 1.06;
+  if (drillType === 'conditioning' && ['RB', 'WR', 'CB', 'S', 'DL', 'LB'].includes(playerPos)) multiplier *= 1.05;
+
+  if (trainingFocus === 'youth_development') multiplier *= 1.08;
+  if (trainingFocus === 'win_now' && ['QB', 'OL', 'DL', 'LB'].includes(playerPos)) multiplier *= 1.04;
+  if (trainingFocus === 'strength_conditioning' && ['OL', 'DL', 'LB', 'TE'].includes(playerPos)) multiplier *= 1.07;
+
+  if (focusGroups.size > 0) {
+    const focused = Object.entries(POSITION_GROUPS).some(([group, positions]) => focusGroups.has(group) && positions.includes(playerPos));
+    if (focused) multiplier *= 1.08;
+  }
+
+  return clamp(multiplier, 0.86, 1.2);
+}
+
+function summarizeNotableNote(pos: string, deltas: Partial<Record<keyof AttributesV2, number>>) {
+  const ranked = Object.entries(deltas)
+    .map(([attr, delta]) => ({ attr, delta: num(delta) }))
+    .sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta));
+  if (!ranked.length || Math.abs(ranked[0].delta) < 1) return null;
+
+  const top = ranked[0];
+  if (pos === 'QB' && top.attr === 'pocketPresence' && top.delta > 0) {
+    return 'Pocket presence gained from sustained clean-dropback volume.';
+  }
+  if (['WR', 'TE'].includes(pos) && top.attr === 'routeRunning' && top.delta > 0) {
+    return 'Route running trend improved after high-volume usage.';
+  }
+  return null;
+}
+
+function applyPositionXp(
+  acc: PlayerDevelopmentAccumulator,
+  pos: string,
+  stats: Record<string, number>,
+  teamStats: Record<string, number>,
+) {
+  const passAtt = num(stats.passAtt);
+  const passComp = num(stats.passComp);
+  const passYd = num(stats.passYd);
+  const passTd = num(stats.passTD);
+  const interceptions = num(stats.interceptions);
+  const sacks = num(stats.sacks);
+  const rushAtt = num(stats.rushAtt);
+  const rushYd = num(stats.rushYd);
+  const rushTd = num(stats.rushTD);
+  const targets = num(stats.targets);
+  const receptions = num(stats.receptions);
+  const recYd = num(stats.recYd);
+  const recTd = num(stats.recTD);
+  const passesDefended = num(stats.passesDefended);
+
+  if (pos === 'QB') {
+    const usage = clamp((passAtt + sacks) / 34, 0, 1.4);
+    const efficiency = passAtt > 0 ? (passComp / passAtt) * 0.8 + (passYd / passAtt) * 0.08 : 0;
+    const production = efficiency + passTd * 0.25 - interceptions * 0.35 - sacks * 0.05;
+    addXp(acc, 'throwAccuracyShort', usage * 4.2 + production * 2.2);
+    addXp(acc, 'throwAccuracyDeep', usage * 3.3 + production * 2.6 + num(teamStats.explosivePlays) * 0.12);
+    addXp(acc, 'decisionMaking', usage * 2.8 + production * 2.5);
+    addXp(acc, 'pocketPresence', usage * 2.1 + (1 - clamp(sacks / Math.max(1, passAtt), 0, 1)) * 2.1);
+    addXp(acc, 'throwPower', (passYd / Math.max(1, passAtt)) * 0.9 + passTd * 0.15);
+    acc.production += production;
+    return;
+  }
+
+  if (pos === 'RB' || pos === 'FB') {
+    const touches = rushAtt + receptions;
+    const usage = clamp(touches / 20, 0, 1.35);
+    const ypc = rushAtt > 0 ? rushYd / rushAtt : 0;
+    const production = ypc * 0.35 + rushTd * 0.25 + recYd * 0.012;
+    addXp(acc, 'decisionMaking', usage * 2.1 + production * 0.9);
+    addXp(acc, 'separation', receptions * 0.32 + production * 0.3);
+    addXp(acc, 'catchInTraffic', receptions * 0.24 + targets * 0.1);
+    addXp(acc, 'throwPower', rushAtt * 0.04 + rushYd * 0.012);
+    acc.production += production;
+    return;
+  }
+
+  if (pos === 'WR' || pos === 'TE') {
+    const usage = clamp(targets / 10, 0, 1.45);
+    const catchRate = targets > 0 ? receptions / targets : 0;
+    const production = catchRate * 0.8 + recYd * 0.015 + recTd * 0.5;
+    addXp(acc, 'release', usage * 1.8 + receptions * 0.38);
+    addXp(acc, 'routeRunning', usage * 3.2 + production * 1.7);
+    addXp(acc, 'separation', usage * 2.8 + production * 1.5 + num(teamStats.explosivePlays) * 0.1);
+    addXp(acc, 'catchInTraffic', receptions * 0.25 + targets * 0.18 + recTd * 0.35);
+    addXp(acc, 'ballTracking', recYd * 0.02 + recTd * 0.45);
+    acc.production += production;
+    return;
+  }
+
+  if (['OL', 'C', 'G', 'T'].includes(pos)) {
+    const plays = num(teamStats.plays);
+    const sackPenalty = num(teamStats.sacksAllowed) * 0.35;
+    const runSupport = num(teamStats.rushYd) / Math.max(1, num(teamStats.rushAtt));
+    const production = clamp((plays / 65) + runSupport * 0.5 - sackPenalty, -1.5, 2.5);
+    addXp(acc, 'passBlockFootwork', plays * 0.06 + production * 2.1);
+    addXp(acc, 'passBlockStrength', runSupport * 1.2 + production * 2.3);
+    addXp(acc, 'decisionMaking', production * 0.6);
+    acc.production += production;
+    return;
+  }
+
+  if (['DL', 'DE', 'DT', 'NT', 'EDGE', 'LB'].includes(pos)) {
+    const pressures = num(stats.pressures);
+    const sacksMade = num(stats.sacks);
+    const tackles = num(stats.tackles);
+    const production = sacksMade * 0.8 + pressures * 0.28 + tackles * 0.06;
+    addXp(acc, 'passRush', production * 2.7 + num(teamStats.sacksMade) * 0.2);
+    addXp(acc, 'decisionMaking', tackles * 0.08 + production * 0.45);
+    addXp(acc, 'zoneCoverage', tackles * 0.04);
+    acc.production += production;
+    return;
+  }
+
+  if (['CB', 'S', 'FS', 'SS'].includes(pos)) {
+    const ints = num(stats.interceptions);
+    const tackles = num(stats.tackles);
+    const production = passesDefended * 0.55 + ints * 1.2 + tackles * 0.05;
+    addXp(acc, 'pressCoverage', production * 1.7 + passesDefended * 0.65);
+    addXp(acc, 'zoneCoverage', production * 1.75 + ints * 0.4);
+    addXp(acc, 'ballTracking', ints * 0.9 + passesDefended * 0.28);
+    acc.production += production;
+  }
+}
+
+function applyParityGuardrail(entries: Array<{ playerId: string; attr: keyof AttributesV2; delta: number }>, playerCount: number) {
+  const positive = entries.reduce((sum, row) => sum + Math.max(0, row.delta), 0);
+  const negative = Math.abs(entries.reduce((sum, row) => sum + Math.min(0, row.delta), 0));
+  const maxNetPositive = Math.max(5, Math.floor(playerCount * 0.12));
+  let net = positive - negative;
+  if (net <= maxNetPositive) return entries;
+
+  const sortedPositives = entries
+    .filter((row) => row.delta > 0)
+    .sort((a, b) => a.delta - b.delta || a.playerId.localeCompare(b.playerId) || a.attr.localeCompare(b.attr));
+
+  for (const row of sortedPositives) {
+    while (row.delta > 0 && net > maxNetPositive) {
+      row.delta -= 1;
+      net -= 1;
+    }
+    if (net <= maxNetPositive) break;
+  }
+  return entries;
+}
+
+export function processWeeklyEvolution(input: WeeklyEvolutionInput): WeeklyEvolutionResult {
+  const stamp = makeStamp(input.seasonId, input.week);
+  const playersById = new Map<string, EvolutionPlayer>();
+  for (const player of input.players) playersById.set(String(player.id), player);
+
+  const accumulators = new Map<string, PlayerDevelopmentAccumulator>();
+  const ensureAccumulator = (playerId: string) => {
+    if (!accumulators.has(playerId)) accumulators.set(playerId, { xp: emptyXp(), production: 0 });
+    return accumulators.get(playerId)!;
+  };
+
+  for (const game of input.results) {
+    const sideEntries: Array<{ box: Record<string, { pos?: string; stats?: Record<string, number> }>; teamStats: Record<string, number>; teamId: number | string | undefined }> = [
+      { box: game.boxScore?.home ?? {}, teamStats: game.teamDriveStats?.home ?? {}, teamId: game.home },
+      { box: game.boxScore?.away ?? {}, teamStats: game.teamDriveStats?.away ?? {}, teamId: game.away },
+    ];
+
+    for (const side of sideEntries) {
+      for (const [rawPlayerId, row] of Object.entries(side.box)) {
+        const playerId = String(rawPlayerId);
+        const player = playersById.get(playerId);
+        if (!player?.attributesV2) continue;
+        const stats = row?.stats ?? {};
+        const pos = String(player.pos ?? row?.pos ?? '').toUpperCase();
+        if (!pos) continue;
+        const acc = ensureAccumulator(playerId);
+        applyPositionXp(acc, pos, stats, side.teamStats);
+
+        const focusKey = String(player.teamId ?? side.teamId ?? '');
+        const focusMultiplier = deriveFocusMultiplier(pos, input.teamFocusByTeamId?.[focusKey]);
+        for (const key of ATTRIBUTE_KEYS) {
+          acc.xp[key] = num(acc.xp[key]) * focusMultiplier;
+        }
+      }
+    }
+  }
+
+  const deltaRows: Array<{ playerId: string; attr: keyof AttributesV2; delta: number }> = [];
+  for (const [playerId, acc] of accumulators.entries()) {
+    const player = playersById.get(playerId);
+    if (!player?.attributesV2) continue;
+    const ageCurve = getAgeCurve(player.age);
+    const productionSoftener = clamp(acc.production * 0.03, 0, 0.55);
+    const veteranPenalty = Number(player.age ?? 0) >= 34 ? 5 : Number(player.age ?? 0) >= 31 ? 2 : 0;
+
+    for (const attr of ATTRIBUTE_KEYS) {
+      const agePressureXp = -(ageCurve.maintenancePressure * 12 * (1 - productionSoftener) + veteranPenalty);
+      const xp = num(player.attributeXp?.[attr]) + num(acc.xp[attr]) * ageCurve.growth + agePressureXp;
+      const boundedXp = clamp(xp, -140, 140);
+      let delta = clamp(Math.trunc(boundedXp / 12), -2, 2);
+      if (Number(player.age ?? 0) >= 34 && ['throwPower', 'separation', 'passRush', 'pressCoverage'].includes(attr)) {
+        delta = Math.min(delta, -1);
+      }
+      deltaRows.push({ playerId, attr, delta });
+    }
+  }
+
+  applyParityGuardrail(deltaRows, input.players.length);
+
+  const deltasByPlayer = new Map<string, Partial<Record<keyof AttributesV2, number>>>();
+  for (const row of deltaRows) {
+    const existing = deltasByPlayer.get(row.playerId) ?? {};
+    existing[row.attr] = row.delta;
+    deltasByPlayer.set(row.playerId, existing);
+  }
+
+  const updates: PlayerEvolutionUpdate[] = [];
+  const developmentEvents: WeeklyEvolutionResult['developmentEvents'] = [];
+
+  for (const [playerId, deltas] of deltasByPlayer.entries()) {
+    const player = playersById.get(playerId);
+    if (!player?.attributesV2) continue;
+
+    const nextAttributes = { ...player.attributesV2 };
+    let totalDelta = 0;
+    for (const key of ATTRIBUTE_KEYS) {
+      const delta = num(deltas[key]);
+      if (delta === 0) continue;
+      totalDelta += delta;
+      nextAttributes[key] = clamp(num(nextAttributes[key]) + delta, 25, 99);
+    }
+
+    const acc = accumulators.get(playerId);
+    const nextXp: Partial<Record<keyof AttributesV2, number>> = { ...(player.attributeXp ?? {}) };
+    const ageCurve = getAgeCurve(player.age);
+    for (const key of ATTRIBUTE_KEYS) {
+      const raw = num(player.attributeXp?.[key]) + num(acc?.xp[key]) * ageCurve.growth;
+      const consumed = num(deltas[key]) * 12;
+      nextXp[key] = clamp(raw - consumed, -140, 140);
+    }
+
+    const notes: string[] = [];
+    if (Math.abs(totalDelta) >= 2 && (player.pos === 'QB' || player.pos === 'WR' || player.pos === 'TE')) {
+      const note = summarizeNotableNote(String(player.pos ?? ''), deltas);
+      if (note) notes.push(note);
+    }
+
+    const growthHistoryEntry = {
+      seasonId: input.seasonId,
+      week: input.week,
+      deltas,
+      totalDelta,
+      notes,
+    };
+
+    updates.push({
+      playerId,
+      attributesV2: nextAttributes,
+      attributeXp: nextXp,
+      growthHistoryEntry,
+      notableNote: notes[0],
+    });
+
+    if (notes[0]) {
+      developmentEvents.push({
+        playerId,
+        teamId: player.teamId ?? null,
+        week: input.week,
+        seasonId: input.seasonId,
+        note: notes[0],
+      });
+    }
+  }
+
+  const totalPositiveDelta = updates.reduce((sum, update) => sum + Object.values(update.growthHistoryEntry.deltas).reduce((inner, delta) => inner + Math.max(0, num(delta)), 0), 0);
+  const totalNegativeDelta = updates.reduce((sum, update) => sum + Object.values(update.growthHistoryEntry.deltas).reduce((inner, delta) => inner + Math.abs(Math.min(0, num(delta))), 0), 0);
+
+  return {
+    updates,
+    developmentEvents,
+    stamp,
+    summary: {
+      processedPlayers: updates.length,
+      totalPositiveDelta,
+      totalNegativeDelta,
+      netDelta: totalPositiveDelta - totalNegativeDelta,
+    },
+  };
+}

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -170,6 +170,11 @@ export const State = {
       playoffs: null,
       trainingPlan: null,
       pendingOffers: [],
+      weeklyDevelopmentLog: [],
+      developmentModel: {
+        version: 1,
+        lastEvolutionStamp: null,
+      },
       
       // User interface
       currentView: 'hub',
@@ -454,6 +459,13 @@ export const State = {
         history: [],
       };
       migratedTeam.rivalTeamId = migratedTeam?.rivalTeamId ?? null;
+      migratedTeam.weeklyDevelopmentFocus = migratedTeam?.weeklyDevelopmentFocus ?? null;
+      migratedTeam.roster = migratedTeam.roster.map((player) => ({
+        ...player,
+        attributeXp: player?.attributeXp ?? {},
+        growthHistory: Array.isArray(player?.growthHistory) ? player.growthHistory : [],
+        lastEvolutionWeek: player?.lastEvolutionWeek ?? null,
+      }));
       if (migratedTeam.staff && typeof migratedTeam.staff === 'object') {
         Object.keys(migratedTeam.staff).forEach((key) => {
           if (migratedTeam.staff[key] && typeof migratedTeam.staff[key] === 'object') {

--- a/src/state/saveSchema.js
+++ b/src/state/saveSchema.js
@@ -1,4 +1,4 @@
-export const CURRENT_SAVE_SCHEMA_VERSION = 5.5;
+export const CURRENT_SAVE_SCHEMA_VERSION = 5.6;
 
 function migratePreVersioned(meta = {}) {
   return {
@@ -45,6 +45,7 @@ const MIGRATIONS = {
   5.2: migrateV52ToV53,
   5.3: migrateV53ToV54,
   5.4: migrateV54ToV55,
+  5.5: migrateV55ToV56,
 };
 
 function migrateV4ToV5(meta = {}) {
@@ -147,6 +148,21 @@ function migrateV54ToV55(meta = {}) {
     financialSystem,
     baselineRevenue,
     saveVersion: 5.5,
+  };
+}
+
+function migrateV55ToV56(meta = {}) {
+  const developmentModel = {
+    version: 1,
+    lastEvolutionStamp: null,
+    ...(meta?.developmentModel ?? {}),
+  };
+  const weeklyDevelopmentLog = Array.isArray(meta?.weeklyDevelopmentLog) ? meta.weeklyDevelopmentLog : [];
+  return {
+    ...meta,
+    developmentModel,
+    weeklyDevelopmentLog,
+    saveVersion: 5.6,
   };
 }
 

--- a/src/state/saveSchema.test.js
+++ b/src/state/saveSchema.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { CURRENT_SAVE_SCHEMA_VERSION, migrateSaveMetaToCurrent } from './saveSchema.js';
+
+describe('saveSchema migration', () => {
+  it('safely defaults progression metadata for legacy/partial saves', () => {
+    const legacy = {
+      saveVersion: 5.5,
+      year: 2030,
+      schedule: { weeks: [] },
+    };
+
+    const migrated = migrateSaveMetaToCurrent(legacy);
+
+    expect(migrated.migratedTo).toBe(CURRENT_SAVE_SCHEMA_VERSION);
+    expect(migrated.migrated.developmentModel).toEqual({
+      version: 1,
+      lastEvolutionStamp: null,
+    });
+    expect(migrated.migrated.weeklyDevelopmentLog).toEqual([]);
+  });
+});

--- a/src/ui/components/game/GameDetailV2.tsx
+++ b/src/ui/components/game/GameDetailV2.tsx
@@ -55,6 +55,11 @@ function TacticalBar({ label, awayValue, homeValue, awayRaw, homeRaw }: {
 
 export default function GameDetailV2({ game, awayTeam, homeTeam }: { game: any; awayTeam: any; homeTeam: any; }) {
   const digest = useMemo(() => (Array.isArray(game?.eventDigest) ? game.eventDigest : []), [game?.eventDigest]);
+  const developmentFlash = useMemo(() => {
+    const source = game?.developmentFlash ?? game?.summary?.developmentFlash;
+    if (!Array.isArray(source)) return [];
+    return source.filter((note) => typeof note === 'string' && note.trim().length > 0).slice(0, 2);
+  }, [game?.developmentFlash, game?.summary?.developmentFlash]);
 
   const tacticalReasons = useMemo(() => {
     const reasons = [game?.topReason1, game?.topReason2, game?.summary?.topReason1, game?.summary?.topReason2].filter(Boolean);
@@ -145,7 +150,7 @@ export default function GameDetailV2({ game, awayTeam, homeTeam }: { game: any; 
     return notes.slice(0, 5);
   }, [digest, driveStats, awayTeam?.abbr, homeTeam?.abbr]);
 
-  const hasRecapData = digest.length > 0 || tacticalReasons.length > 0 || headlineMoments.length > 0 || comparisonRows.length > 0 || flowStory.length > 0;
+  const hasRecapData = digest.length > 0 || tacticalReasons.length > 0 || headlineMoments.length > 0 || comparisonRows.length > 0 || flowStory.length > 0 || developmentFlash.length > 0;
   if (!hasRecapData) return null;
 
   return (
@@ -177,6 +182,15 @@ export default function GameDetailV2({ game, awayTeam, homeTeam }: { game: any; 
           <h5>Game flow &amp; momentum</h5>
           <ul className="bs-list">
             {flowStory.map((line, idx) => <li key={`flow-${idx}`} className="bs-list-item">{line}</li>)}
+          </ul>
+        </div>
+      ) : null}
+
+      {developmentFlash.length ? (
+        <div className="bs-storylines-box" data-testid="game-development-flash">
+          <h5>Development flash</h5>
+          <ul className="bs-list">
+            {developmentFlash.map((line: string, idx: number) => <li key={`dev-flash-${idx}`} className="bs-list-item">{line}</li>)}
           </ul>
         </div>
       ) : null}

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -103,6 +103,7 @@ import NewsEngine, { createNewsItem, addNewsItem } from '../core/news-engine.js'
 import { calculateAwardRaces } from '../core/awards-logic.js';
 import { Constants } from '../core/constants.js';
 import { processPlayerProgression } from '../core/progression-logic.js';
+import { processWeeklyEvolution } from '../core/progression/evolutionEngine.ts';
 import { evaluateRetirements }     from '../core/retirement-system.js';
 import { runAIToAITrades, generateAITradeProposalsForUser, evaluateCounterOffer } from '../core/trade-logic.js';
 import { processSeasonRecords, createEmptyRecords, getMostPlayedTeam } from '../core/records.js';
@@ -2390,6 +2391,35 @@ async function handleAdvanceWeek(payload, id) {
     post(toUI.NOTIFICATION, { level: 'info', message: 'Weekly simulation ran on the AttributesV2 engine.' });
   }
 
+  // SAFETY: If simulation produced 0 results, don't advance the week
+  if (results.length === 0) {
+    console.error(`[Worker] ADVANCE_WEEK: simulation returned 0 results for week ${week} (${gamesToSim.length} games attempted) — aborting advance.`);
+    post(toUI.WEEK_COMPLETE, {
+      week,
+      results:    [],
+      standings:  buildStandings(),
+      nextWeek:   week,       // stay on same week
+      phase:      cache.getPhase(),
+      isSeasonOver: false,
+    }, id);
+    post(toUI.STATE_UPDATE, buildViewState());
+    post(toUI.NOTIFICATION, { level: 'warn', message: `Week ${week} simulation failed — please try again.`, retryable: true });
+    return;
+  }
+
+  const evolutionOutcome = applyWeeklyEvolution({
+    week,
+    seasonId,
+    results,
+    metaObj: meta,
+  });
+  if (!evolutionOutcome.skipped && evolutionOutcome.developmentEvents.length > 0) {
+    post(toUI.NOTIFICATION, {
+      level: 'info',
+      message: `Weekly development updated for ${evolutionOutcome.developmentEvents.length} players from game usage and production.`,
+    });
+  }
+
   // Apply each game result to cache and emit GAME_EVENT per game
   for (const res of results) {
     applyGameResultToCache(res, week, seasonId);
@@ -2442,22 +2472,6 @@ async function handleAdvanceWeek(payload, id) {
         teamDriveStats: res.teamDriveStats ?? null,
       });
     }
-  }
-
-  // SAFETY: If simulation produced 0 results, don't advance the week
-  if (results.length === 0) {
-    console.error(`[Worker] ADVANCE_WEEK: simulation returned 0 results for week ${week} (${gamesToSim.length} games attempted) — aborting advance.`);
-    post(toUI.WEEK_COMPLETE, {
-      week,
-      results:    [],
-      standings:  buildStandings(),
-      nextWeek:   week,       // stay on same week
-      phase:      cache.getPhase(),
-      isSeasonOver: false,
-    }, id);
-    post(toUI.STATE_UPDATE, buildViewState());
-    post(toUI.NOTIFICATION, { level: 'warn', message: `Week ${week} simulation failed — please try again.`, retryable: true });
-    return;
   }
 
   // --- Advance week / phase ---
@@ -3145,7 +3159,9 @@ function applyGameResultToCache(result, week, seasonId) {
       playerOfGame: playerLeaders?.playerOfGame ?? null,
       standoutPerformances: playerLeaders?.standouts ?? [],
       storyline,
+      developmentFlash: Array.isArray(result?.developmentFlash) ? result.developmentFlash.slice(0, 2) : [],
     },
+    developmentFlash: Array.isArray(result?.developmentFlash) ? result.developmentFlash.slice(0, 2) : [],
     teamStats,
     turningPoints,
     notablePerformances: playerLeaders?.standouts ?? [],
@@ -3189,6 +3205,101 @@ function buildStandings() {
 function winPct(t) {
   const g = (t.wins ?? 0) + (t.losses ?? 0) + (t.ties ?? 0);
   return g === 0 ? 0 : ((t.wins ?? 0) + (t.ties ?? 0) * 0.5) / g;
+}
+
+function normalizeWeeklyDevelopmentMeta(metaObj = {}) {
+  return {
+    ...(metaObj?.developmentModel ?? {}),
+    version: 1,
+    lastEvolutionStamp: metaObj?.developmentModel?.lastEvolutionStamp ?? null,
+  };
+}
+
+function buildTeamDevelopmentFocusMap(metaObj = ensureDynastyMeta(cache.getMeta())) {
+  const map = {};
+  for (const team of cache.getAllTeams()) {
+    const focus = team?.weeklyDevelopmentFocus ?? {};
+    map[String(team.id)] = {
+      trainingFocus: team?.franchiseInvestments?.trainingFocus ?? 'balanced',
+      intensity: focus?.intensity ?? 'normal',
+      drillType: focus?.drillType ?? 'technique',
+      positionGroups: Array.isArray(focus?.positionGroups) ? focus.positionGroups : [],
+    };
+  }
+  return map;
+}
+
+function applyWeeklyEvolution({ week, seasonId, results, metaObj }) {
+  const stamp = `${seasonId}:${week}`;
+  const model = normalizeWeeklyDevelopmentMeta(metaObj);
+  if (model.lastEvolutionStamp === stamp) {
+    return { skipped: true, stamp, developmentEvents: [] };
+  }
+
+  const evolution = processWeeklyEvolution({
+    players: cache.getAllPlayers(),
+    results,
+    week,
+    seasonId,
+    seed: buildDeterministicSeed({ year: Number(metaObj?.year ?? 2025), week, salt: 'weekly_evolution_v1' }),
+    teamFocusByTeamId: buildTeamDevelopmentFocusMap(metaObj),
+  });
+
+  const gameFlashByPlayer = new Map();
+  for (const event of evolution.developmentEvents) {
+    if (!event?.note) continue;
+    if (!gameFlashByPlayer.has(event.playerId)) gameFlashByPlayer.set(event.playerId, []);
+    const list = gameFlashByPlayer.get(event.playerId);
+    if (list.length < 2) list.push(event.note);
+  }
+
+  for (const update of evolution.updates) {
+    const player = cache.getPlayer(update.playerId);
+    if (!player) continue;
+    const history = Array.isArray(player?.growthHistory) ? player.growthHistory : [];
+    const trimmedHistory = [...history.slice(-23), update.growthHistoryEntry];
+    cache.updatePlayer(update.playerId, {
+      attributesV2: update.attributesV2,
+      attributeXp: update.attributeXp,
+      growthHistory: trimmedHistory,
+      lastEvolutionWeek: evolution.stamp,
+    });
+  }
+
+  const weeklyLog = Array.isArray(metaObj?.weeklyDevelopmentLog) ? metaObj.weeklyDevelopmentLog : [];
+  const nextLogEntry = {
+    stamp: evolution.stamp,
+    seasonId,
+    week,
+    summary: evolution.summary,
+    events: evolution.developmentEvents.slice(0, 20),
+  };
+  const nextWeeklyLog = [...weeklyLog.slice(-23), nextLogEntry];
+  cache.setMeta({
+    developmentModel: { ...model, lastEvolutionStamp: evolution.stamp },
+    weeklyDevelopmentLog: nextWeeklyLog,
+  });
+
+  for (const result of results) {
+    const sideBoxes = [
+      ...(Object.keys(result?.boxScore?.home ?? {})),
+      ...(Object.keys(result?.boxScore?.away ?? {})),
+    ];
+    const notes = [];
+    for (const playerId of sideBoxes) {
+      const playerNotes = gameFlashByPlayer.get(String(playerId)) ?? [];
+      for (const note of playerNotes) {
+        if (!notes.includes(note)) notes.push(note);
+        if (notes.length >= 2) break;
+      }
+      if (notes.length >= 2) break;
+    }
+    if (notes.length > 0) {
+      result.developmentFlash = notes.slice(0, 2);
+    }
+  }
+
+  return { skipped: false, stamp: evolution.stamp, developmentEvents: evolution.developmentEvents };
 }
 
 // ── Handler: SIM_TO_WEEK ─────────────────────────────────────────────────────
@@ -5319,6 +5430,15 @@ async function handleConductDrill({ teamId, intensity, drillType, positionGroups
             (POS_GROUP_MAP[grp] || [grp]).forEach(pos => activePosSet.add(pos));
         }
     }
+
+    cache.updateTeam(numId, {
+      weeklyDevelopmentFocus: {
+        intensity: intensity || 'normal',
+        drillType: drillType || 'technique',
+        positionGroups: Array.from(focusSet),
+        stamp: `${meta?.currentSeasonId ?? 1}:${meta?.currentWeek ?? 1}`,
+      },
+    });
 
     // Drill type bonus: Technique/Conditioning/TeamDrills/FilmStudy
     // Each unlocks slightly different boosts


### PR DESCRIPTION
### Motivation
- Provide a deterministic, performance-focused weekly progression foundation that makes real usage/production, age, and minimal training focus drive attribute growth/regression. 
- Keep the change small-surface: core engine + safe persistence + worker lifecycle wiring + tiny UI signal for postgame surfacing.

### Description
- New engine: added `src/core/progression/evolutionEngine.ts` implementing `processWeeklyEvolution(input)` which: derives per-attribute XP from box-score usage/production, applies age-curve growth/regression multipliers, applies lightweight team/training focus multipliers, converts XP into bounded attribute deltas, and returns deterministic updates + concise development events; includes league parity guardrails to cap net positive growth. 
- Worker lifecycle integration: wired evolution to run once after weekly simulation in `src/worker/worker.js` (idempotent via `developmentModel.lastEvolutionStamp`), applies updates to players safely (updates `attributesV2`, `attributeXp`, appends `growthHistory`, sets `lastEvolutionWeek`), and writes a concise `weeklyDevelopmentLog` to meta. 
- Training bridge (foundation): `CONDUCT_DRILL` now persists a minimal `weeklyDevelopmentFocus` on the team (intensity, drillType, positionGroups, stamp) so the evolution engine can consume it without a TrainingHub rewrite. 
- Minimal UI surfacing: attach up to two deterministic `developmentFlash` notes to archived game payloads and show a compact “Development flash” section in `GameDetailV2` (clinical, max 1–2 notes). 
- Safe persistence & migration: bumped save schema to `5.6` and added safe defaults and migrations for `developmentModel` and `weeklyDevelopmentLog`; also added per-player defaults (`attributeXp`, `growthHistory`, `lastEvolutionWeek`) in state migration/initialization. 

### Testing
- Unit tests added: `src/core/__tests__/evolutionEngine.test.ts` (starter vs bench growth, veteran maintenance/regression, determinism, anti-inflation guardrail) and `src/state/saveSchema.test.js` (migration defaults). 
- Ran targeted unit test suite: `vitest` executed `evolutionEngine.test.ts`, `saveSchema.test.js`, and existing `weekSimulationBridge` tests; all tests passed (10/10 assertions across the targeted files). 
- Notes: determinism enforced by avoiding uncontrolled randomness (seeded/deterministic math, no use of `Math.random()` in engine-critical conversions) and idempotency via a season:week stamp to prevent double application on reloads.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e31c0129b0832da28a842f7b6d33e6)