### PR TITLE
Dynasty audit performance + true short soak harness V1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "preview": "vite preview",
     "test": "playwright test",
     "test:unit": "vitest run",
-    "test:soak": "vitest run tests/unit/dynastySoakAudit.test.js tests/integration/dynastySoak.test.js",
+    "test:soak": "vitest run tests/unit/dynastySoakAudit.test.js tests/unit/dynastySoakCli.test.js tests/unit/dynastySoakPersistence.test.js tests/unit/dynastySoakMergeAudit.test.js tests/integration/dynastySoak.test.js",
     "audit:dynasty": "tsx scripts/dynasty-soak.mjs",
     "test:e2e": "playwright test",
     "check:netlify-parity": "bash scripts/netlify-parity-check.sh",

--- a/scripts/dynasty-soak.mjs
+++ b/scripts/dynasty-soak.mjs
@@ -9,98 +9,51 @@
 import 'fake-indexeddb/auto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
-
-function parseArgs(argv) {
-  const out = { ci: false, seasons: null, seed: null, outDir: null };
-  for (let i = 2; i < argv.length; i += 1) {
-    const a = argv[i];
-    if (a === '--ci') out.ci = true;
-    else if (a.startsWith('--seasons=')) out.seasons = Number(a.split('=')[1]);
-    else if (a.startsWith('--seed=')) out.seed = Number(a.split('=')[1]);
-    else if (a.startsWith('--outDir=')) out.outDir = a.split('=').slice(1).join('=');
-    else if (a === '--seasons' && argv[i + 1]) {
-      out.seasons = Number(argv[i + 1]);
-      i += 1;
-    } else if (a === '--seed' && argv[i + 1]) {
-      out.seed = Number(argv[i + 1]);
-      i += 1;
-    }
-  }
-  return out;
-}
-
-function mdEscape(s) {
-  return String(s ?? '')
-    .replace(/\\/g, '\\\\')
-    .replace(/\|/g, '\\|')
-    .replace(/\r?\n/g, ' ');
-}
-
-function buildMarkdownReport(result) {
-  const lines = [];
-  lines.push('# Dynasty soak report');
-  lines.push('');
-  lines.push(`- **Seed:** ${result.seed}`);
-  lines.push(`- **Seasons:** ${result.seasonsSimmed}`);
-  lines.push(`- **Runtime ms:** ${result.runtimeMs}`);
-  lines.push(`- **Passed:** ${result.passed ? 'yes' : 'no'}`);
-  lines.push(`- **Severity:** ${result.severity}`);
-  lines.push('');
-  lines.push('## Summary buckets');
-  lines.push('');
-  lines.push('| Bucket | Status |');
-  lines.push('| --- | --- |');
-  for (const [k, v] of Object.entries(result.summary || {})) {
-    lines.push(`| ${k} | ${v} |`);
-  }
-  lines.push('');
-  lines.push('## Failures');
-  lines.push('');
-  if (!result.failures?.length) lines.push('_None_');
-  else {
-    for (const f of result.failures) {
-      lines.push(`- **${f.code}:** ${mdEscape(f.message)}`);
-    }
-  }
-  lines.push('');
-  lines.push('## Warnings');
-  lines.push('');
-  if (!result.warnings?.length) lines.push('_None_');
-  else {
-    for (const w of result.warnings) {
-      lines.push(`- **${w.code}:** ${mdEscape(w.message)}`);
-    }
-  }
-  lines.push('');
-  lines.push('## Notes');
-  lines.push('');
-  lines.push('- Failures block CI; warnings are informational.');
-  lines.push('- Thresholds are intentionally broad (audit V1, not balance tuning).');
-  return lines.join('\n');
-}
+import {
+  parseDynastySoakArgv,
+  resolveDynastySoakConfig,
+  buildMarkdownReport,
+  slimDynastySoakResultForJson,
+  DYNASTY_SOAK_USAGE,
+} from '../src/testSupport/dynastySoakCli.js';
 
 async function main() {
-  const args = parseArgs(process.argv);
-  const seed = Number.isFinite(args.seed) ? args.seed : 1383;
-  const seasons = Number.isFinite(args.seasons)
-    ? args.seasons
-    : args.ci
-      ? 1
-      : 5;
+  const parsed = parseDynastySoakArgv(process.argv);
+  if (parsed.errors.length) {
+    console.error(DYNASTY_SOAK_USAGE);
+    for (const err of parsed.errors) console.error(`[dynasty-soak] ${err}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const { errors, resolved } = resolveDynastySoakConfig(parsed.raw);
+  if (errors.length || !resolved) {
+    console.error(DYNASTY_SOAK_USAGE);
+    for (const err of errors) console.error(`[dynasty-soak] ${err}`);
+    process.exitCode = 1;
+    return;
+  }
 
   const { runDynastySoakOnce } = await import('../src/testSupport/dynastySoakRunner.js');
 
-  console.log(`[dynasty-soak] seed=${seed} seasons=${seasons}${args.ci ? ' (ci)' : ''}`);
-  const result = await runDynastySoakOnce({ seasons, seed });
-  result.seed = seed;
+  console.log(
+    `[dynasty-soak] seed=${resolved.seed} seasons=${resolved.seasons}${resolved.ci ? ' (ci)' : ''} deepEachSeason=${resolved.deepEachSeason}`,
+  );
+  const result = await runDynastySoakOnce(resolved);
 
-  const outDir = resolve(process.cwd(), args.outDir || 'artifacts/dynasty-soak');
+  const outDir = resolve(process.cwd(), resolved.outDir || 'artifacts/dynasty-soak');
   await mkdir(outDir, { recursive: true });
-  await writeFile(resolve(outDir, 'latest.json'), JSON.stringify(result, null, 2), 'utf8');
+  await writeFile(
+    resolve(outDir, 'latest.json'),
+    JSON.stringify(slimDynastySoakResultForJson(result), null, 2),
+    'utf8',
+  );
   const md = buildMarkdownReport(result);
   await writeFile(resolve(outDir, 'latest.md'), md, 'utf8');
 
-  console.log(`[dynasty-soak] passed=${result.passed} runtimeMs=${result.runtimeMs} failures=${result.failures?.length ?? 0} warnings=${result.warnings?.length ?? 0}`);
+  console.log(
+    `[dynasty-soak] passed=${result.passed} runtimeMs=${result.runtimeMs} failures=${result.failures?.length ?? 0} warnings=${result.warnings?.length ?? 0}`,
+  );
   if (result.failures?.length) {
     for (const f of result.failures.slice(0, 20)) {
       console.error(`  FAIL ${f.code}: ${f.message}`);

--- a/src/core/dynastySoakAudit.js
+++ b/src/core/dynastySoakAudit.js
@@ -120,6 +120,141 @@ export function validateTransactionTimelineV1Shape(block) {
   return { ok: errors.length === 0, errors };
 }
 
+/**
+ * @param {string[]} archetypes
+ * @returns {Record<string, number>}
+ */
+export function buildArchetypeDistribution(archetypes) {
+  const dist = {};
+  for (const a of archetypes || []) {
+    const k = String(a || 'unknown');
+    dist[k] = (dist[k] || 0) + 1;
+  }
+  return dist;
+}
+
+/**
+ * @param {object[]} transactions
+ * @returns {Record<string, number>}
+ */
+export function countTransactionTypes(transactions) {
+  const m = {};
+  for (const t of transactions || []) {
+    const k = String(t?.type ?? 'unknown').toUpperCase();
+    m[k] = (m[k] || 0) + 1;
+  }
+  return m;
+}
+
+/**
+ * Harness-only persistence checklist (does not mutate state).
+ * @param {object} input
+ * @returns {{ allOk: boolean, assertions: { id: string, ok: boolean, detail: string }[] }}
+ */
+export function buildPersistenceAssertions(input = {}) {
+  const viewState = input.viewState ?? {};
+  const leagueHistory = Array.isArray(viewState.leagueHistory) ? viewState.leagueHistory : [];
+  const latest = leagueHistory.length ? leagueHistory[leagueHistory.length - 1] : null;
+  const assertions = [];
+
+  assertions.push({
+    id: 'latest_season_archive',
+    ok: !!(latest && latest.id),
+    detail: latest?.id ? `latest season id=${latest.id}` : 'leagueHistory missing or empty',
+  });
+
+  const hasTx = Array.isArray(input.transactionsRecent) && input.transactionsRecent.length > 0;
+  assertions.push({
+    id: 'transactions_recent_available',
+    ok: hasTx || !input.expectTransactions,
+    detail: hasTx
+      ? `${input.transactionsRecent.length} recent rows`
+      : input.expectTransactions
+        ? 'no transactions in recent strip but activity expected'
+        : 'no recent transactions (ok if none expected)',
+  });
+
+  if (input.seasonTxQueryOk != null) {
+    assertions.push({
+      id: 'get_transactions_by_season',
+      ok: !!input.seasonTxQueryOk,
+      detail: input.seasonTxQueryOk ? 'GET_TRANSACTIONS by season ok' : 'GET_TRANSACTIONS by season failed',
+    });
+  }
+
+  const statsShape = validatePlayerSeasonStatsV1Shape(latest?.playerSeasonStatsV1);
+  const statsRows = latest?.playerSeasonStatsV1?.rows;
+  const hasStatsRows = Array.isArray(statsRows) && statsRows.length > 0;
+  assertions.push({
+    id: 'player_season_stats_v1',
+    ok: statsShape.ok && (!input.expectStatRows || hasStatsRows),
+    detail: statsShape.ok
+      ? hasStatsRows
+        ? `${statsRows.length} stat rows`
+        : 'archive present, no stat rows (ok early-season)'
+      : statsShape.errors.join('; '),
+  });
+
+  const tvShape = validateTransactionTimelineV1Shape(latest?.transactionTimelineV1);
+  const tvRows = latest?.transactionTimelineV1?.rows;
+  const hasTxRows = Array.isArray(tvRows) && tvRows.length > 0;
+  assertions.push({
+    id: 'transaction_timeline_v1',
+    ok: tvShape.ok && (!input.expectTimelineRows || hasTxRows),
+    detail: tvShape.ok
+      ? hasTxRows
+        ? `${tvRows.length} timeline rows`
+        : 'timeline object ok, empty rows'
+      : tvShape.errors.join('; '),
+  });
+
+  assertions.push({
+    id: 'get_season_history',
+    ok: input.getSeasonHistoryOk !== false,
+    detail:
+      input.getSeasonHistorySkipped
+        ? 'skipped (shallow probe mode)'
+        : input.getSeasonHistoryOk
+          ? 'GET_SEASON_HISTORY returned data'
+          : 'GET_SEASON_HISTORY failed or empty',
+  });
+
+  assertions.push({
+    id: 'get_records',
+    ok: input.recordsProbeOk !== false,
+    detail:
+      input.recordsProbeSkipped
+        ? 'skipped (shallow probe mode)'
+        : input.recordsProbeOk
+          ? 'GET_RECORDS ok'
+          : 'GET_RECORDS missing recordBook',
+  });
+
+  assertions.push({
+    id: 'get_hall_of_fame',
+    ok: input.hofProbeOk !== false,
+    detail:
+      input.hofProbeSkipped
+        ? 'skipped (shallow probe mode)'
+        : input.hofProbeOk
+          ? 'GET_HALL_OF_FAME ok'
+          : 'GET_HALL_OF_FAME invalid shape',
+  });
+
+  assertions.push({
+    id: 'get_draft_classes',
+    ok: input.draftClassesProbeOk !== false,
+    detail:
+      input.draftClassesProbeSkipped
+        ? 'skipped (shallow probe mode)'
+        : input.draftClassesProbeOk
+          ? `GET_DRAFT_CLASSES count=${input.draftClassCount ?? 0}`
+          : 'GET_DRAFT_CLASSES invalid',
+  });
+
+  return { allOk: assertions.every((a) => a.ok), assertions };
+}
+
 function countByPos(roster) {
   const m = {};
   for (const p of roster || []) {
@@ -561,6 +696,24 @@ export function runDynastySoakAudit(input = {}) {
         ? 'warn'
         : 'ok';
 
+  const draftClassesForSummary = input.draftClassesPayload?.classes;
+  const reportSummary = {
+    seasonIndex,
+    phase: metaPhase,
+    year,
+    teamCount: teams.length,
+    teamsWithoutQb,
+    archetypeDistribution: buildArchetypeDistribution(archetypes),
+    transactionCountsByType: countTransactionTypes(rawTx),
+    draftClassCount: Array.isArray(draftClassesForSummary) ? draftClassesForSummary.length : null,
+    warningCount: warnings.length,
+    failureCount: failures.length,
+    failureCodes: failures.slice(0, 40).map((f) => f.code),
+    warningCodesSample: warnings.slice(0, 30).map((w) => w.code),
+    capStressedWarnings: warnings.filter((w) => w.code === 'cap_stressed').length,
+    depthWarnings: warnings.filter((w) => String(w.code).startsWith('depth_')).length,
+  };
+
   return {
     passed,
     severity,
@@ -569,5 +722,6 @@ export function runDynastySoakAudit(input = {}) {
     warnings,
     failures,
     summary,
+    reportSummary,
   };
 }

--- a/src/testSupport/dynastySoakCli.js
+++ b/src/testSupport/dynastySoakCli.js
@@ -1,0 +1,273 @@
+/**
+ * Dynasty soak CLI argument parsing and report helpers (no fake-indexeddb).
+ * Used by scripts/dynasty-soak.mjs and Vitest.
+ */
+
+export const DYNASTY_SOAK_USAGE = `Usage: npm run audit:dynasty -- [options]
+
+Options:
+  --ci                    CI short soak (1 season, tighter timeouts, shallow mid-season probes)
+  --seasons=N             Number of seasons to simulate (default: 5, or 1 with --ci)
+  --seed=N                RNG seed (default: 1383)
+  --outDir=PATH           Report output directory (default: artifacts/dynasty-soak)
+  --deep                  No-op (reserved); default is full probes on the final season only
+  --deep-each-season      Full GET_* probes every season (slowest; matches legacy harness)
+  --phase-timeout-ms=N    Timeout per SIM_TO_PHASE attempt and per GET_* (default: 60m)
+  --max-runtime-ms=N      Hard cap on wall time between checkpoints (not mid-SIM_TO_PHASE); default unlimited
+  --skip-report-open      Reserved no-op (reports are files only)
+  --teams=N               Reserved; only 32 is supported (smaller leagues deferred — see report)
+`;
+
+function parseEq(argv, i, prefix) {
+  const a = argv[i];
+  if (a.startsWith(`${prefix}=`)) return a.slice(prefix.length + 1);
+  if (a === prefix && argv[i + 1] != null && !String(argv[i + 1]).startsWith('-')) {
+    return argv[i + 1];
+  }
+  return null;
+}
+
+/**
+ * @param {string[]} argv - process.argv
+ * @returns {{ raw: object, errors: string[] }}
+ */
+export function parseDynastySoakArgv(argv) {
+  const raw = {
+    ci: false,
+    deepEachSeason: false,
+    seasons: null,
+    seed: null,
+    outDir: null,
+    phaseTimeoutMs: null,
+    maxRuntimeMs: null,
+    skipReportOpen: false,
+    teams: null,
+    unknown: [],
+  };
+  const errors = [];
+  for (let i = 2; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--ci') raw.ci = true;
+    else if (a === '--deep') {
+      /* reserved: default harness already runs full probes on the last season */
+    } else if (a === '--deep-each-season') raw.deepEachSeason = true;
+    else if (a === '--skip-report-open') raw.skipReportOpen = true;
+    else if (a.startsWith('--seasons=')) raw.seasons = Number(a.split('=')[1]);
+    else if (a.startsWith('--seed=')) raw.seed = Number(a.split('=')[1]);
+    else if (a.startsWith('--outDir=')) raw.outDir = a.split('=').slice(1).join('=');
+    else if (a.startsWith('--phase-timeout-ms=')) raw.phaseTimeoutMs = Number(a.split('=')[1]);
+    else if (a.startsWith('--max-runtime-ms=')) raw.maxRuntimeMs = Number(a.split('=')[1]);
+    else if (a.startsWith('--teams=')) raw.teams = Number(a.split('=')[1]);
+    else if (a === '--seasons') {
+      const v = argv[i + 1];
+      if (v == null || String(v).startsWith('-')) errors.push('--seasons requires a number');
+      else {
+        raw.seasons = Number(v);
+        i += 1;
+      }
+    } else if (a === '--seed') {
+      const v = argv[i + 1];
+      if (v == null || String(v).startsWith('-')) errors.push('--seed requires a number');
+      else {
+        raw.seed = Number(v);
+        i += 1;
+      }
+    } else if (a === '--phase-timeout-ms') {
+      const v = argv[i + 1];
+      if (v == null || String(v).startsWith('-')) errors.push('--phase-timeout-ms requires a number');
+      else {
+        raw.phaseTimeoutMs = Number(v);
+        i += 1;
+      }
+    } else if (a === '--max-runtime-ms') {
+      const v = argv[i + 1];
+      if (v == null || String(v).startsWith('-')) errors.push('--max-runtime-ms requires a number');
+      else {
+        raw.maxRuntimeMs = Number(v);
+        i += 1;
+      }
+    } else if (a === '--teams') {
+      const v = argv[i + 1];
+      if (v == null || String(v).startsWith('-')) errors.push('--teams requires a number');
+      else {
+        raw.teams = Number(v);
+        i += 1;
+      }
+    } else if (a.startsWith('-')) {
+      raw.unknown.push(a);
+      errors.push(`Unknown option: ${a}`);
+    }
+  }
+  return { raw, errors };
+}
+
+/**
+ * @param {ReturnType<typeof parseDynastySoakArgv>['raw']} raw
+ * @returns {{ errors: string[], resolved: object | null }}
+ */
+export function resolveDynastySoakConfig(raw) {
+  const errors = [];
+  if (raw.unknown?.length) {
+    /* already in parse errors */
+  }
+  const seasons =
+    raw.seasons != null && Number.isFinite(Number(raw.seasons))
+      ? Math.max(1, Math.min(50, Number(raw.seasons)))
+      : raw.ci
+        ? 1
+        : 5;
+  const seed = raw.seed != null && Number.isFinite(Number(raw.seed)) ? Number(raw.seed) : 1383;
+
+  if (raw.teams != null && Number.isFinite(raw.teams) && Number(raw.teams) !== 32) {
+    errors.push(
+      `--teams=${raw.teams} is not supported. Playoff/schedule/conference logic assumes a 32-team league; smaller audit leagues are deferred.`,
+    );
+  }
+
+  const phaseTimeoutMs =
+    raw.phaseTimeoutMs != null && Number.isFinite(Number(raw.phaseTimeoutMs))
+      ? Math.max(10_000, Number(raw.phaseTimeoutMs))
+      : 3_600_000;
+
+  const maxRuntimeMs =
+    raw.maxRuntimeMs != null && Number.isFinite(Number(raw.maxRuntimeMs))
+      ? Math.max(30_000, Number(raw.maxRuntimeMs))
+      : null;
+
+  const deepEachSeason = !!raw.deepEachSeason;
+
+  if (errors.length) {
+    return { errors, resolved: null };
+  }
+
+  return {
+    errors: [],
+    resolved: {
+      seasons,
+      seed,
+      ci: !!raw.ci,
+      deepEachSeason,
+      phaseTimeoutMs,
+      maxRuntimeMs,
+      simTimeoutMs: phaseTimeoutMs,
+      outDir: raw.outDir || null,
+      skipReportOpen: !!raw.skipReportOpen,
+      teams: 32,
+      smallerLeagueNote:
+        'Only 32-team safe starter leagues are enabled; parameterized default league counts require playoff seeding and conference balance work — deferred.',
+    },
+  };
+}
+
+export function mdEscape(s) {
+  return String(s ?? '')
+    .replace(/\\/g, '\\\\')
+    .replace(/\|/g, '\\|')
+    .replace(/\r?\n/g, ' ');
+}
+
+/**
+ * @param {object} result - runDynastySoakOnce output (JSON-serializable)
+ */
+export function buildMarkdownReport(result) {
+  const lines = [];
+  lines.push('# Dynasty soak report');
+  lines.push('');
+  lines.push(`- **Seed:** ${result.seed}`);
+  lines.push(`- **Seasons completed:** ${result.seasonsSimmed}`);
+  lines.push(`- **Runtime ms:** ${result.runtimeMs}`);
+  lines.push(`- **Final phase:** ${result.finalPhase ?? 'n/a'}`);
+  lines.push(`- **Final year:** ${result.finalYear ?? 'n/a'}`);
+  lines.push(`- **Passed:** ${result.passed ? 'yes' : 'no'}`);
+  lines.push(`- **Severity:** ${result.severity}`);
+  if (result.harnessConfig) {
+    lines.push(`- **Harness:** ci=${result.harnessConfig.ci} deepEachSeason=${result.harnessConfig.deepEachSeason}`);
+  }
+  lines.push('');
+
+  if (result.smallerLeagueNote) {
+    lines.push('## League mode');
+    lines.push('');
+    lines.push(mdEscape(result.smallerLeagueNote));
+    lines.push('');
+  }
+
+  if (result.timings?.topSlowCheckpoints?.length) {
+    lines.push('## Slowest checkpoints');
+    lines.push('');
+    lines.push('| Rank | Checkpoint | ms |');
+    lines.push('| --- | --- | --- |');
+    let r = 1;
+    for (const c of result.timings.topSlowCheckpoints) {
+      lines.push(`| ${r} | ${mdEscape(c.name)} | ${c.ms} |`);
+      r += 1;
+    }
+    lines.push('');
+  }
+
+  if (result.reportSummary) {
+    const rs = result.reportSummary;
+    lines.push('## AI / roster snapshot (last audited season)');
+    lines.push('');
+    lines.push(`- **Teams:** ${rs.teamCount ?? 'n/a'}`);
+    lines.push(`- **Teams without QB:** ${rs.teamsWithoutQb ?? 'n/a'}`);
+    lines.push(`- **Archetype distribution:** ${mdEscape(JSON.stringify(rs.archetypeDistribution ?? {}))}`);
+    if (rs.transactionCountsByType && Object.keys(rs.transactionCountsByType).length) {
+      lines.push(`- **Transaction counts (sample strip):** ${mdEscape(JSON.stringify(rs.transactionCountsByType))}`);
+    }
+    lines.push(`- **Draft classes listed:** ${rs.draftClassCount ?? 'n/a'}`);
+    lines.push('');
+  }
+
+  if (result.persistenceAssertions?.length) {
+    lines.push('## Persistence probes');
+    lines.push('');
+    for (const a of result.persistenceAssertions) {
+      const st = a.ok ? 'ok' : 'FAIL';
+      lines.push(`- **${st}** \`${a.id}\`: ${mdEscape(a.detail || '')}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('## Summary buckets');
+  lines.push('');
+  lines.push('| Bucket | Status |');
+  lines.push('| --- | --- |');
+  for (const [k, v] of Object.entries(result.summary || {})) {
+    lines.push(`| ${k} | ${v} |`);
+  }
+  lines.push('');
+  lines.push('## Failures');
+  lines.push('');
+  if (!result.failures?.length) lines.push('_None_');
+  else {
+    for (const f of result.failures) {
+      lines.push(`- **${f.code}:** ${mdEscape(f.message)}`);
+    }
+  }
+  lines.push('');
+  lines.push('## Warnings');
+  lines.push('');
+  if (!result.warnings?.length) lines.push('_None_');
+  else {
+    for (const w of result.warnings) {
+      lines.push(`- **${w.code}:** ${mdEscape(w.message)}`);
+    }
+  }
+  lines.push('');
+  lines.push('## Notes');
+  lines.push('');
+  lines.push('- Failures block CI; warnings are informational.');
+  lines.push('- Phase timings and checkpoints are stored in `latest.json` under `checkpoints` / `timings`.');
+  return lines.join('\n');
+}
+
+/**
+ * Strip huge fields before writing latest.json
+ * @param {object} result
+ */
+export function slimDynastySoakResultForJson(result) {
+  const out = { ...result };
+  delete out.finalView;
+  return out;
+}

--- a/src/testSupport/dynastySoakRunner.js
+++ b/src/testSupport/dynastySoakRunner.js
@@ -5,7 +5,10 @@
  */
 
 import { toWorker, toUI } from '../worker/protocol.js';
-import { runDynastySoakAudit } from '../core/dynastySoakAudit.js';
+import {
+  runDynastySoakAudit,
+  buildPersistenceAssertions,
+} from '../core/dynastySoakAudit.js';
 
 const RESPONSE_BY_REQUEST = {
   [toWorker.INIT]: [toUI.READY, toUI.ERROR],
@@ -104,7 +107,7 @@ export function loadWorkerModule() {
   return workerImportPromise;
 }
 
-function mergeAudit(into, next, seasonLabel) {
+export function mergeAudit(into, next, seasonLabel) {
   const prefix = `[${seasonLabel}]`;
   for (const f of next.failures || []) {
     into.failures.push({ ...f, message: `${prefix} ${f.message}`, code: f.code });
@@ -126,60 +129,93 @@ function mergeAudit(into, next, seasonLabel) {
   into.seasonsSimmed = Math.max(into.seasonsSimmed || 0, next.seasonsSimmed || 0);
 }
 
-/**
- * @param {object} opts
- * @param {number} [opts.seasons=5]
- * @param {number} [opts.seed=1383]
- * @param {number} [opts.simTimeoutMs]
- * @param {function} [opts.onBroadcast]
- */
+function pushCheckpoint(checkpoints, name, ms, meta = null) {
+  checkpoints.push({ name, ms, meta });
+}
+
+function topSlowCheckpoints(checkpoints, n = 10) {
+  return [...checkpoints].sort((a, b) => b.ms - a.ms).slice(0, n);
+}
+
 /**
  * `SIM_TO_PHASE` may stop before `preseason` when the worker hits its per-call
  * iteration guard mid-pipeline; repeat until preseason or hard cap.
+ * @param {number} simTimeoutMs
+ * @param {{ checkpoints: object[], label: string }} ctx
  */
-async function simUntilPreseason(simTimeoutMs) {
+async function simUntilPreseason(simTimeoutMs, ctx) {
   let lastMsg = null;
+  const attempts = [];
   for (let attempt = 0; attempt < 12; attempt += 1) {
+    const t = Date.now();
     lastMsg = await dispatchWorker(
       toWorker.SIM_TO_PHASE,
       { targetPhase: 'preseason' },
       { timeoutMs: simTimeoutMs },
     );
-    if (lastMsg.type === toUI.ERROR) return lastMsg;
+    const ms = Date.now() - t;
     const ph = String(lastMsg.payload?.phase ?? '');
-    if (ph === 'preseason') return lastMsg;
+    const yr = Number(lastMsg.payload?.year ?? 0);
+    attempts.push({
+      attempt,
+      ms,
+      phaseAfter: ph,
+      yearAfter: yr,
+      error: lastMsg.type === toUI.ERROR,
+    });
+    pushCheckpoint(ctx.checkpoints, `${ctx.label}.SIM_TO_PHASE`, ms, {
+      attempt,
+      phaseAfter: ph,
+      yearAfter: yr,
+    });
+    if (lastMsg.type === toUI.ERROR) return { lastMsg, attempts };
+    if (ph === 'preseason') return { lastMsg, attempts };
   }
-  return lastMsg;
+  return { lastMsg, attempts };
 }
 
+function checkMaxRuntime(t0, maxRuntimeMs) {
+  if (maxRuntimeMs == null || !Number.isFinite(maxRuntimeMs)) return;
+  if (Date.now() - t0 > maxRuntimeMs) {
+    const e = new Error(`max-runtime-ms exceeded (${maxRuntimeMs})`);
+    e.code = 'max_runtime_exceeded';
+    throw e;
+  }
+}
+
+/**
+ * @typedef {object} DynastySoakRunnerOptions
+ * @property {number} [seasons=5]
+ * @property {number} [seed=1383]
+ * @property {boolean} [ci=false]
+ * @property {boolean} [deepEachSeason=false]
+ * @property {number} [simTimeoutMs]
+ * @property {number} [phaseTimeoutMs] - alias override for simTimeoutMs / GET timeouts
+ * @property {number|null} [maxRuntimeMs]
+ * @property {function} [onBroadcast]
+ */
+
+/**
+ * @param {DynastySoakRunnerOptions} opts
+ */
 export async function runDynastySoakOnce(opts = {}) {
   const seasons = Math.max(1, Math.min(50, Number(opts.seasons) || 5));
   const seed = Number.isFinite(Number(opts.seed)) ? Number(opts.seed) : 1383;
-  const simTimeoutMs = opts.simTimeoutMs ?? 3_600_000;
+  const ci = !!opts.ci;
+  const deepEachSeason = !!opts.deepEachSeason;
+  const phaseTimeoutMs = Number.isFinite(Number(opts.phaseTimeoutMs))
+    ? Number(opts.phaseTimeoutMs)
+    : Number.isFinite(Number(opts.simTimeoutMs))
+      ? Number(opts.simTimeoutMs)
+      : 3_600_000;
+  const simTimeoutMs = phaseTimeoutMs;
+  const maxRuntimeMs =
+    opts.maxRuntimeMs === null || opts.maxRuntimeMs === undefined
+      ? null
+      : Number(opts.maxRuntimeMs);
 
-  globalThis.__dynastySoakBroadcast = opts.onBroadcast || null;
-  /** @see persistSimSession in worker — avoids hundreds of IndexedDB flushes per batch sim */
-  globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__ = true;
-
-  const t0 = Date.now();
-  try {
-  await loadWorkerModule();
-
-  await dispatchWorker(toWorker.INIT, {}, { timeoutMs: 120_000 });
-
-  const bootMsg = await dispatchWorker(
-    toWorker.USE_SAFE_STARTER_LEAGUE,
-    {
-      slotKey: 'save_slot_1',
-      options: { rngSeed: seed, userTeamId: 0, name: `Dynasty Soak ${seed}` },
-    },
-    { timeoutMs: 180_000 },
-  );
-  if (bootMsg.type === toUI.ERROR) {
-    throw new Error(bootMsg.payload?.message || 'USE_SAFE_STARTER_LEAGUE failed');
-  }
-  /** @type {any} */
-  let view = bootMsg.payload;
+  const checkpoints = [];
+  const simAttemptsPerSeason = [];
 
   const aggregate = {
     passed: true,
@@ -200,110 +236,314 @@ export async function runDynastySoakOnce(opts = {}) {
       developmentHealth: 'ok',
       historyHealth: 'ok',
     },
+    checkpoints,
+    simAttemptsPerSeason,
+    timings: {
+      bootMs: 0,
+      topSlowCheckpoints: [],
+      totalMs: 0,
+    },
+    harnessConfig: {
+      ci,
+      deepEachSeason,
+      phaseTimeoutMs,
+      maxRuntimeMs,
+    },
+    smallerLeagueNote:
+      'Only 32-team safe starter leagues are supported for this harness. Smaller default leagues are deferred (playoff seeding and conference balance are coupled to 32 teams).',
+    persistenceAssertions: [],
   };
 
-  for (let s = 1; s <= seasons; s += 1) {
-    const yearBefore = Number(view?.year ?? 0);
-    const phaseBefore = String(view?.phase ?? '');
+  globalThis.__dynastySoakBroadcast = opts.onBroadcast || null;
+  globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__ = true;
+  globalThis.__DYNASTY_SOAK_THROTTLE_PERSIST__ = true;
+  globalThis.__DYNASTY_SOAK_PROFILE__ = true;
+  globalThis.__DYNASTY_SOAK_LAST_BATCH__ = undefined;
 
-    const simMsg = await simUntilPreseason(simTimeoutMs);
-    if (simMsg.type === toUI.ERROR) {
-      mergeAudit(aggregate, {
-        passed: false,
-        severity: 'error',
-        seasonsSimmed: s,
-        checks: [],
-        warnings: [],
-        failures: [{ code: 'sim_error', message: simMsg.payload?.message || 'SIM_TO_PHASE error' }],
-        summary: aggregate.summary,
-      }, `S${s}`);
-      break;
-    }
-    view = simMsg.payload;
-    const yearAfter = Number(view?.year ?? 0);
-    const phaseAfter = String(view?.phase ?? '');
-    if (phaseAfter !== 'preseason') {
-      mergeAudit(aggregate, {
-        passed: false,
-        severity: 'error',
-        seasonsSimmed: s,
-        checks: [],
-        warnings: [],
-        failures: [{
-          code: 'phase_not_preseason',
-          message: `Expected preseason after sim; got ${phaseAfter} (was ${phaseBefore})`,
-        }],
-        summary: aggregate.summary,
-      }, `S${s}`);
-      aggregate.passed = false;
-      break;
-    }
-    if (yearAfter <= yearBefore) {
-      mergeAudit(aggregate, {
-        passed: false,
-        severity: 'error',
-        seasonsSimmed: s,
-        checks: [],
-        warnings: [],
-        failures: [{
-          code: 'year_stuck',
-          message: `Year did not advance (${yearBefore} -> ${yearAfter}); possible sim stall`,
-        }],
-        summary: aggregate.summary,
-      }, `S${s}`);
-      aggregate.passed = false;
-      break;
-    }
+  const t0 = Date.now();
+  /** @type {any} */
+  let view = null;
+  let lastReportSummary = null;
 
-    const allSeasonsMsg = await dispatchWorker(toWorker.GET_ALL_SEASONS, {}, { timeoutMs: 120_000 });
-    const txMsg = await dispatchWorker(toWorker.GET_TRANSACTIONS, { mode: 'recent', limit: 400 }, { timeoutMs: 120_000 });
-    const txSeasonMsg = await dispatchWorker(
-      toWorker.GET_TRANSACTIONS,
-      { seasonId: view?.seasonId, limit: 200 },
-      { timeoutMs: 120_000 },
+  try {
+    await loadWorkerModule();
+
+    let t = Date.now();
+    await dispatchWorker(toWorker.INIT, {}, { timeoutMs: Math.min(120_000, phaseTimeoutMs) });
+    pushCheckpoint(checkpoints, 'boot.INIT', Date.now() - t, null);
+
+    checkMaxRuntime(t0, maxRuntimeMs);
+
+    t = Date.now();
+    const bootMsg = await dispatchWorker(
+      toWorker.USE_SAFE_STARTER_LEAGUE,
+      {
+        slotKey: 'save_slot_1',
+        options: { rngSeed: seed, userTeamId: 0, name: `Dynasty Soak ${seed}` },
+      },
+      { timeoutMs: Math.min(180_000, phaseTimeoutMs) },
     );
-    const recordsMsg = await dispatchWorker(toWorker.GET_RECORDS, {}, { timeoutMs: 120_000 });
-    const hofMsg = await dispatchWorker(toWorker.GET_HALL_OF_FAME, {}, { timeoutMs: 120_000 });
-    const draftClassesMsg = await dispatchWorker(toWorker.GET_DRAFT_CLASSES, {}, { timeoutMs: 120_000 });
+    pushCheckpoint(checkpoints, 'boot.USE_SAFE_STARTER_LEAGUE', Date.now() - t, null);
 
-    const leagueHistory = view?.leagueHistory ?? [];
-    const latestSeason = leagueHistory.length ? leagueHistory[leagueHistory.length - 1] : null;
-    let seasonHistory = null;
-    if (latestSeason?.id) {
-      const histMsg = await dispatchWorker(toWorker.GET_SEASON_HISTORY, { seasonId: latestSeason.id }, { timeoutMs: 120_000 });
-      if (histMsg.type !== toUI.ERROR) {
-        seasonHistory = histMsg.payload?.data ?? null;
+    if (bootMsg.type === toUI.ERROR) {
+      throw new Error(bootMsg.payload?.message || 'USE_SAFE_STARTER_LEAGUE failed');
+    }
+    view = bootMsg.payload;
+
+    for (let s = 1; s <= seasons; s += 1) {
+      checkMaxRuntime(t0, maxRuntimeMs);
+      const yearBefore = Number(view?.year ?? 0);
+      const phaseBefore = String(view?.phase ?? '');
+      const fullProbes = deepEachSeason || s === seasons;
+
+      const simCtx = { checkpoints, label: `S${s}` };
+      const { lastMsg: simMsg, attempts } = await simUntilPreseason(simTimeoutMs, simCtx);
+      simAttemptsPerSeason.push({ season: s, attempts });
+
+      if (simMsg.type === toUI.ERROR) {
+        mergeAudit(
+          aggregate,
+          {
+            passed: false,
+            severity: 'error',
+            seasonsSimmed: s,
+            checks: [],
+            warnings: [],
+            failures: [{ code: 'sim_error', message: simMsg.payload?.message || 'SIM_TO_PHASE error' }],
+            summary: aggregate.summary,
+          },
+          `S${s}`,
+        );
+        break;
       }
+      view = simMsg.payload;
+      const yearAfter = Number(view?.year ?? 0);
+      const phaseAfter = String(view?.phase ?? '');
+
+      if (phaseAfter !== 'preseason') {
+        mergeAudit(
+          aggregate,
+          {
+            passed: false,
+            severity: 'error',
+            seasonsSimmed: s,
+            checks: [],
+            warnings: [],
+            failures: [
+              {
+                code: 'phase_not_preseason',
+                message: `Expected preseason after sim; got ${phaseAfter} (was ${phaseBefore})`,
+              },
+            ],
+            summary: aggregate.summary,
+          },
+          `S${s}`,
+        );
+        aggregate.passed = false;
+        break;
+      }
+      if (yearAfter <= yearBefore) {
+        mergeAudit(
+          aggregate,
+          {
+            passed: false,
+            severity: 'error',
+            seasonsSimmed: s,
+            checks: [],
+            warnings: [],
+            failures: [
+              {
+                code: 'year_stuck',
+                message: `Year did not advance (${yearBefore} -> ${yearAfter}); possible sim stall`,
+              },
+            ],
+            summary: aggregate.summary,
+          },
+          `S${s}`,
+        );
+        aggregate.passed = false;
+        break;
+      }
+
+      let tProbe = Date.now();
+      const allSeasonsMsg = await dispatchWorker(toWorker.GET_ALL_SEASONS, {}, { timeoutMs: phaseTimeoutMs });
+      pushCheckpoint(checkpoints, `S${s}.GET_ALL_SEASONS`, Date.now() - tProbe, { fullProbes });
+
+      tProbe = Date.now();
+      const txMsg = await dispatchWorker(
+        toWorker.GET_TRANSACTIONS,
+        { mode: 'recent', limit: 400 },
+        { timeoutMs: phaseTimeoutMs },
+      );
+      pushCheckpoint(checkpoints, `S${s}.GET_TRANSACTIONS_recent`, Date.now() - tProbe, null);
+
+      let txSeasonMsg;
+      if (fullProbes) {
+        tProbe = Date.now();
+        txSeasonMsg = await dispatchWorker(
+          toWorker.GET_TRANSACTIONS,
+          { seasonId: view?.seasonId, limit: 200 },
+          { timeoutMs: phaseTimeoutMs },
+        );
+        pushCheckpoint(checkpoints, `S${s}.GET_TRANSACTIONS_season`, Date.now() - tProbe, null);
+      } else {
+        txSeasonMsg = { type: toUI.TRANSACTIONS, payload: { transactions: [] } };
+      }
+
+      let recordsMsg;
+      let hofMsg;
+      let draftClassesMsg;
+      if (fullProbes) {
+        tProbe = Date.now();
+        recordsMsg = await dispatchWorker(toWorker.GET_RECORDS, {}, { timeoutMs: phaseTimeoutMs });
+        pushCheckpoint(checkpoints, `S${s}.GET_RECORDS`, Date.now() - tProbe, null);
+
+        tProbe = Date.now();
+        hofMsg = await dispatchWorker(toWorker.GET_HALL_OF_FAME, {}, { timeoutMs: phaseTimeoutMs });
+        pushCheckpoint(checkpoints, `S${s}.GET_HALL_OF_FAME`, Date.now() - tProbe, null);
+
+        tProbe = Date.now();
+        draftClassesMsg = await dispatchWorker(toWorker.GET_DRAFT_CLASSES, {}, { timeoutMs: phaseTimeoutMs });
+        pushCheckpoint(checkpoints, `S${s}.GET_DRAFT_CLASSES`, Date.now() - tProbe, null);
+      } else {
+        recordsMsg = { type: toUI.RECORDS, payload: null };
+        hofMsg = { type: toUI.HALL_OF_FAME, payload: null };
+        draftClassesMsg = { type: toUI.DRAFT_CLASSES, payload: { classes: [] } };
+      }
+
+      const leagueHistory = view?.leagueHistory ?? [];
+      const latestSeason = leagueHistory.length ? leagueHistory[leagueHistory.length - 1] : null;
+      let seasonHistory = null;
+      let getSeasonHistoryOk = null;
+      let getSeasonHistorySkipped = !fullProbes;
+      if (fullProbes && latestSeason?.id) {
+        tProbe = Date.now();
+        const histMsg = await dispatchWorker(
+          toWorker.GET_SEASON_HISTORY,
+          { seasonId: latestSeason.id },
+          { timeoutMs: phaseTimeoutMs },
+        );
+        pushCheckpoint(checkpoints, `S${s}.GET_SEASON_HISTORY`, Date.now() - tProbe, null);
+        if (histMsg.type !== toUI.ERROR) {
+          seasonHistory = histMsg.payload?.data ?? null;
+          getSeasonHistoryOk = true;
+        } else {
+          getSeasonHistoryOk = false;
+        }
+      } else {
+        getSeasonHistoryOk = fullProbes ? null : true;
+      }
+
+      tProbe = Date.now();
+      const audit = runDynastySoakAudit({
+        viewState: view,
+        seasonIndex: s,
+        allSeasons: allSeasonsMsg.payload?.seasons ?? null,
+        seasonHistory,
+        transactions: txMsg.payload?.transactions ?? [],
+        recordsPayload: recordsMsg.payload ?? null,
+        hofPayload: hofMsg.payload ?? null,
+        draftClassesPayload: draftClassesMsg.payload ?? null,
+      });
+      pushCheckpoint(checkpoints, `S${s}.runDynastySoakAudit`, Date.now() - tProbe, null);
+      lastReportSummary = audit.reportSummary ?? null;
+
+      if (fullProbes && txSeasonMsg.type === toUI.ERROR) {
+        audit.failures.push({
+          code: 'get_transactions_season',
+          message: txSeasonMsg.payload?.message || 'GET_TRANSACTIONS by season failed',
+        });
+        audit.passed = false;
+      }
+
+      mergeAudit(aggregate, audit, `S${s}`);
+
+      if (fullProbes) {
+        const draftClassCount = Array.isArray(draftClassesMsg.payload?.classes)
+          ? draftClassesMsg.payload.classes.length
+          : 0;
+        const expectTx = s >= 2;
+        const expectStats = s >= 2;
+        const persInput = {
+          viewState: view,
+          transactionsRecent: txMsg.payload?.transactions ?? [],
+          expectTransactions: expectTx,
+          expectStatRows: expectStats,
+          expectTimelineRows: expectTx,
+          seasonTxQueryOk: txSeasonMsg.type !== toUI.ERROR,
+          getSeasonHistoryOk,
+          getSeasonHistorySkipped,
+          recordsProbeOk:
+            recordsMsg.type === toUI.ERROR
+              ? false
+              : !!(recordsMsg.payload?.recordBook || recordsMsg.payload?.records),
+          recordsProbeSkipped: false,
+          hofProbeOk:
+            hofMsg.type === toUI.ERROR ? false : !hofMsg.payload || Array.isArray(hofMsg.payload?.players),
+          hofProbeSkipped: false,
+          draftClassesProbeOk: draftClassesMsg.type !== toUI.ERROR,
+          draftClassesProbeSkipped: false,
+          draftClassCount,
+        };
+        const pers = buildPersistenceAssertions(persInput);
+        aggregate.persistenceAssertions = pers.assertions;
+        if (!pers.allOk) {
+          aggregate.passed = false;
+          mergeAudit(
+            aggregate,
+            {
+              passed: false,
+              severity: 'error',
+              seasonsSimmed: s,
+              checks: [],
+              warnings: [],
+              failures: [
+                {
+                  code: 'persistence_probe_failed',
+                  message: 'One or more persistence probes failed; see persistenceAssertions in latest.json',
+                },
+              ],
+              summary: aggregate.summary,
+            },
+            `S${s}`,
+          );
+        }
+      }
+
+      tProbe = Date.now();
+      await dispatchWorker(toWorker.ADVANCE_WEEK, { skipUserGame: true }, { timeoutMs: phaseTimeoutMs });
+      pushCheckpoint(checkpoints, `S${s}.ADVANCE_WEEK`, Date.now() - tProbe, null);
     }
 
-    const audit = runDynastySoakAudit({
-      viewState: view,
-      seasonIndex: s,
-      allSeasons: allSeasonsMsg.payload?.seasons ?? null,
-      seasonHistory,
-      transactions: txMsg.payload?.transactions ?? [],
-      recordsPayload: recordsMsg.payload ?? null,
-      hofPayload: hofMsg.payload ?? null,
-      draftClassesPayload: draftClassesMsg.payload ?? null,
-    });
+    aggregate.severity = aggregate.failures.length ? 'error' : aggregate.warnings.length ? 'warn' : 'ok';
+    aggregate.runtimeMs = Date.now() - t0;
+    aggregate.seed = seed;
+    aggregate.finalPhase = view?.phase ?? null;
+    aggregate.finalYear = view?.year ?? null;
+    aggregate.reportSummary = lastReportSummary;
+    aggregate.timings.bootMs = checkpoints.filter((c) => c.name.startsWith('boot.')).reduce((a, c) => a + c.ms, 0);
+    aggregate.timings.topSlowCheckpoints = topSlowCheckpoints(checkpoints);
+    aggregate.timings.totalMs = aggregate.runtimeMs;
+    aggregate.dynastySoakSimBatch = view?.dynastySoakSimBatch ?? null;
 
-    /* cross-check second transaction query did not throw */
-    if (txSeasonMsg.type === toUI.ERROR) {
-      audit.failures.push({ code: 'get_transactions_season', message: txSeasonMsg.payload?.message || 'GET_TRANSACTIONS by season failed' });
-      audit.passed = false;
-    }
-
-    mergeAudit(aggregate, audit, `S${s}`);
-
-    await dispatchWorker(toWorker.ADVANCE_WEEK, { skipUserGame: true }, { timeoutMs: 120_000 });
-  }
-
-  aggregate.severity = aggregate.failures.length ? 'error' : aggregate.warnings.length ? 'warn' : 'ok';
-  aggregate.runtimeMs = Date.now() - t0;
-  aggregate.seed = seed;
-  aggregate.finalView = view;
-  return aggregate;
+    return aggregate;
+  } catch (e) {
+    aggregate.passed = false;
+    aggregate.severity = 'error';
+    aggregate.failures.push({ code: e?.code || 'runner_fatal', message: e?.message || String(e) });
+    aggregate.runtimeMs = Date.now() - t0;
+    aggregate.seed = seed;
+    aggregate.finalPhase = view?.phase ?? null;
+    aggregate.finalYear = view?.year ?? null;
+    aggregate.reportSummary = lastReportSummary;
+    aggregate.timings.bootMs = checkpoints.filter((c) => c.name.startsWith('boot.')).reduce((a, c) => a + c.ms, 0);
+    aggregate.timings.topSlowCheckpoints = topSlowCheckpoints(checkpoints);
+    aggregate.timings.totalMs = aggregate.runtimeMs;
+    return aggregate;
   } finally {
     globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__ = false;
+    globalThis.__DYNASTY_SOAK_THROTTLE_PERSIST__ = false;
+    globalThis.__DYNASTY_SOAK_PROFILE__ = false;
+    globalThis.__DYNASTY_SOAK_LAST_BATCH__ = undefined;
   }
 }

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -295,6 +295,19 @@ async function persistSimSession(update = {}) {
   await flushDirty();
 }
 
+/** Dynasty-soak harness: reduce persistSimSession frequency during long batch sim (IDB flush already no-op in batch). */
+async function maybePersistSimSession(update = {}, iterationIndex, opts = {}) {
+  const force = !!opts?.force;
+  const batch = typeof globalThis !== 'undefined' && globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__;
+  const throttle =
+    typeof globalThis !== 'undefined' && globalThis.__DYNASTY_SOAK_THROTTLE_PERSIST__;
+  if (batch && throttle && !force) {
+    const every = Math.max(1, Number(globalThis.__DYNASTY_SOAK_PERSIST_EVERY__) || 25);
+    if (iterationIndex % every !== 0) return;
+  }
+  await persistSimSession(update);
+}
+
 function validateLeagueFlowState({ stage = 'runtime', requireDraftState = false } = {}) {
   const meta = ensureDynastyMeta(cache.getMeta());
   const players = cache.getAllPlayers();
@@ -840,6 +853,9 @@ function buildViewState() {
     standings: standingsRows,
     standingsContext,
     teams,
+    ...(typeof globalThis !== 'undefined' && globalThis.__DYNASTY_SOAK_PROFILE__ && globalThis.__DYNASTY_SOAK_LAST_BATCH__
+      ? { dynastySoakSimBatch: { ...globalThis.__DYNASTY_SOAK_LAST_BATCH__ } }
+      : {}),
   };
 }
 
@@ -2979,8 +2995,10 @@ function buildLeagueForSim(schedule, week, seasonId) {
     })
     .filter(Boolean);
 
-  // Diagnostic logging for schedule population
-  console.log(`[Worker] Week ${week} schedule entries: ${weekData?.games?.length ?? 0}, unplayed: ${weekGames.length}`);
+  // Diagnostic logging for schedule population (skip in Node dynasty batch sim — very noisy / slow)
+  if (typeof globalThis === 'undefined' || !globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__) {
+    console.log(`[Worker] Week ${week} schedule entries: ${weekData?.games?.length ?? 0}, unplayed: ${weekGames.length}`);
+  }
 
   // Defensive logging: if weekGames is empty, log why
   if (weekGames.length === 0) {
@@ -3674,6 +3692,15 @@ async function handleSimToPhase({ targetPhase }, id) {
 
   // Already at target?
   if (isTarget(meta)) {
+    if (typeof globalThis !== 'undefined' && globalThis.__DYNASTY_SOAK_PROFILE__) {
+      globalThis.__DYNASTY_SOAK_LAST_BATCH__ = {
+        iterationsUsed: 0,
+        reachedTarget: true,
+        hitIterationCap: false,
+        lastPhase: meta?.phase ?? null,
+        targetPhase,
+      };
+    }
     post(toUI.FULL_STATE, buildViewState(), id);
     return;
   }
@@ -3682,6 +3709,17 @@ async function handleSimToPhase({ targetPhase }, id) {
   // can exceed 200 steps when each outer tick is one week/offseason day/draft episode).
   const MAX_ITERATIONS = 800;
   let iterations = 0;
+  const recordDynastySoakBatchProfile = (iterUsed, reached) => {
+    if (typeof globalThis === 'undefined' || !globalThis.__DYNASTY_SOAK_PROFILE__) return;
+    const m = cache.getMeta();
+    globalThis.__DYNASTY_SOAK_LAST_BATCH__ = {
+      iterationsUsed: iterUsed,
+      reachedTarget: !!reached,
+      hitIterationCap: iterUsed >= MAX_ITERATIONS && !reached,
+      lastPhase: m?.phase ?? null,
+      targetPhase,
+    };
+  };
   batchSimControl = {
     running: true,
     cancelRequested: false,
@@ -3709,6 +3747,7 @@ async function handleSimToPhase({ targetPhase }, id) {
         if (typeof globalThis !== 'undefined' && globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__) {
           await flushDirty(true);
         }
+        recordDynastySoakBatchProfile(iterations, isTarget(cache.getMeta()));
         post(toUI.FULL_STATE, buildViewState(), id);
         return;
       }
@@ -3719,12 +3758,16 @@ async function handleSimToPhase({ targetPhase }, id) {
         phase: currentMeta.phase,
         targetPhase,
       });
-      await persistSimSession({
-        status: 'running',
-        targetPhase,
-        stage: currentMeta.phase,
-        checkpoint: `iter_${iterations}`,
-      });
+      await maybePersistSimSession(
+        {
+          status: 'running',
+          targetPhase,
+          stage: currentMeta.phase,
+          checkpoint: `iter_${iterations}`,
+        },
+        iterations,
+        {},
+      );
 
       // Advance based on current phase
       // Pass skipUserGame:true during batch sim to avoid prompting the user
@@ -3742,10 +3785,18 @@ async function handleSimToPhase({ targetPhase }, id) {
         // for transitioning into the next season (handleSimDraftPick and
         // handleMakeDraftPick both call handleStartNewSeason once all picks
         // are made), so we deliberately do NOT call handleAdvanceOffseason here.
-        await persistSimSession({ status: 'running', targetPhase, stage: 'draft_setup', checkpoint: 'ensure_draft_state' });
+        await maybePersistSimSession(
+          { status: 'running', targetPhase, stage: 'draft_setup', checkpoint: 'ensure_draft_state' },
+          iterations,
+          { force: true },
+        );
         await handleStartDraft({}, null);
         validateLeagueFlowState({ stage: 'draft_setup', requireDraftState: true });
-        await persistSimSession({ status: 'running', targetPhase, stage: 'draft_execution', checkpoint: 'start' });
+        await maybePersistSimSession(
+          { status: 'running', targetPhase, stage: 'draft_execution', checkpoint: 'start' },
+          iterations,
+          { force: true },
+        );
         let draftDone = false;
         let draftGuard = 0;
         while (!draftDone && draftGuard < 500) {
@@ -3769,6 +3820,7 @@ async function handleSimToPhase({ targetPhase }, id) {
           if (typeof globalThis !== 'undefined' && globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__) {
             await flushDirty(true);
           }
+          recordDynastySoakBatchProfile(iterations, isTarget(cache.getMeta()));
           post(toUI.FULL_STATE, buildViewState(), id);
           return;
         }
@@ -3794,6 +3846,7 @@ async function handleSimToPhase({ targetPhase }, id) {
     if (typeof globalThis !== 'undefined' && globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__) {
       await flushDirty(true);
     }
+    recordDynastySoakBatchProfile(iterations, isTarget(cache.getMeta()));
     post(toUI.FULL_STATE, buildViewState(), id);
   } catch (error) {
     await persistSimSession({
@@ -3808,6 +3861,7 @@ async function handleSimToPhase({ targetPhase }, id) {
     }
     post(toUI.SIM_BATCH_STATUS, { status: 'failed', targetPhase, stage: cache.getMeta()?.phase ?? null });
     post(toUI.NOTIFICATION, { level: 'warn', message: `Simulation paused: ${error?.message ?? 'unknown error'}. You can retry or cancel.` });
+    recordDynastySoakBatchProfile(iterations, isTarget(cache.getMeta()));
     post(toUI.FULL_STATE, buildViewState(), id);
   } finally {
     batchSimControl = {

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -3684,11 +3684,13 @@ async function handleSimToPhase({ targetPhase }, id) {
     regular:    (m) => m.phase === 'regular',
   };
 
-  const isTarget = PHASE_TARGETS[targetPhase];
-  if (!isTarget) {
+  const hasTarget = Object.prototype.hasOwnProperty.call(PHASE_TARGETS, targetPhase);
+  const resolvedTarget = hasTarget ? PHASE_TARGETS[targetPhase] : null;
+  if (typeof resolvedTarget !== 'function') {
     post(toUI.ERROR, { message: `Unknown target phase: ${targetPhase}` }, id);
     return;
   }
+  const isTarget = resolvedTarget;
 
   // Already at target?
   if (isTarget(meta)) {

--- a/tests/integration/dynastySoak.test.js
+++ b/tests/integration/dynastySoak.test.js
@@ -91,5 +91,7 @@ describe('dynasty soak integration (audit fixture)', () => {
 
     expect(r.passed).toBe(true);
     expect(['ok', 'warn']).toContain(r.severity);
+    expect(r.reportSummary?.teamCount).toBe(2);
+    expect(r.reportSummary?.archetypeDistribution).toBeDefined();
   });
 });

--- a/tests/unit/dynastySoakAudit.test.js
+++ b/tests/unit/dynastySoakAudit.test.js
@@ -94,6 +94,9 @@ describe('dynastySoakAudit', () => {
     expect(r.passed).toBe(true);
     expect(r.failures.length).toBe(0);
     expect(['ok', 'warn']).toContain(r.summary.rosterHealth);
+    expect(r.reportSummary?.teamCount).toBe(2);
+    expect(r.reportSummary?.archetypeDistribution).toBeDefined();
+    expect(r.reportSummary?.transactionCountsByType?.DRAFT).toBeGreaterThanOrEqual(1);
   });
 
   it('fails on empty roster', () => {

--- a/tests/unit/dynastySoakCli.test.js
+++ b/tests/unit/dynastySoakCli.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseDynastySoakArgv,
+  resolveDynastySoakConfig,
+  buildMarkdownReport,
+  slimDynastySoakResultForJson,
+} from '../../src/testSupport/dynastySoakCli.js';
+
+describe('dynastySoakCli', () => {
+  it('parses --ci, --seasons, --seed, --deep-each-season', () => {
+    const { raw, errors } = parseDynastySoakArgv([
+      'node',
+      'dynasty-soak.mjs',
+      '--ci',
+      '--seasons=2',
+      '--seed=99',
+      '--deep-each-season',
+    ]);
+    expect(errors).toEqual([]);
+    expect(raw.ci).toBe(true);
+    expect(raw.seasons).toBe(2);
+    expect(raw.seed).toBe(99);
+    expect(raw.deepEachSeason).toBe(true);
+  });
+
+  it('rejects unknown flags', () => {
+    const { errors } = parseDynastySoakArgv(['node', 'x.mjs', '--nope']);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('resolves CI defaults and phase timeout', () => {
+    const { raw } = parseDynastySoakArgv(['node', 'x.mjs', '--ci']);
+    const { errors, resolved } = resolveDynastySoakConfig(raw);
+    expect(errors).toEqual([]);
+    expect(resolved.seasons).toBe(1);
+    expect(resolved.ci).toBe(true);
+    expect(resolved.phaseTimeoutMs).toBe(3_600_000);
+    expect(resolved.maxRuntimeMs).toBeNull();
+  });
+
+  it('defaults to 5 seasons when not CI', () => {
+    const { raw } = parseDynastySoakArgv(['node', 'x.mjs']);
+    const { resolved } = resolveDynastySoakConfig(raw);
+    expect(resolved.seasons).toBe(5);
+    expect(resolved.seed).toBe(1383);
+  });
+
+  it('rejects --teams other than 32', () => {
+    const { raw } = parseDynastySoakArgv(['node', 'x.mjs', '--teams=8']);
+    const { errors, resolved } = resolveDynastySoakConfig(raw);
+    expect(resolved).toBeNull();
+    expect(errors.some((e) => e.includes('32'))).toBe(true);
+  });
+
+  it('buildMarkdownReport includes timing and AI snapshot sections', () => {
+    const md = buildMarkdownReport({
+      seed: 1,
+      seasonsSimmed: 1,
+      runtimeMs: 100,
+      passed: true,
+      severity: 'ok',
+      summary: { rosterHealth: 'ok' },
+      failures: [],
+      warnings: [],
+      finalPhase: 'preseason',
+      finalYear: 2027,
+      harnessConfig: { ci: true, deepEachSeason: false },
+      timings: {
+        topSlowCheckpoints: [
+          { name: 'S1.SIM_TO_PHASE', ms: 80 },
+          { name: 'boot.INIT', ms: 5 },
+        ],
+      },
+      reportSummary: {
+        teamCount: 32,
+        teamsWithoutQb: 0,
+        archetypeDistribution: { contender: 10 },
+        transactionCountsByType: { DRAFT: 32 },
+        draftClassCount: 1,
+      },
+      persistenceAssertions: [{ id: 'latest_season_archive', ok: true, detail: 'ok' }],
+    });
+    expect(md).toContain('Slowest checkpoints');
+    expect(md).toContain('S1.SIM_TO_PHASE');
+    expect(md).toContain('AI / roster snapshot');
+    expect(md).toContain('contender');
+    expect(md).toContain('Persistence probes');
+  });
+
+  it('slimDynastySoakResultForJson removes finalView', () => {
+    const slim = slimDynastySoakResultForJson({ a: 1, finalView: { big: true } });
+    expect(slim.finalView).toBeUndefined();
+    expect(slim.a).toBe(1);
+  });
+});

--- a/tests/unit/dynastySoakMergeAudit.test.js
+++ b/tests/unit/dynastySoakMergeAudit.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { mergeAudit } from '../../src/testSupport/dynastySoakRunner.js';
+
+function emptyAggregate() {
+  return {
+    passed: true,
+    seasonsSimmed: 0,
+    checks: [],
+    warnings: [],
+    failures: [],
+    summary: {
+      rosterHealth: 'ok',
+      capHealth: 'ok',
+      statHealth: 'ok',
+      archiveHealth: 'ok',
+      aiHealth: 'ok',
+      transactionHealth: 'ok',
+      draftHealth: 'ok',
+      scoutingHealth: 'ok',
+      developmentHealth: 'ok',
+      historyHealth: 'ok',
+    },
+  };
+}
+
+describe('mergeAudit', () => {
+  it('prefixes messages and merges failure state', () => {
+    const into = emptyAggregate();
+    mergeAudit(
+      into,
+      {
+        passed: false,
+        seasonsSimmed: 1,
+        checks: [{ severity: 'failure', code: 'x', message: 'bad' }],
+        warnings: [],
+        failures: [{ code: 'cap_nan', message: 'nan' }],
+        summary: { capHealth: 'fail', rosterHealth: 'ok' },
+      },
+      'S1',
+    );
+    expect(into.passed).toBe(false);
+    expect(into.failures[0].message.startsWith('[S1]')).toBe(true);
+    expect(into.summary.capHealth).toBe('fail');
+  });
+});

--- a/tests/unit/dynastySoakPersistence.test.js
+++ b/tests/unit/dynastySoakPersistence.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPersistenceAssertions,
+  validateTransactionTimelineV1Shape,
+} from '../../src/core/dynastySoakAudit.js';
+
+describe('buildPersistenceAssertions', () => {
+  it('fails when leagueHistory has no latest season', () => {
+    const r = buildPersistenceAssertions({
+      viewState: { leagueHistory: [] },
+      transactionsRecent: [{ type: 'X' }],
+      expectTransactions: false,
+      getSeasonHistoryOk: true,
+      getSeasonHistorySkipped: false,
+      recordsProbeOk: true,
+      hofProbeOk: true,
+      draftClassesProbeOk: true,
+      draftClassCount: 0,
+    });
+    expect(r.allOk).toBe(false);
+    expect(r.assertions.find((a) => a.id === 'latest_season_archive')?.ok).toBe(false);
+  });
+
+  it('fails transaction timeline when rows are malformed type', () => {
+    expect(validateTransactionTimelineV1Shape({ schemaVersion: 1, rows: {} }).ok).toBe(false);
+  });
+
+  it('passes minimal healthy snapshot', () => {
+    const r = buildPersistenceAssertions({
+      viewState: {
+        leagueHistory: [
+          {
+            id: 's1',
+            playerSeasonStatsV1: { schemaVersion: 1, rows: [{ playerId: 1, pos: 'QB' }] },
+            transactionTimelineV1: { schemaVersion: 1, rows: [{ rawId: 1, type: 'draft' }] },
+          },
+        ],
+      },
+      transactionsRecent: [{ type: 'DRAFT' }],
+      expectTransactions: true,
+      expectStatRows: true,
+      expectTimelineRows: true,
+      seasonTxQueryOk: true,
+      getSeasonHistoryOk: true,
+      getSeasonHistorySkipped: false,
+      recordsProbeOk: true,
+      hofProbeOk: true,
+      draftClassesProbeOk: true,
+      draftClassCount: 1,
+    });
+    expect(r.allOk).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR makes the worker-driven dynasty audit **measurable and more practical** without changing gameplay rules or weakening existing smoke or Playwright coverage.

## Root cause of slowness (measured / inferred)

- **Dominant cost:** a single `SIM_TO_PHASE` → `preseason` run simulates the full 32-team regular season, playoffs, offseason, free agency, and draft inside one worker batch loop (up to 800 inner iterations per outer call). Wall time can exceed **60 minutes** on a modest CPU; a **20-minute** per-call timeout was too aggressive and produced false `runner_fatal` timeouts.
- **Secondary cost:** per-week `console.log` spam during schedule build under batch sim added avoidable I/O overhead.
- **Harness overhead:** redundant deep `GET_*` probes every season; mitigated by **full probes on the last season only** unless `--deep-each-season`.

## What changed

- **Instrumentation:** `checkpoints[]`, `simAttemptsPerSeason`, `timings.topSlowCheckpoints`, optional `dynastySoakSimBatch` on `FULL_STATE` when profiling is on.
- **CLI:** new [`src/testSupport/dynastySoakCli.js`](src/testSupport/dynastySoakCli.js) with usage, validation (`Number(null)` bug fixed for timeouts/seasons/seed), `--deep-each-season`, `--phase-timeout-ms`, `--max-runtime-ms`, `--teams` (rejects non-32 with deferral text), reserved `--deep` no-op.
- **Runner:** shallow mid-season probes; full persistence probes + `buildPersistenceAssertions` on the **final** season; `reportSummary` from audit in `latest.json`; `slimDynastySoakResultForJson` strips `finalView` from JSON.
- **Worker:** `maybePersistSimSession` throttles `persistSimSession` during batch sim when `__DYNASTY_SOAK_THROTTLE_PERSIST__` is set; `flushDirty(true)` behavior unchanged at batch completion; schedule diagnostic `console.log` skipped under `__FOOTBALL_GM_LITE_BATCH_SIM__`.
- **Smaller league:** **deferred** — `--teams=8` etc. rejected with explanation (playoff/conference coupling to 32 teams).
- **Tests:** CLI, persistence assertions, `mergeAudit`, `reportSummary`; `test:soak` expanded.

## Defaults and limits

- **Phase timeout default:** **60 minutes** per `SIM_TO_PHASE` / `GET_*` (CI and non-CI).
- **`--max-runtime-ms`:** **opt-in only**; default unlimited. It only runs between harness checkpoints and **does not** interrupt an in-flight `SIM_TO_PHASE` RPC.

## Verification run in this environment

- `npm run test:unit` — pass (754 tests).
- `npm run test:soak` — pass.
- `npm run build` — pass.
- `npm run check:deploy` — pass.
- `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` — pass (after `npx playwright install chromium`).
- `npx playwright test` — 18/18 pass.
- Full `npm run audit:dynasty -- --ci --seed=1383` was **not** allowed to finish in the agent window after the timeout fix (single batch still **>60 min CPU** here); re-run locally/CI with a job timeout ≥90m or tune `--phase-timeout-ms` upward if needed.

## Remaining limitations (for AI Balance Tuning V2)

- One full 32-team season in batch mode remains **CPU-heavy**; the report now surfaces **where** time went (checkpoints + `dynastySoakSimBatch.iterationsUsed`) for further harness-only tuning.
- Smaller-league audit mode remains a **follow-up** once schedule/playoff invariants support sub-32 safely.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3c12229-ee68-46c9-b1cd-662abcaf356d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3c12229-ee68-46c9-b1cd-662abcaf356d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

