### PR TITLE
Franchise HQ UI: redesign topbar and simplify dashboard sections

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 import { autoBuildDepthChart, depthWarnings } from '../../core/depthChart.js';
 import { markWeeklyPrepStep } from '../utils/weeklyPrep.js';
 import { selectFranchiseHQViewModel } from '../utils/franchiseCommandCenter.js';
@@ -21,9 +20,8 @@ function safeNum(value, fallback = 0) {
   return Number.isFinite(n) ? n : fallback;
 }
 
-export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdvanceWeek, busy, simulating }) {
+export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, simulating }) {
   const [lineupToast, setLineupToast] = useState(null);
-  const [expandedPressure, setExpandedPressure] = useState(false);
   const command = useMemo(() => selectFranchiseHQViewModel(league), [league]);
 
   if (command.readyState !== 'ready') {
@@ -57,28 +55,28 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdva
   ];
 
   const lastGame = command.lastGameSummary;
-  const mandate = command.ownerMandate;
-  const cap = command.capSnapshot;
-
-  const handlePrepChecklistToggle = (item) => {
-    const nextValue = !item?.done;
-    markWeeklyPrepStep(league, item?.key, nextValue);
-    if (!nextValue) return;
-    onNavigate?.(item?.tab ?? 'Weekly Prep');
-  };
+  const upcomingLabel = command.nextGame?.isHome ? `vs ${command.nextOpponent}` : `@ ${command.nextOpponent}`;
 
   return (
     <div className="app-screen-stack franchise-hq franchise-command-center">
+      <section className="app-hq-topbar card" aria-label="Franchise HQ top bar">
+        <div className="app-hq-topbar__left">
+          <strong>Franchise HQ</strong>
+          <span>{command.seasonLabel}</span>
+        </div>
+        <div className="app-hq-topbar__meta">
+          <StatusChip label={command.weekLabel} tone="league" />
+          <StatusChip label={command.teamRecord} tone="team" />
+          <StatusChip label={command.prepStatus} tone="info" />
+        </div>
+      </section>
+
       <WeeklyHero
         eyebrow={`${command.seasonLabel} · ${command.weekLabel}`}
-        title={`Next: ${command.nextGame?.isHome ? 'vs' : '@'} ${command.nextOpponent}`}
-        subtitle={`Your record ${command.teamRecord} ${command.momentum?.icon ?? '→'} · Opponent ${command.nextOpponentRecord}`}
-        rightMeta={<StatusChip label={`${command.prepStatus} · ${command.momentum?.label ?? 'No trend yet'}`} tone="info" />}
-        actions={(
-          <>
-            <Button size="sm" className="app-advance-btn app-command-advance" onClick={onAdvanceWeek} disabled={busy || simulating}>{busy || simulating ? 'Advancing…' : 'Advance Week'}</Button>
-          </>
-        )}
+        title={upcomingLabel}
+        subtitle={`Your record ${command.teamRecord} · Opponent ${command.nextOpponentRecord}`}
+        rightMeta={<StatusChip label={command.standingSummary} tone="info" />}
+        actions={<Button size="sm" className="app-advance-btn app-command-advance" onClick={onAdvanceWeek} disabled={busy || simulating}>{busy || simulating ? 'Advancing…' : 'Advance Week'}</Button>}
       >
         <div className="app-hero-summary-grid app-hero-summary-grid-command">
           <div>
@@ -90,128 +88,47 @@ export default function FranchiseHQ({ league, onNavigate, onOpenBoxScore, onAdva
             <strong>{command.standingSummary}</strong>
           </div>
           <div>
-            <span>Owner Pressure</span>
-            <strong>{command.pressureSummary} {command.momentum?.icon ?? '→'}</strong>
+            <span>Owner Pulse</span>
+            <strong>{command.pressureSummary}</strong>
           </div>
         </div>
-        {command.lastGameMoments?.length ? (
-          <div className="app-moment-list">
-            {command.lastGameMoments.map((moment) => <p key={moment.id}>• {moment.text}</p>)}
-          </div>
-        ) : null}
-        <div className="app-prep-checklist">
-          {command.prepChecklist?.map((item) => (
-            <button
-              key={item.key}
-              type="button"
-              className={`app-prep-checklist__item ${item.done ? 'is-done' : ''}`}
-              onClick={() => handlePrepChecklistToggle(item)}
-            >
-              <span className="app-prep-checklist__check">{item.done ? '✓' : '○'}</span>
-              <span>{item.label}</span>
-            </button>
-          ))}
-        </div>
-        {command.blockers?.length ? <div className="app-blocker-row"><StatusChip label={`${command.blockers.length} prep blocker${command.blockers.length > 1 ? 's' : ''}`} tone="warning" /></div> : null}
       </WeeklyHero>
 
-      <div className="app-action-grid-2x2">
-        {actionTiles.map((action) => (
-          <ActionTile key={action.title} icon={action.icon} title={action.title} subtitle={action.subtitle} badge={action.badge ? <StatusChip label={action.badge} tone="warning" /> : null} onClick={action.onClick} tone="info" />
-        ))}
-      </div>
+      <section className="app-section-stack" aria-label="Weekly Action Grid">
+        <div className="app-section-heading">Weekly Action Grid</div>
+        <div className="app-action-grid-2x2">
+          {actionTiles.map((action) => (
+            <ActionTile key={action.title} icon={action.icon} title={action.title} subtitle={action.subtitle} badge={action.badge ? <StatusChip label={action.badge} tone="warning" /> : null} onClick={action.onClick} tone="info" />
+          ))}
+        </div>
+      </section>
       {lineupToast ? <p className="app-inline-toast">{lineupToast}</p> : null}
 
-      <SectionCard title="Weekly Agenda" subtitle="Front office priorities ranked for this week." variant="compact">
+      <SectionCard title="Weekly Agenda" subtitle="Curated priorities for this week." variant="compact">
         <WeeklyAgenda items={command.weeklyAgenda} onOpenTask={(task) => onNavigate?.(task?.targetRoute ?? task?.tab ?? 'HQ')} />
       </SectionCard>
 
-      <SectionCard title="Owner Mandate" subtitle="Approval impact by likely outcomes." variant="compact">
-        <div className="app-mandate-meter" role="meter" aria-valuemin={0} aria-valuemax={100} aria-valuenow={mandate?.approval ?? 0}>
-          <div className="app-mandate-meter__segment tone-danger" />
-          <div className="app-mandate-meter__segment tone-warning" />
-          <div className="app-mandate-meter__segment tone-ok" />
-          <div className="app-mandate-meter__needle" style={{ left: `${Math.max(0, Math.min(100, mandate?.approval ?? 0))}%` }} />
-        </div>
-        <p className="app-mandate-caption">{mandate?.approval ?? 0}% approval · {command.pressureSummary}</p>
-        <button type="button" className="btn btn-sm" onClick={() => setExpandedPressure((prev) => !prev)}>
-          {expandedPressure ? 'Hide trigger details' : 'Show trigger details'}
-        </button>
-        {expandedPressure ? (
-          <div className="app-mandate-deltas">
-            {mandate?.deltas?.map((row) => <p key={row.label}><strong>{row.label}</strong> <span>{row.delta > 0 ? `+${row.delta}` : row.delta}</span></p>)}
-          </div>
-        ) : null}
-        <div className="app-expiring-list">
-          <strong>{mandate?.expiringStarters?.length ?? 0} expiring starters</strong>
-          {(mandate?.expiringStarters ?? []).slice(0, 5).map((player) => (
-            <button key={player.id} type="button" className="app-expiring-list__row" onClick={() => onNavigate?.('Contract Center')}>
-              <span>{player.pos} · {player.name} ({player.ovr} OVR)</span>
-              <span>${player.estCost.toFixed(1)}M</span>
-            </button>
-          ))}
-        </div>
+      <SectionCard title="Team Overview" subtitle="Franchise health at a glance." variant="compact">
+        <SummaryGrid items={command.teamOverview} />
       </SectionCard>
 
-      <div className="app-command-bottom-grid">
-        <SectionCard title="Snapshot" subtitle="Quick pressure and readiness indicators." variant="compact">
-          <SummaryGrid items={command.teamOverview} />
-          <div className="app-cap-thermometer">
-            <div className={`app-cap-thermometer__fill tone-${cap?.tone ?? 'ok'}`} style={{ width: `${cap?.capUsedPct ?? 0}%` }} />
-            {cap?.deadCapPct > 0 ? <div className="app-cap-thermometer__dead" style={{ width: `${cap.deadCapPct}%` }} /> : null}
-          </div>
-          <p className="app-cap-caption">
-            Used ${cap?.capUsed?.toFixed(1) ?? '0.0'}M / ${cap?.capTotal?.toFixed(1) ?? '0.0'}M · Room ${cap?.capRoom?.toFixed(1) ?? '0.0'}M · Rollover ${cap?.projectedRollover?.toFixed(1) ?? '0.0'}M
-          </p>
-        </SectionCard>
-        <SectionCard title="League Pulse" subtitle="Compact headlines around the league." variant="compact">
-          <div className="app-division-mini-table">
-            {(command.divisionMiniStandings ?? []).map((teamRow) => (
-              <div key={teamRow.id} className={`app-division-mini-table__row ${teamRow.isUser ? 'is-user' : ''}`}>
-                <strong>{teamRow.abbr}</strong>
-                <span>{teamRow.record}</span>
-                <span>PF {teamRow.pf}</span>
-                <span>PA {teamRow.pa}</span>
-                <span>{teamRow.streak}</span>
-              </div>
-            ))}
-          </div>
-          <div className="app-spotlight-results">
-            {(command.spotlightResults ?? []).map((game) => <p key={game.id}>{game.label}</p>)}
-          </div>
-          <div className="app-news-compact-list">
-            {(command.leagueNews ?? []).slice(0, 3).map((item) => (
-              <CompactNewsCard key={item.id} title={item.headline} subtitle={item.detail} />
-            ))}
-            {!command.leagueNews?.length ? <EmptyState title="No league headlines yet." body="Advance to generate weekly stories." /> : null}
-          </div>
-        </SectionCard>
-      </div>
-
-      {lastGame ? (
-        <SectionCard title="Last Game Recap" subtitle="Open full recap and box score." variant="compact">
-          <CompactListRow
-            title={`${lastGame.userWon ? 'Win' : 'Loss'} · Week ${lastGame.week ?? league?.week ?? 1}`}
-            subtitle={`${lastGame.awayAbbr} ${safeNum(lastGame?.score?.away)} @ ${lastGame.homeAbbr} ${safeNum(lastGame?.score?.home)}`}
-            meta={<StatusChip label="Recap" tone="league" />}
-          >
-            <Button size="sm" variant="outline" onClick={() => openResolvedBoxScore({ ...command.latestArchived, id: command.latestArchived?.id ?? lastGame?.id }, { seasonId: league?.seasonId, week: Number(command.latestArchived?.week ?? lastGame?.week ?? league?.week ?? 1), source: 'hq_last_game' }, onOpenBoxScore)} disabled={command.latestArchived ? !command.latestGamePresentation?.canOpen : false}>Box Score</Button>
-          </CompactListRow>
-        </SectionCard>
-      ) : null}
-
-      <SectionCard title="Injury Spotlight" subtitle="Highest-impact injury this week." variant="compact">
-        {command.injurySpotlight ? (
-          <CompactListRow
-            title={`${command.injurySpotlight.name} · ${command.injurySpotlight.pos} · ${command.injurySpotlight.ovr} OVR`}
-            subtitle={`${command.injurySpotlight.severity} · Expected return Week ${command.injurySpotlight.returnWeek}`}
-            meta={<StatusChip label={command.injurySpotlight.severity} tone={command.injurySpotlight.severity === 'IR' ? 'danger' : 'warning'} />}
-          >
-            <Button size="sm" variant="outline" onClick={() => onNavigate?.('Injuries')}>Open injuries</Button>
-          </CompactListRow>
-        ) : (
-          <EmptyState title="No major injuries" body="Your top rotation is currently available." />
-        )}
+      <SectionCard title="League News" subtitle="Around the league this week." variant="compact">
+        <CompactListRow
+          title="Next Game"
+          subtitle={`${upcomingLabel} · Opponent ${command.nextOpponentRecord}`}
+          meta={<StatusChip label={command.weekLabel} tone="league" />}
+        />
+        <CompactListRow
+          title="Last Game"
+          subtitle={lastGame ? `${lastGame.awayAbbr} ${safeNum(lastGame?.score?.away)} @ ${lastGame.homeAbbr} ${safeNum(lastGame?.score?.home)}` : 'No results yet.'}
+          meta={<StatusChip label={lastGame ? 'Final' : 'Pending'} tone="info" />}
+        />
+        <div className="app-news-compact-list">
+          {(command.leagueNews ?? []).slice(0, 3).map((item) => (
+            <CompactNewsCard key={item.id} title={item.headline} subtitle={item.detail} />
+          ))}
+          {!command.leagueNews?.length ? <EmptyState title="No league headlines yet." body="Advance to generate weekly stories." /> : null}
+        </div>
       </SectionCard>
     </div>
   );

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -77,10 +77,9 @@ describe('FranchiseHQ', () => {
     expect(html).toContain('Scout Opponent');
     expect(html).toContain('News &amp; Injuries');
     expect(html).toContain('Weekly Agenda');
-    expect(html).toContain('Snapshot');
-    expect(html).toContain('Owner Mandate');
-    expect(html).toContain('League Pulse');
-    expect(html).toContain('Last Game Recap');
+    expect(html).toContain('Weekly Action Grid');
+    expect(html).toContain('Team Overview');
+    expect(html).toContain('League News');
   });
 
   it('is safe with partial/older save payloads', () => {

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -229,6 +229,33 @@
 }
 
 .franchise-command-center { gap: var(--space-4); }
+
+.app-hq-topbar {
+  padding: 10px 12px;
+  border: 1px solid var(--hairline);
+  background: color-mix(in srgb, #070b12 88%, var(--surface) 12%);
+  border-radius: var(--radius-md);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+}
+.app-hq-topbar__left { display: grid; gap: 2px; min-width: 0; }
+.app-hq-topbar__left strong { font-size: var(--text-sm); letter-spacing: .01em; }
+.app-hq-topbar__left span { font-size: 11px; color: var(--text-subtle); text-transform: uppercase; letter-spacing: .08em; }
+.app-hq-topbar__meta { display: flex; gap: 6px; flex-wrap: wrap; justify-content: flex-end; }
+.app-section-stack { display: grid; gap: 8px; }
+.app-section-heading { font-size: 11px; color: var(--text-subtle); text-transform: uppercase; letter-spacing: .08em; font-weight: 700; }
+
+
+.franchise-command-center .app-hero-card {
+  padding: var(--space-4);
+  gap: var(--space-3);
+  border-color: color-mix(in srgb, var(--accent) 30%, var(--hairline));
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.32);
+  background: linear-gradient(160deg, color-mix(in srgb, #060b14 90%, var(--accent) 10%), color-mix(in srgb, #060b14 82%, var(--surface) 18%));
+}
+.franchise-command-center .app-section-card { box-shadow: 0 8px 20px rgba(0,0,0,.16); }
 .app-command-advance { min-width: 220px; font-size: var(--text-base); font-weight: 800; box-shadow: 0 10px 24px rgba(var(--accent-rgb), .26); }
 .app-blocker-row { display: flex; flex-wrap: wrap; gap: 8px; }
 .app-command-bottom-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
@@ -315,11 +342,18 @@
 }
 
 @media (max-width: 768px) {
-  .app-action-grid-2x2 { grid-template-columns: 1fr; }
+  .app-action-grid-2x2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .app-task-row { grid-template-columns: 20px 1fr auto; }
   .app-task-row .app-status-chip { display: none; }
-  .app-command-advance { width: 100%; min-width: 0; }
-  .app-summary-grid { grid-template-columns: 1fr; }
+  .app-command-advance { width: 100%; min-width: 0; min-height: 48px; }
+  .app-summary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .app-hero-card__actions { grid-template-columns: 1fr; }
   .app-hero-card__actions .btn { width: 100%; }
+  .app-hq-topbar { flex-direction: column; align-items: flex-start; }
+  .app-hq-topbar__meta { width: 100%; justify-content: flex-start; }
+}
+
+@media (max-width: 420px) {
+  .app-action-grid-2x2 { grid-template-columns: 1fr; }
+  .app-summary-grid { grid-template-columns: 1fr; }
 }

--- a/src/ui/utils/franchiseCommandCenter.js
+++ b/src/ui/utils/franchiseCommandCenter.js
@@ -439,9 +439,10 @@ export function selectFranchiseHQViewModel(league) {
     latestGamePresentation,
     teamOverview: [
       { label: 'Cap Space', value: formatMoneyM(cap.capRoom), tone: cap.capRoom < 5 ? 'warning' : 'ok' },
-      { label: 'Roster', value: `${rosterCount}/53`, tone: rosterCount > 53 ? 'danger' : 'info' },
+      { label: 'Roster Count', value: `${rosterCount}/53`, tone: rosterCount > 53 ? 'danger' : 'info' },
       { label: 'Injuries', value: `${safeNum(weekly?.pressurePoints?.injuriesCount, 0)}`, tone: safeNum(weekly?.pressurePoints?.injuriesCount, 0) >= 3 ? 'warning' : 'info' },
-      { label: 'Owner Confidence', value: `${safeNum(weekly?.pressurePoints?.ownerApproval ?? vm.league?.ownerApproval ?? vm.league?.ownerMood, 50)}%`, tone: safeNum(weekly?.pressurePoints?.ownerApproval ?? vm.league?.ownerApproval ?? vm.league?.ownerMood, 50) < 50 ? 'danger' : 'ok' },
+      { label: 'Morale', value: weekly?.chemistry?.state ?? 'Stable', tone: String(weekly?.chemistry?.state ?? '').toLowerCase().includes('fragmented') ? 'danger' : String(weekly?.chemistry?.state ?? '').toLowerCase().includes('uneasy') ? 'warning' : 'ok' },
+      { label: 'Owner Approval', value: `${safeNum(weekly?.pressurePoints?.ownerApproval ?? vm.league?.ownerApproval ?? vm.league?.ownerMood, 50)}%`, tone: safeNum(weekly?.pressurePoints?.ownerApproval ?? vm.league?.ownerApproval ?? vm.league?.ownerMood, 50) < 50 ? 'danger' : 'ok' },
     ],
     capSnapshot: {
       capTotal,


### PR DESCRIPTION
### Motivation
- Refresh the Franchise HQ layout to surface key team status and simplify the weekly dashboard for clearer at-a-glance information.
- Remove some legacy/detail panels (owner mandate, cap snapshot, last game recap) in favor of compact team overview and league news rails.

### Description
- Reworked `FranchiseHQ` component layout to add a new topbar, simplify the `WeeklyHero` content, and introduce `Weekly Action Grid`, `Team Overview`, and `League News` sections while removing the old mandate, snapshot, league pulse and last game recap panels.
- Removed the `onOpenBoxScore` prop and `openResolvedBoxScore` usage from the component and tests, and adjusted the last-game display to a compact row instead of an expandable recap/box-score button.
- Updated view-model mappings in `selectFranchiseHQViewModel` to rename/adjust `teamOverview` items (renamed roster label, added `Morale` and reordered owner approval) and preserved related cap snapshot data but no longer rendered in the main HQ screen.
- Added CSS rules in `screen-system.css` to style the new topbar, section headings, hero card tweaks, and responsive layout adjustments for the action grid and summary grid.

### Testing
- Updated `FranchiseHQ` component unit test (`FranchiseHQ.test.jsx`) expectations to match the new headings and removed box-score related assertions, and the test suite was executed and passed.
- Ran the component unit tests via the project test runner (`yarn test`), and all modified tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90429cc44832d8cedcfcec8d26348)