### PR TITLE
Add Weekly Intelligence panel and actionable HQ priorities

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -89,6 +89,17 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
   }, [command.divisionMiniStandings, command.nextGame?.isHome, command.nextOpponent, command.nextOpponentRecord, command.standingSummary, lastGameDisplay.heroLine, league?.week, opponent?.abbr, userTeam?.recentResults]);
 
   const capSpace = command.teamOverview?.find((item) => item.label === 'Cap Space')?.value ?? '—';
+  const weeklyIntel = useMemo(() => command.weeklyIntelligence?.insights ?? [], [command.weeklyIntelligence?.insights]);
+  const postAdvanceNote = useMemo(() => {
+    const latestNews = (command.leagueNews ?? [])[0] ?? null;
+    const recordDelta = lastGame ? `Record now ${formatRecordInline(command.teamRecord)}` : 'Advance to generate game feedback';
+    return {
+      result: lastGameDisplay.overviewLine,
+      recordDelta,
+      nextOpponent: `${nextOpponentDisplay.isHome ? 'vs' : '@'} ${nextOpponentDisplay.opponentAbbr}`,
+      note: latestNews?.headline ?? 'No new league bulletin yet.',
+    };
+  }, [command.leagueNews, command.teamRecord, lastGame, lastGameDisplay.overviewLine, nextOpponentDisplay.isHome, nextOpponentDisplay.opponentAbbr]);
   const nextOpponents = useMemo(() => (league?.schedule?.weeks ?? [])
     .filter((week) => safeNum(week?.week, 0) >= safeNum(league?.week, 1))
     .flatMap((week) => (week?.games ?? []).map((game) => ({ ...game, week: week.week })))
@@ -168,6 +179,14 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
         <p className="app-hq-hero-footnote">Sim to Sunday • {footerDays} days until kickoff</p>
       </section>
 
+      <SectionCard title={command.weeklyIntelligence?.heading ?? 'Coordinator Brief'} subtitle="Matchup intel for this week’s decision loop." variant="compact">
+        <div className="app-hq-intel-list" role="list" aria-label="Weekly intelligence">
+          {weeklyIntel.map((insight) => (
+            <p key={insight.id} role="listitem" className={`app-hq-intel-item tone-${insight.tone ?? 'info'}`}>{insight.text}</p>
+          ))}
+        </div>
+      </SectionCard>
+
       <section className="app-section-stack" aria-label="This Week Action Center">
         <h2 className="app-section-heading">Prepare for Kickoff</h2>
         <div className="app-action-grid-2x2">
@@ -178,14 +197,16 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
       </section>
       {lineupToast ? <p className="app-inline-toast" role="status" aria-live="polite">{lineupToast}</p> : null}
 
-      <SectionCard title="Week Command" subtitle="Resolve weekly priorities before advancing." variant="compact">
+      <SectionCard title="Week Command" subtitle="What needs attention, why it matters, and where to handle it." variant="compact">
         <WeeklyAgenda items={(command.weeklyAgenda ?? []).slice(0, 3)} onOpenTask={(task) => onNavigate?.(task?.targetRoute ?? task?.tab ?? 'HQ')} />
       </SectionCard>
 
       <SectionCard title="Operations Snapshot" subtitle="Last result, standing, and upcoming slate." variant="compact">
         <div className="app-hq-team-overview">
-          <div><span>Last Game</span><strong>{lastGameDisplay.overviewLine}</strong></div>
-          <div><span>Standing</span><strong>{command.standingSummary}</strong></div>
+          <div><span>Last Game</span><strong>{postAdvanceNote.result}</strong></div>
+          <div><span>Record Update</span><strong>{postAdvanceNote.recordDelta}</strong></div>
+          <div><span>Next Opponent</span><strong>{postAdvanceNote.nextOpponent}</strong></div>
+          <div><span>News Note</span><strong>{postAdvanceNote.note}</strong></div>
           <div><span>Next 3</span><div className="app-hq-opponent-chips">{nextOpponents.length ? nextOpponents.map((chip) => <em key={chip}>{chip}</em>) : <em>No future games on file</em>}</div></div>
         </div>
       </SectionCard>

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -52,6 +52,10 @@ describe('FranchiseHQ', () => {
     expect(screen.getByRole('button', { name: /^set lineup:/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /^training:/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /^scout opponent:/i })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /coordinator brief/i })).toBeTruthy();
+    expect(screen.getAllByText(/home matchup vs det/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/ratings are tightly clustered/i)).toBeTruthy();
+    expect(screen.getByText(/open roster \/ depth/i)).toBeTruthy();
   });
 
   it('renders record, standing, and fallback copy when schedule is missing', () => {
@@ -66,6 +70,7 @@ describe('FranchiseHQ', () => {
     );
 
     expect(screen.getByText(/no completed game yet/i)).toBeTruthy();
+    expect(screen.getByText(/no opponent is locked yet/i)).toBeTruthy();
     expect(screen.getByText(/no future games on file/i)).toBeTruthy();
     expect(screen.getAllByText(/0-0 · 0 0/i).length).toBeGreaterThan(0);
   });

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -480,6 +480,10 @@
 .app-hq-opponent-chips { display: flex; gap: 6px; flex-wrap: wrap; }
 .app-hq-opponent-chips em { font-style: normal; font-size: 11px; border: 1px solid #2A3441; border-radius: 999px; padding: 3px 8px; color: #E6EDF3; background: #111722; }
 .app-hq-opponent-chips em:only-child { border-style: dashed; color: #c5d0df; }
+.app-hq-intel-list { display: grid; gap: 8px; }
+.app-hq-intel-item { margin: 0; border: 1px solid var(--hairline); border-radius: 10px; padding: 8px 10px; font-size: 12px; line-height: 1.35; color: #d9e5f7; background: color-mix(in srgb, var(--surface) 95%, black 5%); }
+.app-hq-intel-item.tone-warning { border-color: rgba(255,159,10,.45); background: rgba(255,159,10,.08); }
+.app-hq-intel-item.tone-ok { border-color: rgba(52,199,89,.45); background: rgba(52,199,89,.08); }
 .app-moment-list { margin-top: var(--space-2); display: grid; gap: var(--space-1); }
 .app-moment-list p { margin: 0; font-size: var(--text-xs); color: var(--text-muted); }
 .app-prep-checklist { display: grid; gap: var(--space-2); margin-top: var(--space-2); }
@@ -552,6 +556,7 @@
 .app-task-row__copy { display: grid; min-width: 0; }
 .app-task-row__copy strong { font-size: var(--text-sm); }
 .app-task-row__copy span { color: var(--text-muted); font-size: var(--text-xs); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.app-task-row:focus-visible { outline: 0.14rem solid #ffd166; outline-offset: 0.12rem; }
 .app-task-row__chevron { color: var(--text-subtle); font-size: 1.1rem; }
 .app-task-row.tone-warning { border-color: rgba(255, 159, 10, .45); }
 .app-task-row.tone-danger { border-color: rgba(255, 69, 58, .4); background: rgba(255, 69, 58, .02); }
@@ -583,6 +588,8 @@
 
 @media (max-width: 420px) {
   .franchise-command-center { overflow-x: clip; }
+  .app-task-row__copy span { white-space: normal; }
+  .app-hq-bottom-nav { gap: 6px; }
   .app-action-grid-2x2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .app-summary-grid { grid-template-columns: 1fr; }
   .app-hq-hero-subcards { grid-template-columns: 1fr; }

--- a/src/ui/utils/franchiseCommandCenter.js
+++ b/src/ui/utils/franchiseCommandCenter.js
@@ -7,6 +7,7 @@ import { buildCompletedGamePresentation } from './boxScoreAccess.js';
 import { getRecentGames as getArchivedRecentGames } from '../../core/archive/gameArchive.ts';
 import { logChronicleEvent, syncFranchiseChronicle } from './franchiseChronicle.js';
 import { applyEventDecision, pickWorstEventChoice, resolveWeeklyEvent } from './franchiseEvents.js';
+import { buildWeeklyIntelligence, buildActionableWeeklyPriorities } from './weeklyIntelligence.js';
 
 function safeNum(value, fallback = 0) {
   const n = Number(value);
@@ -495,7 +496,13 @@ export function selectFranchiseHQViewModel(league) {
     },
     blockers: prep?.blockers ?? [],
     actionStatuses: deriveActionStatuses(weekly, nextGame),
-    weeklyAgenda: buildWeeklyAgenda({ team, league: vm.league, weekly, prep, nextGame }),
+    weeklyIntelligence: buildWeeklyIntelligence({ league: vm.league, team, nextGame, prep }),
+    weeklyAgenda: buildActionableWeeklyPriorities({
+      team,
+      nextGame,
+      prep,
+      weeklyAgenda: buildWeeklyAgenda({ team, league: vm.league, weekly, prep, nextGame }),
+    }),
     lastGameSummary: latestArchived ?? fallbackLastGame,
     standingSummary: `${formatRecord(team)} · ${team?.conf ?? ''} ${team?.div ?? ''}`.trim(),
     latestArchived,

--- a/src/ui/utils/weeklyIntelligence.js
+++ b/src/ui/utils/weeklyIntelligence.js
@@ -1,0 +1,158 @@
+function safeNum(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function formatRecord(team) {
+  if (!team) return '—';
+  const ties = safeNum(team?.ties, 0);
+  return `${safeNum(team?.wins, 0)}-${safeNum(team?.losses, 0)}${ties ? `-${ties}` : ''}`;
+}
+
+function lastResult(team) {
+  const recent = Array.isArray(team?.recentResults) ? team.recentResults : [];
+  const latest = String(recent[recent.length - 1] ?? '').toUpperCase();
+  if (latest === 'W') return 'Won last week';
+  if (latest === 'L') return 'Lost last week';
+  if (latest === 'T') return 'Tied last week';
+  return null;
+}
+
+function routeLabel(route) {
+  if (!route) return 'HQ';
+  if (route.includes('Depth')) return 'Roster / Depth';
+  if (route.includes('Game Plan')) return 'Game Plan';
+  if (route.includes('Training')) return 'Training';
+  if (route.includes('Weekly Prep')) return 'Weekly Prep';
+  if (route.includes('Injur')) return 'Injuries';
+  return route;
+}
+
+export function buildWeeklyIntelligence({ league, team, nextGame, prep }) {
+  const opponent = nextGame?.opp ?? null;
+  if (!team || !opponent) {
+    return {
+      heading: 'Coordinator Brief',
+      insights: [{ id: 'intel-fallback', tone: 'info', text: 'No opponent is locked yet. Review lineup, training, and game plan readiness before advancing.' }],
+    };
+  }
+
+  const insights = [];
+  const userOff = safeNum(team?.offenseRating ?? team?.offRating ?? team?.offense, null);
+  const userDef = safeNum(team?.defenseRating ?? team?.defRating ?? team?.defense, null);
+  const oppOff = safeNum(opponent?.offenseRating ?? opponent?.offRating ?? opponent?.offense, null);
+  const oppDef = safeNum(opponent?.defenseRating ?? opponent?.defRating ?? opponent?.defense, null);
+
+  insights.push({
+    id: 'intel-record',
+    tone: 'info',
+    text: `${nextGame?.isHome ? 'Home' : 'Road'} matchup vs ${opponent?.abbr ?? opponent?.name ?? 'TBD'} (${formatRecord(opponent)}).`,
+  });
+
+  if (Number.isFinite(userOff) && Number.isFinite(oppDef)) {
+    if (userOff >= oppDef + 4) insights.push({ id: 'intel-off-edge', tone: 'ok', text: `Your offense has the edge (${userOff} vs ${oppDef}). Prioritize passing efficiency and tempo control.` });
+    else if (oppDef >= userOff + 4) insights.push({ id: 'intel-off-risk', tone: 'warning', text: `Their defense has the edge (${oppDef} vs ${userOff}). Protect possessions and avoid long-yardage situations.` });
+  }
+
+  if (Number.isFinite(userDef) && Number.isFinite(oppOff)) {
+    if (userDef >= oppOff + 4) insights.push({ id: 'intel-def-edge', tone: 'ok', text: `Your defense has a matchup advantage (${userDef} vs ${oppOff}). Aggressive coverage can force mistakes.` });
+    else if (oppOff >= userDef + 4) insights.push({ id: 'intel-def-risk', tone: 'warning', text: `Opponent offense is the pressure point (${oppOff} vs ${userDef}). Keep explosive plays contained.` });
+  }
+
+  if (insights.length < 3) {
+    insights.push({ id: 'intel-ratings-fallback', tone: 'info', text: 'Ratings are tightly clustered this week. Situational execution should decide the matchup.' });
+  }
+
+  const oppForm = prep?.opponentSnapshot?.recentForm?.summary;
+  if (oppForm) {
+    insights.push({ id: 'intel-form', tone: 'info', text: `${opponent?.abbr ?? opponent?.name ?? 'Opponent'} form: ${oppForm}.` });
+  } else {
+    const note = lastResult(opponent);
+    if (note) insights.push({ id: 'intel-last-result', tone: 'info', text: `${opponent?.abbr ?? opponent?.name ?? 'Opponent'} ${note.toLowerCase()}.` });
+  }
+
+  const injuries = safeNum(prep?.lineupIssues?.filter((issue) => String(issue?.label ?? '').toLowerCase().includes('injur')).length, 0);
+  if (injuries > 0) {
+    insights.push({ id: 'intel-injuries', tone: injuries >= 2 ? 'warning' : 'info', text: `${injuries} injury-related lineup concern${injuries > 1 ? 's' : ''} flagged for this week.` });
+  }
+
+  const week = safeNum(league?.week, 1);
+  if (week >= 10) {
+    insights.push({ id: 'intel-implication', tone: 'warning', text: 'Late-season standings pressure: this week can shift playoff position.' });
+  }
+
+  return {
+    heading: 'Coordinator Brief',
+    insights: insights.slice(0, 5),
+  };
+}
+
+export function buildActionableWeeklyPriorities({ team, nextGame, prep, weeklyAgenda = [] }) {
+  const lineupWarnings = safeNum(team?.depthChartWarnings?.missingStarters ?? team?.missingStarters ?? prep?.lineupIssues?.length, 0);
+  const opp = nextGame?.opp;
+  const oppDef = safeNum(opp?.defenseRating ?? opp?.defRating ?? opp?.defense, null);
+  const oppOff = safeNum(opp?.offenseRating ?? opp?.offRating ?? opp?.offense, null);
+
+  const base = [
+    {
+      id: 'priority-lineup',
+      icon: '🧩',
+      title: 'Set Lineup',
+      description: lineupWarnings > 0
+        ? `${lineupWarnings} depth chart warning${lineupWarnings > 1 ? 's could' : ' could'} affect sim performance.`
+        : 'Confirm starters before kickoff to avoid hidden mismatch penalties.',
+      severity: lineupWarnings > 1 ? 'warning' : 'info',
+      ctaLabel: 'Open Roster / Depth',
+      targetRoute: 'Team:Roster / Depth',
+    },
+    {
+      id: 'priority-training',
+      icon: '🎯',
+      title: 'Training',
+      description: 'Allocate reps before kickoff to influence player growth and readiness.',
+      severity: 'info',
+      ctaLabel: 'Open Training',
+      targetRoute: 'Training',
+    },
+    {
+      id: 'priority-game-plan',
+      icon: '📋',
+      title: 'Game Plan',
+      description: Number.isFinite(oppDef)
+        ? `Opponent defense rates ${oppDef}. Tune your offensive approach before advance.`
+        : 'Review your offensive and defensive approach before kickoff.',
+      severity: Number.isFinite(oppOff) && Number.isFinite(safeNum(team?.defenseRating ?? team?.defRating ?? team?.defense, null)) && oppOff >= safeNum(team?.defenseRating ?? team?.defRating ?? team?.defense, 0) + 4 ? 'warning' : 'info',
+      ctaLabel: 'Open Game Plan',
+      targetRoute: 'Game Plan',
+    },
+    {
+      id: 'priority-scout',
+      icon: '🔎',
+      title: 'Scout Opponent',
+      description: opp ? `Review the ${opp?.abbr ?? opp?.name} matchup report before advancing.` : 'Review the upcoming matchup report before advancing.',
+      severity: 'info',
+      ctaLabel: 'Open Weekly Prep',
+      targetRoute: 'Weekly Prep',
+    },
+  ];
+
+  const merged = [...base, ...weeklyAgenda]
+    .map((item, index) => ({
+      ...item,
+      id: item?.id ?? `agenda-${index}`,
+      ctaLabel: item?.ctaLabel || `Open ${routeLabel(item?.targetRoute ?? item?.tab)}`,
+      description: item?.description ?? item?.detail ?? 'Review this weekly item before simming forward.',
+      targetRoute: item?.targetRoute ?? item?.tab ?? 'HQ',
+    }));
+
+  const deduped = [];
+  const seen = new Set();
+  for (const item of merged) {
+    const key = String(item?.title ?? '').toLowerCase();
+    if (!item?.title || seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(item);
+  }
+
+  return deduped.slice(0, 5);
+}

--- a/src/ui/utils/weeklyIntelligence.test.js
+++ b/src/ui/utils/weeklyIntelligence.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { buildActionableWeeklyPriorities, buildWeeklyIntelligence } from './weeklyIntelligence.js';
+
+const team = { id: 1, abbr: 'CHI', wins: 6, losses: 3, ties: 0, offenseRating: 80, defenseRating: 87 };
+const opponent = { id: 2, abbr: 'DET', wins: 7, losses: 2, ties: 0, offenseRating: 88, defenseRating: 74 };
+
+describe('buildWeeklyIntelligence', () => {
+  it('adds offensive-risk insight when opponent offense is stronger', () => {
+    const intel = buildWeeklyIntelligence({
+      league: { week: 8 },
+      team,
+      nextGame: { isHome: true, opp: { ...opponent, defenseRating: 90, offenseRating: 92 } },
+      prep: { lineupIssues: [] },
+    });
+    expect(intel.insights.some((item) => item.text.includes('Opponent offense is the pressure point'))).toBe(true);
+  });
+
+  it('adds defensive edge insight when user defense is stronger', () => {
+    const intel = buildWeeklyIntelligence({
+      league: { week: 8 },
+      team,
+      nextGame: { isHome: false, opp: { ...opponent, offenseRating: 80 } },
+      prep: { lineupIssues: [] },
+    });
+    expect(intel.insights.some((item) => item.text.includes('Your defense has a matchup advantage'))).toBe(true);
+  });
+
+  it('returns tasteful fallback when opponent is missing', () => {
+    const intel = buildWeeklyIntelligence({ league: { week: 3 }, team, nextGame: null, prep: {} });
+    expect(intel.insights).toHaveLength(1);
+    expect(intel.insights[0].text).toMatch(/No opponent is locked yet/i);
+  });
+
+  it('uses ratings fallback when ratings are unavailable', () => {
+    const intel = buildWeeklyIntelligence({
+      league: { week: 3 },
+      team: { id: 1, abbr: 'CHI', wins: 1, losses: 1 },
+      nextGame: { isHome: true, opp: { id: 2, abbr: 'DET', wins: 1, losses: 1 } },
+      prep: { lineupIssues: [] },
+    });
+    expect(intel.insights.some((item) => item.id === 'intel-ratings-fallback')).toBe(true);
+  });
+});
+
+describe('buildActionableWeeklyPriorities', () => {
+  it('generates agenda reasons from real state', () => {
+    const priorities = buildActionableWeeklyPriorities({
+      team: { ...team, depthChartWarnings: { missingStarters: 2 } },
+      nextGame: { opp: opponent },
+      prep: { lineupIssues: [{ id: 'x' }] },
+      weeklyAgenda: [{ id: 'ext1', title: 'Cap check', detail: 'Review cap', tab: 'Financials' }],
+    });
+    expect(priorities[0].title).toBe('Set Lineup');
+    expect(priorities[0].description).toContain('2 depth chart warnings');
+    expect(priorities.some((item) => item.title === 'Game Plan')).toBe(true);
+    expect(priorities.some((item) => item.ctaLabel.startsWith('Open'))).toBe(true);
+  });
+});

--- a/tests/e2e/franchise_hq_mobile_smoke.spec.js
+++ b/tests/e2e/franchise_hq_mobile_smoke.spec.js
@@ -12,6 +12,7 @@ for (const viewport of [
 
     await expect(page.getByText(/Week\s+\d+/i).first()).toBeVisible({ timeout: 60000 });
     await expect(page.getByText(/Last Result/i).first()).toBeVisible();
+    await expect(page.getByText(/Coordinator Brief|Weekly Intelligence|Opponent Intel/i).first()).toBeVisible();
     await expect(page.getByRole('button', { name: /Advance Week/i })).toBeVisible();
 
     for (const label of ['Game Plan', 'Set Lineup', 'Training', 'Scout Opponent']) {


### PR DESCRIPTION
### Motivation
- Make Franchise HQ feel like a real weekly football GM decision loop by surfacing opponent intel, matchup story, clear recommended actions, and compact post-advance feedback without changing simulation outcomes or navigation flows.

### Description
- Add a pure helper `buildWeeklyIntelligence` and `buildActionableWeeklyPriorities` in `src/ui/utils/weeklyIntelligence.js` to derive matchup insights and explicit actionable priorities from real league/team/opponent data. 
- Wire the helpers into the HQ view model in `src/ui/utils/franchiseCommandCenter.js` so `selectFranchiseHQViewModel` now provides `weeklyIntelligence` and an improved `weeklyAgenda` derived from existing data. 
- Render the new Coordinator Brief (Weekly Intelligence) section, strengthen Week Command copy, and add a compact post-advance snapshot in `src/ui/components/FranchiseHQ.jsx`, keeping the single dominant Advance Week CTA and existing navigation targets. 
- Add mobile-first UI polish and focus/overflow/accessibility improvements in `src/ui/styles/screen-system.css`, and add unit/component tests in `src/ui/utils/weeklyIntelligence.test.js` and `src/ui/components/__tests__/FranchiseHQ.test.jsx`, plus an updated E2E smoke expectation in `tests/e2e/franchise_hq_mobile_smoke.spec.js`.

### Testing
- Ran `npm ci` successfully and built the production bundle with `npm run build` successfully. 
- Ran full deploy parity and Netlify CLI preview checks with `npm run check:deploy`, and the parity/Netlify build validations completed OK. 
- Ran targeted unit/component tests (`vitest` for `weeklyIntelligence` and updated `FranchiseHQ` tests) and they passed; the broader `npm run test:unit` run showed two unrelated existing label-copy expectation failures in `TeamHub.test.jsx` and `NewsFeed.test.jsx` that are not caused by these changes. 
- Attempted Playwright E2E mobile smoke, but browser binaries were not installed in this environment so Playwright runs failed with a missing browser executable; CI should run `npx playwright install` (or use hosted runners) to validate the E2E step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebcd59fa38832d8897f142a638bf5b)