### PR TITLE
Fix dynasty soak batch persistence

### DIFF
--- a/src/core/dynastySoakAudit.js
+++ b/src/core/dynastySoakAudit.js
@@ -151,17 +151,63 @@ export function countTransactionTypes(transactions) {
  * @param {object} input
  * @returns {{ allOk: boolean, assertions: { id: string, ok: boolean, detail: string }[] }}
  */
+function transactionBucket(tx) {
+  const raw = String(tx?.type ?? tx?.legacyType ?? '').toLowerCase();
+  if (raw === 'sign' || raw === 'signing') return 'signing';
+  if (raw === 'draft') return 'draft';
+  if (raw === 'retirement') return 'retirement';
+  return raw;
+}
+
+function hasSeasonId(row, seasonId) {
+  return seasonId != null && String(row?.id ?? row?.seasonId ?? '') === String(seasonId);
+}
+
 export function buildPersistenceAssertions(input = {}) {
   const viewState = input.viewState ?? {};
   const leagueHistory = Array.isArray(viewState.leagueHistory) ? viewState.leagueHistory : [];
   const latest = leagueHistory.length ? leagueHistory[leagueHistory.length - 1] : null;
   const assertions = [];
 
+  const latestSeasonId = input.latestSeasonId ?? latest?.id ?? null;
+
   assertions.push({
     id: 'latest_season_archive',
     ok: !!(latest && latest.id),
     detail: latest?.id ? `latest season id=${latest.id}` : 'leagueHistory missing or empty',
   });
+
+  if (Array.isArray(input.allSeasons) && latestSeasonId != null) {
+    const found = input.allSeasons.some((season) => hasSeasonId(season, latestSeasonId));
+    assertions.push({
+      id: 'get_all_seasons_latest',
+      ok: found,
+      detail: found
+        ? `GET_ALL_SEASONS includes latest season ${latestSeasonId}`
+        : `GET_ALL_SEASONS missing latest season ${latestSeasonId}`,
+    });
+  }
+
+  if (input.dbLatestSeasonFound != null) {
+    assertions.push({
+      id: 'db_latest_season_archive',
+      ok: !!input.dbLatestSeasonFound,
+      detail: input.dbLatestSeasonFound
+        ? `IndexedDB contains latest season ${latestSeasonId ?? '(unknown)'}`
+        : `IndexedDB missing latest season ${latestSeasonId ?? '(unknown)'}`,
+    });
+  }
+
+  if (Array.isArray(input.dbAllSeasons) && latestSeasonId != null) {
+    const found = input.dbAllSeasons.some((season) => hasSeasonId(season, latestSeasonId));
+    assertions.push({
+      id: 'db_all_seasons_latest',
+      ok: found,
+      detail: found
+        ? `IndexedDB season list includes latest season ${latestSeasonId}`
+        : `IndexedDB season list missing latest season ${latestSeasonId}`,
+    });
+  }
 
   const hasTx = Array.isArray(input.transactionsRecent) && input.transactionsRecent.length > 0;
   assertions.push({
@@ -218,6 +264,37 @@ export function buildPersistenceAssertions(input = {}) {
           ? 'GET_SEASON_HISTORY returned data'
           : 'GET_SEASON_HISTORY failed or empty',
   });
+
+  if (input.seasonHistory !== undefined && latestSeasonId != null && !input.getSeasonHistorySkipped) {
+    const found = input.seasonHistory && hasSeasonId(input.seasonHistory, latestSeasonId);
+    assertions.push({
+      id: 'get_season_history_latest',
+      ok: !!found,
+      detail: found
+        ? `GET_SEASON_HISTORY returned latest season ${latestSeasonId}`
+        : `GET_SEASON_HISTORY missing latest season ${latestSeasonId}`,
+    });
+  }
+
+  const transactionProbeRows = [
+    ...(Array.isArray(input.transactionsRecent) ? input.transactionsRecent : []),
+    ...(Array.isArray(input.transactionsSeason) ? input.transactionsSeason : []),
+    ...(Array.isArray(input.dbTransactions) ? input.dbTransactions : []),
+  ];
+  const expectedTransactionTypes = Array.isArray(input.expectedTransactionTypes)
+    ? input.expectedTransactionTypes.map((type) => String(type).toLowerCase())
+    : [];
+  if (expectedTransactionTypes.length) {
+    const present = new Set(transactionProbeRows.map(transactionBucket));
+    const missing = expectedTransactionTypes.filter((type) => !present.has(type));
+    assertions.push({
+      id: 'expected_transaction_types',
+      ok: missing.length === 0,
+      detail: missing.length
+        ? `missing transaction buckets: ${missing.join(', ')}`
+        : `found transaction buckets: ${expectedTransactionTypes.join(', ')}`,
+    });
+  }
 
   assertions.push({
     id: 'get_records',

--- a/src/testSupport/dynastySoakRunner.js
+++ b/src/testSupport/dynastySoakRunner.js
@@ -5,6 +5,7 @@
  */
 
 import { toWorker, toUI } from '../worker/protocol.js';
+import { Seasons, Transactions } from '../db/index.js';
 import {
   runDynastySoakAudit,
   buildPersistenceAssertions,
@@ -369,6 +370,10 @@ export async function runDynastySoakOnce(opts = {}) {
       const allSeasonsMsg = await dispatchWorker(toWorker.GET_ALL_SEASONS, {}, { timeoutMs: phaseTimeoutMs });
       pushCheckpoint(checkpoints, `S${s}.GET_ALL_SEASONS`, Date.now() - tProbe, { fullProbes });
 
+      const leagueHistory = view?.leagueHistory ?? [];
+      const latestSeason = leagueHistory.length ? leagueHistory[leagueHistory.length - 1] : null;
+      const latestSeasonId = latestSeason?.id ?? null;
+
       tProbe = Date.now();
       const txMsg = await dispatchWorker(
         toWorker.GET_TRANSACTIONS,
@@ -382,7 +387,7 @@ export async function runDynastySoakOnce(opts = {}) {
         tProbe = Date.now();
         txSeasonMsg = await dispatchWorker(
           toWorker.GET_TRANSACTIONS,
-          { seasonId: view?.seasonId, limit: 200 },
+          { seasonId: latestSeasonId ?? view?.seasonId, limit: 200 },
           { timeoutMs: phaseTimeoutMs },
         );
         pushCheckpoint(checkpoints, `S${s}.GET_TRANSACTIONS_season`, Date.now() - tProbe, null);
@@ -411,8 +416,6 @@ export async function runDynastySoakOnce(opts = {}) {
         draftClassesMsg = { type: toUI.DRAFT_CLASSES, payload: { classes: [] } };
       }
 
-      const leagueHistory = view?.leagueHistory ?? [];
-      const latestSeason = leagueHistory.length ? leagueHistory[leagueHistory.length - 1] : null;
       let seasonHistory = null;
       let getSeasonHistoryOk = null;
       let getSeasonHistorySkipped = !fullProbes;
@@ -432,6 +435,28 @@ export async function runDynastySoakOnce(opts = {}) {
         }
       } else {
         getSeasonHistoryOk = fullProbes ? null : true;
+      }
+
+      const txSeasonRows = txSeasonMsg.payload?.transactions ?? [];
+      let dbLatestSeason = null;
+      let dbAllSeasons = null;
+      let dbTransactions = null;
+      let dbProbeError = null;
+      if (fullProbes && latestSeasonId) {
+        tProbe = Date.now();
+        try {
+          [dbLatestSeason, dbAllSeasons, dbTransactions] = await Promise.all([
+            Seasons.load(latestSeasonId),
+            Seasons.loadRecent(200),
+            Transactions.bySeason(latestSeasonId),
+          ]);
+        } catch (err) {
+          dbProbeError = err;
+        }
+        pushCheckpoint(checkpoints, `S${s}.DB_PERSISTENCE_PROBES`, Date.now() - tProbe, {
+          latestSeasonId,
+          dbProbeOk: !dbProbeError,
+        });
       }
 
       tProbe = Date.now();
@@ -471,7 +496,15 @@ export async function runDynastySoakOnce(opts = {}) {
           expectStatRows: expectStats,
           expectTimelineRows: expectTx,
           seasonTxQueryOk: txSeasonMsg.type !== toUI.ERROR,
-          getSeasonHistoryOk,
+          transactionsSeason: txSeasonRows,
+          allSeasons: allSeasonsMsg.payload?.seasons ?? null,
+          latestSeasonId,
+          seasonHistory,
+          dbLatestSeasonFound: latestSeasonId ? !!dbLatestSeason : null,
+          dbAllSeasons,
+          dbTransactions: dbTransactions ?? [],
+          expectedTransactionTypes: expectTx ? ['draft', 'retirement', 'signing'] : [],
+          getSeasonHistoryOk: dbProbeError ? false : getSeasonHistoryOk,
           getSeasonHistorySkipped,
           recordsProbeOk:
             recordsMsg.type === toUI.ERROR

--- a/src/worker/dirtyFlushAccumulator.js
+++ b/src/worker/dirtyFlushAccumulator.js
@@ -1,0 +1,47 @@
+function emptyDirtySnapshot() {
+  return {
+    meta: false,
+    teams: [],
+    players: [],
+    games: [],
+    seasonStats: [],
+    draftPicks: [],
+  };
+}
+
+function uniqueConcat(a = [], b = []) {
+  return [...new Set([...(Array.isArray(a) ? a : []), ...(Array.isArray(b) ? b : [])])];
+}
+
+export function hasDirtySnapshot(dirty = null) {
+  return !!(
+    dirty?.meta ||
+    dirty?.teams?.length ||
+    dirty?.players?.length ||
+    dirty?.games?.length ||
+    dirty?.seasonStats?.length ||
+    dirty?.draftPicks?.length
+  );
+}
+
+export function mergeDirtySnapshots(...snapshots) {
+  const merged = emptyDirtySnapshot();
+  for (const snapshot of snapshots) {
+    if (!snapshot || typeof snapshot !== 'object') continue;
+    merged.meta = merged.meta || !!snapshot.meta;
+    merged.teams = uniqueConcat(merged.teams, snapshot.teams);
+    merged.players = uniqueConcat(merged.players, snapshot.players);
+    merged.games = [...merged.games, ...(Array.isArray(snapshot.games) ? snapshot.games : [])];
+    merged.seasonStats = uniqueConcat(merged.seasonStats, snapshot.seasonStats);
+    merged.draftPicks = uniqueConcat(merged.draftPicks, snapshot.draftPicks);
+  }
+  return merged;
+}
+
+export function queueDirtySnapshot(currentPending, dirty) {
+  return mergeDirtySnapshots(currentPending, dirty);
+}
+
+export function createEmptyDirtySnapshot() {
+  return emptyDirtySnapshot();
+}

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -53,6 +53,12 @@
  */
 
 import { toWorker, toUI } from './protocol.js';
+import {
+  createEmptyDirtySnapshot,
+  hasDirtySnapshot,
+  mergeDirtySnapshots,
+  queueDirtySnapshot,
+} from './dirtyFlushAccumulator.js';
 import { cache }          from '../db/cache.js';
 import {
   Meta, Teams, Players, Rosters, Games,
@@ -1366,6 +1372,7 @@ function hydrateAllPlayersForDevelopment() {
 // / handleUseSafeStarterLeague.
 // Every other path that might call flushDirty() is therefore safely blocked.
 let _saveIsExplicitlyLoaded = false;
+let pendingBatchDirty = createEmptyDirtySnapshot();
 
 const LEAGUE_DB_PREFIX = 'FootballGM_League_';
 
@@ -1467,7 +1474,8 @@ async function flushDirty(forceFlush = false) {
     return;
   }
 
-  if (!cache.isDirty()) return;
+  const hasPendingBatchDirty = hasDirtySnapshot(pendingBatchDirty);
+  if (!cache.isDirty() && !hasPendingBatchDirty) return;
 
   // SECONDARY SAFETY CHECK: Never flush if cache isn't fully loaded (prevent empty overwrite)
   if (!cache.isLoaded()) {
@@ -1475,16 +1483,23 @@ async function flushDirty(forceFlush = false) {
       return;
   }
 
-  // Node dynasty-soak harness: skip IndexedDB writes during long SIM_TO_PHASE batches, but
-  // still drain dirty flags so dirty tracking does not grow without bound (would slow to a crawl).
+  // Node dynasty-soak harness: skip IndexedDB writes during long SIM_TO_PHASE batches.
+  // Drain the cache so dirty tracking stays bounded, but retain the drained dirty IDs
+  // and write them on the final forced flush instead of discarding them.
   if (typeof globalThis !== 'undefined' && globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__ && !forceFlush) {
     if (cache.isDirty()) {
-      cache.drainDirty();
+      pendingBatchDirty = queueDirtySnapshot(pendingBatchDirty, cache.drainDirty());
+      globalThis.__DYNASTY_SOAK_PENDING_DIRTY__ = pendingBatchDirty;
     }
     return;
   }
 
-  const dirty = cache.drainDirty();
+  const currentDirty = cache.isDirty() ? cache.drainDirty() : createEmptyDirtySnapshot();
+  const dirty = forceFlush
+    ? mergeDirtySnapshots(pendingBatchDirty, currentDirty)
+    : currentDirty;
+
+  if (!hasDirtySnapshot(dirty)) return;
 
   // Resolve dirty IDs → full objects, dropping any that are null (already deleted).
   const teams   = dirty.teams.map(id => cache.getTeam(id)).filter(Boolean);
@@ -1576,6 +1591,13 @@ async function flushDirty(forceFlush = false) {
       });
     }
   } catch (_) { /* non-fatal — manifest is best-effort */ }
+
+  if (forceFlush && hasPendingBatchDirty) {
+    pendingBatchDirty = createEmptyDirtySnapshot();
+    if (typeof globalThis !== 'undefined') {
+      globalThis.__DYNASTY_SOAK_PENDING_DIRTY__ = pendingBatchDirty;
+    }
+  }
 }
 
 // ── Bootstrap ────────────────────────────────────────────────────────────────

--- a/tests/unit/dynastySoakPersistence.test.js
+++ b/tests/unit/dynastySoakPersistence.test.js
@@ -3,6 +3,44 @@ import {
   buildPersistenceAssertions,
   validateTransactionTimelineV1Shape,
 } from '../../src/core/dynastySoakAudit.js';
+import {
+  createEmptyDirtySnapshot,
+  hasDirtySnapshot,
+  mergeDirtySnapshots,
+  queueDirtySnapshot,
+} from '../../src/worker/dirtyFlushAccumulator.js';
+
+describe('dynasty soak batch dirty accumulator', () => {
+  it('keeps dirty IDs drained during batch and merges them into final flush', () => {
+    const drainedDuringBatch = {
+      meta: true,
+      teams: [1],
+      players: ['p1'],
+      games: [{ id: 'g1' }],
+      seasonStats: ['s1_p1'],
+      draftPicks: ['2028_1_1'],
+    };
+    const dirtyAtForcedFlush = {
+      meta: false,
+      teams: [2],
+      players: ['p1', 'p2'],
+      games: [{ id: 'g2' }],
+      seasonStats: ['s1_p2'],
+      draftPicks: ['2028_1_2'],
+    };
+
+    const pending = queueDirtySnapshot(createEmptyDirtySnapshot(), drainedDuringBatch);
+    const finalDirty = mergeDirtySnapshots(pending, dirtyAtForcedFlush);
+
+    expect(hasDirtySnapshot(finalDirty)).toBe(true);
+    expect(finalDirty.meta).toBe(true);
+    expect(finalDirty.teams).toEqual([1, 2]);
+    expect(finalDirty.players).toEqual(['p1', 'p2']);
+    expect(finalDirty.games.map((g) => g.id)).toEqual(['g1', 'g2']);
+    expect(finalDirty.seasonStats).toEqual(['s1_p1', 's1_p2']);
+    expect(finalDirty.draftPicks).toEqual(['2028_1_1', '2028_1_2']);
+  });
+});
 
 describe('buildPersistenceAssertions', () => {
   it('fails when leagueHistory has no latest season', () => {
@@ -23,6 +61,41 @@ describe('buildPersistenceAssertions', () => {
 
   it('fails transaction timeline when rows are malformed type', () => {
     expect(validateTransactionTimelineV1Shape({ schemaVersion: 1, rows: {} }).ok).toBe(false);
+  });
+
+  it('fails when latest completed season is missing from DB-backed archive probes', () => {
+    const r = buildPersistenceAssertions({
+      viewState: {
+        leagueHistory: [
+          {
+            id: 's2',
+            playerSeasonStatsV1: { schemaVersion: 1, rows: [{ playerId: 1, pos: 'QB' }] },
+            transactionTimelineV1: { schemaVersion: 1, rows: [{ rawId: 1, type: 'draft' }] },
+          },
+        ],
+      },
+      allSeasons: [{ id: 's2' }],
+      seasonHistory: { id: 's2' },
+      transactionsRecent: [{ type: 'DRAFT' }, { type: 'SIGN' }],
+      transactionsSeason: [{ type: 'SIGN' }],
+      dbLatestSeasonFound: false,
+      dbAllSeasons: [],
+      dbTransactions: [{ type: 'DRAFT' }],
+      expectedTransactionTypes: ['draft', 'signing'],
+      expectTransactions: true,
+      expectStatRows: true,
+      expectTimelineRows: true,
+      seasonTxQueryOk: true,
+      getSeasonHistoryOk: true,
+      getSeasonHistorySkipped: false,
+      recordsProbeOk: true,
+      hofProbeOk: true,
+      draftClassesProbeOk: true,
+      draftClassCount: 1,
+    });
+    expect(r.allOk).toBe(false);
+    expect(r.assertions.find((a) => a.id === 'db_latest_season_archive')?.ok).toBe(false);
+    expect(r.assertions.find((a) => a.id === 'db_all_seasons_latest')?.ok).toBe(false);
   });
 
   it('passes minimal healthy snapshot', () => {


### PR DESCRIPTION
### Motivation

- Prevent loss of dirty IDs during long dynasty-soak batch runs where the existing non-forced `flushDirty()` branch drained and discarded dirty tracking, causing final forced flush to miss records in IndexedDB.  
- Strengthen persistence probes so the harness verifies data is actually present in the DB (not only in `viewState`/memory) for the latest completed season and transactions.

### Description

- Add a small accumulator module `src/worker/dirtyFlushAccumulator.js` that provides `createEmptyDirtySnapshot()`, `queueDirtySnapshot()`, `mergeDirtySnapshots()`, and helpers to track/merge pending dirty snapshots.  
- Change `flushDirty(forceFlush = false)` in `src/worker/worker.js` to queue drained dirty IDs when `__FOOTBALL_GM_LITE_BATCH_SIM__` is active and to merge the queued IDs with the current dirty set when `flushDirty(true)` is invoked, and only clear the pending accumulator after a successful forced flush; the accumulator is also exposed on `globalThis.__DYNASTY_SOAK_PENDING_DIRTY__` for harness visibility.  
- Extend the harness in `src/testSupport/dynastySoakRunner.js` to perform DB-backed probes (`Seasons.load`, `Seasons.loadRecent`, `Transactions.bySeason`) for the latest completed season and include those results when building persistence assertions.  
- Harden `src/core/dynastySoakAudit.js` `buildPersistenceAssertions()` with new checks: `get_all_seasons_latest`, `db_latest_season_archive`, `db_all_seasons_latest`, `get_season_history_latest`, and `expected_transaction_types` to detect missing DB archives or missing transaction buckets.  
- Add unit tests in `tests/unit/dynastySoakPersistence.test.js` that cover the dirty-accumulator behavior and a failing case when the DB-backed latest-season archive is missing.

### Testing

- Ran targeted unit tests with `npm run test:unit -- tests/unit/dynastySoakPersistence.test.js` and all tests in that file passed (5 tests).  
- Built the production bundle with `npm run build` and the build completed successfully (Vite emitted an existing chunk-size warning only).  
- Added deterministic unit coverage for the new accumulator functions and for the new DB-backed persistence assertions which were exercised by the unit test above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01fa62c15c832d829339ae682d8148)