### PR TITLE
Fix Dashboard Button Listener and Mobile Navigation State

### DIFF
--- a/legacy/main.js
+++ b/legacy/main.js
@@ -2420,9 +2420,9 @@ class GameController {
         const btnDashboard = document.getElementById('btnDashboard');
         if (btnDashboard) {
             this.addEventListener(btnDashboard, 'click', () => {
-                if (window.show) window.show('leagueDashboard');
-                if (window.renderDashboard) window.renderDashboard();
-
+                // Route navigation correctly
+                location.hash = '#/leagueDashboard';
+                this.router('leagueDashboard');
                 // Close menu if open (standardized for mobile/legacy)
                 const sidebar = document.getElementById('nav-sidebar');
                 if (window.toggleNavigation && sidebar && (sidebar.classList.contains('nav-open') || sidebar.classList.contains('active'))) {


### PR DESCRIPTION
This change fixes the dashboard button click listener in `legacy/main.js`. The implementation now correctly routes navigation using the hash-based routing system and ensures the mobile sidebar is closed when navigating to the dashboard, improving UX consistency across desktop and mobile.

---
*PR created automatically by Jules for task [4597289249085270966](https://jules.google.com/task/4597289249085270966) started by @rbcati*