### PR TITLE
Stabilize Franchise HQ and add Netlify build-parity check

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "test": "playwright test",
     "test:unit": "vitest run",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "check:netlify-parity": "bash scripts/netlify-parity-check.sh"
   },
   "dependencies": {
     "@vitejs/plugin-react": "^5.1.4",

--- a/scripts/netlify-parity-check.sh
+++ b/scripts/netlify-parity-check.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[netlify-parity] Node: $(node -v)"
+echo "[netlify-parity] npm: $(npm -v)"
+
+echo "[netlify-parity] Cleaning install artifacts"
+rm -rf node_modules dist
+
+echo "[netlify-parity] Installing dependencies from package-lock.json"
+npm ci
+
+echo "[netlify-parity] Building production bundle"
+npm run build
+
+if [[ ! -f "dist/index.html" ]]; then
+  echo "[netlify-parity] ERROR: dist/index.html missing after build"
+  exit 1
+fi
+
+echo "[netlify-parity] OK: dist/index.html present"

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -24,6 +24,31 @@ function formatRecordInline(record) {
   return record;
 }
 
+function getLastGameDisplay(lastGame, userTeamId) {
+  if (!lastGame) {
+    return {
+      heroLine: 'No completed game yet',
+      overviewLine: 'No completed game yet',
+      oppAbbr: 'TBD',
+    };
+  }
+  const userId = Number(userTeamId);
+  const homeId = Number(lastGame?.homeId ?? lastGame?.home?.id);
+  const awayId = Number(lastGame?.awayId ?? lastGame?.away?.id);
+  const userIsHome = homeId === userId;
+  const userIsAway = awayId === userId;
+  const userScore = userIsHome ? safeNum(lastGame?.score?.home) : safeNum(lastGame?.score?.away);
+  const oppScore = userIsHome ? safeNum(lastGame?.score?.away) : safeNum(lastGame?.score?.home);
+  const oppAbbr = userIsHome ? (lastGame?.awayAbbr ?? 'TBD') : (lastGame?.homeAbbr ?? 'TBD');
+  const location = userIsHome ? 'vs' : userIsAway ? '@' : 'vs';
+  const resultLabel = lastGame?.userWon ? 'W' : 'L';
+  return {
+    heroLine: `${resultLabel} · ${userScore}-${oppScore} ${location} ${oppAbbr}`,
+    overviewLine: `${resultLabel} ${userScore}-${oppScore} ${location} ${oppAbbr}`,
+    oppAbbr,
+  };
+}
+
 export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, simulating }) {
   const [lineupToast, setLineupToast] = useState(null);
   const command = useMemo(() => selectFranchiseHQViewModel(league), [league]);
@@ -75,9 +100,6 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
   const hasTwoWins = lastTwo.length === 2 && lastTwo.every((result) => result === 'W');
   const hasTwoLosses = lastTwo.length === 2 && lastTwo.every((result) => result === 'L');
   const lastGameStory = hasTwoWins ? 'Won 2 straight heading into kickoff' : hasTwoLosses ? 'Need division response this week' : (lastGame?.userWon ? 'Carrying momentum from last win' : 'Rebound spot after last result');
-  const lastGameOpponentAbbr = lastGame
-    ? (lastGame?.awayAbbr === userTeam?.abbr ? lastGame?.homeAbbr : lastGame?.awayAbbr)
-    : null;
   const capSpace = command.teamOverview?.find((item) => item.label === 'Cap Space')?.value ?? '—';
   const operationHeading = `WEEK ${safeNum(league?.week, 1)} ${homeAwayVerb} ${opponent?.abbr ?? command.nextOpponent ?? 'TBD'}`.toUpperCase();
   const nextOppSummary = [
@@ -85,7 +107,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
     formatRecordInline(command.nextOpponentRecord),
     hasTwoWins ? 'Win streak 2' : hasTwoLosses ? 'Loss streak 2' : 'Momentum balanced',
   ].filter(Boolean).join(' • ');
-  const nextOpponents = (league?.schedule?.weeks ?? [])
+  const nextOpponents = useMemo(() => (league?.schedule?.weeks ?? [])
     .filter((week) => safeNum(week?.week, 0) >= safeNum(league?.week, 1))
     .flatMap((week) => (week?.games ?? []).map((game) => ({ ...game, week: week.week })))
     .filter((game) => {
@@ -102,7 +124,8 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
       const oppId = isHome ? awayId : homeId;
       const oppTeam = (league?.teams ?? []).find((t) => Number(t?.id) === Number(oppId));
       return `W${safeNum(game?.week, 0)} ${isHome ? 'vs' : '@'} ${oppTeam?.abbr ?? 'TBD'}`;
-    });
+    }), [league]);
+  const lastGameDisplay = useMemo(() => getLastGameDisplay(lastGame, league?.userTeamId), [lastGame, league?.userTeamId]);
 
   return (
     <div className="app-screen-stack franchise-hq franchise-command-center">
@@ -137,7 +160,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
               <HQIcon name="lastGame" size={14} />
               <strong>Last Game</strong>
             </div>
-            <p className="app-hq-hero-subcard__value">{lastGame ? `${lastGame.userWon ? 'W' : 'L'} · ${lastGame.awayAbbr} ${safeNum(lastGame?.score?.away)} @ ${lastGame.homeAbbr} ${safeNum(lastGame?.score?.home)}` : 'No completed game yet'}</p>
+            <p className="app-hq-hero-subcard__value">{lastGameDisplay.heroLine}</p>
             <small>{lastGame ? lastGameStory : 'Play this week to establish momentum.'}</small>
           </div>
           <div className="app-hq-hero-subcard">
@@ -155,7 +178,6 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
 
       <section className="app-section-stack" aria-label="This Week Action Center">
         <div className="app-section-heading">This Week</div>
-        <span style={{ display: 'none' }}>News &amp; Injuries</span>
         <div className="app-action-grid-2x2">
           {actionTiles.map((action) => (
             <ActionTile key={action.title} icon={action.icon} title={action.title} subtitle={action.subtitle} badge={action.badge ? <StatusChip label={action.badge} tone="warning" /> : null} onClick={action.onClick} tone="info" />
@@ -170,7 +192,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
 
       <SectionCard title="Team Overview" subtitle="Last result, standing, and upcoming slate." variant="compact">
         <div className="app-hq-team-overview">
-          <div><span>Last Game</span><strong>{lastGame ? `${lastGame.userWon ? 'W' : 'L'} ${safeNum(lastGame?.score?.away)}-${safeNum(lastGame?.score?.home)} vs ${lastGameOpponentAbbr ?? 'TBD'}` : 'No completed game yet'}</strong></div>
+          <div><span>Last Game</span><strong>{lastGameDisplay.overviewLine}</strong></div>
           <div><span>Standing</span><strong>{command.standingSummary}</strong></div>
           <div><span>Next 3</span><div className="app-hq-opponent-chips">{nextOpponents.map((chip) => <em key={chip}>{chip}</em>)}</div></div>
         </div>

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -75,13 +75,13 @@ describe('FranchiseHQ', () => {
     expect(html).toContain('Set Lineup');
     expect(html).toContain('Game Plan');
     expect(html).toContain('Scout Opponent');
-    expect(html).toContain('News &amp; Injuries');
     expect(html).toContain('Weekly Agenda');
     expect(html).toContain('This Week');
     expect(html).toContain('Team Overview');
     expect(html).toContain('League News');
     expect(html).toContain('Next Opponent');
     expect(html).toContain('Home');
+    expect(html).toContain('News');
     expect(html).toContain('More');
   });
 

--- a/tests/e2e/franchise_hq_mobile_smoke.spec.js
+++ b/tests/e2e/franchise_hq_mobile_smoke.spec.js
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+import { launchFranchise } from './helpers/franchise.js';
+
+test.use({ viewport: { width: 390, height: 844 } });
+
+test('mobile HQ shows weekly command center essentials', async ({ page }) => {
+  await launchFranchise(page);
+
+  await expect(page.getByText(/Week\s+\d+/i).first()).toBeVisible({ timeout: 60000 });
+  await expect(page.getByText('Next Opponent').first()).toBeVisible();
+  await expect(page.getByRole('button', { name: /Advance Week/i })).toBeVisible();
+
+  await expect(page.getByText('Game Plan').first()).toBeVisible();
+  await expect(page.getByText('Set Lineup').first()).toBeVisible();
+  await expect(page.getByText('Training').first()).toBeVisible();
+  await expect(page.getByText('Scout Opponent').first()).toBeVisible();
+
+  const advance = page.getByRole('button', { name: /Advance Week/i });
+  await expect(advance).toBeEnabled();
+  await expect(page.getByText('Something went wrong')).toHaveCount(0);
+});


### PR DESCRIPTION
### Motivation
- Netlify preview deploys for recent HQ polish PRs (#1290–#1294) were failing and the exact upstream log was not accessible from this environment, so a small local parity check was needed before changing UI code. 
- Remove hidden DOM/test appeasement code and fix visible last-game / opponent copy to reflect the user-team perspective while preserving the premium mobile HQ hierarchy. 

### Description
- Added a compact Netlify parity script `scripts/netlify-parity-check.sh` and `npm` script `check:netlify-parity` that performs a clean `npm ci`, `npm run build`, and asserts `dist/index.html` exists to mirror Netlify preview steps. 
- Reworked `FranchiseHQ.jsx` to remove the hidden `display:none` “News & Injuries” DOM hack, moved schedule-derived `Next 3` opponents calculation into `useMemo`, and introduced `getLastGameDisplay` (memoized) to format last-game copy from the user-team perspective (W/L, user score first, clear `vs/@` context) used in both hero subcard and Team Overview. 
- Updated unit test expectations in `src/ui/components/__tests__/FranchiseHQ.test.jsx` to assert visible UI labels (replaced hidden label assertion with `News`) and added a lightweight Playwright mobile smoke test `tests/e2e/franchise_hq_mobile_smoke.spec.js` that checks HQ essentials (Week, Next Opponent, Advance Week, action tiles). 

### Testing
- Ran `npm ci` which completed successfully. 
- Ran `npm run build` which produced `dist/index.html` successfully. 
- Ran targeted unit tests with `npm run test:unit -- src/ui/components/__tests__/FranchiseHQ.test.jsx src/ui/components/__tests__/freshSaveScreens.test.jsx src/ui/components/__tests__/weeklyLoopCohesion.test.jsx` and all 3 files passed (12 tests). 
- Ran `npm run check:netlify-parity` which executed the parity script end-to-end and verified `dist/index.html` is present. 
- Added Playwright mobile smoke `npx playwright test tests/e2e/franchise_hq_mobile_smoke.spec.js`, which fails in this environment due to missing Playwright browser binaries and requests `npx playwright install`; the test itself is ready for CI once browsers are provisioned. 

Notes / remaining risks: Netlify deploy API returned HTTP 403 in this environment so the exact Netlify-hosted failure message could not be retrieved here and requires a Netlify UI/API access check by a user with project permissions, and the Playwright smoke test requires `npx playwright install` in CI to run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba0231578832d852f2370b5009f17)