### PR TITLE
[codex] Tighten Game Book archive quality

### DIFF
--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -98,12 +98,13 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
   const teamRows = vm.teamComparisonRows ?? [];
   const dataChips = [
     ["Score", vm.availableData?.finalScore],
-    ["Quarter", vm.availableData?.quarterScores],
+    ["Linescore", vm.availableData?.quarterScores],
     ["Team stats", vm.availableData?.teamStats],
     ["Player stats", vm.availableData?.playerStats],
     ["Scoring", vm.availableData?.scoringSummary],
     ["Drives", vm.availableData?.drives],
     ["Plays", vm.availableData?.playByPlay],
+    ["Turning points", vm.availableData?.turningPoints],
   ];
 
   const tableSections = buildPlayerStatSections(vm.playerTables, sortState);

--- a/src/ui/components/BoxScore.test.jsx
+++ b/src/ui/components/BoxScore.test.jsx
@@ -47,7 +47,7 @@ describe('BoxScore game book rendering', () => {
 
   it('uses placeholders for score-only games and omits stat tables', () => {
     const html = renderToString(<BoxScore gameId="g4" league={{ ...baseLeague, gameById: { g4: { homeId: 1, awayId: 2, homeScore: 6, awayScore: 3 } } }} embedded />);
-    expect(html).toContain('Detailed box score data was not recorded for this game.');
+    expect(html).toContain('Score-only archive: no detailed Game Book sections were recorded.');
     expect(html).toContain('Drive summary was not recorded for this game.');
     expect(html).toContain('Play-by-play was not recorded for this game.');
     expect(html).toContain('Scoring summary was not recorded for this game.');

--- a/src/ui/components/WeeklyResultsCenter.jsx
+++ b/src/ui/components/WeeklyResultsCenter.jsx
@@ -48,6 +48,7 @@ function ResultRow({ row, seasonId, onGameSelect, source = 'weekly_results_cente
       </div>
       <div className="app-game-center-context-strip" aria-label="Game quick context">
         <span>{contextLabel}</span>
+        <span>{presentation.statusLabel}</span>
         <span>{performers.hasOffense ? performers.offense : 'Top player unavailable'}</span>
       </div>
       <p className="app-game-center-card__summary">{row.recap}</p>
@@ -61,6 +62,7 @@ function ResultRow({ row, seasonId, onGameSelect, source = 'weekly_results_cente
         >
           {clickable ? 'Open Game Book' : (presentation?.statusLabel ?? 'Archive unavailable')}
         </button>
+        <StatusChip label={presentation.statusLabel} tone={presentation.archiveQuality === 'full' ? 'ok' : presentation.archiveQuality === 'partial' ? 'info' : 'neutral'} />
       </div>
     </article>
   );
@@ -262,7 +264,10 @@ export default function WeeklyResultsCenter({ league, initialWeek = null, onGame
           <article className="app-game-center-card app-game-center-user card" data-testid="user-game-result-card">
             <div className="app-game-center-card__top">
               <strong>Week {userTeamResult.week} • {userTeamResult.outcome === 'W' ? 'Win' : userTeamResult.outcome === 'L' ? 'Loss' : 'Tie'} • {userTeamResult.isHome ? 'vs' : '@'} {userTeamResult.opponent?.abbr ?? 'TBD'}</strong>
-              <StatusChip label={`${userTeamResult.userScore}-${userTeamResult.oppScore}`} tone={userTeamResult.outcome === 'W' ? 'ok' : userTeamResult.outcome === 'L' ? 'warning' : 'info'} />
+              <div className="app-game-center-card__chips">
+                <StatusChip label={`${userTeamResult.userScore}-${userTeamResult.oppScore}`} tone={userTeamResult.outcome === 'W' ? 'ok' : userTeamResult.outcome === 'L' ? 'warning' : 'info'} />
+                <StatusChip label={userResultPresentation?.statusLabel ?? 'Archive unavailable'} tone={userResultPresentation?.archiveQuality === 'full' ? 'ok' : userResultPresentation?.archiveQuality === 'partial' ? 'info' : 'neutral'} />
+              </div>
             </div>
             <div className="app-game-center-result-score" aria-label="Final score">
               <span>{userResultPresentation?.displayScoreLine ?? `${userTeamResult.userScore}-${userTeamResult.oppScore}`}</span>

--- a/src/ui/components/WeeklyResultsCenter.test.jsx
+++ b/src/ui/components/WeeklyResultsCenter.test.jsx
@@ -51,6 +51,7 @@ describe('WeeklyResultsCenter', () => {
     expect(screen.getByText('Weekly Spotlight')).toBeTruthy();
     expect(screen.getAllByRole('button', { name: /open game book/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/close game|point margin|blowout/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/partial detail/i).length).toBeGreaterThan(0);
   });
 
   it('shows game-plan recap and reasons when prep impact exists', () => {
@@ -112,6 +113,7 @@ describe('WeeklyResultsCenter', () => {
     const html = renderToString(<WeeklyResultsCenter league={legacyLeague} initialWeek={3} onGameSelect={() => {}} onNavigate={() => {}} />);
     expect(html).toContain('DAL won by 4 (3-7).');
     expect(html).toContain('Open Game Book');
+    expect(html).toContain('Score only');
     expect(html).not.toContain('Game-plan impact recap');
   });
 

--- a/src/ui/utils/boxScoreAccess.js
+++ b/src/ui/utils/boxScoreAccess.js
@@ -1,14 +1,19 @@
 import { buildCanonicalGameId, toTeamId } from "../../core/gameIdentity.js";
-import { classifyArchiveQuality, normalizeArchivedGamePayload, recoverArchivedGameFromSchedule } from "../../core/gameArchive.js";
+import { normalizeArchivedGamePayload, recoverArchivedGameFromSchedule } from "../../core/gameArchive.js";
+import { buildBoxScoreViewModel } from "./boxScoreViewModel.js";
 
 const ARCHIVE_QUALITY_LABELS = {
-  full: "Full box score",
-  partial: "Partial archive",
-  missing: "Archive unavailable",
+  full: "Full detail",
+  partial: "Partial detail",
+  score: "Score only",
+  missing: "Missing detail",
 };
 
-function detectArchiveQuality(game) {
-  return classifyArchiveQuality(game);
+function archiveQualityKey(label) {
+  if (label === "Full detail") return "full";
+  if (label === "Partial detail") return "partial";
+  if (label === "Score only") return "score";
+  return "missing";
 }
 
 function hasFinalScore(game) {
@@ -51,23 +56,20 @@ export function resolveBoxScoreGameId(game, context = {}) {
 export function getBoxScoreAvailability(game, context = {}) {
   const normalized = normalizeArchivedGamePayload(normalizeCompletedGameRecord(game, context) ?? game);
   const resolvedGameId = resolveBoxScoreGameId(normalized, context);
-  const archiveQuality = detectArchiveQuality(normalized);
   const isCompleted = hasFinalScore(normalized);
-  const hasAnyDetail = Boolean(
-    normalized?.recap
-    || normalized?.summary
-    || normalized?.quarterScores
-    || (normalized?.playLog?.length ?? 0) > 0
-    || (normalized?.eventDigest?.length ?? 0) > 0
-    || normalized?.teamDriveStats?.home
-    || normalized?.teamDriveStats?.away,
-  );
+  const vm = buildBoxScoreViewModel({
+    league: { teams: Object.values(context?.teamById ?? {}) },
+    game: normalized,
+    gameId: resolvedGameId,
+    context,
+  });
+  const archiveQuality = archiveQualityKey(vm?.archiveQuality);
   const canOpen = Boolean(isCompleted && resolvedGameId);
   let fallbackReason = null;
   if (!isCompleted) fallbackReason = "Game not completed";
   else if (!resolvedGameId) fallbackReason = "Missing game identity";
   else if (!canOpen) fallbackReason = "Archive unavailable";
-  return { resolvedGameId, archiveQuality, canOpen, fallbackReason, isCompleted };
+  return { resolvedGameId, archiveQuality, archiveQualityLabel: vm?.archiveQuality ?? ARCHIVE_QUALITY_LABELS.missing, canOpen, fallbackReason, isCompleted };
 }
 
 export function getArchiveQualityLabel(archiveQuality) {
@@ -76,23 +78,17 @@ export function getArchiveQualityLabel(archiveQuality) {
 
 export function buildCompletedGamePresentation(game, context = {}) {
   const availability = getBoxScoreAvailability(game, context);
-  const hasTacticalData = Boolean(
-    (Array.isArray(game?.eventDigest) && game.eventDigest.length > 0)
-    || (Array.isArray(game?.summary?.headlineMoments) && game.summary.headlineMoments.length > 0)
-    || game?.topReason1
-    || game?.topReason2
-    || game?.teamDriveStats?.home
-    || game?.teamDriveStats?.away,
-  );
   const away = context?.teamById?.[toTeamId(game?.awayId ?? game?.away)] ?? null;
   const home = context?.teamById?.[toTeamId(game?.homeId ?? game?.home)] ?? null;
   const displayScoreLine = `${away?.abbr ?? "AWY"} ${game?.awayScore ?? "—"} - ${game?.homeScore ?? "—"} ${home?.abbr ?? "HME"}`;
   return {
     ...availability,
     ctaLabel: availability.canOpen
-      ? (hasTacticalData
-        ? "Tactical breakdown"
-        : "View Game Book")
+      ? (availability.archiveQuality === "full"
+        ? "Open full Game Book"
+        : availability.archiveQuality === "partial"
+          ? "Open partial Game Book"
+          : "Open score-only Game Book")
       : "View result",
     statusLabel: getArchiveQualityLabel(availability.archiveQuality),
     displayScoreLine,

--- a/src/ui/utils/boxScoreAccess.test.js
+++ b/src/ui/utils/boxScoreAccess.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { openResolvedBoxScore } from './boxScoreAccess.js';
+import { buildCompletedGamePresentation, openResolvedBoxScore } from './boxScoreAccess.js';
 
 describe('box score access clickthrough', () => {
   it('opens completed game scores when archive quality is available', () => {
@@ -33,5 +33,30 @@ describe('box score access clickthrough', () => {
     const opened = openResolvedBoxScore(game, { seasonId: '2026', week: 8, source: 'unit_test' }, onOpen);
     expect(opened).toBe(true);
     expect(onOpen).toHaveBeenCalledWith('2026_w8_3_4');
+  });
+
+  it('labels score-only and partial detail using Game Book view-model quality', () => {
+    const scoreOnly = buildCompletedGamePresentation({
+      gameId: '2026_w8_3_4',
+      played: true,
+      homeId: 3,
+      awayId: 4,
+      homeScore: 13,
+      awayScore: 10,
+    }, { seasonId: '2026', week: 8 });
+    const driveOnly = buildCompletedGamePresentation({
+      gameId: '2026_w9_3_4',
+      played: true,
+      homeId: 3,
+      awayId: 4,
+      homeScore: 20,
+      awayScore: 17,
+      driveSummary: [{ teamId: 3, quarter: 4, result: 'FG', points: 3 }],
+    }, { seasonId: '2026', week: 9 });
+
+    expect(scoreOnly.archiveQuality).toBe('score');
+    expect(scoreOnly.statusLabel).toBe('Score only');
+    expect(driveOnly.archiveQuality).toBe('partial');
+    expect(driveOnly.statusLabel).toBe('Partial detail');
   });
 });

--- a/src/ui/utils/boxScoreViewModel.js
+++ b/src/ui/utils/boxScoreViewModel.js
@@ -10,6 +10,10 @@ const toNum = (v) => {
 
 const mdash = '—';
 
+function hasValues(obj) {
+  return Boolean(obj && typeof obj === 'object' && Object.keys(obj).length > 0);
+}
+
 function pickFirst(row = {}, keys = []) {
   for (const key of keys) {
     const value = row?.[key];
@@ -476,14 +480,9 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
 
   const hasScore = homeScore != null && awayScore != null;
   const hasQuarter = Array.isArray(quarterScores?.home) || Array.isArray(quarterScores?.away);
-  const hasTeamTotals = Boolean(teamStats?.home || teamStats?.away);
+  const hasTeamTotals = hasValues(teamStats?.home) || hasValues(teamStats?.away);
   const hasPlayerStats = homePlayers.length > 0 || awayPlayers.length > 0;
   const hasScoringSummary = scoringSummary.length > 0;
-
-  let archiveQuality = QUALITY.missing;
-  if (hasScore && hasQuarter && hasTeamTotals && hasPlayerStats) archiveQuality = QUALITY.full;
-  else if (hasScore && (hasQuarter || hasTeamTotals || hasPlayerStats || hasScoringSummary)) archiveQuality = QUALITY.partial;
-  else if (hasScore) archiveQuality = QUALITY.score;
 
   const awayTeam = teamInfo(league, awayId, 'away', payload);
   const homeTeam = teamInfo(league, homeId, 'home', payload);
@@ -497,6 +496,28 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
   const turningPointRows = normalizeTurningPointRows({ payload, scoringSummary, playByPlayRows, teams: teamContext, finalScore });
   const notablePerformanceRows = normalizeNotablePerformanceRows(payload, teamContext);
   const injuryRows = normalizeInjuryRows(payload, teamContext);
+  const hasDriveRows = driveSummaryRows.length > 0;
+  const hasPlayRows = playByPlayRows.length > 0;
+  const hasTurningPoints = turningPointRows.length > 0;
+  const hasNotablePerformances = notablePerformanceRows.length > 0;
+  const hasInjuries = injuryRows.length > 0;
+  const hasStoryLayerDetail = hasScoringSummary || hasDriveRows || hasPlayRows || hasTurningPoints || hasNotablePerformances || hasInjuries;
+  const hasAnyMeaningfulDetail = hasQuarter || hasTeamTotals || hasPlayerStats || hasStoryLayerDetail;
+
+  let archiveQuality = QUALITY.missing;
+  if (hasScore && hasQuarter && hasTeamTotals && hasPlayerStats && hasStoryLayerDetail) archiveQuality = QUALITY.full;
+  else if (hasScore && hasAnyMeaningfulDetail) archiveQuality = QUALITY.partial;
+  else if (hasScore) archiveQuality = QUALITY.score;
+
+  const detailWarning = (() => {
+    if (archiveQuality === QUALITY.full) return null;
+    if (archiveQuality === QUALITY.partial) {
+      if (!hasTeamTotals || !hasPlayerStats) return 'Partial archive: some Game Book sections were recorded, but team/player stat detail is incomplete.';
+      return 'Partial archive: some Game Book sections were recorded, but full detail is incomplete.';
+    }
+    if (archiveQuality === QUALITY.score) return 'Score-only archive: no detailed Game Book sections were recorded.';
+    return 'Game data missing.';
+  })();
 
   return {
     gameId: payload?.gameId ?? payload?.id ?? gameId ?? null,
@@ -529,15 +550,15 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
       teamStats: hasTeamTotals,
       playerStats: hasPlayerStats,
       scoringSummary: hasScoringSummary,
-      playByPlay: playByPlayRows.length > 0,
-      drives: driveSummaryRows.length > 0,
-      turningPoints: turningPointRows.length > 0,
-      notablePerformances: notablePerformanceRows.length > 0,
-      injuries: injuryRows.length > 0,
+      playByPlay: hasPlayRows,
+      drives: hasDriveRows,
+      turningPoints: hasTurningPoints,
+      notablePerformances: hasNotablePerformances,
+      injuries: hasInjuries,
     },
     prepImpact: Array.isArray(payload?.prepImpact) ? payload.prepImpact : (payload?.prepImpact ? [String(payload.prepImpact)] : []),
-    detailWarning: archiveQuality === QUALITY.partial ? 'Partial archive: some Game Book sections were not recorded.' : archiveQuality === QUALITY.score ? 'Detailed box score data was not recorded for this game.' : archiveQuality === QUALITY.missing ? 'Game data missing.' : null,
-    missingDetailReason: archiveQuality === QUALITY.partial ? 'Partial archive: some Game Book sections were not recorded.' : archiveQuality === QUALITY.score ? 'Detailed box score data was not recorded for this game.' : archiveQuality === QUALITY.missing ? 'Game data missing.' : null,
+    detailWarning,
+    missingDetailReason: detailWarning,
     hasDetailedStats: archiveQuality === QUALITY.full || archiveQuality === QUALITY.partial,
   };
 }

--- a/src/ui/utils/boxScoreViewModel.test.js
+++ b/src/ui/utils/boxScoreViewModel.test.js
@@ -18,8 +18,8 @@ describe('buildBoxScoreViewModel', () => {
     expect(unwrapBoxScoreResponse({ game: topLevelGame })).toBe(topLevelGame);
   });
 
-  it('classifies full detail when major sections exist', () => {
-    const vm = buildBoxScoreViewModel({ game: { played: true, homeId: 1, awayId: 2, homeScore: 21, awayScore: 17, quarterScores: { home: [7,7,7,0], away: [3,7,0,7] }, teamStats: { home: { passYards: 220 }, away: { passYards: 200 } }, playerStats: { home: { '10': { name: 'QB', stats: { passAtt: 20 } } }, away: {} } } });
+  it('classifies full detail when major stat sections and recorded detail exist', () => {
+    const vm = buildBoxScoreViewModel({ game: { played: true, homeId: 1, awayId: 2, homeScore: 21, awayScore: 17, quarterScores: { home: [7,7,7,0], away: [3,7,0,7] }, teamStats: { home: { passYards: 220 }, away: { passYards: 200 } }, playerStats: { home: { '10': { name: 'QB', stats: { passAtt: 20 } } }, away: {} }, scoringSummary: [{ quarter: 1, time: '8:00', teamAbbr: 'HOME', type: 'TD', scoreAfter: { home: 7, away: 0 } }] } });
     expect(vm.archiveQuality).toBe('Full detail');
     expect(vm.detailWarning).toBeNull();
   });
@@ -33,7 +33,23 @@ describe('buildBoxScoreViewModel', () => {
   it('classifies score only data warning copy', () => {
     const vm = buildBoxScoreViewModel({ game: { played: true, homeScore: 3, awayScore: 0 } });
     expect(vm.archiveQuality).toBe('Score only');
-    expect(vm.detailWarning).toContain('Detailed box score data');
+    expect(vm.detailWarning).toBe('Score-only archive: no detailed Game Book sections were recorded.');
+  });
+
+  it('classifies final score plus drive summary as partial detail', () => {
+    const vm = buildBoxScoreViewModel({
+      game: { played: true, homeId: 1, awayId: 2, homeScore: 10, awayScore: 7, driveSummary: [{ teamId: 1, quarter: 4, result: 'FG', plays: 6, yards: 42, points: 3 }] },
+    });
+    expect(vm.archiveQuality).toBe('Partial detail');
+    expect(vm.detailWarning).toBe('Partial archive: some Game Book sections were recorded, but team/player stat detail is incomplete.');
+  });
+
+  it('classifies final score plus play log as partial detail without overclaiming full detail', () => {
+    const vm = buildBoxScoreViewModel({
+      game: { played: true, homeId: 1, awayId: 2, homeScore: 10, awayScore: 7, playLog: [{ quarter: 4, clock: '1:00', teamId: 1, text: 'Touchdown run', isTouchdown: true }] },
+    });
+    expect(vm.archiveQuality).toBe('Partial detail');
+    expect(vm.detailWarning).toContain('team/player stat detail is incomplete');
   });
 
   it('classifies missing detail when score unavailable', () => {


### PR DESCRIPTION
## Summary
- Updates Game Book archive-quality classification so drive, play-by-play, turning point, notable performance, and injury rows count as meaningful detail.
- Replaces misleading score-only/partial warning copy with text that matches the actual available Game Book sections.
- Reuses the Box Score view model quality in completed-game presentation helpers so weekly/results status labels match the Game Book.
- Adds compact detail indicators to weekly completed result rows and the user-game result card without changing openResolvedBoxScore behavior.

## Why
PR #1442 added real story-layer Game Book sections, but quality labels still mostly looked at stat tables. A game with a recorded drive or play log could show Score only even when the Game Book had useful football detail. These labels now follow the same normalized view-model data used by the UI.

## Validation
- `npm.cmd run test:unit -- src/ui/utils/boxScoreViewModel.test.js src/ui/components/BoxScore.test.jsx src/ui/utils/boxScoreAccess.test.js src/ui/components/WeeklyResultsCenter.test.jsx src/ui/utils/gameCenterResults.test.js` passed: 5 files, 48 tests.
- `npm.cmd run test:unit` passed: 192 files, 898 tests.
- `npm.cmd run build` passed. Vite emitted the existing large chunk warning only.
- `npx.cmd playwright test tests/e2e/fresh_franchise_first_week_smoke.spec.js` initially failed because Playwright Chromium was missing; after `npx.cmd playwright install chromium`, rerun passed: 1 test.
- `npx.cmd playwright test tests/e2e/daily_regression.spec.js` passed: 5 tests.

## Not run
- `npm run test:soak` was not run because no simulation, worker, or season-advancement logic changed.