### PR TITLE
Enhance dynasty soak timing instrumentation and CLI report

### DIFF
--- a/src/testSupport/dynastySoakCli.js
+++ b/src/testSupport/dynastySoakCli.js
@@ -166,6 +166,23 @@ export function mdEscape(s) {
     .replace(/\r?\n/g, ' ');
 }
 
+
+function formatPhaseBreakdownLabel(key) {
+  const labels = {
+    boot: 'Boot',
+    sim: 'Simulation',
+    getProbes: 'GET probes',
+    auditEvaluation: 'Audit evaluation',
+    finalAdvance: 'Final advance',
+  };
+  return labels[key] || key;
+}
+
+function formatCheckpointMeta(meta) {
+  if (!meta || typeof meta !== 'object' || !Object.keys(meta).length) return '';
+  return mdEscape(JSON.stringify(meta));
+}
+
 /**
  * @param {object} result - runDynastySoakOnce output (JSON-serializable)
  */
@@ -192,14 +209,27 @@ export function buildMarkdownReport(result) {
     lines.push('');
   }
 
+  const phaseBreakdown = result.timings?.phaseBreakdown;
+  if (phaseBreakdown && Object.keys(phaseBreakdown).length) {
+    lines.push('## Phase timing breakdown');
+    lines.push('');
+    lines.push('| Phase group | ms | Checkpoints |');
+    lines.push('| --- | --- | --- |');
+    for (const [key, value] of Object.entries(phaseBreakdown)) {
+      const entry = value && typeof value === 'object' ? value : { ms: value, count: null };
+      lines.push(`| ${mdEscape(formatPhaseBreakdownLabel(key))} | ${entry.ms ?? 0} | ${entry.count ?? 'n/a'} |`);
+    }
+    lines.push('');
+  }
+
   if (result.timings?.topSlowCheckpoints?.length) {
     lines.push('## Slowest checkpoints');
     lines.push('');
-    lines.push('| Rank | Checkpoint | ms |');
-    lines.push('| --- | --- | --- |');
+    lines.push('| Rank | Checkpoint | ms | Metadata |');
+    lines.push('| --- | --- | --- | --- |');
     let r = 1;
     for (const c of result.timings.topSlowCheckpoints) {
-      lines.push(`| ${r} | ${mdEscape(c.name)} | ${c.ms} |`);
+      lines.push(`| ${r} | ${mdEscape(c.name)} | ${c.ms} | ${formatCheckpointMeta(c.meta)} |`);
       r += 1;
     }
     lines.push('');

--- a/src/testSupport/dynastySoakRunner.js
+++ b/src/testSupport/dynastySoakRunner.js
@@ -137,16 +137,46 @@ function topSlowCheckpoints(checkpoints, n = 10) {
   return [...checkpoints].sort((a, b) => b.ms - a.ms).slice(0, n);
 }
 
+function buildPhaseBreakdown(checkpoints) {
+  const groups = {
+    boot: { ms: 0, count: 0 },
+    sim: { ms: 0, count: 0 },
+    getProbes: { ms: 0, count: 0 },
+    auditEvaluation: { ms: 0, count: 0 },
+    finalAdvance: { ms: 0, count: 0 },
+  };
+
+  for (const checkpoint of checkpoints) {
+    const name = String(checkpoint?.name ?? '');
+    const ms = Number(checkpoint?.ms ?? 0);
+    let bucket = null;
+    if (name.startsWith('boot.')) bucket = groups.boot;
+    else if (name.endsWith('.SIM_TO_PHASE')) bucket = groups.sim;
+    else if (name.includes('.GET_')) bucket = groups.getProbes;
+    else if (name.endsWith('.runDynastySoakAudit')) bucket = groups.auditEvaluation;
+    else if (name.endsWith('.ADVANCE_WEEK')) bucket = groups.finalAdvance;
+    if (!bucket) continue;
+    bucket.ms += ms;
+    bucket.count += 1;
+  }
+
+  return groups;
+}
+
 /**
  * `SIM_TO_PHASE` may stop before `preseason` when the worker hits its per-call
  * iteration guard mid-pipeline; repeat until preseason or hard cap.
  * @param {number} simTimeoutMs
- * @param {{ checkpoints: object[], label: string }} ctx
+ * @param {{ checkpoints: object[], label: string, phaseBefore?: string, yearBefore?: number }} ctx
  */
 async function simUntilPreseason(simTimeoutMs, ctx) {
   let lastMsg = null;
   const attempts = [];
+  let currentPhase = String(ctx.phaseBefore ?? '');
+  let currentYear = Number(ctx.yearBefore ?? 0);
   for (let attempt = 0; attempt < 12; attempt += 1) {
+    const phaseBefore = currentPhase;
+    const yearBefore = currentYear;
     const t = Date.now();
     lastMsg = await dispatchWorker(
       toWorker.SIM_TO_PHASE,
@@ -156,19 +186,31 @@ async function simUntilPreseason(simTimeoutMs, ctx) {
     const ms = Date.now() - t;
     const ph = String(lastMsg.payload?.phase ?? '');
     const yr = Number(lastMsg.payload?.year ?? 0);
-    attempts.push({
+    const batch = lastMsg.payload?.dynastySoakSimBatch ?? null;
+    const simBatchMeta = {
+      iterationsUsed: batch?.iterationsUsed ?? null,
+      reachedTarget: batch?.reachedTarget ?? null,
+      hitIterationCap: batch?.hitIterationCap ?? null,
+      lastPhase: batch?.lastPhase ?? null,
+      targetPhase: batch?.targetPhase ?? 'preseason',
+    };
+    const meta = {
       attempt,
-      ms,
+      phaseBefore,
+      yearBefore,
       phaseAfter: ph,
       yearAfter: yr,
+      ...simBatchMeta,
+    };
+    attempts.push({
+      ...meta,
+      ms,
       error: lastMsg.type === toUI.ERROR,
     });
-    pushCheckpoint(ctx.checkpoints, `${ctx.label}.SIM_TO_PHASE`, ms, {
-      attempt,
-      phaseAfter: ph,
-      yearAfter: yr,
-    });
+    pushCheckpoint(ctx.checkpoints, `${ctx.label}.SIM_TO_PHASE`, ms, meta);
     if (lastMsg.type === toUI.ERROR) return { lastMsg, attempts };
+    currentPhase = ph;
+    currentYear = yr;
     if (ph === 'preseason') return { lastMsg, attempts };
   }
   return { lastMsg, attempts };
@@ -240,6 +282,7 @@ export async function runDynastySoakOnce(opts = {}) {
     simAttemptsPerSeason,
     timings: {
       bootMs: 0,
+      phaseBreakdown: buildPhaseBreakdown([]),
       topSlowCheckpoints: [],
       totalMs: 0,
     },
@@ -296,7 +339,7 @@ export async function runDynastySoakOnce(opts = {}) {
       const phaseBefore = String(view?.phase ?? '');
       const fullProbes = deepEachSeason || s === seasons;
 
-      const simCtx = { checkpoints, label: `S${s}` };
+      const simCtx = { checkpoints, label: `S${s}`, phaseBefore, yearBefore };
       const { lastMsg: simMsg, attempts } = await simUntilPreseason(simTimeoutMs, simCtx);
       simAttemptsPerSeason.push({ season: s, attempts });
 
@@ -523,6 +566,7 @@ export async function runDynastySoakOnce(opts = {}) {
     aggregate.reportSummary = lastReportSummary;
     aggregate.timings.bootMs = checkpoints.filter((c) => c.name.startsWith('boot.')).reduce((a, c) => a + c.ms, 0);
     aggregate.timings.topSlowCheckpoints = topSlowCheckpoints(checkpoints);
+    aggregate.timings.phaseBreakdown = buildPhaseBreakdown(checkpoints);
     aggregate.timings.totalMs = aggregate.runtimeMs;
     aggregate.dynastySoakSimBatch = view?.dynastySoakSimBatch ?? null;
 
@@ -538,6 +582,7 @@ export async function runDynastySoakOnce(opts = {}) {
     aggregate.reportSummary = lastReportSummary;
     aggregate.timings.bootMs = checkpoints.filter((c) => c.name.startsWith('boot.')).reduce((a, c) => a + c.ms, 0);
     aggregate.timings.topSlowCheckpoints = topSlowCheckpoints(checkpoints);
+    aggregate.timings.phaseBreakdown = buildPhaseBreakdown(checkpoints);
     aggregate.timings.totalMs = aggregate.runtimeMs;
     return aggregate;
   } finally {

--- a/tests/unit/dynastySoakCli.test.js
+++ b/tests/unit/dynastySoakCli.test.js
@@ -66,8 +66,25 @@ describe('dynastySoakCli', () => {
       finalYear: 2027,
       harnessConfig: { ci: true, deepEachSeason: false },
       timings: {
+        phaseBreakdown: {
+          boot: { ms: 5, count: 1 },
+          sim: { ms: 80, count: 1 },
+          getProbes: { ms: 12, count: 2 },
+          auditEvaluation: { ms: 3, count: 1 },
+          finalAdvance: { ms: 7, count: 1 },
+        },
         topSlowCheckpoints: [
-          { name: 'S1.SIM_TO_PHASE', ms: 80 },
+          {
+            name: 'S1.SIM_TO_PHASE',
+            ms: 80,
+            meta: {
+              iterationsUsed: 42,
+              reachedTarget: true,
+              hitIterationCap: false,
+              lastPhase: 'preseason',
+              targetPhase: 'preseason',
+            },
+          },
           { name: 'boot.INIT', ms: 5 },
         ],
       },
@@ -80,8 +97,13 @@ describe('dynastySoakCli', () => {
       },
       persistenceAssertions: [{ id: 'latest_season_archive', ok: true, detail: 'ok' }],
     });
+    expect(md).toContain('Phase timing breakdown');
+    expect(md).toContain('GET probes');
+    expect(md).toContain('| Simulation | 80 | 1 |');
     expect(md).toContain('Slowest checkpoints');
     expect(md).toContain('S1.SIM_TO_PHASE');
+    expect(md).toContain('iterationsUsed');
+    expect(md).toContain('hitIterationCap');
     expect(md).toContain('AI / roster snapshot');
     expect(md).toContain('contender');
     expect(md).toContain('Persistence probes');


### PR DESCRIPTION
### Motivation
- Improve observability of the dynasty soak runner by capturing pre-/post-sim context and worker batch metadata so timing and failure analysis are more actionable.
- Provide a compact phase-level timing summary in reports to quickly surface where wall time is spent (boot, simulation, GET probes, audit evaluation, final advance).
- Surface per-checkpoint metadata (iteration counts / iteration-cap hits) in the CLI markdown so slow checkpoints carry useful diagnostic info.

### Description
- In `src/testSupport/dynastySoakRunner.js` enhanced `simUntilPreseason()` to accept and use `phaseBefore`/`yearBefore`, capture `dynastySoakSimBatch` fields (`iterationsUsed`, `reachedTarget`, `hitIterationCap`, `lastPhase`, `targetPhase`), include those fields in each attempt entry, and save them into each `SIM_TO_PHASE` checkpoint `meta` and into `simAttemptsPerSeason`.
- Added `buildPhaseBreakdown()` in `src/testSupport/dynastySoakRunner.js` to aggregate checkpoint durations into groups `boot`, `sim`, `getProbes`, `auditEvaluation`, and `finalAdvance`, and populated `aggregate.timings.phaseBreakdown` on both success and error paths.
- Updated `src/testSupport/dynastySoakCli.js` `buildMarkdownReport()` to add a `## Phase timing breakdown` table and to include a `Metadata` column for the `## Slowest checkpoints` table, plus helper formatters `formatPhaseBreakdownLabel()` and `formatCheckpointMeta()`.
- Added/updated unit test `tests/unit/dynastySoakCli.test.js` to assert the markdown contains the new phase breakdown rows and that slowest checkpoint metadata keys like `iterationsUsed` and `hitIterationCap` are present.

### Testing
- Ran the targeted unit test: `npm run test:unit -- tests/unit/dynastySoakCli.test.js`, which completed successfully with `1 test file, 7 tests passed`.
- No full test suite, build, or E2E checks were run as part of this change (only the focused unit test above was executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01fa678598832dae8c720156ff5a78)