### PR TITLE
Guard new-save bootstrap: finalize pending slot and enter shell only after minimum-playable league

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -52,7 +52,12 @@ import { SettingsProvider, useSettings } from './context/SettingsContext.jsx';
 import { ACTION_LABELS } from './constants/navigationCopy.js';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from './utils/boxScoreAccess.js';
 import { buildOffseasonActionCenter } from './utils/offseasonActionCenter.js';
-import { hasMinimumPlayableLeague, summarizeBootstrapState } from './utils/leagueBootstrap.js';
+import {
+  hasMinimumPlayableLeague,
+  shouldFinalizeNewSlotBootstrap,
+  shouldShowNewFranchiseBootstrapGate,
+  summarizeBootstrapState,
+} from './utils/leagueBootstrap.js';
 import { clearWeeklyPrepForWeek, pruneWeeklyPrepStorage } from './utils/weeklyPrep.js';
 import { buildCanonicalGameId } from '../core/gameIdentity.js';
 import { getRecentGames, saveGame } from '../core/archive/gameArchive.ts';
@@ -137,6 +142,12 @@ function AppContent() {
   const [postGameResult, setPostGameResult] = useState(null);
   const [initFlow, setInitFlow] = useState(null);
   const archiveMigrationRef = useRef(null);
+  const leagueReady = hasMinimumPlayableLeague(league);
+  const isNewFranchiseBootstrapping = shouldShowNewFranchiseBootstrapGate({
+    league,
+    pendingNewSlot,
+    initFlowMode: initFlow?.mode,
+  });
 
   // Local guard to prevent rapid-click double submission before 'busy' propagates
   const advancingRef = useRef(false);
@@ -210,10 +221,10 @@ function AppContent() {
 
   // Auto-save when user navigates away
   useEffect(() => {
-    const handler = () => { if (league && activeSlot) actions.saveSlot(activeSlot); };
+    const handler = () => { if (leagueReady && activeSlot) actions.saveSlot(activeSlot); };
     window.addEventListener('beforeunload', handler);
     return () => window.removeEventListener('beforeunload', handler);
-  }, [league, activeSlot, actions]);
+  }, [leagueReady, activeSlot, actions]);
 
   // ── Handlers ──────────────────────────────────────────────────────────────
 
@@ -340,7 +351,7 @@ function AppContent() {
         e.preventDefault();
         if (typeof handleAdvanceWeek === 'function') handleAdvanceWeek();
       } else if (e.key === 's' || e.key === 'S') {
-        if (!busy && league) {
+        if (!busy && leagueReady) {
           if (activeSlot) actions.saveSlot(activeSlot);
         }
       } else if (e.key === '?') {
@@ -349,7 +360,7 @@ function AppContent() {
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [league, busy, postGameResult, promptUserGame, userGameLogs, handleAdvanceWeek, actions]);
+  }, [league, busy, leagueReady, postGameResult, promptUserGame, userGameLogs, handleAdvanceWeek, actions, activeSlot]);
 
   // Expose state and actions to window for E2E testing
   useEffect(() => {
@@ -368,7 +379,7 @@ function AppContent() {
 
 
   useEffect(() => {
-    if (!league || !activeSlot) return;
+    if (!leagueReady || !activeSlot) return;
     const slotNum = activeSlot?.split('_')?.[2];
     if (!slotNum) return;
     const userTeam = Array.isArray(league?.teams) ? league.teams.find(t => t?.id === league?.userTeamId) : null;
@@ -383,7 +394,7 @@ function AppContent() {
       lastSaved: new Date().toISOString(),
     };
     localStorage.setItem(`footballgm_slot_${slotNum}_meta`, JSON.stringify(nextMeta));
-  }, [league, activeSlot]);
+  }, [leagueReady, league, activeSlot]);
 
   useEffect(() => {
     if (!league) return;
@@ -403,7 +414,7 @@ function AppContent() {
   }, [league?.seasonId, league?.year, league?.week, league?.userTeamId]);
 
   useEffect(() => {
-    if (!league || !pendingNewSlot) return;
+    if (!shouldFinalizeNewSlotBootstrap({ league, pendingNewSlot })) return;
     actions.saveSlot(pendingNewSlot);
     setActiveSlot(pendingNewSlot);
     setPendingNewSlot(null);
@@ -604,13 +615,37 @@ function AppContent() {
   }
 
   const bootstrapSummary = summarizeBootstrapState(league);
-  const leagueReady = bootstrapSummary.ready;
   const userTeam = league?.teams?.find(t => t.id === league.userTeamId);
   const isCutdownRequired = league.phase === 'preseason' && (userTeam?.rosterCount ?? 0) > 53;
 
   const isPostseason = league?.phase === 'playoffs';
 
   const themeClass = league?.phase ? `theme-${league.phase}` : 'theme-default';
+
+  if (isNewFranchiseBootstrapping) {
+    return (
+      <div className="app-loading">
+        <div className="app-loading-spinner" />
+        <p className="app-loading-text">
+          Loading playable league state… {bootstrapSummary.reasons[0] ?? 'Preparing franchise data.'}
+        </p>
+        {initFlow?.timedOut && (
+          <div role="alert" className="app-banner app-banner-error" style={{ marginTop: 12 }}>
+            <span>{initFlow.message}</span>
+            <div style={{ display: 'inline-flex', gap: 8, marginLeft: 10 }}>
+              <button className="btn btn-primary app-banner-btn" onClick={() => setActiveView('new_league')}>
+                Retry Setup
+              </button>
+              <button className="btn app-banner-btn" onClick={() => { setActiveSlot(null); setActiveView('saves'); }}>
+                Back to Slots
+              </button>
+            </div>
+          </div>
+        )}
+        <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+      </div>
+    );
+  }
 
   return (
     <div className={`app-shell ${isPostseason ? 'postseason' : ''} ${themeClass}`} key="league_dashboard" data-testid="app-shell-ready">

--- a/src/ui/components/__tests__/freshSaveScreens.test.jsx
+++ b/src/ui/components/__tests__/freshSaveScreens.test.jsx
@@ -68,6 +68,16 @@ describe('fresh save core screens', () => {
     )).not.toThrow();
   });
 
+  it('keeps extracted dashboard surfaces safe when league is null/partial', () => {
+    expect(() => renderToString(
+      <LeagueDashboard league={null} actions={actions} busy={false} simulating={false} onAdvanceWeek={() => {}} />,
+    )).not.toThrow();
+
+    expect(() => renderToString(
+      <LeagueDashboard league={{ teams: [], userTeamId: 0, phase: 'preseason' }} actions={actions} busy={false} simulating={false} onAdvanceWeek={() => {}} />,
+    )).not.toThrow();
+  });
+
   it('renders trade workspace without offers', () => {
     expect(() => renderToString(
       <TradeWorkspace league={freshLeague} actions={actions} onPlayerSelect={() => {}} initialView="Offers" />,

--- a/src/ui/utils/leagueBootstrap.js
+++ b/src/ui/utils/leagueBootstrap.js
@@ -20,3 +20,14 @@ export function summarizeBootstrapState(league) {
   if (!hasUserTeam) reasons.push('Your team assignment is still resolving.');
   return { ready: hasMinimumPlayableLeague(league), reasons };
 }
+
+export function shouldFinalizeNewSlotBootstrap({ league, pendingNewSlot }) {
+  if (!pendingNewSlot) return false;
+  return hasMinimumPlayableLeague(league);
+}
+
+export function shouldShowNewFranchiseBootstrapGate({ league, pendingNewSlot, initFlowMode }) {
+  if (initFlowMode !== 'new') return false;
+  if (!pendingNewSlot) return false;
+  return !hasMinimumPlayableLeague(league);
+}

--- a/src/ui/utils/leagueBootstrap.test.js
+++ b/src/ui/utils/leagueBootstrap.test.js
@@ -1,11 +1,17 @@
 import { describe, it, expect } from 'vitest';
-import { hasMinimumPlayableLeague, summarizeBootstrapState } from './leagueBootstrap.js';
+import {
+  hasMinimumPlayableLeague,
+  shouldFinalizeNewSlotBootstrap,
+  shouldShowNewFranchiseBootstrapGate,
+  summarizeBootstrapState,
+} from './leagueBootstrap.js';
 
 describe('league bootstrap guards', () => {
   it('accepts minimal playable league payload', () => {
     expect(hasMinimumPlayableLeague({
       phase: 'regular',
       week: 1,
+      userTeamId: 0,
       teams: [{ id: 0, name: 'A' }],
     })).toBe(true);
   });
@@ -14,5 +20,38 @@ describe('league bootstrap guards', () => {
     const summary = summarizeBootstrapState({ teams: [], userTeamId: 0 });
     expect(summary.ready).toBe(false);
     expect(summary.reasons.length).toBeGreaterThan(0);
+  });
+
+  it('does not finalize pending slot save for partial new-league payloads', () => {
+    expect(shouldFinalizeNewSlotBootstrap({
+      pendingNewSlot: 'save_slot_1',
+      league: { teams: [{ id: 4 }], userTeamId: 4 },
+    })).toBe(false);
+  });
+
+  it('finalizes pending slot save when minimum playable league is ready', () => {
+    expect(shouldFinalizeNewSlotBootstrap({
+      pendingNewSlot: 'save_slot_1',
+      league: {
+        phase: 'preseason',
+        week: 1,
+        userTeamId: 4,
+        teams: [{ id: 4 }],
+      },
+    })).toBe(true);
+  });
+
+  it('gates main dashboard during new franchise bootstrap, but not existing-slot flow', () => {
+    expect(shouldShowNewFranchiseBootstrapGate({
+      pendingNewSlot: 'save_slot_1',
+      initFlowMode: 'new',
+      league: { teams: [{ id: 3 }], userTeamId: 3 },
+    })).toBe(true);
+
+    expect(shouldShowNewFranchiseBootstrapGate({
+      pendingNewSlot: null,
+      initFlowMode: 'load',
+      league: { teams: [{ id: 3 }], userTeamId: 3 },
+    })).toBe(false);
   });
 });


### PR DESCRIPTION
### Motivation
- A newly created franchise was treated as "ready" as soon as a non-null `league` object existed, which let App effects write slot metadata, trigger `saveSlot`, and transition into the main shell while the league payload was still partial.  This produced mixed UI states and could wedge a new save in a partial-loading state.  
- The goal is to ensure new-slot finalization, slot saves, and shell/dashboard entry only occur after `hasMinimumPlayableLeague(league)` is true, while leaving existing-slot load/save flows unchanged and preserving the extracted dashboard surfaces from prior refactors.

### Description
- Added two bootstrap helpers in `src/ui/utils/leagueBootstrap.js`: `shouldFinalizeNewSlotBootstrap(...)` and `shouldShowNewFranchiseBootstrapGate(...)`, which are thin wrappers around `hasMinimumPlayableLeague(...)` to express intent for the new-slot flow.  
- In `src/ui/App.jsx` gated all save/metadata effects for new saves: the `beforeunload` auto-save, the slot metadata mirror effect, manual keyboard `S` save, and the `pendingNewSlot` finalize `useEffect` now require the minimum-playable check (via the new helpers) before writing or clearing slot state.  
- Introduced a single authoritative bootstrap gate in `App` that keeps new-franchise users in a dedicated loading UI while their league is still bootstrapping (timeout/retry/back-to-slots behavior preserved), preventing premature shell/dashboard interactions.  
- Added regression tests and a safety regression ensuring extracted dashboard surfaces stay safe with `null` or partial league payloads (tests updated in `src/ui/utils/leagueBootstrap.test.js` and `src/ui/components/__tests__/freshSaveScreens.test.jsx`).

### Testing
- Ran unit tests for the modified areas with Vitest using: `npm run test:unit -- src/ui/utils/leagueBootstrap.test.js src/ui/components/__tests__/freshSaveScreens.test.jsx`.  
- Results: both test files passed (all tests green): 2 test files, 11 tests total — all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e387d25848832dab1c29c622b0c287)