### PR TITLE
Draft Board v2: restore board workflow, enrich analysis metadata, and add class identity

### DIFF
--- a/src/core/draft/__tests__/draftBoardAnalysis.test.ts
+++ b/src/core/draft/__tests__/draftBoardAnalysis.test.ts
@@ -55,4 +55,28 @@ describe('draftBoardAnalysis', () => {
     const out = buildDraftBoardAnalysis({ team, prospects: [], draftPicks: [], teamBuilder: baseTeamBuilder });
     expect(out.draftNeeds[0].pos).toBe('QB');
   });
+  it('manualOrderIds affects ordering', () => {
+    const out = buildDraftBoardAnalysis({ team, prospects: [{id:1,name:'A',pos:'QB',ovr:80,potential:82},{id:2,name:'B',pos:'QB',ovr:70,potential:71}], manualOrderIds:[2,1], draftPicks: [], teamBuilder: baseTeamBuilder });
+    expect(out.prospectRows[0].prospectId).toBe(2);
+  });
+  it('shortlistIds marks rows', () => {
+    const out = buildDraftBoardAnalysis({ team, prospects: [{id:8,name:'A',pos:'QB'}], shortlistIds:[8], draftPicks: [], teamBuilder: baseTeamBuilder });
+    expect(out.prospectRows[0].isShortlist).toBe(true);
+  });
+  it('tier labels assigned', () => {
+    const out = buildDraftBoardAnalysis({ team, prospects: Array.from({ length: 20 }).map((_, i) => ({ id:i+1, name:`P${i}`, pos:'QB', ovr:80-i, potential:85-i })), draftPicks: [], teamBuilder: baseTeamBuilder });
+    expect(out.prospectRows[0].tier).toBe('Tier 1');
+    expect(out.prospectRows[10].tier).toBe('Tier 2');
+  });
+  it('class identity and early runs populated', () => {
+    const out = buildDraftBoardAnalysis({ team, prospects: [{id:1,name:'A',pos:'QB',projectedRound:1},{id:2,name:'B',pos:'QB',projectedRound:2},{id:3,name:'C',pos:'WR',projectedRound:1},{id:4,name:'D',pos:'P',projectedRound:7}], draftPicks: [], teamBuilder: baseTeamBuilder });
+    expect(out.classIdentity.strengths.length).toBeGreaterThan(0);
+    expect(out.classIdentity.thinSpots).toContain('P');
+    expect(out.classIdentity.likelyEarlyRuns).toContain('QB');
+  });
+  it('comparison receipt and sort keys present', () => {
+    const out = buildDraftBoardAnalysis({ team, prospects: [{id:1,name:'A',pos:'QB',projectedRound:1,scoutingConfidence:10,rawness:80}], draftPicks: [{teamId:1,round:3,pick:1}], teamBuilder: baseTeamBuilder });
+    expect(out.prospectRows[0].comparisonReceipt.length).toBeGreaterThan(0);
+    expect(out.prospectRows[0].sortKeys).toBeTruthy();
+  });
 });

--- a/src/core/draft/draftBoardAnalysis.js
+++ b/src/core/draft/draftBoardAnalysis.js
@@ -42,12 +42,15 @@ function buildPickAssets(draftPicks = [], teamId) {
     .sort((a, b) => a.round - b.round);
 }
 
-export function buildDraftBoardAnalysis({ team, roster = [], prospects = [], draftPicks = [], teamBuilder = null }) {
+export function buildDraftBoardAnalysis({ team, roster = [], prospects = [], draftPicks = [], teamBuilder = null, shortlistIds = [], manualOrderIds = [] }) {
   const rosterAnalysis = !teamBuilder ? buildRosterBuildingAnalysis({ team, roster, draftPicks }) : null;
   const draftNeeds = deriveDraftNeeds(teamBuilder, rosterAnalysis);
   const needMap = new Map(draftNeeds.map((n) => [n.pos, n]));
   const pickAssets = buildPickAssets(draftPicks, team?.id);
   const firstPickRound = pickAssets[0]?.round ?? null;
+
+  const shortlistSet = new Set((shortlistIds ?? []).map((id) => Number(id)));
+  const manualOrderMap = new Map((manualOrderIds ?? []).map((id, index) => [Number(id), index]));
 
   const prospectRows = prospects.map((p) => {
     const need = needMap.get(p?.pos) ?? { needLevel: 'stable', needScore: 15 };
@@ -75,13 +78,32 @@ export function buildDraftBoardAnalysis({ team, roster = [], prospects = [], dra
     const fitScore = Math.round(clamp(ratingBase + needBoost + upsideBoost + schemeBoost + posWeight - riskPenalty, 1, 100));
 
     const pickValueFit = projectedRound == null || firstPickRound == null ? 'unknown' : projectedRound >= firstPickRound + 2 ? 'reach' : projectedRound <= firstPickRound - 1 ? 'bargain' : 'fair_value';
+    const riskCount = riskFlags.length;
+    const safePick = !riskFlags.some((f) => ['injury', 'raw', 'unknown_eval'].includes(f));
     const roleProjection = fitScore >= 80 ? 'starter_path' : fitScore >= 65 ? 'depth_patch' : upsideBoost >= 12 ? 'development_stash' : p?.pos === 'K' || p?.pos === 'P' ? 'special_teams' : 'low_fit';
     const recommendation = fitScore >= 82 && !riskFlags.includes('unknown_eval') ? 'target' : fitScore >= 68 ? 'consider' : fitScore >= 55 ? 'watch' : 'avoid';
+
+    const workflowTags = [];
+    if (need.needLevel === 'urgent' || need.needLevel === 'thin') workflowTags.push('fits_team_need');
+    if (roleProjection === 'starter_path') workflowTags.push('starter_path');
+    if (roleProjection === 'development_stash') workflowTags.push('young_upside');
+    if (safePick) workflowTags.push('safe_pick');
+    if (pickValueFit === 'bargain') workflowTags.push('bargain');
+    if (riskCount > 0) workflowTags.push('high_risk');
+
+    const receipt = [];
+    if (need.needLevel === 'urgent') receipt.push(`Urgent ${p?.pos ?? 'UNK'} need`);
+    if (projectedRound != null) receipt.push(`projected Round ${projectedRound}`);
+    if (pickValueFit === 'bargain') receipt.push('Bargain vs next pick');
+    if (scoutingConfidence === 'low' || scoutingConfidence === 'unknown') receipt.push('Low confidence evaluation');
+    if (riskFlags.includes('raw')) receipt.push('High upside but raw');
+    if (need.needLevel === 'stable') receipt.push('Stable position, luxury fit');
 
     return {
       prospectId: p?.id,
       name: p?.name ?? 'Unknown prospect',
       pos: p?.pos ?? 'UNK',
+      college: p?.college ?? null,
       age,
       projectedRound,
       ovr,
@@ -97,14 +119,60 @@ export function buildDraftBoardAnalysis({ team, roster = [], prospects = [], dra
       riskFlags,
       fitScore,
       recommendation,
+      workflowTags,
+      comparisonReceipt: receipt.join(' · '),
+      sortKeys: {
+        fitScore: fitScore ?? null,
+        ovr,
+        potential,
+        projectedRound,
+        scoutingConfidenceRank: scoutingConfidence === 'high' ? 3 : scoutingConfidence === 'medium' ? 2 : scoutingConfidence === 'low' ? 1 : 0,
+        pickValueRank: pickValueFit === 'bargain' ? 3 : pickValueFit === 'fair_value' ? 2 : pickValueFit === 'reach' ? 1 : 0,
+        riskCount,
+      },
+      pickWindowLabel: projectedRound == null ? null : projectedRound <= 1 ? 'Early target' : projectedRound <= 3 ? 'Day 2 target' : 'Day 3 target',
+      isShortlist: shortlistSet.has(Number(p?.id)),
       reason: `${need.needLevel} ${p?.pos ?? ''} need${pickValueFit !== 'unknown' ? ` · ${pickValueFit} value` : ''}`.trim(),
     };
-  }).sort((a, b) => b.fitScore - a.fitScore);
+  }).sort((a, b) => {
+    const ai = manualOrderMap.get(Number(a.prospectId));
+    const bi = manualOrderMap.get(Number(b.prospectId));
+    if (ai != null && bi != null) return ai - bi;
+    if (ai != null) return -1;
+    if (bi != null) return 1;
+    return b.fitScore - a.fitScore;
+  }).map((p, index) => ({
+    ...p,
+    boardRank: index + 1,
+    defaultRank: index + 1,
+    tier: index < 6 ? 'Tier 1' : index < 16 ? 'Tier 2' : index < 32 ? 'Tier 3' : 'Tier 4',
+  }));
 
   const topFits = prospectRows.slice(0, 10);
   const safePicks = prospectRows.filter((p) => !p.riskFlags.some((f) => ['injury', 'raw', 'unknown_eval'].includes(f))).slice(0, 5);
   const upsidePicks = prospectRows.filter((p) => (num(p.potential, 0) - num(p.ovr, 0) >= 10) && num(p.age, 99) <= 22).slice(0, 5);
   const riskFlags = prospectRows.filter((p) => p.riskFlags.length > 0).slice(0, 8);
+  const top24 = prospectRows.slice(0, 24);
+  const posCounts = new Map();
+  const earlyRunCounts = new Map();
+  prospects.forEach((p) => {
+    const pos = p?.pos ?? 'UNK';
+    posCounts.set(pos, (posCounts.get(pos) ?? 0) + 1);
+  });
+  top24.forEach((p) => earlyRunCounts.set(p.pos, (earlyRunCounts.get(p.pos) ?? 0) + 1));
+  prospectRows.forEach((p) => {
+    if (p.projectedRound != null && p.projectedRound <= 2) earlyRunCounts.set(p.pos, (earlyRunCounts.get(p.pos) ?? 0) + 1);
+  });
+  const sortedStrengths = [...posCounts.entries()].sort((a, b) => b[1] - a[1]);
+  const strengths = sortedStrengths.slice(0, 3).map(([pos]) => pos);
+  const thinSpots = sortedStrengths.filter(([, c]) => c <= 1).map(([pos]) => pos).slice(0, 3);
+  const likelyEarlyRuns = [...earlyRunCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 3).map(([pos]) => pos);
+  const classIdentity = {
+    headline: strengths.length > 0 ? `${strengths.join('/')} lead this class` : 'Class distribution still forming',
+    strengths,
+    thinSpots,
+    likelyEarlyRuns,
+  };
 
   return {
     summary: {
@@ -113,6 +181,7 @@ export function buildDraftBoardAnalysis({ team, roster = [], prospects = [], dra
       safestPick: safePicks[0] ?? null,
       highestUpsidePick: upsidePicks[0] ?? null,
       nextPick: pickAssets[0] ?? null,
+      classIdentity,
     },
     draftNeeds,
     pickAssets,
@@ -121,6 +190,7 @@ export function buildDraftBoardAnalysis({ team, roster = [], prospects = [], dra
     safePicks,
     upsidePicks,
     riskFlags,
+    classIdentity,
     filters: ['all', 'need', 'starter_path', 'young_upside', 'safe_pick', 'high_risk', 'bargain'],
   };
 }

--- a/src/ui/components/Draft.test.jsx
+++ b/src/ui/components/Draft.test.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { describe, expect, it } from "vitest";
 import { renderToString } from "react-dom/server";
 import Draft, { normalizeIncomingDraftState } from "./Draft.jsx";
+import DraftBigBoard from "./DraftBigBoard.jsx";
 
 describe("Draft safeguards", () => {
   it("normalizes incomplete draft payloads", () => {
@@ -21,5 +22,17 @@ describe("Draft safeguards", () => {
       />,
     );
     expect(html).toContain("NFL Draft");
+  });
+});
+
+describe("DraftBigBoard", () => {
+  it("renders board controls and class identity", () => {
+    const html = renderToString(
+      <DraftBigBoard
+        league={{ userTeamId: 1, teams: [{ id: 1, roster: [] }], draftClass: [{ id: 1, name: 'A', pos: 'QB' }], draftState: { picks: [] } }}
+      />,
+    );
+    expect(html).toContain("Board Controls");
+    expect(html).toContain("Class:");
   });
 });

--- a/src/ui/components/DraftBigBoard.jsx
+++ b/src/ui/components/DraftBigBoard.jsx
@@ -3,12 +3,18 @@ import { buildDraftBoardAnalysis } from '../../core/draft/draftBoardAnalysis.js'
 
 const POS_FILTERS = ['ALL', 'QB', 'WR', 'RB', 'TE', 'OL', 'DL', 'LB', 'CB', 'S', 'K', 'P'];
 const FILTERS = ['all', 'need', 'starter_path', 'young_upside', 'safe_pick', 'high_risk', 'bargain'];
+const SORTS = ['board_rank', 'best_fit', 'ovr', 'potential', 'projected_round', 'scouting_confidence', 'lowest_risk'];
 
 export default function DraftBigBoard({ league, onPlayerSelect }) {
   const prospects = Array.isArray(league?.draftClass) ? league?.draftClass : [];
   const userTeam = league?.teams?.find((t) => t.id === league?.userTeamId) ?? null;
   const [positionFilter, setPositionFilter] = useState('ALL');
   const [activeFilter, setActiveFilter] = useState('all');
+  const [viewMode, setViewMode] = useState('board');
+  const [search, setSearch] = useState('');
+  const [sortBy, setSortBy] = useState('board_rank');
+  const [watchlist, setWatchlist] = useState(() => Array.isArray(league?.draftBoard?.shortlist) ? league.draftBoard.shortlist : []);
+  const [manualOrder, setManualOrder] = useState([]);
 
   const analysis = useMemo(() => buildDraftBoardAnalysis({
     team: userTeam,
@@ -16,11 +22,16 @@ export default function DraftBigBoard({ league, onPlayerSelect }) {
     prospects,
     draftPicks: league?.draftState?.picks ?? userTeam?.draftPicks ?? [],
     teamBuilder: league?.teamBuilderAnalysis ?? null,
+    shortlistIds: watchlist,
+    manualOrderIds: manualOrder,
     phase: league?.phase,
-  }), [userTeam, prospects, league?.draftState?.picks, league?.teamBuilderAnalysis, league?.phase]);
+  }), [userTeam, prospects, league?.draftState?.picks, league?.teamBuilderAnalysis, league?.phase, watchlist, manualOrder]);
 
   const visibleProspects = useMemo(() => analysis.prospectRows.filter((p) => {
+    if (viewMode === 'watchlist' && !p.isShortlist) return false;
     if (positionFilter !== 'ALL' && p.pos !== positionFilter) return false;
+    const needle = search.trim().toLowerCase();
+    if (needle && !`${p.name} ${p.pos} ${p.college ?? ''}`.toLowerCase().includes(needle)) return false;
     if (activeFilter === 'need') return p.currentTeamNeedLevel === 'urgent' || p.currentTeamNeedLevel === 'thin';
     if (activeFilter === 'starter_path') return p.roleProjection === 'starter_path';
     if (activeFilter === 'young_upside') return p.roleProjection === 'development_stash';
@@ -28,7 +39,26 @@ export default function DraftBigBoard({ league, onPlayerSelect }) {
     if (activeFilter === 'high_risk') return p.riskFlags.length > 0;
     if (activeFilter === 'bargain') return p.pickValueFit === 'bargain';
     return true;
-  }).slice(0, 10), [analysis, positionFilter, activeFilter]);
+  }).sort((a, b) => {
+    if (sortBy === 'best_fit') return b.sortKeys.fitScore - a.sortKeys.fitScore;
+    if (sortBy === 'ovr') return (b.sortKeys.ovr ?? -1) - (a.sortKeys.ovr ?? -1);
+    if (sortBy === 'potential') return (b.sortKeys.potential ?? -1) - (a.sortKeys.potential ?? -1);
+    if (sortBy === 'projected_round') return (a.sortKeys.projectedRound ?? 99) - (b.sortKeys.projectedRound ?? 99);
+    if (sortBy === 'scouting_confidence') return (b.sortKeys.scoutingConfidenceRank ?? -1) - (a.sortKeys.scoutingConfidenceRank ?? -1);
+    if (sortBy === 'lowest_risk') return (a.sortKeys.riskCount ?? 99) - (b.sortKeys.riskCount ?? 99);
+    return a.boardRank - b.boardRank;
+  }), [analysis, positionFilter, activeFilter, viewMode, search, sortBy]);
+
+  const moveProspect = (prospectId, dir) => {
+    const ids = (manualOrder.length > 0 ? manualOrder : analysis.prospectRows.map((p) => p.prospectId)).filter(Boolean);
+    const idx = ids.indexOf(prospectId);
+    if (idx < 0) return;
+    const next = idx + dir;
+    if (next < 0 || next >= ids.length) return;
+    const clone = [...ids];
+    [clone[idx], clone[next]] = [clone[next], clone[idx]];
+    setManualOrder(clone);
+  };
 
   return <div className="card-premium" style={{ padding: 12 }}>
     <h3>Draft Board</h3>
@@ -42,10 +72,18 @@ export default function DraftBigBoard({ league, onPlayerSelect }) {
     </div>
     <h4 style={{ marginTop: 10 }}>Team Needs Board</h4>
     {analysis.draftNeeds.slice(0,6).map((n)=><div key={n.pos} style={{fontSize:12, marginBottom:4}}>{n.pos} · {n.needLevel} · {n.targetRoundRange}</div>)}
-    <h4 style={{ marginTop: 10 }}>Filters</h4>
+    <h4 style={{ marginTop: 10 }}>Draft Snapshot</h4>
+    <div style={{ fontSize: 12 }}>Class: {analysis.classIdentity.headline}</div>
+    <div style={{ fontSize: 12 }}>Strengths: {analysis.classIdentity.strengths.join(', ') || 'Unknown'}</div>
+    <div style={{ fontSize: 12 }}>Thin spots: {analysis.classIdentity.thinSpots.join(', ') || 'Unknown'}</div>
+    <div style={{ fontSize: 12 }}>Likely early runs: {analysis.classIdentity.likelyEarlyRuns.join(', ') || 'Unknown'}</div>
+    <h4 style={{ marginTop: 10 }}>Board Controls</h4>
+    <div><button className="btn" onClick={() => setViewMode('board')}>Board</button><button className="btn" onClick={() => setViewMode('watchlist')}>Watchlist</button></div>
+    <input aria-label="Search prospects" value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search name / pos / college" style={{ width: '100%', marginTop: 6 }} />
     <div style={{ display:'flex', gap:6, flexWrap:'wrap' }}>{FILTERS.map((f)=><button key={f} className="btn" onClick={()=>setActiveFilter(f)}>{f}</button>)}{POS_FILTERS.map((p)=><button key={p} className="btn" onClick={()=>setPositionFilter(p)}>{p}</button>)}</div>
-    <h4 style={{ marginTop: 10 }}>Prospect Fits</h4>
-    {visibleProspects.length===0 ? <div style={{fontSize:12}}>No prospects available for current filters.</div> : visibleProspects.map((p)=><button key={p.prospectId} className="btn" style={{display:'block', width:'100%', textAlign:'left', marginBottom:6}} onClick={()=>onPlayerSelect?.(p.prospectId)}>{p.name} · {p.pos} · Fit {p.fitScore} · {p.recommendation} · {p.pickValueFit} · Scout {p.scoutingConfidence}</button>)}
+    <select aria-label="Sort prospects" value={sortBy} onChange={(e) => setSortBy(e.target.value)}>{SORTS.map((s) => <option key={s} value={s}>{s}</option>)}</select>
+    <h4 style={{ marginTop: 10 }}>Prospect Board</h4>
+    {visibleProspects.length===0 ? <div style={{fontSize:12}}>No prospects available for current filters.</div> : visibleProspects.map((p)=><div key={p.prospectId} className="stat-box" style={{marginBottom:6,padding:8}}><div style={{fontSize:12}}>{p.boardRank}. {p.name} · {p.pos} {p.college ? `· ${p.college}` : ''}</div><div style={{fontSize:11}}>OVR {p.ovr ?? 'N/A'} POT {p.potential ?? 'N/A'} · Round {p.projectedRound ?? 'Unknown'} · Fit {p.fitScore}</div><div style={{fontSize:11}}>{p.comparisonReceipt || p.reason}</div><div><button className="btn" onClick={()=>setWatchlist((prev)=>prev.includes(p.prospectId)?prev.filter((id)=>id!==p.prospectId):[...prev,p.prospectId])}>{p.isShortlist ? 'Unwatch' : 'Watch'}</button><button className="btn" onClick={()=>moveProspect(p.prospectId,-1)}>↑</button><button className="btn" onClick={()=>moveProspect(p.prospectId,1)}>↓</button><button className="btn" onClick={()=>onPlayerSelect?.(p.prospectId)}>Open profile</button></div></div>)}
     <h4 style={{ marginTop: 10 }}>Pick Assets</h4>
     {analysis.pickAssets.length===0 ? <div style={{fontSize:12}}>No user picks available.</div> : analysis.pickAssets.slice(0,6).map((pick)=><div key={pick.pickId} style={{fontSize:12}}>{pick.label} · value {pick.pickValue} · {pick.targetTier}</div>)}
   </div>;


### PR DESCRIPTION
### Motivation
- Restore a usable Draft Big Board workflow (search, board/watchlist toggle, sorting, manual ordering) so the Draft screen becomes a true scouting workspace rather than a lightweight list.  
- Provide richer, machine-friendly analysis metadata so the UI can surface comparisons, tiering, shortlist state, and multiple sort keys without re-computing heuristics in the component.  
- Preserve existing Draft Board v1 analysis and team-needs/pick-asset outputs while keeping all data honest (no invented prospect/scouting/college data).  

### Description
- Extended `buildDraftBoardAnalysis` to accept optional `shortlistIds` and `manualOrderIds` and return per-row workflow metadata including `boardRank`, `defaultRank`, `tier`, `college`, `workflowTags`, `comparisonReceipt`, `pickWindowLabel`, `isShortlist`, and `sortKeys` for safe, null-aware sorting.  
- Added `classIdentity` summary (`headline`, `strengths`, `thinSpots`, `likelyEarlyRuns`) derived from the actual prospect distribution and top/top-24 or projected R1-2 signals, and surfaced it in both `summary` and the root analysis object.  
- Upgraded `DraftBigBoard.jsx` into a workflow screen with Board/Watchlist toggle, search (name/pos/college), position and analysis filters, a sort selector, per-row cards showing richer fields, watch/unwatch action, and local move up/down manual ordering; watchlist and manual order are local UI state (not written to league).  
- Preserved all v1 outputs (draftNeeds, pickAssets, topFits, safePicks, etc.), implemented only UI/local-state ordering (no league mutation), and added defensive null-safe fallbacks so missing college/projectedRound/scouting data does not crash the UI.  
- Known limitations and truthfulness notes: watchlist/manual order is local-only in this PR and not persisted across sessions; no draft execution or team/trade/free agency logic was changed; no prospect data was invented—unknown fields are shown as unknown or hidden and picks during non-draft phases are labeled as a planning board.  

### Testing
- Ran `npm run test:unit -- src/core/draft/__tests__/draftBoardAnalysis.test.ts` and the suite passed.  
- Ran `npm run test:unit -- src/ui/components/Draft.test.jsx src/core/trades/__tests__/tradeFinderAnalysis.test.ts src/core/freeAgency/__tests__/freeAgencyMarketAnalysis.test.ts src/core/__tests__/rosterBuildingAnalysis.test.ts src/ui/utils/weeklyCommandHub.test.js src/ui/utils/leagueBootstrap.test.js` and all listed suites passed.  
- No dedicated Playability Smoke Test command was found in `package.json`, so no playability smoke script was executed.  
- Unit tests added/updated cover manual ordering influence, shortlist marking, tier assignment, class identity detection, likely early-run detection, comparison receipt presence, and null-safe sortKeys; all new tests passed in CI-local unit runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f526316b7c832d9d132f6f307fc13a)