### PR TITLE
Weekly Prep War Room: add pure screen model, refactor UI, and tests

### DIFF
--- a/src/ui/components/WeeklyPrepScreen.jsx
+++ b/src/ui/components/WeeklyPrepScreen.jsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { EmptyState, SectionCard } from './common/UiPrimitives.jsx';
-import { markWeeklyPrepStep, deriveWeeklyPrepState } from '../utils/weeklyPrep.js';
-import { HQIcon, TeamIdentityBadge } from './HQVisuals.jsx';
+import { markWeeklyPrepStep } from '../utils/weeklyPrep.js';
+import { buildWeeklyPrepScreenModel } from '../utils/weeklyPrepScreenModel.js';
+import { TeamIdentityBadge } from './HQVisuals.jsx';
 
 function TonePill({ tone = 'info', label }) {
   const palette = {
@@ -13,14 +14,15 @@ function TonePill({ tone = 'info', label }) {
   };
   const active = palette[tone] ?? palette.info;
   return (
-    <span style={{ fontSize: 'var(--text-xs)', border: `1px solid ${active.border}`, background: active.bg, borderRadius: 999, padding: '2px 8px' }}>
+    <span className="weekly-prep-pill" style={{ border: `1px solid ${active.border}`, background: active.bg }}>
       {label}
     </span>
   );
 }
 
 export default function WeeklyPrepScreen({ league, onNavigate }) {
-  const prep = useMemo(() => deriveWeeklyPrepState(league), [league]);
+  const model = useMemo(() => buildWeeklyPrepScreenModel({ league }), [league]);
+  const prep = model.prep;
 
   useEffect(() => {
     markWeeklyPrepStep(league, 'opponentScouted', true);
@@ -36,104 +38,94 @@ export default function WeeklyPrepScreen({ league, onNavigate }) {
   };
 
   return (
-    <div className="app-screen-stack weekly-prep-screen" style={{ display: 'grid', gap: 'var(--space-2)' }}>
+    <div className="app-screen-stack weekly-prep-screen">
       <SectionCard
-        title={`Scout & Prep · Week ${prep.nextGame.week}`}
-        subtitle={`Opponent ${prep.opponentSnapshot.record} · ${prep.opponentSnapshot.homeAway} game`}
-        actions={<TonePill tone={prep.prepSummary?.severity === 'major_risk' ? 'danger' : prep.remaining === 0 ? 'success' : 'warning'} label={prep.prepSummary?.status ?? prep.readinessLabel} />}
+        title={`Weekly Prep War Room · Week ${model.week}`}
+        subtitle={model.matchupHeadline}
+        actions={<TonePill tone={model.readinessTone} label={model.readinessStatus} />}
       >
-        <div className="weekly-prep-opponent-head">
+        <div className="weekly-prep-hero-row">
           <div className="weekly-prep-team">
-            <TeamIdentityBadge team={prep.team} size={36} emphasize />
+            <TeamIdentityBadge team={prep.team} size={40} emphasize />
             <strong>{prep.team?.abbr ?? 'YOU'}</strong>
           </div>
           <span>{prep.nextGame.isHome ? 'vs' : '@'}</span>
           <div className="weekly-prep-team">
-            <TeamIdentityBadge team={prep.opponent} size={36} />
-            <strong>{prep.opponent?.abbr ?? prep.opponent?.name ?? 'OPP'}</strong>
+            <TeamIdentityBadge team={prep.opponent} size={40} />
+            <strong>{model.opponentAbbr}</strong>
           </div>
         </div>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: 8 }}>
-          <div style={{ fontSize: 'var(--text-xs)' }}><strong>You:</strong> OVR {prep.teamSnapshot.overall} · OFF {prep.teamSnapshot.offense} · DEF {prep.teamSnapshot.defense}</div>
-          <div style={{ fontSize: 'var(--text-xs)' }}><strong>Opp:</strong> OVR {prep.opponentSnapshot.overall} · OFF {prep.opponentSnapshot.offense} · DEF {prep.opponentSnapshot.defense}</div>
-          <div style={{ fontSize: 'var(--text-xs)' }}><strong>Form:</strong> You {prep.teamSnapshot.recentForm.summary} · Opp {prep.opponentSnapshot.recentForm.summary}</div>
+        <div className="weekly-prep-mini-grid">
+          <div><strong>You:</strong> OVR {prep.teamSnapshot.overall} · OFF {prep.teamSnapshot.offense} · DEF {prep.teamSnapshot.defense}</div>
+          <div><strong>Opp:</strong> OVR {prep.opponentSnapshot.overall} · OFF {prep.opponentSnapshot.offense} · DEF {prep.opponentSnapshot.defense}</div>
+          <div><strong>Form:</strong> You {prep.teamSnapshot.recentForm.summary} · Opp {prep.opponentSnapshot.recentForm.summary}</div>
         </div>
       </SectionCard>
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(290px, 1fr))', gap: 'var(--space-2)' }}>
-        <SectionCard title="Opponent scout" subtitle="Football-specific matchup context.">
-          <div style={{ display: 'grid', gap: 8 }}>
-            <div>
-              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}><HQIcon name="shield" size={12} /> Strengths</div>
-              <ul style={{ margin: '4px 0 0', paddingLeft: 16 }}>
-                {(prep.opponentStrengths.length ? prep.opponentStrengths : ['No clear dominant opponent edge identified yet.']).map((item) => <li key={item} style={{ fontSize: 'var(--text-sm)' }}>{item}</li>)}
-              </ul>
-            </div>
-            <div>
-              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}><HQIcon name="target" size={12} /> Exploitable weaknesses</div>
-              <ul style={{ margin: '4px 0 0', paddingLeft: 16 }}>
-                {(prep.opponentWeaknesses.length ? prep.opponentWeaknesses : ['No obvious weakness — game script and execution will decide this one.']).map((item) => <li key={item} style={{ fontSize: 'var(--text-sm)' }}>{item}</li>)}
-              </ul>
-            </div>
-            <div>
-              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}><HQIcon name="alert" size={12} /> Pressure points</div>
-              <ul style={{ margin: '4px 0 0', paddingLeft: 16 }}>
-                {(prep.pressurePoints.length ? prep.pressurePoints : ['No major pressure point flagged.']).map((item) => <li key={item} style={{ fontSize: 'var(--text-sm)' }}>{item}</li>)}
-              </ul>
-            </div>
-          </div>
-        </SectionCard>
+      <SectionCard title="Readiness Command" subtitle="Confirm prep quality before returning to HQ.">
+        <div className="weekly-prep-command-row">
+          <TonePill tone={model.readinessTone} label={`${model.readinessScore}% ready`} />
+          <TonePill tone={prep.remaining === 0 ? 'success' : 'warning'} label={`${4 - prep.remaining}/4 complete`} />
+          <TonePill tone={model.readyToAdvance ? 'success' : 'warning'} label={model.readyToAdvance ? 'Ready to Advance' : 'Needs Attention'} />
+        </div>
+        <p className="weekly-prep-caption">{model.keyRiskLabel}</p>
+      </SectionCard>
 
-        <SectionCard title="Lineup readiness" subtitle="Depth/injury blockers before kickoff.">
-          <div style={{ display: 'grid', gap: 8 }}>
-            {prep.lineupIssues.length === 0 ? (
-              <div style={{ fontSize: 'var(--text-sm)' }}>No lineup blockers detected. Depth chart and injury coverage look stable.</div>
-            ) : prep.lineupIssues.map((issue) => (
-              <div key={issue.id} style={{ border: '1px solid var(--hairline)', borderRadius: 'var(--radius-md)', padding: 8 }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
-                  <strong style={{ fontSize: 'var(--text-sm)' }}>{issue.label}</strong>
-                  <TonePill tone={issue.level === 'urgent' ? 'danger' : 'warning'} label={issue.level} />
-                </div>
-                <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', marginTop: 2 }}>{issue.detail}</div>
-                <Button size="sm" variant="outline" style={{ marginTop: 6 }} onClick={() => openAction(issue.actionTab, issue.actionTab === 'Injuries' ? 'injuriesReviewed' : 'lineupChecked')}>
-                  {issue.actionLabel}
-                </Button>
+      <SectionCard title="Priority Actions" subtitle="Complete these before sim day.">
+        <div className="weekly-prep-action-grid">
+          {model.priorityActions.slice(0, 4).map((action) => (
+            <article key={action.id} className="weekly-prep-action-card">
+              <div className="weekly-prep-action-head">
+                <strong>{action.title}</strong>
+                <TonePill tone={action.statusTone} label={action.statusLabel} />
               </div>
-            ))}
-          </div>
-        </SectionCard>
-      </div>
-
-      <SectionCard title="Game plan recommendations" subtitle="Data-driven weekly suggestions.">
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 8 }}>
-          {prep.recommendations.map((card) => (
-            <div key={card.title} style={{ border: '1px solid var(--hairline)', borderRadius: 'var(--radius-md)', padding: 10 }}>
-              <div style={{ fontWeight: 700, fontSize: 'var(--text-sm)' }}>{card.title}</div>
-              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', marginTop: 4 }}>{card.reason}</div>
-              <Button size="sm" variant="outline" style={{ marginTop: 8 }} onClick={() => openAction(card.actionTab, 'planReviewed')}>
-                {card.actionLabel}
-              </Button>
-            </div>
+              <p>{action.reason}</p>
+              <Button size="sm" variant="outline" onClick={() => openAction(action.route, action.completionStep)}>{action.ctaLabel}</Button>
+            </article>
           ))}
         </div>
+        <div className="weekly-prep-nav-row">
+          <Button size="sm" variant="secondary" onClick={() => onNavigate?.('HQ')}>Back to HQ</Button>
+        </div>
       </SectionCard>
 
-      <SectionCard title="Active effects" subtitle="Strategy synergy and readiness impacts for this week.">
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 8 }}>
+      <SectionCard title="Matchup Intel" subtitle="Strengths, weaknesses, and pressure points.">
+        <div className="weekly-prep-intel-grid">
+          <div>
+            <div className="weekly-prep-intel-head">Strengths</div>
+            <ul>
+              {(prep.opponentStrengths.length ? prep.opponentStrengths : ['No clear dominant opponent edge identified yet.']).map((item) => <li key={item}>{item}</li>)}
+            </ul>
+          </div>
+          <div>
+            <div className="weekly-prep-intel-head">Exploitable weaknesses</div>
+            <ul>
+              {(prep.opponentWeaknesses.length ? prep.opponentWeaknesses : ['No obvious weakness — execution will decide this one.']).map((item) => <li key={item}>{item}</li>)}
+            </ul>
+          </div>
+          <div>
+            <div className="weekly-prep-intel-head">Pressure points</div>
+            <ul>
+              {(prep.pressurePoints.length ? prep.pressurePoints : ['No major pressure point flagged.']).map((item) => <li key={item}>{item}</li>)}
+            </ul>
+          </div>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Active Effects" subtitle="Strategy synergy and readiness impacts for this week.">
+        <div className="weekly-prep-command-row">
           <TonePill tone={prep.prepSummary?.severity === 'major_risk' ? 'danger' : prep.prepSummary?.severity === 'minor_risk' ? 'warning' : 'success'} label={`Prep state: ${prep.prepSummary?.status ?? 'Ready'}`} />
           <TonePill tone={prep.prepSummary?.netImpact >= 0 ? 'success' : 'warning'} label={`Net impact ${prep.prepSummary?.netImpact >= 0 ? '+' : ''}${Number(prep.prepSummary?.netImpact ?? 0).toFixed(3)}`} />
         </div>
-        <div style={{ display: 'grid', gap: 6 }}>
+        <div className="weekly-prep-effects-grid">
           {(prep.prepSummary?.reasons?.length ? prep.prepSummary.reasons : ['No active matchup synergy or readiness penalties.']).map((reason) => (
-            <div key={reason} style={{ fontSize: 'var(--text-sm)', border: '1px solid var(--hairline)', borderRadius: 'var(--radius-md)', padding: 8 }}>
-              {reason}
-            </div>
+            <div key={reason} className="weekly-prep-effect-row">{reason}</div>
           ))}
         </div>
       </SectionCard>
 
-      <SectionCard title="Prep completion" subtitle="Lightweight weekly readiness checklist.">
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+      <SectionCard title="Prep Checklist" subtitle="Status-driven checks aligned with HQ loop.">
+        <div className="weekly-prep-command-row">
           <TonePill tone={prep.completion.lineupChecked ? 'success' : 'warning'} label={`Lineup ${prep.completion.lineupChecked ? 'checked' : 'pending'}`} />
           <TonePill tone={prep.completion.injuriesReviewed ? 'success' : 'warning'} label={`Injuries ${prep.completion.injuriesReviewed ? 'reviewed' : 'pending'}`} />
           <TonePill tone={prep.completion.opponentScouted ? 'success' : 'warning'} label={`Opponent ${prep.completion.opponentScouted ? 'scouted' : 'pending'}`} />

--- a/src/ui/components/__tests__/WeeklyPrepScreen.test.jsx
+++ b/src/ui/components/__tests__/WeeklyPrepScreen.test.jsx
@@ -1,6 +1,7 @@
+/** @vitest-environment jsdom */
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { renderToString } from 'react-dom/server';
+import { fireEvent, render, screen } from '@testing-library/react';
 import WeeklyPrepScreen from '../WeeklyPrepScreen.jsx';
 
 const league = {
@@ -20,7 +21,7 @@ const league = {
       offenseRating: 82,
       defenseRating: 83,
       recentResults: ['W', 'W', 'L', 'W'],
-      roster: [{ id: 11, pos: 'QB', ovr: 80, teamId: 1 }],
+      roster: [{ id: 11, pos: 'QB', ovr: 80, teamId: 1, depthChart: { rowKey: 'QB' } }],
     },
     {
       id: 2,
@@ -41,22 +42,34 @@ const league = {
 };
 
 describe('WeeklyPrepScreen', () => {
-  it('renders prep workflow sections for an upcoming game', () => {
-    const html = renderToString(<WeeklyPrepScreen league={league} onNavigate={vi.fn()} />);
-    expect(html).toContain('Opponent scout');
-    expect(html).toContain('Lineup readiness');
-    expect(html).toContain('Game plan recommendations');
-    expect(html).toContain('Active effects');
-    expect(html).toContain('Prep completion');
+  it('renders war room flow and completion chips', () => {
+    render(<WeeklyPrepScreen league={league} onNavigate={vi.fn()} />);
+    expect(screen.getByText(/Weekly Prep War Room/i)).toBeTruthy();
+    expect(screen.getByText(/Readiness Command/i)).toBeTruthy();
+    expect(screen.getByText(/Priority Actions/i)).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /Matchup Intel/i })).toBeTruthy();
+    expect(screen.getByText(/Prep Checklist/i)).toBeTruthy();
+    expect(screen.getByText(/Opponent (scouted|pending)/i)).toBeTruthy();
+  });
+
+  it('routes action cards and secondary HQ CTA through onNavigate', () => {
+    const onNavigate = vi.fn();
+    render(<WeeklyPrepScreen league={league} onNavigate={onNavigate} />);
+
+    screen.getAllByRole('button', { name: /open|review|adjust|set/i }).forEach((btn) => fireEvent.click(btn));
+    screen.getAllByRole('button', { name: /back to hq/i }).forEach((btn) => fireEvent.click(btn));
+
+    expect(onNavigate).toHaveBeenCalledWith('HQ');
+    expect(onNavigate.mock.calls.some((args) => String(args?.[0] ?? '').includes('Game Plan'))).toBe(true);
   });
 
   it('handles missing matchup data safely', () => {
-    const html = renderToString(
+    render(
       <WeeklyPrepScreen
         league={{ year: 2027, week: 1, userTeamId: 1, teams: [{ id: 1, name: 'Legacy', roster: [] }], schedule: { weeks: [] } }}
         onNavigate={vi.fn()}
       />,
     );
-    expect(html).toContain('Weekly prep unavailable');
+    expect(screen.getByText(/Weekly prep unavailable/i)).toBeTruthy();
   });
 });

--- a/src/ui/components/__tests__/weeklyLoopCohesion.test.jsx
+++ b/src/ui/components/__tests__/weeklyLoopCohesion.test.jsx
@@ -66,8 +66,8 @@ describe('weekly loop cohesion surfaces', () => {
 
   it('renders WeeklyPrepScreen matchup framing safely', () => {
     const html = renderToString(<WeeklyPrepScreen league={league} onNavigate={() => {}} />);
-    expect(html).toContain('Scout &amp; Prep');
-    expect(html).toContain('Lineup readiness');
+    expect(html).toContain('Weekly Prep War Room');
+    expect(html).toContain('Readiness Command');
   });
 
   it('renders GamePlanScreen strategy header safely', () => {

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -699,3 +699,29 @@
   .app-game-plan-team-pill--opp { justify-content: flex-start; text-align: left; }
   .app-game-plan-hero h1 { text-align: left; }
 }
+
+.weekly-prep-screen { gap: var(--space-2); }
+.weekly-prep-pill { font-size: var(--text-xs); border-radius: 999px; padding: 2px 8px; }
+.weekly-prep-hero-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.weekly-prep-team { display: flex; align-items: center; gap: 8px; font-size: var(--text-sm); }
+.weekly-prep-mini-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(180px, 100%), 1fr)); gap: 8px; font-size: var(--text-xs); }
+.weekly-prep-command-row { display: flex; gap: 8px; flex-wrap: wrap; }
+.weekly-prep-caption { margin: 0; font-size: var(--text-sm); color: var(--text-muted); }
+.weekly-prep-action-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(220px, 100%), 1fr)); gap: 8px; }
+.weekly-prep-action-card { border: 1px solid var(--hairline); border-radius: var(--radius-md); padding: 10px; display: grid; gap: 8px; background: color-mix(in srgb, var(--surface) 94%, black 6%); }
+.weekly-prep-action-head { display: flex; gap: 8px; justify-content: space-between; align-items: flex-start; }
+.weekly-prep-action-card p { margin: 0; font-size: var(--text-xs); color: var(--text-muted); }
+.weekly-prep-nav-row { display: flex; justify-content: flex-end; }
+.weekly-prep-intel-grid { display: grid; gap: 8px; grid-template-columns: repeat(auto-fit, minmax(min(200px, 100%), 1fr)); }
+.weekly-prep-intel-head { font-size: var(--text-xs); color: var(--text-muted); text-transform: uppercase; }
+.weekly-prep-intel-grid ul { margin: 4px 0 0; padding-left: 16px; display: grid; gap: 4px; }
+.weekly-prep-intel-grid li { font-size: var(--text-sm); }
+.weekly-prep-effects-grid { display: grid; gap: 6px; }
+.weekly-prep-effect-row { font-size: var(--text-sm); border: 1px solid var(--hairline); border-radius: var(--radius-md); padding: 8px; }
+
+@media (max-width: 480px) {
+  .weekly-prep-action-card .btn,
+  .weekly-prep-nav-row .btn {
+    min-height: 40px;
+  }
+}

--- a/src/ui/utils/weeklyPrepScreenModel.js
+++ b/src/ui/utils/weeklyPrepScreenModel.js
@@ -1,0 +1,162 @@
+import { deriveWeeklyPrepState } from './weeklyPrep.js';
+
+function safeNum(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function toneFromSeverity(severity = 'ok') {
+  if (severity === 'major_risk') return 'danger';
+  if (severity === 'minor_risk') return 'warning';
+  return 'success';
+}
+
+function mapRoute(route = 'HQ') {
+  if (route === 'Injuries') return 'Team:Injuries';
+  if (route === 'Roster Hub') return 'Team:Roster / Depth';
+  return route;
+}
+
+function buildPriorityActions(prep) {
+  const actions = [];
+  if (!prep) return actions;
+
+  const push = (item) => {
+    if (!item?.title || !item?.route) return;
+    if (actions.some((entry) => entry.route === item.route)) return;
+    actions.push(item);
+  };
+
+  if (!prep.completion?.planReviewed || safeNum(prep.matchup?.ovrGap, 0) <= -3) {
+    push({
+      id: 'plan',
+      title: 'Tune Game Plan',
+      reason: prep.recommendations?.[0]?.reason ?? 'Lock your tactical script before kickoff.',
+      statusTone: prep.completion?.planReviewed ? 'info' : 'warning',
+      statusLabel: prep.completion?.planReviewed ? 'Reviewed' : 'Needs review',
+      ctaLabel: 'Open Game Plan',
+      route: 'Game Plan',
+      completionStep: 'planReviewed',
+    });
+  }
+
+  if (!prep.completion?.lineupChecked || prep.lineupIssues?.length) {
+    const lineupIssue = prep.lineupIssues?.[0];
+    push({
+      id: 'lineup',
+      title: 'Set Lineup',
+      reason: lineupIssue?.detail ?? 'Confirm starters and depth chart assignments.',
+      statusTone: lineupIssue?.level === 'urgent' ? 'danger' : prep.completion?.lineupChecked ? 'info' : 'warning',
+      statusLabel: lineupIssue?.level === 'urgent' ? 'Blocker' : prep.completion?.lineupChecked ? 'Checked' : 'Pending',
+      ctaLabel: 'Open Roster / Depth',
+      route: 'Team:Roster / Depth',
+      completionStep: 'lineupChecked',
+    });
+  }
+
+  if (!prep.completion?.injuriesReviewed || prep.lineupIssues?.some((issue) => issue.actionTab === 'Injuries')) {
+    const injuryIssue = prep.lineupIssues?.find((issue) => issue.actionTab === 'Injuries');
+    push({
+      id: 'injuries',
+      title: 'Review Injuries',
+      reason: injuryIssue?.detail ?? 'Check injury timelines and replacement readiness.',
+      statusTone: injuryIssue?.level === 'urgent' ? 'danger' : prep.completion?.injuriesReviewed ? 'info' : 'warning',
+      statusLabel: prep.completion?.injuriesReviewed ? 'Reviewed' : 'Pending',
+      ctaLabel: 'Open Injuries',
+      route: 'Team:Injuries',
+      completionStep: 'injuriesReviewed',
+    });
+  }
+
+  if (!prep.completion?.opponentScouted || !(prep.opponentStrengths?.length || prep.opponentWeaknesses?.length)) {
+    push({
+      id: 'scout',
+      title: 'Scout Opponent',
+      reason: prep.keyMatchupNote ?? 'Review strengths, weaknesses, and pressure points.',
+      statusTone: prep.completion?.opponentScouted ? 'info' : 'warning',
+      statusLabel: prep.completion?.opponentScouted ? 'Scouted' : 'Pending',
+      ctaLabel: 'Review Matchup Intel',
+      route: 'Weekly Prep',
+      completionStep: 'opponentScouted',
+    });
+  }
+
+  return actions.slice(0, 4);
+}
+
+export function buildWeeklyPrepScreenModel({ league } = {}) {
+  const prep = deriveWeeklyPrepState(league);
+  const fallbackWeek = safeNum(league?.week, 1);
+  const week = safeNum(prep?.nextGame?.week, fallbackWeek);
+  const opponentAbbr = prep?.opponent?.abbr ?? prep?.opponent?.name ?? 'TBD';
+  const homeAway = prep?.nextGame ? (prep.nextGame.isHome ? 'Home' : 'Away') : 'TBD';
+  const matchupHeadline = prep?.nextGame
+    ? `${homeAway} matchup ${prep.nextGame.isHome ? 'vs' : '@'} ${opponentAbbr}`
+    : 'No opponent locked yet';
+
+  const completionValues = Object.values(prep?.completion ?? {});
+  const completedCount = completionValues.filter(Boolean).length;
+  const totalCount = completionValues.length || 4;
+  const readinessScore = Math.round((completedCount / totalCount) * 100);
+  const severity = prep?.prepSummary?.severity ?? 'minor_risk';
+  const readinessStatus = severity === 'major_risk'
+    ? 'Major Risk'
+    : readinessScore >= 100
+      ? 'Ready to Advance'
+      : readinessScore >= 50
+        ? 'Needs Attention'
+        : 'Major Risk';
+
+  const keyRiskLabel = prep?.pressurePoints?.[0]
+    ?? prep?.lineupIssues?.[0]?.label
+    ?? prep?.prepSummary?.reasons?.[0]
+    ?? 'No major matchup risk flagged yet.';
+
+  const matchupEdges = [
+    ...(prep?.opponentWeaknesses ?? []).map((item) => ({ type: 'weakness', text: item })),
+    ...(prep?.opponentStrengths ?? []).map((item) => ({ type: 'threat', text: item })),
+  ].slice(0, 3);
+
+  const lineupBlockers = (prep?.lineupIssues ?? []).filter((issue) => issue.level === 'urgent').slice(0, 2);
+  const priorityActions = buildPriorityActions(prep);
+  const topPrepTasks = priorityActions.slice(0, 3);
+
+  const recommendedNextAction = priorityActions[0]
+    ? {
+      label: priorityActions[0].ctaLabel,
+      route: mapRoute(priorityActions[0].route),
+      reason: priorityActions[0].reason,
+    }
+    : {
+      label: 'Back to HQ',
+      route: 'HQ',
+      reason: 'No blocking tasks detected.',
+    };
+
+  const readyToAdvance = readinessScore >= 100 && severity !== 'major_risk' && lineupBlockers.length === 0;
+
+  return {
+    prep,
+    week,
+    opponentAbbr,
+    homeAway,
+    matchupHeadline,
+    readinessScore,
+    readinessStatus,
+    readinessTone: toneFromSeverity(severity),
+    keyRiskLabel,
+    topPrepTasks,
+    matchupEdges,
+    lineupBlockers,
+    recommendedNextAction,
+    readyToAdvance,
+    routeTargets: {
+      gamePlan: 'Game Plan',
+      lineup: 'Team:Roster / Depth',
+      injuries: 'Team:Injuries',
+      scout: 'Weekly Prep',
+      hq: 'HQ',
+    },
+    priorityActions: priorityActions.map((item) => ({ ...item, route: mapRoute(item.route) })),
+  };
+}

--- a/src/ui/utils/weeklyPrepScreenModel.test.js
+++ b/src/ui/utils/weeklyPrepScreenModel.test.js
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { buildWeeklyPrepScreenModel } from './weeklyPrepScreenModel.js';
+
+const league = {
+  year: 2028,
+  week: 6,
+  seasonId: 's-2028',
+  phase: 'regular',
+  userTeamId: 1,
+  teams: [
+    {
+      id: 1,
+      name: 'Bears',
+      abbr: 'CHI',
+      wins: 4,
+      losses: 1,
+      ovr: 85,
+      offenseRating: 84,
+      defenseRating: 82,
+      roster: [
+        { id: 11, pos: 'QB', ovr: 86, teamId: 1, depthChart: { rowKey: 'QB' } },
+        { id: 12, pos: 'RB', ovr: 80, teamId: 1, injuredWeeks: 3, depthChart: { rowKey: 'RB' } },
+      ],
+    },
+    {
+      id: 2,
+      name: 'Lions',
+      abbr: 'DET',
+      wins: 2,
+      losses: 3,
+      ovr: 80,
+      offenseRating: 87,
+      defenseRating: 74,
+      ptsFor: 110,
+      ptsAgainst: 145,
+      roster: [],
+    },
+  ],
+  schedule: {
+    weeks: [{ week: 6, games: [{ id: 'g6', home: { id: 1 }, away: { id: 2 }, played: false }] }],
+  },
+};
+
+describe('weeklyPrepScreenModel', () => {
+  it('derives matchup headline, readiness status, and routed priority actions', () => {
+    const model = buildWeeklyPrepScreenModel({ league });
+    expect(model.matchupHeadline).toContain('Home matchup');
+    expect(['Needs Attention', 'Major Risk', 'Ready to Advance']).toContain(model.readinessStatus);
+    expect(model.priorityActions.length).toBeGreaterThan(0);
+    expect(model.priorityActions[0].route).toBeTruthy();
+    expect(model.routeTargets.lineup).toBe('Team:Roster / Depth');
+  });
+
+  it('has safe fallback when opponent/schedule are missing', () => {
+    const model = buildWeeklyPrepScreenModel({ league: { year: 2028, week: 1, userTeamId: 1, teams: [{ id: 1, name: 'Legacy', roster: [] }], schedule: { weeks: [] } } });
+    expect(model.matchupHeadline).toContain('No opponent locked yet');
+    expect(model.week).toBe(1);
+    expect(model.recommendedNextAction.route).toBeTruthy();
+    expect(Array.isArray(model.topPrepTasks)).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation
- Make Weekly Prep the central, mobile-first confirmation screen (a “War Room”) that ties HQ recommendations, opponent scouting, lineup/injury readiness, game-plan completion, and advance readiness together without changing simulation outcomes.
- Provide a single pure view-model to derive readiness, risks, prioritized actions, and safe fallbacks so presentational components stay simple and deterministic.
- Preserve existing prep progression semantics to avoid accidental changes to weekly simulation state while improving clarity and navigation cohesion.

### Description
- Added a pure screen model `buildWeeklyPrepScreenModel` that reuses `deriveWeeklyPrepState` and derives matchup headline, readiness score/status, key risk label, top prep tasks, matchup edges, lineup/injury blockers, recommended next action, ready-to-advance flag, and route targets, with safe fallbacks; file: `src/ui/utils/weeklyPrepScreenModel.js`.
- Refactored `WeeklyPrepScreen` into a mobile-first “Weekly Prep War Room” hierarchy (Hero header, Readiness Command, Priority Actions, Matchup Intel, Active Effects, Prep Checklist) that routes actions via `onNavigate` and marks related prep steps explicitly; file: `src/ui/components/WeeklyPrepScreen.jsx`.
- Kept `opponentScouted` behavior backward-compatible: opening Weekly Prep still fires `markWeeklyPrepStep(league, 'opponentScouted', true)` via `useEffect`, while action CTAs mark other completion steps before navigating.
- Added compact, mobile-first styles to `src/ui/styles/screen-system.css` to match existing screen-system patterns and tap targets, and added/updated unit tests for the new model and updated screen expectations (`src/ui/utils/weeklyPrepScreenModel.test.js`, updated `src/ui/components/__tests__/WeeklyPrepScreen.test.jsx`, updated `weeklyLoopCohesion` test).
- No simulation, schedule, roster, or outcome logic was modified; all changes are UI/view-model only and reuse existing helpers like `deriveWeeklyPrepState`, `buildGamePlanImpact`, and stored prep helpers.

### Testing
- Installed dependencies with `npm ci` (succeeded).
- Ran targeted unit tests with `npx vitest run src/ui/utils/weeklyPrep.test.js src/ui/utils/weeklyPrepScreenModel.test.js src/ui/components/__tests__/WeeklyPrepScreen.test.jsx src/ui/components/__tests__/weeklyLoopCohesion.test.jsx` and all tests passed (12 tests total, all passing).
- Built production bundle with `npm run build` (vite build succeeded) and ran Netlify parity/rules checks with `npm run check:deploy` (checks completed OK for parity and offline Netlify build).
- Playwright/e2e was not run because browser tooling/binaries are not available in this environment and were therefore skipped.
- Summary: unit tests, build, and deploy checks completed successfully; no simulation/regression tests were changed and no runtime simulation behavior was altered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeac975708832dbe62f0a1552d68b4)