### PR TITLE
Refine Franchise HQ into a unified weekly command center

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -3,18 +3,17 @@ import { Button } from '@/components/ui/button';
 import { openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 import { autoBuildDepthChart, depthWarnings } from '../../core/depthChart.js';
 import { markWeeklyPrepStep } from '../utils/weeklyPrep.js';
-import { selectFranchiseCommandCenter } from '../utils/franchiseCommandCenter.js';
+import { selectFranchiseHQViewModel } from '../utils/franchiseCommandCenter.js';
 import {
   EmptyState,
   StatusChip,
-  HeroPanel,
+  WeeklyHero,
   ActionTile,
   SectionCard,
   CompactListRow,
-  SectionHeader,
-  SummaryCard,
-  TaskList,
-  NewsList,
+  SummaryGrid,
+  WeeklyAgenda,
+  CompactNewsCard,
 } from './ScreenSystem.jsx';
 
 function safeNum(value, fallback = 0) {
@@ -24,7 +23,7 @@ function safeNum(value, fallback = 0) {
 
 export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdvanceWeek, busy, simulating }) {
   const [lineupToast, setLineupToast] = useState(null);
-  const command = useMemo(() => selectFranchiseCommandCenter(league), [league]);
+  const command = useMemo(() => selectFranchiseHQViewModel(league), [league]);
 
   if (command.readyState !== 'ready') {
     return <EmptyState title="HQ loading" body="Team context is still loading or this save is missing team ownership metadata." />;
@@ -60,13 +59,11 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdva
 
   return (
     <div className="app-screen-stack franchise-hq franchise-command-center">
-      <SectionHeader eyebrow="Franchise Command Center" title={`${command.weekLabel} Command Center`} subtitle={command.seasonLabel} actions={<StatusChip label={command.standingSummary} tone="team" />} />
-
-      <HeroPanel
-        eyebrow={`${command.weekLabel} matchup`}
+      <WeeklyHero
+        eyebrow={`${command.seasonLabel} · ${command.weekLabel}`}
         title={`${command.nextGame?.isHome ? 'vs' : '@'} ${command.nextOpponent}`}
-        subtitle={`Opponent record ${command.nextOpponentRecord}`}
-        rightMeta={<StatusChip label={command.prep?.readinessLabel ?? 'Prep status unavailable'} tone="info" />}
+        subtitle={`Your record ${command.teamRecord} · Opponent ${command.nextOpponentRecord}`}
+        rightMeta={<StatusChip label={command.prepStatus} tone="info" />}
         actions={(
           <>
             <Button size="sm" variant="outline" onClick={() => onNavigate?.('Weekly Prep')}>Prep Details</Button>
@@ -74,7 +71,7 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdva
           </>
         )}
       >
-        <div className="app-hero-summary-grid">
+        <div className="app-hero-summary-grid app-hero-summary-grid-command">
           <div>
             <span>Last Game</span>
             <strong>{lastGame ? `${lastGame.userWon ? 'W' : 'L'} · ${lastGame.awayAbbr} ${safeNum(lastGame?.score?.away)} @ ${lastGame.homeAbbr} ${safeNum(lastGame?.score?.home)}` : 'No completed game yet'}</strong>
@@ -85,7 +82,7 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdva
           </div>
         </div>
         {command.blockers?.length ? <div className="app-blocker-row"><StatusChip label={`${command.blockers.length} prep blocker${command.blockers.length > 1 ? 's' : ''}`} tone="warning" /></div> : null}
-      </HeroPanel>
+      </WeeklyHero>
 
       <div className="app-action-grid-2x2">
         {actionTiles.map((action) => (
@@ -94,14 +91,21 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdva
       </div>
       {lineupToast ? <p className="app-inline-toast">{lineupToast}</p> : null}
 
-      <SectionCard title="Priority Tasks" subtitle="Top weekly agenda items to keep your franchise on track." variant="compact">
-        <TaskList tasks={command.weeklyAgenda} onOpenTask={(task) => onNavigate?.(task?.tab ?? 'HQ')} />
+      <SectionCard title="Weekly Agenda" subtitle="Front office priorities ranked for this week." variant="compact">
+        <WeeklyAgenda items={command.weeklyAgenda} onOpenTask={(task) => onNavigate?.(task?.targetRoute ?? task?.tab ?? 'HQ')} />
       </SectionCard>
 
       <div className="app-command-bottom-grid">
-        <SummaryCard title="Team Overview" subtitle="Quick team health and franchise pressure." items={command.teamOverview} />
-        <SectionCard title="League News" subtitle="Around the league this week." variant="compact">
-          <NewsList items={command.leagueNews} emptyLabel="No league headlines yet. Advance to generate weekly stories." />
+        <SectionCard title="Snapshot" subtitle="Quick pressure and readiness indicators." variant="compact">
+          <SummaryGrid items={command.teamOverview} />
+        </SectionCard>
+        <SectionCard title="League Pulse" subtitle="Compact headlines around the league." variant="compact">
+          <div className="app-news-compact-list">
+            {(command.leagueNews ?? []).slice(0, 3).map((item) => (
+              <CompactNewsCard key={item.id} title={item.headline} subtitle={item.detail} />
+            ))}
+            {!command.leagueNews?.length ? <EmptyState title="No league headlines yet." body="Advance to generate weekly stories." /> : null}
+          </div>
         </SectionCard>
       </div>
 

--- a/src/ui/components/MobileNav.jsx
+++ b/src/ui/components/MobileNav.jsx
@@ -34,10 +34,10 @@ const MORE_GROUPS = [
 ];
 
 const BOTTOM_TABS = [
-  { id: 'Home', label: 'Home', icon: HomeIcon, action: 'section', value: SHELL_SECTIONS.hq },
-  { id: 'Lineup', label: 'Lineup', icon: RosterIcon, action: 'destination', value: 'Team:Roster / Depth' },
-  { id: 'Scouting', label: 'Scouting', icon: DraftIcon, action: 'destination', value: 'Weekly Prep' },
-  { id: 'Office', label: 'Office', icon: StaffIcon, action: 'destination', value: 'Staff' },
+  { id: 'HQ', label: 'HQ', icon: HomeIcon, action: 'section', value: SHELL_SECTIONS.hq },
+  { id: 'Team', label: 'Team', icon: RosterIcon, action: 'section', value: SHELL_SECTIONS.team },
+  { id: 'League', label: 'League', icon: StandingsIcon, action: 'section', value: SHELL_SECTIONS.league },
+  { id: 'News', label: 'News', icon: NewsIcon, action: 'destination', value: 'News' },
 ];
 
 export default function MobileNav({ activeSection, activeTab, onSectionChange, onDestinationChange, onAdvance, advanceLabel, advanceDisabled, league }) {
@@ -118,7 +118,7 @@ export default function MobileNav({ activeSection, activeTab, onSectionChange, o
         })}
 
         <button
-          className="mobile-bottom-tab premium-bottom-tab mobile-bottom-tab-advance"
+          className="mobile-bottom-tab premium-bottom-tab mobile-bottom-tab-advance mobile-bottom-tab-advance-subtle"
           onClick={onAdvance}
           disabled={advanceDisabled}
           aria-label={advanceLabel || 'Advance'}

--- a/src/ui/components/MobileNav.test.jsx
+++ b/src/ui/components/MobileNav.test.jsx
@@ -20,8 +20,8 @@ describe('MobileNav', () => {
     );
 
     expect(html).toContain('premium-bottom-nav');
-    expect(html).toContain('premium-bottom-tab active" aria-label="Lineup"');
-    expect(html).toContain('Lineup');
+    expect(html).toContain('premium-bottom-tab active" aria-label="Team"');
+    expect(html).toContain('Team');
     expect(html).toContain('Advance Week');
   });
 
@@ -41,6 +41,6 @@ describe('MobileNav', () => {
     expect(html).toContain('Command Menu');
     expect(html).toContain('Trades');
     expect(html).toContain('Free Agency');
-    expect(html).toContain('Office');
+    expect(html).toContain('League');
   });
 });

--- a/src/ui/components/ScreenSystem.jsx
+++ b/src/ui/components/ScreenSystem.jsx
@@ -84,6 +84,7 @@ export function HeroCard({ eyebrow, title, subtitle, rightMeta = null, children,
 }
 
 export const HeroPanel = HeroCard;
+export const WeeklyHero = HeroCard;
 
 export function ActionTile({ icon = null, title, subtitle, badge = null, onClick, tone = 'info' }) {
   return (
@@ -141,6 +142,7 @@ export function EmptyState({ title, body }) {
 export function StatusChip({ label, tone = 'neutral' }) {
   return <span className={`app-status-chip tone-${tone}`}>{label}</span>;
 }
+export const StatusBadge = StatusChip;
 
 export function CtaRow({ actions = [] }) {
   if (!actions.length) return null;
@@ -202,12 +204,34 @@ export function TaskList({ tasks = [], onOpenTask }) {
           key={task.id}
           icon={task.icon ?? '🏈'}
           title={task.title}
-          subtitle={task.detail}
-          badge={task.badge}
+          subtitle={task.description ?? task.detail}
+          badge={task.badge ?? task.ctaLabel}
           tone={task.severity ?? 'info'}
           onClick={() => onOpenTask?.(task)}
         />
       ))}
+    </div>
+  );
+}
+
+export function AgendaItemRow({ item, onOpenTask }) {
+  return (
+    <TaskRow
+      icon={item?.icon ?? '🏈'}
+      title={item?.title}
+      subtitle={item?.description ?? item?.detail}
+      badge={item?.badge ?? item?.ctaLabel}
+      tone={item?.severity ?? 'info'}
+      onClick={() => onOpenTask?.(item)}
+    />
+  );
+}
+
+export function WeeklyAgenda({ items = [], onOpenTask }) {
+  if (!items.length) return <EmptyState title="Agenda clear" body="No urgent front office tasks this week." />;
+  return (
+    <div className="app-task-list">
+      {items.map((item) => <AgendaItemRow key={item.id} item={item} onOpenTask={onOpenTask} />)}
     </div>
   );
 }
@@ -226,6 +250,15 @@ export function SummaryCard({ title, subtitle, items = [] }) {
   );
 }
 
+export function SummaryGrid({ items = [] }) {
+  if (!items.length) return null;
+  return (
+    <div className="app-summary-grid">
+      {items.map((item) => <StatPair key={`${item.label}-${item.value}`} label={item.label} value={item.value} tone={item.tone} />)}
+    </div>
+  );
+}
+
 export function NewsList({ items = [], emptyLabel = 'No major league updates yet.' }) {
   if (!items.length) return <p className="app-news-empty">{emptyLabel}</p>;
   return (
@@ -237,6 +270,15 @@ export function NewsList({ items = [], emptyLabel = 'No major league updates yet
         </li>
       ))}
     </ul>
+  );
+}
+
+export function CompactNewsCard({ title, subtitle }) {
+  return (
+    <div className="app-compact-news-card">
+      <strong>{title}</strong>
+      {subtitle ? <span>{subtitle}</span> : null}
+    </div>
   );
 }
 

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -77,9 +77,9 @@ describe('FranchiseHQ', () => {
     expect(html).toContain('Gameplan');
     expect(html).toContain('Scouting');
     expect(html).toContain('Team News');
-    expect(html).toContain('Priority Tasks');
-    expect(html).toContain('Team Overview');
-    expect(html).toContain('League News');
+    expect(html).toContain('Weekly Agenda');
+    expect(html).toContain('Snapshot');
+    expect(html).toContain('League Pulse');
     expect(html).toContain('Last Game Recap');
   });
 

--- a/src/ui/styles/app-mobile.css
+++ b/src/ui/styles/app-mobile.css
@@ -1481,3 +1481,30 @@
   background: linear-gradient(160deg, rgba(var(--accent-rgb), 0.3), rgba(var(--accent-rgb), 0.16));
   color: var(--text);
 }
+
+.premium-bottom-nav {
+  min-height: 62px;
+  padding: 6px 8px calc(6px + env(safe-area-inset-bottom));
+  align-items: stretch;
+}
+
+.premium-bottom-tab {
+  min-height: 50px;
+  gap: 4px;
+}
+
+.premium-bottom-tab svg {
+  width: 18px;
+  height: 18px;
+}
+
+.mobile-bottom-label {
+  font-size: 10px;
+  line-height: 1.1;
+}
+
+.mobile-bottom-tab-advance-subtle {
+  border-color: rgba(var(--accent-rgb), 0.34);
+  background: linear-gradient(160deg, rgba(var(--accent-rgb), 0.18), rgba(var(--accent-rgb), 0.08));
+  box-shadow: inset 0 0 0 1px rgba(var(--accent-rgb), 0.16);
+}

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -229,11 +229,23 @@
 }
 
 .franchise-command-center { gap: var(--space-4); }
-.app-command-advance { min-width: 210px; font-size: var(--text-base); font-weight: 800; box-shadow: 0 10px 24px rgba(var(--accent-rgb), .35); }
+.app-command-advance { min-width: 220px; font-size: var(--text-base); font-weight: 800; box-shadow: 0 10px 24px rgba(var(--accent-rgb), .26); }
 .app-blocker-row { display: flex; flex-wrap: wrap; gap: 8px; }
 .app-command-bottom-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+.app-summary-grid { display: grid; gap: 8px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.app-news-compact-list { display: grid; gap: 6px; }
+.app-compact-news-card {
+  border: 1px solid var(--hairline);
+  border-radius: 10px;
+  padding: 8px 10px;
+  display: grid;
+  gap: 2px;
+  background: color-mix(in srgb, var(--surface) 95%, black 5%);
+}
+.app-compact-news-card strong { font-size: var(--text-xs); }
+.app-compact-news-card span { font-size: 11px; color: var(--text-muted); }
 
-.app-action-tile { min-height: 92px; transition: transform .16s ease, border-color .16s ease, background .16s ease; }
+.app-action-tile { min-height: 102px; transition: transform .16s ease, border-color .16s ease, background .16s ease; }
 .app-action-tile:hover, .app-action-tile:focus-visible { transform: translateY(-2px); border-color: rgba(var(--accent-rgb), .5); background: color-mix(in srgb, var(--surface-2) 86%, var(--accent) 14%); }
 .app-action-tile:active { transform: translateY(0); }
 .app-action-tile__icon { margin-right: 6px; }
@@ -258,7 +270,7 @@
 .app-task-row__copy span { color: var(--text-muted); font-size: var(--text-xs); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .app-task-row__chevron { color: var(--text-subtle); font-size: 1.1rem; }
 .app-task-row.tone-warning { border-color: rgba(255, 159, 10, .45); }
-.app-task-row.tone-danger { border-color: rgba(255, 69, 58, .45); background: rgba(255, 69, 58, .06); }
+.app-task-row.tone-danger { border-color: rgba(255, 69, 58, .45); background: rgba(255, 69, 58, .04); }
 
 .app-news-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
 .app-news-list li { border-bottom: 1px solid var(--hairline); padding-bottom: 8px; display: grid; gap: 2px; }
@@ -275,4 +287,6 @@
   .app-action-grid-2x2 { grid-template-columns: 1fr; }
   .app-task-row { grid-template-columns: 20px 1fr auto; }
   .app-task-row .app-status-chip { display: none; }
+  .app-command-advance { width: 100%; min-width: 0; }
+  .app-summary-grid { grid-template-columns: 1fr; }
 }

--- a/src/ui/utils/franchiseCommandCenter.js
+++ b/src/ui/utils/franchiseCommandCenter.js
@@ -44,44 +44,70 @@ function deriveActionStatuses(weekly, nextGame) {
 export function buildWeeklyAgenda({ team, league, weekly, prep, nextGame }) {
   if (!team || !league) return [];
   const ranked = rankHqPriorityItems(team, league, weekly, nextGame);
-  const items = [ranked.featured, ...(ranked.secondary ?? [])]
+  const mappedRanked = [ranked.featured, ...(ranked.secondary ?? [])]
     .filter(Boolean)
     .map((item, idx) => ({
       id: `priority-${idx}`,
+      icon: item.level === 'urgent' ? '⛳' : item.level === 'recommended' ? '⚠️' : '📌',
       title: item.label,
-      detail: item.detail,
+      description: item.detail,
       severity: item.level === 'urgent' ? 'danger' : item.level === 'recommended' ? 'warning' : 'info',
-      badge: item.level === 'urgent' ? 'Urgent' : item.level === 'recommended' ? 'Needs attention' : 'Optional',
-      tab: item.tab ?? 'HQ',
+      ctaLabel: item.verb ?? 'Open',
+      targetRoute: item.tab ?? 'HQ',
     }));
 
+  const items = [...mappedRanked];
+
   const injuries = (team?.roster ?? []).filter((player) => safeNum(player?.injury?.gamesRemaining ?? player?.injuryWeeksRemaining, 0) > 0).length;
-  if (injuries > 0 && !items.some((item) => item.tab?.includes('Injur'))) {
+  if (injuries > 0 && !items.some((item) => item.targetRoute?.includes('Injur'))) {
     items.push({
       id: 'injury-followup',
+      icon: injuries >= 3 ? '🚑' : '🩹',
       title: 'Adjust injury replacements',
-      detail: `${injuries} player${injuries > 1 ? 's are' : ' is'} unavailable this week.`,
+      description: `${injuries} player${injuries > 1 ? 's are' : ' is'} unavailable this week.`,
       severity: injuries >= 3 ? 'danger' : 'warning',
-      badge: injuries >= 3 ? 'Critical' : 'Monitor',
-      tab: 'Team:Injuries',
+      ctaLabel: 'Review injuries',
+      targetRoute: 'Team:Injuries',
     });
   }
 
   if (prep?.completionPct != null && prep.completionPct < 75) {
     items.push({
       id: 'prep-incomplete',
+      icon: '🧠',
       title: 'Complete weekly prep checklist',
-      detail: `Only ${Math.round(prep.completionPct)}% complete before kickoff.`,
+      description: `Only ${Math.round(prep.completionPct)}% complete before kickoff.`,
       severity: 'warning',
-      badge: 'Prep incomplete',
-      tab: 'Weekly Prep',
+      ctaLabel: 'Open prep',
+      targetRoute: 'Weekly Prep',
+    });
+  }
+
+  if ((weekly?.scouting?.completionPct ?? 100) < 70) {
+    items.push({
+      id: 'scouting-incomplete',
+      icon: '🔬',
+      title: 'Scouting package unfinished',
+      description: `${Math.round(safeNum(weekly?.scouting?.completionPct, 0))}% of this week’s opponent report is complete.`,
+      severity: 'info',
+      ctaLabel: 'Scout opponent',
+      targetRoute: 'Weekly Prep',
     });
   }
 
   return items.slice(0, 5);
 }
 
-export function selectFranchiseCommandCenter(league) {
+export function selectWeeklyAgenda(league) {
+  const vm = getHQViewModel(league);
+  if (!vm.userTeam) return [];
+  const weekly = evaluateWeeklyContext(vm.league);
+  const prep = deriveWeeklyPrepState(vm.league);
+  const nextGame = getPrepNextGame(vm.league);
+  return buildWeeklyAgenda({ team: vm.userTeam, league: vm.league, weekly, prep, nextGame });
+}
+
+export function selectFranchiseHQViewModel(league) {
   const vm = getHQViewModel(league);
   if (!vm.userTeam) {
     return { readyState: 'loading', weeklyAgenda: [] };
@@ -131,10 +157,12 @@ export function selectFranchiseCommandCenter(league) {
     readyState: 'ready',
     seasonLabel: `${vm.league?.year ?? 'Season'} · ${String(vm.league?.phase ?? 'regular').replaceAll('_', ' ')}`,
     weekLabel: `Week ${vm.league?.week ?? 1}`,
+    teamRecord: formatRecord(team),
     nextOpponent: nextGame?.opp?.name ?? 'TBD',
     nextOpponentRecord: nextGame?.opp ? formatRecord(nextGame.opp) : '—',
     nextGame,
     prep,
+    prepStatus: prep?.readinessLabel ?? 'Prep status unavailable',
     blockers: prep?.blockers ?? [],
     actionStatuses: deriveActionStatuses(weekly, nextGame),
     weeklyAgenda: buildWeeklyAgenda({ team, league: vm.league, weekly, prep, nextGame }),
@@ -151,3 +179,5 @@ export function selectFranchiseCommandCenter(league) {
     leagueNews,
   };
 }
+
+export const selectFranchiseCommandCenter = selectFranchiseHQViewModel;


### PR DESCRIPTION
### Motivation
- Improve visual hierarchy and mobile-native feeling of the Franchise HQ by consolidating scattered top controls into one clear weekly hero and reducing duplicated advance controls.
- Replace the static Priority Rail with a state-driven Weekly Agenda that surfaces the top 3–5 actionable franchise priorities derived from live state.
- Tighten lower-priority modules and polish the mobile bottom nav to make the screen easier to scan and act on within seconds.

### Description
- Consolidated the HQ top area into a single `WeeklyHero` that shows season/week, opponent context, team record, prep/readiness, last-game snapshot, standing, and the single primary in-content `Advance Week` CTA (moved into `FranchiseHQ`).
- Reworked the priority rail into a derived `WeeklyAgenda` (`buildWeeklyAgenda`, `selectWeeklyAgenda`) where each item includes `id`, `icon`, `title`, `description`, `severity`, `ctaLabel`, and `targetRoute`, and added `AgendaItemRow`/`WeeklyAgenda` UI primitives for tappable rows. (see `src/ui/utils/franchiseCommandCenter.js`, `src/ui/components/ScreenSystem.jsx`).
- Centralized HQ view shaping with `selectFranchiseHQViewModel` which returns a single view-model (seasonLabel, weekLabel, teamRecord, nextOpponent, prepStatus, weeklyAgenda, teamOverview, leagueNews, etc.) and preserved a compatibility alias for `selectFranchiseCommandCenter`.
- Upgraded the four weekly verbs into stronger `ActionTile`s and tightened lower sections into `Snapshot` (SummaryGrid), `League Pulse` (compact news), and `Last Game Recap` to reduce vertical bloat and reinforce hierarchy (updates to `FranchiseHQ.jsx`, `screen-system.css`, and `app-mobile.css`).
- Polished mobile bottom nav: replaced old tab set with `HQ / Team / League / News / More`, refined icon/label sizing and safe-area padding, and made the promoted advance button visually subordinate (`mobile-bottom-tab-advance-subtle`).
- Added small UI primitives: `WeeklyHero`, `StatusBadge` alias, `AgendaItemRow`, `WeeklyAgenda`, `SummaryGrid`, and `CompactNewsCard` to reduce one-off layouts and standardize appearance (`ScreenSystem.jsx`).

### Testing
- Ran targeted unit tests: `npm run test:unit -- src/ui/components/__tests__/FranchiseHQ.test.jsx src/ui/components/MobileNav.test.jsx` and both test files passed (4 tests total).
- Updated the affected unit tests to assert renamed sections and mobile nav semantics and confirmed they render without throwing with partial/legacy payloads.
- No simulation or state-flow logic was changed beyond creating view-model/selectors, and existing route destinations and player profile modal paths were preserved by design.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e854a69320832d82e79fb85996eb09)