### PR TITLE
Upgrade Training into weekly Practice Plan flow

### DIFF
--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -1221,6 +1221,7 @@ export default function LeagueDashboard({
               league={league}
               actions={actions}
               onPlayerSelect={setSelectedPlayerId}
+              onNavigate={setActiveTab}
             />
           </TabErrorBoundary>
         )}

--- a/src/ui/components/TrainingCamp.jsx
+++ b/src/ui/components/TrainingCamp.jsx
@@ -5,57 +5,28 @@
  * and develop players through focused training sessions.
  */
 
-import React, { useState, useMemo, useCallback } from "react";
-
-const POSITION_GROUPS = [
-  { id: "qb", label: "QB Room", positions: ["QB"], icon: "🏈", color: "#FF9F0A" },
-  { id: "rb", label: "RB Room", positions: ["RB"], icon: "🏃", color: "#34C759" },
-  { id: "wr", label: "WR Corps", positions: ["WR"], icon: "📡", color: "#0A84FF" },
-  { id: "te", label: "TE Room", positions: ["TE"], icon: "🛡️", color: "#5E5CE6" },
-  { id: "ol", label: "O-Line", positions: ["OL"], icon: "⚔️", color: "#64D2FF" },
-  { id: "dl", label: "D-Line", positions: ["DL"], icon: "💪", color: "#FF453A" },
-  { id: "lb", label: "Linebackers", positions: ["LB"], icon: "🦅", color: "#FF6961" },
-  { id: "db", label: "Secondary", positions: ["CB", "S"], icon: "🔒", color: "#FFD60A" },
-  { id: "st", label: "Special Teams", positions: ["K", "P"], icon: "🦶", color: "#AEC6CF" },
-];
+import React, { useState, useMemo, useCallback } from 'react';
+import { buildTrainingPlanModel, POSITION_GROUPS } from '../utils/trainingPlanModel.js';
 
 const INTENSITY_LEVELS = [
-  { id: "light", label: "Light", color: "#34C759", devMult: 0.6, injuryChance: 0.01, desc: "Low risk, moderate gains" },
-  { id: "normal", label: "Normal", color: "#FFD60A", devMult: 1.0, injuryChance: 0.03, desc: "Balanced risk and reward" },
-  { id: "hard", label: "Hard", color: "#FF453A", devMult: 1.5, injuryChance: 0.07, desc: "High gains, injury risk" },
+  { id: 'light', label: 'Light', color: '#34C759', devMult: 0.6, injuryChance: 0.01, desc: 'Low risk, moderate gains' },
+  { id: 'normal', label: 'Normal', color: '#FFD60A', devMult: 1.0, injuryChance: 0.03, desc: 'Balanced risk and reward' },
+  { id: 'hard', label: 'Hard', color: '#FF453A', devMult: 1.5, injuryChance: 0.07, desc: 'High gains, injury risk' },
 ];
 
 const DRILL_TYPES = [
-  { id: "technique", label: "Technique", desc: "Fundamentals and position skills" },
-  { id: "conditioning", label: "Conditioning", desc: "Speed, stamina, durability" },
-  { id: "teamwork", label: "Team Drills", desc: "Coordination and chemistry" },
-  { id: "film", label: "Film Study", desc: "Mental preparation and awareness" },
+  { id: 'technique', label: 'Technique', desc: 'Fundamentals and position skills' },
+  { id: 'conditioning', label: 'Conditioning', desc: 'Speed, stamina, durability' },
+  { id: 'teamwork', label: 'Team Drills', desc: 'Coordination and chemistry' },
+  { id: 'film', label: 'Film Study', desc: 'Mental preparation and awareness' },
 ];
 
 function seededRandom(seed) {
   let s = seed;
-  return function() {
+  return function seeded() {
     s = (s * 1103515245 + 12345) & 0x7fffffff;
     return s / 0x7fffffff;
   };
-}
-
-function ProgressBar({ value, max, color, height = 6, label }) {
-  const pct = Math.min(100, Math.max(0, (value / max) * 100));
-  return (
-    <div style={{ width: "100%" }}>
-      {label && <div style={{ fontSize: 10, color: "var(--text-muted)", marginBottom: 2 }}>{label}</div>}
-      <div style={{
-        height, background: "var(--surface-strong, #1a1a2e)", borderRadius: height,
-        overflow: "hidden", position: "relative",
-      }}>
-        <div style={{
-          height: "100%", width: `${pct}%`, background: color || "var(--accent)",
-          borderRadius: height, transition: "width 0.8s cubic-bezier(0.2,0.8,0.2,1)",
-        }} />
-      </div>
-    </div>
-  );
 }
 
 function PlayerDrillRow({ player, result, onSelect }) {
@@ -67,41 +38,46 @@ function PlayerDrillRow({ player, result, onSelect }) {
     <div
       onClick={() => onSelect?.(player.id)}
       style={{
-        display: "flex", alignItems: "center", gap: 8, padding: "6px 8px",
-        borderBottom: "1px solid var(--hairline)", cursor: "pointer",
-        background: injured ? "rgba(255,69,58,0.05)" : "transparent",
-        transition: "background 0.2s",
+        display: 'flex', alignItems: 'center', gap: 8, padding: '6px 8px',
+        borderBottom: '1px solid var(--hairline)', cursor: 'pointer',
+        background: injured ? 'rgba(255,69,58,0.05)' : 'transparent',
+        transition: 'background 0.2s',
       }}
     >
-      <div style={{
-        width: 28, height: 28, borderRadius: "50%", background: "var(--surface-strong, #1a1a2e)",
-        display: "flex", alignItems: "center", justifyContent: "center",
-        fontSize: 10, fontWeight: 800, color: "var(--text-muted)", flexShrink: 0,
-      }}>
+      <div
+        style={{
+          width: 28, height: 28, borderRadius: '50%', background: 'var(--surface-strong, #1a1a2e)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          fontSize: 10, fontWeight: 800, color: 'var(--text-muted)', flexShrink: 0,
+        }}
+      >
         {player.pos}
       </div>
       <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ fontSize: 12, fontWeight: 600, color: "var(--text)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+        <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--text)', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
           {player.name}
         </div>
-        <div style={{ fontSize: 10, color: "var(--text-muted)" }}>
+        <div style={{ fontSize: 10, color: 'var(--text-muted)' }}>
           Age {player.age} · OVR {player.ovr}
           {player.potential != null && ` · POT ${player.potential}`}
         </div>
       </div>
       {result && (
-        <div style={{ textAlign: "right", flexShrink: 0 }}>
+        <div style={{ textAlign: 'right', flexShrink: 0 }}>
           {injured ? (
-            <span style={{ fontSize: 11, fontWeight: 700, color: "var(--danger)" }}>INJURED</span>
+            <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--danger)' }}>INJURED</span>
           ) : change !== 0 ? (
-            <span style={{
-              fontSize: 12, fontWeight: 800,
-              color: change > 0 ? "var(--success)" : "var(--danger)",
-            }}>
-              {change > 0 ? "+" : ""}{change}
+            <span
+              style={{
+                fontSize: 12, fontWeight: 800,
+                color: change > 0 ? 'var(--success)' : 'var(--danger)',
+              }}
+            >
+              {change > 0 ? '+' : ''}
+              {change}
             </span>
           ) : (
-            <span style={{ fontSize: 11, color: "var(--text-subtle)" }}>No change</span>
+            <span style={{ fontSize: 11, color: 'var(--text-subtle)' }}>No change</span>
           )}
         </div>
       )}
@@ -109,46 +85,46 @@ function PlayerDrillRow({ player, result, onSelect }) {
   );
 }
 
-export default function TrainingCamp({ league, actions, onPlayerSelect }) {
-  const [intensity, setIntensity] = useState("normal");
+export default function TrainingCamp({ league, actions, onPlayerSelect, onNavigate }) {
+  const [intensity, setIntensity] = useState('normal');
   const [focusGroups, setFocusGroups] = useState(new Set());
-  const [drillType, setDrillType] = useState("technique");
+  const [drillType, setDrillType] = useState('technique');
   const [results, setResults] = useState(null);
-  const [expanded, setExpanded] = useState(new Set(["qb"]));
+  const [expanded, setExpanded] = useState(new Set(['qb']));
   const [drillsRun, setDrillsRun] = useState(0);
+  const [persistState, setPersistState] = useState('idle');
 
-  const isTrainingCamp = league?.phase === "preseason";
-  const maxDrills = isTrainingCamp ? 5 : 2;
-  const drillsRemaining = maxDrills - drillsRun;
+  const model = useMemo(() => buildTrainingPlanModel({ league, intensity, drillType, drillsRun, actions }), [league, intensity, drillType, drillsRun, actions]);
+  const { roster, drillsRemaining } = model;
 
-  // Get user team roster
-  const roster = useMemo(() => {
-    if (!league?.roster) return [];
-    return (league.roster || []).filter(p => p.teamId === league.userTeamId);
-  }, [league?.roster, league?.userTeamId]);
-
-  // Group players by position group
   const groups = useMemo(() => {
     const map = {};
-    POSITION_GROUPS.forEach(g => { map[g.id] = { ...g, players: [] }; });
-    roster.forEach(p => {
-      const group = POSITION_GROUPS.find(g => g.positions.includes(p.pos));
+    POSITION_GROUPS.forEach((g) => { map[g.id] = { ...g, players: [] }; });
+    roster.forEach((p) => {
+      const group = POSITION_GROUPS.find((g) => g.positions.includes(String(p?.pos ?? '').toUpperCase()));
       if (group && map[group.id]) map[group.id].players.push(p);
     });
     return map;
   }, [roster]);
 
   const toggleFocus = useCallback((groupId) => {
-    setFocusGroups(prev => {
+    setFocusGroups((prev) => {
       const next = new Set(prev);
-      if (next.has(groupId)) { next.delete(groupId); }
-      else if (next.size < 2) { next.add(groupId); }
+      if (next.has(groupId)) next.delete(groupId);
+      else if (next.size < 2) next.add(groupId);
       return next;
     });
   }, []);
 
+  const applyRecommendation = useCallback((recommendation) => {
+    if (!recommendation) return;
+    setFocusGroups(new Set([recommendation.groupId]));
+    setDrillType(recommendation.suggestedDrillType);
+    setIntensity(recommendation.suggestedIntensity);
+  }, []);
+
   const toggleExpand = useCallback((groupId) => {
-    setExpanded(prev => {
+    setExpanded((prev) => {
       const next = new Set(prev);
       if (next.has(groupId)) next.delete(groupId);
       else next.add(groupId);
@@ -156,16 +132,16 @@ export default function TrainingCamp({ league, actions, onPlayerSelect }) {
     });
   }, []);
 
-  const runDrills = useCallback(() => {
+  const runDrills = useCallback(async () => {
     if (drillsRemaining <= 0) return;
 
     const seed = (league?.year ?? 2025) * 1000 + (league?.week ?? 1) * 100 + drillsRun;
     const rng = seededRandom(seed);
-    const config = INTENSITY_LEVELS.find(l => l.id === intensity);
+    const config = INTENSITY_LEVELS.find((l) => l.id === intensity) ?? INTENSITY_LEVELS[1];
     const newResults = {};
 
-    roster.forEach(p => {
-      const group = POSITION_GROUPS.find(g => g.positions.includes(p.pos));
+    roster.forEach((p) => {
+      const group = POSITION_GROUPS.find((g) => g.positions.includes(String(p?.pos ?? '').toUpperCase()));
       if (!group) return;
 
       const isFocused = focusGroups.has(group.id);
@@ -179,71 +155,120 @@ export default function TrainingCamp({ league, actions, onPlayerSelect }) {
       if (roll < devChance * 0.3) change = 2;
       else if (roll < devChance) change = 1;
 
-      const injured = rng() < config.injuryChance * (intensity === "hard" ? 1.5 : 1);
+      const injured = rng() < config.injuryChance * (intensity === 'hard' ? 1.5 : 1);
 
       newResults[p.id] = { change, injured, devChance };
     });
 
     setResults(newResults);
-    setDrillsRun(prev => prev + 1);
+    setDrillsRun((prev) => prev + 1);
 
-    // Persist training boosts to the worker so the sim engine can use them
-    if (actions?.conductDrill) {
-      const teamId = league?.userTeamId;
-      const posGroups = focusGroups.size > 0 ? Array.from(focusGroups) : [];
-      actions.conductDrill(teamId, intensity, drillType, posGroups);
+    if (typeof actions?.conductDrill === 'function') {
+      try {
+        const teamId = league?.userTeamId;
+        const posGroups = focusGroups.size > 0 ? Array.from(focusGroups) : [];
+        await actions.conductDrill(teamId, intensity, drillType, posGroups);
+        setPersistState('persisted');
+      } catch {
+        setPersistState('preview');
+      }
+    } else {
+      setPersistState('preview');
     }
-  }, [roster, intensity, focusGroups, drillType, drillsRun, drillsRemaining, league, actions]);
+  }, [drillsRemaining, league, drillsRun, intensity, roster, focusGroups, drillType, actions]);
 
-  // Summary stats
   const summary = useMemo(() => {
     if (!results) return null;
-    let improved = 0, injured = 0, totalGain = 0;
-    Object.values(results).forEach(r => {
-      if (r.change > 0) improved++;
-      if (r.injured) injured++;
+    let improved = 0; let injured = 0; let totalGain = 0;
+    Object.values(results).forEach((r) => {
+      if (r.change > 0) improved += 1;
+      if (r.injured) injured += 1;
       totalGain += r.change;
     });
     return { improved, injured, totalGain, total: Object.keys(results).length };
   }, [results]);
 
   return (
-    <div style={{ maxWidth: 800, margin: "0 auto" }}>
-      {/* Header */}
-      <div style={{
-        display: "flex", alignItems: "center", justifyContent: "space-between",
-        marginBottom: "var(--space-4, 16px)",
-      }}>
-        <div>
-          <h2 style={{ margin: 0, fontSize: "var(--text-lg, 18px)", fontWeight: 800, color: "var(--text)" }}>
-            {isTrainingCamp ? "Training Camp" : "Weekly Practice"}
-          </h2>
-          <p style={{ margin: "2px 0 0", fontSize: "var(--text-xs, 12px)", color: "var(--text-muted)" }}>
-            {isTrainingCamp ? "Preseason camp — develop your roster" : `Week ${league?.week ?? 1} practice`}
-            {" · "}{drillsRemaining} drill{drillsRemaining !== 1 ? "s" : ""} remaining
-          </p>
+    <div style={{ maxWidth: 800, margin: '0 auto', paddingBottom: 16 }}>
+      <div className="stat-box" style={{ marginBottom: 'var(--space-4, 16px)', padding: '12px' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>
+          <div>
+            <h2 style={{ margin: 0, fontSize: 'var(--text-lg, 18px)', fontWeight: 800, color: 'var(--text)' }}>{model.phaseLabel}</h2>
+            <p style={{ margin: '4px 0 0', fontSize: 'var(--text-xs, 12px)', color: 'var(--text-muted)' }}>{model.weekLabel} · {model.practiceStateLabel}</p>
+          </div>
+          <span style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '6px 10px', alignSelf: 'flex-start' }}>
+            {model.risk.label}
+          </span>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 8, marginTop: 10, fontSize: 12 }}>
+          <div>Drills Remaining: <strong>{model.drillsRemaining}/{model.maxDrills}</strong></div>
+          <div>Intensity: <strong>{intensity}</strong></div>
+        </div>
+        <p style={{ margin: '10px 0 0', fontSize: 12, color: 'var(--text-muted)' }}>{model.recommendedNextAction}</p>
+        <p style={{ margin: '6px 0 0', fontSize: 11, color: 'var(--text-subtle)' }}>{model.matchupTrainingNote}</p>
+        <p style={{ margin: '6px 0 0', fontSize: 11, color: 'var(--text-subtle)' }}>{model.prepSupportLabel}</p>
+        <div style={{ display: 'flex', gap: 8, marginTop: 10, flexWrap: 'wrap' }}>
+          <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('Weekly Prep')}>Back to Weekly Prep</button>
+          <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('HQ')}>Back to HQ</button>
         </div>
       </div>
 
-      {/* Controls */}
-      <div className="stat-box" style={{ marginBottom: "var(--space-4, 16px)", padding: "12px" }}>
-        {/* Intensity */}
+      {model.recommendedFocus.length > 0 && (
+        <div className="stat-box" style={{ marginBottom: 'var(--space-4, 16px)', padding: 12 }}>
+          <div style={{ fontSize: 12, fontWeight: 800, marginBottom: 8 }}>Recommended Focus</div>
+          <div style={{ display: 'grid', gap: 8 }}>
+            {model.recommendedFocus.map((rec) => (
+              <article key={rec.groupId} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: 10 }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'center' }}>
+                  <strong style={{ fontSize: 13 }}>{rec.groupLabel}</strong>
+                  <button type="button" className="btn btn-xs" onClick={() => applyRecommendation(rec)}>Select this focus</button>
+                </div>
+                <p style={{ margin: '6px 0 0', fontSize: 12, color: 'var(--text-muted)' }}>{rec.reason}</p>
+                <p style={{ margin: '4px 0 0', fontSize: 11, color: 'var(--text-subtle)' }}>
+                  Suggested: {rec.suggestedDrillType} · {rec.suggestedIntensity} intensity · {rec.riskNote}
+                </p>
+              </article>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {model.developmentCandidates.length > 0 && (
+        <div className="stat-box" style={{ marginBottom: 'var(--space-4, 16px)', padding: 12 }}>
+          <div style={{ fontSize: 12, fontWeight: 800, marginBottom: 8 }}>Development Candidates</div>
+          <div style={{ display: 'grid', gap: 6 }}>
+            {model.developmentCandidates.map((player) => (
+              <div key={player.playerId} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, borderBottom: '1px solid var(--hairline)', paddingBottom: 6 }}>
+                <div style={{ minWidth: 0 }}>
+                  <div style={{ fontSize: 12, fontWeight: 700 }}>{player.name} · {player.pos}</div>
+                  <div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Age {player.age} · OVR {player.ovr} · POT {player.potential}</div>
+                  <div style={{ fontSize: 11, color: 'var(--text-subtle)' }}>{player.reason}</div>
+                </div>
+                {onPlayerSelect ? <button type="button" className="btn btn-xs" onClick={() => onPlayerSelect(player.playerId)}>View Player</button> : null}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="stat-box" style={{ marginBottom: 'var(--space-4, 16px)', padding: '12px' }}>
         <div style={{ marginBottom: 12 }}>
-          <div style={{ fontSize: 11, fontWeight: 700, color: "var(--text-muted)", marginBottom: 6, textTransform: "uppercase", letterSpacing: "0.5px" }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-muted)', marginBottom: 6, textTransform: 'uppercase', letterSpacing: '0.5px' }}>
             Practice Intensity
           </div>
-          <div style={{ display: "flex", gap: 6 }}>
-            {INTENSITY_LEVELS.map(level => (
+          <div style={{ display: 'flex', gap: 6 }}>
+            {INTENSITY_LEVELS.map((level) => (
               <button
                 key={level.id}
                 className="btn"
                 onClick={() => setIntensity(level.id)}
+                aria-pressed={intensity === level.id}
                 style={{
-                  flex: 1, padding: "8px", fontSize: 12, fontWeight: 700,
-                  background: intensity === level.id ? level.color + "22" : "var(--surface-strong, #1a1a2e)",
-                  color: intensity === level.id ? level.color : "var(--text-muted)",
-                  border: `2px solid ${intensity === level.id ? level.color : "transparent"}`,
-                  borderRadius: "var(--radius-md, 8px)", cursor: "pointer",
+                  flex: 1, padding: '8px', fontSize: 12, fontWeight: 700,
+                  background: intensity === level.id ? `${level.color}22` : 'var(--surface-strong, #1a1a2e)',
+                  color: intensity === level.id ? level.color : 'var(--text-muted)',
+                  border: `2px solid ${intensity === level.id ? level.color : 'transparent'}`,
+                  borderRadius: 'var(--radius-md, 8px)', cursor: 'pointer',
                 }}
               >
                 {level.label}
@@ -251,25 +276,26 @@ export default function TrainingCamp({ league, actions, onPlayerSelect }) {
               </button>
             ))}
           </div>
+          {intensity === 'hard' && <p style={{ margin: '6px 0 0', fontSize: 11, color: 'var(--warning)' }}>Hard intensity increases drill injury risk this week.</p>}
         </div>
 
-        {/* Drill Type */}
         <div style={{ marginBottom: 12 }}>
-          <div style={{ fontSize: 11, fontWeight: 700, color: "var(--text-muted)", marginBottom: 6, textTransform: "uppercase", letterSpacing: "0.5px" }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-muted)', marginBottom: 6, textTransform: 'uppercase', letterSpacing: '0.5px' }}>
             Drill Focus
           </div>
-          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-            {DRILL_TYPES.map(drill => (
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            {DRILL_TYPES.map((drill) => (
               <button
                 key={drill.id}
                 className="btn"
                 onClick={() => setDrillType(drill.id)}
+                aria-pressed={drillType === drill.id}
                 style={{
-                  padding: "6px 12px", fontSize: 11, fontWeight: 600,
-                  background: drillType === drill.id ? "var(--accent)" + "22" : "var(--surface-strong, #1a1a2e)",
-                  color: drillType === drill.id ? "var(--accent)" : "var(--text-muted)",
-                  border: `1px solid ${drillType === drill.id ? "var(--accent)" : "transparent"}`,
-                  borderRadius: "var(--radius-pill, 100px)", cursor: "pointer",
+                  padding: '6px 12px', fontSize: 11, fontWeight: 600,
+                  background: drillType === drill.id ? 'var(--accent)22' : 'var(--surface-strong, #1a1a2e)',
+                  color: drillType === drill.id ? 'var(--accent)' : 'var(--text-muted)',
+                  border: `1px solid ${drillType === drill.id ? 'var(--accent)' : 'transparent'}`,
+                  borderRadius: 'var(--radius-pill, 100px)', cursor: 'pointer',
                 }}
               >
                 {drill.label}
@@ -278,107 +304,94 @@ export default function TrainingCamp({ league, actions, onPlayerSelect }) {
           </div>
         </div>
 
-        {/* Focus Groups */}
         <div style={{ marginBottom: 12 }}>
-          <div style={{ fontSize: 11, fontWeight: 700, color: "var(--text-muted)", marginBottom: 6, textTransform: "uppercase", letterSpacing: "0.5px" }}>
+          <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-muted)', marginBottom: 6, textTransform: 'uppercase', letterSpacing: '0.5px' }}>
             Focus Groups (pick up to 2 for bonus development)
           </div>
-          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-            {POSITION_GROUPS.map(g => (
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+            {POSITION_GROUPS.map((g) => (
               <button
                 key={g.id}
                 className="btn"
                 onClick={() => toggleFocus(g.id)}
+                aria-pressed={focusGroups.has(g.id)}
                 style={{
-                  padding: "5px 10px", fontSize: 11, fontWeight: 600,
-                  background: focusGroups.has(g.id) ? g.color + "22" : "var(--surface-strong, #1a1a2e)",
-                  color: focusGroups.has(g.id) ? g.color : "var(--text-muted)",
-                  border: `1px solid ${focusGroups.has(g.id) ? g.color : "transparent"}`,
-                  borderRadius: "var(--radius-pill, 100px)", cursor: "pointer",
+                  padding: '5px 10px', fontSize: 11, fontWeight: 600,
+                  background: focusGroups.has(g.id) ? 'var(--accent)22' : 'var(--surface-strong, #1a1a2e)',
+                  color: focusGroups.has(g.id) ? 'var(--accent)' : 'var(--text-muted)',
+                  border: `1px solid ${focusGroups.has(g.id) ? 'var(--accent)' : 'transparent'}`,
+                  borderRadius: 'var(--radius-pill, 100px)', cursor: 'pointer',
                 }}
               >
-                {g.icon} {g.label}
+                {g.label}
               </button>
             ))}
           </div>
         </div>
 
-        {/* Run Drills Button */}
         <button
           className="btn"
           onClick={runDrills}
           disabled={drillsRemaining <= 0}
           style={{
-            width: "100%", padding: "12px", fontSize: 14, fontWeight: 800,
-            background: drillsRemaining > 0 ? "var(--accent)" : "var(--surface-strong, #1a1a2e)",
-            color: drillsRemaining > 0 ? "white" : "var(--text-subtle)",
-            border: "none", borderRadius: "var(--radius-md, 8px)", cursor: drillsRemaining > 0 ? "pointer" : "not-allowed",
+            width: '100%', padding: '12px', fontSize: 14, fontWeight: 800,
+            background: drillsRemaining > 0 ? 'var(--accent)' : 'var(--surface-strong, #1a1a2e)',
+            color: drillsRemaining > 0 ? 'white' : 'var(--text-subtle)',
+            border: 'none', borderRadius: 'var(--radius-md, 8px)', cursor: drillsRemaining > 0 ? 'pointer' : 'not-allowed',
           }}
         >
-          {drillsRemaining > 0 ? `Run Drills (${drillsRemaining} remaining)` : "No Drills Remaining This Week"}
+          {drillsRemaining > 0 ? `Run Drills (${drillsRemaining} remaining)` : 'No Drills Remaining This Week'}
         </button>
       </div>
 
-      {/* Results Summary */}
       {summary && (
-        <div className="stat-box fade-in" style={{
-          marginBottom: "var(--space-4, 16px)", padding: "12px",
-          display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 12, textAlign: "center",
-        }}>
+        <div className="stat-box fade-in" style={{ marginBottom: 'var(--space-4, 16px)', padding: '12px', display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12, textAlign: 'center' }}>
           <div>
-            <div style={{ fontSize: 20, fontWeight: 800, color: "var(--success)" }}>{summary.improved}</div>
-            <div style={{ fontSize: 10, color: "var(--text-muted)" }}>Players Improved</div>
+            <div style={{ fontSize: 20, fontWeight: 800, color: 'var(--success)' }}>{summary.improved}</div>
+            <div style={{ fontSize: 10, color: 'var(--text-muted)' }}>Players Improved</div>
           </div>
           <div>
-            <div style={{ fontSize: 20, fontWeight: 800, color: "var(--accent)" }}>+{summary.totalGain}</div>
-            <div style={{ fontSize: 10, color: "var(--text-muted)" }}>Total OVR Gained</div>
+            <div style={{ fontSize: 20, fontWeight: 800, color: 'var(--accent)' }}>+{summary.totalGain}</div>
+            <div style={{ fontSize: 10, color: 'var(--text-muted)' }}>Total OVR Gained</div>
           </div>
           <div>
-            <div style={{ fontSize: 20, fontWeight: 800, color: summary.injured > 0 ? "var(--danger)" : "var(--text-muted)" }}>
-              {summary.injured}
-            </div>
-            <div style={{ fontSize: 10, color: "var(--text-muted)" }}>Injuries</div>
+            <div style={{ fontSize: 20, fontWeight: 800, color: summary.injured > 0 ? 'var(--danger)' : 'var(--text-muted)' }}>{summary.injured}</div>
+            <div style={{ fontSize: 10, color: 'var(--text-muted)' }}>Injuries</div>
           </div>
         </div>
       )}
 
-      {/* Position Group Cards */}
-      {POSITION_GROUPS.map(group => {
+      {results && (
+        <div className="stat-box" style={{ marginBottom: 12, padding: 10, fontSize: 12 }}>
+          {persistState === 'persisted' ? 'Drill effects were sent to simulation via conductDrill (weekly boosts/injury risk persist for this week).' : 'Persistence unavailable — this run is a local preview for planning only.'}
+        </div>
+      )}
+
+      {POSITION_GROUPS.map((group) => {
         const data = groups[group.id];
         if (!data || data.players.length === 0) return null;
         const isExpanded = expanded.has(group.id);
         const isFocused = focusGroups.has(group.id);
-        const groupResults = results ? data.players.map(p => ({ player: p, result: results[p.id] })) : null;
-        const groupImproved = groupResults?.filter(r => r.result?.change > 0).length ?? 0;
+        const groupResults = results ? data.players.map((p) => ({ player: p, result: results[p.id] })) : null;
+        const groupImproved = groupResults?.filter((r) => r.result?.change > 0).length ?? 0;
 
         return (
-          <div key={group.id} className="stat-box" style={{
-            marginBottom: "var(--space-3, 12px)", overflow: "hidden",
-            border: isFocused ? `1px solid ${group.color}44` : undefined,
-          }}>
+          <div key={group.id} className="stat-box" style={{ marginBottom: 'var(--space-3, 12px)', overflow: 'hidden', border: isFocused ? '1px solid var(--accent)' : undefined }}>
             <div
               onClick={() => toggleExpand(group.id)}
-              style={{
-                display: "flex", alignItems: "center", gap: 8, padding: "10px 12px",
-                cursor: "pointer", borderBottom: isExpanded ? "1px solid var(--hairline)" : "none",
-              }}
+              style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', cursor: 'pointer', borderBottom: isExpanded ? '1px solid var(--hairline)' : 'none' }}
             >
-              <span style={{ fontSize: 18 }}>{group.icon}</span>
               <div style={{ flex: 1 }}>
-                <div style={{ fontSize: 13, fontWeight: 700, color: "var(--text)" }}>
+                <div style={{ fontSize: 13, fontWeight: 700, color: 'var(--text)' }}>
                   {group.label}
-                  {isFocused && <span style={{ fontSize: 9, color: group.color, marginLeft: 6, fontWeight: 800 }}>FOCUS</span>}
+                  {isFocused && <span style={{ fontSize: 9, color: 'var(--accent)', marginLeft: 6, fontWeight: 800 }}>FOCUS</span>}
                 </div>
-                <div style={{ fontSize: 10, color: "var(--text-muted)" }}>
+                <div style={{ fontSize: 10, color: 'var(--text-muted)' }}>
                   {data.players.length} players
                   {groupResults && ` · ${groupImproved} improved`}
                 </div>
               </div>
-              <div style={{
-                width: 24, height: 24, display: "flex", alignItems: "center", justifyContent: "center",
-                color: "var(--text-subtle)", fontSize: 14, transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)",
-                transition: "transform 0.2s",
-              }}>
+              <div style={{ width: 24, height: 24, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--text-subtle)', fontSize: 14, transform: isExpanded ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s' }}>
                 ▼
               </div>
             </div>
@@ -386,7 +399,7 @@ export default function TrainingCamp({ league, actions, onPlayerSelect }) {
               <div>
                 {data.players
                   .sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0))
-                  .map(p => (
+                  .map((p) => (
                     <PlayerDrillRow
                       key={p.id}
                       player={p}
@@ -401,7 +414,7 @@ export default function TrainingCamp({ league, actions, onPlayerSelect }) {
       })}
 
       {roster.length === 0 && (
-        <div style={{ textAlign: "center", padding: 40, color: "var(--text-muted)" }}>
+        <div style={{ textAlign: 'center', padding: 40, color: 'var(--text-muted)' }}>
           <div style={{ fontSize: 32, marginBottom: 8 }}>🏈</div>
           <div style={{ fontSize: 14, fontWeight: 600 }}>No roster data available</div>
           <div style={{ fontSize: 12, marginTop: 4 }}>Load a league to access training camp</div>

--- a/src/ui/components/__tests__/TrainingCamp.test.jsx
+++ b/src/ui/components/__tests__/TrainingCamp.test.jsx
@@ -1,0 +1,68 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import TrainingCamp from '../TrainingCamp.jsx';
+
+afterEach(() => cleanup());
+
+const league = {
+  year: 2028,
+  seasonId: 's2028',
+  week: 6,
+  phase: 'regular',
+  userTeamId: 1,
+  teams: [
+    {
+      id: 1,
+      abbr: 'CHI',
+      ovr: 83,
+      offenseRating: 82,
+      defenseRating: 84,
+      roster: [
+        { id: 10, name: 'Caleb North', pos: 'QB', age: 22, ovr: 74, potential: 86, progressionDelta: 2, teamId: 1 },
+        { id: 11, name: 'Terry Wide', pos: 'WR', age: 23, ovr: 71, potential: 83, progressionDelta: 3, teamId: 1 },
+        { id: 12, name: 'Miles Hill', pos: 'LB', age: 25, ovr: 72, potential: 78, progressionDelta: 1, teamId: 1 },
+      ],
+    },
+    { id: 2, abbr: 'DET', ovr: 79, offenseRating: 81, defenseRating: 75, roster: [] },
+  ],
+  schedule: { weeks: [{ week: 6, games: [{ played: false, home: { id: 1 }, away: { id: 2 } }] }] },
+};
+
+describe('TrainingCamp', () => {
+  it('selecting recommended focus updates local controls', () => {
+    render(<TrainingCamp league={league} actions={{}} onNavigate={vi.fn()} onPlayerSelect={vi.fn()} />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: /select this focus/i })[0]);
+
+    expect(screen.getByRole('button', { name: /hard/i, pressed: true })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /technique/i, pressed: true })).toBeTruthy();
+  });
+
+  it('runs drills and calls conductDrill when available', async () => {
+    const conductDrill = vi.fn().mockResolvedValue({});
+    render(<TrainingCamp league={league} actions={{ conductDrill }} onNavigate={vi.fn()} onPlayerSelect={vi.fn()} />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Run Drills/i })[0]);
+    await waitFor(() => expect(conductDrill).toHaveBeenCalled());
+    expect(screen.getByText(/sent to simulation via conductDrill/i)).toBeTruthy();
+  });
+
+  it('shows honest preview copy when persistence is unavailable', () => {
+    render(<TrainingCamp league={league} actions={{}} onNavigate={vi.fn()} onPlayerSelect={vi.fn()} />);
+    fireEvent.click(screen.getAllByRole('button', { name: /Run Drills/i })[0]);
+    expect(screen.getByText(/local preview for planning only/i)).toBeTruthy();
+  });
+
+  it('routes back actions', () => {
+    const onNavigate = vi.fn();
+    render(<TrainingCamp league={league} actions={{}} onNavigate={onNavigate} onPlayerSelect={vi.fn()} />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Back to Weekly Prep/i })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: /Back to HQ/i })[0]);
+
+    expect(onNavigate).toHaveBeenCalledWith('Weekly Prep');
+    expect(onNavigate).toHaveBeenCalledWith('HQ');
+  });
+});

--- a/src/ui/utils/trainingPlanModel.js
+++ b/src/ui/utils/trainingPlanModel.js
@@ -1,0 +1,229 @@
+import { deriveWeeklyPrepState } from './weeklyPrep.js';
+import { buildTeamIntelligence } from './teamIntelligence.js';
+import { classifyDevelopmentTrend, getSchemeFitSignal } from './playerDevelopmentSignals.js';
+
+const POSITION_GROUPS = [
+  { id: 'qb', label: 'QB Room', positions: ['QB'] },
+  { id: 'rb', label: 'RB Room', positions: ['RB', 'HB', 'FB'] },
+  { id: 'wr', label: 'WR Corps', positions: ['WR', 'FL', 'SE'] },
+  { id: 'te', label: 'TE Room', positions: ['TE'] },
+  { id: 'ol', label: 'O-Line', positions: ['OL', 'C', 'G', 'T', 'OT', 'OG', 'LT', 'RT', 'LG', 'RG'] },
+  { id: 'dl', label: 'D-Line', positions: ['DL', 'DE', 'DT', 'NT', 'EDGE', 'IDL'] },
+  { id: 'lb', label: 'Linebackers', positions: ['LB', 'MLB', 'OLB', 'ILB'] },
+  { id: 'db', label: 'Secondary', positions: ['CB', 'S', 'FS', 'SS', 'DB', 'NCB'] },
+  { id: 'st', label: 'Special Teams', positions: ['K', 'P'] },
+];
+
+const GROUP_BY_POS = new Map(POSITION_GROUPS.flatMap((group) => group.positions.map((pos) => [pos, group.id])));
+const NEED_POS_MAP = { QB: 'qb', RB: 'rb', WR: 'wr', TE: 'te', OL: 'ol', DL: 'dl', LB: 'lb', CB: 'db', S: 'db' };
+const INTENSITY_RISK = {
+  light: { score: 1, label: 'Low', note: 'Light load keeps injury exposure down.' },
+  normal: { score: 2, label: 'Moderate', note: 'Balanced load with moderate injury exposure.' },
+  hard: { score: 3, label: 'High', note: 'Hard sessions can create short-term injury risk.' },
+};
+
+function safeNum(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function normalizePos(player) {
+  return String(player?.pos ?? player?.position ?? '').toUpperCase();
+}
+
+function getGroupIdForPlayer(player) {
+  return GROUP_BY_POS.get(normalizePos(player)) ?? null;
+}
+
+function getUserTeam(league) {
+  const teams = Array.isArray(league?.teams) ? league.teams : [];
+  return teams.find((team) => Number(team?.id) === Number(league?.userTeamId)) ?? null;
+}
+
+function deriveRoster(league, userTeam) {
+  const leagueRoster = Array.isArray(league?.roster)
+    ? league.roster.filter((player) => Number(player?.teamId) === Number(league?.userTeamId))
+    : [];
+  if (leagueRoster.length > 0) return leagueRoster;
+  return Array.isArray(userTeam?.roster) ? userTeam.roster : [];
+}
+
+function isInjured(player) {
+  return safeNum(player?.injuryWeeksRemaining ?? player?.injury?.weeksRemaining ?? player?.injuredWeeks ?? 0) > 0
+    || String(player?.status ?? '').toLowerCase() === 'injured';
+}
+
+function summarizeRisk(intensity, injuredCount) {
+  const base = INTENSITY_RISK[intensity] ?? INTENSITY_RISK.normal;
+  const riskScore = base.score + (injuredCount >= 4 ? 2 : injuredCount >= 2 ? 1 : 0);
+  if (riskScore >= 4) return { level: 'high', label: 'High Risk', note: `${base.note} Existing injuries increase replacement volatility.` };
+  if (riskScore >= 3) return { level: 'medium', label: 'Manage Risk', note: base.note };
+  return { level: 'low', label: 'Low Risk', note: base.note };
+}
+
+function buildMatchupNote(prep, focusLabel) {
+  if (!prep?.nextGame) return 'No locked opponent yet — keep base install balanced.';
+  const weakness = prep?.opponentWeaknesses?.[0];
+  const threat = prep?.opponentStrengths?.[0];
+  if (weakness && focusLabel) return `${focusLabel} emphasis can help exploit: ${weakness}`;
+  if (threat && focusLabel) return `${focusLabel} prep helps answer: ${threat}`;
+  return prep?.keyMatchupNote ?? 'Matchup is balanced; execution details will decide this week.';
+}
+
+function createRecommendedFocus({ roster, intelligence, prep, riskLevel }) {
+  const injuryCounts = {};
+  const youngUpsideCounts = {};
+
+  for (const player of roster) {
+    const groupId = getGroupIdForPlayer(player);
+    if (!groupId) continue;
+    if (isInjured(player)) injuryCounts[groupId] = (injuryCounts[groupId] ?? 0) + 1;
+    const upsideGap = safeNum(player?.potential, safeNum(player?.ovr, 60) + 4) - safeNum(player?.ovr, 60);
+    if (safeNum(player?.age, 30) <= 24 && upsideGap >= 6) {
+      youngUpsideCounts[groupId] = (youngUpsideCounts[groupId] ?? 0) + 1;
+    }
+  }
+
+  const needs = Array.isArray(intelligence?.needsNow) ? intelligence.needsNow : [];
+  const scoreMap = new Map(POSITION_GROUPS.map((g) => [g.id, 0]));
+  const reasonMap = new Map(POSITION_GROUPS.map((g) => [g.id, []]));
+
+  for (const need of needs) {
+    const groupId = NEED_POS_MAP[String(need?.pos ?? '').toUpperCase()];
+    if (!groupId) continue;
+    scoreMap.set(groupId, (scoreMap.get(groupId) ?? 0) + safeNum(need?.severity, 1) + 2);
+    reasonMap.get(groupId)?.push(need?.label ?? `${need?.pos} depth need`);
+  }
+
+  for (const [groupId, count] of Object.entries(injuryCounts)) {
+    scoreMap.set(groupId, (scoreMap.get(groupId) ?? 0) + count + 1);
+    reasonMap.get(groupId)?.push(count > 1 ? `${count} injured players in this room` : 'Starter availability needs support');
+  }
+
+  for (const [groupId, count] of Object.entries(youngUpsideCounts)) {
+    scoreMap.set(groupId, (scoreMap.get(groupId) ?? 0) + count + 1);
+    reasonMap.get(groupId)?.push(count > 1 ? `${count} upside prospects can gain from reps` : 'Young upside player available for growth reps');
+  }
+
+  const weakness = prep?.opponentWeaknesses?.[0] ?? '';
+  if (/defense|secondary|coverage/i.test(weakness)) {
+    scoreMap.set('qb', (scoreMap.get('qb') ?? 0) + 1);
+    scoreMap.set('wr', (scoreMap.get('wr') ?? 0) + 1);
+    reasonMap.get('wr')?.push('Opponent coverage profile is attackable this week');
+  }
+
+  const ranked = POSITION_GROUPS
+    .map((group) => ({ group, score: scoreMap.get(group.id) ?? 0, reasons: reasonMap.get(group.id) ?? [] }))
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 4);
+
+  return ranked.map((entry) => {
+    const riskNote = riskLevel === 'high'
+      ? 'Consider normal/light intensity if this room is already strained.'
+      : riskLevel === 'medium'
+        ? 'Monitor availability after each drill.'
+        : 'Current roster health supports extra reps.';
+    return {
+      groupId: entry.group.id,
+      groupLabel: entry.group.label,
+      reason: entry.reasons[0] ?? 'Weekly operations signal says this group can gain leverage.',
+      suggestedDrillType: entry.group.id === 'ol' || entry.group.id === 'dl' || entry.group.id === 'lb' ? 'conditioning' : 'technique',
+      suggestedIntensity: riskLevel === 'high' ? 'normal' : 'hard',
+      riskNote,
+    };
+  });
+}
+
+function rankDevelopmentCandidates(roster, needsNow) {
+  const needSet = new Set((Array.isArray(needsNow) ? needsNow : []).map((need) => NEED_POS_MAP[String(need?.pos ?? '').toUpperCase()]).filter(Boolean));
+
+  return roster
+    .map((player) => {
+      const age = safeNum(player?.age, 30);
+      const ovr = safeNum(player?.ovr, 60);
+      const potential = safeNum(player?.potential, ovr + 2);
+      const upside = Math.max(0, potential - ovr);
+      const trend = classifyDevelopmentTrend(player);
+      const fit = getSchemeFitSignal(player);
+      const groupId = getGroupIdForPlayer(player);
+
+      let score = upside * 3 + Math.max(0, 27 - age);
+      if (age <= 24) score += 4;
+      if (needSet.has(groupId)) score += 3;
+      if (trend.key === 'breakout_candidate') score += 3;
+      if (trend.key === 'trending_up') score += 2;
+      if (fit.key === 'strong_fit') score += 1;
+      if (isInjured(player)) score -= 2;
+
+      const reasons = [];
+      if (age <= 24) reasons.push('Young player development window');
+      if (upside >= 6) reasons.push('High upside gap');
+      if (needSet.has(groupId)) reasons.push('Depth need this week');
+      if (fit.key === 'strong_fit') reasons.push('Scheme fit supports gains');
+      if (isInjured(player)) reasons.push('Injury replacement planning');
+      if (!reasons.length) reasons.push('Maintain weekly growth cadence');
+
+      return {
+        playerId: player?.id,
+        name: player?.name ?? 'Unknown Player',
+        pos: normalizePos(player) || 'N/A',
+        age,
+        ovr,
+        potential,
+        reason: reasons[0],
+        score,
+      };
+    })
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 5);
+}
+
+export function buildTrainingPlanModel({ league, intensity = 'normal', drillType = 'technique', drillsRun = 0, actions } = {}) {
+  const userTeam = getUserTeam(league);
+  const roster = deriveRoster(league, userTeam).filter((player) => player && typeof player === 'object');
+  const prep = deriveWeeklyPrepState(league);
+  const intelligence = buildTeamIntelligence(userTeam ?? { roster }, { week: safeNum(league?.week, 1) });
+
+  const isTrainingCamp = String(league?.phase ?? '').toLowerCase() === 'preseason';
+  const maxDrills = isTrainingCamp ? 5 : 2;
+  const safeDrillsRun = Math.max(0, safeNum(drillsRun, 0));
+  const drillsRemaining = Math.max(0, maxDrills - safeDrillsRun);
+
+  const seasonKey = league?.seasonId ?? league?.year ?? 'season';
+  const week = safeNum(league?.week, 1);
+  const focusStamp = userTeam?.weeklyDevelopmentFocus?.stamp;
+  const usedThisWeek = Boolean(focusStamp && focusStamp === `${seasonKey}:${week}`);
+
+  const injuredCount = roster.filter(isInjured).length;
+  const risk = summarizeRisk(intensity, injuredCount);
+  const recommendedFocus = createRecommendedFocus({ roster, intelligence, prep, riskLevel: risk.level });
+
+  const suggested = recommendedFocus[0] ?? null;
+  const recommendedNextAction = suggested
+    ? `Set ${suggested.groupLabel} to ${suggested.suggestedDrillType} and run a ${suggested.suggestedIntensity} drill.`
+    : 'Select one focus group and run a low-risk install drill.';
+
+  return {
+    week,
+    phaseLabel: isTrainingCamp ? 'Training Camp' : 'Weekly Practice',
+    weekLabel: isTrainingCamp ? `Preseason Week ${week}` : `Week ${week}`,
+    isTrainingCamp,
+    maxDrills,
+    drillsRemaining,
+    practiceStateLabel: usedThisWeek ? 'Practice already logged this week' : 'Practice available this week',
+    usedThisWeek,
+    intensity,
+    drillType,
+    risk,
+    recommendedFocus,
+    developmentCandidates: rankDevelopmentCandidates(roster, intelligence?.needsNow),
+    matchupTrainingNote: buildMatchupNote(prep, suggested?.groupLabel),
+    recommendedNextAction,
+    persistenceAvailable: typeof actions?.conductDrill === 'function',
+    prepSupportLabel: 'Training supports prep quality but does not complete a required Weekly Prep checklist step.',
+    roster,
+  };
+}
+
+export { POSITION_GROUPS };

--- a/src/ui/utils/trainingPlanModel.test.js
+++ b/src/ui/utils/trainingPlanModel.test.js
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildTrainingPlanModel } from './trainingPlanModel.js';
+
+const baseLeague = {
+  year: 2028,
+  seasonId: 's2028',
+  week: 4,
+  phase: 'regular',
+  userTeamId: 1,
+  teams: [
+    {
+      id: 1,
+      abbr: 'CHI',
+      ovr: 82,
+      offenseRating: 81,
+      defenseRating: 83,
+      weeklyDevelopmentFocus: { stamp: 's2028:4' },
+      roster: [
+        { id: 1, name: 'Young QB', pos: 'QB', age: 22, ovr: 71, potential: 84, progressionDelta: 2, schemeFit: 80, teamId: 1 },
+        { id: 2, name: 'Vet RB', pos: 'RB', age: 30, ovr: 78, potential: 79, progressionDelta: -1, schemeFit: 52, teamId: 1 },
+        { id: 3, name: 'WR Prospect', pos: 'WR', age: 23, ovr: 69, potential: 82, progressionDelta: 3, schemeFit: 77, teamId: 1 },
+        { id: 4, name: 'Injured CB', pos: 'CB', age: 25, ovr: 74, potential: 78, injuryWeeksRemaining: 1, schemeFit: 62, teamId: 1 },
+      ],
+    },
+    { id: 2, abbr: 'DET', ovr: 80, offenseRating: 84, defenseRating: 76, roster: [] },
+  ],
+  schedule: {
+    weeks: [{ week: 4, games: [{ played: false, home: { id: 1 }, away: { id: 2 } }] }],
+  },
+};
+
+describe('trainingPlanModel', () => {
+  it('builds weekly practice model defaults', () => {
+    const model = buildTrainingPlanModel({ league: baseLeague, intensity: 'normal', drillsRun: 1, actions: { conductDrill: vi.fn() } });
+    expect(model.phaseLabel).toBe('Weekly Practice');
+    expect(model.drillsRemaining).toBe(1);
+    expect(model.usedThisWeek).toBe(true);
+    expect(model.practiceStateLabel).toMatch(/already logged/i);
+  });
+
+  it('supports preseason training camp limits', () => {
+    const model = buildTrainingPlanModel({ league: { ...baseLeague, phase: 'preseason' }, drillsRun: 0 });
+    expect(model.phaseLabel).toBe('Training Camp');
+    expect(model.maxDrills).toBe(5);
+  });
+
+  it('handles empty roster safely', () => {
+    const model = buildTrainingPlanModel({ league: { ...baseLeague, roster: [], teams: [{ id: 1, abbr: 'CHI', roster: [] }], schedule: { weeks: [] } } });
+    expect(model.roster).toEqual([]);
+    expect(model.developmentCandidates).toEqual([]);
+    expect(model.matchupTrainingNote).toMatch(/No locked opponent/i);
+  });
+
+  it('returns recommended focus groups and ranked development candidates', () => {
+    const model = buildTrainingPlanModel({ league: baseLeague });
+    expect(model.recommendedFocus.length).toBeGreaterThanOrEqual(1);
+    expect(model.recommendedFocus[0]).toHaveProperty('groupId');
+    expect(model.developmentCandidates.map((p) => p.name)).toContain('Young QB');
+    expect(model.developmentCandidates[0].score).toBeGreaterThanOrEqual(model.developmentCandidates[1].score);
+  });
+});


### PR DESCRIPTION
### Motivation
- Make Training/Weekly Practice a meaningful weekly-operations destination that communicates opportunity, risks, and development priorities inside the existing Weekly Prep → HQ loop.
- Surface which position groups and young players to invest in each week and be explicit about what is persisted vs local preview.
- Preserve simulation determinism and avoid changing injury/recovery or core progression algorithms. 

### Description
- Added a pure training screen model `src/ui/utils/trainingPlanModel.js` that derives phase label, drills allowed/remaining, recommended focus groups with reasons, risk level, top development candidates, matchup training note, practice-used state, and safe fallbacks for missing/malformed data; it reuses `weeklyPrep`, `teamIntelligence`, and `playerDevelopmentSignals` where appropriate.
- Reworked `src/ui/components/TrainingCamp.jsx` into a mobile-first “Practice Plan” header + content layout that preserves the existing drill controls but adds: week/phase, drills remaining, risk chip, recommended next action, navigation CTAs back to `Weekly Prep`/`HQ`, “Recommended Focus” cards (2–4) with a CTA that updates only local selection, and a compact “Development Candidates” list with optional player view CTA.
- Clarified run-drill behavior so the UI shows deterministic local drill preview results and also reports whether `actions.conductDrill` was called and succeeded (persisted weekly boosts/injury effects in the worker) or whether the run was a local preview when persistence is unavailable/fails.
- Kept behavior additive and safe: no changes to injury generation/recovery, no changes to core progression/evolution systems, `drillsRun` remains local component state, and training does not introduce a new Weekly Prep completion step.
- Wired `onNavigate` into Training by passing it from `LeagueDashboard` so the screen can navigate back to `Weekly Prep` and `HQ` cleanly. Files touched: `src/ui/utils/trainingPlanModel.js` (new), `src/ui/components/TrainingCamp.jsx` (updated), `src/ui/components/LeagueDashboard.jsx` (small wiring), plus unit tests added under `src/ui/utils` and `src/ui/components/__tests__`.

### Testing
- `npm ci` completed successfully and installed dev dependencies with warnings only.
- Unit tests: ran `npx vitest run src/ui/utils/trainingPlanModel.test.js src/ui/components/__tests__/TrainingCamp.test.jsx` and all added tests passed (total tests exercised: the two new test files passed locally).
- Build: ran `npm run build` and the production bundle built successfully (Vite build completed; chunk-size warnings are informational only).
- Deployment checks: ran `npm run check:deploy` and Netlify parity/rules/build checks completed successfully in the offline validation run.
- Playwright/E2E: attempted `npx playwright install --list` but Playwright browser binaries were not available in this environment (install failed with ENOENT under ms-playwright cache), so e2e Playwright tests were not executed.

Known limitations and safety notes: training drills still call `actions.conductDrill(teamId, intensity, drillType, positionGroups)` when available to persist weekly boosts and possible drill injuries via the worker; if `conductDrill` is absent or rejects the UI shows honest preview-only copy; `drillsRun` is intentionally local and not persisted to avoid unintended prep state changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef0513afbc832db4f523da508d1364)