### PR TITLE
Implement premium mobile-first Franchise HQ weekly command center

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -6,10 +6,8 @@ import { selectFranchiseHQViewModel } from '../utils/franchiseCommandCenter.js';
 import {
   EmptyState,
   StatusChip,
-  WeeklyHero,
   ActionTile,
   SectionCard,
-  CompactListRow,
   SummaryGrid,
   WeeklyAgenda,
   CompactNewsCard,
@@ -20,6 +18,19 @@ function safeNum(value, fallback = 0) {
   return Number.isFinite(n) ? n : fallback;
 }
 
+function formatRecordInline(record) {
+  if (!record || record === '—') return '0-0';
+  return record;
+}
+
+function getMatchupMeta(command, nextGame) {
+  // TODO(hq-data): replace fallback weekday/time/location with canonical scheduled kickoff metadata once exposed in the weekly selector.
+  const day = nextGame?.dayLabel ?? nextGame?.kickoffDay ?? 'Sunday';
+  const time = nextGame?.kickoffTime ?? '1:00 PM';
+  const location = nextGame?.venueName ?? (nextGame?.isHome ? 'Home Field' : 'Away');
+  return `${day} • ${time} • ${location}`;
+}
+
 export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, simulating }) {
   const [lineupToast, setLineupToast] = useState(null);
   const command = useMemo(() => selectFranchiseHQViewModel(league), [league]);
@@ -27,6 +38,9 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
   if (command.readyState !== 'ready') {
     return <EmptyState title="HQ loading" body="Team context is still loading or this save is missing team ownership metadata." />;
   }
+
+  const userTeam = (league?.teams ?? []).find((t) => Number(t?.id) === Number(league?.userTeamId));
+  const opponent = command.nextGame?.opp ?? null;
 
   const handleSetLineup = () => {
     const team = (league?.teams ?? []).find((t) => Number(t?.id) === Number(league?.userTeamId));
@@ -50,52 +64,78 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
   const actionTiles = [
     { title: 'Set Lineup', icon: '🧩', subtitle: command.actionStatuses.lineup.subtitle, badge: command.actionStatuses.lineup.badge, onClick: handleSetLineup },
     { title: 'Game Plan', icon: '📋', subtitle: command.actionStatuses.gameplan.subtitle, badge: command.actionStatuses.gameplan.badge || 'Recommended', onClick: () => { markWeeklyPrepStep(league, 'planReviewed', true); onNavigate?.('Game Plan'); } },
-    { title: 'Scout Opponent', icon: '🔎', subtitle: command.actionStatuses.scouting.subtitle, badge: command.actionStatuses.scouting.badge, onClick: () => { markWeeklyPrepStep(league, 'opponentScouted', true); onNavigate?.('Weekly Prep'); } },
+    { title: 'Scout Opponent', icon: '🔎', subtitle: command.actionStatuses.scouting.subtitle, badge: command.actionStatuses.scouting.badge || 'New report', onClick: () => { markWeeklyPrepStep(league, 'opponentScouted', true); onNavigate?.('Weekly Prep'); } },
     { title: 'News & Injuries', icon: '📰', subtitle: command.actionStatuses.news.subtitle, badge: command.actionStatuses.news.badge, onClick: () => { markWeeklyPrepStep(league, 'injuriesReviewed', true); onNavigate?.('News'); } },
   ];
 
   const lastGame = command.lastGameSummary;
-  const upcomingLabel = command.nextGame?.isHome ? `vs ${command.nextOpponent}` : `@ ${command.nextOpponent}`;
+  const homeAwayVerb = command.nextGame?.isHome ? 'vs' : '@';
+  const footerDays = Math.max(0, 7 - ((safeNum(league?.week, 1) - 1) % 7));
 
   return (
     <div className="app-screen-stack franchise-hq franchise-command-center">
       <section className="app-hq-topbar card" aria-label="Franchise HQ top bar">
         <div className="app-hq-topbar__left">
-          <strong>Franchise HQ</strong>
           <span>{command.seasonLabel}</span>
+          <strong>{command.weekLabel}</strong>
         </div>
         <div className="app-hq-topbar__meta">
-          <StatusChip label={command.weekLabel} tone="league" />
+          <StatusChip label={String(league?.phase ?? 'Regular').replaceAll('_', ' ')} tone="league" />
           <StatusChip label={command.teamRecord} tone="team" />
-          <StatusChip label={command.prepStatus} tone="info" />
+        </div>
+        <div className="app-hq-topbar__team">
+          <div className="app-hq-team-badge" aria-hidden>{userTeam?.abbr?.slice(0, 2) ?? 'TM'}</div>
+          <div className="app-hq-team-copy">
+            <strong>{userTeam?.name ?? 'Your Team'}</strong>
+            <span>{userTeam?.abbr ?? 'TEAM'}</span>
+          </div>
+          <button className="app-hq-settings" type="button" aria-label="Open settings" onClick={() => onNavigate?.('Settings')}>⚙</button>
         </div>
       </section>
 
-      <WeeklyHero
-        eyebrow={`${command.seasonLabel} · ${command.weekLabel}`}
-        title={upcomingLabel}
-        subtitle={`Your record ${command.teamRecord} · Opponent ${command.nextOpponentRecord}`}
-        rightMeta={<StatusChip label={command.standingSummary} tone="info" />}
-        actions={<Button size="sm" className="app-advance-btn app-command-advance" onClick={onAdvanceWeek} disabled={busy || simulating}>{busy || simulating ? 'Advancing…' : 'Advance Week'}</Button>}
-      >
-        <div className="app-hero-summary-grid app-hero-summary-grid-command">
-          <div>
+      <section className="app-hq-matchup-hero card" aria-label="Weekly Hero">
+        <div className="app-hq-matchup-hero__header">
+          <span className="app-hq-matchup-hero__eyebrow">Next Opponent</span>
+          <span className="app-hq-matchup-hero__meta">{getMatchupMeta(command, command.nextGame)}</span>
+        </div>
+
+        <div className="app-hq-matchup-main">
+          <div className="app-hq-team app-hq-team--user">
+            <div className="app-hq-team-logo">{userTeam?.abbr ?? 'YOU'}</div>
+            <strong>{userTeam?.name ?? 'Your Team'}</strong>
+            <span>{formatRecordInline(command.teamRecord)}</span>
+          </div>
+          <div className="app-hq-vs-block">
+            <span>Week {safeNum(league?.week, 1)}</span>
+            <strong>VS</strong>
+            <small>{homeAwayVerb}</small>
+          </div>
+          <div className="app-hq-team app-hq-team--opp">
+            <div className="app-hq-team-logo">{opponent?.abbr ?? 'OPP'}</div>
+            <strong>{opponent?.name ?? command.nextOpponent}</strong>
+            <span>{formatRecordInline(command.nextOpponentRecord)}</span>
+          </div>
+        </div>
+
+        <div className="app-hq-hero-subcards">
+          <div className="app-hq-hero-subcard">
             <span>Last Game</span>
             <strong>{lastGame ? `${lastGame.userWon ? 'W' : 'L'} · ${lastGame.awayAbbr} ${safeNum(lastGame?.score?.away)} @ ${lastGame.homeAbbr} ${safeNum(lastGame?.score?.home)}` : 'No completed game yet'}</strong>
           </div>
-          <div>
+          <div className="app-hq-hero-subcard">
             <span>Standing</span>
             <strong>{command.standingSummary}</strong>
           </div>
-          <div>
-            <span>Owner Pulse</span>
-            <strong>{command.pressureSummary}</strong>
-          </div>
         </div>
-      </WeeklyHero>
 
-      <section className="app-section-stack" aria-label="Weekly Action Grid">
-        <div className="app-section-heading">Weekly Action Grid</div>
+        <Button className="app-command-advance app-command-advance-gold" onClick={onAdvanceWeek} disabled={busy || simulating}>
+          {busy || simulating ? 'Advancing…' : 'Advance Week'}
+        </Button>
+        <p className="app-hq-hero-footnote">Sim to Sunday • {footerDays} days until kickoff</p>
+      </section>
+
+      <section className="app-section-stack" aria-label="This Week Action Center">
+        <div className="app-section-heading">This Week</div>
         <div className="app-action-grid-2x2">
           {actionTiles.map((action) => (
             <ActionTile key={action.title} icon={action.icon} title={action.title} subtitle={action.subtitle} badge={action.badge ? <StatusChip label={action.badge} tone="warning" /> : null} onClick={action.onClick} tone="info" />
@@ -104,7 +144,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
       </section>
       {lineupToast ? <p className="app-inline-toast">{lineupToast}</p> : null}
 
-      <SectionCard title="Weekly Agenda" subtitle="Curated priorities for this week." variant="compact">
+      <SectionCard title="Weekly Agenda" subtitle="Priority tasks before kickoff." variant="compact">
         <WeeklyAgenda items={command.weeklyAgenda} onOpenTask={(task) => onNavigate?.(task?.targetRoute ?? task?.tab ?? 'HQ')} />
       </SectionCard>
 
@@ -113,23 +153,21 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
       </SectionCard>
 
       <SectionCard title="League News" subtitle="Around the league this week." variant="compact">
-        <CompactListRow
-          title="Next Game"
-          subtitle={`${upcomingLabel} · Opponent ${command.nextOpponentRecord}`}
-          meta={<StatusChip label={command.weekLabel} tone="league" />}
-        />
-        <CompactListRow
-          title="Last Game"
-          subtitle={lastGame ? `${lastGame.awayAbbr} ${safeNum(lastGame?.score?.away)} @ ${lastGame.homeAbbr} ${safeNum(lastGame?.score?.home)}` : 'No results yet.'}
-          meta={<StatusChip label={lastGame ? 'Final' : 'Pending'} tone="info" />}
-        />
         <div className="app-news-compact-list">
-          {(command.leagueNews ?? []).slice(0, 3).map((item) => (
+          {(command.leagueNews ?? []).slice(0, 4).map((item) => (
             <CompactNewsCard key={item.id} title={item.headline} subtitle={item.detail} />
           ))}
           {!command.leagueNews?.length ? <EmptyState title="No league headlines yet." body="Advance to generate weekly stories." /> : null}
         </div>
       </SectionCard>
+
+      <nav className="app-hq-bottom-nav" aria-label="HQ quick bottom navigation">
+        <button type="button" className="is-active" onClick={() => onNavigate?.('HQ')}>Home</button>
+        <button type="button" onClick={() => onNavigate?.('Team:Overview')}>Team</button>
+        <button type="button" onClick={() => onNavigate?.('League:Overview')}>League</button>
+        <button type="button" onClick={() => onNavigate?.('News')}>News</button>
+        <button type="button" onClick={() => onNavigate?.('More')}>More</button>
+      </nav>
     </div>
   );
 }

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -59,7 +59,7 @@ const baseLeague = {
 };
 
 describe('FranchiseHQ', () => {
-  it('renders premium hero + action grid + compact rails', () => {
+  it('renders weekly command center hierarchy and mobile nav labels', () => {
     const html = renderToString(
       <FranchiseHQ
         league={baseLeague}
@@ -77,9 +77,12 @@ describe('FranchiseHQ', () => {
     expect(html).toContain('Scout Opponent');
     expect(html).toContain('News &amp; Injuries');
     expect(html).toContain('Weekly Agenda');
-    expect(html).toContain('Weekly Action Grid');
+    expect(html).toContain('This Week');
     expect(html).toContain('Team Overview');
     expect(html).toContain('League News');
+    expect(html).toContain('Next Opponent');
+    expect(html).toContain('Home');
+    expect(html).toContain('More');
   });
 
   it('is safe with partial/older save payloads', () => {

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -231,32 +231,130 @@
 .franchise-command-center { gap: var(--space-4); }
 
 .app-hq-topbar {
-  padding: 10px 12px;
+  padding: 8px 10px;
   border: 1px solid var(--hairline);
   background: color-mix(in srgb, #070b12 88%, var(--surface) 12%);
   border-radius: var(--radius-md);
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto auto 1fr;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
 }
 .app-hq-topbar__left { display: grid; gap: 2px; min-width: 0; }
-.app-hq-topbar__left strong { font-size: var(--text-sm); letter-spacing: .01em; }
+.app-hq-topbar__left strong { font-size: var(--text-base); letter-spacing: .01em; }
 .app-hq-topbar__left span { font-size: 11px; color: var(--text-subtle); text-transform: uppercase; letter-spacing: .08em; }
 .app-hq-topbar__meta { display: flex; gap: 6px; flex-wrap: wrap; justify-content: flex-end; }
+.app-hq-topbar__team { margin-left: auto; display: flex; align-items: center; gap: 8px; min-width: 0; }
+.app-hq-team-badge {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, .18);
+  background: radial-gradient(circle at 30% 20%, rgba(255,255,255,.18), rgba(255,255,255,.04));
+  display: grid;
+  place-items: center;
+  font-size: 10px;
+  font-weight: 800;
+}
+.app-hq-team-copy { display: grid; line-height: 1.1; }
+.app-hq-team-copy strong { font-size: 12px; }
+.app-hq-team-copy span { font-size: 10px; color: var(--text-subtle); letter-spacing: .08em; }
+.app-hq-settings {
+  border: 1px solid var(--hairline);
+  background: rgba(255,255,255,.03);
+  color: var(--text-muted);
+  border-radius: 8px;
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+}
 .app-section-stack { display: grid; gap: 8px; }
 .app-section-heading { font-size: 11px; color: var(--text-subtle); text-transform: uppercase; letter-spacing: .08em; font-weight: 700; }
 
 
-.franchise-command-center .app-hero-card {
+.app-hq-matchup-hero {
   padding: var(--space-4);
-  gap: var(--space-3);
-  border-color: color-mix(in srgb, var(--accent) 30%, var(--hairline));
+  border-color: color-mix(in srgb, #ffd166 20%, var(--hairline));
   box-shadow: 0 16px 40px rgba(0, 0, 0, 0.32);
-  background: linear-gradient(160deg, color-mix(in srgb, #060b14 90%, var(--accent) 10%), color-mix(in srgb, #060b14 82%, var(--surface) 18%));
+  background:
+    radial-gradient(120% 180% at 10% 20%, rgba(77, 133, 255, .16), transparent 45%),
+    radial-gradient(120% 180% at 90% 20%, rgba(255, 84, 84, .14), transparent 45%),
+    linear-gradient(165deg, #060b13, #0c111a 55%, #101726 100%);
+  display: grid;
+  gap: 12px;
 }
-.franchise-command-center .app-section-card { box-shadow: 0 8px 20px rgba(0,0,0,.16); }
-.app-command-advance { min-width: 220px; font-size: var(--text-base); font-weight: 800; box-shadow: 0 10px 24px rgba(var(--accent-rgb), .26); }
+.app-hq-matchup-hero__header { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.app-hq-matchup-hero__eyebrow { font-size: 11px; letter-spacing: .09em; text-transform: uppercase; color: #d9dfed; font-weight: 700; }
+.app-hq-matchup-hero__meta { font-size: 11px; color: var(--text-subtle); }
+.app-hq-matchup-main { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 10px; }
+.app-hq-team { display: grid; gap: 4px; justify-items: center; text-align: center; }
+.app-hq-team-logo {
+  width: clamp(62px, 16vw, 88px);
+  aspect-ratio: 1;
+  border-radius: 999px;
+  border: 1px solid rgba(255,255,255,.2);
+  background: radial-gradient(circle at 30% 20%, rgba(255,255,255,.2), rgba(255,255,255,.06));
+  display: grid;
+  place-items: center;
+  font-size: clamp(12px, 3.4vw, 15px);
+  font-weight: 800;
+}
+.app-hq-team strong { font-size: clamp(12px, 3.4vw, 14px); }
+.app-hq-team span { color: var(--text-subtle); font-size: 12px; font-weight: 600; }
+.app-hq-vs-block { display: grid; justify-items: center; gap: 2px; color: var(--text-subtle); }
+.app-hq-vs-block strong { font-size: clamp(1rem, 5vw, 1.5rem); letter-spacing: .08em; color: #f8fbff; }
+.app-hq-vs-block small { text-transform: uppercase; letter-spacing: .08em; font-size: 10px; }
+.app-hq-hero-subcards { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+.app-hq-hero-subcard {
+  border: 1px solid var(--hairline);
+  border-radius: 12px;
+  background: rgba(255,255,255,.03);
+  padding: 8px 10px;
+  display: grid;
+  gap: 3px;
+}
+.app-hq-hero-subcard span { font-size: 10px; text-transform: uppercase; letter-spacing: .09em; color: var(--text-subtle); }
+.app-hq-hero-subcard strong { font-size: 12px; line-height: 1.3; }
+.app-command-advance { min-width: 220px; font-size: var(--text-base); font-weight: 800; }
+.app-command-advance-gold {
+  width: 100%;
+  min-height: 50px;
+  font-size: var(--text-base);
+  font-weight: 800;
+  border: 1px solid rgba(255, 224, 120, .65);
+  background: linear-gradient(180deg, #ffd46b, #f5b72c);
+  color: #17120a;
+  box-shadow: 0 12px 28px rgba(245, 183, 44, .24);
+}
+.app-hq-hero-footnote { margin: 0; text-align: center; color: var(--text-subtle); font-size: 11px; }
+
+.franchise-command-center .app-section-card {
+  box-shadow: 0 8px 20px rgba(0,0,0,.16);
+  background: color-mix(in srgb, #0a0f19 85%, var(--surface) 15%);
+}
+.app-hq-bottom-nav {
+  position: sticky;
+  bottom: 72px;
+  z-index: 3;
+  border: 1px solid var(--hairline);
+  border-radius: 14px;
+  background: color-mix(in srgb, #0b111b 92%, var(--surface) 8%);
+  padding: 6px;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 4px;
+}
+.app-hq-bottom-nav button {
+  border: 0;
+  background: transparent;
+  color: var(--text-subtle);
+  border-radius: 10px;
+  padding: 8px 6px;
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.app-hq-bottom-nav button.is-active { color: #f5f9ff; background: rgba(255,255,255,.08); }
 .app-blocker-row { display: flex; flex-wrap: wrap; gap: 8px; }
 .app-command-bottom-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
 .app-summary-grid { display: grid; gap: 8px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
@@ -349,11 +447,19 @@
   .app-summary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .app-hero-card__actions { grid-template-columns: 1fr; }
   .app-hero-card__actions .btn { width: 100%; }
-  .app-hq-topbar { flex-direction: column; align-items: flex-start; }
-  .app-hq-topbar__meta { width: 100%; justify-content: flex-start; }
+  .app-hq-topbar {
+    grid-template-columns: 1fr auto;
+    grid-template-areas: "left meta" "team team";
+  }
+  .app-hq-topbar__left { grid-area: left; }
+  .app-hq-topbar__meta { grid-area: meta; justify-content: flex-end; }
+  .app-hq-topbar__team { grid-area: team; margin-left: 0; }
+  .app-hq-matchup-main { grid-template-columns: 1fr auto 1fr; }
+  .app-hq-bottom-nav { bottom: 78px; }
 }
 
 @media (max-width: 420px) {
   .app-action-grid-2x2 { grid-template-columns: 1fr; }
   .app-summary-grid { grid-template-columns: 1fr; }
+  .app-hq-hero-subcards { grid-template-columns: 1fr; }
 }


### PR DESCRIPTION
### Motivation
- Replace the generic HQ/dashboard layout with a hero-first, mobile-first weekly command center that matches the provided visual hierarchy and composition.  
- Upgrade in-place so existing app shell, navigation and game flows remain intact and actions map to real routes (not a detached prototype).  
- Provide a premium dark sports UI with a dominant matchup hero and a single strong CTA while keeping data-driven wiring and graceful fallbacks for missing fields.

### Description
- Reworked `FranchiseHQ` presentation and structure in `src/ui/components/FranchiseHQ.jsx` to follow the exact section order: compact top app bar → Weekly Hero (matchup-first) → "This Week" action grid → Weekly Agenda → Team Overview → League News → sticky HQ bottom nav, and wired existing actions (`onAdvanceWeek`, `Team:Roster / Depth`, `Game Plan`, `Weekly Prep`, `News`).
- Implemented a premium matchup hero (eyebrow "Next Opponent", team badges, VS block, small metadata row, Last Game + Standing subcards, full-width gold `Advance Week` CTA and kickoff footnote) and small fallback adapter `getMatchupMeta` for kickoff metadata when canonical fields are missing.  
- Styling upgrades in `src/ui/styles/screen-system.css` for topbar/team identity, dark hero gradients/tints, gold CTA treatment, hero subcards, and a sticky HQ-local bottom nav to match mobile-native tab feel while preserving the global shell.  
- Tests updated: changed `src/ui/components/__tests__/FranchiseHQ.test.jsx` expectations to cover new labels/hierarchy and ensured existing smoke coverage (`freshSaveScreens.test.jsx`) still passes; no new component files added (reused `SectionCard`, `ActionTile`, `WeeklyAgenda`, `SummaryGrid`, `CompactNewsCard`, `StatusChip`, `EmptyState`).

### Testing
- Ran unit tests with `npm run test:unit -- src/ui/components/__tests__/FranchiseHQ.test.jsx src/ui/components/__tests__/freshSaveScreens.test.jsx`, both files passed (2 test files, 8 tests total) ✅.  
- No browser screenshots were produced from this environment (screenshot tooling unavailable), noted in PR summary as a limitation.  
- Changes were committed on the current branch and are ready for review; the design keeps real data wiring and preserves navigation/advance flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea502c3fb0832dab884735295c1082)