### PR TITLE
Refactor HQ into Weekly Command Center with Agenda and Mobile Bottom Nav

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -1,136 +1,37 @@
-import { summarizeRosterDevelopment } from "../utils/playerDevelopmentSignals.js";
-import React, { useMemo, useState } from "react";
-import { Button } from "@/components/ui/button";
-import { evaluateWeeklyContext } from "../utils/weeklyContext.js";
-import { deriveTeamCapSnapshot, formatMoneyM } from "../utils/numberFormatting.js";
-import { getHQViewModel } from "../../state/selectors.js";
-import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/boxScoreAccess.js";
+import React, { useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { openResolvedBoxScore } from '../utils/boxScoreAccess.js';
+import { autoBuildDepthChart, depthWarnings } from '../../core/depthChart.js';
+import { markWeeklyPrepStep } from '../utils/weeklyPrep.js';
+import { selectFranchiseCommandCenter } from '../utils/franchiseCommandCenter.js';
 import {
   EmptyState,
   StatusChip,
-  HeroCard,
+  HeroPanel,
   ActionTile,
-  StatStrip,
   SectionCard,
-  CompactInsightCard,
   CompactListRow,
   SectionHeader,
-} from "./ScreenSystem.jsx";
-import { getRecentGames as getArchivedRecentGames } from "../../core/archive/gameArchive.ts";
-import { autoBuildDepthChart, depthWarnings } from "../../core/depthChart.js";
-import {
-  getTeamStatusLine,
-  getActionContext,
-  getActionDestination,
-  rankHqPriorityItems,
-  getTeamSnapshotNotes,
-} from "../utils/hqHelpers.js";
-import { deriveWeeklyPrepState, markWeeklyPrepStep } from "../utils/weeklyPrep.js";
+  SummaryCard,
+  TaskList,
+  NewsList,
+} from './ScreenSystem.jsx';
 
 function safeNum(value, fallback = 0) {
   const n = Number(value);
   return Number.isFinite(n) ? n : fallback;
 }
 
-function formatRecord(team) {
-  if (!team) return "0-0";
-  const ties = safeNum(team.ties);
-  return `${safeNum(team.wins)}-${safeNum(team.losses)}${ties ? `-${ties}` : ""}`;
-}
-
-function getNextGame(league) {
-  const weeks = league?.schedule?.weeks ?? [];
-  for (const week of weeks) {
-    for (const game of week?.games ?? []) {
-      if (game?.played) continue;
-      const homeId = Number(game?.home?.id ?? game?.home);
-      const awayId = Number(game?.away?.id ?? game?.away);
-      if (homeId !== Number(league?.userTeamId) && awayId !== Number(league?.userTeamId)) continue;
-      const isHome = homeId === Number(league?.userTeamId);
-      const oppId = isHome ? awayId : homeId;
-      const opp = (league?.teams ?? []).find((t) => Number(t?.id) === oppId);
-      return { week: Number(week?.week ?? 1), isHome, opp, game };
-    }
-  }
-  return null;
-}
-
-function getPrevGame(league) {
-  const weeks = [...(league?.schedule?.weeks ?? [])].sort((a, b) => Number(b?.week ?? 0) - Number(a?.week ?? 0));
-  for (const week of weeks) {
-    const games = [...(week?.games ?? [])].reverse();
-    for (const game of games) {
-      if (!game?.played) continue;
-      const homeId = Number(game?.home?.id ?? game?.home);
-      const awayId = Number(game?.away?.id ?? game?.away);
-      if (homeId !== Number(league?.userTeamId) && awayId !== Number(league?.userTeamId)) continue;
-      return { ...game, week: Number(week?.week ?? league?.week ?? 1), homeId, awayId };
-    }
-  }
-  return null;
-}
-
-function getSeverityTone(level) {
-  if (level === "urgent" || level === "blocker") return "danger";
-  if (level === "recommended" || level === "warning" || level === "recommendation") return "warning";
-  return "info";
-}
-
 export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdvanceWeek, busy, simulating }) {
-  const vm = useMemo(() => getHQViewModel(league), [league]);
   const [lineupToast, setLineupToast] = useState(null);
-  const developmentSummary = useMemo(() => summarizeRosterDevelopment(vm.userTeam?.roster ?? [], new Map()), [vm.userTeam?.roster]);
-  const weekly = useMemo(() => evaluateWeeklyContext(vm.league), [vm.league]);
-  const prep = useMemo(() => deriveWeeklyPrepState(vm.league), [vm.league]);
-  const nextGame = useMemo(() => getNextGame(vm.league), [vm.league]);
-  const previousScheduledGame = useMemo(() => getPrevGame(vm.league), [vm.league]);
-  const latestArchived = useMemo(() => getArchivedRecentGames(1)?.[0] ?? null, [vm.league?.seasonId, vm.league?.week]);
+  const command = useMemo(() => selectFranchiseCommandCenter(league), [league]);
 
-  if (!vm.userTeam) {
+  if (command.readyState !== 'ready') {
     return <EmptyState title="HQ loading" body="Team context is still loading or this save is missing team ownership metadata." />;
   }
 
-  const team = vm.userTeam;
-  const cap = deriveTeamCapSnapshot(team, { fallbackCapTotal: 255 });
-  const record = formatRecord(team);
-  const statusLine = getTeamStatusLine(team, vm.league, weekly);
-  const rankedPriorities = rankHqPriorityItems(team, vm.league, weekly, nextGame);
-
-  const latestGamePresentation = latestArchived
-    ? buildCompletedGamePresentation(
-      {
-        ...latestArchived,
-        homeScore: latestArchived?.score?.home,
-        awayScore: latestArchived?.score?.away,
-      },
-      { seasonId: vm.league?.seasonId, week: Number(latestArchived?.week ?? vm.league?.week ?? 1), source: "hq_last_game" },
-    )
-    : null;
-
-  const fallbackLastGame = previousScheduledGame
-    ? {
-      id: previousScheduledGame?.id,
-      homeAbbr: previousScheduledGame?.home?.abbr ?? "HOME",
-      awayAbbr: previousScheduledGame?.away?.abbr ?? "AWAY",
-      score: {
-        home: safeNum(previousScheduledGame?.homeScore),
-        away: safeNum(previousScheduledGame?.awayScore),
-      },
-      week: previousScheduledGame?.week,
-      userWon:
-          (previousScheduledGame?.homeId === Number(vm.league?.userTeamId)
-            && safeNum(previousScheduledGame?.homeScore) > safeNum(previousScheduledGame?.awayScore))
-          || (previousScheduledGame?.awayId === Number(vm.league?.userTeamId)
-            && safeNum(previousScheduledGame?.awayScore) > safeNum(previousScheduledGame?.homeScore)),
-    }
-    : null;
-
-  const lastGame = latestArchived ?? fallbackLastGame;
-  const recapCtaLabel = latestGamePresentation?.canOpen
-    ? (latestGamePresentation?.ctaLabel?.toLowerCase().includes("tactical") ? "Tactical Recap" : "Box Score")
-    : "View Result";
-
   const handleSetLineup = () => {
+    const team = (league?.teams ?? []).find((t) => Number(t?.id) === Number(league?.userTeamId));
     const roster = Array.isArray(team?.roster) ? team.roster : [];
     const existingAssignments = {};
     for (const player of roster) {
@@ -141,191 +42,80 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdva
     }
     const assignments = autoBuildDepthChart(roster, existingAssignments);
     const warnings = depthWarnings(assignments, roster);
-    const hasBlockingLineupIssue = warnings.some((warning) => warning.level === "error");
-    if (!hasBlockingLineupIssue) markWeeklyPrepStep(vm.league, "lineupChecked", true);
-    setLineupToast(hasBlockingLineupIssue ? "Depth chart still has missing starters." : "Lineup is valid. Opening depth chart.");
+    const hasBlockingLineupIssue = warnings.some((warning) => warning.level === 'error');
+    if (!hasBlockingLineupIssue) markWeeklyPrepStep(league, 'lineupChecked', true);
+    setLineupToast(hasBlockingLineupIssue ? 'Depth chart still has missing starters.' : 'Lineup is valid. Opening depth chart.');
     window.setTimeout(() => setLineupToast(null), 2200);
-    onNavigate?.("Team:Roster / Depth");
+    onNavigate?.('Team:Roster / Depth');
   };
 
-  const commandCenterActions = [
-    { label: "Set Lineup", type: "lineup", onClick: handleSetLineup },
-    { label: "Game Plan", type: "gameplan", onClick: () => { markWeeklyPrepStep(vm.league, "planReviewed", true); onNavigate?.(getActionDestination("gameplan", nextGame)); } },
-    { label: "Scout Opponent", type: "opponent", onClick: () => { markWeeklyPrepStep(vm.league, "opponentScouted", true); onNavigate?.(getActionDestination("opponent", nextGame)); } },
-    { label: "News & Injuries", type: "news", onClick: () => { markWeeklyPrepStep(vm.league, "injuriesReviewed", true); onNavigate?.(getActionDestination("news", nextGame)); } },
-  ].map((a) => ({ ...a, context: getActionContext(a.type, weekly, nextGame) }));
+  const actionTiles = [
+    { title: 'Set Lineup', icon: '🧩', subtitle: command.actionStatuses.lineup.subtitle, badge: command.actionStatuses.lineup.badge, onClick: handleSetLineup },
+    { title: 'Gameplan', icon: '📋', subtitle: command.actionStatuses.gameplan.subtitle, badge: command.actionStatuses.gameplan.badge, onClick: () => { markWeeklyPrepStep(league, 'planReviewed', true); onNavigate?.('Game Plan'); } },
+    { title: 'Scouting', icon: '🔎', subtitle: command.actionStatuses.scouting.subtitle, badge: command.actionStatuses.scouting.badge, onClick: () => { markWeeklyPrepStep(league, 'opponentScouted', true); onNavigate?.('Weekly Prep'); } },
+    { title: 'Team News', icon: '📰', subtitle: command.actionStatuses.news.subtitle, badge: command.actionStatuses.news.badge, onClick: () => { markWeeklyPrepStep(league, 'injuriesReviewed', true); onNavigate?.('News'); } },
+  ];
 
-  const previewPriorities = [rankedPriorities.featured, ...(rankedPriorities.secondary ?? [])].filter(Boolean).slice(0, 3);
-
-  const ownerApproval = safeNum(weekly?.pressurePoints?.ownerApproval ?? vm.league?.ownerApproval ?? vm.league?.ownerMood, null);
-  const expiringCount = safeNum(weekly?.pressurePoints?.expiringCount);
-  const rosterCount = Array.isArray(team?.roster) ? team.roster.length : safeNum(team?.rosterCount, 0);
-  const snapshotNotes = getTeamSnapshotNotes(team, weekly, cap.capRoom);
-  const nextDecision = rankedPriorities.featured ?? null;
-  const topNeedRows = previewPriorities.filter((item) => String(item?.tab ?? "").toLowerCase().includes("team")).slice(0, 3);
-  const injuryRows = (team?.roster ?? [])
-    .filter((player) => safeNum(player?.injury?.gamesRemaining ?? player?.injuryWeeksRemaining, 0) > 0)
-    .sort((a, b) => safeNum(b?.ovr, 0) - safeNum(a?.ovr, 0))
-    .slice(0, 3);
+  const lastGame = command.lastGameSummary;
 
   return (
-    <div className="app-screen-stack franchise-hq">
-      <HeroCard
-        eyebrow={`${league?.year ?? "Season"} · Week ${league?.week ?? 1} · ${String(league?.phase ?? "regular").replaceAll("_", " ")}`}
-        title={`${team?.city ?? ""} ${team?.name ?? "Team"}`}
-        subtitle={`${record} · ${nextGame ? `${nextGame.isHome ? "vs" : "@"} ${nextGame.opp?.name ?? "TBD"} (${formatRecord(nextGame.opp)})` : "No upcoming opponent"}`}
-        rightMeta={<StatusChip label={statusLine} tone="team" />}
+    <div className="app-screen-stack franchise-hq franchise-command-center">
+      <SectionHeader eyebrow="Franchise Command Center" title={`${command.weekLabel} Command Center`} subtitle={command.seasonLabel} actions={<StatusChip label={command.standingSummary} tone="team" />} />
+
+      <HeroPanel
+        eyebrow={`${command.weekLabel} matchup`}
+        title={`${command.nextGame?.isHome ? 'vs' : '@'} ${command.nextOpponent}`}
+        subtitle={`Opponent record ${command.nextOpponentRecord}`}
+        rightMeta={<StatusChip label={command.prep?.readinessLabel ?? 'Prep status unavailable'} tone="info" />}
         actions={(
           <>
-            <Button size="sm" variant="outline" onClick={() => onNavigate?.("Weekly Prep")}>Prepare Game</Button>
-            <Button size="sm" className="app-advance-btn" onClick={onAdvanceWeek} disabled={busy || simulating}>{busy || simulating ? "Working…" : "Advance Week"}</Button>
+            <Button size="sm" variant="outline" onClick={() => onNavigate?.('Weekly Prep')}>Prep Details</Button>
+            <Button size="sm" className="app-advance-btn app-command-advance" onClick={onAdvanceWeek} disabled={busy || simulating}>{busy || simulating ? 'Advancing…' : 'Advance Week'}</Button>
           </>
         )}
       >
         <div className="app-hero-summary-grid">
           <div>
-            <span>Last result</span>
-            <strong>
-              {lastGame
-                ? `${lastGame.userWon ? "W" : "L"} · ${lastGame.awayAbbr} ${safeNum(lastGame?.score?.away)} @ ${lastGame.homeAbbr} ${safeNum(lastGame?.score?.home)}`
-                : "No completed game yet"}
-            </strong>
+            <span>Last Game</span>
+            <strong>{lastGame ? `${lastGame.userWon ? 'W' : 'L'} · ${lastGame.awayAbbr} ${safeNum(lastGame?.score?.away)} @ ${lastGame.homeAbbr} ${safeNum(lastGame?.score?.home)}` : 'No completed game yet'}</strong>
           </div>
           <div>
-            <span>Prep status</span>
-            <strong>{prep?.readinessLabel ?? "Prep status unavailable"}</strong>
+            <span>Standing</span>
+            <strong>{command.standingSummary}</strong>
           </div>
         </div>
-      </HeroCard>
+        {command.blockers?.length ? <div className="app-blocker-row"><StatusChip label={`${command.blockers.length} prep blocker${command.blockers.length > 1 ? 's' : ''}`} tone="warning" /></div> : null}
+      </HeroPanel>
 
       <div className="app-action-grid-2x2">
-        {commandCenterActions.map((action) => (
-          <ActionTile key={action.label} title={action.label} subtitle={action.context} onClick={action.onClick} tone="info" />
+        {actionTiles.map((action) => (
+          <ActionTile key={action.title} icon={action.icon} title={action.title} subtitle={action.subtitle} badge={action.badge ? <StatusChip label={action.badge} tone="warning" /> : null} onClick={action.onClick} tone="info" />
         ))}
       </div>
       {lineupToast ? <p className="app-inline-toast">{lineupToast}</p> : null}
 
-      <SectionCard title="Next Action" subtitle="Your highest-priority decision this week." variant="compact">
-        {nextDecision ? (
-          <CompactListRow
-            title={nextDecision.label}
-            subtitle={nextDecision.detail}
-            meta={<StatusChip label={nextDecision.level === "urgent" ? "Urgent" : "Recommended"} tone={getSeverityTone(nextDecision.level)} />}
-          >
-            <Button size="sm" onClick={() => onNavigate?.(nextDecision?.tab ?? "Team")}>{nextDecision.verb ?? "Open task"}</Button>
-          </CompactListRow>
-        ) : (
-          <CompactInsightCard title="No urgent blockers" subtitle="Use this week to gain edges in prep and depth." tone="info" ctaLabel="Open Team" onCta={() => onNavigate?.("Team:Overview")} />
-        )}
+      <SectionCard title="Priority Tasks" subtitle="Top weekly agenda items to keep your franchise on track." variant="compact">
+        <TaskList tasks={command.weeklyAgenda} onOpenTask={(task) => onNavigate?.(task?.tab ?? 'HQ')} />
       </SectionCard>
-      {developmentSummary.rising.length > 0 && (
-        <SectionCard title="Development Outlook" subtitle="Risers and breakout candidates." variant="compact">
-          <div className="app-priority-rail">
-            {developmentSummary.rising.slice(0, 2).map((p) => (
-              <CompactInsightCard
-                key={p.id}
-                title={p.name}
-                subtitle={`${p.pos} · Rising trend · OVR ${p.ovr}`}
-                tone="ok"
-                ctaLabel="Profile"
-                onCta={() => onNavigate?.("Team:Development")}
-              />
-            ))}
-          </div>
+
+      <div className="app-command-bottom-grid">
+        <SummaryCard title="Team Overview" subtitle="Quick team health and franchise pressure." items={command.teamOverview} />
+        <SectionCard title="League News" subtitle="Around the league this week." variant="compact">
+          <NewsList items={command.leagueNews} emptyLabel="No league headlines yet. Advance to generate weekly stories." />
         </SectionCard>
-      )}
+      </div>
 
-      <SectionHeader eyebrow="Team status" title="Command Snapshot" subtitle="Core team state in one pass." />
-      <StatStrip items={[
-        { label: "OVR", value: `${safeNum(team?.ovr, 0)}`, tone: "team" },
-        { label: "Cap Room", value: formatMoneyM(cap.capRoom), tone: cap.capRoom < 10 ? "warning" : "ok" },
-        { label: "Roster", value: `${rosterCount}/53`, tone: rosterCount > 53 ? "danger" : "neutral" },
-        { label: "Expiring", value: `${expiringCount}`, tone: expiringCount >= 8 ? "warning" : "neutral" },
-      ]} />
-
-      <SectionCard title="Team Health Snapshot" subtitle="Current injuries and availability impact." variant="compact">
-        <div className="app-row-stack">
-          {injuryRows.length === 0 ? (
-            <CompactInsightCard title="No active injuries" subtitle="Primary rotation is currently available." tone="ok" />
-          ) : injuryRows.map((player) => (
-            <CompactListRow
-              key={player.id}
-              title={`${player.name} · ${player.pos}`}
-              subtitle={`${safeNum(player?.injury?.gamesRemaining ?? player?.injuryWeeksRemaining, 0)} game(s) out`}
-              meta={<StatusChip label="Unavailable" tone="warning" />}
-            >
-              <Button size="sm" variant="ghost" onClick={() => onNavigate?.("Team:Injuries")}>Injury report</Button>
-            </CompactListRow>
-          ))}
-        </div>
-      </SectionCard>
-
-      <SectionCard title="Latest Game Result" subtitle="Open full recap and box score." variant="compact">
+      <SectionCard title="Last Game Recap" subtitle="Open full recap and box score." variant="compact">
         {lastGame ? (
           <CompactListRow
-            title={`${lastGame.userWon ? "Win" : "Loss"} · Week ${lastGame.week ?? vm.league?.week ?? 1}`}
+            title={`${lastGame.userWon ? 'Win' : 'Loss'} · Week ${lastGame.week ?? league?.week ?? 1}`}
             subtitle={`${lastGame.awayAbbr} ${safeNum(lastGame?.score?.away)} @ ${lastGame.homeAbbr} ${safeNum(lastGame?.score?.home)}`}
             meta={<StatusChip label="Recap" tone="league" />}
           >
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => openResolvedBoxScore(
-                {
-                  ...latestArchived,
-                  id: latestArchived?.id ?? lastGame?.id,
-                  week: latestArchived?.week ?? lastGame?.week,
-                  homeScore: latestArchived?.score?.home ?? lastGame?.score?.home,
-                  awayScore: latestArchived?.score?.away ?? lastGame?.score?.away,
-                },
-                { seasonId: vm.league?.seasonId, week: Number(latestArchived?.week ?? lastGame?.week ?? vm.league?.week ?? 1), source: "hq_last_game" },
-                onOpenBoxScore,
-              )}
-              disabled={latestArchived ? !latestGamePresentation?.canOpen : false}
-            >
-              {recapCtaLabel}
-            </Button>
+            <Button size="sm" variant="outline" onClick={() => openResolvedBoxScore({ ...command.latestArchived, id: command.latestArchived?.id ?? lastGame?.id }, { seasonId: league?.seasonId, week: Number(command.latestArchived?.week ?? lastGame?.week ?? league?.week ?? 1), source: 'hq_last_game' }, onOpenBoxScore)} disabled={command.latestArchived ? !command.latestGamePresentation?.canOpen : false}>Box Score</Button>
           </CompactListRow>
-        ) : (
-          <CompactInsightCard title="No final yet" subtitle="Play your next game to unlock full recap context." tone="info" ctaLabel="Open Schedule" onCta={() => onNavigate?.("Schedule")} />
-        )}
+        ) : <EmptyState title="No final yet" body="Play your next game to unlock recap context." />}
       </SectionCard>
-
-      <SectionCard title="Cap & Contracts Snapshot" subtitle="Financial pressure and expiration risk." variant="compact">
-        <div className="app-priority-rail">
-          <CompactInsightCard title={formatMoneyM(cap.capRoom)} subtitle={snapshotNotes.capNote} tone={cap.capRoom < 5 ? "warning" : "ok"} ctaLabel="Open cap" onCta={() => onNavigate?.("💰 Cap")} />
-          <CompactInsightCard title={`${expiringCount} expiring`} subtitle={snapshotNotes.expiringNote} tone={expiringCount >= 6 ? "warning" : "info"} ctaLabel="Contracts" onCta={() => onNavigate?.("Team:Contracts")} />
-        </div>
-      </SectionCard>
-
-      <SectionCard title="Top Roster Needs" subtitle="Where depth or planning work should happen next." variant="compact">
-        <div className="app-priority-rail">
-          {topNeedRows.length > 0 ? topNeedRows.map((item, idx) => (
-            <CompactInsightCard
-              key={`${item.label}-${idx}`}
-              title={item.label}
-              subtitle={item.detail}
-              tone={getSeverityTone(item.level)}
-              ctaLabel={item.verb || "Open"}
-              onCta={() => onNavigate?.(item?.tab ?? "Team")}
-            />
-          )) : (
-            <CompactInsightCard title={snapshotNotes.rosterNote} subtitle="No high-priority roster alarms this week." tone="ok" ctaLabel="Roster / Depth" onCta={() => onNavigate?.("Team:Roster / Depth")} />
-          )}
-        </div>
-      </SectionCard>
-
-      <section className="app-teaser-strip card">
-        <CompactListRow title="Team View" subtitle="Roster, depth chart, contracts, and injuries." meta={<StatusChip label="Team" tone="team" />}>
-          <Button size="sm" variant="ghost" onClick={() => onNavigate?.("Team:Overview")}>Open Team Hub</Button>
-        </CompactListRow>
-        <CompactListRow title="League View" subtitle="Standings, weekly scores, and spotlight games." meta={<StatusChip label="League" tone="league" />}>
-          <Button size="sm" variant="ghost" onClick={() => onNavigate?.("League:Results")}>Open Results</Button>
-        </CompactListRow>
-        <CompactListRow title="Recent Team / League News" subtitle={ownerApproval == null ? "Approval unavailable" : `Owner approval ${ownerApproval}`} meta={<StatusChip label="News" tone={ownerApproval != null && ownerApproval < 55 ? "warning" : "info"} />}>
-          <Button size="sm" variant="ghost" onClick={() => onNavigate?.("🤖 GM Advisor")}>Open Advisor</Button>
-        </CompactListRow>
-      </section>
     </div>
   );
 }

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -227,6 +227,8 @@ const NAV_TEST_IDS = {
 };
 
 const TEAM_FACING_TABS = new Set(["Roster", "Depth Chart", "Roster Hub", "Weekly Prep", "Game Plan", "Training", "Injuries", "Staff", "Financials", "Contract Center"]);
+const HQ_QUICK_TABS = ['Roster Hub', 'Schedule', 'Standings', 'Staff'];
+
 const TAB_ALIASES = {
   Trades: "Transactions",
 };
@@ -777,7 +779,7 @@ export default function LeagueDashboard({
           ))}
         </div>
         <div className="standings-tabs" style={{ flexWrap: "nowrap", overflowX: "auto", gap: 6 }}>
-          {(NAV_GROUPS.find((group) => group.id === activeSection)?.tabs ?? ["HQ"])
+          {(activeSection === SHELL_SECTIONS.hq ? HQ_QUICK_TABS : (NAV_GROUPS.find((group) => group.id === activeSection)?.tabs ?? ['HQ']))
             .filter((tab) => TABS.includes(tab))
             .map((tab) => (
               <button
@@ -1277,6 +1279,7 @@ export default function LeagueDashboard({
       {/* ── Mobile Navigation (bottom bar + slide-in) ── */}
       <MobileNav
         activeSection={activeSection}
+        activeTab={activeTab}
         onSectionChange={handleSectionChange}
         onDestinationChange={(tab) => setActiveTab(canonicalizeMobileTab(tab))}
         onAdvance={onAdvanceWeek}

--- a/src/ui/components/MobileNav.jsx
+++ b/src/ui/components/MobileNav.jsx
@@ -34,13 +34,13 @@ const MORE_GROUPS = [
 ];
 
 const BOTTOM_TABS = [
-  { id: SHELL_SECTIONS.hq, label: NAV_LABELS.hq, icon: HomeIcon },
-  { id: SHELL_SECTIONS.team, label: NAV_LABELS.team, icon: RosterIcon },
-  { id: SHELL_SECTIONS.league, label: NAV_LABELS.league, icon: StandingsIcon },
-  { id: SHELL_SECTIONS.news, label: NAV_LABELS.news, icon: NewsIcon },
+  { id: 'Home', label: 'Home', icon: HomeIcon, action: 'section', value: SHELL_SECTIONS.hq },
+  { id: 'Lineup', label: 'Lineup', icon: RosterIcon, action: 'destination', value: 'Team:Roster / Depth' },
+  { id: 'Scouting', label: 'Scouting', icon: DraftIcon, action: 'destination', value: 'Weekly Prep' },
+  { id: 'Office', label: 'Office', icon: StaffIcon, action: 'destination', value: 'Staff' },
 ];
 
-export default function MobileNav({ activeSection, onSectionChange, onDestinationChange, onAdvance, advanceLabel, advanceDisabled, league }) {
+export default function MobileNav({ activeSection, activeTab, onSectionChange, onDestinationChange, onAdvance, advanceLabel, advanceDisabled, league }) {
   const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => setMenuOpen(false), [activeSection]);
@@ -106,9 +106,11 @@ export default function MobileNav({ activeSection, onSectionChange, onDestinatio
       <div className="mobile-bottom-bar premium-bottom-nav">
         {BOTTOM_TABS.map((tab) => {
           const Icon = tab.icon;
-          const isActive = activeSection === tab.id;
+          const isActive = (tab.action === 'section' && activeSection === tab.value)
+            || (tab.action === 'destination' && activeTab === tab.value);
+          const onClick = () => (tab.action === 'section' ? handleSectionClick(tab.value) : handleDestinationClick(tab.value));
           return (
-            <button key={tab.id} className={`mobile-bottom-tab premium-bottom-tab ${isActive ? 'active' : ''}`} onClick={() => handleSectionClick(tab.id)} aria-label={tab.label}>
+            <button key={tab.id} className={`mobile-bottom-tab premium-bottom-tab ${isActive ? 'active' : ''}`} onClick={onClick} aria-label={tab.label}>
               <Icon size={20} />
               <span className="mobile-bottom-label">{tab.label}</span>
             </button>

--- a/src/ui/components/MobileNav.test.jsx
+++ b/src/ui/components/MobileNav.test.jsx
@@ -9,6 +9,7 @@ describe('MobileNav', () => {
     const html = renderToString(
       <MobileNav
         activeSection={SHELL_SECTIONS.team}
+        activeTab="Team:Roster / Depth"
         onSectionChange={vi.fn()}
         onDestinationChange={vi.fn()}
         onAdvance={vi.fn()}
@@ -19,8 +20,8 @@ describe('MobileNav', () => {
     );
 
     expect(html).toContain('premium-bottom-nav');
-    expect(html).toContain('premium-bottom-tab active');
-    expect(html).toContain('Team');
+    expect(html).toContain('premium-bottom-tab active" aria-label="Lineup"');
+    expect(html).toContain('Lineup');
     expect(html).toContain('Advance Week');
   });
 
@@ -40,6 +41,6 @@ describe('MobileNav', () => {
     expect(html).toContain('Command Menu');
     expect(html).toContain('Trades');
     expect(html).toContain('Free Agency');
-    expect(html).toContain('League Leaders');
+    expect(html).toContain('Office');
   });
 });

--- a/src/ui/components/ScreenSystem.jsx
+++ b/src/ui/components/ScreenSystem.jsx
@@ -83,11 +83,13 @@ export function HeroCard({ eyebrow, title, subtitle, rightMeta = null, children,
   );
 }
 
-export function ActionTile({ title, subtitle, badge = null, onClick, tone = 'info' }) {
+export const HeroPanel = HeroCard;
+
+export function ActionTile({ icon = null, title, subtitle, badge = null, onClick, tone = 'info' }) {
   return (
     <button type="button" className={`app-action-tile tone-${tone}`} onClick={onClick}>
       <div className="app-action-tile__title-row">
-        <strong>{title}</strong>
+        <strong>{icon ? <span className="app-action-tile__icon">{icon}</span> : null}{title}</strong>
         {badge}
       </div>
       {subtitle ? <span className="app-action-tile__subtitle">{subtitle}</span> : null}
@@ -174,6 +176,67 @@ export function CompactListRow({ title, subtitle, meta, children }) {
       {meta ? <div className="app-compact-list-row__meta">{meta}</div> : null}
       {children ? <div className="app-compact-list-row__actions">{children}</div> : null}
     </div>
+  );
+}
+
+export function TaskRow({ icon = '🏈', title, subtitle, badge, tone = 'info', onClick }) {
+  return (
+    <button type="button" className={`app-task-row tone-${tone}`} onClick={onClick}>
+      <span className="app-task-row__icon" aria-hidden>{icon}</span>
+      <span className="app-task-row__copy">
+        <strong>{title}</strong>
+        <span>{subtitle}</span>
+      </span>
+      {badge ? <StatusChip label={badge} tone={tone} /> : null}
+      <span className="app-task-row__chevron" aria-hidden>›</span>
+    </button>
+  );
+}
+
+export function TaskList({ tasks = [], onOpenTask }) {
+  if (!tasks.length) return <EmptyState title="No urgent tasks" body="You're set for this week. Explore team and scouting upgrades." />;
+  return (
+    <div className="app-task-list">
+      {tasks.map((task) => (
+        <TaskRow
+          key={task.id}
+          icon={task.icon ?? '🏈'}
+          title={task.title}
+          subtitle={task.detail}
+          badge={task.badge}
+          tone={task.severity ?? 'info'}
+          onClick={() => onOpenTask?.(task)}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function StatPair({ label, value, tone = 'neutral' }) {
+  return <StatPill label={label} value={value} tone={tone} />;
+}
+
+export function SummaryCard({ title, subtitle, items = [] }) {
+  return (
+    <SectionCard title={title} subtitle={subtitle} variant="compact">
+      <div className="app-stat-strip">
+        {items.map((item) => <StatPair key={`${item.label}-${item.value}`} label={item.label} value={item.value} tone={item.tone} />)}
+      </div>
+    </SectionCard>
+  );
+}
+
+export function NewsList({ items = [], emptyLabel = 'No major league updates yet.' }) {
+  if (!items.length) return <p className="app-news-empty">{emptyLabel}</p>;
+  return (
+    <ul className="app-news-list">
+      {items.map((item) => (
+        <li key={item.id}>
+          <strong>{item.headline}</strong>
+          {item.detail ? <span>{item.detail}</span> : null}
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -72,15 +72,15 @@ describe('FranchiseHQ', () => {
     );
 
     expect(html).toContain('Advance Week');
-    expect(html).toContain('Prepare Game');
+    expect(html).toContain('Prep Details');
     expect(html).toContain('Set Lineup');
-    expect(html).toContain('Game Plan');
-    expect(html).toContain('Scout Opponent');
-    expect(html).toContain('News &amp; Injuries');
-    expect(html).toContain('Next Action');
-    expect(html).toContain('Command Snapshot');
-    expect(html).toContain('Recent Team / League News');
-    expect(html).toContain('Open Results');
+    expect(html).toContain('Gameplan');
+    expect(html).toContain('Scouting');
+    expect(html).toContain('Team News');
+    expect(html).toContain('Priority Tasks');
+    expect(html).toContain('Team Overview');
+    expect(html).toContain('League News');
+    expect(html).toContain('Last Game Recap');
   });
 
   it('is safe with partial/older save payloads', () => {

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -227,3 +227,52 @@
   }
   .standings-center-row > :nth-child(n + 5) { display: none; }
 }
+
+.franchise-command-center { gap: var(--space-4); }
+.app-command-advance { min-width: 210px; font-size: var(--text-base); font-weight: 800; box-shadow: 0 10px 24px rgba(var(--accent-rgb), .35); }
+.app-blocker-row { display: flex; flex-wrap: wrap; gap: 8px; }
+.app-command-bottom-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+
+.app-action-tile { min-height: 92px; transition: transform .16s ease, border-color .16s ease, background .16s ease; }
+.app-action-tile:hover, .app-action-tile:focus-visible { transform: translateY(-2px); border-color: rgba(var(--accent-rgb), .5); background: color-mix(in srgb, var(--surface-2) 86%, var(--accent) 14%); }
+.app-action-tile:active { transform: translateY(0); }
+.app-action-tile__icon { margin-right: 6px; }
+
+.app-task-list { display: grid; gap: 8px; }
+.app-task-row {
+  width: 100%;
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface) 96%, black 4%);
+  color: var(--text);
+  min-height: 58px;
+  padding: 10px;
+  display: grid;
+  grid-template-columns: 20px 1fr auto auto;
+  align-items: center;
+  gap: 8px;
+  text-align: left;
+}
+.app-task-row__copy { display: grid; min-width: 0; }
+.app-task-row__copy strong { font-size: var(--text-sm); }
+.app-task-row__copy span { color: var(--text-muted); font-size: var(--text-xs); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.app-task-row__chevron { color: var(--text-subtle); font-size: 1.1rem; }
+.app-task-row.tone-warning { border-color: rgba(255, 159, 10, .45); }
+.app-task-row.tone-danger { border-color: rgba(255, 69, 58, .45); background: rgba(255, 69, 58, .06); }
+
+.app-news-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
+.app-news-list li { border-bottom: 1px solid var(--hairline); padding-bottom: 8px; display: grid; gap: 2px; }
+.app-news-list li:last-child { border-bottom: 0; padding-bottom: 0; }
+.app-news-list li strong { font-size: var(--text-sm); }
+.app-news-list li span { font-size: var(--text-xs); color: var(--text-muted); }
+.app-news-empty { margin: 0; font-size: var(--text-xs); color: var(--text-muted); }
+
+@media (max-width: 900px) {
+  .app-command-bottom-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 768px) {
+  .app-action-grid-2x2 { grid-template-columns: 1fr; }
+  .app-task-row { grid-template-columns: 20px 1fr auto; }
+  .app-task-row .app-status-chip { display: none; }
+}

--- a/src/ui/utils/franchiseCommandCenter.js
+++ b/src/ui/utils/franchiseCommandCenter.js
@@ -1,0 +1,153 @@
+import { evaluateWeeklyContext } from './weeklyContext.js';
+import { deriveWeeklyPrepState, getNextGame as getPrepNextGame } from './weeklyPrep.js';
+import { deriveTeamCapSnapshot, formatMoneyM } from './numberFormatting.js';
+import { getHQViewModel } from '../../state/selectors.js';
+import { rankHqPriorityItems, getActionContext } from './hqHelpers.js';
+import { buildCompletedGamePresentation } from './boxScoreAccess.js';
+import { getRecentGames as getArchivedRecentGames } from '../../core/archive/gameArchive.ts';
+
+function safeNum(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function formatRecord(team) {
+  if (!team) return '0-0';
+  const ties = safeNum(team.ties);
+  return `${safeNum(team.wins)}-${safeNum(team.losses)}${ties ? `-${ties}` : ''}`;
+}
+
+function getPrevGame(league) {
+  const weeks = [...(league?.schedule?.weeks ?? [])].sort((a, b) => Number(b?.week ?? 0) - Number(a?.week ?? 0));
+  for (const week of weeks) {
+    const games = [...(week?.games ?? [])].reverse();
+    for (const game of games) {
+      if (!game?.played) continue;
+      const homeId = Number(game?.home?.id ?? game?.home);
+      const awayId = Number(game?.away?.id ?? game?.away);
+      if (homeId !== Number(league?.userTeamId) && awayId !== Number(league?.userTeamId)) continue;
+      return { ...game, week: Number(week?.week ?? league?.week ?? 1), homeId, awayId };
+    }
+  }
+  return null;
+}
+
+function deriveActionStatuses(weekly, nextGame) {
+  return {
+    lineup: { subtitle: getActionContext('lineup', weekly, nextGame), badge: safeNum(weekly?.pressurePoints?.injuriesCount, 0) > 1 ? `${safeNum(weekly?.pressurePoints?.injuriesCount, 0)} injuries` : null },
+    gameplan: { subtitle: getActionContext('gameplan', weekly, nextGame), badge: nextGame?.opp?.ovr && safeNum(nextGame.opp.ovr) >= 85 ? 'Tough matchup' : null },
+    scouting: { subtitle: getActionContext('opponent', weekly, nextGame), badge: weekly?.scouting?.completionPct != null && weekly.scouting.completionPct < 70 ? 'Needs attention' : null },
+    news: { subtitle: getActionContext('news', weekly, nextGame), badge: safeNum(weekly?.pressurePoints?.incomingTradeCount, 0) > 0 ? `${safeNum(weekly?.pressurePoints?.incomingTradeCount, 0)} unresolved` : null },
+  };
+}
+
+export function buildWeeklyAgenda({ team, league, weekly, prep, nextGame }) {
+  if (!team || !league) return [];
+  const ranked = rankHqPriorityItems(team, league, weekly, nextGame);
+  const items = [ranked.featured, ...(ranked.secondary ?? [])]
+    .filter(Boolean)
+    .map((item, idx) => ({
+      id: `priority-${idx}`,
+      title: item.label,
+      detail: item.detail,
+      severity: item.level === 'urgent' ? 'danger' : item.level === 'recommended' ? 'warning' : 'info',
+      badge: item.level === 'urgent' ? 'Urgent' : item.level === 'recommended' ? 'Needs attention' : 'Optional',
+      tab: item.tab ?? 'HQ',
+    }));
+
+  const injuries = (team?.roster ?? []).filter((player) => safeNum(player?.injury?.gamesRemaining ?? player?.injuryWeeksRemaining, 0) > 0).length;
+  if (injuries > 0 && !items.some((item) => item.tab?.includes('Injur'))) {
+    items.push({
+      id: 'injury-followup',
+      title: 'Adjust injury replacements',
+      detail: `${injuries} player${injuries > 1 ? 's are' : ' is'} unavailable this week.`,
+      severity: injuries >= 3 ? 'danger' : 'warning',
+      badge: injuries >= 3 ? 'Critical' : 'Monitor',
+      tab: 'Team:Injuries',
+    });
+  }
+
+  if (prep?.completionPct != null && prep.completionPct < 75) {
+    items.push({
+      id: 'prep-incomplete',
+      title: 'Complete weekly prep checklist',
+      detail: `Only ${Math.round(prep.completionPct)}% complete before kickoff.`,
+      severity: 'warning',
+      badge: 'Prep incomplete',
+      tab: 'Weekly Prep',
+    });
+  }
+
+  return items.slice(0, 5);
+}
+
+export function selectFranchiseCommandCenter(league) {
+  const vm = getHQViewModel(league);
+  if (!vm.userTeam) {
+    return { readyState: 'loading', weeklyAgenda: [] };
+  }
+  const team = vm.userTeam;
+  const weekly = evaluateWeeklyContext(vm.league);
+  const prep = deriveWeeklyPrepState(vm.league);
+  const nextGame = getPrepNextGame(vm.league);
+  const previousScheduledGame = getPrevGame(vm.league);
+  const latestArchived = getArchivedRecentGames(1)?.[0] ?? null;
+  const latestGamePresentation = latestArchived
+    ? buildCompletedGamePresentation(
+      {
+        ...latestArchived,
+        homeScore: latestArchived?.score?.home,
+        awayScore: latestArchived?.score?.away,
+      },
+      { seasonId: vm.league?.seasonId, week: Number(latestArchived?.week ?? vm.league?.week ?? 1), source: 'hq_last_game' },
+    )
+    : null;
+
+  const fallbackLastGame = previousScheduledGame
+    ? {
+      id: previousScheduledGame?.id,
+      homeAbbr: previousScheduledGame?.home?.abbr ?? 'HOME',
+      awayAbbr: previousScheduledGame?.away?.abbr ?? 'AWAY',
+      score: {
+        home: safeNum(previousScheduledGame?.homeScore),
+        away: safeNum(previousScheduledGame?.awayScore),
+      },
+      week: previousScheduledGame?.week,
+      userWon:
+          (previousScheduledGame?.homeId === Number(vm.league?.userTeamId)
+            && safeNum(previousScheduledGame?.homeScore) > safeNum(previousScheduledGame?.awayScore))
+          || (previousScheduledGame?.awayId === Number(vm.league?.userTeamId)
+            && safeNum(previousScheduledGame?.awayScore) > safeNum(previousScheduledGame?.homeScore)),
+    }
+    : null;
+
+  const cap = deriveTeamCapSnapshot(team, { fallbackCapTotal: 255 });
+  const rosterCount = Array.isArray(team?.roster) ? team.roster.length : safeNum(team?.rosterCount, 0);
+  const leagueNews = (Array.isArray(vm.league?.newsItems) ? vm.league.newsItems : [])
+    .slice(0, 4)
+    .map((item, index) => ({ id: item.id ?? `news-${index}`, headline: item.headline ?? item.title ?? 'League update', detail: item.summary ?? item.body ?? null }));
+
+  return {
+    readyState: 'ready',
+    seasonLabel: `${vm.league?.year ?? 'Season'} · ${String(vm.league?.phase ?? 'regular').replaceAll('_', ' ')}`,
+    weekLabel: `Week ${vm.league?.week ?? 1}`,
+    nextOpponent: nextGame?.opp?.name ?? 'TBD',
+    nextOpponentRecord: nextGame?.opp ? formatRecord(nextGame.opp) : '—',
+    nextGame,
+    prep,
+    blockers: prep?.blockers ?? [],
+    actionStatuses: deriveActionStatuses(weekly, nextGame),
+    weeklyAgenda: buildWeeklyAgenda({ team, league: vm.league, weekly, prep, nextGame }),
+    lastGameSummary: latestArchived ?? fallbackLastGame,
+    standingSummary: `${formatRecord(team)} · ${team?.conf ?? ''} ${team?.div ?? ''}`.trim(),
+    latestArchived,
+    latestGamePresentation,
+    teamOverview: [
+      { label: 'Cap Space', value: formatMoneyM(cap.capRoom), tone: cap.capRoom < 5 ? 'warning' : 'ok' },
+      { label: 'Roster', value: `${rosterCount}/53`, tone: rosterCount > 53 ? 'danger' : 'info' },
+      { label: 'Injuries', value: `${safeNum(weekly?.pressurePoints?.injuriesCount, 0)}`, tone: safeNum(weekly?.pressurePoints?.injuriesCount, 0) >= 3 ? 'warning' : 'info' },
+      { label: 'Owner Confidence', value: `${safeNum(weekly?.pressurePoints?.ownerApproval ?? vm.league?.ownerApproval ?? vm.league?.ownerMood, 50)}%`, tone: safeNum(weekly?.pressurePoints?.ownerApproval ?? vm.league?.ownerApproval ?? vm.league?.ownerMood, 50) < 50 ? 'danger' : 'ok' },
+    ],
+    leagueNews,
+  };
+}


### PR DESCRIPTION
### Motivation
- Make the franchise home/HQ feel like a premium, mobile-native weekly command center with a clear next-opponent focus and a dominant Advance Week CTA. 
- Surface weekly activities and the top 3–5 franchise priorities so users immediately know the week state, next opponent, last result, standings, and the next action. 
- Consolidate fragile UI transforms into a single selector/view-model to reduce duplicated logic and lower regression risk while preserving existing simulation and routing behavior. 

### Description
- Introduced a centralized HQ view-model and agenda generator in `src/ui/utils/franchiseCommandCenter.js` with `selectFranchiseCommandCenter(...)` and `buildWeeklyAgenda(...)` to return a stable HQ payload (`seasonLabel`, `weekLabel`, `nextOpponent`, `actionStatuses`, `weeklyAgenda`, `teamOverview`, `leagueNews`, etc.).
- Refactored the HQ screen into a weekly command center in `src/ui/components/FranchiseHQ.jsx` that consumes the view-model and renders: a dominant Next Opponent hero, a visually-primary `Advance Week` CTA, compact last-game/standing context, a 2x2 action tile grid, a `Priority Tasks` agenda, and a bottom two-card grid for Team Overview and League News. 
- Added and normalized reusable primitives in `src/ui/components/ScreenSystem.jsx` (`HeroPanel` alias, icon-capable `ActionTile`, `TaskRow`/`TaskList`, `SummaryCard`/`StatPair`, `NewsList`) and adjusted CSS in `src/ui/styles/screen-system.css` for improved hierarchy, spacing, and responsive behavior. 
- Improved mobile UX by adding a thumb-first bottom nav in `src/ui/components/MobileNav.jsx` (Home, Lineup, Scouting, Office, Advance + More drawer) with destination-aware active-state handling (`activeTab` support), and focused HQ quick tabs in `src/ui/components/LeagueDashboard.jsx` to reduce header clutter. 
- Kept simulation, save/load, roster and routing logic intact and wired action tiles/tasks to existing destinations; updated tests to reflect the new labels/layout. 

### Testing
- Ran unit tests for the updated screens: `npx vitest run src/ui/components/__tests__/FranchiseHQ.test.jsx src/ui/components/MobileNav.test.jsx`, and both test files passed. 
- Verified the HQ component renders safely with partial/legacy payload shapes via updated HQ unit test that exercises safe rendering logic. 
- Sanity-checked mobile nav render and active-state behavior with updated MobileNav unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e851224b38832da617d31915c5f99a)