### PR TITLE
feat(ui): history data density V2 (team, league archive, player log, transactions)

### DIFF
--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from "@/components/ui/table";
@@ -8,6 +8,7 @@ import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/b
 import { AWARD_DISPLAY_NAMES } from '../../core/footballMeta';
 import { buildLeagueHistoryTopPerformers } from '../../core/playerSeasonStatsArchive.js';
 import { normalizeArchivedMajorTransactions } from '../../core/transactionTimeline.js';
+import { buildShowingLabel, rowMatchesSearch, stableSortRows, uniqueFilterOptions } from '../utils/dataBrowser.js';
 
 const RECORD_LABELS = {
   passYd: "Passing Yards",
@@ -168,7 +169,7 @@ export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenB
           <TabsTrigger value="compare">Compare Players</TabsTrigger>
         </TabsList>
 
-        <TabsContent value="seasons">
+        <TabsContent value="seasons" data-testid="league-history-season-archive-browser">
           <SeasonExplorer seasons={seasons} actions={api} onPlayerSelect={onPlayerSelect} onOpenBoxScore={onOpenBoxScore} league={league} initialSelectedSeasonId={initialSelectedSeasonId} />
         </TabsContent>
 
@@ -180,7 +181,7 @@ export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenB
           <AwardsHistory seasons={seasons} onPlayerSelect={onPlayerSelect} />
         </TabsContent>
 
-        <TabsContent value="office">
+        <TabsContent value="office" data-testid="league-history-office-tab">
           <LeagueOfficeHistory transactions={transactions} onPlayerSelect={onPlayerSelect} />
         </TabsContent>
 
@@ -342,6 +343,71 @@ function SeasonDraftClassSnippet({ seasonId, year, actions, onPlayerSelect }) {
 
 function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, league, initialSelectedSeasonId = null }) {
   const [selectedSeasonId, setSelectedSeasonId] = useState(initialSelectedSeasonId ?? seasons?.[0]?.id ?? null);
+  const [seasonArchiveQuery, setSeasonArchiveQuery] = useState('');
+  const [championFilter, setChampionFilter] = useState('all');
+  const [seasonArchiveSort, setSeasonArchiveSort] = useState('desc');
+
+  const championFilterOptions = useMemo(() => {
+    const rows = seasons ?? [];
+    const withAbbr = uniqueFilterOptions(
+      rows.filter((s) => s?.champion?.abbr || s?.champion?.name),
+      (s) => s?.champion?.abbr ?? s?.champion?.name,
+    );
+    const noneAvailable = rows.some((s) => !s?.champion);
+    return { withAbbr, noneAvailable };
+  }, [seasons]);
+
+  const filteredArchiveSeasons = useMemo(() => {
+    let rows = [...(seasons ?? [])];
+    if (championFilter === '__none__') {
+      rows = rows.filter((s) => !s?.champion);
+    } else if (championFilter !== 'all') {
+      rows = rows.filter((s) => {
+        const ab = s?.champion?.abbr ?? s?.champion?.name ?? '';
+        return String(ab) === championFilter;
+      });
+    }
+    rows = rows.filter((s) =>
+      rowMatchesSearch(s, seasonArchiveQuery, [
+        'year',
+        (x) => x?.id,
+        (x) => x?.champion?.abbr,
+        (x) => x?.champion?.name,
+        (x) => x?.runnerUp?.abbr,
+        (x) => x?.runnerUp?.name,
+      ]),
+    );
+    const dir = seasonArchiveSort === 'asc' ? 'asc' : 'desc';
+    return stableSortRows(rows, (x) => Number(x?.year ?? 0), dir, (x) => String(x?.id ?? ''));
+  }, [seasons, seasonArchiveQuery, championFilter, seasonArchiveSort]);
+
+  const seasonArchiveShowingLabel = buildShowingLabel(filteredArchiveSeasons.length, (seasons ?? []).length, 'season');
+
+  const selected = useMemo(
+    () => (!seasons?.length ? null : seasons.find((s) => s.id === selectedSeasonId) ?? seasons[0] ?? null),
+    [seasons, selectedSeasonId],
+  );
+
+  const topPerformers = useMemo(
+    () => (selected ? buildLeagueHistoryTopPerformers(selected, { perBucket: 2 }) : null),
+    [selected],
+  );
+
+  const seasonMajorTx = useMemo(() => {
+    if (!selected) return [];
+    const v1 = selected?.transactionTimelineV1?.rows;
+    if (Array.isArray(v1) && v1.length) return v1.slice(0, 10);
+    const raw = selected?.majorTransactions;
+    if (!Array.isArray(raw) || !raw.length) return [];
+    const teams = league?.teams ?? [];
+    const teamsById = new Map(teams.map((t) => [Number(t.id), t]));
+    return normalizeArchivedMajorTransactions(raw, {
+      teams,
+      teamsById,
+      year: selected?.year ?? null,
+      phase: null,
+    }).slice(0, 10);
+  }, [selected, league?.teams]);
 
   useEffect(() => {
     if (!seasons?.length) return;
@@ -364,7 +430,6 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
     );
   }
 
-  const selected = seasons.find((s) => s.id === selectedSeasonId) ?? seasons[0];
   const sortedStandings = [...(selected?.standings ?? [])].sort((a, b) => pct(b) - pct(a)).slice(0, 8);
   const championBoard = buildChampionMap(seasons).slice(0, 5);
   const playoffMentions = (selected?.standings ?? []).filter((row) => Number(row?.wins ?? 0) >= 10).slice(0, 6);
@@ -380,41 +445,79 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
   const championshipGame = (selected?.gameIndex ?? []).find((g) => String(g?.id) === String(selected?.championshipGameId)) ?? null;
   const notableGames = Array.isArray(selected?.notableGames) ? selected.notableGames : [];
   const selectedSeasonIndex = seasons.findIndex((s) => s.id === selected?.id);
-  const topPerformers = useMemo(() => buildLeagueHistoryTopPerformers(selected, { perBucket: 2 }), [selected]);
-
-  const seasonMajorTx = useMemo(() => {
-    const v1 = selected?.transactionTimelineV1?.rows;
-    if (Array.isArray(v1) && v1.length) return v1.slice(0, 10);
-    const raw = selected?.majorTransactions;
-    if (!Array.isArray(raw) || !raw.length) return [];
-    const teams = league?.teams ?? [];
-    const teamsById = new Map(teams.map((t) => [Number(t.id), t]));
-    return normalizeArchivedMajorTransactions(raw, {
-      teams,
-      teamsById,
-      year: selected?.year ?? null,
-      phase: null,
-    }).slice(0, 10);
-  }, [selected, league?.teams]);
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[260px_1fr] gap-4">
       <Card className="card-premium">
         <CardHeader><CardTitle>Season Archive</CardTitle></CardHeader>
-        <CardContent className="p-0">
-          <ScrollArea className="h-[520px]">
-            <div className="divide-y divide-[color:var(--hairline)]">
-              {seasons.map((s) => (
-                <button
-                  key={s.id}
-                  className={`w-full text-left px-4 py-3 ${selected?.id === s.id ? "bg-[color:var(--surface-strong)]" : ""}`}
-                  onClick={() => setSelectedSeasonId(s.id)}
+        <CardContent className="p-0 space-y-0">
+          <div className="p-3 space-y-2 border-b border-[color:var(--hairline)]">
+            <input
+              type="search"
+              value={seasonArchiveQuery}
+              onChange={(e) => setSeasonArchiveQuery(e.target.value)}
+              placeholder="Search year, teams, champion…"
+              className="h-9 w-full rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-sm"
+              aria-label="Search archived seasons"
+            />
+            <div className="flex flex-wrap gap-2 items-center">
+              <label className="text-xs text-[color:var(--text-muted)] flex items-center gap-1">
+                Champion
+                <select
+                  value={championFilter}
+                  onChange={(e) => setChampionFilter(e.target.value)}
+                  className="h-8 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-1 text-xs max-w-[140px]"
                 >
-                  <div className="font-bold text-sm">{s.year}</div>
-                  <div className="text-xs text-[color:var(--text-muted)]">{s.champion?.abbr ?? "TBD"} champion</div>
-                </button>
-              ))}
+                  <option value="all">All</option>
+                  {championFilterOptions.noneAvailable ? <option value="__none__">No champion in archive</option> : null}
+                  {championFilterOptions.withAbbr.map((abbr) => (
+                    <option key={abbr} value={abbr}>{abbr}</option>
+                  ))}
+                </select>
+              </label>
+              <button
+                type="button"
+                className="btn btn-sm"
+                onClick={() => setSeasonArchiveSort((d) => (d === 'asc' ? 'desc' : 'asc'))}
+              >
+                Year {seasonArchiveSort === 'asc' ? '↑' : '↓'}
+              </button>
+              <button
+                type="button"
+                className="btn btn-secondary btn-sm"
+                onClick={() => {
+                  setSeasonArchiveQuery('');
+                  setChampionFilter('all');
+                  setSeasonArchiveSort('desc');
+                }}
+              >
+                Reset
+              </button>
             </div>
+            <div className="text-[10px] text-[color:var(--text-muted)] leading-tight">{seasonArchiveShowingLabel}</div>
+          </div>
+          <ScrollArea className="h-[460px] lg:h-[520px]">
+            {filteredArchiveSeasons.length === 0 ? (
+              <div className="px-4 py-8 text-center text-sm text-[color:var(--text-muted)]">
+                No seasons match these filters. Clear search or reset to see the full archive.
+              </div>
+            ) : (
+              <div className="divide-y divide-[color:var(--hairline)]" data-testid="league-history-season-archive-list">
+                {filteredArchiveSeasons.map((s) => (
+                  <button
+                    key={s.id}
+                    className={`w-full text-left px-4 py-2.5 sm:py-3 ${selected?.id === s.id ? "bg-[color:var(--surface-strong)]" : ""}`}
+                    onClick={() => setSelectedSeasonId(s.id)}
+                  >
+                    <div className="font-bold text-sm leading-tight">{s.year}</div>
+                    <div className="text-[11px] sm:text-xs text-[color:var(--text-muted)] leading-snug">
+                      {(s.champion?.abbr ?? s.champion?.name) || "—"}
+                      <span className="text-[color:var(--text-subtle)]"> · champ</span>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
           </ScrollArea>
         </CardContent>
       </Card>
@@ -838,10 +941,11 @@ function AwardsHistory({ seasons, onPlayerSelect }) {
 }
 
 function LeagueOfficeHistory({ transactions, onPlayerSelect }) {
-  if (!transactions?.length) return <div className="py-8 text-center text-[color:var(--text-muted)]">No transaction history tracked yet.</div>;
+  const [txQuery, setTxQuery] = useState('');
+  const [txTypeFilter, setTxTypeFilter] = useState('all');
+  const [txSortNewest, setTxSortNewest] = useState(true);
 
-  const rows = transactions.slice(0, 120);
-  const describe = (tx) => {
+  const describeTx = useCallback((tx) => {
     const leg = tx.legacyType ?? "";
     const bucket = tx.type ?? "";
     const isTrade = leg === "TRADE" || bucket === "trade";
@@ -861,28 +965,127 @@ function LeagueOfficeHistory({ transactions, onPlayerSelect }) {
     if (isDraft) return `${tx.teamAbbr ?? "??"} drafted ${tx.playerName ?? "player"}.`;
     if (isRetire) return `${tx.playerName ?? "Player"} retired${tx.detail ? ` (${tx.detail})` : ""}.`;
     return tx.headline ?? tx.typeLabel ?? tx.type;
-  };
+  }, []);
+
+  const typeOptions = useMemo(
+    () => uniqueFilterOptions(transactions ?? [], (t) => t?.typeLabel ?? t?.type),
+    [transactions],
+  );
+
+  const filteredTransactions = useMemo(() => {
+    let rows = [...(transactions ?? [])];
+    if (txTypeFilter !== 'all') {
+      rows = rows.filter((t) => String(t?.typeLabel ?? t?.type ?? '') === txTypeFilter);
+    }
+    rows = rows.filter((t) =>
+      rowMatchesSearch(t, txQuery, [
+        'playerName',
+        'teamAbbr',
+        'fromTeamAbbr',
+        'toTeamAbbr',
+        'typeLabel',
+        'type',
+        'headline',
+        'seasonId',
+        (x) => describeTx(x),
+      ]),
+    );
+    const dir = txSortNewest ? 'desc' : 'asc';
+    const seasonOrdinal = (sid) => {
+      const s = String(sid ?? '');
+      const m = /^s(\d+)$/i.exec(s);
+      if (m) return Number(m[1]);
+      const n = Number(s);
+      return Number.isFinite(n) ? n : 0;
+    };
+    return stableSortRows(
+      rows,
+      (t) => seasonOrdinal(t?.seasonId) * 1e4 + Number(t?.week ?? 0),
+      dir,
+      (t) => Number(t?.id ?? t?.rawId ?? 0),
+    );
+  }, [transactions, txQuery, txTypeFilter, txSortNewest, describeTx]);
+
+  const txCap = 200;
+  const visibleTransactions = filteredTransactions.slice(0, txCap);
+  const txShowingLabel = buildShowingLabel(visibleTransactions.length, filteredTransactions.length, 'move');
+
+  if (!transactions?.length) {
+    return (
+      <div className="py-8 text-center text-[color:var(--text-muted)]" data-testid="league-office-history-empty">
+        No transaction history tracked yet.
+      </div>
+    );
+  }
 
   return (
-    <Card className="card-premium">
+    <Card className="card-premium" data-testid="league-office-history-browser">
       <CardHeader><CardTitle>League Moves Log</CardTitle></CardHeader>
-      <CardContent className="p-0">
-        <ScrollArea className="h-[560px]">
-          <div className="divide-y divide-[color:var(--hairline)]">
-            {rows.map((tx, idx) => (
-              <div key={`${tx.id ?? idx}`} className="px-4 py-3 text-sm">
-                <div className="flex items-center justify-between gap-2">
-                  <strong>{tx.typeLabel ?? tx.type}</strong>
-                  <span className="text-xs text-[color:var(--text-muted)]">Week {tx.week ?? "?"}</span>
-                </div>
-                <div className="text-[color:var(--text-muted)] mt-1">{describe(tx)}</div>
-                {tx.playerId != null && (
-                  <button className="btn mt-2 text-xs" onClick={() => onPlayerSelect?.(tx.playerId)}>Open player</button>
-                )}
-              </div>
-            ))}
+      <CardContent className="p-0 space-y-0">
+        <div className="px-4 py-3 space-y-2 border-b border-[color:var(--hairline)]">
+          <input
+            type="search"
+            value={txQuery}
+            onChange={(e) => setTxQuery(e.target.value)}
+            placeholder="Search player, team, headline, season…"
+            className="h-9 w-full rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-sm"
+            aria-label="Search transactions"
+          />
+          <div className="flex flex-wrap gap-2 items-center">
+            <label className="text-xs text-[color:var(--text-muted)] flex items-center gap-1">
+              Type
+              <select
+                value={txTypeFilter}
+                onChange={(e) => setTxTypeFilter(e.target.value)}
+                className="h-8 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-xs max-w-[160px]"
+              >
+                <option value="all">All types</option>
+                {typeOptions.map((opt) => (
+                  <option key={opt} value={opt}>{opt}</option>
+                ))}
+              </select>
+            </label>
+            <button type="button" className="btn btn-sm" onClick={() => setTxSortNewest((v) => !v)}>
+              {txSortNewest ? 'Newest first' : 'Oldest first'}
+            </button>
+            <button
+              type="button"
+              className="btn btn-secondary btn-sm"
+              onClick={() => {
+                setTxQuery('');
+                setTxTypeFilter('all');
+                setTxSortNewest(true);
+              }}
+            >
+              Reset
+            </button>
           </div>
-        </ScrollArea>
+          <div className="text-[10px] text-[color:var(--text-muted)]">{txShowingLabel}{filteredTransactions.length > txCap ? ' (list capped)' : ''}</div>
+        </div>
+        {visibleTransactions.length === 0 ? (
+          <div className="px-4 py-10 text-center text-sm text-[color:var(--text-muted)]" data-testid="league-office-history-filtered-empty">
+            No moves match these filters. Reset to see the full log.
+          </div>
+        ) : (
+          <ScrollArea className="h-[520px]">
+            <div className="divide-y divide-[color:var(--hairline)]">
+              {visibleTransactions.map((tx, idx) => (
+                <div key={`${tx.id ?? idx}`} className="px-4 py-2.5 sm:py-3 text-sm">
+                  <div className="flex items-center justify-between gap-2 flex-wrap">
+                    <strong className="text-[13px] sm:text-sm">{tx.typeLabel ?? tx.type}</strong>
+                    <span className="text-[10px] sm:text-xs text-[color:var(--text-muted)] tabular-nums shrink-0">
+                      {tx.seasonId != null ? `${tx.seasonId} · ` : ''}Week {tx.week ?? "?"}
+                    </span>
+                  </div>
+                  <div className="text-[color:var(--text-muted)] mt-1 text-xs sm:text-sm leading-snug">{describeTx(tx)}</div>
+                  {tx.playerId != null && (
+                    <button type="button" className="btn mt-2 text-xs" onClick={() => onPlayerSelect?.(tx.playerId)}>Open player</button>
+                  )}
+                </div>
+              ))}
+            </div>
+          </ScrollArea>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -31,6 +31,7 @@ import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 import { getPlayerGameLogs } from "../utils/playerGameLogs.js";
 import { buildMergedPlayerAwardTimeline, buildPlayerAwardHeaderBadges } from "../../core/playerAwardTimeline.js";
 import { buildPlayerRecordContext, mergePlayerProfileSeasonRows } from "../../core/recordBookV1.js";
+import { buildShowingLabel, rowMatchesSearch, stableSortRows } from "../utils/dataBrowser.js";
 import { buildLegacyScoreReport, shouldShowLegacyProfileSection } from "../../core/legacyScore.js";
 import { buildPlayerDevelopmentModel } from "../../core/playerDevelopmentModel.js";
 import { buildProspectScoutingReport } from "../../core/scoutingModel.js";
@@ -420,6 +421,10 @@ export default function PlayerProfile({
   const [showProjections, setShowProjections] = useState(false);
   const [activeProfileTab, setActiveProfileTab] = useState("Overview");
   const [draftContext, setDraftContext] = useState(null);
+  const [seasonLogQuery, setSeasonLogQuery] = useState('');
+  const [seasonLogTeamFilter, setSeasonLogTeamFilter] = useState('');
+  const [seasonLogSortKey, setSeasonLogSortKey] = useState('season');
+  const [seasonLogSortDir, setSeasonLogSortDir] = useState('desc');
   const requestKey = useMemo(() => buildRouteRequestKey("player", playerId), [playerId]);
   const cacheScopeKey = useMemo(() => buildLeagueCacheScopeKey(league), [league]);
   const fetchProfileData = React.useCallback(async () => {
@@ -647,6 +652,45 @@ export default function PlayerProfile({
   const mergedProfileSeasonRows = useMemo(
     () => mergePlayerProfileSeasonRows(effectivePlayer, archivedSeasons),
     [effectivePlayer, archivedSeasons],
+  );
+
+  const displaySeasonLogRows = useMemo(() => {
+    const rows = mergedProfileSeasonRows ?? [];
+    const posU = String(player?.pos ?? player?.position ?? '').toUpperCase();
+    let out = rows;
+    if (seasonLogTeamFilter) out = out.filter((r) => String(r.team ?? '') === seasonLogTeamFilter);
+    out = out.filter((r) =>
+      rowMatchesSearch(r, seasonLogQuery, ['season', 'team', (x) => String(x.year ?? '')]),
+    );
+    const keyStatGetter = (line) => {
+      if (posU === 'QB') return Number(line.passYds ?? 0);
+      if (['RB', 'FB'].includes(posU)) return Number(line.rushYds ?? 0);
+      if (['WR', 'TE'].includes(posU)) return Number(line.recYds ?? 0);
+      if (['DE', 'DT', 'LB', 'CB', 'S', 'DL', 'EDGE'].includes(posU)) {
+        return Number(line.tackles ?? 0) + Number(line.sacks ?? 0) * 12 + Number(line.defInts ?? line.defInterceptions ?? 0) * 8;
+      }
+      if (posU === 'K') return Number(line.fgMade ?? 0);
+      return Number(line.gamesPlayed ?? line.gp ?? 0);
+    };
+    if (seasonLogSortKey === 'season') {
+      return stableSortRows(out, (l) => String(l.season ?? ''), seasonLogSortDir, (l) => String(l.team ?? ''));
+    }
+    if (seasonLogSortKey === 'team') {
+      return stableSortRows(out, (l) => String(l.team ?? ''), seasonLogSortDir, (l) => String(l.season ?? ''));
+    }
+    if (seasonLogSortKey === 'games') {
+      return stableSortRows(out, (l) => Number(l.gamesPlayed ?? l.gp ?? 0), seasonLogSortDir, (l) => String(l.season ?? ''));
+    }
+    if (seasonLogSortKey === 'keyStat') {
+      return stableSortRows(out, keyStatGetter, seasonLogSortDir, (l) => String(l.season ?? ''));
+    }
+    return stableSortRows(out, (l) => String(l.season ?? ''), 'desc', (l) => String(l.team ?? ''));
+  }, [mergedProfileSeasonRows, seasonLogQuery, seasonLogTeamFilter, seasonLogSortKey, seasonLogSortDir, player?.pos, player?.position]);
+
+  const seasonLogShowingLabel = buildShowingLabel(
+    displaySeasonLogRows.length,
+    (mergedProfileSeasonRows ?? []).length,
+    'season',
   );
   const teamJourney = [...new Set(mergedProfileSeasonRows.map((line) => line.team).filter(Boolean))];
   const careerArcRows = useMemo(() => {
@@ -1916,7 +1960,7 @@ export default function PlayerProfile({
 
           {/* ── Per-season career log (player.careerStats + archived playerSeasonStatsV1) ── */}
           {!loading && mergedProfileSeasonRows.length > 0 && (
-            <section className="card-enter">
+            <section className="card-enter" data-testid="player-profile-season-log-browser">
               <h3
                 style={{
                   fontSize: "var(--text-sm)",
@@ -1930,13 +1974,119 @@ export default function PlayerProfile({
               >
                 Season Log
               </h3>
-              <div className="table-wrapper" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
+              <div
+                style={{
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: 8,
+                  marginBottom: 10,
+                  alignItems: "center",
+                }}
+              >
+                <input
+                  type="search"
+                  value={seasonLogQuery}
+                  onChange={(e) => setSeasonLogQuery(e.target.value)}
+                  placeholder="Search season, team…"
+                  aria-label="Search season log"
+                  style={{
+                    flex: "1 1 140px",
+                    minWidth: 0,
+                    maxWidth: "100%",
+                    padding: "6px 10px",
+                    borderRadius: 8,
+                    border: "1px solid var(--hairline)",
+                    background: "var(--surface)",
+                    color: "var(--text)",
+                    fontSize: "0.8rem",
+                  }}
+                />
+                {teamJourney.length > 1 ? (
+                  <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
+                    Team
+                    <select
+                      value={seasonLogTeamFilter}
+                      onChange={(e) => setSeasonLogTeamFilter(e.target.value)}
+                      style={{ padding: "4px 8px", borderRadius: 8, border: "1px solid var(--hairline)", background: "var(--surface)", color: "var(--text)", fontSize: "0.75rem", maxWidth: 120 }}
+                    >
+                      <option value="">All</option>
+                      {teamJourney.map((t) => (
+                        <option key={t} value={t}>{t}</option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
+                <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
+                  Sort
+                  <select
+                    value={seasonLogSortKey}
+                    onChange={(e) => setSeasonLogSortKey(e.target.value)}
+                    style={{ padding: "4px 8px", borderRadius: 8, border: "1px solid var(--hairline)", background: "var(--surface)", color: "var(--text)", fontSize: "0.75rem" }}
+                  >
+                    <option value="season">Season</option>
+                    <option value="team">Team</option>
+                    <option value="games">Games</option>
+                    <option value="keyStat">Primary stat (pos)</option>
+                  </select>
+                </label>
+                <button type="button" className="btn btn-sm" onClick={() => setSeasonLogSortDir((d) => (d === "asc" ? "desc" : "asc"))}>
+                  {seasonLogSortDir === "asc" ? "Asc ↑" : "Desc ↓"}
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-secondary btn-sm"
+                  onClick={() => {
+                    setSeasonLogQuery("");
+                    setSeasonLogTeamFilter("");
+                    setSeasonLogSortKey("season");
+                    setSeasonLogSortDir("desc");
+                  }}
+                >
+                  Reset
+                </button>
+              </div>
+              <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginBottom: 8 }}>{seasonLogShowingLabel}</div>
+              {careerTotals.gamesPlayed > 0 ? (
+                <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginBottom: 10, lineHeight: 1.4 }}>
+                  <span style={{ fontWeight: 700, color: "var(--text)" }}>Log career totals</span>
+                  {" · "}
+                  GP {careerTotals.gamesPlayed}
+                  {["QB"].includes(player.pos) ? ` · ${careerTotals.passYds.toLocaleString()} pass yd · ${careerTotals.passTDs} pass TD` : null}
+                  {["RB", "FB"].includes(player.pos) ? ` · ${careerTotals.rushYds.toLocaleString()} rush yd` : null}
+                  {["WR", "TE"].includes(player.pos) ? ` · ${careerTotals.recYds.toLocaleString()} rec yd` : null}
+                  {["DE", "DT", "LB", "CB", "S", "DL", "EDGE"].includes(player.pos) ? ` · ${careerTotals.tackles} tkl · ${careerTotals.sacks} sk` : null}
+                </div>
+              ) : null}
+              {displaySeasonLogRows.length === 0 ? (
+                <p style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--text-muted)" }}>No seasons match these filters. Reset to see the full log.</p>
+              ) : (
+                <>
+                  <div className="table-wrapper md:hidden" style={{ display: "grid", gap: 8, marginBottom: 10 }}>
+                    {displaySeasonLogRows.map((line, i) => (
+                      <div
+                        key={`card-${String(line.season)}-${line.team}-${i}`}
+                        style={{
+                          border: "1px solid var(--hairline)",
+                          borderRadius: 8,
+                          padding: "8px 10px",
+                          fontSize: "0.78rem",
+                        }}
+                      >
+                        <div style={{ fontWeight: 700, display: "flex", justifyContent: "space-between", gap: 8 }}>
+                          <span>{line.season}</span>
+                          <span style={{ color: "var(--text-muted)", fontWeight: 600 }}>{line.team}</span>
+                        </div>
+                        <div style={{ color: "var(--text-muted)", marginTop: 4 }}>GP {line.gamesPlayed ?? "—"} · OVR {line.ovr ?? "—"}</div>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="table-wrapper hidden md:block" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
                 <Table
                   className="standings-table"
                   style={{
                     width: "100%",
                     fontVariantNumeric: "tabular-nums",
-                    minWidth: 480,
+                    minWidth: 320,
                     fontSize: "0.76rem",
                   }}
                 >
@@ -1995,8 +2145,8 @@ export default function PlayerProfile({
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {[...mergedProfileSeasonRows].reverse().map((line, i) => (
-                      <TableRow key={i}>
+                    {displaySeasonLogRows.map((line, i) => (
+                      <TableRow key={`${String(line.season)}-${line.team}-${i}`}>
                         <TableCell
                           style={{
                             paddingLeft: "var(--space-4)",
@@ -2101,6 +2251,8 @@ export default function PlayerProfile({
                   </TableBody>
                 </Table>
               </div>
+                </>
+              )}
             </section>
           )}
           {!loading && mergedProfileSeasonRows.length === 0 && !isProspect && (

--- a/src/ui/components/TeamHistoryScreen.jsx
+++ b/src/ui/components/TeamHistoryScreen.jsx
@@ -3,6 +3,7 @@ import { ScreenHeader, SectionCard, EmptyState } from './ScreenSystem.jsx';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 import { buildFranchiseHistoryModel, PLAYOFF_CALIBER_WINS } from '../../core/franchiseHistoryModel.js';
 import { RECORD_BOOK_PLAYER_KEYS, RECORD_LABELS } from '../../core/recordBookV1.js';
+import { buildShowingLabel, rowMatchesSearch, stableSortRows } from '../utils/dataBrowser.js';
 
 function buildSeasonTeamMap(season) {
   const map = {};
@@ -34,8 +35,10 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
   const [hofPlayers, setHofPlayers] = useState([]);
   const [hofClasses, setHofClasses] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [queryYear, setQueryYear] = useState('');
+  const [seasonQueryText, setSeasonQueryText] = useState('');
   const [scope, setScope] = useState('all');
+  const [timelineSortKey, setTimelineSortKey] = useState('year');
+  const [timelineSortDir, setTimelineSortDir] = useState('desc');
   const [majorMoves, setMajorMoves] = useState([]);
   const [draftFlash, setDraftFlash] = useState([]);
 
@@ -146,16 +149,57 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
 
   const { summary, franchiseRecords, franchiseLegends, playoffHistory, bestGames, milestones } = model;
 
-  const filteredTimeline = useMemo(() => {
-    return (model.seasons ?? []).filter((row) => {
-      if (scope === 'champions' && !row.champion) return false;
-      if (scope === 'playoff' && !row.playoffCaliber) return false;
-      if (scope === 'losing' && !row.losingSeason) return false;
-      if (scope === 'elite' && !row.eliteSeason) return false;
-      if (!queryYear.trim()) return true;
-      return String(row.year).includes(queryYear.trim());
-    });
-  }, [model.seasons, queryYear, scope]);
+  const scopeFilteredSeasonRows = useMemo(
+    () =>
+      (model.seasons ?? []).filter((row) => {
+        if (scope === 'champions' && !row.champion) return false;
+        if (scope === 'playoff' && !row.playoffCaliber) return false;
+        if (scope === 'losing' && !row.losingSeason) return false;
+        if (scope === 'elite' && !row.eliteSeason) return false;
+        return true;
+      }),
+    [model.seasons, scope],
+  );
+
+  const searchFilteredSeasonRows = useMemo(
+    () =>
+      scopeFilteredSeasonRows.filter((row) =>
+        rowMatchesSearch(row, seasonQueryText, [
+          'year',
+          (r) => `${r.wins}-${r.losses}${r.ties ? `-${r.ties}` : ''}`,
+          (r) => (r.champion ? 'champion title ring' : ''),
+          (r) => (r.runnerUp ? 'runner-up finalist' : ''),
+          (r) => (r.truePlayoff ? 'postseason playoffs bracket' : ''),
+          (r) => (r.playoffCaliber ? 'playoff-caliber' : ''),
+          (r) => (r.eliteSeason ? 'elite' : ''),
+          (r) => (r.losingSeason ? 'losing season' : ''),
+          (r) => r.mvp?.name,
+          (r) => r.pf,
+          (r) => r.pa,
+          (r) => r.pointDifferential,
+        ]),
+      ),
+    [scopeFilteredSeasonRows, seasonQueryText],
+  );
+
+  const displaySeasonTimeline = useMemo(() => {
+    const getters = {
+      year: (r) => Number(r.year ?? 0),
+      wins: (r) => Number(r.wins ?? 0),
+      losses: (r) => Number(r.losses ?? 0),
+      pf: (r) => Number(r.pf ?? 0),
+      pa: (r) => Number(r.pa ?? 0),
+      winPct: (r) => Number(r.winPct ?? 0),
+    };
+    const get = getters[timelineSortKey] ?? getters.year;
+    return stableSortRows(searchFilteredSeasonRows, get, timelineSortDir, (r) => Number(r.year ?? 0));
+  }, [searchFilteredSeasonRows, timelineSortKey, timelineSortDir]);
+
+  const seasonTimelineShowingLabel = buildShowingLabel(
+    displaySeasonTimeline.length,
+    scopeFilteredSeasonRows.length,
+    'season',
+  );
 
   const completedGameRows = useMemo(() => {
     const rows = [];
@@ -455,59 +499,127 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
         )}
       </SectionCard>
 
-      <SectionCard title="Season-by-season timeline">
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 10 }}>
-          <input
-            value={queryYear}
-            onChange={(e) => setQueryYear(e.target.value)}
-            placeholder="Filter by year"
-            style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)', minWidth: 160 }}
+      <SectionCard title="Season-by-season timeline" subtitle="Search and sort archived franchise seasons. Counts reflect the current scope chips.">
+        {(model.seasons ?? []).length === 0 ? (
+          <EmptyState
+            title="No franchise seasons in the archive yet"
+            body="Finish and archive seasons to unlock year-by-year records, tags, and MVP links for this team."
           />
-          {[
-            { key: 'all', label: 'All-time' },
-            { key: 'playoff', label: 'Playoff-caliber' },
-            { key: 'champions', label: 'Championship years' },
-            { key: 'elite', label: 'Elite seasons' },
-            { key: 'losing', label: 'Losing seasons' },
-          ].map((opt) => (
-            <button key={opt.key} type="button" className="btn" onClick={() => setScope(opt.key)} style={{ opacity: scope === opt.key ? 1 : 0.7 }}>
-              {opt.label}
-            </button>
-          ))}
-        </div>
-        <div style={{ display: 'grid', gap: 8, maxHeight: 420, overflow: 'auto' }}>
-          {filteredTimeline.length === 0 ? (
-            <EmptyState title="No team history for this filter" body="Adjust filters or archive more seasons." />
-          ) : (
-            filteredTimeline.slice().reverse().map((s) => (
-              <div key={s.year} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: 10 }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
-                  <strong>{s.year}</strong>
-                  <span>
-                    {s.wins}-{s.losses}
-                    {s.ties ? `-${s.ties}` : ''}
-                    {s.champion ? ' · Champion' : ''}
-                    {s.runnerUp ? ' · Runner-up' : ''}
-                  </span>
-                </div>
-                <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
-                  PF {s.pf} · PA {s.pa}
-                  {s.truePlayoff ? ' · Postseason (documented)' : s.playoffCaliber ? ' · Playoff-caliber' : ''}
-                </div>
-                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 4 }}>
-                  {s.champion ? <span style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 8px' }}>Title season</span> : null}
-                  {s.eliteSeason ? <span style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 8px' }}>Elite year</span> : null}
-                  {s.losingSeason ? <span style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 8px' }}>Losing season</span> : null}
-                </div>
-                {s.mvp?.playerId != null ? (
-                  <button type="button" className="btn-link" onClick={() => onPlayerSelect?.(s.mvp.playerId)}>
-                    League MVP: {s.mvp.name}
-                  </button>
-                ) : null}
-              </div>
-            ))
-          )}
-        </div>
+        ) : (
+          <div data-testid="team-history-season-timeline">
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 10, alignItems: 'center' }}>
+              <input
+                value={seasonQueryText}
+                onChange={(e) => setSeasonQueryText(e.target.value)}
+                placeholder="Search year, record, MVP, PF/PA…"
+                aria-label="Search franchise seasons"
+                style={{
+                  background: 'var(--surface)',
+                  border: '1px solid var(--hairline)',
+                  borderRadius: 8,
+                  padding: '6px 10px',
+                  color: 'var(--text)',
+                  minWidth: 0,
+                  flex: '1 1 160px',
+                  maxWidth: '100%',
+                }}
+              />
+              <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 'var(--text-xs)', color: 'var(--text-muted)', flexWrap: 'wrap' }}>
+                <span>Sort</span>
+                <select
+                  value={timelineSortKey}
+                  onChange={(e) => setTimelineSortKey(e.target.value)}
+                  style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '4px 8px', color: 'var(--text)' }}
+                >
+                  <option value="year">Year</option>
+                  <option value="wins">Wins</option>
+                  <option value="losses">Losses</option>
+                  <option value="pf">Points for</option>
+                  <option value="pa">Points allowed</option>
+                  <option value="winPct">Win %</option>
+                </select>
+                <button
+                  type="button"
+                  className="btn btn-sm"
+                  onClick={() => setTimelineSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))}
+                  aria-label={`Sort direction ${timelineSortDir === 'asc' ? 'ascending' : 'descending'}`}
+                >
+                  {timelineSortDir === 'asc' ? 'Asc ↑' : 'Desc ↓'}
+                </button>
+              </label>
+              <button
+                type="button"
+                className="btn btn-secondary btn-sm"
+                onClick={() => {
+                  setSeasonQueryText('');
+                  setScope('all');
+                  setTimelineSortKey('year');
+                  setTimelineSortDir('desc');
+                }}
+              >
+                Reset filters
+              </button>
+            </div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 10 }}>
+              {[
+                { key: 'all', label: 'All-time' },
+                { key: 'playoff', label: 'Playoff-caliber' },
+                { key: 'champions', label: 'Championship years' },
+                { key: 'elite', label: 'Elite seasons' },
+                { key: 'losing', label: 'Losing seasons' },
+              ].map((opt) => (
+                <button key={opt.key} type="button" className="btn" onClick={() => setScope(opt.key)} style={{ opacity: scope === opt.key ? 1 : 0.7 }}>
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+            <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', marginBottom: 8 }}>{seasonTimelineShowingLabel}</div>
+            <div style={{ display: 'grid', gap: 6, maxHeight: 420, overflow: 'auto' }}>
+              {displaySeasonTimeline.length === 0 ? (
+                <EmptyState
+                  title="No seasons match these filters"
+                  body="Clear search text, reset filters, or pick a different scope to see the full franchise timeline."
+                />
+              ) : (
+                displaySeasonTimeline.map((s) => (
+                  <div
+                    key={String(s.seasonId ?? `year-${s.year}`)}
+                    style={{
+                      border: '1px solid var(--hairline)',
+                      borderRadius: 8,
+                      padding: 'clamp(6px, 2vw, 10px)',
+                      fontSize: 'clamp(0.72rem, 2.8vw, var(--text-sm))',
+                    }}
+                  >
+                    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>
+                      <strong>{s.year}</strong>
+                      <span>
+                        {s.wins}-{s.losses}
+                        {s.ties ? `-${s.ties}` : ''}
+                        {s.champion ? ' · Champion' : ''}
+                        {s.runnerUp ? ' · Runner-up' : ''}
+                      </span>
+                    </div>
+                    <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+                      PF {s.pf} · PA {s.pa}
+                      {s.truePlayoff ? ' · Postseason (documented)' : s.playoffCaliber ? ' · Playoff-caliber' : ''}
+                    </div>
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 4 }}>
+                      {s.champion ? <span style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 8px' }}>Title season</span> : null}
+                      {s.eliteSeason ? <span style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 8px' }}>Elite year</span> : null}
+                      {s.losingSeason ? <span style={{ fontSize: 11, border: '1px solid var(--hairline)', borderRadius: 999, padding: '1px 8px' }}>Losing season</span> : null}
+                    </div>
+                    {s.mvp?.playerId != null ? (
+                      <button type="button" className="btn-link" onClick={() => onPlayerSelect?.(s.mvp.playerId)}>
+                        League MVP: {s.mvp.name}
+                      </button>
+                    ) : null}
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        )}
       </SectionCard>
 
       <SectionCard title="Completed game history">

--- a/src/ui/components/__tests__/LeagueHistory.test.jsx
+++ b/src/ui/components/__tests__/LeagueHistory.test.jsx
@@ -1,10 +1,13 @@
 /** @vitest-environment jsdom */
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
 import LeagueHistory from '../LeagueHistory.jsx';
 
 describe('LeagueHistory', () => {
+  afterEach(() => {
+    cleanup();
+  });
   it('opens the selected archived season and handles missing championship data safely', async () => {
     render(
       <LeagueHistory
@@ -157,6 +160,44 @@ describe('LeagueHistory', () => {
       expect(screen.getByTestId('league-history-top-performers-s9')).toBeTruthy();
       expect(screen.getByTestId('league-history-top-performers-s9').textContent).toMatch(/Air/);
       expect(screen.getByTestId('league-history-top-performers-s9').textContent).toMatch(/4,?800/);
+    });
+  });
+
+  it('filters season archive sidebar and restores full list when cleared', async () => {
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        initialSelectedSeasonId="s1"
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                { id: 's1', year: 2030, champion: { abbr: 'DAL' }, standings: [], awards: {} },
+                { id: 's2', year: 2031, champion: { abbr: 'NYG' }, standings: [], awards: {} },
+              ],
+            },
+          }),
+          getRecords: vi.fn().mockResolvedValue({ payload: { records: null } }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('league-history-season-archive-browser')).toBeTruthy();
+    });
+    const archiveBrowser = screen.getByTestId('league-history-season-archive-browser');
+    fireEvent.change(archiveBrowser.querySelector('input[type="search"]'), { target: { value: '2031' } });
+    await waitFor(() => {
+      expect(archiveBrowser.textContent).toMatch(/Showing 1 of 2 seasons/);
+    });
+
+    fireEvent.change(archiveBrowser.querySelector('input[type="search"]'), { target: { value: '' } });
+    await waitFor(() => {
+      expect(archiveBrowser.textContent).toMatch(/Showing 2 of 2 seasons/);
     });
   });
 

--- a/src/ui/components/__tests__/TeamHistoryScreen.test.jsx
+++ b/src/ui/components/__tests__/TeamHistoryScreen.test.jsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, cleanup, within } from '@testing-library/react';
 import TeamHistoryScreen from '../TeamHistoryScreen.jsx';
 
 describe('TeamHistoryScreen', () => {
@@ -57,6 +57,73 @@ describe('TeamHistoryScreen', () => {
     );
     await waitFor(() => {
       expect(screen.getByText('Playoff appearances')).toBeTruthy();
+    });
+  });
+
+  it('filters and sorts season timeline with stable search and showing label', async () => {
+    render(
+      <TeamHistoryScreen
+        league={{ teams: [{ id: 7, name: 'Seattle', abbr: 'SEA' }], userTeamId: 7 }}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                {
+                  year: 2030,
+                  id: 's1',
+                  standings: [{ id: 7, abbr: 'SEA', wins: 8, losses: 9, ties: 0, pf: 300, pa: 310 }],
+                  awards: { mvp: { playerId: 1, name: 'Alex Peak' } },
+                  playoffBracketSnapshot: { mode: 'empty', rounds: [] },
+                },
+                {
+                  year: 2032,
+                  id: 's2',
+                  standings: [{ id: 7, abbr: 'SEA', wins: 12, losses: 5, ties: 0, pf: 410, pa: 300 }],
+                  champion: { id: 7, abbr: 'SEA' },
+                  awards: {},
+                  playoffBracketSnapshot: { mode: 'empty', rounds: [] },
+                },
+              ],
+            },
+          }),
+          getHallOfFame: vi.fn().mockResolvedValue({ payload: { players: [], classes: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+          getDraftClasses: vi.fn().mockResolvedValue({ payload: { classes: [] } }),
+          getDraftClass: vi.fn().mockResolvedValue({ payload: { model: null } }),
+        }}
+        onBack={vi.fn()}
+        onPlayerSelect={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-season-timeline')).toBeTruthy();
+    });
+    const timeline = screen.getByTestId('team-history-season-timeline');
+    expect(screen.getByText(/Showing 2 of 2 seasons/i)).toBeTruthy();
+
+    const search = screen.getByLabelText(/Search franchise seasons/i);
+    fireEvent.change(search, { target: { value: 'alex' } });
+    await waitFor(() => {
+      expect(screen.getByText(/Showing 1 of 2 seasons/i)).toBeTruthy();
+    });
+    const gridAfterSearch = timeline.querySelector('[style*="display: grid"]');
+    expect(gridAfterSearch).toBeTruthy();
+    expect(within(gridAfterSearch).getByText('2030')).toBeTruthy();
+    expect(within(gridAfterSearch).queryByText('2032')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /Reset filters/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/Showing 2 of 2 seasons/i)).toBeTruthy();
+    });
+
+    const sortSelect = timeline.querySelector('select');
+    expect(sortSelect).toBeTruthy();
+    fireEvent.change(sortSelect, { target: { value: 'wins' } });
+    fireEvent.click(screen.getByRole('button', { name: /Sort direction/i }));
+    await waitFor(() => {
+      const grid = timeline.querySelector('[style*="display: grid"]');
+      const blob = grid?.textContent ?? '';
+      expect(blob.indexOf('8-9')).toBeLessThan(blob.indexOf('12-5'));
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Dynasty-history browsing improvements on **four UI areas** using `normalizeSearchText` / `rowMatchesSearch` / `stableSortRows` / `uniqueFilterOptions` / `buildShowingLabel` from `src/ui/utils/dataBrowser.js`. No simulation, economy, persistence, or archive schema changes.

## Screens improved
1. **Team History** — Season-by-season timeline: search (year, record, champion/runner-up/postseason tags, MVP, PF/PA/diff); sort (year, wins, losses, PF, PA, win %); **Showing X of Y seasons** (Y = rows after scope chips); reset; compact responsive rows; empty state when there are zero archived franchise seasons.
2. **League History → Season Archive** — Sidebar search (year, season id, champion/runner-up text); champion filter including **No champion in archive**; year order toggle + reset; **Showing X of Y**; champion preview uses **—** when absent (no “TBD” champion label). `data-testid` moved to the seasons `TabsContent` wrapper.
3. **League History → League Office** — Transaction search (players, teams, types, headlines, `seasonId`, narrative blurbs); type filter; newest/oldest (season ordinal + week + id); **Showing X of Y moves** with cap note; reset; filtered-empty message.
4. **Player Profile → Season Log** — Search / team filter / sort (season, team, games, position-aware primary stat); **Showing X of Y**; reset; **log career totals** line from existing `careerTotals`; filtered-empty message; **mobile card stack** plus tighter table on `md+`.

## Fallback / missing data
- No franchise seasons: timeline `EmptyState` instead of filter chrome only.
- Filters match nothing: explicit copy; reset restores full lists.
- No merged season rows: unchanged empty/messaging; no invented stat lines.

## Mobile UX
- Team timeline: flexible toolbar + `clamp` typography/padding.
- Player log: `md:hidden` cards with season/team/GP/OVR; table from `md` up.

## Validation (this branch)
| Command | Result |
|--------|--------|
| `npm ci` | OK |
| `node --check src/ui/utils/dataBrowser.js` | OK |
| `npm run test:unit` | **842** tests passed |
| `npm run test:soak` | **40** tests passed |
| `npm run audit:dynasty -- --ci --seed=1383` | **passed**, ~**7286 ms**, 0 failures, 1 CI warning (`hof_empty_young`) |
| `npm run build` | OK |
| `npm run check:deploy` | OK |
| `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` | **1** passed |

## Deferred
- Awards & Records / HOF / Draft redraft browsers (separate scope).
- Full Playwright matrix (smoke only here).
- jsdom integration test for Radix League Office tab activation (panel focus); office UI shipped and covered by unit tests on archive + manual smoke.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e76d3fa8-383d-4cce-9d8e-1aca99a1c170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e76d3fa8-383d-4cce-9d8e-1aca99a1c170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

