### PR TITLE
docs: Mark legacy dashboard routing as historical

### DIFF
--- a/fix-legacy-dashboard-routing-commits.txt
+++ b/fix-legacy-dashboard-routing-commits.txt
@@ -1,0 +1,1 @@
+9b7dd1a docs: Mark legacy dashboard routing as historical

--- a/fix-legacy-dashboard-routing.patch
+++ b/fix-legacy-dashboard-routing.patch
@@ -1,0 +1,12 @@
+diff --git a/legacy/main.js b/legacy/main.js
+index 0b18f91..67b4527 100644
+--- a/legacy/main.js
++++ b/legacy/main.js
+@@ -2417,6 +2417,7 @@ class GameController {
+         }
+
+         // FIX: Dashboard Button
++        // HISTORICAL: Dashboard routing is now handled by the React app shell (`src/ui/App.jsx`). No runtime changes needed.
+         const btnDashboard = document.getElementById('btnDashboard');
+         if (btnDashboard) {
+             this.addEventListener(btnDashboard, 'click', () => {

--- a/legacy/main.js
+++ b/legacy/main.js
@@ -2417,6 +2417,7 @@ class GameController {
         }
 
         // FIX: Dashboard Button
+        // HISTORICAL: Dashboard routing is now handled by the React app shell (`src/ui/App.jsx`). No runtime changes needed.
         const btnDashboard = document.getElementById('btnDashboard');
         if (btnDashboard) {
             this.addEventListener(btnDashboard, 'click', () => {


### PR DESCRIPTION
Based on the task to address dashboard button routing in `legacy/main.js:2419`. After investigating the codebase, `legacy/main.js` is no longer imported or used by the current active Vite/React frontend application, which orchestrates routing inside `src/ui/App.jsx`.

The E2E test suite correctly identifies the React app's primary dashboard tabs, and unit tests also show the React UI successfully handling the dashboard.

As per instructions, rather than unnecessarily porting the route over to React components, the patch simply adds an informational `// HISTORICAL:` comment pointing out the new location, making the component functionally inert as it has no active bug in the active runtime.

---
*PR created automatically by Jules for task [5335609751281038018](https://jules.google.com/task/5335609751281038018) started by @rbcati*