### PR TITLE
Preserve Game Book player profile context and add regression tests

### DIFF
--- a/src/ui/components/BoxScore.test.jsx
+++ b/src/ui/components/BoxScore.test.jsx
@@ -41,11 +41,19 @@ describe('BoxScore game book rendering', () => {
     expect(html).not.toContain('Special Teams');
   });
 
-  it('player buttons trigger selection handlers when ids are present', () => {
+  it('player buttons trigger selection handlers with Game Book return context when ids are present', () => {
     const onSelect = vi.fn();
-    const { container } = render(<PlayerButton player={{ playerId: 55, name: 'Tester' }} onSelect={onSelect} context={{ source: 'test' }} />);
+    const player = { playerId: 55, name: 'Tester', stats: { passYd: 123 } };
+    const { container } = render(<PlayerButton player={player} onSelect={onSelect} context={{ source: 'game-book', gameId: 'g-context', returnTo: 'game-book' }} />);
     fireEvent.click(container.querySelector('button'));
     expect(onSelect.mock.calls[0][0]).toBe(55);
+    expect(onSelect.mock.calls[0][1]).toMatchObject({
+      source: 'game-book',
+      gameId: 'g-context',
+      returnTo: 'game-book',
+      player,
+      statLine: player.stats,
+    });
   });
 
   it('top performers trigger player profile selection when ids are present', () => {
@@ -54,6 +62,14 @@ describe('BoxScore game book rendering', () => {
     const { getAllByTestId } = render(<BoxScore gameId="g4" league={{ ...baseLeague, gameById: { g4: game } }} onPlayerSelect={onSelect} embedded />);
     fireEvent.click(getAllByTestId('game-book-top-performer-link')[0]);
     expect(onSelect.mock.calls[0][0]).toBe(11);
+    expect(onSelect.mock.calls[0][1]).toMatchObject({
+      source: 'game-book',
+      gameId: 'g4',
+      week: 2,
+      seasonId: 2031,
+      role: 'Top offensive player',
+      returnTo: 'game-book',
+    });
   });
 
   it('renders Defense and scoring summary rows when detailed stats exist', () => {


### PR DESCRIPTION
### Motivation
- Ensure the Game Book / Box Score player links preserve the newer context-aware `openPlayerProfile` metadata (game id, week, seasonId, `returnTo: "game-book"`, role, player stat line) and prevent regressions after prior history-data merges.
- Verify there is no active merge conflict or accidental nested-repo/gitlink noise in the branch and add focused test coverage rather than broad UI rewrites. 

### Description
- Added assertions in `src/ui/components/BoxScore.test.jsx` to verify `PlayerButton` calls `onSelect` with the Game Book context and stat-line metadata and that top-performer links include `source`, `gameId`, `week`, `seasonId`, `role`, and `returnTo: "game-book"`.
- Inspected `src/ui/components/BoxScore.jsx` and confirmed it already uses `openPlayerProfile` and contains no conflict markers; no source edits to `BoxScore.jsx` were required.
- Verified there are no staged gitlink/submodule entries or nested `.git` checkouts in the canonical repo root and therefore no nested-repo cleanup changes were needed; committed the test-only change.
- Kept the change minimal and focused on preserving navigation/context behavior without touching simulation logic, archive schema, history data-density files, or mobile layout code.

### Testing
- Ran `npm ci` successfully in the workspace.
- Ran targeted unit tests: `npm run test:unit -- src/ui/components/BoxScore.test.jsx src/ui/components/__tests__/FranchiseHQ.test.jsx`, and both test files passed (2 files, 15 tests total).
- Verified `git diff --check` and the worktree/index are clean after committing (`Guard Game Book player profile context`).
- Attempted the first-week Playwright smoke (`npx playwright test tests/e2e/fresh_franchise_first_week_smoke.spec.js`) but it failed because Chromium was not installed in the environment, and `npx playwright install chromium` failed due to CDN/proxy returning `403 Domain forbidden` (Playwright download blocked); therefore E2E smoke and first-session smoke could not be executed here.
- `audit:dynasty --ci` was not run in this session and is therefore skipped; recommend running it in CI where the environment has network access and Playwright browsers if required.

What I intentionally deferred: full Box Score V2 layout/UI changes, play-by-play or drive charts, win-probability/EPA metrics, any simulation or archive schema changes, and broader mobile layout adjustments; this PR only secures the player-profile navigation context and adds regression tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03e98bc338832d8c532ef1f9ef3f66)