### PR TITLE
docs: reword award races fix comment to neutral explanatory language

### DIFF
--- a/award-races-fix-commits.txt
+++ b/award-races-fix-commits.txt
@@ -1,0 +1,1 @@
+1163398 docs: reword award races fix comment to neutral explanatory language

--- a/award-races-fix.patch
+++ b/award-races-fix.patch
@@ -1,0 +1,15 @@
+diff --git a/src/worker/worker.js b/src/worker/worker.js
+index c8b231c..dc414bb 100644
+--- a/src/worker/worker.js
++++ b/src/worker/worker.js
+@@ -3457,8 +3457,8 @@ function applyGameResultToCache(result, week, seasonId) {
+   // ── 3. Aggregate per-player game stats into seasonal totals ───────────────
+   // result.boxScore shape: { home: {[pid]: {name, pos, stats:{...}}}, away: {...} }
+   //
+-  // AWARD RACES FIX: Always inject `gamesPlayed: 1` for every player who
+-  // appears in a box score.  calculateAwardRaces() filters on
++  // Count a game played for each player represented in the box score
++  // so award eligibility can use season totals. calculateAwardRaces() filters on
+   // `totals.gamesPlayed >= MIN_GAMES_AWARD` — if the simulator never emits
+   // this field the accumulator stays 0 and ALL players are excluded.
+   const aggregateSide = (teamId, boxSide) => {

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -3457,8 +3457,8 @@ function applyGameResultToCache(result, week, seasonId) {
   // ── 3. Aggregate per-player game stats into seasonal totals ───────────────
   // result.boxScore shape: { home: {[pid]: {name, pos, stats:{...}}}, away: {...} }
   //
-  // AWARD RACES FIX: Always inject `gamesPlayed: 1` for every player who
-  // appears in a box score.  calculateAwardRaces() filters on
+  // Count a game played for each player represented in the box score
+  // so award eligibility can use season totals. calculateAwardRaces() filters on
   // `totals.gamesPlayed >= MIN_GAMES_AWARD` — if the simulator never emits
   // this field the accumulator stays 0 and ALL players are excluded.
   const aggregateSide = (teamId, boxSide) => {


### PR DESCRIPTION
Reworded the comment in applyGameResultToCache to clarify that we count a game played for each player represented in the box score so award eligibility can use season totals. This replaces the old "AWARD RACES FIX" placeholder text with accurate, neutral explanatory language while confirming the injection logic is fully functional and safely operating. Tests were verified and no actual logic changes were needed as the bug was previously fixed.

---
*PR created automatically by Jules for task [8161857157738188404](https://jules.google.com/task/8161857157738188404) started by @rbcati*