### PR TITLE
Remove Duplicate Menu Toggle Handler Comments

### DIFF
--- a/legacy/main.js
+++ b/legacy/main.js
@@ -2355,9 +2355,6 @@ class GameController {
             }
         });
 
-        // FIX: Menu Toggle (ZenGM Style) - Removed duplicate handler
-        // ui-interactions.js handles mobile menu toggle via .nav-toggle
-
         // Sound Toggle UI
         const navContainer = document.querySelector('.nav-toggle-container');
         if (navContainer && !document.getElementById('soundToggle')) {

--- a/vite.log
+++ b/vite.log
@@ -1,0 +1,9 @@
+
+> football-gm-sim@2.0.0 dev
+> vite
+
+
+  VITE v7.3.3  ready in 520 ms
+
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose


### PR DESCRIPTION
Removed the redundant ZenGM-style menu toggle handler comments from setupEventListeners in legacy/main.js. This functionality was previously identified as a duplicate and is now properly handled by legacy/ui-interactions.js. This cleanup improves code readability and maintains the intended separation of concerns.

---
*PR created automatically by Jules for task [5790987955046550209](https://jules.google.com/task/5790987955046550209) started by @rbcati*