### PR TITLE
Post-merge stabilization: Netlify deploy resilience + Hall of Fame / Legacy safety

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,6 +11,8 @@
 
 [build.environment]
   NODE_VERSION = "22"
+  # Large Vite bundles can OOM on smaller Netlify build runners; keep headroom.
+  NODE_OPTIONS = "--max-old-space-size=4096"
   # Skip Netlify's default npm install; build.command runs npm ci instead.
   NETLIFY_INSTALL_JS_DEPENDENCIES = "false"
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.0.0",
   "type": "module",
   "description": "The ultimate browser-based American Football GM simulator",
+  "engines": {
+    "node": ">=22 <23"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/scripts/netlify-parity-check.sh
+++ b/scripts/netlify-parity-check.sh
@@ -43,8 +43,9 @@ echo "[netlify-parity] Cleaning publish directory"
 rm -rf "$NETLIFY_PUBLISH"
 
 echo "[netlify-parity] Building production bundle with Netlify-like env"
+# Match netlify.toml [build].environment (NODE_OPTIONS reduces OOM risk on large Vite builds).
 # Match netlify.toml [build].command (includes npm ci when configured).
-CI=true NETLIFY=true CONTEXT=production bash -c "$NETLIFY_CMD"
+CI=true NETLIFY=true CONTEXT=production NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=4096}" bash -c "$NETLIFY_CMD"
 
 if [[ -f "public/sw.js" && ! -f "$NETLIFY_PUBLISH/sw.js" ]]; then
   echo "[netlify-parity] ERROR: $NETLIFY_PUBLISH/sw.js missing (public/sw.js should be copied)"

--- a/src/ui/components/HallOfFame.jsx
+++ b/src/ui/components/HallOfFame.jsx
@@ -141,8 +141,8 @@ export default function HallOfFame({ onPlayerSelect, actions }) {
               <div key={c.classId ?? `hof-${c.year}`} className="border border-[color:var(--hairline)] rounded-lg p-3 space-y-2">
                 <div className="text-sm font-semibold">Class of {c.year}</div>
                 <ul className="space-y-2 text-sm">
-                  {(c.inductees ?? []).map((ind) => (
-                    <li key={String(ind.playerId)} className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1">
+                  {(c.inductees ?? []).map((ind, idx) => (
+                    <li key={ind?.playerId != null ? String(ind.playerId) : `hof-${c.year ?? "y"}-${idx}`} className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1">
                       <button
                         type="button"
                         className="text-left font-medium text-[color:var(--accent)] hover:underline"

--- a/src/ui/components/HistoryHub.jsx
+++ b/src/ui/components/HistoryHub.jsx
@@ -59,7 +59,8 @@ export default function HistoryHub({ onNavigate, actions, onSelectSeason, league
         <SectionCard title="Hall of Fame" subtitle="Latest induction class.">
           {(() => {
             const classes = [...(hofPreview.classes || [])].sort((a, b) => Number(b?.year ?? 0) - Number(a?.year ?? 0));
-            const latest = classes[0];
+            const latest =
+              classes.find((c) => Array.isArray(c?.inductees) && c.inductees.length > 0) ?? classes[0];
             const inductees = latest?.inductees ?? [];
             const top = [...(hofPreview.players || [])].sort((a, b) => Number(b?.legacyScore ?? b?.hofScore ?? 0) - Number(a?.legacyScore ?? a?.hofScore ?? 0))[0];
             const topName = inductees.length

--- a/src/ui/components/HistoryHub.test.jsx
+++ b/src/ui/components/HistoryHub.test.jsx
@@ -70,6 +70,67 @@ describe('HistoryHub', () => {
     });
   });
 
+  it('shows Hall of Fame preview when getHallOfFame returns players or classes', async () => {
+    render(
+      <HistoryHub
+        onNavigate={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({ payload: { seasons: [] } }),
+          getHallOfFame: vi.fn().mockResolvedValue({
+            payload: {
+              players: [{ id: 'p1', name: 'Legend', legacyScore: 90, hofScore: 90 }],
+              classes: [{ year: 2031, classId: 'hof-2031', inductees: [{ playerId: 'p1', name: 'Legend', legacyScore: 90, score: 90 }] }],
+            },
+          }),
+        }}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('history-hub-hof-preview')).toBeTruthy();
+      expect(screen.getByText(/Class of 2031/)).toBeTruthy();
+    });
+  });
+
+  it('does not show HOF preview when getHallOfFame rejects', async () => {
+    render(
+      <HistoryHub
+        onNavigate={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({ payload: { seasons: [] } }),
+          getHallOfFame: vi.fn().mockRejectedValue(new Error('worker')),
+        }}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId('history-hub-hof-preview')).toBeNull();
+    });
+  });
+
+  it('prefers latest class with inductees for HOF preview headline', async () => {
+    render(
+      <HistoryHub
+        onNavigate={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({ payload: { seasons: [] } }),
+          getHallOfFame: vi.fn().mockResolvedValue({
+            payload: {
+              players: [],
+              classes: [
+                { year: 2032, classId: 'hof-2032', inductees: [] },
+                { year: 2030, classId: 'hof-2030', inductees: [{ playerId: 'x', name: 'Old Star', legacyScore: 88, score: 88 }] },
+              ],
+            },
+          }),
+        }}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('history-hub-hof-preview')).toBeTruthy();
+      expect(screen.getByText(/Class of 2030/)).toBeTruthy();
+      expect(screen.getByText(/Spotlight: Old Star/)).toBeTruthy();
+    });
+  });
+
   it('routes to history with selected season when preview clicked', async () => {
     const onNavigate = vi.fn();
     const onSelectSeason = vi.fn();

--- a/src/ui/components/__tests__/HallOfFame.test.jsx
+++ b/src/ui/components/__tests__/HallOfFame.test.jsx
@@ -22,6 +22,26 @@ describe('HallOfFame', () => {
     });
   });
 
+  it('renders class card when a class has empty inductees (no crash)', async () => {
+    render(
+      <HallOfFame
+        onPlayerSelect={vi.fn()}
+        actions={{
+          getHallOfFame: vi.fn().mockResolvedValue({
+            payload: {
+              players: [{ id: 'solo', name: 'Solo', pos: 'QB', legacyScore: 70, accoladeSummary: { mvps: 0, superBowls: 0, proBowls: 0 }, stats: {} }],
+              classes: [{ year: 2033, classId: 'hof-2033', inductees: [] }],
+            },
+          }),
+        }}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('hall-of-fame-classes')).toBeTruthy();
+      expect(screen.getAllByText(/Class of 2033/).length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
   it('renders induction class list from payload', async () => {
     render(
       <HallOfFame

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -233,6 +233,65 @@ describe('PlayerProfile', () => {
     expect(screen.queryByTestId('player-profile-record-book')).toBeNull();
   });
 
+  it('renders active player with no careerStats, no accolades, and failed getRecords without crashing', async () => {
+    const bare = {
+      id: 99,
+      name: 'Sparse Active',
+      pos: 'WR',
+      age: 23,
+      ovr: 72,
+      teamId: 1,
+      status: 'active',
+      accolades: [],
+      contract: { years: 1, baseAnnual: 1 },
+      traits: [],
+      ratings: {},
+    };
+    const bareActions = {
+      getPlayerCareer: vi.fn(async () => ({
+        payload: { player: bare, stats: [], teammates: [], meta: { userTeamId: 1, week: 1 } },
+      })),
+      getAllSeasons: vi.fn(async () => ({ payload: { seasons: [] } })),
+      getRecords: vi.fn(async () => Promise.reject(new Error('idb'))),
+    };
+    const teams = [{ id: 1, name: 'Dallas', abbr: 'DAL', roster: [bare] }];
+    render(
+      <PlayerProfile playerId={99} onClose={vi.fn()} actions={bareActions} teams={teams} league={{ ...league, teams }} />,
+    );
+    await waitFor(() => expect(screen.getByTestId('player-profile-summary').textContent).toContain('Sparse Active'));
+    expect(screen.queryByTestId('player-profile-record-book')).toBeNull();
+  });
+
+  it('renders retired HOF inductee with no careerStats in payload without crashing', async () => {
+    const bareHof = {
+      id: 88,
+      name: 'Ghost Legend',
+      pos: 'RB',
+      age: 38,
+      ovr: 80,
+      teamId: null,
+      status: 'retired',
+      hof: true,
+      contract: null,
+      traits: [],
+      ratings: {},
+    };
+    const bareActions = {
+      getPlayerCareer: vi.fn(async () => ({
+        payload: { player: bareHof, stats: [], teammates: [], meta: { userTeamId: 1, week: 1 } },
+      })),
+      getAllSeasons: vi.fn(async () => ({ payload: { seasons: [] } })),
+      getRecords: vi.fn(async () => ({ payload: { recordBook: null } })),
+    };
+    const teams = [{ id: 1, name: 'Dallas', abbr: 'DAL', roster: [] }];
+    render(
+      <PlayerProfile playerId={88} onClose={vi.fn()} actions={bareActions} teams={teams} league={{ ...league, teams }} />,
+    );
+    await waitFor(() => expect(screen.getByTestId('player-profile-summary').textContent).toContain('Ghost Legend'));
+    await waitFor(() => expect(screen.getByTestId('player-profile-legacy-watch')).toBeTruthy());
+    expect(screen.getByText(/Hall of Fame inductee/i)).toBeTruthy();
+  });
+
   it('shows legacy watch when career stats and accolades justify legacy scoring', async () => {
     const careerPlayer = {
       id: 22,

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -3902,9 +3902,15 @@ async function handleGetTransactions({ seasonId = null, teamId = null } = {}, id
 // ── Handler: GET_HALL_OF_FAME ────────────────────────────────────────────────
 
 async function handleGetHallOfFame(payload, id) {
+  try {
   const meta = ensureLeagueMemoryMeta(ensureDynastyMeta(cache.getMeta()));
   // Collect all HOF players from DB (retired + any active HOF)
-  const allDBPlayers = await Players.loadAll();
+  let allDBPlayers = [];
+  try {
+    allDBPlayers = await Players.loadAll();
+  } catch (err) {
+    console.error('[Worker] Players.loadAll() failed in handleGetHallOfFame:', err);
+  }
   const hofPlayers = allDBPlayers.filter(p => p.hof === true);
 
   const teamAbbrMap = {};
@@ -4031,6 +4037,10 @@ async function handleGetHallOfFame(payload, id) {
   result.sort((a, b) => (Number(b.legacyScore ?? b.hofScore ?? 0) - Number(a.legacyScore ?? a.hofScore ?? 0)) || (Number(b.inductionYear ?? 0) - Number(a.inductionYear ?? 0)));
 
   post(toUI.HALL_OF_FAME, { players: result, classes: classesPayload }, id);
+  } catch (err) {
+    console.error('[Worker] handleGetHallOfFame failed:', err);
+    post(toUI.HALL_OF_FAME, { players: [], classes: [] }, id);
+  }
 }
 
 function getTeamColor(abbr, teams) {
@@ -8202,7 +8212,11 @@ async function handleAdvanceOffseason(payload, id) {
       // Sudden retirement — high-priority news
       await NewsEngine.logSuddenRetirement(ret);
     } else if (isHof) {
-      NewsEngine.logNews('HOF', `LEGEND CROWNED: ${player.pos} ${player.name} has been enshrined into the Hall of Fame, cementing an unforgettable legacy!`);
+      try {
+        await NewsEngine.logNews('HOF', `LEGEND CROWNED: ${player.pos} ${player.name} has been enshrined into the Hall of Fame, cementing an unforgettable legacy!`);
+      } catch (err) {
+        console.error('[Worker] HOF retirement news log failed (non-fatal):', err);
+      }
     } else if ((player.ovr >= 85) || (ret.age >= 35 && player.ovr >= 75)) {
       NewsEngine.logNews('RETIREMENT', `END OF AN ERA: ${player.pos} ${player.name} has officially announced their retirement from professional football.`);
     }
@@ -8623,13 +8637,20 @@ async function archiveSeason(seasonId) {
     const hofSync = syncHallOfFameAfterRecordBook(memoryMeta, cache.getAllPlayers(), year, { teams, teamAbbrMap: hofArchiveTeamAbbrMap });
     memoryMeta = hofSync.memoryMeta;
     for (const row of hofSync.newInductees) {
-      const pl = cache.getPlayer(row.playerId);
+      let pl = cache.getPlayer(row.playerId);
+      if (!pl) {
+        pl = await Players.load(row.playerId).catch(() => null);
+      }
       if (!pl || pl.hof === true) continue;
       const accoladeTrail = Array.isArray(pl.accolades)
         ? [...pl.accolades, { type: 'HOF', year, reasons: row.reasons, score: row.legacyScore }]
         : [{ type: 'HOF', year, reasons: row.reasons, score: row.legacyScore }];
       cache.updatePlayer(row.playerId, { hof: true, hofScore: row.legacyScore, hofReasons: row.reasons, accolades: accoladeTrail });
-      await NewsEngine.logNews('HOF', `LEGEND CROWNED: ${row.pos} ${row.name} has been enshrined into the Hall of Fame, cementing an unforgettable legacy!`);
+      try {
+        await NewsEngine.logNews('HOF', `LEGEND CROWNED: ${row.pos} ${row.name} has been enshrined into the Hall of Fame, cementing an unforgettable legacy!`);
+      } catch (err) {
+        console.error('[Worker] HOF archive news log failed (non-fatal):', err);
+      }
     }
     memoryMeta.seasonStorylines = buildSeasonStorylineSnapshot(memoryMeta, teams, meta.userTeamId);
     cache.setMeta({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Post-merge stabilization after PR #1374 (Hall of Fame + Legacy Score). The Netlify deploy log for commit `27646b400ac46e7caccc9a13f26d7cbe1704631e` was not readable from automation (dashboard requires login), so this PR combines **evidence-backed local parity** (`npm run check:deploy`) with **defensive fixes** that address the most likely cloud vs CI gaps and HOF runtime risks called out in the audit.

### Root cause of the Netlify deploy failure

**Not confirmed from logs.** Local reproduction on Node 22 with `npm ci`, `npm run build`, and full `npm run check:deploy` (including offline `netlify build` for `production` and `deploy-preview`) **passes** on this branch. Likely cloud-only causes remain: smaller build runner memory (Vite bundle ~2.1 MB JS + worker), Netlify site plugins, or post-build deploy steps not exercised by `--offline` CLI.

### Why GitHub Actions passed but Netlify could still fail

- CI runs the same `npm ci` / `test:unit` / `check:deploy` / smoke workflow as documented in `netlify-parity.yml`, but **offline** `netlify build` does not mirror every Netlify-hosted plugin or post-processing step.
- Netlify’s build VM may hit **heap OOM** during `vite build` where GitHub Actions succeeds.

### What changed

**Netlify / build parity**

- `netlify.toml`: set `NODE_OPTIONS=--max-old-space-size=4096` under `[build.environment]` to reduce OOM risk on Netlify.
- `package.json`: `engines.node` `>=22 <23` to match `NODE_VERSION` in `netlify.toml` and the parity script.
- `scripts/netlify-parity-check.sh`: default the same `NODE_OPTIONS` when running the Netlify-matched build so CI and Netlify stay aligned.

**Hall of Fame / Legacy runtime safety**

- `handleGetHallOfFame`: outer try/catch posts `{ players: [], classes: [] }` on any failure; inner try/catch around `Players.loadAll()`.
- Offseason retirement HOF news: `await` + try/catch so `News.add` failures do not surface as unhandled rejections.
- `archiveSeason` HOF sync: if `cache.getPlayer` misses a retired inductee, **fallback `Players.load`** before updating `hof` flags; HOF `logNews` wrapped in try/catch so news cannot abort the archive path.

**UI**

- `HistoryHub`: Hall of Fame preview picks the **latest class that actually has inductees**, avoiding a misleading “Class of …” when the newest year is an empty shell.
- `HallOfFame`: React list keys for inductees without `playerId`.

**Tests**

- `HistoryHub.test.jsx`: HOF preview happy path, rejected `getHallOfFame`, and “newest year empty / older year has inductees”.
- `HallOfFame.test.jsx`: class with empty `inductees` + one player.
- `PlayerProfile.test.jsx`: sparse active player + failed `getRecords`; retired HOF with no `careerStats` in payload.

### Old-save compatibility

- No schema changes; worker continues to rely on `ensureLeagueMemoryMeta` defaults for missing `hallOfFame` / `recordBook`.
- Safer HOF fetch and archive paths reduce crashes from partial DB or news failures.

### Tests run (all passing)

- `npm ci`
- `npm run test:unit` (665 tests)
- `npm run build`
- `npm run check:deploy`
- `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js`

### Known limitations for follow-up

- Exact Netlify cloud error string still needs a pasted deploy log if previews fail again after this merge.
- If failures persist with no OOM signature, inspect Netlify **site-level** build plugins and deploy hooks outside this repository.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-125cd897-e144-47c6-baf7-d5568c8723e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-125cd897-e144-47c6-baf7-d5568c8723e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

