### PR TITLE
Fix dynasty soak runner parity syntax

### DIFF
--- a/src/testSupport/dynastySoakRunner.js
+++ b/src/testSupport/dynastySoakRunner.js
@@ -439,12 +439,6 @@ export async function runDynastySoakOnce(opts = {}) {
         phaseBefore = String(view?.phase ?? '');
       }
 
-      const simCtx = {
-        checkpoints,
-        label: `S${s}`,
-        phaseBefore: String(view?.phase ?? ''),
-        yearBefore: Number(view?.year ?? 0),
-      };
       const simCtx = { checkpoints, label: `S${s}`, phaseBefore, yearBefore };
       const { lastMsg: simMsg, attempts } = await simUntilPreseason(simTimeoutMs, simCtx, runnerDispatch);
       simAttemptsPerSeason.push({ season: s, attempts });

--- a/tests/unit/dynastySoakPersistence.test.js
+++ b/tests/unit/dynastySoakPersistence.test.js
@@ -4,19 +4,11 @@ import {
   validateTransactionTimelineV1Shape,
 } from '../../src/core/dynastySoakAudit.js';
 import {
-  payloadArrayHasRows,
-  probeHandlerSucceeded,
-} from '../../src/testSupport/dynastySoakRunner.js';
-import {
   createEmptyDirtySnapshot,
   hasDirtySnapshot,
   mergeDirtySnapshots,
   queueDirtySnapshot,
 } from '../../src/worker/dirtyFlushAccumulator.js';
-import {
-  payloadArrayHasRows,
-  probeHandlerSucceeded,
-} from '../../src/testSupport/dynastySoakRunner.js';
 
 describe('dynasty soak batch dirty accumulator', () => {
   it('keeps dirty IDs drained during batch and merges them into final flush', () => {
@@ -144,7 +136,6 @@ describe('buildPersistenceAssertions', () => {
           },
         ],
       },
-      transactionsRecent: [],
       transactionsRecent: txPayload.transactions,
       expectTransactions: true,
       transactionsRecentProbeOk: false,

--- a/tests/unit/dynastySoakRunner.test.js
+++ b/tests/unit/dynastySoakRunner.test.js
@@ -116,7 +116,12 @@ describe('runDynastySoakOnce', () => {
     });
 
     const simAttempt = result.simAttemptsPerSeason[0].attempts[0];
-    expect(simAttempt).toMatchObject({ phaseAfter: 'preseason', yearAfter: 2027 });
+    expect(simAttempt).toMatchObject({
+      phaseBefore: 'regular',
+      yearBefore: 2026,
+      phaseAfter: 'preseason',
+      yearAfter: 2027,
+    });
     expect(simAttempt.yearAfter).toBeGreaterThan(checkpoint.meta.yearBefore);
   });
 


### PR DESCRIPTION
### Motivation
- A merge-conflict-style duplicate `const simCtx` was left in `src/testSupport/dynastySoakRunner.js`, causing a parse-time `SyntaxError: Identifier 'simCtx' has already been declared` and breaking Netlify Build Parity unit-test collection.
- The change is a narrow hotfix to restore CI/Netlify parity without changing harness semantics or softening tests.

### Description
- Removed the duplicate/merge-conflict `simCtx` declaration and left a single clear `simCtx` created after any preseason `ADVANCE_WEEK` step so `simUntilPreseason` is called exactly once per season. (removed the stale block that re-declared `simCtx`).
- Preserved preseason-boundary behavior: capture `yearBefore`/`phaseBefore`, call `advanceOutOfCurrentTargetPhase` when starting in `preseason`, refresh the `view`/`yearBefore`/`phaseBefore` from the advance result, then create the single `simCtx` and run `simUntilPreseason` as intended.
- Kept injected dispatcher usage intact by continuing to pass the injected `dispatchWorker` (`runnerDispatch`) into `SIM_TO_PHASE`, `ADVANCE_WEEK`, `GET_*` and deep probes so tests can control probe behavior; no stray direct `dispatchWorker(...)` calls were introduced in those paths.
- Reconciled persistence test imports by removing unnecessary runner helper imports from `tests/unit/dynastySoakPersistence.test.js` and ensuring persistence assertions are driven by explicit booleans/data passed into `buildPersistenceAssertions` (so persistence tests remain pure and lightweight).
- Added a tighter regression assertion in the runner test so `simAttemptsPerSeason[0].attempts[0]` includes the post-advance `phaseBefore`/`yearBefore` (keeps `S1.advance_out_of_preseason` checkpoint semantics intact); no audit/harness expansion or gameplay changes were made.

### Testing
- Ran `node --check src/testSupport/dynastySoakRunner.js` and it passed (no syntax error).
- Ran unit tests: `npm run test:unit` and targeted suites: `tests/unit/dynastySoakRunner.test.js`, `tests/unit/dynastySoakMergeAudit.test.js`, `tests/unit/dynastySoakPersistence.test.js`, and `tests/unit/dynastySoakCli.test.js`; all passed and the full `npm run test:unit` finished successfully (182 files / 772 tests passed).
- Ran soak subset: `npm run test:soak` and it passed (5 files / 29 tests).
- Built the app with `npm run build` (Vite build succeeded; large-chunk warning is unchanged) and ran deploy checks `npm run check:deploy` which completed successfully (Netlify parity and packaging checks passed offline).
- E2E/Playwright could not complete in this environment: `npx playwright install --with-deps chromium` failed to download browsers because the environment blocked `cdn.playwright.dev` with a `403 Domain forbidden`, so `npx playwright test` / `npm run test -- tests/e2e/...` remain environment-blocked and were not completed here.
- Optional `npm run audit:dynasty -- --ci --seed=1383 --max-runtime-ms=300000` was attempted but did not complete within the runtime window in this environment and was stopped; this is an environment/runtime limitation rather than a code regression.

Notes / confirmation
- Root cause: duplicate `simCtx` declaration (merge conflict residue) in `src/testSupport/dynastySoakRunner.js` that prevented module parsing.
- Exact duplicate removed: the stale `const simCtx = { checkpoints, label: `S${s}`, phaseBefore: String(view?.phase ?? ''), yearBefore: Number(view?.year ?? 0) };` block was removed and a single `simCtx = { checkpoints, label: `S${s}`, phaseBefore, yearBefore };` remains.
- Preseason advance ordering, injected dispatcher behavior, persistence assertion purity, `--deep`/`--deep-each-season` semantics, and explicit failed-probe payload behavior were preserved.
- Remaining limitation: Playwright browser downloads are blocked by the environment proxy so full E2E runs and browser installation could not be completed in this run; CI/Netlify parity and unit/soak checks are restored and green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02084297bc832da1903ebc5b7a1de3)