### PR TITLE
Archive completed seasons into league.history during season rollover

### DIFF
--- a/src/ui/components/History.jsx
+++ b/src/ui/components/History.jsx
@@ -13,9 +13,10 @@ export default function History({ league, onNavigateTeam, onNavigatePlayer }) {
         <strong>History Overview</strong>
         <div>Season {model.currentSeasonSnapshot.season ?? '—'} · Week {model.currentSeasonSnapshot.week ?? '—'}</div>
         <div>Archived seasons: {model.seasons.length}</div>
+        <div style={{ color: 'var(--text-muted)', fontSize: 12 }}>{model.seasons.length ? 'Archived season data' : 'Current season preview'}</div>
         {model.warnings.map((w) => <div key={w} style={{ color: 'var(--text-muted)' }}>{w}</div>)}
       </div>
-      <ScrollTable><table><thead><tr><th>Season</th><th>Champion</th><th>Runner-up</th></tr></thead><tbody>{model.champions.length ? model.champions.map((c) => <tr key={c.season}><td>{c.season}</td><td>{c.name ?? c.abbr}</td><td>{c.runnerUp?.name ?? '—'}</td></tr>) : <tr><td colSpan={3}>No champions have been archived yet.</td></tr>}</tbody></table></ScrollTable>
+      <ScrollTable><table><thead><tr><th>Season</th><th>Champion</th><th>Runner-up</th></tr></thead><tbody>{model.champions.length ? model.champions.map((c) => <tr key={c.season}><td>{c.season}</td><td>{c.name ?? c.abbr}</td><td>{c.runnerUp?.name ?? '—'}</td></tr>) : <tr><td colSpan={3}>No champions have been archived yet. Completed seasons will appear here after a season rollover.</td></tr>}</tbody></table></ScrollTable>
       <ScrollTable><table><thead><tr><th>Season</th><th>MVP</th><th>Note</th></tr></thead><tbody>{model.awards.some((a) => a.awards) ? model.awards.map((a) => <tr key={`a-${a.season}`}><td>{a.season}</td><td>{a.awards?.mvp?.name ?? '—'}</td><td>{a.source === 'derived' ? 'Derived from season stats' : 'Archived'}</td></tr>) : <tr><td colSpan={3}>Awards have not been recorded yet.</td></tr>}</tbody></table></ScrollTable>
       <ScrollTable><table><thead><tr><th>Record</th><th>Player</th><th>Team</th><th>Season</th><th>Value</th></tr></thead><tbody>{model.leagueRecords.length ? model.leagueRecords.map((r) => <tr key={r.key}><td>{r.label}</td><td><button onClick={() => onNavigatePlayer?.(r.playerId)}>{r.player}</button></td><td><button onClick={() => onNavigateTeam?.(r.teamId)}>{r.team}</button></td><td>{r.season ?? '—'}</td><td>{r.value}</td></tr>) : <tr><td colSpan={5}>Records will appear once season snapshots include stat leaders.</td></tr>}</tbody></table></ScrollTable>
     </div>

--- a/src/ui/utils/leagueHistory.js
+++ b/src/ui/utils/leagueHistory.js
@@ -36,10 +36,16 @@ export function buildCurrentSeasonSnapshot(league = {}) {
   const warnings = [];
   const standings = asArray(league.standings);
   if (!standings.length) warnings.push('Current standings are unavailable.');
+  const awards = league.awards ?? (asArray(league.playerStats ?? league.stats).length ? deriveAwardWinnersFromStats({ playerRows: asArray(league.playerStats ?? league.stats) }) : null);
   return {
     season: league.seasonId ?? league.year ?? null,
     week: league.week ?? null,
     standings,
+    champion: league.champion ?? null,
+    runnerUp: league.runnerUp ?? null,
+    playoffResults: asArray(league.playoffResults),
+    leaders: asArray(league.leaders),
+    awards,
     stats: asArray(league.playerStats ?? league.stats),
     warnings,
   };
@@ -77,6 +83,40 @@ export function buildTeamYearHistory(history = [], league = {}) {
     }
   }
   return [...byTeam.values()];
+}
+
+
+
+export function ensureLeagueHistoryContainer(league = {}) {
+  const history = league?.history && typeof league.history === 'object' ? league.history : {};
+  const seasons = asArray(history.seasons);
+  return { ...league, history: { ...history, seasons } };
+}
+
+export function archiveCompletedSeasonIfNeeded(league = {}, options = {}) {
+  const safeLeague = ensureLeagueHistoryContainer(league);
+  const seasonKey = options.season ?? safeLeague.seasonId ?? safeLeague.year ?? null;
+  if (seasonKey == null) return safeLeague;
+
+  const existing = asArray(safeLeague.history?.seasons);
+  const alreadyArchived = existing.some((s) => Number(s?.season ?? s?.year ?? s?.id) === Number(seasonKey));
+  if (alreadyArchived) return safeLeague;
+
+  const snapshot = buildCurrentSeasonSnapshot({ ...safeLeague, seasonId: seasonKey, year: seasonKey });
+  const warnings = [...asArray(snapshot.warnings)];
+  if (!snapshot.champion) warnings.push('Champion data unavailable at archive time.');
+  if (!asArray(snapshot.playoffResults).length) warnings.push('Playoff results unavailable at archive time.');
+  if (!snapshot.awards) warnings.push('Awards unavailable at archive time.');
+
+  const archivedSeason = {
+    year: seasonKey,
+    season: seasonKey,
+    ...snapshot,
+    warnings: [...new Set(warnings)],
+  };
+
+  const seasons = [...existing, archivedSeason].sort((a, b) => Number(a?.year ?? a?.season ?? 0) - Number(b?.year ?? b?.season ?? 0));
+  return { ...safeLeague, history: { ...safeLeague.history, seasons } };
 }
 
 export function buildLeagueHistoryModel(league = {}) {

--- a/src/ui/utils/leagueHistory.test.js
+++ b/src/ui/utils/leagueHistory.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildLeagueHistoryModel, buildCurrentSeasonSnapshot, deriveAwardWinnersFromStats, deriveLeagueRecords, buildTeamYearHistory } from './leagueHistory.js';
+import { buildLeagueHistoryModel, buildCurrentSeasonSnapshot, deriveAwardWinnersFromStats, deriveLeagueRecords, buildTeamYearHistory, archiveCompletedSeasonIfNeeded } from './leagueHistory.js';
 
 describe('leagueHistory utils', () => {
   it('handles missing league.history', () => {
@@ -11,6 +11,14 @@ describe('leagueHistory utils', () => {
     const s = buildCurrentSeasonSnapshot({ seasonId: 2026, week: 2, standings: [{ id: 1 }] });
     expect(s.season).toBe(2026);
     expect(s.standings).toHaveLength(1);
+  });
+  it('archiveCompletedSeasonIfNeeded creates history and avoids duplicates', () => {
+    const league = { seasonId: 2026, standings: [{ id: 1, wins: 11 }], playerStats: [{ name: 'Star', position: 'QB', stats: { passYd: 3500, passTD: 28 } }] };
+    const once = archiveCompletedSeasonIfNeeded(league);
+    expect(once.history.seasons).toHaveLength(1);
+    const twice = archiveCompletedSeasonIfNeeded(once);
+    expect(twice.history.seasons).toHaveLength(1);
+    expect(twice.history.seasons[0].awards?.source).toBe('derived');
   });
   it('award derivation avoids zero stat players and labels derived', () => {
     const awards = deriveAwardWinnersFromStats({ playerRows: [{ name: 'Zero', position: 'QB', stats: { passYd: 0 } }, { name: 'Star', position: 'QB', stats: { passYd: 3000, passTD: 30 } }] });

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -118,6 +118,7 @@ import { getPlayerCapHit, getRosterLimitForPhase, validateLeagueTeamLegality } f
 import { DEFAULT_LEAGUE_SETTINGS, normalizeLeagueSettings, getRuleEditType } from '../core/leagueSettings.js';
 import { migrateSaveMetaToCurrent, CURRENT_SAVE_SCHEMA_VERSION } from '../state/saveSchema.js';
 import { getTradeWindowSnapshot, isTradeWindowOpen } from '../core/tradeWindow.js';
+import { archiveCompletedSeasonIfNeeded, ensureLeagueHistoryContainer } from '../ui/utils/leagueHistory.js';
 import { ensurePersonalityProfile, mentorshipBonusForPlayer, contractPersonalityModifier } from '../core/development/personalitySystem.js';
 import { buildCanonicalGameId, buildArchivedGame, toTeamId } from '../core/gameIdentity.js';
 import { normalizeArchivedGamePayload, classifyArchiveQuality, validateArchivedGame, recoverArchivedGameFromSchedule, enrichArchivedGamePayload } from '../core/gameArchive.js';
@@ -8173,6 +8174,19 @@ async function archiveSeason(seasonId) {
       teams,
       seasonStats: populatedStats,
     });
+    const archivedLeagueView = archiveCompletedSeasonIfNeeded(ensureLeagueHistoryContainer({
+      seasonId: year,
+      year,
+      standings: standingsRows,
+      champion: championSummary,
+      runnerUp: runnerUpSummary,
+      playoffResults: seasonSummary?.playoffResults ?? [],
+      leaders,
+      awards,
+      playerStats: populatedStats,
+      history: meta?.history,
+      leagueHistory: meta?.leagueHistory,
+    }), { season: year });
 
     meta = ensureLeagueMemoryMeta(meta);
     const historyRows = [...(meta.leagueHistory || []).filter((s) => s?.id !== seasonId), seasonSummary]
@@ -8187,6 +8201,7 @@ async function archiveSeason(seasonId) {
       franchiseHistoryByTeam: memoryMeta.franchiseHistoryByTeam,
       recordBook: memoryMeta.recordBook,
       seasonStorylines: memoryMeta.seasonStorylines,
+      history: archivedLeagueView.history,
     });
 
     await Seasons.save(seasonSummary);


### PR DESCRIPTION
### Motivation
- The History viewer/model added in the prior change remained a read-only preview because completed seasons were not persisted automatically at rollover. 
- We need safe, idempotent persistence of one truthful completed-season snapshot at the real season rollover point without fabricating missing data or breaking old saves.

### Description
- Add helpers `ensureLeagueHistoryContainer` and `archiveCompletedSeasonIfNeeded` in `src/ui/utils/leagueHistory.js` to normalize old saves, build a `buildCurrentSeasonSnapshot`-based archive row, append a single season to `history.seasons`, and prevent duplicate archives by checking season/year/id. 
- Extend `buildCurrentSeasonSnapshot` to include available `champion`, `runnerUp`, `playoffResults`, `leaders`, and `awards` so persisted snapshots carry truthful fields when present and collect explicit `warnings` when data is missing. 
- Wire the archive helper into the worker rollover flow inside `archiveSeason` invoked by `handleStartNewSeason` so the completed season is archived before team records/schedule/meta are reset and `meta.history` is written alongside legacy `meta.leagueHistory` for backward compatibility. 
- Make a minimal UI copy update in `src/ui/components/History.jsx` to show an archive badge (`Archived season data` vs `Current season preview`) and clearer guidance when no archived seasons exist. 

### Testing
- Unit tests added/updated: `src/ui/utils/leagueHistory.test.js` covering `archiveCompletedSeasonIfNeeded` creation, duplicate prevention, and derived award labeling, and existing `src/ui/components/History.test.jsx` verifies rendering of persisted/empty states. 
- Commands run: `npm run test:unit -- src/ui/utils/leagueHistory.test.js src/ui/components/History.test.jsx`, `npm run test:unit -- src/ui/utils/leagueStatsHub.test.js src/ui/components/LeagueStats.test.jsx`, and `npm run test:unit -- src/ui/utils/boxScoreViewModel.test.js src/ui/utils/playerGameLogs.test.js src/ui/components/BoxScore.test.jsx` and all targeted tests passed successfully. 
- Known limitations: this PR does not backfill pre-existing seasons into `history.seasons` (automatic persistence begins at the next rollover) and archived completeness depends on data present in the worker/cache at archive time (missing fields are recorded as warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a79f96e4832d86d82fb82f12a79d)