### PR TITLE
Weekly decision impact helper, Decision Review UI, and season fun audit

### DIFF
--- a/docs/SEASON_FUN_AUDIT.md
+++ b/docs/SEASON_FUN_AUDIT.md
@@ -1,0 +1,59 @@
+# Season Fun Audit (Weekly Decision Impact + Season Loop)
+
+## What already works
+- Weekly command loop has clear prep surfaces (HQ, Game Plan, Weekly Prep/War Room, Roster/Depth, Injuries, Training) and now closes the loop with a postgame Decision Review.
+- The new simulation path applies game-plan/prep multipliers into play calling and success modeling, which makes weekly tactical choices visible in outcomes without fake certainty.
+- Weekly practice is persisted (`weeklyDevelopmentFocus`, `weeklyTrainingBoost`) and now represented with explicit “logged vs not logged” language.
+
+## Decision input audit (what reaches sim vs not)
+
+| Input | Classification | Notes |
+|---|---|---|
+| offensive scheme (`offScheme`) | **Stored but not used** | Saved on team strategies for UX continuity; not consumed in weekSimulationBridge/rich sim path yet. |
+| defensive scheme (`defScheme`) | **Stored but not used** | Same as above. |
+| gamePlan sliders (`runPassBalance`, `aggressionLevel`, `deepShortBalance`) | **Used directly by sim** | Read in `buildWeekMatchupsFromLeague` → `deriveGamePlanMultipliers` → `simulateRichGame` play bias and attribute tuning. |
+| risk / plan IDs (`offPlanId`, `defPlanId`, `riskId`) | **Used directly by legacy sim only** | Consumed by `game-simulator.js` strategy modifiers; rich sim currently uses slider+prep model. |
+| depth chart assignments | **Used directly by sim (legacy), partial in rich sim** | Legacy sim uses depth order and injury filtering per group; rich sim aggregates roster by ratings (depth order not fully honored). |
+| injured starters / unavailable players | **Used directly by sim** | Injury states affect lineup pools in legacy sim; rich sim prep penalties read injury stress and blocking starter injuries. |
+| `weeklyTrainingBoost` from `conductDrill` | **Used directly by legacy sim only** | Applied to player OVR in legacy game sim; cleared on week advance. Rich sim does not yet map individual boosts into AttributesV2 aggregation. |
+| `weeklyDevelopmentFocus` | **Stored + used by progression system** | Used by weekly evolution/development, not by in-game causal attribution. |
+| prep completion state (`lineupChecked`, `planReviewed`, etc.) | **UI-only for now (new sim path unclear/future work)** | Tracked in local UI prep store and surfaced in UX; not currently persisted into worker sim inputs. |
+
+## Postgame data audit (what exists today)
+
+| Postgame artifact | Status |
+|---|---|
+| final score | ✅ present |
+| box score | ✅ present in archived rich game payloads when available |
+| team stats | ✅ present (`teamDriveStats`/`teamStats`) |
+| player stats | ✅ present (`boxScore.home/away`) |
+| injuries | ✅ present (`injuries` array on game result) |
+| game summary/headline/storyline | ✅ present (`summary.storyline`, recap/headline fallbacks) |
+| game-plan effects | ⚠️ indirect only (prep multipliers + reasons captured, no per-play attribution report) |
+| matchup effects | ⚠️ indirect only (rating/prep influence in sim and recap copy, not explicit causal ledger) |
+| training effects | ⚠️ partial (practice logs + weekly boosts exist; box score does not expose direct credit mapping) |
+
+## What feels thin
+- Rich sim does not yet ingest explicit depth-order usage, so lineup coaching can feel less tangible than UI implies.
+- Prep checklist completion is not persisted into worker-facing sim inputs; UX can feel ahead of sim in that dimension.
+- Training impact is real in legacy path and progression systems, but postgame attribution remains coarse.
+- Game Book currently lacks a dedicated, trust-preserving prep context strip unless surfaced from decision review helpers.
+
+## Top 5 highest-value next PRs
+1. **Persist weekly prep completion state to worker input** and wire it into `deriveGamePlanMultipliers.hasTracking` (small schema + adapter).
+2. **Map depth-order starters into rich sim roster aggregation** (starter-weighted unit aggregation, no rebalance).
+3. **Emit prep snapshot on each completed game** (`planSaved`, `trainingStamp`, `injuryRiskCount`) for deterministic postgame context.
+4. **Expose non-causal prep diagnostics in Game Book** (e.g., “pass bias +4%, injury stress active”) from existing sim factors.
+5. **Unify legacy/rich training effect messaging** so users always see whether weekly training affected game sim, progression, or both.
+
+## Systems most likely to make a full season feel fun
+- Weekly tactical loop fidelity (Game Plan ↔ matchups ↔ postgame review).
+- Injury/depth contingency play (meaningful starter loss management).
+- Game Book storytelling quality (clear narrative + stats + drive context).
+- Progression visibility tied to weekly operations decisions.
+
+## Systems most likely to drive multi-season stickiness
+- Development/progression arc clarity (prospect growth, aging curves, staff/facility leverage).
+- Roster identity continuity (scheme/coach fit + draft/development outcomes).
+- League memory/chronicle surfacing rivalry and franchise milestones.
+- Offseason consequence loops (contracts, cap, succession planning).

--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -55,11 +55,12 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
           { label: 'Week', value: weekFromId ?? '—' },
         ]}
       />
-      <SectionCard variant="compact" title="Preparation Context" subtitle={prepContext?.resultSummary ?? 'Weekly decision context unavailable for this game.'}>
+      <SectionCard variant="compact" title="Preparation Context" subtitle="Pregame context captured before kickoff. This strip does not assign direct causality.">
         <div className="app-hq-intel-list" role="list" aria-label="Preparation context">
-          {(prepContext?.bullets ?? []).slice(0, 3).map((bullet, idx) => (
+          {(prepContext?.preparationBullets ?? []).slice(0, 3).map((bullet, idx) => (
             <p key={`prep-context-${idx}`} role="listitem" className="app-hq-intel-item tone-info">{bullet}</p>
           ))}
+          {!(prepContext?.preparationBullets ?? []).length ? <p className="app-hq-intel-item tone-info">No pregame preparation markers were found for this game.</p> : null}
         </div>
       </SectionCard>
       <SectionCard variant="info" title="Game Book Detail" subtitle="Summary → Team stats → Player leaders → Drive/play recap.">

--- a/src/ui/components/GameDetailScreen.test.jsx
+++ b/src/ui/components/GameDetailScreen.test.jsx
@@ -18,6 +18,34 @@ describe('GameDetailScreen canonical title', () => {
     expect(html).not.toContain('Completed Game Detail');
   });
 
+
+
+  it('renders preparation context strip with non-causal copy when markers are present', () => {
+    const html = renderToString(
+      <GameDetailScreen
+        gameId="2031_w1_1_2"
+        league={{
+          seasonId: '2031',
+          userTeamId: 1,
+          teams: [{
+            id: 1,
+            strategies: { gamePlan: { runPassBalance: 55 } },
+            weeklyDevelopmentFocus: { stamp: '2031:1', positionGroups: ['qb'] },
+            roster: [{ id: 4, injuryWeeksRemaining: 2 }],
+          }],
+          schedule: {
+            weeks: [{ week: 1, games: [{ gameId: '2031_w1_1_2', home: { id: 1, abbr: 'AAA' }, away: { id: 2, abbr: 'BBB' }, homeScore: 20, awayScore: 17, played: true }] }],
+          },
+        }}
+        actions={{ getBoxScore: async () => ({ game: null }) }}
+      />,
+    );
+
+    expect(html).toContain('Preparation Context');
+    expect(html).toContain('does not assign direct causality');
+    expect(html).toContain('Game plan was saved before kickoff');
+  });
+
   it('renders an explicit empty state when no game is selected', () => {
     const html = renderToString(
       <GameDetailScreen

--- a/src/ui/utils/weeklyDecisionImpact.js
+++ b/src/ui/utils/weeklyDecisionImpact.js
@@ -174,16 +174,13 @@ function chooseRecommendation({ result, contextBullets }) {
     return { label: 'Review Availability', reason: 'Injury risk was already present.', route: lineupBullet.targetRoute };
   }
 
-  return { label: 'Review Game Book', reason: 'Review drive detail before making next-week changes.', route: result?.gameId ? `Game Book:${result.gameId}` : 'Weekly Results' };
+  return {
+    label: 'Review Game Book',
+    reason: 'Review drive detail before making next-week changes.',
+    route: result?.gameId ? `Game Book:${result.gameId}` : 'Weekly Results',
+  };
 }
 
-/**
- * Weekly Decision Impact Audit surface.
- * Category notes:
- * - strategy IDs/sliders are stored and referenced only as "saved" context here (no causal claim).
- * - depth/injury state is used as pregame risk context only.
- * - training focus stamp is treated as logged/not logged context only.
- */
 export function buildWeeklyDecisionImpact({ league, userTeam, lastGame } = {}) {
   const team = userTeam ?? (league?.teams ?? []).find((entry) => Number(entry?.id) === Number(league?.userTeamId)) ?? null;
   const result = normalizeResult({ lastGame, userTeamId: league?.userTeamId });
@@ -192,6 +189,12 @@ export function buildWeeklyDecisionImpact({ league, userTeam, lastGame } = {}) {
     return {
       heading: 'Decision Review',
       resultSummary: 'No completed user game available yet.',
+      offensiveTakeaway: 'Advance the week to generate a game result and decision review.',
+      defensiveTakeaway: 'No defensive snapshot yet.',
+      gamePlanTakeaway: 'No saved game result to evaluate this week.',
+      lineupInjuryTakeaway: 'Injury and lineup context appears after a completed game.',
+      trainingTakeaway: 'Practice logs will appear after a completed game week.',
+      preparationBullets: ['No completed user game available yet.'],
       bullets: [
         'Advance the week to generate a game result and decision review.',
       ],
@@ -200,6 +203,7 @@ export function buildWeeklyDecisionImpact({ league, userTeam, lastGame } = {}) {
         reason: 'Finish prep steps before kickoff.',
         route: 'Weekly Prep',
       },
+      routeTarget: 'Weekly Prep',
     };
   }
 
@@ -207,10 +211,9 @@ export function buildWeeklyDecisionImpact({ league, userTeam, lastGame } = {}) {
     ? team.roster.filter((player) => safeNum(player?.injuryWeeksRemaining ?? player?.injuredWeeks ?? player?.injury?.weeksRemaining ?? player?.injury?.gamesRemaining, 0) > 0).length
     : 0;
 
-  const coreBullets = [
-    buildOffensiveTakeaway({ result }),
-    buildDefensiveTakeaway({ result }),
-  ];
+  const offensiveTakeaway = buildOffensiveTakeaway({ result });
+  const defensiveTakeaway = buildDefensiveTakeaway({ result });
+
   const contextBullets = buildContextTakeaway({
     result,
     userTeam: team,
@@ -218,14 +221,28 @@ export function buildWeeklyDecisionImpact({ league, userTeam, lastGame } = {}) {
     injuryRiskCount,
   });
 
+  const gamePlanTakeaway = contextBullets.find((item) => item.id === 'game-plan')?.text
+    ?? 'No saved game-plan snapshot was found for this matchup.';
+  const lineupInjuryTakeaway = contextBullets.find((item) => item.id === 'lineup-injury')?.text
+    ?? 'No pregame injury-risk marker was found in this review window.';
+  const trainingTakeaway = contextBullets.find((item) => item.id.startsWith('training'))?.text
+    ?? 'No weekly practice log was matched to this game week.';
+
   const recommendedAction = chooseRecommendation({ result, contextBullets });
 
   return {
     heading: 'Decision Review',
     resultSummary: result.resultLine,
-    bullets: [...coreBullets, ...contextBullets.map((item) => item.text)].slice(0, 4),
+    offensiveTakeaway,
+    defensiveTakeaway,
+    gamePlanTakeaway,
+    lineupInjuryTakeaway,
+    trainingTakeaway,
+    bullets: [offensiveTakeaway, defensiveTakeaway, gamePlanTakeaway, lineupInjuryTakeaway].slice(0, 4),
+    preparationBullets: [gamePlanTakeaway, trainingTakeaway, lineupInjuryTakeaway].filter((text) => typeof text === 'string' && text.trim()),
     contextRoutes: contextBullets,
     recommendedAction,
+    routeTarget: recommendedAction?.route ?? 'Weekly Prep',
     metadata: {
       hasStrategyContext: hasSavedGamePlan(team?.strategies),
       hasTrainingContext: contextBullets.some((item) => item.id.startsWith('training')),

--- a/src/ui/utils/weeklyDecisionImpact.test.js
+++ b/src/ui/utils/weeklyDecisionImpact.test.js
@@ -46,9 +46,10 @@ describe('buildWeeklyDecisionImpact', () => {
     });
 
     expect(result.resultSummary).toContain('W 27-17 vs PHI');
-    expect(result.bullets.join(' ')).toContain('Game plan was saved before kickoff');
-    expect(result.bullets.join(' ')).toContain('Practice effects were logged this week');
+    expect(result.gamePlanTakeaway).toContain('Game plan was saved before kickoff');
+    expect(result.trainingTakeaway).toContain('Practice effects were logged this week');
     expect(result.metadata.hasTeamStats).toBe(true);
+    expect(result.routeTarget).toBe('Game Book:2026_w5_1_2');
   });
 
   it('derives a loss review and recommends game plan changes after low output', () => {
@@ -66,8 +67,34 @@ describe('buildWeeklyDecisionImpact', () => {
     });
 
     expect(result.resultSummary).toContain('L 13-24 @ PHI');
-    expect(result.bullets[0]).toMatch(/low offensive output|offensive output/i);
+    expect(result.offensiveTakeaway).toMatch(/low offensive output|offensive output/i);
     expect(result.recommendedAction.route).toBe('Game Plan');
+  });
+
+  it('flags injury risk context and routes recommendation to availability', () => {
+    const leagueWithInjury = {
+      ...baseLeague,
+      teams: [{
+        ...baseLeague.teams[0],
+        roster: [{ id: 17, injuryWeeksRemaining: 2 }],
+      }],
+    };
+
+    const result = buildWeeklyDecisionImpact({
+      league: leagueWithInjury,
+      userTeam: leagueWithInjury.teams[0],
+      lastGame: {
+        gameId: '2026_w5_1_2',
+        week: 5,
+        home: { id: 1, abbr: 'DAL' },
+        away: { id: 2, abbr: 'PHI' },
+        homeScore: 24,
+        awayScore: 21,
+      },
+    });
+
+    expect(result.lineupInjuryTakeaway).toContain('Injury/availability risk was active entering the week');
+    expect(result.recommendedAction.route).toBe('Team:Injuries');
   });
 
   it('falls back safely when box score team stats are missing', () => {
@@ -98,5 +125,34 @@ describe('buildWeeklyDecisionImpact', () => {
 
     expect(result.resultSummary).toContain('No completed user game available yet');
     expect(result.recommendedAction.route).toBe('Weekly Prep');
+  });
+
+  it('uses safe copy when context markers are missing and avoids fake causality', () => {
+    const cleanLeague = {
+      ...baseLeague,
+      teams: [{
+        ...baseLeague.teams[0],
+        strategies: {},
+        weeklyDevelopmentFocus: null,
+        roster: [{ id: 1, injuryWeeksRemaining: 0 }],
+      }],
+    };
+
+    const result = buildWeeklyDecisionImpact({
+      league: cleanLeague,
+      userTeam: cleanLeague.teams[0],
+      lastGame: {
+        gameId: '2026_w5_1_2',
+        week: 5,
+        home: { id: 1, abbr: 'DAL' },
+        away: { id: 2, abbr: 'PHI' },
+        homeScore: 21,
+        awayScore: 20,
+      },
+    });
+
+    expect(result.gamePlanTakeaway).toContain('No saved game-plan snapshot');
+    expect(result.trainingTakeaway).toContain('No weekly practice log was matched');
+    expect(result.bullets.join(' ')).not.toMatch(/won the game|caused the win|directly improved/i);
   });
 });


### PR DESCRIPTION
### Motivation
- The HQ/Results UI loop was strengthened and now needs honest, attribution-safe feedback so players understand what decisions actually affected outcomes. 
- Provide a small, high-value helper and minimal UI surfaces that surface prep/game context without inventing causality or changing simulator balance. 
- Deliver actionable next steps for follow-up engineering work (persist prep state, depth-order mapping, prep snapshots) without large architecture changes.

### Description
- Added a durable, attribution-safe helper `src/ui/utils/weeklyDecisionImpact.js` that derives `resultSummary`, `offensiveTakeaway`, `defensiveTakeaway`, `gamePlanTakeaway`, `lineupInjuryTakeaway`, `trainingTakeaway`, `preparationBullets`, `recommendedAction`, and `routeTarget`, and returns metadata for UI consumers. 
- Surfaced a compact, non-causal “Preparation Context” strip in the Game Book by updating `src/ui/components/GameDetailScreen.jsx` to show `preparationBullets` with a safe fallback when markers are missing. 
- Added unit tests and component tests in `src/ui/utils/weeklyDecisionImpact.test.js` and `src/ui/components/GameDetailScreen.test.jsx` and updated existing HQ/Results tests to assert Decision Review rendering and routes. 
- Added `docs/SEASON_FUN_AUDIT.md` with a concise Season Fun Audit, a decision-input classification, postgame data audit, thin spots, and prioritized next PRs. 
- Decision-input classification (Part A):
  - Used directly by sim: game-plan sliders (`runPassBalance`, `aggressionLevel`, `deepShortBalance`), injured/unavailable player state, depth assignments in legacy sim (partial in rich sim). 
  - Stored but not used (or not wired to rich sim): offensive/defensive scheme IDs. 
  - Legacy-only / partial usage: `offPlanId`/`defPlanId`/`riskId` and `weeklyTrainingBoost` (legacy sim applies boosts). 
  - Stored + used outside direct game attribution: `weeklyDevelopmentFocus` (feeds progression/evolution). 
  - UI-only / future work: prep completion checkboxes (`lineupChecked`, `planReviewed`, `injuriesReviewed`, `opponentScouted`) are tracked by the UI and not persisted into worker sim inputs yet. 
- Postgame data audit (Part B): final score, box score, team stats, player stats, injuries, and storyline/headline exist; game-plan/matchup/training effects are available only as indirect/contextual signals and not as deterministic causal attributions. 
- Implementation intentionally avoids simulator rewrites, rebalancing, hidden test hooks, or large architectural changes; copy is careful to avoid causal claims unless the data supports them.

### Testing
- Ran `npm ci` successfully to install dependencies. 
- Ran targeted unit/component tests with `npx vitest run src/ui/utils/weeklyDecisionImpact.test.js src/ui/components/__tests__/FranchiseHQ.test.jsx src/ui/components/WeeklyResultsCenter.test.jsx src/ui/components/GameDetailScreen.test.jsx` and all tests passed (18 tests total). 
- Built production bundle with `npm run build` which completed successfully. 
- Ran deployment checks `npm run check:deploy` (Netlify parity/build/rules) which completed successfully in this environment. 
- Attempted `npx playwright install --list` but browser binaries / Playwright cache were unavailable so Playwright e2e checks were skipped and not claimed as passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f02fb7a33c832d9fcb9ef37375f6a4)