### PR TITLE
Pending Offer Cap Reservation V1

### DIFF
--- a/src/core/__tests__/pendingOfferCapModel.test.js
+++ b/src/core/__tests__/pendingOfferCapModel.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { evaluatePendingOfferCapReservation } from '../pendingOfferCapModel.js';
+
+const team = { id: 1, capRoom: 30, capTotal: 255, capUsed: 225 };
+
+describe('pending offer cap reservation model', () => {
+  it('returns safe zero commitment with no pending offers', () => {
+    const result = evaluatePendingOfferCapReservation({ team, freeAgents: [], teamId: 1 });
+    expect(result).toMatchObject({
+      currentCapRoom: 30,
+      pendingAnnualCommitment: 0,
+      pendingOfferCount: 0,
+      estimatedCapRoomAfterPending: 30,
+      capReservationStatus: 'safe',
+    });
+  });
+
+  it('reduces estimated cap room for one pending offer', () => {
+    const result = evaluatePendingOfferCapReservation({
+      team,
+      teamId: 1,
+      freeAgents: [{ id: 10, name: 'Starter WR', offers: [{ teamId: 1, contract: { baseAnnual: 8, yearsTotal: 3, signingBonus: 0 } }] }],
+    });
+    expect(result.pendingAnnualCommitment).toBe(8);
+    expect(result.estimatedCapRoomAfterPending).toBe(22);
+    expect(result.offerRows[0]).toMatchObject({ playerId: 10, playerName: 'Starter WR', annualValue: 8, years: 3 });
+  });
+
+  it('aggregates multiple pending annual commitments', () => {
+    const result = evaluatePendingOfferCapReservation({
+      team,
+      teamId: 1,
+      freeAgents: [
+        { id: 10, name: 'QB', offers: [{ teamId: 1, contract: { baseAnnual: 12, yearsTotal: 2 } }] },
+        { id: 11, name: 'CB', offers: [{ teamId: 1, contract: { baseAnnual: 6.5, yearsTotal: 1 } }] },
+      ],
+    });
+    expect(result.pendingOfferCount).toBe(2);
+    expect(result.pendingAnnualCommitment).toBe(18.5);
+    expect(result.estimatedCapRoomAfterPending).toBe(11.5);
+    expect(result.capReservationStatus).toBe('manageable');
+  });
+
+  it('marks overcommitted pending offers with warning and blocking reason only for obvious overage', () => {
+    const result = evaluatePendingOfferCapReservation({
+      team: { id: 1, capRoom: 20 },
+      teamId: 1,
+      freeAgents: [
+        { id: 10, name: 'QB', offers: [{ teamId: 1, contract: { baseAnnual: 22, yearsTotal: 3 } }] },
+        { id: 11, name: 'EDGE', offers: [{ teamId: 1, contract: { baseAnnual: 14, yearsTotal: 2 } }] },
+      ],
+    });
+    expect(result.capReservationStatus).toBe('overcommitted');
+    expect(result.warnings.join(' ')).toMatch(/exceed current cap room/i);
+    expect(result.blockingReasons.length).toBe(1);
+  });
+
+  it('treats missing salary as unknown without inventing cap values', () => {
+    const result = evaluatePendingOfferCapReservation({
+      team,
+      teamId: 1,
+      freeAgents: [{ id: 10, name: 'Legacy FA', offers: [{ teamId: 1, contract: { yearsTotal: 2 } }] }],
+    });
+    expect(result.pendingOfferCount).toBe(1);
+    expect(result.pendingAnnualCommitment).toBe(0);
+    expect(result.unknownOfferCount).toBe(1);
+    expect(result.offerRows[0].status).toBe('unknown');
+    expect(result.warnings.join(' ')).toMatch(/missing annual salary data/i);
+  });
+
+  it('uses annual cap hit instead of total multi-year value', () => {
+    const result = evaluatePendingOfferCapReservation({
+      team,
+      teamId: 1,
+      freeAgents: [{ id: 10, name: 'Long Deal', offers: [{ teamId: 1, totalValue: 80, contract: { baseAnnual: 10, yearsTotal: 4, signingBonus: 8 } }] }],
+    });
+    expect(result.pendingAnnualCommitment).toBe(12);
+    expect(result.estimatedCapRoomAfterPending).toBe(18);
+  });
+
+  it('handles old-save summarized UI offer shapes', () => {
+    const result = evaluatePendingOfferCapReservation({
+      team,
+      teamId: 1,
+      freeAgents: [{ id: 10, name: 'Summarized Bid', offers: { userOffered: true, userBidAnnual: 7.2, userBidYears: 2 } }],
+    });
+    expect(result.pendingAnnualCommitment).toBe(7.2);
+    expect(result.offerRows[0]).toMatchObject({ playerName: 'Summarized Bid', years: 2 });
+  });
+});

--- a/src/core/pendingOfferCapModel.js
+++ b/src/core/pendingOfferCapModel.js
@@ -1,0 +1,210 @@
+const STATUS_LABELS = Object.freeze({
+  safe: 'Safe',
+  manageable: 'Manageable',
+  tight: 'Tight',
+  overcommitted: 'Overcommitted',
+  unknown: 'Unknown',
+});
+
+function toFiniteNumber(value, fallback = null) {
+  if (value == null || value === '') return fallback;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function roundMoney(value) {
+  const n = toFiniteNumber(value, null);
+  return n == null ? null : Math.round(n * 10) / 10;
+}
+
+function resolveCurrentCapRoom(team = {}, explicitCapRoom = null) {
+  const direct = toFiniteNumber(explicitCapRoom, null) ?? toFiniteNumber(team?.capRoom, null) ?? toFiniteNumber(team?.capSpace, null);
+  if (direct != null) return roundMoney(direct);
+  const total = toFiniteNumber(team?.capTotal, null);
+  const used = toFiniteNumber(team?.capUsed, null);
+  const dead = toFiniteNumber(team?.deadCap, 0);
+  if (total != null && used != null) return roundMoney(total - used - dead);
+  return null;
+}
+
+function resolveYears(offer = {}, player = {}) {
+  return toFiniteNumber(
+    offer?.contract?.yearsTotal
+      ?? offer?.contract?.years
+      ?? offer?.contract?.yearsRemaining
+      ?? offer?.yearsTotal
+      ?? offer?.years
+      ?? offer?.userBidYears
+      ?? offer?.topBidYears
+      ?? player?.offers?.userBidYears
+      ?? player?.offers?.topBidYears,
+    null,
+  );
+}
+
+function resolveAnnualValue(offer = {}, player = {}) {
+  const years = Math.max(1, toFiniteNumber(resolveYears(offer, player), 1));
+  const baseAnnual = toFiniteNumber(
+    offer?.annualCapHit
+      ?? offer?.capHit
+      ?? offer?.contract?.annualCapHit
+      ?? offer?.contract?.capHit,
+    null,
+  );
+  if (baseAnnual != null) return roundMoney(baseAnnual);
+
+  const base = toFiniteNumber(
+    offer?.contract?.baseAnnual
+      ?? offer?.contract?.annualSalary
+      ?? offer?.contract?.annual
+      ?? offer?.baseAnnual
+      ?? offer?.annualSalary
+      ?? offer?.annualValue
+      ?? offer?.salary
+      ?? offer?.userBidAnnual
+      ?? player?.offers?.userBidAnnual,
+    null,
+  );
+  if (base == null || base <= 0) return null;
+
+  const bonus = toFiniteNumber(offer?.contract?.signingBonus ?? offer?.signingBonus, 0);
+  return roundMoney(base + (bonus > 0 ? bonus / years : 0));
+}
+
+function normalizeOfferRowsFromPlayer(player, teamId) {
+  const rows = [];
+  const numericTeamId = teamId == null ? null : Number(teamId);
+  const offers = player?.offers;
+
+  if (Array.isArray(offers)) {
+    for (const offer of offers) {
+      if (!offer) continue;
+      if (numericTeamId != null && Number(offer.teamId) !== numericTeamId) continue;
+      rows.push({ player, offer });
+    }
+    return rows;
+  }
+
+  if (offers && typeof offers === 'object' && offers.userOffered) {
+    rows.push({
+      player,
+      offer: {
+        teamId,
+        userBidAnnual: offers.userBidAnnual,
+        userBidYears: offers.userBidYears,
+        annualCapHit: offers.userBidAnnualCapHit,
+        contractModel: offers.userOfferContractModel,
+      },
+    });
+  }
+
+  return rows;
+}
+
+function buildRow({ player = {}, offer = {}, currentCapRoom = null }) {
+  const annualValue = resolveAnnualValue(offer, player);
+  const years = resolveYears(offer, player);
+  const modelCapFit = offer?.contractModel?.capFit ?? offer?.capFit ?? null;
+  let capFit = modelCapFit;
+  if (!capFit) {
+    if (annualValue == null || currentCapRoom == null) capFit = 'unknown';
+    else if (annualValue > currentCapRoom) capFit = 'over_cap';
+    else if (annualValue >= Math.max(10, currentCapRoom * 0.5)) capFit = 'risky';
+    else if (annualValue >= Math.max(6, currentCapRoom * 0.32)) capFit = 'tight';
+    else capFit = 'safe';
+  }
+  return {
+    playerId: player?.id ?? offer?.playerId ?? null,
+    playerName: player?.name ?? offer?.playerName ?? 'Unknown player',
+    annualValue,
+    years: years == null ? null : Math.max(1, Math.round(years)),
+    capFit,
+    status: annualValue == null ? 'unknown' : 'pending',
+  };
+}
+
+function buildWarnings({ currentCapRoom, pendingAnnualCommitment, estimatedCapRoomAfterPending, unknownCount }) {
+  const warnings = [];
+  const blockingReasons = [];
+  if (unknownCount > 0) {
+    warnings.push(`${unknownCount} pending offer${unknownCount === 1 ? '' : 's'} missing annual salary data; cap reservation is partial.`);
+  }
+  if (currentCapRoom == null) {
+    warnings.push('Current cap room is unavailable, so pending cap impact cannot be estimated.');
+    return { warnings, blockingReasons };
+  }
+  if (estimatedCapRoomAfterPending == null) return { warnings, blockingReasons };
+  if (estimatedCapRoomAfterPending < 0) {
+    warnings.push(`Pending offers would exceed current cap room by $${Math.abs(estimatedCapRoomAfterPending).toFixed(1)}M if all were accepted.`);
+  } else if (estimatedCapRoomAfterPending < 5) {
+    warnings.push('Pending offers would leave less than $5.0M in cap room if all were accepted.');
+  } else if (estimatedCapRoomAfterPending < 10) {
+    warnings.push('Pending offers would leave a tight cap cushion if all were accepted.');
+  }
+  const obviousOverage = Math.max(10, Math.abs(currentCapRoom) * 0.25);
+  if (pendingAnnualCommitment > currentCapRoom + obviousOverage) {
+    blockingReasons.push(`Accepting every pending offer is obviously over cap by more than $${obviousOverage.toFixed(1)}M.`);
+  }
+  return { warnings, blockingReasons };
+}
+
+function resolveStatus({ currentCapRoom, pendingAnnualCommitment, estimatedCapRoomAfterPending, pendingOfferCount, unknownCount }) {
+  if (currentCapRoom == null) return 'unknown';
+  if (pendingOfferCount === 0) return unknownCount > 0 ? 'unknown' : 'safe';
+  if (unknownCount > 0 && pendingAnnualCommitment <= 0) return 'unknown';
+  if (estimatedCapRoomAfterPending == null) return 'unknown';
+  if (estimatedCapRoomAfterPending < 0) return 'overcommitted';
+  if (estimatedCapRoomAfterPending < 5) return 'tight';
+  if (estimatedCapRoomAfterPending < 15) return 'manageable';
+  return 'safe';
+}
+
+export function evaluatePendingOfferCapReservation({
+  team = {},
+  freeAgents = [],
+  players = null,
+  pendingOffers = [],
+  teamId = team?.id,
+  currentCapRoom: explicitCapRoom = null,
+  proposedOffer = null,
+} = {}) {
+  const currentCapRoom = resolveCurrentCapRoom(team, explicitCapRoom);
+  const sourcePlayers = Array.isArray(players) ? players : Array.isArray(freeAgents) ? freeAgents : [];
+  let rowInputs = sourcePlayers.flatMap((player) => normalizeOfferRowsFromPlayer(player, teamId));
+
+  if (Array.isArray(pendingOffers)) {
+    rowInputs = rowInputs.concat(pendingOffers.filter(Boolean).map((offer) => ({ player: offer?.player ?? {}, offer })));
+  }
+
+  if (proposedOffer?.player || proposedOffer?.offer) {
+    const proposedPlayerId = proposedOffer?.player?.id ?? proposedOffer?.offer?.playerId;
+    if (proposedOffer?.replaceExisting !== false && proposedPlayerId != null) {
+      rowInputs = rowInputs.filter(({ player, offer }) => (player?.id ?? offer?.playerId) !== proposedPlayerId);
+    }
+    rowInputs.push({ player: proposedOffer?.player ?? {}, offer: proposedOffer?.offer ?? proposedOffer });
+  }
+
+  const offerRows = rowInputs.map((input) => buildRow({ ...input, currentCapRoom }));
+  const pendingOfferCount = offerRows.length;
+  const knownRows = offerRows.filter((row) => row.annualValue != null);
+  const unknownCount = pendingOfferCount - knownRows.length;
+  const pendingAnnualCommitment = roundMoney(knownRows.reduce((sum, row) => sum + row.annualValue, 0)) ?? 0;
+  const estimatedCapRoomAfterPending = currentCapRoom == null ? null : roundMoney(currentCapRoom - pendingAnnualCommitment);
+  const capReservationStatus = resolveStatus({ currentCapRoom, pendingAnnualCommitment, estimatedCapRoomAfterPending, pendingOfferCount, unknownCount });
+  const { warnings, blockingReasons } = buildWarnings({ currentCapRoom, pendingAnnualCommitment, estimatedCapRoomAfterPending, unknownCount });
+
+  return {
+    currentCapRoom,
+    pendingAnnualCommitment,
+    pendingOfferCount,
+    estimatedCapRoomAfterPending,
+    capReservationStatus,
+    capReservationStatusLabel: STATUS_LABELS[capReservationStatus] ?? 'Unknown',
+    warnings,
+    blockingReasons,
+    unknownOfferCount: unknownCount,
+    offerRows,
+  };
+}
+
+export default evaluatePendingOfferCapReservation;

--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -53,6 +53,7 @@ import { formatDemandTier } from "../utils/offseasonActionCenter.js";
 import { buildFreeAgencyMarketAnalysis } from "../../core/freeAgency/freeAgencyMarketAnalysis.js";
 import { buildFreeAgencyProfileContext } from "../utils/playerProfileContext.js";
 import { buildContractOfferInsight, toneToContractInsightColor } from "../utils/contractOfferInsights.js";
+import { evaluatePendingOfferCapReservation } from "../../core/pendingOfferCapModel.js";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -334,6 +335,69 @@ export function ContractOfferInsightBlock({ player, capRoom, compact = false, sh
   );
 }
 
+
+const RESERVATION_TONE = Object.freeze({
+  safe: 'var(--success)',
+  manageable: 'var(--accent)',
+  tight: 'var(--warning)',
+  overcommitted: 'var(--danger)',
+  unknown: 'var(--text-muted)',
+});
+
+function formatCapValue(value) {
+  return Number.isFinite(Number(value)) ? `$${Number(value).toFixed(1)}M` : 'Unknown';
+}
+
+function CapImpactStat({ label, value, color = 'var(--text)' }) {
+  return (
+    <div style={{ border: '1px solid var(--hairline)', borderRadius: 'var(--radius-md)', padding: '8px 10px', background: 'var(--surface)' }}>
+      <div style={{ fontSize: 10, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.5px' }}>{label}</div>
+      <div style={{ fontSize: 'var(--text-sm)', fontWeight: 800, color, fontVariantNumeric: 'tabular-nums' }}>{value}</div>
+    </div>
+  );
+}
+
+export function PendingCapImpactPanel({ reservation }) {
+  const status = reservation?.capReservationStatus ?? 'unknown';
+  const tone = RESERVATION_TONE[status] ?? RESERVATION_TONE.unknown;
+  const rows = Array.isArray(reservation?.offerRows) ? reservation.offerRows : [];
+  return (
+    <Card className="card-premium" style={{ marginBottom: "var(--space-4)" }}>
+      <CardContent style={{ padding: "var(--space-4)", display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 10, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: "0.7px", fontWeight: 800 }}>Pending cap impact</div>
+            <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginTop: 3 }}>Annual cap reservation if every pending bid is accepted.</div>
+          </div>
+          <Badge variant="outline" style={{ color: tone, borderColor: tone, background: `${tone}14` }}>{reservation?.capReservationStatusLabel ?? 'Unknown'}</Badge>
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))", gap: 8 }}>
+          <CapImpactStat label="Current Room" value={formatCapValue(reservation?.currentCapRoom)} color={tone} />
+          <CapImpactStat label="Pending Offers" value={String(reservation?.pendingOfferCount ?? 0)} />
+          <CapImpactStat label="Annual Reserved" value={formatCapValue(reservation?.pendingAnnualCommitment)} color={reservation?.pendingAnnualCommitment > 0 ? "var(--warning)" : "var(--text)"} />
+          <CapImpactStat label="After Pending" value={formatCapValue(reservation?.estimatedCapRoomAfterPending)} color={tone} />
+        </div>
+        {rows.length > 0 ? (
+          <div style={{ display: "grid", gap: 4 }}>
+            {rows.slice(0, 4).map((row) => (
+              <div key={`${row.playerId ?? row.playerName}-${row.annualValue ?? 'unknown'}`} style={{ display: "flex", justifyContent: "space-between", gap: 8, fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
+                <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{row.playerName}</span>
+                <strong style={{ color: row.status === 'unknown' ? "var(--text-muted)" : "var(--text)", whiteSpace: "nowrap" }}>{row.status === 'unknown' ? 'Unknown annual' : `${formatCapValue(row.annualValue)} / yr`}{row.years ? ` · ${row.years}y` : ''}</strong>
+              </div>
+            ))}
+            {rows.length > 4 ? <div style={{ fontSize: "10px", color: "var(--text-subtle)" }}>+{rows.length - 4} more pending offer{rows.length - 4 === 1 ? '' : 's'}</div> : null}
+          </div>
+        ) : (
+          <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>No pending bids are reserving cap right now.</div>
+        )}
+        {(reservation?.warnings ?? []).map((warning) => (
+          <div key={warning} role="status" style={{ fontSize: "var(--text-xs)", color: status === 'overcommitted' ? "var(--danger)" : "var(--warning)", background: `${status === 'overcommitted' ? 'var(--danger)' : 'var(--warning)'}14`, border: `1px solid ${status === 'overcommitted' ? 'var(--danger)' : 'var(--warning)'}55`, borderRadius: "var(--radius-md)", padding: "8px 10px" }}>{warning}</div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
 // ── Cap banner ────────────────────────────────────────────────────────────────
 
 function CapBanner({ userTeam }) {
@@ -428,7 +492,7 @@ function CapBanner({ userTeam }) {
 // Renders as a full-width <td colSpan=7> in its own table row, appearing
 // directly below the highlighted player row (two-row pattern from Roster.jsx).
 
-function SignInlineForm({ player, capRoom, rosterCount = 53, rosterLimit = 53, onSubmit, onCancel, asDiv }) {
+export function SignInlineForm({ player, capRoom, rosterCount = 53, rosterLimit = 53, pendingCapContext = null, onSubmit, onCancel, asDiv }) {
   const defaultSalary = suggestedSalary(player.ovr, player.pos, player.age);
   const defaultYears = suggestedYears(player.age);
   const [annual, setAnnual] = useState(defaultSalary);
@@ -455,8 +519,20 @@ function SignInlineForm({ player, capRoom, rosterCount = 53, rosterLimit = 53, o
 
   const Wrapper = asDiv ? 'div' : 'td';
   const props = asDiv ? {} : { colSpan: 9 };
-  const postMoveCap = Number(capRoom) - Number(annual || 0);
+  const proposedReservation = useMemo(() => {
+    if (!pendingCapContext) return null;
+    return evaluatePendingOfferCapReservation({
+      ...pendingCapContext,
+      proposedOffer: {
+        player,
+        replaceExisting: true,
+        offer: { contract: { baseAnnual: Number(annual || 0), yearsTotal: Number(years || 1), signingBonus: 0 } },
+      },
+    });
+  }, [pendingCapContext, player, annual, years]);
+  const postMoveCap = proposedReservation?.estimatedCapRoomAfterPending ?? (Number(capRoom) - Number(annual || 0));
   const postMoveRoster = Number(rosterCount) + 1;
+  const projectedWarnings = proposedReservation?.warnings ?? [];
 
   return (
     <Wrapper
@@ -499,11 +575,14 @@ function SignInlineForm({ player, capRoom, rosterCount = 53, rosterLimit = 53, o
         </div>
         <div style={{ display: "grid", gap: 2, marginLeft: "auto", minWidth: 170 }}>
           <div style={{ fontSize: "10px", color: "var(--text-muted)" }}>
-            Cap after bid: <strong style={{ color: postMoveCap < 0 ? "var(--danger)" : "var(--text)" }}>${postMoveCap.toFixed(1)}M</strong>
+            Cap after all pending: <strong style={{ color: postMoveCap < 0 ? "var(--danger)" : postMoveCap < 5 ? "var(--warning)" : "var(--text)" }}>{formatCapValue(postMoveCap)}</strong>
           </div>
           <div style={{ fontSize: "10px", color: "var(--text-muted)" }}>
             Roster after signing: <strong style={{ color: postMoveRoster > rosterLimit ? "var(--warning)" : "var(--text)" }}>{postMoveRoster}/{rosterLimit}</strong>
           </div>
+          {projectedWarnings.slice(0, 1).map((warning) => (
+            <div key={warning} style={{ fontSize: "10px", color: postMoveCap < 0 ? "var(--danger)" : "var(--warning)" }}>{warning}</div>
+          ))}
         </div>
 
         {/* Inputs */}
@@ -601,7 +680,7 @@ function SignInlineForm({ player, capRoom, rosterCount = 53, rosterLimit = 53, o
 
 // ── Player Preview Bottom Sheet ──────────────────────────────────────────────
 
-function PlayerPreviewSheet({ player, capRoom, onClose, onSubmitBid }) {
+function PlayerPreviewSheet({ player, capRoom, pendingCapContext = null, onClose, onSubmitBid }) {
   const [phase, setPhase] = useState("view"); // "view" | "bid"
   const offers = player?.offers || {};
 
@@ -694,6 +773,7 @@ function PlayerPreviewSheet({ player, capRoom, onClose, onSubmitBid }) {
                 <SignInlineForm
                   player={player}
                   capRoom={capRoom}
+                  pendingCapContext={pendingCapContext}
                   asDiv
                   onCancel={() => setPhase("view")}
                   onSubmit={(c) => { onSubmitBid(player.id, c); onClose(); }}
@@ -824,6 +904,16 @@ export default function FreeAgency({
   }), [userTeam, evaluatedFaPool, capRoom, capUsed, deadCap]);
 
   const marketRowsById = useMemo(() => new Map((marketAnalysis?.marketRows ?? []).map((r) => [r.playerId, r])), [marketAnalysis]);
+  const pendingCapContext = useMemo(() => ({
+    team: userTeam,
+    freeAgents: evaluatedFaPool,
+    teamId: activeTeamId,
+    currentCapRoom: capRoom,
+  }), [userTeam, evaluatedFaPool, activeTeamId, capRoom]);
+  const pendingCapReservation = useMemo(
+    () => evaluatePendingOfferCapReservation(pendingCapContext),
+    [pendingCapContext],
+  );
 
   const displayed = useMemo(() => {
     const base = filterFreeAgentsForView(evaluatedFaPool, {
@@ -1094,6 +1184,7 @@ export default function FreeAgency({
       )}
 
       <CapBanner userTeam={userTeam} />
+      <PendingCapImpactPanel reservation={pendingCapReservation} />
 
       {flash && (
         <div
@@ -1538,6 +1629,7 @@ export default function FreeAgency({
                             <SignInlineForm
                               player={player}
                               capRoom={capRoom}
+                              pendingCapContext={pendingCapContext}
                               rosterCount={rosterCount}
                               rosterLimit={rosterLimit}
                               onCancel={() => setSigningPlayerId(null)}
@@ -1732,7 +1824,7 @@ export default function FreeAgency({
 
                         {isSigningThis ? (
                             <div style={{ borderTop: "1px solid var(--hairline)", paddingTop: "var(--space-3)", marginTop: "var(--space-2)" }}>
-                               <SignInlineForm player={player} capRoom={capRoom} rosterCount={rosterCount} rosterLimit={rosterLimit} asDiv onCancel={() => setSigningPlayerId(null)} onSubmit={(c) => handleSign(player.id, c)} />
+                               <SignInlineForm player={player} capRoom={capRoom} pendingCapContext={pendingCapContext} rosterCount={rosterCount} rosterLimit={rosterLimit} asDiv onCancel={() => setSigningPlayerId(null)} onSubmit={(c) => handleSign(player.id, c)} />
                             </div>
                         ) : (
                             <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
@@ -1766,6 +1858,7 @@ export default function FreeAgency({
         <PlayerPreviewSheet
           player={previewPlayer}
           capRoom={capRoom}
+          pendingCapContext={pendingCapContext}
           onClose={() => setPreviewPlayer(null)}
           onSubmitBid={handleSign}
         />

--- a/src/ui/components/__tests__/FreeAgencyPendingCapImpact.test.jsx
+++ b/src/ui/components/__tests__/FreeAgencyPendingCapImpact.test.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import { PendingCapImpactPanel, SignInlineForm } from '../FreeAgency.jsx';
+import { evaluatePendingOfferCapReservation } from '../../../core/pendingOfferCapModel.js';
+
+describe('FreeAgency pending cap impact UI', () => {
+  it('shows pending cap impact totals and mobile-safe labels', () => {
+    const reservation = evaluatePendingOfferCapReservation({
+      team: { id: 1, capRoom: 25 },
+      teamId: 1,
+      freeAgents: [{ id: 10, name: 'Cap WR', offers: { userOffered: true, userBidAnnual: 8.5, userBidYears: 2 } }],
+    });
+    const html = renderToString(<PendingCapImpactPanel reservation={reservation} />);
+    expect(html).toContain('Pending cap impact');
+    expect(html).toContain('Current Room');
+    expect(html).toContain('Annual Reserved');
+    expect(html).toContain('After Pending');
+    expect(html).toContain('$16.5M');
+    expect(html).toContain('Cap WR');
+  });
+
+  it('renders warning copy when pending offers overcommit cap', () => {
+    const reservation = evaluatePendingOfferCapReservation({
+      team: { id: 1, capRoom: 10 },
+      teamId: 1,
+      freeAgents: [{ id: 10, name: 'Cap QB', offers: { userOffered: true, userBidAnnual: 16, userBidYears: 3 } }],
+    });
+    const html = renderToString(<PendingCapImpactPanel reservation={reservation} />);
+    expect(html).toContain('Overcommitted');
+    expect(html).toContain('would exceed current cap room');
+  });
+
+  it('shows honest unknown fallback for legacy pending offers', () => {
+    const reservation = evaluatePendingOfferCapReservation({
+      team: { id: 1, capRoom: 10 },
+      teamId: 1,
+      freeAgents: [{ id: 10, name: 'Legacy Bid', offers: { userOffered: true } }],
+    });
+    const html = renderToString(<PendingCapImpactPanel reservation={reservation} />);
+    expect(html).toContain('Unknown annual');
+    expect(html).toContain('missing annual salary data');
+  });
+
+  it('keeps the primary bid action visible while showing projected pending warning', () => {
+    const pendingCapContext = {
+      team: { id: 1, capRoom: 12 },
+      teamId: 1,
+      currentCapRoom: 12,
+      freeAgents: [{ id: 99, name: 'Existing Bid', offers: { userOffered: true, userBidAnnual: 9, userBidYears: 1 } }],
+    };
+    const html = renderToString(
+      <SignInlineForm
+        player={{ id: 10, name: 'New Bid', pos: 'WR', age: 26, ovr: 76, _ask: 5 }}
+        capRoom={12}
+        pendingCapContext={pendingCapContext}
+        asDiv
+        onCancel={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+    expect(html).toContain('Cap after all pending');
+    expect(html).toContain('Confirm Bid');
+    expect(html).toContain('would exceed current cap room');
+  });
+});

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -5961,6 +5961,14 @@ async function handleGetFreeAgents(payload, id) {
             }
         }
 
+        const annualCapHitForOffer = (offer) => {
+            const c = offer?.contract ?? {};
+            const years = Math.max(1, Number(c.yearsTotal ?? c.years ?? 1));
+            const baseAnnual = Number(c.baseAnnual ?? c.annualSalary ?? c.annual ?? 0);
+            const signingBonus = Number(c.signingBonus ?? 0);
+            return Math.round((baseAnnual + (signingBonus / years)) * 10) / 10;
+        };
+
         // Calculate user's bid value if they have one
         let userBidValue = 0;
         if (userOffer) {
@@ -6088,9 +6096,11 @@ async function handleGetFreeAgents(payload, id) {
               topOfferValue: Math.round(topOfferValue * 10) / 10,
               topBidTeam: topBid ? topBid.teamName : null,
               topBidAnnual: topBid ? Math.round(topBid.contract.baseAnnual * 10) / 10 : 0,
+              topBidAnnualCapHit: topBid ? annualCapHitForOffer(topBid) : 0,
               topBidYears: topBid ? topBid.contract.yearsTotal : 0,
               topOfferContractModel: topBid?.contractModel ?? null,
               userBidAnnual: userOffer ? Math.round(userOffer.contract.baseAnnual * 10) / 10 : 0,
+              userBidAnnualCapHit: userOffer ? annualCapHitForOffer(userOffer) : 0,
               userBidYears: userOffer ? userOffer.contract.yearsTotal : 0,
               userOfferContractModel: userOffer?.contractModel ?? null,
               userBidValue: Math.round(userBidValue * 10) / 10,


### PR DESCRIPTION
### Motivation
- Free agency previously validated single offers but did not surface or aggregate the combined annual cap impact of multiple pending bids, leaving the user without a realistic view of how outstanding offers affect available cap room.  
- Provide a safe, read-only reservation layer (V1) that warns about portfolio-level cap pressure without changing contract guarantees, signing flows, or save compatibility.  
- Keep the feature deterministic, pure (helper only), and resilient to legacy/partial offer shapes so old saves and automated tests remain stable.

### Description
- Added a pure helper `src/core/pendingOfferCapModel.js` that reads pending offers from both raw `player.offers[]` and summarized UI shapes, and returns `{ currentCapRoom, pendingAnnualCommitment, pendingOfferCount, estimatedCapRoomAfterPending, capReservationStatus, capReservationStatusLabel, warnings, blockingReasons, unknownOfferCount, offerRows }`.  
- Integrated a compact UI panel `PendingCapImpactPanel` into `src/ui/components/FreeAgency.jsx` showing current room, pending offers, aggregated annual reserved, estimated room after pending, per-offer rows, a status chip (Safe / Manageable / Tight / Overcommitted / Unknown), and warnings; added a projected preview into `SignInlineForm` so a proposed bid shows "Cap after all pending" while keeping the primary confirm action.  
- Worker/UI plumbing: added an `annualCapHitForOffer` helper in `src/worker/worker.js` and exposed `userBidAnnualCapHit` / `topBidAnnualCapHit` in FA summary so the UI prefers annual cap-hit metadata when available.  
- Tests: added unit tests for the helper (`src/core/__tests__/pendingOfferCapModel.test.js`) and UI server-render tests (`src/ui/components/__tests__/FreeAgencyPendingCapImpact.test.jsx`).

### Testing
- Ran `npm ci` and `node --check` on changed support files; dependency install passed (npm audit warnings noted).  
- Unit tests: ran targeted unit subset and the full suite; `npm run test:unit` passed (187 files, 812 tests).  
- Soak/audit: `npm run test:soak` passed; `npm run audit:dynasty -- --ci --seed=1383` passed (no failures, one expected early-league HoF warning).  
- Build / deploy checks: `npm run build` and `npm run check:deploy` passed with expected Vite chunk-size warnings.  
- E2E smoke: `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` failed because Playwright Chromium was not available in the environment (browser download blocked by CDN 403); `npx playwright install` attempted but the browser archive download was blocked by the environment, so full Playwright E2E run was not completed.

Notes / deferred work: V1 intentionally does not implement guarantees, dead cap, multi-year per-year forecasting, restructures, franchise tags, RFA logic, or automated CPU portfolio throttling; those are out-of-scope and noted for follow-up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03704cdc10832d90d0b21e39c162ea)