### PR TITLE
Add Contract/Cap Realism V1

### DIFF
--- a/src/core/__tests__/aiFreeAgencyOffers.test.js
+++ b/src/core/__tests__/aiFreeAgencyOffers.test.js
@@ -105,7 +105,8 @@ describe('AiLogic.makeFreeAgencyOffers stale contract handling', () => {
         offers: expect.arrayContaining([
           expect.objectContaining({
             teamId: 1,
-            contract: expect.objectContaining({ baseAnnual: 4 }),
+            contract: expect.objectContaining({ baseAnnual: 4.3, yearsTotal: 1 }),
+            contractModel: expect.objectContaining({ marketTier: 'aging veteran' }),
           }),
         ]),
       }),
@@ -248,7 +249,8 @@ describe('AiLogic.makeFreeAgencyOffers stale contract handling', () => {
         offers: expect.arrayContaining([
           expect.objectContaining({
             teamId: 1,
-            contract: expect.objectContaining({ baseAnnual: 5, yearsTotal: 2 }),
+            contract: expect.objectContaining({ baseAnnual: 5.4, yearsTotal: 1 }),
+            contractModel: expect.objectContaining({ capFit: expect.any(String) }),
           }),
         ]),
       }),
@@ -267,7 +269,7 @@ describe('AiLogic.makeFreeAgencyOffers stale contract handling', () => {
       expect.objectContaining({
         teamId: 1,
         status: 'active',
-        contract: expect.objectContaining({ baseAnnual: 5, yearsTotal: 2 }),
+        contract: expect.objectContaining({ baseAnnual: 5.4, yearsTotal: 1 }),
         offers: [],
       }),
     );

--- a/src/core/__tests__/contractModel.test.js
+++ b/src/core/__tests__/contractModel.test.js
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { buildContractFromMarket, evaluateContractMarket } from '../contractModel.js';
+
+const ctx = (overrides = {}) => ({
+  teamArchetype: 'middle',
+  capHealth: 65,
+  teamCapRoom: 60,
+  positionalNeed: 1.2,
+  ...overrides,
+});
+
+describe('Contract/Cap Realism V1 contract model', () => {
+  it('prices an elite QB as a premium longer-term contract', () => {
+    const out = evaluateContractMarket({ pos: 'QB', ovr: 92, potential: 94, age: 27 }, ctx({ teamArchetype: 'contender', positionalNeed: 1.6, teamCapRoom: 120, capHealth: 80 }));
+    expect(out.marketTier).toBe('elite starter');
+    expect(out.premiumPosition).toBe(true);
+    expect(out.suggestedAnnual).toBeGreaterThan(45);
+    expect(out.suggestedYears).toBeGreaterThanOrEqual(5);
+    expect(out.shouldPursue).toBe(true);
+  });
+
+  it('keeps an older RB short and cheaper with decline risk', () => {
+    const out = evaluateContractMarket({ pos: 'RB', ovr: 82, potential: 82, age: 31 }, ctx({ positionalNeed: 1.4 }));
+    expect(out.marketTier).toBe('aging veteran');
+    expect(out.suggestedYears).toBe(1);
+    expect(out.suggestedAnnual).toBeLessThan(8);
+    expect(out.riskTags).toContain('aging RB decline risk');
+  });
+
+  it('flags old expensive non-QB veterans as risky for rebuilds', () => {
+    const out = evaluateContractMarket({ pos: 'WR', ovr: 88, potential: 88, age: 32 }, ctx({ teamArchetype: 'rebuild', positionalNeed: 1.5, teamCapRoom: 35, capHealth: 45 }));
+    expect(out.riskTags).toContain('age/decline risk');
+    expect(out.shouldAvoid).toBe(true);
+  });
+
+  it('gives young high-potential players upside value and modest term', () => {
+    const out = evaluateContractMarket({ pos: 'CB', ovr: 75, potential: 86, age: 23 }, ctx({ teamArchetype: 'development', positionalNeed: 1.5 }));
+    expect(['bridge starter', 'prospect upside']).toContain(out.marketTier);
+    expect(out.suggestedYears).toBeGreaterThanOrEqual(2);
+    expect(out.reasons.join(' ')).toMatch(/upside/i);
+  });
+
+  it('keeps low OVR depth players on low short offers', () => {
+    const out = evaluateContractMarket({ pos: 'LB', ovr: 60, potential: 62, age: 27 }, ctx());
+    expect(out.marketTier).toBe('replacement level');
+    expect(out.suggestedYears).toBe(1);
+    expect(out.suggestedAnnual).toBeLessThanOrEqual(1.5);
+  });
+
+  it('values premium positions above low-premium positions at similar OVR', () => {
+    const edge = evaluateContractMarket({ pos: 'DE', ovr: 80, potential: 82, age: 26 }, ctx());
+    const safety = evaluateContractMarket({ pos: 'S', ovr: 80, potential: 82, age: 26 }, ctx());
+    expect(edge.suggestedAnnual).toBeGreaterThan(safety.suggestedAnnual);
+    expect(edge.premiumPosition).toBe(true);
+    expect(safety.lowPremiumPosition).toBe(true);
+  });
+
+  it('cap-stressed context lowers safe cap fit', () => {
+    const stressed = evaluateContractMarket({ pos: 'WR', ovr: 84, potential: 85, age: 27 }, ctx({ teamCapRoom: 12, capHealth: 20, positionalNeed: 1.1 }));
+    const healthy = evaluateContractMarket({ pos: 'WR', ovr: 84, potential: 85, age: 27 }, ctx({ teamCapRoom: 60, capHealth: 80, positionalNeed: 1.1 }));
+    expect(stressed.suggestedAnnual).toBeLessThan(healthy.suggestedAnnual);
+    expect(stressed.exceedsSafeCapBand).toBe(true);
+    expect(stressed.shouldAvoid).toBe(true);
+  });
+
+  it('lets contenders tolerate more short-term spend than rebuilds', () => {
+    const player = { pos: 'CB', ovr: 86, potential: 86, age: 32 };
+    const contender = evaluateContractMarket(player, ctx({ teamArchetype: 'contender', teamCapRoom: 25, capHealth: 55, positionalNeed: 1.8 }));
+    const rebuild = evaluateContractMarket(player, ctx({ teamArchetype: 'rebuild', teamCapRoom: 25, capHealth: 55, positionalNeed: 1.8 }));
+    expect(contender.shouldPursue).toBe(true);
+    expect(rebuild.shouldAvoid).toBe(true);
+    expect(contender.suggestedAnnual).toBeGreaterThan(rebuild.suggestedAnnual);
+  });
+
+  it('builds a compatible flat contract shape from the model output', () => {
+    const market = evaluateContractMarket({ pos: 'TE', ovr: 74, potential: 78, age: 25 }, ctx());
+    const contract = buildContractFromMarket(market, { startYear: 2030 });
+    expect(contract).toMatchObject({ years: market.suggestedYears, yearsTotal: market.suggestedYears, startYear: 2030 });
+    expect(contract.baseAnnual).toBe(market.suggestedAnnual);
+  });
+});

--- a/src/core/ai-logic.js
+++ b/src/core/ai-logic.js
@@ -17,6 +17,7 @@ import { getTeamContextForNegotiation } from './teamContext/negotiationContext.j
 import { evaluateContractOffer } from './contracts/negotiation.js';
 import { evaluateReSigningPriority } from './retention/reSigning.js';
 import { buildFreeAgencyMarketAnalysis } from './freeAgency/freeAgencyMarketAnalysis.js';
+import { buildContractFromMarket, evaluateContractMarket } from './contractModel.js';
 
 class AiLogic {
     static NEED_GROUP_TO_POS = Object.freeze({
@@ -497,17 +498,42 @@ class AiLogic {
                 // Check if we already have an active offer out to this player
                 if (fa.offers && fa.offers.find(o => o.teamId === teamId)) continue;
 
-                // Calculate Ask / Offer
+                // Calculate Ask / Offer through the V1 contract model.
                 const demand = demandByPlayerId.get(fa.id) ?? calculateExtensionDemand(fa);
                 if (!demand) continue;
+                const market = evaluateContractMarket(fa, {
+                    team,
+                    strategy,
+                    teamArchetype: strategy?.archetype,
+                    capHealth: strategy?.capHealth,
+                    teamCapRoom: team.capRoom,
+                    positionalNeed: needs[pos] ?? 1,
+                });
+                const marketRiskTags = Array.isArray(market.riskTags) ? market.riskTags : [];
                 const age = Number(fa?.age ?? 27);
                 const isVeteran = age >= 30;
-                const isExpensive = Number(demand?.baseAnnual ?? 0) >= 14;
-                const avoidVeteranSpend = (['rebuild', 'development'].includes(strategy?.archetype) && isVeteran && isExpensive)
-                    || (strategy?.archetype === 'retool' && age >= 31 && isExpensive);
-                if (avoidVeteranSpend) continue;
+                const demandAnnual = Number(demand?.baseAnnual ?? market.suggestedAnnual ?? 0);
+                const modelAnnualForRisk = Number(market?.annualCapHit ?? market?.suggestedAnnual ?? demandAnnual);
+                const oldExpensiveNonQb = isVeteran && fa.pos !== 'QB' && modelAnnualForRisk >= 10;
+                const oldExpensiveQbRebuild = fa.pos === 'QB' && age >= 33 && demandAnnual >= 14 && ['rebuild', 'development'].includes(strategy?.archetype);
+                if ((['rebuild', 'development'].includes(strategy?.archetype) && oldExpensiveNonQb) || oldExpensiveQbRebuild) continue;
+                if (strategy?.archetype === 'retool' && age >= 31 && oldExpensiveNonQb) continue;
+                if (marketRiskTags.includes('long veteran commitment') && ['rebuild', 'development', 'retool'].includes(strategy?.archetype)) continue;
 
-                const capHit = demand.baseAnnual + (demand.signingBonus / demand.yearsTotal);
+                const demandYears = Math.max(1, Number(demand?.yearsTotal ?? demand?.years ?? market.suggestedYears ?? 1));
+                const modelAnnual = Number(market.suggestedAnnual ?? demandAnnual);
+                const baseAnnual = Math.round(Math.min(modelAnnual, demandAnnual * 1.08) * 10) / 10;
+                const years = Math.max(1, Math.min(Number(market.suggestedYears ?? demandYears), demandYears));
+                const bonusRatio = demandAnnual > 0 ? Math.min(0.22, Number(demand?.signingBonus ?? 0) / Math.max(1, demandAnnual * demandYears)) : 0;
+                const offerContract = buildContractFromMarket({
+                    ...market,
+                    suggestedAnnual: baseAnnual,
+                    suggestedYears: years,
+                    signingBonus: Math.round(baseAnnual * years * bonusRatio * 10) / 10,
+                }, { startYear: cache.getMeta().year });
+                offerContract.years = offerContract.yearsTotal;
+
+                const capHit = offerContract.baseAnnual + (offerContract.signingBonus / offerContract.yearsTotal);
                 const capHealth = Number(strategy?.capHealth ?? 55);
                 let capLimit = strategy?.archetype === 'contender'
                     ? 0.74
@@ -521,7 +547,7 @@ class AiLogic {
                 const maxAllowedHit = Math.max(3, Number(team.capRoom ?? 0) * capLimit);
                 const qbDesperate = pos === 'QB' && Number(needs.QB ?? 0) >= 1.12;
                 if (!urgentPos && capHit > maxAllowedHit) {
-                    const qbException = qbDesperate && capHit <= maxAllowedHit * 1.28 && capHealth >= 18;
+                    const qbException = qbDesperate && market.controlledException && capHit <= maxAllowedHit * 1.28 && capHealth >= 18;
                     if (!qbException) continue;
                 }
 
@@ -531,9 +557,12 @@ class AiLogic {
                     const offer = {
                         teamId,
                         teamName: team.name, // Snapshot name
-                        contract: {
-                            ...demand,
-                            startYear: cache.getMeta().year
+                        contract: offerContract,
+                        contractModel: {
+                            marketTier: market.marketTier,
+                            capFit: market.capFit,
+                            riskTags: market.riskTags,
+                            reasons: market.reasons,
                         },
                         timestamp: Date.now()
                     };

--- a/src/core/contractModel.js
+++ b/src/core/contractModel.js
@@ -1,0 +1,209 @@
+import { Constants } from './constants.js';
+
+const round1 = (v) => Math.round(Number(v || 0) * 10) / 10;
+const clamp = (v, min, max) => Math.max(min, Math.min(max, Number(v)));
+const num = (v, fb = 0) => (Number.isFinite(Number(v)) ? Number(v) : fb);
+
+const PREMIUM_POSITIONS = new Set(['QB', 'DE', 'EDGE', 'DL', 'OL', 'OT', 'T', 'WR', 'CB']);
+const LOW_PREMIUM_POSITIONS = new Set(['RB', 'LB', 'MLB', 'OLB', 'S', 'SS', 'FS', 'K', 'P']);
+
+const POSITION_MULTIPLIER = Object.freeze({
+  QB: 1.75,
+  DE: 1.22,
+  EDGE: 1.22,
+  DL: 1.16,
+  OT: 1.16,
+  T: 1.16,
+  OL: 1.12,
+  WR: 1.14,
+  CB: 1.12,
+  TE: 0.92,
+  RB: 0.78,
+  LB: 0.86,
+  MLB: 0.86,
+  OLB: 0.9,
+  S: 0.84,
+  SS: 0.84,
+  FS: 0.84,
+  K: 0.34,
+  P: 0.34,
+});
+
+const ARCHETYPE_AGGRESSION = Object.freeze({
+  contender: { annual: 1.06, years: 0, risk: 1.16, capBand: 0.7 },
+  playoff_hunt: { annual: 1.02, years: 0, risk: 1.0, capBand: 0.62 },
+  middle: { annual: 0.98, years: 0, risk: 0.86, capBand: 0.54 },
+  retool: { annual: 0.94, years: -1, risk: 0.68, capBand: 0.48 },
+  rebuild: { annual: 0.9, years: -1, risk: 0.48, capBand: 0.42 },
+  development: { annual: 0.88, years: -1, risk: 0.46, capBand: 0.4 },
+});
+
+function classifyMarketTier({ ovr, potential, age, pos }) {
+  if (age >= 30 && (pos === 'RB' || ovr < 86)) return 'aging veteran';
+  if (ovr >= 88 || (pos === 'QB' && ovr >= 84)) return 'elite starter';
+  if (ovr >= 80) return 'quality starter';
+  if (ovr >= 73) return 'bridge starter';
+  if (age <= 24 && potential >= ovr + 6 && ovr >= 66) return 'prospect upside';
+  if (ovr >= 64) return 'rotation / depth';
+  return 'replacement level';
+}
+
+function baseAnnualByTier(tier, ovr) {
+  const over = Math.max(0, ovr - 60);
+  if (tier === 'elite starter') return 18 + Math.max(0, ovr - 84) * 2.3;
+  if (tier === 'quality starter') return 10.5 + Math.max(0, ovr - 80) * 1.25;
+  if (tier === 'bridge starter') return 5.2 + Math.max(0, ovr - 73) * 0.85;
+  if (tier === 'prospect upside') return 3.2 + Math.max(0, ovr - 66) * 0.45;
+  if (tier === 'aging veteran') return 4.8 + Math.max(0, ovr - 72) * 0.7;
+  if (tier === 'rotation / depth') return 1.8 + Math.max(0, over - 4) * 0.22;
+  return 0.75 + Math.max(0, ovr - 55) * 0.08;
+}
+
+function ageAnnualMultiplier(pos, age, ovr) {
+  if (pos === 'QB') {
+    if (age >= 36) return 0.82;
+    if (age >= 33) return 0.92;
+    if (age <= 25 && ovr >= 74) return 1.08;
+    return 1;
+  }
+  if (pos === 'RB') {
+    if (age >= 31) return 0.56;
+    if (age >= 29) return 0.68;
+    if (age >= 27) return 0.84;
+    if (age <= 24) return 1.05;
+    return 1;
+  }
+  if (age >= 34) return 0.64;
+  if (age >= 32) return 0.78;
+  if (age >= 30) return 0.9;
+  if (age <= 25 && ovr >= 74) return 1.06;
+  return 1;
+}
+
+function chooseYears({ tier, pos, age, potential, ovr, archetype }) {
+  let years = 1;
+  if (tier === 'elite starter') years = pos === 'QB' ? 5 : 4;
+  else if (tier === 'quality starter') years = age <= 27 ? 4 : 3;
+  else if (tier === 'bridge starter') years = age <= 28 ? 3 : 2;
+  else if (tier === 'prospect upside') years = 3;
+  else if (tier === 'rotation / depth') years = age <= 25 && potential > ovr + 5 ? 2 : 1;
+
+  if (pos === 'RB' && age >= 27) years = Math.min(years, age >= 30 ? 1 : 2);
+  else if (pos !== 'QB' && age >= 31) years = Math.min(years, 2);
+  else if (pos === 'QB' && age >= 34) years = Math.min(years, 2);
+
+  const adj = ARCHETYPE_AGGRESSION[archetype]?.years ?? 0;
+  years += adj;
+
+  if (['rebuild', 'development', 'retool'].includes(archetype) && age >= 30) years = Math.min(years, 1);
+  if (['contender', 'playoff_hunt'].includes(archetype) && age >= 30 && ovr >= 76) years = Math.max(years, 1);
+
+  return Math.round(clamp(years, 1, 6));
+}
+
+export function getPremiumPositionInfo(pos) {
+  const normalized = String(pos ?? '').toUpperCase();
+  return {
+    pos: normalized,
+    isPremium: PREMIUM_POSITIONS.has(normalized),
+    isLowPremium: LOW_PREMIUM_POSITIONS.has(normalized),
+    multiplier: POSITION_MULTIPLIER[normalized] ?? 1,
+  };
+}
+
+export function evaluateContractMarket(player = {}, context = {}) {
+  const pos = String(player?.pos ?? 'UNK').toUpperCase();
+  const ovr = clamp(num(player?.ovr, 60), 35, 99);
+  const potential = clamp(num(player?.potential, ovr), 35, 99);
+  const age = clamp(num(player?.age, 27), 18, 45);
+  const archetype = context?.teamArchetype ?? context?.strategy?.archetype ?? 'middle';
+  const capRoom = num(context?.teamCapRoom ?? context?.capRoom ?? context?.team?.capRoom, 999);
+  const capHealth = clamp(num(context?.capHealth ?? context?.strategy?.capHealth, capRoom >= 20 ? 65 : 35), 0, 100);
+  const needMultiplier = clamp(num(context?.positionalNeed ?? context?.needMultiplier, 1), 0.5, 2.2);
+  const severeNeed = needMultiplier >= 1.7;
+  const premium = getPremiumPositionInfo(pos);
+  const tier = classifyMarketTier({ ovr, potential, age, pos });
+  const arch = ARCHETYPE_AGGRESSION[archetype] ?? ARCHETYPE_AGGRESSION.middle;
+
+  const upsideDelta = Math.max(0, potential - ovr);
+  let annual = baseAnnualByTier(tier, ovr);
+  annual *= premium.multiplier;
+  annual *= ageAnnualMultiplier(pos, age, ovr);
+  annual *= 1 + Math.min(0.16, upsideDelta * (age <= 25 ? 0.022 : 0.008));
+  annual *= 0.94 + Math.min(0.16, Math.max(0, needMultiplier - 1) * 0.16);
+  annual *= arch.annual;
+
+  if (capHealth < 25) annual *= 0.84;
+  else if (capHealth < 40) annual *= 0.92;
+  else if (capHealth >= 72 && ['contender', 'playoff_hunt'].includes(archetype)) annual *= 1.04;
+
+  if (['rebuild', 'development'].includes(archetype) && age >= 30 && pos !== 'QB') annual *= 0.78;
+  if (['contender', 'playoff_hunt'].includes(archetype) && age >= 30 && severeNeed) annual *= 1.04;
+
+  annual = round1(clamp(annual, Constants.SALARY_CAP.MIN_CONTRACT, Constants.SALARY_CAP.MAX_CONTRACT));
+  const years = chooseYears({ tier, pos, age, potential, ovr, archetype });
+  const signingBonusPct = tier === 'elite starter' ? 0.18 : tier === 'quality starter' ? 0.14 : tier === 'bridge starter' ? 0.1 : 0.06;
+  const signingBonus = round1(annual * years * signingBonusPct);
+  const annualCapHit = round1(annual + signingBonus / Math.max(1, years));
+  const safeCapBand = Math.max(2.5, capRoom * arch.capBand * (capHealth < 30 ? 0.72 : capHealth < 45 ? 0.88 : 1));
+  const exceedsSafeCapBand = annualCapHit > safeCapBand;
+  const hardCapAffordable = annualCapHit <= capRoom - 0.5;
+
+  const riskTags = [];
+  if (age >= 30) riskTags.push(pos === 'RB' ? 'aging RB decline risk' : 'age/decline risk');
+  if (annualCapHit >= Math.max(10, capRoom * 0.5)) riskTags.push('large cap share');
+  if (years >= 4 && age >= 29) riskTags.push('long veteran commitment');
+  if (premium.isLowPremium && annual >= 10) riskTags.push('low-premium spend');
+  if (exceedsSafeCapBand) riskTags.push('outside safe cap band');
+
+  const reasons = [
+    `${tier} based on ${ovr} OVR${potential > ovr ? ` / ${potential} POT` : ''}.`,
+    premium.isPremium ? `${pos} receives premium-position weighting.` : premium.isLowPremium ? `${pos} is treated as a lower-premium market.` : `${pos} uses neutral positional weighting.`,
+    age >= 30 ? `Age ${age} keeps term conservative.` : age <= 25 && potential > ovr ? `Age ${age} with upside supports added term/value.` : `Age ${age} supports normal term.`,
+    capHealth < 40 ? `Cap health ${capHealth} tightens the offer band.` : `Cap health ${capHealth} leaves normal offer room.`,
+  ];
+  if (needMultiplier >= 1.2) reasons.push(`Team need multiplier ${needMultiplier.toFixed(2)} improves fit.`);
+  if (['rebuild', 'development'].includes(archetype)) reasons.push('Rebuild/development plan values youth and cap flexibility.');
+  if (archetype === 'contender') reasons.push('Contender plan can tolerate more short-term spend.');
+
+  const oldExpensiveVeteran = age >= 30 && annualCapHit >= 10 && pos !== 'QB';
+  const controlledQbException = pos === 'QB' && severeNeed && annualCapHit <= Math.max(safeCapBand * 1.28, capRoom - 1) && capHealth >= 18;
+  const avoid = !hardCapAffordable
+    || (exceedsSafeCapBand && !controlledQbException && !(archetype === 'contender' && severeNeed && age < 34 && years <= 2))
+    || (['rebuild', 'development'].includes(archetype) && oldExpensiveVeteran)
+    || (['retool'].includes(archetype) && oldExpensiveVeteran && years > 1);
+
+  return {
+    annualSalary: annual,
+    suggestedAnnual: annual,
+    suggestedYears: years,
+    years,
+    signingBonus,
+    totalValue: round1(annual * years + signingBonus),
+    annualCapHit,
+    marketTier: tier,
+    confidence: capHealth < 30 || riskTags.length >= 3 ? 'low' : riskTags.length ? 'medium' : 'high',
+    premiumPosition: premium.isPremium,
+    lowPremiumPosition: premium.isLowPremium,
+    riskTags,
+    reasons,
+    capFit: !hardCapAffordable ? 'over_cap' : exceedsSafeCapBand ? 'risky' : 'safe',
+    safeCapBand: round1(safeCapBand),
+    exceedsSafeCapBand,
+    shouldPursue: !avoid,
+    shouldAvoid: avoid,
+    controlledException: controlledQbException,
+  };
+}
+
+export function buildContractFromMarket(market = {}, extras = {}) {
+  const years = Math.max(1, Math.round(num(market?.suggestedYears ?? market?.years, 1)));
+  return {
+    years,
+    yearsTotal: years,
+    baseAnnual: round1(num(market?.suggestedAnnual ?? market?.annualSalary, Constants.SALARY_CAP.MIN_CONTRACT)),
+    signingBonus: round1(num(market?.signingBonus, 0)),
+    guaranteedPct: market?.marketTier === 'elite starter' ? 0.55 : market?.marketTier === 'quality starter' ? 0.45 : 0.3,
+    ...extras,
+  };
+}

--- a/src/testSupport/dynastySoakCli.js
+++ b/src/testSupport/dynastySoakCli.js
@@ -295,6 +295,19 @@ export function buildMarkdownReport(result) {
     for (const [name, entry] of exerciseEntries.filter(([, entry]) => !String(entry?.status ?? '').startsWith('skipped'))) {
       lines.push(`| ${mdEscape(name)} | ${mdEscape(exerciseStatusLabel(entry))} | ${mdEscape(exerciseDetail(entry))} |`);
     }
+    const workerProbeDetail = String(result.exerciseMatrix?.workerProbes?.detail ?? '');
+    const workerProbeHandlers = [
+      workerProbeDetail.includes('GET_RECORDS') ? 'getRecordsHandler' : null,
+      workerProbeDetail.includes('GET_ALL_SEASONS') ? 'getAllSeasonsHandler' : null,
+      workerProbeDetail.includes('GET_TRANSACTIONS') ? 'getTransactionsHandler' : null,
+      workerProbeDetail.includes('GET_HALL_OF_FAME') ? 'getHallOfFameHandler' : null,
+    ].filter(Boolean);
+    if (workerProbeHandlers.length) {
+      lines.push('');
+      lines.push('### Worker probe handlers');
+      lines.push('');
+      for (const handler of workerProbeHandlers) lines.push(`- ${mdEscape(handler)}`);
+    }
     lines.push('');
 
     lines.push('## What was skipped');


### PR DESCRIPTION
### Motivation

- Improve roster/economy believability by adding a focused, pure contract valuation layer that factors position premium, age, potential, team archetype, positional need, and cap health into FA/trade/extension decisions. 
- Do a small, reviewable integration into AI free-agent offer flows so CPU behavior shows cap-aware, length-sensible, and premium-weighted offers without rewriting the whole economy.

### Description

- Added a pure contract valuation helper `src/core/contractModel.js` that computes `marketTier`, `suggestedAnnual`, `suggestedYears`, `annualCapHit`, `capFit`, `riskTags`, `reasons`, `shouldPursue`/`shouldAvoid`, and a compatible flat `contract` shape via `buildContractFromMarket`. 
- Integrated the model into AI free agency offer generation (`src/core/ai-logic.js`) so AI offers are now derived from the contract model (still respecting `calculateExtensionDemand` for legacy/stale paths), with controlled QB exceptions, rebuild/retool veteran avoidance, and cap-fit checks before creating offers. 
- Kept signing and legality flow unchanged (cap still validated at sign time, offers are persisted to `player.offers`), and added `contractModel` metadata to AI-generated offers for future UI explainability. 
- Small quality-of-life test and reporting changes: added deterministic unit tests `src/core/__tests__/contractModel.test.js`, updated AI FA tests `src/core/__tests__/aiFreeAgencyOffers.test.js`, and included worker-probe handler names in dynasty soak markdown reports (`src/testSupport/dynastySoakCli.js`) so CI audit output lists exercised handlers. 
- Files touched: `src/core/contractModel.js`, `src/core/ai-logic.js`, `src/core/__tests__/contractModel.test.js`, updated `src/core/__tests__/aiFreeAgencyOffers.test.js`, and `src/testSupport/dynastySoakCli.js`.

Before / after examples (illustrative):
- Elite QB: before — broad QB salary bands with noisy term; after — 92 OVR / 94 POT age 27 → `elite starter`, premium-weighted, high annual (>$45M) and multi-year (≈5+ years) in contender cap contexts.
- Aging RB: before — could receive mid-length offers; after — age 31 / 82 OVR RB → `aging veteran`, 1-year short deal, discounted (sub-$8M), tagged with decline risk.
- Young high-potential starter: before — value was generic; after — 23yo 75 OVR / 86 POT CB → `prospect upside`, multi-year modest term, explicit upside reasons in model output.
- Low-OVR depth player: before — flat small-band offers; after — 60 OVR LB → `replacement level`, one-year, low/minimum-ish annual value.

What was intentionally deferred: guarantees/dead-cap math, restructures/void years, franchise tags, RFA/comp picks, practice squad, full multi-year cap forecasting, and a dedicated UI change to display the new model text (we inject metadata for future UI work).

### Testing

- Unit tests: `npm run test:unit` — full suite ran; final result: all unit tests passed (184 files / 792 tests passed). 
- Targeted unit tests: ran `vitest` on `src/core/__tests__/contractModel.test.js`, `src/core/__tests__/aiFreeAgencyOffers.test.js`, `src/core/__tests__/aiTeamStrategy.test.js`, and `src/core/__tests__/trade-logic.test.js` — all passed. 
- Soak/audit: `npm run test:soak` (dynasty soak subset) — passed (6 files / 40 tests). 
- CI audit: `npm run audit:dynasty -- --ci --seed=1383` — passed with summary "passed=true runtimeMs=18322 failures=0 warnings=1" (warning: early HOF empty in early years). 
- Build & deploy checks: `npm run build` succeeded (warning about large chunks >500KB is expected), and `npm run check:deploy` (Netlify parity + rules + offline builds) passed in this environment. 
- E2E smoke: `npx playwright test tests/e2e/fresh_franchise_first_week_smoke.spec.js` — failed to run because Playwright browsers were not present; attempted `npx playwright install --with-deps chromium` but the environment could not download the Chromium archive (CDN returned 403 / proxy restriction), so browser-based E2E could not be completed here. Exact error: Playwright failed to download Chromium from CDN (HTTP 403 Domain forbidden). 

Notes on validation commands executed (all completed unless noted): `npm ci`; `node --check` on new/changed core files; `npm run test:unit` (full suite); `npm run test:soak`; `npm run audit:dynasty -- --ci --seed=1383` (passed); `npm run build` (passed); `npm run check:deploy` (passed); attempted Playwright browser install failed due to network/CDN/proxy constraints (E2E smoke not completed here). 

Risks & follow-ups

- This is a first-pass realism layer; follow-ups should include UI presentation of `contractModel` metadata, optional cap reservation for placed offers, more refined guarantee/dead-cap modeling, and tuning via longer dynasty audits. 
- Playwright/E2E remains environment-dependent; CI should install browsers (or allow Playwright CDN access) to run the smoke E2E in CI.

If you want, I can (in a separate PR): surface `marketTier`/`capFit` tags on the FA UI rows, add an opt-in cap reservation for pending offers, or run further audit sweeps with different seeds to validate long-term churn metrics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0327f6dae8832da8ac237c6eff25d5)