### PR TITLE
Add Long‑Dynasty / Multi‑Seed Stability Audit V1

### DIFF
--- a/docs/dynasty-stability-audit.md
+++ b/docs/dynasty-stability-audit.md
@@ -1,0 +1,81 @@
+# Long-Dynasty / Multi-Seed Stability Audit V1
+
+FootballGMSim is a client-side dynasty simulator: the core franchise loop, completed-season archives, transaction memory, draft history, record book, Hall of Fame, and saves all have to survive long browser-only careers. This audit upgrades the existing dynasty soak harness into a named V1 release check aimed at ZenGM-style long-run trust.
+
+## What V1 checks
+
+`stability-v1` runs deterministic multi-seed, completed-season dynasty audits without replacing the existing fast CI smoke profiles. For each configured seed it exercises:
+
+- Worker boot and safe starter league creation.
+- Full-season simulation through regular season, playoffs, offseason, free agency, draft, and next preseason.
+- Current league shape: year, phase, user team, team count, rosters, standings, cap fields, player ratings/contracts, and current schedule state.
+- Roster integrity: roster containers exist, no empty active rosters, QB scarcity collapse is detected, and duplicate player IDs across team/free-agent/draft containers fail the run.
+- History integrity: completed season archives, plausible standings, season history handler shape, record book rebuild, Hall of Fame handler shape, transaction timeline, player-season stats archive, and draft class history.
+- Economy/balance warnings: teams over cap, pending-offer overcommitment, duplicate expensive CPU offer groups, rebuilding teams overpaying old veterans, missing contender win-now activity, cheap premium-player trade flags, veteran cap-dump-like swaps, QB scarcity, and draft/history quality signals.
+- Persistence proof: force `SAVE_NOW`, reload through the worker `LOAD_SAVE` path, re-run history/transaction/draft/records/HOF handlers, and compare year, phase, team count, current season ID, completed season count, transaction sample size, and user team ID before/after reload.
+
+Hard corruption is a failure. Balance concerns are warnings by default and only fail the process when `--fail-on-warnings` is passed.
+
+## Commands
+
+### Safe CI / fast checks
+
+```bash
+npm run test:soak
+npm run audit:dynasty:multi
+```
+
+`test:soak` is fast Vitest coverage for the audit parser, reporter, aggregation, persistence assertion formatting, and pure invariant checks. `audit:dynasty:multi` is still the short multi-seed real-worker smoke path and does **not** complete seasons.
+
+### Manual release stability audit
+
+```bash
+npm run audit:dynasty:stability
+```
+
+Default V1 depth is intentionally manual and bounded: **5 completed seasons x 3 deterministic seeds**. It should be run before releases when validating dynasty trust, but it is not wired into normal push CI.
+
+### Deeper manual audit
+
+```bash
+npm run audit:dynasty:stability:deep
+```
+
+This runs more seasons/seeds and enables deep final-season probes. You can tune depth directly:
+
+```bash
+npm run audit:dynasty -- --audit-profile=stability-v1 --seasons=20 --seeds=1383,1408,1426,1451,1499 --deep --fail-on-warnings
+```
+
+## Reports
+
+Every CLI run writes JSON and Markdown artifacts under `artifacts/dynasty-soak/`:
+
+- `latest.json` / `latest.md`
+- `latest-multi-seed.json` / `latest-multi-seed.md` for multi-seed profiles
+
+The Markdown report includes profile name, seeds, seasons per seed, runtime per seed, pass/fail/warn summary, first failure per failed seed, warning categories by seed, final year/phase, completed archive counts, economy/cap warnings, persistence/reload summary, slow checkpoints, what the run proves, what it does not prove yet, and a suggested next-depth command.
+
+The JSON report keeps structured per-seed results and summaries so future agents can compare regressions.
+
+## Interpreting failures vs warnings
+
+- **Failures** mean dynasty corruption or broken handler behavior: crashes, invalid league year/phase, missing teams/rosters, duplicate player IDs, impossible cap/standings/player values, broken archives, failed save/load, or malformed required history data.
+- **Warnings** mean sports-sim balance or early-dynasty quality concerns: cap stress, roster depth warnings, sparse transactions, empty early HOF, suspicious AI economy behavior, outlier stat leaders, or missing optional archive enrichments.
+- Use `--fail-on-warnings` for strict release-candidate audits when you want balance warnings to block the run.
+
+## Known limitations
+
+- V1 is not an always-on 20-50 season CI soak.
+- The harness runs in Node with fake IndexedDB, not on mobile Safari/Chrome live storage.
+- It checks shaped data and suspicious balance indicators, but does not yet produce full AI team-building grades.
+- It is deterministic by seed but does not snapshot full statistical distributions across versions.
+- Smaller league sizes remain deferred because playoff/schedule/conference assumptions are 32-team-oriented.
+
+## Future V2 ideas
+
+- 20 to 50 season scheduled soak with regression baselines.
+- Saved-game migration audit across archived old saves.
+- Mobile live-site E2E dynasty smoke against IndexedDB.
+- AI team-building scorecards for contenders, rebuilders, cap-strapped teams, and QB-needy teams.
+- Statistical distribution snapshots across versions for talent, caps, standings, awards, injuries, draft quality, and career records.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "check:netlify-rules": "node scripts/validate-netlify-rules.mjs",
     "check:deploy": "npm run check:netlify-parity && npm run check:netlify-rules && npm run check:netlify-cli-build && npm run check:netlify-cli-build:preview",
     "check:netlify-cli-build:preview": "npx --yes netlify-cli@latest build --context deploy-preview --offline",
-    "audit:dynasty:multi": "npm run audit:dynasty -- --audit-profile=multi-seed-ci"
+    "audit:dynasty:multi": "npm run audit:dynasty -- --audit-profile=multi-seed-ci",
+    "audit:dynasty:stability": "npm run audit:dynasty -- --audit-profile=stability-v1",
+    "audit:dynasty:stability:deep": "npm run audit:dynasty -- --audit-profile=stability-v1 --seasons=10 --seeds=1383,1408,1426,1451,1499 --deep"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/dynasty-soak.mjs
+++ b/scripts/dynasty-soak.mjs
@@ -42,7 +42,7 @@ async function main() {
     );
   }
   if (resolved.isLongProfile) {
-    console.warn('[dynasty-soak] long-ci/stability is optional/manual and is not part of default push CI.');
+    console.warn('[dynasty-soak] long-ci/stability/stability-v1 is optional/manual and is not part of default push CI.');
   }
 
   const result = resolved.isMultiSeed

--- a/src/core/dynastySoakAudit.js
+++ b/src/core/dynastySoakAudit.js
@@ -44,6 +44,20 @@ function isBadNum(v) {
   return !Number.isFinite(v) || Number.isNaN(v) || v === Infinity || v === -Infinity;
 }
 
+function isBadCriticalValue(v) {
+  if (v == null) return true;
+  return typeof v === 'number' && isBadNum(v);
+}
+
+function scanCriticalFields(obj, paths, label, fail) {
+  for (const path of paths) {
+    const value = path.split('.').reduce((acc, key) => (acc == null ? undefined : acc[key]), obj);
+    if (isBadCriticalValue(value)) {
+      fail('critical_value_invalid', `${label}.${path} is ${value == null ? 'null/missing' : 'non-finite'}`, { label, path, value });
+    }
+  }
+}
+
 function emptySummary() {
   return {
     rosterHealth: 'ok',
@@ -499,8 +513,14 @@ function collectAllPlayers(viewState) {
   const out = [];
   for (const t of teams) {
     for (const p of t?.roster || []) {
-      if (p && typeof p === 'object') out.push({ ...p, teamId: p.teamId ?? t.id });
+      if (p && typeof p === 'object') out.push({ ...p, teamId: p.teamId ?? t.id, _auditContainer: `team:${t.id}` });
     }
+  }
+  for (const p of viewState?.freeAgents || []) {
+    if (p && typeof p === 'object') out.push({ ...p, teamId: p.teamId ?? null, _auditContainer: 'freeAgents' });
+  }
+  for (const p of viewState?.draftPool || viewState?.draftClass || []) {
+    if (p && typeof p === 'object') out.push({ ...p, teamId: p.teamId ?? null, _auditContainer: 'draftPool' });
   }
   return out;
 }
@@ -586,12 +606,30 @@ export function runDynastySoakAudit(input = {}) {
     }
   }
 
+  if (!Number.isFinite(year) || year < 1900) {
+    fail('league_year_invalid', `League year is invalid: ${viewState?.year}`);
+    bumpSummary(summary, 'historyHealth', 'fail');
+  }
+  if (!metaPhase) {
+    fail('league_phase_invalid', 'League phase is missing');
+    bumpSummary(summary, 'historyHealth', 'fail');
+  }
+
   // --- Roster / cap / AI strategy ---
   let teamsWithoutQb = 0;
   const archetypes = [];
   for (const team of teams) {
     const tid = team?.id;
     const roster = Array.isArray(team?.roster) ? team.roster : [];
+    if (team?.id == null || team.id === '') {
+      fail('team_id_missing', 'Team missing id');
+      bumpSummary(summary, 'rosterHealth', 'fail');
+    }
+    if (!Array.isArray(team?.roster)) {
+      fail('roster_container_missing', `Team ${tid} roster container missing or invalid`, { teamId: tid });
+      bumpSummary(summary, 'rosterHealth', 'fail');
+    }
+    scanCriticalFields(team, ['capUsed', 'capTotal', 'capRoom', 'wins', 'losses', 'ptsFor', 'ptsAgainst'], `team:${tid}`, fail);
     const n = roster.length;
     if (n === 0) {
       fail('roster_empty', `Team ${tid} has an empty roster`, { teamId: tid });
@@ -609,6 +647,21 @@ export function runDynastySoakAudit(input = {}) {
       if (c < need) {
         warn(`depth_${label.toLowerCase()}`, `Team ${tid} has ${c} ${label} (warn if < ${need})`, { teamId: tid });
         bumpSummary(summary, 'rosterHealth', 'warn');
+      }
+    }
+
+    for (const p of roster.slice(0, 120)) {
+      scanCriticalFields(p, ['id', 'age', 'ovr', 'potential'], `player:${p?.id ?? 'missing'}@team:${tid}`, fail);
+      if (!p?.pos && !p?.position) {
+        fail('player_position_missing', `Player ${p?.id ?? 'unknown'} on team ${tid} missing position`, { teamId: tid, playerId: p?.id });
+        bumpSummary(summary, 'rosterHealth', 'fail');
+      }
+      const contract = p?.contract ?? p;
+      for (const key of ['baseAnnual', 'yearsRemaining']) {
+        if (contract?.[key] != null && isBadNum(num(contract[key]))) {
+          fail('contract_value_invalid', `Player ${p?.id ?? 'unknown'} contract.${key} is non-finite`, { playerId: p?.id, key });
+          bumpSummary(summary, 'capHealth', 'fail');
+        }
       }
     }
 
@@ -674,6 +727,15 @@ export function runDynastySoakAudit(input = {}) {
     }
   }
 
+  const teamsWithoutViableQb = teams.filter((team) => {
+    const roster = Array.isArray(team?.roster) ? team.roster : [];
+    return !roster.some((p) => String(p?.pos ?? p?.position ?? '').toUpperCase() === 'QB' && num(p?.ovr) >= 55);
+  }).length;
+  if (teamsWithoutViableQb >= 8) {
+    warn('qb_scarcity_collapse', `${teamsWithoutViableQb} teams lack a viable 55+ OVR QB option`);
+    bumpSummary(summary, 'rosterHealth', 'warn');
+  }
+
   if (teamsWithoutQb >= 2) {
     fail('multi_team_no_qb', `${teamsWithoutQb} teams lack a QB`);
     bumpSummary(summary, 'rosterHealth', 'fail');
@@ -718,6 +780,25 @@ export function runDynastySoakAudit(input = {}) {
       if (!season?.transactionTimelineV1) {
         warn('transaction_timeline_archive_missing', `Completed season archive ${seasonId} missing transactionTimelineV1`, { seasonId });
         bumpSummary(summary, 'transactionHealth', 'warn');
+      }
+      const archivedStandings = Array.isArray(season?.standings) ? season.standings : [];
+      if (archivedStandings.length) {
+        let totalWins = 0;
+        let totalLosses = 0;
+        for (const row of archivedStandings) {
+          const wins = num(row?.wins);
+          const losses = num(row?.losses);
+          if (isBadNum(wins) || isBadNum(losses) || wins < 0 || losses < 0 || wins > 25 || losses > 25) {
+            fail('archived_standings_impossible', `Completed season ${seasonId} has invalid standings row`, { seasonId, wins, losses });
+            bumpSummary(summary, 'historyHealth', 'fail');
+          }
+          totalWins += Number.isFinite(wins) ? wins : 0;
+          totalLosses += Number.isFinite(losses) ? losses : 0;
+        }
+        if (archivedStandings.length >= 30 && Math.abs(totalWins - totalLosses) > 8) {
+          warn('archived_standings_unbalanced', `Completed season ${seasonId} win/loss totals differ (${totalWins}/${totalLosses})`, { seasonId });
+          bumpSummary(summary, 'historyHealth', 'warn');
+        }
       }
     }
     if (seasonIndex > 0 && leagueHistory.length < seasonIndex) {
@@ -809,6 +890,21 @@ export function runDynastySoakAudit(input = {}) {
 
   // --- Record book rebuild ---
   const allPlayers = collectAllPlayers(viewState);
+  const seenPlayerIds = new Map();
+  for (const p of allPlayers) {
+    const pid = p?.id;
+    if (pid == null || pid === '') {
+      fail('player_id_missing', `Player missing id in ${p?._auditContainer ?? 'unknown'}`);
+      bumpSummary(summary, 'rosterHealth', 'fail');
+      continue;
+    }
+    const key = String(pid);
+    if (seenPlayerIds.has(key)) {
+      fail('duplicate_player_id', `Player id ${key} appears in both ${seenPlayerIds.get(key)} and ${p?._auditContainer ?? 'unknown'}`, { playerId: pid });
+      bumpSummary(summary, 'rosterHealth', 'fail');
+    }
+    seenPlayerIds.set(key, p?._auditContainer ?? 'unknown');
+  }
   try {
     rebuildRecordBookV1({
       leagueHistory,
@@ -879,6 +975,11 @@ export function runDynastySoakAudit(input = {}) {
     warn('economy_rebuild_old_veteran_offer', `${economyRegressionSnapshot.oldVeteranOffersByRebuildTeams} old expensive veteran CPU offer(s) by rebuild teams`);
     bumpSummary(summary, 'aiHealth', 'warn');
   }
+  const contenderTeams = teams.filter((team) => ['contender', 'playoff_hunt', 'desperate'].includes(String(team?.archetype ?? team?.strategy?.archetype ?? team?.teamArchetype ?? '').toLowerCase()));
+  if (contenderTeams.length >= 4 && economyRegressionSnapshot.cpuOfferCount > 0 && economyRegressionSnapshot.contenderVeteranOfferCount === 0) {
+    warn('economy_contenders_no_win_now_moves', 'Contender archetypes exist but no win-now veteran CPU offer activity was observed in the snapshot');
+    bumpSummary(summary, 'aiHealth', 'warn');
+  }
   if (economyRegressionSnapshot.premiumYoungPlayerTradeDiscountFlags > 0 || economyRegressionSnapshot.expensiveVeteranSwapFlags > 0) {
     warn('economy_trade_realism_flags', 'Trade realism warning flags detected in economy regression snapshot', {
       premiumYoungPlayerTradeDiscountFlags: economyRegressionSnapshot.premiumYoungPlayerTradeDiscountFlags,
@@ -888,7 +989,27 @@ export function runDynastySoakAudit(input = {}) {
   }
 
   // --- Transactions + draft class memory ---
+  const finiteOvrs = allPlayers.map((p) => num(p?.ovr)).filter(Number.isFinite);
+  if (finiteOvrs.length >= 500) {
+    const avgOvr = finiteOvrs.reduce((sum, value) => sum + value, 0) / finiteOvrs.length;
+    const eliteCount = finiteOvrs.filter((value) => value >= 90).length;
+    if (avgOvr < 58 || avgOvr > 78 || eliteCount > teams.length * 2.5) {
+      warn('league_talent_distribution_outlier', `League talent distribution looks unrealistic: avgOvr=${Math.round(avgOvr * 10) / 10}, elite90=${eliteCount}`);
+      bumpSummary(summary, 'developmentHealth', 'warn');
+    }
+  }
+
   const rawTx = Array.isArray(input.transactions) ? input.transactions : [];
+  if (rawTx.length > 5000) {
+    fail('transactions_exploded', `Recent transaction sample unexpectedly huge (${rawTx.length})`);
+    bumpSummary(summary, 'transactionHealth', 'fail');
+  }
+  for (const tx of rawTx.slice(0, 1000)) {
+    if (tx?.playerId != null && !seenPlayerIds.has(String(tx.playerId)) && !String(tx?.type ?? '').toLowerCase().includes('draft')) {
+      warn('transaction_orphan_player_ref', `Transaction ${tx?.id ?? 'unknown'} references missing player ${tx.playerId}`, { transactionId: tx?.id, playerId: tx.playerId });
+      bumpSummary(summary, 'transactionHealth', 'warn');
+    }
+  }
   if (seasonIndex >= 2 && rawTx.length < 3) {
     warn('transactions_sparse', `Very few transactions (${rawTx.length}) after ${seasonIndex} seasons`);
     bumpSummary(summary, 'transactionHealth', 'warn');
@@ -946,6 +1067,29 @@ export function runDynastySoakAudit(input = {}) {
   if (Array.isArray(draftClasses) && seasonIndex >= 2 && draftClasses.length === 0) {
     warn('draft_classes_empty', 'GET_DRAFT_CLASSES returned no seasons after multiple sims');
     bumpSummary(summary, 'draftHealth', 'warn');
+  }
+  if (Array.isArray(draftClasses)) {
+    for (const klass of draftClasses.slice(0, 20)) {
+      if (!klass || typeof klass !== 'object' || !klass.seasonId) {
+        fail('draft_class_shape', 'Draft class entry missing seasonId or object shape');
+        bumpSummary(summary, 'draftHealth', 'fail');
+      }
+      const picks = Array.isArray(klass?.picks) ? klass.picks : Array.isArray(klass?.players) ? klass.players : [];
+      const draftOvrs = picks.map((pick) => num(pick?.ovr ?? pick?.player?.ovr)).filter(Number.isFinite);
+      if (draftOvrs.length >= 20) {
+        const avgDraftOvr = draftOvrs.reduce((sum, value) => sum + value, 0) / draftOvrs.length;
+        if (avgDraftOvr < 45 || avgDraftOvr > 82) {
+          warn('draft_class_quality_outlier', `Draft class ${klass?.seasonId ?? 'unknown'} average OVR looks unrealistic (${Math.round(avgDraftOvr * 10) / 10})`);
+          bumpSummary(summary, 'draftHealth', 'warn');
+        }
+      }
+      for (const pick of picks.slice(0, 256)) {
+        if (pick && typeof pick === 'object' && (pick.playerId == null && pick.id == null)) {
+          fail('draft_class_player_broken', `Draft class ${klass?.seasonId ?? 'unknown'} contains a broken player/pick object`);
+          bumpSummary(summary, 'draftHealth', 'fail');
+        }
+      }
+    }
   }
 
   // --- GET payloads ---

--- a/src/testSupport/dynastySoakCli.js
+++ b/src/testSupport/dynastySoakCli.js
@@ -10,9 +10,9 @@ export const DYNASTY_SOAK_USAGE = `Usage: npm run audit:dynasty -- [options]
 
 Options:
   --ci                    Alias for --audit-profile=ci (fast real-worker smoke audit)
-  --audit-profile=ci|full|multi-seed-ci|long-ci|stability
-                          Profile to run: ci=short partial phase path, full=legacy manual audit, multi-seed-ci=3 short deterministic seeds, long-ci/stability=bounded 3-season manual audit
-  --seasons=N             Number of seasons to simulate with --audit-profile=full/long-ci/stability (default: full=5, long-ci=3; CI uses a short path)
+  --audit-profile=ci|full|multi-seed-ci|long-ci|stability|stability-v1
+                          Profile to run: ci=short partial phase path, full=legacy manual audit, multi-seed-ci=3 short deterministic seeds, long-ci/stability=bounded manual audit, stability-v1=manual 5-season/3-seed V1 audit
+  --seasons=N             Number of seasons to simulate with --audit-profile=full/long-ci/stability/stability-v1 (default: full=5, long-ci/stability=3, stability-v1=5; CI uses a short path)
   --seed=N                RNG seed for single-seed profiles (default: 1383)
   --seeds=A,B,C           Comma-separated seeds for multi-seed profiles (default: 1383,1408,1426)
   --fail-on-warnings      Treat warnings as a failing audit exit for manual strict mode (default: false)
@@ -42,6 +42,7 @@ function parseRequiredNumber(flag, value, errors) {
 }
 
 export const DEFAULT_MULTI_SEED_CI_SEEDS = [1383, 1408, 1426];
+export const DEFAULT_STABILITY_V1_SEEDS = [1383, 1408, 1426];
 
 export function parseSeedList(value, errors = []) {
   const rawValue = value == null ? '' : String(value);
@@ -176,22 +177,25 @@ export function resolveDynastySoakConfig(raw) {
   }
   const requestedProfile = raw.auditProfile ?? (raw.ci ? 'ci' : 'full');
   const auditProfile = String(requestedProfile || '').toLowerCase();
-  const supportedProfiles = ['ci', 'full', 'multi-seed-ci', 'long-ci', 'stability'];
+  const supportedProfiles = ['ci', 'full', 'multi-seed-ci', 'long-ci', 'stability', 'stability-v1'];
   if (!supportedProfiles.includes(auditProfile)) {
     errors.push(`Unknown audit profile: ${requestedProfile}. Expected one of: ${supportedProfiles.join(', ')}.`);
   }
-  const isMultiSeed = auditProfile === 'multi-seed-ci';
-  const isLongProfile = auditProfile === 'long-ci' || auditProfile === 'stability';
-  const runnerProfile = isMultiSeed ? 'ci' : isLongProfile ? 'full' : auditProfile;
+  const isStabilityV1 = auditProfile === 'stability-v1';
+  const isMultiSeed = auditProfile === 'multi-seed-ci' || isStabilityV1;
+  const isLongProfile = auditProfile === 'long-ci' || auditProfile === 'stability' || isStabilityV1;
+  const runnerProfile = auditProfile === 'multi-seed-ci' ? 'ci' : isLongProfile ? 'full' : auditProfile;
   const requestedSeasons =
     raw.seasons != null && Number.isFinite(Number(raw.seasons))
       ? Math.max(1, Math.min(50, Number(raw.seasons)))
       : null;
   const seasons = runnerProfile === 'ci'
     ? 1
-    : requestedSeasons ?? (isLongProfile ? 3 : 5);
+    : requestedSeasons ?? (isStabilityV1 ? 5 : isLongProfile ? 3 : 5);
   const seed = raw.seed != null && Number.isFinite(Number(raw.seed)) ? Number(raw.seed) : 1383;
-  const seeds = isMultiSeed ? (Array.isArray(raw.seeds) && raw.seeds.length ? raw.seeds : DEFAULT_MULTI_SEED_CI_SEEDS) : [seed];
+  const seeds = isMultiSeed
+    ? (Array.isArray(raw.seeds) && raw.seeds.length ? raw.seeds : (isStabilityV1 ? DEFAULT_STABILITY_V1_SEEDS : DEFAULT_MULTI_SEED_CI_SEEDS))
+    : [seed];
 
   if (raw.teams != null && Number.isFinite(raw.teams) && Number(raw.teams) !== 32) {
     errors.push(
@@ -227,16 +231,23 @@ export function resolveDynastySoakConfig(raw) {
       runnerProfile,
       isMultiSeed,
       isLongProfile,
+      isStabilityV1,
       phasePath: runnerProfile === 'ci' ? 'short' : 'full-season',
       requestedSeasons,
       effectiveSeasons: seasons,
       ciWeeks: runnerProfile === 'ci' ? 2 : null,
-      profileNotes: isMultiSeed
+      profileNotes: isStabilityV1
         ? [
-            'Multi-seed CI profile runs the existing short real-worker CI path once per deterministic seed.',
-            'It intentionally does not complete seasons; use --audit-profile=long-ci for bounded completed-season coverage.',
+            'Long-Dynasty / Multi-Seed Stability Audit V1 is optional/manual and runs completed-season coverage across deterministic seeds.',
+            'Default V1 depth is 5 seasons x 3 seeds; use --seasons and --seeds to tune release depth without changing push CI.',
+            'Warnings are balance concerns unless --fail-on-warnings is set; corruption remains a hard failure.',
           ]
-        : runnerProfile === 'ci'
+        : isMultiSeed
+          ? [
+              'Multi-seed CI profile runs the existing short real-worker CI path once per deterministic seed.',
+              'It intentionally does not complete seasons; use --audit-profile=stability-v1 for multi-seed completed-season coverage.',
+            ]
+          : runnerProfile === 'ci'
           ? [
               'CI profile runs a short real-worker phase path and does not complete a season.',
               'Use --audit-profile=full --seasons=1 for the full manual season audit.',
@@ -338,11 +349,13 @@ export function buildMultiSeedMarkdownReport(result) {
   lines.push('');
   lines.push(`- **Profile:** ${mdEscape(result.auditProfile ?? 'multi-seed-ci')}`);
   lines.push(`- **Runner profile:** ${mdEscape(result.runnerProfile ?? 'ci')}`);
-  lines.push(`- **Seeds:** ${(result.seeds ?? []).join(', ')}`);
+  lines.push(`- **Seeds tested:** ${(result.seeds ?? []).join(', ')}`);
+  lines.push(`- **Seasons per seed:** ${result.seasons ?? result.harnessConfig?.seasons ?? 'n/a'}`);
   lines.push(`- **Seed count:** ${result.seedCount ?? 0}`);
   lines.push(`- **Pass / fail:** ${result.passCount ?? 0} / ${result.failCount ?? 0}`);
   lines.push(`- **Warning seeds:** ${result.warningSeedCount ?? 0}`);
   lines.push(`- **Runtime total ms:** ${result.runtimeTotalMs ?? result.runtimeMs ?? 0}`);
+  lines.push(`- **Runtime per seed:** ${mdEscape(JSON.stringify(result.runtimePerSeed ?? {}))}`);
   lines.push(`- **Passed:** ${result.passed ? 'yes' : 'no'}`);
   lines.push(`- **Severity:** ${mdEscape(result.severity ?? 'unknown')}`);
   lines.push(`- **Fail on warnings:** ${result.failOnWarnings ? 'yes' : 'no'}`);
@@ -357,11 +370,11 @@ export function buildMultiSeedMarkdownReport(result) {
 
   lines.push('## Per-seed summary');
   lines.push('');
-  lines.push('| Seed | Passed | Severity | Runtime ms | Seasons | Final phase | Final year | Failures | Warnings | First failure |');
-  lines.push('| --- | --- | --- | ---: | ---: | --- | --- | ---: | ---: | --- |');
+  lines.push('| Seed | Passed | Severity | Runtime ms | Seasons | Final phase | Final year | Completed archives | Failures | Warnings | First failure |');
+  lines.push('| --- | --- | --- | ---: | ---: | --- | --- | ---: | ---: | ---: | --- |');
   for (const row of result.seedSummaries ?? []) {
     const firstFailure = row.firstFailure ? `${row.firstFailure.code}: ${row.firstFailure.message}` : '';
-    lines.push(`| ${row.seed} | ${row.passed ? 'yes' : 'no'} | ${mdEscape(row.severity)} | ${row.runtimeMs} | ${row.seasonsSimmed} | ${mdEscape(row.finalPhase ?? 'n/a')} | ${row.finalYear ?? 'n/a'} | ${row.failureCount} | ${row.warningCount} | ${mdEscape(firstFailure)} |`);
+    lines.push(`| ${row.seed} | ${row.passed ? 'yes' : 'no'} | ${mdEscape(row.severity)} | ${row.runtimeMs} | ${row.seasonsSimmed} | ${mdEscape(row.finalPhase ?? 'n/a')} | ${row.finalYear ?? 'n/a'} | ${row.completedSeasonCount ?? 'n/a'} | ${row.failureCount} | ${row.warningCount} | ${mdEscape(firstFailure)} |`);
   }
   lines.push('');
 
@@ -401,6 +414,19 @@ export function buildMultiSeedMarkdownReport(result) {
   }
   lines.push('');
 
+  lines.push('## Persistence/reload summary');
+  lines.push('');
+  if (!Array.isArray(result.persistenceReloadSummary) || result.persistenceReloadSummary.length === 0) lines.push('_No reload summaries recorded._');
+  else {
+    lines.push('| Seed | Reload ok | Year | Phase | Teams | Season ID | Completed archives | Tx sample | Mismatches |');
+    lines.push('| --- | --- | --- | --- | ---: | --- | ---: | ---: | --- |');
+    for (const row of result.persistenceReloadSummary) {
+      const after = row.after ?? {};
+      lines.push(`| ${row.seed} | ${row.ok === true ? 'yes' : row.ok === false ? 'no' : 'n/a'} | ${after.year ?? 'n/a'} | ${mdEscape(after.phase ?? 'n/a')} | ${after.teamCount ?? 'n/a'} | ${mdEscape(after.currentSeasonId ?? 'n/a')} | ${after.completedSeasonCount ?? 'n/a'} | ${after.transactionCountSample ?? 'n/a'} | ${mdEscape((row.mismatches ?? []).map((m) => m.key).join(', ') || '')} |`);
+    }
+  }
+  lines.push('');
+
   lines.push('## Persistence/archive warnings by seed');
   lines.push('');
   if (!result.persistenceWarningsBySeed?.length) lines.push('_None_');
@@ -409,6 +435,38 @@ export function buildMultiSeedMarkdownReport(result) {
       lines.push(`- **Seed ${row.seed}:** ${mdEscape((row.assertionFailures ?? []).map((a) => `${a.id}: ${a.detail}`).join('; '))}`);
     }
   }
+  lines.push('');
+  lines.push('## Slowest checkpoints');
+  lines.push('');
+  const slow = (result.results ?? []).flatMap((r) => (r.timings?.topSlowCheckpoints ?? []).map((c) => ({ ...c, seed: r.seed }))).sort((a, b) => (b.ms ?? 0) - (a.ms ?? 0)).slice(0, 10);
+  if (!slow.length) lines.push('_None recorded._');
+  else {
+    lines.push('| Rank | Seed | Checkpoint | ms | Metadata |');
+    lines.push('| --- | --- | --- | ---: | --- |');
+    slow.forEach((c, i) => lines.push(`| ${i + 1} | ${c.seed} | ${mdEscape(c.name)} | ${c.ms ?? 0} | ${formatCheckpointMeta(c.meta)} |`));
+  }
+  lines.push('');
+
+  lines.push('## What this proves');
+  lines.push('');
+  if (result.auditProfile === 'stability-v1') {
+    lines.push('- Completed-season dynasty flow survived the configured seeds/seasons through boot, simulation, playoffs/offseason, draft/free agency windows, save/load, and history probes.');
+    lines.push('- Hard corruption signals fail the run; economy and roster-balance concerns remain warnings unless strict mode is enabled.');
+  } else if ((result.runnerProfile ?? 'ci') === 'ci') {
+    lines.push('- Short real-worker smoke stability across deterministic seeds without completing seasons.');
+  } else {
+    lines.push('- Completed-season stability for the configured manual profile.');
+  }
+  lines.push('');
+  lines.push('## What this does not prove yet');
+  lines.push('');
+  lines.push('- It is not a 20-50 season migration/statistical distribution proof.');
+  lines.push('- It does not exercise mobile live-site browser storage or every old-save migration path.');
+  lines.push('- Balance warnings identify suspicious patterns; they are not a complete AI team-building scorecard yet.');
+  lines.push('');
+  lines.push('## Suggested next audit depth command');
+  lines.push('');
+  lines.push('`npm run audit:dynasty:stability:deep`');
   lines.push('');
   lines.push('## Notes');
   lines.push('');

--- a/src/testSupport/dynastySoakRunner.js
+++ b/src/testSupport/dynastySoakRunner.js
@@ -18,6 +18,8 @@ const RESPONSE_BY_REQUEST = {
   [toWorker.SIM_TO_PHASE]: [toUI.FULL_STATE, toUI.ERROR],
   [toWorker.ADVANCE_WEEK]: [toUI.WEEK_COMPLETE, toUI.ERROR, toUI.FULL_STATE],
   [toWorker.SAVE_NOW]: [toUI.SAVED, toUI.ERROR],
+  [toWorker.LOAD_SAVE]: [toUI.FULL_STATE, toUI.ERROR],
+  [toWorker.LOAD_SLOT]: [toUI.FULL_STATE, toUI.ERROR],
   [toWorker.GET_ALL_SEASONS]: [toUI.ALL_SEASONS, toUI.ERROR],
   [toWorker.GET_TRANSACTIONS]: [toUI.TRANSACTIONS, toUI.ERROR],
   [toWorker.GET_RECORDS]: [toUI.RECORDS, toUI.ERROR],
@@ -443,6 +445,9 @@ const ECONOMY_AGGREGATE_FIELDS = [
 
 function buildSeedSummary(result) {
   const economy = result?.reportSummary?.economyRegressionSnapshot ?? null;
+  const completedSeasonCount = Array.isArray(result?.finalView?.leagueHistory)
+    ? result.finalView.leagueHistory.length
+    : (result?.reloadSummary?.after?.completedSeasonCount ?? result?.reportSummary?.completedSeasonCount ?? null);
   return {
     seed: result?.seed,
     passed: !!result?.passed,
@@ -451,6 +456,9 @@ function buildSeedSummary(result) {
     seasonsSimmed: result?.seasonsSimmed ?? 0,
     finalPhase: result?.finalPhase ?? null,
     finalYear: result?.finalYear ?? null,
+    completedSeasonCount,
+    currentSeasonId: result?.reloadSummary?.after?.currentSeasonId ?? result?.finalView?.seasonId ?? null,
+    userTeamId: result?.reloadSummary?.after?.userTeamId ?? result?.finalView?.userTeamId ?? null,
     failureCount: result?.failures?.length ?? 0,
     warningCount: result?.warnings?.length ?? 0,
     firstFailure: result?.failures?.[0]
@@ -458,6 +466,7 @@ function buildSeedSummary(result) {
       : null,
     warningsByCode: countWarningsByCode(result?.warnings ?? []),
     economyRegressionSnapshot: economy,
+    reloadSummary: result?.reloadSummary ?? null,
     persistenceAssertionFailures: (result?.persistenceAssertions ?? [])
       .filter((assertion) => assertion?.ok === false)
       .map((assertion) => ({ id: assertion.id, code: assertion.code, detail: assertion.detail })),
@@ -544,6 +553,13 @@ function buildMultiSeedAggregate({ profileConfig, seedResults, t0 }) {
     failuresBySeed,
     warningsBySeed,
     economyAggregate,
+    persistenceReloadSummary: seedSummaries.map((summary) => ({
+      seed: summary.seed,
+      ok: summary.reloadSummary?.ok ?? null,
+      before: summary.reloadSummary?.before ?? null,
+      after: summary.reloadSummary?.after ?? null,
+      mismatches: summary.reloadSummary?.mismatches ?? [],
+    })),
     persistenceWarningsBySeed,
     results: seedResults,
     failures: failuresBySeed.flatMap((row) => row.failures.map((failure) => ({ ...failure, seed: row.seed, message: `[seed ${row.seed}] ${failure.message}` }))),
@@ -569,6 +585,33 @@ function buildMultiSeedAggregate({ profileConfig, seedResults, t0 }) {
 /**
  * @param {DynastySoakRunnerOptions} opts
  */
+function snapshotReloadFields(view, transactionsRecent = []) {
+  const leagueHistory = Array.isArray(view?.leagueHistory) ? view.leagueHistory : [];
+  return {
+    year: view?.year ?? null,
+    phase: view?.phase ?? null,
+    teamCount: Array.isArray(view?.teams) ? view.teams.length : null,
+    currentSeasonId: view?.seasonId ?? view?.currentSeasonId ?? null,
+    completedSeasonCount: leagueHistory.length,
+    transactionCountSample: Array.isArray(transactionsRecent) ? transactionsRecent.length : null,
+    userTeamId: view?.userTeamId ?? null,
+  };
+}
+
+function compareReloadSummary(before, after) {
+  const required = ['year', 'phase', 'teamCount', 'currentSeasonId', 'completedSeasonCount', 'userTeamId'];
+  const mismatches = [];
+  for (const key of required) {
+    if (String(before?.[key] ?? '') !== String(after?.[key] ?? '')) {
+      mismatches.push({ key, before: before?.[key] ?? null, after: after?.[key] ?? null });
+    }
+  }
+  if (Number(after?.transactionCountSample ?? 0) < Math.min(5, Number(before?.transactionCountSample ?? 0))) {
+    mismatches.push({ key: 'transactionCountSample', before: before?.transactionCountSample ?? null, after: after?.transactionCountSample ?? null });
+  }
+  return { ok: mismatches.length === 0, before, after, mismatches };
+}
+
 async function runFullDynastySoakOnce(opts = {}) {
   const seasons = Math.max(1, Math.min(50, Number(opts.seasons) || 5));
   const seed = Number.isFinite(Number(opts.seed)) ? Number(opts.seed) : 1383;
@@ -586,6 +629,7 @@ async function runFullDynastySoakOnce(opts = {}) {
       ? null
       : Number(opts.maxRuntimeMs);
   const runnerDispatch = typeof opts.dispatchWorker === 'function' ? opts.dispatchWorker : dispatchWorker;
+  const requestedAuditProfile = String(opts.auditProfile ?? 'full');
   const runnerLoadWorkerModule = typeof opts.loadWorkerModule === 'function' ? opts.loadWorkerModule : loadWorkerModule;
 
   const checkpoints = [];
@@ -620,7 +664,7 @@ async function runFullDynastySoakOnce(opts = {}) {
     },
     harnessConfig: {
       ci,
-      auditProfile: 'full',
+      auditProfile: requestedAuditProfile,
       phasePath: 'full-season',
       deep,
       deepEachSeason,
@@ -630,7 +674,7 @@ async function runFullDynastySoakOnce(opts = {}) {
     smallerLeagueNote:
       'Only 32-team safe starter leagues are supported for this harness. Smaller default leagues are deferred (playoff seeding and conference balance are coupled to 32 teams).',
     persistenceAssertions: [],
-    auditProfile: 'full',
+    auditProfile: requestedAuditProfile,
     phasePath: 'full-season',
     profileNotes: opts.profileNotes ?? ['Full profile preserves the legacy full-season SIM_TO_PHASE audit and may be slow.'],
     exerciseMatrix: buildFullExerciseMatrix(),
@@ -1024,17 +1068,86 @@ async function runFullDynastySoakOnce(opts = {}) {
       pushCheckpoint(checkpoints, `S${s}.ADVANCE_WEEK`, Date.now() - tProbe, null);
     }
 
+    let finalRecentTransactions = [];
+    try {
+      const saveT = Date.now();
+      const saveMsg = await runnerDispatch(toWorker.SAVE_NOW, {}, { timeoutMs: Math.min(120_000, phaseTimeoutMs) });
+      pushCheckpoint(checkpoints, 'final.SAVE_NOW', Date.now() - saveT, null);
+      const saveOk = probeHandlerSucceeded(saveMsg);
+      aggregate.persistenceAssertions.push({
+        id: 'final_save_now_flush',
+        ok: saveOk,
+        code: saveOk ? undefined : 'save_now_failed',
+        detail: saveOk ? 'Final SAVE_NOW flush ok before reload proof' : (saveMsg.payload?.message || 'Final SAVE_NOW flush failed'),
+      });
+      const beforeTx = await runnerDispatch(toWorker.GET_TRANSACTIONS, { mode: 'recent', limit: 100 }, { timeoutMs: phaseTimeoutMs });
+      finalRecentTransactions = beforeTx.payload?.transactions ?? [];
+      const before = snapshotReloadFields(view, finalRecentTransactions);
+      const loadT = Date.now();
+      const loadMsg = await runnerDispatch(toWorker.LOAD_SAVE, { leagueId: 'save_slot_1' }, { timeoutMs: Math.min(180_000, phaseTimeoutMs) });
+      pushCheckpoint(checkpoints, 'final.LOAD_SAVE', Date.now() - loadT, null);
+      if (!probeHandlerSucceeded(loadMsg)) {
+        aggregate.reloadSummary = { ok: false, before, after: null, mismatches: [{ key: 'LOAD_SAVE', before: 'ok', after: loadMsg.payload?.message || 'failed' }] };
+      } else {
+        view = loadMsg.payload;
+        const reloadAllSeasons = await runnerDispatch(toWorker.GET_ALL_SEASONS, {}, { timeoutMs: phaseTimeoutMs });
+        const reloadTx = await runnerDispatch(toWorker.GET_TRANSACTIONS, { mode: 'recent', limit: 100 }, { timeoutMs: phaseTimeoutMs });
+        const reloadRecords = await runnerDispatch(toWorker.GET_RECORDS, {}, { timeoutMs: phaseTimeoutMs });
+        const reloadHof = await runnerDispatch(toWorker.GET_HALL_OF_FAME, {}, { timeoutMs: phaseTimeoutMs });
+        const reloadDraftClasses = await runnerDispatch(toWorker.GET_DRAFT_CLASSES, {}, { timeoutMs: phaseTimeoutMs });
+        const reloadedLatest = Array.isArray(view?.leagueHistory) && view.leagueHistory.length ? view.leagueHistory[view.leagueHistory.length - 1] : null;
+        let reloadHistoryOk = true;
+        if (reloadedLatest?.id) {
+          const reloadHistory = await runnerDispatch(toWorker.GET_SEASON_HISTORY, { seasonId: reloadedLatest.id }, { timeoutMs: phaseTimeoutMs });
+          reloadHistoryOk = probeHandlerSucceeded(reloadHistory) && !!reloadHistory.payload?.data;
+        }
+        const after = snapshotReloadFields(view, reloadTx.payload?.transactions ?? []);
+        aggregate.reloadSummary = compareReloadSummary(before, after);
+        aggregate.reloadSummary.handlerProbeOk = {
+          allSeasons: probeHandlerSucceeded(reloadAllSeasons),
+          seasonHistory: reloadHistoryOk,
+          recentTransactions: probeHandlerSucceeded(reloadTx),
+          draftClasses: probeHandlerSucceeded(reloadDraftClasses),
+          records: probeHandlerSucceeded(reloadRecords) && !!(reloadRecords.payload?.recordBook || reloadRecords.payload?.records),
+          hallOfFame: probeHandlerSucceeded(reloadHof) && (!reloadHof.payload || Array.isArray(reloadHof.payload?.players)),
+        };
+        if (Object.values(aggregate.reloadSummary.handlerProbeOk).some((ok) => !ok)) {
+          aggregate.reloadSummary.ok = false;
+          aggregate.reloadSummary.mismatches.push({ key: 'reload_handler_probe', before: 'ok', after: JSON.stringify(aggregate.reloadSummary.handlerProbeOk) });
+        }
+      }
+      aggregate.persistenceAssertions.push({
+        id: 'reload_same_persistence_path',
+        ok: aggregate.reloadSummary?.ok === true,
+        code: aggregate.reloadSummary?.ok === true ? undefined : 'reload_corrupted_state',
+        detail: aggregate.reloadSummary?.ok === true
+          ? `Reload preserved year=${aggregate.reloadSummary.after.year} phase=${aggregate.reloadSummary.after.phase} seasons=${aggregate.reloadSummary.after.completedSeasonCount}`
+          : `Reload mismatch: ${JSON.stringify(aggregate.reloadSummary?.mismatches ?? [])}`,
+      });
+      if (aggregate.reloadSummary?.ok !== true) {
+        aggregate.passed = false;
+        aggregate.failures.push({ code: 'reload_corrupted_state', message: 'Save/load proof lost or corrupted critical dynasty state; see reloadSummary.' });
+      }
+    } catch (err) {
+      aggregate.passed = false;
+      aggregate.reloadSummary = { ok: false, error: err?.message || String(err) };
+      aggregate.failures.push({ code: 'reload_probe_throw', message: err?.message || String(err) });
+    }
+
     aggregate.severity = aggregate.failures.length ? 'error' : aggregate.warnings.length ? 'warn' : 'ok';
+    if (opts.failOnWarnings && aggregate.warnings.length > 0) aggregate.passed = false;
     aggregate.runtimeMs = Date.now() - t0;
     aggregate.seed = seed;
     aggregate.finalPhase = view?.phase ?? null;
     aggregate.finalYear = view?.year ?? null;
     aggregate.reportSummary = lastReportSummary;
+    aggregate.finalView = view;
     aggregate.timings.bootMs = checkpoints.filter((c) => c.name.startsWith('boot.')).reduce((a, c) => a + c.ms, 0);
     aggregate.timings.topSlowCheckpoints = topSlowCheckpoints(checkpoints);
     aggregate.timings.phaseBreakdown = buildPhaseBreakdown(checkpoints);
     aggregate.timings.totalMs = aggregate.runtimeMs;
     aggregate.dynastySoakSimBatch = view?.dynastySoakSimBatch ?? null;
+    aggregate.finalView = view;
 
     return aggregate;
   } catch (e) {
@@ -1391,7 +1504,7 @@ async function runCiDynastySoakOnce(opts = {}) {
 export async function runDynastySoakOnce(opts = {}) {
   const auditProfile = String(opts.runnerProfile ?? opts.auditProfile ?? (opts.ci ? 'ci' : 'full')).toLowerCase();
   if (auditProfile === 'ci') return runCiDynastySoakOnce({ ...opts, ci: true, auditProfile: 'ci' });
-  return runFullDynastySoakOnce({ ...opts, ci: false, auditProfile: 'full' });
+  return runFullDynastySoakOnce({ ...opts, ci: false, auditProfile: opts.auditProfile ?? 'full' });
 }
 
 export async function runDynastySoakMultiSeed(opts = {}) {
@@ -1405,7 +1518,7 @@ export async function runDynastySoakMultiSeed(opts = {}) {
       ...opts,
       seed,
       seeds: undefined,
-      auditProfile: opts.runnerProfile ?? 'ci',
+      auditProfile: opts.auditProfile ?? opts.runnerProfile ?? 'ci',
       runnerProfile: opts.runnerProfile ?? 'ci',
       ci: (opts.runnerProfile ?? 'ci') === 'ci',
     });

--- a/tests/unit/dynastySoakCli.test.js
+++ b/tests/unit/dynastySoakCli.test.js
@@ -366,6 +366,54 @@ describe('dynastySoakCli', () => {
     expect(longResolved.seasons).toBe(3);
   });
 
+
+
+  it('resolves stability-v1 as manual multi-seed completed-season profile', () => {
+    const parsed = parseDynastySoakArgv([
+      'node',
+      'x.mjs',
+      '--audit-profile=stability-v1',
+      '--seasons=7',
+      '--seeds=1,2,2,3',
+      '--fail-on-warnings',
+      '--max-runtime-ms=90000',
+      '--deep',
+      '--deep-each-season',
+    ]);
+    expect(parsed.errors).toEqual([]);
+
+    const { errors, resolved } = resolveDynastySoakConfig(parsed.raw);
+    expect(errors).toEqual([]);
+    expect(resolved.auditProfile).toBe('stability-v1');
+    expect(resolved.runnerProfile).toBe('full');
+    expect(resolved.phasePath).toBe('full-season');
+    expect(resolved.isMultiSeed).toBe(true);
+    expect(resolved.isStabilityV1).toBe(true);
+    expect(resolved.seasons).toBe(7);
+    expect(resolved.seeds).toEqual([1, 2, 3]);
+    expect(resolved.failOnWarnings).toBe(true);
+    expect(resolved.maxRuntimeMs).toBe(90000);
+    expect(resolved.deep).toBe(true);
+    expect(resolved.deepEachSeason).toBe(true);
+  });
+
+  it('keeps default CI behavior short and does not accidentally select stability-v1', () => {
+    const defaultResolved = resolveDynastySoakConfig(parseDynastySoakArgv(['node', 'x.mjs', '--ci']).raw).resolved;
+    expect(defaultResolved.auditProfile).toBe('ci');
+    expect(defaultResolved.runnerProfile).toBe('ci');
+    expect(defaultResolved.seasons).toBe(1);
+    expect(defaultResolved.seeds).toEqual([1383]);
+    expect(defaultResolved.isStabilityV1).toBe(false);
+  });
+
+  it('uses stability-v1 manual defaults of five seasons and three deterministic seeds', () => {
+    const { raw } = parseDynastySoakArgv(['node', 'x.mjs', '--audit-profile=stability-v1']);
+    const { resolved } = resolveDynastySoakConfig(raw);
+    expect(resolved.seasons).toBe(5);
+    expect(resolved.seeds).toEqual([1383, 1408, 1426]);
+    expect(resolved.ci).toBe(false);
+  });
+
   it('buildMarkdownReport includes multi-seed summary and grouped warnings', () => {
     const md = buildMarkdownReport({
       multiSeed: true,
@@ -395,6 +443,10 @@ describe('dynastySoakCli', () => {
     expect(md).toContain('Seed 1383');
     expect(md).toContain('runner_fatal');
     expect(md).toContain('Economy warning aggregate');
+    expect(md).toContain('Persistence/reload summary');
+    expect(md).toContain('What this proves');
+    expect(md).toContain('What this does not prove yet');
+    expect(md).toContain('Suggested next audit depth command');
     expect(md).toContain('economy_snapshot_missing');
   });
 

--- a/tests/unit/dynastySoakRunner.test.js
+++ b/tests/unit/dynastySoakRunner.test.js
@@ -417,4 +417,42 @@ describe('runDynastySoakOnce', () => {
     expect((await runDynastySoakMultiSeed({ ...base, failOnWarnings: true })).passed).toBe(false);
   });
 
+
+  it('keeps stability-v1 aggregation on the full-season runner profile', async () => {
+    const { runDynastySoakMultiSeed } = await import('../../src/testSupport/dynastySoakRunner.js');
+    const runOne = vi.fn(async ({ seed, auditProfile, runnerProfile, ci, seasons }) => ({
+      seed,
+      auditProfile,
+      runnerProfile,
+      passed: true,
+      severity: 'ok',
+      runtimeMs: 5,
+      seasonsSimmed: seasons,
+      finalPhase: 'preseason',
+      finalYear: 2031,
+      failures: [],
+      warnings: [],
+      persistenceAssertions: [{ id: 'reload_same_persistence_path', ok: true, detail: 'ok' }],
+      reloadSummary: { ok: true, before: { year: 2031 }, after: { year: 2031, phase: 'preseason', teamCount: 32, currentSeasonId: 's2031', completedSeasonCount: 5, transactionCountSample: 20, userTeamId: 0 }, mismatches: [] },
+      reportSummary: { economyRegressionSnapshot: { teamsOverCap: 0, teamsWithPendingOfferOvercommit: 0, pendingOfferOvercommitCount: 0, duplicateExpensiveSameGroupOffers: 0, oldVeteranOffersByRebuildTeams: 0, contenderVeteranOfferCount: 0, severeQbNeedOfferCount: 0, premiumYoungPlayerTradeDiscountFlags: 0, expensiveVeteranSwapFlags: 0, cpuOfferCount: 0, unknownOfferValueCount: 0, skippedReasons: [], warnings: [] } },
+      finalView: { seasonId: 's2031', userTeamId: 0, leagueHistory: [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }, { id: 'e' }] },
+      harnessConfig: { ci },
+    }));
+
+    const result = await runDynastySoakMultiSeed({
+      auditProfile: 'stability-v1',
+      runnerProfile: 'full',
+      phasePath: 'full-season',
+      seeds: [1383, 1408],
+      seasons: 5,
+      runOne,
+    });
+
+    expect(runOne).toHaveBeenCalledWith(expect.objectContaining({ auditProfile: 'stability-v1', runnerProfile: 'full', ci: false, seasons: 5 }));
+    expect(result.auditProfile).toBe('stability-v1');
+    expect(result.runnerProfile).toBe('full');
+    expect(result.seedSummaries[0].completedSeasonCount).toBe(5);
+    expect(result.persistenceReloadSummary[0].ok).toBe(true);
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Provide a named, CI‑safe Long‑Dynasty / Multi‑Seed Stability Audit V1 to surface long‑run dynasty regressions (multi‑season persistence, archive/history integrity, roster/cap stability, draft/offseason loops). 
- Preserve fast CI smoke paths while enabling a bounded manual release audit that can be tuned by season/seed/depth flags.
- Add persistence/reload proof and stronger hard invariants so corruption fails the audit instead of being hidden as a warning.

### Description
- CLI/profile: add `stability-v1` support and defaults (5 seasons × 3 deterministic seeds), accept `--seasons`, `--seeds`, `--fail-on-warnings`, `--max-runtime-ms`, `--deep`, and `--deep-each-season`; keep CI short path unchanged (`src/testSupport/dynastySoakCli.js`).
- Runner + persistence: extend full‑season runner to force `SAVE_NOW`, `LOAD_SAVE` through worker, re‑probe `GET_*` handlers, snapshot before/after fields and compare (year/phase/teamCount/currentSeasonId/completedSeasonCount/tx sample/userTeamId), and fail on reload corruption (`src/testSupport/dynastySoakRunner.js`).
- Stronger invariants & balance checks: add numeric/shape validations and new warnings/failures (league year/phase, missing team/roster containers, duplicate player IDs, contract/cap critical values, archived standings plausibility, transaction explosion/orphan refs, QB scarcity collapse, talent/draft quality outliers, contender offer sanity) in the pure audit (`src/core/dynastySoakAudit.js`).
- Reporting & docs: expand multi‑seed JSON/Markdown output with seeds/seasons per seed/runtime per seed/completed archives/persistence reload summaries/slow checkpoints/“what this proves” text and add `docs/dynasty-stability-audit.md` describing usage and limits (`src/testSupport/dynastySoakCli.js`).
- Scripts & tests: add npm scripts `audit:dynasty:stability` and `audit:dynasty:stability:deep`, update `audit:dynasty:multi` behavior, and add fast Vitest unit tests for CLI parsing, multi‑seed aggregation, report generation and reload aggregation (`package.json`, `tests/unit/*`).

### Testing
- Static checks: `node --check` run against modified helpers (`src/testSupport/dynastySoakRunner.js`, `src/testSupport/dynastySoakCli.js`, `src/core/dynastySoakAudit.js`, `scripts/dynasty-soak.mjs`) and `git diff --check` completed with no issues.
- Unit / soak tests: `npm run test:soak` (Vitest subset) and `npm run test:unit` (full Vitest) both passed (all audit unit tests and repository unit tests succeeded).
- Build: `npm run build` completed successfully (classic large worker chunk warning retained as expected).
- Real‑worker runs: `npm run audit:dynasty:multi` executed (multi‑seed CI smoke path; completed quickly and wrote artifacts); `npm run audit:dynasty:stability -- --max-runtime-ms=120000` was attempted but the full 32‑team `SIM_TO_PHASE` work is inherently long and the attempt was terminated after a worker call exceeded the interactive window (this matches the harness design that `--max-runtime-ms` is checked between checkpoints rather than mid‑SIM_TO_PHASE).

Notes: normal CI behavior was preserved (CI/profile remains short), balance issues are warnings by default and can be made blocking with `--fail-on-warnings`, and the PR includes documentation and unit tests to validate parsing, aggregation, and reporting for Stability V1.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04d6930090832da5ec99a0fa3b2a20)