### PR TITLE
feat: Team + Player History Data Density V2 — search/sort/filter for 4 history surfaces

### DIFF
--- a/src/ui/components/LeagueActivityLog.jsx
+++ b/src/ui/components/LeagueActivityLog.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { buildShowingLabel } from "../utils/dataBrowser.js";
 
 const TYPE_FILTERS = [
   { value: "all", label: "All types" },
@@ -134,7 +135,24 @@ export default function LeagueActivityLog({ league, actions, onPlayerSelect, onT
         <button type="button" className="btn btn-secondary h-9 text-sm" onClick={() => load()}>
           Refresh
         </button>
+        {(type !== 'all' || teamId !== 'all' || seasonId !== 'all' || search.trim()) ? (
+          <button
+            type="button"
+            className="btn btn-secondary h-9 text-sm"
+            data-testid="league-activity-reset"
+            onClick={() => { setSeasonId('all'); setTeamId('all'); setType('all'); setSearch(''); }}
+          >
+            Reset
+          </button>
+        ) : null}
       </div>
+
+      {!loading && (
+        <div className="text-xs text-[color:var(--text-muted)]" data-testid="league-activity-showing">
+          {buildShowingLabel(rows.length, rows.length, 'transactions')}
+          {(type !== 'all' || teamId !== 'all' || search.trim()) ? ' (filtered)' : ''}
+        </div>
+      )}
 
       {loading ? (
         <div className="py-8 text-center text-sm text-[color:var(--text-muted)]">Loading activity…</div>

--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -8,6 +8,7 @@ import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/b
 import { AWARD_DISPLAY_NAMES } from '../../core/footballMeta';
 import { buildLeagueHistoryTopPerformers } from '../../core/playerSeasonStatsArchive.js';
 import { normalizeArchivedMajorTransactions } from '../../core/transactionTimeline.js';
+import { normalizeSearchText, rowMatchesSearch, stableSortRows, buildShowingLabel } from '../utils/dataBrowser.js';
 
 const RECORD_LABELS = {
   passYd: "Passing Yards",
@@ -342,6 +343,7 @@ function SeasonDraftClassSnippet({ seasonId, year, actions, onPlayerSelect }) {
 
 function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, league, initialSelectedSeasonId = null }) {
   const [selectedSeasonId, setSelectedSeasonId] = useState(initialSelectedSeasonId ?? seasons?.[0]?.id ?? null);
+  const [seasonSearch, setSeasonSearch] = useState('');
 
   useEffect(() => {
     if (!seasons?.length) return;
@@ -352,6 +354,16 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
     }
     setSelectedSeasonId((prev) => prev ?? seasons[0]?.id ?? null);
   }, [initialSelectedSeasonId, seasons]);
+
+  const filteredSeasons = useMemo(() => {
+    const q = normalizeSearchText(seasonSearch);
+    if (!q) return seasons;
+    return seasons.filter((s) => {
+      const yr = String(s.year ?? '');
+      const champ = String(s.champion?.abbr ?? s.champion?.name ?? '');
+      return yr.includes(q) || normalizeSearchText(champ).includes(q);
+    });
+  }, [seasons, seasonSearch]);
 
   if (!seasons?.length) {
     return (
@@ -400,11 +412,28 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
   return (
     <div className="grid grid-cols-1 lg:grid-cols-[260px_1fr] gap-4">
       <Card className="card-premium">
-        <CardHeader><CardTitle>Season Archive</CardTitle></CardHeader>
+        <CardHeader>
+          <CardTitle>Season Archive</CardTitle>
+          <div className="text-xs text-[color:var(--text-muted)]" data-testid="league-history-season-count">
+            {buildShowingLabel(filteredSeasons.length, seasons.length, 'seasons')}
+          </div>
+        </CardHeader>
         <CardContent className="p-0">
-          <ScrollArea className="h-[520px]">
+          <div className="px-3 py-2">
+            <input
+              type="search"
+              value={seasonSearch}
+              onChange={(e) => setSeasonSearch(e.target.value)}
+              placeholder="Search year or champion…"
+              data-testid="league-history-season-search"
+              className="h-8 w-full rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-xs"
+            />
+          </div>
+          <ScrollArea className="h-[480px]">
             <div className="divide-y divide-[color:var(--hairline)]">
-              {seasons.map((s) => (
+              {filteredSeasons.length === 0 ? (
+                <div className="px-4 py-6 text-center text-xs text-[color:var(--text-muted)]">No seasons match your search.</div>
+              ) : filteredSeasons.map((s) => (
                 <button
                   key={s.id}
                   className={`w-full text-left px-4 py-3 ${selected?.id === s.id ? "bg-[color:var(--surface-strong)]" : ""}`}
@@ -800,17 +829,59 @@ function RecordsExplorer({ records, recordBook, seasons, onPlayerSelect }) {
 }
 
 function AwardsHistory({ seasons, onPlayerSelect }) {
+  const [awardSearch, setAwardSearch] = useState('');
+  const [awardSortDir, setAwardSortDir] = useState('desc');
+
   if (!seasons?.length) return <div className="py-8 text-center text-[color:var(--text-muted)]">No award history yet.</div>;
+
+  const q = normalizeSearchText(awardSearch);
+  const filtered = q
+    ? seasons.filter((s) => {
+        const fields = [
+          String(s.year ?? ''),
+          s.champion?.abbr, s.champion?.name,
+          s.awards?.mvp?.name, s.awards?.opoy?.name, s.awards?.dpoy?.name, s.awards?.roty?.name,
+        ];
+        return fields.some((f) => f && normalizeSearchText(f).includes(q));
+      })
+    : seasons;
+  const sorted = [...filtered].sort((a, b) => awardSortDir === 'desc' ? (b.year ?? 0) - (a.year ?? 0) : (a.year ?? 0) - (b.year ?? 0));
 
   return (
     <Card className="card-premium">
-      <CardHeader><CardTitle>Awards by Season</CardTitle></CardHeader>
+      <CardHeader>
+        <CardTitle>Awards by Season</CardTitle>
+        <div className="flex flex-wrap items-center gap-2 mt-1">
+          <input
+            type="search"
+            value={awardSearch}
+            onChange={(e) => setAwardSearch(e.target.value)}
+            placeholder="Search year, champion, or award winner…"
+            data-testid="awards-history-search"
+            className="h-8 w-full sm:w-64 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-xs"
+          />
+          <span className="text-xs text-[color:var(--text-muted)]" data-testid="awards-history-count">
+            {buildShowingLabel(sorted.length, seasons.length, 'seasons')}
+          </span>
+          {q && (
+            <button type="button" className="text-xs text-[color:var(--accent)]" onClick={() => setAwardSearch('')}>
+              Reset
+            </button>
+          )}
+        </div>
+      </CardHeader>
       <CardContent className="p-0">
         <ScrollArea className="h-[560px]">
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead className="pl-5">Year</TableHead>
+                <TableHead
+                  className="pl-5"
+                  style={{ cursor: 'pointer', userSelect: 'none' }}
+                  onClick={() => setAwardSortDir((d) => d === 'asc' ? 'desc' : 'asc')}
+                >
+                  Year {awardSortDir === 'asc' ? '↑' : '↓'}
+                </TableHead>
                 <TableHead>Champion</TableHead>
                 <TableHead>MVP</TableHead>
                 <TableHead>{AWARD_DISPLAY_NAMES.opoy}</TableHead>
@@ -819,7 +890,9 @@ function AwardsHistory({ seasons, onPlayerSelect }) {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {seasons.map((s) => (
+              {sorted.length === 0 ? (
+                <TableRow><TableCell colSpan={6} className="text-center py-6 text-[color:var(--text-muted)]">No awards match your search.</TableCell></TableRow>
+              ) : sorted.map((s) => (
                 <TableRow key={s.id}>
                   <TableCell className="pl-5 font-bold">{s.year}</TableCell>
                   <TableCell>{s.champion?.abbr ?? "—"}</TableCell>
@@ -838,9 +911,11 @@ function AwardsHistory({ seasons, onPlayerSelect }) {
 }
 
 function LeagueOfficeHistory({ transactions, onPlayerSelect }) {
+  const [txSearch, setTxSearch] = useState('');
+  const [txType, setTxType] = useState('all');
+
   if (!transactions?.length) return <div className="py-8 text-center text-[color:var(--text-muted)]">No transaction history tracked yet.</div>;
 
-  const rows = transactions.slice(0, 120);
   const describe = (tx) => {
     const leg = tx.legacyType ?? "";
     const bucket = tx.type ?? "";
@@ -863,13 +938,56 @@ function LeagueOfficeHistory({ transactions, onPlayerSelect }) {
     return tx.headline ?? tx.typeLabel ?? tx.type;
   };
 
+  const q = normalizeSearchText(txSearch);
+  const allRows = transactions.slice(0, 200);
+  const filtered = allRows.filter((tx) => {
+    if (txType !== 'all' && (tx.type ?? tx.legacyType ?? '').toLowerCase() !== txType) return false;
+    if (!q) return true;
+    return [tx.playerName, tx.teamAbbr, tx.typeLabel, tx.headline, tx.fromTeamAbbr, tx.toTeamAbbr]
+      .some((f) => f && normalizeSearchText(f).includes(q));
+  });
+
+  const typeOptions = [...new Set(allRows.map((tx) => tx.type ?? tx.legacyType).filter(Boolean))].sort();
+  const hasFilters = q || txType !== 'all';
+
   return (
     <Card className="card-premium">
-      <CardHeader><CardTitle>League Moves Log</CardTitle></CardHeader>
+      <CardHeader>
+        <CardTitle>League Moves Log</CardTitle>
+        <div className="flex flex-wrap items-center gap-2 mt-1">
+          <input
+            type="search"
+            value={txSearch}
+            onChange={(e) => setTxSearch(e.target.value)}
+            placeholder="Search player or team…"
+            data-testid="league-office-tx-search"
+            className="h-8 w-full sm:w-56 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-xs"
+          />
+          <select
+            value={txType}
+            onChange={(e) => setTxType(e.target.value)}
+            data-testid="league-office-tx-type"
+            className="h-8 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-xs"
+          >
+            <option value="all">All types</option>
+            {typeOptions.map((t) => <option key={t} value={t.toLowerCase()}>{t}</option>)}
+          </select>
+          <span className="text-xs text-[color:var(--text-muted)]" data-testid="league-office-tx-count">
+            {buildShowingLabel(filtered.length, allRows.length, 'moves')}
+          </span>
+          {hasFilters && (
+            <button type="button" className="text-xs text-[color:var(--accent)]" onClick={() => { setTxSearch(''); setTxType('all'); }}>
+              Reset
+            </button>
+          )}
+        </div>
+      </CardHeader>
       <CardContent className="p-0">
         <ScrollArea className="h-[560px]">
           <div className="divide-y divide-[color:var(--hairline)]">
-            {rows.map((tx, idx) => (
+            {filtered.length === 0 ? (
+              <div className="px-4 py-8 text-center text-sm text-[color:var(--text-muted)]">No moves match your filters.</div>
+            ) : filtered.map((tx, idx) => (
               <div key={`${tx.id ?? idx}`} className="px-4 py-3 text-sm">
                 <div className="flex items-center justify-between gap-2">
                   <strong>{tx.typeLabel ?? tx.type}</strong>

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -33,6 +33,7 @@ import { buildPlayerRecordContext, mergePlayerProfileSeasonRows } from "../../co
 import { buildLegacyScoreReport, shouldShowLegacyProfileSection } from "../../core/legacyScore.js";
 import { buildPlayerDevelopmentModel } from "../../core/playerDevelopmentModel.js";
 import { buildProspectScoutingReport } from "../../core/scoutingModel.js";
+import { stableSortRows, buildShowingLabel } from "../utils/dataBrowser.js";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
@@ -646,6 +647,17 @@ export default function PlayerProfile({
     () => mergePlayerProfileSeasonRows(effectivePlayer, archivedSeasons),
     [effectivePlayer, archivedSeasons],
   );
+  const [seasonLogSortKey, setSeasonLogSortKey] = useState('year');
+  const [seasonLogSortDir, setSeasonLogSortDir] = useState('desc');
+  const sortedSeasonLogRows = useMemo(
+    () => stableSortRows(mergedProfileSeasonRows, seasonLogSortKey, seasonLogSortDir),
+    [mergedProfileSeasonRows, seasonLogSortKey, seasonLogSortDir],
+  );
+  const toggleSeasonLogSort = (key) => {
+    if (seasonLogSortKey === key) { setSeasonLogSortDir((d) => d === 'asc' ? 'desc' : 'asc'); }
+    else { setSeasonLogSortKey(key); setSeasonLogSortDir('desc'); }
+  };
+  const seasonLogSortArrow = (key) => seasonLogSortKey === key ? (seasonLogSortDir === 'asc' ? ' ↑' : ' ↓') : '';
   const teamJourney = [...new Set(mergedProfileSeasonRows.map((line) => line.team).filter(Boolean))];
   const careerArcRows = useMemo(() => {
     const seasonRows = mergedProfileSeasonRows.map((line) => ({
@@ -1880,20 +1892,24 @@ export default function PlayerProfile({
 
           {/* ── Per-season career log (player.careerStats + archived playerSeasonStatsV1) ── */}
           {!loading && mergedProfileSeasonRows.length > 0 && (
-            <section className="card-enter">
-              <h3
-                style={{
-                  fontSize: "var(--text-sm)",
-                  fontWeight: 700,
-                  marginBottom: "var(--space-2)",
-                  marginTop: 0,
-                  color: "var(--text-muted)",
-                  textTransform: "uppercase",
-                  letterSpacing: ".07em",
-                }}
-              >
-                Season Log
-              </h3>
+            <section className="card-enter" data-testid="player-profile-season-log">
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", flexWrap: "wrap", gap: 8, marginBottom: "var(--space-2)" }}>
+                <h3
+                  style={{
+                    fontSize: "var(--text-sm)",
+                    fontWeight: 700,
+                    margin: 0,
+                    color: "var(--text-muted)",
+                    textTransform: "uppercase",
+                    letterSpacing: ".07em",
+                  }}
+                >
+                  Season Log
+                </h3>
+                <span style={{ fontSize: 11, color: "var(--text-muted)" }} data-testid="player-season-log-count">
+                  {buildShowingLabel(sortedSeasonLogRows.length, mergedProfileSeasonRows.length, 'seasons')}
+                </span>
+              </div>
               <div className="table-wrapper" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
                 <Table
                   className="standings-table"
@@ -1910,56 +1926,59 @@ export default function PlayerProfile({
                         style={{
                           textAlign: "left",
                           paddingLeft: "var(--space-4)",
+                          cursor: "pointer",
+                          userSelect: "none",
                         }}
+                        onClick={() => toggleSeasonLogSort('year')}
                       >
-                        Season
+                        Season{seasonLogSortArrow('year')}
                       </TableHead>
-                      <TableHead style={{ textAlign: "left" }}>Team</TableHead>
+                      <TableHead style={{ textAlign: "left", cursor: "pointer", userSelect: "none" }} onClick={() => toggleSeasonLogSort('team')}>Team{seasonLogSortArrow('team')}</TableHead>
                       <TableHead style={{ textAlign: "center" }}>Pos</TableHead>
-                      <TableHead style={{ textAlign: "center" }}>GP</TableHead>
+                      <TableHead style={{ textAlign: "center", cursor: "pointer", userSelect: "none" }} onClick={() => toggleSeasonLogSort('gamesPlayed')}>GP{seasonLogSortArrow('gamesPlayed')}</TableHead>
                       {["QB"].includes(player.pos) && (
                         <>
-                          <TableHead style={{ textAlign: "center" }}>YDS</TableHead>
-                          <TableHead style={{ textAlign: "center" }}>TD</TableHead>
-                          <TableHead style={{ textAlign: "center" }}>INT</TableHead>
+                          <TableHead style={{ textAlign: "center", cursor: "pointer", userSelect: "none" }} onClick={() => toggleSeasonLogSort('passYds')}>YDS{seasonLogSortArrow('passYds')}</TableHead>
+                          <TableHead style={{ textAlign: "center", cursor: "pointer", userSelect: "none" }} onClick={() => toggleSeasonLogSort('passTDs')}>TD{seasonLogSortArrow('passTDs')}</TableHead>
+                          <TableHead style={{ textAlign: "center", cursor: "pointer", userSelect: "none" }} onClick={() => toggleSeasonLogSort('ints')}>INT{seasonLogSortArrow('ints')}</TableHead>
                           <TableHead style={{ textAlign: "center" }}>CMP%</TableHead>
                         </>
                       )}
                       {["RB", "FB"].includes(player.pos) && (
                         <>
-                          <TableHead style={{ textAlign: "center" }}>RYDS</TableHead>
-                          <TableHead style={{ textAlign: "center" }}>RTD</TableHead>
-                          <TableHead style={{ textAlign: "center" }}>REC</TableHead>
-                          <TableHead style={{ textAlign: "center" }}>RCYDS</TableHead>
+                          <TableHead style={{ textAlign: "center", cursor: "pointer", userSelect: "none" }} onClick={() => toggleSeasonLogSort('rushYds')}>RYDS{seasonLogSortArrow('rushYds')}</TableHead>
+                          <TableHead style={{ textAlign: "center", cursor: "pointer", userSelect: "none" }} onClick={() => toggleSeasonLogSort('rushTDs')}>RTD{seasonLogSortArrow('rushTDs')}</TableHead>
+                          <TableHead style={{ textAlign: "center", cursor: "pointer", userSelect: "none" }} onClick={() => toggleSeasonLogSort('receptions')}>REC{seasonLogSortArrow('receptions')}</TableHead>
+                          <TableHead style={{ textAlign: "center", cursor: "pointer", userSelect: "none" }} onClick={() => toggleSeasonLogSort('recYds')}>RCYDS{seasonLogSortArrow('recYds')}</TableHead>
                         </>
                       )}
                       {["WR", "TE"].includes(player.pos) && (
                         <>
-                          <TableHead style={{ textAlign: "center" }}>REC</TableHead>
-                          <TableHead style={{ textAlign: "center" }}>YDS</TableHead>
-                          <TableHead style={{ textAlign: "center" }}>TD</TableHead>
+                          <TableHead style={{ textAlign: "center", cursor: "pointer", userSelect: "none" }} onClick={() => toggleSeasonLogSort('receptions')}>REC{seasonLogSortArrow('receptions')}</TableHead>
+                          <TableHead style={{ textAlign: "center", cursor: "pointer", userSelect: "none" }} onClick={() => toggleSeasonLogSort('recYds')}>YDS{seasonLogSortArrow('recYds')}</TableHead>
+                          <TableHead style={{ textAlign: "center", cursor: "pointer", userSelect: "none" }} onClick={() => toggleSeasonLogSort('recTDs')}>TD{seasonLogSortArrow('recTDs')}</TableHead>
                         </>
                       )}
                       {["DE", "DT", "LB", "CB", "S", "DL", "EDGE"].includes(
                         player.pos,
                       ) && (
                         <>
-                          <TableHead style={{ textAlign: "center" }}>TKL</TableHead>
-                          <TableHead style={{ textAlign: "center" }}>SCK</TableHead>
-                          <TableHead style={{ textAlign: "center" }}>D-INT</TableHead>
+                          <TableHead style={{ textAlign: "center", cursor: "pointer", userSelect: "none" }} onClick={() => toggleSeasonLogSort('tackles')}>TKL{seasonLogSortArrow('tackles')}</TableHead>
+                          <TableHead style={{ textAlign: "center", cursor: "pointer", userSelect: "none" }} onClick={() => toggleSeasonLogSort('sacks')}>SCK{seasonLogSortArrow('sacks')}</TableHead>
+                          <TableHead style={{ textAlign: "center", cursor: "pointer", userSelect: "none" }} onClick={() => toggleSeasonLogSort('defInts')}>D-INT{seasonLogSortArrow('defInts')}</TableHead>
                         </>
                       )}
                       {["K"].includes(player.pos) && (
                         <>
-                          <TableHead style={{ textAlign: "center" }}>FGM</TableHead>
-                          <TableHead style={{ textAlign: "center" }}>XPM</TableHead>
+                          <TableHead style={{ textAlign: "center", cursor: "pointer", userSelect: "none" }} onClick={() => toggleSeasonLogSort('fgMade')}>FGM{seasonLogSortArrow('fgMade')}</TableHead>
+                          <TableHead style={{ textAlign: "center", cursor: "pointer", userSelect: "none" }} onClick={() => toggleSeasonLogSort('xpMade')}>XPM{seasonLogSortArrow('xpMade')}</TableHead>
                         </>
                       )}
-                      <TableHead style={{ textAlign: "center" }}>OVR</TableHead>
+                      <TableHead style={{ textAlign: "center", cursor: "pointer", userSelect: "none" }} onClick={() => toggleSeasonLogSort('ovr')}>OVR{seasonLogSortArrow('ovr')}</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {[...mergedProfileSeasonRows].reverse().map((line, i) => (
+                    {sortedSeasonLogRows.map((line, i) => (
                       <TableRow key={i}>
                         <TableCell
                           style={{

--- a/src/ui/components/TeamHistoryScreen.jsx
+++ b/src/ui/components/TeamHistoryScreen.jsx
@@ -3,6 +3,7 @@ import { ScreenHeader, SectionCard, EmptyState } from './ScreenSystem.jsx';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 import { buildFranchiseHistoryModel, PLAYOFF_CALIBER_WINS } from '../../core/franchiseHistoryModel.js';
 import { RECORD_BOOK_PLAYER_KEYS, RECORD_LABELS } from '../../core/recordBookV1.js';
+import { stableSortRows, buildShowingLabel } from '../utils/dataBrowser.js';
 
 function buildSeasonTeamMap(season) {
   const map = {};
@@ -36,6 +37,8 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
   const [loading, setLoading] = useState(true);
   const [queryYear, setQueryYear] = useState('');
   const [scope, setScope] = useState('all');
+  const [sortKey, setSortKey] = useState('year');
+  const [sortDir, setSortDir] = useState('desc');
   const [majorMoves, setMajorMoves] = useState([]);
   const [draftFlash, setDraftFlash] = useState([]);
 
@@ -147,7 +150,7 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
   const { summary, franchiseRecords, franchiseLegends, playoffHistory, bestGames, milestones } = model;
 
   const filteredTimeline = useMemo(() => {
-    return (model.seasons ?? []).filter((row) => {
+    const filtered = (model.seasons ?? []).filter((row) => {
       if (scope === 'champions' && !row.champion) return false;
       if (scope === 'playoff' && !row.playoffCaliber) return false;
       if (scope === 'losing' && !row.losingSeason) return false;
@@ -155,7 +158,16 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
       if (!queryYear.trim()) return true;
       return String(row.year).includes(queryYear.trim());
     });
-  }, [model.seasons, queryYear, scope]);
+    return stableSortRows(filtered, sortKey, sortDir);
+  }, [model.seasons, queryYear, scope, sortKey, sortDir]);
+
+  const totalSeasonCount = (model.seasons ?? []).length;
+  const hasActiveFilters = scope !== 'all' || queryYear.trim() !== '';
+  const resetFilters = () => { setQueryYear(''); setScope('all'); setSortKey('year'); setSortDir('desc'); };
+  const toggleSort = (key) => {
+    if (sortKey === key) { setSortDir((d) => d === 'asc' ? 'desc' : 'asc'); }
+    else { setSortKey(key); setSortDir(key === 'year' ? 'desc' : 'desc'); }
+  };
 
   const completedGameRows = useMemo(() => {
     const rows = [];
@@ -456,12 +468,13 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
       </SectionCard>
 
       <SectionCard title="Season-by-season timeline">
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 10 }}>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 10, alignItems: 'center' }}>
           <input
             value={queryYear}
             onChange={(e) => setQueryYear(e.target.value)}
             placeholder="Filter by year"
-            style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)', minWidth: 160 }}
+            data-testid="team-history-year-filter"
+            style={{ background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 8, padding: '6px 10px', color: 'var(--text)', minWidth: 120, maxWidth: 160 }}
           />
           {[
             { key: 'all', label: 'All-time' },
@@ -470,17 +483,48 @@ export default function TeamHistoryScreen({ league, actions, teamId, onPlayerSel
             { key: 'elite', label: 'Elite seasons' },
             { key: 'losing', label: 'Losing seasons' },
           ].map((opt) => (
-            <button key={opt.key} type="button" className="btn" onClick={() => setScope(opt.key)} style={{ opacity: scope === opt.key ? 1 : 0.7 }}>
+            <button key={opt.key} type="button" className="btn" onClick={() => setScope(opt.key)} style={{ opacity: scope === opt.key ? 1 : 0.7, fontSize: 'var(--text-xs)' }}>
               {opt.label}
             </button>
           ))}
+          {hasActiveFilters ? (
+            <button type="button" className="btn btn-secondary" onClick={resetFilters} style={{ fontSize: 'var(--text-xs)' }} data-testid="team-history-reset-filters">
+              Reset
+            </button>
+          ) : null}
         </div>
+
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 8, alignItems: 'center' }}>
+          <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }} data-testid="team-history-showing-label">
+            {buildShowingLabel(filteredTimeline.length, totalSeasonCount, 'seasons')}
+          </span>
+          <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>·</span>
+          {[
+            { key: 'year', label: 'Year' },
+            { key: 'wins', label: 'Wins' },
+            { key: 'losses', label: 'Losses' },
+            { key: 'pf', label: 'PF' },
+            { key: 'pa', label: 'PA' },
+          ].map((col) => (
+            <button
+              key={col.key}
+              type="button"
+              className="btn"
+              onClick={() => toggleSort(col.key)}
+              data-testid={`team-history-sort-${col.key}`}
+              style={{ fontSize: 11, opacity: sortKey === col.key ? 1 : 0.6, padding: '2px 8px', minWidth: 0 }}
+            >
+              {col.label} {sortKey === col.key ? (sortDir === 'asc' ? '↑' : '↓') : ''}
+            </button>
+          ))}
+        </div>
+
         <div style={{ display: 'grid', gap: 8, maxHeight: 420, overflow: 'auto' }}>
           {filteredTimeline.length === 0 ? (
             <EmptyState title="No team history for this filter" body="Adjust filters or archive more seasons." />
           ) : (
-            filteredTimeline.slice().reverse().map((s) => (
-              <div key={s.year} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: 10 }}>
+            filteredTimeline.map((s) => (
+              <div key={s.year} style={{ border: '1px solid var(--hairline)', borderRadius: 10, padding: 10 }} data-testid={`team-history-season-${s.year}`}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
                   <strong>{s.year}</strong>
                   <span>

--- a/src/ui/components/__tests__/LeagueHistory.test.jsx
+++ b/src/ui/components/__tests__/LeagueHistory.test.jsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import LeagueHistory from '../LeagueHistory.jsx';
 
 describe('LeagueHistory', () => {
@@ -195,6 +195,60 @@ describe('LeagueHistory', () => {
     await waitFor(() => {
       expect(screen.getByTestId('league-history-major-tx-sx')).toBeTruthy();
       expect(screen.getByTestId('league-history-major-tx-sx').textContent).toMatch(/DAL signed Test Player/);
+    });
+  });
+
+  it('renders season search input in the sidebar when seasons exist', async () => {
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        initialSelectedSeasonId="s1"
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                { id: 's1', year: 2030, standings: [{ id: 1, wins: 8, losses: 9 }], awards: {}, champion: { abbr: 'DAL' } },
+                { id: 's2', year: 2031, standings: [], awards: {}, champion: { abbr: 'NYG' } },
+              ],
+            },
+          }),
+          getRecords: vi.fn().mockResolvedValue({ payload: { records: null } }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/2030 League Snapshot/i)).toBeTruthy();
+    });
+
+    const searchInputs = screen.queryAllByPlaceholderText(/Search year or champion/);
+    expect(searchInputs.length).toBeGreaterThan(0);
+
+    const countEls = screen.queryAllByTestId('league-history-season-count');
+    expect(countEls.length).toBeGreaterThan(0);
+    expect(countEls.some((el) => el.textContent.includes('seasons'))).toBe(true);
+  });
+
+  it('renders empty state when no archived seasons', async () => {
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({ payload: { seasons: [] } }),
+          getRecords: vi.fn().mockResolvedValue({ payload: { records: null } }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+        }}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/No archived seasons yet/i)).toBeTruthy();
     });
   });
 });

--- a/src/ui/components/__tests__/TeamHistoryScreen.test.jsx
+++ b/src/ui/components/__tests__/TeamHistoryScreen.test.jsx
@@ -109,4 +109,81 @@ describe('TeamHistoryScreen', () => {
     const arg = onOpen.mock.calls[0][0];
     expect(String(arg)).toMatch(/2055/);
   });
+
+  it('shows showing label and supports sort by wins', async () => {
+    render(
+      <TeamHistoryScreen
+        league={{ teams: [{ id: 7, name: 'Seattle', abbr: 'SEA' }], userTeamId: 7 }}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                { year: 2030, standings: [{ id: 7, abbr: 'SEA', wins: 8, losses: 9, ties: 0, pf: 300, pa: 310 }], champion: { id: 2, abbr: 'OTH' }, runnerUp: { id: 3, abbr: 'THD' }, playoffBracketSnapshot: { mode: 'empty', rounds: [] } },
+                { year: 2031, standings: [{ id: 7, abbr: 'SEA', wins: 12, losses: 5, ties: 0, pf: 420, pa: 280 }], champion: { id: 7, abbr: 'SEA' }, runnerUp: { id: 2, abbr: 'OTH' }, playoffBracketSnapshot: { mode: 'empty', rounds: [] } },
+                { year: 2032, standings: [{ id: 7, abbr: 'SEA', wins: 5, losses: 12, ties: 0, pf: 250, pa: 400 }], champion: { id: 2, abbr: 'OTH' }, runnerUp: { id: 3, abbr: 'THD' }, playoffBracketSnapshot: { mode: 'empty', rounds: [] } },
+              ],
+            },
+          }),
+          getHallOfFame: vi.fn().mockResolvedValue({ payload: { players: [], classes: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+          getDraftClasses: vi.fn().mockResolvedValue({ payload: { classes: [] } }),
+          getDraftClass: vi.fn().mockResolvedValue({ payload: { model: null } }),
+        }}
+        onBack={vi.fn()}
+        onPlayerSelect={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-showing-label').textContent).toBe('3 seasons');
+    });
+
+    const winsBtn = screen.getByTestId('team-history-sort-wins');
+    expect(winsBtn).toBeTruthy();
+    fireEvent.click(winsBtn);
+    await waitFor(() => {
+      const seasonCards = screen.getAllByTestId(/^team-history-season-/);
+      expect(seasonCards.length).toBe(3);
+    });
+  });
+
+  it('filters seasons by year and shows reset button', async () => {
+    render(
+      <TeamHistoryScreen
+        league={{ teams: [{ id: 7, name: 'Seattle', abbr: 'SEA' }], userTeamId: 7 }}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [
+                { year: 2030, standings: [{ id: 7, abbr: 'SEA', wins: 8, losses: 9, ties: 0, pf: 300, pa: 310 }], champion: { id: 2, abbr: 'OTH' }, runnerUp: { id: 3, abbr: 'THD' }, playoffBracketSnapshot: { mode: 'empty', rounds: [] } },
+                { year: 2031, standings: [{ id: 7, abbr: 'SEA', wins: 12, losses: 5, ties: 0, pf: 420, pa: 280 }], champion: { id: 7, abbr: 'SEA' }, runnerUp: { id: 2, abbr: 'OTH' }, playoffBracketSnapshot: { mode: 'empty', rounds: [] } },
+              ],
+            },
+          }),
+          getHallOfFame: vi.fn().mockResolvedValue({ payload: { players: [], classes: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+          getDraftClasses: vi.fn().mockResolvedValue({ payload: { classes: [] } }),
+          getDraftClass: vi.fn().mockResolvedValue({ payload: { model: null } }),
+        }}
+        onBack={vi.fn()}
+        onPlayerSelect={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-showing-label').textContent).toBe('2 seasons');
+    });
+
+    const yearInput = screen.getByTestId('team-history-year-filter');
+    fireEvent.change(yearInput, { target: { value: '2031' } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-showing-label').textContent).toBe('Showing 1 of 2 seasons');
+    });
+
+    const resetBtn = screen.getByTestId('team-history-reset-filters');
+    fireEvent.click(resetBtn);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('team-history-showing-label').textContent).toBe('2 seasons');
+    });
+  });
 });

--- a/src/ui/utils/dataBrowser.js
+++ b/src/ui/utils/dataBrowser.js
@@ -1,0 +1,115 @@
+/**
+ * dataBrowser.js — Reusable data-browsing helpers for search, sort, filter,
+ * and presentation across history/archive surfaces.
+ *
+ * Used by Team History, Player Profile, League History, League Activity, etc.
+ */
+
+/**
+ * Lowercase + trim for search comparison. Returns '' for nullish input.
+ * @param {*} text
+ * @returns {string}
+ */
+export function normalizeSearchText(text) {
+  if (text == null) return '';
+  return String(text).trim().toLowerCase();
+}
+
+/**
+ * Returns true when `row` matches a search query.
+ * Checks every field listed in `keys` against the normalized query.
+ *
+ * @param {object} row
+ * @param {string} query — raw user input (will be normalized)
+ * @param {string[]} keys — property names to match against
+ * @returns {boolean}
+ */
+export function rowMatchesSearch(row, query, keys) {
+  const q = normalizeSearchText(query);
+  if (!q) return true;
+  if (!row || !keys?.length) return false;
+  return keys.some((k) => {
+    const v = row[k];
+    if (v == null) return false;
+    return normalizeSearchText(v).includes(q);
+  });
+}
+
+/**
+ * Compare two values for sorting (numbers compared numerically,
+ * strings compared with localeCompare, nullish pushed to the end).
+ *
+ * @param {*} a
+ * @param {*} b
+ * @param {'asc'|'desc'} dir
+ * @returns {number}
+ */
+export function compareValues(a, b, dir = 'asc') {
+  const aNull = a == null || a === '';
+  const bNull = b == null || b === '';
+  if (aNull && bNull) return 0;
+  if (aNull) return 1;
+  if (bNull) return -1;
+
+  const aNum = Number(a);
+  const bNum = Number(b);
+  const bothNumeric = Number.isFinite(aNum) && Number.isFinite(bNum);
+
+  let cmp;
+  if (bothNumeric) {
+    cmp = aNum - bNum;
+  } else {
+    cmp = String(a).localeCompare(String(b), undefined, { sensitivity: 'base' });
+  }
+  return dir === 'desc' ? -cmp : cmp;
+}
+
+/**
+ * Stable sort that preserves original order for equal elements.
+ *
+ * @param {Array} rows
+ * @param {string} key — property to sort by
+ * @param {'asc'|'desc'} dir
+ * @returns {Array} — new sorted array
+ */
+export function stableSortRows(rows, key, dir = 'asc') {
+  if (!rows?.length || !key) return rows ?? [];
+  const indexed = rows.map((row, i) => ({ row, i }));
+  indexed.sort((a, b) => {
+    const cmp = compareValues(a.row[key], b.row[key], dir);
+    return cmp !== 0 ? cmp : a.i - b.i;
+  });
+  return indexed.map((e) => e.row);
+}
+
+/**
+ * Extract unique non-empty string values for a given key from rows.
+ * Useful for building filter dropdowns.
+ *
+ * @param {Array} rows
+ * @param {string} key
+ * @returns {string[]}
+ */
+export function uniqueFilterOptions(rows, key) {
+  if (!rows?.length || !key) return [];
+  const set = new Set();
+  for (const row of rows) {
+    const v = row[key];
+    if (v != null && v !== '') set.add(String(v));
+  }
+  return [...set].sort();
+}
+
+/**
+ * Build a "Showing X of Y items" label.
+ *
+ * @param {number} visible
+ * @param {number} total
+ * @param {string} [noun='items']
+ * @returns {string}
+ */
+export function buildShowingLabel(visible, total, noun = 'items') {
+  if (total === 0) return `No ${noun}`;
+  if (visible === total) return `${total} ${noun}`;
+  return `Showing ${visible} of ${total} ${noun}`;
+}

--- a/src/ui/utils/dataBrowser.test.js
+++ b/src/ui/utils/dataBrowser.test.js
@@ -1,0 +1,124 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeSearchText,
+  rowMatchesSearch,
+  compareValues,
+  stableSortRows,
+  uniqueFilterOptions,
+  buildShowingLabel,
+} from './dataBrowser.js';
+
+describe('dataBrowser helpers', () => {
+  describe('normalizeSearchText', () => {
+    it('lowercases and trims', () => {
+      expect(normalizeSearchText('  Hello World  ')).toBe('hello world');
+    });
+    it('returns empty string for null/undefined', () => {
+      expect(normalizeSearchText(null)).toBe('');
+      expect(normalizeSearchText(undefined)).toBe('');
+    });
+    it('coerces numbers to strings', () => {
+      expect(normalizeSearchText(2032)).toBe('2032');
+    });
+  });
+
+  describe('rowMatchesSearch', () => {
+    const row = { name: 'Aaron Rodgers', team: 'NYJ', year: 2025 };
+    it('returns true when query is empty', () => {
+      expect(rowMatchesSearch(row, '', ['name'])).toBe(true);
+      expect(rowMatchesSearch(row, '  ', ['name'])).toBe(true);
+    });
+    it('matches partial name', () => {
+      expect(rowMatchesSearch(row, 'rod', ['name', 'team'])).toBe(true);
+    });
+    it('matches team abbr', () => {
+      expect(rowMatchesSearch(row, 'nyj', ['name', 'team'])).toBe(true);
+    });
+    it('matches year as string', () => {
+      expect(rowMatchesSearch(row, '2025', ['name', 'year'])).toBe(true);
+    });
+    it('does not match unrelated text', () => {
+      expect(rowMatchesSearch(row, 'mahomes', ['name', 'team'])).toBe(false);
+    });
+    it('returns false for null row', () => {
+      expect(rowMatchesSearch(null, 'test', ['name'])).toBe(false);
+    });
+  });
+
+  describe('compareValues', () => {
+    it('sorts numbers ascending', () => {
+      expect(compareValues(3, 7, 'asc')).toBeLessThan(0);
+      expect(compareValues(10, 2, 'asc')).toBeGreaterThan(0);
+    });
+    it('sorts numbers descending', () => {
+      expect(compareValues(3, 7, 'desc')).toBeGreaterThan(0);
+    });
+    it('sorts strings with locale compare', () => {
+      expect(compareValues('alpha', 'beta', 'asc')).toBeLessThan(0);
+    });
+    it('pushes nullish to end', () => {
+      expect(compareValues(null, 5, 'asc')).toBeGreaterThan(0);
+      expect(compareValues(5, null, 'asc')).toBeLessThan(0);
+      expect(compareValues(null, null, 'asc')).toBe(0);
+    });
+  });
+
+  describe('stableSortRows', () => {
+    it('sorts by numeric key ascending', () => {
+      const rows = [{ year: 2030 }, { year: 2028 }, { year: 2032 }];
+      const sorted = stableSortRows(rows, 'year', 'asc');
+      expect(sorted.map((r) => r.year)).toEqual([2028, 2030, 2032]);
+    });
+    it('sorts by numeric key descending', () => {
+      const rows = [{ year: 2030 }, { year: 2028 }, { year: 2032 }];
+      const sorted = stableSortRows(rows, 'year', 'desc');
+      expect(sorted.map((r) => r.year)).toEqual([2032, 2030, 2028]);
+    });
+    it('preserves order for equal elements (stable)', () => {
+      const rows = [
+        { year: 2030, name: 'A' },
+        { year: 2030, name: 'B' },
+        { year: 2030, name: 'C' },
+      ];
+      const sorted = stableSortRows(rows, 'year', 'asc');
+      expect(sorted.map((r) => r.name)).toEqual(['A', 'B', 'C']);
+    });
+    it('handles empty array', () => {
+      expect(stableSortRows([], 'year', 'asc')).toEqual([]);
+    });
+    it('handles null input', () => {
+      expect(stableSortRows(null, 'year', 'asc')).toEqual([]);
+    });
+  });
+
+  describe('uniqueFilterOptions', () => {
+    it('returns sorted unique values', () => {
+      const rows = [{ type: 'trade' }, { type: 'signing' }, { type: 'trade' }, { type: 'draft' }];
+      expect(uniqueFilterOptions(rows, 'type')).toEqual(['draft', 'signing', 'trade']);
+    });
+    it('skips null/empty values', () => {
+      const rows = [{ type: 'trade' }, { type: null }, { type: '' }, { type: 'draft' }];
+      expect(uniqueFilterOptions(rows, 'type')).toEqual(['draft', 'trade']);
+    });
+    it('returns empty for empty input', () => {
+      expect(uniqueFilterOptions([], 'type')).toEqual([]);
+      expect(uniqueFilterOptions(null, 'type')).toEqual([]);
+    });
+  });
+
+  describe('buildShowingLabel', () => {
+    it('shows total when all visible', () => {
+      expect(buildShowingLabel(10, 10, 'seasons')).toBe('10 seasons');
+    });
+    it('shows filtered count', () => {
+      expect(buildShowingLabel(3, 10, 'seasons')).toBe('Showing 3 of 10 seasons');
+    });
+    it('handles zero total', () => {
+      expect(buildShowingLabel(0, 0, 'seasons')).toBe('No seasons');
+    });
+    it('uses default noun', () => {
+      expect(buildShowingLabel(5, 5)).toBe('5 items');
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds lightweight, mobile-friendly data browsing improvements to 4 high-impact dynasty-history surfaces, making FootballGMSim feel more like a serious long-term sports sim. Reuses a new shared `dataBrowser.js` utility module.

## Screens improved

| Screen | New capabilities |
|--------|-----------------|
| **Team History** (season timeline) | Sort by year/wins/losses/PF/PA, "Showing X of Y seasons" label, reset filters button |
| **Player Profile** (season log) | Sortable column headers (year, team, GP, all position-specific stats, OVR), season count |
| **League History** (season archive sidebar) | Search by year/champion, showing count, filtered sidebar |
| **League History** (Awards History tab) | Search by year/champion/award winner, sort by year asc/desc, showing count, reset |
| **League History** (League Office tab) | Search by player/team, filter by type, showing count, reset |
| **League Activity Log** | Showing count label, reset filters button |

## Fields used for search/sort/filter

- **Team History**: year, wins, losses, pf, pa, scope (champion/playoff/elite/losing)
- **Player Profile Season Log**: year, team, gamesPlayed, passYds, passTDs, ints, rushYds, rushTDs, receptions, recYds, recTDs, tackles, sacks, defInts, fgMade, xpMade, ovr
- **League History Seasons**: year, champion abbr/name
- **Awards History**: year, champion abbr/name, MVP/OPOY/DPOY/ROTY names
- **League Office Moves**: playerName, teamAbbr, headline, type

## Fallback behavior for missing data

- Empty season lists render existing `EmptyState` components safely
- No fake champion/history text — all data comes from existing archive fields
- Players without archived stats show "Season logs appear after seasons are archived" message
- Missing award winners render as "—"
- Old saves without postseason data are handled by existing caliber-based fallbacks

## Mobile UX notes

- All new inputs use compact heights (h-8/h-9) and responsive widths
- Sort buttons use minimal padding for tight mobile layouts
- Season timeline cards remain stacked with compact info density
- Search inputs expand to full width on small screens

## New utility: `src/ui/utils/dataBrowser.js`

Reusable helpers (25 unit tests):
- `normalizeSearchText` — lowercase + trim
- `rowMatchesSearch` — multi-field search matching
- `stableSortRows` — stable sort preserving original order for ties
- `compareValues` — numeric/string comparison with nullish-last semantics
- `uniqueFilterOptions` — extract filter dropdown values
- `buildShowingLabel` — "Showing X of Y items" formatting

## Tests run/results

- ✅ `npm run test:unit` — **183 files, 801 tests all pass**
- ✅ `npm run test:soak` — 5 files, 29 tests pass
- ✅ `npm run build` — production bundle succeeds
- ✅ `npm run check:deploy` — Netlify parity + rules + CLI build all pass
- ✅ `npx playwright test tests/e2e/fresh_franchise_first_week_smoke.spec.js` — E2E smoke passes
- ⚠️ `npm run audit:dynasty --ci --seed=1383` — hangs after initial output (expected: this is a long-running simulation soak unrelated to UI changes)

## What was intentionally deferred

- Draft History / Draft Class Memory data browsing
- Hall of Fame screen improvements
- Awards & Records screen improvements (standalone)
- Career totals summary in Player Profile (already exists in Career Stats tab)
- Full-text search across all history fields (kept to existing data fields only)
- Keyboard shortcuts for sort toggling

## Demo

[history_data_density_v2_demo.mp4](https://cursor.com/agents/bc-63e4c960-43e8-4d4d-bbc2-71854b2442e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_data_density_v2_demo.mp4)

[Team History sort/filter controls](https://cursor.com/agents/bc-63e4c960-43e8-4d4d-bbc2-71854b2442e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fteam_history_sort_filters.webp)
[League History season search](https://cursor.com/agents/bc-63e4c960-43e8-4d4d-bbc2-71854b2442e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fleague_history_search.webp)
[Player Profile sortable season log](https://cursor.com/agents/bc-63e4c960-43e8-4d4d-bbc2-71854b2442e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplayer_season_log_sort.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63e4c960-43e8-4d4d-bbc2-71854b2442e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63e4c960-43e8-4d4d-bbc2-71854b2442e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

