### PR TITLE
Fix TrainingCamp practice-state consistency and truthful drill persistence copy

### DIFF
--- a/src/ui/components/TrainingCamp.jsx
+++ b/src/ui/components/TrainingCamp.jsx
@@ -96,6 +96,7 @@ export default function TrainingCamp({ league, actions, onPlayerSelect, onNaviga
 
   const model = useMemo(() => buildTrainingPlanModel({ league, intensity, drillType, drillsRun, actions }), [league, intensity, drillType, drillsRun, actions]);
   const { roster, drillsRemaining } = model;
+  const runDisabled = drillsRemaining <= 0 || model.practiceLocked;
 
   const groups = useMemo(() => {
     const map = {};
@@ -133,7 +134,7 @@ export default function TrainingCamp({ league, actions, onPlayerSelect, onNaviga
   }, []);
 
   const runDrills = useCallback(async () => {
-    if (drillsRemaining <= 0) return;
+    if (runDisabled) return;
 
     const seed = (league?.year ?? 2025) * 1000 + (league?.week ?? 1) * 100 + drillsRun;
     const rng = seededRandom(seed);
@@ -170,12 +171,12 @@ export default function TrainingCamp({ league, actions, onPlayerSelect, onNaviga
         await actions.conductDrill(teamId, intensity, drillType, posGroups);
         setPersistState('persisted');
       } catch {
-        setPersistState('preview');
+        setPersistState('failed');
       }
     } else {
-      setPersistState('preview');
+      setPersistState('unavailable');
     }
-  }, [drillsRemaining, league, drillsRun, intensity, roster, focusGroups, drillType, actions]);
+  }, [runDisabled, league, drillsRun, intensity, roster, focusGroups, drillType, actions]);
 
   const summary = useMemo(() => {
     if (!results) return null;
@@ -188,6 +189,14 @@ export default function TrainingCamp({ league, actions, onPlayerSelect, onNaviga
     return { improved, injured, totalGain, total: Object.keys(results).length };
   }, [results]);
 
+  const practiceStateChip = useMemo(() => {
+    if (persistState === 'persisted') return { label: 'Persisted This Session', color: 'var(--success)' };
+    if (persistState === 'failed') return { label: 'Preview Only', color: 'var(--warning)' };
+    if (persistState === 'unavailable') return { label: 'Persistence Unavailable', color: 'var(--warning)' };
+    if (model.practiceLocked) return { label: 'Practice Already Logged', color: 'var(--text-muted)' };
+    return { label: 'Practice Available', color: 'var(--accent)' };
+  }, [persistState, model.practiceLocked]);
+
   return (
     <div style={{ maxWidth: 800, margin: '0 auto', paddingBottom: 16 }}>
       <div className="stat-box" style={{ marginBottom: 'var(--space-4, 16px)', padding: '12px' }}>
@@ -198,6 +207,11 @@ export default function TrainingCamp({ league, actions, onPlayerSelect, onNaviga
           </div>
           <span style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '6px 10px', alignSelf: 'flex-start' }}>
             {model.risk.label}
+          </span>
+        </div>
+        <div style={{ marginTop: 8 }}>
+          <span style={{ fontSize: 11, border: `1px solid ${practiceStateChip.color}`, color: practiceStateChip.color, borderRadius: 999, padding: '4px 10px', display: 'inline-block' }}>
+            {practiceStateChip.label}
           </span>
         </div>
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 8, marginTop: 10, fontSize: 12 }}>
@@ -332,15 +346,19 @@ export default function TrainingCamp({ league, actions, onPlayerSelect, onNaviga
         <button
           className="btn"
           onClick={runDrills}
-          disabled={drillsRemaining <= 0}
+          disabled={runDisabled}
           style={{
             width: '100%', padding: '12px', fontSize: 14, fontWeight: 800,
-            background: drillsRemaining > 0 ? 'var(--accent)' : 'var(--surface-strong, #1a1a2e)',
-            color: drillsRemaining > 0 ? 'white' : 'var(--text-subtle)',
-            border: 'none', borderRadius: 'var(--radius-md, 8px)', cursor: drillsRemaining > 0 ? 'pointer' : 'not-allowed',
+            background: !runDisabled ? 'var(--accent)' : 'var(--surface-strong, #1a1a2e)',
+            color: !runDisabled ? 'white' : 'var(--text-subtle)',
+            border: 'none', borderRadius: 'var(--radius-md, 8px)', cursor: !runDisabled ? 'pointer' : 'not-allowed',
           }}
         >
-          {drillsRemaining > 0 ? `Run Drills (${drillsRemaining} remaining)` : 'No Drills Remaining This Week'}
+          {!model.practiceLocked && drillsRemaining > 0
+            ? `Run Drills (${drillsRemaining} remaining)`
+            : model.practiceLocked
+              ? 'Practice Already Logged This Week'
+              : 'No Drills Remaining This Week'}
         </button>
       </div>
 
@@ -348,11 +366,11 @@ export default function TrainingCamp({ league, actions, onPlayerSelect, onNaviga
         <div className="stat-box fade-in" style={{ marginBottom: 'var(--space-4, 16px)', padding: '12px', display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12, textAlign: 'center' }}>
           <div>
             <div style={{ fontSize: 20, fontWeight: 800, color: 'var(--success)' }}>{summary.improved}</div>
-            <div style={{ fontSize: 10, color: 'var(--text-muted)' }}>Players Improved</div>
+            <div style={{ fontSize: 10, color: 'var(--text-muted)' }}>Players with Positive Drill Result</div>
           </div>
           <div>
             <div style={{ fontSize: 20, fontWeight: 800, color: 'var(--accent)' }}>+{summary.totalGain}</div>
-            <div style={{ fontSize: 10, color: 'var(--text-muted)' }}>Total OVR Gained</div>
+            <div style={{ fontSize: 10, color: 'var(--text-muted)' }}>Preview Gain Signal</div>
           </div>
           <div>
             <div style={{ fontSize: 20, fontWeight: 800, color: summary.injured > 0 ? 'var(--danger)' : 'var(--text-muted)' }}>{summary.injured}</div>
@@ -363,7 +381,11 @@ export default function TrainingCamp({ league, actions, onPlayerSelect, onNaviga
 
       {results && (
         <div className="stat-box" style={{ marginBottom: 12, padding: 10, fontSize: 12 }}>
-          {persistState === 'persisted' ? 'Drill effects were sent to simulation via conductDrill (weekly boosts/injury risk persist for this week).' : 'Persistence unavailable — this run is a local preview for planning only.'}
+          {persistState === 'persisted'
+            ? 'Preview complete. conductDrill persisted weekly training effects (temporary weekly boosts and drill injury outcomes) for this week.'
+            : persistState === 'failed'
+              ? 'Preview complete. conductDrill failed, so this run stayed local preview only and did not persist weekly effects.'
+              : 'Preview complete. Persistence unavailable, so this run stayed local preview only.'}
         </div>
       )}
 

--- a/src/ui/components/__tests__/TrainingCamp.test.jsx
+++ b/src/ui/components/__tests__/TrainingCamp.test.jsx
@@ -29,6 +29,20 @@ const league = {
   ],
   schedule: { weeks: [{ week: 6, games: [{ played: false, home: { id: 1 }, away: { id: 2 } }] }] },
 };
+const loggedLeague = {
+  ...league,
+  teams: [
+    {
+      ...league.teams[0],
+      weeklyDevelopmentFocus: { stamp: 's2028:6' },
+    },
+    league.teams[1],
+  ],
+};
+const preseasonLoggedLeague = {
+  ...loggedLeague,
+  phase: 'preseason',
+};
 
 describe('TrainingCamp', () => {
   it('selecting recommended focus updates local controls', () => {
@@ -46,13 +60,42 @@ describe('TrainingCamp', () => {
 
     fireEvent.click(screen.getAllByRole('button', { name: /Run Drills/i })[0]);
     await waitFor(() => expect(conductDrill).toHaveBeenCalled());
-    expect(screen.getByText(/sent to simulation via conductDrill/i)).toBeTruthy();
+    expect(screen.getByText(/persisted weekly training effects/i)).toBeTruthy();
   });
 
   it('shows honest preview copy when persistence is unavailable', () => {
     render(<TrainingCamp league={league} actions={{}} onNavigate={vi.fn()} onPlayerSelect={vi.fn()} />);
     fireEvent.click(screen.getAllByRole('button', { name: /Run Drills/i })[0]);
-    expect(screen.getByText(/local preview for planning only/i)).toBeTruthy();
+    expect(screen.getByText(/stayed local preview only/i)).toBeTruthy();
+    expect(screen.getAllByText(/Persistence Unavailable/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows preview-only copy when conductDrill fails', async () => {
+    const conductDrill = vi.fn().mockRejectedValue(new Error('worker unavailable'));
+    render(<TrainingCamp league={league} actions={{ conductDrill }} onNavigate={vi.fn()} onPlayerSelect={vi.fn()} />);
+    fireEvent.click(screen.getAllByRole('button', { name: /Run Drills/i })[0]);
+    await waitFor(() => expect(conductDrill).toHaveBeenCalled());
+    expect(screen.getByText(/conductDrill failed/i)).toBeTruthy();
+    expect(screen.getAllByText(/Preview Only/i).length).toBeGreaterThan(0);
+  });
+
+  it('locks regular-season practice when already logged this week', () => {
+    const conductDrill = vi.fn().mockResolvedValue({});
+    render(<TrainingCamp league={loggedLeague} actions={{ conductDrill }} onNavigate={vi.fn()} onPlayerSelect={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /Practice Already Logged This Week/i }).getAttribute('disabled')).not.toBeNull();
+  });
+
+  it('still allows preseason drills when weekly stamp exists', () => {
+    const conductDrill = vi.fn().mockResolvedValue({});
+    render(<TrainingCamp league={preseasonLoggedLeague} actions={{ conductDrill }} onNavigate={vi.fn()} onPlayerSelect={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /Run Drills/i }).getAttribute('disabled')).toBeNull();
+  });
+
+  it('uses preview-safe labels for local drill summaries', () => {
+    render(<TrainingCamp league={league} actions={{}} onNavigate={vi.fn()} onPlayerSelect={vi.fn()} />);
+    fireEvent.click(screen.getAllByRole('button', { name: /Run Drills/i })[0]);
+    expect(screen.getByText(/Players with Positive Drill Result/i)).toBeTruthy();
+    expect(screen.getByText(/Preview Gain Signal/i)).toBeTruthy();
   });
 
   it('routes back actions', () => {

--- a/src/ui/utils/trainingPlanModel.js
+++ b/src/ui/utils/trainingPlanModel.js
@@ -187,13 +187,15 @@ export function buildTrainingPlanModel({ league, intensity = 'normal', drillType
 
   const isTrainingCamp = String(league?.phase ?? '').toLowerCase() === 'preseason';
   const maxDrills = isTrainingCamp ? 5 : 2;
-  const safeDrillsRun = Math.max(0, safeNum(drillsRun, 0));
-  const drillsRemaining = Math.max(0, maxDrills - safeDrillsRun);
 
   const seasonKey = league?.seasonId ?? league?.year ?? 'season';
   const week = safeNum(league?.week, 1);
   const focusStamp = userTeam?.weeklyDevelopmentFocus?.stamp;
-  const usedThisWeek = Boolean(focusStamp && focusStamp === `${seasonKey}:${week}`);
+  // weeklyDevelopmentFocus.stamp is authoritative for weekly practice usage in regular season.
+  // Preseason training camp keeps local per-screen drill limits.
+  const usedThisWeek = !isTrainingCamp && Boolean(focusStamp && focusStamp === `${seasonKey}:${week}`);
+  const safeDrillsRun = Math.max(0, safeNum(drillsRun, 0));
+  const drillsRemaining = usedThisWeek ? 0 : Math.max(0, maxDrills - safeDrillsRun);
 
   const injuredCount = roster.filter(isInjured).length;
   const risk = summarizeRisk(intensity, injuredCount);
@@ -211,6 +213,7 @@ export function buildTrainingPlanModel({ league, intensity = 'normal', drillType
     isTrainingCamp,
     maxDrills,
     drillsRemaining,
+    practiceLocked: usedThisWeek,
     practiceStateLabel: usedThisWeek ? 'Practice already logged this week' : 'Practice available this week',
     usedThisWeek,
     intensity,

--- a/src/ui/utils/trainingPlanModel.test.js
+++ b/src/ui/utils/trainingPlanModel.test.js
@@ -33,8 +33,9 @@ describe('trainingPlanModel', () => {
   it('builds weekly practice model defaults', () => {
     const model = buildTrainingPlanModel({ league: baseLeague, intensity: 'normal', drillsRun: 1, actions: { conductDrill: vi.fn() } });
     expect(model.phaseLabel).toBe('Weekly Practice');
-    expect(model.drillsRemaining).toBe(1);
+    expect(model.drillsRemaining).toBe(0);
     expect(model.usedThisWeek).toBe(true);
+    expect(model.practiceLocked).toBe(true);
     expect(model.practiceStateLabel).toMatch(/already logged/i);
   });
 
@@ -42,6 +43,8 @@ describe('trainingPlanModel', () => {
     const model = buildTrainingPlanModel({ league: { ...baseLeague, phase: 'preseason' }, drillsRun: 0 });
     expect(model.phaseLabel).toBe('Training Camp');
     expect(model.maxDrills).toBe(5);
+    expect(model.usedThisWeek).toBe(false);
+    expect(model.drillsRemaining).toBe(5);
   });
 
   it('handles empty roster safely', () => {


### PR DESCRIPTION
### Motivation
- Align UI with persisted weekly practice truth so the app doesn't show available drills when a weekly practice has already been logged in the worker state.
- Make result and persistence copy honest about what is a local preview vs what `conductDrill` actually persists so users are not misled about permanent OVR changes.
- Keep preseason Training Camp behavior and existing simulation/progression/injury logic unchanged while making minimal, high-confidence UI fixes.

### Description
- Treat `weeklyDevelopmentFocus.stamp` as authoritative for regular-season practice usage in `buildTrainingPlanModel`, expose `practiceLocked`, and set `drillsRemaining` to `0` when the stamp matches the current `season:week`; keep preseason `maxDrills = 5` behavior intact. (file: `src/ui/utils/trainingPlanModel.js`)
- Disable the Run Drills CTA when `practiceLocked` is true and show explicit CTA text `Practice Already Logged This Week`; introduce `runDisabled` to centralize that rule. (file: `src/ui/components/TrainingCamp.jsx`)
- Add a compact top practice/persistence status chip with clear states: `Practice Available`, `Practice Already Logged`, `Persisted This Session`, `Preview Only`, `Persistence Unavailable`. (file: `src/ui/components/TrainingCamp.jsx`)
- Replace misleading preview/result labels: `Players Improved` → `Players with Positive Drill Result`, `Total OVR Gained` → `Preview Gain Signal`, and clarify persistence messages to distinguish (a) preview-only, (b) `conductDrill` persisted weekly-effects, and (c) `conductDrill` failure. (file: `src/ui/components/TrainingCamp.jsx`)
- No changes to core progression math, injury generation, recovery, or `conductDrill` worker behavior were made; only UI/view-model and tests were updated.
- Confirmed `conductDrill` persistence semantics in the worker: it persists `team.weeklyDevelopmentFocus` (with `stamp`), per-player `weeklyTrainingBoost` (temporary weekly boost consumed by sim and cleared on week advance), and drill injuries (`injured`, `injuryWeeksRemaining`); it does not persist permanent OVR changes. (file: `src/worker/worker.js`)

### Testing
- Unit/component tests run: `npx vitest run src/ui/utils/trainingPlanModel.test.js src/ui/components/__tests__/TrainingCamp.test.jsx` and all tests passed (12 tests, 0 failures).
- Install/build checks: ran `npm ci`, `npm run build`, and `npm run check:deploy` and they completed successfully.
- Playwright/e2e: attempted `npx playwright install --dry-run chromium`; browser binaries are not preinstalled in this environment so full Playwright e2e tests were not executed and therefore not claimed as passed.
- Tests added/updated: model behavior when weekly `stamp` matches current week (practice locked + `drillsRemaining === 0`), preseason still allows drills even if stamp exists, TrainingCamp CTA lock state, preview-safe summary labels, persistence success/failure/unavailable messaging, and navigation back to Weekly Prep / HQ (files: updated tests in `src/ui/utils/trainingPlanModel.test.js` and `src/ui/components/__tests__/TrainingCamp.test.jsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef6f17f1e0832d9484c9ca7070d7bb)