### PR TITLE
Enhance HQ feedback, cap visualization, and mobile navigation

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -23,6 +23,7 @@ function safeNum(value, fallback = 0) {
 
 export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdvanceWeek, busy, simulating }) {
   const [lineupToast, setLineupToast] = useState(null);
+  const [expandedPressure, setExpandedPressure] = useState(false);
   const command = useMemo(() => selectFranchiseHQViewModel(league), [league]);
 
   if (command.readyState !== 'ready') {
@@ -56,17 +57,25 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdva
   ];
 
   const lastGame = command.lastGameSummary;
+  const mandate = command.ownerMandate;
+  const cap = command.capSnapshot;
+
+  const handlePrepChecklistToggle = (item) => {
+    const nextValue = !item?.done;
+    markWeeklyPrepStep(league, item?.key, nextValue);
+    if (!nextValue) return;
+    onNavigate?.(item?.tab ?? 'Weekly Prep');
+  };
 
   return (
     <div className="app-screen-stack franchise-hq franchise-command-center">
       <WeeklyHero
         eyebrow={`${command.seasonLabel} · ${command.weekLabel}`}
         title={`Next: ${command.nextGame?.isHome ? 'vs' : '@'} ${command.nextOpponent}`}
-        subtitle={`Your record ${command.teamRecord} · Opponent ${command.nextOpponentRecord}`}
-        rightMeta={<StatusChip label={command.prepStatus} tone="info" />}
+        subtitle={`Your record ${command.teamRecord} ${command.momentum?.icon ?? '→'} · Opponent ${command.nextOpponentRecord}`}
+        rightMeta={<StatusChip label={`${command.prepStatus} · ${command.momentum?.label ?? 'No trend yet'}`} tone="info" />}
         actions={(
           <>
-            <Button size="sm" variant="outline" onClick={() => onNavigate?.('Weekly Prep')}>Prep Details</Button>
             <Button size="sm" className="app-advance-btn app-command-advance" onClick={onAdvanceWeek} disabled={busy || simulating}>{busy || simulating ? 'Advancing…' : 'Advance Week'}</Button>
           </>
         )}
@@ -82,8 +91,26 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdva
           </div>
           <div>
             <span>Owner Pressure</span>
-            <strong>{command.pressureSummary}</strong>
+            <strong>{command.pressureSummary} {command.momentum?.icon ?? '→'}</strong>
           </div>
+        </div>
+        {command.lastGameMoments?.length ? (
+          <div className="app-moment-list">
+            {command.lastGameMoments.map((moment) => <p key={moment.id}>• {moment.text}</p>)}
+          </div>
+        ) : null}
+        <div className="app-prep-checklist">
+          {command.prepChecklist?.map((item) => (
+            <button
+              key={item.key}
+              type="button"
+              className={`app-prep-checklist__item ${item.done ? 'is-done' : ''}`}
+              onClick={() => handlePrepChecklistToggle(item)}
+            >
+              <span className="app-prep-checklist__check">{item.done ? '✓' : '○'}</span>
+              <span>{item.label}</span>
+            </button>
+          ))}
         </div>
         {command.blockers?.length ? <div className="app-blocker-row"><StatusChip label={`${command.blockers.length} prep blocker${command.blockers.length > 1 ? 's' : ''}`} tone="warning" /></div> : null}
       </WeeklyHero>
@@ -99,11 +126,59 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdva
         <WeeklyAgenda items={command.weeklyAgenda} onOpenTask={(task) => onNavigate?.(task?.targetRoute ?? task?.tab ?? 'HQ')} />
       </SectionCard>
 
+      <SectionCard title="Owner Mandate" subtitle="Approval impact by likely outcomes." variant="compact">
+        <div className="app-mandate-meter" role="meter" aria-valuemin={0} aria-valuemax={100} aria-valuenow={mandate?.approval ?? 0}>
+          <div className="app-mandate-meter__segment tone-danger" />
+          <div className="app-mandate-meter__segment tone-warning" />
+          <div className="app-mandate-meter__segment tone-ok" />
+          <div className="app-mandate-meter__needle" style={{ left: `${Math.max(0, Math.min(100, mandate?.approval ?? 0))}%` }} />
+        </div>
+        <p className="app-mandate-caption">{mandate?.approval ?? 0}% approval · {command.pressureSummary}</p>
+        <button type="button" className="btn btn-sm" onClick={() => setExpandedPressure((prev) => !prev)}>
+          {expandedPressure ? 'Hide trigger details' : 'Show trigger details'}
+        </button>
+        {expandedPressure ? (
+          <div className="app-mandate-deltas">
+            {mandate?.deltas?.map((row) => <p key={row.label}><strong>{row.label}</strong> <span>{row.delta > 0 ? `+${row.delta}` : row.delta}</span></p>)}
+          </div>
+        ) : null}
+        <div className="app-expiring-list">
+          <strong>{mandate?.expiringStarters?.length ?? 0} expiring starters</strong>
+          {(mandate?.expiringStarters ?? []).slice(0, 5).map((player) => (
+            <button key={player.id} type="button" className="app-expiring-list__row" onClick={() => onNavigate?.('Contract Center')}>
+              <span>{player.pos} · {player.name} ({player.ovr} OVR)</span>
+              <span>${player.estCost.toFixed(1)}M</span>
+            </button>
+          ))}
+        </div>
+      </SectionCard>
+
       <div className="app-command-bottom-grid">
         <SectionCard title="Snapshot" subtitle="Quick pressure and readiness indicators." variant="compact">
           <SummaryGrid items={command.teamOverview} />
+          <div className="app-cap-thermometer">
+            <div className={`app-cap-thermometer__fill tone-${cap?.tone ?? 'ok'}`} style={{ width: `${cap?.capUsedPct ?? 0}%` }} />
+            {cap?.deadCapPct > 0 ? <div className="app-cap-thermometer__dead" style={{ width: `${cap.deadCapPct}%` }} /> : null}
+          </div>
+          <p className="app-cap-caption">
+            Used ${cap?.capUsed?.toFixed(1) ?? '0.0'}M / ${cap?.capTotal?.toFixed(1) ?? '0.0'}M · Room ${cap?.capRoom?.toFixed(1) ?? '0.0'}M · Rollover ${cap?.projectedRollover?.toFixed(1) ?? '0.0'}M
+          </p>
         </SectionCard>
         <SectionCard title="League Pulse" subtitle="Compact headlines around the league." variant="compact">
+          <div className="app-division-mini-table">
+            {(command.divisionMiniStandings ?? []).map((teamRow) => (
+              <div key={teamRow.id} className={`app-division-mini-table__row ${teamRow.isUser ? 'is-user' : ''}`}>
+                <strong>{teamRow.abbr}</strong>
+                <span>{teamRow.record}</span>
+                <span>PF {teamRow.pf}</span>
+                <span>PA {teamRow.pa}</span>
+                <span>{teamRow.streak}</span>
+              </div>
+            ))}
+          </div>
+          <div className="app-spotlight-results">
+            {(command.spotlightResults ?? []).map((game) => <p key={game.id}>{game.label}</p>)}
+          </div>
           <div className="app-news-compact-list">
             {(command.leagueNews ?? []).slice(0, 3).map((item) => (
               <CompactNewsCard key={item.id} title={item.headline} subtitle={item.detail} />
@@ -124,6 +199,20 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdva
           </CompactListRow>
         </SectionCard>
       ) : null}
+
+      <SectionCard title="Injury Spotlight" subtitle="Highest-impact injury this week." variant="compact">
+        {command.injurySpotlight ? (
+          <CompactListRow
+            title={`${command.injurySpotlight.name} · ${command.injurySpotlight.pos} · ${command.injurySpotlight.ovr} OVR`}
+            subtitle={`${command.injurySpotlight.severity} · Expected return Week ${command.injurySpotlight.returnWeek}`}
+            meta={<StatusChip label={command.injurySpotlight.severity} tone={command.injurySpotlight.severity === 'IR' ? 'danger' : 'warning'} />}
+          >
+            <Button size="sm" variant="outline" onClick={() => onNavigate?.('Injuries')}>Open injuries</Button>
+          </CompactListRow>
+        ) : (
+          <EmptyState title="No major injuries" body="Your top rotation is currently available." />
+        )}
+      </SectionCard>
     </div>
   );
 }

--- a/src/ui/components/MobileNav.jsx
+++ b/src/ui/components/MobileNav.jsx
@@ -40,7 +40,7 @@ const BOTTOM_TABS = [
   { id: 'More', label: 'More', icon: MoreIcon, action: 'menu', value: 'more' },
 ];
 
-export default function MobileNav({ activeSection, activeTab, onSectionChange, onDestinationChange, onAdvance, advanceLabel, advanceDisabled, league }) {
+export default function MobileNav({ activeSection, activeTab, onSectionChange, onDestinationChange, league }) {
   const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => setMenuOpen(false), [activeSection]);
@@ -68,6 +68,9 @@ export default function MobileNav({ activeSection, activeTab, onSectionChange, o
     setMenuOpen(false);
     window.scrollTo(0, 0);
   };
+
+  const hasTeamAlerts = Boolean((league?.incomingTradeOffers ?? []).length) || Boolean((league?.teams ?? []).find((team) => Number(team?.id) === Number(league?.userTeamId))?.roster?.some((player) => Number(player?.injuryWeeksRemaining ?? player?.injuredWeeks ?? player?.injury?.gamesRemaining ?? 0) > 0));
+  const hasLeagueAlerts = Boolean((league?.newsItems ?? []).length);
 
   return (
     <>
@@ -118,19 +121,10 @@ export default function MobileNav({ activeSection, activeTab, onSectionChange, o
             <button key={tab.id} className={`mobile-bottom-tab premium-bottom-tab ${isActive ? 'active' : ''}`} onClick={onClick} aria-label={tab.label}>
               <Icon size={20} />
               <span className="mobile-bottom-label">{tab.label}</span>
+              {(tab.id === 'Team' && hasTeamAlerts) || (tab.id === 'League' && hasLeagueAlerts) ? <span className="mobile-bottom-tab__badge" aria-hidden /> : null}
             </button>
           );
         })}
-
-        <button
-          className="mobile-bottom-tab premium-bottom-tab mobile-bottom-tab-advance mobile-bottom-tab-advance-subtle"
-          onClick={onAdvance}
-          disabled={advanceDisabled}
-          aria-label={advanceLabel || 'Advance'}
-        >
-          <PlayIcon size={22} />
-          <span className="mobile-bottom-label">{advanceLabel || 'Advance'}</span>
-        </button>
       </div>
     </>
   );
@@ -140,7 +134,6 @@ function HomeIcon({ size = 24 }) { return <svg width={size} height={size} viewBo
 function StandingsIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M5 6h14M5 12h14M5 18h14" /></svg>; }
 function RosterIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="9" cy="7" r="4" /><path d="M2 21v-2a5 5 0 0 1 5-5h4a5 5 0 0 1 5 5v2" /></svg>; }
 function NewsIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M4 5h14a2 2 0 0 1 2 2v12H6a2 2 0 0 1-2-2z" /><path d="M8 9h8M8 13h8M8 17h5" /></svg>; }
-function PlayIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor"><path d="m8 5 11 7-11 7z" /></svg>; }
 function FAIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M16 4v8M20 8h-8" /><circle cx="8" cy="8" r="4" /><path d="M2 21v-1a5 5 0 0 1 5-5h2" /></svg>; }
 function TradesIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="m17 1 4 4-4 4" /><path d="M3 11V9a4 4 0 0 1 4-4h14" /><path d="m7 23-4-4 4-4" /><path d="M21 13v2a4 4 0 0 1-4 4H3" /></svg>; }
 function DraftIcon({ size = 24 }) { return <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M14 2H6a2 2 0 0 0-2 2v16h16V8z" /><path d="M14 2v6h6" /></svg>; }

--- a/src/ui/components/MobileNav.test.jsx
+++ b/src/ui/components/MobileNav.test.jsx
@@ -12,17 +12,14 @@ describe('MobileNav', () => {
         activeTab="Team:Roster / Depth"
         onSectionChange={vi.fn()}
         onDestinationChange={vi.fn()}
-        onAdvance={vi.fn()}
-        advanceLabel="Advance Week"
-        advanceDisabled={false}
-        league={{ year: 2026, phase: 'regular' }}
+        league={{ year: 2026, phase: 'regular', userTeamId: 1, teams: [{ id: 1, roster: [{ id: 7, injuryWeeksRemaining: 2 }] }] }}
       />,
     );
 
     expect(html).toContain('premium-bottom-nav');
     expect(html).toContain('premium-bottom-tab active" aria-label="Team"');
     expect(html).toContain('Team');
-    expect(html).toContain('Advance Week');
+    expect(html).toContain('mobile-bottom-tab__badge');
   });
 
   it('keeps command menu destinations wired for more drawer entries', () => {
@@ -31,9 +28,6 @@ describe('MobileNav', () => {
         activeSection={SHELL_SECTIONS.hq}
         onSectionChange={vi.fn()}
         onDestinationChange={vi.fn()}
-        onAdvance={vi.fn()}
-        advanceLabel="Advance"
-        advanceDisabled={false}
         league={{ year: 2026, phase: 'regular' }}
       />,
     );

--- a/src/ui/components/StatLeadersWidget.jsx
+++ b/src/ui/components/StatLeadersWidget.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { teamColor } from "../../data/team-utils.js";
+import EmptyState from "./EmptyState.jsx";
 
 function LeaderList({ title, players, onPlayerSelect }) {
   return (
@@ -111,6 +112,7 @@ export default function StatLeadersWidget({ onPlayerSelect, actions }) {
   const [mode, setMode] = useState("league"); // 'league' | 'team'
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [showProjected, setShowProjected] = useState(false);
 
   useEffect(() => {
     setLoading(true);
@@ -146,6 +148,12 @@ export default function StatLeadersWidget({ onPlayerSelect, actions }) {
   if (!data) return null;
 
   const currentData = mode === "league" ? data.league : data.team;
+
+  const projectedLeaders = {
+    passing: (data?.league?.passing || []).slice(0, 3),
+    rushing: (data?.league?.rushing || []).slice(0, 3),
+    receiving: (data?.league?.receiving || []).slice(0, 3),
+  };
 
   // Determine if there's any data
   const hasData = ["passing", "rushing", "receiving"].some(
@@ -217,16 +225,22 @@ export default function StatLeadersWidget({ onPlayerSelect, actions }) {
       </div>
 
       {!hasData ? (
-        <div
-          style={{
-            textAlign: "center",
-            padding: "var(--space-4) 0",
-            color: "var(--text-muted)",
-            fontSize: "var(--text-sm)",
-          }}
-        >
-          No stats available yet.
-        </div>
+        <>
+          <EmptyState
+            icon="📊"
+            title="Season kicks off this week"
+            subtitle="Stat leaders will appear after Week 1 games are played."
+            action={showProjected ? "Hide League Predictions" : "Preview League Predictions"}
+            onAction={() => setShowProjected((prev) => !prev)}
+          />
+          {showProjected ? (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-4)", marginTop: "var(--space-2)" }}>
+              <LeaderList title="Projected Pass Yds" players={projectedLeaders.passing} onPlayerSelect={onPlayerSelect} />
+              <LeaderList title="Projected Rush Yds" players={projectedLeaders.rushing} onPlayerSelect={onPlayerSelect} />
+              <LeaderList title="Projected Rec Yds" players={projectedLeaders.receiving} onPlayerSelect={onPlayerSelect} />
+            </div>
+          ) : null}
+        </>
       ) : (
         <div
           style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-6)" }}

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -72,13 +72,13 @@ describe('FranchiseHQ', () => {
     );
 
     expect(html).toContain('Advance Week');
-    expect(html).toContain('Prep Details');
     expect(html).toContain('Set Lineup');
     expect(html).toContain('Game Plan');
     expect(html).toContain('Scout Opponent');
     expect(html).toContain('News &amp; Injuries');
     expect(html).toContain('Weekly Agenda');
     expect(html).toContain('Snapshot');
+    expect(html).toContain('Owner Mandate');
     expect(html).toContain('League Pulse');
     expect(html).toContain('Last Game Recap');
   });

--- a/src/ui/styles/app-mobile.css
+++ b/src/ui/styles/app-mobile.css
@@ -1493,6 +1493,7 @@
   min-height: 48px;
   gap: 3px;
   padding-inline: 4px;
+  position: relative;
 }
 
 .premium-bottom-tab svg {
@@ -1503,6 +1504,17 @@
 .mobile-bottom-label {
   font-size: 10px;
   line-height: 1.1;
+}
+
+.mobile-bottom-tab__badge {
+  position: absolute;
+  top: 7px;
+  right: calc(50% - 16px);
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-pill);
+  background: var(--danger);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4);
 }
 
 .mobile-bottom-tab-advance-subtle {

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -233,6 +233,36 @@
 .app-blocker-row { display: flex; flex-wrap: wrap; gap: 8px; }
 .app-command-bottom-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
 .app-summary-grid { display: grid; gap: 8px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.app-moment-list { margin-top: var(--space-2); display: grid; gap: var(--space-1); }
+.app-moment-list p { margin: 0; font-size: var(--text-xs); color: var(--text-muted); }
+.app-prep-checklist { display: grid; gap: var(--space-2); margin-top: var(--space-2); }
+.app-prep-checklist__item { border: 1px solid var(--hairline); border-radius: var(--radius-md); background: color-mix(in srgb, var(--surface) 95%, black 5%); color: var(--text); padding: var(--space-2) var(--space-3); display: flex; align-items: center; gap: var(--space-2); text-align: left; font-size: var(--text-sm); transition: transform .16s ease, border-color .16s ease; }
+.app-prep-checklist__item.is-done { text-decoration: line-through; color: var(--text-subtle); border-color: rgba(52,199,89,.45); }
+.app-prep-checklist__item:hover { transform: translateY(-1px); border-color: var(--hairline-strong); }
+.app-prep-checklist__check { font-weight: 800; min-width: 16px; }
+.app-mandate-meter { margin-top: var(--space-2); position: relative; display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 0; border: 1px solid var(--hairline); border-radius: var(--radius-pill); overflow: hidden; min-height: 12px; }
+.app-mandate-meter__segment.tone-danger { background: rgba(255,69,58,.45); }
+.app-mandate-meter__segment.tone-warning { background: rgba(255,159,10,.45); }
+.app-mandate-meter__segment.tone-ok { background: rgba(52,199,89,.45); }
+.app-mandate-meter__needle { position: absolute; top: -2px; bottom: -2px; width: 2px; background: var(--text); box-shadow: 0 0 0 1px rgba(0,0,0,.35); }
+.app-mandate-caption { margin: var(--space-2) 0; font-size: var(--text-xs); color: var(--text-muted); }
+.app-mandate-deltas { display: grid; gap: var(--space-1); margin-bottom: var(--space-2); }
+.app-mandate-deltas p { margin: 0; display: flex; justify-content: space-between; font-size: var(--text-xs); color: var(--text-muted); }
+.app-expiring-list { margin-top: var(--space-2); display: grid; gap: var(--space-1); }
+.app-expiring-list > strong { font-size: var(--text-sm); }
+.app-expiring-list__row { border: 1px solid var(--hairline); border-radius: var(--radius-sm); background: rgba(255,255,255,.02); color: var(--text); font-size: var(--text-xs); padding: var(--space-2); display: flex; justify-content: space-between; gap: var(--space-2); }
+.app-cap-thermometer { margin-top: var(--space-2); height: 10px; border-radius: var(--radius-pill); background: rgba(255,255,255,.07); overflow: hidden; position: relative; }
+.app-cap-thermometer__fill { height: 100%; }
+.app-cap-thermometer__fill.tone-ok { background: rgba(52,199,89,.7); }
+.app-cap-thermometer__fill.tone-warning { background: rgba(255,159,10,.74); }
+.app-cap-thermometer__fill.tone-danger { background: rgba(255,69,58,.74); }
+.app-cap-thermometer__dead { position: absolute; inset: 0 auto 0 0; background: repeating-linear-gradient(135deg, rgba(255,255,255,.22), rgba(255,255,255,.22) 4px, transparent 4px, transparent 8px); pointer-events: none; }
+.app-cap-caption { margin: var(--space-2) 0 0; font-size: var(--text-xs); color: var(--text-muted); }
+.app-division-mini-table { display: grid; gap: var(--space-1); margin-bottom: var(--space-2); }
+.app-division-mini-table__row { border: 1px solid var(--hairline); border-radius: var(--radius-sm); padding: var(--space-2); font-size: var(--text-xs); display: grid; grid-template-columns: 1fr auto auto auto auto; gap: var(--space-2); align-items: center; }
+.app-division-mini-table__row.is-user { border-color: rgba(var(--accent-rgb), .5); background: rgba(var(--accent-rgb), .08); }
+.app-spotlight-results { display: grid; gap: var(--space-1); margin-bottom: var(--space-2); }
+.app-spotlight-results p { margin: 0; font-size: var(--text-xs); color: var(--text-subtle); }
 .app-news-compact-list { display: grid; gap: 6px; }
 .app-compact-news-card {
   border: 1px solid var(--hairline);

--- a/src/ui/utils/franchiseCommandCenter.js
+++ b/src/ui/utils/franchiseCommandCenter.js
@@ -11,6 +11,97 @@ function safeNum(value, fallback = 0) {
   return Number.isFinite(n) ? n : fallback;
 }
 
+function getScoreDiffs(teamId, scheduleWeeks = []) {
+  const diffs = [];
+  for (const week of [...scheduleWeeks].sort((a, b) => safeNum(a?.week) - safeNum(b?.week))) {
+    for (const game of week?.games ?? []) {
+      if (!game?.played) continue;
+      const homeId = Number(game?.home?.id ?? game?.home);
+      const awayId = Number(game?.away?.id ?? game?.away);
+      if (homeId !== Number(teamId) && awayId !== Number(teamId)) continue;
+      const homeScore = safeNum(game?.homeScore ?? game?.score?.home);
+      const awayScore = safeNum(game?.awayScore ?? game?.score?.away);
+      diffs.push(homeId === Number(teamId) ? homeScore - awayScore : awayScore - homeScore);
+    }
+  }
+  return diffs;
+}
+
+function deriveMomentum(teamId, scheduleWeeks = []) {
+  const recent = getScoreDiffs(teamId, scheduleWeeks).slice(-3);
+  const total = recent.reduce((sum, value) => sum + value, 0);
+  if (!recent.length) return { icon: '→', label: 'No trend yet' };
+  if (total > 0) return { icon: '↗', label: `Trending up (${total > 9 ? '+' : ''}${total} in last ${recent.length})` };
+  if (total < 0) return { icon: '↘', label: `Trending down (${total} in last ${recent.length})` };
+  return { icon: '→', label: `Flat trend (last ${recent.length})` };
+}
+
+function parsePlayLogMoment(raw, fallback = 'Key swing play') {
+  if (typeof raw !== 'string' || !raw.trim()) return fallback;
+  const compact = raw.replace(/\s+/g, ' ').trim();
+  const quarterMatch = compact.match(/Q[1-4]|OT/i);
+  const quarter = quarterMatch ? quarterMatch[0].toUpperCase() : null;
+  const clipped = compact.length > 88 ? `${compact.slice(0, 85).trimEnd()}…` : compact;
+  return quarter ? `${clipped} (${quarter})` : clipped;
+}
+
+function deriveLastGameMoments(lastGameSummary) {
+  const logs = lastGameSummary?.boxScore?.playLogs;
+  if (!Array.isArray(logs) || !logs.length) return [];
+  const picks = [logs[0], logs[Math.floor(logs.length / 2)], logs[logs.length - 1]].filter(Boolean);
+  return picks.map((entry, idx) => ({
+    id: `moment-${idx}`,
+    text: parsePlayLogMoment(typeof entry === 'string' ? entry : entry?.text),
+  }));
+}
+
+function toMandateDelta({ ownerApproval, capRoom, expiringStarters, incomingTradeCount }) {
+  const deltas = [];
+  deltas.push({ label: 'Win this week', delta: ownerApproval < 55 ? +15 : +10 });
+  deltas.push({ label: 'Trade for a starter', delta: incomingTradeCount > 0 ? +10 : +8 });
+  deltas.push({ label: 'Ignore expiring contracts', delta: expiringStarters >= 4 ? -20 : -12 });
+  if (capRoom < 0) deltas.push({ label: 'Stay over cap', delta: -18 });
+  return deltas;
+}
+
+function estimateResignCost(player) {
+  const annual = safeNum(player?.contract?.baseAnnual ?? player?.contract?.salary ?? player?.contract?.amount, 0);
+  const ovr = safeNum(player?.ovr, 70);
+  const baseline = annual > 0 ? annual : Math.max(1.5, (ovr - 55) * 0.35);
+  return Math.round(baseline * 10) / 10;
+}
+
+function getDisplayName(player) {
+  const composed = `${player?.firstName ?? ''} ${player?.lastName ?? ''}`.trim();
+  if (player?.name) return player.name;
+  if (composed) return composed;
+  return `Player ${player?.id ?? ''}`.trim();
+}
+
+function formatStreak(recentResults = []) {
+  const tail = Array.isArray(recentResults) ? recentResults.slice().reverse() : [];
+  if (!tail.length) return '—';
+  const first = String(tail[0] ?? '').toUpperCase();
+  if (!['W', 'L', 'T'].includes(first)) return '—';
+  let count = 0;
+  for (const value of tail) {
+    if (String(value ?? '').toUpperCase() !== first) break;
+    count += 1;
+  }
+  return `${first}${count}`;
+}
+
+function sortByStandings(teams = []) {
+  return [...teams].sort((a, b) => {
+    const aGames = safeNum(a?.wins) + safeNum(a?.losses) + safeNum(a?.ties);
+    const bGames = safeNum(b?.wins) + safeNum(b?.losses) + safeNum(b?.ties);
+    const aPct = aGames ? (safeNum(a?.wins) + safeNum(a?.ties) * 0.5) / aGames : 0;
+    const bPct = bGames ? (safeNum(b?.wins) + safeNum(b?.ties) * 0.5) / bGames : 0;
+    if (bPct !== aPct) return bPct - aPct;
+    return safeNum(b?.ptsFor) - safeNum(a?.ptsFor);
+  });
+}
+
 function formatRecord(team) {
   if (!team) return '0-0';
   const ties = safeNum(team.ties);
@@ -208,6 +299,69 @@ export function selectFranchiseHQViewModel(league) {
     .map((item, index) => ({ id: item.id ?? `news-${index}`, headline: item.headline ?? item.title ?? 'League update', detail: item.summary ?? item.body ?? null }));
 
   const ownerApproval = safeNum(weekly?.pressurePoints?.ownerApproval ?? vm.league?.ownerApproval ?? vm.league?.ownerMood, 50);
+  const momentum = deriveMomentum(team?.id, vm.league?.schedule?.weeks ?? []);
+  const lastGameMoments = deriveLastGameMoments(latestArchived ?? fallbackLastGame);
+  const prepChecklist = [
+    { key: 'lineupChecked', label: 'Set Lineup', tab: 'Team:Roster / Depth', done: Boolean(prep?.completion?.lineupChecked) },
+    { key: 'opponentScouted', label: 'Scout Opponent', tab: 'Weekly Prep', done: Boolean(prep?.completion?.opponentScouted) },
+    { key: 'planReviewed', label: 'Game Plan', tab: 'Game Plan', done: Boolean(prep?.completion?.planReviewed) },
+  ];
+  const expiringStarters = (team?.roster ?? [])
+    .filter((player) => safeNum(player?.contract?.yearsRemaining ?? player?.contract?.years ?? 0) <= 1 && safeNum(player?.ovr, 0) >= 75)
+    .sort((a, b) => safeNum(b?.ovr) - safeNum(a?.ovr))
+    .slice(0, 8)
+    .map((player) => ({
+      id: player?.id,
+      name: getDisplayName(player),
+      pos: player?.pos ?? '—',
+      ovr: safeNum(player?.ovr, 0),
+      estCost: estimateResignCost(player),
+    }));
+  const mandateDeltas = toMandateDelta({
+    ownerApproval,
+    capRoom: cap.capRoom,
+    expiringStarters: expiringStarters.length,
+    incomingTradeCount: safeNum(weekly?.pressurePoints?.incomingTradeCount, 0),
+  });
+  const capTotal = Math.max(1, safeNum(cap.capTotal, 255));
+  const capUsed = safeNum(cap.capUsed, 0);
+  const deadCap = safeNum(team?.deadCap ?? team?.deadMoney ?? 0);
+  const capUsedPct = Math.max(0, Math.min(100, (capUsed / capTotal) * 100));
+  const deadCapPct = Math.max(0, Math.min(capUsedPct, (deadCap / capTotal) * 100));
+  const projectedRollover = Math.round((cap.capRoom - deadCap * 0.25) * 10) / 10;
+  const divisionTeams = (vm.league?.teams ?? []).filter((candidate) => Number(candidate?.conf) === Number(team?.conf) && Number(candidate?.div) === Number(team?.div));
+  const divisionMiniStandings = sortByStandings(divisionTeams).slice(0, 4).map((candidate) => ({
+    id: candidate?.id,
+    abbr: candidate?.abbr ?? candidate?.name ?? 'TEAM',
+    record: formatRecord(candidate),
+    pf: safeNum(candidate?.ptsFor, 0),
+    pa: safeNum(candidate?.ptsAgainst, 0),
+    streak: formatStreak(candidate?.recentResults),
+    isUser: Number(candidate?.id) === Number(team?.id),
+  }));
+  const latestWeek = [...(vm.league?.schedule?.weeks ?? [])]
+    .filter((week) => (week?.games ?? []).some((game) => game?.played))
+    .sort((a, b) => safeNum(b?.week) - safeNum(a?.week))[0];
+  const spotlightResults = (latestWeek?.games ?? [])
+    .filter((game) => game?.played)
+    .map((game, idx) => {
+      const homeId = Number(game?.home?.id ?? game?.home);
+      const awayId = Number(game?.away?.id ?? game?.away);
+      const homeTeam = vm.league?.teams?.find((candidate) => Number(candidate?.id) === homeId);
+      const awayTeam = vm.league?.teams?.find((candidate) => Number(candidate?.id) === awayId);
+      const total = safeNum(game?.homeScore) + safeNum(game?.awayScore);
+      const margin = Math.abs(safeNum(game?.homeScore) - safeNum(game?.awayScore));
+      return {
+        id: game?.id ?? `spotlight-${idx}`,
+        label: `${awayTeam?.abbr ?? 'AWY'} ${safeNum(game?.awayScore)} @ ${homeTeam?.abbr ?? 'HME'} ${safeNum(game?.homeScore)}${safeNum(game?.overtimePeriods ?? game?.ot, 0) > 0 ? ' OT' : ''}`,
+        scoreWeight: total + (margin <= 3 ? 8 : 0),
+      };
+    })
+    .sort((a, b) => b.scoreWeight - a.scoreWeight)
+    .slice(0, 2);
+  const injuredSpotlight = (team?.roster ?? [])
+    .filter((player) => safeNum(player?.injuryWeeksRemaining ?? player?.injuredWeeks ?? player?.injury?.gamesRemaining ?? 0) > 0)
+    .sort((a, b) => safeNum(b?.ovr) - safeNum(a?.ovr))[0] ?? null;
 
   return {
     readyState: 'ready',
@@ -219,7 +373,16 @@ export function selectFranchiseHQViewModel(league) {
     nextGame,
     prep,
     prepStatus: prep?.readinessLabel ?? 'Prep status unavailable',
+    prepChecklist,
+    momentum,
+    lastGameMoments,
     pressureSummary: ownerApproval < 45 ? `Owner pressure high (${ownerApproval}%)` : ownerApproval < 60 ? `Owner pressure elevated (${ownerApproval}%)` : `Owner confidence stable (${ownerApproval}%)`,
+    ownerMandate: {
+      approval: ownerApproval,
+      tone: ownerApproval < 45 ? 'danger' : ownerApproval < 65 ? 'warning' : 'ok',
+      deltas: mandateDeltas,
+      expiringStarters,
+    },
     blockers: prep?.blockers ?? [],
     actionStatuses: deriveActionStatuses(weekly, nextGame),
     weeklyAgenda: buildWeeklyAgenda({ team, league: vm.league, weekly, prep, nextGame }),
@@ -233,6 +396,32 @@ export function selectFranchiseHQViewModel(league) {
       { label: 'Injuries', value: `${safeNum(weekly?.pressurePoints?.injuriesCount, 0)}`, tone: safeNum(weekly?.pressurePoints?.injuriesCount, 0) >= 3 ? 'warning' : 'info' },
       { label: 'Owner Confidence', value: `${safeNum(weekly?.pressurePoints?.ownerApproval ?? vm.league?.ownerApproval ?? vm.league?.ownerMood, 50)}%`, tone: safeNum(weekly?.pressurePoints?.ownerApproval ?? vm.league?.ownerApproval ?? vm.league?.ownerMood, 50) < 50 ? 'danger' : 'ok' },
     ],
+    capSnapshot: {
+      capTotal,
+      capUsed,
+      capRoom: safeNum(cap.capRoom, 0),
+      capUsedPct,
+      deadCap,
+      deadCapPct,
+      projectedRollover,
+      tone: safeNum(cap.capRoom, 0) < 5 ? 'danger' : safeNum(cap.capRoom, 0) < 12 ? 'warning' : 'ok',
+    },
+    divisionMiniStandings,
+    spotlightResults,
+    injurySpotlight: injuredSpotlight
+      ? {
+        id: injuredSpotlight?.id,
+        name: getDisplayName(injuredSpotlight),
+        pos: injuredSpotlight?.pos ?? '—',
+        ovr: safeNum(injuredSpotlight?.ovr, 0),
+        severity: safeNum(injuredSpotlight?.injuryWeeksRemaining ?? injuredSpotlight?.injuredWeeks ?? injuredSpotlight?.injury?.gamesRemaining, 0) >= 8
+          ? 'IR'
+          : safeNum(injuredSpotlight?.injuryWeeksRemaining ?? injuredSpotlight?.injuredWeeks ?? injuredSpotlight?.injury?.gamesRemaining, 0) >= 2
+            ? 'OUT'
+            : 'DTD',
+        returnWeek: safeNum(vm.league?.week, 1) + safeNum(injuredSpotlight?.injuryWeeksRemaining ?? injuredSpotlight?.injuredWeeks ?? injuredSpotlight?.injury?.gamesRemaining, 0),
+      }
+      : null,
     leagueNews,
     navState: {
       activeSection: 'hq',


### PR DESCRIPTION
### Motivation
- Make the Weekly/Franchise HQ less of a black box by surfacing why recent results matter and what actions move owner sentiment and cap health. 
- Let users act directly from HQ on urgent prep items, expiring starters, and cap pressure without navigating deep into menus. 
- Reduce navigation clutter on mobile by removing duplicate advance affordances and surfacing actionable badges for Team/League.

### Description
- Added game-feedback utilities and derived view model fields in `src/ui/utils/franchiseCommandCenter.js`: `deriveMomentum`, `deriveLastGameMoments`, `prepChecklist`, `ownerMandate` deltas, `capSnapshot`, `divisionMiniStandings`, `spotlightResults`, and `injurySpotlight`.
- Rendered HQ UI enhancements in `src/ui/components/FranchiseHQ.jsx`: momentum arrow + label, 3-play mini play-by-play, tappable prep checklist items that mark weekly prep steps, segmented owner-mandate meter with expandable trigger deltas, expiring-starters drill-down with estimated re-sign cost, cap thermometer with dead-cap overlay and rollover estimate, division mini-standings, spotlight result cards, and injury spotlight quick view.
- Streamlined mobile navigation in `src/ui/components/MobileNav.jsx` by removing the bottom advance pill and adding red-dot badges to `Team`/`League` when actionable items exist, with accompanying CSS in `src/ui/styles/app-mobile.css`.
- Reused shared `EmptyState` in `src/ui/components/StatLeadersWidget.jsx` to show a contextual kickoff empty state and an opt-in projected leaders preview (keeps existing components/tokens and animation classes).
- Added CSS rules in `src/ui/styles/screen-system.css` and `src/ui/styles/app-mobile.css` for the new HQ sections (prep checklist, moment list, mandate meter, cap thermometer, division mini-table, and mobile tab badges).
- Updated component tests to reflect the new HQ and MobileNav expectations (`src/ui/components/__tests__/FranchiseHQ.test.jsx` and `src/ui/components/MobileNav.test.jsx`).

### Testing
- Ran the focused component tests with `npx vitest run src/ui/components/__tests__/FranchiseHQ.test.jsx src/ui/components/MobileNav.test.jsx src/ui/utils/weeklyPrep.test.js` and all tests passed.
- Verified a production build with `npm run build` locally (build completed; Vite emitted a pre-existing chunk-size warning but the build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f033c5d4832d862984e5959654d5)