### PR TITLE
Fix prep-impact tone and leader mapping; add Game Book postgame film room

### DIFF
--- a/src/core/__tests__/narrative.test.ts
+++ b/src/core/__tests__/narrative.test.ts
@@ -10,7 +10,7 @@ describe('buildGamePlanNarrative', () => {
     });
     const recap = buildGamePlanNarrative(multipliers, { homeScore: 24, awayScore: 17, topRusher: { name: 'RB One', yards: 150 } });
     expect(recap.toLowerCase()).toContain('run-heavy');
-    expect(recap.toLowerCase()).toContain('weak run defense');
+    expect(recap.toLowerCase()).toContain('weak run-defense');
   });
 
   it('mentions chemistry warning for extreme unsupported plan', () => {
@@ -22,5 +22,32 @@ describe('buildGamePlanNarrative', () => {
     expect(recap.toLowerCase()).toContain('warning');
     expect(recap.toLowerCase()).toContain('chemistry');
   });
-});
 
+  it('treats readiness penalty active as warning language', () => {
+    const recap = buildGamePlanNarrative({
+      activeReasons: ['Readiness Penalty Active: no scouting support this week.'],
+      chemistryPenalty: -0.04,
+    }, { homeScore: 17, awayScore: 20 });
+    expect(recap.toLowerCase()).toContain('warning');
+    expect(recap.toLowerCase()).not.toContain('alignment helped execution');
+  });
+
+  it('treats injury stress is active as warning language', () => {
+    const recap = buildGamePlanNarrative({
+      activeReasons: ['Injury stress is active in pass protection.'],
+    }, { homeScore: 24, awayScore: 27 });
+    expect(recap.toLowerCase()).toContain('warning');
+    expect(recap.toLowerCase()).not.toContain('alignment helped execution');
+  });
+
+  it('supports direct leader payload shape from gameSummary categories', () => {
+    const recap = buildGamePlanNarrative({
+      activeReasons: ['Pass Attack Edge: pass-heavy script against soft coverage.'],
+    }, {
+      topPasser: { name: 'QB One', passYd: 312, passTD: 3, interceptions: 1 },
+    });
+    expect(recap).toContain('312 passing yards');
+    expect(recap).toContain('3 pass TD');
+    expect(recap).toContain('1 INT');
+  });
+});

--- a/src/core/narrative.js
+++ b/src/core/narrative.js
@@ -4,8 +4,16 @@ function firstNonEmpty(values = []) {
 
 function parseReasonTone(reason = '') {
   const lower = String(reason).toLowerCase();
-  if (lower.includes('advantage') || lower.includes('edge') || lower.includes('synergy') || lower.includes('active')) return 'positive';
-  if (lower.includes('penalty') || lower.includes('risk') || lower.includes('missing') || lower.includes('gap') || lower.includes('no scouting support')) return 'negative';
+  if (
+    lower.includes('penalty')
+    || lower.includes('risk')
+    || lower.includes('missing')
+    || lower.includes('gap')
+    || lower.includes('no scouting support')
+    || lower.includes('injury stress')
+    || lower.includes('readiness penalty')
+  ) return 'negative';
+  if (lower.includes('advantage') || lower.includes('edge') || lower.includes('synergy')) return 'positive';
   return 'neutral';
 }
 
@@ -21,8 +29,14 @@ export function buildGamePlanNarrative(multipliers, stats = {}) {
   const topRusher = firstNonEmpty([stats?.topRusher?.name, stats?.topRusher?.player, stats?.topRusher?.displayName]);
   const topReceiver = firstNonEmpty([stats?.topReceiver?.name, stats?.topReceiver?.player, stats?.topReceiver?.displayName]);
   const topPasser = firstNonEmpty([stats?.topPasser?.name, stats?.topPasser?.player, stats?.topPasser?.displayName]);
+  const rushAttempts = Number(stats?.topRusher?.attempts ?? stats?.topRusher?.rushAtt);
+  const rushYpc = Number(stats?.topRusher?.ypc ?? stats?.topRusher?.rushYpc);
   const rushYards = Number(stats?.topRusher?.yards ?? stats?.topRusher?.rushYd ?? stats?.rushingYards);
+  const passTds = Number(stats?.topPasser?.tds ?? stats?.topPasser?.passTD);
+  const passInts = Number(stats?.topPasser?.ints ?? stats?.topPasser?.interceptions);
   const passYards = Number(stats?.topPasser?.yards ?? stats?.topPasser?.passYd ?? stats?.passingYards);
+  const sacksAllowed = Number(stats?.sacksAllowed ?? stats?.sacks ?? stats?.teamStats?.sacks);
+  const turnovers = Number(stats?.turnovers ?? stats?.teamStats?.turnovers);
 
   const reasonText = reasons.join(' ').toLowerCase();
   const positiveReason = reasons.find((reason) => parseReasonTone(reason) === 'positive') ?? '';
@@ -30,11 +44,25 @@ export function buildGamePlanNarrative(multipliers, stats = {}) {
 
   let planSentence = `Final score ${scoreLine}.`;
   if (reasonText.includes('run matchup advantage')) {
-    const yardText = Number.isFinite(rushYards) ? `${Math.round(rushYards)} rushing yards` : 'consistent rushing production';
-    planSentence = `Our run-heavy plan attacked a weak run defense and produced ${yardText}.`;
+    const receipts = [
+      Number.isFinite(rushAttempts) ? `${Math.round(rushAttempts)} rush attempts` : '',
+      Number.isFinite(rushYards) ? `${Math.round(rushYards)} rushing yards` : '',
+      Number.isFinite(rushYpc) ? `${rushYpc.toFixed(1)} YPC` : '',
+    ].filter(Boolean).join(', ');
+    planSentence = `Our run-heavy plan aligned with a weak run-defense look and helped create ${receipts || 'steady rushing production'}.`;
   } else if (reasonText.includes('pass attack edge')) {
-    const yardText = Number.isFinite(passYards) ? `${Math.round(passYards)} passing yards` : 'chunk passing gains';
-    planSentence = `Our pass-heavy script exploited the opponent secondary and generated ${yardText}.`;
+    const receipts = [
+      Number.isFinite(passYards) ? `${Math.round(passYards)} passing yards` : '',
+      Number.isFinite(passTds) ? `${Math.round(passTds)} pass TD` : '',
+      Number.isFinite(passInts) ? `${Math.round(passInts)} INT` : '',
+    ].filter(Boolean).join(', ');
+    planSentence = `Our pass-heavy script aligned with the coverage matchup and helped generate ${receipts || 'chunk passing gains'}.`;
+  } else if (reasonText.includes('quick-game') || reasonText.includes('protection')) {
+    const receipts = [
+      Number.isFinite(sacksAllowed) ? `${Math.round(sacksAllowed)} sacks allowed` : '',
+      Number.isFinite(turnovers) ? `${Math.round(turnovers)} turnovers` : '',
+    ].filter(Boolean).join(', ');
+    planSentence = `Our protection-oriented calls aligned with pressure looks${receipts ? `, with ${receipts}.` : '.'}`;
   } else if (positiveReason) {
     planSentence = `Game-plan alignment helped execution: ${positiveReason}`;
   }

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -79,6 +79,7 @@ function TeamLeaderCell({ label, player, statKeys, onPlayerSelect }) {
 
 const SECTION_LINKS = [
   { key: "summary", label: "Summary" },
+  { key: "prep", label: "Game-plan Impact" },
   { key: "team", label: "Team Stats" },
   { key: "players", label: "Players" },
   { key: "scoring", label: "Scoring" },
@@ -428,6 +429,17 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
     game.homeScore != null || game.awayScore != null || game.stats || game.playerStats || game.teamStats || game.recap || game.quarterScores
   ));
   const unavailableMessage = "No data saved for this game.";
+  const prepImpact = game?.prepImpact ?? null;
+  const prepRows = useMemo(() => ([
+    { side: "away", team: awayTeam, impact: prepImpact?.away ?? null },
+    { side: "home", team: homeTeam, impact: prepImpact?.home ?? null },
+  ]).map((entry) => {
+    const reasons = Array.isArray(entry.impact?.activeReasons) ? entry.impact.activeReasons : [];
+    const warnings = reasons.filter((reason) => /penalty|risk|missing|gap|no scouting support|injury stress|readiness penalty/i.test(String(reason)));
+    const positives = reasons.filter((reason) => !warnings.includes(reason));
+    return { ...entry, warnings, positives };
+  }), [awayTeam, homeTeam, prepImpact]);
+  const hasPrepImpact = prepRows.some((row) => row.impact?.narrative || row.warnings.length || row.positives.length);
 
   const shell = (
     <div className={`${embedded ? "card" : "modal-content modal-large box-score-modal"}`} onClick={(e) => !embedded && e.stopPropagation()}>
@@ -521,6 +533,29 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
               </div>
             )}
           </section>
+          {hasPrepImpact && (
+            <section className="bs-section" ref={(node) => { sectionRefs.current.prep = node; }} data-section="prep">
+              <h4>Postgame Film Room</h4>
+              <div className="bs-team-groups">
+                {prepRows.map((row) => (
+                  <div key={row.side} className="bs-team-group">
+                    <h5>{row.team?.abbr ?? row.side.toUpperCase()}</h5>
+                    {row.impact?.narrative ? <div className="bs-list-item">{row.impact.narrative}</div> : <EmptyState title="No game-plan recap" body="No prep impact was archived for this side." />}
+                    {!!row.positives.length && (
+                      <div className="bs-list" aria-label={`${row.side} positive game plan reasons`}>
+                        {row.positives.map((reason, idx) => <div key={`${row.side}-pos-${idx}`} className="bs-list-item">{reason}</div>)}
+                      </div>
+                    )}
+                    {!!row.warnings.length && (
+                      <div className="bs-list" aria-label={`${row.side} warning game plan reasons`}>
+                        {row.warnings.map((reason, idx) => <div key={`${row.side}-warn-${idx}`} className="bs-list-item" style={{ borderColor: "var(--warning)" }}>Warning: {reason}</div>)}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
 
           <GameDetailV2 game={game} awayTeam={awayTeam} homeTeam={homeTeam} />
 

--- a/src/ui/components/BoxScore.test.jsx
+++ b/src/ui/components/BoxScore.test.jsx
@@ -42,6 +42,16 @@ describe('BoxScore postgame command center', () => {
             away: { redZoneScores: 4, redZoneTrips: 5, explosivePlays: 7 },
           },
         },
+        prepImpact: {
+          away: {
+            narrative: 'Our pass-heavy script aligned with the coverage matchup and helped generate 294 passing yards, 3 pass TD, 0 INT.',
+            activeReasons: ['Pass Attack Edge: pass-heavy script targets a soft secondary.'],
+          },
+          home: {
+            narrative: 'Final score 24-31.',
+            activeReasons: ['Readiness Penalty Active: no scouting support this week.'],
+          },
+        },
         teamStats: {
           home: { totalYards: 342, turnovers: 2, sacks: 1, passYards: 212 },
           away: { totalYards: 426, turnovers: 0, sacks: 4, passYards: 294 },
@@ -82,6 +92,8 @@ describe('BoxScore postgame command center', () => {
     expect(html).toContain('Player leaders');
     expect(html).toContain('Scoring summary');
     expect(html).toContain('Game flow &amp; momentum');
+    expect(html).toContain('Postgame Film Room');
+    expect(html).toContain('Warning: <!-- -->Readiness Penalty Active');
   });
 
   it('fails safely for partial archived payloads without crashing', () => {
@@ -111,6 +123,7 @@ describe('BoxScore postgame command center', () => {
 
     expect(html).toContain('Game Book');
     expect(html).toContain('Detailed box score is unavailable');
+    expect(html).not.toContain('Postgame Film Room');
   });
 
   it('player buttons trigger existing selection handlers when player ids are present', () => {

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -221,6 +221,17 @@ function applyDynamicEventEffects(events = []) {
   }
 }
 
+function normalizeLeaderForTeam(leader, teamId) {
+  if (!leader || typeof leader !== 'object') return null;
+  const leaderTeamId = Number(leader?.teamId);
+  if (Number.isFinite(leaderTeamId) && Number.isFinite(Number(teamId)) && leaderTeamId !== Number(teamId)) return null;
+  const stats = leader?.stats ?? {};
+  return {
+    ...leader,
+    ...stats,
+  };
+}
+
 const SIM_SESSION_STAGES = Object.freeze([
   'regular_season',
   'playoffs',
@@ -3035,16 +3046,18 @@ function applyGameResultToCache(result, week, seasonId) {
   const homePlanNarrative = buildGamePlanNarrative(homePrepMultipliers, {
     homeScore: scoreHome,
     awayScore: scoreAway,
-    topPasser: playerLeaders?.categories?.passing?.home,
-    topRusher: playerLeaders?.categories?.rushing?.home,
-    topReceiver: playerLeaders?.categories?.receiving?.home,
+    topPasser: normalizeLeaderForTeam(playerLeaders?.categories?.passing, hId),
+    topRusher: normalizeLeaderForTeam(playerLeaders?.categories?.rushing, hId),
+    topReceiver: normalizeLeaderForTeam(playerLeaders?.categories?.receiving, hId),
+    teamStats: teamStats?.home,
   });
   const awayPlanNarrative = buildGamePlanNarrative(awayPrepMultipliers, {
     homeScore: scoreAway,
     awayScore: scoreHome,
-    topPasser: playerLeaders?.categories?.passing?.away,
-    topRusher: playerLeaders?.categories?.rushing?.away,
-    topReceiver: playerLeaders?.categories?.receiving?.away,
+    topPasser: normalizeLeaderForTeam(playerLeaders?.categories?.passing, aId),
+    topRusher: normalizeLeaderForTeam(playerLeaders?.categories?.rushing, aId),
+    topReceiver: normalizeLeaderForTeam(playerLeaders?.categories?.receiving, aId),
+    teamStats: teamStats?.away,
   });
   const wentOvertime = playLogs.some((log) => Number(log?.quarter) > 4);
   const rivalryGame = Boolean(homeTeamSnapshot?.conf && awayTeamSnapshot?.conf && homeTeamSnapshot?.conf === awayTeamSnapshot?.conf && homeTeamSnapshot?.div === awayTeamSnapshot?.div);


### PR DESCRIPTION
### Motivation
- Repair correctness regressions from the prior prep-impact change so tone and leader data are truthful and robust.
- Ensure narratives are stat-backed (when receipts are archived) and avoid treating the generic word "active" as a positive signal.
- Surface the deeper postgame prep impact in the Game Book while keeping Weekly Results as a compact view.

### Description
- Fixed reason-tone parsing in `parseReasonTone` to detect negative phrases first and explicitly classify `penalty`, `risk`, `missing`, `gap`, `no scouting support`, `injury stress`, and `readiness penalty` as negative, and removed generic `active` from positive matching (`src/core/narrative.js`).
- Expanded `buildGamePlanNarrative` to include available stat receipts (rush attempts/yards/YPC; passing yards/TD/INT; sacks/turnovers) and to use non-causal wording like "aligned with" or "helped" (`src/core/narrative.js`).
- Fixed worker post-processing by adding `normalizeLeaderForTeam` and using it instead of assuming `categories.passing.home` / `.away`, and passed `teamStats` into the narrative generator; the adapter is defensive for legacy/score-only payloads (`src/worker/worker.js`).
- Added a `Postgame Film Room` (Game-plan Impact) section in the Game Book that shows the narrative, groups active reasons into warnings vs positives, and hides when `prepImpact` is missing; Weekly Results continues to show the compact recap if present (`src/ui/components/BoxScore.jsx`, `src/ui/components/WeeklyResultsCenter.jsx`).
- Added/updated unit tests for negative reason classification, leader payload shape handling, Game Book rendering of prepImpact, and legacy (score-only) safety (`src/core/__tests__/narrative.test.ts`, `src/ui/components/BoxScore.test.jsx`, `src/ui/components/WeeklyResultsCenter.test.jsx`).

### Testing
- Ran the targeted unit tests with `npm run test:unit -- src/core/__tests__/narrative.test.ts src/ui/components/WeeklyResultsCenter.test.jsx src/ui/components/BoxScore.test.jsx` which initially revealed 2 failing assertions that were fixed and then re-run.
- Final run: all targeted tests passed: 3 test files, 14 tests total, all green.
- Note: I ran only the targeted unit tests above and did not run the full e2e/Playwright test suite or a full repository-wide test run; those broader checks were intentionally skipped because this PR touches unit logic and UI components only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f390977c94832d914df1e338dd78fe)