### PR TITLE
chore: clarify guard comment for league finalization

### DIFF
--- a/league-playable-comment-commits.txt
+++ b/league-playable-comment-commits.txt
@@ -1,0 +1,1 @@
+6f5668b chore: clarify guard comment for league finalization

--- a/league-playable-comment.patch
+++ b/league-playable-comment.patch
@@ -1,0 +1,13 @@
+diff --git a/src/ui/App.jsx b/src/ui/App.jsx
+index 9560f8d..fe2105d 100644
+--- a/src/ui/App.jsx
++++ b/src/ui/App.jsx
+@@ -554,7 +554,7 @@ function AppContent() {
+   useEffect(() => {
+     if (safeStarterInFlightRef.current) return;
+     if (!shouldFinalizeNewSlotBootstrap({ league, pendingNewSlot })) return;
+-    // FIX: Only save and finalize if the league is actually playable
++    // Only save and finalize if the league is actually playable.
+     if (hasMinimumPlayableLeague(league)) {
+       actions.saveSlot(pendingNewSlot);
+       setActiveSlot(pendingNewSlot);

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -554,7 +554,7 @@ function AppContent() {
   useEffect(() => {
     if (safeStarterInFlightRef.current) return;
     if (!shouldFinalizeNewSlotBootstrap({ league, pendingNewSlot })) return;
-    // FIX: Only save and finalize if the league is actually playable
+    // Only save and finalize if the league is actually playable.
     if (hasMinimumPlayableLeague(league)) {
       actions.saveSlot(pendingNewSlot);
       setActiveSlot(pendingNewSlot);


### PR DESCRIPTION
Removes the misleading "FIX:" prefix from the guard comment in `App.jsx` to correctly reflect that it is an active safeguard rather than a pending fix. 

Tested successfully against unit tests and E2E smoke tests.

---
*PR created automatically by Jules for task [3737582779407252330](https://jules.google.com/task/3737582779407252330) started by @rbcati*