### PR TITLE
Add dynamic weekly franchise events, AI GM personas, and negotiation scaffolds

### DIFF
--- a/src/ui/components/EventDecisionModal.jsx
+++ b/src/ui/components/EventDecisionModal.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { SectionCard, StatusChip } from './ScreenSystem.jsx';
+
+export default function EventDecisionModal({ event, onChoose, onClose, onDecideLater }) {
+  if (!event) return null;
+  return (
+    <div style={{ position: 'fixed', inset: 0, zIndex: 10000, background: 'rgba(3,8,20,0.86)', overflowY: 'auto' }}>
+      <div style={{ minHeight: '100%', display: 'grid', placeItems: 'center', padding: 12 }}>
+        <SectionCard title={event.headline ?? 'Weekly Event'} subtitle={`Week ${event.week ?? '—'} decision`} variant="compact">
+          <div className="app-row" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
+            <StatusChip label="Decision Required" tone="warning" />
+            <button type="button" className="btn btn-sm" onClick={onClose}>Close</button>
+          </div>
+          <div className="app-row-stack" style={{ marginTop: 12 }}>
+            {(event.choices ?? []).map((choice) => (
+              <button
+                key={choice.id}
+                type="button"
+                className="btn"
+                style={{ width: '100%', textAlign: 'left', display: 'grid', gap: 2 }}
+                onClick={() => onChoose?.(choice.id)}
+              >
+                <strong>{choice.label}</strong>
+                <span style={{ fontSize: 12, opacity: 0.8 }}>{choice.preview}</span>
+              </button>
+            ))}
+            <button type="button" className="btn" onClick={onDecideLater}>Decide later</button>
+          </div>
+        </SectionCard>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/TradeNegotiation.jsx
+++ b/src/ui/components/TradeNegotiation.jsx
@@ -1,0 +1,27 @@
+import React, { useMemo, useState } from 'react';
+import { SectionCard, StatusChip } from './ScreenSystem.jsx';
+import { evaluateTradeFairness } from '../utils/franchiseEvents.js';
+
+export default function TradeNegotiation({ baseAskValue = 100, relationship = 0, deadlineWeek = false, onClose, onFinalize }) {
+  const [offerValue, setOfferValue] = useState(baseAskValue);
+  const [round, setRound] = useState(1);
+  const verdict = useMemo(() => evaluateTradeFairness({ offerValue, askValue: baseAskValue, relationship, deadlineWeek }), [offerValue, baseAskValue, relationship, deadlineWeek]);
+
+  return (
+    <SectionCard title="Trade negotiation" subtitle={`Round ${round}/3`} variant="compact">
+      <div className="app-row" style={{ justifyContent: 'space-between' }}>
+        <StatusChip label={verdict.meter.toUpperCase()} tone={verdict.meter === 'green' ? 'ok' : verdict.meter === 'yellow' ? 'warning' : 'danger'} />
+        <span style={{ fontSize: 12, opacity: 0.8 }}>{verdict.reasoning}</span>
+      </div>
+      <label style={{ display: 'grid', gap: 6, marginTop: 10 }}>
+        Offer value
+        <input type="range" min={0} max={baseAskValue * 2} value={offerValue} onChange={(e) => setOfferValue(Number(e.target.value))} />
+      </label>
+      <div className="app-row" style={{ gap: 8, marginTop: 12 }}>
+        <button type="button" className="btn" onClick={onClose}>Walk away</button>
+        <button type="button" className="btn" disabled={round >= 3} onClick={() => setRound((value) => Math.min(3, value + 1))}>Counter</button>
+        <button type="button" className="btn btn-primary" onClick={() => onFinalize?.(verdict)}>Finalize</button>
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/ui/utils/franchiseChronicle.js
+++ b/src/ui/utils/franchiseChronicle.js
@@ -152,6 +152,54 @@ function deriveBadgeState(league, team, chronicle) {
   }));
 }
 
+
+export function logChronicleEvent(league, payload = {}) {
+  if (!league || typeof league !== 'object') return null;
+  if (!Array.isArray(league.franchiseChronicle)) league.franchiseChronicle = [];
+
+  const week = safeNum(payload?.week, safeNum(league?.week, 1));
+  const season = safeNum(payload?.season, safeNum(league?.year, 0));
+  const entry = {
+    id: payload?.id ?? `${season}-wk${week}-event-${String(payload?.type ?? 'custom')}`,
+    season,
+    week,
+    result: payload?.result ?? 'EVT',
+    summary: payload?.summary ?? payload?.headline ?? 'Franchise event',
+    headline: payload?.headline ?? 'Franchise event update',
+    events: Array.isArray(payload?.events) ? payload.events : [payload?.outcome].filter(Boolean),
+    standout: payload?.standout ?? null,
+    moments: Array.isArray(payload?.moments) ? payload.moments : [],
+    meta: { type: payload?.type ?? 'event', ...(payload?.meta ?? {}) },
+  };
+
+  league.franchiseChronicle.push(entry);
+  league.franchiseChronicle = [...league.franchiseChronicle]
+    .sort((a, b) => (safeNum(a?.season) - safeNum(b?.season)) || (safeNum(a?.week) - safeNum(b?.week)))
+    .slice(-340);
+  return entry;
+}
+
+export function logTradeOutcome(league, payload = {}) {
+  return logChronicleEvent(league, {
+    ...payload,
+    type: 'trade',
+    result: payload?.result ?? 'TRD',
+    headline: payload?.headline ?? 'Trade talks concluded',
+    summary: payload?.summary ?? payload?.reasoning ?? 'Trade negotiation completed.',
+    outcome: payload?.outcome,
+  });
+}
+
+export function logContractOutcome(league, payload = {}) {
+  return logChronicleEvent(league, {
+    ...payload,
+    type: 'contract',
+    result: payload?.result ?? 'CON',
+    headline: payload?.headline ?? 'Contract negotiation update',
+    summary: payload?.summary ?? payload?.outcome ?? 'Contract decision recorded.',
+  });
+}
+
 export function syncFranchiseChronicle(league) {
   if (!league || typeof league !== 'object') return { entries: [], seasonReview: null, badges: [] };
   if (!Array.isArray(league.franchiseChronicle)) league.franchiseChronicle = [];

--- a/src/ui/utils/franchiseCommandCenter.js
+++ b/src/ui/utils/franchiseCommandCenter.js
@@ -6,6 +6,7 @@ import { rankHqPriorityItems, getActionContext } from './hqHelpers.js';
 import { buildCompletedGamePresentation } from './boxScoreAccess.js';
 import { getRecentGames as getArchivedRecentGames } from '../../core/archive/gameArchive.ts';
 import { syncFranchiseChronicle } from './franchiseChronicle.js';
+import { resolveWeeklyEvent } from './franchiseEvents.js';
 
 function safeNum(value, fallback = 0) {
   const n = Number(value);
@@ -139,6 +140,35 @@ function toSeverity(level) {
   return 'info';
 }
 
+
+const DEFAULT_GM_PERSONAS = ['Trader', 'Draft-and-Develop', 'Win-Now', 'Tanker', 'Cap Hoarder', 'Loyalist'];
+
+function ensureLeaguePersonasAndRelationships(league) {
+  if (!league || typeof league !== 'object') return;
+  if (!league.gmRelationships || typeof league.gmRelationships !== 'object') league.gmRelationships = {};
+  for (const team of league.teams ?? []) {
+    const key = String(team?.id ?? '');
+    if (!team?.gmPersona) {
+      const idx = Math.abs(safeNum(team?.id, 0)) % DEFAULT_GM_PERSONAS.length;
+      team.gmPersona = DEFAULT_GM_PERSONAS[idx];
+    }
+    if (!(key in league.gmRelationships)) league.gmRelationships[key] = 0;
+  }
+}
+
+function maybeQueueWeeklyEvent(league) {
+  if (!league || typeof league !== 'object') return null;
+  if (!Array.isArray(league.pendingWeeklyEvents)) league.pendingWeeklyEvents = [];
+  const currentWeek = safeNum(league?.week, 1);
+  const unresolved = league.pendingWeeklyEvents.find((evt) => evt?.state !== 'resolved');
+  if (unresolved) return unresolved;
+  const resolvedThisWeek = (league.pendingWeeklyEvents ?? []).some((evt) => safeNum(evt?.week) === currentWeek);
+  if (resolvedThisWeek) return null;
+  const event = resolveWeeklyEvent({ league });
+  if (event) league.pendingWeeklyEvents.push(event);
+  return event;
+}
+
 export function buildWeeklyAgenda({ team, league, weekly, prep, nextGame }) {
   if (!team || !league) return [];
   const ranked = rankHqPriorityItems(team, league, weekly, nextGame);
@@ -232,6 +262,19 @@ export function buildWeeklyAgenda({ team, league, weekly, prep, nextGame }) {
     });
   }
 
+  const unresolvedEvent = (league?.pendingWeeklyEvents ?? []).find((event) => event?.state !== 'resolved');
+  if (unresolvedEvent) {
+    items.unshift({
+      id: `weekly-event-${unresolvedEvent.id}`,
+      icon: '🗞️',
+      title: unresolvedEvent.headline ?? 'Franchise event awaiting decision',
+      description: 'Decide now or risk an automatic negative outcome.',
+      severity: 'warning',
+      ctaLabel: 'Open event',
+      targetRoute: 'HQ:Events',
+    });
+  }
+
   const deduped = [];
   const seen = new Set();
   for (const item of items) {
@@ -259,6 +302,7 @@ export function selectFranchiseHQViewModel(league) {
     return { readyState: 'loading', weeklyAgenda: [] };
   }
   const team = vm.userTeam;
+  ensureLeaguePersonasAndRelationships(vm.league);
   const weekly = evaluateWeeklyContext(vm.league);
   const prep = deriveWeeklyPrepState(vm.league);
   const nextGame = getPrepNextGame(vm.league);
@@ -360,6 +404,7 @@ export function selectFranchiseHQViewModel(league) {
     })
     .sort((a, b) => b.scoreWeight - a.scoreWeight)
     .slice(0, 2);
+  const queuedEvent = maybeQueueWeeklyEvent(vm.league);
   const story = syncFranchiseChronicle(vm.league);
   const injuredSpotlight = (team?.roster ?? [])
     .filter((player) => safeNum(player?.injuryWeeksRemaining ?? player?.injuredWeeks ?? player?.injury?.gamesRemaining ?? 0) > 0)
@@ -426,6 +471,7 @@ export function selectFranchiseHQViewModel(league) {
       : null,
     leagueNews,
     story,
+    weeklyEvent: queuedEvent,
     navState: {
       activeSection: 'hq',
       suggestedDestinations: ['HQ', 'Team', 'League', 'News', 'Story', 'More'],

--- a/src/ui/utils/franchiseEvents.js
+++ b/src/ui/utils/franchiseEvents.js
@@ -1,0 +1,221 @@
+import { Utils as U } from '../../core/utils.js';
+
+function safeNum(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function pct(team) {
+  const wins = safeNum(team?.wins);
+  const losses = safeNum(team?.losses);
+  const ties = safeNum(team?.ties);
+  const games = wins + losses + ties;
+  return games > 0 ? (wins + ties * 0.5) / games : 0;
+}
+
+function getUserTeam(league) {
+  return (league?.teams ?? []).find((team) => Number(team?.id) === Number(league?.userTeamId)) ?? null;
+}
+
+function getLosingStreak(team) {
+  const reversed = Array.isArray(team?.recentResults) ? [...team.recentResults].reverse() : [];
+  let streak = 0;
+  for (const entry of reversed) {
+    if (String(entry ?? '').toUpperCase() !== 'L') break;
+    streak += 1;
+  }
+  return streak;
+}
+
+function hasEliteExpiringPlayer(team) {
+  return (team?.roster ?? []).some((player) => safeNum(player?.ovr) >= 88 && safeNum(player?.contract?.yearsRemaining ?? player?.contract?.years) <= 1);
+}
+
+function hasAgingStarter(team) {
+  return (team?.roster ?? []).some((player) => safeNum(player?.ovr) >= 75 && safeNum(player?.age, 26) >= 30);
+}
+
+function isPredraftPhase(league) {
+  const phase = String(league?.phase ?? '').toLowerCase();
+  return phase.includes('draft') || phase.includes('offseason');
+}
+
+function buildWeeklyEventPool({ league, team }) {
+  const trainingRank = safeNum(team?.facilities?.trainingRank ?? team?.trainingFacilityRank, 16);
+  const streak = getLosingStreak(team);
+  const losing = pct(team) < 0.45;
+  const nextGame = league?.nextGame ?? null;
+  const isDivisionGame = Boolean(nextGame?.isDivision || nextGame?.opp?.isDivisionRival);
+
+  return [
+    {
+      id: 'star_extension_demand',
+      weight: hasEliteExpiringPlayer(team) ? 16 : 0,
+      headline: 'Your star player\'s agent requests immediate extension talks',
+      choices: [
+        { id: 'open_talks', label: 'Open talks now', preview: 'Owner +4 · Morale +6 · Cap -2.5M', effects: { ownerApproval: 4, morale: 6, capImpact: -2.5, fanSentiment: 3 } },
+        { id: 'delay', label: 'Ask for two weeks', preview: 'Owner -2 · Morale -5', effects: { ownerApproval: -2, morale: -5, fanSentiment: -3 } },
+      ],
+    },
+    {
+      id: 'veteran_trade_request',
+      weight: losing && hasAgingStarter(team) ? 14 : 0,
+      headline: 'A veteran starter privately requests a trade to a contender',
+      choices: [
+        { id: 'grant', label: 'Honor request', preview: 'Owner +2 · Fans -5 · Locker room +4', effects: { ownerApproval: 2, morale: 4, fanSentiment: -5 } },
+        { id: 'deny', label: 'Deny request', preview: 'Morale -8 · Fans +2', effects: { morale: -8, fanSentiment: 2 } },
+      ],
+    },
+    {
+      id: 'injury_bug',
+      weight: trainingRank >= 20 ? 18 : trainingRank >= 14 ? 10 : 2,
+      headline: 'Training staff flags a soft-tissue injury spike risk this week',
+      choices: [
+        { id: 'light_practice', label: 'Reduce practice intensity', preview: 'Morale +2 · Sim prep -small', effects: { morale: 2, prepPenalty: 0.04 } },
+        { id: 'stay_course', label: 'Keep full speed', preview: 'Injury risk ↑ · Owner +1', effects: { ownerApproval: 1, injuryRiskDelta: 0.08 } },
+      ],
+    },
+    {
+      id: 'scandal',
+      weight: 2,
+      headline: 'A late-night off-field scandal breaks before media day',
+      choices: [
+        { id: 'support_player', label: 'Back player publicly', preview: 'Morale +5 · Fans -4', effects: { morale: 5, fanSentiment: -4 } },
+        { id: 'discipline', label: 'Issue team discipline', preview: 'Owner +5 · Morale -4', effects: { ownerApproval: 5, morale: -4, fanSentiment: 1 } },
+      ],
+      rare: true,
+    },
+    {
+      id: 'rivalry_bonus',
+      weight: isDivisionGame ? 12 : 0,
+      headline: 'Rivalry week buzz surges ticket demand and locker-room intensity',
+      choices: [
+        { id: 'embrace', label: 'Lean into rivalry', preview: 'Fans +7 · Turnover volatility +small', effects: { fanSentiment: 7, volatilityDelta: 0.05 } },
+        { id: 'steady', label: 'Keep it business-as-usual', preview: 'Owner +1 · Fans +1', effects: { ownerApproval: 1, fanSentiment: 1 } },
+      ],
+    },
+    {
+      id: 'coach_hot_seat',
+      weight: streak >= 3 ? 16 : 0,
+      headline: 'Ownership hints your staff could be on the hot seat',
+      choices: [
+        { id: 'fire_coordinator', label: 'Shake up staff', preview: 'Owner +6 · Morale -3', effects: { ownerApproval: 6, morale: -3 } },
+        { id: 'keep_staff', label: 'Back current staff', preview: 'Owner -5 · Morale +2', effects: { ownerApproval: -5, morale: 2 } },
+      ],
+      autoResolveChoiceId: 'keep_staff',
+    },
+    {
+      id: 'prospect_workout',
+      weight: isPredraftPhase(league) ? 10 : 0,
+      headline: 'A local top prospect asks for a private workout',
+      choices: [
+        { id: 'host_workout', label: 'Host private workout', preview: 'Scouting +8 · Budget -0.4M', effects: { scoutingBoost: 8, capImpact: -0.4 } },
+        { id: 'decline', label: 'Decline request', preview: 'Scouting -4 · Budget +0.2M', effects: { scoutingBoost: -4, capImpact: 0.2 } },
+      ],
+      autoResolveChoiceId: 'decline',
+    },
+  ].filter((item) => item.weight > 0);
+}
+
+function pickWeightedEvent(pool, rng = U.random) {
+  if (!pool.length) return null;
+  const total = pool.reduce((sum, item) => sum + safeNum(item.weight, 0), 0);
+  if (total <= 0) return null;
+  let cursor = rng() * total;
+  for (const candidate of pool) {
+    cursor -= safeNum(candidate.weight, 0);
+    if (cursor <= 0) return candidate;
+  }
+  return pool[pool.length - 1] ?? null;
+}
+
+export function resolveWeeklyEvent({ league, rng = U.random } = {}) {
+  const team = getUserTeam(league);
+  if (!team) return null;
+  const pool = buildWeeklyEventPool({ league, team });
+  if (!pool.length) return null;
+
+  const baseChance = 0.32;
+  const urgencyBonus = getLosingStreak(team) >= 3 ? 0.12 : 0;
+  if (rng() > baseChance + urgencyBonus) return null;
+
+  const chosen = pickWeightedEvent(pool, rng);
+  if (!chosen) return null;
+
+  return {
+    ...chosen,
+    id: `${safeNum(league?.year, 0)}-wk${safeNum(league?.week, 1)}-${chosen.id}`,
+    week: safeNum(league?.week, 1),
+    season: safeNum(league?.year, 0),
+    state: 'pending',
+    ignoredWeeks: 0,
+  };
+}
+
+export function applyEventDecision(event, choiceId) {
+  const choice = (event?.choices ?? []).find((entry) => entry?.id === choiceId);
+  if (!event || !choice) return null;
+  return {
+    ...event,
+    state: 'resolved',
+    choiceId,
+    choiceLabel: choice.label,
+    outcome: choice.preview,
+    effects: { ...(choice.effects ?? {}) },
+  };
+}
+
+export function updateRelationshipScore(currentValue, delta) {
+  return Math.max(-100, Math.min(100, safeNum(currentValue, 0) + safeNum(delta, 0)));
+}
+
+export function evaluateTradeFairness({ offerValue = 0, askValue = 0, relationship = 0, deadlineWeek = false } = {}) {
+  const demand = Math.max(1, safeNum(askValue, 1));
+  const baseRatio = safeNum(offerValue, 0) / demand;
+  const relBonus = safeNum(relationship, 0) / 500;
+  const deadlineBonus = deadlineWeek ? 0.04 : 0;
+  const adjustedRatio = baseRatio + relBonus + deadlineBonus;
+  const gap = adjustedRatio - 1;
+  const meter = adjustedRatio >= 1.02 ? 'green' : adjustedRatio >= 0.9 ? 'yellow' : 'red';
+  return {
+    adjustedRatio,
+    meter,
+    verdict: adjustedRatio >= 1.0 ? 'Accept' : adjustedRatio >= 0.88 ? 'Counter' : 'Decline',
+    reasoning: adjustedRatio >= 1.0
+      ? 'This offer meets our current roster and value goals.'
+      : adjustedRatio >= 0.88
+        ? 'Close, but we need one more quality asset.'
+        : 'This package falls short of our valuation.',
+    counterDelta: gap >= -0.12 ? Math.max(0, Math.round((1 - adjustedRatio) * demand)) : null,
+  };
+}
+
+export function buildContractCounterOffer({
+  demandYears = 3,
+  demandAav = 12,
+  demandGuarantee = 55,
+  offerYears = 3,
+  offerAav = 12,
+  offerGuarantee = 55,
+  teamWinPct = 0.5,
+  morale = 65,
+  marketHeat = 1,
+} = {}) {
+  const winAdj = teamWinPct >= 0.6 ? -0.06 : teamWinPct <= 0.4 ? 0.08 : 0;
+  const moraleAdj = morale >= 75 ? -0.03 : morale <= 45 ? 0.06 : 0;
+  const marketAdj = (safeNum(marketHeat, 1) - 1) * 0.1;
+
+  const minAav = safeNum(demandAav) * (1 + winAdj + moraleAdj + marketAdj);
+  const counterAav = Math.max(minAav, (safeNum(offerAav) + safeNum(demandAav)) / 2);
+  const counterGuarantee = Math.max(
+    safeNum(demandGuarantee) * (1 + marketAdj * 0.5),
+    (safeNum(offerGuarantee) + safeNum(demandGuarantee)) / 2,
+  );
+  const counterYears = Math.min(5, Math.max(1, Math.round((safeNum(offerYears) + safeNum(demandYears)) / 2)));
+
+  return {
+    years: counterYears,
+    aav: Math.round(counterAav * 10) / 10,
+    guaranteePct: Math.round(Math.max(15, Math.min(100, counterGuarantee))),
+  };
+}

--- a/src/ui/utils/franchiseEvents.test.js
+++ b/src/ui/utils/franchiseEvents.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveWeeklyEvent,
+  evaluateTradeFairness,
+  buildContractCounterOffer,
+  updateRelationshipScore,
+} from './franchiseEvents.js';
+
+function buildLeague(overrides = {}) {
+  return {
+    year: 2028,
+    week: 8,
+    phase: 'regular',
+    userTeamId: 1,
+    teams: [{
+      id: 1,
+      wins: 2,
+      losses: 5,
+      ties: 0,
+      trainingFacilityRank: 24,
+      recentResults: ['W', 'L', 'L', 'L'],
+      roster: [
+        { id: 11, ovr: 91, age: 27, contract: { yearsRemaining: 1 } },
+        { id: 12, ovr: 80, age: 32, contract: { yearsRemaining: 2 } },
+      ],
+    }],
+    ...overrides,
+  };
+}
+
+describe('resolveWeeklyEvent', () => {
+  it('creates pending events when weighted triggers are present', () => {
+    const league = buildLeague();
+    const event = resolveWeeklyEvent({ league, rng: () => 0 });
+    expect(event).toBeTruthy();
+    expect(event.state).toBe('pending');
+    expect(event.id).toContain('wk8');
+  });
+});
+
+describe('evaluateTradeFairness', () => {
+  it('marks close offers as counter and strong offers as accept', () => {
+    const counter = evaluateTradeFairness({ offerValue: 90, askValue: 100, relationship: 0 });
+    const accept = evaluateTradeFairness({ offerValue: 104, askValue: 100, relationship: 0 });
+    expect(counter.verdict).toBe('Counter');
+    expect(accept.verdict).toBe('Accept');
+  });
+});
+
+describe('buildContractCounterOffer', () => {
+  it('adds a loser tax when team performance and morale are low', () => {
+    const lowState = buildContractCounterOffer({ demandAav: 20, offerAav: 16, teamWinPct: 0.2, morale: 35, marketHeat: 1.1 });
+    expect(lowState.aav).toBeGreaterThan(20);
+  });
+});
+
+describe('updateRelationshipScore', () => {
+  it('clamps the score between -100 and 100', () => {
+    expect(updateRelationshipScore(95, 20)).toBe(100);
+    expect(updateRelationshipScore(-95, -20)).toBe(-100);
+  });
+});


### PR DESCRIPTION
### Motivation
- Make the franchise chronicle record meaningful emergent narrative by introducing unpredictable weekly events and decision points. 
- Give AI teams personality and relationship state so trades/FA feel contextful instead of RNG-driven. 
- Provide negotiation scaffolds so trades and contracts become interactive, testable flows that can feed the chronicle.

### Description
- Added `src/ui/utils/franchiseEvents.js` implementing `resolveWeeklyEvent`, `applyEventDecision`, `evaluateTradeFairness`, `buildContractCounterOffer`, and `updateRelationshipScore` with seeded-RNG friendly logic and weighted event pools. 
- Added `EventDecisionModal.jsx` and `TradeNegotiation.jsx` UI scaffolds (mobile-first, reuses screen primitives) to present event decisions and trade negotiation flows. 
- Extended HQ derivation in `franchiseCommandCenter.js` to bootstrap GM personas and `gmRelationships`, queue one unresolved weekly event, and surface `weeklyEvent` in the returned view model; also surface unresolved event in the weekly agenda. 
- Extended `franchiseChronicle.js` with `logChronicleEvent`, `logTradeOutcome`, and `logContractOutcome` helpers so event/negotiation outcomes can be persisted into the franchise chronicle. 
- Added unit tests `src/ui/utils/franchiseEvents.test.js` covering event resolution, trade fairness math, contract counter logic, and relationship clamping, and updated/kept existing chronicle tests to ensure backward compatibility.

### Testing
- Ran targeted unit tests with `npm run test:unit -- src/ui/utils/franchiseEvents.test.js src/ui/utils/franchiseChronicle.test.js` and they passed. 
- Ran the full unit suite with `npm run test:unit`, yielding all tests passing (full suite: 117 files, 364 tests all green). 
- Built production bundle with `npm run build` which completed successfully (Vite build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8fc8d0440832d8c4cc86be1e130c1)