### PR TITLE
Test deep dynasty soak injected probes

### DIFF
--- a/src/testSupport/dynastySoakRunner.js
+++ b/src/testSupport/dynastySoakRunner.js
@@ -406,8 +406,6 @@ export async function runDynastySoakOnce(opts = {}) {
       const recentTransactionLimit = deepFinalProbes ? 1_000 : 400;
       const seasonTransactionLimit = deepFinalProbes ? 1_000 : 200;
 
-      const simCtx = { checkpoints, label: `S${s}`, phaseBefore, yearBefore };
-      const { lastMsg: simMsg, attempts } = await simUntilPreseason(simTimeoutMs, simCtx);
       if (phaseBefore === 'preseason') {
         const advanceResult = await advanceOutOfCurrentTargetPhase(view, {
           checkpoints,
@@ -509,10 +507,8 @@ export async function runDynastySoakOnce(opts = {}) {
       }
 
       let tProbe = Date.now();
-      const allSeasonsMsg = await dispatchWorker(toWorker.GET_ALL_SEASONS, {}, { timeoutMs: phaseTimeoutMs });
-      pushCheckpoint(checkpoints, `S${s}.GET_ALL_SEASONS`, Date.now() - tProbe, { fullProbes, deepFinalProbes });
       const allSeasonsMsg = await runnerDispatch(toWorker.GET_ALL_SEASONS, {}, { timeoutMs: phaseTimeoutMs });
-      pushCheckpoint(checkpoints, `S${s}.GET_ALL_SEASONS`, Date.now() - tProbe, { fullProbes });
+      pushCheckpoint(checkpoints, `S${s}.GET_ALL_SEASONS`, Date.now() - tProbe, { fullProbes, deepFinalProbes });
 
       const leagueHistory = view?.leagueHistory ?? [];
       const latestSeason = leagueHistory.length ? leagueHistory[leagueHistory.length - 1] : null;
@@ -531,8 +527,7 @@ export async function runDynastySoakOnce(opts = {}) {
         tProbe = Date.now();
         txSeasonMsg = await runnerDispatch(
           toWorker.GET_TRANSACTIONS,
-          { seasonId: view?.seasonId, limit: seasonTransactionLimit },
-          { seasonId: latestSeasonId ?? view?.seasonId, limit: 200 },
+          { seasonId: latestSeasonId ?? view?.seasonId, limit: seasonTransactionLimit },
           { timeoutMs: phaseTimeoutMs },
         );
         pushCheckpoint(checkpoints, `S${s}.GET_TRANSACTIONS_season`, Date.now() - tProbe, null);
@@ -585,7 +580,7 @@ export async function runDynastySoakOnce(opts = {}) {
           let archiveOk = true;
           for (const season of archiveSample) {
             tProbe = Date.now();
-            const sampledHistMsg = await dispatchWorker(
+            const sampledHistMsg = await runnerDispatch(
               toWorker.GET_SEASON_HISTORY,
               { seasonId: season.id },
               { timeoutMs: phaseTimeoutMs },
@@ -612,7 +607,7 @@ export async function runDynastySoakOnce(opts = {}) {
         let draftClassOk = true;
         for (const klass of draftClassSample) {
           tProbe = Date.now();
-          const draftClassMsg = await dispatchWorker(
+          const draftClassMsg = await runnerDispatch(
             toWorker.GET_DRAFT_CLASS,
             { seasonId: klass.seasonId },
             { timeoutMs: phaseTimeoutMs },
@@ -628,6 +623,9 @@ export async function runDynastySoakOnce(opts = {}) {
           detail: draftClassSample.length
             ? `${draftClassSample.length} draft class models sampled`
             : 'no draft classes available to sample',
+        });
+      }
+
       const txSeasonRows = txSeasonMsg.payload?.transactions ?? [];
       let dbLatestSeason = null;
       let dbAllSeasons = null;

--- a/tests/unit/dynastySoakRunner.test.js
+++ b/tests/unit/dynastySoakRunner.test.js
@@ -119,4 +119,104 @@ describe('runDynastySoakOnce', () => {
     expect(simAttempt).toMatchObject({ phaseAfter: 'preseason', yearAfter: 2027 });
     expect(simAttempt.yearAfter).toBeGreaterThan(checkpoint.meta.yearBefore);
   });
+
+  it('uses injected worker hooks for deep final probes without deepEachSeason', async () => {
+    const calls = [];
+    const bootState = makeState({ phase: 'regular', year: 2026 });
+    const finalState = {
+      ...makeState({ phase: 'preseason', year: 2027 }),
+      seasonId: 's2027',
+      leagueHistory: [
+        { id: 's2023', year: 2023 },
+        { id: 's2024', year: 2024 },
+        { id: 's2025', year: 2025 },
+        { id: 's2026', year: 2026 },
+      ],
+    };
+    const draftClasses = [
+      { seasonId: 's2026', year: 2026 },
+      { seasonId: 's2025', year: 2025 },
+    ];
+
+    const dispatchWorker = vi.fn(async (type, payload = {}) => {
+      calls.push({ type, payload });
+      switch (type) {
+        case toWorker.INIT:
+          return { type: toUI.READY, payload: {} };
+        case toWorker.USE_SAFE_STARTER_LEAGUE:
+          return { type: toUI.FULL_STATE, payload: bootState };
+        case toWorker.SIM_TO_PHASE:
+          expect(payload).toEqual({ targetPhase: 'preseason' });
+          return { type: toUI.FULL_STATE, payload: finalState };
+        case toWorker.GET_ALL_SEASONS:
+          return { type: toUI.ALL_SEASONS, payload: { seasons: finalState.leagueHistory } };
+        case toWorker.GET_TRANSACTIONS:
+          return { type: toUI.TRANSACTIONS, payload: { transactions: [] } };
+        case toWorker.GET_RECORDS:
+          return { type: toUI.RECORDS, payload: { recordBook: {} } };
+        case toWorker.GET_HALL_OF_FAME:
+          return { type: toUI.HALL_OF_FAME, payload: { players: [] } };
+        case toWorker.GET_DRAFT_CLASSES:
+          return { type: toUI.DRAFT_CLASSES, payload: { classes: draftClasses } };
+        case toWorker.GET_SEASON_HISTORY:
+          return {
+            type: toUI.SEASON_HISTORY,
+            payload: { seasonId: payload.seasonId, data: { id: payload.seasonId } },
+          };
+        case toWorker.GET_DRAFT_CLASS:
+          return {
+            type: toUI.DRAFT_CLASS,
+            payload: { seasonId: payload.seasonId, model: { seasonId: payload.seasonId } },
+          };
+        case toWorker.ADVANCE_WEEK:
+          return { type: toUI.WEEK_COMPLETE, payload: finalState };
+        default:
+          throw new Error(`Unexpected worker call: ${type}`);
+      }
+    });
+    const loadWorkerModule = vi.fn(async () => {});
+
+    const { runDynastySoakOnce } = await import('../../src/testSupport/dynastySoakRunner.js');
+    const result = await runDynastySoakOnce({
+      seasons: 1,
+      seed: 123,
+      deep: true,
+      deepEachSeason: false,
+      dispatchWorker,
+      loadWorkerModule,
+    });
+
+    expect(loadWorkerModule).toHaveBeenCalledTimes(1);
+    expect(result.harnessConfig.deep).toBe(true);
+    expect(result.harnessConfig.deepEachSeason).toBe(false);
+
+    expect(calls).toContainEqual({
+      type: toWorker.GET_TRANSACTIONS,
+      payload: { mode: 'recent', limit: 1000 },
+    });
+    expect(calls).toContainEqual({
+      type: toWorker.GET_TRANSACTIONS,
+      payload: { seasonId: 's2026', limit: 1000 },
+    });
+
+    const seasonHistoryCalls = calls.filter((c) => c.type === toWorker.GET_SEASON_HISTORY);
+    for (const seasonId of ['s2023', 's2024', 's2025', 's2026']) {
+      expect(seasonHistoryCalls).toContainEqual({
+        type: toWorker.GET_SEASON_HISTORY,
+        payload: { seasonId },
+      });
+    }
+
+    const draftClassCalls = calls.filter((c) => c.type === toWorker.GET_DRAFT_CLASS);
+    expect(draftClassCalls).toEqual([
+      { type: toWorker.GET_DRAFT_CLASS, payload: { seasonId: 's2026' } },
+      { type: toWorker.GET_DRAFT_CLASS, payload: { seasonId: 's2025' } },
+    ]);
+
+    expect(result.persistenceAssertions.map((assertion) => assertion.id)).toEqual([
+      'deep_archive_history_sample',
+      'deep_draft_class_model_sample',
+    ]);
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Add a focused unit test to verify the runner’s deep final-probe behavior when `deep: true` and `deepEachSeason: false` and ensure injected worker hooks are honored.
- Ensure deep probes exercise archived season history sampling, draft-class model sampling, and the larger transaction limits used for deep probes.

### Description
- Added a new mocked unit test in `tests/unit/dynastySoakRunner.test.js` that injects `dispatchWorker` and `loadWorkerModule` and asserts harness config, recent/season transaction payload limits, archived season history requests, draft class requests, and deep persistence assertion IDs.
- Updated `src/testSupport/dynastySoakRunner.js` to consistently use the injected `runnerDispatch` hook for deep probe paths (replacing stray direct `dispatchWorker` calls), preserve the deep transaction limits (`limit: 1000`), and correctly append the deep assertion objects.
- Fixed a small syntax/structure issue around deep assertion array assembly so deep assertions are closed and merged into `aggregate.persistenceAssertions` as intended.

### Testing
- Ran `node --check src/testSupport/dynastySoakRunner.js` which completed without errors.
- Ran `npm run test:unit -- tests/unit/dynastySoakRunner.test.js` (Vitest) and observed the test file pass with 2 tests succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02034819b4832d86d0312ca02c6b71)