### PR TITLE
Add multi-seed dynasty stability audit (multi-seed-ci + long-ci)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "check:netlify-cli-build": "npx --yes netlify-cli@latest build --context production --offline",
     "check:netlify-rules": "node scripts/validate-netlify-rules.mjs",
     "check:deploy": "npm run check:netlify-parity && npm run check:netlify-rules && npm run check:netlify-cli-build && npm run check:netlify-cli-build:preview",
-    "check:netlify-cli-build:preview": "npx --yes netlify-cli@latest build --context deploy-preview --offline"
+    "check:netlify-cli-build:preview": "npx --yes netlify-cli@latest build --context deploy-preview --offline",
+    "audit:dynasty:multi": "npm run audit:dynasty -- --audit-profile=multi-seed-ci"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/dynasty-soak.mjs
+++ b/scripts/dynasty-soak.mjs
@@ -31,22 +31,38 @@ async function main() {
     return;
   }
 
-  const { runDynastySoakOnce } = await import('../src/testSupport/dynastySoakRunner.js');
+  const { runDynastySoakOnce, runDynastySoakMultiSeed } = await import('../src/testSupport/dynastySoakRunner.js');
 
   console.log(
-    `[dynasty-soak] profile=${resolved.auditProfile} seed=${resolved.seed} seasons=${resolved.seasons}${resolved.ci ? ' (ci short path)' : ''} deep=${resolved.deep} deepEachSeason=${resolved.deepEachSeason}`,
+    `[dynasty-soak] profile=${resolved.auditProfile} runnerProfile=${resolved.runnerProfile} seeds=${resolved.seeds.join(',')} seasons=${resolved.seasons}${resolved.ci ? ' (ci short path)' : ''} deep=${resolved.deep} deepEachSeason=${resolved.deepEachSeason}`,
   );
-  if (resolved.auditProfile === 'full') {
+  if (resolved.auditProfile === 'full' || resolved.isLongProfile) {
     console.warn(
       '[dynasty-soak] full profile is a manual full-season SIM_TO_PHASE audit; a single worker request may run for a long time before --max-runtime-ms is checked.',
     );
   }
-  const result = await runDynastySoakOnce(resolved);
+  if (resolved.isLongProfile) {
+    console.warn('[dynasty-soak] long-ci/stability is optional/manual and is not part of default push CI.');
+  }
+
+  const result = resolved.isMultiSeed
+    ? await runDynastySoakMultiSeed({
+        ...resolved,
+        onSeedStart(seed, index, total) {
+          console.log(`[dynasty-soak] seed ${index}/${total} start seed=${seed}`);
+        },
+        onSeedComplete(seedResult, index, total) {
+          console.log(`[dynasty-soak] seed ${index}/${total} done seed=${seedResult.seed} passed=${seedResult.passed} runtimeMs=${seedResult.runtimeMs} failures=${seedResult.failures?.length ?? 0} warnings=${seedResult.warnings?.length ?? 0}`);
+        },
+      })
+    : await runDynastySoakOnce(resolved);
 
   const { outDir } = await writeDynastySoakReports(result, resolved.outDir || 'artifacts/dynasty-soak');
 
   console.log(
-    `[dynasty-soak] passed=${result.passed} runtimeMs=${result.runtimeMs} failures=${result.failures?.length ?? 0} warnings=${result.warnings?.length ?? 0}`,
+    result.multiSeed
+      ? `[dynasty-soak] passed=${result.passed} seeds=${result.seedCount} pass=${result.passCount} fail=${result.failCount} runtimeMs=${result.runtimeMs} warningSeeds=${result.warningSeedCount}`
+      : `[dynasty-soak] passed=${result.passed} runtimeMs=${result.runtimeMs} failures=${result.failures?.length ?? 0} warnings=${result.warnings?.length ?? 0}`,
   );
   if (result.failures?.length) {
     for (const f of result.failures.slice(0, 20)) {
@@ -58,7 +74,7 @@ async function main() {
       console.warn(`  WARN ${w.code}: ${w.message}`);
     }
   }
-  console.log(`[dynasty-soak] reports -> ${outDir}/latest.{json,md}`);
+  console.log(`[dynasty-soak] reports -> ${outDir}/latest.{json,md}${result.multiSeed ? ' and latest-multi-seed.{json,md}' : ''}`);
 
   if (!result.passed) {
     process.exitCode = 1;

--- a/src/core/dynastySoakAudit.js
+++ b/src/core/dynastySoakAudit.js
@@ -548,6 +548,12 @@ export function runDynastySoakAudit(input = {}) {
   const leagueHistory = viewState?.leagueHistory ?? [];
   const incomingTradeOffers = Array.isArray(viewState?.incomingTradeOffers) ? viewState.incomingTradeOffers : [];
 
+  const expectedTeamCount = input.expectedTeamCount == null ? null : Number(input.expectedTeamCount);
+  if (Number.isFinite(expectedTeamCount) && teams.length !== expectedTeamCount) {
+    fail('team_count_unstable', `Expected ${expectedTeamCount} teams, found ${teams.length}`);
+    bumpSummary(summary, 'historyHealth', 'fail');
+  }
+
   // --- Phase / user / schedule ---
   if (userTeamId == null || userTeamId === '') {
     fail('user_team_missing', 'userTeamId is missing from view state');
@@ -567,6 +573,15 @@ export function runDynastySoakAudit(input = {}) {
     }
     if (metaPhase === 'regular' && standings.length === 0) {
       fail('standings_empty', 'Standings empty during regular season');
+      bumpSummary(summary, 'historyHealth', 'fail');
+    }
+  }
+  for (const row of standings) {
+    const wins = num(row?.wins);
+    const losses = num(row?.losses);
+    const ties = num(row?.ties ?? 0);
+    if (isBadNum(wins) || isBadNum(losses) || isBadNum(ties) || wins < 0 || losses < 0 || ties < 0) {
+      fail('standings_impossible', `Team ${row?.id ?? row?.teamId ?? 'unknown'} has invalid standings values`, { wins, losses, ties });
       bumpSummary(summary, 'historyHealth', 'fail');
     }
   }
@@ -678,12 +693,41 @@ export function runDynastySoakAudit(input = {}) {
   }
 
   // --- League history / champion ---
+  if (Array.isArray(leagueHistory) && leagueHistory.length) {
+    const seenSeasonIds = new Set();
+    for (let i = 0; i < leagueHistory.length; i += 1) {
+      const season = leagueHistory[i];
+      const seasonId = season?.id ?? season?.seasonId ?? `${season?.year ?? 'unknown'}:${i}`;
+      if (seenSeasonIds.has(String(seasonId))) {
+        fail('season_archive_duplicate', `Duplicate completed-season archive id ${seasonId}`);
+        bumpSummary(summary, 'archiveHealth', 'fail');
+      }
+      seenSeasonIds.add(String(seasonId));
+      if (!season?.champion && (season?.standings?.length ?? 0) > 0) {
+        fail('champion_missing', `Completed season archive ${seasonId} has standings but no champion`, { seasonId });
+        bumpSummary(summary, 'historyHealth', 'fail');
+      }
+      if (season?.champion && !season?.playoffBracketSnapshot) {
+        warn('playoff_bracket_snapshot_missing', `Completed season archive ${seasonId} has a champion but no playoffBracketSnapshot`, { seasonId });
+        bumpSummary(summary, 'archiveHealth', 'warn');
+      }
+      if (!season?.playerSeasonStatsV1) {
+        warn('player_season_stats_archive_missing', `Completed season archive ${seasonId} missing playerSeasonStatsV1`, { seasonId });
+        bumpSummary(summary, 'archiveHealth', 'warn');
+      }
+      if (!season?.transactionTimelineV1) {
+        warn('transaction_timeline_archive_missing', `Completed season archive ${seasonId} missing transactionTimelineV1`, { seasonId });
+        bumpSummary(summary, 'transactionHealth', 'warn');
+      }
+    }
+    if (seasonIndex > 0 && leagueHistory.length < seasonIndex) {
+      warn('season_archive_missing_count', `Completed season archive count ${leagueHistory.length} < seasonIndex ${seasonIndex}`);
+      bumpSummary(summary, 'archiveHealth', 'warn');
+    }
+  }
+
   const latest = latestCompletedSeasonSummary(leagueHistory);
   if (latest && seasonIndex > 0) {
-    if (!latest.champion && (latest.standings?.length ?? 0) > 0) {
-      fail('champion_missing', 'Latest leagueHistory entry has standings but no champion', { seasonId: latest.seasonId });
-      bumpSummary(summary, 'historyHealth', 'fail');
-    }
     const v1 = validatePlayerSeasonStatsV1Shape(latest.playerSeasonStatsV1);
     if (!v1.ok) {
       for (const e of v1.errors) fail('player_season_stats_shape', e);
@@ -703,6 +747,30 @@ export function runDynastySoakAudit(input = {}) {
         if (String(pos).toUpperCase() === 'QB' && qbInt > 40 && defInt > 40) {
           warn('qb_int_def_int_sanity', 'Unusually high QB pass INT and defensive INT columns on same row', { playerId: row.playerId });
           bumpSummary(summary, 'statHealth', 'warn');
+        }
+      }
+    }
+    if (Array.isArray(latest.games)) {
+      const seenGameIds = new Set();
+      for (const game of latest.games.slice(0, 400)) {
+        const gameId = game?.id ?? game?.gameId ?? null;
+        if (gameId != null) {
+          const key = String(gameId);
+          if (seenGameIds.has(key)) {
+            fail('game_archive_duplicate', `Duplicate game archive row ${key}`);
+            bumpSummary(summary, 'archiveHealth', 'fail');
+          }
+          seenGameIds.add(key);
+        }
+        const homeScore = num(game?.homeScore ?? game?.home?.score);
+        const awayScore = num(game?.awayScore ?? game?.away?.score);
+        if ((game?.homeScore != null || game?.awayScore != null) && (isBadNum(homeScore) || isBadNum(awayScore) || homeScore < 0 || awayScore < 0)) {
+          fail('game_archive_score_malformed', `Game archive row ${gameId ?? '(no id)'} has invalid score`, { homeScore, awayScore });
+          bumpSummary(summary, 'archiveHealth', 'fail');
+        }
+        if (game?.boxScore != null && (typeof game.boxScore !== 'object' || Array.isArray(game.boxScore))) {
+          fail('box_score_archive_malformed', `Game archive row ${gameId ?? '(no id)'} has malformed boxScore`);
+          bumpSummary(summary, 'archiveHealth', 'fail');
         }
       }
     }

--- a/src/testSupport/dynastySoakCli.js
+++ b/src/testSupport/dynastySoakCli.js
@@ -10,9 +10,12 @@ export const DYNASTY_SOAK_USAGE = `Usage: npm run audit:dynasty -- [options]
 
 Options:
   --ci                    Alias for --audit-profile=ci (fast real-worker smoke audit)
-  --audit-profile=ci|full Profile to run: ci=short partial phase path, full=legacy full-season manual audit
-  --seasons=N             Number of seasons to simulate with --audit-profile=full (default: 5; CI uses a short path)
-  --seed=N                RNG seed (default: 1383)
+  --audit-profile=ci|full|multi-seed-ci|long-ci|stability
+                          Profile to run: ci=short partial phase path, full=legacy manual audit, multi-seed-ci=3 short deterministic seeds, long-ci/stability=bounded 3-season manual audit
+  --seasons=N             Number of seasons to simulate with --audit-profile=full/long-ci/stability (default: full=5, long-ci=3; CI uses a short path)
+  --seed=N                RNG seed for single-seed profiles (default: 1383)
+  --seeds=A,B,C           Comma-separated seeds for multi-seed profiles (default: 1383,1408,1426)
+  --fail-on-warnings      Treat warnings as a failing audit exit for manual strict mode (default: false)
   --outDir=PATH           Report output directory (default: artifacts/dynasty-soak)
   --deep                  Full final-season probes plus larger transaction/draft/archive samples
   --deep-each-season      Full GET_* probes every season (slowest; matches legacy harness)
@@ -38,6 +41,27 @@ function parseRequiredNumber(flag, value, errors) {
   return { ok: true, value: numberValue };
 }
 
+export const DEFAULT_MULTI_SEED_CI_SEEDS = [1383, 1408, 1426];
+
+export function parseSeedList(value, errors = []) {
+  const rawValue = value == null ? '' : String(value);
+  const parts = rawValue.split(',').map((part) => part.trim()).filter(Boolean);
+  if (!parts.length) {
+    errors.push('--seeds requires at least one finite numeric seed');
+    return [];
+  }
+  const seeds = [];
+  for (const part of parts) {
+    const n = Number(part);
+    if (!Number.isFinite(n)) {
+      errors.push(`--seeds contains a non-finite seed: ${part}`);
+      continue;
+    }
+    seeds.push(n);
+  }
+  return [...new Set(seeds)];
+}
+
 /**
  * @param {string[]} argv - process.argv
  * @returns {{ raw: object, errors: string[] }}
@@ -50,11 +74,13 @@ export function parseDynastySoakArgv(argv) {
     deepEachSeason: false,
     seasons: null,
     seed: null,
+    seeds: null,
     outDir: null,
     phaseTimeoutMs: null,
     maxRuntimeMs: null,
     skipReportOpen: false,
     teams: null,
+    failOnWarnings: false,
     unknown: [],
   };
   const errors = [];
@@ -74,12 +100,15 @@ export function parseDynastySoakArgv(argv) {
     else if (a === '--deep') raw.deep = true;
     else if (a === '--deep-each-season') raw.deepEachSeason = true;
     else if (a === '--skip-report-open') raw.skipReportOpen = true;
+    else if (a === '--fail-on-warnings') raw.failOnWarnings = true;
     else if (a.startsWith('--seasons=')) {
       const parsed = parseRequiredNumber('--seasons', a.slice('--seasons='.length), errors);
       if (parsed.ok) raw.seasons = parsed.value;
     } else if (a.startsWith('--seed=')) {
       const parsed = parseRequiredNumber('--seed', a.slice('--seed='.length), errors);
       if (parsed.ok) raw.seed = parsed.value;
+    } else if (a.startsWith('--seeds=')) {
+      raw.seeds = parseSeedList(a.slice('--seeds='.length), errors);
     } else if (a.startsWith('--outDir=')) raw.outDir = a.split('=').slice(1).join('=');
     else if (a.startsWith('--phase-timeout-ms=')) {
       const parsed = parseRequiredNumber('--phase-timeout-ms', a.slice('--phase-timeout-ms='.length), errors);
@@ -104,6 +133,9 @@ export function parseDynastySoakArgv(argv) {
         raw.seed = parsed.value;
         i += 1;
       }
+    } else if (a === '--seeds') {
+      raw.seeds = parseSeedList(argv[i + 1], errors);
+      i += 1;
     } else if (a === '--phase-timeout-ms') {
       const v = argv[i + 1];
       const parsed = parseRequiredNumber('--phase-timeout-ms', v, errors);
@@ -144,17 +176,22 @@ export function resolveDynastySoakConfig(raw) {
   }
   const requestedProfile = raw.auditProfile ?? (raw.ci ? 'ci' : 'full');
   const auditProfile = String(requestedProfile || '').toLowerCase();
-  if (!['ci', 'full'].includes(auditProfile)) {
-    errors.push(`Unknown audit profile: ${requestedProfile}. Expected --audit-profile=ci or --audit-profile=full.`);
+  const supportedProfiles = ['ci', 'full', 'multi-seed-ci', 'long-ci', 'stability'];
+  if (!supportedProfiles.includes(auditProfile)) {
+    errors.push(`Unknown audit profile: ${requestedProfile}. Expected one of: ${supportedProfiles.join(', ')}.`);
   }
+  const isMultiSeed = auditProfile === 'multi-seed-ci';
+  const isLongProfile = auditProfile === 'long-ci' || auditProfile === 'stability';
+  const runnerProfile = isMultiSeed ? 'ci' : isLongProfile ? 'full' : auditProfile;
   const requestedSeasons =
     raw.seasons != null && Number.isFinite(Number(raw.seasons))
       ? Math.max(1, Math.min(50, Number(raw.seasons)))
       : null;
-  const seasons = auditProfile === 'ci'
+  const seasons = runnerProfile === 'ci'
     ? 1
-    : requestedSeasons ?? 5;
+    : requestedSeasons ?? (isLongProfile ? 3 : 5);
   const seed = raw.seed != null && Number.isFinite(Number(raw.seed)) ? Number(raw.seed) : 1383;
+  const seeds = isMultiSeed ? (Array.isArray(raw.seeds) && raw.seeds.length ? raw.seeds : DEFAULT_MULTI_SEED_CI_SEEDS) : [seed];
 
   if (raw.teams != null && Number.isFinite(raw.teams) && Number(raw.teams) !== 32) {
     errors.push(
@@ -184,18 +221,32 @@ export function resolveDynastySoakConfig(raw) {
     resolved: {
       seasons,
       seed,
-      ci: auditProfile === 'ci',
+      seeds,
+      ci: runnerProfile === 'ci',
       auditProfile,
-      phasePath: auditProfile === 'ci' ? 'short' : 'full-season',
+      runnerProfile,
+      isMultiSeed,
+      isLongProfile,
+      phasePath: runnerProfile === 'ci' ? 'short' : 'full-season',
       requestedSeasons,
       effectiveSeasons: seasons,
-      ciWeeks: auditProfile === 'ci' ? 2 : null,
-      profileNotes: auditProfile === 'ci'
+      ciWeeks: runnerProfile === 'ci' ? 2 : null,
+      profileNotes: isMultiSeed
         ? [
-            'CI profile runs a short real-worker phase path and does not complete a season.',
-            'Use --audit-profile=full --seasons=1 for the full manual season audit.',
+            'Multi-seed CI profile runs the existing short real-worker CI path once per deterministic seed.',
+            'It intentionally does not complete seasons; use --audit-profile=long-ci for bounded completed-season coverage.',
           ]
-        : ['Full profile preserves the legacy full-season SIM_TO_PHASE audit and may be slow.'],
+        : runnerProfile === 'ci'
+          ? [
+              'CI profile runs a short real-worker phase path and does not complete a season.',
+              'Use --audit-profile=full --seasons=1 for the full manual season audit.',
+            ]
+          : isLongProfile
+            ? [
+                'Long CI/stability profile is optional/manual and runs a bounded 3-season full-season audit by default.',
+                'It is not part of the default push/parity profile because SIM_TO_PHASE can be slow.',
+              ]
+            : ['Full profile preserves the legacy full-season SIM_TO_PHASE audit and may be slow.'],
       deep,
       deepEachSeason,
       phaseTimeoutMs,
@@ -203,6 +254,7 @@ export function resolveDynastySoakConfig(raw) {
       simTimeoutMs: phaseTimeoutMs,
       outDir: raw.outDir || null,
       skipReportOpen: !!raw.skipReportOpen,
+      failOnWarnings: !!raw.failOnWarnings,
       teams: 32,
       smallerLeagueNote:
         'Only 32-team safe starter leagues are enabled; parameterized default league counts require playoff seeding and conference balance work — deferred.',
@@ -279,10 +331,97 @@ function exerciseDetail(entry) {
   return parts.join('; ');
 }
 
+
+export function buildMultiSeedMarkdownReport(result) {
+  const lines = [];
+  lines.push('# Dynasty multi-seed soak report');
+  lines.push('');
+  lines.push(`- **Profile:** ${mdEscape(result.auditProfile ?? 'multi-seed-ci')}`);
+  lines.push(`- **Runner profile:** ${mdEscape(result.runnerProfile ?? 'ci')}`);
+  lines.push(`- **Seeds:** ${(result.seeds ?? []).join(', ')}`);
+  lines.push(`- **Seed count:** ${result.seedCount ?? 0}`);
+  lines.push(`- **Pass / fail:** ${result.passCount ?? 0} / ${result.failCount ?? 0}`);
+  lines.push(`- **Warning seeds:** ${result.warningSeedCount ?? 0}`);
+  lines.push(`- **Runtime total ms:** ${result.runtimeTotalMs ?? result.runtimeMs ?? 0}`);
+  lines.push(`- **Passed:** ${result.passed ? 'yes' : 'no'}`);
+  lines.push(`- **Severity:** ${mdEscape(result.severity ?? 'unknown')}`);
+  lines.push(`- **Fail on warnings:** ${result.failOnWarnings ? 'yes' : 'no'}`);
+  lines.push('');
+
+  lines.push('## Profile notes');
+  lines.push('');
+  for (const note of result.profileNotes ?? []) lines.push(`- ${mdEscape(note)}`);
+  lines.push('- Default seeds are `1383`, `1408`, and `1426` to exercise three deterministic starter-league RNG paths without changing the existing single-seed CI audit runtime.');
+  lines.push('- Full 20–50 season soaks and always-on long-run CI remain intentionally manual/deferred.');
+  lines.push('');
+
+  lines.push('## Per-seed summary');
+  lines.push('');
+  lines.push('| Seed | Passed | Severity | Runtime ms | Seasons | Final phase | Final year | Failures | Warnings | First failure |');
+  lines.push('| --- | --- | --- | ---: | ---: | --- | --- | ---: | ---: | --- |');
+  for (const row of result.seedSummaries ?? []) {
+    const firstFailure = row.firstFailure ? `${row.firstFailure.code}: ${row.firstFailure.message}` : '';
+    lines.push(`| ${row.seed} | ${row.passed ? 'yes' : 'no'} | ${mdEscape(row.severity)} | ${row.runtimeMs} | ${row.seasonsSimmed} | ${mdEscape(row.finalPhase ?? 'n/a')} | ${row.finalYear ?? 'n/a'} | ${row.failureCount} | ${row.warningCount} | ${mdEscape(firstFailure)} |`);
+  }
+  lines.push('');
+
+  lines.push('## Warnings by seed');
+  lines.push('');
+  if (!result.warningsBySeed?.length) lines.push('_None_');
+  else {
+    for (const row of result.warningsBySeed) {
+      lines.push(`- **Seed ${row.seed}:** ${mdEscape(JSON.stringify(row.warningsByCode ?? {}))}`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Failures by seed');
+  lines.push('');
+  if (!result.failuresBySeed?.length) lines.push('_None_');
+  else {
+    for (const row of result.failuresBySeed) {
+      lines.push(`- **Seed ${row.seed}:** ${mdEscape((row.failures ?? []).map((f) => `${f.code}: ${f.message}`).join('; '))}`);
+    }
+  }
+  lines.push('');
+
+  lines.push('## Economy warning aggregate');
+  lines.push('');
+  const eco = result.economyAggregate ?? {};
+  lines.push(`- **Snapshots present:** ${eco.snapshotsPresent ?? 0} / ${result.seedCount ?? 0}`);
+  const totals = eco.totals ?? {};
+  lines.push(`- **Cap / pending offers:** teams over cap=${totals.teamsOverCap ?? 0}, teams pending-overcommitted=${totals.teamsWithPendingOfferOvercommit ?? 0}, overcommitted offers=${totals.pendingOfferOvercommitCount ?? 0}, unknown offer values=${totals.unknownOfferValueCount ?? 0}`);
+  lines.push(`- **CPU offer sanity:** CPU offers=${totals.cpuOfferCount ?? 0}, duplicate expensive same-group buckets=${totals.duplicateExpensiveSameGroupOffers ?? 0}, rebuild old-vet offers=${totals.oldVeteranOffersByRebuildTeams ?? 0}, contender veteran offers=${totals.contenderVeteranOfferCount ?? 0}, severe QB exceptions=${totals.severeQbNeedOfferCount ?? 0}`);
+  lines.push(`- **Trade realism flags:** young premium discount flags=${totals.premiumYoungPlayerTradeDiscountFlags ?? 0}, expensive veteran swap flags=${totals.expensiveVeteranSwapFlags ?? 0}`);
+  if (Array.isArray(eco.skippedReasonsBySeed) && eco.skippedReasonsBySeed.length) {
+    lines.push(`- **Unknown/skipped:** ${mdEscape(eco.skippedReasonsBySeed.map((row) => `seed ${row.seed} ${row.code}: ${row.reason}`).join('; '))}`);
+  }
+  if (Array.isArray(eco.warningsBySeed) && eco.warningsBySeed.length) {
+    lines.push(`- **Economy warnings:** ${mdEscape(eco.warningsBySeed.map((row) => `seed ${row.seed}: ${row.warnings.join('; ')}`).join(' | '))}`);
+  }
+  lines.push('');
+
+  lines.push('## Persistence/archive warnings by seed');
+  lines.push('');
+  if (!result.persistenceWarningsBySeed?.length) lines.push('_None_');
+  else {
+    for (const row of result.persistenceWarningsBySeed) {
+      lines.push(`- **Seed ${row.seed}:** ${mdEscape((row.assertionFailures ?? []).map((a) => `${a.id}: ${a.detail}`).join('; '))}`);
+    }
+  }
+  lines.push('');
+  lines.push('## Notes');
+  lines.push('');
+  lines.push('- Failures block CI; warnings are informational unless `--fail-on-warnings` is set.');
+  lines.push('- Per-seed raw results are stored in `latest.json` under `results`.');
+  return lines.join('\n');
+}
+
 /**
  * @param {object} result - runDynastySoakOnce output (JSON-serializable)
  */
 export function buildMarkdownReport(result) {
+  if (result?.multiSeed) return buildMultiSeedMarkdownReport(result);
   const lines = [];
   lines.push('# Dynasty soak report');
   lines.push('');
@@ -521,11 +660,13 @@ export async function writeDynastySoakReports(result, outDir = 'artifacts/dynast
   const jsonPath = resolve(resolvedOutDir, 'latest.json');
   const markdownPath = resolve(resolvedOutDir, 'latest.md');
   await mkdir(resolvedOutDir, { recursive: true });
-  await writeFile(
-    jsonPath,
-    JSON.stringify(slimDynastySoakResultForJson(result), null, 2),
-    'utf8',
-  );
-  await writeFile(markdownPath, buildMarkdownReport(result), 'utf8');
+  const jsonText = JSON.stringify(slimDynastySoakResultForJson(result), null, 2);
+  const markdownText = buildMarkdownReport(result);
+  await writeFile(jsonPath, jsonText, 'utf8');
+  await writeFile(markdownPath, markdownText, 'utf8');
+  if (result?.multiSeed) {
+    await writeFile(resolve(resolvedOutDir, 'latest-multi-seed.json'), jsonText, 'utf8');
+    await writeFile(resolve(resolvedOutDir, 'latest-multi-seed.md'), markdownText, 'utf8');
+  }
   return { outDir: resolvedOutDir, jsonPath, markdownPath };
 }

--- a/src/testSupport/dynastySoakRunner.js
+++ b/src/testSupport/dynastySoakRunner.js
@@ -417,6 +417,140 @@ async function timedDispatch({ checkpoints, name, runnerDispatch, type, payload 
   return msg;
 }
 
+
+function countWarningsByCode(warnings = []) {
+  const out = {};
+  for (const warning of warnings || []) {
+    const code = String(warning?.code ?? 'unknown');
+    out[code] = (out[code] || 0) + 1;
+  }
+  return out;
+}
+
+const ECONOMY_AGGREGATE_FIELDS = [
+  'teamsOverCap',
+  'teamsWithPendingOfferOvercommit',
+  'pendingOfferOvercommitCount',
+  'duplicateExpensiveSameGroupOffers',
+  'oldVeteranOffersByRebuildTeams',
+  'contenderVeteranOfferCount',
+  'severeQbNeedOfferCount',
+  'premiumYoungPlayerTradeDiscountFlags',
+  'expensiveVeteranSwapFlags',
+  'cpuOfferCount',
+  'unknownOfferValueCount',
+];
+
+function buildSeedSummary(result) {
+  const economy = result?.reportSummary?.economyRegressionSnapshot ?? null;
+  return {
+    seed: result?.seed,
+    passed: !!result?.passed,
+    severity: result?.severity ?? 'unknown',
+    runtimeMs: result?.runtimeMs ?? 0,
+    seasonsSimmed: result?.seasonsSimmed ?? 0,
+    finalPhase: result?.finalPhase ?? null,
+    finalYear: result?.finalYear ?? null,
+    failureCount: result?.failures?.length ?? 0,
+    warningCount: result?.warnings?.length ?? 0,
+    firstFailure: result?.failures?.[0]
+      ? { code: result.failures[0].code, message: result.failures[0].message }
+      : null,
+    warningsByCode: countWarningsByCode(result?.warnings ?? []),
+    economyRegressionSnapshot: economy,
+    persistenceAssertionFailures: (result?.persistenceAssertions ?? [])
+      .filter((assertion) => assertion?.ok === false)
+      .map((assertion) => ({ id: assertion.id, code: assertion.code, detail: assertion.detail })),
+  };
+}
+
+function aggregateEconomy(seedSummaries) {
+  const totals = {};
+  for (const field of ECONOMY_AGGREGATE_FIELDS) totals[field] = 0;
+  const skippedReasonsBySeed = [];
+  const warningsBySeed = [];
+  let snapshotsPresent = 0;
+  for (const seedSummary of seedSummaries) {
+    const eco = seedSummary.economyRegressionSnapshot;
+    if (!eco || typeof eco !== 'object') {
+      skippedReasonsBySeed.push({ seed: seedSummary.seed, code: 'economy_snapshot_missing', reason: 'No economyRegressionSnapshot was produced for this seed.' });
+      continue;
+    }
+    snapshotsPresent += 1;
+    for (const field of ECONOMY_AGGREGATE_FIELDS) {
+      totals[field] += Number(eco[field] ?? 0) || 0;
+    }
+    if (Array.isArray(eco.skippedReasons) && eco.skippedReasons.length) {
+      skippedReasonsBySeed.push(...eco.skippedReasons.map((row) => ({ seed: seedSummary.seed, ...row })));
+    }
+    if (Array.isArray(eco.warnings) && eco.warnings.length) {
+      warningsBySeed.push({ seed: seedSummary.seed, warnings: eco.warnings });
+    }
+  }
+  return { snapshotsPresent, totals, skippedReasonsBySeed, warningsBySeed };
+}
+
+function buildMultiSeedAggregate({ profileConfig, seedResults, t0 }) {
+  const seedSummaries = seedResults.map(buildSeedSummary);
+  const failuresBySeed = seedResults
+    .filter((result) => !result?.passed || (result?.failures?.length ?? 0) > 0)
+    .map((result) => ({ seed: result.seed, failures: result.failures ?? [], firstFailure: result.failures?.[0] ?? null }));
+  const warningsBySeed = seedResults
+    .filter((result) => (result?.warnings?.length ?? 0) > 0)
+    .map((result) => ({ seed: result.seed, warnings: result.warnings ?? [], warningsByCode: countWarningsByCode(result.warnings ?? []) }));
+  const persistenceWarningsBySeed = seedSummaries
+    .filter((summary) => summary.persistenceAssertionFailures.length > 0)
+    .map((summary) => ({ seed: summary.seed, assertionFailures: summary.persistenceAssertionFailures }));
+  const economyAggregate = aggregateEconomy(seedSummaries);
+  const totalRuntimeMs = Date.now() - t0;
+  const passedSeeds = seedResults.filter((result) => !!result?.passed).length;
+  const failedSeeds = seedResults.length - passedSeeds;
+  const warningSeeds = seedResults.filter((result) => (result?.warnings?.length ?? 0) > 0).length;
+  const passedWithoutWarnings = profileConfig.failOnWarnings
+    ? failedSeeds === 0 && warningSeeds === 0
+    : failedSeeds === 0;
+  return {
+    multiSeed: true,
+    passed: passedWithoutWarnings,
+    severity: failedSeeds > 0 ? 'error' : warningSeeds > 0 ? 'warn' : 'ok',
+    auditProfile: profileConfig.auditProfile ?? 'multi-seed-ci',
+    runnerProfile: profileConfig.runnerProfile ?? 'ci',
+    phasePath: profileConfig.phasePath ?? 'short',
+    seeds: seedResults.map((result) => result.seed),
+    seedCount: seedResults.length,
+    passCount: passedSeeds,
+    failCount: failedSeeds,
+    warningSeedCount: warningSeeds,
+    runtimeMs: totalRuntimeMs,
+    runtimeTotalMs: totalRuntimeMs,
+    runtimePerSeed: Object.fromEntries(seedResults.map((result) => [String(result.seed), result.runtimeMs ?? 0])),
+    seasons: profileConfig.seasons,
+    failOnWarnings: !!profileConfig.failOnWarnings,
+    profileNotes: profileConfig.profileNotes ?? [],
+    harnessConfig: {
+      auditProfile: profileConfig.auditProfile ?? 'multi-seed-ci',
+      runnerProfile: profileConfig.runnerProfile ?? 'ci',
+      phasePath: profileConfig.phasePath ?? 'short',
+      seeds: seedResults.map((result) => result.seed),
+      seasons: profileConfig.seasons,
+      ci: (profileConfig.runnerProfile ?? 'ci') === 'ci',
+      deep: !!profileConfig.deep,
+      deepEachSeason: !!profileConfig.deepEachSeason,
+      phaseTimeoutMs: profileConfig.phaseTimeoutMs,
+      maxRuntimeMs: profileConfig.maxRuntimeMs,
+      failOnWarnings: !!profileConfig.failOnWarnings,
+    },
+    seedSummaries,
+    failuresBySeed,
+    warningsBySeed,
+    economyAggregate,
+    persistenceWarningsBySeed,
+    results: seedResults,
+    failures: failuresBySeed.flatMap((row) => row.failures.map((failure) => ({ ...failure, seed: row.seed, message: `[seed ${row.seed}] ${failure.message}` }))),
+    warnings: warningsBySeed.flatMap((row) => row.warnings.map((warning) => ({ ...warning, seed: row.seed, message: `[seed ${row.seed}] ${warning.message}` }))),
+  };
+}
+
 /**
  * @typedef {object} DynastySoakRunnerOptions
  * @property {number} [seasons=5]
@@ -796,6 +930,7 @@ async function runFullDynastySoakOnce(opts = {}) {
       const audit = runDynastySoakAudit({
         viewState: view,
         seasonIndex: s,
+        expectedTeamCount: 32,
         allSeasons: allSeasonsMsg.payload?.seasons ?? null,
         seasonHistory,
         transactions: txMsg.payload?.transactions ?? [],
@@ -1189,6 +1324,7 @@ async function runCiDynastySoakOnce(opts = {}) {
     const audit = runDynastySoakAudit({
       viewState: view,
       seasonIndex: 0,
+      expectedTeamCount: 32,
       allSeasons: allSeasonsMsg.payload?.seasons ?? null,
       seasonHistory: null,
       transactions: txMsg.payload?.transactions ?? [],
@@ -1253,7 +1389,28 @@ async function runCiDynastySoakOnce(opts = {}) {
  * @param {DynastySoakRunnerOptions} opts
  */
 export async function runDynastySoakOnce(opts = {}) {
-  const auditProfile = String(opts.auditProfile ?? (opts.ci ? 'ci' : 'full')).toLowerCase();
+  const auditProfile = String(opts.runnerProfile ?? opts.auditProfile ?? (opts.ci ? 'ci' : 'full')).toLowerCase();
   if (auditProfile === 'ci') return runCiDynastySoakOnce({ ...opts, ci: true, auditProfile: 'ci' });
   return runFullDynastySoakOnce({ ...opts, ci: false, auditProfile: 'full' });
+}
+
+export async function runDynastySoakMultiSeed(opts = {}) {
+  const seeds = Array.isArray(opts.seeds) && opts.seeds.length ? opts.seeds : [1383, 1408, 1426];
+  const t0 = Date.now();
+  const seedResults = [];
+  const runOne = typeof opts.runOne === 'function' ? opts.runOne : runDynastySoakOnce;
+  for (const seed of seeds) {
+    if (typeof opts.onSeedStart === 'function') opts.onSeedStart(seed, seedResults.length + 1, seeds.length);
+    const result = await runOne({
+      ...opts,
+      seed,
+      seeds: undefined,
+      auditProfile: opts.runnerProfile ?? 'ci',
+      runnerProfile: opts.runnerProfile ?? 'ci',
+      ci: (opts.runnerProfile ?? 'ci') === 'ci',
+    });
+    seedResults.push({ ...result, seed });
+    if (typeof opts.onSeedComplete === 'function') opts.onSeedComplete(seedResults[seedResults.length - 1], seedResults.length, seeds.length);
+  }
+  return buildMultiSeedAggregate({ profileConfig: opts, seedResults, t0 });
 }

--- a/tests/unit/dynastySoakAudit.test.js
+++ b/tests/unit/dynastySoakAudit.test.js
@@ -179,4 +179,46 @@ describe('dynastySoakAudit', () => {
   it('exposes broad stat leader warn bounds', () => {
     expect(STAT_LEADER_WARN.passYds.max).toBeGreaterThan(STAT_LEADER_WARN.passYds.min);
   });
+
+  it('keeps empty young Hall of Fame as a warning, not a failure', () => {
+    const r = runDynastySoakAudit({
+      viewState: baseView({ hallOfFameClasses: [] }),
+      seasonIndex: 1,
+      hofPayload: { players: [], classes: [] },
+    });
+    expect(r.warnings.some((w) => w.code === 'hof_empty_young')).toBe(true);
+    expect(r.failures.some((f) => f.code === 'hof_empty_young')).toBe(false);
+  });
+
+  it('reports missing economy offer/trade inputs as skipped/unknown without failing', () => {
+    const r = runDynastySoakAudit({
+      viewState: baseView(),
+      seasonIndex: 0,
+    });
+    expect(r.passed).toBe(true);
+    expect(r.reportSummary.economyRegressionSnapshot.skippedReasons.some((row) => row.code === 'pending_offers_missing')).toBe(true);
+    expect(r.reportSummary.economyRegressionSnapshot.skippedReasons.some((row) => row.code === 'trades_missing')).toBe(true);
+  });
+
+  it('detects duplicate season archives and malformed game rows', () => {
+    const season = {
+      id: 's2',
+      year: 2027,
+      champion: { id: 0, abbr: 'AAA' },
+      standings: [{ id: 0, wins: 10, losses: 6 }],
+      playoffBracketSnapshot: { rounds: [] },
+      playerSeasonStatsV1: { schemaVersion: 1, rows: [{ playerId: 'p1', pos: 'QB', totals: {} }] },
+      transactionTimelineV1: { schemaVersion: 1, rows: [] },
+      games: [{ id: 'g1', homeScore: -1, awayScore: 20, boxScore: [] }],
+    };
+    const r = runDynastySoakAudit({
+      viewState: baseView({ leagueHistory: [season, { ...season }] }),
+      seasonIndex: 2,
+    });
+    expect(r.passed).toBe(false);
+    expect(r.failures.some((f) => f.code === 'season_archive_duplicate')).toBe(true);
+    expect(r.failures.some((f) => f.code === 'game_archive_score_malformed')).toBe(true);
+    expect(r.failures.some((f) => f.code === 'box_score_archive_malformed')).toBe(true);
+  });
+
 });

--- a/tests/unit/dynastySoakCli.test.js
+++ b/tests/unit/dynastySoakCli.test.js
@@ -333,4 +333,69 @@ describe('dynastySoakCli', () => {
     expect(slim.finalView).toBeUndefined();
     expect(slim.a).toBe(1);
   });
+
+  it('parses comma-separated seeds and resolves multi-seed-ci defaults', () => {
+    const parsed = parseDynastySoakArgv(['node', 'x.mjs', '--audit-profile=multi-seed-ci', '--seeds=1383,1408,1426']);
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.raw.seeds).toEqual([1383, 1408, 1426]);
+
+    const { errors, resolved } = resolveDynastySoakConfig(parsed.raw);
+    expect(errors).toEqual([]);
+    expect(resolved.isMultiSeed).toBe(true);
+    expect(resolved.runnerProfile).toBe('ci');
+    expect(resolved.seasons).toBe(1);
+    expect(resolved.seeds).toEqual([1383, 1408, 1426]);
+  });
+
+  it('uses default multi-seed-ci seeds when --seeds is omitted', () => {
+    const { raw } = parseDynastySoakArgv(['node', 'x.mjs', '--audit-profile=multi-seed-ci']);
+    const { resolved } = resolveDynastySoakConfig(raw);
+    expect(resolved.seeds).toEqual([1383, 1408, 1426]);
+    expect(resolved.ci).toBe(true);
+  });
+
+  it('keeps long-ci optional/manual and does not trigger it by default', () => {
+    const defaultResolved = resolveDynastySoakConfig(parseDynastySoakArgv(['node', 'x.mjs']).raw).resolved;
+    expect(defaultResolved.auditProfile).toBe('full');
+    expect(defaultResolved.isLongProfile).toBe(false);
+
+    const longResolved = resolveDynastySoakConfig(parseDynastySoakArgv(['node', 'x.mjs', '--audit-profile=long-ci']).raw).resolved;
+    expect(longResolved.auditProfile).toBe('long-ci');
+    expect(longResolved.runnerProfile).toBe('full');
+    expect(longResolved.isLongProfile).toBe(true);
+    expect(longResolved.seasons).toBe(3);
+  });
+
+  it('buildMarkdownReport includes multi-seed summary and grouped warnings', () => {
+    const md = buildMarkdownReport({
+      multiSeed: true,
+      auditProfile: 'multi-seed-ci',
+      runnerProfile: 'ci',
+      seeds: [1383, 1408],
+      seedCount: 2,
+      passCount: 1,
+      failCount: 1,
+      warningSeedCount: 1,
+      runtimeTotalMs: 1234,
+      passed: false,
+      severity: 'error',
+      failOnWarnings: false,
+      profileNotes: ['multi seed note'],
+      seedSummaries: [
+        { seed: 1383, passed: true, severity: 'warn', runtimeMs: 100, seasonsSimmed: 0, finalPhase: 'regular', finalYear: 2026, failureCount: 0, warningCount: 1, warningsByCode: { hof_empty_young: 1 }, persistenceAssertionFailures: [] },
+        { seed: 1408, passed: false, severity: 'error', runtimeMs: 200, seasonsSimmed: 0, finalPhase: 'regular', finalYear: 2026, failureCount: 1, warningCount: 0, firstFailure: { code: 'runner_fatal', message: 'boom' }, persistenceAssertionFailures: [] },
+      ],
+      warningsBySeed: [{ seed: 1383, warningsByCode: { hof_empty_young: 1 }, warnings: [{ code: 'hof_empty_young', message: 'young league' }] }],
+      failuresBySeed: [{ seed: 1408, failures: [{ code: 'runner_fatal', message: 'boom' }] }],
+      economyAggregate: { snapshotsPresent: 1, totals: { teamsOverCap: 0, cpuOfferCount: 2 }, skippedReasonsBySeed: [{ seed: 1408, code: 'economy_snapshot_missing', reason: 'No economyRegressionSnapshot was produced for this seed.' }] },
+      persistenceWarningsBySeed: [],
+    });
+    expect(md).toContain('Dynasty multi-seed soak report');
+    expect(md).toContain('Pass / fail');
+    expect(md).toContain('Seed 1383');
+    expect(md).toContain('runner_fatal');
+    expect(md).toContain('Economy warning aggregate');
+    expect(md).toContain('economy_snapshot_missing');
+  });
+
 });

--- a/tests/unit/dynastySoakRunner.test.js
+++ b/tests/unit/dynastySoakRunner.test.js
@@ -353,4 +353,68 @@ describe('runDynastySoakOnce', () => {
     expect(result.failures.some((f) => f.code === 'audit_checkpoint_failed')).toBe(true);
   });
 
+
+  it('aggregates multi-seed pass/fail results and groups warnings by seed', async () => {
+    const { runDynastySoakMultiSeed } = await import('../../src/testSupport/dynastySoakRunner.js');
+    const result = await runDynastySoakMultiSeed({
+      auditProfile: 'multi-seed-ci',
+      runnerProfile: 'ci',
+      seeds: [1383, 1408, 1426],
+      seasons: 1,
+      phaseTimeoutMs: 10000,
+      runOne: vi.fn(async ({ seed }) => ({
+        seed,
+        passed: seed !== 1408,
+        severity: seed === 1408 ? 'error' : seed === 1426 ? 'warn' : 'ok',
+        runtimeMs: seed - 1300,
+        seasonsSimmed: 0,
+        finalPhase: 'regular',
+        finalYear: 2026,
+        failures: seed === 1408 ? [{ code: 'runner_fatal', message: 'boom' }] : [],
+        warnings: seed === 1426 ? [{ code: 'hof_empty_young', message: 'young league warning' }] : [],
+        persistenceAssertions: seed === 1408 ? [{ id: 'get_records', ok: false, detail: 'failed' }] : [],
+        reportSummary: {
+          economyRegressionSnapshot: seed === 1383
+            ? { teamsOverCap: 1, teamsWithPendingOfferOvercommit: 0, pendingOfferOvercommitCount: 0, duplicateExpensiveSameGroupOffers: 0, oldVeteranOffersByRebuildTeams: 0, contenderVeteranOfferCount: 0, severeQbNeedOfferCount: 0, premiumYoungPlayerTradeDiscountFlags: 0, expensiveVeteranSwapFlags: 0, cpuOfferCount: 3, unknownOfferValueCount: 0, skippedReasons: [], warnings: [] }
+            : null,
+        },
+      })),
+    });
+
+    expect(result.multiSeed).toBe(true);
+    expect(result.passed).toBe(false);
+    expect(result.seedCount).toBe(3);
+    expect(result.passCount).toBe(2);
+    expect(result.failCount).toBe(1);
+    expect(result.failuresBySeed).toHaveLength(1);
+    expect(result.failuresBySeed[0].seed).toBe(1408);
+    expect(result.warningsBySeed).toHaveLength(1);
+    expect(result.warningsBySeed[0].warningsByCode.hof_empty_young).toBe(1);
+    expect(result.economyAggregate.snapshotsPresent).toBe(1);
+    expect(result.economyAggregate.totals.teamsOverCap).toBe(1);
+    expect(result.economyAggregate.skippedReasonsBySeed.some((row) => row.code === 'economy_snapshot_missing')).toBe(true);
+    expect(result.persistenceWarningsBySeed[0].seed).toBe(1408);
+  });
+
+  it('can fail multi-seed on warnings only when strict mode is requested', async () => {
+    const { runDynastySoakMultiSeed } = await import('../../src/testSupport/dynastySoakRunner.js');
+    const base = {
+      auditProfile: 'multi-seed-ci',
+      runnerProfile: 'ci',
+      seeds: [1383],
+      runOne: vi.fn(async ({ seed }) => ({
+        seed,
+        passed: true,
+        severity: 'warn',
+        runtimeMs: 1,
+        failures: [],
+        warnings: [{ code: 'hof_empty_young', message: 'young league warning' }],
+        persistenceAssertions: [],
+        reportSummary: { economyRegressionSnapshot: null },
+      })),
+    };
+    expect((await runDynastySoakMultiSeed(base)).passed).toBe(true);
+    expect((await runDynastySoakMultiSeed({ ...base, failOnWarnings: true })).passed).toBe(false);
+  });
+
 });


### PR DESCRIPTION
### Motivation

- Provide practical long-run / multi-seed dynasty coverage that can be run manually or in a controlled CI/profile mode to catch crashes, persistence corruption, archive issues, and economy/AI sanity regressions.  
- Keep the fast single-seed CI path unchanged while adding an opt-in multi-seed profile and an optional bounded long-run profile so standard CI is not slowed.  
- Surface per-seed failures, grouped warnings, and economy aggregates to make triage of stability regressions deterministic and reviewer-friendly.

### Description

- CLI + profiles: extended `scripts/dynasty-soak.mjs` and `src/testSupport/dynastySoakCli.js` to add `--audit-profile=multi-seed-ci`, `--audit-profile=long-ci|stability`, `--seeds=A,B,C`, and `--fail-on-warnings`; added `npm run audit:dynasty:multi` alias.  Default multi-seed list is `1383,1408,1426` to exercise three deterministic starter-league RNG paths without changing the single-seed CI runtime.  
- Multi-seed runner & aggregation: added `runDynastySoakMultiSeed` in `src/testSupport/dynastySoakRunner.js` which sequentially runs the existing harness per seed, builds per-seed summaries and an aggregated multi-seed result (pass/fail counts, runtime per seed/total, failures/warnings by seed, persistence failures, and economy aggregates).  
- Reports & Markdown: extended `writeDynastySoakReports` and `buildMarkdownReport` to emit readable multi-seed markdown and JSON; multi-run artifacts are written to `artifacts/dynasty-soak/latest-multi-seed.{json,md}` in addition to `latest.{json,md}`.  
- Additional health checks (read-only audit): extended `src/core/dynastySoakAudit.js` with bounded long-run safety checks that detect `team_count_unstable`, `standings_impossible`, duplicate season archives, missing playoffBracket snapshots, missing `playerSeasonStatsV1` / `transactionTimelineV1` archive warnings, duplicate/malformed game archive rows, and malformed `boxScore` shapes; economy aggregation reuses `economyRegressionAudit`.  

### Testing

- Commands run (all automated): `npm ci`, `node --check scripts/dynasty-soak.mjs`, `node --check src/testSupport/dynastySoakRunner.js`, `node --check src/testSupport/dynastySoakCli.js`, `node --check src/core/dynastySoakAudit.js`, `node --check src/core/economyRegressionAudit.js`, `npm run test:unit`, `npm run test:soak`, `npm run build`, and `npm run check:deploy`.  
- Unit test results: `npm run test:unit` passed (191 files / 865 tests) and targeted dynasty soak unit tests passed (`tests/unit/dynastySoak*.test.js`); `npm run test:soak` passed (dynasty soak subset).  
- Single-seed CI audit: `npm run audit:dynasty -- --ci --seed=1383` passed in ~19,620 ms with 0 failures and 1 early-league HOF warning (expected).  
- Multi-seed CI audit: `npm run audit:dynasty -- --audit-profile=multi-seed-ci --seeds=1383,1408,1426` passed, total ~55,325 ms with per-seed runtimes ~19,254 ms / 17,986 ms / 18,081 ms and only the expected early-league HOF warnings per seed; artifacts written to `artifacts/dynasty-soak/latest.{json,md}` and `latest-multi-seed.{json,md}`.  
- Build & parity: `npm run build` and `npm run check:deploy` succeeded (build emits the existing large chunk warning).  
- E2E note: Playwright e2e smoke (`npx playwright test`) could not be completed here because `npx playwright install --with-deps chromium` failed to fetch the Chromium binary (CDN returned `403 Domain forbidden` in this environment); the failure is environmental and no code changes were made to Playwright or E2E tests.  

Notes: multi-seed and long profiles are opt-in; the short `ci` single-seed path is unchanged.  Warnings are informational by default and can be treated as failures by passing `--fail-on-warnings`/`failOnWarnings` when strict behavior is desired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b22c8660832dafeb00a12c3bb750)