### PR TITLE
Harden dynasty audit CLI report artifacts

### DIFF
--- a/scripts/dynasty-soak.mjs
+++ b/scripts/dynasty-soak.mjs
@@ -7,13 +7,10 @@
  * For CI, `npm run test:soak` runs fast Vitest audit coverage instead.
  */
 import 'fake-indexeddb/auto';
-import { mkdir, writeFile } from 'node:fs/promises';
-import { resolve } from 'node:path';
 import {
   parseDynastySoakArgv,
   resolveDynastySoakConfig,
-  buildMarkdownReport,
-  slimDynastySoakResultForJson,
+  writeDynastySoakReports,
   DYNASTY_SOAK_USAGE,
 } from '../src/testSupport/dynastySoakCli.js';
 
@@ -39,17 +36,14 @@ async function main() {
   console.log(
     `[dynasty-soak] profile=${resolved.auditProfile} seed=${resolved.seed} seasons=${resolved.seasons}${resolved.ci ? ' (ci short path)' : ''} deep=${resolved.deep} deepEachSeason=${resolved.deepEachSeason}`,
   );
+  if (resolved.auditProfile === 'full') {
+    console.warn(
+      '[dynasty-soak] full profile is a manual full-season SIM_TO_PHASE audit; a single worker request may run for a long time before --max-runtime-ms is checked.',
+    );
+  }
   const result = await runDynastySoakOnce(resolved);
 
-  const outDir = resolve(process.cwd(), resolved.outDir || 'artifacts/dynasty-soak');
-  await mkdir(outDir, { recursive: true });
-  await writeFile(
-    resolve(outDir, 'latest.json'),
-    JSON.stringify(slimDynastySoakResultForJson(result), null, 2),
-    'utf8',
-  );
-  const md = buildMarkdownReport(result);
-  await writeFile(resolve(outDir, 'latest.md'), md, 'utf8');
+  const { outDir } = await writeDynastySoakReports(result, resolved.outDir || 'artifacts/dynasty-soak');
 
   console.log(
     `[dynasty-soak] passed=${result.passed} runtimeMs=${result.runtimeMs} failures=${result.failures?.length ?? 0} warnings=${result.warnings?.length ?? 0}`,

--- a/src/testSupport/dynastySoakCli.js
+++ b/src/testSupport/dynastySoakCli.js
@@ -3,6 +3,9 @@
  * Used by scripts/dynasty-soak.mjs and Vitest.
  */
 
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
 export const DYNASTY_SOAK_USAGE = `Usage: npm run audit:dynasty -- [options]
 
 Options:
@@ -416,4 +419,27 @@ export function slimDynastySoakResultForJson(result) {
   const out = { ...result };
   delete out.finalView;
   return out;
+}
+
+/**
+ * Write the canonical dynasty soak JSON and Markdown reports.
+ * Kept in the CLI helper so tests can exercise the real artifact path without
+ * launching the worker.
+ * @param {object} result
+ * @param {string} [outDir]
+ * @param {string} [cwd]
+ * @returns {Promise<{ outDir: string, jsonPath: string, markdownPath: string }>}
+ */
+export async function writeDynastySoakReports(result, outDir = 'artifacts/dynasty-soak', cwd = process.cwd()) {
+  const resolvedOutDir = resolve(cwd, outDir);
+  const jsonPath = resolve(resolvedOutDir, 'latest.json');
+  const markdownPath = resolve(resolvedOutDir, 'latest.md');
+  await mkdir(resolvedOutDir, { recursive: true });
+  await writeFile(
+    jsonPath,
+    JSON.stringify(slimDynastySoakResultForJson(result), null, 2),
+    'utf8',
+  );
+  await writeFile(markdownPath, buildMarkdownReport(result), 'utf8');
+  return { outDir: resolvedOutDir, jsonPath, markdownPath };
 }

--- a/tests/unit/dynastySoakCli.test.js
+++ b/tests/unit/dynastySoakCli.test.js
@@ -1,9 +1,13 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   parseDynastySoakArgv,
   resolveDynastySoakConfig,
   buildMarkdownReport,
   slimDynastySoakResultForJson,
+  writeDynastySoakReports,
 } from '../../src/testSupport/dynastySoakCli.js';
 
 describe('dynastySoakCli', () => {
@@ -186,6 +190,97 @@ describe('dynastySoakCli', () => {
     expect(md).toContain('AI / roster snapshot');
     expect(md).toContain('contender');
     expect(md).toContain('Persistence probes');
+  });
+
+
+  it('writes canonical JSON and Markdown artifacts for a realistic CI profile result', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'dynasty-soak-cli-'));
+    const result = {
+      seed: 1383,
+      seasonsSimmed: 0,
+      runtimeMs: 18_776,
+      passed: true,
+      severity: 'warn',
+      summary: { rosterHealth: 'ok', archiveHealth: 'warn' },
+      failures: [],
+      warnings: [{ code: 'hof_empty_young', message: '[CI] Hall of Fame classes empty in early league years' }],
+      finalPhase: 'regular',
+      finalYear: 2026,
+      auditProfile: 'ci',
+      phasePath: 'short',
+      profileNotes: [
+        'CI profile runs a short real-worker phase path and does not complete a season.',
+        'Use --audit-profile=full --seasons=1 for the full manual season audit.',
+      ],
+      harnessConfig: {
+        ci: true,
+        auditProfile: 'ci',
+        phasePath: 'short',
+        deep: false,
+        deepEachSeason: false,
+        phaseTimeoutMs: 3_600_000,
+        maxRuntimeMs: null,
+      },
+      exerciseMatrix: {
+        realWorkerBoot: { status: 'exercised' },
+        safeStarterLeague: { status: 'exercised' },
+        regularWeeks: { status: 'exercised', count: 2 },
+        workerProbes: {
+          status: 'exercised_partial',
+          detail: 'GET_ALL_SEASONS, GET_TRANSACTIONS recent, GET_RECORDS, GET_HALL_OF_FAME',
+        },
+        fullRegularSeason: {
+          status: 'skipped',
+          reason: 'CI profile runs a short real-worker phase path and does not complete a full season',
+        },
+        playoffs: { status: 'skipped', reason: 'CI profile does not complete a full season' },
+        offseason: { status: 'skipped', reason: 'CI profile does not complete a full season' },
+        draft: { status: 'skipped', reason: 'CI profile does not enter draft' },
+        fullSeasonArchive: { status: 'skipped', reason: 'CI profile does not create a completed-season archive' },
+      },
+      timings: {
+        phaseBreakdown: { boot: { ms: 365, count: 2 }, getProbes: { ms: 131, count: 4 } },
+        topSlowCheckpoints: [{ name: 'ci.ADVANCE_WEEK.regular_2', ms: 11_471, meta: { weekBefore: 0 } }],
+      },
+      reportSummary: { teamCount: 32, teamsWithoutQb: 0, archetypeDistribution: { contender: 6 } },
+      persistenceAssertions: [
+        { id: 'latest_season_archive', ok: true, status: 'skipped', detail: 'skipped: CI profile does not complete a season or create a completed-season archive' },
+        { id: 'get_all_seasons_probe', ok: true, detail: 'GET_ALL_SEASONS ok' },
+        { id: 'get_draft_classes', ok: true, status: 'skipped', detail: 'skipped: CI profile does not enter draft, so draft classes are not expected' },
+      ],
+      finalView: { veryLarge: true },
+    };
+
+    try {
+      const written = await writeDynastySoakReports(result, 'reports', tmp);
+      const json = JSON.parse(await readFile(written.jsonPath, 'utf8'));
+      const md = await readFile(written.markdownPath, 'utf8');
+
+      expect(written.outDir).toBe(join(tmp, 'reports'));
+      expect(json.finalView).toBeUndefined();
+      expect(json.auditProfile).toBe('ci');
+      expect(json.phasePath).toBe('short');
+      expect(json.seed).toBe(1383);
+      expect(json.runtimeMs).toBe(18_776);
+      expect(json.finalPhase).toBe('regular');
+      expect(json.finalYear).toBe(2026);
+      expect(json.exerciseMatrix.workerProbes.status).toBe('exercised_partial');
+      expect(json.exerciseMatrix.fullSeasonArchive.status).toBe('skipped');
+      expect(json.persistenceAssertions.some((a) => a.status === 'skipped')).toBe(true);
+      expect(json.failures).toEqual([]);
+      expect(json.warnings).toHaveLength(1);
+
+      expect(md).toContain('**Profile:** ci');
+      expect(md).toContain('**Phase path:** short');
+      expect(md).toContain('Short real-worker smoke audit. It does not complete a season.');
+      expect(md).toContain('Full-season balance, playoffs, offseason, free agency, draft, and completed-season archive are not validated by CI profile.');
+      expect(md).toContain('GET_ALL_SEASONS, GET_TRANSACTIONS recent, GET_RECORDS, GET_HALL_OF_FAME');
+      expect(md).toContain('| fullSeasonArchive | CI profile does not create a completed-season archive |');
+      expect(md).toContain('**skipped** `latest_season_archive`');
+      expect(md).toContain('npm run audit:dynasty -- --audit-profile=full --seasons=1 --seed=1383');
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
   });
 
   it('slimDynastySoakResultForJson removes finalView', () => {

--- a/tests/unit/dynastySoakRunner.test.js
+++ b/tests/unit/dynastySoakRunner.test.js
@@ -114,6 +114,75 @@ describe('runDynastySoakOnce', () => {
     expect(result.exerciseMatrix.fullSeasonArchive.status).toBe('skipped');
   });
 
+
+  it('fails CI profile when an exercised worker probe reports an error', async () => {
+    const auditModule = await import('../../src/core/dynastySoakAudit.js');
+    auditModule.buildPersistenceAssertions.mockReturnValueOnce({
+      allOk: false,
+      assertions: [
+        {
+          id: 'get_records',
+          ok: false,
+          code: 'get_records_failed',
+          detail: 'GET_RECORDS failed: indexeddb read failed',
+        },
+        {
+          id: 'get_draft_classes',
+          ok: true,
+          status: 'skipped',
+          skipped: true,
+          detail: 'skipped: CI profile does not enter draft, so draft classes are not expected',
+        },
+      ],
+    });
+
+    const bootState = makeState({ phase: 'regular', year: 2026 });
+    const week2State = { ...makeState({ phase: 'regular', year: 2026 }), currentWeek: 2 };
+    const week3State = { ...makeState({ phase: 'regular', year: 2026 }), currentWeek: 3 };
+    let advanceCount = 0;
+    const dispatchWorker = vi.fn(async (type) => {
+      switch (type) {
+        case toWorker.INIT:
+          return { type: toUI.READY, payload: {} };
+        case toWorker.USE_SAFE_STARTER_LEAGUE:
+          return { type: toUI.FULL_STATE, payload: bootState };
+        case toWorker.ADVANCE_WEEK:
+          advanceCount += 1;
+          return { type: toUI.WEEK_COMPLETE, payload: advanceCount === 1 ? week2State : week3State };
+        case toWorker.SAVE_NOW:
+          return { type: toUI.SAVED, payload: {} };
+        case toWorker.GET_ALL_SEASONS:
+          return { type: toUI.ALL_SEASONS, payload: { seasons: [] } };
+        case toWorker.GET_TRANSACTIONS:
+          return { type: toUI.TRANSACTIONS, payload: { transactions: [] } };
+        case toWorker.GET_RECORDS:
+          return { type: toUI.ERROR, payload: { message: 'indexeddb read failed' } };
+        case toWorker.GET_HALL_OF_FAME:
+          return { type: toUI.HALL_OF_FAME, payload: { players: [] } };
+        case toWorker.SIM_TO_PHASE:
+          throw new Error('CI profile must not call SIM_TO_PHASE');
+        default:
+          throw new Error(`Unexpected worker call: ${type}`);
+      }
+    });
+
+    const { runDynastySoakOnce } = await import('../../src/testSupport/dynastySoakRunner.js');
+    const result = await runDynastySoakOnce({
+      auditProfile: 'ci',
+      ci: true,
+      dispatchWorker,
+      loadWorkerModule: vi.fn(async () => {}),
+    });
+
+    expect(result.passed).toBe(false);
+    expect(result.failures).toContainEqual({
+      code: 'persistence_probe_failed',
+      message: 'One or more CI persistence/probe assertions failed; see persistenceAssertions in latest.json',
+    });
+    expect(result.persistenceAssertions.find((a) => a.id === 'get_records').ok).toBe(false);
+    expect(result.persistenceAssertions.find((a) => a.id === 'get_draft_classes').status).toBe('skipped');
+  });
+
   it('uses injected worker hooks for deep final probes without deepEachSeason', async () => {
     const calls = [];
     const bootState = makeState({ phase: 'regular', year: 2026 });


### PR DESCRIPTION
### Motivation
- Ensure the real `audit:dynasty` CLI flow is honest and produces canonical artifacts (`latest.json`/`latest.md`) that clearly label CI vs full profiles and list exercised vs skipped checks. 
- Make the CLI output and report wording unambiguous so CI consumers and auditors can rely on the artifact contents. 
- Add small, targeted tests to verify artifact writing and honest failure behavior without changing gameplay or weakening full-profile behavior.

### Description
- Extracted a canonical artifact writer `writeDynastySoakReports()` and used it from the CLI so tests and the real CLI share the same `latest.json` / `latest.md` write path (`src/testSupport/dynastySoakCli.js`, `scripts/dynasty-soak.mjs`).
- Added a transparent startup warning when `--audit-profile=full` is requested to explain that the full profile uses `SIM_TO_PHASE` and a single worker request may run for a long time before `--max-runtime-ms` is checked (`scripts/dynasty-soak.mjs`).
- Added unit tests that (a) exercise report generation from a realistic CI result fixture and assert presence of `auditProfile`, `phasePath`, `seed`, `runtimeMs`, `finalPhase`/`finalYear`, exercise/skipped matrices, `persistenceAssertions`, failures/warnings, and the full-profile command suggestion (`tests/unit/dynastySoakCli.test.js`), and (b) assert that an exercised CI probe error marks the CI run failed while full-only probes remain explicitly skipped (`tests/unit/dynastySoakRunner.test.js`).
- Wire CLI to call `writeDynastySoakReports()` and keep all changes minimal and focused on reporting and tests; no simulation/gameplay logic was altered.

### Testing
- Verified CLI end-to-end (real worker) and artifact generation: `npm run audit:dynasty -- --ci --seed=1383` completed and wrote `artifacts/dynasty-soak/latest.{json,md}` with `runtimeMs=18281` and `auditProfile: "ci"` (report also contains `phasePath: "short"`, `seed`, `finalPhase: "regular"`, `finalYear: 2026`, `exerciseMatrix`, `skipped` reasons, `persistenceAssertions`, `failures`, and `warnings`).
- Re-ran alias: `npm run audit:dynasty -- --audit-profile=ci --seed=1383` completed (`runtimeMs=18731`) and produced artifacts; `--audit-profile=full --seasons=1 --seed=1383 --max-runtime-ms=30000` was smoke-checked and printed the new full-profile warning but was externally timed out (expected external `124` due to long-running full profile). 
- Automated test suite: `node --check` on CLI/runner/audit helpers passed, targeted unit tests added passed, `npm run test:soak` passed, full `npm run test:unit` (all suites) passed, `npm run build` passed, and `npm run check:deploy` passed; the Playwright E2E smoke test failed in this environment because Playwright Chromium could not be downloaded (proxy 403), so browser-driven E2E was not executed here. 

Follow-up: add a guarded archive checkpoint or further full-season runtime optimizations if/when a practical safe early-checkpoint for the full `SIM_TO_PHASE` flow is introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02888d2180832d8f97301f2f4174d4)