### PR TITLE
Stabilize dynasty soak CI checkpoint report assertions

### DIFF
--- a/src/testSupport/dynastySoakCli.js
+++ b/src/testSupport/dynastySoakCli.js
@@ -234,6 +234,37 @@ function formatCheckpointMeta(meta) {
   return mdEscape(JSON.stringify(meta));
 }
 
+function formatCheckpointSystemLabel(name) {
+  switch (String(name ?? '')) {
+    case 'getAllSeasonsHandler':
+      return 'GET_ALL_SEASONS';
+    case 'getTransactionsRecentHandler':
+      return 'GET_TRANSACTIONS recent';
+    case 'getRecordsHandler':
+      return 'GET_RECORDS';
+    case 'getHallOfFameHandler':
+      return 'GET_HALL_OF_FAME';
+    default:
+      return String(name ?? 'unknown');
+  }
+}
+
+function formatProbeText(value) {
+  return String(value ?? '')
+    .replaceAll('getAllSeasonsHandler', 'GET_ALL_SEASONS')
+    .replaceAll('getTransactionsRecentHandler', 'GET_TRANSACTIONS recent')
+    .replaceAll('getRecordsHandler', 'GET_RECORDS')
+    .replaceAll('getHallOfFameHandler', 'GET_HALL_OF_FAME');
+}
+
+function formatPersistenceProbeLabel(id) {
+  const raw = String(id ?? 'unknown');
+  if (raw.startsWith('audit_checkpoint_probe_')) {
+    return `audit_checkpoint_probe_${formatProbeText(raw.slice('audit_checkpoint_probe_'.length))}`;
+  }
+  return formatProbeText(raw);
+}
+
 function exerciseStatusLabel(entry) {
   if (!entry || typeof entry !== 'object') return 'unknown';
   return String(entry.status ?? 'unknown');
@@ -295,19 +326,6 @@ export function buildMarkdownReport(result) {
     for (const [name, entry] of exerciseEntries.filter(([, entry]) => !String(entry?.status ?? '').startsWith('skipped'))) {
       lines.push(`| ${mdEscape(name)} | ${mdEscape(exerciseStatusLabel(entry))} | ${mdEscape(exerciseDetail(entry))} |`);
     }
-    const workerProbeDetail = String(result.exerciseMatrix?.workerProbes?.detail ?? '');
-    const workerProbeHandlers = [
-      workerProbeDetail.includes('GET_RECORDS') ? 'getRecordsHandler' : null,
-      workerProbeDetail.includes('GET_ALL_SEASONS') ? 'getAllSeasonsHandler' : null,
-      workerProbeDetail.includes('GET_TRANSACTIONS') ? 'getTransactionsHandler' : null,
-      workerProbeDetail.includes('GET_HALL_OF_FAME') ? 'getHallOfFameHandler' : null,
-    ].filter(Boolean);
-    if (workerProbeHandlers.length) {
-      lines.push('');
-      lines.push('### Worker probe handlers');
-      lines.push('');
-      for (const handler of workerProbeHandlers) lines.push(`- ${mdEscape(handler)}`);
-    }
     lines.push('');
 
     lines.push('## What was skipped');
@@ -345,7 +363,7 @@ export function buildMarkdownReport(result) {
       lines.push('| System | Status | Detail |');
       lines.push('| --- | --- | --- |');
       for (const [name, entry] of exercised) {
-        lines.push(`| ${mdEscape(name)} | ${mdEscape(entry?.status ?? 'exercised')} | ${mdEscape(entry?.detail || '')} |`);
+        lines.push(`| ${mdEscape(formatCheckpointSystemLabel(name))} | ${mdEscape(entry?.status ?? 'exercised')} | ${mdEscape(entry?.detail || '')} |`);
       }
     }
     lines.push('');
@@ -414,7 +432,7 @@ export function buildMarkdownReport(result) {
     lines.push('');
     for (const a of result.persistenceAssertions) {
       const st = a.status === 'skipped' ? 'skipped' : (a.ok ? 'ok' : 'FAIL');
-      lines.push(`- **${st}** \`${a.id}\`: ${mdEscape(a.detail || '')}`);
+      lines.push(`- **${st}** \`${mdEscape(formatPersistenceProbeLabel(a.id))}\`: ${mdEscape(formatProbeText(a.detail || ''))}`);
     }
     lines.push('');
   }

--- a/tests/unit/dynastySoakCli.test.js
+++ b/tests/unit/dynastySoakCli.test.js
@@ -146,10 +146,6 @@ describe('dynastySoakCli', () => {
         sourceYear: 2026,
         sourceSeasonId: 's2026',
         realWeeksSimulated: 2,
-        exercised: {
-          dbAuditCheckpointWriteRead: { status: 'exercised', detail: 'read back from DB' },
-          getRecordsHandler: { status: 'exercised', detail: 'GET_RECORDS handler returned record data' },
-        },
         exercised: { dbAuditCheckpointWriteRead: { status: 'exercised', detail: 'read back from DB' } },
         skipped: [{ system: 'completedSeasonArchive', reason: 'archiveSeason is not called by checkpoint' }],
       },
@@ -249,8 +245,8 @@ describe('dynastySoakCli', () => {
         exercised: {
           dbAuditCheckpointWriteRead: { status: 'exercised', detail: 'read back from DB' },
           getRecordsHandler: { status: 'exercised', detail: 'GET_RECORDS handler returned record data' },
+          getHallOfFameHandler: { status: 'exercised', detail: 'GET_HALL_OF_FAME handler returned a valid player list' },
         },
-        exercised: { dbAuditCheckpointWriteRead: { status: 'exercised', detail: 'read back from DB' } },
         skipped: [{ system: 'completedSeasonArchive', reason: 'archiveSeason is not called by checkpoint' }],
       },
       exerciseMatrix: {
@@ -279,6 +275,8 @@ describe('dynastySoakCli', () => {
       persistenceAssertions: [
         { id: 'latest_season_archive', ok: true, status: 'skipped', detail: 'skipped: CI profile does not complete a season or create a completed-season archive' },
         { id: 'get_all_seasons_probe', ok: true, detail: 'GET_ALL_SEASONS ok' },
+        { id: 'audit_checkpoint_exercised_systems', ok: true, detail: 'exercised: dbAuditCheckpointWriteRead, getRecordsHandler, getHallOfFameHandler' },
+        { id: 'audit_checkpoint_probe_getRecordsHandler', ok: true, detail: 'getRecordsHandler: GET_RECORDS handler returned record data' },
         { id: 'get_draft_classes', ok: true, status: 'skipped', detail: 'skipped: CI profile does not enter draft, so draft classes are not expected' },
       ],
       finalView: { veryLarge: true },
@@ -309,13 +307,21 @@ describe('dynastySoakCli', () => {
       expect(md).toContain('Short real-worker smoke audit. It does not complete a season.');
       expect(md).toContain('Full-season balance, playoffs, offseason, free agency, draft, and completed-season archive are not validated by CI profile.');
       expect(md).toContain('GET_ALL_SEASONS, GET_TRANSACTIONS recent, GET_RECORDS, GET_HALL_OF_FAME');
+      expect(md).toContain('GET_RECORDS');
+      expect(md).toContain('GET_HALL_OF_FAME');
+      expect(md).not.toContain('getRecordsHandler');
+      expect(md).not.toContain('getHallOfFameHandler');
       expect(md).toContain('## Audit checkpoint');
       expect(md).toContain('**Audit only:** true');
       expect(md).toContain('**Completed season:** false');
       expect(md).toContain('not full-season balance validation');
-      expect(md).toContain('getRecordsHandler');
+      expect(md).toContain('dbAuditCheckpointWriteRead');
+      expect(md).toContain('| completedSeasonArchive | archiveSeason is not called by checkpoint |');
       expect(md).toContain('| fullSeasonArchive | CI profile does not create a completed-season archive |');
       expect(md).toContain('**skipped** `latest_season_archive`');
+      expect(md).toContain('## Warnings');
+      expect(md).toContain('hof_empty_young');
+      expect(md).toContain('## Failures');
       expect(md).toContain('npm run audit:dynasty -- --audit-profile=full --seasons=1 --seed=1383');
     } finally {
       await rm(tmp, { recursive: true, force: true });


### PR DESCRIPTION
### Motivation
- Fix a Netlify/CI parity failure caused by a stale test that expected the internal handler name `getRecordsHandler` to appear in human-facing Markdown.
- The report should show public, user-facing probe labels (e.g. `GET_RECORDS`) rather than internal helper keys.
- Keep audit/checkpoint behavior, JSON output, and probe visibility unchanged while making the Markdown and test assertions reflect public labels.

### Description
- Render checkpoint systems in Markdown using public labels by adding `formatCheckpointSystemLabel`, `formatProbeText`, and `formatPersistenceProbeLabel` helpers to `src/testSupport/dynastySoakCli.js` and use them when building the report.
- Stop emitting a separate "Worker probe handlers" list of internal helper names and instead show public probe names in the exercise and checkpoint tables.
- Update the canonical fixture test `tests/unit/dynastySoakCli.test.js` to assert public/report-facing content (e.g. `GET_RECORDS`, `GET_HALL_OF_FAME`, `dbAuditCheckpointWriteRead`, audit-only metadata, skipped archive rows and reasons, full-season validation warning, warnings and failures sections) and remove the stale expectation for `getRecordsHandler`.
- No gameplay, worker semantics, persistence logic, or JSON checkpoint fields were altered; only Markdown rendering and corresponding test assertions changed.

### Testing
- Ran `node --check src/testSupport/dynastySoakCli.js` to validate JS syntax (passed). 
- Ran targeted unit tests: `npm run test:unit -- tests/unit/dynastySoakCli.test.js` and `npm run test:unit -- tests/unit/dynastySoakRunner.test.js tests/unit/dynastySoakPersistence.test.js src/worker/__tests__/dynastyAuditCheckpointGuard.test.js` (all passed).
- Ran full unit suite `npm run test:unit` (initial full run hit an unrelated flaky `tests/unit/traits.test.js` assertion; reran the suite and final run passed: 184 files / 792 tests).
- Ran soak subset `npm run test:soak` (passed).
- Built production bundle `npm run build` (passed) and ran `npm run check:deploy` parity checks (passed).
- Executed the real CLI smoke `npm run audit:dynasty -- --ci --seed=1383` to produce artifacts and verified `artifacts/dynasty-soak/latest.{json,md}` contains the expected public labels and audit checkpoint sections (passed).
- Attempted Playwright browser install `npx playwright install --with-deps chromium` and running the E2E smoke test, but the environment blocked Chromium download (403 Domain forbidden); this prevented running Playwright E2E here.

Root cause: test asserted an internal helper name (`getRecordsHandler`) that is not intended as a user-facing Markdown label; the fix intentionally maps internal probe keys to stable public names and updates tests to assert those public labels.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0336c5ddfc832da7908b6824853588)