### PR TITLE
Weekly Command Hub v2 for Franchise HQ action consolidation

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { autoBuildDepthChart, depthWarnings } from '../../core/depthChart.js';
 import { markWeeklyPrepStep } from '../utils/weeklyPrep.js';
 import { selectFranchiseHQViewModel } from '../utils/franchiseCommandCenter.js';
+import { buildWeeklyCommandHub } from '../utils/weeklyCommandHub.js';
 import { EmptyState, StatusChip, ActionTile, SectionCard, WeeklyAgenda, CompactNewsCard } from './ScreenSystem.jsx';
 import { getLastGameDisplay, getLatestUserCompletedGame, getNextOpponentDisplay } from '../utils/hqGameDisplay.js';
 import { HQIcon, TeamIdentityBadge } from './HQVisuals.jsx';
@@ -120,6 +121,20 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
     };
   }, [userTeam]);
 
+
+
+  const weeklyCommandHub = useMemo(() => buildWeeklyCommandHub({
+    league,
+    userTeam,
+    command,
+    teamBuilder: hqTeamBuilder,
+    weeklyDecisionImpact: decisionReview,
+    gamePlanImpact: command.gamePlanImpact,
+    weeklyIntelligence: command.weeklyIntelligence,
+    nextGame: command.nextGame,
+    lastGame,
+  }), [league, userTeam, command, hqTeamBuilder, decisionReview, lastGame]);
+
   const nextOpponents = useMemo(() => (league?.schedule?.weeks ?? [])
     .filter((week) => safeNum(week?.week, 0) >= safeNum(league?.week, 1))
     .flatMap((week) => (week?.games ?? []).map((game) => ({ ...game, week: week.week })))
@@ -207,12 +222,32 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
         </div>
       </SectionCard>
 
-      <SectionCard title="Roster Needs" subtitle="Quick Team Builder snapshot for weekly personnel calls." variant="compact">
-        <div className="app-hq-intel-list" role="list" aria-label="Roster needs snapshot">
-          <p role="listitem" className="app-hq-intel-item tone-warning">Biggest need: <strong>{hqTeamBuilder.biggestNeed}</strong></p>
-          <p role="listitem" className="app-hq-intel-item tone-info">Cap pressure: <strong>{hqTeamBuilder.capPressure}</strong></p>
-          <p role="listitem" className="app-hq-intel-item tone-info">Next roster action: {hqTeamBuilder.nextAction}</p>
-          <Button size="sm" onClick={() => onNavigate?.('Team:Roster / Team Builder')}>Open Team Builder</Button>
+
+
+      <SectionCard title="Weekly Command Hub" subtitle="Ranked actions for this week before you advance." variant="compact">
+        <div className="app-hq-intel-list">
+          {(weeklyCommandHub.sections ?? []).map((section) => (
+            <div key={section.key} className="app-hq-impact-card" style={{ marginBottom: 8 }}>
+              <div className="app-hq-impact-card__head">
+                <strong>{section.title}</strong>
+                <StatusChip label={`${section.actions.length} action${section.actions.length === 1 ? '' : 's'}`} tone={section.tone === 'danger' ? 'warning' : 'info'} />
+              </div>
+              {section.actions.length ? section.actions.map((action) => (
+                <button
+                  key={action.id}
+                  type="button"
+                  className="btn btn-sm app-hq-impact-card__cta"
+                  style={{ width: '100%', minHeight: 44, textAlign: 'left', marginTop: 6 }}
+                  disabled={!action.route}
+                  onClick={() => action.route && onNavigate?.(action.route)}
+                  aria-label={`${section.title}: ${action.label}`}
+                >
+                  <strong>{action.label}</strong>
+                  <span style={{ display: 'block', opacity: 0.85 }}>{action.detail}</span>
+                </button>
+              )) : <p className="app-hq-intel-item tone-info">No actions right now.</p>}
+            </div>
+          ))}
         </div>
       </SectionCard>
 
@@ -233,19 +268,10 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
         </div>
       </SectionCard>
 
-      <section className="app-section-stack" aria-label="This Week Action Center">
-        <h2 className="app-section-heading">Prepare for Kickoff</h2>
-        <div className="app-action-grid-2x2">
-          {actionTiles.map((action) => (
-            <ActionTile key={action.title} icon={action.icon} title={action.title} subtitle={action.subtitle} badge={action.badge ? <StatusChip label={action.badge} tone="warning" /> : null} onClick={action.onClick} tone="info" ariaLabel={`${action.title}: ${action.subtitle}`} />
-          ))}
-        </div>
-      </section>
+
       {lineupToast ? <p className="app-inline-toast" role="status" aria-live="polite">{lineupToast}</p> : null}
 
-      <SectionCard title="Week Command" subtitle="What needs attention, why it matters, and where to handle it." variant="compact">
-        <WeeklyAgenda items={(command.weeklyAgenda ?? []).slice(0, 3)} onOpenTask={(task) => onNavigate?.(task?.targetRoute ?? task?.tab ?? 'HQ')} />
-      </SectionCard>
+
 
 
       <SectionCard title={decisionReview?.heading ?? 'What Mattered Last Week'} subtitle={decisionReview?.resultSummary ?? 'Run a completed game to unlock a weekly decision review.'} variant="compact">
@@ -294,6 +320,19 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
           {!command.leagueNews?.length ? <EmptyState title="No league headlines yet." body="Advance to generate weekly stories." /> : null}
         </div>
       </SectionCard>
+
+      <section className="card" aria-label="Advance readiness">
+        <p className="app-hq-intel-item tone-info">
+          {weeklyCommandHub.readiness.readyToAdvance ? 'Ready to advance.' : `${weeklyCommandHub.readiness.criticalOpen} critical item open.`} {' '}
+          {weeklyCommandHub.readiness.recommendedOpen ? `${weeklyCommandHub.readiness.recommendedOpen} recommended actions remaining.` : 'No recommended actions remaining.'}
+          {weeklyCommandHub.readiness.lastCompletedAction ? ` Last review: ${weeklyCommandHub.readiness.lastCompletedAction}.` : ''}
+        </p>
+        {weeklyCommandHub.primaryAction?.blocking ? (
+          <button type="button" className="btn btn-sm app-hq-impact-card__cta" onClick={() => onNavigate?.(weeklyCommandHub.primaryAction.route)}>
+            Resolve blocker: {weeklyCommandHub.primaryAction.label}
+          </button>
+        ) : null}
+      </section>
 
       <div className="app-hq-sticky-advance">
         <Button className="app-command-advance app-command-advance-gold" onClick={onAdvanceWeek} disabled={busy || simulating} aria-label={`Advance Week — move from ${command.weekLabel} to next week`} title="Advance Week">

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -52,26 +52,22 @@ describe('FranchiseHQ', () => {
     expect(screen.getByRole('heading', { name: /week 10/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /advance week/i })).toBeTruthy();
     expect(screen.getAllByRole('button', { name: /advance week/i })).toHaveLength(1);
-    expect(screen.getByRole('button', { name: /^game plan:/i })).toBeTruthy();
-    expect(screen.getByRole('button', { name: /^set lineup:/i })).toBeTruthy();
-    expect(screen.getByRole('button', { name: /^training:/i })).toBeTruthy();
-    expect(screen.getByRole('button', { name: /^scout opponent:/i })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /weekly command hub/i })).toBeTruthy();
+    expect(screen.getByText(/must handle/i)).toBeTruthy();
+    expect(screen.getByText(/tactical edge/i)).toBeTruthy();
     expect(screen.getByRole('heading', { name: /coordinator brief/i })).toBeTruthy();
     expect(screen.getAllByRole('heading', { name: /game plan impact/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/home matchup vs det/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/ratings are tightly clustered/i)).toBeTruthy();
-    expect(screen.getByText(/open roster \/ depth/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /tactical edge: review game plan/i })).toBeTruthy();
   });
 
-  it('routes Game Plan Impact and review CTAs through onNavigate', () => {
+  it('routes weekly command hub action through onNavigate', () => {
     const onNavigate = vi.fn();
     const view = render(<FranchiseHQ league={baseLeague} onNavigate={onNavigate} onAdvanceWeek={() => {}} busy={false} simulating={false} />);
 
-    fireEvent.click(within(view.container).getAllByRole('button', { name: /attack plan: tune game plan/i })[0]);
-    fireEvent.click(within(view.container).getAllByRole('button', { name: /open weekly results/i })[0]);
-
+    fireEvent.click(within(view.container).getAllByRole('button', { name: /tactical edge: review game plan/i })[0]);
     expect(onNavigate).toHaveBeenCalledWith('Game Plan');
-    expect(onNavigate).toHaveBeenCalledWith('Weekly Results:9');
   });
 
 
@@ -80,6 +76,7 @@ describe('FranchiseHQ', () => {
     render(<FranchiseHQ league={baseLeague} onNavigate={onNavigate} onAdvanceWeek={() => {}} busy={false} simulating={false} />);
 
     expect(screen.getAllByRole('heading', { name: /what mattered last week|decision review/i }).length).toBeGreaterThan(0);
+    expect(screen.queryByRole('heading', { name: /roster needs/i })).toBeNull();
     const button = screen.getByRole('button', { name: /decision review:/i });
     fireEvent.click(button);
     expect(onNavigate).toHaveBeenCalled();

--- a/src/ui/utils/weeklyCommandHub.js
+++ b/src/ui/utils/weeklyCommandHub.js
@@ -1,0 +1,190 @@
+function safeNum(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+const PRIORITY_WEIGHT = { critical: 0, high: 1, medium: 2, low: 3 };
+
+function byPriority(a, b) {
+  const pa = PRIORITY_WEIGHT[a?.priority] ?? 9;
+  const pb = PRIORITY_WEIGHT[b?.priority] ?? 9;
+  if (pa !== pb) return pa - pb;
+  return String(a?.label ?? '').localeCompare(String(b?.label ?? ''));
+}
+
+function hasValue(value) {
+  return value !== null && value !== undefined && value !== '';
+}
+
+export function buildWeeklyCommandHub({
+  league,
+  userTeam,
+  command,
+  teamBuilder,
+  weeklyDecisionImpact,
+  gamePlanImpact,
+  weeklyIntelligence,
+  nextGame,
+  lastGame,
+} = {}) {
+  const team = userTeam ?? (league?.teams ?? []).find((t) => Number(t?.id) === Number(league?.userTeamId)) ?? null;
+  const prepState = team?.weeklyPrep ?? {};
+  const actions = [];
+
+  const injuredStarters = Array.isArray(team?.roster)
+    ? team.roster.filter((player) => {
+      const weeks = safeNum(player?.injury?.gamesRemaining ?? player?.injuryWeeksRemaining ?? player?.injury?.weeksRemaining, 0);
+      const starter = hasValue(player?.depthChart?.rowKey) || player?.depthChart?.isStarter === true;
+      return weeks > 0 && starter;
+    })
+    : [];
+
+  if (injuredStarters.length) {
+    actions.push({
+      id: 'injured-starters',
+      label: `${injuredStarters.length} injured starter${injuredStarters.length > 1 ? 's' : ''}`,
+      detail: 'Availability risk can impact this week’s lineup and game plan.',
+      priority: injuredStarters.length > 1 ? 'critical' : 'high',
+      route: 'Team:Injuries',
+      ctaLabel: 'Review injuries',
+      source: 'injury',
+      blocking: injuredStarters.length > 1,
+      completed: false,
+      section: 'must_handle',
+    });
+  }
+
+  const weekly = weeklyIntelligence ?? command?.weeklyIntelligence ?? {};
+  const urgentNeed = teamBuilder?.urgentNeed ?? teamBuilder?.biggestNeed ?? weekly?.urgentNeed ?? null;
+  if (urgentNeed) {
+    actions.push({
+      id: 'urgent-roster-need',
+      label: `Roster need: ${urgentNeed}`,
+      detail: 'Team Builder flagged this as the top personnel issue for upcoming games.',
+      priority: 'high',
+      route: 'Team:Roster / Team Builder',
+      ctaLabel: 'Open Team Builder',
+      source: 'roster',
+      blocking: false,
+      completed: false,
+      section: 'must_handle',
+    });
+  }
+
+  const depthBlocked = Array.isArray(weekly?.insights) && weekly.insights.some((i) => /depth|starter|lineup/i.test(String(i?.text ?? '')) && (i?.tone === 'danger' || i?.tone === 'warning'));
+  if (depthBlocked) {
+    actions.push({
+      id: 'depth-watch',
+      label: 'Depth chart risk detected',
+      detail: 'Review lineup/depth before kickoff to prevent avoidable drop-off.',
+      priority: 'high',
+      route: 'Team:Roster / Depth',
+      ctaLabel: 'Open depth chart',
+      source: 'depth',
+      blocking: true,
+      completed: false,
+      section: 'must_handle',
+    });
+  }
+
+  const planReviewed = prepState.planReviewed === true;
+  if (!planReviewed) {
+    actions.push({
+      id: 'game-plan-review',
+      label: 'Review game plan',
+      detail: gamePlanImpact?.summary ?? 'Adjust approach using this week’s opponent profile.',
+      priority: 'high',
+      route: 'Game Plan',
+      ctaLabel: 'Open Game Plan',
+      source: 'gamePlan',
+      blocking: false,
+      completed: false,
+      section: 'tactical_edge',
+    });
+  }
+
+  if (prepState.trainingCompleted !== true) {
+    actions.push({
+      id: 'training-focus',
+      label: 'Set training focus',
+      detail: 'Lock weekly development priorities before advancing.',
+      priority: 'medium',
+      route: 'Training',
+      ctaLabel: 'Open Training',
+      source: 'training',
+      blocking: false,
+      completed: false,
+      section: 'tactical_edge',
+    });
+  }
+
+  if (prepState.opponentScouted !== true) {
+    actions.push({
+      id: 'scout-opponent',
+      label: 'Scout opponent',
+      detail: nextGame?.opp?.abbr ? `Build report for ${nextGame.opp.abbr}.` : 'Build this week’s scouting report.',
+      priority: 'medium',
+      route: 'Weekly Prep',
+      ctaLabel: 'Open scouting',
+      source: 'scout',
+      blocking: false,
+      completed: false,
+      section: 'tactical_edge',
+    });
+  }
+
+  const hasCompletedGame = Boolean(lastGame?.played || weeklyDecisionImpact?.metadata?.gameId || command?.lastGameSummary?.played);
+  if (hasCompletedGame) {
+    const gameBookRoute = weeklyDecisionImpact?.metadata?.gameId ? `Game Book:${weeklyDecisionImpact.metadata.gameId}` : 'Weekly Results';
+    actions.push({
+      id: 'postgame-film-room',
+      label: 'Review Postgame Film Room',
+      detail: 'Use Game Book and result review before locking next week.',
+      priority: 'medium',
+      route: gameBookRoute,
+      ctaLabel: 'Open Game Book',
+      source: 'results',
+      blocking: false,
+      completed: false,
+      section: 'after_action',
+    });
+  }
+
+  if ((command?.leagueNews ?? []).length) {
+    actions.push({
+      id: 'league-news',
+      label: 'Scan league headlines',
+      detail: 'Optional context for market and standings movement.',
+      priority: 'low',
+      route: 'News',
+      ctaLabel: 'Open news',
+      source: 'news',
+      blocking: false,
+      completed: false,
+      section: 'after_action',
+    });
+  }
+
+  const sections = [
+    { key: 'must_handle', title: 'Must Handle', tone: 'danger', actions: actions.filter((a) => a.section === 'must_handle').sort(byPriority) },
+    { key: 'tactical_edge', title: 'Tactical Edge', tone: 'info', actions: actions.filter((a) => a.section === 'tactical_edge').sort(byPriority) },
+    { key: 'after_action', title: 'After Action', tone: 'neutral', actions: actions.filter((a) => a.section === 'after_action').sort(byPriority) },
+  ];
+
+  const ranked = [...actions].sort(byPriority);
+  const criticalOpen = ranked.filter((a) => a.priority === 'critical' && !a.completed).length;
+  const recommendedOpen = ranked.filter((a) => (a.priority === 'high' || a.priority === 'medium') && !a.completed).length;
+
+  return {
+    status: ranked.length ? (criticalOpen ? 'needs-attention' : 'ready') : 'ready',
+    primaryAction: ranked[0] ?? null,
+    sections,
+    readiness: {
+      criticalOpen,
+      recommendedOpen,
+      readyToAdvance: criticalOpen === 0,
+      lastCompletedAction: weeklyDecisionImpact?.recommendedAction?.label ?? null,
+    },
+    actions: ranked,
+  };
+}

--- a/src/ui/utils/weeklyCommandHub.test.js
+++ b/src/ui/utils/weeklyCommandHub.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { buildWeeklyCommandHub } from './weeklyCommandHub.js';
+
+describe('buildWeeklyCommandHub', () => {
+  it('creates must-handle action for injured starter', () => {
+    const result = buildWeeklyCommandHub({ league: { userTeamId: 1, teams: [{ id: 1, roster: [{ id: 10, depthChart: { rowKey: 'QB1' }, injury: { gamesRemaining: 2 } }] }] } });
+    expect(result.sections[0].actions.some((a) => a.id === 'injured-starters')).toBe(true);
+  });
+
+  it('creates must-handle action for urgent roster need', () => {
+    const result = buildWeeklyCommandHub({ teamBuilder: { urgentNeed: 'OL' } });
+    expect(result.sections[0].actions.some((a) => /roster need/i.test(a.label))).toBe(true);
+  });
+
+  it('creates tactical edge for game plan and training when incomplete', () => {
+    const result = buildWeeklyCommandHub({ league: { userTeamId: 1, teams: [{ id: 1, weeklyPrep: {} }] } });
+    expect(result.sections[1].actions.some((a) => a.id === 'game-plan-review')).toBe(true);
+    expect(result.sections[1].actions.some((a) => a.id === 'training-focus')).toBe(true);
+  });
+
+  it('creates after action game book action after completed game', () => {
+    const result = buildWeeklyCommandHub({ lastGame: { played: true } });
+    expect(result.sections[2].actions.some((a) => a.id === 'postgame-film-room')).toBe(true);
+  });
+
+  it('sorts critical above medium/low', () => {
+    const result = buildWeeklyCommandHub({
+      league: { userTeamId: 1, teams: [{ id: 1, weeklyPrep: {}, roster: [{ depthChart: { rowKey: 'QB1' }, injury: { gamesRemaining: 3 } }, { depthChart: { rowKey: 'WR1' }, injury: { gamesRemaining: 2 } }] }] },
+    });
+    expect(result.actions[0].priority).toBe('critical');
+  });
+
+  it('does not crash with missing data', () => {
+    const result = buildWeeklyCommandHub({});
+    expect(result.status).toBe('ready');
+  });
+});


### PR DESCRIPTION
### Motivation
- The Franchise HQ was becoming vertically long and card-heavy with multiple cards answering “what should I do next?”, causing duplicate guidance and slow mobile scanning. 
- Provide a single, ranked command model so the HQ shows 3–6 compact actions that deep-link to the exact fix and speed the weekly loop. 

### Description
- Added a pure helper `buildWeeklyCommandHub` that consolidates overlapping guidance into three compact sections (`Must Handle`, `Tactical Edge`, `After Action`) and returns `status`, `primaryAction`, `sections`, `readiness`, and `actions` (file: `src/ui/utils/weeklyCommandHub.js`).
- Rendered a new `Weekly Command Hub` card in `FranchiseHQ` beneath the hero, replaced the full `Roster Needs` card and the grid `Prepare for Kickoff` tiles with compact 44px+ tap rows, and collapsed the old `Week Command` card into the hub (file: `src/ui/components/FranchiseHQ.jsx`).
- Hub action model fields include `id`, `label`, `detail`, `priority` (`critical`/`high`/`medium`/`low`), `route`, `ctaLabel`, `source`, `blocking`, and `completed`, plus advance readiness rollup with `criticalOpen`/`recommendedOpen` and `lastCompletedAction`.
- Kept `Game Plan Impact` tactical detail as a separate card and preserved `Decision Review` and `Operations Snapshot` content while surfacing their actionable items through the hub; deep-link routes are disabled (rendered inert) if unavailable to avoid broken navigation.

### Testing
- Added unit tests for the hub (`src/ui/utils/weeklyCommandHub.test.js`) covering injured starter, urgent roster need, game plan/training, postgame film room, priority sorting, and safe fallback when data is missing, and updated HQ tests (`src/ui/components/__tests__/FranchiseHQ.test.jsx`) to validate hub rendering and routing.
- Ran `npm run test:unit -- src/ui/utils/weeklyCommandHub.test.js src/ui/components/__tests__/FranchiseHQ.test.jsx` and `npm run test:unit -- src/core/__tests__/rosterBuildingAnalysis.test.ts src/core/__tests__/narrative.test.ts src/ui/components/BoxScore.test.jsx src/ui/components/WeeklyResultsCenter.test.jsx`, and all targeted unit tests passed.
- Known limitations: the helper infers completion from existing prep flags and snapshots without persisting new completion state, tactical explanatory copy remains in `Game Plan Impact` to avoid losing football context, and further cleanup of legacy HQ helpers is deferred to a follow-up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a38e796c832d9046dd2d439b3a99)