### PR TITLE
Tighten dynasty soak numeric CLI parsing

### DIFF
--- a/src/testSupport/dynastySoakCli.js
+++ b/src/testSupport/dynastySoakCli.js
@@ -18,13 +18,20 @@ Options:
   --teams=N               Reserved; only 32 is supported (smaller leagues deferred — see report)
 `;
 
-function parseEq(argv, i, prefix) {
-  const a = argv[i];
-  if (a.startsWith(`${prefix}=`)) return a.slice(prefix.length + 1);
-  if (a === prefix && argv[i + 1] != null && !String(argv[i + 1]).startsWith('-')) {
-    return argv[i + 1];
+function parseRequiredNumber(flag, value, errors) {
+  const rawValue = value == null ? '' : String(value);
+  if (rawValue.trim() === '') {
+    errors.push(`${flag} requires a finite number`);
+    return { ok: false, value: null };
   }
-  return null;
+
+  const numberValue = Number(rawValue);
+  if (!Number.isFinite(numberValue)) {
+    errors.push(`${flag} requires a finite number`);
+    return { ok: false, value: null };
+  }
+
+  return { ok: true, value: numberValue };
 }
 
 /**
@@ -52,45 +59,55 @@ export function parseDynastySoakArgv(argv) {
       /* reserved: default harness already runs full probes on the last season */
     } else if (a === '--deep-each-season') raw.deepEachSeason = true;
     else if (a === '--skip-report-open') raw.skipReportOpen = true;
-    else if (a.startsWith('--seasons=')) raw.seasons = Number(a.split('=')[1]);
-    else if (a.startsWith('--seed=')) raw.seed = Number(a.split('=')[1]);
-    else if (a.startsWith('--outDir=')) raw.outDir = a.split('=').slice(1).join('=');
-    else if (a.startsWith('--phase-timeout-ms=')) raw.phaseTimeoutMs = Number(a.split('=')[1]);
-    else if (a.startsWith('--max-runtime-ms=')) raw.maxRuntimeMs = Number(a.split('=')[1]);
-    else if (a.startsWith('--teams=')) raw.teams = Number(a.split('=')[1]);
-    else if (a === '--seasons') {
+    else if (a.startsWith('--seasons=')) {
+      const parsed = parseRequiredNumber('--seasons', a.slice('--seasons='.length), errors);
+      if (parsed.ok) raw.seasons = parsed.value;
+    } else if (a.startsWith('--seed=')) {
+      const parsed = parseRequiredNumber('--seed', a.slice('--seed='.length), errors);
+      if (parsed.ok) raw.seed = parsed.value;
+    } else if (a.startsWith('--outDir=')) raw.outDir = a.split('=').slice(1).join('=');
+    else if (a.startsWith('--phase-timeout-ms=')) {
+      const parsed = parseRequiredNumber('--phase-timeout-ms', a.slice('--phase-timeout-ms='.length), errors);
+      if (parsed.ok) raw.phaseTimeoutMs = parsed.value;
+    } else if (a.startsWith('--max-runtime-ms=')) {
+      const parsed = parseRequiredNumber('--max-runtime-ms', a.slice('--max-runtime-ms='.length), errors);
+      if (parsed.ok) raw.maxRuntimeMs = parsed.value;
+    } else if (a.startsWith('--teams=')) {
+      const parsed = parseRequiredNumber('--teams', a.slice('--teams='.length), errors);
+      if (parsed.ok) raw.teams = parsed.value;
+    } else if (a === '--seasons') {
       const v = argv[i + 1];
-      if (v == null || String(v).startsWith('-')) errors.push('--seasons requires a number');
-      else {
-        raw.seasons = Number(v);
+      const parsed = parseRequiredNumber('--seasons', v, errors);
+      if (parsed.ok) {
+        raw.seasons = parsed.value;
         i += 1;
       }
     } else if (a === '--seed') {
       const v = argv[i + 1];
-      if (v == null || String(v).startsWith('-')) errors.push('--seed requires a number');
-      else {
-        raw.seed = Number(v);
+      const parsed = parseRequiredNumber('--seed', v, errors);
+      if (parsed.ok) {
+        raw.seed = parsed.value;
         i += 1;
       }
     } else if (a === '--phase-timeout-ms') {
       const v = argv[i + 1];
-      if (v == null || String(v).startsWith('-')) errors.push('--phase-timeout-ms requires a number');
-      else {
-        raw.phaseTimeoutMs = Number(v);
+      const parsed = parseRequiredNumber('--phase-timeout-ms', v, errors);
+      if (parsed.ok) {
+        raw.phaseTimeoutMs = parsed.value;
         i += 1;
       }
     } else if (a === '--max-runtime-ms') {
       const v = argv[i + 1];
-      if (v == null || String(v).startsWith('-')) errors.push('--max-runtime-ms requires a number');
-      else {
-        raw.maxRuntimeMs = Number(v);
+      const parsed = parseRequiredNumber('--max-runtime-ms', v, errors);
+      if (parsed.ok) {
+        raw.maxRuntimeMs = parsed.value;
         i += 1;
       }
     } else if (a === '--teams') {
       const v = argv[i + 1];
-      if (v == null || String(v).startsWith('-')) errors.push('--teams requires a number');
-      else {
-        raw.teams = Number(v);
+      const parsed = parseRequiredNumber('--teams', v, errors);
+      if (parsed.ok) {
+        raw.teams = parsed.value;
         i += 1;
       }
     } else if (a.startsWith('-')) {

--- a/tests/unit/dynastySoakCli.test.js
+++ b/tests/unit/dynastySoakCli.test.js
@@ -28,6 +28,24 @@ describe('dynastySoakCli', () => {
     expect(errors.length).toBeGreaterThan(0);
   });
 
+  it('rejects invalid numeric args in equals form', () => {
+    for (const flag of ['--seasons', '--seed', '--phase-timeout-ms', '--max-runtime-ms', '--teams']) {
+      for (const value of ['', 'NaN', 'Infinity', 'abc']) {
+        const { errors } = parseDynastySoakArgv(['node', 'x.mjs', `${flag}=${value}`]);
+        expect(errors.length, `${flag}=${value}`).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('rejects invalid numeric args in space-separated form', () => {
+    for (const flag of ['--seasons', '--seed', '--phase-timeout-ms', '--max-runtime-ms', '--teams']) {
+      for (const value of ['', 'NaN', 'Infinity', 'abc']) {
+        const { errors } = parseDynastySoakArgv(['node', 'x.mjs', flag, value]);
+        expect(errors.length, `${flag} ${value}`).toBeGreaterThan(0);
+      }
+    }
+  });
+
   it('resolves CI defaults and phase timeout', () => {
     const { raw } = parseDynastySoakArgv(['node', 'x.mjs', '--ci']);
     const { errors, resolved } = resolveDynastySoakConfig(raw);


### PR DESCRIPTION
### Motivation
- The CLI accepted empty strings, `NaN`, `Infinity`, and other non-finite values as numeric flags which could later be coerced or clamped in `resolveDynastySoakConfig()` and hide user errors.  The intent is to fail fast on invalid numeric inputs. 

### Description
- Added a shared helper `parseRequiredNumber(flag, value, errors)` to validate numeric flag values and return `{ ok, value }` for use by the parser. 
- Applied the helper to both `--flag=value` and `--flag value` forms for `--seasons`, `--seed`, `--phase-timeout-ms`, `--max-runtime-ms`, and `--teams` inside `parseDynastySoakArgv()` so invalid inputs produce parse errors. 
- Left bounds/clamping behavior in `resolveDynastySoakConfig()` unchanged so only finite numeric inputs are clamped/validated further. 
- Added unit tests in `tests/unit/dynastySoakCli.test.js` to assert invalid numeric args produce `errors.length > 0` for equals and space-separated forms. 

### Testing
- Ran the targeted unit tests with `npm run test:unit -- tests/unit/dynastySoakCli.test.js` and the test file passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01fa6a21bc832dac8ff50ad6c86dd6)