### PR TITLE
Add player profile analysis helper with safe fallbacks and tests

### DIFF
--- a/src/core/__tests__/playerProfileAnalysis.test.ts
+++ b/src/core/__tests__/playerProfileAnalysis.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { buildPlayerProfileAnalysis, contractValueLabel, buildPositionStatSummary } from '../playerProfileAnalysis.js';
+
+const basePlayer: any = { id: 'p1', name: 'Test QB', pos: 'QB', age: 24, teamId: 't1', ovr: 78, potential: 86, ratings: { schemeFit: 72 } };
+
+describe('playerProfileAnalysis', () => {
+  it('roster player profile builds with identity/snapshot/ratings', () => {
+    const result = buildPlayerProfileAnalysis({ player: { ...basePlayer, contract: { baseAnnual: 8, yearsRemaining: 2 } }, team: { name: 'Sharks', abbr: 'SHK' } });
+    expect(result.identity.status).toBe('roster');
+    expect(result.snapshot.headline).toContain('Test QB');
+    expect(result.ratings.ovr).toBe(78);
+  });
+
+  it('free agent profile builds without team and does not crash', () => {
+    const result = buildPlayerProfileAnalysis({ player: { ...basePlayer, teamId: null } });
+    expect(result.identity.status).toBe('free_agent');
+  });
+
+  it('draft prospect profile builds with draft_prospect status', () => {
+    const result = buildPlayerProfileAnalysis({ player: { ...basePlayer, isProspect: true, teamId: null } });
+    expect(result.identity.status).toBe('draft_prospect');
+  });
+
+  it('missing stats do not crash and produce missing_stats warning', () => {
+    const result = buildPlayerProfileAnalysis({ player: basePlayer });
+    expect(result.warnings).toContain('missing_stats');
+  });
+
+  it('contract value label handles bargain/fair/expensive/unknown', () => {
+    expect(contractValueLabel({ baseAnnual: 5 }, 80)).toBe('bargain');
+    expect(contractValueLabel({ baseAnnual: 14.4 }, 80)).toBe('fair');
+    expect(contractValueLabel({ baseAnnual: 25 }, 80)).toBe('expensive');
+    expect(contractValueLabel(null as any, 80)).toBe('unknown');
+  });
+
+  it('injury status populates health warning', () => {
+    const result = buildPlayerProfileAnalysis({ player: { ...basePlayer, injury: { status: 'Out', weeksRemaining: 2 } } });
+    expect(result.warnings).toContain('injury');
+  });
+
+  it('potential gap creates development priority', () => {
+    const result = buildPlayerProfileAnalysis({ player: { ...basePlayer, ovr: 70, potential: 85 } });
+    expect(result.development.developmentPriority).toBe('high');
+  });
+
+  it('low scheme fit creates warning', () => {
+    const result = buildPlayerProfileAnalysis({ player: { ...basePlayer, ratings: { schemeFit: 40 } } });
+    expect(result.warnings).toContain('low_scheme_fit');
+  });
+
+  it('position-specific stat summary works', () => {
+    expect(buildPositionStatSummary('QB', { passYd: 3000, passTD: 20 }).label).toContain('QB');
+    expect(buildPositionStatSummary('RB', { rushYd: 1200 }).label).toContain('Rushing');
+    expect(buildPositionStatSummary('WR', { recYd: 900 }).label).toContain('Receiving');
+    expect(buildPositionStatSummary('LB', { tackles: 80 }).label).toContain('Defensive');
+  });
+
+  it('missing player returns safe result', () => {
+    const result = buildPlayerProfileAnalysis({ player: null as any });
+    expect(result.identity).toBeNull();
+  });
+});

--- a/src/core/playerProfileAnalysis.js
+++ b/src/core/playerProfileAnalysis.js
@@ -1,0 +1,122 @@
+function toNum(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function resolveStatus(player, league) {
+  if (!player) return 'unknown';
+  if (player.isRetired || player.retired) return 'retired';
+  if (player.isProspect || player.prospect || player.draftEligible || league?.draftClass?.some((p) => (p.id ?? p.prospectId) === (player.id ?? player.prospectId))) return 'draft_prospect';
+  if (player.teamId == null || player.teamId === 'FA') return 'free_agent';
+  return 'roster';
+}
+
+function contractValueLabel(contract, ovr) {
+  if (!contract) return 'unknown';
+  const annual = toNum(contract.baseAnnual ?? contract.salary ?? contract.avgPerYear ?? contract.valuePerYear);
+  if (annual == null || ovr == null) return 'unknown';
+  const expected = Math.max(1, ovr) * 0.18;
+  if (annual < expected * 0.85) return 'bargain';
+  if (annual > expected * 1.15) return 'expensive';
+  return 'fair';
+}
+
+function buildPositionStatSummary(pos, stats) {
+  if (!stats) return { label: 'No tracked stats yet.', stats: [] };
+  const p = (pos || '').toUpperCase();
+  if (p === 'QB') return { label: 'QB production', stats: [
+    ['Passing Yards', stats.passYd], ['TD', stats.passTD], ['INT', stats.interceptions], ['Completion %', stats.passAtt ? ((stats.passComp || 0) / stats.passAtt * 100).toFixed(1) : null], ['Sacks', stats.sacks],
+  ] };
+  if (p === 'RB' || p === 'FB') return { label: 'Rushing production', stats: [
+    ['Rush Yards', stats.rushYd], ['TD', stats.rushTD], ['Yards/Carry', stats.rushAtt ? ((stats.rushYd || 0) / stats.rushAtt).toFixed(1) : null], ['Rec Yards', stats.recYd],
+  ] };
+  if (p === 'WR' || p === 'TE') return { label: 'Receiving production', stats: [
+    ['Receptions', stats.receptions], ['Rec Yards', stats.recYd], ['TD', stats.recTD], ['Yards/Catch', stats.receptions ? ((stats.recYd || 0) / stats.receptions).toFixed(1) : null],
+  ] };
+  if (p === 'K') return { label: 'Kicking production', stats: [['FG', stats.fgMade], ['XP', stats.xpMade]] };
+  if (p === 'P') return { label: 'Punting production', stats: [['Punts', stats.punts], ['Punt Avg', stats.punts ? ((stats.puntYards || 0) / stats.punts).toFixed(1) : null]] };
+  return { label: 'Defensive production', stats: [['Tackles', stats.tackles], ['Sacks', stats.sacks], ['INT', stats.interceptions], ['Forced Fumbles', stats.forcedFumbles]] };
+}
+
+export function buildPlayerProfileAnalysis({ player, team, league, recentGames = [], userTeam, context }) {
+  if (!player) return { identity: null, warnings: ['unknown_eval'] };
+  const seasonStats = player.seasonStats ?? player.stats ?? null;
+  const careerStats = player.careerStats ?? null;
+  const status = resolveStatus(player, league);
+  const ovr = toNum(player.ovr ?? player.ratings?.ovr);
+  const potential = toNum(player.potential ?? player.ratings?.potential ?? player.pot);
+  const schemeFit = toNum(player.schemeFit ?? player.ratings?.schemeFit);
+  const potentialGap = potential != null && ovr != null ? potential - ovr : null;
+  const contract = player.contract ?? null;
+
+  const warnings = [];
+  if (!seasonStats && !careerStats) warnings.push('missing_stats');
+  if (!contract && status === 'roster') warnings.push('missing_contract');
+  if (schemeFit != null && schemeFit < 50) warnings.push('low_scheme_fit');
+  if (player.injury?.status && player.injury.status !== 'Healthy') warnings.push('injury');
+  if (player.age >= 30) warnings.push('age_decline');
+
+  const summary = buildPositionStatSummary(player.pos, seasonStats);
+
+  return {
+    identity: {
+      playerId: player.id ?? player.prospectId ?? null,
+      name: player.name ?? 'Unknown Player',
+      pos: player.pos ?? 'UNK',
+      age: player.age ?? null,
+      teamId: player.teamId ?? null,
+      teamName: team?.name ?? null,
+      teamAbbr: team?.abbr ?? null,
+      status,
+    },
+    snapshot: {
+      headline: `${player.name ?? 'Unknown'} · ${player.pos ?? 'UNK'}`,
+      subheadline: status === 'draft_prospect' ? 'Draft prospect evaluation' : 'Player evaluation',
+      roleLabel: player.role ?? (status === 'free_agent' ? 'free_agent' : 'unknown'),
+      profileTags: [status, player.archetype].filter(Boolean),
+    },
+    ratings: { ovr, potential, schemeFit, archetype: player.archetype ?? null, strengths: player.strengths ?? [], weaknesses: player.weaknesses ?? [], trend: player.devTrend ?? 'unknown' },
+    role: { label: player.role ?? 'unknown', depthRank: player.depthRank ?? null },
+    contract: contract ? {
+      baseAnnual: contract.baseAnnual ?? contract.salary ?? null,
+      yearsRemaining: contract.yearsRemaining ?? contract.years ?? null,
+      capHit: contract.capHit ?? null,
+      valueLabel: contractValueLabel(contract, ovr),
+      extensionRisk: player.extensionRisk ?? null,
+    } : null,
+    health: {
+      injuryStatus: player.injury?.status ?? 'Healthy',
+      injuryWeeksRemaining: player.injury?.weeksRemaining ?? null,
+      riskLabel: player.injury?.status && player.injury.status !== 'Healthy' ? 'elevated' : 'normal',
+    },
+    morale: player.morale ? { ...player.morale } : null,
+    development: {
+      ageCurveLabel: player.age != null ? (player.age < 25 ? 'ascending' : player.age < 30 ? 'prime' : 'declining') : 'unknown',
+      potentialGap,
+      developmentPriority: potentialGap != null && potentialGap >= 8 ? 'high' : potentialGap != null && potentialGap >= 4 ? 'medium' : 'low',
+      recentTrainingFocus: player.trainingFocus ?? null,
+    },
+    stats: {
+      seasonStats,
+      careerStats,
+      keyStats: summary,
+    },
+    gameLog: Array.isArray(recentGames) ? recentGames : [],
+    career: { seasons: Array.isArray(careerStats) ? careerStats.length : 0 },
+    transactionHistory: Array.isArray(player.transactionHistory) ? player.transactionHistory : [],
+    awards: Array.isArray(player.awards) ? player.awards : [],
+    fitSummary: {
+      whyFits: context?.whyFits ?? null,
+      whyRisky: context?.whyRisky ?? null,
+      action: context?.action ?? 'watch',
+    },
+    recommendationContext: {
+      source: context?.source ?? 'unknown',
+      reason: context?.reason ?? null,
+      comparisonReceipt: context?.comparisonReceipt ?? null,
+    },
+    warnings,
+  };
+}
+
+export { buildPositionStatSummary, contractValueLabel };


### PR DESCRIPTION
### Motivation
- Provide a single pure helper to build a consistent, null-safe player profile model that UI can consume for the Player Profile / Career Page v2 without fabricating data. 
- Ensure roster players, free agents, and draft prospects resolve safely and surface honest warnings when data is missing. 
- Supply position-aware stat summaries and simple heuristics (fit/value/development) so front-end cards can show meaningful, mobile-first summaries without embedding business logic in presentation components.

### Description
- Added `src/core/playerProfileAnalysis.js` which exports `buildPlayerProfileAnalysis` and helpers `buildPositionStatSummary` and `contractValueLabel`, producing structured sections (`identity`, `snapshot`, `ratings`, `role`, `contract`, `health`, `morale`, `development`, `stats`, `gameLog`, `career`, `transactionHistory`, `awards`, `fitSummary`, `recommendationContext`, `warnings`). 
- Implements explicit status resolution for `roster` / `free_agent` / `draft_prospect` / `retired` / `unknown`, a non-op `contractValueLabel` heuristic for bargain/fair/expensive/unknown, position-specific stat summaries for QB/RB/WR/TE/Defense/K/P, and a set of safe warning flags (`missing_stats`, `missing_contract`, `low_scheme_fit`, `injury`, `age_decline`). 
- Uses only existing input fields (no invented stats/awards/contracts/history) and returns `null`/empty values and warnings when data is absent, avoiding throws on missing player input. 
- Known limitations: this PR implements the analysis model and tests only and does not yet wire the helper into every profile UI, market screen passthroughs, or add any persistence/season-summary changes.

### Testing
- Added unit tests at `src/core/__tests__/playerProfileAnalysis.test.ts` covering 10 cases (roster/free-agent/prospect identity, missing stats warning, contract label classifications, injury and low scheme-fit warnings, development priority from potential gap, position stat summaries, and safe handling of a missing player). 
- Ran the new unit test and related suites with: `npm run test:unit -- src/core/__tests__/playerProfileAnalysis.test.ts` which passed, and also re-ran related analysis/unit suites with `npm run test:unit -- src/core/draft/__tests__/draftBoardAnalysis.test.ts src/core/trades/__tests__/tradeFinderAnalysis.test.ts src/core/freeAgency/__tests__/freeAgencyMarketAnalysis.test.ts src/core/__tests__/rosterBuildingAnalysis.test.ts src/ui/utils/weeklyCommandHub.test.js src/ui/utils/leagueBootstrap.test.js`, all of which passed. 
- No UI integration tests or persistence changes were added in this PR, so UI wiring and manual QA checklist items remain to be completed in follow-up work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f52a5f56ac832db2a3f7e4d3365401)