### PR TITLE
Enable Netlify build-parity in CI; harden HQ scoreboard, accessibility, responsiveness, and tests

### DIFF
--- a/.github/workflows/netlify-parity.yml
+++ b/.github/workflows/netlify-parity.yml
@@ -1,0 +1,24 @@
+name: Netlify Build Parity
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node 22 (Netlify parity)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Verify netlify parity build
+        run: npm run check:netlify-parity
+
+      - name: Mirror Netlify with netlify-cli
+        run: npm run check:netlify-cli-build

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.13",
         "@tailwindcss/vite": "^4.2.1",
-        "@vitejs/plugin-react": "^5.1.4",
         "chart.js": "^4.4.7",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -28,19 +27,35 @@
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.2.4",
         "tailwind-merge": "^3.5.0",
-        "tailwindcss": "^4.2.1",
-        "vite": "^7.3.2"
+        "tailwindcss": "^4.2.1"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.0",
         "@playwright/test": "^1.58.2",
+        "@vitejs/plugin-react": "^5.1.4",
         "playwright": "^1.58.2",
+        "vite": "^7.3.2",
         "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -55,6 +70,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -64,6 +80,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -94,6 +111,7 @@
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -110,6 +128,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
@@ -126,6 +145,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -135,6 +155,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -144,6 +165,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
@@ -157,6 +179,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
@@ -174,6 +197,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
       "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -183,6 +207,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -192,6 +217,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -201,6 +227,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -210,6 +237,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
       "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
@@ -223,6 +251,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
       "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -238,6 +267,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
       "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -253,6 +283,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
       "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -268,6 +299,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
@@ -282,6 +314,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -300,6 +333,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -1607,6 +1641,7 @@
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
       "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2253,6 +2288,7 @@
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -2266,6 +2302,7 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
@@ -2275,6 +2312,7 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -2285,6 +2323,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
@@ -2318,6 +2357,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
       "integrity": "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.29.0",
@@ -2471,10 +2511,21 @@
         "node": ">=12"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
       "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -2484,6 +2535,7 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2527,6 +2579,7 @@
       "version": "1.0.30001770",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
       "integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2607,12 +2660,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2670,6 +2725,7 @@
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
@@ -2737,6 +2793,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2823,6 +2880,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2862,12 +2920,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -2880,6 +2940,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -3184,6 +3245,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3208,6 +3270,7 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -3340,6 +3403,7 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
       "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3468,6 +3532,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3646,6 +3711,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3920,6 +3986,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
       "license": "ISC"
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "test": "playwright test",
     "test:unit": "vitest run",
     "test:e2e": "playwright test",
-    "check:netlify-parity": "bash scripts/netlify-parity-check.sh"
+    "check:netlify-parity": "bash scripts/netlify-parity-check.sh",
+    "check:netlify-cli-build": "npx --yes netlify-cli@latest build --context production --offline"
   },
   "dependencies": {
-    "@vitejs/plugin-react": "^5.1.4",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
@@ -33,12 +33,14 @@
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.2.4",
     "tailwind-merge": "^3.5.0",
-    "tailwindcss": "^4.2.1",
-    "vite": "^7.3.2"
+    "tailwindcss": "^4.2.1"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.0",
     "@playwright/test": "^1.58.2",
+    "@vitejs/plugin-react": "^5.1.4",
     "playwright": "^1.58.2",
+    "vite": "^7.3.2",
     "vitest": "^3.2.4"
   }
 }

--- a/scripts/netlify-parity-check.sh
+++ b/scripts/netlify-parity-check.sh
@@ -7,6 +7,12 @@ cd "$ROOT_DIR"
 echo "[netlify-parity] Node: $(node -v)"
 echo "[netlify-parity] npm: $(npm -v)"
 
+NODE_MAJOR="$(node -p "process.versions.node.split('.')[0]")"
+if [[ "$NODE_MAJOR" != "22" ]]; then
+  echo "[netlify-parity] ERROR: Node 22 is required to match netlify.toml (found $(node -v))"
+  exit 1
+fi
+
 echo "[netlify-parity] Cleaning install artifacts"
 rm -rf node_modules dist
 
@@ -14,7 +20,17 @@ echo "[netlify-parity] Installing dependencies from package-lock.json"
 npm ci
 
 echo "[netlify-parity] Building production bundle"
-npm run build
+CI=true NETLIFY=true CONTEXT=production npm run build
+
+if [[ -f "public/sw.js" && ! -f "dist/sw.js" ]]; then
+  echo "[netlify-parity] ERROR: dist/sw.js missing (public/sw.js should be copied)"
+  exit 1
+fi
+
+if [[ -f "public/_headers" && ! -f "dist/_headers" ]]; then
+  echo "[netlify-parity] ERROR: dist/_headers missing (public/_headers should be copied)"
+  exit 1
+fi
 
 if [[ ! -f "dist/index.html" ]]; then
   echo "[netlify-parity] ERROR: dist/index.html missing after build"

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { autoBuildDepthChart, depthWarnings } from '../../core/depthChart.js';
 import { markWeeklyPrepStep } from '../utils/weeklyPrep.js';
@@ -31,7 +31,7 @@ function getGameScores(game) {
   };
 }
 
-function getLastGameDisplay(lastGame, userTeamId) {
+export function getLastGameDisplay(lastGame, userTeamId) {
   if (!lastGame) {
     return {
       heroLine: 'No completed game yet',
@@ -39,6 +39,7 @@ function getLastGameDisplay(lastGame, userTeamId) {
       oppAbbr: 'TBD',
     };
   }
+
   const userId = Number(userTeamId);
   const homeId = Number(lastGame?.homeId ?? lastGame?.home?.id);
   const awayId = Number(lastGame?.awayId ?? lastGame?.away?.id);
@@ -47,14 +48,44 @@ function getLastGameDisplay(lastGame, userTeamId) {
   const scores = getGameScores(lastGame);
   const userScore = userIsHome ? scores.home : userIsAway ? scores.away : scores.home;
   const oppScore = userIsHome ? scores.away : userIsAway ? scores.home : scores.away;
-  const oppAbbr = userIsHome ? (lastGame?.awayAbbr ?? 'TBD') : (lastGame?.homeAbbr ?? 'TBD');
+  const overtimePeriods = safeNum(lastGame?.overtimePeriods ?? lastGame?.ot, 0);
+  const overtimeLabel = overtimePeriods > 1 ? ` ${overtimePeriods}OT` : overtimePeriods === 1 ? ' OT' : '';
+  const opponentAbbr = userIsHome
+    ? (lastGame?.awayAbbr ?? lastGame?.away?.abbr ?? 'TBD')
+    : (lastGame?.homeAbbr ?? lastGame?.home?.abbr ?? 'TBD');
   const location = userIsHome ? 'vs' : userIsAway ? '@' : 'vs';
-  const resultLabel = userScore === oppScore ? 'T' : userScore > oppScore ? 'W' : 'L';
+  const resultLabel = getReadableResultLabel({ userScore, oppScore, overtimePeriods });
+  const scoreLine = `${userScore}-${oppScore}${overtimeLabel}`;
+
   return {
-    heroLine: `${resultLabel} · ${userScore}-${oppScore} ${location} ${oppAbbr}`,
-    overviewLine: `${resultLabel} ${userScore}-${oppScore} ${location} ${oppAbbr}`,
-    oppAbbr,
+    heroLine: `${resultLabel} · ${scoreLine} ${location} ${opponentAbbr}`.trim(),
+    overviewLine: `${resultLabel} ${scoreLine} ${location} ${opponentAbbr}`.trim(),
+    oppAbbr: opponentAbbr,
   };
+}
+
+function getLatestUserCompletedGame(league) {
+  const weeks = [...(league?.schedule?.weeks ?? [])]
+    .sort((a, b) => safeNum(a?.week) - safeNum(b?.week));
+
+  const completedGames = [];
+  for (const week of weeks) {
+    for (const game of (week?.games ?? [])) {
+      if (!game?.played) continue;
+      const homeId = Number(game?.home?.id ?? game?.home ?? game?.homeId);
+      const awayId = Number(game?.away?.id ?? game?.away ?? game?.awayId);
+      if (homeId !== Number(league?.userTeamId) && awayId !== Number(league?.userTeamId)) continue;
+      completedGames.push({ ...game, week: safeNum(week?.week, safeNum(league?.week, 1)), homeId, awayId });
+    }
+  }
+
+  return completedGames.at(-1) ?? null;
+}
+
+function getReadableResultLabel({ userScore, oppScore, overtimePeriods }) {
+  if (userScore === oppScore) return overtimePeriods > 0 ? 'T (OT)' : 'T';
+  const outcome = userScore > oppScore ? 'W' : 'L';
+  return overtimePeriods > 0 ? `${outcome} (OT)` : outcome;
 }
 
 export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, simulating }) {
@@ -94,7 +125,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
     { title: 'Scout Opponent', icon: <HQIcon name="scout" size={22} />, subtitle: command.actionStatuses.scouting.subtitle, badge: command.actionStatuses.scouting.badge || 'New report', onClick: () => { markWeeklyPrepStep(league, 'opponentScouted', true); onNavigate?.('Weekly Prep'); } },
   ];
 
-  const lastGame = command.lastGameSummary;
+  const lastGame = useMemo(() => getLatestUserCompletedGame(league) ?? command.lastGameSummary ?? null, [league, command.lastGameSummary]);
   const lastGameDisplay = useMemo(() => getLastGameDisplay(lastGame, league?.userTeamId), [lastGame, league?.userTeamId]);
   const footerDays = Math.max(0, 7 - ((safeNum(league?.week, 1) - 1) % 7));
   const heroMeta = useMemo(() => {
@@ -139,8 +170,19 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
       return `W${safeNum(game?.week, 0)} ${isHome ? 'vs' : '@'} ${oppTeam?.abbr ?? 'TBD'}`;
     }), [league]);
 
+  useEffect(() => {
+    document.title = `Franchise HQ • ${command.weekLabel} • Football GM Sim`;
+    let description = document.querySelector('meta[name="description"]');
+    if (!description) {
+      description = document.createElement('meta');
+      description.setAttribute('name', 'description');
+      document.head.appendChild(description);
+    }
+    description.setAttribute('content', 'Manage weekly prep, review your last result, and advance your franchise one week at a time.');
+  }, [command.weekLabel]);
+
   return (
-    <div className="app-screen-stack franchise-hq franchise-command-center">
+    <div className="app-screen-stack franchise-hq franchise-command-center" role="main" aria-label="Franchise HQ weekly command center">
       <section className="app-hq-topbar card" aria-label="Franchise HQ top bar">
         <div className="app-hq-topbar__left">
           <span>{command.seasonLabel}</span>
@@ -152,7 +194,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
         </div>
       </section>
 
-      <section className="app-hq-matchup-hero card" aria-label="Weekly Hero">
+      <section className="app-hq-matchup-hero card" aria-label="Weekly Hero" aria-live="polite">
         <div className="app-hq-matchup-main">
           <div className="app-hq-hero-copy">
             <span className="app-hq-matchup-hero__eyebrow">Next Opponent · Week {safeNum(league?.week, 1)} Operations</span>
@@ -192,11 +234,11 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
         <div className="app-section-heading">This Week</div>
         <div className="app-action-grid-2x2">
           {actionTiles.map((action) => (
-            <ActionTile key={action.title} icon={action.icon} title={action.title} subtitle={action.subtitle} badge={action.badge ? <StatusChip label={action.badge} tone="warning" /> : null} onClick={action.onClick} tone="info" />
+            <ActionTile key={action.title} icon={action.icon} title={action.title} subtitle={action.subtitle} badge={action.badge ? <StatusChip label={action.badge} tone="warning" /> : null} onClick={action.onClick} tone="info" ariaLabel={`${action.title}: ${action.subtitle}`} />
           ))}
         </div>
       </section>
-      {lineupToast ? <p className="app-inline-toast">{lineupToast}</p> : null}
+      {lineupToast ? <p className="app-inline-toast" role="status" aria-live="polite">{lineupToast}</p> : null}
 
       <SectionCard title="Weekly Agenda" subtitle="Weekly Priorities for this week." variant="compact">
         <WeeklyAgenda items={(command.weeklyAgenda ?? []).slice(0, 3)} onOpenTask={(task) => onNavigate?.(task?.targetRoute ?? task?.tab ?? 'HQ')} />
@@ -220,7 +262,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
       </SectionCard>
 
       <div className="app-hq-sticky-advance">
-        <Button className="app-command-advance app-command-advance-gold" onClick={onAdvanceWeek} disabled={busy || simulating}>
+        <Button className="app-command-advance app-command-advance-gold" onClick={onAdvanceWeek} disabled={busy || simulating} aria-label={`Advance from ${command.weekLabel} to the next week`}>
           {busy || simulating ? 'Advancing…' : 'Advance Week'}
           <HQIcon name="arrowRight" size={16} />
         </Button>
@@ -233,6 +275,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
             type="button"
             className={item.active ? 'is-active' : ''}
             onClick={() => onNavigate?.(item.route)}
+            aria-label={`Open ${item.label}`}
           >
             <span aria-hidden="true"><HQIcon name={item.icon} size={18} /></span>
             <small>{item.label}</small>

--- a/src/ui/components/ScreenSystem.jsx
+++ b/src/ui/components/ScreenSystem.jsx
@@ -86,9 +86,9 @@ export function HeroCard({ eyebrow, title, subtitle, rightMeta = null, children,
 export const HeroPanel = HeroCard;
 export const WeeklyHero = HeroCard;
 
-export function ActionTile({ icon = null, title, subtitle, badge = null, onClick, tone = 'info' }) {
+export function ActionTile({ icon = null, title, subtitle, badge = null, onClick, tone = 'info', ariaLabel }) {
   return (
-    <button type="button" className={`app-action-tile tone-${tone}`} onClick={onClick}>
+    <button type="button" className={`app-action-tile tone-${tone}`} onClick={onClick} aria-label={ariaLabel ?? title}>
       <div className="app-action-tile__title-row">
         <strong>
           {icon ? <span className="app-action-tile__icon">{icon}</span> : null}

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { renderToString } from 'react-dom/server';
-import FranchiseHQ from '../FranchiseHQ.jsx';
+import FranchiseHQ, { getLastGameDisplay } from '../FranchiseHQ.jsx';
 
 const baseLeague = {
   year: 2026,
@@ -103,5 +103,35 @@ describe('FranchiseHQ', () => {
         simulating={false}
       />,
     )).not.toThrow();
+  });
+
+  it('shows fallback when no completed game exists', () => {
+    const display = getLastGameDisplay(null, 10);
+    expect(display.heroLine).toContain('No completed game yet');
+  });
+
+  it('formats ties and overtime details from user perspective', () => {
+    const tieDisplay = getLastGameDisplay({
+      homeId: 10,
+      awayId: 11,
+      homeAbbr: 'CHI',
+      awayAbbr: 'DET',
+      homeScore: 20,
+      awayScore: 20,
+      overtimePeriods: 1,
+    }, 10);
+    expect(tieDisplay.heroLine).toContain('T (OT)');
+    expect(tieDisplay.heroLine).toContain('20-20 OT');
+    expect(tieDisplay.heroLine).toContain('vs DET');
+  });
+
+  it('uses TBD when opponent metadata is missing', () => {
+    const display = getLastGameDisplay({
+      homeId: 9,
+      awayId: 10,
+      homeScore: 17,
+      awayScore: 24,
+    }, 10);
+    expect(display.heroLine).toContain('@ TBD');
   });
 });

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -351,7 +351,7 @@
 .app-hq-matchup-main { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 10px; min-height: 166px; }
 .app-hq-hero-copy { display: grid; gap: 5px; align-content: center; }
 .app-hq-hero-copy strong { color: #E6EDF3; font-size: clamp(1.2rem, 4.4vw, 1.7rem); letter-spacing: .04em; line-height: 1.02; }
-.app-hq-hero-copy p { margin: 0; color: #8B9BB0; font-size: 12px; }
+.app-hq-hero-copy p { margin: 0; color: #b8c8de; font-size: 0.78rem; }
 .app-hq-team { display: grid; gap: 4px; justify-items: center; text-align: center; position: relative; }
 .app-hq-team--user::before,
 .app-hq-team--opp::before {
@@ -365,7 +365,7 @@
 .app-hq-team--user::before { background: radial-gradient(circle at 20% 40%, rgba(76, 130, 255, .35), transparent 70%); }
 .app-hq-team--opp::before { background: radial-gradient(circle at 80% 40%, rgba(255, 88, 88, .33), transparent 70%); }
 .app-hq-team strong { font-size: clamp(12px, 3.5vw, 14px); }
-.app-hq-team span { color: #8B9BB0; font-size: 12px; font-weight: 500; }
+.app-hq-team span { color: #c0d0e8; font-size: 0.75rem; font-weight: 500; }
 .app-hq-vs-block {
   display: grid;
   justify-items: center;
@@ -389,10 +389,10 @@
   gap: 5px;
   box-shadow: inset 0 1px 0 rgba(255,255,255,.06);
 }
-.app-hq-hero-subcard__head { display: flex; align-items: center; gap: 6px; color: #bdcce1; font-size: 10px; text-transform: uppercase; letter-spacing: .08em; }
-.app-hq-hero-subcard__head strong { font-size: 10px; color: #bdcce1; text-transform: uppercase; letter-spacing: .08em; }
+.app-hq-hero-subcard__head { display: flex; align-items: center; gap: 0.375rem; color: #d7e3f5; font-size: 0.65rem; text-transform: uppercase; letter-spacing: .08em; }
+.app-hq-hero-subcard__head strong { font-size: 0.65rem; color: #d7e3f5; text-transform: uppercase; letter-spacing: .08em; }
 .app-hq-hero-subcard__value { margin: 0; font-size: 13px; line-height: 1.25; font-weight: 800; color: #f2f7ff; }
-.app-hq-hero-subcard small { color: #8ea2be; font-size: 11px; }
+.app-hq-hero-subcard small { color: #c8d5e8; font-size: 0.7rem; }
 .app-command-advance { min-width: 220px; font-size: var(--text-base); font-weight: 800; }
 .app-command-advance-gold {
   width: 100%;
@@ -452,6 +452,12 @@
   font-weight: 700;
   cursor: pointer;
   transition: background .16s ease, color .16s ease, transform .16s ease;
+}
+.app-hq-bottom-nav button:focus-visible,
+.app-command-advance-gold:focus-visible,
+.app-action-tile:focus-visible {
+  outline: 0.14rem solid #ffd166;
+  outline-offset: 0.12rem;
 }
 .app-hq-bottom-nav button span { font-size: 15px; line-height: 1; color: #8ea1bf; display: grid; place-items: center; }
 .app-hq-bottom-nav button svg { width: 17px; height: 17px; }
@@ -577,6 +583,18 @@
   .app-action-grid-2x2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .app-summary-grid { grid-template-columns: 1fr; }
   .app-hq-hero-subcards { grid-template-columns: 1fr; }
+  .app-hq-matchup-main { grid-template-columns: 1fr; justify-items: start; min-height: auto; gap: 0.75rem; }
+  .app-hq-team--opp { width: 100%; justify-items: start; text-align: left; }
+  .app-command-advance-gold { min-height: 3.2rem; font-size: clamp(0.98rem, 4.8vw, 1.05rem); }
+}
+
+@media (max-width: 375px) {
+  .app-hq-topbar { padding: 0.55rem 0.65rem; gap: 0.45rem; }
+  .app-hq-topbar__left strong, .app-hq-topbar__team strong { font-size: 0.78rem; letter-spacing: 0.08em; }
+  .app-hq-matchup-hero { padding: 0.8rem 0.75rem; gap: 0.65rem; }
+  .app-hq-hero-copy strong { font-size: clamp(1rem, 5.5vw, 1.18rem); }
+  .app-hq-bottom-nav { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .app-hq-bottom-nav button small { font-size: 0.58rem; }
 }
 
 @media (min-width: 900px) {

--- a/tests/e2e/franchise_hq_mobile_smoke.spec.js
+++ b/tests/e2e/franchise_hq_mobile_smoke.spec.js
@@ -1,21 +1,56 @@
 import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
 import { launchFranchise } from './helpers/franchise.js';
 
-test.use({ viewport: { width: 390, height: 844 } });
+for (const viewport of [
+  { name: 'small-phone', width: 375, height: 812 },
+  { name: 'tablet', width: 820, height: 1180 },
+]) {
+  test(`${viewport.name}: HQ shows weekly command center essentials`, async ({ page }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await launchFranchise(page);
 
-test('mobile HQ shows weekly command center essentials', async ({ page }) => {
+    await expect(page.getByText(/Week\s+\d+/i).first()).toBeVisible({ timeout: 60000 });
+    await expect(page.getByText('Next Opponent').first()).toBeVisible();
+    await expect(page.getByRole('button', { name: /Advance Week/i })).toBeVisible();
+
+    for (const label of ['Game Plan', 'Set Lineup', 'Training', 'Scout Opponent']) {
+      await expect(page.getByRole('button', { name: new RegExp(label, 'i') }).first()).toBeVisible();
+    }
+
+    const advance = page.getByRole('button', { name: /Advance Week/i });
+    await expect(advance).toBeEnabled();
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  });
+}
+
+test('HQ action buttons preserve shell routing and remain accessible', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
   await launchFranchise(page);
+  const baselineUserTeamId = await page.evaluate(() => window?.state?.league?.userTeamId ?? null);
 
-  await expect(page.getByText(/Week\s+\d+/i).first()).toBeVisible({ timeout: 60000 });
-  await expect(page.getByText('Next Opponent').first()).toBeVisible();
-  await expect(page.getByRole('button', { name: /Advance Week/i })).toBeVisible();
+  await page.getByRole('button', { name: /Game Plan/i }).first().click();
+  await expect(page.locator('[data-testid="section-tab-game-plan"][aria-current="page"]')).toBeVisible();
 
-  await expect(page.getByText('Game Plan').first()).toBeVisible();
-  await expect(page.getByText('Set Lineup').first()).toBeVisible();
-  await expect(page.getByText('Training').first()).toBeVisible();
-  await expect(page.getByText('Scout Opponent').first()).toBeVisible();
+  await page.getByRole('button', { name: /Set Lineup/i }).first().click();
+  await expect(page.locator('[data-testid="section-tab-roster"][aria-current="page"]')).toBeVisible();
 
-  const advance = page.getByRole('button', { name: /Advance Week/i });
-  await expect(advance).toBeEnabled();
-  await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  await page.getByRole('button', { name: /Training/i }).first().click();
+  await expect(page.locator('[data-testid="section-tab-training"][aria-current="page"]')).toBeVisible();
+
+  await page.getByRole('button', { name: /Home/i }).first().click();
+  await expect(page.locator('[data-testid="section-tab-hq"][aria-current="page"]')).toBeVisible();
+
+  await page.getByRole('button', { name: /Scout Opponent/i }).first().click();
+  await expect(page.locator('[data-testid="section-tab-weekly-prep"][aria-current="page"]')).toBeVisible();
+  await expect.poll(async () => page.evaluate(() => window?.state?.league?.userTeamId ?? null)).toBe(baselineUserTeamId);
+});
+
+test('HQ has no critical axe accessibility violations', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await launchFranchise(page);
+  const accessibilityScanResults = await new AxeBuilder({ page })
+    .include('.franchise-command-center')
+    .analyze();
+  expect(accessibilityScanResults.violations).toEqual([]);
 });


### PR DESCRIPTION
### Motivation
- Ensure Netlify build parity so PRs fail early when production builds would fail. 
- Improve the Franchise HQ command-center UX for accessibility, keyboard/screen-reader support and small-screen layouts. 
- Make the hero/scoreboard logic robust to ties, overtime and missing data to avoid misleading UI and runtime errors. 
- Expand automated tests (unit + e2e + a11y) so regressions are caught before deploys.

### Description
- Add a GitHub Actions workflow `/.github/workflows/netlify-parity.yml` that runs a hardened parity script and a `netlify-cli` offline production build using Node 22 to mirror Netlify; this will block PRs when parity checks fail. 
- Harden `scripts/netlify-parity-check.sh` to verify `node` major version (22), run the build with `CI=true NETLIFY=true CONTEXT=production`, and assert presence of critical static assets (`dist/index.html`, `dist/sw.js`, `dist/_headers`). 
- Integrate a Netlify mirror step using `npx netlify-cli build --context production --offline` and add `check:netlify-cli-build` script to `package.json`. 
- Generalise and export last-game logic in `src/ui/components/FranchiseHQ.jsx` by adding `getLatestUserCompletedGame()` and improving `getLastGameDisplay()` to handle ties, overtime and missing opponent metadata, and deriving the last game from schedule order rather than assuming a single summary. 
- Improve accessibility and semantics in `FranchiseHQ.jsx` and `ScreenSystem.jsx` by adding ARIA labels for action tiles, bottom nav and Advance CTA, adding polite `aria-live` regions and `role=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba5cbb494832d824dcaa821da6d58)