### PR TITLE
Harden first-session franchise boot with canonical validation and timeout fail-fast

### DIFF
--- a/src/state/leagueInit.ts
+++ b/src/state/leagueInit.ts
@@ -2,21 +2,37 @@ import { buildDefaultLeague } from '../data/defaultLeague';
 
 const DEFAULT_TIMEOUT_MS = 5000;
 
-export function isPlayableLeagueState(league: any) {
-  if (!league || typeof league !== 'object') return false;
-  if (!league.phase || typeof league.week !== 'number') return false;
-  if (typeof league.year !== 'number' && typeof league.seasonId !== 'number' && typeof league.season !== 'number') return false;
-  if (!Array.isArray(league.teams) || league.teams.length < 2) return false;
+export function getPlayableLeagueValidation(league: any) {
+  const reasons: string[] = [];
+  if (!league || typeof league !== 'object') {
+    return { valid: false, reasons: ['No league state received'] };
+  }
+  if (!league.phase) reasons.push('Missing phase');
+  if (typeof league.week !== 'number') reasons.push('Missing week number');
+  if (typeof league.year !== 'number' && typeof league.seasonId !== 'number' && typeof league.season !== 'number') reasons.push('Missing season/year');
+  if (!Array.isArray(league.teams) || league.teams.length < 2) reasons.push('Teams unavailable');
   const inferredUserTeamId = league.userTeamId ?? league.teams?.[0]?.id;
   const hasUserTeam = inferredUserTeamId != null && league.teams.some((t: any) => Number(t?.id) === Number(inferredUserTeamId));
-  if (!hasUserTeam) return false;
+  if (!hasUserTeam) reasons.push('User team missing');
   const hasRosterData = league.teams.some((team: any) => Array.isArray(team?.roster) ? team.roster.length > 0 : Array.isArray(team?.players) && team.players.length > 0);
-  if (!hasRosterData && Array.isArray(league.players)) return league.players.length > 0;
-  if (!hasRosterData) return false;
+  if (!hasRosterData && Array.isArray(league.players) && league.players.length > 0) {
+    // valid roster fallback via flattened player pool
+  } else if (!hasRosterData) {
+    reasons.push('No roster/player data');
+  }
   const weeks = league?.schedule?.weeks;
-  if (!Array.isArray(weeks) || weeks.length === 0) return false;
+  if (!Array.isArray(weeks) || weeks.length === 0) reasons.push('Schedule missing');
   const hasGames = weeks.some((w: any) => Array.isArray(w?.games) && w.games.length > 0);
-  return hasGames;
+  if (!hasGames) reasons.push('No games available');
+
+  return {
+    valid: reasons.length === 0,
+    reasons,
+  };
+}
+
+export function isPlayableLeagueState(league: any) {
+  return getPlayableLeagueValidation(league).valid;
 }
 
 export async function requestPlayableLeagueState(payload: unknown, fetchImpl: typeof fetch = fetch) {

--- a/src/ui/components/NewLeagueSetup.jsx
+++ b/src/ui/components/NewLeagueSetup.jsx
@@ -43,6 +43,8 @@ const DRAFT_ORDER_TYPES = [
   { value: "random", label: "Random", desc: "Fully randomized draft order" },
 ];
 
+const NEW_FRANCHISE_BOOT_TIMEOUT_MS = 15000;
+
 const SCHEDULE_BALANCE_OPTIONS = [
   { value: "balanced", label: "Balanced" },
   { value: "division-heavy", label: "Division Heavy" },
@@ -108,7 +110,7 @@ export default function NewLeagueSetup({ actions, onCancel, onStartCreate, onCre
     setCreating(true);
     onStartCreate?.();
     try {
-      await actions.newLeague(DEFAULT_TEAMS, {
+      const leagueRequest = actions.newLeague(DEFAULT_TEAMS, {
         userTeamId: selectedTeam,
         year,
         difficulty,
@@ -145,6 +147,10 @@ export default function NewLeagueSetup({ actions, onCancel, onStartCreate, onCre
           leagueName: leagueName || `${selectedTeamData?.name || "My"} Dynasty`,
         },
       });
+      await Promise.race([
+        leagueRequest,
+        new Promise((_, reject) => setTimeout(() => reject(new Error('League creation timed out.')), NEW_FRANCHISE_BOOT_TIMEOUT_MS)),
+      ]);
     } catch (err) {
       onCreateError?.(err);
     } finally {

--- a/src/ui/utils/leagueBootstrap.js
+++ b/src/ui/utils/leagueBootstrap.js
@@ -4,7 +4,7 @@
  * Authoritative readiness gates for league initialization.
  * Prevents race conditions during new franchise creation.
  */
-import { isPlayableLeagueState } from '../../state/leagueInit.ts';
+import { getPlayableLeagueValidation, isPlayableLeagueState } from '../../state/leagueInit.ts';
 
 export const NEW_SLOT_BOOTSTRAP_PHASES = {
   IDLE: 'idle',
@@ -26,18 +26,11 @@ export function hasMinimumPlayableLeague(league) {
  * Diagnostic helper to see exactly why a league isn't ready.
  */
 export function summarizeBootstrapState(league) {
-  const reasons = [];
-  if (!league) {
-    reasons.push('No league state received');
-  } else {
-    if (!league.phase) reasons.push('Missing phase (preseason/regular/etc)');
-    if (typeof league.week !== 'number') reasons.push('Missing week number');
-    if (!Array.isArray(league.teams) || league.teams.length === 0) reasons.push('No teams loaded');
-    if (typeof league.userTeamId === 'undefined' || league.userTeamId === null) reasons.push('No user team assigned');
-  }
+  const validation = getPlayableLeagueValidation(league);
+  const reasons = validation.valid ? [] : validation.reasons;
 
   return {
-    ready: reasons.length === 0,
+    ready: validation.valid,
     reasons,
   };
 }

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -2013,7 +2013,12 @@ async function handleNewLeague(payload, id) {
     post(toUI.FULL_STATE, buildViewState(), id);
   } catch (err) {
     console.error('[Worker] NEW_LEAGUE error:', err);
-    post(toUI.ERROR, { message: err.message, stack: err.stack }, id);
+    post(toUI.ERROR, {
+      code: 'NEW_LEAGUE_BOOT_FAILED',
+      stage: 'new_league',
+      message: err?.message ?? 'Failed to create a playable franchise.',
+      stack: err?.stack,
+    }, id);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Root cause: first-session boot could hang on the opaque "No league state received" path because readiness checks were duplicated and unstructured and the UI had no hard timeout, allowing a stalled worker or network call to keep the app indefinitely in a bootstrap spinner.  
- Goal: make new-franchise creation deterministic by centralizing playable-league validation, failing fast on worker/network faults, and providing structured errors the UI can handle and show retry/back controls.  

### Description
- Introduced a canonical validator `getPlayableLeagueValidation` that returns `{ valid, reasons[] }` and made `isPlayableLeagueState` a thin wrapper, consolidating playable-league rules in `src/state/leagueInit.ts`.  
- Wired bootstrap diagnostics to the canonical validator by updating `summarizeBootstrapState`/bootstrap gates to consume the structured reasons in `src/ui/utils/leagueBootstrap.js`.  
- Added a hard client-side timeout for the Start New Franchise flow (15s) in `src/ui/components/NewLeagueSetup.jsx` so the UI fails fast and shows a retry/back flow instead of waiting indefinitely.  
- Made the worker `NEW_LEAGUE` failure path return a structured error payload (`code`, `stage`, `message`, `stack`) via `toUI.ERROR` so the UI can detect boot-stage failures reliably in `src/worker/worker.js`.  

### Testing
- Ran `npm install` which completed successfully (dependencies up-to-date).  
- Attempted `npm run lint` which failed because the `lint` script is not defined in `package.json`.  
- Ran `npm test` (Playwright suite) which could not complete because browser binaries were missing; Playwright reported the actionable instruction `npx playwright install` and the run terminated with multiple e2e failures due to the missing browsers.  
- Ran `npm run build` which completed successfully producing the production bundles.  
- Notes: end-to-end Playwright tests could not be asserted green in this environment because of missing Playwright browsers; to run the full e2e suite locally or in CI execute `npx playwright install` then `npm test` (expected smoke/e2e coverage for fresh-franchise flows).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6c679c6e0832da15c845cca29caa1)