### PR TITLE
Stabilize player profile modal with guarded selection and crash boundary

### DIFF
--- a/src/ui/components/Draft.jsx
+++ b/src/ui/components/Draft.jsx
@@ -18,6 +18,7 @@
 import React, { useState, useEffect, useMemo, useCallback } from "react";
 import TraitBadge from "./TraitBadge";
 import PlayerProfile from "./PlayerProfile";
+import PlayerProfileModalBoundary from "./PlayerProfileModalBoundary.jsx";
 import PlayerPreview from "./PlayerPreview";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from "@/components/ui/table";
@@ -2486,20 +2487,22 @@ export default function Draft({ league, actions, onNavigate = null }) {
 
       {/* Player profile modal — opened by clicking a prospect's name */}
       {profilePlayerId && (
-        <PlayerProfile
-          playerId={profilePlayerId}
-          onClose={() => setProfilePlayerId(null)}
-          actions={actions}
-          league={league}
-          isUserOnClock={
-            enrichedDraftState?.isUserPick &&
-            !enrichedDraftState?.isDraftComplete
-          }
-          onDraftPlayer={(pid) => {
-            handleDraftPlayer(pid);
-            setProfilePlayerId(null);
-          }}
-        />
+        <PlayerProfileModalBoundary playerId={profilePlayerId} onClose={() => setProfilePlayerId(null)}>
+          <PlayerProfile
+            playerId={profilePlayerId}
+            onClose={() => setProfilePlayerId(null)}
+            actions={actions}
+            league={league}
+            isUserOnClock={
+              enrichedDraftState?.isUserPick &&
+              !enrichedDraftState?.isDraftComplete
+            }
+            onDraftPlayer={(pid) => {
+              handleDraftPlayer(pid);
+              setProfilePlayerId(null);
+            }}
+          />
+        </PlayerProfileModalBoundary>
       )}
     </div>
   );

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -33,6 +33,7 @@ import HallOfFame from "./HallOfFame.jsx";
 import HistoryHub from "./HistoryHub.jsx";
 import TradeWorkspace from "./TradeWorkspace.jsx";
 import PlayerProfile from "./PlayerProfile.jsx";
+import PlayerProfileModalBoundary from "./PlayerProfileModalBoundary.jsx";
 import TeamProfile from "./TeamProfile.jsx";
 import Leaders from "./Leaders.jsx";
 import LeagueLeaders from "./LeagueLeaders.jsx";
@@ -1287,14 +1288,16 @@ export default function LeagueDashboard({
       {/* ── Player Profile modal ── */}
       {selectedPlayerId && (
         <TabErrorBoundary label="Player Profile">
-          <PlayerProfile
-            playerId={selectedPlayerId}
-            onClose={() => setSelectedPlayerId(null)}
-            actions={actions}
-            teams={league.teams}
-            league={league}
-            onNavigate={setActiveTab}
-          />
+          <PlayerProfileModalBoundary playerId={selectedPlayerId} onClose={() => setSelectedPlayerId(null)}>
+            <PlayerProfile
+              playerId={selectedPlayerId}
+              onClose={() => setSelectedPlayerId(null)}
+              actions={actions}
+              teams={league.teams}
+              league={league}
+              onNavigate={setActiveTab}
+            />
+          </PlayerProfileModalBoundary>
         </TabErrorBoundary>
       )}
 

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -334,6 +334,19 @@ function getTeamName(teamId, teams) {
   return getTeamIdentity(teamId, teams).name;
 }
 
+
+function PlayerProfileSkeleton() {
+  return (
+    <div style={{ padding: "var(--space-4)", display: "grid", gap: 10 }}>
+      <div style={{ height: 22, width: "42%", borderRadius: 8, background: "var(--surface-strong)" }} />
+      <div style={{ height: 14, width: "58%", borderRadius: 6, background: "var(--surface-strong)" }} />
+      <div style={{ height: 12, width: "100%", borderRadius: 6, background: "var(--surface-strong)" }} />
+      <div style={{ height: 12, width: "90%", borderRadius: 6, background: "var(--surface-strong)" }} />
+      <div style={{ height: 220, width: "100%", borderRadius: 10, background: "var(--surface-strong)" }} />
+    </div>
+  );
+}
+
 export default function PlayerProfile({
   playerId,
   onClose,
@@ -346,7 +359,6 @@ export default function PlayerProfile({
 }) {
 
   const [data, setData] = useState(null);
-  const [loadingLocal, setLoadingLocal] = useState(true);
   const [extending, setExtending] = useState(false);
   const [showProjections, setShowProjections] = useState(false);
   const [activeProfileTab, setActiveProfileTab] = useState("Overview");
@@ -381,6 +393,8 @@ export default function PlayerProfile({
     if (fetchedData) setData(fetchedData);
   }, [fetchedData]);
   const player = data?.player;
+  const playerMissing = !loading && !player;
+  const loadErrorMessage = requestError?.message || data?.error || null;
   const userTeam = useMemo(() => teams.find((t) => t.id === data?.meta?.userTeamId || t.id === player?.teamId), [teams, data?.meta?.userTeamId, player?.teamId]);
   const teamIntel = useMemo(() => buildTeamIntelligence(userTeam, { week: data?.meta?.week ?? 1 }), [userTeam, data?.meta?.week]);
   const isProspect = player?.status === "draft_eligible";
@@ -510,6 +524,47 @@ export default function PlayerProfile({
     [careerRows],
   );
 
+  if (playerMissing) {
+    return (
+      <div
+        onClick={onClose}
+        style={{
+          position: "fixed",
+          top: 0,
+          left: 0,
+          width: "100%",
+          height: "100%",
+          background: "rgba(0,0,0,0.6)",
+          zIndex: 9000,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <div
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            background: "var(--surface-elevated)",
+            width: "min(520px, 100%)",
+            borderRadius: 12,
+            border: "1px solid var(--hairline)",
+            padding: 16,
+            display: "grid",
+            gap: 10,
+          }}
+        >
+          <strong>Player profile unavailable</strong>
+          <div style={{ color: "var(--text-muted)", fontSize: "var(--text-sm)" }}>
+            {loadErrorMessage ? `Reason: ${loadErrorMessage}.` : "The selected player could not be loaded."}
+          </div>
+          <div>
+            <Button className="btn" onClick={onClose}>Close</Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div
       onClick={onClose}
@@ -594,7 +649,7 @@ export default function PlayerProfile({
           }}
         >
           {loading ? (
-            <div style={{ color: "var(--text-muted)" }}>Loading…</div>
+            <PlayerProfileSkeleton />
           ) : player ? (
             <div
               style={{

--- a/src/ui/components/PlayerProfileModalBoundary.jsx
+++ b/src/ui/components/PlayerProfileModalBoundary.jsx
@@ -1,0 +1,57 @@
+import React, { Component } from "react";
+
+export default class PlayerProfileModalBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.error("[PlayerProfileModalBoundary] Player modal render failed", {
+      error,
+      info,
+      playerId: this.props.playerId,
+    });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{
+          position: "fixed",
+          inset: 0,
+          background: "rgba(0,0,0,0.6)",
+          zIndex: 9000,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: 16,
+        }}>
+          <div style={{
+            width: "min(560px, 100%)",
+            borderRadius: 12,
+            border: "1px solid var(--hairline)",
+            background: "var(--surface-elevated)",
+            padding: 16,
+            display: "grid",
+            gap: 10,
+          }}>
+            <strong>We couldn’t open this player profile.</strong>
+            <div style={{ color: "var(--text-muted)", fontSize: 13 }}>
+              Try closing and reopening the profile. If this keeps happening, save and reload the franchise.
+            </div>
+            <div>
+              <button className="btn" onClick={this.props.onClose}>Close</button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -33,6 +33,7 @@ import TraitBadge from "./TraitBadge";
 import PlayerComparison from "./PlayerComparison.jsx";
 import PlayerCompareTray from "./PlayerCompareTray.jsx";
 import PlayerProfile from "./PlayerProfile.jsx";
+import PlayerProfileModalBoundary from "./PlayerProfileModalBoundary.jsx";
 import ExtensionNegotiationModal from "./ExtensionNegotiationModal.jsx";
 import { teamColor } from "../../data/team-utils.js";
 import { OFFENSIVE_SCHEMES, DEFENSIVE_SCHEMES } from "../../core/scheme-core.js";
@@ -2070,6 +2071,15 @@ export default function Roster({ league, actions, onPlayerSelect, onNavigate = n
   const [viewMode, setViewMode] = useState(initialConfig.safeView); // 'cards' | 'table' | 'depth'
   const [initialFilter, setInitialFilter] = useState(null);
   const [selectedPlayerId, setSelectedPlayerId] = useState(null);
+  const rosterPlayerIds = useMemo(() => new Set(players.map((p) => String(p?.id))), [players]);
+  const handlePlayerSelect = useCallback((playerId) => {
+    if (playerId == null) return;
+    if (rosterPlayerIds.has(String(playerId))) {
+      setSelectedPlayerId(playerId);
+      return;
+    }
+    console.warn("[Roster] Ignored invalid player selection", { playerId, teamId });
+  }, [rosterPlayerIds, teamId]);
 
   const fetchRoster = useCallback(async () => {
     if (teamId == null || !actions?.getRoster) return;
@@ -2346,9 +2356,7 @@ export default function Roster({ league, actions, onPlayerSelect, onNavigate = n
       {!loading && viewMode === "cards" && (
         <PlayerCardGrid
           players={players}
-          onPlayerSelect={(playerId) => {
-            if (playerId != null) setSelectedPlayerId(playerId);
-          }}
+          onPlayerSelect={handlePlayerSelect}
           phase={league?.phase}
           team={team}
           week={league?.week}
@@ -2365,9 +2373,7 @@ export default function Roster({ league, actions, onPlayerSelect, onNavigate = n
           team={team}
           week={league?.week}
           onRefetch={fetchRoster}
-          onPlayerSelect={(playerId) => {
-            if (playerId != null) setSelectedPlayerId(playerId);
-          }}
+          onPlayerSelect={handlePlayerSelect}
           phase={league?.phase}
           chemistry={chemistry}
           initialFilter={initialFilter}
@@ -2420,13 +2426,15 @@ export default function Roster({ league, actions, onPlayerSelect, onNavigate = n
         </CardContent></Card>
       )}
       {selectedPlayerId != null && (
-        <PlayerProfile
-          playerId={selectedPlayerId}
-          actions={actions}
-          teams={league?.teams ?? []}
-          league={league}
-          onClose={() => setSelectedPlayerId(null)}
-        />
+        <PlayerProfileModalBoundary playerId={selectedPlayerId} onClose={() => setSelectedPlayerId(null)}>
+          <PlayerProfile
+            playerId={selectedPlayerId}
+            actions={actions}
+            teams={league?.teams ?? []}
+            league={league}
+            onClose={() => setSelectedPlayerId(null)}
+          />
+        </PlayerProfileModalBoundary>
       )}
     </div>
   );

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import PlayerProfile from '../PlayerProfile.jsx';
+
+describe('PlayerProfile', () => {
+  it('renders safe unavailable state when no player id is provided', () => {
+    const html = renderToString(
+      <PlayerProfile
+        playerId={null}
+        onClose={vi.fn()}
+        actions={{ getPlayerCareer: vi.fn() }}
+        teams={[]}
+        league={{ teams: [], week: 1 }}
+      />,
+    );
+
+    expect(html).toContain('Player profile unavailable');
+    expect(html).toContain('Close');
+  });
+});

--- a/src/ui/components/__tests__/PlayerProfileModalBoundary.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfileModalBoundary.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import PlayerProfileModalBoundary from '../PlayerProfileModalBoundary.jsx';
+
+describe('PlayerProfileModalBoundary', () => {
+  it('renders children during normal flow', () => {
+    const html = renderToString(
+      <PlayerProfileModalBoundary playerId="p1" onClose={vi.fn()}>
+        <div>Child content</div>
+      </PlayerProfileModalBoundary>,
+    );
+
+    expect(html).toContain('Child content');
+  });
+});

--- a/tests/e2e/player_profile_modal_regression.spec.js
+++ b/tests/e2e/player_profile_modal_regression.spec.js
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+import { launchFranchise, goToTab } from './helpers/franchise.js';
+
+test.describe('Player profile modal regression', () => {
+  test('roster player click opens profile without crashing', async ({ page }) => {
+    await launchFranchise(page);
+    await goToTab(page, 'roster');
+
+    const firstPlayerButton = page.locator('#roster button').filter({ hasText: /./ }).first();
+    await expect(firstPlayerButton).toBeVisible();
+    await firstPlayerButton.click();
+
+    await expect(page.getByText(/OVR/i).first()).toBeVisible();
+    await expect(page.getByText(/Pot:/i).first()).toBeVisible();
+    await expect(page.getByText(/Player profile unavailable/i)).toHaveCount(0);
+
+    // Close modal should remain functional.
+    await page.getByRole('button', { name: '×' }).first().click();
+  });
+});


### PR DESCRIPTION
### Motivation

- Opening player profiles sometimes caused a hard React render crash or showed “Player not found”, indicating unguarded modal mounts and missing/failing player fetches.  The change contains focused fixes to prevent the app from crashing and to provide a friendly fallback when player data is unavailable.

### Description

- Add a dedicated error boundary component `PlayerProfileModalBoundary` to catch modal render-time crashes and show a small recovery UI with a close action instead of killing the page.  The boundary is used wherever `PlayerProfile` is shown in a modal.  
- Harden `PlayerProfile` data flow by adding a `PlayerProfileSkeleton` loading placeholder and an explicit fallback UI when player data cannot be resolved (`playerMissing` state) so the modal never renders deep profile UI while the data is invalid.  
- Prevent invalid/stale selections from opening the modal by validating clicks against the current roster in `Roster` (`rosterPlayerIds` + `handlePlayerSelect`) and replace the previous direct `setSelectedPlayerId` usage with the guarded callback.  
- Wrap `PlayerProfile` usages in the modal boundary across entry points (`Roster`, `LeagueDashboard`, `Draft`) and add tests: `PlayerProfile` and `PlayerProfileModalBoundary` unit tests and an E2E regression spec to exercise roster → open profile.

### Testing

- Unit tests: ran `npm run test:unit` for `src/ui/components/__tests__/PlayerProfile.test.jsx`, `src/ui/components/__tests__/PlayerProfileModalBoundary.test.jsx` and the existing roster initial-state test; all unit tests passed.  
- Build: ran `npm run build` to verify app bundles and ensure no syntax/runtime build issues; build succeeded.  
- E2E: attempted `npm run test:e2e` for `tests/e2e/player_profile_modal_regression.spec.js` but the Playwright browser binary was not available in this environment (`npx playwright install` required), so the E2E run could not complete here (test harness failed due to missing Chromium).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ea87ec1c832dab8ad67575a2e921)