### PR TITLE
Add game-memory foundation with box score fallback routing and player game logs

### DIFF
--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -428,7 +428,7 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
   const hasAnyPayload = Boolean(game && (
     game.homeScore != null || game.awayScore != null || game.stats || game.playerStats || game.teamStats || game.recap || game.quarterScores
   ));
-  const unavailableMessage = "No data saved for this game.";
+  const unavailableMessage = "Detailed box score data was not recorded for this game.";
   const prepImpact = game?.prepImpact ?? null;
   const prepRows = useMemo(() => ([
     { side: "away", team: awayTeam, impact: prepImpact?.away ?? null },
@@ -490,7 +490,7 @@ export default function BoxScore({ gameId, actions, league, onClose, onBack, onP
               <div className="bs-list-item" style={{ borderColor: "var(--warning)", color: "var(--text-muted)" }}>
                 {archiveQuality === "partial"
                   ? "Result recorded. Partial archive: final score and summary are available, but complete drive/play detail was not stored."
-                  : "Result recorded. Detailed box score is unavailable for this game, but any recap and context below are still shown."}
+                  : "Detailed box score data was not recorded for this game."}
               </div>
             </section>
           )}

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -27,6 +27,7 @@ import { ToneChip, DevelopmentSignalRow, DevelopmentStatCard } from './PlayerDev
 import EmptyState from './EmptyState.jsx';
 import { buildRouteRequestKey, buildLeagueCacheScopeKey } from "../utils/requestLoopGuard.js";
 import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
+import { getPlayerGameLogs } from "../utils/playerGameLogs.js";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
@@ -356,6 +357,7 @@ export default function PlayerProfile({
   teams = [],
   league = null,
   onNavigate = null,
+  onOpenBoxScore = null,
   isUserOnClock = false,
   onDraftPlayer = null,
   profileContext = null,
@@ -531,6 +533,7 @@ export default function PlayerProfile({
   );
 
   const profileAnalysis = useMemo(() => buildPlayerProfileAnalysis({ player: effectivePlayer, team: resolvedProfile.team, league, context: profileContext ?? {} }), [effectivePlayer, resolvedProfile.team, league, profileContext]);
+  const playerGameLogs = useMemo(() => getPlayerGameLogs(league, effectivePlayer), [league, effectivePlayer]);
   const gmContext = profileAnalysis?.recommendationContext ?? {};
   const hasGmContext = Boolean(
     gmContext?.sourceLabel || gmContext?.reason || gmContext?.comparisonReceipt || gmContext?.recommendation || gmContext?.fitScore != null || gmContext?.capImpactLabel || gmContext?.valueLabel
@@ -881,7 +884,7 @@ export default function PlayerProfile({
         {/* ── Body ── */}
         <div style={{ padding: "var(--space-4)", flex: 1, display: "grid", gap: "var(--space-4)" }}>
           <div className="standings-tabs profile-tab-row" style={{ gap: 6, flexWrap: "nowrap" }}>
-            {["Overview", "Career Stats"].map((tab) => (
+            {["Overview", "Career Stats", "Game Log"].map((tab) => (
               <button
                 key={tab}
                 className={`standings-tab${activeProfileTab === tab ? " active" : ""}`}
@@ -1559,6 +1562,39 @@ export default function PlayerProfile({
             </section>
           )}
             </>
+          )}
+          {activeProfileTab === "Game Log" && (
+            <section className="card-enter">
+              <h3 style={sectionLabelStyle}>Game Log</h3>
+              {playerGameLogs.length === 0 ? (
+                <EmptyState title="No game logs recorded yet." body="Game logs will appear once this player has archived game stats." />
+              ) : (
+                <div className="table-wrapper" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
+                  <Table className="standings-table" style={{ width: "100%", minWidth: 560 }}>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Week</TableHead>
+                        <TableHead>Opponent</TableHead>
+                        <TableHead>Result</TableHead>
+                        <TableHead>Summary</TableHead>
+                        <TableHead>Game</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {playerGameLogs.map((row) => (
+                        <TableRow key={`${row.week}-${row.gameId ?? row.opponentId}`}>
+                          <TableCell>W{row.week}</TableCell>
+                          <TableCell>{row.opponentAbbr}</TableCell>
+                          <TableCell>{row.result}</TableCell>
+                          <TableCell>{row.summary}</TableCell>
+                          <TableCell>{row.gameId ? <button type="button" className="btn-link" onClick={() => onOpenBoxScore?.(row.gameId)}>Open</button> : "—"}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </section>
           )}
           {activeProfileTab === "Career Stats" && (
             <section className="card-enter">

--- a/src/ui/utils/boxScoreAccess.js
+++ b/src/ui/utils/boxScoreAccess.js
@@ -62,7 +62,7 @@ export function getBoxScoreAvailability(game, context = {}) {
     || normalized?.teamDriveStats?.home
     || normalized?.teamDriveStats?.away,
   );
-  const canOpen = Boolean(isCompleted && resolvedGameId && (archiveQuality !== "missing" || hasAnyDetail));
+  const canOpen = Boolean(isCompleted && resolvedGameId);
   let fallbackReason = null;
   if (!isCompleted) fallbackReason = "Game not completed";
   else if (!resolvedGameId) fallbackReason = "Missing game identity";

--- a/src/ui/utils/boxScoreAccess.test.js
+++ b/src/ui/utils/boxScoreAccess.test.js
@@ -18,4 +18,20 @@ describe('box score access clickthrough', () => {
     expect(opened).toBe(true);
     expect(onOpen).toHaveBeenCalledWith('2026_w7_1_2');
   });
+
+  it('still opens completed game scores when detailed archive is missing', () => {
+    const onOpen = vi.fn();
+    const game = {
+      gameId: '2026_w8_3_4',
+      played: true,
+      homeId: 3,
+      awayId: 4,
+      homeScore: 13,
+      awayScore: 10,
+    };
+
+    const opened = openResolvedBoxScore(game, { seasonId: '2026', week: 8, source: 'unit_test' }, onOpen);
+    expect(opened).toBe(true);
+    expect(onOpen).toHaveBeenCalledWith('2026_w8_3_4');
+  });
 });

--- a/src/ui/utils/playerGameLogs.js
+++ b/src/ui/utils/playerGameLogs.js
@@ -1,0 +1,57 @@
+import { resolveCompletedGameId } from './gameResultIdentity.js';
+
+function normalizeTeamId(value) {
+  return Number(value?.id ?? value);
+}
+
+function normalizeResult(game, teamId) {
+  const homeId = normalizeTeamId(game?.homeId ?? game?.home);
+  const awayId = normalizeTeamId(game?.awayId ?? game?.away);
+  const homeScore = Number(game?.homeScore);
+  const awayScore = Number(game?.awayScore);
+  if (!Number.isFinite(homeScore) || !Number.isFinite(awayScore)) return '—';
+  const isHome = teamId === homeId;
+  const teamScore = isHome ? homeScore : awayScore;
+  const oppScore = isHome ? awayScore : homeScore;
+  const prefix = teamScore > oppScore ? 'W' : teamScore < oppScore ? 'L' : 'T';
+  return `${prefix} ${teamScore}-${oppScore}`;
+}
+
+export function summarizePlayerGameStats(stats = {}, pos = '') {
+  const position = String(pos || '').toUpperCase();
+  if (position === 'QB') return `${stats.passComp ?? 0}/${stats.passAtt ?? 0}, ${stats.passYd ?? 0} PYD, ${stats.passTD ?? 0} TD, ${stats.interceptions ?? 0} INT`;
+  if (['RB', 'FB'].includes(position)) return `${stats.rushAtt ?? 0} CAR, ${stats.rushYd ?? 0} RYD, ${stats.rushTD ?? 0} TD`;
+  if (['WR', 'TE'].includes(position)) return `${stats.receptions ?? 0} REC, ${stats.recYd ?? 0} RYD, ${stats.recTD ?? 0} TD`;
+  if (['K'].includes(position)) return `${stats.fieldGoalsMade ?? 0}/${stats.fieldGoalsAttempted ?? 0} FG, ${stats.extraPointsMade ?? 0}/${stats.extraPointsAttempted ?? 0} XP`;
+  if (['P'].includes(position)) return `${stats.punts ?? 0} P, ${stats.puntYards ?? 0} YDS`;
+  return `${stats.tackles ?? 0} TKL, ${stats.sacks ?? 0} SACK, ${stats.interceptions ?? 0} INT`;
+}
+
+export function getPlayerGameLogs(league, player) {
+  if (!league?.schedule?.weeks || !player?.id) return [];
+  const playerId = String(player.id);
+  const rows = [];
+  for (const weekRow of league.schedule.weeks) {
+    const week = Number(weekRow?.week);
+    for (const game of weekRow?.games ?? []) {
+      if (!game?.played) continue;
+      const homeStats = game?.playerStats?.home ?? game?.stats?.home ?? {};
+      const awayStats = game?.playerStats?.away ?? game?.stats?.away ?? {};
+      const statRow = homeStats[playerId] ?? awayStats[playerId] ?? null;
+      if (!statRow) continue;
+      const homeId = normalizeTeamId(game?.homeId ?? game?.home);
+      const awayId = normalizeTeamId(game?.awayId ?? game?.away);
+      const playerTeamId = normalizeTeamId(player?.teamId);
+      const opponentId = playerTeamId === homeId ? awayId : homeId;
+      rows.push({
+        week,
+        gameId: resolveCompletedGameId(game, { seasonId: league?.seasonId, week }),
+        opponentId,
+        opponentAbbr: league?.teamById?.[opponentId]?.abbr ?? 'OPP',
+        result: normalizeResult(game, playerTeamId),
+        summary: summarizePlayerGameStats(statRow?.stats ?? statRow, player?.pos ?? player?.position),
+      });
+    }
+  }
+  return rows.sort((a, b) => a.week - b.week);
+}

--- a/src/ui/utils/playerGameLogs.test.js
+++ b/src/ui/utils/playerGameLogs.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { getPlayerGameLogs } from './playerGameLogs.js';
+
+describe('getPlayerGameLogs', () => {
+  it('returns only games that include the selected player', () => {
+    const league = {
+      seasonId: '2026',
+      teamById: { 1: { abbr: 'AAA' }, 2: { abbr: 'BBB' }, 3: { abbr: 'CCC' } },
+      schedule: {
+        weeks: [
+          { week: 1, games: [{ played: true, home: 1, away: 2, homeScore: 24, awayScore: 17, playerStats: { home: { '12': { stats: { passAtt: 30, passComp: 20, passYd: 250, passTD: 2, interceptions: 1 } } }, away: {} } }] },
+          { week: 2, games: [{ played: true, home: 3, away: 1, homeScore: 10, awayScore: 21, playerStats: { home: {}, away: { '99': { stats: { rushAtt: 10, rushYd: 54 } } } } }] },
+        ],
+      },
+    };
+    const logs = getPlayerGameLogs(league, { id: 12, teamId: 1, pos: 'QB' });
+    expect(logs).toHaveLength(1);
+    expect(logs[0].week).toBe(1);
+    expect(logs[0].opponentAbbr).toBe('BBB');
+    expect(logs[0].result).toBe('W 24-17');
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide the first honest, minimal “game memory” layer so completed games are inspectable and players have per-game logs without rewriting the simulator engine.
- Ensure the UI never fabricates detailed box-score content and shows a truthful fallback when detailed stats were not recorded.
- Keep the change small and defensive so existing saves and simulation flows remain compatible.

### Description
- Allow completed games to open the Game Book even when a full archive is missing by relaxing the `canOpen` check in `src/ui/utils/boxScoreAccess.js` (now only requires a resolvable game id and a completed score). 
- Replace ambiguous fallback copy in `src/ui/components/BoxScore.jsx` with explicit messaging: `"Detailed box score data was not recorded for this game."` for missing-detail states. 
- Add `src/ui/utils/playerGameLogs.js` which derives per-player game-log rows from existing `schedule` + `playerStats`/`stats` (provides `week`, `opponent`, `result`, position-aware `summary`, and `gameId` for deep-links). 
- Surface player game logs in the Player Profile by adding a `Game Log` tab and integrating `getPlayerGameLogs` in `src/ui/components/PlayerProfile.jsx`, and accept an `onOpenBoxScore` prop for the profile to deep-link back to the Game Book; no save-schema changes were introduced. 
- Add/adjust unit tests: new `playerGameLogs.test.js` and an additional case in `boxScoreAccess.test.js` to assert clickthrough when archive detail is missing.

### Testing
- Ran the unit tests for the modified utilities with `npm run test:unit -- src/ui/utils/boxScoreAccess.test.js src/ui/utils/playerGameLogs.test.js`; both test files passed (2 files, 3 tests total) and returned green. 
- Verified the updated `boxScoreAccess` test asserts that `openResolvedBoxScore` returns true for completed games even without detailed archives. 
- Verified the new `playerGameLogs` test ensures only games containing the player’s archived stat row are returned and fields (`week`, `opponentAbbr`, `result`) are formatted as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5781ee38c832da366df62e861164d)