### PR TITLE
Test dynasty soak deep flag resolution

### DIFF
--- a/tests/unit/dynastySoakCli.test.js
+++ b/tests/unit/dynastySoakCli.test.js
@@ -25,7 +25,7 @@ describe('dynastySoakCli', () => {
     expect(raw.deepEachSeason).toBe(true);
   });
 
-  it('resolves --deep into an explicit runner config field', () => {
+  it('resolves --deep into an explicit runner config field without enabling deep-each-season', () => {
     const { raw, errors: parseErrors } = parseDynastySoakArgv(['node', 'x.mjs', '--deep']);
     expect(parseErrors).toEqual([]);
     expect(raw.deep).toBe(true);
@@ -34,6 +34,16 @@ describe('dynastySoakCli', () => {
     expect(errors).toEqual([]);
     expect(resolved.deep).toBe(true);
     expect(resolved.deepEachSeason).toBe(false);
+  });
+
+  it('resolves --deep-each-season into an explicit runner config field', () => {
+    const { raw, errors: parseErrors } = parseDynastySoakArgv(['node', 'x.mjs', '--deep-each-season']);
+    expect(parseErrors).toEqual([]);
+    expect(raw.deepEachSeason).toBe(true);
+
+    const { errors, resolved } = resolveDynastySoakConfig(raw);
+    expect(errors).toEqual([]);
+    expect(resolved.deepEachSeason).toBe(true);
   });
 
   it('rejects unknown flags', () => {
@@ -128,6 +138,7 @@ describe('dynastySoakCli', () => {
       },
       persistenceAssertions: [{ id: 'latest_season_archive', ok: true, detail: 'ok' }],
     });
+    expect(md).toContain('- **Harness:** ci=true deep=true deepEachSeason=false');
     expect(md).toContain('Phase timing breakdown');
     expect(md).toContain('GET probes');
     expect(md).toContain('| Simulation | 80 | 1 |');


### PR DESCRIPTION
### Motivation
- Ensure CLI flag semantics are explicit in tests: `--deep` should enable `resolved.deep` without enabling `resolved.deepEachSeason`, and `--deep-each-season` should enable `resolved.deepEachSeason`.

### Description
- Update unit tests in `tests/unit/dynastySoakCli.test.js` to (1) clarify the `--deep` resolution test to assert `resolved.deep === true` and `resolved.deepEachSeason === false`, (2) add a new test that verifies `--deep-each-season` resolves to `resolved.deepEachSeason === true`, and (3) add coverage asserting the generated markdown includes the harness line showing both flags (e.g. `- **Harness:** ci=true deep=true deepEachSeason=false`); no changes were made to `src/testSupport/dynastySoakCli.js`.

### Testing
- Ran the unit tests with `npm run test:unit -- tests/unit/dynastySoakCli.test.js` and the suite passed: `1 file passed, 11 tests passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a020347e754832d9c283981eba28392)