### PR TITLE
Fix Netlify build command to use Yarn

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 # netlify.toml — Netlify configuration for Football GM SPA
 
 [build]
-  command   = "npm run build"
+  command   = "yarn build"
   publish   = "dist"
 
 [build.environment]


### PR DESCRIPTION
### Motivation
- Netlify deploys were failing because the repository uses Yarn (Berry/PnP) and the configured `npm run build` command does not resolve project binaries like `vite` in the Yarn runtime.

### Description
- Update `netlify.toml` to change the build command from `npm run build` to `yarn build` so Netlify executes the build with the project's package manager.

### Testing
- Ran `yarn install` to ensure dependencies were available and then ran `yarn build`, and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90d0ca974832da281b476bf73fb60)