### PR TITLE
Hall of Fame V1 + Legacy Score (dynasty memory)

### DIFF
--- a/src/core/league-memory.js
+++ b/src/core/league-memory.js
@@ -4,17 +4,12 @@ import {
   mirrorRecordBookForLegacyUi,
   defensiveInterceptionsSeasonValue,
 } from './recordBookV1.js';
-
-const POSITION_HOF_BASELINE = {
-  QB: 12000,
-  RB: 8000,
-  WR: 9000,
-  TE: 7000,
-  DL: 220,
-  LB: 260,
-  CB: 180,
-  S: 160,
-};
+import {
+  buildLegacyScoreReport,
+  HOF_LEGACY_INDUCT_THRESHOLD,
+  HOF_MIN_SEASONS,
+} from './legacyScore.js';
+import { getMostPlayedTeam } from './records.js';
 
 const REVIEW_PREMIUM_POSITIONS = new Set(['QB', 'WR', 'OT', 'EDGE', 'DE', 'CB']);
 
@@ -39,7 +34,7 @@ export function createLeagueMemoryDefaults() {
   return {
     leagueHistory: [],
     seasonStorylines: [],
-    hallOfFame: { classes: [], index: {} },
+    hallOfFame: { schemaVersion: 1, classes: [], index: {} },
     franchiseHistoryByTeam: {},
     recordBook: {
       singleGame: Object.fromEntries(RECORD_CATEGORIES.map((c) => [c.key, blankRecord()])),
@@ -68,6 +63,7 @@ export function ensureLeagueMemoryMeta(meta = {}) {
     leagueHistory: Array.isArray(meta.leagueHistory) ? meta.leagueHistory : defaults.leagueHistory,
     seasonStorylines: Array.isArray(meta.seasonStorylines) ? meta.seasonStorylines : defaults.seasonStorylines,
     hallOfFame: {
+      schemaVersion: meta?.hallOfFame?.schemaVersion ?? defaults.hallOfFame.schemaVersion,
       classes: Array.isArray(meta?.hallOfFame?.classes) ? meta.hallOfFame.classes : defaults.hallOfFame.classes,
       index: meta?.hallOfFame?.index && typeof meta.hallOfFame.index === 'object' ? meta.hallOfFame.index : defaults.hallOfFame.index,
     },
@@ -656,38 +652,115 @@ export function updateRecordBook(memoryMeta, { allPlayers = [] } = {}) {
   return { ...memoryMeta, recordBook: next, recordEvents: [] };
 }
 
-export function evaluateHallOfFameCandidate(player, year) {
-  const accolades = Array.isArray(player?.accolades) ? player.accolades : [];
-  const careerStats = Array.isArray(player?.careerStats) ? player.careerStats : [];
-  const seasons = careerStats.length;
-  const statTotal = player.pos === 'QB'
-    ? careerStats.reduce((s, line) => s + Number(line?.passYds ?? 0), 0)
-    : player.pos === 'RB'
-      ? careerStats.reduce((s, line) => s + Number(line?.rushYds ?? 0), 0)
-      : ['WR', 'TE'].includes(player.pos)
-        ? careerStats.reduce((s, line) => s + Number(line?.recYds ?? 0), 0)
-        : careerStats.reduce((s, line) => s + Number(line?.tackles ?? 0) + Number(line?.sacks ?? 0) * 8, 0);
-
-  const baseline = POSITION_HOF_BASELINE[player.pos] ?? 9000;
-  const mvps = accolades.filter((a) => a.type === 'MVP').length;
-  const titles = accolades.filter((a) => a.type === 'SB_RING').length;
-  const peak = careerStats.reduce((m, line) => Math.max(m, Number(line?.ovr ?? 0)), Number(player?.ovr ?? 0));
-  const score = (statTotal / baseline) * 60 + mvps * 12 + titles * 8 + Math.max(0, seasons - 8) * 1.5 + Math.max(0, peak - 82);
-  const inducted = score >= 78;
-  const reasons = [];
-  if (statTotal >= baseline) reasons.push('Elite career production for position');
-  if (mvps > 0) reasons.push(`${mvps} MVP award${mvps > 1 ? 's' : ''}`);
-  if (titles > 0) reasons.push(`${titles} championship ring${titles > 1 ? 's' : ''}`);
-  if (seasons >= 10) reasons.push(`Long career (${seasons} seasons)`);
-  if (peak >= 92) reasons.push(`Peak dominance (OVR ${peak})`);
-  return { inducted, score: Math.round(score * 10) / 10, reasons: reasons.slice(0, 4), year };
+/**
+ * @param {object} player — usually still active when called from retirement loop
+ * @param {number} year — class / evaluation year (league year)
+ * @param {{ recordBook?: object, archivedSeasons?: any[], teams?: any[] }} [options]
+ */
+export function evaluateHallOfFameCandidate(player, year, options = {}) {
+  const { recordBook = null, archivedSeasons = [], teams = [] } = options;
+  const report = buildLegacyScoreReport(player, { recordBook, archivedSeasons, teams, year });
+  const seasons = report.meta?.seasonsPlayed ?? 0;
+  const inducted = seasons >= HOF_MIN_SEASONS && report.legacyScore >= HOF_LEGACY_INDUCT_THRESHOLD;
+  return {
+    inducted,
+    score: report.legacyScore,
+    reasons: report.reasons.slice(0, 4),
+    year,
+    report,
+  };
 }
 
+export function rebuildHallOfFameIndexFromClasses(classes) {
+  const index = {};
+  for (const c of classes || []) {
+    for (const ind of c.inductees || []) {
+      if (ind?.playerId != null) index[String(ind.playerId)] = ind;
+    }
+  }
+  return index;
+}
+
+/**
+ * @param {object} player
+ * @param {ReturnType<typeof buildLegacyScoreReport>} report
+ * @param {{ teamAbbrMap?: Record<string|number, string>, teams?: any[] }} ctx
+ */
+export function buildHallOfFameInducteeRow(player, report, ctx = {}) {
+  const { teamAbbrMap = {}, teams = [] } = ctx;
+  const abbr = getMostPlayedTeam(player, teamAbbrMap) || null;
+  const team = (teams || []).find((t) => String(t?.abbr) === String(abbr));
+  const legacyScore = report.legacyScore;
+  return {
+    playerId: player.id,
+    name: player.name,
+    pos: player.pos,
+    primaryTeamId: team?.id ?? null,
+    primaryTeamAbbr: abbr,
+    legacyScore,
+    tier: report.tier,
+    reasons: (report.reasons || []).slice(0, 4),
+    score: legacyScore,
+    careerSummary: report.careerSummary || '',
+    awardsSummary: report.awardsSummary || '',
+    recordsSummary: report.recordsSummary || '',
+    breakdown: report.breakdown ?? null,
+  };
+}
+
+/**
+ * Merge inductees into the class for `classYear` (same playerId overwrites with newer fields).
+ */
 export function addHallOfFameClass(memoryMeta, classYear, inductees) {
   if (!inductees?.length) return memoryMeta;
-  const classes = [...memoryMeta.hallOfFame.classes.filter((c) => c.year !== classYear), { year: classYear, inductees }]
-    .sort((a, b) => b.year - a.year);
-  const index = { ...memoryMeta.hallOfFame.index };
-  for (const ind of inductees) index[String(ind.playerId)] = ind;
-  return { ...memoryMeta, hallOfFame: { classes, index } };
+  const prev = memoryMeta.hallOfFame?.classes ?? [];
+  const y = Number(classYear);
+  const existing = prev.find((c) => Number(c.year) === y);
+  const byId = new Map();
+  for (const x of existing?.inductees ?? []) {
+    if (x?.playerId != null) byId.set(String(x.playerId), { ...x });
+  }
+  for (const x of inductees) {
+    if (x?.playerId == null) continue;
+    const id = String(x.playerId);
+    byId.set(id, { ...(byId.get(id) || {}), ...x });
+  }
+  const merged = [...byId.values()];
+  if (!merged.length) return memoryMeta;
+  const classId = existing?.classId ?? `hof-${y}`;
+  const nextClass = { year: y, classId, inductees: merged };
+  const classes = [...prev.filter((c) => Number(c.year) !== y), nextClass].sort((a, b) => b.year - a.year);
+  const index = rebuildHallOfFameIndexFromClasses(classes);
+  return {
+    ...memoryMeta,
+    hallOfFame: {
+      schemaVersion: memoryMeta.hallOfFame?.schemaVersion ?? 1,
+      classes,
+      index,
+    },
+  };
+}
+
+/**
+ * After record book refresh, induct any retired greats not yet in the index.
+ * @returns {{ memoryMeta: object, newInductees: object[] }}
+ */
+export function syncHallOfFameAfterRecordBook(memoryMeta, allPlayers, classYear, opts = {}) {
+  const { teams = [], teamAbbrMap = {} } = opts;
+  const archivedSeasons = memoryMeta.leagueHistory ?? [];
+  const book = memoryMeta.recordBook;
+  const index = memoryMeta.hallOfFame?.index ?? {};
+  const toAdd = [];
+  for (const p of allPlayers || []) {
+    if (!p || String(p.status) !== 'retired') continue;
+    if (index[String(p.id)] != null) continue;
+    if (p.hof === true) continue;
+    const report = buildLegacyScoreReport(p, { recordBook: book, archivedSeasons, teams });
+    if ((report.meta?.seasonsPlayed ?? 0) < HOF_MIN_SEASONS) continue;
+    if (report.legacyScore < HOF_LEGACY_INDUCT_THRESHOLD) continue;
+    toAdd.push(buildHallOfFameInducteeRow(p, report, { teamAbbrMap, teams }));
+  }
+  if (!toAdd.length) return { memoryMeta, newInductees: [] };
+  const nextMeta = addHallOfFameClass(memoryMeta, classYear, toAdd);
+  return { memoryMeta: nextMeta, newInductees: toAdd };
 }

--- a/src/core/legacyScore.js
+++ b/src/core/legacyScore.js
@@ -1,0 +1,436 @@
+/**
+ * Legacy Score V1 — explainable, position-aware; uses only existing player + record book data.
+ */
+
+import { buildMergedPlayerAwardTimeline } from './playerAwardTimeline.js';
+import {
+  RECORD_BOOK_PLAYER_KEYS,
+  RECORD_LABELS,
+  careerLineDefensiveInts,
+} from './recordBookV1.js';
+
+const DEF_POS = new Set(['DL', 'DE', 'DT', 'EDGE', 'LB', 'CB', 'S', 'SS', 'FS']);
+
+/** Minimum seasons before HOF induction is considered (retired players). */
+export const HOF_MIN_SEASONS = 5;
+
+/** Total legacy score needed for automatic induction (retired only). */
+export const HOF_LEGACY_INDUCT_THRESHOLD = 70;
+
+/** Borderline band below induct threshold. */
+export const HOF_LEGACY_BORDERLINE_BAND = 8;
+
+function num(v) {
+  const n = Number(v ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function getPositionBucket(pos) {
+  const p = String(pos ?? '').toUpperCase();
+  if (p === 'QB') return 'QB';
+  if (p === 'RB') return 'RB';
+  if (p === 'WR') return 'WR';
+  if (p === 'TE') return 'TE';
+  if (p === 'K') return 'K';
+  if (DEF_POS.has(p)) return 'defense';
+  return 'other';
+}
+
+/** Production baselines (career totals) — at ~100% of baseline, production nears its cap. */
+const PRODUCTION_BASELINE = {
+  QB: { passYds: 12000 },
+  RB: { rushYds: 6500, recYds: 2000 },
+  WR: { recYds: 8000 },
+  TE: { recYds: 5500 },
+  defense: { tackles: 380, sacks: 35, defInts: 18 },
+  K: { fgMade: 160 },
+  other: { games: 140 },
+};
+
+const PRODUCTION_CAP = 45;
+
+function sumCareerLines(careerStats, key) {
+  return careerStats.reduce((s, row) => s + num(row?.[key]), 0);
+}
+
+function careerGamesPlayed(careerStats) {
+  return careerStats.reduce((s, row) => s + num(row?.gamesPlayed), 0);
+}
+
+function peakOvrFromCareer(player, careerStats) {
+  let m = num(player?.ovr);
+  for (const line of careerStats) m = Math.max(m, num(line?.ovr));
+  return m;
+}
+
+function scoreProduction(bucket, careerStats) {
+  const reasons = [];
+  let raw = 0;
+
+  if (bucket === 'QB') {
+    const passYds = sumCareerLines(careerStats, 'passYds');
+    const passTDs = sumCareerLines(careerStats, 'passTDs');
+    const b = PRODUCTION_BASELINE.QB.passYds;
+    const ratio = b > 0 ? passYds / b : 0;
+    raw = Math.min(PRODUCTION_CAP, ratio * 37.5 + Math.min(6, passTDs / 80));
+    if (passYds >= b) reasons.push('Elite career passing volume');
+    else if (passYds >= b * 0.75) reasons.push('Strong career passing totals');
+  } else if (bucket === 'RB') {
+    const rushYds = sumCareerLines(careerStats, 'rushYds');
+    const recYds = sumCareerLines(careerStats, 'recYds');
+    const bR = PRODUCTION_BASELINE.RB.rushYds;
+    const bRec = PRODUCTION_BASELINE.RB.recYds;
+    const ratio = bR > 0 ? rushYds / bR : 0;
+    const recRatio = bRec > 0 ? recYds / bRec : 0;
+    raw = Math.min(PRODUCTION_CAP, ratio * 26 + recRatio * 10);
+    if (rushYds >= bR) reasons.push('Elite career rushing workload');
+    else if (rushYds >= bR * 0.8) reasons.push('Strong rushing production');
+  } else if (bucket === 'WR' || bucket === 'TE') {
+    const recYds = sumCareerLines(careerStats, 'recYds');
+    const recTDs = sumCareerLines(careerStats, 'recTDs');
+    const b = bucket === 'WR' ? PRODUCTION_BASELINE.WR.recYds : PRODUCTION_BASELINE.TE.recYds;
+    const ratio = b > 0 ? recYds / b : 0;
+    raw = Math.min(PRODUCTION_CAP, ratio * 30 + Math.min(6, recTDs / 50));
+    if (recYds >= b) reasons.push(`Elite career receiving for ${bucket}`);
+    else if (recYds >= b * 0.8) reasons.push('Strong receiving totals');
+  } else if (bucket === 'defense') {
+    const tackles = sumCareerLines(careerStats, 'tackles');
+    const sacks = sumCareerLines(careerStats, 'sacks');
+    let defInts = 0;
+    for (const row of careerStats) defInts += careerLineDefensiveInts(row);
+    const b = PRODUCTION_BASELINE.defense;
+    const tRatio = b.tackles > 0 ? tackles / b.tackles : 0;
+    const sRatio = b.sacks > 0 ? sacks / b.sacks : 0;
+    const iRatio = b.defInts > 0 ? defInts / b.defInts : 0;
+    raw = Math.min(
+      PRODUCTION_CAP,
+      tRatio * 14 + sRatio * 14 + iRatio * 10,
+    );
+    if (tackles >= b.tackles * 0.9 || sacks >= b.sacks * 0.85) reasons.push('Sustained defensive production');
+    if (defInts >= 12) reasons.push('Ball-hawk résumé (interceptions)');
+  } else if (bucket === 'K') {
+    const fg = sumCareerLines(careerStats, 'fgMade');
+    const b = PRODUCTION_BASELINE.K.fgMade;
+    const ratio = b > 0 ? fg / b : 0;
+    raw = Math.min(PRODUCTION_CAP, ratio * 34);
+    if (fg >= b) reasons.push('Elite career field goal volume');
+  } else {
+    const games = careerGamesPlayed(careerStats) || careerStats.length * 10;
+    const b = PRODUCTION_BASELINE.other.games;
+    raw = Math.min(PRODUCTION_CAP, (games / b) * 22);
+  }
+
+  return { production: Math.round(raw * 10) / 10, reasons };
+}
+
+function getMergedAwardCounts(playerId, accolades, archivedSeasons, teams) {
+  const { counts: tCounts } = countAwardsFromTimeline(playerId, accolades, archivedSeasons, teams);
+  const loose = countAccoladesMissingYear(accolades);
+  return {
+    mvp: tCounts.mvp + loose.mvp,
+    opoy: tCounts.opoy + loose.opoy,
+    dpoy: tCounts.dpoy + loose.dpoy,
+    roty: tCounts.roty + loose.roty,
+    sbMvp: tCounts.sbMvp + loose.sbMvp,
+    sbRing: tCounts.sbRing + loose.sbRing,
+    allPro: tCounts.allPro + loose.allPro,
+    bestPos: tCounts.bestPos + loose.bestPos,
+    proBowl: tCounts.proBowl + loose.proBowl,
+  };
+}
+
+function countAwardsFromTimeline(playerId, accolades, archivedSeasons, teams) {
+  const { rows } = buildMergedPlayerAwardTimeline(playerId, accolades, archivedSeasons, teams);
+  const counts = {
+    mvp: 0,
+    opoy: 0,
+    dpoy: 0,
+    roty: 0,
+    sbMvp: 0,
+    sbRing: 0,
+    allPro: 0,
+    bestPos: 0,
+    proBowl: 0,
+  };
+  for (const r of rows) {
+    const c = r.canonical;
+    if (c === 'mvp') counts.mvp += 1;
+    else if (c === 'opoy') counts.opoy += 1;
+    else if (c === 'dpoy') counts.dpoy += 1;
+    else if (c === 'roty' || c === 'oroy' || c === 'droy') counts.roty += 1;
+    else if (c === 'sbMvp') counts.sbMvp += 1;
+    else if (c === 'sb_ring') counts.sbRing += 1;
+    else if (c === 'allProOffense' || c === 'allProDefense') counts.allPro += 1;
+    else if (c === 'bestQB' || c === 'bestRB' || c === 'bestWrTe' || c === 'bestDefensivePlayer' || c === 'bestKicker') counts.bestPos += 1;
+    else if (c === 'pro_bowl' || c === 'PRO_BOWL') counts.proBowl += 1;
+  }
+  return { counts, rows };
+}
+
+function countAccoladesMissingYear(accolades) {
+  const c = {
+    mvp: 0, opoy: 0, dpoy: 0, roty: 0, sbMvp: 0, sbRing: 0, allPro: 0, bestPos: 0, proBowl: 0,
+  };
+  for (const a of Array.isArray(accolades) ? accolades : []) {
+    const t = String(a?.type ?? '');
+    const y = a?.year ?? a?.seasonYear;
+    if (Number.isFinite(Number(y)) && Number(y) > 0) continue;
+    if (t === 'MVP') c.mvp += 1;
+    else if (t === 'OPOY') c.opoy += 1;
+    else if (t === 'DPOY') c.dpoy += 1;
+    else if (t === 'ROTY') c.roty += 1;
+    else if (t === 'SB_MVP') c.sbMvp += 1;
+    else if (t === 'SB_RING') c.sbRing += 1;
+    else if (t === 'PRO_BOWL') c.proBowl += 1;
+  }
+  return c;
+}
+
+function scoreAwards(player, archivedSeasons, teams) {
+  const accolades = Array.isArray(player?.accolades) ? player.accolades : [];
+  const counts = getMergedAwardCounts(player?.id, accolades, archivedSeasons, teams);
+  const proBowlExtra = accolades.filter((a) => String(a?.type) === 'PRO_BOWL').length;
+  const proBowl = Math.max(counts.proBowl, proBowlExtra);
+  const pts = Math.min(
+    26,
+    Math.round(
+      (counts.mvp * 12
+        + counts.opoy * 5
+        + counts.dpoy * 6
+        + counts.roty * 3
+        + counts.sbMvp * 6
+        + counts.allPro * 3
+        + counts.bestPos * 2.5
+        + proBowl * 1.2) * 10,
+    ) / 10,
+  );
+  const reasons = [];
+  if (counts.mvp) reasons.push(`${counts.mvp} MVP${counts.mvp > 1 ? 's' : ''}`);
+  if (counts.dpoy) reasons.push(`${counts.dpoy} DPOY`);
+  if (counts.opoy) reasons.push(`${counts.opoy} OPOY`);
+  if (counts.sbMvp) reasons.push(`${counts.sbMvp} Finals MVP`);
+  if (counts.allPro) reasons.push(`${counts.allPro} First Team All-Pro season${counts.allPro > 1 ? 's' : ''}`);
+  if (proBowl >= 3) reasons.push(`${proBowl} Pro Bowls`);
+  return { awards: pts, reasons: reasons.slice(0, 4), proBowlCount: proBowl };
+}
+
+function scoreRecords(playerId, recordBook) {
+  if (!recordBook || playerId == null) return { records: 0, reasons: [], summary: '' };
+  const pid = String(playerId);
+  const ss = recordBook.singleSeasonV1 ?? {};
+  const cl = recordBook.careerLeadersV1 ?? {};
+  let pts = 0;
+  const reasons = [];
+  const bits = [];
+
+  for (const key of RECORD_BOOK_PLAYER_KEYS) {
+    const holder = ss[key];
+    if (holder && holder.playerId != null && String(holder.playerId) === pid && num(holder.value) > 0) {
+      pts += 4;
+      reasons.push(`Single-season ${RECORD_LABELS[key] ?? key} record`);
+      bits.push(`${RECORD_LABELS[key] ?? key} (season)`);
+    }
+  }
+  for (const key of RECORD_BOOK_PLAYER_KEYS) {
+    const board = Array.isArray(cl[key]) ? cl[key] : [];
+    const idx = board.findIndex((r) => r.playerId != null && String(r.playerId) === pid);
+    if (idx === 0 && board.length) {
+      pts += 5;
+      reasons.push(`Career ${RECORD_LABELS[key] ?? key} leader`);
+      bits.push(`${RECORD_LABELS[key] ?? key} #1`);
+    } else if (idx === 1) {
+      pts += 2.5;
+      bits.push(`${RECORD_LABELS[key] ?? key} #2`);
+    } else if (idx === 2) {
+      pts += 1.5;
+    }
+  }
+  pts = Math.min(15, Math.round(pts * 10) / 10);
+  return {
+    records: pts,
+    reasons: reasons.slice(0, 4),
+    summary: bits.slice(0, 3).join(' · ') || '',
+  };
+}
+
+function scoreChampionships(accolades, archivedSeasons, teams, playerId) {
+  const counts = getMergedAwardCounts(playerId, accolades, archivedSeasons, teams);
+  const rings = counts.sbRing;
+  const pts = Math.min(10, Math.round(rings * 2.8 * 10) / 10);
+  const reasons = [];
+  if (rings) reasons.push(`${rings} ring${rings > 1 ? 's' : ''}`);
+  return { championships: pts, reasons };
+}
+
+function scoreLongevity(seasons) {
+  if (seasons <= 0) return { longevity: 0, reasons: [] };
+  const pts = Math.min(8, Math.max(0, (seasons - 4) * 0.85));
+  const reasons = [];
+  if (seasons >= 10) reasons.push(`Long career (${seasons} seasons)`);
+  else if (seasons >= 7) reasons.push(`${seasons}-year career body of work`);
+  return { longevity: Math.round(pts * 10) / 10, reasons };
+}
+
+function scorePeak(peak) {
+  const pts = Math.min(7, Math.max(0, (peak - 78) * 0.55));
+  const reasons = [];
+  if (peak >= 92) reasons.push(`Peak dominance (OVR ${peak})`);
+  else if (peak >= 88) reasons.push(`Elite peak OVR (${peak})`);
+  return { peak: Math.round(pts * 10) / 10, reasons };
+}
+
+function legacyScoreToTier(score) {
+  if (score >= 88) return 'gold';
+  if (score >= 78) return 'silver';
+  if (score >= 68) return 'bronze';
+  if (score >= 55) return 'watch';
+  return 'minimal';
+}
+
+function buildCareerSummary(bucket, careerStats) {
+  if (!careerStats.length) return '';
+  if (bucket === 'QB') {
+    const y = sumCareerLines(careerStats, 'passYds');
+    const td = sumCareerLines(careerStats, 'passTDs');
+    return `${y.toLocaleString()} pass yds · ${td} TD`;
+  }
+  if (bucket === 'RB') {
+    const y = sumCareerLines(careerStats, 'rushYds');
+    return `${y.toLocaleString()} rush yds`;
+  }
+  if (bucket === 'WR' || bucket === 'TE') {
+    const y = sumCareerLines(careerStats, 'recYds');
+    return `${y.toLocaleString()} rec yds`;
+  }
+  if (bucket === 'defense') {
+    const t = sumCareerLines(careerStats, 'tackles');
+    const sk = sumCareerLines(careerStats, 'sacks');
+    return `${t} TKL · ${sk} SK`;
+  }
+  if (bucket === 'K') {
+    const fg = sumCareerLines(careerStats, 'fgMade');
+    return `${fg} FGM`;
+  }
+  return `${careerStats.length} seasons`;
+}
+
+function buildAwardsSummary(counts, proBowl) {
+  const parts = [];
+  if (counts.mvp) parts.push(`${counts.mvp}x MVP`);
+  if (counts.dpoy) parts.push(`${counts.dpoy}x DPOY`);
+  if (counts.opoy) parts.push(`${counts.opoy}x OPOY`);
+  if (counts.sbRing) parts.push(`${counts.sbRing}x Champ`);
+  if (counts.allPro) parts.push(`${counts.allPro}x All-Pro`);
+  if (proBowl >= 4) parts.push(`${proBowl}x Pro Bowl`);
+  return parts.join(' · ') || '';
+}
+
+/**
+ * Full legacy report for UI + HOF persistence.
+ * @param {object} player
+ * @param {{ recordBook?: object, archivedSeasons?: any[], teams?: any[], year?: number }} context
+ */
+export function buildLegacyScoreReport(player, context = {}) {
+  const { recordBook = null, archivedSeasons = [], teams = [], year: contextYear = null } = context;
+  const pos = String(player?.pos ?? '').toUpperCase() || 'QB';
+  const bucket = getPositionBucket(pos);
+  const careerStats = Array.isArray(player?.careerStats) ? player.careerStats : [];
+  const seasons = careerStats.length;
+  const accolades = Array.isArray(player?.accolades) ? player.accolades : [];
+
+  const prod = scoreProduction(bucket, careerStats);
+  const aw = scoreAwards(player, archivedSeasons, teams);
+  const rec = scoreRecords(player?.id, recordBook);
+  const counts = getMergedAwardCounts(player?.id, accolades, archivedSeasons, teams);
+  const champ = scoreChampionships(accolades, archivedSeasons, teams, player?.id);
+  const long = scoreLongevity(seasons);
+  const peak = peakOvrFromCareer(player, careerStats);
+  const pk = scorePeak(peak);
+
+  const breakdown = {
+    production: prod.production,
+    awards: aw.awards,
+    records: rec.records,
+    championships: champ.championships,
+    longevity: long.longevity,
+    peak: pk.peak,
+  };
+
+  const legacyScore = Math.round(
+    breakdown.production
+      + breakdown.awards
+      + breakdown.records
+      + breakdown.championships
+      + breakdown.longevity
+      + breakdown.peak,
+  );
+
+  const tier = legacyScoreToTier(legacyScore);
+  const status = String(player?.status ?? '');
+  const isRetired = status === 'retired';
+  const isActive = !isRetired && status !== 'draft_eligible';
+
+  const eligible =
+    isRetired
+    && seasons >= HOF_MIN_SEASONS
+    && legacyScore >= HOF_LEGACY_INDUCT_THRESHOLD - 5;
+
+  let recommendation = 'not_eligible';
+  if (isActive) {
+    recommendation = legacyScore >= 52 ? 'legacy_watch' : 'active';
+  } else if (isRetired) {
+    if (legacyScore >= HOF_LEGACY_INDUCT_THRESHOLD) recommendation = 'induct';
+    else if (legacyScore >= HOF_LEGACY_INDUCT_THRESHOLD - HOF_LEGACY_BORDERLINE_BAND) recommendation = 'borderline';
+    else recommendation = 'not_eligible';
+  } else {
+    recommendation = 'not_eligible';
+  }
+
+  const reasons = [
+    ...prod.reasons,
+    ...aw.reasons,
+    ...rec.reasons,
+    ...champ.reasons,
+    ...long.reasons,
+    ...pk.reasons,
+  ].filter(Boolean);
+
+  const careerSummary = buildCareerSummary(bucket, careerStats);
+  const awardsSummary = buildAwardsSummary(counts, aw.proBowlCount ?? 0);
+  const recordsSummary = rec.summary || '';
+
+  return {
+    playerId: player?.id ?? null,
+    playerName: player?.name ?? null,
+    pos,
+    legacyScore,
+    tier,
+    eligible,
+    recommendation,
+    reasons: [...new Set(reasons)].slice(0, 8),
+    breakdown,
+    careerSummary,
+    awardsSummary,
+    recordsSummary,
+    meta: { bucket, seasonsPlayed: seasons, peakOvr: peak, year: contextYear },
+  };
+}
+
+/** Whether Player Profile should show the expanded legacy block. */
+export function shouldShowLegacyProfileSection(report, player) {
+  if (!report) return false;
+  if (player?.hof) return true;
+  if (String(player?.status) === 'retired') return true;
+  const seasons = report.meta?.seasonsPlayed ?? 0;
+  const hasAwards = (player?.accolades?.length ?? 0) > 0;
+  const hasStats = seasons > 0;
+  const scoreOk = (report.legacyScore ?? 0) >= 48;
+  return (hasStats || hasAwards) && scoreOk;
+}
+
+export function isHallOfFameInducteeFromReport(report, player) {
+  if (player?.hof) return true;
+  return String(player?.status) === 'retired'
+    && (report?.legacyScore ?? 0) >= HOF_LEGACY_INDUCT_THRESHOLD
+    && (report?.meta?.seasonsPlayed ?? 0) >= HOF_MIN_SEASONS;
+}

--- a/src/ui/components/HallOfFame.jsx
+++ b/src/ui/components/HallOfFame.jsx
@@ -9,8 +9,24 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ScreenHeader, EmptyState } from "./ScreenSystem.jsx";
 
+function resolvedLegacyScore(player) {
+  const n = Number(player?.legacyScore ?? player?.hofScore);
+  if (Number.isFinite(n) && n > 0) return n;
+  return getLegacyScoreFallback(player);
+}
+
+function getLegacyScoreFallback(player) {
+  const summary = player?.accoladeSummary ?? {};
+  const rings = summary.superBowls ?? 0;
+  const mvps = summary.mvps ?? 0;
+  const pro = summary.proBowls ?? 0;
+  const peak = player?.peakOvr ?? player?.ovr ?? 0;
+  return (rings * 12) + (mvps * 10) + (pro * 2) + Math.round(peak / 5);
+}
+
 export default function HallOfFame({ onPlayerSelect, actions }) {
   const [players, setPlayers] = useState(null);
+  const [classes, setClasses] = useState([]);
   const [loading, setLoading] = useState(true);
   const [positionFilter, setPositionFilter] = useState("ALL");
   const [search, setSearch] = useState("");
@@ -26,6 +42,7 @@ export default function HallOfFame({ onPlayerSelect, actions }) {
       .then((response) => {
         if (mounted) {
           setPlayers(response?.payload?.players ?? []);
+          setClasses(response?.payload?.classes ?? []);
           setLoading(false);
         }
       })
@@ -44,26 +61,48 @@ export default function HallOfFame({ onPlayerSelect, actions }) {
     return ["ALL", ...[...set].sort()];
   }, [players]);
 
+  const classOptions = useMemo(() => {
+    const fromClasses = (classes ?? []).map((c) => String(c.year));
+    const fromPlayers = (players ?? []).map((p) => String(p.inductionYear ?? ""));
+    const merged = [...new Set([...fromClasses, ...fromPlayers].filter(Boolean))];
+    return ["ALL", ...merged.sort((a, b) => Number(b) - Number(a))];
+  }, [players, classes]);
+
   const filteredPlayers = useMemo(() => {
     const list = (players ?? []).filter((p) => {
       if (positionFilter !== "ALL" && p.pos !== positionFilter) return false;
-      if (classFilter !== "ALL" && String(p.inductionYear ?? "Unknown") !== classFilter) return false;
+      if (classFilter !== "ALL") {
+        const cls = (classes ?? []).find((c) => String(c.year) === classFilter);
+        const ids = new Set((cls?.inductees ?? []).map((i) => String(i.playerId)));
+        if (ids.size) {
+          if (!ids.has(String(p.id))) return false;
+        } else if (String(p.inductionYear ?? "") !== classFilter) {
+          return false;
+        }
+      }
       const q = search.trim().toLowerCase();
       if (!q) return true;
-      return [p.name, p.pos, p.primaryTeam]
+      return [p.name, p.pos, p.primaryTeam, p.primaryTeamAbbr]
         .filter(Boolean)
         .some((value) => String(value).toLowerCase().includes(q));
     });
     return [...list].sort((a, b) => sortHallPlayers(a, b, sortKey));
-  }, [players, positionFilter, classFilter, search, sortKey]);
-  const classOptions = useMemo(() => {
-    const years = [...new Set((players ?? []).map((p) => String(p.inductionYear ?? "Unknown")))];
-    return ["ALL", ...years.sort((a, b) => Number(b) - Number(a))];
-  }, [players]);
+  }, [players, classes, positionFilter, classFilter, search, sortKey]);
+
   const latestClass = useMemo(() => {
-    const yr = classOptions.find((value) => value !== "ALL" && value !== "Unknown");
-    return yr ? filteredPlayers.filter((p) => String(p.inductionYear) === yr).slice(0, 3) : filteredPlayers.slice(0, 3);
-  }, [classOptions, filteredPlayers]);
+    const sorted = [...(classes ?? [])].sort((a, b) => Number(b.year) - Number(a.year));
+    const yr = sorted[0]?.year;
+    if (yr == null) {
+      const yr2 = classOptions.find((value) => value !== "ALL");
+      return yr2 ? filteredPlayers.filter((p) => String(p.inductionYear) === yr2).slice(0, 3) : filteredPlayers.slice(0, 3);
+    }
+    return filteredPlayers.filter((p) => String(p.inductionYear) === String(yr)).slice(0, 3);
+  }, [classes, classOptions, filteredPlayers]);
+
+  const sortedClasses = useMemo(
+    () => [...(classes ?? [])].sort((a, b) => Number(b.year) - Number(a.year)),
+    [classes],
+  );
 
   if (loading) {
     return (
@@ -73,22 +112,61 @@ export default function HallOfFame({ onPlayerSelect, actions }) {
     );
   }
 
-  if (!players || players.length === 0) {
+  const hasPlayers = players && players.length > 0;
+  const hasClasses = classes && classes.length > 0;
+  if (!hasPlayers && !hasClasses) {
     return (
-      <div className="app-screen-stack">
+      <div className="app-screen-stack" data-testid="hall-of-fame-empty">
         <ScreenHeader title="Hall of Fame" subtitle="Career achievement archive and notable induction classes." />
-        <EmptyState title="No inductees yet." body="Legendary players will be inducted here once great careers conclude." />
+        <EmptyState
+          title="No Hall of Fame classes yet."
+          body="Retired legends will appear here after their careers are complete."
+        />
       </div>
     );
   }
 
   return (
-    <div className="space-y-4 app-screen-stack">
+    <div className="space-y-4 app-screen-stack" data-testid="hall-of-fame-screen">
       <ScreenHeader
         title="Hall of Fame"
         subtitle="Explore inductions, teams, awards, and peak greatness."
-        metadata={[{ label: "Legends", value: `${filteredPlayers.length}/${players.length}` }]}
+        metadata={[{ label: "Legends", value: `${filteredPlayers.length}/${(players ?? []).length}` }]}
       />
+      {sortedClasses.length > 0 && (
+        <Card className="card-premium" data-testid="hall-of-fame-classes">
+          <CardContent className="p-4 space-y-3">
+            <div className="text-xs uppercase tracking-wide text-[color:var(--text-muted)]">Induction classes</div>
+            {sortedClasses.map((c) => (
+              <div key={c.classId ?? `hof-${c.year}`} className="border border-[color:var(--hairline)] rounded-lg p-3 space-y-2">
+                <div className="text-sm font-semibold">Class of {c.year}</div>
+                <ul className="space-y-2 text-sm">
+                  {(c.inductees ?? []).map((ind) => (
+                    <li key={String(ind.playerId)} className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1">
+                      <button
+                        type="button"
+                        className="text-left font-medium text-[color:var(--accent)] hover:underline"
+                        onClick={() => onPlayerSelect?.(ind.playerId)}
+                      >
+                        {ind.name}
+                        <span className="text-[color:var(--text-muted)] font-normal"> · {ind.pos}</span>
+                        {ind.primaryTeamAbbr ? <span className="text-[color:var(--text-muted)] font-normal"> · {ind.primaryTeamAbbr}</span> : null}
+                      </button>
+                      <div className="flex flex-wrap gap-1 items-center text-xs text-[color:var(--text-muted)]">
+                        {ind.tier ? <Badge variant="outline" className="text-[10px]">{String(ind.tier)}</Badge> : null}
+                        <span>Legacy {ind.legacyScore ?? ind.score ?? "—"}</span>
+                        {Array.isArray(ind.reasons) && ind.reasons.length > 0 ? (
+                          <span className="hidden sm:inline">· {ind.reasons.slice(0, 3).join(" · ")}</span>
+                        ) : null}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
       {latestClass.length > 0 && (
         <Card className="card-premium">
           <CardContent className="p-4 space-y-2">
@@ -105,69 +183,75 @@ export default function HallOfFame({ onPlayerSelect, actions }) {
         </Card>
       )}
 
-      <Card className="card-premium">
-        <CardContent className="p-3 sm:p-4">
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2">
-            <input
-              type="text"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search legends"
-              className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-sm"
-            />
-            <select
-              value={positionFilter}
-              onChange={(e) => setPositionFilter(e.target.value)}
-              className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-sm"
-            >
-              {positions.map((pos) => (
-                <option key={pos} value={pos}>{pos === "ALL" ? "All positions" : pos}</option>
-              ))}
-            </select>
-            <select
-              value={classFilter}
-              onChange={(e) => setClassFilter(e.target.value)}
-              className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-sm"
-            >
-              {classOptions.map((option) => (
-                <option key={option} value={option}>{option === "ALL" ? "All classes" : `Class of ${option}`}</option>
-              ))}
-            </select>
-            <select
-              value={sortKey}
-              onChange={(e) => setSortKey(e.target.value)}
-              className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-sm"
-            >
-              <option value="legacy">Sort: Legacy Score</option>
-              <option value="inductionYear">Sort: Induction Year</option>
-              <option value="awards">Sort: Awards</option>
-              <option value="rings">Sort: Rings</option>
-              <option value="peak">Sort: Peak OVR</option>
-            </select>
-            <div className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-xs text-[color:var(--text-muted)] flex items-center">
-              Click any card to open full player archive.
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      {hasPlayers && (
+        <>
+          <Card className="card-premium">
+            <CardContent className="p-3 sm:p-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2">
+                <input
+                  type="text"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search legends"
+                  className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-sm"
+                />
+                <select
+                  value={positionFilter}
+                  onChange={(e) => setPositionFilter(e.target.value)}
+                  className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-sm"
+                >
+                  {positions.map((pos) => (
+                    <option key={pos} value={pos}>{pos === "ALL" ? "All positions" : pos}</option>
+                  ))}
+                </select>
+                <select
+                  value={classFilter}
+                  onChange={(e) => setClassFilter(e.target.value)}
+                  className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-sm"
+                >
+                  {classOptions.map((option) => (
+                    <option key={option} value={option}>{option === "ALL" ? "All classes" : `Class of ${option}`}</option>
+                  ))}
+                </select>
+                <select
+                  value={sortKey}
+                  onChange={(e) => setSortKey(e.target.value)}
+                  className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-sm"
+                >
+                  <option value="legacy">Sort: Legacy Score</option>
+                  <option value="inductionYear">Sort: Induction Year</option>
+                  <option value="awards">Sort: Awards</option>
+                  <option value="rings">Sort: Rings</option>
+                  <option value="peak">Sort: Peak OVR</option>
+                </select>
+                <div className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-xs text-[color:var(--text-muted)] flex items-center sm:col-span-2">
+                  Click any card to open full player archive.
+                </div>
+              </div>
+            </CardContent>
+          </Card>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {filteredPlayers.map((player) => (
-          <HofCard
-            key={player.id}
-            player={player}
-            onPlayerSelect={onPlayerSelect}
-          />
-        ))}
-      </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4" data-testid="hall-of-fame-cards">
+            {filteredPlayers.map((player) => (
+              <HofCard
+                key={player.id}
+                player={player}
+                onPlayerSelect={onPlayerSelect}
+              />
+            ))}
+          </div>
+        </>
+      )}
     </div>
   );
 }
 
 function HofCard({ player, onPlayerSelect }) {
-  const { stats, accoladeSummary } = player;
+  const { accoladeSummary } = player;
+  const summary = accoladeSummary ?? { mvps: 0, superBowls: 0, proBowls: 0 };
   const primaryStat = getPrimaryStat(player);
-  const legacyScore = getLegacyScore(player);
+  const legacyScore = resolvedLegacyScore(player);
+  const tier = player.tier;
 
   return (
     <Card
@@ -205,7 +289,7 @@ function HofCard({ player, onPlayerSelect }) {
               <div className="flex items-center gap-2 text-sm">
                 <span className="font-semibold text-[color:var(--accent)]">{player.pos}</span>
                 <span className="text-[color:var(--text-muted)]">&middot;</span>
-                <span className="text-[color:var(--text-muted)]">{player.primaryTeam || "N/A"}</span>
+                <span className="text-[color:var(--text-muted)]">{player.primaryTeam || player.primaryTeamAbbr || "N/A"}</span>
               </div>
               <div className="text-xs text-[color:var(--text-muted)] mt-0.5">
                 {player.seasonsPlayed > 0 && `${player.seasonsPlayed} season${player.seasonsPlayed !== 1 ? "s" : ""}`}
@@ -216,11 +300,12 @@ function HofCard({ player, onPlayerSelect }) {
         </div>
 
         <div className="px-4 py-3 space-y-3">
-          {(accoladeSummary.mvps > 0 || accoladeSummary.superBowls > 0 || accoladeSummary.proBowls > 0 || legacyScore > 0) && (
+          {(summary.mvps > 0 || summary.superBowls > 0 || summary.proBowls > 0 || legacyScore > 0 || tier) && (
             <div className="flex flex-wrap gap-1.5">
-              {accoladeSummary.mvps > 0 && <AccoladeBadge label={`${accoladeSummary.mvps}x MVP`} gold />}
-              {accoladeSummary.superBowls > 0 && <AccoladeBadge label={`${accoladeSummary.superBowls}x SB`} gold />}
-              {accoladeSummary.proBowls > 0 && <AccoladeBadge label={`${accoladeSummary.proBowls}x Pro Bowl`} />}
+              {tier ? <AccoladeBadge label={String(tier)} gold /> : null}
+              {summary.mvps > 0 && <AccoladeBadge label={`${summary.mvps}x MVP`} gold />}
+              {summary.superBowls > 0 && <AccoladeBadge label={`${summary.superBowls}x SB`} gold />}
+              {summary.proBowls > 0 && <AccoladeBadge label={`${summary.proBowls}x Pro Bowl`} />}
               {legacyScore > 0 && <AccoladeBadge label={`Legacy ${legacyScore}`} />}
             </div>
           )}
@@ -246,7 +331,7 @@ function HofCard({ player, onPlayerSelect }) {
           )}
           {Array.isArray(player.inductionReasons) && player.inductionReasons.length > 0 && (
             <div className="text-[10px] text-[color:var(--text-muted)]">
-              Why inducted: {player.inductionReasons.slice(0, 2).join(" · ")}
+              Why inducted: {player.inductionReasons.slice(0, 4).join(" · ")}
             </div>
           )}
         </div>
@@ -284,16 +369,7 @@ function sortHallPlayers(a, b, sortKey) {
   if (sortKey === "rings") return (b.accoladeSummary?.superBowls ?? 0) - (a.accoladeSummary?.superBowls ?? 0);
   if (sortKey === "awards") return ((b.accoladeSummary?.mvps ?? 0) + (b.accoladeSummary?.proBowls ?? 0)) - ((a.accoladeSummary?.mvps ?? 0) + (a.accoladeSummary?.proBowls ?? 0));
   if (sortKey === "peak") return (b.peakOvr ?? b.ovr ?? 0) - (a.peakOvr ?? a.ovr ?? 0);
-  return getLegacyScore(b) - getLegacyScore(a);
-}
-
-function getLegacyScore(player) {
-  const summary = player?.accoladeSummary ?? {};
-  const rings = summary.superBowls ?? 0;
-  const mvps = summary.mvps ?? 0;
-  const pro = summary.proBowls ?? 0;
-  const peak = player?.peakOvr ?? player?.ovr ?? 0;
-  return (rings * 12) + (mvps * 10) + (pro * 2) + Math.round(peak / 5);
+  return resolvedLegacyScore(b) - resolvedLegacyScore(a);
 }
 
 function getPrimaryStat(player) {

--- a/src/ui/components/HistoryHub.jsx
+++ b/src/ui/components/HistoryHub.jsx
@@ -10,6 +10,7 @@ const DESTINATIONS = [
 
 export default function HistoryHub({ onNavigate, actions, onSelectSeason, league = null }) {
   const [seasons, setSeasons] = useState([]);
+  const [hofPreview, setHofPreview] = useState(null);
   useEffect(() => {
     let mounted = true;
     (actions?.getAllSeasons?.() ?? Promise.resolve({ payload: { seasons: [] } }))
@@ -26,12 +27,65 @@ export default function HistoryHub({ onNavigate, actions, onSelectSeason, league
     };
   }, [actions]);
 
+  useEffect(() => {
+    let mounted = true;
+    if (!actions?.getHallOfFame) {
+      setHofPreview(null);
+      return () => { mounted = false; };
+    }
+    actions
+      .getHallOfFame()
+      .then((res) => {
+        if (!mounted) return;
+        const players = res?.payload?.players ?? [];
+        const classes = res?.payload?.classes ?? [];
+        setHofPreview({ players, classes });
+      })
+      .catch(() => {
+        if (mounted) setHofPreview(null);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [actions]);
+
   return (
     <div className="app-screen-stack">
       <ScreenHeader
         title="History Hub"
         subtitle="Your save-file memory center: archives, honors, records, and franchise timelines."
       />
+      {hofPreview && (hofPreview.classes?.length > 0 || hofPreview.players?.length > 0) && (
+        <SectionCard title="Hall of Fame" subtitle="Latest induction class.">
+          {(() => {
+            const classes = [...(hofPreview.classes || [])].sort((a, b) => Number(b?.year ?? 0) - Number(a?.year ?? 0));
+            const latest = classes[0];
+            const inductees = latest?.inductees ?? [];
+            const top = [...(hofPreview.players || [])].sort((a, b) => Number(b?.legacyScore ?? b?.hofScore ?? 0) - Number(a?.legacyScore ?? a?.hofScore ?? 0))[0];
+            const topName = inductees.length
+              ? [...inductees].sort((a, b) => Number(b?.legacyScore ?? b?.score ?? 0) - Number(a?.legacyScore ?? a?.score ?? 0))[0]?.name
+              : top?.name;
+            return (
+              <div className="card" style={{ padding: 'var(--space-4)' }} data-testid="history-hub-hof-preview">
+                <div style={{ fontWeight: 800 }}>Class of {latest?.year ?? '—'}</div>
+                <div style={{ marginTop: 6, fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+                  {inductees.length ? `${inductees.length} inductee${inductees.length === 1 ? '' : 's'}` : `${hofPreview.players.length} legend${hofPreview.players.length === 1 ? '' : 's'}`}
+                  {topName ? ` · Spotlight: ${topName}` : ''}
+                </div>
+                <button
+                  type="button"
+                  className="clickable-card"
+                  style={{ marginTop: 10, fontSize: 'var(--text-xs)', fontWeight: 700, color: 'var(--accent)', background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
+                  onClick={() => onNavigate?.('Hall of Fame')}
+                >
+                  View Hall of Fame →
+                </button>
+              </div>
+            );
+          })()}
+        </SectionCard>
+      )}
+
       <SectionCard title="Choose a history destination" subtitle="Consistent archive routes with clear destination naming.">
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(220px,1fr))', gap: 'var(--space-3)' }}>
         {DESTINATIONS.map((item) => (

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -30,6 +30,7 @@ import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 import { getPlayerGameLogs } from "../utils/playerGameLogs.js";
 import { buildMergedPlayerAwardTimeline, buildPlayerAwardHeaderBadges } from "../../core/playerAwardTimeline.js";
 import { buildPlayerRecordContext } from "../../core/recordBookV1.js";
+import { buildLegacyScoreReport, shouldShowLegacyProfileSection } from "../../core/legacyScore.js";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
@@ -490,6 +491,26 @@ export default function PlayerProfile({
     () => buildPlayerRecordContext(recordBook, effectivePlayer?.id ?? playerId),
     [recordBook, effectivePlayer?.id, playerId],
   );
+  const legacyReport = useMemo(() => {
+    if (!effectivePlayer) return null;
+    return buildLegacyScoreReport(effectivePlayer, {
+      recordBook,
+      archivedSeasons,
+      teams,
+    });
+  }, [effectivePlayer, recordBook, archivedSeasons, teams]);
+
+  const legacyStatusLabel = useMemo(() => {
+    if (!legacyReport || !playerView) return null;
+    if (playerView.hof) return "Hall of Fame inductee";
+    const st = String(playerView.status ?? "");
+    if (st !== "retired") {
+      return legacyReport.recommendation === "legacy_watch" ? "Legacy watch" : "Active — building résumé";
+    }
+    if (legacyReport.recommendation === "borderline") return "Borderline — résumé under review";
+    if (legacyReport.recommendation === "induct") return "Qualified résumé (enshrinement tracked in league history)";
+    return "Not in Hall of Fame — keep watching accolades and records";
+  }, [legacyReport, playerView]);
   const playerMissing = !loading && !effectivePlayer;
   const loadErrorMessage = requestError?.message || data?.error || null;
   const userTeam = useMemo(() => teams.find((t) => t.id === data?.meta?.userTeamId || t.id === player?.teamId), [teams, data?.meta?.userTeamId, player?.teamId]);
@@ -1370,16 +1391,23 @@ export default function PlayerProfile({
             </section>
           )}
 
-          {!loading && playerView && (
-            <section className="card-enter">
-              <h3 style={sectionLabelStyle}>Legacy Context</h3>
-              <div style={{ display: "grid", gap: "var(--space-2)", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" }}>
+          {!loading && playerView && shouldShowLegacyProfileSection(legacyReport, playerView) && legacyReport && (
+            <section className="card-enter" data-testid="player-profile-legacy-watch">
+              <h3 style={sectionLabelStyle}>Legacy &amp; Hall of Fame</h3>
+              <div style={{ display: "grid", gap: "var(--space-2)", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))" }}>
                 <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
-                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Hall of Fame</div>
-                  <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>{player.hof ? "Inducted" : "Not inducted"}</div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Legacy score</div>
+                  <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>
+                    {legacyReport.legacyScore}
+                    {legacyReport.tier ? <span style={{ color: "var(--text-muted)", fontWeight: 600, marginLeft: 6 }}>({legacyReport.tier})</span> : null}
+                  </div>
                 </div>
                 <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
-                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Best Season</div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Status</div>
+                  <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>{legacyStatusLabel}</div>
+                </div>
+                <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Best season</div>
                   <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>{bestSeason ? seasonYear(bestSeason.seasonId) : "—"}</div>
                 </div>
                 <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
@@ -1387,10 +1415,23 @@ export default function PlayerProfile({
                   <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>{ringCount}</div>
                 </div>
                 <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
-                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Team Journey</div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Team journey</div>
                   <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>{teamJourney.length ? teamJourney.join(" → ") : "Single team / N/A"}</div>
                 </div>
               </div>
+              {legacyReport.breakdown && (
+                <p style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)", marginTop: 8, marginBottom: 0 }}>
+                  Breakdown: production {legacyReport.breakdown.production} · awards {legacyReport.breakdown.awards} · records {legacyReport.breakdown.records} ·
+                  titles {legacyReport.breakdown.championships} · longevity {legacyReport.breakdown.longevity} · peak {legacyReport.breakdown.peak}
+                </p>
+              )}
+              {Array.isArray(legacyReport.reasons) && legacyReport.reasons.length > 0 && (
+                <ul style={{ margin: "8px 0 0", paddingLeft: 18, fontSize: "var(--text-xs)", color: "var(--text-muted)", lineHeight: 1.45 }}>
+                  {legacyReport.reasons.slice(0, 4).map((r) => (
+                    <li key={r}>{r}</li>
+                  ))}
+                </ul>
+              )}
             </section>
           )}
 

--- a/src/ui/components/__tests__/HallOfFame.test.jsx
+++ b/src/ui/components/__tests__/HallOfFame.test.jsx
@@ -1,0 +1,53 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import HallOfFame from '../HallOfFame.jsx';
+
+afterEach(() => cleanup());
+
+describe('HallOfFame', () => {
+  it('renders empty state copy when no players or classes', async () => {
+    render(
+      <HallOfFame
+        onPlayerSelect={vi.fn()}
+        actions={{
+          getHallOfFame: vi.fn().mockResolvedValue({ payload: { players: [], classes: [] } }),
+        }}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('hall-of-fame-empty')).toBeTruthy();
+      expect(screen.getByText(/No Hall of Fame classes yet/i)).toBeTruthy();
+    });
+  });
+
+  it('renders induction class list from payload', async () => {
+    render(
+      <HallOfFame
+        onPlayerSelect={vi.fn()}
+        actions={{
+          getHallOfFame: vi.fn().mockResolvedValue({
+            payload: {
+              players: [],
+              classes: [
+                {
+                  year: 2032,
+                  classId: 'hof-2032',
+                  inductees: [
+                    { playerId: 'p1', name: 'Ace QB', pos: 'QB', primaryTeamAbbr: 'DAL', legacyScore: 82, tier: 'silver', reasons: ['MVP'] },
+                  ],
+                },
+              ],
+            },
+          }),
+        }}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('hall-of-fame-classes')).toBeTruthy();
+      expect(screen.getByText(/Class of 2032/)).toBeTruthy();
+      expect(screen.getByText(/Ace QB/)).toBeTruthy();
+    });
+  });
+});

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -232,4 +232,40 @@ describe('PlayerProfile', () => {
     await waitFor(() => expect(screen.getByTestId('player-profile-summary').textContent).toContain('Avery Fields'));
     expect(screen.queryByTestId('player-profile-record-book')).toBeNull();
   });
+
+  it('shows legacy watch when career stats and accolades justify legacy scoring', async () => {
+    const careerPlayer = {
+      id: 22,
+      name: 'Star QB',
+      pos: 'QB',
+      age: 30,
+      ovr: 90,
+      teamId: 1,
+      status: 'active',
+      accolades: [{ type: 'MVP', year: 2025 }],
+      careerStats: Array.from({ length: 8 }).map((_, i) => ({ season: `s${i}`, passYds: 4200, ovr: 88 })),
+      contract: { years: 1, baseAnnual: 10 },
+      traits: [],
+      ratings: {},
+    };
+    const legacyActions = {
+      getPlayerCareer: vi.fn(async () => ({
+        payload: { player: careerPlayer, stats: [], meta: { userTeamId: 1, week: 5 } },
+      })),
+      getAllSeasons: vi.fn(async () => ({ payload: { seasons: [] } })),
+      getRecords: vi.fn(async () => ({ payload: { recordBook: null } })),
+    };
+    const teamsWithStar = [{ id: 1, name: 'Dallas', abbr: 'DAL', roster: [careerPlayer] }];
+    render(
+      <PlayerProfile
+        playerId={22}
+        onClose={vi.fn()}
+        actions={legacyActions}
+        teams={teamsWithStar}
+        league={{ ...league, teams: teamsWithStar }}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('player-profile-legacy-watch')).toBeTruthy());
+    expect(screen.getByText(/Legacy score/i)).toBeTruthy();
+  });
 });

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -109,7 +109,7 @@ import { derivePlayerVisibleRatingsPatch } from './playerDerivedRatings.js';
 import { evaluateRetirements }     from '../core/retirement-system.js';
 import { runAIToAITrades, generateAITradeProposalsForUser, evaluateCounterOffer } from '../core/trade-logic.js';
 import { processSeasonRecords, createEmptyRecords, getMostPlayedTeam } from '../core/records.js';
-import { ensureLeagueMemoryMeta, buildSeasonArchiveSummary, updateFranchiseHistory, updateRecordBook, evaluateHallOfFameCandidate, addHallOfFameClass, buildSeasonStorylineSnapshot } from '../core/league-memory.js';
+import { ensureLeagueMemoryMeta, buildSeasonArchiveSummary, updateFranchiseHistory, updateRecordBook, evaluateHallOfFameCandidate, addHallOfFameClass, buildSeasonStorylineSnapshot, buildHallOfFameInducteeRow, syncHallOfFameAfterRecordBook } from '../core/league-memory.js';
 import { rebuildRecordBookV1, mirrorRecordBookForLegacyUi, RECORD_BOOK_SCHEMA_VERSION } from '../core/recordBookV1.js';
 import { inferChampionshipOutcome, isCompletedGame, isPostseasonGame } from '../core/championshipInference.js';
 import { repairDepthChart, validateDepthChart, optimizeDepthChartForPlan } from "../core/roster/depthChartManager.js";
@@ -3954,6 +3954,7 @@ async function handleGetHallOfFame(payload, id) {
       .slice(-10);
 
     const classEntry = meta?.hallOfFame?.index?.[String(p.id)] ?? null;
+    const legacyScore = classEntry?.legacyScore ?? classEntry?.score ?? p?.hofScore ?? null;
     return {
       id: p.id,
       name: p.name,
@@ -3962,6 +3963,7 @@ async function handleGetHallOfFame(payload, id) {
       ovr: p.ovr,
       number: p.number ?? p.jerseyNum ?? null,
       primaryTeam,
+      primaryTeamAbbr: classEntry?.primaryTeamAbbr ?? primaryTeam,
       teamColor: getTeamColor(primaryTeam, cache.getAllTeams()),
       inductionYear,
       seasonsPlayed: careerStats.length,
@@ -3971,11 +3973,64 @@ async function handleGetHallOfFame(payload, id) {
       accoladeSummary: { mvps: mvpCount, superBowls: sbCount, proBowls: proCount },
       accoladeTimeline,
       inductionReasons: classEntry?.reasons ?? p?.hofReasons ?? [],
-      hofScore: classEntry?.score ?? p?.hofScore ?? null,
+      hofScore: legacyScore,
+      legacyScore,
+      tier: classEntry?.tier ?? null,
+      breakdown: classEntry?.breakdown ?? null,
+      careerSummary: classEntry?.careerSummary ?? null,
+      awardsSummary: classEntry?.awardsSummary ?? null,
+      recordsSummary: classEntry?.recordsSummary ?? null,
     };
-  }).sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0));
+  });
 
-  post(toUI.HALL_OF_FAME, { players: result }, id);
+  const seenIds = new Set(result.map((r) => String(r.id)));
+  const allTeamsLocal = cache.getAllTeams();
+  const classesRaw = Array.isArray(meta?.hallOfFame?.classes) ? meta.hallOfFame.classes : [];
+  const classesPayload = classesRaw.slice(0, 40).map((c) => ({
+    year: c.year,
+    classId: c.classId ?? `hof-${c.year}`,
+    inductees: (c.inductees || []).map((ind) => ({ ...ind })),
+  }));
+  for (const c of classesRaw) {
+    const y = Number(c.year);
+    for (const ind of c.inductees || []) {
+      const pid = ind?.playerId;
+      if (pid == null || seenIds.has(String(pid))) continue;
+      seenIds.add(String(pid));
+      const abbr = ind.primaryTeamAbbr || '';
+      result.push({
+        id: pid,
+        name: ind.name,
+        pos: ind.pos,
+        age: null,
+        ovr: null,
+        number: null,
+        primaryTeam: abbr || null,
+        primaryTeamAbbr: abbr || null,
+        teamColor: getTeamColor(abbr, allTeamsLocal),
+        inductionYear: y,
+        seasonsPlayed: 0,
+        peakOvr: null,
+        teamHistory: abbr ? [abbr] : [],
+        stats: { passYds: 0, rushYds: 0, recYds: 0, passTDs: 0, sacks: 0, gamesPlayed: 0 },
+        accoladeSummary: { mvps: 0, superBowls: 0, proBowls: 0 },
+        accoladeTimeline: [],
+        inductionReasons: ind.reasons ?? [],
+        hofScore: ind.legacyScore ?? ind.score ?? null,
+        legacyScore: ind.legacyScore ?? ind.score ?? null,
+        tier: ind.tier ?? null,
+        breakdown: ind.breakdown ?? null,
+        careerSummary: ind.careerSummary ?? null,
+        awardsSummary: ind.awardsSummary ?? null,
+        recordsSummary: ind.recordsSummary ?? null,
+        fromClassOnly: true,
+      });
+    }
+  }
+
+  result.sort((a, b) => (Number(b.legacyScore ?? b.hofScore ?? 0) - Number(a.legacyScore ?? a.hofScore ?? 0)) || (Number(b.inductionYear ?? 0) - Number(a.inductionYear ?? 0)));
+
+  post(toUI.HALL_OF_FAME, { players: result, classes: classesPayload }, id);
 }
 
 function getTeamColor(abbr, teams) {
@@ -8122,6 +8177,15 @@ async function handleAdvanceOffseason(payload, id) {
   const agedPlayers = cache.getAllPlayers();
   const { retirements } = evaluateRetirements(agedPlayers);
 
+  const hofMemoryMeta = ensureLeagueMemoryMeta(ensureDynastyMeta(cache.getMeta()));
+  const hofTeamAbbrMap = {};
+  allTeams.forEach((t) => { hofTeamAbbrMap[t.id] = t.abbr; });
+  const hofEvalContext = {
+    recordBook: hofMemoryMeta.recordBook,
+    archivedSeasons: hofMemoryMeta.leagueHistory ?? [],
+    teams: allTeams,
+  };
+
   const hofClass = [];
   for (const ret of retirements) {
     const player = cache.getPlayer(ret.id);
@@ -8130,7 +8194,7 @@ async function handleAdvanceOffseason(payload, id) {
     retired.push(ret);
     if (player.teamId != null) recalculateTeamCap(player.teamId);
 
-    const hofEval = evaluateHallOfFameCandidate(player, Number(meta?.year ?? 2025));
+    const hofEval = evaluateHallOfFameCandidate(player, Number(meta?.year ?? 2025), hofEvalContext);
     const isHof = hofEval.inducted;
 
     // Log news based on retirement type
@@ -8146,7 +8210,7 @@ async function handleAdvanceOffseason(payload, id) {
     if (isHof) {
       const accoladeTrail = Array.isArray(player.accolades) ? [...player.accolades, { type: 'HOF', year: Number(meta?.year ?? 2025), reasons: hofEval.reasons, score: hofEval.score }] : [{ type: 'HOF', year: Number(meta?.year ?? 2025), reasons: hofEval.reasons, score: hofEval.score }];
       cache.updatePlayer(player.id, { status: 'retired', teamId: null, hof: true, hofScore: hofEval.score, hofReasons: hofEval.reasons, accolades: accoladeTrail });
-      hofClass.push({ playerId: player.id, name: player.name, pos: player.pos, score: hofEval.score, reasons: hofEval.reasons });
+      hofClass.push(buildHallOfFameInducteeRow(player, hofEval.report, { teamAbbrMap: hofTeamAbbrMap, teams: allTeams }));
     } else {
       cache.updatePlayer(player.id, { status: 'retired', teamId: null, hof: false });
     }
@@ -8554,6 +8618,19 @@ async function archiveSeason(seasonId) {
     let memoryMeta = { ...meta, leagueHistory: historyRows };
     memoryMeta = updateFranchiseHistory(memoryMeta, seasonSummary, teams);
     memoryMeta = updateRecordBook(memoryMeta, { allPlayers: cache.getAllPlayers() });
+    const hofArchiveTeamAbbrMap = {};
+    teams.forEach((t) => { hofArchiveTeamAbbrMap[t.id] = t.abbr; });
+    const hofSync = syncHallOfFameAfterRecordBook(memoryMeta, cache.getAllPlayers(), year, { teams, teamAbbrMap: hofArchiveTeamAbbrMap });
+    memoryMeta = hofSync.memoryMeta;
+    for (const row of hofSync.newInductees) {
+      const pl = cache.getPlayer(row.playerId);
+      if (!pl || pl.hof === true) continue;
+      const accoladeTrail = Array.isArray(pl.accolades)
+        ? [...pl.accolades, { type: 'HOF', year, reasons: row.reasons, score: row.legacyScore }]
+        : [{ type: 'HOF', year, reasons: row.reasons, score: row.legacyScore }];
+      cache.updatePlayer(row.playerId, { hof: true, hofScore: row.legacyScore, hofReasons: row.reasons, accolades: accoladeTrail });
+      await NewsEngine.logNews('HOF', `LEGEND CROWNED: ${row.pos} ${row.name} has been enshrined into the Hall of Fame, cementing an unforgettable legacy!`);
+    }
     memoryMeta.seasonStorylines = buildSeasonStorylineSnapshot(memoryMeta, teams, meta.userTeamId);
     cache.setMeta({
       leagueHistory: memoryMeta.leagueHistory,
@@ -8561,6 +8638,7 @@ async function archiveSeason(seasonId) {
       recordBook: memoryMeta.recordBook,
       seasonStorylines: memoryMeta.seasonStorylines,
       history: archivedLeagueView.history,
+      hallOfFame: memoryMeta.hallOfFame,
     });
 
     await Seasons.save(seasonSummary);

--- a/tests/unit/hallOfFamePersistence.test.js
+++ b/tests/unit/hallOfFamePersistence.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ensureLeagueMemoryMeta,
+  addHallOfFameClass,
+  syncHallOfFameAfterRecordBook,
+} from '../../src/core/league-memory.js';
+import { buildLegacyScoreReport, HOF_LEGACY_INDUCT_THRESHOLD } from '../../src/core/legacyScore.js';
+
+describe('Hall of Fame persistence', () => {
+  it('merges same-year classes instead of replacing prior inductees', () => {
+    let meta = ensureLeagueMemoryMeta({});
+    meta = addHallOfFameClass(meta, 2030, [
+      { playerId: 'a', name: 'A', pos: 'QB', legacyScore: 80, tier: 'silver', reasons: [], score: 80 },
+    ]);
+    meta = addHallOfFameClass(meta, 2030, [
+      { playerId: 'b', name: 'B', pos: 'RB', legacyScore: 75, tier: 'bronze', reasons: [], score: 75 },
+    ]);
+    const cls = meta.hallOfFame.classes.find((c) => c.year === 2030);
+    expect(cls.inductees.length).toBe(2);
+    expect(meta.hallOfFame.index.a).toBeTruthy();
+    expect(meta.hallOfFame.index.b).toBeTruthy();
+  });
+
+  it('does not write empty classes', () => {
+    const meta = addHallOfFameClass(ensureLeagueMemoryMeta({}), 2031, []);
+    const y2031 = meta.hallOfFame.classes.filter((c) => c.year === 2031);
+    expect(y2031.length).toBe(0);
+  });
+
+  it('syncHallOfFameAfterRecordBook skips active players and duplicate index entries', () => {
+    const recordBook = { careerLeadersV1: {}, singleSeasonV1: {} };
+    const meta = ensureLeagueMemoryMeta({
+      leagueHistory: [],
+      recordBook,
+      hallOfFame: {
+        classes: [{ year: 2028, classId: 'hof-2028', inductees: [{ playerId: 'old', name: 'Old', pos: 'QB', legacyScore: 90, tier: 'gold', reasons: [], score: 90 }] }],
+        index: { old: { playerId: 'old' } },
+        schemaVersion: 1,
+      },
+    });
+    const active = { id: 'p1', status: 'active', pos: 'QB', careerStats: Array.from({ length: 12 }).map(() => ({ passYds: 5000, ovr: 95 })), accolades: [{ type: 'MVP' }] };
+    const retiredOk = {
+      id: 'p2',
+      status: 'retired',
+      pos: 'QB',
+      careerStats: Array.from({ length: 12 }).map(() => ({ passYds: 1200, ovr: 90 })),
+      accolades: [{ type: 'MVP' }],
+    };
+    const { memoryMeta, newInductees } = syncHallOfFameAfterRecordBook(meta, [active, retiredOk], 2030, { teams: [], teamAbbrMap: {} });
+    expect(newInductees.some((x) => x.playerId === 'p1')).toBe(false);
+    expect(newInductees.some((x) => x.playerId === 'p2')).toBe(true);
+    expect(memoryMeta.hallOfFame.index.p2).toBeTruthy();
+  });
+
+  it('old saves without hallOfFame still get defaults via ensureLeagueMemoryMeta', () => {
+    const meta = ensureLeagueMemoryMeta({ year: 2025 });
+    expect(Array.isArray(meta.hallOfFame.classes)).toBe(true);
+    expect(meta.hallOfFame.schemaVersion).toBe(1);
+  });
+});
+
+describe('duplicate induction guard', () => {
+  it('retired player at threshold is not double-added when already in index', () => {
+    const report = buildLegacyScoreReport(
+      { id: 'x', pos: 'QB', status: 'retired', accolades: [{ type: 'MVP' }], careerStats: Array.from({ length: 12 }).map(() => ({ passYds: 1200, ovr: 90 })) },
+      {},
+    );
+    expect(report.legacyScore).toBeGreaterThanOrEqual(HOF_LEGACY_INDUCT_THRESHOLD);
+    let meta = ensureLeagueMemoryMeta({});
+    meta = addHallOfFameClass(meta, 2029, [{ playerId: 'x', name: 'X', pos: 'QB', legacyScore: report.legacyScore, tier: report.tier, reasons: [], score: report.legacyScore }]);
+    const sync = syncHallOfFameAfterRecordBook(
+      meta,
+      [{ id: 'x', status: 'retired', pos: 'QB', accolades: [{ type: 'MVP' }], careerStats: Array.from({ length: 12 }).map(() => ({ passYds: 1200, ovr: 90 })), hof: true }],
+      2029,
+      { teams: [], teamAbbrMap: {} },
+    );
+    expect(sync.newInductees.length).toBe(0);
+  });
+});

--- a/tests/unit/legacyScore.test.js
+++ b/tests/unit/legacyScore.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildLegacyScoreReport,
+  HOF_LEGACY_INDUCT_THRESHOLD,
+  HOF_MIN_SEASONS,
+  getPositionBucket,
+} from '../../src/core/legacyScore.js';
+import { RECORD_KEYS } from '../../src/core/recordBookV1.js';
+
+describe('legacyScore V1', () => {
+  it('scores an elite QB with MVP and high production near induct threshold', () => {
+    const p = {
+      id: 'qb1',
+      pos: 'QB',
+      accolades: [{ type: 'MVP' }],
+      careerStats: Array.from({ length: 12 }).map(() => ({ passYds: 1200, ovr: 90 })),
+    };
+    const r = buildLegacyScoreReport(p, {});
+    expect(r.legacyScore).toBeGreaterThanOrEqual(HOF_LEGACY_INDUCT_THRESHOLD);
+    expect(r.meta.seasonsPlayed).toBeGreaterThanOrEqual(HOF_MIN_SEASONS);
+    expect(r.breakdown.awards).toBeGreaterThan(0);
+    expect(r.breakdown.production).toBeGreaterThan(30);
+  });
+
+  it('scores a defensive star from tackles/sacks, not passing stats', () => {
+    const p = {
+      id: 'lb1',
+      pos: 'LB',
+      accolades: [{ type: 'DPOY', year: 2030 }],
+      careerStats: Array.from({ length: 10 }).map(() => ({ tackles: 120, sacks: 8, defInts: 2, ovr: 88 })),
+    };
+    const r = buildLegacyScoreReport(p, {});
+    expect(r.breakdown.production).toBeGreaterThan(10);
+    expect(getPositionBucket('LB')).toBe('defense');
+  });
+
+  it('adds record-book contribution when player holds a career board rank', () => {
+    const pid = 'star1';
+    const recordBook = {
+      careerLeadersV1: {
+        [RECORD_KEYS.sacks]: [
+          { playerId: pid, playerName: 'Edge', value: 99, position: 'EDGE' },
+          { playerId: 'x', value: 80 },
+        ],
+      },
+      singleSeasonV1: {},
+    };
+    const p = {
+      id: pid,
+      pos: 'EDGE',
+      careerStats: Array.from({ length: 8 }).map(() => ({ tackles: 40, sacks: 10, ovr: 84 })),
+    };
+    const r = buildLegacyScoreReport(p, { recordBook });
+    expect(r.breakdown.records).toBeGreaterThan(0);
+  });
+
+  it('treats active players as legacy_watch, not induct recommendation', () => {
+    const p = {
+      id: 'a1',
+      pos: 'QB',
+      status: 'active',
+      accolades: [],
+      careerStats: [{ passYds: 4000, ovr: 80 }],
+    };
+    const r = buildLegacyScoreReport(p, {});
+    expect(r.recommendation).not.toBe('induct');
+    expect(r.eligible).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change introduces **Legacy Score V1** as a pure helper and wires it into **Hall of Fame induction**, **season archive sync**, and **History / Profile UI**, without touching retirement rolls themselves.

## Legacy Score formula / breakdown

`buildLegacyScoreReport` in `src/core/legacyScore.js` sums six capped components into a **0–100** `legacyScore`:

- **production** — position bucket (QB / RB / WR / TE / defense / K / other) vs documented baselines; defensive rows use tackles, sacks, and `careerLineDefensiveInts`, not QB passing.
- **awards** — MVP, OPOY, DPOY, ROTY, SB MVP, All‑Pro (from archived season `awards`), best‑position season awards, Pro Bowl; **rings are scored only under championships** to avoid double counting. Accolades **without a year** still count via `countAccoladesMissingYear` (timeline skips those).
- **records** — holder of a `singleSeasonV1` row and/or rank on `careerLeadersV1` boards (same keys as `buildPlayerRecordContext`).
- **championships** — SB rings (timeline + yearless accolades).
- **longevity** — seasons with `careerStats` lines.
- **peak** — max OVR from career lines + player.

Also returns **`tier`** (`gold` / `silver` / `bronze` / `watch` / `minimal`), **`recommendation`** (e.g. `legacy_watch`, `induct`, `borderline`), **`reasons[]`**, and string summaries for persistence.

**Induction threshold:** `legacyScore >= HOF_LEGACY_INDUCT_THRESHOLD` (70) and **`seasonsPlayed >= HOF_MIN_SEASONS` (5)** via `evaluateHallOfFameCandidate` (retirement path does not require `status === 'retired'` because the player is still active at evaluation time).

## Hall of Fame class storage shape

- `meta.hallOfFame.schemaVersion` (default **1**).
- `meta.hallOfFame.classes[]`: `{ year, classId: \`hof-${year}\`, inductees[] }`.
- Each inductee: `playerId`, `name`, `pos`, `primaryTeamId`, `primaryTeamAbbr`, `legacyScore`, `tier`, `reasons`, `score` (alias of legacy score for old readers), `careerSummary`, `awardsSummary`, `recordsSummary`, `breakdown`.
- `meta.hallOfFame.index[playerId]` — latest row for that player.

**`addHallOfFameClass` now merges** inductees for the same `year` by `playerId` and **rebuilds `index` from all classes** (fixes replacing the whole class on a second call).

## Induction eligibility & active exclusion

- **Retirement (`handleAdvanceOffseason`):** same loop as before; `evaluateHallOfFameCandidate` receives `recordBook`, `leagueHistory`, and `teams`. Only retiring players enter the loop — **active players are never evaluated here.**
- **Archive (`archiveSeason`):** after `updateRecordBook`, `syncHallOfFameAfterRecordBook` scans **`status === 'retired'`** only, skips anyone already in `index` or with `hof === true`, and appends merged class rows; **news fires only for newly inducted** players in this pass.

## Duplicate inductees

- Skipped if **`hallOfFame.index[id]`** exists or **`player.hof === true`** before archive sync.
- Same-year merges **overwrite same `playerId` with newer fields** instead of duplicating rows.

## Hall of Fame UI

- Loads **`players` + `classes`** from the worker.
- **Year-grouped “Induction classes”** list with tier, legacy score, top reasons, clickable names.
- **Empty state:** “No Hall of Fame classes yet…” (per spec).
- Cards use **`legacyScore` / `hofScore` from API** with a small fallback heuristic only when those are missing.

## Player Profile legacy context

- **“Legacy & Hall of Fame”** block when `shouldShowLegacyProfileSection` passes (HoF flag, retired, or meaningful career + score ≥ 48): score, tier, status line (legacy watch vs inductee vs borderline), compact **breakdown line**, top reasons. Existing **Record book** section unchanged.

## History Hub

- Optional **`getHallOfFame`** preview: latest class year, inductee count, spotlight name, **View Hall of Fame** navigation.

## Old-save handling

- `ensureLeagueMemoryMeta` supplies defaults for missing `hallOfFame` / `schemaVersion`.
- UI guards missing `classes`, `accoladeSummary`, and payload fields.

## Tests run (all passed)

- `npm run test:unit` (658 tests)
- `npm run build`
- `npm run check:deploy`
- `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` (after `npx playwright install chromium` in this environment)

## Known limitations / follow-ups

- No full historical HOF timelines in this PR.
- Retirement-time evaluation may still use a **slightly stale** record book vs post-archive; archive sync corrects borderline cases after `updateRecordBook`.
- Formula tuning will benefit from live franchise data.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d111b300-b26b-4534-945c-29bf4fe84793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d111b300-b26b-4534-945c-29bf4fe84793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

