### PR TITLE
Game Book v1.1: restore archive loading, add game-story, expand stat tables and sortable tables

### DIFF
--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -1,6 +1,8 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { EmptyState } from "./ScreenSystem.jsx";
 import { buildBoxScoreViewModel } from "../utils/boxScoreViewModel.js";
+import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
+import { buildGameBookStory } from "../utils/gameBookStory.js";
 
 const QUALITY_BADGE_CLASS = {
   "Full detail": "success",
@@ -22,15 +24,26 @@ export function PlayerButton({ player, onSelect }) {
 }
 
 const asNum = (v) => (Number.isFinite(Number(v)) ? Number(v) : null);
+const desc = "desc";
 
 function BoxScore({ gameId, league, actions, onClose, onPlayerSelect, onTeamSelect, embedded = false }) {
-  const game = actions?.getBoxScore ? null : (league?.gameById?.[gameId] ?? null);
+  const canLoadArchive = Boolean(gameId && typeof actions?.getBoxScore === "function");
+  const { data: archiveGame } = useStableRouteRequest({
+    requestKey: canLoadArchive ? `boxscore:${gameId}` : null,
+    enabled: canLoadArchive,
+    cacheScopeKey: league?.id ?? league?.leagueId ?? "global",
+    fetcher: () => actions.getBoxScore(gameId),
+  });
+
+  const fallbackGame = league?.gameById?.[gameId] ?? null;
+  const game = archiveGame ?? fallbackGame;
   const vm = useMemo(() => buildBoxScoreViewModel({ league, game, gameId, context: { season: league?.seasonId, week: league?.week } }), [league, game, gameId]);
+  const [sortState, setSortState] = useState({});
 
   if (!vm || vm.status === "unavailable") {
     return <EmptyState title="Game Book unavailable" body="Game data missing." />;
   }
-
+  const storyBullets = buildGameBookStory(vm);
   const qHome = vm.quarterScores?.home ?? [];
   const qAway = vm.quarterScores?.away ?? [];
   const qCount = Math.max(qHome.length, qAway.length, 4);
@@ -49,18 +62,24 @@ function BoxScore({ gameId, league, actions, onClose, onPlayerSelect, onTeamSele
   ].filter(([, a, h]) => a != null || h != null);
 
   const tables = [
-    { title: "Passing", cols: [["passComp", "Cmp"], ["passAtt", "Att"], ["passYd", "Yds"], ["passTD", "TD"], ["interceptions", "INT"], ["sacked", "Sck"]], include: (s) => asNum(s.passAtt) > 0 },
-    { title: "Rushing", cols: [["rushAtt", "Att"], ["rushYd", "Yds"], ["rushTD", "TD"], ["rushLong", "Long"]], include: (s) => asNum(s.rushAtt) > 0 },
-    { title: "Receiving", cols: [["targets", "Tgt"], ["receptions", "Rec"], ["recYd", "Yds"], ["recTD", "TD"], ["recLong", "Long"]], include: (s) => asNum(s.receptions) > 0 || asNum(s.targets) > 0 },
-    { title: "Defense", cols: [["tackles", "Tkl"], ["sacks", "Sack"], ["tfl", "TFL"], ["interceptions", "INT"], ["passesDefended", "PD"], ["forcedFumbles", "FF"], ["fumbleRecoveries", "FR"], ["defTD", "TD"]], include: (s) => asNum(s.tackles) > 0 || asNum(s.sacks) > 0 },
+    { title: "Passing", defaultSort: "passYd", cols: [["passComp", "Cmp"], ["passAtt", "Att"], ["passYd", "Yds"], ["passTD", "TD"], ["interceptions", "INT"], ["sacked", "Sck"]], include: (s) => asNum(s.passAtt) > 0 },
+    { title: "Rushing", defaultSort: "rushYd", cols: [["rushAtt", "Att"], ["rushYd", "Yds"], ["rushTD", "TD"], ["rushLong", "Long"]], include: (s) => asNum(s.rushAtt) > 0 },
+    { title: "Receiving", defaultSort: "recYd", cols: [["targets", "Tgt"], ["receptions", "Rec"], ["recYd", "Yds"], ["recTD", "TD"], ["recLong", "Long"]], include: (s) => asNum(s.receptions) > 0 || asNum(s.targets) > 0 },
+    { title: "Defense", defaultSort: "tackles", cols: [["tackles", "Tkl"], ["sacks", "Sack"], ["tfl", "TFL"], ["interceptions", "INT"], ["passesDefended", "PD"], ["forcedFumbles", "FF"], ["fumbleRecoveries", "FR"], ["defTD", "TD"]], include: (s) => asNum(s.tackles) > 0 || asNum(s.sacks) > 0 },
+    { title: "Kicking", defaultSort: "points", cols: [["fieldGoalsMade", "FGM"], ["fieldGoalsAttempted", "FGA"], ["fieldGoalPct", "FG%"], ["extraPointsMade", "XPM"], ["extraPointsAttempted", "XPA"], ["points", "Pts"]], include: (s) => asNum(s.fieldGoalsAttempted) > 0 || asNum(s.extraPointsAttempted) > 0 },
+    { title: "Punting", defaultSort: "puntYards", cols: [["punts", "Punt"], ["puntYards", "Yds"], ["puntAvg", "Avg"], ["puntLong", "Long"], ["puntsInside20", "In20"]], include: (s) => asNum(s.punts) > 0 },
+    { title: "Returns", defaultSort: "returnYards", cols: [["kickReturns", "KR"], ["kickReturnYards", "KR Yds"], ["puntReturns", "PR"], ["puntReturnYards", "PR Yds"], ["returnTD", "TD"]], include: (s) => asNum(s.kickReturns) > 0 || asNum(s.puntReturns) > 0 },
+    { title: "Blocking", defaultSort: "passBlockWinRate", cols: [["passBlockWins", "PBW"], ["passBlockAttempts", "PBA"], ["passBlockWinRate", "PBWR"], ["runBlockWins", "RBW"], ["runBlockAttempts", "RBA"], ["runBlockWinRate", "RBWR"]], include: (s) => asNum(s.passBlockAttempts) > 0 || asNum(s.runBlockAttempts) > 0 },
   ];
 
   const renderTable = (spec) => {
-    const away = (vm.playerTables?.away ?? []).filter((p) => spec.include(p.stats ?? {}));
-    const home = (vm.playerTables?.home ?? []).filter((p) => spec.include(p.stats ?? {}));
+    const sort = sortState[spec.title] ?? { key: spec.defaultSort, dir: desc };
+    const sortPlayers = (players) => [...players].sort((a, b) => ((asNum(b.stats?.[sort.key]) ?? -Infinity) - (asNum(a.stats?.[sort.key]) ?? -Infinity)) * (sort.dir === desc ? 1 : -1));
+    const away = sortPlayers((vm.playerTables?.away ?? []).filter((p) => spec.include(p.stats ?? {})));
+    const home = sortPlayers((vm.playerTables?.home ?? []).filter((p) => spec.include(p.stats ?? {})));
     if (!away.length && !home.length) return null;
     const rows = [[vm.awayTeam, away], [vm.homeTeam, home]];
-    return <section key={spec.title} className="bs-section"><h4>{spec.title}</h4><div className="bs-table-wrap"><table className="box-score-table"><thead><tr><th>Team</th><th>Player</th>{spec.cols.map(([, label]) => <th key={label}>{label}</th>)}</tr></thead><tbody>{rows.map(([team, players]) => players.map((p) => <tr key={`${spec.title}-${team?.id}-${p.playerId}`}><td>{team?.abbr}</td><td><PlayerButton player={p} onSelect={onPlayerSelect} /></td>{spec.cols.map(([key, label]) => <td key={label}>{p.stats?.[key] ?? "—"}</td>)}</tr>))}</tbody></table></div></section>;
+    return <section key={spec.title} className="bs-section"><h4>{spec.title}</h4><div className="bs-table-wrap"><table className="box-score-table"><thead><tr><th>Team</th><th>Player</th>{spec.cols.map(([key, label]) => <th key={label}><button className="btn-link" onClick={() => setSortState((prev) => ({ ...prev, [spec.title]: { key, dir: prev?.[spec.title]?.key === key && prev?.[spec.title]?.dir === desc ? "asc" : desc } }))}>{label}</button></th>)}</tr></thead><tbody>{rows.map(([team, players]) => players.map((p) => <tr key={`${spec.title}-${team?.id}-${p.playerId}`}><td>{team?.abbr}</td><td><PlayerButton player={p} onSelect={onPlayerSelect} /></td>{spec.cols.map(([key, label]) => <td key={label}>{p.stats?.[key] ?? "—"}</td>)}</tr>))}</tbody></table></div></section>;
   };
 
   return <div className={embedded ? "card" : "modal-content"}>
@@ -70,15 +89,15 @@ function BoxScore({ gameId, league, actions, onClose, onPlayerSelect, onTeamSele
       <div>{vm.finalScore.away ?? "—"} - {vm.finalScore.home ?? "—"}</div>
       <div>Week {vm.week ?? "—"} · Season {vm.season ?? "—"}</div>
       <span className={`status-chip ${QUALITY_BADGE_CLASS[vm.archiveQuality] ?? "muted"}`}>{vm.archiveQuality}</span>
-      {vm.missingDetailReason ? <p>{vm.missingDetailReason}</p> : null}
+      {vm.detailWarning ? <p>{vm.detailWarning}</p> : null}
     </section>
-
+    <section className="bs-section"><h4>Why this game was decided</h4>{storyBullets.length ? <ul>{storyBullets.map((b) => <li key={b}>{b}</li>)}</ul> : <p>No detailed team/player stats were recorded for this game.</p>}</section>
     <section className="bs-section"><h4>Score by quarter</h4>{hasQuarter ? <div className="bs-table-wrap"><table className="box-score-table"><thead><tr><th>Team</th>{headers.map((h) => <th key={h}>{h}</th>)}<th>Final</th></tr></thead><tbody><tr><td><TeamButton team={vm.awayTeam} onSelect={onTeamSelect} /></td>{headers.map((_, i) => <td key={`a-${i}`}>{qAway[i] ?? "—"}</td>)}<td>{vm.finalScore.away ?? "—"}</td></tr><tr><td><TeamButton team={vm.homeTeam} onSelect={onTeamSelect} /></td>{headers.map((_, i) => <td key={`h-${i}`}>{qHome[i] ?? "—"}</td>)}<td>{vm.finalScore.home ?? "—"}</td></tr></tbody></table></div> : <p>Quarter-by-quarter scoring was not recorded for this game.</p>}</section>
 
     <section className="bs-section"><h4>Team comparison</h4>{teamRows.length ? <div className="bs-table-wrap"><table className="box-score-table"><thead><tr><th>Stat</th><th>{vm.awayTeam.abbr}</th><th>{vm.homeTeam.abbr}</th></tr></thead><tbody>{teamRows.map(([label, a, h]) => <tr key={label}><td>{label}</td><td>{a ?? "—"}</td><td>{h ?? "—"}</td></tr>)}</tbody></table></div> : <p>Team totals were not recorded for this game.</p>}</section>
 
     <section className="bs-section"><h4>Scoring summary</h4>{vm.scoringSummary?.length ? <div className="bs-table-wrap"><table className="box-score-table"><thead><tr><th>Qtr</th><th>Time</th><th>Team</th><th>Type</th><th>Description</th><th>Score</th></tr></thead><tbody>{vm.scoringSummary.map((r, i) => <tr key={i}><td>{r.quarter ?? "—"}</td><td>{r.time ?? r.clock ?? "—"}</td><td>{r.teamAbbr ?? r.team ?? "—"}</td><td>{r.type ?? "—"}</td><td>{r.description ?? r.text ?? "—"}</td><td>{r.scoreAfter ?? "—"}</td></tr>)}</tbody></table></div> : <p>Scoring summary was not recorded for this game.</p>}</section>
-
+    {vm.prepImpact?.length ? <section className="bs-section"><h4>Game-plan impact</h4><ul>{vm.prepImpact.map((item, i) => <li key={`${i}-${item}`}>{item}</li>)}</ul></section> : null}
     {tables.map(renderTable)}
   </div>;
 }

--- a/src/ui/components/BoxScore.test.jsx
+++ b/src/ui/components/BoxScore.test.jsx
@@ -1,32 +1,33 @@
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { renderToString } from 'react-dom/server';
 import BoxScore, { PlayerButton } from './BoxScore.jsx';
 
+vi.mock('../hooks/useStableRouteRequest.js', () => ({ default: vi.fn(() => ({ data: null })) }));
+import useStableRouteRequest from '../hooks/useStableRouteRequest.js';
+
 describe('BoxScore game book rendering', () => {
   const baseLeague = { seasonId: 2031, week: 2, teams: [{ id: 1, abbr: 'KC' }, { id: 2, abbr: 'BUF' }] };
+  beforeEach(() => vi.mocked(useStableRouteRequest).mockReturnValue({ data: null }));
 
-  it('renders score-only game', () => {
-    const html = renderToString(<BoxScore gameId="g1" league={{ ...baseLeague, gameById: { g1: { homeId: 1, awayId: 2, homeScore: 14, awayScore: 10 } } }} embedded />);
-    expect(html).toContain('Score only');
-    expect(html).toContain('Quarter-by-quarter scoring was not recorded for this game.');
-  });
-
-  it('renders partial game', () => {
-    const html = renderToString(<BoxScore gameId="g2" league={{ ...baseLeague, gameById: { g2: { homeId: 1, awayId: 2, homeScore: 21, awayScore: 17, teamStats: { home: { passYards: 201 }, away: { passYards: 230 } } } } }} embedded />);
+  it('renders from actions.getBoxScore archive payload', () => {
+    vi.mocked(useStableRouteRequest).mockReturnValue({ data: { homeId: 1, awayId: 2, homeScore: 14, awayScore: 10, teamStats: { home: { passYards: 100 }, away: { passYards: 80 } } } });
+    const html = renderToString(<BoxScore gameId="g1" league={baseLeague} actions={{ getBoxScore: vi.fn() }} embedded />);
     expect(html).toContain('Partial detail');
-    expect(html).toContain('Team comparison');
   });
 
-  it('renders full-detail game with player tables', () => {
-    const html = renderToString(<BoxScore gameId="g3" league={{ ...baseLeague, gameById: { g3: { homeId: 1, awayId: 2, homeScore: 21, awayScore: 17, quarterScores: { home: [7,7,7,0], away: [3,7,0,7] }, teamStats: { home: { passYards: 201 }, away: { passYards: 230 } }, playerStats: { home: { 11: { name: 'QB Home', stats: { passAtt: 20, passComp: 14 } } }, away: { 22: { name: 'QB Away', stats: { passAtt: 24, passComp: 18 } } } } } } }} embedded />);
-    expect(html).toContain('Full detail');
-    expect(html).toContain('Passing');
+  it('falls back to league.gameById when no action exists', () => {
+    const html = renderToString(<BoxScore gameId="g2" league={{ ...baseLeague, gameById: { g2: { homeId: 1, awayId: 2, homeScore: 14, awayScore: 10 } } }} embedded />);
+    expect(html).toContain('Score only');
   });
 
-  it('renders missing-detail fallback', () => {
-    const html = renderToString(<BoxScore gameId="g4" league={baseLeague} embedded />);
-    expect(html).toContain('Game Book unavailable');
+  it('renders expanded stat tables when data exists', () => {
+    const game = { homeId: 1, awayId: 2, homeScore: 21, awayScore: 17, quarterScores: { home: [7,7,7,0], away: [3,7,0,7] }, teamStats: { home: { passYards: 201 }, away: { passYards: 230 } }, playerStats: { home: { 11: { name: 'K', stats: { fieldGoalsAttempted: 2, fieldGoalsMade: 2, points: 6, punts: 2, puntYards: 90, kickReturns: 1, kickReturnYards: 20, passBlockAttempts: 10, passBlockWinRate: 0.9 } } }, away: { 22: { name: 'QB Away', stats: { passAtt: 24, passComp: 18, passYd: 200 } } } } };
+    const html = renderToString(<BoxScore gameId="g3" league={{ ...baseLeague, gameById: { g3: game } }} embedded />);
+    expect(html).toContain('Kicking');
+    expect(html).toContain('Punting');
+    expect(html).toContain('Returns');
+    expect(html).toContain('Blocking');
   });
 
   it('player buttons trigger selection handlers when ids are present', () => {

--- a/src/ui/utils/boxScoreViewModel.js
+++ b/src/ui/utils/boxScoreViewModel.js
@@ -61,7 +61,9 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {} } = 
     teamTotals: { home: teamStats?.home ?? {}, away: teamStats?.away ?? {} },
     scoringSummary,
     playerTables: { home: homePlayers, away: awayPlayers },
-    missingDetailReason: archiveQuality === QUALITY.full ? null : 'Detailed box score data was not recorded for this game.',
+    prepImpact: Array.isArray(payload?.prepImpact) ? payload.prepImpact : (payload?.prepImpact ? [String(payload.prepImpact)] : []),
+    detailWarning: archiveQuality === QUALITY.partial ? 'Partial archive: some Game Book sections were not recorded.' : archiveQuality === QUALITY.score ? 'Detailed box score data was not recorded for this game.' : archiveQuality === QUALITY.missing ? 'Game data missing.' : null,
+    missingDetailReason: archiveQuality === QUALITY.partial ? 'Partial archive: some Game Book sections were not recorded.' : archiveQuality === QUALITY.score ? 'Detailed box score data was not recorded for this game.' : archiveQuality === QUALITY.missing ? 'Game data missing.' : null,
     hasDetailedStats: archiveQuality === QUALITY.full || archiveQuality === QUALITY.partial,
   };
 }

--- a/src/ui/utils/boxScoreViewModel.test.js
+++ b/src/ui/utils/boxScoreViewModel.test.js
@@ -1,24 +1,35 @@
 import { describe, it, expect } from 'vitest';
 import { buildBoxScoreViewModel } from './boxScoreViewModel.js';
+import { buildGameBookStory } from './gameBookStory.js';
 
 describe('buildBoxScoreViewModel', () => {
   it('classifies full detail when major sections exist', () => {
     const vm = buildBoxScoreViewModel({ game: { played: true, homeId: 1, awayId: 2, homeScore: 21, awayScore: 17, quarterScores: { home: [7,7,7,0], away: [3,7,0,7] }, teamStats: { home: { passYards: 220 }, away: { passYards: 200 } }, playerStats: { home: { '10': { name: 'QB', stats: { passAtt: 20 } } }, away: {} } } });
     expect(vm.archiveQuality).toBe('Full detail');
+    expect(vm.detailWarning).toBeNull();
   });
 
-  it('classifies partial detail when only some detail exists', () => {
+  it('classifies partial detail warning copy', () => {
     const vm = buildBoxScoreViewModel({ game: { played: true, homeScore: 10, awayScore: 7, teamStats: { home: { passYards: 100 }, away: {} } } });
     expect(vm.archiveQuality).toBe('Partial detail');
+    expect(vm.detailWarning).toContain('Partial archive');
   });
 
-  it('classifies score only data', () => {
+  it('classifies score only data warning copy', () => {
     const vm = buildBoxScoreViewModel({ game: { played: true, homeScore: 3, awayScore: 0 } });
     expect(vm.archiveQuality).toBe('Score only');
+    expect(vm.detailWarning).toContain('Detailed box score data');
   });
 
   it('classifies missing detail when score unavailable', () => {
     const vm = buildBoxScoreViewModel({});
     expect(vm.archiveQuality).toBe('Missing detail');
+  });
+
+  it('builds factual game story bullets from available data only', () => {
+    const vm = buildBoxScoreViewModel({ game: { homeId: 1, awayId: 2, homeScore: 17, awayScore: 20, teamStats: { home: { turnovers: 2, totalYards: 290 }, away: { turnovers: 0, totalYards: 350 } }, playerStats: { away: { 1: { name: 'A QB', stats: { passYd: 294, passTD: 3 } } }, home: {} } } });
+    const story = buildGameBookStory(vm).join(' ');
+    expect(story).toContain('turnover battle');
+    expect(story).toContain('294 passing yards');
   });
 });

--- a/src/ui/utils/gameBookStory.js
+++ b/src/ui/utils/gameBookStory.js
@@ -1,0 +1,38 @@
+const n = (v) => (Number.isFinite(Number(v)) ? Number(v) : null);
+
+export function buildGameBookStory(vm) {
+  const bullets = [];
+  const away = vm?.awayTeam?.abbr ?? "Away";
+  const home = vm?.homeTeam?.abbr ?? "Home";
+  const winner = n(vm?.finalScore?.away) > n(vm?.finalScore?.home) ? away : home;
+  const loser = winner === away ? home : away;
+  const tAway = vm?.teamTotals?.away ?? {};
+  const tHome = vm?.teamTotals?.home ?? {};
+
+  const toA = n(tAway.turnovers); const toH = n(tHome.turnovers);
+  if (toA != null && toH != null && toA !== toH) bullets.push(`${winner} won the turnover battle ${winner === away ? `${toH}-${toA}` : `${toA}-${toH}`}.`);
+
+  [["totalYards", "total yards"], ["passYards", "passing yards"], ["rushYards", "rushing yards"], ["sacks", "sacks"]].forEach(([k, label]) => {
+    const a = n(tAway[k]); const h = n(tHome[k]);
+    if (a != null && h != null && a !== h) {
+      const lead = Math.abs(a - h);
+      bullets.push(`${a > h ? away : home} led by ${lead} ${label}.`);
+    }
+  });
+
+  const players = [...(vm?.playerTables?.away ?? []), ...(vm?.playerTables?.home ?? [])];
+  const qb = [...players].sort((a, b) => (n(b.stats?.passYd) ?? -1) - (n(a.stats?.passYd) ?? -1))[0];
+  if (n(qb?.stats?.passYd) > 0) bullets.push(`${qb.name ?? "A QB"} led all passers with ${qb.stats.passYd} passing yards and ${qb.stats?.passTD ?? 0} TD.`);
+
+  const rush = [...players].sort((a, b) => (n(b.stats?.rushYd) ?? -1) - (n(a.stats?.rushYd) ?? -1))[0];
+  if (n(rush?.stats?.rushYd) > 0) bullets.push(`${rush.name ?? "A runner"} led all rushers with ${rush.stats.rushYd} yards.`);
+
+  const rec = [...players].sort((a, b) => (n(b.stats?.recYd) ?? -1) - (n(a.stats?.recYd) ?? -1))[0];
+  if (n(rec?.stats?.recYd) > 0) bullets.push(`${rec.name ?? "A receiver"} led all receivers with ${rec.stats.recYd} yards.`);
+
+  const lastScore = vm?.scoringSummary?.[vm.scoringSummary.length - 1];
+  if (lastScore?.teamAbbr || lastScore?.team) bullets.push(`Last scoring play: ${(lastScore.teamAbbr ?? lastScore.team)} ${lastScore.type ?? "score"} (${lastScore.time ?? lastScore.clock ?? "time unknown"}).`);
+
+  if (!bullets.length && winner && loser) bullets.push(`No detailed team/player stats were recorded for this game.`);
+  return bullets;
+}


### PR DESCRIPTION
### Motivation
- Preserve the normalized `buildBoxScoreViewModel` rendering path while restoring the richer, factual Game Book review depth lost in the previous refactor.
- Safely reintroduce async archive loading so archived games render full detail where available without causing request loops or breaking league-only fallbacks.
- Add concise, data-driven narrative and more player stat categories so the Game Book feels credible and actionable for postgame review.

### Description
- Reintroduced async archive fetch in `BoxScore` using `useStableRouteRequest` keyed by `boxscore:${gameId}` and scoped by the league id, with a safe fallback to `league.gameById[gameId]`, while keeping `buildBoxScoreViewModel` as the single source of truth.
- Added `buildGameBookStory` helper and a compact “Why this game was decided” section that emits only data-backed bullets (turnover margin, yardage edges, top passer/rusher/receiver, last scoring play) and reintroduced `prepImpact` rendering only when archived data exists.
- Expanded player stat tables to include conditional Kicking, Punting, Returns, and Blocking (in addition to Passing, Rushing, Receiving, Defense), and added local UI-only table sorting with default sort keys and header toggles (asc/desc) while preserving horizontal wrappers for mobile.
- Improved archive messaging by exposing `detailWarning` (kept `missingDetailReason` for compatibility) with precise copy for each archive state: Full (no warning), Partial: “Partial archive: some Game Book sections were not recorded.”, Score only: “Detailed box score data was not recorded for this game.”, Missing: “Game data missing.”

### Testing
- Ran unit tests with `npm run test:unit -- src/ui/utils/boxScoreViewModel.test.js src/ui/utils/boxScoreAccess.test.js src/ui/utils/playerGameLogs.test.js src/ui/components/BoxScore.test.jsx` and all targeted test files passed (Test Files 4 passed; Tests 14 passed).
- Added/updated tests to cover async archive rendering path and fallback, partial/score-only warning copy, expanded stat table gates (kicking/punting/returns/blocking), and factual story generation (`src/ui/components/BoxScore.test.jsx`, `src/ui/utils/boxScoreViewModel.test.js`, and new `src/ui/utils/gameBookStory.js`).
- Known limitations: header-click sort interaction is implemented and state-driven but not exhaustively asserted via DOM click integration tests in this PR, and no attempt was made to reconstruct missing drive/play-level detail when archives lack it.
- Mobile notes: all dense tables remain wrapped with `bs-table-wrap` to preserve horizontal scroll and mobile readability, and sorting is local so it won’t affect other flows or layout behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f58b194b00832db629594a5957b2f4)