### PR TITLE
Improve first-loop player profile context

### DIFF
--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -4,6 +4,7 @@ import { buildBoxScoreViewModel } from "../utils/boxScoreViewModel.js";
 import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 import { buildGameBookStory } from "../utils/gameBookStory.js";
 import { getTopPerformers } from "../utils/gameBookHighlights.js";
+import { hasValidPlayerProfileId, openPlayerProfile } from "../utils/playerProfileNavigation.js";
 
 const QUALITY_BADGE_CLASS = {
   "Full detail": "success",
@@ -18,10 +19,10 @@ export function TeamButton({ team, onSelect }) {
   return <button className="btn-link" onClick={() => onSelect(team.id)}>{team.abbr}</button>;
 }
 
-export function PlayerButton({ player, onSelect }) {
+export function PlayerButton({ player, onSelect, context }) {
   if (!player) return <span>—</span>;
-  if (!onSelect || player.playerId == null) return <span>{player.name ?? "Unknown"}</span>;
-  return <button className="btn-link" onClick={() => onSelect(player.playerId)}>{player.name ?? "Unknown"}</button>;
+  if (!onSelect || !hasValidPlayerProfileId(player.playerId)) return <span>{player.name ?? "Unknown"}</span>;
+  return <button type="button" className="btn-link" data-testid="game-book-player-link" onClick={() => openPlayerProfile(player.playerId, onSelect, { ...context, player, statLine: player?.stats })}>{player.name ?? "Unknown"}</button>;
 }
 
 const asNum = (v) => (Number.isFinite(Number(v)) ? Number(v) : null);
@@ -46,6 +47,21 @@ function BoxScore({ gameId, league, actions, onClose, onPlayerSelect, onTeamSele
   }
   const storyBullets = buildGameBookStory(vm);
   const topPerformers = getTopPerformers(vm);
+  const gameContextBase = {
+    source: "game-book",
+    gameId: vm.gameId ?? gameId,
+    week: vm.week,
+    seasonId: vm.season,
+    awayTeam: vm.awayTeam,
+    homeTeam: vm.homeTeam,
+  };
+  const openGameBookPlayer = (player, role) => openPlayerProfile(player?.playerId, onPlayerSelect, {
+    ...gameContextBase,
+    role,
+    player,
+    statLine: player?.stats,
+    returnTo: "game-book",
+  });
   const qHome = vm.quarterScores?.home ?? [];
   const qAway = vm.quarterScores?.away ?? [];
   const qCount = Math.max(qHome.length, qAway.length, 4);
@@ -81,7 +97,7 @@ function BoxScore({ gameId, league, actions, onClose, onPlayerSelect, onTeamSele
     const home = sortPlayers((vm.playerTables?.home ?? []).filter((p) => spec.include(p.stats ?? {})));
     if (!away.length && !home.length) return null;
     const rows = [[vm.awayTeam, away], [vm.homeTeam, home]];
-    return <section key={spec.title} className="bs-section"><h4>{spec.title}</h4><div className="bs-table-wrap"><table className="box-score-table"><thead><tr><th>Team</th><th>Player</th>{spec.cols.map(([key, label]) => <th key={label}><button className="btn-link" onClick={() => setSortState((prev) => ({ ...prev, [spec.title]: { key, dir: prev?.[spec.title]?.key === key && prev?.[spec.title]?.dir === desc ? "asc" : desc } }))}>{label}</button></th>)}</tr></thead><tbody>{rows.map(([team, players]) => players.map((p) => <tr key={`${spec.title}-${team?.id}-${p.playerId}`}><td>{team?.abbr}</td><td><PlayerButton player={p} onSelect={onPlayerSelect} /></td>{spec.cols.map(([key, label]) => <td key={label}>{p.stats?.[key] ?? "—"}</td>)}</tr>))}</tbody></table></div></section>;
+    return <section key={spec.title} className="bs-section"><h4>{spec.title}</h4><div className="bs-table-wrap"><table className="box-score-table"><thead><tr><th>Team</th><th>Player</th>{spec.cols.map(([key, label]) => <th key={label}><button className="btn-link" onClick={() => setSortState((prev) => ({ ...prev, [spec.title]: { key, dir: prev?.[spec.title]?.key === key && prev?.[spec.title]?.dir === desc ? "asc" : desc } }))}>{label}</button></th>)}</tr></thead><tbody>{rows.map(([team, players]) => players.map((p) => <tr key={`${spec.title}-${team?.id}-${p.playerId}`}><td>{team?.abbr}</td><td><PlayerButton player={p} onSelect={onPlayerSelect} context={{ ...gameContextBase, role: spec.title, returnTo: "game-book" }} /></td>{spec.cols.map(([key, label]) => <td key={label}>{p.stats?.[key] ?? "—"}</td>)}</tr>))}</tbody></table></div></section>;
   };
 
   return <div className={embedded ? "card" : "modal-content"}>
@@ -94,7 +110,7 @@ function BoxScore({ gameId, league, actions, onClose, onPlayerSelect, onTeamSele
       {vm.detailWarning ? <p>{vm.detailWarning}</p> : null}
     </section>
     <section className="bs-section" data-testid="game-book-decision-summary"><h4>Why this game was decided</h4>{storyBullets.length ? <ul>{storyBullets.map((b) => <li key={b}>{b}</li>)}</ul> : <p>No detailed team/player stats were recorded for this game.</p>}</section>
-    <section className="bs-section"><h4>Top performers</h4><div className="bs-leaders-grid"><article className="bs-leader-card"><span className="bs-leader-label">Offense</span><p className="bs-leader-name">{topPerformers.offense}</p></article><article className="bs-leader-card"><span className="bs-leader-label">Defense</span><p className="bs-leader-name">{topPerformers.defense}</p></article></div></section>
+    <section className="bs-section"><h4>Top performers</h4><div className="bs-leaders-grid"><article className="bs-leader-card"><span className="bs-leader-label">Offense</span>{topPerformers.offensePlayer && onPlayerSelect ? <button type="button" className="btn-link bs-leader-name" data-testid="game-book-top-performer-link" onClick={() => openGameBookPlayer(topPerformers.offensePlayer, "Top offensive player")}>{topPerformers.offense}</button> : <p className="bs-leader-name">{topPerformers.offense}</p>}</article><article className="bs-leader-card"><span className="bs-leader-label">Defense</span>{topPerformers.defensePlayer && onPlayerSelect ? <button type="button" className="btn-link bs-leader-name" data-testid="game-book-top-performer-link" onClick={() => openGameBookPlayer(topPerformers.defensePlayer, "Top defensive player")}>{topPerformers.defense}</button> : <p className="bs-leader-name">{topPerformers.defense}</p>}</article></div></section>
     <section className="bs-section"><h4>Score by quarter</h4>{hasQuarter ? <div className="bs-table-wrap"><table className="box-score-table"><thead><tr><th>Team</th>{headers.map((h) => <th key={h}>{h}</th>)}<th>Final</th></tr></thead><tbody><tr><td><TeamButton team={vm.awayTeam} onSelect={onTeamSelect} /></td>{headers.map((_, i) => <td key={`a-${i}`}>{qAway[i] ?? "—"}</td>)}<td>{vm.finalScore.away ?? "—"}</td></tr><tr><td><TeamButton team={vm.homeTeam} onSelect={onTeamSelect} /></td>{headers.map((_, i) => <td key={`h-${i}`}>{qHome[i] ?? "—"}</td>)}<td>{vm.finalScore.home ?? "—"}</td></tr></tbody></table></div> : <p>Quarter-by-quarter scoring was not recorded for this game.</p>}</section>
 
     <section className="bs-section"><h4>Team comparison</h4>{teamRows.length ? <div className="bs-table-wrap"><table className="box-score-table"><thead><tr><th>Stat</th><th>{vm.awayTeam.abbr}</th><th>{vm.homeTeam.abbr}</th></tr></thead><tbody>{teamRows.map(([label, a, h]) => <tr key={label}><td>{label}</td><td>{a ?? "—"}</td><td>{h ?? "—"}</td></tr>)}</tbody></table></div> : <p>Team totals were not recorded for this game.</p>}</section>

--- a/src/ui/components/BoxScore.test.jsx
+++ b/src/ui/components/BoxScore.test.jsx
@@ -1,6 +1,8 @@
+/** @vitest-environment jsdom */
 import React from 'react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { renderToString } from 'react-dom/server';
+import { fireEvent, render } from '@testing-library/react';
 import BoxScore, { PlayerButton } from './BoxScore.jsx';
 
 vi.mock('../hooks/useStableRouteRequest.js', () => ({ default: vi.fn(() => ({ data: null })) }));
@@ -34,6 +36,14 @@ describe('BoxScore game book rendering', () => {
     const onSelect = vi.fn();
     const element = PlayerButton({ player: { playerId: 55, name: 'Tester' }, onSelect });
     element.props.onClick();
-    expect(onSelect).toHaveBeenCalledWith(55);
+    expect(onSelect.mock.calls[0][0]).toBe(55);
+  });
+
+  it('top performers trigger player profile selection when ids are present', () => {
+    const onSelect = vi.fn();
+    const game = { gameId: 'g4', week: 2, homeId: 1, awayId: 2, homeScore: 28, awayScore: 17, quarterScores: { home: [7,7,7,7], away: [0,7,3,7] }, teamStats: { home: { passYards: 250 }, away: {} }, playerStats: { home: { 11: { name: 'Home QB', stats: { passAtt: 30, passComp: 20, passYd: 250, passTD: 3 } } }, away: {} } };
+    const { getByTestId } = render(<BoxScore gameId="g4" league={{ ...baseLeague, gameById: { g4: game } }} onPlayerSelect={onSelect} embedded />);
+    fireEvent.click(getByTestId('game-book-top-performer-link'));
+    expect(onSelect.mock.calls[0][0]).toBe(11);
   });
 });

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -857,7 +857,7 @@ export default function LeagueDashboard({
             />
             {league.phase !== "preseason" && (
               <div style={{ marginTop: "var(--space-4)" }}>
-                <StatLeadersWidget onPlayerSelect={setSelectedPlayerId} actions={actions} />
+                <StatLeadersWidget onPlayerSelect={handlePlayerSelect} actions={actions} />
               </div>
             )}
           </TabErrorBoundary>
@@ -887,7 +887,7 @@ export default function LeagueDashboard({
                   playoffSeeds={league.playoffSeeds}
                   onTeamRoster={setSelectedTeamId}
                   league={league}
-                  onPlayerSelect={setSelectedPlayerId}
+                  onPlayerSelect={handlePlayerSelect}
                 />
               )}
             />
@@ -898,7 +898,7 @@ export default function LeagueDashboard({
             <LeagueHub
               league={league}
               actions={actions}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
               onTeamSelect={setSelectedTeamId}
               onNavigateTrade={(teamId = null) => {
                 setTradeInitialView("Finder");
@@ -919,7 +919,7 @@ export default function LeagueDashboard({
                   playoffSeeds={league.playoffSeeds}
                   onTeamRoster={setSelectedTeamId}
                   league={league}
-                  onPlayerSelect={setSelectedPlayerId}
+                  onPlayerSelect={handlePlayerSelect}
                 />
               )}
               renderResults={() => (
@@ -928,6 +928,7 @@ export default function LeagueDashboard({
                   initialWeek={weeklyResultsInitialWeek}
                   onNavigate={setActiveTab}
                   onGameSelect={(gameId) => openGameDetail(gameId, "League")}
+                  onPlayerSelect={handlePlayerSelect}
                 />
               )}
               renderStandings={() => (
@@ -950,7 +951,7 @@ export default function LeagueDashboard({
               mode="full"
               segment={newsSubtab.toLowerCase()}
               onTeamSelect={setSelectedTeamId}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
               onOpenBoxScore={(gameId) => openGameDetail(gameId, "News")}
               onNavigate={setActiveTab}
             />
@@ -987,7 +988,7 @@ export default function LeagueDashboard({
                 setSelectedTeamId(teamId);
               }}
               league={league}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
             />
           </TabErrorBoundary>
         )}
@@ -998,6 +999,7 @@ export default function LeagueDashboard({
               initialWeek={weeklyResultsInitialWeek}
               onNavigate={setActiveTab}
               onGameSelect={(gameId) => openGameDetail(gameId, "Weekly Results")}
+              onPlayerSelect={handlePlayerSelect}
             />
           </TabErrorBoundary>
         )}
@@ -1005,7 +1007,7 @@ export default function LeagueDashboard({
           <TabErrorBoundary label="Stats" onNavigate={setActiveTab}>
             <LeagueStats
               league={league}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
               onTeamSelect={setSelectedTeamId}
             />
           </TabErrorBoundary>
@@ -1013,7 +1015,7 @@ export default function LeagueDashboard({
         {activeTab === "Leaders" && (
           <TabErrorBoundary label="Leaders" onNavigate={setActiveTab}>
             <Leaders
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
               userTeamId={league.userTeamId}
               actions={actions}
               onNavigate={setActiveTab}
@@ -1026,7 +1028,7 @@ export default function LeagueDashboard({
             <LeagueLeaders
               league={league}
               actions={actions}
-              onPlayerSelect={(player) => setSelectedPlayerId(player?.id ?? player)}
+              onPlayerSelect={handlePlayerSelect}
               onNavigate={setActiveTab}
             />
           </TabErrorBoundary>
@@ -1035,7 +1037,7 @@ export default function LeagueDashboard({
           <TabErrorBoundary label="Award Races" onNavigate={setActiveTab}>
             <AwardRaces
               actions={actions}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
             />
           </TabErrorBoundary>
         )}
@@ -1059,7 +1061,7 @@ export default function LeagueDashboard({
             <Roster
               league={league}
               actions={actions}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
               onNavigate={setActiveTab}
               initialState={rosterInitialState}
               initialViewMode={rosterInitialView}
@@ -1071,7 +1073,7 @@ export default function LeagueDashboard({
             <DragAndDropDepthChart
               league={league}
               actions={actions}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
               onNavigate={setActiveTab}
             />
           </TabErrorBoundary>
@@ -1081,7 +1083,7 @@ export default function LeagueDashboard({
             <RosterHub
               league={league}
               actions={actions}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
             />
           </TabErrorBoundary>
         )}
@@ -1101,7 +1103,7 @@ export default function LeagueDashboard({
               league={league}
               actions={actions}
               onNavigate={setActiveTab}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
             />
           </TabErrorBoundary>
         )}
@@ -1120,7 +1122,7 @@ export default function LeagueDashboard({
             <RookieDraft
               league={league}
               actions={actions}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
               onNavigate={setActiveTab}
             />
           </TabErrorBoundary>
@@ -1141,7 +1143,7 @@ export default function LeagueDashboard({
               userTeamId={league.userTeamId}
               league={league}
               actions={actions}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
               onNavigate={setActiveTab}
             />
           </TabErrorBoundary>
@@ -1151,7 +1153,7 @@ export default function LeagueDashboard({
             <TradeWorkspace
               league={league}
               actions={actions}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
               onNavigate={setActiveTab}
               initialView={tradeInitialView}
               initialPartnerTeamId={tradeSeedPartnerId}
@@ -1164,7 +1166,7 @@ export default function LeagueDashboard({
               league={league}
               mode="full"
               onTeamSelect={setSelectedTeamId}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
               onOpenBoxScore={(gameId) => openGameDetail(gameId, "News")}
               onNavigate={setActiveTab}
             />
@@ -1179,7 +1181,7 @@ export default function LeagueDashboard({
               actions={actions}
               onBack={() => setActiveTab("HQ")}
               onNavigate={setActiveTab}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
               onTeamSelect={setSelectedTeamId}
             />
           </TabErrorBoundary>
@@ -1191,7 +1193,7 @@ export default function LeagueDashboard({
         )}
         {activeTab === "History" && (
           <TabErrorBoundary label="History">
-            <History league={league} onNavigatePlayer={setSelectedPlayerId} onNavigateTeam={(teamId) => { setSelectedTeamId?.(teamId); setActiveTab("Team"); }} />
+            <History league={league} onNavigatePlayer={handlePlayerSelect} onNavigateTeam={(teamId) => { setSelectedTeamId?.(teamId); setActiveTab("Team"); }} />
           </TabErrorBoundary>
         )}
         {activeTab === "Team History" && (
@@ -1199,7 +1201,7 @@ export default function LeagueDashboard({
             <TeamHistoryScreen
               league={league}
               actions={actions}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
               onBack={() => setActiveTab("History Hub")}
               teamId={selectedTeamId ?? league?.userTeamId}
               onOpenBoxScore={(gameId) => openGameDetail(gameId, "Team History")}
@@ -1208,12 +1210,12 @@ export default function LeagueDashboard({
         )}
         {activeTab === "Hall of Fame" && (
           <TabErrorBoundary label="Hall of Fame">
-            <HallOfFame onPlayerSelect={setSelectedPlayerId} actions={actions} />
+            <HallOfFame onPlayerSelect={handlePlayerSelect} actions={actions} />
           </TabErrorBoundary>
         )}
         {activeTab === "Awards & Records" && (
           <TabErrorBoundary label="Awards & Records">
-            <AwardsRecordsScreen actions={actions} league={league} onPlayerSelect={setSelectedPlayerId} onBack={() => setActiveTab("History Hub")} />
+            <AwardsRecordsScreen actions={actions} league={league} onPlayerSelect={handlePlayerSelect} onBack={() => setActiveTab("History Hub")} />
           </TabErrorBoundary>
         )}
         {activeTab === "Postseason" && (
@@ -1226,7 +1228,7 @@ export default function LeagueDashboard({
             <TrainingCamp
               league={league}
               actions={actions}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
               onNavigate={setActiveTab}
             />
           </TabErrorBoundary>
@@ -1246,7 +1248,7 @@ export default function LeagueDashboard({
             <MockDraft
               league={league}
               actions={actions}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
             />
           </TabErrorBoundary>
         )}
@@ -1254,7 +1256,7 @@ export default function LeagueDashboard({
           <TabErrorBoundary label="Injuries">
             <InjuryReport
               league={league}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
               onNavigate={setActiveTab}
             />
           </TabErrorBoundary>
@@ -1269,7 +1271,7 @@ export default function LeagueDashboard({
             <AnalyticsHub
               league={league}
               actions={actions}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
               onTeamSelect={setSelectedTeamId}
               onNavigate={setActiveTab}
             />
@@ -1284,7 +1286,7 @@ export default function LeagueDashboard({
           <TabErrorBoundary label="Season Recap">
             <SeasonRecap
               league={league}
-              onPlayerSelect={setSelectedPlayerId}
+              onPlayerSelect={handlePlayerSelect}
               onTeamSelect={setSelectedTeamId}
               onNavigate={setActiveTab}
               onOpenBoxScore={(gameId) => openGameDetail(gameId, "Season Recap")}
@@ -1330,6 +1332,7 @@ export default function LeagueDashboard({
               league={league}
               onNavigate={setActiveTab}
               profileContext={selectedPlayerContext}
+              onOpenBoxScore={(gameId) => openGameDetail(gameId, selectedPlayerContext?.source === 'weekly-results' ? 'Weekly Results' : 'Game Detail')}
             />
           </PlayerProfileModalBoundary>
         </TabErrorBoundary>

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -321,6 +321,49 @@ function AttrRow({ label, value }) {
   );
 }
 
+
+function hasRecordedStats(stats = {}) {
+  return Object.values(stats || {}).some((value) => Number(value) > 0);
+}
+
+function summarizeTrackedStats(stats = {}, position = '') {
+  const pos = String(position || '').toUpperCase();
+  const parts = [];
+  if (Number(stats.passAtt ?? 0) > 0) parts.push(`${stats.passComp ?? 0}/${stats.passAtt ?? 0}, ${stats.passYd ?? 0} pass yds, ${stats.passTD ?? 0} TD, ${stats.interceptions ?? 0} INT`);
+  if (Number(stats.rushAtt ?? 0) > 0) parts.push(`${stats.rushAtt ?? 0} car, ${stats.rushYd ?? 0} rush yds, ${stats.rushTD ?? 0} TD`);
+  if (Number(stats.targets ?? 0) > 0 || Number(stats.receptions ?? 0) > 0) parts.push(`${stats.receptions ?? 0}/${stats.targets ?? 0} rec, ${stats.recYd ?? 0} rec yds, ${stats.recTD ?? 0} TD`);
+  if (Number(stats.tackles ?? 0) > 0 || Number(stats.sacks ?? 0) > 0 || Number(stats.interceptions ?? 0) > 0) parts.push(`${stats.tackles ?? 0} tackles, ${stats.sacks ?? 0} sacks, ${stats.interceptions ?? 0} INT`);
+  if (Number(stats.fieldGoalsAttempted ?? 0) > 0 || Number(stats.extraPointsAttempted ?? 0) > 0) parts.push(`${stats.fieldGoalsMade ?? 0}/${stats.fieldGoalsAttempted ?? 0} FG, ${stats.extraPointsMade ?? 0}/${stats.extraPointsAttempted ?? 0} XP`);
+  if (Number(stats.punts ?? 0) > 0) parts.push(`${stats.punts ?? 0} punts, ${stats.puntYards ?? 0} yards`);
+  if (parts.length) return parts.join(' · ');
+  if (pos === 'QB') return null;
+  return null;
+}
+
+function buildImpactSummary(player, context, statLine) {
+  if (!hasRecordedStats(statLine)) return 'Detailed per-player stats were not recorded for this game.';
+  const name = player?.name ?? 'This player';
+  const line = summarizeTrackedStats(statLine, player?.pos ?? player?.position);
+  if (Number(statLine.passYd ?? 0) > 0) return `${name} mattered this week by driving the passing offense: ${line}.`;
+  if (Number(statLine.rushYd ?? 0) > 0) return `${name} mattered this week by creating rushing production: ${line}.`;
+  if (Number(statLine.recYd ?? 0) > 0 || Number(statLine.receptions ?? 0) > 0) return `${name} mattered this week as a receiving target: ${line}.`;
+  if (Number(statLine.sacks ?? 0) > 0 || Number(statLine.interceptions ?? 0) > 0 || Number(statLine.tackles ?? 0) > 0) return `${name} mattered this week on defense: ${line}.`;
+  return `${name} had a tracked contribution this week: ${line}.`;
+}
+
+function getQuickTags(player) {
+  const tags = [];
+  const age = Number(player?.age);
+  const ovr = Number(player?.ovr);
+  const pot = Number(player?.potential);
+  if (Number.isFinite(age) && age <= 23) tags.push('rookie/developing');
+  if (Number.isFinite(age) && age >= 30) tags.push('veteran');
+  if (Number.isFinite(ovr) && ovr >= 85) tags.push('star');
+  if (Number.isFinite(pot) && Number.isFinite(ovr) && pot >= ovr + 8) tags.push('developing upside');
+  if (player?.depthRank === 1 || player?.starter === true || player?.isStarter === true) tags.push('starter');
+  return tags;
+}
+
 const sectionLabelStyle = {
   margin: "0 0 var(--space-2)",
   fontSize: "var(--text-xs)",
@@ -397,9 +440,10 @@ export default function PlayerProfile({
   useEffect(() => {
     if (fetchedData) setData(fetchedData);
   }, [fetchedData]);
-  const player = data?.player;
+  const fetchedPlayer = data?.player;
   const resolvedProfile = useMemo(() => resolvePlayerForProfile({ playerId, league, context: profileContext ?? {} }), [playerId, league, profileContext]);
-  const effectivePlayer = player ?? resolvedProfile.player;
+  const player = fetchedPlayer ?? resolvedProfile.player;
+  const effectivePlayer = player;
   const playerView = effectivePlayer;
   const playerMissing = !loading && !effectivePlayer;
   const loadErrorMessage = requestError?.message || data?.error || null;
@@ -534,6 +578,12 @@ export default function PlayerProfile({
 
   const profileAnalysis = useMemo(() => buildPlayerProfileAnalysis({ player: effectivePlayer, team: resolvedProfile.team, league, context: profileContext ?? {} }), [effectivePlayer, resolvedProfile.team, league, profileContext]);
   const playerGameLogs = useMemo(() => getPlayerGameLogs(league, effectivePlayer), [league, effectivePlayer]);
+  const contextStatLine = profileContext?.statLine ?? profileContext?.player?.stats ?? null;
+  const hasThisWeekContext = Boolean(profileContext?.source === 'game-book' || profileContext?.source === 'weekly-results' || profileContext?.gameId);
+  const thisWeekLine = contextStatLine && hasRecordedStats(contextStatLine) ? summarizeTrackedStats(contextStatLine, player?.pos ?? player?.position) : null;
+  const thisWeekSummary = hasThisWeekContext ? buildImpactSummary(player, profileContext, contextStatLine) : null;
+  const quickTags = getQuickTags(player);
+  const seasonStatsRecorded = hasRecordedStats(latestTotals);
   const gmContext = profileAnalysis?.recommendationContext ?? {};
   const hasGmContext = Boolean(
     gmContext?.sourceLabel || gmContext?.reason || gmContext?.comparisonReceipt || gmContext?.recommendation || gmContext?.fitScore != null || gmContext?.capImpactLabel || gmContext?.valueLabel
@@ -583,6 +633,7 @@ export default function PlayerProfile({
 
   return (
     <div
+      data-testid="player-profile"
       onClick={onClose}
       style={{
         position: "fixed",
@@ -655,6 +706,7 @@ export default function PlayerProfile({
 
         {/* ── Header ── */}
         <div
+          data-testid="player-profile-summary"
           style={{
             padding: "var(--space-4) var(--space-4)",
             borderBottom: "1px solid var(--hairline)",
@@ -700,10 +752,10 @@ export default function PlayerProfile({
                     marginTop: 4,
                   }}
                 >
-                  {playerView.pos} · Age {playerView.age} ·{" "}
-                  {playerView.status === "active"
+                  {playerView.pos ?? playerView.position ?? "POS —"} · Age {playerView.age ?? "—"} ·{" "}
+                  {playerView.teamId != null
                     ? getTeamName(playerView.teamId, teams)
-                    : "Retired"}
+                    : playerView.status === "retired" ? "Retired" : "Team unavailable"}
                 </div>
 
                 {/* OVR + progression delta + potential */}
@@ -735,7 +787,7 @@ export default function PlayerProfile({
                         {playerView.progressionDelta})
                       </span>
                     )}
-                  {playerView.potential && (
+                  {playerView.potential != null && (
                     <span
                       style={{
                         color: "var(--text-muted)",
@@ -748,6 +800,13 @@ export default function PlayerProfile({
                   )}
                 </div>
 
+
+                <div style={{ marginTop: "var(--space-2)", display: "flex", gap: 6, flexWrap: "wrap", fontSize: "var(--text-xs)" }}>
+                  <span className="status-chip info">Contract: {summaryChips.find((chip) => chip.label === "Contract")?.value ?? "Not available"}</span>
+                  <span className="status-chip muted">Status: {playerView.injuryWeeksRemaining > 0 ? `Out ${playerView.injuryWeeksRemaining}w` : "Available"}</span>
+                  {playerView.draftYear || playerView.draftRound || playerView.draftPick ? <span className="status-chip muted">Draft: {playerView.draftYear ?? "—"} R{playerView.draftRound ?? "—"} P{playerView.draftPick ?? "—"}</span> : null}
+                  {quickTags.map((tag) => <span key={tag} className="status-chip success">{tag}</span>)}
+                </div>
 
                 {playerView.developmentContext && (
                   <div style={{ marginTop: 6, fontSize: 'var(--text-xs)', color: 'var(--text-subtle)' }}>
@@ -883,6 +942,15 @@ export default function PlayerProfile({
 
         {/* ── Body ── */}
         <div style={{ padding: "var(--space-4)", flex: 1, display: "grid", gap: "var(--space-4)" }}>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            {profileContext?.source === 'game-book' || profileContext?.returnTo === 'game-book' ? (
+              <Button size="sm" variant="outline" data-testid="player-profile-return-to-game-book" onClick={() => { if (profileContext?.gameId) onOpenBoxScore?.(profileContext.gameId); onClose?.(); }}>Return to Game Book</Button>
+            ) : null}
+            {profileContext?.source === 'weekly-results' || profileContext?.returnTo === 'weekly-results' ? (
+              <Button size="sm" variant="outline" onClick={() => { onNavigate?.('Weekly Results'); onClose?.(); }}>Return to Weekly Results</Button>
+            ) : null}
+            <Button size="sm" variant="outline" onClick={() => { onNavigate?.('HQ'); onClose?.(); }}>Return to HQ</Button>
+          </div>
           <div className="standings-tabs profile-tab-row" style={{ gap: 6, flexWrap: "nowrap" }}>
             {["Overview", "Career Stats", "Game Log"].map((tab) => (
               <button
@@ -896,6 +964,25 @@ export default function PlayerProfile({
           </div>
           {activeProfileTab === "Overview" && (
             <>
+          {hasThisWeekContext && (
+            <section className="card-enter" data-testid="player-profile-game-impact">
+              <h3 style={sectionLabelStyle}>This Week / Game Impact</h3>
+              <div style={{ fontSize: "var(--text-sm)", fontWeight: 800 }}>{profileContext?.role ?? (profileContext?.source === 'weekly-results' ? 'From Weekly Results' : 'From Game Book')}</div>
+              <div style={{ color: "var(--text-muted)", fontSize: "var(--text-sm)", marginTop: 4 }}>
+                {profileContext?.week ? `From Week ${profileContext.week} ${profileContext?.source === 'game-book' ? 'Game Book' : 'Weekly Results'}` : 'From recent game context'}
+              </div>
+              <p style={{ marginTop: 8 }}>{thisWeekSummary}</p>
+              {thisWeekLine ? <div className="stat-box" style={{ padding: 8 }}>{thisWeekLine}</div> : null}
+            </section>
+          )}
+          <section className="card-enter" data-testid="player-profile-season-stats">
+            <h3 style={sectionLabelStyle}>Season Stats</h3>
+            {seasonStatsRecorded ? (
+              <div className="stat-box" style={{ padding: 8 }}>{summarizeTrackedStats(latestTotals, player?.pos ?? player?.position) ?? 'Tracked season totals are available.'}</div>
+            ) : (
+              <EmptyState icon="📊" title="No tracked season stats yet" subtitle="Season stats will appear after this player records tracked stats." />
+            )}
+          </section>
           {!loading && hasGmContext && (
             <section className="card-enter">
               <h3 style={sectionLabelStyle}>Why this player?</h3>
@@ -1564,10 +1651,10 @@ export default function PlayerProfile({
             </>
           )}
           {activeProfileTab === "Game Log" && (
-            <section className="card-enter">
+            <section className="card-enter" data-testid="player-profile-game-logs">
               <h3 style={sectionLabelStyle}>Game Log</h3>
               {playerGameLogs.length === 0 ? (
-                <EmptyState title="No game logs recorded yet." body="Game logs will appear once this player has archived game stats." />
+                <EmptyState title="No game logs recorded yet." subtitle="Game logs will appear after this player records tracked stats." />
               ) : (
                 <div className="table-wrapper" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
                   <Table className="standings-table" style={{ width: "100%", minWidth: 760 }}>

--- a/src/ui/components/WeeklyResultsCenter.jsx
+++ b/src/ui/components/WeeklyResultsCenter.jsx
@@ -5,6 +5,7 @@ import { buildWeeklyLeagueRecap } from '../utils/weeklyLeagueRecap.js';
 import { buildWeeklyDecisionImpact } from '../utils/weeklyDecisionImpact.js';
 import { buildBoxScoreViewModel } from '../utils/boxScoreViewModel.js';
 import { getTopPerformers } from '../utils/gameBookHighlights.js';
+import { hasValidPlayerProfileId, openPlayerProfile } from '../utils/playerProfileNavigation.js';
 import {
   CompactInsightCard,
   EmptyState,
@@ -53,6 +54,24 @@ function ResultRow({ row, seasonId, onGameSelect, source = 'weekly_results_cente
       </div>
     </article>
   );
+}
+
+
+function TopPerformerCard({ title, performer, player, tone, onPlayerSelect, context }) {
+  if (hasValidPlayerProfileId(player?.playerId) && onPlayerSelect) {
+    return (
+      <button
+        type="button"
+        className="app-compact-insight app-compact-insight--button"
+        data-testid="weekly-results-top-performer-link"
+        onClick={() => openPlayerProfile(player.playerId, onPlayerSelect, { ...context, player, statLine: player?.stats })}
+      >
+        <span>{title}</span>
+        <strong>{performer}</strong>
+      </button>
+    );
+  }
+  return <CompactInsightCard title={title} subtitle={performer} tone={tone} />;
 }
 
 function formatRecord(team) {
@@ -131,7 +150,7 @@ function SpotlightCard({ row, seasonId, onGameSelect }) {
   );
 }
 
-export default function WeeklyResultsCenter({ league, initialWeek, onGameSelect, onNavigate }) {
+export default function WeeklyResultsCenter({ league, initialWeek = null, onGameSelect, onNavigate, onPlayerSelect }) {
   const totalWeeks = Number(league?.schedule?.weeks?.length ?? 0);
   const resolvedWeek = useMemo(() => resolveDefaultResultsWeek(league?.schedule, { initialWeek, currentWeek: league?.week }), [initialWeek, league?.schedule, league?.week]);
   const [selectedWeek, setSelectedWeek] = useState(resolvedWeek);
@@ -241,8 +260,22 @@ export default function WeeklyResultsCenter({ league, initialWeek, onGameSelect,
             </div>
             <p className="app-game-center-card__scoreline">{userTeamResult.recap}</p>
             <div className="app-game-center-performers" aria-label="Top performers">
-              <CompactInsightCard title="Top offensive player" subtitle={topPerformers.offense} tone={topPerformers.hasOffense ? 'ok' : 'info'} />
-              <CompactInsightCard title="Top defensive player" subtitle={topPerformers.defense} tone={topPerformers.hasDefense ? 'ok' : 'info'} />
+              <TopPerformerCard
+                title="Top offensive player"
+                performer={topPerformers.offense}
+                player={topPerformers.offensePlayer}
+                tone={topPerformers.hasOffense ? 'ok' : 'info'}
+                onPlayerSelect={onPlayerSelect}
+                context={{ source: 'weekly-results', gameId: userResultPresentation?.resolvedGameId, week: userTeamResult.week, role: 'Top offensive player', returnTo: 'weekly-results' }}
+              />
+              <TopPerformerCard
+                title="Top defensive player"
+                performer={topPerformers.defense}
+                player={topPerformers.defensePlayer}
+                tone={topPerformers.hasDefense ? 'ok' : 'info'}
+                onPlayerSelect={onPlayerSelect}
+                context={{ source: 'weekly-results', gameId: userResultPresentation?.resolvedGameId, week: userTeamResult.week, role: 'Top defensive player', returnTo: 'weekly-results' }}
+              />
             </div>
             {userTeamResult?.prepImpact?.narrative ? (
               <CompactInsightCard

--- a/src/ui/components/WeeklyResultsCenter.test.jsx
+++ b/src/ui/components/WeeklyResultsCenter.test.jsx
@@ -123,4 +123,27 @@ describe('WeeklyResultsCenter', () => {
     expect(onGameSelect).toHaveBeenCalledTimes(1);
     expect(onGameSelect.mock.calls[0][0]).toMatch(/2026_w2_/);
   });
+  it('opens player profile from weekly top performer when player stats have ids', () => {
+    const onPlayerSelect = vi.fn();
+    const leagueWithStats = {
+      ...league,
+      teams: league.teams.map((team) => team.id === 1 ? { ...team, roster: [{ id: 101, name: 'Dak Test', pos: 'QB', teamId: 1, ovr: 80, potential: 85, contract: { years: 2 } }] } : team),
+      schedule: {
+        weeks: [
+          { week: 2, games: [{
+            gameId: '2026_w2_1_4', home: 1, away: 4, played: true, homeScore: 28, awayScore: 21,
+            quarterScores: { home: [7, 7, 7, 7], away: [7, 7, 0, 7] },
+            teamStats: { home: { passYards: 260 }, away: {} },
+            playerStats: { home: { 101: { name: 'Dak Test', stats: { passAtt: 31, passComp: 21, passYd: 260, passTD: 3 } } }, away: {} },
+          }] },
+        ],
+      },
+    };
+    render(<WeeklyResultsCenter league={leagueWithStats} initialWeek={2} onGameSelect={() => {}} onNavigate={() => {}} onPlayerSelect={onPlayerSelect} />);
+
+    fireEvent.click(screen.getByTestId('weekly-results-top-performer-link'));
+    expect(onPlayerSelect.mock.calls[0][0]).toBe(101);
+    expect(onPlayerSelect.mock.calls[0][1]).toMatchObject({ source: 'weekly-results', gameId: '2026_w2_1_4', week: 2 });
+  });
+
 });

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -1,15 +1,45 @@
+/** @vitest-environment jsdom */
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { renderToString } from 'react-dom/server';
 import PlayerProfile from '../PlayerProfile.jsx';
 
+const player = {
+  id: 11,
+  name: 'Avery Fields',
+  pos: 'QB',
+  age: 24,
+  ovr: 82,
+  potential: 90,
+  teamId: 1,
+  status: 'active',
+  contract: { years: 2, baseAnnual: 12 },
+  traits: [],
+  accolades: [],
+  ratings: {},
+};
+
+const league = {
+  seasonId: '2026',
+  week: 2,
+  teams: [{ id: 1, name: 'Dallas', abbr: 'DAL', roster: [player] }],
+  schedule: { weeks: [] },
+};
+
+const actions = { getPlayerCareer: vi.fn(async () => null) };
+
 describe('PlayerProfile', () => {
+  beforeEach(() => {
+    global.IntersectionObserver = vi.fn(() => ({ observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() }));
+  });
+  afterEach(() => cleanup());
   it('renders safe unavailable state when no player id is provided', () => {
     const html = renderToString(
       <PlayerProfile
         playerId={null}
         onClose={vi.fn()}
-        actions={{ getPlayerCareer: vi.fn() }}
+        actions={actions}
         teams={[]}
         league={{ teams: [], week: 1 }}
       />,
@@ -17,5 +47,53 @@ describe('PlayerProfile', () => {
 
     expect(html).toContain('Player profile unavailable');
     expect(html).toContain('Close');
+  });
+
+  it('renders with minimum generated player data from league state', async () => {
+    render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={actions} teams={league.teams} league={league} />);
+
+    expect(screen.getByTestId('player-profile')).toBeTruthy();
+    await waitFor(() => expect(screen.getByTestId('player-profile-summary').textContent).toContain('Avery Fields'));
+    expect(screen.getByTestId('player-profile-season-stats').textContent).toContain('Season stats will appear after this player records tracked stats.');
+  });
+
+  it('renders game book context and honest missing logs state', () => {
+    render(
+      <PlayerProfile
+        playerId={11}
+        onClose={vi.fn()}
+        actions={actions}
+        teams={league.teams}
+        league={league}
+        profileContext={{ source: 'game-book', gameId: 'g1', week: 2, role: 'Top offensive player', statLine: { passAtt: 28, passComp: 19, passYd: 244, passTD: 2, interceptions: 1 } }}
+      />,
+    );
+
+    expect(screen.getByTestId('player-profile-game-impact').textContent).toContain('244 pass yds');
+    fireEvent.click(screen.getByRole('button', { name: 'Game Log' }));
+    expect(screen.getByTestId('player-profile-game-logs').textContent).toContain('Game logs will appear after this player records tracked stats.');
+  });
+
+  it('return buttons navigate to Game Book and HQ', () => {
+    const onClose = vi.fn();
+    const onOpenBoxScore = vi.fn();
+    const onNavigate = vi.fn();
+    render(
+      <PlayerProfile
+        playerId={11}
+        onClose={onClose}
+        actions={actions}
+        teams={league.teams}
+        league={league}
+        onNavigate={onNavigate}
+        onOpenBoxScore={onOpenBoxScore}
+        profileContext={{ source: 'game-book', gameId: 'g1', week: 2 }}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('player-profile-return-to-game-book'));
+    expect(onOpenBoxScore).toHaveBeenCalledWith('g1');
+    fireEvent.click(screen.getByRole('button', { name: 'Return to HQ' }));
+    expect(onNavigate).toHaveBeenCalledWith('HQ');
   });
 });

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -762,3 +762,15 @@
   .app-game-center-performers { grid-template-columns: 1fr; }
   .app-game-center-card__footer--primary .btn { width: 100%; min-height: 44px; }
 }
+
+.app-compact-insight--button {
+  width: 100%;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.app-compact-insight--button:hover,
+.app-compact-insight--button:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 60%, var(--hairline));
+  outline: none;
+}

--- a/src/ui/utils/gameBookHighlights.js
+++ b/src/ui/utils/gameBookHighlights.js
@@ -42,11 +42,17 @@ function formatDefense(best) {
 
 export function getTopPerformers(vm) {
   const players = [...(vm?.playerTables?.away ?? []), ...(vm?.playerTables?.home ?? [])];
-  const offense = formatOffense(bestBy(players, ['passYd', 'rushYd', 'recYd']));
-  const defense = formatDefense(bestBy(players, ['sacks', 'interceptions', 'tackles']));
+  const offenseBest = bestBy(players, ['passYd', 'rushYd', 'recYd']);
+  const defenseBest = bestBy(players, ['sacks', 'interceptions', 'tackles']);
+  const offense = formatOffense(offenseBest);
+  const defense = formatDefense(defenseBest);
   return {
     offense: offense ?? 'Offensive player stats were not recorded.',
     defense: defense ?? 'Defensive player stats were not recorded.',
+    offensePlayer: offenseBest?.player ?? null,
+    defensePlayer: defenseBest?.player ?? null,
+    offenseStatKey: offenseBest?.key ?? null,
+    defenseStatKey: defenseBest?.key ?? null,
     hasOffense: Boolean(offense),
     hasDefense: Boolean(defense),
   };

--- a/src/ui/utils/playerProfileNavigation.js
+++ b/src/ui/utils/playerProfileNavigation.js
@@ -1,0 +1,24 @@
+export function getPlayerProfileId(playerOrId) {
+  if (playerOrId == null) return null;
+  if (typeof playerOrId === 'object') return playerOrId.id ?? playerOrId.playerId ?? playerOrId.prospectId ?? null;
+  return playerOrId;
+}
+
+export function hasValidPlayerProfileId(playerOrId) {
+  const id = getPlayerProfileId(playerOrId);
+  return id != null && String(id).trim() !== '' && String(id) !== 'NaN';
+}
+
+export function buildPlayerProfileContext(source, context = {}) {
+  return {
+    source: source ?? context?.source ?? 'unknown',
+    ...context,
+  };
+}
+
+export function openPlayerProfile(playerOrId, onOpen, context = {}) {
+  const playerId = getPlayerProfileId(playerOrId);
+  if (!hasValidPlayerProfileId(playerId) || typeof onOpen !== 'function') return false;
+  onOpen(playerId, buildPlayerProfileContext(context?.source, context));
+  return true;
+}

--- a/tests/e2e/fresh_franchise_first_week_smoke.spec.js
+++ b/tests/e2e/fresh_franchise_first_week_smoke.spec.js
@@ -58,6 +58,16 @@ test('fresh franchise first week smoke', async ({ page, context }) => {
   await expect(page.getByTestId('game-book-final-score')).toBeVisible({ timeout: SMOKE_TIMEOUT });
   await expect(page.getByTestId('game-book-decision-summary')).toBeVisible({ timeout: SMOKE_TIMEOUT });
 
+  const gameBookPlayerLink = page.getByTestId('game-book-top-performer-link').first().or(page.getByTestId('game-book-player-link').first());
+  if (await gameBookPlayerLink.isVisible({ timeout: 5000 }).catch(() => false)) {
+    await gameBookPlayerLink.click();
+    await expect(page.getByTestId('player-profile')).toBeVisible({ timeout: SMOKE_TIMEOUT });
+    await expect(page.getByTestId('player-profile-summary')).toBeVisible({ timeout: SMOKE_TIMEOUT });
+    await expect(page.getByTestId('player-profile-game-impact')).toBeVisible({ timeout: SMOKE_TIMEOUT });
+    await page.getByTestId('player-profile-return-to-game-book').click();
+    await expect(page.getByTestId('game-book')).toBeVisible({ timeout: SMOKE_TIMEOUT });
+  }
+
   await page.getByTestId('return-to-hq').click();
   if (!(await page.getByTestId('franchise-hq').isVisible({ timeout: 3000 }).catch(() => false))) {
     await page.getByRole('button', { name: /^Back to HQ$/i }).click();


### PR DESCRIPTION
### Motivation

- New users clicking top performers in Weekly Results or Game Book should land on a Player Profile that explains who the player is and why they mattered this week using only real recorded data.  
- Existing first-session / safe-starter flows must remain stable and not fabricate stats or break profile routing.  
- Provide a single, safe way to open player profiles from multiple contexts while carrying context for return navigation and a truthful game-impact summary.

### Description

- Add a small player navigation utility `src/ui/utils/playerProfileNavigation.js` to normalize player ids, validate them, and open profiles with a consistent `onPlayerSelect(id, context)` shape.  
- Weekly Results: make top-performer cards actionable only when a valid player id exists and pass context (`source`, `gameId`, `week`, `role`, `statLine`) into `onPlayerSelect`. (see `src/ui/components/WeeklyResultsCenter.jsx`).  
- Game Book / BoxScore: return the resolved player row alongside the display text and wire top-performer names and stat-table player names to open Player Profile with game context and a return hint to Game Book. (see `src/ui/utils/gameBookHighlights.js` and `src/ui/components/BoxScore.jsx`).  
- Player Profile: resolve from league state when worker career data is missing, add above-the-fold summary (name, pos, team, age, OVR/potential, contract/draft/status where available, quick tags), add a data-backed “This Week / Game Impact” panel that uses the passed stat line and produces a concise, truthful summary or an honest missing-data fallback, and add season stats + game logs sections with honest empty states. Also add stable test ids: `player-profile`, `player-profile-summary`, `player-profile-game-impact`, `player-profile-game-logs`, `player-profile-season-stats`, `player-profile-return-to-game-book`. (see `src/ui/components/PlayerProfile.jsx`).  
- Dashboard wiring: route `onPlayerSelect` through the dashboard `handlePlayerSelect` so callers can optionally pass profile context without breaking id-only callers (see `src/ui/components/LeagueDashboard.jsx`).  
- Add small mobile/UX polish for clickable Weekly Results performer cards and stable testids for BoxScore and WeeklyResults clickable elements (see `src/ui/styles/screen-system.css`, tests and components).  
- Tests: add/adjust unit tests to assert new linking and profile behaviors and to guard against missing-browser e2e dependency changes (see modified/added tests under `src/ui/components/__tests__` and `src/ui/components/*test.jsx`).

### Testing

- `npm install` — completed successfully (npm reported existing audit findings: 1 moderate, 2 high).  
- `npm run build` — completed successfully; Vite build succeeded with chunk-size warnings about large bundles.  
- Targeted unit test runs executed and passed:  
  - `npm run test:unit -- src/ui/components/__tests__/PlayerProfile.test.jsx src/ui/components/WeeklyResultsCenter.test.jsx src/ui/components/BoxScore.test.jsx` — passed.  
  - `npm run test:unit -- src/ui/utils/leagueBootstrap.test.js tests/unit/leagueInit.test.jsx src/ui/hooks/useWorker.test.js` — passed (tests exercise fallback safe-starter logging).  
  - `npm run test:unit -- src/ui/utils/boxScoreViewModel.test.js src/ui/utils/playerProfileResolver.test.js` — passed.  
  - Combined run across the modified suites reported all unit tests passing (total reported: 49 tests passed across selected suites).  
- E2E/playwright smoke: attempted but blocked due to environment: Playwright failed to launch browsers because Chromium/Chrome binaries are not available in the container; command attempted: `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` (and `PLAYWRIGHT_CHROMIUM_CHANNEL=chrome PLAYWRIGHT_VIEWPORT=iphone npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js`) and both runs were blocked with messages requesting `npx playwright install`.  

Notes and known risks:  
- No simulation logic or player-model changes were made; all changes are UI, resolver, and navigation-level.  
- Playwright smoke was updated to click an available top-performer or player link and assert profile open, but the CI/container must install Playwright browsers for that to run end-to-end.  
- Vite build emits large-chunk warnings (unchanged during this work) and is noted in the test output as a non-blocking advisory.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fba84cc44c832db42c53a14369bab3)