### PR TITLE
docs: add weekly loop simulation audit notes

### DIFF
--- a/docs/weekly-loop-audit-2026-04-28.md
+++ b/docs/weekly-loop-audit-2026-04-28.md
@@ -1,0 +1,10 @@
+# Weekly Loop Audit Notes (2026-04-28)
+
+This document captures code-traced findings for weekly decision impact and postgame attribution.
+
+- `UPDATE_STRATEGY` persists scheme IDs, plan IDs, risk ID, and `gamePlan` to `team.strategies`.
+- `buildWeekMatchupsFromLeague` computes prep multipliers from heuristics and `gamePlan`, but does not use UI weekly prep completion tracking (`hasTracking: false`).
+- `weeklyPrep` completion is stored in browser `localStorage`, not worker state.
+- New AttributesV2 sim path aggregates top players by OVR and position priority, not depth chart order.
+- `weeklyTrainingBoost` is applied in legacy simulator and cleared after advancing week.
+- `conductDrill` and drill injuries use `Math.random()` in worker path.


### PR DESCRIPTION
### Motivation
- Preserve a concise, code-traced record of the weekly-loop audit pointing out where UI decisions (prep, game plan, depth, training) diverge from what the simulation actually consumes.

### Description
- Add `docs/weekly-loop-audit-2026-04-28.md` that summarizes findings and references key implementation points (notably `src/worker/worker.js`, `src/core/sim/gamePlanMultipliers.ts`, `src/core/sim/weekSimulationBridge.ts`, and `src/ui/utils/weeklyPrep.js`).

### Testing
- Documentation-only change; no code tests were run as part of this PR and no behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f04695aea0832d9fcfc794efa6afa1)