### PR TITLE
Team History: franchise records V2 (model + UI)

### DIFF
--- a/src/core/franchiseHistoryModel.js
+++ b/src/core/franchiseHistoryModel.js
@@ -1,0 +1,807 @@
+/**
+ * Pure franchise history / records model from archived seasons (+ optional HOF payload).
+ * No simulation, no persistence writes.
+ */
+
+import {
+  ARCHIVE_LEADER_TO_RECORD,
+  RECORD_BOOK_PLAYER_KEYS,
+  RECORD_LABELS,
+  RECORD_KEYS,
+  careerTotalsFromPlayer,
+  dedupeCareerStatLines,
+  defensiveInterceptionsSeasonValue,
+  leaderEntryToRecordRow,
+} from './recordBookV1.js';
+
+const PLAYOFF_CALIBER_WINS = 10;
+const ELITE_WINS = 12;
+
+function num(v) {
+  const n = Number(v ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function seasonGamesFromStandings(row) {
+  return num(row?.wins) + num(row?.losses) + num(row?.ties);
+}
+
+function normAbbr(a) {
+  if (a == null || a === '') return '';
+  return String(a).trim().toUpperCase();
+}
+
+function teamMatchesFranchise(row, teamId, teamAbbr) {
+  if (!row) return false;
+  const tid = row.teamId ?? row.id;
+  if (teamId != null && Number.isFinite(Number(teamId)) && tid != null && Number(tid) === Number(teamId)) return true;
+  const ab = normAbbr(row.teamAbbr ?? row.abbr);
+  const want = normAbbr(teamAbbr);
+  if (want && ab === want) return true;
+  return false;
+}
+
+function findFranchiseStanding(season, teamId, teamAbbr) {
+  const rows = season?.standings ?? [];
+  const byId = rows.find((t) => teamId != null && Number(t?.id) === Number(teamId));
+  if (byId) return byId;
+  if (teamAbbr) return rows.find((t) => normAbbr(t?.abbr) === normAbbr(teamAbbr)) ?? null;
+  return null;
+}
+
+function championMatches(season, teamId, teamAbbr) {
+  const c = season?.champion;
+  if (!c) return false;
+  if (teamId != null && c.id != null && Number(c.id) === Number(teamId)) return true;
+  if (teamAbbr && normAbbr(c.abbr) === normAbbr(teamAbbr)) return true;
+  return false;
+}
+
+function runnerUpMatches(season, teamId, teamAbbr) {
+  const r = season?.runnerUp;
+  if (!r) return false;
+  if (teamId != null && r.id != null && Number(r.id) === Number(teamId)) return true;
+  if (teamAbbr && normAbbr(r.abbr) === normAbbr(teamAbbr)) return true;
+  return false;
+}
+
+function teamInBracketSnapshot(snapshot, teamId) {
+  if (!snapshot || snapshot.mode === 'empty' || !Array.isArray(snapshot.rounds)) return false;
+  const tid = Number(teamId);
+  for (const r of snapshot.rounds) {
+    for (const g of r.games ?? []) {
+      if (Number(g?.homeId) === tid || Number(g?.awayId) === tid) return true;
+    }
+  }
+  return false;
+}
+
+function leagueHasAnyBracketArchive(seasons) {
+  return (seasons || []).some((s) => s?.playoffBracketSnapshot && s.playoffBracketSnapshot.mode !== 'empty');
+}
+
+function seasonHasTruePlayoffAppearance(season, teamId, teamAbbr) {
+  if (championMatches(season, teamId, teamAbbr) || runnerUpMatches(season, teamId, teamAbbr)) return true;
+  const snap = season?.playoffBracketSnapshot;
+  if (snap && snap.mode !== 'empty' && teamId != null && Number.isFinite(Number(teamId))) {
+    return teamInBracketSnapshot(snap, teamId);
+  }
+  return false;
+}
+
+/** Save has any documented postseason outcome or bracket (enables "Playoff appearances" labeling). */
+function actualPostseasonArchivePresent(seasons) {
+  return (seasons || []).some((s) => {
+    if (s?.champion || s?.runnerUp) return true;
+    if (s?.playoffBracketSnapshot && s.playoffBracketSnapshot.mode !== 'empty') return true;
+    return false;
+  });
+}
+
+function buildSeasonTeamMap(season) {
+  const map = {};
+  for (const row of season?.standings ?? []) {
+    map[Number(row?.id)] = row;
+  }
+  return map;
+}
+
+function opponentAbbrForGame(season, game, franchiseTeamId) {
+  const map = buildSeasonTeamMap(season);
+  const hid = Number(game?.homeId);
+  const aid = Number(game?.awayId);
+  if (hid === franchiseTeamId) return map[aid]?.abbr ?? 'OPP';
+  if (aid === franchiseTeamId) return map[hid]?.abbr ?? 'OPP';
+  return 'OPP';
+}
+
+function franchiseStandingMetrics(season, standing, teamId, teamAbbr) {
+  const games = seasonGamesFromStandings(standing);
+  if (games <= 0) return null;
+  const pf = num(standing.pf ?? standing.ptsFor);
+  const pa = num(standing.pa ?? standing.ptsAgainst);
+  const wins = num(standing.wins);
+  const losses = num(standing.losses);
+  const ties = num(standing.ties);
+  const winPct = (wins + ties * 0.5) / games;
+  return {
+    year: Number(season?.year ?? season?.season ?? 0) || 0,
+    seasonId: season?.seasonId ?? season?.id ?? null,
+    wins,
+    losses,
+    ties,
+    games,
+    pf,
+    pa,
+    winPct,
+    pointDifferential: pf - pa,
+    ppg: pf / games,
+    papg: pa / games,
+    champion: championMatches(season, teamId, teamAbbr),
+    runnerUp: runnerUpMatches(season, teamId, teamAbbr),
+    playoffCaliber: wins >= PLAYOFF_CALIBER_WINS,
+    losingSeason: wins < losses,
+    eliteSeason: wins >= ELITE_WINS,
+    truePlayoff: seasonHasTruePlayoffAppearance(season, teamId, teamAbbr),
+    mvp: season?.awards?.mvp ?? null,
+  };
+}
+
+function pickBetterSeason(a, b, mode) {
+  if (!a) return b;
+  if (!b) return a;
+  if (mode === 'best') {
+    if (a.wins !== b.wins) return a.wins > b.wins ? a : b;
+    if (a.winPct !== b.winPct) return a.winPct > b.winPct ? a : b;
+    return a.pointDifferential >= b.pointDifferential ? a : b;
+  }
+  if (a.wins !== b.wins) return a.wins < b.wins ? a : b;
+  if (a.winPct !== b.winPct) return a.winPct < b.winPct ? a : b;
+  return a.pointDifferential <= b.pointDifferential ? a : b;
+}
+
+function franchiseTeamSeasonBlock(seasonRows) {
+  const candidates = seasonRows.filter(Boolean);
+  if (!candidates.length) {
+    return {
+      wins: null,
+      winPct: null,
+      pointsFor: null,
+      pointsAllowed: null,
+      pointDifferential: null,
+      pointsPerGame: null,
+      pointsAllowedPerGame: null,
+    };
+  }
+  let bestWins = null;
+  let bestWinPct = null;
+  let bestPf = null;
+  let bestPa = null;
+  let bestDiff = null;
+  let bestPpg = null;
+  let bestPapg = null;
+  for (const c of candidates) {
+    bestWins = pickBetterSeason(bestWins, c, 'best');
+    if (
+      !bestWinPct
+      || c.winPct > bestWinPct.winPct
+      || (c.winPct === bestWinPct.winPct && c.wins > bestWinPct.wins)
+    ) bestWinPct = c;
+    bestPf = pickBetterSeason(bestPf, c, 'best');
+    bestPa = bestPa == null || c.pa < bestPa.pa ? c : bestPa;
+    bestDiff = pickBetterSeason(bestDiff, c, 'best');
+    bestPpg = pickBetterSeason(bestPpg, c, 'best');
+    bestPapg = bestPapg == null || c.papg < bestPapg.papg ? c : bestPapg;
+  }
+  const toRow = (key, label, src, valuePick) => {
+    if (!src) return { recordKey: key, label, value: null, year: null, sourceSeasonId: null, source: 'franchise' };
+    return {
+      recordKey: key,
+      label,
+      value: valuePick(src),
+      teamId: src.teamId ?? null,
+      teamAbbr: src.teamAbbr ?? null,
+      year: src.year,
+      sourceSeasonId: src.sourceSeasonId ?? null,
+      source: 'franchiseArchive',
+    };
+  };
+  const tid = candidates[0]?.teamId ?? null;
+  const ab = candidates[0]?.teamAbbr ?? null;
+  const attach = (row) => (row ? { ...row, teamId: tid, teamAbbr: ab } : row);
+  return {
+    wins: attach(toRow('wins', 'Most wins in a season', bestWins, (s) => s.wins)),
+    winPct: attach(toRow('winPct', 'Best win percentage', bestWinPct, (s) => Math.round(s.winPct * 1000) / 1000)),
+    pointsFor: attach(toRow('pointsFor', 'Most points scored (season)', bestPf, (s) => s.pf)),
+    pointsAllowed: attach(toRow('pointsAllowed', 'Fewest points allowed (season)', bestPa, (s) => s.pa)),
+    pointDifferential: attach(toRow('pointDifferential', 'Best point differential', bestDiff, (s) => s.pointDifferential)),
+    pointsPerGame: attach(toRow('pointsPerGame', 'Best points per game', bestPpg, (s) => Math.round(s.ppg * 100) / 100)),
+    pointsAllowedPerGame: attach(toRow('pointsAllowedPerGame', 'Fewest points allowed per game', bestPapg, (s) => Math.round(s.papg * 100) / 100)),
+  };
+}
+
+function readFromTotals(totals, keys) {
+  if (!totals || typeof totals !== 'object') return 0;
+  for (const k of keys) {
+    const v = num(totals[k]);
+    if (v !== 0) return v;
+  }
+  return 0;
+}
+
+const STAT_ROW_VALUE = {
+  [RECORD_KEYS.passingYards]: (s) => readFromTotals(s.totals, ['passYd', 'passingYards']),
+  [RECORD_KEYS.passingTD]: (s) => readFromTotals(s.totals, ['passTD', 'passingTd']),
+  [RECORD_KEYS.rushingYards]: (s) => readFromTotals(s.totals, ['rushYd', 'rushingYards']),
+  [RECORD_KEYS.rushingTD]: (s) => readFromTotals(s.totals, ['rushTD', 'rushingTd']),
+  [RECORD_KEYS.receivingYards]: (s) => readFromTotals(s.totals, ['recYd', 'receivingYards']),
+  [RECORD_KEYS.receivingTD]: (s) => readFromTotals(s.totals, ['recTD', 'receivingTd']),
+  [RECORD_KEYS.tackles]: (s) => readFromTotals(s.totals, ['tackles']),
+  [RECORD_KEYS.sacks]: (s) => readFromTotals(s.totals, ['sacks']),
+  [RECORD_KEYS.interceptions]: (s) => defensiveInterceptionsSeasonValue(s),
+  [RECORD_KEYS.fieldGoalsMade]: (s) => readFromTotals(s.totals, ['fgMade', 'fieldGoalsMade']),
+};
+
+function collectAwardRows(season, teamId, teamAbbr) {
+  const out = [];
+  const awards = season?.awards;
+  if (!awards || typeof awards !== 'object') return out;
+  for (const [awardKey, v] of Object.entries(awards)) {
+    if (!v || typeof v !== 'object' || Array.isArray(v)) continue;
+    if (v.playerId == null && v.id == null) continue;
+    const pid = v.playerId ?? v.id;
+    if (!teamMatchesFranchise(v, teamId, teamAbbr)) continue;
+    out.push({
+      awardKey,
+      playerId: pid,
+      name: v.name ?? null,
+      pos: v.pos ?? v.position ?? null,
+      year: Number(season?.year ?? 0) || null,
+    });
+  }
+  return out;
+}
+
+function archiveRowToCareerLine(row, seasonYear) {
+  const t = row?.totals ?? row?.stats ?? {};
+  const seasonToken = row?.season ?? row?.year ?? seasonYear;
+  const wrap = { ...row, totals: t, pos: row?.pos };
+  return {
+    season: seasonToken,
+    passYds: num(t.passYd ?? t.passingYards),
+    passTDs: num(t.passTD ?? t.passingTd),
+    rushYds: num(t.rushYd ?? t.rushingYards),
+    rushTDs: num(t.rushTD ?? t.rushingTd),
+    recYds: num(t.recYd ?? t.receivingYards),
+    recTDs: num(t.recTD ?? t.receivingTd),
+    tackles: num(t.tackles),
+    sacks: num(t.sacks),
+    fgMade: num(t.fgMade ?? t.fieldGoalsMade),
+    defInts: defensiveInterceptionsSeasonValue(wrap),
+  };
+}
+
+function buildFranchiseCareerLeadersFromArchives(seasons, teamId, teamAbbr) {
+  const byPlayer = new Map();
+  for (const season of seasons || []) {
+    const year = Number(season?.year ?? 0) || null;
+    const seasonId = season?.seasonId ?? season?.id ?? null;
+    const pool = [...(season.playerStats ?? []), ...(season.seasonStats ?? [])];
+    if (!Array.isArray(pool) || !pool.length) continue;
+    for (const row of pool) {
+      if (!teamMatchesFranchise(row, teamId, teamAbbr)) continue;
+      const pid = row.playerId ?? row.id;
+      if (pid == null) continue;
+      const key = String(pid);
+      if (!byPlayer.has(key)) byPlayer.set(key, { playerId: pid, name: row.name ?? null, pos: row.pos ?? null, lines: [] });
+      byPlayer.get(key).lines.push(archiveRowToCareerLine(row, year ?? seasonId));
+    }
+  }
+  const leaders = {};
+  for (const k of RECORD_BOOK_PLAYER_KEYS) leaders[k] = [];
+  for (const { playerId, name, pos, lines } of byPlayer.values()) {
+    if (!lines.length) continue;
+    const deduped = dedupeCareerStatLines(lines);
+    const synthetic = { id: playerId, name, pos, careerStats: deduped };
+    const totals = careerTotalsFromPlayer(synthetic);
+    for (const k of RECORD_BOOK_PLAYER_KEYS) {
+      const v = num(totals[k]);
+      if (v <= 0) continue;
+      leaders[k].push({
+        recordKey: k,
+        label: RECORD_LABELS[k],
+        value: v,
+        playerId,
+        playerName: name,
+        position: pos,
+        source: 'franchiseCareerArchive',
+      });
+    }
+  }
+  for (const k of RECORD_BOOK_PLAYER_KEYS) {
+    leaders[k].sort((a, b) => b.value - a.value);
+    leaders[k] = leaders[k].slice(0, 5);
+  }
+  return { leaders, hadPerSeasonStats: byPlayer.size > 0 };
+}
+
+function summarizeBracket(snapshot) {
+  if (!snapshot || snapshot.mode === 'empty') return null;
+  const parts = [];
+  for (const r of snapshot.rounds ?? []) {
+    const g0 = (r.games ?? [])[0];
+    if (g0) parts.push(`${r.label}: ${g0.awayAbbr ?? '?'} ${g0.awayScore ?? '—'}-${g0.homeScore ?? '—'} ${g0.homeAbbr ?? '?'}`);
+  }
+  return parts.slice(0, 4).join(' · ') || null;
+}
+
+function buildPlayoffHistoryRows(seasons, teamId, teamAbbr) {
+  const rows = [];
+  for (const season of seasons || []) {
+    const year = Number(season?.year ?? 0) || 0;
+    if (!year) continue;
+    const isChamp = championMatches(season, teamId, teamAbbr);
+    const isRun = runnerUpMatches(season, teamId, teamAbbr);
+    if (!isChamp && !isRun && !seasonHasTruePlayoffAppearance(season, teamId, teamAbbr)) continue;
+    const cg = (season.notableGames ?? []).find((g) => g.type === 'championship');
+    const franchiseSide = cg && teamId != null && (Number(cg.homeId) === Number(teamId) || Number(cg.awayId) === Number(teamId));
+    rows.push({
+      year,
+      role: isChamp ? 'champion' : isRun ? 'runner_up' : 'playoffs',
+      finalsText: season?.playoffSummary?.finals ?? null,
+      bracketSummary: summarizeBracket(season.playoffBracketSnapshot),
+      championshipScores: franchiseSide && cg
+        ? { homeScore: cg.homeScore, awayScore: cg.awayScore, week: cg.week, gameId: cg.gameId ?? cg.id }
+        : null,
+    });
+  }
+  return rows.sort((a, b) => b.year - a.year);
+}
+
+function buildBestGames(seasons, teamId, teamAbbr) {
+  if (teamId == null || !Number.isFinite(Number(teamId))) return [];
+  const tid = Number(teamId);
+  const candidates = [];
+
+  const pushCand = (ctx) => {
+    if (!ctx.gameId && !ctx.id) return;
+    candidates.push(ctx);
+  };
+
+  for (const season of seasons || []) {
+    const year = Number(season?.year ?? 0) || 0;
+    const teamMap = buildSeasonTeamMap(season);
+    for (const ng of season.notableGames ?? []) {
+      const hid = Number(ng?.homeId);
+      const aid = Number(ng?.awayId);
+      if (hid !== tid && aid !== tid) continue;
+      if (!Number.isFinite(Number(ng?.homeScore)) || !Number.isFinite(Number(ng?.awayScore))) continue;
+      const opp = opponentAbbrForGame(season, ng, tid);
+      const won = (hid === tid && num(ng.homeScore) > num(ng.awayScore)) || (aid === tid && num(ng.awayScore) > num(ng.homeScore));
+      let reason = ng.type === 'championship' ? 'Championship game' : ng.type === 'highest_scoring' ? 'League highest-scoring game' : 'Notable game';
+      pushCand({
+        gameId: ng.gameId ?? ng.id,
+        id: ng.id ?? ng.gameId,
+        year,
+        week: ng.week,
+        homeId: hid,
+        awayId: aid,
+        home: teamMap[hid],
+        away: teamMap[aid],
+        homeScore: ng.homeScore,
+        awayScore: ng.awayScore,
+        opponentAbbr: opp,
+        reason,
+        margin: Math.abs(num(ng.homeScore) - num(ng.awayScore)),
+        total: num(ng.homeScore) + num(ng.awayScore),
+        won,
+      });
+    }
+
+    for (const g of season.gameIndex ?? []) {
+      const hid = Number(g?.homeId);
+      const aid = Number(g?.awayId);
+      if (hid !== tid && aid !== tid) continue;
+      if (!Number.isFinite(Number(g?.homeScore)) || !Number.isFinite(Number(g?.awayScore))) continue;
+      const hs = num(g.homeScore);
+      const as = num(g.awayScore);
+      const margin = Math.abs(hs - as);
+      const total = hs + as;
+      const won = (hid === tid && hs > as) || (aid === tid && as > hs);
+      let reason = 'Regular season';
+      if (margin <= 3 && margin > 0) reason = won ? 'Close win' : 'Close loss';
+      else if (margin >= 28 && won) reason = 'Big win';
+      pushCand({
+        gameId: g.id,
+        id: g.id,
+        year,
+        week: g.week,
+        homeId: hid,
+        awayId: aid,
+        home: teamMap[hid],
+        away: teamMap[aid],
+        homeScore: g.homeScore,
+        awayScore: g.awayScore,
+        opponentAbbr: opponentAbbrForGame(season, g, tid),
+        reason,
+        margin,
+        total,
+        won,
+      });
+    }
+  }
+
+  const seen = new Set();
+  const uniq = [];
+  for (const c of candidates) {
+    const k = `${c.year}-${c.week}-${c.gameId ?? c.id}`;
+    if (seen.has(k)) continue;
+    seen.add(k);
+    uniq.push(c);
+  }
+
+  const highest = [...uniq].sort((a, b) => b.total - a.total).slice(0, 3).map((c) => ({ ...c, reason: c.total >= 55 ? 'High-scoring game' : c.reason }));
+  const bigWins = [...uniq].filter((c) => c.won).sort((a, b) => b.margin - a.margin).slice(0, 3).map((c) => ({ ...c, reason: 'Biggest win margin' }));
+  const close = [...uniq].filter((c) => c.margin >= 1 && c.margin <= 3).sort((a, b) => b.year - a.year).slice(0, 4);
+
+  const merged = [...highest, ...bigWins, ...close];
+  const out = [];
+  const oseen = new Set();
+  for (const m of merged) {
+    const k = `${m.year}-${m.week}-${m.gameId ?? m.id}`;
+    if (oseen.has(k)) continue;
+    oseen.add(k);
+    out.push(m);
+  }
+  return out.slice(0, 12);
+}
+
+function buildMilestones(summary, bestSeason, worstSeason, titles) {
+  const m = [];
+  if (titles > 0 && bestSeason) m.push({ type: 'peak', text: `Best archived season: ${bestSeason.year} (${bestSeason.wins}-${bestSeason.losses}${bestSeason.ties ? `-${bestSeason.ties}` : ''}).` });
+  if (worstSeason) m.push({ type: 'valley', text: `Toughest archived season: ${worstSeason.year} (${worstSeason.wins}-${worstSeason.losses}${worstSeason.ties ? `-${worstSeason.ties}` : ''}).` });
+  if (summary.titles > 0) m.push({ type: 'titles', text: `${summary.titles} championship${summary.titles === 1 ? '' : 's'} in the archive window.` });
+  return m.slice(0, 8);
+}
+
+const LEGEND_REASON = {
+  HOF: { rank: 100, label: 'Hall of Famer' },
+  MVP: { rank: 85, label: 'League MVP' },
+  CHAMP_STAR: { rank: 78, label: 'Championship star' },
+  RECORD: { rank: 60, label: 'Franchise record holder' },
+  CAREER: { rank: 45, label: 'Franchise career leader' },
+};
+
+function mergeLegend(map, entry) {
+  const id = String(entry.playerId);
+  const prev = map.get(id);
+  if (!prev || entry.rank > prev.rank) {
+    map.set(id, { ...entry });
+    return;
+  }
+  if (entry.rank === prev.rank && num(entry.legacyScore) > num(prev.legacyScore)) {
+    map.set(id, { ...prev, ...entry });
+  }
+}
+
+function buildFranchiseLegends({
+  seasons,
+  teamId,
+  teamAbbr,
+  franchiseRecords,
+  careerLeadersHadStats,
+  careerLeaders,
+  hallOfFamePlayers,
+  hallOfFameClasses,
+}) {
+  const map = new Map();
+
+  for (const cls of hallOfFameClasses || []) {
+    for (const ind of cls.inductees || []) {
+      const match = teamMatchesFranchise(
+        { teamId: ind.primaryTeamId, teamAbbr: ind.primaryTeamAbbr },
+        teamId,
+        teamAbbr,
+      );
+      if (!match) continue;
+      mergeLegend(map, {
+        playerId: ind.playerId,
+        name: ind.name,
+        pos: ind.pos,
+        yearsSummary: ind.careerSummary ? String(ind.careerSummary).slice(0, 80) : `Class of ${cls.year}`,
+        legacyScore: ind.legacyScore ?? ind.score ?? null,
+        topReason: LEGEND_REASON.HOF.label,
+        rank: LEGEND_REASON.HOF.rank,
+        hof: true,
+      });
+    }
+  }
+
+  for (const p of hallOfFamePlayers || []) {
+    const abMatch = normAbbr(p.primaryTeamAbbr ?? p.primaryTeam) === normAbbr(teamAbbr);
+    const hist = Array.isArray(p.teamHistory) && p.teamHistory.some((x) => normAbbr(x) === normAbbr(teamAbbr));
+    if (!abMatch && !hist) continue;
+    if (p.fromClassOnly && map.has(String(p.id))) continue;
+    mergeLegend(map, {
+      playerId: p.id,
+      name: p.name,
+      pos: p.pos,
+      yearsSummary: p.careerSummary ?? (hist ? `Played for ${teamAbbr}` : null),
+      legacyScore: p.legacyScore ?? p.hofScore ?? null,
+      topReason: LEGEND_REASON.HOF.label,
+      rank: LEGEND_REASON.HOF.rank,
+      hof: true,
+    });
+  }
+
+  for (const season of seasons || []) {
+    for (const a of collectAwardRows(season, teamId, teamAbbr)) {
+      if (String(a.awardKey).toLowerCase() === 'mvp') {
+        mergeLegend(map, {
+          playerId: a.playerId,
+          name: a.name,
+          pos: a.pos,
+          yearsSummary: `${a.year} ${a.awardKey}`,
+          legacyScore: null,
+          topReason: LEGEND_REASON.MVP.label,
+          rank: LEGEND_REASON.MVP.rank,
+        });
+      }
+    }
+    if (championMatches(season, teamId, teamAbbr)) {
+      const sb = season?.awards?.sbMvp;
+      if (sb?.playerId != null) {
+        mergeLegend(map, {
+          playerId: sb.playerId,
+          name: sb.name,
+          pos: sb.pos,
+          yearsSummary: `${season.year} SB MVP`,
+          legacyScore: null,
+          topReason: LEGEND_REASON.CHAMP_STAR.label,
+          rank: LEGEND_REASON.CHAMP_STAR.rank,
+        });
+      }
+    }
+  }
+
+  for (const row of Object.values(franchiseRecords.playerSingleSeason ?? {})) {
+    if (!row?.playerId) continue;
+    mergeLegend(map, {
+      playerId: row.playerId,
+      name: row.playerName,
+      pos: row.position,
+      yearsSummary: row.year ? `${row.year}` : null,
+      legacyScore: null,
+      topReason: LEGEND_REASON.RECORD.label,
+      rank: LEGEND_REASON.RECORD.rank,
+    });
+  }
+
+  if (careerLeadersHadStats) {
+    for (const k of RECORD_BOOK_PLAYER_KEYS) {
+      const top = (careerLeaders[k] ?? [])[0];
+      if (!top?.playerId) continue;
+      mergeLegend(map, {
+        playerId: top.playerId,
+        name: top.playerName,
+        pos: top.position,
+        yearsSummary: 'Career (franchise games in archive)',
+        legacyScore: null,
+        topReason: LEGEND_REASON.CAREER.label,
+        rank: LEGEND_REASON.CAREER.rank,
+      });
+    }
+  }
+
+  return [...map.values()].sort((a, b) => {
+    if (b.rank !== a.rank) return b.rank - a.rank;
+    return num(b.legacyScore) - num(a.legacyScore);
+  }).slice(0, 24);
+}
+
+/**
+ * @param {{
+ *   teamId: number|string|null,
+ *   teamAbbr?: string|null,
+ *   teamName?: string|null,
+ *   archivedSeasons: any[],
+ *   hallOfFamePlayers?: any[],
+ *   hallOfFameClasses?: any[],
+ * }} args
+ */
+export function buildFranchiseHistoryModel({
+  teamId,
+  teamAbbr = null,
+  teamName = null,
+  archivedSeasons = [],
+  hallOfFamePlayers = [],
+  hallOfFameClasses = [],
+} = {}) {
+  const seasonsSorted = [...(archivedSeasons || [])].sort((a, b) => (Number(a?.year ?? 0) - Number(b?.year ?? 0)));
+  const tid = teamId != null ? Number(teamId) : null;
+  const ab = teamAbbr ?? '';
+
+  const seasonRows = [];
+  for (const season of seasonsSorted) {
+    let st = findFranchiseStanding(season, tid, ab);
+    if (!st && championMatches(season, tid, ab) && season.champion) {
+      const c = season.champion;
+      st = {
+        id: c.id,
+        name: c.name,
+        abbr: c.abbr,
+        wins: num(c.wins),
+        losses: num(c.losses),
+        ties: num(c.ties),
+        pf: num(c.pf),
+        pa: num(c.pa),
+      };
+    }
+    if (!st) continue;
+    const m = franchiseStandingMetrics(season, st, tid, ab);
+    if (!m) continue;
+    seasonRows.push({
+      ...m,
+      seasonId: season?.seasonId ?? season?.id ?? null,
+      teamId: st.id ?? tid,
+      teamAbbr: st.abbr ?? ab,
+      standing: st,
+    });
+  }
+
+  const timeline = seasonRows;
+  const titles = timeline.filter((t) => t.champion).length;
+  const runnerUps = timeline.filter((t) => t.runnerUp).length;
+  const playoffCaliberYears = timeline.filter((t) => t.playoffCaliber).length;
+  const postseasonArchive = actualPostseasonArchivePresent(archivedSeasons);
+  const bracketArchive = leagueHasAnyBracketArchive(archivedSeasons);
+  const truePlayoffYears = timeline.filter((t) => t.truePlayoff).length;
+
+  let allW = 0;
+  let allL = 0;
+  let allT = 0;
+  let diffSum = 0;
+  for (const t of timeline) {
+    allW += t.wins;
+    allL += t.losses;
+    allT += t.ties;
+    diffSum += t.pointDifferential;
+  }
+  const denom = allW + allL + allT;
+  const winPct = denom > 0 ? (allW + allT * 0.5) / denom : 0;
+
+  const bestSeason = timeline.reduce((a, t) => pickBetterSeason(a, t, 'best'), null);
+  const worstSeason = timeline.reduce((a, t) => pickBetterSeason(a, t, 'worst'), null);
+
+  const lastFive = timeline.slice(-5);
+  const recentFiveYearAvgWins = lastFive.length ? lastFive.reduce((s, t) => s + t.wins, 0) / lastFive.length : 0;
+  const avgPointDifferential = timeline.length ? diffSum / timeline.length : 0;
+
+  const titleYears = timeline.filter((t) => t.champion).map((t) => t.year);
+  const lastTitleYear = titleYears.length ? Math.max(...titleYears) : null;
+  const lastArchivedYear = timeline.length ? timeline[timeline.length - 1].year : null;
+  let currentTitleDroughtSeasons = 0;
+  if (!titleYears.length) {
+    currentTitleDroughtSeasons = timeline.length;
+  } else if (lastArchivedYear != null && lastTitleYear != null) {
+    currentTitleDroughtSeasons = timeline.filter((t) => t.year > lastTitleYear).length;
+  }
+
+  const playerSingleSeason = {};
+  for (const recordKey of RECORD_BOOK_PLAYER_KEYS) {
+    const archiveKey = Object.keys(ARCHIVE_LEADER_TO_RECORD).find((k) => ARCHIVE_LEADER_TO_RECORD[k] === recordKey);
+    if (!archiveKey) continue;
+    let best = null;
+    for (const season of seasonsSorted) {
+      const leader = season?.playerStatLeaders?.[archiveKey];
+      if (!leader || !teamMatchesFranchise(leader, tid, ab)) continue;
+      const row = leaderEntryToRecordRow(recordKey, leader, season);
+      if (!row) continue;
+      if (!best || row.value > best.value) best = row;
+    }
+    for (const season of seasonsSorted) {
+      const pool = [...(season.playerStats ?? []), ...(season.seasonStats ?? [])];
+      if (!Array.isArray(pool)) continue;
+      const pick = STAT_ROW_VALUE[recordKey];
+      if (!pick) continue;
+      for (const s of pool) {
+        if (!teamMatchesFranchise(s, tid, ab)) continue;
+        const v = num(pick(s));
+        if (v <= 0) continue;
+        const year = Number(season?.year ?? 0) || null;
+        const cand = {
+          recordKey,
+          label: RECORD_LABELS[recordKey],
+          value: v,
+          playerId: s.playerId ?? s.id ?? null,
+          playerName: s.name ?? null,
+          position: s.pos ?? null,
+          teamId: s.teamId ?? null,
+          teamAbbr: s.teamAbbr ?? null,
+          year,
+          sourceSeasonId: season?.seasonId ?? season?.id ?? null,
+          source: 'archivedSeason',
+        };
+        if (!best || cand.value > best.value) best = cand;
+      }
+    }
+    playerSingleSeason[recordKey] = best;
+  }
+
+  const metricsForTeamBlock = timeline.map((t) => ({
+    year: t.year,
+    sourceSeasonId: t.seasonId ?? null,
+    teamId: t.teamId,
+    teamAbbr: t.teamAbbr,
+    wins: t.wins,
+    losses: t.losses,
+    ties: t.ties,
+    games: t.games,
+    pf: t.pf,
+    pa: t.pa,
+    winPct: t.winPct,
+    ppg: t.ppg,
+    papg: t.papg,
+    pointDifferential: t.pointDifferential,
+  }));
+  const teamSeasonRecords = franchiseTeamSeasonBlock(metricsForTeamBlock);
+
+  const { leaders: careerFranchiseLeaders, hadPerSeasonStats } = buildFranchiseCareerLeadersFromArchives(seasonsSorted, tid, ab);
+
+  const franchiseRecords = {
+    teamSeason: teamSeasonRecords,
+    playerSingleSeason,
+    careerFranchiseLeaders: hadPerSeasonStats ? careerFranchiseLeaders : {},
+    careerFranchiseLeadersAvailable: hadPerSeasonStats,
+  };
+
+  const playoffHistory = buildPlayoffHistoryRows(seasonsSorted, tid, ab);
+  const bestGames = buildBestGames(seasonsSorted, tid, ab);
+
+  const franchiseLegends = buildFranchiseLegends({
+    seasons: seasonsSorted,
+    teamId: tid,
+    teamAbbr: ab,
+    franchiseRecords,
+    careerLeadersHadStats: hadPerSeasonStats,
+    careerLeaders: careerFranchiseLeaders,
+    hallOfFamePlayers,
+    hallOfFameClasses,
+  });
+
+  const summary = {
+    seasonsArchived: timeline.length,
+    allTimeWins: allW,
+    allTimeLosses: allL,
+    allTimeTies: allT,
+    winPct,
+    titles,
+    runnerUpFinishes: runnerUps,
+    playoffAppearances: truePlayoffYears,
+    playoffCaliberYears,
+    postseasonArchivePresent: postseasonArchive,
+    bracketArchivePresent: bracketArchive,
+    bestSeason,
+    worstSeason,
+    currentTitleDroughtSeasons,
+    recentFiveYearAvgWins,
+    avgPointDifferential,
+  };
+
+  const milestones = buildMilestones(summary, bestSeason, worstSeason, titles);
+
+  return {
+    teamId: tid,
+    teamName: teamName ?? null,
+    teamAbbr: ab || null,
+    summary,
+    seasons: timeline,
+    franchiseRecords,
+    franchiseLegends,
+    bestGames,
+    playoffHistory,
+    milestones,
+  };
+}
+
+export { PLAYOFF_CALIBER_WINS, ELITE_WINS };

--- a/src/ui/components/TeamHistoryScreen.jsx
+++ b/src/ui/components/TeamHistoryScreen.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { ScreenHeader, SectionCard, EmptyState } from './ScreenSystem.jsx';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from '../utils/boxScoreAccess.js';
+import { buildFranchiseHistoryModel, PLAYOFF_CALIBER_WINS } from '../../core/franchiseHistoryModel.js';
+import { RECORD_BOOK_PLAYER_KEYS, RECORD_LABELS } from '../../core/recordBookV1.js';
 
 function buildSeasonTeamMap(season) {
   const map = {};
@@ -10,49 +12,79 @@ function buildSeasonTeamMap(season) {
   return map;
 }
 
+function formatPct(p) {
+  if (!Number.isFinite(p) || p <= 0) return '—';
+  return `${(p * 100).toFixed(1)}%`;
+}
+
+function RecordRow({ label, value, detail }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, fontSize: 'var(--text-sm)', padding: '6px 0', borderBottom: '1px solid var(--hairline)' }}>
+      <span style={{ color: 'var(--text-muted)' }}>{label}</span>
+      <span style={{ textAlign: 'right' }}>
+        <strong>{value == null || value === '' ? '—' : value}</strong>
+        {detail ? <div style={{ fontSize: 11, color: 'var(--text-muted)', fontWeight: 400 }}>{detail}</div> : null}
+      </span>
+    </div>
+  );
+}
+
 export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSelect, onBack, onOpenBoxScore }) {
   const [seasons, setSeasons] = useState([]);
+  const [hofPlayers, setHofPlayers] = useState([]);
+  const [hofClasses, setHofClasses] = useState([]);
   const [loading, setLoading] = useState(true);
   const [queryYear, setQueryYear] = useState('');
   const [scope, setScope] = useState('all');
-  const activeTeam = useMemo(() => (league?.teams ?? []).find((t) => Number(t.id) === Number(teamId ?? league?.userTeamId)), [league?.teams, league?.userTeamId, teamId]);
+
+  const activeTeam = useMemo(
+    () => (league?.teams ?? []).find((t) => Number(t.id) === Number(teamId ?? league?.userTeamId)),
+    [league?.teams, league?.userTeamId, teamId],
+  );
 
   useEffect(() => {
-    let mounted = true;
-    actions?.getAllSeasons?.().then((res) => {
-      if (!mounted) return;
-      setSeasons(res?.payload?.seasons ?? []);
-      setLoading(false);
-    }).catch(() => setLoading(false));
-    return () => { mounted = false; };
+    let cancelled = false;
+    (async () => {
+      try {
+        const pSeasons = actions?.getAllSeasons?.().catch(() => ({ payload: { seasons: [] } })) ?? Promise.resolve({ payload: { seasons: [] } });
+        const pHof = actions?.getHallOfFame?.().catch(() => ({ payload: { players: [], classes: [] } })) ?? Promise.resolve({ payload: { players: [], classes: [] } });
+        const [sRes, hRes] = await Promise.all([pSeasons, pHof]);
+        if (cancelled) return;
+        setSeasons(sRes?.payload?.seasons ?? []);
+        setHofPlayers(hRes?.payload?.players ?? []);
+        setHofClasses(hRes?.payload?.classes ?? []);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
   }, [actions]);
 
-  const timeline = useMemo(() => (seasons ?? []).map((s) => {
-    const standing = (s.standings ?? []).find((t) => t.id === activeTeam?.id || t.abbr === activeTeam?.abbr);
-    const isChampion = s?.champion?.abbr === activeTeam?.abbr;
-    return { year: s.year, wins: standing?.wins ?? 0, losses: standing?.losses ?? 0, ties: standing?.ties ?? 0, pf: standing?.pf ?? 0, pa: standing?.pa ?? 0, champion: isChampion, mvp: s?.awards?.mvp };
-  }).filter((x) => x.wins + x.losses + x.ties > 0 || x.champion), [seasons, activeTeam]);
+  const model = useMemo(
+    () => buildFranchiseHistoryModel({
+      teamId: activeTeam?.id ?? null,
+      teamAbbr: activeTeam?.abbr ?? null,
+      teamName: activeTeam?.name ?? null,
+      archivedSeasons: seasons,
+      hallOfFamePlayers: hofPlayers,
+      hallOfFameClasses: hofClasses,
+    }),
+    [activeTeam?.abbr, activeTeam?.id, activeTeam?.name, seasons, hofPlayers, hofClasses],
+  );
+
+  const { summary, franchiseRecords, franchiseLegends, playoffHistory, bestGames, milestones } = model;
 
   const filteredTimeline = useMemo(() => {
-    return timeline.filter((row) => {
+    return (model.seasons ?? []).filter((row) => {
       if (scope === 'champions' && !row.champion) return false;
-      if (scope === 'playoff' && row.wins < 10) return false;
+      if (scope === 'playoff' && !row.playoffCaliber) return false;
+      if (scope === 'losing' && !row.losingSeason) return false;
+      if (scope === 'elite' && !row.eliteSeason) return false;
       if (!queryYear.trim()) return true;
       return String(row.year).includes(queryYear.trim());
     });
-  }, [timeline, queryYear, scope]);
+  }, [model.seasons, queryYear, scope]);
 
-  const titles = timeline.filter((t) => t.champion).length;
-  const playoffYears = timeline.filter((t) => t.wins >= 10).length;
-  const best = [...timeline].sort((a, b) => b.wins - a.wins)[0];
-  const worst = [...timeline].sort((a, b) => a.wins - b.wins)[0];
-  const drought = [...timeline].reverse().findIndex((t) => t.champion);
-  const recentFive = timeline.slice(-5);
-  const recentTrend = recentFive.length ? (recentFive.reduce((sum, row) => sum + Number(row.wins ?? 0), 0) / recentFive.length).toFixed(1) : "0.0";
-  const avgDiff = timeline.length ? (timeline.reduce((sum, row) => sum + (Number(row.pf ?? 0) - Number(row.pa ?? 0)), 0) / timeline.length).toFixed(1) : "0.0";
-  const timelineStory = timeline.length
-    ? `${activeTeam?.abbr ?? activeTeam?.name ?? "Team"} posted ${titles} title${titles === 1 ? "" : "s"} and ${playoffYears} playoff-caliber seasons across ${timeline.length} archived years.`
-    : "Franchise history starts once completed seasons are archived.";
   const completedGameRows = useMemo(() => {
     const rows = [];
     const targetTeamId = Number(activeTeam?.id);
@@ -81,37 +113,219 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
 
     return rows
       .sort((a, b) => (Number(b.year) - Number(a.year)) || (Number(b.week) - Number(a.week)))
-      .slice(0, 24);
+      .slice(0, 36);
   }, [activeTeam?.id, seasons]);
 
   if (loading) return <div className="card" style={{ padding: 'var(--space-4)' }}>Loading team history…</div>;
+
+  const ab = activeTeam?.abbr ?? activeTeam?.name ?? 'Team';
+  const postseason = summary.postseasonArchivePresent;
+  const story = (model.seasons ?? []).length
+    ? `${ab} archived ${summary.seasonsArchived} season${summary.seasonsArchived === 1 ? '' : 's'}${postseason ? `, ${summary.playoffAppearances} documented postseason appearance${summary.playoffAppearances === 1 ? '' : 's'}` : ''}${!postseason ? ` and ${summary.playoffCaliberYears} playoff-caliber year${summary.playoffCaliberYears === 1 ? '' : 's'} (${PLAYOFF_CALIBER_WINS}+ wins).` : '.'}`
+    : 'Franchise history starts once completed seasons are archived.';
+
+  const droughtLabel = summary.titles === 0
+    ? 'No title yet'
+    : `${summary.currentTitleDroughtSeasons} season${summary.currentTitleDroughtSeasons === 1 ? '' : 's'}`;
 
   return (
     <div className="app-screen-stack">
       <ScreenHeader
         title={`${activeTeam?.name ?? 'Team'} History`}
-        subtitle="Franchise timeline, drought context, best/worst runs, and milestones."
+        subtitle="Franchise record book, legends, postseason truth, and season-by-season identity."
         onBack={onBack}
         backLabel="History Hub"
       />
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(170px,1fr))', gap: 10 }}>
-        <div className="stat-box"><div className="stat-label">Titles</div><div className="stat-value-large">{titles}</div></div>
-        <div className="stat-box"><div className="stat-label">Playoff-caliber years</div><div className="stat-value-large">{playoffYears}</div></div>
-        <div className="stat-box"><div className="stat-label">Current drought</div><div className="stat-value-large">{drought < 0 ? 'No title yet' : `${drought} seasons`}</div></div>
-        <div className="stat-box"><div className="stat-label">Recent avg wins (5y)</div><div className="stat-value-large">{recentTrend}</div></div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit,minmax(150px,1fr))', gap: 10 }}>
+        <div className="stat-box">
+          <div className="stat-label">All-time record</div>
+          <div className="stat-value-large" style={{ fontSize: 'clamp(1.1rem, 4vw, 1.35rem)' }}>
+            {summary.seasonsArchived ? `${summary.allTimeWins}-${summary.allTimeLosses}${summary.allTimeTies ? `-${summary.allTimeTies}` : ''}` : '—'}
+          </div>
+        </div>
+        <div className="stat-box">
+          <div className="stat-label">Win %</div>
+          <div className="stat-value-large">{summary.seasonsArchived ? formatPct(summary.winPct) : '—'}</div>
+        </div>
+        <div className="stat-box">
+          <div className="stat-label">Titles</div>
+          <div className="stat-value-large">{summary.titles}</div>
+        </div>
+        <div className="stat-box">
+          <div className="stat-label">Runner-up</div>
+          <div className="stat-value-large">{summary.runnerUpFinishes}</div>
+        </div>
+        {postseason ? (
+          <div className="stat-box">
+            <div className="stat-label">Playoff appearances</div>
+            <div className="stat-value-large">{summary.playoffAppearances}</div>
+            <div className="stat-label" style={{ marginTop: 4, fontSize: 10, opacity: 0.85 }}>Documented postseason</div>
+          </div>
+        ) : (
+          <div className="stat-box">
+            <div className="stat-label">Playoff-caliber years</div>
+            <div className="stat-value-large">{summary.playoffCaliberYears}</div>
+            <div className="stat-label" style={{ marginTop: 4, fontSize: 10, opacity: 0.85 }}>{`${PLAYOFF_CALIBER_WINS}+ wins (no bracket/champion data in this save)`}</div>
+          </div>
+        )}
+        {postseason ? (
+          <div className="stat-box">
+            <div className="stat-label">Playoff-caliber years</div>
+            <div className="stat-value-large">{summary.playoffCaliberYears}</div>
+            <div className="stat-label" style={{ marginTop: 4, fontSize: 10, opacity: 0.85 }}>{`${PLAYOFF_CALIBER_WINS}+ wins`}</div>
+          </div>
+        ) : null}
+        <div className="stat-box">
+          <div className="stat-label">Title drought</div>
+          <div className="stat-value-large">{droughtLabel}</div>
+        </div>
+        <div className="stat-box">
+          <div className="stat-label">Avg wins (last 5)</div>
+          <div className="stat-value-large">{summary.seasonsArchived ? summary.recentFiveYearAvgWins.toFixed(1) : '—'}</div>
+        </div>
+        <div className="stat-box">
+          <div className="stat-label">Avg pt diff / yr</div>
+          <div className="stat-value-large">{summary.seasonsArchived ? summary.avgPointDifferential.toFixed(1) : '—'}</div>
+        </div>
       </div>
 
       <SectionCard title="Franchise memory capsule">
-        <div style={{ fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}>{timelineStory}</div>
-        <div style={{ marginTop: 8, fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
-          Average point differential across archived seasons: <strong style={{ color: 'var(--text)' }}>{avgDiff}</strong>
-        </div>
+        <div style={{ fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}>{story}</div>
+        {milestones.length ? (
+          <ul style={{ margin: '10px 0 0', paddingLeft: 18, fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+            {milestones.map((m) => (
+              <li key={m.text}>{m.text}</li>
+            ))}
+          </ul>
+        ) : null}
+      </SectionCard>
+
+      <SectionCard title="Franchise records" subtitle="Single-franchise stats from archived seasons only.">
+        <div style={{ fontWeight: 700, marginBottom: 6 }}>Team season</div>
+        {['wins', 'winPct', 'pointsFor', 'pointsAllowed', 'pointDifferential', 'pointsPerGame', 'pointsAllowedPerGame'].map((k) => {
+          const row = franchiseRecords.teamSeason?.[k];
+          const detail = row?.year ? `${row.year}` : null;
+          return <RecordRow key={k} label={row?.label ?? k} value={row?.value} detail={detail} />;
+        })}
+        <div style={{ fontWeight: 700, margin: '14px 0 6px' }}>Player single-season (this franchise)</div>
+        {RECORD_BOOK_PLAYER_KEYS.map((k) => {
+          const row = franchiseRecords.playerSingleSeason?.[k];
+          const label = RECORD_LABELS[k];
+          const detail = row ? [row.year, row.playerName].filter(Boolean).join(' · ') : 'No leader in archive';
+          return <RecordRow key={k} label={label} value={row?.value} detail={detail} />;
+        })}
+        <div style={{ fontWeight: 700, margin: '14px 0 6px' }}>Career franchise leaders</div>
+        {franchiseRecords.careerFranchiseLeadersAvailable ? (
+          RECORD_BOOK_PLAYER_KEYS.map((k) => {
+            const top = franchiseRecords.careerFranchiseLeaders?.[k]?.[0];
+            const label = RECORD_LABELS[k];
+            if (!top) return <RecordRow key={`c-${k}`} label={label} value={null} detail="—" />;
+            return <RecordRow key={`c-${k}`} label={label} value={top.value} detail={top.playerName} />;
+          })
+        ) : (
+          <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+            Career totals need per-season player stats stored on archived seasons. This save only carries league-wide stat leaders in each archive.
+          </div>
+        )}
+      </SectionCard>
+
+      <SectionCard title="Franchise legends" subtitle="Hall of Famers, honors, and record-setters tied to this club.">
+        {franchiseLegends.length === 0 ? (
+          <div style={{ fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}>Franchise legends will emerge as seasons archive.</div>
+        ) : (
+          <div style={{ display: 'grid', gap: 10 }}>
+            {franchiseLegends.map((leg) => (
+              <div key={String(leg.playerId)} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: 10 }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>
+                  {leg.playerId != null ? (
+                    <button type="button" className="btn-link" onClick={() => onPlayerSelect?.(leg.playerId)} style={{ fontWeight: 700 }}>
+                      {leg.name ?? 'Player'}
+                    </button>
+                  ) : (
+                    <strong>{leg.name ?? 'Player'}</strong>
+                  )}
+                  <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>{leg.pos ?? '—'}</span>
+                </div>
+                <div style={{ fontSize: 12, color: 'var(--accent)', marginTop: 4 }}>{leg.topReason}</div>
+                {leg.yearsSummary ? <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 4 }}>{leg.yearsSummary}</div> : null}
+                {leg.legacyScore != null ? <div style={{ fontSize: 11, marginTop: 4 }}>Legacy score: {leg.legacyScore}</div> : null}
+              </div>
+            ))}
+          </div>
+        )}
+      </SectionCard>
+
+      <SectionCard title="Playoff & title history" subtitle={postseason ? 'Titles, runner-up finishes, and bracket snapshots when archived.' : 'Postseason data unavailable for this era of saves — see playoff-caliber years above.'}>
+        {playoffHistory.length === 0 ? (
+          <EmptyState title="No documented postseason for this franchise yet" body="Win a title, reach the final, or archive seasons with playoff brackets to populate this list." />
+        ) : (
+          <div style={{ display: 'grid', gap: 10 }}>
+            {playoffHistory.map((row) => (
+              <div key={row.year} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: 10 }}>
+                <strong>{row.year}</strong>
+                {' · '}
+                <span>{row.role === 'champion' ? 'Champion' : row.role === 'runner_up' ? 'Runner-up' : 'Playoffs'}</span>
+                {row.finalsText ? <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4 }}>{row.finalsText}</div> : null}
+                {row.championshipScores ? (
+                  <div style={{ fontSize: 12, marginTop: 4 }}>
+                    Championship: {row.championshipScores.awayScore ?? '—'}-{row.championshipScores.homeScore ?? '—'}
+                    {row.championshipScores.week != null ? ` · Week ${row.championshipScores.week}` : ''}
+                  </div>
+                ) : null}
+                {row.bracketSummary ? (
+                  <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6 }}>{row.bracketSummary}</div>
+                ) : postseason && row.role === 'playoffs' ? (
+                  <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 6 }}>Postseason bracket not available for this era.</div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        )}
       </SectionCard>
 
       <SectionCard title="Best and worst seasons">
-        <div style={{ fontSize: 'var(--text-sm)' }}>Best: {best ? `${best.year} (${best.wins}-${best.losses}${best.ties ? `-${best.ties}` : ''})` : '—'}</div>
-        <div style={{ fontSize: 'var(--text-sm)' }}>Worst: {worst ? `${worst.year} (${worst.wins}-${worst.losses}${worst.ties ? `-${worst.ties}` : ''})` : '—'}</div>
+        <div style={{ fontSize: 'var(--text-sm)' }}>
+          Best:{' '}
+          {summary.bestSeason
+            ? `${summary.bestSeason.year} (${summary.bestSeason.wins}-${summary.bestSeason.losses}${summary.bestSeason.ties ? `-${summary.bestSeason.ties}` : ''})`
+            : '—'}
+        </div>
+        <div style={{ fontSize: 'var(--text-sm)' }}>
+          Worst:{' '}
+          {summary.worstSeason
+            ? `${summary.worstSeason.year} (${summary.worstSeason.wins}-${summary.worstSeason.losses}${summary.worstSeason.ties ? `-${summary.worstSeason.ties}` : ''})`
+            : '—'}
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Defining games" subtitle="Highlights from notable games and score archives.">
+        {bestGames.length === 0 ? (
+          <EmptyState title="No scored games in archive yet" body="Complete seasons with final scores unlock this list." />
+        ) : (
+          <div style={{ display: 'grid', gap: 8 }}>
+            {bestGames.map((row) => {
+              const presentation = buildCompletedGamePresentation(row, { seasonId: row.year, week: row.week, source: 'team_history' });
+              const clickable = Boolean(presentation.canOpen && onOpenBoxScore);
+              return (
+                <button
+                  key={`def-${row.gameId}-${row.year}-${row.week}`}
+                  type="button"
+                  className="btn"
+                  onClick={() => openResolvedBoxScore(row, { seasonId: row.year, week: row.week, source: 'team_history' }, onOpenBoxScore)}
+                  style={{ textAlign: 'left', opacity: clickable ? 1 : 0.7, cursor: clickable ? 'pointer' : 'default' }}
+                  title={clickable ? presentation.ctaLabel : presentation.statusLabel}
+                >
+                  <strong>
+                    {row.year} · Week {row.week} · vs {row.opponentAbbr ?? 'OPP'} · {row.away?.abbr ?? 'AWY'} {row.awayScore ?? '—'}-{row.homeScore ?? '—'} {row.home?.abbr ?? 'HME'}
+                  </strong>
+                  <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4 }}>{row.reason}</div>
+                  <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 2 }}>{clickable ? presentation.ctaLabel : presentation.statusLabel}</div>
+                </button>
+              );
+            })}
+          </div>
+        )}
       </SectionCard>
 
       <SectionCard title="Season-by-season timeline">
@@ -126,28 +340,46 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
             { key: 'all', label: 'All-time' },
             { key: 'playoff', label: 'Playoff-caliber' },
             { key: 'champions', label: 'Championship years' },
+            { key: 'elite', label: 'Elite seasons' },
+            { key: 'losing', label: 'Losing seasons' },
           ].map((opt) => (
-            <button key={opt.key} className="btn" onClick={() => setScope(opt.key)} style={{ opacity: scope === opt.key ? 1 : 0.7 }}>
+            <button key={opt.key} type="button" className="btn" onClick={() => setScope(opt.key)} style={{ opacity: scope === opt.key ? 1 : 0.7 }}>
               {opt.label}
             </button>
           ))}
         </div>
         <div style={{ display: 'grid', gap: 8, maxHeight: 420, overflow: 'auto' }}>
-          {filteredTimeline.length === 0 ? <EmptyState title="No team history yet" body="Adjust filters or play more seasons to populate this timeline." /> : filteredTimeline.slice().reverse().map((s) => (
-            <div key={s.year} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: 10 }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
-                <strong>{s.year}</strong>
-                <span>{s.wins}-{s.losses}{s.ties ? `-${s.ties}` : ''}{s.champion ? ' · 🏆 Champion' : ''}</span>
+          {filteredTimeline.length === 0 ? (
+            <EmptyState title="No team history for this filter" body="Adjust filters or archive more seasons." />
+          ) : (
+            filteredTimeline.slice().reverse().map((s) => (
+              <div key={s.year} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: 10 }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
+                  <strong>{s.year}</strong>
+                  <span>
+                    {s.wins}-{s.losses}
+                    {s.ties ? `-${s.ties}` : ''}
+                    {s.champion ? ' · Champion' : ''}
+                    {s.runnerUp ? ' · Runner-up' : ''}
+                  </span>
+                </div>
+                <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+                  PF {s.pf} · PA {s.pa}
+                  {s.truePlayoff ? ' · Postseason (documented)' : s.playoffCaliber ? ' · Playoff-caliber' : ''}
+                </div>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 4 }}>
+                  {s.champion ? <span style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 8px' }}>Title season</span> : null}
+                  {s.eliteSeason ? <span style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 8px' }}>Elite year</span> : null}
+                  {s.losingSeason ? <span style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 8px' }}>Losing season</span> : null}
+                </div>
+                {s.mvp?.playerId != null ? (
+                  <button type="button" className="btn-link" onClick={() => onPlayerSelect?.(s.mvp.playerId)}>
+                    League MVP: {s.mvp.name}
+                  </button>
+                ) : null}
               </div>
-              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>PF {s.pf} · PA {s.pa}</div>
-              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 4 }}>
-                {s.champion ? <span style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 8px' }}>Title season</span> : null}
-                {s.wins >= 12 ? <span style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 8px' }}>Elite year</span> : null}
-                {s.wins <= 4 ? <span style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 8px' }}>Rebuild low</span> : null}
-              </div>
-              {s.mvp?.playerId != null ? <button className="btn-link" onClick={() => onPlayerSelect?.(s.mvp.playerId)}>League MVP: {s.mvp.name}</button> : null}
-            </div>
-          ))}
+            ))
+          )}
         </div>
       </SectionCard>
 
@@ -155,22 +387,27 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
         <div style={{ display: 'grid', gap: 8, maxHeight: 420, overflow: 'auto' }}>
           {completedGameRows.length === 0 ? (
             <EmptyState title="No archived results yet" body="Completed game links appear here as season history builds." />
-          ) : completedGameRows.map((row) => {
-            const presentation = buildCompletedGamePresentation(row, { seasonId: row.year, week: row.week, source: 'team_history' });
-            const clickable = Boolean(presentation.canOpen && onOpenBoxScore);
-            return (
-              <button
-                key={`${row.gameId}-${row.year}-${row.week}`}
-                className="btn"
-                onClick={() => openResolvedBoxScore(row, { seasonId: row.year, week: row.week, source: 'team_history' }, onOpenBoxScore)}
-                style={{ textAlign: 'left', opacity: clickable ? 1 : 0.7, cursor: clickable ? 'pointer' : 'default' }}
-                title={clickable ? presentation.ctaLabel : presentation.statusLabel}
-              >
-                <strong>{row.year} · Week {row.week} · {row.away?.abbr ?? 'AWY'} {row.awayScore ?? '—'}-{row.homeScore ?? '—'} {row.home?.abbr ?? 'HME'}</strong>
-                <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4 }}>{clickable ? presentation.ctaLabel : presentation.statusLabel}</div>
-              </button>
-            );
-          })}
+          ) : (
+            completedGameRows.map((row) => {
+              const presentation = buildCompletedGamePresentation(row, { seasonId: row.year, week: row.week, source: 'team_history' });
+              const clickable = Boolean(presentation.canOpen && onOpenBoxScore);
+              return (
+                <button
+                  key={`${row.gameId}-${row.year}-${row.week}`}
+                  type="button"
+                  className="btn"
+                  onClick={() => openResolvedBoxScore(row, { seasonId: row.year, week: row.week, source: 'team_history' }, onOpenBoxScore)}
+                  style={{ textAlign: 'left', opacity: clickable ? 1 : 0.7, cursor: clickable ? 'pointer' : 'default' }}
+                  title={clickable ? presentation.ctaLabel : presentation.statusLabel}
+                >
+                  <strong>
+                    {row.year} · Week {row.week} · {row.away?.abbr ?? 'AWY'} {row.awayScore ?? '—'}-{row.homeScore ?? '—'} {row.home?.abbr ?? 'HME'}
+                  </strong>
+                  <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4 }}>{clickable ? presentation.ctaLabel : presentation.statusLabel}</div>
+                </button>
+              );
+            })
+          )}
         </div>
       </SectionCard>
     </div>

--- a/src/ui/components/__tests__/TeamHistoryScreen.test.jsx
+++ b/src/ui/components/__tests__/TeamHistoryScreen.test.jsx
@@ -1,0 +1,103 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
+import TeamHistoryScreen from '../TeamHistoryScreen.jsx';
+
+describe('TeamHistoryScreen', () => {
+  afterEach(() => {
+    cleanup();
+  });
+  it('renders safely with empty seasons (old save)', async () => {
+    render(
+      <TeamHistoryScreen
+        league={{ teams: [{ id: 1, name: 'Alpha', abbr: 'ALP' }], userTeamId: 1 }}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({ payload: { seasons: [] } }),
+          getHallOfFame: vi.fn().mockResolvedValue({ payload: { players: [], classes: [] } }),
+        }}
+        onBack={vi.fn()}
+        onPlayerSelect={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/Franchise history starts once completed seasons are archived/i)).toBeTruthy();
+    });
+    expect(screen.queryByText('Playoff appearances')).toBeNull();
+    expect(screen.getAllByText(/^Playoff-caliber years$/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows Playoff appearances when postseason archive exists', async () => {
+    render(
+      <TeamHistoryScreen
+        league={{ teams: [{ id: 7, name: 'Seattle', abbr: 'SEA' }], userTeamId: 7 }}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [{
+                year: 2032,
+                standings: [{ id: 7, abbr: 'SEA', wins: 11, losses: 6, ties: 0, pf: 400, pa: 350 }],
+                champion: { id: 2, abbr: 'OTH' },
+                runnerUp: { id: 3, abbr: 'THD' },
+                playoffBracketSnapshot: { mode: 'empty', rounds: [] },
+              }],
+            },
+          }),
+          getHallOfFame: vi.fn().mockResolvedValue({ payload: { players: [], classes: [] } }),
+        }}
+        onBack={vi.fn()}
+        onPlayerSelect={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Playoff appearances')).toBeTruthy();
+    });
+  });
+
+  it('calls onOpenBoxScore when defining game has resolvable id and scores', async () => {
+    const onOpen = vi.fn();
+    render(
+      <TeamHistoryScreen
+        league={{ teams: [{ id: 7, name: 'Seattle', abbr: 'SEA' }], userTeamId: 7 }}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [{
+                year: 2055,
+                standings: [
+                  { id: 7, abbr: 'SEA', wins: 10, losses: 7, ties: 0, pf: 400, pa: 300 },
+                  { id: 3, abbr: 'RIV', wins: 7, losses: 10, ties: 0, pf: 280, pa: 320 },
+                ],
+                champion: { id: 2, abbr: 'OTH' },
+                runnerUp: { id: 3, abbr: 'RIV' },
+                playoffBracketSnapshot: { mode: 'empty', rounds: [] },
+                gameIndex: [{
+                  week: 5,
+                  homeId: 7,
+                  awayId: 3,
+                  homeScore: 31,
+                  awayScore: 17,
+                }],
+              }],
+            },
+          }),
+          getHallOfFame: vi.fn().mockResolvedValue({ payload: { players: [], classes: [] } }),
+        }}
+        onBack={vi.fn()}
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={onOpen}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getAllByText('10-7').length).toBeGreaterThan(0);
+    });
+    const btn = screen.getAllByRole('button').find((b) => b.textContent?.includes('2055') && b.textContent?.includes('Week 5'));
+    expect(btn).toBeTruthy();
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(onOpen).toHaveBeenCalled();
+    });
+    const arg = onOpen.mock.calls[0][0];
+    expect(String(arg)).toMatch(/2055/);
+  });
+});

--- a/tests/unit/franchiseHistoryModel.test.js
+++ b/tests/unit/franchiseHistoryModel.test.js
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import { buildFranchiseHistoryModel } from '../../src/core/franchiseHistoryModel.js';
+import { RECORD_KEYS } from '../../src/core/recordBookV1.js';
+
+const TEAM = { id: 7, abbr: 'SEA', name: 'Seattle' };
+
+function baseSeason(year, overrides = {}) {
+  return {
+    year,
+    seasonId: `s${year}`,
+    id: `s${year}`,
+    standings: [
+      { id: 7, name: 'Seattle', abbr: 'SEA', wins: 10, losses: 7, ties: 0, pf: 380, pa: 340 },
+      { id: 2, name: 'Other', abbr: 'OTH', wins: 8, losses: 9, ties: 0, pf: 300, pa: 310 },
+    ],
+    champion: { id: 2, name: 'Other', abbr: 'OTH' },
+    runnerUp: { id: 3, name: 'Third', abbr: 'THD' },
+    awards: {
+      mvp: { playerId: 'mvp1', name: 'Star QB', pos: 'QB', teamId: 7 },
+    },
+    playerStatLeaders: {
+      passingYards: { playerId: 'qb1', playerName: 'Air', value: 4200, position: 'QB', teamId: 2, teamAbbr: 'OTH' },
+      passingTd: { playerId: 'qb2', playerName: 'Local', value: 32, position: 'QB', teamId: 7, teamAbbr: 'SEA' },
+    },
+    playoffBracketSnapshot: { mode: 'empty', rounds: [] },
+    notableGames: [],
+    gameIndex: [],
+    ...overrides,
+  };
+}
+
+describe('buildFranchiseHistoryModel', () => {
+  it('builds all-time record from archived standings', () => {
+    const m = buildFranchiseHistoryModel({
+      teamId: TEAM.id,
+      teamAbbr: TEAM.abbr,
+      teamName: TEAM.name,
+      archivedSeasons: [
+        baseSeason(2030, { standings: [{ id: 7, abbr: 'SEA', wins: 12, losses: 5, ties: 0, pf: 400, pa: 300 }] }),
+        baseSeason(2031, { standings: [{ id: 7, abbr: 'SEA', wins: 9, losses: 8, ties: 0, pf: 350, pa: 360 }] }),
+      ],
+    });
+    expect(m.summary.allTimeWins).toBe(21);
+    expect(m.summary.allTimeLosses).toBe(13);
+    expect(m.summary.seasonsArchived).toBe(2);
+  });
+
+  it('counts titles and runner-up finishes', () => {
+    const m = buildFranchiseHistoryModel({
+      teamId: 7,
+      teamAbbr: 'SEA',
+      archivedSeasons: [
+        baseSeason(2030, { champion: { id: 7, abbr: 'SEA' }, runnerUp: { id: 2, abbr: 'OTH' } }),
+        baseSeason(2031, { champion: { id: 2, abbr: 'OTH' }, runnerUp: { id: 7, abbr: 'SEA' } }),
+      ],
+    });
+    expect(m.summary.titles).toBe(1);
+    expect(m.summary.runnerUpFinishes).toBe(1);
+  });
+
+  it('counts true playoff appearances from bracket when team appears', () => {
+    const snap = {
+      mode: 'flat',
+      rounds: [{
+        label: 'Postseason',
+        games: [{ homeId: 7, awayId: 2, homeAbbr: 'SEA', awayAbbr: 'OTH', homeScore: 24, awayScore: 21, week: 20 }],
+      }],
+    };
+    const m = buildFranchiseHistoryModel({
+      teamId: 7,
+      teamAbbr: 'SEA',
+      archivedSeasons: [
+        baseSeason(2030, { champion: { id: 9, abbr: 'ZZZ' }, runnerUp: { id: 8, abbr: 'YYY' }, playoffBracketSnapshot: snap }),
+      ],
+    });
+    expect(m.summary.postseasonArchivePresent).toBe(true);
+    expect(m.summary.playoffAppearances).toBeGreaterThanOrEqual(1);
+  });
+
+  it('labels postseason absent: playoff-caliber only, no documented appearances without champ/runner/bracket', () => {
+    const m = buildFranchiseHistoryModel({
+      teamId: 7,
+      teamAbbr: 'SEA',
+      archivedSeasons: [
+        {
+          year: 2020,
+          standings: [{ id: 7, abbr: 'SEA', wins: 11, losses: 6, ties: 0, pf: 400, pa: 350 }],
+          playoffBracketSnapshot: { mode: 'empty', rounds: [] },
+        },
+      ],
+    });
+    expect(m.summary.postseasonArchivePresent).toBe(false);
+    expect(m.summary.playoffAppearances).toBe(0);
+    expect(m.summary.playoffCaliberYears).toBe(1);
+  });
+
+  it('computes franchise team season records from standings', () => {
+    const m = buildFranchiseHistoryModel({
+      teamId: 7,
+      teamAbbr: 'SEA',
+      archivedSeasons: [
+        { year: 2030, standings: [{ id: 7, abbr: 'SEA', wins: 14, losses: 3, ties: 0, pf: 500, pa: 280 }] },
+        { year: 2031, standings: [{ id: 7, abbr: 'SEA', wins: 8, losses: 9, ties: 0, pf: 300, pa: 310 }] },
+      ],
+    });
+    expect(m.franchiseRecords.teamSeason.wins.value).toBe(14);
+    expect(m.franchiseRecords.teamSeason.pointsFor.value).toBe(500);
+  });
+
+  it('only attributes player stat leaders to matching franchise', () => {
+    const m = buildFranchiseHistoryModel({
+      teamId: 7,
+      teamAbbr: 'SEA',
+      archivedSeasons: [baseSeason(2030)],
+    });
+    expect(m.franchiseRecords.playerSingleSeason[RECORD_KEYS.passingYards] == null).toBe(true);
+    expect(m.franchiseRecords.playerSingleSeason[RECORD_KEYS.passingTD]?.playerId).toBe('qb2');
+  });
+
+  it('does not use QB thrown INT for defensive interceptions leader', () => {
+    const m = buildFranchiseHistoryModel({
+      teamId: 7,
+      teamAbbr: 'SEA',
+      archivedSeasons: [{
+        year: 2040,
+        standings: [{ id: 7, abbr: 'SEA', wins: 9, losses: 8, ties: 0, pf: 300, pa: 300 }],
+        seasonStats: [{
+          playerId: 'qb9',
+          name: 'Pick Six',
+          pos: 'QB',
+          teamId: 7,
+          teamAbbr: 'SEA',
+          totals: { interceptions: 18 },
+        }, {
+          playerId: 'lb1',
+          name: 'Ball Hawk',
+          pos: 'LB',
+          teamId: 7,
+          teamAbbr: 'SEA',
+          totals: { interceptions: 4 },
+        }],
+      }],
+    });
+    const row = m.franchiseRecords.playerSingleSeason[RECORD_KEYS.interceptions];
+    expect(row?.playerId).toBe('lb1');
+    expect(row?.value).toBe(4);
+  });
+
+  it('includes matching Hall of Fame inductee in legends', () => {
+    const m = buildFranchiseHistoryModel({
+      teamId: 7,
+      teamAbbr: 'SEA',
+      archivedSeasons: [],
+      hallOfFameClasses: [{
+        year: 2045,
+        inductees: [{ playerId: 'hof1', name: 'Legend', pos: 'QB', primaryTeamAbbr: 'SEA', legacyScore: 91 }],
+      }],
+    });
+    expect(m.franchiseLegends.some((l) => l.playerId === 'hof1')).toBe(true);
+  });
+
+  it('returns safe empty model for no seasons', () => {
+    const m = buildFranchiseHistoryModel({
+      teamId: 1,
+      teamAbbr: 'X',
+      archivedSeasons: [],
+    });
+    expect(m.summary.seasonsArchived).toBe(0);
+    expect(m.franchiseLegends).toEqual([]);
+    expect(m.bestGames).toEqual([]);
+  });
+
+  it('builds best games when gameIndex has scores', () => {
+    const m = buildFranchiseHistoryModel({
+      teamId: 7,
+      teamAbbr: 'SEA',
+      archivedSeasons: [{
+        year: 2050,
+        standings: [
+          { id: 7, abbr: 'SEA', wins: 10, losses: 7, ties: 0, pf: 400, pa: 300 },
+          { id: 3, abbr: 'RIV', wins: 7, losses: 10, ties: 0, pf: 280, pa: 320 },
+        ],
+        gameIndex: [
+          { id: 'g2050_w14_7_3', week: 14, homeId: 7, awayId: 3, homeScore: 45, awayScore: 10 },
+        ],
+      }],
+    });
+    expect(m.bestGames.length).toBeGreaterThanOrEqual(1);
+    expect(m.bestGames[0].gameId).toBeTruthy();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR delivers **Team History / Franchise Records V2** using a new pure helper plus a richer `TeamHistoryScreen`, without new simulation systems, persistence changes, or changes to league-wide record book / Hall of Fame evaluation.

## Franchise history model

Added [`src/core/franchiseHistoryModel.js`](src/core/franchiseHistoryModel.js) with `buildFranchiseHistoryModel({ teamId, teamAbbr, teamName, archivedSeasons, hallOfFamePlayers, hallOfFameClasses })`.

It returns `summary`, per-season `seasons` rows, `franchiseRecords` (team season + player single-season + optional career-from-archive), `franchiseLegends`, `bestGames`, `playoffHistory`, and `milestones`.

## Data sources

- **Primary:** `getAllSeasons` merged archive rows (`standings`, `champion`, `runnerUp`, `awards`, `playerStatLeaders`, `notableGames`, `playoffBracketSnapshot`, `gameIndex`, optional `playerStats` / `seasonStats` when present on a row).
- **Legends:** optional `getHallOfFame` (`classes` inductees + `players` list) filtered to franchise primary / team history.
- **Not used for franchise records:** league-wide `getRecords` / `recordBook` (avoids mis-attributing all-time book entries).

## Playoff appearances vs playoff-caliber

- **Documented postseason (`postseasonArchivePresent`):** any archived season has `champion`, `runnerUp`, or a non-empty `playoffBracketSnapshot`.
- **Playoff appearances (franchise):** seasons where the team is champion, runner-up, or appears in a compacted bracket game when a bracket exists for that year.
- **Playoff-caliber years:** `wins >= 10` (same threshold as prior V1), always labeled separately. If the save never archived champion/runner/bracket data, the UI keeps the playoff-caliber card and does **not** label win-threshold years as true playoff appearances.

## Franchise records

- **Team season:** best/worst metrics computed only from this team’s standing line each year (same numeric ideas as `recordBookV1` team season logic).
- **Player single-season:** `playerStatLeaders` entries only when `teamId` / `teamAbbr` matches; optional scan of `playerStats` / `seasonStats` rows with the same team filter. Defensive INT uses `defensiveInterceptionsSeasonValue` from `recordBookV1` (never QB thrown picks).
- **Career franchise leaders:** only when per-season stat arrays exist with team fields; otherwise an honest empty-state message.

## Franchise legends

Merged, de-duplicated candidates from: HOF class inductees matching franchise; HOF player payload matching primary/team history; franchise MVPs from `awards`; SB MVP on title seasons; franchise record holders; optional career leaders when the career subsection is populated. Stable sort by reason priority then legacy score.

## Team History screen

Parallel fetch of seasons + HOF; mobile-first sections: summary stat grid, memory capsule, franchise records, legends, playoff & title history, best/worst seasons, defining games (notable + scored `gameIndex` highlights), timeline with filters (**All-time**, **Playoff-caliber**, **Championship years**, **Elite seasons** `12+` wins, **Losing seasons** `wins < losses`), and existing completed-game list with Game Book integration.

## Old saves

Missing fields are guarded; empty archives show copy instead of crashing. `getHallOfFame` is optional.

## Tests run

- `npm ci`
- `npm run test:unit` (678 passed)
- `npm run build`
- `npm run check:deploy`
- `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` (after `npx playwright install chromium` in this environment)

## Known limitations / follow-ups

- Standard `buildSeasonArchiveSummary` rows usually omit full `playerStats` arrays, so **career franchise leaders** often stay empty until richer archives exist.
- Without `playoffBracketSnapshot`, non–champion/runner postseason participation cannot be proven year-by-year; UI stays explicit about that.
- `gameIndex` rows lack playoff flags; bracket text comes from `playoffBracketSnapshot` only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c022e0ec-8e4d-431c-96ce-82025071eed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c022e0ec-8e4d-431c-96ce-82025071eed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

