### PR TITLE
Add lineup readiness model and quick actions to Roster / Depth

### DIFF
--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -65,6 +65,8 @@ import { TeamWorkspaceHeader, TeamCapSummaryStrip } from "./TeamWorkspacePrimiti
 import { ToneChip, DevelopmentSignalRow } from "./PlayerDevelopmentUI.jsx";
 import EmptyState from "./EmptyState.jsx";
 import { getPositionColor } from "../constants/positionColors.js";
+import { deriveRosterReadinessModel } from "../utils/rosterReadinessModel.js";
+import { markWeeklyPrepStep } from "../utils/weeklyPrep.js";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -2182,6 +2184,13 @@ export default function Roster({ league, actions, onPlayerSelect, onNavigate = n
   }
   const depthAssignments = autoBuildDepthChart(players, existingDepthAssignments);
   const depthAlerts = depthWarnings(depthAssignments, players);
+  const readiness = useMemo(() => deriveRosterReadinessModel({
+    league,
+    team,
+    roster: players,
+    source: initialState?.source ?? null,
+    assignments: depthAssignments,
+  }), [league, team, players, initialState?.source, depthAssignments]);
   const unassignedDepthCount = players.filter((p) => !p?.depthChart?.rowKey).length;
   const expiringCount = players.filter((p) => getContractYearsLeft(p) <= 1).length;
   const injuredCount = players.filter((p) => isInjuredPlayer(p)).length;
@@ -2210,6 +2219,41 @@ export default function Roster({ league, actions, onPlayerSelect, onNavigate = n
     return map;
   }, [players, team, chemistry, league?.week]);
   const developmentSummary = useMemo(() => summarizeRosterDevelopment(players, moraleById), [players, moraleById]);
+
+  const statusBadgeVariant = readiness.status === 'ready' ? 'secondary' : readiness.status === 'blocked' ? 'destructive' : 'outline';
+
+  const handleAutoBuildDepthChart = useCallback(async () => {
+    const updates = DEPTH_ROWS.flatMap((row) => (readiness.assignments?.[row.key] ?? []).map((playerId, index) => ({
+      playerId,
+      rowKey: row.key,
+      newOrder: index + 1,
+    })));
+
+    if (updates.length === 0) return;
+
+    setPlayers((prev) => prev.map((player) => {
+      const update = updates.find((entry) => Number(entry.playerId) === Number(player.id));
+      if (!update) return player;
+      return {
+        ...player,
+        depthOrder: update.newOrder,
+        depthChart: {
+          ...(player.depthChart ?? {}),
+          rowKey: update.rowKey,
+          order: update.newOrder,
+        },
+      };
+    }));
+
+    if (actions?.updateDepthChart) {
+      await actions.updateDepthChart(updates);
+      await fetchRoster();
+    }
+
+    if (readiness.safeToMarkLineupChecked) {
+      markWeeklyPrepStep(league, 'lineupChecked', true);
+    }
+  }, [actions, fetchRoster, league, readiness.assignments, readiness.safeToMarkLineupChecked]);
 
   return (
     <div>
@@ -2245,6 +2289,35 @@ export default function Roster({ league, actions, onPlayerSelect, onNavigate = n
         starterHealth={`${Math.max(0, starterCount - injuredCount)}/${starterCount || 0} available`}
         expiringCount={expiringCount}
       />
+
+      <Card className="card-premium" style={{ marginBottom: "var(--space-2)", padding: "var(--space-3) var(--space-4)" }}>
+        <CardContent style={{ display: 'grid', gap: 10 }}>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+            <Badge variant={statusBadgeVariant}>Lineup Readiness: {readiness.statusLabel}</Badge>
+            <Badge variant="outline">Roster {readiness.rosterCount}/53</Badge>
+            <Badge variant={readiness.missingStarterCount > 0 ? 'destructive' : 'secondary'}>Missing starters: {readiness.missingStarterCount}</Badge>
+            <Badge variant={readiness.injuryReplacementConcerns > 0 ? 'destructive' : 'outline'}>Injury concerns: {readiness.injuryReplacementConcerns}</Badge>
+          </div>
+          <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{readiness.starterReadiness}</div>
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            {readiness.topRiskyPositionGroups.length > 0
+              ? readiness.topRiskyPositionGroups.map((group) => (
+                  <Badge key={group.rowKey} variant="outline">{group.label}: {group.reason}</Badge>
+                ))
+              : <Badge variant="secondary">No high-risk position groups</Badge>}
+          </div>
+          <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-subtle)' }}>
+            Recommended action: <strong style={{ color: 'var(--text)' }}>{readiness.recommendedNextAction}</strong>
+          </div>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            <Button size="sm" onClick={() => { setViewMode('depth'); setInitialFilter('DEPTH'); }}>Open Depth Chart</Button>
+            <Button variant="outline" size="sm" onClick={() => onNavigate?.('Injuries')}>Review Injuries</Button>
+            {readiness.routeHints.showBackToWeeklyPrep && <Button variant="outline" size="sm" onClick={() => onNavigate?.('Weekly Prep')}>Back to Weekly Prep</Button>}
+            {readiness.routeHints.showBackToHQ && <Button variant="outline" size="sm" onClick={() => onNavigate?.('HQ')}>Back to HQ</Button>}
+          </div>
+        </CardContent>
+      </Card>
+
       <Card className="card-premium" style={{ marginBottom: "var(--space-2)", padding: "var(--space-3) var(--space-4)" }}>
         <CardContent style={{ display: "grid", gap: 8 }}>
           <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 800, textTransform: "uppercase", letterSpacing: ".08em" }}>
@@ -2404,6 +2477,9 @@ export default function Roster({ league, actions, onPlayerSelect, onNavigate = n
                   </div>
                 )) : <div style={{ fontSize: 12, color: 'var(--success)' }}>Starter requirements currently covered.</div>}
                 <div style={{ display: "flex", gap: 8, marginTop: 4 }}>
+                  <Button variant="outline" size="sm" onClick={handleAutoBuildDepthChart}>
+                    Auto-Build Depth Chart
+                  </Button>
                   <Button variant="outline" size="sm" onClick={() => actions.repairRoster(teamId).then(fetchRoster)}>
                     Auto-Fix Missing Assignments
                   </Button>
@@ -2413,6 +2489,9 @@ export default function Roster({ league, actions, onPlayerSelect, onNavigate = n
                   <Button variant="outline" size="sm" onClick={() => actions.optimizeRoster(teamId).then(fetchRoster)}>
                     Optimize for Plan
                   </Button>
+                  <Button variant="outline" size="sm" onClick={() => onNavigate?.('Injuries')}>Review Injuries</Button>
+                  <Button variant="outline" size="sm" onClick={() => onNavigate?.('Weekly Prep')}>Back to Weekly Prep</Button>
+                  <Button variant="outline" size="sm" onClick={() => onNavigate?.('HQ')}>Back to HQ</Button>
                 </div>
               </div>
               <DepthChartView players={players} onReorder={handleReorderDepthChart} schemeName={(() => {

--- a/src/ui/components/TeamHub.jsx
+++ b/src/ui/components/TeamHub.jsx
@@ -68,7 +68,9 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
   const pressureGroups = useMemo(() => getPositionGroupPressure(roster), [roster]);
 
   useEffect(() => {
-    setSubtab(normalizeSection(initialSection));
+    const next = normalizeSection(initialSection);
+    setSubtab(next);
+    if (next === 'Roster / Depth') setRosterMode('depth');
   }, [initialSection]);
 
   const latestGame = useMemo(() => {

--- a/src/ui/components/__tests__/RosterReadinessActions.test.jsx
+++ b/src/ui/components/__tests__/RosterReadinessActions.test.jsx
@@ -1,0 +1,83 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import Roster from '../Roster.jsx';
+
+const { markWeeklyPrepStep, readinessState } = vi.hoisted(() => ({
+  markWeeklyPrepStep: vi.fn(),
+  readinessState: {
+  status: 'needs_attention',
+  statusLabel: 'Needs Attention',
+  rosterCount: 2,
+  starterReadiness: '2/13 staffed groups',
+  missingStarterCount: 5,
+  injuryReplacementConcerns: 1,
+  topRiskyPositionGroups: [{ rowKey: 'QB', label: 'Quarterback', reason: 'Starter injured' }],
+  recommendedNextAction: 'Review injuries and promote healthy backups.',
+  safeToMarkLineupChecked: false,
+  routeHints: { showBackToWeeklyPrep: true, showBackToHQ: true },
+  warnings: [],
+  assignments: { QB: [1, 2] },
+  },
+}));
+
+vi.mock('../../utils/weeklyPrep.js', () => ({ markWeeklyPrepStep }));
+vi.mock('../../utils/rosterReadinessModel.js', () => ({ deriveRosterReadinessModel: () => readinessState }));
+
+describe('Roster lineup readiness actions', () => {
+  beforeEach(() => {
+    markWeeklyPrepStep.mockReset();
+    readinessState.safeToMarkLineupChecked = false;
+  });
+
+  const league = { userTeamId: 1, week: 5, phase: 'regular', teams: [{ id: 1, strategies: {} }] };
+  const payload = {
+    team: { id: 1, name: 'Sharks' },
+    players: [
+      { id: 1, name: 'QB1', pos: 'QB', ovr: 80, teamId: 1, depthChart: { rowKey: 'QB', order: 1 } },
+      { id: 2, name: 'QB2', pos: 'QB', ovr: 72, teamId: 1, depthChart: { rowKey: 'QB', order: 2 } },
+    ],
+  };
+
+  it('calls existing Auto-Build persistence and navigation callbacks', async () => {
+    const onNavigate = vi.fn();
+    const actions = {
+      getRoster: vi.fn(async () => ({ payload })),
+      updateDepthChart: vi.fn(async () => ({})),
+      repairRoster: vi.fn(async () => ({})),
+      optimizeRoster: vi.fn(async () => ({})),
+    };
+
+    render(<Roster league={league} actions={actions} onNavigate={onNavigate} onPlayerSelect={() => {}} initialViewMode="depth" />);
+
+    await screen.findByText(/auto-build depth chart/i);
+    fireEvent.click(screen.getAllByRole('button', { name: /auto-build depth chart/i })[0]);
+
+    await waitFor(() => expect(actions.updateDepthChart).toHaveBeenCalled());
+
+    fireEvent.click(screen.getAllByRole('button', { name: /back to weekly prep/i })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: /back to hq/i })[0]);
+    expect(onNavigate).toHaveBeenCalledWith('Weekly Prep');
+    expect(onNavigate).toHaveBeenCalledWith('HQ');
+  });
+
+  it('marks lineupChecked only when readiness is safe', async () => {
+    const actions = {
+      getRoster: vi.fn(async () => ({ payload })),
+      updateDepthChart: vi.fn(async () => ({})),
+      repairRoster: vi.fn(async () => ({})),
+      optimizeRoster: vi.fn(async () => ({})),
+    };
+
+    const { rerender } = render(<Roster league={league} actions={actions} onNavigate={() => {}} onPlayerSelect={() => {}} initialViewMode="depth" />);
+    await screen.findByText(/auto-build depth chart/i);
+    fireEvent.click(screen.getAllByRole('button', { name: /auto-build depth chart/i })[0]);
+    expect(markWeeklyPrepStep).not.toHaveBeenCalled();
+
+    readinessState.safeToMarkLineupChecked = true;
+    rerender(<Roster league={league} actions={actions} onNavigate={() => {}} onPlayerSelect={() => {}} initialViewMode="depth" />);
+    screen.getAllByRole('button', { name: /auto-build depth chart/i }).forEach((button) => fireEvent.click(button));
+    await waitFor(() => expect(markWeeklyPrepStep).toHaveBeenCalledWith(league, 'lineupChecked', true));
+  });
+});

--- a/src/ui/components/__tests__/TeamHubRouting.test.jsx
+++ b/src/ui/components/__tests__/TeamHubRouting.test.jsx
@@ -1,0 +1,27 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import TeamHub from '../TeamHub.jsx';
+
+const rosterSpy = vi.fn(() => <div data-testid="roster-proxy">Roster Proxy</div>);
+vi.mock('../Roster.jsx', () => ({ default: (props) => rosterSpy(props) }));
+
+describe('TeamHub roster/depth routing context', () => {
+  it('opens depth readiness mode when entering Team:Roster / Depth section', () => {
+    const league = {
+      userTeamId: 1,
+      year: 2026,
+      week: 4,
+      phase: 'regular',
+      teams: [{ id: 1, name: 'Sharks', wins: 2, losses: 1, roster: [] }],
+      schedule: [],
+    };
+
+    render(<TeamHub league={league} actions={{}} initialSection="Roster / Depth" onNavigate={() => {}} onPlayerSelect={() => {}} />);
+
+    expect(screen.getByTestId('roster-proxy')).toBeTruthy();
+    const lastProps = rosterSpy.mock.calls.at(-1)?.[0] ?? {};
+    expect(lastProps.initialViewMode).toBe('depth');
+  });
+});

--- a/src/ui/utils/rosterReadinessModel.js
+++ b/src/ui/utils/rosterReadinessModel.js
@@ -1,0 +1,162 @@
+import { DEPTH_CHART_ROWS, autoBuildDepthChart, depthWarnings } from '../../core/depthChart.js';
+
+function toNumber(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function isInjured(player) {
+  return toNumber(player?.injury?.weeksRemaining ?? player?.injuryWeeksRemaining ?? player?.injury?.gamesRemaining ?? 0) > 0
+    || ['injured', 'ir'].includes(String(player?.status ?? '').toLowerCase());
+}
+
+function buildExistingAssignments(players = []) {
+  const assignments = {};
+  for (const row of DEPTH_CHART_ROWS) assignments[row.key] = [];
+  for (const player of players) {
+    const rowKey = player?.depthChart?.rowKey;
+    if (!rowKey || !assignments[rowKey]) continue;
+    assignments[rowKey].push(Number(player.id));
+  }
+  for (const row of DEPTH_CHART_ROWS) {
+    assignments[row.key] = assignments[row.key]
+      .filter((id) => Number.isFinite(id))
+      .sort((a, b) => {
+        const playerA = players.find((player) => Number(player?.id) === Number(a));
+        const playerB = players.find((player) => Number(player?.id) === Number(b));
+        return toNumber(playerA?.depthChart?.order ?? playerA?.depthOrder, 999) - toNumber(playerB?.depthChart?.order ?? playerB?.depthOrder, 999);
+      });
+  }
+  return assignments;
+}
+
+function topRiskGroups(rows = []) {
+  return rows
+    .sort((a, b) => b.riskScore - a.riskScore || a.label.localeCompare(b.label))
+    .slice(0, 3)
+    .map((row) => ({
+      rowKey: row.rowKey,
+      label: row.label,
+      riskScore: row.riskScore,
+      reason: row.reason,
+    }));
+}
+
+export function deriveRosterReadinessModel({
+  league = null,
+  team = null,
+  roster = [],
+  source = null,
+  assignments = null,
+} = {}) {
+  const safeRoster = Array.isArray(roster) ? roster.filter(Boolean) : [];
+
+  if (!team) {
+    return {
+      status: 'blocked',
+      statusLabel: 'Blocked',
+      rosterCount: 0,
+      starterReadiness: 'No team context',
+      missingStarterCount: DEPTH_CHART_ROWS.length,
+      injuryReplacementConcerns: 0,
+      topRiskyPositionGroups: [],
+      recommendedNextAction: 'Return to HQ and select a controlled team.',
+      safeToMarkLineupChecked: false,
+      routeHints: { showBackToWeeklyPrep: true, showBackToHQ: true, source: source ?? 'unknown' },
+      warnings: [],
+      assignments: {},
+    };
+  }
+
+  if (safeRoster.length === 0) {
+    return {
+      status: 'blocked',
+      statusLabel: 'Blocked',
+      rosterCount: 0,
+      starterReadiness: '0 staffed groups',
+      missingStarterCount: DEPTH_CHART_ROWS.length,
+      injuryReplacementConcerns: 0,
+      topRiskyPositionGroups: [],
+      recommendedNextAction: 'Sign players before setting the depth chart.',
+      safeToMarkLineupChecked: false,
+      routeHints: { showBackToWeeklyPrep: true, showBackToHQ: true, source: source ?? 'unknown' },
+      warnings: [],
+      assignments: {},
+    };
+  }
+
+  const resolvedAssignments = assignments && typeof assignments === 'object'
+    ? assignments
+    : autoBuildDepthChart(safeRoster, buildExistingAssignments(safeRoster));
+  const warnings = depthWarnings(resolvedAssignments, safeRoster);
+  const byId = new Map(safeRoster.map((player) => [Number(player.id), player]));
+
+  const perRowRisk = DEPTH_CHART_ROWS.map((row) => {
+    const ids = Array.isArray(resolvedAssignments?.[row.key]) ? resolvedAssignments[row.key] : [];
+    const starter = byId.get(Number(ids[0]));
+    const injuredInRow = ids
+      .map((id) => byId.get(Number(id)))
+      .filter(Boolean)
+      .filter((player) => isInjured(player)).length;
+    const missing = ids.length === 0 ? 1 : 0;
+    const thin = ids.length < row.min ? 1 : 0;
+    const injuredStarter = starter && isInjured(starter) ? 1 : 0;
+    const riskScore = (missing * 100) + (injuredStarter * 45) + (thin * 20) + (injuredInRow * 8);
+    let reason = 'Stable';
+    if (missing) reason = 'No assigned starter';
+    else if (injuredStarter) reason = 'Starter injured';
+    else if (thin) reason = `Depth thin (${ids.length}/${row.min})`;
+    else if (injuredInRow > 1) reason = `${injuredInRow} injured in group`;
+
+    return {
+      rowKey: row.key,
+      label: row.label,
+      riskScore,
+      reason,
+      missing,
+      thin,
+      injuredStarter,
+    };
+  });
+
+  const missingStarterCount = perRowRisk.reduce((sum, row) => sum + row.missing, 0);
+  const injuryReplacementConcerns = perRowRisk.reduce((sum, row) => sum + row.injuredStarter + (row.thin && row.injuredStarter ? 1 : 0), 0);
+  const riskyGroups = topRiskGroups(perRowRisk.filter((row) => row.riskScore > 0));
+  const staffedGroups = DEPTH_CHART_ROWS.length - missingStarterCount;
+
+  const status = missingStarterCount > 0
+    ? 'blocked'
+    : injuryReplacementConcerns > 0 || riskyGroups.length > 0
+      ? 'needs_attention'
+      : 'ready';
+  const statusLabel = status === 'ready' ? 'Ready' : status === 'blocked' ? 'Blocked' : 'Needs Attention';
+
+  const recommendedNextAction = missingStarterCount > 0
+    ? 'Auto-build depth chart and fill missing starter slots.'
+    : injuryReplacementConcerns > 0
+      ? 'Review injuries and promote healthy backups.'
+      : riskyGroups.length > 0
+        ? `Review ${riskyGroups[0].label} depth order for stability.`
+        : 'Lineup is stable. Return to Weekly Prep and advance readiness.';
+
+  const safeToMarkLineupChecked = missingStarterCount === 0 && injuryReplacementConcerns === 0;
+
+  return {
+    status,
+    statusLabel,
+    rosterCount: safeRoster.length,
+    starterReadiness: `${staffedGroups}/${DEPTH_CHART_ROWS.length} staffed groups`,
+    missingStarterCount,
+    injuryReplacementConcerns,
+    topRiskyPositionGroups: riskyGroups,
+    recommendedNextAction,
+    safeToMarkLineupChecked,
+    routeHints: {
+      showBackToWeeklyPrep: String(league?.phase ?? '').toLowerCase() === 'regular' || source === 'weekly-prep',
+      showBackToHQ: true,
+      source: source ?? 'roster',
+    },
+    warnings,
+    assignments: resolvedAssignments,
+  };
+}

--- a/src/ui/utils/rosterReadinessModel.test.js
+++ b/src/ui/utils/rosterReadinessModel.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { deriveRosterReadinessModel } from './rosterReadinessModel.js';
+
+const team = { id: 1, name: 'Sharks' };
+
+function makePlayer(id, pos, overrides = {}) {
+  return {
+    id,
+    teamId: 1,
+    name: `P${id}`,
+    pos,
+    ovr: 78,
+    depthChart: { rowKey: pos === 'DE' ? 'EDGE' : pos, order: 1 },
+    ...overrides,
+  };
+}
+
+describe('deriveRosterReadinessModel', () => {
+  it('returns ready status for a healthy balanced roster', () => {
+    const roster = [makePlayer(1, 'QB'), makePlayer(2, 'RB'), makePlayer(3, 'WR'), makePlayer(4, 'TE'), makePlayer(5, 'OL'), makePlayer(6, 'DE', { depthChart: { rowKey: 'EDGE', order: 1 } }), makePlayer(7, 'DT', { depthChart: { rowKey: 'IDL', order: 1 } }), makePlayer(8, 'LB'), makePlayer(9, 'CB'), makePlayer(10, 'S'), makePlayer(11, 'K'), makePlayer(12, 'P')];
+    const assignments = {
+      QB: [1, 1],
+      RB: [2, 2, 2],
+      WR: [3, 3, 3, 3],
+      TE: [4, 4],
+      OL: [5, 5, 5, 5, 5, 5],
+      EDGE: [6, 6, 6],
+      IDL: [7, 7, 7],
+      LB: [8, 8, 8, 8],
+      CB: [9, 9, 9, 9],
+      S: [10, 10, 10],
+      K: [11],
+      P: [12],
+      RS: [3],
+    };
+    const model = deriveRosterReadinessModel({ team, roster, league: { phase: 'regular' }, assignments });
+    expect(model.status).toBe('ready');
+    expect(model.missingStarterCount).toBe(0);
+    expect(model.safeToMarkLineupChecked).toBe(true);
+  });
+
+  it('flags missing starter fallback as blocked', () => {
+    const model = deriveRosterReadinessModel({ team, roster: [makePlayer(1, 'QB')] });
+    expect(model.status).toBe('blocked');
+    expect(model.missingStarterCount).toBeGreaterThan(0);
+    expect(model.safeToMarkLineupChecked).toBe(false);
+  });
+
+  it('flags injury replacement concerns', () => {
+    const roster = [makePlayer(1, 'QB', { injuryWeeksRemaining: 2 }), makePlayer(2, 'QB', { depthChart: { rowKey: 'QB', order: 2 } })];
+    const model = deriveRosterReadinessModel({ team, roster });
+    expect(model.injuryReplacementConcerns).toBeGreaterThan(0);
+    expect(model.status).not.toBe('ready');
+  });
+
+  it('handles empty roster and missing team fallback safely', () => {
+    expect(deriveRosterReadinessModel({ team: null, roster: [] }).status).toBe('blocked');
+    expect(deriveRosterReadinessModel({ team, roster: [] }).recommendedNextAction).toMatch(/sign players/i);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a fast, mobile-first "lineup readiness" experience on the existing Roster / Depth screen so Weekly Prep and HQ can answer whether the lineup is ready and what to do next without rewriting the roster system. 
- Surface missing starters, injury replacement risk, and quick recovery actions while preserving the dense roster table and existing depth/persistence flows.

### Description
- Added a pure helper `src/ui/utils/rosterReadinessModel.js` that derives roster count, starter readiness, missing-starter count, injury replacement concerns, top-3 risky position groups, recommended next action, a `safeToMarkLineupChecked` flag, route/context hints, and robust fallbacks for missing team/empty roster/malformed inputs, reusing `autoBuildDepthChart`, `depthWarnings`, and `DEPTH_CHART_ROWS`.
- Integrated the readiness model into `src/ui/components/Roster.jsx` and added a compact Lineup Readiness command card near the top that shows status chip, roster count, missing starters, injury concerns, top risky groups, recommended action, and quick navigation (Open Depth, Review Injuries, Back to Weekly Prep, Back to HQ).
- Added depth quick actions in the Depth view: an "Auto-Build Depth Chart" CTA that applies the model's assignment list and calls existing `actions.updateDepthChart` when available (otherwise updates remain local UI state), plus existing repair/optimize actions and explicit Review Injuries / Back buttons.
- Gate calling `markWeeklyPrepStep(league, 'lineupChecked', true)` to Roster only when the readiness helper reports it is safe (no missing starters and no injury replacement concerns), preserving the previous HQ/Weekly Prep marking behavior and preventing false saves.
- Tweaked TeamHub so entering the Team:Roster / Depth destination opens the nested Roster in depth mode by default while keeping all existing roster features intact (filters, profile modal, compare, contracts, trade controls, scheme/morale, and the depth UI).
- Styling and layout changes are additive and mobile-first within `Roster.jsx` (local component styles and existing card primitives); no global system stylesheet rewrite was performed.

### Testing
- Unit tests: ran `npm run test:unit` for targeted suites and all added/updated tests passed (total tests run: the modified helper and three new component tests passed). Files exercised: `src/ui/utils/rosterReadinessModel.test.js`, `src/ui/components/__tests__/RosterReadinessActions.test.jsx`, `src/ui/components/__tests__/TeamHubRouting.test.jsx`, plus existing `rosterInitialState` and `managementScreenRouting` tests used in validation; outcome: all passed.
- Install/build/check: ran `npm ci` (succeeded), `npm run build` (production build succeeded; noted large chunk warnings), and `npm run check:deploy` (Netlify parity and offline build checks succeeded).
- E2E / Playwright: not executed because browser binaries / E2E environment were not invoked in this run and were therefore skipped.

Notes: auto-build persistence uses the existing `actions.updateDepthChart` when present; if that action is absent the UI applies assignments locally and does not claim persistence. No simulation or core depth-chart algorithms were changed – the work is an additive, UX-focused readiness layer with conservative persistence calls and explicit tests covering healthy, missing-starter, injury-concern, and empty-team fallbacks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef4873b80832d8457d038d265ee21)