### PR TITLE
Introduce audit profiles (ci|full) with CI short-path runner, improved persistence assertions and reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "preview": "vite preview",
     "test": "playwright test",
     "test:unit": "vitest run",
-    "test:soak": "vitest run tests/unit/dynastySoakAudit.test.js tests/unit/dynastySoakCli.test.js tests/unit/dynastySoakPersistence.test.js tests/unit/dynastySoakMergeAudit.test.js tests/integration/dynastySoak.test.js",
+    "test:soak": "vitest run tests/unit/dynastySoakAudit.test.js tests/unit/dynastySoakCli.test.js tests/unit/dynastySoakRunner.test.js tests/unit/dynastySoakPersistence.test.js tests/unit/dynastySoakMergeAudit.test.js tests/integration/dynastySoak.test.js",
     "audit:dynasty": "tsx scripts/dynasty-soak.mjs",
     "test:e2e": "playwright test",
     "check:netlify-parity": "bash scripts/netlify-parity-check.sh",

--- a/scripts/dynasty-soak.mjs
+++ b/scripts/dynasty-soak.mjs
@@ -37,7 +37,7 @@ async function main() {
   const { runDynastySoakOnce } = await import('../src/testSupport/dynastySoakRunner.js');
 
   console.log(
-    `[dynasty-soak] seed=${resolved.seed} seasons=${resolved.seasons}${resolved.ci ? ' (ci)' : ''} deep=${resolved.deep} deepEachSeason=${resolved.deepEachSeason}`,
+    `[dynasty-soak] profile=${resolved.auditProfile} seed=${resolved.seed} seasons=${resolved.seasons}${resolved.ci ? ' (ci short path)' : ''} deep=${resolved.deep} deepEachSeason=${resolved.deepEachSeason}`,
   );
   const result = await runDynastySoakOnce(resolved);
 

--- a/src/core/dynastySoakAudit.js
+++ b/src/core/dynastySoakAudit.js
@@ -170,12 +170,43 @@ export function buildPersistenceAssertions(input = {}) {
   const assertions = [];
 
   const latestSeasonId = input.latestSeasonId ?? latest?.id ?? null;
+  const auditProfile = input.auditProfile ?? 'full';
+  const expectArchive = input.expectArchive ?? auditProfile !== 'ci';
 
-  assertions.push({
-    id: 'latest_season_archive',
-    ok: !!(latest && latest.id),
-    detail: latest?.id ? `latest season id=${latest.id}` : 'leagueHistory missing or empty',
-  });
+  const skipReason = (id, fallback) => String(input.skippedProbeReasons?.[id] || fallback || '').trim();
+  const pushSkipped = (id, reason, detailPrefix = 'skipped') => {
+    const hasReason = !!String(reason || '').trim();
+    assertions.push({
+      id,
+      ok: hasReason,
+      status: 'skipped',
+      skipped: true,
+      code: hasReason ? undefined : 'skipped_probe_missing_reason',
+      detail: hasReason ? `${detailPrefix}: ${reason}` : `${detailPrefix}: missing reason`,
+    });
+  };
+
+  if (expectArchive) {
+    assertions.push({
+      id: 'latest_season_archive',
+      ok: !!(latest && latest.id),
+      detail: latest?.id ? `latest season id=${latest.id}` : 'leagueHistory missing or empty',
+    });
+  } else {
+    pushSkipped(
+      'latest_season_archive',
+      skipReason('latest_season_archive', 'CI profile does not complete a season or create a completed-season archive'),
+    );
+  }
+
+  if (input.allSeasonsProbeOk != null) {
+    assertions.push({
+      id: 'get_all_seasons_probe',
+      ok: !!input.allSeasonsProbeOk,
+      code: input.allSeasonsProbeOk ? undefined : 'get_all_seasons_failed',
+      detail: input.allSeasonsProbeOk ? 'GET_ALL_SEASONS ok' : 'GET_ALL_SEASONS failed',
+    });
+  }
 
   if (Array.isArray(input.allSeasons) && latestSeasonId != null) {
     const found = input.allSeasons.some((season) => hasSeasonId(season, latestSeasonId));
@@ -186,6 +217,11 @@ export function buildPersistenceAssertions(input = {}) {
         ? `GET_ALL_SEASONS includes latest season ${latestSeasonId}`
         : `GET_ALL_SEASONS missing latest season ${latestSeasonId}`,
     });
+  } else if (!expectArchive && input.allSeasonsProbeOk != null) {
+    pushSkipped(
+      'get_all_seasons_latest',
+      skipReason('get_all_seasons_latest', 'CI profile has no completed season archive to find in GET_ALL_SEASONS'),
+    );
   }
 
   if (input.dbLatestSeasonFound != null) {
@@ -209,6 +245,15 @@ export function buildPersistenceAssertions(input = {}) {
     });
   }
 
+  if (input.saveNowOk != null) {
+    assertions.push({
+      id: 'save_now_flush',
+      ok: !!input.saveNowOk,
+      code: input.saveNowOk ? undefined : 'save_now_failed',
+      detail: input.saveNowOk ? 'SAVE_NOW flush ok' : 'SAVE_NOW flush failed',
+    });
+  }
+
   const hasTx = Array.isArray(input.transactionsRecent) && input.transactionsRecent.length > 0;
   const transactionsRecentProbeOk = input.transactionsRecentProbeOk !== false;
   const transactionsRecentHasExpectedData = input.transactionsRecentHasExpectedData ?? hasTx;
@@ -227,7 +272,12 @@ export function buildPersistenceAssertions(input = {}) {
           : 'no recent transactions (ok if none expected)',
   });
 
-  if (input.seasonTxQueryOk != null) {
+  if (input.seasonTxQuerySkipped) {
+    pushSkipped(
+      'get_transactions_by_season',
+      skipReason('get_transactions_by_season', 'CI profile has no completed season archive for a season-scoped transaction query'),
+    );
+  } else if (input.seasonTxQueryOk != null) {
     assertions.push({
       id: 'get_transactions_by_season',
       ok: !!input.seasonTxQueryOk,
@@ -239,39 +289,57 @@ export function buildPersistenceAssertions(input = {}) {
   const statsShape = validatePlayerSeasonStatsV1Shape(latest?.playerSeasonStatsV1);
   const statsRows = latest?.playerSeasonStatsV1?.rows;
   const hasStatsRows = Array.isArray(statsRows) && statsRows.length > 0;
-  assertions.push({
-    id: 'player_season_stats_v1',
-    ok: statsShape.ok && (!input.expectStatRows || hasStatsRows),
-    detail: statsShape.ok
-      ? hasStatsRows
-        ? `${statsRows.length} stat rows`
-        : 'archive present, no stat rows (ok early-season)'
-      : statsShape.errors.join('; '),
-  });
+  if (expectArchive || latest?.playerSeasonStatsV1 != null) {
+    assertions.push({
+      id: 'player_season_stats_v1',
+      ok: statsShape.ok && (!input.expectStatRows || hasStatsRows),
+      detail: statsShape.ok
+        ? hasStatsRows
+          ? `${statsRows.length} stat rows`
+          : 'archive present, no stat rows (ok early-season)'
+        : statsShape.errors.join('; '),
+    });
+  } else {
+    pushSkipped(
+      'player_season_stats_v1',
+      skipReason('player_season_stats_v1', 'CI profile does not create a completed-season player stats archive'),
+    );
+  }
 
   const tvShape = validateTransactionTimelineV1Shape(latest?.transactionTimelineV1);
   const tvRows = latest?.transactionTimelineV1?.rows;
   const hasTxRows = Array.isArray(tvRows) && tvRows.length > 0;
-  assertions.push({
-    id: 'transaction_timeline_v1',
-    ok: tvShape.ok && (!input.expectTimelineRows || hasTxRows),
-    detail: tvShape.ok
-      ? hasTxRows
-        ? `${tvRows.length} timeline rows`
-        : 'timeline object ok, empty rows'
-      : tvShape.errors.join('; '),
-  });
+  if (expectArchive || latest?.transactionTimelineV1 != null) {
+    assertions.push({
+      id: 'transaction_timeline_v1',
+      ok: tvShape.ok && (!input.expectTimelineRows || hasTxRows),
+      detail: tvShape.ok
+        ? hasTxRows
+          ? `${tvRows.length} timeline rows`
+          : 'timeline object ok, empty rows'
+        : tvShape.errors.join('; '),
+    });
+  } else {
+    pushSkipped(
+      'transaction_timeline_v1',
+      skipReason('transaction_timeline_v1', 'CI profile does not create a completed-season transaction timeline archive'),
+    );
+  }
 
-  assertions.push({
-    id: 'get_season_history',
-    ok: input.getSeasonHistoryOk !== false,
-    detail:
-      input.getSeasonHistorySkipped
-        ? 'skipped (shallow probe mode)'
-        : input.getSeasonHistoryOk
-          ? 'GET_SEASON_HISTORY returned data'
-          : 'GET_SEASON_HISTORY failed or empty',
-  });
+  if (input.getSeasonHistorySkipped) {
+    pushSkipped(
+      'get_season_history',
+      skipReason('get_season_history', 'shallow probe mode has no completed season history to query'),
+    );
+  } else {
+    assertions.push({
+      id: 'get_season_history',
+      ok: input.getSeasonHistoryOk !== false,
+      detail: input.getSeasonHistoryOk
+        ? 'GET_SEASON_HISTORY returned data'
+        : 'GET_SEASON_HISTORY failed or empty',
+    });
+  }
 
   if (input.seasonHistory !== undefined && latestSeasonId != null && !input.getSeasonHistorySkipped) {
     const found = input.seasonHistory && hasSeasonId(input.seasonHistory, latestSeasonId);
@@ -304,47 +372,53 @@ export function buildPersistenceAssertions(input = {}) {
     });
   }
 
-  assertions.push({
-    id: 'get_records',
-    ok: input.recordsProbeOk !== false,
-    detail:
-      input.recordsProbeSkipped
-        ? 'skipped (shallow probe mode)'
-        : input.recordsProbeOk
-          ? 'GET_RECORDS ok'
-          : 'GET_RECORDS missing recordBook',
-  });
+  if (input.recordsProbeSkipped) {
+    pushSkipped('get_records', skipReason('get_records', 'records probe skipped by audit profile'));
+  } else {
+    assertions.push({
+      id: 'get_records',
+      ok: input.recordsProbeOk !== false,
+      detail: input.recordsProbeOk
+        ? 'GET_RECORDS ok'
+        : 'GET_RECORDS missing recordBook',
+    });
+  }
 
-  assertions.push({
-    id: 'get_hall_of_fame',
-    ok: input.hofProbeOk !== false,
-    detail:
-      input.hofProbeSkipped
-        ? 'skipped (shallow probe mode)'
-        : input.hofProbeOk
-          ? 'GET_HALL_OF_FAME ok'
-          : 'GET_HALL_OF_FAME invalid shape',
-  });
+  if (input.hofProbeSkipped) {
+    pushSkipped('get_hall_of_fame', skipReason('get_hall_of_fame', 'Hall of Fame probe skipped by audit profile'));
+  } else {
+    assertions.push({
+      id: 'get_hall_of_fame',
+      ok: input.hofProbeOk !== false,
+      detail: input.hofProbeOk
+        ? 'GET_HALL_OF_FAME ok'
+        : 'GET_HALL_OF_FAME invalid shape',
+    });
+  }
 
   const draftClassesProbeOk = input.draftClassesProbeOk !== false;
   const draftClassesHasExpectedData = input.draftClassesHasExpectedData ?? Number(input.draftClassCount ?? 0) > 0;
-  assertions.push({
-    id: 'get_draft_classes',
-    ok: input.draftClassesProbeSkipped || (draftClassesProbeOk && (draftClassesHasExpectedData || !input.expectDraftClasses)),
-    code: !draftClassesProbeOk
-      ? 'get_draft_classes_failed'
-      : (!draftClassesHasExpectedData && input.expectDraftClasses ? 'draft_classes_empty' : undefined),
-    detail:
-      input.draftClassesProbeSkipped
-        ? 'skipped (shallow probe mode)'
-        : !draftClassesProbeOk
-          ? 'GET_DRAFT_CLASSES failed'
-          : draftClassesHasExpectedData
-            ? `GET_DRAFT_CLASSES count=${input.draftClassCount ?? 0}`
-            : 'GET_DRAFT_CLASSES returned no classes (ok if none expected)',
-  });
+  if (input.draftClassesProbeSkipped) {
+    pushSkipped(
+      'get_draft_classes',
+      skipReason('get_draft_classes', 'CI profile does not enter draft, so draft classes are not expected'),
+    );
+  } else {
+    assertions.push({
+      id: 'get_draft_classes',
+      ok: draftClassesProbeOk && (draftClassesHasExpectedData || !input.expectDraftClasses),
+      code: !draftClassesProbeOk
+        ? 'get_draft_classes_failed'
+        : (!draftClassesHasExpectedData && input.expectDraftClasses ? 'draft_classes_empty' : undefined),
+      detail: !draftClassesProbeOk
+        ? 'GET_DRAFT_CLASSES failed'
+        : draftClassesHasExpectedData
+          ? `GET_DRAFT_CLASSES count=${input.draftClassCount ?? 0}`
+          : 'GET_DRAFT_CLASSES returned no classes (ok if none expected)',
+    });
+  }
 
-  return { allOk: assertions.every((a) => a.ok), assertions };
+  return { allOk: assertions.every((a) => a.ok !== false), assertions };
 }
 
 function countByPos(roster) {

--- a/src/testSupport/dynastySoakCli.js
+++ b/src/testSupport/dynastySoakCli.js
@@ -6,8 +6,9 @@
 export const DYNASTY_SOAK_USAGE = `Usage: npm run audit:dynasty -- [options]
 
 Options:
-  --ci                    CI short soak (1 season, tighter timeouts, shallow mid-season probes)
-  --seasons=N             Number of seasons to simulate (default: 5, or 1 with --ci)
+  --ci                    Alias for --audit-profile=ci (fast real-worker smoke audit)
+  --audit-profile=ci|full Profile to run: ci=short partial phase path, full=legacy full-season manual audit
+  --seasons=N             Number of seasons to simulate with --audit-profile=full (default: 5; CI uses a short path)
   --seed=N                RNG seed (default: 1383)
   --outDir=PATH           Report output directory (default: artifacts/dynasty-soak)
   --deep                  Full final-season probes plus larger transaction/draft/archive samples
@@ -41,6 +42,7 @@ function parseRequiredNumber(flag, value, errors) {
 export function parseDynastySoakArgv(argv) {
   const raw = {
     ci: false,
+    auditProfile: null,
     deep: false,
     deepEachSeason: false,
     seasons: null,
@@ -55,7 +57,17 @@ export function parseDynastySoakArgv(argv) {
   const errors = [];
   for (let i = 2; i < argv.length; i += 1) {
     const a = argv[i];
-    if (a === '--ci') raw.ci = true;
+    if (a === '--ci') {
+      raw.ci = true;
+      raw.auditProfile = 'ci';
+    }
+    else if (a.startsWith('--audit-profile=')) {
+      raw.auditProfile = a.slice('--audit-profile='.length);
+    }
+    else if (a === '--audit-profile') {
+      raw.auditProfile = argv[i + 1];
+      i += 1;
+    }
     else if (a === '--deep') raw.deep = true;
     else if (a === '--deep-each-season') raw.deepEachSeason = true;
     else if (a === '--skip-report-open') raw.skipReportOpen = true;
@@ -127,12 +139,18 @@ export function resolveDynastySoakConfig(raw) {
   if (raw.unknown?.length) {
     /* already in parse errors */
   }
-  const seasons =
+  const requestedProfile = raw.auditProfile ?? (raw.ci ? 'ci' : 'full');
+  const auditProfile = String(requestedProfile || '').toLowerCase();
+  if (!['ci', 'full'].includes(auditProfile)) {
+    errors.push(`Unknown audit profile: ${requestedProfile}. Expected --audit-profile=ci or --audit-profile=full.`);
+  }
+  const requestedSeasons =
     raw.seasons != null && Number.isFinite(Number(raw.seasons))
       ? Math.max(1, Math.min(50, Number(raw.seasons)))
-      : raw.ci
-        ? 1
-        : 5;
+      : null;
+  const seasons = auditProfile === 'ci'
+    ? 1
+    : requestedSeasons ?? 5;
   const seed = raw.seed != null && Number.isFinite(Number(raw.seed)) ? Number(raw.seed) : 1383;
 
   if (raw.teams != null && Number.isFinite(raw.teams) && Number(raw.teams) !== 32) {
@@ -163,7 +181,18 @@ export function resolveDynastySoakConfig(raw) {
     resolved: {
       seasons,
       seed,
-      ci: !!raw.ci,
+      ci: auditProfile === 'ci',
+      auditProfile,
+      phasePath: auditProfile === 'ci' ? 'short' : 'full-season',
+      requestedSeasons,
+      effectiveSeasons: seasons,
+      ciWeeks: auditProfile === 'ci' ? 2 : null,
+      profileNotes: auditProfile === 'ci'
+        ? [
+            'CI profile runs a short real-worker phase path and does not complete a season.',
+            'Use --audit-profile=full --seasons=1 for the full manual season audit.',
+          ]
+        : ['Full profile preserves the legacy full-season SIM_TO_PHASE audit and may be slow.'],
       deep,
       deepEachSeason,
       phaseTimeoutMs,
@@ -202,6 +231,20 @@ function formatCheckpointMeta(meta) {
   return mdEscape(JSON.stringify(meta));
 }
 
+function exerciseStatusLabel(entry) {
+  if (!entry || typeof entry !== 'object') return 'unknown';
+  return String(entry.status ?? 'unknown');
+}
+
+function exerciseDetail(entry) {
+  if (!entry || typeof entry !== 'object') return '';
+  const parts = [];
+  if (entry.count != null) parts.push(`count=${entry.count}`);
+  if (entry.reason) parts.push(`reason=${entry.reason}`);
+  if (entry.detail) parts.push(String(entry.detail));
+  return parts.join('; ');
+}
+
 /**
  * @param {object} result - runDynastySoakOnce output (JSON-serializable)
  */
@@ -218,10 +261,52 @@ export function buildMarkdownReport(result) {
   lines.push(`- **Severity:** ${result.severity}`);
   if (result.harnessConfig) {
     lines.push(
-      `- **Harness:** ci=${result.harnessConfig.ci} deep=${!!result.harnessConfig.deep} deepEachSeason=${result.harnessConfig.deepEachSeason}`,
+      `- **Harness:** ci=${result.harnessConfig.ci} profile=${result.auditProfile ?? result.harnessConfig.auditProfile ?? 'full'} phasePath=${result.phasePath ?? result.harnessConfig.phasePath ?? 'full-season'} deep=${!!result.harnessConfig.deep} deepEachSeason=${result.harnessConfig.deepEachSeason}`,
     );
   }
   lines.push('');
+
+  lines.push('## Audit profile');
+  lines.push('');
+  const profile = result.auditProfile ?? result.harnessConfig?.auditProfile ?? (result.harnessConfig?.ci ? 'ci' : 'full');
+  const phasePath = result.phasePath ?? result.harnessConfig?.phasePath ?? (profile === 'ci' ? 'short' : 'full-season');
+  lines.push(`- **Profile:** ${mdEscape(profile)}`);
+  lines.push(`- **Phase path:** ${mdEscape(phasePath)}`);
+  if (profile === 'ci') {
+    lines.push('- **Scope:** Short real-worker smoke audit. It does not complete a season.');
+    lines.push('- **Full manual audit:** `npm run audit:dynasty -- --audit-profile=full --seasons=1 --seed=1383`');
+  } else {
+    lines.push('- **Scope:** Full manual audit that uses `SIM_TO_PHASE` and may be slow.');
+  }
+  for (const note of result.profileNotes ?? result.harnessConfig?.profileNotes ?? []) {
+    lines.push(`- ${mdEscape(note)}`);
+  }
+  lines.push('');
+
+  const exerciseEntries = Object.entries(result.exerciseMatrix || {});
+  if (exerciseEntries.length) {
+    lines.push('## What was exercised');
+    lines.push('');
+    lines.push('| System | Status | Detail |');
+    lines.push('| --- | --- | --- |');
+    for (const [name, entry] of exerciseEntries.filter(([, entry]) => !String(entry?.status ?? '').startsWith('skipped'))) {
+      lines.push(`| ${mdEscape(name)} | ${mdEscape(exerciseStatusLabel(entry))} | ${mdEscape(exerciseDetail(entry))} |`);
+    }
+    lines.push('');
+
+    lines.push('## What was skipped');
+    lines.push('');
+    const skipped = exerciseEntries.filter(([, entry]) => String(entry?.status ?? '').startsWith('skipped'));
+    if (!skipped.length) lines.push('_None_');
+    else {
+      lines.push('| System | Reason |');
+      lines.push('| --- | --- |');
+      for (const [name, entry] of skipped) {
+        lines.push(`| ${mdEscape(name)} | ${mdEscape(entry?.reason || 'skipped by profile')} |`);
+      }
+    }
+    lines.push('');
+  }
 
   if (result.smallerLeagueNote) {
     lines.push('## League mode');
@@ -274,11 +359,21 @@ export function buildMarkdownReport(result) {
     lines.push('## Persistence probes');
     lines.push('');
     for (const a of result.persistenceAssertions) {
-      const st = a.ok ? 'ok' : 'FAIL';
+      const st = a.status === 'skipped' ? 'skipped' : (a.ok ? 'ok' : 'FAIL');
       lines.push(`- **${st}** \`${a.id}\`: ${mdEscape(a.detail || '')}`);
     }
     lines.push('');
   }
+
+  lines.push('## Runtime notes');
+  lines.push('');
+  if ((result.auditProfile ?? result.harnessConfig?.auditProfile) === 'ci') {
+    lines.push('- CI profile intentionally avoids `SIM_TO_PHASE`; `--max-runtime-ms` is checked between short worker checkpoints.');
+    lines.push('- Full-season balance, playoffs, offseason, free agency, draft, and completed-season archive are not validated by CI profile.');
+  } else {
+    lines.push('- Full profile uses `SIM_TO_PHASE`; a single worker request may run for a long time before `--max-runtime-ms` can be checked.');
+  }
+  lines.push('');
 
   lines.push('## Summary buckets');
   lines.push('');

--- a/src/testSupport/dynastySoakRunner.js
+++ b/src/testSupport/dynastySoakRunner.js
@@ -16,6 +16,7 @@ const RESPONSE_BY_REQUEST = {
   [toWorker.USE_SAFE_STARTER_LEAGUE]: [toUI.FULL_STATE, toUI.ERROR],
   [toWorker.SIM_TO_PHASE]: [toUI.FULL_STATE, toUI.ERROR],
   [toWorker.ADVANCE_WEEK]: [toUI.WEEK_COMPLETE, toUI.ERROR, toUI.FULL_STATE],
+  [toWorker.SAVE_NOW]: [toUI.SAVED, toUI.ERROR],
   [toWorker.GET_ALL_SEASONS]: [toUI.ALL_SEASONS, toUI.ERROR],
   [toWorker.GET_TRANSACTIONS]: [toUI.TRANSACTIONS, toUI.ERROR],
   [toWorker.GET_RECORDS]: [toUI.RECORDS, toUI.ERROR],
@@ -164,7 +165,7 @@ function buildPhaseBreakdown(checkpoints) {
     else if (name.endsWith('.SIM_TO_PHASE')) bucket = groups.sim;
     else if (name.includes('.GET_')) bucket = groups.getProbes;
     else if (name.endsWith('.runDynastySoakAudit')) bucket = groups.auditEvaluation;
-    else if (name.endsWith('.ADVANCE_WEEK')) bucket = groups.finalAdvance;
+    else if (name.endsWith('.ADVANCE_WEEK') || name.includes('.ADVANCE_WEEK.')) bucket = groups.finalAdvance;
     if (!bucket) continue;
     bucket.ms += ms;
     bucket.count += 1;
@@ -282,6 +283,121 @@ function checkMaxRuntime(t0, maxRuntimeMs) {
   }
 }
 
+function baseSummary() {
+  return {
+    rosterHealth: 'ok',
+    capHealth: 'ok',
+    statHealth: 'ok',
+    archiveHealth: 'ok',
+    aiHealth: 'ok',
+    transactionHealth: 'ok',
+    draftHealth: 'ok',
+    scoutingHealth: 'ok',
+    developmentHealth: 'ok',
+    historyHealth: 'ok',
+  };
+}
+
+function buildCiExerciseMatrix(regularWeekCount = 0) {
+  const fullSeasonReason = 'CI profile runs a short real-worker phase path and does not complete a full season';
+  return {
+    realWorkerBoot: { status: 'exercised' },
+    safeStarterLeague: { status: 'exercised' },
+    preseasonAdvance: { status: 'pending' },
+    regularWeeks: { status: regularWeekCount > 0 ? 'exercised' : 'pending', count: regularWeekCount },
+    fullRegularSeason: { status: 'skipped', reason: fullSeasonReason },
+    playoffs: { status: 'skipped', reason: 'CI profile does not complete a full season' },
+    offseason: { status: 'skipped', reason: 'CI profile does not complete a full season' },
+    freeAgency: { status: 'skipped', reason: 'CI profile does not enter offseason' },
+    draft: { status: 'skipped', reason: 'CI profile does not enter draft' },
+    fullSeasonArchive: { status: 'skipped', reason: 'CI profile does not create a completed-season archive' },
+    persistenceFlush: { status: 'pending' },
+    workerProbes: { status: 'pending' },
+  };
+}
+
+function buildFullExerciseMatrix() {
+  return {
+    realWorkerBoot: { status: 'exercised' },
+    safeStarterLeague: { status: 'exercised' },
+    simToPhase: { status: 'exercised', detail: 'Full profile uses SIM_TO_PHASE to reach next preseason.' },
+    fullRegularSeason: { status: 'exercised' },
+    playoffs: { status: 'exercised' },
+    offseason: { status: 'exercised' },
+    freeAgency: { status: 'exercised' },
+    draft: { status: 'exercised' },
+    fullSeasonArchive: { status: 'exercised' },
+    persistenceFlush: { status: 'exercised' },
+    workerProbes: { status: 'exercised' },
+  };
+}
+
+function createAggregate({ auditProfile, phasePath, seed, phaseTimeoutMs, maxRuntimeMs, deep, deepEachSeason, profileNotes }) {
+  const checkpoints = [];
+  const simAttemptsPerSeason = [];
+  return {
+    passed: true,
+    severity: 'ok',
+    seasonsSimmed: 0,
+    checks: [],
+    warnings: [],
+    failures: [],
+    summary: baseSummary(),
+    checkpoints,
+    simAttemptsPerSeason,
+    timings: {
+      bootMs: 0,
+      phaseBreakdown: buildPhaseBreakdown([]),
+      topSlowCheckpoints: [],
+      totalMs: 0,
+    },
+    harnessConfig: {
+      ci: auditProfile === 'ci',
+      auditProfile,
+      phasePath,
+      deep: !!deep,
+      deepEachSeason: !!deepEachSeason,
+      phaseTimeoutMs,
+      maxRuntimeMs,
+      profileNotes,
+    },
+    auditProfile,
+    phasePath,
+    profileNotes,
+    seed,
+    smallerLeagueNote:
+      'Only 32-team safe starter leagues are supported for this harness. Smaller default leagues are deferred (playoff seeding and conference balance are coupled to 32 teams).',
+    persistenceAssertions: [],
+    exerciseMatrix: auditProfile === 'ci' ? buildCiExerciseMatrix(0) : buildFullExerciseMatrix(),
+  };
+}
+
+function finalizeAggregate(aggregate, t0, view, lastReportSummary = null) {
+  aggregate.severity = aggregate.failures.length ? 'error' : aggregate.warnings.length ? 'warn' : 'ok';
+  aggregate.runtimeMs = Date.now() - t0;
+  aggregate.finalPhase = view?.phase ?? null;
+  aggregate.finalYear = view?.year ?? null;
+  aggregate.reportSummary = lastReportSummary;
+  aggregate.timings.bootMs = aggregate.checkpoints.filter((c) => c.name.startsWith('boot.')).reduce((a, c) => a + c.ms, 0);
+  aggregate.timings.topSlowCheckpoints = topSlowCheckpoints(aggregate.checkpoints);
+  aggregate.timings.phaseBreakdown = buildPhaseBreakdown(aggregate.checkpoints);
+  aggregate.timings.totalMs = aggregate.runtimeMs;
+  aggregate.dynastySoakSimBatch = view?.dynastySoakSimBatch ?? null;
+  return aggregate;
+}
+
+function mergeViewWithPayload(currentView, msg, latestBroadcastView) {
+  if (latestBroadcastView && typeof latestBroadcastView === 'object') return latestBroadcastView;
+  return { ...(currentView ?? {}), ...(msg?.payload ?? {}) };
+}
+
+async function timedDispatch({ checkpoints, name, runnerDispatch, type, payload = {}, timeoutMs, meta = null }) {
+  const t = Date.now();
+  const msg = await runnerDispatch(type, payload, { timeoutMs });
+  pushCheckpoint(checkpoints, name, Date.now() - t, meta);
+  return msg;
+}
+
 /**
  * @typedef {object} DynastySoakRunnerOptions
  * @property {number} [seasons=5]
@@ -300,7 +416,7 @@ function checkMaxRuntime(t0, maxRuntimeMs) {
 /**
  * @param {DynastySoakRunnerOptions} opts
  */
-export async function runDynastySoakOnce(opts = {}) {
+async function runFullDynastySoakOnce(opts = {}) {
   const seasons = Math.max(1, Math.min(50, Number(opts.seasons) || 5));
   const seed = Number.isFinite(Number(opts.seed)) ? Number(opts.seed) : 1383;
   const ci = !!opts.ci;
@@ -351,6 +467,8 @@ export async function runDynastySoakOnce(opts = {}) {
     },
     harnessConfig: {
       ci,
+      auditProfile: 'full',
+      phasePath: 'full-season',
       deep,
       deepEachSeason,
       phaseTimeoutMs,
@@ -359,6 +477,10 @@ export async function runDynastySoakOnce(opts = {}) {
     smallerLeagueNote:
       'Only 32-team safe starter leagues are supported for this harness. Smaller default leagues are deferred (playoff seeding and conference balance are coupled to 32 teams).',
     persistenceAssertions: [],
+    auditProfile: 'full',
+    phasePath: 'full-season',
+    profileNotes: opts.profileNotes ?? ['Full profile preserves the legacy full-season SIM_TO_PHASE audit and may be slow.'],
+    exerciseMatrix: buildFullExerciseMatrix(),
   };
 
   globalThis.__dynastySoakBroadcast = opts.onBroadcast || null;
@@ -780,4 +902,258 @@ export async function runDynastySoakOnce(opts = {}) {
     globalThis.__DYNASTY_SOAK_PROFILE__ = false;
     globalThis.__DYNASTY_SOAK_LAST_BATCH__ = undefined;
   }
+}
+
+async function runCiDynastySoakOnce(opts = {}) {
+  const seed = Number.isFinite(Number(opts.seed)) ? Number(opts.seed) : 1383;
+  const deep = !!opts.deep;
+  const deepEachSeason = !!opts.deepEachSeason;
+  const phaseTimeoutMs = Number.isFinite(Number(opts.phaseTimeoutMs))
+    ? Number(opts.phaseTimeoutMs)
+    : Number.isFinite(Number(opts.simTimeoutMs))
+      ? Number(opts.simTimeoutMs)
+      : 3_600_000;
+  const maxRuntimeMs =
+    opts.maxRuntimeMs === null || opts.maxRuntimeMs === undefined
+      ? null
+      : Number(opts.maxRuntimeMs);
+  const ciWeeks = Math.max(1, Math.min(2, Number(opts.ciWeeks) || 2));
+  const profileNotes = opts.profileNotes ?? [
+    'CI profile runs a short real-worker phase path and does not complete a season.',
+    'Use --audit-profile=full --seasons=1 for the full manual season audit.',
+  ];
+  const runnerDispatch = typeof opts.dispatchWorker === 'function' ? opts.dispatchWorker : dispatchWorker;
+  const runnerLoadWorkerModule = typeof opts.loadWorkerModule === 'function' ? opts.loadWorkerModule : loadWorkerModule;
+  const aggregate = createAggregate({
+    auditProfile: 'ci',
+    phasePath: 'short',
+    seed,
+    phaseTimeoutMs,
+    maxRuntimeMs,
+    deep,
+    deepEachSeason,
+    profileNotes,
+  });
+  const { checkpoints } = aggregate;
+  const t0 = Date.now();
+  let view = null;
+  let lastReportSummary = null;
+  let latestBroadcastView = null;
+  const upstreamBroadcast = opts.onBroadcast || null;
+
+  globalThis.__dynastySoakBroadcast = (msg) => {
+    if (msg?.type === toUI.STATE_UPDATE || msg?.type === toUI.FULL_STATE) {
+      latestBroadcastView = { ...(latestBroadcastView ?? view ?? {}), ...(msg.payload ?? {}) };
+    }
+    if (typeof upstreamBroadcast === 'function') upstreamBroadcast(msg);
+  };
+  globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__ = false;
+  globalThis.__DYNASTY_SOAK_THROTTLE_PERSIST__ = false;
+  globalThis.__DYNASTY_SOAK_PROFILE__ = true;
+  globalThis.__DYNASTY_SOAK_LAST_BATCH__ = undefined;
+
+  try {
+    await runnerLoadWorkerModule();
+
+    await timedDispatch({
+      checkpoints,
+      name: 'boot.INIT',
+      runnerDispatch,
+      type: toWorker.INIT,
+      timeoutMs: Math.min(120_000, phaseTimeoutMs),
+    });
+    aggregate.exerciseMatrix.realWorkerBoot = { status: 'exercised' };
+    checkMaxRuntime(t0, maxRuntimeMs);
+
+    const bootMsg = await timedDispatch({
+      checkpoints,
+      name: 'boot.USE_SAFE_STARTER_LEAGUE',
+      runnerDispatch,
+      type: toWorker.USE_SAFE_STARTER_LEAGUE,
+      payload: {
+        slotKey: 'save_slot_1',
+        options: { rngSeed: seed, userTeamId: 0, name: `Dynasty Soak ${seed}` },
+      },
+      timeoutMs: Math.min(180_000, phaseTimeoutMs),
+    });
+    if (bootMsg.type === toUI.ERROR) throw new Error(bootMsg.payload?.message || 'USE_SAFE_STARTER_LEAGUE failed');
+    view = bootMsg.payload;
+    latestBroadcastView = view;
+    aggregate.exerciseMatrix.safeStarterLeague = { status: 'exercised' };
+    checkMaxRuntime(t0, maxRuntimeMs);
+
+    if (String(view?.phase ?? '') === 'preseason') {
+      latestBroadcastView = null;
+      const msg = await timedDispatch({
+        checkpoints,
+        name: 'ci.ADVANCE_WEEK.preseason_to_regular',
+        runnerDispatch,
+        type: toWorker.ADVANCE_WEEK,
+        payload: { skipUserGame: true },
+        timeoutMs: phaseTimeoutMs,
+        meta: { purpose: 'leave_preseason' },
+      });
+      if (msg.type === toUI.ERROR) throw new Error(msg.payload?.message || 'ADVANCE_WEEK failed leaving preseason');
+      view = mergeViewWithPayload(view, msg, latestBroadcastView);
+      aggregate.exerciseMatrix.preseasonAdvance = {
+        status: String(view?.phase ?? '') === 'regular' ? 'exercised' : 'warning',
+        detail: `phase=${view?.phase ?? 'unknown'}`,
+      };
+    } else {
+      aggregate.exerciseMatrix.preseasonAdvance = {
+        status: 'not_needed',
+        detail: `Starter league began in phase ${view?.phase ?? 'unknown'}`,
+      };
+    }
+    checkMaxRuntime(t0, maxRuntimeMs);
+
+    let regularWeeksSimmed = 0;
+    for (let i = 0; i < ciWeeks; i += 1) {
+      if (String(view?.phase ?? '') !== 'regular') break;
+      const weekBefore = Number(view?.currentWeek ?? 0);
+      latestBroadcastView = null;
+      const msg = await timedDispatch({
+        checkpoints,
+        name: `ci.ADVANCE_WEEK.regular_${i + 1}`,
+        runnerDispatch,
+        type: toWorker.ADVANCE_WEEK,
+        payload: { skipUserGame: true },
+        timeoutMs: phaseTimeoutMs,
+        meta: { weekBefore },
+      });
+      if (msg.type === toUI.ERROR) throw new Error(msg.payload?.message || `ADVANCE_WEEK failed in CI regular week ${i + 1}`);
+      view = mergeViewWithPayload(view, msg, latestBroadcastView);
+      regularWeeksSimmed += 1;
+      aggregate.exerciseMatrix.regularWeeks = { status: 'exercised', count: regularWeeksSimmed };
+      checkMaxRuntime(t0, maxRuntimeMs);
+    }
+
+    if (regularWeeksSimmed === 0) {
+      aggregate.passed = false;
+      aggregate.failures.push({ code: 'ci_no_regular_weeks', message: 'CI profile did not simulate any real regular-season weeks.' });
+      aggregate.exerciseMatrix.regularWeeks = { status: 'failed', count: 0 };
+    }
+
+    const saveMsg = await timedDispatch({
+      checkpoints,
+      name: 'ci.SAVE_NOW',
+      runnerDispatch,
+      type: toWorker.SAVE_NOW,
+      timeoutMs: Math.min(120_000, phaseTimeoutMs),
+    });
+    const saveNowOk = probeHandlerSucceeded(saveMsg);
+    aggregate.exerciseMatrix.persistenceFlush = saveNowOk
+      ? { status: 'exercised' }
+      : { status: 'failed', reason: saveMsg.payload?.message || 'SAVE_NOW failed' };
+    checkMaxRuntime(t0, maxRuntimeMs);
+
+    const allSeasonsMsg = await timedDispatch({
+      checkpoints,
+      name: 'ci.GET_ALL_SEASONS',
+      runnerDispatch,
+      type: toWorker.GET_ALL_SEASONS,
+      timeoutMs: phaseTimeoutMs,
+    });
+    const txMsg = await timedDispatch({
+      checkpoints,
+      name: 'ci.GET_TRANSACTIONS_recent',
+      runnerDispatch,
+      type: toWorker.GET_TRANSACTIONS,
+      payload: { mode: 'recent', limit: 100 },
+      timeoutMs: phaseTimeoutMs,
+    });
+    const recordsMsg = await timedDispatch({
+      checkpoints,
+      name: 'ci.GET_RECORDS',
+      runnerDispatch,
+      type: toWorker.GET_RECORDS,
+      timeoutMs: phaseTimeoutMs,
+    });
+    const hofMsg = await timedDispatch({
+      checkpoints,
+      name: 'ci.GET_HALL_OF_FAME',
+      runnerDispatch,
+      type: toWorker.GET_HALL_OF_FAME,
+      timeoutMs: phaseTimeoutMs,
+    });
+    aggregate.exerciseMatrix.workerProbes = { status: 'exercised_partial', detail: 'GET_ALL_SEASONS, GET_TRANSACTIONS recent, GET_RECORDS, GET_HALL_OF_FAME' };
+
+    const skippedProbeReasons = {
+      latest_season_archive: 'CI profile does not complete a season or create a completed-season archive',
+      get_all_seasons_latest: 'CI profile has no completed season archive to find in GET_ALL_SEASONS',
+      get_transactions_by_season: 'CI profile has no completed season archive for a season-scoped transaction query',
+      player_season_stats_v1: 'CI profile does not create a completed-season player stats archive',
+      transaction_timeline_v1: 'CI profile does not create a completed-season transaction timeline archive',
+      get_season_history: 'CI profile has no completed season history to query',
+      get_draft_classes: 'CI profile does not enter draft, so draft classes are not expected',
+    };
+
+    const audit = runDynastySoakAudit({
+      viewState: view,
+      seasonIndex: 0,
+      allSeasons: allSeasonsMsg.payload?.seasons ?? null,
+      seasonHistory: null,
+      transactions: txMsg.payload?.transactions ?? [],
+      recordsPayload: recordsMsg.payload ?? null,
+      hofPayload: hofMsg.payload ?? null,
+      draftClassesPayload: null,
+    });
+    pushCheckpoint(checkpoints, 'ci.runDynastySoakAudit', 0, null);
+    lastReportSummary = audit.reportSummary ?? null;
+    mergeAudit(aggregate, audit, 'CI');
+
+    const pers = buildPersistenceAssertions({
+      auditProfile: 'ci',
+      viewState: view,
+      allSeasons: allSeasonsMsg.payload?.seasons ?? null,
+      allSeasonsProbeOk: probeHandlerSucceeded(allSeasonsMsg),
+      transactionsRecent: txMsg.payload?.transactions ?? [],
+      expectArchive: false,
+      expectTransactions: false,
+      transactionsRecentProbeOk: probeHandlerSucceeded(txMsg),
+      transactionsRecentHasExpectedData: payloadArrayHasRows(txMsg.payload, 'transactions'),
+      expectStatRows: false,
+      expectTimelineRows: false,
+      seasonTxQuerySkipped: true,
+      getSeasonHistorySkipped: true,
+      recordsProbeOk: probeHandlerSucceeded(recordsMsg) && !!(recordsMsg.payload?.recordBook || recordsMsg.payload?.records),
+      recordsProbeSkipped: false,
+      hofProbeOk: probeHandlerSucceeded(hofMsg) && (!hofMsg.payload || Array.isArray(hofMsg.payload?.players)),
+      hofProbeSkipped: false,
+      draftClassesProbeSkipped: true,
+      expectDraftClasses: false,
+      draftClassCount: 0,
+      saveNowOk,
+      skippedProbeReasons,
+    });
+    aggregate.persistenceAssertions = pers.assertions;
+    if (!pers.allOk) {
+      aggregate.passed = false;
+      aggregate.failures.push({
+        code: 'persistence_probe_failed',
+        message: 'One or more CI persistence/probe assertions failed; see persistenceAssertions in latest.json',
+      });
+    }
+
+    return finalizeAggregate(aggregate, t0, view, lastReportSummary);
+  } catch (e) {
+    aggregate.passed = false;
+    aggregate.failures.push({ code: e?.code || 'runner_fatal', message: e?.message || String(e) });
+    return finalizeAggregate(aggregate, t0, view, lastReportSummary);
+  } finally {
+    globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__ = false;
+    globalThis.__DYNASTY_SOAK_THROTTLE_PERSIST__ = false;
+    globalThis.__DYNASTY_SOAK_PROFILE__ = false;
+    globalThis.__DYNASTY_SOAK_LAST_BATCH__ = undefined;
+    globalThis.__dynastySoakBroadcast = null;
+  }
+}
+
+/**
+ * @param {DynastySoakRunnerOptions} opts
+ */
+export async function runDynastySoakOnce(opts = {}) {
+  const auditProfile = String(opts.auditProfile ?? (opts.ci ? 'ci' : 'full')).toLowerCase();
+  if (auditProfile === 'ci') return runCiDynastySoakOnce({ ...opts, ci: true, auditProfile: 'ci' });
+  return runFullDynastySoakOnce({ ...opts, ci: false, auditProfile: 'full' });
 }

--- a/tests/unit/dynastySoakCli.test.js
+++ b/tests/unit/dynastySoakCli.test.js
@@ -19,6 +19,7 @@ describe('dynastySoakCli', () => {
     ]);
     expect(errors).toEqual([]);
     expect(raw.ci).toBe(true);
+    expect(raw.auditProfile).toBe('ci');
     expect(raw.seasons).toBe(2);
     expect(raw.seed).toBe(99);
     expect(raw.deep).toBe(true);
@@ -74,9 +75,32 @@ describe('dynastySoakCli', () => {
     const { errors, resolved } = resolveDynastySoakConfig(raw);
     expect(errors).toEqual([]);
     expect(resolved.seasons).toBe(1);
+    expect(resolved.auditProfile).toBe('ci');
+    expect(resolved.phasePath).toBe('short');
     expect(resolved.ci).toBe(true);
     expect(resolved.phaseTimeoutMs).toBe(3_600_000);
     expect(resolved.maxRuntimeMs).toBeNull();
+  });
+
+  it('resolves explicit audit profiles', () => {
+    const ciParsed = parseDynastySoakArgv(['node', 'x.mjs', '--audit-profile=ci', '--seasons=9']);
+    const ciResolved = resolveDynastySoakConfig(ciParsed.raw).resolved;
+    expect(ciResolved.auditProfile).toBe('ci');
+    expect(ciResolved.seasons).toBe(1);
+    expect(ciResolved.requestedSeasons).toBe(9);
+
+    const fullParsed = parseDynastySoakArgv(['node', 'x.mjs', '--audit-profile=full', '--seasons=1']);
+    const fullResolved = resolveDynastySoakConfig(fullParsed.raw).resolved;
+    expect(fullResolved.auditProfile).toBe('full');
+    expect(fullResolved.phasePath).toBe('full-season');
+    expect(fullResolved.seasons).toBe(1);
+  });
+
+  it('rejects invalid audit profiles', () => {
+    const { raw } = parseDynastySoakArgv(['node', 'x.mjs', '--audit-profile=turbo']);
+    const { errors, resolved } = resolveDynastySoakConfig(raw);
+    expect(resolved).toBeNull();
+    expect(errors.some((e) => e.includes('audit profile'))).toBe(true);
   });
 
   it('defaults to 5 seasons when not CI', () => {
@@ -105,7 +129,16 @@ describe('dynastySoakCli', () => {
       warnings: [],
       finalPhase: 'preseason',
       finalYear: 2027,
-      harnessConfig: { ci: true, deep: true, deepEachSeason: false },
+      auditProfile: 'ci',
+      phasePath: 'short',
+      profileNotes: ['CI profile runs a short real-worker phase path and does not complete a season.'],
+      harnessConfig: { ci: true, auditProfile: 'ci', phasePath: 'short', deep: true, deepEachSeason: false },
+      exerciseMatrix: {
+        realWorkerBoot: { status: 'exercised' },
+        regularWeeks: { status: 'exercised', count: 2 },
+        playoffs: { status: 'skipped', reason: 'CI profile does not complete a full season' },
+        draft: { status: 'skipped', reason: 'CI profile does not enter draft' },
+      },
       timings: {
         phaseBreakdown: {
           boot: { ms: 5, count: 1 },
@@ -138,7 +171,11 @@ describe('dynastySoakCli', () => {
       },
       persistenceAssertions: [{ id: 'latest_season_archive', ok: true, detail: 'ok' }],
     });
-    expect(md).toContain('- **Harness:** ci=true deep=true deepEachSeason=false');
+    expect(md).toContain('profile=ci');
+    expect(md).toContain('Audit profile');
+    expect(md).toContain('What was exercised');
+    expect(md).toContain('What was skipped');
+    expect(md).toContain('Short real-worker smoke audit');
     expect(md).toContain('Phase timing breakdown');
     expect(md).toContain('GET probes');
     expect(md).toContain('| Simulation | 80 | 1 |');

--- a/tests/unit/dynastySoakPersistence.test.js
+++ b/tests/unit/dynastySoakPersistence.test.js
@@ -40,6 +40,73 @@ describe('dynasty soak batch dirty accumulator', () => {
     expect(finalDirty.seasonStats).toEqual(['s1_p1', 's1_p2']);
     expect(finalDirty.draftPicks).toEqual(['2028_1_1', '2028_1_2']);
   });
+  it('marks CI full-season-only probes as skipped with reasons without failing', () => {
+    const r = buildPersistenceAssertions({
+      auditProfile: 'ci',
+      viewState: { leagueHistory: [] },
+      allSeasons: [],
+      allSeasonsProbeOk: true,
+      transactionsRecent: [],
+      expectArchive: false,
+      expectTransactions: false,
+      transactionsRecentProbeOk: true,
+      transactionsRecentHasExpectedData: false,
+      expectStatRows: false,
+      expectTimelineRows: false,
+      seasonTxQuerySkipped: true,
+      getSeasonHistorySkipped: true,
+      recordsProbeOk: true,
+      hofProbeOk: true,
+      draftClassesProbeSkipped: true,
+      saveNowOk: true,
+      skippedProbeReasons: {
+        latest_season_archive: 'CI profile does not complete a season',
+        get_all_seasons_latest: 'CI profile has no completed archive',
+        get_transactions_by_season: 'CI profile has no completed archive',
+        player_season_stats_v1: 'CI profile does not create a stat archive',
+        transaction_timeline_v1: 'CI profile does not create a transaction archive',
+        get_season_history: 'CI profile has no season history',
+        get_draft_classes: 'CI profile does not enter draft',
+      },
+    });
+
+    expect(r.allOk).toBe(true);
+    const skipped = r.assertions.filter((a) => a.status === 'skipped');
+    expect(skipped.length).toBeGreaterThan(0);
+    expect(skipped.every((a) => a.skipped === true && a.detail.includes('CI profile'))).toBe(true);
+  });
+
+  it('fails CI exercised probes when handlers fail', () => {
+    const r = buildPersistenceAssertions({
+      auditProfile: 'ci',
+      viewState: { leagueHistory: [] },
+      expectArchive: false,
+      allSeasonsProbeOk: false,
+      transactionsRecent: [],
+      expectTransactions: false,
+      transactionsRecentProbeOk: false,
+      seasonTxQuerySkipped: true,
+      getSeasonHistorySkipped: true,
+      recordsProbeOk: false,
+      hofProbeOk: true,
+      draftClassesProbeSkipped: true,
+      skippedProbeReasons: {
+        latest_season_archive: 'CI profile does not complete a season',
+        get_all_seasons_latest: 'CI profile has no completed archive',
+        get_transactions_by_season: 'CI profile has no completed archive',
+        player_season_stats_v1: 'CI profile does not create a stat archive',
+        transaction_timeline_v1: 'CI profile does not create a transaction archive',
+        get_season_history: 'CI profile has no season history',
+        get_draft_classes: 'CI profile does not enter draft',
+      },
+    });
+
+    expect(r.allOk).toBe(false);
+    expect(r.assertions.find((a) => a.id === 'get_all_seasons_probe')?.ok).toBe(false);
+    expect(r.assertions.find((a) => a.id === 'transactions_recent_available')?.ok).toBe(false);
+    expect(r.assertions.find((a) => a.id === 'get_records')?.ok).toBe(false);
+  });
+
 });
 
 describe('buildPersistenceAssertions', () => {

--- a/tests/unit/dynastySoakRunner.test.js
+++ b/tests/unit/dynastySoakRunner.test.js
@@ -49,11 +49,12 @@ describe('runDynastySoakOnce', () => {
     vi.clearAllMocks();
   });
 
-  it('advances out of boot preseason before simming to the next preseason in CI mode', async () => {
+  it('runs CI profile as a short real-worker path without SIM_TO_PHASE', async () => {
     const calls = [];
     const bootState = makeState({ phase: 'preseason', year: 2026 });
-    const regularState = makeState({ phase: 'regular', year: 2026 });
-    const nextPreseasonState = makeState({ phase: 'preseason', year: 2027 });
+    const regularState = { ...makeState({ phase: 'regular', year: 2026 }), currentWeek: 1 };
+    const week2State = { ...makeState({ phase: 'regular', year: 2026 }), currentWeek: 2 };
+    const week3State = { ...makeState({ phase: 'regular', year: 2026 }), currentWeek: 3 };
 
     const dispatchWorker = vi.fn(async (type, payload = {}) => {
       calls.push({ type, payload });
@@ -62,67 +63,55 @@ describe('runDynastySoakOnce', () => {
           return { type: toUI.READY, payload: {} };
         case toWorker.USE_SAFE_STARTER_LEAGUE:
           return { type: toUI.FULL_STATE, payload: bootState };
-        case toWorker.ADVANCE_WEEK:
+        case toWorker.ADVANCE_WEEK: {
+          const advanceCount = calls.filter((c) => c.type === toWorker.ADVANCE_WEEK).length;
           return {
             type: toUI.WEEK_COMPLETE,
-            payload: calls.filter((c) => c.type === toWorker.ADVANCE_WEEK).length === 1
-              ? regularState
-              : makeState({ phase: 'regular', year: 2027 }),
+            payload: advanceCount === 1 ? regularState : advanceCount === 2 ? week2State : week3State,
           };
-        case toWorker.SIM_TO_PHASE:
-          expect(payload).toEqual({ targetPhase: 'preseason' });
-          return { type: toUI.FULL_STATE, payload: nextPreseasonState };
+        }
+        case toWorker.SAVE_NOW:
+          return { type: toUI.SAVED, payload: {} };
         case toWorker.GET_ALL_SEASONS:
-          return { type: toUI.ALL_SEASONS, payload: { seasons: [{ id: 's2026', year: 2026 }] } };
+          return { type: toUI.ALL_SEASONS, payload: { seasons: [] } };
         case toWorker.GET_TRANSACTIONS:
           return { type: toUI.TRANSACTIONS, payload: { transactions: [] } };
         case toWorker.GET_RECORDS:
           return { type: toUI.RECORDS, payload: { recordBook: {} } };
         case toWorker.GET_HALL_OF_FAME:
           return { type: toUI.HALL_OF_FAME, payload: { players: [] } };
-        case toWorker.GET_DRAFT_CLASSES:
-          return { type: toUI.DRAFT_CLASSES, payload: { classes: [] } };
-        case toWorker.GET_SEASON_HISTORY:
-          return { type: toUI.SEASON_HISTORY, payload: { data: {} } };
+        case toWorker.SIM_TO_PHASE:
+          throw new Error('CI profile must not call SIM_TO_PHASE');
         default:
           throw new Error(`Unexpected worker call: ${type}`);
       }
     });
 
+    const loadWorkerModule = vi.fn(async () => {});
     const { runDynastySoakOnce } = await import('../../src/testSupport/dynastySoakRunner.js');
     const result = await runDynastySoakOnce({
-      seasons: 1,
+      seasons: 9,
       seed: 123,
       ci: true,
+      auditProfile: 'ci',
       dispatchWorker,
-      loadWorkerModule: vi.fn(async () => {}),
+      loadWorkerModule,
     });
 
-    const advanceIndex = calls.findIndex((c) => c.type === toWorker.ADVANCE_WEEK);
-    const simIndex = calls.findIndex((c) => c.type === toWorker.SIM_TO_PHASE);
-    expect(advanceIndex).toBeGreaterThan(-1);
-    expect(simIndex).toBeGreaterThan(advanceIndex);
-    expect(result.finalPhase).toBe('preseason');
-    expect(result.finalYear).toBe(2027);
-    expect(result.failures).toEqual([]);
-
-    const checkpoint = result.checkpoints.find((c) => c.name === 'S1.advance_out_of_preseason');
-    expect(checkpoint?.meta).toMatchObject({
-      phaseBefore: 'preseason',
-      phaseAfter: 'regular',
-      yearBefore: 2026,
-      yearAfter: 2026,
-      advances: 1,
-    });
-
-    const simAttempt = result.simAttemptsPerSeason[0].attempts[0];
-    expect(simAttempt).toMatchObject({
-      phaseBefore: 'regular',
-      yearBefore: 2026,
-      phaseAfter: 'preseason',
-      yearAfter: 2027,
-    });
-    expect(simAttempt.yearAfter).toBeGreaterThan(checkpoint.meta.yearBefore);
+    expect(loadWorkerModule).toHaveBeenCalledTimes(1);
+    expect(calls.map((c) => c.type)).toContain(toWorker.INIT);
+    expect(calls.map((c) => c.type)).toContain(toWorker.USE_SAFE_STARTER_LEAGUE);
+    expect(calls.filter((c) => c.type === toWorker.ADVANCE_WEEK)).toHaveLength(3);
+    expect(calls.some((c) => c.type === toWorker.SIM_TO_PHASE)).toBe(false);
+    expect(result.auditProfile).toBe('ci');
+    expect(result.phasePath).toBe('short');
+    expect(result.seasonsSimmed).toBe(1); // mocked pure audit return; report still labels CI as short path
+    expect(result.finalPhase).toBe('regular');
+    expect(result.exerciseMatrix.regularWeeks).toMatchObject({ status: 'exercised', count: 2 });
+    expect(result.exerciseMatrix.playoffs.status).toBe('skipped');
+    expect(result.exerciseMatrix.offseason.status).toBe('skipped');
+    expect(result.exerciseMatrix.draft.status).toBe('skipped');
+    expect(result.exerciseMatrix.fullSeasonArchive.status).toBe('skipped');
   });
 
   it('uses injected worker hooks for deep final probes without deepEachSeason', async () => {
@@ -192,6 +181,7 @@ describe('runDynastySoakOnce', () => {
     });
 
     expect(loadWorkerModule).toHaveBeenCalledTimes(1);
+    expect(result.auditProfile).toBe('full');
     expect(result.harnessConfig.deep).toBe(true);
     expect(result.harnessConfig.deepEachSeason).toBe(false);
 


### PR DESCRIPTION
### Motivation

- Provide a lightweight CI-friendly audit profile that runs a short real-worker path instead of the slow `SIM_TO_PHASE` full-season flow.  
- Make persistence probes aware of profile-driven skips so CI runs don't fail on artifacts only produced by a completed-season archive.  
- Improve CLI ergonomics and report output to surface the chosen audit profile, what was exercised, and what was intentionally skipped.  

### Description

- Add `--audit-profile=ci|full` support to the dynasty soak CLI and make `--ci` an alias for `--audit-profile=ci`, with `resolveDynastySoakConfig` returning `auditProfile`, `phasePath`, notes and effective season counts.  
- Implement a CI-oriented short-path runner in `src/testSupport/dynastySoakRunner.js` (`runCiDynastySoakOnce`) and keep a full-profile runner (`runFullDynastySoakOnce`), with `runDynastySoakOnce` dispatching based on `auditProfile`; also add helpers for exercise matrices, aggregate creation/finalization, and timed dispatch.  
- Make `buildPersistenceAssertions` in `src/core/dynastySoakAudit.js` support skipped probes with reasons and `auditProfile`/`expectArchive` logic, and change assertion pass semantics to treat explicit skipped probes as non-failing.  
- Enhance `buildMarkdownReport` to show audit profile metadata, exercised vs skipped systems, runtime notes, and mark persistence assertions as `skipped` when appropriate.  
- Wire `SAVE_NOW` handling into the test runner responses and add `ci`-focused probe flows (GET_ALL_SEASONS, recent transactions, records, HOF) and skipped-reason propagation to assertions.  
- Update `scripts/dynasty-soak.mjs` logging to include `profile` and `phasePath`, and add the runner test to the `test:soak` npm script in `package.json`.  
- Update and add unit tests to cover CLI parsing/resolution, report formatting, persistence assertion skip behavior, and the CI runner flow (`tests/unit/dynastySoakCli.test.js`, `dynastySoakRunner.test.js`, `dynastySoakPersistence.test.js` and related expectations).  

### Testing

- Ran unit tests including `tests/unit/dynastySoakCli.test.js`, `tests/unit/dynastySoakRunner.test.js`, and `tests/unit/dynastySoakPersistence.test.js` under `vitest` and they passed.  
- Ran the updated soak script unit grouping via the updated `test:soak` invocation (now including the runner test) and it completed successfully.  
- No automated end-to-end changes were introduced beyond adapting test mocks; CI-profile behavior was validated by the new unit tests and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02288f1200832d9257c5c19a4cb099)