### PR TITLE
Make dynasty soak `--deep` flag active (final-season deep probes)

### DIFF
--- a/scripts/dynasty-soak.mjs
+++ b/scripts/dynasty-soak.mjs
@@ -37,7 +37,7 @@ async function main() {
   const { runDynastySoakOnce } = await import('../src/testSupport/dynastySoakRunner.js');
 
   console.log(
-    `[dynasty-soak] seed=${resolved.seed} seasons=${resolved.seasons}${resolved.ci ? ' (ci)' : ''} deepEachSeason=${resolved.deepEachSeason}`,
+    `[dynasty-soak] seed=${resolved.seed} seasons=${resolved.seasons}${resolved.ci ? ' (ci)' : ''} deep=${resolved.deep} deepEachSeason=${resolved.deepEachSeason}`,
   );
   const result = await runDynastySoakOnce(resolved);
 

--- a/src/testSupport/dynastySoakCli.js
+++ b/src/testSupport/dynastySoakCli.js
@@ -10,7 +10,7 @@ Options:
   --seasons=N             Number of seasons to simulate (default: 5, or 1 with --ci)
   --seed=N                RNG seed (default: 1383)
   --outDir=PATH           Report output directory (default: artifacts/dynasty-soak)
-  --deep                  No-op (reserved); default is full probes on the final season only
+  --deep                  Full final-season probes plus larger transaction/draft/archive samples
   --deep-each-season      Full GET_* probes every season (slowest; matches legacy harness)
   --phase-timeout-ms=N    Timeout per SIM_TO_PHASE attempt and per GET_* (default: 60m)
   --max-runtime-ms=N      Hard cap on wall time between checkpoints (not mid-SIM_TO_PHASE); default unlimited
@@ -34,6 +34,7 @@ function parseEq(argv, i, prefix) {
 export function parseDynastySoakArgv(argv) {
   const raw = {
     ci: false,
+    deep: false,
     deepEachSeason: false,
     seasons: null,
     seed: null,
@@ -48,9 +49,8 @@ export function parseDynastySoakArgv(argv) {
   for (let i = 2; i < argv.length; i += 1) {
     const a = argv[i];
     if (a === '--ci') raw.ci = true;
-    else if (a === '--deep') {
-      /* reserved: default harness already runs full probes on the last season */
-    } else if (a === '--deep-each-season') raw.deepEachSeason = true;
+    else if (a === '--deep') raw.deep = true;
+    else if (a === '--deep-each-season') raw.deepEachSeason = true;
     else if (a === '--skip-report-open') raw.skipReportOpen = true;
     else if (a.startsWith('--seasons=')) raw.seasons = Number(a.split('=')[1]);
     else if (a.startsWith('--seed=')) raw.seed = Number(a.split('=')[1]);
@@ -134,6 +134,7 @@ export function resolveDynastySoakConfig(raw) {
       ? Math.max(30_000, Number(raw.maxRuntimeMs))
       : null;
 
+  const deep = !!raw.deep;
   const deepEachSeason = !!raw.deepEachSeason;
 
   if (errors.length) {
@@ -146,6 +147,7 @@ export function resolveDynastySoakConfig(raw) {
       seasons,
       seed,
       ci: !!raw.ci,
+      deep,
       deepEachSeason,
       phaseTimeoutMs,
       maxRuntimeMs,
@@ -181,7 +183,9 @@ export function buildMarkdownReport(result) {
   lines.push(`- **Passed:** ${result.passed ? 'yes' : 'no'}`);
   lines.push(`- **Severity:** ${result.severity}`);
   if (result.harnessConfig) {
-    lines.push(`- **Harness:** ci=${result.harnessConfig.ci} deepEachSeason=${result.harnessConfig.deepEachSeason}`);
+    lines.push(
+      `- **Harness:** ci=${result.harnessConfig.ci} deep=${!!result.harnessConfig.deep} deepEachSeason=${result.harnessConfig.deepEachSeason}`,
+    );
   }
   lines.push('');
 

--- a/src/testSupport/dynastySoakRunner.js
+++ b/src/testSupport/dynastySoakRunner.js
@@ -20,6 +20,7 @@ const RESPONSE_BY_REQUEST = {
   [toWorker.GET_RECORDS]: [toUI.RECORDS, toUI.ERROR],
   [toWorker.GET_HALL_OF_FAME]: [toUI.HALL_OF_FAME, toUI.ERROR],
   [toWorker.GET_DRAFT_CLASSES]: [toUI.DRAFT_CLASSES, toUI.ERROR],
+  [toWorker.GET_DRAFT_CLASS]: [toUI.DRAFT_CLASS, toUI.ERROR],
   [toWorker.GET_SEASON_HISTORY]: [toUI.SEASON_HISTORY, toUI.ERROR],
 };
 
@@ -188,6 +189,7 @@ function checkMaxRuntime(t0, maxRuntimeMs) {
  * @property {number} [seasons=5]
  * @property {number} [seed=1383]
  * @property {boolean} [ci=false]
+ * @property {boolean} [deep=false] - larger final-season transaction/draft/archive probes
  * @property {boolean} [deepEachSeason=false]
  * @property {number} [simTimeoutMs]
  * @property {number} [phaseTimeoutMs] - alias override for simTimeoutMs / GET timeouts
@@ -202,6 +204,7 @@ export async function runDynastySoakOnce(opts = {}) {
   const seasons = Math.max(1, Math.min(50, Number(opts.seasons) || 5));
   const seed = Number.isFinite(Number(opts.seed)) ? Number(opts.seed) : 1383;
   const ci = !!opts.ci;
+  const deep = !!opts.deep;
   const deepEachSeason = !!opts.deepEachSeason;
   const phaseTimeoutMs = Number.isFinite(Number(opts.phaseTimeoutMs))
     ? Number(opts.phaseTimeoutMs)
@@ -245,6 +248,7 @@ export async function runDynastySoakOnce(opts = {}) {
     },
     harnessConfig: {
       ci,
+      deep,
       deepEachSeason,
       phaseTimeoutMs,
       maxRuntimeMs,
@@ -295,6 +299,9 @@ export async function runDynastySoakOnce(opts = {}) {
       const yearBefore = Number(view?.year ?? 0);
       const phaseBefore = String(view?.phase ?? '');
       const fullProbes = deepEachSeason || s === seasons;
+      const deepFinalProbes = deep && s === seasons;
+      const recentTransactionLimit = deepFinalProbes ? 1_000 : 400;
+      const seasonTransactionLimit = deepFinalProbes ? 1_000 : 200;
 
       const simCtx = { checkpoints, label: `S${s}` };
       const { lastMsg: simMsg, attempts } = await simUntilPreseason(simTimeoutMs, simCtx);
@@ -367,12 +374,12 @@ export async function runDynastySoakOnce(opts = {}) {
 
       let tProbe = Date.now();
       const allSeasonsMsg = await dispatchWorker(toWorker.GET_ALL_SEASONS, {}, { timeoutMs: phaseTimeoutMs });
-      pushCheckpoint(checkpoints, `S${s}.GET_ALL_SEASONS`, Date.now() - tProbe, { fullProbes });
+      pushCheckpoint(checkpoints, `S${s}.GET_ALL_SEASONS`, Date.now() - tProbe, { fullProbes, deepFinalProbes });
 
       tProbe = Date.now();
       const txMsg = await dispatchWorker(
         toWorker.GET_TRANSACTIONS,
-        { mode: 'recent', limit: 400 },
+        { mode: 'recent', limit: recentTransactionLimit },
         { timeoutMs: phaseTimeoutMs },
       );
       pushCheckpoint(checkpoints, `S${s}.GET_TRANSACTIONS_recent`, Date.now() - tProbe, null);
@@ -382,7 +389,7 @@ export async function runDynastySoakOnce(opts = {}) {
         tProbe = Date.now();
         txSeasonMsg = await dispatchWorker(
           toWorker.GET_TRANSACTIONS,
-          { seasonId: view?.seasonId, limit: 200 },
+          { seasonId: view?.seasonId, limit: seasonTransactionLimit },
           { timeoutMs: phaseTimeoutMs },
         );
         pushCheckpoint(checkpoints, `S${s}.GET_TRANSACTIONS_season`, Date.now() - tProbe, null);
@@ -416,6 +423,7 @@ export async function runDynastySoakOnce(opts = {}) {
       let seasonHistory = null;
       let getSeasonHistoryOk = null;
       let getSeasonHistorySkipped = !fullProbes;
+      const deepFinalAssertions = [];
       if (fullProbes && latestSeason?.id) {
         tProbe = Date.now();
         const histMsg = await dispatchWorker(
@@ -430,8 +438,56 @@ export async function runDynastySoakOnce(opts = {}) {
         } else {
           getSeasonHistoryOk = false;
         }
+
+        if (deepFinalProbes) {
+          const archiveSample = leagueHistory.slice(-4).filter((season) => season?.id);
+          let archiveOk = true;
+          for (const season of archiveSample) {
+            tProbe = Date.now();
+            const sampledHistMsg = await dispatchWorker(
+              toWorker.GET_SEASON_HISTORY,
+              { seasonId: season.id },
+              { timeoutMs: phaseTimeoutMs },
+            );
+            pushCheckpoint(checkpoints, `S${s}.GET_SEASON_HISTORY_deep`, Date.now() - tProbe, {
+              seasonId: season.id,
+            });
+            if (sampledHistMsg.type === toUI.ERROR || !sampledHistMsg.payload?.data) archiveOk = false;
+          }
+          deepFinalAssertions.push({
+            id: 'deep_archive_history_sample',
+            ok: archiveOk,
+            detail: archiveSample.length
+              ? `${archiveSample.length} archived season histories sampled`
+              : 'no archived seasons available to sample',
+          });
+        }
       } else {
         getSeasonHistoryOk = fullProbes ? null : true;
+      }
+
+      if (deepFinalProbes && Array.isArray(draftClassesMsg?.payload?.classes)) {
+        const draftClassSample = draftClassesMsg.payload.classes.slice(0, 4).filter((klass) => klass?.seasonId);
+        let draftClassOk = true;
+        for (const klass of draftClassSample) {
+          tProbe = Date.now();
+          const draftClassMsg = await dispatchWorker(
+            toWorker.GET_DRAFT_CLASS,
+            { seasonId: klass.seasonId },
+            { timeoutMs: phaseTimeoutMs },
+          );
+          pushCheckpoint(checkpoints, `S${s}.GET_DRAFT_CLASS_deep`, Date.now() - tProbe, {
+            seasonId: klass.seasonId,
+          });
+          if (draftClassMsg.type === toUI.ERROR || !draftClassMsg.payload?.model) draftClassOk = false;
+        }
+        deepFinalAssertions.push({
+          id: 'deep_draft_class_model_sample',
+          ok: draftClassOk,
+          detail: draftClassSample.length
+            ? `${draftClassSample.length} draft class models sampled`
+            : 'no draft classes available to sample',
+        });
       }
 
       tProbe = Date.now();
@@ -486,8 +542,9 @@ export async function runDynastySoakOnce(opts = {}) {
           draftClassCount,
         };
         const pers = buildPersistenceAssertions(persInput);
-        aggregate.persistenceAssertions = pers.assertions;
-        if (!pers.allOk) {
+        const assertions = deepFinalProbes ? [...pers.assertions, ...deepFinalAssertions] : pers.assertions;
+        aggregate.persistenceAssertions = assertions;
+        if (!pers.allOk || deepFinalAssertions.some((assertion) => !assertion.ok)) {
           aggregate.passed = false;
           mergeAudit(
             aggregate,

--- a/tests/unit/dynastySoakCli.test.js
+++ b/tests/unit/dynastySoakCli.test.js
@@ -7,20 +7,33 @@ import {
 } from '../../src/testSupport/dynastySoakCli.js';
 
 describe('dynastySoakCli', () => {
-  it('parses --ci, --seasons, --seed, --deep-each-season', () => {
+  it('parses --ci, --seasons, --seed, --deep, --deep-each-season', () => {
     const { raw, errors } = parseDynastySoakArgv([
       'node',
       'dynasty-soak.mjs',
       '--ci',
       '--seasons=2',
       '--seed=99',
+      '--deep',
       '--deep-each-season',
     ]);
     expect(errors).toEqual([]);
     expect(raw.ci).toBe(true);
     expect(raw.seasons).toBe(2);
     expect(raw.seed).toBe(99);
+    expect(raw.deep).toBe(true);
     expect(raw.deepEachSeason).toBe(true);
+  });
+
+  it('resolves --deep into an explicit runner config field', () => {
+    const { raw, errors: parseErrors } = parseDynastySoakArgv(['node', 'x.mjs', '--deep']);
+    expect(parseErrors).toEqual([]);
+    expect(raw.deep).toBe(true);
+
+    const { errors, resolved } = resolveDynastySoakConfig(raw);
+    expect(errors).toEqual([]);
+    expect(resolved.deep).toBe(true);
+    expect(resolved.deepEachSeason).toBe(false);
   });
 
   it('rejects unknown flags', () => {
@@ -64,7 +77,7 @@ describe('dynastySoakCli', () => {
       warnings: [],
       finalPhase: 'preseason',
       finalYear: 2027,
-      harnessConfig: { ci: true, deepEachSeason: false },
+      harnessConfig: { ci: true, deep: true, deepEachSeason: false },
       timings: {
         topSlowCheckpoints: [
           { name: 'S1.SIM_TO_PHASE', ms: 80 },


### PR DESCRIPTION
### Motivation
- Make the CLI `--deep` flag honest: it should map to a real runtime config instead of being a reserved no-op. 
- Provide a lightweight, predictable behavior distinct from `--deep-each-season` so teams can request deeper final-season auditing without repeating full probes every season.

### Description
- Parse `raw.deep` in `parseDynastySoakArgv()` and expose `resolved.deep` from `resolveDynastySoakConfig()` so the CLI produces an explicit `deep` field.
- Pass the resolved `deep` flag into `runDynastySoakOnce()` and surface it in the CLI logging and report harness metadata (`harnessConfig.deep`).
- Use `deep` in the runner to enable final-season deep probes (larger `GET_TRANSACTIONS` limits, extra archived `GET_SEASON_HISTORY` sampling, and sampled `GET_DRAFT_CLASS` checks) without turning on per-season full probes; keep `--deep-each-season` as the separate behavior that repeats full probes every season.
- Update usage text and markdown report to reflect the active `--deep` behavior and add unit tests proving `--deep` parses and resolves into the runner config.

### Testing
- Ran unit tests with `npm run test:unit -- dynastySoakCli.test.js`, and all tests passed (Vitest: 8 tests, 1 file). 
- Performed a production build with `npm run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01fa6a53e0832da5e3ea70ebbacae3)