### PR TITLE
Extract shared sport time-unit label helper (Week/Wk) for UI

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -50,7 +50,7 @@ import MilestoneModal      from './components/MilestoneModal.jsx';
 import ThemeToggle         from './components/ThemeToggle.jsx';
 import EventDecisionModal from './components/EventDecisionModal.jsx';
 import { SettingsProvider, useSettings } from './context/SettingsContext.jsx';
-import { ACTION_LABELS } from './constants/navigationCopy.js';
+import { ACTION_LABELS, formatRegularUnitLabel } from './constants/navigationCopy.js';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from './utils/boxScoreAccess.js';
 import { buildOffseasonActionCenter } from './utils/offseasonActionCenter.js';
 import {
@@ -490,7 +490,7 @@ function AppContent() {
       const roundNames = { 19: 'Wild Card', 20: 'Divisional', 21: 'Conf. Champ', 22: 'Super Bowl' };
       return `▶ ${roundNames[league.week] || `Playoffs Wk ${league.week}`}`;
     }
-    return `▶ Advance Week ${league.week}`;
+    return `▶ Advance ${formatRegularUnitLabel(league.week)}`;
   };
 
   const safePhase = league?.phase ?? null;

--- a/src/ui/constants/navigationCopy.js
+++ b/src/ui/constants/navigationCopy.js
@@ -14,3 +14,13 @@ export const ACTION_LABELS = Object.freeze({
   working: 'Working...',
   more: 'More',
 });
+
+export const SPORT_TIME_COPY = Object.freeze({
+  regularUnitLabel: 'Week',
+  shorthandUnitLabel: 'Wk',
+});
+
+export function formatRegularUnitLabel(value, { short = false } = {}) {
+  const prefix = short ? SPORT_TIME_COPY.shorthandUnitLabel : SPORT_TIME_COPY.regularUnitLabel;
+  return `${prefix} ${value}`;
+}

--- a/src/ui/utils/franchiseCommandCenter.js
+++ b/src/ui/utils/franchiseCommandCenter.js
@@ -10,6 +10,7 @@ import { applyEventDecision, pickWorstEventChoice, resolveWeeklyEvent } from './
 import { buildWeeklyIntelligence, buildActionableWeeklyPriorities } from './weeklyIntelligence.js';
 import { buildGamePlanImpact, buildPostGameReview } from './gamePlanImpact.js';
 import { buildWeeklyDecisionImpact } from './weeklyDecisionImpact.js';
+import { formatRegularUnitLabel } from '../constants/navigationCopy.js';
 
 function safeNum(value, fallback = 0) {
   const n = Number(value);
@@ -490,7 +491,7 @@ export function selectFranchiseHQViewModel(league) {
   return {
     readyState: 'ready',
     seasonLabel: `${vm.league?.year ?? 'Season'} · ${String(vm.league?.phase ?? 'regular').replaceAll('_', ' ')}`,
-    weekLabel: `Week ${vm.league?.week ?? 1}`,
+    weekLabel: formatRegularUnitLabel(vm.league?.week ?? 1),
     teamRecord: formatRecord(team),
     nextOpponent: nextGame?.opp?.name ?? 'TBD',
     nextOpponentRecord: nextGame?.opp ? formatRecord(nextGame.opp) : '—',

--- a/tests/unit/navigation_copy.test.js
+++ b/tests/unit/navigation_copy.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { NAV_LABELS, ACTION_LABELS } from "../../src/ui/constants/navigationCopy.js";
+import { NAV_LABELS, ACTION_LABELS, formatRegularUnitLabel } from "../../src/ui/constants/navigationCopy.js";
 
 describe("navigation copy", () => {
   it("keeps the shell navigation labels canonical", () => {
@@ -11,5 +11,10 @@ describe("navigation copy", () => {
 
   it("uses one shared wording for top-level overflow actions", () => {
     expect(NAV_LABELS.more).toBe(ACTION_LABELS.more);
+  });
+
+  it("formats regular-season time unit labels from one helper", () => {
+    expect(formatRegularUnitLabel(7)).toBe("Week 7");
+    expect(formatRegularUnitLabel(12, { short: true })).toBe("Wk 12");
   });
 });


### PR DESCRIPTION
### Motivation
- Centralize the repeated football time-unit copy (`Week` / `Wk`) into a single, sport-configurable helper as a low-risk seam to enable future multi-sport labeling without touching simulation, roster, or schedule logic. 

### Description
- Added `SPORT_TIME_COPY` and `formatRegularUnitLabel()` to `src/ui/constants/navigationCopy.js`, switched the App advance-action label and the HQ `weekLabel` to use the helper (`src/ui/App.jsx`, `src/ui/utils/franchiseCommandCenter.js`), and extended `tests/unit/navigation_copy.test.js` to cover both full and shorthand outputs; no simulation, roster, or routing behavior changed. 

### Testing
- Ran `npx vitest run tests/unit/navigation_copy.test.js` which passed (1 test file, 3 tests); no other test groups were run as this is a targeted, UI-copy change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39ec48aa0832db45158728fe9aa31)