### PR TITLE
Polish Franchise HQ & weekly-flow screens — icons, badges, and Netlify build truth

### DIFF
--- a/src/ui/components/GamePlanScreen.jsx
+++ b/src/ui/components/GamePlanScreen.jsx
@@ -20,6 +20,7 @@ import { OFFENSIVE_PLANS, DEFENSIVE_PLANS } from "../../core/strategy.js";
 import { buildTeamIntelligence } from "../utils/teamIntelligence.js";
 import { deriveTeamCoachingIdentity } from "../utils/coachingIdentity.js";
 import { markWeeklyPrepStep } from '../utils/weeklyPrep.js';
+import { HQIcon, TeamIdentityBadge } from './HQVisuals.jsx';
 
 // ── Local-storage key for game plan sliders ───────────────────────────────────
 const GP_STORAGE_KEY = "footballgm_gameplan_v1";
@@ -57,10 +58,10 @@ function schemeAccent(id = "") {
 // ── Sub-components ────────────────────────────────────────────────────────────
 
 /** Section title row */
-function SectionTitle({ label, emoji, color = "var(--text-muted)" }) {
+function SectionTitle({ label, icon = null, color = "var(--text-muted)" }) {
   return (
     <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
-      {emoji && <span style={{ fontSize: "1.1rem" }}>{emoji}</span>}
+      {icon ? <span aria-hidden>{icon}</span> : null}
       <h3 style={{
         margin: 0, fontSize: "0.72rem", fontWeight: 800,
         color, textTransform: "uppercase", letterSpacing: "1.2px",
@@ -72,7 +73,7 @@ function SectionTitle({ label, emoji, color = "var(--text-muted)" }) {
 }
 
 /** Scheme selector card — shows all options as clickable tiles */
-function SchemeSelector({ title, emoji, schemes, selected, onChange }) {
+function SchemeSelector({ title, icon, schemes, selected, onChange }) {
   const arr = Object.values(schemes);
   return (
     <div style={{
@@ -82,7 +83,7 @@ function SchemeSelector({ title, emoji, schemes, selected, onChange }) {
       padding: "16px",
       marginBottom: 14,
     }}>
-      <SectionTitle label={title} emoji={emoji} />
+      <SectionTitle label={title} icon={icon} />
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         {arr.map(scheme => {
           const isActive = scheme.id === selected;
@@ -419,11 +420,23 @@ export default function GamePlanScreen({ league, actions }) {
           Save Game Plan
         </button>
       </div>
+      {nextGame ? (
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, marginBottom: 12, border: '1px solid var(--hairline)', borderRadius: 10, padding: 10, background: 'rgba(255,255,255,0.02)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <TeamIdentityBadge team={userTeam} size={32} emphasize />
+            <span style={{ fontSize: '0.75rem', fontWeight: 700 }}>Matchup Plan</span>
+          </div>
+          <span style={{ fontSize: '0.7rem', color: 'var(--text-muted)' }}>{nextGame.isHome ? 'vs' : '@'} {nextGame.opp?.name ?? 'Opponent'}</span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <TeamIdentityBadge team={nextGame.opp} size={32} />
+          </div>
+        </div>
+      ) : null}
 
       {/* ── Offensive Scheme ── */}
       <SchemeSelector
         title="Offensive Scheme"
-        emoji="⚔️"
+        icon={<HQIcon name="target" size={14} />}
         schemes={OFFENSIVE_SCHEMES}
         selected={offScheme}
         onChange={setOffScheme}
@@ -432,7 +445,7 @@ export default function GamePlanScreen({ league, actions }) {
       {/* ── Defensive Scheme ── */}
       <SchemeSelector
         title="Defensive Scheme"
-        emoji="🛡️"
+        icon={<HQIcon name="shield" size={14} />}
         schemes={DEFENSIVE_SCHEMES}
         selected={defScheme}
         onChange={setDefScheme}
@@ -446,7 +459,7 @@ export default function GamePlanScreen({ league, actions }) {
         padding: "16px 18px",
         marginBottom: 14,
       }}>
-        <SectionTitle label="Play-Calling" emoji="🎯" />
+        <SectionTitle label="Play-Calling" icon={<HQIcon name="clipboard" size={14} />} />
 
         <PlanSlider
           label="Run / Pass Balance"
@@ -490,7 +503,7 @@ export default function GamePlanScreen({ league, actions }) {
         padding: "16px 18px",
         marginBottom: 14,
       }}>
-        <SectionTitle label="Special Teams" emoji="🦵" />
+        <SectionTitle label="Special Teams" icon={<HQIcon name="lineup" size={14} />} />
 
         <STOption
           label="Kick Return Strategy"

--- a/src/ui/components/HQVisuals.jsx
+++ b/src/ui/components/HQVisuals.jsx
@@ -38,6 +38,14 @@ export function HQIcon({ name, size = 18 }) {
       return <svg {...common}><path {...baseIconProps} d="M5 17.75 10 12l3.25 3.25 5.75-7" /><path {...baseIconProps} d="M18 8.25h1.75V10" /></svg>;
     case 'arrowRight':
       return <svg {...common}><path {...baseIconProps} d="M5 12h14m-5-5 5 5-5 5" /></svg>;
+    case 'target':
+      return <svg {...common}><circle {...baseIconProps} cx="12" cy="12" r="7.25" /><circle {...baseIconProps} cx="12" cy="12" r="3.25" /><path {...baseIconProps} d="M12 4v2.2M20 12h-2.2M12 20v-2.2M4 12h2.2" /></svg>;
+    case 'shield':
+      return <svg {...common}><path {...baseIconProps} d="M12 3.75 4.75 6.9v6.1c0 4.05 3.1 7.65 7.25 8.65 4.15-1 7.25-4.6 7.25-8.65V6.9z" /></svg>;
+    case 'alert':
+      return <svg {...common}><path {...baseIconProps} d="m12 4.5 8 14h-16z" /><path {...baseIconProps} d="M12 9v4.75M12 16.8h.01" /></svg>;
+    case 'clipboard':
+      return <svg {...common}><rect {...baseIconProps} x="6.25" y="5.25" width="11.5" height="14.5" rx="2" /><path {...baseIconProps} d="M9.25 5.25h5.5v2.1h-5.5zM9.5 11h5M9.5 14h5" /></svg>;
     default:
       return null;
   }

--- a/src/ui/components/NewsFeed.jsx
+++ b/src/ui/components/NewsFeed.jsx
@@ -12,6 +12,7 @@ import {
   SectionHeader,
   StatusChip,
 } from './ScreenSystem.jsx';
+import { HQIcon } from './HQVisuals.jsx';
 
 const tickerColor = {
   high: '#f59e0b',
@@ -98,6 +99,13 @@ export default function NewsFeed({ league, mode = 'full', segment = 'all', onTea
   const pressure = useMemo(() => deriveFranchisePressure(league, { intel: teamIntel }), [league, teamIntel]);
 
   const latestFive = useMemo(() => desk.merged.slice(0, 5), [desk.merged]);
+  const teamInjuryItems = useMemo(() => {
+    const teamRoster = Array.isArray(userTeam?.roster) ? userTeam.roster : [];
+    return teamRoster
+      .filter((player) => Number(player?.injury?.gamesRemaining ?? player?.injuryWeeksRemaining ?? 0) > 0)
+      .sort((a, b) => Number(b?.ovr ?? 0) - Number(a?.ovr ?? 0))
+      .slice(0, 5);
+  }, [userTeam?.roster]);
 
   useEffect(() => {
     if (mode !== 'ticker' || latestFive.length <= 1) return undefined;
@@ -125,13 +133,13 @@ export default function NewsFeed({ league, mode = 'full', segment = 'all', onTea
   return (
     <div className="app-screen-stack">
       <HeroCard
-        eyebrow="News Desk"
-        title="Desk View"
-        subtitle="Curated league intelligence with team-priority context and actionable links."
+        eyebrow="Weekly Intelligence"
+        title="News & Injuries"
+        subtitle="What matters this week before kickoff."
       >
         {pressure ? (
           <CompactInsightCard
-            title="Local Pressure Briefing"
+            title="Team pressure briefing"
             subtitle={`Fans ${pressure.fans.state} · Media ${pressure.media.state}`}
             tone="warning"
           />
@@ -171,6 +179,23 @@ export default function NewsFeed({ league, mode = 'full', segment = 'all', onTea
         onPlayerSelect={onPlayerSelect}
       />
 
+      <SectionCard title="Injury board" subtitle="Prioritized player availability risks for this week." variant="compact">
+        <div className="app-screen-stack">
+          {teamInjuryItems.length ? teamInjuryItems.map((player) => (
+            <CompactListRow
+              key={player.id}
+              title={`${player.name} · ${player.pos}`}
+              subtitle={`${player.injury?.name ?? 'Injury'} · ${player.injury?.gamesRemaining ?? player.injuryWeeksRemaining} week(s) remaining`}
+              meta={<StatusChip label="Team impact" tone="warning" />}
+            >
+              <button type="button" className="btn btn-sm" onClick={() => onPlayerSelect?.(player.id)}>Open</button>
+            </CompactListRow>
+          )) : (
+            <CompactInsightCard title="No active injuries" subtitle="Your current injury report is clear." tone="ok" />
+          )}
+        </div>
+      </SectionCard>
+
       {filter === 'all' ? (
         <div className="app-news-aux-grid">
           <NewsSection title="Team Desk" subtitle="Your-team relevant stories" stories={desk.teamStories.slice(0, 3)} onTeamSelect={onTeamSelect} onOpenBoxScore={onOpenBoxScore} onPlayerSelect={onPlayerSelect} />
@@ -180,7 +205,7 @@ export default function NewsFeed({ league, mode = 'full', segment = 'all', onTea
 
       <SectionCard variant="compact">
         <div className="app-news-cta-bar">
-          <div className="app-news-cta-copy">Use filters to keep this desk focused by context.</div>
+          <div className="app-news-cta-copy"><HQIcon name="news" size={14} /> Use filters to keep this desk focused by context.</div>
           <CtaRow
             actions={[
               { label: 'Team', compact: true, onClick: () => onNavigate?.('Team') },

--- a/src/ui/components/TeamHub.jsx
+++ b/src/ui/components/TeamHub.jsx
@@ -7,6 +7,7 @@ import { SectionCard, CtaRow, StatusChip, CompactListRow, HeroCard, StatStrip, S
 import { derivePlayerContractFinancials } from '../utils/contractFormatting.js';
 import { deriveTeamCapSnapshot, formatMoneyM } from '../utils/numberFormatting.js';
 import { summarizeRosterDevelopment } from '../utils/playerDevelopmentSignals.js';
+import { TeamIdentityBadge } from './HQVisuals.jsx';
 
 const TEAM_SECTIONS = ['Overview', 'Roster / Depth', 'Contracts', 'Development', 'Injuries'];
 const CRITICAL_POSITION_MIN = { QB: 2, RB: 3, WR: 5, TE: 3, OL: 8, DL: 8, LB: 6, CB: 5, S: 4, K: 1, P: 1 };
@@ -89,15 +90,26 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
     if (roster.length > 53 && league?.phase === 'preseason') flags.push({ tone: 'danger', label: `Roster cutdown required (${roster.length}/53)`, target: 'Roster / Depth' });
     return flags.slice(0, 3);
   }, [capSnapshot.capRoom, expiringPlayers.length, injuredPlayers.length, pressureGroups.length, roster.length, league?.phase]);
+  const blockingIssues = useMemo(() => pressureGroups.filter((group) => group.severity >= 2), [pressureGroups]);
+  const weeklyLineupFrame = blockingIssues.length
+    ? `${blockingIssues.length} lineup blockers before kickoff`
+    : 'No critical lineup blockers detected';
 
   return (
     <div className="app-screen-stack">
       <HeroCard
         eyebrow={`${league?.year ?? 'Season'} · Week ${league?.week ?? '—'} · ${league?.phase ?? 'regular'}`}
-        title="Team Command Center"
+        title="Lineup Check Before Kickoff"
         subtitle={`${team?.name ?? 'Team'} · ${team?.wins ?? 0}-${team?.losses ?? 0}${team?.ties ? `-${team.ties}` : ''}`}
         rightMeta={<StatusChip label={`${injuredPlayers.length} injuries`} tone={injuredPlayers.length ? 'warning' : 'ok'} />}
       >
+        <div className="team-hub-lineup-frame">
+          <TeamIdentityBadge team={team} size={44} emphasize />
+          <div>
+            <strong>{weeklyLineupFrame}</strong>
+            <small>{upcomingGame ? `Next: ${makeMatchupLabel(upcomingGame, team)}` : 'No scheduled matchup found.'}</small>
+          </div>
+        </div>
         <div className="app-hero-summary-grid">
           <div><span>Last game</span><strong>{latestGame ? makeMatchupLabel(latestGame, team) : 'No completed game yet'}</strong></div>
           <div><span>Next game</span><strong>{upcomingGame ? makeMatchupLabel(upcomingGame, team) : 'No upcoming matchup'}</strong></div>
@@ -155,11 +167,32 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
 
       {subtab === 'Roster / Depth' && (
         <div className="app-screen-stack">
-          <SectionCard title="Roster and depth" subtitle="Set roles and keep the lineup game-ready." variant="compact">
+          <SectionCard title="Weekly lineup decisions" subtitle="Confirm starters, depth insurance, and injury contingencies." variant="compact">
+            {blockingIssues.length > 0 ? (
+              <div className="team-hub-alert-list">
+                {blockingIssues.map((issue) => (
+                  <div key={issue.pos} className="team-hub-alert">
+                    <div>
+                      <strong>{issue.pos} pressure</strong>
+                      <span>{issue.healthy}/{issue.total} healthy · {issue.starterGap ? 'Starter out' : 'Depth thin'}</span>
+                    </div>
+                    <StatusChip label={issue.starterGap ? 'Starter missing' : 'Thin depth'} tone="warning" />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="team-hub-alert team-hub-alert--ok">
+                <div>
+                  <strong>Lineup passes readiness check</strong>
+                  <span>No starter gaps and critical positions are staffed.</span>
+                </div>
+                <StatusChip label="Ready" tone="ok" />
+              </div>
+            )}
             <CtaRow actions={[
               { label: 'Roster table', compact: true, onClick: () => setRosterMode('roster') },
               { label: 'Depth chart', compact: true, onClick: () => setRosterMode('depth') },
-              { label: 'Injured filter', compact: true, onClick: () => setSubtab('Injuries') },
+              { label: 'Open injuries', compact: true, onClick: () => setSubtab('Injuries') },
             ]} />
           </SectionCard>
           <Roster

--- a/src/ui/components/WeeklyPrepScreen.jsx
+++ b/src/ui/components/WeeklyPrepScreen.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { EmptyState, SectionCard } from './common/UiPrimitives.jsx';
 import { markWeeklyPrepStep, deriveWeeklyPrepState } from '../utils/weeklyPrep.js';
+import { HQIcon, TeamIdentityBadge } from './HQVisuals.jsx';
 
 function TonePill({ tone = 'info', label }) {
   const palette = {
@@ -35,12 +36,23 @@ export default function WeeklyPrepScreen({ league, onNavigate }) {
   };
 
   return (
-    <div className="app-screen-stack" style={{ display: 'grid', gap: 'var(--space-2)' }}>
+    <div className="app-screen-stack weekly-prep-screen" style={{ display: 'grid', gap: 'var(--space-2)' }}>
       <SectionCard
-        title={`Week ${prep.nextGame.week} Prep · ${prep.nextGame.isHome ? 'vs' : '@'} ${prep.opponent.abbr ?? prep.opponent.name}`}
+        title={`Scout & Prep · Week ${prep.nextGame.week}`}
         subtitle={`Opponent ${prep.opponentSnapshot.record} · ${prep.opponentSnapshot.homeAway} game`}
         actions={<TonePill tone={prep.prepSummary?.severity === 'major_risk' ? 'danger' : prep.remaining === 0 ? 'success' : 'warning'} label={prep.prepSummary?.status ?? prep.readinessLabel} />}
       >
+        <div className="weekly-prep-opponent-head">
+          <div className="weekly-prep-team">
+            <TeamIdentityBadge team={prep.team} size={36} emphasize />
+            <strong>{prep.team?.abbr ?? 'YOU'}</strong>
+          </div>
+          <span>{prep.nextGame.isHome ? 'vs' : '@'}</span>
+          <div className="weekly-prep-team">
+            <TeamIdentityBadge team={prep.opponent} size={36} />
+            <strong>{prep.opponent?.abbr ?? prep.opponent?.name ?? 'OPP'}</strong>
+          </div>
+        </div>
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: 8 }}>
           <div style={{ fontSize: 'var(--text-xs)' }}><strong>You:</strong> OVR {prep.teamSnapshot.overall} · OFF {prep.teamSnapshot.offense} · DEF {prep.teamSnapshot.defense}</div>
           <div style={{ fontSize: 'var(--text-xs)' }}><strong>Opp:</strong> OVR {prep.opponentSnapshot.overall} · OFF {prep.opponentSnapshot.offense} · DEF {prep.opponentSnapshot.defense}</div>
@@ -52,19 +64,19 @@ export default function WeeklyPrepScreen({ league, onNavigate }) {
         <SectionCard title="Opponent scout" subtitle="Football-specific matchup context.">
           <div style={{ display: 'grid', gap: 8 }}>
             <div>
-              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}>Strengths</div>
+              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}><HQIcon name="shield" size={12} /> Strengths</div>
               <ul style={{ margin: '4px 0 0', paddingLeft: 16 }}>
                 {(prep.opponentStrengths.length ? prep.opponentStrengths : ['No clear dominant opponent edge identified yet.']).map((item) => <li key={item} style={{ fontSize: 'var(--text-sm)' }}>{item}</li>)}
               </ul>
             </div>
             <div>
-              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}>Exploitable weaknesses</div>
+              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}><HQIcon name="target" size={12} /> Exploitable weaknesses</div>
               <ul style={{ margin: '4px 0 0', paddingLeft: 16 }}>
                 {(prep.opponentWeaknesses.length ? prep.opponentWeaknesses : ['No obvious weakness — game script and execution will decide this one.']).map((item) => <li key={item} style={{ fontSize: 'var(--text-sm)' }}>{item}</li>)}
               </ul>
             </div>
             <div>
-              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}>Pressure points</div>
+              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}><HQIcon name="alert" size={12} /> Pressure points</div>
               <ul style={{ margin: '4px 0 0', paddingLeft: 16 }}>
                 {(prep.pressurePoints.length ? prep.pressurePoints : ['No major pressure point flagged.']).map((item) => <li key={item} style={{ fontSize: 'var(--text-sm)' }}>{item}</li>)}
               </ul>

--- a/src/ui/components/__tests__/weeklyLoopCohesion.test.jsx
+++ b/src/ui/components/__tests__/weeklyLoopCohesion.test.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import TeamHub from '../TeamHub.jsx';
+import WeeklyPrepScreen from '../WeeklyPrepScreen.jsx';
+import GamePlanScreen from '../GamePlanScreen.jsx';
+import NewsFeed from '../NewsFeed.jsx';
+
+const league = {
+  year: 2026,
+  week: 6,
+  seasonId: 's6',
+  phase: 'regular',
+  userTeamId: 1,
+  teams: [
+    {
+      id: 1,
+      city: 'Chicago',
+      name: 'Bears',
+      abbr: 'CHI',
+      wins: 3,
+      losses: 2,
+      ties: 0,
+      offenseRating: 82,
+      defenseRating: 80,
+      ovr: 81,
+      roster: [
+        { id: 11, name: 'Starter QB', pos: 'QB', ovr: 84, contract: { yearsRemaining: 2 }, depthChart: { order: 1, rowKey: 'QB' } },
+        { id: 12, name: 'WR1', pos: 'WR', ovr: 82, contract: { yearsRemaining: 1 }, depthChart: { order: 1, rowKey: 'WR' }, injury: { name: 'Hamstring', gamesRemaining: 2 } },
+      ],
+      recentResults: ['W', 'L', 'W'],
+      strategies: { offSchemeId: 'WEST_COAST', defSchemeId: 'COVER_2' },
+    },
+    {
+      id: 2,
+      city: 'Detroit',
+      name: 'Lions',
+      abbr: 'DET',
+      wins: 4,
+      losses: 1,
+      ties: 0,
+      offenseRating: 85,
+      defenseRating: 83,
+      ovr: 84,
+      roster: [],
+    },
+  ],
+  schedule: {
+    weeks: [
+      { week: 5, games: [{ id: 'g5', home: 2, away: 1, homeScore: 24, awayScore: 27, played: true }] },
+      { week: 6, games: [{ id: 'g6', home: 1, away: 2, played: false }] },
+    ],
+  },
+  newsItems: [{ id: 'n1', headline: 'Bears adjust red zone package.', body: 'Coaches looking for situational edge.', priority: 'medium', week: 6, phase: 'regular', teamId: 1 }],
+  incomingTradeOffers: [],
+};
+
+const actions = { send: vi.fn() };
+
+describe('weekly loop cohesion surfaces', () => {
+  it('renders TeamHub lineup framing safely', () => {
+    const html = renderToString(<TeamHub league={league} actions={actions} onNavigate={() => {}} onPlayerSelect={() => {}} />);
+    expect(html).toContain('Lineup Check Before Kickoff');
+    expect(html).toContain('Roster / Depth');
+  });
+
+  it('renders WeeklyPrepScreen matchup framing safely', () => {
+    const html = renderToString(<WeeklyPrepScreen league={league} onNavigate={() => {}} />);
+    expect(html).toContain('Scout &amp; Prep');
+    expect(html).toContain('Lineup readiness');
+  });
+
+  it('renders GamePlanScreen strategy header safely', () => {
+    const html = renderToString(<GamePlanScreen league={league} actions={actions} />);
+    expect(html).toContain('Game Plan');
+    expect(html).toContain('Matchup Plan');
+  });
+
+  it('renders NewsFeed injury board safely', () => {
+    const html = renderToString(<NewsFeed league={league} onNavigate={() => {}} onPlayerSelect={() => {}} />);
+    expect(html).toContain('News &amp; Injuries');
+    expect(html).toContain('Injury board');
+  });
+});

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -1176,6 +1176,54 @@ label {
 .attr-fill { height: 100%; border-radius: var(--radius-pill); transition: width var(--duration-slow) var(--ease-out); }
 .attr-value { font-size: var(--text-xs); font-weight: 700; width: 24px; text-align: right; color: var(--text); }
 
+.team-hub-lineup-frame {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+  background: rgba(255,255,255,0.02);
+  margin-bottom: 8px;
+}
+.team-hub-lineup-frame strong { display: block; font-size: var(--text-sm); }
+.team-hub-lineup-frame small { color: var(--text-muted); font-size: var(--text-xs); }
+.team-hub-alert-list { display: grid; gap: 8px; margin-bottom: 10px; }
+.team-hub-alert {
+  border: 1px solid rgba(245,158,11,0.35);
+  border-radius: var(--radius-md);
+  padding: 8px 10px;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+  background: rgba(245,158,11,0.08);
+}
+.team-hub-alert strong { display: block; font-size: var(--text-sm); }
+.team-hub-alert span { display: block; font-size: var(--text-xs); color: var(--text-muted); margin-top: 2px; }
+.team-hub-alert--ok {
+  border-color: rgba(52,199,89,0.35);
+  background: rgba(52,199,89,0.08);
+  margin-bottom: 10px;
+}
+
+.weekly-prep-opponent-head {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.weekly-prep-team {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-pill);
+}
+.weekly-prep-team strong { font-size: var(--text-xs); letter-spacing: .04em; }
+
 .profile-tab-row, .roster-tab-row { display: flex; gap: var(--space-2); overflow-x: auto; scrollbar-width: none; padding-bottom: var(--space-1); -webkit-overflow-scrolling: touch; }
 .profile-tab-row::-webkit-scrollbar, .roster-tab-row::-webkit-scrollbar { display: none; }
 .profile-tab-row .standings-tab.active, .roster-tab-row .standings-tab.active { color: var(--accent); font-weight: 700; border-bottom: 2px solid var(--accent); }


### PR DESCRIPTION
### Motivation
- Finish the premium polish pass on Franchise HQ and its downstream weekly-flow surfaces so the mobile HQ feels ship-ready rather than a web dashboard sketch. 
- Replace text/emoji placeholder iconography with a single lightweight SVG glyph set for coherent, compact mobile native icons. 
- Strengthen team identity presentation with a reusable badge/fallback treatment and sharpen tertiary copy so weekly content reads as football-specific, actionable intelligence. 
- Verify and ground the Netlify/build toolchain truth so preview deploys are not failing due to command churn.

### Description
- Added new SVG glyphs (`target`, `shield`, `alert`, `clipboard`) to the shared HQ icon system and reused the `HQIcon` glyphs across `GamePlanScreen`, `WeeklyPrepScreen`, and `NewsFeed` to replace emoji/text-style markers. 
- Improved team identity treatment by reusing `TeamIdentityBadge` in `TeamHub`, `GamePlanScreen`, and `WeeklyPrepScreen` and added CSS to present a stronger lineup/hero badge and readiness framing (`team-hub-lineup-frame`, `weekly-prep-opponent-head`). 
- Tightened hero and tertiary copy and framing so the Team Hub hero now reads `Lineup Check Before Kickoff`, lineup blockers are surfaced from derived `pressureGroups`, Weekly Prep uses a `Scout & Prep` header with matchup context, and News shows a prioritized `Injury board` derived from roster injury data. 
- Polished Game Plan entry by replacing emoji section labels with SVG icons and adding a compact matchup card showing both teams via `TeamIdentityBadge`. 
- Added focused render-safety/cohesion tests (`src/ui/components/__tests__/weeklyLoopCohesion.test.jsx`) covering Team Hub, Weekly Prep, Game Plan, and News & Injuries entry surfaces. 
- Did not change app shell or routing; all edits keep existing selectors/view models and reuse shared components; `netlify.toml` was inspected and left as the grounded source of truth (no speculative churn applied). 

### Testing
- Ran unit tests: `vitest` targeted run for updated and related tests passed: 2 test files, 6 tests total, all passing. 
- Verified production build locally using `npm run build` (equivalent to Netlify `npm run build`), and the Vite build completed successfully. 
- Netlify/build truth: repository contains `package-lock.json` and `package.json` scripts use `npm`, and `netlify.toml` already points to `command = "npm run build"`, so the chosen build path is `npm run build`; local build parity is confirmed but actual Netlify PR-preview status must be validated by the CI/Netlify run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5a55f0ac832da19c3572f42662c9)