### PR TITLE
[codex] Log confirmed free agency signings

### DIFF
--- a/src/ui/components/FreeAgencyPanel.jsx
+++ b/src/ui/components/FreeAgencyPanel.jsx
@@ -17,6 +17,7 @@
  */
 
 import React, { useState, useEffect, useMemo, useCallback } from "react";
+import { logFreeAgentSigningOutcome, persistFranchiseChronicle } from "../utils/franchiseChronicle.js";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -280,6 +281,7 @@ export default function FreeAgencyPanel({ league, actions }) {
   const [signing, setSigning] = useState(null); // playerId being signed
   const [signedIds, setSignedIds] = useState(new Set());
   const [msgId, setMsgId] = useState(null);
+  const [signError, setSignError] = useState("");
 
   const fetchFA = useCallback(async () => {
     if (!actions?.getFreeAgents) return;
@@ -333,11 +335,20 @@ export default function FreeAgencyPanel({ league, actions }) {
 
   const handleSign = async (player, contract) => {
     setSigning(null);
-    // Optimistic update
-    setSignedIds((prev) => new Set([...prev, player.id]));
-    actions.signPlayer(player.id, teamId, contract);
-    setMsgId(player.id);
-    setTimeout(() => setMsgId(null), 2500);
+    setSignError("");
+    try {
+      const response = await actions.signPlayer(player.id, teamId, contract);
+      const signingPayload = response?.payload?.freeAgentSigning;
+      if (signingPayload) {
+        logFreeAgentSigningOutcome(league, signingPayload);
+        await persistFranchiseChronicle(actions, league);
+      }
+      setSignedIds((prev) => new Set([...prev, player.id]));
+      setMsgId(player.id);
+      setTimeout(() => setMsgId(null), 2500);
+    } catch (err) {
+      setSignError(err?.message ?? "Signing failed.");
+    }
   };
 
   return (
@@ -429,6 +440,20 @@ export default function FreeAgencyPanel({ league, actions }) {
           />
         </div>
       </div>
+
+      {signError ? (
+        <div
+          className="card"
+          role="alert"
+          style={{
+            marginBottom: "var(--space-4)",
+            padding: "var(--space-3) var(--space-4)",
+            color: "var(--danger)",
+          }}
+        >
+          {signError}
+        </div>
+      ) : null}
 
       {/* Filters */}
       <div

--- a/src/ui/components/FreeAgencyPanel.test.jsx
+++ b/src/ui/components/FreeAgencyPanel.test.jsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import FreeAgencyPanel from './FreeAgencyPanel.jsx';
+
+function buildLeague() {
+  return {
+    year: 2026,
+    week: 5,
+    userTeamId: 1,
+    franchiseChronicle: [],
+    teams: [{
+      id: 1,
+      name: 'Pittsburgh',
+      abbr: 'PIT',
+      capRoom: 35,
+      capUsed: 210,
+      capTotal: 255,
+    }],
+  };
+}
+
+function buildActions(overrides = {}) {
+  return {
+    getFreeAgents: vi.fn().mockResolvedValue({
+      payload: {
+        freeAgents: [{ id: 44, name: 'Max Lane', pos: 'WR', ovr: 78, age: 26, teamId: null, contract: { baseAnnual: 6.5 } }],
+      },
+    }),
+    signPlayer: vi.fn().mockResolvedValue({
+      payload: {
+        freeAgentSigning: {
+          playerId: 44,
+          playerName: 'Max Lane',
+          pos: 'WR',
+          ovr: 78,
+          teamId: 1,
+          teamLabel: 'PIT',
+          years: 2,
+          totalValue: 13,
+          aav: 6.5,
+          season: 2026,
+          week: 5,
+        },
+      },
+    }),
+    updateFranchiseChronicle: vi.fn().mockResolvedValue({}),
+    ...overrides,
+  };
+}
+
+describe('FreeAgencyPanel direct signing chronicle logging', () => {
+  it('logs and persists a confirmed direct free-agent signing', async () => {
+    const league = buildLeague();
+    const actions = buildActions();
+
+    render(<FreeAgencyPanel league={league} actions={actions} />);
+
+    expect(await screen.findByText('Max Lane')).toBeTruthy();
+    fireEvent.click(screen.getByText('Sign'));
+    fireEvent.click(screen.getByText('Confirm'));
+
+    await waitFor(() => expect(actions.signPlayer).toHaveBeenCalledWith(44, 1, expect.objectContaining({ yearsTotal: 2 })));
+    await waitFor(() => expect(actions.updateFranchiseChronicle).toHaveBeenCalledTimes(1));
+    expect(league.franchiseChronicle).toHaveLength(1);
+    expect(league.franchiseChronicle[0]).toMatchObject({
+      id: 'free-agent-signing-2026-wk5-1-44',
+      type: 'contract',
+      meta: {
+        source: 'free_agent_signing',
+        player: { name: 'Max Lane', pos: 'WR', ovr: 78 },
+        totalValue: 13,
+        aav: 6.5,
+      },
+    });
+  });
+
+  it('does not log failed direct free-agent signings', async () => {
+    const league = buildLeague();
+    const actions = buildActions({
+      signPlayer: vi.fn().mockRejectedValue(new Error('Player not found')),
+    });
+
+    render(<FreeAgencyPanel league={league} actions={actions} />);
+
+    expect(await screen.findByText('Max Lane')).toBeTruthy();
+    fireEvent.click(screen.getByText('Sign'));
+    fireEvent.click(screen.getByText('Confirm'));
+
+    expect((await screen.findByRole('alert')).textContent).toContain('Player not found');
+    expect(actions.updateFranchiseChronicle).not.toHaveBeenCalled();
+    expect(league.franchiseChronicle).toEqual([]);
+  });
+});

--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -95,7 +95,7 @@ export function workerReducer(state, action) {
     case 'FULL_STATE':
       return { ...state, busy: false, simulating: false, batchSim: null, league: action.payload, lastWorkerMessageType: action.messageType ?? state.lastWorkerMessageType };
     case 'STATE_UPDATE':
-      // Also clear busy: send()-based actions (signPlayer, releasePlayer, setUserTeam)
+      // Also clear busy: send()-based actions (releasePlayer, setUserTeam)
       // respond with STATE_UPDATE and have no other mechanism to clear the flag.
       return {
         ...state,
@@ -593,7 +593,7 @@ export function useWorker() {
 
     /** Sign a free agent. */
     signPlayer: (playerId, teamId, contract) =>
-      send(toWorker.SIGN_PLAYER, { playerId, teamId, contract }),
+      request(toWorker.SIGN_PLAYER, { playerId, teamId, contract }),
 
     /** Submit an offer to a free agent. */
     submitOffer: (playerId, teamId, contract) =>

--- a/src/ui/utils/franchiseChronicle.js
+++ b/src/ui/utils/franchiseChronicle.js
@@ -551,6 +551,47 @@ export function logCompletedContractAction(league, payload = {}) {
   });
 }
 
+export function logFreeAgentSigningOutcome(league, payload = {}) {
+  const season = safeNum(payload?.season, safeNum(league?.year, safeNum(league?.seasonId, 0)));
+  const week = safeNum(payload?.week, safeNum(league?.week, 1));
+  const player = normalizePlayerMeta(payload?.player ?? {
+    id: payload?.playerId,
+    name: payload?.playerName,
+    pos: payload?.pos,
+    ovr: payload?.ovr,
+  });
+  const teamId = payload?.teamId ?? league?.userTeamId;
+  const years = payload?.years ?? payload?.contract?.yearsTotal ?? payload?.contract?.years ?? null;
+  const aav = payload?.aav ?? payload?.annualValue ?? payload?.contract?.baseAnnual ?? payload?.contract?.salary ?? null;
+  const totalValue = payload?.totalValue ?? (years != null && aav != null
+    ? Math.round((Number(aav) * Number(years) + safeNum(payload?.contract?.signingBonus, 0)) * 10) / 10
+    : null);
+  const id = payload?.id ?? `free-agent-signing-${season}-wk${week}-${teamId}-${player?.id ?? payload?.playerId ?? slugify(player?.name, 'player')}`;
+  const summary = [
+    years ? `${years} years` : null,
+    totalValue != null ? `$${totalValue}M total` : null,
+    aav != null ? `$${Number(aav).toFixed(1)}M AAV` : null,
+  ].filter(Boolean).join(' - ') || 'Free-agent signing completed.';
+
+  return logContractOutcome(league, {
+    id,
+    season,
+    week,
+    player,
+    years,
+    totalValue,
+    aav,
+    headline: payload?.headline ?? (player?.name ? `${player.name} signs in free agency` : 'Free agent signed'),
+    summary: payload?.summary ?? summary,
+    meta: {
+      ...(payload?.meta ?? {}),
+      source: 'free_agent_signing',
+      teamId,
+      team: payload?.teamLabel ?? null,
+    },
+  });
+}
+
 export function logDraftOutcome(league, payload = {}) {
   const player = normalizePlayerMeta(payload?.player ?? payload?.playerName);
   const round = payload?.round ?? payload?.draftRound ?? payload?.pick?.round ?? null;

--- a/src/ui/utils/franchiseChronicle.test.js
+++ b/src/ui/utils/franchiseChronicle.test.js
@@ -6,6 +6,7 @@ import {
   logCompletedTradeAction,
   logContractOutcome,
   logDraftOutcome,
+  logFreeAgentSigningOutcome,
   logInjuryEvent,
   logMilestoneEvent,
   logTradeOutcome,
@@ -244,6 +245,34 @@ describe('typed chronicle events', () => {
     expect(second.id).toBe(first.id);
     expect(first.meta.totalValue).toBe(52);
     expect(first.meta.aav).toBe(12);
+    expect(league.franchiseChronicle).toHaveLength(1);
+  });
+
+  it('logs direct free-agent signings as contract events without duplicates', () => {
+    const league = buildLeague({ franchiseChronicle: [] });
+    const payload = {
+      playerId: 44,
+      playerName: 'Max Lane',
+      pos: 'WR',
+      ovr: 78,
+      teamId: 1,
+      teamLabel: 'PIT',
+      years: 2,
+      totalValue: 13,
+      aav: 6.5,
+      season: 2026,
+      week: 3,
+    };
+    const first = logFreeAgentSigningOutcome(league, payload);
+    const second = logFreeAgentSigningOutcome(league, payload);
+
+    expect(first.type).toBe('contract');
+    expect(first.id).toBe('free-agent-signing-2026-wk3-1-44');
+    expect(second.id).toBe(first.id);
+    expect(first.meta.source).toBe('free_agent_signing');
+    expect(first.meta.player).toMatchObject({ id: 44, name: 'Max Lane', pos: 'WR', ovr: 78 });
+    expect(first.meta.totalValue).toBe(13);
+    expect(first.meta.aav).toBe(6.5);
     expect(league.franchiseChronicle).toHaveLength(1);
   });
 

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -5436,8 +5436,30 @@ async function handleSignPlayer({ playerId, teamId, contract }, id) {
   });
   await NewsEngine.logTransaction('SIGN', { teamId: resolvedTeamId, ...txDetails });
 
+  const signedPlayer = cache.getPlayer(player.id) ?? player;
+  const years = Number(contract?.yearsTotal ?? contract?.years ?? 0) || null;
+  const aav = Number(contract?.baseAnnual ?? contract?.salary ?? 0) || null;
+  const signingBonus = Number(contract?.signingBonus ?? 0) || 0;
+  const totalValue = years != null && aav != null
+    ? Math.round((aav * years + signingBonus) * 10) / 10
+    : null;
+  const playerName = signedPlayer.name ?? [signedPlayer.firstName, signedPlayer.lastName].filter(Boolean).join(' ');
+  const completedSigning = {
+    playerId: signedPlayer.id,
+    playerName: playerName || null,
+    pos: signedPlayer.pos ?? null,
+    ovr: signedPlayer.ovr ?? null,
+    teamId: resolvedTeamId,
+    teamLabel: team?.abbr ?? team?.name ?? null,
+    years,
+    totalValue,
+    aav,
+    season: meta.year ?? meta.currentSeasonId ?? null,
+    week: meta.currentWeek ?? 1,
+  };
+
   await flushDirty();
-  post(toUI.STATE_UPDATE, { roster: buildRosterView(resolvedTeamId), ...buildViewState() }, id);
+  post(toUI.STATE_UPDATE, { roster: buildRosterView(resolvedTeamId), ...buildViewState(), freeAgentSigning: completedSigning }, id);
 }
 
 // ── Handler: SUBMIT_OFFER ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Convert direct free-agent signing from fire-and-forget `SIGN_PLAYER` send to a confirmed request/response flow.
- Return a compact `freeAgentSigning` completion payload after the worker has actually completed the signing.
- Log successful direct signings into the Franchise Chronicle as contract events with deterministic `free-agent-signing-{season}-wk{week}-{teamId}-{playerId}` IDs.
- Preserve failure behavior: invalid/failed signings show an error and do not create chronicle history.

## Flow
`FreeAgencyPanel` confirm -> `actions.signPlayer(...)` -> worker `handleSignPlayer` completes player/team/cap/transaction/news updates -> `STATE_UPDATE.freeAgentSigning` -> UI calls `logFreeAgentSigningOutcome(...)` -> existing chronicle persistence path saves the entry.

## Validation
- `npm.cmd run test:unit` passed: 194 files, 917 tests.
- `npm.cmd run build` passed; expected chunk-size warning only.
- `npm.cmd run test:soak` passed: 6 files, 53 tests.
- `npx.cmd playwright test tests/e2e/daily_regression.spec.js` passed: 5 tests.