### PR TITLE
Harden Netlify deploy parity checks with dist rules validation

### DIFF
--- a/.github/workflows/netlify-parity.yml
+++ b/.github/workflows/netlify-parity.yml
@@ -17,8 +17,8 @@ jobs:
           node-version: 22
           cache: npm
 
-      - name: Verify netlify parity build
-        run: npm run check:netlify-parity
+      - name: Install dependencies
+        run: npm ci
 
-      - name: Mirror Netlify with netlify-cli
-        run: npm run check:netlify-cli-build
+      - name: Verify deploy parity checks
+        run: npm run check:deploy

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test:unit": "vitest run",
     "test:e2e": "playwright test",
     "check:netlify-parity": "bash scripts/netlify-parity-check.sh",
-    "check:netlify-cli-build": "npx --yes netlify-cli@latest build --context production --offline"
+    "check:netlify-cli-build": "npx --yes netlify-cli@latest build --context production --offline",
+    "check:netlify-rules": "node scripts/validate-netlify-rules.mjs",
+    "check:deploy": "npm run check:netlify-parity && npm run check:netlify-rules && npm run check:netlify-cli-build"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/netlify-parity-check.sh
+++ b/scripts/netlify-parity-check.sh
@@ -19,34 +19,45 @@ if [[ ! -f "netlify.toml" ]]; then
 fi
 
 NETLIFY_CMD="$(sed -n 's/^\s*command\s*=\s*"\(.*\)"/\1/p' netlify.toml | head -n 1)"
+NETLIFY_PUBLISH="$(sed -n 's/^\s*publish\s*=\s*"\(.*\)"/\1/p' netlify.toml | head -n 1)"
+
 if [[ -z "$NETLIFY_CMD" ]]; then
   echo "[netlify-parity] ERROR: netlify build command missing in netlify.toml"
   exit 1
 fi
 
-echo "[netlify-parity] netlify.toml build.command=$NETLIFY_CMD"
-echo "[netlify-parity] Cleaning install artifacts"
-rm -rf node_modules dist
+if [[ -z "$NETLIFY_PUBLISH" ]]; then
+  echo "[netlify-parity] ERROR: netlify publish directory missing in netlify.toml"
+  exit 1
+fi
 
-echo "[netlify-parity] Installing dependencies from package-lock.json"
-npm ci --no-audit
+echo "[netlify-parity] netlify.toml build.command=$NETLIFY_CMD"
+echo "[netlify-parity] netlify.toml build.publish=$NETLIFY_PUBLISH"
+
+if [[ ! -d "node_modules" ]]; then
+  echo "[netlify-parity] ERROR: node_modules is missing. Run 'npm ci' before this check."
+  exit 1
+fi
+
+echo "[netlify-parity] Cleaning publish directory"
+rm -rf "$NETLIFY_PUBLISH"
 
 echo "[netlify-parity] Building production bundle with Netlify-like env"
 CI=true NETLIFY=true CONTEXT=production npm run build
 
-if [[ -f "public/sw.js" && ! -f "dist/sw.js" ]]; then
-  echo "[netlify-parity] ERROR: dist/sw.js missing (public/sw.js should be copied)"
+if [[ -f "public/sw.js" && ! -f "$NETLIFY_PUBLISH/sw.js" ]]; then
+  echo "[netlify-parity] ERROR: $NETLIFY_PUBLISH/sw.js missing (public/sw.js should be copied)"
   exit 1
 fi
 
-if [[ -f "public/_headers" && ! -f "dist/_headers" ]]; then
-  echo "[netlify-parity] ERROR: dist/_headers missing (public/_headers should be copied)"
+if [[ -f "public/_headers" && ! -f "$NETLIFY_PUBLISH/_headers" ]]; then
+  echo "[netlify-parity] ERROR: $NETLIFY_PUBLISH/_headers missing (public/_headers should be copied)"
   exit 1
 fi
 
-if [[ ! -f "dist/index.html" ]]; then
-  echo "[netlify-parity] ERROR: dist/index.html missing after build"
+if [[ ! -f "$NETLIFY_PUBLISH/index.html" ]]; then
+  echo "[netlify-parity] ERROR: $NETLIFY_PUBLISH/index.html missing after build"
   exit 1
 fi
 
-echo "[netlify-parity] OK: Netlify parity build completed and dist artifacts are present"
+echo "[netlify-parity] OK: Netlify parity build completed and publish artifacts are present"

--- a/scripts/validate-netlify-rules.mjs
+++ b/scripts/validate-netlify-rules.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DIST_DIR = path.resolve(process.cwd(), 'dist');
+const headersPath = path.join(DIST_DIR, '_headers');
+const redirectsPath = path.join(DIST_DIR, '_redirects');
+
+const allowedRedirectStatus = new Set([200, 301, 302, 303, 307, 308, 404, 410, 451]);
+
+function fail(message) {
+  console.error(`[netlify-rules] ERROR: ${message}`);
+  process.exitCode = 1;
+}
+
+function readLines(filePath) {
+  return fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
+}
+
+function isCommentOrBlank(line) {
+  const trimmed = line.trim();
+  return trimmed === '' || trimmed.startsWith('#');
+}
+
+function validateHeadersFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    fail(`Missing ${path.relative(process.cwd(), filePath)} (expected after build).`);
+    return;
+  }
+
+  const lines = readLines(filePath);
+  let currentBlock = null;
+  let headerCountInBlock = 0;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const lineNo = i + 1;
+    const raw = lines[i];
+
+    if (isCommentOrBlank(raw)) {
+      continue;
+    }
+
+    const isIndented = /^\s+/.test(raw);
+    if (!isIndented) {
+      currentBlock = raw.trim();
+      headerCountInBlock = 0;
+
+      if (!currentBlock.startsWith('/')) {
+        fail(`${path.basename(filePath)}:${lineNo} path must start with '/': ${currentBlock}`);
+      }
+
+      if (/\s/.test(currentBlock)) {
+        fail(`${path.basename(filePath)}:${lineNo} path must not contain spaces: ${currentBlock}`);
+      }
+
+      continue;
+    }
+
+    if (!currentBlock) {
+      fail(`${path.basename(filePath)}:${lineNo} header appears before a path block.`);
+      continue;
+    }
+
+    const match = raw.match(/^\s+([^:\s][^:]*)\s*:\s*(.+)\s*$/);
+    if (!match) {
+      fail(`${path.basename(filePath)}:${lineNo} invalid header line: ${raw.trim()}`);
+      continue;
+    }
+
+    const headerName = match[1].trim();
+    const headerValue = match[2].trim();
+
+    if (!/^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/.test(headerName)) {
+      fail(`${path.basename(filePath)}:${lineNo} invalid header name: ${headerName}`);
+    }
+
+    if (headerValue.length === 0) {
+      fail(`${path.basename(filePath)}:${lineNo} empty value for header ${headerName}`);
+    }
+
+    headerCountInBlock += 1;
+  }
+
+  if (currentBlock && headerCountInBlock === 0) {
+    fail(`${path.basename(filePath)} final block '${currentBlock}' has no headers.`);
+  }
+}
+
+function validateRedirectsFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    console.log(`[netlify-rules] INFO: ${path.relative(process.cwd(), filePath)} not present (optional).`);
+    return;
+  }
+
+  const lines = readLines(filePath);
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const lineNo = i + 1;
+    const raw = lines[i];
+
+    if (isCommentOrBlank(raw)) {
+      continue;
+    }
+
+    if (/^\s/.test(raw)) {
+      fail(`${path.basename(filePath)}:${lineNo} redirects lines must not be indented.`);
+      continue;
+    }
+
+    const tokens = raw.trim().split(/\s+/);
+    if (tokens.length < 3) {
+      fail(`${path.basename(filePath)}:${lineNo} expected 'from to status', got: ${raw.trim()}`);
+      continue;
+    }
+
+    const [from, to, statusToken] = tokens;
+    const status = Number.parseInt(statusToken, 10);
+
+    if (!from.startsWith('/')) {
+      fail(`${path.basename(filePath)}:${lineNo} source must start with '/': ${from}`);
+    }
+
+    if (!to.startsWith('/') && !/^https?:\/\//.test(to)) {
+      fail(`${path.basename(filePath)}:${lineNo} destination must start with '/' or http(s):// : ${to}`);
+    }
+
+    if (!Number.isInteger(status) || !allowedRedirectStatus.has(status)) {
+      fail(`${path.basename(filePath)}:${lineNo} unsupported status '${statusToken}'.`);
+    }
+  }
+}
+
+function validateTomlFallback() {
+  const tomlPath = path.resolve(process.cwd(), 'netlify.toml');
+  if (!fs.existsSync(tomlPath)) {
+    fail('Missing netlify.toml.');
+    return;
+  }
+
+  const toml = fs.readFileSync(tomlPath, 'utf8');
+  const hasBuildCommand = /\[build\][\s\S]*?command\s*=\s*"[^"]+"/m.test(toml);
+  const hasPublish = /\[build\][\s\S]*?publish\s*=\s*"[^"]+"/m.test(toml);
+
+  if (!hasBuildCommand) {
+    fail('netlify.toml is missing [build].command.');
+  }
+
+  if (!hasPublish) {
+    fail('netlify.toml is missing [build].publish.');
+  }
+}
+
+validateTomlFallback();
+validateHeadersFile(headersPath);
+validateRedirectsFile(redirectsPath);
+
+if (process.exitCode) {
+  console.error('[netlify-rules] Validation failed.');
+  process.exit(process.exitCode);
+}
+
+console.log('[netlify-rules] OK: dist/_headers and dist/_redirects passed syntax validation.');


### PR DESCRIPTION
### Motivation
- Netlify deploy previews were failing despite local Vite builds passing, indicating a post-build or Netlify-processing issue (headers/redirects or publish artifact shape) that the repo's checks were not catching. 
- The goal is to map in-repo validation to Netlify deploy stages (build -> copy public files -> Netlify rules processing) so failures are reproducible and diagnostic. 
- Make CI run the same sequence Netlify uses and fail loudly on malformed `_headers`/`_redirects` or missing publish artifacts so the root cause is visible before or in CI.

### Description
- Add `scripts/validate-netlify-rules.mjs` which validates generated `dist/_headers` block/path/header syntax, validates `dist/_redirects` lines and status codes when present, and ensures `netlify.toml` contains `[build].command` and `[build].publish`. 
- Harden `scripts/netlify-parity-check.sh` to read `build.command` and `build.publish` from `netlify.toml`, require preinstalled `node_modules` (so CI must run `npm ci`), clean the publish directory, and verify publish artifacts (`index.html`, `_headers`, `sw.js` when applicable). 
- Add package scripts `check:netlify-rules` and `check:deploy` (runs parity build + rules validation + Netlify CLI build) and keep `check:netlify-cli-build`; update `package.json` accordingly. 
- Update `.github/workflows/netlify-parity.yml` to run `npm ci` and then `npm run check:deploy` so CI installs deps then runs the full, unified deploy-parity validation sequence.

### Testing
- Ran `npm ci` locally and it completed successfully. 
- Ran `npm run build` under Node 22 and the Vite production build completed successfully and produced `dist` artifacts. 
- Ran `npm run check:netlify-parity` and it passed while verifying Node 22 parity and presence of publish artifacts. 
- Ran `npm run check:netlify-rules` and it reported `dist/_redirects` as optional and validated `dist/_headers` successfully. 
- Ran `npm run check:netlify-cli-build` (Netlify CLI offline build) and it completed the Netlify build steps (packaged functions and completed build). 
- Ran `npm run check:deploy` (the combined sequence) and it completed with the above steps green; `dist/index.html` and `dist/_headers` were present and `_redirects` was absent and treated optional; the app builds cleanly under Node 22. 
- Netlify GitHub deploy-preview status is not claimed as green by this PR because external Netlify preview logs are required to confirm; this PR instead adds precise in-repo diagnostics that will surface the exact Netlify processing failure if the preview remains red after merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb89b86d4832dab5521d704d2937b)