### PR TITLE
Polish Franchise HQ: SVG icons, team badges, copy polish, and Netlify build fix

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 # netlify.toml — Netlify configuration for Football GM SPA
 
 [build]
-  command   = "yarn build"
+  command   = "npm run build"
   publish   = "dist"
 
 [build.environment]

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -12,13 +12,14 @@ import {
   WeeklyAgenda,
   CompactNewsCard,
 } from './ScreenSystem.jsx';
+import { HQIcon, TeamIdentityBadge } from './HQVisuals.jsx';
 
 const BOTTOM_NAV_ITEMS = [
-  { label: 'Home', route: 'HQ', icon: '⌂', active: true },
-  { label: 'Team', route: 'Team:Overview', icon: '⚑' },
-  { label: 'League', route: 'League:Overview', icon: '▦' },
-  { label: 'News', route: 'News', icon: '✦' },
-  { label: 'More', route: 'More', icon: '⋯' },
+  { label: 'Home', route: 'HQ', icon: 'home', active: true },
+  { label: 'Team', route: 'Team:Overview', icon: 'team' },
+  { label: 'League', route: 'League:Overview', icon: 'league' },
+  { label: 'News', route: 'News', icon: 'news' },
+  { label: 'More', route: 'More', icon: 'more' },
 ];
 
 function safeNum(value, fallback = 0) {
@@ -37,16 +38,6 @@ function getMatchupMeta(command, nextGame) {
   const time = nextGame?.kickoffTime ?? '1:00 PM';
   const location = nextGame?.venueName ?? (nextGame?.isHome ? 'Home Field' : 'Away');
   return `${day} • ${time} • ${location}`;
-}
-
-function UtilityControlIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M4 7.25h8m4 0h4M4 16.75h4m4 0h8" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
-      <circle cx="14" cy="7.25" r="2.3" fill="none" stroke="currentColor" strokeWidth="1.8" />
-      <circle cx="8" cy="16.75" r="2.3" fill="none" stroke="currentColor" strokeWidth="1.8" />
-    </svg>
-  );
 }
 
 export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, simulating }) {
@@ -80,15 +71,26 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
   };
 
   const actionTiles = [
-    { title: 'Set Lineup', icon: '🧩', subtitle: command.actionStatuses.lineup.subtitle, badge: command.actionStatuses.lineup.badge, onClick: handleSetLineup },
-    { title: 'Game Plan', icon: '📋', subtitle: command.actionStatuses.gameplan.subtitle, badge: command.actionStatuses.gameplan.badge || 'Recommended', onClick: () => { markWeeklyPrepStep(league, 'planReviewed', true); onNavigate?.('Game Plan'); } },
-    { title: 'Scout Opponent', icon: '🔎', subtitle: command.actionStatuses.scouting.subtitle, badge: command.actionStatuses.scouting.badge || 'New report', onClick: () => { markWeeklyPrepStep(league, 'opponentScouted', true); onNavigate?.('Weekly Prep'); } },
-    { title: 'News & Injuries', icon: '📰', subtitle: command.actionStatuses.news.subtitle, badge: command.actionStatuses.news.badge, onClick: () => { markWeeklyPrepStep(league, 'injuriesReviewed', true); onNavigate?.('News'); } },
+    { title: 'Set Lineup', icon: <HQIcon name="lineup" size={16} />, subtitle: command.actionStatuses.lineup.subtitle, badge: command.actionStatuses.lineup.badge, onClick: handleSetLineup },
+    { title: 'Game Plan', icon: <HQIcon name="gamePlan" size={16} />, subtitle: command.actionStatuses.gameplan.subtitle, badge: command.actionStatuses.gameplan.badge || 'Recommended', onClick: () => { markWeeklyPrepStep(league, 'planReviewed', true); onNavigate?.('Game Plan'); } },
+    { title: 'Scout Opponent', icon: <HQIcon name="scout" size={16} />, subtitle: command.actionStatuses.scouting.subtitle, badge: command.actionStatuses.scouting.badge || 'New report', onClick: () => { markWeeklyPrepStep(league, 'opponentScouted', true); onNavigate?.('Weekly Prep'); } },
+    { title: 'News & Injuries', icon: <HQIcon name="injuryNews" size={16} />, subtitle: command.actionStatuses.news.subtitle, badge: command.actionStatuses.news.badge, onClick: () => { markWeeklyPrepStep(league, 'injuriesReviewed', true); onNavigate?.('News'); } },
   ];
 
   const lastGame = command.lastGameSummary;
   const homeAwayVerb = command.nextGame?.isHome ? 'vs' : '@';
   const footerDays = Math.max(0, 7 - ((safeNum(league?.week, 1) - 1) % 7));
+  const divisionRows = command.divisionMiniStandings ?? [];
+  const divisionLeader = divisionRows[0] ?? null;
+  const userRow = divisionRows.find((row) => row?.isUser) ?? null;
+  const leaderWins = safeNum(divisionLeader?.record?.split('-')?.[0]);
+  const userWins = safeNum(userRow?.record?.split('-')?.[0]);
+  const gamesBehind = Math.max(0, leaderWins - userWins);
+  const standingDetail = divisionLeader && !divisionLeader?.isUser ? `${gamesBehind || 1} GB behind ${divisionLeader?.abbr ?? 'division lead'}` : 'Leads division race';
+  const lastTwo = Array.isArray(userTeam?.recentResults) ? userTeam.recentResults.slice(-2).map((r) => String(r).toUpperCase()) : [];
+  const hasTwoWins = lastTwo.length === 2 && lastTwo.every((result) => result === 'W');
+  const hasTwoLosses = lastTwo.length === 2 && lastTwo.every((result) => result === 'L');
+  const lastGameStory = hasTwoWins ? 'Won 2 straight heading into kickoff' : hasTwoLosses ? 'Need division response this week' : (lastGame?.userWon ? 'Carrying momentum from last win' : 'Rebound spot after last result');
 
   return (
     <div className="app-screen-stack franchise-hq franchise-command-center">
@@ -101,13 +103,13 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
           <StatusChip label={String(league?.phase ?? 'Regular').replaceAll('_', ' ')} tone="ok" />
         </div>
         <div className="app-hq-topbar__team">
-          <div className="app-hq-team-badge" aria-hidden>{userTeam?.abbr?.slice(0, 2) ?? 'TM'}</div>
+          <TeamIdentityBadge team={userTeam} size={32} emphasize />
           <div className="app-hq-team-copy">
             <strong>{userTeam?.name ?? 'Your Team'}</strong>
             <span>{userTeam?.abbr ?? 'TEAM'}</span>
           </div>
           <button className="app-hq-settings" type="button" aria-label="Open controls" onClick={() => onNavigate?.('Settings')}>
-            <UtilityControlIcon />
+            <HQIcon name="controls" size={16} />
           </button>
         </div>
       </section>
@@ -120,7 +122,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
 
         <div className="app-hq-matchup-main">
           <div className="app-hq-team app-hq-team--user">
-            <div className="app-hq-team-logo">{userTeam?.abbr ?? 'YOU'}</div>
+            <TeamIdentityBadge team={userTeam} size={86} variant="shield" emphasize />
             <strong>{userTeam?.name ?? 'Your Team'}</strong>
             <span>{formatRecordInline(command.teamRecord)}</span>
           </div>
@@ -130,7 +132,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
             <small>{homeAwayVerb}</small>
           </div>
           <div className="app-hq-team app-hq-team--opp">
-            <div className="app-hq-team-logo">{opponent?.abbr ?? 'OPP'}</div>
+            <TeamIdentityBadge team={opponent} size={86} variant="circle" />
             <strong>{opponent?.name ?? command.nextOpponent}</strong>
             <span>{formatRecordInline(command.nextOpponentRecord)}</span>
           </div>
@@ -139,24 +141,25 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
         <div className="app-hq-hero-subcards">
           <div className="app-hq-hero-subcard">
             <div className="app-hq-hero-subcard__head">
-              <span>🏟</span>
+              <HQIcon name="lastGame" size={14} />
               <strong>Last Game</strong>
             </div>
             <p className="app-hq-hero-subcard__value">{lastGame ? `${lastGame.userWon ? 'W' : 'L'} · ${lastGame.awayAbbr} ${safeNum(lastGame?.score?.away)} @ ${lastGame.homeAbbr} ${safeNum(lastGame?.score?.home)}` : 'No completed game yet'}</p>
-            <small>{lastGame ? `${lastGame.userWon ? 'Win momentum' : 'Bounce-back spot'} heading into week ${safeNum(league?.week, 1)}` : 'Play this week to establish momentum.'}</small>
+            <small>{lastGame ? lastGameStory : 'Play this week to establish momentum.'}</small>
           </div>
           <div className="app-hq-hero-subcard">
             <div className="app-hq-hero-subcard__head">
-              <span>🏆</span>
+              <HQIcon name="standing" size={14} />
               <strong>Standing</strong>
             </div>
             <p className="app-hq-hero-subcard__value">{command.standingSummary}</p>
-            <small>{command.teamRecord} • Division race status</small>
+            <small>{standingDetail}</small>
           </div>
         </div>
 
         <Button className="app-command-advance app-command-advance-gold" onClick={onAdvanceWeek} disabled={busy || simulating}>
           {busy || simulating ? 'Advancing…' : 'Advance Week'}
+          <HQIcon name="arrowRight" size={16} />
         </Button>
         <p className="app-hq-hero-footnote">Sim to Sunday • {footerDays} days until kickoff</p>
       </section>
@@ -196,7 +199,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
             className={item.active ? 'is-active' : ''}
             onClick={() => onNavigate?.(item.route)}
           >
-            <span aria-hidden="true">{item.icon}</span>
+            <span aria-hidden="true"><HQIcon name={item.icon} size={18} /></span>
             <small>{item.label}</small>
           </button>
         ))}

--- a/src/ui/components/HQVisuals.jsx
+++ b/src/ui/components/HQVisuals.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { teamColor } from '../../data/team-utils.js';
+
+const baseIconProps = {
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.9,
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+};
+
+export function HQIcon({ name, size = 18 }) {
+  const common = { width: size, height: size, viewBox: '0 0 24 24', 'aria-hidden': 'true', focusable: 'false' };
+  switch (name) {
+    case 'home':
+      return <svg {...common}><path {...baseIconProps} d="M3.75 11.5 12 4.75l8.25 6.75v8.25a1.5 1.5 0 0 1-1.5 1.5h-4.5v-6h-4.5v6h-4.5a1.5 1.5 0 0 1-1.5-1.5z" /></svg>;
+    case 'team':
+      return <svg {...common}><path {...baseIconProps} d="M12 3.75 4.5 7v5.9c0 4.1 3.2 7.9 7.5 8.95 4.3-1.05 7.5-4.85 7.5-8.95V7z" /></svg>;
+    case 'league':
+      return <svg {...common}><path {...baseIconProps} d="M12 4.75v14.5M4.75 12h14.5" /><circle {...baseIconProps} cx="12" cy="12" r="7.25" /></svg>;
+    case 'news':
+      return <svg {...common}><rect {...baseIconProps} x="4.5" y="4.5" width="15" height="15" rx="2.5" /><path {...baseIconProps} d="M8 9.25h8M8 12h8M8 14.75h5" /></svg>;
+    case 'more':
+      return <svg {...common}><path {...baseIconProps} d="M4.5 7.5h15M4.5 12h15M4.5 16.5h15" /></svg>;
+    case 'lineup':
+      return <svg {...common}><rect {...baseIconProps} x="6" y="4.75" width="12" height="16" rx="2" /><path {...baseIconProps} d="M9 4.75h6M9 10h6M9 13.5h6M9 17h3" /></svg>;
+    case 'gamePlan':
+      return <svg {...common}><path {...baseIconProps} d="M4.5 6.5h7l2 2h6v9a2 2 0 0 1-2 2h-11a2 2 0 0 1-2-2z" /><path {...baseIconProps} d="M9.5 12.25h6M9.5 15.25h4" /></svg>;
+    case 'scout':
+      return <svg {...common}><circle {...baseIconProps} cx="10.5" cy="10.5" r="4.5" /><path {...baseIconProps} d="m14 14 5.25 5.25M7.75 10.5h5.5" /></svg>;
+    case 'injuryNews':
+      return <svg {...common}><path {...baseIconProps} d="M5.25 7.5A2.75 2.75 0 0 1 8 4.75h8a2.75 2.75 0 0 1 2.75 2.75v9A2.75 2.75 0 0 1 16 19.25H8a2.75 2.75 0 0 1-2.75-2.75z" /><path {...baseIconProps} d="M9 9.25h6M9 12.25h6M9 15.25h3.5" /></svg>;
+    case 'controls':
+      return <svg {...common}><path {...baseIconProps} d="M4.75 7.5h8.5m2 0h4M4.75 16.5h4m2 0h8.5" /><circle {...baseIconProps} cx="13.25" cy="7.5" r="1.8" /><circle {...baseIconProps} cx="8.75" cy="16.5" r="1.8" /></svg>;
+    case 'lastGame':
+      return <svg {...common}><path {...baseIconProps} d="M7 18.5h10M8.5 18.5V8.25M15.5 18.5V8.25M10 8.25h4M8 5.25h8" /></svg>;
+    case 'standing':
+      return <svg {...common}><path {...baseIconProps} d="M5 17.75 10 12l3.25 3.25 5.75-7" /><path {...baseIconProps} d="M18 8.25h1.75V10" /></svg>;
+    case 'arrowRight':
+      return <svg {...common}><path {...baseIconProps} d="M5 12h14m-5-5 5 5-5 5" /></svg>;
+    default:
+      return null;
+  }
+}
+
+function hexToRgb(hex) {
+  const normalized = String(hex ?? '').trim().replace('#', '');
+  if (normalized.length !== 6) return { r: 60, g: 92, b: 140 };
+  const num = Number.parseInt(normalized, 16);
+  return { r: (num >> 16) & 255, g: (num >> 8) & 255, b: num & 255 };
+}
+
+export function TeamIdentityBadge({ team, variant = 'circle', size = 78, emphasize = false }) {
+  const abbr = String(team?.abbr ?? 'TM').slice(0, 3).toUpperCase();
+  const color = teamColor(abbr);
+  const rgb = hexToRgb(color);
+  const style = {
+    width: size,
+    height: size,
+    '--badge-rgb': `${rgb.r}, ${rgb.g}, ${rgb.b}`,
+    '--badge-color': color,
+  };
+  return (
+    <span className={`app-team-badge variant-${variant} ${emphasize ? 'is-emphasis' : ''}`} style={style} aria-hidden>
+      <span>{abbr}</span>
+    </span>
+  );
+}

--- a/src/ui/components/ScreenSystem.jsx
+++ b/src/ui/components/ScreenSystem.jsx
@@ -90,7 +90,10 @@ export function ActionTile({ icon = null, title, subtitle, badge = null, onClick
   return (
     <button type="button" className={`app-action-tile tone-${tone}`} onClick={onClick}>
       <div className="app-action-tile__title-row">
-        <strong>{icon ? <span className="app-action-tile__icon">{icon}</span> : null}{title}</strong>
+        <strong>
+          {icon ? <span className="app-action-tile__icon">{icon}</span> : null}
+          {title}
+        </strong>
         {badge}
       </div>
       {subtitle ? <span className="app-action-tile__subtitle">{subtitle}</span> : null}

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -260,15 +260,49 @@
 .app-hq-team-badge {
   width: 30px;
   height: 30px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, .22);
-  background:
-    radial-gradient(circle at 35% 20%, rgba(255,255,255,.25), rgba(255,255,255,.02) 58%),
-    linear-gradient(160deg, rgba(67, 140, 255, .36), rgba(20, 37, 61, .95));
+}
+
+.app-team-badge {
+  width: 34px;
+  height: 34px;
   display: grid;
   place-items: center;
-  font-size: 10px;
+  border: 1px solid rgba(var(--badge-rgb), .55);
+  background:
+    radial-gradient(circle at 28% 24%, rgba(255,255,255,.38), rgba(255,255,255,.08) 34%, transparent 62%),
+    linear-gradient(150deg, rgba(var(--badge-rgb), .95), rgba(7, 12, 22, .92));
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.24), 0 8px 20px rgba(var(--badge-rgb), .32);
+  font-weight: 900;
+  letter-spacing: .03em;
+  color: #f5f8ff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, .45);
+}
+.app-team-badge.variant-circle { border-radius: 999px; }
+.app-team-badge.variant-shield {
+  clip-path: polygon(50% 0%, 89% 9%, 95% 37%, 86% 70%, 50% 100%, 14% 70%, 5% 37%, 11% 9%);
+  border-radius: 16px;
+}
+.app-team-badge.is-emphasis {
+  border-color: color-mix(in srgb, rgba(var(--badge-rgb), 1) 66%, rgba(255,255,255,.88));
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.35), 0 0 0 1px rgba(var(--badge-rgb), .35), 0 14px 30px rgba(var(--badge-rgb), .42);
+}
+.app-team-badge > span { font-size: clamp(10px, 2.8vw, 17px); }
+
+.app-hq-topbar .app-team-badge > span { font-size: 9px; }
+.app-hq-matchup-main .app-team-badge > span { font-size: clamp(18px, 4.8vw, 24px); }
+.app-hq-team-logo {
+  width: clamp(72px, 21vw, 98px);
+  aspect-ratio: 1;
+  border-radius: 999px;
+  border: 1px solid rgba(255,255,255,.24);
+  background: radial-gradient(circle at 30% 20%, rgba(255,255,255,.23), rgba(255,255,255,.02) 60%);
+  box-shadow: inset 0 0 0 3px rgba(255,255,255,.04), 0 10px 24px rgba(0, 0, 0, .32);
+  display: grid;
+  place-items: center;
+  font-size: clamp(13px, 3.8vw, 16px);
   font-weight: 800;
+  position: relative;
+  z-index: 1;
 }
 .app-hq-team-copy { display: grid; line-height: 1.1; }
 .app-hq-team-copy strong { font-size: 12px; max-width: 108px; white-space: nowrap; text-overflow: ellipsis; overflow: hidden; }
@@ -325,22 +359,6 @@
 }
 .app-hq-team--user::before { background: radial-gradient(circle at 20% 40%, rgba(76, 130, 255, .35), transparent 70%); }
 .app-hq-team--opp::before { background: radial-gradient(circle at 80% 40%, rgba(255, 88, 88, .33), transparent 70%); }
-.app-hq-team-logo {
-  width: clamp(72px, 21vw, 98px);
-  aspect-ratio: 1;
-  border-radius: 999px;
-  border: 1px solid rgba(255,255,255,.24);
-  background: radial-gradient(circle at 30% 20%, rgba(255,255,255,.23), rgba(255,255,255,.02) 60%);
-  box-shadow: inset 0 0 0 3px rgba(255,255,255,.04), 0 10px 24px rgba(0, 0, 0, .32);
-  display: grid;
-  place-items: center;
-  font-size: clamp(13px, 3.8vw, 16px);
-  font-weight: 800;
-  position: relative;
-  z-index: 1;
-}
-.app-hq-team--user .app-hq-team-logo { background: radial-gradient(circle at 26% 20%, rgba(255,255,255,.3), rgba(34,87,183,.3) 55%, rgba(7, 17, 32, .86)); }
-.app-hq-team--opp .app-hq-team-logo { background: radial-gradient(circle at 26% 20%, rgba(255,255,255,.28), rgba(189,45,45,.32) 55%, rgba(33, 9, 15, .88)); }
 .app-hq-team strong { font-size: clamp(12px, 3.5vw, 14px); }
 .app-hq-team span { color: #95a7c2; font-size: 12px; font-weight: 700; }
 .app-hq-vs-block {
@@ -381,9 +399,12 @@
   border: 1px solid rgba(255, 224, 120, .78);
   background: linear-gradient(180deg, #ffe189, #fbc23b 56%, #ebad1f);
   color: #17120a;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
   box-shadow: 0 14px 30px rgba(245, 183, 44, .34), inset 0 1px 0 rgba(255,255,255,.4);
 }
-.app-command-advance-gold::after { content: "➜"; margin-left: 8px; font-size: 14px; }
 .app-hq-hero-footnote { margin: 0; text-align: center; color: var(--text-subtle); font-size: 11px; }
 
 .franchise-command-center .app-section-card {
@@ -392,35 +413,39 @@
 }
 .app-hq-bottom-nav {
   position: sticky;
-  bottom: 72px;
+  bottom: calc(66px + env(safe-area-inset-bottom, 0px));
   z-index: 3;
-  border: 1px solid rgba(255,255,255,.16);
+  border: 1px solid rgba(255,255,255,.12);
   border-radius: 16px;
-  background: linear-gradient(180deg, rgba(13,20,32,.97), rgba(10,16,27,.95));
-  padding: 5px;
+  background: linear-gradient(180deg, rgba(13,20,32,.92), rgba(10,16,27,.9));
+  padding: 4px 5px calc(4px + env(safe-area-inset-bottom, 0px));
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 4px;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, .35);
+  gap: 3px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, .28);
+  backdrop-filter: blur(12px);
 }
 .app-hq-bottom-nav button {
   border: 0;
   background: transparent;
   color: var(--text-subtle);
   border-radius: 12px;
-  padding: 6px 4px 5px;
+  padding: 5px 3px 4px;
   display: grid;
   justify-items: center;
-  gap: 2px;
+  gap: 1px;
   font-size: 10px;
   font-weight: 700;
   cursor: pointer;
+  transition: background .16s ease, color .16s ease, transform .16s ease;
 }
-.app-hq-bottom-nav button span { font-size: 15px; line-height: 1; color: #8ea1bf; }
+.app-hq-bottom-nav button span { font-size: 15px; line-height: 1; color: #8ea1bf; display: grid; place-items: center; }
+.app-hq-bottom-nav button svg { width: 17px; height: 17px; }
 .app-hq-bottom-nav button small { font-size: 10px; letter-spacing: .01em; color: #8ea1bf; }
 .app-hq-bottom-nav button.is-active {
   color: #f5f9ff;
-  background: linear-gradient(180deg, rgba(67, 124, 241, .34), rgba(67, 124, 241, .16));
+  background: linear-gradient(180deg, rgba(67, 124, 241, .45), rgba(67, 124, 241, .2));
+  box-shadow: inset 0 0 0 1px rgba(125, 171, 255, .35);
 }
 .app-hq-bottom-nav button.is-active span,
 .app-hq-bottom-nav button.is-active small { color: #f2f7ff; }
@@ -470,9 +495,11 @@
 .app-compact-news-card span { font-size: 11px; color: var(--text-muted); }
 
 .app-action-tile { min-height: 102px; transition: transform .16s ease, border-color .16s ease, background .16s ease; border-color: rgba(255,255,255,.15); background: linear-gradient(180deg, rgba(255,255,255,.07), rgba(255,255,255,.02)); box-shadow: inset 0 1px 0 rgba(255,255,255,.06); }
-.app-action-tile:hover, .app-action-tile:focus-visible { transform: translateY(-2px); border-color: rgba(var(--accent-rgb), .5); background: color-mix(in srgb, var(--surface-2) 75%, var(--accent) 25%); }
+.app-action-tile:hover, .app-action-tile:focus-visible { transform: translateY(-2px); border-color: rgba(var(--accent-rgb), .55); background: color-mix(in srgb, var(--surface-2) 78%, var(--accent) 22%); }
 .app-action-tile:active { transform: translateY(0); }
-.app-action-tile__icon { margin-right: 8px; width: 26px; height: 26px; border-radius: 8px; display: grid; place-items: center; background: rgba(255,255,255,.1); }
+.app-action-tile__title-row strong { display: inline-flex; align-items: center; gap: 8px; font-size: 16px; letter-spacing: -.01em; }
+.app-action-tile__subtitle { color: var(--text-muted); font-size: 12px; line-height: 1.3; }
+.app-action-tile__icon { width: 30px; height: 30px; border-radius: 10px; display: grid; place-items: center; background: linear-gradient(180deg, rgba(255,255,255,.12), rgba(255,255,255,.04)); border: 1px solid rgba(255,255,255,.14); color: #d9e7ff; }
 .app-action-tile .app-status-chip { font-size: 10px; background: rgba(255, 188, 84, .24); border-color: rgba(255, 188, 84, .5); color: #ffd28c; }
 
 .app-task-list { display: grid; gap: 8px; }
@@ -525,7 +552,7 @@
   .app-hq-topbar__team { grid-area: team; margin-left: 0; }
   .app-hq-matchup-main { grid-template-columns: 1fr auto 1fr; }
   .app-hq-hero-subcard__value { font-size: 12px; }
-  .app-hq-bottom-nav { bottom: 78px; }
+  .app-hq-bottom-nav { bottom: calc(72px + env(safe-area-inset-bottom, 0px)); }
 }
 
 @media (max-width: 420px) {


### PR DESCRIPTION
### Motivation
- Raise the Franchise HQ from a good visual approximation to a deploy-ready premium mobile screen by replacing text/emoji icons, strengthening team identity, sharpening tertiary copy, and improving bottom-nav mobile behavior.
- Fix Netlify deploy-preview fragility caused by an incorrect CI build command in repository configuration.

### Description
- Replaced placeholder/Unicode iconography (bottom nav, top utility control, hero subcards, action tiles, CTA arrow) with a lightweight, reusable SVG icon set in `HQIcon`. (`src/ui/components/HQVisuals.jsx`, `src/ui/components/FranchiseHQ.jsx`).
- Added a composable `TeamIdentityBadge` fallback (circle/shield variants, deterministic per-team color theming, abbreviation fallback, emphasis state) and wired it into the top-bar and matchup hero; CSS polish added in `screen-system.css` to match premium treatment. (`src/ui/components/HQVisuals.jsx`, `src/ui/styles/screen-system.css`, `src/ui/components/FranchiseHQ.jsx`).
- Improved hero tertiary copy to be football-specific and data-driven: standing detail now derives a concise games-behind line from `divisionMiniStandings`, and last-game copy is derived from recent results (e.g., `Won 2 straight`, `Need division response this week`, or momentum-driven phrases). (`src/ui/components/FranchiseHQ.jsx`, `src/ui/utils/franchiseCommandCenter.js` usage).
- Tightened action-card layout and icon framing for clearer hierarchy by updating `ActionTile` markup and styles. (`src/ui/components/ScreenSystem.jsx`, `src/ui/styles/screen-system.css`).
- Polished bottom nav for mobile: safe-area-aware bottom offset/padding, tighter icon/label spacing, stronger active state emphasis, and lighter shadow/backdrop styling. (`src/ui/styles/screen-system.css`).
- Addressed Netlify deploy-preview root cause by updating `netlify.toml` build command to use `npm run build` to match the repo toolchain/lockfile. (`netlify.toml`).

### Testing
- Built a production bundle locally with `npm run build`, which completed successfully and produced `dist/` artifacts.
- Ran targeted unit tests with `vitest` using `npm run test:unit -- tests/unit/navigation_copy.test.js`, and the test file passed (2 tests).

Note: I updated only presentation and config; no app-shell or data-model restructuring was performed, and I did not run an external Netlify preview deployment from this environment — the Netlify build command mismatch was corrected and local `npm run build` verifies the change locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5721c470832d9a37b387d9a4f1e7)