### PR TITLE
[codex] Add typed franchise chronicle events

### DIFF
--- a/src/ui/components/FranchiseStoryHub.jsx
+++ b/src/ui/components/FranchiseStoryHub.jsx
@@ -1,12 +1,107 @@
 import React, { useMemo, useState } from 'react';
 import { EmptyState, SectionCard, StatusChip } from './ScreenSystem.jsx';
-import { syncFranchiseChronicle } from '../utils/franchiseChronicle.js';
+import { CHRONICLE_EVENT_LABELS, resolveChronicleEventType, syncFranchiseChronicle } from '../utils/franchiseChronicle.js';
+
+const EVENT_STYLE = {
+  game: { color: 'var(--text-subtle)', tone: 'neutral' },
+  trade: { color: 'var(--accent)', tone: 'info' },
+  contract: { color: 'var(--success)', tone: 'ok' },
+  draft: { color: 'var(--warning)', tone: 'warning' },
+  injury: { color: 'var(--danger)', tone: 'danger' },
+  milestone: { color: 'var(--accent-2, var(--accent))', tone: 'ok' },
+  custom: { color: 'var(--text-subtle)', tone: 'info' },
+  event: { color: 'var(--text-subtle)', tone: 'info' },
+};
 
 function toneForResult(result) {
   const r = String(result ?? '').toUpperCase();
   if (r === 'W') return 'var(--success)';
   if (r === 'L') return 'var(--danger)';
   return 'var(--text-subtle)';
+}
+
+function getEventStyle(entry) {
+  const type = resolveChronicleEventType(entry);
+  if (type === 'game') return { ...EVENT_STYLE.game, color: toneForResult(entry?.result) };
+  return EVENT_STYLE[type] ?? EVENT_STYLE.event;
+}
+
+function formatMoney(value) {
+  if (value == null || value === '') return null;
+  if (typeof value === 'string') return value;
+  const n = Number(value);
+  if (!Number.isFinite(n)) return null;
+  return `$${Math.round(n * 10) / 10}M`;
+}
+
+function compactPlayer(player) {
+  if (!player) return null;
+  if (typeof player === 'string') return player;
+  return [
+    player.name,
+    player.pos,
+    player.ovr != null ? `${player.ovr} OVR` : null,
+  ].filter(Boolean).join(' - ');
+}
+
+function compactPlayers(players = []) {
+  return (Array.isArray(players) ? players : [])
+    .map(compactPlayer)
+    .filter(Boolean)
+    .join(', ');
+}
+
+function metadataLines(entry) {
+  const type = resolveChronicleEventType(entry);
+  const meta = entry?.meta ?? {};
+  const lines = [];
+
+  if (type === 'trade') {
+    const players = compactPlayers(meta.players);
+    const incoming = compactPlayers(meta.incomingPlayers);
+    const outgoing = compactPlayers(meta.outgoingPlayers);
+    const picks = [...(meta.picks ?? []), ...(meta.incomingPicks ?? []), ...(meta.outgoingPicks ?? [])].filter(Boolean).join(', ');
+    const teams = (meta.teams ?? []).filter(Boolean).join(', ');
+    if (incoming) lines.push({ label: 'Added', value: incoming });
+    if (outgoing) lines.push({ label: 'Sent', value: outgoing });
+    if (!incoming && !outgoing && players) lines.push({ label: 'Players', value: players });
+    if (picks) lines.push({ label: 'Picks', value: picks });
+    if (teams) lines.push({ label: 'Teams', value: teams });
+  } else if (type === 'contract') {
+    const player = compactPlayer(meta.player);
+    const term = [
+      meta.years ? `${meta.years} yr` : null,
+      formatMoney(meta.totalValue),
+      meta.aav != null ? `${formatMoney(meta.aav)} AAV` : null,
+    ].filter(Boolean).join(' - ');
+    if (player) lines.push({ label: 'Player', value: player });
+    if (term) lines.push({ label: 'Terms', value: term });
+  } else if (type === 'draft') {
+    const player = compactPlayer(meta.player);
+    const slot = meta.pickLabel ?? [meta.round ? `Round ${meta.round}` : null, meta.pick ? `Pick ${meta.pick}` : null].filter(Boolean).join(' ');
+    if (player) lines.push({ label: 'Player', value: player });
+    if (slot) lines.push({ label: 'Selection', value: slot });
+    if (meta.potential != null) lines.push({ label: 'Potential', value: meta.potential });
+  } else if (type === 'injury') {
+    const player = compactPlayer(meta.player);
+    if (player) lines.push({ label: 'Player', value: player });
+    if (meta.injury) lines.push({ label: 'Injury', value: meta.injury });
+    if (meta.duration) lines.push({ label: 'Duration', value: meta.duration });
+  } else if (type === 'milestone') {
+    if (meta.label) lines.push({ label: 'Milestone', value: meta.label });
+    if (meta.description) lines.push({ label: 'Detail', value: meta.description });
+    if (meta.unlockedOn) lines.push({ label: 'Unlocked', value: meta.unlockedOn });
+  }
+
+  return lines;
+}
+
+function secondaryLine(entry) {
+  const type = resolveChronicleEventType(entry);
+  if (type === 'game') {
+    return `Conf standing: #${entry?.standingsPosition ?? '-'}${entry?.standout?.name ? ` - Standout: ${entry.standout.name}` : ''}`;
+  }
+  return entry?.summary ?? CHRONICLE_EVENT_LABELS[type] ?? 'Franchise event';
 }
 
 export default function FranchiseStoryHub({ league }) {
@@ -20,28 +115,56 @@ export default function FranchiseStoryHub({ league }) {
         {!entries.length ? (
           <EmptyState title="No story entries yet" body="Play your first game to start the chronicle." />
         ) : (
-          <div className="app-list-stack">
+          <div className="app-list-stack" data-testid="franchise-story-list">
             {entries.map((entry) => {
               const open = expandedId === entry.id;
+              const type = resolveChronicleEventType(entry);
+              const style = getEventStyle(entry);
+              const label = CHRONICLE_EVENT_LABELS[type] ?? CHRONICLE_EVENT_LABELS.event;
+              const metaLines = metadataLines(entry);
               return (
-                <article key={entry.id} className="app-story-card" style={{ borderLeft: `4px solid ${toneForResult(entry.result)}`, paddingLeft: 'var(--space-3)' }}>
-                  <button type="button" className="app-story-card__header" onClick={() => setExpandedId(open ? null : entry.id)} style={{ width: '100%', textAlign: 'left', background: 'transparent', border: 0, padding: 0 }}>
-                    <p style={{ margin: 0, fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>Week {entry.week} · {entry.summary}</p>
+                <article
+                  key={entry.id}
+                  className="app-story-card"
+                  data-testid="franchise-story-event"
+                  data-event-type={type}
+                  style={{ borderLeft: `4px solid ${style.color}`, paddingLeft: 'var(--space-3)' }}
+                >
+                  <button
+                    type="button"
+                    className="app-story-card__header"
+                    onClick={() => setExpandedId(open ? null : entry.id)}
+                    style={{ width: '100%', textAlign: 'left', background: 'transparent', border: 0, padding: 0 }}
+                  >
+                    <div className="app-chip-row" style={{ gap: 'var(--space-2)', marginBottom: 4 }}>
+                      <StatusChip label={label} tone={style.tone} />
+                      <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>Week {entry.week}</span>
+                      {type === 'game' && entry.result ? <StatusChip label={String(entry.result).toUpperCase()} tone={String(entry.result).toUpperCase() === 'W' ? 'ok' : String(entry.result).toUpperCase() === 'L' ? 'danger' : 'neutral'} /> : null}
+                    </div>
                     <strong>{entry.headline}</strong>
-                    <p style={{ margin: '4px 0 0', color: 'var(--text-muted)', fontSize: 'var(--text-xs)' }}>Conf standing: #{entry.standingsPosition ?? '—'} {entry.standout?.name ? `· Standout: ${entry.standout.name}` : ''}</p>
+                    <p style={{ margin: '4px 0 0', color: 'var(--text-muted)', fontSize: 'var(--text-xs)' }}>{secondaryLine(entry)}</p>
                   </button>
                   {open ? (
-                    <div style={{ marginTop: 'var(--space-2)' }}>
+                    <div style={{ marginTop: 'var(--space-2)' }} data-testid="franchise-story-event-details">
+                      {metaLines.length ? (
+                        <div style={{ display: 'grid', gap: 4, marginBottom: 'var(--space-2)' }}>
+                          {metaLines.map((line) => (
+                            <p key={`${entry.id}-${line.label}`} style={{ margin: 0, color: 'var(--text-muted)' }}>
+                              <strong style={{ color: 'var(--text-primary)' }}>{line.label}:</strong> {line.value}
+                            </p>
+                          ))}
+                        </div>
+                      ) : null}
                       {!!entry.events?.length && (
                         <>
                           <p style={{ margin: '0 0 4px', fontWeight: 600 }}>Franchise events</p>
-                          {entry.events.map((event, idx) => <p key={`${entry.id}-e-${idx}`} style={{ margin: '0 0 4px', color: 'var(--text-muted)' }}>• {event}</p>)}
+                          {entry.events.map((event, idx) => <p key={`${entry.id}-e-${idx}`} style={{ margin: '0 0 4px', color: 'var(--text-muted)' }}>- {event}</p>)}
                         </>
                       )}
                       {!!entry.moments?.length && (
                         <>
                           <p style={{ margin: '8px 0 4px', fontWeight: 600 }}>Game moments</p>
-                          {entry.moments.map((moment) => <p key={moment.id} style={{ margin: '0 0 4px', color: 'var(--text-muted)' }}>• {moment.text}</p>)}
+                          {entry.moments.map((moment) => <p key={moment.id} style={{ margin: '0 0 4px', color: 'var(--text-muted)' }}>- {moment.text}</p>)}
                         </>
                       )}
                     </div>
@@ -60,7 +183,7 @@ export default function FranchiseStoryHub({ league }) {
       <SectionCard title="Milestone Badges" subtitle="Persistent dynasty achievements." variant="compact">
         <div className="app-chip-row" style={{ gap: 'var(--space-2)' }}>
           {(story.badges ?? []).map((badge) => (
-            <StatusChip key={badge.id} label={badge.unlocked ? `🏆 ${badge.label}` : `🔒 ${badge.label}`} tone={badge.unlocked ? 'ok' : 'info'} />
+            <StatusChip key={badge.id} label={badge.unlocked ? badge.label : `Locked: ${badge.label}`} tone={badge.unlocked ? 'ok' : 'info'} />
           ))}
         </div>
       </SectionCard>

--- a/src/ui/components/FranchiseStoryHub.test.jsx
+++ b/src/ui/components/FranchiseStoryHub.test.jsx
@@ -1,0 +1,124 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import FranchiseStoryHub from './FranchiseStoryHub.jsx';
+
+function buildLeague() {
+  return {
+    year: 2026,
+    week: 8,
+    userTeamId: 1,
+    teams: [{ id: 1, conf: 0, abbr: 'PIT', wins: 5, losses: 3, roster: [] }],
+    schedule: { weeks: [] },
+    franchiseChronicle: [
+      {
+        id: 'legacy-game',
+        season: 2026,
+        week: 3,
+        result: 'W',
+        score: { away: 17, home: 24 },
+        headline: 'Legacy comeback win',
+        summary: 'W BAL 17-24 PIT',
+      },
+      {
+        id: 'trade-1',
+        season: 2026,
+        week: 5,
+        type: 'trade',
+        headline: 'PIT lands Dev Grant',
+        summary: 'Trade negotiation completed.',
+        meta: {
+          type: 'trade',
+          incomingPlayers: [{ name: 'Dev Grant', pos: 'CB', ovr: 82 }],
+          outgoingPicks: ['2027 Round 2 Pick 52'],
+          teams: ['PIT', 'ARI'],
+        },
+      },
+      {
+        id: 'contract-1',
+        season: 2026,
+        week: 6,
+        type: 'contract',
+        headline: 'Jay Stone signs extension',
+        summary: 'Contract decision recorded.',
+        meta: {
+          type: 'contract',
+          player: { name: 'Jay Stone', pos: 'WR', ovr: 84 },
+          years: 3,
+          totalValue: 48,
+          aav: 16,
+        },
+      },
+      {
+        id: 'draft-1',
+        season: 2026,
+        week: 7,
+        type: 'draft',
+        headline: 'Rico Vale joins the class',
+        summary: '2026 Round 3 Pick 91',
+        meta: {
+          type: 'draft',
+          player: { name: 'Rico Vale', pos: 'EDGE', ovr: 74 },
+          pickLabel: '2026 Round 3 Pick 91',
+        },
+      },
+      {
+        id: 'injury-1',
+        season: 2026,
+        week: 8,
+        type: 'injury',
+        headline: 'Ty Cole injury update',
+        summary: 'Hamstring strain - 2 weeks',
+        meta: {
+          type: 'injury',
+          player: { name: 'Ty Cole', pos: 'CB', ovr: 80 },
+          injury: 'Hamstring strain',
+          duration: '2 weeks',
+        },
+      },
+      {
+        id: 'milestone-1',
+        season: 2026,
+        week: 8,
+        type: 'milestone',
+        headline: 'First playoff berth',
+        summary: 'Clinched in Week 17',
+        meta: {
+          type: 'milestone',
+          label: 'First playoff berth',
+          description: 'Clinched in Week 17',
+          unlockedOn: '2026 Week 17',
+        },
+      },
+    ],
+  };
+}
+
+describe('FranchiseStoryHub typed timeline', () => {
+  afterEach(() => cleanup());
+
+  it('renders typed event labels and keeps legacy game entries safe', () => {
+    render(<FranchiseStoryHub league={buildLeague()} />);
+
+    expect(screen.getByText('Game')).toBeTruthy();
+    expect(screen.getByText('Trade')).toBeTruthy();
+    expect(screen.getByText('Contract')).toBeTruthy();
+    expect(screen.getByText('Draft')).toBeTruthy();
+    expect(screen.getByText('Injury')).toBeTruthy();
+    expect(screen.getByText('Milestone')).toBeTruthy();
+    expect(screen.getByText('Legacy comeback win')).toBeTruthy();
+  });
+
+  it('expands non-game metadata without rendering empty placeholders', () => {
+    render(<FranchiseStoryHub league={buildLeague()} />);
+
+    fireEvent.click(screen.getByText('PIT lands Dev Grant'));
+
+    expect(screen.getByText('Added:')).toBeTruthy();
+    expect(screen.getByText(/Dev Grant - CB - 82 OVR/)).toBeTruthy();
+    expect(screen.getByText('Picks:')).toBeTruthy();
+    expect(screen.getByText(/2027 Round 2 Pick 52/)).toBeTruthy();
+    expect(screen.queryByText('undefined')).toBeNull();
+  });
+});

--- a/src/ui/utils/franchiseChronicle.js
+++ b/src/ui/utils/franchiseChronicle.js
@@ -3,6 +3,172 @@ function safeNum(value, fallback = 0) {
   return Number.isFinite(n) ? n : fallback;
 }
 
+const CHRONICLE_CAP = 340;
+
+const CANONICAL_EVENT_TYPES = new Set(['game', 'trade', 'contract', 'draft', 'injury', 'milestone', 'custom', 'event']);
+
+const EVENT_TYPE_ALIASES = {
+  con: 'contract',
+  contract_extension: 'contract',
+  contract_signing: 'contract',
+  extension: 'contract',
+  re_signing: 'contract',
+  resigning: 'contract',
+  trd: 'trade',
+  trade_completed: 'trade',
+  draft_pick: 'draft',
+  rookie: 'draft',
+  hurt: 'injury',
+  weekly_event_auto_resolve: 'event',
+  weekly_event_decision: 'event',
+  weekly_event: 'event',
+};
+
+export const CHRONICLE_EVENT_LABELS = {
+  game: 'Game',
+  trade: 'Trade',
+  contract: 'Contract',
+  draft: 'Draft',
+  injury: 'Injury',
+  milestone: 'Milestone',
+  custom: 'Event',
+  event: 'Event',
+};
+
+function normalizeEventType(value) {
+  const raw = String(value ?? '').trim().toLowerCase();
+  if (!raw) return null;
+  const normalized = raw.replace(/\s+/g, '_').replaceAll('-', '_');
+  const aliased = EVENT_TYPE_ALIASES[normalized] ?? normalized;
+  return CANONICAL_EVENT_TYPES.has(aliased) ? aliased : null;
+}
+
+export function resolveChronicleEventType(entry = {}) {
+  const explicit = normalizeEventType(entry?.type);
+  if (explicit) return explicit;
+  const metaType = normalizeEventType(entry?.meta?.type);
+  if (metaType) return metaType;
+
+  const result = String(entry?.result ?? '').trim().toUpperCase();
+  const hasScore = Boolean(entry?.score)
+    || entry?.homeScore != null
+    || entry?.awayScore != null
+    || entry?.scoreHome != null
+    || entry?.scoreAway != null;
+  if (['W', 'L', 'T'].includes(result) || hasScore) return 'game';
+
+  return 'event';
+}
+
+function slugify(value, fallback = 'event') {
+  const slug = String(value ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 44);
+  return slug || fallback;
+}
+
+function compareChronicleEntries(a, b) {
+  return (safeNum(a?.season) - safeNum(b?.season))
+    || (safeNum(a?.week) - safeNum(b?.week))
+    || String(a?.id ?? '').localeCompare(String(b?.id ?? ''));
+}
+
+function ensureUniqueChronicleId(league, baseId) {
+  const existing = new Set((league?.franchiseChronicle ?? []).map((entry) => String(entry?.id ?? '')).filter(Boolean));
+  let id = String(baseId ?? 'chronicle-event');
+  let index = 2;
+  while (existing.has(id)) {
+    id = `${baseId}-${index}`;
+    index += 1;
+  }
+  return id;
+}
+
+function buildEventId({ league, payload, season, week, type }) {
+  if (payload?.id) return ensureUniqueChronicleId(league, payload.id);
+  const key = payload?.key
+    ?? payload?.meta?.eventId
+    ?? payload?.meta?.playerId
+    ?? payload?.playerId
+    ?? payload?.headline
+    ?? payload?.summary
+    ?? payload?.outcome
+    ?? type;
+  return ensureUniqueChronicleId(league, `${season}-wk${week}-${type}-${slugify(key, type)}`);
+}
+
+function trimText(value) {
+  const text = String(value ?? '').replace(/\s+/g, ' ').trim();
+  return text || null;
+}
+
+function getPlayerName(player) {
+  if (!player) return null;
+  if (typeof player === 'string') return trimText(player);
+  return trimText(player?.name ?? `${player?.firstName ?? ''} ${player?.lastName ?? ''}`) ?? (player?.id != null ? `Player ${player.id}` : null);
+}
+
+function normalizePlayerMeta(player) {
+  const name = getPlayerName(player);
+  if (!name) return null;
+  if (typeof player === 'string') return { name };
+  return {
+    id: player?.id ?? player?.playerId ?? null,
+    name,
+    pos: player?.pos ?? player?.position ?? null,
+    ovr: player?.ovr ?? player?.overall ?? null,
+  };
+}
+
+function normalizePlayerList(value) {
+  const rows = Array.isArray(value) ? value : value ? [value] : [];
+  return rows.map(normalizePlayerMeta).filter(Boolean);
+}
+
+function normalizeLabelList(value) {
+  const rows = Array.isArray(value) ? value : value ? [value] : [];
+  return rows
+    .map((item) => {
+      if (typeof item === 'string') return trimText(item);
+      return trimText(item?.label ?? item?.name ?? item?.abbr ?? item?.teamAbbr ?? item?.teamName);
+    })
+    .filter(Boolean);
+}
+
+function normalizePickLabel(pick) {
+  if (!pick) return null;
+  if (typeof pick === 'string') return trimText(pick);
+  if (pick?.label) return trimText(pick.label);
+  const year = pick?.year ?? pick?.season;
+  const round = pick?.round ?? pick?.rd;
+  const number = pick?.pick ?? pick?.overall ?? pick?.selection;
+  const parts = [
+    year ? `${year}` : null,
+    round ? `Round ${round}` : null,
+    number ? `Pick ${number}` : null,
+  ].filter(Boolean);
+  return parts.length ? parts.join(' ') : null;
+}
+
+function normalizePickLabels(value) {
+  const rows = Array.isArray(value) ? value : value ? [value] : [];
+  return rows.map(normalizePickLabel).filter(Boolean);
+}
+
+function normalizeChronicleEntry(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  const type = resolveChronicleEventType(entry);
+  const rawType = entry?.type ?? entry?.meta?.type;
+  const sourceType = rawType && normalizeEventType(rawType) !== type ? rawType : entry?.meta?.sourceType;
+  return {
+    ...entry,
+    type,
+    meta: { ...(entry?.meta ?? {}), ...(sourceType ? { sourceType } : {}), type },
+  };
+}
+
 function getUserTeam(league) {
   return (league?.teams ?? []).find((team) => Number(team?.id) === Number(league?.userTeamId)) ?? null;
 }
@@ -96,6 +262,7 @@ function buildChronicleEntry({ league, team, week, game }) {
 
   return {
     id: `${safeNum(league?.seasonId, league?.year)}-wk${week}-${game?.id ?? `${awayAbbr}-${homeAbbr}`}`,
+    type: 'game',
     season: safeNum(league?.year, safeNum(league?.seasonId, 0)),
     week,
     result,
@@ -108,6 +275,7 @@ function buildChronicleEntry({ league, team, week, game }) {
     moments: Array.isArray(game?.boxScore?.playLogs)
       ? game.boxScore.playLogs.slice(-3).map((entry, idx) => ({ id: `m-${week}-${idx}`, text: typeof entry === 'string' ? entry : entry?.text ?? 'Key moment' }))
       : [],
+    meta: { type: 'game', gameId: game?.id ?? null },
   };
 }
 
@@ -159,8 +327,11 @@ export function logChronicleEvent(league, payload = {}) {
 
   const week = safeNum(payload?.week, safeNum(league?.week, 1));
   const season = safeNum(payload?.season, safeNum(league?.year, 0));
-  const entry = {
-    id: payload?.id ?? `${season}-wk${week}-event-${String(payload?.type ?? 'custom')}`,
+  const type = resolveChronicleEventType(payload);
+  const entry = normalizeChronicleEntry({
+    ...payload,
+    id: buildEventId({ league, payload, season, week, type }),
+    type,
     season,
     week,
     result: payload?.result ?? 'EVT',
@@ -169,17 +340,27 @@ export function logChronicleEvent(league, payload = {}) {
     events: Array.isArray(payload?.events) ? payload.events : [payload?.outcome].filter(Boolean),
     standout: payload?.standout ?? null,
     moments: Array.isArray(payload?.moments) ? payload.moments : [],
-    meta: { type: payload?.type ?? 'event', ...(payload?.meta ?? {}) },
-  };
+    meta: { ...(payload?.meta ?? {}), type },
+  });
 
   league.franchiseChronicle.push(entry);
   league.franchiseChronicle = [...league.franchiseChronicle]
-    .sort((a, b) => (safeNum(a?.season) - safeNum(b?.season)) || (safeNum(a?.week) - safeNum(b?.week)))
-    .slice(-340);
+    .map(normalizeChronicleEntry)
+    .filter(Boolean)
+    .sort(compareChronicleEntries)
+    .slice(-CHRONICLE_CAP);
   return entry;
 }
 
 export function logTradeOutcome(league, payload = {}) {
+  const players = normalizePlayerList(payload?.players ?? payload?.player ?? payload?.playerName);
+  const incomingPlayers = normalizePlayerList(payload?.incomingPlayers ?? payload?.acquiredPlayers ?? payload?.receivedPlayers);
+  const outgoingPlayers = normalizePlayerList(payload?.outgoingPlayers ?? payload?.sentPlayers ?? payload?.tradedPlayers);
+  const picks = normalizePickLabels(payload?.picks ?? payload?.draftPicks ?? payload?.pick);
+  const incomingPicks = normalizePickLabels(payload?.incomingPicks ?? payload?.acquiredPicks);
+  const outgoingPicks = normalizePickLabels(payload?.outgoingPicks ?? payload?.sentPicks);
+  const teams = normalizeLabelList(payload?.teams ?? payload?.teamLabels ?? [payload?.fromTeam, payload?.toTeam].filter(Boolean));
+
   return logChronicleEvent(league, {
     ...payload,
     type: 'trade',
@@ -187,22 +368,113 @@ export function logTradeOutcome(league, payload = {}) {
     headline: payload?.headline ?? 'Trade talks concluded',
     summary: payload?.summary ?? payload?.reasoning ?? 'Trade negotiation completed.',
     outcome: payload?.outcome,
+    meta: {
+      ...(payload?.meta ?? {}),
+      players,
+      incomingPlayers,
+      outgoingPlayers,
+      picks,
+      incomingPicks,
+      outgoingPicks,
+      teams,
+    },
   });
 }
 
 export function logContractOutcome(league, payload = {}) {
+  const player = normalizePlayerMeta(payload?.player ?? payload?.playerName);
+  const years = payload?.years ?? payload?.contractYears ?? payload?.termYears ?? payload?.contract?.years ?? payload?.contract?.yearsRemaining ?? null;
+  const totalValue = payload?.totalValue ?? payload?.contractValue ?? payload?.totalMoney ?? payload?.contract?.totalValue ?? payload?.contract?.value ?? null;
+  const aav = payload?.aav ?? payload?.annualValue ?? payload?.contract?.aav ?? payload?.contract?.baseAnnual ?? payload?.contract?.salary ?? null;
+
   return logChronicleEvent(league, {
     ...payload,
     type: 'contract',
     result: payload?.result ?? 'CON',
     headline: payload?.headline ?? 'Contract negotiation update',
     summary: payload?.summary ?? payload?.outcome ?? 'Contract decision recorded.',
+    meta: {
+      ...(payload?.meta ?? {}),
+      player,
+      years,
+      totalValue,
+      aav,
+    },
+  });
+}
+
+export function logDraftOutcome(league, payload = {}) {
+  const player = normalizePlayerMeta(payload?.player ?? payload?.playerName);
+  const round = payload?.round ?? payload?.draftRound ?? payload?.pick?.round ?? null;
+  const pick = payload?.pickNumber ?? payload?.overallPick ?? payload?.selection ?? payload?.pick?.pick ?? payload?.pick?.overall ?? null;
+  const pickLabel = normalizePickLabel(payload?.pickLabel ?? (typeof payload?.pick === 'object' ? payload.pick : null) ?? { year: payload?.season ?? league?.year, round, pick });
+  const fallbackSummary = [pickLabel, player?.pos, player?.ovr != null ? `${player.ovr} OVR` : null].filter(Boolean).join(' - ') || 'Draft decision recorded.';
+
+  return logChronicleEvent(league, {
+    ...payload,
+    type: 'draft',
+    result: payload?.result ?? 'DRF',
+    headline: payload?.headline ?? (player?.name ? `${player.name} joins the draft class` : 'Draft pick recorded'),
+    summary: payload?.summary ?? fallbackSummary,
+    meta: {
+      ...(payload?.meta ?? {}),
+      player,
+      round,
+      pick,
+      pickLabel,
+      potential: payload?.potential ?? payload?.pot ?? payload?.player?.potential ?? payload?.player?.pot ?? null,
+    },
+  });
+}
+
+export function logInjuryEvent(league, payload = {}) {
+  const player = normalizePlayerMeta(payload?.player ?? payload?.playerName);
+  const injury = trimText(payload?.injury ?? payload?.injuryLabel ?? payload?.detail ?? payload?.description ?? payload?.player?.injury?.label);
+  const duration = trimText(payload?.duration ?? payload?.durationLabel ?? payload?.weeks ?? payload?.gamesRemaining ?? payload?.player?.injury?.duration);
+  const fallbackSummary = [injury, duration].filter(Boolean).join(' - ') || 'Injury event recorded.';
+
+  return logChronicleEvent(league, {
+    ...payload,
+    type: 'injury',
+    result: payload?.result ?? 'INJ',
+    headline: payload?.headline ?? (player?.name ? `${player.name} injury update` : 'Injury update'),
+    summary: payload?.summary ?? fallbackSummary,
+    meta: {
+      ...(payload?.meta ?? {}),
+      player,
+      injury,
+      duration,
+    },
+  });
+}
+
+export function logMilestoneEvent(league, payload = {}) {
+  const label = trimText(payload?.label ?? payload?.milestone ?? payload?.headline);
+  const description = trimText(payload?.description ?? payload?.summary ?? payload?.outcome);
+  const unlockedOn = trimText(payload?.unlockedOn ?? payload?.date ?? `${safeNum(payload?.season, safeNum(league?.year, 0))} Week ${safeNum(payload?.week, safeNum(league?.week, 1))}`);
+
+  return logChronicleEvent(league, {
+    ...payload,
+    type: 'milestone',
+    result: payload?.result ?? 'MIL',
+    headline: payload?.headline ?? label ?? 'Milestone reached',
+    summary: payload?.summary ?? description ?? 'Franchise milestone recorded.',
+    meta: {
+      ...(payload?.meta ?? {}),
+      label,
+      description,
+      unlockedOn,
+    },
   });
 }
 
 export function syncFranchiseChronicle(league) {
   if (!league || typeof league !== 'object') return { entries: [], seasonReview: null, badges: [] };
   if (!Array.isArray(league.franchiseChronicle)) league.franchiseChronicle = [];
+
+  league.franchiseChronicle = league.franchiseChronicle
+    .map(normalizeChronicleEntry)
+    .filter(Boolean);
 
   const team = getUserTeam(league);
   if (!team) return { entries: [], seasonReview: null, badges: [] };
@@ -217,8 +489,10 @@ export function syncFranchiseChronicle(league) {
   }
 
   league.franchiseChronicle = [...league.franchiseChronicle]
-    .sort((a, b) => (safeNum(a?.season) - safeNum(b?.season)) || (safeNum(a?.week) - safeNum(b?.week)))
-    .slice(-340);
+    .map(normalizeChronicleEntry)
+    .filter(Boolean)
+    .sort(compareChronicleEntries)
+    .slice(-CHRONICLE_CAP);
 
   const seasonReview = buildSeasonInReview(league, team);
   if (seasonReview) {

--- a/src/ui/utils/franchiseChronicle.test.js
+++ b/src/ui/utils/franchiseChronicle.test.js
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { syncFranchiseChronicle } from './franchiseChronicle.js';
+import {
+  logChronicleEvent,
+  logContractOutcome,
+  logDraftOutcome,
+  logInjuryEvent,
+  logMilestoneEvent,
+  logTradeOutcome,
+  resolveChronicleEventType,
+  syncFranchiseChronicle,
+} from './franchiseChronicle.js';
 
 function buildLeague(overrides = {}) {
   return {
@@ -55,6 +64,8 @@ describe('syncFranchiseChronicle', () => {
     expect(story.entries).toHaveLength(1);
     expect(story.entries[0].week).toBe(1);
     expect(story.entries[0].result).toBe('W');
+    expect(story.entries[0].type).toBe('game');
+    expect(story.entries[0].meta.type).toBe('game');
     expect(story.entries[0].events[0]).toContain('extends veteran LT');
   });
 
@@ -72,5 +83,110 @@ describe('syncFranchiseChronicle', () => {
     });
     const story = syncFranchiseChronicle(league);
     expect(story.seasonReview?.text).toContain('2026 Season: 10-7');
+  });
+
+  it('normalizes old game-only entries without duplicating synced games', () => {
+    const league = buildLeague({
+      franchiseChronicle: [{
+        id: 'old-game',
+        season: 2026,
+        week: 2,
+        result: 'L',
+        score: { away: 21, home: 17 },
+        headline: 'Legacy loss',
+        summary: 'L 21-17',
+      }],
+    });
+    const story = syncFranchiseChronicle(league);
+    expect(resolveChronicleEventType(story.entries[0])).toBe('game');
+    expect(story.entries.find((entry) => entry.id === 'old-game')?.meta.type).toBe('game');
+
+    const second = syncFranchiseChronicle(league);
+    expect(second.entries.map((entry) => entry.id).filter((id) => id === '2026-wk1-g1')).toHaveLength(1);
+  });
+});
+
+describe('typed chronicle events', () => {
+  it('stores typed metadata and avoids duplicate ids for same-week events', () => {
+    const league = buildLeague({ franchiseChronicle: [] });
+    const first = logChronicleEvent(league, { week: 3, type: 'custom', headline: 'Owner meeting', summary: 'Budget reviewed.' });
+    const second = logChronicleEvent(league, { week: 3, type: 'custom', headline: 'Owner meeting', summary: 'Budget reviewed again.' });
+
+    expect(first.type).toBe('custom');
+    expect(first.meta.type).toBe('custom');
+    expect(second.id).not.toBe(first.id);
+    expect(resolveChronicleEventType({ meta: { type: 'trade_completed' } })).toBe('trade');
+  });
+
+  it('logs trade outcomes with safe player, pick, and team metadata', () => {
+    const league = buildLeague({ franchiseChronicle: [] });
+    const entry = logTradeOutcome(league, {
+      week: 4,
+      headline: 'PIT adds a corner',
+      incomingPlayers: [{ id: 33, name: 'Dev Grant', pos: 'CB', ovr: 82 }],
+      outgoingPicks: [{ year: 2027, round: 2, pick: 52 }],
+      teams: [{ abbr: 'PIT' }, { abbr: 'ARI' }],
+    });
+
+    expect(entry.type).toBe('trade');
+    expect(entry.meta.incomingPlayers[0]).toMatchObject({ name: 'Dev Grant', pos: 'CB', ovr: 82 });
+    expect(entry.meta.outgoingPicks[0]).toBe('2027 Round 2 Pick 52');
+    expect(entry.meta.teams).toEqual(['PIT', 'ARI']);
+  });
+
+  it('logs contract outcomes with player and money metadata', () => {
+    const league = buildLeague({ franchiseChronicle: [] });
+    const entry = logContractOutcome(league, {
+      player: { id: 10, firstName: 'Jay', lastName: 'Stone', pos: 'WR', ovr: 84 },
+      years: 3,
+      totalValue: 48,
+      aav: 16,
+    });
+
+    expect(entry.type).toBe('contract');
+    expect(entry.meta.player).toMatchObject({ name: 'Jay Stone', pos: 'WR', ovr: 84 });
+    expect(entry.meta.years).toBe(3);
+    expect(entry.meta.totalValue).toBe(48);
+    expect(entry.meta.aav).toBe(16);
+  });
+
+  it('logs draft outcomes safely from sparse payloads', () => {
+    const league = buildLeague({ franchiseChronicle: [] });
+    const entry = logDraftOutcome(league, {
+      playerName: 'Rico Vale',
+      round: 3,
+      pickNumber: 91,
+    });
+
+    expect(entry.type).toBe('draft');
+    expect(entry.meta.player.name).toBe('Rico Vale');
+    expect(entry.meta.pickLabel).toBe('2026 Round 3 Pick 91');
+  });
+
+  it('logs injury events safely from sparse payloads', () => {
+    const league = buildLeague({ franchiseChronicle: [] });
+    const entry = logInjuryEvent(league, {
+      playerName: 'Ty Cole',
+      injury: 'Hamstring strain',
+      duration: '2 weeks',
+    });
+
+    expect(entry.type).toBe('injury');
+    expect(entry.meta.player.name).toBe('Ty Cole');
+    expect(entry.meta.injury).toBe('Hamstring strain');
+    expect(entry.meta.duration).toBe('2 weeks');
+  });
+
+  it('logs milestone events safely from sparse payloads', () => {
+    const league = buildLeague({ franchiseChronicle: [] });
+    const entry = logMilestoneEvent(league, {
+      label: 'First playoff berth',
+      description: 'Clinched in Week 17',
+    });
+
+    expect(entry.type).toBe('milestone');
+    expect(entry.meta.label).toBe('First playoff berth');
+    expect(entry.meta.description).toBe('Clinched in Week 17');
+    expect(entry.meta.unlockedOn).toBe('2026 Week 3');
   });
 });


### PR DESCRIPTION
## Summary
- Add typed Franchise Chronicle event normalization for games, trades, contracts, drafts, injuries, milestones, and fallback events.
- Preserve the existing `league.franchiseChronicle` array shape while adding backward-compatible `type` and `meta.type` fields.
- Upgrade Franchise Story Hub timeline cards with event chips, type-aware left borders, and compact metadata rows for non-game events.
- Add regression coverage for typed helper creation, legacy game entries, duplicate prevention, and typed hub rendering.

## Notes
- No IndexedDB schema/version changes.
- No worker, simulation, season advancement, persistence schema, routing, awards, records, hall of fame, or player career log changes.
- Existing trade/contract call sites were searched; no direct production call sites for `logTradeOutcome`/`logContractOutcome` existed to enrich. Weekly event call sites continue through `logChronicleEvent` and are normalized as fallback Event entries.
- Draft, injury, and milestone helpers are available for future safe UI-layer integration; injury simulation integration is intentionally deferred.

## Validation
- `npm.cmd run test:unit` passed: 193 files, 907 tests.
- `npm.cmd run build` passed; Vite emitted the existing large chunk warning.
- E2E smoke not run because this did not change FranchiseStoryHub routing/navigation/main app flow.
- Soak not run because no simulation/worker/season advancement logic changed.
