### PR TITLE
Expose failed persistence probes to dynasty soak audit

### DIFF
--- a/src/core/dynastySoakAudit.js
+++ b/src/core/dynastySoakAudit.js
@@ -149,7 +149,7 @@ export function countTransactionTypes(transactions) {
 /**
  * Harness-only persistence checklist (does not mutate state).
  * @param {object} input
- * @returns {{ allOk: boolean, assertions: { id: string, ok: boolean, detail: string }[] }}
+ * @returns {{ allOk: boolean, assertions: { id: string, ok: boolean, detail: string, code?: string }[] }}
  */
 export function buildPersistenceAssertions(input = {}) {
   const viewState = input.viewState ?? {};
@@ -164,20 +164,28 @@ export function buildPersistenceAssertions(input = {}) {
   });
 
   const hasTx = Array.isArray(input.transactionsRecent) && input.transactionsRecent.length > 0;
+  const transactionsRecentProbeOk = input.transactionsRecentProbeOk !== false;
+  const transactionsRecentHasExpectedData = input.transactionsRecentHasExpectedData ?? hasTx;
   assertions.push({
     id: 'transactions_recent_available',
-    ok: hasTx || !input.expectTransactions,
-    detail: hasTx
-      ? `${input.transactionsRecent.length} recent rows`
-      : input.expectTransactions
-        ? 'no transactions in recent strip but activity expected'
-        : 'no recent transactions (ok if none expected)',
+    ok: transactionsRecentProbeOk && (transactionsRecentHasExpectedData || !input.expectTransactions),
+    code: !transactionsRecentProbeOk
+      ? 'get_transactions_failed'
+      : (!transactionsRecentHasExpectedData && input.expectTransactions ? 'transactions_recent_empty' : undefined),
+    detail: !transactionsRecentProbeOk
+      ? 'GET_TRANSACTIONS recent failed'
+      : transactionsRecentHasExpectedData
+        ? `${input.transactionsRecent.length} recent rows`
+        : input.expectTransactions
+          ? 'no transactions in recent strip but activity expected'
+          : 'no recent transactions (ok if none expected)',
   });
 
   if (input.seasonTxQueryOk != null) {
     assertions.push({
       id: 'get_transactions_by_season',
       ok: !!input.seasonTxQueryOk,
+      code: input.seasonTxQueryOk ? undefined : 'get_transactions_failed',
       detail: input.seasonTxQueryOk ? 'GET_TRANSACTIONS by season ok' : 'GET_TRANSACTIONS by season failed',
     });
   }
@@ -241,15 +249,22 @@ export function buildPersistenceAssertions(input = {}) {
           : 'GET_HALL_OF_FAME invalid shape',
   });
 
+  const draftClassesProbeOk = input.draftClassesProbeOk !== false;
+  const draftClassesHasExpectedData = input.draftClassesHasExpectedData ?? Number(input.draftClassCount ?? 0) > 0;
   assertions.push({
     id: 'get_draft_classes',
-    ok: input.draftClassesProbeOk !== false,
+    ok: input.draftClassesProbeSkipped || (draftClassesProbeOk && (draftClassesHasExpectedData || !input.expectDraftClasses)),
+    code: !draftClassesProbeOk
+      ? 'get_draft_classes_failed'
+      : (!draftClassesHasExpectedData && input.expectDraftClasses ? 'draft_classes_empty' : undefined),
     detail:
       input.draftClassesProbeSkipped
         ? 'skipped (shallow probe mode)'
-        : input.draftClassesProbeOk
-          ? `GET_DRAFT_CLASSES count=${input.draftClassCount ?? 0}`
-          : 'GET_DRAFT_CLASSES invalid',
+        : !draftClassesProbeOk
+          ? 'GET_DRAFT_CLASSES failed'
+          : draftClassesHasExpectedData
+            ? `GET_DRAFT_CLASSES count=${input.draftClassCount ?? 0}`
+            : 'GET_DRAFT_CLASSES returned no classes (ok if none expected)',
   });
 
   return { allOk: assertions.every((a) => a.ok), assertions };

--- a/src/testSupport/dynastySoakRunner.js
+++ b/src/testSupport/dynastySoakRunner.js
@@ -26,6 +26,14 @@ const RESPONSE_BY_REQUEST = {
 /** @type {Map<string, { resolve: Function, reject: Function, accept: Set<string>, timer: ReturnType<typeof setTimeout> }>} */
 const waiters = new Map();
 
+export function probeHandlerSucceeded(msg) {
+  return msg?.type !== toUI.ERROR && msg?.payload?.ok !== false;
+}
+
+export function payloadArrayHasRows(payload, key) {
+  return Array.isArray(payload?.[key]) && payload[key].length > 0;
+}
+
 let msgSeq = 0;
 function nextId() {
   msgSeq += 1;
@@ -424,7 +432,7 @@ export async function runDynastySoakOnce(opts = {}) {
           { timeoutMs: phaseTimeoutMs },
         );
         pushCheckpoint(checkpoints, `S${s}.GET_SEASON_HISTORY`, Date.now() - tProbe, null);
-        if (histMsg.type !== toUI.ERROR) {
+        if (probeHandlerSucceeded(histMsg)) {
           seasonHistory = histMsg.payload?.data ?? null;
           getSeasonHistoryOk = true;
         } else {
@@ -448,10 +456,10 @@ export async function runDynastySoakOnce(opts = {}) {
       pushCheckpoint(checkpoints, `S${s}.runDynastySoakAudit`, Date.now() - tProbe, null);
       lastReportSummary = audit.reportSummary ?? null;
 
-      if (fullProbes && txSeasonMsg.type === toUI.ERROR) {
+      if (fullProbes && !probeHandlerSucceeded(txSeasonMsg)) {
         audit.failures.push({
           code: 'get_transactions_season',
-          message: txSeasonMsg.payload?.message || 'GET_TRANSACTIONS by season failed',
+          message: txSeasonMsg.payload?.message || txSeasonMsg.payload?.error || 'GET_TRANSACTIONS by season failed',
         });
         audit.passed = false;
       }
@@ -464,25 +472,32 @@ export async function runDynastySoakOnce(opts = {}) {
           : 0;
         const expectTx = s >= 2;
         const expectStats = s >= 2;
+        const expectDraftClasses = s >= 2;
+        const transactionsRecentProbeOk = probeHandlerSucceeded(txMsg);
+        const transactionsRecentHasExpectedData = payloadArrayHasRows(txMsg.payload, 'transactions');
+        const draftClassesProbeOk = probeHandlerSucceeded(draftClassesMsg);
+        const draftClassesHasExpectedData = payloadArrayHasRows(draftClassesMsg.payload, 'classes');
         const persInput = {
           viewState: view,
           transactionsRecent: txMsg.payload?.transactions ?? [],
           expectTransactions: expectTx,
+          transactionsRecentProbeOk,
+          transactionsRecentHasExpectedData,
           expectStatRows: expectStats,
           expectTimelineRows: expectTx,
-          seasonTxQueryOk: txSeasonMsg.type !== toUI.ERROR,
+          seasonTxQueryOk: probeHandlerSucceeded(txSeasonMsg),
           getSeasonHistoryOk,
           getSeasonHistorySkipped,
           recordsProbeOk:
-            recordsMsg.type === toUI.ERROR
-              ? false
-              : !!(recordsMsg.payload?.recordBook || recordsMsg.payload?.records),
+            probeHandlerSucceeded(recordsMsg) && !!(recordsMsg.payload?.recordBook || recordsMsg.payload?.records),
           recordsProbeSkipped: false,
           hofProbeOk:
-            hofMsg.type === toUI.ERROR ? false : !hofMsg.payload || Array.isArray(hofMsg.payload?.players),
+            probeHandlerSucceeded(hofMsg) && (!hofMsg.payload || Array.isArray(hofMsg.payload?.players)),
           hofProbeSkipped: false,
-          draftClassesProbeOk: draftClassesMsg.type !== toUI.ERROR,
+          draftClassesProbeOk,
           draftClassesProbeSkipped: false,
+          draftClassesHasExpectedData,
+          expectDraftClasses,
           draftClassCount,
         };
         const pers = buildPersistenceAssertions(persInput);

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -3878,13 +3878,23 @@ async function handleSimToPhase({ targetPhase }, id) {
 // ── Handler: GET_SEASON_HISTORY ───────────────────────────────────────────────
 
 async function handleGetSeasonHistory({ seasonId }, id) {
-  // Check LRU first
-  let data = cache.getHistorySeason(seasonId);
-  if (!data) {
-    data = await Seasons.load(seasonId);
-    if (data) cache.setHistorySeason(seasonId, data);
+  try {
+    // Check LRU first
+    let data = cache.getHistorySeason(seasonId);
+    if (!data) {
+      data = await Seasons.load(seasonId);
+      if (data) cache.setHistorySeason(seasonId, data);
+    }
+    post(toUI.SEASON_HISTORY, { ok: true, seasonId, data: data ?? null }, id);
+  } catch (err) {
+    console.error('[Worker] GET_SEASON_HISTORY failed:', err);
+    post(toUI.SEASON_HISTORY, {
+      ok: false,
+      error: err?.message || String(err),
+      seasonId,
+      data: null,
+    }, id);
   }
-  post(toUI.SEASON_HISTORY, { seasonId, data: data ?? null }, id);
 }
 
 // ── Handler: GET_ALL_SEASONS ──────────────────────────────────────────────────
@@ -3957,21 +3967,21 @@ async function handleGetTransactions(payload = {}, id) {
     let rows = [];
     if (explicitRecent && teamId == null && seasonId == null && !wantPlayer) {
       const cap = Math.min(4000, Math.max(400, Number(limit) * 5 || 800));
-      rows = await Transactions.loadRecent(cap).catch(() => []);
+      rows = await Transactions.loadRecent(cap);
     } else if (wantPlayer && teamId == null && seasonId == null) {
       const cap = Math.min(4000, Math.max(800, Number(limit) * 25 || 2500));
-      rows = await Transactions.loadRecent(cap).catch(() => []);
+      rows = await Transactions.loadRecent(cap);
     } else if (teamId != null) {
-      rows = await Transactions.byTeam(Number(teamId)).catch(() => []);
+      rows = await Transactions.byTeam(Number(teamId));
       const sid = seasonId ?? resolvedSeasonId;
       if (sid) {
         rows = rows.filter((row) => String(row?.seasonId) === String(sid));
       }
     } else if (resolvedSeasonId) {
-      rows = await Transactions.bySeason(resolvedSeasonId).catch(() => []);
+      rows = await Transactions.bySeason(resolvedSeasonId);
     } else if (explicitRecent) {
       const cap = Math.min(4000, Math.max(400, Number(limit) * 5 || 800));
-      rows = await Transactions.loadRecent(cap).catch(() => []);
+      rows = await Transactions.loadRecent(cap);
     }
 
     const allTeams = cache.getAllTeams();
@@ -4064,10 +4074,14 @@ async function handleGetTransactions(payload = {}, id) {
       legacyTypeLabel: row.legacyType ? txTypeLabel(row.legacyType) : bucketTypeLabel(row.type),
     }));
 
-    post(toUI.TRANSACTIONS, { transactions: stripped }, id);
+    post(toUI.TRANSACTIONS, { ok: true, transactions: stripped }, id);
   } catch (err) {
     console.error("[Worker] GET_TRANSACTIONS failed:", err);
-    post(toUI.TRANSACTIONS, { transactions: [] }, id);
+    post(toUI.TRANSACTIONS, {
+      ok: false,
+      error: err?.message || String(err),
+      transactions: [],
+    }, id);
   }
 }
 
@@ -4085,13 +4099,17 @@ async function loadMergedSeasonSummaries() {
 async function handleGetDraftClasses(payload, id) {
   try {
     const { merged } = await loadMergedSeasonSummaries();
-    const recent = await Transactions.loadRecent(4000).catch(() => []);
+    const recent = await Transactions.loadRecent(4000);
     const draftOnly = recent.filter((tx) => String(tx?.type).toUpperCase() === 'DRAFT');
     const classes = indexDraftClassesFromTransactions(draftOnly, merged);
-    post(toUI.DRAFT_CLASSES, { classes }, id);
+    post(toUI.DRAFT_CLASSES, { ok: true, classes }, id);
   } catch (err) {
     console.error('[Worker] GET_DRAFT_CLASSES failed:', err);
-    post(toUI.DRAFT_CLASSES, { classes: [] }, id);
+    post(toUI.DRAFT_CLASSES, {
+      ok: false,
+      error: err?.message || String(err),
+      classes: [],
+    }, id);
   }
 }
 

--- a/tests/unit/dynastySoakPersistence.test.js
+++ b/tests/unit/dynastySoakPersistence.test.js
@@ -3,6 +3,7 @@ import {
   buildPersistenceAssertions,
   validateTransactionTimelineV1Shape,
 } from '../../src/core/dynastySoakAudit.js';
+import { probeHandlerSucceeded, payloadArrayHasRows } from '../../src/testSupport/dynastySoakRunner.js';
 
 describe('buildPersistenceAssertions', () => {
   it('fails when leagueHistory has no latest season', () => {
@@ -50,4 +51,69 @@ describe('buildPersistenceAssertions', () => {
     });
     expect(r.allOk).toBe(true);
   });
+
+  it('fails clearly when GET_TRANSACTIONS returns an ok:false empty payload', () => {
+    const txMsg = { type: 'TRANSACTIONS', payload: { ok: false, error: 'indexeddb read failed', transactions: [] } };
+    const r = buildPersistenceAssertions({
+      viewState: {
+        leagueHistory: [
+          {
+            id: 's1',
+            playerSeasonStatsV1: { schemaVersion: 1, rows: [] },
+            transactionTimelineV1: { schemaVersion: 1, rows: [] },
+          },
+        ],
+      },
+      transactionsRecent: txMsg.payload.transactions,
+      expectTransactions: true,
+      transactionsRecentProbeOk: probeHandlerSucceeded(txMsg),
+      transactionsRecentHasExpectedData: payloadArrayHasRows(txMsg.payload, 'transactions'),
+      expectStatRows: false,
+      expectTimelineRows: false,
+      seasonTxQueryOk: true,
+      getSeasonHistoryOk: true,
+      recordsProbeOk: true,
+      hofProbeOk: true,
+      draftClassesProbeOk: true,
+      draftClassesHasExpectedData: false,
+      expectDraftClasses: false,
+      draftClassCount: 0,
+    });
+
+    expect(r.allOk).toBe(false);
+    expect(r.assertions.find((a) => a.code === 'get_transactions_failed')?.ok).toBe(false);
+  });
+
+  it('fails clearly when GET_DRAFT_CLASSES returns an ok:false empty payload', () => {
+    const draftMsg = { type: 'DRAFT_CLASSES', payload: { ok: false, error: 'transaction read failed', classes: [] } };
+    const r = buildPersistenceAssertions({
+      viewState: {
+        leagueHistory: [
+          {
+            id: 's1',
+            playerSeasonStatsV1: { schemaVersion: 1, rows: [] },
+            transactionTimelineV1: { schemaVersion: 1, rows: [] },
+          },
+        ],
+      },
+      transactionsRecent: [{ type: 'DRAFT' }],
+      expectTransactions: true,
+      transactionsRecentProbeOk: true,
+      transactionsRecentHasExpectedData: true,
+      expectStatRows: false,
+      expectTimelineRows: false,
+      seasonTxQueryOk: true,
+      getSeasonHistoryOk: true,
+      recordsProbeOk: true,
+      hofProbeOk: true,
+      draftClassesProbeOk: probeHandlerSucceeded(draftMsg),
+      draftClassesHasExpectedData: payloadArrayHasRows(draftMsg.payload, 'classes'),
+      expectDraftClasses: true,
+      draftClassCount: 0,
+    });
+
+    expect(r.allOk).toBe(false);
+    expect(r.assertions.find((a) => a.code === 'get_draft_classes_failed')?.ok).toBe(false);
+  });
+
 });


### PR DESCRIPTION
### Motivation

- Worker probe handlers were masking IndexedDB or other handler exceptions by replying with empty success-shaped payloads, which hid audit failures as benign empty data.
- The soak runner treated any non-`toUI.ERROR` response as success, so handler-level failures were not surfaced to persistence assertions.
- The intent is to make persistence probes explicit so audit failures show as probe failures with clear codes instead of silent empty payloads.

### Description

- Update `src/worker/worker.js` GET handlers (`GET_SEASON_HISTORY`, `GET_TRANSACTIONS`, and `GET_DRAFT_CLASSES`) to return `{ ok: true, ... }` on success and `{ ok: false, error: <message>, ... }` on exception so handler failures are explicit. 
- Add `probeHandlerSucceeded` and `payloadArrayHasRows` helpers to `src/testSupport/dynastySoakRunner.js` and use them when validating probe responses so `payload.ok === false` is treated as a failed handler. 
- Change `runDynastySoakOnce` wiring in `src/testSupport/dynastySoakRunner.js` to pass separate booleans for handler success vs non-empty expected data into `buildPersistenceAssertions`. 
- Modify `src/core/dynastySoakAudit.js` `buildPersistenceAssertions()` to accept handler-success and data-presence inputs, emit failure `code` fields such as `get_transactions_failed` and `get_draft_classes_failed`, and preserve distinct empty-data codes when handlers succeeded but returned empty arrays. 
- Add unit tests in `tests/unit/dynastySoakPersistence.test.js` covering mocked probe messages with `ok: false` and asserting the persistence checklist fails with the new failure codes.

### Testing

- Ran unit tests for the modified assertions with `npm run test:unit -- tests/unit/dynastySoakPersistence.test.js`, which completed successfully (all tests passed). 
- Built the production bundle with `npm run build`, which completed successfully (Vite build succeeded; existing bundle-size warnings remain).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01fa655bc4832d9ac90b855a0fb33d)