### PR TITLE
Dynasty history: award timelines, playoff snapshots, richer League History & History Hub

### DIFF
--- a/src/core/__tests__/playerAwardTimeline.test.js
+++ b/src/core/__tests__/playerAwardTimeline.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { buildMergedPlayerAwardTimeline, buildPlayerAwardHeaderBadges } from '../playerAwardTimeline.js';
+
+const teams = [{ id: 1, abbr: 'DAL' }];
+
+describe('playerAwardTimeline', () => {
+  it('deduplicates MVP from accolades and season archive', () => {
+    const merged = buildMergedPlayerAwardTimeline(
+      11,
+      [{ type: 'MVP', year: 2030 }],
+      [{ year: 2030, awards: { mvp: { playerId: 11, name: 'A', teamId: 1 } } }],
+      teams,
+    );
+    expect(merged.rows.filter((r) => r.canonical === 'mvp')).toHaveLength(1);
+  });
+
+  it('skips duplicate OROY/ROTY archive rows for the same player', () => {
+    const merged = buildMergedPlayerAwardTimeline(
+      11,
+      [],
+      [{
+        year: 2031,
+        awards: {
+          oroy: { playerId: 11, name: 'R', teamId: 1 },
+          roty: { playerId: 11, name: 'R', teamId: 1 },
+        },
+      }],
+      teams,
+    );
+    const rookieRows = merged.rows.filter((r) => r.canonical === 'roty' || r.canonical === 'oroy');
+    expect(rookieRows).toHaveLength(1);
+  });
+
+  it('builds compact MVP header badges', () => {
+    const merged = buildMergedPlayerAwardTimeline(
+      11,
+      [],
+      [
+        { year: 2028, awards: { mvp: { playerId: 11, name: 'A', teamId: 1 } } },
+        { year: 2029, awards: { mvp: { playerId: 11, name: 'A', teamId: 1 } } },
+      ],
+      teams,
+    );
+    const chips = buildPlayerAwardHeaderBadges(merged);
+    expect(chips.some((c) => c.text === '2x MVP')).toBe(true);
+  });
+});

--- a/src/core/__tests__/playoffBracketSnapshot.test.js
+++ b/src/core/__tests__/playoffBracketSnapshot.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { buildPlayoffBracketSnapshot, classifyPlayoffRoundBucket } from '../playoffBracketSnapshot.js';
+
+const teams = [
+  { id: 1, abbr: 'DAL' },
+  { id: 2, abbr: 'NYG' },
+];
+
+describe('playoffBracketSnapshot', () => {
+  it('does not include regular-season games', () => {
+    const games = [
+      { week: 5, homeId: 1, awayId: 2, homeScore: 21, awayScore: 20, isPlayoff: false },
+      { week: 19, homeId: 1, awayId: 2, homeScore: 30, awayScore: 17, isPlayoff: true, playoffRound: 'wildcard' },
+    ];
+    const snap = buildPlayoffBracketSnapshot({ games, teams, championshipGameId: null });
+    expect(snap.mode).not.toBe('empty');
+    const all = (snap.rounds ?? []).flatMap((r) => r.games);
+    expect(all).toHaveLength(1);
+    expect(all[0].week).toBe(19);
+  });
+
+  it('groups by round when metadata is complete', () => {
+    const games = [
+      { id: 'g-wc', week: 19, homeId: 1, awayId: 2, homeScore: 24, awayScore: 17, isPlayoff: true, playoffRound: 'wildcard' },
+      { id: 'g-div', week: 20, homeId: 1, awayId: 2, homeScore: 14, awayScore: 10, isPlayoff: true, playoffRound: 'divisional' },
+      { id: 'g-sb', week: 22, homeId: 1, awayId: 2, homeScore: 31, awayScore: 27, isPlayoff: true, playoffRound: 'superbowl' },
+    ];
+    const snap = buildPlayoffBracketSnapshot({ games, teams, championshipGameId: 'g-sb' });
+    expect(snap.mode).toBe('rounds');
+    expect(snap.rounds.map((r) => r.label)).toEqual(['Wild Card', 'Divisional', 'Championship']);
+    expect(snap.rounds[2].games[0].isChampionshipGame).toBe(true);
+  });
+
+  it('uses a single postseason bucket when round metadata is incomplete', () => {
+    const games = [
+      { id: 'g1', week: 19, homeId: 1, awayId: 2, homeScore: 10, awayScore: 7, isPlayoff: true },
+      { id: 'g2', week: 20, homeId: 1, awayId: 2, homeScore: 12, awayScore: 9, isPlayoff: true, playoffRound: 'divisional' },
+    ];
+    expect(classifyPlayoffRoundBucket(games[0])).toBeNull();
+    const snap = buildPlayoffBracketSnapshot({ games, teams, championshipGameId: null });
+    expect(snap.mode).toBe('flat');
+    expect(snap.rounds).toHaveLength(1);
+    expect(snap.rounds[0].label).toBe('Postseason games');
+    expect(snap.note).toMatch(/Round labels are unavailable/i);
+  });
+});

--- a/src/core/__tests__/seasonArchivePlayoff.test.js
+++ b/src/core/__tests__/seasonArchivePlayoff.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { buildSeasonArchiveSummary } from '../league-memory.js';
+
+describe('buildSeasonArchiveSummary playoff snapshot', () => {
+  it('stores a compact playoff bracket snapshot from full season games', () => {
+    const games = [
+      { id: 'g-r1', week: 1, homeId: 1, awayId: 2, homeScore: 21, awayScore: 20, isPlayoff: false },
+      { id: 'g-wc', week: 19, homeId: 1, awayId: 2, homeScore: 30, awayScore: 17, isPlayoff: true, playoffRound: 'wildcard' },
+      { id: 'g-sb', week: 22, homeId: 1, awayId: 2, homeScore: 27, awayScore: 24, isPlayoff: true, playoffRound: 'superbowl' },
+    ];
+    const teams = [
+      { id: 1, name: 'Dallas', abbr: 'DAL', wins: 12, losses: 5 },
+      { id: 2, name: 'New York', abbr: 'NYG', wins: 10, losses: 7 },
+    ];
+    const summary = buildSeasonArchiveSummary({
+      year: 2030,
+      seasonId: 's1',
+      standings: teams.map((t) => ({ id: t.id, name: t.name, abbr: t.abbr, wins: t.wins, losses: t.losses, ties: 0, pf: 400, pa: 320 })),
+      awards: {},
+      leaders: {},
+      champion: { id: 1, name: 'Dallas', abbr: 'DAL' },
+      runnerUp: { id: 2, name: 'New York', abbr: 'NYG' },
+      userTeamId: 1,
+      games,
+      teams,
+      seasonStats: [],
+      championshipGameId: 'g-sb',
+    });
+    expect(summary.playoffBracketSnapshot?.mode).toBe('rounds');
+    const labels = (summary.playoffBracketSnapshot?.rounds ?? []).map((r) => r.label);
+    expect(labels).toContain('Wild Card');
+    expect(labels).toContain('Championship');
+  });
+});

--- a/src/core/league-memory.js
+++ b/src/core/league-memory.js
@@ -1,3 +1,5 @@
+import { buildPlayoffBracketSnapshot } from './playoffBracketSnapshot.js';
+
 const POSITION_HOF_BASELINE = {
   QB: 12000,
   RB: 8000,
@@ -472,6 +474,11 @@ export function buildSeasonArchiveSummary({ year, seasonId, standings, awards, l
 
   const playerStatLeaders = buildPlayerStatLeaders(seasonStats);
   const teamStatLeaders = buildTeamStatLeaders(sorted);
+  const playoffBracketSnapshot = buildPlayoffBracketSnapshot({
+    games,
+    teams,
+    championshipGameId: championshipGameId ?? null,
+  });
   const notableGames = [];
   const championshipGame = (games || []).find((g) => String(g?.id ?? g?.gameId) === String(championshipGameId));
   if (championshipGame) {
@@ -520,6 +527,7 @@ export function buildSeasonArchiveSummary({ year, seasonId, standings, awards, l
       finals: champion && runnerUp ? `${champion.abbr} over ${runnerUp.abbr}` : null,
       wins: champion?.wins ?? null,
     },
+    playoffBracketSnapshot,
     gameIndex: (games || []).map((g) => ({
       id: g.id,
       week: g.week,

--- a/src/core/playerAwardTimeline.js
+++ b/src/core/playerAwardTimeline.js
@@ -1,0 +1,187 @@
+/**
+ * Merge player.accolades with archived season awards for profile / history UI.
+ * Pure helpers — no invented honors.
+ */
+
+export const ARCHIVE_PLAYER_AWARD_KEYS = [
+  'mvp',
+  'opoy',
+  'dpoy',
+  'roty',
+  'oroy',
+  'droy',
+  'sbMvp',
+  'bestQB',
+  'bestRB',
+  'bestWrTe',
+  'bestDefensivePlayer',
+  'bestKicker',
+];
+
+const AWARD_LABEL = {
+  mvp: 'Most Valuable Player',
+  opoy: 'Offensive Player of the Year',
+  dpoy: 'Defensive Player of the Year',
+  roty: 'Rookie of the Year',
+  oroy: 'Offensive Rookie of the Year',
+  droy: 'Defensive Rookie of the Year',
+  sbMvp: 'Finals MVP',
+  bestQB: 'Best QB',
+  bestRB: 'Best RB',
+  bestWrTe: 'Best WR/TE',
+  bestDefensivePlayer: 'Best Defensive Player',
+  bestKicker: 'Best Kicker',
+};
+
+const ACCOLADE_TO_CANONICAL = {
+  MVP: 'mvp',
+  OPOY: 'opoy',
+  DPOY: 'dpoy',
+  ROTY: 'roty',
+  SB_MVP: 'sbMvp',
+  SB_RING: 'sb_ring',
+};
+
+function teamAbbrFromId(teamId, teams) {
+  if (teamId == null) return null;
+  const t = (teams || []).find((x) => Number(x?.id) === Number(teamId));
+  return t?.abbr ?? null;
+}
+
+function dedupeKeyForCanonical(year, canonical) {
+  return `${canonical}_${year}`;
+}
+
+function collectAllProArchiveRows(awards, year) {
+  const ap = awards?.allPro;
+  if (!ap || typeof ap !== 'object') return [];
+  const off = Array.isArray(ap.firstTeamOffense) ? ap.firstTeamOffense : [];
+  const def = Array.isArray(ap.firstTeamDefense) ? ap.firstTeamDefense : [];
+  const rows = [];
+  for (const row of off) {
+    if (row?.playerId == null) continue;
+    rows.push({
+      playerId: row.playerId,
+      year,
+      canonical: 'allProOffense',
+      label: `First Team All-Pro (${String(row.pos ?? 'Offense')})`,
+      teamId: row.teamId ?? null,
+    });
+  }
+  for (const row of def) {
+    if (row?.playerId == null) continue;
+    rows.push({
+      playerId: row.playerId,
+      year,
+      canonical: 'allProDefense',
+      label: `First Team All-Pro (${String(row.pos ?? 'Defense')})`,
+      teamId: row.teamId ?? null,
+    });
+  }
+  return rows;
+}
+
+/**
+ * @param {string|number} playerId
+ * @param {any[]} accolades from player object
+ * @param {any[]} archivedSeasons newest-first or any order
+ * @param {any[]} teams for abbr lookup
+ */
+export function buildMergedPlayerAwardTimeline(playerId, accolades, archivedSeasons, teams) {
+  const pid = playerId != null ? String(playerId) : '';
+  if (!pid) return { rows: [], dedupeKeys: new Set() };
+
+  const byKey = new Map();
+
+  const addRow = (year, canonical, label, teamId, source) => {
+    const y = Number(year);
+    if (!Number.isFinite(y) || y <= 0) return;
+    const key = dedupeKeyForCanonical(y, canonical);
+    if (byKey.has(key)) return;
+    const teamAbbr = teamAbbrFromId(teamId, teams);
+    byKey.set(key, { year: y, canonical, label, teamAbbr, teamId: teamId ?? null, source });
+  };
+
+  for (const acc of Array.isArray(accolades) ? accolades : []) {
+    const type = String(acc?.type ?? '');
+    const canonical = ACCOLADE_TO_CANONICAL[type] ?? type.toLowerCase();
+    const year = acc?.year ?? acc?.seasonYear;
+    if (canonical === 'sb_ring') {
+      addRow(year, 'sb_ring', 'Super Bowl champion', acc?.teamId ?? null, 'accolade');
+      continue;
+    }
+    const label = (AWARD_LABEL[canonical] ?? type.replaceAll('_', ' ')) || 'Accolade';
+    addRow(year, canonical, label, acc?.teamId ?? null, 'accolade');
+  }
+
+  for (const season of Array.isArray(archivedSeasons) ? archivedSeasons : []) {
+    const year = Number(season?.year ?? 0);
+    if (!Number.isFinite(year)) continue;
+    const awards = season?.awards ?? {};
+    for (const key of ARCHIVE_PLAYER_AWARD_KEYS) {
+      const a = awards[key];
+      if (!a || a.playerId == null) continue;
+      if (String(a.playerId) !== pid) continue;
+      // V1 archives duplicate the same rookie onto both `oroy` and `roty`; show once.
+      if (key === 'oroy' && awards?.roty && String(awards.roty.playerId) === String(a.playerId)) continue;
+      const canonical = key;
+      const label = AWARD_LABEL[key] ?? key;
+      addRow(year, canonical, label, a.teamId ?? null, 'archive');
+    }
+    for (const row of collectAllProArchiveRows(awards, year)) {
+      if (String(row.playerId) !== pid) continue;
+      const key = dedupeKeyForCanonical(year, `${row.canonical}_${row.playerId}_${row.label}`);
+      if (byKey.has(key)) continue;
+      const teamAbbr = teamAbbrFromId(row.teamId, teams);
+      byKey.set(key, { year, canonical: row.canonical, label: row.label, teamAbbr, teamId: row.teamId, source: 'archive' });
+    }
+  }
+
+  const rows = [...byKey.values()].sort((a, b) => b.year - a.year);
+  return { rows, dedupeKeys: new Set(byKey.keys()) };
+}
+
+const SHORT_BADGE = {
+  mvp: 'MVP',
+  opoy: 'OPOY',
+  dpoy: 'DPOY',
+  roty: 'ROTY',
+  oroy: 'OROY',
+  droy: 'DROY',
+  sbMvp: 'SB MVP',
+  bestQB: 'Best QB',
+  bestRB: 'Best RB',
+  bestWrTe: 'Best WR/TE',
+  bestDefensivePlayer: 'Best DP',
+  bestKicker: 'Best K',
+  sb_ring: 'Ring',
+  allProOffense: 'All-Pro',
+  allProDefense: 'All-Pro',
+};
+
+/**
+ * Compact header chips (e.g. "2x MVP", "2031 OPOY"). Omits noisy per-ring lines; rings stay on existing trophy row.
+ * @param {{ rows: any[] }} merged from buildMergedPlayerAwardTimeline
+ */
+export function buildPlayerAwardHeaderBadges(merged) {
+  const rows = merged?.rows ?? [];
+  const chips = [];
+  const mvps = rows.filter((r) => r.canonical === 'mvp').map((r) => r.year).sort((a, b) => b - a);
+  if (mvps.length >= 2) chips.push({ key: 'mvp-count', text: `${mvps.length}x MVP` });
+  else if (mvps.length === 1) chips.push({ key: 'mvp-once', text: `${mvps[0]} MVP` });
+
+  const used = new Set(['mvp', 'sb_ring']);
+  const extras = rows
+    .filter((r) => !used.has(r.canonical) && r.canonical !== 'sb_ring')
+    .sort((a, b) => b.year - a.year);
+
+  const seenCanon = new Set();
+  for (const r of extras) {
+    if (seenCanon.has(r.canonical)) continue;
+    seenCanon.add(r.canonical);
+    const short = SHORT_BADGE[r.canonical] ?? r.label;
+    chips.push({ key: `${r.canonical}-${r.year}`, text: `${r.year} ${short}` });
+    if (chips.length >= 6) break;
+  }
+  return chips;
+}

--- a/src/core/playoffBracketSnapshot.js
+++ b/src/core/playoffBracketSnapshot.js
@@ -1,0 +1,100 @@
+/**
+ * Compact postseason bracket / path view from archived season games.
+ * Pure helpers — no DB, no simulation.
+ */
+
+import { isCompletedGame, isPostseasonGame, resolveGameWinnerLoser } from './championshipInference.js';
+
+const ROUND_ORDER = [
+  { key: 'WILDCARD', label: 'Wild Card' },
+  { key: 'DIVISIONAL', label: 'Divisional' },
+  { key: 'CONF_FINAL', label: 'Conference Championship' },
+  { key: 'CHAMPIONSHIP', label: 'Championship' },
+];
+
+/**
+ * Map a completed postseason game to a coarse round bucket when metadata allows.
+ * Returns null when round cannot be determined without guessing.
+ */
+export function classifyPlayoffRoundBucket(game) {
+  const round = String(game?.playoffRound ?? game?.round ?? game?.stage ?? '').toLowerCase();
+  if (['superbowl', 'super_bowl', 'championship', 'final', 'playoff_final', 'f'].includes(round)) return 'CHAMPIONSHIP';
+  if (game?.isChampionshipGame || game?.isFinal) return 'CHAMPIONSHIP';
+  if (Number(game?.week ?? 0) === 22) return 'CHAMPIONSHIP';
+  if (['wildcard', 'wild_card', 'wc'].includes(round)) return 'WILDCARD';
+  if (['divisional', 'div', 'division'].includes(round)) return 'DIVISIONAL';
+  if (['conference', 'conference_final', 'conf', 'afc_championship', 'nfc_championship'].includes(round)) return 'CONF_FINAL';
+  return null;
+}
+
+function teamAbbrev(teamId, teams) {
+  const t = (teams || []).find((x) => Number(x?.id) === Number(teamId));
+  return t?.abbr ?? (teamId != null ? String(teamId) : '—');
+}
+
+function compactPlayoffGame(g, teams, championshipGameId) {
+  const { winnerId } = resolveGameWinnerLoser(g);
+  const gid = g?.id ?? g?.gameId ?? null;
+  return {
+    id: gid,
+    gameId: gid,
+    week: g?.week ?? null,
+    homeId: g?.homeId ?? null,
+    awayId: g?.awayId ?? null,
+    homeAbbr: teamAbbrev(g?.homeId, teams),
+    awayAbbr: teamAbbrev(g?.awayId, teams),
+    homeScore: g?.homeScore,
+    awayScore: g?.awayScore,
+    winnerId: Number.isFinite(Number(winnerId)) ? Number(winnerId) : null,
+    isChampionshipGame: championshipGameId != null && String(g?.id ?? g?.gameId) === String(championshipGameId),
+  };
+}
+
+/**
+ * @param {{ games?: any[]; teams?: any[]; championshipGameId?: string|number|null }} args
+ * @returns {{ mode: 'empty'|'flat'|'rounds'; rounds: Array<{ label: string; games: any[] }>; note: string|null }}
+ */
+export function buildPlayoffBracketSnapshot({ games = [], teams = [], championshipGameId = null } = {}) {
+  const playoffGames = (games || []).filter((g) => isPostseasonGame(g) && isCompletedGame(g));
+  if (!playoffGames.length) {
+    return { mode: 'empty', rounds: [], note: null };
+  }
+
+  const buckets = playoffGames.map((g) => classifyPlayoffRoundBucket(g));
+  const anyUnknown = buckets.some((b) => b == null);
+
+  const sortByWeek = (a, b) => Number(a?.week ?? 0) - Number(b?.week ?? 0);
+
+  if (anyUnknown) {
+    const sorted = [...playoffGames].sort(sortByWeek);
+    return {
+      mode: 'flat',
+      rounds: [{ label: 'Postseason games', games: sorted.map((g) => compactPlayoffGame(g, teams, championshipGameId)) }],
+      note: 'Round labels are unavailable for some games in this archive; showing all postseason results together.',
+    };
+  }
+
+  const byRound = { WILDCARD: [], DIVISIONAL: [], CONF_FINAL: [], CHAMPIONSHIP: [] };
+  for (const g of playoffGames) {
+    const b = classifyPlayoffRoundBucket(g);
+    if (b && byRound[b]) byRound[b].push(g);
+  }
+  for (const k of Object.keys(byRound)) {
+    byRound[k].sort(sortByWeek);
+  }
+  const rounds = ROUND_ORDER.filter((r) => (byRound[r.key] ?? []).length > 0).map((r) => ({
+    label: r.label,
+    games: byRound[r.key].map((g) => compactPlayoffGame(g, teams, championshipGameId)),
+  }));
+
+  if (!rounds.length) {
+    const sorted = [...playoffGames].sort(sortByWeek);
+    return {
+      mode: 'flat',
+      rounds: [{ label: 'Postseason games', games: sorted.map((g) => compactPlayoffGame(g, teams, championshipGameId)) }],
+      note: 'Playoff results are archived without standard round metadata.',
+    };
+  }
+
+  return { mode: 'rounds', rounds, note: null };
+}

--- a/src/ui/components/HistoryHub.jsx
+++ b/src/ui/components/HistoryHub.jsx
@@ -8,7 +8,7 @@ const DESTINATIONS = [
   { key: 'Awards & Records', title: 'Awards & Records', body: 'Who defined each season and who owns the book.' },
 ];
 
-export default function HistoryHub({ onNavigate, actions, onSelectSeason }) {
+export default function HistoryHub({ onNavigate, actions, onSelectSeason, league = null }) {
   const [seasons, setSeasons] = useState([]);
   useEffect(() => {
     let mounted = true;
@@ -53,12 +53,23 @@ export default function HistoryHub({ onNavigate, actions, onSelectSeason }) {
             No completed seasons are archived yet. History appears automatically after your first full season is completed.
           </div>
         ) : (
-          <div style={{ display: 'grid', gap: 8 }}>
-            {seasons.slice(0, 5).map((season) => (
+          <div style={{ display: 'grid', gap: 8 }} data-testid="history-hub-archived-seasons">
+            {seasons.slice(0, 5).map((season) => {
+              const uid = league?.userTeamId;
+              const userRow = uid != null ? (season?.standings ?? []).find((r) => Number(r?.id) === Number(uid)) : null;
+              const userLine = userRow
+                ? `Your team: ${userRow.wins ?? 0}-${userRow.losses ?? 0}${userRow.ties ? `-${userRow.ties}` : ''}`
+                : season?.userTeamSummary?.record
+                  ? `Your team: ${season.userTeamSummary.record}`
+                  : uid != null
+                    ? 'Your team: —'
+                    : null;
+              return (
               <button
                 key={season.id ?? season.year}
                 className="card clickable-card"
                 style={{ padding: 'var(--space-3)', textAlign: 'left' }}
+                data-testid={`history-hub-season-${season.year}`}
                 onClick={() => {
                   onSelectSeason?.(season.id ?? season.seasonId ?? season.year ?? null);
                   onNavigate?.('History');
@@ -68,10 +79,14 @@ export default function HistoryHub({ onNavigate, actions, onSelectSeason }) {
                   {season.year} · {season?.champion?.abbr ?? season?.champion?.name ?? 'Champion TBD'}
                 </div>
                 <div style={{ marginTop: 4, fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
-                  Runner-up: {season?.runnerUp?.abbr ?? season?.runnerUp?.name ?? 'Unavailable'} · MVP: {season?.awards?.mvp?.name ?? 'Unavailable'}
+                  Runner-up: {season?.runnerUp?.abbr ?? season?.runnerUp?.name ?? '—'} · MVP: {season?.awards?.mvp?.name ?? '—'}
                 </div>
+                {userLine ? (
+                  <div style={{ marginTop: 4, fontSize: 'var(--text-xs)', color: 'var(--text-subtle)' }}>{userLine}</div>
+                ) : null}
+                <div style={{ marginTop: 6, fontSize: 'var(--text-xs)', fontWeight: 700, color: 'var(--accent)' }}>View season →</div>
               </button>
-            ))}
+            );})}
           </div>
         )}
       </SectionCard>

--- a/src/ui/components/HistoryHub.test.jsx
+++ b/src/ui/components/HistoryHub.test.jsx
@@ -35,6 +35,38 @@ describe('HistoryHub', () => {
     await waitFor(() => {
       expect(screen.getByText(/2026 · DAL/)).toBeTruthy();
       expect(screen.getByText(/Runner-up: NYG · MVP: Ace QB/)).toBeTruthy();
+      expect(screen.getByText(/View season →/)).toBeTruthy();
+    });
+  });
+
+  it('shows user team record on archived cards when standings include the user franchise', async () => {
+    render(
+      <HistoryHub
+        league={{ userTeamId: 2 }}
+        onNavigate={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                {
+                  id: 's1',
+                  year: 2026,
+                  champion: { abbr: 'DAL' },
+                  runnerUp: { abbr: 'NYG' },
+                  awards: { mvp: { name: 'Ace QB' } },
+                  standings: [
+                    { id: 1, wins: 8, losses: 9 },
+                    { id: 2, wins: 11, losses: 6 },
+                  ],
+                },
+              ],
+            },
+          }),
+        }}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/Your team: 11-6/)).toBeTruthy();
     });
   });
 

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -1196,7 +1196,7 @@ export default function LeagueDashboard({
         )}
         {activeTab === "History Hub" && (
           <TabErrorBoundary label="History Hub">
-            <HistoryHub onNavigate={setActiveTab} actions={actions} onSelectSeason={setHistorySelectedSeasonId} />
+            <HistoryHub onNavigate={setActiveTab} actions={actions} onSelectSeason={setHistorySelectedSeasonId} league={league} />
           </TabErrorBoundary>
         )}
         {activeTab === "History" && (

--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -48,6 +48,27 @@ const STAT_LABELS = {
 };
 const NOOP_ACTIONS = {};
 const AWARD_KEYS = ["mvp", "opoy", "dpoy", "roty", "sbMvp"];
+const AWARDS_V1_EXTRA = ["oroy", "droy", "bestQB", "bestRB", "bestWrTe", "bestDefensivePlayer", "bestKicker"];
+const AWARDS_V1_LABELS = {
+  bestQB: "Best QB",
+  bestRB: "Best RB",
+  bestWrTe: "Best WR/TE",
+  bestDefensivePlayer: "Best Defensive Player",
+  bestKicker: "Best Kicker",
+};
+
+const PLAYER_LEADER_LABELS = {
+  passingYards: "Passing yards",
+  passingTd: "Passing TD",
+  rushingYards: "Rushing yards",
+  rushingTd: "Rushing TD",
+  receivingYards: "Receiving yards",
+  receivingTd: "Receiving TD",
+  tackles: "Tackles",
+  sacks: "Sacks",
+  interceptions: "Interceptions",
+  fieldGoalsMade: "Field goals",
+};
 
 function pct(row) {
   const wins = Number(row?.wins ?? 0);
@@ -266,6 +287,11 @@ function SeasonExplorer({ seasons, onPlayerSelect, onOpenBoxScore, league, initi
   const championBoard = buildChampionMap(seasons).slice(0, 5);
   const playoffMentions = (selected?.standings ?? []).filter((row) => Number(row?.wins ?? 0) >= 10).slice(0, 6);
   const seasonStoryline = summarizeSeasonStoryline(selected, league?.userTeamId);
+  const teamLookup = (tid) => (selected?.standings ?? []).find((t) => Number(t?.id) === Number(tid));
+  const highScoreGame = (selected?.notableGames ?? []).find((g) => g?.type === "highest_scoring") ?? null;
+  const playerStatLeaders = selected?.playerStatLeaders && typeof selected.playerStatLeaders === "object" ? selected.playerStatLeaders : null;
+  const teamStatLeaders = selected?.teamStatLeaders && typeof selected.teamStatLeaders === "object" ? selected.teamStatLeaders : null;
+  const playoffSnap = selected?.playoffBracketSnapshot ?? null;
   const awardLeaders = AWARD_KEYS
     .map((key) => ({ key, label: AWARD_DISPLAY_NAMES[key] ?? key.toUpperCase(), award: selected?.awards?.[key] }))
     .filter((entry) => entry.award?.name);
@@ -305,6 +331,52 @@ function SeasonExplorer({ seasons, onPlayerSelect, onOpenBoxScore, league, initi
             <button className="btn" onClick={() => selectedSeasonIndex < seasons.length - 1 && setSelectedSeasonId(seasons[selectedSeasonIndex + 1].id)} disabled={selectedSeasonIndex >= seasons.length - 1}>Next season</button>
           </div>
           <div className="rounded-md border border-[color:var(--hairline)] px-3 py-2 text-sm text-[color:var(--text-muted)]">{seasonStoryline}</div>
+
+          <section className="rounded-xl border border-[color:var(--hairline)] bg-[color:var(--surface-strong)]/40 p-4 space-y-3" data-testid={`league-history-season-story-${selected?.id ?? 'none'}`}>
+            <div className="text-xs font-black uppercase tracking-wide text-[color:var(--text-subtle)]">Season story</div>
+            <div className="text-lg font-black text-[color:var(--text)]">
+              {selected?.champion?.abbr ?? selected?.champion?.name ?? "Champion TBD"}
+              {selected?.runnerUp?.abbr || selected?.runnerUp?.name ? (
+                <span className="text-[color:var(--text-muted)] font-semibold text-base"> over {selected?.runnerUp?.abbr ?? selected?.runnerUp?.name}</span>
+              ) : null}
+            </div>
+            <div className="text-sm text-[color:var(--text-muted)]">
+              MVP:{" "}
+              {selected?.awards?.mvp?.name ? (
+                <button type="button" className="text-[color:var(--accent)] font-semibold" onClick={() => onPlayerSelect?.(selected.awards.mvp.playerId)}>
+                  {selected.awards.mvp.name}
+                </button>
+              ) : (
+                "—"
+              )}
+            </div>
+            {highScoreGame ? (
+              <div className="text-sm">
+                <span className="text-[color:var(--text-muted)]">Highest-scoring game: </span>
+                <span className="font-semibold">
+                  {teamLookup(highScoreGame.awayId)?.abbr ?? "Away"} {highScoreGame.awayScore ?? "—"} at {teamLookup(highScoreGame.homeId)?.abbr ?? "Home"} {highScoreGame.homeScore ?? "—"}
+                </span>
+                {highScoreGame.totalPoints != null ? (
+                  <span className="text-[color:var(--text-muted)]"> ({highScoreGame.totalPoints} pts)</span>
+                ) : null}
+                {highScoreGame.gameId != null && onOpenBoxScore ? (
+                  <button type="button" className="ml-2 text-xs text-[color:var(--accent)]" onClick={() => openResolvedBoxScore({ id: highScoreGame.gameId, week: highScoreGame.week, homeId: highScoreGame.homeId, awayId: highScoreGame.awayId, homeScore: highScoreGame.homeScore, awayScore: highScoreGame.awayScore }, { seasonId: selected?.year, week: highScoreGame.week, source: "league_history_story" }, onOpenBoxScore)}>
+                    Game Book
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
+            {teamStatLeaders?.pointsPerGame?.teamAbbr ? (
+              <div className="text-sm text-[color:var(--text-muted)]">
+                Best offense (PPG): <span className="font-semibold text-[color:var(--text)]">{teamStatLeaders.pointsPerGame.teamAbbr}</span> ({teamStatLeaders.pointsPerGame.value})
+              </div>
+            ) : null}
+            {teamStatLeaders?.pointsAllowed?.teamAbbr ? (
+              <div className="text-sm text-[color:var(--text-muted)]">
+                Best defense (Pts allowed / game): <span className="font-semibold text-[color:var(--text)]">{teamStatLeaders.pointsAllowed.teamAbbr}</span> ({teamStatLeaders.pointsAllowed.value})
+              </div>
+            ) : null}
+          </section>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
             <SummaryBox label="Champion" value={selected?.champion?.name ?? "TBD"} />
@@ -350,6 +422,48 @@ function SeasonExplorer({ seasons, onPlayerSelect, onOpenBoxScore, league, initi
             </div>
           </section>
 
+          <section data-testid={`league-history-playoff-bracket-${selected?.id ?? 'none'}`}>
+            <h4 className="text-sm font-bold mb-2">Playoff snapshot</h4>
+            {!playoffSnap || playoffSnap.mode === "empty" ? (
+              <div className="text-xs text-[color:var(--text-muted)] rounded-md border border-[color:var(--hairline)] px-3 py-2">
+                No postseason bracket snapshot is stored for this season. Complete a playoff run and re-archive (or use a newer save) to see round-by-round results here.
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {playoffSnap.note ? <div className="text-xs text-[color:var(--text-muted)]">{playoffSnap.note}</div> : null}
+                {(playoffSnap.rounds ?? []).map((round) => (
+                  <div key={round.label} className="rounded-md border border-[color:var(--hairline)] p-3 space-y-2">
+                    <div className="text-xs font-bold uppercase tracking-wide text-[color:var(--text-subtle)]">{round.label}</div>
+                    <div className="grid gap-2">
+                      {(round.games ?? []).map((g) => {
+                        const presentation = buildCompletedGamePresentation(g, { seasonId: selected?.year, week: g?.week, source: "league_history_playoff" });
+                        const clickable = Boolean(presentation.canOpen && onOpenBoxScore && g.gameId != null);
+                        return (
+                          <div key={String(g.gameId ?? `${g.week}-${g.homeId}-${g.awayId}`)} className="flex flex-wrap items-center justify-between gap-2 text-sm border-b border-[color:var(--hairline)]/60 pb-2 last:border-0 last:pb-0">
+                            <div>
+                              <span className="text-[color:var(--text-muted)] text-xs">Wk {g.week ?? "—"}</span>{" "}
+                              <span className="font-semibold">{g.awayAbbr} {g.awayScore ?? "—"} @ {g.homeAbbr} {g.homeScore ?? "—"}</span>
+                              {g.winnerId != null ? (
+                                <span className="text-xs text-[color:var(--text-muted)]"> · Winner: {teamLookup(g.winnerId)?.abbr ?? g.winnerId}</span>
+                              ) : null}
+                            </div>
+                            {clickable ? (
+                              <button type="button" className="text-xs text-[color:var(--accent)] shrink-0" onClick={() => openResolvedBoxScore({ id: g.gameId, week: g.week, homeId: g.homeId, awayId: g.awayId, homeScore: g.homeScore, awayScore: g.awayScore }, { seasonId: selected?.year, week: g.week, source: "league_history_playoff" }, onOpenBoxScore)}>
+                                Game Book
+                              </button>
+                            ) : (
+                              <span className="text-xs text-[color:var(--text-muted)]">{presentation.statusLabel}</span>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
           <section>
             <h4 className="text-sm font-bold mb-2">Awards & Leaders</h4>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
@@ -365,10 +479,46 @@ function SeasonExplorer({ seasons, onPlayerSelect, onOpenBoxScore, league, initi
                 </button>
               ))}
             </div>
-            <div className="text-xs text-[color:var(--text-muted)] mt-2">
-              Playoff bracket/path is not currently stored in archived season summaries.
+            <div className="mt-3 rounded-md border border-[color:var(--hairline)] p-3" data-testid="league-history-award-winners-card">
+              <div className="text-xs font-bold uppercase tracking-wide text-[color:var(--text-subtle)] mb-2">Full award sheet</div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
+                {AWARDS_V1_EXTRA.map((k) => {
+                  const a = selected?.awards?.[k];
+                  if (!a?.name) return null;
+                  return (
+                    <div key={k} className="flex justify-between gap-2 border-b border-[color:var(--hairline)]/50 pb-1">
+                      <span className="text-[color:var(--text-muted)]">{AWARD_DISPLAY_NAMES[k] ?? AWARDS_V1_LABELS[k] ?? k}</span>
+                      <button type="button" className="font-semibold text-[color:var(--accent)] text-right" onClick={() => a.playerId != null && onPlayerSelect?.(a.playerId)}>
+                        {a.name}
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
             </div>
           </section>
+
+          {playerStatLeaders && Object.keys(playerStatLeaders).length > 0 ? (
+            <section data-testid={`league-history-player-stat-leaders-${selected?.id ?? 'none'}`}>
+              <h4 className="text-sm font-bold mb-2">Stat leaders</h4>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm">
+                {Object.entries(playerStatLeaders).map(([key, row]) => {
+                  if (!row?.playerName) return null;
+                  return (
+                    <div key={key} className="rounded-md border border-[color:var(--hairline)] px-3 py-2 flex justify-between gap-2">
+                      <span className="text-[color:var(--text-muted)] text-xs uppercase">{PLAYER_LEADER_LABELS[key] ?? key}</span>
+                      <span className="text-right">
+                        <button type="button" className="text-[color:var(--accent)] font-semibold" onClick={() => row.playerId != null && onPlayerSelect?.(row.playerId)}>
+                          {row.playerName}
+                        </button>
+                        <span className="text-[color:var(--text-muted)] text-xs"> {row.value != null ? `· ${row.value}` : ""}</span>
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          ) : null}
           <section>
             <h4 className="text-sm font-bold mb-2">Completed game archive</h4>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm">

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -28,6 +28,7 @@ import EmptyState from './EmptyState.jsx';
 import { buildRouteRequestKey, buildLeagueCacheScopeKey } from "../utils/requestLoopGuard.js";
 import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 import { getPlayerGameLogs } from "../utils/playerGameLogs.js";
+import { buildMergedPlayerAwardTimeline, buildPlayerAwardHeaderBadges } from "../../core/playerAwardTimeline.js";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
@@ -407,6 +408,7 @@ export default function PlayerProfile({
 }) {
 
   const [data, setData] = useState(null);
+  const [archivedSeasons, setArchivedSeasons] = useState([]);
   const [extending, setExtending] = useState(false);
   const [showProjections, setShowProjections] = useState(false);
   const [activeProfileTab, setActiveProfileTab] = useState("Overview");
@@ -435,6 +437,26 @@ export default function PlayerProfile({
       console.error("Failed to load player profile:", requestError);
     }
   }, [requestError]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!actions?.getAllSeasons || playerId == null) {
+      setArchivedSeasons([]);
+      return () => { cancelled = true; };
+    }
+    actions
+      .getAllSeasons()
+      .then((res) => {
+        if (cancelled) return;
+        setArchivedSeasons(res?.payload?.seasons ?? res?.seasons ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setArchivedSeasons([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [actions, playerId]);
 
 
   useEffect(() => {
@@ -481,6 +503,19 @@ export default function PlayerProfile({
   const nonRing = accolades
     .filter((a) => a.type !== "SB_RING")
     .sort((a, b) => b.year - a.year);
+  const mergedAwardTimeline = useMemo(
+    () => buildMergedPlayerAwardTimeline(
+      effectivePlayer?.id,
+      Array.isArray(effectivePlayer?.accolades) ? effectivePlayer.accolades : [],
+      archivedSeasons,
+      teams,
+    ),
+    [effectivePlayer?.id, effectivePlayer?.accolades, archivedSeasons, teams],
+  );
+  const awardHeaderBadges = useMemo(
+    () => buildPlayerAwardHeaderBadges(mergedAwardTimeline),
+    [mergedAwardTimeline],
+  );
   const summaryChips = getPlayerSummaryChips(player, ringCount, nonRing);
   const accoladesByYear = [...accolades].sort((a, b) => (a.year ?? 0) - (b.year ?? 0));
   const teamJourney = [...new Set((player?.careerStats ?? []).map((line) => line.team).filter(Boolean))];
@@ -886,7 +921,7 @@ export default function PlayerProfile({
                 )}
 
                 {/* ── Accolades / Legacy ── */}
-                {(ringCount > 0 || nonRing.length > 0) && (
+                {(ringCount > 0 || nonRing.length > 0 || awardHeaderBadges.length > 0) && (
                   <div
                     style={{
                       marginTop: "var(--space-3)",
@@ -900,21 +935,27 @@ export default function PlayerProfile({
                         🏆 {ringCount}x SB Champ
                       </span>
                     )}
-                    {nonRing.map((acc, i) => {
-                      const meta = ACCOLADE_META[acc.type];
-                      if (!meta) return null;
-                      return (
-                        <span
-                          key={i}
-                          style={badgeStyle(
-                            "var(--accent)",
-                            "var(--surface-strong)",
-                          )}
-                        >
-                          {meta.icon} {meta.label(acc.year)}
-                        </span>
-                      );
-                    })}
+                    {mergedAwardTimeline.rows.length > 0
+                      ? awardHeaderBadges.map((chip) => (
+                          <span key={chip.key} style={badgeStyle("var(--accent)", "var(--surface-strong)")}>
+                            {chip.text}
+                          </span>
+                        ))
+                      : nonRing.map((acc, i) => {
+                          const meta = ACCOLADE_META[acc.type];
+                          if (!meta) return null;
+                          return (
+                            <span
+                              key={i}
+                              style={badgeStyle(
+                                "var(--accent)",
+                                "var(--surface-strong)",
+                              )}
+                            >
+                              {meta.icon} {meta.label(acc.year)}
+                            </span>
+                          );
+                        })}
                   </div>
                 )}
 
@@ -1345,16 +1386,37 @@ export default function PlayerProfile({
             </section>
           )}
 
-          {accoladesByYear.length > 0 && (
-            <section className="card-enter">
-              <h3 style={sectionLabelStyle}>Awards Timeline</h3>
-              <div style={{ display: "grid", gap: 4 }}>
-                {accoladesByYear.slice(-12).map((acc, idx) => (
-                  <div key={`${acc.type}-${acc.year}-${idx}`} style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
-                    <strong style={{ color: "var(--text)" }}>{acc.year ?? "—"}</strong> · {acc.type}
-                  </div>
-                ))}
-              </div>
+          {!loading && playerView && (
+            <section className="card-enter" data-testid="player-profile-award-timeline">
+              <h3 style={sectionLabelStyle}>Awards &amp; honors</h3>
+              {mergedAwardTimeline.rows.length === 0 ? (
+                <p style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)", margin: 0 }}>No archived awards yet.</p>
+              ) : (
+                <div style={{ display: "grid", gap: 8 }}>
+                  {mergedAwardTimeline.rows.map((row, idx) => (
+                    <div
+                      key={`${row.year}-${row.canonical}-${idx}`}
+                      style={{
+                        fontSize: "var(--text-sm)",
+                        display: "flex",
+                        flexWrap: "wrap",
+                        justifyContent: "space-between",
+                        gap: 8,
+                        borderBottom: "1px solid var(--hairline)",
+                        paddingBottom: 6,
+                      }}
+                    >
+                      <span>
+                        <strong style={{ color: "var(--text)" }}>{row.year}</strong>
+                        <span style={{ color: "var(--text-muted)", marginLeft: 6 }}>{row.label}</span>
+                      </span>
+                      <span style={{ color: "var(--text-subtle)", fontSize: "var(--text-xs)" }}>
+                        {row.teamAbbr ? `${row.teamAbbr}` : "—"}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
             </section>
           )}
 

--- a/src/ui/components/__tests__/LeagueHistory.test.jsx
+++ b/src/ui/components/__tests__/LeagueHistory.test.jsx
@@ -31,6 +31,65 @@ describe('LeagueHistory', () => {
     await waitFor(() => {
       expect(screen.getByText(/2031 League Snapshot/i)).toBeTruthy();
       expect(screen.getByText(/Championship result is unavailable in this archive/i)).toBeTruthy();
+      expect(screen.getByTestId('league-history-season-story-s2')).toBeTruthy();
+    });
+  });
+
+  it('renders playoff snapshot when archived bracket data exists', async () => {
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        initialSelectedSeasonId="s2"
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                {
+                  id: 's2',
+                  year: 2031,
+                  champion: { id: 1, name: 'Dallas', abbr: 'DAL' },
+                  runnerUp: { id: 2, name: 'NYG', abbr: 'NYG' },
+                  awards: { mvp: { playerId: 9, name: 'Star', teamId: 1 } },
+                  standings: [
+                    { id: 1, name: 'Dallas', abbr: 'DAL', wins: 12, losses: 5 },
+                    { id: 2, name: 'NYG', abbr: 'NYG', wins: 11, losses: 6 },
+                  ],
+                  notableGames: [{ type: 'highest_scoring', gameId: 'gx', week: 3, homeId: 1, awayId: 2, homeScore: 40, awayScore: 38, totalPoints: 78 }],
+                  playerStatLeaders: { passingYards: { playerId: 9, playerName: 'Star', value: 4200 } },
+                  teamStatLeaders: {
+                    pointsPerGame: { teamAbbr: 'DAL', value: 28.5 },
+                    pointsAllowed: { teamAbbr: 'NYG', value: 17.2 },
+                  },
+                  playoffBracketSnapshot: {
+                    mode: 'rounds',
+                    note: null,
+                    rounds: [
+                      {
+                        label: 'Wild Card',
+                        games: [{ id: 'g1', gameId: 'g1', week: 19, homeId: 1, awayId: 2, homeAbbr: 'DAL', awayAbbr: 'NYG', homeScore: 24, awayScore: 17, winnerId: 1 }],
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          }),
+          getRecords: vi.fn().mockResolvedValue({ payload: { records: null } }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      const playoffPanels = screen.queryAllByTestId('league-history-playoff-bracket-s2');
+      const playoff = playoffPanels.find((el) => el.textContent.includes('Wild Card')) ?? playoffPanels[playoffPanels.length - 1];
+      expect(playoff?.textContent ?? '').toMatch(/Wild Card/i);
+      const leaderPanels = screen.queryAllByTestId('league-history-player-stat-leaders-s2');
+      const leaders = leaderPanels.find((el) => el.textContent.includes('Star')) ?? leaderPanels[leaderPanels.length - 1];
+      expect(leaders?.textContent ?? '').toMatch(/Star/i);
     });
   });
 

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -27,7 +27,10 @@ const league = {
   schedule: { weeks: [] },
 };
 
-const actions = { getPlayerCareer: vi.fn(async () => null) };
+const actions = {
+  getPlayerCareer: vi.fn(async () => null),
+  getAllSeasons: vi.fn(async () => ({ payload: { seasons: [] } })),
+};
 
 describe('PlayerProfile', () => {
   beforeEach(() => {
@@ -150,5 +153,42 @@ describe('PlayerProfile', () => {
     expect(onOpenBoxScore).toHaveBeenCalledWith('g1');
     fireEvent.click(screen.getByRole('button', { name: 'Return to HQ' }));
     expect(onNavigate).toHaveBeenCalledWith('HQ');
+  });
+
+  it('shows honest empty award timeline when no honors exist', async () => {
+    render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={actions} teams={league.teams} league={league} />);
+    await waitFor(() => expect(screen.getByTestId('player-profile-award-timeline')).toBeTruthy());
+    expect(screen.getByTestId('player-profile-award-timeline').textContent).toMatch(/No archived awards yet/i);
+  });
+
+  it('merges archived season awards with player accolades without duplicate MVP rows', async () => {
+    const careerActions = {
+      getPlayerCareer: vi.fn(async () => ({
+        payload: {
+          player: {
+            ...player,
+            accolades: [{ type: 'MVP', year: 2030, seasonId: 's1' }],
+          },
+          stats: [],
+          teammates: [],
+          meta: {},
+        },
+      })),
+      getAllSeasons: vi.fn(async () => ({
+        payload: {
+          seasons: [
+            {
+              id: 's1',
+              year: 2030,
+              awards: { mvp: { playerId: 11, name: 'Avery Fields', teamId: 1 } },
+            },
+          ],
+        },
+      })),
+    };
+    render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={careerActions} teams={league.teams} league={league} />);
+    await waitFor(() => expect(screen.getByTestId('player-profile-award-timeline').textContent).toMatch(/Most Valuable Player/i));
+    const block = screen.getByTestId('player-profile-award-timeline').textContent;
+    expect((block.match(/Most Valuable Player/g) ?? []).length).toBe(1);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Connects archived season awards and postseason games into Player Profile, League History season detail, and History Hub preview cards—without new simulation logic or full History UI rewrites.

### Player Profile award timeline

- New pure helper `src/core/playerAwardTimeline.js`: `buildMergedPlayerAwardTimeline()` walks `player.accolades` first, then each archived season’s `awards` (MVP/OPOY/DPOY/ROTY/OROY/DROY/SB MVP/best-by-position) plus flattened `allPro.firstTeamOffense` / `firstTeamDefense` rows when `playerId` matches.
- Rows are sorted **newest → oldest** with optional `teamAbbr` from the current `teams` list.
- **Duplicate avoidance:** a stable dedupe key `"{canonical}_{year}"` (and composite keys for All-Pro rows) ensures the same honor is not listed twice when it exists both on `player.accolades` and in season `awards` (e.g. MVP). OROY rows are skipped when ROTY already references the same player for that season (matches V1 duplicate wiring in the worker).

### Header badges

- `buildPlayerAwardHeaderBadges()` derives compact chips (e.g. `2x MVP`, `2031 OPOY`) from the merged rows. Championship rings stay on the existing gold **SB Champ** row; extra chips omit `sb_ring` to avoid duplication.

### Playoff bracket snapshots

- New `src/core/playoffBracketSnapshot.js` filters games with `isPostseasonGame` + `isCompletedGame` from `src/core/championshipInference.js`—**regular-season games never qualify**.
- When every game maps to a known `playoffRound` / `round` / `stage` (or championship week 22 / final labels), rounds are **Wild Card → Divisional → Conference Championship → Championship**.
- If any postseason game lacks round metadata, **one** truthful bucket **“Postseason games”** is used with an explanatory note (no invented rounds).
- `buildSeasonArchiveSummary()` in `src/core/league-memory.js` now attaches a compact `playoffBracketSnapshot` object built from the full `games[]` passed at archive time (small structure only; no duplicate of the full schedule payload).

### League History season detail

- **Season story** card: champion vs runner-up headline, MVP link, highest-scoring game (from `notableGames`), best offense/defense from `teamStatLeaders` when present.
- **Playoff snapshot** section renders `playoffBracketSnapshot` with week, scoreline, winner abbr from standings, and **Game Book** when a resolvable game id exists.
- **Full award sheet** for V1 keys (best QB/RB/WR-TE/defensive player/kicker, OROY/DROY) and existing **Stat leaders** block from archived `playerStatLeaders`.
- Legacy seasons without `playoffBracketSnapshot` show an honest empty message.

### History Hub

- Passes `league` from `LeagueDashboard` so cards can show **your** record when `standings` (or `userTeamSummary.record`) is available; **View season →** reinforces navigation.

### Old saves / empty states

- Missing `accolades`, `awards`, `playoffBracketSnapshot`, or `playerStatLeaders`: guarded optional chaining; Player Profile shows **“No archived awards yet.”** when the merged list is empty; League History shows the postseason copy instead of crashing.

### Tests run (all passing)

- `npm run test:unit` — 637 tests
- `npm run build`
- `npm run check:deploy`
- `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js`

### Known limitations (explicitly out of scope)

- **Hall of Fame** depth, narrative classes, and **all-time records** hub remain future work; this PR only surfaces what is already archived.
- Playoff snapshots for **seasons archived before this change** have no stored snapshot (game index alone does not carry `isPlayoff` / round flags).
- All-Pro display is first-team offense/defense only when present in archive; no second-team or legacy accolade types beyond what the save already stores.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9e497b9-e83c-4336-a82f-93db66992147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9e497b9-e83c-4336-a82f-93db66992147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

