### PR TITLE
Team + Player History Data Density V2

### DIFF
--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -8,6 +8,7 @@ import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/b
 import { AWARD_DISPLAY_NAMES } from '../../core/footballMeta';
 import { buildLeagueHistoryTopPerformers } from '../../core/playerSeasonStatsArchive.js';
 import { normalizeArchivedMajorTransactions } from '../../core/transactionTimeline.js';
+import { buildShowingLabel, rowMatchesSearch, stableSortRows, uniqueFilterOptions } from '../utils/dataBrowser.js';
 
 const RECORD_LABELS = {
   passYd: "Passing Yards",
@@ -79,6 +80,19 @@ function pct(row) {
   const games = wins + losses + ties;
   if (!games) return 0;
   return (wins + ties * 0.5) / games;
+}
+
+function seasonTokenToNumber(value) {
+  if (value == null) return 0;
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) return numeric;
+  const text = String(value);
+  if (text.startsWith("s")) {
+    const parsed = Number(text.slice(1));
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  const fallback = Number(text.replace(/[^\d.-]/g, ""));
+  return Number.isFinite(fallback) ? fallback : 0;
 }
 
 function buildChampionMap(seasons = []) {
@@ -342,6 +356,9 @@ function SeasonDraftClassSnippet({ seasonId, year, actions, onPlayerSelect }) {
 
 function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, league, initialSelectedSeasonId = null }) {
   const [selectedSeasonId, setSelectedSeasonId] = useState(initialSelectedSeasonId ?? seasons?.[0]?.id ?? null);
+  const [seasonSearch, setSeasonSearch] = useState("");
+  const [seasonSortKey, setSeasonSortKey] = useState("year");
+  const [seasonSortDirection, setSeasonSortDirection] = useState("desc");
 
   useEffect(() => {
     if (!seasons?.length) return;
@@ -353,6 +370,43 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
     setSelectedSeasonId((prev) => prev ?? seasons[0]?.id ?? null);
   }, [initialSelectedSeasonId, seasons]);
 
+  const seasonRows = useMemo(() => {
+    const filtered = (seasons ?? []).filter((season) => rowMatchesSearch(season, seasonSearch, [
+      "year",
+      (row) => row?.champion?.abbr ?? row?.champion?.name ?? "",
+      (row) => row?.runnerUp?.abbr ?? row?.runnerUp?.name ?? "",
+      (row) => row?.awards?.mvp?.name ?? "",
+      (row) => {
+        const userRow = (row?.standings ?? []).find((team) => Number(team?.id) === Number(league?.userTeamId));
+        return userRow ? `${userRow.wins ?? 0}-${userRow.losses ?? 0}${userRow.ties ? `-${userRow.ties}` : ""}` : "";
+      },
+    ]));
+    return stableSortRows(
+      filtered,
+      (season) => {
+        const userRow = (season?.standings ?? []).find((team) => Number(team?.id) === Number(league?.userTeamId));
+        switch (seasonSortKey) {
+          case "champion":
+            return String(season?.champion?.abbr ?? season?.champion?.name ?? "");
+          case "runnerUp":
+            return String(season?.runnerUp?.abbr ?? season?.runnerUp?.name ?? "");
+          case "mvp":
+            return String(season?.awards?.mvp?.name ?? "");
+          case "userWins":
+            return Number(userRow?.wins ?? 0);
+          case "year":
+          default:
+            return Number(season?.year ?? seasonTokenToNumber(season?.id));
+        }
+      },
+      seasonSortDirection,
+      (season) => Number(season?.year ?? seasonTokenToNumber(season?.id)),
+    );
+  }, [league?.userTeamId, seasonSearch, seasonSortDirection, seasonSortKey, seasons]);
+  const seasonShowingLabel = useMemo(
+    () => buildShowingLabel(seasonRows.length, seasons?.length ?? 0, "season"),
+    [seasonRows.length, seasons?.length],
+  );
   if (!seasons?.length) {
     return (
       <Card className="card-premium">
@@ -363,7 +417,6 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
       </Card>
     );
   }
-
   const selected = seasons.find((s) => s.id === selectedSeasonId) ?? seasons[0];
   const sortedStandings = [...(selected?.standings ?? [])].sort((a, b) => pct(b) - pct(a)).slice(0, 8);
   const championBoard = buildChampionMap(seasons).slice(0, 5);
@@ -401,19 +454,67 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
     <div className="grid grid-cols-1 lg:grid-cols-[260px_1fr] gap-4">
       <Card className="card-premium">
         <CardHeader><CardTitle>Season Archive</CardTitle></CardHeader>
-        <CardContent className="p-0">
+        <CardContent className="p-3 pt-0 space-y-2">
+          <input
+            aria-label="Search archived seasons"
+            value={seasonSearch}
+            onChange={(e) => setSeasonSearch(e.target.value)}
+            placeholder="Search year/champion/MVP"
+            className="h-9 w-full rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-xs"
+          />
+          <div className="grid grid-cols-2 gap-2">
+            <select
+              aria-label="Sort archived seasons"
+              value={seasonSortKey}
+              onChange={(e) => setSeasonSortKey(e.target.value)}
+              className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-xs"
+            >
+              <option value="year">Year</option>
+              <option value="champion">Champion</option>
+              <option value="runnerUp">Runner-up</option>
+              <option value="mvp">MVP</option>
+              <option value="userWins">User team wins</option>
+            </select>
+            <select
+              aria-label="Sort direction for archived seasons"
+              value={seasonSortDirection}
+              onChange={(e) => setSeasonSortDirection(e.target.value)}
+              className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-xs"
+            >
+              <option value="desc">Desc</option>
+              <option value="asc">Asc</option>
+            </select>
+          </div>
+          <div className="flex items-center justify-between gap-2">
+            <div data-testid="league-history-season-showing" className="text-[10px] text-[color:var(--text-muted)]">{seasonShowingLabel}</div>
+            <button
+              type="button"
+              aria-label="Reset archived season filters"
+              className="text-[10px] text-[color:var(--accent)]"
+              onClick={() => {
+                setSeasonSearch("");
+                setSeasonSortKey("year");
+                setSeasonSortDirection("desc");
+              }}
+            >
+              Reset
+            </button>
+          </div>
           <ScrollArea className="h-[520px]">
             <div className="divide-y divide-[color:var(--hairline)]">
-              {seasons.map((s) => (
+              {seasonRows.length > 0 ? seasonRows.map((s) => (
                 <button
                   key={s.id}
+                  data-testid={`league-history-season-list-item-${s.id}`}
                   className={`w-full text-left px-4 py-3 ${selected?.id === s.id ? "bg-[color:var(--surface-strong)]" : ""}`}
                   onClick={() => setSelectedSeasonId(s.id)}
                 >
                   <div className="font-bold text-sm">{s.year}</div>
                   <div className="text-xs text-[color:var(--text-muted)]">{s.champion?.abbr ?? "TBD"} champion</div>
                 </button>
-              ))}
+              )) : (
+                <div className="px-4 py-3 text-xs text-[color:var(--text-muted)]">No archived seasons match this filter.</div>
+              )}
             </div>
           </ScrollArea>
         </CardContent>
@@ -838,9 +939,52 @@ function AwardsHistory({ seasons, onPlayerSelect }) {
 }
 
 function LeagueOfficeHistory({ transactions, onPlayerSelect }) {
-  if (!transactions?.length) return <div className="py-8 text-center text-[color:var(--text-muted)]">No transaction history tracked yet.</div>;
-
-  const rows = transactions.slice(0, 120);
+  const [search, setSearch] = useState("");
+  const [typeFilter, setTypeFilter] = useState("all");
+  const [sortKey, setSortKey] = useState("date");
+  const [sortDirection, setSortDirection] = useState("desc");
+  const rows = useMemo(() => (transactions ?? []).slice(0, 160), [transactions]);
+  const typeOptions = useMemo(
+    () => uniqueFilterOptions(rows, (tx) => tx?.typeLabel ?? tx?.type ?? "Unknown"),
+    [rows],
+  );
+  const visibleRows = useMemo(() => {
+    const filtered = rows
+      .filter((tx) => typeFilter === "all" || (tx?.typeLabel ?? tx?.type ?? "Unknown") === typeFilter)
+      .filter((tx) => rowMatchesSearch(tx, search, [
+        "type",
+        "typeLabel",
+        "headline",
+        "detail",
+        "playerName",
+        "teamAbbr",
+        "fromTeamAbbr",
+        "toTeamAbbr",
+        "seasonId",
+        "week",
+      ]));
+    return stableSortRows(
+      filtered,
+      (tx) => {
+        switch (sortKey) {
+          case "type":
+            return String(tx?.typeLabel ?? tx?.type ?? "");
+          case "player":
+            return String(tx?.playerName ?? "");
+          case "date":
+          default:
+            return seasonTokenToNumber(tx?.seasonId) * 100 + Number(tx?.week ?? 0);
+        }
+      },
+      sortDirection,
+      (tx) => Number(tx?.id ?? 0),
+    );
+  }, [rows, search, sortDirection, sortKey, typeFilter]);
+  const showingLabel = useMemo(
+    () => buildShowingLabel(visibleRows.length, rows.length, "transaction"),
+    [rows.length, visibleRows.length],
+  );
+  if (!rows.length) return <div className="py-8 text-center text-[color:var(--text-muted)]">No transaction history tracked yet.</div>;
   const describe = (tx) => {
     const leg = tx.legacyType ?? "";
     const bucket = tx.type ?? "";
@@ -867,9 +1011,64 @@ function LeagueOfficeHistory({ transactions, onPlayerSelect }) {
     <Card className="card-premium">
       <CardHeader><CardTitle>League Moves Log</CardTitle></CardHeader>
       <CardContent className="p-0">
+        <div className="px-4 py-3 border-b border-[color:var(--hairline)] space-y-2">
+          <input
+            aria-label="Search league transactions"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search player/team/type"
+            className="h-9 w-full rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-xs"
+          />
+          <div className="grid grid-cols-2 gap-2">
+            <select
+              aria-label="Filter league transactions by type"
+              value={typeFilter}
+              onChange={(e) => setTypeFilter(e.target.value)}
+              className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-xs"
+            >
+              <option value="all">All types</option>
+              {typeOptions.map((type) => (
+                <option key={type} value={type}>{type}</option>
+              ))}
+            </select>
+            <select
+              aria-label="Sort league transactions"
+              value={`${sortKey}:${sortDirection}`}
+              onChange={(e) => {
+                const [nextKey, nextDirection] = String(e.target.value).split(":");
+                setSortKey(nextKey || "date");
+                setSortDirection(nextDirection || "desc");
+              }}
+              className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-xs"
+            >
+              <option value="date:desc">Newest first</option>
+              <option value="date:asc">Oldest first</option>
+              <option value="type:asc">Type A-Z</option>
+              <option value="type:desc">Type Z-A</option>
+              <option value="player:asc">Player A-Z</option>
+              <option value="player:desc">Player Z-A</option>
+            </select>
+          </div>
+          <div className="flex items-center justify-between gap-2">
+            <div data-testid="league-office-showing" className="text-[10px] text-[color:var(--text-muted)]">{showingLabel}</div>
+            <button
+              type="button"
+              aria-label="Reset league transaction filters"
+              className="text-[10px] text-[color:var(--accent)]"
+              onClick={() => {
+                setSearch("");
+                setTypeFilter("all");
+                setSortKey("date");
+                setSortDirection("desc");
+              }}
+            >
+              Reset
+            </button>
+          </div>
+        </div>
         <ScrollArea className="h-[560px]">
           <div className="divide-y divide-[color:var(--hairline)]">
-            {rows.map((tx, idx) => (
+            {visibleRows.length > 0 ? visibleRows.map((tx, idx) => (
               <div key={`${tx.id ?? idx}`} className="px-4 py-3 text-sm">
                 <div className="flex items-center justify-between gap-2">
                   <strong>{tx.typeLabel ?? tx.type}</strong>
@@ -880,7 +1079,9 @@ function LeagueOfficeHistory({ transactions, onPlayerSelect }) {
                   <button className="btn mt-2 text-xs" onClick={() => onPlayerSelect?.(tx.playerId)}>Open player</button>
                 )}
               </div>
-            ))}
+            )) : (
+              <div className="px-4 py-3 text-xs text-[color:var(--text-muted)]">No transactions match this filter.</div>
+            )}
           </div>
         </ScrollArea>
       </CardContent>

--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -123,14 +123,14 @@ function summarizeSeasonStoryline(season, userTeamId) {
   return lines.join(" ");
 }
 
-export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenBoxScore, initialSelectedSeasonId = null }) {
+export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenBoxScore, initialSelectedSeasonId = null, initialActiveTab = "seasons" }) {
   const api = actions ?? NOOP_ACTIONS;
   const [seasons, setSeasons] = useState([]);
   const [records, setRecords] = useState(null);
   const [recordBook, setRecordBook] = useState(null);
   const [allPlayers, setAllPlayers] = useState([]);
   const [transactions, setTransactions] = useState([]);
-  const [activeTab, setActiveTab] = useState("seasons");
+  const [activeTab, setActiveTab] = useState(initialActiveTab);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -29,6 +29,7 @@ import EmptyState from './EmptyState.jsx';
 import { buildRouteRequestKey, buildLeagueCacheScopeKey } from "../utils/requestLoopGuard.js";
 import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 import { getPlayerGameLogs } from "../utils/playerGameLogs.js";
+import { buildShowingLabel, rowMatchesSearch, stableSortRows, uniqueFilterOptions } from "../utils/dataBrowser.js";
 import { buildMergedPlayerAwardTimeline, buildPlayerAwardHeaderBadges } from "../../core/playerAwardTimeline.js";
 import { buildPlayerRecordContext, mergePlayerProfileSeasonRows } from "../../core/recordBookV1.js";
 import { buildLegacyScoreReport, shouldShowLegacyProfileSection } from "../../core/legacyScore.js";
@@ -253,6 +254,18 @@ function seasonYear(seasonId) {
   return seasonId;
 }
 
+function seasonSortValue(line) {
+  const explicitYear = Number(line?.year ?? NaN);
+  if (Number.isFinite(explicitYear)) return explicitYear;
+  const token = line?.season ?? line?.seasonId;
+  if (token == null) return 0;
+  const resolvedYear = seasonYear(String(token));
+  const numericYear = Number(resolvedYear);
+  if (Number.isFinite(numericYear)) return numericYear;
+  const fallbackNumber = Number(String(token).replace(/[^\d.-]/g, ""));
+  return Number.isFinite(fallbackNumber) ? fallbackNumber : 0;
+}
+
 function getSeasonProductionSummary(player) {
   if (!player?.careerStats?.length) return null;
   const latest = player.careerStats[player.careerStats.length - 1];
@@ -420,6 +433,10 @@ export default function PlayerProfile({
   const [showProjections, setShowProjections] = useState(false);
   const [activeProfileTab, setActiveProfileTab] = useState("Overview");
   const [draftContext, setDraftContext] = useState(null);
+  const [seasonLogSearch, setSeasonLogSearch] = useState("");
+  const [seasonLogTeamFilter, setSeasonLogTeamFilter] = useState("all");
+  const [seasonLogSortKey, setSeasonLogSortKey] = useState("season");
+  const [seasonLogSortDirection, setSeasonLogSortDirection] = useState("desc");
   const requestKey = useMemo(() => buildRouteRequestKey("player", playerId), [playerId]);
   const cacheScopeKey = useMemo(() => buildLeagueCacheScopeKey(league), [league]);
   const fetchProfileData = React.useCallback(async () => {
@@ -648,6 +665,66 @@ export default function PlayerProfile({
     () => mergePlayerProfileSeasonRows(effectivePlayer, archivedSeasons),
     [effectivePlayer, archivedSeasons],
   );
+  const seasonLogTeamOptions = useMemo(
+    () => uniqueFilterOptions(mergedProfileSeasonRows, (line) => line?.team ?? null),
+    [mergedProfileSeasonRows],
+  );
+  const seasonLogPrimaryStat = useMemo(() => {
+    const pos = String(effectivePlayer?.pos ?? effectivePlayer?.position ?? "").toUpperCase();
+    if (pos === "QB") return { key: "passYds", label: "Pass Yds" };
+    if (["RB", "FB"].includes(pos)) return { key: "rushYds", label: "Rush Yds" };
+    if (["WR", "TE"].includes(pos)) return { key: "recYds", label: "Rec Yds" };
+    if (["DE", "DT", "LB", "CB", "S", "DL", "EDGE"].includes(pos)) return { key: "tackles", label: "Tackles" };
+    if (pos === "K") return { key: "fgMade", label: "FG Made" };
+    return { key: "gamesPlayed", label: "Games" };
+  }, [effectivePlayer?.pos, effectivePlayer?.position]);
+  const seasonLogRows = useMemo(() => {
+    const filtered = mergedProfileSeasonRows
+      .filter((line) => seasonLogTeamFilter === "all" || String(line?.team ?? "—") === seasonLogTeamFilter)
+      .filter((line) => rowMatchesSearch(line, seasonLogSearch, [
+        (row) => row?.season ?? row?.seasonId ?? "",
+        (row) => row?.year ?? "",
+        (row) => row?.team ?? "",
+        (row) => row?.ovr ?? "",
+        (row) => row?.gamesPlayed ?? row?.gp ?? "",
+        (row) => row?.passYds ?? row?.passingYards ?? "",
+        (row) => row?.passTDs ?? row?.touchdowns ?? "",
+        (row) => row?.rushYds ?? row?.rushingYards ?? "",
+        (row) => row?.rushTDs ?? row?.rushingTDs ?? "",
+        (row) => row?.receptions ?? "",
+        (row) => row?.recYds ?? row?.receivingYards ?? "",
+        (row) => row?.recTDs ?? row?.receivingTDs ?? "",
+        (row) => row?.tackles ?? row?.totalTackles ?? "",
+        (row) => row?.sacks ?? "",
+        (row) => row?.defInts ?? row?.defInterceptions ?? "",
+        (row) => row?.fgMade ?? "",
+        (row) => row?.xpMade ?? "",
+      ]));
+    return stableSortRows(
+      filtered,
+      (line) => {
+        switch (seasonLogSortKey) {
+          case "team":
+            return String(line?.team ?? "");
+          case "games":
+            return Number(line?.gamesPlayed ?? line?.gp ?? 0);
+          case "primaryStat":
+            return Number(line?.[seasonLogPrimaryStat.key] ?? 0);
+          case "ovr":
+            return Number(line?.ovr ?? 0);
+          case "season":
+          default:
+            return seasonSortValue(line);
+        }
+      },
+      seasonLogSortDirection,
+      (line) => seasonSortValue(line),
+    );
+  }, [mergedProfileSeasonRows, seasonLogPrimaryStat.key, seasonLogSearch, seasonLogSortDirection, seasonLogSortKey, seasonLogTeamFilter]);
+  const seasonLogShowingLabel = useMemo(
+    () => buildShowingLabel(seasonLogRows.length, mergedProfileSeasonRows.length, "season"),
+    [seasonLogRows.length, mergedProfileSeasonRows.length],
+  );
   const teamJourney = [...new Set(mergedProfileSeasonRows.map((line) => line.team).filter(Boolean))];
   const careerArcRows = useMemo(() => {
     const seasonRows = mergedProfileSeasonRows.map((line) => ({
@@ -739,6 +816,12 @@ export default function PlayerProfile({
       gamesPlayed: 0, passYds: 0, passTDs: 0, rushYds: 0, rushTDs: 0, receptions: 0, recYds: 0, recTDs: 0, tackles: 0, sacks: 0, interceptions: 0,
     });
   }, [careerRows, effectivePlayer?.pos, effectivePlayer?.position]);
+  const careerSeasonLogPrimaryTotal = useMemo(() => {
+    return careerRows.reduce((sum, line) => {
+      if (seasonLogPrimaryStat.key === "gamesPlayed") return sum + Number(line?.gamesPlayed ?? line?.gp ?? 0);
+      return sum + Number(line?.[seasonLogPrimaryStat.key] ?? 0);
+    }, 0);
+  }, [careerRows, seasonLogPrimaryStat.key]);
 
   const profileAnalysis = useMemo(() => buildPlayerProfileAnalysis({ player: effectivePlayer, team: resolvedProfile.team, league, context: profileContext ?? {} }), [effectivePlayer, resolvedProfile.team, league, profileContext]);
   const playerGameLogs = useMemo(() => getPlayerGameLogs(league, effectivePlayer), [league, effectivePlayer]);
@@ -1930,6 +2013,92 @@ export default function PlayerProfile({
               >
                 Season Log
               </h3>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginBottom: "var(--space-2)" }}>
+                <input
+                  aria-label="Search player season log"
+                  value={seasonLogSearch}
+                  onChange={(e) => setSeasonLogSearch(e.target.value)}
+                  placeholder="Search season/team/stats"
+                  style={{
+                    background: "var(--surface)",
+                    border: "1px solid var(--hairline)",
+                    borderRadius: "var(--radius-sm)",
+                    padding: "6px 10px",
+                    color: "var(--text)",
+                    minWidth: 170,
+                  }}
+                />
+                <select
+                  aria-label="Filter player season log by team"
+                  value={seasonLogTeamFilter}
+                  onChange={(e) => setSeasonLogTeamFilter(e.target.value)}
+                  style={{
+                    background: "var(--surface)",
+                    border: "1px solid var(--hairline)",
+                    borderRadius: "var(--radius-sm)",
+                    padding: "6px 10px",
+                    color: "var(--text)",
+                  }}
+                >
+                  <option value="all">All teams</option>
+                  {seasonLogTeamOptions.map((team) => (
+                    <option key={team} value={team}>{team}</option>
+                  ))}
+                </select>
+                <select
+                  aria-label="Sort player season log"
+                  value={seasonLogSortKey}
+                  onChange={(e) => setSeasonLogSortKey(e.target.value)}
+                  style={{
+                    background: "var(--surface)",
+                    border: "1px solid var(--hairline)",
+                    borderRadius: "var(--radius-sm)",
+                    padding: "6px 10px",
+                    color: "var(--text)",
+                  }}
+                >
+                  <option value="season">Season</option>
+                  <option value="team">Team</option>
+                  <option value="games">Games</option>
+                  <option value="primaryStat">{seasonLogPrimaryStat.label}</option>
+                  <option value="ovr">OVR</option>
+                </select>
+                <select
+                  aria-label="Sort direction for player season log"
+                  value={seasonLogSortDirection}
+                  onChange={(e) => setSeasonLogSortDirection(e.target.value)}
+                  style={{
+                    background: "var(--surface)",
+                    border: "1px solid var(--hairline)",
+                    borderRadius: "var(--radius-sm)",
+                    padding: "6px 10px",
+                    color: "var(--text)",
+                  }}
+                >
+                  <option value="desc">Desc</option>
+                  <option value="asc">Asc</option>
+                </select>
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  aria-label="Reset player season log filters"
+                  onClick={() => {
+                    setSeasonLogSearch("");
+                    setSeasonLogTeamFilter("all");
+                    setSeasonLogSortKey("season");
+                    setSeasonLogSortDirection("desc");
+                  }}
+                >
+                  Reset
+                </button>
+              </div>
+              <div data-testid="player-profile-season-log-showing" style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginBottom: "var(--space-2)" }}>
+                {seasonLogShowingLabel} · Career totals: {careerTotals.gamesPlayed || 0} GP
+                {seasonLogPrimaryStat.key !== "gamesPlayed" ? ` · ${seasonLogPrimaryStat.label} ${careerSeasonLogPrimaryTotal.toLocaleString()}` : ""}
+              </div>
+              {seasonLogRows.length === 0 ? (
+                <EmptyState title="No season rows match this filter." subtitle="Reset filters to show the full archived season log." />
+              ) : null}
               <div className="table-wrapper" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
                 <Table
                   className="standings-table"
@@ -1995,8 +2164,8 @@ export default function PlayerProfile({
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {[...mergedProfileSeasonRows].reverse().map((line, i) => (
-                      <TableRow key={i}>
+                    {seasonLogRows.map((line, i) => (
+                      <TableRow key={i} data-testid={`player-profile-season-log-row-${line?.season ?? line?.seasonId ?? i}`}>
                         <TableCell
                           style={{
                             paddingLeft: "var(--space-4)",

--- a/src/ui/components/TeamHistoryScreen.jsx
+++ b/src/ui/components/TeamHistoryScreen.jsx
@@ -3,6 +3,7 @@ import { ScreenHeader, SectionCard, EmptyState } from './ScreenSystem.jsx';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 import { buildFranchiseHistoryModel, PLAYOFF_CALIBER_WINS } from '../../core/franchiseHistoryModel.js';
 import { RECORD_BOOK_PLAYER_KEYS, RECORD_LABELS } from '../../core/recordBookV1.js';
+import { buildShowingLabel, rowMatchesSearch, stableSortRows } from '../utils/dataBrowser.js';
 
 function buildSeasonTeamMap(season) {
   const map = {};
@@ -34,8 +35,10 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
   const [hofPlayers, setHofPlayers] = useState([]);
   const [hofClasses, setHofClasses] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [queryYear, setQueryYear] = useState('');
+  const [timelineSearch, setTimelineSearch] = useState('');
   const [scope, setScope] = useState('all');
+  const [timelineSortKey, setTimelineSortKey] = useState('year');
+  const [timelineSortDirection, setTimelineSortDirection] = useState('desc');
   const [majorMoves, setMajorMoves] = useState([]);
   const [draftFlash, setDraftFlash] = useState([]);
 
@@ -146,16 +149,52 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
 
   const { summary, franchiseRecords, franchiseLegends, playoffHistory, bestGames, milestones } = model;
 
+  const totalTimelineSeasons = model.seasons?.length ?? 0;
   const filteredTimeline = useMemo(() => {
-    return (model.seasons ?? []).filter((row) => {
+    const scopedRows = (model.seasons ?? []).filter((row) => {
       if (scope === 'champions' && !row.champion) return false;
       if (scope === 'playoff' && !row.playoffCaliber) return false;
       if (scope === 'losing' && !row.losingSeason) return false;
       if (scope === 'elite' && !row.eliteSeason) return false;
-      if (!queryYear.trim()) return true;
-      return String(row.year).includes(queryYear.trim());
+      return true;
     });
-  }, [model.seasons, queryYear, scope]);
+    const searchedRows = scopedRows.filter((row) => rowMatchesSearch(row, timelineSearch, [
+      'year',
+      (r) => `${r.wins}-${r.losses}${r.ties ? `-${r.ties}` : ''}`,
+      (r) => (r.champion ? 'champion' : r.runnerUp ? 'runner up' : r.truePlayoff ? 'playoff' : r.playoffCaliber ? 'playoff caliber' : 'regular season'),
+      (r) => (r.truePlayoff ? 'documented postseason' : r.playoffCaliber ? 'playoff caliber' : 'no postseason'),
+      (r) => r?.mvp?.name ?? '',
+      (r) => activeTeam?.abbr ?? activeTeam?.name ?? '',
+      'pf',
+      'pa',
+    ]));
+    return stableSortRows(
+      searchedRows,
+      (row) => {
+        switch (timelineSortKey) {
+          case 'wins':
+            return Number(row?.wins ?? 0);
+          case 'losses':
+            return Number(row?.losses ?? 0);
+          case 'pf':
+            return Number(row?.pf ?? 0);
+          case 'pa':
+            return Number(row?.pa ?? 0);
+          case 'result':
+            return row?.champion ? 4 : row?.runnerUp ? 3 : row?.truePlayoff ? 2 : row?.playoffCaliber ? 1 : 0;
+          case 'year':
+          default:
+            return Number(row?.year ?? 0);
+        }
+      },
+      timelineSortDirection,
+      (row) => Number(row?.year ?? 0),
+    );
+  }, [model.seasons, scope, timelineSearch, timelineSortDirection, timelineSortKey, activeTeam?.abbr, activeTeam?.name]);
+  const timelineShowingLabel = useMemo(
+    () => buildShowingLabel(filteredTimeline.length, totalTimelineSeasons, 'season'),
+    [filteredTimeline.length, totalTimelineSeasons],
+  );
 
   const completedGameRows = useMemo(() => {
     const rows = [];
@@ -458,11 +497,34 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
       <SectionCard title="Season-by-season timeline">
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 10 }}>
           <input
-            value={queryYear}
-            onChange={(e) => setQueryYear(e.target.value)}
-            placeholder="Filter by year"
+            aria-label="Search team history seasons"
+            value={timelineSearch}
+            onChange={(e) => setTimelineSearch(e.target.value)}
+            placeholder="Search year/result/MVP/team"
             style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)', minWidth: 160 }}
           />
+          <select
+            aria-label="Sort team history seasons"
+            value={timelineSortKey}
+            onChange={(e) => setTimelineSortKey(e.target.value)}
+            style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)' }}
+          >
+            <option value="year">Year</option>
+            <option value="wins">Wins</option>
+            <option value="losses">Losses</option>
+            <option value="pf">Points For</option>
+            <option value="pa">Points Allowed</option>
+            <option value="result">Playoff Result</option>
+          </select>
+          <select
+            aria-label="Sort direction for team history seasons"
+            value={timelineSortDirection}
+            onChange={(e) => setTimelineSortDirection(e.target.value)}
+            style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)' }}
+          >
+            <option value="desc">Desc</option>
+            <option value="asc">Asc</option>
+          </select>
           {[
             { key: 'all', label: 'All-time' },
             { key: 'playoff', label: 'Playoff-caliber' },
@@ -474,13 +536,28 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
               {opt.label}
             </button>
           ))}
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={() => {
+              setTimelineSearch('');
+              setScope('all');
+              setTimelineSortKey('year');
+              setTimelineSortDirection('desc');
+            }}
+          >
+            Reset filters
+          </button>
+        </div>
+        <div data-testid="team-history-timeline-showing" style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', marginBottom: 8 }}>
+          {timelineShowingLabel}
         </div>
         <div style={{ display: 'grid', gap: 8, maxHeight: 420, overflow: 'auto' }}>
           {filteredTimeline.length === 0 ? (
-            <EmptyState title="No team history for this filter" body="Adjust filters or archive more seasons." />
+            <EmptyState title="No team seasons match this filter" body="Reset filters or archive additional seasons to grow your timeline." />
           ) : (
-            filteredTimeline.slice().reverse().map((s) => (
-              <div key={s.year} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: 10 }}>
+            filteredTimeline.map((s) => (
+              <div key={s.year} data-testid={`team-history-season-row-${s.year}`} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: 10 }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
                   <strong>{s.year}</strong>
                   <span>

--- a/src/ui/components/__tests__/LeagueHistory.test.jsx
+++ b/src/ui/components/__tests__/LeagueHistory.test.jsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import LeagueHistory from '../LeagueHistory.jsx';
 
 describe('LeagueHistory', () => {
@@ -195,6 +195,83 @@ describe('LeagueHistory', () => {
     await waitFor(() => {
       expect(screen.getByTestId('league-history-major-tx-sx')).toBeTruthy();
       expect(screen.getByTestId('league-history-major-tx-sx').textContent).toMatch(/DAL signed Test Player/);
+    });
+  });
+
+  it('filters and resets archived season list controls', async () => {
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        initialSelectedSeasonId="s2"
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                { id: 's1', year: 2030, champion: { abbr: 'DAL' }, standings: [], awards: { mvp: { name: 'Alpha QB' } } },
+                { id: 's2', year: 2031, champion: { abbr: 'NYG' }, standings: [], awards: { mvp: { name: 'Bravo QB' } } },
+              ],
+            },
+          }),
+          getRecords: vi.fn().mockResolvedValue({ payload: { records: null } }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('league-history-season-showing').textContent).toContain('Showing 2 of 2 seasons');
+    });
+
+    fireEvent.change(screen.getByLabelText('Search archived seasons'), { target: { value: 'nyg' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('league-history-season-showing').textContent).toContain('Showing 1 of 2 seasons');
+    });
+    expect(screen.getByTestId('league-history-season-list-item-s2')).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText('Reset archived season filters'));
+    await waitFor(() => {
+      expect(screen.getByTestId('league-history-season-showing').textContent).toContain('Showing 2 of 2 seasons');
+    });
+  });
+
+  it('filters league office transactions by type and search', async () => {
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({ payload: { seasons: [{ id: 's1', year: 2030, standings: [], awards: {} }] } }),
+          getRecords: vi.fn().mockResolvedValue({ payload: { records: null } }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({
+            payload: {
+              transactions: [
+                { id: 'tx1', seasonId: 's1', week: 3, type: 'trade', typeLabel: 'Trade', playerName: 'Player One', fromTeamAbbr: 'DAL', toTeamAbbr: 'NYG' },
+                { id: 'tx2', seasonId: 's1', week: 4, type: 'signing', typeLabel: 'Signing', playerName: 'Player Two', teamAbbr: 'DAL' },
+              ],
+            },
+          }),
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'League Office' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('league-office-showing').textContent).toContain('Showing 2 of 2 transactions');
+    });
+
+    fireEvent.change(screen.getByLabelText('Filter league transactions by type'), { target: { value: 'Trade' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('league-office-showing').textContent).toContain('Showing 1 of 2 transactions');
+    });
+
+    fireEvent.change(screen.getByLabelText('Search league transactions'), { target: { value: 'missing player' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('league-office-showing').textContent).toContain('Showing 0 of 2 transactions');
     });
   });
 });

--- a/src/ui/components/__tests__/LeagueHistory.test.jsx
+++ b/src/ui/components/__tests__/LeagueHistory.test.jsx
@@ -1,10 +1,12 @@
 /** @vitest-environment jsdom */
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import LeagueHistory from '../LeagueHistory.jsx';
 
 describe('LeagueHistory', () => {
+  afterEach(() => cleanup());
+
   it('opens the selected archived season and handles missing championship data safely', async () => {
     render(
       <LeagueHistory
@@ -241,6 +243,7 @@ describe('LeagueHistory', () => {
     render(
       <LeagueHistory
         league={{ userTeamId: 1 }}
+        initialActiveTab="office"
         onPlayerSelect={vi.fn()}
         onOpenBoxScore={vi.fn()}
         actions={{
@@ -259,7 +262,6 @@ describe('LeagueHistory', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('tab', { name: 'League Office' }));
     await waitFor(() => {
       expect(screen.getByTestId('league-office-showing').textContent).toContain('Showing 2 of 2 transactions');
     });

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -256,17 +256,61 @@ describe('PlayerProfile', () => {
         payload: {
           player: {
             ...player,
-            careerStats: [
-              { season: 's1', year: 2030, team: 'DAL', gamesPlayed: 16, passYds: 3600, passTDs: 24, ints: 10, ovr: 79 },
-              { season: 's2', year: 2031, team: 'NYG', gamesPlayed: 17, passYds: 4200, passTDs: 31, ints: 8, ovr: 84 },
-            ],
+            careerStats: [],
           },
           stats: [],
           teammates: [],
           meta: {},
         },
       })),
-      getAllSeasons: vi.fn(async () => ({ payload: { seasons: [] } })),
+      getAllSeasons: vi.fn(async () => ({
+        payload: {
+          seasons: [
+            {
+              id: 's1',
+              year: 2030,
+              playerSeasonStatsV1: {
+                schemaVersion: 1,
+                rows: [{
+                  playerId: 11,
+                  playerName: 'Avery Fields',
+                  pos: 'QB',
+                  teamId: 1,
+                  teamAbbr: 'DAL',
+                  year: 2030,
+                  seasonId: 's1',
+                  gamesPlayed: 16,
+                  passYds: 3600,
+                  passTDs: 24,
+                  passInts: 10,
+                }],
+                meta: {},
+              },
+            },
+            {
+              id: 's2',
+              year: 2031,
+              playerSeasonStatsV1: {
+                schemaVersion: 1,
+                rows: [{
+                  playerId: 11,
+                  playerName: 'Avery Fields',
+                  pos: 'QB',
+                  teamId: 2,
+                  teamAbbr: 'NYG',
+                  year: 2031,
+                  seasonId: 's2',
+                  gamesPlayed: 17,
+                  passYds: 4200,
+                  passTDs: 31,
+                  passInts: 8,
+                }],
+                meta: {},
+              },
+            },
+          ],
+        },
+      })),
       getPlayerDraftContext: vi.fn(async () => ({ payload: { context: { known: false } } })),
       getRecords: vi.fn(async () => ({ payload: { recordBook: null } })),
     };
@@ -284,7 +328,7 @@ describe('PlayerProfile', () => {
     await waitFor(() => {
       expect(screen.getByTestId('player-profile-season-log-showing').textContent).toContain('Showing 1 of 2 seasons');
     });
-    expect(screen.getByText('DAL')).toBeTruthy();
+    expect(screen.getAllByText('DAL').length).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByLabelText('Reset player season log filters'));
     await waitFor(() => {

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -250,6 +250,48 @@ describe('PlayerProfile', () => {
     expect(screen.getByText('4,100')).toBeTruthy();
   });
 
+  it('supports season log search, sort, and reset controls', async () => {
+    const seasonLogActions = {
+      getPlayerCareer: vi.fn(async () => ({
+        payload: {
+          player: {
+            ...player,
+            careerStats: [
+              { season: 's1', year: 2030, team: 'DAL', gamesPlayed: 16, passYds: 3600, passTDs: 24, ints: 10, ovr: 79 },
+              { season: 's2', year: 2031, team: 'NYG', gamesPlayed: 17, passYds: 4200, passTDs: 31, ints: 8, ovr: 84 },
+            ],
+          },
+          stats: [],
+          teammates: [],
+          meta: {},
+        },
+      })),
+      getAllSeasons: vi.fn(async () => ({ payload: { seasons: [] } })),
+      getPlayerDraftContext: vi.fn(async () => ({ payload: { context: { known: false } } })),
+      getRecords: vi.fn(async () => ({ payload: { recordBook: null } })),
+    };
+    render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={seasonLogActions} teams={league.teams} league={league} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('player-profile-season-log-showing').textContent).toContain('Showing 2 of 2 seasons');
+    });
+
+    fireEvent.change(screen.getByLabelText('Sort player season log'), { target: { value: 'primaryStat' } });
+    const rows = screen.getAllByTestId(/player-profile-season-log-row-/i);
+    expect(rows[0].textContent).toContain('NYG');
+
+    fireEvent.change(screen.getByLabelText('Search player season log'), { target: { value: 'dal' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('player-profile-season-log-showing').textContent).toContain('Showing 1 of 2 seasons');
+    });
+    expect(screen.getByText('DAL')).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText('Reset player season log filters'));
+    await waitFor(() => {
+      expect(screen.getByTestId('player-profile-season-log-showing').textContent).toContain('Showing 2 of 2 seasons');
+    });
+  });
+
   it('shows honest empty award timeline when no honors exist', async () => {
     render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={actions} teams={league.teams} league={league} />);
     await waitFor(() => expect(screen.getByTestId('player-profile-award-timeline')).toBeTruthy());

--- a/src/ui/components/__tests__/TeamHistoryScreen.test.jsx
+++ b/src/ui/components/__tests__/TeamHistoryScreen.test.jsx
@@ -109,4 +109,65 @@ describe('TeamHistoryScreen', () => {
     const arg = onOpen.mock.calls[0][0];
     expect(String(arg)).toMatch(/2055/);
   });
+
+  it('filters, sorts, and resets season timeline rows', async () => {
+    render(
+      <TeamHistoryScreen
+        league={{ teams: [{ id: 7, name: 'Seattle', abbr: 'SEA' }], userTeamId: 7 }}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                {
+                  year: 2030,
+                  standings: [
+                    { id: 7, abbr: 'SEA', wins: 12, losses: 5, ties: 0, pf: 420, pa: 300 },
+                    { id: 9, abbr: 'RIV', wins: 8, losses: 9, ties: 0, pf: 320, pa: 360 },
+                  ],
+                  champion: { id: 7, abbr: 'SEA' },
+                  runnerUp: { id: 9, abbr: 'RIV' },
+                  playoffBracketSnapshot: { mode: 'empty', rounds: [] },
+                },
+                {
+                  year: 2031,
+                  standings: [
+                    { id: 7, abbr: 'SEA', wins: 8, losses: 9, ties: 0, pf: 300, pa: 330 },
+                    { id: 5, abbr: 'BOS', wins: 11, losses: 6, ties: 0, pf: 390, pa: 310 },
+                  ],
+                  champion: { id: 5, abbr: 'BOS' },
+                  runnerUp: { id: 7, abbr: 'SEA' },
+                  playoffBracketSnapshot: { mode: 'empty', rounds: [] },
+                },
+              ],
+            },
+          }),
+          getHallOfFame: vi.fn().mockResolvedValue({ payload: { players: [], classes: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+          getDraftClasses: vi.fn().mockResolvedValue({ payload: { classes: [] } }),
+          getDraftClass: vi.fn().mockResolvedValue({ payload: { model: null } }),
+        }}
+        onBack={vi.fn()}
+        onPlayerSelect={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-timeline-showing').textContent).toContain('Showing 2 of 2 seasons');
+    });
+
+    fireEvent.change(screen.getByLabelText('Sort team history seasons'), { target: { value: 'wins' } });
+    const sortedRows = screen.getAllByTestId(/team-history-season-row-/i);
+    expect(sortedRows[0].textContent).toContain('2030');
+
+    fireEvent.change(screen.getByLabelText('Search team history seasons'), { target: { value: 'champion' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-timeline-showing').textContent).toContain('Showing 1 of 2 seasons');
+    });
+    expect(screen.getByTestId('team-history-season-row-2030')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset filters' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-timeline-showing').textContent).toContain('Showing 2 of 2 seasons');
+    });
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Implemented focused history-browser density upgrades across 4 high-impact archive surfaces without changing simulation/economy/history storage.

### Screens improved
1. `TeamHistoryScreen` (season timeline)
2. `PlayerProfile` (season log)
3. `LeagueHistory` season archive panel (`SeasonExplorer`)
4. `LeagueHistory` league activity/transactions (`LeagueOfficeHistory`)

### Data-browser behaviors added
- Shared helper reuse from `src/ui/utils/dataBrowser.js` (`rowMatchesSearch`, `stableSortRows`, `uniqueFilterOptions`, `buildShowingLabel`).
- Search + sort + filter + reset controls where relevant.
- "Showing X of Y …" labels on surfaced lists.
- Stable sort fallbacks for deterministic ordering.
- Empty-state safety for young saves / missing archive data.

### Fields used (no fabricated data)
- Team History timeline: `year`, `wins/losses/ties`, `pf`, `pa`, champion/runner-up/playoff-caliber flags, MVP name.
- Player season log: `season/year`, `team`, `gamesPlayed`, position-relevant key stat, `ovr`.
- League History seasons: `year`, champion, runner-up, MVP, user-team W-L context.
- League Office: transaction `type/typeLabel`, `headline/detail`, `player/team`, `seasonId/week`.

### Fallback behavior
- No fabricated seasons/champions/awards/transactions.
- Filtered-empty states render safely with clear reset guidance.
- Saves lacking archive depth continue to render without crashes.

### Mobile UX notes
- Controls are compact and wrap-friendly.
- Existing card/list layouts were preserved (no app-shell rewrite).
- Dense rows remain scroll-safe and readable on small widths.

### Walkthrough artifacts
[season archive controls](https://cursor.com/agents/bc-0e6481d9-0274-423a-aaf1-996ec2c7ece0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_density_season_archive_initial.webp)
[league office filtered](https://cursor.com/agents/bc-0e6481d9-0274-423a-aaf1-996ec2c7ece0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_density_league_office_filtered.webp)
[league office reset](https://cursor.com/agents/bc-0e6481d9-0274-423a-aaf1-996ec2c7ece0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_density_league_office_reset.webp)

### Tests run
- `node --check src/ui/utils/dataBrowser.js`
- `npm run test:unit -- src/ui/utils/dataBrowser.test.js`
- `npm run test:unit -- src/ui/components/__tests__/TeamHistoryScreen.test.jsx src/ui/components/__tests__/PlayerProfile.test.jsx src/ui/components/__tests__/LeagueHistory.test.jsx`
- `npm run test:unit`
- `npm run test:soak`
- `npm run audit:dynasty -- --ci --seed=1383` (runtime ~6.8s, pass with expected early-save HOF warning)
- `npm run build`
- `npm run check:deploy`
- `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js`
- `npx playwright test`

### Intentionally deferred
- Additional history surfaces (Awards/Records/HOF standalone screens, draft memory deep pass) were deferred to keep this PR reviewable and within the requested 2–4 surface scope.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e6481d9-0274-423a-aaf1-996ec2c7ece0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e6481d9-0274-423a-aaf1-996ec2c7ece0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

