### PR TITLE
Harden Trade Finder: safe framework handoff and cap-safe filtering

### DIFF
--- a/src/ui/components/TradeFinder.jsx
+++ b/src/ui/components/TradeFinder.jsx
@@ -192,7 +192,7 @@ export default function TradeFinder({ league, actions, onPlayerSelect, onOpenTra
     if (finderFilter === 'cap_relief') return (idea.capImpact ?? 0) > 0;
     if (finderFilter === 'high_confidence') return idea.confidence === 'high';
     if (finderFilter === 'needs_more_value') return idea.feasibilityLabel === 'needs_more_value';
-    if (finderFilter === 'cap_safe') return idea.capImpact == null || idea.capImpact >= 0;
+    if (finderFilter === 'cap_safe') return !(idea.warnings ?? []).some((w) => String(w).toLowerCase().includes('cap')) && (idea.capImpact == null || idea.capImpact >= 0);
     if (finderFilter === 'long_shot') return idea.feasibilityLabel === 'long_shot';
     if (finderFilter === 'selected') return idea.id === selectedFrameworkId;
     if (finderFilter === 'avoid_risks') return (idea.riskFlags ?? []).length === 0;
@@ -210,8 +210,13 @@ export default function TradeFinder({ league, actions, onPlayerSelect, onOpenTra
       outgoingPlayerIds: idea.outgoingPlayerIds ?? [],
       source: 'tradeFinder',
     };
+
+    if (typeof onOpenTradeCenter !== 'function') return;
+
     try {
-      onOpenTradeCenter?.(payload);
+      if (onOpenTradeCenter.length >= 1) {
+        onOpenTradeCenter(payload);
+      }
     } catch (_err) {
       // fallback panel still preserves framework context
     }


### PR DESCRIPTION
### Motivation
- Make Trade Finder suggestions more truthful and safer to hand off into the existing Builder flow by preventing accidental payload calls to legacy/no-arg callbacks and avoiding false “cap safe” labels. 
- Preserve the heuristic analysis foundations (no AI acceptance changes, no auto-submits) while improving UI affordances and filter honesty. 
- Validate that the analysis surface and exported API remain stable after the readability/helper organization of the analysis logic.

### Description
- Tightened the `cap_safe` Suggested Framework filter so it now excludes ideas that carry cap-related warnings and still requires neutral/positive (or unknown) cap impact, instead of relying on cap impact alone (change in `TradeFinder.jsx`).
- Hardened the “Use Framework” handoff: the UI prepares the payload but only invokes `onOpenTradeCenter` when the callback is a function and appears to accept parameters (`onOpenTradeCenter.length >= 1`), otherwise the Selected Framework panel remains the non-destructive fallback (change in `TradeFinder.jsx`).
- Confirmed and validated the trade analysis remains a pure, helper-based module with a stable `buildTradeFinderAnalysis` export and that trade ideas include the expected fields such as `confidence`, `confidenceReasons`, `warnings`, `feasibilityLabel`, and `frameworkType` (no changes to trade execution, AI acceptance, or worker logic).
- Kept the Selected Framework UX intact: selecting a framework sets local state and surfaces a compact panel with the target, outgoing package, value match, confidence, feasibility label, cap impact, warnings, and an explicit `Open Trade Center` button.

### Testing
- Ran unit tests for the trade analysis and related modules with `npm run test:unit -- src/core/trades/__tests__/tradeFinderAnalysis.test.ts` and it passed (12 tests passed).
- Ran broader targeted suites with `npm run test:unit -- src/core/freeAgency/__tests__/freeAgencyMarketAnalysis.test.ts src/core/__tests__/rosterBuildingAnalysis.test.ts src/ui/utils/weeklyCommandHub.test.js` and they passed (33 tests passed across files).
- Ran UI/util tests with `npm run test:unit -- src/ui/utils/tradeFinder.test.js src/ui/utils/tradeFinderOffers.test.js` and they passed (7 tests passed).
- All unit checks executed in this rollout passed; no test failures were introduced.

Known limitations
- Frameworks remain heuristic suggestions and do not imply or guarantee AI acceptance or auto-submission of trades. 
- The callback compatibility check is intentionally conservative (`function.length`), so some legacy integrations that accept payloads but report a smaller arity will fall back to the Selected Framework panel until integrations are updated.
- Draft picks and multi-asset package generation are intentionally deferred for future work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f42582f568832db661f70f6c126692)