### PR TITLE
Fix dynasty soak runner JavaScript flow

### DIFF
--- a/src/testSupport/dynastySoakRunner.js
+++ b/src/testSupport/dynastySoakRunner.js
@@ -399,15 +399,13 @@ export async function runDynastySoakOnce(opts = {}) {
 
     for (let s = 1; s <= seasons; s += 1) {
       checkMaxRuntime(t0, maxRuntimeMs);
-      const yearBefore = Number(view?.year ?? 0);
-      const phaseBefore = String(view?.phase ?? '');
+      let yearBefore = Number(view?.year ?? 0);
+      let phaseBefore = String(view?.phase ?? '');
       const fullProbes = deepEachSeason || s === seasons;
       const deepFinalProbes = deep && s === seasons;
       const recentTransactionLimit = deepFinalProbes ? 1_000 : 400;
       const seasonTransactionLimit = deepFinalProbes ? 1_000 : 200;
 
-      const simCtx = { checkpoints, label: `S${s}`, phaseBefore, yearBefore };
-      const { lastMsg: simMsg, attempts } = await simUntilPreseason(simTimeoutMs, simCtx);
       if (phaseBefore === 'preseason') {
         const advanceResult = await advanceOutOfCurrentTargetPhase(view, {
           checkpoints,
@@ -437,9 +435,11 @@ export async function runDynastySoakOnce(opts = {}) {
           break;
         }
         view = advanceResult.lastMsg.payload;
+        yearBefore = Number(view?.year ?? 0);
+        phaseBefore = String(view?.phase ?? '');
       }
 
-      const simCtx = { checkpoints, label: `S${s}` };
+      const simCtx = { checkpoints, label: `S${s}`, phaseBefore, yearBefore };
       const { lastMsg: simMsg, attempts } = await simUntilPreseason(simTimeoutMs, simCtx, runnerDispatch);
       simAttemptsPerSeason.push({ season: s, attempts });
 
@@ -509,10 +509,8 @@ export async function runDynastySoakOnce(opts = {}) {
       }
 
       let tProbe = Date.now();
-      const allSeasonsMsg = await dispatchWorker(toWorker.GET_ALL_SEASONS, {}, { timeoutMs: phaseTimeoutMs });
-      pushCheckpoint(checkpoints, `S${s}.GET_ALL_SEASONS`, Date.now() - tProbe, { fullProbes, deepFinalProbes });
       const allSeasonsMsg = await runnerDispatch(toWorker.GET_ALL_SEASONS, {}, { timeoutMs: phaseTimeoutMs });
-      pushCheckpoint(checkpoints, `S${s}.GET_ALL_SEASONS`, Date.now() - tProbe, { fullProbes });
+      pushCheckpoint(checkpoints, `S${s}.GET_ALL_SEASONS`, Date.now() - tProbe, { fullProbes, deepFinalProbes });
 
       const leagueHistory = view?.leagueHistory ?? [];
       const latestSeason = leagueHistory.length ? leagueHistory[leagueHistory.length - 1] : null;
@@ -531,8 +529,7 @@ export async function runDynastySoakOnce(opts = {}) {
         tProbe = Date.now();
         txSeasonMsg = await runnerDispatch(
           toWorker.GET_TRANSACTIONS,
-          { seasonId: view?.seasonId, limit: seasonTransactionLimit },
-          { seasonId: latestSeasonId ?? view?.seasonId, limit: 200 },
+          { seasonId: latestSeasonId ?? view?.seasonId, limit: seasonTransactionLimit },
           { timeoutMs: phaseTimeoutMs },
         );
         pushCheckpoint(checkpoints, `S${s}.GET_TRANSACTIONS_season`, Date.now() - tProbe, null);
@@ -585,7 +582,7 @@ export async function runDynastySoakOnce(opts = {}) {
           let archiveOk = true;
           for (const season of archiveSample) {
             tProbe = Date.now();
-            const sampledHistMsg = await dispatchWorker(
+            const sampledHistMsg = await runnerDispatch(
               toWorker.GET_SEASON_HISTORY,
               { seasonId: season.id },
               { timeoutMs: phaseTimeoutMs },
@@ -612,7 +609,7 @@ export async function runDynastySoakOnce(opts = {}) {
         let draftClassOk = true;
         for (const klass of draftClassSample) {
           tProbe = Date.now();
-          const draftClassMsg = await dispatchWorker(
+          const draftClassMsg = await runnerDispatch(
             toWorker.GET_DRAFT_CLASS,
             { seasonId: klass.seasonId },
             { timeoutMs: phaseTimeoutMs },
@@ -628,6 +625,8 @@ export async function runDynastySoakOnce(opts = {}) {
           detail: draftClassSample.length
             ? `${draftClassSample.length} draft class models sampled`
             : 'no draft classes available to sample',
+        });
+      }
       const txSeasonRows = txSeasonMsg.payload?.transactions ?? [];
       let dbLatestSeason = null;
       let dbAllSeasons = null;


### PR DESCRIPTION
### Motivation
- Repair malformed JavaScript in `src/testSupport/dynastySoakRunner.js` that duplicated season-simulation logic and left an unclosed block, causing runtime / parse errors and confusing worker call ordering. 
- Ensure the soak runner advances out of an initial `preseason` deterministically before attempting the season simulation so the sim always runs with a correct `phaseBefore`/`yearBefore` context. 
- Make soak probe calls use the injected `runnerDispatch` consistently and fix argument shapes for worker calls to avoid incorrect payloads.

### Description
- Consolidated the duplicated season flow so `yearBefore` and `phaseBefore` are captured, an initial `advanceOutOfCurrentTargetPhase` is invoked when `phaseBefore === 'preseason'`, the result is checked for `toUI.ERROR` and merged into the audit on failure, and `view`, `yearBefore`, and `phaseBefore` are updated before calling `simUntilPreseason` exactly once with the updated context and `runnerDispatch`.
- Removed duplicate `simCtx` / duplicate `simUntilPreseason` invocations and removed the earlier duplicate `GET_ALL_SEASONS` call so probes use the injected `runnerDispatch` consistently.
- Replaced stray `dispatchWorker` calls used for deep probes with the injected `runnerDispatch` and fixed the by-season `GET_TRANSACTIONS` call to pass a single payload object and a single options object: `{ seasonId: latestSeasonId ?? view?.seasonId, limit: seasonTransactionLimit }`, `{ timeoutMs: phaseTimeoutMs }`.
- Closed the `deep_draft_class_model_sample` assertion block properly before reading `txSeasonRows` and performed small related cleanup to restore valid JS and coherent control flow.

### Testing
- Ran a syntax check with `node --check src/testSupport/dynastySoakRunner.js` which succeeded. 
- Ran the targeted unit test with `npm run test:unit -- tests/unit/dynastySoakRunner.test.js` and it passed (`1 test` passed). 
- Performed a production build with `npm run build` (Vite) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0203308e48832d874b7895f92abf14)