### PR TITLE
AI Balance Tuning V2: strategy, FA, draft scoring, CPU trade guardrails

### DIFF
--- a/src/core/__tests__/aiFreeAgencyOffers.test.js
+++ b/src/core/__tests__/aiFreeAgencyOffers.test.js
@@ -273,6 +273,85 @@ describe('AiLogic.makeFreeAgencyOffers stale contract handling', () => {
     );
   });
 
+  it('skips non-urgent splash offers when cap hit exceeds tightened middle cap band', async () => {
+    const splashFa = {
+      id: 41,
+      name: 'Splash WR',
+      pos: 'WR',
+      status: 'free_agent',
+      ovr: 78,
+      age: 28,
+      offers: [],
+    };
+    mockCache.getTeam.mockReturnValue({
+      id: 2,
+      name: 'Middle Tight',
+      abbr: 'MID',
+      wins: 8,
+      losses: 8,
+      capRoom: 6,
+      capUsed: 292,
+      deadCap: 8,
+    });
+    mockCache.getPlayersByTeam.mockReturnValue([
+      { id: 201, pos: 'WR', ovr: 66, age: 26, potential: 68, contract: { years: 2 } },
+      { id: 202, pos: 'WR', ovr: 64, age: 25, potential: 66, contract: { years: 2 } },
+      { id: 204, pos: 'QB', ovr: 78, age: 29, potential: 80, contract: { years: 2 } },
+      ...Array.from({ length: 12 }, (_, i) => ({
+        id: 210 + i,
+        pos: 'OL',
+        ovr: 71,
+        age: 26,
+        potential: 74,
+        contract: { years: 2 },
+      })),
+    ]);
+    mockCalculateExtensionDemand.mockReturnValue({ years: 3, yearsTotal: 3, baseAnnual: 16, signingBonus: 10 });
+
+    await AiLogic.makeFreeAgencyOffers(2, { WR: [splashFa] });
+
+    expect(mockCache.updatePlayer).not.toHaveBeenCalled();
+  });
+
+  it('allows a controlled QB exception when cap is tight but QB need is severe', async () => {
+    const qbFa = {
+      id: 42,
+      name: 'Bridge QB',
+      pos: 'QB',
+      status: 'free_agent',
+      ovr: 76,
+      age: 30,
+      offers: [],
+    };
+    mockCache.getTeam.mockReturnValue({
+      id: 3,
+      name: 'QB Needy',
+      abbr: 'QBN',
+      wins: 4,
+      losses: 13,
+      capRoom: 10,
+      capUsed: 290,
+      deadCap: 6,
+    });
+    mockCache.getPlayersByTeam.mockReturnValue([
+      { id: 301, pos: 'QB', ovr: 61, age: 32, potential: 63, contract: { years: 1 } },
+      { id: 302, pos: 'WR', ovr: 80, age: 26, potential: 84, contract: { years: 2 } },
+      { id: 303, pos: 'WR', ovr: 78, age: 25, potential: 82, contract: { years: 2 } },
+      { id: 304, pos: 'WR', ovr: 76, age: 24, potential: 80, contract: { years: 2 } },
+    ]);
+    // Cap hit ~5.0M: above strict rebuild band for $10M room, but inside QB exception window.
+    mockCalculateExtensionDemand.mockReturnValue({ years: 2, yearsTotal: 2, baseAnnual: 4.5, signingBonus: 1 });
+
+    await AiLogic.makeFreeAgencyOffers(3, { QB: [qbFa] });
+
+    expect(mockCache.updatePlayer).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({
+        offers: expect.arrayContaining([expect.objectContaining({ teamId: 3 })]),
+      }),
+    );
+  });
+
   it('calculateTeamNeeds keeps QB as high priority when QB room is weak', () => {
     mockCache.getTeam.mockReturnValue({
       id: 1,

--- a/src/core/__tests__/aiTeamStrategy.test.js
+++ b/src/core/__tests__/aiTeamStrategy.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildAiTeamStrategy, __internal } from '../aiTeamStrategy.js';
+import { buildAiTeamStrategy, mapPlayerPosToNeedGroup, __internal } from '../aiTeamStrategy.js';
 
 function makePlayer({ pos, ovr, age = 27, potential = ovr + 2, yearsLeft = 2 }) {
   return {
@@ -57,6 +57,51 @@ describe('buildAiTeamStrategy', () => {
     const qbNeed = __internal.buildPositionalNeed('QB', roster, 'middle');
     const kpNeed = __internal.buildPositionalNeed('KP', roster, 'middle');
     expect(qbNeed.priority).toBeGreaterThan(kpNeed.priority);
+  });
+
+  it('maps granular positions to strategy need groups for draft/FA scoring', () => {
+    expect(mapPlayerPosToNeedGroup('DE')).toBe('DL_EDGE');
+    expect(mapPlayerPosToNeedGroup('OT')).toBe('OL');
+    expect(mapPlayerPosToNeedGroup('K')).toBe('KP');
+    expect(mapPlayerPosToNeedGroup('QB')).toBe('QB');
+  });
+
+  it('classifies elite roster with playoff pace as contender', () => {
+    const team = { id: 3, abbr: 'BUF', wins: 10, losses: 7, capRoom: 14, capUsed: 278, deadCap: 4 };
+    const roster = [
+      makePlayer({ pos: 'QB', ovr: 84 }),
+      ...Array.from({ length: 6 }, () => makePlayer({ pos: 'WR', ovr: 79 })),
+      ...Array.from({ length: 8 }, () => makePlayer({ pos: 'OL', ovr: 78 })),
+      ...Array.from({ length: 10 }, () => makePlayer({ pos: 'DL', ovr: 79 })),
+      ...Array.from({ length: 6 }, () => makePlayer({ pos: 'CB', ovr: 78 })),
+    ];
+    const out = buildAiTeamStrategy({ team, roster, league: { year: 2031, phase: 'regular' } });
+    expect(out.archetype).toBe('contender');
+  });
+
+  it('classifies weak-but-not-empty roster as development instead of defaulting everyone to rebuild', () => {
+    const team = { id: 4, abbr: 'CAR', wins: 7, losses: 10, capRoom: 22, capUsed: 260, deadCap: 2 };
+    const roster = [
+      makePlayer({ pos: 'QB', ovr: 72, age: 28 }),
+      ...Array.from({ length: 4 }, () => makePlayer({ pos: 'WR', ovr: 67 })),
+      ...Array.from({ length: 5 }, () => makePlayer({ pos: 'OL', ovr: 66 })),
+      ...Array.from({ length: 6 }, () => makePlayer({ pos: 'DL', ovr: 65 })),
+    ];
+    const out = buildAiTeamStrategy({ team, roster, league: { year: 2031, phase: 'regular' } });
+    expect(['development', 'middle', 'retool']).toContain(out.archetype);
+  });
+
+  it('surfaces QB context in strategy reasons', () => {
+    const weakQbRoster = [
+      makePlayer({ pos: 'QB', ovr: 58, potential: 62 }),
+      makePlayer({ pos: 'WR', ovr: 82 }),
+    ];
+    const out = buildAiTeamStrategy({
+      team: { id: 5, abbr: 'TEN', wins: 8, losses: 9, capRoom: 12, capUsed: 270, deadCap: 0 },
+      roster: weakQbRoster,
+      league: { year: 2032, phase: 'regular' },
+    });
+    expect(out.reasons.some((r) => /QB/i.test(r))).toBe(true);
   });
 });
 

--- a/src/core/__tests__/trade-logic.test.js
+++ b/src/core/__tests__/trade-logic.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { calculatePlayerValue } from '../trade-logic.js';
+import { calculatePlayerValue, shouldBlockCpuUniformPlayerSwap } from '../trade-logic.js';
 
 describe('calculatePlayerValue', () => {
   it('values younger high-potential players above older equivalents', () => {
@@ -50,6 +50,17 @@ describe('calculatePlayerValue', () => {
     };
 
     expect(calculatePlayerValue(poorAsset)).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('shouldBlockCpuUniformPlayerSwap', () => {
+  it('blocks uniform swaps that involve a quarterback', () => {
+    expect(shouldBlockCpuUniformPlayerSwap({ pos: 'QB' }, { pos: 'WR' })).toBe(true);
+    expect(shouldBlockCpuUniformPlayerSwap({ pos: 'LB' }, { pos: 'QB' })).toBe(true);
+  });
+
+  it('allows non-QB uniform swaps', () => {
+    expect(shouldBlockCpuUniformPlayerSwap({ pos: 'WR' }, { pos: 'CB' })).toBe(false);
   });
 });
 

--- a/src/core/ai-logic.js
+++ b/src/core/ai-logic.js
@@ -401,9 +401,21 @@ class AiLogic {
             year: meta?.year,
         });
 
-        // 1. Identify Needs
+        // 1. Identify Needs (prioritize highest gaps; contenders focus on a few real upgrades per day)
         const needs = this._teamNeedsFromStrategy(strategy);
-        const highNeedPositions = Object.keys(needs).filter(pos => needs[pos] >= 1.2);
+        let highNeedPositions = Object.keys(needs).filter(pos => needs[pos] >= 1.2);
+        const needSortScore = (pos) => Number(needs[pos] ?? 0) + (pos === 'QB' ? 0.72 : 0);
+        highNeedPositions.sort((a, b) => needSortScore(b) - needSortScore(a));
+        const arch = strategy?.archetype;
+        const maxNeedSlots = arch === 'contender' || arch === 'playoff_hunt'
+          ? 3
+          : arch === 'rebuild' || arch === 'development'
+            ? 6
+            : 4;
+        highNeedPositions = highNeedPositions.slice(0, maxNeedSlots);
+        if (Number(needs.QB ?? 0) >= 1.12 && !highNeedPositions.includes('QB')) {
+          highNeedPositions = ['QB', ...highNeedPositions].slice(0, maxNeedSlots);
+        }
 
         if (highNeedPositions.length === 0) return;
 
@@ -491,17 +503,27 @@ class AiLogic {
                 const age = Number(fa?.age ?? 27);
                 const isVeteran = age >= 30;
                 const isExpensive = Number(demand?.baseAnnual ?? 0) >= 14;
-                const avoidVeteranSpend = ['rebuild', 'development'].includes(strategy?.archetype) && isVeteran && isExpensive;
+                const avoidVeteranSpend = (['rebuild', 'development'].includes(strategy?.archetype) && isVeteran && isExpensive)
+                    || (strategy?.archetype === 'retool' && age >= 31 && isExpensive);
                 if (avoidVeteranSpend) continue;
 
                 const capHit = demand.baseAnnual + (demand.signingBonus / demand.yearsTotal);
-                const capLimit = strategy?.archetype === 'contender'
-                    ? 0.8
+                const capHealth = Number(strategy?.capHealth ?? 55);
+                let capLimit = strategy?.archetype === 'contender'
+                    ? 0.74
                     : ['rebuild', 'development'].includes(strategy?.archetype)
-                        ? 0.45
-                        : 0.65;
+                        ? 0.42
+                        : strategy?.archetype === 'middle'
+                          ? 0.58
+                          : 0.62;
+                if (capHealth < 28) capLimit *= 0.68;
+                else if (capHealth < 40) capLimit *= 0.86;
                 const maxAllowedHit = Math.max(3, Number(team.capRoom ?? 0) * capLimit);
-                if (!urgentPos && capHit > maxAllowedHit) continue;
+                const qbDesperate = pos === 'QB' && Number(needs.QB ?? 0) >= 1.12;
+                if (!urgentPos && capHit > maxAllowedHit) {
+                    const qbException = qbDesperate && capHit <= maxAllowedHit * 1.28 && capHealth >= 18;
+                    if (!qbException) continue;
+                }
 
                 // Check Cap
                 if ((team.capRoom ?? 0) > (capHit + 1)) {

--- a/src/core/aiTeamStrategy.js
+++ b/src/core/aiTeamStrategy.js
@@ -136,11 +136,15 @@ function buildPositionalNeed(group, roster, archetype = 'middle') {
 }
 
 function classifyArchetype({ winPct, rosterStrength, capHealth, qbNeedPriority }) {
-  if (winPct >= 0.67 && rosterStrength >= 74 && qbNeedPriority < 62) return 'contender';
-  if (winPct >= 0.55 && rosterStrength >= 70) return 'playoff_hunt';
-  if (winPct <= 0.32 && (capHealth <= 45 || qbNeedPriority >= 70)) return 'rebuild';
-  if (winPct <= 0.4 && rosterStrength < 66) return 'development';
-  if (winPct <= 0.45 || capHealth <= 35) return 'retool';
+  // Strong roster can carry a softer record into contender territory without
+  // letting obvious QB holes project as win-now.
+  if (winPct >= 0.58 && rosterStrength >= 78 && qbNeedPriority < 58) return 'contender';
+  if (winPct >= 0.64 && rosterStrength >= 73 && qbNeedPriority < 62) return 'contender';
+  if (winPct >= 0.53 && rosterStrength >= 69) return 'playoff_hunt';
+  if (winPct <= 0.34 && (capHealth <= 48 || qbNeedPriority >= 72)) return 'rebuild';
+  if (winPct <= 0.28 && rosterStrength < 70) return 'rebuild';
+  if (winPct <= 0.42 && rosterStrength < 65 && rosterStrength >= 48) return 'development';
+  if (winPct <= 0.46 || capHealth <= 38) return 'retool';
   return 'middle';
 }
 
@@ -193,7 +197,7 @@ export function buildAiTeamStrategy({
   const capRoom = toNum(team?.capRoom, 0);
   const deadCap = toNum(team?.deadCap, 0);
   const capUsed = toNum(team?.capUsed, 0);
-  const capHealth = clamp(Math.round(60 + capRoom * 2 - deadCap * 2 - Math.max(0, capUsed - 295) * 1.1), 0, 100);
+  const capHealth = clamp(Math.round(60 + capRoom * 2 - deadCap * 2 - Math.max(0, capUsed - 295) * 1.05), 0, 100);
   const rosterStrength = Math.round(avg(normalizedRoster.map((p) => p.ovr)));
   const ageCurve = {
     avgAge: Number(avg(normalizedRoster.map((p) => p.age)).toFixed(1)),
@@ -222,6 +226,11 @@ export function buildAiTeamStrategy({
     `Record profile ${(winPct * 100).toFixed(1)}% win pace.`,
     `Roster strength ${rosterStrength || 0} OVR with cap health ${capHealth}.`,
     topNeed ? `Top need ${topNeed.positionGroup} (${topNeed.severity}).` : 'No clear top need.',
+    qBPlaceholderNeeds >= 68
+      ? 'QB room grades as a priority risk.'
+      : qBPlaceholderNeeds <= 35
+        ? 'QB situation looks stable for the window.'
+        : 'QB need is manageable relative to other roster spots.',
   ];
 
   return {
@@ -246,6 +255,23 @@ export function buildAiTeamStrategy({
   };
 }
 
+/**
+ * Map a roster position code to aiTeamStrategy positional need groups (QB, DL_EDGE, …).
+ * Used by draft/FA scoring so OL/DL/LB variants pick up grouped need priorities.
+ * @param {string|null|undefined} pos
+ * @returns {string|null}
+ */
+export function mapPlayerPosToNeedGroup(pos) {
+  const p = String(pos ?? '').toUpperCase();
+  if (!p) return null;
+  for (const group of POSITION_GROUPS) {
+    const accepted = GROUP_TO_POS[group];
+    if (accepted?.includes(p)) return group;
+    if (!accepted && group === p) return group;
+  }
+  return null;
+}
+
 export function buildAiTeamStrategyFromRosterAnalysis({
   team = {},
   analysis = null,
@@ -265,5 +291,6 @@ export const __internal = Object.freeze({
   DEPTH_TARGET,
   classifyArchetype,
   buildPositionalNeed,
+  mapPlayerPosToNeedGroup,
 });
 

--- a/src/core/trade-logic.js
+++ b/src/core/trade-logic.js
@@ -53,6 +53,11 @@ const MAX_TRADES_PER_WEEK = 2;
 /** Value ratio tolerance (±10 % of fair value). */
 const VALUE_TOLERANCE = 0.10;
 
+/** CPU vs CPU uniform swaps avoid quarterbacks (validation + narrative safety). */
+export function shouldBlockCpuUniformPlayerSwap(playerA, playerB) {
+  return String(playerA?.pos ?? '') === 'QB' || String(playerB?.pos ?? '') === 'QB';
+}
+
 // ── Asset Valuation ───────────────────────────────────────────────────────────
 
 /**
@@ -299,6 +304,8 @@ export async function runAIToAITrades() {
       // Check trade fairness: values must be within ±VALUE_TOLERANCE.
       const ratio = valueA / valueB;
       if (ratio < (1 - VALUE_TOLERANCE) || ratio > (1 + VALUE_TOLERANCE)) continue;
+
+      if (shouldBlockCpuUniformPlayerSwap(playerFromA, playerFromB)) continue;
 
       // Trade is fair — execute it.
       await executeTrade(teamA.id, playerFromA, teamB.id, playerFromB);

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -170,7 +170,7 @@ import {
 import { deriveGamePlanMultipliers } from '../core/sim/gamePlanMultipliers.ts';
 import { buildGamePlanNarrative } from '../core/narrative.js';
 import { buildRosterBuildingAnalysis } from '../core/rosterBuildingAnalysis.js';
-import { buildAiTeamStrategy } from '../core/aiTeamStrategy.js';
+import { buildAiTeamStrategy, mapPlayerPosToNeedGroup } from '../core/aiTeamStrategy.js';
 
 // ── DB Reload Guard ───────────────────────────────────────────────────────────
 // Register a callback with db/index.js so that when IDB fires onblocked or
@@ -7860,6 +7860,8 @@ async function handleSimDraftPick(payload, id) {
 
   // Optimisation: Filter draft pool once
   const draftPool = cache.getAllPlayers().filter(p => p.status === 'draft_eligible');
+  /** @type {Map<string, number>} key `${teamId}|${needGroup}` → picks already made this draft run */
+  const sessionPicksByTeamNeedGroup = new Map();
 
   while (currentPickIndex < picks.length) {
     const pick = picks[currentPickIndex];
@@ -7894,23 +7896,42 @@ async function handleSimDraftPick(payload, id) {
           schemeFit: p?.schemeFit ?? 65,
           archetypeTag: p?.archetypeTag ?? p?.pos,
         }, team, { teamNeeds: needs });
-        const posPriority = Number(needPriorityByPos.get(p?.pos) ?? 0);
+        const needGroup = mapPlayerPosToNeedGroup(p?.pos) ?? String(p?.pos ?? '');
+        let posPriority = Number(needPriorityByPos.get(needGroup) ?? 0);
+        const qbNeedP = Number(needPriorityByPos.get('QB') ?? 0);
+        if (String(p?.pos) === 'QB' && qbNeedP >= 56) {
+          posPriority = Math.min(100, posPriority + Math.round((qbNeedP - 52) * 0.55));
+        }
         const talentGapGuard = Math.max(0, Number((p?.ovr ?? 60) - 80));
         const archetypeNeedFactor = strategy?.archetype === 'contender'
-          ? 0.05
+          ? 0.056
           : ['rebuild', 'development'].includes(strategy?.archetype)
-            ? 0.08
-            : 0.065;
-        const needBoost = Math.min(7.5, posPriority * archetypeNeedFactor);
+            ? 0.086
+            : 0.069;
+        const needBoost = Math.min(6.75, posPriority * archetypeNeedFactor);
         // Keep BPA available: suppress need boost on clearly elite prospects.
-        const eliteProspectReduction = talentGapGuard >= 8 ? 0.25 : talentGapGuard >= 4 ? 0.55 : 1;
-        const val = Number(boardScore?.score ?? 0) + (needBoost * eliteProspectReduction);
+        const eliteProspectReduction = talentGapGuard >= 8 ? 0.22 : talentGapGuard >= 4 ? 0.52 : 1;
+        const sessionKey = `${pick.teamId}|${needGroup}`;
+        const dupDepth = Number(sessionPicksByTeamNeedGroup.get(sessionKey) || 0);
+        const hoardPenalty = dupDepth > 0
+          ? Math.min(3.6, dupDepth * 1.75) * (eliteProspectReduction < 0.95 ? 0.42 : 1)
+          : 0;
+        const val = Number(boardScore?.score ?? 0) + (needBoost * eliteProspectReduction) - hoardPenalty;
 
         if (val > bestValue) {
             bestValue = val;
             bestProspect = p;
             bestIdx = i;
-        } else if (val === bestValue && (!bestProspect || (p.ovr > bestProspect.ovr))) {
+        } else if (val === bestValue && bestProspect) {
+            const rBest = Number(bestProspect?.interviewReport?.riskScore ?? 40);
+            const rNew = Number(p?.interviewReport?.riskScore ?? 40);
+            const ovrNew = Number(p?.ovr ?? 0);
+            const ovrBest = Number(bestProspect?.ovr ?? 0);
+            if (ovrNew > ovrBest || (ovrNew === ovrBest && rNew < rBest)) {
+              bestProspect = p;
+              bestIdx = i;
+            }
+        } else if (val === bestValue && !bestProspect) {
             bestProspect = p;
             bestIdx = i;
         }
@@ -7919,6 +7940,9 @@ async function handleSimDraftPick(payload, id) {
     if (!bestProspect) break; // pool exhausted
 
     _executeDraftPick(currentPickIndex, bestProspect.id, pick.teamId);
+    const pickedGroup = mapPlayerPosToNeedGroup(bestProspect?.pos) ?? String(bestProspect?.pos ?? '');
+    const sgKey = `${pick.teamId}|${pickedGroup}`;
+    sessionPicksByTeamNeedGroup.set(sgKey, Number(sessionPicksByTeamNeedGroup.get(sgKey) || 0) + 1);
     await logDraftPickTransaction(ensureDynastyMeta(cache.getMeta()), pick, bestProspect.id);
     // _executeDraftPick increments draftState.currentPickIndex inside setMeta;
     // read the updated value from the live meta reference


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This pass tunes CPU-facing weights and guardrails without rewriting FA, draft, trade pipelines, or scouting or development systems. Work is grounded in harness and code inspection. The dynasty audit CLI did not finish within a 45-minute wall clock in this agent environment on the throttled full-league sim, so no fresh `artifacts/dynasty-soak/latest.json` was captured here. `npm run test:soak`, `tests/integration/dynastySoak.test.js`, and the other checks listed below are green.

## Audit and code findings that drove changes

1. **Draft need boost was largely blind for grouped positions** — `needPriorityByPos` keys are strategy groups (`DL_EDGE`, `OL`, `KP`, …) but the worker looked up `p.pos` (`DE`, `OT`, …), so need-based draft pressure often read as zero for DL or OL variants. That weakens need versus BPA for premium spots without touching prospect generation.
2. **FA offer queue could starve QB on thin rebuild boards** — sorting only by raw `needs[pos]`, a sparse roster could fill the daily slot budget with defensive groups while **QB** sat below the slice threshold even when `needs.QB >= 1.2`. A minimal synthetic roster reproduces this.
3. **Cap-stressed middle teams** could still entertain large non-urgent cap hits relative to room; contenders had a wide `0.8 * capRoom` band.

## Archetype and cap snapshot (`aiTeamStrategy.js`)

- **Contender path**: allow a high-roster team with about a 0.58 win pace when QB need is clean; keep a stricter bar at 0.64 wins and 73 roster strength with a QB gate.
- **Playoff hunt**: 0.53 wins and 69 roster strength (slightly broader middle).
- **Rebuild and development**: split poor records without forcing every weak roster into development; add an explicit disaster-season rebuild line.
- **Retool**: slightly relaxed cap floor (38 versus 35) and win band (0.46).
- **Cap health formula**: soften the cap-used overrun penalty (1.05 versus 1.1).
- **Reasons**: fourth line explains QB pressure versus stability for explainability.
- **`mapPlayerPosToNeedGroup`**: new exported helper and `__internal` mirror for tests.

## Free agency (`ai-logic.js`)

- Sort high-need positions with a **QB bias** so QB stays competitive against inflated default need groups on thin rosters.
- **Slot limits**: three active need buckets per day for contender or playoff hunt; six for rebuild or development, with QB forced in when `needs.QB` is at least 1.12 but was sliced out.
- **Cap bands**: contender 0.74, middle 0.58, rebuild or development 0.42, retool 0.62, scaled down when `strategy.capHealth` is poor.
- **Veterans**: retool teams skip expensive deals for ages 31 and up; rebuild and development behavior preserved.
- **QB exception**: when cap hit exceeds the normal band but QB need is real (`needs.QB` at least 1.12) and the deal is only modestly over the band, allow a controlled offer. Final `capRoom` check unchanged.

## Draft AI (`worker.js`, `handleSimDraftPick`)

- Resolve need priority via **`mapPlayerPosToNeedGroup`** plus extra **QB need ramp** when the QB group is stressed.
- Slightly retuned `archetypeNeedFactor`, lower **needBoost** cap (6.75), stronger elite suppression so BPA stays primary.
- **Same-draft hoarding guard**: small penalty when a team already picked the same need group in this auto-pick run, scaled down for elite prospects.
- **Tie-break**: at equal score, prefer lower interview `riskScore` before raw overall (light scouting context only).

## CPU versus CPU trades (`trade-logic.js`)

- Skip uniform player swaps that involve a **quarterback**. Exported `shouldBlockCpuUniformPlayerSwap` for unit tests. User trades unchanged.

## Tests added or extended

- `aiTeamStrategy`: mapping, elite roster contender, weak roster band, QB reason line.
- `aiFreeAgencyOffers`: cap-tight middle splash refusal, QB exception path.
- `trade-logic`: QB block helper.

## Commands run on this branch

- `npm ci`
- `npm run test:unit` (762 tests)
- `npm run test:soak`
- `npm run build`
- `npm run check:deploy`
- `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js`
- `npx playwright install chromium` (browsers were missing on the image)
- `npx playwright test` (18 tests)
- `npm run audit:dynasty -- --ci --seed=1383` — did not complete within a 45-minute wall in this environment; please run on CI or a longer local job to capture `artifacts/dynasty-soak/latest.json`.

## Risks and follow-ups

- Dynasty audit CLI runtime remains heavy on throttled sims; profiling `SIM_TO_PHASE` batch sizes may help CI time.
- CPU uniform trade QB ban is conservative by design.
- FA QB sort lift (0.72) is a fixed constant; tune with real audit distributions when available.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1db42a9-b47c-4547-a143-e3993d323a36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1db42a9-b47c-4547-a143-e3993d323a36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

