### PR TITLE
Simplify dynasty persistence assertion tests

### DIFF
--- a/tests/unit/dynastySoakPersistence.test.js
+++ b/tests/unit/dynastySoakPersistence.test.js
@@ -125,7 +125,6 @@ describe('buildPersistenceAssertions', () => {
   });
 
   it('fails clearly when GET_TRANSACTIONS returns an ok:false empty payload', () => {
-    const txMsg = { type: 'TRANSACTIONS', payload: { ok: false, error: 'indexeddb read failed', transactions: [] } };
     const r = buildPersistenceAssertions({
       viewState: {
         leagueHistory: [
@@ -136,10 +135,10 @@ describe('buildPersistenceAssertions', () => {
           },
         ],
       },
-      transactionsRecent: txMsg.payload.transactions,
+      transactionsRecent: [],
       expectTransactions: true,
-      transactionsRecentProbeOk: probeHandlerSucceeded(txMsg),
-      transactionsRecentHasExpectedData: payloadArrayHasRows(txMsg.payload, 'transactions'),
+      transactionsRecentProbeOk: false,
+      transactionsRecentHasExpectedData: false,
       expectStatRows: false,
       expectTimelineRows: false,
       seasonTxQueryOk: true,
@@ -157,7 +156,6 @@ describe('buildPersistenceAssertions', () => {
   });
 
   it('fails clearly when GET_DRAFT_CLASSES returns an ok:false empty payload', () => {
-    const draftMsg = { type: 'DRAFT_CLASSES', payload: { ok: false, error: 'transaction read failed', classes: [] } };
     const r = buildPersistenceAssertions({
       viewState: {
         leagueHistory: [
@@ -178,8 +176,8 @@ describe('buildPersistenceAssertions', () => {
       getSeasonHistoryOk: true,
       recordsProbeOk: true,
       hofProbeOk: true,
-      draftClassesProbeOk: probeHandlerSucceeded(draftMsg),
-      draftClassesHasExpectedData: payloadArrayHasRows(draftMsg.payload, 'classes'),
+      draftClassesProbeOk: false,
+      draftClassesHasExpectedData: false,
       expectDraftClasses: true,
       draftClassCount: 0,
     });


### PR DESCRIPTION
### Motivation
- Replace use of the heavier runner helper calls `probeHandlerSucceeded(...)` and `payloadArrayHasRows(...)` in the persistence unit tests with the pure `buildPersistenceAssertions` boolean inputs so the tests remain focused and lightweight.

### Description
- Update `tests/unit/dynastySoakPersistence.test.js` to remove the synthetic `txMsg` and `draftMsg` probe objects and to pass `transactionsRecentProbeOk`, `transactionsRecentHasExpectedData`, `draftClassesProbeOk`, and `draftClassesHasExpectedData` boolean fields directly to `buildPersistenceAssertions` instead of calling the runner helpers.

### Testing
- Ran `npm run test:unit -- tests/unit/dynastySoakPersistence.test.js` and the file passed (1 file, 7 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0203405380832dbfdf60e19e985f8a)