### PR TITLE
Post-PR #1369 stabilization: Netlify npm ci parity, championship inference, awards archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ manager_flow_error.png
 server.log
 verify_manager_flow.js
 dist/
+.netlify/
 test-results/

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,18 @@
 # netlify.toml — Netlify configuration for Football GM SPA
+#
+# Netlify's default "npm install" has diverged from GitHub Actions ("npm ci")
+# and triggered npm/arborist ERR_INVALID_ARG_TYPE on some previews. We skip
+# the automatic JS dependency install and run `npm ci` inside build.command
+# so deploys match CI (see scripts/netlify-parity-check.sh).
 
 [build]
-  command   = "npm run build"
+  command   = "npm ci && npm run build"
   publish   = "dist"
 
 [build.environment]
   NODE_VERSION = "22"
+  # Skip Netlify's default npm install; build.command runs npm ci instead.
+  NETLIFY_INSTALL_JS_DEPENDENCIES = "false"
 
 # Redirect/header rules are defined in public/_redirects and public/_headers so
 # Netlify parses a single source of truth in deploy previews and production.

--- a/scripts/netlify-parity-check.sh
+++ b/scripts/netlify-parity-check.sh
@@ -43,7 +43,8 @@ echo "[netlify-parity] Cleaning publish directory"
 rm -rf "$NETLIFY_PUBLISH"
 
 echo "[netlify-parity] Building production bundle with Netlify-like env"
-CI=true NETLIFY=true CONTEXT=production npm run build
+# Match netlify.toml [build].command (includes npm ci when configured).
+CI=true NETLIFY=true CONTEXT=production bash -c "$NETLIFY_CMD"
 
 if [[ -f "public/sw.js" && ! -f "$NETLIFY_PUBLISH/sw.js" ]]; then
   echo "[netlify-parity] ERROR: $NETLIFY_PUBLISH/sw.js missing (public/sw.js should be copied)"

--- a/scripts/validate-netlify-rules.mjs
+++ b/scripts/validate-netlify-rules.mjs
@@ -176,8 +176,27 @@ export function validateRedirectsContent(lines, fileLabel = '_redirects') {
   return errors;
 }
 
+/** Ensure Netlify matches GitHub Actions: skip default npm install, run npm ci in build.command. */
+export function validateNetlifyInstallParity(tomlRaw) {
+  const failures = [];
+  if (!/NETLIFY_INSTALL_JS_DEPENDENCIES\s*=\s*["']?false["']?/i.test(tomlRaw)) {
+    failures.push(
+      'netlify.toml must set NETLIFY_INSTALL_JS_DEPENDENCIES=false so the default npm install step is skipped (use npm ci in build.command).',
+    );
+  }
+  if (!/^\s*command\s*=\s*"npm\s+ci\s+&&/m.test(tomlRaw)) {
+    failures.push('netlify.toml [build].command must begin with npm ci && to match GitHub Actions (npm ci) and avoid flaky npm install.');
+  }
+  return failures;
+}
+
 export function validateNetlifyRules({ repoRoot = process.cwd() } = {}) {
   const failures = [];
+  const tomlPath = path.resolve(repoRoot, 'netlify.toml');
+  const tomlContent = fs.existsSync(tomlPath) ? fs.readFileSync(tomlPath, 'utf8') : '';
+  if (tomlContent) {
+    failures.push(...validateNetlifyInstallParity(tomlContent));
+  }
   const publishInfo = resolvePublishDirectory({ repoRoot });
 
   failures.push(...publishInfo.errors);
@@ -186,8 +205,6 @@ export function validateNetlifyRules({ repoRoot = process.cwd() } = {}) {
   }
 
   const { resolvedPublishDir, publish } = publishInfo;
-  const tomlPath = path.resolve(repoRoot, 'netlify.toml');
-  const tomlContent = fs.readFileSync(tomlPath, 'utf8');
   const headersPath = path.join(resolvedPublishDir, '_headers');
   const redirectsPath = path.join(resolvedPublishDir, '_redirects');
   const indexPath = path.join(resolvedPublishDir, 'index.html');

--- a/src/core/championshipInference.js
+++ b/src/core/championshipInference.js
@@ -1,0 +1,94 @@
+/**
+ * Pure helpers to infer championship winner / runner-up from season games and meta.
+ * Prefers explicit postseason / Super Bowl signals; avoids treating early playoff
+ * rounds as the title game when the final is missing.
+ */
+
+export function isCompletedGame(game) {
+  return Number.isFinite(Number(game?.homeScore)) && Number.isFinite(Number(game?.awayScore));
+}
+
+export function isPostseasonGame(game) {
+  const round = String(game?.playoffRound ?? game?.round ?? game?.stage ?? '').toLowerCase();
+  return Boolean(
+    game?.isPlayoff ||
+      game?.isPostseason ||
+      ['wildcard', 'divisional', 'conference', 'conference_final', 'final', 'championship', 'superbowl', 'super_bowl'].includes(round),
+  );
+}
+
+/** True only for games that may represent the league championship / Super Bowl. */
+export function isChampionshipFinalGame(game) {
+  if (!isPostseasonGame(game) || !isCompletedGame(game)) return false;
+  const round = String(game?.playoffRound ?? game?.round ?? game?.stage ?? '').toLowerCase();
+  const week = Number(game?.week ?? 0);
+  if (game?.isChampionshipGame || game?.isFinal) return true;
+  if (['superbowl', 'super_bowl', 'championship', 'final', 'playoff_final'].includes(round)) return true;
+  if (week === 22) return true;
+  return false;
+}
+
+export function resolveGameWinnerLoser(game) {
+  if (!isCompletedGame(game)) return { winnerId: null, loserId: null };
+  const homeScore = Number(game.homeScore);
+  const awayScore = Number(game.awayScore);
+  if (homeScore === awayScore) return { winnerId: null, loserId: null };
+  if (homeScore > awayScore) return { winnerId: Number(game.homeId), loserId: Number(game.awayId) };
+  return { winnerId: Number(game.awayId), loserId: Number(game.homeId) };
+}
+
+function findGameById(seasonGames, gameId) {
+  if (gameId == null || gameId === '') return null;
+  const idStr = String(gameId);
+  return (seasonGames || []).find((g) => String(g?.id ?? g?.gameId) === idStr) ?? null;
+}
+
+/**
+ * @param {{ seasonGames?: any[]; meta?: Record<string, unknown> }} args
+ * @returns {{ championshipGame: any | null; championTeamId: number | null; runnerUpTeamId: number | null }}
+ */
+function finalsGameIdFromPlayoffResults(meta) {
+  const pr = Array.isArray(meta?.playoffResults) ? meta.playoffResults : [];
+  const finalsRow = [...pr].reverse().find((r) => {
+    const rRound = String(r?.round ?? r?.playoffRound ?? r?.stage ?? '').toLowerCase();
+    return ['superbowl', 'super_bowl', 'championship', 'final', 'playoff_final', 'f'].includes(rRound);
+  });
+  if (!finalsRow) return null;
+  return finalsRow.gameId ?? finalsRow.id ?? finalsRow.game_id ?? null;
+}
+
+export function inferChampionshipOutcome({ seasonGames = [], meta = {} }) {
+  const metaChamp = meta?.championTeamId != null ? Number(meta.championTeamId) : null;
+  const metaRunner = meta?.runnerUpTeamId != null ? Number(meta.runnerUpTeamId) : null;
+  const metaFinalGameId = meta?.championshipGameId ?? meta?.superBowlGameId ?? finalsGameIdFromPlayoffResults(meta) ?? null;
+
+  const completedPostseason = (seasonGames || []).filter((g) => isCompletedGame(g) && isPostseasonGame(g));
+  const finalCandidates = completedPostseason.filter(isChampionshipFinalGame);
+
+  let resolvedGame =
+    (metaFinalGameId != null ? findGameById(seasonGames, metaFinalGameId) : null) ||
+    [...finalCandidates].sort((a, b) => Number(b?.week ?? 0) - Number(a?.week ?? 0))[0] ||
+    null;
+
+  const fromGame = resolveGameWinnerLoser(resolvedGame);
+
+  let championTeamId = Number.isFinite(fromGame.winnerId) ? fromGame.winnerId : null;
+  let runnerUpTeamId = Number.isFinite(fromGame.loserId) ? fromGame.loserId : null;
+
+  if (championTeamId == null && Number.isFinite(metaChamp)) {
+    championTeamId = metaChamp;
+  }
+  if (runnerUpTeamId == null && Number.isFinite(metaRunner)) {
+    runnerUpTeamId = metaRunner;
+  }
+
+  if (championTeamId != null && runnerUpTeamId == null && resolvedGame && Number.isFinite(fromGame.winnerId)) {
+    runnerUpTeamId = Number.isFinite(fromGame.loserId) ? fromGame.loserId : null;
+  }
+
+  return {
+    championshipGame: resolvedGame,
+    championTeamId: Number.isFinite(championTeamId) ? championTeamId : null,
+    runnerUpTeamId: Number.isFinite(runnerUpTeamId) ? runnerUpTeamId : null,
+  };
+}

--- a/src/ui/components/AwardsRecordsScreen.jsx
+++ b/src/ui/components/AwardsRecordsScreen.jsx
@@ -3,6 +3,7 @@ import { filterAwardRows } from '../utils/historyDestinations.js';
 import { ScreenHeader, SectionCard, StickySubnav, EmptyState } from './ScreenSystem.jsx';
 import { getStickyTopOffset } from '../utils/screenSystem.js';
 import { AWARD_DISPLAY_NAMES, AWARDS_HISTORY_ORDER } from '../../core/footballMeta';
+
 const AWARDS_V1_ORDER = [...AWARDS_HISTORY_ORDER, 'oroy', 'droy', 'bestQB', 'bestRB', 'bestWrTe', 'bestDefensivePlayer', 'bestKicker'];
 const AWARDS_V1_LABELS = {
   bestQB: 'Best QB',
@@ -26,33 +27,91 @@ export default function AwardsRecordsScreen({ actions, league, onPlayerSelect, o
 
   const awardRows = useMemo(() => (seasons ?? []).flatMap((s) => AWARDS_V1_ORDER.map((k) => ({
     season: s.year,
+    awardKey: k,
     award: AWARD_DISPLAY_NAMES[k] ?? AWARDS_V1_LABELS[k] ?? k.toUpperCase(),
     ...s?.awards?.[k],
   }))).filter((r) => r?.name), [seasons]);
 
   const filteredAwardRows = filterAwardRows(awardRows.slice().reverse(), scope);
+
+  const seasonsGrouped = useMemo(() => {
+    const sorted = [...(seasons ?? [])].sort((a, b) => Number(b?.year ?? 0) - Number(a?.year ?? 0));
+    let blocks = sorted.map((s) => ({
+      year: s.year,
+      seasonId: s.id ?? s.seasonId ?? null,
+      lines: AWARDS_V1_ORDER.map((k) => {
+        const a = s?.awards?.[k];
+        if (!a?.name) return null;
+        return {
+          key: k,
+          label: AWARD_DISPLAY_NAMES[k] ?? AWARDS_V1_LABELS[k] ?? k,
+          playerId: a.playerId ?? null,
+          name: a.name,
+          pos: a.pos ?? '',
+        };
+      }).filter(Boolean),
+    })).filter((b) => b.lines.length > 0);
+    if (scope === 'recent') blocks = blocks.slice(0, 6);
+    if (scope === 'mvp') {
+      blocks = blocks
+        .map((b) => ({ ...b, lines: b.lines.filter((l) => l.key === 'mvp') }))
+        .filter((b) => b.lines.length > 0);
+    }
+    return blocks;
+  }, [seasons, scope]);
+
   return (
     <div className="app-screen-stack" style={{ '--screen-sticky-top': getStickyTopOffset('compact') }}>
       <ScreenHeader
         title="Awards & Records"
-        subtitle="Award history, league records, and fast browsing controls."
+        subtitle="Archived season honors (V1). League records stay honest until a dedicated records release."
         onBack={onBack}
         backLabel="History Hub"
       />
 
       <StickySubnav title="Filter">
-        <button className={`standings-tab ${scope === 'all' ? 'active' : ''}`} onClick={() => setScope('all')}>All awards</button>
-        <button className={`standings-tab ${scope === 'recent' ? 'active' : ''}`} onClick={() => setScope('recent')}>Recent awards</button>
-        <button className={`standings-tab ${scope === 'mvp' ? 'active' : ''}`} onClick={() => setScope('mvp')}>MVP history</button>
+        <button type="button" className={`standings-tab ${scope === 'all' ? 'active' : ''}`} onClick={() => setScope('all')}>All awards</button>
+        <button type="button" className={`standings-tab ${scope === 'recent' ? 'active' : ''}`} onClick={() => setScope('recent')}>Recent seasons</button>
+        <button type="button" className={`standings-tab ${scope === 'mvp' ? 'active' : ''}`} onClick={() => setScope('mvp')}>MVP history</button>
       </StickySubnav>
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(260px,1fr))', gap: 10 }}>
-        <SectionCard title="Award history">
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(280px,1fr))', gap: 10 }}>
+        <SectionCard title="By season" subtitle="MVP, OPOY, DPOY, rookies, and best-by-position from each archive.">
+          <div style={{ display: 'grid', gap: 10, maxHeight: 480, overflow: 'auto' }}>
+            {seasonsGrouped.length === 0 ? (
+              <EmptyState title="No archived award data yet." body="Complete a full season to populate the archive." />
+            ) : (
+              seasonsGrouped.map((block) => (
+                <div
+                  key={`${block.year}-${block.seasonId ?? ''}`}
+                  style={{ border: '1px solid var(--hairline)', borderRadius: 8, padding: '10px 12px' }}
+                >
+                  <div style={{ fontWeight: 800, marginBottom: 6 }}>Season {block.year}</div>
+                  <ul style={{ margin: 0, paddingLeft: 18, fontSize: 'var(--text-xs)', lineHeight: 1.45 }}>
+                    {block.lines.map((line) => (
+                      <li key={line.key} style={{ marginBottom: 4 }}>
+                        <span style={{ color: 'var(--text-muted)' }}>{line.label}: </span>
+                        {line.playerId != null ? (
+                          <button type="button" className="btn-link" onClick={() => onPlayerSelect?.(line.playerId)}>{line.name}</button>
+                        ) : (
+                          <strong>{line.name}</strong>
+                        )}
+                        {line.pos ? <span style={{ color: 'var(--text-muted)' }}> ({line.pos})</span> : null}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))
+            )}
+          </div>
+        </SectionCard>
+
+        <SectionCard title="Flat list" subtitle="Same data as a compact scrollable list.">
           <div style={{ display: 'grid', gap: 8, maxHeight: 420, overflow: 'auto' }}>
-            {filteredAwardRows.length === 0 ? <EmptyState title="No award rows available." body="Advance the league to generate award history entries." /> : filteredAwardRows.map((row, idx) => (
+            {filteredAwardRows.length === 0 ? <EmptyState title="No award rows in this filter." body="Try another filter or advance the league." /> : filteredAwardRows.map((row, idx) => (
               <div key={`${row.season}-${row.award}-${idx}`} style={{ border: '1px solid var(--hairline)', borderRadius: 8, padding: 8 }}>
                 <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{row.season} · {row.award}</div>
-                {row.playerId != null ? <button className="btn-link" onClick={() => onPlayerSelect?.(row.playerId)}>{row.name}</button> : <strong>{row.name}</strong>}
+                {row.playerId != null ? <button type="button" className="btn-link" onClick={() => onPlayerSelect?.(row.playerId)}>{row.name}</button> : <strong>{row.name}</strong>}
                 <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{row.pos ?? ''}</div>
               </div>
             ))}

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -548,6 +548,13 @@ export default function LeagueDashboard({
   const [rosterInitialView, setRosterInitialView] = useState("table");
   const [statsInitialFamily, setStatsInitialFamily] = useState("passing");
   const [historySelectedSeasonId, setHistorySelectedSeasonId] = useState(null);
+
+  useEffect(() => {
+    if (activeTab === "History Hub") {
+      setHistorySelectedSeasonId(null);
+    }
+  }, [activeTab]);
+
   const [leagueInitialSection, setLeagueInitialSection] = useState("Overview");
   const [teamInitialSection, setTeamInitialSection] = useState("Overview");
   const [newsSubtab, setNewsSubtab] = useState("All");

--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -241,12 +241,14 @@ function SeasonExplorer({ seasons, onPlayerSelect, onOpenBoxScore, league, initi
   const [selectedSeasonId, setSelectedSeasonId] = useState(initialSelectedSeasonId ?? seasons?.[0]?.id ?? null);
 
   useEffect(() => {
+    if (!seasons?.length) return;
     if (initialSelectedSeasonId != null) {
-      setSelectedSeasonId(initialSelectedSeasonId);
+      const exists = seasons.some((s) => String(s?.id) === String(initialSelectedSeasonId));
+      setSelectedSeasonId(exists ? initialSelectedSeasonId : (seasons[0]?.id ?? null));
       return;
     }
-    if (!selectedSeasonId && seasons.length) setSelectedSeasonId(seasons[0].id);
-  }, [initialSelectedSeasonId, seasons, selectedSeasonId]);
+    setSelectedSeasonId((prev) => prev ?? seasons[0]?.id ?? null);
+  }, [initialSelectedSeasonId, seasons]);
 
   if (!seasons?.length) {
     return (

--- a/src/ui/components/__tests__/AwardsRecordsScreen.test.jsx
+++ b/src/ui/components/__tests__/AwardsRecordsScreen.test.jsx
@@ -5,7 +5,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import AwardsRecordsScreen from '../AwardsRecordsScreen.jsx';
 
 describe('AwardsRecordsScreen', () => {
-  it('renders archived V1 award rows and honest records placeholder', async () => {
+  it('renders archived V1 awards by season and honest records placeholder', async () => {
     render(
       <AwardsRecordsScreen
         onBack={vi.fn()}
@@ -20,7 +20,7 @@ describe('AwardsRecordsScreen', () => {
                   mvp: { playerId: 1, name: 'Ace QB', pos: 'QB' },
                   opoy: { playerId: 2, name: 'Top RB', pos: 'RB' },
                   dpoy: { playerId: 3, name: 'Edge Star', pos: 'EDGE' },
-                  bestQB: { playerId: 1, name: 'Ace QB', pos: 'QB' },
+                  bestQB: { playerId: 4, name: 'Also QB', pos: 'QB' },
                 },
               }],
             },
@@ -30,8 +30,11 @@ describe('AwardsRecordsScreen', () => {
     );
 
     await waitFor(() => {
+      expect(screen.getByText(/By season/i)).toBeTruthy();
+      expect(screen.getByText(/Season 2031/i)).toBeTruthy();
+      expect(screen.getByText(/Most Valuable Player:/i)).toBeTruthy();
+      expect(screen.getAllByText(/Ace QB/i).length).toBeGreaterThanOrEqual(1);
       expect(screen.getByText(/2031 · Most Valuable Player/i)).toBeTruthy();
-      expect(screen.getByText(/2031 · Best QB/i)).toBeTruthy();
       expect(screen.getByText(/Records coming later/i)).toBeTruthy();
     });
   });

--- a/src/ui/components/__tests__/LeagueHistory.test.jsx
+++ b/src/ui/components/__tests__/LeagueHistory.test.jsx
@@ -33,4 +33,32 @@ describe('LeagueHistory', () => {
       expect(screen.getByText(/Championship result is unavailable in this archive/i)).toBeTruthy();
     });
   });
+
+  it('falls back to the first archived season when initialSelectedSeasonId is unknown', async () => {
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        initialSelectedSeasonId="missing-id"
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                { id: 's1', year: 2030, standings: [], awards: {} },
+                { id: 's2', year: 2031, standings: [], awards: {} },
+              ],
+            },
+          }),
+          getRecords: vi.fn().mockResolvedValue({ payload: { records: null } }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/2030 League Snapshot/i)).toBeTruthy();
+    });
+  });
 });

--- a/src/ui/utils/historyDestinations.js
+++ b/src/ui/utils/historyDestinations.js
@@ -7,6 +7,6 @@ export function resolveHistoryDestination(tab) {
 
 export function filterAwardRows(rows = [], scope = 'all') {
   if (scope === 'recent') return rows.slice(-24).reverse();
-  if (scope === 'mvp') return rows.filter((r) => r.award === 'MVP');
+  if (scope === 'mvp') return rows.filter((r) => r.awardKey === 'mvp' || r.award === 'Most Valuable Player');
   return rows;
 }

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -110,6 +110,7 @@ import { evaluateRetirements }     from '../core/retirement-system.js';
 import { runAIToAITrades, generateAITradeProposalsForUser, evaluateCounterOffer } from '../core/trade-logic.js';
 import { processSeasonRecords, createEmptyRecords, getMostPlayedTeam } from '../core/records.js';
 import { ensureLeagueMemoryMeta, buildSeasonArchiveSummary, updateFranchiseHistory, updateRecordBook, evaluateHallOfFameCandidate, addHallOfFameClass, buildSeasonStorylineSnapshot } from '../core/league-memory.js';
+import { inferChampionshipOutcome, isCompletedGame, isPostseasonGame } from '../core/championshipInference.js';
 import { repairDepthChart, validateDepthChart, optimizeDepthChartForPlan } from "../core/roster/depthChartManager.js";
 import { ensureDynastyMeta, generateOwnerGoals, applyGameFanApproval, updateGoalsForWin } from '../core/dynasty-story.js';
 import { isValidSaveId, sanitizeSaveList } from './saveIntegrity.js';
@@ -2711,15 +2712,20 @@ async function handleAdvanceWeek(payload, id) {
     seasonEndFlag = true;
     // Find and announce the champion
     let sbChampId = null;
+    let sbRunnerUpId = null;
     if (results.length > 0) {
       const sbR = results[0];
       const hScore = sbR.scoreHome ?? sbR.homeScore ?? 0;
       const aScore = sbR.scoreAway ?? sbR.awayScore ?? 0;
       const rawW   = hScore >= aScore ? (sbR.home ?? sbR.homeTeamId) : (sbR.away ?? sbR.awayTeamId);
+      const rawL   = hScore >= aScore ? (sbR.away ?? sbR.awayTeamId) : (sbR.home ?? sbR.homeTeamId);
       const wId    = Number(typeof rawW === 'object' ? rawW?.id : rawW);
+      const lId    = Number(typeof rawL === 'object' ? rawL?.id : rawL);
       const champ  = cache.getTeam(wId);
+      const runner = cache.getTeam(lId);
       if (champ) {
         sbChampId = wId;
+        if (runner && Number.isFinite(lId)) sbRunnerUpId = lId;
         post(toUI.NOTIFICATION, { level: 'info', message: `🏆 ${champ.name} win the Super Bowl! Season complete.` });
         await NewsEngine.logAward('SUPER_BOWL', champ);
         const titleNews = createNewsItem('championship_won', { teamName: champ?.name, season: meta?.season, teamId: champ?.id }, week, meta?.season);
@@ -2734,6 +2740,7 @@ async function handleAdvanceWeek(payload, id) {
       phase: 'offseason_resign',
       currentWeek: 0,
       championTeamId: sbChampId,
+      runnerUpTeamId: sbRunnerUpId,
       offseasonProgressionDone: false,
       draftState: null,
       freeAgencyState: null,
@@ -7734,6 +7741,21 @@ function calculateLeaders(stats) {
   };
 }
 
+function seasonStatsHaveAwardEligibleTotals(populatedStats) {
+  const rows = (populatedStats || []).filter((s) => s?.totals && typeof s.totals === 'object');
+  if (!rows.length) return false;
+  const offensiveKeys = ['passYd', 'passingYards', 'rushYd', 'rushingYards', 'recYd', 'receivingYards', 'passTD', 'passingTd', 'rushTD', 'rushingTd', 'recTD', 'receivingTd'];
+  const defensiveKeys = ['tackles', 'sacks', 'defInterceptions', 'forcedFumbles'];
+  for (const row of rows) {
+    const totals = row.totals;
+    if (offensiveKeys.some((k) => Number(totals[k] ?? 0) !== 0)) return true;
+    if (defensiveKeys.some((k) => Number(totals[k] ?? 0) !== 0)) return true;
+    const pos = String(row?.pos ?? '').toUpperCase();
+    if (['DL', 'DE', 'DT', 'EDGE', 'LB', 'CB', 'S', 'SS', 'FS'].includes(pos) && Number(totals.interceptions ?? 0) !== 0) return true;
+  }
+  return false;
+}
+
 function calculateSeasonAwardsV1(stats, teams, year) {
   const rows = (stats || []).filter((s) => s?.totals);
   const emptyAwards = {
@@ -7782,8 +7804,19 @@ function calculateSeasonAwardsV1(stats, teams, year) {
   };
   const offensiveCandidates = offense.filter(hasOffenseStats);
   const defensiveCandidates = defense.filter(hasDefenseStats);
-  const passingInts = (row) => statValue(t(row), ['passInt', 'interceptionsThrown', 'interceptions']);
-  const defensiveInts = (row) => statValue(t(row), ['defInterceptions', 'interceptions']);
+  const passingInts = (row) => {
+    const qb = String(row?.pos ?? '').toUpperCase() === 'QB';
+    const keys = qb
+      ? ['passInt', 'interceptionsThrown', 'intsThrown', 'interceptions']
+      : ['passInt', 'interceptionsThrown', 'intsThrown'];
+    return statValue(t(row), keys);
+  };
+  const defensiveInts = (row) => {
+    const pos = String(row?.pos ?? '').toUpperCase();
+    const defPos = ['DL', 'DE', 'DT', 'EDGE', 'LB', 'CB', 'S', 'SS', 'FS'].includes(pos);
+    const keys = defPos ? ['defInterceptions', 'interceptions'] : ['defInterceptions'];
+    return statValue(t(row), keys);
+  };
   const kickingMade = (row) => statValue(t(row), ['fgMade', 'fieldGoalsMade']);
   const extraPointsMade = (row) => statValue(t(row), ['xpMade', 'extraPointsMade']);
 
@@ -7833,55 +7866,6 @@ function calculateSeasonAwardsV1(stats, teams, year) {
     bestWrTe: toAward(bestWrTe),
     bestDefensivePlayer: toAward(bestDefensivePlayer),
     ...(bestKicker ? { bestKicker: toAward(bestKicker) } : { bestKicker: null }),
-  };
-}
-
-function isCompletedGame(game) {
-  return Number.isFinite(Number(game?.homeScore)) && Number.isFinite(Number(game?.awayScore));
-}
-
-function isPostseasonGame(game) {
-  const round = String(game?.playoffRound ?? game?.round ?? game?.stage ?? '').toLowerCase();
-  return Boolean(game?.isPlayoff || game?.isPostseason || ['wildcard', 'divisional', 'conference', 'conference_final', 'final', 'championship', 'superbowl', 'super_bowl'].includes(round));
-}
-
-function isChampionshipGameMarker(game) {
-  const round = String(game?.playoffRound ?? game?.round ?? game?.stage ?? '').toLowerCase();
-  const week = Number(game?.week ?? 0);
-  return Boolean(
-    game?.isChampionshipGame ||
-    game?.isFinal ||
-    ['superbowl', 'super_bowl', 'championship', 'final', 'playoff_final'].includes(round) ||
-    (isPostseasonGame(game) && week >= 22)
-  );
-}
-
-function resolveGameWinnerLoser(game) {
-  if (!isCompletedGame(game)) return { winnerId: null, loserId: null };
-  const homeScore = Number(game.homeScore);
-  const awayScore = Number(game.awayScore);
-  if (homeScore === awayScore) return { winnerId: null, loserId: null };
-  if (homeScore > awayScore) return { winnerId: Number(game.homeId), loserId: Number(game.awayId) };
-  return { winnerId: Number(game.awayId), loserId: Number(game.homeId) };
-}
-
-function inferChampionshipOutcome({ seasonGames = [], meta = {} }) {
-  const completedGames = seasonGames.filter(isCompletedGame);
-  const postseasonGames = completedGames.filter(isPostseasonGame);
-  const explicitChampionshipGame = [...postseasonGames]
-    .filter(isChampionshipGameMarker)
-    .sort((a, b) => Number(b?.week ?? 0) - Number(a?.week ?? 0))[0] ?? null;
-  const fallbackPostseasonFinal = explicitChampionshipGame
-    ? null
-    : [...postseasonGames]
-      .sort((a, b) => Number(b?.week ?? 0) - Number(a?.week ?? 0))[0] ?? null;
-  const resolvedGame = explicitChampionshipGame ?? fallbackPostseasonFinal;
-  const fromGame = resolveGameWinnerLoser(resolvedGame);
-  const championTeamId = fromGame.winnerId ?? (meta?.championTeamId != null ? Number(meta.championTeamId) : null);
-  return {
-    championshipGame: resolvedGame,
-    championTeamId: Number.isFinite(championTeamId) ? championTeamId : null,
-    runnerUpTeamId: fromGame.loserId ?? null,
   };
 }
 
@@ -8364,7 +8348,9 @@ async function archiveSeason(seasonId) {
     await Promise.all(seasonStats.map(async (s) => {
       const p = await resolvePlayer(s.playerId);
       if (p) {
-        populatedStats.push({ ...s, name: p.name, pos: p.pos, teamId: p.teamId, age: p.age, draftYear: p.year ?? null });
+        const entryYear = Number(p?.year ?? 0);
+        const draftYear = entryYear === Number(year) ? year : null;
+        populatedStats.push({ ...s, name: p.name, pos: p.pos, teamId: p.teamId, age: p.age, draftYear });
       }
     }));
 
@@ -8423,12 +8409,12 @@ async function archiveSeason(seasonId) {
     const legacyAwards = calculateAwards(populatedStats, teams);
     const staffRows = teams.map((t) => ({ teamId: t.id, name: t?.staff?.headCoach?.name ?? `${t?.abbr ?? 'Team'} HC` }));
     const seasonAwards = calculateSeasonAwards({ stats: populatedStats, teams, year, coaches: staffRows });
-    const v1Awards = calculateSeasonAwardsV1(populatedStats, teams, year);
+    const awardSignal = seasonStatsHaveAwardEligibleTotals(populatedStats);
+    const v1Awards = calculateSeasonAwardsV1(awardSignal ? populatedStats : [], teams, year);
     const awards = {
       ...legacyAwards,
       ...seasonAwards,
       ...v1Awards,
-      roty: seasonAwards?.roty ?? legacyAwards?.roty ?? null,
       allPro: seasonAwards?.allPro ?? { firstTeamOffense: [], firstTeamDefense: [] },
     };
 
@@ -8630,6 +8616,7 @@ async function handleStartNewSeason(payload, id) {
     freeAgencyState:         null, // Reset FA state
     contractMarketMemory:    {},
     championTeamId:          null,
+    runnerUpTeamId:          null,
     offseasonProgressionDone:false,
     ownerGoals: generateOwnerGoals(),
     offseasonReleaseMap: {},

--- a/tests/unit/championshipInference.test.js
+++ b/tests/unit/championshipInference.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { inferChampionshipOutcome, isChampionshipFinalGame } from '../../src/core/championshipInference.js';
+
+describe('championshipInference', () => {
+  it('resolves Super Bowl week 22 with playoffRound superbowl', () => {
+    const seasonGames = [
+      { id: 's1_w18_0_1', week: 18, homeId: 0, awayId: 1, homeScore: 21, awayScore: 17, isPlayoff: false },
+      { id: 's1_w21_2_3', week: 21, homeId: 2, awayId: 3, homeScore: 24, awayScore: 20, isPlayoff: true, playoffRound: 'conference' },
+      {
+        id: 's1_w22_2_3',
+        week: 22,
+        homeId: 2,
+        awayId: 3,
+        homeScore: 31,
+        awayScore: 28,
+        isPlayoff: true,
+        playoffRound: 'superbowl',
+      },
+    ];
+    const out = inferChampionshipOutcome({ seasonGames, meta: {} });
+    expect(out.championshipGame?.id).toBe('s1_w22_2_3');
+    expect(out.championTeamId).toBe(2);
+    expect(out.runnerUpTeamId).toBe(3);
+  });
+
+  it('does not treat conference final as championship when no final marker', () => {
+    const seasonGames = [
+      { id: 'g21', week: 21, homeId: 1, awayId: 2, homeScore: 20, awayScore: 17, isPlayoff: true, playoffRound: 'conference' },
+    ];
+    const out = inferChampionshipOutcome({ seasonGames, meta: {} });
+    expect(out.championshipGame).toBe(null);
+    expect(out.championTeamId).toBe(null);
+    expect(out.runnerUpTeamId).toBe(null);
+  });
+
+  it('uses meta.championTeamId when no final game is present', () => {
+    const out = inferChampionshipOutcome({
+      seasonGames: [{ id: 'g18', week: 18, homeId: 1, awayId: 2, homeScore: 10, awayScore: 7, isPlayoff: false }],
+      meta: { championTeamId: 7, runnerUpTeamId: 8 },
+    });
+    expect(out.championshipGame).toBe(null);
+    expect(out.championTeamId).toBe(7);
+    expect(out.runnerUpTeamId).toBe(8);
+  });
+
+  it('matches meta.championshipGameId to a stored game', () => {
+    const seasonGames = [
+      { id: 'sb1', week: 22, homeId: 0, awayId: 1, homeScore: 14, awayScore: 10, isPlayoff: true, playoffRound: 'superbowl' },
+    ];
+    const out = inferChampionshipOutcome({ seasonGames, meta: { championshipGameId: 'sb1' } });
+    expect(out.championshipGame?.id).toBe('sb1');
+    expect(out.championTeamId).toBe(0);
+    expect(out.runnerUpTeamId).toBe(1);
+  });
+
+  it('isChampionshipFinalGame rejects regular-season week 18', () => {
+    expect(isChampionshipFinalGame({ week: 18, homeScore: 1, awayScore: 0, isPlayoff: false })).toBe(false);
+  });
+});

--- a/tests/unit/historyDestinations.test.js
+++ b/tests/unit/historyDestinations.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { filterAwardRows } from '../../src/ui/utils/historyDestinations.js';
+
+describe('filterAwardRows', () => {
+  it('filters MVP scope using awardKey or display name', () => {
+    const rows = [
+      { season: 2030, awardKey: 'mvp', award: 'Most Valuable Player', name: 'A' },
+      { season: 2030, awardKey: 'opoy', award: 'Offensive Player of the Year', name: 'B' },
+    ];
+    const mvp = filterAwardRows(rows, 'mvp');
+    expect(mvp).toHaveLength(1);
+    expect(mvp[0].awardKey).toBe('mvp');
+  });
+});

--- a/tests/unit/league_memory.test.js
+++ b/tests/unit/league_memory.test.js
@@ -62,9 +62,13 @@ describe('league memory helpers', () => {
       seasonStats: [],
     });
     expect(season.schemaVersion).toBe(1);
+    expect(season.seasonId).toBe('s9');
+    expect(season.id).toBe('s9');
     expect(typeof season.completedAt).toBe('string');
     expect(season.playoffSummary.finals).toBe(null);
     expect(Array.isArray(season.notableGames)).toBe(true);
+    expect(season.awards).toEqual({});
+    expect(season.leaders).toEqual({});
   });
 
   it('updates record book and hall evaluations', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stabilizes Season History / Awards V1 after PR #1369: fixes the Netlify preview install path, hardens championship and award archive logic, improves History navigation and Awards UI, and adds targeted tests.

## Netlify deploy failure — root cause and fix

**Root cause:** GitHub Actions runs `npm ci` while Netlify’s default step runs `npm install`. On Node 22 / npm 10 that mismatch can surface as `ERR_INVALID_ARG_TYPE` / `"from" … undefined` during dependency install (Arborist path), so Actions could stay green while deploy previews failed before `npm run build`.

**Fix:**
- `netlify.toml`: `NETLIFY_INSTALL_JS_DEPENDENCIES = "false"` so Netlify skips its automatic JS install.
- `build.command = "npm ci && npm run build"` so installs match CI and are deterministic.
- `scripts/netlify-parity-check.sh` runs the same `build.command` as Netlify.
- `scripts/validate-netlify-rules.mjs` asserts the above so it cannot regress silently.
- `.gitignore`: ignore `.netlify/` local CLI output.

**Note:** Netlify preview must be re-checked on this branch (not verifiable from this agent).

## Champion / runner-up inference

New module [`src/core/championshipInference.js`](src/core/championshipInference.js):

1. Resolve the title game only from **final** signals: `playoffRound` in superbowl/championship/final family, `week === 22` with postseason context, `isChampionshipGame` / `isFinal`, `meta.championshipGameId` / `superBowlGameId`, or a finals row in `meta.playoffResults`.
2. **Removed** the old fallback that picked the latest postseason game by week (could treat a **conference** game as the championship).
3. If no final game: use **`meta.championTeamId`** and **`meta.runnerUpTeamId`** when set.
4. Super Bowl completion in the worker now sets **`runnerUpTeamId`** alongside `championTeamId`; both cleared on new season.

## Award generation validation

- **ROTY merge bug:** Removed the explicit `roty: seasonAwards ?? legacy` line that overwrote V1 `roty` after `...v1Awards`.
- **Score-only / empty stats:** `seasonStatsHaveAwardEligibleTotals` gates V1 awards; if there is no real counting-stat signal, V1 awards are all null (legacy/coach/all-pro paths unchanged for compatibility).
- **INT keys:** `passingInts` only falls back to `interceptions` for **QB** rows; `defensiveInts` only uses ambiguous `interceptions` for **defensive** positions.
- **Rookie `draftYear`:** Populated only when `player.year === league year` (same signal as other rookie logic).

## History Hub / League History / Awards & Records

- **Awards & Records:** “By season” cards list MVP, OPOY, DPOY, rookies, best QB/RB/WR-TE, best defensive player, best kicker when present; flat list retained; records stay “coming later.”
- **History Hub:** Opening the hub clears a stale `historySelectedSeasonId` so League History does not highlight a missing season.
- **League History:** Unknown `initialSelectedSeasonId` falls back to the first archived season.
- **MVP filter:** `filterAwardRows` uses `awardKey === 'mvp'` or the full MVP display name.

## Old saves and empty states

- Championship inference returns nulls when metadata and final games are missing; UI copy already treats missing champions honestly.
- Archive summary tests assert stable fields when awards/leaders are empty.

## Tests run (this branch)

- `npm run test:unit` — pass (626 tests)
- `npm run build` — pass
- `npm run check:deploy` — pass (parity, netlify-rules, netlify-cli production + deploy-preview offline)
- `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` — pass

## Known limitations (unchanged)

- Hall of Fame and all-time records remain out of scope; no new gameplay systems.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70c380cc-4069-4f37-9785-130ac3f354fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70c380cc-4069-4f37-9785-130ac3f354fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

