### PR TITLE
Stabilize Netlify parity and polish mobile Franchise HQ weekly flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,10 +32,26 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.11.0",
         "@playwright/test": "^1.58.2",
+        "@testing-library/react": "^16.3.0",
         "@vitejs/plugin-react": "^5.1.4",
+        "jsdom": "^26.1.0",
         "playwright": "^1.58.2",
         "vite": "^7.3.2",
         "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
       }
     },
     "node_modules/@axe-core/playwright": {
@@ -295,6 +311,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -341,6 +367,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -2284,6 +2425,63 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2489,6 +2687,41 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -2499,6 +2732,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/assertion-error": {
@@ -2663,6 +2907,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2681,12 +2953,30 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2711,6 +3001,14 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dset": {
       "version": "3.1.4",
@@ -2739,6 +3037,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -2901,10 +3212,71 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jiti": {
@@ -2922,6 +3294,46 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -3223,6 +3635,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/lucide-react": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.6.0.tgz",
@@ -3230,6 +3649,17 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -3272,6 +3702,26 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -3368,6 +3818,32 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -3398,6 +3874,14 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -3522,6 +4006,33 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3612,6 +4123,13 @@
         "url": "https://github.com/fontello/svg2ttf?sponsor=1"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
@@ -3699,6 +4217,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tslib": {
@@ -3965,6 +4529,67 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3981,6 +4606,45 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.11.0",
     "@playwright/test": "^1.58.2",
+    "@testing-library/react": "^16.3.0",
     "@vitejs/plugin-react": "^5.1.4",
+    "jsdom": "^26.1.0",
     "playwright": "^1.58.2",
     "vite": "^7.3.2",
     "vitest": "^3.2.4"

--- a/scripts/netlify-parity-check.sh
+++ b/scripts/netlify-parity-check.sh
@@ -13,13 +13,25 @@ if [[ "$NODE_MAJOR" != "22" ]]; then
   exit 1
 fi
 
+if [[ ! -f "netlify.toml" ]]; then
+  echo "[netlify-parity] ERROR: netlify.toml not found"
+  exit 1
+fi
+
+NETLIFY_CMD="$(sed -n 's/^\s*command\s*=\s*"\(.*\)"/\1/p' netlify.toml | head -n 1)"
+if [[ -z "$NETLIFY_CMD" ]]; then
+  echo "[netlify-parity] ERROR: netlify build command missing in netlify.toml"
+  exit 1
+fi
+
+echo "[netlify-parity] netlify.toml build.command=$NETLIFY_CMD"
 echo "[netlify-parity] Cleaning install artifacts"
 rm -rf node_modules dist
 
 echo "[netlify-parity] Installing dependencies from package-lock.json"
-npm ci
+npm ci --no-audit
 
-echo "[netlify-parity] Building production bundle"
+echo "[netlify-parity] Building production bundle with Netlify-like env"
 CI=true NETLIFY=true CONTEXT=production npm run build
 
 if [[ -f "public/sw.js" && ! -f "dist/sw.js" ]]; then
@@ -37,4 +49,4 @@ if [[ ! -f "dist/index.html" ]]; then
   exit 1
 fi
 
-echo "[netlify-parity] OK: dist/index.html present"
+echo "[netlify-parity] OK: Netlify parity build completed and dist artifacts are present"

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -4,6 +4,7 @@ import { autoBuildDepthChart, depthWarnings } from '../../core/depthChart.js';
 import { markWeeklyPrepStep } from '../utils/weeklyPrep.js';
 import { selectFranchiseHQViewModel } from '../utils/franchiseCommandCenter.js';
 import { EmptyState, StatusChip, ActionTile, SectionCard, WeeklyAgenda, CompactNewsCard } from './ScreenSystem.jsx';
+import { getLastGameDisplay, getLatestUserCompletedGame, getNextOpponentDisplay } from '../utils/hqGameDisplay.js';
 import { HQIcon, TeamIdentityBadge } from './HQVisuals.jsx';
 
 const BOTTOM_NAV_ITEMS = [
@@ -24,70 +25,6 @@ function formatRecordInline(record) {
   return record;
 }
 
-function getGameScores(game) {
-  return {
-    home: safeNum(game?.score?.home ?? game?.homeScore),
-    away: safeNum(game?.score?.away ?? game?.awayScore),
-  };
-}
-
-export function getLastGameDisplay(lastGame, userTeamId) {
-  if (!lastGame) {
-    return {
-      heroLine: 'No completed game yet',
-      overviewLine: 'No completed game yet',
-      oppAbbr: 'TBD',
-    };
-  }
-
-  const userId = Number(userTeamId);
-  const homeId = Number(lastGame?.homeId ?? lastGame?.home?.id);
-  const awayId = Number(lastGame?.awayId ?? lastGame?.away?.id);
-  const userIsHome = homeId === userId;
-  const userIsAway = awayId === userId;
-  const scores = getGameScores(lastGame);
-  const userScore = userIsHome ? scores.home : userIsAway ? scores.away : scores.home;
-  const oppScore = userIsHome ? scores.away : userIsAway ? scores.home : scores.away;
-  const overtimePeriods = safeNum(lastGame?.overtimePeriods ?? lastGame?.ot, 0);
-  const overtimeLabel = overtimePeriods > 1 ? ` ${overtimePeriods}OT` : overtimePeriods === 1 ? ' OT' : '';
-  const opponentAbbr = userIsHome
-    ? (lastGame?.awayAbbr ?? lastGame?.away?.abbr ?? 'TBD')
-    : (lastGame?.homeAbbr ?? lastGame?.home?.abbr ?? 'TBD');
-  const location = userIsHome ? 'vs' : userIsAway ? '@' : 'vs';
-  const resultLabel = getReadableResultLabel({ userScore, oppScore, overtimePeriods });
-  const scoreLine = `${userScore}-${oppScore}${overtimeLabel}`;
-
-  return {
-    heroLine: `${resultLabel} · ${scoreLine} ${location} ${opponentAbbr}`.trim(),
-    overviewLine: `${resultLabel} ${scoreLine} ${location} ${opponentAbbr}`.trim(),
-    oppAbbr: opponentAbbr,
-  };
-}
-
-function getLatestUserCompletedGame(league) {
-  const weeks = [...(league?.schedule?.weeks ?? [])]
-    .sort((a, b) => safeNum(a?.week) - safeNum(b?.week));
-
-  const completedGames = [];
-  for (const week of weeks) {
-    for (const game of (week?.games ?? [])) {
-      if (!game?.played) continue;
-      const homeId = Number(game?.home?.id ?? game?.home ?? game?.homeId);
-      const awayId = Number(game?.away?.id ?? game?.away ?? game?.awayId);
-      if (homeId !== Number(league?.userTeamId) && awayId !== Number(league?.userTeamId)) continue;
-      completedGames.push({ ...game, week: safeNum(week?.week, safeNum(league?.week, 1)), homeId, awayId });
-    }
-  }
-
-  return completedGames.at(-1) ?? null;
-}
-
-function getReadableResultLabel({ userScore, oppScore, overtimePeriods }) {
-  if (userScore === oppScore) return overtimePeriods > 0 ? 'T (OT)' : 'T';
-  const outcome = userScore > oppScore ? 'W' : 'L';
-  return overtimePeriods > 0 ? `${outcome} (OT)` : outcome;
-}
-
 export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, simulating }) {
   const [lineupToast, setLineupToast] = useState(null);
   const command = useMemo(() => selectFranchiseHQViewModel(league), [league]);
@@ -98,6 +35,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
 
   const userTeam = (league?.teams ?? []).find((t) => Number(t?.id) === Number(league?.userTeamId));
   const opponent = command.nextGame?.opp ?? null;
+  const nextOpponentDisplay = useMemo(() => getNextOpponentDisplay(command.nextGame), [command.nextGame]);
 
   const handleSetLineup = () => {
     const team = (league?.teams ?? []).find((t) => Number(t?.id) === Number(league?.userTeamId));
@@ -197,13 +135,13 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
       <section className="app-hq-matchup-hero card" aria-label="Weekly Hero" aria-live="polite">
         <div className="app-hq-matchup-main">
           <div className="app-hq-hero-copy">
-            <span className="app-hq-matchup-hero__eyebrow">Next Opponent · Week {safeNum(league?.week, 1)} Operations</span>
-            <strong>{heroMeta.operationHeading}</strong>
-            <p>{heroMeta.nextOppSummary}</p>
+            <span className="app-hq-matchup-hero__eyebrow">Week Command • {command.weekLabel}</span>
+            <h1 className="app-hq-hero-title">{heroMeta.operationHeading}</h1>
+            <p>{nextOpponentDisplay.detail} • {heroMeta.nextOppSummary}</p>
           </div>
           <div className="app-hq-team app-hq-team--opp">
             <TeamIdentityBadge team={opponent} size={112} variant="circle" />
-            <strong>{opponent?.abbr ?? command.nextOpponent}</strong>
+            <strong>{nextOpponentDisplay.opponentAbbr}</strong>
             <span>{formatRecordInline(command.nextOpponentRecord)}</span>
           </div>
         </div>
@@ -212,10 +150,10 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
           <div className="app-hq-hero-subcard">
             <div className="app-hq-hero-subcard__head">
               <HQIcon name="lastGame" size={14} />
-              <strong>Last Game</strong>
+              <strong>Last Result</strong>
             </div>
             <p className="app-hq-hero-subcard__value">{lastGameDisplay.heroLine}</p>
-            <small>{lastGame ? heroMeta.lastGameStory : 'Play this week to establish momentum.'}</small>
+            <small>{lastGame ? heroMeta.lastGameStory : 'No final yet. Build your plan and get ready for kickoff.'}</small>
           </div>
           <div className="app-hq-hero-subcard">
             <div className="app-hq-hero-subcard__head">
@@ -231,7 +169,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
       </section>
 
       <section className="app-section-stack" aria-label="This Week Action Center">
-        <div className="app-section-heading">This Week</div>
+        <h2 className="app-section-heading">Prepare for Kickoff</h2>
         <div className="app-action-grid-2x2">
           {actionTiles.map((action) => (
             <ActionTile key={action.title} icon={action.icon} title={action.title} subtitle={action.subtitle} badge={action.badge ? <StatusChip label={action.badge} tone="warning" /> : null} onClick={action.onClick} tone="info" ariaLabel={`${action.title}: ${action.subtitle}`} />
@@ -240,15 +178,15 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
       </section>
       {lineupToast ? <p className="app-inline-toast" role="status" aria-live="polite">{lineupToast}</p> : null}
 
-      <SectionCard title="Weekly Agenda" subtitle="Weekly Priorities for this week." variant="compact">
+      <SectionCard title="Week Command" subtitle="Resolve weekly priorities before advancing." variant="compact">
         <WeeklyAgenda items={(command.weeklyAgenda ?? []).slice(0, 3)} onOpenTask={(task) => onNavigate?.(task?.targetRoute ?? task?.tab ?? 'HQ')} />
       </SectionCard>
 
-      <SectionCard title="Team Overview" subtitle="Last result, standing, and upcoming slate." variant="compact">
+      <SectionCard title="Operations Snapshot" subtitle="Last result, standing, and upcoming slate." variant="compact">
         <div className="app-hq-team-overview">
           <div><span>Last Game</span><strong>{lastGameDisplay.overviewLine}</strong></div>
           <div><span>Standing</span><strong>{command.standingSummary}</strong></div>
-          <div><span>Next 3</span><div className="app-hq-opponent-chips">{nextOpponents.map((chip) => <em key={chip}>{chip}</em>)}</div></div>
+          <div><span>Next 3</span><div className="app-hq-opponent-chips">{nextOpponents.length ? nextOpponents.map((chip) => <em key={chip}>{chip}</em>) : <em>No future games on file</em>}</div></div>
         </div>
       </SectionCard>
 
@@ -262,7 +200,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
       </SectionCard>
 
       <div className="app-hq-sticky-advance">
-        <Button className="app-command-advance app-command-advance-gold" onClick={onAdvanceWeek} disabled={busy || simulating} aria-label={`Advance from ${command.weekLabel} to the next week`}>
+        <Button className="app-command-advance app-command-advance-gold" onClick={onAdvanceWeek} disabled={busy || simulating} aria-label={`Advance Week — move from ${command.weekLabel} to next week`} title="Advance Week">
           {busy || simulating ? 'Advancing…' : 'Advance Week'}
           <HQIcon name="arrowRight" size={16} />
         </Button>

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -1,7 +1,8 @@
+/** @vitest-environment jsdom */
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { renderToString } from 'react-dom/server';
-import FranchiseHQ, { getLastGameDisplay } from '../FranchiseHQ.jsx';
+import { render, screen } from '@testing-library/react';
+import FranchiseHQ from '../FranchiseHQ.jsx';
 
 const baseLeague = {
   year: 2026,
@@ -25,28 +26,10 @@ const baseLeague = {
       offenseRating: 82,
       defenseRating: 83,
       capRoom: 7,
-      roster: [
-        { id: 1, contract: { yearsRemaining: 1 } },
-        { id: 2, contract: { yearsRemaining: 1 }, injury: 'Ankle', injuredWeeks: 1 },
-      ],
+      roster: [{ id: 1 }, { id: 2 }],
       recentResults: ['W', 'W', 'L', 'W'],
     },
-    {
-      id: 11,
-      city: 'Detroit',
-      name: 'Lions',
-      abbr: 'DET',
-      conf: 1,
-      div: 0,
-      wins: 5,
-      losses: 4,
-      ties: 0,
-      ovr: 83,
-      offenseRating: 86,
-      defenseRating: 80,
-      capRoom: 11,
-      roster: [],
-    },
+    { id: 11, city: 'Detroit', name: 'Lions', abbr: 'DET', conf: 1, div: 0, wins: 5, losses: 4, ties: 0, ovr: 83, offenseRating: 86, defenseRating: 80, capRoom: 11, roster: [] },
   ],
   schedule: {
     weeks: [
@@ -59,79 +42,31 @@ const baseLeague = {
 };
 
 describe('FranchiseHQ', () => {
-  it('renders weekly command center hierarchy and mobile nav labels', () => {
-    const html = renderToString(
+  it('renders visible weekly command center essentials and one primary advance CTA', () => {
+    render(<FranchiseHQ league={baseLeague} onNavigate={() => {}} onAdvanceWeek={() => {}} busy={false} simulating={false} />);
+
+    expect(screen.getByRole('heading', { name: /week 10/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /advance week/i })).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: /advance week/i })).toHaveLength(1);
+    expect(screen.getByRole('button', { name: /^game plan:/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /^set lineup:/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /^training:/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /^scout opponent:/i })).toBeTruthy();
+  });
+
+  it('renders record, standing, and fallback copy when schedule is missing', () => {
+    render(
       <FranchiseHQ
-        league={baseLeague}
-        onNavigate={() => {}}
-        onOpenBoxScore={() => {}}
-        onAdvanceWeek={() => {}}
+        league={{ year: 2026, week: 2, phase: 'regular', userTeamId: 1, teams: [{ id: 1, name: 'Legacy Team', city: 'Legacy', conf: 0, div: 0, wins: 0, losses: 0, ties: 0 }], schedule: { weeks: [] } }}
+        onNavigate={vi.fn()}
+        onAdvanceWeek={vi.fn()}
         busy={false}
         simulating={false}
       />,
     );
 
-    expect(html).toContain('Advance Week');
-    expect(html).toContain('Set Lineup');
-    expect(html).toContain('Game Plan');
-    expect(html).toContain('Scout Opponent');
-    expect(html).toContain('Weekly Agenda');
-    expect(html).toContain('This Week');
-    expect(html).toContain('Team Overview');
-    expect(html).toContain('League News');
-    expect(html).toContain('Next Opponent');
-    expect(html).toContain('Home');
-    expect(html).toContain('News');
-    expect(html).toContain('More');
-  });
-
-  it('is safe with partial/older save payloads', () => {
-    expect(() => renderToString(
-      <FranchiseHQ
-        league={{
-          year: 2026,
-          week: 2,
-          phase: 'regular',
-          userTeamId: 1,
-          teams: [{ id: 1, name: 'Legacy Team', city: 'Legacy', conf: 0, div: 0 }],
-          schedule: { weeks: [] },
-        }}
-        onNavigate={vi.fn()}
-        onOpenBoxScore={vi.fn()}
-        onAdvanceWeek={vi.fn()}
-        busy={false}
-        simulating={false}
-      />,
-    )).not.toThrow();
-  });
-
-  it('shows fallback when no completed game exists', () => {
-    const display = getLastGameDisplay(null, 10);
-    expect(display.heroLine).toContain('No completed game yet');
-  });
-
-  it('formats ties and overtime details from user perspective', () => {
-    const tieDisplay = getLastGameDisplay({
-      homeId: 10,
-      awayId: 11,
-      homeAbbr: 'CHI',
-      awayAbbr: 'DET',
-      homeScore: 20,
-      awayScore: 20,
-      overtimePeriods: 1,
-    }, 10);
-    expect(tieDisplay.heroLine).toContain('T (OT)');
-    expect(tieDisplay.heroLine).toContain('20-20 OT');
-    expect(tieDisplay.heroLine).toContain('vs DET');
-  });
-
-  it('uses TBD when opponent metadata is missing', () => {
-    const display = getLastGameDisplay({
-      homeId: 9,
-      awayId: 10,
-      homeScore: 17,
-      awayScore: 24,
-    }, 10);
-    expect(display.heroLine).toContain('@ TBD');
+    expect(screen.getByText(/no completed game yet/i)).toBeTruthy();
+    expect(screen.getByText(/no future games on file/i)).toBeTruthy();
+    expect(screen.getAllByText(/0-0 · 0 0/i).length).toBeGreaterThan(0);
   });
 });

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -350,7 +350,7 @@
 .app-hq-matchup-hero__meta { font-size: 10px; color: #a6b6ce; text-align: right; }
 .app-hq-matchup-main { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 10px; min-height: 166px; }
 .app-hq-hero-copy { display: grid; gap: 5px; align-content: center; }
-.app-hq-hero-copy strong { color: #E6EDF3; font-size: clamp(1.2rem, 4.4vw, 1.7rem); letter-spacing: .04em; line-height: 1.02; }
+.app-hq-hero-title { margin: 0; color: #E6EDF3; font-size: clamp(1.2rem, 4.4vw, 1.7rem); letter-spacing: .04em; line-height: 1.02; text-transform: uppercase; }
 .app-hq-hero-copy p { margin: 0; color: #b8c8de; font-size: 0.78rem; }
 .app-hq-team { display: grid; gap: 4px; justify-items: center; text-align: center; position: relative; }
 .app-hq-team--user::before,
@@ -439,7 +439,8 @@
   box-shadow: 0 8px 20px rgba(0, 0, 0, .28);
   backdrop-filter: blur(12px);
 }
-.app-hq-bottom-nav button {
+ .app-hq-bottom-nav button {
+  min-height: 44px;
   border: 0;
   background: transparent;
   color: var(--text-subtle);
@@ -478,6 +479,7 @@
 .app-hq-team-overview strong { color: #E6EDF3; font-size: 14px; font-weight: 600; }
 .app-hq-opponent-chips { display: flex; gap: 6px; flex-wrap: wrap; }
 .app-hq-opponent-chips em { font-style: normal; font-size: 11px; border: 1px solid #2A3441; border-radius: 999px; padding: 3px 8px; color: #E6EDF3; background: #111722; }
+.app-hq-opponent-chips em:only-child { border-style: dashed; color: #c5d0df; }
 .app-moment-list { margin-top: var(--space-2); display: grid; gap: var(--space-1); }
 .app-moment-list p { margin: 0; font-size: var(--text-xs); color: var(--text-muted); }
 .app-prep-checklist { display: grid; gap: var(--space-2); margin-top: var(--space-2); }
@@ -520,10 +522,10 @@
 .app-compact-news-card strong { font-size: var(--text-xs); color: #E6EDF3; font-weight: 600; }
 .app-compact-news-card span { font-size: 11px; color: #8B9BB0; }
 
-.app-action-tile { min-height: 132px; transition: transform .16s ease, border-color .16s ease, background .16s ease; border-color: #2A3441; background: linear-gradient(180deg, #0B0F14, #121821); box-shadow: inset 0 1px 0 rgba(255,255,255,.06); padding: 12px; }
+ .app-action-tile { min-height: 132px; min-width: 0; transition: transform .16s ease, border-color .16s ease, background .16s ease; border-color: #2A3441; background: linear-gradient(180deg, #0B0F14, #121821); box-shadow: inset 0 1px 0 rgba(255,255,255,.06); padding: 12px; }
 .app-action-tile:hover, .app-action-tile:focus-visible { transform: translateY(-2px); border-color: rgba(var(--accent-rgb), .55); background: color-mix(in srgb, var(--surface-2) 78%, var(--accent) 22%); }
 .app-action-tile:active { transform: translateY(0); }
-.app-action-tile__title-row strong { display: inline-flex; align-items: center; gap: 8px; font-size: 16px; letter-spacing: -.01em; }
+.app-action-tile__title-row strong { display: inline-flex; align-items: center; gap: 8px; font-size: 16px; letter-spacing: -.01em; min-width: 0; }
 .app-action-tile__subtitle { color: var(--text-muted); font-size: 12px; line-height: 1.3; }
 .app-action-tile__icon { width: 88px; height: 88px; border-radius: 12px; display: grid; place-items: center; padding: 12px; background: linear-gradient(180deg, #0B0F14, #121821); border: 1px solid #2A3441; color: #d9e7ff; }
 .app-action-tile .app-status-chip { font-size: 10px; background: rgba(255, 188, 84, .24); border-color: rgba(255, 188, 84, .5); color: #ffd28c; }
@@ -580,6 +582,7 @@
 }
 
 @media (max-width: 420px) {
+  .franchise-command-center { overflow-x: clip; }
   .app-action-grid-2x2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .app-summary-grid { grid-template-columns: 1fr; }
   .app-hq-hero-subcards { grid-template-columns: 1fr; }
@@ -593,7 +596,7 @@
   .app-hq-topbar__left strong, .app-hq-topbar__team strong { font-size: 0.78rem; letter-spacing: 0.08em; }
   .app-hq-matchup-hero { padding: 0.8rem 0.75rem; gap: 0.65rem; }
   .app-hq-hero-copy strong { font-size: clamp(1rem, 5.5vw, 1.18rem); }
-  .app-hq-bottom-nav { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .app-hq-bottom-nav { grid-template-columns: repeat(3, minmax(0, 1fr)); bottom: calc(124px + env(safe-area-inset-bottom, 0px)); }
   .app-hq-bottom-nav button small { font-size: 0.58rem; }
 }
 

--- a/src/ui/utils/hqGameDisplay.js
+++ b/src/ui/utils/hqGameDisplay.js
@@ -1,0 +1,112 @@
+function safeNum(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function asTeamId(raw) {
+  const num = Number(raw);
+  return Number.isFinite(num) ? num : null;
+}
+
+function gameSortKey(game, fallbackWeek = 0, index = 0) {
+  const week = safeNum(game?.week, fallbackWeek);
+  const slot = safeNum(game?.slot ?? game?.gameNumber, index);
+  return week * 1000 + slot;
+}
+
+export function getLatestUserCompletedGame(league) {
+  const weeks = Array.isArray(league?.schedule?.weeks) ? league.schedule.weeks : [];
+  const userTeamId = asTeamId(league?.userTeamId);
+  if (userTeamId == null || weeks.length === 0) return null;
+
+  const completed = [];
+  for (const week of weeks) {
+    const weekNum = safeNum(week?.week, safeNum(league?.week, 1));
+    for (const [idx, game] of (week?.games ?? []).entries()) {
+      if (!game?.played) continue;
+      const homeId = asTeamId(game?.homeId ?? game?.home?.id ?? game?.home);
+      const awayId = asTeamId(game?.awayId ?? game?.away?.id ?? game?.away);
+      if (homeId !== userTeamId && awayId !== userTeamId) continue;
+      completed.push({ ...game, homeId, awayId, week: weekNum, __sortKey: gameSortKey({ ...game, week: weekNum }, weekNum, idx) });
+    }
+  }
+
+  if (!completed.length) return null;
+  completed.sort((a, b) => a.__sortKey - b.__sortKey);
+  const latest = completed[completed.length - 1];
+  delete latest.__sortKey;
+  return latest;
+}
+
+function getResultLabel({ userScore, oppScore, overtimePeriods }) {
+  if (userScore === oppScore) return overtimePeriods > 0 ? 'T (OT)' : 'T';
+  const outcome = userScore > oppScore ? 'W' : 'L';
+  return overtimePeriods > 0 ? `${outcome} (OT)` : outcome;
+}
+
+function getScorePair(game) {
+  return {
+    home: safeNum(game?.score?.home ?? game?.homeScore),
+    away: safeNum(game?.score?.away ?? game?.awayScore),
+  };
+}
+
+export function getLastGameDisplay(lastGame, userTeamId) {
+  if (!lastGame) {
+    return {
+      heroLine: 'No final yet — your season opener is still ahead.',
+      overviewLine: 'No completed game yet',
+      oppAbbr: 'TBD',
+    };
+  }
+
+  const userId = asTeamId(userTeamId);
+  const homeId = asTeamId(lastGame?.homeId ?? lastGame?.home?.id ?? lastGame?.home);
+  const awayId = asTeamId(lastGame?.awayId ?? lastGame?.away?.id ?? lastGame?.away);
+  const userIsHome = userId != null && homeId === userId;
+  const userIsAway = userId != null && awayId === userId;
+
+  const scores = getScorePair(lastGame);
+  const userScore = userIsHome ? scores.home : userIsAway ? scores.away : scores.home;
+  const oppScore = userIsHome ? scores.away : userIsAway ? scores.home : scores.away;
+
+  const overtimePeriods = safeNum(lastGame?.overtimePeriods ?? lastGame?.ot, 0);
+  const overtimeLabel = overtimePeriods > 1 ? ` ${overtimePeriods}OT` : overtimePeriods === 1 ? ' OT' : '';
+
+  const opponentAbbr = userIsHome
+    ? (lastGame?.awayAbbr ?? lastGame?.away?.abbr ?? 'TBD')
+    : (lastGame?.homeAbbr ?? lastGame?.home?.abbr ?? 'TBD');
+  const location = userIsHome ? 'vs' : userIsAway ? '@' : 'vs';
+
+  const resultLabel = getResultLabel({ userScore, oppScore, overtimePeriods });
+  const scoreLine = `${userScore}-${oppScore}${overtimeLabel}`;
+
+  return {
+    heroLine: `${resultLabel} · ${scoreLine} ${location} ${opponentAbbr}`.trim(),
+    overviewLine: `${resultLabel} ${scoreLine} ${location} ${opponentAbbr}`.trim(),
+    oppAbbr: opponentAbbr,
+  };
+}
+
+export function getNextOpponentDisplay(nextGame) {
+  if (!nextGame) {
+    return {
+      heading: 'No opponent locked in yet',
+      detail: 'No upcoming game on the schedule.',
+      opponentAbbr: 'TBD',
+      isHome: true,
+    };
+  }
+  const opponentAbbr = nextGame?.opp?.abbr ?? nextGame?.opp?.name ?? 'TBD';
+  const homeAway = nextGame?.isHome ? 'vs' : '@';
+  const opponentRecord = nextGame?.opp
+    ? `${safeNum(nextGame.opp?.wins, 0)}-${safeNum(nextGame.opp?.losses, 0)}${safeNum(nextGame.opp?.ties, 0) ? `-${safeNum(nextGame.opp?.ties, 0)}` : ''}`
+    : '—';
+
+  return {
+    heading: `Next Assignment ${homeAway} ${opponentAbbr}`,
+    detail: `Prepare for kickoff ${homeAway} ${opponentAbbr} (${opponentRecord}).`,
+    opponentAbbr,
+    isHome: Boolean(nextGame?.isHome),
+  };
+}

--- a/src/ui/utils/hqGameDisplay.test.js
+++ b/src/ui/utils/hqGameDisplay.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { getLatestUserCompletedGame, getLastGameDisplay, getNextOpponentDisplay } from './hqGameDisplay.js';
+
+describe('hqGameDisplay helpers', () => {
+  it('returns null when schedule is missing', () => {
+    expect(getLatestUserCompletedGame({ userTeamId: 1 })).toBeNull();
+  });
+
+  it('finds the latest completed user game from unsorted schedule weeks', () => {
+    const league = {
+      userTeamId: 10,
+      week: 6,
+      schedule: {
+        weeks: [
+          { week: 5, games: [{ id: 'w5g1', played: true, home: { id: 10 }, away: { id: 22 }, homeScore: 20, awayScore: 17 }] },
+          { week: 3, games: [{ id: 'w3g1', played: true, home: { id: 22 }, away: { id: 10 }, homeScore: 24, awayScore: 21 }] },
+        ],
+      },
+    };
+    expect(getLatestUserCompletedGame(league)?.id).toBe('w5g1');
+  });
+
+  it('builds last game display from home perspective', () => {
+    const display = getLastGameDisplay({ homeId: 10, awayId: 11, homeAbbr: 'CHI', awayAbbr: 'DET', homeScore: 27, awayScore: 17 }, 10);
+    expect(display.heroLine).toContain('W');
+    expect(display.heroLine).toContain('27-17 vs DET');
+  });
+
+  it('builds last game display from away perspective including overtime tie', () => {
+    const display = getLastGameDisplay({ homeId: 11, awayId: 10, homeAbbr: 'DET', awayAbbr: 'CHI', homeScore: 24, awayScore: 24, overtimePeriods: 1 }, 10);
+    expect(display.heroLine).toContain('T (OT)');
+    expect(display.heroLine).toContain('24-24 OT @ DET');
+  });
+
+  it('handles missing score/opponent data safely', () => {
+    const display = getLastGameDisplay({ homeId: 11, awayId: 10 }, 10);
+    expect(display.heroLine).toContain('0-0 @ TBD');
+  });
+
+  it('returns no-game fallback copy', () => {
+    expect(getLastGameDisplay(null, 10).overviewLine).toContain('No completed game yet');
+  });
+
+  it('builds next opponent fallback and populated labels', () => {
+    expect(getNextOpponentDisplay(null).opponentAbbr).toBe('TBD');
+    const next = getNextOpponentDisplay({ isHome: false, opp: { abbr: 'GB', wins: 8, losses: 2, ties: 0 } });
+    expect(next.heading).toContain('@ GB');
+    expect(next.detail).toContain('(8-2)');
+  });
+});

--- a/tests/e2e/franchise_hq_mobile_smoke.spec.js
+++ b/tests/e2e/franchise_hq_mobile_smoke.spec.js
@@ -3,15 +3,15 @@ import AxeBuilder from '@axe-core/playwright';
 import { launchFranchise } from './helpers/franchise.js';
 
 for (const viewport of [
-  { name: 'small-phone', width: 375, height: 812 },
-  { name: 'tablet', width: 820, height: 1180 },
+  { name: 'iphone-390', width: 390, height: 844 },
+  { name: 'narrow-360', width: 360, height: 780 },
 ]) {
   test(`${viewport.name}: HQ shows weekly command center essentials`, async ({ page }) => {
     await page.setViewportSize({ width: viewport.width, height: viewport.height });
     await launchFranchise(page);
 
     await expect(page.getByText(/Week\s+\d+/i).first()).toBeVisible({ timeout: 60000 });
-    await expect(page.getByText('Next Opponent').first()).toBeVisible();
+    await expect(page.getByText(/Last Result/i).first()).toBeVisible();
     await expect(page.getByRole('button', { name: /Advance Week/i })).toBeVisible();
 
     for (const label of ['Game Plan', 'Set Lineup', 'Training', 'Scout Opponent']) {
@@ -20,30 +20,32 @@ for (const viewport of [
 
     const advance = page.getByRole('button', { name: /Advance Week/i });
     await expect(advance).toBeEnabled();
-    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+    await expect(advance).toBeInViewport();
+    await expect(page.locator('html, body')).not.toContainText('Something went wrong');
   });
 }
 
-test('HQ action buttons preserve shell routing and remain accessible', async ({ page }) => {
+test('HQ action buttons navigate out/back and preserve team context', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await launchFranchise(page);
   const baselineUserTeamId = await page.evaluate(() => window?.state?.league?.userTeamId ?? null);
 
-  await page.getByRole('button', { name: /Game Plan/i }).first().click();
-  await expect(page.locator('[data-testid="section-tab-game-plan"][aria-current="page"]')).toBeVisible();
+  const steps = [
+    { action: /Game Plan/i, tab: 'game-plan' },
+    { action: /Set Lineup/i, tab: 'roster' },
+    { action: /Training/i, tab: 'training' },
+    { action: /Scout Opponent/i, tab: 'weekly-prep' },
+  ];
 
-  await page.getByRole('button', { name: /Set Lineup/i }).first().click();
-  await expect(page.locator('[data-testid="section-tab-roster"][aria-current="page"]')).toBeVisible();
+  for (const step of steps) {
+    await page.getByRole('button', { name: step.action }).first().click();
+    await expect(page.locator(`[data-testid="section-tab-${step.tab}"][aria-current="page"]`)).toBeVisible();
+    await page.getByRole('button', { name: /Home/i }).first().click();
+    await expect(page.locator('[data-testid="section-tab-hq"][aria-current="page"]')).toBeVisible();
+  }
 
-  await page.getByRole('button', { name: /Training/i }).first().click();
-  await expect(page.locator('[data-testid="section-tab-training"][aria-current="page"]')).toBeVisible();
-
-  await page.getByRole('button', { name: /Home/i }).first().click();
-  await expect(page.locator('[data-testid="section-tab-hq"][aria-current="page"]')).toBeVisible();
-
-  await page.getByRole('button', { name: /Scout Opponent/i }).first().click();
-  await expect(page.locator('[data-testid="section-tab-weekly-prep"][aria-current="page"]')).toBeVisible();
   await expect.poll(async () => page.evaluate(() => window?.state?.league?.userTeamId ?? null)).toBe(baselineUserTeamId);
+  await expect(page.locator('html, body')).not.toContainText('Something went wrong');
 });
 
 test('HQ has no critical axe accessibility violations', async ({ page }) => {


### PR DESCRIPTION
### Motivation
- Stop intermittent Netlify deploy red (make local build reproducible with the same checks Netlify runs). 
- Make Franchise HQ a clear, mobile-first weekly Command Center that prioritizes week, team identity, last result, next opponent and one dominant Advance Week CTA. 
- Replace brittle, component-local game-display logic with a pure view-model helper and harden tests to validate visible UI and flows rather than hidden DOM strings.

### Description
- Netlify parity: strengthen `scripts/netlify-parity-check.sh` to validate `netlify.toml`, print the resolved build command, use `npm ci --no-audit`, run with Netlify-like env vars, and keep strict artifact checks (`dist/index.html`, `dist/sw.js`, `dist/_headers`).
- HQ view-model: extract last-game/next-opponent logic into a pure helper module `src/ui/utils/hqGameDisplay.js` that correctly handles unsorted schedules, home/away perspective, ties/OT, missing opponent/score, and provides `getLatestUserCompletedGame`, `getLastGameDisplay`, and `getNextOpponentDisplay`.
- UI/UX polish: update `src/ui/components/FranchiseHQ.jsx` for hero-first, football-specific copy ("Week Command", "Last Result", "Next Assignment", "Prepare for Kickoff"), simplify headings for accessibility, present a single dominant accessible Advance Week CTA (`aria-label` + `title`), and add safe fallbacks for no completed games / missing schedule.
- Mobile & a11y CSS: tighten `src/ui/styles/screen-system.css` to improve bottom-nav tap targets, avoid horizontal overflow on narrow viewports, ensure action-tile sizing and focus outlines, and add opponent-chip fallback styling.
- Tests: add `src/ui/utils/hqGameDisplay.test.js` unit tests; convert/refactor `src/ui/components/__tests__/FranchiseHQ.test.jsx` to use `@testing-library/react` (jsdom) and role/name queries; strengthen Playwright mobile smoke spec `tests/e2e/franchise_hq_mobile_smoke.spec.js` to assert in-viewport CTA, route-out/back preservation, and accessibility scan inclusion.
- Tooling: add `@testing-library/react` and `jsdom` dev deps to enable component tests in the CI node environment without hidden DOM hooks; no hidden DOM/test appeasement strings were added.

Files touched (high level): `scripts/netlify-parity-check.sh`, `src/ui/components/FranchiseHQ.jsx`, `src/ui/utils/hqGameDisplay.js`, `src/ui/utils/hqGameDisplay.test.js`, `src/ui/components/__tests__/FranchiseHQ.test.jsx`, `src/ui/styles/screen-system.css`, `tests/e2e/franchise_hq_mobile_smoke.spec.js`, `package.json`, `package-lock.json`.

### Testing
- Repro steps and results (exact commands run):
  - `npm ci` — succeeded (dependencies installed).
  - `npm run build` — succeeded (Vite production build completed and `dist/index.html` created).
  - `npm run check:netlify-parity` — succeeded (script validated `netlify.toml`, ran `npm ci --no-audit`, built with `CI=true NETLIFY=true CONTEXT=production`, and verified dist artifacts).
  - `npm run check:netlify-cli-build` — succeeded (mirrored Netlify build via `netlify-cli` and produced same artifacts).
  - `npm run test:unit -- src/ui/utils/hqGameDisplay.test.js src/ui/components/__tests__/FranchiseHQ.test.jsx` — succeeded (all unit/component tests passed; helper unit coverage verifies last-game/next-opponent edge cases).
  - `npx playwright test tests/e2e/franchise_hq_mobile_smoke.spec.js` — could not run to completion in this environment due to missing Playwright browser binary.
  - `npx playwright install --with-deps chromium` — attempted but the Playwright CDN browser download was blocked by an external network policy (HTTP 403), so browser binaries were not installed here; this is an environment-level restriction and not a functional test failure in the codebase.
- Test outcomes summary: all non-browser-dependent checks passed (install, build, Netlify-parity, unit and component tests), and the Playwright smoke spec and browser install failed due to CI/environment network restrictions (403 from Playwright CDN) rather than application regression.

Remaining risk and notes:
- Playwright e2e verification requires Chromium available in CI; add `npx playwright install --with-deps chromium` as a pre-step in CI or ensure runner has Playwright browsers preinstalled to make Netlify/CI fully green.
- No hidden DOM hacks or fake labels were introduced; tests now use role/name queries and visible UI assertions to avoid brittle, non-semantic selectors.
- Core simulation/state flows were not modified; view-model extraction is pure and read-only and preserves save/load and weekly advancement behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebaae19ab4832dba0f680af0a01af7)