### PR TITLE
Expand Team Builder analysis model and roster workspace UX

### DIFF
--- a/src/core/__tests__/rosterBuildingAnalysis.test.ts
+++ b/src/core/__tests__/rosterBuildingAnalysis.test.ts
@@ -2,24 +2,44 @@ import { describe, expect, it } from 'vitest';
 import { buildRosterBuildingAnalysis } from '../rosterBuildingAnalysis.js';
 
 describe('buildRosterBuildingAnalysis', () => {
-  it('flags urgent need when starter and depth are weak', () => {
-    const res = buildRosterBuildingAnalysis({ roster: [{ id: 1, name: 'QB A', pos: 'QB', ovr: 62, age: 31, contract: { yearsRemaining: 1 } }] });
+  it('flags QB urgent need when starter is weak despite backup depth', () => {
+    const res = buildRosterBuildingAnalysis({ roster: [{ id: 1, name: 'QB1', pos: 'QB', ovr: 60, age: 30 }] });
     expect(res.positionGroups.find((g) => g.key === 'QB')?.needLevel).toBe('urgent');
   });
 
-  it('flags strong group when quality is high', () => {
-    const res = buildRosterBuildingAnalysis({ roster: [{ id: 1, name: 'WR1', pos: 'WR', ovr: 88, age: 25 }, { id: 2, name: 'WR2', pos: 'WR', ovr: 83, age: 26 }, { id: 3, name: 'WR3', pos: 'WR', ovr: 80, age: 24 }] });
-    expect(['strong', 'elite']).toContain(res.positionGroups.find((g) => g.key === 'WR')?.needLevel);
+  it('uses WR top-3 starter window', () => {
+    const res = buildRosterBuildingAnalysis({ roster: [{ id: 1, name: 'WR1', pos: 'WR', ovr: 89 }, { id: 2, name: 'WR2', pos: 'WR', ovr: 62 }, { id: 3, name: 'WR3', pos: 'WR', ovr: 61 }] });
+    expect(res.positionGroups.find((g) => g.key === 'WR')?.starterOVR).toBe(71);
   });
 
-  it('marks high cap pressure when cap room is negative', () => {
-    const res = buildRosterBuildingAnalysis({ cap: { capRoom: -2, capUsed: 260, deadCap: 20 } });
-    expect(res.capSummary.payrollPressure).toBe('critical');
+  it('uses OL top-5 starters and does not hide weak line', () => {
+    const res = buildRosterBuildingAnalysis({ roster: [{ id: 1, name: 'OL1', pos: 'OL', ovr: 92 }, { id: 2, name: 'OL2', pos: 'OL', ovr: 62 }, { id: 3, name: 'OL3', pos: 'OL', ovr: 61 }, { id: 4, name: 'OL4', pos: 'OL', ovr: 60 }, { id: 5, name: 'OL5', pos: 'OL', ovr: 59 }, { id: 6, name: 'OL6', pos: 'OL', ovr: 58 }] });
+    const group = res.positionGroups.find((g) => g.key === 'OL');
+    expect(group?.starterCountExpected).toBe(5);
+    expect(group?.needLevel).toMatch(/urgent|thin/);
   });
 
-  it('prioritizes high-ovr expiring player as must_keep', () => {
-    const res = buildRosterBuildingAnalysis({ roster: [{ id: 1, name: 'CB1', pos: 'CB', ovr: 86, potential: 88, age: 27, contract: { yearsRemaining: 1, baseAnnual: 14 } }] });
-    expect(res.expiringContracts[0]?.priority).toBe('must_keep');
+  it('increases RB age risk earlier', () => {
+    const res = buildRosterBuildingAnalysis({ roster: [{ id: 1, name: 'RB Vet', pos: 'RB', ovr: 80, age: 29 }] });
+    expect((res.positionGroups.find((g) => g.key === 'RB')?.ageRisk ?? 0)).toBeGreaterThan(0);
+  });
+
+  it('sets starter expectations for DL/LB/CB/S', () => {
+    const res = buildRosterBuildingAnalysis({ roster: [] });
+    expect(res.positionGroups.find((g) => g.key === 'DL')?.starterCountExpected).toBe(4);
+    expect(res.positionGroups.find((g) => g.key === 'LB')?.starterCountExpected).toBe(3);
+    expect(res.positionGroups.find((g) => g.key === 'CB')?.starterCountExpected).toBe(3);
+    expect(res.positionGroups.find((g) => g.key === 'S')?.starterCountExpected).toBe(2);
+  });
+
+  it('adds matching free-agent candidate when available', () => {
+    const res = buildRosterBuildingAnalysis({ roster: [{ id: 1, name: 'QB A', pos: 'QB', ovr: 58 }], freeAgents: [{ id: 99, name: 'FA QB', pos: 'QB', ovr: 74 }] });
+    expect(res.candidateActions.some((a) => a.type === 'freeAgency' && a.playerName === 'FA QB')).toBe(true);
+  });
+
+  it('does not add free-agent action when no matching FA exists', () => {
+    const res = buildRosterBuildingAnalysis({ roster: [{ id: 1, name: 'QB A', pos: 'QB', ovr: 58 }], freeAgents: [{ id: 99, name: 'FA RB', pos: 'RB', ovr: 74 }] });
+    expect(res.candidateActions.some((a) => a.type === 'freeAgency' && a.pos === 'QB')).toBe(false);
   });
 
   it('detects aging expensive low-fit veteran as value risk', () => {
@@ -27,12 +47,12 @@ describe('buildRosterBuildingAnalysis', () => {
     expect(res.valueRisks.length).toBeGreaterThan(0);
   });
 
-  it('adds young high-potential development target', () => {
-    const res = buildRosterBuildingAnalysis({ roster: [{ id: 1, name: 'LB Dev', pos: 'LB', ovr: 68, potential: 81, age: 22, schemeFit: 70 }] });
-    expect(res.developmentTargets[0]?.id).toBe(1);
+  it('creates training action from development target', () => {
+    const res = buildRosterBuildingAnalysis({ roster: [{ id: 1, name: 'LB Dev', pos: 'LB', ovr: 68, potential: 81, age: 22, schemeFit: 70 }, { id: 2, name: 'LB Vet', pos: 'LB', ovr: 48, age: 31 }], draftPicks: [{ round: 2 }] });
+    expect(res.candidateActions.some((a) => a.type === 'training')).toBe(true);
   });
 
-  it('does not crash on missing fields', () => {
+  it('does not crash on missing cap/free-agent/draft data', () => {
     const res = buildRosterBuildingAnalysis({ roster: [{ id: 1, name: 'Unknown', pos: 'K' }] });
     expect(res.capSummary).toBeTruthy();
   });

--- a/src/core/rosterBuildingAnalysis.js
+++ b/src/core/rosterBuildingAnalysis.js
@@ -1,28 +1,71 @@
 const POSITION_GROUPS = ['QB', 'RB', 'WR', 'TE', 'OL', 'DL', 'LB', 'CB', 'S', 'K', 'P'];
 
+const GROUP_CONFIG = {
+  QB: { label: 'Quarterbacks', starterCountExpected: 1, depthSlots: 2, weights: { starter: 0.65, depth: 0.2, age: 0.05, injury: 0.05, scheme: 0.05 }, priority: 1.2 },
+  RB: { label: 'Running Backs', starterCountExpected: 1, depthSlots: 3, weights: { starter: 0.35, depth: 0.35, age: 0.15, injury: 0.1, scheme: 0.05 }, priority: 0.95, ageThreshold: 27 },
+  WR: { label: 'Wide Receivers', starterCountExpected: 3, depthSlots: 5, weights: { starter: 0.45, depth: 0.35, age: 0.05, injury: 0.1, scheme: 0.05 }, priority: 1.05 },
+  TE: { label: 'Tight Ends', starterCountExpected: 1, depthSlots: 2, weights: { starter: 0.45, depth: 0.35, age: 0.05, injury: 0.1, scheme: 0.05 }, priority: 0.9 },
+  OL: { label: 'Offensive Line', starterCountExpected: 5, depthSlots: 7, weights: { starter: 0.4, depth: 0.35, age: 0.08, injury: 0.1, scheme: 0.07 }, priority: 1.15 },
+  DL: { label: 'Defensive Line', starterCountExpected: 4, depthSlots: 6, weights: { starter: 0.45, depth: 0.3, age: 0.08, injury: 0.12, scheme: 0.05 }, priority: 1.0 },
+  LB: { label: 'Linebackers', starterCountExpected: 3, depthSlots: 5, weights: { starter: 0.45, depth: 0.3, age: 0.08, injury: 0.12, scheme: 0.05 }, priority: 1.0 },
+  CB: { label: 'Cornerbacks', starterCountExpected: 3, depthSlots: 5, weights: { starter: 0.45, depth: 0.3, age: 0.08, injury: 0.12, scheme: 0.05 }, priority: 1.05 },
+  S: { label: 'Safeties', starterCountExpected: 2, depthSlots: 4, weights: { starter: 0.5, depth: 0.25, age: 0.08, injury: 0.12, scheme: 0.05 }, priority: 1.0 },
+  K: { label: 'Kickers', starterCountExpected: 1, depthSlots: 1, weights: { starter: 0.8, depth: 0.05, age: 0.05, injury: 0.05, scheme: 0.05 }, priority: 0.5 },
+  P: { label: 'Punters', starterCountExpected: 1, depthSlots: 1, weights: { starter: 0.8, depth: 0.05, age: 0.05, injury: 0.05, scheme: 0.05 }, priority: 0.5 },
+};
+
 const avg = (arr = []) => (arr.length ? arr.reduce((s, n) => s + n, 0) / arr.length : 0);
 const num = (v, fb = 0) => (Number.isFinite(Number(v)) ? Number(v) : fb);
+const clamp = (v, min = 0, max = 100) => Math.max(min, Math.min(max, v));
 
 function yearsRemaining(player) {
   return num(player?.contract?.yearsRemaining ?? player?.contract?.years ?? player?.years ?? 0, 0);
 }
 
+function toRoute(type) {
+  return type === 'freeAgency' ? 'Free Agency' : type === 'trade' ? 'Trade Center' : type === 'draft' ? 'Draft' : type === 'training' ? 'Training' : type === 'extension' ? 'Contract Center' : 'Team:Roster / Depth';
+}
+
 export function buildRosterBuildingAnalysis({ team, roster = [], cap = {}, freeAgents = [], draftPicks = [] } = {}) {
   const positionGroups = POSITION_GROUPS.map((key) => {
+    const cfg = GROUP_CONFIG[key];
     const players = roster.filter((p) => p?.pos === key);
     const sorted = [...players].sort((a, b) => num(b?.schemeAdjustedOVR ?? b?.ovr) - num(a?.schemeAdjustedOVR ?? a?.ovr));
-    const starterOVR = num(sorted[0]?.schemeAdjustedOVR ?? sorted[0]?.ovr, 0);
-    const topThreeOVR = avg(sorted.slice(0, 3).map((p) => num(p?.schemeAdjustedOVR ?? p?.ovr, 0)));
-    const depthScore = Math.round(topThreeOVR);
-    const ageRisk = Math.round(avg(players.map((p) => Math.max(0, num(p?.age, 26) - 26) * 4)));
-    const injuryRisk = Math.round(avg(players.map((p) => (String(p?.status ?? '').toLowerCase().includes('inj') ? 70 : 20))));
-    const schemeFit = Math.round(avg(players.map((p) => num(p?.schemeFit, 50))));
+    const topWindow = sorted.slice(0, cfg.starterCountExpected);
+    const depthWindow = sorted.slice(0, cfg.depthSlots);
+    const unitOVR = Math.round(avg(depthWindow.map((p) => num(p?.schemeAdjustedOVR ?? p?.ovr, 0))));
+    const starterOVR = Math.round(avg(topWindow.map((p) => num(p?.schemeAdjustedOVR ?? p?.ovr, 0))));
+    const starterCountAvailable = Math.min(cfg.starterCountExpected, sorted.length);
+    const depthScore = Math.round(avg(depthWindow.map((p) => num(p?.schemeAdjustedOVR ?? p?.ovr, 0))));
+    const ageThreshold = cfg.ageThreshold ?? 28;
+    const ageRisk = Math.round(avg(players.map((p) => clamp((num(p?.age, ageThreshold) - ageThreshold) * 8, 0, 100))));
+    const injuryRisk = Math.round(avg(players.map((p) => (String(p?.status ?? '').toLowerCase().includes('inj') ? 70 : 18))));
+    const schemeFit = Math.round(avg(players.map((p) => num(p?.schemeFit, 55))));
     const expiringCount = players.filter((p) => yearsRemaining(p) <= 1).length;
     const contractRisk = players.length ? Math.round((expiringCount / players.length) * 100) : 0;
-    const needScore = (starterOVR < 68 ? 3 : 0) + (depthScore < 65 ? 3 : 0) + (players.length <= 1 ? 4 : 0) + (ageRisk > 45 ? 1 : 0);
-    const needLevel = needScore >= 7 ? 'urgent' : needScore >= 5 ? 'thin' : starterOVR >= 84 && depthScore >= 78 ? 'elite' : starterOVR >= 78 ? 'strong' : 'stable';
+
+    const starterNeed = clamp(80 - starterOVR);
+    const depthNeed = clamp(76 - depthScore + ((cfg.starterCountExpected - starterCountAvailable) * 8));
+    const schemeNeed = clamp(60 - schemeFit);
+    let needScore = Math.round(clamp((starterNeed * cfg.weights.starter + depthNeed * cfg.weights.depth + ageRisk * cfg.weights.age + injuryRisk * cfg.weights.injury + schemeNeed * cfg.weights.scheme + contractRisk * 0.08) * cfg.priority));
+    if (key === 'QB' && starterOVR <= 66) needScore = Math.max(needScore, 68);
+    if (key === 'OL' && depthScore <= 66) needScore = Math.max(needScore, 50);
+
+    const issues = [
+      { key: 'starter_quality', score: starterNeed },
+      { key: 'depth', score: depthNeed },
+      { key: 'age', score: ageRisk },
+      { key: 'injury', score: injuryRisk },
+      { key: 'scheme_fit', score: schemeNeed },
+      { key: 'contract', score: contractRisk },
+    ].sort((a, b) => b.score - a.score);
+    const primaryIssue = players.length === 0 ? 'none' : (issues[0]?.score > 20 ? issues[0].key : 'none');
+    const secondaryIssues = issues.filter((i) => i.key !== primaryIssue && i.score > 18).slice(0, 2).map((i) => i.key);
+    const needLevel = needScore >= 60 ? 'urgent' : needScore >= 45 ? 'thin' : needScore <= 18 && starterOVR >= 83 ? 'elite' : needScore <= 28 ? 'strong' : 'stable';
     const reason = players.length === 0 ? 'Needs more data' : `Starter ${starterOVR} • depth ${depthScore} • ${expiringCount} expiring soon`;
-    return { key, starterOVR, topThreeOVR: Math.round(topThreeOVR), depthScore, ageRisk, injuryRisk, schemeFit, contractRisk, needLevel, reason };
+    const recommendedTargetType = primaryIssue === 'contract' ? 'extension' : primaryIssue === 'age' ? 'draft' : primaryIssue === 'scheme_fit' ? 'training' : primaryIssue === 'depth' ? 'internal_depth' : 'free_agent';
+
+    return { key, label: cfg.label, unitOVR, starterOVR, starterCountExpected: cfg.starterCountExpected, starterCountAvailable, depthScore, ageRisk, injuryRisk, schemeFit, contractRisk, needLevel, needScore, primaryIssue, secondaryIssues, reason, recommendedTargetType };
   });
 
   const capRoom = num(cap?.capRoom ?? team?.capRoom, 0);
@@ -36,20 +79,34 @@ export function buildRosterBuildingAnalysis({ team, roster = [], cap = {}, freeA
     const highValue = num(p?.ovr) >= 82 || (num(p?.potential) - num(p?.ovr) >= 4);
     return { id: p.id, name: p.name, pos: p.pos, age: p.age, ovr: p.ovr, potential: p.potential ?? null, baseAnnual: num(p?.contract?.baseAnnual ?? p?.baseAnnual, null), yearsRemaining: yearsRemaining(p), priority: highValue ? 'must_keep' : num(p?.ovr) >= 74 ? 'consider' : 'replaceable', reason: highValue ? 'Core contributor approaching expiry.' : 'Evaluate market alternatives before re-signing.' };
   });
-
   const valueRisks = roster.filter((p) => num(p?.age) >= 30 && (num(p?.contract?.baseAnnual ?? p?.baseAnnual) >= 12 || num(p?.schemeFit, 50) < 45 || num(p?.ovr) < 72)).slice(0, 5).map((p) => ({ id: p.id, name: p.name, pos: p.pos, age: p.age, ovr: p.ovr, capHit: num(p?.contract?.baseAnnual ?? p?.baseAnnual, 0), reason: 'Possible value risk: age/cost/fit profile may reduce return.' }));
-
   const developmentTargets = roster.filter((p) => num(p?.age) <= 24 && num(p?.potential) > num(p?.ovr) && num(p?.schemeFit, 50) >= 55).sort((a, b) => (num(b?.potential) - num(b?.ovr)) - (num(a?.potential) - num(a?.ovr))).slice(0, 5).map((p) => ({ id: p.id, name: p.name, pos: p.pos, age: p.age, ovr: p.ovr, potential: p.potential, recommendedTrainingGroup: p.pos, reason: 'Young upside with scheme-compatible development path.' }));
+
+  const candidateActions = [];
+  positionGroups.filter((g) => g.needLevel === 'urgent' || g.needLevel === 'thin').slice(0, 3).forEach((group) => {
+    const bench = roster.filter((p) => p?.pos === group.key).sort((a, b) => num(b.ovr) - num(a.ovr))[group.starterCountExpected] ?? null;
+    if (bench) candidateActions.push({ label: `Promote ${bench.name} for ${group.key} depth`, type: 'internal', priority: 'high', playerId: bench.id, playerName: bench.name, pos: bench.pos, ovr: bench.ovr, potential: bench.potential ?? null, age: bench.age ?? null, route: toRoute('internal'), reason: 'Possible internal depth adjustment before external spending.' });
+    const fa = freeAgents.filter((p) => p?.pos === group.key).sort((a, b) => num(b.ovr) - num(a.ovr))[0] ?? null;
+    if (fa) candidateActions.push({ label: `Review best available FA at ${group.key}`, type: 'freeAgency', priority: 'medium', playerId: fa.id, playerName: fa.name, pos: fa.pos, ovr: fa.ovr, potential: fa.potential ?? null, age: fa.age ?? null, baseAnnual: num(fa?.contract?.baseAnnual ?? fa?.baseAnnual, null), route: toRoute('freeAgency'), reason: 'Possible short-term patch if fit and budget align.' });
+    if (!fa && (payrollPressure === 'high' || payrollPressure === 'critical' || valueRisks.length > 0)) candidateActions.push({ label: `Scan trade market for ${group.key}`, type: 'trade', priority: 'medium', pos: group.key, route: toRoute('trade'), reason: 'No clear FA option in cache; trade exploration may be required.' });
+    if (draftPicks.length > 0) candidateActions.push({ label: `Queue ${group.key} for draft board`, type: 'draft', priority: 'low', pos: group.key, route: toRoute('draft'), reason: 'Rookie contracts can stabilize medium-term roster depth.' });
+    const dev = developmentTargets.find((p) => p.pos === group.key);
+    if (dev) candidateActions.push({ label: `Boost ${group.key} development reps`, type: 'training', priority: 'medium', playerId: dev.id, playerName: dev.name, pos: dev.pos, ovr: dev.ovr, potential: dev.potential, age: dev.age, route: toRoute('training'), reason: 'Young player upside can address need internally over time.' });
+  });
+
+  if (!candidateActions.some((a) => a.type === 'training') && developmentTargets[0]) {
+    const dev = developmentTargets[0];
+    candidateActions.push({ label: `Develop ${dev.pos} pipeline reps`, type: 'training', priority: 'low', playerId: dev.id, playerName: dev.name, pos: dev.pos, ovr: dev.ovr, potential: dev.potential, age: dev.age, route: toRoute('training'), reason: 'Possible internal growth path from current development targets.' });
+  }
 
   const urgent = positionGroups.find((g) => g.needLevel === 'urgent') ?? positionGroups.find((g) => g.needLevel === 'thin');
   const recommendedActions = [
-    urgent ? { label: `Find ${urgent.key} depth before advancing`, priority: 'high', targetArea: 'depth', route: 'Team:Roster / Depth', reason: urgent.reason } : null,
-    expiringContracts[0] ? { label: `Review ${expiringContracts[0].pos} extension decision`, priority: 'high', targetArea: 'extension', route: 'Team:Roster / Depth', reason: expiringContracts[0].reason } : null,
+    ...candidateActions.slice(0, 3),
+    expiringContracts[0] ? { label: `Review ${expiringContracts[0].pos} extension decision`, priority: 'high', targetArea: 'extension', route: 'Contract Center', reason: expiringContracts[0].reason } : null,
     payrollPressure === 'high' || payrollPressure === 'critical' ? { label: 'Audit cap pressure and restructure options', priority: 'high', targetArea: 'trade', route: 'Cap Manager', reason: 'Limited cap room may block near-term moves.' } : null,
     developmentTargets[0] ? { label: `Train ${developmentTargets[0].pos} group this week`, priority: 'medium', targetArea: 'training', route: 'Training', reason: developmentTargets[0].reason } : null,
-    freeAgents.length > 0 && urgent ? { label: `Check free agency for ${urgent.key}`, priority: 'medium', targetArea: 'freeAgency', route: 'Free Agency', reason: 'Need flagged and market appears available.' } : null,
     draftPicks.length > 0 && urgent ? { label: `Prioritize ${urgent.key} on draft board`, priority: 'low', targetArea: 'draft', route: 'Draft', reason: 'Roster pressure can be buffered with rookie contracts.' } : null,
   ].filter(Boolean).slice(0, 6);
 
-  return { positionGroups, capSummary, expiringContracts, valueRisks, developmentTargets, recommendedActions };
+  return { positionGroups, capSummary, expiringContracts, valueRisks, developmentTargets, candidateActions: candidateActions.slice(0, 12), recommendedActions };
 }

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -108,6 +108,18 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
 
   const decisionReview = useMemo(() => command.weeklyDecisionImpact ?? null, [command.weeklyDecisionImpact]);
 
+  const hqTeamBuilder = useMemo(() => {
+    const roster = Array.isArray(userTeam?.roster) ? userTeam.roster : [];
+    const byPos = ['QB','RB','WR','TE','OL','DL','LB','CB','S'].map((pos) => ({ pos, players: roster.filter((p) => p?.pos === pos).sort((a,b)=>safeNum(b?.ovr)-safeNum(a?.ovr)) }));
+    const weakest = byPos.map((g) => ({ pos: g.pos, top: safeNum(g.players[0]?.ovr, 0), depth: g.players.length })).sort((a,b)=>(a.top + a.depth*2)-(b.top + b.depth*2))[0] ?? null;
+    const capPressure = safeNum(userTeam?.capRoom, 0) < 0 ? 'critical' : safeNum(userTeam?.capRoom, 0) < 10 ? 'high' : 'managed';
+    return {
+      biggestNeed: weakest?.pos ?? 'Needs more data',
+      capPressure,
+      nextAction: weakest ? `Review ${weakest.pos} starter/depth plan` : 'Review roster needs',
+    };
+  }, [userTeam]);
+
   const nextOpponents = useMemo(() => (league?.schedule?.weeks ?? [])
     .filter((week) => safeNum(week?.week, 0) >= safeNum(league?.week, 1))
     .flatMap((week) => (week?.games ?? []).map((game) => ({ ...game, week: week.week })))
@@ -192,6 +204,15 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
           {weeklyIntel.map((insight) => (
             <p key={insight.id} role="listitem" className={`app-hq-intel-item tone-${insight.tone ?? 'info'}`}>{insight.text}</p>
           ))}
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Roster Needs" subtitle="Quick Team Builder snapshot for weekly personnel calls." variant="compact">
+        <div className="app-hq-intel-list" role="list" aria-label="Roster needs snapshot">
+          <p role="listitem" className="app-hq-intel-item tone-warning">Biggest need: <strong>{hqTeamBuilder.biggestNeed}</strong></p>
+          <p role="listitem" className="app-hq-intel-item tone-info">Cap pressure: <strong>{hqTeamBuilder.capPressure}</strong></p>
+          <p role="listitem" className="app-hq-intel-item tone-info">Next roster action: {hqTeamBuilder.nextAction}</p>
+          <Button size="sm" onClick={() => onNavigate?.('Team:Roster / Team Builder')}>Open Team Builder</Button>
         </div>
       </SectionCard>
 

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -2295,17 +2295,38 @@ export default function Roster({ league, actions, onPlayerSelect, onNavigate = n
       />
       {teamBuilder ? (
         <Card className="card-premium" style={{ marginBottom: "var(--space-2)", padding: "var(--space-3) var(--space-4)" }}>
-          <CardContent style={{ display: "grid", gap: 8 }}>
-            <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 800, textTransform: "uppercase", letterSpacing: ".08em" }}>
-              Roster Building Command Center
-            </div>
+          <CardContent style={{ display: "grid", gap: 10 }}>
+            <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 800, textTransform: "uppercase", letterSpacing: ".08em" }}>Team Builder Workspace</div>
             <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
               <Badge variant={teamBuilder?.capSummary?.payrollPressure === 'critical' ? 'destructive' : 'outline'}>Cap pressure: {teamBuilder?.capSummary?.payrollPressure ?? 'needs data'}</Badge>
               <Badge variant={urgentNeed?.needLevel === 'urgent' ? 'destructive' : 'secondary'}>Biggest need: {urgentNeed?.key ?? 'Needs more data'}</Badge>
-              <Badge variant="outline">Expiring: {teamBuilder?.expiringContracts?.length ?? 0}</Badge>
-              <Badge variant="outline">Dev targets: {teamBuilder?.developmentTargets?.length ?? 0}</Badge>
+              <Badge variant="outline">Top expiring: {teamBuilder?.expiringContracts?.[0]?.name ?? '—'}</Badge>
+              <Badge variant="outline">Best dev target: {teamBuilder?.developmentTargets?.[0]?.name ?? '—'}</Badge>
             </div>
-            {nextAction ? <div style={{ fontSize: "var(--text-xs)" }}>Next best move: <strong>{nextAction.label}</strong> — {nextAction.reason}</div> : null}
+            {nextAction ? <div style={{ fontSize: "var(--text-xs)" }}>Next best action: <strong>{nextAction.label}</strong> — {nextAction.reason}</div> : null}
+            <div style={{ display: 'grid', gap: 6 }}>
+              <div style={{ fontSize: "var(--text-xs)", fontWeight: 700 }}>Position Needs Board</div>
+              <div style={{ display: 'grid', gap: 6 }}>
+                {(teamBuilder?.positionGroups ?? []).map((g) => (
+                  <button key={g.key} type="button" className="btn" style={{ textAlign: 'left', padding: '8px 10px', border: '1px solid var(--hairline)', borderRadius: 8, background: g.needLevel === 'urgent' ? 'rgba(255,69,58,0.15)' : 'transparent' }} onClick={() => { setViewMode('table'); setInitialFilter(g.key); }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, fontSize: 'var(--text-xs)' }}>
+                      <strong>{g.key} • {g.needLevel}</strong>
+                      <span>Unit {g.unitOVR ?? 0}</span>
+                    </div>
+                    <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>Starters {g.starterCountAvailable}/{g.starterCountExpected} • {g.primaryIssue?.replace('_', ' ') ?? 'none'}</div>
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div style={{ display: 'grid', gap: 6 }}>
+              <div style={{ fontSize: "var(--text-xs)", fontWeight: 700 }}>Action Queue</div>
+              {(teamBuilder?.candidateActions ?? []).slice(0, 6).map((action, idx) => (
+                <div key={`${action.type}-${idx}`} style={{ fontSize: 'var(--text-xs)', display: 'flex', justifyContent: 'space-between', gap: 8 }}>
+                  <span><strong>{action.label}</strong> — {action.reason}</span>
+                  {action.route ? <Button size="sm" variant="outline" onClick={() => onNavigate?.(action.route)}>{action.type}</Button> : null}
+                </div>
+              ))}
+            </div>
           </CardContent>
         </Card>
       ) : null}


### PR DESCRIPTION
### Motivation
- Upgrade the shallow Roster snapshot into a practical, mobile-first Team Builder workspace that surfaces urgent needs and next clicks without rewriting roster flows.
- Improve `buildRosterBuildingAnalysis` so position-specific concerns (QB starter dominance, RB age risk, WR top-3, OL top-5, DL/LB/CB/S starter windows) drive need scoring and recommendations.
- Provide actionable, data-driven candidate options (internal, FA, trade, draft, training) based only on inputs already available from `GET_ROSTER` and cached market data. 

### Description
- Extended `buildRosterBuildingAnalysis` with a `GROUP_CONFIG` table and position-aware windows and weights, returning richer `positionGroups` fields including `unitOVR`, `starterOVR`, `starterCountExpected`, `starterCountAvailable`, `depthScore`, `ageRisk`, `injuryRisk`, `schemeFit`, `contractRisk`, `needLevel`, `needScore`, `primaryIssue`, `secondaryIssues`, `reason`, and `recommendedTargetType` (`src/core/rosterBuildingAnalysis.js`).
- Added `candidateActions` generation using real `roster`, `freeAgents`, `draftPicks`, `developmentTargets`, and cap signals to produce cautious recommendations of types `internal`, `freeAgency`, `trade`, `draft`, `training` and a flagged `extension` in recommended actions, plus route hints but no fabricated players. (`src/core/rosterBuildingAnalysis.js`).
- Upgraded the Roster UI to embed a compact Team Builder workspace (Team Builder Snapshot, Position Needs Board with click-to-filter, and Action Queue) while preserving existing roster/depth UI and mobile-first layout; action buttons use existing `onNavigate` routes when available (`src/ui/components/Roster.jsx`).
- Added a small “Roster Needs” snapshot card to Franchise HQ to surface biggest need, cap pressure, and a CTA into the Team Builder without redesigning HQ (`src/ui/components/FranchiseHQ.jsx`).
- Kept helper pure and worker integration unchanged other than feeding the expanded analysis into the `ROSTER_DATA` payload; did not touch simulation formulas or core roster/trade/FA mechanics.  

### Testing
- Ran `npm run test:unit -- src/core/__tests__/rosterBuildingAnalysis.test.ts` and the updated test suite passed (all tests in that file succeeded). 
- Ran `npm run test:unit -- src/core/__tests__/narrative.test.ts src/ui/components/BoxScore.test.jsx src/ui/components/WeeklyResultsCenter.test.jsx` and all tests passed. 
- Ran `npm run test:unit -- src/ui/components/__tests__/FranchiseHQ.test.jsx` and the HQ UI test passed. 
- Notes: tests exercised QB urgency, WR/OL windows, RB age risk, starter-count expectations, FA candidate presence/absence, development→training candidate creation, value-risk detection, and missing-data safety; all automated checks listed above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39c4f1184832d8763887313b31680)