### PR TITLE
Include Netlify deploy-preview context in parity checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "test:e2e": "playwright test",
     "check:netlify-parity": "bash scripts/netlify-parity-check.sh",
     "check:netlify-cli-build": "npx --yes netlify-cli@latest build --context production --offline",
+    "check:netlify-cli-build:preview": "npx --yes netlify-cli@latest build --context deploy-preview --offline",
     "check:netlify-rules": "node scripts/validate-netlify-rules.mjs",
-    "check:deploy": "npm run check:netlify-parity && npm run check:netlify-rules && npm run check:netlify-cli-build"
+    "check:deploy": "npm run check:netlify-parity && npm run check:netlify-rules && npm run check:netlify-cli-build && npm run check:netlify-cli-build:preview"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
### Motivation
- Netlify Deploy Preview was failing but the repo's parity checks only validated production context, so preview-specific processing needed to be reproducible in CI.

### Description
- Add `check:netlify-cli-build:preview` to run `npx netlify-cli build --context deploy-preview --offline` and update `check:deploy` to run both production and deploy-preview Netlify CLI builds after the existing parity and rules validation (`scripts/netlify-parity-check.sh` and `scripts/validate-netlify-rules.mjs`).

### Testing
- Ran `npm run check:deploy`, which runs `bash scripts/netlify-parity-check.sh`, `node scripts/validate-netlify-rules.mjs`, and both Netlify CLI builds (`--context production` and `--context deploy-preview`), and the sequence completed successfully with `_headers` validated and `dist` artifacts produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebbb04bd54832d920c2705bbad8a0e)