### PR TITLE
[codex] Add Game Book story layer

### DIFF
--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -60,6 +60,7 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
   const game = unwrapBoxScoreResponse(archiveGame) ?? fallbackGame;
   const vm = useMemo(() => buildBoxScoreViewModel({ league, game, gameId, scheduleGame: fallbackGame, context: { season: league?.seasonId, week: league?.week } }), [league, game, gameId, fallbackGame]);
   const [sortState, setSortState] = useState({});
+  const [showAllPlays, setShowAllPlays] = useState(false);
 
   if (!vm || vm.status === "unavailable") {
     return <EmptyState title="Game Book unavailable" body="Game data missing." />;
@@ -101,9 +102,31 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
     ["Team stats", vm.availableData?.teamStats],
     ["Player stats", vm.availableData?.playerStats],
     ["Scoring", vm.availableData?.scoringSummary],
+    ["Drives", vm.availableData?.drives],
+    ["Plays", vm.availableData?.playByPlay],
   ];
 
   const tableSections = buildPlayerStatSections(vm.playerTables, sortState);
+  const driveRows = vm.driveSummaryRows ?? [];
+  const turningPointRows = vm.turningPointRows ?? [];
+  const notablePerformanceRows = vm.notablePerformanceRows ?? [];
+  const injuryRows = vm.injuryRows ?? [];
+  const playRows = vm.playByPlayRows ?? [];
+  const keyPlayRows = playRows.filter((row) => row.isKey);
+  const defaultPlayRows = keyPlayRows.slice(0, 12);
+  const visiblePlayRows = showAllPlays ? playRows : defaultPlayRows;
+  const canTogglePlays = playRows.length > 0 && (showAllPlays || visiblePlayRows.length < playRows.length || keyPlayRows.length === 0);
+  const playCountLabel = showAllPlays
+    ? `Showing all ${playRows.length} recorded plays`
+    : keyPlayRows.length
+      ? `Showing ${visiblePlayRows.length} key plays`
+      : "No key plays detected";
+
+  const renderPlayTags = (tags = []) => tags.length ? (
+    <span className="bs-data-chip-row">
+      {tags.map((tag) => <span key={tag} className="bs-data-chip is-available">{tag}</span>)}
+    </span>
+  ) : null;
 
   const renderTable = (spec) => {
     const sort = spec.sort ?? { key: spec.defaultSort, dir: desc };
@@ -189,6 +212,23 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
         <h4>Why this game was decided</h4>
         {storyBullets.length ? <ul>{storyBullets.map((b) => <li key={b}>{b}</li>)}</ul> : <p>No detailed team/player stats were recorded for this game.</p>}
       </section>
+      <section className="bs-section" data-testid="game-book-turning-points">
+        <div className="bs-section-header">
+          <h4>Turning points</h4>
+          <span className="bs-section-count">{turningPointRows.length ? `${turningPointRows.length} moments` : "Not recorded"}</span>
+        </div>
+        {turningPointRows.length ? (
+          <ul className="bs-list">
+            {turningPointRows.map((row) => (
+              <li key={row.id} className="bs-list-item" data-testid="game-book-turning-point-row">
+                <strong>{row.teamAbbr ?? "Game"} {row.inferred ? "(inferred)" : ""}</strong>
+                <span>{row.quarter != null ? `Q${row.quarter}` : mdash} {row.clock ?? mdash}</span>
+                <span>{row.text}</span>
+              </li>
+            ))}
+          </ul>
+        ) : <p>Turning points were not recorded or safely inferable for this game.</p>}
+      </section>
       <section className="bs-section" data-testid="game-book-top-performers">
         <div className="bs-section-header">
           <h4>Top performers</h4>
@@ -205,6 +245,93 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
             </article>
           ))}
         </div>
+      </section>
+      {notablePerformanceRows.length ? (
+        <section className="bs-section" data-testid="game-book-notable-performances">
+          <div className="bs-section-header">
+            <h4>Notable performances</h4>
+            <span className="bs-section-count">{notablePerformanceRows.length} recorded</span>
+          </div>
+          <ul className="bs-list">
+            {notablePerformanceRows.map((row) => (
+              <li key={row.id} className="bs-list-item" data-testid="game-book-notable-performance-row">
+                <strong>{row.name}{row.teamAbbr ? ` · ${row.teamAbbr}` : ""}</strong>
+                <span>{row.label}</span>
+                {row.text ? <span>{row.text}</span> : null}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+      {injuryRows.length ? (
+        <section className="bs-section" data-testid="game-book-injuries">
+          <div className="bs-section-header">
+            <h4>Injuries</h4>
+            <span className="bs-section-count">{injuryRows.length} recorded</span>
+          </div>
+          <ul className="bs-list">
+            {injuryRows.map((row) => (
+              <li key={row.id} className="bs-list-item" data-testid="game-book-injury-row">
+                <strong>{row.name}{row.teamAbbr ? ` · ${row.teamAbbr}` : ""}</strong>
+                <span>{row.detail}{row.duration != null ? ` · ${row.duration}` : ""}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+      <section className="bs-section" data-testid="game-book-drive-summary">
+        <div className="bs-section-header">
+          <h4>Drive Summary</h4>
+          <span className="bs-section-count">{driveRows.length ? `${driveRows.length} drives` : "Not recorded"}</span>
+        </div>
+        {driveRows.length ? (
+          <div className="bs-table-wrap">
+            <table className="box-score-table">
+              <thead><tr><th>Qtr</th><th>Team</th><th>Start</th><th>End</th><th>Result</th><th>Plays</th><th>Yards</th><th>Pts</th></tr></thead>
+              <tbody>
+                {driveRows.map((row) => (
+                  <tr key={row.id} data-testid="game-book-drive-row">
+                    <td>{row.quarter ?? mdash}</td>
+                    <td>{row.teamAbbr ?? mdash}</td>
+                    <td>{row.startClock ?? mdash}</td>
+                    <td>{row.endClock ?? mdash}</td>
+                    <td>{row.result ?? row.summary ?? mdash}</td>
+                    <td>{row.plays ?? mdash}</td>
+                    <td>{row.yards ?? mdash}</td>
+                    <td>{row.points ?? mdash}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : <p>Drive summary was not recorded for this game.</p>}
+      </section>
+      <section className="bs-section" data-testid="game-book-play-by-play">
+        <div className="bs-section-header">
+          <div>
+            <h4>Key Plays / Play-by-Play</h4>
+            <span className="bs-section-count">{playCountLabel}</span>
+          </div>
+          {canTogglePlays ? (
+            <button type="button" className="btn btn-sm btn-secondary" data-testid="game-book-play-toggle" onClick={() => setShowAllPlays((prev) => !prev)}>
+              {showAllPlays ? "Show key plays" : "Show all plays"}
+            </button>
+          ) : null}
+        </div>
+        {!playRows.length ? <p>Play-by-play was not recorded for this game.</p> : null}
+        {playRows.length && !visiblePlayRows.length ? <p>No key plays were detected in the recorded play log.</p> : null}
+        {visiblePlayRows.length ? (
+          <ul className="bs-list">
+            {visiblePlayRows.map((row) => (
+              <li key={row.id} className="bs-list-item" data-testid="game-book-play-row">
+                <strong>{row.teamAbbr ?? "Game"} {row.playType ?? "play"}</strong>
+                <span>{row.quarter != null ? `Q${row.quarter}` : mdash} {row.clock ?? mdash}{row.scoreAfter ? ` · ${formatScoreAfter(row.scoreAfter)}` : ""}</span>
+                <span>{row.text}</span>
+                {renderPlayTags(row.tags)}
+              </li>
+            ))}
+          </ul>
+        ) : null}
       </section>
       <section className="bs-section" data-testid="game-book-quarter-scores">
         <h4>Score by quarter</h4>

--- a/src/ui/components/BoxScore.test.jsx
+++ b/src/ui/components/BoxScore.test.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { renderToString } from 'react-dom/server';
-import { fireEvent, render } from '@testing-library/react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
 import BoxScore, { PlayerButton } from './BoxScore.jsx';
 
 vi.mock('../hooks/useStableRouteRequest.js', () => ({ default: vi.fn(() => ({ data: null })) }));
@@ -10,7 +10,10 @@ import useStableRouteRequest from '../hooks/useStableRouteRequest.js';
 
 describe('BoxScore game book rendering', () => {
   const baseLeague = { seasonId: 2031, week: 2, teams: [{ id: 1, abbr: 'KC' }, { id: 2, abbr: 'BUF' }] };
-  beforeEach(() => vi.mocked(useStableRouteRequest).mockReturnValue({ data: null }));
+  beforeEach(() => {
+    cleanup();
+    vi.mocked(useStableRouteRequest).mockReturnValue({ data: null });
+  });
 
   it('renders from actions.getBoxScore archive payload', () => {
     vi.mocked(useStableRouteRequest).mockReturnValue({ data: { homeId: 1, awayId: 2, homeScore: 14, awayScore: 10, teamStats: { home: { passYards: 100 }, away: { passYards: 80 } } } });
@@ -45,6 +48,8 @@ describe('BoxScore game book rendering', () => {
   it('uses placeholders for score-only games and omits stat tables', () => {
     const html = renderToString(<BoxScore gameId="g4" league={{ ...baseLeague, gameById: { g4: { homeId: 1, awayId: 2, homeScore: 6, awayScore: 3 } } }} embedded />);
     expect(html).toContain('Detailed box score data was not recorded for this game.');
+    expect(html).toContain('Drive summary was not recorded for this game.');
+    expect(html).toContain('Play-by-play was not recorded for this game.');
     expect(html).toContain('Scoring summary was not recorded for this game.');
     expect(html).not.toContain('Special Teams');
   });
@@ -101,6 +106,70 @@ describe('BoxScore game book rendering', () => {
     const scoringBlock = container.querySelector('[data-testid="game-book-scoring-summary"]');
     expect(scoringBlock?.textContent).toContain('8:12');
     expect(scoringBlock?.textContent).toContain('7-0');
+  });
+
+  it('renders Drive Summary rows when archived drives exist', () => {
+    const game = {
+      homeId: 1,
+      awayId: 2,
+      homeScore: 28,
+      awayScore: 17,
+      driveSummary: [
+        { id: 'd1', teamId: 1, quarter: 2, startClock: '12:00', endClock: '7:42', result: 'TD', plays: 9, yards: 80, points: 7 },
+      ],
+    };
+    const { getByTestId, getAllByTestId } = render(<BoxScore gameId="g-drive" league={{ ...baseLeague, gameById: { 'g-drive': game } }} embedded />);
+    expect(getByTestId('game-book-drive-summary').textContent).toContain('Drive Summary');
+    expect(getAllByTestId('game-book-drive-row')).toHaveLength(1);
+    expect(getByTestId('game-book-drive-summary').textContent).toContain('TD');
+    expect(getByTestId('game-book-drive-summary').textContent).toContain('80');
+  });
+
+  it('renders Key Plays from playLog and defaults to a curated list', () => {
+    const game = {
+      homeId: 1,
+      awayId: 2,
+      homeScore: 35,
+      awayScore: 14,
+      playLog: [
+        { id: 'p1', quarter: 1, clock: '14:30', teamId: 1, text: 'Ordinary run for 3 yards', yards: 3 },
+        { id: 'p2', quarter: 1, clock: '12:11', teamId: 1, text: 'Touchdown pass to the corner', isTouchdown: true, yards: 14 },
+        { id: 'p3', quarter: 2, clock: '11:00', teamId: 2, text: 'Ordinary pass for 5 yards', yards: 5 },
+        { id: 'p4', quarter: 2, clock: '8:33', teamId: 1, text: 'Run up the middle for 4 yards', yards: 4 },
+        { id: 'p5', quarter: 3, clock: '13:02', teamId: 2, text: 'Quarterback sack for a loss', yards: -7 },
+        { id: 'p6', quarter: 3, clock: '6:22', teamId: 1, text: 'Screen pass for 6 yards', yards: 6 },
+        { id: 'p7', quarter: 4, clock: '9:41', teamId: 2, text: 'Draw play for 2 yards', yards: 2 },
+        { id: 'p8', quarter: 4, clock: '2:05', teamId: 1, text: 'Kneel down', yards: -1 },
+      ],
+    };
+    const { getAllByTestId, getByTestId, queryByText } = render(<BoxScore gameId="g-plays" league={{ ...baseLeague, gameById: { 'g-plays': game } }} embedded />);
+    expect(getByTestId('game-book-play-by-play').textContent).toContain('Key Plays / Play-by-Play');
+    expect(getAllByTestId('game-book-play-row')).toHaveLength(2);
+    expect(getByTestId('game-book-play-by-play').textContent).toContain('Touchdown pass');
+    expect(getByTestId('game-book-play-by-play').textContent).toContain('Quarterback sack');
+    expect(queryByText('Ordinary run for 3 yards')).toBeNull();
+  });
+
+  it('toggles from key plays to the full play log', () => {
+    const game = {
+      homeId: 1,
+      awayId: 2,
+      homeScore: 35,
+      awayScore: 14,
+      playLog: [
+        { id: 'p1', quarter: 1, clock: '14:30', teamId: 1, text: 'Ordinary run for 3 yards', yards: 3 },
+        { id: 'p2', quarter: 1, clock: '12:11', teamId: 1, text: 'Touchdown pass to the corner', isTouchdown: true, yards: 14 },
+        { id: 'p3', quarter: 2, clock: '11:00', teamId: 2, text: 'Ordinary pass for 5 yards', yards: 5 },
+        { id: 'p4', quarter: 2, clock: '8:33', teamId: 1, text: 'Run up the middle for 4 yards', yards: 4 },
+        { id: 'p5', quarter: 3, clock: '13:02', teamId: 2, text: 'Quarterback sack for a loss', yards: -7 },
+      ],
+    };
+    const { getAllByTestId, getByTestId, getByText } = render(<BoxScore gameId="g-toggle" league={{ ...baseLeague, gameById: { 'g-toggle': game } }} embedded />);
+    expect(getAllByTestId('game-book-play-row')).toHaveLength(2);
+    fireEvent.click(getByTestId('game-book-play-toggle'));
+    expect(getAllByTestId('game-book-play-row')).toHaveLength(5);
+    expect(getByText('Ordinary run for 3 yards')).toBeTruthy();
+    expect(getByTestId('game-book-play-toggle').textContent).toBe('Show key plays');
   });
 
   it('renders final score density, data availability chips, sorted player rows, and embedded back action', () => {

--- a/src/ui/utils/boxScoreViewModel.js
+++ b/src/ui/utils/boxScoreViewModel.js
@@ -1,4 +1,5 @@
 import { mergeArchivedGameWithScheduleResult, normalizeArchivedGamePayload } from '../../core/gameArchive.js';
+import { isScoringLikeLog, normalizePlayLogEntry } from '../../core/gameEvents.js';
 
 const QUALITY = { full: 'Full detail', partial: 'Partial detail', score: 'Score only', missing: 'Missing detail' };
 
@@ -8,6 +9,14 @@ const toNum = (v) => {
 };
 
 const mdash = '—';
+
+function pickFirst(row = {}, keys = []) {
+  for (const key of keys) {
+    const value = row?.[key];
+    if (value != null && value !== '') return value;
+  }
+  return null;
+}
 
 function teamInfo(league, id, side, game) {
   const team = (league?.teams ?? []).find((t) => Number(t?.id) === Number(id)) ?? league?.teamById?.[id] ?? null;
@@ -214,6 +223,229 @@ function normalizeScoringSummary(rows) {
   }));
 }
 
+function teamAbbrForId(teamId, teams = {}) {
+  const id = Number(teamId);
+  if (Number.isFinite(id)) {
+    if (id === Number(teams.home?.id)) return teams.home?.abbr ?? null;
+    if (id === Number(teams.away?.id)) return teams.away?.abbr ?? null;
+  }
+  return null;
+}
+
+function teamAbbrForSide(value, teams = {}) {
+  const side = String(value ?? '').toLowerCase();
+  if (side === 'home') return teams.home?.abbr ?? null;
+  if (side === 'away') return teams.away?.abbr ?? null;
+  return null;
+}
+
+function formatClockValue(value) {
+  if (value == null || value === '') return null;
+  if (typeof value === 'string') return value;
+  const seconds = toNum(value);
+  if (seconds == null) return value;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}:${String(seconds % 60).padStart(2, '0')}`;
+}
+
+function normalizeScoreAfter(row = {}) {
+  const scoreAfter = row?.scoreAfter ?? row?.runningScore ?? row?.score ?? null;
+  if (typeof scoreAfter === 'string') return scoreAfter;
+  if (scoreAfter && typeof scoreAfter === 'object') return scoreAfter;
+  const home = toNum(row?.scoreHomeAfter ?? row?.homeScore ?? row?.scoreHome);
+  const away = toNum(row?.scoreAwayAfter ?? row?.awayScore ?? row?.scoreAway);
+  return home != null && away != null ? { home, away } : null;
+}
+
+function normalizeDriveSummaryRows(payload = {}, teams = {}) {
+  const rows = Array.isArray(payload?.driveSummary)
+    ? payload.driveSummary
+    : Array.isArray(payload?.drives)
+      ? payload.drives
+      : Array.isArray(payload?.teamDriveStats?.drives)
+        ? payload.teamDriveStats.drives
+        : [];
+  return rows
+    .filter((row) => row && typeof row === 'object')
+    .map((row, idx) => {
+      const teamId = pickFirst(row, ['teamId', 'offenseTeamId', 'possessionTeamId']);
+      return {
+        id: row?.id ?? row?.driveId ?? `drive-${idx}`,
+        quarter: pickFirst(row, ['quarter', 'qtr', 'period']),
+        teamId: teamId ?? null,
+        teamAbbr: row?.teamAbbr ?? row?.abbr ?? teamAbbrForSide(row?.team ?? row?.possession, teams) ?? row?.team ?? teamAbbrForId(teamId, teams),
+        startClock: formatClockValue(pickFirst(row, ['startClock', 'startTime', 'start', 'startClockSec'])),
+        endClock: formatClockValue(pickFirst(row, ['endClock', 'endTime', 'end', 'endClockSec'])),
+        result: pickFirst(row, ['result', 'endState', 'outcome']) ?? 'Drive',
+        yards: pickFirst(row, ['yards', 'driveYards', 'netYards']),
+        plays: pickFirst(row, ['plays', 'playCount', 'numPlays']),
+        points: pickFirst(row, ['points', 'pointsScored']),
+        summary: pickFirst(row, ['summary', 'description', 'text']),
+        keyPlay: pickFirst(row, ['keyPlay', 'lastPlay']),
+      };
+    });
+}
+
+function classifyPlayRow(normalized = {}) {
+  const text = String(normalized?.text ?? normalized?.result ?? '').toLowerCase();
+  const tags = [];
+  const scoring = isScoringLikeLog(normalized);
+  const turnover = Boolean(normalized?.turnover) || /interception|fumble|turnover/.test(text);
+  const sack = normalized?.playType === 'sack' || text.includes('sack');
+  const explosive = Math.abs(Number(normalized?.yards ?? 0)) >= 20;
+  const fourthDown = Boolean(normalized?.fourthDown) || /4th|fourth|turnover on downs/.test(text);
+  const redZone = Boolean(normalized?.redZone) || (Number(normalized?.fieldPosition ?? normalized?.yardLine) >= 80);
+  if (scoring) tags.push('scoring');
+  if (turnover) tags.push('turnover');
+  if (sack) tags.push('sack');
+  if (explosive) tags.push('explosive');
+  if (fourthDown) tags.push('fourth-down');
+  if (redZone) tags.push('red-zone');
+  return { tags, isKey: tags.length > 0 };
+}
+
+function normalizePlayByPlayRows(payload = {}, teams = {}) {
+  const source = Array.isArray(payload?.playLog) && payload.playLog.length
+    ? payload.playLog
+    : Array.isArray(payload?.eventLog) && payload.eventLog.length
+      ? payload.eventLog
+      : Array.isArray(payload?.eventDigest)
+        ? payload.eventDigest
+        : [];
+  return source
+    .filter((row) => row && typeof row === 'object')
+    .map((row, idx) => {
+      const normalized = normalizePlayLogEntry(row, idx, { homeId: teams.home?.id, awayId: teams.away?.id });
+      const text = normalized.text && normalized.text !== 'Play'
+        ? normalized.text
+        : (row?.playText ?? row?.description ?? row?.summary ?? row?.result ?? 'Play');
+      const tagData = classifyPlayRow({ ...normalized, text });
+      const teamId = normalized.teamId ?? normalized.offenseTeamId ?? row?.teamId ?? row?.scoringTeamId ?? null;
+      const rawClock = normalized.clock || row?.clockSec || row?.timeSec || row?.timeLeftSec || row?.time || row?.timeLeft;
+      const clock = formatClockValue(rawClock);
+      return {
+        id: normalized.id ?? row?.id ?? `play-${idx}`,
+        sortIndex: idx,
+        quarter: normalized.quarter ?? row?.qtr ?? row?.period ?? null,
+        clock,
+        teamId,
+        teamAbbr: row?.teamAbbr ?? row?.abbr ?? teamAbbrForSide(row?.team ?? row?.possession, teams) ?? row?.team ?? teamAbbrForId(teamId, teams),
+        playType: normalized.playType ?? row?.type ?? 'play',
+        text,
+        yards: normalized.yards ?? toNum(row?.yards),
+        scoreAfter: normalizeScoreAfter(row),
+        tags: tagData.tags,
+        isKey: tagData.isKey,
+      };
+    });
+}
+
+function applyCloseGameLastPlays(playRows = [], finalScore = {}) {
+  const home = toNum(finalScore.home);
+  const away = toNum(finalScore.away);
+  if (home == null || away == null || Math.abs(home - away) > 8 || playRows.length <= 5) return playRows;
+  const lastFiveIds = new Set(playRows.slice(-5).map((row) => row.id));
+  return playRows.map((row) => lastFiveIds.has(row.id)
+    ? { ...row, isKey: true, tags: Array.from(new Set([...(row.tags ?? []), 'late-close'])) }
+    : row);
+}
+
+function normalizeTurningPointRows({ payload = {}, scoringSummary = [], playByPlayRows = [], teams = {}, finalScore = {} } = {}) {
+  const explicit = Array.isArray(payload?.turningPoints) ? payload.turningPoints : [];
+  if (explicit.length) {
+    return explicit
+      .filter((row) => row && typeof row === 'object')
+      .map((row, idx) => {
+        const teamId = pickFirst(row, ['teamId', 'scoringTeamId', 'offenseTeamId']);
+        return {
+          id: row?.id ?? `turning-${idx}`,
+          quarter: pickFirst(row, ['quarter', 'qtr', 'period']),
+          clock: pickFirst(row, ['clock', 'time', 'timeLeft']),
+          teamId,
+          teamAbbr: row?.teamAbbr ?? row?.abbr ?? row?.team ?? teamAbbrForId(teamId, teams),
+          text: pickFirst(row, ['text', 'description', 'summary']) ?? 'Turning point',
+          source: 'recorded',
+          inferred: false,
+        };
+      }).slice(0, 6);
+  }
+
+  const inferred = [];
+  const seen = new Set();
+  const add = (row) => {
+    const key = `${row.quarter}-${row.clock}-${row.teamAbbr}-${row.text}`;
+    if (seen.has(key) || inferred.length >= 6) return;
+    seen.add(key);
+    inferred.push({ ...row, source: 'inferred', inferred: true });
+  };
+
+  scoringSummary.forEach((row, idx) => {
+    const score = normalizeScoreAfter(row);
+    if (!score || typeof score === 'string') return;
+    const home = toNum(score.home);
+    const away = toNum(score.away);
+    if (home == null || away == null || home === away) return;
+    const q = Number(row?.quarter ?? 0);
+    const margin = Math.abs(home - away);
+    const teamAbbr = row?.teamAbbr ?? row?.team ?? null;
+    if (q >= 4 && margin <= 8) {
+      add({ id: `turning-score-${idx}`, quarter: row?.quarter, clock: row?.time ?? row?.clock, teamAbbr, text: `Late ${row?.type ?? 'score'} kept this a one-score game.` });
+    } else if (margin <= 7) {
+      add({ id: `turning-go-ahead-${idx}`, quarter: row?.quarter, clock: row?.time ?? row?.clock, teamAbbr, text: `${row?.type ?? 'Score'} created a one-score swing.` });
+    }
+  });
+
+  playByPlayRows.forEach((row) => {
+    if (row.tags?.includes('turnover')) add({ id: `turning-${row.id}`, quarter: row.quarter, clock: row.clock, teamAbbr: row.teamAbbr, text: row.text });
+    if (Number(row.quarter) >= 4 && row.tags?.includes('explosive')) add({ id: `turning-${row.id}`, quarter: row.quarter, clock: row.clock, teamAbbr: row.teamAbbr, text: row.text });
+  });
+
+  const home = toNum(finalScore.home);
+  const away = toNum(finalScore.away);
+  if (inferred.length === 0 && home != null && away != null && Math.abs(home - away) <= 8) {
+    playByPlayRows.filter((row) => row.isKey).slice(-2).forEach((row) => add({ id: `turning-close-${row.id}`, quarter: row.quarter, clock: row.clock, teamAbbr: row.teamAbbr, text: row.text }));
+  }
+
+  return inferred.slice(0, 6);
+}
+
+function normalizeNotablePerformanceRows(payload = {}, teams = {}) {
+  const rows = Array.isArray(payload?.notablePerformances) ? payload.notablePerformances : [];
+  return rows
+    .filter((row) => row && typeof row === 'object')
+    .map((row, idx) => {
+      const teamId = pickFirst(row, ['teamId', 'team']);
+      return {
+        id: row?.id ?? row?.playerId ?? `notable-${idx}`,
+        playerId: row?.playerId ?? row?.id ?? null,
+        teamId,
+        teamAbbr: row?.teamAbbr ?? row?.abbr ?? teamAbbrForId(teamId, teams),
+        name: row?.name ?? row?.playerName ?? 'Impact player',
+        label: row?.label ?? row?.pos ?? row?.role ?? 'Notable',
+        text: row?.text ?? row?.summary ?? row?.description ?? null,
+        stats: row?.stats ?? {},
+      };
+    });
+}
+
+function normalizeInjuryRows(payload = {}, teams = {}) {
+  const rows = Array.isArray(payload?.injuries) ? payload.injuries : [];
+  return rows
+    .filter((row) => row && typeof row === 'object')
+    .map((row, idx) => {
+      const teamId = pickFirst(row, ['teamId', 'team']);
+      return {
+        id: row?.id ?? row?.playerId ?? `injury-${idx}`,
+        playerId: row?.playerId ?? row?.id ?? null,
+        teamId,
+        teamAbbr: row?.teamAbbr ?? row?.abbr ?? teamAbbrForId(teamId, teams),
+        name: row?.name ?? row?.playerName ?? 'Player',
+        detail: row?.detail ?? row?.injury ?? row?.type ?? row?.description ?? 'Injury recorded',
+        duration: row?.duration ?? row?.weeks ?? row?.gamesRemaining ?? row?.weeksRemaining ?? null,
+      };
+    });
+}
+
 export function unwrapBoxScoreResponse(response) {
   if (response == null) return null;
   if (response?.payload && typeof response.payload === 'object' && Object.prototype.hasOwnProperty.call(response.payload, 'game')) {
@@ -259,6 +491,12 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
   const teamTotals = { home: teamStats?.home ?? {}, away: teamStats?.away ?? {} };
   const playerTables = { home: homePlayers, away: awayPlayers };
   const winnerSide = hasScore && awayScore !== homeScore ? (awayScore > homeScore ? 'away' : 'home') : null;
+  const teamContext = { home: homeTeam, away: awayTeam };
+  const driveSummaryRows = normalizeDriveSummaryRows(payload, teamContext);
+  const playByPlayRows = applyCloseGameLastPlays(normalizePlayByPlayRows(payload, teamContext), finalScore);
+  const turningPointRows = normalizeTurningPointRows({ payload, scoringSummary, playByPlayRows, teams: teamContext, finalScore });
+  const notablePerformanceRows = normalizeNotablePerformanceRows(payload, teamContext);
+  const injuryRows = normalizeInjuryRows(payload, teamContext);
 
   return {
     gameId: payload?.gameId ?? payload?.id ?? gameId ?? null,
@@ -277,6 +515,11 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
     teamTotals,
     teamComparisonRows: buildTeamComparisonRows(teamTotals),
     scoringSummary,
+    driveSummaryRows,
+    playByPlayRows,
+    turningPointRows,
+    notablePerformanceRows,
+    injuryRows,
     playerTables,
     playerStatSections: buildPlayerStatSections(playerTables),
     statLeaderCards: buildStatLeaderCards(playerTables),
@@ -286,8 +529,11 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
       teamStats: hasTeamTotals,
       playerStats: hasPlayerStats,
       scoringSummary: hasScoringSummary,
-      playByPlay: Array.isArray(payload?.playLog) && payload.playLog.length > 0,
-      drives: Array.isArray(payload?.driveSummary) && payload.driveSummary.length > 0,
+      playByPlay: playByPlayRows.length > 0,
+      drives: driveSummaryRows.length > 0,
+      turningPoints: turningPointRows.length > 0,
+      notablePerformances: notablePerformanceRows.length > 0,
+      injuries: injuryRows.length > 0,
     },
     prepImpact: Array.isArray(payload?.prepImpact) ? payload.prepImpact : (payload?.prepImpact ? [String(payload.prepImpact)] : []),
     detailWarning: archiveQuality === QUALITY.partial ? 'Partial archive: some Game Book sections were not recorded.' : archiveQuality === QUALITY.score ? 'Detailed box score data was not recorded for this game.' : archiveQuality === QUALITY.missing ? 'Game data missing.' : null,

--- a/src/ui/utils/boxScoreViewModel.test.js
+++ b/src/ui/utils/boxScoreViewModel.test.js
@@ -142,4 +142,103 @@ describe('buildBoxScoreViewModel', () => {
     expect(vm.availableData.scoringSummary).toBe(false);
     expect(vm.playerStatSections).toEqual([]);
   });
+
+  it('normalizes drive, play, turning point, notable performance, and injury rows from rich archives', () => {
+    const vm = buildBoxScoreViewModel({
+      league: { teams: [{ id: 1, abbr: 'KC' }, { id: 2, abbr: 'BUF' }] },
+      game: {
+        gameId: 'rich-game',
+        homeId: 1,
+        awayId: 2,
+        homeScore: 27,
+        awayScore: 24,
+        driveSummary: [
+          { driveId: 'd1', teamId: 1, quarter: 4, startClock: '5:12', endClock: '1:02', result: 'TD', plays: 8, yards: 75, points: 7 },
+        ],
+        playLog: [
+          { id: 'p1', quarter: 4, clock: '5:12', teamId: 1, text: 'Pass complete for 22 yards', yards: 22, scoreHomeAfter: 20, scoreAwayAfter: 24 },
+          { id: 'p2', quarter: 4, clock: '1:02', teamId: 1, text: 'Touchdown pass gives KC the lead', isTouchdown: true, scoreHomeAfter: 27, scoreAwayAfter: 24 },
+        ],
+        turningPoints: [
+          { id: 't1', quarter: 4, clock: '1:02', teamId: 1, text: 'Go-ahead touchdown capped the final scoring drive.' },
+        ],
+        notablePerformances: [
+          { playerId: 11, name: 'Home QB', teamId: 1, label: 'QB', text: 'Three touchdown passes' },
+        ],
+        injuries: [
+          { playerId: 22, name: 'Away RB', teamId: 2, injury: 'Ankle', duration: '2 weeks' },
+        ],
+      },
+    });
+    expect(vm.driveSummaryRows[0]).toMatchObject({ teamAbbr: 'KC', result: 'TD', plays: 8, yards: 75, points: 7 });
+    expect(vm.playByPlayRows.map((row) => row.teamAbbr)).toEqual(['KC', 'KC']);
+    expect(vm.playByPlayRows[0].tags).toContain('explosive');
+    expect(vm.playByPlayRows[1].tags).toContain('scoring');
+    expect(vm.turningPointRows[0]).toMatchObject({ source: 'recorded', inferred: false, teamAbbr: 'KC' });
+    expect(vm.notablePerformanceRows[0]).toMatchObject({ name: 'Home QB', teamAbbr: 'KC' });
+    expect(vm.injuryRows[0]).toMatchObject({ name: 'Away RB', teamAbbr: 'BUF', detail: 'Ankle' });
+    expect(vm.availableData).toMatchObject({ drives: true, playByPlay: true, turningPoints: true, notablePerformances: true, injuries: true });
+  });
+
+  it('does not throw on malformed story-layer arrays and keeps score-only fallback arrays empty', () => {
+    expect(() => buildBoxScoreViewModel({
+      game: {
+        homeId: 1,
+        awayId: 2,
+        homeScore: 3,
+        awayScore: 0,
+        driveSummary: 'bad',
+        playLog: { bad: true },
+        turningPoints: null,
+        notablePerformances: 'bad',
+        injuries: 42,
+      },
+    })).not.toThrow();
+    const vm = buildBoxScoreViewModel({
+      game: { homeId: 1, awayId: 2, homeScore: 3, awayScore: 0, driveSummary: 'bad', playLog: { bad: true } },
+    });
+    expect(vm.archiveQuality).toBe('Score only');
+    expect(vm.driveSummaryRows).toEqual([]);
+    expect(vm.playByPlayRows).toEqual([]);
+    expect(vm.turningPointRows).toEqual([]);
+    expect(vm.notablePerformanceRows).toEqual([]);
+    expect(vm.injuryRows).toEqual([]);
+  });
+
+  it('conservatively infers turning points from recorded scoring and key play rows', () => {
+    const vm = buildBoxScoreViewModel({
+      league: { teams: [{ id: 1, abbr: 'KC' }, { id: 2, abbr: 'BUF' }] },
+      game: {
+        homeId: 1,
+        awayId: 2,
+        homeScore: 20,
+        awayScore: 17,
+        scoringSummary: [
+          { quarter: 4, time: '0:44', teamAbbr: 'KC', type: 'FG', scoreAfter: { home: 20, away: 17 } },
+        ],
+        playLog: [
+          { id: 'late-sack', quarter: 4, clock: '1:10', teamId: 1, text: 'Sack forces third and long', yards: -8 },
+        ],
+      },
+    });
+    expect(vm.turningPointRows.length).toBeGreaterThan(0);
+    expect(vm.turningPointRows[0].source).toBe('inferred');
+  });
+
+  it('uses eventDigest as a play-by-play fallback with side and clock normalization', () => {
+    const vm = buildBoxScoreViewModel({
+      league: { teams: [{ id: 1, abbr: 'HME' }, { id: 2, abbr: 'AWY' }] },
+      game: {
+        homeId: 1,
+        awayId: 2,
+        homeScore: 20,
+        awayScore: 24,
+        eventDigest: [
+          { quarter: 4, clockSec: 89, team: 'away', type: 'turnover', text: 'Late interception seals it', awayScore: 24, homeScore: 20, turnover: true },
+        ],
+      },
+    });
+    expect(vm.playByPlayRows[0]).toMatchObject({ teamAbbr: 'AWY', clock: '1:29', text: 'Late interception seals it' });
+    expect(vm.playByPlayRows[0].tags).toContain('turnover');
+  });
 });

--- a/src/ui/utils/gameBookStory.js
+++ b/src/ui/utils/gameBookStory.js
@@ -1,5 +1,22 @@
 const n = (v) => (Number.isFinite(Number(v)) ? Number(v) : null);
 
+function formatMoment(row = {}) {
+  const parts = [];
+  if (row.quarter != null) parts.push(`Q${row.quarter}`);
+  if (row.clock) parts.push(row.clock);
+  if (row.teamAbbr) parts.push(row.teamAbbr);
+  return parts.length ? `${parts.join(" ")}: ` : "";
+}
+
+function formatDriveLine(drive = {}) {
+  const details = [];
+  if (drive.plays != null) details.push(`${drive.plays} plays`);
+  if (drive.yards != null) details.push(`${drive.yards} yards`);
+  if (drive.points != null) details.push(`${drive.points} points`);
+  const detailText = details.length ? ` (${details.join(", ")})` : "";
+  return `${drive.teamAbbr ?? "A team"} finished a drive with ${drive.result ?? "a result"}${detailText}.`;
+}
+
 export function buildGameBookStory(vm) {
   const bullets = [];
   const away = vm?.awayTeam?.abbr ?? "Away";
@@ -32,6 +49,19 @@ export function buildGameBookStory(vm) {
 
   const lastScore = vm?.scoringSummary?.[vm.scoringSummary.length - 1];
   if (lastScore?.teamAbbr || lastScore?.team) bullets.push(`Last scoring play: ${(lastScore.teamAbbr ?? lastScore.team)} ${lastScore.type ?? "score"} (${lastScore.time ?? lastScore.clock ?? "time unknown"}).`);
+
+  const turningPoint = vm?.turningPointRows?.[0];
+  if (turningPoint?.text) {
+    const sourceLabel = turningPoint.inferred ? "Inferred turning point" : "Turning point";
+    bullets.push(`${sourceLabel}: ${formatMoment(turningPoint)}${turningPoint.text}`);
+  }
+
+  const keyDrive = (vm?.driveSummaryRows ?? []).find((drive) => {
+    const points = n(drive?.points);
+    const result = String(drive?.result ?? "").toLowerCase();
+    return (points != null && points > 0) || /td|touchdown|fg|field goal|safety/.test(result);
+  });
+  if (keyDrive) bullets.push(formatDriveLine(keyDrive));
 
   const awayScore = n(vm?.finalScore?.away);
   const homeScore = n(vm?.finalScore?.home);


### PR DESCRIPTION
## Summary
- Adds normalized Game Book view-model rows for drives, play-by-play, turning points, notable performances, and injuries using existing archived game fields.
- Adds compact Drive Summary, Turning Points, Key Plays / Play-by-Play, and optional Notable Performances / Injuries sections to the Box Score UI.
- Keeps default play rendering curated to key plays, with a Show all plays toggle for full recorded logs.
- Extends Game Book story bullets with real turning-point and scoring-drive context when present.

## Archive data used
- Drive rows read existing `driveSummary`, `drives`, or `teamDriveStats.drives`.
- Play rows read existing `playLog`, `eventLog`, or `eventDigest`, including side/team and clock normalization.
- Turning points prefer existing `turningPoints`, then conservatively infer from recorded scoring/key play rows.
- Notable performances and injuries render only when `notablePerformances` or `injuries` exists.

## Validation
- `npm.cmd run test:unit` passed: 192 files, 895 tests.
- `npm.cmd run build` passed. Vite emitted the existing large chunk warning only.

## Not run
- Fresh franchise E2E smoke was not run because this patch did not change BoxScore routing, completed-game opening, or Game Book navigation.
- `npm run test:soak` was not run because no simulation, worker, or core season-advancement logic was changed.