### PR TITLE
Expose game-plan impact reasons and narrative recap in weekly results

### DIFF
--- a/src/core/__tests__/narrative.test.ts
+++ b/src/core/__tests__/narrative.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { deriveGamePlanMultipliers } from '../sim/gamePlanMultipliers.ts';
+import { buildGamePlanNarrative } from '../narrative.js';
+
+describe('buildGamePlanNarrative', () => {
+  it('mentions run advantage when scouting and plan align', () => {
+    const multipliers = deriveGamePlanMultipliers({
+      weeklyPrepState: { insights: { weakRunDefense: true }, hasTracking: true, completion: { planReviewed: true, lineupChecked: true, injuriesReviewed: true, opponentScouted: true } },
+      gamePlan: { runPassBalance: 35 },
+    });
+    const recap = buildGamePlanNarrative(multipliers, { homeScore: 24, awayScore: 17, topRusher: { name: 'RB One', yards: 150 } });
+    expect(recap.toLowerCase()).toContain('run-heavy');
+    expect(recap.toLowerCase()).toContain('weak run defense');
+  });
+
+  it('mentions chemistry warning for extreme unsupported plan', () => {
+    const multipliers = deriveGamePlanMultipliers({
+      weeklyPrepState: { insights: { balancedMatchup: true }, hasTracking: true, completion: { planReviewed: true, lineupChecked: true, injuriesReviewed: true, opponentScouted: true } },
+      gamePlan: { runPassBalance: 80 },
+    });
+    const recap = buildGamePlanNarrative(multipliers, { homeScore: 13, awayScore: 20 });
+    expect(recap.toLowerCase()).toContain('warning');
+    expect(recap.toLowerCase()).toContain('chemistry');
+  });
+});
+

--- a/src/core/narrative.js
+++ b/src/core/narrative.js
@@ -1,0 +1,53 @@
+function firstNonEmpty(values = []) {
+  return values.find((value) => typeof value === 'string' && value.trim()) ?? '';
+}
+
+function parseReasonTone(reason = '') {
+  const lower = String(reason).toLowerCase();
+  if (lower.includes('advantage') || lower.includes('edge') || lower.includes('synergy') || lower.includes('active')) return 'positive';
+  if (lower.includes('penalty') || lower.includes('risk') || lower.includes('missing') || lower.includes('gap') || lower.includes('no scouting support')) return 'negative';
+  return 'neutral';
+}
+
+export function buildGamePlanNarrative(multipliers, stats = {}) {
+  if (!multipliers || typeof multipliers !== 'object') return '';
+  const reasons = Array.isArray(multipliers?.activeReasons) ? multipliers.activeReasons.filter(Boolean) : [];
+  const homeScore = Number(stats?.homeScore);
+  const awayScore = Number(stats?.awayScore);
+  const scoreLine = Number.isFinite(homeScore) && Number.isFinite(awayScore)
+    ? `${homeScore}-${awayScore}`
+    : 'final score unavailable';
+
+  const topRusher = firstNonEmpty([stats?.topRusher?.name, stats?.topRusher?.player, stats?.topRusher?.displayName]);
+  const topReceiver = firstNonEmpty([stats?.topReceiver?.name, stats?.topReceiver?.player, stats?.topReceiver?.displayName]);
+  const topPasser = firstNonEmpty([stats?.topPasser?.name, stats?.topPasser?.player, stats?.topPasser?.displayName]);
+  const rushYards = Number(stats?.topRusher?.yards ?? stats?.topRusher?.rushYd ?? stats?.rushingYards);
+  const passYards = Number(stats?.topPasser?.yards ?? stats?.topPasser?.passYd ?? stats?.passingYards);
+
+  const reasonText = reasons.join(' ').toLowerCase();
+  const positiveReason = reasons.find((reason) => parseReasonTone(reason) === 'positive') ?? '';
+  const warningReason = reasons.find((reason) => parseReasonTone(reason) === 'negative') ?? '';
+
+  let planSentence = `Final score ${scoreLine}.`;
+  if (reasonText.includes('run matchup advantage')) {
+    const yardText = Number.isFinite(rushYards) ? `${Math.round(rushYards)} rushing yards` : 'consistent rushing production';
+    planSentence = `Our run-heavy plan attacked a weak run defense and produced ${yardText}.`;
+  } else if (reasonText.includes('pass attack edge')) {
+    const yardText = Number.isFinite(passYards) ? `${Math.round(passYards)} passing yards` : 'chunk passing gains';
+    planSentence = `Our pass-heavy script exploited the opponent secondary and generated ${yardText}.`;
+  } else if (positiveReason) {
+    planSentence = `Game-plan alignment helped execution: ${positiveReason}`;
+  }
+
+  const leaders = [topPasser, topRusher, topReceiver].filter(Boolean);
+  const leaderSentence = leaders.length
+    ? `Leaders: ${leaders.join(', ')} kept the offense on schedule.`
+    : '';
+
+  const hasChemistryPenalty = Number(multipliers?.chemistryPenalty ?? 0) < 0;
+  const warningSentence = warningReason
+    ? `Warning: ${warningReason}${hasChemistryPenalty ? ' Chemistry took a hit.' : ''}`
+    : (hasChemistryPenalty ? 'Warning: chemistry penalties showed up from prep gaps.' : '');
+
+  return [planSentence, leaderSentence, warningSentence].filter(Boolean).join(' ');
+}

--- a/src/ui/components/WeeklyResultsCenter.jsx
+++ b/src/ui/components/WeeklyResultsCenter.jsx
@@ -71,6 +71,7 @@ function buildUserTeamResult(row, userTeamId) {
     userScore,
     oppScore,
     outcome,
+    prepImpact: row?.game?.prepImpact?.[isUserHome ? 'home' : 'away'] ?? null,
   };
 }
 
@@ -220,6 +221,20 @@ export default function WeeklyResultsCenter({ league, initialWeek, onGameSelect,
             </div>
             <p className="app-game-center-card__scoreline">{userTeamResult.recap}</p>
             <p className="app-game-center-card__summary">{userResultPresentation?.displayScoreLine ?? 'Final score unavailable.'}</p>
+            {userTeamResult?.prepImpact?.narrative ? (
+              <CompactInsightCard
+                title="Game-plan impact recap"
+                subtitle={userTeamResult.prepImpact.narrative}
+                tone="info"
+              />
+            ) : null}
+            {Array.isArray(userTeamResult?.prepImpact?.activeReasons) && userTeamResult.prepImpact.activeReasons.length ? (
+              <div className="app-hq-intel-list" role="list" aria-label="Game plan reasons">
+                {userTeamResult.prepImpact.activeReasons.map((reason, idx) => (
+                  <p key={`plan-reason-${idx}`} role="listitem" className="app-hq-intel-item tone-info">{reason}</p>
+                ))}
+              </div>
+            ) : null}
             {decisionReview?.bullets?.length ? (
               <div className="app-hq-intel-list" role="list" aria-label="Decision review">
                 {decisionReview.bullets.slice(0, 2).map((bullet, idx) => (

--- a/src/ui/components/WeeklyResultsCenter.test.jsx
+++ b/src/ui/components/WeeklyResultsCenter.test.jsx
@@ -52,6 +52,30 @@ describe('WeeklyResultsCenter', () => {
     expect(screen.getAllByRole('button', { name: /open game book/i }).length).toBeGreaterThan(0);
   });
 
+  it('shows game-plan recap and reasons when prep impact exists', () => {
+    const leagueWithPrep = {
+      ...league,
+      schedule: {
+        weeks: [
+          ...league.schedule.weeks.slice(0, 1),
+          {
+            week: 2,
+            games: [
+              {
+                gameId: '2026_w2_1_4', home: 1, away: 4, played: true, homeScore: 20, awayScore: 21,
+                summary: { storyline: 'Game-winning drive in final minute.' },
+                prepImpact: { home: { narrative: 'Our run-heavy plan attacked a weak run defense.', activeReasons: ['Run Matchup Advantage: run-heavy script targets a soft front.'] } },
+              },
+            ],
+          },
+        ],
+      },
+    };
+    render(<WeeklyResultsCenter league={leagueWithPrep} initialWeek={2} onGameSelect={() => {}} onNavigate={() => {}} />);
+    expect(screen.getByText(/game-plan impact recap/i)).toBeTruthy();
+    expect(screen.getByRole('list', { name: /game plan reasons/i })).toBeTruthy();
+  });
+
   it('opens Game Book from the user-team spotlight card', () => {
     const onGameSelect = vi.fn();
     render(<WeeklyResultsCenter league={league} initialWeek={2} onGameSelect={onGameSelect} onNavigate={() => {}} />);
@@ -87,6 +111,7 @@ describe('WeeklyResultsCenter', () => {
     const html = renderToString(<WeeklyResultsCenter league={legacyLeague} initialWeek={3} onGameSelect={() => {}} onNavigate={() => {}} />);
     expect(html).toContain('DAL won by 4 (3-7).');
     expect(html).toContain('Game Book unavailable (Archive unavailable)');
+    expect(html).not.toContain('Game-plan impact recap');
   });
 
   it('routes spotlight game records through current game book open helper', () => {

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -149,6 +149,7 @@ import {
   simulateWithOptionalNewEngine,
 } from '../core/sim/weekSimulationBridge.ts';
 import { deriveGamePlanMultipliers } from '../core/sim/gamePlanMultipliers.ts';
+import { buildGamePlanNarrative } from '../core/narrative.js';
 
 // ── DB Reload Guard ───────────────────────────────────────────────────────────
 // Register a callback with db/index.js so that when IDB fires onblocked or
@@ -3000,6 +3001,51 @@ function applyGameResultToCache(result, week, seasonId) {
   const turningPoints = buildTurningPointsFromGameEvents(playLogs, archiveContext);
   const teamStats = buildTeamStatComparisonFromArchive(result.boxScore ?? {}, archiveContext);
   const playerLeaders = buildPlayerLeadersFromArchive(result.boxScore ?? {}, archiveContext);
+  const getRating = (team, key) => Number(team?.[key] ?? team?.[`${key}Rating`] ?? team?.[`${key}Ovr`] ?? team?.ovr ?? 0);
+  const countInjured = (roster = []) => roster.filter((player) => {
+    const weeks = Number(player?.injuryWeeksRemaining ?? player?.injuredWeeks ?? player?.injuryDuration ?? 0);
+    const status = String(player?.status ?? '').toLowerCase();
+    return weeks > 0 || status === 'injured' || status === 'ir';
+  }).length;
+  const blockingLineupIssue = (roster = []) => {
+    const starters = roster.filter((p) => Number(p?.depthOrder ?? 0) === 1 || Number(p?.depthChart?.order ?? 0) === 1);
+    const startersWithInjury = starters.filter((p) => Number(p?.injuryWeeksRemaining ?? p?.injuredWeeks ?? 0) > 0).length;
+    return starters.length > 0 && startersWithInjury >= 2;
+  };
+  const homeGap = getRating(homeTeamSnapshot, 'ovr') - getRating(awayTeamSnapshot, 'ovr');
+  const buildPrep = ({ team, opp, plan, isHome }) => deriveGamePlanMultipliers({
+    weeklyPrepState: {
+      insights: {
+        weakSecondary: getRating(opp, 'defense') <= 76 || (getRating(team, 'offense') - getRating(opp, 'defense')) >= 6,
+        weakRunDefense: getRating(opp, 'defense') <= 78 || (getRating(team, 'offense') - getRating(opp, 'defense')) >= 4,
+        elitePassRush: getRating(opp, 'defense') >= 85,
+        explosiveOpponentOffense: getRating(opp, 'offense') >= 84,
+        balancedMatchup: Math.abs(homeGap * (isHome ? 1 : -1)) <= 4,
+      },
+      hasTracking: false,
+    },
+    gamePlan: plan,
+    teamContext: {
+      majorInjuryStress: countInjured(team?.roster ?? []) >= 3,
+      hasBlockingLineupIssue: blockingLineupIssue(team?.roster ?? []),
+    },
+  });
+  const homePrepMultipliers = buildPrep({ team: homeTeamSnapshot, opp: awayTeamSnapshot, plan: homeTeamSnapshot?.strategies?.gamePlan ?? {}, isHome: true });
+  const awayPrepMultipliers = buildPrep({ team: awayTeamSnapshot, opp: homeTeamSnapshot, plan: awayTeamSnapshot?.strategies?.gamePlan ?? {}, isHome: false });
+  const homePlanNarrative = buildGamePlanNarrative(homePrepMultipliers, {
+    homeScore: scoreHome,
+    awayScore: scoreAway,
+    topPasser: playerLeaders?.categories?.passing?.home,
+    topRusher: playerLeaders?.categories?.rushing?.home,
+    topReceiver: playerLeaders?.categories?.receiving?.home,
+  });
+  const awayPlanNarrative = buildGamePlanNarrative(awayPrepMultipliers, {
+    homeScore: scoreAway,
+    awayScore: scoreHome,
+    topPasser: playerLeaders?.categories?.passing?.away,
+    topRusher: playerLeaders?.categories?.rushing?.away,
+    topReceiver: playerLeaders?.categories?.receiving?.away,
+  });
   const wentOvertime = playLogs.some((log) => Number(log?.quarter) > 4);
   const rivalryGame = Boolean(homeTeamSnapshot?.conf && awayTeamSnapshot?.conf && homeTeamSnapshot?.conf === awayTeamSnapshot?.conf && homeTeamSnapshot?.div === awayTeamSnapshot?.div);
   const gameScript = classifyGameScript({
@@ -3085,6 +3131,16 @@ function applyGameResultToCache(result, week, seasonId) {
         game.homeScore = scoreHome;
         game.awayScore = scoreAway;
         game.archiveQuality = archiveQuality;
+        game.prepImpact = {
+          home: {
+            activeReasons: homePrepMultipliers.activeReasons ?? [],
+            narrative: homePlanNarrative ?? '',
+          },
+          away: {
+            activeReasons: awayPrepMultipliers.activeReasons ?? [],
+            narrative: awayPlanNarrative ?? '',
+          },
+        };
       } else {
         console.warn(`[Worker] applyGameResultToCache: Could not find game ${hId} vs ${aId} in week ${week} schedule (${weekData.games.length} games in week)`);
       }


### PR DESCRIPTION
### Motivation
- Players only saw scores and generic recaps after a game, leaving a gap in understanding how their game-plan and prep choices affected outcomes.  This adds a clear feedback loop tying decisions to results. 
- The change surfaces existing signals from `deriveGamePlanMultipliers` (`activeReasons`, deltas, chemistry penalty) into a readable narrative so players can learn from scouting alignment and skipped prep without changing simulation formulas.

### Description
- Added a new helper `buildGamePlanNarrative` in `src/core/narrative.js` that consumes a `DerivedGamePlanMultipliers` object plus basic stats (final score and top leaders) and returns a short templated narrative highlighting run/pass matchup advantages, leader callouts, and prep/chemistry warnings.
- Updated worker post-processing in `src/worker/worker.js` to derive per-team prep multipliers after simulation output assembly (using the same `deriveGamePlanMultipliers` inputs pattern) and attach `prepImpact` onto completed schedule games as `{ activeReasons: string[], narrative: string }` without altering sim internals or blocking yield frames.
- Updated UI `WeeklyResultsCenter` (`src/ui/components/WeeklyResultsCenter.jsx`) to show a “Game-plan impact recap” card under the user-team final score and list each `activeReason` when present, and to hide the section when no `prepImpact` exists.
- Added unit tests: `src/core/__tests__/narrative.test.ts` (narrative mentions run advantage and chemistry warning) and extended `src/ui/components/WeeklyResultsCenter.test.jsx` to assert the recap and reason list render when `prepImpact` is present and remain hidden for legacy score-only payloads.

### Testing
- Ran unit tests with Vitest via `npm run test:unit -- src/core/__tests__/narrative.test.ts src/ui/components/WeeklyResultsCenter.test.jsx` and all tests passed (2 test files, 8 tests total).
- Attempted `npm test` (project default maps to Playwright e2e) with the two file paths which returned "No tests found" because `npm test` targets the e2e runner and the provided paths are unit tests; this is expected and does not indicate failing unit checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f383af7078832d95922b245bf3040d)