### PR TITLE
Draft Class Memory / Redraft V1 + LeagueDashboard TABS TDZ fix

### DIFF
--- a/src/core/draftClassHistory.js
+++ b/src/core/draftClassHistory.js
@@ -1,0 +1,573 @@
+/**
+ * Draft Class Memory / Redraft V1 — pure helpers (no worker, no React).
+ * Builds explainable draft-class views from DRAFT transactions + player career signals.
+ */
+
+import { buildLegacyScoreReport } from './legacyScore.js';
+
+function num(v) {
+  const n = Number(v ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function str(v) {
+  if (v == null) return '';
+  return String(v).trim();
+}
+
+function teamAbbrFromCtx(teamId, ctx = {}) {
+  const id = num(teamId);
+  if (!id) return '';
+  if (ctx.teamsById instanceof Map) {
+    return str(ctx.teamsById.get(id)?.abbr);
+  }
+  const t = (ctx.teams || []).find((x) => num(x?.id) === id);
+  return str(t?.abbr);
+}
+
+/**
+ * Normalize a raw IndexedDB DRAFT transaction (or enriched worker row) to a pick row.
+ * @param {object} rawTx
+ * @param {{ teams?: any[], teamsById?: Map<number, any> }} ctx
+ */
+export function normalizeDraftPickRow(rawTx, ctx = {}) {
+  const d = rawTx?.details && typeof rawTx.details === 'object' ? rawTx.details : {};
+  const playerId = d.playerId != null ? num(d.playerId) : num(rawTx?.playerId);
+  const pl = ctx.playersById instanceof Map
+    ? ctx.playersById.get(playerId)
+    : (ctx.players || []).find((p) => num(p?.id) === playerId);
+  const draftTeamId = num(rawTx?.teamId);
+  const abbr = str(rawTx?.teamAbbr) || teamAbbrFromCtx(draftTeamId, ctx);
+  const overall = d.overall != null ? num(d.overall) : null;
+  const round = d.round != null ? num(d.round) : null;
+  const pickInRound = d.pickInRound != null ? num(d.pickInRound) : null;
+  let originalPickLabel = '';
+  if (overall > 0) originalPickLabel = `#${overall}`;
+  else if (round > 0) originalPickLabel = `R${round}${pickInRound > 0 ? ` · ${pickInRound}` : ''}`;
+
+  return {
+    playerId: playerId > 0 ? playerId : null,
+    playerName: str(rawTx?.playerName) || str(pl?.name) || '',
+    pos: str(rawTx?.playerPos) || str(pl?.pos) || '',
+    draftTeamId: draftTeamId > 0 ? draftTeamId : null,
+    draftTeamAbbr: abbr || null,
+    round: round > 0 ? round : null,
+    pickInRound: pickInRound > 0 ? pickInRound : null,
+    overall: overall > 0 ? overall : null,
+    originalPickLabel: originalPickLabel || null,
+    seasonId: rawTx?.seasonId != null ? str(rawTx.seasonId) : null,
+    _originalTeamId: d.originalTeamId != null ? num(d.originalTeamId) : null,
+  };
+}
+
+/** @typedef {'developing'|'mature'|'historic'|'weak'} DraftClassLeagueStatus */
+
+function careerGamesPlayed(player) {
+  const cs = Array.isArray(player?.careerStats) ? player.careerStats : [];
+  return cs.reduce((s, row) => s + num(row?.gamesPlayed), 0) || cs.length * 8;
+}
+
+function careerSeasonCount(player) {
+  const cs = Array.isArray(player?.careerStats) ? player.careerStats : [];
+  return cs.length;
+}
+
+/**
+ * @param {object} player
+ * @param {object} report - buildLegacyScoreReport result
+ * @param {number} seasonsSinceDraft
+ * @param {{ isDevelopingClass?: boolean }} opts
+ */
+export function assignOutcomeTier(player, report, seasonsSinceDraft, opts = {}) {
+  const reasons = [];
+  const isDevelopingClass = Boolean(opts.isDevelopingClass);
+  const seasonsPlayed = careerSeasonCount(player);
+  const games = careerGamesPlayed(player);
+  const ls = num(report?.legacyScore);
+  const hof = Boolean(player?.hof);
+
+  if (hof) {
+    reasons.push('Hall of Fame résumé');
+    return { tier: 'HOF', outcomeLabel: 'Hall of Fame', reasons };
+  }
+
+  if (isDevelopingClass || seasonsSinceDraft <= 1) {
+    reasons.push('Draft class still developing in the league');
+    return { tier: 'TOO_EARLY', outcomeLabel: 'Too early', reasons };
+  }
+
+  if (seasonsSinceDraft <= 2 || seasonsPlayed <= 1) {
+    reasons.push('Early-career sample; outcomes not finalized');
+    return { tier: 'DEVELOPING', outcomeLabel: 'Developing', reasons };
+  }
+
+  if (seasonsPlayed <= 2 && games < 20) {
+    reasons.push('Limited NFL sample so far');
+    return { tier: 'UNKNOWN', outcomeLabel: 'Unknown / too early', reasons };
+  }
+
+  const mvp = (player?.accolades || []).filter((a) => a?.type === 'MVP').length;
+  const allPro = (player?.accolades || []).filter((a) => a?.type === 'ALL_PRO' || a?.type === 'ALLPRO').length;
+
+  if (ls >= 82 || mvp >= 1) {
+    if (mvp) reasons.push(`${mvp}x MVP`);
+    if (ls >= 82) reasons.push(`Elite legacy score (${ls})`);
+    return { tier: 'SUPERSTAR', outcomeLabel: 'Superstar', reasons };
+  }
+  if (ls >= 72 || allPro >= 2) {
+    if (allPro) reasons.push(`${allPro}x All-Pro`);
+    return { tier: 'STAR', outcomeLabel: 'Star', reasons };
+  }
+  if (ls >= 58 && games >= 40) {
+    reasons.push('Solid multi-season production');
+    return { tier: 'LONG_STARTER', outcomeLabel: 'Long-term starter', reasons };
+  }
+  if (ls >= 48 && games >= 24) {
+    return { tier: 'CONTRIBUTOR', outcomeLabel: 'Contributor', reasons: ['Positive career value'] };
+  }
+  if (ls >= 38) {
+    return { tier: 'REPLACEMENT', outcomeLabel: 'Replacement-level', reasons: ['Modest career impact to date'] };
+  }
+
+  if (seasonsSinceDraft >= 5 && seasonsPlayed >= 3 && ls < 32 && games >= 30) {
+    reasons.push('Multiple seasons without standout impact');
+    return { tier: 'BUST', outcomeLabel: 'Bust', reasons };
+  }
+
+  reasons.push('Career arc still open');
+  return { tier: 'UNKNOWN', outcomeLabel: 'Unknown / too early', reasons };
+}
+
+/**
+ * Outcome score for redraft ordering: legacy-first with games + accolades nudge.
+ */
+export function computeOutcomeScore(player, report) {
+  let s = num(report?.legacyScore);
+  s += Math.min(10, careerGamesPlayed(player) / 30);
+  if (player?.hof) s += 25;
+  const mvp = (player?.accolades || []).filter((a) => a?.type === 'MVP').length;
+  s += mvp * 6;
+  const ap = (player?.accolades || []).filter((a) => a?.type === 'ALL_PRO' || a?.type === 'ALLPRO').length;
+  s += ap * 3;
+  return s;
+}
+
+/**
+ * @param {object[]} draftTransactions - raw DB rows type DRAFT
+ * @param {{ teams?: any[], teamsById?: Map<number,any>, players?: any[], playersById?: Map<number,any> }} ctx
+ */
+export function picksFromDraftTransactions(draftTransactions, ctx = {}) {
+  if (!Array.isArray(draftTransactions)) return [];
+  const byPlayer = new Map();
+  for (const tx of draftTransactions) {
+    if (str(tx?.type).toUpperCase() !== 'DRAFT') continue;
+    const row = normalizeDraftPickRow(tx, ctx);
+    if (!row.playerId) continue;
+    byPlayer.set(row.playerId, row);
+  }
+  return [...byPlayer.values()].sort((a, b) => num(a.overall) - num(b.overall) || num(a.playerId) - num(b.playerId));
+}
+
+/**
+ * Add picks from player roster fields when no transaction exists for that player/year.
+ * @param {number} draftYear
+ * @param {object[]} players
+ * @param {Set<number>} existingPlayerIds
+ * @param {{ teams?: any[], teamsById?: Map<number,any> }} ctx
+ */
+export function mergePlayerFieldFallbackPicks(draftYear, players, existingPlayerIds, ctx = {}) {
+  if (!Number.isFinite(draftYear) || draftYear <= 0 || !Array.isArray(players)) return [];
+  const out = [];
+  for (const p of players) {
+    const pid = num(p?.id);
+    if (!pid || existingPlayerIds.has(pid)) continue;
+    const py = num(p?.draftYear);
+    if (py !== draftYear) continue;
+    const tid = num(p?.draftTeamId);
+    if (!tid) continue;
+    out.push({
+      playerId: pid,
+      playerName: str(p?.name),
+      pos: str(p?.pos),
+      draftTeamId: tid,
+      draftTeamAbbr: str(p?.draftTeamAbbr) || teamAbbrFromCtx(tid, ctx),
+      round: num(p?.draftRound) > 0 ? num(p?.draftRound) : null,
+      pickInRound: num(p?.draftPick) > 0 ? num(p?.draftPick) : null,
+      overall: num(p?.draftOverall ?? p?.draftOverallPick) > 0 ? num(p?.draftOverall ?? p?.draftOverallPick) : null,
+      originalPickLabel: num(p?.draftOverall ?? p?.draftOverallPick) > 0
+        ? `#${num(p?.draftOverall ?? p?.draftOverallPick)}`
+        : (num(p?.draftRound) > 0 ? `R${num(p?.draftRound)}` : null),
+      seasonId: null,
+      _fromPlayerFields: true,
+    });
+  }
+  return out;
+}
+
+function leagueClassStatus(medianScore, pickCount, isDevelopingClass) {
+  if (isDevelopingClass) return 'developing';
+  if (pickCount < 8) return 'weak';
+  if (medianScore >= 52) return 'historic';
+  if (medianScore >= 44) return 'mature';
+  if (medianScore < 38) return 'weak';
+  return 'mature';
+}
+
+/**
+ * @param {object} model - output of buildDraftClassModel (needs picks with outcomeScore, redraftRank)
+ */
+export function buildRedraftBoard(model) {
+  const sorted = [...(model?.picks || [])].sort((a, b) => num(b.outcomeScore) - num(a.outcomeScore));
+  return sorted.map((p, idx) => ({ ...p, redraftRank: idx + 1 }));
+}
+
+/**
+ * @param {object} model
+ * @param {number} teamId
+ */
+export function gradeTeamDraftClass(model, teamId) {
+  const tid = num(teamId);
+  const picks = (model?.picks || []).filter((p) => num(p.draftTeamId) === tid);
+  const incomplete = model?.meta?.isDevelopingClass || picks.length === 0;
+  if (incomplete || picks.length < 2) {
+    return {
+      teamId: tid,
+      pickCount: picks.length,
+      bestPick: null,
+      totalValue: 0,
+      avgValue: 0,
+      steals: 0,
+      busts: 0,
+      gradeLabel: 'Incomplete',
+    };
+  }
+  const scores = picks.map((p) => num(p.outcomeScore));
+  const total = scores.reduce((a, b) => a + b, 0);
+  const avg = total / picks.length;
+  const bestPick = [...picks].sort((a, b) => num(b.outcomeScore) - num(a.outcomeScore))[0] || null;
+  const steals = picks.filter((p) => num(p.redraftDelta) >= 40 && !model.meta?.suppressStealsBusts).length;
+  const busts = picks.filter((p) => num(p.redraftDelta) <= -35 && p.outcomeTier === 'BUST' && !model.meta?.suppressStealsBusts).length;
+
+  let gradeLabel = 'C';
+  if (avg >= 62) gradeLabel = 'A+';
+  else if (avg >= 56) gradeLabel = 'A';
+  else if (avg >= 50) gradeLabel = 'B';
+  else if (avg >= 44) gradeLabel = 'C';
+  else if (avg >= 36) gradeLabel = 'D';
+  else gradeLabel = 'D';
+
+  return {
+    teamId: tid,
+    pickCount: picks.length,
+    bestPick: bestPick
+      ? { playerId: bestPick.playerId, playerName: bestPick.playerName, outcomeScore: bestPick.outcomeScore }
+      : null,
+    totalValue: Math.round(total * 10) / 10,
+    avgValue: Math.round(avg * 10) / 10,
+    steals,
+    busts,
+    gradeLabel,
+  };
+}
+
+/**
+ * @param {object} player
+ * @param {object[]} draftTransactions - recent raw DRAFT rows (optional)
+ */
+export function findPlayerDraftOrigin(player, draftTransactions = []) {
+  const pid = num(player?.id);
+  if (!pid) return null;
+  if (Array.isArray(draftTransactions)) {
+    const hit = draftTransactions.find((tx) => {
+      if (str(tx?.type).toUpperCase() !== 'DRAFT') return false;
+      const d = tx?.details || {};
+      const id = d.playerId != null ? num(d.playerId) : num(tx?.playerId);
+      return id === pid;
+    });
+    if (hit) {
+      const row = normalizeDraftPickRow(hit, { players: [player] });
+      return {
+        source: 'transaction',
+        ...row,
+        draftYear: null,
+      };
+    }
+  }
+  const dy = num(player?.draftYear);
+  if (dy > 0 && num(player?.draftTeamId) > 0) {
+    return {
+      source: 'player',
+      playerId: pid,
+      playerName: str(player?.name),
+      pos: str(player?.pos),
+      draftTeamId: num(player?.draftTeamId),
+      draftTeamAbbr: str(player?.draftTeamAbbr) || null,
+      round: num(player?.draftRound) > 0 ? num(player?.draftRound) : null,
+      pickInRound: num(player?.draftPick) > 0 ? num(player?.draftPick) : null,
+      overall: num(player?.draftOverall ?? player?.draftOverallPick) > 0 ? num(player?.draftOverall ?? player?.draftOverallPick) : null,
+      originalPickLabel: num(player?.draftOverall ?? player?.draftOverallPick) > 0
+        ? `#${num(player?.draftOverall ?? player?.draftOverallPick)}`
+        : null,
+      draftYear: dy,
+      seasonId: null,
+    };
+  }
+  return null;
+}
+
+/**
+ * Build full draft class model + redraft + team grades + steals/busts lists.
+ * @param {{
+ *   year: number,
+ *   seasonId: string|null,
+ *   draftTransactions: object[],
+ *   playersById: Map<number, object>,
+ *   currentLeagueYear: number,
+ *   recordBook?: object|null,
+ *   archivedSeasons?: any[],
+ *   teams?: any[],
+ * }} input
+ */
+export function buildDraftClassModel(input) {
+  const {
+    year,
+    seasonId = null,
+    draftTransactions = [],
+    playersById = new Map(),
+    currentLeagueYear = year,
+    recordBook = null,
+    archivedSeasons = [],
+    teams = [],
+  } = input;
+
+  const teamsById = new Map((teams || []).map((t) => [num(t?.id), t]));
+  const ctx = { teams, teamsById, playersById };
+
+  let basePicks = picksFromDraftTransactions(draftTransactions, ctx);
+  const existingIds = new Set(basePicks.map((p) => num(p.playerId)).filter((x) => x > 0));
+  const fallback = mergePlayerFieldFallbackPicks(
+    year,
+    [...playersById.values()],
+    existingIds,
+    ctx,
+  );
+  basePicks = [...basePicks, ...fallback];
+
+  const seasonsSinceDraft = Math.max(0, num(currentLeagueYear) - num(year));
+  const isDevelopingClass = seasonsSinceDraft < 2;
+  const suppressStealsBusts = isDevelopingClass || seasonsSinceDraft < 3;
+
+  const legacyCtx = { recordBook, archivedSeasons, teams, year: currentLeagueYear };
+
+  const enriched = basePicks.map((pick) => {
+    const pl = playersById.get(num(pick.playerId)) || null;
+    const report = pl ? buildLegacyScoreReport(pl, legacyCtx) : null;
+    const outcome = assignOutcomeTier(pl || {}, report || {}, seasonsSinceDraft, { isDevelopingClass });
+    const outcomeScore = pl && report ? computeOutcomeScore(pl, report) : 0;
+    const curTid = pl ? num(pl.teamId) : null;
+    return {
+      ...pick,
+      currentTeamId: curTid > 0 ? curTid : null,
+      currentTeamAbbr: teamAbbrFromCtx(curTid, ctx) || null,
+      careerSummary: report?.careerSummary || '',
+      legacyScore: report ? num(report.legacyScore) : null,
+      outcomeTier: outcome.tier,
+      outcomeLabel: outcome.outcomeLabel,
+      reasons: [...(pick._fromPlayerFields ? ['From roster draft fields (no logged pick)'] : []), ...outcome.reasons],
+      outcomeScore: Math.round(outcomeScore * 100) / 100,
+      redraftRank: null,
+      redraftDelta: null,
+    };
+  });
+
+  const sortedByOutcome = [...enriched].sort((a, b) => num(b.outcomeScore) - num(a.outcomeScore));
+  const redraftByPlayerId = new Map();
+  sortedByOutcome.forEach((p, idx) => {
+    const orig = num(p.overall) > 0 ? num(p.overall) : idx + 32;
+    const redraftRank = idx + 1;
+    const redraftDelta = orig - redraftRank;
+    redraftByPlayerId.set(num(p.playerId), { redraftRank, redraftDelta });
+  });
+  const byOriginal = [...enriched].sort(
+    (a, b) => num(a.overall) - num(b.overall) || num(a.playerId) - num(b.playerId),
+  );
+  const withRedraft = byOriginal.map((p) => {
+    const rr = redraftByPlayerId.get(num(p.playerId)) || { redraftRank: null, redraftDelta: null };
+    return { ...p, redraftRank: rr.redraftRank, redraftDelta: rr.redraftDelta };
+  });
+
+  const redraftTop10 = sortedByOutcome.slice(0, 10).map((p, idx) => {
+    const orig = num(p.overall) > 0 ? num(p.overall) : idx + 32;
+    const redraftRank = idx + 1;
+    const redraftDelta = orig - redraftRank;
+    return {
+      playerId: p.playerId,
+      playerName: p.playerName,
+      pos: p.pos,
+      originalOverall: p.overall,
+      redraftRank,
+      redraftDelta,
+      outcomeLabel: p.outcomeLabel,
+      reason: (p.reasons && p.reasons[0]) || '',
+    };
+  });
+
+  let steals = [];
+  let busts = [];
+  if (!suppressStealsBusts) {
+    steals = [...withRedraft]
+      .filter((p) => num(p.redraftDelta) >= 48 && num(p.overall) > 0)
+      .sort((a, b) => num(b.redraftDelta) - num(a.redraftDelta))
+      .slice(0, 5)
+      .map((p) => ({
+        playerId: p.playerId,
+        playerName: p.playerName,
+        redraftDelta: p.redraftDelta,
+        note: `Drafted #${p.overall} · now redraft #${p.redraftRank}`,
+      }));
+    busts = [...withRedraft]
+      .filter((p) => p.outcomeTier === 'BUST' && num(p.redraftDelta) < -20)
+      .sort((a, b) => num(a.redraftDelta) - num(b.redraftDelta))
+      .slice(0, 5)
+      .map((p) => ({
+        playerId: p.playerId,
+        playerName: p.playerName,
+        redraftDelta: p.redraftDelta,
+        note: 'Late-career value never matched draft capital',
+      }));
+  }
+
+  const teamIds = [...new Set(withRedraft.map((p) => num(p.draftTeamId)).filter((x) => x > 0))];
+  const teamGrades = teamIds.map((tid) => gradeTeamDraftClass(
+    { picks: withRedraft, meta: { isDevelopingClass, suppressStealsBusts } },
+    tid,
+  ));
+
+  const legacies = withRedraft.map((p) => num(p.legacyScore)).filter((x) => Number.isFinite(x));
+  const medianScore = legacies.length
+    ? [...legacies].sort((a, b) => a - b)[Math.floor(legacies.length / 2)]
+    : 0;
+  const classLeagueStatus = leagueClassStatus(medianScore, withRedraft.length, isDevelopingClass);
+
+  const starCount = withRedraft.filter((p) => p.outcomeTier === 'STAR' || p.outcomeTier === 'SUPERSTAR' || p.outcomeTier === 'HOF').length;
+  const starterCount = withRedraft.filter((p) =>
+    ['LONG_STARTER', 'STAR', 'SUPERSTAR', 'HOF', 'CONTRIBUTOR'].includes(p.outcomeTier)).length;
+  const hofCount = withRedraft.filter((p) => p.outcomeTier === 'HOF').length;
+  const mvpCount = withRedraft.filter((p) => (p.playerId && (playersById.get(num(p.playerId))?.accolades || []).some((a) => a?.type === 'MVP'))).length;
+  const allProCount = withRedraft.filter((p) => (p.playerId && (playersById.get(num(p.playerId))?.accolades || []).some((a) => a?.type === 'ALL_PRO' || a?.type === 'ALLPRO'))).length;
+  const avgLegacyScore = legacies.length
+    ? Math.round((legacies.reduce((a, b) => a + b, 0) / legacies.length) * 10) / 10
+    : null;
+
+  return {
+    year,
+    seasonId,
+    picks: withRedraft.map((p) => ({
+      playerId: p.playerId,
+      playerName: p.playerName,
+      pos: p.pos,
+      draftTeamId: p.draftTeamId,
+      draftTeamAbbr: p.draftTeamAbbr,
+      round: p.round,
+      pickInRound: p.pickInRound,
+      overall: p.overall,
+      originalPickLabel: p.originalPickLabel,
+      currentTeamId: p.currentTeamId,
+      currentTeamAbbr: p.currentTeamAbbr,
+      careerSummary: p.careerSummary,
+      legacyScore: p.legacyScore,
+      redraftRank: p.redraftRank,
+      redraftDelta: p.redraftDelta,
+      outcomeTier: p.outcomeTier,
+      outcomeLabel: p.outcomeLabel,
+      reasons: (p.reasons || []).slice(0, 6),
+    })),
+    redraftTop10,
+    steals,
+    busts,
+    teamGrades,
+    classSummary: {
+      totalPicks: withRedraft.length,
+      starCount,
+      starterCount,
+      hofCount,
+      mvpCount,
+      allProCount,
+      avgLegacyScore,
+      classLeagueStatus,
+      isDevelopingClass,
+      seasonsSinceDraft,
+    },
+    meta: {
+      isDevelopingClass,
+      suppressStealsBusts,
+      seasonsSinceDraft,
+    },
+  };
+}
+
+/**
+ * Summarize which seasons have DRAFT data (for History / worker list).
+ * @param {object[]} rawTransactions - capped recent list or season slice
+ * @param {{ id: string, year: number }[]} seasonRows - merged season summaries
+ */
+export function indexDraftClassesFromTransactions(rawTransactions, seasonRows = []) {
+  const yearBySeasonId = new Map((seasonRows || []).map((s) => [str(s?.id), num(s?.year)]));
+  const groups = new Map();
+  for (const tx of rawTransactions || []) {
+    if (str(tx?.type).toUpperCase() !== 'DRAFT') continue;
+    const sid = tx?.seasonId != null ? str(tx.seasonId) : '';
+    if (!sid) continue;
+    if (!groups.has(sid)) {
+      groups.set(sid, { seasonId: sid, pickCount: 0, teamIds: new Set() });
+    }
+    const g = groups.get(sid);
+    g.pickCount += 1;
+    const tid = num(tx?.teamId);
+    if (tid > 0) g.teamIds.add(tid);
+  }
+  const list = [...groups.values()].map((g) => ({
+    seasonId: g.seasonId,
+    year: yearBySeasonId.get(g.seasonId) || null,
+    pickCount: g.pickCount,
+    teamIds: [...g.teamIds],
+  }));
+  list.sort((a, b) => num(b.year) - num(a.year) || str(b.seasonId).localeCompare(str(a.seasonId)));
+  return list;
+}
+
+/**
+ * Compact player draft strip (UI + worker GET_PLAYER_DRAFT_CONTEXT).
+ * @param {object} player
+ * @param {object|null} classModel - optional full class model for this player's draft year
+ */
+export function buildPlayerDraftContext(player, classModel = null, draftTransactions = []) {
+  const origin = findPlayerDraftOrigin(player, draftTransactions);
+  const pid = num(player?.id);
+  let redraftRank = null;
+  let stealBustNote = '';
+  if (classModel?.picks && pid) {
+    const row = classModel.picks.find((p) => num(p.playerId) === pid);
+    if (row) {
+      redraftRank = row.redraftRank;
+      if (classModel.classSummary?.isDevelopingClass) stealBustNote = 'Developing class — no steal/bust labels yet.';
+      else if (num(row.redraftDelta) >= 48) stealBustNote = 'One of the biggest values vs draft slot.';
+      else if (row.outcomeTier === 'BUST') stealBustNote = 'Draft capital has not paid off to date.';
+    }
+  }
+  if (!origin && !redraftRank) {
+    return { known: false };
+  }
+  const dy = num(player?.draftYear) || num(classModel?.year) || null;
+  return {
+    known: true,
+    draftedByAbbr: origin?.draftTeamAbbr || player?.draftTeamAbbr || null,
+    round: (origin?.round ?? num(player?.draftRound)) || null,
+    pickInRound: (origin?.pickInRound ?? num(player?.draftPick)) || null,
+    overall: (origin?.overall ?? num(player?.draftOverall ?? player?.draftOverallPick)) || null,
+    draftYear: dy,
+    redraftRank,
+    outcomeLabel: classModel?.picks?.find((p) => num(p.playerId) === pid)?.outcomeLabel || null,
+    stealBustNote,
+  };
+}

--- a/src/ui/components/DraftHistory.jsx
+++ b/src/ui/components/DraftHistory.jsx
@@ -1,0 +1,236 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { ScreenHeader, SectionCard } from './ScreenSystem.jsx';
+
+const EMPTY_COPY = 'Draft history will appear after completed drafts are logged in your dynasty.';
+
+export default function DraftHistory({ league, actions, onPlayerSelect, onNavigate }) {
+  const [classes, setClasses] = useState([]);
+  const [selectedId, setSelectedId] = useState(null);
+  const [model, setModel] = useState(null);
+  const [loadingList, setLoadingList] = useState(true);
+  const [loadingModel, setLoadingModel] = useState(false);
+  const [error, setError] = useState(null);
+
+  const loadList = useCallback(() => {
+    if (!actions?.getDraftClasses) return Promise.resolve();
+    setLoadingList(true);
+    setError(null);
+    return actions
+      .getDraftClasses()
+      .then((res) => {
+        const list = res?.payload?.classes ?? [];
+        setClasses(list);
+        setSelectedId((prev) => prev ?? (list[0]?.seasonId ?? null));
+      })
+      .catch(() => {
+        setClasses([]);
+        setError('Could not load draft classes.');
+      })
+      .finally(() => setLoadingList(false));
+  }, [actions]);
+
+  useEffect(() => {
+    loadList();
+  }, [loadList]);
+
+  useEffect(() => {
+    if (!selectedId || !actions?.getDraftClass) {
+      setModel(null);
+      return undefined;
+    }
+    let cancelled = false;
+    setLoadingModel(true);
+    actions
+      .getDraftClass({ seasonId: selectedId })
+      .then((res) => {
+        if (cancelled) return;
+        setModel(res?.payload?.model ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setModel(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingModel(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId, actions]);
+
+  const summary = model?.classSummary;
+  const developing = summary?.isDevelopingClass;
+
+  return (
+    <div className="app-screen-stack" data-testid="draft-history-root">
+      <ScreenHeader
+        title="Draft History"
+        subtitle="Redraft boards, class grades, and how picks aged — built from your logged DRAFT transactions."
+        metadata={league?.year != null ? [{ label: 'League year', value: String(league.year) }] : []}
+      />
+
+      <SectionCard title="Season / class" subtitle="Pick a draft year (by season id) with logged picks.">
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
+          <button type="button" className="btn btn-secondary" onClick={() => onNavigate?.('History Hub')}>
+            Back to History Hub
+          </button>
+          {loadingList ? (
+            <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>Loading classes…</span>
+          ) : null}
+        </div>
+        {error ? <div style={{ marginTop: 8, color: 'var(--danger)', fontSize: 'var(--text-xs)' }}>{error}</div> : null}
+        {!loadingList && classes.length === 0 ? (
+          <div style={{ marginTop: 12, fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}>{EMPTY_COPY}</div>
+        ) : (
+          <div style={{ marginTop: 12, display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+            {classes.map((c) => (
+              <button
+                key={c.seasonId}
+                type="button"
+                className={`btn${selectedId === c.seasonId ? '' : ' btn-secondary'}`}
+                data-testid={`draft-history-season-${c.seasonId}`}
+                onClick={() => setSelectedId(c.seasonId)}
+              >
+                {c.year ?? c.seasonId} · {c.pickCount} picks
+              </button>
+            ))}
+          </div>
+        )}
+      </SectionCard>
+
+      {selectedId && (
+        <>
+          <SectionCard title="Class summary" subtitle={developing ? 'Developing class — redraft is provisional.' : 'Career-weighted snapshot for this draft.'}>
+            {loadingModel ? (
+              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>Loading class…</div>
+            ) : !model?.picks?.length ? (
+              <div style={{ fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}>{EMPTY_COPY}</div>
+            ) : (
+              <div style={{ display: 'grid', gap: 8, fontSize: 'var(--text-xs)' }}>
+                <div>
+                  <strong>Status:</strong> {summary?.classLeagueStatus ?? '—'} ·{' '}
+                  <strong>Picks:</strong> {summary?.totalPicks ?? 0} · <strong>Avg legacy:</strong>{' '}
+                  {summary?.avgLegacyScore != null ? summary.avgLegacyScore : '—'}
+                </div>
+                <div>
+                  <strong>Stars + HOF:</strong> {summary?.starCount ?? 0} · <strong>Contributors+:</strong>{' '}
+                  {summary?.starterCount ?? 0}
+                </div>
+              </div>
+            )}
+          </SectionCard>
+
+          {model?.redraftTop10?.length > 0 && (
+            <SectionCard title="Redraft top 10" subtitle="Sorted by career outcome score (legacy + production signals).">
+              <div style={{ display: 'grid', gap: 6 }}>
+                {model.redraftTop10.map((row, i) => (
+                  <div
+                    key={row.playerId ?? i}
+                    style={{
+                      display: 'grid',
+                      gridTemplateColumns: '28px 1fr auto',
+                      gap: 8,
+                      alignItems: 'center',
+                      fontSize: 'var(--text-xs)',
+                      borderBottom: '1px solid var(--hairline)',
+                      paddingBottom: 6,
+                    }}
+                  >
+                    <span style={{ fontWeight: 800 }}>{row.redraftRank}</span>
+                    <div>
+                      <button
+                        type="button"
+                        className="linkish"
+                        style={{ fontWeight: 700, background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: 'var(--accent)' }}
+                        onClick={() => row.playerId != null && onPlayerSelect?.(row.playerId)}
+                      >
+                        {row.playerName}
+                      </button>
+                      <span style={{ color: 'var(--text-muted)' }}> · {row.pos} · was #{row.originalOverall ?? '—'}</span>
+                      <div style={{ color: 'var(--text-muted)' }}>{row.outcomeLabel}{row.reason ? ` — ${row.reason}` : ''}</div>
+                    </div>
+                    <span style={{ color: row.redraftDelta >= 0 ? 'var(--success)' : 'var(--danger)' }}>Δ{row.redraftDelta}</span>
+                  </div>
+                ))}
+              </div>
+            </SectionCard>
+          )}
+
+          {model?.steals?.length > 0 && (
+            <SectionCard title="Biggest values vs slot" subtitle="Large positive redraft delta; requires a few seasons of separation.">
+              <ul style={{ margin: 0, paddingLeft: 18, fontSize: 'var(--text-xs)' }}>
+                {model.steals.map((s) => (
+                  <li key={s.playerId}>{s.playerName}: {s.note}</li>
+                ))}
+              </ul>
+            </SectionCard>
+          )}
+
+          {model?.busts?.length > 0 && (
+            <SectionCard title="Reached / missed" subtitle="Only when late-career data supports the label — never for developing classes.">
+              <ul style={{ margin: 0, paddingLeft: 18, fontSize: 'var(--text-xs)' }}>
+                {model.busts.map((s) => (
+                  <li key={s.playerId}>{s.playerName}: {s.note}</li>
+                ))}
+              </ul>
+            </SectionCard>
+          )}
+
+          {model?.teamGrades?.length > 0 && (
+            <SectionCard title="Team draft grades" subtitle="Incomplete when the class is still young or a team only has one pick.">
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                {model.teamGrades.map((g) => (
+                  <div key={g.teamId} className="card" style={{ padding: 'var(--space-3)', minWidth: 140, fontSize: 'var(--text-xs)' }}>
+                    <div style={{ fontWeight: 800 }}>
+                      {(league?.teams ?? []).find((t) => Number(t?.id) === Number(g.teamId))?.abbr ?? `Team ${g.teamId}`}
+                    </div>
+                    <div>Grade: {g.gradeLabel}</div>
+                    <div style={{ color: 'var(--text-muted)' }}>Avg value {g.avgValue} · Picks {g.pickCount}</div>
+                  </div>
+                ))}
+              </div>
+            </SectionCard>
+          )}
+
+          {model?.picks?.length > 0 && (
+            <SectionCard title="Full class" subtitle="Original order · redraft rank · outcome.">
+              <div style={{ overflowX: 'auto' }}>
+                <table className="table-compact" style={{ width: '100%', fontSize: 'var(--text-xs)' }}>
+                  <thead>
+                    <tr>
+                      <th>Ovr</th>
+                      <th>Player</th>
+                      <th>Pos</th>
+                      <th>By</th>
+                      <th>Redraft</th>
+                      <th>Outcome</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {model.picks.map((p) => (
+                      <tr key={p.playerId}>
+                        <td>{p.overall ?? '—'}</td>
+                        <td>
+                          <button
+                            type="button"
+                            style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: 'var(--accent)', fontWeight: 600 }}
+                            onClick={() => p.playerId != null && onPlayerSelect?.(p.playerId)}
+                          >
+                            {p.playerName}
+                          </button>
+                        </td>
+                        <td>{p.pos}</td>
+                        <td>{p.draftTeamAbbr ?? '—'}</td>
+                        <td>{p.redraftRank ?? '—'}</td>
+                        <td>{p.outcomeLabel}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </SectionCard>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/HistoryHub.jsx
+++ b/src/ui/components/HistoryHub.jsx
@@ -3,6 +3,7 @@ import { ScreenHeader, SectionCard } from './ScreenSystem.jsx';
 
 const DESTINATIONS = [
   { key: 'History', title: 'League Archive', body: 'Champions, season snapshots, and year-to-year memory.' },
+  { key: 'Draft History', title: 'Draft classes & redraft', body: 'Who panned out, steals vs reaches, and team draft grades by year.' },
   { key: 'Team History', title: 'Franchise Timeline', body: 'Highs/lows, droughts, and long-run identity by club.' },
   { key: 'Transactions:Activity', title: 'League activity', body: 'Dynasty-wide signings, trades, draft picks, and roster moves.' },
   { key: 'Hall of Fame', title: 'Hall of Fame', body: 'All-time greats, induction classes, and legacy scoreboards.' },

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -31,6 +31,7 @@ import TeamHistoryScreen from "./TeamHistoryScreen.jsx";
 import AwardsRecordsScreen from "./AwardsRecordsScreen.jsx";
 import HallOfFame from "./HallOfFame.jsx";
 import HistoryHub from "./HistoryHub.jsx";
+import DraftHistory from "./DraftHistory.jsx";
 import TradeWorkspace from "./TradeWorkspace.jsx";
 import PlayerProfile from "./PlayerProfile.jsx";
 import PlayerProfileModalBoundary from "./PlayerProfileModalBoundary.jsx";
@@ -199,6 +200,7 @@ const BASE_TABS = [
   "Draft Room",
   "Mock Draft",
   "History Hub",
+  "Draft History",
   "History",
   "Team History",
   "Hall of Fame",
@@ -217,7 +219,7 @@ const BASE_TABS = [
 const NAV_GROUPS = [
   { id: SHELL_SECTIONS.hq, title: "HQ", tabs: ["HQ"] },
   { id: SHELL_SECTIONS.team, title: "Team Management", tabs: ["Team", "Roster Hub", "Roster", "Depth Chart", "Weekly Prep", "Game Plan", "Training", "Injuries", "Staff", "Financials", "Contract Center", "💰 Cap"] },
-  { id: SHELL_SECTIONS.league, title: "League Office", tabs: ["League", "Weekly Results", "Schedule", "Standings", "Stats", "League Leaders", "Transactions", "Free Agency", "Draft", "History Hub", "History", "Awards & Records", "Season Recap"] },
+  { id: SHELL_SECTIONS.league, title: "League Office", tabs: ["League", "Weekly Results", "Schedule", "Standings", "Stats", "League Leaders", "Transactions", "Free Agency", "Draft", "History Hub", "Draft History", "History", "Awards & Records", "Season Recap"] },
   { id: SHELL_SECTIONS.news, title: "News", tabs: ["News", "Story"] },
 ];
 
@@ -555,18 +557,6 @@ export default function LeagueDashboard({
     }
   }, [activeTab]);
 
-  const handleHistoryHubNavigate = React.useCallback(
-    (dest) => {
-      const parsed = normalizeManagementDestination(dest);
-      if (parsed.tab === "Transactions" && parsed.tradeView) {
-        setTradeInitialView(parsed.tradeView);
-      }
-      const next = parsed.tab && TABS.includes(parsed.tab) ? parsed.tab : "HQ";
-      setActiveTab(next);
-    },
-    [TABS],
-  );
-
   const [leagueInitialSection, setLeagueInitialSection] = useState("Overview");
   const [teamInitialSection, setTeamInitialSection] = useState("Overview");
   const [newsSubtab, setNewsSubtab] = useState("All");
@@ -575,7 +565,7 @@ export default function LeagueDashboard({
   // Track the previous phase so we can detect transitions.
   const prevPhaseRef = React.useRef(null);
 
-  // Dynamic tabs: add Postseason when in playoffs
+  // Dynamic tabs: add Postseason when in playoffs (must be declared before hooks that depend on TABS)
   const TABS = useMemo(() => {
     const isPlayoffs = league?.phase === "playoffs" || league?.playoffSeeds;
     if (isPlayoffs) {
@@ -587,6 +577,18 @@ export default function LeagueDashboard({
     }
     return BASE_TABS;
   }, [league?.phase, league?.playoffSeeds]);
+
+  const handleHistoryHubNavigate = React.useCallback(
+    (dest) => {
+      const parsed = normalizeManagementDestination(dest);
+      if (parsed.tab === "Transactions" && parsed.tradeView) {
+        setTradeInitialView(parsed.tradeView);
+      }
+      const next = parsed.tab && TABS.includes(parsed.tab) ? parsed.tab : "HQ";
+      setActiveTab(next);
+    },
+    [TABS],
+  );
 
   // Auto-navigate based on phase transitions:
   //  draft       → go to Draft tab (so the user sees the board immediately)
@@ -1212,6 +1214,11 @@ export default function LeagueDashboard({
             <HistoryHub onNavigate={handleHistoryHubNavigate} actions={actions} onSelectSeason={setHistorySelectedSeasonId} league={league} />
           </TabErrorBoundary>
         )}
+        {activeTab === "Draft History" && (
+          <TabErrorBoundary label="Draft History">
+            <DraftHistory league={league} actions={actions} onPlayerSelect={handlePlayerSelect} onNavigate={setActiveTab} />
+          </TabErrorBoundary>
+        )}
         {activeTab === "History" && (
           <TabErrorBoundary label="History">
             <LeagueHistory
@@ -1232,6 +1239,7 @@ export default function LeagueDashboard({
               onBack={() => setActiveTab("History Hub")}
               teamId={selectedTeamId ?? league?.userTeamId}
               onOpenBoxScore={(gameId) => openGameDetail(gameId, "Team History")}
+              onOpenDraftHistory={() => setActiveTab("Draft History")}
             />
           </TabErrorBoundary>
         )}

--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -169,7 +169,7 @@ export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenB
         </TabsList>
 
         <TabsContent value="seasons">
-          <SeasonExplorer seasons={seasons} onPlayerSelect={onPlayerSelect} onOpenBoxScore={onOpenBoxScore} league={league} initialSelectedSeasonId={initialSelectedSeasonId} />
+          <SeasonExplorer seasons={seasons} actions={api} onPlayerSelect={onPlayerSelect} onOpenBoxScore={onOpenBoxScore} league={league} initialSelectedSeasonId={initialSelectedSeasonId} />
         </TabsContent>
 
         <TabsContent value="records">
@@ -260,7 +260,87 @@ function DraftHistoryExplorer({ seasons, league, onPlayerSelect }) {
   );
 }
 
-function SeasonExplorer({ seasons, onPlayerSelect, onOpenBoxScore, league, initialSelectedSeasonId = null }) {
+function SeasonDraftClassSnippet({ seasonId, year, actions, onPlayerSelect }) {
+  const [model, setModel] = useState(null);
+  const [err, setErr] = useState(false);
+
+  useEffect(() => {
+    if (!seasonId || !actions?.getDraftClass) {
+      setModel(null);
+      return undefined;
+    }
+    let cancelled = false;
+    setErr(false);
+    actions
+      .getDraftClass({ seasonId: String(seasonId) })
+      .then((res) => {
+        if (cancelled) return;
+        const m = res?.payload?.model;
+        if (!m?.picks?.length) {
+          setModel(null);
+          return;
+        }
+        setModel(m);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setErr(true);
+          setModel(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [seasonId, actions]);
+
+  if (err || !model?.picks?.length) return null;
+
+  const sortedByOvr = [...model.picks].sort((a, b) => Number(a?.overall ?? 999) - Number(b?.overall ?? 999));
+  const topPick = sortedByOvr[0];
+  const best = [...model.picks].sort((a, b) => Number(b?.legacyScore ?? 0) - Number(a?.legacyScore ?? 0))[0];
+  const status = model?.classSummary?.classLeagueStatus ?? '—';
+
+  return (
+    <section className="rounded-xl border border-[color:var(--hairline)] bg-[color:var(--surface-strong)]/30 p-4 space-y-2" data-testid="league-season-draft-snippet">
+      <div className="text-xs font-black uppercase tracking-wide text-[color:var(--text-subtle)]">Draft class memory</div>
+      <div className="text-sm text-[color:var(--text-muted)]">
+        Class status: <span className="font-semibold text-[color:var(--text)]">{status}</span>
+        {year != null ? <span> · {year} class</span> : null}
+      </div>
+      {topPick ? (
+        <div className="text-sm">
+          <span className="text-[color:var(--text-muted)]">Top pick (by slot): </span>
+          {topPick.playerId != null ? (
+            <button type="button" className="text-[color:var(--accent)] font-semibold" onClick={() => onPlayerSelect?.(topPick.playerId)}>
+              {topPick.playerName ?? '—'}
+            </button>
+          ) : (
+            <span className="font-semibold">{topPick.playerName ?? '—'}</span>
+          )}
+          <span className="text-[color:var(--text-muted)]"> #{topPick.overall ?? '—'}</span>
+        </div>
+      ) : null}
+      {best ? (
+        <div className="text-sm">
+          <span className="text-[color:var(--text-muted)]">Best résumé so far: </span>
+          {best.playerId != null ? (
+            <button type="button" className="text-[color:var(--accent)] font-semibold" onClick={() => onPlayerSelect?.(best.playerId)}>
+              {best.playerName ?? '—'}
+            </button>
+          ) : (
+            <span className="font-semibold">{best.playerName ?? '—'}</span>
+          )}
+          <span className="text-[color:var(--text-muted)]"> · {best.outcomeLabel ?? '—'}</span>
+        </div>
+      ) : null}
+      {model.classSummary?.isDevelopingClass ? (
+        <div className="text-xs text-[color:var(--text-muted)]">Developing class — redraft labels stay soft until more seasons pass.</div>
+      ) : null}
+    </section>
+  );
+}
+
+function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, league, initialSelectedSeasonId = null }) {
   const [selectedSeasonId, setSelectedSeasonId] = useState(initialSelectedSeasonId ?? seasons?.[0]?.id ?? null);
 
   useEffect(() => {
@@ -349,6 +429,8 @@ function SeasonExplorer({ seasons, onPlayerSelect, onOpenBoxScore, league, initi
             <button className="btn" onClick={() => selectedSeasonIndex < seasons.length - 1 && setSelectedSeasonId(seasons[selectedSeasonIndex + 1].id)} disabled={selectedSeasonIndex >= seasons.length - 1}>Next season</button>
           </div>
           <div className="rounded-md border border-[color:var(--hairline)] px-3 py-2 text-sm text-[color:var(--text-muted)]">{seasonStoryline}</div>
+
+          <SeasonDraftClassSnippet seasonId={selected?.id} year={selected?.year} actions={actions} onPlayerSelect={onPlayerSelect} />
 
           <section className="rounded-xl border border-[color:var(--hairline)] bg-[color:var(--surface-strong)]/40 p-4 space-y-3" data-testid={`league-history-season-story-${selected?.id ?? 'none'}`}>
             <div className="text-xs font-black uppercase tracking-wide text-[color:var(--text-subtle)]">Season story</div>

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -416,6 +416,7 @@ export default function PlayerProfile({
   const [extending, setExtending] = useState(false);
   const [showProjections, setShowProjections] = useState(false);
   const [activeProfileTab, setActiveProfileTab] = useState("Overview");
+  const [draftContext, setDraftContext] = useState(null);
   const requestKey = useMemo(() => buildRouteRequestKey("player", playerId), [playerId]);
   const cacheScopeKey = useMemo(() => buildLeagueCacheScopeKey(league), [league]);
   const fetchProfileData = React.useCallback(async () => {
@@ -456,6 +457,28 @@ export default function PlayerProfile({
       })
       .catch(() => {
         if (!cancelled) setArchivedSeasons([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [actions, playerId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!actions?.getPlayerDraftContext || playerId == null) {
+      setDraftContext(null);
+      return () => {
+        cancelled = true;
+      };
+    }
+    actions
+      .getPlayerDraftContext(playerId)
+      .then((res) => {
+        if (cancelled) return;
+        setDraftContext(res?.payload?.context ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setDraftContext(null);
       });
     return () => {
       cancelled = true;
@@ -980,6 +1003,44 @@ export default function PlayerProfile({
                   {playerView.draftYear || playerView.draftRound || playerView.draftPick ? <span className="status-chip muted">Draft: {playerView.draftYear ?? "—"} R{playerView.draftRound ?? "—"} P{playerView.draftPick ?? "—"}</span> : null}
                   {quickTags.map((tag) => <span key={tag} className="status-chip success">{tag}</span>)}
                 </div>
+
+                {draftContext?.known ? (
+                  <div
+                    style={{
+                      marginTop: "var(--space-2)",
+                      padding: "var(--space-3)",
+                      borderRadius: "var(--radius-md)",
+                      border: "1px solid var(--hairline)",
+                      background: "var(--surface-strong)",
+                      fontSize: "var(--text-xs)",
+                    }}
+                    data-testid="player-profile-draft-memory"
+                  >
+                    <div style={sectionLabelStyle}>Draft memory</div>
+                    <div style={{ color: "var(--text-muted)", lineHeight: 1.5 }}>
+                      {draftContext.draftedByAbbr ? (
+                        <span>
+                          Drafted by <strong style={{ color: "var(--text)" }}>{draftContext.draftedByAbbr}</strong>
+                          {draftContext.draftYear != null ? ` · ${draftContext.draftYear}` : ""}
+                          {draftContext.round != null ? ` · R${draftContext.round}` : ""}
+                          {draftContext.pickInRound != null ? ` pick ${draftContext.pickInRound}` : ""}
+                          {draftContext.overall != null ? ` (#${draftContext.overall})` : ""}
+                        </span>
+                      ) : (
+                        <span>Draft origin partially logged.</span>
+                      )}
+                    </div>
+                    {draftContext.redraftRank != null ? (
+                      <div style={{ marginTop: 6, color: "var(--text)" }}>
+                        Redraft rank (class): <strong>#{draftContext.redraftRank}</strong>
+                        {draftContext.outcomeLabel ? <span style={{ color: "var(--text-muted)" }}> · {draftContext.outcomeLabel}</span> : null}
+                      </div>
+                    ) : null}
+                    {draftContext.stealBustNote ? (
+                      <div style={{ marginTop: 6, color: "var(--text-subtle)" }}>{draftContext.stealBustNote}</div>
+                    ) : null}
+                  </div>
+                ) : null}
 
                 {playerView.developmentContext && (
                   <div style={{ marginTop: 6, fontSize: 'var(--text-xs)', color: 'var(--text-subtle)' }}>

--- a/src/ui/components/TeamHistoryScreen.jsx
+++ b/src/ui/components/TeamHistoryScreen.jsx
@@ -29,7 +29,7 @@ function RecordRow({ label, value, detail }) {
   );
 }
 
-export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSelect, onBack, onOpenBoxScore }) {
+export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSelect, onBack, onOpenBoxScore, onOpenDraftHistory }) {
   const [seasons, setSeasons] = useState([]);
   const [hofPlayers, setHofPlayers] = useState([]);
   const [hofClasses, setHofClasses] = useState([]);
@@ -37,6 +37,7 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
   const [queryYear, setQueryYear] = useState('');
   const [scope, setScope] = useState('all');
   const [majorMoves, setMajorMoves] = useState([]);
+  const [draftFlash, setDraftFlash] = useState([]);
 
   const activeTeam = useMemo(
     () => (league?.teams ?? []).find((t) => Number(t.id) === Number(teamId ?? league?.userTeamId)),
@@ -86,6 +87,49 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
         if (!cancelled) setMajorMoves([]);
       });
     return () => { cancelled = true; };
+  }, [actions, activeTeam?.id]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tid = Number(activeTeam?.id);
+    if (!Number.isFinite(tid) || !actions?.getDraftClasses || !actions?.getDraftClass) {
+      setDraftFlash([]);
+      return () => {
+        cancelled = true;
+      };
+    }
+    (async () => {
+      try {
+        const res = await actions.getDraftClasses();
+        const list = res?.payload?.classes ?? [];
+        const mine = list.filter((c) => Array.isArray(c.teamIds) && c.teamIds.includes(tid)).slice(0, 4);
+        const rows = [];
+        for (const entry of mine) {
+          if (cancelled) return;
+          const mRes = await actions.getDraftClass({ seasonId: entry.seasonId }).catch(() => null);
+          const m = mRes?.payload?.model;
+          if (!m?.picks?.length) continue;
+          const g = (m.teamGrades || []).find((x) => Number(x.teamId) === tid);
+          const teamPicks = m.picks.filter((p) => Number(p.draftTeamId) === tid);
+          const best = [...teamPicks].sort((a, b) => Number(b.legacyScore ?? 0) - Number(a.legacyScore ?? 0))[0];
+          const steal = teamPicks.filter((p) => Number(p.redraftDelta) >= 40).sort((a, b) => Number(b.redraftDelta) - Number(a.redraftDelta))[0];
+          rows.push({
+            year: entry.year ?? m.year,
+            seasonId: entry.seasonId,
+            grade: g?.gradeLabel ?? '—',
+            bestName: best?.playerName,
+            stealName: steal?.playerName,
+            pickCount: teamPicks.length,
+          });
+        }
+        if (!cancelled) setDraftFlash(rows);
+      } catch {
+        if (!cancelled) setDraftFlash([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [actions, activeTeam?.id]);
 
   const model = useMemo(
@@ -227,6 +271,32 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
             ))}
           </ul>
         ) : null}
+      </SectionCard>
+
+      <SectionCard title="Draft classes" subtitle="Recent classes where this franchise held picks (from DRAFT transaction log).">
+        <div data-testid="team-history-draft-classes">
+        {draftFlash.length === 0 ? (
+          <div style={{ fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}>
+            No logged draft classes yet for this team, or data is still accumulating. Open Draft History for the full redraft board.
+          </div>
+        ) : (
+          <ul style={{ margin: 0, paddingLeft: 16, fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+            {draftFlash.map((d) => (
+              <li key={d.seasonId} style={{ marginBottom: 8 }}>
+                <strong style={{ color: 'var(--text)' }}>{d.year ?? d.seasonId}</strong>
+                {` · Grade ${d.grade} · ${d.pickCount} pick${d.pickCount === 1 ? '' : 's'}`}
+                {d.bestName ? <span>{` · Best: ${d.bestName}`}</span> : null}
+                {d.stealName ? <span style={{ color: 'var(--success)' }}>{` · Value: ${d.stealName}`}</span> : null}
+              </li>
+            ))}
+          </ul>
+        )}
+        {typeof onOpenDraftHistory === 'function' ? (
+          <button type="button" className="btn btn-secondary" style={{ marginTop: 10 }} onClick={() => onOpenDraftHistory()}>
+            Open Draft History
+          </button>
+        ) : null}
+        </div>
       </SectionCard>
 
       <SectionCard title="Major moves" subtitle="Recent signings, trades, draft picks, and releases involving this franchise (from transaction log).">

--- a/src/ui/components/__tests__/DraftHistory.test.jsx
+++ b/src/ui/components/__tests__/DraftHistory.test.jsx
@@ -1,0 +1,92 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import DraftHistory from '../DraftHistory.jsx';
+
+describe('DraftHistory', () => {
+  afterEach(() => cleanup());
+
+  it('renders empty state when no draft classes', async () => {
+    render(
+      <DraftHistory
+        league={{ year: 2030, teams: [] }}
+        actions={{
+          getDraftClasses: vi.fn().mockResolvedValue({ payload: { classes: [] } }),
+          getDraftClass: vi.fn(),
+        }}
+        onPlayerSelect={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/Draft history will appear after completed drafts/i)).toBeTruthy();
+    });
+  });
+
+  it('renders redraft top 10 when model has data', async () => {
+    const model = {
+      year: 2029,
+      seasonId: 's1',
+      picks: [
+        {
+          playerId: 1,
+          playerName: 'A',
+          pos: 'QB',
+          draftTeamAbbr: 'XX',
+          overall: 5,
+          redraftRank: 1,
+          redraftDelta: 4,
+          outcomeLabel: 'Star',
+          legacyScore: 70,
+          reasons: ['Strong'],
+        },
+      ],
+      redraftTop10: [
+        {
+          playerId: 1,
+          playerName: 'A',
+          pos: 'QB',
+          originalOverall: 5,
+          redraftRank: 1,
+          redraftDelta: 4,
+          outcomeLabel: 'Star',
+          reason: 'Strong',
+        },
+      ],
+      steals: [],
+      busts: [],
+      teamGrades: [],
+      classSummary: {
+        totalPicks: 1,
+        starCount: 1,
+        starterCount: 1,
+        hofCount: 0,
+        mvpCount: 0,
+        allProCount: 0,
+        avgLegacyScore: 70,
+        classLeagueStatus: 'mature',
+        isDevelopingClass: false,
+        seasonsSinceDraft: 4,
+      },
+      meta: { isDevelopingClass: false, suppressStealsBusts: false, seasonsSinceDraft: 4 },
+    };
+    render(
+      <DraftHistory
+        league={{ year: 2033, teams: [{ id: 1, abbr: 'XX' }] }}
+        actions={{
+          getDraftClasses: vi.fn().mockResolvedValue({
+            payload: { classes: [{ seasonId: 's1', year: 2029, pickCount: 1, teamIds: [1] }] },
+          }),
+          getDraftClass: vi.fn().mockResolvedValue({ payload: { model } }),
+        }}
+        onPlayerSelect={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/Redraft top 10/i)).toBeTruthy();
+    });
+    expect(screen.getAllByRole('button', { name: 'A' }).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -30,6 +30,8 @@ const league = {
 const actions = {
   getPlayerCareer: vi.fn(async () => null),
   getAllSeasons: vi.fn(async () => ({ payload: { seasons: [] } })),
+  getPlayerDraftContext: vi.fn(async () => ({ payload: { context: { known: false } } })),
+  getRecords: vi.fn(async () => ({ payload: { recordBook: null } })),
 };
 
 describe('PlayerProfile', () => {

--- a/src/ui/components/__tests__/TeamHistoryScreen.test.jsx
+++ b/src/ui/components/__tests__/TeamHistoryScreen.test.jsx
@@ -15,6 +15,9 @@ describe('TeamHistoryScreen', () => {
         actions={{
           getAllSeasons: vi.fn().mockResolvedValue({ payload: { seasons: [] } }),
           getHallOfFame: vi.fn().mockResolvedValue({ payload: { players: [], classes: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+          getDraftClasses: vi.fn().mockResolvedValue({ payload: { classes: [] } }),
+          getDraftClass: vi.fn().mockResolvedValue({ payload: { model: null } }),
         }}
         onBack={vi.fn()}
         onPlayerSelect={vi.fn()}
@@ -44,6 +47,9 @@ describe('TeamHistoryScreen', () => {
             },
           }),
           getHallOfFame: vi.fn().mockResolvedValue({ payload: { players: [], classes: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+          getDraftClasses: vi.fn().mockResolvedValue({ payload: { classes: [] } }),
+          getDraftClass: vi.fn().mockResolvedValue({ payload: { model: null } }),
         }}
         onBack={vi.fn()}
         onPlayerSelect={vi.fn()}
@@ -82,6 +88,9 @@ describe('TeamHistoryScreen', () => {
             },
           }),
           getHallOfFame: vi.fn().mockResolvedValue({ payload: { players: [], classes: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+          getDraftClasses: vi.fn().mockResolvedValue({ payload: { classes: [] } }),
+          getDraftClass: vi.fn().mockResolvedValue({ payload: { model: null } }),
         }}
         onBack={vi.fn()}
         onPlayerSelect={vi.fn()}

--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -554,6 +554,13 @@ export function useWorker() {
     getTransactions: (payload = {}) =>
       request(toWorker.GET_TRANSACTIONS, payload, { silent: true }),
 
+    getDraftClasses: () => request(toWorker.GET_DRAFT_CLASSES, {}, { silent: true }),
+
+    getDraftClass: (payload) => request(toWorker.GET_DRAFT_CLASS, payload, { silent: true }),
+
+    getPlayerDraftContext: (playerId) =>
+      request(toWorker.GET_PLAYER_DRAFT_CONTEXT, { playerId }, { silent: true }),
+
     /** Force an immediate DB flush. */
     save: ()                     => send(toWorker.SAVE_NOW),
 

--- a/src/ui/utils/shellNavigation.js
+++ b/src/ui/utils/shellNavigation.js
@@ -58,6 +58,7 @@ const TAB_TO_SECTION = Object.freeze({
   'Mock Draft': SHELL_SECTIONS.league,
 
   'History Hub': SHELL_SECTIONS.league,
+  'Draft History': SHELL_SECTIONS.league,
   History: SHELL_SECTIONS.league,
   'Team History': SHELL_SECTIONS.league,
   'Hall of Fame': SHELL_SECTIONS.league,

--- a/src/ui/utils/shellNavigation.test.js
+++ b/src/ui/utils/shellNavigation.test.js
@@ -13,6 +13,7 @@ describe('shell navigation mapping', () => {
     expect(getShellSectionForDashboardTab('Standings')).toBe('league');
     expect(getShellSectionForDashboardTab('Transactions')).toBe('league');
     expect(getShellSectionForDashboardTab('Season Recap')).toBe('league');
+    expect(getShellSectionForDashboardTab('Draft History')).toBe('league');
   });
 
   it('accepts legacy mobile ids as section inputs', () => {

--- a/src/worker/protocol.js
+++ b/src/worker/protocol.js
@@ -151,6 +151,11 @@ export const toWorker = Object.freeze({
   GET_RECORDS:        'GET_RECORDS',          // {} — fetch all-time and single-season records
   GET_HALL_OF_FAME:   'GET_HALL_OF_FAME',     // {} — fetch all HOF inductees
   GET_TRANSACTIONS:   'GET_TRANSACTIONS',     // { seasonId?, teamId?, playerId?, type?, year?, limit?, mode?: 'auto'|'recent', search? } — normalized move log; empty array on failure
+
+  /** Draft class memory (compact, safe on old saves) */
+  GET_DRAFT_CLASSES:    'GET_DRAFT_CLASSES',    // {} — seasons with logged DRAFT picks
+  GET_DRAFT_CLASS:      'GET_DRAFT_CLASS',      // { seasonId } — full redraft model for one class
+  GET_PLAYER_DRAFT_CONTEXT: 'GET_PLAYER_DRAFT_CONTEXT', // { playerId } — profile strip + optional class hook
 });
 
 // ─────────────────────────────────────────────
@@ -230,6 +235,9 @@ export const toUI = Object.freeze({
   RECORDS:            'RECORDS',              // { records }
   HALL_OF_FAME:       'HALL_OF_FAME',         // { players[] }
   TRANSACTIONS:       'TRANSACTIONS',         // { transactions[] }
+  DRAFT_CLASSES:        'DRAFT_CLASSES',        // { classes: [{ seasonId, year, pickCount, teamIds }] }
+  DRAFT_CLASS:          'DRAFT_CLASS',          // { model } — buildDraftClassModel payload
+  PLAYER_DRAFT_CONTEXT: 'PLAYER_DRAFT_CONTEXT', // { context, classModel? }
 
   /** Season lifecycle */
   SEASON_START:       'SEASON_START',         // { year, season, phase } — forces UI to Standings tab

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -119,6 +119,11 @@ import {
   normalizeRawTransaction,
   stripInternalTimelineFields,
 } from '../core/transactionTimeline.js';
+import {
+  buildDraftClassModel,
+  indexDraftClassesFromTransactions,
+  buildPlayerDraftContext,
+} from '../core/draftClassHistory.js';
 import { rebuildRecordBookV1, mirrorRecordBookForLegacyUi, RECORD_BOOK_SCHEMA_VERSION } from '../core/recordBookV1.js';
 import { inferChampionshipOutcome, isCompletedGame, isPostseasonGame } from '../core/championshipInference.js';
 import { repairDepthChart, validateDepthChart, optimizeDepthChartForPlan } from "../core/roster/depthChartManager.js";
@@ -3978,6 +3983,137 @@ async function handleGetTransactions(payload = {}, id) {
   } catch (err) {
     console.error("[Worker] GET_TRANSACTIONS failed:", err);
     post(toUI.TRANSACTIONS, { transactions: [] }, id);
+  }
+}
+
+async function loadMergedSeasonSummaries() {
+  const seasons = await Seasons.loadRecent(200);
+  const meta = ensureLeagueMemoryMeta(ensureDynastyMeta(cache.getMeta()));
+  const merged = [...seasons];
+  for (const row of meta.leagueHistory || []) {
+    if (!merged.some((s) => s?.id === row?.id)) merged.push(row);
+  }
+  merged.sort((a, b) => (b?.year ?? 0) - (a?.year ?? 0));
+  return { merged, memoryMeta: meta };
+}
+
+async function handleGetDraftClasses(payload, id) {
+  try {
+    const { merged } = await loadMergedSeasonSummaries();
+    const recent = await Transactions.loadRecent(4000).catch(() => []);
+    const draftOnly = recent.filter((tx) => String(tx?.type).toUpperCase() === 'DRAFT');
+    const classes = indexDraftClassesFromTransactions(draftOnly, merged);
+    post(toUI.DRAFT_CLASSES, { classes }, id);
+  } catch (err) {
+    console.error('[Worker] GET_DRAFT_CLASSES failed:', err);
+    post(toUI.DRAFT_CLASSES, { classes: [] }, id);
+  }
+}
+
+async function handleGetDraftClass({ seasonId }, id) {
+  try {
+    if (!seasonId) {
+      post(toUI.DRAFT_CLASS, { model: null }, id);
+      return;
+    }
+    const { merged, memoryMeta } = await loadMergedSeasonSummaries();
+    const yearRow = merged.find((s) => String(s?.id) === String(seasonId));
+    const draftYear = Number(yearRow?.year) || Number(ensureDynastyMeta(cache.getMeta())?.year) || 0;
+    const rows = await Transactions.bySeason(seasonId).catch(() => []);
+    const draftRows = rows.filter((tx) => String(tx?.type).toUpperCase() === 'DRAFT');
+    const playersById = new Map();
+    for (const tx of draftRows) {
+      const pid = Number(tx?.details?.playerId ?? tx?.playerId);
+      if (Number.isFinite(pid) && pid > 0) {
+        const pl = cache.getPlayer(pid);
+        if (pl) playersById.set(pid, pl);
+      }
+    }
+    for (const pl of cache.getAllPlayers()) {
+      const pid = Number(pl?.id);
+      if (!Number.isFinite(pid) || pid <= 0) continue;
+      if (Number(pl?.draftYear) === draftYear && !playersById.has(pid)) {
+        playersById.set(pid, pl);
+      }
+    }
+    const teams = cache.getAllTeams();
+    const currentLeagueYear = Number(ensureDynastyMeta(cache.getMeta())?.year) || draftYear;
+    const recordBook = memoryMeta?.recordBook ?? null;
+    const archivedSeasons = memoryMeta?.leagueHistory ?? [];
+    const model = buildDraftClassModel({
+      year: draftYear,
+      seasonId: String(seasonId),
+      draftTransactions: draftRows,
+      playersById,
+      currentLeagueYear,
+      recordBook,
+      archivedSeasons,
+      teams,
+    });
+    post(toUI.DRAFT_CLASS, { model }, id);
+  } catch (err) {
+    console.error('[Worker] GET_DRAFT_CLASS failed:', err);
+    post(toUI.DRAFT_CLASS, { model: null }, id);
+  }
+}
+
+async function handleGetPlayerDraftContext({ playerId }, id) {
+  try {
+    const pid = Number(playerId);
+    if (!Number.isFinite(pid) || pid <= 0) {
+      post(toUI.PLAYER_DRAFT_CONTEXT, { context: { known: false }, classModel: null }, id);
+      return;
+    }
+    const player = cache.getPlayer(pid);
+    if (!player) {
+      post(toUI.PLAYER_DRAFT_CONTEXT, { context: { known: false }, classModel: null }, id);
+      return;
+    }
+    const recent = await Transactions.loadRecent(3000).catch(() => []);
+    const draftTxs = recent.filter((tx) => {
+      if (String(tx?.type).toUpperCase() !== 'DRAFT') return false;
+      const d = tx?.details || {};
+      const idVal = Number(d.playerId ?? tx?.playerId);
+      return idVal === pid;
+    });
+    let classModel = null;
+    const firstSeason = draftTxs[0]?.seasonId;
+    if (firstSeason) {
+      const { merged, memoryMeta } = await loadMergedSeasonSummaries();
+      const yearRow = merged.find((s) => String(s?.id) === String(firstSeason));
+      const draftYear = Number(yearRow?.year) || Number(ensureDynastyMeta(cache.getMeta())?.year) || 0;
+      const rows = await Transactions.bySeason(firstSeason).catch(() => []);
+      const draftRows = rows.filter((tx) => String(tx?.type).toUpperCase() === 'DRAFT');
+      const playersById = new Map();
+      for (const tx of draftRows) {
+        const p = Number(tx?.details?.playerId ?? tx?.playerId);
+        if (Number.isFinite(p) && p > 0) {
+          const pl = cache.getPlayer(p);
+          if (pl) playersById.set(p, pl);
+        }
+      }
+      for (const pl of cache.getAllPlayers()) {
+        const p = Number(pl?.id);
+        if (Number.isFinite(p) && p > 0 && Number(pl?.draftYear) === draftYear && !playersById.has(p)) {
+          playersById.set(p, pl);
+        }
+      }
+      classModel = buildDraftClassModel({
+        year: draftYear,
+        seasonId: String(firstSeason),
+        draftTransactions: draftRows,
+        playersById,
+        currentLeagueYear: Number(ensureDynastyMeta(cache.getMeta())?.year) || draftYear,
+        recordBook: memoryMeta?.recordBook ?? null,
+        archivedSeasons: memoryMeta?.leagueHistory ?? [],
+        teams: cache.getAllTeams(),
+      });
+    }
+    const context = buildPlayerDraftContext(player, classModel, draftTxs);
+    post(toUI.PLAYER_DRAFT_CONTEXT, { context, classModel }, id);
+  } catch (err) {
+    console.error('[Worker] GET_PLAYER_DRAFT_CONTEXT failed:', err);
+    post(toUI.PLAYER_DRAFT_CONTEXT, { context: { known: false }, classModel: null }, id);
   }
 }
 
@@ -9825,6 +9961,9 @@ async function handleMessage(event) {
       case toWorker.GET_RECORDS:        return await handleGetRecords(payload, id);
       case toWorker.GET_HALL_OF_FAME:   return await handleGetHallOfFame(payload, id);
       case toWorker.GET_TRANSACTIONS:   return await handleGetTransactions(payload, id);
+      case toWorker.GET_DRAFT_CLASSES:  return await handleGetDraftClasses(payload, id);
+      case toWorker.GET_DRAFT_CLASS:    return await handleGetDraftClass(payload, id);
+      case toWorker.GET_PLAYER_DRAFT_CONTEXT: return await handleGetPlayerDraftContext(payload, id);
 
       default:
         console.warn(`[Worker] Unknown message type: ${type}`);

--- a/tests/unit/draftClassHistory.test.js
+++ b/tests/unit/draftClassHistory.test.js
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeDraftPickRow,
+  picksFromDraftTransactions,
+  mergePlayerFieldFallbackPicks,
+  buildDraftClassModel,
+  assignOutcomeTier,
+  findPlayerDraftOrigin,
+  indexDraftClassesFromTransactions,
+} from '../../src/core/draftClassHistory.js';
+import { buildLegacyScoreReport } from '../../src/core/legacyScore.js';
+
+const teams = [{ id: 1, abbr: 'AAA' }, { id: 2, abbr: 'BBB' }];
+const teamsById = new Map(teams.map((t) => [t.id, t]));
+
+describe('draftClassHistory', () => {
+  it('normalizes DRAFT transaction rows', () => {
+    const raw = {
+      type: 'DRAFT',
+      seasonId: 's2030',
+      teamId: 1,
+      playerId: 50,
+      details: { playerId: 50, overall: 12, round: 1, pickInRound: 12 },
+    };
+    const row = normalizeDraftPickRow(raw, { teamsById, players: [{ id: 50, name: 'Joe', pos: 'WR' }] });
+    expect(row.playerId).toBe(50);
+    expect(row.overall).toBe(12);
+    expect(row.draftTeamAbbr).toBe('AAA');
+  });
+
+  it('builds a draft class from transaction rows', () => {
+    const txs = [
+      { type: 'DRAFT', seasonId: 's1', teamId: 1, details: { playerId: 1, overall: 1, round: 1, pickInRound: 1 } },
+      { type: 'DRAFT', seasonId: 's1', teamId: 2, details: { playerId: 2, overall: 2, round: 1, pickInRound: 2 } },
+    ];
+    const p1 = {
+      id: 1,
+      name: 'Late Gem',
+      pos: 'RB',
+      teamId: 1,
+      status: 'retired',
+      careerStats: Array.from({ length: 8 }, (_, i) => ({ season: 2030 + i, gamesPlayed: 16, rushYds: 900, ovr: 88 })),
+      accolades: [{ type: 'MVP', year: 2035 }],
+    };
+    const p2 = {
+      id: 2,
+      name: 'Early Reach',
+      pos: 'QB',
+      teamId: 2,
+      status: 'retired',
+      careerStats: Array.from({ length: 3 }, (_, i) => ({ season: 2030 + i, gamesPlayed: 10, passYds: 2200, ovr: 72 })),
+      accolades: [],
+    };
+    const playersById = new Map([
+      [1, p1],
+      [2, p2],
+    ]);
+    const model = buildDraftClassModel({
+      year: 2030,
+      seasonId: 's1',
+      draftTransactions: txs,
+      playersById,
+      currentLeagueYear: 2045,
+      recordBook: null,
+      archivedSeasons: [],
+      teams,
+    });
+    expect(model.picks.length).toBe(2);
+    const gem = model.picks.find((p) => p.playerId === 1);
+    const reach = model.picks.find((p) => p.playerId === 2);
+    expect(gem.redraftRank).toBeLessThan(reach.redraftRank);
+    expect(Number(gem.legacyScore ?? 0)).toBeGreaterThan(Number(reach.legacyScore ?? 0));
+    expect(model.redraftTop10.length).toBeGreaterThan(0);
+    expect(model.classSummary.totalPicks).toBe(2);
+  });
+
+  it('player fields fallback when transactions missing', () => {
+    const players = [
+      {
+        id: 9,
+        name: 'Solo',
+        pos: 'TE',
+        draftYear: 2028,
+        draftTeamId: 1,
+        draftTeamAbbr: 'AAA',
+        draftRound: 3,
+        draftPick: 5,
+        teamId: 1,
+        status: 'active',
+        careerStats: [{ season: 2028, gamesPlayed: 14, recYds: 200 }],
+        accolades: [],
+      },
+    ];
+    const fb = mergePlayerFieldFallbackPicks(2028, players, new Set(), { teamsById });
+    expect(fb.length).toBe(1);
+    expect(fb[0].playerId).toBe(9);
+  });
+
+  it('recent class avoids bust-heavy labeling', () => {
+    const rookie = {
+      id: 3,
+      name: 'Rook',
+      pos: 'WR',
+      status: 'active',
+      careerStats: [{ season: 2044, gamesPlayed: 8, recYds: 120 }],
+      accolades: [],
+    };
+    const report = buildLegacyScoreReport(rookie, { recordBook: null, archivedSeasons: [], teams, year: 2044 });
+    const out = assignOutcomeTier(rookie, report, 0, { isDevelopingClass: true });
+    expect(out.tier).not.toBe('BUST');
+  });
+
+  it('findPlayerDraftOrigin prefers transaction', () => {
+    const txs = [{ type: 'DRAFT', teamId: 2, details: { playerId: 5, overall: 99, round: 3, pickInRound: 40 } }];
+    const player = { id: 5, name: 'X', draftYear: 2020, draftTeamId: 1, draftRound: 1, draftPick: 1 };
+    const o = findPlayerDraftOrigin(player, txs);
+    expect(o.source).toBe('transaction');
+    expect(o.draftTeamId).toBe(2);
+  });
+
+  it('indexes draft classes by season', () => {
+    const txs = [
+      { type: 'DRAFT', seasonId: 'a', teamId: 1, details: { playerId: 1 } },
+      { type: 'DRAFT', seasonId: 'a', teamId: 2, details: { playerId: 2 } },
+      { type: 'DRAFT', seasonId: 'b', teamId: 1, details: { playerId: 3 } },
+    ];
+    const idx = indexDraftClassesFromTransactions(txs, [{ id: 'a', year: 2031 }, { id: 'b', year: 2032 }]);
+    expect(idx.length).toBe(2);
+    expect(idx[0].year).toBe(2032);
+    expect(idx[0].teamIds).toContain(1);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change ships **Draft Class Memory / Redraft V1**: pure modeling from logged `DRAFT` transactions plus career signals, compact worker APIs, and UI surfaces (Draft History tab, profile strip, team/league snippets). It also fixes the **PR #1379 `TABS` temporal dead zone** in `LeagueDashboard` by declaring `TABS` before `handleHistoryHubNavigate`.

## Root cause (LeagueDashboard)

`useCallback(..., [TABS])` ran before `const TABS = useMemo(...)`, triggering `ReferenceError: Cannot access 'TABS' before initialization` on any render that reached those hooks (including `league === null` in `freshSaveScreens`).

**Fix:** move the `TABS` `useMemo` block immediately above `handleHistoryHubNavigate`.

## Draft class model (core)

New [`src/core/draftClassHistory.js`](src/core/draftClassHistory.js):

- **`normalizeDraftPickRow`** — maps IndexedDB `DRAFT` rows + `details` (`overall`, `round`, `pickInRound`) to canonical pick rows.
- **`buildDraftClassModel`** — merges transactions with `cache` players, runs `buildLegacyScoreReport`, assigns **outcome tiers** (HOF → … → Bust / too early), computes **redraft** order by `computeOutcomeScore` (legacy + games + key accolades), **`redraftDelta = originalOverall - redraftRank`** (positive = value vs slot), **steals/busts** only when the class is not *developing* and enough seasons have elapsed, **`classSummary.classLeagueStatus`** (`developing` | `mature` | `historic` | `weak`).
- **`gradeTeamDraftClass`** — per-team grade or **`Incomplete`** for young/single-pick classes.
- **`findPlayerDraftOrigin` / `buildPlayerDraftContext`** — transaction-first, player `draft*` fields fallback.
- **`indexDraftClassesFromTransactions`** — lists `{ seasonId, year, pickCount, teamIds }` from capped recent `DRAFT` rows.

No full player objects are returned in API payloads—only compact scalars and short strings.

## Worker / protocol

- `GET_DRAFT_CLASSES` → `DRAFT_CLASSES`
- `GET_DRAFT_CLASS` `{ seasonId }` → `DRAFT_CLASS` `{ model }`
- `GET_PLAYER_DRAFT_CONTEXT` `{ playerId }` → `PLAYER_DRAFT_CONTEXT` `{ context, classModel? }`

Handlers load `Transactions.loadRecent` / `bySeason`, merge season summaries like `GET_ALL_SEASONS`, and reuse `recordBook` + `leagueHistory` for legacy context.

## UI

- **Draft History** dashboard tab + **History Hub** card; [`DraftHistory.jsx`](src/ui/components/DraftHistory.jsx) with empty copy: *Draft history will appear after completed drafts are logged in your dynasty.*
- **Player Profile** — compact **Draft memory** block when `getPlayerDraftContext` returns `known: true`.
- **Team History** — **Draft classes** summary + optional **Open Draft History** (wires `onOpenDraftHistory` from `LeagueDashboard`).
- **League History → Season Archive** — **`SeasonDraftClassSnippet`** when `getDraftClass` returns picks for the selected `seasonId`.

## Tests run

| Command | Result |
|---------|--------|
| `npm ci` | Pass |
| `npm run test:unit` | Pass (714 tests) |
| `npm run build` | Pass |
| `npm run check:deploy` | Pass |
| `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` | **Flaky in CI sandbox** — first run timed out on `app-shell-ready` after reload; re-run with full Playwright passed this spec |
| `npx playwright test` | **17 passed, 1 failed** — `phase_hydration_regression` flow A/D could not find draft tab copy (`/NFL Draft|Draft Board|Draft Room|draft class/i`) within 45s; appears unrelated to Draft History routing (no nav change to Draft tab); treat as existing flake or sim timing |

## Known limitations / follow-ups

- Draft class list is built from **capped recent** `Transactions.loadRecent(4000)`; very old `DRAFT` rows beyond the cap may not appear in `GET_DRAFT_CLASSES` (full class still works when `seasonId` is known).
- **Undrafted / FA** paths are omitted (no invented data).
- Player **`draftOverall`** field is optional; fallback uses `draftOverallPick` alias if present.
- E2E: one **phase hydration** draft-flow assertion failed once in full suite; needs separate stabilization if reproducible on `main`.

## PR #1379 parity

Transaction timeline / `GET_TRANSACTIONS` behavior unchanged aside from new messages. `Transactions:Activity` routing untouched (TABS order fix restores prior hook semantics).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0f61cb0-ab09-4bec-bfd7-e54006060203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0f61cb0-ab09-4bec-bfd7-e54006060203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

