### PR TITLE
Add Trade + Free Agency Market Realism V2

### DIFF
--- a/src/core/__tests__/aiFreeAgencyOffers.test.js
+++ b/src/core/__tests__/aiFreeAgencyOffers.test.js
@@ -354,6 +354,96 @@ describe('AiLogic.makeFreeAgencyOffers stale contract handling', () => {
     );
   });
 
+
+  it('pending offer cap reservation prevents CPU overcommitment on non-QB splash', async () => {
+    const pendingQb = {
+      id: 51,
+      name: 'Pending QB',
+      pos: 'QB',
+      status: 'free_agent',
+      ovr: 75,
+      age: 28,
+      offers: [{ teamId: 4, contract: { years: 1, yearsTotal: 1, baseAnnual: 8, signingBonus: 0 } }],
+    };
+    const rbFa = {
+      id: 52,
+      name: 'Costly RB',
+      pos: 'RB',
+      status: 'free_agent',
+      ovr: 79,
+      age: 28,
+      offers: [],
+    };
+    mockCache.getTeam.mockReturnValue({
+      id: 4,
+      name: 'Pending Tight',
+      abbr: 'PEN',
+      wins: 8,
+      losses: 8,
+      capRoom: 12,
+      capUsed: 288,
+      deadCap: 4,
+    });
+    mockCache.getPlayersByTeam.mockReturnValue([
+      { id: 401, pos: 'QB', ovr: 78, age: 29, potential: 78, contract: { years: 2 } },
+      { id: 402, pos: 'RB', ovr: 61, age: 24, potential: 64, contract: { years: 1 } },
+    ]);
+    mockCalculateExtensionDemand.mockImplementation((player) => {
+      if (player.id === 52) return { years: 2, yearsTotal: 2, baseAnnual: 9, signingBonus: 2 };
+      return { years: 1, yearsTotal: 1, baseAnnual: 8, signingBonus: 0 };
+    });
+
+    await AiLogic.makeFreeAgencyOffers(4, { QB: [pendingQb], RB: [rbFa] });
+
+    expect(mockCache.updatePlayer).not.toHaveBeenCalledWith(
+      52,
+      expect.objectContaining({ offers: expect.any(Array) }),
+    );
+  });
+
+  it('avoids duplicate expensive non-QB pending offers in the same position group', async () => {
+    const pendingWr = {
+      id: 61,
+      name: 'Pending WR',
+      pos: 'WR',
+      status: 'free_agent',
+      ovr: 80,
+      age: 27,
+      offers: [{ teamId: 5, contract: { years: 2, yearsTotal: 2, baseAnnual: 12, signingBonus: 0 } }],
+    };
+    const wrFa = {
+      id: 62,
+      name: 'Second WR',
+      pos: 'WR',
+      status: 'free_agent',
+      ovr: 78,
+      age: 27,
+      offers: [],
+    };
+    mockCache.getTeam.mockReturnValue({
+      id: 5,
+      name: 'Duplicate Watch',
+      abbr: 'DUP',
+      wins: 9,
+      losses: 8,
+      capRoom: 45,
+      capUsed: 250,
+      deadCap: 0,
+    });
+    mockCache.getPlayersByTeam.mockReturnValue([
+      { id: 501, pos: 'QB', ovr: 80, age: 29, potential: 80, contract: { years: 3 } },
+      { id: 502, pos: 'WR', ovr: 64, age: 25, potential: 68, contract: { years: 1 } },
+    ]);
+    mockCalculateExtensionDemand.mockReturnValue({ years: 2, yearsTotal: 2, baseAnnual: 11, signingBonus: 2 });
+
+    await AiLogic.makeFreeAgencyOffers(5, { WR: [pendingWr, wrFa] });
+
+    expect(mockCache.updatePlayer).not.toHaveBeenCalledWith(
+      62,
+      expect.objectContaining({ offers: expect.any(Array) }),
+    );
+  });
+
   it('calculateTeamNeeds keeps QB as high priority when QB room is weak', () => {
     mockCache.getTeam.mockReturnValue({
       id: 1,

--- a/src/core/__tests__/marketRealismModel.test.js
+++ b/src/core/__tests__/marketRealismModel.test.js
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { evaluatePlayerMarketRealism, adjustTradeValueForMarketRealism } from '../marketRealismModel.js';
+
+const team = (overrides = {}) => ({ id: 1, capRoom: 50, capTotal: 255, ...overrides });
+const strategy = (archetype = 'middle', priority = 55) => ({
+  archetype,
+  positionalNeeds: [{ positionGroup: 'QB', priority }, { positionGroup: 'DL_EDGE', priority }, { positionGroup: 'RB', priority }],
+});
+
+describe('Trade + Free Agency Market Realism V2 model', () => {
+  it('gives elite young QB/premium players high market demand', () => {
+    const out = evaluatePlayerMarketRealism({
+      player: { pos: 'QB', ovr: 90, potential: 95, age: 24 },
+      team: team({ capRoom: 120 }),
+      strategy: strategy('retool', 80),
+      positionalNeed: 1.8,
+      proposedAnnual: 45,
+    });
+
+    expect(out.marketDemandScore).toBeGreaterThanOrEqual(70);
+    expect(out.positionalPremium).toBe(100);
+    expect(out.reasons).toContain('premium position tax');
+    expect(out.shouldPursue).toBe(true);
+  });
+
+  it('keeps aging running backs as low or short-term demand assets', () => {
+    const out = evaluatePlayerMarketRealism({
+      player: { pos: 'RB', ovr: 82, potential: 82, age: 31 },
+      team: team({ capRoom: 45 }),
+      strategy: strategy('middle', 35),
+      positionalNeed: 1.1,
+      proposedAnnual: 8,
+    });
+
+    expect(out.marketDemandScore).toBeLessThan(55);
+    expect(out.ageRisk).toBeGreaterThanOrEqual(70);
+    expect(out.flags).toContain('age_risk');
+  });
+
+  it('flags old expensive veterans with high cap and age risk', () => {
+    const out = evaluatePlayerMarketRealism({
+      player: { pos: 'WR', ovr: 86, potential: 86, age: 33 },
+      team: team({ capRoom: 18 }),
+      strategy: strategy('rebuild', 60),
+      positionalNeed: 1.5,
+      proposedAnnual: 18,
+    });
+
+    expect(out.capRisk).toBeGreaterThanOrEqual(70);
+    expect(out.ageRisk).toBeGreaterThanOrEqual(45);
+    expect(out.shouldAvoid).toBe(true);
+    expect(out.reasons).toContain('rebuild avoids old expensive veteran');
+  });
+
+  it('treats young high-potential premium players as strong rebuild/retool fits', () => {
+    const out = evaluatePlayerMarketRealism({
+      player: { pos: 'CB', ovr: 76, potential: 88, age: 23 },
+      team: team({ capRoom: 38 }),
+      strategy: strategy('rebuild', 72),
+      positionalNeed: 1.7,
+      proposedAnnual: 9,
+    });
+
+    expect(out.teamFitTier).toMatch(/strong|good/);
+    expect(out.flags).toContain('rebuild_fit');
+    expect(out.shouldPursue).toBe(true);
+  });
+
+  it('scores low OVR depth players with low market demand', () => {
+    const out = evaluatePlayerMarketRealism({
+      player: { pos: 'LB', ovr: 61, potential: 63, age: 27 },
+      team: team(),
+      strategy: strategy('middle', 20),
+      positionalNeed: 1.05,
+      proposedAnnual: 1.2,
+    });
+
+    expect(out.marketDemandScore).toBeLessThan(35);
+    expect(out.shouldPursue).toBe(false);
+  });
+
+  it('lowers fit score for cap-stressed teams chasing expensive players', () => {
+    const player = { pos: 'DE', ovr: 84, potential: 86, age: 27 };
+    const healthy = evaluatePlayerMarketRealism({ player, team: team({ capRoom: 70 }), strategy: strategy('middle', 65), positionalNeed: 1.5, proposedAnnual: 16 });
+    const stressed = evaluatePlayerMarketRealism({ player, team: team({ capRoom: 12 }), strategy: strategy('middle', 65), positionalNeed: 1.5, proposedAnnual: 16 });
+
+    expect(stressed.fitScore).toBeLessThan(healthy.fitScore);
+    expect(stressed.capRisk).toBeGreaterThan(healthy.capRisk);
+  });
+
+  it('distinguishes contender veteran fit from rebuild veteran fit', () => {
+    const player = { pos: 'CB', ovr: 84, potential: 84, age: 32 };
+    const contender = evaluatePlayerMarketRealism({ player, team: team({ capRoom: 32 }), strategy: strategy('contender', 82), positionalNeed: 1.8, proposedAnnual: 11 });
+    const rebuild = evaluatePlayerMarketRealism({ player, team: team({ capRoom: 32 }), strategy: strategy('rebuild', 82), positionalNeed: 1.8, proposedAnnual: 11 });
+
+    expect(contender.shouldPursue).toBe(true);
+    expect(contender.reasons).toContain('contender rental');
+    expect(rebuild.shouldAvoid).toBe(true);
+    expect(rebuild.fitScore).toBeLessThan(contender.fitScore);
+  });
+
+  it('adds a premium tax so young premium players are not undervalued in trades', () => {
+    const base = 120;
+    const qb = adjustTradeValueForMarketRealism({ pos: 'QB', ovr: 78, potential: 90, age: 23, contract: { baseAnnual: 5 } }, base);
+    const rb = adjustTradeValueForMarketRealism({ pos: 'RB', ovr: 78, potential: 90, age: 29, contract: { baseAnnual: 5 } }, base);
+
+    expect(qb).toBeGreaterThan(base + 40);
+    expect(rb).toBeLessThan(base);
+  });
+});

--- a/src/core/__tests__/trade-logic.test.js
+++ b/src/core/__tests__/trade-logic.test.js
@@ -64,3 +64,43 @@ describe('shouldBlockCpuUniformPlayerSwap', () => {
   });
 });
 
+
+describe('Trade Market Realism V2 valuation guardrails', () => {
+  it('protects young premium quarterbacks from being undervalued', () => {
+    const youngQb = {
+      pos: 'QB',
+      ovr: 77,
+      potential: 90,
+      age: 23,
+      contract: { baseAnnual: 5 },
+    };
+    const veteranRb = {
+      pos: 'RB',
+      ovr: 84,
+      potential: 84,
+      age: 30,
+      contract: { baseAnnual: 9 },
+    };
+
+    expect(calculatePlayerValue(youngQb)).toBeGreaterThan(calculatePlayerValue(veteranRb));
+  });
+
+  it('contract burden lowers offer value for old expensive veterans', () => {
+    const reasonableVeteran = {
+      pos: 'CB',
+      ovr: 82,
+      potential: 82,
+      age: 31,
+      contract: { baseAnnual: 7 },
+    };
+    const burdenVeteran = {
+      pos: 'CB',
+      ovr: 82,
+      potential: 82,
+      age: 31,
+      contract: { baseAnnual: 24 },
+    };
+
+    expect(calculatePlayerValue(burdenVeteran)).toBeLessThan(calculatePlayerValue(reasonableVeteran));
+  });
+});

--- a/src/core/ai-logic.js
+++ b/src/core/ai-logic.js
@@ -18,6 +18,8 @@ import { evaluateContractOffer } from './contracts/negotiation.js';
 import { evaluateReSigningPriority } from './retention/reSigning.js';
 import { buildFreeAgencyMarketAnalysis } from './freeAgency/freeAgencyMarketAnalysis.js';
 import { buildContractFromMarket, evaluateContractMarket } from './contractModel.js';
+import { evaluatePendingOfferCapReservation } from './pendingOfferCapModel.js';
+import { evaluatePlayerMarketRealism, normalizePositionGroup } from './marketRealismModel.js';
 
 class AiLogic {
     static NEED_GROUP_TO_POS = Object.freeze({
@@ -482,6 +484,25 @@ class AiLogic {
             return legacyGetCandidates(pos);
         };
 
+
+        const hasDuplicateExpensivePendingOffer = (pos, proposedCapHit) => {
+            if (pos === 'QB' || proposedCapHit < 10 || !freeAgentsMap) return false;
+            const group = normalizePositionGroup(pos);
+            return Object.values(freeAgentsMap)
+                .flat()
+                .filter(Boolean)
+                .some((player) => {
+                    if (normalizePositionGroup(player?.pos) !== group) return false;
+                    return Array.isArray(player?.offers) && player.offers.some((offer) => {
+                        if (Number(offer?.teamId) !== Number(teamId)) return false;
+                        const c = offer?.contract ?? {};
+                        const years = Math.max(1, Number(c.yearsTotal ?? c.years ?? 1));
+                        const annual = Number(c.baseAnnual ?? 0) + (Number(c.signingBonus ?? 0) / years);
+                        return annual >= 10;
+                    });
+                });
+        };
+
         // 4. Attempt to fill each high need position
         for (const pos of highNeedPositions) {
             const candidates = getCandidatesForPos(pos);
@@ -520,6 +541,19 @@ class AiLogic {
                 if (strategy?.archetype === 'retool' && age >= 31 && oldExpensiveNonQb) continue;
                 if (marketRiskTags.includes('long veteran commitment') && ['rebuild', 'development', 'retool'].includes(strategy?.archetype)) continue;
 
+                const qbDesperate = pos === 'QB' && Number(needs.QB ?? 0) >= 1.12;
+                const realism = evaluatePlayerMarketRealism({
+                    player: fa,
+                    team,
+                    roster: strategy?.roster ?? cache.getPlayersByTeam(teamId),
+                    strategy,
+                    positionalNeed: needs[pos] ?? 1,
+                    capRoom: team.capRoom,
+                    proposedAnnual: modelAnnualForRisk,
+                    action: 'free_agency',
+                });
+                if (realism.shouldAvoid && !realism.flags.includes('qb_need_exception') && !qbDesperate) continue;
+
                 const demandYears = Math.max(1, Number(demand?.yearsTotal ?? demand?.years ?? market.suggestedYears ?? 1));
                 const modelAnnual = Number(market.suggestedAnnual ?? demandAnnual);
                 const baseAnnual = Math.round(Math.min(modelAnnual, demandAnnual * 1.08) * 10) / 10;
@@ -534,6 +568,21 @@ class AiLogic {
                 offerContract.years = offerContract.yearsTotal;
 
                 const capHit = offerContract.baseAnnual + (offerContract.signingBonus / offerContract.yearsTotal);
+                if (hasDuplicateExpensivePendingOffer(pos, capHit)) continue;
+
+                const pendingCap = evaluatePendingOfferCapReservation({
+                    team,
+                    freeAgents: freeAgentsMap ? Object.values(freeAgentsMap).flat().filter(Boolean) : [],
+                    teamId,
+                    currentCapRoom: team.capRoom,
+                    proposedOffer: { player: fa, offer: { teamId, contract: offerContract } },
+                });
+                const pendingAfter = Number(pendingCap?.estimatedCapRoomAfterPending ?? team.capRoom);
+                const pendingStatus = pendingCap?.capReservationStatus;
+                const pendingBlocks = ['overcommitted'].includes(pendingStatus) || pendingAfter < 0;
+                const pendingQbException = pos === 'QB' && Number(needs.QB ?? 0) >= 1.12 && pendingAfter >= -2;
+                if (pendingBlocks && !pendingQbException) continue;
+
                 const capHealth = Number(strategy?.capHealth ?? 55);
                 let capLimit = strategy?.archetype === 'contender'
                     ? 0.74
@@ -545,9 +594,8 @@ class AiLogic {
                 if (capHealth < 28) capLimit *= 0.68;
                 else if (capHealth < 40) capLimit *= 0.86;
                 const maxAllowedHit = Math.max(3, Number(team.capRoom ?? 0) * capLimit);
-                const qbDesperate = pos === 'QB' && Number(needs.QB ?? 0) >= 1.12;
                 if (!urgentPos && capHit > maxAllowedHit) {
-                    const qbException = qbDesperate && market.controlledException && capHit <= maxAllowedHit * 1.28 && capHealth >= 18;
+                    const qbException = qbDesperate && (market.controlledException || realism.flags.includes('qb_need_exception')) && capHit <= maxAllowedHit * 1.8;
                     if (!qbException) continue;
                 }
 
@@ -562,7 +610,16 @@ class AiLogic {
                             marketTier: market.marketTier,
                             capFit: market.capFit,
                             riskTags: market.riskTags,
-                            reasons: market.reasons,
+                            reasons: [...new Set([...(market.reasons ?? []), ...(realism.reasons ?? [])])],
+                            marketRealism: {
+                                marketDemandScore: realism.marketDemandScore,
+                                fitScore: realism.fitScore,
+                                capRisk: realism.capRisk,
+                                ageRisk: realism.ageRisk,
+                                contractBurden: realism.contractBurden,
+                                teamFitTier: realism.teamFitTier,
+                                flags: realism.flags,
+                            },
                         },
                         timestamp: Date.now()
                     };

--- a/src/core/marketRealismModel.js
+++ b/src/core/marketRealismModel.js
@@ -1,0 +1,208 @@
+import { Constants } from './constants.js';
+
+const clamp = (v, min = 0, max = 100) => Math.max(min, Math.min(max, v));
+const num = (v, fb = 0) => (Number.isFinite(Number(v)) ? Number(v) : fb);
+
+export const PREMIUM_POSITIONS = Object.freeze(['QB', 'OT', 'EDGE', 'DE', 'CB', 'WR', 'DL']);
+const LOW_PREMIUM_POSITIONS = Object.freeze(['RB', 'K', 'P']);
+const REBUILD_ARCHETYPES = Object.freeze(['rebuild', 'development', 'rebuilding']);
+const WIN_NOW_ARCHETYPES = Object.freeze(['contender', 'playoff_hunt', 'desperate']);
+
+export function normalizePositionGroup(pos = '') {
+  const p = String(pos || '').toUpperCase();
+  if (['OT', 'OG', 'C', 'G', 'T'].includes(p)) return 'OL';
+  if (['DE', 'DT', 'EDGE', 'NT', 'DL'].includes(p)) return 'DL_EDGE';
+  if (['MLB', 'OLB'].includes(p)) return 'LB';
+  if (['SS', 'FS'].includes(p)) return 'S';
+  if (['K', 'P'].includes(p)) return 'KP';
+  return p;
+}
+
+export function getAnnualContractCost(player = {}, explicitAnnual = null) {
+  if (explicitAnnual != null && Number.isFinite(Number(explicitAnnual))) return num(explicitAnnual);
+  const contract = player?.contract ?? {};
+  const base = num(contract.baseAnnual ?? player.baseAnnual, 0);
+  const bonus = num(contract.signingBonus, 0);
+  const years = Math.max(1, num(contract.yearsTotal ?? contract.years ?? player.years, 1));
+  return Math.round((base + bonus / years) * 10) / 10;
+}
+
+export function getPositionalPremium(pos = '') {
+  const p = String(pos || '').toUpperCase();
+  if (p === 'QB') return 100;
+  if (['OT', 'EDGE', 'DE', 'CB', 'WR'].includes(p)) return 82;
+  if (['DL', 'DT'].includes(p)) return 72;
+  if (['OL', 'TE', 'S'].includes(p)) return 58;
+  if (['LB'].includes(p)) return 50;
+  if (p === 'RB') return 34;
+  if (['K', 'P'].includes(p)) return 16;
+  return 45;
+}
+
+function inferNeedScore({ positionalNeed = 1, strategy = {}, player = {} }) {
+  const group = normalizePositionGroup(player.pos);
+  const matchingNeed = Array.isArray(strategy?.positionalNeeds)
+    ? strategy.positionalNeeds.find((row) => normalizePositionGroup(row?.positionGroup) === group)
+    : null;
+  const priority = matchingNeed ? num(matchingNeed.priority, 0) : clamp((num(positionalNeed, 1) - 1) * 100, 0, 100);
+  return clamp(Math.max(priority, clamp((num(positionalNeed, 1) - 1) * 110, 0, 100)), 0, 100);
+}
+
+function inferCapRoom({ team = {}, capRoom = null }) {
+  if (capRoom != null && Number.isFinite(Number(capRoom))) return num(capRoom);
+  return num(team?.capRoom, 0);
+}
+
+export function evaluatePlayerMarketRealism({
+  player = {},
+  team = {},
+  roster = [],
+  strategy = {},
+  positionalNeed = 1,
+  capRoom = null,
+  proposedAnnual = null,
+  action = 'free_agency',
+} = {}) {
+  const pos = String(player?.pos ?? '').toUpperCase();
+  const positionGroup = normalizePositionGroup(pos);
+  const archetype = String(strategy?.archetype ?? strategy?.teamArchetype ?? team?.archetype ?? 'middle');
+  const ovr = num(player?.ovr, 60);
+  const potential = num(player?.potential, ovr);
+  const age = num(player?.age, 27);
+  const annualCost = getAnnualContractCost(player, proposedAnnual);
+  const room = inferCapRoom({ team, capRoom });
+  const capTotal = Math.max(1, num(team?.capTotal ?? Constants?.SALARY_CAP?.HARD_CAP, 255));
+  const capPct = annualCost / capTotal;
+  const roomPct = room <= 0 ? 1 : annualCost / Math.max(1, room);
+  const positionalPremium = getPositionalPremium(pos);
+  const premiumPosition = PREMIUM_POSITIONS.includes(pos);
+  const lowPremiumPosition = LOW_PREMIUM_POSITIONS.includes(pos);
+  const needScore = inferNeedScore({ positionalNeed, strategy, player });
+  const rosterAtPos = Array.isArray(roster) ? roster.filter((p) => normalizePositionGroup(p?.pos) === positionGroup) : [];
+  const expensiveSameGroup = rosterAtPos.filter((p) => getAnnualContractCost(p) >= 10).length;
+
+  const ageRisk = pos === 'QB'
+    ? clamp((age - 32) * 12, 0, 100)
+    : pos === 'RB'
+      ? clamp((age - 26) * 18, 0, 100)
+      : clamp((age - 29) * 12, 0, 100);
+  const capRisk = clamp(roomPct * 72 + capPct * 120 + (room < 8 ? 16 : 0), 0, 100);
+  const contractBurden = clamp(annualCost * (premiumPosition ? 1.35 : lowPremiumPosition ? 2.25 : 1.75), 0, 100);
+  const youthUpside = clamp((26 - age) * 8 + Math.max(0, potential - ovr) * 4, 0, 100);
+  const quality = clamp((ovr - 58) * 2.2 + Math.max(0, potential - ovr) * (age <= 25 ? 2.8 : 0.9), 0, 100);
+
+  let marketDemandScore = clamp(quality * 0.48 + positionalPremium * 0.26 + youthUpside * 0.18 - ageRisk * 0.22 - contractBurden * 0.14, 0, 100);
+  if (pos === 'QB' && ovr >= 74) marketDemandScore += 10;
+  if (pos === 'RB' && age >= 29) marketDemandScore -= 16;
+  if (ovr < 66) marketDemandScore -= 18;
+  marketDemandScore = clamp(Math.round(marketDemandScore), 0, 100);
+
+  let archetypeFit = 50;
+  if (WIN_NOW_ARCHETYPES.includes(archetype)) {
+    archetypeFit += ovr >= 76 ? 16 : 0;
+    archetypeFit += needScore >= 60 ? 14 : 0;
+    archetypeFit -= ageRisk >= 70 ? 10 : 0;
+  } else if (REBUILD_ARCHETYPES.includes(archetype)) {
+    archetypeFit += youthUpside * 0.32;
+    archetypeFit += premiumPosition && age <= 26 ? 12 : 0;
+    archetypeFit -= ageRisk * 0.35;
+    archetypeFit -= contractBurden * 0.18;
+  } else if (archetype === 'retool') {
+    archetypeFit += youthUpside * 0.22;
+    archetypeFit -= ageRisk * 0.25;
+    archetypeFit -= contractBurden * 0.12;
+  } else {
+    archetypeFit += quality * 0.12 + needScore * 0.12 - capRisk * 0.14;
+  }
+
+  let fitScore = clamp(
+    marketDemandScore * 0.34 + needScore * 0.3 + archetypeFit * 0.24 + positionalPremium * 0.12 - capRisk * 0.28,
+    0,
+    100,
+  );
+
+  const reasons = [];
+  const flags = [];
+  if (premiumPosition) { reasons.push('premium position tax'); flags.push('premium_position'); }
+  if (needScore >= 70) { reasons.push('need match'); flags.push('severe_need'); }
+  if (capRisk >= 70) { reasons.push('cap burden'); flags.push('cap_burden'); }
+  if (ageRisk >= 70) { reasons.push('age risk'); flags.push('age_risk'); }
+  if (REBUILD_ARCHETYPES.includes(archetype) && age <= 26 && premiumPosition) { reasons.push('rebuild fit'); flags.push('rebuild_fit'); }
+  if (WIN_NOW_ARCHETYPES.includes(archetype) && age >= 30 && needScore >= 60) { reasons.push('contender rental'); flags.push('contender_rental'); }
+  if (expensiveSameGroup > 0 && annualCost >= 10 && pos !== 'QB') { reasons.push('duplicate expensive position spend'); flags.push('duplicate_expensive_position'); }
+
+  const oldExpensiveVeteran = age >= (pos === 'QB' ? 34 : 31) && annualCost >= (pos === 'QB' ? 18 : 10);
+  const lowNeedDepthSplash = needScore < 35 && annualCost >= 8 && ovr < 82;
+  const capStressedSplash = capRisk >= 78 && annualCost >= 8 && !(pos === 'QB' && needScore >= 75);
+  const rebuildVetAvoid = REBUILD_ARCHETYPES.includes(archetype) && oldExpensiveVeteran;
+  const duplicateAvoid = action === 'free_agency' && flags.includes('duplicate_expensive_position') && needScore < 78;
+  const qbNeedException = pos === 'QB' && needScore >= 75 && ovr >= 70 && capRisk < 92;
+  const contenderVeteranException = WIN_NOW_ARCHETYPES.includes(archetype) && needScore >= 65 && age >= 30 && capRisk < 78;
+
+  let shouldAvoid = rebuildVetAvoid || lowNeedDepthSplash || capStressedSplash || duplicateAvoid;
+  if (qbNeedException || contenderVeteranException) shouldAvoid = false;
+  const shouldPursue = !shouldAvoid && fitScore >= 46 && (needScore >= 45 || marketDemandScore >= 68 || qbNeedException);
+
+  if (shouldAvoid && rebuildVetAvoid) reasons.push('rebuild avoids old expensive veteran');
+  if (shouldAvoid && capStressedSplash) reasons.push('cap-stressed team avoids non-QB splash');
+  if (qbNeedException) { reasons.push('severe QB need exception'); flags.push('qb_need_exception'); }
+
+  if (shouldAvoid) fitScore = clamp(fitScore - 22, 0, 100);
+
+  const teamFitTier = fitScore >= 78 ? 'strong' : fitScore >= 60 ? 'good' : fitScore >= 42 ? 'borderline' : 'poor';
+
+  return {
+    marketDemandScore,
+    fitScore: Math.round(fitScore),
+    capRisk: Math.round(capRisk),
+    ageRisk: Math.round(ageRisk),
+    contractBurden: Math.round(contractBurden),
+    positionalPremium,
+    premiumPosition,
+    teamFitTier,
+    shouldPursue,
+    shouldAvoid,
+    reasons: [...new Set(reasons)],
+    flags: [...new Set(flags)],
+    positionGroup,
+    needScore: Math.round(needScore),
+    annualCost,
+  };
+}
+
+export function adjustTradeValueForMarketRealism(player = {}, baseValue = 0) {
+  const age = num(player?.age, 27);
+  const ovr = num(player?.ovr, 60);
+  const potential = num(player?.potential, ovr);
+  const pos = String(player?.pos ?? '').toUpperCase();
+  const premium = getPositionalPremium(pos);
+  let adjusted = num(baseValue, 0);
+  if (premium >= 80 && age <= 26) adjusted += 18 + Math.max(0, potential - ovr) * 2.5;
+  if (pos === 'QB' && age <= 28 && ovr >= 74) adjusted += 28;
+  if (pos === 'RB' && age >= 28) adjusted -= (age - 27) * 8;
+  adjusted -= Math.max(0, getAnnualContractCost(player) - (premium >= 80 ? 22 : 12)) * (premium >= 80 ? 1.3 : 2.2);
+  return Math.max(0, Math.round(adjusted * 10) / 10);
+}
+
+export function evaluateTradeActionRealism({ acquiringTeam = {}, acquiringRoster = [], acquiringStrategy = {}, player = {}, positionalNeed = 1 } = {}) {
+  return evaluatePlayerMarketRealism({
+    player,
+    team: acquiringTeam,
+    roster: acquiringRoster,
+    strategy: acquiringStrategy,
+    positionalNeed,
+    capRoom: acquiringTeam?.capRoom,
+    action: 'trade',
+  });
+}
+
+export function buildTradeRealismReasonTags(realism = {}) {
+  return (realism?.reasons ?? []).filter((reason) => [
+    'cap burden',
+    'rebuild fit',
+    'contender rental',
+    'premium position tax',
+    'age risk',
+    'need match',
+  ].includes(reason));
+}

--- a/src/core/trade-logic.js
+++ b/src/core/trade-logic.js
@@ -29,6 +29,11 @@ import NewsEngine       from './news-engine.js';
 import { Constants }    from './constants.js';
 import { Utils as U }   from './utils.js';
 import { buildAiTeamStrategy } from './aiTeamStrategy.js';
+import {
+  adjustTradeValueForMarketRealism,
+  buildTradeRealismReasonTags,
+  evaluateTradeActionRealism,
+} from './marketRealismModel.js';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -101,7 +106,7 @@ export function calculatePlayerValue(player) {
   const ovrWeight = age <= 25 ? 0.8 : 1.5;
 
   const rawValue = ((ovr * ovrWeight) + (pot * potWeight)) * posMult;
-  return Math.max(0, rawValue - agePenalty - contractPenalty);
+  return adjustTradeValueForMarketRealism(player, Math.max(0, rawValue - agePenalty - contractPenalty));
 }
 
 // ── Roster Analysis ───────────────────────────────────────────────────────────
@@ -251,10 +256,21 @@ export async function runAIToAITrades() {
   // Randomise order so the same teams don't always trade first.
   const shuffled = U.shuffle([...allTeams]);
 
-  // Build surplus/need map upfront — avoids repeated roster scans.
+  // Build surplus/need/strategy maps upfront — avoids repeated roster scans.
   const surplusMap = {};
   const needsMap   = {};
+  const rosterMap = {};
+  const strategyMap = {};
   for (const team of shuffled) {
+    const roster = cache.getPlayersByTeam(team.id);
+    rosterMap[team.id] = roster;
+    strategyMap[team.id] = buildAiTeamStrategy({
+      team,
+      roster,
+      league: { year: meta?.year, phase: meta?.phase },
+      phase: meta?.phase,
+      year: meta?.year,
+    });
     surplusMap[team.id] = getSurplusPlayers(team.id);
     needsMap[team.id]   = getTeamNeeds(team.id);
   }
@@ -301,8 +317,33 @@ export async function runAIToAITrades() {
       // Both players must have positive value (sanity check).
       if (valueA <= 0 || valueB <= 0) continue;
 
-      // Check trade fairness: values must be within ±VALUE_TOLERANCE.
-      const ratio = valueA / valueB;
+      const realismForTeamA = evaluateTradeActionRealism({
+        acquiringTeam: teamA,
+        acquiringRoster: rosterMap[teamA.id] ?? [],
+        acquiringStrategy: strategyMap[teamA.id] ?? {},
+        player: playerFromB,
+        positionalNeed: 1 + Number(topNeed?.urgency ?? 0) / 50,
+      });
+      const realismForTeamB = evaluateTradeActionRealism({
+        acquiringTeam: teamB,
+        acquiringRoster: rosterMap[teamB.id] ?? [],
+        acquiringStrategy: strategyMap[teamB.id] ?? {},
+        player: playerFromA,
+        positionalNeed: 1 + Number(teamBTopNeed?.urgency ?? 0) / 50,
+      });
+      if (realismForTeamA.shouldAvoid || realismForTeamB.shouldAvoid) continue;
+
+      const directionlessVeteranSwap = Number(playerFromA?.age ?? 27) >= 30
+        && Number(playerFromB?.age ?? 27) >= 30
+        && (realismForTeamA.capRisk >= 55 || realismForTeamB.capRisk >= 55)
+        && !realismForTeamA.flags.includes('contender_rental')
+        && !realismForTeamB.flags.includes('contender_rental');
+      if (directionlessVeteranSwap) continue;
+
+      // Check trade fairness: values must be within ±VALUE_TOLERANCE after team-fit realism.
+      const teamAIncomingValue = valueB * (0.72 + realismForTeamA.fitScore / 100);
+      const teamBIncomingValue = valueA * (0.72 + realismForTeamB.fitScore / 100);
+      const ratio = teamAIncomingValue / teamBIncomingValue;
       if (ratio < (1 - VALUE_TOLERANCE) || ratio > (1 + VALUE_TOLERANCE)) continue;
 
       if (shouldBlockCpuUniformPlayerSwap(playerFromA, playerFromB)) continue;
@@ -647,7 +688,15 @@ export function generateAITradeProposalsForUser({
 
     const offerType = computeOfferType({ userDirection, aiDirection, userCapRoom, week });
     const urgency = nearDeadline && aiDirection === 'contender' ? 'high' : aiDirection === 'desperate' ? 'high' : 'medium';
-    const reason = offerReasonCopy(offerType, aiTeam.abbr, topUserNeed.pos, week);
+    const offerRealism = evaluateTradeActionRealism({
+      acquiringTeam: userTeam,
+      acquiringRoster: cache.getPlayersByTeam(userTeamId),
+      acquiringStrategy: buildAiTeamStrategy({ team: userTeam, roster: cache.getPlayersByTeam(userTeamId), league: { year: meta?.year, phase: meta?.phase }, phase: meta?.phase, year: meta?.year }),
+      player: aiOfferCandidate.player,
+      positionalNeed: 1 + Number(topUserNeed?.urgency ?? 0) / 50,
+    });
+    const realismTags = buildTradeRealismReasonTags(offerRealism);
+    const reason = [offerReasonCopy(offerType, aiTeam.abbr, topUserNeed.pos, week), ...realismTags].join(' · ');
     const stance = stanceCopy(aiDirection, offerType, nearDeadline);
     const offeringPickSnapshots = [];
     const receivingPickSnapshots = [];

--- a/src/core/trades/tradeFinderAnalysis.js
+++ b/src/core/trades/tradeFinderAnalysis.js
@@ -1,4 +1,5 @@
 import { calculatePlayerValue } from '../trade-logic.js';
+import { buildTradeRealismReasonTags, evaluatePlayerMarketRealism } from '../marketRealismModel.js';
 import { FOOTBALL_ROSTER_CONFIG } from '../sports/footballRosterConfig.js';
 
 const PREMIUM_POS = new Set(['QB', 'WR', 'OL', 'DL', 'CB']);
@@ -173,12 +174,21 @@ function buildIdea({ need, target, outgoingAssets, teams, cap, packageType }) {
   const valueMatch = classifyValueMatch(valueDelta);
   const capData = calculatePackageCapImpact({ target, outgoingAssets, cap });
   const warnings = buildPackageWarnings({ outgoingAssets, valueMatch });
+  const realism = evaluatePlayerMarketRealism({
+    player: target,
+    team: teams.find((x) => num(x.id) === num(target.teamId)) ?? {},
+    roster: [],
+    positionalNeed: need.needLevel === 'urgent' ? 1.7 : 1.25,
+    action: 'trade_finder',
+  });
+  const realismReasons = buildTradeRealismReasonTags(realism);
   const feasibilityLabel = classifyFeasibility({ valueMatch, warnings, capImpact: capData.capImpact });
   const confidenceReasons = [];
   if (valueMatch === 'fair') confidenceReasons.push('Near fair value package.');
   if (need.needLevel === 'urgent') confidenceReasons.push(`Addresses urgent ${need.pos} need.`);
   if (capData.capImpact != null && capData.capImpact > 6) confidenceReasons.push('Cap cost is significant.');
   if (warnings.includes(PREMIUM_PICK_WARNING)) confidenceReasons.push('Premium pick included.');
+  confidenceReasons.push(...realismReasons);
   if (valueMatch === 'expensive' || valueMatch === 'unrealistic') confidenceReasons.push('Package remains short on value.');
   const confidence = feasibilityLabel === 'likely_reasonable' && !warnings.includes(PREMIUM_PICK_WARNING) ? 'high' : feasibilityLabel === 'long_shot' || feasibilityLabel === 'cap_constrained' || feasibilityLabel === 'overpay_risk' ? 'low' : 'medium';
   return {


### PR DESCRIPTION
### Motivation
- CPU free agency and AI trade flows were overly brittle and often produced unrealistic roster movement because decisions were driven mainly by need/cap-band thresholds and symmetric trade-value checks.
- The intent is to add a focused, deterministic realism layer that biases CPU moves by archetype, cap pressure, age/contract risk, positional premium and market demand without rewriting existing systems. 
- Changes must be small, testable, preserve old saves/determinism, respect the pending-offer cap helper, and avoid heavy UI or economy-wide rewrites. 

### Description
- Added a pure helper `src/core/marketRealismModel.js` that evaluates `marketDemandScore`, `fitScore`, `capRisk`, `ageRisk`, `contractBurden`, `positionalPremium`, `teamFitTier`, `shouldPursue`/`shouldAvoid`, `reasons` and `flags`, plus `adjustTradeValueForMarketRealism` and trade-evaluation helpers. 
- Wired the model into free agency offer generation (`src/core/ai-logic.js`) so CPU FA offers now: consult the realism model, skip duplicate expensive same-group pending offers, respect pending-offer cap reservation via `evaluatePendingOfferCapReservation`, and allow controlled QB exceptions for severe need. 
- Integrated market realism into trades (`src/core/trade-logic.js` and `src/core/trades/tradeFinderAnalysis.js`) by applying premium-player value protection in `calculatePlayerValue`, evaluating acquiring-team fit when matching, blocking directionless veteran-for-veteran swaps, and appending realism tags to AI trade proposals. 
- Kept changes localized to helpers and decision points only, preserved transaction logging, deterministic behavior, and added lightweight reason tags used by trade finder/presenter (no UI overhaul). 

### Testing
- Ran `npm ci`, `node --check src/core/marketRealismModel.js` and checked updated core files with no syntax errors. 
- Ran targeted unit tests: `npm run test:unit -- src/core/__tests__/marketRealismModel.test.js` and `npm run test:unit -- src/core/__tests__/contractModel.test.js src/core/__tests__/aiFreeAgencyOffers.test.js src/core/__tests__/aiTeamStrategy.test.js src/core/__tests__/trade-logic.test.js` and all passed. 
- Ran full unit suite `npm run test:unit` (188 files, 824 tests) and soak `npm run test:soak` (dynasty soak subset) and both passed; also ran `npm run build` and `npm run check:deploy` which passed (build emitted existing chunk-size warning). 
- Ran dynasty audit `npm run audit:dynasty -- --ci --seed=1383` which passed (runtime ~18174ms, failures=0, one expected HOF warning). 
- E2E smoke `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` could not complete because Playwright Chromium was not available in this environment and `npx playwright install --with-deps chromium` failed to download browsers from `cdn.playwright.dev` with `403 Domain forbidden`, so Playwright E2E was not run here. 

Risks / Follow-ups
- We intentionally preserved existing random gating and offer formats; long-run tuning across many dynasty runs is recommended before broad difficulty changes. 
- Deferred work: full multi-year cap forecasting, guarantees/dead-cap/restructures/franchise tags/comp-picks, and more aggressive trade-proposal generation refinements. 

Before/After examples (high level)
- Contender pursuing veteran: contender archetypes can now classify some veteran signings as `contender rental` and will pursue them if `marketRealism` and cap fit allow. 
- Rebuild rejecting old expensive player: rebuild/development archetypes will mark old expensive veterans as `shouldAvoid` and avoid bidding/trading for them. 
- Severe QB need exception: teams with severe QB need can make a controlled exception while still being guarded by pending-offer cap reservation. 
- Premium young player valuation: young premium QBs and other premium positions receive a value uplift so they are less likely to be undervalued or moved cheaply. 

If you want, I can split tuning constants into a small config file next so we can iterate weights without code edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0378953ad8832daf90c72ef0ac0e5b)