### PR TITLE
Improve history data browsing density

### DIFF
--- a/src/ui/components/LeagueActivityLog.jsx
+++ b/src/ui/components/LeagueActivityLog.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { buildShowingLabel, rowMatchesSearch, stableSortRows } from "../utils/dataBrowser.js";
 
 const TYPE_FILTERS = [
   { value: "all", label: "All types" },
@@ -22,6 +23,7 @@ export default function LeagueActivityLog({ league, actions, onPlayerSelect, onT
   const [teamId, setTeamId] = useState("all");
   const [type, setType] = useState("all");
   const [search, setSearch] = useState("");
+  const [sort, setSort] = useState({ key: "date", dir: "desc" });
 
   const teams = league?.teams ?? [];
   const [archiveSeasons, setArchiveSeasons] = useState([]);
@@ -79,6 +81,44 @@ export default function LeagueActivityLog({ league, actions, onPlayerSelect, onT
     load();
   }, [load]);
 
+  const displayRows = useMemo(() => {
+    const filtered = (rows ?? []).filter((tx) => {
+      if (type !== "all" && tx?.type !== type && tx?.typeLabel !== type) return false;
+      if (teamId !== "all") {
+        const tid = Number(teamId);
+        const matchesTeam = [tx?.teamId, tx?.fromTeamId, tx?.toTeamId].some((value) => Number(value) === tid);
+        if (!matchesTeam) return false;
+      }
+      return rowMatchesSearch(tx, search, [
+        "playerName",
+        "teamAbbr",
+        "fromTeamAbbr",
+        "toTeamAbbr",
+        "type",
+        "typeLabel",
+        "headline",
+        "detail",
+        "seasonId",
+        "week",
+      ]);
+    });
+    return stableSortRows(filtered, (tx) => {
+      if (sort.key === "type") return tx?.typeLabel ?? tx?.type;
+      if (sort.key === "player") return tx?.playerName ?? tx?.headline;
+      if (sort.key === "team") return tx?.teamAbbr ?? tx?.fromTeamAbbr ?? tx?.toTeamAbbr;
+      return `${tx?.seasonId ?? ""}-${String(tx?.week ?? 0).padStart(2, "0")}-${String(tx?.id ?? 0).padStart(8, "0")}`;
+    }, sort.dir, (tx) => tx?.id ?? tx?.headline);
+  }, [rows, type, teamId, search, sort]);
+
+  const hasActiveFilters = seasonId !== "all" || teamId !== "all" || type !== "all" || search.trim() || sort.key !== "date" || sort.dir !== "desc";
+  const resetFilters = () => {
+    setSeasonId("all");
+    setTeamId("all");
+    setType("all");
+    setSearch("");
+    setSort({ key: "date", dir: "desc" });
+  };
+
   return (
     <div className="space-y-3" data-testid="league-activity-log">
       <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-end">
@@ -134,19 +174,41 @@ export default function LeagueActivityLog({ league, actions, onPlayerSelect, onT
         <button type="button" className="btn btn-secondary h-9 text-sm" onClick={() => load()}>
           Refresh
         </button>
+        <label className="flex flex-col gap-1 text-xs font-semibold text-[color:var(--text-muted)]">
+          Sort
+          <select
+            className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-sm"
+            value={sort.key}
+            onChange={(e) => setSort((curr) => ({ ...curr, key: e.target.value }))}
+          >
+            <option value="date">Date / week</option>
+            <option value="type">Type</option>
+            <option value="player">Player</option>
+            <option value="team">Team</option>
+          </select>
+        </label>
+        <button type="button" className="btn h-9 text-sm" onClick={() => setSort((curr) => ({ ...curr, dir: curr.dir === "asc" ? "desc" : "asc" }))}>
+          {sort.dir === "asc" ? "Asc" : "Desc"}
+        </button>
+        <button type="button" className="btn btn-secondary h-9 text-sm" onClick={resetFilters}>
+          Reset filters
+        </button>
+      </div>
+      <div className="text-xs text-[color:var(--text-muted)]">
+        {buildShowingLabel(displayRows.length, rows.length, "transaction")}
       </div>
 
       {loading ? (
         <div className="py-8 text-center text-sm text-[color:var(--text-muted)]">Loading activity…</div>
-      ) : !rows.length ? (
+      ) : !displayRows.length ? (
         <div className="rounded-lg border border-[color:var(--hairline)] bg-[color:var(--surface-strong)]/30 px-4 py-6 text-center text-sm text-[color:var(--text-muted)]">
-          Transactions will appear as your league signs, drafts, trades, releases, and retires players.
+          {hasActiveFilters ? "No transactions match these filters." : "Transactions will appear as your league signs, drafts, trades, releases, and retires players."}
         </div>
       ) : (
         <ScrollArea className="h-[min(520px,65vh)] rounded-lg border border-[color:var(--hairline)]">
           <ul className="divide-y divide-[color:var(--hairline)]">
-            {rows.map((tx, idx) => (
-              <li key={`${tx.id ?? idx}-${idx}`} className="px-3 py-3 text-sm">
+            {displayRows.map((tx, idx) => (
+              <li key={`${tx.id ?? idx}-${idx}`} className="px-3 py-3 text-sm" data-testid="league-activity-row">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">
                     {tx.typeLabel ?? tx.type ?? "—"}

--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -5,6 +5,7 @@ import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from "@
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/boxScoreAccess.js";
+import { buildShowingLabel, rowMatchesSearch, stableSortRows, uniqueFilterOptions } from "../utils/dataBrowser.js";
 import { AWARD_DISPLAY_NAMES } from '../../core/footballMeta';
 import { buildLeagueHistoryTopPerformers } from '../../core/playerSeasonStatsArchive.js';
 import { normalizeArchivedMajorTransactions } from '../../core/transactionTimeline.js';
@@ -107,6 +108,29 @@ function summarizeSeasonStoryline(season, userTeamId) {
     lines.push(`Your franchise finished ${userRow.wins}-${userRow.losses}${userRow.ties ? `-${userRow.ties}` : ""}.`);
   }
   return lines.join(" ");
+}
+
+function userTeamStandingForSeason(season, userTeamId) {
+  return (season?.standings ?? []).find((row) => Number(row?.id) === Number(userTeamId)) ?? null;
+}
+
+function seasonArchiveSortValue(season, sortKey, userTeamId) {
+  if (sortKey === "champion") return season?.champion?.abbr ?? season?.champion?.name ?? "";
+  if (sortKey === "teams") return season?.standings?.length ?? 0;
+  if (sortKey === "userWins") return userTeamStandingForSeason(season, userTeamId)?.wins ?? "";
+  return season?.year;
+}
+
+function seasonArchiveSearchFields(season) {
+  return [
+    season?.year,
+    season?.champion?.abbr,
+    season?.champion?.name,
+    season?.runnerUp?.abbr,
+    season?.runnerUp?.name,
+    season?.awards?.mvp?.name,
+    ...(season?.standings ?? []).flatMap((team) => [team?.abbr, team?.name, `${team?.wins ?? 0}-${team?.losses ?? 0}`]),
+  ].filter(Boolean).join(" ");
 }
 
 export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenBoxScore, initialSelectedSeasonId = null }) {
@@ -342,6 +366,8 @@ function SeasonDraftClassSnippet({ seasonId, year, actions, onPlayerSelect }) {
 
 function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, league, initialSelectedSeasonId = null }) {
   const [selectedSeasonId, setSelectedSeasonId] = useState(initialSelectedSeasonId ?? seasons?.[0]?.id ?? null);
+  const [seasonSearch, setSeasonSearch] = useState("");
+  const [seasonSort, setSeasonSort] = useState({ key: "year", dir: "desc" });
 
   useEffect(() => {
     if (!seasons?.length) return;
@@ -352,6 +378,24 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
     }
     setSelectedSeasonId((prev) => prev ?? seasons[0]?.id ?? null);
   }, [initialSelectedSeasonId, seasons]);
+
+  const browsedSeasons = useMemo(() => {
+    const filtered = (seasons ?? []).filter((season) => rowMatchesSearch(season, seasonSearch, [
+      "year",
+      (s) => s?.champion?.abbr,
+      (s) => s?.champion?.name,
+      (s) => s?.runnerUp?.abbr,
+      (s) => s?.runnerUp?.name,
+      (s) => s?.awards?.mvp?.name,
+      seasonArchiveSearchFields,
+    ]));
+    return stableSortRows(filtered, (season) => seasonArchiveSortValue(season, seasonSort.key, league?.userTeamId), seasonSort.dir, (season) => season?.year);
+  }, [seasons, seasonSearch, seasonSort, league?.userTeamId]);
+
+  const resetSeasonBrowser = () => {
+    setSeasonSearch("");
+    setSeasonSort({ key: "year", dir: "desc" });
+  };
 
   if (!seasons?.length) {
     return (
@@ -402,16 +446,52 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
       <Card className="card-premium">
         <CardHeader><CardTitle>Season Archive</CardTitle></CardHeader>
         <CardContent className="p-0">
+          <div className="p-3 space-y-2 border-b border-[color:var(--hairline)]">
+            <input
+              type="search"
+              value={seasonSearch}
+              onChange={(e) => setSeasonSearch(e.target.value)}
+              placeholder="Search year, team, champion, MVP"
+              className="h-9 w-full rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-sm"
+              aria-label="Search archived seasons"
+            />
+            <div className="grid grid-cols-2 gap-2">
+              <select
+                value={seasonSort.key}
+                onChange={(e) => setSeasonSort((curr) => ({ ...curr, key: e.target.value }))}
+                className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-xs"
+                aria-label="Sort archived seasons"
+              >
+                <option value="year">Year</option>
+                <option value="champion">Champion</option>
+                <option value="userWins">User wins</option>
+                <option value="teams">Teams</option>
+              </select>
+              <button type="button" className="btn text-xs" onClick={() => setSeasonSort((curr) => ({ ...curr, dir: curr.dir === "asc" ? "desc" : "asc" }))}>
+                {seasonSort.dir === "asc" ? "Asc" : "Desc"}
+              </button>
+            </div>
+            <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-[color:var(--text-muted)]">
+              <span>{buildShowingLabel(browsedSeasons.length, seasons.length, "season")}</span>
+              <button type="button" className="text-[color:var(--accent)]" onClick={resetSeasonBrowser}>Reset filters</button>
+            </div>
+          </div>
           <ScrollArea className="h-[520px]">
             <div className="divide-y divide-[color:var(--hairline)]">
-              {seasons.map((s) => (
+              {browsedSeasons.length === 0 ? (
+                <div className="px-4 py-6 text-sm text-[color:var(--text-muted)]">No archived seasons match this search.</div>
+              ) : browsedSeasons.map((s) => (
                 <button
                   key={s.id}
                   className={`w-full text-left px-4 py-3 ${selected?.id === s.id ? "bg-[color:var(--surface-strong)]" : ""}`}
                   onClick={() => setSelectedSeasonId(s.id)}
+                  data-testid="league-history-season-row"
                 >
                   <div className="font-bold text-sm">{s.year}</div>
-                  <div className="text-xs text-[color:var(--text-muted)]">{s.champion?.abbr ?? "TBD"} champion</div>
+                  <div className="text-xs text-[color:var(--text-muted)]">
+                    {s.champion?.abbr || s.champion?.name ? `${s.champion?.abbr ?? s.champion?.name} champion` : "Champion unavailable"}
+                    {s.runnerUp?.abbr || s.runnerUp?.name ? ` · over ${s.runnerUp?.abbr ?? s.runnerUp?.name}` : ""}
+                  </div>
                 </button>
               ))}
             </div>
@@ -435,7 +515,7 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
           <section className="rounded-xl border border-[color:var(--hairline)] bg-[color:var(--surface-strong)]/40 p-4 space-y-3" data-testid={`league-history-season-story-${selected?.id ?? 'none'}`}>
             <div className="text-xs font-black uppercase tracking-wide text-[color:var(--text-subtle)]">Season story</div>
             <div className="text-lg font-black text-[color:var(--text)]">
-              {selected?.champion?.abbr ?? selected?.champion?.name ?? "Champion TBD"}
+              {selected?.champion?.abbr ?? selected?.champion?.name ?? "Champion unavailable"}
               {selected?.runnerUp?.abbr || selected?.runnerUp?.name ? (
                 <span className="text-[color:var(--text-muted)] font-semibold text-base"> over {selected?.runnerUp?.abbr ?? selected?.runnerUp?.name}</span>
               ) : null}
@@ -479,7 +559,7 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
           </section>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-            <SummaryBox label="Champion" value={selected?.champion?.name ?? "TBD"} />
+            <SummaryBox label="Champion" value={selected?.champion?.name ?? selected?.champion?.abbr ?? "—"} muted={!selected?.champion} />
             <SummaryBox label="Runner-up" value={selected?.runnerUp?.name ?? "—"} muted={!selected?.runnerUp} />
             <SummaryBox label="MVP" value={selected?.awards?.mvp?.name ?? "—"} onClick={selected?.awards?.mvp?.playerId != null ? () => onPlayerSelect?.(selected.awards.mvp.playerId) : undefined} />
           </div>
@@ -838,9 +918,9 @@ function AwardsHistory({ seasons, onPlayerSelect }) {
 }
 
 function LeagueOfficeHistory({ transactions, onPlayerSelect }) {
-  if (!transactions?.length) return <div className="py-8 text-center text-[color:var(--text-muted)]">No transaction history tracked yet.</div>;
-
-  const rows = transactions.slice(0, 120);
+  const [search, setSearch] = useState("");
+  const [typeFilter, setTypeFilter] = useState("all");
+  const [sort, setSort] = useState({ key: "date", dir: "desc" });
   const describe = (tx) => {
     const leg = tx.legacyType ?? "";
     const bucket = tx.type ?? "";
@@ -863,13 +943,83 @@ function LeagueOfficeHistory({ transactions, onPlayerSelect }) {
     return tx.headline ?? tx.typeLabel ?? tx.type;
   };
 
+  const typeOptions = useMemo(
+    () => ["all", ...uniqueFilterOptions(transactions ?? [], (tx) => tx?.typeLabel ?? tx?.type).slice(0, 12)],
+    [transactions],
+  );
+
+  const browsedRows = useMemo(() => {
+    const filtered = (transactions ?? []).filter((tx) => {
+      const txType = tx?.typeLabel ?? tx?.type ?? "";
+      if (typeFilter !== "all" && txType !== typeFilter) return false;
+      return rowMatchesSearch(tx, search, [
+        "type",
+        "typeLabel",
+        "headline",
+        "detail",
+        "playerName",
+        "teamAbbr",
+        "fromTeamAbbr",
+        "toTeamAbbr",
+        "seasonId",
+        "week",
+        describe,
+      ]);
+    });
+    const sorted = stableSortRows(filtered, (tx) => {
+      if (sort.key === "type") return tx?.typeLabel ?? tx?.type;
+      if (sort.key === "player") return tx?.playerName ?? tx?.headline;
+      if (sort.key === "team") return tx?.teamAbbr ?? tx?.fromTeamAbbr ?? tx?.toTeamAbbr;
+      return `${tx?.seasonId ?? ""}-${String(tx?.week ?? 0).padStart(2, "0")}-${String(tx?.id ?? 0).padStart(8, "0")}`;
+    }, sort.dir, (tx) => tx?.id ?? tx?.headline);
+    return sorted.slice(0, 120);
+  }, [transactions, typeFilter, search, sort]);
+
+  const resetOfficeBrowser = () => {
+    setSearch("");
+    setTypeFilter("all");
+    setSort({ key: "date", dir: "desc" });
+  };
+
+  if (!transactions?.length) return <div className="py-8 text-center text-[color:var(--text-muted)]">No transaction history tracked yet.</div>;
+
   return (
     <Card className="card-premium">
       <CardHeader><CardTitle>League Moves Log</CardTitle></CardHeader>
       <CardContent className="p-0">
+        <div className="p-3 space-y-2 border-b border-[color:var(--hairline)]">
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search player, team, type, detail"
+            className="h-9 w-full rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-sm"
+            aria-label="Search league office transactions"
+          />
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+            <select value={typeFilter} onChange={(e) => setTypeFilter(e.target.value)} className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-xs" aria-label="Filter league office transactions by type">
+              {typeOptions.map((option) => <option key={option} value={option}>{option === "all" ? "All types" : option}</option>)}
+            </select>
+            <select value={sort.key} onChange={(e) => setSort((curr) => ({ ...curr, key: e.target.value }))} className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-xs" aria-label="Sort league office transactions">
+              <option value="date">Sort: Date</option>
+              <option value="type">Sort: Type</option>
+              <option value="player">Sort: Player</option>
+              <option value="team">Sort: Team</option>
+            </select>
+            <button type="button" className="btn text-xs" onClick={() => setSort((curr) => ({ ...curr, dir: curr.dir === "asc" ? "desc" : "asc" }))}>
+              {sort.dir === "asc" ? "Asc" : "Desc"}
+            </button>
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-[color:var(--text-muted)]">
+            <span>{buildShowingLabel(browsedRows.length, transactions.length, "transaction")}</span>
+            <button type="button" className="text-[color:var(--accent)]" onClick={resetOfficeBrowser}>Reset filters</button>
+          </div>
+        </div>
         <ScrollArea className="h-[560px]">
           <div className="divide-y divide-[color:var(--hairline)]">
-            {rows.map((tx, idx) => (
+            {browsedRows.length === 0 ? (
+              <div className="px-4 py-6 text-sm text-[color:var(--text-muted)]">No transactions match these filters.</div>
+            ) : browsedRows.map((tx, idx) => (
               <div key={`${tx.id ?? idx}`} className="px-4 py-3 text-sm">
                 <div className="flex items-center justify-between gap-2">
                   <strong>{tx.typeLabel ?? tx.type}</strong>

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -29,6 +29,7 @@ import EmptyState from './EmptyState.jsx';
 import { buildRouteRequestKey, buildLeagueCacheScopeKey } from "../utils/requestLoopGuard.js";
 import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 import { getPlayerGameLogs } from "../utils/playerGameLogs.js";
+import { buildShowingLabel, rowMatchesSearch, stableSortRows, uniqueFilterOptions } from "../utils/dataBrowser.js";
 import { buildMergedPlayerAwardTimeline, buildPlayerAwardHeaderBadges } from "../../core/playerAwardTimeline.js";
 import { buildPlayerRecordContext, mergePlayerProfileSeasonRows } from "../../core/recordBookV1.js";
 import { buildLegacyScoreReport, shouldShowLegacyProfileSection } from "../../core/legacyScore.js";
@@ -332,6 +333,56 @@ function hasRecordedStats(stats = {}) {
   return Object.values(stats || {}).some((value) => Number(value) > 0);
 }
 
+function playerSeasonYearValue(line) {
+  const direct = Number(line?.year ?? line?.seasonYear);
+  if (Number.isFinite(direct) && direct > 0) return direct;
+  const derived = Number(seasonYear(line?.season ?? line?.seasonId));
+  return Number.isFinite(derived) ? derived : 0;
+}
+
+function playerSeasonStatValue(line, key) {
+  if (key === 'games') return Number(line?.gamesPlayed ?? line?.gp ?? 0);
+  if (key === 'passYds') return Number(line?.passYds ?? line?.passingYards ?? 0);
+  if (key === 'rushYds') return Number(line?.rushYds ?? line?.rushingYards ?? 0);
+  if (key === 'recYds') return Number(line?.recYds ?? line?.receivingYards ?? 0);
+  if (key === 'tackles') return Number(line?.tackles ?? line?.totalTackles ?? 0);
+  if (key === 'sacks') return Number(line?.sacks ?? 0);
+  if (key === 'defInts') return Number(line?.defInts ?? line?.defInterceptions ?? 0);
+  if (key === 'fgMade') return Number(line?.fgMade ?? 0);
+  if (key === 'ovr') return Number(line?.ovr ?? 0);
+  return playerSeasonYearValue(line);
+}
+
+function primarySeasonStatKey(pos) {
+  const p = String(pos ?? '').toUpperCase();
+  if (p === 'QB') return 'passYds';
+  if (['RB', 'FB'].includes(p)) return 'rushYds';
+  if (['WR', 'TE'].includes(p)) return 'recYds';
+  if (['DE', 'DT', 'DL', 'EDGE'].includes(p)) return 'sacks';
+  if (['LB', 'CB', 'S', 'SS', 'FS'].includes(p)) return 'tackles';
+  if (p === 'K') return 'fgMade';
+  return 'games';
+}
+
+function primarySeasonStatLabel(pos) {
+  const key = primarySeasonStatKey(pos);
+  return {
+    games: 'Games',
+    passYds: 'Pass yds',
+    rushYds: 'Rush yds',
+    recYds: 'Rec yds',
+    tackles: 'Tackles',
+    sacks: 'Sacks',
+    fgMade: 'FGM',
+  }[key] ?? 'Key stat';
+}
+
+function formatCompactNumber(value) {
+  const n = Number(value ?? 0);
+  if (!Number.isFinite(n) || n <= 0) return '—';
+  return Number.isInteger(n) ? n.toLocaleString() : n.toFixed(1);
+}
+
 function summarizeTrackedStats(stats = {}, position = '') {
   const pos = String(position || '').toUpperCase();
   const parts = [];
@@ -419,6 +470,9 @@ export default function PlayerProfile({
   const [extending, setExtending] = useState(false);
   const [showProjections, setShowProjections] = useState(false);
   const [activeProfileTab, setActiveProfileTab] = useState("Overview");
+  const [seasonLogSearch, setSeasonLogSearch] = useState("");
+  const [seasonLogTeam, setSeasonLogTeam] = useState("all");
+  const [seasonLogSort, setSeasonLogSort] = useState({ key: "year", dir: "desc" });
   const [draftContext, setDraftContext] = useState(null);
   const requestKey = useMemo(() => buildRouteRequestKey("player", playerId), [playerId]);
   const cacheScopeKey = useMemo(() => buildLeagueCacheScopeKey(league), [league]);
@@ -718,6 +772,64 @@ export default function PlayerProfile({
   }), [devHistory]);
 
   const careerRows = useMemo(() => mergedProfileSeasonRows, [mergedProfileSeasonRows]);
+  const awardLabelsByYear = useMemo(() => {
+    const map = new Map();
+    for (const row of mergedAwardTimeline?.rows ?? []) {
+      const year = Number(row?.year);
+      if (!Number.isFinite(year)) continue;
+      const list = map.get(year) ?? [];
+      list.push(row?.label ?? 'Award');
+      map.set(year, list);
+    }
+    return map;
+  }, [mergedAwardTimeline]);
+  const seasonLogRows = useMemo(() => {
+    const pos = effectivePlayer?.pos ?? effectivePlayer?.position;
+    const keyStat = primarySeasonStatKey(pos);
+    return (mergedProfileSeasonRows ?? []).map((line, index) => {
+      const year = playerSeasonYearValue(line);
+      const awards = awardLabelsByYear.get(year) ?? [];
+      return {
+        ...line,
+        _rowIndex: index,
+        _year: year,
+        _team: line?.team ?? '—',
+        _awardLabels: awards,
+        _awardText: awards.join(' · '),
+        _awardCount: awards.length,
+        _keyStatLabel: primarySeasonStatLabel(pos),
+        _keyStatValue: playerSeasonStatValue(line, keyStat),
+      };
+    });
+  }, [mergedProfileSeasonRows, awardLabelsByYear, effectivePlayer?.pos, effectivePlayer?.position]);
+  const seasonLogTeamOptions = useMemo(() => uniqueFilterOptions(seasonLogRows, (line) => line?._team), [seasonLogRows]);
+  const visibleSeasonLogRows = useMemo(() => {
+    const filtered = seasonLogRows.filter((line) => {
+      if (seasonLogTeam !== 'all' && line?._team !== seasonLogTeam) return false;
+      return rowMatchesSearch(line, seasonLogSearch, [
+        'season',
+        'seasonId',
+        'year',
+        '_year',
+        '_team',
+        '_awardText',
+        (row) => `${row?.gamesPlayed ?? row?.gp ?? 0} games`,
+        (row) => `${row?._keyStatLabel} ${row?._keyStatValue}`,
+      ]);
+    });
+    return stableSortRows(filtered, (line) => {
+      if (seasonLogSort.key === 'team') return line?._team;
+      if (seasonLogSort.key === 'games') return playerSeasonStatValue(line, 'games');
+      if (seasonLogSort.key === 'keyStat') return line?._keyStatValue;
+      if (seasonLogSort.key === 'awards') return line?._awardCount;
+      return line?._year;
+    }, seasonLogSort.dir, (line) => line?._rowIndex);
+  }, [seasonLogRows, seasonLogTeam, seasonLogSearch, seasonLogSort]);
+  const resetSeasonLogBrowser = () => {
+    setSeasonLogSearch("");
+    setSeasonLogTeam("all");
+    setSeasonLogSort({ key: "year", dir: "desc" });
+  };
   const careerTotals = useMemo(() => {
     const posU = String(effectivePlayer?.pos ?? effectivePlayer?.position ?? '').toUpperCase();
     const defSkill = ['DE', 'DT', 'LB', 'CB', 'S', 'DL', 'EDGE'].includes(posU);
@@ -1930,6 +2042,52 @@ export default function PlayerProfile({
               >
                 Season Log
               </h3>
+              <div style={{ display: "grid", gap: 8, marginBottom: 10 }}>
+                <input
+                  type="search"
+                  value={seasonLogSearch}
+                  onChange={(e) => setSeasonLogSearch(e.target.value)}
+                  placeholder="Search season, team, award, key stat"
+                  aria-label="Search player season log"
+                  style={{ width: "100%", background: "var(--surface)", border: "1px solid var(--hairline)", borderRadius: 8, padding: "7px 10px", color: "var(--text)", fontSize: "var(--text-sm)" }}
+                />
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit,minmax(120px,1fr))", gap: 8 }}>
+                  <select
+                    value={seasonLogTeam}
+                    onChange={(e) => setSeasonLogTeam(e.target.value)}
+                    aria-label="Filter player season log by team"
+                    style={{ background: "var(--surface)", border: "1px solid var(--hairline)", borderRadius: 8, padding: "7px 8px", color: "var(--text)", fontSize: "var(--text-xs)" }}
+                  >
+                    <option value="all">All teams</option>
+                    {seasonLogTeamOptions.map((team) => <option key={team} value={team}>{team}</option>)}
+                  </select>
+                  <select
+                    value={seasonLogSort.key}
+                    onChange={(e) => setSeasonLogSort((curr) => ({ ...curr, key: e.target.value }))}
+                    aria-label="Sort player season log"
+                    style={{ background: "var(--surface)", border: "1px solid var(--hairline)", borderRadius: 8, padding: "7px 8px", color: "var(--text)", fontSize: "var(--text-xs)" }}
+                  >
+                    <option value="year">Sort: Year</option>
+                    <option value="team">Sort: Team</option>
+                    <option value="games">Sort: Games</option>
+                    <option value="keyStat">Sort: {primarySeasonStatLabel(player?.pos ?? player?.position)}</option>
+                    <option value="awards">Sort: Awards</option>
+                  </select>
+                  <button type="button" className="btn" onClick={() => setSeasonLogSort((curr) => ({ ...curr, dir: curr.dir === "asc" ? "desc" : "asc" }))}>
+                    {seasonLogSort.dir === "asc" ? "Asc" : "Desc"}
+                  </button>
+                  <button type="button" className="btn btn-secondary" onClick={resetSeasonLogBrowser}>
+                    Reset filters
+                  </button>
+                </div>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 8, flexWrap: "wrap", fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
+                  <span>{buildShowingLabel(visibleSeasonLogRows.length, mergedProfileSeasonRows.length, "season")}</span>
+                  <span>{primarySeasonStatLabel(player?.pos ?? player?.position)} total: {formatCompactNumber(visibleSeasonLogRows.reduce((sum, line) => sum + Number(line?._keyStatValue ?? 0), 0))}</span>
+                </div>
+              </div>
+              {visibleSeasonLogRows.length === 0 ? (
+                <EmptyState icon="📉" title="No season rows match these filters" subtitle="Reset filters or archive more seasons for this player." />
+              ) : (
               <div className="table-wrapper" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
                 <Table
                   className="standings-table"
@@ -1953,6 +2111,7 @@ export default function PlayerProfile({
                       <TableHead style={{ textAlign: "left" }}>Team</TableHead>
                       <TableHead style={{ textAlign: "center" }}>Pos</TableHead>
                       <TableHead style={{ textAlign: "center" }}>GP</TableHead>
+                      <TableHead style={{ textAlign: "center" }}>Awards</TableHead>
                       {["QB"].includes(player.pos) && (
                         <>
                           <TableHead style={{ textAlign: "center" }}>YDS</TableHead>
@@ -1995,8 +2154,8 @@ export default function PlayerProfile({
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {[...mergedProfileSeasonRows].reverse().map((line, i) => (
-                      <TableRow key={i}>
+                    {visibleSeasonLogRows.map((line, i) => (
+                      <TableRow key={`${line._rowIndex}-${i}`} data-testid="player-profile-season-log-row">
                         <TableCell
                           style={{
                             paddingLeft: "var(--space-4)",
@@ -2030,6 +2189,9 @@ export default function PlayerProfile({
                         </TableCell>
                         <TableCell style={{ textAlign: "center" }}>
                           {line.gamesPlayed}
+                        </TableCell>
+                        <TableCell style={{ textAlign: "center", fontSize: "var(--text-xs)", color: line._awardCount ? "var(--accent)" : "var(--text-muted)" }}>
+                          {line._awardText || "—"}
                         </TableCell>
                         {["QB"].includes(player.pos) && (
                           <>
@@ -2101,6 +2263,7 @@ export default function PlayerProfile({
                   </TableBody>
                 </Table>
               </div>
+              )}
             </section>
           )}
           {!loading && mergedProfileSeasonRows.length === 0 && !isProspect && (

--- a/src/ui/components/TeamHistoryScreen.jsx
+++ b/src/ui/components/TeamHistoryScreen.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { ScreenHeader, SectionCard, EmptyState } from './ScreenSystem.jsx';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from '../utils/boxScoreAccess.js';
+import { buildShowingLabel, rowMatchesSearch, stableSortRows } from '../utils/dataBrowser.js';
 import { buildFranchiseHistoryModel, PLAYOFF_CALIBER_WINS } from '../../core/franchiseHistoryModel.js';
 import { RECORD_BOOK_PLAYER_KEYS, RECORD_LABELS } from '../../core/recordBookV1.js';
 
@@ -15,6 +16,26 @@ function buildSeasonTeamMap(season) {
 function formatPct(p) {
   if (!Number.isFinite(p) || p <= 0) return '—';
   return `${(p * 100).toFixed(1)}%`;
+}
+
+function teamSeasonResultLabel(row) {
+  if (row?.champion) return 'Champion';
+  if (row?.runnerUp) return 'Runner-up';
+  if (row?.truePlayoff) return 'Documented postseason';
+  if (row?.playoffCaliber) return 'Playoff-caliber';
+  if (row?.eliteSeason) return 'Elite season';
+  if (row?.losingSeason) return 'Losing season';
+  return 'Archived season';
+}
+
+function teamSeasonSortValue(row, sortKey) {
+  if (sortKey === 'wins') return row?.wins;
+  if (sortKey === 'losses') return row?.losses;
+  if (sortKey === 'pf') return row?.pf;
+  if (sortKey === 'pa') return row?.pa;
+  if (sortKey === 'pointDifferential') return row?.pointDifferential;
+  if (sortKey === 'result') return teamSeasonResultLabel(row);
+  return row?.year;
 }
 
 function RecordRow({ label, value, detail }) {
@@ -36,6 +57,7 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
   const [loading, setLoading] = useState(true);
   const [queryYear, setQueryYear] = useState('');
   const [scope, setScope] = useState('all');
+  const [timelineSort, setTimelineSort] = useState({ key: 'year', dir: 'desc' });
   const [majorMoves, setMajorMoves] = useState([]);
   const [draftFlash, setDraftFlash] = useState([]);
 
@@ -147,15 +169,30 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
   const { summary, franchiseRecords, franchiseLegends, playoffHistory, bestGames, milestones } = model;
 
   const filteredTimeline = useMemo(() => {
-    return (model.seasons ?? []).filter((row) => {
+    const rows = (model.seasons ?? []).filter((row) => {
       if (scope === 'champions' && !row.champion) return false;
       if (scope === 'playoff' && !row.playoffCaliber) return false;
       if (scope === 'losing' && !row.losingSeason) return false;
       if (scope === 'elite' && !row.eliteSeason) return false;
-      if (!queryYear.trim()) return true;
-      return String(row.year).includes(queryYear.trim());
+      return rowMatchesSearch(row, queryYear, [
+        'year',
+        'wins',
+        'losses',
+        'pf',
+        'pa',
+        (r) => `${r?.wins ?? 0}-${r?.losses ?? 0}${r?.ties ? `-${r.ties}` : ''}`,
+        (r) => teamSeasonResultLabel(r),
+        (r) => r?.mvp?.name,
+      ]);
     });
-  }, [model.seasons, queryYear, scope]);
+    return stableSortRows(rows, (row) => teamSeasonSortValue(row, timelineSort.key), timelineSort.dir, (row) => row?.year);
+  }, [model.seasons, queryYear, scope, timelineSort]);
+
+  const resetTimelineFilters = () => {
+    setQueryYear('');
+    setScope('all');
+    setTimelineSort({ key: 'year', dir: 'desc' });
+  };
 
   const completedGameRows = useMemo(() => {
     const rows = [];
@@ -456,13 +493,44 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
       </SectionCard>
 
       <SectionCard title="Season-by-season timeline">
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 10 }}>
+        <div style={{ display: 'grid', gap: 8, marginBottom: 10 }}>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
           <input
             value={queryYear}
             onChange={(e) => setQueryYear(e.target.value)}
-            placeholder="Filter by year"
+            placeholder="Search year, record, result, MVP"
             style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)', minWidth: 160 }}
+            aria-label="Search team seasons"
           />
+          <select
+            value={timelineSort.key}
+            onChange={(e) => setTimelineSort((curr) => ({ ...curr, key: e.target.value }))}
+            style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)' }}
+            aria-label="Sort team seasons"
+          >
+            <option value="year">Sort: Year</option>
+            <option value="wins">Sort: Wins</option>
+            <option value="losses">Sort: Losses</option>
+            <option value="pf">Sort: Points for</option>
+            <option value="pa">Sort: Points allowed</option>
+            <option value="pointDifferential">Sort: Point diff</option>
+            <option value="result">Sort: Result</option>
+          </select>
+          <button
+            type="button"
+            className="btn"
+            onClick={() => setTimelineSort((curr) => ({ ...curr, dir: curr.dir === 'asc' ? 'desc' : 'asc' }))}
+          >
+            {timelineSort.dir === 'asc' ? 'Asc' : 'Desc'}
+          </button>
+          <button type="button" className="btn btn-secondary" onClick={resetTimelineFilters}>
+            Reset filters
+          </button>
+          <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+            {buildShowingLabel(filteredTimeline.length, model.seasons?.length ?? 0, 'season')}
+          </span>
+          </div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
           {[
             { key: 'all', label: 'All-time' },
             { key: 'playoff', label: 'Playoff-caliber' },
@@ -474,13 +542,14 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
               {opt.label}
             </button>
           ))}
+          </div>
         </div>
         <div style={{ display: 'grid', gap: 8, maxHeight: 420, overflow: 'auto' }}>
           {filteredTimeline.length === 0 ? (
-            <EmptyState title="No team history for this filter" body="Adjust filters or archive more seasons." />
+            <EmptyState title={(model.seasons ?? []).length ? 'No team history for this filter' : 'No archived team seasons yet'} body={(model.seasons ?? []).length ? 'Adjust filters or archive more seasons.' : 'Complete and archive seasons to populate this franchise timeline.'} />
           ) : (
-            filteredTimeline.slice().reverse().map((s) => (
-              <div key={s.year} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: 10 }}>
+            filteredTimeline.map((s) => (
+              <div key={s.year} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: 10 }} data-testid="team-history-season-row">
                 <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
                   <strong>{s.year}</strong>
                   <span>
@@ -491,7 +560,7 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
                   </span>
                 </div>
                 <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
-                  PF {s.pf} · PA {s.pa}
+                  {teamSeasonResultLabel(s)} · PF {s.pf} · PA {s.pa} · Diff {s.pointDifferential}
                   {s.truePlayoff ? ' · Postseason (documented)' : s.playoffCaliber ? ' · Playoff-caliber' : ''}
                 </div>
                 <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 4 }}>

--- a/src/ui/components/__tests__/LeagueActivityLog.test.jsx
+++ b/src/ui/components/__tests__/LeagueActivityLog.test.jsx
@@ -1,0 +1,40 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import LeagueActivityLog from '../LeagueActivityLog.jsx';
+
+describe('LeagueActivityLog', () => {
+  it('searches, filters, sorts, counts, and resets transaction rows client-side', async () => {
+    const transactions = [
+      { id: 1, seasonId: 's1', week: 1, type: 'signing', typeLabel: 'Signing', playerId: 11, playerName: 'Zed Runner', teamId: 1, teamAbbr: 'DAL', headline: 'DAL signed Zed Runner' },
+      { id: 2, seasonId: 's1', week: 2, type: 'trade', typeLabel: 'Trade', playerId: 12, playerName: 'Avery Fields', fromTeamId: 2, fromTeamAbbr: 'NYG', toTeamId: 1, toTeamAbbr: 'DAL', headline: 'NYG and DAL completed a trade' },
+    ];
+    render(
+      <LeagueActivityLog
+        league={{ seasonId: 's1', year: 2030, teams: [{ id: 1, abbr: 'DAL' }, { id: 2, abbr: 'NYG' }] }}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({ payload: { seasons: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions } }),
+        }}
+        onPlayerSelect={vi.fn()}
+        onTeamSelect={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText(/Showing 2 of 2 transactions/i)).toBeTruthy());
+    fireEvent.change(screen.getByLabelText(/^Search$/i), { target: { value: 'Avery' } });
+    expect(screen.getByText(/Showing 1 of 2 transactions/i)).toBeTruthy();
+    await waitFor(() => expect(screen.getAllByTestId('league-activity-row')[0].textContent).toMatch(/Avery Fields/));
+
+    fireEvent.click(screen.getByRole('button', { name: /Reset filters/i }));
+    await waitFor(() => expect(screen.getByText(/Showing 2 of 2 transactions/i)).toBeTruthy());
+    fireEvent.change(screen.getByLabelText(/^Sort$/i), { target: { value: 'player' } });
+    fireEvent.click(screen.getByRole('button', { name: /Desc/i }));
+    await waitFor(() => expect(screen.getAllByTestId('league-activity-row')[0].textContent).toMatch(/Avery Fields/));
+
+    fireEvent.change(screen.getByLabelText(/^Type$/i), { target: { value: 'trade' } });
+    expect(screen.getByText(/Showing 1 of 2 transactions/i)).toBeTruthy();
+    await waitFor(() => expect(screen.getAllByTestId('league-activity-row')[0].textContent).toMatch(/Trade/));
+  });
+});

--- a/src/ui/components/__tests__/LeagueHistory.test.jsx
+++ b/src/ui/components/__tests__/LeagueHistory.test.jsx
@@ -1,8 +1,10 @@
 /** @vitest-environment jsdom */
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import LeagueHistory from '../LeagueHistory.jsx';
+
+afterEach(() => cleanup());
 
 describe('LeagueHistory', () => {
   it('opens the selected archived season and handles missing championship data safely', async () => {
@@ -196,5 +198,38 @@ describe('LeagueHistory', () => {
       expect(screen.getByTestId('league-history-major-tx-sx')).toBeTruthy();
       expect(screen.getByTestId('league-history-major-tx-sx').textContent).toMatch(/DAL signed Test Player/);
     });
+  });
+
+  it('searches, sorts, counts, and resets the season archive picker', async () => {
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                { id: 's1', year: 2030, champion: { id: 2, abbr: 'DAL', name: 'Dallas' }, standings: [{ id: 1, name: 'User', abbr: 'USR', wins: 12, losses: 5 }], awards: {} },
+                { id: 's2', year: 2031, champion: { id: 3, abbr: 'NYG', name: 'New York' }, standings: [{ id: 1, name: 'User', abbr: 'USR', wins: 6, losses: 11 }], awards: {} },
+              ],
+            },
+          }),
+          getRecords: vi.fn().mockResolvedValue({ payload: { records: null } }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText(/Showing 2 of 2 seasons/i)).toBeTruthy());
+    fireEvent.change(screen.getByLabelText(/Search archived seasons/i), { target: { value: 'DAL' } });
+    expect(screen.getByText(/Showing 1 of 2 seasons/i)).toBeTruthy();
+    expect(screen.getAllByTestId('league-history-season-row')[0].textContent).toMatch(/2030/);
+
+    fireEvent.click(screen.getByRole('button', { name: /Reset filters/i }));
+    fireEvent.change(screen.getByLabelText(/Sort archived seasons/i), { target: { value: 'userWins' } });
+    fireEvent.click(screen.getByRole('button', { name: /Desc/i }));
+    expect(screen.getAllByTestId('league-history-season-row')[0].textContent).toMatch(/2031/);
   });
 });

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -250,6 +250,80 @@ describe('PlayerProfile', () => {
     expect(screen.getByText('4,100')).toBeTruthy();
   });
 
+  it('filters, sorts, counts, and resets archived player season rows', async () => {
+    const logActions = {
+      getPlayerCareer: vi.fn(async () => ({
+        payload: {
+          player: { ...player, careerStats: [] },
+          stats: [],
+          teammates: [],
+          meta: {},
+        },
+      })),
+      getAllSeasons: vi.fn(async () => ({
+        payload: {
+          seasons: [
+            {
+              id: 's1',
+              year: 2030,
+              awards: { mvp: { playerId: 11, name: 'Avery Fields', teamId: 1 } },
+              playerSeasonStatsV1: {
+                schemaVersion: 1,
+                rows: [{
+                  playerId: 11,
+                  playerName: 'Avery Fields',
+                  pos: 'QB',
+                  teamId: 1,
+                  teamAbbr: 'DAL',
+                  year: 2030,
+                  seasonId: 's1',
+                  gamesPlayed: 12,
+                  passYds: 4100,
+                  passTDs: 31,
+                  passInts: 9,
+                }],
+              },
+            },
+            {
+              id: 's2',
+              year: 2031,
+              awards: {},
+              playerSeasonStatsV1: {
+                schemaVersion: 1,
+                rows: [{
+                  playerId: 11,
+                  playerName: 'Avery Fields',
+                  pos: 'QB',
+                  teamId: 2,
+                  teamAbbr: 'NYG',
+                  year: 2031,
+                  seasonId: 's2',
+                  gamesPlayed: 10,
+                  passYds: 2500,
+                  passTDs: 15,
+                  passInts: 7,
+                }],
+              },
+            },
+          ],
+        },
+      })),
+      getRecords: vi.fn(async () => ({ payload: { recordBook: null } })),
+    };
+    render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={logActions} teams={league.teams} league={league} />);
+
+    await waitFor(() => expect(screen.getByText(/Showing 2 of 2 seasons/i)).toBeTruthy());
+    expect(screen.getByTestId('player-profile')).toBeTruthy();
+    fireEvent.change(screen.getByLabelText(/Filter player season log by team/i), { target: { value: 'NYG' } });
+    expect(screen.getByText(/Showing 1 of 2 seasons/i)).toBeTruthy();
+    expect(screen.getAllByTestId('player-profile-season-log-row')[0].textContent).toMatch(/NYG/);
+
+    fireEvent.click(screen.getByRole('button', { name: /Reset filters/i }));
+    fireEvent.change(screen.getByLabelText(/Sort player season log/i), { target: { value: 'keyStat' } });
+    expect(screen.getAllByTestId('player-profile-season-log-row')[0].textContent).toMatch(/4,100/);
+    expect(screen.getAllByTestId('player-profile-season-log-row')[0].textContent).toMatch(/Most Valuable Player/);
+  });
+
   it('shows honest empty award timeline when no honors exist', async () => {
     render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={actions} teams={league.teams} league={league} />);
     await waitFor(() => expect(screen.getByTestId('player-profile-award-timeline')).toBeTruthy());

--- a/src/ui/components/__tests__/TeamHistoryScreen.test.jsx
+++ b/src/ui/components/__tests__/TeamHistoryScreen.test.jsx
@@ -109,4 +109,50 @@ describe('TeamHistoryScreen', () => {
     const arg = onOpen.mock.calls[0][0];
     expect(String(arg)).toMatch(/2055/);
   });
+
+  it('searches, sorts, counts, and resets the season timeline without inventing results', async () => {
+    render(
+      <TeamHistoryScreen
+        league={{ teams: [{ id: 7, name: 'Seattle', abbr: 'SEA' }], userTeamId: 7 }}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                {
+                  id: 's1',
+                  year: 2030,
+                  standings: [{ id: 7, name: 'Seattle', abbr: 'SEA', wins: 7, losses: 10, ties: 0, pf: 310, pa: 380 }],
+                  awards: {},
+                },
+                {
+                  id: 's2',
+                  year: 2031,
+                  standings: [{ id: 7, name: 'Seattle', abbr: 'SEA', wins: 12, losses: 5, ties: 0, pf: 470, pa: 320 }],
+                  champion: { id: 7, abbr: 'SEA' },
+                  awards: { mvp: { playerId: 11, name: 'Avery Fields' } },
+                },
+              ],
+            },
+          }),
+          getHallOfFame: vi.fn().mockResolvedValue({ payload: { players: [], classes: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+          getDraftClasses: vi.fn().mockResolvedValue({ payload: { classes: [] } }),
+          getDraftClass: vi.fn().mockResolvedValue({ payload: { model: null } }),
+        }}
+        onBack={vi.fn()}
+        onPlayerSelect={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText(/Showing 2 of 2 seasons/i)).toBeTruthy());
+    fireEvent.change(screen.getByLabelText(/Search team seasons/i), { target: { value: 'Avery' } });
+    expect(screen.getByText(/Showing 1 of 2 seasons/i)).toBeTruthy();
+    expect(screen.getAllByTestId('team-history-season-row')[0].textContent).toMatch(/2031/);
+
+    fireEvent.click(screen.getByRole('button', { name: /Reset filters/i }));
+    expect(screen.getByText(/Showing 2 of 2 seasons/i)).toBeTruthy();
+    fireEvent.change(screen.getByLabelText(/Sort team seasons/i), { target: { value: 'wins' } });
+    fireEvent.click(screen.getByRole('button', { name: /Desc/i }));
+    expect(screen.getAllByTestId('team-history-season-row')[0].textContent).toMatch(/2030/);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Improves dynasty-history browsing density on Team History, Player Profile season logs, League History, and League Activity.
- Reuses `dataBrowser` helpers for normalized search, stable sorting, showing counts, unique options, and resettable filters.
- Keeps changes scoped to UI browsing and component tests; no archive, simulation, or economy logic changes.

## Screens improved
- Team History: season timeline search by year/record/result/MVP, sort by year/wins/losses/PF/PA/diff/result, count, reset, compact cards.
- Player Profile: archived season log search/filter by team/year/award/key stat, sort by year/team/games/key stat/awards, count, reset, derived visible-total summary.
- League History: season archive picker search by year/team/champion/runner-up/MVP, sort by year/champion/user wins/team count, count, reset, champion-unavailable fallback.
- League Activity: transaction search by player/team/type/detail, type/team/season filters, sort by date/type/player/team, count, reset.

## Fallback behavior
- Empty or young saves keep honest empty states and never fabricate champions, awards, stats, transactions, or draft/history rows.
- Missing champions render as unavailable/blank rather than guessed.

## Mobile UX notes
- Controls use compact wrapped rows/grids and retain card/list layouts to avoid wide desktop-only controls.

## Walkthrough artifact
[league_activity_controls_playwright.mp4](https://cursor.com/agents/bc-45df5957-edf9-41d4-8187-9d5da6c6fed4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fleague_activity_controls_playwright.mp4)

## Tests run/results
- `npm ci` passed; npm reported existing 2 high-severity audit findings.
- `node --check src/ui/utils/dataBrowser.js` passed.
- `npm run test:unit -- src/ui/utils/dataBrowser.test.js` passed.
- `npm run test:unit -- src/ui/components/__tests__/TeamHistoryScreen.test.jsx src/ui/components/__tests__/LeagueHistory.test.jsx src/ui/components/__tests__/PlayerProfile.test.jsx src/ui/components/__tests__/LeagueActivityLog.test.jsx` passed (27 tests).
- `npm run test:unit` passed (191 files, 844 tests).
- `npm run test:soak` passed (6 files, 40 tests).
- `npm run audit:dynasty -- --ci --seed=1383` passed in 6358ms; warning only: young-league HOF empty.
- `npm run build` passed; expected chunk-size warning only.
- `npm run check:deploy` passed; npm audit warnings and expected chunk-size warnings only.
- `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` passed.
- `npx playwright test` passed (18 tests, 4.8m).

## Deferred
- Awards/Records, Hall of Fame, and Draft History browsing upgrades beyond existing functionality were intentionally deferred to keep this PR focused on the preferred highest-impact surfaces.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45df5957-edf9-41d4-8187-9d5da6c6fed4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45df5957-edf9-41d4-8187-9d5da6c6fed4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

