### PR TITLE
Add guarded dynasty audit checkpoint (audit-only Meta checkpoint + CI wiring)

### DIFF
--- a/src/core/dynastySoakAudit.js
+++ b/src/core/dynastySoakAudit.js
@@ -254,6 +254,66 @@ export function buildPersistenceAssertions(input = {}) {
     });
   }
 
+  if (auditProfile === 'ci') {
+    const cp = input.auditCheckpoint ?? null;
+    if (!cp) {
+      assertions.push({
+        id: 'audit_checkpoint_present',
+        ok: false,
+        code: 'audit_checkpoint_missing',
+        detail: 'CI profile did not return an audit checkpoint payload',
+      });
+    } else {
+      assertions.push({
+        id: 'audit_checkpoint_ok',
+        ok: cp.ok === true,
+        code: cp.ok === true ? undefined : 'audit_checkpoint_failed',
+        detail: cp.ok === true ? 'audit checkpoint ok' : `audit checkpoint failed: ${cp.error || JSON.stringify(cp.failures || [])}`,
+      });
+      assertions.push({
+        id: 'audit_checkpoint_metadata',
+        ok: cp.auditOnly === true && cp.archiveType === 'audit_checkpoint' && cp.completedSeason === false,
+        code: cp.auditOnly === true && cp.archiveType === 'audit_checkpoint' && cp.completedSeason === false ? undefined : 'audit_checkpoint_not_guarded',
+        detail: `auditOnly=${cp.auditOnly === true} archiveType=${cp.archiveType ?? 'missing'} completedSeason=${cp.completedSeason === false ? 'false' : String(cp.completedSeason)}`,
+      });
+      assertions.push({
+        id: 'audit_checkpoint_real_weeks',
+        ok: Number(cp.realWeeksSimulated ?? 0) >= 1,
+        code: Number(cp.realWeeksSimulated ?? 0) >= 1 ? undefined : 'audit_checkpoint_exercised_data_missing',
+        detail: `realWeeksSimulated=${cp.realWeeksSimulated ?? 'missing'}`,
+      });
+      const exercised = cp.exercised && typeof cp.exercised === 'object' ? cp.exercised : {};
+      const exercisedEntries = Object.entries(exercised);
+      assertions.push({
+        id: 'audit_checkpoint_exercised_systems',
+        ok: exercisedEntries.length > 0,
+        code: exercisedEntries.length > 0 ? undefined : 'audit_checkpoint_exercised_data_missing',
+        detail: exercisedEntries.length ? `exercised: ${exercisedEntries.map(([name]) => name).join(', ')}` : 'no checkpoint systems marked exercised',
+      });
+      for (const [name, entry] of exercisedEntries) {
+        const failed = entry?.status === 'failed' || entry?.ok === false;
+        assertions.push({
+          id: `audit_checkpoint_probe_${name}`,
+          ok: !failed,
+          code: failed ? 'audit_checkpoint_probe_failed' : undefined,
+          detail: failed ? `${name} failed: ${entry?.detail || entry?.error || 'no detail'}` : `${name}: ${entry?.detail || entry?.status || 'exercised'}`,
+        });
+      }
+      const skipped = Array.isArray(cp.skipped) ? cp.skipped : [];
+      for (const row of skipped) {
+        const reason = String(row?.reason || '').trim();
+        assertions.push({
+          id: `audit_checkpoint_skipped_${row?.system || 'unknown'}`,
+          ok: !!reason,
+          status: 'skipped',
+          skipped: true,
+          code: reason ? undefined : 'audit_checkpoint_skipped_without_reason',
+          detail: reason ? `skipped: ${reason}` : 'skipped: missing reason',
+        });
+      }
+    }
+  }
+
   const hasTx = Array.isArray(input.transactionsRecent) && input.transactionsRecent.length > 0;
   const transactionsRecentProbeOk = input.transactionsRecentProbeOk !== false;
   const transactionsRecentHasExpectedData = input.transactionsRecentHasExpectedData ?? hasTx;

--- a/src/testSupport/dynastySoakCli.js
+++ b/src/testSupport/dynastySoakCli.js
@@ -311,6 +311,44 @@ export function buildMarkdownReport(result) {
     lines.push('');
   }
 
+  if (result.auditCheckpoint) {
+    const cp = result.auditCheckpoint;
+    lines.push('## Audit checkpoint');
+    lines.push('');
+    lines.push(`- **Status:** ${cp.ok === true ? 'ok' : 'FAIL'}`);
+    lines.push(`- **Type:** ${mdEscape(cp.archiveType ?? 'unknown')}`);
+    lines.push(`- **Audit only:** ${cp.auditOnly === true ? 'true' : 'false'}`);
+    lines.push(`- **Completed season:** ${cp.completedSeason === false ? 'false' : mdEscape(String(cp.completedSeason))}`);
+    lines.push(`- **Source:** phase=${mdEscape(cp.sourcePhase ?? 'n/a')} year=${mdEscape(cp.sourceYear ?? 'n/a')} seasonId=${mdEscape(cp.sourceSeasonId ?? 'n/a')}`);
+    lines.push(`- **Real weeks simulated before checkpoint:** ${mdEscape(cp.realWeeksSimulated ?? 'n/a')}`);
+    lines.push('- **Warning:** This checkpoint is audit-only partial-season coverage, not full-season balance validation and not a completed-season archive.');
+    lines.push('- **Full completed-season validation:** `npm run audit:dynasty -- --audit-profile=full --seasons=1 --seed=1383`');
+    lines.push('');
+    const exercised = Object.entries(cp.exercised || {});
+    lines.push('### Checkpoint systems exercised');
+    lines.push('');
+    if (!exercised.length) lines.push('_None_');
+    else {
+      lines.push('| System | Status | Detail |');
+      lines.push('| --- | --- | --- |');
+      for (const [name, entry] of exercised) {
+        lines.push(`| ${mdEscape(name)} | ${mdEscape(entry?.status ?? 'exercised')} | ${mdEscape(entry?.detail || '')} |`);
+      }
+    }
+    lines.push('');
+    lines.push('### Checkpoint systems skipped');
+    lines.push('');
+    if (!Array.isArray(cp.skipped) || cp.skipped.length === 0) lines.push('_None_');
+    else {
+      lines.push('| System | Reason |');
+      lines.push('| --- | --- |');
+      for (const row of cp.skipped) {
+        lines.push(`| ${mdEscape(row?.system ?? 'unknown')} | ${mdEscape(row?.reason || 'missing reason')} |`);
+      }
+    }
+    lines.push('');
+  }
+
   if (result.smallerLeagueNote) {
     lines.push('## League mode');
     lines.push('');

--- a/src/testSupport/dynastySoakRunner.js
+++ b/src/testSupport/dynastySoakRunner.js
@@ -14,6 +14,7 @@ import {
 const RESPONSE_BY_REQUEST = {
   [toWorker.INIT]: [toUI.READY, toUI.ERROR],
   [toWorker.USE_SAFE_STARTER_LEAGUE]: [toUI.FULL_STATE, toUI.ERROR],
+  [toWorker.RUN_DYNASTY_AUDIT_CHECKPOINT]: [toUI.DYNASTY_AUDIT_CHECKPOINT, toUI.ERROR],
   [toWorker.SIM_TO_PHASE]: [toUI.FULL_STATE, toUI.ERROR],
   [toWorker.ADVANCE_WEEK]: [toUI.WEEK_COMPLETE, toUI.ERROR, toUI.FULL_STATE],
   [toWorker.SAVE_NOW]: [toUI.SAVED, toUI.ERROR],
@@ -163,6 +164,7 @@ function buildPhaseBreakdown(checkpoints) {
     let bucket = null;
     if (name.startsWith('boot.')) bucket = groups.boot;
     else if (name.endsWith('.SIM_TO_PHASE')) bucket = groups.sim;
+    else if (name.includes('AUDIT_CHECKPOINT')) bucket = groups.getProbes;
     else if (name.includes('.GET_')) bucket = groups.getProbes;
     else if (name.endsWith('.runDynastySoakAudit')) bucket = groups.auditEvaluation;
     else if (name.endsWith('.ADVANCE_WEEK') || name.includes('.ADVANCE_WEEK.')) bucket = groups.finalAdvance;
@@ -487,6 +489,7 @@ async function runFullDynastySoakOnce(opts = {}) {
   globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__ = true;
   globalThis.__DYNASTY_SOAK_THROTTLE_PERSIST__ = true;
   globalThis.__DYNASTY_SOAK_PROFILE__ = true;
+  globalThis.__DYNASTY_SOAK_AUDIT_CHECKPOINT_ENABLED__ = false;
   globalThis.__DYNASTY_SOAK_LAST_BATCH__ = undefined;
 
   const t0 = Date.now();
@@ -900,6 +903,7 @@ async function runFullDynastySoakOnce(opts = {}) {
     globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__ = false;
     globalThis.__DYNASTY_SOAK_THROTTLE_PERSIST__ = false;
     globalThis.__DYNASTY_SOAK_PROFILE__ = false;
+    globalThis.__DYNASTY_SOAK_AUDIT_CHECKPOINT_ENABLED__ = false;
     globalThis.__DYNASTY_SOAK_LAST_BATCH__ = undefined;
   }
 }
@@ -950,6 +954,7 @@ async function runCiDynastySoakOnce(opts = {}) {
   globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__ = false;
   globalThis.__DYNASTY_SOAK_THROTTLE_PERSIST__ = false;
   globalThis.__DYNASTY_SOAK_PROFILE__ = true;
+  globalThis.__DYNASTY_SOAK_AUDIT_CHECKPOINT_ENABLED__ = true;
   globalThis.__DYNASTY_SOAK_LAST_BATCH__ = undefined;
 
   try {
@@ -1047,6 +1052,38 @@ async function runCiDynastySoakOnce(opts = {}) {
       : { status: 'failed', reason: saveMsg.payload?.message || 'SAVE_NOW failed' };
     checkMaxRuntime(t0, maxRuntimeMs);
 
+    const checkpointMsg = await timedDispatch({
+      checkpoints,
+      name: 'ci.RUN_DYNASTY_AUDIT_CHECKPOINT',
+      runnerDispatch,
+      type: toWorker.RUN_DYNASTY_AUDIT_CHECKPOINT,
+      payload: { realWeeksSimulated: regularWeeksSimmed, auditProfile: 'ci' },
+      timeoutMs: Math.min(180_000, phaseTimeoutMs),
+      meta: { realWeeksSimulated: regularWeeksSimmed },
+    });
+    const auditCheckpoint = checkpointMsg.payload ?? null;
+    aggregate.auditCheckpoint = auditCheckpoint;
+    if (probeHandlerSucceeded(checkpointMsg) && auditCheckpoint?.ok === true && auditCheckpoint?.auditOnly === true && auditCheckpoint?.completedSeason === false) {
+      aggregate.exerciseMatrix.auditCheckpoint = {
+        status: 'exercised_partial',
+        detail: 'audit-only checkpoint persisted metadata and shaped safe partial archive probes',
+        archiveType: auditCheckpoint.archiveType,
+        completedSeason: auditCheckpoint.completedSeason,
+        realWeeksSimulated: auditCheckpoint.realWeeksSimulated,
+      };
+    } else {
+      aggregate.passed = false;
+      aggregate.exerciseMatrix.auditCheckpoint = {
+        status: 'failed',
+        reason: auditCheckpoint?.error || auditCheckpoint?.failures?.map((f) => f?.error || f?.system).join('; ') || 'audit checkpoint failed',
+      };
+      aggregate.failures.push({
+        code: 'audit_checkpoint_failed',
+        message: aggregate.exerciseMatrix.auditCheckpoint.reason,
+      });
+    }
+    checkMaxRuntime(t0, maxRuntimeMs);
+
     const allSeasonsMsg = await timedDispatch({
       checkpoints,
       name: 'ci.GET_ALL_SEASONS',
@@ -1124,6 +1161,7 @@ async function runCiDynastySoakOnce(opts = {}) {
       expectDraftClasses: false,
       draftClassCount: 0,
       saveNowOk,
+      auditCheckpoint,
       skippedProbeReasons,
     });
     aggregate.persistenceAssertions = pers.assertions;
@@ -1144,6 +1182,7 @@ async function runCiDynastySoakOnce(opts = {}) {
     globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__ = false;
     globalThis.__DYNASTY_SOAK_THROTTLE_PERSIST__ = false;
     globalThis.__DYNASTY_SOAK_PROFILE__ = false;
+    globalThis.__DYNASTY_SOAK_AUDIT_CHECKPOINT_ENABLED__ = false;
     globalThis.__DYNASTY_SOAK_LAST_BATCH__ = undefined;
     globalThis.__dynastySoakBroadcast = null;
   }

--- a/src/worker/protocol.js
+++ b/src/worker/protocol.js
@@ -23,6 +23,7 @@ export const toWorker = Object.freeze({
   INIT:               'INIT',
   NEW_LEAGUE:         'NEW_LEAGUE',
   USE_SAFE_STARTER_LEAGUE: 'USE_SAFE_STARTER_LEAGUE',
+  RUN_DYNASTY_AUDIT_CHECKPOINT: 'RUN_DYNASTY_AUDIT_CHECKPOINT', // audit harness only; never used by normal UI
   RELOCATE_TEAM:      'RELOCATE_TEAM',
 
   /** Regular-season flow */
@@ -202,6 +203,7 @@ export const toUI = Object.freeze({
   SEASON_HISTORY:     'SEASON_HISTORY',       // { seasonId, data }
   PLAYER_CAREER:      'PLAYER_CAREER',        // { playerId, data }
   ALL_SEASONS:        'ALL_SEASONS',          // { seasons[] }
+  DYNASTY_AUDIT_CHECKPOINT: 'DYNASTY_AUDIT_CHECKPOINT', // { ok, auditOnly, archiveType, completedSeason, ... }
   GAME_LOG:           'GAME_LOG',             // { games[] }
   ALL_SAVES:          'ALL_SAVES',            // { saves[] }
 

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -3897,6 +3897,179 @@ async function handleSimToPhase({ targetPhase }, id) {
   }
 }
 
+
+// ── Handler: RUN_DYNASTY_AUDIT_CHECKPOINT ───────────────────────────────────
+
+function auditCheckpointEntry(name, status, detail = '', extra = {}) {
+  const entry = { status, detail: String(detail || '') };
+  if (status === 'skipped') entry.reason = String(detail || 'skipped by audit checkpoint');
+  return { name, entry: { ...entry, ...extra } };
+}
+
+async function handleRunDynastyAuditCheckpoint(payload = {}, id) {
+  try {
+    if (!(typeof globalThis !== 'undefined' && globalThis.__DYNASTY_SOAK_AUDIT_CHECKPOINT_ENABLED__ === true)) {
+      post(toUI.DYNASTY_AUDIT_CHECKPOINT, { ok: false, error: 'Dynasty audit checkpoint is only available to the explicit audit harness.' }, id);
+      return;
+    }
+
+    const meta = ensureDynastyMeta(cache.getMeta());
+    if (!cache.isLoaded() || !meta?.currentSeasonId) {
+      post(toUI.DYNASTY_AUDIT_CHECKPOINT, { ok: false, error: 'No league loaded for dynasty audit checkpoint.' }, id);
+      return;
+    }
+
+    const realWeeksSimulated = Math.max(0, Number(payload?.realWeeksSimulated ?? 0) || 0);
+    if (realWeeksSimulated < 1) {
+      post(toUI.DYNASTY_AUDIT_CHECKPOINT, { ok: false, error: 'Dynasty audit checkpoint requires at least one real ADVANCE_WEEK before it can run.' }, id);
+      return;
+    }
+
+    const checkpointId = `audit_checkpoint_${meta.currentSeasonId}_${Date.now()}`;
+    const sourcePhase = String(meta?.phase ?? 'unknown');
+    const sourceYear = Number(meta?.year ?? new Date().getUTCFullYear());
+    const sourceSeasonId = meta?.currentSeasonId ?? null;
+    const exercised = {};
+    const skipped = [];
+    const failures = [];
+
+    const mark = (name, status, detail, extra = {}) => {
+      const { entry } = auditCheckpointEntry(name, status, detail, extra);
+      if (status === 'skipped') skipped.push({ system: name, reason: entry.reason || detail });
+      else exercised[name] = entry;
+    };
+    const failProbe = (name, error) => {
+      const message = error?.message || String(error || 'unknown failure');
+      exercised[name] = { status: 'failed', detail: message };
+      failures.push({ system: name, error: message });
+    };
+
+    try {
+      await flushDirty(true);
+      mark('forcedDirtyFlush', 'exercised', 'flushDirty(true) completed before audit metadata write');
+    } catch (err) {
+      failProbe('forcedDirtyFlush', err);
+    }
+
+    let playerSeasonStatsV1 = null;
+    try {
+      const statsRows = cache.getAllSeasonStats();
+      const teams = cache.getAllTeams();
+      playerSeasonStatsV1 = buildPlayerSeasonStatsArchiveRows(statsRows, {
+        teams,
+        year: sourceYear,
+        seasonId: sourceSeasonId,
+        createdAt: new Date().toISOString(),
+      });
+      if (Array.isArray(playerSeasonStatsV1?.rows) && playerSeasonStatsV1.rows.length > 0) {
+        mark('playerSeasonStatsV1Shape', 'exercised', `${playerSeasonStatsV1.rows.length} current-state stat rows shaped without archiving`, { rowCount: playerSeasonStatsV1.rows.length });
+      } else {
+        skipped.push({ system: 'playerSeasonStatsV1Shape', reason: 'Current partial season has no player stat rows to shape safely.' });
+      }
+    } catch (err) {
+      failProbe('playerSeasonStatsV1Shape', err);
+    }
+
+    try {
+      const txRows = await Transactions.loadRecent(400).catch(() => []);
+      if (Array.isArray(txRows) && txRows.length > 0) {
+        const teams = cache.getAllTeams();
+        const players = cache.getAllPlayers();
+        const ctx = {
+          teams,
+          teamsById: new Map(teams.map((t) => [Number(t.id), t])),
+          players,
+          playersById: new Map(players.map((pl) => [Number(pl.id), pl])),
+          year: sourceYear,
+          phase: sourcePhase,
+        };
+        const normalized = dedupeNormalizedTransactions(txRows.map((tx) => normalizeRawTransaction(tx, ctx)));
+        const compact = compactRowsForArchive(normalized, 32);
+        mark('transactionTimelineV1Shape', 'exercised', `${compact.length} compact transaction rows shaped from ${txRows.length} recent DB rows`, { rowCount: compact.length });
+      } else {
+        skipped.push({ system: 'transactionTimelineV1Shape', reason: 'No DB transactions exist yet in this partial CI run.' });
+      }
+    } catch (err) {
+      failProbe('transactionTimelineV1Shape', err);
+    }
+
+    let seasonsCount = null;
+    try {
+      const seasons = await Seasons.loadRecent(5);
+      seasonsCount = Array.isArray(seasons) ? seasons.length : 0;
+      mark('dbSeasonsRead', 'exercised', `Seasons.loadRecent read ${seasonsCount} completed-season rows without treating checkpoint as a season`, { count: seasonsCount });
+    } catch (err) {
+      failProbe('dbSeasonsRead', err);
+    }
+
+    skipped.push(
+      { system: 'normalLeagueHistoryWrite', reason: 'Audit checkpoint deliberately does not write leagueHistory or completed-season rows.' },
+      { system: 'getSeasonHistoryCompletedSeason', reason: 'Partial CI run has no safe completed-season id for GET_SEASON_HISTORY.' },
+      { system: 'completedSeasonArchive', reason: 'archiveSeason is reserved for completed seasons and is not called by this checkpoint.' },
+    );
+
+    const checkpoint = {
+      id: checkpointId,
+      ok: failures.length === 0,
+      auditOnly: true,
+      archiveType: 'audit_checkpoint',
+      completedSeason: false,
+      sourcePhase,
+      sourceYear,
+      sourceSeasonId,
+      realWeeksSimulated,
+      createdAt: new Date().toISOString(),
+      exercised,
+      skipped,
+      failures,
+      rowCounts: {
+        playerSeasonStatsV1: Array.isArray(playerSeasonStatsV1?.rows) ? playerSeasonStatsV1.rows.length : 0,
+        dbSeasons: seasonsCount,
+      },
+    };
+
+    try {
+      const existing = Array.isArray(meta?.dynastyAuditCheckpoints) ? meta.dynastyAuditCheckpoints : [];
+      const checkpointForSave = {
+        id: checkpoint.id,
+        auditOnly: true,
+        archiveType: checkpoint.archiveType,
+        completedSeason: false,
+        sourcePhase,
+        sourceYear,
+        sourceSeasonId,
+        realWeeksSimulated,
+        createdAt: checkpoint.createdAt,
+        exercised: Object.fromEntries(Object.entries(exercised).map(([k, v]) => [k, { status: v.status, detail: v.detail, rowCount: v.rowCount, count: v.count }])),
+        skipped,
+        failures,
+      };
+      cache.setMeta({ dynastyAuditCheckpoints: [...existing.filter((row) => row?.id !== checkpoint.id), checkpointForSave].slice(-5) });
+      await flushDirty(true);
+      const persisted = await Meta.load();
+      const persistedFound = Array.isArray(persisted?.dynastyAuditCheckpoints)
+        && persisted.dynastyAuditCheckpoints.some((row) => row?.id === checkpoint.id && row?.auditOnly === true && row?.completedSeason === false);
+      if (persistedFound) {
+        checkpoint.exercised.dbAuditCheckpointWriteRead = { status: 'exercised', detail: 'audit-only checkpoint metadata persisted to Meta and read back from IndexedDB' };
+      } else {
+        checkpoint.ok = false;
+        checkpoint.failures.push({ system: 'dbAuditCheckpointWriteRead', error: 'persisted checkpoint metadata was not found on Meta.load()' });
+        checkpoint.exercised.dbAuditCheckpointWriteRead = { status: 'failed', detail: 'persisted checkpoint metadata was not found on Meta.load()' };
+      }
+    } catch (err) {
+      checkpoint.ok = false;
+      failProbe('dbAuditCheckpointWriteRead', err);
+      checkpoint.failures = failures;
+      checkpoint.exercised = exercised;
+    }
+
+    post(toUI.DYNASTY_AUDIT_CHECKPOINT, checkpoint, id);
+  } catch (err) {
+    console.error('[Worker] RUN_DYNASTY_AUDIT_CHECKPOINT failed:', err);
+    post(toUI.DYNASTY_AUDIT_CHECKPOINT, { ok: false, error: err?.message || String(err) }, id);
+  }
+}
+
 // ── Handler: GET_SEASON_HISTORY ───────────────────────────────────────────────
 
 async function handleGetSeasonHistory({ seasonId }, id) {
@@ -10047,6 +10220,7 @@ async function handleMessage(event) {
       case toWorker.DUPLICATE_SAVE:     return await handleDuplicateSave(payload, id);
       case toWorker.NEW_LEAGUE:         return await handleNewLeague(payload, id);
       case toWorker.USE_SAFE_STARTER_LEAGUE: return await handleUseSafeStarterLeague(payload, id);
+      case toWorker.RUN_DYNASTY_AUDIT_CHECKPOINT: return await handleRunDynastyAuditCheckpoint(payload, id);
       case toWorker.ADVANCE_WEEK:       return await handleAdvanceWeek(payload, id);
       case toWorker.SIM_TO_WEEK:        return await handleSimToWeek(payload, id);
       case toWorker.SIM_TO_PLAYOFFS:    return await handleSimToWeek({ targetWeek: 18 }, id);

--- a/tests/unit/dynastySoakCli.test.js
+++ b/tests/unit/dynastySoakCli.test.js
@@ -137,6 +137,18 @@ describe('dynastySoakCli', () => {
       phasePath: 'short',
       profileNotes: ['CI profile runs a short real-worker phase path and does not complete a season.'],
       harnessConfig: { ci: true, auditProfile: 'ci', phasePath: 'short', deep: true, deepEachSeason: false },
+      auditCheckpoint: {
+        ok: true,
+        auditOnly: true,
+        archiveType: 'audit_checkpoint',
+        completedSeason: false,
+        sourcePhase: 'regular',
+        sourceYear: 2026,
+        sourceSeasonId: 's2026',
+        realWeeksSimulated: 2,
+        exercised: { dbAuditCheckpointWriteRead: { status: 'exercised', detail: 'read back from DB' } },
+        skipped: [{ system: 'completedSeasonArchive', reason: 'archiveSeason is not called by checkpoint' }],
+      },
       exerciseMatrix: {
         realWorkerBoot: { status: 'exercised' },
         regularWeeks: { status: 'exercised', count: 2 },
@@ -221,10 +233,23 @@ describe('dynastySoakCli', () => {
         phaseTimeoutMs: 3_600_000,
         maxRuntimeMs: null,
       },
+      auditCheckpoint: {
+        ok: true,
+        auditOnly: true,
+        archiveType: 'audit_checkpoint',
+        completedSeason: false,
+        sourcePhase: 'regular',
+        sourceYear: 2026,
+        sourceSeasonId: 's2026',
+        realWeeksSimulated: 2,
+        exercised: { dbAuditCheckpointWriteRead: { status: 'exercised', detail: 'read back from DB' } },
+        skipped: [{ system: 'completedSeasonArchive', reason: 'archiveSeason is not called by checkpoint' }],
+      },
       exerciseMatrix: {
         realWorkerBoot: { status: 'exercised' },
         safeStarterLeague: { status: 'exercised' },
         regularWeeks: { status: 'exercised', count: 2 },
+        auditCheckpoint: { status: 'exercised_partial', archiveType: 'audit_checkpoint', completedSeason: false, realWeeksSimulated: 2 },
         workerProbes: {
           status: 'exercised_partial',
           detail: 'GET_ALL_SEASONS, GET_TRANSACTIONS recent, GET_RECORDS, GET_HALL_OF_FAME',
@@ -265,6 +290,7 @@ describe('dynastySoakCli', () => {
       expect(json.finalPhase).toBe('regular');
       expect(json.finalYear).toBe(2026);
       expect(json.exerciseMatrix.workerProbes.status).toBe('exercised_partial');
+      expect(json.auditCheckpoint).toMatchObject({ auditOnly: true, completedSeason: false, archiveType: 'audit_checkpoint' });
       expect(json.exerciseMatrix.fullSeasonArchive.status).toBe('skipped');
       expect(json.persistenceAssertions.some((a) => a.status === 'skipped')).toBe(true);
       expect(json.failures).toEqual([]);
@@ -275,6 +301,10 @@ describe('dynastySoakCli', () => {
       expect(md).toContain('Short real-worker smoke audit. It does not complete a season.');
       expect(md).toContain('Full-season balance, playoffs, offseason, free agency, draft, and completed-season archive are not validated by CI profile.');
       expect(md).toContain('GET_ALL_SEASONS, GET_TRANSACTIONS recent, GET_RECORDS, GET_HALL_OF_FAME');
+      expect(md).toContain('## Audit checkpoint');
+      expect(md).toContain('**Audit only:** true');
+      expect(md).toContain('**Completed season:** false');
+      expect(md).toContain('not full-season balance validation');
       expect(md).toContain('| fullSeasonArchive | CI profile does not create a completed-season archive |');
       expect(md).toContain('**skipped** `latest_season_archive`');
       expect(md).toContain('npm run audit:dynasty -- --audit-profile=full --seasons=1 --seed=1383');

--- a/tests/unit/dynastySoakPersistence.test.js
+++ b/tests/unit/dynastySoakPersistence.test.js
@@ -59,6 +59,15 @@ describe('dynasty soak batch dirty accumulator', () => {
       hofProbeOk: true,
       draftClassesProbeSkipped: true,
       saveNowOk: true,
+      auditCheckpoint: {
+        ok: true,
+        auditOnly: true,
+        archiveType: 'audit_checkpoint',
+        completedSeason: false,
+        realWeeksSimulated: 2,
+        exercised: { forcedDirtyFlush: { status: 'exercised', detail: 'ok' } },
+        skipped: [{ system: 'completedSeasonArchive', reason: 'CI profile does not call archiveSeason for partial data' }],
+      },
       skippedProbeReasons: {
         latest_season_archive: 'CI profile does not complete a season',
         get_all_seasons_latest: 'CI profile has no completed archive',
@@ -73,7 +82,28 @@ describe('dynasty soak batch dirty accumulator', () => {
     expect(r.allOk).toBe(true);
     const skipped = r.assertions.filter((a) => a.status === 'skipped');
     expect(skipped.length).toBeGreaterThan(0);
-    expect(skipped.every((a) => a.skipped === true && a.detail.includes('CI profile'))).toBe(true);
+    expect(skipped.every((a) => a.skipped === true && a.detail)).toBe(true);
+  });
+
+
+  it('fails CI checkpoint assertions when a skipped checkpoint subsystem has no reason', () => {
+    const r = buildPersistenceAssertions({
+      auditProfile: 'ci',
+      viewState: { leagueHistory: [] },
+      expectArchive: false,
+      auditCheckpoint: {
+        ok: true,
+        auditOnly: true,
+        archiveType: 'audit_checkpoint',
+        completedSeason: false,
+        realWeeksSimulated: 2,
+        exercised: { forcedDirtyFlush: { status: 'exercised', detail: 'ok' } },
+        skipped: [{ system: 'completedSeasonArchive', reason: '' }],
+      },
+    });
+
+    expect(r.allOk).toBe(false);
+    expect(r.assertions.find((a) => a.code === 'audit_checkpoint_skipped_without_reason')).toBeTruthy();
   });
 
   it('fails CI exercised probes when handlers fail', () => {

--- a/tests/unit/dynastySoakRunner.test.js
+++ b/tests/unit/dynastySoakRunner.test.js
@@ -31,6 +31,26 @@ vi.mock('../../src/core/dynastySoakAudit.js', () => ({
   })),
 }));
 
+
+function makeAuditCheckpoint(realWeeksSimulated = 2) {
+  return {
+    ok: true,
+    auditOnly: true,
+    archiveType: 'audit_checkpoint',
+    completedSeason: false,
+    sourcePhase: 'regular',
+    sourceYear: 2026,
+    realWeeksSimulated,
+    exercised: {
+      forcedDirtyFlush: { status: 'exercised', detail: 'ok' },
+      dbAuditCheckpointWriteRead: { status: 'exercised', detail: 'ok' },
+    },
+    skipped: [
+      { system: 'completedSeasonArchive', reason: 'archiveSeason is not called for partial CI runs' },
+    ],
+  };
+}
+
 function makeState({ phase, year }) {
   return {
     phase,
@@ -72,6 +92,8 @@ describe('runDynastySoakOnce', () => {
         }
         case toWorker.SAVE_NOW:
           return { type: toUI.SAVED, payload: {} };
+        case toWorker.RUN_DYNASTY_AUDIT_CHECKPOINT:
+          return { type: toUI.DYNASTY_AUDIT_CHECKPOINT, payload: makeAuditCheckpoint(payload.realWeeksSimulated) };
         case toWorker.GET_ALL_SEASONS:
           return { type: toUI.ALL_SEASONS, payload: { seasons: [] } };
         case toWorker.GET_TRANSACTIONS:
@@ -103,6 +125,7 @@ describe('runDynastySoakOnce', () => {
     expect(calls.map((c) => c.type)).toContain(toWorker.USE_SAFE_STARTER_LEAGUE);
     expect(calls.filter((c) => c.type === toWorker.ADVANCE_WEEK)).toHaveLength(3);
     expect(calls.some((c) => c.type === toWorker.SIM_TO_PHASE)).toBe(false);
+    expect(calls.some((c) => c.type === toWorker.RUN_DYNASTY_AUDIT_CHECKPOINT)).toBe(true);
     expect(result.auditProfile).toBe('ci');
     expect(result.phasePath).toBe('short');
     expect(result.seasonsSimmed).toBe(1); // mocked pure audit return; report still labels CI as short path
@@ -112,6 +135,8 @@ describe('runDynastySoakOnce', () => {
     expect(result.exerciseMatrix.offseason.status).toBe('skipped');
     expect(result.exerciseMatrix.draft.status).toBe('skipped');
     expect(result.exerciseMatrix.fullSeasonArchive.status).toBe('skipped');
+    expect(result.exerciseMatrix.auditCheckpoint.status).toBe('exercised_partial');
+    expect(result.auditCheckpoint).toMatchObject({ auditOnly: true, completedSeason: false, archiveType: 'audit_checkpoint' });
   });
 
 
@@ -140,7 +165,7 @@ describe('runDynastySoakOnce', () => {
     const week2State = { ...makeState({ phase: 'regular', year: 2026 }), currentWeek: 2 };
     const week3State = { ...makeState({ phase: 'regular', year: 2026 }), currentWeek: 3 };
     let advanceCount = 0;
-    const dispatchWorker = vi.fn(async (type) => {
+    const dispatchWorker = vi.fn(async (type, payload = {}) => {
       switch (type) {
         case toWorker.INIT:
           return { type: toUI.READY, payload: {} };
@@ -151,6 +176,8 @@ describe('runDynastySoakOnce', () => {
           return { type: toUI.WEEK_COMPLETE, payload: advanceCount === 1 ? week2State : week3State };
         case toWorker.SAVE_NOW:
           return { type: toUI.SAVED, payload: {} };
+        case toWorker.RUN_DYNASTY_AUDIT_CHECKPOINT:
+          return { type: toUI.DYNASTY_AUDIT_CHECKPOINT, payload: makeAuditCheckpoint(payload.realWeeksSimulated) };
         case toWorker.GET_ALL_SEASONS:
           return { type: toUI.ALL_SEASONS, payload: { seasons: [] } };
         case toWorker.GET_TRANSACTIONS:
@@ -277,10 +304,49 @@ describe('runDynastySoakOnce', () => {
       { type: toWorker.GET_DRAFT_CLASS, payload: { seasonId: 's2025' } },
     ]);
 
-    expect(result.persistenceAssertions.map((assertion) => assertion.id)).toEqual([
+    expect(result.persistenceAssertions.map((assertion) => assertion.id)).toEqual(expect.arrayContaining([
       'deep_archive_history_sample',
       'deep_draft_class_model_sample',
-    ]);
+    ]));
+  });
+
+
+  it('fails CI profile when the audit checkpoint returns ok false', async () => {
+    const bootState = makeState({ phase: 'regular', year: 2026 });
+    const week2State = { ...makeState({ phase: 'regular', year: 2026 }), currentWeek: 2 };
+    let advanceCount = 0;
+    const dispatchWorker = vi.fn(async (type) => {
+      switch (type) {
+        case toWorker.INIT:
+          return { type: toUI.READY, payload: {} };
+        case toWorker.USE_SAFE_STARTER_LEAGUE:
+          return { type: toUI.FULL_STATE, payload: bootState };
+        case toWorker.ADVANCE_WEEK:
+          advanceCount += 1;
+          return { type: toUI.WEEK_COMPLETE, payload: week2State };
+        case toWorker.SAVE_NOW:
+          return { type: toUI.SAVED, payload: {} };
+        case toWorker.RUN_DYNASTY_AUDIT_CHECKPOINT:
+          return { type: toUI.DYNASTY_AUDIT_CHECKPOINT, payload: { ok: false, error: 'guard failed' } };
+        case toWorker.GET_ALL_SEASONS:
+          return { type: toUI.ALL_SEASONS, payload: { seasons: [] } };
+        case toWorker.GET_TRANSACTIONS:
+          return { type: toUI.TRANSACTIONS, payload: { transactions: [] } };
+        case toWorker.GET_RECORDS:
+          return { type: toUI.RECORDS, payload: { recordBook: {} } };
+        case toWorker.GET_HALL_OF_FAME:
+          return { type: toUI.HALL_OF_FAME, payload: { players: [] } };
+        default:
+          throw new Error(`Unexpected worker call: ${type}`);
+      }
+    });
+
+    const { runDynastySoakOnce } = await import('../../src/testSupport/dynastySoakRunner.js');
+    const result = await runDynastySoakOnce({ auditProfile: 'ci', ci: true, dispatchWorker, loadWorkerModule: vi.fn(async () => {}) });
+
+    expect(result.passed).toBe(false);
+    expect(result.exerciseMatrix.auditCheckpoint.status).toBe('failed');
+    expect(result.failures.some((f) => f.code === 'audit_checkpoint_failed')).toBe(true);
   });
 
 });


### PR DESCRIPTION
### Motivation

- Provide a guarded, audit-only checkpoint so the fast CI audit can exercise archive/persistence/history logic without creating fake completed-season history or calling `archiveSeason` on partial runs.
- Avoid polluting user-visible `leagueHistory`/`Seasons` or producing a fake champion while increasing persistence and archive coverage in CI profile.
- Keep full-profile behavior and strict full-season archive expectations unchanged while enabling CI to validate safe, non-destructive probes.

### Description

- Chosen design: Option A — a dedicated audit-only checkpoint persisted to league Meta under `dynastyAuditCheckpoints`, never written to `leagueHistory` or `Seasons`, and explicitly labeled `auditOnly: true` / `archiveType: 'audit_checkpoint'` / `completedSeason: false` (safe non-production artifact). Files touched: `src/worker/worker.js`, `src/worker/protocol.js`, `src/testSupport/dynastySoakRunner.js`, `src/core/dynastySoakAudit.js`, `src/testSupport/dynastySoakCli.js`, plus unit test updates.
- Added worker protocol + handler: `RUN_DYNASTY_AUDIT_CHECKPOINT` (toWorker) and `DYNASTY_AUDIT_CHECKPOINT` (toUI); handler enforces guards: only runs when harness enables `__DYNASTY_SOAK_AUDIT_CHECKPOINT_ENABLED__`, a league is loaded, and at least one real `ADVANCE_WEEK` has occurred. The handler rejects with `{ ok: false, error: "..." }` if guards fail.
- Checkpoint metadata shape includes clear audit flags and provenance: `ok`, `auditOnly`, `archiveType`, `completedSeason`, `sourcePhase`, `sourceYear`, `sourceSeasonId`, `realWeeksSimulated`, `createdAt`, `exercised`, `skipped`, `failures`, and `rowCounts`.
- CI wiring: `runCiDynastySoakOnce` now dispatches the guarded checkpoint after `SAVE_NOW` and regular-week advances; the harness toggles the audit checkpoint guard on for CI and ensures full profile leaves guard off.
- Audit probes exercised safely: forced `flushDirty(true)`, DB read of recent `Seasons`, shaping current-state `playerSeasonStatsV1` (dry-run shape, not persisted as a completed season), transaction timeline normalization/compact when DB rows exist, Meta write/read verification for the audit-only checkpoint, and existing worker probes (`GET_ALL_SEASONS`, `GET_TRANSACTIONS recent`, `GET_RECORDS`, `GET_HALL_OF_FAME`).
- Explicitly skipped (with reasons) unsafe systems: normal `leagueHistory`/completed-season writes, `GET_SEASON_HISTORY` for a completed season, `archiveSeason` and any code that would create a completed-season archive or champion from a partial run.
- Reporting: CLI/report output (`latest.json` + `latest.md`) extended to include `auditCheckpoint` section and human-readable Markdown section warning that checkpoint is partial and not full-season balance validation.

### Testing

- Unit/integration: ran targeted unit suites and integration checks; `npm run test:unit` and `npm run test:soak` passed locally (Vitest: 182 files / 780 tests across project); added/updated tests covering checkpoint dispatch, guard rejection, persistence assertions, skipped-reason enforcement, and report generation — all new/updated tests passed.
- Local CI audit smoke: `npm run audit:dynasty -- --ci --seed=1383` and `npm run audit:dynasty -- --audit-profile=ci --seed=1383` completed successfully (~17s and ~16.9s respectively) and produced artifacts in `artifacts/dynasty-soak/latest.json` + `latest.md` containing the checkpoint metadata; `latest.json` includes `auditCheckpoint` fields described above.
- Full-profile attempt: `--audit-profile=full --seasons=1 --max-runtime-ms=30000` was exercised but the long-running `SIM_TO_PHASE` work may exceed runtime limits; this run was observed and is expected to remain manual/long-running (no change to full-profile behavior).
- E2E / Playwright: `tests/e2e/fresh_franchise_first_week_smoke.spec.js` failed in this environment because Playwright Chromium could not be downloaded due to network/proxy restrictions (download returned HTTP 403 from cdn.playwright.dev); Playwright browser install is blocked by the environment and is listed as a skipped external prerequisite.

Notes and follow-ups

- No normal `leagueHistory` or `Seasons` completed-season rows are written by the checkpoint; normal UI history remains protected.
- The checkpoint intentionally does not validate full-season-only systems (playoffs, draft, completed-season archives); full-profile remains the authoritative path for those checks.
- If CI later provides a longer/transaction-rich short-path, the transaction timeline probe will exercise more rows; currently the checkpoint skips that probe with an explicit reason when no transactions are present.
- Playwright E2E in CI requires `npx playwright install --with-deps chromium` and an environment that allows the browser binary download (proxy/cdn access).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0297032c1c832db4c53ec8e6dedc18)