### PR TITLE
Add weekly decision impact recap for HQ, Weekly Results, and Game Book

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -106,6 +106,8 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
     };
   }, [command.leagueNews, command.postGameReview, command.teamRecord, lastGame, lastGameDisplay.overviewLine, nextOpponentDisplay.isHome, nextOpponentDisplay.opponentAbbr]);
 
+  const decisionReview = useMemo(() => command.weeklyDecisionImpact ?? null, [command.weeklyDecisionImpact]);
+
   const nextOpponents = useMemo(() => (league?.schedule?.weeks ?? [])
     .filter((week) => safeNum(week?.week, 0) >= safeNum(league?.week, 1))
     .flatMap((week) => (week?.games ?? []).map((game) => ({ ...game, week: week.week })))
@@ -222,6 +224,32 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
 
       <SectionCard title="Week Command" subtitle="What needs attention, why it matters, and where to handle it." variant="compact">
         <WeeklyAgenda items={(command.weeklyAgenda ?? []).slice(0, 3)} onOpenTask={(task) => onNavigate?.(task?.targetRoute ?? task?.tab ?? 'HQ')} />
+      </SectionCard>
+
+
+      <SectionCard title={decisionReview?.heading ?? 'What Mattered Last Week'} subtitle={decisionReview?.resultSummary ?? 'Run a completed game to unlock a weekly decision review.'} variant="compact">
+        <div className="app-hq-intel-list" role="list" aria-label="Weekly decision impact recap">
+          {(decisionReview?.bullets ?? []).slice(0, 4).map((bullet, idx) => (
+            <p key={`decision-${idx}`} role="listitem" className="app-hq-intel-item tone-info">{bullet}</p>
+          ))}
+        </div>
+        {decisionReview?.recommendedAction ? (
+          <div className="app-hq-impact-card tone-info" style={{ marginTop: 10 }}>
+            <div className="app-hq-impact-card__head">
+              <strong>Recommended next action</strong>
+              <StatusChip label={decisionReview.recommendedAction.label} tone="info" />
+            </div>
+            <p>{decisionReview.recommendedAction.reason}</p>
+            <button
+              type="button"
+              className="btn btn-sm app-hq-impact-card__cta"
+              onClick={() => onNavigate?.(decisionReview.recommendedAction.route)}
+              aria-label={`Decision review: ${decisionReview.recommendedAction.label}`}
+            >
+              {decisionReview.recommendedAction.label}
+            </button>
+          </div>
+        ) : null}
       </SectionCard>
 
       <SectionCard title="Operations Snapshot" subtitle="Last result, standing, and upcoming slate." variant="compact">

--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -1,9 +1,25 @@
 import React from 'react';
 import BoxScorePanel from './BoxScorePanel.jsx';
 import { EmptyState, ScreenHeader, SectionCard, StatusChip } from './ScreenSystem.jsx';
+import { buildWeeklyDecisionImpact } from '../utils/weeklyDecisionImpact.js';
+
+function findScheduleGame(league, gameId) {
+  for (const week of league?.schedule?.weeks ?? []) {
+    for (const game of week?.games ?? []) {
+      const candidate = game?.gameId ?? game?.id;
+      if (String(candidate) === String(gameId)) return { ...game, week: Number(week?.week ?? league?.week ?? 1) };
+    }
+  }
+  return null;
+}
+
 
 export default function GameDetailScreen({ gameId, league, actions, onBack, onPlayerSelect, onTeamSelect }) {
   const weekFromId = typeof gameId === 'string' ? gameId.match(/_w(\d+)_/i)?.[1] : null;
+
+  const scheduleGame = findScheduleGame(league, gameId);
+  const userTeam = (league?.teams ?? []).find((team) => Number(team?.id) === Number(league?.userTeamId));
+  const prepContext = buildWeeklyDecisionImpact({ league, userTeam, lastGame: scheduleGame });
 
   if (!gameId) {
     return (
@@ -39,6 +55,13 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
           { label: 'Week', value: weekFromId ?? '—' },
         ]}
       />
+      <SectionCard variant="compact" title="Preparation Context" subtitle={prepContext?.resultSummary ?? 'Weekly decision context unavailable for this game.'}>
+        <div className="app-hq-intel-list" role="list" aria-label="Preparation context">
+          {(prepContext?.bullets ?? []).slice(0, 3).map((bullet, idx) => (
+            <p key={`prep-context-${idx}`} role="listitem" className="app-hq-intel-item tone-info">{bullet}</p>
+          ))}
+        </div>
+      </SectionCard>
       <SectionCard variant="info" title="Game Book Detail" subtitle="Summary → Team stats → Player leaders → Drive/play recap.">
         <BoxScorePanel
           gameId={gameId}

--- a/src/ui/components/WeeklyResultsCenter.jsx
+++ b/src/ui/components/WeeklyResultsCenter.jsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 import { deriveCompactResultRecap, getGameLifecycleBucket, resolveDefaultResultsWeek, selectWeekGames } from '../utils/gameCenterResults.js';
 import { buildWeeklyLeagueRecap } from '../utils/weeklyLeagueRecap.js';
+import { buildWeeklyDecisionImpact } from '../utils/weeklyDecisionImpact.js';
 import {
   CompactInsightCard,
   EmptyState,
@@ -165,6 +166,15 @@ export default function WeeklyResultsCenter({ league, initialWeek, onGameSelect,
   );
   const canOpenUserGame = Boolean(userResultPresentation?.canOpen && onGameSelect);
 
+  const decisionReview = useMemo(() => {
+    if (!userTeamResult) return null;
+    return buildWeeklyDecisionImpact({
+      league,
+      userTeam: teamById[Number(league?.userTeamId)],
+      lastGame: { ...userTeamResult.game, week: userTeamResult.week },
+    });
+  }, [league, teamById, userTeamResult]);
+
   if (!totalWeeks) {
     return <EmptyState title="No schedule data available for weekly results." body="Weekly game center will populate when league schedule weeks are present." />;
   }
@@ -210,6 +220,13 @@ export default function WeeklyResultsCenter({ league, initialWeek, onGameSelect,
             </div>
             <p className="app-game-center-card__scoreline">{userTeamResult.recap}</p>
             <p className="app-game-center-card__summary">{userResultPresentation?.displayScoreLine ?? 'Final score unavailable.'}</p>
+            {decisionReview?.bullets?.length ? (
+              <div className="app-hq-intel-list" role="list" aria-label="Decision review">
+                {decisionReview.bullets.slice(0, 2).map((bullet, idx) => (
+                  <p key={`user-impact-${idx}`} role="listitem" className="app-hq-intel-item tone-info">{bullet}</p>
+                ))}
+              </div>
+            ) : null}
             <div className="app-game-center-card__footer">
               <button
                 type="button"
@@ -221,6 +238,9 @@ export default function WeeklyResultsCenter({ league, initialWeek, onGameSelect,
                 {canOpenUserGame ? 'Open Game Book' : `Game Book unavailable (${userResultPresentation?.statusLabel ?? 'Archive unavailable'})`}
               </button>
               <button type="button" className="btn btn-sm btn-secondary" onClick={() => onNavigate?.('Weekly Prep')}>Continue Weekly Prep</button>
+              {decisionReview?.recommendedAction ? (
+                <button type="button" className="btn btn-sm btn-secondary" onClick={() => onNavigate?.(decisionReview.recommendedAction.route)}>{decisionReview.recommendedAction.label}</button>
+              ) : null}
             </div>
           </article>
         </SectionCard>

--- a/src/ui/components/WeeklyResultsCenter.test.jsx
+++ b/src/ui/components/WeeklyResultsCenter.test.jsx
@@ -63,6 +63,22 @@ describe('WeeklyResultsCenter', () => {
     expect(onGameSelect.mock.calls[0][0]).toMatch(/2026_w2_/);
   });
 
+
+  it('renders decision review in Your Game and routes recommended action', () => {
+    const onNavigate = vi.fn();
+    const leagueWithInjuryContext = {
+      ...league,
+      teams: league.teams.map((team) => (team.id === 1
+        ? { ...team, roster: [{ id: 88, injuryWeeksRemaining: 2 }], strategies: { gamePlan: { runPassBalance: 60 } } }
+        : team)),
+    };
+    render(<WeeklyResultsCenter league={leagueWithInjuryContext} initialWeek={2} onGameSelect={() => {}} onNavigate={onNavigate} />);
+
+    expect(screen.getByRole('list', { name: /decision review/i })).toBeTruthy();
+    const cta = screen.getByRole('button', { name: /review availability/i });
+    fireEvent.click(cta);
+    expect(onNavigate).toHaveBeenCalledWith('Team:Injuries');
+  });
   it('is safe for older partial payloads with score-only games', () => {
     const legacyLeague = {
       ...league,

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import FranchiseHQ from '../FranchiseHQ.jsx';
 
 const baseLeague = {
@@ -42,6 +42,10 @@ const baseLeague = {
 };
 
 describe('FranchiseHQ', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it('renders visible weekly command center essentials and one primary advance CTA', () => {
     render(<FranchiseHQ league={baseLeague} onNavigate={() => {}} onAdvanceWeek={() => {}} busy={false} simulating={false} />);
 
@@ -70,6 +74,16 @@ describe('FranchiseHQ', () => {
     expect(onNavigate).toHaveBeenCalledWith('Weekly Results:9');
   });
 
+
+  it('renders weekly decision review and routes the recommended action', () => {
+    const onNavigate = vi.fn();
+    render(<FranchiseHQ league={baseLeague} onNavigate={onNavigate} onAdvanceWeek={() => {}} busy={false} simulating={false} />);
+
+    expect(screen.getAllByRole('heading', { name: /what mattered last week|decision review/i }).length).toBeGreaterThan(0);
+    const button = screen.getByRole('button', { name: /decision review:/i });
+    fireEvent.click(button);
+    expect(onNavigate).toHaveBeenCalled();
+  });
   it('renders record, standing, and fallback copy when schedule is missing', () => {
     render(
       <FranchiseHQ

--- a/src/ui/utils/franchiseCommandCenter.js
+++ b/src/ui/utils/franchiseCommandCenter.js
@@ -9,6 +9,7 @@ import { logChronicleEvent, syncFranchiseChronicle } from './franchiseChronicle.
 import { applyEventDecision, pickWorstEventChoice, resolveWeeklyEvent } from './franchiseEvents.js';
 import { buildWeeklyIntelligence, buildActionableWeeklyPriorities } from './weeklyIntelligence.js';
 import { buildGamePlanImpact, buildPostGameReview } from './gamePlanImpact.js';
+import { buildWeeklyDecisionImpact } from './weeklyDecisionImpact.js';
 
 function safeNum(value, fallback = 0) {
   const n = Number(value);
@@ -477,6 +478,11 @@ export function selectFranchiseHQViewModel(league) {
     userTeamId: vm.league?.userTeamId,
     latestNews: leagueNews?.[0] ?? null,
   });
+  const weeklyDecisionImpact = buildWeeklyDecisionImpact({
+    league: vm.league,
+    userTeam: team,
+    lastGame: latestArchived ?? fallbackLastGame,
+  });
   const injuredSpotlight = (team?.roster ?? [])
     .filter((player) => safeNum(player?.injuryWeeksRemaining ?? player?.injuredWeeks ?? player?.injury?.gamesRemaining ?? 0) > 0)
     .sort((a, b) => safeNum(b?.ovr) - safeNum(a?.ovr))[0] ?? null;
@@ -507,6 +513,7 @@ export function selectFranchiseHQViewModel(league) {
     gamePlanImpact,
     recommendedAdjustments: gamePlanImpact.recommendedAdjustments,
     postGameReview,
+    weeklyDecisionImpact,
     advanceFeedback: postGameReview,
     weeklyAgenda: buildActionableWeeklyPriorities({
       team,

--- a/src/ui/utils/weeklyDecisionImpact.js
+++ b/src/ui/utils/weeklyDecisionImpact.js
@@ -1,0 +1,238 @@
+function safeNum(value, fallback = null) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function hasAnyValue(values = []) {
+  return values.some((value) => value !== null && value !== undefined && value !== '');
+}
+
+function formatResultLine({ userScore, oppScore, opponentAbbr, isHome }) {
+  if (!Number.isFinite(userScore) || !Number.isFinite(oppScore)) {
+    return 'Final score is unavailable for this game.';
+  }
+  const outcome = userScore > oppScore ? 'W' : userScore < oppScore ? 'L' : 'T';
+  return `${outcome} ${userScore}-${oppScore} ${isHome ? 'vs' : '@'} ${opponentAbbr ?? 'TBD'}`;
+}
+
+function normalizeResult({ lastGame, userTeamId }) {
+  const homeId = Number(lastGame?.homeId ?? lastGame?.home?.id ?? lastGame?.home);
+  const awayId = Number(lastGame?.awayId ?? lastGame?.away?.id ?? lastGame?.away);
+  const isHome = homeId === Number(userTeamId);
+  const isAway = awayId === Number(userTeamId);
+  if (!isHome && !isAway) return null;
+
+  const userScore = safeNum(isHome ? (lastGame?.score?.home ?? lastGame?.homeScore) : (lastGame?.score?.away ?? lastGame?.awayScore));
+  const oppScore = safeNum(isHome ? (lastGame?.score?.away ?? lastGame?.awayScore) : (lastGame?.score?.home ?? lastGame?.homeScore));
+  const opponentAbbr = isHome
+    ? (lastGame?.awayAbbr ?? lastGame?.away?.abbr ?? lastGame?.away?.name)
+    : (lastGame?.homeAbbr ?? lastGame?.home?.abbr ?? lastGame?.home?.name);
+
+  const teamStats = isHome ? lastGame?.teamStats?.home ?? null : lastGame?.teamStats?.away ?? null;
+  const oppStats = isHome ? lastGame?.teamStats?.away ?? null : lastGame?.teamStats?.home ?? null;
+
+  return {
+    isHome,
+    userScore,
+    oppScore,
+    opponentAbbr: opponentAbbr ?? 'TBD',
+    resultLine: formatResultLine({ userScore, oppScore, opponentAbbr, isHome }),
+    teamStats,
+    oppStats,
+    week: safeNum(lastGame?.week, null),
+    gameId: lastGame?.gameId ?? lastGame?.id ?? null,
+  };
+}
+
+function buildOffensiveTakeaway({ result }) {
+  const points = result?.userScore;
+  const yards = safeNum(result?.teamStats?.totalYards);
+  const successRate = safeNum(result?.teamStats?.successRate);
+
+  if (successRate != null) {
+    if (successRate >= 0.5) return 'Offense posted efficient down-to-down success. Keep the current attack structure unless matchup health changed.';
+    if (successRate <= 0.38) return 'Offensive efficiency lagged. Revisit your attack plan and check if your scripted balance fits this opponent profile.';
+  }
+
+  if (yards != null && yards <= 275) {
+    return 'Total offense was limited. Review Game Plan and compare your call sheet to drive-by-drive outcomes in Game Book.';
+  }
+
+  if (Number.isFinite(points) && points <= 17) {
+    return 'Low offensive output suggests revisiting your attack plan before the next kickoff.';
+  }
+
+  if (Number.isFinite(points) && points >= 30) {
+    return 'Scoring output was strong. Preserve your base offensive structure and only adjust for new injuries.';
+  }
+
+  return 'Open Game Book to review your offense by quarter before making major plan changes.';
+}
+
+function buildDefensiveTakeaway({ result }) {
+  const allowed = result?.oppScore;
+  const oppSuccess = safeNum(result?.oppStats?.successRate);
+
+  if (oppSuccess != null) {
+    if (oppSuccess <= 0.4) return 'Defense held opponent efficiency down. Keep your defensive structure unless availability changed.';
+    if (oppSuccess >= 0.5) return 'Opponent moved the ball efficiently. Re-check coverage pressure and situational calls in Game Plan.';
+  }
+
+  if (Number.isFinite(allowed) && allowed <= 17) {
+    return 'Defense held opponent scoring down; keep current defensive structure unless injuries changed.';
+  }
+
+  if (Number.isFinite(allowed) && allowed >= 30) {
+    return 'Points allowed were high. Review defensive priorities and lineup assignments before advancing again.';
+  }
+
+  return 'Inspect Game Book defensive splits before changing your base structure.';
+}
+
+function parseStamp(stamp) {
+  if (typeof stamp !== 'string') return { season: null, week: null };
+  const [season, week] = stamp.split(':');
+  return { season, week: safeNum(week, null) };
+}
+
+function hasSavedGamePlan(strategies = {}) {
+  const gamePlan = strategies?.gamePlan ?? {};
+  return hasAnyValue([
+    strategies?.offPlanId,
+    strategies?.defPlanId,
+    strategies?.riskId,
+    gamePlan?.runPassBalance,
+    gamePlan?.aggressionLevel,
+    gamePlan?.deepShortBalance,
+    gamePlan?.blitzFrequency,
+  ]);
+}
+
+function buildContextTakeaway({ result, userTeam, seasonId, injuryRiskCount }) {
+  const bullets = [];
+
+  if (hasSavedGamePlan(userTeam?.strategies)) {
+    bullets.push({
+      id: 'game-plan',
+      text: 'Game plan was saved before kickoff. Open Game Book to inspect whether your script held up in live drives.',
+      route: 'Game Book',
+      targetRoute: result?.gameId ? `Game Book:${result.gameId}` : 'Game Plan',
+    });
+  }
+
+  if (injuryRiskCount > 0) {
+    bullets.push({
+      id: 'lineup-injury',
+      text: 'Injury/availability risk was active entering the week. Review Availability and depth replacements before next kickoff.',
+      route: 'Team:Injuries',
+      targetRoute: 'Team:Injuries',
+    });
+  }
+
+  const focus = userTeam?.weeklyDevelopmentFocus;
+  const stamp = parseStamp(focus?.stamp);
+  if (stamp.week != null && (stamp.week === result?.week || stamp.week === (result?.week != null ? result.week - 1 : null))) {
+    const focusLabel = Array.isArray(focus?.positionGroups) && focus.positionGroups.length
+      ? ` (${focus.positionGroups.join('/').toUpperCase()})`
+      : '';
+    bullets.push({
+      id: 'training',
+      text: `Practice effects were logged this week${focusLabel}, but box score attribution is not detailed enough to assign direct credit.`,
+      route: 'Training',
+      targetRoute: 'Training',
+    });
+  } else if (stamp.week != null && seasonId != null && String(stamp.season) === String(seasonId)) {
+    bullets.push({
+      id: 'training-stale',
+      text: 'A prior practice plan exists, but no matching weekly practice stamp was found for this game week.',
+      route: 'Training',
+      targetRoute: 'Training',
+    });
+  }
+
+  return bullets;
+}
+
+function chooseRecommendation({ result, contextBullets }) {
+  if (!result) {
+    return {
+      label: 'Open Weekly Prep',
+      reason: 'No completed user game is available yet.',
+      route: 'Weekly Prep',
+    };
+  }
+
+  if (Number.isFinite(result.userScore) && result.userScore <= 17) {
+    return { label: 'Tune Game Plan', reason: 'Low offensive output needs a plan review.', route: 'Game Plan' };
+  }
+  if (Number.isFinite(result.oppScore) && result.oppScore >= 28) {
+    return { label: 'Review Injuries', reason: 'High opponent scoring and availability risk can compound quickly.', route: 'Team:Injuries' };
+  }
+
+  const lineupBullet = contextBullets.find((bullet) => bullet.id === 'lineup-injury');
+  if (lineupBullet) {
+    return { label: 'Review Availability', reason: 'Injury risk was already present.', route: lineupBullet.targetRoute };
+  }
+
+  return { label: 'Review Game Book', reason: 'Review drive detail before making next-week changes.', route: result?.gameId ? `Game Book:${result.gameId}` : 'Weekly Results' };
+}
+
+/**
+ * Weekly Decision Impact Audit surface.
+ * Category notes:
+ * - strategy IDs/sliders are stored and referenced only as "saved" context here (no causal claim).
+ * - depth/injury state is used as pregame risk context only.
+ * - training focus stamp is treated as logged/not logged context only.
+ */
+export function buildWeeklyDecisionImpact({ league, userTeam, lastGame } = {}) {
+  const team = userTeam ?? (league?.teams ?? []).find((entry) => Number(entry?.id) === Number(league?.userTeamId)) ?? null;
+  const result = normalizeResult({ lastGame, userTeamId: league?.userTeamId });
+
+  if (!result) {
+    return {
+      heading: 'Decision Review',
+      resultSummary: 'No completed user game available yet.',
+      bullets: [
+        'Advance the week to generate a game result and decision review.',
+      ],
+      recommendedAction: {
+        label: 'Open Weekly Prep',
+        reason: 'Finish prep steps before kickoff.',
+        route: 'Weekly Prep',
+      },
+    };
+  }
+
+  const injuryRiskCount = Array.isArray(team?.roster)
+    ? team.roster.filter((player) => safeNum(player?.injuryWeeksRemaining ?? player?.injuredWeeks ?? player?.injury?.weeksRemaining ?? player?.injury?.gamesRemaining, 0) > 0).length
+    : 0;
+
+  const coreBullets = [
+    buildOffensiveTakeaway({ result }),
+    buildDefensiveTakeaway({ result }),
+  ];
+  const contextBullets = buildContextTakeaway({
+    result,
+    userTeam: team,
+    seasonId: league?.seasonId ?? league?.year ?? null,
+    injuryRiskCount,
+  });
+
+  const recommendedAction = chooseRecommendation({ result, contextBullets });
+
+  return {
+    heading: 'Decision Review',
+    resultSummary: result.resultLine,
+    bullets: [...coreBullets, ...contextBullets.map((item) => item.text)].slice(0, 4),
+    contextRoutes: contextBullets,
+    recommendedAction,
+    metadata: {
+      hasStrategyContext: hasSavedGamePlan(team?.strategies),
+      hasTrainingContext: contextBullets.some((item) => item.id.startsWith('training')),
+      injuryRiskCount,
+      hasTeamStats: Boolean(result?.teamStats || result?.oppStats),
+      gameId: result?.gameId ?? null,
+      week: result?.week ?? null,
+    },
+  };
+}

--- a/src/ui/utils/weeklyDecisionImpact.test.js
+++ b/src/ui/utils/weeklyDecisionImpact.test.js
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { buildWeeklyDecisionImpact } from './weeklyDecisionImpact.js';
+
+const baseLeague = {
+  seasonId: '2026',
+  year: 2026,
+  week: 6,
+  userTeamId: 1,
+  teams: [
+    {
+      id: 1,
+      abbr: 'DAL',
+      roster: [
+        { id: 11, name: 'QB One', injuryWeeksRemaining: 0 },
+        { id: 12, name: 'LT One', injuryWeeksRemaining: 0 },
+      ],
+      strategies: {
+        offPlanId: 'BALANCED',
+        gamePlan: { runPassBalance: 58, aggressionLevel: 47 },
+      },
+      weeklyDevelopmentFocus: {
+        stamp: '2026:5',
+        positionGroups: ['qb'],
+      },
+    },
+  ],
+};
+
+describe('buildWeeklyDecisionImpact', () => {
+  it('derives a compact review for a win with strategy and training context', () => {
+    const result = buildWeeklyDecisionImpact({
+      league: baseLeague,
+      userTeam: baseLeague.teams[0],
+      lastGame: {
+        gameId: '2026_w5_1_2',
+        week: 5,
+        home: { id: 1, abbr: 'DAL' },
+        away: { id: 2, abbr: 'PHI' },
+        homeScore: 27,
+        awayScore: 17,
+        teamStats: {
+          home: { successRate: 0.51, totalYards: 365 },
+          away: { successRate: 0.38, totalYards: 248 },
+        },
+      },
+    });
+
+    expect(result.resultSummary).toContain('W 27-17 vs PHI');
+    expect(result.bullets.join(' ')).toContain('Game plan was saved before kickoff');
+    expect(result.bullets.join(' ')).toContain('Practice effects were logged this week');
+    expect(result.metadata.hasTeamStats).toBe(true);
+  });
+
+  it('derives a loss review and recommends game plan changes after low output', () => {
+    const result = buildWeeklyDecisionImpact({
+      league: baseLeague,
+      userTeam: baseLeague.teams[0],
+      lastGame: {
+        gameId: '2026_w5_2_1',
+        week: 5,
+        home: { id: 2, abbr: 'PHI' },
+        away: { id: 1, abbr: 'DAL' },
+        homeScore: 24,
+        awayScore: 13,
+      },
+    });
+
+    expect(result.resultSummary).toContain('L 13-24 @ PHI');
+    expect(result.bullets[0]).toMatch(/low offensive output|offensive output/i);
+    expect(result.recommendedAction.route).toBe('Game Plan');
+  });
+
+  it('falls back safely when box score team stats are missing', () => {
+    const result = buildWeeklyDecisionImpact({
+      league: baseLeague,
+      userTeam: baseLeague.teams[0],
+      lastGame: {
+        gameId: '2026_w5_2_1',
+        week: 5,
+        home: { id: 2, abbr: 'PHI' },
+        away: { id: 1, abbr: 'DAL' },
+        homeScore: 17,
+        awayScore: 17,
+      },
+    });
+
+    expect(result.metadata.hasTeamStats).toBe(false);
+    expect(result.bullets.length).toBeGreaterThan(1);
+    expect(result.resultSummary).toContain('T 17-17');
+  });
+
+  it('returns no-game fallback when no user game is available', () => {
+    const result = buildWeeklyDecisionImpact({
+      league: baseLeague,
+      userTeam: baseLeague.teams[0],
+      lastGame: null,
+    });
+
+    expect(result.resultSummary).toContain('No completed user game available yet');
+    expect(result.recommendedAction.route).toBe('Weekly Prep');
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve honesty and player understanding by surfacing a compact, evidence-based recap of what decisions were present and what can be reviewed after a completed game.

### Description
- Added a pure helper `buildWeeklyDecisionImpact` at `src/ui/utils/weeklyDecisionImpact.js` that derives a compact postgame recap from real game/team data (result line, offense/defense takeaways, saved game-plan presence, injury/availability context, training-stamp context, recommended next action and route). The helper is fallback-safe and avoids causal claims.【F:src/ui/utils/weeklyDecisionImpact.js】
- Wired the helper into the HQ view-model and UI: `selectFranchiseHQViewModel` now includes `weeklyDecisionImpact` and `FranchiseHQ.jsx` shows a compact “Decision Review / What Mattered Last Week” card with 2–4 bullets and one recommended action CTA.【F:src/ui/utils/franchiseCommandCenter.js】【F:src/ui/components/FranchiseHQ.jsx】
- Surfaced the recap in `WeeklyResultsCenter.jsx` under the user game (brief bullets + recommended-action button).【F:src/ui/components/WeeklyResultsCenter.jsx】
- Added a small “Preparation Context” strip in `GameDetailScreen.jsx` when the schedule game record is found to show same contextual bullets.【F:src/ui/components/GameDetailScreen.jsx】
- Kept language conservative: no fake attribution, no changes to core sim math, and only uses persisted/safely-derivable fields (scores, team stats, gamePlan presence, weeklyTrainingFocus stamp, injury flags).【F:src/ui/utils/weeklyDecisionImpact.js】
- Tests: added `src/ui/utils/weeklyDecisionImpact.test.js` and updated component tests to assert rendering and routing for HQ and Weekly Results decision review. UI changes are minimal and mobile-friendly (compact cards, 2–4 bullets).【F:src/ui/utils/weeklyDecisionImpact.test.js】【F:src/ui/components/WeeklyResultsCenter.test.jsx】【F:src/ui/components/__tests__/FranchiseHQ.test.jsx】

### Testing
- `npm ci` ran successfully (dependencies installed).
- Unit tests: ran `npm run test:unit -- src/ui/utils/weeklyDecisionImpact.test.js src/ui/components/__tests__/FranchiseHQ.test.jsx src/ui/components/WeeklyResultsCenter.test.jsx` and all specified tests passed (13 tests). ✅
- Build: `npm run build` completed and produced production artifacts (Vite build), with a non-blocking chunk-size warning. ✅
- Deploy checks: `npm run check:deploy` partially completed; `check:netlify-parity` and `check:netlify-rules` passed, but the environment hung during the offline `netlify-cli` build step in this sandbox, so full `check:deploy` could not be completed end-to-end here (noted as a follow-up). ⚠️

Notes and audit summary (concise):
- Inputs observed and classification: `gamePlan` sliders — used in prep multipliers sent to sim; `offPlanId/defPlanId/riskId` — persisted and used by legacy strategy modifiers but not forwarded to rich-engine payloads; depth chart / lineup — used for readiness checks and pre-sim repair and influence on team-context penalties; injured/unavailable players — used for injury stress and legacy engine per-player selection; `weeklyTrainingBoost` — persisted and consumed by legacy simulator rating flow but rich engine aggregation path currently does not apply it; `weeklyDevelopmentFocus` — persisted as practice stamp and used for UX but not a direct causal sim field; prep completion flags — stored in UI local tracking and only affect multipliers when tracking is sent (worker currently sets `hasTracking: false` in matchup builder).【F:src/worker/worker.js】【F:src/core/sim/gamePlanMultipliers.ts】【F:src/core/game-simulator.js】

Follow-ups (intentional deferrals):
- Align rich-sim aggregation to consume `weeklyTrainingBoost` (left as follow-up work — no changes to core sim math in this PR). 
- If richer causal attributions become provable from sim outputs, expand helper to include explicit, validated attribution fields; until then wording stays conservative.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f02cfaa324832da435d48dc161c478)