### PR TITLE
Fix Netlify publish-dir parsing, _headers validation, and restore deploy-preview parity on main

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "check:netlify-parity": "bash scripts/netlify-parity-check.sh",
     "check:netlify-cli-build": "npx --yes netlify-cli@latest build --context production --offline",
     "check:netlify-rules": "node scripts/validate-netlify-rules.mjs",
-    "check:deploy": "npm run check:netlify-parity && npm run check:netlify-rules && npm run check:netlify-cli-build"
+    "check:deploy": "npm run check:netlify-parity && npm run check:netlify-rules && npm run check:netlify-cli-build && npm run check:netlify-cli-build:preview",
+    "check:netlify-cli-build:preview": "npx --yes netlify-cli@latest build --context deploy-preview --offline"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/validate-netlify-rules.mjs
+++ b/scripts/validate-netlify-rules.mjs
@@ -2,19 +2,55 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const DIST_DIR = path.resolve(process.cwd(), 'dist');
-const headersPath = path.join(DIST_DIR, '_headers');
-const redirectsPath = path.join(DIST_DIR, '_redirects');
-
 const allowedRedirectStatus = new Set([200, 301, 302, 303, 307, 308, 404, 410, 451]);
 
-function fail(message) {
-  console.error(`[netlify-rules] ERROR: ${message}`);
-  process.exitCode = 1;
+function parseBuildBlock(tomlContent) {
+  const sectionMatch = tomlContent.match(/(^|\n)\[build\]\s*\n([\s\S]*?)(?=\n\s*\[[^\]]+\]\s*\n|$)/);
+  return sectionMatch ? sectionMatch[2] : null;
 }
 
-function readLines(filePath) {
-  return fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
+function parseTomlStringValue(block, key) {
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp(`^\\s*${escapedKey}\\s*=\\s*"([^"]+)"\\s*$`, 'm');
+  const match = block.match(regex);
+  return match ? match[1] : null;
+}
+
+export function resolvePublishDirectory({ repoRoot = process.cwd(), tomlPath = path.resolve(repoRoot, 'netlify.toml') } = {}) {
+  if (!fs.existsSync(tomlPath)) {
+    return { errors: ['Missing netlify.toml.'] };
+  }
+
+  const toml = fs.readFileSync(tomlPath, 'utf8');
+  const buildBlock = parseBuildBlock(toml);
+
+  if (!buildBlock) {
+    return { errors: ['netlify.toml is missing [build] section.'] };
+  }
+
+  const buildCommand = parseTomlStringValue(buildBlock, 'command');
+  const publish = parseTomlStringValue(buildBlock, 'publish');
+  const errors = [];
+
+  if (!buildCommand) {
+    errors.push('netlify.toml is missing [build].command.');
+  }
+
+  if (!publish) {
+    errors.push('netlify.toml is missing [build].publish.');
+  }
+
+  if (errors.length > 0) {
+    return { errors };
+  }
+
+  const resolvedPublishDir = path.resolve(repoRoot, publish);
+  return {
+    buildCommand,
+    publish,
+    resolvedPublishDir,
+    errors: [],
+  };
 }
 
 function isCommentOrBlank(line) {
@@ -22,15 +58,23 @@ function isCommentOrBlank(line) {
   return trimmed === '' || trimmed.startsWith('#');
 }
 
-function validateHeadersFile(filePath) {
-  if (!fs.existsSync(filePath)) {
-    fail(`Missing ${path.relative(process.cwd(), filePath)} (expected after build).`);
+function readLines(filePath) {
+  return fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
+}
+
+function validateHeaderBlock(errors, fileLabel, block, lineNo) {
+  if (!block) {
     return;
   }
 
-  const lines = readLines(filePath);
+  if (block.headerCount === 0) {
+    errors.push(`${fileLabel}:${lineNo} block '${block.path}' has no headers.`);
+  }
+}
+
+export function validateHeadersContent(lines, fileLabel = '_headers') {
+  const errors = [];
   let currentBlock = null;
-  let headerCountInBlock = 0;
 
   for (let i = 0; i < lines.length; i += 1) {
     const lineNo = i + 1;
@@ -42,28 +86,33 @@ function validateHeadersFile(filePath) {
 
     const isIndented = /^\s+/.test(raw);
     if (!isIndented) {
-      currentBlock = raw.trim();
-      headerCountInBlock = 0;
+      validateHeaderBlock(errors, fileLabel, currentBlock, lineNo - 1);
 
-      if (!currentBlock.startsWith('/')) {
-        fail(`${path.basename(filePath)}:${lineNo} path must start with '/': ${currentBlock}`);
+      const blockPath = raw.trim();
+      currentBlock = {
+        path: blockPath,
+        headerCount: 0,
+      };
+
+      if (!blockPath.startsWith('/')) {
+        errors.push(`${fileLabel}:${lineNo} path must start with '/': ${blockPath}`);
       }
 
-      if (/\s/.test(currentBlock)) {
-        fail(`${path.basename(filePath)}:${lineNo} path must not contain spaces: ${currentBlock}`);
+      if (/\s/.test(blockPath)) {
+        errors.push(`${fileLabel}:${lineNo} path must not contain spaces: ${blockPath}`);
       }
 
       continue;
     }
 
     if (!currentBlock) {
-      fail(`${path.basename(filePath)}:${lineNo} header appears before a path block.`);
+      errors.push(`${fileLabel}:${lineNo} header appears before a path block.`);
       continue;
     }
 
     const match = raw.match(/^\s+([^:\s][^:]*)\s*:\s*(.+)\s*$/);
     if (!match) {
-      fail(`${path.basename(filePath)}:${lineNo} invalid header line: ${raw.trim()}`);
+      errors.push(`${fileLabel}:${lineNo} invalid header line: ${raw.trim()}`);
       continue;
     }
 
@@ -71,28 +120,23 @@ function validateHeadersFile(filePath) {
     const headerValue = match[2].trim();
 
     if (!/^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/.test(headerName)) {
-      fail(`${path.basename(filePath)}:${lineNo} invalid header name: ${headerName}`);
+      errors.push(`${fileLabel}:${lineNo} invalid header name: ${headerName}`);
     }
 
     if (headerValue.length === 0) {
-      fail(`${path.basename(filePath)}:${lineNo} empty value for header ${headerName}`);
+      errors.push(`${fileLabel}:${lineNo} empty value for header ${headerName}`);
     }
 
-    headerCountInBlock += 1;
+    currentBlock.headerCount += 1;
   }
 
-  if (currentBlock && headerCountInBlock === 0) {
-    fail(`${path.basename(filePath)} final block '${currentBlock}' has no headers.`);
-  }
+  validateHeaderBlock(errors, fileLabel, currentBlock, lines.length);
+
+  return errors;
 }
 
-function validateRedirectsFile(filePath) {
-  if (!fs.existsSync(filePath)) {
-    console.log(`[netlify-rules] INFO: ${path.relative(process.cwd(), filePath)} not present (optional).`);
-    return;
-  }
-
-  const lines = readLines(filePath);
+export function validateRedirectsContent(lines, fileLabel = '_redirects') {
+  const errors = [];
 
   for (let i = 0; i < lines.length; i += 1) {
     const lineNo = i + 1;
@@ -103,13 +147,13 @@ function validateRedirectsFile(filePath) {
     }
 
     if (/^\s/.test(raw)) {
-      fail(`${path.basename(filePath)}:${lineNo} redirects lines must not be indented.`);
+      errors.push(`${fileLabel}:${lineNo} redirects lines must not be indented.`);
       continue;
     }
 
     const tokens = raw.trim().split(/\s+/);
     if (tokens.length < 3) {
-      fail(`${path.basename(filePath)}:${lineNo} expected 'from to status', got: ${raw.trim()}`);
+      errors.push(`${fileLabel}:${lineNo} expected 'from to status', got: ${raw.trim()}`);
       continue;
     }
 
@@ -117,46 +161,90 @@ function validateRedirectsFile(filePath) {
     const status = Number.parseInt(statusToken, 10);
 
     if (!from.startsWith('/')) {
-      fail(`${path.basename(filePath)}:${lineNo} source must start with '/': ${from}`);
+      errors.push(`${fileLabel}:${lineNo} source must start with '/': ${from}`);
     }
 
     if (!to.startsWith('/') && !/^https?:\/\//.test(to)) {
-      fail(`${path.basename(filePath)}:${lineNo} destination must start with '/' or http(s):// : ${to}`);
+      errors.push(`${fileLabel}:${lineNo} destination must start with '/' or http(s):// : ${to}`);
     }
 
     if (!Number.isInteger(status) || !allowedRedirectStatus.has(status)) {
-      fail(`${path.basename(filePath)}:${lineNo} unsupported status '${statusToken}'.`);
+      errors.push(`${fileLabel}:${lineNo} unsupported status '${statusToken}'.`);
     }
   }
+
+  return errors;
 }
 
-function validateTomlFallback() {
-  const tomlPath = path.resolve(process.cwd(), 'netlify.toml');
-  if (!fs.existsSync(tomlPath)) {
-    fail('Missing netlify.toml.');
-    return;
+export function validateNetlifyRules({ repoRoot = process.cwd() } = {}) {
+  const failures = [];
+  const publishInfo = resolvePublishDirectory({ repoRoot });
+
+  failures.push(...publishInfo.errors);
+  if (publishInfo.errors.length > 0) {
+    return { failures, publishInfo: null };
   }
 
-  const toml = fs.readFileSync(tomlPath, 'utf8');
-  const hasBuildCommand = /\[build\][\s\S]*?command\s*=\s*"[^"]+"/m.test(toml);
-  const hasPublish = /\[build\][\s\S]*?publish\s*=\s*"[^"]+"/m.test(toml);
+  const { resolvedPublishDir, publish } = publishInfo;
+  const headersPath = path.join(resolvedPublishDir, '_headers');
+  const redirectsPath = path.join(resolvedPublishDir, '_redirects');
+  const indexPath = path.join(resolvedPublishDir, 'index.html');
 
-  if (!hasBuildCommand) {
-    fail('netlify.toml is missing [build].command.');
+  if (!fs.existsSync(indexPath)) {
+    failures.push(`Missing ${path.relative(repoRoot, indexPath)} (expected after build).`);
   }
 
-  if (!hasPublish) {
-    fail('netlify.toml is missing [build].publish.');
+  if (!fs.existsSync(headersPath)) {
+    failures.push(`Missing ${path.relative(repoRoot, headersPath)} (expected after build).`);
+  } else {
+    failures.push(...validateHeadersContent(readLines(headersPath), path.basename(headersPath)));
   }
+
+  if (!fs.existsSync(redirectsPath)) {
+    // Optional in Netlify builds.
+  } else {
+    failures.push(...validateRedirectsContent(readLines(redirectsPath), path.basename(redirectsPath)));
+  }
+
+  return {
+    failures,
+    publishInfo: {
+      ...publishInfo,
+      publish,
+      headersPath,
+      redirectsPath,
+      indexPath,
+    },
+  };
 }
 
-validateTomlFallback();
-validateHeadersFile(headersPath);
-validateRedirectsFile(redirectsPath);
+function runCli() {
+  const { failures, publishInfo } = validateNetlifyRules();
 
-if (process.exitCode) {
-  console.error('[netlify-rules] Validation failed.');
-  process.exit(process.exitCode);
+  if (publishInfo) {
+    console.log(`[netlify-rules] netlify.toml build.publish='${publishInfo.publish}'`);
+    console.log(`[netlify-rules] resolved publish directory: ${publishInfo.resolvedPublishDir}`);
+    console.log(`[netlify-rules] checking ${path.relative(process.cwd(), publishInfo.indexPath)}`);
+    console.log(`[netlify-rules] checking ${path.relative(process.cwd(), publishInfo.headersPath)}`);
+
+    if (!fs.existsSync(publishInfo.redirectsPath)) {
+      console.log(`[netlify-rules] INFO: ${path.relative(process.cwd(), publishInfo.redirectsPath)} not present (optional).`);
+    } else {
+      console.log(`[netlify-rules] checking ${path.relative(process.cwd(), publishInfo.redirectsPath)}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    for (const message of failures) {
+      console.error(`[netlify-rules] ERROR: ${message}`);
+    }
+    console.error('[netlify-rules] Validation failed.');
+    process.exit(1);
+  }
+
+  console.log('[netlify-rules] OK: Netlify publish artifacts passed validation.');
 }
 
-console.log('[netlify-rules] OK: dist/_headers and dist/_redirects passed syntax validation.');
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runCli();
+}

--- a/tests/unit/validateNetlifyRules.test.js
+++ b/tests/unit/validateNetlifyRules.test.js
@@ -1,0 +1,96 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolvePublishDirectory,
+  validateHeadersContent,
+  validateRedirectsContent,
+} from '../../scripts/validate-netlify-rules.mjs';
+
+describe('validate-netlify-rules headers', () => {
+  it('accepts valid multi-block _headers', () => {
+    const lines = [
+      '/index.html',
+      '  Cache-Control: no-cache',
+      '/assets/*',
+      '  Cache-Control: public, max-age=31536000, immutable',
+    ];
+
+    expect(validateHeadersContent(lines)).toEqual([]);
+  });
+
+  it('fails when first block has no headers', () => {
+    const lines = ['/index.html', '/assets/*', '  Cache-Control: public'];
+    const errors = validateHeadersContent(lines);
+    expect(errors.some((e) => e.includes("block '/index.html' has no headers"))).toBe(true);
+  });
+
+  it('fails when middle block has no headers', () => {
+    const lines = ['/one', '  X-Test: 1', '/two', '/three', '  X-Test: 3'];
+    const errors = validateHeadersContent(lines);
+    expect(errors.some((e) => e.includes("block '/two' has no headers"))).toBe(true);
+  });
+
+  it('fails when final block has no headers', () => {
+    const lines = ['/one', '  X-Test: 1', '/two'];
+    const errors = validateHeadersContent(lines);
+    expect(errors.some((e) => e.includes("block '/two' has no headers"))).toBe(true);
+  });
+
+  it('fails when header appears before any path block', () => {
+    const lines = ['  X-Test: 1', '/one', '  X-Test: 2'];
+    const errors = validateHeadersContent(lines);
+    expect(errors.some((e) => e.includes('header appears before a path block'))).toBe(true);
+  });
+
+  it('fails on invalid header names', () => {
+    const lines = ['/one', '  Bad Header: value'];
+    const errors = validateHeadersContent(lines);
+    expect(errors.some((e) => e.includes('invalid header name'))).toBe(true);
+  });
+
+  it('fails when path does not start with slash', () => {
+    const lines = ['index.html', '  X-Test: 1'];
+    const errors = validateHeadersContent(lines);
+    expect(errors.some((e) => e.includes("path must start with '/'"))).toBe(true);
+  });
+
+  it('fails when path contains spaces', () => {
+    const lines = ['/index html', '  X-Test: 1'];
+    const errors = validateHeadersContent(lines);
+    expect(errors.some((e) => e.includes('path must not contain spaces'))).toBe(true);
+  });
+});
+
+describe('validate-netlify-rules redirects', () => {
+  it('allows valid redirects and comments', () => {
+    const lines = ['# comment', '/old /new 301', '/foo https://example.com 302'];
+    expect(validateRedirectsContent(lines)).toEqual([]);
+  });
+
+  it('fails invalid redirects syntax', () => {
+    const lines = ['  /old /new 301', 'old /new 301', '/old ftp://example.com 301', '/old /new 999', '/short /missing'];
+    const errors = validateRedirectsContent(lines);
+    expect(errors.some((e) => e.includes('must not be indented'))).toBe(true);
+    expect(errors.some((e) => e.includes("source must start with '/'"))).toBe(true);
+    expect(errors.some((e) => e.includes('destination must start'))).toBe(true);
+    expect(errors.some((e) => e.includes('unsupported status'))).toBe(true);
+    expect(errors.some((e) => e.includes("expected 'from to status'"))).toBe(true);
+  });
+});
+
+describe('resolvePublishDirectory', () => {
+  it('resolves relative publish directory from repo root', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'netlify-rules-'));
+    fs.writeFileSync(path.join(dir, 'netlify.toml'), '[build]\n  command = "npm run build"\n  publish = "dist"\n');
+
+    const result = resolvePublishDirectory({ repoRoot: dir });
+
+    expect(result.errors).toEqual([]);
+    expect(result.publish).toBe('dist');
+    expect(result.resolvedPublishDir).toBe(path.join(dir, 'dist'));
+  });
+});


### PR DESCRIPTION
### Motivation
- Netlify parity checks were unreliable because the validator hardcoded `dist` instead of reading `[build].publish` from `netlify.toml`. 
- `_headers` validation only checked the final block, letting headerless blocks (first/middle) slip through and causing deploy-time surprises. 
- `check:deploy` on `main` did not run the deploy-preview offline build, so preview parity from #1301 was missing and needed to be restored on `main`.

### Description
- Rewrote `scripts/validate-netlify-rules.mjs` to parse `netlify.toml` (read `[build].command` and `[build].publish`), resolve the publish directory from the repo root, and print the resolved publish directory for diagnostics. 
- Fixed `_headers` parsing to validate every path block (first, middle, and final) and added stricter header name/value and path checks, while keeping `_redirects` optional but validating syntax/status/destination when present. 
- Added unit tests `tests/unit/validateNetlifyRules.test.js` covering multi-block `_headers`, missing-header blocks (first/middle/final), header-before-path, invalid header names, path syntax, and `_redirects` edge cases. 
- Restored deploy-preview parity by adding `check:netlify-cli-build:preview` and updating `check:deploy` in `package.json` to run parity build, rules validation, production offline build, and deploy-preview offline build; created branch `codex/netlify-parity-main-fixes` intended to target `main` so these changes land on `main` (not a Codex feature branch).

### Testing
- Ran `npm ci` which completed successfully. 
- Ran unit tests with `npm run test:unit -- tests/unit/validateNetlifyRules.test.js` and all tests passed (`11/11`). 
- Ran the full parity flow with `npm run check:deploy` and observed: parity build succeeded, `node scripts/validate-netlify-rules.mjs` printed the resolved publish dir and passed, `npx netlify-cli build --context production --offline` succeeded, and `npx netlify-cli build --context deploy-preview --offline` succeeded. 
- Netlify status truth: repository-side parity and validator checks are green in this branch, but I do not claim the live GitHub/Netlify Deploy Preview check is green from this environment because remote check logs/status cannot be read here; please verify the PR's GitHub Checks / Netlify UI after opening this branch against `main`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc0e3ff58832d8e3e1bd5e7ecddd2)