### PR TITLE
Improve completed game box score density

### DIFF
--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { EmptyState } from "./ScreenSystem.jsx";
-import { buildBoxScoreViewModel } from "../utils/boxScoreViewModel.js";
+import { buildBoxScoreViewModel, buildPlayerStatSections } from "../utils/boxScoreViewModel.js";
 import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 import { buildGameBookStory } from "../utils/gameBookStory.js";
 import { getTopPerformers } from "../utils/gameBookHighlights.js";
@@ -35,7 +35,6 @@ export function PlayerButton({ player, onSelect, context }) {
   );
 }
 
-const asNum = (v) => (Number.isFinite(Number(v)) ? Number(v) : null);
 const desc = "desc";
 const mdash = "—";
 
@@ -43,7 +42,7 @@ function tableTestId(title) {
   return `game-book-table-${title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}`;
 }
 
-function BoxScore({ gameId, league, actions, onClose, onPlayerSelect, onTeamSelect, embedded = false }) {
+function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, onTeamSelect, embedded = false }) {
   const canLoadArchive = Boolean(gameId && typeof actions?.getBoxScore === "function");
   const { data: archiveGame } = useStableRouteRequest({
     requestKey: canLoadArchive ? `boxscore:${gameId}` : null,
@@ -83,13 +82,6 @@ function BoxScore({ gameId, league, actions, onClose, onPlayerSelect, onTeamSele
   const qCount = Math.max(qHome.length, qAway.length, 4);
   const hasQuarter = qHome.length || qAway.length;
   const headers = Array.from({ length: qCount }, (_, i) => (i < 4 ? `Q${i + 1}` : `OT${i - 3}`));
-  const teamVal = (side, ...keys) => {
-    const stats = vm.teamTotals?.[side] ?? {};
-    for (const key of keys) {
-      if (stats[key] != null) return stats[key];
-    }
-    return null;
-  };
   const formatScoreAfter = (score) => {
     if (!score) return mdash;
     if (typeof score === "string") return score;
@@ -97,41 +89,30 @@ function BoxScore({ gameId, league, actions, onClose, onPlayerSelect, onTeamSele
     return mdash;
   };
 
-  const teamRows = [
-    ["Pass Yards", teamVal("away", "passYards", "passYd", "passYds"), teamVal("home", "passYards", "passYd", "passYds")],
-    ["Rush Yards", teamVal("away", "rushYards", "rushYd", "rushYds"), teamVal("home", "rushYards", "rushYd", "rushYds")],
-    ["Total Yards", teamVal("away", "totalYards"), teamVal("home", "totalYards")],
-    ["Turnovers", teamVal("away", "turnovers"), teamVal("home", "turnovers")],
-    ["Sacks", teamVal("away", "sacks"), teamVal("home", "sacks")],
-    ["Sacks Allowed", teamVal("away", "sacksAllowed"), teamVal("home", "sacksAllowed")],
-    ["Penalties", teamVal("away", "penalties"), teamVal("home", "penalties")],
-    ["First Downs", teamVal("away", "firstDowns"), teamVal("home", "firstDowns")],
-    ["Time of Possession", teamVal("away", "timePossession"), teamVal("home", "timePossession")],
-  ].filter(([, a, h]) => a != null || h != null);
-
-  const tables = [
-    { title: "Passing", defaultSort: "passYd", cols: [["passComp", "Cmp"], ["passAtt", "Att"], ["passYd", "Yds"], ["passTD", "TD"], ["interceptions", "INT"], ["sacked", "Sck"], ["passerRating", "Rate"]], include: (s) => asNum(s.passAtt) > 0 },
-    { title: "Rushing", defaultSort: "rushYd", cols: [["rushAtt", "Att"], ["rushYd", "Yds"], ["rushTD", "TD"], ["fumbles", "Fum"], ["rushLong", "Long"]], include: (s) => asNum(s.rushAtt) > 0 },
-    { title: "Receiving", defaultSort: "recYd", cols: [["targets", "Tgt"], ["receptions", "Rec"], ["recYd", "Yds"], ["recTD", "TD"], ["drops", "Drop"], ["recLong", "Long"]], include: (s) => asNum(s.receptions) > 0 || asNum(s.targets) > 0 },
-    { title: "Defense", defaultSort: "tackles", cols: [["tackles", "Tkl"], ["sacks", "Sack"], ["tfl", "TFL"], ["interceptions", "INT"], ["passesDefended", "PD"], ["forcedFumbles", "FF"], ["fumbleRecoveries", "FR"], ["defTD", "TD"]], include: (s) => asNum(s.tackles) > 0 || asNum(s.sacks) > 0 },
-    { title: "Special Teams", defaultSort: "points", cols: [["fieldGoalsMade", "FGM"], ["fieldGoalsAttempted", "FGA"], ["extraPointsMade", "XPM"], ["extraPointsAttempted", "XPA"], ["punts", "Punt"], ["puntYards", "Punt Yds"], ["kickReturns", "KR"], ["kickReturnYards", "KR Yds"], ["puntReturns", "PR"], ["puntReturnYards", "PR Yds"], ["returnTD", "TD"]], include: (s) => asNum(s.fieldGoalsAttempted) > 0 || asNum(s.extraPointsAttempted) > 0 || asNum(s.punts) > 0 || asNum(s.kickReturns) > 0 || asNum(s.puntReturns) > 0 },
-    { title: "Kicking", defaultSort: "points", cols: [["fieldGoalsMade", "FGM"], ["fieldGoalsAttempted", "FGA"], ["fieldGoalPct", "FG%"], ["extraPointsMade", "XPM"], ["extraPointsAttempted", "XPA"], ["points", "Pts"]], include: (s) => asNum(s.fieldGoalsAttempted) > 0 || asNum(s.extraPointsAttempted) > 0 },
-    { title: "Punting", defaultSort: "puntYards", cols: [["punts", "Punt"], ["puntYards", "Yds"], ["puntAvg", "Avg"], ["puntLong", "Long"], ["puntsInside20", "In20"]], include: (s) => asNum(s.punts) > 0 },
-    { title: "Returns", defaultSort: "returnYards", cols: [["kickReturns", "KR"], ["kickReturnYards", "KR Yds"], ["puntReturns", "PR"], ["puntReturnYards", "PR Yds"], ["returnTD", "TD"]], include: (s) => asNum(s.kickReturns) > 0 || asNum(s.puntReturns) > 0 },
-    { title: "Blocking", defaultSort: "passBlockWinRate", cols: [["passBlockWins", "PBW"], ["passBlockAttempts", "PBA"], ["passBlockWinRate", "PBWR"], ["runBlockWins", "RBW"], ["runBlockAttempts", "RBA"], ["runBlockWinRate", "RBWR"]], include: (s) => asNum(s.passBlockAttempts) > 0 || asNum(s.runBlockAttempts) > 0 },
+  const teamRows = vm.teamComparisonRows ?? [];
+  const dataChips = [
+    ["Score", vm.availableData?.finalScore],
+    ["Quarter", vm.availableData?.quarterScores],
+    ["Team stats", vm.availableData?.teamStats],
+    ["Player stats", vm.availableData?.playerStats],
+    ["Scoring", vm.availableData?.scoringSummary],
   ];
 
+  const tableSections = buildPlayerStatSections(vm.playerTables, sortState);
+
   const renderTable = (spec) => {
-    const sort = sortState[spec.title] ?? { key: spec.defaultSort, dir: desc };
-    const sortPlayers = (players) => [...players].sort((a, b) => ((asNum(b.stats?.[sort.key]) ?? -Infinity) - (asNum(a.stats?.[sort.key]) ?? -Infinity)) * (sort.dir === desc ? 1 : -1));
-    const away = sortPlayers((vm.playerTables?.away ?? []).filter((p) => spec.include(p.stats ?? {})));
-    const home = sortPlayers((vm.playerTables?.home ?? []).filter((p) => spec.include(p.stats ?? {})));
+    const sort = spec.sort ?? { key: spec.defaultSort, dir: desc };
+    const away = spec.teams?.away ?? [];
+    const home = spec.teams?.home ?? [];
     if (!away.length && !home.length) return null;
     const rows = [[vm.awayTeam, away], [vm.homeTeam, home]];
     return (
       <section key={spec.title} className="bs-section" data-testid={tableTestId(spec.title)}>
-        <h4>{spec.title}</h4>
-        <div className="bs-table-wrap">
+        <div className="bs-section-header">
+          <h4>{spec.title}</h4>
+          <span className="bs-section-count">{spec.showingLabel}</span>
+        </div>
+        <div className="bs-table-wrap bs-table-wrap--compact">
           <table className="box-score-table">
             <thead>
               <tr>
@@ -164,16 +145,39 @@ function BoxScore({ gameId, league, actions, onClose, onPlayerSelect, onTeamSele
   return (
     <div className={embedded ? "card" : "modal-content"}>
       <div className="box-score-header">
-        <h2>Game Book</h2>
-        {!embedded && <button type="button" className="btn" onClick={onClose}>Close</button>}
+        <div>
+          <h2>Game Book</h2>
+          <p className="bs-header-subtitle">Final score, leaders, team comparison, and recorded scoring context.</p>
+        </div>
+        <div className="bs-header-actions">
+          {embedded && onBack ? <button type="button" className="btn btn-sm btn-secondary" data-testid="game-book-back-action" onClick={onBack}>Back to flow</button> : null}
+          {!embedded && <button type="button" className="btn" onClick={onClose}>Close</button>}
+        </div>
       </div>
       <section className="bs-section bs-summary-card">
-        <h3><TeamButton team={vm.awayTeam} onSelect={onTeamSelect} /> vs <TeamButton team={vm.homeTeam} onSelect={onTeamSelect} /></h3>
-        <div className="bs-scoreline" data-testid="game-book-final-score">
-          {vm.awayTeam.abbr} {vm.finalScore.away ?? mdash} - {vm.finalScore.home ?? mdash} {vm.homeTeam.abbr}
+        <div className="bs-final-hero">
+          <div className={vm.winnerSide === "away" ? "bs-final-team is-winner" : "bs-final-team"}>
+            <span className="bs-team-kicker">Away</span>
+            <strong><TeamButton team={vm.awayTeam} onSelect={onTeamSelect} /></strong>
+            <span className="bs-final-score-number">{vm.finalScore.away ?? mdash}</span>
+          </div>
+          <div className="bs-final-center">
+            <span className="bs-final-pill">Final</span>
+            <span className="bs-final-margin">{vm.margin != null ? `${vm.margin}-point ${vm.margin === 1 ? "game" : "margin"}` : "Score pending"}</span>
+          </div>
+          <div className={vm.winnerSide === "home" ? "bs-final-team is-winner" : "bs-final-team"}>
+            <span className="bs-team-kicker">Home</span>
+            <strong><TeamButton team={vm.homeTeam} onSelect={onTeamSelect} /></strong>
+            <span className="bs-final-score-number">{vm.finalScore.home ?? mdash}</span>
+          </div>
         </div>
+        <h3>{vm.headlineSummary}</h3>
+        <div className="bs-scoreline" data-testid="game-book-final-score">{vm.finalScoreLine}</div>
         <div>Week {vm.week ?? mdash} · Season {vm.season ?? mdash}</div>
-        <span className={`status-chip ${QUALITY_BADGE_CLASS[vm.archiveQuality] ?? "muted"}`}>{vm.archiveQuality}</span>
+        <div className="bs-data-chip-row" aria-label="Recorded game data">
+          <span className={`status-chip ${QUALITY_BADGE_CLASS[vm.archiveQuality] ?? "muted"}`}>{vm.archiveQuality}</span>
+          {dataChips.map(([label, exists]) => <span key={label} className={exists ? "bs-data-chip is-available" : "bs-data-chip"}>{label}</span>)}
+        </div>
         {vm.detailWarning ? <p>{vm.detailWarning}</p> : null}
       </section>
       <section className="bs-section" data-testid="game-book-decision-summary">
@@ -228,7 +232,7 @@ function BoxScore({ gameId, league, actions, onClose, onPlayerSelect, onTeamSele
           <div className="bs-table-wrap">
             <table className="box-score-table">
               <thead><tr><th>Stat</th><th>{vm.awayTeam.abbr}</th><th>{vm.homeTeam.abbr}</th></tr></thead>
-              <tbody>{teamRows.map(([label, a, h]) => <tr key={label}><td>{label}</td><td>{a ?? mdash}</td><td>{h ?? mdash}</td></tr>)}</tbody>
+              <tbody>{teamRows.map((row) => <tr key={row.key ?? row.label}><td>{row.label}</td><td className={row.winner === "away" ? "bs-compare-value--winner" : undefined}>{row.away ?? mdash}</td><td className={row.winner === "home" ? "bs-compare-value--winner" : undefined}>{row.home ?? mdash}</td></tr>)}</tbody>
             </table>
           </div>
         ) : <p>Team totals were not recorded for this game.</p>}
@@ -259,7 +263,12 @@ function BoxScore({ gameId, league, actions, onClose, onPlayerSelect, onTeamSele
       {vm.prepImpact?.length ? (
         <section className="bs-section"><h4>Game-plan impact</h4><ul>{vm.prepImpact.map((item, i) => <li key={`${i}-${item}`}>{item}</li>)}</ul></section>
       ) : null}
-      {tables.map(renderTable)}
+      {tableSections.length ? tableSections.map(renderTable) : (
+        <section className="bs-section" data-testid="game-book-player-stats-empty">
+          <h4>Player stat tables</h4>
+          <p>Player box score rows were not recorded for this game.</p>
+        </section>
+      )}
     </div>
   );
 }

--- a/src/ui/components/BoxScore.test.jsx
+++ b/src/ui/components/BoxScore.test.jsx
@@ -94,4 +94,31 @@ describe('BoxScore game book rendering', () => {
     expect(scoringBlock?.textContent).toContain('8:12');
     expect(scoringBlock?.textContent).toContain('7-0');
   });
+
+  it('renders final score density, data availability chips, sorted player rows, and embedded back action', () => {
+    const onBack = vi.fn();
+    const game = {
+      homeId: 1,
+      awayId: 2,
+      homeScore: 30,
+      awayScore: 27,
+      teamStats: { home: { totalYards: 410, turnovers: 1 }, away: { totalYards: 350, turnovers: 2 } },
+      playerStats: {
+        home: {
+          11: { name: 'Second QB', stats: { passAtt: 15, passYd: 120 } },
+          12: { name: 'First QB', stats: { passAtt: 30, passYd: 280 } },
+        },
+        away: {},
+      },
+    };
+    const { container, getByTestId, getByText, getAllByText } = render(<BoxScore gameId="g-density" league={{ ...baseLeague, gameById: { 'g-density': game } }} onBack={onBack} embedded />);
+    expect(getByText('KC defeated BUF by 3')).toBeTruthy();
+    expect(getAllByText('Team stats').length).toBeGreaterThan(0);
+    expect(getByText('Showing 2 passers')).toBeTruthy();
+    const passingText = container.querySelector('[data-testid="game-book-table-passing"]').textContent;
+    expect(passingText.indexOf('First QB')).toBeLessThan(passingText.indexOf('Second QB'));
+    fireEvent.click(getByTestId('game-book-back-action'));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
 });

--- a/src/ui/components/WeeklyResultsCenter.jsx
+++ b/src/ui/components/WeeklyResultsCenter.jsx
@@ -29,6 +29,12 @@ function formatPeriodLabel(game) {
 
 function ResultRow({ row, seasonId, onGameSelect, source = 'weekly_results_center' }) {
   const presentation = buildCompletedGamePresentation(row.game, { seasonId, week: row.week, teamById: row.teamById, source });
+  const vm = buildBoxScoreViewModel({ game: row.game, gameId: presentation.resolvedGameId, league: { teams: Object.values(row.teamById ?? {}) }, context: { season: seasonId, week: row.week } });
+  const performers = getTopPerformers(vm);
+  const margin = Number(vm?.margin);
+  const contextLabel = Number.isFinite(margin)
+    ? (margin <= 3 ? 'Close game' : margin >= 17 ? 'Blowout' : `${margin}-point margin`)
+    : 'Final';
   const clickable = Boolean(presentation.canOpen && onGameSelect);
 
   return (
@@ -38,7 +44,11 @@ function ResultRow({ row, seasonId, onGameSelect, source = 'weekly_results_cente
         <StatusChip label={formatPeriodLabel(row.game)} tone="ok" />
       </div>
       <div className="app-game-center-card__scoreline">
-        {row.away.abbr} {row.game?.awayScore ?? '—'} @ {row.home.abbr} {row.game?.homeScore ?? '—'}
+        {vm?.finalScoreLine ?? `${row.away.abbr} ${row.game?.awayScore ?? '—'} @ ${row.home.abbr} ${row.game?.homeScore ?? '—'}`}
+      </div>
+      <div className="app-game-center-context-strip" aria-label="Game quick context">
+        <span>{contextLabel}</span>
+        <span>{performers.hasOffense ? performers.offense : 'Top player unavailable'}</span>
       </div>
       <p className="app-game-center-card__summary">{row.recap}</p>
       <div className="app-game-center-card__footer">

--- a/src/ui/components/WeeklyResultsCenter.test.jsx
+++ b/src/ui/components/WeeklyResultsCenter.test.jsx
@@ -50,6 +50,7 @@ describe('WeeklyResultsCenter', () => {
     expect(screen.getByText('Weekly League Recap')).toBeTruthy();
     expect(screen.getByText('Weekly Spotlight')).toBeTruthy();
     expect(screen.getAllByRole('button', { name: /open game book/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/close game|point margin|blowout/i).length).toBeGreaterThan(0);
   });
 
   it('shows game-plan recap and reasons when prep impact exists', () => {

--- a/src/ui/styles/style.css
+++ b/src/ui/styles/style.css
@@ -7559,6 +7559,25 @@ details[open] .nav-summary::after {
 }
 
 .bs-scoreline { font-size: 1.8rem; font-weight: 900; letter-spacing: -0.02em; }
+
+.bs-header-subtitle { margin: 2px 0 0; color: var(--text-muted); font-size: 12px; }
+.bs-header-actions { display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+.bs-final-hero { display: grid; grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr); align-items: stretch; gap: 10px; margin-bottom: 10px; }
+.bs-final-team { display: grid; gap: 4px; justify-items: center; border: 1px solid var(--hairline); border-radius: 12px; padding: 10px; background: var(--surface-strong); }
+.bs-final-team.is-winner { border-color: color-mix(in srgb, var(--accent) 62%, var(--hairline)); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent); }
+.bs-team-kicker { font-size: 10px; text-transform: uppercase; color: var(--text-subtle); letter-spacing: .08em; }
+.bs-final-score-number { font-size: clamp(2rem, 9vw, 3.25rem); line-height: .95; font-weight: 900; font-variant-numeric: tabular-nums; color: var(--text-primary); }
+.bs-final-center { display: grid; gap: 6px; align-content: center; justify-items: center; min-width: 72px; color: var(--text-muted); }
+.bs-final-margin { font-size: 11px; text-align: center; }
+.bs-data-chip-row { display: flex; flex-wrap: wrap; gap: 6px; justify-content: center; margin-top: 8px; }
+.bs-data-chip { font-size: 10px; text-transform: uppercase; letter-spacing: .06em; border: 1px solid var(--hairline); color: var(--text-subtle); border-radius: 999px; padding: 3px 8px; }
+.bs-data-chip.is-available { color: var(--text-primary); border-color: color-mix(in srgb, var(--accent) 45%, var(--hairline)); background: color-mix(in srgb, var(--accent) 10%, transparent); }
+.bs-section-count { color: var(--text-subtle); font-size: 11px; text-transform: uppercase; letter-spacing: .06em; }
+.bs-table-wrap--compact .box-score-table th:first-child,
+.bs-table-wrap--compact .box-score-table td:first-child { position: sticky; left: 0; background: var(--surface); z-index: 1; }
+.app-game-center-context-strip { display: flex; flex-wrap: wrap; gap: 6px; margin: 8px 0 2px; }
+.app-game-center-context-strip span { border: 1px solid var(--hairline); border-radius: 999px; padding: 4px 8px; color: var(--text-muted); background: var(--surface-strong); font-size: 11px; font-weight: 700; }
+
 .bs-scoreline-wrap { display: grid; gap: 4px; justify-items: center; }
 .bs-final-pill { font-size: 10px; text-transform: uppercase; letter-spacing: .08em; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--hairline); }
 .bs-team-col { display: grid; gap: 3px; justify-items: center; }
@@ -7648,6 +7667,12 @@ details[open] .nav-summary::after {
     grid-template-columns: 1fr;
     gap: 6px;
   }
+
+  .bs-final-hero { grid-template-columns: 1fr; }
+  .bs-final-center { min-width: 0; }
+  .bs-header-actions { justify-content: stretch; }
+  .bs-header-actions .btn { flex: 1; }
+
   .bs-quick-nav { top: 58px; }
   .bs-facts-grid { grid-template-columns: 1fr 1fr; }
 

--- a/src/ui/utils/boxScoreViewModel.js
+++ b/src/ui/utils/boxScoreViewModel.js
@@ -7,6 +7,8 @@ const toNum = (v) => {
   return Number.isFinite(n) ? n : null;
 };
 
+const mdash = '—';
+
 function teamInfo(league, id, side, game) {
   const team = (league?.teams ?? []).find((t) => Number(t?.id) === Number(id)) ?? league?.teamById?.[id] ?? null;
   return {
@@ -21,6 +23,124 @@ function normalizePlayers(raw = {}, side, teamId) {
   return Object.entries(raw || {}).map(([id, row]) => ({ playerId: Number(id), teamId, teamSide: side, ...row, stats: row?.stats ?? row ?? {} }));
 }
 
+function formatScoreLine(awayTeam, homeTeam, finalScore) {
+  return `${awayTeam?.abbr ?? 'AWY'} ${finalScore?.away ?? mdash} - ${finalScore?.home ?? mdash} ${homeTeam?.abbr ?? 'HME'}`;
+}
+
+function buildHeadline({ awayTeam, homeTeam, finalScore, status }) {
+  const away = toNum(finalScore?.away);
+  const home = toNum(finalScore?.home);
+  if (away == null || home == null) return status === 'Final' ? 'Final score unavailable' : 'Game not final';
+  if (away === home) return `${awayTeam?.abbr ?? 'Away'} and ${homeTeam?.abbr ?? 'Home'} finished tied`;
+  const winner = away > home ? awayTeam : homeTeam;
+  const loser = away > home ? homeTeam : awayTeam;
+  return `${winner?.abbr ?? 'Winner'} defeated ${loser?.abbr ?? 'Opponent'} by ${Math.abs(away - home)}`;
+}
+
+function teamStatValue(teamTotals, side, keys) {
+  const stats = teamTotals?.[side] ?? {};
+  for (const key of keys) {
+    if (stats[key] != null) return stats[key];
+  }
+  return null;
+}
+
+function formatThirdDown(stats) {
+  const made = stats?.thirdDownMade;
+  const att = stats?.thirdDownAtt;
+  if (made == null && att == null) return null;
+  return `${made ?? 0}/${att ?? 0}`;
+}
+
+function formatRedZone(stats) {
+  const made = stats?.redZoneMade ?? stats?.redZoneScores;
+  const att = stats?.redZoneAtt ?? stats?.redZoneTrips;
+  if (made == null && att == null) return null;
+  return `${made ?? 0}/${att ?? 0}`;
+}
+
+function buildTeamComparisonRows(teamTotals = {}) {
+  const rows = [
+    { key: 'totalYards', label: 'Total Yards', away: teamStatValue(teamTotals, 'away', ['totalYards']), home: teamStatValue(teamTotals, 'home', ['totalYards']), higherIsBetter: true },
+    { key: 'passYards', label: 'Pass Yards', away: teamStatValue(teamTotals, 'away', ['passYards', 'passYd', 'passYds']), home: teamStatValue(teamTotals, 'home', ['passYards', 'passYd', 'passYds']), higherIsBetter: true },
+    { key: 'rushYards', label: 'Rush Yards', away: teamStatValue(teamTotals, 'away', ['rushYards', 'rushYd', 'rushYds']), home: teamStatValue(teamTotals, 'home', ['rushYards', 'rushYd', 'rushYds']), higherIsBetter: true },
+    { key: 'plays', label: 'Plays', away: teamStatValue(teamTotals, 'away', ['plays']), home: teamStatValue(teamTotals, 'home', ['plays']), higherIsBetter: true },
+    { key: 'yardsPerPlay', label: 'Yards/Play', away: teamStatValue(teamTotals, 'away', ['yardsPerPlay']), home: teamStatValue(teamTotals, 'home', ['yardsPerPlay']), higherIsBetter: true },
+    { key: 'turnovers', label: 'Turnovers', away: teamStatValue(teamTotals, 'away', ['turnovers']), home: teamStatValue(teamTotals, 'home', ['turnovers']), higherIsBetter: false },
+    { key: 'sacks', label: 'Sacks', away: teamStatValue(teamTotals, 'away', ['sacks']), home: teamStatValue(teamTotals, 'home', ['sacks']), higherIsBetter: true },
+    { key: 'sacksAllowed', label: 'Sacks Allowed', away: teamStatValue(teamTotals, 'away', ['sacksAllowed']), home: teamStatValue(teamTotals, 'home', ['sacksAllowed']), higherIsBetter: false },
+    { key: 'penalties', label: 'Penalties', away: teamStatValue(teamTotals, 'away', ['penalties']), home: teamStatValue(teamTotals, 'home', ['penalties']), higherIsBetter: false },
+    { key: 'firstDowns', label: 'First Downs', away: teamStatValue(teamTotals, 'away', ['firstDowns']), home: teamStatValue(teamTotals, 'home', ['firstDowns']), higherIsBetter: true },
+    { key: 'thirdDown', label: 'Third Down', away: formatThirdDown(teamTotals.away), home: formatThirdDown(teamTotals.home), compareAway: teamStatValue(teamTotals, 'away', ['thirdDownMade']), compareHome: teamStatValue(teamTotals, 'home', ['thirdDownMade']), higherIsBetter: true },
+    { key: 'redZone', label: 'Red Zone', away: formatRedZone(teamTotals.away), home: formatRedZone(teamTotals.home), compareAway: teamStatValue(teamTotals, 'away', ['redZoneMade', 'redZoneScores']), compareHome: teamStatValue(teamTotals, 'home', ['redZoneMade', 'redZoneScores']), higherIsBetter: true },
+    { key: 'timePossession', label: 'Time of Possession', away: teamStatValue(teamTotals, 'away', ['timePossession']), home: teamStatValue(teamTotals, 'home', ['timePossession']), higherIsBetter: true },
+  ].filter((row) => row.away != null || row.home != null);
+
+  return rows.map((row) => {
+    const awayNum = toNum(row.compareAway ?? row.away);
+    const homeNum = toNum(row.compareHome ?? row.home);
+    let winner = null;
+    if (awayNum != null && homeNum != null && awayNum !== homeNum) {
+      winner = row.higherIsBetter === false
+        ? (awayNum < homeNum ? 'away' : 'home')
+        : (awayNum > homeNum ? 'away' : 'home');
+    }
+    return { ...row, winner };
+  });
+}
+
+const PLAYER_SECTION_SPECS = [
+  { key: 'passing', title: 'Passing', defaultSort: 'passYd', countLabel: 'passers', cols: [['passComp', 'Cmp'], ['passAtt', 'Att'], ['passYd', 'Yds'], ['passTD', 'TD'], ['interceptions', 'INT'], ['sacked', 'Sck'], ['passerRating', 'Rate']], include: (s) => toNum(s.passAtt) > 0 },
+  { key: 'rushing', title: 'Rushing', defaultSort: 'rushYd', countLabel: 'rushers', cols: [['rushAtt', 'Att'], ['rushYd', 'Yds'], ['rushTD', 'TD'], ['fumbles', 'Fum'], ['rushLong', 'Long']], include: (s) => toNum(s.rushAtt) > 0 },
+  { key: 'receiving', title: 'Receiving', defaultSort: 'recYd', countLabel: 'receivers', cols: [['targets', 'Tgt'], ['receptions', 'Rec'], ['recYd', 'Yds'], ['recTD', 'TD'], ['drops', 'Drop'], ['recLong', 'Long']], include: (s) => toNum(s.receptions) > 0 || toNum(s.targets) > 0 },
+  { key: 'defense', title: 'Defense', defaultSort: 'tackles', countLabel: 'defenders', cols: [['tackles', 'Tkl'], ['sacks', 'Sack'], ['tfl', 'TFL'], ['interceptions', 'INT'], ['passesDefended', 'PD'], ['forcedFumbles', 'FF'], ['fumbleRecoveries', 'FR'], ['defTD', 'TD']], include: (s) => toNum(s.tackles) > 0 || toNum(s.sacks) > 0 || toNum(s.interceptions) > 0 || toNum(s.passesDefended) > 0 || toNum(s.forcedFumbles) > 0 },
+  { key: 'specialTeams', title: 'Special Teams', defaultSort: 'points', countLabel: 'specialists', cols: [['fieldGoalsMade', 'FGM'], ['fieldGoalsAttempted', 'FGA'], ['extraPointsMade', 'XPM'], ['extraPointsAttempted', 'XPA'], ['punts', 'Punt'], ['puntYards', 'Punt Yds'], ['kickReturns', 'KR'], ['kickReturnYards', 'KR Yds'], ['puntReturns', 'PR'], ['puntReturnYards', 'PR Yds'], ['returnTD', 'TD']], include: (s) => toNum(s.fieldGoalsAttempted) > 0 || toNum(s.extraPointsAttempted) > 0 || toNum(s.punts) > 0 || toNum(s.kickReturns) > 0 || toNum(s.puntReturns) > 0 },
+  { key: 'kicking', title: 'Kicking', defaultSort: 'points', countLabel: 'kickers', cols: [['fieldGoalsMade', 'FGM'], ['fieldGoalsAttempted', 'FGA'], ['fieldGoalPct', 'FG%'], ['extraPointsMade', 'XPM'], ['extraPointsAttempted', 'XPA'], ['points', 'Pts']], include: (s) => toNum(s.fieldGoalsAttempted) > 0 || toNum(s.extraPointsAttempted) > 0 },
+  { key: 'punting', title: 'Punting', defaultSort: 'puntYards', countLabel: 'punters', cols: [['punts', 'Punt'], ['puntYards', 'Yds'], ['puntAvg', 'Avg'], ['puntLong', 'Long'], ['puntsInside20', 'In20']], include: (s) => toNum(s.punts) > 0 },
+  { key: 'returns', title: 'Returns', defaultSort: 'returnYards', countLabel: 'returners', cols: [['kickReturns', 'KR'], ['kickReturnYards', 'KR Yds'], ['puntReturns', 'PR'], ['puntReturnYards', 'PR Yds'], ['returnTD', 'TD']], include: (s) => toNum(s.kickReturns) > 0 || toNum(s.puntReturns) > 0 },
+  { key: 'blocking', title: 'Blocking', defaultSort: 'passBlockWinRate', countLabel: 'blockers', cols: [['passBlockWins', 'PBW'], ['passBlockAttempts', 'PBA'], ['passBlockWinRate', 'PBWR'], ['runBlockWins', 'RBW'], ['runBlockAttempts', 'RBA'], ['runBlockWinRate', 'RBWR']], include: (s) => toNum(s.passBlockAttempts) > 0 || toNum(s.runBlockAttempts) > 0 },
+];
+
+function sortPlayers(players, sortKey, dir = 'desc') {
+  const direction = dir === 'asc' ? 1 : -1;
+  return [...players].sort((a, b) => {
+    const aVal = toNum(a?.stats?.[sortKey]) ?? -Infinity;
+    const bVal = toNum(b?.stats?.[sortKey]) ?? -Infinity;
+    const delta = (aVal - bVal) * direction;
+    if (delta !== 0) return delta;
+    return String(a?.name ?? '').localeCompare(String(b?.name ?? '')) || Number(a?.playerId ?? 0) - Number(b?.playerId ?? 0);
+  });
+}
+
+export function buildPlayerStatSections(playerTables = {}, sortOverrides = {}) {
+  return PLAYER_SECTION_SPECS.map((spec) => {
+    const sort = sortOverrides[spec.title] ?? { key: spec.defaultSort, dir: 'desc' };
+    const away = sortPlayers((playerTables.away ?? []).filter((p) => spec.include(p.stats ?? {})), sort.key, sort.dir);
+    const home = sortPlayers((playerTables.home ?? []).filter((p) => spec.include(p.stats ?? {})), sort.key, sort.dir);
+    return {
+      ...spec,
+      sort,
+      teams: { away, home },
+      totalPlayers: away.length + home.length,
+      empty: away.length === 0 && home.length === 0,
+      showingLabel: `Showing ${away.length + home.length} ${spec.countLabel}`,
+    };
+  }).filter((section) => !section.empty);
+}
+
+function normalizeScoringSummary(rows) {
+  if (!Array.isArray(rows)) return [];
+  return rows.map((row, idx) => ({
+    id: row?.id ?? `score-${idx}`,
+    quarter: row?.quarter ?? row?.period ?? null,
+    time: row?.time ?? row?.clock ?? null,
+    teamAbbr: row?.teamAbbr ?? row?.team ?? null,
+    type: row?.type ?? row?.scoreType ?? null,
+    description: row?.description ?? row?.text ?? null,
+    scoreAfter: row?.scoreAfter ?? row?.runningScore ?? row?.score ?? null,
+  }));
+}
+
 export function buildBoxScoreViewModel({ league, game, gameId, context = {} } = {}) {
   const payload = normalizeArchivedGamePayload(game ?? null) ?? game ?? null;
   if (!payload) {
@@ -31,7 +151,7 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {} } = 
   const homeScore = toNum(payload?.homeScore);
   const awayScore = toNum(payload?.awayScore);
   const quarterScores = payload?.quarterScores ?? null;
-  const scoringSummary = Array.isArray(payload?.scoringSummary) ? payload.scoringSummary : [];
+  const scoringSummary = normalizeScoringSummary(payload?.scoringSummary);
   const teamStats = payload?.teamStats ?? payload?.stats?.team ?? {};
   const playerStats = payload?.playerStats ?? payload?.stats?.players ?? payload?.stats ?? {};
   const homePlayers = normalizePlayers(playerStats?.home, 'home', homeId);
@@ -48,19 +168,41 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {} } = 
   else if (hasScore && (hasQuarter || hasTeamTotals || hasPlayerStats || hasScoringSummary)) archiveQuality = QUALITY.partial;
   else if (hasScore) archiveQuality = QUALITY.score;
 
+  const awayTeam = teamInfo(league, awayId, 'away', payload);
+  const homeTeam = teamInfo(league, homeId, 'home', payload);
+  const finalScore = { home: homeScore, away: awayScore };
+  const teamTotals = { home: teamStats?.home ?? {}, away: teamStats?.away ?? {} };
+  const playerTables = { home: homePlayers, away: awayPlayers };
+  const winnerSide = hasScore && awayScore !== homeScore ? (awayScore > homeScore ? 'away' : 'home') : null;
+
   return {
     gameId: payload?.gameId ?? payload?.id ?? gameId ?? null,
     season: payload?.seasonId ?? context?.season ?? league?.seasonId ?? null,
     week: payload?.week ?? context?.week ?? null,
-    status: payload?.played ? 'Final' : 'Scheduled',
+    status: payload?.played === false ? 'Scheduled' : 'Final',
     archiveQuality,
-    homeTeam: teamInfo(league, homeId, 'home', payload),
-    awayTeam: teamInfo(league, awayId, 'away', payload),
-    finalScore: { home: homeScore, away: awayScore },
+    homeTeam,
+    awayTeam,
+    finalScore,
+    finalScoreLine: formatScoreLine(awayTeam, homeTeam, finalScore),
+    headlineSummary: buildHeadline({ awayTeam, homeTeam, finalScore, status: payload?.played === false ? 'Scheduled' : 'Final' }),
+    winnerSide,
+    margin: hasScore ? Math.abs(homeScore - awayScore) : null,
     quarterScores,
-    teamTotals: { home: teamStats?.home ?? {}, away: teamStats?.away ?? {} },
+    teamTotals,
+    teamComparisonRows: buildTeamComparisonRows(teamTotals),
     scoringSummary,
-    playerTables: { home: homePlayers, away: awayPlayers },
+    playerTables,
+    playerStatSections: buildPlayerStatSections(playerTables),
+    availableData: {
+      finalScore: hasScore,
+      quarterScores: hasQuarter,
+      teamStats: hasTeamTotals,
+      playerStats: hasPlayerStats,
+      scoringSummary: hasScoringSummary,
+      playByPlay: Array.isArray(payload?.playLog) && payload.playLog.length > 0,
+      drives: Array.isArray(payload?.driveSummary) && payload.driveSummary.length > 0,
+    },
     prepImpact: Array.isArray(payload?.prepImpact) ? payload.prepImpact : (payload?.prepImpact ? [String(payload.prepImpact)] : []),
     detailWarning: archiveQuality === QUALITY.partial ? 'Partial archive: some Game Book sections were not recorded.' : archiveQuality === QUALITY.score ? 'Detailed box score data was not recorded for this game.' : archiveQuality === QUALITY.missing ? 'Game data missing.' : null,
     missingDetailReason: archiveQuality === QUALITY.partial ? 'Partial archive: some Game Book sections were not recorded.' : archiveQuality === QUALITY.score ? 'Detailed box score data was not recorded for this game.' : archiveQuality === QUALITY.missing ? 'Game data missing.' : null,

--- a/src/ui/utils/boxScoreViewModel.test.js
+++ b/src/ui/utils/boxScoreViewModel.test.js
@@ -32,4 +32,54 @@ describe('buildBoxScoreViewModel', () => {
     expect(story).toContain('turnover battle');
     expect(story).toContain('294 passing yards');
   });
+
+  it('builds final score headline and team comparison rows from existing stats only', () => {
+    const vm = buildBoxScoreViewModel({
+      league: { teams: [{ id: 1, abbr: 'KC' }, { id: 2, abbr: 'BUF' }] },
+      game: {
+        played: true,
+        homeId: 1,
+        awayId: 2,
+        homeScore: 24,
+        awayScore: 27,
+        teamStats: { home: { totalYards: 330, turnovers: 2 }, away: { totalYards: 360, turnovers: 0 } },
+      },
+    });
+    expect(vm.finalScoreLine).toBe('BUF 27 - 24 KC');
+    expect(vm.headlineSummary).toBe('BUF defeated KC by 3');
+    expect(vm.teamComparisonRows.map((row) => row.label)).toEqual(['Total Yards', 'Turnovers']);
+    expect(vm.teamComparisonRows.find((row) => row.key === 'turnovers')?.winner).toBe('away');
+  });
+
+  it('builds sorted player stat sections with stable defaults', () => {
+    const vm = buildBoxScoreViewModel({
+      game: {
+        homeId: 1,
+        awayId: 2,
+        homeScore: 14,
+        awayScore: 10,
+        playerStats: {
+          home: {
+            10: { name: 'Lower QB', stats: { passAtt: 20, passYd: 150 } },
+            11: { name: 'Higher QB', stats: { passAtt: 25, passYd: 240 } },
+          },
+          away: {
+            20: { name: 'Away RB', stats: { rushAtt: 15, rushYd: 80 } },
+          },
+        },
+      },
+    });
+    const passing = vm.playerStatSections.find((section) => section.key === 'passing');
+    expect(passing?.showingLabel).toBe('Showing 2 passers');
+    expect(passing?.teams.home.map((player) => player.name)).toEqual(['Higher QB', 'Lower QB']);
+    expect(vm.playerStatSections.find((section) => section.key === 'rushing')?.teams.away[0].name).toBe('Away RB');
+  });
+
+  it('does not render quarter/scoring availability when old archives omit those sections', () => {
+    const vm = buildBoxScoreViewModel({ game: { homeId: 1, awayId: 2, homeScore: 6, awayScore: 3 } });
+    expect(vm.archiveQuality).toBe('Score only');
+    expect(vm.availableData.quarterScores).toBe(false);
+    expect(vm.availableData.scoringSummary).toBe(false);
+    expect(vm.playerStatSections).toEqual([]);
+  });
 });


### PR DESCRIPTION
### Motivation
- Completed-game presentation felt sparse and ad-hoc, making it harder to scan final scores, leaders, and team comparisons on mobile and desktop.
- Need a view-model that derives stable, display-safe sections (headline, final score line, team comparison, top performers, player stat groups) while preserving old-save fallbacks and not altering simulation data.

### Description
- Added/extended pure view-model helpers in `src/ui/utils/boxScoreViewModel.js` to produce: final score line, headline summary, winner side, margin, `teamComparisonRows`, normalized `scoringSummary`, `availableData` flags, `playerStatSections` (stable sorted groups), and compact `playerTables` mapping; this keeps presentation logic out of the UI and preserves backward compatibility.
- Reworked `BoxScore` UI (`src/ui/components/BoxScore.jsx`) to use the new view-model: stronger final-score hero with winner emphasis, recorded-data chips, headline summary, team comparison highlighting, compact grouped player stat tables with "Showing X players", sortable columns, clear empty states for missing player rows, and an embedded `Back to flow` action when rendered in-panel.
- Enhanced `WeeklyResultsCenter` (`src/ui/components/WeeklyResultsCenter.jsx`) to show quick game context for completed cards using the same view-model (final score line, close/blowout/margin label, and top offensive performer when available).
- Added smaller, mobile-first CSS for the new density UI (data chips, hero layout, compact table behavior) in `src/ui/styles/style.css`.
- Tests updated/added to assert: VM headline/final score, team comparison rows, stable player-stat sorting and section labels, safe fallbacks for old archives, BoxScore embedded back action, and WeeklyResults quick context.

### Testing
- Ran `npm ci` (noting npm proxy warning) — success.
- Syntax checks: `node --check src/ui/utils/boxScorePresentation.js` and `node --check src/ui/utils/boxScoreViewModel.js` — passed.
- Unit tests (targeted): `npm run test:unit -- src/ui/utils/boxScorePresentation.test.js src/ui/utils/boxScoreViewModel.test.js` — passed.
- Component/unit tests: `npm run test:unit -- src/ui/components/BoxScore.test.jsx src/ui/components/GameDetailScreen.test.jsx src/ui/components/game/GameDetailV2.test.tsx src/ui/components/PostGameScreen.test.jsx src/ui/components/WeeklyResultsCenter.test.jsx` — passed.
- Full unit suite: `npm run test:unit` — all tests passed (191 files, 853 tests).
- Soak tests: `npm run test:soak` — passed (6 files / 40 tests).
- Dynasty audit: `npm run audit:dynasty -- --ci --seed=1383` — passed (runtime ~18.94s) with an unrelated early-league `hof_empty_young` warning reported.
- Build: `npm run build` — success with expected large-chunk warning (>500KB) (no functional errors).
- Netlify parity: `npm run check:deploy` — passed offline parity checks and preview build.
- E2E smoke: `npm run test -- tests/e2e/fresh_franchise_first_week_smoke.spec.js` — failed to run because Playwright Chromium binary could not be downloaded in this environment (CDN/proxy returned 403); attempted `npx playwright install --with-deps chromium` installed OS deps but the browser download was blocked by CDN/proxy, so Playwright E2E was not executed here.

Notes: Playwright browser download failure is environmental (proxy/CDN 403), not code-related; all unit/soak/audit/build checks that the PR requires have passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04873a8a90832db32c8548b383713f)