### PR TITLE
Franchise HQ visual-fidelity pass (post-#1290 structure merge)

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -13,6 +13,14 @@ import {
   CompactNewsCard,
 } from './ScreenSystem.jsx';
 
+const BOTTOM_NAV_ITEMS = [
+  { label: 'Home', route: 'HQ', icon: '⌂', active: true },
+  { label: 'Team', route: 'Team:Overview', icon: '⚑' },
+  { label: 'League', route: 'League:Overview', icon: '▦' },
+  { label: 'News', route: 'News', icon: '✦' },
+  { label: 'More', route: 'More', icon: '⋯' },
+];
+
 function safeNum(value, fallback = 0) {
   const n = Number(value);
   return Number.isFinite(n) ? n : fallback;
@@ -29,6 +37,16 @@ function getMatchupMeta(command, nextGame) {
   const time = nextGame?.kickoffTime ?? '1:00 PM';
   const location = nextGame?.venueName ?? (nextGame?.isHome ? 'Home Field' : 'Away');
   return `${day} • ${time} • ${location}`;
+}
+
+function UtilityControlIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M4 7.25h8m4 0h4M4 16.75h4m4 0h8" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+      <circle cx="14" cy="7.25" r="2.3" fill="none" stroke="currentColor" strokeWidth="1.8" />
+      <circle cx="8" cy="16.75" r="2.3" fill="none" stroke="currentColor" strokeWidth="1.8" />
+    </svg>
+  );
 }
 
 export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, simulating }) {
@@ -80,8 +98,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
           <strong>{command.weekLabel}</strong>
         </div>
         <div className="app-hq-topbar__meta">
-          <StatusChip label={String(league?.phase ?? 'Regular').replaceAll('_', ' ')} tone="league" />
-          <StatusChip label={command.teamRecord} tone="team" />
+          <StatusChip label={String(league?.phase ?? 'Regular').replaceAll('_', ' ')} tone="ok" />
         </div>
         <div className="app-hq-topbar__team">
           <div className="app-hq-team-badge" aria-hidden>{userTeam?.abbr?.slice(0, 2) ?? 'TM'}</div>
@@ -89,7 +106,9 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
             <strong>{userTeam?.name ?? 'Your Team'}</strong>
             <span>{userTeam?.abbr ?? 'TEAM'}</span>
           </div>
-          <button className="app-hq-settings" type="button" aria-label="Open settings" onClick={() => onNavigate?.('Settings')}>⚙</button>
+          <button className="app-hq-settings" type="button" aria-label="Open controls" onClick={() => onNavigate?.('Settings')}>
+            <UtilityControlIcon />
+          </button>
         </div>
       </section>
 
@@ -119,12 +138,20 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
 
         <div className="app-hq-hero-subcards">
           <div className="app-hq-hero-subcard">
-            <span>Last Game</span>
-            <strong>{lastGame ? `${lastGame.userWon ? 'W' : 'L'} · ${lastGame.awayAbbr} ${safeNum(lastGame?.score?.away)} @ ${lastGame.homeAbbr} ${safeNum(lastGame?.score?.home)}` : 'No completed game yet'}</strong>
+            <div className="app-hq-hero-subcard__head">
+              <span>🏟</span>
+              <strong>Last Game</strong>
+            </div>
+            <p className="app-hq-hero-subcard__value">{lastGame ? `${lastGame.userWon ? 'W' : 'L'} · ${lastGame.awayAbbr} ${safeNum(lastGame?.score?.away)} @ ${lastGame.homeAbbr} ${safeNum(lastGame?.score?.home)}` : 'No completed game yet'}</p>
+            <small>{lastGame ? `${lastGame.userWon ? 'Win momentum' : 'Bounce-back spot'} heading into week ${safeNum(league?.week, 1)}` : 'Play this week to establish momentum.'}</small>
           </div>
           <div className="app-hq-hero-subcard">
-            <span>Standing</span>
-            <strong>{command.standingSummary}</strong>
+            <div className="app-hq-hero-subcard__head">
+              <span>🏆</span>
+              <strong>Standing</strong>
+            </div>
+            <p className="app-hq-hero-subcard__value">{command.standingSummary}</p>
+            <small>{command.teamRecord} • Division race status</small>
           </div>
         </div>
 
@@ -162,11 +189,17 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
       </SectionCard>
 
       <nav className="app-hq-bottom-nav" aria-label="HQ quick bottom navigation">
-        <button type="button" className="is-active" onClick={() => onNavigate?.('HQ')}>Home</button>
-        <button type="button" onClick={() => onNavigate?.('Team:Overview')}>Team</button>
-        <button type="button" onClick={() => onNavigate?.('League:Overview')}>League</button>
-        <button type="button" onClick={() => onNavigate?.('News')}>News</button>
-        <button type="button" onClick={() => onNavigate?.('More')}>More</button>
+        {BOTTOM_NAV_ITEMS.map((item) => (
+          <button
+            key={item.label}
+            type="button"
+            className={item.active ? 'is-active' : ''}
+            onClick={() => onNavigate?.(item.route)}
+          >
+            <span aria-hidden="true">{item.icon}</span>
+            <small>{item.label}</small>
+          </button>
+        ))}
       </nav>
     </div>
   );

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -231,41 +231,57 @@
 .franchise-command-center { gap: var(--space-4); }
 
 .app-hq-topbar {
-  padding: 8px 10px;
-  border: 1px solid var(--hairline);
-  background: color-mix(in srgb, #070b12 88%, var(--surface) 12%);
-  border-radius: var(--radius-md);
+  padding: 9px 10px;
+  border: 1px solid color-mix(in srgb, #54e58f 24%, var(--hairline));
+  background:
+    linear-gradient(145deg, rgba(13, 22, 36, .96), rgba(7, 13, 22, .95)),
+    radial-gradient(120% 260% at 20% -20%, rgba(102, 227, 145, .13), transparent 56%);
+  border-radius: 15px;
   display: grid;
   grid-template-columns: auto auto 1fr;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
 }
 .app-hq-topbar__left { display: grid; gap: 2px; min-width: 0; }
-.app-hq-topbar__left strong { font-size: var(--text-base); letter-spacing: .01em; }
-.app-hq-topbar__left span { font-size: 11px; color: var(--text-subtle); text-transform: uppercase; letter-spacing: .08em; }
+.app-hq-topbar__left strong { font-size: 15px; letter-spacing: .01em; line-height: 1.05; }
+.app-hq-topbar__left span { font-size: 10px; color: #9aadc7; text-transform: uppercase; letter-spacing: .11em; font-weight: 700; }
 .app-hq-topbar__meta { display: flex; gap: 6px; flex-wrap: wrap; justify-content: flex-end; }
-.app-hq-topbar__team { margin-left: auto; display: flex; align-items: center; gap: 8px; min-width: 0; }
+.app-hq-topbar__meta .app-status-chip {
+  background: linear-gradient(180deg, #37d57d, #1da962);
+  color: #052713;
+  border-color: rgba(124, 255, 184, .65);
+  text-transform: uppercase;
+  letter-spacing: .07em;
+  font-size: 10px;
+  font-weight: 800;
+  box-shadow: 0 4px 12px rgba(25, 169, 98, .35);
+}
+.app-hq-topbar__team { margin-left: auto; display: flex; align-items: center; gap: 7px; min-width: 0; }
 .app-hq-team-badge {
-  width: 28px;
-  height: 28px;
+  width: 30px;
+  height: 30px;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, .18);
-  background: radial-gradient(circle at 30% 20%, rgba(255,255,255,.18), rgba(255,255,255,.04));
+  border: 1px solid rgba(255, 255, 255, .22);
+  background:
+    radial-gradient(circle at 35% 20%, rgba(255,255,255,.25), rgba(255,255,255,.02) 58%),
+    linear-gradient(160deg, rgba(67, 140, 255, .36), rgba(20, 37, 61, .95));
   display: grid;
   place-items: center;
   font-size: 10px;
   font-weight: 800;
 }
 .app-hq-team-copy { display: grid; line-height: 1.1; }
-.app-hq-team-copy strong { font-size: 12px; }
-.app-hq-team-copy span { font-size: 10px; color: var(--text-subtle); letter-spacing: .08em; }
+.app-hq-team-copy strong { font-size: 12px; max-width: 108px; white-space: nowrap; text-overflow: ellipsis; overflow: hidden; }
+.app-hq-team-copy span { font-size: 10px; color: #8ea2be; letter-spacing: .08em; }
 .app-hq-settings {
-  border: 1px solid var(--hairline);
-  background: rgba(255,255,255,.03);
-  color: var(--text-muted);
-  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, .22);
+  background: linear-gradient(180deg, rgba(255,255,255,.12), rgba(255,255,255,.04));
+  color: #dbe8fa;
+  border-radius: 999px;
   width: 28px;
   height: 28px;
+  display: grid;
+  place-items: center;
   cursor: pointer;
 }
 .app-section-stack { display: grid; gap: 8px; }
@@ -273,59 +289,101 @@
 
 
 .app-hq-matchup-hero {
-  padding: var(--space-4);
+  position: relative;
+  overflow: hidden;
+  padding: 14px 14px 12px;
   border-color: color-mix(in srgb, #ffd166 20%, var(--hairline));
-  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.32);
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.38);
   background:
-    radial-gradient(120% 180% at 10% 20%, rgba(77, 133, 255, .16), transparent 45%),
-    radial-gradient(120% 180% at 90% 20%, rgba(255, 84, 84, .14), transparent 45%),
+    repeating-linear-gradient(102deg, rgba(255,255,255,.03), rgba(255,255,255,.03) 2px, transparent 2px, transparent 18px),
+    radial-gradient(105% 170% at 11% 20%, rgba(58, 121, 255, .3), transparent 47%),
+    radial-gradient(105% 170% at 90% 16%, rgba(255, 68, 68, .27), transparent 45%),
     linear-gradient(165deg, #060b13, #0c111a 55%, #101726 100%);
   display: grid;
   gap: 12px;
 }
+.app-hq-matchup-hero::after {
+  content: "";
+  position: absolute;
+  inset: 38% -8% auto;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,.14), transparent);
+}
 .app-hq-matchup-hero__header { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .app-hq-matchup-hero__eyebrow { font-size: 11px; letter-spacing: .09em; text-transform: uppercase; color: #d9dfed; font-weight: 700; }
-.app-hq-matchup-hero__meta { font-size: 11px; color: var(--text-subtle); }
-.app-hq-matchup-main { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 10px; }
-.app-hq-team { display: grid; gap: 4px; justify-items: center; text-align: center; }
+.app-hq-matchup-hero__meta { font-size: 10px; color: #a6b6ce; text-align: right; }
+.app-hq-matchup-main { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 6px; }
+.app-hq-team { display: grid; gap: 4px; justify-items: center; text-align: center; position: relative; }
+.app-hq-team--user::before,
+.app-hq-team--opp::before {
+  content: "";
+  position: absolute;
+  inset: 2px 14px auto;
+  height: 50px;
+  border-radius: 999px;
+  z-index: 0;
+}
+.app-hq-team--user::before { background: radial-gradient(circle at 20% 40%, rgba(76, 130, 255, .35), transparent 70%); }
+.app-hq-team--opp::before { background: radial-gradient(circle at 80% 40%, rgba(255, 88, 88, .33), transparent 70%); }
 .app-hq-team-logo {
-  width: clamp(62px, 16vw, 88px);
+  width: clamp(72px, 21vw, 98px);
   aspect-ratio: 1;
   border-radius: 999px;
-  border: 1px solid rgba(255,255,255,.2);
-  background: radial-gradient(circle at 30% 20%, rgba(255,255,255,.2), rgba(255,255,255,.06));
+  border: 1px solid rgba(255,255,255,.24);
+  background: radial-gradient(circle at 30% 20%, rgba(255,255,255,.23), rgba(255,255,255,.02) 60%);
+  box-shadow: inset 0 0 0 3px rgba(255,255,255,.04), 0 10px 24px rgba(0, 0, 0, .32);
   display: grid;
   place-items: center;
-  font-size: clamp(12px, 3.4vw, 15px);
+  font-size: clamp(13px, 3.8vw, 16px);
   font-weight: 800;
+  position: relative;
+  z-index: 1;
 }
-.app-hq-team strong { font-size: clamp(12px, 3.4vw, 14px); }
-.app-hq-team span { color: var(--text-subtle); font-size: 12px; font-weight: 600; }
-.app-hq-vs-block { display: grid; justify-items: center; gap: 2px; color: var(--text-subtle); }
-.app-hq-vs-block strong { font-size: clamp(1rem, 5vw, 1.5rem); letter-spacing: .08em; color: #f8fbff; }
+.app-hq-team--user .app-hq-team-logo { background: radial-gradient(circle at 26% 20%, rgba(255,255,255,.3), rgba(34,87,183,.3) 55%, rgba(7, 17, 32, .86)); }
+.app-hq-team--opp .app-hq-team-logo { background: radial-gradient(circle at 26% 20%, rgba(255,255,255,.28), rgba(189,45,45,.32) 55%, rgba(33, 9, 15, .88)); }
+.app-hq-team strong { font-size: clamp(12px, 3.5vw, 14px); }
+.app-hq-team span { color: #95a7c2; font-size: 12px; font-weight: 700; }
+.app-hq-vs-block {
+  display: grid;
+  justify-items: center;
+  gap: 1px;
+  color: #a9b7cc;
+  border: 1px solid rgba(255,255,255,.18);
+  border-radius: 16px;
+  padding: 6px 9px;
+  background: linear-gradient(180deg, rgba(255,255,255,.1), rgba(255,255,255,.02));
+  min-width: 66px;
+}
+.app-hq-vs-block strong { font-size: clamp(1.05rem, 5.2vw, 1.7rem); letter-spacing: .08em; color: #f8fbff; line-height: .95; }
 .app-hq-vs-block small { text-transform: uppercase; letter-spacing: .08em; font-size: 10px; }
 .app-hq-hero-subcards { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
 .app-hq-hero-subcard {
-  border: 1px solid var(--hairline);
+  border: 1px solid rgba(255,255,255,.14);
   border-radius: 12px;
-  background: rgba(255,255,255,.03);
+  background: linear-gradient(180deg, rgba(255,255,255,.075), rgba(255,255,255,.03));
   padding: 8px 10px;
   display: grid;
-  gap: 3px;
+  gap: 5px;
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.06);
 }
-.app-hq-hero-subcard span { font-size: 10px; text-transform: uppercase; letter-spacing: .09em; color: var(--text-subtle); }
-.app-hq-hero-subcard strong { font-size: 12px; line-height: 1.3; }
+.app-hq-hero-subcard__head { display: flex; align-items: center; gap: 6px; color: #bdcce1; font-size: 10px; text-transform: uppercase; letter-spacing: .08em; }
+.app-hq-hero-subcard__head strong { font-size: 10px; color: #bdcce1; text-transform: uppercase; letter-spacing: .08em; }
+.app-hq-hero-subcard__value { margin: 0; font-size: 13px; line-height: 1.25; font-weight: 800; color: #f2f7ff; }
+.app-hq-hero-subcard small { color: #8ea2be; font-size: 11px; }
 .app-command-advance { min-width: 220px; font-size: var(--text-base); font-weight: 800; }
 .app-command-advance-gold {
   width: 100%;
-  min-height: 50px;
-  font-size: var(--text-base);
+  min-height: 56px;
+  margin-top: 2px;
+  font-size: 17px;
   font-weight: 800;
-  border: 1px solid rgba(255, 224, 120, .65);
-  background: linear-gradient(180deg, #ffd46b, #f5b72c);
+  border-radius: 999px;
+  border: 1px solid rgba(255, 224, 120, .78);
+  background: linear-gradient(180deg, #ffe189, #fbc23b 56%, #ebad1f);
   color: #17120a;
-  box-shadow: 0 12px 28px rgba(245, 183, 44, .24);
+  box-shadow: 0 14px 30px rgba(245, 183, 44, .34), inset 0 1px 0 rgba(255,255,255,.4);
 }
+.app-command-advance-gold::after { content: "➜"; margin-left: 8px; font-size: 14px; }
 .app-hq-hero-footnote { margin: 0; text-align: center; color: var(--text-subtle); font-size: 11px; }
 
 .franchise-command-center .app-section-card {
@@ -336,25 +394,36 @@
   position: sticky;
   bottom: 72px;
   z-index: 3;
-  border: 1px solid var(--hairline);
-  border-radius: 14px;
-  background: color-mix(in srgb, #0b111b 92%, var(--surface) 8%);
-  padding: 6px;
+  border: 1px solid rgba(255,255,255,.16);
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(13,20,32,.97), rgba(10,16,27,.95));
+  padding: 5px;
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 4px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, .35);
 }
 .app-hq-bottom-nav button {
   border: 0;
   background: transparent;
   color: var(--text-subtle);
-  border-radius: 10px;
-  padding: 8px 6px;
-  font-size: 11px;
+  border-radius: 12px;
+  padding: 6px 4px 5px;
+  display: grid;
+  justify-items: center;
+  gap: 2px;
+  font-size: 10px;
   font-weight: 700;
   cursor: pointer;
 }
-.app-hq-bottom-nav button.is-active { color: #f5f9ff; background: rgba(255,255,255,.08); }
+.app-hq-bottom-nav button span { font-size: 15px; line-height: 1; color: #8ea1bf; }
+.app-hq-bottom-nav button small { font-size: 10px; letter-spacing: .01em; color: #8ea1bf; }
+.app-hq-bottom-nav button.is-active {
+  color: #f5f9ff;
+  background: linear-gradient(180deg, rgba(67, 124, 241, .34), rgba(67, 124, 241, .16));
+}
+.app-hq-bottom-nav button.is-active span,
+.app-hq-bottom-nav button.is-active small { color: #f2f7ff; }
 .app-blocker-row { display: flex; flex-wrap: wrap; gap: 8px; }
 .app-command-bottom-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
 .app-summary-grid { display: grid; gap: 8px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
@@ -400,11 +469,11 @@
 .app-compact-news-card strong { font-size: var(--text-xs); }
 .app-compact-news-card span { font-size: 11px; color: var(--text-muted); }
 
-.app-action-tile { min-height: 102px; transition: transform .16s ease, border-color .16s ease, background .16s ease; }
-.app-action-tile:hover, .app-action-tile:focus-visible { transform: translateY(-2px); border-color: rgba(var(--accent-rgb), .5); background: color-mix(in srgb, var(--surface-2) 86%, var(--accent) 14%); }
+.app-action-tile { min-height: 102px; transition: transform .16s ease, border-color .16s ease, background .16s ease; border-color: rgba(255,255,255,.15); background: linear-gradient(180deg, rgba(255,255,255,.07), rgba(255,255,255,.02)); box-shadow: inset 0 1px 0 rgba(255,255,255,.06); }
+.app-action-tile:hover, .app-action-tile:focus-visible { transform: translateY(-2px); border-color: rgba(var(--accent-rgb), .5); background: color-mix(in srgb, var(--surface-2) 75%, var(--accent) 25%); }
 .app-action-tile:active { transform: translateY(0); }
-.app-action-tile__icon { margin-right: 6px; }
-.app-action-tile .app-status-chip { font-size: 10px; }
+.app-action-tile__icon { margin-right: 8px; width: 26px; height: 26px; border-radius: 8px; display: grid; place-items: center; background: rgba(255,255,255,.1); }
+.app-action-tile .app-status-chip { font-size: 10px; background: rgba(255, 188, 84, .24); border-color: rgba(255, 188, 84, .5); color: #ffd28c; }
 
 .app-task-list { display: grid; gap: 8px; }
 .app-task-row {
@@ -455,6 +524,7 @@
   .app-hq-topbar__meta { grid-area: meta; justify-content: flex-end; }
   .app-hq-topbar__team { grid-area: team; margin-left: 0; }
   .app-hq-matchup-main { grid-template-columns: 1fr auto 1fr; }
+  .app-hq-hero-subcard__value { font-size: 12px; }
   .app-hq-bottom-nav { bottom: 78px; }
 }
 


### PR DESCRIPTION
### Motivation
- Tighten the merged Franchise HQ implementation to match the premium mobile screenshot more closely by focusing on top bar, matchup hero, subcards, CTA, bottom nav, and action tile feel.
- Preserve the existing upgrade-in-place architecture and data wiring while moving visuals from “dashboard” toward a mobile-native game UI composition.
- Keep interactions and routes intact and avoid rebuilding the app shell or duplicating dashboard architecture.

### Description
- Updated `src/ui/components/FranchiseHQ.jsx` to tighten top-bar composition (stacked season/week, single green phase pill, compact team area), replace the gear glyph with a compact `UtilityControlIcon`, add structured subcard markup for Last Game and Standing, and render a mobile-style bottom nav from a `BOTTOM_NAV_ITEMS` array. 
- Updated `src/ui/styles/screen-system.css` to implement the visual pass: refined topbar gradients/border, prominent green status pill styling, more dramatic blue-vs-red hero lighting and textured backdrop, larger dimensional circular team discs, a framed central VS block, enriched hero subcard hierarchy (title/icon row, prominent value, tertiary context), a larger pill-shaped gold CTA with arrow affordance, tactile action-tile visuals (icon box, badge styling), and a mobile-native icon+label bottom tab bar with active state. 
- Preserved existing selectors, view model usage, routes, and event wiring so no data/behavioral changes were introduced. 

### Testing
- Ran targeted unit render tests with `npm run test:unit -- src/ui/components/__tests__/FranchiseHQ.test.jsx src/ui/components/__tests__/freshSaveScreens.test.jsx`. 
- Result: both test files passed (8 tests total) and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea532e1124832dbbff0fd6e88dc9ce)