### PR TITLE
Add Free Agency Market Board v1 analysis and fit-driven filtering

### DIFF
--- a/src/core/freeAgency/__tests__/freeAgencyMarketAnalysis.test.ts
+++ b/src/core/freeAgency/__tests__/freeAgencyMarketAnalysis.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { buildFreeAgencyMarketAnalysis } from '../freeAgencyMarketAnalysis.js';
+
+const team = { capRoom: 20 };
+const roster = [
+  { id: 1, name: 'QB A', pos: 'QB', ovr: 68, age: 28 },
+  { id: 2, name: 'RB A', pos: 'RB', ovr: 70, age: 29 },
+  { id: 3, name: 'K A', pos: 'K', ovr: 70, age: 28 },
+];
+
+const teamBuilder = {
+  positionGroups: [
+    { key: 'QB', needLevel: 'urgent', needScore: 72 },
+    { key: 'RB', needLevel: 'stable', needScore: 28 },
+    { key: 'K', needLevel: 'stable', needScore: 20 },
+    { key: 'WR', needLevel: 'thin', needScore: 55 },
+  ],
+  capSummary: { payrollPressure: 'low' },
+};
+
+describe('buildFreeAgencyMarketAnalysis', () => {
+  it('urgent need boosts matching fit score and wrong position does not', () => {
+    const res = buildFreeAgencyMarketAnalysis({ team, roster, teamBuilder, freeAgents: [
+      { id: 10, name: 'FA QB', pos: 'QB', ovr: 74, age: 27, potential: 78, contractDemand: { baseAnnual: 8 } },
+      { id: 11, name: 'FA RB', pos: 'RB', ovr: 74, age: 27, potential: 78, contractDemand: { baseAnnual: 8 } },
+    ] });
+    expect(res.marketRows.find((r) => r.playerId === 10)?.fitScore).toBeGreaterThan(res.marketRows.find((r) => r.playerId === 11)?.fitScore ?? 0);
+  });
+
+  it('higher OVR than starter gets starter_upgrade', () => {
+    const res = buildFreeAgencyMarketAnalysis({ team, roster, teamBuilder, freeAgents: [{ id: 10, name: 'FA QB', pos: 'QB', ovr: 80, age: 27, potential: 82, contractDemand: { baseAnnual: 10 } }] });
+    expect(res.marketRows[0].roleFit).toBe('starter_upgrade');
+  });
+
+  it('young high potential becomes development_stash/young upside', () => {
+    const res = buildFreeAgencyMarketAnalysis({ team, roster, teamBuilder, freeAgents: [{ id: 15, name: 'FA WR', pos: 'WR', ovr: 66, age: 23, potential: 80, contractDemand: { baseAnnual: 2 } }] });
+    expect(['development_stash', 'depth_patch', 'starter_upgrade']).toContain(res.marketRows[0].roleFit);
+    expect(res.filters.youngUpside(res.marketRows[0])).toBe(true);
+  });
+
+  it('old expensive low fit gets avoid risk', () => {
+    const res = buildFreeAgencyMarketAnalysis({ team: { capRoom: 4 }, roster, teamBuilder: { ...teamBuilder, capSummary: { payrollPressure: 'high' } }, freeAgents: [{ id: 20, name: 'Old RB', pos: 'RB', ovr: 69, age: 33, potential: 69, schemeFit: 40, contractDemand: { baseAnnual: 9 } }] });
+    expect(res.marketRows[0].recommendation).toBe('avoid');
+    expect(res.marketRows[0].riskFlags).toContain('expensive');
+  });
+
+  it('high cap pressure penalizes expensive cap fit', () => {
+    const res = buildFreeAgencyMarketAnalysis({ team: { capRoom: 5 }, roster, teamBuilder: { ...teamBuilder, capSummary: { payrollPressure: 'high' } }, freeAgents: [{ id: 21, name: 'Costly QB', pos: 'QB', ovr: 82, age: 28, potential: 84, contractDemand: { baseAnnual: 8 } }] });
+    expect(res.marketRows[0].capFit).toBe('expensive');
+  });
+
+  it('K/P not over-prioritized unless urgent', () => {
+    const res = buildFreeAgencyMarketAnalysis({ team, roster, teamBuilder, freeAgents: [
+      { id: 30, name: 'FA K', pos: 'K', ovr: 90, age: 27, potential: 91, contractDemand: { baseAnnual: 1.5 } },
+      { id: 31, name: 'FA QB', pos: 'QB', ovr: 78, age: 27, potential: 80, contractDemand: { baseAnnual: 9 } },
+    ] });
+    expect(res.marketRows.find((r) => r.playerId === 31)?.fitScore).toBeGreaterThan(res.marketRows.find((r) => r.playerId === 30)?.fitScore ?? 0);
+  });
+
+  it('missing salary/cap/scheme data does not crash', () => {
+    const res = buildFreeAgencyMarketAnalysis({ team: {}, roster, freeAgents: [{ id: 40, name: 'Unknown', pos: 'QB', ovr: 70 }] });
+    expect(res.marketRows[0].capFit).toBe('unknown');
+  });
+
+  it('topFits sorted by fitScore descending', () => {
+    const res = buildFreeAgencyMarketAnalysis({ team, roster, teamBuilder, freeAgents: [
+      { id: 51, name: 'A', pos: 'QB', ovr: 80, age: 27, potential: 81, contractDemand: { baseAnnual: 7 } },
+      { id: 52, name: 'B', pos: 'QB', ovr: 72, age: 31, potential: 72, contractDemand: { baseAnnual: 11 } },
+    ] });
+    expect(res.topFits[0].fitScore).toBeGreaterThanOrEqual(res.topFits[1].fitScore);
+  });
+
+  it('bargainOptions require affordable/low-cost data', () => {
+    const res = buildFreeAgencyMarketAnalysis({ team, roster, teamBuilder, freeAgents: [
+      { id: 61, name: 'Cheap', pos: 'WR', ovr: 71, age: 24, potential: 76, contractDemand: { baseAnnual: 2 } },
+      { id: 62, name: 'Expensive', pos: 'WR', ovr: 80, age: 28, potential: 82, contractDemand: { baseAnnual: 20 } },
+    ] });
+    expect(res.bargainOptions.some((p) => p.playerId === 61)).toBe(true);
+    expect(res.bargainOptions.some((p) => p.playerId === 62)).toBe(false);
+  });
+});

--- a/src/core/freeAgency/freeAgencyMarketAnalysis.js
+++ b/src/core/freeAgency/freeAgencyMarketAnalysis.js
@@ -1,0 +1,131 @@
+import { buildRosterBuildingAnalysis } from '../rosterBuildingAnalysis.js';
+
+const num = (v, fb = null) => (Number.isFinite(Number(v)) ? Number(v) : fb);
+const clamp = (v, min = 0, max = 100) => Math.max(min, Math.min(max, v));
+const COST_KEYS = ['contractDemand.baseAnnual', 'contractDemand.annual', 'desiredContract.baseAnnual', 'desiredContract.annual', 'askingPrice', 'ask', 'contract.baseAnnual', 'baseAnnual'];
+
+const getPath = (obj, path) => path.split('.').reduce((acc, key) => (acc == null ? acc : acc[key]), obj);
+const getCost = (player) => {
+  for (const key of COST_KEYS) {
+    const value = num(getPath(player, key));
+    if (value != null && value > 0) return value;
+  }
+  return null;
+};
+
+export function buildFreeAgencyMarketAnalysis({ team = {}, roster = [], freeAgents = [], cap = {}, teamBuilder = null } = {}) {
+  const fallbackAnalysis = buildRosterBuildingAnalysis({ team, roster, freeAgents, cap });
+  const base = teamBuilder ?? fallbackAnalysis;
+  const positionGroups = base?.positionGroups ?? [];
+  const urgentNeeds = positionGroups.filter((g) => g.needLevel === 'urgent' || g.needLevel === 'thin').sort((a, b) => (b.needScore ?? 0) - (a.needScore ?? 0));
+  const biggestNeed = urgentNeeds[0] ?? positionGroups.sort((a, b) => (b.needScore ?? 0) - (a.needScore ?? 0))[0] ?? null;
+  const capRoom = num(cap?.capRoom ?? team?.capRoom, null);
+  const capPressure = base?.capSummary?.payrollPressure ?? (capRoom == null ? 'unknown' : capRoom < 0 ? 'critical' : capRoom < 8 ? 'high' : capRoom < 20 ? 'medium' : 'low');
+  const starterByPos = Object.fromEntries((Object.entries(roster.reduce((acc, p) => {
+    const pos = p?.pos;
+    if (!pos) return acc;
+    acc[pos] ??= [];
+    acc[pos].push(p);
+    return acc;
+  }, {}))).map(([pos, players]) => [pos, [...players].sort((a, b) => (num(b?.ovr, 0) - num(a?.ovr, 0)))[0]]));
+
+  const needMap = new Map(positionGroups.map((g) => [g.key, g]));
+
+  const marketRows = freeAgents.map((p) => {
+    const group = needMap.get(p?.pos);
+    const needScore = num(group?.needScore, 0);
+    const needLevel = group?.needLevel ?? 'stable';
+    const schemeFit = num(p?.schemeFit, num(p?._eval?.schemeFit?.score, null));
+    const age = num(p?.age, null);
+    const ovr = num(p?.ovr, 0);
+    const potential = num(p?.potential, ovr);
+    const cost = getCost(p);
+    const starter = starterByPos[p?.pos];
+    const replacementDelta = starter ? ovr - num(starter?.ovr, 0) : null;
+
+    const isUrgentNeed = needLevel === 'urgent' || needLevel === 'thin';
+    const needBoost = isUrgentNeed ? 18 : needScore >= 35 ? 8 : 0;
+    const replacementBoost = replacementDelta == null ? 4 : replacementDelta >= 6 ? 22 : replacementDelta >= 1 ? 12 : replacementDelta >= -3 ? 4 : 0;
+    const upsideBoost = age != null && age <= 25 && potential >= ovr + 4 ? 10 : 0;
+    const schemeBoost = schemeFit == null ? 0 : Math.round((schemeFit - 50) * 0.25);
+    const agePenalty = age == null ? 0 : age >= 33 ? 20 : age >= 30 ? 12 : 0;
+    const rbAgePenalty = p?.pos === 'RB' && age != null && age >= 30 ? 10 : 0;
+    const expensive = cost != null && capRoom != null && cost > Math.max(3, capRoom * 0.5);
+    const capPenalty = cost == null || capRoom == null ? 0 : expensive ? (capPressure === 'high' || capPressure === 'critical' ? 22 : 12) : 0;
+    const lowFitPenalty = schemeFit != null && schemeFit < 45 ? 12 : 0;
+    const stPenalty = ['K', 'P'].includes(p?.pos) && !isUrgentNeed ? 12 : 0;
+
+    const fitScore = Math.round(clamp(50 + needBoost + replacementBoost + upsideBoost + schemeBoost - agePenalty - rbAgePenalty - capPenalty - lowFitPenalty - stPenalty, 0, 100));
+
+    const capFit = cost == null || capRoom == null ? 'unknown' : cost <= capRoom * 0.33 ? 'affordable' : cost <= capRoom ? 'tight' : 'expensive';
+    const roleFit = replacementDelta != null && replacementDelta >= 5 ? 'starter_upgrade' : isUrgentNeed && replacementDelta != null && replacementDelta >= 0 ? 'depth_patch' : age != null && age <= 25 && potential >= ovr + 4 ? 'development_stash' : ['K', 'P'].includes(p?.pos) ? 'special_teams' : 'low_fit';
+    const riskFlags = [
+      age != null && age >= 30 ? 'old' : null,
+      capFit === 'expensive' ? 'expensive' : null,
+      schemeFit != null && schemeFit < 45 ? 'low_fit' : null,
+      String(p?.status ?? '').toLowerCase().includes('inj') ? 'injury' : null,
+      potential <= ovr ? 'low_upside' : null,
+    ].filter(Boolean);
+
+    const recommendation = fitScore >= 78 ? 'pursue' : fitScore >= 62 ? 'consider' : fitScore >= 45 ? 'watch' : 'avoid';
+    const reason = replacementDelta != null && replacementDelta >= 5
+      ? `Possible starter upgrade at ${p?.pos}.`
+      : isUrgentNeed
+        ? `Helps address ${p?.pos} need depth.`
+        : age != null && age <= 25 && potential > ovr
+          ? 'Young upside option for development.'
+          : 'Market depth option with moderate fit.';
+
+    return {
+      playerId: p?.id,
+      name: p?.name ?? 'Unknown',
+      pos: p?.pos ?? 'UNK',
+      age,
+      ovr,
+      potential,
+      schemeFit,
+      baseAnnual: cost,
+      estimatedCost: cost,
+      years: num(p?.contractDemand?.years ?? p?.desiredContract?.years ?? p?.years, null),
+      currentTeamNeedLevel: needLevel,
+      currentTeamNeedScore: needScore,
+      replacementDelta,
+      capFit,
+      roleFit,
+      riskFlags,
+      fitScore,
+      recommendation,
+      reason,
+      _player: p,
+    };
+  }).sort((a, b) => b.fitScore - a.fitScore);
+
+  const topFits = marketRows.slice(0, 5);
+  const bargainOptions = marketRows.filter((r) => (r.capFit === 'affordable' || (r.baseAnnual != null && r.baseAnnual <= 3)) && r.recommendation !== 'avoid').slice(0, 5);
+  const shortTermPatches = marketRows.filter((r) => r.roleFit === 'depth_patch' || r.roleFit === 'starter_upgrade').slice(0, 5);
+  const avoidRisks = marketRows.filter((r) => r.riskFlags.includes('old') || r.riskFlags.includes('expensive') || r.riskFlags.includes('low_fit')).slice(0, 5);
+
+  return {
+    summary: {
+      capRoom,
+      capPressure,
+      biggestNeed,
+      topFit: topFits[0] ?? null,
+      bargainOption: bargainOptions[0] ?? null,
+      totalFreeAgents: marketRows.length,
+    },
+    needs: urgentNeeds,
+    marketRows,
+    topFits,
+    bargainOptions,
+    shortTermPatches,
+    avoidRisks,
+    filters: {
+      fitsTeamNeed: (row) => ['urgent', 'thin'].includes(row.currentTeamNeedLevel),
+      affordable: (row) => row.capFit === 'affordable',
+      starterUpgrades: (row) => row.roleFit === 'starter_upgrade',
+      youngUpside: (row) => (row.age ?? 99) <= 25 && (row.potential ?? 0) > (row.ovr ?? 0),
+      avoidRisks: (row) => row.recommendation === 'avoid' || row.riskFlags.length > 0,
+    },
+  };
+}

--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -50,6 +50,7 @@ import { applyAdvancedPlayerFilters } from "../../core/footballAdvancedFilters";
 import { buildPlayerEvaluation } from "../../core/playerEvaluation.js";
 import { usePlayerCompare } from "../utils/playerCompare.js";
 import { formatDemandTier } from "../utils/offseasonActionCenter.js";
+import { buildFreeAgencyMarketAnalysis } from "../../core/freeAgency/freeAgencyMarketAnalysis.js";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -674,6 +675,7 @@ export default function FreeAgency({
   const [positionNeedOnly, setPositionNeedOnly] = useState(false);
   const [watchlistIds, setWatchlistIds] = useState(new Set());
   const [sortPreset, setSortPreset] = useState("best_available");
+  const [marketFilter, setMarketFilter] = useState("all");
 
   // Sorting
   const [sortKey, setSortKey] = useState("ovr");
@@ -748,19 +750,33 @@ export default function FreeAgency({
     }),
   })), [faPool, teamIntel, userTeam?.roster, userTeam?.gamePlan, needsSummary?.needs]);
   const topNeeds = useMemo(() => (needsSummary?.needs ?? []).slice(0, 4), [needsSummary?.needs]);
+  const marketAnalysis = useMemo(() => buildFreeAgencyMarketAnalysis({
+    team: userTeam,
+    roster: userTeam?.roster ?? [],
+    freeAgents: evaluatedFaPool,
+    cap: { capRoom, capUsed, deadCap },
+  }), [userTeam, evaluatedFaPool, capRoom, capUsed, deadCap]);
+
+  const marketRowsById = useMemo(() => new Map((marketAnalysis?.marketRows ?? []).map((r) => [r.playerId, r])), [marketAnalysis]);
 
   const displayed = useMemo(() => {
     const base = filterFreeAgentsForView(evaluatedFaPool, {
       signedIds, posFilter, minOvr, nameFilter, advancedFilters, archetypeFilter, fitTierFilter, roleFilter, positionNeedOnly, needs: topNeeds,
     });
     return base.filter((player) => {
+      const marketRow = marketRowsById.get(player.id);
+      if (marketFilter === "need" && !marketAnalysis.filters.fitsTeamNeed(marketRow || {})) return false;
+      if (marketFilter === "affordable" && !marketAnalysis.filters.affordable(marketRow || {})) return false;
+      if (marketFilter === "starter" && !marketAnalysis.filters.starterUpgrades(marketRow || {})) return false;
+      if (marketFilter === "young" && !marketAnalysis.filters.youngUpside(marketRow || {})) return false;
+      if (marketFilter === "risk" && !marketAnalysis.filters.avoidRisks(marketRow || {})) return false;
       if ((player.age ?? 99) > maxAge) return false;
       if ((player._eval?.schemeFit?.score ?? player.schemeFit ?? 0) < minSchemeFit) return false;
       if (demandTier !== "ALL" && formatDemandTier(player) !== demandTier) return false;
       if (watchOnly && !watchlistIds.has(player.id)) return false;
       return true;
     });
-  }, [evaluatedFaPool, signedIds, posFilter, nameFilter, minOvr, advancedFilters, archetypeFilter, fitTierFilter, roleFilter, positionNeedOnly, topNeeds, maxAge, minSchemeFit, demandTier, watchOnly, watchlistIds]);
+  }, [evaluatedFaPool, signedIds, posFilter, nameFilter, minOvr, advancedFilters, archetypeFilter, fitTierFilter, roleFilter, positionNeedOnly, topNeeds, maxAge, minSchemeFit, demandTier, watchOnly, watchlistIds, marketFilter, marketAnalysis, marketRowsById]);
 
   const sortedAgents = useMemo(() => {
     return sortFreeAgentsForView(displayed, { sortPreset, sortKey, sortDir, needs: (needsSummary?.needs ?? []).slice(0, 4) });
@@ -872,6 +888,32 @@ export default function FreeAgency({
           { label: "Phase", value: faState?.phase ?? "loading" },
         ]}
       />
+      <Card className="card-premium" style={{ marginBottom: "var(--space-4)" }}>
+        <CardContent style={{ padding: "var(--space-4)", display: "grid", gap: 10 }}>
+          <div style={{ fontSize: "var(--text-xs)", textTransform: "uppercase", color: "var(--text-muted)" }}>Market Snapshot</div>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(2, minmax(0,1fr))", gap: 8 }}>
+            <Badge variant="outline">Cap Room: {marketAnalysis?.summary?.capRoom != null ? `$${marketAnalysis.summary.capRoom.toFixed(1)}M` : "Unknown"}</Badge>
+            <Badge variant="outline">Need: {marketAnalysis?.summary?.biggestNeed?.key ?? "Unknown"}</Badge>
+            <Badge variant="outline">Top Fit: {marketAnalysis?.summary?.topFit?.name ?? "None"}</Badge>
+            <Badge variant="outline">Bargain: {marketAnalysis?.summary?.bargainOption?.name ?? "None"}</Badge>
+          </div>
+          {(marketAnalysis?.summary?.capPressure === "high" || marketAnalysis?.summary?.capPressure === "critical") && <div style={{ color: "var(--warning)", fontSize: "var(--text-xs)" }}>Cap pressure is high. Expensive options may be risky.</div>}
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+            {[["all","All"],["need","Fits Team Need"],["affordable","Affordable"],["starter","Starter Upgrades"],["young","Young Upside"],["risk","Avoid Risks"]].map(([k,l]) => (
+              <Button key={k} size="sm" variant={marketFilter===k?"default":"outline"} onClick={() => setMarketFilter(k)}>{l}</Button>
+            ))}
+          </div>
+          <div style={{ display: "grid", gap: 6 }}>
+            {(marketAnalysis?.topFits ?? []).slice(0,5).map((row) => (
+              <button key={row.playerId} type="button" onClick={() => onPlayerSelect?.(row._player)} style={{ textAlign: "left", background: "var(--surface)", border: "1px solid var(--hairline)", borderRadius: 10, padding: 8 }}>
+                <div style={{ fontWeight: 700 }}>{row.name} · {row.pos} · OVR {row.ovr}</div>
+                <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>{row.recommendation} · fit {row.fitScore} · {row.capFit} · {row.reason}</div>
+              </button>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
       <Card className="card-premium" style={{ marginBottom: "var(--space-4)" }}>
         <CardContent style={{ padding: "var(--space-4)", display: "grid", gap: 8 }}>
           <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: "0.5px" }}>Free Agency · transaction workspace</div>


### PR DESCRIPTION
### Motivation
- Improve the Free Agency screen so users can quickly evaluate available free agents against roster needs, cap room, scheme fit, age risk, and replacement value without changing signing mechanics. 
- Provide a focused, mobile-first Market Snapshot and recommended-fit list that closes the loop from Weekly Command Hub / Team Builder to actionable FA options. 

### Description
- Added a pure helper `buildFreeAgencyMarketAnalysis` at `src/core/freeAgency/freeAgencyMarketAnalysis.js` that builds normalized `marketRows`, `summary`, buckets (`topFits`, `bargainOptions`, `shortTermPatches`, `avoidRisks`) and reusable filter predicates. 
- Integrated the helper into `FreeAgency.jsx` to render a compact Market Snapshot (cap room, biggest need, top fit, bargain) plus quick filter pills and the top 5 recommended fit cards that open the player profile via `onPlayerSelect` when available. 
- FitScore is heuristic: baseline + position-need boost from roster/team analysis, replacement delta vs current starter, youth/potential upside and scheme-fit bonus, minus age/RB-specific penalties, cap-pressure penalty, low-fit/ST de-prioritization; recommendations are `pursue/consider/watch/avoid` and do not alter signing logic. 
- Kept data truthfulness: only uses existing fields for cost/ask/fit (labels become `unknown` when missing) and falls back to `buildRosterBuildingAnalysis` when explicit Team Builder data is not supplied. 
- Known limitations: route-based position preselection and richer desktop table view are intentionally out of scope for this v1, and no signing/negotiation mechanics were changed. 

### Testing
- Unit tests added at `src/core/freeAgency/__tests__/freeAgencyMarketAnalysis.test.ts` covering urgent-need boosts, starter upgrades, young-upside handling, old/expensive low-fit avoidance, cap-pressure behavior, K/P deprioritization, missing-data safety, sorting, and bargain qualification. 
- Ran `npm run test:unit -- src/core/freeAgency/__tests__/freeAgencyMarketAnalysis.test.ts` and the new test file passed (9 tests). 
- Also ran `npm run test:unit -- src/core/__tests__/rosterBuildingAnalysis.test.ts src/ui/utils/weeklyCommandHub.test.js src/ui/components/__tests__/FranchiseHQ.test.jsx` and `npm run test:unit -- src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx` and those suites passed. 
- No signing, negotiation, or worker APIs were modified, and the change is limited to analysis + UI filtering to avoid introducing deterministic or simulation-state changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a9b13680832d8da82113f1c78a9b)