### PR TITLE
Upgrade Injury Report into weekly availability command center

### DIFF
--- a/src/ui/components/InjuryReport.jsx
+++ b/src/ui/components/InjuryReport.jsx
@@ -1,24 +1,16 @@
 /**
- * InjuryReport.jsx — League-wide injury report with focus on user's team.
+ * InjuryReport.jsx — Availability-first injury operations screen.
  *
- * Shows injured players across the league with severity color-coding,
- * recovery timeline visualization, filtering, sorting, and quick stats.
- *
- * Props:
- *  - league: league view-model (roster, teams, userTeamId, season)
- *  - onPlayerSelect: (playerId) => void
+ * Top hierarchy now supports weekly readiness loop while preserving
+ * league-wide injury browsing, filters, stats, and injury history.
  */
 
 import React, { useState, useMemo, useEffect } from "react";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from "@/components/ui/table";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { markWeeklyPrepStep } from "../utils/weeklyPrep.js";
-
-// ── Constants ────────────────────────────────────────────────────────────────
+import { deriveInjuryReadinessModel, getInjuryWeeksRemaining, isPlayerInjured } from "../utils/injuryReadinessModel.js";
 
 const POS_COLORS = {
   QB: "#ef4444", RB: "#22c55e", WR: "#3b82f6", TE: "#a855f7",
@@ -26,25 +18,20 @@ const POS_COLORS = {
   S: "#6366f1", K: "#9ca3af", P: "#6b7280",
 };
 
-const SEVERITY_LEVELS = {
-  Minor:         { color: "#22c55e", bg: "rgba(34,197,94,0.12)",  label: "Minor" },
-  Moderate:      { color: "#eab308", bg: "rgba(234,179,8,0.12)",  label: "Moderate" },
-  Serious:       { color: "#f97316", bg: "rgba(249,115,22,0.12)", label: "Serious" },
-  Severe:        { color: "#ef4444", bg: "rgba(239,68,68,0.12)",  label: "Severe" },
-  "Season-Ending": { color: "#991b1b", bg: "rgba(153,27,27,0.15)", label: "Season-Ending" },
+const STATUS_COLORS = {
+  ok: { color: "#22c55e", bg: "rgba(34,197,94,0.14)", border: "rgba(34,197,94,0.4)" },
+  info: { color: "#3b82f6", bg: "rgba(59,130,246,0.14)", border: "rgba(59,130,246,0.4)" },
+  warning: { color: "#f59e0b", bg: "rgba(245,158,11,0.14)", border: "rgba(245,158,11,0.4)" },
+  danger: { color: "#ef4444", bg: "rgba(239,68,68,0.14)", border: "rgba(239,68,68,0.4)" },
 };
 
-function getSeverity(injury) {
-  if (!injury) return SEVERITY_LEVELS.Minor;
-  const w = injury.weeksRemaining ?? 0;
-  if (injury.type?.toLowerCase().includes("acl") ||
-      injury.type?.toLowerCase().includes("achilles") ||
-      injury.seasonEnding || w >= 16) return SEVERITY_LEVELS["Season-Ending"];
-  if (w >= 8) return SEVERITY_LEVELS.Severe;
-  if (w >= 4) return SEVERITY_LEVELS.Serious;
-  if (w >= 2) return SEVERITY_LEVELS.Moderate;
-  return SEVERITY_LEVELS.Minor;
-}
+const SEVERITY_LEVELS = {
+  Minor: { color: "#22c55e", bg: "rgba(34,197,94,0.12)", label: "Minor" },
+  Moderate: { color: "#eab308", bg: "rgba(234,179,8,0.12)", label: "Moderate" },
+  Serious: { color: "#f97316", bg: "rgba(249,115,22,0.12)", label: "Serious" },
+  Severe: { color: "#ef4444", bg: "rgba(239,68,68,0.12)", label: "Severe" },
+  "Season-Ending": { color: "#991b1b", bg: "rgba(153,27,27,0.15)", label: "Season-Ending" },
+};
 
 const POS_FILTERS = ["ALL", "QB", "RB", "WR", "TE", "OL", "DL", "LB", "CB", "S", "K", "P"];
 const SEVERITY_FILTERS = ["ALL", "Minor", "Moderate", "Serious", "Severe", "Season-Ending"];
@@ -56,46 +43,15 @@ const SORT_OPTIONS = [
 
 const SEVERITY_ORDER = { "Season-Ending": 5, Severe: 4, Serious: 3, Moderate: 2, Minor: 1 };
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
-
-function getAllInjuredPlayers(league) {
-  const players = [];
-  const teams = league.teams || [];
-
-  for (const team of teams) {
-    const roster = team.roster || team.players || [];
-    for (const p of roster) {
-      if (p.injured || (p.injury && p.injury.weeksRemaining > 0)) {
-        players.push({
-          ...p,
-          teamName: team.name || team.abbr || "???",
-          teamAbbr: team.abbr || team.name?.slice(0, 3)?.toUpperCase() || "???",
-          teamId: team.id ?? team.tid,
-        });
-      }
-    }
-  }
-
-  // Also check league.roster for user team players not in teams array
-  if (league.roster) {
-    const existingIds = new Set(players.map(p => p.id ?? p.pid));
-    for (const p of league.roster) {
-      if ((p.injured || (p.injury && p.injury.weeksRemaining > 0)) && !existingIds.has(p.id ?? p.pid)) {
-        const userTeam = teams.find(t => (t.id ?? t.tid) === league.userTeamId);
-        players.push({
-          ...p,
-          teamName: userTeam?.name || "My Team",
-          teamAbbr: userTeam?.abbr || "USR",
-          teamId: league.userTeamId,
-        });
-      }
-    }
-  }
-
-  return players;
+function getSeverity(injury) {
+  if (!injury) return SEVERITY_LEVELS.Minor;
+  const w = getInjuryWeeksRemaining({ injury });
+  if (injury.type?.toLowerCase().includes("acl") || injury.type?.toLowerCase().includes("achilles") || injury.seasonEnding || w >= 16) return SEVERITY_LEVELS["Season-Ending"];
+  if (w >= 8) return SEVERITY_LEVELS.Severe;
+  if (w >= 4) return SEVERITY_LEVELS.Serious;
+  if (w >= 2) return SEVERITY_LEVELS.Moderate;
+  return SEVERITY_LEVELS.Minor;
 }
-
-// ── Timeline Bar ─────────────────────────────────────────────────────────────
 
 function RecoveryTimeline({ weeksRemaining, totalWeeks, severity }) {
   const total = totalWeeks || Math.max(weeksRemaining + 2, weeksRemaining * 1.5) || 4;
@@ -104,29 +60,16 @@ function RecoveryTimeline({ weeksRemaining, totalWeeks, severity }) {
 
   return (
     <div style={{ width: "100%", marginTop: 6 }}>
-      <div style={{
-        display: "flex", justifyContent: "space-between",
-        fontSize: 10, color: "var(--text-muted)", marginBottom: 3,
-      }}>
+      <div style={{ display: "flex", justifyContent: "space-between", fontSize: 10, color: "var(--text-muted)", marginBottom: 3 }}>
         <span>Recovery Progress</span>
         <span>{weeksRemaining}w remaining</span>
       </div>
-      <div style={{
-        width: "100%", height: 6, borderRadius: 3,
-        background: "var(--hairline)",
-        overflow: "hidden",
-      }}>
-        <div style={{
-          width: `${pct}%`, height: "100%", borderRadius: 3,
-          background: severity.color,
-          transition: "width 0.6s ease",
-        }} />
+      <div style={{ width: "100%", height: 6, borderRadius: 3, background: "var(--hairline)", overflow: "hidden" }}>
+        <div style={{ width: `${pct}%`, height: "100%", borderRadius: 3, background: severity.color, transition: "width 0.6s ease" }} />
       </div>
     </div>
   );
 }
-
-// ── Injury Card ──────────────────────────────────────────────────────────────
 
 function InjuryCard({ player, onPlayerSelect, showTeam = false }) {
   const injury = player.injury || {};
@@ -134,35 +77,28 @@ function InjuryCard({ player, onPlayerSelect, showTeam = false }) {
   const pos = player.pos || player.position || "??";
   const posColor = POS_COLORS[pos] || "var(--text-muted)";
   const isIR = player.onIR || injury.ir || false;
+  const weeksRemaining = getInjuryWeeksRemaining(player);
 
   return (
-    <div
+    <button
+      type="button"
       className="fade-in"
       onClick={() => onPlayerSelect?.(player.id ?? player.pid)}
       style={{
+        width: "100%",
+        textAlign: "left",
         background: "var(--surface)",
         border: `1px solid var(--hairline)`,
         borderLeft: `4px solid ${severity.color}`,
         borderRadius: 10,
         padding: "14px 16px",
         cursor: onPlayerSelect ? "pointer" : "default",
-        transition: "transform 0.15s, box-shadow 0.15s",
         display: "flex",
         flexDirection: "column",
         gap: 8,
       }}
-      onMouseEnter={e => {
-        e.currentTarget.style.transform = "translateY(-2px)";
-        e.currentTarget.style.boxShadow = "0 4px 16px rgba(0,0,0,0.12)";
-      }}
-      onMouseLeave={e => {
-        e.currentTarget.style.transform = "";
-        e.currentTarget.style.boxShadow = "";
-      }}
     >
-      {/* Header row */}
       <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-        {/* Player avatar circle */}
         <div style={{
           width: 40, height: 40, borderRadius: "50%", flexShrink: 0,
           background: `${posColor}18`, border: `2px solid ${posColor}`,
@@ -174,67 +110,39 @@ function InjuryCard({ player, onPlayerSelect, showTeam = false }) {
 
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
-            <span style={{ fontWeight: 700, fontSize: 14, color: "var(--text)" }}>
-              {player.name || "Unknown"}
-            </span>
-            {isIR && (
-              <Badge variant="destructive" className="text-xs px-1 py-0">IR</Badge>
-            )}
+            <span style={{ fontWeight: 700, fontSize: 14, color: "var(--text)" }}>{player.name || "Unknown"}</span>
+            {isIR && <Badge variant="destructive" className="text-xs px-1 py-0">IR</Badge>}
           </div>
-          <div style={{
-            display: "flex", alignItems: "center", gap: 6, marginTop: 2,
-            fontSize: 12, color: "var(--text-muted)",
-          }}>
-            <Badge variant="outline" style={{
-              fontWeight: 700, fontSize: 10, padding: "1px 6px", borderRadius: 4,
-              background: `${posColor}18`, color: posColor,
-            }}>{pos}</Badge>
+          <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 2, fontSize: 12, color: "var(--text-muted)" }}>
+            <Badge variant="outline" style={{ fontWeight: 700, fontSize: 10, padding: "1px 6px", borderRadius: 4, background: `${posColor}18`, color: posColor }}>{pos}</Badge>
             <span>OVR {player.ovr ?? "?"}</span>
             {showTeam && <span>· {player.teamAbbr}</span>}
           </div>
         </div>
 
-        {/* Severity badge */}
-        <Badge
-          style={{ background: severity.bg, color: severity.color, border: "none" }}
-          className="text-xs font-bold whitespace-nowrap"
-        >
+        <Badge style={{ background: severity.bg, color: severity.color, border: "none" }} className="text-xs font-bold whitespace-nowrap">
           {severity.label}
         </Badge>
       </div>
 
-      {/* Injury info */}
-      <div style={{
-        display: "flex", alignItems: "center", gap: 8,
-        fontSize: 13, color: "var(--text)",
-      }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, color: "var(--text)" }}>
         <span style={{ fontSize: 16 }}>🩹</span>
         <span style={{ fontWeight: 600 }}>{injury.type || "General Injury"}</span>
         <span style={{ marginLeft: "auto", fontSize: 12, color: "var(--text-muted)" }}>
-          {injury.weeksRemaining ?? 0} {(injury.weeksRemaining ?? 0) === 1 ? "week" : "weeks"}
+          {weeksRemaining} {weeksRemaining === 1 ? "week" : "weeks"}
         </span>
       </div>
 
-      {/* Recovery timeline */}
-      <RecoveryTimeline
-        weeksRemaining={injury.weeksRemaining ?? 0}
-        totalWeeks={injury.totalWeeks}
-        severity={severity}
-      />
-    </div>
+      <RecoveryTimeline weeksRemaining={weeksRemaining} totalWeeks={injury.totalWeeks} severity={severity} />
+    </button>
   );
 }
 
-// ── Quick Stats Banner ───────────────────────────────────────────────────────
-
 function QuickStats({ players }) {
   const total = players.length;
-  const avgRecovery = total > 0
-    ? (players.reduce((s, p) => s + (p.injury?.weeksRemaining ?? 0), 0) / total).toFixed(1)
-    : "0.0";
+  const avgRecovery = total > 0 ? (players.reduce((s, p) => s + getInjuryWeeksRemaining(p), 0) / total).toFixed(1) : "0.0";
   const seasonEnding = players.filter(p => getSeverity(p.injury).label === "Season-Ending").length;
   const onIR = players.filter(p => p.onIR || p.injury?.ir).length;
-
   const stats = [
     { label: "Total Injuries", value: total, color: "var(--accent)" },
     { label: "Avg Recovery", value: `${avgRecovery}w`, color: "var(--warning)" },
@@ -243,10 +151,7 @@ function QuickStats({ players }) {
   ];
 
   return (
-    <div style={{
-      display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))",
-      gap: 10, marginBottom: 20,
-    }}>
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))", gap: 10, marginBottom: 20 }}>
       {stats.map(s => (
         <Card key={s.label} className="card-premium">
           <CardContent className="p-3 text-center">
@@ -259,122 +164,120 @@ function QuickStats({ players }) {
   );
 }
 
-// ── Filter / Sort Bar ────────────────────────────────────────────────────────
+function AvailabilityCommand({ model, onNavigate }) {
+  const statusColors = STATUS_COLORS[model.status?.tone] ?? STATUS_COLORS.info;
+  return (
+    <Card className="card-premium" style={{ marginBottom: 16 }}>
+      <CardContent className="p-4" style={{ display: "grid", gap: 12 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
+          <div>
+            <div style={{ fontSize: 16, fontWeight: 800 }}>Availability Command</div>
+            <div style={{ fontSize: 12, color: "var(--text-muted)" }}>Season {model.context?.season ?? "?"} · Week {model.context?.week ?? "?"}</div>
+          </div>
+          <span style={{ fontSize: 12, fontWeight: 700, padding: "6px 10px", borderRadius: 999, color: statusColors.color, background: statusColors.bg, border: `1px solid ${statusColors.border}` }}>
+            {model.status?.label ?? 'Manageable'}
+          </span>
+        </div>
 
-function FilterBar({ posFilter, setPosFilter, sevFilter, setSevFilter, teamFilter,
-  setTeamFilter, sortKey, setSortKey, teams }) {
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 8 }}>
+          <div style={{ border: "1px solid var(--hairline)", borderRadius: 8, padding: 10 }}><div style={{ fontSize: 11, color: "var(--text-muted)" }}>My Team Injured</div><strong>{model.myTeamInjured.length}</strong></div>
+          <div style={{ border: "1px solid var(--hairline)", borderRadius: 8, padding: 10 }}><div style={{ fontSize: 11, color: "var(--text-muted)" }}>Injured Starters</div><strong>{model.injuredStarterCount}</strong></div>
+          <div style={{ border: "1px solid var(--hairline)", borderRadius: 8, padding: 10 }}><div style={{ fontSize: 11, color: "var(--text-muted)" }}>Replacement Risk</div><strong>{model.replacementRiskCount}</strong></div>
+        </div>
 
+        <div style={{ fontSize: 13, color: "var(--text-muted)" }}>{model.recommendedNextAction}</div>
+
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <Button size="sm" onClick={() => onNavigate?.(model.routeHints.rosterDepth)}>Open Roster / Depth for Replacements</Button>
+          <Button size="sm" variant="outline" onClick={() => onNavigate?.(model.routeHints.weeklyPrep)}>Back to Weekly Prep</Button>
+          <Button size="sm" variant="secondary" onClick={() => onNavigate?.(model.routeHints.hq)}>Back to HQ</Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function MyTeamAvailability({ model, onPlayerSelect, onNavigate }) {
+  return (
+    <Card className="card-premium" style={{ marginBottom: 20 }}>
+      <CardContent className="p-4">
+        <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>⭐ My Team Availability</h2>
+        {model.myTeamInjured.length === 0 ? (
+          <div style={{ textAlign: "center", padding: "18px 0", color: "var(--text-muted)", fontSize: 13 }}>✅ No active injuries on your roster.</div>
+        ) : (
+          <div style={{ display: "grid", gap: 10 }}>
+            {model.myTeamInjured.map((player) => {
+              const weeksRemaining = getInjuryWeeksRemaining(player);
+              const severity = getSeverity(player.injury || {});
+              return (
+                <div key={player.id ?? player.pid ?? player.name} style={{ border: "1px solid var(--hairline)", borderLeft: `4px solid ${severity.color}`, borderRadius: 10, padding: 12 }}>
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                    <strong style={{ fontSize: 14 }}>{player.name}</strong>
+                    <Badge variant="outline">{player.pos || player.position || '??'}</Badge>
+                    <span style={{ fontSize: 12, color: "var(--text-muted)" }}>OVR {player.ovr ?? '?'}</span>
+                    {player.isStarter && <Badge style={{ background: "rgba(239,68,68,0.12)", color: "#ef4444", border: "none" }}>Starter</Badge>}
+                    {!player.isStarter && player.isKeyContributor && <Badge style={{ background: "rgba(59,130,246,0.12)", color: "#3b82f6", border: "none" }}>Key Contributor</Badge>}
+                    {player.replacementRisk && <Badge style={{ background: "rgba(245,158,11,0.16)", color: "#f59e0b", border: "none" }}>Replacement Risk</Badge>}
+                  </div>
+                  <div style={{ fontSize: 13, marginTop: 6, color: "var(--text-muted)" }}>
+                    {player.injury?.type || 'General Injury'} · {weeksRemaining} {weeksRemaining === 1 ? 'week' : 'weeks'} remaining
+                  </div>
+                  <div style={{ display: "flex", gap: 8, marginTop: 10, flexWrap: "wrap" }}>
+                    {onPlayerSelect && <Button size="sm" variant="outline" onClick={() => onPlayerSelect(player.id ?? player.pid)}>View Player</Button>}
+                    <Button size="sm" onClick={() => onNavigate?.('Team:Roster / Depth')}>Open Roster / Depth for Replacements</Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function FilterBar({ posFilter, setPosFilter, sevFilter, setSevFilter, teamFilter, setTeamFilter, sortKey, setSortKey, teams }) {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 10, marginBottom: 16 }}>
-      {/* Position filters */}
       <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
         {POS_FILTERS.map(p => (
-          <Button
-            key={p}
-            variant={posFilter === p ? "default" : "outline"}
-            size="sm"
-            onClick={() => setPosFilter(p)}
-          >
-            {p}
-          </Button>
+          <Button key={p} variant={posFilter === p ? "default" : "outline"} size="sm" onClick={() => setPosFilter(p)}>{p}</Button>
         ))}
       </div>
-
-      {/* Severity + team + sort row */}
       <div style={{ display: "flex", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
-        <select
-          value={sevFilter}
-          onChange={e => setSevFilter(e.target.value)}
-          style={{
-            background: "var(--surface)", color: "var(--text)",
-            border: "1px solid var(--hairline)", borderRadius: 6,
-            padding: "5px 8px", fontSize: 12,
-          }}
-        >
-          {SEVERITY_FILTERS.map(s => (
-            <option key={s} value={s}>{s === "ALL" ? "All Severities" : s}</option>
-          ))}
+        <select value={sevFilter} onChange={e => setSevFilter(e.target.value)} style={{ background: "var(--surface)", color: "var(--text)", border: "1px solid var(--hairline)", borderRadius: 6, padding: "5px 8px", fontSize: 12 }}>
+          {SEVERITY_FILTERS.map(s => <option key={s} value={s}>{s === "ALL" ? "All Severities" : s}</option>)}
         </select>
-
-        <select
-          value={teamFilter}
-          onChange={e => setTeamFilter(e.target.value)}
-          style={{
-            background: "var(--surface)", color: "var(--text)",
-            border: "1px solid var(--hairline)", borderRadius: 6,
-            padding: "5px 8px", fontSize: 12,
-          }}
-        >
+        <select value={teamFilter} onChange={e => setTeamFilter(e.target.value)} style={{ background: "var(--surface)", color: "var(--text)", border: "1px solid var(--hairline)", borderRadius: 6, padding: "5px 8px", fontSize: 12 }}>
           <option value="ALL">All Teams</option>
-          {teams.map(t => (
-            <option key={t.id ?? t.tid} value={t.id ?? t.tid}>
-              {t.abbr || t.name}
-            </option>
-          ))}
+          {teams.map(t => <option key={t.id ?? t.tid} value={t.id ?? t.tid}>{t.abbr || t.name}</option>)}
         </select>
-
-        <div style={{ marginLeft: "auto", display: "flex", gap: 4, alignItems: "center" }}>
+        <div style={{ marginLeft: "auto", display: "flex", gap: 4, alignItems: "center", flexWrap: "wrap" }}>
           <span style={{ fontSize: 11, color: "var(--text-muted)" }}>Sort:</span>
-          {SORT_OPTIONS.map(o => (
-            <Button
-              key={o.key}
-              variant={sortKey === o.key ? "default" : "outline"}
-              size="sm"
-              onClick={() => setSortKey(o.key)}
-            >
-              {o.label}
-            </Button>
-          ))}
+          {SORT_OPTIONS.map(o => <Button key={o.key} variant={sortKey === o.key ? "default" : "outline"} size="sm" onClick={() => setSortKey(o.key)}>{o.label}</Button>)}
         </div>
       </div>
     </div>
   );
 }
 
-// ── Injury History Log ───────────────────────────────────────────────────────
-
 function InjuryHistoryLog({ league }) {
-  const log = league.injuryLog || league.injuries || [];
+  const log = league?.injuryLog || league?.injuries || [];
   const recent = log.slice(-15).reverse();
-
   if (recent.length === 0) return null;
-
   return (
-    <div style={{
-      background: "var(--surface)", border: "1px solid var(--hairline)",
-      borderRadius: 10, padding: 16, marginTop: 20,
-    }}>
-      <h3 style={{
-        fontSize: 14, fontWeight: 700, color: "var(--text)",
-        marginBottom: 12, display: "flex", alignItems: "center", gap: 6,
-      }}>
-        📋 Recent Injury Log
-      </h3>
+    <div style={{ background: "var(--surface)", border: "1px solid var(--hairline)", borderRadius: 10, padding: 16, marginTop: 20 }}>
+      <h3 style={{ fontSize: 14, fontWeight: 700, color: "var(--text)", marginBottom: 12, display: "flex", alignItems: "center", gap: 6 }}>📋 Recent Injury Log</h3>
       <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
         {recent.map((entry, i) => {
           const sev = getSeverity(entry);
           return (
-            <div key={i} style={{
-              display: "flex", alignItems: "center", gap: 8,
-              fontSize: 12, padding: "6px 0",
-              borderBottom: i < recent.length - 1 ? "1px solid var(--hairline)" : "none",
-            }}>
-              <span style={{
-                width: 8, height: 8, borderRadius: "50%",
-                background: sev.color, flexShrink: 0,
-              }} />
-              <span style={{ fontWeight: 600, color: "var(--text)" }}>
-                {entry.playerName || entry.name || "Unknown"}
-              </span>
-              <span style={{ color: "var(--text-muted)" }}>
-                {entry.teamAbbr && `(${entry.teamAbbr})`}
-              </span>
-              <span style={{ color: "var(--text-muted)", flex: 1 }}>
-                — {entry.type || "Injury"}
-              </span>
-              <span style={{ color: "var(--text-muted)", fontSize: 11 }}>
-                Wk {entry.week ?? "?"}
-              </span>
+            <div key={i} style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12, padding: "6px 0", borderBottom: i < recent.length - 1 ? "1px solid var(--hairline)" : "none" }}>
+              <span style={{ width: 8, height: 8, borderRadius: "50%", background: sev.color, flexShrink: 0 }} />
+              <span style={{ fontWeight: 600, color: "var(--text)" }}>{entry.playerName || entry.name || "Unknown"}</span>
+              <span style={{ color: "var(--text-muted)" }}>{entry.teamAbbr && `(${entry.teamAbbr})`}</span>
+              <span style={{ color: "var(--text-muted)", flex: 1 }}>— {entry.type || "Injury"}</span>
+              <span style={{ color: "var(--text-muted)", fontSize: 11 }}>Wk {entry.week ?? "?"}</span>
             </div>
           );
         })}
@@ -383,11 +286,7 @@ function InjuryHistoryLog({ league }) {
   );
 }
 
-// ── Main Component ───────────────────────────────────────────────────────────
-
-export default function InjuryReport({
-  league, onPlayerSelect,
-}) {
+export default function InjuryReport({ league, onPlayerSelect, onNavigate }) {
   useEffect(() => {
     markWeeklyPrepStep(league, 'injuriesReviewed', true);
   }, [league?.seasonId, league?.week, league?.userTeamId]);
@@ -397,24 +296,16 @@ export default function InjuryReport({
   const [teamFilter, setTeamFilter] = useState("ALL");
   const [sortKey, setSortKey] = useState("weeksRemaining");
 
-  const teams = league.teams || [];
-  const userTeamId = league.userTeamId;
+  const teams = league?.teams || [];
+  const availabilityModel = useMemo(() => deriveInjuryReadinessModel({ league, source: 'team-injuries' }), [league]);
+  const allInjured = availabilityModel.leagueInjuredPlayers;
 
-  const allInjured = useMemo(() => getAllInjuredPlayers(league), [league]);
-
-  const myTeamInjured = useMemo(
-    () => allInjured.filter(p => p.teamId === userTeamId),
-    [allInjured, userTeamId],
-  );
-
-  const teamBurden = useMemo(() => {
-    return teams.map((t) => {
-      const roster = t.roster || t.players || [];
-      const injured = roster.filter((p) => p.injured || (p.injury && p.injury.weeksRemaining > 0));
-      const totalWeeks = injured.reduce((sum, p) => sum + Number(p?.injury?.weeksRemaining ?? 0), 0);
-      return { id: t.id ?? t.tid, abbr: t.abbr || t.name, count: injured.length, totalWeeks };
-    }).sort((a, b) => (b.count - a.count) || (b.totalWeeks - a.totalWeeks)).slice(0, 8);
-  }, [teams]);
+  const teamBurden = useMemo(() => teams.map((t) => {
+    const roster = t.roster || t.players || [];
+    const injured = roster.filter((p) => isPlayerInjured(p));
+    const totalWeeks = injured.reduce((sum, p) => sum + getInjuryWeeksRemaining(p), 0);
+    return { id: t.id ?? t.tid, abbr: t.abbr || t.name, count: injured.length, totalWeeks };
+  }).sort((a, b) => (b.count - a.count) || (b.totalWeeks - a.totalWeeks)).slice(0, 8), [teams]);
 
   const positionPressure = useMemo(() => {
     const buckets = {};
@@ -427,61 +318,37 @@ export default function InjuryReport({
 
   const filteredLeague = useMemo(() => {
     let list = [...allInjured];
-
-    if (posFilter !== "ALL") {
-      list = list.filter(p => (p.pos || p.position) === posFilter);
-    }
-    if (sevFilter !== "ALL") {
-      list = list.filter(p => getSeverity(p.injury).label === sevFilter);
-    }
+    if (posFilter !== "ALL") list = list.filter(p => (p.pos || p.position) === posFilter);
+    if (sevFilter !== "ALL") list = list.filter(p => getSeverity(p.injury).label === sevFilter);
     if (teamFilter !== "ALL") {
       const tid = typeof teamFilter === "string" ? parseInt(teamFilter, 10) : teamFilter;
       list = list.filter(p => p.teamId === tid || p.teamId === teamFilter);
     }
-
     list.sort((a, b) => {
-      if (sortKey === "weeksRemaining") {
-        return (b.injury?.weeksRemaining ?? 0) - (a.injury?.weeksRemaining ?? 0);
-      }
+      if (sortKey === "weeksRemaining") return getInjuryWeeksRemaining(b) - getInjuryWeeksRemaining(a);
       if (sortKey === "severity") {
         const sa = getSeverity(a.injury).label;
         const sb = getSeverity(b.injury).label;
         return (SEVERITY_ORDER[sb] || 0) - (SEVERITY_ORDER[sa] || 0);
       }
-      if (sortKey === "ovr") {
-        return (b.ovr ?? 0) - (a.ovr ?? 0);
-      }
+      if (sortKey === "ovr") return (b.ovr ?? 0) - (a.ovr ?? 0);
       return 0;
     });
-
     return list;
   }, [allInjured, posFilter, sevFilter, teamFilter, sortKey]);
 
-  // ── Render ───────────────────────────────────────────────────────────────
-
   return (
     <div className="fade-in" style={{ padding: "var(--space-4)", maxWidth: 960, margin: "0 auto" }}>
-      {/* Header */}
-      <div style={{
-        display: "flex", alignItems: "center", justifyContent: "space-between",
-        marginBottom: 20, flexWrap: "wrap", gap: 10,
-      }}>
-        <h1 style={{
-          fontSize: 22, fontWeight: 800, color: "var(--text)", margin: 0,
-          display: "flex", alignItems: "center", gap: 8,
-        }}>
-          🏥 Injury Report
-        </h1>
-        <Badge variant="outline" style={{
-          fontSize: 12, color: "var(--text-muted)",
-          background: "var(--surface)", padding: "4px 10px", borderRadius: 6,
-          border: "1px solid var(--hairline)",
-        }}>
-          Season {league.season ?? "?"} · Week {league.week ?? "?"}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 16, flexWrap: "wrap", gap: 10 }}>
+        <h1 style={{ fontSize: 22, fontWeight: 800, color: "var(--text)", margin: 0, display: "flex", alignItems: "center", gap: 8 }}>🏥 Injury Report</h1>
+        <Badge variant="outline" style={{ fontSize: 12, color: "var(--text-muted)", background: "var(--surface)", padding: "4px 10px", borderRadius: 6, border: "1px solid var(--hairline)" }}>
+          Season {league?.season ?? "?"} · Week {league?.week ?? "?"}
         </Badge>
       </div>
 
-      {/* Quick Stats */}
+      <AvailabilityCommand model={availabilityModel} onNavigate={onNavigate} />
+      <MyTeamAvailability model={availabilityModel} onPlayerSelect={onPlayerSelect} onNavigate={onNavigate} />
+
       <QuickStats players={allInjured} />
 
       <Card className="card-premium" style={{ marginBottom: 20 }}>
@@ -490,122 +357,37 @@ export default function InjuryReport({
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 10 }}>
             <div style={{ border: "1px solid var(--hairline)", borderRadius: 8, padding: 10 }}>
               <div style={{ fontSize: 11, color: "var(--text-muted)", marginBottom: 6 }}>Most impacted teams</div>
-              {teamBurden.map((t) => (
-                <div key={t.id} style={{ display: "flex", justifyContent: "space-between", fontSize: 12, marginBottom: 3 }}>
-                  <span>{t.abbr}</span>
-                  <span>{t.count} injuries · {t.totalWeeks} wks</span>
-                </div>
-              ))}
+              {teamBurden.map((t) => <div key={t.id} style={{ display: "flex", justifyContent: "space-between", fontSize: 12, marginBottom: 3 }}><span>{t.abbr}</span><span>{t.count} injuries · {t.totalWeeks} wks</span></div>)}
             </div>
             <div style={{ border: "1px solid var(--hairline)", borderRadius: 8, padding: 10 }}>
               <div style={{ fontSize: 11, color: "var(--text-muted)", marginBottom: 6 }}>Position-group pressure</div>
-              {positionPressure.map((p) => (
-                <div key={p.pos} style={{ display: "flex", justifyContent: "space-between", fontSize: 12, marginBottom: 3 }}>
-                  <span>{p.pos}</span>
-                  <span>{p.count} out</span>
-                </div>
-              ))}
+              {positionPressure.map((p) => <div key={p.pos} style={{ display: "flex", justifyContent: "space-between", fontSize: 12, marginBottom: 3 }}><span>{p.pos}</span><span>{p.count} out</span></div>)}
             </div>
           </div>
         </CardContent>
       </Card>
 
-      {/* ── My Team Section ─────────────────────────────────────────────── */}
-      <Card className="card-premium" style={{ marginBottom: 24 }}>
-        <CardContent className="p-4">
-          <h2 style={{
-            fontSize: 16, fontWeight: 700, color: "var(--text)",
-            marginBottom: 14, display: "flex", alignItems: "center", gap: 8,
-          }}>
-            ⭐ My Team
-            <Badge
-              style={{
-                background: myTeamInjured.length > 0 ? "rgba(239,68,68,0.12)" : "rgba(34,197,94,0.12)",
-                color: myTeamInjured.length > 0 ? "#ef4444" : "#22c55e",
-                border: "none",
-              }}
-              className="text-xs font-semibold"
-            >
-              {myTeamInjured.length} {myTeamInjured.length === 1 ? "injury" : "injuries"}
-            </Badge>
-          </h2>
-
-          {myTeamInjured.length === 0 ? (
-            <div style={{
-              textAlign: "center", padding: "24px 0",
-              color: "var(--text-muted)", fontSize: 13,
-            }}>
-              ✅ No injuries on your team — full strength!
-            </div>
-          ) : (
-            <div style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
-              gap: 12,
-            }}>
-              {myTeamInjured.map(p => (
-                <InjuryCard
-                  key={p.id ?? p.pid ?? p.name}
-                  player={p}
-                  onPlayerSelect={onPlayerSelect}
-                />
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* ── League Injuries Section ─────────────────────────────────────── */}
       <Card className="card-premium">
         <CardContent className="p-4">
-          <h2 style={{
-            fontSize: 16, fontWeight: 700, color: "var(--text)",
-            marginBottom: 14, display: "flex", alignItems: "center", gap: 8,
-          }}>
+          <h2 style={{ fontSize: 16, fontWeight: 700, color: "var(--text)", marginBottom: 14, display: "flex", alignItems: "center", gap: 8 }}>
             🏈 League Injuries
-            <Badge
-              style={{ background: "rgba(99,102,241,0.12)", color: "#6366f1", border: "none" }}
-              className="text-xs font-semibold"
-            >
-              {filteredLeague.length} players
-            </Badge>
+            <Badge style={{ background: "rgba(99,102,241,0.12)", color: "#6366f1", border: "none" }} className="text-xs font-semibold">{filteredLeague.length} players</Badge>
           </h2>
 
-          <FilterBar
-            posFilter={posFilter} setPosFilter={setPosFilter}
-            sevFilter={sevFilter} setSevFilter={setSevFilter}
-            teamFilter={teamFilter} setTeamFilter={setTeamFilter}
-            sortKey={sortKey} setSortKey={setSortKey}
-            teams={teams}
-          />
+          <FilterBar posFilter={posFilter} setPosFilter={setPosFilter} sevFilter={sevFilter} setSevFilter={setSevFilter} teamFilter={teamFilter} setTeamFilter={setTeamFilter} sortKey={sortKey} setSortKey={setSortKey} teams={teams} />
 
           {filteredLeague.length === 0 ? (
-            <div style={{
-              textAlign: "center", padding: "32px 0",
-              color: "var(--text-muted)", fontSize: 13,
-            }}>
-              No injuries match current filters.
-            </div>
+            <div style={{ textAlign: "center", padding: "32px 0", color: "var(--text-muted)", fontSize: 13 }}>No injuries match current filters.</div>
           ) : (
-            <div style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))",
-              gap: 12,
-            }}>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))", gap: 12 }}>
               {filteredLeague.map(p => (
-                <InjuryCard
-                  key={`${p.teamId}-${p.id ?? p.pid ?? p.name}`}
-                  player={p}
-                  onPlayerSelect={onPlayerSelect}
-                  showTeam
-                />
+                <InjuryCard key={`${p.teamId}-${p.id ?? p.pid ?? p.name}`} player={p} onPlayerSelect={onPlayerSelect} showTeam />
               ))}
             </div>
           )}
         </CardContent>
       </Card>
 
-      {/* ── Injury History Log ──────────────────────────────────────────── */}
       <InjuryHistoryLog league={league} />
     </div>
   );

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -1248,6 +1248,7 @@ export default function LeagueDashboard({
             <InjuryReport
               league={league}
               onPlayerSelect={setSelectedPlayerId}
+              onNavigate={setActiveTab}
             />
           </TabErrorBoundary>
         )}

--- a/src/ui/components/TeamHub.jsx
+++ b/src/ui/components/TeamHub.jsx
@@ -228,7 +228,7 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
           />
         </div>
       )}
-      {subtab === 'Injuries' && <InjuryReport league={league} onPlayerSelect={onPlayerSelect} />}
+      {subtab === 'Injuries' && <InjuryReport league={league} onPlayerSelect={onPlayerSelect} onNavigate={onNavigate} />}
     </div>
   );
 }

--- a/src/ui/components/__tests__/InjuryReportAvailability.test.jsx
+++ b/src/ui/components/__tests__/InjuryReportAvailability.test.jsx
@@ -1,0 +1,51 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import InjuryReport from '../InjuryReport.jsx';
+
+const { markWeeklyPrepStep } = vi.hoisted(() => ({ markWeeklyPrepStep: vi.fn() }));
+vi.mock('../../utils/weeklyPrep.js', () => ({ markWeeklyPrepStep }));
+
+const baseLeague = {
+  season: 2026,
+  seasonId: '2026',
+  week: 4,
+  userTeamId: 1,
+  teams: [
+    {
+      id: 1,
+      abbr: 'YOU',
+      roster: [
+        { id: 10, name: 'QB One', pos: 'QB', ovr: 89, injured: true, injury: { type: 'Shoulder', weeksRemaining: 3 }, depthChart: { rowKey: 'QB', order: 1 } },
+        { id: 11, name: 'QB Two', pos: 'QB', ovr: 72, depthChart: { rowKey: 'QB', order: 2 } },
+      ],
+    },
+    { id: 2, abbr: 'OPP', roster: [{ id: 21, name: 'WR Opp', pos: 'WR', ovr: 80, injuryWeeksRemaining: 2 }] },
+  ],
+};
+
+describe('InjuryReport availability command', () => {
+  beforeEach(() => {
+    markWeeklyPrepStep.mockReset();
+  });
+
+  it('renders availability command status and marks injuries reviewed on open', () => {
+    render(<InjuryReport league={baseLeague} />);
+    expect(screen.getByText(/Availability Command/i)).toBeTruthy();
+    expect(markWeeklyPrepStep).toHaveBeenCalledWith(baseLeague, 'injuriesReviewed', true);
+  });
+
+  it('navigates to roster/depth, weekly prep, and hq', () => {
+    const onNavigate = vi.fn();
+    render(<InjuryReport league={baseLeague} onNavigate={onNavigate} />);
+
+    screen.getAllByRole('button', { name: /Open Roster \/ Depth/i }).forEach((btn) => fireEvent.click(btn));
+    screen.getAllByRole('button', { name: /Back to Weekly Prep/i }).forEach((btn) => fireEvent.click(btn));
+    screen.getAllByRole('button', { name: /Back to HQ/i }).forEach((btn) => fireEvent.click(btn));
+
+    expect(onNavigate).toHaveBeenCalledWith('Team:Roster / Depth');
+    expect(onNavigate).toHaveBeenCalledWith('Weekly Prep');
+    expect(onNavigate).toHaveBeenCalledWith('HQ');
+  });
+});

--- a/src/ui/utils/injuryReadinessModel.js
+++ b/src/ui/utils/injuryReadinessModel.js
@@ -1,0 +1,247 @@
+import { DEPTH_CHART_ROWS, autoBuildDepthChart } from '../../core/depthChart.js';
+
+function toNumber(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function normalizeStatus(status) {
+  return String(status ?? '').toLowerCase();
+}
+
+export function getInjuryWeeksRemaining(player) {
+  const fromObject = player?.injury?.weeksRemaining;
+  const fromFlat = player?.injuryWeeksRemaining;
+  const fromGames = player?.injury?.gamesRemaining;
+  const values = [fromObject, fromFlat, fromGames]
+    .map((value) => toNumber(value, 0))
+    .filter((value) => value > 0);
+  return values.length ? Math.max(...values) : 0;
+}
+
+export function isPlayerInjured(player) {
+  if (!player || typeof player !== 'object') return false;
+  if (player.injured === true) return true;
+  if (player.onIR || player?.injury?.ir) return true;
+  if (['injured', 'ir'].includes(normalizeStatus(player.status))) return true;
+  return getInjuryWeeksRemaining(player) > 0;
+}
+
+function getPlayerId(player) {
+  return Number(player?.id ?? player?.pid);
+}
+
+function buildExistingAssignments(players = []) {
+  const assignments = {};
+  for (const row of DEPTH_CHART_ROWS) assignments[row.key] = [];
+  for (const player of players) {
+    const rowKey = player?.depthChart?.rowKey;
+    if (!rowKey || !assignments[rowKey]) continue;
+    assignments[rowKey].push(getPlayerId(player));
+  }
+  for (const row of DEPTH_CHART_ROWS) {
+    assignments[row.key] = assignments[row.key]
+      .filter((id) => Number.isFinite(id))
+      .sort((a, b) => {
+        const playerA = players.find((player) => getPlayerId(player) === a);
+        const playerB = players.find((player) => getPlayerId(player) === b);
+        const orderA = toNumber(playerA?.depthChart?.order ?? playerA?.depthOrder, 999);
+        const orderB = toNumber(playerB?.depthChart?.order ?? playerB?.depthOrder, 999);
+        return orderA - orderB;
+      });
+  }
+  return assignments;
+}
+
+function mapPositionGroup(player) {
+  const explicit = String(player?.depthChart?.rowKey ?? '').toUpperCase();
+  if (explicit && DEPTH_CHART_ROWS.some((row) => row.key === explicit)) return explicit;
+  const normalizedPos = String(player?.pos ?? player?.position ?? '').toUpperCase();
+  const row = DEPTH_CHART_ROWS.find((entry) => entry.match.includes(normalizedPos));
+  return row?.key ?? (normalizedPos || 'UNK');
+}
+
+function collectLeagueInjuredPlayers(league) {
+  const teams = Array.isArray(league?.teams) ? league.teams : [];
+  const injured = [];
+
+  for (const team of teams) {
+    const roster = Array.isArray(team?.roster) ? team.roster : Array.isArray(team?.players) ? team.players : [];
+    for (const player of roster) {
+      if (!isPlayerInjured(player)) continue;
+      injured.push({
+        ...player,
+        teamId: team?.id ?? team?.tid,
+        teamAbbr: team?.abbr ?? team?.name?.slice(0, 3)?.toUpperCase() ?? 'UNK',
+        teamName: team?.name ?? team?.abbr ?? 'Unknown Team',
+      });
+    }
+  }
+
+  const seen = new Set(injured.map((player) => getPlayerId(player)).filter(Number.isFinite));
+  if (Array.isArray(league?.roster)) {
+    for (const player of league.roster) {
+      if (!isPlayerInjured(player)) continue;
+      const id = getPlayerId(player);
+      if (Number.isFinite(id) && seen.has(id)) continue;
+      seen.add(id);
+      injured.push({
+        ...player,
+        teamId: league?.userTeamId,
+        teamAbbr: 'USR',
+        teamName: 'My Team',
+      });
+    }
+  }
+
+  return injured;
+}
+
+function sortByImpact(players = []) {
+  return [...players].sort((a, b) => {
+    if (Number(Boolean(b.isStarter)) !== Number(Boolean(a.isStarter))) return Number(Boolean(b.isStarter)) - Number(Boolean(a.isStarter));
+    if (Number(Boolean(b.isKeyContributor)) !== Number(Boolean(a.isKeyContributor))) return Number(Boolean(b.isKeyContributor)) - Number(Boolean(a.isKeyContributor));
+    const ovrGap = toNumber(b.ovr, 0) - toNumber(a.ovr, 0);
+    if (ovrGap !== 0) return ovrGap;
+    return getInjuryWeeksRemaining(b) - getInjuryWeeksRemaining(a);
+  });
+}
+
+function inferAvailabilityStatus({ injuredCount, starterCount, replacementRiskCount }) {
+  if (injuredCount <= 0) return { key: 'full_strength', label: 'Full Strength', tone: 'ok' };
+  if (starterCount >= 3 || replacementRiskCount >= 3) return { key: 'critical', label: 'Critical', tone: 'danger' };
+  if (starterCount >= 1 || replacementRiskCount >= 2 || injuredCount >= 5) return { key: 'needs_attention', label: 'Needs Attention', tone: 'warning' };
+  return { key: 'manageable', label: 'Manageable', tone: 'info' };
+}
+
+function inferNextAction(status, affectedGroups = []) {
+  if (status.key === 'full_strength') return 'No immediate replacement action required. Keep monitoring practice injuries.';
+  if (status.key === 'critical') return `Open Roster / Depth now and stabilize ${affectedGroups[0]?.label ?? 'your top position group'}.`;
+  if (status.key === 'needs_attention') return 'Review depth order and promote healthy backups for injured contributors.';
+  return 'Monitor injuries and prepare contingency substitutions for next kickoff.';
+}
+
+export function deriveInjuryReadinessModel({ league = null, source = 'injury-report' } = {}) {
+  const teams = Array.isArray(league?.teams) ? league.teams : [];
+  const userTeamId = Number(league?.userTeamId);
+  const userTeam = teams.find((team) => Number(team?.id ?? team?.tid) === userTeamId) ?? null;
+
+  const teamRoster = userTeam
+    ? (Array.isArray(userTeam?.roster) ? userTeam.roster : Array.isArray(userTeam?.players) ? userTeam.players : [])
+    : [];
+  const fallbackUserRoster = Array.isArray(league?.roster) ? league.roster : [];
+  const roster = teamRoster.length > 0 ? teamRoster : fallbackUserRoster;
+  const safeRoster = Array.isArray(roster) ? roster.filter(Boolean) : [];
+
+  const allLeagueInjured = collectLeagueInjuredPlayers(league);
+
+  if (!league || !userTeam || safeRoster.length === 0) {
+    return {
+      status: { key: 'manageable', label: 'Manageable', tone: 'info' },
+      myTeamInjured: [],
+      leagueInjuredPlayers: allLeagueInjured,
+      leagueInjuredCount: allLeagueInjured.length,
+      injuredStarterCount: 0,
+      keyContributorInjuries: 0,
+      replacementRiskCount: 0,
+      affectedPositionGroups: [],
+      recommendedNextAction: 'Open Roster / Depth to verify assignments before advance week.',
+      routeHints: {
+        rosterDepth: 'Team:Roster / Depth',
+        weeklyPrep: 'Weekly Prep',
+        hq: 'HQ',
+        source,
+      },
+      context: {
+        season: league?.season ?? league?.year ?? null,
+        week: league?.week ?? null,
+      },
+    };
+  }
+
+  const assignments = autoBuildDepthChart(safeRoster, buildExistingAssignments(safeRoster));
+  const byId = new Map(safeRoster.map((player) => [getPlayerId(player), player]));
+  const starterIds = new Set(
+    Object.values(assignments)
+      .map((ids) => (Array.isArray(ids) ? ids[0] : null))
+      .filter((id) => Number.isFinite(Number(id)))
+      .map((id) => Number(id)),
+  );
+
+  const depthByGroup = DEPTH_CHART_ROWS.reduce((acc, row) => {
+    acc[row.key] = (assignments[row.key] ?? [])
+      .map((id) => byId.get(Number(id)))
+      .filter(Boolean);
+    return acc;
+  }, {});
+
+  const decoratedTeamInjured = safeRoster
+    .filter((player) => isPlayerInjured(player))
+    .map((player) => {
+      const playerId = getPlayerId(player);
+      const groupKey = mapPositionGroup(player);
+      const depthGroup = depthByGroup[groupKey] ?? [];
+      const healthyBackups = depthGroup.slice(1).filter((depthPlayer) => !isPlayerInjured(depthPlayer));
+      const isStarter = starterIds.has(playerId) || toNumber(player?.depthChart?.order ?? player?.depthOrder, 99) === 1;
+      const isKeyContributor = isStarter || toNumber(player?.ovr, 0) >= 80 || toNumber(player?.depthChart?.order ?? player?.depthOrder, 99) <= 2;
+      const weeksRemaining = getInjuryWeeksRemaining(player);
+      const replacementRisk = isStarter || (isKeyContributor && weeksRemaining >= 2) || healthyBackups.length === 0 || weeksRemaining >= 4;
+
+      return {
+        ...player,
+        injury: { ...(player?.injury ?? {}), weeksRemaining },
+        positionGroup: groupKey,
+        isStarter,
+        isKeyContributor,
+        replacementRisk,
+      };
+    });
+
+  const myTeamInjured = sortByImpact(decoratedTeamInjured);
+  const injuredStarterCount = myTeamInjured.filter((player) => player.isStarter).length;
+  const keyContributorInjuries = myTeamInjured.filter((player) => player.isKeyContributor).length;
+  const replacementRiskCount = myTeamInjured.filter((player) => player.replacementRisk).length;
+
+  const affectedPositionGroups = DEPTH_CHART_ROWS
+    .map((row) => {
+      const injuries = myTeamInjured.filter((player) => player.positionGroup === row.key);
+      return {
+        key: row.key,
+        label: row.label,
+        injuredCount: injuries.length,
+        starterInjuries: injuries.filter((player) => player.isStarter).length,
+        replacementRiskCount: injuries.filter((player) => player.replacementRisk).length,
+      };
+    })
+    .filter((entry) => entry.injuredCount > 0)
+    .sort((a, b) => b.replacementRiskCount - a.replacementRiskCount || b.starterInjuries - a.starterInjuries || b.injuredCount - a.injuredCount)
+    .slice(0, 4);
+
+  const status = inferAvailabilityStatus({
+    injuredCount: myTeamInjured.length,
+    starterCount: injuredStarterCount,
+    replacementRiskCount,
+  });
+
+  return {
+    status,
+    myTeamInjured,
+    leagueInjuredPlayers: allLeagueInjured,
+    leagueInjuredCount: allLeagueInjured.length,
+    injuredStarterCount,
+    keyContributorInjuries,
+    replacementRiskCount,
+    affectedPositionGroups,
+    recommendedNextAction: inferNextAction(status, affectedPositionGroups),
+    routeHints: {
+      rosterDepth: 'Team:Roster / Depth',
+      weeklyPrep: 'Weekly Prep',
+      hq: 'HQ',
+      source,
+    },
+    context: {
+      season: league?.season ?? league?.year ?? null,
+      week: league?.week ?? null,
+    },
+  };
+}

--- a/src/ui/utils/injuryReadinessModel.test.js
+++ b/src/ui/utils/injuryReadinessModel.test.js
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { deriveInjuryReadinessModel, isPlayerInjured } from './injuryReadinessModel.js';
+
+function makePlayer(id, pos, overrides = {}) {
+  return {
+    id,
+    name: `P${id}`,
+    pos,
+    ovr: 75,
+    injury: { type: 'Hamstring', weeksRemaining: 0 },
+    ...overrides,
+  };
+}
+
+describe('injuryReadinessModel', () => {
+  it('returns full strength when no injuries exist', () => {
+    const league = {
+      userTeamId: 1,
+      teams: [{ id: 1, abbr: 'YOU', roster: [makePlayer(1, 'QB'), makePlayer(2, 'RB')] }],
+    };
+    const model = deriveInjuryReadinessModel({ league });
+    expect(model.status.label).toBe('Full Strength');
+    expect(model.myTeamInjured).toHaveLength(0);
+  });
+
+  it('flags injured starter and high-ovr key contributor', () => {
+    const league = {
+      userTeamId: 1,
+      teams: [{
+        id: 1,
+        abbr: 'YOU',
+        roster: [
+          makePlayer(1, 'QB', { ovr: 91, injured: true, injury: { type: 'ACL', weeksRemaining: 12 }, depthChart: { rowKey: 'QB', order: 1 } }),
+          makePlayer(2, 'QB', { ovr: 72, depthChart: { rowKey: 'QB', order: 2 } }),
+        ],
+      }],
+    };
+    const model = deriveInjuryReadinessModel({ league });
+    expect(model.injuredStarterCount).toBe(1);
+    expect(model.keyContributorInjuries).toBe(1);
+    expect(model.status.label).toMatch(/Needs Attention|Critical/);
+  });
+
+  it('derives replacement risk when depth is thin', () => {
+    const league = {
+      userTeamId: 1,
+      teams: [{
+        id: 1,
+        abbr: 'YOU',
+        roster: [makePlayer(10, 'WR', { injuryWeeksRemaining: 5, depthChart: { rowKey: 'WR', order: 1 }, ovr: 84 })],
+      }],
+    };
+    const model = deriveInjuryReadinessModel({ league });
+    expect(model.replacementRiskCount).toBeGreaterThan(0);
+    expect(model.affectedPositionGroups[0].key).toBe('WR');
+  });
+
+  it('handles malformed injury fields safely', () => {
+    expect(isPlayerInjured({ status: 'IR' })).toBe(true);
+    expect(isPlayerInjured({ injury: { gamesRemaining: '3' } })).toBe(true);
+    expect(isPlayerInjured({ injuryWeeksRemaining: 'x' })).toBe(false);
+  });
+
+  it('returns safe fallback for empty roster or missing team', () => {
+    const missingTeam = deriveInjuryReadinessModel({ league: { userTeamId: 99, teams: [] } });
+    const emptyRoster = deriveInjuryReadinessModel({ league: { userTeamId: 1, teams: [{ id: 1, roster: [] }] } });
+    expect(missingTeam.routeHints.hq).toBe('HQ');
+    expect(emptyRoster.myTeamInjured).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
### Motivation
- Make the Injury Report screen act as an immediate “Availability Report” for weekly operations so the weekly readiness loop can answer who is hurt, whether they're starters/key contributors, replacement risk, affected groups, recommended action, and return routes to lineup flows. 
- Preserve existing injury generation, recovery simulation, and depth-chart algorithms while keeping the UX mobile-first and additively enhancing the weekly flow.

### Description
- Added a new pure helper `src/ui/utils/injuryReadinessModel.js` that normalizes supported injury fields (`injured`, `injury.weeksRemaining`, `injuryWeeksRemaining`, `injury.gamesRemaining`, `onIR`, `injury.ir`, `status`), derives injured starters, key contributors, replacement-risk heuristics, affected position groups, availability status (`Full Strength`, `Manageable`, `Needs Attention`, `Critical`), recommended next action, and deterministic route hints with safe fallbacks. 
- Reworked `src/ui/components/InjuryReport.jsx` into an availability-first screen by adding an `Availability Command` card and a `My Team Availability` prioritized list at the top while preserving the league-wide injury browsing (quick stats, filters, sorting, injury cards, and history) below. 
- Reused existing depth helpers (`autoBuildDepthChart`, existing assignments) to infer starter/depth context without changing core algorithms, and preserved `markWeeklyPrepStep(league, 'injuriesReviewed', true)` behavior so opening the report still marks injuries as reviewed. 
- Wired `onNavigate` into `InjuryReport` by passing it from `TeamHub` and `LeagueDashboard` so the quick CTAs can route to `Team:Roster / Depth`, `Weekly Prep`, and `HQ`; kept player selection callbacks intact. 
- Added unit tests for the new helper and component interactions: `src/ui/utils/injuryReadinessModel.test.js` and `src/ui/components/__tests__/InjuryReportAvailability.test.jsx`, and kept all changes additive and deterministic (no simulation logic changed).

### Testing
- Ran `npm ci` successfully. 
- Ran targeted unit tests with `npm run test:unit` for the new test files and related assertions, and all tests passed (`src/ui/utils/injuryReadinessModel.test.js` and `src/ui/components/__tests__/InjuryReportAvailability.test.jsx`) — total: 7 tests passed. 
- Built the app with `npm run build` successfully and verified the production bundle was produced. 
- Ran `npm run check:deploy` which executed the Netlify-like checks and succeeded. 
- Playwright/e2e tests were not executed in this run (no browser-binary verification performed) and therefore end-to-end browser tests were skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeff5dd3b8832d9890cd8ff92e723b)