### PR TITLE
Improve history data browsing on archive screens

### DIFF
--- a/src/ui/components/DraftHistory.jsx
+++ b/src/ui/components/DraftHistory.jsx
@@ -1,7 +1,16 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ScreenHeader, SectionCard } from './ScreenSystem.jsx';
+import { buildShowingLabel, rowMatchesSearch, stableSortRows, uniqueFilterOptions } from '../utils/dataBrowser.js';
 
 const EMPTY_COPY = 'Draft history will appear after completed drafts are logged in your dynasty.';
+const DRAFT_SORT_OPTIONS = [
+  { value: 'overall', label: 'Original order' },
+  { value: 'playerName', label: 'Player' },
+  { value: 'draftTeamAbbr', label: 'Team' },
+  { value: 'redraftRank', label: 'Redraft rank' },
+  { value: 'redraftDelta', label: 'Redraft delta' },
+  { value: 'legacyScore', label: 'Legacy score' },
+];
 
 export default function DraftHistory({ league, actions, onPlayerSelect, onNavigate }) {
   const [classes, setClasses] = useState([]);
@@ -10,6 +19,11 @@ export default function DraftHistory({ league, actions, onPlayerSelect, onNaviga
   const [loadingList, setLoadingList] = useState(true);
   const [loadingModel, setLoadingModel] = useState(false);
   const [error, setError] = useState(null);
+  const [search, setSearch] = useState('');
+  const [teamFilter, setTeamFilter] = useState('ALL');
+  const [positionFilter, setPositionFilter] = useState('ALL');
+  const [sortKey, setSortKey] = useState('overall');
+  const [sortDir, setSortDir] = useState('asc');
 
   const loadList = useCallback(() => {
     if (!actions?.getDraftClasses) return Promise.resolve();
@@ -59,6 +73,34 @@ export default function DraftHistory({ league, actions, onPlayerSelect, onNaviga
 
   const summary = model?.classSummary;
   const developing = summary?.isDevelopingClass;
+  const teamOptions = useMemo(() => uniqueFilterOptions(model?.picks ?? [], (pick) => pick?.draftTeamAbbr ?? ''), [model?.picks]);
+  const positionOptions = useMemo(() => uniqueFilterOptions(model?.picks ?? [], (pick) => pick?.pos ?? ''), [model?.picks]);
+  const fullClassRows = useMemo(() => {
+    const filtered = (model?.picks ?? []).filter((pick) => {
+      if (teamFilter !== 'ALL' && (pick?.draftTeamAbbr ?? '') !== teamFilter) return false;
+      if (positionFilter !== 'ALL' && (pick?.pos ?? '') !== positionFilter) return false;
+      return rowMatchesSearch(pick, search, [
+        'overall',
+        'playerName',
+        'pos',
+        'draftTeamAbbr',
+        'outcomeLabel',
+        'redraftRank',
+        'redraftDelta',
+      ]);
+    });
+    return stableSortRows(filtered, (pick) => pick?.[sortKey], sortDir, (pick) => pick?.overall ?? 999);
+  }, [model?.picks, positionFilter, search, sortDir, sortKey, teamFilter]);
+  const hasClassFilters = Boolean(search.trim()) || teamFilter !== 'ALL' || positionFilter !== 'ALL' || sortKey !== 'overall' || sortDir !== 'asc';
+
+  useEffect(() => {
+    if (teamFilter !== 'ALL' && !teamOptions.includes(teamFilter)) {
+      setTeamFilter('ALL');
+    }
+    if (positionFilter !== 'ALL' && !positionOptions.includes(positionFilter)) {
+      setPositionFilter('ALL');
+    }
+  }, [positionFilter, positionOptions, teamFilter, teamOptions]);
 
   return (
     <div className="app-screen-stack" data-testid="draft-history-root">
@@ -193,39 +235,141 @@ export default function DraftHistory({ league, actions, onPlayerSelect, onNaviga
 
           {model?.picks?.length > 0 && (
             <SectionCard title="Full class" subtitle="Original order · redraft rank · outcome.">
-              <div style={{ overflowX: 'auto' }}>
-                <table className="table-compact" style={{ width: '100%', fontSize: 'var(--text-xs)' }}>
-                  <thead>
-                    <tr>
-                      <th>Ovr</th>
-                      <th>Player</th>
-                      <th>Pos</th>
-                      <th>By</th>
-                      <th>Redraft</th>
-                      <th>Outcome</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {model.picks.map((p) => (
-                      <tr key={p.playerId}>
-                        <td>{p.overall ?? '—'}</td>
-                        <td>
-                          <button
-                            type="button"
-                            style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: 'var(--accent)', fontWeight: 600 }}
-                            onClick={() => p.playerId != null && onPlayerSelect?.(p.playerId)}
-                          >
-                            {p.playerName}
-                          </button>
-                        </td>
-                        <td>{p.pos}</td>
-                        <td>{p.draftTeamAbbr ?? '—'}</td>
-                        <td>{p.redraftRank ?? '—'}</td>
-                        <td>{p.outcomeLabel}</td>
-                      </tr>
+              <div style={{ display: 'grid', gap: 8 }}>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                  <input
+                    aria-label="Search draft history picks"
+                    type="search"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    placeholder="Search player, team, outcome"
+                    style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)', minWidth: 220, flex: '1 1 220px' }}
+                  />
+                  <select
+                    aria-label="Filter draft history picks by team"
+                    value={teamFilter}
+                    onChange={(e) => setTeamFilter(e.target.value)}
+                    style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)', minWidth: 120 }}
+                  >
+                    <option value="ALL">All teams</option>
+                    {teamOptions.map((team) => (
+                      <option key={team} value={team}>{team}</option>
                     ))}
-                  </tbody>
-                </table>
+                  </select>
+                  <select
+                    aria-label="Filter draft history picks by position"
+                    value={positionFilter}
+                    onChange={(e) => setPositionFilter(e.target.value)}
+                    style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)', minWidth: 120 }}
+                  >
+                    <option value="ALL">All positions</option>
+                    {positionOptions.map((position) => (
+                      <option key={position} value={position}>{position}</option>
+                    ))}
+                  </select>
+                  <select
+                    aria-label="Sort draft history picks"
+                    value={sortKey}
+                    onChange={(e) => setSortKey(e.target.value)}
+                    style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)', minWidth: 140 }}
+                  >
+                    {DRAFT_SORT_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>{option.label}</option>
+                    ))}
+                  </select>
+                  <button type="button" className="btn btn-secondary" aria-label="Toggle draft history sort direction" onClick={() => setSortDir((prev) => (prev === 'asc' ? 'desc' : 'asc'))}>
+                    {sortDir === 'asc' ? 'Lowest/A first' : 'Highest/Z first'}
+                  </button>
+                  {hasClassFilters ? (
+                    <button
+                      type="button"
+                      className="btn btn-secondary"
+                      onClick={() => {
+                        setSearch('');
+                        setTeamFilter('ALL');
+                        setPositionFilter('ALL');
+                        setSortKey('overall');
+                        setSortDir('asc');
+                      }}
+                    >
+                      Reset filters
+                    </button>
+                  ) : null}
+                </div>
+                <div data-testid="draft-history-class-count" style={{ display: 'flex', flexWrap: 'wrap', gap: 10, fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+                  <span>{buildShowingLabel(fullClassRows.length, model.picks.length, 'pick')}</span>
+                  <span>Sort: {DRAFT_SORT_OPTIONS.find((option) => option.value === sortKey)?.label ?? sortKey} {sortDir === 'asc' ? '↑' : '↓'}</span>
+                  {teamFilter !== 'ALL' ? <span>Team: {teamFilter}</span> : null}
+                  {positionFilter !== 'ALL' ? <span>Pos: {positionFilter}</span> : null}
+                </div>
+                {fullClassRows.length === 0 ? (
+                  <div style={{ fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}>
+                    No draft picks match those filters.
+                  </div>
+                ) : (
+                  <>
+                    <div className="grid gap-2 md:hidden" data-testid="draft-history-class-cards">
+                      {fullClassRows.map((p) => (
+                        <div key={`card-${p.playerId ?? p.overall}`} data-testid={`draft-history-pick-card-${p.playerId ?? p.overall}`} className="card" style={{ padding: 'var(--space-3)', fontSize: 'var(--text-xs)' }}>
+                          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'center' }}>
+                            <strong>#{p.overall ?? '—'}</strong>
+                            <span style={{ color: 'var(--text-muted)' }}>{p.draftTeamAbbr ?? '—'} · {p.pos ?? '—'}</span>
+                          </div>
+                          <div style={{ marginTop: 6 }}>
+                            <button
+                              type="button"
+                              style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: 'var(--accent)', fontWeight: 700 }}
+                              onClick={() => p.playerId != null && onPlayerSelect?.(p.playerId)}
+                            >
+                              {p.playerName}
+                            </button>
+                          </div>
+                          <div style={{ color: 'var(--text-muted)', marginTop: 4 }}>
+                            Redraft #{p.redraftRank ?? '—'}
+                            {p.redraftDelta != null ? ` · Δ${p.redraftDelta}` : ''}
+                          </div>
+                          <div style={{ marginTop: 4 }}>{p.outcomeLabel ?? 'Outcome pending'}</div>
+                        </div>
+                      ))}
+                    </div>
+                    <div className="hidden md:block" style={{ overflowX: 'auto' }}>
+                      <table className="table-compact" style={{ width: '100%', fontSize: 'var(--text-xs)' }}>
+                        <thead>
+                          <tr>
+                            <th>Ovr</th>
+                            <th>Player</th>
+                            <th>Pos</th>
+                            <th>By</th>
+                            <th>Redraft</th>
+                            <th>Delta</th>
+                            <th>Outcome</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {fullClassRows.map((p) => (
+                            <tr key={p.playerId}>
+                              <td>{p.overall ?? '—'}</td>
+                              <td>
+                                <button
+                                  type="button"
+                                  style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', color: 'var(--accent)', fontWeight: 600 }}
+                                  onClick={() => p.playerId != null && onPlayerSelect?.(p.playerId)}
+                                >
+                                  {p.playerName}
+                                </button>
+                              </td>
+                              <td>{p.pos}</td>
+                              <td>{p.draftTeamAbbr ?? '—'}</td>
+                              <td>{p.redraftRank ?? '—'}</td>
+                              <td>{p.redraftDelta ?? '—'}</td>
+                              <td>{p.outcomeLabel}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </>
+                )}
               </div>
             </SectionCard>
           )}

--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -8,6 +8,7 @@ import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/b
 import { AWARD_DISPLAY_NAMES } from '../../core/footballMeta';
 import { buildLeagueHistoryTopPerformers } from '../../core/playerSeasonStatsArchive.js';
 import { normalizeArchivedMajorTransactions } from '../../core/transactionTimeline.js';
+import { buildShowingLabel, rowMatchesSearch, stableSortRows, uniqueFilterOptions } from "../utils/dataBrowser.js";
 
 const RECORD_LABELS = {
   passYd: "Passing Yards",
@@ -71,6 +72,32 @@ const PLAYER_LEADER_LABELS = {
   interceptions: "Interceptions",
   fieldGoalsMade: "Field goals",
 };
+
+const SEASON_SORT_OPTIONS = [
+  { value: "year", label: "Year" },
+  { value: "champion", label: "Champion" },
+  { value: "userWins", label: "Your wins" },
+];
+
+function buildSeasonArchiveSearchText(season) {
+  return [
+    season?.year,
+    season?.champion?.abbr,
+    season?.champion?.name,
+    season?.runnerUp?.abbr,
+    season?.runnerUp?.name,
+    season?.awards?.mvp?.name,
+    (season?.standings ?? []).map((team) => `${team?.abbr ?? ""} ${team?.name ?? ""}`).join(" "),
+  ].filter(Boolean).join(" ");
+}
+
+function transactionTypeLabel(tx) {
+  return tx?.typeLabel ?? tx?.type ?? tx?.legacyType ?? "Other";
+}
+
+function transactionSortStamp(tx) {
+  return `${tx?.seasonId ?? tx?.year ?? ""} ${tx?.week ?? ""} ${tx?.id ?? tx?.rawId ?? ""}`;
+}
 
 function pct(row) {
   const wins = Number(row?.wins ?? 0);
@@ -342,6 +369,10 @@ function SeasonDraftClassSnippet({ seasonId, year, actions, onPlayerSelect }) {
 
 function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, league, initialSelectedSeasonId = null }) {
   const [selectedSeasonId, setSelectedSeasonId] = useState(initialSelectedSeasonId ?? seasons?.[0]?.id ?? null);
+  const [search, setSearch] = useState("");
+  const [championFilter, setChampionFilter] = useState("ALL");
+  const [sortKey, setSortKey] = useState("year");
+  const [sortDir, setSortDir] = useState("desc");
 
   useEffect(() => {
     if (!seasons?.length) return;
@@ -352,6 +383,37 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
     }
     setSelectedSeasonId((prev) => prev ?? seasons[0]?.id ?? null);
   }, [initialSelectedSeasonId, seasons]);
+
+  const championOptions = useMemo(
+    () => uniqueFilterOptions(seasons, (season) => season?.champion?.abbr ?? season?.champion?.name ?? ""),
+    [seasons],
+  );
+
+  const filteredSeasons = useMemo(() => {
+    const rows = (seasons ?? []).filter((season) => {
+      const champion = season?.champion?.abbr ?? season?.champion?.name ?? "";
+      if (championFilter !== "ALL" && champion !== championFilter) return false;
+      return rowMatchesSearch(season, search, [
+        "year",
+        buildSeasonArchiveSearchText,
+      ]);
+    });
+    return stableSortRows(rows, (season) => {
+      if (sortKey === "champion") return season?.champion?.abbr ?? season?.champion?.name ?? "";
+      if (sortKey === "userWins") {
+        return (season?.standings ?? []).find((row) => Number(row?.id) === Number(league?.userTeamId))?.wins ?? -1;
+      }
+      return season?.year ?? 0;
+    }, sortDir, (season) => season?.year ?? 0);
+  }, [championFilter, league?.userTeamId, search, seasons, sortDir, sortKey]);
+
+  useEffect(() => {
+    if (!filteredSeasons.length) return;
+    const exists = filteredSeasons.some((season) => String(season?.id) === String(selectedSeasonId));
+    if (!exists) {
+      setSelectedSeasonId(filteredSeasons[0]?.id ?? null);
+    }
+  }, [filteredSeasons, selectedSeasonId]);
 
   if (!seasons?.length) {
     return (
@@ -364,7 +426,7 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
     );
   }
 
-  const selected = seasons.find((s) => s.id === selectedSeasonId) ?? seasons[0];
+  const selected = filteredSeasons.find((s) => s.id === selectedSeasonId) ?? filteredSeasons[0] ?? null;
   const sortedStandings = [...(selected?.standings ?? [])].sort((a, b) => pct(b) - pct(a)).slice(0, 8);
   const championBoard = buildChampionMap(seasons).slice(0, 5);
   const playoffMentions = (selected?.standings ?? []).filter((row) => Number(row?.wins ?? 0) >= 10).slice(0, 6);
@@ -379,8 +441,9 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
     .filter((entry) => entry.award?.name);
   const championshipGame = (selected?.gameIndex ?? []).find((g) => String(g?.id) === String(selected?.championshipGameId)) ?? null;
   const notableGames = Array.isArray(selected?.notableGames) ? selected.notableGames : [];
-  const selectedSeasonIndex = seasons.findIndex((s) => s.id === selected?.id);
+  const selectedSeasonIndex = filteredSeasons.findIndex((s) => s.id === selected?.id);
   const topPerformers = useMemo(() => buildLeagueHistoryTopPerformers(selected, { perBucket: 2 }), [selected]);
+  const hasSeasonFilters = Boolean(search.trim()) || championFilter !== "ALL" || sortKey !== "year" || sortDir !== "desc";
 
   const seasonMajorTx = useMemo(() => {
     const v1 = selected?.transactionTimelineV1?.rows;
@@ -401,19 +464,100 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
     <div className="grid grid-cols-1 lg:grid-cols-[260px_1fr] gap-4">
       <Card className="card-premium">
         <CardHeader><CardTitle>Season Archive</CardTitle></CardHeader>
-        <CardContent className="p-0">
+        <CardContent className="p-3 space-y-3">
+          <div className="space-y-2">
+            <input
+              aria-label="Search league history seasons"
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search year, champion, team, MVP"
+              className="h-9 w-full rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-sm"
+            />
+            <div className="flex flex-wrap gap-2">
+              <select
+                aria-label="Filter league history seasons by champion"
+                className="h-9 min-w-[130px] rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-sm"
+                value={championFilter}
+                onChange={(e) => setChampionFilter(e.target.value)}
+              >
+                <option value="ALL">All champions</option>
+                {championOptions.map((option) => (
+                  <option key={option} value={option}>{option}</option>
+                ))}
+              </select>
+              <select
+                aria-label="Sort league history seasons"
+                className="h-9 min-w-[120px] rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-sm"
+                value={sortKey}
+                onChange={(e) => setSortKey(e.target.value)}
+              >
+                {SEASON_SORT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+              <button
+                type="button"
+                className="btn btn-secondary h-9 text-sm"
+                aria-label="Toggle league history season sort direction"
+                onClick={() => setSortDir((prev) => (prev === "asc" ? "desc" : "asc"))}
+              >
+                {sortDir === "desc" ? "Newest/highest first" : "Oldest/lowest first"}
+              </button>
+              {hasSeasonFilters ? (
+                <button
+                  type="button"
+                  className="btn btn-secondary h-9 text-sm"
+                  onClick={() => {
+                    setSearch("");
+                    setChampionFilter("ALL");
+                    setSortKey("year");
+                    setSortDir("desc");
+                  }}
+                >
+                  Reset filters
+                </button>
+              ) : null}
+            </div>
+            <div
+              data-testid="league-season-archive-count"
+              className="flex flex-wrap gap-2 text-xs text-[color:var(--text-muted)]"
+            >
+              <span>{buildShowingLabel(filteredSeasons.length, seasons.length, "season")}</span>
+              <span>Sort: {SEASON_SORT_OPTIONS.find((option) => option.value === sortKey)?.label ?? sortKey} {sortDir === "asc" ? "↑" : "↓"}</span>
+              {championFilter !== "ALL" ? <span>Champion: {championFilter}</span> : null}
+            </div>
+          </div>
           <ScrollArea className="h-[520px]">
             <div className="divide-y divide-[color:var(--hairline)]">
-              {seasons.map((s) => (
-                <button
-                  key={s.id}
-                  className={`w-full text-left px-4 py-3 ${selected?.id === s.id ? "bg-[color:var(--surface-strong)]" : ""}`}
-                  onClick={() => setSelectedSeasonId(s.id)}
-                >
-                  <div className="font-bold text-sm">{s.year}</div>
-                  <div className="text-xs text-[color:var(--text-muted)]">{s.champion?.abbr ?? "TBD"} champion</div>
-                </button>
-              ))}
+              {filteredSeasons.length === 0 ? (
+                <div className="px-4 py-6 text-sm text-[color:var(--text-muted)]">
+                  No archived seasons match these filters.
+                </div>
+              ) : filteredSeasons.map((s) => {
+                const userRow = (s?.standings ?? []).find((row) => Number(row?.id) === Number(league?.userTeamId));
+                return (
+                  <button
+                    key={s.id}
+                    data-testid={`league-season-button-${s.id}`}
+                    className={`w-full text-left px-4 py-3 ${selected?.id === s.id ? "bg-[color:var(--surface-strong)]" : ""}`}
+                    onClick={() => setSelectedSeasonId(s.id)}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="font-bold text-sm">{s.year}</div>
+                      {s.champion?.abbr ? <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">{s.champion.abbr}</Badge> : null}
+                    </div>
+                    <div className="text-xs text-[color:var(--text-muted)]">
+                      {s.champion?.abbr ?? s.champion?.name ?? "Champion TBD"}
+                      {s.runnerUp?.abbr || s.runnerUp?.name ? ` over ${s.runnerUp?.abbr ?? s.runnerUp?.name}` : ""}
+                    </div>
+                    <div className="text-[11px] text-[color:var(--text-muted)] mt-1">
+                      {userRow ? `You: ${userRow.wins}-${userRow.losses}${userRow.ties ? `-${userRow.ties}` : ""}` : "League snapshot"}
+                      {s.awards?.mvp?.name ? ` · MVP ${s.awards.mvp.name}` : ""}
+                    </div>
+                  </button>
+                );
+              })}
             </div>
           </ScrollArea>
         </CardContent>
@@ -421,12 +565,18 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
 
       <Card className="card-premium">
         <CardHeader>
-          <CardTitle>{selected?.year} League Snapshot</CardTitle>
+          <CardTitle>{selected?.year ?? "Filtered"} League Snapshot</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
+          {!selected ? (
+            <div className="rounded-md border border-[color:var(--hairline)] px-4 py-8 text-center text-sm text-[color:var(--text-muted)]">
+              No archived seasons match the current search or champion filter.
+            </div>
+          ) : (
+            <>
           <div className="flex flex-wrap items-center gap-2">
-            <button className="btn" onClick={() => selectedSeasonIndex > 0 && setSelectedSeasonId(seasons[selectedSeasonIndex - 1].id)} disabled={selectedSeasonIndex <= 0}>Previous season</button>
-            <button className="btn" onClick={() => selectedSeasonIndex < seasons.length - 1 && setSelectedSeasonId(seasons[selectedSeasonIndex + 1].id)} disabled={selectedSeasonIndex >= seasons.length - 1}>Next season</button>
+            <button className="btn" onClick={() => selectedSeasonIndex > 0 && setSelectedSeasonId(filteredSeasons[selectedSeasonIndex - 1].id)} disabled={selectedSeasonIndex <= 0}>Previous season</button>
+            <button className="btn" onClick={() => selectedSeasonIndex < filteredSeasons.length - 1 && setSelectedSeasonId(filteredSeasons[selectedSeasonIndex + 1].id)} disabled={selectedSeasonIndex >= filteredSeasons.length - 1}>Next season</button>
           </div>
           <div className="rounded-md border border-[color:var(--hairline)] px-3 py-2 text-sm text-[color:var(--text-muted)]">{seasonStoryline}</div>
 
@@ -703,6 +853,8 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
               </div>
             </section>
           )}
+            </>
+          )}
         </CardContent>
       </Card>
     </div>
@@ -838,9 +990,10 @@ function AwardsHistory({ seasons, onPlayerSelect }) {
 }
 
 function LeagueOfficeHistory({ transactions, onPlayerSelect }) {
-  if (!transactions?.length) return <div className="py-8 text-center text-[color:var(--text-muted)]">No transaction history tracked yet.</div>;
+  const [search, setSearch] = useState("");
+  const [typeFilter, setTypeFilter] = useState("ALL");
+  const [sortDir, setSortDir] = useState("desc");
 
-  const rows = transactions.slice(0, 120);
   const describe = (tx) => {
     const leg = tx.legacyType ?? "";
     const bucket = tx.type ?? "";
@@ -863,26 +1016,113 @@ function LeagueOfficeHistory({ transactions, onPlayerSelect }) {
     return tx.headline ?? tx.typeLabel ?? tx.type;
   };
 
+  const typeOptions = useMemo(
+    () => uniqueFilterOptions(transactions, (tx) => transactionTypeLabel(tx)),
+    [transactions],
+  );
+
+  const rows = useMemo(() => {
+    const filtered = (transactions ?? []).filter((tx) => {
+      if (typeFilter !== "ALL" && transactionTypeLabel(tx) !== typeFilter) return false;
+      return rowMatchesSearch(tx, search, [
+        "headline",
+        "detail",
+        "playerName",
+        "teamAbbr",
+        "fromTeamAbbr",
+        "toTeamAbbr",
+        transactionTypeLabel,
+      ]);
+    });
+    return stableSortRows(filtered, transactionSortStamp, sortDir, (tx) => tx?.headline ?? tx?.playerName ?? "");
+  }, [search, sortDir, transactions, typeFilter]);
+
+  const hasFilters = Boolean(search.trim()) || typeFilter !== "ALL" || sortDir !== "desc";
+
+  if (!transactions?.length) return <div className="py-8 text-center text-[color:var(--text-muted)]">No transaction history tracked yet.</div>;
+
   return (
     <Card className="card-premium">
       <CardHeader><CardTitle>League Moves Log</CardTitle></CardHeader>
-      <CardContent className="p-0">
-        <ScrollArea className="h-[560px]">
-          <div className="divide-y divide-[color:var(--hairline)]">
-            {rows.map((tx, idx) => (
-              <div key={`${tx.id ?? idx}`} className="px-4 py-3 text-sm">
-                <div className="flex items-center justify-between gap-2">
-                  <strong>{tx.typeLabel ?? tx.type}</strong>
-                  <span className="text-xs text-[color:var(--text-muted)]">Week {tx.week ?? "?"}</span>
-                </div>
-                <div className="text-[color:var(--text-muted)] mt-1">{describe(tx)}</div>
-                {tx.playerId != null && (
-                  <button className="btn mt-2 text-xs" onClick={() => onPlayerSelect?.(tx.playerId)}>Open player</button>
-                )}
-              </div>
-            ))}
+      <CardContent className="p-3 space-y-3">
+        <div className="space-y-2">
+          <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+            <input
+              aria-label="Search league office transactions"
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search player, team, type"
+              className="h-9 flex-1 min-w-[180px] rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-sm"
+            />
+            <select
+              aria-label="Filter league office transactions by type"
+              className="h-9 min-w-[150px] rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-sm"
+              value={typeFilter}
+              onChange={(e) => setTypeFilter(e.target.value)}
+            >
+              <option value="ALL">All types</option>
+              {typeOptions.map((option) => (
+                <option key={option} value={option}>{option}</option>
+              ))}
+            </select>
+            <select
+              aria-label="Sort league office transactions"
+              className="h-9 min-w-[140px] rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-sm"
+              value={sortDir}
+              onChange={(e) => setSortDir(e.target.value)}
+            >
+              <option value="desc">Newest first</option>
+              <option value="asc">Oldest first</option>
+            </select>
+            {hasFilters ? (
+              <button
+                type="button"
+                className="btn btn-secondary h-9 text-sm"
+                onClick={() => {
+                  setSearch("");
+                  setTypeFilter("ALL");
+                  setSortDir("desc");
+                }}
+              >
+                Reset filters
+              </button>
+            ) : null}
           </div>
-        </ScrollArea>
+          <div data-testid="league-office-count" className="flex flex-wrap gap-2 text-xs text-[color:var(--text-muted)]">
+            <span>{buildShowingLabel(rows.length, transactions.length, "transaction")}</span>
+            {typeFilter !== "ALL" ? <span>Type: {typeFilter}</span> : null}
+            <span>Sort: {sortDir === "desc" ? "Newest first" : "Oldest first"}</span>
+          </div>
+        </div>
+        {rows.length === 0 ? (
+          <div className="rounded-md border border-[color:var(--hairline)] px-4 py-8 text-center text-sm text-[color:var(--text-muted)]">
+            No transactions match these filters.
+          </div>
+        ) : (
+          <ScrollArea className="h-[560px]">
+            <div className="divide-y divide-[color:var(--hairline)]">
+              {rows.map((tx, idx) => (
+                <div key={`${tx.id ?? idx}`} data-testid={`league-office-row-${tx.id ?? idx}`} className="px-4 py-3 text-sm">
+                  <div className="flex items-center justify-between gap-2">
+                    <strong>{transactionTypeLabel(tx)}</strong>
+                    <span className="text-xs text-[color:var(--text-muted)]">
+                      {tx.seasonId ?? tx.year ?? "Season ?"}
+                      {tx.week != null ? ` · Week ${tx.week}` : ""}
+                    </span>
+                  </div>
+                  <div className="text-[color:var(--text-muted)] mt-1">{describe(tx)}</div>
+                  <div className="mt-1 text-xs text-[color:var(--text-muted)]">
+                    {[tx.teamAbbr, tx.fromTeamAbbr && tx.toTeamAbbr ? `${tx.fromTeamAbbr} ↔ ${tx.toTeamAbbr}` : null].filter(Boolean).join(" · ")}
+                  </div>
+                  {tx.playerId != null && (
+                    <button className="btn mt-2 text-xs" onClick={() => onPlayerSelect?.(tx.playerId)}>Open player</button>
+                  )}
+                </div>
+              ))}
+            </div>
+          </ScrollArea>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -9,7 +9,6 @@ import { AWARD_DISPLAY_NAMES } from '../../core/footballMeta';
 import { buildLeagueHistoryTopPerformers } from '../../core/playerSeasonStatsArchive.js';
 import { normalizeArchivedMajorTransactions } from '../../core/transactionTimeline.js';
 import { buildShowingLabel, rowMatchesSearch, stableSortRows, uniqueFilterOptions } from "../utils/dataBrowser.js";
-import { buildShowingLabel, rowMatchesSearch, stableSortRows, uniqueFilterOptions } from '../utils/dataBrowser.js';
 
 const RECORD_LABELS = {
   passYd: "Passing Yards",
@@ -109,19 +108,6 @@ function pct(row) {
   return (wins + ties * 0.5) / games;
 }
 
-function seasonTokenToNumber(value) {
-  if (value == null) return 0;
-  const numeric = Number(value);
-  if (Number.isFinite(numeric)) return numeric;
-  const text = String(value);
-  if (text.startsWith("s")) {
-    const parsed = Number(text.slice(1));
-    if (Number.isFinite(parsed)) return parsed;
-  }
-  const fallback = Number(text.replace(/[^\d.-]/g, ""));
-  return Number.isFinite(fallback) ? fallback : 0;
-}
-
 function buildChampionMap(seasons = []) {
   const map = new Map();
   for (const season of seasons) {
@@ -150,14 +136,14 @@ function summarizeSeasonStoryline(season, userTeamId) {
   return lines.join(" ");
 }
 
-export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenBoxScore, initialSelectedSeasonId = null, initialActiveTab = "seasons" }) {
+export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenBoxScore, initialSelectedSeasonId = null }) {
   const api = actions ?? NOOP_ACTIONS;
   const [seasons, setSeasons] = useState([]);
   const [records, setRecords] = useState(null);
   const [recordBook, setRecordBook] = useState(null);
   const [allPlayers, setAllPlayers] = useState([]);
   const [transactions, setTransactions] = useState([]);
-  const [activeTab, setActiveTab] = useState(initialActiveTab);
+  const [activeTab, setActiveTab] = useState("seasons");
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -387,9 +373,6 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
   const [championFilter, setChampionFilter] = useState("ALL");
   const [sortKey, setSortKey] = useState("year");
   const [sortDir, setSortDir] = useState("desc");
-  const [seasonSearch, setSeasonSearch] = useState("");
-  const [seasonSortKey, setSeasonSortKey] = useState("year");
-  const [seasonSortDirection, setSeasonSortDirection] = useState("desc");
 
   useEffect(() => {
     if (!seasons?.length) return;
@@ -432,43 +415,6 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
     }
   }, [filteredSeasons, selectedSeasonId]);
 
-  const seasonRows = useMemo(() => {
-    const filtered = (seasons ?? []).filter((season) => rowMatchesSearch(season, seasonSearch, [
-      "year",
-      (row) => row?.champion?.abbr ?? row?.champion?.name ?? "",
-      (row) => row?.runnerUp?.abbr ?? row?.runnerUp?.name ?? "",
-      (row) => row?.awards?.mvp?.name ?? "",
-      (row) => {
-        const userRow = (row?.standings ?? []).find((team) => Number(team?.id) === Number(league?.userTeamId));
-        return userRow ? `${userRow.wins ?? 0}-${userRow.losses ?? 0}${userRow.ties ? `-${userRow.ties}` : ""}` : "";
-      },
-    ]));
-    return stableSortRows(
-      filtered,
-      (season) => {
-        const userRow = (season?.standings ?? []).find((team) => Number(team?.id) === Number(league?.userTeamId));
-        switch (seasonSortKey) {
-          case "champion":
-            return String(season?.champion?.abbr ?? season?.champion?.name ?? "");
-          case "runnerUp":
-            return String(season?.runnerUp?.abbr ?? season?.runnerUp?.name ?? "");
-          case "mvp":
-            return String(season?.awards?.mvp?.name ?? "");
-          case "userWins":
-            return Number(userRow?.wins ?? 0);
-          case "year":
-          default:
-            return Number(season?.year ?? seasonTokenToNumber(season?.id));
-        }
-      },
-      seasonSortDirection,
-      (season) => Number(season?.year ?? seasonTokenToNumber(season?.id)),
-    );
-  }, [league?.userTeamId, seasonSearch, seasonSortDirection, seasonSortKey, seasons]);
-  const seasonShowingLabel = useMemo(
-    () => buildShowingLabel(seasonRows.length, seasons?.length ?? 0, "season"),
-    [seasonRows.length, seasons?.length],
-  );
   if (!seasons?.length) {
     return (
       <Card className="card-premium">
@@ -481,7 +427,6 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
   }
 
   const selected = filteredSeasons.find((s) => s.id === selectedSeasonId) ?? filteredSeasons[0] ?? null;
-  const selected = seasons.find((s) => s.id === selectedSeasonId) ?? seasons[0];
   const sortedStandings = [...(selected?.standings ?? [])].sort((a, b) => pct(b) - pct(a)).slice(0, 8);
   const championBoard = buildChampionMap(seasons).slice(0, 5);
   const playoffMentions = (selected?.standings ?? []).filter((row) => Number(row?.wins ?? 0) >= 10).slice(0, 6);
@@ -569,60 +514,6 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
                     setSortKey("year");
                     setSortDir("desc");
                   }}
-        <CardContent className="p-3 pt-0 space-y-2">
-          <input
-            aria-label="Search archived seasons"
-            value={seasonSearch}
-            onChange={(e) => setSeasonSearch(e.target.value)}
-            placeholder="Search year/champion/MVP"
-            className="h-9 w-full rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-xs"
-          />
-          <div className="grid grid-cols-2 gap-2">
-            <select
-              aria-label="Sort archived seasons"
-              value={seasonSortKey}
-              onChange={(e) => setSeasonSortKey(e.target.value)}
-              className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-xs"
-            >
-              <option value="year">Year</option>
-              <option value="champion">Champion</option>
-              <option value="runnerUp">Runner-up</option>
-              <option value="mvp">MVP</option>
-              <option value="userWins">User team wins</option>
-            </select>
-            <select
-              aria-label="Sort direction for archived seasons"
-              value={seasonSortDirection}
-              onChange={(e) => setSeasonSortDirection(e.target.value)}
-              className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-xs"
-            >
-              <option value="desc">Desc</option>
-              <option value="asc">Asc</option>
-            </select>
-          </div>
-          <div className="flex items-center justify-between gap-2">
-            <div data-testid="league-history-season-showing" className="text-[10px] text-[color:var(--text-muted)]">{seasonShowingLabel}</div>
-            <button
-              type="button"
-              aria-label="Reset archived season filters"
-              className="text-[10px] text-[color:var(--accent)]"
-              onClick={() => {
-                setSeasonSearch("");
-                setSeasonSortKey("year");
-                setSeasonSortDirection("desc");
-              }}
-            >
-              Reset
-            </button>
-          </div>
-          <ScrollArea className="h-[520px]">
-            <div className="divide-y divide-[color:var(--hairline)]">
-              {seasonRows.length > 0 ? seasonRows.map((s) => (
-                <button
-                  key={s.id}
-                  data-testid={`league-history-season-list-item-${s.id}`}
-                  className={`w-full text-left px-4 py-3 ${selected?.id === s.id ? "bg-[color:var(--surface-strong)]" : ""}`}
-                  onClick={() => setSelectedSeasonId(s.id)}
                 >
                   Reset filters
                 </button>
@@ -667,9 +558,6 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
                   </button>
                 );
               })}
-              )) : (
-                <div className="px-4 py-3 text-xs text-[color:var(--text-muted)]">No archived seasons match this filter.</div>
-              )}
             </div>
           </ScrollArea>
         </CardContent>
@@ -1106,51 +994,6 @@ function LeagueOfficeHistory({ transactions, onPlayerSelect }) {
   const [typeFilter, setTypeFilter] = useState("ALL");
   const [sortDir, setSortDir] = useState("desc");
 
-  const [typeFilter, setTypeFilter] = useState("all");
-  const [sortKey, setSortKey] = useState("date");
-  const [sortDirection, setSortDirection] = useState("desc");
-  const rows = useMemo(() => (transactions ?? []).slice(0, 160), [transactions]);
-  const typeOptions = useMemo(
-    () => uniqueFilterOptions(rows, (tx) => tx?.typeLabel ?? tx?.type ?? "Unknown"),
-    [rows],
-  );
-  const visibleRows = useMemo(() => {
-    const filtered = rows
-      .filter((tx) => typeFilter === "all" || (tx?.typeLabel ?? tx?.type ?? "Unknown") === typeFilter)
-      .filter((tx) => rowMatchesSearch(tx, search, [
-        "type",
-        "typeLabel",
-        "headline",
-        "detail",
-        "playerName",
-        "teamAbbr",
-        "fromTeamAbbr",
-        "toTeamAbbr",
-        "seasonId",
-        "week",
-      ]));
-    return stableSortRows(
-      filtered,
-      (tx) => {
-        switch (sortKey) {
-          case "type":
-            return String(tx?.typeLabel ?? tx?.type ?? "");
-          case "player":
-            return String(tx?.playerName ?? "");
-          case "date":
-          default:
-            return seasonTokenToNumber(tx?.seasonId) * 100 + Number(tx?.week ?? 0);
-        }
-      },
-      sortDirection,
-      (tx) => Number(tx?.id ?? 0),
-    );
-  }, [rows, search, sortDirection, sortKey, typeFilter]);
-  const showingLabel = useMemo(
-    () => buildShowingLabel(visibleRows.length, rows.length, "transaction"),
-    [rows.length, visibleRows.length],
-  );
-  if (!rows.length) return <div className="py-8 text-center text-[color:var(--text-muted)]">No transaction history tracked yet.</div>;
   const describe = (tx) => {
     const leg = tx.legacyType ?? "";
     const bucket = tx.type ?? "";
@@ -1245,78 +1088,6 @@ function LeagueOfficeHistory({ transactions, onPlayerSelect }) {
                 Reset filters
               </button>
             ) : null}
-      <CardContent className="p-0">
-        <div className="px-4 py-3 border-b border-[color:var(--hairline)] space-y-2">
-          <input
-            aria-label="Search league transactions"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search player/team/type"
-            className="h-9 w-full rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-xs"
-          />
-          <div className="grid grid-cols-2 gap-2">
-            <select
-              aria-label="Filter league transactions by type"
-              value={typeFilter}
-              onChange={(e) => setTypeFilter(e.target.value)}
-              className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-xs"
-            >
-              <option value="all">All types</option>
-              {typeOptions.map((type) => (
-                <option key={type} value={type}>{type}</option>
-              ))}
-            </select>
-            <select
-              aria-label="Sort league transactions"
-              value={`${sortKey}:${sortDirection}`}
-              onChange={(e) => {
-                const [nextKey, nextDirection] = String(e.target.value).split(":");
-                setSortKey(nextKey || "date");
-                setSortDirection(nextDirection || "desc");
-              }}
-              className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-xs"
-            >
-              <option value="date:desc">Newest first</option>
-              <option value="date:asc">Oldest first</option>
-              <option value="type:asc">Type A-Z</option>
-              <option value="type:desc">Type Z-A</option>
-              <option value="player:asc">Player A-Z</option>
-              <option value="player:desc">Player Z-A</option>
-            </select>
-          </div>
-          <div className="flex items-center justify-between gap-2">
-            <div data-testid="league-office-showing" className="text-[10px] text-[color:var(--text-muted)]">{showingLabel}</div>
-            <button
-              type="button"
-              aria-label="Reset league transaction filters"
-              className="text-[10px] text-[color:var(--accent)]"
-              onClick={() => {
-                setSearch("");
-                setTypeFilter("all");
-                setSortKey("date");
-                setSortDirection("desc");
-              }}
-            >
-              Reset
-            </button>
-          </div>
-        </div>
-        <ScrollArea className="h-[560px]">
-          <div className="divide-y divide-[color:var(--hairline)]">
-            {visibleRows.length > 0 ? visibleRows.map((tx, idx) => (
-              <div key={`${tx.id ?? idx}`} className="px-4 py-3 text-sm">
-                <div className="flex items-center justify-between gap-2">
-                  <strong>{tx.typeLabel ?? tx.type}</strong>
-                  <span className="text-xs text-[color:var(--text-muted)]">Week {tx.week ?? "?"}</span>
-                </div>
-                <div className="text-[color:var(--text-muted)] mt-1">{describe(tx)}</div>
-                {tx.playerId != null && (
-                  <button className="btn mt-2 text-xs" onClick={() => onPlayerSelect?.(tx.playerId)}>Open player</button>
-                )}
-              </div>
-            )) : (
-              <div className="px-4 py-3 text-xs text-[color:var(--text-muted)]">No transactions match this filter.</div>
-            )}
           </div>
           <div data-testid="league-office-count" className="flex flex-wrap gap-2 text-xs text-[color:var(--text-muted)]">
             <span>{buildShowingLabel(rows.length, transactions.length, "transaction")}</span>

--- a/src/ui/components/TeamHistoryScreen.jsx
+++ b/src/ui/components/TeamHistoryScreen.jsx
@@ -3,6 +3,7 @@ import { ScreenHeader, SectionCard, EmptyState } from './ScreenSystem.jsx';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 import { buildFranchiseHistoryModel, PLAYOFF_CALIBER_WINS } from '../../core/franchiseHistoryModel.js';
 import { RECORD_BOOK_PLAYER_KEYS, RECORD_LABELS } from '../../core/recordBookV1.js';
+import { buildShowingLabel, rowMatchesSearch, stableSortRows } from '../utils/dataBrowser.js';
 
 function buildSeasonTeamMap(season) {
   const map = {};
@@ -29,12 +30,46 @@ function RecordRow({ label, value, detail }) {
   );
 }
 
+const TIMELINE_SORT_OPTIONS = [
+  { value: 'year', label: 'Year' },
+  { value: 'wins', label: 'Wins' },
+  { value: 'losses', label: 'Losses' },
+  { value: 'playoffResult', label: 'Playoff result' },
+  { value: 'pf', label: 'Points for' },
+  { value: 'pointDifferential', label: 'Point diff' },
+];
+
+function timelinePlayoffResultValue(row) {
+  if (row?.champion) return 4;
+  if (row?.runnerUp) return 3;
+  if (row?.truePlayoff) return 2;
+  if (row?.playoffCaliber) return 1;
+  return 0;
+}
+
+function buildTimelineSearchText(row) {
+  return [
+    row?.year,
+    row?.teamAbbr,
+    `${row?.wins ?? 0}-${row?.losses ?? 0}${row?.ties ? `-${row.ties}` : ''}`,
+    row?.champion ? 'champion title season' : '',
+    row?.runnerUp ? 'runner up finals' : '',
+    row?.truePlayoff ? 'documented postseason playoff bracket' : '',
+    row?.playoffCaliber ? 'playoff caliber' : '',
+    row?.eliteSeason ? 'elite season' : '',
+    row?.losingSeason ? 'losing season' : '',
+    row?.mvp?.name,
+  ].filter(Boolean).join(' ');
+}
+
 export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSelect, onBack, onOpenBoxScore, onOpenDraftHistory }) {
   const [seasons, setSeasons] = useState([]);
   const [hofPlayers, setHofPlayers] = useState([]);
   const [hofClasses, setHofClasses] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [queryYear, setQueryYear] = useState('');
+  const [timelineSearch, setTimelineSearch] = useState('');
+  const [timelineSortKey, setTimelineSortKey] = useState('year');
+  const [timelineSortDir, setTimelineSortDir] = useState('desc');
   const [scope, setScope] = useState('all');
   const [majorMoves, setMajorMoves] = useState([]);
   const [draftFlash, setDraftFlash] = useState([]);
@@ -152,10 +187,30 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
       if (scope === 'playoff' && !row.playoffCaliber) return false;
       if (scope === 'losing' && !row.losingSeason) return false;
       if (scope === 'elite' && !row.eliteSeason) return false;
-      if (!queryYear.trim()) return true;
-      return String(row.year).includes(queryYear.trim());
+      return rowMatchesSearch(row, timelineSearch, [
+        'year',
+        'wins',
+        'losses',
+        'ties',
+        'pf',
+        'pa',
+        buildTimelineSearchText,
+      ]);
     });
-  }, [model.seasons, queryYear, scope]);
+  }, [model.seasons, scope, timelineSearch]);
+
+  const timelineRows = useMemo(() => {
+    const getSortValue = (row) => {
+      if (timelineSortKey === 'playoffResult') return timelinePlayoffResultValue(row);
+      if (timelineSortKey === 'pointDifferential') {
+        return Number(row?.pointDifferential ?? (Number(row?.pf ?? 0) - Number(row?.pa ?? 0)));
+      }
+      return row?.[timelineSortKey];
+    };
+    return stableSortRows(filteredTimeline, getSortValue, timelineSortDir, (row) => row?.year);
+  }, [filteredTimeline, timelineSortDir, timelineSortKey]);
+
+  const hasTimelineFilters = Boolean(timelineSearch.trim()) || scope !== 'all' || timelineSortKey !== 'year' || timelineSortDir !== 'desc';
 
   const completedGameRows = useMemo(() => {
     const rows = [];
@@ -456,13 +511,59 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
       </SectionCard>
 
       <SectionCard title="Season-by-season timeline">
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 10 }}>
-          <input
-            value={queryYear}
-            onChange={(e) => setQueryYear(e.target.value)}
-            placeholder="Filter by year"
-            style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)', minWidth: 160 }}
-          />
+        <div style={{ display: 'grid', gap: 8, marginBottom: 10 }}>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+            <input
+              aria-label="Search team history seasons"
+              value={timelineSearch}
+              onChange={(e) => setTimelineSearch(e.target.value)}
+              placeholder="Search year, result, phase, MVP"
+              style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)', minWidth: 220, flex: '1 1 220px' }}
+            />
+            <select
+              aria-label="Sort team history seasons"
+              value={timelineSortKey}
+              onChange={(e) => setTimelineSortKey(e.target.value)}
+              style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)', minWidth: 150 }}
+            >
+              {TIMELINE_SORT_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              aria-label="Toggle team history season sort direction"
+              onClick={() => setTimelineSortDir((prev) => (prev === 'asc' ? 'desc' : 'asc'))}
+            >
+              {timelineSortDir === 'desc' ? 'Newest/highest first' : 'Oldest/lowest first'}
+            </button>
+            {hasTimelineFilters ? (
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={() => {
+                  setTimelineSearch('');
+                  setTimelineSortKey('year');
+                  setTimelineSortDir('desc');
+                  setScope('all');
+                }}
+              >
+                Reset filters
+              </button>
+            ) : null}
+          </div>
+          <div
+            data-testid="team-history-timeline-count"
+            style={{ display: 'flex', flexWrap: 'wrap', gap: 10, fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}
+          >
+            <span>{buildShowingLabel(timelineRows.length, model.seasons?.length ?? 0, 'season')}</span>
+            <span>
+              Sort: {TIMELINE_SORT_OPTIONS.find((opt) => opt.value === timelineSortKey)?.label ?? timelineSortKey} {timelineSortDir === 'asc' ? '↑' : '↓'}
+            </span>
+            {scope !== 'all' ? <span>Scope: {scope}</span> : null}
+          </div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
           {[
             { key: 'all', label: 'All-time' },
             { key: 'playoff', label: 'Playoff-caliber' },
@@ -474,13 +575,14 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
               {opt.label}
             </button>
           ))}
+          </div>
         </div>
         <div style={{ display: 'grid', gap: 8, maxHeight: 420, overflow: 'auto' }}>
-          {filteredTimeline.length === 0 ? (
+          {timelineRows.length === 0 ? (
             <EmptyState title="No team history for this filter" body="Adjust filters or archive more seasons." />
           ) : (
-            filteredTimeline.slice().reverse().map((s) => (
-              <div key={s.year} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: 10 }}>
+            timelineRows.map((s) => (
+              <div key={s.year} data-testid={`team-history-season-${s.year}`} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: 10 }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
                   <strong>{s.year}</strong>
                   <span>
@@ -492,6 +594,7 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
                 </div>
                 <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
                   PF {s.pf} · PA {s.pa}
+                  {s.pointDifferential != null ? ` · Diff ${s.pointDifferential > 0 ? '+' : ''}${s.pointDifferential}` : ''}
                   {s.truePlayoff ? ' · Postseason (documented)' : s.playoffCaliber ? ' · Playoff-caliber' : ''}
                 </div>
                 <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 4 }}>

--- a/src/ui/components/TeamHistoryScreen.jsx
+++ b/src/ui/components/TeamHistoryScreen.jsx
@@ -71,8 +71,6 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
   const [timelineSortKey, setTimelineSortKey] = useState('year');
   const [timelineSortDir, setTimelineSortDir] = useState('desc');
   const [scope, setScope] = useState('all');
-  const [timelineSortKey, setTimelineSortKey] = useState('year');
-  const [timelineSortDirection, setTimelineSortDirection] = useState('desc');
   const [majorMoves, setMajorMoves] = useState([]);
   const [draftFlash, setDraftFlash] = useState([]);
 
@@ -183,9 +181,8 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
 
   const { summary, franchiseRecords, franchiseLegends, playoffHistory, bestGames, milestones } = model;
 
-  const totalTimelineSeasons = model.seasons?.length ?? 0;
   const filteredTimeline = useMemo(() => {
-    const scopedRows = (model.seasons ?? []).filter((row) => {
+    return (model.seasons ?? []).filter((row) => {
       if (scope === 'champions' && !row.champion) return false;
       if (scope === 'playoff' && !row.playoffCaliber) return false;
       if (scope === 'losing' && !row.losingSeason) return false;
@@ -214,45 +211,6 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
   }, [filteredTimeline, timelineSortDir, timelineSortKey]);
 
   const hasTimelineFilters = Boolean(timelineSearch.trim()) || scope !== 'all' || timelineSortKey !== 'year' || timelineSortDir !== 'desc';
-      return true;
-    });
-    const searchedRows = scopedRows.filter((row) => rowMatchesSearch(row, timelineSearch, [
-      'year',
-      (r) => `${r.wins}-${r.losses}${r.ties ? `-${r.ties}` : ''}`,
-      (r) => (r.champion ? 'champion' : r.runnerUp ? 'runner up' : r.truePlayoff ? 'playoff' : r.playoffCaliber ? 'playoff caliber' : 'regular season'),
-      (r) => (r.truePlayoff ? 'documented postseason' : r.playoffCaliber ? 'playoff caliber' : 'no postseason'),
-      (r) => r?.mvp?.name ?? '',
-      (r) => activeTeam?.abbr ?? activeTeam?.name ?? '',
-      'pf',
-      'pa',
-    ]));
-    return stableSortRows(
-      searchedRows,
-      (row) => {
-        switch (timelineSortKey) {
-          case 'wins':
-            return Number(row?.wins ?? 0);
-          case 'losses':
-            return Number(row?.losses ?? 0);
-          case 'pf':
-            return Number(row?.pf ?? 0);
-          case 'pa':
-            return Number(row?.pa ?? 0);
-          case 'result':
-            return row?.champion ? 4 : row?.runnerUp ? 3 : row?.truePlayoff ? 2 : row?.playoffCaliber ? 1 : 0;
-          case 'year':
-          default:
-            return Number(row?.year ?? 0);
-        }
-      },
-      timelineSortDirection,
-      (row) => Number(row?.year ?? 0),
-    );
-  }, [model.seasons, scope, timelineSearch, timelineSortDirection, timelineSortKey, activeTeam?.abbr, activeTeam?.name]);
-  const timelineShowingLabel = useMemo(
-    () => buildShowingLabel(filteredTimeline.length, totalTimelineSeasons, 'season'),
-    [filteredTimeline.length, totalTimelineSeasons],
-  );
 
   const completedGameRows = useMemo(() => {
     const rows = [];
@@ -606,36 +564,6 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
             {scope !== 'all' ? <span>Scope: {scope}</span> : null}
           </div>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 10 }}>
-          <input
-            aria-label="Search team history seasons"
-            value={timelineSearch}
-            onChange={(e) => setTimelineSearch(e.target.value)}
-            placeholder="Search year/result/MVP/team"
-            style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)', minWidth: 160 }}
-          />
-          <select
-            aria-label="Sort team history seasons"
-            value={timelineSortKey}
-            onChange={(e) => setTimelineSortKey(e.target.value)}
-            style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)' }}
-          >
-            <option value="year">Year</option>
-            <option value="wins">Wins</option>
-            <option value="losses">Losses</option>
-            <option value="pf">Points For</option>
-            <option value="pa">Points Allowed</option>
-            <option value="result">Playoff Result</option>
-          </select>
-          <select
-            aria-label="Sort direction for team history seasons"
-            value={timelineSortDirection}
-            onChange={(e) => setTimelineSortDirection(e.target.value)}
-            style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)' }}
-          >
-            <option value="desc">Desc</option>
-            <option value="asc">Asc</option>
-          </select>
           {[
             { key: 'all', label: 'All-time' },
             { key: 'playoff', label: 'Playoff-caliber' },
@@ -655,28 +583,6 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
           ) : (
             timelineRows.map((s) => (
               <div key={s.year} data-testid={`team-history-season-${s.year}`} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: 10 }}>
-          <button
-            type="button"
-            className="btn btn-secondary"
-            onClick={() => {
-              setTimelineSearch('');
-              setScope('all');
-              setTimelineSortKey('year');
-              setTimelineSortDirection('desc');
-            }}
-          >
-            Reset filters
-          </button>
-        </div>
-        <div data-testid="team-history-timeline-showing" style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', marginBottom: 8 }}>
-          {timelineShowingLabel}
-        </div>
-        <div style={{ display: 'grid', gap: 8, maxHeight: 420, overflow: 'auto' }}>
-          {filteredTimeline.length === 0 ? (
-            <EmptyState title="No team seasons match this filter" body="Reset filters or archive additional seasons to grow your timeline." />
-          ) : (
-            filteredTimeline.map((s) => (
-              <div key={s.year} data-testid={`team-history-season-row-${s.year}`} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: 10 }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
                   <strong>{s.year}</strong>
                   <span>

--- a/src/ui/components/__tests__/DraftHistory.test.jsx
+++ b/src/ui/components/__tests__/DraftHistory.test.jsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, cleanup, within } from '@testing-library/react';
 import DraftHistory from '../DraftHistory.jsx';
 
 describe('DraftHistory', () => {
@@ -88,5 +88,101 @@ describe('DraftHistory', () => {
       expect(screen.getByText(/Redraft top 10/i)).toBeTruthy();
     });
     expect(screen.getAllByRole('button', { name: 'A' }).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('supports search, filters, sort controls, showing count, and card view in full class', async () => {
+    const model = {
+      year: 2029,
+      seasonId: 's1',
+      picks: [
+        {
+          playerId: 1,
+          playerName: 'Anchor QB',
+          pos: 'QB',
+          draftTeamAbbr: 'XX',
+          overall: 1,
+          redraftRank: 3,
+          redraftDelta: -2,
+          outcomeLabel: 'Reach',
+          legacyScore: 50,
+        },
+        {
+          playerId: 2,
+          playerName: 'Sleeper WR',
+          pos: 'WR',
+          draftTeamAbbr: 'XX',
+          overall: 18,
+          redraftRank: 1,
+          redraftDelta: 17,
+          outcomeLabel: 'Star',
+          legacyScore: 92,
+        },
+        {
+          playerId: 3,
+          playerName: 'Solid LB',
+          pos: 'LB',
+          draftTeamAbbr: 'YY',
+          overall: 9,
+          redraftRank: 2,
+          redraftDelta: 7,
+          outcomeLabel: 'Starter',
+          legacyScore: 75,
+        },
+      ],
+      redraftTop10: [],
+      steals: [],
+      busts: [],
+      teamGrades: [],
+      classSummary: {
+        totalPicks: 3,
+        starCount: 1,
+        starterCount: 2,
+        avgLegacyScore: 72,
+        classLeagueStatus: 'mature',
+        isDevelopingClass: false,
+      },
+    };
+
+    render(
+      <DraftHistory
+        league={{ year: 2033, teams: [{ id: 1, abbr: 'XX' }, { id: 2, abbr: 'YY' }] }}
+        actions={{
+          getDraftClasses: vi.fn().mockResolvedValue({
+            payload: { classes: [{ seasonId: 's1', year: 2029, pickCount: 3, teamIds: [1, 2] }] },
+          }),
+          getDraftClass: vi.fn().mockResolvedValue({ payload: { model } }),
+        }}
+        onPlayerSelect={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('draft-history-class-count').textContent).toContain('Showing 3 of 3 picks');
+    });
+
+    fireEvent.change(screen.getByLabelText(/Search draft history picks/i), { target: { value: 'Sleeper' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('draft-history-class-count').textContent).toContain('Showing 1 of 3 picks');
+    });
+    expect(screen.getByTestId('draft-history-class-cards').textContent).toContain('Sleeper WR');
+
+    fireEvent.click(screen.getByRole('button', { name: /Reset filters/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('draft-history-class-count').textContent).toContain('Showing 3 of 3 picks');
+    });
+
+    fireEvent.change(screen.getByLabelText(/Filter draft history picks by team/i), { target: { value: 'XX' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('draft-history-class-count').textContent).toContain('Showing 2 of 3 picks');
+    });
+
+    fireEvent.change(screen.getByLabelText(/Sort draft history picks/i), { target: { value: 'redraftDelta' } });
+    fireEvent.click(screen.getByLabelText(/Toggle draft history sort direction/i));
+    await waitFor(() => {
+      const cards = within(screen.getByTestId('draft-history-class-cards')).getAllByTestId(/draft-history-pick-card-/);
+      expect(cards[0].textContent).toContain('Sleeper WR');
+      expect(cards[0].textContent).toContain('Δ17');
+    });
   });
 });

--- a/src/ui/components/__tests__/LeagueHistory.test.jsx
+++ b/src/ui/components/__tests__/LeagueHistory.test.jsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import LeagueHistory from '../LeagueHistory.jsx';
 
 describe('LeagueHistory', () => {
@@ -195,6 +195,123 @@ describe('LeagueHistory', () => {
     await waitFor(() => {
       expect(screen.getByTestId('league-history-major-tx-sx')).toBeTruthy();
       expect(screen.getByTestId('league-history-major-tx-sx').textContent).toMatch(/DAL signed Test Player/);
+    });
+  });
+
+  it('supports season archive search, champion filtering, and reset controls', async () => {
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                {
+                  id: 's1',
+                  year: 2030,
+                  champion: { id: 1, name: 'Dallas', abbr: 'DAL' },
+                  standings: [{ id: 1, name: 'Dallas', abbr: 'DAL', wins: 12, losses: 5 }],
+                  awards: { mvp: { playerId: 1, name: 'Title QB' } },
+                },
+                {
+                  id: 's2',
+                  year: 2031,
+                  champion: { id: 2, name: 'New York', abbr: 'NYG' },
+                  standings: [{ id: 1, name: 'Dallas', abbr: 'DAL', wins: 10, losses: 7 }],
+                  awards: { mvp: { playerId: 2, name: 'Apex RB' } },
+                },
+                {
+                  id: 's3',
+                  year: 2032,
+                  champion: { id: 3, name: 'Philadelphia', abbr: 'PHI' },
+                  standings: [{ id: 3, name: 'Philadelphia', abbr: 'PHI', wins: 11, losses: 6 }],
+                  awards: { mvp: { playerId: 3, name: 'Edge Star' } },
+                },
+              ],
+            },
+          }),
+          getRecords: vi.fn().mockResolvedValue({ payload: { records: null } }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('league-season-archive-count').textContent).toContain('Showing 3 of 3 seasons');
+    });
+
+    fireEvent.change(screen.getByLabelText(/Search league history seasons/i), { target: { value: 'Dallas' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('league-season-archive-count').textContent).toContain('Showing 2 of 3 seasons');
+    });
+
+    fireEvent.change(screen.getByLabelText(/Filter league history seasons by champion/i), { target: { value: 'NYG' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('league-season-archive-count').textContent).toContain('Showing 1 of 3 seasons');
+    });
+    expect(screen.getByTestId('league-season-button-s2')).toBeTruthy();
+    expect(screen.queryByTestId('league-season-button-s1')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /Reset filters/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('league-season-archive-count').textContent).toContain('Showing 3 of 3 seasons');
+    });
+  });
+
+  it('supports search, type filters, sort direction, and counts in league office history', async () => {
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({ payload: { seasons: [{ id: 's1', year: 2030, standings: [], awards: {} }] } }),
+          getRecords: vi.fn().mockResolvedValue({ payload: { records: null } }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({
+            payload: {
+              transactions: [
+                { id: 1, seasonId: 2032, week: 3, type: 'signing', typeLabel: 'Signing', teamAbbr: 'DAL', playerId: 10, playerName: 'Miles Carter' },
+                { id: 2, seasonId: 2033, week: 5, type: 'trade', typeLabel: 'Trade', fromTeamAbbr: 'DAL', toTeamAbbr: 'PHI', playerId: 11, playerName: 'Kane Moss' },
+                { id: 3, seasonId: 2034, week: 1, type: 'release', typeLabel: 'Release', teamAbbr: 'NYG', playerId: 12, playerName: 'Duke Lane' },
+              ],
+            },
+          }),
+        }}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole('tab', { name: /League Office/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('league-office-count').textContent).toContain('Showing 3 of 3 transactions');
+    });
+
+    fireEvent.change(screen.getByLabelText(/Search league office transactions/i), { target: { value: 'Miles' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('league-office-count').textContent).toContain('Showing 1 of 3 transactions');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Reset filters/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('league-office-count').textContent).toContain('Showing 3 of 3 transactions');
+    });
+
+    fireEvent.change(screen.getByLabelText(/Filter league office transactions by type/i), { target: { value: 'Trade' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('league-office-count').textContent).toContain('Showing 1 of 3 transactions');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Reset filters/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('league-office-count').textContent).toContain('Showing 3 of 3 transactions');
+    });
+
+    fireEvent.change(screen.getByLabelText(/Sort league office transactions/i), { target: { value: 'asc' } });
+    await waitFor(() => {
+      expect(screen.getAllByTestId(/league-office-row-/)[0].textContent).toContain('2032');
     });
   });
 });

--- a/src/ui/components/__tests__/LeagueHistory.test.jsx
+++ b/src/ui/components/__tests__/LeagueHistory.test.jsx
@@ -1,13 +1,13 @@
 /** @vitest-environment jsdom */
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import LeagueHistory from '../LeagueHistory.jsx';
 
 describe('LeagueHistory', () => {
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+  });
 
   it('opens the selected archived season and handles missing championship data safely', async () => {
     render(
@@ -121,7 +121,8 @@ describe('LeagueHistory', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/2030 League Snapshot/i)).toBeTruthy();
+      expect(screen.getByTestId('league-season-button-s1')).toBeTruthy();
+      expect(screen.getByRole('button', { name: /Previous season/i }).hasAttribute('disabled')).toBe(true);
     });
   });
 
@@ -206,11 +207,6 @@ describe('LeagueHistory', () => {
     render(
       <LeagueHistory
         league={{ userTeamId: 1 }}
-  it('filters and resets archived season list controls', async () => {
-    render(
-      <LeagueHistory
-        league={{ userTeamId: 1 }}
-        initialSelectedSeasonId="s2"
         onPlayerSelect={vi.fn()}
         onOpenBoxScore={vi.fn()}
         actions={{
@@ -238,8 +234,6 @@ describe('LeagueHistory', () => {
                   standings: [{ id: 3, name: 'Philadelphia', abbr: 'PHI', wins: 11, losses: 6 }],
                   awards: { mvp: { playerId: 3, name: 'Edge Star' } },
                 },
-                { id: 's1', year: 2030, champion: { abbr: 'DAL' }, standings: [], awards: { mvp: { name: 'Alpha QB' } } },
-                { id: 's2', year: 2031, champion: { abbr: 'NYG' }, standings: [], awards: { mvp: { name: 'Bravo QB' } } },
               ],
             },
           }),
@@ -276,26 +270,6 @@ describe('LeagueHistory', () => {
     render(
       <LeagueHistory
         league={{ userTeamId: 1 }}
-      expect(screen.getByTestId('league-history-season-showing').textContent).toContain('Showing 2 of 2 seasons');
-    });
-
-    fireEvent.change(screen.getByLabelText('Search archived seasons'), { target: { value: 'nyg' } });
-    await waitFor(() => {
-      expect(screen.getByTestId('league-history-season-showing').textContent).toContain('Showing 1 of 2 seasons');
-    });
-    expect(screen.getByTestId('league-history-season-list-item-s2')).toBeTruthy();
-
-    fireEvent.click(screen.getByLabelText('Reset archived season filters'));
-    await waitFor(() => {
-      expect(screen.getByTestId('league-history-season-showing').textContent).toContain('Showing 2 of 2 seasons');
-    });
-  });
-
-  it('filters league office transactions by type and search', async () => {
-    render(
-      <LeagueHistory
-        league={{ userTeamId: 1 }}
-        initialActiveTab="office"
         onPlayerSelect={vi.fn()}
         onOpenBoxScore={vi.fn()}
         actions={{
@@ -315,7 +289,9 @@ describe('LeagueHistory', () => {
       />,
     );
 
-    fireEvent.click(await screen.findByRole('tab', { name: /League Office/i }));
+    const officeTab = await screen.findByRole('tab', { name: /League Office/i });
+    fireEvent.mouseDown(officeTab);
+    fireEvent.click(officeTab);
     await waitFor(() => {
       expect(screen.getByTestId('league-office-count').textContent).toContain('Showing 3 of 3 transactions');
     });
@@ -343,27 +319,6 @@ describe('LeagueHistory', () => {
     fireEvent.change(screen.getByLabelText(/Sort league office transactions/i), { target: { value: 'asc' } });
     await waitFor(() => {
       expect(screen.getAllByTestId(/league-office-row-/)[0].textContent).toContain('2032');
-                { id: 'tx1', seasonId: 's1', week: 3, type: 'trade', typeLabel: 'Trade', playerName: 'Player One', fromTeamAbbr: 'DAL', toTeamAbbr: 'NYG' },
-                { id: 'tx2', seasonId: 's1', week: 4, type: 'signing', typeLabel: 'Signing', playerName: 'Player Two', teamAbbr: 'DAL' },
-              ],
-            },
-          }),
-        }}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByTestId('league-office-showing').textContent).toContain('Showing 2 of 2 transactions');
-    });
-
-    fireEvent.change(screen.getByLabelText('Filter league transactions by type'), { target: { value: 'Trade' } });
-    await waitFor(() => {
-      expect(screen.getByTestId('league-office-showing').textContent).toContain('Showing 1 of 2 transactions');
-    });
-
-    fireEvent.change(screen.getByLabelText('Search league transactions'), { target: { value: 'missing player' } });
-    await waitFor(() => {
-      expect(screen.getByTestId('league-office-showing').textContent).toContain('Showing 0 of 2 transactions');
     });
   });
 });

--- a/src/ui/components/__tests__/TeamHistoryScreen.test.jsx
+++ b/src/ui/components/__tests__/TeamHistoryScreen.test.jsx
@@ -114,10 +114,6 @@ describe('TeamHistoryScreen', () => {
     render(
       <TeamHistoryScreen
         league={{ teams: [{ id: 1, name: 'Dallas', abbr: 'DAL' }], userTeamId: 1 }}
-  it('filters, sorts, and resets season timeline rows', async () => {
-    render(
-      <TeamHistoryScreen
-        league={{ teams: [{ id: 7, name: 'Seattle', abbr: 'SEA' }], userTeamId: 7 }}
         actions={{
           getAllSeasons: vi.fn().mockResolvedValue({
             payload: {
@@ -138,23 +134,6 @@ describe('TeamHistoryScreen', () => {
                   year: 2032,
                   standings: [{ id: 1, name: 'Dallas', abbr: 'DAL', wins: 4, losses: 13, ties: 0, pf: 260, pa: 410 }],
                   awards: {},
-                  standings: [
-                    { id: 7, abbr: 'SEA', wins: 12, losses: 5, ties: 0, pf: 420, pa: 300 },
-                    { id: 9, abbr: 'RIV', wins: 8, losses: 9, ties: 0, pf: 320, pa: 360 },
-                  ],
-                  champion: { id: 7, abbr: 'SEA' },
-                  runnerUp: { id: 9, abbr: 'RIV' },
-                  playoffBracketSnapshot: { mode: 'empty', rounds: [] },
-                },
-                {
-                  year: 2031,
-                  standings: [
-                    { id: 7, abbr: 'SEA', wins: 8, losses: 9, ties: 0, pf: 300, pa: 330 },
-                    { id: 5, abbr: 'BOS', wins: 11, losses: 6, ties: 0, pf: 390, pa: 310 },
-                  ],
-                  champion: { id: 5, abbr: 'BOS' },
-                  runnerUp: { id: 7, abbr: 'SEA' },
-                  playoffBracketSnapshot: { mode: 'empty', rounds: [] },
                 },
               ],
             },
@@ -193,22 +172,6 @@ describe('TeamHistoryScreen', () => {
     fireEvent.click(screen.getByRole('button', { name: /Reset filters/i }));
     await waitFor(() => {
       expect(screen.getByTestId('team-history-timeline-count').textContent).toContain('Showing 3 of 3 seasons');
-      expect(screen.getByTestId('team-history-timeline-showing').textContent).toContain('Showing 2 of 2 seasons');
-    });
-
-    fireEvent.change(screen.getByLabelText('Sort team history seasons'), { target: { value: 'wins' } });
-    const sortedRows = screen.getAllByTestId(/team-history-season-row-/i);
-    expect(sortedRows[0].textContent).toContain('2030');
-
-    fireEvent.change(screen.getByLabelText('Search team history seasons'), { target: { value: 'champion' } });
-    await waitFor(() => {
-      expect(screen.getByTestId('team-history-timeline-showing').textContent).toContain('Showing 1 of 2 seasons');
-    });
-    expect(screen.getByTestId('team-history-season-row-2030')).toBeTruthy();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Reset filters' }));
-    await waitFor(() => {
-      expect(screen.getByTestId('team-history-timeline-showing').textContent).toContain('Showing 2 of 2 seasons');
     });
   });
 });

--- a/src/ui/components/__tests__/TeamHistoryScreen.test.jsx
+++ b/src/ui/components/__tests__/TeamHistoryScreen.test.jsx
@@ -109,4 +109,69 @@ describe('TeamHistoryScreen', () => {
     const arg = onOpen.mock.calls[0][0];
     expect(String(arg)).toMatch(/2055/);
   });
+
+  it('supports timeline search, numeric sort, showing counts, and reset filters', async () => {
+    render(
+      <TeamHistoryScreen
+        league={{ teams: [{ id: 1, name: 'Dallas', abbr: 'DAL' }], userTeamId: 1 }}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                {
+                  year: 2030,
+                  standings: [{ id: 1, name: 'Dallas', abbr: 'DAL', wins: 12, losses: 5, ties: 0, pf: 420, pa: 310 }],
+                  champion: { id: 1, abbr: 'DAL' },
+                  awards: { mvp: { playerId: 7, name: 'Title QB' } },
+                },
+                {
+                  year: 2031,
+                  standings: [{ id: 1, name: 'Dallas', abbr: 'DAL', wins: 9, losses: 8, ties: 0, pf: 360, pa: 340 }],
+                  runnerUp: { id: 2, abbr: 'PHI' },
+                  awards: { mvp: { playerId: 9, name: 'Ace Star' } },
+                },
+                {
+                  year: 2032,
+                  standings: [{ id: 1, name: 'Dallas', abbr: 'DAL', wins: 4, losses: 13, ties: 0, pf: 260, pa: 410 }],
+                  awards: {},
+                },
+              ],
+            },
+          }),
+          getHallOfFame: vi.fn().mockResolvedValue({ payload: { players: [], classes: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+          getDraftClasses: vi.fn().mockResolvedValue({ payload: { classes: [] } }),
+          getDraftClass: vi.fn().mockResolvedValue({ payload: { model: null } }),
+        }}
+        onBack={vi.fn()}
+        onPlayerSelect={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-timeline-count').textContent).toContain('Showing 3 of 3 seasons');
+    });
+
+    fireEvent.change(screen.getByLabelText(/Sort team history seasons/i), { target: { value: 'wins' } });
+    let seasonCards = screen.getAllByTestId(/team-history-season-/);
+    expect(seasonCards[0].textContent).toContain('2030');
+
+    fireEvent.click(screen.getByLabelText(/Toggle team history season sort direction/i));
+    await waitFor(() => {
+      seasonCards = screen.getAllByTestId(/team-history-season-/);
+      expect(seasonCards[0].textContent).toContain('2032');
+    });
+
+    fireEvent.change(screen.getByLabelText(/Search team history seasons/i), { target: { value: 'Ace Star' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-timeline-count').textContent).toContain('Showing 1 of 3 seasons');
+    });
+    expect(screen.getByTestId('team-history-season-2031')).toBeTruthy();
+    expect(screen.queryByTestId('team-history-season-2030')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /Reset filters/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-timeline-count').textContent).toContain('Showing 3 of 3 seasons');
+    });
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- improve `TeamHistoryScreen` season timeline browsing with normalized search, stable sort controls, showing-count feedback, and reset filters
- improve `LeagueHistory` season archive browsing plus `League Office` transaction filtering/sorting with reusable `dataBrowser` helpers
- improve `DraftHistory` full-class browsing with search, team/position filters, stable sorting, showing counts, and compact cards
- extend focused tests for history browsing controls, resets, and safe archive fallbacks

## Screens improved
- `Team History` season timeline
- `League History` season archive
- `League History` → `League Office` transaction log
- `Draft History` full class browser

## Search / sort / filter fields
- Team History: year, record text, points for/against, playoff/result labels, MVP name; sorts by year, wins, losses, playoff result, points for, point differential
- League History: year, champion, runner-up, standings team names/abbrs, MVP; champion filter and stable sorting by year/champion/user wins
- League Office: headline/detail, player, team/from/to abbreviations, transaction type; type filter and newest/oldest sorting
- Draft History: player name, position, drafting team, outcome, overall/redraft values; team and position filters with stable sorting by original order, player, team, redraft rank/delta, legacy score

## Fallback behavior
- empty/new-save history states remain explicit and honest
- missing archive rows still render safely without fabricated champions, awards, or transactions
- filters reset back to full datasets without mutating archive data

## Mobile UX notes
- kept controls stacked/wrapping and tap-friendly
- retained card-based/archive-friendly layouts on Team History and League Office
- added compact draft pick cards alongside the denser table view for smaller screens

## Validation
- `npm ci`
- `node --check src/ui/utils/dataBrowser.js`
- targeted unit suites for `dataBrowser`, `TeamHistoryScreen`, `LeagueHistory`, and `DraftHistory`
- full `npm run test:unit`
- `npm run test:soak`
- `npm run audit:dynasty -- --ci --seed=1383` → passed, `runtimeMs=6619`, warning only: `hof_empty_young`
- `npm run build`
- `npm run check:deploy`
- `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js`
- `npx playwright test`

## Deferred intentionally
- Player Profile season-log browsing
- Awards & Records / Hall of Fame density improvements
- broader archive-shell refactors or history-system rewrites
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c6d010c-156f-4ab3-afcc-2c8c1a86ad6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c6d010c-156f-4ab3-afcc-2c8c1a86ad6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

