### PR TITLE
Fix completed Game Book score integrity and polish limited-detail fallbacks

### DIFF
--- a/src/core/__tests__/gameArchive.test.js
+++ b/src/core/__tests__/gameArchive.test.js
@@ -3,11 +3,48 @@ import {
   classifyArchiveQuality,
   enrichArchivedGamePayload,
   normalizeArchivedGamePayload,
+  mergeArchivedGameWithScheduleResult,
   recoverArchivedGameFromSchedule,
   summarizeArchiveDefects,
 } from '../gameArchive.js';
 
 describe('gameArchive helpers', () => {
+
+  it('retains completed-game score and detail through JSON save/reload normalization', () => {
+    const archived = normalizeArchivedGamePayload({
+      id: '2031_w2_1_2',
+      seasonId: '2031',
+      week: 2,
+      homeId: 1,
+      awayId: 2,
+      homeScore: 31,
+      awayScore: 28,
+      quarterScores: { home: [7, 7, 7, 10], away: [7, 7, 7, 7] },
+      teamStats: { home: { totalYards: 410 }, away: { totalYards: 390 } },
+      playerStats: { home: { 10: { name: 'Home QB', stats: { passYd: 301 } } }, away: { 20: { name: 'Away QB', stats: { passYd: 288 } } } },
+      recap: 'Home team won late.',
+    });
+    const reloaded = normalizeArchivedGamePayload(JSON.parse(JSON.stringify(archived)));
+    expect(reloaded.homeScore).toBe(31);
+    expect(reloaded.awayScore).toBe(28);
+    expect(reloaded.quarterScores.home).toEqual([7, 7, 7, 10]);
+    expect(reloaded.teamStats.home.totalYards).toBe(410);
+    expect(reloaded.playerStats.home[10].stats.passYd).toBe(301);
+    expect(reloaded.recap).toBe('Home team won late.');
+  });
+
+  it('reconciles stale archive scores with the completed schedule source of truth', () => {
+    const merged = mergeArchivedGameWithScheduleResult(
+      { id: '2031_w4_1_2', seasonId: '2031', week: 4, homeId: 1, awayId: 2, homeScore: 0, awayScore: 0, playerStats: { home: { 10: { stats: { passYd: 200 } } }, away: {} } },
+      { gameId: '2031_w4_1_2', seasonId: '2031', week: 4, home: { id: 1, abbr: 'PIT' }, away: { id: 2, abbr: 'MIN' }, homeScore: 13, awayScore: 24, played: true },
+    );
+    expect(merged.homeScore).toBe(13);
+    expect(merged.awayScore).toBe(24);
+    expect(merged.playerStats.home[10].stats.passYd).toBe(200);
+    expect(merged.homeAbbr).toBe('PIT');
+    expect(merged.awayAbbr).toBe('MIN');
+  });
+
   it('classifies full archives only when core sections exist', () => {
     const game = normalizeArchivedGamePayload({
       id: '2030_w3_1_2',

--- a/src/core/gameArchive.js
+++ b/src/core/gameArchive.js
@@ -13,6 +13,13 @@ const asNumberOrNull = (value) => {
 
 const hasValues = (obj) => Boolean(obj && typeof obj === 'object' && Object.keys(obj).length > 0);
 
+const hasFinalScore = (game) => Number.isFinite(Number(game?.homeScore ?? game?.scoreHome ?? game?.score?.home))
+  && Number.isFinite(Number(game?.awayScore ?? game?.scoreAway ?? game?.score?.away));
+
+function teamLabel(rawGame, side, key) {
+  return rawGame?.[`${side}${key}`] ?? rawGame?.[side]?.[key.toLowerCase()] ?? rawGame?.[side]?.[key] ?? null;
+}
+
 function normalizeQuarterScores(input) {
   if (!input || typeof input !== 'object') return null;
   const home = Array.isArray(input.home) ? input.home : Array.isArray(input.h) ? input.h : null;
@@ -168,6 +175,10 @@ export function normalizeArchivedGamePayload(rawGame) {
     phase: rawGame?.phase ?? null,
     homeId,
     awayId,
+    homeAbbr: teamLabel(rawGame, 'home', 'Abbr'),
+    awayAbbr: teamLabel(rawGame, 'away', 'Abbr'),
+    homeName: teamLabel(rawGame, 'home', 'Name'),
+    awayName: teamLabel(rawGame, 'away', 'Name'),
     homeScore: asNumberOrNull(rawGame?.homeScore ?? rawGame?.scoreHome ?? rawGame?.score?.home),
     awayScore: asNumberOrNull(rawGame?.awayScore ?? rawGame?.scoreAway ?? rawGame?.score?.away),
     quarterScores: normalizeQuarterScores(rawGame?.quarterScores ?? rawGame?.linescore),
@@ -233,6 +244,43 @@ function buildSyntheticPlayerRows(game) {
   addLeader(categories.receive, ['targets', 'receptions', 'recYd', 'recTD']);
   addLeader(categories.defense, ['tackles', 'sacks', 'interceptions', 'passesDefended', 'forcedFumbles']);
   return template;
+}
+
+export function mergeArchivedGameWithScheduleResult(archivedGame, scheduleGame) {
+  const archived = normalizeArchivedGamePayload(archivedGame);
+  const schedule = normalizeArchivedGamePayload(scheduleGame);
+  if (!archived && !schedule) return null;
+  if (!schedule || !hasFinalScore(schedule)) return archived;
+  if (!archived) return schedule;
+
+  const sameId = Boolean(schedule.id && archived.id && String(schedule.id) === String(archived.id));
+  const sameMatchup = Number(schedule.homeId) === Number(archived.homeId)
+    && Number(schedule.awayId) === Number(archived.awayId)
+    && (schedule.week == null || archived.week == null || Number(schedule.week) === Number(archived.week));
+  if (!sameId && !sameMatchup) return archived;
+
+  return normalizeArchivedGamePayload({
+    ...archived,
+    id: archived.id ?? schedule.id,
+    gameId: archived.gameId ?? schedule.gameId ?? schedule.id,
+    seasonId: archived.seasonId ?? schedule.seasonId,
+    week: archived.week ?? schedule.week,
+    phase: archived.phase ?? schedule.phase,
+    played: true,
+    homeId: schedule.homeId ?? archived.homeId,
+    awayId: schedule.awayId ?? archived.awayId,
+    homeAbbr: archived.homeAbbr ?? schedule.homeAbbr,
+    awayAbbr: archived.awayAbbr ?? schedule.awayAbbr,
+    homeName: archived.homeName ?? schedule.homeName,
+    awayName: archived.awayName ?? schedule.awayName,
+    homeScore: schedule.homeScore,
+    awayScore: schedule.awayScore,
+    quarterScores: archived.quarterScores ?? schedule.quarterScores,
+    recap: archived.recap ?? schedule.recap,
+    recapText: archived.recapText ?? schedule.recapText,
+    summary: archived.summary ?? schedule.summary,
+    archiveQuality: archived.archiveQuality,
+  });
 }
 
 export function enrichArchivedGamePayload(rawGame) {
@@ -308,6 +356,10 @@ export function recoverArchivedGameFromSchedule(gameId, leagueState) {
         awayId: rowAway,
         homeScore: row?.homeScore,
         awayScore: row?.awayScore,
+        homeAbbr: row?.homeAbbr ?? row?.home?.abbr ?? null,
+        awayAbbr: row?.awayAbbr ?? row?.away?.abbr ?? null,
+        homeName: row?.homeName ?? row?.home?.name ?? null,
+        awayName: row?.awayName ?? row?.away?.name ?? null,
         quarterScores: row?.quarterScores ?? null,
         recap: row?.recap ?? 'Legacy result restored from schedule final score.',
         summary: row?.summary ?? null,

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { EmptyState } from "./ScreenSystem.jsx";
-import { buildBoxScoreViewModel, buildPlayerStatSections } from "../utils/boxScoreViewModel.js";
+import { buildBoxScoreViewModel, buildPlayerStatSections, unwrapBoxScoreResponse } from "../utils/boxScoreViewModel.js";
 import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 import { buildGameBookStory } from "../utils/gameBookStory.js";
 import { getPlayerProfileId, hasValidPlayerProfileId, openPlayerProfile } from "../utils/playerProfileNavigation.js";
@@ -47,7 +47,7 @@ function leaderProfileRole(card) {
   return `${card?.label ?? "Box score"} leader`;
 }
 
-function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, onTeamSelect, embedded = false }) {
+function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, onTeamSelect, embedded = false, scheduleGame = null }) {
   const canLoadArchive = Boolean(gameId && typeof actions?.getBoxScore === "function");
   const { data: archiveGame } = useStableRouteRequest({
     requestKey: canLoadArchive ? `boxscore:${gameId}` : null,
@@ -56,9 +56,9 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
     fetcher: () => actions.getBoxScore(gameId),
   });
 
-  const fallbackGame = league?.gameById?.[gameId] ?? null;
-  const game = archiveGame ?? fallbackGame;
-  const vm = useMemo(() => buildBoxScoreViewModel({ league, game, gameId, context: { season: league?.seasonId, week: league?.week } }), [league, game, gameId]);
+  const fallbackGame = scheduleGame ?? league?.gameById?.[gameId] ?? null;
+  const game = unwrapBoxScoreResponse(archiveGame) ?? fallbackGame;
+  const vm = useMemo(() => buildBoxScoreViewModel({ league, game, gameId, scheduleGame: fallbackGame, context: { season: league?.seasonId, week: league?.week } }), [league, game, gameId, fallbackGame]);
   const [sortState, setSortState] = useState({});
 
   if (!vm || vm.status === "unavailable") {
@@ -187,8 +187,9 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
       </section>
       <section className="bs-section" data-testid="game-book-decision-summary">
         <h4>Why this game was decided</h4>
-        {storyBullets.length ? <ul>{storyBullets.map((b) => <li key={b}>{b}</li>)}</ul> : <p>No detailed team/player stats were recorded for this game.</p>}
+        {storyBullets.length ? <ul>{storyBullets.map((b) => <li key={b}>{b}</li>)}</ul> : <p>{vm.missingDetailReason ?? "Limited game detail is available for this archived result."}</p>}
       </section>
+      {statLeaderCards.some((card) => card.available) ? (
       <section className="bs-section" data-testid="game-book-top-performers">
         <div className="bs-section-header">
           <h4>Top performers</h4>
@@ -201,15 +202,16 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
               {card.player && onPlayerSelect ? (
                 <button type="button" className="btn-link bs-leader-name" data-testid="game-book-top-performer-link" onClick={() => openGameBookPlayer(card.player, leaderProfileRole(card))}>{card.line}</button>
               ) : <p className="bs-leader-name">{card.line}</p>}
-              {card.teamSide ? <span className="bs-leader-team">{card.teamSide === "away" ? vm.awayTeam.abbr : vm.homeTeam.abbr}</span> : <span className="bs-leader-team">Stat group missing</span>}
+              {card.teamSide ? <span className="bs-leader-team">{card.teamSide === "away" ? vm.awayTeam.abbr : vm.homeTeam.abbr}</span> : null}
             </article>
           ))}
         </div>
       </section>
+      ) : null}
+      {hasQuarter ? (
       <section className="bs-section" data-testid="game-book-quarter-scores">
         <h4>Score by quarter</h4>
-        {hasQuarter ? (
-          <div className="bs-table-wrap">
+        <div className="bs-table-wrap">
             <table className="box-score-table">
               <thead>
                 <tr><th>Team</th>{headers.map((h) => <th key={h}>{h}</th>)}<th>Final</th></tr>
@@ -228,24 +230,24 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
               </tbody>
             </table>
           </div>
-        ) : <p>Quarter-by-quarter scoring was not recorded for this game.</p>}
       </section>
+      ) : null}
 
+      {teamRows.length ? (
       <section className="bs-section" data-testid="game-book-team-comparison">
         <h4>Team comparison</h4>
-        {teamRows.length ? (
           <div className="bs-table-wrap">
             <table className="box-score-table">
               <thead><tr><th>Stat</th><th>{vm.awayTeam.abbr}</th><th>{vm.homeTeam.abbr}</th></tr></thead>
               <tbody>{teamRows.map((row) => <tr key={row.key ?? row.label}><td>{row.label}</td><td className={row.winner === "away" ? "bs-compare-value--winner" : undefined}>{row.away ?? mdash}</td><td className={row.winner === "home" ? "bs-compare-value--winner" : undefined}>{row.home ?? mdash}</td></tr>)}</tbody>
             </table>
           </div>
-        ) : <p>Team totals were not recorded for this game.</p>}
       </section>
+      ) : null}
 
+      {vm.scoringSummary?.length ? (
       <section className="bs-section" data-testid="game-book-scoring-summary">
         <h4>Scoring summary</h4>
-        {vm.scoringSummary?.length ? (
           <div className="bs-table-wrap">
             <table className="box-score-table">
               <thead><tr><th>Qtr</th><th>Time</th><th>Team</th><th>Type</th><th>Description</th><th>Score</th></tr></thead>
@@ -263,17 +265,12 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
               </tbody>
             </table>
           </div>
-        ) : <p>Scoring summary was not recorded for this game.</p>}
       </section>
+      ) : null}
       {vm.prepImpact?.length ? (
         <section className="bs-section"><h4>Game-plan impact</h4><ul>{vm.prepImpact.map((item, i) => <li key={`${i}-${item}`}>{item}</li>)}</ul></section>
       ) : null}
-      {tableSections.length ? tableSections.map(renderTable) : (
-        <section className="bs-section" data-testid="game-book-player-stats-empty">
-          <h4>Player stat tables</h4>
-          <p>Player box score rows were not recorded for this game.</p>
-        </section>
-      )}
+      {tableSections.length ? tableSections.map(renderTable) : null}
     </div>
   );
 }

--- a/src/ui/components/BoxScore.test.jsx
+++ b/src/ui/components/BoxScore.test.jsx
@@ -36,9 +36,26 @@ describe('BoxScore game book rendering', () => {
 
   it('uses placeholders for score-only games and omits stat tables', () => {
     const html = renderToString(<BoxScore gameId="g4" league={{ ...baseLeague, gameById: { g4: { homeId: 1, awayId: 2, homeScore: 6, awayScore: 3 } } }} embedded />);
-    expect(html).toContain('Detailed box score data was not recorded for this game.');
-    expect(html).toContain('Scoring summary was not recorded for this game.');
+    expect(html).toContain('Limited game detail is available for this archived result.');
+    expect(html).not.toContain('Scoring summary was not recorded for this game.');
     expect(html).not.toContain('Special Teams');
+  });
+
+  it('keeps Game Book final score aligned with completed weekly card data when archive score is stale', () => {
+    vi.mocked(useStableRouteRequest).mockReturnValue({ data: { payload: { game: { gameId: '2031_w4_1_2', homeId: 1, awayId: 2, homeScore: 0, awayScore: 0 } } } });
+    const scheduleGame = { gameId: '2031_w4_1_2', home: { id: 1, abbr: 'KC' }, away: { id: 2, abbr: 'BUF' }, homeScore: 13, awayScore: 24, played: true, week: 4 };
+    const { getByTestId, container } = render(<BoxScore gameId="2031_w4_1_2" league={baseLeague} actions={{ getBoxScore: vi.fn() }} scheduleGame={scheduleGame} embedded />);
+    expect(getByTestId('game-book-final-score').textContent).toBe('BUF 24 - 13 KC');
+    expect(container.textContent).not.toContain('BUF 0 - 0 KC');
+  });
+
+  it('uses polished limited-detail fallback copy and hides debug-style empty sections', () => {
+    const { container, queryByTestId } = render(<BoxScore gameId="g-limited" league={{ ...baseLeague, gameById: { 'g-limited': { homeId: 1, awayId: 2, homeScore: 6, awayScore: 3 } } }} embedded />);
+    expect(container.textContent).toContain('Limited game detail is available for this archived result.');
+    expect(container.textContent).not.toContain('Stat group missing');
+    expect(container.textContent).not.toContain('Player box score rows were not recorded');
+    expect(queryByTestId('game-book-top-performers')).toBeNull();
+    expect(queryByTestId('game-book-player-stats-empty')).toBeNull();
   });
 
   it('player buttons trigger selection handlers with Game Book return context when ids are present', () => {
@@ -112,7 +129,7 @@ describe('BoxScore game book rendering', () => {
       },
     };
     const { container, getByTestId, getByText, getAllByText } = render(<BoxScore gameId="g-density" league={{ ...baseLeague, gameById: { 'g-density': game } }} onBack={onBack} embedded />);
-    expect(getByText('KC defeated BUF by 3')).toBeTruthy();
+    expect(getAllByText('KC defeated BUF by 3').length).toBeGreaterThan(0);
     expect(getAllByText('Team stats').length).toBeGreaterThan(0);
     expect(getByText('Showing 2 passers')).toBeTruthy();
     const passingText = container.querySelector('[data-testid="game-book-table-passing"]').textContent;

--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -21,7 +21,7 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
   const scheduleGame = findScheduleGame(league, gameId);
   const userTeam = (league?.teams ?? []).find((team) => Number(team?.id) === Number(league?.userTeamId));
   const prepContext = buildWeeklyDecisionImpact({ league, userTeam, lastGame: scheduleGame });
-  const detailVm = buildBoxScoreViewModel({ league, game: scheduleGame ?? league?.gameById?.[gameId], gameId, context: { season: league?.seasonId, week: weekFromId ?? league?.week } });
+  const detailVm = buildBoxScoreViewModel({ league, game: scheduleGame ?? league?.gameById?.[gameId], gameId, scheduleGame, context: { season: league?.seasonId, week: weekFromId ?? league?.week } });
   const screenTitle = detailVm?.availableData?.finalScore ? detailVm.headlineSummary : 'Game Book';
   const screenSubtitle = detailVm?.availableData?.finalScore
     ? `${detailVm.finalScoreLine} · Game Book sections show only data recorded for this final.`
@@ -82,6 +82,7 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
           onBack={onBack}
           onPlayerSelect={onPlayerSelect}
           onTeamSelect={onTeamSelect}
+          scheduleGame={scheduleGame}
         />
       </SectionCard>
     </div>

--- a/src/ui/utils/boxScoreViewModel.js
+++ b/src/ui/utils/boxScoreViewModel.js
@@ -1,4 +1,4 @@
-import { normalizeArchivedGamePayload } from '../../core/gameArchive.js';
+import { mergeArchivedGameWithScheduleResult, normalizeArchivedGamePayload } from '../../core/gameArchive.js';
 
 const QUALITY = { full: 'Full detail', partial: 'Partial detail', score: 'Score only', missing: 'Missing detail' };
 
@@ -13,8 +13,8 @@ function teamInfo(league, id, side, game) {
   const team = (league?.teams ?? []).find((t) => Number(t?.id) === Number(id)) ?? league?.teamById?.[id] ?? null;
   return {
     id: id ?? null,
-    abbr: team?.abbr ?? game?.[`${side}Abbr`] ?? (side === 'home' ? 'HOME' : 'AWAY'),
-    name: team?.name ?? game?.[`${side}Name`] ?? team?.abbr ?? 'Unknown',
+    abbr: team?.abbr ?? game?.[`${side}Abbr`] ?? game?.[side]?.abbr ?? (side === 'home' ? 'HOME' : 'AWAY'),
+    name: team?.name ?? game?.[`${side}Name`] ?? game?.[side]?.name ?? team?.abbr ?? 'Unknown',
     logo: team?.logo ?? team?.logoUrl ?? null,
   };
 }
@@ -214,8 +214,13 @@ function normalizeScoringSummary(rows) {
   }));
 }
 
-export function buildBoxScoreViewModel({ league, game, gameId, context = {} } = {}) {
-  const payload = normalizeArchivedGamePayload(game ?? null) ?? game ?? null;
+export function unwrapBoxScoreResponse(response) {
+  return response?.payload?.game ?? response?.game ?? response ?? null;
+}
+
+export function buildBoxScoreViewModel({ league, game, gameId, context = {}, scheduleGame = null } = {}) {
+  const rawGame = unwrapBoxScoreResponse(game);
+  const payload = mergeArchivedGameWithScheduleResult(rawGame, scheduleGame) ?? normalizeArchivedGamePayload(rawGame ?? null) ?? rawGame ?? null;
   if (!payload) {
     return { gameId: gameId ?? null, status: 'unavailable', archiveQuality: QUALITY.missing, hasDetailedStats: false, missingDetailReason: 'Game data missing' };
   }
@@ -278,8 +283,8 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {} } = 
       drives: Array.isArray(payload?.driveSummary) && payload.driveSummary.length > 0,
     },
     prepImpact: Array.isArray(payload?.prepImpact) ? payload.prepImpact : (payload?.prepImpact ? [String(payload.prepImpact)] : []),
-    detailWarning: archiveQuality === QUALITY.partial ? 'Partial archive: some Game Book sections were not recorded.' : archiveQuality === QUALITY.score ? 'Detailed box score data was not recorded for this game.' : archiveQuality === QUALITY.missing ? 'Game data missing.' : null,
-    missingDetailReason: archiveQuality === QUALITY.partial ? 'Partial archive: some Game Book sections were not recorded.' : archiveQuality === QUALITY.score ? 'Detailed box score data was not recorded for this game.' : archiveQuality === QUALITY.missing ? 'Game data missing.' : null,
+    detailWarning: archiveQuality === QUALITY.partial || archiveQuality === QUALITY.score ? 'Limited game detail is available for this archived result.' : archiveQuality === QUALITY.missing ? 'Game data missing.' : null,
+    missingDetailReason: archiveQuality === QUALITY.partial || archiveQuality === QUALITY.score ? 'Limited game detail is available for this archived result.' : archiveQuality === QUALITY.missing ? 'Game data missing.' : null,
     hasDetailedStats: archiveQuality === QUALITY.full || archiveQuality === QUALITY.partial,
   };
 }

--- a/src/ui/utils/boxScoreViewModel.test.js
+++ b/src/ui/utils/boxScoreViewModel.test.js
@@ -12,13 +12,13 @@ describe('buildBoxScoreViewModel', () => {
   it('classifies partial detail warning copy', () => {
     const vm = buildBoxScoreViewModel({ game: { played: true, homeScore: 10, awayScore: 7, teamStats: { home: { passYards: 100 }, away: {} } } });
     expect(vm.archiveQuality).toBe('Partial detail');
-    expect(vm.detailWarning).toContain('Partial archive');
+    expect(vm.detailWarning).toBe('Limited game detail is available for this archived result.');
   });
 
   it('classifies score only data warning copy', () => {
     const vm = buildBoxScoreViewModel({ game: { played: true, homeScore: 3, awayScore: 0 } });
     expect(vm.archiveQuality).toBe('Score only');
-    expect(vm.detailWarning).toContain('Detailed box score data');
+    expect(vm.detailWarning).toBe('Limited game detail is available for this archived result.');
   });
 
   it('classifies missing detail when score unavailable', () => {
@@ -51,6 +51,25 @@ describe('buildBoxScoreViewModel', () => {
     expect(vm.teamComparisonRows.find((row) => row.key === 'turnovers')?.winner).toBe('away');
   });
 
+  it('uses the completed schedule result as score source of truth over stale archive scores', () => {
+    const vm = buildBoxScoreViewModel({
+      league: { teams: [{ id: 1, abbr: 'PIT' }, { id: 2, abbr: 'MIN' }] },
+      game: { gameId: '2031_w4_1_2', homeId: 1, awayId: 2, homeScore: 0, awayScore: 0, playerStats: { home: {}, away: {} } },
+      scheduleGame: { gameId: '2031_w4_1_2', home: { id: 1, abbr: 'PIT' }, away: { id: 2, abbr: 'MIN' }, homeScore: 13, awayScore: 24, played: true, week: 4 },
+    });
+    expect(vm.finalScore).toEqual({ home: 13, away: 24 });
+    expect(vm.finalScoreLine).toBe('MIN 24 - 13 PIT');
+    expect(vm.headlineSummary).toBe('MIN defeated PIT by 11');
+  });
+
+  it('unwraps worker BOX_SCORE response envelopes before building the game book', () => {
+    const vm = buildBoxScoreViewModel({
+      league: { teams: [{ id: 1, abbr: 'KC' }, { id: 2, abbr: 'BUF' }] },
+      game: { type: 'BOX_SCORE', payload: { game: { homeId: 1, awayId: 2, homeScore: 20, awayScore: 23 } } },
+    });
+    expect(vm.finalScoreLine).toBe('BUF 23 - 20 KC');
+  });
+
   it('builds sorted player stat sections with stable defaults', () => {
     const vm = buildBoxScoreViewModel({
       game: {
@@ -74,7 +93,6 @@ describe('buildBoxScoreViewModel', () => {
     expect(passing?.teams.home.map((player) => player.name)).toEqual(['Higher QB', 'Lower QB']);
     expect(vm.playerStatSections.find((section) => section.key === 'rushing')?.teams.away[0].name).toBe('Away RB');
   });
-
 
   it('builds deterministic top performer cards for passing/rushing/receiving/defense/kicking only from recorded stats', () => {
     const vm = buildBoxScoreViewModel({

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -143,7 +143,7 @@ import { getTradeWindowSnapshot, isTradeWindowOpen } from '../core/tradeWindow.j
 import { archiveCompletedSeasonIfNeeded, ensureLeagueHistoryContainer } from '../core/leagueHistory.js';
 import { ensurePersonalityProfile, mentorshipBonusForPlayer, contractPersonalityModifier } from '../core/development/personalitySystem.js';
 import { buildCanonicalGameId, buildArchivedGame, toTeamId } from '../core/gameIdentity.js';
-import { normalizeArchivedGamePayload, classifyArchiveQuality, validateArchivedGame, recoverArchivedGameFromSchedule, enrichArchivedGamePayload } from '../core/gameArchive.js';
+import { normalizeArchivedGamePayload, classifyArchiveQuality, validateArchivedGame, recoverArchivedGameFromSchedule, enrichArchivedGamePayload, mergeArchivedGameWithScheduleResult } from '../core/gameArchive.js';
 import {
   DEFAULT_LEAGUE_ECONOMY,
   normalizeLeagueEconomy,
@@ -3498,6 +3498,9 @@ function applyGameResultToCache(result, week, seasonId) {
       recapThreeSentence,
       leaders: playerLeaders?.categories ?? null,
       playerOfGame: playerLeaders?.playerOfGame ?? null,
+      result: tie ? 'tie' : (homeWin ? 'home_win' : 'away_win'),
+      winnerId: tie ? null : winnerId,
+      loserId: tie ? null : (winnerId === hId ? aId : hId),
       standoutPerformances: playerLeaders?.standouts ?? [],
       storyline,
       developmentFlash: Array.isArray(result?.developmentFlash) ? result.developmentFlash.slice(0, 2) : [],
@@ -4837,7 +4840,8 @@ async function handleGetBoxScore({ gameId }, id) {
       }
     }
 
-    if (!game) game = buildScheduleFallback();
+    const scheduleFallback = buildScheduleFallback();
+    game = game ? mergeArchivedGameWithScheduleResult(game, scheduleFallback) : scheduleFallback;
 
     game = enrichArchivedGamePayload(game);
 


### PR DESCRIPTION
### Motivation
- The Game Book detail could load a stale/minimal archived payload (or a worker response envelope) while the weekly result card used the schedule row, allowing completed finals to display as 0-0 and exposing raw debug fallback strings.
- Completed games need a single source of truth for final score and a polished, mobile-first Game Book presentation when detailed stats are partial or missing.

### Description
- Reconcile archive vs schedule: add `mergeArchivedGameWithScheduleResult` to `src/core/gameArchive.js` to let a completed schedule result override stale archive score fields while preserving recorded player/team details and labels. (core/gameArchive)
- Worker change: `GET_BOX_SCORE` now merges the schedule fallback with any archived payload before enrichment so responses returned to the UI can't be overwritten by stale 0-0 archives. (worker/worker.js)
- ViewModel & envelope handling: `buildBoxScoreViewModel` now unwraps worker `BOX_SCORE` envelopes and accepts a `scheduleGame` override; it builds its view model from the reconciled payload and consolidates fallback copy to a single polished message. (ui/utils/boxScoreViewModel.js)
- UI presentation: `BoxScore` (Game Book) uses the schedule fallback, hides empty/debug-style sections (Top Performers, quarter/team/scoring/players) when unavailable, and shows a dominant final-score header with a single limited-detail explanation when needed. (ui/components/BoxScore.jsx, GameDetailScreen.jsx)
- Tests: add regression/unit coverage for stale archive vs schedule reconciliation, worker envelope unwrapping, save/reload normalization, and the polished limited-detail UI. (core/__tests__/gameArchive.test.js, ui/utils/boxScoreViewModel.test.js, ui/components/BoxScore.test.jsx)

### Testing
- Ran unit tests: `npm run test:unit` — all unit tests passed (full test suite green in CI-local run).
- Ran dynasty soak subset: `npm run test:soak` — soak tests passed.
- Built production bundle: `npm run build` — build succeeded (chunk-size warnings only).
- Playwright smoke: `npx playwright test tests/e2e/fresh_franchise_first_week_smoke.spec.js` — attempted but blocked because browsers are not installed in the environment (Playwright requested `npx playwright install --with-deps chromium`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04f8b4f49c832d9b0a1273e3f39c75)