### PR TITLE
Fix dynasty soak preseason advance ordering

### DIFF
--- a/src/testSupport/dynastySoakRunner.js
+++ b/src/testSupport/dynastySoakRunner.js
@@ -406,8 +406,6 @@ export async function runDynastySoakOnce(opts = {}) {
       const recentTransactionLimit = deepFinalProbes ? 1_000 : 400;
       const seasonTransactionLimit = deepFinalProbes ? 1_000 : 200;
 
-      const simCtx = { checkpoints, label: `S${s}`, phaseBefore, yearBefore };
-      const { lastMsg: simMsg, attempts } = await simUntilPreseason(simTimeoutMs, simCtx);
       if (phaseBefore === 'preseason') {
         const advanceResult = await advanceOutOfCurrentTargetPhase(view, {
           checkpoints,
@@ -439,7 +437,12 @@ export async function runDynastySoakOnce(opts = {}) {
         view = advanceResult.lastMsg.payload;
       }
 
-      const simCtx = { checkpoints, label: `S${s}` };
+      const simCtx = {
+        checkpoints,
+        label: `S${s}`,
+        phaseBefore: String(view?.phase ?? ''),
+        yearBefore: Number(view?.year ?? 0),
+      };
       const { lastMsg: simMsg, attempts } = await simUntilPreseason(simTimeoutMs, simCtx, runnerDispatch);
       simAttemptsPerSeason.push({ season: s, attempts });
 
@@ -509,10 +512,8 @@ export async function runDynastySoakOnce(opts = {}) {
       }
 
       let tProbe = Date.now();
-      const allSeasonsMsg = await dispatchWorker(toWorker.GET_ALL_SEASONS, {}, { timeoutMs: phaseTimeoutMs });
-      pushCheckpoint(checkpoints, `S${s}.GET_ALL_SEASONS`, Date.now() - tProbe, { fullProbes, deepFinalProbes });
       const allSeasonsMsg = await runnerDispatch(toWorker.GET_ALL_SEASONS, {}, { timeoutMs: phaseTimeoutMs });
-      pushCheckpoint(checkpoints, `S${s}.GET_ALL_SEASONS`, Date.now() - tProbe, { fullProbes });
+      pushCheckpoint(checkpoints, `S${s}.GET_ALL_SEASONS`, Date.now() - tProbe, { fullProbes, deepFinalProbes });
 
       const leagueHistory = view?.leagueHistory ?? [];
       const latestSeason = leagueHistory.length ? leagueHistory[leagueHistory.length - 1] : null;
@@ -531,8 +532,7 @@ export async function runDynastySoakOnce(opts = {}) {
         tProbe = Date.now();
         txSeasonMsg = await runnerDispatch(
           toWorker.GET_TRANSACTIONS,
-          { seasonId: view?.seasonId, limit: seasonTransactionLimit },
-          { seasonId: latestSeasonId ?? view?.seasonId, limit: 200 },
+          { seasonId: latestSeasonId ?? view?.seasonId, limit: seasonTransactionLimit },
           { timeoutMs: phaseTimeoutMs },
         );
         pushCheckpoint(checkpoints, `S${s}.GET_TRANSACTIONS_season`, Date.now() - tProbe, null);
@@ -563,7 +563,7 @@ export async function runDynastySoakOnce(opts = {}) {
 
       let seasonHistory = null;
       let getSeasonHistoryOk = null;
-      let getSeasonHistorySkipped = !fullProbes;
+      const getSeasonHistorySkipped = !fullProbes;
       const deepFinalAssertions = [];
       if (fullProbes && latestSeason?.id) {
         tProbe = Date.now();
@@ -585,7 +585,7 @@ export async function runDynastySoakOnce(opts = {}) {
           let archiveOk = true;
           for (const season of archiveSample) {
             tProbe = Date.now();
-            const sampledHistMsg = await dispatchWorker(
+            const sampledHistMsg = await runnerDispatch(
               toWorker.GET_SEASON_HISTORY,
               { seasonId: season.id },
               { timeoutMs: phaseTimeoutMs },
@@ -612,7 +612,7 @@ export async function runDynastySoakOnce(opts = {}) {
         let draftClassOk = true;
         for (const klass of draftClassSample) {
           tProbe = Date.now();
-          const draftClassMsg = await dispatchWorker(
+          const draftClassMsg = await runnerDispatch(
             toWorker.GET_DRAFT_CLASS,
             { seasonId: klass.seasonId },
             { timeoutMs: phaseTimeoutMs },
@@ -628,6 +628,9 @@ export async function runDynastySoakOnce(opts = {}) {
           detail: draftClassSample.length
             ? `${draftClassSample.length} draft class models sampled`
             : 'no draft classes available to sample',
+        });
+      }
+
       const txSeasonRows = txSeasonMsg.payload?.transactions ?? [];
       let dbLatestSeason = null;
       let dbAllSeasons = null;

--- a/tests/unit/dynastySoakPersistence.test.js
+++ b/tests/unit/dynastySoakPersistence.test.js
@@ -4,6 +4,10 @@ import {
   validateTransactionTimelineV1Shape,
 } from '../../src/core/dynastySoakAudit.js';
 import {
+  payloadArrayHasRows,
+  probeHandlerSucceeded,
+} from '../../src/testSupport/dynastySoakRunner.js';
+import {
   createEmptyDirtySnapshot,
   hasDirtySnapshot,
   mergeDirtySnapshots,


### PR DESCRIPTION
### Motivation
- Ensure a boot-state preseason is advanced via `ADVANCE_WEEK` before the first `SIM_TO_PHASE` so CI harness sim metadata reflects a post-advance starting point.  
- Avoid SIM returning immediately without crossing a season boundary by seeding sim attempt metadata from the view after the advance.  
- Route all probe calls through the injected runner dispatch hook to make test hooks and CI behavior deterministic.  
- Make persistence tests able to detect `ok:false` probe payloads by sharing probe helper functions with the test suite.

### Description
- Change the season loop in `src/testSupport/dynastySoakRunner.js` to advance out of a boot `preseason` first and then build `simCtx` using the post-advance `phase`/`year` before calling `simUntilPreseason`.  
- Pass the injected `runnerDispatch` into subsequent probe calls and the `simUntilPreseason` invocation so test-provided `dispatchWorker` is used for GET probes, deep archive probes, and draft-class probes.  
- Replace direct `dispatchWorker` usage in several places with `runnerDispatch`, and fix several malformed probe call argument orders and checkpoint metadata (including adding `deepFinalProbes` to the `GET_ALL_SEASONS` checkpoint).  
- Make small housekeeping fixes (use `const` for `getSeasonHistorySkipped`, close a misplaced block around deep draft class handling).  
- Import `payloadArrayHasRows` and `probeHandlerSucceeded` from `src/testSupport/dynastySoakRunner.js` into `tests/unit/dynastySoakPersistence.test.js` so persistence assertions can evaluate `ok:false` probe payloads.

### Testing
- Ran `node --check src/testSupport/dynastySoakRunner.js` with no syntax errors. (success)  
- Ran the focused tests `npm run test:unit -- tests/unit/dynastySoakRunner.test.js` and `npm run test:unit -- tests/unit/dynastySoakPersistence.test.js tests/unit/dynastySoakRunner.test.js` and both passed. (success)  
- Ran the full unit suite `npm run test:unit` and all tests passed: 182 test files, 770 tests passed. (success)  
- The changes preserve the original test assertions that `ADVANCE_WEEK` occurs before `SIM_TO_PHASE`, `result.finalPhase` is `preseason`, `result.finalYear` advanced, the `S1.advance_out_of_preseason` checkpoint meta fields exist, and the first `simAttemptsPerSeason[0].attempts[0]` reflects the later preseason/year.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a020345c3c4832d82a267269fdf9ec9)