### PR TITLE
Fix Safe Starter recovery to hydrate playable state instead of window placeholder

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -152,6 +152,7 @@ function AppContent() {
   const [postGameResult, setPostGameResult] = useState(null);
   const [initFlow, setInitFlow] = useState(null);
   const [bootRequestId, setBootRequestId] = useState(null);
+  const [safeStarterWarning, setSafeStarterWarning] = useState('');
   const [bootDiagnostics, setBootDiagnostics] = useState([]);
   const isBootDebugEnabled = import.meta.env.DEV || (typeof window !== 'undefined' && localStorage.getItem('DEBUG_BOOT') === '1');
   const pushBootDiag = useCallback((stage, extra = {}) => {
@@ -499,6 +500,7 @@ function AppContent() {
   }, [initFlow, league, pushBootDiag]);
 
   const handleSafeStarterLeague = useCallback(() => {
+    const safeBootRequestId = `safe_boot_${Date.now()}`;
     const safeLeague = buildDefaultLeague();
     const validation = getPlayableLeagueValidation(safeLeague);
     pushBootDiag('fallback_validation_result', { valid: validation.valid, reasons: validation.reasons });
@@ -506,11 +508,18 @@ function AppContent() {
       setInitFlow((prev) => prev ? { ...prev, timedOut: true, message: `Safe starter failed validation: ${validation.reasons?.[0] ?? 'unknown'}` } : prev);
       return;
     }
-    window.__SAFE_STARTER_LEAGUE__ = safeLeague;
+    actions.setActiveBootRequestId(safeBootRequestId);
+    actions.hydrateLeagueSnapshot(safeLeague, { bootRequestId: null });
+    actions.saveSlot(pendingNewSlot);
+    setActiveSlot(pendingNewSlot);
     setPendingNewSlot(null);
     setInitFlow(null);
-    setActiveView('saves');
-  }, [pushBootDiag]);
+    setBootRequestId(null);
+    actions.setActiveBootRequestId(null);
+    setSafeStarterWarning('Loaded a safe starter league because normal franchise setup did not respond.');
+    pushBootDiag('fallback_committed_to_slot', { slotKey: pendingNewSlot });
+    setActiveView('league_dashboard');
+  }, [actions, pendingNewSlot, pushBootDiag]);
   const getAdvanceLabel = () => {
     if (batchSim) return `Simulating…`;
     if (simulating) return `Simulating ${simProgress}%`;
@@ -1017,6 +1026,11 @@ function AppContent() {
           Still setting up your franchise… {bootstrapSummary.reasons[0] ?? 'Preparing franchise data.'}
         </div>
       )}
+      {safeStarterWarning ? (
+        <div role="status" className="app-banner app-banner-warn" data-testid="safe-starter-warning">
+          {safeStarterWarning}
+        </div>
+      ) : null}
 
       {/* ── Notifications ──────────────────────────────────────────────── */}
       {Array.isArray(notifications) && notifications.length > 0 && (

--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -458,6 +458,12 @@ export function useWorker() {
     newLeague: (teams, options) =>
       (activeBootRequestIdRef.current = options?.bootRequestId ?? null,
       request(toWorker.NEW_LEAGUE, { teams, options }, { silent: false })),
+    setActiveBootRequestId: (requestId = null) => {
+      activeBootRequestIdRef.current = requestId;
+    },
+    hydrateLeagueSnapshot: (league, { bootRequestId = null } = {}) => {
+      dispatch({ type: 'FULL_STATE', payload: { ...league, bootRequestId } });
+    },
 
     /** Watch the user game (returns a Promise resolving to logs). */
     watchGame: () => request(toWorker.WATCH_GAME, {}, { silent: false }),


### PR DESCRIPTION
### Motivation
- The previous Safe Starter path (introduced in PR #1353) only stored a fallback league on `window.__SAFE_STARTER_LEAGUE__` and routed users back to the saves view, which did not persist the league, hydrate the app/worker state, set the active slot, or route into Franchise HQ for immediate play.
- Users hitting a timed-out or failed `NEW_LEAGUE` boot could be stranded or unable to advance week / open game-book because the app never committed a FULL_STATE-equivalent save and didn't clear bootstrap flags.
- The goal is a minimal, targeted fix so the emergency "Use Safe Starter League" path results in a playable, persistent franchise and prevents late/stale worker responses from overwriting the fallback.

### Description
- Added two emergency helper actions to `useWorker`: `setActiveBootRequestId(requestId)` to control boot scoping and `hydrateLeagueSnapshot(league, { bootRequestId })` which dispatches a `FULL_STATE`-shaped payload into the UI worker state for immediate hydration.
- Reworked `handleSafeStarterLeague` in `App.jsx` to: build and validate the default league, set a temporary `safeBootRequestId`, call `actions.hydrateLeagueSnapshot(...)` to inject the FULL_STATE into the UI, persist the league via `actions.saveSlot(pendingNewSlot)`, set the `activeSlot`, clear `pendingNewSlot`, `initFlow`, and `bootRequestId`, clear the temporary boot scope, and route the user directly to the league/dashboard (Franchise HQ) instead of the saves screen.
- Added a non-blocking warning banner with stable test id `safe-starter-warning` and set a concise message: "Loaded a safe starter league because normal franchise setup did not respond." so users are aware a fallback was used.
- Preserved stale-response protection by leveraging the existing `bootRequestId` checks in `useWorker`/worker message handling and by temporarily setting an emergency `activeBootRequestIdRef` during commit so late FULL_STATE messages with mismatched `bootRequestId` are ignored.

### Testing
- Built production bundle with `npm run build` (Vite build completed successfully).
- Ran unit tests: `npm run test:unit -- src/ui/utils/leagueBootstrap.test.js` and all tests passed (10 tests).
- Notes on checks not run here: browser e2e/manual deploy-preview QA (simulate worker timeout → click Use Safe Starter → Advance Week → open Game Book → reload persistence) was not executed in this environment and should be run on a deploy preview or CI with browser capabilities to confirm full UX acceptance criteria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e00f0408832dbdc9b014a20e12aa)