### PR TITLE
feat: Team + Player History Data Density V2 – search/sort/filter on 4 history screens

### DIFF
--- a/src/ui/components/LeagueActivityLog.jsx
+++ b/src/ui/components/LeagueActivityLog.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { buildShowingLabel } from "../utils/dataBrowser.js";
 
 const TYPE_FILTERS = [
   { value: "all", label: "All types" },
@@ -134,6 +135,14 @@ export default function LeagueActivityLog({ league, actions, onPlayerSelect, onT
         <button type="button" className="btn btn-secondary h-9 text-sm" onClick={() => load()}>
           Refresh
         </button>
+        <button
+          type="button"
+          className="btn btn-secondary h-9 text-sm"
+          onClick={() => { setSeasonId("all"); setTeamId("all"); setType("all"); setSearch(""); }}
+          data-testid="league-activity-reset"
+        >
+          Reset
+        </button>
       </div>
 
       {loading ? (
@@ -143,6 +152,13 @@ export default function LeagueActivityLog({ league, actions, onPlayerSelect, onT
           Transactions will appear as your league signs, drafts, trades, releases, and retires players.
         </div>
       ) : (
+        <>
+          <div
+            className="text-xs text-[color:var(--text-muted)] px-1"
+            data-testid="league-activity-showing"
+          >
+            {buildShowingLabel(rows.length, rows.length, "transaction")}
+          </div>
         <ScrollArea className="h-[min(520px,65vh)] rounded-lg border border-[color:var(--hairline)]">
           <ul className="divide-y divide-[color:var(--hairline)]">
             {rows.map((tx, idx) => (
@@ -182,6 +198,7 @@ export default function LeagueActivityLog({ league, actions, onPlayerSelect, onT
             ))}
           </ul>
         </ScrollArea>
+        </>
       )}
     </div>
   );

--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -8,6 +8,7 @@ import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/b
 import { AWARD_DISPLAY_NAMES } from '../../core/footballMeta';
 import { buildLeagueHistoryTopPerformers } from '../../core/playerSeasonStatsArchive.js';
 import { normalizeArchivedMajorTransactions } from '../../core/transactionTimeline.js';
+import { rowMatchesSearch, buildShowingLabel } from "../utils/dataBrowser.js";
 
 const RECORD_LABELS = {
   passYd: "Passing Yards",
@@ -176,7 +177,7 @@ export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenB
           <RecordsExplorer records={records} recordBook={recordBook} seasons={seasons} onPlayerSelect={onPlayerSelect} />
         </TabsContent>
 
-        <TabsContent value="awards">
+        <TabsContent value="awards" forceMount style={activeTab !== "awards" ? { display: "none" } : undefined}>
           <AwardsHistory seasons={seasons} onPlayerSelect={onPlayerSelect} />
         </TabsContent>
 
@@ -342,6 +343,18 @@ function SeasonDraftClassSnippet({ seasonId, year, actions, onPlayerSelect }) {
 
 function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, league, initialSelectedSeasonId = null }) {
   const [selectedSeasonId, setSelectedSeasonId] = useState(initialSelectedSeasonId ?? seasons?.[0]?.id ?? null);
+  const [seasonListSearch, setSeasonListSearch] = useState("");
+
+  const filteredSeasonList = useMemo(() => {
+    if (!seasonListSearch.trim()) return seasons ?? [];
+    return (seasons ?? []).filter((s) =>
+      rowMatchesSearch(s, seasonListSearch, [
+        (row) => String(row?.year ?? ""),
+        (row) => row?.champion?.abbr,
+        (row) => row?.champion?.name,
+      ])
+    );
+  }, [seasons, seasonListSearch]);
 
   useEffect(() => {
     if (!seasons?.length) return;
@@ -402,18 +415,39 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
       <Card className="card-premium">
         <CardHeader><CardTitle>Season Archive</CardTitle></CardHeader>
         <CardContent className="p-0">
-          <ScrollArea className="h-[520px]">
+          <div className="px-3 py-2 border-b border-[color:var(--hairline)]">
+            <input
+              type="search"
+              value={seasonListSearch}
+              onChange={(e) => setSeasonListSearch(e.target.value)}
+              placeholder="Search year or champion…"
+              aria-label="Search seasons"
+              className="h-8 w-full rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-xs"
+              data-testid="league-history-season-search"
+            />
+            <div
+              className="mt-1 text-[10px] text-[color:var(--text-muted)]"
+              data-testid="league-history-season-showing"
+            >
+              {buildShowingLabel(filteredSeasonList.length, (seasons ?? []).length, "season")}
+            </div>
+          </div>
+          <ScrollArea className="h-[460px]">
             <div className="divide-y divide-[color:var(--hairline)]">
-              {seasons.map((s) => (
-                <button
-                  key={s.id}
-                  className={`w-full text-left px-4 py-3 ${selected?.id === s.id ? "bg-[color:var(--surface-strong)]" : ""}`}
-                  onClick={() => setSelectedSeasonId(s.id)}
-                >
-                  <div className="font-bold text-sm">{s.year}</div>
-                  <div className="text-xs text-[color:var(--text-muted)]">{s.champion?.abbr ?? "TBD"} champion</div>
-                </button>
-              ))}
+              {filteredSeasonList.length === 0 ? (
+                <div className="px-4 py-4 text-xs text-[color:var(--text-muted)]">No seasons match your search.</div>
+              ) : (
+                filteredSeasonList.map((s) => (
+                  <button
+                    key={s.id}
+                    className={`w-full text-left px-4 py-3 ${selected?.id === s.id ? "bg-[color:var(--surface-strong)]" : ""}`}
+                    onClick={() => setSelectedSeasonId(s.id)}
+                  >
+                    <div className="font-bold text-sm">{s.year}</div>
+                    <div className="text-xs text-[color:var(--text-muted)]">{s.champion?.abbr ?? "TBD"} champion</div>
+                  </button>
+                ))
+              )}
             </div>
           </ScrollArea>
         </CardContent>
@@ -800,13 +834,59 @@ function RecordsExplorer({ records, recordBook, seasons, onPlayerSelect }) {
 }
 
 function AwardsHistory({ seasons, onPlayerSelect }) {
+  const [awardsSearch, setAwardsSearch] = useState("");
+
+  const filteredAwardSeasons = useMemo(() => {
+    if (!awardsSearch.trim()) return seasons ?? [];
+    return (seasons ?? []).filter((s) =>
+      rowMatchesSearch(s, awardsSearch, [
+        (row) => String(row?.year ?? ""),
+        (row) => row?.champion?.abbr,
+        (row) => row?.champion?.name,
+        (row) => row?.awards?.mvp?.name,
+        (row) => row?.awards?.opoy?.name,
+        (row) => row?.awards?.dpoy?.name,
+        (row) => row?.awards?.roty?.name,
+      ])
+    );
+  }, [seasons, awardsSearch]);
+
   if (!seasons?.length) return <div className="py-8 text-center text-[color:var(--text-muted)]">No award history yet.</div>;
 
   return (
     <Card className="card-premium">
-      <CardHeader><CardTitle>Awards by Season</CardTitle></CardHeader>
+      <CardHeader>
+        <CardTitle>Awards by Season</CardTitle>
+      </CardHeader>
       <CardContent className="p-0">
-        <ScrollArea className="h-[560px]">
+        <div className="flex flex-wrap items-center gap-2 px-4 py-2 border-b border-[color:var(--hairline)]">
+          <input
+            type="search"
+            value={awardsSearch}
+            onChange={(e) => setAwardsSearch(e.target.value)}
+            placeholder="Search year, champion, or winner…"
+            aria-label="Search awards"
+            className="h-8 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-xs flex-1 min-w-[160px]"
+            data-testid="league-history-awards-search"
+          />
+          {awardsSearch ? (
+            <button
+              type="button"
+              className="btn text-xs px-2 py-1"
+              onClick={() => setAwardsSearch("")}
+              data-testid="league-history-awards-reset"
+            >
+              Clear
+            </button>
+          ) : null}
+          <span
+            className="text-[10px] text-[color:var(--text-muted)]"
+            data-testid="league-history-awards-showing"
+          >
+            {buildShowingLabel(filteredAwardSeasons.length, (seasons ?? []).length, "season")}
+          </span>
+        </div>
+        <ScrollArea className="h-[520px]">
           <Table>
             <TableHeader>
               <TableRow>
@@ -819,16 +899,22 @@ function AwardsHistory({ seasons, onPlayerSelect }) {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {seasons.map((s) => (
-                <TableRow key={s.id}>
-                  <TableCell className="pl-5 font-bold">{s.year}</TableCell>
-                  <TableCell>{s.champion?.abbr ?? "—"}</TableCell>
-                  <TableCell><AwardCell award={s.awards?.mvp} onPlayerSelect={onPlayerSelect} /></TableCell>
-                  <TableCell><AwardCell award={s.awards?.opoy} onPlayerSelect={onPlayerSelect} /></TableCell>
-                  <TableCell><AwardCell award={s.awards?.dpoy} onPlayerSelect={onPlayerSelect} /></TableCell>
-                  <TableCell><AwardCell award={s.awards?.roty} onPlayerSelect={onPlayerSelect} /></TableCell>
+              {filteredAwardSeasons.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="py-6 text-center text-xs text-[color:var(--text-muted)]">No seasons match your search.</TableCell>
                 </TableRow>
-              ))}
+              ) : (
+                filteredAwardSeasons.map((s) => (
+                  <TableRow key={s.id}>
+                    <TableCell className="pl-5 font-bold">{s.year}</TableCell>
+                    <TableCell>{s.champion?.abbr ?? "—"}</TableCell>
+                    <TableCell><AwardCell award={s.awards?.mvp} onPlayerSelect={onPlayerSelect} /></TableCell>
+                    <TableCell><AwardCell award={s.awards?.opoy} onPlayerSelect={onPlayerSelect} /></TableCell>
+                    <TableCell><AwardCell award={s.awards?.dpoy} onPlayerSelect={onPlayerSelect} /></TableCell>
+                    <TableCell><AwardCell award={s.awards?.roty} onPlayerSelect={onPlayerSelect} /></TableCell>
+                  </TableRow>
+                ))
+              )}
             </TableBody>
           </Table>
         </ScrollArea>

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -28,6 +28,7 @@ import { ToneChip, DevelopmentSignalRow, DevelopmentStatCard } from './PlayerDev
 import EmptyState from './EmptyState.jsx';
 import { buildRouteRequestKey, buildLeagueCacheScopeKey } from "../utils/requestLoopGuard.js";
 import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
+import { stableSortRows, buildShowingLabel } from "../utils/dataBrowser.js";
 import { getPlayerGameLogs } from "../utils/playerGameLogs.js";
 import { buildMergedPlayerAwardTimeline, buildPlayerAwardHeaderBadges } from "../../core/playerAwardTimeline.js";
 import { buildPlayerRecordContext, mergePlayerProfileSeasonRows } from "../../core/recordBookV1.js";
@@ -419,6 +420,8 @@ export default function PlayerProfile({
   const [extending, setExtending] = useState(false);
   const [showProjections, setShowProjections] = useState(false);
   const [activeProfileTab, setActiveProfileTab] = useState("Overview");
+  const [seasonLogSortField, setSeasonLogSortField] = useState('season');
+  const [seasonLogSortDir, setSeasonLogSortDir] = useState('desc');
   const [draftContext, setDraftContext] = useState(null);
   const requestKey = useMemo(() => buildRouteRequestKey("player", playerId), [playerId]);
   const cacheScopeKey = useMemo(() => buildLeagueCacheScopeKey(league), [league]);
@@ -718,6 +721,23 @@ export default function PlayerProfile({
   }), [devHistory]);
 
   const careerRows = useMemo(() => mergedProfileSeasonRows, [mergedProfileSeasonRows]);
+
+  const sortedSeasonLogRows = useMemo(() => {
+    const getVal = (row) => {
+      if (seasonLogSortField === 'ovr') return row.ovr ?? 0;
+      if (seasonLogSortField === 'gamesPlayed') return row.gamesPlayed ?? 0;
+      if (seasonLogSortField === 'primaryStat') {
+        const pos = String(effectivePlayer?.pos ?? '').toUpperCase();
+        if (['QB'].includes(pos)) return row.passYds ?? 0;
+        if (['RB', 'FB'].includes(pos)) return row.rushYds ?? 0;
+        if (['WR', 'TE'].includes(pos)) return row.recYds ?? 0;
+        if (['DE', 'DT', 'LB', 'CB', 'S', 'DL', 'EDGE'].includes(pos)) return row.tackles ?? 0;
+        return row.gamesPlayed ?? 0;
+      }
+      return row.season ?? '';
+    };
+    return stableSortRows(mergedProfileSeasonRows, getVal, seasonLogSortDir);
+  }, [mergedProfileSeasonRows, seasonLogSortField, seasonLogSortDir, effectivePlayer?.pos]);
   const careerTotals = useMemo(() => {
     const posU = String(effectivePlayer?.pos ?? effectivePlayer?.position ?? '').toUpperCase();
     const defSkill = ['DE', 'DT', 'LB', 'CB', 'S', 'DL', 'EDGE'].includes(posU);
@@ -1916,20 +1936,54 @@ export default function PlayerProfile({
 
           {/* ── Per-season career log (player.careerStats + archived playerSeasonStatsV1) ── */}
           {!loading && mergedProfileSeasonRows.length > 0 && (
-            <section className="card-enter">
-              <h3
-                style={{
-                  fontSize: "var(--text-sm)",
-                  fontWeight: 700,
-                  marginBottom: "var(--space-2)",
-                  marginTop: 0,
-                  color: "var(--text-muted)",
-                  textTransform: "uppercase",
-                  letterSpacing: ".07em",
-                }}
-              >
-                Season Log
-              </h3>
+            <section className="card-enter" data-testid="player-profile-season-log">
+              <div style={{ display: "flex", flexWrap: "wrap", alignItems: "center", justifyContent: "space-between", gap: 8, marginBottom: "var(--space-2)" }}>
+                <h3
+                  style={{
+                    fontSize: "var(--text-sm)",
+                    fontWeight: 700,
+                    margin: 0,
+                    color: "var(--text-muted)",
+                    textTransform: "uppercase",
+                    letterSpacing: ".07em",
+                  }}
+                >
+                  Season Log
+                </h3>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: 4, alignItems: "center" }}>
+                  <span style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>Sort:</span>
+                  {[
+                    { key: "season", label: "Year" },
+                    { key: "gamesPlayed", label: "GP" },
+                    { key: "primaryStat", label: "Key Stat" },
+                    { key: "ovr", label: "OVR" },
+                  ].map((opt) => (
+                    <button
+                      key={opt.key}
+                      type="button"
+                      className="btn"
+                      onClick={() => {
+                        if (seasonLogSortField === opt.key) {
+                          setSeasonLogSortDir((d) => d === "asc" ? "desc" : "asc");
+                        } else {
+                          setSeasonLogSortField(opt.key);
+                          setSeasonLogSortDir("desc");
+                        }
+                      }}
+                      style={{ fontSize: "0.68rem", padding: "2px 7px", fontWeight: seasonLogSortField === opt.key ? 700 : 400, opacity: seasonLogSortField === opt.key ? 1 : 0.6 }}
+                      aria-pressed={seasonLogSortField === opt.key}
+                    >
+                      {opt.label}{seasonLogSortField === opt.key ? (seasonLogSortDir === "desc" ? " ▼" : " ▲") : ""}
+                    </button>
+                  ))}
+                  <span
+                    style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginLeft: 4 }}
+                    data-testid="season-log-showing-label"
+                  >
+                    {buildShowingLabel(sortedSeasonLogRows.length, mergedProfileSeasonRows.length, "season")}
+                  </span>
+                </div>
+              </div>
               <div className="table-wrapper" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
                 <Table
                   className="standings-table"
@@ -1995,7 +2049,7 @@ export default function PlayerProfile({
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {[...mergedProfileSeasonRows].reverse().map((line, i) => (
+                    {sortedSeasonLogRows.map((line, i) => (
                       <TableRow key={i}>
                         <TableCell
                           style={{

--- a/src/ui/components/TeamHistoryScreen.jsx
+++ b/src/ui/components/TeamHistoryScreen.jsx
@@ -3,6 +3,7 @@ import { ScreenHeader, SectionCard, EmptyState } from './ScreenSystem.jsx';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 import { buildFranchiseHistoryModel, PLAYOFF_CALIBER_WINS } from '../../core/franchiseHistoryModel.js';
 import { RECORD_BOOK_PLAYER_KEYS, RECORD_LABELS } from '../../core/recordBookV1.js';
+import { stableSortRows, buildShowingLabel } from '../utils/dataBrowser.js';
 
 function buildSeasonTeamMap(season) {
   const map = {};
@@ -36,6 +37,8 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
   const [loading, setLoading] = useState(true);
   const [queryYear, setQueryYear] = useState('');
   const [scope, setScope] = useState('all');
+  const [sortField, setSortField] = useState('year');
+  const [sortDir, setSortDir] = useState('desc');
   const [majorMoves, setMajorMoves] = useState([]);
   const [draftFlash, setDraftFlash] = useState([]);
 
@@ -147,7 +150,7 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
   const { summary, franchiseRecords, franchiseLegends, playoffHistory, bestGames, milestones } = model;
 
   const filteredTimeline = useMemo(() => {
-    return (model.seasons ?? []).filter((row) => {
+    const filtered = (model.seasons ?? []).filter((row) => {
       if (scope === 'champions' && !row.champion) return false;
       if (scope === 'playoff' && !row.playoffCaliber) return false;
       if (scope === 'losing' && !row.losingSeason) return false;
@@ -155,7 +158,8 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
       if (!queryYear.trim()) return true;
       return String(row.year).includes(queryYear.trim());
     });
-  }, [model.seasons, queryYear, scope]);
+    return stableSortRows(filtered, (r) => r[sortField] ?? r.year, sortDir);
+  }, [model.seasons, queryYear, scope, sortField, sortDir]);
 
   const completedGameRows = useMemo(() => {
     const rows = [];
@@ -456,12 +460,13 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
       </SectionCard>
 
       <SectionCard title="Season-by-season timeline">
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 10 }}>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 8 }}>
           <input
             value={queryYear}
             onChange={(e) => setQueryYear(e.target.value)}
             placeholder="Filter by year"
-            style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)', minWidth: 160 }}
+            aria-label="Filter by year"
+            style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)', minWidth: 130 }}
           />
           {[
             { key: 'all', label: 'All-time' },
@@ -475,11 +480,52 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
             </button>
           ))}
         </div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 10, alignItems: 'center' }}>
+          <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', fontWeight: 600, marginRight: 2 }}>Sort:</span>
+          {[
+            { key: 'year', label: 'Year' },
+            { key: 'wins', label: 'Wins' },
+            { key: 'losses', label: 'Losses' },
+          ].map((opt) => (
+            <button
+              key={opt.key}
+              type="button"
+              className="btn"
+              onClick={() => {
+                if (sortField === opt.key) {
+                  setSortDir((d) => d === 'asc' ? 'desc' : 'asc');
+                } else {
+                  setSortField(opt.key);
+                  setSortDir(opt.key === 'year' ? 'desc' : 'desc');
+                }
+              }}
+              style={{ fontSize: 'var(--text-xs)', opacity: sortField === opt.key ? 1 : 0.6, fontWeight: sortField === opt.key ? 700 : 400 }}
+              aria-pressed={sortField === opt.key}
+            >
+              {opt.label}{sortField === opt.key ? (sortDir === 'desc' ? ' ▼' : ' ▲') : ''}
+            </button>
+          ))}
+          <button
+            type="button"
+            className="btn btn-secondary"
+            onClick={() => { setQueryYear(''); setScope('all'); setSortField('year'); setSortDir('desc'); }}
+            style={{ fontSize: 'var(--text-xs)', marginLeft: 4 }}
+            data-testid="team-history-reset-filters"
+          >
+            Reset
+          </button>
+          <span
+            style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', marginLeft: 4 }}
+            data-testid="team-history-showing-label"
+          >
+            {buildShowingLabel(filteredTimeline.length, (model.seasons ?? []).length, 'season')}
+          </span>
+        </div>
         <div style={{ display: 'grid', gap: 8, maxHeight: 420, overflow: 'auto' }}>
           {filteredTimeline.length === 0 ? (
             <EmptyState title="No team history for this filter" body="Adjust filters or archive more seasons." />
           ) : (
-            filteredTimeline.slice().reverse().map((s) => (
+            filteredTimeline.map((s) => (
               <div key={s.year} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: 10 }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
                   <strong>{s.year}</strong>

--- a/src/ui/components/__tests__/LeagueActivityLog.test.jsx
+++ b/src/ui/components/__tests__/LeagueActivityLog.test.jsx
@@ -1,0 +1,82 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
+import LeagueActivityLog from '../LeagueActivityLog.jsx';
+
+const makeTx = (id, type, playerName, teamAbbr, week) => ({
+  id,
+  type,
+  typeLabel: type.charAt(0).toUpperCase() + type.slice(1),
+  headline: `${teamAbbr} ${type} ${playerName}`,
+  playerName,
+  playerId: id,
+  teamAbbr,
+  teamId: 1,
+  week,
+});
+
+describe('LeagueActivityLog', () => {
+  afterEach(() => cleanup());
+
+  it('renders empty state when no transactions exist', async () => {
+    render(
+      <LeagueActivityLog
+        league={{ teams: [] }}
+        actions={{ getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }) }}
+        onPlayerSelect={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/Transactions will appear as your league/i)).toBeTruthy();
+    });
+  });
+
+  it('shows showing count when transactions are loaded', async () => {
+    const txs = [
+      makeTx(1, 'signing', 'Alpha Jones', 'DAL', 1),
+      makeTx(2, 'trade', 'Beta Smith', 'NYG', 2),
+      makeTx(3, 'release', 'Gamma Lee', 'DAL', 3),
+    ];
+    render(
+      <LeagueActivityLog
+        league={{ teams: [{ id: 1, abbr: 'DAL', name: 'Dallas' }] }}
+        actions={{ getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: txs } }) }}
+        onPlayerSelect={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('league-activity-showing').textContent).toMatch(/Showing 3 of 3 transactions/i);
+    });
+  });
+
+  it('reset button clears all filter selections', async () => {
+    const txs = [makeTx(1, 'signing', 'Alpha Jones', 'DAL', 1)];
+    render(
+      <LeagueActivityLog
+        league={{ teams: [{ id: 1, abbr: 'DAL', name: 'Dallas' }] }}
+        actions={{ getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: txs } }) }}
+        onPlayerSelect={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('league-activity-reset')).toBeTruthy());
+    const resetBtn = screen.getByTestId('league-activity-reset');
+    fireEvent.click(resetBtn);
+    await waitFor(() => {
+      expect(screen.getByTestId('league-activity-showing')).toBeTruthy();
+    });
+  });
+
+  it('renders safe with no actions.getTransactions', async () => {
+    render(
+      <LeagueActivityLog
+        league={{ teams: [] }}
+        actions={{}}
+        onPlayerSelect={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/Transactions will appear/i)).toBeTruthy();
+    });
+  });
+});

--- a/src/ui/components/__tests__/LeagueHistory.test.jsx
+++ b/src/ui/components/__tests__/LeagueHistory.test.jsx
@@ -1,10 +1,11 @@
 /** @vitest-environment jsdom */
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
 import LeagueHistory from '../LeagueHistory.jsx';
 
 describe('LeagueHistory', () => {
+  afterEach(() => cleanup());
   it('opens the selected archived season and handles missing championship data safely', async () => {
     render(
       <LeagueHistory
@@ -157,6 +158,77 @@ describe('LeagueHistory', () => {
       expect(screen.getByTestId('league-history-top-performers-s9')).toBeTruthy();
       expect(screen.getByTestId('league-history-top-performers-s9').textContent).toMatch(/Air/);
       expect(screen.getByTestId('league-history-top-performers-s9').textContent).toMatch(/4,?800/);
+    });
+  });
+
+  it('season search filters the season list and updates showing count', async () => {
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                { id: 's1', year: 2030, champion: { abbr: 'DAL', name: 'Dallas' }, standings: [], awards: {} },
+                { id: 's2', year: 2031, champion: { abbr: 'NYG', name: 'Giants' }, standings: [], awards: {} },
+                { id: 's3', year: 2032, champion: { abbr: 'DAL', name: 'Dallas' }, standings: [], awards: {} },
+              ],
+            },
+          }),
+          getRecords: vi.fn().mockResolvedValue({ payload: { records: null } }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('league-history-season-search')).toBeTruthy();
+    });
+    const showingEl = screen.getByTestId('league-history-season-showing');
+    expect(showingEl.textContent).toMatch(/Showing 3 of 3/i);
+
+    const searchInput = screen.getByTestId('league-history-season-search');
+    fireEvent.change(searchInput, { target: { value: '2031' } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('league-history-season-showing').textContent).toMatch(/Showing 1 of 3/i);
+    });
+  });
+
+  it('awards search filters by winner name and updates showing count', async () => {
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        initialSelectedSeasonId="s1"
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                { id: 's1', year: 2030, champion: { abbr: 'DAL' }, standings: [], awards: { mvp: { playerId: 1, name: 'Alpha Player', pos: 'QB' } } },
+                { id: 's2', year: 2031, champion: { abbr: 'NYG' }, standings: [], awards: { mvp: { playerId: 2, name: 'Beta Player', pos: 'RB' } } },
+              ],
+            },
+          }),
+          getRecords: vi.fn().mockResolvedValue({ payload: { records: null } }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+        }}
+      />,
+    );
+
+    // Awards TabsContent is force-mounted; just wait for loading to complete
+    const awardsSearch = await screen.findByTestId('league-history-awards-search');
+    expect(screen.getByTestId('league-history-awards-showing').textContent).toMatch(/Showing 2 of 2/i);
+
+    fireEvent.change(awardsSearch, { target: { value: 'Alpha' } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('league-history-awards-showing').textContent).toMatch(/Showing 1 of 2/i);
     });
   });
 

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -422,4 +422,60 @@ describe('PlayerProfile', () => {
     await waitFor(() => expect(screen.getByTestId('player-profile-legacy-watch')).toBeTruthy());
     expect(screen.getByText(/Legacy score/i)).toBeTruthy();
   });
+
+  it('shows season log sort controls and showing count when season log rows exist', async () => {
+    const multiSeasonActions = {
+      getPlayerCareer: vi.fn(async () => ({
+        payload: {
+          player: { ...player, careerStats: [] },
+          stats: [],
+          teammates: [],
+          meta: {},
+        },
+      })),
+      getAllSeasons: vi.fn(async () => ({
+        payload: {
+          seasons: [
+            {
+              id: 's1',
+              year: 2030,
+              playerSeasonStatsV1: {
+                schemaVersion: 1,
+                rows: [{ playerId: 11, playerName: 'Avery Fields', pos: 'QB', teamId: 1, teamAbbr: 'DAL', year: 2030, seasonId: 's1', gamesPlayed: 14, passYds: 3800, passTDs: 28, passInts: 8, rushYds: 0, rushTDs: 0, recYds: 0, recTDs: 0, tackles: 0, sacks: 0, defInts: 0, fgMade: 0, xpMade: 0 }],
+                meta: {},
+              },
+            },
+            {
+              id: 's2',
+              year: 2031,
+              playerSeasonStatsV1: {
+                schemaVersion: 1,
+                rows: [{ playerId: 11, playerName: 'Avery Fields', pos: 'QB', teamId: 1, teamAbbr: 'DAL', year: 2031, seasonId: 's2', gamesPlayed: 16, passYds: 4500, passTDs: 35, passInts: 7, rushYds: 0, rushTDs: 0, recYds: 0, recTDs: 0, tackles: 0, sacks: 0, defInts: 0, fgMade: 0, xpMade: 0 }],
+                meta: {},
+              },
+            },
+          ],
+        },
+      })),
+      getRecords: vi.fn(async () => ({ payload: { recordBook: null } })),
+    };
+
+    render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={multiSeasonActions} teams={league.teams} league={league} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('player-profile-season-log')).toBeTruthy();
+    });
+
+    expect(screen.getByTestId('season-log-showing-label').textContent).toMatch(/Showing 2 of 2 seasons/i);
+
+    const sortButtons = screen.getAllByRole('button').filter((b) => b.getAttribute('aria-pressed') !== null);
+    expect(sortButtons.length).toBeGreaterThan(0);
+  });
+
+  it('season log renders safely with no archive data (safe fallback)', async () => {
+    render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={actions} teams={league.teams} league={league} />);
+    await waitFor(() => {
+      expect(screen.queryByTestId('player-profile-season-log')).toBeNull();
+    });
+  });
 });

--- a/src/ui/components/__tests__/TeamHistoryScreen.test.jsx
+++ b/src/ui/components/__tests__/TeamHistoryScreen.test.jsx
@@ -60,6 +60,102 @@ describe('TeamHistoryScreen', () => {
     });
   });
 
+  it('shows showing count and sort controls after seasons load', async () => {
+    render(
+      <TeamHistoryScreen
+        league={{ teams: [{ id: 7, name: 'Seattle', abbr: 'SEA' }], userTeamId: 7 }}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                { year: 2030, standings: [{ id: 7, abbr: 'SEA', wins: 12, losses: 5, ties: 0, pf: 420, pa: 300 }], champion: { id: 7, abbr: 'SEA' }, playoffBracketSnapshot: { mode: 'empty', rounds: [] } },
+                { year: 2031, standings: [{ id: 7, abbr: 'SEA', wins: 8, losses: 9, ties: 0, pf: 320, pa: 330 }], playoffBracketSnapshot: { mode: 'empty', rounds: [] } },
+                { year: 2032, standings: [{ id: 7, abbr: 'SEA', wins: 5, losses: 12, ties: 0, pf: 280, pa: 390 }], playoffBracketSnapshot: { mode: 'empty', rounds: [] } },
+              ],
+            },
+          }),
+          getHallOfFame: vi.fn().mockResolvedValue({ payload: { players: [], classes: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+          getDraftClasses: vi.fn().mockResolvedValue({ payload: { classes: [] } }),
+          getDraftClass: vi.fn().mockResolvedValue({ payload: { model: null } }),
+        }}
+        onBack={vi.fn()}
+        onPlayerSelect={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      const showLabel = screen.getByTestId('team-history-showing-label');
+      expect(showLabel.textContent).toMatch(/Showing 3 of 3 seasons/i);
+    });
+  });
+
+  it('filters timeline by year text and updates showing count', async () => {
+    render(
+      <TeamHistoryScreen
+        league={{ teams: [{ id: 7, name: 'Seattle', abbr: 'SEA' }], userTeamId: 7 }}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                { year: 2030, standings: [{ id: 7, abbr: 'SEA', wins: 12, losses: 5, ties: 0, pf: 420, pa: 300 }], champion: { id: 7, abbr: 'SEA' }, playoffBracketSnapshot: { mode: 'empty', rounds: [] } },
+                { year: 2031, standings: [{ id: 7, abbr: 'SEA', wins: 8, losses: 9, ties: 0, pf: 320, pa: 330 }], playoffBracketSnapshot: { mode: 'empty', rounds: [] } },
+              ],
+            },
+          }),
+          getHallOfFame: vi.fn().mockResolvedValue({ payload: { players: [], classes: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+          getDraftClasses: vi.fn().mockResolvedValue({ payload: { classes: [] } }),
+          getDraftClass: vi.fn().mockResolvedValue({ payload: { model: null } }),
+        }}
+        onBack={vi.fn()}
+        onPlayerSelect={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-showing-label').textContent).toMatch(/Showing 2 of 2/i);
+    });
+    const input = screen.getByPlaceholderText('Filter by year');
+    fireEvent.change(input, { target: { value: '2030' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-showing-label').textContent).toMatch(/Showing 1 of 2/i);
+    });
+  });
+
+  it('reset filters restores full showing count', async () => {
+    render(
+      <TeamHistoryScreen
+        league={{ teams: [{ id: 7, name: 'Seattle', abbr: 'SEA' }], userTeamId: 7 }}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                { year: 2030, standings: [{ id: 7, abbr: 'SEA', wins: 12, losses: 5, ties: 0, pf: 420, pa: 300 }], champion: { id: 7, abbr: 'SEA' }, playoffBracketSnapshot: { mode: 'empty', rounds: [] } },
+                { year: 2031, standings: [{ id: 7, abbr: 'SEA', wins: 8, losses: 9, ties: 0, pf: 320, pa: 330 }], playoffBracketSnapshot: { mode: 'empty', rounds: [] } },
+              ],
+            },
+          }),
+          getHallOfFame: vi.fn().mockResolvedValue({ payload: { players: [], classes: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+          getDraftClasses: vi.fn().mockResolvedValue({ payload: { classes: [] } }),
+          getDraftClass: vi.fn().mockResolvedValue({ payload: { model: null } }),
+        }}
+        onBack={vi.fn()}
+        onPlayerSelect={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('team-history-showing-label')).toBeTruthy());
+    const input = screen.getByPlaceholderText('Filter by year');
+    fireEvent.change(input, { target: { value: '2030' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-showing-label').textContent).toMatch(/Showing 1 of 2/i);
+    });
+    const resetBtn = screen.getByTestId('team-history-reset-filters');
+    fireEvent.click(resetBtn);
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-showing-label').textContent).toMatch(/Showing 2 of 2/i);
+    });
+  });
+
   it('calls onOpenBoxScore when defining game has resolvable id and scores', async () => {
     const onOpen = vi.fn();
     render(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds lightweight, mobile-friendly data-browsing improvements to four high-impact history surfaces, reusing the existing `src/ui/utils/dataBrowser.js` helpers throughout. No simulation logic, economy logic, history systems, or archived data was modified.

---

## Screens improved

| Screen | Changes |
|--------|---------|
| **TeamHistoryScreen** | Sort controls (Year ▼ / Wins / Losses), "Showing X of Y seasons" label, Reset filters button |
| **PlayerProfile – Season Log** | Sortable header buttons (Year / GP / Key Stat / OVR), "Showing X of Y seasons" count |
| **LeagueHistory – Season Archive** | Search input (year or champion abbr/name), "Showing X of Y seasons" count |
| **LeagueHistory – Awards History** | Search input (year, champion, winner name), "Showing X of Y seasons" count, Clear button |
| **LeagueActivityLog** | "Showing X of Y transactions" count, Reset All button |

---

## Fields used for search/sort/filter

- **TeamHistoryScreen**: `year`, `wins`, `losses` (sort); `year` text (filter)
- **PlayerProfile season log**: `season` (year sort), `gamesPlayed`, `ovr`, position-specific primary stat (`passYds`/`rushYds`/`recYds`/`tackles`)
- **LeagueHistory season list**: `year`, `champion.abbr`, `champion.name`
- **LeagueHistory awards**: `year`, `champion.abbr`, `awards.mvp.name`, `awards.opoy.name`, `awards.dpoy.name`, `awards.roty.name`
- **LeagueActivityLog**: uses existing server-side filtering; client-side `buildShowingLabel` for visible count

---

## Fallback behavior for missing data

- **No archived seasons**: "Showing 0 of 0 seasons" – no crash, clear empty state preserved
- **Player with no season log**: Section is hidden entirely (`mergedProfileSeasonRows.length === 0`)
- **New save with no transactions**: "Transactions will appear…" empty state unchanged
- **Awards with no winners**: Empty row handling preserved; search returns "No seasons match"

---

## dataBrowser helpers reused

| Helper | Used in |
|--------|---------|
| `stableSortRows` | TeamHistoryScreen, PlayerProfile season log |
| `rowMatchesSearch` | LeagueHistory season list, LeagueHistory awards |
| `buildShowingLabel` | All 5 surfaces |

No new helpers were added to `dataBrowser.js`.

---

## Mobile UX notes

- Sort buttons in TeamHistoryScreen and PlayerProfile use compact `flex-wrap` rows — collapse to multi-line on narrow screens
- `aria-pressed` on all sort buttons for accessibility
- LeagueHistory season search sits inside the `ScrollArea` card header and compresses gracefully
- LeagueActivityLog Reset/Refresh buttons stay in the `flex-row sm:flex-wrap` filter bar

---

## Walkthrough artifacts

[Team History – sort controls and showing count](https://cursor.com/agents/bc-79eae8dd-bacd-4a32-9305-9952e6f55ca7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_v2_team.png)
*Team History: Sort by Year ▼ / Wins / Losses, Reset, Showing X of Y seasons*

[League History – season archive search](https://cursor.com/agents/bc-79eae8dd-bacd-4a32-9305-9952e6f55ca7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_v2_league.png)
*League History Season Archive: search by year/champion, Showing X of Y count*

[Awards History search input](https://cursor.com/agents/bc-79eae8dd-bacd-4a32-9305-9952e6f55ca7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_v2_awards.png)
*Awards History: search input and Showing X of Y seasons*

[Player Season Log sort controls](https://cursor.com/agents/bc-79eae8dd-bacd-4a32-9305-9952e6f55ca7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_v2_player_log.png)
*Player Profile Season Log: sort buttons (Year / GP / Key Stat / OVR) and showing count*

[Activity Log – Reset button and Showing 46 of 46 transactions](https://cursor.com/agents/bc-79eae8dd-bacd-4a32-9305-9952e6f55ca7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_v2_activity.png)
*League Activity Log: Reset All button + "Showing 46 of 46 transactions" with live game data*

[history_data_density_v2_demo.mp4](https://cursor.com/agents/bc-79eae8dd-bacd-4a32-9305-9952e6f55ca7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_data_density_v2_demo.mp4)

---

## Tests

| File | New tests |
|------|-----------|
| `TeamHistoryScreen.test.jsx` | 3 added: showing count renders, filter updates count, reset restores count |
| `LeagueHistory.test.jsx` | 2 added: season search filters + count, awards search filters + count |
| `PlayerProfile.test.jsx` | 2 added: sort controls + showing label exist, safe fallback with no archive |
| `LeagueActivityLog.test.jsx` | **New file** – 4 tests: empty state, showing count, reset button, no-actions safe |

Full suite result: ✅ **191 test files, 851 tests, all passing**

---

## Validation

- ✅ `npm run test:unit` — 191 files, 851 tests passed
- ✅ `npm run test:soak` — 40 tests passed
- ✅ `npm run build` — succeeds (expected chunk size warning only)
- ✅ `npm run check:deploy` — Netlify parity check passed
- ✅ `npx playwright test tests/e2e/fresh_franchise_first_week_smoke.spec.js` — 1/1 passed (17.2s)
- ✅ Manual UI test — all 5 surfaces verified in browser including live "46 of 46 transactions" count

---

## What was intentionally deferred

- **HallOfFame.jsx**: Already has robust search/sort/filter controls (search, position filter, class filter, sort key). Not touched.
- **DraftHistory.jsx**: `DraftHistoryExplorer` inside `LeagueHistory` shows minimal draft data (season artifacts only when present) — adding search/sort here would require expanding the data model. Deferred.
- **AwardsRecordsScreen.jsx**: Already has tab-based filtering (All / Recent / MVP history). Not in scope for this iteration.
- **Sort on LeagueActivity**: The server-side `getTransactions` API already handles type/team/season filters; adding client-side sort on a 400-row list is a possible follow-up.
- **Save-old compatibility**: Explicitly verified — components degrade gracefully when season archive is empty.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79eae8dd-bacd-4a32-9305-9952e6f55ca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79eae8dd-bacd-4a32-9305-9952e6f55ca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

