### PR TITLE
Harden first-session new franchise bootstrap with playable-state fallback

### DIFF
--- a/src/ui/utils/leagueBootstrap.js
+++ b/src/ui/utils/leagueBootstrap.js
@@ -4,6 +4,7 @@
  * Authoritative readiness gates for league initialization.
  * Prevents race conditions during new franchise creation.
  */
+import { isPlayableLeagueState } from '../../state/leagueInit.ts';
 
 export const NEW_SLOT_BOOTSTRAP_PHASES = {
   IDLE: 'idle',
@@ -16,13 +17,9 @@ export const NEW_SLOT_BOOTSTRAP_PHASES = {
  * Returns true only if the league object has all critical fields
  * required to render the dashboard and simulate games.
  */
+
 export function hasMinimumPlayableLeague(league) {
-  if (!league) return false;
-  const hasPhase = !!league.phase;
-  const hasWeek = typeof league.week === 'number';
-  const hasTeams = Array.isArray(league.teams) && league.teams.length > 0;
-  const hasUserTeam = typeof league.userTeamId !== 'undefined' && league.userTeamId !== null;
-  return hasPhase && hasWeek && hasTeams && hasUserTeam;
+  return isPlayableLeagueState(league);
 }
 
 /**
@@ -120,4 +117,3 @@ export function shouldShowNewFranchiseBootstrapGate({ league, pendingNewSlot, in
   if (initFlowMode !== 'new' || !pendingNewSlot) return false;
   return !hasMinimumPlayableLeague(league);
 }
-import { isPlayableLeagueState } from '../../state/leagueInit.ts';

--- a/src/ui/utils/leagueBootstrap.test.js
+++ b/src/ui/utils/leagueBootstrap.test.js
@@ -13,9 +13,11 @@ import {
 const playableLeague = {
   activeLeagueId: 'save_slot_1',
   phase: 'preseason',
+  year: 2025,
   week: 1,
   userTeamId: 4,
-  teams: [{ id: 4, name: 'Phoenix' }],
+  teams: [{ id: 4, name: 'Phoenix', roster: [{ id: 10 }] }, { id: 2, name: 'Vegas', roster: [{ id: 11 }] }],
+  schedule: { weeks: [{ week: 1, games: [{ home: 4, away: 2, played: false }] }] },
 };
 
 describe('league bootstrap guards', () => {

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -144,6 +144,8 @@ import { generateDynamicEvents, calculateSeasonAwards } from '../core/events/eve
 import { validateCustomRoster, validateDraftClass, validateLeagueFile, validateLeagueSettingsPayload, summarizeValidationErrors } from './modding/schemaValidation.js';
 import { buildDraftOrder } from './modding/ruleEngine.js';
 import { simulationManager } from './WorkerPool.ts';
+import { buildDefaultLeague } from '../data/defaultLeague.ts';
+import { isPlayableLeagueState } from '../state/leagueInit.ts';
 import {
   aggregateTeamUnitsFromRoster,
   buildDeterministicSeed,
@@ -1867,7 +1869,7 @@ async function handleNewLeague(payload, id) {
     }
 
     // Generate via existing core logic
-    const league = makeLeague(configuredTeams, {
+    let league = makeLeague(configuredTeams, {
         ...options,
         settings: resolvedSettings,
       }, {
@@ -1875,9 +1877,14 @@ async function handleNewLeague(payload, id) {
         generateInitialStaff: generateInitialStaff
     });
 
-    // Validate schedule
-    if (!league.schedule || !Array.isArray(league.schedule.weeks) || league.schedule.weeks.length === 0) {
-        throw new Error('League generation failed: Schedule is missing or empty.');
+    // Validate league state. If generation failed or is stale/incomplete,
+    // recover with the default offline league to keep first-session boot playable.
+    if (!isPlayableLeagueState(league)) {
+      console.warn('[Worker] NEW_LEAGUE produced an invalid league payload; falling back to default league.');
+      league = buildDefaultLeague();
+    }
+    if (!isPlayableLeagueState(league)) {
+      throw new Error('League generation failed: no playable league state available.');
     }
 
     const seasonId = `s${league.season ?? 1}`;


### PR DESCRIPTION
### Motivation

- Finish the first-session playability work by making the real Start New Franchise flow resilient to invalid/stale league payloads and by removing the split validator mismatch that could leave the app stuck on the bootstrap gate.

### Description

- Wire fallback into the authoritative new-league path by validating the generated league in the worker `handleNewLeague` using `isPlayableLeagueState`; if invalid, log a `console.warn` and substitute `buildDefaultLeague()` before continuing with the normal DB persistence + `toUI.FULL_STATE` commit path so the app exits the bootstrap gate.
- Unify the validation contract by making `hasMinimumPlayableLeague` delegate to `isPlayableLeagueState` (import fixed) so UI gating and gameplay readiness use the same rule and avoid contradictory “ready” vs “not playable” decisions.
- Update unit test fixtures to use a fully playable league (schedule + rosters) so bootstrap guards reflect the stronger validator expectations; keep `SchedulePage` component actions intact (no Schedule wiring changes in this PR because the live schedule flow remains driven by `ScheduleCenter` inside `LeagueDashboard`).
- Files changed: `src/worker/worker.js` (fallback wiring + warn), `src/ui/utils/leagueBootstrap.js` (validator delegation + import), and `src/ui/utils/leagueBootstrap.test.js` (fixture updates and tests).
- Implementation notes: the fallback path is committed via the same worker hydrate/persist flow (so both API/worker success and fallback produce the same `FULL_STATE` emission to UI), and fallback activation emits a `console.warn` for developer visibility while presenting the normal recovery UX to users.

### Testing

- Built the app: `npm run build` — succeeded (vite build completed).
- Ran unit tests: `npm run test:unit -- tests/unit/leagueInit.test.jsx src/ui/utils/leagueBootstrap.test.js` — all unit tests passed.
- Ran e2e smoke test: `npm run test:e2e -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` — test run failed in this environment because Playwright browser binaries are missing; Playwright printed: "Please run the following command to download new browsers: npx playwright install".
- Notes on e2e and environment: the smoke test itself is present and uses stable test IDs/selectors; to run e2e locally or CI, ensure Playwright browsers are installed with `npx playwright install` before `npm run test:e2e`.

Summary of the required checklist:
- The real Start New Franchise path now uses the resilient initialization (yes, `NEW_LEAGUE` flow wired). 
- Fallback league is committed through the same worker persistence / `FULL_STATE` path (yes).
- Validation gates unified so the shell and gameplay checks use the same `isPlayableLeagueState` contract (yes).
- `SchedulePage` component already accepts callbacks, but the app's schedule flow is still routed via `ScheduleCenter`/`LeagueDashboard` and was not modified here (no wiring changes made in this PR).
- First-session e2e smoke test exists and was executed here but could not complete due to missing Playwright browsers; `npx playwright install` is required to run it successfully in this environment.
- Commands run and results are listed above (build ✅, unit tests ✅, e2e blocked by missing browsers).

Known blocker: Playwright browser binaries are not available in this execution environment; run `npx playwright install` to enable e2e runs. No other unrelated changes or architecture rewrites were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b32ca320832d9f152d3039afa630)