### PR TITLE
Player season stat snapshots (playerSeasonStatsV1) for archives & UI

### DIFF
--- a/src/core/franchiseHistoryModel.js
+++ b/src/core/franchiseHistoryModel.js
@@ -13,6 +13,12 @@ import {
   defensiveInterceptionsSeasonValue,
   leaderEntryToRecordRow,
 } from './recordBookV1.js';
+import {
+  getArchivedPlayerSeasonRows,
+  normalizeArchivedPlayerStatRow,
+  singleSeasonStatValueFromV1Row,
+  v1ArchiveRowToCareerLineInput,
+} from './playerSeasonStatsArchive.js';
 
 const PLAYOFF_CALIBER_WINS = 10;
 const ELITE_WINS = 12;
@@ -281,17 +287,46 @@ function archiveRowToCareerLine(row, seasonYear) {
   };
 }
 
+function franchiseStatSeasonDedupeKey(season, row) {
+  const pid = row?.playerId ?? row?.id ?? '';
+  const sid = row?.seasonId ?? season?.seasonId ?? season?.id ?? '';
+  const y = row?.year ?? Number(season?.year ?? 0) ?? '';
+  return `${pid}|${sid}|${y}`;
+}
+
 function buildFranchiseCareerLeadersFromArchives(seasons, teamId, teamAbbr) {
   const byPlayer = new Map();
+  const seenLine = new Set();
   for (const season of seasons || []) {
     const year = Number(season?.year ?? 0) || null;
     const seasonId = season?.seasonId ?? season?.id ?? null;
+    const v1rows = getArchivedPlayerSeasonRows(season);
+    const v1ForTeam = v1rows
+      .map((raw) => normalizeArchivedPlayerStatRow(raw))
+      .filter((row) => row && teamMatchesFranchise(row, teamId, teamAbbr));
+    if (v1ForTeam.length) {
+      for (const row of v1ForTeam) {
+        const pid = row.playerId;
+        if (pid == null) continue;
+        const pair = franchiseStatSeasonDedupeKey(season, row);
+        if (seenLine.has(pair)) continue;
+        seenLine.add(pair);
+        const key = String(pid);
+        if (!byPlayer.has(key)) byPlayer.set(key, { playerId: pid, name: row.playerName ?? null, pos: row.pos ?? null, lines: [] });
+        const conv = v1ArchiveRowToCareerLineInput(row);
+        if (conv) byPlayer.get(key).lines.push(conv);
+      }
+      continue;
+    }
     const pool = [...(season.playerStats ?? []), ...(season.seasonStats ?? [])];
     if (!Array.isArray(pool) || !pool.length) continue;
     for (const row of pool) {
       if (!teamMatchesFranchise(row, teamId, teamAbbr)) continue;
       const pid = row.playerId ?? row.id;
       if (pid == null) continue;
+      const pair = franchiseStatSeasonDedupeKey(season, row);
+      if (seenLine.has(pair)) continue;
+      seenLine.add(pair);
       const key = String(pid);
       if (!byPlayer.has(key)) byPlayer.set(key, { playerId: pid, name: row.name ?? null, pos: row.pos ?? null, lines: [] });
       byPlayer.get(key).lines.push(archiveRowToCareerLine(row, year ?? seasonId));
@@ -700,6 +735,32 @@ export function buildFranchiseHistoryModel({
       if (!best || row.value > best.value) best = row;
     }
     for (const season of seasonsSorted) {
+      const v1rows = getArchivedPlayerSeasonRows(season);
+      const v1ForTeam = v1rows
+        .map((raw) => normalizeArchivedPlayerStatRow(raw))
+        .filter((s) => s && teamMatchesFranchise(s, tid, ab));
+      if (v1ForTeam.length) {
+        for (const s of v1ForTeam) {
+          const v = num(singleSeasonStatValueFromV1Row(recordKey, s));
+          if (v <= 0) continue;
+          const year = Number(season?.year ?? 0) || null;
+          const cand = {
+            recordKey,
+            label: RECORD_LABELS[recordKey],
+            value: v,
+            playerId: s.playerId ?? null,
+            playerName: s.playerName ?? null,
+            position: s.pos ?? null,
+            teamId: s.teamId ?? null,
+            teamAbbr: s.teamAbbr ?? null,
+            year,
+            sourceSeasonId: season?.seasonId ?? season?.id ?? null,
+            source: 'archivedSeason',
+          };
+          if (!best || cand.value > best.value) best = cand;
+        }
+        continue;
+      }
       const pool = [...(season.playerStats ?? []), ...(season.seasonStats ?? [])];
       if (!Array.isArray(pool)) continue;
       const pick = STAT_ROW_VALUE[recordKey];

--- a/src/core/league-memory.js
+++ b/src/core/league-memory.js
@@ -498,7 +498,7 @@ function buildTeamStatLeaders(standings = []) {
   };
 }
 
-export function buildSeasonArchiveSummary({ year, seasonId, standings, awards, leaders, champion, runnerUp, userTeamId, transactions = [], games = [], teams = [], seasonStats = [], championshipGameId = null }) {
+export function buildSeasonArchiveSummary({ year, seasonId, standings, awards, leaders, champion, runnerUp, userTeamId, transactions = [], games = [], teams = [], seasonStats = [], championshipGameId = null, playerSeasonStatsV1 = null }) {
   const sorted = [...(standings || [])].sort((a, b) => (b.wins ?? 0) - (a.wins ?? 0));
   const userRow = sorted.find((t) => Number(t.id) === Number(userTeamId)) || null;
   const userTeam = teams.find((t) => Number(t?.id) === Number(userTeamId)) ?? null;
@@ -544,7 +544,7 @@ export function buildSeasonArchiveSummary({ year, seasonId, standings, awards, l
     });
   }
 
-  return {
+  const out = {
     id: seasonId,
     year,
     seasonId,
@@ -584,6 +584,10 @@ export function buildSeasonArchiveSummary({ year, seasonId, standings, awards, l
     } : null,
     majorTransactions: (transactions || []).slice(0, 8),
   };
+  if (playerSeasonStatsV1 && Array.isArray(playerSeasonStatsV1.rows) && playerSeasonStatsV1.rows.length > 0) {
+    out.playerSeasonStatsV1 = playerSeasonStatsV1;
+  }
+  return out;
 }
 
 export function updateFranchiseHistory(memoryMeta, seasonSummary, teams) {

--- a/src/core/playerSeasonStatsArchive.js
+++ b/src/core/playerSeasonStatsArchive.js
@@ -1,0 +1,320 @@
+/**
+ * Compact per-player season stat snapshots for archived seasons (pure helpers).
+ * @see playerSeasonStatsV1 on season archive rows.
+ *
+ * Intentionally does not import recordBookV1 (recordBookV1 imports this module for scans).
+ */
+
+export const PLAYER_SEASON_STATS_ARCHIVE_SCHEMA_VERSION = 1;
+
+const DEFENSIVE_POS = new Set(['DL', 'DE', 'DT', 'EDGE', 'LB', 'CB', 'S', 'SS', 'FS']);
+
+function num(v) {
+  const n = Number(v ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function readTotals(totals, keys) {
+  if (!totals || typeof totals !== 'object') return 0;
+  for (const k of keys) {
+    const v = num(totals[k]);
+    if (v !== 0) return v;
+  }
+  return 0;
+}
+
+/**
+ * Mirrors recordBookV1.defensiveInterceptionsSeasonValue — QB thrown INT never counts as defensive INT.
+ */
+export function defensiveIntsFromTotalsForArchive(pos, totals) {
+  const t = totals || {};
+  const p = String(pos ?? '').toUpperCase();
+  const defPick = readTotals(t, ['defInterceptions', 'interceptionsDef', 'interceptionsMade']);
+  if (defPick > 0) return defPick;
+  if (DEFENSIVE_POS.has(p)) return readTotals(t, ['interceptions']);
+  return 0;
+}
+
+/** QB thrown interceptions (distinct from defensive INT). */
+export function passIntsThrownFromTotals(pos, totals) {
+  const p = String(pos ?? '').toUpperCase();
+  if (p !== 'QB') return 0;
+  return num(totals?.interceptions);
+}
+
+function teamAbbrForId(teams, teamId) {
+  if (teamId == null || !Array.isArray(teams)) return '';
+  const t = teams.find((x) => Number(x?.id) === Number(teamId));
+  return t?.abbr != null ? String(t.abbr) : '';
+}
+
+function rowHasMeaningfulStats(r) {
+  if (!r || typeof r !== 'object') return false;
+  if (num(r.gamesPlayed) >= 1) return true;
+  return (
+    num(r.passYds) > 0
+    || num(r.passTDs) > 0
+    || num(r.passInts) > 0
+    || num(r.rushYds) > 0
+    || num(r.rushTDs) > 0
+    || num(r.recYds) > 0
+    || num(r.recTDs) > 0
+    || num(r.tackles) > 0
+    || num(r.sacks) > 0
+    || num(r.defInts) > 0
+    || num(r.fgMade) > 0
+    || num(r.xpMade) > 0
+  );
+}
+
+/**
+ * @param {Array<object>} populatedStats - worker season stat rows with totals, name, pos, teamId, age
+ * @param {{ teams?: any[], year: number, seasonId: string, createdAt?: string }} ctx
+ */
+export function buildPlayerSeasonStatsArchiveRows(populatedStats, ctx = {}) {
+  const { teams = [], year, seasonId, createdAt } = ctx;
+  const y = Number(year);
+  const sid = seasonId != null ? String(seasonId) : '';
+  const rows = [];
+  const seen = new Set();
+  let skippedEmpty = 0;
+  for (const s of populatedStats || []) {
+    const playerId = s.playerId ?? s.id;
+    if (playerId == null) continue;
+    const dedupeKey = String(playerId);
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    const totals = s.totals && typeof s.totals === 'object' ? s.totals : {};
+    const pos = s.pos ?? '';
+    const passYds = readTotals(totals, ['passYd', 'passingYards']);
+    const passTDs = readTotals(totals, ['passTD', 'passingTd']);
+    const rushYds = readTotals(totals, ['rushYd', 'rushingYards']);
+    const rushTDs = readTotals(totals, ['rushTD', 'rushingTd']);
+    const recYds = readTotals(totals, ['recYd', 'receivingYards']);
+    const recTDs = readTotals(totals, ['recTD', 'receivingTd']);
+    const tackles = readTotals(totals, ['tackles']);
+    const sacks = readTotals(totals, ['sacks']);
+    const fgMade = readTotals(totals, ['fgMade', 'fieldGoalsMade']);
+    const xpMade = readTotals(totals, ['xpMade', 'extraPointsMade', 'patMade']);
+    const gamesPlayed = num(totals.gamesPlayed);
+    const defInts = defensiveIntsFromTotalsForArchive(pos, totals);
+    const passInts = passIntsThrownFromTotals(pos, totals);
+
+    const row = normalizeArchivedPlayerStatRow({
+      playerId,
+      playerName: s.name ?? null,
+      pos,
+      teamId: s.teamId ?? null,
+      teamAbbr: s.teamAbbr ?? teamAbbrForId(teams, s.teamId),
+      age: s.age ?? null,
+      year: Number.isFinite(y) ? y : null,
+      seasonId: sid || null,
+      gamesPlayed,
+      passYds,
+      passTDs,
+      passInts,
+      rushYds,
+      rushTDs,
+      recYds,
+      recTDs,
+      tackles,
+      sacks,
+      defInts,
+      fgMade,
+      xpMade,
+    });
+    if (!rowHasMeaningfulStats(row)) {
+      skippedEmpty += 1;
+      continue;
+    }
+    rows.push(row);
+  }
+
+  const partial = skippedEmpty > 0;
+  return {
+    schemaVersion: PLAYER_SEASON_STATS_ARCHIVE_SCHEMA_VERSION,
+    rows,
+    meta: {
+      source: 'seasonStats',
+      partial,
+      createdAt: createdAt ?? new Date().toISOString(),
+    },
+  };
+}
+
+export function normalizeArchivedPlayerStatRow(row) {
+  if (!row || typeof row !== 'object') return null;
+  const out = {
+    playerId: row.playerId ?? row.id ?? null,
+    playerName: row.playerName ?? row.name ?? null,
+    pos: row.pos ?? null,
+    teamId: row.teamId != null ? Number(row.teamId) : null,
+    teamAbbr: row.teamAbbr != null && row.teamAbbr !== '' ? String(row.teamAbbr) : null,
+    age: row.age != null ? num(row.age) : null,
+    year: row.year != null ? num(row.year) : null,
+    seasonId: row.seasonId != null ? String(row.seasonId) : null,
+    gamesPlayed: num(row.gamesPlayed),
+    passYds: num(row.passYds),
+    passTDs: num(row.passTDs),
+    passInts: num(row.passInts),
+    rushYds: num(row.rushYds),
+    rushTDs: num(row.rushTDs),
+    recYds: num(row.recYds),
+    recTDs: num(row.recTDs),
+    tackles: num(row.tackles),
+    sacks: num(row.sacks),
+    defInts: num(row.defInts),
+    fgMade: num(row.fgMade),
+    xpMade: num(row.xpMade),
+  };
+  if (out.playerId == null) return null;
+  return out;
+}
+
+export function getArchivedPlayerSeasonRows(season) {
+  const raw = season?.playerSeasonStatsV1?.rows;
+  if (!Array.isArray(raw)) return [];
+  return raw.map(normalizeArchivedPlayerStatRow).filter(Boolean);
+}
+
+export function summarizePlayerSeasonRows(rows) {
+  const list = Array.isArray(rows) ? rows : [];
+  return {
+    rowCount: list.length,
+    gamesSum: list.reduce((s, r) => s + num(r?.gamesPlayed), 0),
+  };
+}
+
+export function groupArchivedPlayerStatsByPlayer(rows) {
+  const map = new Map();
+  for (const r of rows || []) {
+    const id = r?.playerId;
+    if (id == null) continue;
+    const k = String(id);
+    if (!map.has(k)) map.set(k, []);
+    map.get(k).push(r);
+  }
+  return map;
+}
+
+export function archivedRowSeasonDedupeKey(row) {
+  if (!row) return '';
+  if (row.seasonId) return `id:${String(row.seasonId)}`;
+  if (row.year != null && Number.isFinite(num(row.year))) return `y:${num(row.year)}`;
+  return '';
+}
+
+/**
+ * Convert a compact V1 row to the same shape as `dedupeCareerStatLines` input (per-season bucket).
+ */
+export function v1ArchiveRowToCareerLineInput(row) {
+  const r = normalizeArchivedPlayerStatRow(row);
+  if (!r) return null;
+  const seasonToken = r.seasonId ?? r.year;
+  if (seasonToken == null || String(seasonToken) === '') return null;
+  return {
+    season: seasonToken,
+    passYds: r.passYds,
+    passTDs: r.passTDs,
+    rushYds: r.rushYds,
+    rushTDs: r.rushTDs,
+    recYds: r.recYds,
+    recTDs: r.recTDs,
+    tackles: r.tackles,
+    sacks: r.sacks,
+    fgMade: r.fgMade,
+    defInts: r.defInts,
+    ints: r.passInts,
+    gamesPlayed: r.gamesPlayed,
+    team: r.teamAbbr ?? (r.teamId != null ? String(r.teamId) : 'FA'),
+    year: r.year,
+    seasonId: r.seasonId,
+    pos: r.pos,
+  };
+}
+
+export function careerLineSeasonKey(line) {
+  if (!line) return '';
+  if (line.season != null && String(line.season) !== '') return `s:${String(line.season)}`;
+  if (line.seasonId != null) return `s:${String(line.seasonId)}`;
+  if (line.year != null) return `y:${num(line.year)}`;
+  return '';
+}
+
+export function collectArchiveOnlyCareerLinesForPlayer(playerId, leagueHistory, existingLineKeys) {
+  const keys = new Set(existingLineKeys || []);
+  const out = [];
+  if (playerId == null) return out;
+  for (const season of leagueHistory || []) {
+    for (const row of getArchivedPlayerSeasonRows(season)) {
+      if (String(row.playerId) !== String(playerId)) continue;
+      const conv = v1ArchiveRowToCareerLineInput(row);
+      if (!conv) continue;
+      const k = careerLineSeasonKey(conv);
+      if (!k || keys.has(k)) continue;
+      keys.add(k);
+      out.push(conv);
+    }
+  }
+  return out;
+}
+
+/** Canonical record key string → value from a normalized V1 row */
+export function singleSeasonStatValueFromV1Row(recordKey, row) {
+  const r = normalizeArchivedPlayerStatRow(row);
+  if (!r) return 0;
+  switch (recordKey) {
+    case 'passingYards': return r.passYds;
+    case 'passingTD': return r.passTDs;
+    case 'rushingYards': return r.rushYds;
+    case 'rushingTD': return r.rushTDs;
+    case 'receivingYards': return r.recYds;
+    case 'receivingTD': return r.recTDs;
+    case 'tackles': return r.tackles;
+    case 'sacks': return r.sacks;
+    case 'interceptions': return r.defInts;
+    case 'fieldGoalsMade': return r.fgMade;
+    default: return 0;
+  }
+}
+
+const TOP_SORTS = [
+  { key: 'passYds', pick: (r) => r.passYds, label: 'Pass yds' },
+  { key: 'rushYds', pick: (r) => r.rushYds, label: 'Rush yds' },
+  { key: 'recYds', pick: (r) => r.recYds, label: 'Rec yds' },
+  { key: 'tackles', pick: (r) => r.tackles, label: 'Tackles' },
+  { key: 'defInts', pick: (r) => r.defInts, label: 'Def INT' },
+];
+
+/**
+ * Compact buckets for League History "Top performers" (max 2 per bucket, unique players preferred).
+ */
+export function buildLeagueHistoryTopPerformers(season, opts = {}) {
+  const perBucket = Number(opts.perBucket ?? 2);
+  const rows = getArchivedPlayerSeasonRows(season).map(normalizeArchivedPlayerStatRow).filter(Boolean);
+  if (!rows.length) return null;
+  const buckets = {};
+  for (const { key, pick, label } of TOP_SORTS) {
+    const sorted = [...rows].filter((r) => num(pick(r)) > 0).sort((a, b) => num(pick(b)) - num(pick(a)));
+    const used = new Set();
+    const acc = [];
+    for (const r of sorted) {
+      if (acc.length >= perBucket) break;
+      const pid = String(r.playerId);
+      if (used.has(pid)) continue;
+      used.add(pid);
+      acc.push({
+        category: label,
+        statKey: key,
+        value: num(pick(r)),
+        playerId: r.playerId,
+        playerName: r.playerName,
+        pos: r.pos,
+        teamAbbr: r.teamAbbr,
+      });
+    }
+    buckets[key] = acc;
+  }
+  return buckets;
+}

--- a/src/core/recordBookV1.js
+++ b/src/core/recordBookV1.js
@@ -3,6 +3,15 @@
  * Pure helpers; safe on partial / legacy saves.
  */
 
+import {
+  getArchivedPlayerSeasonRows,
+  normalizeArchivedPlayerStatRow,
+  singleSeasonStatValueFromV1Row,
+  collectArchiveOnlyCareerLinesForPlayer,
+  careerLineSeasonKey,
+  v1ArchiveRowToCareerLineInput,
+} from './playerSeasonStatsArchive.js';
+
 export const RECORD_BOOK_SCHEMA_VERSION = 1;
 
 /** Canonical record keys (persisted under singleSeason / careerLeaders) */
@@ -196,10 +205,15 @@ export function careerTotalsFromPlayer(player) {
   return out;
 }
 
-function topNPlayersByCareer(players, recordKey, n = 10) {
+function topNPlayersByCareer(players, leagueHistory, recordKey, n = 10) {
   const rows = [];
   for (const p of players || []) {
-    const totals = careerTotalsFromPlayer(p);
+    const deduped = dedupeCareerStatLines(p?.careerStats);
+    const existingKeys = deduped.map((l) => careerLineSeasonKey(l)).filter(Boolean);
+    const archiveOnly = collectArchiveOnlyCareerLinesForPlayer(p?.id ?? p?.playerId, leagueHistory, existingKeys);
+    const mergedLines = dedupeCareerStatLines([...deduped, ...archiveOnly]);
+    const synthetic = { ...p, careerStats: mergedLines };
+    const totals = careerTotalsFromPlayer(synthetic);
     const v = num(totals[recordKey]);
     if (v <= 0) continue;
     rows.push({
@@ -215,7 +229,7 @@ function topNPlayersByCareer(players, recordKey, n = 10) {
       year: null,
       sourceSeasonId: null,
       statKey: recordKey,
-      source: 'careerStats',
+      source: archiveOnly.length ? 'careerStats+archiveV1' : 'careerStats',
     });
   }
   rows.sort((a, b) => b.value - a.value);
@@ -267,6 +281,39 @@ function scanSeasonStatsForBest(leagueHistory, pickValueFn, recordKey) {
   return best;
 }
 
+function scanPlayerSeasonStatsV1ForBest(leagueHistory, recordKey) {
+  let best = null;
+  for (const season of leagueHistory || []) {
+    const rows = getArchivedPlayerSeasonRows(season);
+    if (!rows.length) continue;
+    const year = Number(season?.year ?? 0) || null;
+    const seasonId = season?.seasonId ?? season?.id ?? null;
+    for (const raw of rows) {
+      const r = normalizeArchivedPlayerStatRow(raw);
+      if (!r) continue;
+      const v = num(singleSeasonStatValueFromV1Row(recordKey, r));
+      if (v <= 0) continue;
+      const cand = {
+        recordKey,
+        label: RECORD_LABELS[recordKey],
+        value: v,
+        playerId: r.playerId ?? null,
+        playerName: r.playerName ?? null,
+        position: r.pos ?? null,
+        teamId: r.teamId ?? null,
+        teamName: null,
+        teamAbbr: r.teamAbbr ?? null,
+        year,
+        sourceSeasonId: seasonId,
+        statKey: recordKey,
+        source: 'archivedSeason',
+      };
+      if (!best || cand.value > best.value) best = cand;
+    }
+  }
+  return best;
+}
+
 function singleSeasonBestForKey(leagueHistory, recordKey) {
   const fromLeaders = bestSingleSeasonFromArchives(leagueHistory, recordKey);
   const pickFns = {
@@ -282,9 +329,10 @@ function singleSeasonBestForKey(leagueHistory, recordKey) {
     [RECORD_KEYS.fieldGoalsMade]: (s) => readFromTotals(s.totals, ['fgMade', 'fieldGoalsMade']),
   };
   const fromStats = scanSeasonStatsForBest(leagueHistory, pickFns[recordKey], recordKey);
-  if (!fromLeaders) return fromStats;
-  if (!fromStats) return fromLeaders;
-  return fromStats.value > fromLeaders.value ? fromStats : fromLeaders;
+  const fromV1 = scanPlayerSeasonStatsV1ForBest(leagueHistory, recordKey);
+  const candidates = [fromLeaders, fromStats, fromV1].filter(Boolean);
+  if (!candidates.length) return null;
+  return candidates.reduce((a, b) => (num(b.value) > num(a.value) ? b : a));
 }
 
 function mergeRecordRowPreferMax(existing, incoming) {
@@ -412,7 +460,7 @@ export function rebuildRecordBookV1({ leagueHistory = [], players = [], previous
 
   const careerLeaders = {};
   for (const key of PLAYER_STAT_ORDER) {
-    careerLeaders[key] = topNPlayersByCareer(players, key, 10);
+    careerLeaders[key] = topNPlayersByCareer(players, leagueHistory, key, 10);
   }
 
   const teamSeason = buildTeamSeasonBlock(leagueHistory);
@@ -554,6 +602,54 @@ export function mirrorRecordBookForLegacyUi(v1Book) {
     playoffStreak: { holderId: null, holderName: null, teamId: null, teamAbbr: null, season: null, value: 0 },
   };
   return { singleSeason, career, team };
+}
+
+/**
+ * Merge worker `player.careerStats` with compact `playerSeasonStatsV1` rows for profile season log.
+ * Player rows win when the same season bucket exists.
+ */
+export function mergePlayerProfileSeasonRows(player, leagueHistory) {
+  const bySeason = new Map();
+  for (const line of Array.isArray(player?.careerStats) ? player.careerStats : []) {
+    const k = careerLineSeasonKey(line);
+    if (k) bySeason.set(k, line);
+  }
+  const pid = player?.id ?? player?.playerId;
+  if (pid != null) {
+    for (const season of leagueHistory || []) {
+      for (const raw of getArchivedPlayerSeasonRows(season)) {
+        const row = normalizeArchivedPlayerStatRow(raw);
+        if (!row || String(row.playerId) !== String(pid)) continue;
+        const conv = v1ArchiveRowToCareerLineInput(row);
+        if (!conv) continue;
+        const k = careerLineSeasonKey(conv);
+        if (!k || bySeason.has(k)) continue;
+        bySeason.set(k, {
+          season: row.seasonId ?? row.year,
+          year: row.year,
+          team: row.teamAbbr ?? (row.teamId != null ? String(row.teamId) : 'FA'),
+          gamesPlayed: row.gamesPlayed,
+          passYds: row.passYds,
+          passTDs: row.passTDs,
+          ints: row.passInts,
+          compPct: 0,
+          rushYds: row.rushYds,
+          rushTDs: row.rushTDs,
+          receptions: 0,
+          recYds: row.recYds,
+          recTDs: row.recTDs,
+          tackles: row.tackles,
+          sacks: row.sacks,
+          defInts: row.defInts,
+          fgMade: row.fgMade,
+          xpMade: row.xpMade,
+          ffum: 0,
+          ovr: null,
+        });
+      }
+    }
+  }
+  return [...bySeason.values()].sort((a, b) => String(a.season).localeCompare(String(b.season)));
 }
 
 export function buildPlayerRecordContext(recordBook, playerId) {

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -1347,6 +1347,10 @@ export default function LeagueDashboard({
               onNavigate={setActiveTab}
               profileContext={selectedPlayerContext}
               onOpenBoxScore={(gameId) => openGameDetail(gameId, selectedPlayerContext?.source === 'weekly-results' ? 'Weekly Results' : 'Game Detail')}
+              onFocusLeagueHistorySeason={(seasonId) => {
+                setHistorySelectedSeasonId(seasonId);
+                setActiveTab('History');
+              }}
             />
           </PlayerProfileModalBoundary>
         </TabErrorBoundary>

--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/boxScoreAccess.js";
 import { AWARD_DISPLAY_NAMES } from '../../core/footballMeta';
+import { buildLeagueHistoryTopPerformers } from '../../core/playerSeasonStatsArchive.js';
 
 const RECORD_LABELS = {
   passYd: "Passing Yards",
@@ -298,6 +299,7 @@ function SeasonExplorer({ seasons, onPlayerSelect, onOpenBoxScore, league, initi
   const championshipGame = (selected?.gameIndex ?? []).find((g) => String(g?.id) === String(selected?.championshipGameId)) ?? null;
   const notableGames = Array.isArray(selected?.notableGames) ? selected.notableGames : [];
   const selectedSeasonIndex = seasons.findIndex((s) => s.id === selected?.id);
+  const topPerformers = useMemo(() => buildLeagueHistoryTopPerformers(selected, { perBucket: 2 }), [selected]);
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[260px_1fr] gap-4">
@@ -498,6 +500,28 @@ function SeasonExplorer({ seasons, onPlayerSelect, onOpenBoxScore, league, initi
             </div>
           </section>
 
+          {topPerformers && Object.values(topPerformers).some((arr) => Array.isArray(arr) && arr.length) ? (
+            <section className="rounded-md border border-[color:var(--hairline)] p-3" data-testid={`league-history-top-performers-${selected?.id ?? 'none'}`}>
+              <h4 className="text-sm font-bold mb-2">Top performers (archived stat snapshots)</h4>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs">
+                {Object.entries(topPerformers).map(([bucket, arr]) => (
+                  (arr ?? []).length > 0 ? (
+                    <div key={bucket} className="space-y-1">
+                      <div className="font-semibold text-[color:var(--text-muted)] uppercase tracking-wide">{(arr[0] && arr[0].category) || bucket}</div>
+                      {(arr ?? []).map((r) => (
+                        <div key={`${bucket}-${r.playerId}`} className="flex justify-between gap-2 border-b border-[color:var(--hairline)]/40 pb-1 last:border-0">
+                          <button type="button" className="text-left text-[color:var(--accent)] font-semibold truncate" onClick={() => r.playerId != null && onPlayerSelect?.(r.playerId)}>
+                            {r.playerName ?? "—"}{r.pos ? ` · ${r.pos}` : ""}{r.teamAbbr ? ` (${r.teamAbbr})` : ""}
+                          </button>
+                          <span className="tabular-nums shrink-0">{r.value?.toLocaleString?.() ?? r.value}</span>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null
+                ))}
+              </div>
+            </section>
+          ) : null}
           {playerStatLeaders && Object.keys(playerStatLeaders).length > 0 ? (
             <section data-testid={`league-history-player-stat-leaders-${selected?.id ?? 'none'}`}>
               <h4 className="text-sm font-bold mb-2">Stat leaders</h4>

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -29,7 +29,7 @@ import { buildRouteRequestKey, buildLeagueCacheScopeKey } from "../utils/request
 import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 import { getPlayerGameLogs } from "../utils/playerGameLogs.js";
 import { buildMergedPlayerAwardTimeline, buildPlayerAwardHeaderBadges } from "../../core/playerAwardTimeline.js";
-import { buildPlayerRecordContext } from "../../core/recordBookV1.js";
+import { buildPlayerRecordContext, mergePlayerProfileSeasonRows } from "../../core/recordBookV1.js";
 import { buildLegacyScoreReport, shouldShowLegacyProfileSection } from "../../core/legacyScore.js";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
@@ -209,7 +209,7 @@ const POS_COLUMNS = {
 const PASS_POSITIONS = ["QB"];
 const RUSH_POSITIONS = ["RB", "FB"];
 const REC_POSITIONS = ["WR", "TE"];
-const DEF_POSITIONS = ["CB", "S", "SS", "FS", "LB", "MLB", "OLB", "DE", "DT", "NT"];
+const DEF_POSITIONS = ["CB", "S", "SS", "FS", "LB", "MLB", "OLB", "DE", "DT", "NT", "DL", "EDGE"];
 const SPEC_POSITIONS = ["K", "P", "LS"];
 
 function getColumns(pos) {
@@ -407,6 +407,7 @@ export default function PlayerProfile({
   isUserOnClock = false,
   onDraftPlayer = null,
   profileContext = null,
+  onFocusLeagueHistorySeason = null,
 }) {
 
   const [data, setData] = useState(null);
@@ -562,10 +563,14 @@ export default function PlayerProfile({
   );
   const summaryChips = getPlayerSummaryChips(player, ringCount, nonRing);
   const accoladesByYear = [...accolades].sort((a, b) => (a.year ?? 0) - (b.year ?? 0));
-  const teamJourney = [...new Set((player?.careerStats ?? []).map((line) => line.team).filter(Boolean))];
+  const mergedProfileSeasonRows = useMemo(
+    () => mergePlayerProfileSeasonRows(effectivePlayer, archivedSeasons),
+    [effectivePlayer, archivedSeasons],
+  );
+  const teamJourney = [...new Set(mergedProfileSeasonRows.map((line) => line.team).filter(Boolean))];
   const careerArcRows = useMemo(() => {
-    const seasonRows = (player?.careerStats ?? []).map((line) => ({
-      year: Number(line?.season ?? 0),
+    const seasonRows = mergedProfileSeasonRows.map((line) => ({
+      year: Number(line?.year ?? 0) || (typeof line?.season === 'number' ? line.season : 0),
       label: `Season ${line?.season ?? "—"}`,
       detail: `${line?.team ?? "FA"} · OVR ${line?.ovr ?? "—"}`,
     }));
@@ -578,7 +583,7 @@ export default function PlayerProfile({
       .filter((row) => Number.isFinite(row.year) && row.year > 0)
       .sort((a, b) => b.year - a.year)
       .slice(0, 12);
-  }, [player?.careerStats, accoladesByYear]);
+  }, [mergedProfileSeasonRows, accoladesByYear]);
   const keyColumns = columns.filter((c) => !c.fmt && c.key !== "gamesPlayed").slice(0, 4);
   const careerHighs = keyColumns
     .map((col) => {
@@ -631,29 +636,28 @@ export default function PlayerProfile({
     ],
   }), [devHistory]);
 
-  const careerRows = useMemo(
-    () => (Array.isArray(effectivePlayer?.careerStats) ? [...effectivePlayer.careerStats] : []),
-    [effectivePlayer?.careerStats],
-  );
-  const careerTotals = useMemo(
-    () =>
-      careerRows.reduce((totals, line) => ({
-        gamesPlayed: totals.gamesPlayed + Number(line?.gamesPlayed ?? line?.gp ?? 0),
-        passYds: totals.passYds + Number(line?.passYds ?? line?.passingYards ?? 0),
-        passTDs: totals.passTDs + Number(line?.passTDs ?? line?.touchdowns ?? 0),
-        rushYds: totals.rushYds + Number(line?.rushYds ?? line?.rushingYards ?? 0),
-        rushTDs: totals.rushTDs + Number(line?.rushTDs ?? line?.rushingTDs ?? 0),
-        receptions: totals.receptions + Number(line?.receptions ?? 0),
-        recYds: totals.recYds + Number(line?.recYds ?? line?.receivingYards ?? 0),
-        recTDs: totals.recTDs + Number(line?.recTDs ?? line?.receivingTDs ?? 0),
-        tackles: totals.tackles + Number(line?.tackles ?? line?.totalTackles ?? 0),
-        sacks: totals.sacks + Number(line?.sacks ?? 0),
-        interceptions: totals.interceptions + Number(line?.interceptions ?? line?.ints ?? 0),
-      }), {
-        gamesPlayed: 0, passYds: 0, passTDs: 0, rushYds: 0, rushTDs: 0, receptions: 0, recYds: 0, recTDs: 0, tackles: 0, sacks: 0, interceptions: 0,
-      }),
-    [careerRows],
-  );
+  const careerRows = useMemo(() => mergedProfileSeasonRows, [mergedProfileSeasonRows]);
+  const careerTotals = useMemo(() => {
+    const posU = String(effectivePlayer?.pos ?? effectivePlayer?.position ?? '').toUpperCase();
+    const defSkill = ['DE', 'DT', 'LB', 'CB', 'S', 'DL', 'EDGE'].includes(posU);
+    return careerRows.reduce((totals, line) => ({
+      gamesPlayed: totals.gamesPlayed + Number(line?.gamesPlayed ?? line?.gp ?? 0),
+      passYds: totals.passYds + Number(line?.passYds ?? line?.passingYards ?? 0),
+      passTDs: totals.passTDs + Number(line?.passTDs ?? line?.touchdowns ?? 0),
+      rushYds: totals.rushYds + Number(line?.rushYds ?? line?.rushingYards ?? 0),
+      rushTDs: totals.rushTDs + Number(line?.rushTDs ?? line?.rushingTDs ?? 0),
+      receptions: totals.receptions + Number(line?.receptions ?? 0),
+      recYds: totals.recYds + Number(line?.recYds ?? line?.receivingYards ?? 0),
+      recTDs: totals.recTDs + Number(line?.recTDs ?? line?.receivingTDs ?? 0),
+      tackles: totals.tackles + Number(line?.tackles ?? line?.totalTackles ?? 0),
+      sacks: totals.sacks + Number(line?.sacks ?? 0),
+      interceptions: totals.interceptions + (defSkill
+        ? Number(line?.defInts ?? line?.defInterceptions ?? 0)
+        : Number(line?.interceptions ?? line?.ints ?? 0)),
+    }), {
+      gamesPlayed: 0, passYds: 0, passTDs: 0, rushYds: 0, rushTDs: 0, receptions: 0, recYds: 0, recTDs: 0, tackles: 0, sacks: 0, interceptions: 0,
+    });
+  }, [careerRows, effectivePlayer?.pos, effectivePlayer?.position]);
 
   const profileAnalysis = useMemo(() => buildPlayerProfileAnalysis({ player: effectivePlayer, team: resolvedProfile.team, league, context: profileContext ?? {} }), [effectivePlayer, resolvedProfile.team, league, profileContext]);
   const playerGameLogs = useMemo(() => getPlayerGameLogs(league, effectivePlayer), [league, effectivePlayer]);
@@ -1668,8 +1672,8 @@ export default function PlayerProfile({
             })()}
           </section>
 
-          {/* ── Per-season Career Stats (from player.careerStats archive) ── */}
-          {!loading && player?.careerStats?.length > 0 && (
+          {/* ── Per-season career log (player.careerStats + archived playerSeasonStatsV1) ── */}
+          {!loading && mergedProfileSeasonRows.length > 0 && (
             <section className="card-enter">
               <h3
                 style={{
@@ -1705,6 +1709,7 @@ export default function PlayerProfile({
                         Season
                       </TableHead>
                       <TableHead style={{ textAlign: "left" }}>Team</TableHead>
+                      <TableHead style={{ textAlign: "center" }}>Pos</TableHead>
                       <TableHead style={{ textAlign: "center" }}>GP</TableHead>
                       {["QB"].includes(player.pos) && (
                         <>
@@ -1729,20 +1734,26 @@ export default function PlayerProfile({
                           <TableHead style={{ textAlign: "center" }}>TD</TableHead>
                         </>
                       )}
-                      {["DE", "DT", "LB", "CB", "S", "DL"].includes(
+                      {["DE", "DT", "LB", "CB", "S", "DL", "EDGE"].includes(
                         player.pos,
                       ) && (
                         <>
                           <TableHead style={{ textAlign: "center" }}>TKL</TableHead>
                           <TableHead style={{ textAlign: "center" }}>SCK</TableHead>
-                          <TableHead style={{ textAlign: "center" }}>FF</TableHead>
+                          <TableHead style={{ textAlign: "center" }}>D-INT</TableHead>
+                        </>
+                      )}
+                      {["K"].includes(player.pos) && (
+                        <>
+                          <TableHead style={{ textAlign: "center" }}>FGM</TableHead>
+                          <TableHead style={{ textAlign: "center" }}>XPM</TableHead>
                         </>
                       )}
                       <TableHead style={{ textAlign: "center" }}>OVR</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {[...player.careerStats].reverse().map((line, i) => (
+                    {[...mergedProfileSeasonRows].reverse().map((line, i) => (
                       <TableRow key={i}>
                         <TableCell
                           style={{
@@ -1750,7 +1761,19 @@ export default function PlayerProfile({
                             fontWeight: 600,
                           }}
                         >
-                          {line.season}
+                          <span style={{ display: "inline-flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                            {line.season}
+                            {onFocusLeagueHistorySeason && line.season != null && String(line.season).startsWith("s") ? (
+                              <button
+                                type="button"
+                                className="btn-link"
+                                style={{ fontSize: "0.7rem", fontWeight: 600 }}
+                                onClick={() => onFocusLeagueHistorySeason(String(line.season))}
+                              >
+                                League History
+                              </button>
+                            ) : null}
+                          </span>
                         </TableCell>
                         <TableCell
                           style={{
@@ -1759,6 +1782,9 @@ export default function PlayerProfile({
                           }}
                         >
                           {line.team}
+                        </TableCell>
+                        <TableCell style={{ textAlign: "center", fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
+                          {player?.pos ?? "—"}
                         </TableCell>
                         <TableCell style={{ textAlign: "center" }}>
                           {line.gamesPlayed}
@@ -1773,7 +1799,7 @@ export default function PlayerProfile({
                             </TableCell>
                             <TableCell style={{ textAlign: "center" }}>{line.ints}</TableCell>
                             <TableCell style={{ textAlign: "center" }}>
-                              {line.compPct?.toFixed(1)}%
+                              {Number(line.compPct) > 0 ? `${Number(line.compPct).toFixed(1)}%` : "—"}
                             </TableCell>
                           </>
                         )}
@@ -1806,7 +1832,7 @@ export default function PlayerProfile({
                             </TableCell>
                           </>
                         )}
-                        {["DE", "DT", "LB", "CB", "S", "DL"].includes(
+                        {["DE", "DT", "LB", "CB", "S", "DL", "EDGE"].includes(
                           player.pos,
                         ) && (
                           <>
@@ -1816,17 +1842,30 @@ export default function PlayerProfile({
                             <TableCell style={{ textAlign: "center" }}>
                               {line.sacks}
                             </TableCell>
-                            <TableCell style={{ textAlign: "center" }}>{line.ffum}</TableCell>
+                            <TableCell style={{ textAlign: "center" }}>{line.defInts ?? line.defInterceptions ?? "—"}</TableCell>
+                          </>
+                        )}
+                        {["K"].includes(player.pos) && (
+                          <>
+                            <TableCell style={{ textAlign: "center" }}>{line.fgMade ?? "—"}</TableCell>
+                            <TableCell style={{ textAlign: "center" }}>{line.xpMade ?? "—"}</TableCell>
                           </>
                         )}
                         <TableCell style={{ textAlign: "center" }}>
-                          <strong>{line.ovr}</strong>
+                          <strong>{line.ovr != null ? line.ovr : "—"}</strong>
                         </TableCell>
                       </TableRow>
                     ))}
                   </TableBody>
                 </Table>
               </div>
+            </section>
+          )}
+          {!loading && mergedProfileSeasonRows.length === 0 && !isProspect && (
+            <section className="card-enter" style={{ marginTop: "var(--space-3)" }}>
+              <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--text-muted)" }}>
+                Season logs appear after seasons are archived with stat snapshots.
+              </p>
             </section>
           )}
             </>
@@ -1890,7 +1929,7 @@ export default function PlayerProfile({
                           {PASS_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableCell style={{ textAlign: "right" }}>{Number(line?.passYds ?? line?.passingYards ?? 0) > 0 ? Number(line?.passYds ?? line?.passingYards ?? 0).toLocaleString() : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{Number(line?.passTDs ?? line?.touchdowns ?? 0) > 0 ? Number(line?.passTDs ?? line?.touchdowns ?? 0) : "—"}</TableCell></>)}
                           {RUSH_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableCell style={{ textAlign: "right" }}>{Number(line?.rushYds ?? line?.rushingYards ?? 0) > 0 ? Number(line?.rushYds ?? line?.rushingYards ?? 0).toLocaleString() : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{Number(line?.rushTDs ?? line?.rushingTDs ?? 0) > 0 ? Number(line?.rushTDs ?? line?.rushingTDs ?? 0) : "—"}</TableCell></>)}
                           {REC_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableCell style={{ textAlign: "right" }}>{Number(line?.receptions ?? 0) > 0 ? Number(line?.receptions ?? 0) : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{Number(line?.recYds ?? line?.receivingYards ?? 0) > 0 ? Number(line?.recYds ?? line?.receivingYards ?? 0).toLocaleString() : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{Number(line?.recTDs ?? line?.receivingTDs ?? 0) > 0 ? Number(line?.recTDs ?? line?.receivingTDs ?? 0) : "—"}</TableCell></>)}
-                          {DEF_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableCell style={{ textAlign: "right" }}>{Number(line?.tackles ?? line?.totalTackles ?? 0) > 0 ? Number(line?.tackles ?? line?.totalTackles ?? 0) : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{Number(line?.sacks ?? 0) > 0 ? Number(line?.sacks ?? 0) : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{Number(line?.interceptions ?? line?.ints ?? 0) > 0 ? Number(line?.interceptions ?? line?.ints ?? 0) : "—"}</TableCell></>)}
+                          {DEF_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableCell style={{ textAlign: "right" }}>{Number(line?.tackles ?? line?.totalTackles ?? 0) > 0 ? Number(line?.tackles ?? line?.totalTackles ?? 0) : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{Number(line?.sacks ?? 0) > 0 ? Number(line?.sacks ?? 0) : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{Number(line?.defInts ?? line?.defInterceptions ?? 0) > 0 ? Number(line?.defInts ?? line?.defInterceptions ?? 0) : "—"}</TableCell></>)}
                           {SPEC_POSITIONS.includes(player?.position ?? player?.pos) && (<><TableCell style={{ textAlign: "right" }}>{line?.fgMade || 0 ? line?.fgMade ?? 0 : "—"}</TableCell><TableCell style={{ textAlign: "right" }}>{line?.xpMade || 0 ? line?.xpMade ?? 0 : "—"}</TableCell></>)}
                         </TableRow>
                       ))}

--- a/src/ui/components/__tests__/LeagueHistory.test.jsx
+++ b/src/ui/components/__tests__/LeagueHistory.test.jsx
@@ -120,4 +120,43 @@ describe('LeagueHistory', () => {
       expect(screen.getByText(/2030 League Snapshot/i)).toBeTruthy();
     });
   });
+
+  it('shows top performers when playerSeasonStatsV1 snapshots exist', async () => {
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        initialSelectedSeasonId="s9"
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [{
+                id: 's9',
+                year: 2095,
+                standings: [{ id: 1, abbr: 'DAL', wins: 8, losses: 9 }],
+                awards: {},
+                playerSeasonStatsV1: {
+                  schemaVersion: 1,
+                  rows: [
+                    { playerId: 'qb1', playerName: 'Air', pos: 'QB', teamId: 1, teamAbbr: 'DAL', year: 2095, seasonId: 's9', gamesPlayed: 10, passYds: 4800, passTDs: 35, passInts: 10, rushYds: 0, rushTDs: 0, recYds: 0, recTDs: 0, tackles: 0, sacks: 0, defInts: 0, fgMade: 0, xpMade: 0 },
+                  ],
+                  meta: {},
+                },
+              }],
+            },
+          }),
+          getRecords: vi.fn().mockResolvedValue({ payload: { records: null } }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('league-history-top-performers-s9')).toBeTruthy();
+      expect(screen.getByTestId('league-history-top-performers-s9').textContent).toMatch(/Air/);
+      expect(screen.getByTestId('league-history-top-performers-s9').textContent).toMatch(/4,?800/);
+    });
+  });
 });

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -155,6 +155,57 @@ describe('PlayerProfile', () => {
     expect(onNavigate).toHaveBeenCalledWith('HQ');
   });
 
+  it('renders season log from playerSeasonStatsV1 when careerStats is empty', async () => {
+    const logActions = {
+      getPlayerCareer: vi.fn(async () => ({
+        payload: {
+          player: { ...player, careerStats: [] },
+          stats: [],
+          teammates: [],
+          meta: {},
+        },
+      })),
+      getAllSeasons: vi.fn(async () => ({
+        payload: {
+          seasons: [{
+            id: 's1',
+            year: 2030,
+            playerSeasonStatsV1: {
+              schemaVersion: 1,
+              rows: [{
+                playerId: 11,
+                playerName: 'Avery Fields',
+                pos: 'QB',
+                teamId: 1,
+                teamAbbr: 'DAL',
+                year: 2030,
+                seasonId: 's1',
+                gamesPlayed: 12,
+                passYds: 4100,
+                passTDs: 31,
+                passInts: 9,
+                rushYds: 0,
+                rushTDs: 0,
+                recYds: 0,
+                recTDs: 0,
+                tackles: 0,
+                sacks: 0,
+                defInts: 0,
+                fgMade: 0,
+                xpMade: 0,
+              }],
+              meta: { source: 'seasonStats', partial: false, createdAt: 't' },
+            },
+          }],
+        },
+      })),
+      getRecords: vi.fn(async () => ({ payload: { recordBook: null } })),
+    };
+    render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={logActions} teams={league.teams} league={league} />);
+    await waitFor(() => expect(screen.getByText('Season Log')).toBeTruthy());
+    expect(screen.getByText('4,100')).toBeTruthy();
+  });
+
   it('shows honest empty award timeline when no honors exist', async () => {
     render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={actions} teams={league.teams} league={league} />);
     await waitFor(() => expect(screen.getByTestId('player-profile-award-timeline')).toBeTruthy());

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -110,6 +110,7 @@ import { evaluateRetirements }     from '../core/retirement-system.js';
 import { runAIToAITrades, generateAITradeProposalsForUser, evaluateCounterOffer } from '../core/trade-logic.js';
 import { processSeasonRecords, createEmptyRecords, getMostPlayedTeam } from '../core/records.js';
 import { ensureLeagueMemoryMeta, buildSeasonArchiveSummary, updateFranchiseHistory, updateRecordBook, evaluateHallOfFameCandidate, addHallOfFameClass, buildSeasonStorylineSnapshot, buildHallOfFameInducteeRow, syncHallOfFameAfterRecordBook } from '../core/league-memory.js';
+import { buildPlayerSeasonStatsArchiveRows } from '../core/playerSeasonStatsArchive.js';
 import { rebuildRecordBookV1, mirrorRecordBookForLegacyUi, RECORD_BOOK_SCHEMA_VERSION } from '../core/recordBookV1.js';
 import { inferChampionshipOutcome, isCompletedGame, isPostseasonGame } from '../core/championshipInference.js';
 import { repairDepthChart, validateDepthChart, optimizeDepthChartForPlan } from "../core/roster/depthChartManager.js";
@@ -8434,6 +8435,8 @@ async function archiveSeason(seasonId) {
       cache.updatePlayer(playerId, { accolades });
     };
 
+    const year = meta.year;
+
     // 3. Populate stats with player details
     const populatedStats = [];
     await Promise.all(seasonStats.map(async (s) => {
@@ -8490,7 +8493,6 @@ async function archiveSeason(seasonId) {
     }
 
     // 4. Determine Champion and runner-up from season games when possible.
-    const year = meta.year;
     const championshipInference = inferChampionshipOutcome({ seasonGames, meta });
     const championshipGame = championshipInference.championshipGame;
     const championId = championshipInference.championTeamId;
@@ -8596,6 +8598,13 @@ async function archiveSeason(seasonId) {
     const standingsRows = standings.map(s => ({
       id: s.id, name: s.name, abbr: s.abbr, wins: s.wins, losses: s.losses, ties: s.ties, pct: s.pct, pf: s.pf, pa: s.pa
     }));
+    const playerSeasonStatsV1Raw = buildPlayerSeasonStatsArchiveRows(populatedStats, {
+      teams,
+      year,
+      seasonId,
+    });
+    const playerSeasonStatsV1 = playerSeasonStatsV1Raw.rows.length ? playerSeasonStatsV1Raw : null;
+
     const seasonSummary = buildSeasonArchiveSummary({
       year,
       seasonId,
@@ -8610,6 +8619,7 @@ async function archiveSeason(seasonId) {
       transactions: await Transactions.bySeason(seasonId).catch(() => []),
       teams,
       seasonStats: populatedStats,
+      playerSeasonStatsV1: playerSeasonStatsV1 ?? undefined,
     });
     const archivedLeagueView = archiveCompletedSeasonIfNeeded(ensureLeagueHistoryContainer({
       seasonId: year,

--- a/tests/unit/franchiseHistoryModel.test.js
+++ b/tests/unit/franchiseHistoryModel.test.js
@@ -117,6 +117,31 @@ describe('buildFranchiseHistoryModel', () => {
     expect(m.franchiseRecords.playerSingleSeason[RECORD_KEYS.passingTD]?.playerId).toBe('qb2');
   });
 
+  it('populates franchise career leaders from playerSeasonStatsV1 and dedupes same player/season', () => {
+    const m = buildFranchiseHistoryModel({
+      teamId: 7,
+      teamAbbr: 'SEA',
+      archivedSeasons: [{
+        year: 2051,
+        seasonId: 's51',
+        id: 's51',
+        standings: [{ id: 7, abbr: 'SEA', wins: 10, losses: 7, ties: 0, pf: 300, pa: 300 }],
+        playerSeasonStatsV1: {
+          schemaVersion: 1,
+          rows: [
+            { playerId: 'rb1', playerName: 'Runner', pos: 'RB', teamId: 7, teamAbbr: 'SEA', year: 2051, seasonId: 's51', gamesPlayed: 12, rushYds: 1200, rushTDs: 8, recYds: 200, recTDs: 1 },
+            { playerId: 'rb1', playerName: 'Runner', pos: 'RB', teamId: 7, teamAbbr: 'SEA', year: 2051, seasonId: 's51', gamesPlayed: 12, rushYds: 1200, rushTDs: 8, recYds: 200, recTDs: 1 },
+          ],
+          meta: { source: 'seasonStats', partial: false, createdAt: 'x' },
+        },
+      }],
+    });
+    expect(m.franchiseRecords.careerFranchiseLeadersAvailable).toBe(true);
+    const rush = m.franchiseRecords.careerFranchiseLeaders[RECORD_KEYS.rushingYards];
+    expect(rush?.[0]?.value).toBe(1200);
+    expect(rush?.[0]?.playerId).toBe('rb1');
+  });
+
   it('does not use QB thrown INT for defensive interceptions leader', () => {
     const m = buildFranchiseHistoryModel({
       teamId: 7,

--- a/tests/unit/league_memory.test.js
+++ b/tests/unit/league_memory.test.js
@@ -7,6 +7,7 @@ import {
   buildSeasonArchiveSummary,
   buildSeasonStorylineSnapshot,
 } from '../../src/core/league-memory.js';
+import { PLAYER_SEASON_STATS_ARCHIVE_SCHEMA_VERSION } from '../../src/core/playerSeasonStatsArchive.js';
 
 describe('league memory helpers', () => {
   it('adds defaults for old saves', () => {
@@ -46,6 +47,28 @@ describe('league memory helpers', () => {
     meta = updateFranchiseHistory(meta, season, []);
     expect(meta.franchiseHistoryByTeam['0'].totals.championships).toBe(1);
     expect(meta.franchiseHistoryByTeam['0'].milestones.length).toBe(1);
+  });
+
+  it('includes playerSeasonStatsV1 when provided with rows', () => {
+    const season = buildSeasonArchiveSummary({
+      year: 2044,
+      seasonId: 's44',
+      standings: [],
+      awards: {},
+      leaders: {},
+      champion: null,
+      runnerUp: null,
+      userTeamId: 0,
+      games: [],
+      seasonStats: [],
+      playerSeasonStatsV1: {
+        schemaVersion: PLAYER_SEASON_STATS_ARCHIVE_SCHEMA_VERSION,
+        rows: [{ playerId: 'z', playerName: 'Zed', pos: 'QB', teamId: 1, year: 2044, seasonId: 's44', gamesPlayed: 1, passYds: 50, passTDs: 0, passInts: 0, rushYds: 0, rushTDs: 0, recYds: 0, recTDs: 0, tackles: 0, sacks: 0, defInts: 0, fgMade: 0, xpMade: 0 }],
+        meta: { source: 'seasonStats', partial: false, createdAt: 'now' },
+      },
+    });
+    expect(season.playerSeasonStatsV1.rows).toHaveLength(1);
+    expect(season.playerSeasonStatsV1.schemaVersion).toBe(1);
   });
 
   it('keeps archive shape stable when championship data is unavailable', () => {

--- a/tests/unit/playerSeasonStatsArchive.test.js
+++ b/tests/unit/playerSeasonStatsArchive.test.js
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildPlayerSeasonStatsArchiveRows,
+  normalizeArchivedPlayerStatRow,
+  getArchivedPlayerSeasonRows,
+  summarizePlayerSeasonRows,
+  groupArchivedPlayerStatsByPlayer,
+  defensiveIntsFromTotalsForArchive,
+  passIntsThrownFromTotals,
+  singleSeasonStatValueFromV1Row,
+  buildLeagueHistoryTopPerformers,
+} from '../../src/core/playerSeasonStatsArchive.js';
+import { RECORD_KEYS } from '../../src/core/recordBookV1.js';
+
+describe('playerSeasonStatsArchive', () => {
+  it('builds compact rows and omits statless players', () => {
+    const populated = [
+      {
+        playerId: 'a',
+        seasonId: 's1',
+        name: 'Statless',
+        pos: 'WR',
+        teamId: 1,
+        totals: { gamesPlayed: 0 },
+      },
+      {
+        playerId: 'b',
+        seasonId: 's1',
+        name: 'Busy',
+        pos: 'QB',
+        teamId: 1,
+        age: 24,
+        totals: { gamesPlayed: 12, passYd: 3200, passTD: 22, interceptions: 8 },
+      },
+    ];
+    const arch = buildPlayerSeasonStatsArchiveRows(populated, {
+      teams: [{ id: 1, abbr: 'ZZ' }],
+      year: 2033,
+      seasonId: 's1',
+    });
+    expect(arch.rows).toHaveLength(1);
+    expect(arch.rows[0].playerId).toBe('b');
+    expect(arch.rows[0].passInts).toBe(8);
+    expect(arch.rows[0].defInts).toBe(0);
+    expect(arch.meta.source).toBe('seasonStats');
+  });
+
+  it('does not treat QB picks as defensive INTs', () => {
+    const populated = [{
+      playerId: 'qb1',
+      seasonId: 's1',
+      name: 'Thrower',
+      pos: 'QB',
+      teamId: 2,
+      totals: { gamesPlayed: 10, passYd: 2000, interceptions: 14 },
+    }];
+    const arch = buildPlayerSeasonStatsArchiveRows(populated, { teams: [], year: 1, seasonId: 's1' });
+    expect(arch.rows[0].defInts).toBe(0);
+    expect(arch.rows[0].passInts).toBe(14);
+  });
+
+  it('uses defensive-specific INT fields when present', () => {
+    const populated = [{
+      playerId: 's1',
+      pos: 'S',
+      teamId: 1,
+      name: 'Safety',
+      totals: { gamesPlayed: 10, interceptions: 1, defInterceptions: 5 },
+    }];
+    const arch = buildPlayerSeasonStatsArchiveRows(populated, { teams: [], year: 1, seasonId: 's1' });
+    expect(arch.rows[0].defInts).toBe(5);
+  });
+
+  it('normalizes stat aliases on rows', () => {
+    const r = normalizeArchivedPlayerStatRow({
+      playerId: 'x',
+      playerName: 'N',
+      pos: 'RB',
+      teamId: 3,
+      passYds: 0,
+      rushYds: 100,
+      passInts: 0,
+      defInts: 0,
+    });
+    expect(r.rushYds).toBe(100);
+  });
+
+  it('getArchivedPlayerSeasonRows returns empty for legacy seasons', () => {
+    expect(getArchivedPlayerSeasonRows({ year: 1 })).toEqual([]);
+  });
+
+  it('summarizePlayerSeasonRows and groupArchivedPlayerStatsByPlayer', () => {
+    const base = { playerId: 'p1', seasonId: 's1', year: 2030, pos: 'RB', teamId: 1 };
+    const rows = [
+      normalizeArchivedPlayerStatRow({ ...base, gamesPlayed: 2, passYds: 100 }),
+      normalizeArchivedPlayerStatRow({ ...base, gamesPlayed: 1, rushYds: 50 }),
+    ].filter(Boolean);
+    expect(summarizePlayerSeasonRows(rows).rowCount).toBe(2);
+    expect(groupArchivedPlayerStatsByPlayer(rows).get('p1').length).toBe(2);
+  });
+
+  it('singleSeasonStatValueFromV1Row reads defensive INT from defInts only', () => {
+    const row = normalizeArchivedPlayerStatRow({
+      playerId: 'lb',
+      seasonId: 's2',
+      pos: 'LB',
+      passInts: 0,
+      defInts: 3,
+      passYds: 0,
+      gamesPlayed: 10,
+    });
+    expect(singleSeasonStatValueFromV1Row(RECORD_KEYS.interceptions, row)).toBe(3);
+  });
+
+  it('buildLeagueHistoryTopPerformers returns null without snapshots', () => {
+    expect(buildLeagueHistoryTopPerformers({ year: 1 })).toBe(null);
+  });
+
+  it('defensiveIntsFromTotalsForArchive matches QB vs LB behavior', () => {
+    expect(defensiveIntsFromTotalsForArchive('QB', { interceptions: 12 })).toBe(0);
+    expect(defensiveIntsFromTotalsForArchive('LB', { interceptions: 4 })).toBe(4);
+    expect(passIntsThrownFromTotals('QB', { interceptions: 4 })).toBe(4);
+    expect(passIntsThrownFromTotals('LB', { interceptions: 4 })).toBe(0);
+  });
+});

--- a/tests/unit/recordBookV1.test.js
+++ b/tests/unit/recordBookV1.test.js
@@ -8,6 +8,47 @@ import {
 } from '../../src/core/recordBookV1.js';
 
 describe('recordBookV1', () => {
+  it('single-season scan prefers playerSeasonStatsV1 when present', () => {
+    const book = rebuildRecordBookV1({
+      leagueHistory: [{
+        year: 2090,
+        seasonId: 'sx',
+        id: 'sx',
+        standings: [],
+        playerSeasonStatsV1: {
+          schemaVersion: 1,
+          rows: [
+            { playerId: 'wr9', playerName: 'Deep', pos: 'WR', teamId: 2, year: 2090, seasonId: 'sx', gamesPlayed: 11, recYds: 1700, recTDs: 14 },
+          ],
+          meta: { source: 'seasonStats', partial: false, createdAt: 't' },
+        },
+      }],
+      players: [],
+    });
+    expect(book.singleSeasonV1[RECORD_KEYS.receivingYards].value).toBe(1700);
+    expect(book.singleSeasonV1[RECORD_KEYS.receivingYards].playerId).toBe('wr9');
+  });
+
+  it('career leaders merge archive V1 when player lacks careerStats lines', () => {
+    const book = rebuildRecordBookV1({
+      leagueHistory: [{
+        year: 2099,
+        seasonId: 's9',
+        id: 's9',
+        playerSeasonStatsV1: {
+          schemaVersion: 1,
+          rows: [
+            { playerId: 'ghost', playerName: 'Ghost', pos: 'WR', teamId: 1, year: 2099, seasonId: 's9', gamesPlayed: 10, recYds: 900, recTDs: 6 },
+          ],
+          meta: { source: 'seasonStats', partial: false, createdAt: 't' },
+        },
+      }],
+      players: [{ id: 'ghost', name: 'Ghost', pos: 'WR', careerStats: [] }],
+    });
+    expect(book.careerLeadersV1[RECORD_KEYS.receivingYards][0]?.value).toBeGreaterThanOrEqual(900);
+    expect(book.careerLeadersV1[RECORD_KEYS.receivingYards][0]?.playerId).toBe('ghost');
+  });
+
   it('builds single-season records from archived playerStatLeaders', () => {
     const book = rebuildRecordBookV1({
       leagueHistory: [{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **compact `playerSeasonStatsV1`** blobs on archived season rows (written at `archiveSeason`), plus pure helpers and UI/record-book wiring so franchise career leaders, player season logs, the record book, and League History can use per-player totals **without** full game logs or full player objects.

## `playerSeasonStatsV1` shape

- `schemaVersion: 1`
- `rows[]`: `playerId`, `playerName`, `pos`, `teamId`, `teamAbbr`, `age`, `year`, `seasonId`, `gamesPlayed`, `passYds`, `passTDs`, `passInts` (QB thrown only), `rushYds`, `rushTDs`, `recYds`, `recTDs`, `tackles`, `sacks`, `defInts` (defensive picks only), `fgMade`, `xpMade`
- `meta`: `{ source: "seasonStats", partial, createdAt }` — `partial` is true when any populated stat row was dropped for having no meaningful totals/GP

## How rows are built

`buildPlayerSeasonStatsArchiveRows(populatedStats, { teams, year, seasonId })` in `src/core/playerSeasonStatsArchive.js`:

- Reads sim totals via shared aliases (`passYd`/`passingYards`, `fgMade`/`fieldGoalsMade`, etc.).
- One row per `playerId` from the archive pass; skips rows with no GP and all counting stats zero.
- **Defensive INT** uses the same rules as the record book: `defInterceptions` / `interceptionsDef` / `interceptionsMade`, else defensive positions may use `interceptions`; **QB `interceptions` → `passInts` only, never `defInts`.**

## Wiring

- **Worker** (`archiveSeason`): builds V1 after `populatedStats`; passes into `buildSeasonArchiveSummary`; fixes `year` being used before assignment when resolving draft year.
- **`buildSeasonArchiveSummary`**: attaches `playerSeasonStatsV1` only when `rows.length > 0` (old saves unchanged).
- **`franchiseHistoryModel`**: prefers V1 rows **for the franchise** when any exist for that season; otherwise legacy `playerStats`/`seasonStats`. Dedupes `playerId` + `seasonId`/`year`. Franchise single-season scan uses the same rule.
- **`recordBookV1`**: single-season best now considers **leaders + legacy stats scan + V1 scan** (max wins). Career boards merge `careerStats` with **archive-only** V1 seasons (no double-count vs existing `careerStats` season keys via `careerLineSeasonKey`).
- **`mergePlayerProfileSeasonRows`** (recordBookV1): merges profile season log; **PlayerProfile** + **Career Stats** tab use it; honest copy when empty; defense shows **D-INT**; optional **League History** jump via `onFocusLeagueHistorySeason` from **LeagueDashboard**.
- **LeagueHistory**: compact **Top performers** from `buildLeagueHistoryTopPerformers` when snapshots exist.

## Tests / checks run

- `npm ci`
- `npm run test:unit` — **693 passed** (full suite; `traits` test can rarely flake on probabilistic assertion—re-run clean if seen)
- `npm run build`
- `npm run check:deploy`
- `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js`
- `npx playwright install chromium` (CI/agent browsers) then `npx playwright test` — **18 passed**

## Known limitations / follow-ups

- Seasons that **fail archive gating** (no postseason completion markers) still produce **no** snapshot, as before.
- If a save has `playerSeasonStatsV1` with **no rows for a given franchise** in a season, that season **falls back** to legacy pools for franchise math.
- Rows omit **fantasy** (field not present in sim totals here).
- `traits.test.js` uses randomness; extremely rare flake on strict ratio—documented above.

EOF
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0156603a-3a3b-495a-bbc5-2b0a954fe85c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0156603a-3a3b-495a-bbc5-2b0a954fe85c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

