### PR TITLE
Verify first-session franchise smoke path and add CI Playwright smoke job

### DIFF
--- a/.github/workflows/netlify-parity.yml
+++ b/.github/workflows/netlify-parity.yml
@@ -22,3 +22,24 @@ jobs:
 
       - name: Verify deploy parity checks
         run: npm run check:deploy
+
+  first-session-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node 22 (Netlify parity)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run fresh franchise first-week smoke
+        run: npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig } from '@playwright/test';
 
+const chromiumChannel = process.env.PLAYWRIGHT_CHROMIUM_CHANNEL || undefined;
+const mobileViewport = process.env.PLAYWRIGHT_VIEWPORT === 'iphone'
+  ? { viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true }
+  : {};
+
 export default defineConfig({
   testDir: 'tests/e2e',
   testMatch: '**/*.spec.js',
@@ -8,6 +13,8 @@ export default defineConfig({
   use: {
     baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:4173',
     trace: 'on-first-retry',
+    ...(chromiumChannel ? { channel: chromiumChannel } : {}),
+    ...mobileViewport,
   },
   webServer: {
     command: 'npm run build && npm run preview -- --host 127.0.0.1 --port 4173',

--- a/src/ui/components/LiveGame.jsx
+++ b/src/ui/components/LiveGame.jsx
@@ -238,6 +238,7 @@ function MatchupCard({ event, userTeamId, pending, onOpenBoxScore }) {
         cursor: interactive ? "pointer" : "default",
       }}
       {...interactiveProps}
+      {...(interactive ? { "data-testid": "completed-game-link" } : {})}
     >
       {/* Away team */}
       <TeamBadge abbr={awayAbbr} size={32} isUser={Number(awayId) === numericUserTeamId} />

--- a/tests/e2e/helpers/franchise.js
+++ b/tests/e2e/helpers/franchise.js
@@ -82,7 +82,17 @@ export async function goToTab(page, name) {
       await primaryLocator.click();
     }
   }
-  await page.locator(`[data-testid="section-tab-${tab}"]`).first().click();
+  const sectionTab = page.locator(`[data-testid="section-tab-${tab}"]`).first();
+  if (await sectionTab.isVisible().catch(() => false)) {
+    await sectionTab.click();
+    return;
+  }
+
+  if (tab === 'weekly-results' && await page.getByTestId('completed-game-link').first().isVisible().catch(() => false)) {
+    return;
+  }
+
+  await sectionTab.click();
 }
 
 export async function simulateSingleWeek(page) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,13 +4,17 @@ import tailwindcss from '@tailwindcss/vite';
 import { fileURLToPath, URL } from 'node:url';
 import { readFileSync } from 'node:fs';
 
+function getDeployRef() {
+  return process.env.VITE_GIT_SHA || process.env.COMMIT_REF || process.env.VERCEL_GIT_COMMIT_SHA || process.env.GITHUB_SHA || 'local';
+}
+
 function injectSwVersion() {
   return {
     name: 'inject-sw-version',
     apply: 'build',
     generateBundle(_, bundle) {
       const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
-      const deployRef = process.env.COMMIT_REF || process.env.VERCEL_GIT_COMMIT_SHA || process.env.GITHUB_SHA || Date.now().toString();
+      const deployRef = getDeployRef();
       const cacheVersion = `fgm-${pkg.version}-${String(deployRef).slice(0, 12)}`;
 
       const swAsset = Object.values(bundle).find(
@@ -28,6 +32,10 @@ export default defineConfig({
     tailwindcss(),
     react(),
   ],
+  define: {
+    'import.meta.env.VITE_BUILD_TIME': JSON.stringify(process.env.VITE_BUILD_TIME || new Date().toISOString()),
+    'import.meta.env.VITE_GIT_SHA': JSON.stringify(getDeployRef()),
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src/ui', import.meta.url)),


### PR DESCRIPTION
### Motivation
- Prove and harden the fresh first-session playability path (Start New Franchise → Franchise HQ → Advance Week → Game Book → reload) on deploy and mobile, and capture regressions in CI. 
- Prevent users getting stuck on the bootstrap spinner or stale service-worker caches by making build marker and SW cache-versioning deterministic. 
- Make the smallest, targeted changes needed to let automated mobile smoke tests (and manual QA) open completed game box scores reliably. 

### Description
- Add a CI smoke job in `.github/workflows/netlify-parity.yml` named `first-session-smoke` that installs Playwright Chromium and runs the fresh-franchise first-week smoke test. 
- Add Playwright runtime toggles in `playwright.config.ts` for `PLAYWRIGHT_CHROMIUM_CHANNEL` (Chrome-channel fallback) and `PLAYWRIGHT_VIEWPORT=iphone` (mobile/touch viewport) to allow desktop and iPhone-sized local smoke runs. 
- Make scoreboard matchup cards testable by automation by exposing `data-testid="completed-game-link"` on interactive cards in `src/ui/components/LiveGame.jsx`. 
- Harden the e2e navigation helper `tests/e2e/helpers/franchise.js` so tests work when Weekly Results content is already visible (responsive/mobile layouts). 
- Make build marker and SW cache versioning robust in `vite.config.js` by deriving `VITE_GIT_SHA` / `VITE_BUILD_TIME` from CI/Netlify/GitHub env vars with a timestamp fallback. 

### Testing
- Git cleanup and PR status: ran `git fetch origin && git checkout main && git pull origin main && git status` and verified `git branch --contains 46f24058fdffcc70adb927ed205618a64c6fdcbc` shows the commit is already in `main`, and attempting to close/comment PR #1355 with `gh` failed here because `gh` is not installed. 
- Local build and unit tests: ran `npm install`, `npm run build`, and `npm run test:unit -- src/ui/utils/leagueBootstrap.test.js tests/unit/leagueInit.test.jsx src/ui/hooks/useWorker.test.js src/ui/components/__tests__/FranchiseHQ.test.jsx` and they passed (4 files, 26 tests). 
- Playwright e2e (local): initial `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` failed because Playwright browsers were missing and `npx playwright install` hit CDN `403 Domain forbidden`, then `npx playwright install chrome` (system Chrome fallback) succeeded; afterwards `PLAYWRIGHT_CHROMIUM_CHANNEL=chrome npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` passed and `PLAYWRIGHT_CHROMIUM_CHANNEL=chrome PLAYWRIGHT_VIEWPORT=iphone npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` also passed after the mobile/testability fixes. 
- Deploy / production smoke: attempted `PLAYWRIGHT_CHROMIUM_CHANNEL=chrome PLAYWRIGHT_BASE_URL=https://footballgmsim.netlify.app npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` and `curl -I https://footballgmsim.netlify.app/` but both were blocked by the environment with `net::ERR_TUNNEL_CONNECTION_FAILED` / proxy `403 Forbidden`, so deploy-preview and production live smoke remain to be run from a normal network/browser after this PR is merged and Netlify preview is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb6ed22df0832dad34cbb439dc5b17)