### PR TITLE
Data-density: add lightweight table helpers + search/sort/filter to LeagueStats, LeagueLeaders, Roster, FreeAgency

### DIFF
--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -54,6 +54,7 @@ import { buildFreeAgencyMarketAnalysis } from "../../core/freeAgency/freeAgencyM
 import { buildFreeAgencyProfileContext } from "../utils/playerProfileContext.js";
 import { buildContractOfferInsight, toneToContractInsightColor } from "../utils/contractOfferInsights.js";
 import { evaluatePendingOfferCapReservation } from "../../core/pendingOfferCapModel.js";
+import { buildShowingLabel, stableSortRows } from "../utils/dataBrowser.js";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -189,18 +190,13 @@ export function sortFreeAgentsForView(displayed, { sortPreset, sortKey, sortDir,
     arr.sort((a, b) => (rowFor(a).riskFlags?.length ?? 0) - (rowFor(b).riskFlags?.length ?? 0) || (rowFor(b).sortKeys?.fitScore ?? 0) - (rowFor(a).sortKeys?.fitScore ?? 0));
     return arr;
   }
-  arr.sort((a, b) => {
-    let va = a[sortKey];
-    let vb = b[sortKey];
-    if (sortKey === "ask") {
-      va = a._ask;
-      vb = b._ask;
-    }
-    if (va === vb) return 0;
-    if (sortDir === "asc") return va > vb ? 1 : -1;
-    return va < vb ? 1 : -1;
-  });
-  return arr;
+  return stableSortRows(arr, (player) => {
+    const marketRow = rowFor(player);
+    if (sortKey === "ask") return player._ask;
+    if (sortKey === "fitScore") return marketRow.sortKeys?.fitScore ?? player?._eval?.schemeFit?.score ?? player.schemeFit ?? 0;
+    if (sortKey === "capFit") return marketRow.sortKeys?.capFit ?? marketRow.sortKeys?.affordability ?? 0;
+    return player?.[sortKey];
+  }, sortDir, (player) => player?.name);
 }
 
 // ── Shared sub-components (identical signature & appearance to Roster.jsx) ────
@@ -1030,6 +1026,22 @@ export default function FreeAgency({
     showFlash(isResignPhase ? "Re-sign priorities loaded: OVR 75+." : "Top-target quick filter loaded: OVR 75+.");
   };
 
+  const resetMarketFilters = () => {
+    setNameFilter("");
+    setPosFilter("ALL");
+    setMinOvr(0);
+    setMaxAge(40);
+    setMinSchemeFit(0);
+    setDemandTier("ALL");
+    setFitTierFilter("ALL");
+    setArchetypeFilter("ALL");
+    setRoleFilter("ALL");
+    setPositionNeedOnly(false);
+    setWatchOnly(false);
+    setMarketFilter("all");
+    setAdvancedFilters([]);
+  };
+
   // ── Render ─────────────────────────────────────────────────────────────────
 
   return (
@@ -1360,6 +1372,10 @@ export default function FreeAgency({
           </div>
         </CardContent>
       </Card>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 8, flexWrap: "wrap", alignItems: "center", marginBottom: "var(--space-3)", fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
+        <span>{buildShowingLabel(sortedAgents.length, evaluatedFaPool.length, faState?.phase === "offseason_resign" ? "re-sign target" : "free agent")}</span>
+        <Button type="button" variant="outline" onClick={resetMarketFilters}>Reset filters</Button>
+      </div>
       <AdvancedPlayerSearch
         filters={advancedFilters}
         onChange={setAdvancedFilters}

--- a/src/ui/components/LeagueLeaders.jsx
+++ b/src/ui/components/LeagueLeaders.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import EmptyState from "./EmptyState.jsx";
 import { getSafeLeagueLeaderCategories } from "../../state/selectors.js";
 import { buildLeagueStatsHubModel } from "../utils/leagueStatsHub.js";
+import { buildShowingLabel, rowMatchesSearch, stableSortRows, uniqueFilterOptions } from "../utils/dataBrowser.js";
 
 const TABS = ["Passing", "Rushing", "Receiving", "Tackles", "Sacks", "Interceptions", "Kicking"];
 
@@ -114,6 +115,10 @@ const API_TAB_MAP = Object.freeze({
 export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavigate }) {
   const [activeTab, setActiveTab] = useState("Passing");
   const [leaderPayload, setLeaderPayload] = useState({ categories: null, source: null, phase: null });
+  const [search, setSearch] = useState("");
+  const [positionFilter, setPositionFilter] = useState("ALL");
+  const [teamFilter, setTeamFilter] = useState("ALL");
+  const [sort, setSort] = useState({ key: "primary", dir: "desc" });
   const firstTabRef = useRef(null);
   const teams = Array.isArray(league?.teams) ? league.teams : [];
 
@@ -159,6 +164,7 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
             name: row.name,
             teamName: row.teamAbbr,
             teamId: row.teamId,
+            pos: row.raw?.pos ?? row.raw?.position ?? row.raw?.player?.pos ?? row.raw?.player?.position ?? "",
             isUserTeam: Number(row.teamId) === Number(league?.userTeamId),
           },
           primary: row.value,
@@ -188,6 +194,7 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
           name: row.name,
           teamName: row.team,
           teamId: row.teamId,
+          pos: row.pos ?? row.position ?? "",
           isUserTeam: Number(row.teamId) === Number(league?.userTeamId),
         },
         primary: config.getPrimary(row) ?? 0,
@@ -196,6 +203,29 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
       .sort((a, b) => (b.primary ?? 0) - (a.primary ?? 0))
       .slice(0, 10);
   }, [activeTab, league?.userTeamId, model.playerTables, remoteCategories]);
+
+
+  const positionOptions = useMemo(() => uniqueFilterOptions(rows, (entry) => entry.player?.pos), [rows]);
+  const teamOptions = useMemo(() => uniqueFilterOptions(rows, (entry) => entry.player?.teamName), [rows]);
+  const visibleRows = useMemo(() => {
+    const filtered = rows.filter((entry) => {
+      if (positionFilter !== "ALL" && entry.player?.pos !== positionFilter) return false;
+      if (teamFilter !== "ALL" && entry.player?.teamName !== teamFilter) return false;
+      return rowMatchesSearch(entry.player, search, ["name", "teamName", "pos"]);
+    });
+    const getValue = (entry) => {
+      if (sort.key === "name") return entry.player?.name;
+      if (sort.key === "team") return entry.player?.teamName;
+      if (sort.key === "secondary") return entry.secondary;
+      return entry.primary;
+    };
+    return stableSortRows(filtered, getValue, sort.dir, (entry) => entry.player?.name);
+  }, [rows, positionFilter, teamFilter, search, sort]);
+  const resetFilters = () => { setSearch(""); setPositionFilter("ALL"); setTeamFilter("ALL"); };
+  const hasActiveFilters = Boolean(search.trim()) || positionFilter !== "ALL" || teamFilter !== "ALL";
+  const handleSort = (key) => setSort((current) => current.key === key
+    ? { key, dir: current.dir === "asc" ? "desc" : "asc" }
+    : { key, dir: key === "name" || key === "team" ? "asc" : "desc" });
 
   const config = CATEGORY_CONFIG[activeTab] ?? CATEGORY_CONFIG.Passing;
   const sourceLabel = leaderPayload?.source === "last_completed_regular_season"
@@ -212,26 +242,39 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
             role="tab"
             aria-selected={activeTab === tab}
             className={`standings-tab${activeTab === tab ? " active" : ""}`}
-            onClick={() => setActiveTab(tab)}
+            onClick={() => { setActiveTab(tab); resetFilters(); setSort({ key: "primary", dir: "desc" }); }}
           >
             {tab}
           </button>
         ))}
       </div>
       <div style={{ color: "var(--text-muted)", fontSize: "var(--text-xs)" }}>{sourceLabel}</div>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+        <input aria-label="Search league leaders" value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search player/team" style={{ minHeight: 32, flex: "1 1 180px" }} />
+        <select aria-label="Filter leaders by position" value={positionFilter} onChange={(e) => setPositionFilter(e.target.value)} style={{ minHeight: 32 }}>
+          <option value="ALL">All positions</option>
+          {positionOptions.map((pos) => <option key={pos} value={pos}>{pos}</option>)}
+        </select>
+        <select aria-label="Filter leaders by team" value={teamFilter} onChange={(e) => setTeamFilter(e.target.value)} style={{ minHeight: 32 }}>
+          <option value="ALL">All teams</option>
+          {teamOptions.map((team) => <option key={team} value={team}>{team}</option>)}
+        </select>
+        {hasActiveFilters ? <button type="button" onClick={resetFilters} style={{ minHeight: 32 }}>Reset filters</button> : null}
+      </div>
+      <div style={{ color: "var(--text-muted)", fontSize: "var(--text-xs)" }}>{buildShowingLabel(visibleRows.length, rows.length, "leader")}</div>
       <div className="table-wrapper" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
         <table className="standings-table" style={{ width: "100%", minWidth: 680 }}>
           <thead>
             <tr>
               <th style={{ width: 70 }}>Rank</th>
-              <th>Player</th>
-              <th>Team</th>
-              <th style={{ textAlign: "right" }}>{config.primaryLabel}</th>
+              <th><button type="button" onClick={() => handleSort("name")}>Player{sort.key === "name" ? (sort.dir === "asc" ? " ↑" : " ↓") : ""}</button></th>
+              <th><button type="button" onClick={() => handleSort("team")}>Team{sort.key === "team" ? (sort.dir === "asc" ? " ↑" : " ↓") : ""}</button></th>
+              <th style={{ textAlign: "right" }}><button type="button" onClick={() => handleSort("primary")}>{config.primaryLabel}{sort.key === "primary" ? (sort.dir === "asc" ? " ↑" : " ↓") : ""}</button></th>
               <th style={{ textAlign: "right" }}>{config.secondaryLabel}</th>
             </tr>
           </thead>
           <tbody>
-            {rows.map((entry, index) => (
+            {visibleRows.map((entry, index) => (
               <tr
                 key={`${entry.player?.id ?? entry.player?.name ?? "player"}-${index}`}
                 className="card-enter"
@@ -252,7 +295,7 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
                 <td style={{ textAlign: "right" }}>{entry.secondary ?? "—"}</td>
               </tr>
             ))}
-            {rows.length === 0 && (
+            {visibleRows.length === 0 && (
               <tr>
                 <td colSpan={5} style={{ padding: 0 }}>
                   <EmptyState

--- a/src/ui/components/LeagueStats.jsx
+++ b/src/ui/components/LeagueStats.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { buildLeagueStatsHubModel } from "../utils/leagueStatsHub.js";
+import { buildShowingLabel, rowMatchesSearch, stableSortRows, uniqueFilterOptions } from "../utils/dataBrowser.js";
 
 const leaderCards = [["Passing yards", "passing", "passYds"],["Passing TD", "passing", "passTd"],["Rushing yards", "rushing", "rushYds"],["Receiving yards", "receiving", "recYds"],["Tackles", "defense", "tkl"],["Sacks", "defense", "sack"],["Interceptions", "defense", "defInt"],["Field goals made", "kicking", "fgm"]];
 
@@ -27,14 +28,21 @@ export default function LeagueStats({ league, onPlayerSelect, onTeamSelect }) {
   const [search, setSearch] = useState("");
   const [tab, setTab] = useState("passing");
   const [sort, setSort] = useState({ key: defaultSort.passing, dir: "desc" });
-  const filtered = (model.playerTables[tab] ?? []).filter((r) => (`${r.name} ${r.team} ${r.pos}`).toLowerCase().includes(search.toLowerCase()));
-  const rows = useMemo(() => [...filtered].sort((a, b) => {
-    const ak = a?.[sort.key]; const bk = b?.[sort.key];
-    const d = typeof ak === "string" ? String(ak).localeCompare(String(bk)) : Number(ak ?? 0) - Number(bk ?? 0);
-    return sort.dir === "asc" ? d : -d;
-  }), [filtered, sort]);
-  const setTabWithSort = (t) => { setTab(t); setSort({ key: defaultSort[t], dir: "desc" }); };
-  const clickSort = (key) => setSort((s) => s.key === key ? { key, dir: s.dir === "asc" ? "desc" : "asc" } : { key, dir: "desc" });
+  const [posFilter, setPosFilter] = useState("ALL");
+  const [teamFilter, setTeamFilter] = useState("ALL");
+  const sourceRows = model.playerTables[tab] ?? [];
+  const positionOptions = useMemo(() => uniqueFilterOptions(sourceRows, (r) => r.pos), [sourceRows]);
+  const teamOptions = useMemo(() => uniqueFilterOptions(sourceRows, (r) => r.team), [sourceRows]);
+  const filtered = useMemo(() => sourceRows.filter((r) => {
+    if (posFilter !== "ALL" && r.pos !== posFilter) return false;
+    if (teamFilter !== "ALL" && r.team !== teamFilter) return false;
+    return rowMatchesSearch(r, search, ["name", "team", "pos"]);
+  }), [sourceRows, posFilter, teamFilter, search]);
+  const rows = useMemo(() => stableSortRows(filtered, (r) => r?.[sort.key], sort.dir, (r) => r?.name), [filtered, sort]);
+  const hasActiveFilters = Boolean(search.trim()) || posFilter !== "ALL" || teamFilter !== "ALL";
+  const resetFilters = () => { setSearch(""); setPosFilter("ALL"); setTeamFilter("ALL"); };
+  const setTabWithSort = (t) => { setTab(t); setSort({ key: defaultSort[t], dir: "desc" }); setPosFilter("ALL"); setTeamFilter("ALL"); };
+  const clickSort = (key) => setSort((s) => s.key === key ? { key, dir: s.dir === "asc" ? "desc" : "asc" } : { key, dir: key === "name" || key === "team" || key === "pos" ? "asc" : "desc" });
 
   return <div style={{ display: "grid", gap: 12 }}>
     <div className="card" style={{ padding: 12 }}>
@@ -47,9 +55,29 @@ export default function LeagueStats({ league, onPlayerSelect, onTeamSelect }) {
       {leaderCards.map(([label, bucket, key]) => <div key={label} className="card" style={{ padding: 10 }}><div>{label}</div>{(model.playerLeaders[bucket] ?? []).map((r,i)=><button key={`${r.playerId}-${i}`} onClick={()=>onPlayerSelect?.(r.playerId)} style={{display:'flex',width:'100%',justifyContent:'space-between'}}><span>{r.name} ({r.team})</span><span>{fmt(key, r[key])}</span></button>)}</div>)}
     </div>
     <div className="card" style={{ padding: 10 }}>
-      <div style={{ display:'flex', gap:8, flexWrap:'wrap' }}>{['passing','rushing','receiving','defense','kicking'].map((t)=><button key={t} onClick={()=>setTabWithSort(t)} style={{fontWeight: tab===t?700:500, textTransform:'capitalize'}}>{t}</button>)}<input value={search} onChange={(e)=>setSearch(e.target.value)} placeholder="Search name/team/pos" /></div>
-      <div style={{ overflowX:'auto' }}><table style={{ minWidth: 980, width:'100%' }}><thead><tr>{columns[tab].map(([label,key])=><th key={key}><button onClick={()=>clickSort(key)}>{label}{sort.key===key?(sort.dir==='asc'?' ↑':' ↓'):''}</button></th>)}</tr></thead><tbody>
-          {rows.length ? rows.map((r)=><tr key={`${r.playerId}-${tab}`}><td><button onClick={()=>onPlayerSelect?.(r.playerId)}>{r.name}</button></td>{columns[tab].slice(1).map(([,k])=><td key={k}>{fmt(k, r[k])}</td>)}</tr>) : <tr><td colSpan={columns[tab].length}>{tab==='passing'?'No passing stats recorded yet.':tab==='rushing'?'No rushing stats recorded yet.':'No data for this category yet.'}</td></tr>}
+      <div style={{ display:'grid', gap:8 }}>
+        <div style={{ display:'flex', gap:8, flexWrap:'wrap', alignItems:'center' }}>
+          {['passing','rushing','receiving','defense','kicking'].map((t)=><button key={t} onClick={()=>setTabWithSort(t)} style={{fontWeight: tab===t?700:500, textTransform:'capitalize', minHeight:32}}>{t}</button>)}
+          <input aria-label="Search player stats" value={search} onChange={(e)=>setSearch(e.target.value)} placeholder="Search player/team/pos" style={{ minHeight:32, flex:'1 1 180px' }} />
+          <select aria-label="Filter by position" value={posFilter} onChange={(e)=>setPosFilter(e.target.value)} style={{ minHeight:32 }}>
+            <option value="ALL">All positions</option>
+            {positionOptions.map((pos) => <option key={pos} value={pos}>{pos}</option>)}
+          </select>
+          <select aria-label="Filter by team" value={teamFilter} onChange={(e)=>setTeamFilter(e.target.value)} style={{ minHeight:32 }}>
+            <option value="ALL">All teams</option>
+            {teamOptions.map((team) => <option key={team} value={team}>{team}</option>)}
+          </select>
+          {hasActiveFilters ? <button type="button" onClick={resetFilters} style={{ minHeight:32 }}>Reset filters</button> : null}
+        </div>
+        <div style={{ display:'flex', gap:6, flexWrap:'wrap', alignItems:'center', fontSize:12, color:'var(--text-muted)' }}>
+          <span>{buildShowingLabel(rows.length, sourceRows.length, 'player')}</span>
+          {posFilter !== 'ALL' ? <span>Position: {posFilter}</span> : null}
+          {teamFilter !== 'ALL' ? <span>Team: {teamFilter}</span> : null}
+          <span>Sort: {columns[tab].find(([, key]) => key === sort.key)?.[0] ?? sort.key} {sort.dir === 'asc' ? '↑' : '↓'}</span>
+        </div>
+      </div>
+      <div style={{ overflowX:'auto' }}><table aria-label="Player stat table" style={{ minWidth: 980, width:'100%' }}><thead><tr>{columns[tab].map(([label,key])=><th key={key}><button aria-label={`Sort by ${label}`} onClick={()=>clickSort(key)}>{label}{sort.key===key?(sort.dir==='asc'?' ↑':' ↓'):''}</button></th>)}</tr></thead><tbody>
+          {rows.length ? rows.map((r)=><tr key={`${r.playerId}-${tab}`}><td><button onClick={()=>onPlayerSelect?.(r.playerId)}>{r.name}</button></td>{columns[tab].slice(1).map(([,k])=><td key={k} data-label={columns[tab].find(([, key]) => key === k)?.[0]}>{fmt(k, r[k])}</td>)}</tr>) : <tr><td colSpan={columns[tab].length}>{hasActiveFilters ? 'No player stats match those filters.' : tab==='passing'?'No passing stats recorded yet.':tab==='rushing'?'No rushing stats recorded yet.':'No data for this category yet.'}</td></tr>}
       </tbody></table></div>
     </div>
     <div className="card" style={{ padding: 10 }}>

--- a/src/ui/components/LeagueStats.test.jsx
+++ b/src/ui/components/LeagueStats.test.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 afterEach(() => cleanup());
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
 import LeagueStats from './LeagueStats.jsx';
 
 const league = {seasonId:2026,week:4,teams:[{id:1,abbr:'AAA',roster:[{id:1,name:'QB',position:'QB',seasonStats:{passYards:200,passComp:20,passAtt:30,rushYards:10,recYards:0,tackles:1,fgm:0}},{id:2,name:'RB',position:'RB',seasonStats:{rushYards:120,rushAtt:20}}]},{id:2,abbr:'BBB',roster:[{id:3,name:'WR',position:'WR',seasonStats:{recYards:140,receptions:7,targets:10}}]}],schedule:[{played:true,homeId:1,awayId:2,homeScore:24,awayScore:17}]};
@@ -10,19 +10,20 @@ const league = {seasonId:2026,week:4,teams:[{id:1,abbr:'AAA',roster:[{id:1,name:
 describe('LeagueStats', () => {
   it('renders full passing columns and filters search', () => {
     render(<LeagueStats league={league} />);
-    expect(screen.getByRole('button', { name: /^Cmp/ })).toBeTruthy();
-    expect(screen.getByRole('button', { name: /^Rate/ })).toBeTruthy();
-    fireEvent.change(screen.getByPlaceholderText(/Search name\/team\/pos/i), { target: { value: 'WR' } });
-    expect(screen.queryByRole('button', { name: /^QB$/ })).toBeFalsy();
+    expect(screen.getByRole('button', { name: 'Sort by Cmp' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Sort by Rate' })).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('Search player stats'), { target: { value: 'WR' } });
+    expect(within(screen.getByRole('table', { name: 'Player stat table' })).queryByRole('button', { name: /^QB$/ })).toBeFalsy();
     expect(screen.getByRole('button', { name: 'passing' }).getAttribute('style')).toContain('font-weight: 700');
   });
 
   it('sorting changes row order', () => {
     render(<LeagueStats league={{...league, teams:[{id:1,abbr:'AAA',roster:[{id:1,name:'A',position:'QB',seasonStats:{passYards:100}},{id:2,name:'B',position:'QB',seasonStats:{passYards:300}}]}]}} />);
-    const yds = screen.getByRole('button', { name: /^Yds ↓/ });
-    expect(screen.getAllByRole('button', { name: /^(A|B)$/ })[0].textContent).toBe('B');
+    const yds = screen.getByRole('button', { name: 'Sort by Yds' });
+    const table = () => within(screen.getByRole('table', { name: 'Player stat table' }));
+    expect(table().getAllByRole('button', { name: /^(A|B)$/ })[0].textContent).toBe('B');
     fireEvent.click(yds);
-    expect(screen.getAllByRole('button', { name: /^(A|B)$/ })[0].textContent).toBe('A');
+    expect(table().getAllByRole('button', { name: /^(A|B)$/ })[0].textContent).toBe('A');
   });
 
   it('calls player select and shows team rankings fallback', () => {

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -67,6 +67,7 @@ import EmptyState from "./EmptyState.jsx";
 import { getPositionColor } from "../constants/positionColors.js";
 import { deriveRosterReadinessModel } from "../utils/rosterReadinessModel.js";
 import { markWeeklyPrepStep } from "../utils/weeklyPrep.js";
+import { buildShowingLabel, rowMatchesSearch, stableSortRows } from "../utils/dataBrowser.js";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -235,42 +236,21 @@ function SchemeFitIndicator({ fit, bonus, topAttr, schemeName }) {
   );
 }
 
+function getRosterSortValue(player, sortKey) {
+  switch (sortKey) {
+    case "ovr": return player?.ovr ?? 0;
+    case "age": return player?.age ?? 0;
+    case "salary": return derivePlayerContractFinancials(player).annualSalary ?? 0;
+    case "fit": return player?.schemeFit ?? 50;
+    case "morale": return player?.morale ?? 75;
+    case "pos": return player?.pos ?? "";
+    case "name": return player?.name ?? "";
+    default: return 0;
+  }
+}
+
 function sortPlayers(players, sortKey, sortDir) {
-  return [...players].sort((a, b) => {
-    let va, vb;
-    switch (sortKey) {
-      case "ovr":
-        va = a.ovr ?? 0;
-        vb = b.ovr ?? 0;
-        break;
-      case "age":
-        va = a.age ?? 0;
-        vb = b.age ?? 0;
-        break;
-      case "salary":
-        va = derivePlayerContractFinancials(a).annualSalary ?? 0;
-        vb = derivePlayerContractFinancials(b).annualSalary ?? 0;
-        break;
-      case "fit":
-        va = a.schemeFit ?? 50;
-        vb = b.schemeFit ?? 50;
-        break;
-      case "morale":
-        va = a.morale ?? 75;
-        vb = b.morale ?? 75;
-        break;
-      case "name":
-        va = a.name ?? "";
-        vb = b.name ?? "";
-        break;
-      default:
-        va = 0;
-        vb = 0;
-    }
-    if (va < vb) return sortDir === "asc" ? -1 : 1;
-    if (va > vb) return sortDir === "asc" ? 1 : -1;
-    return 0;
-  });
+  return stableSortRows(players, (player) => getRosterSortValue(player, sortKey), sortDir, (player) => player?.name);
 }
 
 function getContractYearsLeft(player) {
@@ -510,6 +490,7 @@ function RosterTable({
   const [releasing, setReleasing] = useState(null);
   const [extending, setExtending] = useState(null);
   const [advancedFilters, setAdvancedFilters] = useState([]);
+  const [search, setSearch] = useState("");
   const [evaluationMode, setEvaluationMode] = useState(true);
   const {
     compareIds,
@@ -523,9 +504,10 @@ function RosterTable({
 
   const displayed = useMemo(() => {
     const quickFiltered = applyRosterQuickFilter(players, posFilter);
-    const filtered = applyAdvancedPlayerFilters(quickFiltered, advancedFilters);
+    const searched = quickFiltered.filter((player) => rowMatchesSearch(player, search, ["name", "pos", (p) => p?.college, (p) => p?.archetype]));
+    const filtered = applyAdvancedPlayerFilters(searched, advancedFilters);
     return sortPlayers(filtered, sortKey, sortDir);
-  }, [players, posFilter, sortKey, sortDir, advancedFilters]);
+  }, [players, posFilter, search, sortKey, sortDir, advancedFilters]);
   const evaluatedDisplayed = useMemo(() => displayed.map((player) => ({
     player,
     eval: buildPlayerEvaluation(player, {
@@ -542,6 +524,8 @@ function RosterTable({
   );
 
   const activeFilters = isResignPhase ? ["EXPIRING", "STARTERS", "DEPTH", "INJURED", "DEVELOPMENT", ...POSITIONS] : ["STARTERS", "DEPTH", "INJURED", "EXPIRING", "DEVELOPMENT", ...POSITIONS];
+  const hasActiveFilters = Boolean(search.trim()) || posFilter !== "ALL" || advancedFilters.length > 0;
+  const resetBrowseFilters = () => { setSearch(""); setPosFilter("ALL"); setAdvancedFilters([]); };
 
   useEffect(() => {
     if (initialFilter) setPosFilter(initialFilter);
@@ -664,6 +648,17 @@ function RosterTable({
           <span><strong style={{ color: "#BF5AF2" }}>{decisionSummary.trade_or_tag}</strong> tag/trade calls</span>
         </div>
       )}
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center", marginBottom: "var(--space-3)" }}>
+        <Input
+          aria-label="Search roster players"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search roster by player, position, college"
+          style={{ minHeight: 36, flex: "1 1 220px" }}
+        />
+        <span style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>{buildShowingLabel(displayed.length, players.length, "player")}</span>
+        {hasActiveFilters ? <Button type="button" variant="outline" onClick={resetBrowseFilters}>Reset filters</Button> : null}
+      </div>
       <div className="roster-filter-bar" style={{ marginBottom: "var(--space-4)" }}>
 
         {activeFilters.map((pos) => (
@@ -850,7 +845,7 @@ function RosterTable({
                       title="No players match this filter"
                       subtitle="Try clearing one or more roster filters."
                       action="Reset filter"
-                      onAction={() => setPosFilter("ALL")}
+                      onAction={resetBrowseFilters}
                     />
                   </TableCell>
                 </TableRow>
@@ -1884,14 +1879,16 @@ function PlayerCardGrid({ players, onPlayerSelect, phase, team, week, initialFil
   const [sortKey, setSortKey] = useState("ovr");
   const [sortDir, setSortDir] = useState("desc");
   const [advancedFilters, setAdvancedFilters] = useState([]);
+  const [search, setSearch] = useState("");
 
   const activeFilters = isResignPhase ? ["EXPIRING", "STARTERS", "DEPTH", "INJURED", "DEVELOPMENT", ...POSITIONS] : ["STARTERS", "DEPTH", "INJURED", "EXPIRING", "DEVELOPMENT", ...POSITIONS];
 
   const displayed = useMemo(() => {
     const quickFiltered = applyRosterQuickFilter(players, posFilter);
-    const filtered = applyAdvancedPlayerFilters(quickFiltered, advancedFilters);
+    const searched = quickFiltered.filter((player) => rowMatchesSearch(player, search, ["name", "pos", (p) => p?.college, (p) => p?.archetype]));
+    const filtered = applyAdvancedPlayerFilters(searched, advancedFilters);
     return sortPlayers(filtered, sortKey, sortDir);
-  }, [players, posFilter, sortKey, sortDir, advancedFilters]);
+  }, [players, posFilter, search, sortKey, sortDir, advancedFilters]);
   const direction = useMemo(() => classifyTeamDirection(team, week), [team, week]);
   const decisionSummary = useMemo(
     () => buildExpiringDecisionSummary(players, { team, roster: players, direction }),
@@ -1927,6 +1924,18 @@ function PlayerCardGrid({ players, onPlayerSelect, phase, team, week, initialFil
         flexDirection: "column",
         gap: "var(--space-3)",
       }}>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+          <Input
+            aria-label="Search roster cards"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search roster"
+            style={{ minHeight: 36, flex: "1 1 200px" }}
+          />
+          {(search.trim() || posFilter !== "ALL" || advancedFilters.length > 0) ? (
+            <Button type="button" variant="outline" onClick={() => { setSearch(""); setPosFilter("ALL"); setAdvancedFilters([]); }}>Reset filters</Button>
+          ) : null}
+        </div>
         <AdvancedPlayerSearch
           filters={advancedFilters}
           onChange={setAdvancedFilters}
@@ -2025,7 +2034,7 @@ function PlayerCardGrid({ players, onPlayerSelect, phase, team, week, initialFil
         fontSize: "var(--text-xs)", color: "var(--text-muted)",
         marginBottom: "var(--space-3)",
       }}>
-        {displayed.length} player{displayed.length !== 1 ? "s" : ""}
+        {buildShowingLabel(displayed.length, players.length, "player")}
         {posFilter !== "ALL" ? ` · ${posFilter}` : ""}
       </div>
 

--- a/src/ui/components/__tests__/LeagueStats.test.jsx
+++ b/src/ui/components/__tests__/LeagueStats.test.jsx
@@ -1,43 +1,57 @@
 /** @vitest-environment jsdom */
 import React from 'react';
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, describe, it, expect } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import LeagueStats from '../LeagueStats.jsx';
+
+function makeStatsLeague() {
+  return {
+    seasonId: 's1',
+    week: 1,
+    teams: [
+      { id: 1, name: 'AAA', abbr: 'AAA' },
+      { id: 2, name: 'BBB', abbr: 'BBB' },
+    ],
+    schedule: {
+      weeks: [
+        {
+          week: 1,
+          games: [
+            {
+              id: 'g1',
+              played: true,
+              homeId: 1,
+              awayId: 2,
+              homeScore: 24,
+              awayScore: 10,
+              teamStats: {
+                home: { passYd: 220, rushYd: 80, sacks: 3, sacksAllowed: 1, giveaways: 1, takeaways: 2 },
+                away: { passYd: 150, rushYd: 60, sacks: 1, sacksAllowed: 3, giveaways: 2, takeaways: 1 },
+              },
+              playerStats: {
+                home: {
+                  101: { name: 'Alpha Passer', pos: 'QB', stats: { passYd: 320, passTD: 3, passComp: 24, passAtt: 33 } },
+                  102: { name: 'Beta Runner', pos: 'RB', stats: { rushYd: 88, rushAtt: 15, rushTD: 1 } },
+                },
+                away: {
+                  201: { name: 'Gamma Passer', pos: 'QB', stats: { passYd: 180, passTD: 1, passComp: 18, passAtt: 29 } },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+afterEach(() => cleanup());
 
 describe('LeagueStats', () => {
   it('renders team rankings rows from completed-game teamStats', () => {
-    const league = {
-      seasonId: 's1',
-      week: 1,
-      teams: [
-        { id: 1, name: 'AAA', abbr: 'AAA' },
-        { id: 2, name: 'BBB', abbr: 'BBB' },
-      ],
-      schedule: {
-        weeks: [
-          {
-            week: 1,
-            games: [
-              {
-                played: true,
-                homeId: 1,
-                awayId: 2,
-                homeScore: 24,
-                awayScore: 10,
-                teamStats: {
-                  home: { passYd: 220, rushYd: 80, sacks: 3, sacksAllowed: 1, giveaways: 1, takeaways: 2 },
-                  away: { passYd: 150, rushYd: 60, sacks: 1, sacksAllowed: 3, giveaways: 2, takeaways: 1 },
-                },
-              },
-            ],
-          },
-        ],
-      },
-    };
-
     render(
       <LeagueStats
-        league={league}
+        league={makeStatsLeague()}
         onPlayerSelect={() => {}}
         onTeamSelect={() => {}}
       />,
@@ -45,7 +59,47 @@ describe('LeagueStats', () => {
 
     // Offense rankings should include AAA with visible PF/PPG context.
     expect(screen.getByText('League Stats')).toBeTruthy();
-  expect(screen.getAllByText(/^AAA$/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/^AAA$/).length).toBeGreaterThan(0);
+  });
+
+  it('filters player rows by search, position, team, and reset restores the table', () => {
+    render(<LeagueStats league={makeStatsLeague()} onPlayerSelect={() => {}} onTeamSelect={() => {}} />);
+
+    expect(screen.getAllByText('Alpha Passer').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Gamma Passer').length).toBeGreaterThan(0);
+
+    fireEvent.change(screen.getByLabelText('Search player stats'), { target: { value: 'Gamma' } });
+    const statsTableAfterSearch = within(screen.getByRole('table', { name: 'Player stat table' }));
+    expect(statsTableAfterSearch.queryByText('Alpha Passer')).toBeNull();
+    expect(statsTableAfterSearch.getByText('Gamma Passer')).toBeTruthy();
+    expect(screen.getByText('Showing 1 of 2 players')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Reset filters'));
+    fireEvent.change(screen.getByLabelText('Filter by team'), { target: { value: 'AAA' } });
+    const statsTableAfterTeam = within(screen.getByRole('table', { name: 'Player stat table' }));
+    expect(statsTableAfterTeam.getByText('Alpha Passer')).toBeTruthy();
+    expect(statsTableAfterTeam.queryByText('Gamma Passer')).toBeNull();
+
+    fireEvent.click(screen.getByText('Reset filters'));
+    fireEvent.change(screen.getByLabelText('Filter by position'), { target: { value: 'QB' } });
+    const statsTableAfterPosition = within(screen.getByRole('table', { name: 'Player stat table' }));
+    expect(statsTableAfterPosition.getByText('Alpha Passer')).toBeTruthy();
+    expect(statsTableAfterPosition.getByText('Gamma Passer')).toBeTruthy();
+  });
+
+  it('sorts numeric stats ascending and descending without losing mobile labels', () => {
+    render(<LeagueStats league={makeStatsLeague()} onPlayerSelect={() => {}} onTeamSelect={() => {}} />);
+
+    const getFirstPlayerName = () => within(screen.getByRole('table', { name: 'Player stat table' })).getAllByRole('row')[1].textContent;
+    expect(getFirstPlayerName()).toContain('Alpha Passer');
+
+    const statsTable = within(screen.getByRole('table', { name: 'Player stat table' }));
+    fireEvent.click(statsTable.getByLabelText('Sort by Yds'));
+    expect(getFirstPlayerName()).toContain('Gamma Passer');
+    fireEvent.click(statsTable.getByLabelText('Sort by Yds'));
+    expect(getFirstPlayerName()).toContain('Alpha Passer');
+
+    const yardsCells = screen.getAllByText('320').filter((node) => node.getAttribute('data-label') === 'Yds');
+    expect(yardsCells.length).toBeGreaterThan(0);
   });
 });
-

--- a/src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx
+++ b/src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx
@@ -51,4 +51,25 @@ describe('free agency playbook knowledge display', () => {
     ], { sortPreset: 'tactical_fit', sortKey: 'ovr', sortDir: 'desc', needs: [] });
     expect(sorted.map((p) => p.id)).toEqual([2, 3, 1]);
   });
+
+  it('keeps manual name sorting stable for equal names and supports market fit sort keys', () => {
+    const marketRowsById = new Map([
+      [1, { sortKeys: { fitScore: 55 } }],
+      [2, { sortKeys: { fitScore: 90 } }],
+      [3, { sortKeys: { fitScore: 55 } }],
+    ]);
+    const sortedByFit = sortFreeAgentsForView([
+      { id: 1, name: 'Same', ovr: 80 },
+      { id: 2, name: 'Best', ovr: 78 },
+      { id: 3, name: 'Same', ovr: 76 },
+    ], { sortPreset: 'manual', sortKey: 'fitScore', sortDir: 'desc', marketRowsById });
+    expect(sortedByFit.map((p) => p.id)).toEqual([2, 1, 3]);
+
+    const sortedByName = sortFreeAgentsForView([
+      { id: 1, name: 'Same', ovr: 80 },
+      { id: 3, name: 'Same', ovr: 76 },
+      { id: 2, name: 'Best', ovr: 78 },
+    ], { sortPreset: 'manual', sortKey: 'name', sortDir: 'asc', marketRowsById });
+    expect(sortedByName.map((p) => p.id)).toEqual([2, 1, 3]);
+  });
 });

--- a/src/ui/utils/dataBrowser.js
+++ b/src/ui/utils/dataBrowser.js
@@ -1,0 +1,59 @@
+export function normalizeSearchText(value) {
+  return String(value ?? "")
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim();
+}
+
+export function rowMatchesSearch(row, query, fields = []) {
+  const needle = normalizeSearchText(query);
+  if (!needle) return true;
+  const haystack = fields
+    .map((field) => (typeof field === "function" ? field(row) : row?.[field]))
+    .filter((value) => value != null)
+    .join(" ");
+  return normalizeSearchText(haystack).includes(needle);
+}
+
+export function compareValues(aValue, bValue, direction = "asc") {
+  const dir = direction === "desc" ? -1 : 1;
+  const aNum = Number(aValue);
+  const bNum = Number(bValue);
+  const bothNumeric = Number.isFinite(aNum) && Number.isFinite(bNum) && String(aValue ?? "").trim() !== "" && String(bValue ?? "").trim() !== "";
+  if (bothNumeric) {
+    if (aNum === bNum) return 0;
+    return aNum > bNum ? dir : -dir;
+  }
+  const textCompare = String(aValue ?? "").localeCompare(String(bValue ?? ""), undefined, {
+    numeric: true,
+    sensitivity: "base",
+  });
+  return textCompare * dir;
+}
+
+export function stableSortRows(rows = [], getValue, direction = "asc", fallbackGetValue = null) {
+  return [...(Array.isArray(rows) ? rows : [])]
+    .map((row, index) => ({ row, index }))
+    .sort((a, b) => {
+      const primary = compareValues(getValue?.(a.row), getValue?.(b.row), direction);
+      if (primary !== 0) return primary;
+      if (fallbackGetValue) {
+        const fallback = compareValues(fallbackGetValue(a.row), fallbackGetValue(b.row), "asc");
+        if (fallback !== 0) return fallback;
+      }
+      return a.index - b.index;
+    })
+    .map(({ row }) => row);
+}
+
+export function uniqueFilterOptions(rows = [], getValue) {
+  return Array.from(new Set((Array.isArray(rows) ? rows : []).map(getValue).filter(Boolean))).sort((a, b) => String(a).localeCompare(String(b), undefined, { numeric: true }));
+}
+
+export function buildShowingLabel(visibleCount, totalCount, noun = "row") {
+  const safeVisible = Number.isFinite(Number(visibleCount)) ? Number(visibleCount) : 0;
+  const safeTotal = Number.isFinite(Number(totalCount)) ? Number(totalCount) : 0;
+  const label = safeTotal === 1 ? noun : `${noun}s`;
+  return `Showing ${safeVisible} of ${safeTotal} ${label}`;
+}

--- a/src/ui/utils/dataBrowser.test.js
+++ b/src/ui/utils/dataBrowser.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { buildShowingLabel, rowMatchesSearch, stableSortRows, uniqueFilterOptions } from './dataBrowser.js';
+
+describe('dataBrowser helpers', () => {
+  it('matches search across configured fields safely', () => {
+    const row = { name: 'José Rocket', team: 'NYJ', pos: 'WR' };
+    expect(rowMatchesSearch(row, 'jose', ['name', 'team'])).toBe(true);
+    expect(rowMatchesSearch(row, 'qb', ['name', 'team', 'pos'])).toBe(false);
+    expect(rowMatchesSearch(null, '', ['name'])).toBe(true);
+  });
+
+  it('sorts numeric and string values with stable same-key order', () => {
+    const rows = [
+      { id: 1, name: 'Beta', yards: 10 },
+      { id: 2, name: 'Alpha', yards: 30 },
+      { id: 3, name: 'Gamma', yards: 30 },
+    ];
+    expect(stableSortRows(rows, (r) => r.yards, 'desc').map((r) => r.id)).toEqual([2, 3, 1]);
+    expect(stableSortRows(rows, (r) => r.name, 'asc').map((r) => r.id)).toEqual([2, 1, 3]);
+  });
+
+  it('builds compact filter metadata', () => {
+    expect(uniqueFilterOptions([{ pos: 'QB' }, { pos: 'WR' }, { pos: 'QB' }], (r) => r.pos)).toEqual(['QB', 'WR']);
+    expect(buildShowingLabel(2, 3, 'player')).toBe('Showing 2 of 3 players');
+    expect(buildShowingLabel(1, 1, 'team')).toBe('Showing 1 of 1 team');
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve data browsing density and discoverability (ZenGM-style) on high-value screens without rewriting shells or changing simulation/economy logic.  
- Provide small, reusable pure helpers for stable sorting, normalized search matching, and simple filter metadata to avoid ad-hoc copies across components.  
- Target safest, highest-impact surfaces: League Stats / Leaders, Roster, Free Agency, and Trade/History adjacent views to make mobile-first discovery faster and more compact.

### Description
- Added a small pure utility `src/ui/utils/dataBrowser.js` exporting `normalizeSearchText`, `rowMatchesSearch`, `compareValues`, `stableSortRows`, `uniqueFilterOptions`, and `buildShowingLabel`, plus unit tests in `src/ui/utils/dataBrowser.test.js`.  
- Integrated search/filter/sort controls and the helpers into `LeagueStats.jsx`, `LeagueLeaders.jsx`, `Roster.jsx`, and `FreeAgency.jsx` to provide: inline search boxes, position/team selects, reset-filters buttons, stable numeric/string sorting, and a compact "Showing X of Y" count; these changes preserve existing columns/fields and use only existing player/team/stat properties.  
- Roster improvements include a lightweight roster search, card/grid and table parity, and use of `stableSortRows` for deterministic ordering while preserving name-stable tiebreaks; no business/simulation code was altered.  
- FreeAgency sorting now reuses `stableSortRows` and adds a market pool count / reset toolbar; TradeFinder/History flows were inspected and left intact except for non-invasive view helpers in the screens above.  

### Testing
- Unit tests: ran targeted Vitest subset including `src/ui/utils/dataBrowser.test.js`, `src/ui/components/__tests__/LeagueStats.test.jsx`, `src/ui/components/__tests__/LeagueLeaders.test.jsx`, `src/ui/components/__tests__/freeAgencyPlaybookKnowledge.test.jsx`, and `src/ui/components/__tests__/rosterInitialState.test.js`; all tests passed (5 files, 13 tests).  
- Build: ran `npm run build` (Vite) and the production build succeeded; Vite emitted expected chunk-size warning for a large worker bundle (>500KB) but build finished successfully.  
- Commands intentionally skipped in this rollout: `npm run test:soak` (dynasty soak), `npm run audit:dynasty -- --ci` (dynasty audit), and full E2E Playwright smoke tests (`npm run test:e2e`) because they require longer runtime and browser installation in CI; these checks should be run in CI or prior to merge per repo PR checklist.  

Notes/UX: mobile-first inputs include accessible `aria-label`s, preserved tap-target sizing, and no hover-only controls; all changes avoid fabricating data or touching simulation/economy logic and add safe fallbacks for sparse/archived saves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038bea607c832dbf55eca16fcf737f)