### PR TITLE
Add Economy Regression Audit + CI Reporting (V1)

### DIFF
--- a/src/core/__tests__/economyRegressionAudit.test.js
+++ b/src/core/__tests__/economyRegressionAudit.test.js
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { summarizeEconomyRegressionSnapshot } from '../economyRegressionAudit.js';
+
+const team = (overrides = {}) => ({ id: 1, name: 'Team', capRoom: 30, capUsed: 225, capTotal: 255, archetype: 'middle', ...overrides });
+const offer = (overrides = {}) => ({ teamId: 1, contract: { baseAnnual: 12, yearsTotal: 1, signingBonus: 0 }, ...overrides });
+const player = (overrides = {}) => ({ id: 101, name: 'Player', pos: 'WR', age: 27, ovr: 78, potential: 78, offers: [], ...overrides });
+
+describe('economy regression audit summary', () => {
+  it('counts overcommitted pending offers', () => {
+    const out = summarizeEconomyRegressionSnapshot({
+      teams: [team({ capRoom: 12 })],
+      freeAgents: [
+        player({ id: 1, offers: [offer({ contract: { baseAnnual: 9, yearsTotal: 1 } })] }),
+        player({ id: 2, pos: 'CB', offers: [offer({ contract: { baseAnnual: 8, yearsTotal: 1 } })] }),
+      ],
+    });
+
+    expect(out.teamsWithPendingOfferOvercommit).toBe(1);
+    expect(out.pendingOfferOvercommitCount).toBe(2);
+    expect(out.pendingOfferTeamSummaries[0].capReservationStatus).toBe('overcommitted');
+  });
+
+  it('flags duplicate expensive same-position/group CPU offers', () => {
+    const out = summarizeEconomyRegressionSnapshot({
+      teams: [team()],
+      freeAgents: [
+        player({ id: 1, pos: 'OT', offers: [offer({ contract: { baseAnnual: 16, yearsTotal: 2 } })] }),
+        player({ id: 2, pos: 'OG', offers: [offer({ contract: { baseAnnual: 14, yearsTotal: 2 } })] }),
+      ],
+    });
+
+    expect(out.duplicateExpensiveSameGroupOffers).toBe(1);
+    expect(out.duplicateExpensiveSameGroupOfferFlags[0]).toEqual(expect.objectContaining({ positionGroup: 'OL', count: 2 }));
+  });
+
+  it('flags rebuild team offering an old expensive veteran', () => {
+    const out = summarizeEconomyRegressionSnapshot({
+      teams: [team({ archetype: 'rebuild', capRoom: 40 })],
+      freeAgents: [player({ id: 3, pos: 'WR', age: 33, offers: [offer({ contract: { baseAnnual: 13, yearsTotal: 2 } })] })],
+    });
+
+    expect(out.oldVeteranOffersByRebuildTeams).toBe(1);
+  });
+
+  it('does not treat contender short-term veteran offers as rebuild-vet mistakes', () => {
+    const out = summarizeEconomyRegressionSnapshot({
+      teams: [team({ archetype: 'contender', capRoom: 35 })],
+      freeAgents: [player({ id: 4, pos: 'WR', age: 32, offers: [offer({ contract: { baseAnnual: 11, yearsTotal: 1 } })] })],
+    });
+
+    expect(out.contenderVeteranOfferCount).toBe(1);
+    expect(out.oldVeteranOffersByRebuildTeams).toBe(0);
+  });
+
+  it('recognizes severe QB need exception separately from normal over-aggression', () => {
+    const out = summarizeEconomyRegressionSnapshot({
+      teams: [team({
+        archetype: 'rebuild',
+        capRoom: 25,
+        positionalNeeds: [{ positionGroup: 'QB', priority: 90 }],
+      })],
+      freeAgents: [player({ id: 5, pos: 'QB', age: 29, offers: [offer({
+        contract: { baseAnnual: 20, yearsTotal: 2 },
+        contractModel: { marketRealism: { flags: ['qb_need_exception'] }, reasons: ['severe QB need exception'] },
+      })] })],
+    });
+
+    expect(out.severeQbNeedOfferCount).toBe(1);
+    expect(out.oldVeteranOffersByRebuildTeams).toBe(0);
+  });
+
+  it('flags a young premium player trade discount', () => {
+    const out = summarizeEconomyRegressionSnapshot({
+      teams: [team()],
+      incomingTradeOffers: [{
+        id: 't1',
+        offeringPlayerSnapshots: [{ id: 10, pos: 'QB', age: 23, ovr: 78, potential: 90, contract: { baseAnnual: 5 } }],
+        receivingPlayerSnapshots: [{ id: 11, pos: 'RB', age: 30, ovr: 78, potential: 78, contract: { baseAnnual: 7 } }],
+      }],
+    });
+
+    expect(out.premiumYoungPlayerTradeDiscountFlags).toBe(1);
+  });
+
+  it('flags an expensive veteran-for-veteran swap', () => {
+    const out = summarizeEconomyRegressionSnapshot({
+      teams: [team()],
+      trades: [{
+        id: 't2',
+        offeringPlayerSnapshots: [{ id: 12, pos: 'WR', age: 33, ovr: 84, potential: 84, contract: { baseAnnual: 16 } }],
+        receivingPlayerSnapshots: [{ id: 13, pos: 'CB', age: 32, ovr: 82, potential: 82, contract: { baseAnnual: 14 } }],
+      }],
+    });
+
+    expect(out.expensiveVeteranSwapFlags).toBe(1);
+  });
+
+  it('returns unknown/skipped reasons for missing short-snapshot data without crashing', () => {
+    const out = summarizeEconomyRegressionSnapshot({});
+
+    expect(out.skippedReasons.map((row) => row.code)).toEqual(expect.arrayContaining(['teams_missing', 'pending_offers_missing', 'trades_missing']));
+    expect(out.cpuOfferCount).toBe(0);
+    expect(out.unknownOfferValueCount).toBe(0);
+  });
+});

--- a/src/core/__tests__/marketRealismModel.test.js
+++ b/src/core/__tests__/marketRealismModel.test.js
@@ -99,6 +99,23 @@ describe('Trade + Free Agency Market Realism V2 model', () => {
     expect(rebuild.fitScore).toBeLessThan(contender.fitScore);
   });
 
+
+  it('keeps severe QB need exception controlled and explicit', () => {
+    const out = evaluatePlayerMarketRealism({
+      player: { pos: 'QB', ovr: 75, potential: 79, age: 30 },
+      team: team({ capRoom: 10 }),
+      strategy: strategy('rebuild', 92),
+      positionalNeed: 1.85,
+      proposedAnnual: 8,
+      action: 'free_agency',
+    });
+
+    expect(out.flags).toContain('qb_need_exception');
+    expect(out.reasons).toContain('severe QB need exception');
+    expect(out.shouldAvoid).toBe(false);
+    expect(out.capRisk).toBeLessThan(92);
+  });
+
   it('adds a premium tax so young premium players are not undervalued in trades', () => {
     const base = 120;
     const qb = adjustTradeValueForMarketRealism({ pos: 'QB', ovr: 78, potential: 90, age: 23, contract: { baseAnnual: 5 } }, base);

--- a/src/core/__tests__/trade-logic.test.js
+++ b/src/core/__tests__/trade-logic.test.js
@@ -62,6 +62,13 @@ describe('shouldBlockCpuUniformPlayerSwap', () => {
   it('allows non-QB uniform swaps', () => {
     expect(shouldBlockCpuUniformPlayerSwap({ pos: 'WR' }, { pos: 'CB' })).toBe(false);
   });
+
+  it('blocks directionless veteran-for-veteran swaps involving a quarterback', () => {
+    const expensiveQb = { pos: 'QB', age: 35, ovr: 76, potential: 76, contract: { baseAnnual: 22 } };
+    const expensiveWr = { pos: 'WR', age: 33, ovr: 79, potential: 79, contract: { baseAnnual: 14 } };
+
+    expect(shouldBlockCpuUniformPlayerSwap(expensiveQb, expensiveWr)).toBe(true);
+  });
 });
 
 

--- a/src/core/dynastySoakAudit.js
+++ b/src/core/dynastySoakAudit.js
@@ -15,6 +15,7 @@ import {
 } from './draftClassHistory.js';
 import { buildAiTeamStrategy } from './aiTeamStrategy.js';
 import { buildPlayerDevelopmentModel } from './playerDevelopmentModel.js';
+import { summarizeEconomyRegressionSnapshot } from './economyRegressionAudit.js';
 import { buildProspectScoutingReport } from './scoutingModel.js';
 import {
   defensiveIntsFromTotalsForArchive,
@@ -545,6 +546,7 @@ export function runDynastySoakAudit(input = {}) {
   const schedule = viewState?.schedule;
   const standings = Array.isArray(viewState?.standings) ? viewState.standings : [];
   const leagueHistory = viewState?.leagueHistory ?? [];
+  const incomingTradeOffers = Array.isArray(viewState?.incomingTradeOffers) ? viewState.incomingTradeOffers : [];
 
   // --- Phase / user / schedule ---
   if (userTeamId == null || userTeamId === '') {
@@ -784,6 +786,39 @@ export function runDynastySoakAudit(input = {}) {
     }
   }
 
+  // --- Economy regression snapshot (informational, warning-only) ---
+  const economyRegressionSnapshot = summarizeEconomyRegressionSnapshot({
+    teams,
+    players: allPlayers,
+    userTeamId,
+    incomingTradeOffers,
+  });
+  if (economyRegressionSnapshot.teamsOverCap > 0) {
+    warn('economy_teams_over_cap', `${economyRegressionSnapshot.teamsOverCap} team(s) are over cap in economy regression snapshot`);
+    bumpSummary(summary, 'capHealth', 'warn');
+  }
+  if (economyRegressionSnapshot.teamsWithPendingOfferOvercommit > 0) {
+    warn('economy_pending_offer_overcommit', `${economyRegressionSnapshot.teamsWithPendingOfferOvercommit} team(s) are overcommitted by pending offers`, {
+      pendingOfferOvercommitCount: economyRegressionSnapshot.pendingOfferOvercommitCount,
+    });
+    bumpSummary(summary, 'capHealth', 'warn');
+  }
+  if (economyRegressionSnapshot.duplicateExpensiveSameGroupOffers > 0) {
+    warn('economy_duplicate_expensive_same_group_offers', `${economyRegressionSnapshot.duplicateExpensiveSameGroupOffers} duplicate expensive same-group CPU offer bucket(s)`);
+    bumpSummary(summary, 'aiHealth', 'warn');
+  }
+  if (economyRegressionSnapshot.oldVeteranOffersByRebuildTeams > 0) {
+    warn('economy_rebuild_old_veteran_offer', `${economyRegressionSnapshot.oldVeteranOffersByRebuildTeams} old expensive veteran CPU offer(s) by rebuild teams`);
+    bumpSummary(summary, 'aiHealth', 'warn');
+  }
+  if (economyRegressionSnapshot.premiumYoungPlayerTradeDiscountFlags > 0 || economyRegressionSnapshot.expensiveVeteranSwapFlags > 0) {
+    warn('economy_trade_realism_flags', 'Trade realism warning flags detected in economy regression snapshot', {
+      premiumYoungPlayerTradeDiscountFlags: economyRegressionSnapshot.premiumYoungPlayerTradeDiscountFlags,
+      expensiveVeteranSwapFlags: economyRegressionSnapshot.expensiveVeteranSwapFlags,
+    });
+    bumpSummary(summary, 'aiHealth', 'warn');
+  }
+
   // --- Transactions + draft class memory ---
   const rawTx = Array.isArray(input.transactions) ? input.transactions : [];
   if (seasonIndex >= 2 && rawTx.length < 3) {
@@ -938,6 +973,7 @@ export function runDynastySoakAudit(input = {}) {
     warningCodesSample: warnings.slice(0, 30).map((w) => w.code),
     capStressedWarnings: warnings.filter((w) => w.code === 'cap_stressed').length,
     depthWarnings: warnings.filter((w) => String(w.code).startsWith('depth_')).length,
+    economyRegressionSnapshot,
   };
 
   return {

--- a/src/core/economyRegressionAudit.js
+++ b/src/core/economyRegressionAudit.js
@@ -1,0 +1,289 @@
+import { evaluatePendingOfferCapReservation } from './pendingOfferCapModel.js';
+import { normalizePositionGroup, getAnnualContractCost, getPositionalPremium } from './marketRealismModel.js';
+
+const REBUILD_ARCHETYPES = new Set(['rebuild', 'rebuilding', 'development']);
+const CONTENDER_ARCHETYPES = new Set(['contender', 'playoff_hunt', 'desperate']);
+const PREMIUM_POSITIONS = new Set(['QB', 'OT', 'EDGE', 'DE', 'CB', 'WR', 'DL']);
+
+function toNum(value, fallback = null) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function round(value) {
+  const n = toNum(value, null);
+  return n == null ? null : Math.round(n * 10) / 10;
+}
+
+function pushSkipped(skipped, code, reason) {
+  skipped.push({ code, reason });
+}
+
+function annualForOffer(offer = {}, player = {}) {
+  const explicit = toNum(
+    offer?.annualCapHit
+      ?? offer?.capHit
+      ?? offer?.annualValue
+      ?? offer?.baseAnnual
+      ?? offer?.contract?.annualCapHit
+      ?? offer?.contract?.capHit,
+    null,
+  );
+  if (explicit != null && explicit > 0) return round(explicit);
+  const base = toNum(
+    offer?.contract?.baseAnnual
+      ?? offer?.contract?.annualSalary
+      ?? offer?.contract?.annual
+      ?? offer?.salary
+      ?? player?.contract?.baseAnnual,
+    null,
+  );
+  if (base == null || base <= 0) return null;
+  const years = Math.max(1, toNum(offer?.contract?.yearsTotal ?? offer?.contract?.years ?? offer?.yearsTotal ?? offer?.years, 1));
+  const bonus = toNum(offer?.contract?.signingBonus ?? offer?.signingBonus, 0);
+  return round(base + bonus / years);
+}
+
+function normalizePlayerOfferRows({ players, freeAgents, pendingOffers, offers }) {
+  const rows = [];
+  const addRow = (player, offer, source) => {
+    if (!offer || typeof offer !== 'object') return;
+    rows.push({
+      player: player ?? offer?.player ?? {},
+      offer,
+      source,
+      teamId: offer?.teamId ?? offer?.offeringTeamId ?? offer?.bidderTeamId ?? null,
+      annualValue: annualForOffer(offer, player ?? offer?.player ?? {}),
+    });
+  };
+
+  for (const p of [...(Array.isArray(players) ? players : []), ...(Array.isArray(freeAgents) ? freeAgents : [])]) {
+    if (Array.isArray(p?.offers)) {
+      for (const offer of p.offers) addRow(p, offer, 'player.offers');
+    } else if (p?.offers && typeof p.offers === 'object' && p.offers.userOffered) {
+      addRow(p, {
+        teamId: p.offers.teamId,
+        annualCapHit: p.offers.userBidAnnualCapHit ?? p.offers.userBidAnnual,
+        contractModel: p.offers.userOfferContractModel,
+      }, 'player.offerSummary');
+    }
+  }
+  for (const offer of Array.isArray(pendingOffers) ? pendingOffers : []) addRow(offer?.player, offer, 'pendingOffers');
+  for (const offer of Array.isArray(offers) ? offers : []) addRow(offer?.player, offer, 'offers');
+  return rows;
+}
+
+function isUserOffer(row, userTeamId) {
+  return userTeamId != null && row?.teamId != null && Number(row.teamId) === Number(userTeamId);
+}
+
+function getTeamArchetype(team = {}) {
+  return String(team?.archetype ?? team?.strategy?.archetype ?? team?.teamArchetype ?? '').toLowerCase();
+}
+
+function hasSevereQbNeed(row, team = {}) {
+  const player = row?.player ?? {};
+  if (String(player?.pos ?? '').toUpperCase() !== 'QB') return false;
+  const realism = row?.offer?.contractModel?.marketRealism ?? row?.offer?.marketRealism ?? {};
+  const flags = Array.isArray(realism?.flags) ? realism.flags : [];
+  const reasons = Array.isArray(row?.offer?.contractModel?.reasons) ? row.offer.contractModel.reasons : [];
+  if (flags.includes('qb_need_exception') || reasons.some((r) => /severe QB need exception/i.test(String(r)))) return true;
+  if (team?.severeQbNeed === true || team?.qbNeedException === true) return true;
+  const needs = Array.isArray(team?.positionalNeeds) ? team.positionalNeeds : Array.isArray(team?.strategy?.positionalNeeds) ? team.strategy.positionalNeeds : [];
+  return needs.some((n) => normalizePositionGroup(n?.positionGroup ?? n?.pos ?? n?.position) === 'QB' && toNum(n?.priority ?? n?.needScore, 0) >= 75);
+}
+
+function isOldExpensiveVeteran(player = {}, annualValue = null) {
+  const pos = String(player?.pos ?? '').toUpperCase();
+  const age = toNum(player?.age, 0);
+  const annual = annualValue ?? getAnnualContractCost(player);
+  return age >= (pos === 'QB' ? 34 : 31) && annual >= (pos === 'QB' ? 18 : 10);
+}
+
+function isExpensiveOffer(row) {
+  const pos = String(row?.player?.pos ?? '').toUpperCase();
+  const annual = row?.annualValue;
+  if (annual == null) return false;
+  return annual >= (pos === 'QB' ? 18 : 10);
+}
+
+function sidePlayers(trade = {}, key) {
+  const snapshots = trade?.[`${key}PlayerSnapshots`];
+  if (Array.isArray(snapshots)) return snapshots;
+  const players = trade?.[`${key}Players`];
+  if (Array.isArray(players)) return players;
+  return [];
+}
+
+function playerTradeValue(player = {}) {
+  const ovr = toNum(player?.ovr, 60);
+  const pot = toNum(player?.potential, ovr);
+  const age = toNum(player?.age, 27);
+  const posPremium = getPositionalPremium(player?.pos);
+  const ageMult = age <= 24 ? 1.2 : age >= 31 ? 0.78 : 1;
+  const premiumMult = posPremium >= 80 ? 1.18 : 1;
+  const contractDrag = Math.max(0, getAnnualContractCost(player) - (posPremium >= 80 ? 22 : 12)) * 2;
+  return Math.max(0, ((ovr * 1.05) + (pot * 0.85)) * ageMult * premiumMult - contractDrag);
+}
+
+function hasPremiumYoungPlayer(players = []) {
+  return players.some((p) => {
+    const pos = String(p?.pos ?? '').toUpperCase();
+    return toNum(p?.age, 99) <= 26 && (PREMIUM_POSITIONS.has(pos) || getPositionalPremium(pos) >= 80) && toNum(p?.potential ?? p?.ovr, 0) >= 78;
+  });
+}
+
+function sideValue(players = [], picks = []) {
+  const playerValue = players.reduce((sum, p) => sum + playerTradeValue(p), 0);
+  const pickValue = (Array.isArray(picks) ? picks : []).reduce((sum, p) => sum + (toNum(p?.valueScore, null) ?? (toNum(p?.round, 7) === 1 ? 175 : toNum(p?.round, 7) === 2 ? 125 : 70)), 0);
+  return playerValue + pickValue;
+}
+
+function buildTradeFlags(trades = []) {
+  const premiumYoungPlayerTradeDiscountFlags = [];
+  const expensiveVeteranSwapFlags = [];
+
+  for (const trade of Array.isArray(trades) ? trades : []) {
+    const offering = sidePlayers(trade, 'offering');
+    const receiving = sidePlayers(trade, 'receiving');
+    const offeringPicks = Array.isArray(trade?.offeringPickSnapshots) ? trade.offeringPickSnapshots : [];
+    const receivingPicks = Array.isArray(trade?.receivingPickSnapshots) ? trade.receivingPickSnapshots : [];
+    const offeringValue = toNum(trade?.offeringValue, null) ?? sideValue(offering, offeringPicks);
+    const receivingValue = toNum(trade?.receivingValue, null) ?? sideValue(receiving, receivingPicks);
+
+    if (hasPremiumYoungPlayer(offering) && receivingValue < offeringValue * 0.85) {
+      premiumYoungPlayerTradeDiscountFlags.push({ tradeId: trade?.id ?? null, side: 'offering', valueGap: round(offeringValue - receivingValue) });
+    }
+    if (hasPremiumYoungPlayer(receiving) && offeringValue < receivingValue * 0.85) {
+      premiumYoungPlayerTradeDiscountFlags.push({ tradeId: trade?.id ?? null, side: 'receiving', valueGap: round(receivingValue - offeringValue) });
+    }
+    const offeringOldExpensive = offering.some((p) => isOldExpensiveVeteran(p));
+    const receivingOldExpensive = receiving.some((p) => isOldExpensiveVeteran(p));
+    if (offeringOldExpensive && receivingOldExpensive) {
+      expensiveVeteranSwapFlags.push({ tradeId: trade?.id ?? null, offeringValue: round(offeringValue), receivingValue: round(receivingValue) });
+    }
+  }
+
+  return { premiumYoungPlayerTradeDiscountFlags, expensiveVeteranSwapFlags };
+}
+
+export function summarizeEconomyRegressionSnapshot(input = {}) {
+  const skippedReasons = [];
+  const warnings = [];
+  const teams = Array.isArray(input?.teams) ? input.teams : [];
+  const players = Array.isArray(input?.players) ? input.players : [];
+  const freeAgents = Array.isArray(input?.freeAgents) ? input.freeAgents : [];
+  const userTeamId = input?.userTeamId ?? null;
+  const teamsById = new Map(teams.map((t) => [Number(t?.id), t]));
+  const offerRows = normalizePlayerOfferRows({
+    players,
+    freeAgents,
+    pendingOffers: input?.pendingOffers,
+    offers: input?.offers,
+  });
+
+  if (!teams.length) pushSkipped(skippedReasons, 'teams_missing', 'No team snapshot was provided; cap and archetype metrics are partial.');
+  if (!offerRows.length) pushSkipped(skippedReasons, 'pending_offers_missing', 'No pending/free-agent offer rows were provided in this snapshot.');
+
+  const teamsOverCap = teams.filter((t) => {
+    const capRoom = toNum(t?.capRoom, null);
+    const capUsed = toNum(t?.capUsed, null);
+    const capTotal = toNum(t?.capTotal, null);
+    return (capRoom != null && capRoom < 0) || (capUsed != null && capTotal != null && capTotal > 0 && capUsed > capTotal);
+  }).length;
+
+  const pendingByTeam = new Map();
+  for (const row of offerRows) {
+    if (row.teamId == null) continue;
+    const key = Number(row.teamId);
+    if (!pendingByTeam.has(key)) pendingByTeam.set(key, []);
+    pendingByTeam.get(key).push({ ...row.offer, player: row.player });
+  }
+
+  let teamsWithPendingOfferOvercommit = 0;
+  let pendingOfferOvercommitCount = 0;
+  let unknownOfferValueCount = 0;
+  const pendingOfferTeamSummaries = [];
+  for (const [teamId, pendingOffers] of pendingByTeam.entries()) {
+    const team = teamsById.get(Number(teamId)) ?? { id: teamId };
+    const reservation = evaluatePendingOfferCapReservation({ team, pendingOffers, teamId });
+    unknownOfferValueCount += reservation.unknownOfferCount ?? 0;
+    if (reservation.capReservationStatus === 'overcommitted') {
+      teamsWithPendingOfferOvercommit += 1;
+      pendingOfferOvercommitCount += reservation.pendingOfferCount ?? 0;
+    }
+    pendingOfferTeamSummaries.push({
+      teamId,
+      pendingOfferCount: reservation.pendingOfferCount,
+      pendingAnnualCommitment: reservation.pendingAnnualCommitment,
+      estimatedCapRoomAfterPending: reservation.estimatedCapRoomAfterPending,
+      capReservationStatus: reservation.capReservationStatus,
+      unknownOfferCount: reservation.unknownOfferCount,
+    });
+  }
+
+  const cpuRows = offerRows.filter((row) => !isUserOffer(row, userTeamId));
+  const userRows = offerRows.filter((row) => isUserOffer(row, userTeamId));
+  const duplicateBuckets = new Map();
+  for (const row of cpuRows.filter(isExpensiveOffer)) {
+    const group = normalizePositionGroup(row?.player?.pos);
+    const key = `${row.teamId ?? 'unknown'}:${group}`;
+    if (!duplicateBuckets.has(key)) duplicateBuckets.set(key, []);
+    duplicateBuckets.get(key).push(row);
+  }
+  const duplicateExpensiveSameGroupOffers = [...duplicateBuckets.entries()]
+    .filter(([, rows]) => rows.length >= 2)
+    .map(([key, rows]) => ({
+      key,
+      teamId: rows[0]?.teamId ?? null,
+      positionGroup: normalizePositionGroup(rows[0]?.player?.pos),
+      count: rows.length,
+      playerIds: rows.map((row) => row?.player?.id ?? null),
+    }));
+
+  let oldVeteranOffersByRebuildTeams = 0;
+  let contenderVeteranOfferCount = 0;
+  let severeQbNeedOfferCount = 0;
+  for (const row of cpuRows) {
+    const team = teamsById.get(Number(row.teamId)) ?? {};
+    const archetype = getTeamArchetype(team);
+    if (hasSevereQbNeed(row, team)) severeQbNeedOfferCount += 1;
+    if (REBUILD_ARCHETYPES.has(archetype) && isOldExpensiveVeteran(row.player, row.annualValue)) oldVeteranOffersByRebuildTeams += 1;
+    if (CONTENDER_ARCHETYPES.has(archetype) && toNum(row?.player?.age, 0) >= 30 && row.annualValue != null && row.annualValue >= 8) contenderVeteranOfferCount += 1;
+  }
+  if (cpuRows.some((row) => row.teamId != null) && teams.length === 0) {
+    warnings.push('CPU offer rows were present, but team archetypes were unavailable; rebuild/contender offer sanity is partial.');
+  }
+
+  const trades = [
+    ...(Array.isArray(input?.trades) ? input.trades : []),
+    ...(Array.isArray(input?.incomingTradeOffers) ? input.incomingTradeOffers : []),
+  ];
+  if (!trades.length) pushSkipped(skippedReasons, 'trades_missing', 'No trade proposal snapshot was provided; trade realism warning counts are unavailable.');
+  const tradeFlags = buildTradeFlags(trades);
+
+  const status = warnings.length ? 'warning' : 'ok';
+  return {
+    status,
+    teamsOverCap,
+    teamsWithPendingOfferOvercommit,
+    pendingOfferOvercommitCount,
+    duplicateExpensiveSameGroupOffers: duplicateExpensiveSameGroupOffers.length,
+    duplicateExpensiveSameGroupOfferFlags: duplicateExpensiveSameGroupOffers,
+    oldVeteranOffersByRebuildTeams,
+    contenderVeteranOfferCount,
+    severeQbNeedOfferCount,
+    premiumYoungPlayerTradeDiscountFlags: tradeFlags.premiumYoungPlayerTradeDiscountFlags.length,
+    premiumYoungPlayerTradeDiscountFlagDetails: tradeFlags.premiumYoungPlayerTradeDiscountFlags,
+    expensiveVeteranSwapFlags: tradeFlags.expensiveVeteranSwapFlags.length,
+    expensiveVeteranSwapFlagDetails: tradeFlags.expensiveVeteranSwapFlags,
+    cpuOfferCount: cpuRows.length,
+    userOfferCount: userRows.length,
+    unknownOfferValueCount,
+    pendingOfferTeamSummaries,
+    skippedReasons,
+    warnings,
+  };
+}
+
+export default summarizeEconomyRegressionSnapshot;

--- a/src/testSupport/dynastySoakCli.js
+++ b/src/testSupport/dynastySoakCli.js
@@ -425,6 +425,23 @@ export function buildMarkdownReport(result) {
     }
     lines.push(`- **Draft classes listed:** ${rs.draftClassCount ?? 'n/a'}`);
     lines.push('');
+
+    if (rs.economyRegressionSnapshot) {
+      const eco = rs.economyRegressionSnapshot;
+      lines.push('## Economy regression snapshot');
+      lines.push('');
+      lines.push(`- **Pending offer cap health:** overcommitted teams=${eco.teamsWithPendingOfferOvercommit ?? 'n/a'}, overcommitted offers=${eco.pendingOfferOvercommitCount ?? 'n/a'}, unknown offer values=${eco.unknownOfferValueCount ?? 'n/a'}`);
+      lines.push(`- **CPU FA offer sanity:** CPU offers=${eco.cpuOfferCount ?? 'n/a'}, duplicate expensive same-group buckets=${eco.duplicateExpensiveSameGroupOffers ?? 'n/a'}, rebuild old-vet offers=${eco.oldVeteranOffersByRebuildTeams ?? 'n/a'}, contender veteran offers=${eco.contenderVeteranOfferCount ?? 'n/a'}, severe QB exceptions=${eco.severeQbNeedOfferCount ?? 'n/a'}`);
+      lines.push(`- **Market realism warnings:** teams over cap=${eco.teamsOverCap ?? 'n/a'}`);
+      lines.push(`- **Trade realism warnings:** young premium discount flags=${eco.premiumYoungPlayerTradeDiscountFlags ?? 'n/a'}, expensive veteran swap flags=${eco.expensiveVeteranSwapFlags ?? 'n/a'}`);
+      if (Array.isArray(eco.skippedReasons) && eco.skippedReasons.length) {
+        lines.push(`- **Unknown/skipped:** ${mdEscape(eco.skippedReasons.map((row) => `${row.code}: ${row.reason}`).join('; '))}`);
+      }
+      if (Array.isArray(eco.warnings) && eco.warnings.length) {
+        lines.push(`- **Warnings:** ${mdEscape(eco.warnings.join('; '))}`);
+      }
+      lines.push('');
+    }
   }
 
   if (result.persistenceAssertions?.length) {


### PR DESCRIPTION
### Motivation

- After the recent contract/cap/market realism work there is risk that CPU free agency, pending-offer cap reservation, and trade realism regressions can slip past unit tests without clear, deterministic visibility. 
- The goal is to add a small, pure, testable snapshot helper and a compact CI-visible report so regressions like CPU overcommitment, duplicate expensive offers, or rebuilds chasing old veterans are caught early. 

### Description

- Added a pure audit helper `summarizeEconomyRegressionSnapshot` in `src/core/economyRegressionAudit.js` that normalizes offer rows and reports metrics including `teamsOverCap`, `teamsWithPendingOfferOvercommit`, `pendingOfferOvercommitCount`, `duplicateExpensiveSameGroupOffers`, `oldVeteranOffersByRebuildTeams`, `contenderVeteranOfferCount`, `severeQbNeedOfferCount`, `premiumYoungPlayerTradeDiscountFlags`, `expensiveVeteranSwapFlags`, `cpuOfferCount`, `userOfferCount`, `unknownOfferValueCount`, and `skippedReasons` / `warnings` (pure, no side-effects). 
- Wired the snapshot into the dynasty soak audit (warning-only) so `reportSummary.economyRegressionSnapshot` is populated and an `Economy regression snapshot` section is added to the Markdown output via `src/testSupport/dynastySoakCli.js`, with compact lines for pending-offer cap health, CPU FA sanity, market/trade warnings, and unknown/skipped reasons. 
- Added deterministic unit tests in `src/core/__tests__/economyRegressionAudit.test.js` and strengthened focused tests in `marketRealismModel.test.js` and `trade-logic.test.js` to cover severe QB exceptions and directionless veteran-swap guardrails; no simulation or AI constants were changed and this is audit/report only. 

### Testing

- Unit tests: ran `npm run test:unit` (full suite) and focused runs; result: all unit tests passed (189 files, 834 tests). 
- Soak/audit: ran `npm run test:soak` and `npm run audit:dynasty -- --ci --seed=1383`; both passed and the dynasty audit reported `runtimeMs=19338` (≈20.5s wall time) with one expected early-warning (`hof_empty_young`). 
- Build & deploy checks: `npm run build` passed (Vite chunk-size warning expected) and `npm run check:deploy` passed. 
- E2E / Playwright: Playwright browser install and E2E runs were blocked by environment CDN/proxy (Playwright attempted `npx playwright install --with-deps chromium` but the browser download from `https://cdn.playwright.dev` returned `403 Domain forbidden`), so Playwright end-to-end tests could not complete in this environment and are therefore marked as blocked rather than failed. 

Notes and follow-ups: no tuning constants or gameplay logic were altered; the economy snapshot intentionally reports `skipped`/`unknown` when short CI snapshots lack pending-offer or trade data so the CI profile remains fast and stable; follow-up work could add multi-seed aggregation if longer multi-seed audit runs are desired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0384a92dd8832db9f60519c8f93d79)