### PR TITLE
Harden first-session franchise smoke path and bootstrap validation; add stable e2e selectors

### DIFF
--- a/src/state/leagueInit.ts
+++ b/src/state/leagueInit.ts
@@ -11,17 +11,18 @@ export function getPlayableLeagueValidation(league: any) {
   if (typeof league.week !== 'number') reasons.push('Missing week number');
   if (typeof league.year !== 'number' && typeof league.seasonId !== 'number' && typeof league.season !== 'number') reasons.push('Missing season/year');
   if (!Array.isArray(league.teams) || league.teams.length < 2) reasons.push('Teams unavailable');
-  const inferredUserTeamId = league.userTeamId ?? league.teams?.[0]?.id;
-  const hasUserTeam = inferredUserTeamId != null && league.teams.some((t: any) => Number(t?.id) === Number(inferredUserTeamId));
+  const teams = Array.isArray(league.teams) ? league.teams : [];
+  const inferredUserTeamId = league.userTeamId ?? teams[0]?.id;
+  const hasUserTeam = inferredUserTeamId != null && teams.some((t: any) => Number(t?.id) === Number(inferredUserTeamId));
   if (!hasUserTeam) reasons.push('User team missing');
-  const hasRosterData = league.teams.some((team: any) => Array.isArray(team?.roster) ? team.roster.length > 0 : Array.isArray(team?.players) && team.players.length > 0);
+  const hasRosterData = teams.some((team: any) => Array.isArray(team?.roster) ? team.roster.length > 0 : Array.isArray(team?.players) && team.players.length > 0);
   if (!hasRosterData && Array.isArray(league.players) && league.players.length > 0) {
     // valid roster fallback via flattened player pool
   } else if (!hasRosterData) {
     reasons.push('No roster/player data');
   }
-  const weeks = league?.schedule?.weeks;
-  if (!Array.isArray(weeks) || weeks.length === 0) reasons.push('Schedule missing');
+  const weeks = Array.isArray(league?.schedule?.weeks) ? league.schedule.weeks : [];
+  if (weeks.length === 0) reasons.push('Schedule missing');
   const hasGames = weeks.some((w: any) => Array.isArray(w?.games) && w.games.length > 0);
   if (!hasGames) reasons.push('No games available');
 

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -86,7 +86,7 @@ function BoxScore({ gameId, league, actions, onClose, onPlayerSelect, onTeamSele
     <div className="box-score-header"><h2>Game Book</h2>{!embedded && <button className="btn" onClick={onClose}>Close</button>}</div>
     <section className="bs-section">
       <h3><TeamButton team={vm.awayTeam} onSelect={onTeamSelect} /> vs <TeamButton team={vm.homeTeam} onSelect={onTeamSelect} /></h3>
-      <div>{vm.finalScore.away ?? "—"} - {vm.finalScore.home ?? "—"}</div>
+      <div data-testid="game-book-final-score">{vm.finalScore.away ?? "—"} - {vm.finalScore.home ?? "—"}</div>
       <div>Week {vm.week ?? "—"} · Season {vm.season ?? "—"}</div>
       <span className={`status-chip ${QUALITY_BADGE_CLASS[vm.archiveQuality] ?? "muted"}`}>{vm.archiveQuality}</span>
       {vm.detailWarning ? <p>{vm.detailWarning}</p> : null}

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -166,7 +166,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
   }, [command.weekLabel]);
 
   return (
-    <div className="app-screen-stack franchise-hq franchise-command-center" role="main" aria-label="Franchise HQ weekly command center">
+    <div className="app-screen-stack franchise-hq franchise-command-center" data-testid="franchise-hq" role="main" aria-label="Franchise HQ weekly command center">
       <section className="app-hq-topbar card" aria-label="Franchise HQ top bar">
         <div className="app-hq-topbar__left">
           <span>{command.seasonLabel}</span>
@@ -335,7 +335,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
       </section>
 
       <div className="app-hq-sticky-advance">
-        <Button className="app-command-advance app-command-advance-gold" onClick={onAdvanceWeek} disabled={busy || simulating} aria-label={`Advance Week — move from ${command.weekLabel} to next week`} title="Advance Week">
+        <Button className="app-command-advance app-command-advance-gold" data-testid="advance-week-cta" onClick={onAdvanceWeek} disabled={busy || simulating} aria-label={`Advance Week — move from ${command.weekLabel} to next week`} title="Advance Week">
           {busy || simulating ? 'Advancing…' : 'Advance Week'}
           <HQIcon name="arrowRight" size={16} />
         </Button>

--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -23,7 +23,7 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
 
   if (!gameId) {
     return (
-      <div className="app-screen-stack">
+      <div className="app-screen-stack" data-testid="game-book">
         <ScreenHeader
           eyebrow="Game Book"
           title="Game Book"

--- a/src/ui/components/ScreenSystem.jsx
+++ b/src/ui/components/ScreenSystem.jsx
@@ -15,7 +15,7 @@ export function ScreenHeader({
       <div className="app-screen-header__main">
         {(eyebrow || onBack) && (
           <div className="app-screen-header__top">
-            {onBack ? <button className="btn app-screen-header__back" onClick={onBack}>← {backLabel ?? 'Back'}</button> : null}
+            {onBack ? <button data-testid="return-to-hq" className="btn app-screen-header__back" onClick={onBack}>← {backLabel ?? 'Back'}</button> : null}
             {eyebrow ? <span className="app-screen-header__eyebrow">{eyebrow}</span> : null}
           </div>
         )}

--- a/src/ui/components/WeeklyResultsCenter.jsx
+++ b/src/ui/components/WeeklyResultsCenter.jsx
@@ -246,6 +246,7 @@ export default function WeeklyResultsCenter({ league, initialWeek, onGameSelect,
               <button
                 type="button"
                 className="btn btn-sm"
+                data-testid="completed-game-link"
                 onClick={canOpenUserGame ? () => openResolvedBoxScore(userTeamResult.game, { seasonId: league?.seasonId, week: userTeamResult.week, source: 'weekly_results_user_game' }, onGameSelect) : undefined}
                 disabled={!canOpenUserGame}
                 title={canOpenUserGame ? 'Open full Game Book' : (userResultPresentation?.statusLabel ?? 'Archive unavailable')}

--- a/tests/e2e/fresh_franchise_first_week_smoke.spec.js
+++ b/tests/e2e/fresh_franchise_first_week_smoke.spec.js
@@ -1,33 +1,52 @@
 import { test, expect } from '@playwright/test';
-import { launchFranchise } from './helpers/franchise.js';
 
-test('fresh franchise first week smoke', async ({ page }) => {
+const SMOKE_TIMEOUT = 90000;
+
+test('fresh franchise first week smoke', async ({ page, context }) => {
   const consoleErrors = [];
   page.on('pageerror', (err) => consoleErrors.push(String(err)));
   page.on('console', (msg) => {
     if (msg.type() === 'error') consoleErrors.push(msg.text());
   });
 
+  await context.clearCookies();
   await page.goto('/');
-  await expect(page.getByTestId('start-new-franchise-cta')).toBeVisible({ timeout: 60000 });
-  await launchFranchise(page);
+  await page.evaluate(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+  await page.reload();
 
-  await expect(page.getByTestId('app-shell-ready')).toBeVisible({ timeout: 60000 });
-  const advanceBtn = page.getByRole('button', { name: /advance week|simulate week|simulate/i }).first();
+  const startCta = page.getByTestId('start-new-franchise-cta');
+  await expect(startCta).toBeVisible({ timeout: SMOKE_TIMEOUT });
+  await startCta.click();
+
+  await expect(page.getByTestId('app-bootstrap-loading')).toBeHidden({ timeout: SMOKE_TIMEOUT });
+  await expect(page.getByText(/No league state received/i)).toHaveCount(0);
+  await expect(page.getByTestId('app-shell-ready')).toBeVisible({ timeout: SMOKE_TIMEOUT });
+  await expect(page.getByTestId('franchise-hq')).toBeVisible({ timeout: SMOKE_TIMEOUT });
+
+  await expect(page.getByText(/Week\s+\d+/i).first()).toBeVisible();
+  await expect(page.getByText(/\b[A-Z]{2,4}\s*\(\d+-\d+\)/).first()).toBeVisible();
+
+  const advanceBtn = page.getByTestId('advance-week-cta');
   await expect(advanceBtn).toBeVisible();
   await advanceBtn.click();
 
-  await expect(page.getByText(/Week Results|Recent Results|Last Result/i).first()).toBeVisible({ timeout: 60000 });
-  const resultLink = page.getByRole('button', { name: /game book|box score/i }).first();
-  await expect(resultLink).toBeVisible({ timeout: 60000 });
-  await resultLink.click();
+  const completedGameLink = page.getByTestId('completed-game-link').first();
+  await expect(completedGameLink).toBeVisible({ timeout: SMOKE_TIMEOUT });
+  await completedGameLink.click();
 
-  await expect(page.getByText(/Final|Box Score|Game Book/i).first()).toBeVisible({ timeout: 30000 });
-  await expect(page.getByText(/Detailed box score data was not recorded for this game\.|Q1|Passing|Rushing/i).first()).toBeVisible();
+  await expect(page.getByTestId('game-book')).toBeVisible({ timeout: SMOKE_TIMEOUT });
+  await expect(page.getByTestId('game-book-final-score')).toBeVisible({ timeout: SMOKE_TIMEOUT });
 
-  const backBtn = page.getByRole('button', { name: /back|close|return/i }).first();
-  if (await backBtn.isVisible()) await backBtn.click();
-  await expect(page.getByTestId('app-shell-ready')).toBeVisible();
+  await page.getByTestId('return-to-hq').click();
+  await expect(page.getByTestId('franchise-hq')).toBeVisible({ timeout: SMOKE_TIMEOUT });
 
-  expect(consoleErrors.join('\n')).not.toContain('Uncaught');
+  await page.reload();
+  await expect(page.getByTestId('app-bootstrap-loading')).toBeHidden({ timeout: SMOKE_TIMEOUT });
+  await expect(page.getByTestId('app-shell-ready')).toBeVisible({ timeout: SMOKE_TIMEOUT });
+  await expect(page.getByTestId('franchise-hq')).toBeVisible({ timeout: SMOKE_TIMEOUT });
+
+  expect(consoleErrors.join('\n')).not.toMatch(/Uncaught|TypeError|ReferenceError/);
 });

--- a/tests/e2e/helpers/franchise.js
+++ b/tests/e2e/helpers/franchise.js
@@ -57,7 +57,6 @@ export async function ensureLeagueLoaded(page) {
 }
 
 export async function launchFranchise(page) {
-  await page.goto('http://localhost:5173');
   await ensureLeagueLoaded(page);
 }
 


### PR DESCRIPTION
### Motivation
- The end-to-end verification for a fresh Start New Franchise flow was not authoritative and e2e did not run in prior work, so the deploy preview and CI never proved the first-session playable loop. 
- Partial/invalid league payloads could throw during validation (e.g. calling `.some` on undefined), which caused bootstrap gating to be fragile and inhibited reliable fallback behavior. 
- Tests and manual QA were brittle because key UI surfaces lacked stable test IDs and the e2e helper re-navigated to a hardcoded URL, bypassing Playwright baseURL/server configuration. 

### Description
- Fixed validation safety in `getPlayableLeagueValidation` to avoid `.some` on undefined by normalizing `teams` and `weeks` arrays and returning structured invalid reasons instead of throwing. (src/state/leagueInit.ts) 
- Added stable test IDs to the smoke-path surfaces used by the e2e flow: `franchise-hq`, `advance-week-cta`, `completed-game-link`, `game-book`, `game-book-final-score`, and `return-to-hq`. (src/ui/components/FranchiseHQ.jsx, WeeklyResultsCenter.jsx, GameDetailScreen.jsx, BoxScore.jsx, ScreenSystem.jsx) 
- Upgraded the fresh-franchise smoke e2e to be authoritative and deterministic by clearing storage for a fresh session, clicking the Start New Franchise CTA, asserting bootstrap and HQ visibility, advancing a week, opening the Game Book, verifying final score, returning to HQ, and reloading to confirm persistence. (tests/e2e/fresh_franchise_first_week_smoke.spec.js) 
- Removed a hardcoded second navigation from the e2e helper so tests respect Playwright server/baseURL configuration. (tests/e2e/helpers/franchise.js) 

### Testing
- Commands executed: `npm install`; `npx playwright install` (attempted); `npm run build`; `npm run test:unit -- tests/unit/leagueInit.test.jsx src/ui/utils/leagueBootstrap.test.js`; `npm run test:e2e -- tests/e2e/fresh_franchise_first_week_smoke.spec.js`.
- `npx playwright install` failed in this environment due to CDN download being blocked with a `403 Domain forbidden`, so Playwright browser binaries were not installed and e2e execution was blocked. (install failed) 
- `npm run build` completed successfully and produced the production bundle. (success) 
- Unit tests were run with `npm run test:unit -- tests/unit/leagueInit.test.jsx src/ui/utils/leagueBootstrap.test.js` and passed (all unit tests in those files succeeded). (success) 
- `npm run test:e2e -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` was executed but failed to run because Playwright browser executables were missing due to the failed `npx playwright install` step; the smoke test itself is now authoritative and ready to run once browsers are available. (blocked)

Known limitations and follow-ups: the PR does not add request-scoping (request id/boot token) or change worker-side guarantees in this rollout; it hardens validation, adds stable selectors, and makes the smoke test authoritative so the next step is to re-run e2e after Playwright browsers are installed (or run on CI with browsers available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6c7db2e90832db13a82e3079b250c)