### PR TITLE
Fix franchise boot gate and safe starter persistence

### DIFF
--- a/src/data/defaultLeague.ts
+++ b/src/data/defaultLeague.ts
@@ -1,47 +1,229 @@
 import { DEFAULT_TEAMS } from './default-teams.js';
 
 const TEAM_COUNT = 32;
-const ROSTER_SIZE = 53;
+const START_YEAR = 2026;
+const SEASON_ID = 's1';
+const ROSTER_POSITIONS = [
+  ['QB', 3],
+  ['RB', 4],
+  ['WR', 6],
+  ['TE', 3],
+  ['OL', 9],
+  ['DL', 9],
+  ['LB', 7],
+  ['CB', 6],
+  ['S', 4],
+  ['K', 1],
+  ['P', 1],
+] as const;
 
-function makePlayer(teamId: number, index: number) {
+const RATING_KEYS = [
+  'throwPower',
+  'throwAccuracy',
+  'awareness',
+  'catching',
+  'catchInTraffic',
+  'acceleration',
+  'speed',
+  'agility',
+  'trucking',
+  'juking',
+  'passRushSpeed',
+  'passRushPower',
+  'runStop',
+  'coverage',
+  'runBlock',
+  'passBlock',
+  'intelligence',
+  'kickPower',
+  'kickAccuracy',
+];
+
+function buildRatings(pos: string, ovr: number) {
+  const ratings = Object.fromEntries(RATING_KEYS.map((key) => [key, Math.max(45, Math.min(90, ovr - 2))]));
+  const boost = (keys: string[], amount = 8) => {
+    keys.forEach((key) => {
+      ratings[key] = Math.max(45, Math.min(95, ovr + amount));
+    });
+  };
+
+  if (pos === 'QB') boost(['throwPower', 'throwAccuracy', 'awareness', 'intelligence']);
+  if (pos === 'RB') boost(['speed', 'acceleration', 'trucking', 'juking', 'awareness']);
+  if (pos === 'WR') boost(['speed', 'acceleration', 'catching', 'catchInTraffic']);
+  if (pos === 'TE') boost(['catching', 'catchInTraffic', 'runBlock', 'passBlock']);
+  if (pos === 'OL') boost(['runBlock', 'passBlock', 'awareness']);
+  if (pos === 'DL') boost(['passRushPower', 'passRushSpeed', 'runStop']);
+  if (pos === 'LB') boost(['speed', 'runStop', 'coverage', 'awareness']);
+  if (pos === 'CB') boost(['speed', 'acceleration', 'coverage', 'intelligence']);
+  if (pos === 'S') boost(['speed', 'coverage', 'runStop', 'awareness']);
+  if (pos === 'K' || pos === 'P') boost(['kickPower', 'kickAccuracy', 'awareness']);
+
+  return ratings;
+}
+
+function makePlayer(teamId: number, index: number, pos: string, depthOrder: number) {
+  const ovr = Math.max(58, Math.min(84, 74 - Math.floor(depthOrder / 2) + ((teamId + index) % 5)));
+  const ratings = buildRatings(pos, ovr);
+  const id = teamId * 1000 + index + 1;
   return {
-    id: teamId * 1000 + index,
-    name: `Player ${teamId + 1}-${index + 1}`,
-    pos: 'UNK',
-    age: 24,
-    ovr: 60,
-    pot: 65,
-    contract: { years: 2, amount: 1.2 },
+    id,
+    name: `${pos} Starter ${teamId + 1}-${depthOrder}`,
+    pos,
+    age: 23 + ((teamId + index) % 10),
+    ratings,
+    trueRatings: { ...ratings },
+    visibleRatings: { ...ratings },
+    ovr,
+    displayOvr: ovr,
+    trueOvr: ovr,
+    scoutedOvr: ovr,
+    pot: Math.min(95, ovr + 6),
+    potential: Math.min(95, ovr + 6),
+    years: 2,
+    yearsTotal: 2,
+    baseAnnual: pos === 'QB' ? 8 : pos === 'K' || pos === 'P' ? 1.2 : 2.2,
+    signingBonus: 0,
+    guaranteedPct: 0.45,
+    contract: { years: 2, yearsTotal: 2, salary: pos === 'QB' ? 8 : 2.2, amount: pos === 'QB' ? 8 : 2.2 },
+    status: 'active',
     teamId,
+    depthOrder,
+    injuryWeeksRemaining: 0,
+    injuryWeeks: 0,
+    fatigue: 0,
+    morale: 75,
+    stats: {
+      game: {},
+      season: {},
+      career: {},
+    },
+    awards: [],
+    history: [],
+    traits: [],
+    abilities: [],
   };
 }
 
-export function buildDefaultLeague() {
-  const teams = DEFAULT_TEAMS.slice(0, TEAM_COUNT).map((team, idx) => ({
-    ...team,
-    id: idx,
-    wins: 0,
-    losses: 0,
-    ties: 0,
-    roster: Array.from({ length: ROSTER_SIZE }, (_, playerIndex) => makePlayer(idx, playerIndex)),
-  }));
-
-  const games = [] as Array<{ home: number; away: number; played: boolean }>;
-  for (let i = 0; i < teams.length; i += 2) {
-    if (teams[i + 1]) games.push({ away: teams[i].id, home: teams[i + 1].id, played: false });
+function makeRoster(teamId: number) {
+  const roster = [];
+  let index = 0;
+  for (const [pos, count] of ROSTER_POSITIONS) {
+    for (let depth = 1; depth <= count; depth += 1) {
+      roster.push(makePlayer(teamId, index, pos, depth));
+      index += 1;
+    }
   }
+  return roster;
+}
+
+function makeDraftPicks(teamId: number) {
+  const picks = [];
+  for (let yearOffset = 0; yearOffset < 3; yearOffset += 1) {
+    for (let round = 1; round <= 7; round += 1) {
+      picks.push({
+        id: `safe-pick-${teamId}-${START_YEAR + yearOffset}-${round}`,
+        round,
+        season: START_YEAR + yearOffset,
+        originalOwner: teamId,
+        currentOwner: teamId,
+        isCompensatory: false,
+      });
+    }
+  }
+  return picks;
+}
+
+function makeSchedule(teams: Array<{ id: number }>) {
+  const ids = teams.map((team) => team.id);
+  const weeks = [];
+  for (let week = 1; week <= 18; week += 1) {
+    const offset = (week - 1) % ids.length;
+    const rotated = ids.slice(offset).concat(ids.slice(0, offset));
+    const games = [];
+    for (let i = 0; i < rotated.length; i += 2) {
+      const away = rotated[i];
+      const home = rotated[i + 1];
+      if (home == null || away == null) continue;
+      const gameId = `${SEASON_ID}_w${week}_${home}_${away}`;
+      games.push({
+        id: gameId,
+        gameId,
+        seasonId: SEASON_ID,
+        week,
+        away,
+        home,
+        played: false,
+      });
+    }
+    weeks.push({ week, games });
+  }
+  return { weeks };
+}
+
+export function buildDefaultLeague(options: { userTeamId?: number; name?: string; year?: number } = {}) {
+  const userTeamId = Number.isFinite(Number(options.userTeamId)) ? Number(options.userTeamId) : 0;
+  const year = Number.isFinite(Number(options.year)) ? Number(options.year) : START_YEAR;
+  const teams = DEFAULT_TEAMS.slice(0, TEAM_COUNT).map((team, idx) => {
+    const roster = makeRoster(idx);
+    return {
+      ...team,
+      id: idx,
+      wins: 0,
+      losses: 0,
+      ties: 0,
+      ptsFor: 0,
+      ptsAgainst: 0,
+      roster,
+      rosterIds: roster.map((player) => player.id),
+      rosterCount: roster.length,
+      picks: makeDraftPicks(idx),
+      capTotal: 301.2,
+      capUsed: 0,
+      capRoom: 301.2,
+      capSpace: 301.2,
+      fanApproval: 50,
+      history: [],
+      stats: { season: {}, game: {} },
+      strategies: { offPlanId: 'BALANCED', defPlanId: 'BALANCED', riskId: 'BALANCED', starTargetId: null },
+      franchiseInvestments: {
+        stadiumLevel: 1,
+        concessionsStrategy: 'balanced',
+        trainingLevel: 1,
+        scoutingLevel: 1,
+        scoutingRegion: 'national',
+        ownerCapacity: 10,
+        usedCapacity: 4,
+        trainingFocus: 'balanced',
+        history: [],
+      },
+    };
+  });
+
+  const schedule = makeSchedule(teams);
 
   return {
     id: 'fallback-league',
-    name: 'Fallback League',
+    name: options.name ?? 'Safe Starter League',
     phase: 'regular',
     week: 1,
-    year: 2026,
+    year,
     season: 1,
-    userTeamId: 0,
+    seasonId: SEASON_ID,
+    currentSeasonId: SEASON_ID,
+    userTeamId,
     teams,
-    schedule: {
-      weeks: [{ week: 1, games }],
+    schedule,
+    resultsByWeek: [],
+    transactions: [],
+    newsItems: [],
+    ownerGoals: [],
+    retiredPlayers: [],
+    records: {
+      mostPassingYardsSeason: null,
+      mostRushingYardsSeason: null,
+      mostWinsSeason: null,
+      mostChampionships: null,
+      highestOvrPlayer: null,
     },
   };
 }

--- a/src/state/leagueInit.ts
+++ b/src/state/leagueInit.ts
@@ -2,29 +2,66 @@ import { buildDefaultLeague } from '../data/defaultLeague';
 
 const DEFAULT_TIMEOUT_MS = 5000;
 
-export function getPlayableLeagueValidation(league: any) {
+export function getBootViewStateValidation(viewState: any) {
   const reasons: string[] = [];
-  if (!league || typeof league !== 'object') {
+  if (!viewState || typeof viewState !== 'object') {
     return { valid: false, reasons: ['No league state received'] };
   }
-  if (!league.phase) reasons.push('Missing phase');
-  if (typeof league.week !== 'number') reasons.push('Missing week number');
-  if (typeof league.year !== 'number' && typeof league.seasonId !== 'number' && typeof league.season !== 'number') reasons.push('Missing season/year');
-  if (!Array.isArray(league.teams) || league.teams.length < 2) reasons.push('Teams unavailable');
-  const teams = Array.isArray(league.teams) ? league.teams : [];
-  const inferredUserTeamId = league.userTeamId ?? teams[0]?.id;
+
+  if (!viewState.phase) reasons.push('Missing phase');
+  if (typeof viewState.week !== 'number') reasons.push('Missing week number');
+  if (typeof viewState.year !== 'number' && typeof viewState.seasonId !== 'number' && typeof viewState.season !== 'number') {
+    reasons.push('Missing season/year');
+  }
+
+  const teams = Array.isArray(viewState.teams) ? viewState.teams : [];
+  if (teams.length < 2) reasons.push('Teams unavailable');
+  const inferredUserTeamId = viewState.userTeamId ?? teams[0]?.id;
   const hasUserTeam = inferredUserTeamId != null && teams.some((t: any) => Number(t?.id) === Number(inferredUserTeamId));
   if (!hasUserTeam) reasons.push('User team missing');
+
+  return {
+    valid: reasons.length === 0,
+    reasons,
+    inferredUserTeamId,
+  };
+}
+
+export function isBootViewStateReady(viewState: any) {
+  return getBootViewStateValidation(viewState).valid;
+}
+
+export function getPlayableLeagueValidation(league: any) {
+  const bootValidation = getBootViewStateValidation(league);
+  const reasons: string[] = [...bootValidation.reasons];
+  if (!league || typeof league !== 'object') {
+    return { valid: false, reasons };
+  }
+
+  const teams = Array.isArray(league.teams) ? league.teams : [];
+  const flattenedPlayers = Array.isArray(league.players) ? league.players : [];
+  const teamsMissingRoster = teams.filter((team: any) => {
+    if (Array.isArray(team?.roster) && team.roster.length > 0) return false;
+    if (Array.isArray(team?.players) && team.players.length > 0) return false;
+    return !flattenedPlayers.some((player: any) => Number(player?.teamId) === Number(team?.id));
+  });
   const hasRosterData = teams.some((team: any) => Array.isArray(team?.roster) ? team.roster.length > 0 : Array.isArray(team?.players) && team.players.length > 0);
-  if (!hasRosterData && Array.isArray(league.players) && league.players.length > 0) {
-    // valid roster fallback via flattened player pool
-  } else if (!hasRosterData) {
+  if (teamsMissingRoster.length > 0) {
+    reasons.push('No roster/player data');
+  } else if (!hasRosterData && flattenedPlayers.length === 0) {
     reasons.push('No roster/player data');
   }
+
   const weeks = Array.isArray(league?.schedule?.weeks) ? league.schedule.weeks : [];
   if (weeks.length === 0) reasons.push('Schedule missing');
   const hasGames = weeks.some((w: any) => Array.isArray(w?.games) && w.games.length > 0);
   if (!hasGames) reasons.push('No games available');
+  const hasScheduledMatchup = weeks.some((w: any) => (w?.games ?? []).some((game: any) => {
+    const home = game?.home?.id ?? game?.home ?? game?.homeId;
+    const away = game?.away?.id ?? game?.away ?? game?.awayId;
+    return home != null && away != null;
+  }));
+  if (hasGames && !hasScheduledMatchup) reasons.push('No scheduled matchups');
 
   return {
     valid: reasons.length === 0,

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -64,12 +64,48 @@ import { buildCanonicalGameId } from '../core/gameIdentity.js';
 import { getRecentGames, saveGame } from '../core/archive/gameArchive.ts';
 import { applyEventDecision } from './utils/franchiseEvents.js';
 import { logChronicleEvent } from './utils/franchiseChronicle.js';
-import { buildDefaultLeague } from '../data/defaultLeague.ts';
-import { getPlayableLeagueValidation } from '../state/leagueInit.ts';
+import { getBootViewStateValidation, getPlayableLeagueValidation } from '../state/leagueInit.ts';
 
 // Increment this when shipping notable UX/bugfix updates so users
 // see the in-app changelog popup once per version.
 const APP_VERSION = '1.2.1-first-playable-reliability';
+const ACTIVE_SLOT_STORAGE_KEY = 'footballgm_active_slot_v1';
+const VALID_SLOT_KEYS = new Set(['save_slot_1', 'save_slot_2', 'save_slot_3']);
+
+function readStoredActiveSlot() {
+  if (typeof window === 'undefined') return null;
+  try {
+    const value = window.localStorage.getItem(ACTIVE_SLOT_STORAGE_KEY);
+    return VALID_SLOT_KEYS.has(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredActiveSlot(slotKey) {
+  if (typeof window === 'undefined') return;
+  try {
+    if (VALID_SLOT_KEYS.has(slotKey)) {
+      window.localStorage.setItem(ACTIVE_SLOT_STORAGE_KEY, slotKey);
+    } else {
+      window.localStorage.removeItem(ACTIVE_SLOT_STORAGE_KEY);
+    }
+  } catch {
+    // Persistence is best-effort; slot selection still works in memory.
+  }
+}
+
+function readStoredSlotMeta(slotKey) {
+  if (typeof window === 'undefined' || !VALID_SLOT_KEYS.has(slotKey)) return null;
+  const slotNum = slotKey?.split('_')?.[2];
+  if (!slotNum) return null;
+  try {
+    const raw = window.localStorage.getItem(`footballgm_slot_${slotNum}_meta`);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
 
 // ── GameSimulation Error Boundary ────────────────────────────────────────────
 // Prevents a crash inside GameSimulation from killing the whole app.
@@ -127,10 +163,11 @@ function AppContent() {
     promptUserGame,
     userGameLogs,
     userGameLiveStats,
+    lastWorkerMessageType,
   } = state;
 
   const [activeView, setActiveView] = useState('saves');
-  const [activeSlot, setActiveSlot] = useState(null);
+  const [activeSlot, setActiveSlot] = useState(() => readStoredActiveSlot());
   const [pendingNewSlot, setPendingNewSlot] = useState(null);
   const [watchMode, setWatchMode] = useState('watch');
   const [externalBoxScoreId, setExternalBoxScoreId] = useState(null);
@@ -162,13 +199,46 @@ function AppContent() {
     console.log('[BOOT_TRACE]', row);
   }, [isBootDebugEnabled]);
   const archiveMigrationRef = useRef(null);
+  const safeStarterInFlightRef = useRef(false);
+  const autoLoadActiveSlotRef = useRef(false);
   const leagueReady = hasMinimumPlayableLeague(league);
   const isNewFranchiseBootstrapping = shouldShowNewFranchiseBootstrapGate({
     league,
     pendingNewSlot,
     initFlowMode: initFlow?.mode,
+    initFlowActive: initFlow?.active,
   });
   const loadingSlot = initFlow?.active ? initFlow?.slotKey ?? null : null;
+
+  useEffect(() => {
+    writeStoredActiveSlot(activeSlot);
+  }, [activeSlot]);
+
+  useEffect(() => {
+    if (!workerReady || leagueReady || pendingNewSlot || initFlow?.active || autoLoadActiveSlotRef.current) return;
+
+    const slotKey = activeSlot ?? readStoredActiveSlot();
+    if (!slotKey) return;
+
+    const slotMeta = readStoredSlotMeta(slotKey);
+    if (!slotMeta?.lastSaved) {
+      writeStoredActiveSlot(null);
+      if (activeSlot === slotKey) setActiveSlot(null);
+      return;
+    }
+
+    autoLoadActiveSlotRef.current = true;
+    setActiveSlot(slotKey);
+    setInitFlow({ active: true, mode: 'load', slotKey, timedOut: false, message: '' });
+    actions.loadSlot(slotKey).catch((err) => {
+      setInitFlow((prev) => prev?.slotKey === slotKey ? {
+        ...prev,
+        active: true,
+        timedOut: true,
+        message: `Failed to load franchise: ${err?.message ?? 'unknown error'}`,
+      } : prev);
+    });
+  }, [workerReady, leagueReady, pendingNewSlot, initFlow?.active, activeSlot, actions]);
 
   // Local guard to prevent rapid-click double submission before 'busy' propagates
   const advancingRef = useRef(false);
@@ -375,6 +445,19 @@ function AppContent() {
     }
   }, [actions]);
 
+  const handleSafeReset = useCallback(() => {
+    if (bootRequestId) {
+      actions.invalidateBootRequestId(bootRequestId);
+    }
+    actions.setActiveBootRequestId(null);
+    safeStarterInFlightRef.current = false;
+    setBootRequestId(null);
+    setPendingNewSlot(null);
+    setInitFlow(null);
+    setActiveSlot(null);
+    setActiveView('saves');
+  }, [actions, bootRequestId]);
+
   // ── Keyboard shortcuts (desktop) ──────────────────────────────────────────
   // Space / Enter  → Advance week (when not busy and no modal open)
   // S              → Manual save
@@ -469,6 +552,7 @@ function AppContent() {
   }, []);
 
   useEffect(() => {
+    if (safeStarterInFlightRef.current) return;
     if (!shouldFinalizeNewSlotBootstrap({ league, pendingNewSlot })) return;
     // FIX: Only save and finalize if the league is actually playable
     if (hasMinimumPlayableLeague(league)) {
@@ -499,27 +583,72 @@ function AppContent() {
     return () => clearTimeout(timer);
   }, [initFlow, league, pushBootDiag]);
 
-  const handleSafeStarterLeague = useCallback(() => {
-    const safeBootRequestId = `safe_boot_${Date.now()}`;
-    const safeLeague = buildDefaultLeague();
-    const validation = getPlayableLeagueValidation(safeLeague);
-    pushBootDiag('fallback_validation_result', { valid: validation.valid, reasons: validation.reasons });
-    if (!validation.valid) {
-      setInitFlow((prev) => prev ? { ...prev, timedOut: true, message: `Safe starter failed validation: ${validation.reasons?.[0] ?? 'unknown'}` } : prev);
+  const handleSafeStarterLeague = useCallback(async () => {
+    const slotKey = pendingNewSlot ?? initFlow?.slotKey;
+    if (!slotKey) {
+      setInitFlow((prev) => prev ? {
+        ...prev,
+        timedOut: true,
+        message: 'Safe starter needs a selected franchise slot. Return to slots and try again.',
+      } : prev);
       return;
     }
+
+    if (bootRequestId) {
+      actions.invalidateBootRequestId(bootRequestId);
+    }
+    const safeBootRequestId = `safe_boot_${Date.now()}`;
+    safeStarterInFlightRef.current = true;
+    setBootRequestId(safeBootRequestId);
     actions.setActiveBootRequestId(safeBootRequestId);
-    actions.hydrateLeagueSnapshot(safeLeague, { bootRequestId: null });
-    actions.saveSlot(pendingNewSlot);
-    setActiveSlot(pendingNewSlot);
-    setPendingNewSlot(null);
-    setInitFlow(null);
-    setBootRequestId(null);
-    actions.setActiveBootRequestId(null);
-    setSafeStarterWarning('Loaded a safe starter league because normal franchise setup did not respond.');
-    pushBootDiag('fallback_committed_to_slot', { slotKey: pendingNewSlot });
-    setActiveView('league_dashboard');
-  }, [actions, pendingNewSlot, pushBootDiag]);
+    pushBootDiag('fallback_worker_commit_requested', {
+      slotKey,
+      invalidatedBootRequestId: bootRequestId,
+      safeBootRequestId,
+      userTeamId: initFlow?.userTeamId,
+    });
+
+    try {
+      const response = await actions.useSafeStarterLeague(slotKey, {
+        bootRequestId: safeBootRequestId,
+        userTeamId: initFlow?.userTeamId,
+        name: initFlow?.leagueName,
+        year: initFlow?.year,
+        difficulty: initFlow?.difficulty,
+        salaryCap: initFlow?.salaryCap,
+      });
+      const viewValidation = getBootViewStateValidation(response?.payload);
+      const fullValidation = getPlayableLeagueValidation(response?.payload);
+      pushBootDiag('fallback_worker_commit_result', {
+        slotKey,
+        safeBootRequestId,
+        uiBootValid: viewValidation.valid,
+        uiBootReasons: viewValidation.reasons,
+        fullSimValidForViewSnapshot: fullValidation.valid,
+        fullSimReasonsForViewSnapshot: fullValidation.reasons,
+      });
+      setActiveSlot(slotKey);
+      setPendingNewSlot(null);
+      setInitFlow(null);
+      setBootRequestId(null);
+      setSafeStarterWarning('Loaded a safe starter league because normal franchise setup did not respond.');
+      setActiveView('league_dashboard');
+    } catch (err) {
+      pushBootDiag('fallback_worker_commit_failed', {
+        slotKey,
+        safeBootRequestId,
+        message: err?.message ?? 'unknown',
+      });
+      setInitFlow((prev) => prev ? {
+        ...prev,
+        timedOut: true,
+        message: `Safe starter failed: ${err?.message ?? 'unknown error'}`,
+      } : prev);
+    } finally {
+      safeStarterInFlightRef.current = false;
+      actions.setActiveBootRequestId(null);
+    }
+  }, [actions, pendingNewSlot, initFlow, bootRequestId, pushBootDiag]);
   const getAdvanceLabel = () => {
     if (batchSim) return `Simulating…`;
     if (simulating) return `Simulating ${simProgress}%`;
@@ -649,7 +778,9 @@ function AppContent() {
     return <Loading message="Starting game engine…" />;
   }
 
-  if ((!leagueReady && !pendingNewSlot) || activeSlot === null) {
+  const shouldShowNewLeagueSetup = activeView === 'new_league' && !initFlow?.active && !leagueReady;
+
+  if (shouldShowNewLeagueSetup || (!leagueReady && !pendingNewSlot) || activeSlot === null) {
     const initTimeoutPanel = initFlow?.timedOut ? (
       <div role="alert" className="app-banner app-banner-error" style={{ marginBottom: 12 }}>
         <span>{initFlow.message}</span>
@@ -664,28 +795,29 @@ function AppContent() {
               Retry
             </button>
           )}
-          <button className="btn app-banner-btn" onClick={() => { setActiveSlot(null); setActiveView('saves'); }}>
+          <button className="btn app-banner-btn" onClick={handleSafeReset}>
             Safe Reset
           </button>
         </div>
       </div>
     ) : null;
-    if (activeView === 'new_league') {
+    if (shouldShowNewLeagueSetup) {
       return (
         <ErrorBoundary contextHint="new-franchise-setup">
           <div className="view fade-in" key="new_league" data-testid="app-new-league-setup">
             {initTimeoutPanel}
             <NewLeagueSetup
               actions={actions}
-              onStartCreate={(requestId) => {
+              onStartCreate={(requestId, createMeta = {}) => {
                 setBootRequestId(requestId);
-                pushBootDiag('new_league_setup_submit', { requestId, pendingNewSlot });
+                pushBootDiag('new_league_setup_submit', { requestId, pendingNewSlot, ...createMeta });
                 setInitFlow({
                   active: true,
                   mode: 'new',
                   slotKey: pendingNewSlot,
                   timedOut: false,
                   message: '',
+                  ...createMeta,
                 });
               }}
               onCreateError={(err) => {
@@ -697,7 +829,12 @@ function AppContent() {
                   message: `Failed to create league: ${err?.message ?? 'unknown error'}`,
                 } : prev);
               }}
-              onCancel={() => setActiveView('saves')}
+              onCancel={() => {
+                setPendingNewSlot(null);
+                setInitFlow(null);
+                setActiveSlot(null);
+                setActiveView('saves');
+              }}
             />
           </div>
       </ErrorBoundary>
@@ -741,7 +878,9 @@ function AppContent() {
   const safeWeek = shellLeague?.week ?? null;
   const safeYear = shellLeague?.year ?? shellLeague?.seasonId ?? null;
   const safeUserTeamId = shellLeague?.userTeamId ?? null;
-  const bootstrapSummary = summarizeBootstrapState(shellLeague);
+  const bootstrapSummary = summarizeBootstrapState(league);
+  const bootViewValidation = getBootViewStateValidation(league);
+  const fullSimValidationForUiState = getPlayableLeagueValidation(league);
   const userTeam = Array.isArray(shellLeague?.teams)
     ? shellLeague.teams.find((t) => Number(t?.id) === Number(safeUserTeamId))
     : null;
@@ -768,7 +907,7 @@ function AppContent() {
               <button data-testid="app-bootstrap-safe-starter" className="btn btn-primary app-banner-btn" onClick={handleSafeStarterLeague}>
                 Use Safe Starter League
               </button>
-              <button data-testid="app-bootstrap-back-to-slots" className="btn app-banner-btn" onClick={() => { setActiveSlot(null); setActiveView('saves'); }}>
+              <button data-testid="app-bootstrap-back-to-slots" className="btn app-banner-btn" onClick={handleSafeReset}>
                 Safe Reset
               </button>
             </div>
@@ -786,7 +925,16 @@ function AppContent() {
               pendingNewSlot,
               initFlow,
               bootRequestId,
+              lastWorkerMessageType,
               hasLeague: !!league,
+              uiBootValidation: {
+                valid: bootViewValidation.valid,
+                reasons: bootViewValidation.reasons,
+              },
+              fullSimValidationForUiState: {
+                valid: fullSimValidationForUiState.valid,
+                reasons: fullSimValidationForUiState.reasons,
+              },
               teamCount: Array.isArray(league?.teams) ? league.teams.length : 0,
               weekCount: Array.isArray(league?.schedule?.weeks) ? league.schedule.weeks.length : 0,
               trace: bootDiagnostics,
@@ -1015,7 +1163,7 @@ function AppContent() {
                 Retry
               </button>
             )}
-            <button className="btn app-banner-btn" onClick={() => setActiveSlot(null)}>
+            <button className="btn app-banner-btn" onClick={handleSafeReset}>
               Safe Reset
             </button>
           </div>

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -154,6 +154,42 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
       return `W${safeNum(game?.week, 0)} ${isHome ? 'vs' : '@'} ${oppTeam?.abbr ?? 'TBD'}`;
     }), [league]);
 
+  const seasonPulse = useMemo(() => {
+    const approval = Math.max(0, Math.min(100, safeNum(command.ownerMandate?.approval, 50)));
+    const mandateTone = command.ownerMandate?.tone ?? (approval < 45 ? 'danger' : approval < 65 ? 'warning' : 'ok');
+    const capRoom = safeNum(command.capSnapshot?.capRoom, safeNum(userTeam?.capRoom, 0));
+    const capTone = command.capSnapshot?.tone ?? (capRoom < 5 ? 'danger' : capRoom < 12 ? 'warning' : 'ok');
+    const capLabel = `${capRoom >= 0 ? '$' : '-$'}${Math.abs(capRoom).toFixed(1)}M`;
+    const gameId = decisionReview?.metadata?.gameId ?? lastGame?.gameId ?? lastGame?.id ?? null;
+    return {
+      approval,
+      mandateTone,
+      pressureSummary: command.pressureSummary ?? `Owner approval ${approval}%`,
+      momentumLabel: command.momentum?.label ?? 'No trend yet',
+      filmLabel: lastGame ? lastGameDisplay.heroLine : 'Kickoff ahead',
+      filmDetail: lastGame ? 'Open the latest final before changing next week.' : 'Scout the opponent and lock a plan before kickoff.',
+      filmRoute: gameId ? `Game Book:${gameId}` : 'Weekly Prep',
+      filmCta: gameId ? 'Open Game Book' : 'Open Weekly Prep',
+      rosterNeed: hqTeamBuilder.biggestNeed ?? 'No urgent need',
+      rosterDetail: hqTeamBuilder.nextAction ?? 'Review team builder for leverage.',
+      capLabel,
+      capTone,
+    };
+  }, [
+    command.ownerMandate?.approval,
+    command.ownerMandate?.tone,
+    command.pressureSummary,
+    command.momentum?.label,
+    command.capSnapshot?.capRoom,
+    command.capSnapshot?.tone,
+    decisionReview?.metadata?.gameId,
+    hqTeamBuilder.biggestNeed,
+    hqTeamBuilder.nextAction,
+    lastGame,
+    lastGameDisplay.heroLine,
+    userTeam?.capRoom,
+  ]);
+
   useEffect(() => {
     document.title = `Franchise HQ • ${command.weekLabel} • Football GM Sim`;
     let description = document.querySelector('meta[name="description"]');
@@ -223,6 +259,57 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
       </SectionCard>
 
 
+
+      <SectionCard title="Season Pulse" subtitle="Pressure, form, and roster leverage at a glance." variant="compact">
+        <div className="app-hq-pulse-grid" data-testid="season-pulse">
+          <article className={`app-hq-pulse-card tone-${seasonPulse.mandateTone}`}>
+            <div className="app-hq-pulse-card__head">
+              <span>Owner Mandate</span>
+              <StatusChip label={`${seasonPulse.approval}%`} tone={seasonPulse.mandateTone} />
+            </div>
+            <strong>{seasonPulse.pressureSummary}</strong>
+            <div className="app-mandate-meter" aria-hidden="true">
+              <span className="app-mandate-meter__segment tone-danger" />
+              <span className="app-mandate-meter__segment tone-warning" />
+              <span className="app-mandate-meter__segment tone-ok" />
+              <span className="app-mandate-meter__needle" style={{ left: `${seasonPulse.approval}%` }} />
+            </div>
+          </article>
+
+          <article className="app-hq-pulse-card tone-info">
+            <div className="app-hq-pulse-card__head">
+              <span>Momentum</span>
+              <StatusChip label={formatRecordInline(command.teamRecord)} tone="info" />
+            </div>
+            <strong>{seasonPulse.momentumLabel}</strong>
+            <p>{seasonPulse.filmLabel}</p>
+          </article>
+
+          <article className={`app-hq-pulse-card tone-${seasonPulse.capTone}`}>
+            <div className="app-hq-pulse-card__head">
+              <span>Roster Lever</span>
+              <StatusChip label={seasonPulse.rosterNeed} tone={seasonPulse.capTone} />
+            </div>
+            <strong>{seasonPulse.capLabel} cap room</strong>
+            <p>{seasonPulse.rosterDetail}</p>
+            <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('Team:Roster / Team Builder')}>
+              Open Team Builder
+            </button>
+          </article>
+
+          <article className="app-hq-pulse-card tone-ok">
+            <div className="app-hq-pulse-card__head">
+              <span>Film Room</span>
+              <StatusChip label={lastGame ? 'Postgame' : 'Pregame'} tone={lastGame ? 'ok' : 'warning'} />
+            </div>
+            <strong>{seasonPulse.filmCta}</strong>
+            <p>{seasonPulse.filmDetail}</p>
+            <button type="button" className="btn btn-sm" onClick={() => onNavigate?.(seasonPulse.filmRoute)}>
+              {seasonPulse.filmCta}
+            </button>
+          </article>
+        </div>
+      </SectionCard>
 
       <SectionCard title="Weekly Command Hub" subtitle="Ranked actions for this week before you advance." variant="compact">
         <div className="app-hq-intel-list">

--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -41,7 +41,7 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
   }
 
   return (
-    <div className="app-screen-stack">
+    <div className="app-screen-stack" data-testid="game-book">
       <ScreenHeader
         eyebrow="Game Book"
         title="Game Book"

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -919,7 +919,7 @@ export default function LeagueDashboard({
               renderResults={() => (
                 <WeeklyResultsCenter
                   league={league}
-                  initialWeek={weeklyResultsInitialWeek ?? league?.week}
+                  initialWeek={weeklyResultsInitialWeek}
                   onNavigate={setActiveTab}
                   onGameSelect={(gameId) => openGameDetail(gameId, "League")}
                 />
@@ -989,7 +989,7 @@ export default function LeagueDashboard({
           <TabErrorBoundary label="Weekly Results" onNavigate={setActiveTab} fallbackTab="League">
             <WeeklyResultsCenter
               league={league}
-              initialWeek={weeklyResultsInitialWeek ?? league?.week}
+              initialWeek={weeklyResultsInitialWeek}
               onNavigate={setActiveTab}
               onGameSelect={(gameId) => openGameDetail(gameId, "Weekly Results")}
             />

--- a/src/ui/components/NewLeagueSetup.jsx
+++ b/src/ui/components/NewLeagueSetup.jsx
@@ -109,7 +109,13 @@ export default function NewLeagueSetup({ actions, onCancel, onStartCreate, onCre
     if (selectedTeam === null) return;
     setCreating(true);
     const bootRequestId = `boot_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-    onStartCreate?.(bootRequestId);
+    onStartCreate?.(bootRequestId, {
+      userTeamId: selectedTeam,
+      leagueName: leagueName || `${selectedTeamData?.name || "My"} Dynasty`,
+      year,
+      difficulty,
+      salaryCap,
+    });
     try {
       const leagueRequest = actions.newLeague(DEFAULT_TEAMS, {
         bootRequestId,

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -56,6 +56,11 @@ describe('FranchiseHQ', () => {
     expect(screen.getByText(/must handle/i)).toBeTruthy();
     expect(screen.getByText(/tactical edge/i)).toBeTruthy();
     expect(screen.getByRole('heading', { name: /coordinator brief/i })).toBeTruthy();
+    const seasonPulse = within(screen.getByTestId('season-pulse'));
+    expect(seasonPulse.getByText(/owner mandate/i)).toBeTruthy();
+    expect(seasonPulse.getByText(/momentum/i)).toBeTruthy();
+    expect(seasonPulse.getByText(/roster lever/i)).toBeTruthy();
+    expect(seasonPulse.getByText(/film room/i)).toBeTruthy();
     expect(screen.getAllByRole('heading', { name: /game plan impact/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/home matchup vs det/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/ratings are tightly clustered/i)).toBeTruthy();
@@ -68,6 +73,14 @@ describe('FranchiseHQ', () => {
 
     fireEvent.click(within(view.container).getAllByRole('button', { name: /tactical edge: review game plan/i })[0]);
     expect(onNavigate).toHaveBeenCalledWith('Game Plan');
+  });
+
+  it('routes season pulse roster action through onNavigate', () => {
+    const onNavigate = vi.fn();
+    render(<FranchiseHQ league={baseLeague} onNavigate={onNavigate} onAdvanceWeek={() => {}} busy={false} simulating={false} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /open team builder/i }));
+    expect(onNavigate).toHaveBeenCalledWith('Team:Roster / Team Builder');
   });
 
 

--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -62,10 +62,22 @@ export const INITIAL_WORKER_STATE = {
   promptUserGame: false,
   userGameLogs: null,
   userGameLiveStats: null,
+  lastWorkerMessageType: null,
 };
 
 function isWeeklyResultsPhase(phase) {
   return phase === 'preseason' || phase === 'regular' || phase === 'playoffs';
+}
+
+export function shouldAcceptBootScopedPayload(payload = {}, activeBootRequestId = null, ignoredBootRequestIds = []) {
+  const requestId = payload?.bootRequestId ?? null;
+  if (!requestId) return true;
+  const ignored = ignoredBootRequestIds instanceof Set
+    ? ignoredBootRequestIds
+    : new Set(Array.isArray(ignoredBootRequestIds) ? ignoredBootRequestIds : []);
+  if (ignored.has(requestId)) return false;
+  if (activeBootRequestId && requestId !== activeBootRequestId) return false;
+  return true;
 }
 
 export function workerReducer(state, action) {
@@ -79,15 +91,16 @@ export function workerReducer(state, action) {
     case 'IDLE':
       return { ...state, busy: false, simulating: false, simProgress: 0 };
     case 'WORKER_READY':
-      return { ...state, workerReady: true, hasSave: action.hasSave ?? false, busy: false };
+      return { ...state, workerReady: true, hasSave: action.hasSave ?? false, busy: false, lastWorkerMessageType: action.messageType ?? state.lastWorkerMessageType };
     case 'FULL_STATE':
-      return { ...state, busy: false, simulating: false, batchSim: null, league: action.payload };
+      return { ...state, busy: false, simulating: false, batchSim: null, league: action.payload, lastWorkerMessageType: action.messageType ?? state.lastWorkerMessageType };
     case 'STATE_UPDATE':
       // Also clear busy: send()-based actions (signPlayer, releasePlayer, setUserTeam)
       // respond with STATE_UPDATE and have no other mechanism to clear the flag.
       return {
         ...state,
         busy: false,
+        lastWorkerMessageType: action.messageType ?? state.lastWorkerMessageType,
         league: { ...(state.league ?? {}), ...action.payload },
         ...(action.payload?.phase && !isWeeklyResultsPhase(action.payload.phase)
           ? { lastResults: [], lastSimWeek: null, gameEvents: [] }
@@ -149,7 +162,9 @@ export function workerReducer(state, action) {
     case 'DRAFT_TRADE_OFFER':
       return { ...state, draftTradeProposal: action.proposal ?? null };
     case 'ERROR':
-      return { ...state, busy: false, simulating: false, error: action.message };
+      return { ...state, busy: false, simulating: false, error: action.message, lastWorkerMessageType: action.messageType ?? state.lastWorkerMessageType };
+    case 'WORKER_MESSAGE':
+      return { ...state, lastWorkerMessageType: action.messageType ?? null };
     case 'NOTIFY':
       {
         const now = Date.now();
@@ -205,6 +220,7 @@ export function useWorker() {
     waiters: [],
   });
   const activeBootRequestIdRef = useRef(null);
+  const ignoredBootRequestIdsRef = useRef(new Set());
 
   // ── Spawn worker once ──────────────────────────────────────────────────────
   useEffect(() => {
@@ -247,22 +263,24 @@ export function useWorker() {
         dispatch({ type: silent ? 'CLEAR_BUSY' : 'IDLE' });
       }
 
+      dispatch({ type: 'WORKER_MESSAGE', messageType: type });
+
       // Then update React state
       switch (type) {
         case toUI.READY:
-          dispatch({ type: 'WORKER_READY', hasSave: payload.hasSave });
+          dispatch({ type: 'WORKER_READY', hasSave: payload.hasSave, messageType: type });
           break;
         case toUI.FULL_STATE:
-          if (payload?.bootRequestId && activeBootRequestIdRef.current && payload.bootRequestId !== activeBootRequestIdRef.current) {
+          if (!shouldAcceptBootScopedPayload(payload, activeBootRequestIdRef.current, ignoredBootRequestIdsRef.current)) {
             break;
           }
           if (payload?.bootRequestId && activeBootRequestIdRef.current === payload.bootRequestId) {
             activeBootRequestIdRef.current = null;
           }
-          dispatch({ type: 'FULL_STATE', payload });
+          dispatch({ type: 'FULL_STATE', payload, messageType: type });
           break;
         case toUI.STATE_UPDATE:
-          dispatch({ type: 'STATE_UPDATE', payload });
+          dispatch({ type: 'STATE_UPDATE', payload, messageType: type });
           break;
         case toUI.PROMPT_USER_GAME:
           dispatch({ type: 'PROMPT_USER_GAME' });
@@ -317,10 +335,10 @@ export function useWorker() {
           dispatch({ type: 'IDLE' });
           break;
         case toUI.ERROR:
-          if (payload?.bootRequestId && activeBootRequestIdRef.current && payload.bootRequestId !== activeBootRequestIdRef.current) {
+          if (!shouldAcceptBootScopedPayload(payload, activeBootRequestIdRef.current, ignoredBootRequestIdsRef.current)) {
             break;
           }
-          dispatch({ type: 'ERROR', message: payload.message });
+          dispatch({ type: 'ERROR', message: payload.message, messageType: type });
           break;
         case toUI.SIM_BATCH_PROGRESS:
           dispatch({ type: 'BATCH_SIM_PROGRESS', currentWeek: payload.currentWeek, phase: payload.phase });
@@ -457,12 +475,30 @@ export function useWorker() {
     /** Generate a new league. teams = array of team definitions. */
     newLeague: (teams, options) =>
       (activeBootRequestIdRef.current = options?.bootRequestId ?? null,
+      options?.bootRequestId ? ignoredBootRequestIdsRef.current.delete(options.bootRequestId) : null,
       request(toWorker.NEW_LEAGUE, { teams, options }, { silent: false })),
     setActiveBootRequestId: (requestId = null) => {
       activeBootRequestIdRef.current = requestId;
     },
+    invalidateBootRequestId: (requestId = null) => {
+      if (!requestId) {
+        activeBootRequestIdRef.current = null;
+        return;
+      }
+      ignoredBootRequestIdsRef.current.add(requestId);
+      if (activeBootRequestIdRef.current === requestId) {
+        activeBootRequestIdRef.current = null;
+      }
+    },
     hydrateLeagueSnapshot: (league, { bootRequestId = null } = {}) => {
       dispatch({ type: 'FULL_STATE', payload: { ...league, bootRequestId } });
+    },
+    useSafeStarterLeague: (slotKey, options = {}) => {
+      if (options?.bootRequestId) {
+        activeBootRequestIdRef.current = options.bootRequestId;
+        ignoredBootRequestIdsRef.current.delete(options.bootRequestId);
+      }
+      return request(toWorker.USE_SAFE_STARTER_LEAGUE, { slotKey, options }, { silent: false });
     },
 
     /** Watch the user game (returns a Promise resolving to logs). */

--- a/src/ui/hooks/useWorker.test.js
+++ b/src/ui/hooks/useWorker.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { INITIAL_WORKER_STATE, workerReducer } from './useWorker.js';
+import { INITIAL_WORKER_STATE, shouldAcceptBootScopedPayload, workerReducer } from './useWorker.js';
 
 describe('workerReducer', () => {
   it('preserves league state on WORKER_READY while clearing busy', () => {
@@ -24,5 +24,12 @@ describe('workerReducer', () => {
     expect(next.workerReady).toBe(true);
     expect(next.hasSave).toBe(true);
     expect(next.busy).toBe(false);
+  });
+
+  it('rejects stale boot-scoped payloads after a boot id is invalidated', () => {
+    expect(shouldAcceptBootScopedPayload({ bootRequestId: 'boot_1' }, null, ['boot_1'])).toBe(false);
+    expect(shouldAcceptBootScopedPayload({ bootRequestId: 'boot_1' }, 'safe_boot_1', [])).toBe(false);
+    expect(shouldAcceptBootScopedPayload({ bootRequestId: 'safe_boot_1' }, 'safe_boot_1', ['boot_1'])).toBe(true);
+    expect(shouldAcceptBootScopedPayload({ phase: 'regular' }, null, ['boot_1'])).toBe(true);
   });
 });

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -519,6 +519,17 @@
 .app-hq-impact-card__cta { justify-self: start; min-height: 34px; }
 .app-hq-impact-card.tone-warning { border-color: rgba(255,159,10,.45); background: rgba(255,159,10,.08); }
 .app-hq-impact-card.tone-ok { border-color: rgba(52,199,89,.45); background: rgba(52,199,89,.08); }
+.app-hq-pulse-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+.app-hq-pulse-card { border: 1px solid var(--hairline); border-radius: 10px; padding: 10px; background: color-mix(in srgb, var(--surface) 95%, black 5%); display: grid; gap: 8px; min-width: 0; }
+.app-hq-pulse-card.tone-danger { border-color: rgba(255,69,58,.45); background: rgba(255,69,58,.08); }
+.app-hq-pulse-card.tone-warning { border-color: rgba(255,159,10,.45); background: rgba(255,159,10,.08); }
+.app-hq-pulse-card.tone-ok { border-color: rgba(52,199,89,.45); background: rgba(52,199,89,.08); }
+.app-hq-pulse-card.tone-info { border-color: rgba(var(--accent-rgb), .38); background: rgba(var(--accent-rgb), .07); }
+.app-hq-pulse-card__head { display: flex; align-items: center; justify-content: space-between; gap: 8px; min-width: 0; }
+.app-hq-pulse-card__head span { color: #8B9BB0; font-size: 11px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.app-hq-pulse-card strong { color: #E6EDF3; font-size: 13px; line-height: 1.25; }
+.app-hq-pulse-card p { margin: 0; color: #c9d8ed; font-size: 12px; line-height: 1.35; }
+.app-hq-pulse-card .btn { justify-self: start; min-height: 34px; }
 .app-moment-list { margin-top: var(--space-2); display: grid; gap: var(--space-1); }
 .app-moment-list p { margin: 0; font-size: var(--text-xs); color: var(--text-muted); }
 .app-prep-checklist { display: grid; gap: var(--space-2); margin-top: var(--space-2); }
@@ -627,6 +638,8 @@
   .app-hq-bottom-nav { gap: 6px; }
   .app-action-grid-2x2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .app-summary-grid { grid-template-columns: 1fr; }
+  .app-hq-pulse-grid { grid-template-columns: 1fr; }
+  .app-hq-pulse-card .btn { width: 100%; }
   .app-hq-impact-card__head { align-items: flex-start; flex-direction: column; }
   .app-hq-impact-card__cta { width: 100%; }
   .app-hq-hero-subcards { grid-template-columns: 1fr; }

--- a/src/ui/utils/leagueBootstrap.js
+++ b/src/ui/utils/leagueBootstrap.js
@@ -1,10 +1,10 @@
 /**
  * leagueBootstrap.js
  *
- * Authoritative readiness gates for league initialization.
+ * Authoritative UI readiness gates for league initialization.
  * Prevents race conditions during new franchise creation.
  */
-import { getPlayableLeagueValidation, isPlayableLeagueState } from '../../state/leagueInit.ts';
+import { getBootViewStateValidation, isBootViewStateReady } from '../../state/leagueInit.ts';
 
 export const NEW_SLOT_BOOTSTRAP_PHASES = {
   IDLE: 'idle',
@@ -14,19 +14,23 @@ export const NEW_SLOT_BOOTSTRAP_PHASES = {
 };
 
 /**
- * Returns true only if the league object has all critical fields
- * required to render the dashboard and simulate games.
+ * Returns true once the worker view-state has the critical fields
+ * required to leave the bootstrap overlay and render Franchise HQ.
+ *
+ * This intentionally does not validate the full simulation league blob.
+ * React state stores buildViewState() output, while the worker validates
+ * full league objects before persisting them.
  */
 
 export function hasMinimumPlayableLeague(league) {
-  return isPlayableLeagueState(league);
+  return isBootViewStateReady(league);
 }
 
 /**
  * Diagnostic helper to see exactly why a league isn't ready.
  */
 export function summarizeBootstrapState(league) {
-  const validation = getPlayableLeagueValidation(league);
+  const validation = getBootViewStateValidation(league);
   const reasons = validation.valid ? [] : validation.reasons;
 
   return {
@@ -106,7 +110,8 @@ export function shouldFinalizeNewSlotBootstrap({ pendingNewSlot, bootstrapPhase,
 /**
  * Gates the main dashboard view during new franchise creation.
  */
-export function shouldShowNewFranchiseBootstrapGate({ league, pendingNewSlot, initFlowMode }) {
+export function shouldShowNewFranchiseBootstrapGate({ league, pendingNewSlot, initFlowMode, initFlowActive = false }) {
   if (initFlowMode !== 'new' || !pendingNewSlot) return false;
+  if (!initFlowActive) return false;
   return !hasMinimumPlayableLeague(league);
 }

--- a/src/ui/utils/leagueBootstrap.test.js
+++ b/src/ui/utils/leagueBootstrap.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import {
+  getBootViewStateValidation,
+  getPlayableLeagueValidation,
+  isPlayableLeagueState,
+} from '../../state/leagueInit.ts';
+import {
   canPersistActiveSlot,
   hasMinimumPlayableLeague,
   NEW_SLOT_BOOTSTRAP_PHASES,
@@ -9,6 +14,7 @@ import {
   shouldStartNewSlotInitialSave,
   summarizeBootstrapState,
 } from './leagueBootstrap.js';
+import { buildDefaultLeague } from '../../data/defaultLeague.ts';
 
 const playableLeague = {
   activeLeagueId: 'save_slot_1',
@@ -20,7 +26,23 @@ const playableLeague = {
   schedule: { weeks: [{ week: 1, games: [{ home: 4, away: 2, played: false }] }] },
 };
 
+const bootViewState = {
+  activeLeagueId: 'save_slot_1',
+  phase: 'regular',
+  year: 2026,
+  week: 1,
+  userTeamId: 4,
+  teams: [{ id: 4, name: 'Phoenix' }, { id: 2, name: 'Vegas' }],
+};
+
 describe('league bootstrap guards', () => {
+  it('separates UI boot-view readiness from full simulation readiness', () => {
+    expect(getBootViewStateValidation(bootViewState).valid).toBe(true);
+    expect(hasMinimumPlayableLeague(bootViewState)).toBe(true);
+    expect(getPlayableLeagueValidation(bootViewState).valid).toBe(false);
+    expect(isPlayableLeagueState(bootViewState)).toBe(false);
+  });
+
   it('accepts minimal playable league payload', () => {
     expect(hasMinimumPlayableLeague(playableLeague)).toBe(true);
   });
@@ -36,16 +58,45 @@ describe('league bootstrap guards', () => {
     expect(summary.reasons.length).toBeGreaterThan(0);
   });
 
+  it('boot-view validator fails missing user team and phase/week fields', () => {
+    expect(getBootViewStateValidation({ ...bootViewState, userTeamId: 99 }).reasons).toContain('User team missing');
+    expect(getBootViewStateValidation({ ...bootViewState, phase: '' }).reasons).toContain('Missing phase');
+    expect(getBootViewStateValidation({ ...bootViewState, week: undefined }).reasons).toContain('Missing week number');
+  });
+
+  it('full sim validator passes upgraded default league and fails missing sim data', () => {
+    const fallbackLeague = buildDefaultLeague();
+    expect(getPlayableLeagueValidation(fallbackLeague).valid).toBe(true);
+    expect(isPlayableLeagueState(fallbackLeague)).toBe(true);
+    expect(getPlayableLeagueValidation({ ...fallbackLeague, schedule: { weeks: [] } }).reasons).toContain('Schedule missing');
+    expect(getPlayableLeagueValidation({
+      ...fallbackLeague,
+      teams: fallbackLeague.teams.map(({ roster, ...team }) => team),
+    }).reasons).toContain('No roster/player data');
+    expect(getPlayableLeagueValidation({
+      ...fallbackLeague,
+      schedule: { weeks: [{ week: 1, games: [] }] },
+    }).reasons).toContain('No games available');
+  });
+
   it('new-franchise bootstrap gate clears once league is playable', () => {
     expect(shouldShowNewFranchiseBootstrapGate({
       league: null,
       pendingNewSlot: 'save_slot_1',
       initFlowMode: 'new',
+      initFlowActive: false,
+    })).toBe(false);
+    expect(shouldShowNewFranchiseBootstrapGate({
+      league: null,
+      pendingNewSlot: 'save_slot_1',
+      initFlowMode: 'new',
+      initFlowActive: true,
     })).toBe(true);
     expect(shouldShowNewFranchiseBootstrapGate({
       league: playableLeague,
       pendingNewSlot: 'save_slot_1',
       initFlowMode: 'new',
+      initFlowActive: true,
     })).toBe(false);
   });
 
@@ -53,6 +104,7 @@ describe('league bootstrap guards', () => {
     expect(shouldFinalizeNewSlotBootstrap({ pendingNewSlot: null, league: playableLeague })).toBe(false);
     expect(shouldFinalizeNewSlotBootstrap({ pendingNewSlot: 'save_slot_1', league: { teams: [] } })).toBe(false);
     expect(shouldFinalizeNewSlotBootstrap({ pendingNewSlot: 'save_slot_1', league: playableLeague })).toBe(true);
+    expect(shouldFinalizeNewSlotBootstrap({ pendingNewSlot: 'save_slot_1', league: bootViewState })).toBe(true);
   });
 
   it('does not request the first new-save write before a league is minimally playable', () => {

--- a/src/worker/protocol.js
+++ b/src/worker/protocol.js
@@ -22,6 +22,7 @@ export const toWorker = Object.freeze({
   /** Bootstrap: load an existing save or create a fresh league */
   INIT:               'INIT',
   NEW_LEAGUE:         'NEW_LEAGUE',
+  USE_SAFE_STARTER_LEAGUE: 'USE_SAFE_STARTER_LEAGUE',
   RELOCATE_TEAM:      'RELOCATE_TEAM',
 
   /** Regular-season flow */

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -145,7 +145,7 @@ import { validateCustomRoster, validateDraftClass, validateLeagueFile, validateL
 import { buildDraftOrder } from './modding/ruleEngine.js';
 import { simulationManager } from './WorkerPool.ts';
 import { buildDefaultLeague } from '../data/defaultLeague.ts';
-import { isPlayableLeagueState } from '../state/leagueInit.ts';
+import { getPlayableLeagueValidation, isPlayableLeagueState } from '../state/leagueInit.ts';
 import {
   aggregateTeamUnitsFromRoster,
   buildDeterministicSeed,
@@ -771,6 +771,7 @@ function buildViewState() {
   }
 
   return {
+    activeLeagueId: getActiveLeagueId() ?? meta?.activeLeagueId ?? null,
     seasonId:   meta?.currentSeasonId,
     year:       meta?.year,
     week:       meta?.currentWeek ?? 1,
@@ -1313,7 +1314,8 @@ function hydrateAllPlayersForDevelopment() {
 // allowed to run before a save is explicitly loaded (via LOAD_SAVE or NEW_LEAGUE),
 // it would write an empty state to IndexedDB, wiping the player's save.
 //
-// _saveIsExplicitlyLoaded is ONLY set to true by handleLoadSave / handleNewLeague.
+// _saveIsExplicitlyLoaded is ONLY set to true by handleLoadSave / handleNewLeague
+// / handleUseSafeStarterLeague.
 // Every other path that might call flushDirty() is therefore safely blocked.
 let _saveIsExplicitlyLoaded = false;
 
@@ -2034,6 +2036,10 @@ function slimifySchedule(schedule, teams) {
     weeks: schedule.weeks.map(week => ({
       week:  week.week,
       games: (week.games ?? []).map(g => ({
+        id:     g.id ?? g.gameId,
+        gameId: g.gameId ?? g.id,
+        seasonId: g.seasonId,
+        week:   g.week ?? week.week,
         home:   (typeof g.home === 'object') ? g.home.id : g.home,
         away:   (typeof g.away === 'object') ? g.away.id : g.away,
         played: g.played ?? false,
@@ -2049,12 +2055,166 @@ function expandSchedule(slimSchedule) {
     weeks: slimSchedule.weeks.map(week => ({
       week:  week.week,
       games: (week.games ?? []).map(g => ({
+        id: g.id ?? g.gameId,
+        gameId: g.gameId ?? g.id,
+        seasonId: g.seasonId,
+        week: g.week ?? week.week,
         home: cache.getTeam(g.home),
         away: cache.getTeam(g.away),
         played: g.played ?? false,
       })).filter(g => g.home && g.away),
     })),
   };
+}
+
+async function handleUseSafeStarterLeague(payload, id) {
+  const bootRequestId = payload?.options?.bootRequestId ?? null;
+  const slotKey = payload?.slotKey ?? null;
+  if (!isValidSlotKey(slotKey)) {
+    post(toUI.ERROR, { message: 'Invalid slot key', bootRequestId }, id);
+    return;
+  }
+
+  try {
+    const safeLeague = buildDefaultLeague({
+      userTeamId: payload?.options?.userTeamId,
+      name: payload?.options?.name ?? `Safe Starter ${slotKey?.split('_')?.[2] ?? '1'}`,
+      year: payload?.options?.year,
+    });
+    const validation = getPlayableLeagueValidation(safeLeague);
+    if (!validation.valid) {
+      throw new Error(`Safe starter failed validation: ${validation.reasons?.[0] ?? 'unknown error'}`);
+    }
+
+    configureActiveLeague(slotKey);
+    await clearAllData();
+    cache.reset();
+
+    const year = Number(safeLeague.year ?? 2026);
+    const season = Number(safeLeague.season ?? 1);
+    const seasonId = safeLeague.seasonId ?? safeLeague.currentSeasonId ?? `s${season}`;
+    const userTeamId = Number.isFinite(Number(safeLeague.userTeamId)) ? Number(safeLeague.userTeamId) : 0;
+    const salaryCap = Number(payload?.options?.salaryCap ?? 301.2);
+    const economy = normalizeLeagueEconomy({
+      ...DEFAULT_LEAGUE_ECONOMY,
+      baseSalaryCap: salaryCap,
+      currentSalaryCap: salaryCap,
+    }, { year });
+    const settings = normalizeLeagueSettings({
+      ...DEFAULT_LEAGUE_SETTINGS,
+      salaryCap: economy.currentSalaryCap,
+      leagueName: safeLeague.name,
+    });
+
+    const meta = ensureLeagueMemoryMeta({
+      id: 'league',
+      name: String(safeLeague.name ?? `Safe Starter ${slotKey?.split('_')?.[2] ?? '1'}`).slice(0, 80),
+      userTeamId,
+      currentSeasonId: seasonId,
+      currentWeek: Number(safeLeague.week ?? 1),
+      year,
+      season,
+      phase: safeLeague.phase ?? 'regular',
+      difficulty: payload?.options?.difficulty ?? 'Normal',
+      settings,
+      economy,
+      commissionerMode: false,
+      commissionerEverEnabled: false,
+      commissionerLog: [],
+      newsItems: Array.isArray(safeLeague.newsItems) ? safeLeague.newsItems : [],
+      ownerGoals: Array.isArray(safeLeague.ownerGoals) && safeLeague.ownerGoals.length ? safeLeague.ownerGoals : generateOwnerGoals(),
+      retiredPlayers: Array.isArray(safeLeague.retiredPlayers) ? safeLeague.retiredPlayers : [],
+      records: safeLeague.records ?? {
+        mostPassingYardsSeason: null,
+        mostRushingYardsSeason: null,
+        mostWinsSeason: null,
+        mostChampionships: null,
+        highestOvrPlayer: null,
+      },
+    });
+
+    const teams = safeLeague.teams.map((team) => {
+      const { roster, players, ...teamWithoutRoster } = team;
+      const rosterRows = Array.isArray(roster) ? roster : Array.isArray(players) ? players : [];
+      const normalizedStaff = ensureTeamStaff(teamWithoutRoster, { year });
+      return {
+        ...teamWithoutRoster,
+        staff: normalizedStaff,
+        draftBoard: teamWithoutRoster?.draftBoard ?? { ranks: {}, notes: {}, tags: {}, shortlist: [], avoid: [] },
+        rosterIds: rosterRows.map((player) => player.id),
+        rosterCount: rosterRows.length,
+        capTotal: economy.currentSalaryCap,
+        capRoom: economy.currentSalaryCap,
+        capSpace: economy.currentSalaryCap,
+        wins: Number(teamWithoutRoster?.wins ?? 0),
+        losses: Number(teamWithoutRoster?.losses ?? 0),
+        ties: Number(teamWithoutRoster?.ties ?? 0),
+        ptsFor: Number(teamWithoutRoster?.ptsFor ?? 0),
+        ptsAgainst: Number(teamWithoutRoster?.ptsAgainst ?? 0),
+        fanApproval: teamWithoutRoster?.fanApproval ?? 50,
+        franchiseInvestments: normalizeFranchiseInvestments(teamWithoutRoster?.franchiseInvestments),
+        rivalTeamId: teamWithoutRoster?.rivalTeamId ?? null,
+      };
+    });
+
+    const players = [];
+    safeLeague.teams.forEach((team) => {
+      const rosterRows = Array.isArray(team?.roster) ? team.roster : Array.isArray(team?.players) ? team.players : [];
+      rosterRows.forEach((player) => {
+        players.push({ ...player, teamId: team.id });
+      });
+    });
+
+    const draftPicks = [];
+    safeLeague.teams.forEach((team) => {
+      (team.picks ?? []).forEach((pick) => {
+        draftPicks.push({ ...pick, currentOwner: team.id });
+      });
+    });
+
+    cache.hydrate({ meta, teams, players, draftPicks });
+    hydrateAllPlayersForDevelopment();
+    for (const team of cache.getAllTeams()) {
+      recalculateTeamCap(team.id);
+    }
+    cache.setMeta({ schedule: slimifySchedule(safeLeague.schedule, safeLeague.teams) });
+
+    _saveIsExplicitlyLoaded = true;
+    await Meta.save(cache.getMeta());
+    await Promise.all([
+      Teams.saveBulk(cache.getAllTeams()),
+      Players.saveBulk(cache.getAllPlayers()),
+      DraftPicks.saveBulk(cache.getAllDraftPicks()),
+    ]);
+    cache.drainDirty();
+
+    const userTeam = cache.getTeam(userTeamId);
+    const saveEntry = {
+      id: slotKey,
+      name: meta.name,
+      year: meta.year,
+      teamId: userTeamId,
+      teamAbbr: userTeam?.abbr ?? '???',
+      lastPlayed: Date.now(),
+    };
+    await Saves.save(saveEntry);
+    postManifestUpdate(saveEntry);
+
+    post(toUI.NOTIFICATION, {
+      level: 'warn',
+      message: 'Loaded a safe starter league because normal franchise setup did not respond.',
+    });
+    post(toUI.FULL_STATE, { ...buildViewState(), bootRequestId }, id);
+  } catch (err) {
+    console.error('[Worker] USE_SAFE_STARTER_LEAGUE error:', err);
+    post(toUI.ERROR, {
+      code: 'SAFE_STARTER_BOOT_FAILED',
+      stage: 'safe_starter',
+      bootRequestId,
+      message: err?.message ?? 'Failed to load safe starter league.',
+      stack: err?.stack,
+    }, id);
+  }
 }
 
 // ── Playoff bracket builder ────────────────────────────────────────────────────
@@ -9133,6 +9293,7 @@ async function handleMessage(event) {
       case toWorker.RENAME_SAVE:        return await handleRenameSave(payload, id);
       case toWorker.DUPLICATE_SAVE:     return await handleDuplicateSave(payload, id);
       case toWorker.NEW_LEAGUE:         return await handleNewLeague(payload, id);
+      case toWorker.USE_SAFE_STARTER_LEAGUE: return await handleUseSafeStarterLeague(payload, id);
       case toWorker.ADVANCE_WEEK:       return await handleAdvanceWeek(payload, id);
       case toWorker.SIM_TO_WEEK:        return await handleSimToWeek(payload, id);
       case toWorker.SIM_TO_PLAYOFFS:    return await handleSimToWeek({ targetWeek: 18 }, id);

--- a/tests/e2e/fresh_franchise_first_week_smoke.spec.js
+++ b/tests/e2e/fresh_franchise_first_week_smoke.spec.js
@@ -1,6 +1,9 @@
 import { test, expect } from '@playwright/test';
+import { goToTab, launchFranchise } from './helpers/franchise.js';
 
 const SMOKE_TIMEOUT = 90000;
+
+test.setTimeout(120000);
 
 test('fresh franchise first week smoke', async ({ page, context }) => {
   const consoleErrors = [];
@@ -10,17 +13,9 @@ test('fresh franchise first week smoke', async ({ page, context }) => {
   });
 
   await context.clearCookies();
-  await page.goto('/');
-  await page.evaluate(() => {
-    localStorage.clear();
-    sessionStorage.clear();
-  });
-  await page.reload();
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
 
-  const startCta = page.getByTestId('start-new-franchise-cta');
-  await expect(startCta).toBeVisible({ timeout: SMOKE_TIMEOUT });
-  await startCta.click();
-
+  await launchFranchise(page);
   await expect(page.getByTestId('app-bootstrap-loading')).toBeHidden({ timeout: SMOKE_TIMEOUT });
   await expect(page.getByText(/No league state received/i)).toHaveCount(0);
   await expect(page.getByTestId('app-shell-ready')).toBeVisible({ timeout: SMOKE_TIMEOUT });
@@ -29,9 +24,28 @@ test('fresh franchise first week smoke', async ({ page, context }) => {
   await expect(page.getByText(/Week\s+\d+/i).first()).toBeVisible();
   await expect(page.getByText(/\b[A-Z]{2,4}\s*\(\d+-\d+\)/).first()).toBeVisible();
 
+  const closeChangelog = page.getByLabel('Close changelog');
+  if (await closeChangelog.isVisible().catch(() => false)) {
+    await closeChangelog.click();
+  }
+
   const advanceBtn = page.getByTestId('advance-week-cta');
   await expect(advanceBtn).toBeVisible();
+  const startWeek = await page.evaluate(() => window?.state?.league?.week ?? 1);
   await advanceBtn.click();
+  const skipPrompt = page.getByRole('button', { name: /Simulate \(Skip\)/i });
+  await skipPrompt.click({ timeout: 10000 }).catch(() => {});
+  await page.waitForFunction(
+    (baseline) => {
+      const state = window?.state;
+      const week = state?.league?.week ?? baseline;
+      const hasResults = Array.isArray(state?.lastResults) && state.lastResults.length > 0;
+      return !state?.busy && !state?.simulating && (week > baseline || hasResults);
+    },
+    startWeek,
+    { timeout: SMOKE_TIMEOUT },
+  );
+  await goToTab(page, 'weekly-results');
 
   const completedGameLink = page.getByTestId('completed-game-link').first();
   await expect(completedGameLink).toBeVisible({ timeout: SMOKE_TIMEOUT });
@@ -41,6 +55,9 @@ test('fresh franchise first week smoke', async ({ page, context }) => {
   await expect(page.getByTestId('game-book-final-score')).toBeVisible({ timeout: SMOKE_TIMEOUT });
 
   await page.getByTestId('return-to-hq').click();
+  if (!(await page.getByTestId('franchise-hq').isVisible({ timeout: 3000 }).catch(() => false))) {
+    await page.getByRole('button', { name: /^Back to HQ$/i }).click();
+  }
   await expect(page.getByTestId('franchise-hq')).toBeVisible({ timeout: SMOKE_TIMEOUT });
 
   await page.reload();

--- a/tests/e2e/helpers/franchise.js
+++ b/tests/e2e/helpers/franchise.js
@@ -41,15 +41,13 @@ export async function ensureLeagueLoaded(page) {
 
   if (state === 'team_select') {
     await page.locator(`${TEAM_SELECT} .team-card`).first().click();
-    state = await detectBootstrapState(page);
   }
 
-  while (state === 'onboarding_continue') {
+  while (await page.locator(ONBOARDING_CONTINUE).first().isVisible().catch(() => false)) {
     await page.locator(ONBOARDING_CONTINUE).first().click();
-    state = await detectBootstrapState(page);
   }
 
-  if (state === 'start_dynasty') {
+  if (await page.locator(START_DYNASTY).first().isVisible().catch(() => false)) {
     await page.locator(START_DYNASTY).first().click();
   }
 
@@ -71,6 +69,7 @@ export async function goToTab(page, name) {
     schedule: 'league',
     stats: 'league',
     'league-leaders': 'league',
+    'weekly-results': 'league',
     draft: 'transactions',
     transactions: 'transactions',
     'free-agency': 'transactions',

--- a/tests/unit/leagueInit.test.jsx
+++ b/tests/unit/leagueInit.test.jsx
@@ -2,17 +2,52 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { requestPlayableLeagueState, isPlayableLeagueState } from '../../src/state/leagueInit.ts';
+import {
+  getBootViewStateValidation,
+  getPlayableLeagueValidation,
+  requestPlayableLeagueState,
+  isPlayableLeagueState,
+} from '../../src/state/leagueInit.ts';
 import { buildDefaultLeague } from '../../src/data/defaultLeague.ts';
 import SchedulePage from '../../src/ui/components/SchedulePage.jsx';
 
 describe('league initialization', () => {
+  it('boot-view validation accepts worker view state without full sim data', () => {
+    const viewState = {
+      activeLeagueId: 'save_slot_1',
+      phase: 'regular',
+      week: 1,
+      year: 2026,
+      userTeamId: 0,
+      teams: [{ id: 0, abbr: 'BUF' }, { id: 1, abbr: 'MIA' }],
+    };
+    expect(getBootViewStateValidation(viewState).valid).toBe(true);
+    expect(getPlayableLeagueValidation(viewState).valid).toBe(false);
+  });
+
   it('isPlayableLeagueState validates expected shape', () => {
     const league = buildDefaultLeague();
     expect(isPlayableLeagueState(league)).toBe(true);
     expect(isPlayableLeagueState(null)).toBe(false);
     expect(isPlayableLeagueState({ ...league, teams: [] })).toBe(false);
     expect(isPlayableLeagueState({ ...league, schedule: { weeks: [] } })).toBe(false);
+    expect(getPlayableLeagueValidation({
+      ...league,
+      teams: league.teams.map(({ roster, ...team }) => team),
+    }).valid).toBe(false);
+  });
+
+  it('default safe starter league has required football roster positions and scheduled games', () => {
+    const league = buildDefaultLeague({ userTeamId: 3 });
+    const requiredPositions = ['QB', 'RB', 'WR', 'TE', 'OL', 'DL', 'LB', 'CB', 'S', 'K', 'P'];
+    const userTeam = league.teams.find((team) => team.id === 3);
+    expect(userTeam).toBeTruthy();
+    for (const pos of requiredPositions) {
+      expect(userTeam.roster.some((player) => player.pos === pos)).toBe(true);
+    }
+    expect(league.schedule.weeks.length).toBeGreaterThanOrEqual(1);
+    expect(league.schedule.weeks[0].games.every((game) => game.id && game.home != null && game.away != null)).toBe(true);
+    expect(league.schedule.weeks[0].games[0].gameId).toMatch(/^s1_w1_\d+_\d+$/);
   });
 
   it('uses API league when response is valid', async () => {


### PR DESCRIPTION
## Summary
- Split bootstrap validation into strict full-sim league validation and lighter UI boot-view validation, so worker `FULL_STATE` view snapshots can leave the bootstrap gate without requiring the full simulation blob in React state.
- Kept worker `NEW_LEAGUE` strict before persistence, and added a worker-backed `USE_SAFE_STARTER_LEAGUE` path that builds, validates, sets internal league state, saves to the selected slot, and posts the same `FULL_STATE` view shape as normal new-league success.
- Upgraded the safe starter league with realistic positions, stable ids, schedules, stat/history containers, and enough data for Franchise HQ, Advance Week, Weekly Results, Game Book, and reload.
- Added a compact Franchise HQ Season Pulse panel for owner pressure, momentum, roster leverage, and film-room routes to make the first playable loop more engaging.

## Root Cause
The UI bootstrap gate was validating React `state.league` with full simulation requirements. `useWorker` does not store the full league blob in React state; it stores the worker `buildViewState()` snapshot. That snapshot is enough to render Franchise HQ, but it can omit full rosters/schedule internals that only the worker/save layer should validate.

## Validators
- `getPlayableLeagueValidation(fullLeague)` remains the strict worker/full-sim validator for generated, fallback, and persisted league objects.
- `getBootViewStateValidation(viewState)` is the UI bootstrap/render-readiness validator for the `FULL_STATE` view-model shape.
- `hasMinimumPlayableLeague()` and bootstrap diagnostics now use the UI boot-view validator.

## Worker And Safe Starter
- Normal `NEW_LEAGUE` still validates the full league before save and before posting `FULL_STATE`.
- Safe Starter now commits through the worker and persistence path instead of only hydrating React state or storing a window placeholder.
- Boot request scoping is invalidated so stale failed-boot responses cannot overwrite the safe starter path.

## GitHub / Product Review Notes
Open issues are empty. The open PR list is mostly stale polish/regression/security work, including UI polish/tension PRs and the Dependabot PostCSS bump. This PR keeps scope tight: first make the first-session franchise loop reliable, then add one concrete HQ feedback panel that helps the game feel more alive without adding feature depth.

## Tests
- `npm.cmd run test:unit -- src/ui/components/__tests__/FranchiseHQ.test.jsx`
- `npm.cmd run test:unit -- src/ui/utils/leagueBootstrap.test.js tests/unit/leagueInit.test.jsx src/ui/hooks/useWorker.test.js src/ui/components/__tests__/FranchiseHQ.test.jsx`
- `npm.cmd run build`
- `npm.cmd run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js`

## Manual QA
- Deploy preview URL: pending Netlify preview for this PR.
- Manual deploy-preview QA not yet completed, so this PR does not claim live first-session verification yet.
- Local Playwright smoke passed: fresh Start New Franchise, Franchise HQ, Advance Week, completed game link/Game Book, return flow, and reload persistence.