### PR TITLE
Handle HQ “Review Game Book” routing (accept Game Book:<id> intents)

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -7,6 +7,7 @@ import { buildWeeklyCommandHub } from '../utils/weeklyCommandHub.js';
 import { EmptyState, StatusChip, ActionTile, SectionCard, WeeklyAgenda, CompactNewsCard } from './ScreenSystem.jsx';
 import { getLastGameDisplay, getLatestUserCompletedGame, getNextOpponentDisplay } from '../utils/hqGameDisplay.js';
 import { HQIcon, TeamIdentityBadge } from './HQVisuals.jsx';
+import { buildGameBookDestination } from '../utils/managementScreenRouting.js';
 
 const BOTTOM_NAV_ITEMS = [
   { label: 'Home', route: 'HQ', icon: 'home', active: true },
@@ -188,7 +189,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
       momentumLabel: command.momentum?.label ?? 'No trend yet',
       filmLabel: lastGame ? lastGameDisplay.heroLine : 'Kickoff ahead',
       filmDetail: lastGame ? 'Open the latest final before changing next week.' : 'Scout the opponent and lock a plan before kickoff.',
-      filmRoute: gameId ? `Game Book:${gameId}` : 'Weekly Prep',
+      filmRoute: gameId ? buildGameBookDestination(gameId) : 'Weekly Prep',
       filmCta: gameId ? 'Open Game Book' : 'Open Weekly Prep',
       rosterNeed: hqTeamBuilder.biggestNeed ?? 'No urgent need',
       rosterDetail: hqTeamBuilder.nextAction ?? 'Review team builder for leverage.',

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -81,7 +81,7 @@ import {
   safeRound,
 } from "../utils/numberFormatting.js";
 import { deriveFranchisePressure } from "../utils/pressureModel.js";
-import { normalizeManagementDestination } from "../utils/managementScreenRouting.js";
+import { normalizeManagementDestination, parseGameBookDestination } from "../utils/managementScreenRouting.js";
 import { safeGetLeagueState, getSafePhaseContext, getSafeStandingsRows } from "../../state/selectors.js";
 import {
   SHELL_SECTIONS,
@@ -821,6 +821,12 @@ export default function LeagueDashboard({
               <FranchiseHQ
                 league={safeLeague}
                 onNavigate={(tab) => {
+                  const gameBookRoute = parseGameBookDestination(tab);
+                  if (gameBookRoute) {
+                    openGameDetail(gameBookRoute.gameId, "HQ");
+                    return;
+                  }
+
                   const destination = normalizeManagementDestination(tab);
                   if (destination.tradeView) {
                     setTradeInitialView(destination.tradeView);

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import FranchiseHQ from '../FranchiseHQ.jsx';
+import LeagueDashboard from '../LeagueDashboard.jsx';
+import { normalizeManagementDestination, parseGameBookDestination } from '../../utils/managementScreenRouting.js';
 
 const baseLeague = {
   year: 2026,
@@ -33,9 +35,12 @@ const baseLeague = {
   ],
   schedule: {
     weeks: [
-      { week: 9, games: [{ id: 'g-9', home: { id: 11, abbr: 'DET' }, away: { id: 10, abbr: 'CHI' }, homeScore: 20, awayScore: 23, played: true }] },
+      { week: 9, games: [{ id: 'g-9', home: { id: 11, abbr: 'DET' }, away: { id: 10, abbr: 'CHI' }, homeId: 11, awayId: 10, homeAbbr: 'DET', awayAbbr: 'CHI', homeScore: 20, awayScore: 23, played: true }] },
       { week: 10, games: [{ id: 'g-10', home: { id: 10, abbr: 'CHI' }, away: { id: 11, abbr: 'DET' }, played: false }] },
     ],
+  },
+  gameById: {
+    'g-9': { id: 'g-9', home: 11, away: 10, homeId: 11, awayId: 10, week: 9, played: true, homeScore: 20, awayScore: 23 },
   },
   incomingTradeOffers: [],
   newsItems: [{ id: 'n1', teamId: 10, headline: 'Starter upgraded to probable status.' }],
@@ -94,6 +99,38 @@ describe('FranchiseHQ', () => {
     fireEvent.click(button);
     expect(onNavigate).toHaveBeenCalled();
   });
+
+  it('renders Review Game Book as the postgame next action and emits a Game Book route', () => {
+    const onNavigate = vi.fn();
+    render(<FranchiseHQ league={baseLeague} onNavigate={onNavigate} onAdvanceWeek={() => {}} busy={false} simulating={false} />);
+
+    const nextAction = within(screen.getByTestId('hq-next-action'));
+    expect(nextAction.getAllByText('Review Game Book').length).toBeGreaterThan(0);
+    fireEvent.click(nextAction.getByRole('button', { name: /review game book/i }));
+
+    expect(onNavigate).toHaveBeenCalledWith('Game Book:g-9');
+  });
+
+  it('parses Game Book route intents before tab normalization can reject them', () => {
+    expect(parseGameBookDestination('Game Book:g-9')).toEqual({ type: 'gameBook', gameId: 'g-9' });
+    expect(parseGameBookDestination({ type: 'gameBook', gameId: 'g-9' })).toEqual({ type: 'gameBook', gameId: 'g-9' });
+    expect(normalizeManagementDestination('Game Book:g-9').tab).toBe('Game Book');
+  });
+
+  it('opens Game Detail from the HQ Review Game Book next action and returns to Franchise HQ', async () => {
+    window.matchMedia = window.matchMedia ?? (() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }));
+    render(<LeagueDashboard league={baseLeague} actions={{ getDashboardLeaders: vi.fn(() => Promise.resolve({ league: {}, team: {} })) }} busy={false} simulating={false} onAdvanceWeek={() => {}} />);
+
+    const nextAction = within(screen.getByTestId('hq-next-action'));
+    fireEvent.click(nextAction.getByRole('button', { name: /review game book/i }));
+
+    expect(await screen.findByTestId('game-book')).toBeTruthy();
+    expect(screen.getByTestId('game-book-final-score').textContent).toContain('CHI 23 - 20 DET');
+
+    fireEvent.click(screen.getByTestId('return-to-hq'));
+    expect(await screen.findByTestId('franchise-hq')).toBeTruthy();
+  });
+
   it('renders record, standing, and fallback copy when schedule is missing', () => {
     render(
       <FranchiseHQ

--- a/src/ui/utils/franchiseCommandCenter.js
+++ b/src/ui/utils/franchiseCommandCenter.js
@@ -22,8 +22,8 @@ function getScoreDiffs(teamId, scheduleWeeks = []) {
   for (const week of [...scheduleWeeks].sort((a, b) => safeNum(a?.week) - safeNum(b?.week))) {
     for (const game of week?.games ?? []) {
       if (!game?.played) continue;
-      const homeId = Number(game?.home?.id ?? game?.home);
-      const awayId = Number(game?.away?.id ?? game?.away);
+      const homeId = Number(game?.homeId ?? game?.home?.id ?? game?.home);
+      const awayId = Number(game?.awayId ?? game?.away?.id ?? game?.away);
       if (homeId !== Number(teamId) && awayId !== Number(teamId)) continue;
       const homeScore = safeNum(game?.homeScore ?? game?.score?.home);
       const awayScore = safeNum(game?.awayScore ?? game?.score?.away);
@@ -158,8 +158,8 @@ function getPrevGame(league) {
     const games = [...(week?.games ?? [])].reverse();
     for (const game of games) {
       if (!game?.played) continue;
-      const homeId = Number(game?.home?.id ?? game?.home);
-      const awayId = Number(game?.away?.id ?? game?.away);
+      const homeId = Number(game?.homeId ?? game?.home?.id ?? game?.home);
+      const awayId = Number(game?.awayId ?? game?.away?.id ?? game?.away);
       if (homeId !== Number(league?.userTeamId) && awayId !== Number(league?.userTeamId)) continue;
       return { ...game, week: Number(week?.week ?? league?.week ?? 1), homeId, awayId };
     }
@@ -389,6 +389,8 @@ export function selectFranchiseHQViewModel(league) {
   const fallbackLastGame = previousScheduledGame
     ? {
       id: previousScheduledGame?.id,
+      homeId: previousScheduledGame?.homeId,
+      awayId: previousScheduledGame?.awayId,
       homeAbbr: previousScheduledGame?.home?.abbr ?? 'HOME',
       awayAbbr: previousScheduledGame?.away?.abbr ?? 'AWAY',
       score: {

--- a/src/ui/utils/managementScreenRouting.js
+++ b/src/ui/utils/managementScreenRouting.js
@@ -5,6 +5,29 @@ const STAT_FAMILIES = new Set(["passing", "rushing", "receiving", "defense"]);
 const LEAGUE_SECTIONS = new Set(["Overview", "Results", "Standings", "News", "Leaders"]);
 const TEAM_SECTIONS = new Set(["Overview", "Roster / Depth", "Contracts", "Development", "Injuries"]);
 
+
+export function buildGameBookDestination(gameId) {
+  return gameId ? `Game Book:${String(gameId)}` : 'Weekly Results';
+}
+
+export function parseGameBookDestination(destination) {
+  if (!destination) return null;
+  if (typeof destination === "object") {
+    const type = String(destination.type ?? destination.kind ?? "").toLowerCase();
+    const gameId = destination.gameId ?? destination.id ?? null;
+    if ((type === "gamebook" || type === "game-book" || type === "game_book") && gameId != null && String(gameId).trim()) {
+      return { type: "gameBook", gameId: String(gameId).trim() };
+    }
+    return null;
+  }
+  if (typeof destination !== "string") return null;
+  const [route, ...rest] = destination.split(":");
+  if (route.trim().toLowerCase() !== "game book") return null;
+  const gameId = rest.join(":").trim();
+  if (!gameId) return null;
+  return { type: "gameBook", gameId };
+}
+
 export function normalizeManagementDestination(tabToken) {
   const normalized = {
     tab: tabToken,

--- a/src/ui/utils/weeklyDecisionImpact.js
+++ b/src/ui/utils/weeklyDecisionImpact.js
@@ -1,3 +1,5 @@
+import { buildGameBookDestination } from './managementScreenRouting.js';
+
 function safeNum(value, fallback = null) {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : fallback;
@@ -116,7 +118,7 @@ function buildContextTakeaway({ result, userTeam, seasonId, injuryRiskCount }) {
       id: 'game-plan',
       text: 'Game plan was saved before kickoff. Open Game Book to inspect whether your script held up in live drives.',
       route: 'Game Book',
-      targetRoute: result?.gameId ? `Game Book:${result.gameId}` : 'Game Plan',
+      targetRoute: result?.gameId ? buildGameBookDestination(result.gameId) : 'Game Plan',
     });
   }
 
@@ -177,7 +179,7 @@ function chooseRecommendation({ result, contextBullets }) {
   return {
     label: 'Review Game Book',
     reason: 'Review drive detail before making next-week changes.',
-    route: result?.gameId ? `Game Book:${result.gameId}` : 'Weekly Results',
+    route: buildGameBookDestination(result?.gameId),
   };
 }
 

--- a/tests/e2e/fresh_franchise_first_week_smoke.spec.js
+++ b/tests/e2e/fresh_franchise_first_week_smoke.spec.js
@@ -66,6 +66,16 @@ test('fresh franchise first week smoke', async ({ page, context }) => {
   await expect(page.getByTestId('hq-last-result')).toBeVisible({ timeout: SMOKE_TIMEOUT });
   await expect(page.getByTestId('hq-next-action')).toBeVisible({ timeout: SMOKE_TIMEOUT });
 
+  const hqNextAction = page.getByTestId('hq-next-action');
+  const reviewGameBookCta = hqNextAction.getByRole('button', { name: /Review Game Book/i });
+  if (await reviewGameBookCta.isVisible().catch(() => false)) {
+    await reviewGameBookCta.click();
+    await expect(page.getByTestId('game-book')).toBeVisible({ timeout: SMOKE_TIMEOUT });
+    await expect(page.getByTestId('game-book-final-score')).toBeVisible({ timeout: SMOKE_TIMEOUT });
+    await page.getByTestId('return-to-hq').click();
+    await expect(page.getByTestId('franchise-hq')).toBeVisible({ timeout: SMOKE_TIMEOUT });
+  }
+
   await page.reload();
   await expect(page.getByTestId('app-bootstrap-loading')).toBeHidden({ timeout: SMOKE_TIMEOUT });
   await expect(page.getByTestId('app-shell-ready')).toBeVisible({ timeout: SMOKE_TIMEOUT });


### PR DESCRIPTION
### Motivation
- The Franchise HQ Next Action emitted a legacy route like `Game Book:<gameId>` which was treated as a tab token and rejected by the tab-only `normalizeManagementDestination` flow, so the CTA fell back to HQ instead of opening the selected completed game's Game Book.
- The change is narrowly scoped to accept Game Book route intents (string or typed object) and route them to the existing Game Detail path without altering normal tab navigation.
- Preserve backward compatibility for the existing string route form while centralizing build/parse helpers to avoid future mismatch.

### Description
- Added `buildGameBookDestination` and `parseGameBookDestination` helpers in `src/ui/utils/managementScreenRouting.js` to build and parse both legacy `"Game Book:<id>"` strings and typed `{ type: "gameBook", gameId }` intents.
- Updated `LeagueDashboard` to detect Game Book intents via `parseGameBookDestination(tab)` before calling `normalizeManagementDestination`, and to call the existing `openGameDetail(gameId, "HQ")` path to open Game Detail (no tab-only normalization for these intents). (Behavior for normal tabs is unchanged.)
- Switched `FranchiseHQ` and `weeklyDecisionImpact` to use the shared `buildGameBookDestination` helper instead of fragile inline string format, and preserved fallback last-game identity handling in `franchiseCommandCenter` so HQ can resolve completed schedule games as before.
- Added/updated tests: unit/component tests in `src/ui/components/__tests__/FranchiseHQ.test.jsx` to assert the Next Action CTA renders and opens Game Detail, and extended the first-session Playwright smoke `tests/e2e/fresh_franchise_first_week_smoke.spec.js` to optionally exercise the HQ next-action click-through.

### Testing
- Ran `npm install` (completed; npm audit warnings noted). 
- Built the app with `npm run build` (Vite build succeeded; standard large-chunk warning only).
- Unit tests run:
  - `npm run test:unit -- src/ui/components/__tests__/FranchiseHQ.test.jsx src/ui/components/WeeklyResultsCenter.test.jsx src/ui/components/GameDetailScreen.test.jsx` — passed.
  - `npm run test:unit -- src/ui/utils/leagueBootstrap.test.js tests/unit/leagueInit.test.jsx src/ui/hooks/useWorker.test.js` — passed (expected league bootstrap fallback warnings observed).
- Playwright smoke:
  - `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` attempted but failed to run in this environment because Playwright Chromium / Chrome executables are not available; `npx playwright install chromium` also failed due to CDN download `403 Domain forbidden` in this environment.
- Summary: all unit/build checks passed locally; end-to-end browser smoke could not be executed in this environment due to missing Playwright browser binaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb801c66e8832da4af2e6671c0145b)