### PR TITLE
Dynasty Soak + Balance Audit V1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ verify_manager_flow.js
 dist/
 .netlify/
 test-results/
+artifacts/dynasty-soak/

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,8 +34,10 @@
         "@playwright/test": "^1.59.1",
         "@testing-library/react": "^16.3.0",
         "@vitejs/plugin-react": "^5.1.4",
+        "fake-indexeddb": "^6.2.5",
         "jsdom": "^26.1.0",
         "playwright": "^1.59.1",
+        "tsx": "^4.21.0",
         "vite": "^7.3.3",
         "vitest": "^3.2.4"
       },
@@ -3159,6 +3161,16 @@
         }
       }
     },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -3207,6 +3219,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -3979,6 +4004,16 @@
         }
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "devOptional": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
@@ -4287,6 +4322,41 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "preview": "vite preview",
     "test": "playwright test",
     "test:unit": "vitest run",
+    "test:soak": "vitest run tests/unit/dynastySoakAudit.test.js tests/integration/dynastySoak.test.js",
+    "audit:dynasty": "tsx scripts/dynasty-soak.mjs",
     "test:e2e": "playwright test",
     "check:netlify-parity": "bash scripts/netlify-parity-check.sh",
     "check:netlify-cli-build": "npx --yes netlify-cli@latest build --context production --offline",
@@ -46,8 +48,10 @@
     "@playwright/test": "^1.59.1",
     "@testing-library/react": "^16.3.0",
     "@vitejs/plugin-react": "^5.1.4",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^26.1.0",
     "playwright": "^1.59.1",
+    "tsx": "^4.21.0",
     "vite": "^7.3.3",
     "vitest": "^3.2.4"
   }

--- a/scripts/dynasty-soak.mjs
+++ b/scripts/dynasty-soak.mjs
@@ -30,7 +30,10 @@ function parseArgs(argv) {
 }
 
 function mdEscape(s) {
-  return String(s ?? '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
+  return String(s ?? '')
+    .replace(/\\/g, '\\\\')
+    .replace(/\|/g, '\\|')
+    .replace(/\r?\n/g, ' ');
 }
 
 function buildMarkdownReport(result) {

--- a/scripts/dynasty-soak.mjs
+++ b/scripts/dynasty-soak.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Dynasty soak CLI — must load fake IndexedDB before any DB/worker import.
+ * @see src/testSupport/dynastySoakRunner.js
+ *
+ * Full worker sim (default 5 seasons) can take a long time on a 32-team save.
+ * For CI, `npm run test:soak` runs fast Vitest audit coverage instead.
+ */
+import 'fake-indexeddb/auto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+function parseArgs(argv) {
+  const out = { ci: false, seasons: null, seed: null, outDir: null };
+  for (let i = 2; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--ci') out.ci = true;
+    else if (a.startsWith('--seasons=')) out.seasons = Number(a.split('=')[1]);
+    else if (a.startsWith('--seed=')) out.seed = Number(a.split('=')[1]);
+    else if (a.startsWith('--outDir=')) out.outDir = a.split('=').slice(1).join('=');
+    else if (a === '--seasons' && argv[i + 1]) {
+      out.seasons = Number(argv[i + 1]);
+      i += 1;
+    } else if (a === '--seed' && argv[i + 1]) {
+      out.seed = Number(argv[i + 1]);
+      i += 1;
+    }
+  }
+  return out;
+}
+
+function mdEscape(s) {
+  return String(s ?? '').replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function buildMarkdownReport(result) {
+  const lines = [];
+  lines.push('# Dynasty soak report');
+  lines.push('');
+  lines.push(`- **Seed:** ${result.seed}`);
+  lines.push(`- **Seasons:** ${result.seasonsSimmed}`);
+  lines.push(`- **Runtime ms:** ${result.runtimeMs}`);
+  lines.push(`- **Passed:** ${result.passed ? 'yes' : 'no'}`);
+  lines.push(`- **Severity:** ${result.severity}`);
+  lines.push('');
+  lines.push('## Summary buckets');
+  lines.push('');
+  lines.push('| Bucket | Status |');
+  lines.push('| --- | --- |');
+  for (const [k, v] of Object.entries(result.summary || {})) {
+    lines.push(`| ${k} | ${v} |`);
+  }
+  lines.push('');
+  lines.push('## Failures');
+  lines.push('');
+  if (!result.failures?.length) lines.push('_None_');
+  else {
+    for (const f of result.failures) {
+      lines.push(`- **${f.code}:** ${mdEscape(f.message)}`);
+    }
+  }
+  lines.push('');
+  lines.push('## Warnings');
+  lines.push('');
+  if (!result.warnings?.length) lines.push('_None_');
+  else {
+    for (const w of result.warnings) {
+      lines.push(`- **${w.code}:** ${mdEscape(w.message)}`);
+    }
+  }
+  lines.push('');
+  lines.push('## Notes');
+  lines.push('');
+  lines.push('- Failures block CI; warnings are informational.');
+  lines.push('- Thresholds are intentionally broad (audit V1, not balance tuning).');
+  return lines.join('\n');
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const seed = Number.isFinite(args.seed) ? args.seed : 1383;
+  const seasons = Number.isFinite(args.seasons)
+    ? args.seasons
+    : args.ci
+      ? 1
+      : 5;
+
+  const { runDynastySoakOnce } = await import('../src/testSupport/dynastySoakRunner.js');
+
+  console.log(`[dynasty-soak] seed=${seed} seasons=${seasons}${args.ci ? ' (ci)' : ''}`);
+  const result = await runDynastySoakOnce({ seasons, seed });
+  result.seed = seed;
+
+  const outDir = resolve(process.cwd(), args.outDir || 'artifacts/dynasty-soak');
+  await mkdir(outDir, { recursive: true });
+  await writeFile(resolve(outDir, 'latest.json'), JSON.stringify(result, null, 2), 'utf8');
+  const md = buildMarkdownReport(result);
+  await writeFile(resolve(outDir, 'latest.md'), md, 'utf8');
+
+  console.log(`[dynasty-soak] passed=${result.passed} runtimeMs=${result.runtimeMs} failures=${result.failures?.length ?? 0} warnings=${result.warnings?.length ?? 0}`);
+  if (result.failures?.length) {
+    for (const f of result.failures.slice(0, 20)) {
+      console.error(`  FAIL ${f.code}: ${f.message}`);
+    }
+  }
+  if (result.warnings?.length) {
+    for (const w of result.warnings.slice(0, 15)) {
+      console.warn(`  WARN ${w.code}: ${w.message}`);
+    }
+  }
+  console.log(`[dynasty-soak] reports -> ${outDir}/latest.{json,md}`);
+
+  if (!result.passed) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((e) => {
+  console.error('[dynasty-soak] fatal:', e);
+  process.exitCode = 1;
+});

--- a/src/core/dynastySoakAudit.js
+++ b/src/core/dynastySoakAudit.js
@@ -1,0 +1,573 @@
+/**
+ * Dynasty soak / balance audit V1 — pure integrity checks on snapshots from the worker.
+ * No I/O, no mutations to game state.
+ */
+
+import { rebuildRecordBookV1 } from './recordBookV1.js';
+import { syncHallOfFameAfterRecordBook } from './league-memory.js';
+import {
+  TRANSACTION_TIMELINE_SCHEMA_VERSION,
+  normalizeRawTransaction,
+} from './transactionTimeline.js';
+import {
+  indexDraftClassesFromTransactions,
+  buildDraftClassModel,
+} from './draftClassHistory.js';
+import { buildAiTeamStrategy } from './aiTeamStrategy.js';
+import { buildPlayerDevelopmentModel } from './playerDevelopmentModel.js';
+import { buildProspectScoutingReport } from './scoutingModel.js';
+import {
+  defensiveIntsFromTotalsForArchive,
+  passIntsThrownFromTotals,
+  PLAYER_SEASON_STATS_ARCHIVE_SCHEMA_VERSION,
+} from './playerSeasonStatsArchive.js';
+
+/** Broad stat leader bounds (regular NFL-ish full season); outside = warning only */
+export const STAT_LEADER_WARN = {
+  passYds: { min: 800, max: 6200 },
+  rushYds: { min: 150, max: 2800 },
+  recYds: { min: 200, max: 3200 },
+  sacks: { min: 0, max: 40 },
+  tackles: { min: 0, max: 220 },
+};
+
+const ROSTER_WARN_MIN = 40;
+const DEPTH_WARN = { OL: 4, WR: 3, CB: 3, DL: 3 };
+
+function num(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : NaN;
+}
+
+function isBadNum(v) {
+  return !Number.isFinite(v) || Number.isNaN(v) || v === Infinity || v === -Infinity;
+}
+
+function emptySummary() {
+  return {
+    rosterHealth: 'ok',
+    capHealth: 'ok',
+    statHealth: 'ok',
+    archiveHealth: 'ok',
+    aiHealth: 'ok',
+    transactionHealth: 'ok',
+    draftHealth: 'ok',
+    scoutingHealth: 'ok',
+    developmentHealth: 'ok',
+    historyHealth: 'ok',
+  };
+}
+
+function bumpSummary(summary, key, level) {
+  const order = { ok: 0, warn: 1, fail: 2 };
+  const cur = summary[key] || 'ok';
+  if (order[level] > order[cur]) summary[key] = level;
+}
+
+/**
+ * Validate compact playerSeasonStatsV1 archive shape (rows + schemaVersion).
+ * @param {unknown} block
+ * @returns {{ ok: boolean, errors: string[] }}
+ */
+export function validatePlayerSeasonStatsV1Shape(block) {
+  const errors = [];
+  if (block == null) return { ok: true, errors: [] };
+  if (typeof block !== 'object') {
+    errors.push('playerSeasonStatsV1 must be an object');
+    return { ok: false, errors };
+  }
+  const sv = block.schemaVersion;
+  if (sv != null && Number(sv) !== PLAYER_SEASON_STATS_ARCHIVE_SCHEMA_VERSION) {
+    errors.push(`unexpected playerSeasonStatsV1.schemaVersion: ${sv}`);
+  }
+  const rows = block.rows;
+  if (!Array.isArray(rows)) {
+    errors.push('playerSeasonStatsV1.rows must be an array');
+    return { ok: false, errors };
+  }
+  for (let i = 0; i < Math.min(rows.length, 5000); i += 1) {
+    const r = rows[i];
+    if (!r || typeof r !== 'object') {
+      errors.push(`row ${i} not an object`);
+      continue;
+    }
+    if (r.playerId == null && r.id == null) errors.push(`row ${i} missing playerId`);
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+/**
+ * Validate transactionTimelineV1 compact archive shape.
+ * @param {unknown} block
+ * @returns {{ ok: boolean, errors: string[] }}
+ */
+export function validateTransactionTimelineV1Shape(block) {
+  const errors = [];
+  if (block == null) return { ok: true, errors: [] };
+  if (typeof block !== 'object') {
+    errors.push('transactionTimelineV1 must be an object');
+    return { ok: false, errors };
+  }
+  const sv = block.schemaVersion;
+  if (sv != null && Number(sv) !== TRANSACTION_TIMELINE_SCHEMA_VERSION) {
+    errors.push(`unexpected transactionTimelineV1.schemaVersion: ${sv}`);
+  }
+  const rows = block.rows;
+  if (!Array.isArray(rows)) {
+    errors.push('transactionTimelineV1.rows must be an array');
+    return { ok: false, errors };
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+function countByPos(roster) {
+  const m = {};
+  for (const p of roster || []) {
+    const pos = String(p?.pos ?? p?.position ?? '').toUpperCase();
+    if (!pos) continue;
+    m[pos] = (m[pos] || 0) + 1;
+  }
+  const ol = (m.OL || 0) + (m.OT || 0) + (m.OG || 0) + (m.C || 0) + (m.G || 0) + (m.T || 0);
+  const dl = (m.DL || 0) + (m.DE || 0) + (m.DT || 0) + (m.EDGE || 0) + (m.NT || 0);
+  return { ...m, OL: ol, DL: dl };
+}
+
+function collectAllPlayers(viewState) {
+  const teams = Array.isArray(viewState?.teams) ? viewState.teams : [];
+  const out = [];
+  for (const t of teams) {
+    for (const p of t?.roster || []) {
+      if (p && typeof p === 'object') out.push({ ...p, teamId: p.teamId ?? t.id });
+    }
+  }
+  return out;
+}
+
+function latestCompletedSeasonSummary(leagueHistory) {
+  const h = Array.isArray(leagueHistory) ? leagueHistory : [];
+  if (!h.length) return null;
+  return h[h.length - 1] || null;
+}
+
+/**
+ * @param {object} input
+ * @param {object} input.viewState — worker FULL_STATE / buildViewState shape
+ * @param {number} [input.seasonIndex] — 1-based season completed count (for warnings)
+ * @param {object[]} [input.allSeasons] — GET_ALL_SEASONS.seasons
+ * @param {object|null} [input.seasonHistory] — GET_SEASON_HISTORY.data for one season
+ * @param {object[]} [input.transactions] — GET_TRANSACTIONS.transactions strip
+ * @param {object|null} [input.recordsPayload] — GET_RECORDS { records, recordBook }
+ * @param {object|null} [input.hofPayload] — GET_HALL_OF_FAME { players, classes }
+ * @param {object|null} [input.draftClassesPayload] — GET_DRAFT_CLASSES { classes }
+ */
+export function runDynastySoakAudit(input = {}) {
+  const viewState = input.viewState ?? {};
+  const seasonIndex = Number(input.seasonIndex) || 0;
+  const checks = [];
+  const failures = [];
+  const warnings = [];
+  const summary = emptySummary();
+
+  const fail = (code, message, detail = null) => {
+    failures.push({ code, message, detail });
+    checks.push({ severity: 'failure', code, message, detail });
+  };
+  const warn = (code, message, detail = null) => {
+    warnings.push({ code, message, detail });
+    checks.push({ severity: 'warning', code, message, detail });
+  };
+
+  const metaPhase = String(viewState?.phase ?? '');
+  const year = num(viewState?.year);
+  const userTeamId = viewState?.userTeamId;
+  const teams = Array.isArray(viewState?.teams) ? viewState.teams : [];
+  const schedule = viewState?.schedule;
+  const standings = Array.isArray(viewState?.standings) ? viewState.standings : [];
+  const leagueHistory = viewState?.leagueHistory ?? [];
+
+  // --- Phase / user / schedule ---
+  if (userTeamId == null || userTeamId === '') {
+    fail('user_team_missing', 'userTeamId is missing from view state');
+    bumpSummary(summary, 'historyHealth', 'fail');
+  } else {
+    const ut = teams.find((t) => Number(t?.id) === Number(userTeamId));
+    if (!ut) {
+      fail('user_team_not_found', 'User team id not found in teams list');
+      bumpSummary(summary, 'rosterHealth', 'fail');
+    }
+  }
+
+  if (['regular', 'playoffs'].includes(metaPhase)) {
+    if (!schedule?.weeks?.length) {
+      fail('schedule_missing', `No schedule weeks while phase=${metaPhase}`);
+      bumpSummary(summary, 'historyHealth', 'fail');
+    }
+    if (metaPhase === 'regular' && standings.length === 0) {
+      fail('standings_empty', 'Standings empty during regular season');
+      bumpSummary(summary, 'historyHealth', 'fail');
+    }
+  }
+
+  // --- Roster / cap / AI strategy ---
+  let teamsWithoutQb = 0;
+  const archetypes = [];
+  for (const team of teams) {
+    const tid = team?.id;
+    const roster = Array.isArray(team?.roster) ? team.roster : [];
+    const n = roster.length;
+    if (n === 0) {
+      fail('roster_empty', `Team ${tid} has an empty roster`, { teamId: tid });
+      bumpSummary(summary, 'rosterHealth', 'fail');
+    } else if (n < ROSTER_WARN_MIN) {
+      warn('roster_thin', `Team ${tid} roster count ${n} below comfort threshold ${ROSTER_WARN_MIN}`, { teamId: tid });
+      bumpSummary(summary, 'rosterHealth', 'warn');
+    }
+
+    const counts = countByPos(roster);
+    if (!counts.QB) teamsWithoutQb += 1;
+
+    for (const [label, need] of Object.entries(DEPTH_WARN)) {
+      const c = counts[label] ?? 0;
+      if (c < need) {
+        warn(`depth_${label.toLowerCase()}`, `Team ${tid} has ${c} ${label} (warn if < ${need})`, { teamId: tid });
+        bumpSummary(summary, 'rosterHealth', 'warn');
+      }
+    }
+
+    const capUsed = num(team?.capUsed);
+    const capTotal = num(team?.capTotal);
+    const capRoom = num(team?.capRoom);
+    if (isBadNum(capUsed) || isBadNum(capTotal) || isBadNum(capRoom)) {
+      fail('cap_nan', `Team ${tid} has non-finite cap fields`, { teamId: tid, capUsed, capTotal, capRoom });
+      bumpSummary(summary, 'capHealth', 'fail');
+    } else if (capTotal > 0 && capUsed > capTotal * 1.2) {
+      fail('cap_impossible', `Team ${tid} capUsed exceeds 120% of capTotal`, { teamId: tid });
+      bumpSummary(summary, 'capHealth', 'fail');
+    } else if (capTotal > 0 && capUsed > capTotal * 1.02) {
+      warn('cap_stressed', `Team ${tid} capUsed > 102% capTotal`, { teamId: tid });
+      bumpSummary(summary, 'capHealth', 'warn');
+    }
+
+    const pf = num(team?.ptsFor);
+    const pa = num(team?.ptsAgainst);
+    if (isBadNum(pf) || isBadNum(pa)) {
+      fail('team_points_nan', `Team ${tid} non-finite ptsFor/ptsAgainst`, { teamId: tid, pf, pa });
+      bumpSummary(summary, 'statHealth', 'fail');
+    }
+
+    try {
+      const strategy = buildAiTeamStrategy({
+        team: {
+          id: team.id,
+          abbr: team.abbr,
+          wins: team.wins ?? 0,
+          losses: team.losses ?? 0,
+          capRoom: team.capRoom ?? 0,
+          capUsed: team.capUsed ?? 0,
+          deadCap: team.deadCap ?? 0,
+          picks: team.picks ?? [],
+        },
+        roster: roster.map((p) => ({
+          id: p.id,
+          pos: p.pos,
+          age: p.age,
+          ovr: p.ovr,
+          potential: p.potential,
+          contract: p.contract ?? {
+            years: p.yearsRemaining ?? p.yearsTotal,
+            yearsRemaining: p.yearsRemaining ?? p.yearsTotal,
+            baseAnnual: p.baseAnnual,
+          },
+        })),
+        league: { year: viewState?.year ?? 2025, phase: metaPhase },
+      });
+      if (!strategy?.archetype) {
+        fail('ai_strategy_shape', `Team ${tid} strategy missing archetype`, { teamId: tid });
+        bumpSummary(summary, 'aiHealth', 'fail');
+      }
+      if (!Number.isFinite(strategy?.capHealth)) {
+        fail('ai_strategy_cap_health', `Team ${tid} strategy.capHealth not finite`, { teamId: tid });
+        bumpSummary(summary, 'aiHealth', 'fail');
+      }
+      archetypes.push(String(strategy.archetype));
+    } catch (e) {
+      fail('ai_strategy_throw', `buildAiTeamStrategy threw for team ${tid}: ${e?.message}`, { teamId: tid });
+      bumpSummary(summary, 'aiHealth', 'fail');
+    }
+  }
+
+  if (teamsWithoutQb >= 2) {
+    fail('multi_team_no_qb', `${teamsWithoutQb} teams lack a QB`);
+    bumpSummary(summary, 'rosterHealth', 'fail');
+  } else if (teamsWithoutQb === 1) {
+    warn('one_team_no_qb', 'One team has no QB on roster');
+    bumpSummary(summary, 'rosterHealth', 'warn');
+  }
+
+  if (archetypes.length >= 8) {
+    const dist = {};
+    for (const a of archetypes) dist[a] = (dist[a] || 0) + 1;
+    const maxShare = Math.max(...Object.values(dist)) / archetypes.length;
+    if (maxShare > 0.75) {
+      warn('ai_archetype_cluster', `Archetype distribution skewed: ${JSON.stringify(dist)}`);
+      bumpSummary(summary, 'aiHealth', 'warn');
+    }
+  }
+
+  // --- League history / champion ---
+  const latest = latestCompletedSeasonSummary(leagueHistory);
+  if (latest && seasonIndex > 0) {
+    if (!latest.champion && (latest.standings?.length ?? 0) > 0) {
+      fail('champion_missing', 'Latest leagueHistory entry has standings but no champion', { seasonId: latest.seasonId });
+      bumpSummary(summary, 'historyHealth', 'fail');
+    }
+    const v1 = validatePlayerSeasonStatsV1Shape(latest.playerSeasonStatsV1);
+    if (!v1.ok) {
+      for (const e of v1.errors) fail('player_season_stats_shape', e);
+      if (v1.errors.length) bumpSummary(summary, 'archiveHealth', 'fail');
+    }
+    const tv = validateTransactionTimelineV1Shape(latest.transactionTimelineV1);
+    if (!tv.ok) {
+      for (const e of tv.errors) fail('transaction_timeline_shape', e);
+      if (tv.errors.length) bumpSummary(summary, 'archiveHealth', 'fail');
+    }
+    if (Array.isArray(latest.playerSeasonStatsV1?.rows)) {
+      for (const row of latest.playerSeasonStatsV1.rows.slice(0, 2000)) {
+        const pos = row?.pos;
+        const totals = row?.totals && typeof row.totals === 'object' ? row.totals : {};
+        const defInt = defensiveIntsFromTotalsForArchive(pos, totals);
+        const qbInt = passIntsThrownFromTotals(pos, totals);
+        if (String(pos).toUpperCase() === 'QB' && qbInt > 40 && defInt > 40) {
+          warn('qb_int_def_int_sanity', 'Unusually high QB pass INT and defensive INT columns on same row', { playerId: row.playerId });
+          bumpSummary(summary, 'statHealth', 'warn');
+        }
+      }
+    }
+  }
+
+  if (seasonIndex >= 1 && leagueHistory.length === 0) {
+    warn('league_history_empty', 'Expected leagueHistory to grow after completed seasons');
+    bumpSummary(summary, 'historyHealth', 'warn');
+  }
+
+  // --- Stat leaders (warnings) from latest archive ---
+  if (latest?.playerStatLeaders && typeof latest.playerStatLeaders === 'object') {
+    const pl = latest.playerStatLeaders;
+    const passYds = num(pl.passingYards?.value ?? pl.passingYards);
+    if (Number.isFinite(passYds)) {
+      if (passYds < STAT_LEADER_WARN.passYds.min || passYds > STAT_LEADER_WARN.passYds.max) {
+        warn('leader_pass_yds_outlier', `Passing yards leader ${passYds}`);
+        bumpSummary(summary, 'statHealth', 'warn');
+      }
+    }
+    const rushYds = num(pl.rushingYards?.value ?? pl.rushingYards);
+    if (Number.isFinite(rushYds)) {
+      if (rushYds < STAT_LEADER_WARN.rushYds.min || rushYds > STAT_LEADER_WARN.rushYds.max) {
+        warn('leader_rush_yds_outlier', `Rushing yards leader ${rushYds}`);
+        bumpSummary(summary, 'statHealth', 'warn');
+      }
+    }
+    const recYds = num(pl.receivingYards?.value ?? pl.receivingYards);
+    if (Number.isFinite(recYds)) {
+      if (recYds < STAT_LEADER_WARN.recYds.min || recYds > STAT_LEADER_WARN.recYds.max) {
+        warn('leader_rec_yds_outlier', `Receiving yards leader ${recYds}`);
+        bumpSummary(summary, 'statHealth', 'warn');
+      }
+    }
+  }
+
+  // --- Record book rebuild ---
+  const allPlayers = collectAllPlayers(viewState);
+  try {
+    rebuildRecordBookV1({
+      leagueHistory,
+      players: allPlayers,
+      previousRecordBook: viewState?.recordBook ?? null,
+    });
+  } catch (e) {
+    fail('record_book_rebuild_throw', e?.message || String(e));
+    bumpSummary(summary, 'archiveHealth', 'fail');
+  }
+
+  // --- HOF sync safety (dry run on cloned meta) ---
+  try {
+    const memoryMeta = {
+      leagueHistory,
+      recordBook: viewState?.recordBook ?? {},
+      hallOfFame: { classes: viewState?.hallOfFameClasses ?? [], index: {}, schemaVersion: 1 },
+    };
+    syncHallOfFameAfterRecordBook(memoryMeta, allPlayers, year, { teams });
+  } catch (e) {
+    fail('hof_sync_throw', e?.message || String(e));
+    bumpSummary(summary, 'archiveHealth', 'fail');
+  }
+
+  if (seasonIndex <= 2 && (!viewState?.hallOfFameClasses || viewState.hallOfFameClasses.length === 0)) {
+    warn('hof_empty_young', 'Hall of Fame classes empty in early league years');
+    bumpSummary(summary, 'archiveHealth', 'warn');
+  }
+
+  // --- allSeasons growth ---
+  const allSeasons = Array.isArray(input.allSeasons) ? input.allSeasons : null;
+  if (allSeasons && seasonIndex > 0 && allSeasons.length < seasonIndex) {
+    warn('all_seasons_short', `allSeasons length ${allSeasons.length} < seasonIndex ${seasonIndex}`);
+    bumpSummary(summary, 'archiveHealth', 'warn');
+  }
+
+  // --- seasonHistory sample ---
+  if (input.seasonHistory && typeof input.seasonHistory === 'object') {
+    const sh = validatePlayerSeasonStatsV1Shape(input.seasonHistory.playerSeasonStatsV1);
+    if (!sh.ok) {
+      for (const e of sh.errors) fail('season_history_stats_shape', e);
+      bumpSummary(summary, 'archiveHealth', 'fail');
+    }
+  }
+
+  // --- Transactions + draft class memory ---
+  const rawTx = Array.isArray(input.transactions) ? input.transactions : [];
+  if (seasonIndex >= 2 && rawTx.length < 3) {
+    warn('transactions_sparse', `Very few transactions (${rawTx.length}) after ${seasonIndex} seasons`);
+    bumpSummary(summary, 'transactionHealth', 'warn');
+  }
+
+  try {
+    const ctxNorm = {
+      teams,
+      teamsById: new Map(teams.map((t) => [Number(t.id), t])),
+      players: allPlayers,
+      playersById: new Map(allPlayers.map((p) => [Number(p.id), p])),
+      year,
+      phase: metaPhase,
+    };
+    for (const tx of rawTx.slice(0, 3000)) {
+      try {
+        normalizeRawTransaction(tx, ctxNorm);
+      } catch (e) {
+        fail('normalize_transaction_throw', e?.message || String(e));
+        bumpSummary(summary, 'transactionHealth', 'fail');
+      }
+    }
+    const draftTxs = rawTx.filter((t) => String(t?.type ?? '').toUpperCase() === 'DRAFT');
+    const indexed = indexDraftClassesFromTransactions(rawTx, leagueHistory);
+    const playersById = new Map(allPlayers.map((p) => [num(p.id), p]));
+    for (const entry of indexed.slice(0, 10)) {
+      const sid = entry.seasonId;
+      const seasonYear = num(entry.year) || year;
+      const seasonDraftTxs = draftTxs.filter((t) => String(t?.seasonId ?? '') === String(sid));
+      const model = buildDraftClassModel({
+        year: seasonYear,
+        seasonId: sid,
+        draftTransactions: seasonDraftTxs,
+        playersById,
+        currentLeagueYear: year,
+        recordBook: viewState?.recordBook ?? null,
+        archivedSeasons: leagueHistory,
+        teams,
+      });
+      if (!model || typeof model !== 'object' || !Array.isArray(model.picks)) {
+        fail('draft_class_model_shape', `buildDraftClassModel invalid for ${sid}`);
+        bumpSummary(summary, 'draftHealth', 'fail');
+      }
+    }
+    if (!indexed.length && seasonIndex >= 2 && draftTxs.length === 0) {
+      warn('draft_class_index_empty', 'No DRAFT transactions found after multiple seasons');
+      bumpSummary(summary, 'draftHealth', 'warn');
+    }
+  } catch (e) {
+    fail('draft_index_throw', e?.message || String(e));
+    bumpSummary(summary, 'draftHealth', 'fail');
+  }
+
+  const draftClasses = input.draftClassesPayload?.classes;
+  if (Array.isArray(draftClasses) && seasonIndex >= 2 && draftClasses.length === 0) {
+    warn('draft_classes_empty', 'GET_DRAFT_CLASSES returned no seasons after multiple sims');
+    bumpSummary(summary, 'draftHealth', 'warn');
+  }
+
+  // --- GET payloads ---
+  if (input.recordsPayload?.recordBook && isBadNum(num(input.recordsPayload.recordBook.schemaVersion))) {
+    warn('records_payload_shape', 'recordBook in RECORDS payload looks odd');
+    bumpSummary(summary, 'archiveHealth', 'warn');
+  }
+  if (input.hofPayload && !Array.isArray(input.hofPayload.players)) {
+    fail('hof_payload_shape', 'HALL_OF_FAME.players must be an array when present');
+    bumpSummary(summary, 'archiveHealth', 'fail');
+  }
+
+  // --- Scouting / development (sample, mutation check) ---
+  const samplePlayers = allPlayers.slice(0, 25);
+  for (const p of samplePlayers) {
+    const snap = JSON.stringify({ ovr: p.ovr, age: p.age, pos: p.pos });
+    try {
+      buildPlayerDevelopmentModel(p, { team: teams.find((t) => Number(t.id) === Number(p.teamId)) });
+    } catch (e) {
+      fail('dev_model_throw', `buildPlayerDevelopmentModel: ${e?.message}`, { playerId: p.id });
+      bumpSummary(summary, 'developmentHealth', 'fail');
+    }
+    if (JSON.stringify({ ovr: p.ovr, age: p.age, pos: p.pos }) !== snap) {
+      fail('dev_model_mutated', 'buildPlayerDevelopmentModel mutated player fields', { playerId: p.id });
+      bumpSummary(summary, 'developmentHealth', 'fail');
+    }
+  }
+
+  const sparseProspect = {
+    id: 'audit-sparse',
+    pos: 'WR',
+    name: 'Sparse',
+    combineResults: {},
+    interviewReport: {},
+  };
+  try {
+    const rep = buildProspectScoutingReport(sparseProspect, {});
+    if (rep?.confidence === 'high') {
+      warn('scouting_sparse_confidence', 'Sparse prospect returned high confidence');
+      bumpSummary(summary, 'scoutingHealth', 'warn');
+    }
+  } catch (e) {
+    fail('scouting_throw', e?.message || String(e));
+    bumpSummary(summary, 'scoutingHealth', 'fail');
+  }
+
+  for (const p of allPlayers.slice(0, 8)) {
+    if (String(p?.pos).toUpperCase() !== 'QB') continue;
+    const prospectLike = {
+      id: p.id,
+      pos: p.pos,
+      name: p.name,
+      ovr: num(p.ovr),
+      potential: num(p.potential),
+      combineResults: {},
+      interviewReport: {},
+    };
+    const snap = JSON.stringify({ ovr: p.ovr, potential: p.potential });
+    try {
+      buildProspectScoutingReport(prospectLike, {});
+    } catch (e) {
+      fail('scouting_prospect_throw', e?.message || String(e));
+      bumpSummary(summary, 'scoutingHealth', 'fail');
+    }
+    if (JSON.stringify({ ovr: p.ovr, potential: p.potential }) !== snap) {
+      fail('scouting_mutated', 'buildProspectScoutingReport mutated prospect fields', { playerId: p.id });
+      bumpSummary(summary, 'scoutingHealth', 'fail');
+    }
+  }
+
+  const passed = failures.length === 0;
+  const severity = failures.some((f) => /throw|crash|missing|nan|empty roster|impossible/i.test(f.code))
+    ? 'error'
+    : failures.length
+      ? 'error'
+      : warnings.length
+        ? 'warn'
+        : 'ok';
+
+  return {
+    passed,
+    severity,
+    seasonsSimmed: seasonIndex,
+    checks,
+    warnings,
+    failures,
+    summary,
+  };
+}

--- a/src/testSupport/dynastySoakRunner.js
+++ b/src/testSupport/dynastySoakRunner.js
@@ -1,0 +1,309 @@
+/**
+ * Dynasty soak runner — loads fake IndexedDB + worker in Node.
+ * Must import `fake-indexeddb/auto` before this module (this file does not import it
+ * so Vitest can register IDB in a setup file if needed). The CLI imports IDB first.
+ */
+
+import { toWorker, toUI } from '../worker/protocol.js';
+import { runDynastySoakAudit } from '../core/dynastySoakAudit.js';
+
+const RESPONSE_BY_REQUEST = {
+  [toWorker.INIT]: [toUI.READY, toUI.ERROR],
+  [toWorker.USE_SAFE_STARTER_LEAGUE]: [toUI.FULL_STATE, toUI.ERROR],
+  [toWorker.SIM_TO_PHASE]: [toUI.FULL_STATE, toUI.ERROR],
+  [toWorker.ADVANCE_WEEK]: [toUI.WEEK_COMPLETE, toUI.ERROR, toUI.FULL_STATE],
+  [toWorker.GET_ALL_SEASONS]: [toUI.ALL_SEASONS, toUI.ERROR],
+  [toWorker.GET_TRANSACTIONS]: [toUI.TRANSACTIONS, toUI.ERROR],
+  [toWorker.GET_RECORDS]: [toUI.RECORDS, toUI.ERROR],
+  [toWorker.GET_HALL_OF_FAME]: [toUI.HALL_OF_FAME, toUI.ERROR],
+  [toWorker.GET_DRAFT_CLASSES]: [toUI.DRAFT_CLASSES, toUI.ERROR],
+  [toWorker.GET_SEASON_HISTORY]: [toUI.SEASON_HISTORY, toUI.ERROR],
+};
+
+/** @type {Map<string, { resolve: Function, reject: Function, accept: Set<string>, timer: ReturnType<typeof setTimeout> }>} */
+const waiters = new Map();
+
+let msgSeq = 0;
+function nextId() {
+  msgSeq += 1;
+  return `dynasty-soak-${msgSeq}`;
+}
+
+function ensureSelfBridge() {
+  if (globalThis.self?.postMessage && typeof globalThis.self.onmessage === 'function') return;
+
+  const bridge = {
+    onmessage: null,
+    postMessage(msg) {
+      const { type, payload, id } = msg || {};
+      if (id && waiters.has(id)) {
+        const w = waiters.get(id);
+        if (type === toUI.ERROR) {
+          clearTimeout(w.timer);
+          waiters.delete(id);
+          w.reject(new Error(payload?.message || 'Worker ERROR'));
+          return;
+        }
+        if (w.accept.has(type)) {
+          clearTimeout(w.timer);
+          waiters.delete(id);
+          w.resolve({ type, payload, id });
+          return;
+        }
+      }
+      if (globalThis.__dynastySoakBroadcast) {
+        globalThis.__dynastySoakBroadcast({ type, payload, id });
+      }
+    },
+  };
+  globalThis.self = bridge;
+}
+
+/**
+ * @param {string} type - toWorker.*
+ * @param {object} payload
+ * @param {{ timeoutMs?: number }} [opts]
+ */
+export function dispatchWorker(type, payload = {}, opts = {}) {
+  ensureSelfBridge();
+  if (typeof globalThis.self.onmessage !== 'function') {
+    return Promise.reject(new Error('Worker onmessage not registered; import worker/worker.js first'));
+  }
+  const id = nextId();
+  const timeoutMs = opts.timeoutMs ?? 1_200_000;
+  const acceptList = RESPONSE_BY_REQUEST[type] || [toUI.FULL_STATE, toUI.ERROR];
+  const accept = new Set(acceptList);
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      if (waiters.has(id)) {
+        waiters.delete(id);
+        reject(new Error(`Timeout ${timeoutMs}ms waiting for ${type} response (id=${id})`));
+      }
+    }, timeoutMs);
+    waiters.set(id, { resolve, reject, accept, timer });
+    queueMicrotask(() => {
+      try {
+        globalThis.self.onmessage({ data: { type, payload, id } });
+      } catch (e) {
+        clearTimeout(timer);
+        waiters.delete(id);
+        reject(e);
+      }
+    });
+  });
+}
+
+let workerImportPromise = null;
+
+export function loadWorkerModule() {
+  if (!workerImportPromise) {
+    ensureSelfBridge();
+    workerImportPromise = import('../worker/worker.js');
+  }
+  return workerImportPromise;
+}
+
+function mergeAudit(into, next, seasonLabel) {
+  const prefix = `[${seasonLabel}]`;
+  for (const f of next.failures || []) {
+    into.failures.push({ ...f, message: `${prefix} ${f.message}`, code: f.code });
+  }
+  for (const w of next.warnings || []) {
+    into.warnings.push({ ...w, message: `${prefix} ${w.message}`, code: w.code });
+  }
+  for (const c of next.checks || []) {
+    into.checks.push({ ...c, message: `${prefix} ${c.message}` });
+  }
+  const ord = { ok: 0, warn: 1, fail: 2 };
+  const nextSum = next.summary && typeof next.summary === 'object' ? next.summary : {};
+  for (const key of Object.keys(into.summary)) {
+    const a = into.summary[key];
+    const b = nextSum[key] ?? 'ok';
+    if (ord[b] > ord[a]) into.summary[key] = b;
+  }
+  into.passed = into.passed && next.passed;
+  into.seasonsSimmed = Math.max(into.seasonsSimmed || 0, next.seasonsSimmed || 0);
+}
+
+/**
+ * @param {object} opts
+ * @param {number} [opts.seasons=5]
+ * @param {number} [opts.seed=1383]
+ * @param {number} [opts.simTimeoutMs]
+ * @param {function} [opts.onBroadcast]
+ */
+/**
+ * `SIM_TO_PHASE` may stop before `preseason` when the worker hits its per-call
+ * iteration guard mid-pipeline; repeat until preseason or hard cap.
+ */
+async function simUntilPreseason(simTimeoutMs) {
+  let lastMsg = null;
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    lastMsg = await dispatchWorker(
+      toWorker.SIM_TO_PHASE,
+      { targetPhase: 'preseason' },
+      { timeoutMs: simTimeoutMs },
+    );
+    if (lastMsg.type === toUI.ERROR) return lastMsg;
+    const ph = String(lastMsg.payload?.phase ?? '');
+    if (ph === 'preseason') return lastMsg;
+  }
+  return lastMsg;
+}
+
+export async function runDynastySoakOnce(opts = {}) {
+  const seasons = Math.max(1, Math.min(50, Number(opts.seasons) || 5));
+  const seed = Number.isFinite(Number(opts.seed)) ? Number(opts.seed) : 1383;
+  const simTimeoutMs = opts.simTimeoutMs ?? 3_600_000;
+
+  globalThis.__dynastySoakBroadcast = opts.onBroadcast || null;
+  /** @see persistSimSession in worker — avoids hundreds of IndexedDB flushes per batch sim */
+  globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__ = true;
+
+  const t0 = Date.now();
+  try {
+  await loadWorkerModule();
+
+  await dispatchWorker(toWorker.INIT, {}, { timeoutMs: 120_000 });
+
+  const bootMsg = await dispatchWorker(
+    toWorker.USE_SAFE_STARTER_LEAGUE,
+    {
+      slotKey: 'save_slot_1',
+      options: { rngSeed: seed, userTeamId: 0, name: `Dynasty Soak ${seed}` },
+    },
+    { timeoutMs: 180_000 },
+  );
+  if (bootMsg.type === toUI.ERROR) {
+    throw new Error(bootMsg.payload?.message || 'USE_SAFE_STARTER_LEAGUE failed');
+  }
+  /** @type {any} */
+  let view = bootMsg.payload;
+
+  const aggregate = {
+    passed: true,
+    severity: 'ok',
+    seasonsSimmed: 0,
+    checks: [],
+    warnings: [],
+    failures: [],
+    summary: {
+      rosterHealth: 'ok',
+      capHealth: 'ok',
+      statHealth: 'ok',
+      archiveHealth: 'ok',
+      aiHealth: 'ok',
+      transactionHealth: 'ok',
+      draftHealth: 'ok',
+      scoutingHealth: 'ok',
+      developmentHealth: 'ok',
+      historyHealth: 'ok',
+    },
+  };
+
+  for (let s = 1; s <= seasons; s += 1) {
+    const yearBefore = Number(view?.year ?? 0);
+    const phaseBefore = String(view?.phase ?? '');
+
+    const simMsg = await simUntilPreseason(simTimeoutMs);
+    if (simMsg.type === toUI.ERROR) {
+      mergeAudit(aggregate, {
+        passed: false,
+        severity: 'error',
+        seasonsSimmed: s,
+        checks: [],
+        warnings: [],
+        failures: [{ code: 'sim_error', message: simMsg.payload?.message || 'SIM_TO_PHASE error' }],
+        summary: aggregate.summary,
+      }, `S${s}`);
+      break;
+    }
+    view = simMsg.payload;
+    const yearAfter = Number(view?.year ?? 0);
+    const phaseAfter = String(view?.phase ?? '');
+    if (phaseAfter !== 'preseason') {
+      mergeAudit(aggregate, {
+        passed: false,
+        severity: 'error',
+        seasonsSimmed: s,
+        checks: [],
+        warnings: [],
+        failures: [{
+          code: 'phase_not_preseason',
+          message: `Expected preseason after sim; got ${phaseAfter} (was ${phaseBefore})`,
+        }],
+        summary: aggregate.summary,
+      }, `S${s}`);
+      aggregate.passed = false;
+      break;
+    }
+    if (yearAfter <= yearBefore) {
+      mergeAudit(aggregate, {
+        passed: false,
+        severity: 'error',
+        seasonsSimmed: s,
+        checks: [],
+        warnings: [],
+        failures: [{
+          code: 'year_stuck',
+          message: `Year did not advance (${yearBefore} -> ${yearAfter}); possible sim stall`,
+        }],
+        summary: aggregate.summary,
+      }, `S${s}`);
+      aggregate.passed = false;
+      break;
+    }
+
+    const allSeasonsMsg = await dispatchWorker(toWorker.GET_ALL_SEASONS, {}, { timeoutMs: 120_000 });
+    const txMsg = await dispatchWorker(toWorker.GET_TRANSACTIONS, { mode: 'recent', limit: 400 }, { timeoutMs: 120_000 });
+    const txSeasonMsg = await dispatchWorker(
+      toWorker.GET_TRANSACTIONS,
+      { seasonId: view?.seasonId, limit: 200 },
+      { timeoutMs: 120_000 },
+    );
+    const recordsMsg = await dispatchWorker(toWorker.GET_RECORDS, {}, { timeoutMs: 120_000 });
+    const hofMsg = await dispatchWorker(toWorker.GET_HALL_OF_FAME, {}, { timeoutMs: 120_000 });
+    const draftClassesMsg = await dispatchWorker(toWorker.GET_DRAFT_CLASSES, {}, { timeoutMs: 120_000 });
+
+    const leagueHistory = view?.leagueHistory ?? [];
+    const latestSeason = leagueHistory.length ? leagueHistory[leagueHistory.length - 1] : null;
+    let seasonHistory = null;
+    if (latestSeason?.id) {
+      const histMsg = await dispatchWorker(toWorker.GET_SEASON_HISTORY, { seasonId: latestSeason.id }, { timeoutMs: 120_000 });
+      if (histMsg.type !== toUI.ERROR) {
+        seasonHistory = histMsg.payload?.data ?? null;
+      }
+    }
+
+    const audit = runDynastySoakAudit({
+      viewState: view,
+      seasonIndex: s,
+      allSeasons: allSeasonsMsg.payload?.seasons ?? null,
+      seasonHistory,
+      transactions: txMsg.payload?.transactions ?? [],
+      recordsPayload: recordsMsg.payload ?? null,
+      hofPayload: hofMsg.payload ?? null,
+      draftClassesPayload: draftClassesMsg.payload ?? null,
+    });
+
+    /* cross-check second transaction query did not throw */
+    if (txSeasonMsg.type === toUI.ERROR) {
+      audit.failures.push({ code: 'get_transactions_season', message: txSeasonMsg.payload?.message || 'GET_TRANSACTIONS by season failed' });
+      audit.passed = false;
+    }
+
+    mergeAudit(aggregate, audit, `S${s}`);
+
+    await dispatchWorker(toWorker.ADVANCE_WEEK, { skipUserGame: true }, { timeoutMs: 120_000 });
+  }
+
+  aggregate.severity = aggregate.failures.length ? 'error' : aggregate.warnings.length ? 'warn' : 'ok';
+  aggregate.runtimeMs = Date.now() - t0;
+  aggregate.seed = seed;
+  aggregate.finalView = view;
+  return aggregate;
+  } finally {
+    globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__ = false;
+  }
+}

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -126,7 +126,7 @@ import {
 } from '../core/draftClassHistory.js';
 import { rebuildRecordBookV1, mirrorRecordBookForLegacyUi, RECORD_BOOK_SCHEMA_VERSION } from '../core/recordBookV1.js';
 import { inferChampionshipOutcome, isCompletedGame, isPostseasonGame } from '../core/championshipInference.js';
-import { repairDepthChart, validateDepthChart, optimizeDepthChartForPlan } from "../core/roster/depthChartManager.js";
+import { repairDepthChart, validateDepthChart, optimizeDepthChartForPlan } from "../core/roster/depthChartManager.ts";
 import { ensureDynastyMeta, generateOwnerGoals, applyGameFanApproval, updateGoalsForWin } from '../core/dynasty-story.js';
 import { isValidSaveId, sanitizeSaveList } from './saveIntegrity.js';
 import { autoBuildDepthChart, applyDepthChartToPlayers } from '../core/depthChart.js';
@@ -1443,7 +1443,7 @@ async function createUniqueLeagueId() {
  *   "Failed to store record in an IDBObjectStore: Evaluating the object store's
  *    key path did not yield a value."
  */
-async function flushDirty() {
+async function flushDirty(forceFlush = false) {
   // PRIMARY iOS GUARD: Never flush until a save has been explicitly loaded or created.
   // This is the bootloader protection — the worker must never write an empty state.
   if (!_saveIsExplicitlyLoaded) {
@@ -1457,6 +1457,15 @@ async function flushDirty() {
   if (!cache.isLoaded()) {
       console.warn('[Worker] flushDirty called but cache is not loaded. Aborting DB write.');
       return;
+  }
+
+  // Node dynasty-soak harness: skip IndexedDB writes during long SIM_TO_PHASE batches, but
+  // still drain dirty flags so dirty tracking does not grow without bound (would slow to a crawl).
+  if (typeof globalThis !== 'undefined' && globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__ && !forceFlush) {
+    if (cache.isDirty()) {
+      cache.drainDirty();
+    }
+    return;
   }
 
   const dirty = cache.drainDirty();
@@ -1859,6 +1868,9 @@ async function handleNewLeague(payload, id) {
   try {
     const bootRequestId = payload?.options?.bootRequestId ?? null;
     const { teams: teamDefs, options = {} } = payload;
+    if (Number.isFinite(Number(options?.rngSeed))) {
+      Utils.setSeed(Number(options.rngSeed));
+    }
     const userTeamId = options.userTeamId ?? 0;
     const resolvedSettings = normalizeLeagueSettings({
       ...(options.settings ?? {}),
@@ -2108,6 +2120,9 @@ async function handleUseSafeStarterLeague(payload, id) {
   }
 
   try {
+    if (Number.isFinite(Number(payload?.options?.rngSeed))) {
+      Utils.setSeed(Number(payload.options.rngSeed));
+    }
     const safeLeague = buildDefaultLeague({
       userTeamId: payload?.options?.userTeamId,
       name: payload?.options?.name ?? `Safe Starter ${slotKey?.split('_')?.[2] ?? '1'}`,
@@ -3663,8 +3678,9 @@ async function handleSimToPhase({ targetPhase }, id) {
     return;
   }
 
-  // Safety: max iterations to prevent infinite loops
-  const MAX_ITERATIONS = 200;
+  // Safety: max iterations to prevent infinite loops (32-team full year + FA + draft
+  // can exceed 200 steps when each outer tick is one week/offseason day/draft episode).
+  const MAX_ITERATIONS = 800;
   let iterations = 0;
   batchSimControl = {
     running: true,
@@ -3690,6 +3706,9 @@ async function handleSimToPhase({ targetPhase }, id) {
           targetPhase,
           stage: currentMeta.phase,
         });
+        if (typeof globalThis !== 'undefined' && globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__) {
+          await flushDirty(true);
+        }
         post(toUI.FULL_STATE, buildViewState(), id);
         return;
       }
@@ -3747,6 +3766,9 @@ async function handleSimToPhase({ targetPhase }, id) {
             targetPhase,
             stage: 'draft',
           });
+          if (typeof globalThis !== 'undefined' && globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__) {
+            await flushDirty(true);
+          }
           post(toUI.FULL_STATE, buildViewState(), id);
           return;
         }
@@ -3769,6 +3791,9 @@ async function handleSimToPhase({ targetPhase }, id) {
       checkpoint: 'complete',
       lastError: null,
     });
+    if (typeof globalThis !== 'undefined' && globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__) {
+      await flushDirty(true);
+    }
     post(toUI.FULL_STATE, buildViewState(), id);
   } catch (error) {
     await persistSimSession({
@@ -3778,6 +3803,9 @@ async function handleSimToPhase({ targetPhase }, id) {
       checkpoint: 'error',
       lastError: error?.message ?? 'Unknown simulation error',
     });
+    if (typeof globalThis !== 'undefined' && globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__) {
+      await flushDirty(true);
+    }
     post(toUI.SIM_BATCH_STATUS, { status: 'failed', targetPhase, stage: cache.getMeta()?.phase ?? null });
     post(toUI.NOTIFICATION, { level: 'warn', message: `Simulation paused: ${error?.message ?? 'unknown error'}. You can retry or cancel.` });
     post(toUI.FULL_STATE, buildViewState(), id);

--- a/tests/e2e/phase_hydration_regression.spec.js
+++ b/tests/e2e/phase_hydration_regression.spec.js
@@ -37,7 +37,7 @@ test.describe('Phase hydration regression', () => {
     await page.waitForFunction(() => window?.state?.league?.phase === 'draft', { timeout: 120000 });
 
     await goToTab(page, 'draft');
-    await expect(page.getByTestId('draft-room-heading')).toBeVisible({ timeout: 45000 });
+    await expect(page.getByTestId('draft-room-heading')).toBeVisible({ timeout: 90000 });
     await expect(page.getByText(/Draft data is still initializing/i)).toHaveCount(0);
 
     await page.evaluate(() => window.gameController.simDraftPick());

--- a/tests/integration/dynastySoak.test.js
+++ b/tests/integration/dynastySoak.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { runDynastySoakAudit } from '../../src/core/dynastySoakAudit.js';
+
+/**
+ * Integration-style check without loading the game worker (full worker soak is
+ * `npm run audit:dynasty`, which can take a long time on a 32-team save).
+ */
+describe('dynasty soak integration (audit fixture)', () => {
+  it('passes audit on a compact multi-season-shaped snapshot', () => {
+    const viewState = {
+      phase: 'preseason',
+      year: 2030,
+      userTeamId: 0,
+      seasonId: 's5',
+      schedule: { weeks: [{ week: 1, games: [{ home: 0, away: 1 }] }] },
+      standings: [{ id: 0, wins: 9, losses: 7 }],
+      leagueHistory: [
+        {
+          id: 's4',
+          year: 2029,
+          champion: { id: 0, abbr: 'BUF' },
+          standings: [{ id: 0, wins: 11, losses: 5 }],
+          playerSeasonStatsV1: {
+            schemaVersion: 1,
+            rows: [
+              { playerId: 'qb1', pos: 'QB', totals: { passYds: 3800, passInts: 12, gamesPlayed: 16 } },
+            ],
+          },
+          transactionTimelineV1: {
+            schemaVersion: 1,
+            rows: [{ rawId: 10, type: 'draft', seasonId: 's4', teamId: 0 }],
+          },
+        },
+      ],
+      recordBook: { schemaVersion: 1 },
+      hallOfFameClasses: [],
+      teams: [
+        {
+          id: 0,
+          abbr: 'BUF',
+          wins: 12,
+          losses: 4,
+          ptsFor: 0,
+          ptsAgainst: 0,
+          capUsed: 180,
+          capRoom: 120,
+          capTotal: 301,
+          roster: Array.from({ length: 45 }).map((_, i) => ({
+            id: `pl${i}`,
+            pos: i === 0 ? 'QB' : i < 10 ? 'OL' : i < 18 ? 'WR' : i < 26 ? 'CB' : 'DL',
+            age: 24 + (i % 6),
+            ovr: 68 + (i % 8),
+            potential: 75,
+            contract: { yearsRemaining: 2, baseAnnual: 2 },
+          })),
+        },
+        {
+          id: 1,
+          abbr: 'MIA',
+          wins: 5,
+          losses: 11,
+          ptsFor: 0,
+          ptsAgainst: 0,
+          capUsed: 190,
+          capRoom: 110,
+          capTotal: 301,
+          roster: Array.from({ length: 45 }).map((_, i) => ({
+            id: `m${i}`,
+            pos: i === 0 ? 'QB' : 'RB',
+            age: 25,
+            ovr: 70,
+            potential: 76,
+            contract: { yearsRemaining: 2, baseAnnual: 2 },
+          })),
+        },
+      ],
+    };
+
+    const r = runDynastySoakAudit({
+      viewState,
+      seasonIndex: 3,
+      allSeasons: [{ id: 's4', year: 2029 }, { id: 's5', year: 2030 }],
+      transactions: [
+        { type: 'DRAFT', seasonId: 's4', teamId: 0, details: { playerId: 101, overall: 5, round: 1 } },
+        { type: 'RETIREMENT', seasonId: 's4', teamId: 0, details: { playerId: 99 } },
+      ],
+      recordsPayload: { records: {}, recordBook: { schemaVersion: 1 } },
+      hofPayload: { players: [], classes: [] },
+      draftClassesPayload: { classes: [{ seasonId: 's4', year: 2029, pickCount: 20, teamIds: [0, 1] }] },
+    });
+
+    expect(r.passed).toBe(true);
+    expect(['ok', 'warn']).toContain(r.severity);
+  });
+});

--- a/tests/unit/dynastySoakAudit.test.js
+++ b/tests/unit/dynastySoakAudit.test.js
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import {
+  runDynastySoakAudit,
+  validatePlayerSeasonStatsV1Shape,
+  validateTransactionTimelineV1Shape,
+  STAT_LEADER_WARN,
+} from '../../src/core/dynastySoakAudit.js';
+import { buildAiTeamStrategy } from '../../src/core/aiTeamStrategy.js';
+
+function baseView(overrides = {}) {
+  const mkRoster = (prefix, qbId) => {
+    const out = [
+      { id: qbId, pos: 'QB', age: 26, ovr: 78, potential: 82, contract: { yearsRemaining: 2, baseAnnual: 5 } },
+    ];
+    for (let i = 0; i < 44; i += 1) {
+      const pos = ['OL', 'WR', 'CB', 'DL', 'LB', 'S', 'TE', 'RB'][i % 8];
+      out.push({
+        id: `${prefix}${i}`,
+        pos,
+        age: 23 + (i % 8),
+        ovr: 68 + (i % 10),
+        potential: 75,
+        contract: { yearsRemaining: 2, baseAnnual: 2 },
+      });
+    }
+    return out;
+  };
+  const teams = [
+    {
+      id: 0,
+      abbr: 'AAA',
+      wins: 8,
+      losses: 8,
+      ptsFor: 300,
+      ptsAgainst: 280,
+      capUsed: 200,
+      capRoom: 100,
+      capTotal: 301,
+      roster: mkRoster('a', 'p1'),
+    },
+    {
+      id: 1,
+      abbr: 'BBB',
+      wins: 7,
+      losses: 9,
+      ptsFor: 280,
+      ptsAgainst: 300,
+      capUsed: 210,
+      capRoom: 90,
+      capTotal: 301,
+      roster: mkRoster('b', 'p8'),
+    },
+  ];
+  return {
+    phase: 'preseason',
+    year: 2028,
+    userTeamId: 0,
+    seasonId: 's3',
+    schedule: { weeks: [{ week: 1, games: [{ home: 0, away: 1 }] }] },
+    standings: [{ id: 0, wins: 8, losses: 8 }],
+    leagueHistory: [
+      {
+        id: 's2',
+        year: 2027,
+        champion: { id: 0, abbr: 'AAA' },
+        standings: [{ id: 0, wins: 10, losses: 6 }],
+        playerSeasonStatsV1: { schemaVersion: 1, rows: [{ playerId: 'p1', pos: 'QB', totals: { passYds: 4000, gamesPlayed: 16 } }] },
+        transactionTimelineV1: { schemaVersion: 1, rows: [{ rawId: 1, type: 'draft', seasonId: 's2' }] },
+        playerStatLeaders: {
+          passingYards: { value: 4000 },
+          rushingYards: { value: 900 },
+          receivingYards: { value: 1100 },
+        },
+      },
+    ],
+    recordBook: { schemaVersion: 1 },
+    hallOfFameClasses: [],
+    teams,
+    ...overrides,
+  };
+}
+
+describe('dynastySoakAudit', () => {
+  it('marks a healthy preseason snapshot as passing', () => {
+    const r = runDynastySoakAudit({
+      viewState: baseView(),
+      seasonIndex: 1,
+      allSeasons: [{ id: 's2', year: 2027 }],
+      transactions: [{ type: 'DRAFT', seasonId: 's2', teamId: 0, details: { playerId: 1, overall: 1 } }],
+      recordsPayload: { records: {}, recordBook: { schemaVersion: 1 } },
+      hofPayload: { players: [], classes: [] },
+      draftClassesPayload: { classes: [{ seasonId: 's2', year: 2027, pickCount: 1, teamIds: [0] }] },
+    });
+    expect(r.passed).toBe(true);
+    expect(r.failures.length).toBe(0);
+    expect(['ok', 'warn']).toContain(r.summary.rosterHealth);
+  });
+
+  it('fails on empty roster', () => {
+    const v = baseView({
+      teams: [{ id: 0, abbr: 'BAD', wins: 0, losses: 0, ptsFor: 0, ptsAgainst: 0, capUsed: 0, capRoom: 300, capTotal: 301, roster: [] }],
+    });
+    const r = runDynastySoakAudit({ viewState: v, seasonIndex: 1 });
+    expect(r.passed).toBe(false);
+    expect(r.failures.some((f) => f.code === 'roster_empty')).toBe(true);
+  });
+
+  it('fails when two teams lack a QB', () => {
+    const teams = [
+      { id: 0, abbr: 'A', wins: 0, losses: 0, ptsFor: 0, ptsAgainst: 0, capUsed: 10, capRoom: 290, capTotal: 301, roster: [{ id: 'x', pos: 'RB', age: 22, ovr: 70, potential: 75, contract: { yearsRemaining: 1, baseAnnual: 1 } }] },
+      { id: 1, abbr: 'B', wins: 0, losses: 0, ptsFor: 0, ptsAgainst: 0, capUsed: 10, capRoom: 290, capTotal: 301, roster: [{ id: 'y', pos: 'WR', age: 23, ovr: 70, potential: 75, contract: { yearsRemaining: 1, baseAnnual: 1 } }] },
+    ];
+    const r = runDynastySoakAudit({
+      viewState: baseView({ teams, userTeamId: 0 }),
+      seasonIndex: 1,
+    });
+    expect(r.passed).toBe(false);
+    expect(r.failures.some((f) => f.code === 'multi_team_no_qb')).toBe(true);
+  });
+
+  it('fails on NaN cap', () => {
+    const teams = baseView().teams;
+    teams[0].capUsed = NaN;
+    const r = runDynastySoakAudit({ viewState: baseView({ teams }), seasonIndex: 1 });
+    expect(r.passed).toBe(false);
+    expect(r.failures.some((f) => f.code === 'cap_nan')).toBe(true);
+  });
+
+  it('warns on one team without QB', () => {
+    const teams = baseView().teams;
+    teams[1] = {
+      ...teams[1],
+      roster: Array.from({ length: 45 }, (_, i) => ({
+        id: `z${i}`,
+        pos: 'RB',
+        age: 22,
+        ovr: 70,
+        potential: 75,
+        contract: { yearsRemaining: 1, baseAnnual: 1 },
+      })),
+    };
+    const r = runDynastySoakAudit({ viewState: baseView({ teams }), seasonIndex: 1 });
+    expect(r.warnings.some((w) => w.code === 'one_team_no_qb')).toBe(true);
+  });
+
+  it('validates playerSeasonStatsV1 shape', () => {
+    expect(validatePlayerSeasonStatsV1Shape(null).ok).toBe(true);
+    expect(validatePlayerSeasonStatsV1Shape({ schemaVersion: 1, rows: [{ playerId: 'a' }] }).ok).toBe(true);
+    expect(validatePlayerSeasonStatsV1Shape({ rows: 'nope' }).ok).toBe(false);
+  });
+
+  it('validates transactionTimelineV1 shape', () => {
+    expect(validateTransactionTimelineV1Shape({ schemaVersion: 1, rows: [] }).ok).toBe(true);
+    expect(validateTransactionTimelineV1Shape({ rows: {} }).ok).toBe(false);
+  });
+
+  it('buildAiTeamStrategy returns safe output for every team snapshot', () => {
+    for (const t of baseView().teams) {
+      const s = buildAiTeamStrategy({
+        team: { id: t.id, abbr: t.abbr, wins: t.wins, losses: t.losses, capRoom: t.capRoom, capUsed: t.capUsed, deadCap: 0, picks: [] },
+        roster: (t.roster || []).map((p) => ({
+          id: p.id,
+          pos: p.pos,
+          age: p.age,
+          ovr: p.ovr,
+          potential: p.potential,
+          contract: p.contract,
+        })),
+        league: { year: 2028, phase: 'preseason' },
+      });
+      expect(s.archetype).toBeTruthy();
+      expect(Number.isFinite(s.capHealth)).toBe(true);
+    }
+  });
+
+  it('exposes broad stat leader warn bounds', () => {
+    expect(STAT_LEADER_WARN.passYds.max).toBeGreaterThan(STAT_LEADER_WARN.passYds.min);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     include: [
       'src/**/*.test.{js,jsx,ts,tsx}',
       'tests/unit/**/*.test.{js,jsx,ts,tsx}',
+      'tests/integration/**/*.test.{js,jsx,ts,tsx}',
     ],
     exclude: [
       'tests/e2e/**',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **pure audit module** (`dynastySoakAudit.js`), **Vitest gate** (`npm run test:soak`), and a **manual headless worker harness** (`npm run audit:dynasty` via `scripts/dynasty-soak.mjs` + `dynastySoakRunner.js`). Includes small **worker integrity/perf guards** for long `SIM_TO_PHASE` runs and a **flaky E2E** timeout tweak.

## New scripts

| Script | Behavior |
|--------|----------|
| `npm run test:soak` | Fast: `vitest run` on `tests/unit/dynastySoakAudit.test.js` + `tests/integration/dynastySoak.test.js` (fixture snapshot, no full multi-season sim). |
| `npm run audit:dynasty` | Headless: `tsx scripts/dynasty-soak.mjs` — boots safe starter league, runs `SIM_TO_PHASE('preseason')` per season, optional `GET_*` probes, writes `artifacts/dynasty-soak/latest.{json,md}`. **Default 5 seasons**; `--ci` uses 1 season. **Can take a long time** on a 32-team save (offseason + FA + draft). |

## Health checks (`runDynastySoakAudit`)

- **Phase / user / schedule / standings** (contextual)
- **Roster**: empty roster = failure; thin depth / one team without QB = warnings; ≥2 teams without QB = failure
- **Cap / team points**: NaN / impossible cap = failure; mild cap stress = warning
- **`buildAiTeamStrategy`** per team (throws = failure); archetype clustering = warning
- **Archives**: `playerSeasonStatsV1` / `transactionTimelineV1` shape; latest `leagueHistory` champion when standings exist; `rebuildRecordBookV1` + `syncHallOfFameAfterRecordBook` must not throw
- **Transactions / draft memory**: normalize sample rows; `indexDraftClassesFromTransactions` + `buildDraftClassModel` per indexed season
- **Scouting / dev**: sample `buildPlayerDevelopmentModel` / `buildProspectScoutingReport`; mutation sniff on JSON snapshots; sparse prospect handling

## Worker / harness fixes

- **`options.rngSeed`** on `NEW_LEAGUE` and `USE_SAFE_STARTER_LEAGUE` → `Utils.setSeed` before generation.
- **`SIM_TO_PHASE`**: `MAX_ITERATIONS` **200 → 800** so full-year + offseason pipelines are less likely to stop mid-pipeline.
- **`flushDirty(forceFlush)`**: when `globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__` (set only by the Node harness), **skip IndexedDB bulk writes** but **still `drainDirty()`** so dirty tracking cannot grow without bound; **`flushDirty(true)`** at batch end / cancel paths.
- **`depthChartManager` import**: `.js` → `.ts` so Node/tsx can resolve the module.
- **E2E**: `draft-room-heading` wait **45s → 90s** (flake under load).

## Tests run

- `npm run test:unit` (full suite)
- `npm run test:soak`
- `npm run build`
- `npm run check:deploy`
- `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js`
- `npx playwright install chromium` (CI env)
- `npx playwright test` (18/18)
- `npm run audit:dynasty -- --seasons=5 --seed=1383` — **not completed within 15–60m wall time** in this environment after regular season (post–Week 22 pipeline still very heavy). Harness and reports are in place; recommend a **long local run** or future perf work (e.g. throttled FA/draft in harness-only mode).

## Known limitations / follow-ups

- Full **`audit:dynasty`** on 32 teams × multiple seasons remains **CPU- and wall-time heavy**; CI uses **`test:soak`** (Vitest) instead.
- Determinism: `rngSeed` seeds `Utils`; stray `Math.random()` outside `Utils` may still add variance.
- Further speedups could add a **smaller-league boot path** validated by `isPlayableLeagueState` (8-team `NEW_LEAGUE` currently fails playable validation and falls back to 32).

## Artifacts

Writes under `artifacts/dynasty-soak/` (gitignored): `latest.json`, `latest.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87bd496a-fed3-49b5-a852-5afc9e6cf1e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87bd496a-fed3-49b5-a852-5afc9e6cf1e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

