### PR TITLE
[codex] Wire franchise chronicle action logging

### DIFF
--- a/src/ui/components/ContractCenter.jsx
+++ b/src/ui/components/ContractCenter.jsx
@@ -13,6 +13,7 @@ import { derivePlayerContractFinancials } from '../utils/contractFormatting.js';
 import { deriveTeamCapSnapshot } from '../utils/numberFormatting.js';
 import { evaluateResignRecommendation } from '../utils/contractInsights.js';
 import { buildContractOfferInsight, toneToContractInsightColor } from '../utils/contractOfferInsights.js';
+import { logCompletedContractAction, persistFranchiseChronicle } from '../utils/franchiseChronicle.js';
 
 const PREMIUM_POSITIONS = new Set(['QB', 'LT', 'EDGE', 'CB']);
 const SORT_PRESETS = [
@@ -220,17 +221,27 @@ function ReSigningCenter({ league, team, actions, onNavigate, setStatusMessage }
   const confirmExtension = async () => {
     if (!previewRow || !actions?.extendContract || !team?.id) return;
     setBusyPlayerId(previewRow.player.id);
+    const contract = {
+      years: previewRow.demand.yearsTotal,
+      yearsTotal: previewRow.demand.yearsTotal,
+      baseAnnual: previewRow.demand.baseAnnual,
+      signingBonus: previewRow.demand.signingBonus,
+      guaranteedPct: previewRow.demand.guaranteedPct,
+    };
     try {
-      const response = await actions.extendContract(previewRow.player.id, team.id, {
-        years: previewRow.demand.yearsTotal,
-        yearsTotal: previewRow.demand.yearsTotal,
-        baseAnnual: previewRow.demand.baseAnnual,
-        signingBonus: previewRow.demand.signingBonus,
-        guaranteedPct: previewRow.demand.guaranteedPct,
-      });
+      const response = await actions.extendContract(previewRow.player.id, team.id, contract);
       const status = response?.payload?.status;
       if (status === 'accepted') {
+        logCompletedContractAction(league, {
+          id: `contract-${league?.seasonId ?? league?.year}-wk${league?.week ?? 1}-resign-${team.id}-${previewRow.player.id}`,
+          player: previewRow.player,
+          contract,
+          team,
+          source: 'resigning_center',
+          headline: `${previewRow.player.name} signs extension`,
+        });
         await actions.updatePlayerManagement(previewRow.player.id, team.id, { extensionDecision: 'extended' });
+        await persistFranchiseChronicle(actions, league);
         setStatusMessage(`${previewRow.player.name} extension accepted.`);
       } else if (status === 'counter') {
         setStatusMessage(`${previewRow.player.name} countered. Ask increased to ${money(response?.payload?.counter?.baseAnnual)}.`);
@@ -378,7 +389,16 @@ export default function ContractCenter({ league, actions, compact = false, onNav
     }
     try {
       await actions.applyFranchiseTag(player.id, team.id);
+      logCompletedContractAction(league, {
+        id: `contract-${league?.seasonId ?? league?.year}-wk${league?.week ?? 1}-tag-${team.id}-${player.id}`,
+        player,
+        team,
+        source: 'franchise_tag',
+        headline: `${player.name} receives franchise tag`,
+        summary: 'Franchise tag applied.',
+      });
       await actions.updatePlayerManagement?.(player.id, team.id, { extensionDecision: 'tagged' });
+      await persistFranchiseChronicle(actions, league);
       setStatusMessage(`Tagged ${player.name}.`);
     } catch (err) {
       setStatusMessage(err?.message || 'Special retention tool not yet available.');
@@ -452,7 +472,16 @@ export default function ContractCenter({ league, actions, compact = false, onNav
           actions={actions}
           cacheScopeKey={buildLeagueCacheScopeKey(league)}
           onClose={() => setExtensionPlayer(null)}
-          onComplete={() => {
+          onComplete={async (_payload, signedContract) => {
+            logCompletedContractAction(league, {
+              id: `contract-${league?.seasonId ?? league?.year}-wk${league?.week ?? 1}-extension-${team?.id}-${extensionPlayer.id}`,
+              player: extensionPlayer,
+              contract: signedContract,
+              team,
+              source: 'extension_modal',
+              headline: `${extensionPlayer.name} signs extension`,
+            });
+            await persistFranchiseChronicle(actions, league);
             setStatusMessage(`${extensionPlayer.name} extension signed.`);
             setExtensionPlayer(null);
           }}

--- a/src/ui/components/Draft.jsx
+++ b/src/ui/components/Draft.jsx
@@ -36,6 +36,7 @@ import { usePlayerCompare } from "../utils/playerCompare.js";
 import EmptyState from "./EmptyState.jsx";
 import { POS_COLORS } from "../constants/positionColors.js";
 import { buildProspectScoutingReport } from "../../core/scoutingModel.js";
+import { logCompletedDraftAction, persistFranchiseChronicle } from "../utils/franchiseChronicle.js";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -2351,6 +2352,12 @@ export default function Draft({ league, actions, onNavigate = null }) {
               (pk) => pk.teamId === league?.userTeamId && pk.playerOvr != null,
             );
           if (lastUserPick) {
+            logCompletedDraftAction(league, {
+              id: `draft-${league?.seasonId ?? league?.year}-${lastUserPick.overall ?? lastUserPick.pickInRound}-${lastUserPick.playerId}`,
+              pick: lastUserPick,
+              source: 'draft_room',
+            });
+            await persistFranchiseChronicle(actions, league);
             const grade = calculatePickGrade(
               lastUserPick.playerOvr,
               lastUserPick.overall,
@@ -2363,7 +2370,7 @@ export default function Draft({ league, actions, onNavigate = null }) {
         setError(err.message);
       }
     },
-    [actions, league?.userTeamId, normalizeDraftState],
+    [actions, league, normalizeDraftState],
   );
 
   // ── Render ─────────────────────────────────────────────────────────────────

--- a/src/ui/components/ExtensionNegotiationModal.jsx
+++ b/src/ui/components/ExtensionNegotiationModal.jsx
@@ -59,7 +59,7 @@ export default function ExtensionNegotiationModal({
       const resp = await actions.extendContract(player.id, teamId, offer);
       const payload = resp?.payload || {};
       setResponse(payload);
-      if (payload.status === 'accepted') onComplete();
+      if (payload.status === 'accepted') await onComplete?.(payload, offer);
       if (payload.status === 'counter' && payload.counter) setOffer(payload.counter);
     } finally {
       setSubmitting(false);

--- a/src/ui/components/FranchiseStoryHub.jsx
+++ b/src/ui/components/FranchiseStoryHub.jsx
@@ -1,6 +1,6 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { EmptyState, SectionCard, StatusChip } from './ScreenSystem.jsx';
-import { CHRONICLE_EVENT_LABELS, resolveChronicleEventType, syncFranchiseChronicle } from '../utils/franchiseChronicle.js';
+import { CHRONICLE_EVENT_LABELS, persistFranchiseChronicle, resolveChronicleEventType, syncFranchiseChronicle } from '../utils/franchiseChronicle.js';
 
 const EVENT_STYLE = {
   game: { color: 'var(--text-subtle)', tone: 'neutral' },
@@ -56,7 +56,17 @@ function metadataLines(entry) {
   const meta = entry?.meta ?? {};
   const lines = [];
 
-  if (type === 'trade') {
+  if (type === 'game') {
+    const score = entry?.score ?? {};
+    const scoreLine = score.awayAbbr && score.homeAbbr && score.away != null && score.home != null
+      ? `${score.awayAbbr} ${score.away} - ${score.homeAbbr} ${score.home}`
+      : entry?.summary;
+    if (scoreLine) lines.push({ label: 'Final', value: scoreLine });
+    if (entry?.result) lines.push({ label: 'Result', value: String(entry.result).toUpperCase() });
+    if (entry?.standingsPosition != null) lines.push({ label: 'Conf standing', value: `#${entry.standingsPosition}` });
+    if (entry?.standout?.name) lines.push({ label: 'Standout', value: [entry.standout.name, entry.standout.detail].filter(Boolean).join(' - ') });
+    if (entry?.season != null) lines.push({ label: 'Season', value: entry.season });
+  } else if (type === 'trade') {
     const players = compactPlayers(meta.players);
     const incoming = compactPlayers(meta.incomingPlayers);
     const outgoing = compactPlayers(meta.outgoingPlayers);
@@ -104,10 +114,19 @@ function secondaryLine(entry) {
   return entry?.summary ?? CHRONICLE_EVENT_LABELS[type] ?? 'Franchise event';
 }
 
-export default function FranchiseStoryHub({ league }) {
+export default function FranchiseStoryHub({ league, actions = null }) {
   const [expandedId, setExpandedId] = useState(null);
+  const lastPersistedKeyRef = useRef('');
   const story = useMemo(() => syncFranchiseChronicle(league), [league]);
   const entries = [...(story.entries ?? [])].reverse();
+  const entryKey = (story.entries ?? []).map((entry) => entry?.id).filter(Boolean).join('|');
+
+  useEffect(() => {
+    if (!actions?.updateFranchiseChronicle || !Array.isArray(league?.franchiseChronicle)) return;
+    if (!entryKey || lastPersistedKeyRef.current === entryKey) return;
+    lastPersistedKeyRef.current = entryKey;
+    persistFranchiseChronicle(actions, league);
+  }, [actions, entryKey, league]);
 
   return (
     <div className="app-screen-stack franchise-story-hub">

--- a/src/ui/components/FranchiseStoryHub.test.jsx
+++ b/src/ui/components/FranchiseStoryHub.test.jsx
@@ -121,4 +121,16 @@ describe('FranchiseStoryHub typed timeline', () => {
     expect(screen.getByText(/2027 Round 2 Pick 52/)).toBeTruthy();
     expect(screen.queryByText('undefined')).toBeNull();
   });
+
+  it('expands game entries with compact final score metadata', () => {
+    render(<FranchiseStoryHub league={buildLeague()} />);
+
+    fireEvent.click(screen.getByText('Legacy comeback win'));
+
+    expect(screen.getByText('Final:')).toBeTruthy();
+    expect(screen.getByText(/W BAL 17-24 PIT/)).toBeTruthy();
+    expect(screen.getByText('Result:')).toBeTruthy();
+    expect(screen.getAllByText('W').length).toBeGreaterThan(0);
+    expect(screen.queryByText('undefined')).toBeNull();
+  });
 });

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -989,7 +989,7 @@ export default function LeagueDashboard({
         )}
         {activeTab === "Story" && (
           <TabErrorBoundary label="Story" onNavigate={setActiveTab} fallbackTab="HQ">
-            <FranchiseStoryHub league={league} />
+            <FranchiseStoryHub league={league} actions={actions} />
           </TabErrorBoundary>
         )}
         {activeTab === "Standings" && (

--- a/src/ui/components/TradeCenter.jsx
+++ b/src/ui/components/TradeCenter.jsx
@@ -20,6 +20,7 @@ import { DeadlineBanner } from "./common/UiPrimitives.jsx";
 import { buildTradeAssetDisplay } from "../utils/tradeAssetDisplay.js";
 import { getTradeLockReason } from "../utils/tradeLockReason.js";
 import { getBudgetLabel, toneToCssColor } from "../utils/transactionMarket.js";
+import { logCompletedTradeAction, persistFranchiseChronicle } from "../utils/franchiseChronicle.js";
 
 // ── Original helpers (kept exactly as you had) ─────────────────────────────────
 
@@ -123,6 +124,14 @@ function CapImpact({ myTeam, theirTeam, myCapAfter, theirCapAfter }) {
 function pickLabel(pk) {
   const display = buildTradeAssetDisplay(pk, { type: 'pick' });
   return `${display.title}${display.subtitle ? ` · ${display.subtitle}` : ''}`;
+}
+
+function findLeaguePlayer(league, playerId) {
+  for (const team of league?.teams ?? []) {
+    const found = (team?.roster ?? []).find((player) => String(player?.id) === String(playerId));
+    if (found) return found;
+  }
+  return null;
 }
 
 function PickSelector({ side, picks, onChange, availablePicks = [] }) {
@@ -511,21 +520,61 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
     try {
       const outgoing = { playerIds: [...offering].map((id) => Number(id)), pickIds: myPicks.map(p => p.id) };
       const incoming = { playerIds: [...receiving].map((id) => Number(id)), pickIds: theirPicks.map(p => p.id) };
+      const outgoingPlayers = [...offering].map((id) => myRosterMap.get(toAssetId(id))).filter(Boolean);
+      const incomingPlayers = [...receiving].map((id) => theirRosterMap.get(toAssetId(id))).filter(Boolean);
       const resp = counterOfferId
         ? await actions.counterIncomingTrade(counterOfferId, outgoing, incoming)
         : await actions.submitTrade(myTeamId, targetId, outgoing, incoming);
       if (resp?.payload) setTradeResult(resp.payload);
       if (resp?.payload?.accepted) {
+        logCompletedTradeAction(league, {
+          id: `trade-${league?.seasonId ?? league?.year}-wk${league?.week ?? 1}-${counterOfferId ? `counter-${counterOfferId}` : `${myTeamId}-${targetId}`}-${outgoing.playerIds.join('.') || 'none'}-${incoming.playerIds.join('.') || 'none'}-${outgoing.pickIds.join('.') || 'none'}-${incoming.pickIds.join('.') || 'none'}`,
+          fromTeamId: myTeamId,
+          toTeamId: targetId,
+          userTeam: liveMyTeam,
+          partnerTeam: liveTheirTeam,
+          outgoingPlayers,
+          incomingPlayers,
+          outgoingPicks: myPicks,
+          incomingPicks: theirPicks,
+          source: counterOfferId ? 'counter_trade' : 'trade_builder',
+        });
         setOffering(new Set()); setReceiving(new Set()); setMyPicks([]); setTheirPicks([]);
         setCounterOfferId(null);
         await fetchRosters(targetId);
-        actions.save();
+        await persistFranchiseChronicle(actions, league);
         setShowSavedToast(true);
       }
     } catch (e) {
       console.error(e);
       setTradeResult({ accepted: false, reason: "Trade failed – engine error." });
     } finally { setSubmitting(false); }
+  };
+
+  const handleAcceptIncomingTrade = async (offer) => {
+    if (!offer?.id || tradeLocked || !actions?.acceptIncomingTrade) return;
+    const resp = await actions.acceptIncomingTrade(offer.id);
+    if (resp?.payload?.accepted) {
+      const partnerTeam = league?.teams?.find((team) => Number(team?.id) === Number(offer.offeringTeamId)) ?? { id: offer.offeringTeamId, abbr: offer.offeringTeamAbbr };
+      const incomingPlayerIds = offer?.offering?.playerIds ?? [offer?.offeringPlayerId].filter(Boolean);
+      const outgoingPlayerIds = offer?.receiving?.playerIds ?? [offer?.receivingPlayerId].filter(Boolean);
+      logCompletedTradeAction(league, {
+        id: `trade-${league?.seasonId ?? league?.year}-wk${league?.week ?? 1}-incoming-${offer.id}`,
+        fromTeamId: myTeamId,
+        toTeamId: offer.offeringTeamId,
+        userTeam: liveMyTeam,
+        partnerTeam,
+        incomingPlayers: incomingPlayerIds.map((playerId) => findLeaguePlayer(league, playerId)).filter(Boolean),
+        outgoingPlayers: outgoingPlayerIds.map((playerId) => findLeaguePlayer(league, playerId)).filter(Boolean),
+        incomingPicks: (offer?.offering?.pickIds ?? []).map((id) => theirAvailablePicksMap.get(String(id)) ?? { id }),
+        outgoingPicks: (offer?.receiving?.pickIds ?? []).map((id) => myAvailablePicksMap.get(String(id)) ?? { id }),
+        source: 'incoming_trade',
+      });
+      await persistFranchiseChronicle(actions, league);
+      await fetchRosters(Number(offer.offeringTeamId));
+      setShowSavedToast(true);
+    }
+    if (resp?.payload) setTradeResult(resp.payload);
   };
 
   const handleTradeBlockRemove = async (playerId) => {
@@ -652,7 +701,7 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
                       </div>
                     ) : null}
                     <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-                      <Button size="sm" disabled={tradeLocked} onClick={() => actions?.acceptIncomingTrade?.(offer.id)}>Accept</Button>
+                      <Button size="sm" disabled={tradeLocked} onClick={() => handleAcceptIncomingTrade(offer)}>Accept</Button>
                       <Button size="sm" variant="secondary" disabled={tradeLocked} onClick={() => actions?.rejectIncomingTrade?.(offer.id)}>Reject</Button>
                       <Button size="sm" variant="outline" disabled={tradeLocked} onClick={() => startCounterOffer(offer)}>Counter</Button>
                       <Button size="sm" variant="outline" onClick={() => setTargetId(Number(offer.offeringTeamId))}>Open Team</Button>

--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -563,6 +563,8 @@ export function useWorker() {
 
     /** Force an immediate DB flush. */
     save: ()                     => send(toWorker.SAVE_NOW),
+    updateFranchiseChronicle: (entries) =>
+      request(toWorker.UPDATE_FRANCHISE_CHRONICLE, { entries }, { silent: true }),
 
     loadSlot: (slotKey)          => request(toWorker.LOAD_SLOT, { slotKey }, { silent: false }),
     saveSlot: (slotKey)          => send(toWorker.SAVE_SLOT, { slotKey }),

--- a/src/ui/utils/franchiseChronicle.js
+++ b/src/ui/utils/franchiseChronicle.js
@@ -40,7 +40,11 @@ function normalizeEventType(value) {
   if (!raw) return null;
   const normalized = raw.replace(/\s+/g, '_').replaceAll('-', '_');
   const aliased = EVENT_TYPE_ALIASES[normalized] ?? normalized;
-  return CANONICAL_EVENT_TYPES.has(aliased) ? aliased : null;
+  if (CANONICAL_EVENT_TYPES.has(aliased)) return aliased;
+  if (import.meta.env?.DEV) {
+    console.warn(`[franchiseChronicle] Unknown event type "${raw}" normalized to Event.`);
+  }
+  return null;
 }
 
 export function resolveChronicleEventType(entry = {}) {
@@ -75,6 +79,18 @@ function compareChronicleEntries(a, b) {
     || String(a?.id ?? '').localeCompare(String(b?.id ?? ''));
 }
 
+function hasChronicleId(league, id) {
+  return (league?.franchiseChronicle ?? []).some((entry) => String(entry?.id ?? '') === String(id ?? ''));
+}
+
+export function persistFranchiseChronicle(actions, league) {
+  if (actions?.updateFranchiseChronicle && Array.isArray(league?.franchiseChronicle)) {
+    return actions.updateFranchiseChronicle(league.franchiseChronicle);
+  }
+  actions?.save?.();
+  return Promise.resolve(null);
+}
+
 function ensureUniqueChronicleId(league, baseId) {
   const existing = new Set((league?.franchiseChronicle ?? []).map((entry) => String(entry?.id ?? '')).filter(Boolean));
   let id = String(baseId ?? 'chronicle-event');
@@ -87,7 +103,7 @@ function ensureUniqueChronicleId(league, baseId) {
 }
 
 function buildEventId({ league, payload, season, week, type }) {
-  if (payload?.id) return ensureUniqueChronicleId(league, payload.id);
+  if (payload?.id) return String(payload.id);
   const key = payload?.key
     ?? payload?.meta?.eventId
     ?? payload?.meta?.playerId
@@ -155,6 +171,20 @@ function normalizePickLabel(pick) {
 function normalizePickLabels(value) {
   const rows = Array.isArray(value) ? value : value ? [value] : [];
   return rows.map(normalizePickLabel).filter(Boolean);
+}
+
+function stableKeyPart(value) {
+  const rows = Array.isArray(value) ? value : value ? [value] : [];
+  return rows
+    .map((item) => {
+      if (item == null) return null;
+      if (typeof item === 'object') return item.id ?? item.playerId ?? item.pickId ?? item.label ?? item.name;
+      return item;
+    })
+    .filter((item) => item != null && item !== '')
+    .map((item) => String(item))
+    .sort()
+    .join('.');
 }
 
 function normalizeChronicleEntry(entry) {
@@ -281,7 +311,9 @@ function buildChronicleEntry({ league, team, week, game }) {
 
 function buildSeasonInReview(league, team) {
   const games = safeNum(team?.wins) + safeNum(team?.losses) + safeNum(team?.ties);
-  const regularSeasonComplete = games >= 17 || String(league?.phase ?? '').toLowerCase().includes('offseason');
+  const configuredSeasonLength = safeNum(league?.settings?.seasonLength ?? league?.seasonLength, 0);
+  const seasonLength = configuredSeasonLength > 0 ? configuredSeasonLength : 17; // NFL-style fallback for legacy saves.
+  const regularSeasonComplete = games >= seasonLength || String(league?.phase ?? '').toLowerCase().includes('offseason');
   if (!regularSeasonComplete) return null;
 
   const breakout = [...(team?.roster ?? [])]
@@ -305,6 +337,14 @@ export const CHRONICLE_BADGES = [
 function deriveBadgeState(league, team, chronicle) {
   const rookies = (team?.roster ?? []).filter((player) => safeNum(player?.yearsPro, 0) <= 1);
   const expiring = (team?.roster ?? []).filter((player) => safeNum(player?.contract?.yearsRemaining ?? player?.contract?.years, 0) <= 1 && safeNum(player?.ovr) >= 75);
+  const milestoneEntries = Array.isArray(chronicle)
+    ? chronicle.filter((entry) => resolveChronicleEventType(entry) === 'milestone')
+    : [];
+  const existingMilestones = new Map(
+    milestoneEntries
+      .map((entry) => [entry?.meta?.badgeId ?? entry?.meta?.milestoneId ?? entry?.id, entry])
+      .filter(([key]) => key),
+  );
 
   const unlocked = {
     first_playoff_berth: Boolean(team?.playoffAppearances ?? team?.playoffSeed ?? team?.madePlayoffs),
@@ -313,11 +353,33 @@ function deriveBadgeState(league, team, chronicle) {
     cap_wizard: safeNum(team?.capRoom, safeNum(team?.salaryCap, 0) - safeNum(team?.payroll, 0)) > 0 && expiring.length >= 3,
   };
 
-  return CHRONICLE_BADGES.map((badge) => ({
-    ...badge,
-    unlocked: Boolean(unlocked[badge.id]),
-    unlockedOn: unlocked[badge.id] ? `${safeNum(league?.year, 0)} Week ${safeNum(league?.week, 1)}` : null,
-  }));
+  return CHRONICLE_BADGES.map((badge) => {
+    const existing = existingMilestones.get(badge.id) ?? existingMilestones.get(`milestone-${badge.id}`);
+    const isUnlocked = Boolean(unlocked[badge.id]) || Boolean(existing);
+    return {
+      ...badge,
+      unlocked: isUnlocked,
+      unlockedOn: existing?.meta?.unlockedOn ?? (isUnlocked ? `${safeNum(league?.year, 0)} Week ${safeNum(league?.week, 1)}` : null),
+    };
+  });
+}
+
+function logNewBadgeMilestones(league, badges = []) {
+  if (!league || !Array.isArray(badges)) return;
+  for (const badge of badges) {
+    if (!badge?.unlocked) continue;
+    const id = `milestone-${badge.id}`;
+    if (hasChronicleId(league, id)) continue;
+    logMilestoneEvent(league, {
+      id,
+      week: safeNum(league?.week, 1),
+      season: safeNum(league?.year, safeNum(league?.seasonId, 0)),
+      label: badge.label,
+      description: badge.description,
+      unlockedOn: badge.unlockedOn,
+      meta: { badgeId: badge.id },
+    });
+  }
 }
 
 
@@ -328,9 +390,15 @@ export function logChronicleEvent(league, payload = {}) {
   const week = safeNum(payload?.week, safeNum(league?.week, 1));
   const season = safeNum(payload?.season, safeNum(league?.year, 0));
   const type = resolveChronicleEventType(payload);
+  const entryId = buildEventId({ league, payload, season, week, type });
+  const existing = league.franchiseChronicle.find((entry) => String(entry?.id ?? '') === String(entryId));
+  if (existing) {
+    Object.assign(existing, normalizeChronicleEntry(existing));
+    return existing;
+  }
   const entry = normalizeChronicleEntry({
     ...payload,
-    id: buildEventId({ league, payload, season, week, type }),
+    id: entryId,
     type,
     season,
     week,
@@ -381,6 +449,53 @@ export function logTradeOutcome(league, payload = {}) {
   });
 }
 
+export function logCompletedTradeAction(league, payload = {}) {
+  const season = safeNum(payload?.season, safeNum(league?.year, safeNum(league?.seasonId, 0)));
+  const week = safeNum(payload?.week, safeNum(league?.week, 1));
+  const fromTeamId = payload?.fromTeamId ?? league?.userTeamId;
+  const toTeamId = payload?.toTeamId ?? payload?.partnerTeamId;
+  const incomingPlayers = normalizePlayerList(payload?.incomingPlayers);
+  const outgoingPlayers = normalizePlayerList(payload?.outgoingPlayers);
+  const incomingPicks = normalizePickLabels(payload?.incomingPicks);
+  const outgoingPicks = normalizePickLabels(payload?.outgoingPicks);
+  const partner = payload?.partnerTeam ?? payload?.toTeam ?? null;
+  const partnerLabel = trimText(partner?.abbr ?? partner?.name ?? payload?.partnerTeamLabel) ?? 'trade partner';
+  const fallbackSummary = [incomingPlayers.length ? `Added ${incomingPlayers.map((p) => p.name).join(', ')}` : null, outgoingPlayers.length ? `Sent ${outgoingPlayers.map((p) => p.name).join(', ')}` : null]
+    .filter(Boolean)
+    .join(' - ') || 'Trade completed.';
+  const id = payload?.id ?? [
+    'trade',
+    season,
+    `wk${week}`,
+    payload?.source ?? 'completed',
+    fromTeamId,
+    toTeamId,
+    stableKeyPart(incomingPlayers),
+    stableKeyPart(outgoingPlayers),
+    stableKeyPart(incomingPicks),
+    stableKeyPart(outgoingPicks),
+  ].filter((part) => part != null && part !== '').join('-');
+
+  return logTradeOutcome(league, {
+    id,
+    season,
+    week,
+    headline: payload?.headline ?? `Trade completed with ${partnerLabel}`,
+    summary: payload?.summary ?? fallbackSummary,
+    incomingPlayers,
+    outgoingPlayers,
+    incomingPicks,
+    outgoingPicks,
+    teams: normalizeLabelList(payload?.teams ?? ([payload?.userTeam, partner].filter(Boolean))),
+    meta: {
+      ...(payload?.meta ?? {}),
+      source: payload?.source ?? 'completed_trade',
+      fromTeamId,
+      toTeamId,
+    },
+  });
+}
+
 export function logContractOutcome(league, payload = {}) {
   const player = normalizePlayerMeta(payload?.player ?? payload?.playerName);
   const years = payload?.years ?? payload?.contractYears ?? payload?.termYears ?? payload?.contract?.years ?? payload?.contract?.yearsRemaining ?? null;
@@ -399,6 +514,39 @@ export function logContractOutcome(league, payload = {}) {
       years,
       totalValue,
       aav,
+    },
+  });
+}
+
+export function logCompletedContractAction(league, payload = {}) {
+  const season = safeNum(payload?.season, safeNum(league?.year, safeNum(league?.seasonId, 0)));
+  const week = safeNum(payload?.week, safeNum(league?.week, 1));
+  const player = normalizePlayerMeta(payload?.player ?? payload?.playerName);
+  const contract = payload?.contract ?? {};
+  const years = payload?.years ?? contract?.yearsTotal ?? contract?.years ?? null;
+  const aav = payload?.aav ?? contract?.baseAnnual ?? contract?.salary ?? null;
+  const totalValue = payload?.totalValue ?? (aav != null && years != null ? Math.round((Number(aav) * Number(years) + safeNum(contract?.signingBonus, 0)) * 10) / 10 : null);
+  const teamId = payload?.teamId ?? league?.userTeamId;
+  const id = payload?.id ?? ['contract', season, `wk${week}`, payload?.source ?? 'signed', teamId, player?.id ?? slugify(player?.name, 'player')].join('-');
+  const fallbackSummary = [years ? `${years} years` : null, totalValue != null ? `$${totalValue}M total` : null, aav != null ? `$${Number(aav).toFixed(1)}M AAV` : null]
+    .filter(Boolean)
+    .join(' - ') || 'Contract completed.';
+
+  return logContractOutcome(league, {
+    id,
+    season,
+    week,
+    player,
+    years,
+    totalValue,
+    aav,
+    headline: payload?.headline ?? (player?.name ? `${player.name} signs with the franchise` : 'Contract signed'),
+    summary: payload?.summary ?? fallbackSummary,
+    meta: {
+      ...(payload?.meta ?? {}),
+      source: payload?.source ?? 'completed_contract',
+      teamId,
+      team: normalizeLabelList(payload?.team ? [payload.team] : []).at(0) ?? null,
     },
   });
 }
@@ -423,6 +571,39 @@ export function logDraftOutcome(league, payload = {}) {
       pick,
       pickLabel,
       potential: payload?.potential ?? payload?.pot ?? payload?.player?.potential ?? payload?.player?.pot ?? null,
+    },
+  });
+}
+
+export function logCompletedDraftAction(league, payload = {}) {
+  const pick = payload?.pick ?? payload;
+  const season = safeNum(payload?.season, safeNum(league?.year, safeNum(league?.seasonId, 0)));
+  const week = safeNum(payload?.week, safeNum(league?.week, 1));
+  const player = normalizePlayerMeta(payload?.player ?? {
+    id: pick?.playerId,
+    name: pick?.playerName,
+    pos: pick?.playerPos,
+    ovr: pick?.playerOvr,
+  });
+  const round = payload?.round ?? pick?.round ?? null;
+  const pickNumber = payload?.pickNumber ?? pick?.pickInRound ?? pick?.pick ?? null;
+  const overallPick = payload?.overallPick ?? pick?.overall ?? null;
+  const id = payload?.id ?? ['draft', season, overallPick ?? pickNumber ?? 'pick', player?.id ?? slugify(player?.name, 'player')].join('-');
+
+  return logDraftOutcome(league, {
+    id,
+    season,
+    week,
+    player,
+    round,
+    pickNumber,
+    overallPick,
+    potential: payload?.potential ?? pick?.playerPotential ?? pick?.potential ?? null,
+    headline: payload?.headline ?? (player?.name ? `${player.name} drafted by the franchise` : 'Draft pick made'),
+    meta: {
+      ...(payload?.meta ?? {}),
+      source: payload?.source ?? 'user_draft_pick',
+      teamId: payload?.teamId ?? pick?.teamId ?? league?.userTeamId,
     },
   });
 }
@@ -501,7 +682,16 @@ export function syncFranchiseChronicle(league) {
     if (!hasReview) league.franchiseSeasonReviews.push(seasonReview);
   }
 
-  const badges = deriveBadgeState(league, team, league.franchiseChronicle);
+  let badges = deriveBadgeState(league, team, league.franchiseChronicle);
+  logNewBadgeMilestones(league, badges);
+  if (league.franchiseChronicle.some((entry) => resolveChronicleEventType(entry) === 'milestone')) {
+    league.franchiseChronicle = [...league.franchiseChronicle]
+      .map(normalizeChronicleEntry)
+      .filter(Boolean)
+      .sort(compareChronicleEntries)
+      .slice(-CHRONICLE_CAP);
+    badges = deriveBadgeState(league, team, league.franchiseChronicle);
+  }
   return {
     entries: league.franchiseChronicle,
     seasonReview: seasonReview ?? [...(league.franchiseSeasonReviews ?? [])].slice(-1)[0] ?? null,

--- a/src/ui/utils/franchiseChronicle.test.js
+++ b/src/ui/utils/franchiseChronicle.test.js
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   logChronicleEvent,
+  logCompletedContractAction,
+  logCompletedDraftAction,
+  logCompletedTradeAction,
   logContractOutcome,
   logDraftOutcome,
   logInjuryEvent,
@@ -60,20 +63,22 @@ describe('syncFranchiseChronicle', () => {
   it('builds chronicle entries and keeps backward compatibility for missing saves', () => {
     const league = buildLeague({ franchiseChronicle: undefined });
     const story = syncFranchiseChronicle(league);
+    const gameEntries = story.entries.filter((entry) => entry.type === 'game');
     expect(Array.isArray(league.franchiseChronicle)).toBe(true);
-    expect(story.entries).toHaveLength(1);
-    expect(story.entries[0].week).toBe(1);
-    expect(story.entries[0].result).toBe('W');
-    expect(story.entries[0].type).toBe('game');
-    expect(story.entries[0].meta.type).toBe('game');
-    expect(story.entries[0].events[0]).toContain('extends veteran LT');
+    expect(gameEntries).toHaveLength(1);
+    expect(gameEntries[0].week).toBe(1);
+    expect(gameEntries[0].result).toBe('W');
+    expect(gameEntries[0].type).toBe('game');
+    expect(gameEntries[0].meta.type).toBe('game');
+    expect(gameEntries[0].events[0]).toContain('extends veteran LT');
   });
 
   it('does not duplicate entries when called repeatedly', () => {
     const league = buildLeague();
     syncFranchiseChronicle(league);
     const second = syncFranchiseChronicle(league);
-    expect(second.entries).toHaveLength(1);
+    expect(second.entries.filter((entry) => entry.type === 'game')).toHaveLength(1);
+    expect(second.entries.map((entry) => entry.id).filter((id) => id === '2026-wk1-g1')).toHaveLength(1);
   });
 
   it('generates season review once regular season is complete', () => {
@@ -116,6 +121,15 @@ describe('typed chronicle events', () => {
     expect(first.meta.type).toBe('custom');
     expect(second.id).not.toBe(first.id);
     expect(resolveChronicleEventType({ meta: { type: 'trade_completed' } })).toBe('trade');
+  });
+
+  it('dedupes repeated completed events that provide a deterministic id', () => {
+    const league = buildLeague({ franchiseChronicle: [] });
+    const first = logChronicleEvent(league, { id: 'event-once', week: 3, type: 'milestone', headline: 'One time' });
+    const second = logChronicleEvent(league, { id: 'event-once', week: 3, type: 'milestone', headline: 'One time again' });
+
+    expect(second.id).toBe(first.id);
+    expect(league.franchiseChronicle).toHaveLength(1);
   });
 
   it('logs trade outcomes with safe player, pick, and team metadata', () => {
@@ -188,5 +202,85 @@ describe('typed chronicle events', () => {
     expect(entry.meta.label).toBe('First playoff berth');
     expect(entry.meta.description).toBe('Clinched in Week 17');
     expect(entry.meta.unlockedOn).toBe('2026 Week 3');
+  });
+
+  it('logs completed trade actions with deterministic duplicate prevention', () => {
+    const league = buildLeague({ franchiseChronicle: [] });
+    const payload = {
+      id: 'trade-fixed',
+      fromTeamId: 1,
+      toTeamId: 2,
+      userTeam: { abbr: 'PIT' },
+      partnerTeam: { abbr: 'BAL' },
+      incomingPlayers: [{ id: 30, name: 'Rae Bell', pos: 'S', ovr: 81 }],
+      outgoingPicks: [{ year: 2027, round: 3, pick: 84 }],
+    };
+    const first = logCompletedTradeAction(league, payload);
+    const second = logCompletedTradeAction(league, payload);
+
+    expect(first.type).toBe('trade');
+    expect(second.id).toBe(first.id);
+    expect(first.meta.incomingPlayers[0].name).toBe('Rae Bell');
+    expect(first.meta.outgoingPicks[0]).toBe('2027 Round 3 Pick 84');
+    expect(league.franchiseChronicle).toHaveLength(1);
+  });
+
+  it('logs completed contract actions with deterministic duplicate prevention', () => {
+    const league = buildLeague({ franchiseChronicle: [] });
+    const first = logCompletedContractAction(league, {
+      id: 'contract-fixed',
+      player: { id: 10, name: 'Jay Stone', pos: 'WR', ovr: 84 },
+      contract: { yearsTotal: 4, baseAnnual: 12, signingBonus: 4 },
+      team: { abbr: 'PIT' },
+    });
+    const second = logCompletedContractAction(league, {
+      id: 'contract-fixed',
+      player: { id: 10, name: 'Jay Stone', pos: 'WR', ovr: 84 },
+      contract: { yearsTotal: 4, baseAnnual: 12, signingBonus: 4 },
+      team: { abbr: 'PIT' },
+    });
+
+    expect(first.type).toBe('contract');
+    expect(second.id).toBe(first.id);
+    expect(first.meta.totalValue).toBe(52);
+    expect(first.meta.aav).toBe(12);
+    expect(league.franchiseChronicle).toHaveLength(1);
+  });
+
+  it('logs completed draft actions with deterministic duplicate prevention', () => {
+    const league = buildLeague({ franchiseChronicle: [] });
+    const pick = { overall: 91, round: 3, pickInRound: 27, teamId: 1, playerId: 77, playerName: 'Rico Vale', playerPos: 'EDGE', playerOvr: 74 };
+    const first = logCompletedDraftAction(league, { pick });
+    const second = logCompletedDraftAction(league, { pick });
+
+    expect(first.type).toBe('draft');
+    expect(second.id).toBe(first.id);
+    expect(first.meta.player.name).toBe('Rico Vale');
+    expect(first.meta.pickLabel).toBe('2026 Round 3 Pick 27');
+    expect(league.franchiseChronicle).toHaveLength(1);
+  });
+
+  it('logs newly unlocked badge milestones once during sync', () => {
+    const league = buildLeague({
+      franchiseChronicle: [],
+      teams: [{ ...buildLeague().teams[0], wins: 10, losses: 0 }, buildLeague().teams[1]],
+    });
+    const first = syncFranchiseChronicle(league);
+    const second = syncFranchiseChronicle(league);
+    const milestones = second.entries.filter((entry) => entry.type === 'milestone' && entry.meta?.badgeId === 'ten_win_season');
+
+    expect(first.badges.find((badge) => badge.id === 'ten_win_season')?.unlocked).toBe(true);
+    expect(milestones).toHaveLength(1);
+  });
+
+  it('uses configured season length before generating season review', () => {
+    const league = buildLeague({
+      settings: { seasonLength: 18 },
+      teams: [{ ...buildLeague().teams[0], wins: 10, losses: 7 }, buildLeague().teams[1]],
+    });
+    expect(syncFranchiseChronicle(league).seasonReview).toBeNull();
+
+    league.teams[0].wins = 11;
+    expect(syncFranchiseChronicle(league).seasonReview?.text).toContain('2026 Season: 11-7');
   });
 });

--- a/src/worker/protocol.js
+++ b/src/worker/protocol.js
@@ -97,6 +97,7 @@ export const toWorker = Object.freeze({
   SAVE_SLOT:          'SAVE_SLOT',            // { slotKey }
   DELETE_SLOT:        'DELETE_SLOT',          // { slotKey }
   RESET_LEAGUE:       'RESET_LEAGUE',         // wipe everything
+  UPDATE_FRANCHISE_CHRONICLE: 'UPDATE_FRANCHISE_CHRONICLE', // { entries }
   EXPORT_SAVE:        'EXPORT_SAVE',          // { leagueId? }
   IMPORT_SAVE:        'IMPORT_SAVE',          // { data, saveName? }
   EXPORT_LEAGUE_CONFIG: 'EXPORT_LEAGUE_CONFIG', // {}

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -849,6 +849,8 @@ function buildViewState() {
     records: meta?.records ?? null,
     recordBook: meta?.recordBook ?? null,
     leagueHistory: Array.isArray(meta?.leagueHistory) ? meta.leagueHistory.slice(-60) : [],
+    franchiseChronicle: Array.isArray(meta?.franchiseChronicle) ? meta.franchiseChronicle.slice(-340) : [],
+    franchiseSeasonReviews: Array.isArray(meta?.franchiseSeasonReviews) ? meta.franchiseSeasonReviews.slice(-40) : [],
     seasonStorylines: Array.isArray(meta?.seasonStorylines) ? meta.seasonStorylines : [],
     hallOfFameClasses: Array.isArray(meta?.hallOfFame?.classes) ? meta.hallOfFame.classes.slice(0, 20) : [],
     settings: normalizeLeagueSettings(meta?.settings ?? {}),
@@ -5324,6 +5326,23 @@ async function handleSaveNow(payload, id) {
 }
 
 // ── Handler: RESET_LEAGUE ─────────────────────────────────────────────────────
+
+function normalizeChronicleEntriesForMeta(entries) {
+  if (!Array.isArray(entries)) return [];
+  return entries
+    .filter((entry) => entry && typeof entry === 'object')
+    .map((entry) => ({
+      ...entry,
+      meta: entry.meta && typeof entry.meta === 'object' ? { ...entry.meta } : entry.meta,
+    }))
+    .slice(-340);
+}
+
+async function handleUpdateFranchiseChronicle({ entries }, id) {
+  cache.setMeta({ franchiseChronicle: normalizeChronicleEntriesForMeta(entries) });
+  await flushDirty();
+  post(toUI.STATE_UPDATE, buildViewState(), id);
+}
 
 async function handleResetLeague(payload, id) {
   _saveIsExplicitlyLoaded = false;
@@ -10286,6 +10305,7 @@ async function handleMessage(event) {
       case toWorker.SAVE_SLOT:          return await handleSaveSlot(payload, id);
       case toWorker.DELETE_SLOT:        return await handleDeleteSlot(payload, id);
       case toWorker.RESET_LEAGUE:       return await handleResetLeague(payload, id);
+      case toWorker.UPDATE_FRANCHISE_CHRONICLE: return await handleUpdateFranchiseChronicle(payload, id);
       case toWorker.EXPORT_SAVE:        return await handleExportSave(payload, id);
       case toWorker.IMPORT_SAVE:        return await handleImportSave(payload, id);
       case toWorker.EXPORT_LEAGUE_CONFIG: return await handleExportLeagueConfig(payload, id);


### PR DESCRIPTION
## Summary
- Wire typed Franchise Chronicle logging into completed trade, contract, and user draft-pick flows with deterministic IDs and duplicate prevention.
- Add a small worker-backed chronicle persistence action so additive timeline entries are saved on the existing league meta without changing IndexedDB schema/version.
- Persist synced game/badge chronicle entries from the Story tab, add expanded game metadata rows, use configured season length for season reviews, and keep dev-only unknown type warnings.

## Real-action logging
- Trades: accepted trade-builder/counter offers and accepted incoming trade offers.
- Contracts: accepted re-signing center extensions, extension modal signings, and franchise tags.
- Draft: completed user draft picks after the worker confirms the pick.
- Milestones: badge unlocks are logged once with stable `milestone-{badgeId}` IDs.

## Deferred
- Direct free-agent signing is still deferred because the current UI path uses a fire-and-forget `signPlayer` send with no completed-action response.
- Injury simulation logging is deferred because there is no simple completed UI-layer injury event path; wiring it would touch simulation/injury internals.

## Validation
- `npm.cmd run test:unit` passed: 193 files, 914 tests.
- `npm.cmd run build` passed; expected chunk-size warning only.
- `npm.cmd run test:soak` passed: 6 files, 53 tests.
- `npx.cmd playwright test tests/e2e/fresh_franchise_first_week_smoke.spec.js` passed: 1 test.