### PR TITLE
Polish core GM loop UX on HQ, results cards, and Game Book

### DIFF
--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -510,34 +510,19 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
                 </ul>
               </div>
             )}
+            {!!momentumNotes.length && (
+              <div className="bs-storylines-box" style={{ marginTop: 16 }}>
+                <h5>Recap narrative</h5>
+                <ul className="bs-list">
+                  {momentumNotes.slice(0, expanded ? 8 : 4).map((note, idx) => (
+                    <li key={`momentum-${idx}`} className="bs-list-item">{note?.text ?? note}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </section>
 
           <GameDetailV2 game={game} awayTeam={awayTeam} homeTeam={homeTeam} />
-
-          {hasTeamLeaders && (
-            <section className="bs-section" data-testid="team-leaders">
-              <h4>Team leaders</h4>
-              <div className="bs-team-groups">
-                {[{ side: "away", team: awayTeam }, { side: "home", team: homeTeam }].map(({ side, team }) => {
-                  const rows = teamLeaders?.[side] ?? {};
-                  return (
-                    <div key={side} className="bs-team-group">
-                      <h5>{team?.abbr ?? side.toUpperCase()}</h5>
-                      <div className="bs-list">
-                        <TeamLeaderCell label="Passing" player={rows.passing} statKeys={["passComp", "passAtt", "passYd", "passTD", "interceptions"]} onPlayerSelect={onPlayerSelect} />
-                        <TeamLeaderCell label="Rushing" player={rows.rushing} statKeys={["rushAtt", "rushYd", "rushTD"]} onPlayerSelect={onPlayerSelect} />
-                        <TeamLeaderCell label="Receiving" player={rows.receiving} statKeys={["receptions", "recYd", "recTD"]} onPlayerSelect={onPlayerSelect} />
-                        <TeamLeaderCell label="Tackles" player={rows.tackles} statKeys={["tackles", "sacks"]} onPlayerSelect={onPlayerSelect} />
-                        <TeamLeaderCell label="Sacks" player={rows.sacks} statKeys={["sacks", "tackles"]} onPlayerSelect={onPlayerSelect} />
-                        <TeamLeaderCell label="Interceptions" player={rows.interceptions} statKeys={["interceptions", "passesDefended"]} onPlayerSelect={onPlayerSelect} />
-                        <TeamLeaderCell label="Kicking" player={rows.kicking} statKeys={["fieldGoalsMade", "fieldGoalsAttempted", "extraPointsMade", "extraPointsAttempted"]} onPlayerSelect={onPlayerSelect} />
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </section>
-          )}
 
           <section className="bs-section" ref={(node) => { sectionRefs.current.team = node; }} data-section="team">
             <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
@@ -568,6 +553,31 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
               )}
             </div>
           </section>
+
+          {hasTeamLeaders && (
+            <section className="bs-section" data-testid="team-leaders">
+              <h4>Player leaders</h4>
+              <div className="bs-team-groups">
+                {[{ side: "away", team: awayTeam }, { side: "home", team: homeTeam }].map(({ side, team }) => {
+                  const rows = teamLeaders?.[side] ?? {};
+                  return (
+                    <div key={side} className="bs-team-group">
+                      <h5>{team?.abbr ?? side.toUpperCase()}</h5>
+                      <div className="bs-list">
+                        <TeamLeaderCell label="Passing" player={rows.passing} statKeys={["passComp", "passAtt", "passYd", "passTD", "interceptions"]} onPlayerSelect={onPlayerSelect} />
+                        <TeamLeaderCell label="Rushing" player={rows.rushing} statKeys={["rushAtt", "rushYd", "rushTD"]} onPlayerSelect={onPlayerSelect} />
+                        <TeamLeaderCell label="Receiving" player={rows.receiving} statKeys={["receptions", "recYd", "recTD"]} onPlayerSelect={onPlayerSelect} />
+                        <TeamLeaderCell label="Tackles" player={rows.tackles} statKeys={["tackles", "sacks"]} onPlayerSelect={onPlayerSelect} />
+                        <TeamLeaderCell label="Sacks" player={rows.sacks} statKeys={["sacks", "tackles"]} onPlayerSelect={onPlayerSelect} />
+                        <TeamLeaderCell label="Interceptions" player={rows.interceptions} statKeys={["interceptions", "passesDefended"]} onPlayerSelect={onPlayerSelect} />
+                        <TeamLeaderCell label="Kicking" player={rows.kicking} statKeys={["fieldGoalsMade", "fieldGoalsAttempted", "extraPointsMade", "extraPointsAttempted"]} onPlayerSelect={onPlayerSelect} />
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          )}
 
           {sections.scoringSummary && (
             <section className="bs-section" ref={(node) => { sectionRefs.current.scoring = node; }} data-section="scoring">

--- a/src/ui/components/BoxScore.test.jsx
+++ b/src/ui/components/BoxScore.test.jsx
@@ -79,7 +79,7 @@ describe('BoxScore postgame command center', () => {
     );
 
     expect(html).toContain('Standout storylines');
-    expect(html).toContain('Team leaders');
+    expect(html).toContain('Player leaders');
     expect(html).toContain('Scoring summary');
     expect(html).toContain('Game flow &amp; momentum');
   });

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -23,6 +23,7 @@ import {
   getActionContext,
   getActionDestination,
   rankHqPriorityItems,
+  getTeamSnapshotNotes,
 } from "../utils/hqHelpers.js";
 import { deriveWeeklyPrepState, markWeeklyPrepStep } from "../utils/weeklyPrep.js";
 
@@ -159,6 +160,13 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdva
   const ownerApproval = safeNum(weekly?.pressurePoints?.ownerApproval ?? vm.league?.ownerApproval ?? vm.league?.ownerMood, null);
   const expiringCount = safeNum(weekly?.pressurePoints?.expiringCount);
   const rosterCount = Array.isArray(team?.roster) ? team.roster.length : safeNum(team?.rosterCount, 0);
+  const snapshotNotes = getTeamSnapshotNotes(team, weekly, cap.capRoom);
+  const nextDecision = rankedPriorities.featured ?? null;
+  const topNeedRows = previewPriorities.filter((item) => String(item?.tab ?? "").toLowerCase().includes("team")).slice(0, 3);
+  const injuryRows = (team?.roster ?? [])
+    .filter((player) => safeNum(player?.injury?.gamesRemaining ?? player?.injuryWeeksRemaining, 0) > 0)
+    .sort((a, b) => safeNum(b?.ovr, 0) - safeNum(a?.ovr, 0))
+    .slice(0, 3);
 
   return (
     <div className="app-screen-stack franchise-hq">
@@ -197,21 +205,18 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdva
       </div>
       {lineupToast ? <p className="app-inline-toast">{lineupToast}</p> : null}
 
-      <SectionCard title="Priority Rail" subtitle="Top front-office actions this week." variant="compact">
-        <div className="app-priority-rail">
-          {previewPriorities.length > 0 ? previewPriorities.map((item, idx) => (
-            <CompactInsightCard
-              key={`${item.label}-${idx}`}
-              title={item.label}
-              subtitle={item.detail}
-              tone={getSeverityTone(item.level)}
-              ctaLabel={item.verb || "Review"}
-              onCta={() => onNavigate?.(item?.tab ?? "Team")}
-            />
-          )) : (
-            <CompactInsightCard title="No urgent blockers" subtitle="Use this week to gain edges in prep and depth." tone="info" ctaLabel="Open Team" onCta={() => onNavigate?.("Team:Overview")} />
-          )}
-        </div>
+      <SectionCard title="Next Action" subtitle="Your highest-priority decision this week." variant="compact">
+        {nextDecision ? (
+          <CompactListRow
+            title={nextDecision.label}
+            subtitle={nextDecision.detail}
+            meta={<StatusChip label={nextDecision.level === "urgent" ? "Urgent" : "Recommended"} tone={getSeverityTone(nextDecision.level)} />}
+          >
+            <Button size="sm" onClick={() => onNavigate?.(nextDecision?.tab ?? "Team")}>{nextDecision.verb ?? "Open task"}</Button>
+          </CompactListRow>
+        ) : (
+          <CompactInsightCard title="No urgent blockers" subtitle="Use this week to gain edges in prep and depth." tone="info" ctaLabel="Open Team" onCta={() => onNavigate?.("Team:Overview")} />
+        )}
       </SectionCard>
       {developmentSummary.rising.length > 0 && (
         <SectionCard title="Development Outlook" subtitle="Risers and breakout candidates." variant="compact">
@@ -230,7 +235,7 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdva
         </SectionCard>
       )}
 
-      <SectionHeader eyebrow="Team status" title="Snapshot" subtitle="Roster and cap in one line." />
+      <SectionHeader eyebrow="Team status" title="Command Snapshot" subtitle="Core team state in one pass." />
       <StatStrip items={[
         { label: "OVR", value: `${safeNum(team?.ovr, 0)}`, tone: "team" },
         { label: "Cap Room", value: formatMoneyM(cap.capRoom), tone: cap.capRoom < 10 ? "warning" : "ok" },
@@ -238,7 +243,24 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdva
         { label: "Expiring", value: `${expiringCount}`, tone: expiringCount >= 8 ? "warning" : "neutral" },
       ]} />
 
-      <SectionCard title="Last Result" variant="compact">
+      <SectionCard title="Team Health Snapshot" subtitle="Current injuries and availability impact." variant="compact">
+        <div className="app-row-stack">
+          {injuryRows.length === 0 ? (
+            <CompactInsightCard title="No active injuries" subtitle="Primary rotation is currently available." tone="ok" />
+          ) : injuryRows.map((player) => (
+            <CompactListRow
+              key={player.id}
+              title={`${player.name} · ${player.pos}`}
+              subtitle={`${safeNum(player?.injury?.gamesRemaining ?? player?.injuryWeeksRemaining, 0)} game(s) out`}
+              meta={<StatusChip label="Unavailable" tone="warning" />}
+            >
+              <Button size="sm" variant="ghost" onClick={() => onNavigate?.("Team:Injuries")}>Injury report</Button>
+            </CompactListRow>
+          ))}
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Latest Game Result" subtitle="Open full recap and box score." variant="compact">
         {lastGame ? (
           <CompactListRow
             title={`${lastGame.userWon ? "Win" : "Loss"} · Week ${lastGame.week ?? vm.league?.week ?? 1}`}
@@ -269,11 +291,38 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdva
         )}
       </SectionCard>
 
+      <SectionCard title="Cap & Contracts Snapshot" subtitle="Financial pressure and expiration risk." variant="compact">
+        <div className="app-priority-rail">
+          <CompactInsightCard title={formatMoneyM(cap.capRoom)} subtitle={snapshotNotes.capNote} tone={cap.capRoom < 5 ? "warning" : "ok"} ctaLabel="Open cap" onCta={() => onNavigate?.("💰 Cap")} />
+          <CompactInsightCard title={`${expiringCount} expiring`} subtitle={snapshotNotes.expiringNote} tone={expiringCount >= 6 ? "warning" : "info"} ctaLabel="Contracts" onCta={() => onNavigate?.("Team:Contracts")} />
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Top Roster Needs" subtitle="Where depth or planning work should happen next." variant="compact">
+        <div className="app-priority-rail">
+          {topNeedRows.length > 0 ? topNeedRows.map((item, idx) => (
+            <CompactInsightCard
+              key={`${item.label}-${idx}`}
+              title={item.label}
+              subtitle={item.detail}
+              tone={getSeverityTone(item.level)}
+              ctaLabel={item.verb || "Open"}
+              onCta={() => onNavigate?.(item?.tab ?? "Team")}
+            />
+          )) : (
+            <CompactInsightCard title={snapshotNotes.rosterNote} subtitle="No high-priority roster alarms this week." tone="ok" ctaLabel="Roster / Depth" onCta={() => onNavigate?.("Team:Roster / Depth")} />
+          )}
+        </div>
+      </SectionCard>
+
       <section className="app-teaser-strip card">
-        <CompactListRow title="League Results" subtitle="Open full recap and spotlight games." meta={<StatusChip label="League" tone="league" />}>
+        <CompactListRow title="Team View" subtitle="Roster, depth chart, contracts, and injuries." meta={<StatusChip label="Team" tone="team" />}>
+          <Button size="sm" variant="ghost" onClick={() => onNavigate?.("Team:Overview")}>Open Team Hub</Button>
+        </CompactListRow>
+        <CompactListRow title="League View" subtitle="Standings, weekly scores, and spotlight games." meta={<StatusChip label="League" tone="league" />}>
           <Button size="sm" variant="ghost" onClick={() => onNavigate?.("League:Results")}>Open Results</Button>
         </CompactListRow>
-        <CompactListRow title="Owner Mandate" subtitle={ownerApproval == null ? "Approval unavailable" : `Approval ${ownerApproval}`} meta={<StatusChip label="HQ" tone={ownerApproval != null && ownerApproval < 55 ? "warning" : "info"} />}>
+        <CompactListRow title="Recent Team / League News" subtitle={ownerApproval == null ? "Approval unavailable" : `Owner approval ${ownerApproval}`} meta={<StatusChip label="News" tone={ownerApproval != null && ownerApproval < 55 ? "warning" : "info"} />}>
           <Button size="sm" variant="ghost" onClick={() => onNavigate?.("🤖 GM Advisor")}>Open Advisor</Button>
         </CompactListRow>
       </section>

--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -29,7 +29,7 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
       <ScreenHeader
         eyebrow="Game Book"
         title="Game Book"
-        subtitle="Final score, recap narrative, team comparison, and player box score in one place."
+        subtitle="Scan the final, review the recap narrative, compare team stats, then drill into player leaders and play detail."
         onBack={onBack}
         backLabel="Back"
         primaryAction={<StatusChip label="Command View" tone="info" />}
@@ -39,7 +39,7 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
           { label: 'Week', value: weekFromId ?? '—' },
         ]}
       />
-      <SectionCard variant="info" title="Game Book Detail" subtitle="Box score, recap, and player-level logs.">
+      <SectionCard variant="info" title="Game Book Detail" subtitle="Summary → Team stats → Player leaders → Drive/play recap.">
         <BoxScorePanel
           gameId={gameId}
           actions={actions}

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -213,8 +213,8 @@ const BASE_TABS = [
 
 const NAV_GROUPS = [
   { id: SHELL_SECTIONS.hq, title: "HQ", tabs: ["HQ"] },
-  { id: SHELL_SECTIONS.team, title: "Team", tabs: ["Team", "Roster", "Depth Chart", "Weekly Prep", "Game Plan", "Training", "Injuries", "Staff", "Financials", "Contract Center"] },
-  { id: SHELL_SECTIONS.league, title: "League", tabs: ["League", "Weekly Results", "Schedule", "Standings", "Stats", "League Leaders", "Transactions", "History Hub", "History", "Awards & Records", "Season Recap"] },
+  { id: SHELL_SECTIONS.team, title: "Team Management", tabs: ["Team", "Roster Hub", "Roster", "Depth Chart", "Weekly Prep", "Game Plan", "Training", "Injuries", "Staff", "Financials", "Contract Center", "💰 Cap"] },
+  { id: SHELL_SECTIONS.league, title: "League Office", tabs: ["League", "Weekly Results", "Schedule", "Standings", "Stats", "League Leaders", "Transactions", "Free Agency", "Draft", "History Hub", "History", "Awards & Records", "Season Recap"] },
   { id: SHELL_SECTIONS.news, title: "News", tabs: ["News"] },
 ];
 

--- a/src/ui/components/MobileNav.jsx
+++ b/src/ui/components/MobileNav.jsx
@@ -4,16 +4,10 @@ import { SHELL_SECTIONS } from '../utils/shellNavigation.js';
 
 const MORE_GROUPS = [
   {
-    title: 'Transactions',
+    title: 'Team Management',
     items: [
-      { id: 'Transactions', label: 'Trades', icon: TradesIcon },
-      { id: 'Free Agency', label: 'Free Agency', icon: FAIcon },
-      { id: 'Draft', label: 'Draft', icon: DraftIcon },
-    ],
-  },
-  {
-    title: 'Team Ops',
-    items: [
+      { id: 'Team:Overview', label: 'Team Hub', icon: HomeIcon },
+      { id: 'Team:Roster / Depth', label: 'Roster / Depth', icon: RosterIcon },
       { id: 'Staff', label: 'Staff', icon: StaffIcon },
       { id: 'Training', label: 'Training', icon: TrainingIcon },
       { id: 'Injuries', label: 'Injuries', icon: InjuryIcon },
@@ -22,8 +16,13 @@ const MORE_GROUPS = [
     ],
   },
   {
-    title: 'League + History',
+    title: 'League Office',
     items: [
+      { id: 'League:Overview', label: 'League Hub', icon: StandingsIcon },
+      { id: 'League:Results', label: 'Weekly Results', icon: StandingsIcon },
+      { id: 'Transactions', label: 'Trades', icon: TradesIcon },
+      { id: 'Free Agency', label: 'Free Agency', icon: FAIcon },
+      { id: 'Draft', label: 'Draft', icon: DraftIcon },
       { id: 'league-leaders', label: 'League Leaders', icon: StandingsIcon },
       { id: 'History Hub', label: 'History', icon: HomeIcon },
       { id: 'Analytics', label: 'Analytics', icon: AnalyticsIcon },

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -77,9 +77,9 @@ describe('FranchiseHQ', () => {
     expect(html).toContain('Game Plan');
     expect(html).toContain('Scout Opponent');
     expect(html).toContain('News &amp; Injuries');
-    expect(html).toContain('Priority Rail');
-    expect(html).toContain('Snapshot');
-    expect(html).toContain('Owner Mandate');
+    expect(html).toContain('Next Action');
+    expect(html).toContain('Command Snapshot');
+    expect(html).toContain('Recent Team / League News');
     expect(html).toContain('Open Results');
   });
 

--- a/src/ui/components/common/GameResultCards.jsx
+++ b/src/ui/components/common/GameResultCards.jsx
@@ -78,6 +78,8 @@ export function CompletedGameCard({
   const { awayWon, homeWon, tied } = winnerState(game);
   const interactive = Boolean(onOpen && (canOpenBoxScore || canOpenResult));
   const primaryLabel = canOpenBoxScore ? "Open box score" : canOpenResult ? "View result" : "Unavailable";
+  const detailRows = [summary, recap].filter(Boolean).slice(0, 2);
+  const outcomeLabel = tied ? "Tie" : awayWon ? `${away?.abbr} won` : homeWon ? `${home?.abbr} won` : "Final";
   return (
     <article className={`premium-game-card is-completed ${isUserGame ? "is-user-game" : ""} ${interactive ? "is-clickable" : "is-disabled"}`}>
       <div className="premium-game-card__head">
@@ -89,19 +91,29 @@ export function CompletedGameCard({
       </div>
       <button
         type="button"
-        className="premium-game-card__scoreblock"
+        className="premium-game-card__interactive"
         onClick={interactive ? onOpen : undefined}
         disabled={!interactive}
         aria-label={interactive ? `${primaryLabel}: ${away?.abbr} at ${home?.abbr}` : undefined}
       >
-        <TeamLine team={away} score={game?.awayScore} won={awayWon} side="away" />
-        <span className="premium-game-card__at">@</span>
-        <TeamLine team={home} score={game?.homeScore} won={homeWon} side="home" />
+        <div className="premium-game-card__scoreblock">
+          <TeamLine team={away} score={game?.awayScore} won={awayWon} side="away" />
+          <span className="premium-game-card__at">@</span>
+          <TeamLine team={home} score={game?.homeScore} won={homeWon} side="home" />
+        </div>
+        <div className="premium-game-card__statusline">
+          <strong>{outcomeLabel}</strong>
+          <span>{statusLabel ?? "Archive status unavailable"}</span>
+        </div>
+        {detailRows.length > 0 ? (
+          <ul className="premium-game-card__details">
+            {detailRows.map((detail, idx) => <li key={`${week}-${idx}`}>{detail}</li>)}
+          </ul>
+        ) : null}
+        <div className="premium-game-card__cta">
+          <span>{interactive ? `${primaryLabel} →` : "Game detail unavailable"}</span>
+        </div>
       </button>
-      <div className="premium-game-card__statusline">
-        <strong>{primaryLabel}</strong>
-        <span>{statusLabel ?? "Archive status unavailable"}</span>
-      </div>
       {!interactive ? (
         <div className={`premium-game-card__fallback ${archiveQuality === "partial" ? "is-partial" : "is-missing"}`}>
           <strong>{archiveQuality === "partial" ? "Partial archive available" : "Detailed box score unavailable"}</strong>
@@ -112,12 +124,6 @@ export function CompletedGameCard({
           </p>
           {summary ? <p>{summary}</p> : null}
           {recap ? <p>{recap}</p> : null}
-        </div>
-      ) : null}
-      {(tied || recap || summary) && interactive ? (
-        <div className="premium-game-card__story">
-          {summary ? <strong>{summary}</strong> : null}
-          <span>{recap ?? (tied ? "Final ended tied." : "Open game for full breakdown.")}</span>
         </div>
       ) : null}
       {secondaryActions ? <div className="premium-game-card__actions">{secondaryActions}</div> : null}

--- a/src/ui/styles/style.css
+++ b/src/ui/styles/style.css
@@ -7712,8 +7712,28 @@ details[open] .nav-summary::after {
   align-items: center;
   gap: 8px;
 }
-.premium-game-card__scoreblock { cursor: pointer; }
-.premium-game-card__scoreblock:disabled { cursor: default; opacity: .74; }
+.premium-game-card__interactive {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  display: grid;
+  gap: 8px;
+}
+.premium-game-card.is-clickable .premium-game-card__interactive { cursor: pointer; }
+.premium-game-card.is-disabled .premium-game-card__interactive { cursor: default; opacity: .84; }
+.premium-game-card.is-clickable:hover,
+.premium-game-card.is-clickable:focus-within {
+  border-color: color-mix(in oklab, var(--accent) 48%, var(--hairline));
+  box-shadow: 0 0 0 1px color-mix(in oklab, var(--accent) 26%, transparent);
+}
+.premium-game-card__interactive:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--accent) 64%, white 4%);
+  outline-offset: 2px;
+  border-radius: 10px;
+}
 .premium-game-card__at { color: var(--text-subtle); font-size: 11px; font-weight: 700; }
 .game-team-line { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; color: var(--text-muted); }
 .game-team-line.is-winner { color: var(--text); font-weight: 800; }
@@ -7722,7 +7742,22 @@ details[open] .nav-summary::after {
 .game-team-line__score { font-size: 20px; line-height: 1; font-weight: 900; }
 .premium-game-card__statusline { display: grid; gap: 2px; font-size: 12px; color: var(--text-muted); }
 .premium-game-card__statusline strong { color: var(--text); }
-.premium-game-card__story { border: 1px solid var(--hairline); border-radius: 8px; padding: 7px 8px; display: grid; gap: 2px; font-size: 12px; color: var(--text-muted); }
+.premium-game-card__details {
+  margin: 0;
+  padding: 0 0 0 16px;
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.premium-game-card__cta {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--accent);
+}
 .premium-game-card__fallback { border-radius: 8px; padding: 8px; font-size: 12px; display: grid; gap: 4px; }
 .premium-game-card__fallback.is-missing { border: 1px solid color-mix(in oklab, var(--warning) 50%, transparent); background: color-mix(in oklab, var(--warning) 12%, transparent); }
 .premium-game-card__fallback.is-partial { border: 1px solid color-mix(in oklab, var(--accent) 48%, transparent); background: color-mix(in oklab, var(--accent) 8%, transparent); }


### PR DESCRIPTION
### Motivation
- Make the weekly GM loop feel more purposeful and scannable without changing sim/save logic. 
- Surface the single next decision, recent result, injuries, cap pressure, and top roster needs immediately on HQ. 
- Make completed results and the Game Book feel interactive and rewarding to explore so players are incentivized to drill into recaps and box scores.

### Description
- Reworked `FranchiseHQ` into a compact GM command center with explicit modules: `Next Action`, `Command Snapshot`, `Team Health Snapshot`, `Latest Game Result`, `Cap & Contracts Snapshot`, `Top Roster Needs`, and clearer Team vs League entry CTAs (file: `src/ui/components/FranchiseHQ.jsx`).
- Upgraded completed game cards so the whole card is an interactive surface with clearer outcome label, 1–2 summary/detail rows, explicit CTA copy, and improved focus/hover affordances (files: `src/ui/components/common/GameResultCards.jsx`, `src/ui/styles/style.css`).
- Improved Box Score / Game Book flow by adding a recap narrative section, surfacing momentum/recap bullets, and reordering presentation to read Summary → Team Stats → Player Leaders → Drives/Plays (file: `src/ui/components/BoxScore.jsx` and `src/ui/components/GameDetailScreen.jsx`).
- Clarified Team vs League information architecture in shell/mobile navigation by grouping Team/League destinations and adding direct Team/League hub entries (files: `src/ui/components/LeagueDashboard.jsx`, `src/ui/components/MobileNav.jsx`).
- Minor UI polish and accessibility improvements: interactive card keyboard/focus states, CTA hierarchy, and small copy tweaks on Game Detail framing; updated a few unit tests to match new labels (tests: `FranchiseHQ.test.jsx`, `BoxScore.test.jsx`).

### Testing
- Ran the component unit tests with `npm run test:unit` targeting affected suites: `FranchiseHQ`, `BoxScore`, `GameDetailScreen`, `WeeklyResultsCenter`, `LeagueHub`, and `MobileNav` via the repository test command; all targeted unit tests passed (15 tests, 15 passed).
- Existing archive/data fallback behavior preserved and validated by the BoxScore tests that include partial/legacy payload cases which continued to render safely.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c7e7e9e8832da906529973c436a1)