### PR TITLE
Enhance Free Agency Market Board analysis, sorting, and watchlist filtering

### DIFF
--- a/src/core/freeAgency/__tests__/freeAgencyMarketAnalysis.test.ts
+++ b/src/core/freeAgency/__tests__/freeAgencyMarketAnalysis.test.ts
@@ -19,6 +19,14 @@ const teamBuilder = {
 };
 
 describe('buildFreeAgencyMarketAnalysis', () => {
+  it('market row includes current starter comparison and labels', () => {
+    const res = buildFreeAgencyMarketAnalysis({ team, roster, teamBuilder, freeAgents: [{ id: 70, name: 'FA QB', pos: 'QB', ovr: 76, age: 27, potential: 80, contractDemand: { baseAnnual: 8 } }] });
+    expect(res.marketRows[0].currentStarterName).toBe('QB A');
+    expect(res.marketRows[0].currentStarterOVR).toBe(68);
+    expect(res.marketRows[0].currentStarterAge).toBe(28);
+    expect(res.marketRows[0].replacementDeltaLabel).toBe('+8 vs starter');
+  });
+
   it('urgent need boosts matching fit score and wrong position does not', () => {
     const res = buildFreeAgencyMarketAnalysis({ team, roster, teamBuilder, freeAgents: [
       { id: 10, name: 'FA QB', pos: 'QB', ovr: 74, age: 27, potential: 78, contractDemand: { baseAnnual: 8 } },
@@ -30,6 +38,18 @@ describe('buildFreeAgencyMarketAnalysis', () => {
   it('higher OVR than starter gets starter_upgrade', () => {
     const res = buildFreeAgencyMarketAnalysis({ team, roster, teamBuilder, freeAgents: [{ id: 10, name: 'FA QB', pos: 'QB', ovr: 80, age: 27, potential: 82, contractDemand: { baseAnnual: 10 } }] });
     expect(res.marketRows[0].roleFit).toBe('starter_upgrade');
+  });
+
+  it('projected cap room is calculated when cost and cap are known', () => {
+    const res = buildFreeAgencyMarketAnalysis({ team: { capRoom: 20 }, roster, teamBuilder, freeAgents: [{ id: 12, name: 'FA QB', pos: 'QB', ovr: 78, age: 27, potential: 80, contractDemand: { baseAnnual: 7.6 } }] });
+    expect(res.marketRows[0].projectedCapRoomAfterSigning).toBe(12.4);
+    expect(res.marketRows[0].capImpactLabel).toContain('$12.4M');
+  });
+
+  it('projected cap room is unknown when cost is missing', () => {
+    const res = buildFreeAgencyMarketAnalysis({ team: { capRoom: 20 }, roster, teamBuilder, freeAgents: [{ id: 13, name: 'Unknown Cost QB', pos: 'QB', ovr: 75, age: 26, potential: 78 }] });
+    expect(res.marketRows[0].projectedCapRoomAfterSigning).toBeNull();
+    expect(res.marketRows[0].capImpactLabel).toBe('cost unknown');
   });
 
   it('young high potential becomes development_stash/young upside', () => {
@@ -60,6 +80,43 @@ describe('buildFreeAgencyMarketAnalysis', () => {
   it('missing salary/cap/scheme data does not crash', () => {
     const res = buildFreeAgencyMarketAnalysis({ team: {}, roster, freeAgents: [{ id: 40, name: 'Unknown', pos: 'QB', ovr: 70 }] });
     expect(res.marketRows[0].capFit).toBe('unknown');
+  });
+
+  it('market tier and value tags classify players reasonably', () => {
+    const res = buildFreeAgencyMarketAnalysis({ team, roster, teamBuilder, freeAgents: [
+      { id: 80, name: 'Premium QB', pos: 'QB', ovr: 90, age: 27, potential: 92, contractDemand: { baseAnnual: 20 } },
+      { id: 81, name: 'Cheap Fit WR', pos: 'WR', ovr: 78, age: 24, potential: 83, contractDemand: { baseAnnual: 3 } },
+      { id: 82, name: 'Unknown Cost', pos: 'WR', ovr: 70, age: 25, potential: 72 },
+    ] });
+    expect(res.marketRows.find((r) => r.playerId === 80)?.marketTier).toBe('premium');
+    expect(res.marketRows.find((r) => r.playerId === 81)?.valueTag).toBe('bargain');
+    expect(res.marketRows.find((r) => r.playerId === 82)?.valueTag).toBe('unknown');
+  });
+
+  it('needFitTag prioritizes urgent needs and de-prioritizes luxury K/P', () => {
+    const res = buildFreeAgencyMarketAnalysis({ team, roster, teamBuilder, freeAgents: [
+      { id: 90, name: 'QB Need', pos: 'QB', ovr: 72, age: 26, potential: 74, contractDemand: { baseAnnual: 5 } },
+      { id: 91, name: 'K Luxury', pos: 'K', ovr: 88, age: 27, potential: 89, contractDemand: { baseAnnual: 1 } },
+    ] });
+    expect(res.marketRows.find((r) => r.playerId === 90)?.needFitTag).toBe('urgent_need');
+    expect(res.marketRows.find((r) => r.playerId === 91)?.needFitTag).toBe('low_priority');
+  });
+
+  it('sortKeys are present and numeric/null safe', () => {
+    const res = buildFreeAgencyMarketAnalysis({ team, roster, teamBuilder, freeAgents: [{ id: 92, name: 'QB', pos: 'QB', ovr: 75, age: 26, potential: 78 }] });
+    expect(typeof res.marketRows[0].sortKeys.fitScore).toBe('number');
+    expect(typeof res.marketRows[0].sortKeys.recommendationRank).toBe('number');
+    expect(res.marketRows[0].sortKeys.cost).toBeNull();
+  });
+
+  it('low-risk young upside outranks old expensive low-fit in same position', () => {
+    const res = buildFreeAgencyMarketAnalysis({ team: { capRoom: 5 }, roster, teamBuilder, freeAgents: [
+      { id: 100, name: 'Young QB', pos: 'QB', ovr: 74, age: 23, potential: 82, schemeFit: 78, contractDemand: { baseAnnual: 3 } },
+      { id: 101, name: 'Old QB', pos: 'QB', ovr: 75, age: 34, potential: 75, schemeFit: 38, contractDemand: { baseAnnual: 12 } },
+    ] });
+    const young = res.marketRows.find((r) => r.playerId === 100);
+    const old = res.marketRows.find((r) => r.playerId === 101);
+    expect((young?.fitScore ?? 0)).toBeGreaterThan(old?.fitScore ?? 0);
   });
 
   it('topFits sorted by fitScore descending', () => {

--- a/src/core/freeAgency/freeAgencyMarketAnalysis.js
+++ b/src/core/freeAgency/freeAgencyMarketAnalysis.js
@@ -30,6 +30,8 @@ export function buildFreeAgencyMarketAnalysis({ team = {}, roster = [], freeAgen
   }, {}))).map(([pos, players]) => [pos, [...players].sort((a, b) => (num(b?.ovr, 0) - num(a?.ovr, 0)))[0]]));
 
   const needMap = new Map(positionGroups.map((g) => [g.key, g]));
+  const recommendationRankMap = { pursue: 4, consider: 3, watch: 2, avoid: 1 };
+  const capFitRankMap = { affordable: 4, tight: 3, expensive: 2, unknown: 1 };
 
   const marketRows = freeAgents.map((p) => {
     const group = needMap.get(p?.pos);
@@ -42,6 +44,11 @@ export function buildFreeAgencyMarketAnalysis({ team = {}, roster = [], freeAgen
     const cost = getCost(p);
     const starter = starterByPos[p?.pos];
     const replacementDelta = starter ? ovr - num(starter?.ovr, 0) : null;
+    const projectedCapRoomAfterSigning = cost != null && capRoom != null ? Number((capRoom - cost).toFixed(1)) : null;
+    const replacementDeltaLabel = starter
+      ? `${replacementDelta >= 0 ? "+" : ""}${replacementDelta} vs starter`
+      : "No current starter";
+    const capImpactLabel = projectedCapRoomAfterSigning == null ? "cost unknown" : `$${projectedCapRoomAfterSigning.toFixed(1)}M after signing`;
 
     const isUrgentNeed = needLevel === 'urgent' || needLevel === 'thin';
     const needBoost = isUrgentNeed ? 18 : needScore >= 35 ? 8 : 0;
@@ -68,6 +75,33 @@ export function buildFreeAgencyMarketAnalysis({ team = {}, roster = [], freeAgen
     ].filter(Boolean);
 
     const recommendation = fitScore >= 78 ? 'pursue' : fitScore >= 62 ? 'consider' : fitScore >= 45 ? 'watch' : 'avoid';
+    const marketTier = recommendation === 'avoid'
+      ? 'avoid'
+      : ovr >= 88
+        ? 'premium'
+        : ovr >= 80
+          ? 'starter'
+          : ovr >= 73
+            ? 'rotation'
+            : age != null && age <= 24 && potential > ovr
+              ? 'stash'
+              : 'depth';
+    const valueTag = cost == null
+      ? 'unknown'
+      : fitScore >= 74 && cost <= 6
+        ? 'bargain'
+        : fitScore >= 60 && cost <= 12
+          ? 'fair'
+          : 'expensive';
+    const needFitTag = ['K', 'P'].includes(p?.pos) && !isUrgentNeed
+      ? 'low_priority'
+      : isUrgentNeed
+        ? 'urgent_need'
+        : needScore >= 35
+          ? 'team_need'
+          : fitScore >= 75
+            ? 'luxury'
+            : 'low_priority';
     const reason = replacementDelta != null && replacementDelta >= 5
       ? `Possible starter upgrade at ${p?.pos}.`
       : isUrgentNeed
@@ -90,11 +124,31 @@ export function buildFreeAgencyMarketAnalysis({ team = {}, roster = [], freeAgen
       currentTeamNeedLevel: needLevel,
       currentTeamNeedScore: needScore,
       replacementDelta,
+      replacementDeltaLabel,
+      currentStarterName: starter?.name ?? null,
+      currentStarterOVR: starter ? num(starter?.ovr, null) : null,
+      currentStarterAge: starter ? num(starter?.age, null) : null,
+      currentUnitOVR: group ? num(group?.currentUnitOvr ?? group?.unitOvr, null) : null,
       capFit,
+      projectedCapRoomAfterSigning,
+      capImpactLabel,
       roleFit,
+      marketTier,
+      valueTag,
+      needFitTag,
       riskFlags,
       fitScore,
       recommendation,
+      sortKeys: {
+        fitScore,
+        ovr,
+        age: age ?? null,
+        cost: cost ?? null,
+        replacementDelta: replacementDelta ?? null,
+        schemeFit: schemeFit ?? null,
+        recommendationRank: recommendationRankMap[recommendation] ?? 0,
+        capFitRank: capFitRankMap[capFit] ?? 0,
+      },
       reason,
       _player: p,
     };

--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -150,14 +150,15 @@ export function filterFreeAgentsForView(faPool, { signedIds, posFilter, minOvr, 
   return applyAdvancedPlayerFilters(baseFiltered, advancedFilters);
 }
 
-export function sortFreeAgentsForView(displayed, { sortPreset, sortKey, sortDir, needs = [] }) {
+export function sortFreeAgentsForView(displayed, { sortPreset, sortKey, sortDir, needs = [], marketRowsById = new Map() }) {
   const arr = [...displayed];
+  const rowFor = (p) => marketRowsById.get(p?.id) ?? {};
   if (sortPreset === "best_available") {
-    arr.sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0));
+    arr.sort((a, b) => (rowFor(b).sortKeys?.fitScore ?? 0) - (rowFor(a).sortKeys?.fitScore ?? 0) || (b.ovr ?? 0) - (a.ovr ?? 0));
     return arr;
   }
   if (sortPreset === "cheapest_value") {
-    arr.sort((a, b) => ((b.ovr ?? 0) / Math.max(0.2, b._ask ?? 1)) - ((a.ovr ?? 0) / Math.max(0.2, a._ask ?? 1)));
+    arr.sort((a, b) => (rowFor(a).sortKeys?.cost ?? a._ask ?? 999) - (rowFor(b).sortKeys?.cost ?? b._ask ?? 999));
     return arr;
   }
   if (sortPreset === "youngest") {
@@ -171,6 +172,18 @@ export function sortFreeAgentsForView(displayed, { sortPreset, sortKey, sortDir,
   }
   if (sortPreset === "tactical_fit") {
     arr.sort((a, b) => (b?._eval?.schemeFit?.score ?? 0) - (a?._eval?.schemeFit?.score ?? 0) || (b.ovr ?? 0) - (a.ovr ?? 0));
+    return arr;
+  }
+  if (sortPreset === "starter_upgrade") {
+    arr.sort((a, b) => (rowFor(b).sortKeys?.replacementDelta ?? -999) - (rowFor(a).sortKeys?.replacementDelta ?? -999));
+    return arr;
+  }
+  if (sortPreset === "young_upside") {
+    arr.sort((a, b) => ((b.potential ?? b.ovr ?? 0) - (b.age ?? 99)) - ((a.potential ?? a.ovr ?? 0) - (a.age ?? 99)));
+    return arr;
+  }
+  if (sortPreset === "lowest_risk") {
+    arr.sort((a, b) => (rowFor(a).riskFlags?.length ?? 0) - (rowFor(b).riskFlags?.length ?? 0) || (rowFor(b).sortKeys?.fitScore ?? 0) - (rowFor(a).sortKeys?.fitScore ?? 0));
     return arr;
   }
   arr.sort((a, b) => {
@@ -770,6 +783,7 @@ export default function FreeAgency({
       if (marketFilter === "starter" && !marketAnalysis.filters.starterUpgrades(marketRow || {})) return false;
       if (marketFilter === "young" && !marketAnalysis.filters.youngUpside(marketRow || {})) return false;
       if (marketFilter === "risk" && !marketAnalysis.filters.avoidRisks(marketRow || {})) return false;
+      if (marketFilter === "watchlist" && !watchlistIds.has(player.id)) return false;
       if ((player.age ?? 99) > maxAge) return false;
       if ((player._eval?.schemeFit?.score ?? player.schemeFit ?? 0) < minSchemeFit) return false;
       if (demandTier !== "ALL" && formatDemandTier(player) !== demandTier) return false;
@@ -779,8 +793,8 @@ export default function FreeAgency({
   }, [evaluatedFaPool, signedIds, posFilter, nameFilter, minOvr, advancedFilters, archetypeFilter, fitTierFilter, roleFilter, positionNeedOnly, topNeeds, maxAge, minSchemeFit, demandTier, watchOnly, watchlistIds, marketFilter, marketAnalysis, marketRowsById]);
 
   const sortedAgents = useMemo(() => {
-    return sortFreeAgentsForView(displayed, { sortPreset, sortKey, sortDir, needs: (needsSummary?.needs ?? []).slice(0, 4) });
-  }, [displayed, sortKey, sortDir, sortPreset, needsSummary?.needs]);
+    return sortFreeAgentsForView(displayed, { sortPreset, sortKey, sortDir, needs: (needsSummary?.needs ?? []).slice(0, 4), marketRowsById });
+  }, [displayed, sortKey, sortDir, sortPreset, needsSummary?.needs, marketRowsById]);
   const archetypeOptions = useMemo(
     () => Array.from(new Set(evaluatedFaPool.map((p) => p?._eval?.archetype?.archetype).filter(Boolean))).slice(0, 24),
     [evaluatedFaPool],
@@ -899,16 +913,20 @@ export default function FreeAgency({
           </div>
           {(marketAnalysis?.summary?.capPressure === "high" || marketAnalysis?.summary?.capPressure === "critical") && <div style={{ color: "var(--warning)", fontSize: "var(--text-xs)" }}>Cap pressure is high. Expensive options may be risky.</div>}
           <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-            {[["all","All"],["need","Fits Team Need"],["affordable","Affordable"],["starter","Starter Upgrades"],["young","Young Upside"],["risk","Avoid Risks"]].map(([k,l]) => (
+            {[["all","All"],["need","Fits Team Need"],["affordable","Affordable"],["starter","Starter Upgrades"],["young","Young Upside"],["risk","Avoid Risks"],["watchlist","Watchlist"]].map(([k,l]) => (
               <Button key={k} size="sm" variant={marketFilter===k?"default":"outline"} onClick={() => setMarketFilter(k)}>{l}</Button>
             ))}
           </div>
           <div style={{ display: "grid", gap: 6 }}>
             {(marketAnalysis?.topFits ?? []).slice(0,5).map((row) => (
-              <button key={row.playerId} type="button" onClick={() => onPlayerSelect?.(row._player)} style={{ textAlign: "left", background: "var(--surface)", border: "1px solid var(--hairline)", borderRadius: 10, padding: 8 }}>
-                <div style={{ fontWeight: 700 }}>{row.name} · {row.pos} · OVR {row.ovr}</div>
-                <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>{row.recommendation} · fit {row.fitScore} · {row.capFit} · {row.reason}</div>
-              </button>
+              <div key={row.playerId} style={{ textAlign: "left", background: "var(--surface)", border: "1px solid var(--hairline)", borderRadius: 10, padding: 8 }}>
+                <button type="button" onClick={() => onPlayerSelect?.(row._player)} style={{ width: "100%", textAlign: "left", background: "transparent", border: 0, padding: 0 }}>
+                  <div style={{ fontWeight: 700 }}>{row.name} · {row.pos} · OVR {row.ovr}</div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>{row.recommendation} · fit {row.fitScore} · {row.capFit} · {row.replacementDeltaLabel}</div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>{row.capImpactLabel}</div>
+                </button>
+                <Button size="sm" variant="outline" onClick={() => setWatchlistIds((prev) => { const next = new Set(prev); if (next.has(row.playerId)) next.delete(row.playerId); else next.add(row.playerId); return next; })}>{watchlistIds.has(row.playerId) ? "Unwatch" : "Watch"}</Button>
+              </div>
             ))}
           </div>
         </CardContent>
@@ -1122,11 +1140,13 @@ export default function FreeAgency({
               <option value="premium">Demand: Premium</option>
             </select>
             <select value={sortPreset} onChange={(e) => setSortPreset(e.target.value)} style={{ height: 30, borderRadius: 8, background: "var(--surface-strong)", border: "1px solid var(--hairline)", color: "var(--text)", fontSize: 12 }}>
-              <option value="best_available">Sort: Best available</option>
-              <option value="cheapest_value">Sort: Cheapest value</option>
-              <option value="youngest">Sort: Youngest</option>
+              <option value="best_available">Sort: Best Fit</option>
+              <option value="cheapest_value">Sort: Cheapest</option>
+              <option value="young_upside">Sort: Young Upside</option>
               <option value="position_need">Sort: Position need</option>
-              <option value="tactical_fit">Sort: Tactical fit</option>
+              <option value="starter_upgrade">Sort: Starter Upgrade</option>
+              <option value="tactical_fit">Sort: Scheme Fit</option>
+              <option value="lowest_risk">Sort: Lowest Risk</option>
               <option value="manual">Sort: Manual columns</option>
             </select>
             <select value={fitTierFilter} onChange={(e) => setFitTierFilter(e.target.value)} style={{ height: 30, borderRadius: 8, background: "var(--surface-strong)", border: "1px solid var(--hairline)", color: "var(--text)", fontSize: 12 }}>


### PR DESCRIPTION
### Motivation
- Improve the Free Agency Market Board from a snapshot/top-5 layer toward a sortable, dense decision workspace by providing deterministic comparison and cap signals for each free agent. 
- Keep changes focused on analysis, sorting, filtering, and UI clarity while preserving signing, negotiation, and worker architecture.

### Description
- Extended `buildFreeAgencyMarketAnalysis` to include starter/unit comparisons and readable receipts (fields added: `currentStarterName`, `currentStarterOVR`, `currentStarterAge`, `currentUnitOVR`, `replacementDeltaLabel`, `projectedCapRoomAfterSigning`, `capImpactLabel`, `marketTier`, `valueTag`, `needFitTag`) and a numeric `sortKeys` object for downstream sorting; the helper remains pure and does not mutate input players (file: `src/core/freeAgency/freeAgencyMarketAnalysis.js`).
- Added normalized ranking maps and `sortKeys` entries (`fitScore`, `ovr`, `age`, `cost`, `replacementDelta`, `schemeFit`, `recommendationRank`, `capFitRank`) to make list sorting predictable and null-safe (file: `src/core/freeAgency/freeAgencyMarketAnalysis.js`).
- Integrated market-analysis-driven sorting into the existing `sortPreset` pipeline (no competing sort system) and added presets: `best_available` (now fit-first), `cheapest_value` (cost-first), `young_upside`, `starter_upgrade`, and `lowest_risk`, wiring `marketRowsById` into `sortFreeAgentsForView` (file: `src/ui/components/FreeAgency.jsx`).
- Improved the UI snapshot/top-fit cards to show replacement and cap receipts and added an in-place Watch/Unwatch action; added a `Watchlist` quick filter connected to existing local `watchlistIds` behavior and preserved existing flows for profile view and signing (file: `src/ui/components/FreeAgency.jsx`).
- Expanded unit tests for market analysis to cover starter comparison labels, projection known/unknown handling, market/value/need tags, `sortKeys` shape, and ranking behaviour for young low-risk vs old expensive low-fit players (file: `src/core/freeAgency/__tests__/freeAgencyMarketAnalysis.test.ts`).

### Testing
- Ran the updated market analysis unit tests: `npm run test:unit -- src/core/freeAgency/__tests__/freeAgencyMarketAnalysis.test.ts` and they passed (`16 tests` passed).
- Ran related unit suites to validate no regressions: `npm run test:unit -- src/core/__tests__/rosterBuildingAnalysis.test.ts src/ui/utils/weeklyCommandHub.test.js src/ui/components/__tests__/FranchiseHQ.test.jsx` and `npm run test:unit -- src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx`; all ran and passed (total files run in these checks passed).
- Notes: test runs confirm the analysis helper is stable and the new sort presets integrate without breaking existing filters or watchlist behavior; no signing/contract/worker logic was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3b39686e0832da2c93d730ca9b857)