### PR TITLE
Fix dynasty soak preseason loop

### DIFF
--- a/src/testSupport/dynastySoakRunner.js
+++ b/src/testSupport/dynastySoakRunner.js
@@ -399,15 +399,13 @@ export async function runDynastySoakOnce(opts = {}) {
 
     for (let s = 1; s <= seasons; s += 1) {
       checkMaxRuntime(t0, maxRuntimeMs);
-      const yearBefore = Number(view?.year ?? 0);
-      const phaseBefore = String(view?.phase ?? '');
+      let yearBefore = Number(view?.year ?? 0);
+      let phaseBefore = String(view?.phase ?? '');
       const fullProbes = deepEachSeason || s === seasons;
       const deepFinalProbes = deep && s === seasons;
       const recentTransactionLimit = deepFinalProbes ? 1_000 : 400;
       const seasonTransactionLimit = deepFinalProbes ? 1_000 : 200;
 
-      const simCtx = { checkpoints, label: `S${s}`, phaseBefore, yearBefore };
-      const { lastMsg: simMsg, attempts } = await simUntilPreseason(simTimeoutMs, simCtx);
       if (phaseBefore === 'preseason') {
         const advanceResult = await advanceOutOfCurrentTargetPhase(view, {
           checkpoints,
@@ -437,9 +435,11 @@ export async function runDynastySoakOnce(opts = {}) {
           break;
         }
         view = advanceResult.lastMsg.payload;
+        yearBefore = Number(view?.year ?? 0);
+        phaseBefore = String(view?.phase ?? '');
       }
 
-      const simCtx = { checkpoints, label: `S${s}` };
+      const simCtx = { checkpoints, label: `S${s}`, phaseBefore, yearBefore };
       const { lastMsg: simMsg, attempts } = await simUntilPreseason(simTimeoutMs, simCtx, runnerDispatch);
       simAttemptsPerSeason.push({ season: s, attempts });
 
@@ -509,10 +509,8 @@ export async function runDynastySoakOnce(opts = {}) {
       }
 
       let tProbe = Date.now();
-      const allSeasonsMsg = await dispatchWorker(toWorker.GET_ALL_SEASONS, {}, { timeoutMs: phaseTimeoutMs });
-      pushCheckpoint(checkpoints, `S${s}.GET_ALL_SEASONS`, Date.now() - tProbe, { fullProbes, deepFinalProbes });
       const allSeasonsMsg = await runnerDispatch(toWorker.GET_ALL_SEASONS, {}, { timeoutMs: phaseTimeoutMs });
-      pushCheckpoint(checkpoints, `S${s}.GET_ALL_SEASONS`, Date.now() - tProbe, { fullProbes });
+      pushCheckpoint(checkpoints, `S${s}.GET_ALL_SEASONS`, Date.now() - tProbe, { fullProbes, deepFinalProbes });
 
       const leagueHistory = view?.leagueHistory ?? [];
       const latestSeason = leagueHistory.length ? leagueHistory[leagueHistory.length - 1] : null;
@@ -531,8 +529,7 @@ export async function runDynastySoakOnce(opts = {}) {
         tProbe = Date.now();
         txSeasonMsg = await runnerDispatch(
           toWorker.GET_TRANSACTIONS,
-          { seasonId: view?.seasonId, limit: seasonTransactionLimit },
-          { seasonId: latestSeasonId ?? view?.seasonId, limit: 200 },
+          { seasonId: latestSeasonId ?? view?.seasonId, limit: seasonTransactionLimit },
           { timeoutMs: phaseTimeoutMs },
         );
         pushCheckpoint(checkpoints, `S${s}.GET_TRANSACTIONS_season`, Date.now() - tProbe, null);
@@ -585,7 +582,7 @@ export async function runDynastySoakOnce(opts = {}) {
           let archiveOk = true;
           for (const season of archiveSample) {
             tProbe = Date.now();
-            const sampledHistMsg = await dispatchWorker(
+            const sampledHistMsg = await runnerDispatch(
               toWorker.GET_SEASON_HISTORY,
               { seasonId: season.id },
               { timeoutMs: phaseTimeoutMs },
@@ -612,7 +609,7 @@ export async function runDynastySoakOnce(opts = {}) {
         let draftClassOk = true;
         for (const klass of draftClassSample) {
           tProbe = Date.now();
-          const draftClassMsg = await dispatchWorker(
+          const draftClassMsg = await runnerDispatch(
             toWorker.GET_DRAFT_CLASS,
             { seasonId: klass.seasonId },
             { timeoutMs: phaseTimeoutMs },
@@ -628,6 +625,8 @@ export async function runDynastySoakOnce(opts = {}) {
           detail: draftClassSample.length
             ? `${draftClassSample.length} draft class models sampled`
             : 'no draft classes available to sample',
+        });
+      }
       const txSeasonRows = txSeasonMsg.payload?.transactions ?? [];
       let dbLatestSeason = null;
       let dbAllSeasons = null;

--- a/tests/unit/dynastySoakPersistence.test.js
+++ b/tests/unit/dynastySoakPersistence.test.js
@@ -9,6 +9,10 @@ import {
   mergeDirtySnapshots,
   queueDirtySnapshot,
 } from '../../src/worker/dirtyFlushAccumulator.js';
+import {
+  payloadArrayHasRows,
+  probeHandlerSucceeded,
+} from '../../src/testSupport/dynastySoakRunner.js';
 
 describe('dynasty soak batch dirty accumulator', () => {
   it('keeps dirty IDs drained during batch and merges them into final flush', () => {


### PR DESCRIPTION
### Motivation
- A merge conflict introduced duplicated `const simCtx` declarations and a broken flow around preseason-starting seasons, causing a syntax error and incorrect sim sequencing in the dynasty soak harness.
- The intent is to ensure preseason-starting views advance out at least one tick before a single `SIM_TO_PHASE -> preseason` flow is run and to preserve the deep/full probe behavior.

### Description
- Reworked the per-season loop in `src/testSupport/dynastySoakRunner.js` to compute `yearBefore` / `phaseBefore` once, compute `fullProbes` / `deepFinalProbes` / transaction limits, and only declare `simCtx` once with `phaseBefore` and `yearBefore`.
- If the current view boots in `preseason`, call `advanceOutOfCurrentTargetPhase` first and refresh `view`, `yearBefore`, and `phaseBefore` before calling `simUntilPreseason` once via `runnerDispatch` and then push `simAttemptsPerSeason`.
- Replaced stray/duplicated `dispatchWorker` calls with the configured `runnerDispatch` for deep probes (season history and draft-class sampling) and fixed malformed block closures for the deep draft-class assertions.
- Added imports for `payloadArrayHasRows` and `probeHandlerSucceeded` from the soak runner into `tests/unit/dynastySoakPersistence.test.js` so tests that assert `ok:false` probe payloads use the same helpers.

### Testing
- Ran the soak unit/integration suite with `npm run test:soak` and all tests passed (5 files, 28 tests).
- Verified syntax and runtime entry with `node --check src/testSupport/dynastySoakRunner.js` and ran a production build with `npm run build`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0203414380832d8bc53495e436e40c)