### PR TITLE
Stabilize attributesV2 derived-rating sync in evolution passes

### DIFF
--- a/src/worker/__tests__/playerDerivedRatings.test.js
+++ b/src/worker/__tests__/playerDerivedRatings.test.js
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { calculateOverallFromAttributesV2, derivePlayerVisibleRatingsPatch } from '../playerDerivedRatings.js';
+
+function makeAttrs(value) {
+  return {
+    release: value,
+    routeRunning: value,
+    separation: value,
+    catchInTraffic: value,
+    ballTracking: value,
+    throwAccuracyShort: value,
+    throwAccuracyDeep: value,
+    throwPower: value,
+    decisionMaking: value,
+    pocketPresence: value,
+    passBlockFootwork: value,
+    passBlockStrength: value,
+    passRush: value,
+    pressCoverage: value,
+    zoneCoverage: value,
+  };
+}
+
+describe('playerDerivedRatings', () => {
+  it('stays build/runtime safe when attributesV2 players have no ratings object', () => {
+    const player = { id: 11, pos: 'QB', attributesV2: makeAttrs(82) };
+    const patch = derivePlayerVisibleRatingsPatch(player, player.attributesV2);
+
+    expect(patch).toBeTruthy();
+    expect(patch.ovr).toBe(82);
+    expect(patch.ratings.overall).toBe(82);
+    expect(patch.ratings.ovr).toBe(82);
+  });
+
+  it('synchronizes visible ovr fields from offseason attributesV2 updates', () => {
+    const player = {
+      id: 7,
+      pos: 'WR',
+      ovr: 70,
+      ratings: { overall: 70, ovr: 70 },
+      attributesV2: makeAttrs(70),
+    };
+
+    const boosted = {
+      ...makeAttrs(70),
+      release: 88,
+      routeRunning: 87,
+      separation: 90,
+      catchInTraffic: 84,
+      ballTracking: 86,
+    };
+
+    const patch = derivePlayerVisibleRatingsPatch(player, boosted);
+    expect(patch.ovr).toBeGreaterThan(player.ovr);
+    expect(patch.ratings.overall).toBe(patch.ovr);
+  });
+
+  it('is deterministic and legacy-safe in mixed-mode saves', () => {
+    const attrPlayer = { id: 1, pos: 'LB', attributesV2: makeAttrs(76) };
+    const legacyPlayer = { id: 2, pos: 'LB', ovr: 73 };
+
+    const first = calculateOverallFromAttributesV2(attrPlayer, attrPlayer.attributesV2);
+    const second = calculateOverallFromAttributesV2(attrPlayer, attrPlayer.attributesV2);
+    const legacy = derivePlayerVisibleRatingsPatch(legacyPlayer, legacyPlayer.attributesV2);
+
+    expect(first).toBe(second);
+    expect(legacy).toBeNull();
+  });
+});

--- a/src/worker/playerDerivedRatings.js
+++ b/src/worker/playerDerivedRatings.js
@@ -1,0 +1,180 @@
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+const POSITION_ATTRIBUTE_WEIGHTS = {
+  QB: [
+    ['throwAccuracyShort', 0.24],
+    ['throwAccuracyDeep', 0.22],
+    ['throwPower', 0.2],
+    ['decisionMaking', 0.2],
+    ['pocketPresence', 0.14],
+  ],
+  RB: [
+    ['decisionMaking', 0.28],
+    ['separation', 0.2],
+    ['catchInTraffic', 0.2],
+    ['ballTracking', 0.16],
+    ['passBlockStrength', 0.16],
+  ],
+  FB: [
+    ['passBlockStrength', 0.28],
+    ['passBlockFootwork', 0.24],
+    ['decisionMaking', 0.2],
+    ['catchInTraffic', 0.14],
+    ['separation', 0.14],
+  ],
+  WR: [
+    ['release', 0.22],
+    ['routeRunning', 0.24],
+    ['separation', 0.24],
+    ['catchInTraffic', 0.15],
+    ['ballTracking', 0.15],
+  ],
+  TE: [
+    ['routeRunning', 0.18],
+    ['catchInTraffic', 0.22],
+    ['ballTracking', 0.16],
+    ['passBlockFootwork', 0.18],
+    ['passBlockStrength', 0.26],
+  ],
+  OL: [
+    ['passBlockFootwork', 0.48],
+    ['passBlockStrength', 0.37],
+    ['decisionMaking', 0.15],
+  ],
+  C: [
+    ['passBlockFootwork', 0.48],
+    ['passBlockStrength', 0.37],
+    ['decisionMaking', 0.15],
+  ],
+  G: [
+    ['passBlockFootwork', 0.48],
+    ['passBlockStrength', 0.37],
+    ['decisionMaking', 0.15],
+  ],
+  T: [
+    ['passBlockFootwork', 0.48],
+    ['passBlockStrength', 0.37],
+    ['decisionMaking', 0.15],
+  ],
+  DL: [
+    ['passRush', 0.45],
+    ['passBlockStrength', 0.2],
+    ['decisionMaking', 0.2],
+    ['pressCoverage', 0.15],
+  ],
+  DE: [
+    ['passRush', 0.45],
+    ['passBlockStrength', 0.2],
+    ['decisionMaking', 0.2],
+    ['pressCoverage', 0.15],
+  ],
+  DT: [
+    ['passRush', 0.45],
+    ['passBlockStrength', 0.2],
+    ['decisionMaking', 0.2],
+    ['pressCoverage', 0.15],
+  ],
+  NT: [
+    ['passRush', 0.45],
+    ['passBlockStrength', 0.2],
+    ['decisionMaking', 0.2],
+    ['pressCoverage', 0.15],
+  ],
+  EDGE: [
+    ['passRush', 0.45],
+    ['passBlockStrength', 0.2],
+    ['decisionMaking', 0.2],
+    ['pressCoverage', 0.15],
+  ],
+  LB: [
+    ['passRush', 0.27],
+    ['zoneCoverage', 0.24],
+    ['pressCoverage', 0.2],
+    ['decisionMaking', 0.29],
+  ],
+  MLB: [
+    ['passRush', 0.27],
+    ['zoneCoverage', 0.24],
+    ['pressCoverage', 0.2],
+    ['decisionMaking', 0.29],
+  ],
+  OLB: [
+    ['passRush', 0.27],
+    ['zoneCoverage', 0.24],
+    ['pressCoverage', 0.2],
+    ['decisionMaking', 0.29],
+  ],
+  CB: [
+    ['pressCoverage', 0.34],
+    ['zoneCoverage', 0.32],
+    ['ballTracking', 0.18],
+    ['release', 0.16],
+  ],
+  S: [
+    ['zoneCoverage', 0.32],
+    ['pressCoverage', 0.26],
+    ['ballTracking', 0.2],
+    ['decisionMaking', 0.22],
+  ],
+  FS: [
+    ['zoneCoverage', 0.32],
+    ['pressCoverage', 0.26],
+    ['ballTracking', 0.2],
+    ['decisionMaking', 0.22],
+  ],
+  SS: [
+    ['zoneCoverage', 0.32],
+    ['pressCoverage', 0.26],
+    ['ballTracking', 0.2],
+    ['decisionMaking', 0.22],
+  ],
+};
+
+function numeric(value, fallback = 50) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function normalizePosition(pos) {
+  const value = String(pos ?? '').toUpperCase();
+  if (['LT', 'RT', 'LG', 'RG', 'OT', 'OG'].includes(value)) return 'T';
+  if (['HB'].includes(value)) return 'RB';
+  if (['DB'].includes(value)) return 'CB';
+  if (['ILB'].includes(value)) return 'LB';
+  return value;
+}
+
+function fallbackOverall(attributesV2) {
+  const values = Object.values(attributesV2 ?? {})
+    .map((value) => numeric(value, NaN))
+    .filter((value) => Number.isFinite(value));
+  if (!values.length) return 50;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+export function calculateOverallFromAttributesV2(player, attributesV2 = player?.attributesV2) {
+  if (!attributesV2 || typeof attributesV2 !== 'object') return null;
+  const position = normalizePosition(player?.pos);
+  const weights = POSITION_ATTRIBUTE_WEIGHTS[position] ?? [];
+
+  if (!weights.length) {
+    return clamp(Math.round(fallbackOverall(attributesV2)), 25, 99);
+  }
+
+  const weighted = weights.reduce((sum, [key, weight]) => sum + (numeric(attributesV2[key], 50) * weight), 0);
+  return clamp(Math.round(weighted), 25, 99);
+}
+
+export function derivePlayerVisibleRatingsPatch(player, attributesV2 = player?.attributesV2) {
+  const nextOverall = calculateOverallFromAttributesV2(player, attributesV2);
+  if (!Number.isFinite(nextOverall)) return null;
+  const ratings = {
+    ...(player?.ratings ?? {}),
+    overall: nextOverall,
+    ovr: nextOverall,
+  };
+  return {
+    ovr: nextOverall,
+    ratings,
+  };
+}

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -105,6 +105,7 @@ import { Constants } from '../core/constants.js';
 import { processPlayerProgression } from '../core/progression-logic.js';
 import { processOffseasonEvolution, processWeeklyEvolution } from '../core/progression/evolutionEngine.ts';
 import { buildTeamDevelopmentFocusMap as buildCanonicalDevelopmentFocusMap } from './developmentFocus.js';
+import { derivePlayerVisibleRatingsPatch } from './playerDerivedRatings.js';
 import { evaluateRetirements }     from '../core/retirement-system.js';
 import { runAIToAITrades, generateAITradeProposalsForUser, evaluateCounterOffer } from '../core/trade-logic.js';
 import { processSeasonRecords, createEmptyRecords, getMostPlayedTeam } from '../core/records.js';
@@ -452,6 +453,7 @@ function deriveTeamUnitRatings(teamId) {
     defRating: def,
     offOvr: off,
     defOvr: def,
+    ovr: averageOvr(roster),
   };
 }
 
@@ -3282,11 +3284,13 @@ function applyWeeklyEvolution({ week, seasonId, results, metaObj }) {
     if (!player) continue;
     const history = Array.isArray(player?.growthHistory) ? player.growthHistory : [];
     const trimmedHistory = [...history.slice(-23), update.growthHistoryEntry];
+    const visibleRatingsPatch = derivePlayerVisibleRatingsPatch(player, update.attributesV2);
     cache.updatePlayer(update.playerId, {
       attributesV2: update.attributesV2,
       attributeXp: update.attributeXp,
       growthHistory: trimmedHistory,
       lastEvolutionWeek: evolution.stamp,
+      ...(visibleRatingsPatch ?? {}),
     });
   }
 
@@ -7600,16 +7604,19 @@ async function handleAdvanceOffseason(payload, id) {
     seed: buildDeterministicSeed({ year: Number(meta?.year ?? 2025), week: 0, salt: 'offseason_evolution_v1' }),
     teamFocusByTeamId: focusByTeamId,
   });
+  const touchedAttrTeamIds = new Set();
   for (const update of offseasonEvolution.updates) {
     const player = cache.getPlayer(update.playerId);
     if (!player) continue;
     const history = Array.isArray(player?.growthHistory) ? player.growthHistory : [];
+    const visibleRatingsPatch = derivePlayerVisibleRatingsPatch(player, update.attributesV2);
     cache.updatePlayer(update.playerId, {
       attributesV2: update.attributesV2,
       attributeXp: update.attributeXp,
       growthHistory: [...history.slice(-23), update.growthHistoryEntry],
       lastEvolutionWeek: offseasonEvolution.stamp,
       progressionDelta: Number(update?.growthHistoryEntry?.totalDelta ?? 0),
+      ...(visibleRatingsPatch ?? {}),
       developmentHistory: [...(Array.isArray(player?.developmentHistory) ? player.developmentHistory.slice(-11) : []), {
         season: Number(meta?.year ?? 2025),
         phase: 'offseason',
@@ -7617,6 +7624,12 @@ async function handleAdvanceOffseason(payload, id) {
         totalDelta: Number(update?.growthHistoryEntry?.totalDelta ?? 0),
       }],
     });
+    const teamId = resolvePlayerTeamId(player);
+    if (teamId != null) touchedAttrTeamIds.add(teamId);
+  }
+
+  for (const teamId of touchedAttrTeamIds) {
+    cache.updateTeam(teamId, deriveTeamUnitRatings(teamId));
   }
 
   // Backward compatibility: keep the legacy progression path for players that


### PR DESCRIPTION
### Motivation
- The worker-side evolution path was updating `attributesV2`/XP/history but not the user-visible rating fields (`player.ovr`, `player.ratings.overall/ovr`) that many UI slices and team rollups consume, causing stale displays after progression rather than a syntax/build error. 
- Ensure attributesV2 players produce consistent, deterministic visible ratings after both weekly and offseason evolution without changing the progression architecture.
- Preserve legacy fallback behavior for players without `attributesV2` and keep the worker as source-of-truth.

### Description
- Added `src/worker/playerDerivedRatings.js` which deterministically maps `attributesV2` → visible `ovr` and `ratings.overall` using position-weighted attribute weights and clamping (`calculateOverallFromAttributesV2`, `derivePlayerVisibleRatingsPatch`).
- Wired the derived-rating sync into the worker update paths so evolution writes now include the visible patch: applied in `applyWeeklyEvolution` and in `handleAdvanceOffseason` inside `src/worker/worker.js` (minimal changes to call `derivePlayerVisibleRatingsPatch` and spread the patch into `cache.updatePlayer`).
- After offseason attributesV2 updates, recompute affected team unit ratings (including team-level `ovr`) by collecting touched teamIds and calling `deriveTeamUnitRatings(teamId)` and `cache.updateTeam(...)` to keep team displays consistent.
- Small team-rating improvement: `deriveTeamUnitRatings` now includes `ovr: averageOvr(roster)` so team `ovr` reflects up-to-date player `ovr` averages.
- Added targeted tests at `src/worker/__tests__/playerDerivedRatings.test.js` covering runtime-safe patching when `ratings` is missing, visible OVR sync after attributes changes, and deterministic/legacy behavior in mixed-mode saves.

### Testing
- Built production bundle with `npm run build` and the build completed successfully (Vite build output, no fatal errors). — succeeded.
- Ran targeted unit tests with `vitest` for the new/related slices: `npm run test:unit -- src/worker/__tests__/playerDerivedRatings.test.js src/worker/__tests__/developmentFocus.test.js src/core/progression/__tests__/evolutionEngine.test.js src/ui/components/__tests__/FranchiseHQ.test.jsx`, and all targeted tests passed. — succeeded.
- Ran full unit test suite `npm run test:unit` to surface unrelated regressions; the full run still contains pre-existing unrelated failures across several suites (e.g., Playwright spec ingestion, selectors/ownerMessages/shellNavigation, and some progression tests) which are outside the scope of this stabilization change. — full-suite failed (unrelated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e686b3190c832d81caf4ed324f30d5)