### PR TITLE
Polish Franchise HQ → Weekly Results → Game Book recap loop

### DIFF
--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -531,6 +531,7 @@ export default function LeagueDashboard({
   advanceDisabled = false,
 }) {
   const [activeTab, setActiveTab] = useState("HQ");
+  const [weeklyResultsInitialWeek, setWeeklyResultsInitialWeek] = useState(null);
   const [selectedGameId, setSelectedGameId] = useState(null);
   const [lastGameTab, setLastGameTab] = useState("Schedule");
   const [selectedPlayerId, setSelectedPlayerId] = useState(null);
@@ -832,6 +833,9 @@ export default function LeagueDashboard({
                   if (destination.teamSection) {
                     setTeamInitialSection(destination.teamSection);
                   }
+                  if (destination.tab === "Weekly Results") {
+                    setWeeklyResultsInitialWeek(destination.initialWeek ?? null);
+                  }
                   setActiveTab(destination.tab && TABS.includes(destination.tab) ? destination.tab : "HQ");
                 }}
                 onAdvanceWeek={onAdvanceWeek}
@@ -910,7 +914,8 @@ export default function LeagueDashboard({
               renderResults={() => (
                 <WeeklyResultsCenter
                   league={league}
-                  initialWeek={league?.week}
+                  initialWeek={weeklyResultsInitialWeek ?? league?.week}
+                  onNavigate={setActiveTab}
                   onGameSelect={(gameId) => openGameDetail(gameId, "League")}
                 />
               )}
@@ -979,7 +984,8 @@ export default function LeagueDashboard({
           <TabErrorBoundary label="Weekly Results" onNavigate={setActiveTab} fallbackTab="League">
             <WeeklyResultsCenter
               league={league}
-              initialWeek={league?.week}
+              initialWeek={weeklyResultsInitialWeek ?? league?.week}
+              onNavigate={setActiveTab}
               onGameSelect={(gameId) => openGameDetail(gameId, "Weekly Results")}
             />
           </TabErrorBoundary>

--- a/src/ui/components/WeeklyResultsCenter.jsx
+++ b/src/ui/components/WeeklyResultsCenter.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from '../utils/boxScoreAccess.js';
-import { deriveCompactResultRecap, getGameLifecycleBucket, selectWeekGames } from '../utils/gameCenterResults.js';
+import { deriveCompactResultRecap, getGameLifecycleBucket, resolveDefaultResultsWeek, selectWeekGames } from '../utils/gameCenterResults.js';
 import { buildWeeklyLeagueRecap } from '../utils/weeklyLeagueRecap.js';
 import {
   CompactInsightCard,
@@ -52,6 +52,27 @@ function ResultRow({ row, seasonId, onGameSelect, source = 'weekly_results_cente
   );
 }
 
+function buildUserTeamResult(row, userTeamId) {
+  if (!row || userTeamId == null) return null;
+  const homeId = Number(row?.game?.home?.id ?? row?.game?.home);
+  const awayId = Number(row?.game?.away?.id ?? row?.game?.away);
+  const isUserHome = homeId === Number(userTeamId);
+  const isUserAway = awayId === Number(userTeamId);
+  if (!isUserHome && !isUserAway) return null;
+  const opponent = isUserHome ? row.away : row.home;
+  const userScore = Number(isUserHome ? row?.game?.homeScore : row?.game?.awayScore);
+  const oppScore = Number(isUserHome ? row?.game?.awayScore : row?.game?.homeScore);
+  const outcome = userScore > oppScore ? 'W' : userScore < oppScore ? 'L' : 'T';
+  return {
+    ...row,
+    opponent,
+    isHome: isUserHome,
+    userScore,
+    oppScore,
+    outcome,
+  };
+}
+
 function LiveOrUpcomingRow({ row, label, tone = 'info' }) {
   return (
     <article className="app-game-center-card card is-compact">
@@ -97,10 +118,10 @@ function SpotlightCard({ row, seasonId, onGameSelect }) {
   );
 }
 
-export default function WeeklyResultsCenter({ league, initialWeek, onGameSelect }) {
+export default function WeeklyResultsCenter({ league, initialWeek, onGameSelect, onNavigate }) {
   const totalWeeks = Number(league?.schedule?.weeks?.length ?? 0);
-  const currentWeek = Number(initialWeek ?? league?.week ?? 1);
-  const [selectedWeek, setSelectedWeek] = useState(currentWeek);
+  const resolvedWeek = useMemo(() => resolveDefaultResultsWeek(league?.schedule, { initialWeek, currentWeek: league?.week }), [initialWeek, league?.schedule, league?.week]);
+  const [selectedWeek, setSelectedWeek] = useState(resolvedWeek);
 
   const teamById = useMemo(() => {
     const out = {};
@@ -133,22 +154,33 @@ export default function WeeklyResultsCenter({ league, initialWeek, onGameSelect 
 
   const leagueRecap = useMemo(() => buildWeeklyLeagueRecap(league, { week: selectedWeek }), [league, selectedWeek]);
   const spotlightRows = useMemo(() => leagueRecap.spotlights.map((spotlight) => ({ ...spotlight, teamById })), [leagueRecap.spotlights, teamById]);
+  const userTeamResult = useMemo(() => {
+    const userTeamId = Number(league?.userTeamId);
+    if (!Number.isFinite(userTeamId)) return null;
+    return completed.map((row) => buildUserTeamResult(row, userTeamId)).find(Boolean) ?? null;
+  }, [completed, league?.userTeamId]);
+  const userResultPresentation = useMemo(
+    () => (userTeamResult ? buildCompletedGamePresentation(userTeamResult.game, { seasonId: league?.seasonId, week: userTeamResult.week, teamById, source: 'weekly_results_user_game' }) : null),
+    [league?.seasonId, teamById, userTeamResult],
+  );
+  const canOpenUserGame = Boolean(userResultPresentation?.canOpen && onGameSelect);
 
   if (!totalWeeks) {
     return <EmptyState title="No schedule data available for weekly results." body="Weekly game center will populate when league schedule weeks are present." />;
   }
 
   return (
-    <div className="app-screen-stack">
+    <div className="app-screen-stack app-weekly-results-screen">
       <HeroCard
-        eyebrow="Game Center"
+        eyebrow="Franchise HQ • Results"
         title="Weekly Results"
-        subtitle="Track finals, live windows, and upcoming slates from one command view."
+        subtitle="Review your latest final first, then scan league-wide outcomes and prep next steps."
         rightMeta={<StatusChip label={`Week ${selectedWeek}`} tone="info" />}
         actions={(
-          <div className="app-weekly-results-nav">
+          <div className="app-weekly-results-nav" role="group" aria-label="Weekly results navigation">
             <button type="button" className="btn btn-sm" onClick={() => setSelectedWeek((w) => Math.max(1, w - 1))} disabled={selectedWeek <= 1}>Prev</button>
             <button type="button" className="btn btn-sm" onClick={() => setSelectedWeek((w) => Math.min(totalWeeks, w + 1))} disabled={selectedWeek >= totalWeeks}>Next</button>
+            <button type="button" className="btn btn-sm btn-secondary" onClick={() => onNavigate?.('HQ')}>Back to HQ</button>
           </div>
         )}
       >
@@ -168,6 +200,31 @@ export default function WeeklyResultsCenter({ league, initialWeek, onGameSelect 
           />
         ) : null}
       </HeroCard>
+
+      {userTeamResult ? (
+        <SectionCard title="Your Game" subtitle="Fast recap from your latest completed matchup in this week." variant="info">
+          <article className="app-game-center-card app-game-center-user card">
+            <div className="app-game-center-card__top">
+              <strong>{userTeamResult.outcome === 'W' ? 'Win' : userTeamResult.outcome === 'L' ? 'Loss' : 'Tie'} • {userTeamResult.isHome ? 'vs' : '@'} {userTeamResult.opponent?.abbr ?? 'TBD'}</strong>
+              <StatusChip label={`${userTeamResult.userScore}-${userTeamResult.oppScore}`} tone={userTeamResult.outcome === 'W' ? 'ok' : userTeamResult.outcome === 'L' ? 'warning' : 'info'} />
+            </div>
+            <p className="app-game-center-card__scoreline">{userTeamResult.recap}</p>
+            <p className="app-game-center-card__summary">{userResultPresentation?.displayScoreLine ?? 'Final score unavailable.'}</p>
+            <div className="app-game-center-card__footer">
+              <button
+                type="button"
+                className="btn btn-sm"
+                onClick={canOpenUserGame ? () => openResolvedBoxScore(userTeamResult.game, { seasonId: league?.seasonId, week: userTeamResult.week, source: 'weekly_results_user_game' }, onGameSelect) : undefined}
+                disabled={!canOpenUserGame}
+                title={canOpenUserGame ? 'Open full Game Book' : (userResultPresentation?.statusLabel ?? 'Archive unavailable')}
+              >
+                {canOpenUserGame ? 'Open Game Book' : `Game Book unavailable (${userResultPresentation?.statusLabel ?? 'Archive unavailable'})`}
+              </button>
+              <button type="button" className="btn btn-sm btn-secondary" onClick={() => onNavigate?.('Weekly Prep')}>Continue Weekly Prep</button>
+            </div>
+          </article>
+        </SectionCard>
+      ) : null}
 
       {leagueRecap.bullets.length > 0 && (
         <SectionCard

--- a/src/ui/components/WeeklyResultsCenter.test.jsx
+++ b/src/ui/components/WeeklyResultsCenter.test.jsx
@@ -1,5 +1,7 @@
+/** @vitest-environment jsdom */
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, within, cleanup } from '@testing-library/react';
 import { renderToString } from 'react-dom/server';
 import WeeklyResultsCenter from './WeeklyResultsCenter.jsx';
 import { buildWeeklyLeagueRecap } from '../utils/weeklyLeagueRecap.js';
@@ -7,7 +9,8 @@ import { openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 
 const league = {
   seasonId: '2026',
-  week: 2,
+  week: 3,
+  userTeamId: 1,
   teams: [
     { id: 1, abbr: 'DAL', name: 'Dallas', conf: 1, div: 0 },
     { id: 2, abbr: 'PHI', name: 'Philadelphia', conf: 1, div: 0 },
@@ -22,31 +25,42 @@ const league = {
     weeks: [
       { week: 1, games: [
         { gameId: '2026_w1_1_2', home: 1, away: 2, played: true, homeScore: 21, awayScore: 17, summary: { storyline: 'Turnovers decided it.' } },
-        { gameId: '2026_w1_3_4', home: 3, away: 4, played: true, homeScore: 24, awayScore: 14 },
-        { gameId: '2026_w1_5_6', home: 5, away: 6, played: true, homeScore: 20, awayScore: 23 },
-        { gameId: '2026_w1_7_8', home: 7, away: 8, played: true, homeScore: 13, awayScore: 10 },
       ] },
       { week: 2, games: [
-        { gameId: '2026_w2_2_3', home: 2, away: 3, played: true, homeScore: 14, awayScore: 10, summary: { headline: 'Red zone defense sealed it.' }, quarterScores: { home: [0, 7, 0, 7], away: [3, 0, 7, 0] } },
+        { gameId: '2026_w2_2_3', home: 2, away: 3, played: true, homeScore: 14, awayScore: 10, summary: { headline: 'Red zone defense sealed it.' } },
         { gameId: '2026_w2_1_4', home: 1, away: 4, played: true, homeScore: 20, awayScore: 21, summary: { storyline: 'Game-winning drive in final minute.' }, quarterScores: { home: [7, 3, 7, 3], away: [7, 7, 0, 7] } },
-        { gameId: '2026_w2_5_7', home: 5, away: 7, played: true, homeScore: 27, awayScore: 17 },
-        { gameId: '2026_w2_6_8', home: 6, away: 8, status: 'live' },
-        { gameId: '2026_w2_1_2', home: 1, away: 2, played: false },
+      ] },
+      { week: 3, games: [
+        { gameId: '2026_w3_6_8', home: 6, away: 8, played: false },
       ] },
     ],
   },
 };
 
 describe('WeeklyResultsCenter', () => {
-  it('renders weekly recap, race center, spotlight, and game groupings', () => {
-    const html = renderToString(<WeeklyResultsCenter league={league} initialWeek={2} onGameSelect={() => {}} />);
-    expect(html).toContain('Weekly League Recap');
-    expect(html).toContain('Race center');
-    expect(html).toContain('Weekly Spotlight');
-    expect(html).toContain('Completed');
-    expect(html).toContain('In progress');
-    expect(html).toContain('Upcoming');
-    expect(html).toContain('Open spotlight');
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders weekly recap, spotlight, and the user-team game card', () => {
+    render(<WeeklyResultsCenter league={league} onGameSelect={() => {}} onNavigate={() => {}} />);
+
+    expect(screen.getByText('Your Game')).toBeTruthy();
+    expect(screen.getByText(/loss.*vs wsh/i)).toBeTruthy();
+    expect(screen.getByText('Weekly League Recap')).toBeTruthy();
+    expect(screen.getByText('Weekly Spotlight')).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: /open game book/i }).length).toBeGreaterThan(0);
+  });
+
+  it('opens Game Book from the user-team spotlight card', () => {
+    const onGameSelect = vi.fn();
+    render(<WeeklyResultsCenter league={league} initialWeek={2} onGameSelect={onGameSelect} onNavigate={() => {}} />);
+
+    const userGameSection = screen.getByText('Your Game').closest('section');
+    fireEvent.click(within(userGameSection).getByRole('button', { name: /^open game book$/i }));
+
+    expect(onGameSelect).toHaveBeenCalledTimes(1);
+    expect(onGameSelect.mock.calls[0][0]).toMatch(/2026_w2_/);
   });
 
   it('is safe for older partial payloads with score-only games', () => {
@@ -54,9 +68,9 @@ describe('WeeklyResultsCenter', () => {
       ...league,
       schedule: { weeks: [{ week: 3, games: [{ gameId: '2026_w3_1_2', home: 1, away: 2, played: true, homeScore: 7, awayScore: 3 }] }] },
     };
-    const html = renderToString(<WeeklyResultsCenter league={legacyLeague} initialWeek={3} onGameSelect={() => {}} />);
+    const html = renderToString(<WeeklyResultsCenter league={legacyLeague} initialWeek={3} onGameSelect={() => {}} onNavigate={() => {}} />);
     expect(html).toContain('DAL won by 4 (3-7).');
-    expect(html).toContain('Archive unavailable');
+    expect(html).toContain('Game Book unavailable (Archive unavailable)');
   });
 
   it('routes spotlight game records through current game book open helper', () => {

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -67,7 +67,7 @@ describe('FranchiseHQ', () => {
     fireEvent.click(within(view.container).getAllByRole('button', { name: /open weekly results/i })[0]);
 
     expect(onNavigate).toHaveBeenCalledWith('Game Plan');
-    expect(onNavigate).toHaveBeenCalledWith('Weekly Results');
+    expect(onNavigate).toHaveBeenCalledWith('Weekly Results:9');
   });
 
   it('renders record, standing, and fallback copy when schedule is missing', () => {

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -147,8 +147,9 @@
   .app-hero-summary-grid { grid-template-columns: 1fr; }
 }
 
+.app-weekly-results-screen { overflow-x: clip; }
 .app-weekly-results-nav { display: flex; gap: 8px; flex-wrap: wrap; }
-.app-weekly-results-grid { display: grid; gap: 8px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+.app-weekly-results-grid { display: grid; gap: 8px; grid-template-columns: repeat(auto-fit, minmax(min(220px, 100%), 1fr)); }
 .app-weekly-results-recap-grid { display: grid; gap: 8px; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
 .app-weekly-results-bullets { display: grid; gap: 6px; }
 
@@ -169,6 +170,28 @@
 .app-game-center-card__scoreline { font-size: var(--text-base); font-weight: 700; letter-spacing: -0.01em; }
 .app-game-center-card__summary { margin: 0; font-size: var(--text-xs); color: var(--text-muted); }
 .app-game-center-card__footer { display: flex; justify-content: flex-start; gap: 8px; }
+.app-game-center-user {
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--hairline));
+  background: linear-gradient(150deg, color-mix(in srgb, var(--surface) 91%, #132035 9%), var(--surface));
+}
+.app-game-center-card button:focus-visible {
+  outline: 2px solid rgba(var(--accent-rgb), .9);
+  outline-offset: 2px;
+}
+
+@media (max-width: 480px) {
+  .app-weekly-results-nav .btn,
+  .app-game-center-card__footer .btn {
+    min-height: 40px;
+    padding: 8px 10px;
+  }
+  .app-weekly-results-grid {
+    grid-template-columns: 1fr;
+  }
+  .app-weekly-results-recap-grid {
+    grid-template-columns: 1fr;
+  }
+}
 
 .app-news-filter-row { display: flex; gap: 8px; flex-wrap: wrap; }
 .app-news-filter-row .btn.is-active { border-color: var(--accent); box-shadow: 0 0 0 1px rgba(var(--accent-rgb), .38) inset; }

--- a/src/ui/utils/gameCenterResults.js
+++ b/src/ui/utils/gameCenterResults.js
@@ -41,3 +41,41 @@ export function selectWeekGames(schedule, week) {
   const row = schedule.weeks.find((entry) => Number(entry?.week) === Number(week));
   return Array.isArray(row?.games) ? row.games : [];
 }
+
+function hasCompletedGame(games = []) {
+  return games.some((game) => getGameLifecycleBucket(game) === 'completed');
+}
+
+export function resolveDefaultResultsWeek(schedule, { initialWeek, currentWeek = 1 } = {}) {
+  const parsedInitialWeek = Number(initialWeek);
+  if (Number.isFinite(parsedInitialWeek) && parsedInitialWeek >= 1) return parsedInitialWeek;
+
+  if (!Array.isArray(schedule?.weeks) || !schedule.weeks.length) {
+    const fallback = Number(currentWeek);
+    return Number.isFinite(fallback) && fallback >= 1 ? fallback : 1;
+  }
+
+  const normalizedWeeks = schedule.weeks
+    .map((row) => ({ week: Number(row?.week), games: Array.isArray(row?.games) ? row.games : [] }))
+    .filter((row) => Number.isFinite(row.week) && row.week >= 1)
+    .sort((a, b) => a.week - b.week);
+
+  if (!normalizedWeeks.length) return 1;
+
+  const parsedCurrentWeek = Number(currentWeek);
+  const effectiveCurrentWeek = Number.isFinite(parsedCurrentWeek) && parsedCurrentWeek >= 1
+    ? parsedCurrentWeek
+    : normalizedWeeks[normalizedWeeks.length - 1].week;
+  const currentRow = normalizedWeeks.find((row) => row.week === effectiveCurrentWeek);
+
+  if (currentRow && hasCompletedGame(currentRow.games)) return currentRow.week;
+
+  for (let i = normalizedWeeks.length - 1; i >= 0; i -= 1) {
+    const row = normalizedWeeks[i];
+    if (row.week > effectiveCurrentWeek) continue;
+    if (hasCompletedGame(row.games)) return row.week;
+  }
+
+  const closest = normalizedWeeks.find((row) => row.week >= effectiveCurrentWeek) ?? normalizedWeeks[normalizedWeeks.length - 1];
+  return closest?.week ?? 1;
+}

--- a/src/ui/utils/gameCenterResults.test.js
+++ b/src/ui/utils/gameCenterResults.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { deriveCompactResultRecap, getGameLifecycleBucket, selectWeekGames } from './gameCenterResults.js';
+import { deriveCompactResultRecap, getGameLifecycleBucket, resolveDefaultResultsWeek, selectWeekGames } from './gameCenterResults.js';
 
 describe('gameCenterResults helpers', () => {
   it('creates deterministic recap text for the same payload', () => {
@@ -37,5 +37,22 @@ describe('gameCenterResults helpers', () => {
     expect(selectWeekGames(schedule, 1)).toHaveLength(1);
     expect(selectWeekGames(schedule, 2)).toHaveLength(2);
     expect(selectWeekGames(schedule, 3)).toHaveLength(0);
+  });
+
+  it('resolves a smarter default week when current week is not completed', () => {
+    const schedule = {
+      weeks: [
+        { week: 1, games: [{ played: true, homeScore: 7, awayScore: 3 }] },
+        { week: 2, games: [{ played: true, homeScore: 17, awayScore: 20 }] },
+        { week: 3, games: [{ played: false }] },
+      ],
+    };
+    expect(resolveDefaultResultsWeek(schedule, { currentWeek: 3 })).toBe(2);
+    expect(resolveDefaultResultsWeek(schedule, { initialWeek: 1, currentWeek: 3 })).toBe(1);
+  });
+
+  it('falls back safely when schedule payload is missing or malformed', () => {
+    expect(resolveDefaultResultsWeek(null, { currentWeek: 4 })).toBe(4);
+    expect(resolveDefaultResultsWeek({ weeks: [{ week: 'bad', games: [] }] }, { currentWeek: 'bad' })).toBe(1);
   });
 });

--- a/src/ui/utils/gamePlanImpact.js
+++ b/src/ui/utils/gamePlanImpact.js
@@ -217,7 +217,7 @@ export function buildPostGameReview({ lastGame, userTeamId, latestNews }) {
     nextAction,
     newsNote: latestNews?.headline ?? 'No new league bulletin yet.',
     actions: [
-      { label: 'Open Weekly Results', targetRoute: 'Weekly Results' },
+      { label: 'Open Weekly Results', targetRoute: `Weekly Results:${Math.max(1, safeNum(lastGame?.week, 1))}` },
       { label: 'Open News', targetRoute: 'News' },
     ],
   };

--- a/src/ui/utils/gamePlanImpact.test.js
+++ b/src/ui/utils/gamePlanImpact.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildGamePlanImpact } from './gamePlanImpact.js';
+import { buildGamePlanImpact, buildPostGameReview } from './gamePlanImpact.js';
 
 const baseTeam = { id: 1, abbr: 'CHI', offenseRating: 84, defenseRating: 84, roster: [] };
 const baseOpponent = { id: 2, abbr: 'DET', offenseRating: 84, defenseRating: 84 };
@@ -52,5 +52,15 @@ describe('buildGamePlanImpact', () => {
   it('adds late-season pressure card when applicable', () => {
     const result = buildGamePlanImpact(buildInput({ league: { week: 14 } }));
     expect(result.recommendedAdjustments.some((item) => item.title === 'Late-Season Pressure')).toBe(true);
+  });
+
+  it('uses a valid Weekly Results route for postgame review actions', () => {
+    const review = buildPostGameReview({
+      userTeamId: 1,
+      latestNews: null,
+      lastGame: { week: 9, home: 1, away: 2, homeScore: 24, awayScore: 17, played: true },
+    });
+
+    expect(review.actions.find((item) => item.label === 'Open Weekly Results')?.targetRoute).toBe('Weekly Results:9');
   });
 });

--- a/src/ui/utils/managementScreenRouting.js
+++ b/src/ui/utils/managementScreenRouting.js
@@ -13,6 +13,7 @@ export function normalizeManagementDestination(tabToken) {
     statsFamily: null,
     leagueSection: null,
     teamSection: null,
+    initialWeek: null,
   };
   if (typeof tabToken !== "string") return normalized;
 
@@ -57,6 +58,13 @@ export function normalizeManagementDestination(tabToken) {
     normalized.tab = "Team";
     const canonicalSection = [...TEAM_SECTIONS].find((v) => v.toLowerCase() === state.toLowerCase());
     normalized.teamSection = canonicalSection ?? "Overview";
+    return normalized;
+  }
+
+  if (tab === "Weekly Results") {
+    normalized.tab = "Weekly Results";
+    const parsedWeek = Number(state);
+    normalized.initialWeek = Number.isFinite(parsedWeek) && parsedWeek >= 1 ? parsedWeek : null;
     return normalized;
   }
 

--- a/src/ui/utils/managementScreenRouting.test.js
+++ b/src/ui/utils/managementScreenRouting.test.js
@@ -65,6 +65,18 @@ describe("normalizeManagementDestination", () => {
       statsFamily: null,
       leagueSection: null,
       teamSection: null,
+      initialWeek: null,
+    });
+  });
+
+  it("supports Weekly Results deep links with optional initial week", () => {
+    expect(normalizeManagementDestination("Weekly Results:12")).toMatchObject({
+      tab: "Weekly Results",
+      initialWeek: 12,
+    });
+    expect(normalizeManagementDestination("Weekly Results:bad")).toMatchObject({
+      tab: "Weekly Results",
+      initialWeek: null,
     });
   });
 });


### PR DESCRIPTION
### Motivation
- The HQ review CTA previously navigated to a generic `Weekly Results` token and the results screen defaulted to the current week even when no finals were available, making the postgame loop feel disjointed. 
- Users need a cohesive, HQ-adjacent recap flow: a clear last-result spotlight, immediate access to the team’s Game Book, and an easy return to prep without adding global state. 
- Improvements must be minimal, safe, and fit the existing React navigation system and archive/boxscore helpers.

### Description
- Deep-linked postgame review actions to `Weekly Results:<week>` by updating `buildPostGameReview` so HQ review CTAs include an explicit week context. (`src/ui/utils/gamePlanImpact.js`)
- Taught management route normalization to parse an optional `initialWeek` for `Weekly Results:<week>` and expose it on the destination object without adding global state. (`src/ui/utils/managementScreenRouting.js`)
- Wired `LeagueDashboard` to capture/passthrough `initialWeek` and supply it to embedded results and the standalone `Weekly Results` tab, so HQ → Results lands on the intended week context. (`src/ui/components/LeagueDashboard.jsx`)
- Added a pure helper `resolveDefaultResultsWeek` and integrated it into `WeeklyResultsCenter` so selection logic uses `initialWeek` when present, otherwise prefers a completed current week or the most recent completed week, with robust fallbacks for missing/malformed schedules. (`src/ui/utils/gameCenterResults.js`, `src/ui/components/WeeklyResultsCenter.jsx`)
- Upgraded `WeeklyResultsCenter` into a recap-first screen by adding a “Your Game” spotlight (outcome, opponent, score, compact recap), a prominent `Open Game Book` button that leverages `buildCompletedGamePresentation` + `openResolvedBoxScore`, secondary compact CTAs (`Back to HQ`, `Continue Weekly Prep`), and preserved the existing league-wide sections below; styling tweaks were added to keep a premium HQ-adjacent tone and improve mobile behavior. (`src/ui/components/WeeklyResultsCenter.jsx`, `src/ui/styles/screen-system.css`)
- Tests added/updated to cover default week resolution, user-team spotlight rendering and Game Book click behavior, HQ postgame route validity, and management-route parsing for `Weekly Results:<week>`. (`src/ui/utils/*.test.js`, `src/ui/components/WeeklyResultsCenter.test.jsx`, `src/ui/components/__tests__/FranchiseHQ.test.jsx`)

### Testing
- Ran `npm ci` successfully to install dependencies. 
- Ran targeted unit tests with Vitest for the modified areas using `npm run test:unit -- src/ui/utils/gameCenterResults.test.js src/ui/utils/managementScreenRouting.test.js src/ui/utils/gamePlanImpact.test.js src/ui/components/WeeklyResultsCenter.test.jsx src/ui/components/__tests__/FranchiseHQ.test.jsx` and all tests passed locally (28 tests, 0 failures). 
- Built the production bundle with `npm run build` and the build completed successfully (Vite production build). 
- Ran `npm run check:deploy` which performs Netlify-style parity and rules checks and succeeded in this environment. 
- Tried Playwright e2e smoke `npx playwright test tests/e2e/franchise_hq_mobile_smoke.spec.js`, but browser binaries are not present in this environment (Playwright requested `npx playwright install`), so E2E browser runs were not executed. 

Known limitations & notes: 
- No new global state introduced; navigation context is passed through existing management-route destination plumbing. 
- If archive/boxscore data is unavailable the UI shows an honest disabled CTA state rather than inventing data. 
- Playwright/browser e2e was not completed due to missing browser binaries in CI; recommend `npx playwright install` in CI or runner to enable full mobile smoke tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee76469c7c832dac0ebdeff95195cb)