### PR TITLE
Surface Contract/Cap Realism V1 insights in FA, Player Profile, and Contract Center

### DIFF
--- a/src/ui/components/ContractCenter.jsx
+++ b/src/ui/components/ContractCenter.jsx
@@ -12,6 +12,7 @@ import { summarizeNegotiationStance } from '../../core/contracts/negotiation.js'
 import { derivePlayerContractFinancials } from '../utils/contractFormatting.js';
 import { deriveTeamCapSnapshot } from '../utils/numberFormatting.js';
 import { evaluateResignRecommendation } from '../utils/contractInsights.js';
+import { buildContractOfferInsight, toneToContractInsightColor } from '../utils/contractOfferInsights.js';
 
 const PREMIUM_POSITIONS = new Set(['QB', 'LT', 'EDGE', 'CB']);
 const SORT_PRESETS = [
@@ -159,9 +160,11 @@ function ReSigningCenter({ league, team, actions, onNavigate, setStatusMessage }
       const decision = String(player?.extensionDecision ?? 'pending');
       const premium = PREMIUM_POSITIONS.has(String(player?.pos ?? '').toUpperCase());
       const unresolved = !['extended', 'let_walk', 'tagged'].includes(decision);
+      const insight = buildContractOfferInsight(player, { capRoom: capSnapshot.capRoom, team }, { contract: demand });
       return {
         player,
         demand,
+        insight,
         decision,
         decisionLabel: decisionLabel(decision),
         currentCapHit,
@@ -174,7 +177,7 @@ function ReSigningCenter({ league, team, actions, onNavigate, setStatusMessage }
         sortPriorityScore: (isKeyPlayer(player) ? 150 : 0) + (rec.tier === 'priority_resign' ? 80 : rec.tier === 'resign_if_price' ? 40 : 0) + (unresolved ? 20 : -15) + toNumber(player?.ovr, 60),
       };
     });
-  }, [expiringPlayers, roster, team]);
+  }, [expiringPlayers, roster, team, capSnapshot.capRoom]);
 
   const sortedRows = useMemo(() => {
     const clone = [...rows];
@@ -287,6 +290,11 @@ function ReSigningCenter({ league, team, actions, onNavigate, setStatusMessage }
           <div style={{ marginTop: 6, fontSize: 12, color: 'var(--text-muted)' }}>
             {money(previewRow.demand.baseAnnual)} AAV · {previewRow.demand.yearsTotal} years · Total {money(previewRow.demand.baseAnnual * previewRow.demand.yearsTotal)}.
           </div>
+          <div style={{ marginTop: 6, display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+            <span style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '2px 8px', color: 'var(--text-subtle)' }}>Market estimate: {previewRow.insight.marketTierLabel}</span>
+            <span style={{ fontSize: 11, border: `1px solid ${toneToContractInsightColor(previewRow.insight.capFitTone)}`, borderRadius: 999, padding: '2px 8px', color: toneToContractInsightColor(previewRow.insight.capFitTone) }}>{previewRow.insight.capFitLabel}</span>
+            {previewRow.insight.riskTags.slice(0, 2).map((tag) => <span key={`preview-${tag}`} style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '2px 8px', color: 'var(--text-subtle)' }}>{tag}</span>)}
+          </div>
           {capSnapshot.capRoom - Math.max(0, previewRow.projectedCapHit - previewRow.currentCapHit) < 5 ? (
             <div style={{ marginTop: 6, fontSize: 12, color: 'var(--warning)' }}>Warning: this creates cap stress heading into free agency.</div>
           ) : null}
@@ -313,6 +321,10 @@ function ReSigningCenter({ league, team, actions, onNavigate, setStatusMessage }
                 <td style={{ padding: 8, fontWeight: 700 }}>
                   {row.player.name} <span style={{ color: 'var(--text-muted)' }}>({row.player.pos})</span>
                   {row.premium ? <span style={{ marginLeft: 6, fontSize: 10, border: '1px solid var(--warning)', borderRadius: 10, padding: '1px 6px', color: 'var(--warning)' }}>Key</span> : null}
+                  <div style={{ marginTop: 3, display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+                    <span style={{ fontSize: 10, border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 6px', color: 'var(--text-subtle)' }}>{row.insight.marketTierLabel}</span>
+                    <span style={{ fontSize: 10, border: `1px solid ${toneToContractInsightColor(row.insight.capFitTone)}`, borderRadius: 999, padding: '1px 6px', color: toneToContractInsightColor(row.insight.capFitTone) }}>{row.insight.capFitLabel}</span>
+                  </div>
                 </td>
                 <td style={{ padding: 8 }}>{row.player.age ?? '—'}</td>
                 <td style={{ padding: 8 }}>{row.player.ovr ?? '—'}</td>

--- a/src/ui/components/ContractCenter.test.jsx
+++ b/src/ui/components/ContractCenter.test.jsx
@@ -29,6 +29,8 @@ describe('ContractCenter re-signing mode', () => {
     expect(html).toContain('Projected cap room (pending)');
     expect(html).toContain('Premium positions at risk');
     expect(html).toContain('Core QB');
+    expect(html).toContain('Elite starter');
+    expect(html).toContain('Good cap fit');
     expect(html).toContain('Let Walk');
     expect(html).toContain('Defer');
   });

--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -52,6 +52,7 @@ import { usePlayerCompare } from "../utils/playerCompare.js";
 import { formatDemandTier } from "../utils/offseasonActionCenter.js";
 import { buildFreeAgencyMarketAnalysis } from "../../core/freeAgency/freeAgencyMarketAnalysis.js";
 import { buildFreeAgencyProfileContext } from "../utils/playerProfileContext.js";
+import { buildContractOfferInsight, toneToContractInsightColor } from "../utils/contractOfferInsights.js";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -287,6 +288,52 @@ function PipBar({ value, color }) {
   );
 }
 
+function InsightChip({ label, tone = "neutral" }) {
+  return (
+    <span style={{
+      fontSize: 10,
+      border: `1px solid ${toneToContractInsightColor(tone)}`,
+      borderRadius: 999,
+      padding: "1px 6px",
+      color: toneToContractInsightColor(tone),
+      background: `${toneToContractInsightColor(tone)}14`,
+      lineHeight: 1.5,
+    }}>
+      {label}
+    </span>
+  );
+}
+
+export function ContractOfferInsightBlock({ player, capRoom, compact = false, showReasons = false, offer = null }) {
+  const insight = buildContractOfferInsight(player, { capRoom }, offer ?? {});
+  const chips = [
+    { label: insight.marketTierLabel, tone: insight.hasMetadata ? "ok" : "neutral" },
+    { label: insight.capFitLabel, tone: insight.capFitTone },
+    { label: insight.termLabel, tone: "neutral" },
+    ...insight.riskTags.slice(0, compact ? 2 : 3).map((label) => ({ label, tone: label.includes("Clean") || label.includes("Need") ? "ok" : "warning" })),
+  ];
+  return (
+    <div aria-label="Contract market read" style={{ display: "grid", gap: 4, marginTop: 4 }}>
+      <div style={{ display: "flex", gap: 4, flexWrap: "wrap", alignItems: "center" }}>
+        {chips.map((chip) => <InsightChip key={`${player?.id ?? player?.name}-${chip.label}`} label={chip.label} tone={chip.tone} />)}
+      </div>
+      {!compact && (
+        <div style={{ fontSize: 10, color: "var(--text-muted)" }}>
+          Market read: {insight.annualValueLabel} · {insight.hasMetadata ? "offer metadata" : "model estimate for your cap"}
+        </div>
+      )}
+      {showReasons && insight.reasonBullets.length > 0 ? (
+        <div style={{ display: "grid", gap: 2, fontSize: 10, color: "var(--text-subtle)" }}>
+          {insight.reasonBullets.map((reason, idx) => <div key={`why-${player?.id ?? player?.name}-${idx}`}>Why this deal? {reason}</div>)}
+        </div>
+      ) : null}
+      {insight.fallback ? (
+        <div style={{ fontSize: 10, color: "var(--text-subtle)" }}>Contract metadata unavailable; showing safe estimate only.</div>
+      ) : null}
+    </div>
+  );
+}
+
 // ── Cap banner ────────────────────────────────────────────────────────────────
 
 function CapBanner({ userTeam }) {
@@ -448,6 +495,7 @@ function SignInlineForm({ player, capRoom, rosterCount = 53, rosterLimit = 53, o
             ${(player._ask ?? 0).toFixed(1)}M / yr · {suggestedYears(player.age)}{" "}
             years
           </div>
+          <ContractOfferInsightBlock player={player} capRoom={capRoom} compact offer={{ contract: { baseAnnual: Number(annual || 0), yearsTotal: Number(years || 1), signingBonus: 0 } }} />
         </div>
         <div style={{ display: "grid", gap: 2, marginLeft: "auto", minWidth: 170 }}>
           <div style={{ fontSize: "10px", color: "var(--text-muted)" }}>
@@ -593,6 +641,10 @@ function PlayerPreviewSheet({ player, capRoom, onClose, onSubmitBid }) {
           <PlayerCard player={player} variant="hero" onClose={onClose} />
           <div style={{ marginTop: 10, fontSize: "0.8rem", color: "var(--text-muted)" }}>
             Team playbook knowledge: <strong style={{ color: "var(--text)" }}>{formatPlaybookKnowledge(player?.playbookKnowledge)}</strong>
+          </div>
+          <div style={{ marginTop: 10, border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: 10, background: "var(--surface)" }}>
+            <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700, marginBottom: 2 }}>Market context</div>
+            <ContractOfferInsightBlock player={player} capRoom={capRoom} showReasons />
           </div>
 
           {/* Bid form or trigger */}
@@ -1462,6 +1514,7 @@ export default function FreeAgency({
                               <div style={{ fontSize: 10, color: "var(--text-subtle)", marginTop: 2 }}>
                                 {player?._eval?.archetype?.archetype ?? "Balanced"} · {player?._eval?.roleProjection?.role ?? "Depth"} · {player?._eval?.simImpact?.summary}
                               </div>
+                              <ContractOfferInsightBlock player={player} capRoom={capRoom} compact />
                             </TableCell>
                             <TableCell style={{ whiteSpace: "nowrap" }}>
                               {(player.traits || []).map((t) => <TraitBadge key={t} traitId={t} />)}
@@ -1506,6 +1559,7 @@ export default function FreeAgency({
                           <div style={{ fontSize: 10, color: "var(--text-subtle)", marginTop: 2 }}>
                             {player?._eval?.archetype?.archetype ?? "Balanced"} · {player?._eval?.roleProjection?.replaceContext ?? "Depth option"}
                           </div>
+                          <ContractOfferInsightBlock player={player} capRoom={capRoom} compact />
                         </TableCell>
                         <TableCell style={{ whiteSpace: "nowrap" }}>
                           {(player.traits || []).map((t) => <TraitBadge key={t} traitId={t} />)}
@@ -1575,6 +1629,7 @@ export default function FreeAgency({
                     <div style={{ fontSize: 12, color: "var(--text-muted)" }}>{player?._eval?.roleProjection?.replaceContext ?? "Depth option"} · {player?._eval?.simImpact?.summary}</div>
                     <div style={{ fontSize: 12, color: "var(--text-muted)" }}>Playbook {formatPlaybookKnowledge(player?.playbookKnowledge)}</div>
                     <div style={{ fontSize: 12, marginTop: 4 }}>Demand {(player?.demandProfile?.askAnnual ?? player._ask ?? 0).toFixed(1)}M / yr</div>
+                    <ContractOfferInsightBlock player={player} capRoom={capRoom} showReasons />
                     <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: 4 }}>
                       {getMarketPlayerTags(player, { capRoom, needs: needsSummary?.needs ?? [], surplus: needsSummary?.surplus ?? [] }).map((tag) => (
                         <span key={`${player.id}-${tag.label}`} style={{ fontSize: 10, border: "1px solid var(--hairline)", padding: "1px 6px", borderRadius: 999, color: toneToCssColor(tag.tone) }}>{tag.label}</span>
@@ -1623,6 +1678,7 @@ export default function FreeAgency({
                                 <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginTop: 2 }}>
                                    Age {player.age} · Ask: ${(player?.demandProfile?.askAnnual ?? player._ask ?? 0).toFixed(1)}M/yr ({askYrs} yr)
                                 </div>
+                                <ContractOfferInsightBlock player={player} capRoom={capRoom} compact />
                                <div style={{ fontSize: 10, color: "var(--text-subtle)", marginTop: 2 }}>
                                   {player?._eval?.archetype?.archetype ?? "Balanced"} · Fit {player?._eval?.schemeFit?.score ?? player.schemeFit ?? 50} ({player?._eval?.schemeFit?.tier ?? "Neutral"}) · {player?._eval?.roleProjection?.role ?? "Depth"}
                                </div>

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from "@/components/ui/table";
 import { formatMoneyM, safeRound, toFiniteNumber } from "../utils/numberFormatting.js";
 import { derivePlayerContractFinancials } from "../utils/contractFormatting.js";
+import { buildContractOfferInsight, toneToContractInsightColor } from "../utils/contractOfferInsights.js";
 import { buildTeamIntelligence, classifyNeedFitForProspect, describeProspectProfile, describeRookieOnboarding } from "../utils/teamIntelligence.js";
 import { buildTeamChemistrySummary, describePlayerMoraleContext } from "../utils/teamChemistry.js";
 import { normalizeManagement, TRADE_STATUS_LABELS, TRADE_STATUS_TOOLTIPS, TRADE_STATUSES, CONTRACT_PLAN_FLAGS, CONTRACT_PLAN_LABELS, toggleContractPlan } from "../utils/playerManagement.js";
@@ -593,6 +594,7 @@ export default function PlayerProfile({
   const chemistry = useMemo(() => buildTeamChemistrySummary(userTeam, { week: data?.meta?.week ?? 1, direction: teamIntel?.direction }), [userTeam, data?.meta?.week, teamIntel]);
   const moraleContext = useMemo(() => describePlayerMoraleContext(player, { team: userTeam, chemistry, week: data?.meta?.week ?? 1 }), [player, userTeam, chemistry, data?.meta?.week]);
   const onboardingContext = useMemo(() => ((isProspect || Number(player?.age ?? 30) <= 24) ? describeRookieOnboarding(player, teamIntel) : null), [isProspect, player, teamIntel]);
+  const contractMarketRead = useMemo(() => buildContractOfferInsight(player ?? {}, { capRoom: userTeam?.capRoom, team: userTeam, teamIntel }), [player, userTeam, teamIntel]);
   const developmentSignal = useMemo(() => classifyDevelopmentTrend(player), [player]);
   const readinessSignal = useMemo(() => getPlayerReadiness(player), [player]);
   const fitSignal = useMemo(() => getSchemeFitSignal(player), [player]);
@@ -1543,6 +1545,40 @@ export default function PlayerProfile({
                   </span>
                 ))}
               </div>
+            </section>
+          )}
+
+
+          {!loading && playerView && (
+            <section className="card-enter">
+              <h3 style={sectionLabelStyle}>Contract Read</h3>
+              <div style={{ display: "grid", gap: "var(--space-2)", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" }}>
+                <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Market tier</div>
+                  <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2 }}>{contractMarketRead.marketTierLabel}</div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)", marginTop: 2 }}>{contractMarketRead.hasMetadata ? "From saved offer metadata" : "Market estimate from current ratings/cap context"}</div>
+                </div>
+                <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Cap fit</div>
+                  <div style={{ fontSize: "var(--text-sm)", fontWeight: 700, marginTop: 2, color: toneToContractInsightColor(contractMarketRead.capFitTone) }}>{contractMarketRead.capFitLabel}</div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)", marginTop: 2 }}>{contractMarketRead.annualValueLabel} · {contractMarketRead.termLabel}</div>
+                </div>
+                <div style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px" }}>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Risk tags</div>
+                  <div style={{ marginTop: 4, display: "flex", gap: 4, flexWrap: "wrap" }}>
+                    {(contractMarketRead.riskTags.length ? contractMarketRead.riskTags : ["No major model risk tags"]).slice(0, 4).map((tag) => (
+                      <span key={`profile-contract-${tag}`} style={{ fontSize: 11, border: "1px solid var(--hairline)", borderRadius: 999, padding: "2px 8px", color: "var(--text-subtle)" }}>{tag}</span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              {contractMarketRead.reasonBullets.length > 0 ? (
+                <div style={{ marginTop: 6, display: "grid", gap: 3 }}>
+                  {contractMarketRead.reasonBullets.map((reason, idx) => (
+                    <div key={`profile-contract-reason-${idx}`} style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>• Why this deal? {reason}</div>
+                  ))}
+                </div>
+              ) : null}
             </section>
           )}
 

--- a/src/ui/components/__tests__/FreeAgencyContractInsights.test.jsx
+++ b/src/ui/components/__tests__/FreeAgencyContractInsights.test.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import { ContractOfferInsightBlock } from '../FreeAgency.jsx';
+
+const metaPlayer = {
+  id: 1,
+  name: 'Market QB',
+  pos: 'QB',
+  age: 27,
+  ovr: 89,
+  potential: 92,
+  offers: {
+    topOfferContractModel: {
+      marketTier: 'elite starter',
+      capFit: 'risky',
+      riskTags: ['large cap share'],
+      reasons: ['elite starter based on 89 OVR / 92 POT.'],
+      suggestedAnnual: 34,
+      suggestedYears: 5,
+    },
+  },
+};
+
+describe('FreeAgency contract insight UI', () => {
+  it('renders market tier, cap fit, risk chips, and visible why copy from metadata', () => {
+    const html = renderToString(<ContractOfferInsightBlock player={metaPlayer} capRoom={55} showReasons />);
+    expect(html).toContain('Elite starter');
+    expect(html).toContain('Risky cap fit');
+    expect(html).toContain('Cap squeeze');
+    expect(html).toContain('Why this deal?');
+    expect(html).toContain('offer metadata');
+  });
+
+  it('renders fallback estimate without hover-only text when metadata is missing', () => {
+    const html = renderToString(<ContractOfferInsightBlock player={{ id: 2, name: 'Depth LB', pos: 'LB', age: 26, ovr: 60, potential: 61 }} capRoom={20} />);
+    expect(html).toContain('Replacement level');
+    expect(html).toContain('model estimate for your cap');
+    expect(html).toContain('Contract market read');
+  });
+});

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -60,6 +60,8 @@ describe('PlayerProfile', () => {
     expect(screen.getByTestId('player-profile')).toBeTruthy();
     await waitFor(() => expect(screen.getByTestId('player-profile-summary').textContent).toContain('Avery Fields'));
     expect(screen.getByTestId('player-profile-season-stats').textContent).toContain('Season stats will appear after this player records tracked stats.');
+    await waitFor(() => expect(screen.getByText('Contract Read')).toBeTruthy());
+    expect(screen.getByText('Market tier')).toBeTruthy();
   });
 
   it('shows career arc snapshot for active players', async () => {

--- a/src/ui/utils/contractFormatting.test.js
+++ b/src/ui/utils/contractFormatting.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { derivePlayerContractFinancials } from './contractFormatting.js';
+import { buildContractOfferInsight } from './contractOfferInsights.js';
 
 describe('derivePlayerContractFinancials', () => {
   it('normalizes salary from canonical and legacy fields', () => {
@@ -16,5 +17,17 @@ describe('derivePlayerContractFinancials', () => {
     const missing = derivePlayerContractFinancials({ contract: { yearsTotal: 4 } });
     expect(missing.annualSalary).toBeNull();
     expect(missing.totalValue).toBeNull();
+  });
+});
+
+
+describe('contract insight money labels', () => {
+  it('formats annual values from contract model metadata', () => {
+    const insight = buildContractOfferInsight(
+      { contractModel: { marketTier: 'quality starter', capFit: 'safe', suggestedAnnual: 12.25, suggestedYears: 3 } },
+      { capRoom: 40 },
+    );
+    expect(insight.annualValueLabel).toBe('$12.3M/yr');
+    expect(insight.termLabel).toContain('3 yrs');
   });
 });

--- a/src/ui/utils/contractInsights.test.js
+++ b/src/ui/utils/contractInsights.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { evaluateResignRecommendation } from './contractInsights.js';
+import { buildContractOfferInsight } from './contractOfferInsights.js';
 
 describe('contract insights prioritization', () => {
   it('marks elite expensive non-contender as trade/tag candidate', () => {
@@ -16,5 +17,48 @@ describe('contract insights prioritization', () => {
       { team: { capRoom: 35 }, direction: 'contender', roster: [{ pos: 'QB' }] },
     );
     expect(rec.tier).toBe('priority_resign');
+  });
+});
+
+
+describe('contract offer insight adapter', () => {
+  it('displays elite QB as premium / elite starter', () => {
+    const insight = buildContractOfferInsight({ pos: 'QB', age: 26, ovr: 90, potential: 94 }, { capRoom: 80 });
+    expect(insight.marketTierLabel).toBe('Elite starter');
+    expect(insight.riskTags).toContain('Premium position cost');
+  });
+
+  it('displays aging RB as short-term risk', () => {
+    const insight = buildContractOfferInsight({ pos: 'RB', age: 31, ovr: 78, potential: 78 }, { capRoom: 35 });
+    expect(insight.marketTierLabel).toBe('Aging veteran');
+    expect(insight.termLabel).toContain('short-term');
+    expect(insight.riskTags).toContain('Short-term RB risk');
+  });
+
+  it('displays young high-potential player as upside', () => {
+    const insight = buildContractOfferInsight({ pos: 'WR', age: 23, ovr: 68, potential: 80 }, { capRoom: 45 });
+    expect(insight.marketTierLabel).toBe('Prospect upside');
+    expect(insight.reasonBullets.join(' ')).toMatch(/upside|POT/i);
+  });
+
+  it('displays low OVR depth player as replacement/depth', () => {
+    const insight = buildContractOfferInsight({ pos: 'LB', age: 26, ovr: 59, potential: 61 }, { capRoom: 20 });
+    expect(insight.marketTierLabel).toBe('Replacement level');
+  });
+
+  it('handles missing/legacy metadata safely and keeps cap fit labels stable', () => {
+    const insight = buildContractOfferInsight({}, { capRoom: 0 }, { contract: { baseAnnual: 2, yearsTotal: 1 } });
+    expect(insight.marketTierLabel).toBeTruthy();
+    expect(['Good cap fit', 'Manageable cap fit', 'Tight cap fit', 'Risky cap fit', 'Over cap']).toContain(insight.capFitLabel);
+  });
+
+  it('uses saved contractModel metadata when present', () => {
+    const insight = buildContractOfferInsight(
+      { pos: 'QB', offers: { topOfferContractModel: { marketTier: 'elite starter', capFit: 'risky', riskTags: ['large cap share'], reasons: ['CPU offer context.'], suggestedAnnual: 32, suggestedYears: 5 } } },
+      { capRoom: 50 },
+    );
+    expect(insight.hasMetadata).toBe(true);
+    expect(insight.capFitLabel).toBe('Risky cap fit');
+    expect(insight.annualValueLabel).toBe('$32.0M/yr');
   });
 });

--- a/src/ui/utils/contractOfferInsights.js
+++ b/src/ui/utils/contractOfferInsights.js
@@ -1,0 +1,175 @@
+import { evaluateContractMarket } from '../../core/contractModel.js';
+import { formatMoneyM, toFiniteNumber } from './numberFormatting.js';
+
+const MARKET_TIER_LABELS = Object.freeze({
+  'elite starter': 'Elite starter',
+  'quality starter': 'Quality starter',
+  'bridge starter': 'Bridge starter',
+  'rotation / depth': 'Rotation / depth',
+  'prospect upside': 'Prospect upside',
+  'aging veteran': 'Aging veteran',
+  'replacement level': 'Replacement level',
+});
+
+const CAP_FIT_LABELS = Object.freeze({
+  safe: 'Good cap fit',
+  manageable: 'Manageable cap fit',
+  tight: 'Tight cap fit',
+  risky: 'Risky cap fit',
+  over_cap: 'Over cap',
+});
+
+const CAP_FIT_TONES = Object.freeze({
+  safe: 'ok',
+  manageable: 'ok',
+  tight: 'warning',
+  risky: 'warning',
+  over_cap: 'danger',
+});
+
+const RISK_TAG_LABELS = Object.freeze({
+  'aging RB decline risk': 'Short-term RB risk',
+  'age/decline risk': 'Age decline risk',
+  'large cap share': 'Cap squeeze',
+  'long veteran commitment': 'Long veteran commitment',
+  'low-premium spend': 'Low-premium spend',
+  'outside safe cap band': 'Outside safe cap band',
+});
+
+function cleanLabel(value) {
+  return String(value ?? '')
+    .trim()
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/^./, (c) => c.toUpperCase());
+}
+
+function normalizeCapFit(value, annualCapHit, capRoom) {
+  const raw = String(value ?? '').toLowerCase();
+  if (CAP_FIT_LABELS[raw]) return raw;
+  const hit = toFiniteNumber(annualCapHit, null);
+  const room = toFiniteNumber(capRoom, null);
+  if (hit != null && room != null) {
+    if (hit > room) return 'over_cap';
+    if (hit >= Math.max(10, room * 0.5)) return 'risky';
+    if (hit >= Math.max(6, room * 0.32)) return 'tight';
+    return 'safe';
+  }
+  return 'manageable';
+}
+
+function normalizeTerm(years) {
+  const y = Math.max(1, Math.round(toFiniteNumber(years, 1)));
+  if (y === 1) return '1 yr · short-term';
+  if (y <= 2) return `${y} yrs · short-term`;
+  if (y <= 3) return `${y} yrs · bridge/upside`;
+  return `${y} yrs · long-term`;
+}
+
+function normalizeRiskTags(tags) {
+  const raw = Array.isArray(tags) ? tags : [];
+  return raw
+    .filter(Boolean)
+    .map((tag) => RISK_TAG_LABELS[tag] ?? cleanLabel(tag))
+    .filter(Boolean)
+    .slice(0, 4);
+}
+
+function getOfferMetadata(player = {}, offer = {}) {
+  const offersSummary = player?.offers ?? {};
+  return offer?.contractModel
+    ?? player?.contractModel
+    ?? player?.market?.contractModel
+    ?? offersSummary?.topContractModel
+    ?? offersSummary?.topOfferContractModel
+    ?? offersSummary?.userContractModel
+    ?? offersSummary?.userOfferContractModel
+    ?? null;
+}
+
+function getAnnualValue(player = {}, offer = {}, model = {}) {
+  return toFiniteNumber(
+    offer?.contract?.baseAnnual
+      ?? offer?.baseAnnual
+      ?? model?.suggestedAnnual
+      ?? model?.annualSalary
+      ?? model?.annualCapHit
+      ?? player?.demandProfile?.askAnnual
+      ?? player?._ask
+      ?? player?.contractDemand?.baseAnnual
+      ?? player?.contract?.baseAnnual,
+    null,
+  );
+}
+
+function getYears(player = {}, offer = {}, model = {}) {
+  return toFiniteNumber(
+    offer?.contract?.yearsTotal
+      ?? offer?.contract?.years
+      ?? offer?.yearsTotal
+      ?? offer?.years
+      ?? model?.suggestedYears
+      ?? model?.years
+      ?? player?.demandProfile?.askYears
+      ?? player?.contractDemand?.yearsTotal
+      ?? player?.contract?.yearsTotal
+      ?? player?.contract?.years,
+    null,
+  );
+}
+
+function contextForMarket(player = {}, context = {}) {
+  return {
+    teamArchetype: context?.teamArchetype ?? context?.teamIntel?.direction ?? context?.teamIntel?.archetype ?? context?.direction ?? 'middle',
+    teamCapRoom: context?.teamCapRoom ?? context?.capRoom ?? context?.team?.capRoom,
+    capHealth: context?.capHealth ?? context?.teamIntel?.capHealth,
+    positionalNeed: context?.positionalNeed ?? context?.needMultiplier,
+  };
+}
+
+export function buildContractOfferInsight(player = {}, context = {}, offer = {}) {
+  const providedModel = getOfferMetadata(player, offer);
+  let model = providedModel;
+  let source = providedModel ? 'metadata' : 'estimate';
+  try {
+    if (!model) model = evaluateContractMarket(player, contextForMarket(player, context));
+  } catch {
+    model = null;
+    source = 'missing';
+  }
+
+  const annualValue = getAnnualValue(player, offer, model ?? {});
+  const years = getYears(player, offer, model ?? {});
+  const annualCapHit = toFiniteNumber(model?.annualCapHit ?? annualValue, annualValue);
+  const capFit = normalizeCapFit(model?.capFit, annualCapHit, context?.capRoom ?? context?.teamCapRoom ?? context?.team?.capRoom);
+  const marketTier = model?.marketTier ?? null;
+  const riskTags = normalizeRiskTags(model?.riskTags);
+  const reasons = Array.isArray(model?.reasons) ? model.reasons.filter(Boolean).map(String) : [];
+
+  if (model?.premiumPosition && !riskTags.includes('Premium position cost')) riskTags.unshift('Premium position cost');
+  if (model?.shouldAvoid && !riskTags.includes('Avoid unless price drops')) riskTags.push('Avoid unless price drops');
+  if (model?.shouldPursue && riskTags.length === 0) riskTags.push('Clean market fit');
+
+  const fallback = !model || source === 'missing';
+  return {
+    marketTierLabel: marketTier ? (MARKET_TIER_LABELS[marketTier] ?? cleanLabel(marketTier)) : 'Market estimate unavailable',
+    capFit,
+    capFitLabel: CAP_FIT_LABELS[capFit] ?? 'Manageable cap fit',
+    capFitTone: CAP_FIT_TONES[capFit] ?? 'neutral',
+    riskTags: riskTags.slice(0, 4),
+    reasonBullets: reasons.slice(0, 3),
+    termLabel: years != null ? normalizeTerm(years) : 'Term unavailable',
+    annualValueLabel: annualValue != null ? `${formatMoneyM(annualValue, '—')}/yr` : 'AAV unavailable',
+    confidence: model?.confidence ?? (fallback ? 'fallback' : 'medium'),
+    source,
+    fallback,
+    hasMetadata: !!providedModel,
+  };
+}
+
+export function toneToContractInsightColor(tone) {
+  if (tone === 'ok') return 'var(--success)';
+  if (tone === 'warning') return 'var(--warning)';
+  if (tone === 'danger') return 'var(--danger)';
+  return 'var(--text-subtle)';
+}

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -6089,8 +6089,10 @@ async function handleGetFreeAgents(payload, id) {
               topBidTeam: topBid ? topBid.teamName : null,
               topBidAnnual: topBid ? Math.round(topBid.contract.baseAnnual * 10) / 10 : 0,
               topBidYears: topBid ? topBid.contract.yearsTotal : 0,
+              topOfferContractModel: topBid?.contractModel ?? null,
               userBidAnnual: userOffer ? Math.round(userOffer.contract.baseAnnual * 10) / 10 : 0,
               userBidYears: userOffer ? userOffer.contract.yearsTotal : 0,
+              userOfferContractModel: userOffer?.contractModel ?? null,
               userBidValue: Math.round(userBidValue * 10) / 10,
               userTrailReason,
           }


### PR DESCRIPTION
### Motivation

- The Contract/Cap Realism V1 model (added in prior work) produced rich metadata on AI offers but the UI did not surface that metadata to players making FA/contract decisions.  
- Players needed compact, mobile-first explainability (market tier, cap-fit, risk tags, short “why” bullets) so offers and decisions feel believable and transparent.  
- Changes must be presentation-only: keep the contract model, values, and simulation balance untouched and provide safe fallbacks for legacy saves.

### Description

- Added a pure UI adapter `src/ui/utils/contractOfferInsights.js` to convert saved `contractModel` metadata or a model-derived estimate into display-safe labels: `marketTierLabel`, `capFitLabel`/tone, `riskTags`, `reasonBullets`, `termLabel`, `annualValueLabel`, `confidence/source`, and a fallback flag.  
- Surfaced compact contract/cap chips and a small explainability block in Free Agency rows, card view, mobile cards, the inline sign form, and the player preview sheet using a new `ContractOfferInsightBlock` UI primitive in `src/ui/components/FreeAgency.jsx`, mobile-first and not hover-dependent.  
- Added a “Contract Read” block to `src/ui/components/PlayerProfile.jsx` showing market tier, cap fit, risk tags, short reasons and an explicit label when data is a model estimate (not saved metadata).  
- Exposed offer metadata for UI consumption without changing economics by plumbing `topOfferContractModel` and `userOfferContractModel` into the free-agent payload in `src/worker/worker.js`, and added small market/cap chips to `ContractCenter` rows and preview; all derived values are read-only presentation only.

### Testing

- Ran environment checks and static verification: `npm ci` (ok), `node --check src/core/contractModel.js` (ok), `node --check src/core/ai-logic.js` (ok), `node --check src/ui/utils/contractOfferInsights.js` (ok).  
- Unit test suites: `npm run test:unit` (full suite) passed — 185 files / 801 tests passed; targeted unit groups also passed (contract model & AI FA offers, contract insight/formatting, Contract Center/PlayerProfile/FA insight UI tests).  
- Soak and audit: `npm run test:soak` passed (6 files / 40 tests); `npm run audit:dynasty -- --ci --seed=1383` passed (reported runtimeMs=17602; 0 failures, 1 expected early-league HOF warning).  
- Build & deploy checks: `npm run build` passed (bundle emitted with expected >500KB chunk warning) and `npm run check:deploy` passed (Netlify parity checks completed); note npm audit reported unrelated existing advisories.  
- E2E smoke: `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` failed due to missing Playwright Chromium binary in this environment; `npx playwright install --with-deps chromium` attempted but browser download was blocked by network/proxy (cdn.playwright.dev returned 403), so Playwright-driven E2E could not be completed in this run and should be re-run in CI or an environment with browser download access.

What was intentionally deferred: cap reservation/pending-offer holds, guarantees/dead-cap/rescopes, restructures, franchise tags, and multi-year cap forecasting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03606c6894832d8e77bdb102603be6)