### PR TITLE
Stabilize franchise bootstrap flow and add phased hardening backlog

### DIFF
--- a/docs/PHASED_STABILITY_BACKLOG.md
+++ b/docs/PHASED_STABILITY_BACKLOG.md
@@ -1,0 +1,80 @@
+# Football GM Sim phased hardening backlog
+
+This backlog is intentionally scoped to reliability and core GM loop UX before any broad feature expansion.
+
+## Must-fix (Phase 1: stability and trust)
+
+1. **Franchise bootstrap state clarity + recovery**
+   - **User problem:** Loading a save or starting a franchise can look stalled with unclear next action.
+   - **Fix:** Add explicit in-progress slot state, contextual retry actions (retry load vs retry setup), and visible recovery copy.
+   - **Manual verify:** Start/load a slot, interrupt network/worker, confirm clear error + retry path.
+
+2. **Loading-gate reliability around save metadata writes**
+   - **User problem:** Corrupted local slot metadata can throw during autosave metadata sync and create brittle startup behavior.
+   - **Fix:** Guard slot metadata parse/write path and default safely.
+   - **Manual verify:** Corrupt `footballgm_slot_X_meta` in localStorage and ensure app still enters playable franchise.
+
+3. **Error action routing should not mutate simulation state incorrectly**
+   - **User problem:** Global error retry currently uses week-advance action even for load/setup failures.
+   - **Fix:** Route retry by context (load/new/reload) rather than simulation actions.
+   - **Manual verify:** Force load failure and ensure retry does `loadSlot`, not `advanceWeek`.
+
+## Should-fix (Phase 2: core GM loop UX, highest value first)
+
+1. **Dashboard quick triage strip**
+   - Show team need summary, cap red flags, and pending decisions at top of HQ.
+2. **Transactions IA split**
+   - Separate Team actions vs League feed vs Trade workspace with clear labels.
+3. **Box score affordances**
+   - Standardize “Open Game Book” entry points on dashboard ticker, weekly results, and schedule cards.
+4. **Roster/depth chart flow friction**
+   - Keep depth and roster action bars pinned while scrolling on dense tables.
+
+## Nice-to-have (Phase 3+)
+
+1. Visual hierarchy standardization pass (cards, headers, spacing, badges).
+2. Mobile-first 375px optimization for dense roster/contracts tables.
+3. Performance pass: memoize heavy transforms in dashboard and transaction screens.
+4. Accessibility pass: landmark structure + heading levels + keyboard trap audits.
+
+## Manual QA checklist (run after each reliability/core-loop batch)
+
+### Dashboard
+1. Load an existing slot and verify HQ renders without console errors.
+2. Confirm top actions: Advance, Sim to phase, Save, Slots, Reset.
+3. Confirm error banner retry uses contextual action (load/setup/reload).
+
+### Roster management
+1. Open Team → Roster.
+2. Release/sign/update a player.
+3. Verify state reflects in roster count and salary cap panel.
+
+### Depth chart edits
+1. Open Team → Depth Chart.
+2. Make several rapid reorder changes.
+3. Verify final ordering persists after navigation + save/load.
+
+### Game result review
+1. Sim one week in regular season.
+2. Open result from ticker and Weekly Results center.
+3. Verify box score opens with recap + team/player stat sections.
+
+### Transactions
+1. Open Transactions center and inspect latest actions.
+2. Submit/accept/reject one trade flow.
+3. Confirm notifications and roster/cap updates are consistent.
+
+### Draft flow
+1. Enter draft phase.
+2. Open Draft/Draft Room, make user pick, simulate AI picks.
+3. Confirm next pick state and board updates are deterministic.
+
+### Free agency
+1. Enter Free Agency.
+2. Submit offers/sign player.
+3. Advance FA day and verify contract/cap changes and transaction log.
+
+### Week advance
+1. Advance week from preseason/regular/playoffs.
+2. Verify deterministic week progression and standings update.
+3. Confirm no duplicate simulations from rapid clicks.

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -148,6 +148,7 @@ function AppContent() {
     pendingNewSlot,
     initFlowMode: initFlow?.mode,
   });
+  const loadingSlot = initFlow?.active ? initFlow?.slotKey ?? null : null;
 
   // Local guard to prevent rapid-click double submission before 'busy' propagates
   const advancingRef = useRef(false);
@@ -383,8 +384,13 @@ function AppContent() {
     const slotNum = activeSlot?.split('_')?.[2];
     if (!slotNum) return;
     const userTeam = Array.isArray(league?.teams) ? league.teams.find(t => t?.id === league?.userTeamId) : null;
-    const existingRaw = localStorage.getItem(`footballgm_slot_${slotNum}_meta`);
-    const existing = existingRaw ? JSON.parse(existingRaw) : {};
+    let existing = {};
+    try {
+      const existingRaw = localStorage.getItem(`footballgm_slot_${slotNum}_meta`);
+      existing = existingRaw ? JSON.parse(existingRaw) : {};
+    } catch {
+      existing = {};
+    }
     const nextMeta = {
       name: existing?.name ?? `Franchise ${slotNum}`,
       teamName: userTeam?.name ?? userTeam?.abbr ?? 'Unknown Team',
@@ -460,6 +466,26 @@ function AppContent() {
 
   const safePhase = league?.phase ?? null;
   const canUseTopActions = !!safePhase && !(busy || simulating || isBatchSimBlocking);
+  const retryLabel = initFlow?.mode === 'load' ? 'Retry Load' : initFlow?.mode === 'new' ? 'Retry Setup' : 'Reload App';
+  const handlePrimaryRetry = () => {
+    if (initFlow?.mode === 'load' && initFlow?.slotKey) {
+      setInitFlow((prev) => prev ? { ...prev, active: true, timedOut: false, message: '' } : prev);
+      actions.loadSlot(initFlow.slotKey).catch((err) => {
+        setInitFlow((prev) => prev ? {
+          ...prev,
+          active: true,
+          timedOut: true,
+          message: `Failed to load franchise: ${err?.message ?? 'unknown error'}`,
+        } : prev);
+      });
+      return;
+    }
+    if (initFlow?.mode === 'new') {
+      setActiveView('new_league');
+      return;
+    }
+    window.location.reload();
+  };
 
   const topSecondaryAction = useMemo(() => {
     if (!safePhase) return null;
@@ -586,6 +612,14 @@ function AppContent() {
                   message: '',
                 });
               }}
+              onCreateError={(err) => {
+                setInitFlow((prev) => prev ? {
+                  ...prev,
+                  active: true,
+                  timedOut: true,
+                  message: `Failed to create league: ${err?.message ?? 'unknown error'}`,
+                } : prev);
+              }}
               onCancel={() => setActiveView('saves')}
             />
           </div>
@@ -598,10 +632,19 @@ function AppContent() {
           {initTimeoutPanel}
           <SaveSlotManager
             activeSlot={activeSlot}
+            loadingSlot={loadingSlot}
+            loadingLabel={initFlow?.mode === 'load' ? 'Loading franchise state…' : 'Preparing franchise setup…'}
             onLoad={(slotKey) => {
               setInitFlow({ active: true, mode: 'load', slotKey, timedOut: false, message: '' });
               setActiveSlot(slotKey);
-              actions.loadSlot(slotKey);
+              actions.loadSlot(slotKey).catch((err) => {
+                setInitFlow((prev) => prev?.slotKey === slotKey ? {
+                  ...prev,
+                  active: true,
+                  timedOut: true,
+                  message: `Failed to load franchise: ${err?.message ?? 'unknown error'}`,
+                } : prev);
+              });
             }}
             onSave={(slotKey) => { setActiveSlot(slotKey); actions.saveSlot(slotKey); }}
             onDelete={(slotKey) => { actions.deleteSlot(slotKey); if (activeSlot === slotKey) setActiveSlot(null); }}
@@ -839,8 +882,8 @@ function AppContent() {
       {error && (
         <div role="alert" className="app-banner app-banner-error">
           <span>{error}</span>
-          <button className="btn app-banner-btn" onClick={handleAdvanceWeek} disabled={busy || simulating}>
-            Retry
+          <button className="btn app-banner-btn" onClick={handlePrimaryRetry} disabled={busy || simulating}>
+            {retryLabel}
           </button>
         </div>
       )}

--- a/src/ui/components/NewLeagueSetup.jsx
+++ b/src/ui/components/NewLeagueSetup.jsx
@@ -49,7 +49,7 @@ const SCHEDULE_BALANCE_OPTIONS = [
   { value: "conference-heavy", label: "Conference Heavy" },
 ];
 
-export default function NewLeagueSetup({ actions, onCancel, onStartCreate }) {
+export default function NewLeagueSetup({ actions, onCancel, onStartCreate, onCreateError }) {
   // Step management
   const [step, setStep] = useState(0); // 0: team, 1: settings, 2: confirm
 
@@ -145,10 +145,12 @@ export default function NewLeagueSetup({ actions, onCancel, onStartCreate }) {
           leagueName: leagueName || `${selectedTeamData?.name || "My"} Dynasty`,
         },
       });
+    } catch (err) {
+      onCreateError?.(err);
     } finally {
       setCreating(false);
     }
-  }, [selectedTeam, year, difficulty, leagueName, selectedTeamData, playoffFormat, draftOrder, salaryCap, godMode, injuryFrequency, tradeRealism, seasonLength, playoffTeams, capFloor, progressionVolatility, regressionSeverity, scoutingFogStrength, ownerPatienceStrictness, playerMoodVolatility, staffImpactStrength, freeAgencyAggressiveness, leagueSize, draftRounds, scheduleBalancePreset, conferenceNames, divisionNames, actions, onStartCreate]);
+  }, [selectedTeam, year, difficulty, leagueName, selectedTeamData, playoffFormat, draftOrder, salaryCap, godMode, injuryFrequency, tradeRealism, seasonLength, playoffTeams, capFloor, progressionVolatility, regressionSeverity, scoutingFogStrength, ownerPatienceStrictness, playerMoodVolatility, staffImpactStrength, freeAgencyAggressiveness, leagueSize, draftRounds, scheduleBalancePreset, conferenceNames, divisionNames, actions, onStartCreate, onCreateError]);
 
   const canProceed = step === 0 ? selectedTeam !== null : true;
 

--- a/src/ui/components/SaveSlotManager.jsx
+++ b/src/ui/components/SaveSlotManager.jsx
@@ -47,7 +47,15 @@ export function createSlotActionHandlers({ onLoad, onSave }, slotKey) {
   };
 }
 
-export default function SaveSlotManager({ activeSlot, onLoad, onSave, onDelete, onNew }) {
+export default function SaveSlotManager({
+  activeSlot,
+  onLoad,
+  onSave,
+  onDelete,
+  onNew,
+  loadingSlot = null,
+  loadingLabel = 'Loading franchise…',
+}) {
   const [editing, setEditing] = useState(null);
   const [value, setValue] = useState('');
   const [refreshKey, setRefreshKey] = useState(0);
@@ -74,6 +82,8 @@ export default function SaveSlotManager({ activeSlot, onLoad, onSave, onDelete, 
       {slots.map((slot) => {
         const isActive = activeSlot === slot.key;
         const isEmpty = !slot.meta?.lastSaved;
+        const isLoadingThisSlot = loadingSlot === slot.key;
+        const disableSlotActions = Boolean(loadingSlot);
         const slotName = slot.meta?.name ?? `Franchise ${slot.slotNum}`;
         const accent = teamAccent(slot.meta);
         const slotActions = createSlotActionHandlers({ onLoad, onSave }, slot.key);
@@ -92,11 +102,11 @@ export default function SaveSlotManager({ activeSlot, onLoad, onSave, onDelete, 
                 {isActive && <Badge>Active</Badge>}
                 {editing === slot.slotNum ? (
                   <>
-                    <input value={value} onChange={(e) => setValue(e.target.value)} aria-label={`Rename slot ${slot.slotNum}`} />
-                    <Button size="sm" onClick={() => persistName(slot.slotNum)}>Save</Button>
+                    <input value={value} onChange={(e) => setValue(e.target.value)} aria-label={`Rename slot ${slot.slotNum}`} disabled={disableSlotActions} />
+                    <Button size="sm" onClick={() => persistName(slot.slotNum)} disabled={disableSlotActions}>Save</Button>
                   </>
                 ) : (
-                  <Button variant="ghost" size="sm" onClick={() => { setEditing(slot.slotNum); setValue(slotName); }}>Rename</Button>
+                  <Button variant="ghost" size="sm" onClick={() => { setEditing(slot.slotNum); setValue(slotName); }} disabled={disableSlotActions}>Rename</Button>
                 )}
               </div>
             </CardHeader>
@@ -118,15 +128,20 @@ export default function SaveSlotManager({ activeSlot, onLoad, onSave, onDelete, 
                   </div>
 
                   <div className="save-slot-v2__actions">
-                    <Button onClick={slotActions.onEnterFranchise}>Enter Franchise</Button>
-                    <Button variant="secondary" onClick={slotActions.onSaveChanges}>Save Changes</Button>
+                    <Button onClick={slotActions.onEnterFranchise} disabled={disableSlotActions}>Enter Franchise</Button>
+                    <Button variant="secondary" onClick={slotActions.onSaveChanges} disabled={disableSlotActions}>Save Changes</Button>
                     <Button variant="destructive" onClick={() => {
                       if (!window.confirm('Delete this slot? This clears all franchise data in this slot.')) return;
                       localStorage.removeItem(`footballgm_slot_${slot.slotNum}_meta`);
                       onDelete?.(slot.key);
                       setRefreshKey((k) => k + 1);
-                    }}>Delete</Button>
+                    }} disabled={disableSlotActions}>Delete</Button>
                   </div>
+                  {isLoadingThisSlot && (
+                    <p role="status" style={{ marginTop: 10, fontSize: 13, color: 'var(--text-muted)' }}>
+                      {loadingLabel}
+                    </p>
+                  )}
                 </>
               )}
             </CardContent>


### PR DESCRIPTION
### Motivation
- The franchise bootstrap, save/load, and init flows could stall or surface unclear retry paths, making the app feel unreliable and blocking the core GM loop.
- Startup failures and malformed local slot metadata could cause brittle behavior during autosave/metadata sync and prevent clean entry to a playable franchise.
- Provide clear, contextual recovery (retry load vs retry setup vs reload) while preserving deterministic simulation behavior and avoiding UI-driven state mutations that could desync league state.

### Description
- Add slot-level loading UX to `SaveSlotManager` by accepting `loadingSlot` and `loadingLabel` props, disabling mutating actions while a slot is in-progress, and showing an inline loading status. (`src/ui/components/SaveSlotManager.jsx`)
- Harden `App.jsx` bootstrap flow by tracking `loadingSlot` from `initFlow`, safely parsing `footballgm_slot_*_meta` with a JSON fallback, passing loading state into the slot manager, and surfacing contextual retry behavior via `handlePrimaryRetry` that retries `loadSlot`, re-enters `new_league`, or reloads the app as appropriate. (`src/ui/App.jsx`)
- Make `NewLeagueSetup` surface create failures to the app shell by adding `onCreateError` and reporting errors back to the `initFlow` so users see explicit failure messages and recovery options. (`src/ui/components/NewLeagueSetup.jsx`)
- Add a prioritized, phase-driven backlog and manual QA checklist focused on stability-first hardening in `docs/PHASED_STABILITY_BACKLOG.md` to guide subsequent phases of the refactor.

### Testing
- Ran the unit tests via `npm run test:unit -- src/worker/__tests__/loadPipelineRegression.test.js src/worker/__tests__/saveIntegrity.test.js src/ui/components/BoxScore.test.jsx` and they all passed (3 files, 11 tests passed).
- No automated regressions were introduced in the exercised test surface; manual QA steps are documented in the included backlog for further verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c3af0998832da0062390b05a88f7)