### PR TITLE
Add transaction activity log view model

### DIFF
--- a/src/ui/components/LeagueActivityLog.jsx
+++ b/src/ui/components/LeagueActivityLog.jsx
@@ -1,17 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { buildShowingLabel, rowMatchesSearch, stableSortRows } from "../utils/dataBrowser.js";
-
-const TYPE_FILTERS = [
-  { value: "all", label: "All types" },
-  { value: "trade", label: "Trades" },
-  { value: "signing", label: "Signings" },
-  { value: "release", label: "Releases" },
-  { value: "draft", label: "Draft" },
-  { value: "retirement", label: "Retirements" },
-  { value: "extension", label: "Extensions" },
-];
+import { stableSortRows } from "../utils/dataBrowser.js";
+import { ACTIVITY_LOG_FILTERS, buildActivityLogViewModel } from "../utils/activityLogViewModel.js";
 
 const SORT_OPTIONS = [
   { value: "date", label: "Date / week" },
@@ -21,21 +12,22 @@ const SORT_OPTIONS = [
 ];
 
 function transactionStamp(tx) {
-  const seasonNumber = Number(String(tx?.seasonId ?? "").replace(/[^0-9]/g, "")) || Number(tx?.season ?? 0) || 0;
+  if (Number.isFinite(Number(tx?.sortDate))) return Number(tx.sortDate);
+  const seasonNumber = Number(String(tx?.seasonId ?? "").replace(/[^0-9]/g, "")) || Number(tx?.season ?? 0) || Number(tx?.year ?? 0) || 0;
   return seasonNumber * 1000 + Number(tx?.week ?? 0);
 }
 
 function sortValue(tx, key) {
-  if (key === "type") return tx?.typeLabel ?? tx?.type ?? "";
+  if (key === "type") return tx?.label ?? tx?.typeLabel ?? tx?.type ?? "";
   if (key === "player") return tx?.playerName ?? tx?.headline ?? "";
-  if (key === "team") return tx?.teamAbbr ?? tx?.fromTeamAbbr ?? tx?.toTeamAbbr ?? "";
+  if (key === "team") return tx?.teamAbbr ?? tx?.fromTeamAbbr ?? tx?.toTeamAbbr ?? tx?.team?.abbr ?? "";
   return transactionStamp(tx);
 }
 
-function matchesTeam(tx, teamId) {
-  if (teamId === "all") return true;
-  const selected = Number(teamId);
-  return [tx?.teamId, tx?.fromTeamId, tx?.toTeamId].some((value) => Number(value) === selected);
+function buildActivityShowingLabel(visible, total) {
+  const safeVisible = Number.isFinite(Number(visible)) ? Number(visible) : 0;
+  const safeTotal = Number.isFinite(Number(total)) ? Number(total) : 0;
+  return `Showing ${safeVisible} of ${safeTotal} ${safeTotal === 1 ? "activity" : "activities"}`;
 }
 
 /**
@@ -73,7 +65,7 @@ export default function LeagueActivityLog({ league, actions, onPlayerSelect, onT
     if (league?.seasonId != null) {
       map.set(String(league.seasonId), {
         id: String(league.seasonId),
-        label: `Current (${league?.year ?? "—"})`,
+        label: `Current (${league?.year ?? "-"})`,
       });
     }
     for (const season of archiveSeasons) {
@@ -81,7 +73,7 @@ export default function LeagueActivityLog({ league, actions, onPlayerSelect, onT
       if (!id || map.has(id)) continue;
       map.set(id, {
         id,
-        label: `${season?.year ?? id}${season?.champion?.abbr ? ` · ${season.champion.abbr}` : ""}`,
+        label: `${season?.year ?? id}${season?.champion?.abbr ? ` - ${season.champion.abbr}` : ""}`,
       });
     }
     return [...map.values()];
@@ -115,25 +107,19 @@ export default function LeagueActivityLog({ league, actions, onPlayerSelect, onT
     loadTransactions();
   }, [loadTransactions]);
 
-  const displayRows = useMemo(() => {
-    const filtered = (rows ?? []).filter((tx) => {
-      if (type !== "all" && tx?.type !== type && tx?.typeLabel !== type) return false;
-      if (!matchesTeam(tx, teamId)) return false;
-      return rowMatchesSearch(tx, search, [
-        "playerName",
-        "teamAbbr",
-        "fromTeamAbbr",
-        "toTeamAbbr",
-        "type",
-        "typeLabel",
-        "headline",
-        "detail",
-        "seasonId",
-        "week",
-      ]);
-    });
-    return stableSortRows(filtered, (tx) => sortValue(tx, sort.key), sort.dir, (tx) => Number(tx?.id ?? 0));
-  }, [rows, search, sort.dir, sort.key, teamId, type]);
+  const activityModel = useMemo(() => buildActivityLogViewModel({
+    league,
+    transactions: rows,
+  }, {
+    seasonId,
+    teamId,
+    type,
+    search,
+  }), [league, rows, search, seasonId, teamId, type]);
+
+  const displayRows = useMemo(() => (
+    stableSortRows(activityModel.rows, (tx) => sortValue(tx, sort.key), sort.dir, (tx) => String(tx?.id ?? ""))
+  ), [activityModel.rows, sort.dir, sort.key]);
 
   const filtersActive = seasonId !== "all" || teamId !== "all" || type !== "all" || Boolean(search.trim()) || sort.key !== "date" || sort.dir !== "desc";
 
@@ -184,7 +170,7 @@ export default function LeagueActivityLog({ league, actions, onPlayerSelect, onT
             onChange={(e) => setType(e.target.value)}
             aria-label="Type"
           >
-            {TYPE_FILTERS.map((option) => (
+            {ACTIVITY_LOG_FILTERS.map((option) => (
               <option key={option.value} value={option.value}>{option.label}</option>
             ))}
           </select>
@@ -235,15 +221,15 @@ export default function LeagueActivityLog({ league, actions, onPlayerSelect, onT
       </div>
 
       <div className="flex items-center justify-between text-xs text-[color:var(--text-muted)]" data-testid="league-activity-count">
-        <span data-testid="league-activity-showing">{buildShowingLabel(displayRows.length, rows.length, "transaction")}</span>
-        <span>Sort: {SORT_OPTIONS.find((option) => option.value === sort.key)?.label ?? sort.key} {sort.dir === "asc" ? "↑" : "↓"}</span>
+        <span data-testid="league-activity-showing">{buildActivityShowingLabel(displayRows.length, activityModel.counts.total)}</span>
+        <span>Sort: {SORT_OPTIONS.find((option) => option.value === sort.key)?.label ?? sort.key} {sort.dir === "asc" ? "up" : "down"}</span>
       </div>
 
       {loading ? (
-        <div className="py-8 text-center text-sm text-[color:var(--text-muted)]">Loading activity…</div>
+        <div className="py-8 text-center text-sm text-[color:var(--text-muted)]">Loading activity...</div>
       ) : !displayRows.length ? (
         <div className="rounded-lg border border-[color:var(--hairline)] bg-[color:var(--surface-strong)]/30 px-4 py-6 text-center text-sm text-[color:var(--text-muted)]">
-          {filtersActive ? "No transactions match these filters." : "Transactions will appear as your league signs, drafts, trades, releases, and retires players."}
+          {filtersActive ? "No activity matches these filters." : "Activity will appear as your league signs, drafts, trades, releases, and retires players."}
         </div>
       ) : (
         <ScrollArea className="h-[min(520px,65vh)] rounded-lg border border-[color:var(--hairline)]">
@@ -252,16 +238,16 @@ export default function LeagueActivityLog({ league, actions, onPlayerSelect, onT
               <li key={`${tx.id ?? idx}-${idx}`} className="px-3 py-3 text-sm" data-testid="league-activity-row">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">
-                    {tx.typeLabel ?? tx.type ?? "—"}
+                    {tx.label ?? tx.typeLabel ?? tx.type ?? "Activity"}
                   </Badge>
                   <span className="text-[11px] text-[color:var(--text-muted)]">
                     {tx.dateLabel ?? (tx.week != null ? `Week ${tx.week}` : "")}
-                    {tx.teamAbbr ? ` · ${tx.teamAbbr}` : ""}
+                    {tx.teamAbbr ? ` - ${tx.teamAbbr}` : ""}
                   </span>
                 </div>
-                <div className="mt-1 font-semibold text-[color:var(--text)]">{tx.headline ?? tx.typeLabel ?? "League activity"}</div>
+                <div className="mt-1 font-semibold text-[color:var(--text)]">{tx.headline ?? tx.summary ?? tx.label ?? "League activity"}</div>
                 {tx.detail ? <div className="mt-0.5 text-xs text-[color:var(--text-muted)]">{tx.detail}</div> : null}
-                <div className="mt-2 flex flex-wrap gap-2">
+                <div className="mt-2 flex flex-wrap items-center gap-2">
                   {tx.playerId != null ? (
                     <button type="button" className="text-xs font-semibold text-[color:var(--accent)]" onClick={() => onPlayerSelect?.(tx.playerId)}>
                       {tx.playerName ?? "Player profile"}
@@ -272,6 +258,9 @@ export default function LeagueActivityLog({ league, actions, onPlayerSelect, onT
                       {tx.teamAbbr ?? `Team ${tx.teamId}`}
                     </button>
                   ) : null}
+                  <span className="rounded-full border border-[color:var(--hairline)] px-2 py-0.5 text-[10px] uppercase tracking-wide text-[color:var(--text-muted)]">
+                    {tx.source}
+                  </span>
                 </div>
               </li>
             ))}

--- a/src/ui/components/__tests__/LeagueActivityLog.test.jsx
+++ b/src/ui/components/__tests__/LeagueActivityLog.test.jsx
@@ -6,9 +6,18 @@ import LeagueActivityLog from '../LeagueActivityLog.jsx';
 
 const baseTransactions = [
   { id: 1, type: 'signing', typeLabel: 'Signing', seasonId: 's2030', week: 2, teamId: 1, teamAbbr: 'ALP', playerId: 11, playerName: 'Avery Fields', headline: 'ALP signed Avery Fields' },
-  { id: 2, type: 'trade', typeLabel: 'Trade', seasonId: 's2030', week: 5, teamId: 2, teamAbbr: 'BRV', headline: 'ALP ↔ BRV completed a trade package' },
+  { id: 2, type: 'trade', typeLabel: 'Trade', seasonId: 's2030', week: 5, teamId: 2, teamAbbr: 'BRV', headline: 'ALP and BRV completed a trade package' },
   { id: 3, type: 'release', typeLabel: 'Release', seasonId: 's2031', week: 1, teamId: 1, teamAbbr: 'ALP', playerId: 12, playerName: 'Other Player', headline: 'ALP released Other Player' },
 ];
+
+const baseLeague = {
+  teams: [{ id: 1, abbr: 'ALP' }, { id: 2, abbr: 'BRV' }],
+  userTeamId: 1,
+  seasonId: 's2031',
+  year: 2031,
+  franchiseChronicle: [],
+  newsItems: [],
+};
 
 function makeActions(transactions = baseTransactions) {
   return {
@@ -17,10 +26,10 @@ function makeActions(transactions = baseTransactions) {
   };
 }
 
-function renderActivity(actions = makeActions()) {
+function renderActivity(actions = makeActions(), league = baseLeague) {
   render(
     <LeagueActivityLog
-      league={{ teams: [{ id: 1, abbr: 'ALP' }, { id: 2, abbr: 'BRV' }], userTeamId: 1, seasonId: 's2031', year: 2031 }}
+      league={league}
       actions={actions}
       onPlayerSelect={vi.fn()}
       onTeamSelect={vi.fn()}
@@ -31,20 +40,20 @@ function renderActivity(actions = makeActions()) {
 describe('LeagueActivityLog', () => {
   afterEach(() => cleanup());
 
-  it('searches, filters, sorts, counts, and resets transaction rows client-side', async () => {
+  it('searches, filters, sorts, counts, and resets activity rows client-side', async () => {
     renderActivity();
 
-    await waitFor(() => expect(screen.getByTestId('league-activity-count').textContent).toMatch(/Showing 3 of 3 transactions/));
+    await waitFor(() => expect(screen.getByTestId('league-activity-count').textContent).toMatch(/Showing 3 of 3 activities/));
 
     fireEvent.change(screen.getByLabelText(/^Search$/i), { target: { value: 'Avery' } });
-    expect(screen.getByTestId('league-activity-count').textContent).toMatch(/Showing 1 of 3 transactions/);
+    expect(screen.getByTestId('league-activity-count').textContent).toMatch(/Showing 1 of 3 activities/);
     expect(screen.getAllByTestId('league-activity-row')[0].textContent).toMatch(/Avery Fields/);
 
     fireEvent.click(screen.getByRole('button', { name: /Reset filters/i }));
-    await waitFor(() => expect(screen.getByTestId('league-activity-count').textContent).toMatch(/Showing 3 of 3 transactions/));
+    await waitFor(() => expect(screen.getByTestId('league-activity-count').textContent).toMatch(/Showing 3 of 3 activities/));
 
     fireEvent.change(screen.getByLabelText(/^Type$/i), { target: { value: 'trade' } });
-    expect(screen.getByTestId('league-activity-count').textContent).toMatch(/Showing 1 of 3 transactions/);
+    expect(screen.getByTestId('league-activity-count').textContent).toMatch(/Showing 1 of 3 activities/);
     expect(screen.getAllByTestId('league-activity-row')[0].textContent).toMatch(/Trade/);
   });
 
@@ -61,16 +70,34 @@ describe('LeagueActivityLog', () => {
     });
   });
 
-  it('shows a safe empty state when no transactions are tracked', async () => {
+  it('shows a safe empty state when no activity is tracked', async () => {
     renderActivity(makeActions([]));
 
-    await waitFor(() => expect(screen.getByText(/Transactions will appear/i)).toBeTruthy());
-    expect(screen.getByTestId('league-activity-count').textContent).toMatch(/Showing 0 of 0 transactions/);
+    await waitFor(() => expect(screen.getByText(/Activity will appear/i)).toBeTruthy());
+    expect(screen.getByTestId('league-activity-count').textContent).toMatch(/Showing 0 of 0 activities/);
   });
 
   it('renders safely when actions.getTransactions is unavailable', async () => {
     renderActivity({ getAllSeasons: vi.fn().mockResolvedValue({ payload: { seasons: [] } }) });
 
-    await waitFor(() => expect(screen.getByText(/Transactions will appear/i)).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(/Activity will appear/i)).toBeTruthy());
+  });
+
+  it('renders chronicle activity when transaction rows are unavailable', async () => {
+    renderActivity(makeActions([]), {
+      ...baseLeague,
+      franchiseChronicle: [{
+        id: 'contract-2031-wk4-1-77',
+        type: 'contract',
+        season: 2031,
+        week: 4,
+        headline: 'Mason Vale signs with the franchise',
+        summary: '2 years - $18M total',
+        meta: { teamId: 1, player: { id: 77, name: 'Mason Vale' } },
+      }],
+    });
+
+    await waitFor(() => expect(screen.getByText(/Mason Vale signs with the franchise/i)).toBeTruthy());
+    expect(screen.getByTestId('league-activity-count').textContent).toMatch(/Showing 1 of 1 activity/);
   });
 });

--- a/src/ui/utils/activityLogViewModel.js
+++ b/src/ui/utils/activityLogViewModel.js
@@ -1,0 +1,327 @@
+const TYPE_LABELS = {
+  all: 'All',
+  trade: 'Trade',
+  signing: 'Signing',
+  contract: 'Contract',
+  draft: 'Draft',
+  release: 'Release',
+  retirement: 'Retirement',
+  other: 'Activity',
+};
+
+const ACTIVITY_TYPES = new Set(['trade', 'signing', 'contract', 'draft', 'release', 'retirement', 'other']);
+const CONTRACT_TYPES = new Set(['contract', 'extension', 'franchise_tag', 'restructure']);
+const SIGNING_SOURCES = new Set(['free_agent_signing', 'signing', 'completed_contract', 'free agency']);
+const TRANSACTION_TYPE_MAP = {
+  sign: 'signing',
+  signing: 'signing',
+  free_agent_signing: 'signing',
+  release: 'release',
+  released: 'release',
+  trade: 'trade',
+  traded: 'trade',
+  draft: 'draft',
+  draft_pick: 'draft',
+  drafted: 'draft',
+  retirement: 'retirement',
+  retire: 'retirement',
+  extend: 'contract',
+  extension: 'contract',
+  resigning: 'contract',
+  re_signing: 'contract',
+  re_sign: 'contract',
+  contract: 'contract',
+  restructure: 'contract',
+  franchise_tag: 'contract',
+};
+
+function text(value) {
+  if (value == null) return '';
+  return String(value).trim();
+}
+
+function num(value, fallback = null) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function slug(value, fallback = 'row') {
+  const s = text(value).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return s || fallback;
+}
+
+function teamForId(league, teamId) {
+  const id = num(teamId);
+  if (id == null) return null;
+  return (league?.teams ?? []).find((team) => Number(team?.id) === id) ?? null;
+}
+
+function normalizeType(value, meta = {}) {
+  const raw = text(value).toLowerCase().replaceAll('-', '_').replace(/\s+/g, '_');
+  if (raw === 'contract' && SIGNING_SOURCES.has(text(meta?.source).toLowerCase())) return 'signing';
+  if (CONTRACT_TYPES.has(raw)) return 'contract';
+  const mapped = TRANSACTION_TYPE_MAP[raw] ?? raw;
+  return ACTIVITY_TYPES.has(mapped) ? mapped : 'other';
+}
+
+function typeLabel(type) {
+  return TYPE_LABELS[type] ?? TYPE_LABELS.other;
+}
+
+function seasonFromId(seasonId) {
+  const n = Number(text(seasonId).replace(/[^0-9]/g, ''));
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+function resolveSeason(row, league) {
+  return row?.season ?? row?.year ?? row?.seasonYear ?? seasonFromId(row?.seasonId ?? row?.meta?.seasonId) ?? league?.year ?? null;
+}
+
+function resolveSeasonId(row, league) {
+  const explicit = row?.seasonId ?? row?.meta?.seasonId ?? null;
+  if (explicit != null) return explicit;
+  const season = resolveSeason(row, league);
+  if (season != null && league?.seasonId != null && Number(season) === Number(league?.year)) return league.seasonId;
+  return null;
+}
+
+function dateScore(row) {
+  const season = num(row?.season, 0) ?? 0;
+  const week = num(row?.week, 0) ?? 0;
+  const raw = num(row?.rawId ?? row?.meta?.rawId, 0) ?? 0;
+  return season * 100000 + week * 1000 + raw;
+}
+
+function dateLabel(row) {
+  if (row?.dateLabel) return row.dateLabel;
+  const season = row?.year ?? row?.season;
+  const week = row?.week;
+  if (season != null && week != null) return `Y${season} W${week}`;
+  if (week != null) return `Week ${week}`;
+  if (season != null) return `Season ${season}`;
+  return '';
+}
+
+function compactTeamIds(...ids) {
+  return [...new Set(ids.map((id) => num(id)).filter((id) => id != null))];
+}
+
+function playerFromMeta(meta = {}) {
+  const player = meta.player && typeof meta.player === 'object' ? meta.player : null;
+  if (player) return player;
+  return null;
+}
+
+function normalizeTransaction(row, league) {
+  if (!row || typeof row !== 'object') return null;
+  const type = normalizeType(row.type ?? row.legacyType ?? row.typeLabel, row.meta);
+  const teamId = row.teamId ?? row.fromTeamId ?? row.toTeamId ?? null;
+  const team = row.teamAbbr
+    ? { id: teamId, abbr: row.teamAbbr, name: row.teamName }
+    : teamForId(league, teamId);
+  const fromTeamId = row.fromTeamId ?? row.meta?.fromTeamId ?? null;
+  const toTeamId = row.toTeamId ?? row.meta?.toTeamId ?? row.meta?.toTeam ?? null;
+  const player = row.playerName || row.playerId != null
+    ? { id: row.playerId ?? null, name: row.playerName ?? null, pos: row.pos ?? row.playerPos ?? null }
+    : null;
+  const summary = row.headline ?? row.summary ?? row.detail ?? typeLabel(type);
+  const detail = row.detail ?? row.contractSummary ?? row.assetSummary ?? row.pickSummary ?? null;
+
+  const normalized = {
+    id: `transaction:${row.id ?? row.rawId ?? slug(row.headline ?? row.type)}`,
+    type,
+    label: typeLabel(type),
+    season: resolveSeason(row, league),
+    seasonId: resolveSeasonId(row, league),
+    year: row.year ?? null,
+    week: row.week ?? null,
+    team,
+    teamId,
+    teamAbbr: team?.abbr ?? row.teamAbbr ?? null,
+    fromTeamId,
+    fromTeamAbbr: row.fromTeamAbbr ?? null,
+    toTeamId,
+    toTeamAbbr: row.toTeamAbbr ?? null,
+    participantTeamIds: compactTeamIds(teamId, fromTeamId, toTeamId),
+    player,
+    playerId: row.playerId ?? null,
+    playerName: row.playerName ?? null,
+    summary,
+    headline: summary,
+    detail,
+    meta: { ...row },
+    source: 'transaction',
+    rawId: row.rawId ?? row.id ?? null,
+  };
+  normalized.typeLabel = normalized.label;
+  normalized.dateLabel = dateLabel(normalized);
+  normalized.sortDate = dateScore(normalized);
+  return normalized;
+}
+
+function normalizeChronicle(row, league) {
+  if (!row || typeof row !== 'object') return null;
+  const meta = row.meta && typeof row.meta === 'object' ? row.meta : {};
+  const type = normalizeType(row.type ?? meta.type, meta);
+  if (!['trade', 'signing', 'contract', 'draft', 'release'].includes(type)) return null;
+  const player = playerFromMeta(meta);
+  const teamId = meta.teamId ?? row.teamId ?? league?.userTeamId ?? null;
+  const team = meta.team ? { id: teamId, abbr: meta.team, name: meta.team } : teamForId(league, teamId);
+  const playerName = player?.name ?? null;
+  const summary = row.headline ?? row.summary ?? typeLabel(type);
+  const detail = row.summary ?? meta.description ?? meta.summary ?? null;
+
+  const normalized = {
+    id: `chronicle:${row.id ?? slug(row.headline ?? row.summary)}`,
+    type,
+    label: typeLabel(type),
+    season: resolveSeason(row, league),
+    seasonId: resolveSeasonId(row, league),
+    year: row.year ?? null,
+    week: row.week ?? null,
+    team,
+    teamId,
+    teamAbbr: team?.abbr ?? meta.team ?? null,
+    participantTeamIds: compactTeamIds(teamId, meta.partnerTeamId, meta.fromTeamId, meta.toTeamId),
+    player,
+    playerId: player?.id ?? null,
+    playerName,
+    summary,
+    headline: summary,
+    detail,
+    meta: { ...meta, chronicleId: row.id ?? null },
+    source: 'chronicle',
+    rawId: row.id ?? null,
+  };
+  normalized.typeLabel = normalized.label;
+  normalized.dateLabel = dateLabel(normalized);
+  normalized.sortDate = dateScore(normalized);
+  return normalized;
+}
+
+function normalizeNews(row, league) {
+  if (!row || typeof row !== 'object') return null;
+  const type = normalizeType(row.type ?? row.category ?? row.kind, row.meta);
+  if (!['trade', 'signing', 'contract', 'draft', 'release'].includes(type)) return null;
+  const teamId = row.teamId ?? row.meta?.teamId ?? null;
+  const team = teamForId(league, teamId);
+  const playerName = row.playerName ?? row.meta?.playerName ?? null;
+  const summary = row.headline ?? row.title ?? row.body ?? typeLabel(type);
+  const detail = row.body ?? row.summary ?? null;
+  const normalized = {
+    id: `news:${row.id ?? row.dedupeKey ?? slug(row.headline ?? row.body)}`,
+    type,
+    label: typeLabel(type),
+    season: resolveSeason(row, league),
+    seasonId: resolveSeasonId(row, league),
+    year: row.year ?? null,
+    week: row.week ?? league?.week ?? null,
+    team,
+    teamId,
+    teamAbbr: team?.abbr ?? row.teamAbbr ?? row.meta?.teamAbbr ?? null,
+    participantTeamIds: compactTeamIds(teamId),
+    player: playerName ? { id: row.playerId ?? row.meta?.playerId ?? null, name: playerName } : null,
+    playerId: row.playerId ?? row.meta?.playerId ?? null,
+    playerName,
+    summary,
+    headline: summary,
+    detail,
+    meta: { ...(row.meta ?? {}), newsId: row.id ?? null },
+    source: 'news',
+    rawId: row.id ?? row.dedupeKey ?? null,
+  };
+  normalized.typeLabel = normalized.label;
+  normalized.dateLabel = dateLabel(normalized);
+  normalized.sortDate = dateScore(normalized);
+  return normalized;
+}
+
+function dedupeKey(row) {
+  const player = row.playerId ?? slug(row.playerName);
+  const team = row.teamId ?? row.team?.abbr ?? '';
+  const summary = slug(row.summary, '');
+  if (row.playerId != null || row.playerName) {
+    return [row.type, row.season ?? '', row.seasonId ?? '', row.week ?? '', team, player].join('|');
+  }
+  return [row.type, row.season ?? '', row.seasonId ?? '', row.week ?? '', team, summary].join('|');
+}
+
+const SOURCE_PRIORITY = {
+  transaction: 0,
+  chronicle: 1,
+  news: 2,
+};
+
+export const ACTIVITY_LOG_FILTERS = [
+  { value: 'all', label: 'All' },
+  { value: 'trade', label: 'Trades' },
+  { value: 'signing', label: 'Signings' },
+  { value: 'contract', label: 'Contracts' },
+  { value: 'draft', label: 'Draft' },
+  { value: 'release', label: 'Releases' },
+];
+
+export function buildActivityLogRows({ league = {}, transactions = [], chronicleRows = null, newsRows = null } = {}) {
+  const rows = [
+    ...(Array.isArray(transactions) ? transactions.map((row) => normalizeTransaction(row, league)) : []),
+    ...(Array.isArray(chronicleRows ?? league?.franchiseChronicle) ? (chronicleRows ?? league.franchiseChronicle).map((row) => normalizeChronicle(row, league)) : []),
+    ...(Array.isArray(newsRows ?? league?.newsItems) ? (newsRows ?? league.newsItems).map((row) => normalizeNews(row, league)) : []),
+  ].filter(Boolean);
+
+  const byKey = new Map();
+  for (const row of rows) {
+    const key = dedupeKey(row);
+    const current = byKey.get(key);
+    if (!current || SOURCE_PRIORITY[row.source] < SOURCE_PRIORITY[current.source]) {
+      byKey.set(key, row);
+    }
+  }
+
+  return [...byKey.values()].sort((a, b) => {
+    const d = dateScore(b) - dateScore(a);
+    if (d !== 0) return d;
+    const source = SOURCE_PRIORITY[a.source] - SOURCE_PRIORITY[b.source];
+    if (source !== 0) return source;
+    return String(a.id).localeCompare(String(b.id));
+  });
+}
+
+export function filterActivityLogRows(rows = [], { type = 'all', teamId = 'all', seasonId = 'all', search = '' } = {}) {
+  const q = text(search).toLowerCase();
+  const selectedTeamId = teamId === 'all' ? null : num(teamId);
+  const selectedSeasonId = seasonId === 'all' ? null : text(seasonId);
+  return (Array.isArray(rows) ? rows : []).filter((row) => {
+    if (type !== 'all' && row.type !== type) return false;
+    if (selectedSeasonId && text(row.seasonId) !== selectedSeasonId && `s${row.season}` !== selectedSeasonId) return false;
+    if (selectedTeamId != null) {
+      const participantTeamIds = Array.isArray(row.participantTeamIds) ? row.participantTeamIds : [row.teamId];
+      if (!participantTeamIds.some((id) => Number(id) === selectedTeamId)) return false;
+    }
+    if (!q) return true;
+    const hay = [
+      row.label,
+      row.summary,
+      row.detail,
+      row.playerName,
+      row.player?.name,
+      row.team?.abbr,
+      row.team?.name,
+      row.source,
+    ].filter(Boolean).join(' ').toLowerCase();
+    return hay.includes(q);
+  });
+}
+
+export function buildActivityLogViewModel(input = {}, filters = {}) {
+  const rows = buildActivityLogRows(input);
+  const filteredRows = filterActivityLogRows(rows, filters);
+  return {
+    rows: filteredRows,
+    allRows: rows,
+    filters: ACTIVITY_LOG_FILTERS,
+    counts: {
+      total: rows.length,
+      shown: filteredRows.length,
+    },
+  };
+}

--- a/src/ui/utils/activityLogViewModel.test.js
+++ b/src/ui/utils/activityLogViewModel.test.js
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildActivityLogRows,
+  buildActivityLogViewModel,
+  filterActivityLogRows,
+} from './activityLogViewModel.js';
+
+const league = {
+  year: 2032,
+  week: 6,
+  userTeamId: 1,
+  seasonId: 's2032',
+  teams: [
+    { id: 1, abbr: 'ALP', name: 'Alphas' },
+    { id: 2, abbr: 'BRV', name: 'Braves' },
+  ],
+};
+
+describe('activityLogViewModel', () => {
+  it('normalizes chronicle rows into practical activity records', () => {
+    const rows = buildActivityLogRows({
+      league: {
+        ...league,
+        franchiseChronicle: [{
+          id: 'contract-2032-wk6-1-44',
+          type: 'contract',
+          season: 2032,
+          week: 6,
+          headline: 'Dana Moss signs with the franchise',
+          summary: '3 years - $36M total',
+          meta: {
+            teamId: 1,
+            player: { id: 44, name: 'Dana Moss', pos: 'QB' },
+            years: 3,
+            totalValue: 36,
+          },
+        }],
+      },
+      transactions: [],
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      source: 'chronicle',
+      type: 'contract',
+      label: 'Contract',
+      teamId: 1,
+      playerId: 44,
+      playerName: 'Dana Moss',
+      summary: 'Dana Moss signs with the franchise',
+    });
+  });
+
+  it('normalizes transaction rows and maps extensions into the contract filter', () => {
+    const rows = buildActivityLogRows({
+      league,
+      transactions: [{
+        id: 5,
+        type: 'extension',
+        seasonId: 's2032',
+        year: 2032,
+        week: 4,
+        teamId: 1,
+        teamAbbr: 'ALP',
+        playerId: 20,
+        playerName: 'Remy Holt',
+        headline: 'ALP extended Remy Holt',
+        detail: '4y - $52M',
+      }],
+      chronicleRows: [],
+      newsRows: [],
+    });
+
+    expect(rows[0]).toMatchObject({
+      source: 'transaction',
+      type: 'contract',
+      label: 'Contract',
+      teamAbbr: 'ALP',
+      playerName: 'Remy Holt',
+      headline: 'ALP extended Remy Holt',
+    });
+  });
+
+  it('normalizes transaction-like news rows when they exist', () => {
+    const rows = buildActivityLogRows({
+      league,
+      transactions: [],
+      chronicleRows: [],
+      newsRows: [{
+        id: 'news-trade-1',
+        type: 'trade',
+        season: 2032,
+        week: 3,
+        teamId: 2,
+        headline: 'BRV added a veteran corner',
+        body: 'Trade terms were filed with the league office.',
+      }],
+    });
+
+    expect(rows[0]).toMatchObject({
+      source: 'news',
+      type: 'trade',
+      teamId: 2,
+      headline: 'BRV added a veteran corner',
+    });
+  });
+
+  it('dedupes obvious transaction and chronicle overlap while preferring transaction rows', () => {
+    const rows = buildActivityLogRows({
+      league: {
+        ...league,
+        franchiseChronicle: [{
+          id: 'free-agent-signing-2032-wk6-1-44',
+          type: 'contract',
+          season: 2032,
+          week: 6,
+          headline: 'Dana Moss signs in free agency',
+          meta: {
+            source: 'free_agent_signing',
+            teamId: 1,
+            player: { id: 44, name: 'Dana Moss' },
+          },
+        }],
+      },
+      transactions: [{
+        id: 9,
+        type: 'signing',
+        season: 2032,
+        seasonId: 's2032',
+        week: 6,
+        teamId: 1,
+        teamAbbr: 'ALP',
+        playerId: 44,
+        playerName: 'Dana Moss',
+        headline: 'ALP signed Dana Moss',
+      }],
+      newsRows: [],
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      source: 'transaction',
+      type: 'signing',
+      headline: 'ALP signed Dana Moss',
+    });
+  });
+
+  it('filters by type, team participant, and search text', () => {
+    const rows = buildActivityLogRows({
+      league,
+      transactions: [
+        { id: 1, type: 'trade', season: 2032, week: 5, teamId: 1, fromTeamId: 1, toTeamId: 2, headline: 'Trade: ALP to BRV' },
+        { id: 2, type: 'draft', season: 2032, week: 1, teamId: 2, playerName: 'Kai Stone', headline: 'BRV drafted Kai Stone' },
+      ],
+      chronicleRows: [],
+      newsRows: [],
+    });
+
+    expect(filterActivityLogRows(rows, { type: 'trade', teamId: 2 })).toHaveLength(1);
+    expect(filterActivityLogRows(rows, { type: 'draft', search: 'kai' })).toHaveLength(1);
+    expect(filterActivityLogRows(rows, { type: 'signing' })).toHaveLength(0);
+  });
+
+  it('handles legacy sparse rows without throwing', () => {
+    expect(() => buildActivityLogViewModel({
+      league: { franchiseChronicle: [{ result: 'W', score: '21-17' }], newsItems: [{}] },
+      transactions: [null, { type: null }],
+    })).not.toThrow();
+
+    const model = buildActivityLogViewModel({
+      league: { franchiseChronicle: [{ result: 'W', score: '21-17' }], newsItems: [{}] },
+      transactions: [{ type: null }],
+    });
+    expect(model.rows[0]).toMatchObject({ type: 'other', source: 'transaction' });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a unified activity-log view model that normalizes transaction rows, typed franchise chronicle rows, and transaction-like news items into a compact front-office record shape.
- Updates the existing League Activity Log under Transactions to use that unified model with All/Trades/Signings/Contracts/Draft/Releases filters, team/search filters, source chips, and deterministic sorting.
- Adds regression coverage for normalization, sparse legacy rows, transaction/chronicle dedupe, filters, empty UI state, and chronicle-only activity rendering.

## Data sources
- Existing worker `getTransactions` response from the IndexedDB transactions store.
- Existing `league.franchiseChronicle` entries.
- Existing `league.newsItems` when they are already transaction-like.

## Safety
- No IndexedDB schema or DB version changes.
- No worker protocol changes.
- No simulation outcome changes.

## Validation
- `npm.cmd run test:unit` passed: 195 files, 924 tests.
- `npm.cmd run build` passed, with the existing Vite large chunk warning.
- `npx.cmd playwright test tests/e2e/fresh_franchise_first_week_smoke.spec.js` passed: 1 test.
- `npm.cmd run test:soak` not run because worker protocol, persistence, and simulation logic were not changed.