### PR TITLE
chore: clarify Names/Generation race condition comment

### DIFF
--- a/names-generation-comment-clarification-commits.txt
+++ b/names-generation-comment-clarification-commits.txt
@@ -1,0 +1,1 @@
+5377a94 chore: clarify Names/Generation race condition comment

--- a/names-generation-comment-clarification.patch
+++ b/names-generation-comment-clarification.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core/constants.js b/src/core/constants.js
+index 6e0140a..bc04a5f 100644
+--- a/src/core/constants.js
++++ b/src/core/constants.js
+@@ -461,7 +461,7 @@
+     LEAGUE_GEN_CONFIG,
+     ROSTER_LIMITS,
+
+-    // Names/Generation - Replaced hard-coded names with getters to prevent "Race Condition" bugs
++    // Names/Generation - Preserve generation order so names are available before dependent league data is finalized
+     // Using dynamic getters ensures that even if window.EXPANDED_*_NAMES are loaded
+     // after this module initializes, we still return the correct full lists.
+     get FIRST_NAMES() { return getFirstNames(); },

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -461,7 +461,7 @@
     LEAGUE_GEN_CONFIG,
     ROSTER_LIMITS,
 
-    // Names/Generation - Replaced hard-coded names with getters to prevent "Race Condition" bugs
+    // Names/Generation - Preserve generation order so names are available before dependent league data is finalized
     // Using dynamic getters ensures that even if window.EXPANDED_*_NAMES are loaded
     // after this module initializes, we still return the correct full lists.
     get FIRST_NAMES() { return getFirstNames(); },


### PR DESCRIPTION
This PR addresses the "Names/Generation Race Condition" task.

After analyzing the `src/core/constants.js` file, it was determined that the race condition was already mitigated using dynamic getters (`get FIRST_NAMES() { return getFirstNames(); }`). This ensures that the global window name variables are accessed only when needed at runtime, bypassing any script-loading order race conditions. 

Since no active bug remains, this PR updates the comment documenting this architectural choice to use the preferred neutral wording, ensuring it no longer reads like an active to-do item.

Tests and builds pass successfully. No runtime logic was modified.

---
*PR created automatically by Jules for task [9748329871680795886](https://jules.google.com/task/9748329871680795886) started by @rbcati*