### PR TITLE
Phase A: Harden app shell readiness — preserve league on WORKER_READY + App null-safety

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -689,13 +689,19 @@ function AppContent() {
     );
   }
 
-  const bootstrapSummary = summarizeBootstrapState(league);
-  const userTeam = league?.teams?.find((t) => t.id === league?.userTeamId);
-  const isCutdownRequired = (league?.phase === 'preseason') && (userTeam?.rosterCount ?? 0) > 53;
+  const shellLeague = leagueReady ? league : null;
+  const safeWeek = shellLeague?.week ?? null;
+  const safeYear = shellLeague?.year ?? shellLeague?.seasonId ?? null;
+  const safeUserTeamId = shellLeague?.userTeamId ?? null;
+  const bootstrapSummary = summarizeBootstrapState(shellLeague);
+  const userTeam = Array.isArray(shellLeague?.teams)
+    ? shellLeague.teams.find((t) => Number(t?.id) === Number(safeUserTeamId))
+    : null;
+  const isCutdownRequired = (safePhase === 'preseason') && (userTeam?.rosterCount ?? 0) > 53;
 
-  const isPostseason = league?.phase === 'playoffs';
+  const isPostseason = safePhase === 'playoffs';
 
-  const themeClass = league?.phase ? `theme-${league.phase}` : 'theme-default';
+  const themeClass = safePhase ? `theme-${safePhase}` : 'theme-default';
 
   if (isNewFranchiseBootstrapping) {
     return (
@@ -708,10 +714,10 @@ function AppContent() {
           <div role="alert" className="app-banner app-banner-error" style={{ marginTop: 12 }}>
             <span>{initFlow.message}</span>
             <div style={{ display: 'inline-flex', gap: 8, marginLeft: 10 }}>
-              <button className="btn btn-primary app-banner-btn" onClick={() => setActiveView('new_league')}>
+              <button data-testid="app-bootstrap-retry" className="btn btn-primary app-banner-btn" onClick={() => setActiveView('new_league')}>
                 Retry Setup
               </button>
-              <button className="btn app-banner-btn" onClick={() => { setActiveSlot(null); setActiveView('saves'); }}>
+              <button data-testid="app-bootstrap-back-to-slots" className="btn app-banner-btn" onClick={() => { setActiveSlot(null); setActiveView('saves'); }}>
                 Back to Slots
               </button>
             </div>
@@ -752,19 +758,19 @@ function AppContent() {
         <div className="app-header-left">
           <h1 className="app-title">Football GM</h1>
           <div className="app-season-info">
-            <span className="app-season-year">{league.year ?? league.seasonId}</span>
+            <span className="app-season-year">{safeYear}</span>
             <span className="app-season-sep">&middot;</span>
-            <span>{league.week ? `Week ${league.week}` : 'Offseason'}</span>
+            <span>{safeWeek ? `Week ${safeWeek}` : 'Offseason'}</span>
             <span className="app-season-sep">&middot;</span>
             <span className="app-phase-badge">{
-              league.phase === 'regular' ? 'Regular Season' :
-              league.phase === 'playoffs' ? 'Playoffs' :
-              league.phase === 'preseason' ? 'Preseason' :
-              league.phase === 'offseason_resign' ? 'Re-Signing' :
-              league.phase === 'offseason' ? 'Offseason' :
-              league.phase === 'free_agency' ? 'Free Agency' :
-              league.phase === 'draft' ? 'Draft' :
-              league.phase
+              safePhase === 'regular' ? 'Regular Season' :
+              safePhase === 'playoffs' ? 'Playoffs' :
+              safePhase === 'preseason' ? 'Preseason' :
+              safePhase === 'offseason_resign' ? 'Re-Signing' :
+              safePhase === 'offseason' ? 'Offseason' :
+              safePhase === 'free_agency' ? 'Free Agency' :
+              safePhase === 'draft' ? 'Draft' :
+              safePhase
             }</span>
             {userTeam && (
               <>

--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -28,7 +28,7 @@ const WORKER_TIMEOUT_BY_TYPE = Object.freeze({
 
 // ── State shape ───────────────────────────────────────────────────────────────
 
-const INITIAL_STATE = {
+export const INITIAL_WORKER_STATE = {
   /** true while the worker is handling a command */
   busy:         false,
   /** true while multi-game sim is in progress */
@@ -68,7 +68,7 @@ function isWeeklyResultsPhase(phase) {
   return phase === 'preseason' || phase === 'regular' || phase === 'playoffs';
 }
 
-function reducer(state, action) {
+export function workerReducer(state, action) {
   switch (action.type) {
     case 'BUSY':
       return { ...state, busy: true, error: null };
@@ -185,7 +185,7 @@ function reducer(state, action) {
 // ── Hook ──────────────────────────────────────────────────────────────────────
 
 export function useWorker() {
-  const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
+  const [state, dispatch] = useReducer(workerReducer, INITIAL_WORKER_STATE);
   const leagueRef = useRef(null);
   useEffect(() => {
     leagueRef.current = state.league;

--- a/src/ui/hooks/useWorker.test.js
+++ b/src/ui/hooks/useWorker.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { INITIAL_WORKER_STATE, workerReducer } from './useWorker.js';
+
+describe('workerReducer', () => {
+  it('preserves league state on WORKER_READY while clearing busy', () => {
+    const league = {
+      activeLeagueId: 'save_slot_1',
+      year: 2028,
+      week: 3,
+      phase: 'regular',
+      userTeamId: 7,
+      teams: [{ id: 7, abbr: 'BOS' }],
+    };
+    const state = {
+      ...INITIAL_WORKER_STATE,
+      busy: true,
+      workerReady: false,
+      league,
+    };
+
+    const next = workerReducer(state, { type: 'WORKER_READY', hasSave: true });
+
+    expect(next.league).toBe(league);
+    expect(next.workerReady).toBe(true);
+    expect(next.hasSave).toBe(true);
+    expect(next.busy).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent the Playability smoke test from hanging by ensuring the worker readiness path does not wipe an already-loaded league and by removing unsafe direct reads from `App.jsx` during bootstrap transitions.
- Make the `WORKER_READY` reducer behavior testable so regressions can be caught at the reducer level without refactoring the hook.
- Improve testability of bootstrap recovery flows by adding stable test IDs for existing retry/back-to-slots controls.

### Description
- Exported the reducer and initial state from `src/ui/hooks/useWorker.js` as `workerReducer` and `INITIAL_WORKER_STATE` and switched the hook to `useReducer(workerReducer, INITIAL_WORKER_STATE)` so reducer behavior can be unit-tested.
- Added a focused reducer unit test `src/ui/hooks/useWorker.test.js` that asserts a valid `league` in state is preserved when the reducer processes `WORKER_READY`, and that `workerReady` becomes `true` and `busy` becomes `false`.
- Hardened `src/ui/App.jsx` by deriving a `shellLeague` only when `leagueReady` is true and introducing safe derived values (`safeYear`, `safeWeek`, `safeUserTeamId`) plus a guarded `userTeam` lookup using `Array.isArray(...)` and numeric id coercion to avoid null/shape crashes during bootstrap.
- Added stable test IDs on existing bootstrap timeout controls: `data-testid="app-bootstrap-retry"` and `data-testid="app-bootstrap-back-to-slots"` and ensured `app-shell-ready` remains only on the real shell container.
- No worker architecture rewrites or Draft Board v2 feature work were introduced; changes are narrowly scoped and backward-compatible.

### Testing
- Ran unit tests: `npm run test:unit -- src/ui/utils/leagueBootstrap.test.js src/ui/hooks/useWorker.test.js`, and the tests passed (2 files, 11 tests total passed).
- Ran broader unit checks: `npm run test:unit -- src/core/draft/__tests__/draftBoardAnalysis.test.ts src/core/trades/__tests__/tradeFinderAnalysis.test.ts src/core/freeAgency/__tests__/freeAgencyMarketAnalysis.test.ts src/core/__tests__/rosterBuildingAnalysis.test.ts src/ui/utils/weeklyCommandHub.test.js`, and these suites passed (5 files, 55 tests total passed).
- Attempted the Playability smoke test with `npm run test:e2e -- tests/e2e/fresh_franchise_bootstrap_smoke.spec.js`, but it was blocked in this environment due to a missing Playwright browser binary (`chrome-headless-shell`), so I could not validate runtime arrival at `[data-testid="app-shell-ready"]` here and therefore stopped before Phase B.
- Files changed: `src/ui/hooks/useWorker.js`, `src/ui/App.jsx`, and added `src/ui/hooks/useWorker.test.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5216473bc832d92da078a7438351c)