### PR TITLE
Block Advance Week for unresolved franchise events; add event impact chips, auto-escalation, power rankings & league headlines

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -48,6 +48,7 @@ import { toWorker }        from '../worker/protocol.js';
 import { DEFAULT_TEAMS }   from '../data/default-teams.js';
 import MilestoneModal      from './components/MilestoneModal.jsx';
 import ThemeToggle         from './components/ThemeToggle.jsx';
+import EventDecisionModal from './components/EventDecisionModal.jsx';
 import { SettingsProvider, useSettings } from './context/SettingsContext.jsx';
 import { ACTION_LABELS } from './constants/navigationCopy.js';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from './utils/boxScoreAccess.js';
@@ -61,6 +62,8 @@ import {
 import { clearWeeklyPrepForWeek, pruneWeeklyPrepStorage } from './utils/weeklyPrep.js';
 import { buildCanonicalGameId } from '../core/gameIdentity.js';
 import { getRecentGames, saveGame } from '../core/archive/gameArchive.ts';
+import { applyEventDecision } from './utils/franchiseEvents.js';
+import { logChronicleEvent } from './utils/franchiseChronicle.js';
 
 // Increment this when shipping notable UX/bugfix updates so users
 // see the in-app changelog popup once per version.
@@ -130,12 +133,17 @@ function AppContent() {
   const [watchMode, setWatchMode] = useState('watch');
   const [externalBoxScoreId, setExternalBoxScoreId] = useState(null);
   const [showChangelog, setShowChangelog] = useState(false);
+  const [showWeeklyEventModal, setShowWeeklyEventModal] = useState(false);
   const { settings, updateSetting } = useSettings();
   const soundEnabled = settings?.soundEnabled ?? true;
   const isWeeklyResultPhase = league?.phase === 'preseason' || league?.phase === 'regular' || league?.phase === 'playoffs';
   const authoritativeResults = useMemo(
     () => (isWeeklyResultPhase && Array.isArray(lastResults) ? lastResults : []),
     [isWeeklyResultPhase, lastResults],
+  );
+  const unresolvedWeeklyEvent = useMemo(
+    () => (league?.pendingWeeklyEvents ?? []).find((event) => event?.state !== 'resolved') ?? null,
+    [league?.pendingWeeklyEvents],
   );
 
   // Post-game result shown after GameSimulation completes (before advancing week)
@@ -287,6 +295,10 @@ function AppContent() {
   const handleAdvanceWeek = useCallback(() => {
     if (busy || simulating || advancingRef.current) return;
     if (!league?.phase) return;
+    if (unresolvedWeeklyEvent) {
+      setShowWeeklyEventModal(true);
+      return;
+    }
 
     if (['regular', 'playoffs', 'preseason'].includes(league.phase)) {
       advancingRef.current = true;
@@ -310,7 +322,24 @@ function AppContent() {
       // Note: getDraftState is silent, so busy won't toggle. We don't lock for this.
       actions.getDraftState();
     }
-  }, [busy, simulating, actions, league]);
+  }, [busy, simulating, actions, league, unresolvedWeeklyEvent]);
+
+  const handleResolveWeeklyEvent = useCallback((choiceId) => {
+    if (!league || !unresolvedWeeklyEvent || !choiceId) return;
+    const resolved = applyEventDecision(unresolvedWeeklyEvent, choiceId);
+    if (!resolved) return;
+    Object.assign(unresolvedWeeklyEvent, resolved, { lastCheckedWeek: league?.week ?? 1 });
+    logChronicleEvent(league, {
+      week: league?.week,
+      season: league?.year,
+      type: 'weekly_event_decision',
+      headline: unresolvedWeeklyEvent?.headline ?? 'Franchise event resolved',
+      summary: `${resolved?.choiceLabel ?? 'Decision'} selected`,
+      outcome: resolved?.outcome,
+      meta: { eventId: unresolvedWeeklyEvent?.id, choiceId },
+    });
+    setShowWeeklyEventModal(false);
+  }, [league, unresolvedWeeklyEvent]);
 
   const handleSimToPhase = useCallback((targetPhase) => {
     if (busy || simulating || advancingRef.current || isBatchSimBlocking) return;
@@ -814,6 +843,15 @@ function AppContent() {
               ? `Simulating ${simPhaseLabel} · ${simProgress}% complete.`
               : `Processing ${simPhaseLabel} updates…`}
           </span>
+        </div>
+      )}
+      {unresolvedWeeklyEvent && !simulating && !busy && (
+        <div role="alert" className="app-banner app-banner-error" style={{ marginTop: 8, cursor: 'pointer', animation: 'eventPulse 1.25s ease-in-out infinite' }} onClick={() => setShowWeeklyEventModal(true)}>
+          <span className="app-banner-text">Franchise Event Requires Decision · Advance Week is blocked.</span>
+          <button className="btn app-banner-btn" onClick={(e) => { e.stopPropagation(); setShowWeeklyEventModal(true); }}>
+            Open Event
+          </button>
+          <style>{`@keyframes eventPulse { 0%{opacity:0.8} 50%{opacity:1} 100%{opacity:0.8} }`}</style>
         </div>
       )}
 
@@ -1346,6 +1384,14 @@ function AppContent() {
             </ul>
           </div>
         </div>
+      )}
+      {showWeeklyEventModal && unresolvedWeeklyEvent && (
+        <EventDecisionModal
+          event={unresolvedWeeklyEvent}
+          onChoose={handleResolveWeeklyEvent}
+          onClose={() => setShowWeeklyEventModal(false)}
+          onDecideLater={() => setShowWeeklyEventModal(false)}
+        />
       )}
     </div>
   );

--- a/src/ui/components/EventDecisionModal.jsx
+++ b/src/ui/components/EventDecisionModal.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { SectionCard, StatusChip } from './ScreenSystem.jsx';
+import { buildEventChoiceImpactChips } from '../utils/franchiseEvents.js';
 
 export default function EventDecisionModal({ event, onChoose, onClose, onDecideLater }) {
   if (!event) return null;
@@ -22,6 +23,13 @@ export default function EventDecisionModal({ event, onChoose, onClose, onDecideL
               >
                 <strong>{choice.label}</strong>
                 <span style={{ fontSize: 12, opacity: 0.8 }}>{choice.preview}</span>
+                <div className="app-row" style={{ gap: 6, flexWrap: 'wrap', marginTop: 4 }}>
+                  {buildEventChoiceImpactChips(choice).map((chip) => (
+                    <span key={chip.key} style={{ fontSize: 11, borderRadius: 999, padding: '2px 8px', border: '1px solid var(--hairline)', background: chip.tone === 'negative' ? 'rgba(255,69,58,0.14)' : chip.tone === 'positive' ? 'rgba(52,199,89,0.14)' : 'rgba(120,120,120,0.14)' }}>
+                      {chip.label}
+                    </span>
+                  ))}
+                </div>
               </button>
             ))}
             <button type="button" className="btn" onClick={onDecideLater}>Decide later</button>

--- a/src/ui/utils/franchiseCommandCenter.js
+++ b/src/ui/utils/franchiseCommandCenter.js
@@ -5,8 +5,8 @@ import { getHQViewModel } from '../../state/selectors.js';
 import { rankHqPriorityItems, getActionContext } from './hqHelpers.js';
 import { buildCompletedGamePresentation } from './boxScoreAccess.js';
 import { getRecentGames as getArchivedRecentGames } from '../../core/archive/gameArchive.ts';
-import { syncFranchiseChronicle } from './franchiseChronicle.js';
-import { resolveWeeklyEvent } from './franchiseEvents.js';
+import { logChronicleEvent, syncFranchiseChronicle } from './franchiseChronicle.js';
+import { applyEventDecision, pickWorstEventChoice, resolveWeeklyEvent } from './franchiseEvents.js';
 
 function safeNum(value, fallback = 0) {
   const n = Number(value);
@@ -104,6 +104,44 @@ function sortByStandings(teams = []) {
   });
 }
 
+function winPct(team) {
+  const games = safeNum(team?.wins) + safeNum(team?.losses) + safeNum(team?.ties);
+  return games > 0 ? (safeNum(team?.wins) + safeNum(team?.ties) * 0.5) / games : 0;
+}
+
+export function buildPowerRankings(league, { limit = 32 } = {}) {
+  const teams = Array.isArray(league?.teams) ? league.teams : [];
+  return [...teams]
+    .sort((a, b) => {
+      const aScore = winPct(a) * 100 + (safeNum(a?.ptsFor) - safeNum(a?.ptsAgainst)) * 0.08 + safeNum((a?.recentResults ?? []).slice(-3).filter((r) => String(r).toUpperCase() === 'W').length) * 0.9;
+      const bScore = winPct(b) * 100 + (safeNum(b?.ptsFor) - safeNum(b?.ptsAgainst)) * 0.08 + safeNum((b?.recentResults ?? []).slice(-3).filter((r) => String(r).toUpperCase() === 'W').length) * 0.9;
+      return bScore - aScore;
+    })
+    .slice(0, limit)
+    .map((team, index) => ({
+      rank: index + 1,
+      teamId: team?.id,
+      teamAbbr: team?.abbr ?? team?.name ?? `Team ${team?.id ?? ''}`.trim(),
+      summary: `${team?.gmPersona ?? 'Balanced'} outlook · ${formatRecord(team)} record`,
+    }));
+}
+
+export function buildLeagueHeadlines(league, { limit = 10 } = {}) {
+  const week = safeNum(league?.week, 1);
+  const raw = Array.isArray(league?.newsItems) ? league.newsItems : [];
+  return raw
+    .filter((item) => safeNum(item?.week ?? item?.meta?.week, week) <= week)
+    .slice(-limit)
+    .reverse()
+    .map((item, index) => ({
+      id: item?.id ?? `league-headline-${index}`,
+      headline: item?.headline ?? item?.title ?? 'League update',
+      detail: item?.summary ?? item?.body ?? item?.detail ?? '',
+      timestamp: `Week ${safeNum(item?.week ?? item?.meta?.week, week)}`,
+      teamId: item?.teamId ?? null,
+    }));
+}
+
 function formatRecord(team) {
   if (!team) return '0-0';
   const ties = safeNum(team.ties);
@@ -161,7 +199,32 @@ function maybeQueueWeeklyEvent(league) {
   if (!Array.isArray(league.pendingWeeklyEvents)) league.pendingWeeklyEvents = [];
   const currentWeek = safeNum(league?.week, 1);
   const unresolved = league.pendingWeeklyEvents.find((evt) => evt?.state !== 'resolved');
-  if (unresolved) return unresolved;
+  if (unresolved) {
+    const currentWeek = safeNum(league?.week, 1);
+    const trackedWeek = safeNum(unresolved?.lastCheckedWeek, safeNum(unresolved?.week, currentWeek));
+    const elapsed = Math.max(0, currentWeek - trackedWeek);
+    if (elapsed > 0) {
+      unresolved.ignoredWeeks = safeNum(unresolved?.ignoredWeeks, 0) + elapsed;
+      unresolved.lastCheckedWeek = currentWeek;
+    }
+    if (safeNum(unresolved?.ignoredWeeks, 0) >= 2) {
+      const fallbackChoice = pickWorstEventChoice(unresolved);
+      if (fallbackChoice?.id) {
+        const resolved = applyEventDecision(unresolved, fallbackChoice.id);
+        Object.assign(unresolved, resolved, { autoResolved: true, ignoredTag: 'Ignored — escalated' });
+        logChronicleEvent(league, {
+          week: currentWeek,
+          season: safeNum(league?.year, 0),
+          type: 'weekly_event_auto_resolve',
+          headline: unresolved?.headline ?? 'Franchise event auto-resolved',
+          outcome: `${resolved?.choiceLabel ?? fallbackChoice.label} · Ignored — escalated`,
+          summary: 'A weekly event was ignored for multiple weeks and escalated.',
+          meta: { ignoredWeeks: safeNum(unresolved?.ignoredWeeks, 0) },
+        });
+      }
+    }
+    return unresolved;
+  }
   const resolvedThisWeek = (league.pendingWeeklyEvents ?? []).some((evt) => safeNum(evt?.week) === currentWeek);
   if (resolvedThisWeek) return null;
   const event = resolveWeeklyEvent({ league });
@@ -473,6 +536,8 @@ export function selectFranchiseHQViewModel(league) {
     leagueNews,
     story,
     weeklyEvent: queuedEvent,
+    powerRankings: buildPowerRankings(vm.league, { limit: 32 }),
+    leagueHeadlines: buildLeagueHeadlines(vm.league, { limit: 10 }),
     navState: {
       activeSection: 'hq',
       suggestedDestinations: ['HQ', 'Team', 'League', 'News', 'Story', 'More'],

--- a/src/ui/utils/franchiseCommandCenter.test.js
+++ b/src/ui/utils/franchiseCommandCenter.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { buildLeagueHeadlines, buildPowerRankings } from './franchiseCommandCenter.js';
+
+describe('buildPowerRankings', () => {
+  it('sorts teams by weekly power score with record-leading teams first', () => {
+    const league = {
+      teams: [
+        { id: 1, abbr: 'AAA', wins: 2, losses: 5, ties: 0, ptsFor: 120, ptsAgainst: 180, recentResults: ['L', 'L', 'L'] },
+        { id: 2, abbr: 'BBB', wins: 6, losses: 1, ties: 0, ptsFor: 190, ptsAgainst: 110, recentResults: ['W', 'W', 'W'] },
+      ],
+    };
+    const rankings = buildPowerRankings(league, { limit: 2 });
+    expect(rankings).toHaveLength(2);
+    expect(rankings[0].teamAbbr).toBe('BBB');
+  });
+});
+
+describe('buildLeagueHeadlines', () => {
+  it('generates newest-first headlines with timestamp labels', () => {
+    const league = {
+      week: 9,
+      newsItems: [
+        { id: 'n1', week: 8, headline: 'Old', summary: 'Old summary' },
+        { id: 'n2', week: 9, headline: 'New', summary: 'New summary' },
+      ],
+    };
+    const headlines = buildLeagueHeadlines(league, { limit: 5 });
+    expect(headlines[0].headline).toBe('New');
+    expect(headlines[0].timestamp).toBe('Week 9');
+  });
+});

--- a/src/ui/utils/franchiseEvents.js
+++ b/src/ui/utils/franchiseEvents.js
@@ -165,8 +165,56 @@ export function applyEventDecision(event, choiceId) {
   };
 }
 
+export function buildEventChoiceImpactChips(choice = {}) {
+  const effects = choice?.effects ?? {};
+  const chips = [];
+  if (Number.isFinite(Number(effects?.ownerApproval))) {
+    chips.push({ key: 'owner', label: `Owner ${safeNum(effects.ownerApproval) >= 0 ? '+' : ''}${safeNum(effects.ownerApproval)}%`, tone: safeNum(effects.ownerApproval) >= 0 ? 'positive' : 'negative' });
+  }
+  if (Number.isFinite(Number(effects?.morale))) {
+    chips.push({ key: 'morale', label: `Morale ${safeNum(effects.morale) >= 0 ? '+' : ''}${safeNum(effects.morale)}`, tone: safeNum(effects.morale) >= 0 ? 'positive' : 'negative' });
+  }
+  if (Number.isFinite(Number(effects?.capImpact)) && safeNum(effects.capImpact) !== 0) {
+    chips.push({ key: 'cap', label: `Cap ${safeNum(effects.capImpact) >= 0 ? '+' : ''}$${Math.abs(safeNum(effects.capImpact)).toFixed(1)}M`, tone: safeNum(effects.capImpact) <= 0 ? 'negative' : 'neutral' });
+  } else {
+    chips.push({ key: 'cap', label: 'Cap none', tone: 'neutral' });
+  }
+  if (choice?.relationship?.gmName || Number.isFinite(Number(choice?.relationship?.delta))) {
+    const delta = safeNum(choice?.relationship?.delta, 0);
+    chips.push({ key: 'relationship', label: `${choice?.relationship?.gmName ?? 'GM'} ${delta >= 0 ? '+' : ''}${delta}`, tone: delta >= 0 ? 'positive' : 'negative' });
+  }
+  return chips.slice(0, 4);
+}
+
+export function pickWorstEventChoice(event = {}) {
+  const choices = Array.isArray(event?.choices) ? event.choices : [];
+  if (!choices.length) return null;
+  return [...choices].sort((a, b) => {
+    const scoreA = safeNum(a?.effects?.ownerApproval) + safeNum(a?.effects?.morale) + safeNum(a?.effects?.fanSentiment) + Math.min(0, safeNum(a?.effects?.capImpact) * 2);
+    const scoreB = safeNum(b?.effects?.ownerApproval) + safeNum(b?.effects?.morale) + safeNum(b?.effects?.fanSentiment) + Math.min(0, safeNum(b?.effects?.capImpact) * 2);
+    return scoreA - scoreB;
+  })[0];
+}
+
 export function updateRelationshipScore(currentValue, delta) {
   return Math.max(-100, Math.min(100, safeNum(currentValue, 0) + safeNum(delta, 0)));
+}
+
+export function resolveHoldoutReturnChance({
+  weeksHeldOut = 0,
+  morale = 50,
+  teamWinPct = 0.5,
+  rng = U.random,
+} = {}) {
+  const base = 0.2;
+  const weekBoost = Math.min(0.2, safeNum(weeksHeldOut) * 0.05);
+  const moraleBoost = safeNum(morale) <= 45 ? 0 : safeNum(morale) >= 75 ? 0.08 : 0.03;
+  const teamBoost = safeNum(teamWinPct) >= 0.6 ? 0.05 : 0;
+  const chance = Math.max(0.2, Math.min(0.5, base + weekBoost + moraleBoost + teamBoost));
+  return {
+    chance,
+    returns: rng() < chance,
+  };
 }
 
 export function evaluateTradeFairness({ offerValue = 0, askValue = 0, relationship = 0, deadlineWeek = false } = {}) {

--- a/src/ui/utils/franchiseEvents.test.js
+++ b/src/ui/utils/franchiseEvents.test.js
@@ -3,6 +3,8 @@ import {
   resolveWeeklyEvent,
   evaluateTradeFairness,
   buildContractCounterOffer,
+  buildEventChoiceImpactChips,
+  resolveHoldoutReturnChance,
   updateRelationshipScore,
 } from './franchiseEvents.js';
 
@@ -58,5 +60,25 @@ describe('updateRelationshipScore', () => {
   it('clamps the score between -100 and 100', () => {
     expect(updateRelationshipScore(95, 20)).toBe(100);
     expect(updateRelationshipScore(-95, -20)).toBe(-100);
+  });
+});
+
+describe('resolveHoldoutReturnChance', () => {
+  it('stays in 20%-50% band and is deterministic with provided rng', () => {
+    const low = resolveHoldoutReturnChance({ weeksHeldOut: 0, morale: 25, teamWinPct: 0.2, rng: () => 0.3 });
+    const high = resolveHoldoutReturnChance({ weeksHeldOut: 6, morale: 88, teamWinPct: 0.8, rng: () => 0.3 });
+    expect(low.chance).toBeGreaterThanOrEqual(0.2);
+    expect(low.chance).toBeLessThanOrEqual(0.5);
+    expect(high.chance).toBeLessThanOrEqual(0.5);
+    expect(high.returns).toBe(true);
+  });
+});
+
+describe('buildEventChoiceImpactChips', () => {
+  it('builds readable impact chips including cap fallback', () => {
+    const chips = buildEventChoiceImpactChips({ effects: { ownerApproval: 4, morale: -6, capImpact: 0 } });
+    expect(chips.some((chip) => chip.label.includes('Owner +4%'))).toBe(true);
+    expect(chips.some((chip) => chip.label.includes('Morale -6'))).toBe(true);
+    expect(chips.some((chip) => chip.label.includes('Cap none'))).toBe(true);
   });
 });


### PR DESCRIPTION
### Motivation
- Make weekly franchise events interrupt the weekly loop with visible urgency so users must decide or suffer consequences. 
- Surface consequence previews in the existing EventDecisionModal so choices feel tactical and informed.
- Auto-resolve ignored events to avoid permanently stalled saves and record that escalation in the chronicle.
- Provide lightweight league-level context (power rankings, headlines) for a livelier league view.

### Description
- Wired a blocking weekly-event flow into the main app loop so `Advance Week` is blocked when a pending event exists and a pulsing banner opens the `EventDecisionModal`. (changes in `src/ui/App.jsx`)
- Added pre-decision impact chips rendered inside the existing `EventDecisionModal` to preview Owner approval, Morale, Cap impact, and Relationship deltas. (changes in `src/ui/components/EventDecisionModal.jsx` and `src/ui/utils/franchiseEvents.js`)
- Extended event utilities with `buildEventChoiceImpactChips`, `pickWorstEventChoice`, and `resolveHoldoutReturnChance` (seeded-RNG friendly and constrained to 20%–50%). (changes in `src/ui/utils/franchiseEvents.js`)
- Implemented auto-escalation in the command-center: unresolved weekly events track `ignoredWeeks`, auto-apply the worst choice after 2+ weeks, and log an "Ignored — escalated" chronicle entry. (changes in `src/ui/utils/franchiseCommandCenter.js`)
- Added simple league helpers `buildPowerRankings` and `buildLeagueHeadlines` and surface `powerRankings` + `leagueHeadlines` on the HQ view model. (changes in `src/ui/utils/franchiseCommandCenter.js`)
- Kept to existing scaffolds and view-model patterns; chronicle logging is performed via `logChronicleEvent` when decisions or auto-resolves occur. (changes in `src/ui/App.jsx`, `src/ui/utils/franchiseChronicle.js` usage)
- Small tests added to cover: holdout return chance determinism/range, event impact chip generation, power ranking ordering, and league headline ordering/timestamps. (new/updated tests in `src/ui/utils/franchiseEvents.test.js` and `src/ui/utils/franchiseCommandCenter.test.js`)

### Testing
- Ran targeted unit tests: `npm run test:unit -- src/ui/utils/franchiseEvents.test.js src/ui/utils/franchiseChronicle.test.js src/ui/utils/newsDesk.test.js src/ui/utils/franchiseCommandCenter.test.js` and they passed.
- Ran full unit suite: `npm run test:unit` which completed successfully (all unit tests passed).
- Built production bundle: `npm run build` which completed successfully without fatal errors.
- New tests added: holdout return chance, event impact chips, power ranking sorting, and league headline generation; all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e910ed6aac832d81a7ff9bd2164742)