### PR TITLE
Add Weekly Game Plan Impact loop to Franchise HQ

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -90,16 +90,22 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
 
   const capSpace = command.teamOverview?.find((item) => item.label === 'Cap Space')?.value ?? '—';
   const weeklyIntel = useMemo(() => command.weeklyIntelligence?.insights ?? [], [command.weeklyIntelligence?.insights]);
+  const gamePlanImpactCards = useMemo(() => command.gamePlanImpact?.recommendedAdjustments ?? [], [command.gamePlanImpact?.recommendedAdjustments]);
   const postAdvanceNote = useMemo(() => {
-    const latestNews = (command.leagueNews ?? [])[0] ?? null;
+    const review = command.postGameReview ?? null;
     const recordDelta = lastGame ? `Record now ${formatRecordInline(command.teamRecord)}` : 'Advance to generate game feedback';
     return {
-      result: lastGameDisplay.overviewLine,
+      heading: review?.heading ?? 'Review Last Week',
+      result: review?.result ?? lastGameDisplay.overviewLine,
+      takeaway: review?.takeaway ?? 'Result recorded. Open box score for full drive details.',
+      nextAction: review?.nextAction ?? "Tune this week's prep before advancing again.",
       recordDelta,
       nextOpponent: `${nextOpponentDisplay.isHome ? 'vs' : '@'} ${nextOpponentDisplay.opponentAbbr}`,
-      note: latestNews?.headline ?? 'No new league bulletin yet.',
+      note: review?.newsNote ?? (command.leagueNews ?? [])[0]?.headline ?? 'No new league bulletin yet.',
+      actions: Array.isArray(review?.actions) ? review.actions : [],
     };
-  }, [command.leagueNews, command.teamRecord, lastGame, lastGameDisplay.overviewLine, nextOpponentDisplay.isHome, nextOpponentDisplay.opponentAbbr]);
+  }, [command.leagueNews, command.postGameReview, command.teamRecord, lastGame, lastGameDisplay.overviewLine, nextOpponentDisplay.isHome, nextOpponentDisplay.opponentAbbr]);
+
   const nextOpponents = useMemo(() => (league?.schedule?.weeks ?? [])
     .filter((week) => safeNum(week?.week, 0) >= safeNum(league?.week, 1))
     .flatMap((week) => (week?.games ?? []).map((game) => ({ ...game, week: week.week })))
@@ -187,6 +193,23 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
         </div>
       </SectionCard>
 
+      <SectionCard title={command.gamePlanImpact?.heading ?? 'Game Plan Impact'} subtitle={command.gamePlanImpact?.summary ?? 'Translate coordinator intel into fast football actions.'} variant="compact">
+        <div className="app-hq-impact-list" role="list" aria-label="Game plan impact recommendations">
+          {gamePlanImpactCards.map((item) => (
+            <article key={item.id} role="listitem" className={`app-hq-impact-card tone-${item.tag?.tone ?? 'info'}`}>
+              <div className="app-hq-impact-card__head">
+                <strong>{item.title}</strong>
+                <StatusChip label={item.tag?.label ?? `${item.confidenceLevel ?? 'medium'} confidence`} tone={item.tag?.tone ?? 'warning'} />
+              </div>
+              <p>{item.explanation}</p>
+              <button type="button" className="btn btn-sm app-hq-impact-card__cta" onClick={() => onNavigate?.(item.targetRoute)} aria-label={`${item.title}: ${item.ctaLabel}`}>
+                {item.ctaLabel}
+              </button>
+            </article>
+          ))}
+        </div>
+      </SectionCard>
+
       <section className="app-section-stack" aria-label="This Week Action Center">
         <h2 className="app-section-heading">Prepare for Kickoff</h2>
         <div className="app-action-grid-2x2">
@@ -203,10 +226,13 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
 
       <SectionCard title="Operations Snapshot" subtitle="Last result, standing, and upcoming slate." variant="compact">
         <div className="app-hq-team-overview">
-          <div><span>Last Game</span><strong>{postAdvanceNote.result}</strong></div>
+          <div><span>{postAdvanceNote.heading}</span><strong>{postAdvanceNote.result}</strong></div>
+          <div><span>Key Takeaway</span><strong>{postAdvanceNote.takeaway}</strong></div>
+          <div><span>Next Action</span><strong>{postAdvanceNote.nextAction}</strong></div>
           <div><span>Record Update</span><strong>{postAdvanceNote.recordDelta}</strong></div>
           <div><span>Next Opponent</span><strong>{postAdvanceNote.nextOpponent}</strong></div>
           <div><span>News Note</span><strong>{postAdvanceNote.note}</strong></div>
+          <div><span>Review Routes</span><div className="app-hq-opponent-chips">{postAdvanceNote.actions.length ? postAdvanceNote.actions.map((action) => <button key={action.targetRoute} type="button" onClick={() => onNavigate?.(action.targetRoute)}>{action.label}</button>) : <em>No review actions</em>}</div></div>
           <div><span>Next 3</span><div className="app-hq-opponent-chips">{nextOpponents.length ? nextOpponents.map((chip) => <em key={chip}>{chip}</em>) : <em>No future games on file</em>}</div></div>
         </div>
       </SectionCard>

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import FranchiseHQ from '../FranchiseHQ.jsx';
 
 const baseLeague = {
@@ -53,9 +53,21 @@ describe('FranchiseHQ', () => {
     expect(screen.getByRole('button', { name: /^training:/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /^scout opponent:/i })).toBeTruthy();
     expect(screen.getByRole('heading', { name: /coordinator brief/i })).toBeTruthy();
+    expect(screen.getAllByRole('heading', { name: /game plan impact/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/home matchup vs det/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/ratings are tightly clustered/i)).toBeTruthy();
     expect(screen.getByText(/open roster \/ depth/i)).toBeTruthy();
+  });
+
+  it('routes Game Plan Impact and review CTAs through onNavigate', () => {
+    const onNavigate = vi.fn();
+    const view = render(<FranchiseHQ league={baseLeague} onNavigate={onNavigate} onAdvanceWeek={() => {}} busy={false} simulating={false} />);
+
+    fireEvent.click(within(view.container).getAllByRole('button', { name: /attack plan: tune game plan/i })[0]);
+    fireEvent.click(within(view.container).getAllByRole('button', { name: /open weekly results/i })[0]);
+
+    expect(onNavigate).toHaveBeenCalledWith('Game Plan');
+    expect(onNavigate).toHaveBeenCalledWith('Weekly Results');
   });
 
   it('renders record, standing, and fallback copy when schedule is missing', () => {
@@ -71,6 +83,7 @@ describe('FranchiseHQ', () => {
 
     expect(screen.getByText(/no completed game yet/i)).toBeTruthy();
     expect(screen.getByText(/no opponent is locked yet/i)).toBeTruthy();
+    expect(screen.getAllByRole('heading', { name: /game plan impact/i }).length).toBeGreaterThan(0);
     expect(screen.getByText(/no future games on file/i)).toBeTruthy();
     expect(screen.getAllByText(/0-0 · 0 0/i).length).toBeGreaterThan(0);
   });

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -478,12 +478,24 @@
 .app-hq-team-overview span { font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: #8B9BB0; }
 .app-hq-team-overview strong { color: #E6EDF3; font-size: 14px; font-weight: 600; }
 .app-hq-opponent-chips { display: flex; gap: 6px; flex-wrap: wrap; }
-.app-hq-opponent-chips em { font-style: normal; font-size: 11px; border: 1px solid #2A3441; border-radius: 999px; padding: 3px 8px; color: #E6EDF3; background: #111722; }
+.app-hq-opponent-chips em,
+.app-hq-opponent-chips button { font-style: normal; font-size: 11px; border: 1px solid #2A3441; border-radius: 999px; padding: 3px 8px; color: #E6EDF3; background: #111722; }
+.app-hq-opponent-chips button { cursor: pointer; min-height: 30px; }
+.app-hq-opponent-chips button:focus-visible { outline: 2px solid #ffd166; outline-offset: 2px; }
 .app-hq-opponent-chips em:only-child { border-style: dashed; color: #c5d0df; }
 .app-hq-intel-list { display: grid; gap: 8px; }
 .app-hq-intel-item { margin: 0; border: 1px solid var(--hairline); border-radius: 10px; padding: 8px 10px; font-size: 12px; line-height: 1.35; color: #d9e5f7; background: color-mix(in srgb, var(--surface) 95%, black 5%); }
 .app-hq-intel-item.tone-warning { border-color: rgba(255,159,10,.45); background: rgba(255,159,10,.08); }
 .app-hq-intel-item.tone-ok { border-color: rgba(52,199,89,.45); background: rgba(52,199,89,.08); }
+.app-hq-impact-list { display: grid; gap: 8px; }
+.app-hq-impact-card { border: 1px solid var(--hairline); border-radius: 10px; padding: 9px 10px; background: color-mix(in srgb, var(--surface) 95%, black 5%); display: grid; gap: 8px; }
+.app-hq-impact-card__head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.app-hq-impact-card__head strong { color: #e6edf3; font-size: 12px; letter-spacing: .02em; }
+.app-hq-impact-card p { margin: 0; font-size: 12px; line-height: 1.35; color: #c9d8ed; }
+.app-hq-impact-card .app-status-chip { font-size: 10px; }
+.app-hq-impact-card__cta { justify-self: start; min-height: 34px; }
+.app-hq-impact-card.tone-warning { border-color: rgba(255,159,10,.45); background: rgba(255,159,10,.08); }
+.app-hq-impact-card.tone-ok { border-color: rgba(52,199,89,.45); background: rgba(52,199,89,.08); }
 .app-moment-list { margin-top: var(--space-2); display: grid; gap: var(--space-1); }
 .app-moment-list p { margin: 0; font-size: var(--text-xs); color: var(--text-muted); }
 .app-prep-checklist { display: grid; gap: var(--space-2); margin-top: var(--space-2); }
@@ -592,6 +604,8 @@
   .app-hq-bottom-nav { gap: 6px; }
   .app-action-grid-2x2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .app-summary-grid { grid-template-columns: 1fr; }
+  .app-hq-impact-card__head { align-items: flex-start; flex-direction: column; }
+  .app-hq-impact-card__cta { width: 100%; }
   .app-hq-hero-subcards { grid-template-columns: 1fr; }
   .app-hq-matchup-main { grid-template-columns: 1fr; justify-items: start; min-height: auto; gap: 0.75rem; }
   .app-hq-team--opp { width: 100%; justify-items: start; text-align: left; }

--- a/src/ui/utils/franchiseCommandCenter.js
+++ b/src/ui/utils/franchiseCommandCenter.js
@@ -8,6 +8,7 @@ import { getRecentGames as getArchivedRecentGames } from '../../core/archive/gam
 import { logChronicleEvent, syncFranchiseChronicle } from './franchiseChronicle.js';
 import { applyEventDecision, pickWorstEventChoice, resolveWeeklyEvent } from './franchiseEvents.js';
 import { buildWeeklyIntelligence, buildActionableWeeklyPriorities } from './weeklyIntelligence.js';
+import { buildGamePlanImpact, buildPostGameReview } from './gamePlanImpact.js';
 
 function safeNum(value, fallback = 0) {
   const n = Number(value);
@@ -470,6 +471,12 @@ export function selectFranchiseHQViewModel(league) {
     .slice(0, 2);
   const queuedEvent = maybeQueueWeeklyEvent(vm.league);
   const story = syncFranchiseChronicle(vm.league);
+  const gamePlanImpact = buildGamePlanImpact({ league: vm.league, team, nextGame, prep });
+  const postGameReview = buildPostGameReview({
+    lastGame: latestArchived ?? fallbackLastGame,
+    userTeamId: vm.league?.userTeamId,
+    latestNews: leagueNews?.[0] ?? null,
+  });
   const injuredSpotlight = (team?.roster ?? [])
     .filter((player) => safeNum(player?.injuryWeeksRemaining ?? player?.injuredWeeks ?? player?.injury?.gamesRemaining ?? 0) > 0)
     .sort((a, b) => safeNum(b?.ovr) - safeNum(a?.ovr))[0] ?? null;
@@ -497,6 +504,10 @@ export function selectFranchiseHQViewModel(league) {
     blockers: prep?.blockers ?? [],
     actionStatuses: deriveActionStatuses(weekly, nextGame),
     weeklyIntelligence: buildWeeklyIntelligence({ league: vm.league, team, nextGame, prep }),
+    gamePlanImpact,
+    recommendedAdjustments: gamePlanImpact.recommendedAdjustments,
+    postGameReview,
+    advanceFeedback: postGameReview,
     weeklyAgenda: buildActionableWeeklyPriorities({
       team,
       nextGame,

--- a/src/ui/utils/gamePlanImpact.js
+++ b/src/ui/utils/gamePlanImpact.js
@@ -1,0 +1,224 @@
+function safeNum(value, fallback = null) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function readRating(team, type) {
+  if (!team || typeof team !== 'object') return null;
+  if (type === 'offense') return safeNum(team?.offenseRating ?? team?.offRating ?? team?.offense ?? team?.offOvr, null);
+  if (type === 'defense') return safeNum(team?.defenseRating ?? team?.defRating ?? team?.defense ?? team?.defOvr, null);
+  return safeNum(team?.ovr, null);
+}
+
+function countLineupRisk({ team, prep }) {
+  const prepIssues = Array.isArray(prep?.lineupIssues) ? prep.lineupIssues : [];
+  const injuryIssues = prepIssues.filter((issue) => String(issue?.label ?? issue?.detail ?? '').toLowerCase().includes('injur')).length;
+  const missingStarters = safeNum(team?.depthChartWarnings?.missingStarters ?? team?.missingStarters, 0) ?? 0;
+  const rosterInjuries = Array.isArray(team?.roster)
+    ? team.roster.filter((player) => safeNum(player?.injuryWeeksRemaining ?? player?.injuredWeeks ?? player?.injury?.gamesRemaining, 0) > 0).length
+    : 0;
+  return Math.max(injuryIssues, missingStarters, rosterInjuries > 0 ? Math.min(2, rosterInjuries) : 0);
+}
+
+function buildRatingDeltaSummary(delta, strongerLabel, weakerLabel) {
+  const gap = Math.abs(delta);
+  if (gap < 3) return `${strongerLabel} and ${weakerLabel} are tightly matched.`;
+  if (gap < 7) return `${strongerLabel} has a slight edge.`;
+  return `${strongerLabel} has a clear ratings edge.`;
+}
+
+function toTag(riskLevel, confidenceLevel) {
+  if (riskLevel === 'high') return { tone: 'warning', label: `High risk · ${confidenceLevel} confidence` };
+  if (riskLevel === 'medium') return { tone: 'warning', label: `Manage risk · ${confidenceLevel} confidence` };
+  return { tone: 'ok', label: `${confidenceLevel} confidence` };
+}
+
+export function buildGamePlanImpact({ league, team, nextGame, prep }) {
+  const opponent = nextGame?.opp ?? null;
+  const week = safeNum(league?.week, 1) ?? 1;
+  if (!team || !opponent) {
+    return {
+      heading: 'Game Plan Impact',
+      summary: 'No matchup lock yet. Keep the roster and plan board ready before advancing.',
+      pressurePoint: 'Matchup awaiting opponent assignment.',
+      riskLevel: 'medium',
+      confidenceLevel: 'low',
+      recommendedAdjustments: [
+        {
+          id: 'impact-fallback-plan',
+          title: 'Attack Plan',
+          explanation: 'No opponent data yet. Confirm your base game plan and avoid empty prep steps.',
+          riskLevel: 'medium',
+          confidenceLevel: 'low',
+          targetRoute: 'Game Plan',
+          ctaLabel: 'Tune Game Plan',
+          tag: toTag('medium', 'low'),
+        },
+        {
+          id: 'impact-fallback-lineup',
+          title: 'Lineup Risk',
+          explanation: 'Lock starters and depth assignments now so sim penalties do not surprise you.',
+          riskLevel: 'medium',
+          confidenceLevel: 'medium',
+          targetRoute: 'Team:Roster / Depth',
+          ctaLabel: 'Set Lineup',
+          tag: toTag('medium', 'medium'),
+        },
+      ],
+    };
+  }
+
+  const userOff = readRating(team, 'offense');
+  const userDef = readRating(team, 'defense');
+  const oppOff = readRating(opponent, 'offense');
+  const oppDef = readRating(opponent, 'defense');
+
+  const offDelta = Number.isFinite(userOff) && Number.isFinite(oppDef) ? userOff - oppDef : null;
+  const defDelta = Number.isFinite(userDef) && Number.isFinite(oppOff) ? userDef - oppOff : null;
+  const lineupRisk = countLineupRisk({ team, prep });
+  const playoffPressure = week >= 12;
+
+  const offensiveAdjustment = {
+    id: 'impact-attack',
+    title: 'Attack Plan',
+    explanation: 'Ratings are tight. Stay on schedule and avoid empty possessions.',
+    riskLevel: 'medium',
+    confidenceLevel: 'medium',
+    targetRoute: 'Game Plan',
+    ctaLabel: 'Tune Game Plan',
+  };
+  if (Number.isFinite(offDelta)) {
+    if (offDelta <= -4) {
+      offensiveAdjustment.explanation = `Their defense has the edge (${oppDef} vs ${userOff}). Shorten the passing game and avoid long-yardage downs.`;
+      offensiveAdjustment.riskLevel = 'high';
+      offensiveAdjustment.confidenceLevel = 'high';
+    } else if (offDelta >= 4) {
+      offensiveAdjustment.explanation = `Your offense has the edge (${userOff} vs ${oppDef}). Lean into tempo and scripted early throws.`;
+      offensiveAdjustment.riskLevel = 'low';
+      offensiveAdjustment.confidenceLevel = 'high';
+    } else {
+      offensiveAdjustment.explanation = buildRatingDeltaSummary(offDelta, 'Their defense', 'your offense');
+    }
+  }
+
+  const defensiveAdjustment = {
+    id: 'impact-defense',
+    title: 'Defensive Priority',
+    explanation: 'Force long drives and keep field position clean.',
+    riskLevel: 'medium',
+    confidenceLevel: 'medium',
+    targetRoute: 'Weekly Prep',
+    ctaLabel: 'Scout Opponent',
+  };
+  if (Number.isFinite(defDelta)) {
+    if (defDelta <= -4) {
+      defensiveAdjustment.explanation = `Opponent offense is the pressure point (${oppOff} vs ${userDef}). Limit explosives and protect field position.`;
+      defensiveAdjustment.riskLevel = 'high';
+      defensiveAdjustment.confidenceLevel = 'high';
+      defensiveAdjustment.targetRoute = 'Game Plan';
+      defensiveAdjustment.ctaLabel = 'Adjust Defense';
+    } else if (defDelta >= 4) {
+      defensiveAdjustment.explanation = `Your defense has a ratings edge (${userDef} vs ${oppOff}). Consider more aggressive coverage.`;
+      defensiveAdjustment.riskLevel = 'low';
+      defensiveAdjustment.confidenceLevel = 'high';
+      defensiveAdjustment.targetRoute = 'Game Plan';
+      defensiveAdjustment.ctaLabel = 'Set Coverage';
+    } else {
+      defensiveAdjustment.explanation = buildRatingDeltaSummary(defDelta, 'Your defense', 'their offense');
+    }
+  }
+
+  const adjustments = [offensiveAdjustment, defensiveAdjustment];
+
+  if (lineupRisk > 0) {
+    adjustments.push({
+      id: 'impact-lineup',
+      title: 'Lineup Risk',
+      explanation: lineupRisk > 1
+        ? 'Injuries are affecting starter depth. Confirm replacements before kickoff.'
+        : 'Starter availability shifted this week. Verify depth chart replacements.',
+      riskLevel: lineupRisk > 1 ? 'high' : 'medium',
+      confidenceLevel: 'medium',
+      targetRoute: 'Team:Roster / Depth',
+      ctaLabel: 'Set Lineup',
+    });
+  }
+
+  if (playoffPressure && adjustments.length < 3) {
+    adjustments.push({
+      id: 'impact-late-season',
+      title: 'Late-Season Pressure',
+      explanation: 'Standings leverage is rising. Finish prep before advancing so this week does not swing your race.',
+      riskLevel: 'medium',
+      confidenceLevel: 'medium',
+      targetRoute: 'Weekly Prep',
+      ctaLabel: 'Finish Weekly Prep',
+    });
+  }
+
+  const enriched = adjustments.slice(0, 3).map((item) => ({ ...item, tag: toTag(item.riskLevel, item.confidenceLevel) }));
+
+  const highRiskCount = enriched.filter((item) => item.riskLevel === 'high').length;
+  const riskLevel = highRiskCount >= 2 ? 'high' : highRiskCount === 1 ? 'medium' : 'low';
+  const confidenceLevel = enriched.some((item) => item.confidenceLevel === 'low')
+    ? 'low'
+    : enriched.filter((item) => item.confidenceLevel === 'high').length >= 2 ? 'high' : 'medium';
+
+  const pressurePoint = defensiveAdjustment.riskLevel === 'high'
+    ? 'Opponent offense is the pressure point this week.'
+    : offensiveAdjustment.riskLevel === 'high'
+      ? 'Opponent defense is driving the matchup pressure.'
+      : 'This matchup should hinge on execution and prep detail.';
+
+  return {
+    heading: 'Game Plan Impact',
+    summary: `${nextGame?.isHome ? 'Home' : 'Road'} setup vs ${opponent?.abbr ?? opponent?.name ?? 'TBD'}. ${pressurePoint}`,
+    pressurePoint,
+    riskLevel,
+    confidenceLevel,
+    recommendedAdjustments: enriched,
+  };
+}
+
+export function buildPostGameReview({ lastGame, userTeamId, latestNews }) {
+  if (!lastGame) {
+    return {
+      heading: 'Review Last Week',
+      result: 'No completed game yet',
+      takeaway: 'Result will appear after the next advance.',
+      nextAction: 'Finalize prep before you simulate forward.',
+      actions: [{ label: 'Open Weekly Prep', targetRoute: 'Weekly Prep' }],
+    };
+  }
+
+  const homeId = Number(lastGame?.homeId ?? lastGame?.home?.id ?? lastGame?.home);
+  const awayId = Number(lastGame?.awayId ?? lastGame?.away?.id ?? lastGame?.away);
+  const isHome = homeId === Number(userTeamId);
+  const userScore = safeNum(isHome ? (lastGame?.score?.home ?? lastGame?.homeScore) : (lastGame?.score?.away ?? lastGame?.awayScore), 0) ?? 0;
+  const oppScore = safeNum(isHome ? (lastGame?.score?.away ?? lastGame?.awayScore) : (lastGame?.score?.home ?? lastGame?.homeScore), 0) ?? 0;
+  const oppAbbr = isHome ? (lastGame?.awayAbbr ?? lastGame?.away?.abbr ?? 'TBD') : (lastGame?.homeAbbr ?? lastGame?.home?.abbr ?? 'TBD');
+  const resultPrefix = userScore > oppScore ? 'W' : userScore < oppScore ? 'L' : 'T';
+
+  let takeaway = 'Result recorded. Open box score for full drive details.';
+  let nextAction = 'Use this result to tune this week’s prep and game plan.';
+
+  if (userScore <= 17 && userScore < oppScore) {
+    takeaway = 'Offense needs attention after a low-scoring result.';
+    nextAction = 'Tune Game Plan before advancing again.';
+  } else if (oppScore <= 17 && userScore >= oppScore) {
+    takeaway = 'Defense held up on the scoreboard.';
+    nextAction = 'Carry forward your defensive emphasis in Weekly Prep.';
+  }
+
+  return {
+    heading: 'Review Last Week',
+    result: `${resultPrefix} ${userScore}-${oppScore} ${isHome ? 'vs' : '@'} ${oppAbbr}`,
+    takeaway,
+    nextAction,
+    newsNote: latestNews?.headline ?? 'No new league bulletin yet.',
+    actions: [
+      { label: 'Open Weekly Results', targetRoute: 'Weekly Results' },
+      { label: 'Open News', targetRoute: 'News' },
+    ],
+  };
+}

--- a/src/ui/utils/gamePlanImpact.test.js
+++ b/src/ui/utils/gamePlanImpact.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { buildGamePlanImpact } from './gamePlanImpact.js';
+
+const baseTeam = { id: 1, abbr: 'CHI', offenseRating: 84, defenseRating: 84, roster: [] };
+const baseOpponent = { id: 2, abbr: 'DET', offenseRating: 84, defenseRating: 84 };
+
+function buildInput(overrides = {}) {
+  return {
+    league: { week: 8, ...overrides.league },
+    team: { ...baseTeam, ...(overrides.team ?? {}) },
+    nextGame: overrides.hasOwnProperty('nextGame')
+      ? overrides.nextGame
+      : { isHome: true, opp: { ...baseOpponent, ...(overrides.opponent ?? {}) } },
+    prep: { lineupIssues: [], ...(overrides.prep ?? {}) },
+  };
+}
+
+describe('buildGamePlanImpact', () => {
+  it('handles no opponent fallback safely', () => {
+    const result = buildGamePlanImpact(buildInput({ nextGame: null }));
+    expect(result.recommendedAdjustments.length).toBeGreaterThanOrEqual(2);
+    expect(result.summary).toMatch(/no matchup lock yet/i);
+  });
+
+  it('uses balanced messaging on equal ratings', () => {
+    const result = buildGamePlanImpact(buildInput());
+    expect(result.recommendedAdjustments[0].explanation).toMatch(/tightly matched/i);
+    expect(result.riskLevel).toBe('low');
+  });
+
+  it('flags user offense edge', () => {
+    const result = buildGamePlanImpact(buildInput({ team: { offenseRating: 90 }, opponent: { defenseRating: 80 } }));
+    expect(result.recommendedAdjustments[0].explanation).toMatch(/your offense has the edge/i);
+  });
+
+  it('flags opponent defense edge', () => {
+    const result = buildGamePlanImpact(buildInput({ team: { offenseRating: 79 }, opponent: { defenseRating: 88 } }));
+    expect(result.recommendedAdjustments[0].explanation).toMatch(/their defense has the edge/i);
+  });
+
+  it('flags opponent offense pressure point', () => {
+    const result = buildGamePlanImpact(buildInput({ team: { defenseRating: 78 }, opponent: { offenseRating: 88 } }));
+    const defensiveCard = result.recommendedAdjustments.find((item) => item.title === 'Defensive Priority');
+    expect(defensiveCard.explanation).toMatch(/opponent offense is the pressure point/i);
+  });
+
+  it('adds lineup risk adjustment when injuries are present', () => {
+    const result = buildGamePlanImpact(buildInput({ prep: { lineupIssues: [{ label: 'Injury replacement required' }] } }));
+    expect(result.recommendedAdjustments.some((item) => item.title === 'Lineup Risk')).toBe(true);
+  });
+
+  it('adds late-season pressure card when applicable', () => {
+    const result = buildGamePlanImpact(buildInput({ league: { week: 14 } }));
+    expect(result.recommendedAdjustments.some((item) => item.title === 'Late-Season Pressure')).toBe(true);
+  });
+});

--- a/tests/e2e/franchise_hq_mobile_smoke.spec.js
+++ b/tests/e2e/franchise_hq_mobile_smoke.spec.js
@@ -13,6 +13,7 @@ for (const viewport of [
     await expect(page.getByText(/Week\s+\d+/i).first()).toBeVisible({ timeout: 60000 });
     await expect(page.getByText(/Last Result/i).first()).toBeVisible();
     await expect(page.getByText(/Coordinator Brief|Weekly Intelligence|Opponent Intel/i).first()).toBeVisible();
+    await expect(page.getByText(/Game Plan Impact/i).first()).toBeVisible();
     await expect(page.getByRole('button', { name: /Advance Week/i })).toBeVisible();
 
     for (const label of ['Game Plan', 'Set Lineup', 'Training', 'Scout Opponent']) {
@@ -22,6 +23,12 @@ for (const viewport of [
     const advance = page.getByRole('button', { name: /Advance Week/i });
     await expect(advance).toBeEnabled();
     await expect(advance).toBeInViewport();
+
+    const noOverflow = await page.evaluate(() => {
+      const doc = document.documentElement;
+      return doc.scrollWidth <= doc.clientWidth + 1;
+    });
+    expect(noOverflow).toBeTruthy();
     await expect(page.locator('html, body')).not.toContainText('Something went wrong');
   });
 }


### PR DESCRIPTION
### Motivation
- Connect the Coordinator Brief and weekly priorities to concrete, football-native adjustments so the HQ feels like a real operations loop rather than passive advice cards. 
- Surface concise, actionable recommendations (attack/defense/lineup) that map directly to existing routes so the user can act with one tap and keep the single dominant `Advance Week` CTA. 
- Preserve existing architecture and simulation integrity by deriving guidance from safe selectors and prep state instead of mutating sim outcomes or adding hidden DOM artifacts. 
- Keep the change mobile-first, compact, and conservative where data is missing (honest fallbacks instead of invented analysis). 

### Description
- Added a pure helper `buildGamePlanImpact` (and `buildPostGameReview`) at `src/ui/utils/gamePlanImpact.js` that derives matchup pressure points, offensive/defensive recommended adjustments, lineup risk, risk/confidence tags, CTA targets, and compact post-game review text; the functions use defensive fallbacks for missing opponent, ratings, schedule, or malformed saves. 
- Wired the model into the HQ view model via `selectFranchiseHQViewModel` so `gamePlanImpact`, `recommendedAdjustments`, `postGameReview`, and `advanceFeedback` are exposed for the UI without changing existing simulation, worker, or navigation flows. 
- Updated `src/ui/components/FranchiseHQ.jsx` to render a compact “Game Plan Impact” SectionCard containing 2–3 recommendation cards (title, short football-specific explanation, tag, and CTA) and to upgrade the Operations Snapshot into a concise `Review Last Week` summary with result, one takeaway, next action, and optional review routes. 
- Minor styling additions in `src/ui/styles/screen-system.css` for compact impact cards, focus-visible states, mobile layout guards (no horizontal overflow on narrow screens), and accessible review-route chips, and added unit/component tests and a small e2e smoke spec update to validate presence and layout. 

### Testing
- Ran `npm ci` which completed successfully. 
- Ran targeted unit/component tests with `npx vitest run src/ui/utils/gamePlanImpact.test.js src/ui/components/__tests__/FranchiseHQ.test.jsx src/ui/utils/franchiseCommandCenter.test.js` and those suites passed. 
- Built the production bundle with `npm run build` and validated Netlify-parity with `npm run check:deploy`, both completing successfully. 
- Attempted Playwright e2e smoke run `npx playwright test tests/e2e/franchise_hq_mobile_smoke.spec.js` but the browser binaries are not installed in this environment (missing `chromium_headless_shell`), so Playwright could not run and those e2e checks were not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee71cf90d4832d9bcf589028b2c82f)