### PR TITLE
Fix failed-payload assertions in dynastySoak persistence tests

### DIFF
--- a/tests/unit/dynastySoakPersistence.test.js
+++ b/tests/unit/dynastySoakPersistence.test.js
@@ -125,7 +125,7 @@ describe('buildPersistenceAssertions', () => {
   });
 
   it('fails clearly when GET_TRANSACTIONS returns an ok:false empty payload', () => {
-    const txMsg = { type: 'TRANSACTIONS', payload: { ok: false, error: 'indexeddb read failed', transactions: [] } };
+    const txPayload = { ok: false, error: 'indexeddb read failed', transactions: [] };
     const r = buildPersistenceAssertions({
       viewState: {
         leagueHistory: [
@@ -136,10 +136,10 @@ describe('buildPersistenceAssertions', () => {
           },
         ],
       },
-      transactionsRecent: txMsg.payload.transactions,
+      transactionsRecent: txPayload.transactions,
       expectTransactions: true,
-      transactionsRecentProbeOk: probeHandlerSucceeded(txMsg),
-      transactionsRecentHasExpectedData: payloadArrayHasRows(txMsg.payload, 'transactions'),
+      transactionsRecentProbeOk: false,
+      transactionsRecentHasExpectedData: false,
       expectStatRows: false,
       expectTimelineRows: false,
       seasonTxQueryOk: true,
@@ -157,7 +157,7 @@ describe('buildPersistenceAssertions', () => {
   });
 
   it('fails clearly when GET_DRAFT_CLASSES returns an ok:false empty payload', () => {
-    const draftMsg = { type: 'DRAFT_CLASSES', payload: { ok: false, error: 'transaction read failed', classes: [] } };
+    const draftPayload = { ok: false, error: 'transaction read failed', classes: [] };
     const r = buildPersistenceAssertions({
       viewState: {
         leagueHistory: [
@@ -178,10 +178,10 @@ describe('buildPersistenceAssertions', () => {
       getSeasonHistoryOk: true,
       recordsProbeOk: true,
       hofProbeOk: true,
-      draftClassesProbeOk: probeHandlerSucceeded(draftMsg),
-      draftClassesHasExpectedData: payloadArrayHasRows(draftMsg.payload, 'classes'),
+      draftClassesProbeOk: false,
+      draftClassesHasExpectedData: false,
       expectDraftClasses: true,
-      draftClassCount: 0,
+      draftClassCount: draftPayload.classes.length,
     });
 
     expect(r.allOk).toBe(false);


### PR DESCRIPTION
### Motivation
- Decouple worker message parsing from a pure persistence/audit unit test by avoiding calls to worker message helpers in this file.
- Make the tests for `GET_TRANSACTIONS` and `GET_DRAFT_CLASSES` explicitly express failed probe/data conditions so the assertions are deterministic and focused on persistence logic.

### Description
- Replaced uses of `probeHandlerSucceeded(txMsg)` and `payloadArrayHasRows(txMsg.payload, 'transactions')` with explicit `transactionsRecentProbeOk: false` and `transactionsRecentHasExpectedData: false` in the `GET_TRANSACTIONS` failed-payload test.
- Replaced uses of `probeHandlerSucceeded(draftMsg)` and `payloadArrayHasRows(draftMsg.payload, 'classes')` with explicit `draftClassesProbeOk: false` and `draftClassesHasExpectedData: false` in the `GET_DRAFT_CLASSES` failed-payload test.
- Introduced local `txPayload` and `draftPayload` objects and set `draftClassCount` to `draftPayload.classes.length` to keep the test self-contained without importing `src/testSupport/dynastySoakRunner.js`.
- Left `probeHandlerSucceeded` and `payloadArrayHasRows` owned by `src/testSupport/dynastySoakRunner.js` where worker message parsing belongs.

### Testing
- Ran `npm run test:unit -- tests/unit/dynastySoakPersistence.test.js` and the file passed: 1 test file, 7 tests passed.
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02030c53c0832db130c000b6bdfbfc)