### PR TITLE
Add Franchise Chronicle and Story tab (persistent timeline)

### DIFF
--- a/src/ui/components/FranchiseStoryHub.jsx
+++ b/src/ui/components/FranchiseStoryHub.jsx
@@ -1,0 +1,69 @@
+import React, { useMemo, useState } from 'react';
+import { EmptyState, SectionCard, StatusChip } from './ScreenSystem.jsx';
+import { syncFranchiseChronicle } from '../utils/franchiseChronicle.js';
+
+function toneForResult(result) {
+  const r = String(result ?? '').toUpperCase();
+  if (r === 'W') return 'var(--success)';
+  if (r === 'L') return 'var(--danger)';
+  return 'var(--text-subtle)';
+}
+
+export default function FranchiseStoryHub({ league }) {
+  const [expandedId, setExpandedId] = useState(null);
+  const story = useMemo(() => syncFranchiseChronicle(league), [league]);
+  const entries = [...(story.entries ?? [])].reverse();
+
+  return (
+    <div className="app-screen-stack franchise-story-hub">
+      <SectionCard title="Franchise Chronicle" subtitle="A living timeline of each week in your dynasty run." variant="compact">
+        {!entries.length ? (
+          <EmptyState title="No story entries yet" body="Play your first game to start the chronicle." />
+        ) : (
+          <div className="app-list-stack">
+            {entries.map((entry) => {
+              const open = expandedId === entry.id;
+              return (
+                <article key={entry.id} className="app-story-card" style={{ borderLeft: `4px solid ${toneForResult(entry.result)}`, paddingLeft: 'var(--space-3)' }}>
+                  <button type="button" className="app-story-card__header" onClick={() => setExpandedId(open ? null : entry.id)} style={{ width: '100%', textAlign: 'left', background: 'transparent', border: 0, padding: 0 }}>
+                    <p style={{ margin: 0, fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>Week {entry.week} · {entry.summary}</p>
+                    <strong>{entry.headline}</strong>
+                    <p style={{ margin: '4px 0 0', color: 'var(--text-muted)', fontSize: 'var(--text-xs)' }}>Conf standing: #{entry.standingsPosition ?? '—'} {entry.standout?.name ? `· Standout: ${entry.standout.name}` : ''}</p>
+                  </button>
+                  {open ? (
+                    <div style={{ marginTop: 'var(--space-2)' }}>
+                      {!!entry.events?.length && (
+                        <>
+                          <p style={{ margin: '0 0 4px', fontWeight: 600 }}>Franchise events</p>
+                          {entry.events.map((event, idx) => <p key={`${entry.id}-e-${idx}`} style={{ margin: '0 0 4px', color: 'var(--text-muted)' }}>• {event}</p>)}
+                        </>
+                      )}
+                      {!!entry.moments?.length && (
+                        <>
+                          <p style={{ margin: '8px 0 4px', fontWeight: 600 }}>Game moments</p>
+                          {entry.moments.map((moment) => <p key={moment.id} style={{ margin: '0 0 4px', color: 'var(--text-muted)' }}>• {moment.text}</p>)}
+                        </>
+                      )}
+                    </div>
+                  ) : null}
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </SectionCard>
+
+      <SectionCard title="Season in Review" subtitle="Auto-generated recap when the year closes." variant="compact">
+        {story.seasonReview ? <p style={{ margin: 0 }}>{story.seasonReview.text}</p> : <EmptyState title="Season still in progress" body="Finish the regular season to unlock your review card." />}
+      </SectionCard>
+
+      <SectionCard title="Milestone Badges" subtitle="Persistent dynasty achievements." variant="compact">
+        <div className="app-chip-row" style={{ gap: 'var(--space-2)' }}>
+          {(story.badges ?? []).map((badge) => (
+            <StatusChip key={badge.id} label={badge.unlocked ? `🏆 ${badge.label}` : `🔒 ${badge.label}`} tone={badge.unlocked ? 'ok' : 'info'} />
+          ))}
+        </div>
+      </SectionCard>
+    </div>
+  );
+}

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -67,6 +67,7 @@ import DraftBigBoard from "./DraftBigBoard.jsx";
 import CoachingScreen from "./CoachingScreen.jsx";
 import TeamHub from "./TeamHub.jsx";
 import LeagueHub from "./LeagueHub.jsx";
+import FranchiseStoryHub from "./FranchiseStoryHub.jsx";
 import ScheduleCenter from "./ScheduleCenter.jsx";
 import StandingsCenter from "./StandingsCenter.jsx";
 import SectionSubnav from "./SectionSubnav.jsx";
@@ -171,6 +172,7 @@ const BASE_TABS = [
   "Team",
   "League",
   "News",
+  "Story",
   "Standings",
   "Schedule",
   "Weekly Results",
@@ -216,7 +218,7 @@ const NAV_GROUPS = [
   { id: SHELL_SECTIONS.hq, title: "HQ", tabs: ["HQ"] },
   { id: SHELL_SECTIONS.team, title: "Team Management", tabs: ["Team", "Roster Hub", "Roster", "Depth Chart", "Weekly Prep", "Game Plan", "Training", "Injuries", "Staff", "Financials", "Contract Center", "💰 Cap"] },
   { id: SHELL_SECTIONS.league, title: "League Office", tabs: ["League", "Weekly Results", "Schedule", "Standings", "Stats", "League Leaders", "Transactions", "Free Agency", "Draft", "History Hub", "History", "Awards & Records", "Season Recap"] },
-  { id: SHELL_SECTIONS.news, title: "News", tabs: ["News"] },
+  { id: SHELL_SECTIONS.news, title: "News", tabs: ["News", "Story"] },
 ];
 
 const NAV_TEST_IDS = {
@@ -927,6 +929,11 @@ export default function LeagueDashboard({
               onOpenBoxScore={(gameId) => openGameDetail(gameId, "News")}
               onNavigate={setActiveTab}
             />
+          </TabErrorBoundary>
+        )}
+        {activeTab === "Story" && (
+          <TabErrorBoundary label="Story" onNavigate={setActiveTab} fallbackTab="HQ">
+            <FranchiseStoryHub league={league} />
           </TabErrorBoundary>
         )}
         {activeTab === "Standings" && (

--- a/src/ui/components/MobileNav.jsx
+++ b/src/ui/components/MobileNav.jsx
@@ -19,6 +19,7 @@ const MORE_GROUPS = [
     items: [
       { id: 'League:Overview', label: 'League Hub', icon: StandingsIcon },
       { id: 'League:Results', label: 'Weekly Results', icon: StandingsIcon },
+      { id: 'Story', label: 'Story', icon: NewsIcon },
       { id: 'Transactions', label: 'Trades', icon: TradesIcon },
       { id: 'Free Agency', label: 'Free Agency', icon: FAIcon },
       { id: 'Draft', label: 'Draft', icon: DraftIcon },

--- a/src/ui/utils/franchiseChronicle.js
+++ b/src/ui/utils/franchiseChronicle.js
@@ -1,0 +1,188 @@
+function safeNum(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function getUserTeam(league) {
+  return (league?.teams ?? []).find((team) => Number(team?.id) === Number(league?.userTeamId)) ?? null;
+}
+
+function getPlayedUserGames(league) {
+  const userId = Number(league?.userTeamId);
+  const rows = [];
+  for (const week of [...(league?.schedule?.weeks ?? [])].sort((a, b) => safeNum(a?.week) - safeNum(b?.week))) {
+    for (const game of week?.games ?? []) {
+      if (!game?.played) continue;
+      const homeId = Number(game?.home?.id ?? game?.home);
+      const awayId = Number(game?.away?.id ?? game?.away);
+      if (homeId !== userId && awayId !== userId) continue;
+      rows.push({ game, week: safeNum(week?.week, 1), homeId, awayId });
+    }
+  }
+  return rows;
+}
+
+function deriveMomentHeadline(game, fallbackLabel) {
+  const logs = game?.boxScore?.playLogs;
+  if (Array.isArray(logs) && logs.length) {
+    const first = logs.find((entry) => typeof entry === 'string' || entry?.text);
+    const text = typeof first === 'string' ? first : first?.text;
+    if (typeof text === 'string' && text.trim()) {
+      const compact = text.replace(/\s+/g, ' ').trim();
+      return compact.length > 110 ? `${compact.slice(0, 107).trimEnd()}…` : compact;
+    }
+  }
+  return fallbackLabel;
+}
+
+function buildStandingsPosition(league, team) {
+  const confTeams = (league?.teams ?? []).filter((candidate) => Number(candidate?.conf) === Number(team?.conf));
+  const ranked = [...confTeams].sort((a, b) => {
+    const aGames = safeNum(a?.wins) + safeNum(a?.losses) + safeNum(a?.ties);
+    const bGames = safeNum(b?.wins) + safeNum(b?.losses) + safeNum(b?.ties);
+    const aPct = aGames ? (safeNum(a?.wins) + safeNum(a?.ties) * 0.5) / aGames : 0;
+    const bPct = bGames ? (safeNum(b?.wins) + safeNum(b?.ties) * 0.5) / bGames : 0;
+    if (bPct !== aPct) return bPct - aPct;
+    return safeNum(b?.ptsFor) - safeNum(a?.ptsFor);
+  });
+  const index = ranked.findIndex((candidate) => Number(candidate?.id) === Number(team?.id));
+  return index >= 0 ? index + 1 : null;
+}
+
+function resolveStandout(game, team) {
+  const playerOfGame = game?.summary?.playerOfGame;
+  if (playerOfGame?.name) {
+    return {
+      name: playerOfGame.name,
+      detail: playerOfGame?.statLine ?? playerOfGame?.summary ?? 'Player of the game',
+    };
+  }
+  const roster = Array.isArray(team?.roster) ? team.roster : [];
+  const best = [...roster].sort((a, b) => safeNum(b?.ovr) - safeNum(a?.ovr))[0];
+  return best
+    ? { name: `${best?.firstName ?? ''} ${best?.lastName ?? ''}`.trim() || best?.name || `Player ${best?.id}`, detail: `${best?.pos ?? 'POS'} · ${safeNum(best?.ovr)} OVR` }
+    : null;
+}
+
+function findFranchiseEvents(league, week, team) {
+  const abbr = String(team?.abbr ?? '').toUpperCase();
+  const headlines = (league?.newsItems ?? [])
+    .filter((item) => safeNum(item?.week ?? item?.meta?.week ?? week) === week)
+    .map((item) => item?.headline ?? item?.title ?? '')
+    .filter((line) => typeof line === 'string' && line.trim());
+
+  return headlines
+    .filter((line) => !abbr || line.toUpperCase().includes(abbr))
+    .slice(0, 3);
+}
+
+function formatResult({ won, tied, awayAbbr, homeAbbr, awayScore, homeScore }) {
+  if (tied) return `T ${awayAbbr} ${awayScore}-${homeScore} ${homeAbbr}`;
+  return `${won ? 'W' : 'L'} ${awayAbbr} ${awayScore}-${homeScore} ${homeAbbr}`;
+}
+
+function buildChronicleEntry({ league, team, week, game }) {
+  const homeAbbr = game?.home?.abbr ?? 'HOME';
+  const awayAbbr = game?.away?.abbr ?? 'AWAY';
+  const homeScore = safeNum(game?.homeScore ?? game?.score?.home);
+  const awayScore = safeNum(game?.awayScore ?? game?.score?.away);
+  const userIsHome = Number(game?.home?.id ?? game?.home) === Number(team?.id);
+  const won = userIsHome ? homeScore > awayScore : awayScore > homeScore;
+  const tied = homeScore === awayScore;
+  const result = tied ? 'T' : won ? 'W' : 'L';
+  const fallbackHeadline = won
+    ? `${team?.abbr ?? team?.name ?? 'Team'} closes out ${awayAbbr} ${awayScore}-${homeScore} ${homeAbbr}`
+    : `${team?.abbr ?? team?.name ?? 'Team'} drops a tough one ${awayAbbr} ${awayScore}-${homeScore} ${homeAbbr}`;
+
+  return {
+    id: `${safeNum(league?.seasonId, league?.year)}-wk${week}-${game?.id ?? `${awayAbbr}-${homeAbbr}`}`,
+    season: safeNum(league?.year, safeNum(league?.seasonId, 0)),
+    week,
+    result,
+    score: { away: awayScore, home: homeScore, awayAbbr, homeAbbr },
+    summary: formatResult({ won, tied, awayAbbr, homeAbbr, awayScore, homeScore }),
+    headline: deriveMomentHeadline(game, fallbackHeadline),
+    standingsPosition: buildStandingsPosition(league, team),
+    standout: resolveStandout(game, team),
+    events: findFranchiseEvents(league, week, team),
+    moments: Array.isArray(game?.boxScore?.playLogs)
+      ? game.boxScore.playLogs.slice(-3).map((entry, idx) => ({ id: `m-${week}-${idx}`, text: typeof entry === 'string' ? entry : entry?.text ?? 'Key moment' }))
+      : [],
+  };
+}
+
+function buildSeasonInReview(league, team) {
+  const games = safeNum(team?.wins) + safeNum(team?.losses) + safeNum(team?.ties);
+  const regularSeasonComplete = games >= 17 || String(league?.phase ?? '').toLowerCase().includes('offseason');
+  if (!regularSeasonComplete) return null;
+
+  const breakout = [...(team?.roster ?? [])]
+    .sort((a, b) => safeNum(b?.stats?.recYd ?? b?.stats?.passYd ?? b?.stats?.rushYd) - safeNum(a?.stats?.recYd ?? a?.stats?.passYd ?? a?.stats?.rushYd))[0];
+  const breakoutYards = breakout ? safeNum(breakout?.stats?.recYd ?? breakout?.stats?.passYd ?? breakout?.stats?.rushYd) : 0;
+  const divisionTitle = buildStandingsPosition(league, team) === 1;
+
+  return {
+    season: safeNum(league?.year, safeNum(league?.seasonId, 0)),
+    text: `${safeNum(league?.year, 0)} Season: ${safeNum(team?.wins)}-${safeNum(team?.losses)}${safeNum(team?.ties) ? `-${safeNum(team?.ties)}` : ''}${divisionTitle ? ', Division Leaders' : ''}.${breakout ? ` Breakout star: ${breakout?.pos ?? 'Player'} ${breakout?.lastName ?? breakout?.name ?? ''} ${breakoutYards} yds.` : ''}`,
+  };
+}
+
+export const CHRONICLE_BADGES = [
+  { id: 'first_playoff_berth', label: 'First Playoff Berth', description: 'Reach the postseason for the first time.' },
+  { id: 'ten_win_season', label: '10-Win Season', description: 'Finish a season with 10+ wins.' },
+  { id: 'draft_steal', label: 'Draft Steal Found', description: 'Start a rookie selected outside round 1 at 80+ OVR.' },
+  { id: 'cap_wizard', label: 'Cap Wizard', description: 'Carry positive cap room while 3+ starters are re-signed.' },
+];
+
+function deriveBadgeState(league, team, chronicle) {
+  const rookies = (team?.roster ?? []).filter((player) => safeNum(player?.yearsPro, 0) <= 1);
+  const expiring = (team?.roster ?? []).filter((player) => safeNum(player?.contract?.yearsRemaining ?? player?.contract?.years, 0) <= 1 && safeNum(player?.ovr) >= 75);
+
+  const unlocked = {
+    first_playoff_berth: Boolean(team?.playoffAppearances ?? team?.playoffSeed ?? team?.madePlayoffs),
+    ten_win_season: safeNum(team?.wins) >= 10,
+    draft_steal: rookies.some((player) => safeNum(player?.draft?.round, 9) >= 2 && safeNum(player?.ovr) >= 80),
+    cap_wizard: safeNum(team?.capRoom, safeNum(team?.salaryCap, 0) - safeNum(team?.payroll, 0)) > 0 && expiring.length >= 3,
+  };
+
+  return CHRONICLE_BADGES.map((badge) => ({
+    ...badge,
+    unlocked: Boolean(unlocked[badge.id]),
+    unlockedOn: unlocked[badge.id] ? `${safeNum(league?.year, 0)} Week ${safeNum(league?.week, 1)}` : null,
+  }));
+}
+
+export function syncFranchiseChronicle(league) {
+  if (!league || typeof league !== 'object') return { entries: [], seasonReview: null, badges: [] };
+  if (!Array.isArray(league.franchiseChronicle)) league.franchiseChronicle = [];
+
+  const team = getUserTeam(league);
+  if (!team) return { entries: [], seasonReview: null, badges: [] };
+
+  const existing = new Set(league.franchiseChronicle.map((entry) => entry?.id).filter(Boolean));
+  for (const row of getPlayedUserGames(league)) {
+    const entry = buildChronicleEntry({ league, team, week: row.week, game: row.game });
+    if (!existing.has(entry.id)) {
+      league.franchiseChronicle.push(entry);
+      existing.add(entry.id);
+    }
+  }
+
+  league.franchiseChronicle = [...league.franchiseChronicle]
+    .sort((a, b) => (safeNum(a?.season) - safeNum(b?.season)) || (safeNum(a?.week) - safeNum(b?.week)))
+    .slice(-340);
+
+  const seasonReview = buildSeasonInReview(league, team);
+  if (seasonReview) {
+    if (!Array.isArray(league.franchiseSeasonReviews)) league.franchiseSeasonReviews = [];
+    const hasReview = league.franchiseSeasonReviews.some((entry) => safeNum(entry?.season) === safeNum(seasonReview?.season));
+    if (!hasReview) league.franchiseSeasonReviews.push(seasonReview);
+  }
+
+  const badges = deriveBadgeState(league, team, league.franchiseChronicle);
+  return {
+    entries: league.franchiseChronicle,
+    seasonReview: seasonReview ?? [...(league.franchiseSeasonReviews ?? [])].slice(-1)[0] ?? null,
+    badges,
+  };
+}

--- a/src/ui/utils/franchiseChronicle.test.js
+++ b/src/ui/utils/franchiseChronicle.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { syncFranchiseChronicle } from './franchiseChronicle.js';
+
+function buildLeague(overrides = {}) {
+  return {
+    year: 2026,
+    week: 3,
+    userTeamId: 1,
+    phase: 'regular',
+    teams: [
+      {
+        id: 1,
+        conf: 0,
+        div: 1,
+        abbr: 'PIT',
+        wins: 2,
+        losses: 1,
+        ties: 0,
+        capRoom: 15,
+        roster: [
+          { id: 10, firstName: 'Jay', lastName: 'Stone', pos: 'WR', ovr: 84, yearsPro: 1, draft: { round: 3 }, contract: { yearsRemaining: 1 }, stats: { recYd: 410 } },
+          { id: 11, firstName: 'Ty', lastName: 'Cole', pos: 'CB', ovr: 80, yearsPro: 5, contract: { yearsRemaining: 1 } },
+          { id: 12, firstName: 'Sam', lastName: 'Roe', pos: 'LT', ovr: 79, yearsPro: 4, contract: { yearsRemaining: 1 } },
+        ],
+      },
+      { id: 2, conf: 0, div: 1, abbr: 'BAL', wins: 1, losses: 2, ties: 0 },
+    ],
+    schedule: {
+      weeks: [
+        {
+          week: 1,
+          games: [{
+            id: 'g1',
+            played: true,
+            home: { id: 1, abbr: 'PIT' },
+            away: { id: 2, abbr: 'BAL' },
+            homeScore: 24,
+            awayScore: 17,
+            summary: { playerOfGame: { name: 'Jay Stone', statLine: '7 rec, 121 yds, 1 TD' } },
+            boxScore: { playLogs: ['Q4 01:20 Jay Stone 32-yard TD catch for the lead.'] },
+          }],
+        },
+      ],
+    },
+    newsItems: [{ week: 1, headline: 'PIT extends veteran LT through 2028.' }],
+    ...overrides,
+  };
+}
+
+describe('syncFranchiseChronicle', () => {
+  it('builds chronicle entries and keeps backward compatibility for missing saves', () => {
+    const league = buildLeague({ franchiseChronicle: undefined });
+    const story = syncFranchiseChronicle(league);
+    expect(Array.isArray(league.franchiseChronicle)).toBe(true);
+    expect(story.entries).toHaveLength(1);
+    expect(story.entries[0].week).toBe(1);
+    expect(story.entries[0].result).toBe('W');
+    expect(story.entries[0].events[0]).toContain('extends veteran LT');
+  });
+
+  it('does not duplicate entries when called repeatedly', () => {
+    const league = buildLeague();
+    syncFranchiseChronicle(league);
+    const second = syncFranchiseChronicle(league);
+    expect(second.entries).toHaveLength(1);
+  });
+
+  it('generates season review once regular season is complete', () => {
+    const league = buildLeague({
+      phase: 'offseason',
+      teams: [{ ...buildLeague().teams[0], wins: 10, losses: 7 }, buildLeague().teams[1]],
+    });
+    const story = syncFranchiseChronicle(league);
+    expect(story.seasonReview?.text).toContain('2026 Season: 10-7');
+  });
+});

--- a/src/ui/utils/franchiseCommandCenter.js
+++ b/src/ui/utils/franchiseCommandCenter.js
@@ -5,6 +5,7 @@ import { getHQViewModel } from '../../state/selectors.js';
 import { rankHqPriorityItems, getActionContext } from './hqHelpers.js';
 import { buildCompletedGamePresentation } from './boxScoreAccess.js';
 import { getRecentGames as getArchivedRecentGames } from '../../core/archive/gameArchive.ts';
+import { syncFranchiseChronicle } from './franchiseChronicle.js';
 
 function safeNum(value, fallback = 0) {
   const n = Number(value);
@@ -359,6 +360,7 @@ export function selectFranchiseHQViewModel(league) {
     })
     .sort((a, b) => b.scoreWeight - a.scoreWeight)
     .slice(0, 2);
+  const story = syncFranchiseChronicle(vm.league);
   const injuredSpotlight = (team?.roster ?? [])
     .filter((player) => safeNum(player?.injuryWeeksRemaining ?? player?.injuredWeeks ?? player?.injury?.gamesRemaining ?? 0) > 0)
     .sort((a, b) => safeNum(b?.ovr) - safeNum(a?.ovr))[0] ?? null;
@@ -423,9 +425,10 @@ export function selectFranchiseHQViewModel(league) {
       }
       : null,
     leagueNews,
+    story,
     navState: {
       activeSection: 'hq',
-      suggestedDestinations: ['HQ', 'Team', 'League', 'News', 'More'],
+      suggestedDestinations: ['HQ', 'Team', 'League', 'News', 'Story', 'More'],
       hasSecondaryAdvance: true,
     },
   };


### PR DESCRIPTION
### Motivation
- Provide a persistent narrative layer so players see a franchise-level timeline and season story rather than just weekly results. 
- Expose key weekly context (headline, standout, standings, events, moments) in a mobile-first UI and keep all derived state inside the existing HQ pipeline. 
- Keep backward compatibility with older saves by safely initializing chronicle metadata when missing.

### Description
- Added `syncFranchiseChronicle` (`src/ui/utils/franchiseChronicle.js`) which backfills/updates `league.franchiseChronicle`, builds `ChronicleEntry` objects per played user game (result, score, headline, standings position, standout, events, moments), generates a season-in-review, and computes milestone badge state. 
- New Story screen `FranchiseStoryHub` (`src/ui/components/FranchiseStoryHub.jsx`) that renders a vertical timeline with colored result borders, expandable week cards (events + moments), season review, and badge grid using existing primitives (`SectionCard`, `EmptyState`, `StatusChip`). 
- Wired Story into navigation by registering the `Story` tab in `LeagueDashboard.jsx` and adding a `Story` destination to `MobileNav.jsx` so it appears in the League Office group and is reachable from mobile. 
- Extended the existing HQ-derived pipeline (`src/ui/utils/franchiseCommandCenter.js`) to surface `story` data (via `syncFranchiseChronicle`) so no parallel data pipeline was introduced and Story is suggested in HQ destinations. 
- Added unit tests (`src/ui/utils/franchiseChronicle.test.js`) covering chronicle generation, dedupe behavior, backward-compatible initialization, and season review generation.

### Testing
- Ran targeted unit test `npm run test:unit -- src/ui/utils/franchiseChronicle.test.js`, which passed. 
- Ran full unit suite `npm run test:unit`, which completed successfully (all unit tests passed). 
- Built production bundle with `npm run build`, which completed successfully (build warnings about large chunks were informational only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f8cbd300832dbd7166fbd2280fc3)