### PR TITLE
Fix dynasty soak preseason boundary

### DIFF
--- a/src/testSupport/dynastySoakRunner.js
+++ b/src/testSupport/dynastySoakRunner.js
@@ -143,12 +143,12 @@ function topSlowCheckpoints(checkpoints, n = 10) {
  * @param {number} simTimeoutMs
  * @param {{ checkpoints: object[], label: string }} ctx
  */
-async function simUntilPreseason(simTimeoutMs, ctx) {
+async function simUntilPreseason(simTimeoutMs, ctx, runnerDispatch = dispatchWorker) {
   let lastMsg = null;
   const attempts = [];
   for (let attempt = 0; attempt < 12; attempt += 1) {
     const t = Date.now();
-    lastMsg = await dispatchWorker(
+    lastMsg = await runnerDispatch(
       toWorker.SIM_TO_PHASE,
       { targetPhase: 'preseason' },
       { timeoutMs: simTimeoutMs },
@@ -174,6 +174,53 @@ async function simUntilPreseason(simTimeoutMs, ctx) {
   return { lastMsg, attempts };
 }
 
+
+/**
+ * When the current view is already in the target phase, SIM_TO_PHASE can return
+ * immediately without crossing a season boundary. Advance at least one real
+ * worker tick first so a preseason-starting soak still simulates a full season.
+ * @param {any} view
+ * @param {{ checkpoints: object[], label: string, phaseTimeoutMs: number, runnerDispatch?: Function }} ctx
+ */
+async function advanceOutOfCurrentTargetPhase(view, ctx) {
+  const phaseBefore = String(view?.phase ?? '');
+  const yearBefore = Number(view?.year ?? 0);
+  let phaseAfter = phaseBefore;
+  let yearAfter = yearBefore;
+  let lastMsg = { payload: view };
+  let currentView = view ?? {};
+  let advances = 0;
+  const runnerDispatch = ctx.runnerDispatch || dispatchWorker;
+  const t = Date.now();
+
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    advances += 1;
+    lastMsg = await runnerDispatch(
+      toWorker.ADVANCE_WEEK,
+      { skipUserGame: true },
+      { timeoutMs: ctx.phaseTimeoutMs },
+    );
+    if (lastMsg.type === toUI.ERROR) break;
+
+    currentView = { ...currentView, ...(lastMsg.payload ?? {}) };
+    lastMsg = { ...lastMsg, payload: currentView };
+    phaseAfter = String(currentView.phase ?? '');
+    yearAfter = Number(currentView.year ?? 0);
+
+    if (phaseAfter !== phaseBefore || yearAfter !== yearBefore) break;
+  }
+
+  pushCheckpoint(ctx.checkpoints, `${ctx.label}.advance_out_of_${phaseBefore}`, Date.now() - t, {
+    phaseBefore,
+    phaseAfter,
+    yearBefore,
+    yearAfter,
+    advances,
+  });
+
+  return { lastMsg, phaseBefore, phaseAfter, yearBefore, yearAfter, advances };
+}
+
 function checkMaxRuntime(t0, maxRuntimeMs) {
   if (maxRuntimeMs == null || !Number.isFinite(maxRuntimeMs)) return;
   if (Date.now() - t0 > maxRuntimeMs) {
@@ -193,6 +240,8 @@ function checkMaxRuntime(t0, maxRuntimeMs) {
  * @property {number} [phaseTimeoutMs] - alias override for simTimeoutMs / GET timeouts
  * @property {number|null} [maxRuntimeMs]
  * @property {function} [onBroadcast]
+ * @property {function} [dispatchWorker] - test hook for worker dispatches
+ * @property {function} [loadWorkerModule] - test hook for worker module loading
  */
 
 /**
@@ -213,6 +262,8 @@ export async function runDynastySoakOnce(opts = {}) {
     opts.maxRuntimeMs === null || opts.maxRuntimeMs === undefined
       ? null
       : Number(opts.maxRuntimeMs);
+  const runnerDispatch = typeof opts.dispatchWorker === 'function' ? opts.dispatchWorker : dispatchWorker;
+  const runnerLoadWorkerModule = typeof opts.loadWorkerModule === 'function' ? opts.loadWorkerModule : loadWorkerModule;
 
   const checkpoints = [];
   const simAttemptsPerSeason = [];
@@ -266,16 +317,16 @@ export async function runDynastySoakOnce(opts = {}) {
   let lastReportSummary = null;
 
   try {
-    await loadWorkerModule();
+    await runnerLoadWorkerModule();
 
     let t = Date.now();
-    await dispatchWorker(toWorker.INIT, {}, { timeoutMs: Math.min(120_000, phaseTimeoutMs) });
+    await runnerDispatch(toWorker.INIT, {}, { timeoutMs: Math.min(120_000, phaseTimeoutMs) });
     pushCheckpoint(checkpoints, 'boot.INIT', Date.now() - t, null);
 
     checkMaxRuntime(t0, maxRuntimeMs);
 
     t = Date.now();
-    const bootMsg = await dispatchWorker(
+    const bootMsg = await runnerDispatch(
       toWorker.USE_SAFE_STARTER_LEAGUE,
       {
         slotKey: 'save_slot_1',
@@ -296,8 +347,39 @@ export async function runDynastySoakOnce(opts = {}) {
       const phaseBefore = String(view?.phase ?? '');
       const fullProbes = deepEachSeason || s === seasons;
 
+      if (phaseBefore === 'preseason') {
+        const advanceResult = await advanceOutOfCurrentTargetPhase(view, {
+          checkpoints,
+          label: `S${s}`,
+          phaseTimeoutMs,
+          runnerDispatch,
+        });
+        if (advanceResult.lastMsg.type === toUI.ERROR) {
+          mergeAudit(
+            aggregate,
+            {
+              passed: false,
+              severity: 'error',
+              seasonsSimmed: s,
+              checks: [],
+              warnings: [],
+              failures: [
+                {
+                  code: 'advance_out_of_preseason_error',
+                  message: advanceResult.lastMsg.payload?.message || 'ADVANCE_WEEK error leaving preseason',
+                },
+              ],
+              summary: aggregate.summary,
+            },
+            `S${s}`,
+          );
+          break;
+        }
+        view = advanceResult.lastMsg.payload;
+      }
+
       const simCtx = { checkpoints, label: `S${s}` };
-      const { lastMsg: simMsg, attempts } = await simUntilPreseason(simTimeoutMs, simCtx);
+      const { lastMsg: simMsg, attempts } = await simUntilPreseason(simTimeoutMs, simCtx, runnerDispatch);
       simAttemptsPerSeason.push({ season: s, attempts });
 
       if (simMsg.type === toUI.ERROR) {
@@ -366,11 +448,11 @@ export async function runDynastySoakOnce(opts = {}) {
       }
 
       let tProbe = Date.now();
-      const allSeasonsMsg = await dispatchWorker(toWorker.GET_ALL_SEASONS, {}, { timeoutMs: phaseTimeoutMs });
+      const allSeasonsMsg = await runnerDispatch(toWorker.GET_ALL_SEASONS, {}, { timeoutMs: phaseTimeoutMs });
       pushCheckpoint(checkpoints, `S${s}.GET_ALL_SEASONS`, Date.now() - tProbe, { fullProbes });
 
       tProbe = Date.now();
-      const txMsg = await dispatchWorker(
+      const txMsg = await runnerDispatch(
         toWorker.GET_TRANSACTIONS,
         { mode: 'recent', limit: 400 },
         { timeoutMs: phaseTimeoutMs },
@@ -380,7 +462,7 @@ export async function runDynastySoakOnce(opts = {}) {
       let txSeasonMsg;
       if (fullProbes) {
         tProbe = Date.now();
-        txSeasonMsg = await dispatchWorker(
+        txSeasonMsg = await runnerDispatch(
           toWorker.GET_TRANSACTIONS,
           { seasonId: view?.seasonId, limit: 200 },
           { timeoutMs: phaseTimeoutMs },
@@ -395,15 +477,15 @@ export async function runDynastySoakOnce(opts = {}) {
       let draftClassesMsg;
       if (fullProbes) {
         tProbe = Date.now();
-        recordsMsg = await dispatchWorker(toWorker.GET_RECORDS, {}, { timeoutMs: phaseTimeoutMs });
+        recordsMsg = await runnerDispatch(toWorker.GET_RECORDS, {}, { timeoutMs: phaseTimeoutMs });
         pushCheckpoint(checkpoints, `S${s}.GET_RECORDS`, Date.now() - tProbe, null);
 
         tProbe = Date.now();
-        hofMsg = await dispatchWorker(toWorker.GET_HALL_OF_FAME, {}, { timeoutMs: phaseTimeoutMs });
+        hofMsg = await runnerDispatch(toWorker.GET_HALL_OF_FAME, {}, { timeoutMs: phaseTimeoutMs });
         pushCheckpoint(checkpoints, `S${s}.GET_HALL_OF_FAME`, Date.now() - tProbe, null);
 
         tProbe = Date.now();
-        draftClassesMsg = await dispatchWorker(toWorker.GET_DRAFT_CLASSES, {}, { timeoutMs: phaseTimeoutMs });
+        draftClassesMsg = await runnerDispatch(toWorker.GET_DRAFT_CLASSES, {}, { timeoutMs: phaseTimeoutMs });
         pushCheckpoint(checkpoints, `S${s}.GET_DRAFT_CLASSES`, Date.now() - tProbe, null);
       } else {
         recordsMsg = { type: toUI.RECORDS, payload: null };
@@ -418,7 +500,7 @@ export async function runDynastySoakOnce(opts = {}) {
       let getSeasonHistorySkipped = !fullProbes;
       if (fullProbes && latestSeason?.id) {
         tProbe = Date.now();
-        const histMsg = await dispatchWorker(
+        const histMsg = await runnerDispatch(
           toWorker.GET_SEASON_HISTORY,
           { seasonId: latestSeason.id },
           { timeoutMs: phaseTimeoutMs },
@@ -511,7 +593,7 @@ export async function runDynastySoakOnce(opts = {}) {
       }
 
       tProbe = Date.now();
-      await dispatchWorker(toWorker.ADVANCE_WEEK, { skipUserGame: true }, { timeoutMs: phaseTimeoutMs });
+      await runnerDispatch(toWorker.ADVANCE_WEEK, { skipUserGame: true }, { timeoutMs: phaseTimeoutMs });
       pushCheckpoint(checkpoints, `S${s}.ADVANCE_WEEK`, Date.now() - tProbe, null);
     }
 

--- a/tests/unit/dynastySoakRunner.test.js
+++ b/tests/unit/dynastySoakRunner.test.js
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { toUI, toWorker } from '../../src/worker/protocol.js';
+
+const okSummary = {
+  rosterHealth: 'ok',
+  capHealth: 'ok',
+  statHealth: 'ok',
+  archiveHealth: 'ok',
+  aiHealth: 'ok',
+  transactionHealth: 'ok',
+  draftHealth: 'ok',
+  scoutingHealth: 'ok',
+  developmentHealth: 'ok',
+  historyHealth: 'ok',
+};
+
+vi.mock('../../src/core/dynastySoakAudit.js', () => ({
+  runDynastySoakAudit: vi.fn(() => ({
+    passed: true,
+    severity: 'ok',
+    seasonsSimmed: 1,
+    checks: [],
+    warnings: [],
+    failures: [],
+    summary: okSummary,
+    reportSummary: { teamCount: 32 },
+  })),
+  buildPersistenceAssertions: vi.fn(() => ({
+    allOk: true,
+    assertions: [],
+  })),
+}));
+
+function makeState({ phase, year }) {
+  return {
+    phase,
+    year,
+    userTeamId: 0,
+    seasonId: `s${year}`,
+    leagueHistory: [{ id: `s${year - 1}`, year: year - 1 }],
+    teams: [],
+    standings: [],
+    schedule: { weeks: [] },
+  };
+}
+
+describe('runDynastySoakOnce', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('advances out of boot preseason before simming to the next preseason in CI mode', async () => {
+    const calls = [];
+    const bootState = makeState({ phase: 'preseason', year: 2026 });
+    const regularState = makeState({ phase: 'regular', year: 2026 });
+    const nextPreseasonState = makeState({ phase: 'preseason', year: 2027 });
+
+    const dispatchWorker = vi.fn(async (type, payload = {}) => {
+      calls.push({ type, payload });
+      switch (type) {
+        case toWorker.INIT:
+          return { type: toUI.READY, payload: {} };
+        case toWorker.USE_SAFE_STARTER_LEAGUE:
+          return { type: toUI.FULL_STATE, payload: bootState };
+        case toWorker.ADVANCE_WEEK:
+          return {
+            type: toUI.WEEK_COMPLETE,
+            payload: calls.filter((c) => c.type === toWorker.ADVANCE_WEEK).length === 1
+              ? regularState
+              : makeState({ phase: 'regular', year: 2027 }),
+          };
+        case toWorker.SIM_TO_PHASE:
+          expect(payload).toEqual({ targetPhase: 'preseason' });
+          return { type: toUI.FULL_STATE, payload: nextPreseasonState };
+        case toWorker.GET_ALL_SEASONS:
+          return { type: toUI.ALL_SEASONS, payload: { seasons: [{ id: 's2026', year: 2026 }] } };
+        case toWorker.GET_TRANSACTIONS:
+          return { type: toUI.TRANSACTIONS, payload: { transactions: [] } };
+        case toWorker.GET_RECORDS:
+          return { type: toUI.RECORDS, payload: { recordBook: {} } };
+        case toWorker.GET_HALL_OF_FAME:
+          return { type: toUI.HALL_OF_FAME, payload: { players: [] } };
+        case toWorker.GET_DRAFT_CLASSES:
+          return { type: toUI.DRAFT_CLASSES, payload: { classes: [] } };
+        case toWorker.GET_SEASON_HISTORY:
+          return { type: toUI.SEASON_HISTORY, payload: { data: {} } };
+        default:
+          throw new Error(`Unexpected worker call: ${type}`);
+      }
+    });
+
+    const { runDynastySoakOnce } = await import('../../src/testSupport/dynastySoakRunner.js');
+    const result = await runDynastySoakOnce({
+      seasons: 1,
+      seed: 123,
+      ci: true,
+      dispatchWorker,
+      loadWorkerModule: vi.fn(async () => {}),
+    });
+
+    const advanceIndex = calls.findIndex((c) => c.type === toWorker.ADVANCE_WEEK);
+    const simIndex = calls.findIndex((c) => c.type === toWorker.SIM_TO_PHASE);
+    expect(advanceIndex).toBeGreaterThan(-1);
+    expect(simIndex).toBeGreaterThan(advanceIndex);
+    expect(result.finalPhase).toBe('preseason');
+    expect(result.finalYear).toBe(2027);
+    expect(result.failures).toEqual([]);
+
+    const checkpoint = result.checkpoints.find((c) => c.name === 'S1.advance_out_of_preseason');
+    expect(checkpoint?.meta).toMatchObject({
+      phaseBefore: 'preseason',
+      phaseAfter: 'regular',
+      yearBefore: 2026,
+      yearAfter: 2026,
+      advances: 1,
+    });
+
+    const simAttempt = result.simAttemptsPerSeason[0].attempts[0];
+    expect(simAttempt).toMatchObject({ phaseAfter: 'preseason', yearAfter: 2027 });
+    expect(simAttempt.yearAfter).toBeGreaterThan(checkpoint.meta.yearBefore);
+  });
+});


### PR DESCRIPTION
### Motivation
- `SIM_TO_PHASE` can return immediately when the view already reports `preseason`, which meant a requested season might not cross a real season boundary; the runner must ensure each simulated season completes a real phase/week transition. 
- Make the runner testable without the real worker by adding injectable dispatch/load hooks so unit tests can mock worker responses.

### Description
- Added `advanceOutOfCurrentTargetPhase(view, ctx)` which dispatches `ADVANCE_WEEK` (with `{ skipUserGame: true }`) until the phase/year changes or a small attempt cap, and records a `S#.advance_out_of_preseason` checkpoint with `phaseBefore`, `phaseAfter`, `yearBefore`, `yearAfter`, and `advances` metadata. 
- Updated `simUntilPreseason` to accept an optional `runnerDispatch` so it can be driven by a test hook; replaced direct `dispatchWorker` calls with the injected dispatch where appropriate. 
- Added `runnerDispatch` and `runnerLoadWorkerModule` test hooks (via `opts.dispatchWorker` / `opts.loadWorkerModule`) to `runDynastySoakOnce` while preserving default behavior. 
- When a season boot state is `preseason`, `runDynastySoakOnce` now calls the advance helper before `SIM_TO_PHASE` to guarantee a full season boundary is crossed. 
- Added `tests/unit/dynastySoakRunner.test.js` that mocks worker responses and verifies an `ADVANCE_WEEK` occurs before `SIM_TO_PHASE`, the checkpoint metadata, and that the resulting preseason `yearAfter` is greater than `yearBefore`.

### Testing
- Ran unit tests: `npm run test:unit -- tests/unit/dynastySoakRunner.test.js tests/unit/dynastySoakMergeAudit.test.js`, both tests passed (2 files, 2 tests total). 
- Built the app: `npm run build`, which completed successfully (Vite reported existing large chunk-size warnings but build exited OK). 
- The new unit test asserts the `ADVANCE_WEEK` dispatch occurs before `SIM_TO_PHASE`, the checkpoint `S1.advance_out_of_preseason` contains the expected metadata, and the simulated preseason year advanced; the assertion suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01fa604084832db6b4e2cd42a92e24)