### PR TITLE
Scouting / Player Development Depth V1

### DIFF
--- a/src/core/playerDevelopmentModel.js
+++ b/src/core/playerDevelopmentModel.js
@@ -1,0 +1,209 @@
+/**
+ * Pure, deterministic player development arc context from visible save data only.
+ * Does not mutate the player object.
+ */
+
+const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
+
+function toNum(v, fb = 0) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fb;
+}
+
+function normalizeDepthOrder(player) {
+  return toNum(player?.depthChart?.order ?? player?.depthOrder ?? 99, 99);
+}
+
+/**
+ * @param {object|null} player
+ * @param {object} [context]
+ * @param {object} [context.developmentContext] — optional preseason/training snapshot from profile
+ * @param {object} [context.team] — optional team for staff hint only
+ */
+export function buildPlayerDevelopmentModel(player = null, context = {}) {
+  const reasons = [];
+  const growthSignals = [];
+  const regressionRisks = [];
+
+  if (!player || typeof player !== 'object') {
+    return {
+      playerId: null,
+      name: null,
+      age: null,
+      pos: null,
+      currentOvr: null,
+      potential: null,
+      devStage: 'unknown',
+      devTrend: 'unknown',
+      arcType: 'unknown',
+      ceilingBand: 'unknown',
+      floorBand: 'unknown',
+      growthSignals: [],
+      regressionRisks: [],
+      staffImpact: null,
+      trainingImpact: null,
+      playingTimeImpact: null,
+      confidence: 'low',
+      summary: 'Insufficient player data for a development read.',
+      reasons: ['No player record'],
+    };
+  }
+
+  const playerId = player.id ?? null;
+  const name = player.name ?? null;
+  const age = toNum(player.age, 27);
+  const pos = String(player.pos ?? player.position ?? '').toUpperCase() || null;
+  const currentOvr = toNum(player.ovr, toNum(player.ratings?.overall, 60));
+  const potential = toNum(player.potential, currentOvr);
+  const delta = toNum(player.progressionDelta, 0);
+  const upsideGap = clamp(potential - currentOvr, 0, 99);
+  const injuryWeeks = toNum(player.injuryWeeksRemaining ?? player.injury?.weeksRemaining, 0);
+  const schemeFit = toNum(player.schemeFit, 50);
+  const depthOrder = normalizeDepthOrder(player);
+  const devCtx = context.developmentContext ?? player.developmentContext ?? null;
+  const staffMod = devCtx?.staffDevelopmentModifier != null ? toNum(devCtx.staffDevelopmentModifier, 0) : null;
+  const trainingFocus = devCtx?.trainingFocus ?? null;
+  const playingMod = devCtx?.playingTimeModifier != null ? String(devCtx.playingTimeModifier) : null;
+
+  const history = Array.isArray(player.developmentHistory) ? player.developmentHistory : [];
+  const historyLen = history.length;
+
+  /** @type {'rookie'|'developing'|'prime'|'late_prime'|'declining'|'veteran_depth'|'unknown'} */
+  let devStage = 'unknown';
+  if (age <= 22) {
+    devStage = 'rookie';
+    reasons.push(`Age ${age}: early-career profile.`);
+  } else if (age <= 25) {
+    devStage = 'developing';
+    reasons.push(`Age ${age}: typical development window.`);
+  } else if (age <= 29) {
+    devStage = 'prime';
+    reasons.push(`Age ${age}: prime window for most positions.`);
+  } else if (age <= 33) {
+    devStage = 'late_prime';
+    reasons.push(`Age ${age}: late-prime / maintenance phase.`);
+  } else if (age <= 37) {
+    devStage = 'declining';
+    reasons.push(`Age ${age}: regression risk rises without ideal usage.`);
+  } else {
+    devStage = 'veteran_depth';
+    reasons.push(`Age ${age}: depth / roster-ballast phase unless elite production exists.`);
+  }
+
+  /** @type {'rising'|'stable'|'falling'|'unknown'} */
+  let devTrend = 'stable';
+  if (delta >= 2) {
+    devTrend = 'rising';
+    growthSignals.push(`Recent OVR trend +${delta} vs prior checkpoint.`);
+  } else if (delta <= -2) {
+    devTrend = 'falling';
+    regressionRisks.push(`Recent OVR trend ${delta}.`);
+  } else if (delta === 0 && historyLen >= 2) {
+    devTrend = 'stable';
+    reasons.push('Flat progression snapshot across logged history.');
+  } else {
+    reasons.push(`Progression delta ${delta >= 0 ? '+' : ''}${delta} (small move).`);
+  }
+
+  /** @type {'early_breakout'|'late_bloomer'|'steady_developer'|'boom_bust'|'capped_out'|'aging_veteran'|'unknown'} */
+  let arcType = 'steady_developer';
+  if (age >= 32) {
+    arcType = 'aging_veteran';
+    reasons.push(currentOvr >= 78 ? 'Late-career arc with remaining high-end profile.' : 'Late-career arc; durability and role drive value.');
+  } else if (upsideGap <= 2 && age >= 27) {
+    arcType = 'capped_out';
+    reasons.push(`OVR (${currentOvr}) near listed potential (${potential}) — limited projected gains.`);
+  } else if (age >= 26 && delta >= 2 && upsideGap >= 4) {
+    arcType = 'late_bloomer';
+    growthSignals.push('Older developmental window still showing gains vs listed upside.');
+  } else if (age <= 24 && delta >= 3) {
+    arcType = 'early_breakout';
+    growthSignals.push('Young profile with a sharp recent progression signal.');
+  } else if (upsideGap >= 12 && Math.abs(delta) <= 1 && age <= 24) {
+    arcType = 'boom_bust';
+    regressionRisks.push('Large upside gap but flat recent progression — outcome uncertainty.');
+  } else if (age <= 26 && (delta >= 1 || upsideGap >= 6)) {
+    arcType = 'steady_developer';
+    growthSignals.push('Room to grow vs listed potential while age supports development.');
+  } else {
+    reasons.push('Steady trajectory — few extreme arc signals in visible data.');
+  }
+
+  const ceil = clamp(Math.round(potential), 40, 99);
+  const floorGuess = clamp(Math.round(currentOvr - Math.max(0, upsideGap * 0.35)), 40, ceil);
+  const ceilingBand = `${ceil - 2}–${ceil}`;
+  const floorBand = `${floorGuess}–${clamp(floorGuess + 4, floorGuess, ceil)}`;
+
+  if (schemeFit >= 72) growthSignals.push(`Scheme fit ${schemeFit} supports development environment.`);
+  else if (schemeFit <= 42) regressionRisks.push(`Scheme fit ${schemeFit} may cap weekly impact.`);
+
+  if (injuryWeeks > 0) regressionRisks.push(`Injury timeline (${injuryWeeks}w) limits developmental reps.`);
+
+  if (depthOrder >= 3 && age <= 25 && currentOvr >= 68) {
+    regressionRisks.push('Buried on depth chart — fewer live reps for growth.');
+  }
+
+  let staffImpact = null;
+  if (staffMod != null && staffMod !== 0) {
+    staffImpact = `Staff development modifier ${staffMod >= 0 ? '+' : ''}${staffMod}% (from training snapshot).`;
+    reasons.push(staffImpact);
+  } else {
+    staffImpact = 'Staff impact not flagged in save data.';
+  }
+
+  let trainingImpact = null;
+  if (trainingFocus) {
+    trainingImpact = `Training focus: ${String(trainingFocus).replace(/_/g, ' ')}.`;
+    reasons.push(trainingImpact);
+  } else {
+    trainingImpact = 'Training focus not logged for this snapshot.';
+  }
+
+  let playingTimeImpact = null;
+  if (playingMod) {
+    playingTimeImpact = `Playing-time modifier from progression context: ${playingMod}.`;
+    reasons.push(playingTimeImpact);
+  } else if (depthOrder <= 2) {
+    playingTimeImpact = 'Early depth — starter-path snaps likely.';
+    growthSignals.push(playingTimeImpact);
+  } else if (depthOrder >= 4) {
+    playingTimeImpact = 'Deep rotation — fewer developmental snaps.';
+    regressionRisks.push(playingTimeImpact);
+  } else {
+    playingTimeImpact = 'Playing-time impact not explicitly logged.';
+  }
+
+  /** @type {'high'|'medium'|'low'} */
+  let confidence = 'medium';
+  const signalCount =
+    (historyLen >= 2 ? 1 : 0) +
+    (player.progressionDelta != null && Number.isFinite(Number(player.progressionDelta)) ? 1 : 0) +
+    (devCtx ? 1 : 0) +
+    (schemeFit !== 50 ? 1 : 0);
+  if (signalCount >= 4) confidence = 'high';
+  else if (signalCount <= 1) confidence = 'low';
+
+  const summary = `${name ?? 'Player'} — ${devStage.replace(/_/g, ' ')}, ${arcType.replace(/_/g, ' ')}, trend ${devTrend}.`;
+
+  return {
+    playerId,
+    name,
+    age,
+    pos,
+    currentOvr,
+    potential,
+    devStage,
+    devTrend,
+    arcType,
+    ceilingBand,
+    floorBand,
+    growthSignals: growthSignals.slice(0, 5),
+    regressionRisks: regressionRisks.slice(0, 5),
+    staffImpact,
+    trainingImpact,
+    playingTimeImpact,
+    confidence,
+    summary,
+    reasons: reasons.slice(0, 8),
+  };
+}

--- a/src/core/scoutingModel.js
+++ b/src/core/scoutingModel.js
@@ -1,0 +1,214 @@
+/**
+ * Prospect scouting context derived only from fields already on the prospect object.
+ * Deterministic — no hidden rolls or invented traits.
+ */
+
+const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
+
+function toNum(v, fb = 0) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fb;
+}
+
+function combineSignalsFrom(combine = {}) {
+  const out = [];
+  const forty = Number(combine.fortyTime);
+  const vert = Number(combine.verticalLeap);
+  const agility = Number(combine.agility);
+  if (Number.isFinite(forty)) {
+    if (forty <= 4.55) out.push(`Fast forty (${forty}) for profile.`);
+    else if (forty >= 5.05) out.push(`Slow forty (${forty}) — mobility flag for speed roles.`);
+  }
+  if (Number.isFinite(vert) && vert >= 38) out.push(`Elite vertical (${vert}).`);
+  if (Number.isFinite(agility) && agility <= 7.05) out.push(`Quick agility (${agility}).`);
+  return out.slice(0, 3);
+}
+
+function interviewSignalsFrom(interview = {}) {
+  const risk = toNum(interview.riskScore, 40);
+  const out = [];
+  if (risk <= 28) out.push('Interview profile reads as high-character / low drama.');
+  else if (risk >= 58) out.push(`Interview risk elevated (${risk}) — maturity runway matters.`);
+  else out.push(`Interview risk score ${risk} — typical variance.`);
+  return out.slice(0, 2);
+}
+
+function projectedRoleForPos(posU, est, pot) {
+  const p = String(posU || '').toUpperCase();
+  const avg = (est + pot) / 2;
+  if (['QB'].includes(p)) {
+    if (avg >= 82) return 'Franchise QB projection';
+    if (avg >= 74) return 'Starter-caliber QB projection';
+    return 'Development QB / backup path';
+  }
+  if (['WR', 'TE'].includes(p)) {
+    if (avg >= 78) return 'Primary passing-game weapon';
+    if (avg >= 70) return 'Starter / rotation contributor';
+    return 'Depth / special teams path';
+  }
+  if (['RB', 'FB'].includes(p)) {
+    if (avg >= 76) return 'Lead-back upside';
+    return 'Committee / depth runner';
+  }
+  if (['OL'].includes(p) || ['OT', 'OG', 'C', 'G', 'T'].includes(p)) {
+    if (avg >= 76) return 'Plug-and-play line starter potential';
+    return 'Developmental lineman';
+  }
+  if (['DL', 'DE', 'DT', 'EDGE', 'NT', 'LB'].includes(p)) {
+    if (avg >= 78) return 'Front-seven impact starter path';
+    return 'Rotation / developmental defender';
+  }
+  if (['CB', 'S', 'FS', 'SS'].includes(p)) {
+    if (avg >= 77) return 'Coverage starter upside';
+    return 'Depth DB / special teams contributor';
+  }
+  if (['K', 'P'].includes(p)) return 'Specialist projection';
+  return avg >= 74 ? 'Starter-profile athlete' : 'Depth / developmental profile';
+}
+
+/**
+ * @param {object|null} prospect
+ * @param {object} [context]
+ * @param {object} [context.team] — optional user team for scheme copy only
+ */
+export function buildProspectScoutingReport(prospect = null, context = {}) {
+  if (!prospect || typeof prospect !== 'object') {
+    return {
+      playerId: null,
+      name: null,
+      pos: null,
+      projectedRole: 'Unknown',
+      scoutingGrade: null,
+      confidence: 'unknown',
+      riskLevel: 'normal',
+      upsideLabel: 'unknown',
+      floorLabel: 'unknown',
+      traits: [],
+      redFlags: [],
+      combineSignals: [],
+      interviewSignals: [],
+      schemeFitSummary: 'No prospect data.',
+      bestFitTeams: [],
+      summary: 'No prospect loaded.',
+      reasons: ['Missing prospect'],
+    };
+  }
+
+  const reasons = [];
+  const traits = [];
+  const redFlags = [];
+
+  const playerId = prospect.id ?? null;
+  const name = prospect.name ?? null;
+  const pos = String(prospect.pos ?? '').toUpperCase() || null;
+  const potential = toNum(prospect.potential ?? prospect.truePotential, 65);
+  const estimated = toNum(
+    prospect.ovr ?? prospect.scoutedOvr ?? prospect.trueOvr,
+    potential - 4,
+  );
+  const schemeFit = toNum(prospect.schemeFit, 65);
+  const combine = prospect.combineResults ?? {};
+  const interview = prospect.interviewReport ?? {};
+  const riskScore = toNum(interview.riskScore, 40);
+  const collegeBoost = toNum(prospect.collegeProductionScore, 0);
+
+  const hcScheme = String(context.team?.staff?.headCoach?.schemePreference ?? '').toLowerCase();
+  const archeTag = String(prospect.archetypeTag ?? '').toLowerCase();
+  let schemeFitSummary = `Listed scheme fit ${schemeFit}/100.`;
+  if (hcScheme && archeTag.includes(hcScheme)) {
+    schemeFitSummary = `Archetype aligns with your HC preference (${hcScheme}); listed fit ${schemeFit}.`;
+    traits.push('Coach-scheme alignment (tag match)');
+  } else if (hcScheme) {
+    schemeFitSummary = `HC favors ${hcScheme}; compare to archetype tags vs listed fit ${schemeFit}.`;
+  }
+
+  const combineSignals = combineSignalsFrom(combine);
+  const interviewSignals = interviewSignalsFrom(interview);
+
+  let signalScore = 0;
+  if (Object.keys(combine).length > 0 && combine.fortyTime != null) signalScore += 2;
+  else if (Object.keys(combine).length > 0) signalScore += 1;
+  if (interview && Object.keys(interview).length > 0) signalScore += 2;
+  if (prospect.potential != null || prospect.truePotential != null) signalScore += 1;
+  if (prospect.ovr != null || prospect.scoutedOvr != null || prospect.trueOvr != null) signalScore += 1;
+  if (collegeBoost > 0) signalScore += 1;
+
+  /** @type {'high'|'medium'|'low'|'unknown'} */
+  let confidence = 'medium';
+  if (signalScore >= 6) confidence = 'high';
+  else if (signalScore <= 2) confidence = 'low';
+  if (!prospect.id && signalScore <= 1) confidence = 'unknown';
+
+  /** @type {'safe'|'normal'|'volatile'|'boom_bust'|'injury_or_age_risk'} */
+  let riskLevel = 'normal';
+  if (riskScore >= 62 && potential - estimated >= 10) riskLevel = 'boom_bust';
+  else if (riskScore >= 55) riskLevel = 'volatile';
+  else if (riskScore <= 30 && Math.abs(potential - estimated) <= 8) riskLevel = 'safe';
+
+  const age = toNum(prospect.age, 21);
+  if (pos === 'RB' && age >= 23) {
+    riskLevel = riskLevel === 'safe' ? 'injury_or_age_risk' : riskLevel;
+    redFlags.push('RB age curve — rookie contract runway shorter than premium positions.');
+    reasons.push('Age/context adds roster-risk nuance for RB profiles.');
+  }
+
+  /** @type {'franchise_cornerstone'|'high-end_starter'|'starter_upside'|'role_player'|'depth'} */
+  let upsideLabel = 'role_player';
+  if (potential >= 92) upsideLabel = 'franchise_cornerstone';
+  else if (potential >= 86) upsideLabel = 'high-end_starter';
+  else if (potential >= 78) upsideLabel = 'starter_upside';
+  else if (potential >= 70) upsideLabel = 'role_player';
+  else upsideLabel = 'depth';
+
+  /** @type {'franchise_cornerstone'|'high-end_starter'|'starter_upside'|'role_player'|'depth'} */
+  let floorLabel = 'depth';
+  if (estimated >= 82) floorLabel = 'high-end_starter';
+  else if (estimated >= 76) floorLabel = 'starter_upside';
+  else if (estimated >= 68) floorLabel = 'role_player';
+  else floorLabel = 'depth';
+
+  const gradeNum = clamp(Math.round(estimated * 0.55 + potential * 0.35 + schemeFit * 0.08 + collegeBoost * 0.02), 40, 99);
+  let letter = 'C';
+  if (gradeNum >= 90) letter = 'A+';
+  else if (gradeNum >= 85) letter = 'A';
+  else if (gradeNum >= 80) letter = 'B+';
+  else if (gradeNum >= 75) letter = 'B';
+  else if (gradeNum >= 70) letter = 'C+';
+  else if (gradeNum >= 64) letter = 'C';
+  else if (gradeNum >= 58) letter = 'D';
+  else letter = 'F';
+
+  const scoutingGrade = `${letter} (${gradeNum})`;
+
+  const projectedRole = projectedRoleForPos(pos, estimated, potential);
+
+  if (potential - estimated >= 14) {
+    traits.push('Large OVR-to-potential gap — boom/bust variance');
+    reasons.push('Wide projection band based on listed ratings only.');
+  }
+  if (collegeBoost >= 18) traits.push('Strong college production signal');
+
+  const summary = `${name ?? 'Prospect'} — ${upsideLabel.replace(/_/g, ' ')} upside vs ${floorLabel.replace(/_/g, ' ')} floor read (${confidence} confidence).`;
+
+  reasons.push('Grade blends listed OVR/scouted estimate, potential, scheme fit, and production score only.');
+
+  return {
+    playerId,
+    name,
+    pos,
+    projectedRole,
+    scoutingGrade,
+    confidence,
+    riskLevel,
+    upsideLabel,
+    floorLabel,
+    traits: traits.slice(0, 6),
+    redFlags: redFlags.slice(0, 4),
+    combineSignals,
+    interviewSignals,
+    schemeFitSummary,
+    bestFitTeams: [],
+    summary,
+    reasons: reasons.slice(0, 8),
+  };
+}

--- a/src/ui/components/Draft.jsx
+++ b/src/ui/components/Draft.jsx
@@ -35,6 +35,7 @@ import { applyAdvancedPlayerFilters, allFilters } from "../../core/footballAdvan
 import { usePlayerCompare } from "../utils/playerCompare.js";
 import EmptyState from "./EmptyState.jsx";
 import { POS_COLORS } from "../constants/positionColors.js";
+import { buildProspectScoutingReport } from "../../core/scoutingModel.js";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -123,6 +124,38 @@ function getScoutReport(trueOvr, playerId, scoutAccuracy = 0.65) {
   else                        { grade = "F";  gradeColor = "#FF453A"; }
 
   return { grade, gradeColor, range: `${low}–${high}` };
+}
+
+/** Presentational only — no hooks (avoids hook-order edge cases in dense Draft table renders). */
+function ProspectScoutingChips({ prospect, team }) {
+  const report = buildProspectScoutingReport(prospect, { team });
+  const chip = (k, v) => (
+    <span
+      key={k}
+      className="status-chip muted"
+      style={{ fontSize: "10px", padding: "1px 6px", lineHeight: 1.2 }}
+      title={report.summary}
+    >
+      {k}: {v}
+    </span>
+  );
+  return (
+    <div
+      data-testid="draft-scouting-chips"
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: 4,
+        marginTop: 4,
+        maxWidth: 220,
+      }}
+    >
+      {chip("conf", report.confidence)}
+      {chip("risk", String(report.riskLevel).replace(/_/g, " "))}
+      {chip("fit", `${Math.round(Number(prospect?.schemeFit ?? 65))}`)}
+      {chip("role", String(report.projectedRole).slice(0, 28))}
+    </div>
+  );
 }
 
 function ScoutBadge({ player, team }) {
@@ -1994,11 +2027,20 @@ function DraftBoard({
                       <TableCell style={{ color: "var(--text-muted)" }}>{p.age}</TableCell>
                       <TableCell style={{ textAlign: "center" }}><Button title={compareIds.includes(p.id) ? "Remove from compare" : "Add to compare"} onClick={() => toggleCompare(p)} style={{ width: 22, height: 22, borderRadius: "var(--radius-sm)", border: `1.5px solid ${compareIds.includes(p.id) ? "var(--accent)" : "var(--hairline)"}`, background: compareIds.includes(p.id) ? "var(--accent-muted)" : "transparent", fontSize: 12, color: compareIds.includes(p.id) ? "var(--accent)" : "var(--text-subtle)" }}>{compareIds.includes(p.id) ? "✓" : "⊕"}</Button></TableCell>
                       <TableCell>
-                        {/* Fog of War: show scout grade before drafted, true OVR after */}
-                        {isDraftComplete
-                          ? <OvrBadge ovr={p.ovr} />
-                          : <ScoutBadge player={p} team={(league?.teams ?? []).find((t) => t.id === league?.userTeamId)} />
-                        }
+                        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 2 }}>
+                          {/* Fog of War: show scout grade before drafted, true OVR after */}
+                          {isDraftComplete ? (
+                            <OvrBadge ovr={p.ovr} />
+                          ) : (
+                            <>
+                              <ScoutBadge player={p} team={(league?.teams ?? []).find((t) => t.id === league?.userTeamId)} />
+                              <ProspectScoutingChips
+                                prospect={p}
+                                team={(league?.teams ?? []).find((t) => t.id === league?.userTeamId)}
+                              />
+                            </>
+                          )}
+                        </div>
                       </TableCell>
                       <TableCell
                         style={{
@@ -2339,6 +2381,7 @@ export default function Draft({ league, actions, onNavigate = null }) {
       >
         <div>
           <h1
+            data-testid="draft-room-heading"
             style={{
               fontWeight: 800,
               fontSize: "var(--text-xl)",

--- a/src/ui/components/Draft.test.jsx
+++ b/src/ui/components/Draft.test.jsx
@@ -34,5 +34,6 @@ describe("DraftBigBoard", () => {
     );
     expect(html).toContain("Board Controls");
     expect(html).toContain("Class:");
+    expect(html).toContain("draft-board-scouting-inline");
   });
 });

--- a/src/ui/components/DraftBigBoard.jsx
+++ b/src/ui/components/DraftBigBoard.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { buildDraftBoardAnalysis } from '../../core/draft/draftBoardAnalysis.js';
 import { buildDraftProfileContext } from '../utils/playerProfileContext.js';
+import { buildProspectScoutingReport } from '../../core/scoutingModel.js';
 
 const POS_FILTERS = ['ALL', 'QB', 'WR', 'RB', 'TE', 'OL', 'DL', 'LB', 'CB', 'S', 'K', 'P'];
 const FILTERS = ['all', 'need', 'starter_path', 'young_upside', 'safe_pick', 'high_risk', 'bargain'];
@@ -84,7 +85,23 @@ export default function DraftBigBoard({ league, onPlayerSelect }) {
     <div style={{ display:'flex', gap:6, flexWrap:'wrap' }}>{FILTERS.map((f)=><button key={f} className="btn" onClick={()=>setActiveFilter(f)}>{f}</button>)}{POS_FILTERS.map((p)=><button key={p} className="btn" onClick={()=>setPositionFilter(p)}>{p}</button>)}</div>
     <select aria-label="Sort prospects" value={sortBy} onChange={(e) => setSortBy(e.target.value)}>{SORTS.map((s) => <option key={s} value={s}>{s}</option>)}</select>
     <h4 style={{ marginTop: 10 }}>Prospect Board</h4>
-    {visibleProspects.length===0 ? <div style={{fontSize:12}}>No prospects available for current filters.</div> : visibleProspects.map((p)=><div key={p.prospectId} className="stat-box" style={{marginBottom:6,padding:8}}><div style={{fontSize:12}}>{p.boardRank}. {p.name} · {p.pos} {p.college ? `· ${p.college}` : ''}</div><div style={{fontSize:11}}>OVR {p.ovr ?? 'N/A'} POT {p.potential ?? 'N/A'} · Round {p.projectedRound ?? 'Unknown'} · Fit {p.fitScore}</div><div style={{fontSize:11}}>{p.comparisonReceipt || p.reason}</div><div><button className="btn" onClick={()=>setWatchlist((prev)=>prev.includes(p.prospectId)?prev.filter((id)=>id!==p.prospectId):[...prev,p.prospectId])}>{p.isShortlist ? 'Unwatch' : 'Watch'}</button><button className="btn" onClick={()=>moveProspect(p.prospectId,-1)}>↑</button><button className="btn" onClick={()=>moveProspect(p.prospectId,1)}>↓</button><button className="btn" onClick={()=>onPlayerSelect?.(p.prospectId, buildDraftProfileContext(p))}>Open profile</button></div></div>)}
+    {visibleProspects.length===0 ? <div style={{fontSize:12}}>No prospects available for current filters.</div> : visibleProspects.map((p) => {
+      const rawProspect = (prospects ?? []).find((x) => String(x?.id) === String(p.prospectId)) ?? p;
+      const sr = buildProspectScoutingReport(rawProspect, { team: userTeam });
+      return (
+        <div key={p.prospectId} className="stat-box" style={{marginBottom:6,padding:8}} data-testid="draft-big-board-row">
+          <div style={{fontSize:12}}>{p.boardRank}. {p.name} · {p.pos} {p.college ? `· ${p.college}` : ''}</div>
+          <div style={{fontSize:11}}>OVR {p.ovr ?? 'N/A'} POT {p.potential ?? 'N/A'} · Round {p.projectedRound ?? 'Unknown'} · Fit {p.fitScore}</div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginTop: 4 }} data-testid="draft-board-scouting-inline">
+            <span className="status-chip muted" style={{ fontSize: 10 }}>conf {sr.confidence}</span>
+            <span className="status-chip muted" style={{ fontSize: 10 }}>{String(sr.riskLevel).replace(/_/g,' ')}</span>
+            <span className="status-chip muted" style={{ fontSize: 10 }}>{sr.upsideLabel.replace(/_/g,' ')}</span>
+          </div>
+          <div style={{fontSize:11}}>{p.comparisonReceipt || p.reason}</div>
+          <div><button className="btn" onClick={()=>setWatchlist((prev)=>prev.includes(p.prospectId)?prev.filter((id)=>id!==p.prospectId):[...prev,p.prospectId])}>{p.isShortlist ? 'Unwatch' : 'Watch'}</button><button className="btn" onClick={()=>moveProspect(p.prospectId,-1)}>↑</button><button className="btn" onClick={()=>moveProspect(p.prospectId,1)}>↓</button><button className="btn" onClick={()=>onPlayerSelect?.(p.prospectId, buildDraftProfileContext(p))}>Open profile</button></div>
+        </div>
+      );
+    })}
     <h4 style={{ marginTop: 10 }}>Pick Assets</h4>
     {analysis.pickAssets.length===0 ? <div style={{fontSize:12}}>No user picks available.</div> : analysis.pickAssets.slice(0,6).map((pick)=><div key={pick.pickId} style={{fontSize:12}}>{pick.label} · value {pick.pickValue} · {pick.targetTier}</div>)}
   </div>;

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -31,6 +31,8 @@ import { getPlayerGameLogs } from "../utils/playerGameLogs.js";
 import { buildMergedPlayerAwardTimeline, buildPlayerAwardHeaderBadges } from "../../core/playerAwardTimeline.js";
 import { buildPlayerRecordContext, mergePlayerProfileSeasonRows } from "../../core/recordBookV1.js";
 import { buildLegacyScoreReport, shouldShowLegacyProfileSection } from "../../core/legacyScore.js";
+import { buildPlayerDevelopmentModel } from "../../core/playerDevelopmentModel.js";
+import { buildProspectScoutingReport } from "../../core/scoutingModel.js";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
@@ -598,6 +600,14 @@ export default function PlayerProfile({
   const ageCurve = useMemo(() => getAgeCurveContext(player), [player]);
   const developmentSnapshot = useMemo(() => getDevelopmentSnapshot(player), [player]);
   const developmentDrivers = useMemo(() => getDevelopmentDrivers(player, moraleContext), [player, moraleContext]);
+  const developmentArcModel = useMemo(
+    () => buildPlayerDevelopmentModel(effectivePlayer, { developmentContext: effectivePlayer?.developmentContext }),
+    [effectivePlayer],
+  );
+  const prospectScoutingReport = useMemo(
+    () => (isProspect ? buildProspectScoutingReport(player, { team: userTeam }) : null),
+    [isProspect, player, userTeam],
+  );
 
   const management = useMemo(() => normalizeManagement(player), [player]);
   const updateManagement = async (updates) => {
@@ -1059,6 +1069,45 @@ export default function PlayerProfile({
                   ]}
                 />
 
+                {!isProspect && playerView && (
+                  <div
+                    data-testid="player-profile-dev-arc"
+                    style={{
+                      marginTop: "var(--space-2)",
+                      padding: "var(--space-3)",
+                      borderRadius: "var(--radius-md)",
+                      border: "1px solid var(--hairline)",
+                      background: "var(--surface-strong)",
+                      fontSize: "var(--text-xs)",
+                    }}
+                  >
+                    <div style={{ ...sectionLabelStyle, marginBottom: 6 }}>Career arc snapshot</div>
+                    <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 6 }}>
+                      <span className="status-chip info">{developmentArcModel.devStage.replace(/_/g, " ")}</span>
+                      <span className="status-chip muted">{developmentArcModel.arcType.replace(/_/g, " ")}</span>
+                      <span className="status-chip muted">Trend: {developmentArcModel.devTrend}</span>
+                      <span className="status-chip muted">Confidence: {developmentArcModel.confidence}</span>
+                    </div>
+                    <div style={{ color: "var(--text-muted)", lineHeight: 1.45, marginBottom: 6 }}>
+                      Ceiling band ~{developmentArcModel.ceilingBand} · Floor band ~{developmentArcModel.floorBand}
+                    </div>
+                    <div style={{ color: "var(--text)", fontWeight: 600, marginBottom: 4 }}>{developmentArcModel.summary}</div>
+                    {developmentArcModel.growthSignals[0] ? (
+                      <div style={{ color: "var(--text-subtle)" }}>↑ {developmentArcModel.growthSignals[0]}</div>
+                    ) : null}
+                    {developmentArcModel.regressionRisks[0] ? (
+                      <div style={{ color: "var(--text-subtle)" }}>↓ {developmentArcModel.regressionRisks[0]}</div>
+                    ) : null}
+                    <div style={{ marginTop: 6, color: "var(--text-subtle)", fontSize: "var(--text-xs)" }}>
+                      {developmentArcModel.staffImpact}
+                      {" · "}
+                      {developmentArcModel.trainingImpact}
+                      {" · "}
+                      {developmentArcModel.playingTimeImpact}
+                    </div>
+                  </div>
+                )}
+
                 {/* Traits */}
                 {player.traits?.length > 0 && (
                   <div
@@ -1332,6 +1381,30 @@ export default function PlayerProfile({
             </section>
           )}
 
+          {!loading && player && isProspect && prospectScoutingReport && (
+            <section className="card-enter" data-testid="player-profile-scouting-report">
+              <h3 style={sectionLabelStyle}>Scouting snapshot</h3>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 8 }}>
+                <span className="status-chip info">{prospectScoutingReport.scoutingGrade}</span>
+                <span className="status-chip muted">Conf: {prospectScoutingReport.confidence}</span>
+                <span className="status-chip muted">Risk: {prospectScoutingReport.riskLevel.replace(/_/g, " ")}</span>
+                <span className="status-chip muted">↑ {prospectScoutingReport.upsideLabel.replace(/_/g, " ")}</span>
+                <span className="status-chip muted">Floor: {prospectScoutingReport.floorLabel.replace(/_/g, " ")}</span>
+              </div>
+              <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginBottom: 4 }}>{prospectScoutingReport.projectedRole}</div>
+              <p style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginBottom: 8 }}>{prospectScoutingReport.summary}</p>
+              <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)", marginBottom: 6 }}>{prospectScoutingReport.schemeFitSummary}</div>
+              {prospectScoutingReport.combineSignals[0] ? (
+                <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>Combine: {prospectScoutingReport.combineSignals[0]}</div>
+              ) : null}
+              {prospectScoutingReport.interviewSignals[0] ? (
+                <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>Interview: {prospectScoutingReport.interviewSignals[0]}</div>
+              ) : null}
+              {prospectScoutingReport.traits[0] ? (
+                <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginTop: 6 }}>Notes: {prospectScoutingReport.traits.slice(0, 2).join(" · ")}</div>
+              ) : null}
+            </section>
+          )}
           {!loading && player && isProspect && (
             <section className="card-enter">
               <h3 style={sectionLabelStyle}>Prospect Evaluation</h3>

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -62,6 +62,46 @@ describe('PlayerProfile', () => {
     expect(screen.getByTestId('player-profile-season-stats').textContent).toContain('Season stats will appear after this player records tracked stats.');
   });
 
+  it('shows career arc snapshot for active players', async () => {
+    render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={actions} teams={league.teams} league={league} />);
+    await waitFor(() => expect(screen.getByTestId('player-profile-dev-arc')).toBeTruthy());
+    expect(screen.getByTestId('player-profile-dev-arc').textContent).toMatch(/Career arc snapshot/i);
+  });
+
+  it('shows scouting snapshot for draft-eligible prospects', async () => {
+    const prospect = {
+      id: 55,
+      name: 'Draft Prospect',
+      pos: 'QB',
+      age: 21,
+      status: 'draft_eligible',
+      ovr: 74,
+      potential: 88,
+      schemeFit: 66,
+      combineResults: { fortyTime: 4.58, verticalLeap: 34 },
+      interviewReport: { riskScore: 38 },
+      traits: [],
+      accolades: [],
+    };
+    const prospectLeague = {
+      ...league,
+      teams: [{ id: 1, name: 'Dallas', abbr: 'DAL', roster: [], staff: { headCoach: { schemePreference: 'vertical' } } }],
+    };
+    const prospectActions = {
+      getPlayerCareer: vi.fn(async () => ({
+        payload: { player: prospect, stats: [], teammates: [], meta: { userTeamId: 1 } },
+      })),
+      getAllSeasons: vi.fn(async () => ({ payload: { seasons: [] } })),
+      getPlayerDraftContext: vi.fn(async () => ({ payload: { context: { known: false } } })),
+      getRecords: vi.fn(async () => ({ payload: { recordBook: null } })),
+    };
+    render(
+      <PlayerProfile playerId={55} onClose={vi.fn()} actions={prospectActions} teams={prospectLeague.teams} league={prospectLeague} />,
+    );
+    await waitFor(() => expect(screen.getByTestId('player-profile-scouting-report')).toBeTruthy());
+    expect(screen.getByTestId('player-profile-scouting-report').textContent).toMatch(/Scouting snapshot/i);
+  });
+
   it('renders game book context and honest missing logs state', () => {
     render(
       <PlayerProfile

--- a/tests/e2e/phase_hydration_regression.spec.js
+++ b/tests/e2e/phase_hydration_regression.spec.js
@@ -37,7 +37,7 @@ test.describe('Phase hydration regression', () => {
     await page.waitForFunction(() => window?.state?.league?.phase === 'draft', { timeout: 120000 });
 
     await goToTab(page, 'draft');
-    await expect(page.getByText(/NFL Draft|Draft Board|Draft Room|draft class/i).first()).toBeVisible({ timeout: 45000 });
+    await expect(page.getByTestId('draft-room-heading')).toBeVisible({ timeout: 45000 });
     await expect(page.getByText(/Draft data is still initializing/i)).toHaveCount(0);
 
     await page.evaluate(() => window.gameController.simDraftPick());

--- a/tests/unit/playerDevelopmentModel.test.js
+++ b/tests/unit/playerDevelopmentModel.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { buildPlayerDevelopmentModel } from '../../src/core/playerDevelopmentModel.js';
+
+describe('playerDevelopmentModel', () => {
+  it('returns safe unknown payload for missing player', () => {
+    const m = buildPlayerDevelopmentModel(null);
+    expect(m.devStage).toBe('unknown');
+    expect(m.arcType).toBe('unknown');
+    expect(m.confidence).toBe('low');
+    expect(m.reasons.length).toBeGreaterThan(0);
+  });
+
+  it('classifies rookie/prime/veteran stages by age', () => {
+    expect(buildPlayerDevelopmentModel({ id: 1, name: 'Y', pos: 'WR', age: 21, ovr: 72, potential: 82 }).devStage).toBe('rookie');
+    expect(buildPlayerDevelopmentModel({ id: 2, name: 'P', pos: 'WR', age: 27, ovr: 80, potential: 82 }).devStage).toBe('prime');
+    expect(buildPlayerDevelopmentModel({ id: 3, name: 'V', pos: 'WR', age: 35, ovr: 78, potential: 78 }).devStage).toBe('declining');
+    expect(buildPlayerDevelopmentModel({ id: 4, name: 'VD', pos: 'WR', age: 39, ovr: 70, potential: 70 }).devStage).toBe('veteran_depth');
+  });
+
+  it('labels late bloomer when older player gains with upside gap', () => {
+    const m = buildPlayerDevelopmentModel({
+      id: 'x',
+      pos: 'QB',
+      age: 27,
+      ovr: 76,
+      potential: 86,
+      progressionDelta: 3,
+    });
+    expect(m.arcType).toBe('late_bloomer');
+    expect(m.devTrend).toBe('rising');
+  });
+
+  it('labels capped_out when near potential', () => {
+    const m = buildPlayerDevelopmentModel({
+      id: 'y',
+      pos: 'CB',
+      age: 28,
+      ovr: 84,
+      potential: 85,
+      progressionDelta: 0,
+    });
+    expect(m.arcType).toBe('capped_out');
+  });
+
+  it('does not mutate player input', () => {
+    const p = { id: 1, pos: 'RB', age: 24, ovr: 70, potential: 85 };
+    const copy = { ...p };
+    buildPlayerDevelopmentModel(p);
+    expect(p).toEqual(copy);
+  });
+});

--- a/tests/unit/scoutingModel.test.js
+++ b/tests/unit/scoutingModel.test.js
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { buildProspectScoutingReport } from '../../src/core/scoutingModel.js';
+
+describe('scoutingModel', () => {
+  it('returns safe fallback for null prospect', () => {
+    const r = buildProspectScoutingReport(null);
+    expect(r.confidence).toBe('unknown');
+    expect(r.summary).toMatch(/No prospect/i);
+  });
+
+  it('uses combine and interview for confidence and risk signals', () => {
+    const r = buildProspectScoutingReport({
+      id: 'p1',
+      name: 'Test QB',
+      pos: 'QB',
+      age: 21,
+      ovr: 78,
+      potential: 92,
+      schemeFit: 72,
+      combineResults: { fortyTime: 4.52, verticalLeap: 36, agility: 6.9 },
+      interviewReport: { riskScore: 28 },
+      collegeProductionScore: 22,
+    });
+    expect(['high', 'medium']).toContain(r.confidence);
+    expect(r.combineSignals.length).toBeGreaterThan(0);
+    expect(r.interviewSignals.length).toBeGreaterThan(0);
+    expect(r.upsideLabel).toMatch(/franchise|high-end|starter/i);
+  });
+
+  it('falls back to low confidence when few fields exist', () => {
+    const r = buildProspectScoutingReport({
+      id: 'sparse',
+      pos: 'WR',
+      potential: 70,
+    });
+    expect(r.confidence === 'low' || r.confidence === 'unknown' || r.confidence === 'medium').toBe(true);
+  });
+
+  it('projects QB vs defensive roles differently at similar grades', () => {
+    const qb = buildProspectScoutingReport({
+      id: 'qb',
+      pos: 'QB',
+      ovr: 76,
+      potential: 88,
+      schemeFit: 60,
+      interviewReport: { riskScore: 40 },
+    });
+    const cb = buildProspectScoutingReport({
+      id: 'cb',
+      pos: 'CB',
+      ovr: 76,
+      potential: 88,
+      schemeFit: 60,
+      interviewReport: { riskScore: 40 },
+    });
+    expect(qb.projectedRole.toLowerCase()).toContain('qb');
+    expect(cb.projectedRole.toLowerCase()).not.toContain('quarterback');
+  });
+
+  it('flags boom_bust risk when interview and upside gap are extreme', () => {
+    const r = buildProspectScoutingReport({
+      id: 'bb',
+      pos: 'WR',
+      ovr: 68,
+      potential: 92,
+      interviewReport: { riskScore: 68 },
+      combineResults: { fortyTime: 4.48 },
+    });
+    expect(r.riskLevel).toBe('boom_bust');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds **pure** scouting & player-development explainability (no hidden ratings invented), compact UI on Player Profile and Draft surfaces, and regression-safe e2e.

### Core helpers
- **`buildPlayerDevelopmentModel(player, context)`** ([src/core/playerDevelopmentModel.js](src/core/playerDevelopmentModel.js)): deterministic `devStage`, `devTrend`, `arcType`, ceiling/floor bands, growth/regression notes, staff/training/playing-time copy from **existing** `developmentContext` / roster signals only.
- **`buildProspectScoutingReport(prospect, context)`** ([src/core/scoutingModel.js](src/core/scoutingModel.js)): confidence/risk/upside/floor from **listed** OVR/potential, combine, interview `riskScore`, scheme fit, college production score — honest low-confidence when data is sparse.

### UI
- **Player Profile**: “Career arc snapshot” (`data-testid="player-profile-dev-arc"`) for roster players; “Scouting snapshot” (`player-profile-scouting-report`) for `draft_eligible` prospects.
- **Draft room**: compact chips under scout grade (`draft-scouting-chips`) — conf / risk / scheme fit / role projection.
- **Draft Big Board**: inline chips (`draft-board-scouting-inline`).
- **Draft heading**: `data-testid="draft-room-heading"` for stable automation.

### Bugfix (prod Draft render)
`ProspectScoutingChips` no longer uses hooks — avoids React **#185** render-boundary failures on the Draft tab in production builds.

### E2E
`phase_hydration_regression` now waits for `draft-room-heading` instead of fragile text regex.

### Tests
- New unit tests: `tests/unit/playerDevelopmentModel.test.js`, `tests/unit/scoutingModel.test.js`
- Extended `PlayerProfile.test.jsx`, `Draft.test.jsx`

### Commands run
- `npm ci`, `npm run test:unit` (733 tests), `npm run build`, `npm run check:deploy`
- `npx playwright test` — **18/18 passed**
- **Note:** `npm run test:soak` / `npm run audit:dynasty` are **not defined** in `package.json` on this branch — skipped.

### Limitations / follow-ups
- Scouting “confidence” is **derived from how many real fields exist**, not a hidden scout accuracy roll.
- Dynasty soak CLI should be wired when `audit:dynasty` lands.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afd0ef26-74cd-49a3-8aae-ff56396d9385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afd0ef26-74cd-49a3-8aae-ff56396d9385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

