### PR TITLE
Add player career timeline

### DIFF
--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -35,8 +35,11 @@ import { buildPlayerRecordContext, mergePlayerProfileSeasonRows } from "../../co
 import { buildLegacyScoreReport, shouldShowLegacyProfileSection } from "../../core/legacyScore.js";
 import { buildPlayerDevelopmentModel } from "../../core/playerDevelopmentModel.js";
 import { buildProspectScoutingReport } from "../../core/scoutingModel.js";
+import { buildPlayerCareerTimeline } from "../utils/playerCareerTimeline.js";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+const CAREER_TIMELINE_LIMIT = 8;
 
 // ── Accolade badge config ─────────────────────────────────────────────────────
 
@@ -437,6 +440,8 @@ export default function PlayerProfile({
   const [seasonLogTeamFilter, setSeasonLogTeamFilter] = useState("all");
   const [seasonLogSortKey, setSeasonLogSortKey] = useState("season");
   const [seasonLogSortDirection, setSeasonLogSortDirection] = useState("desc");
+  const [careerTransactions, setCareerTransactions] = useState([]);
+  const [showAllCareerTimeline, setShowAllCareerTimeline] = useState(false);
   const requestKey = useMemo(() => buildRouteRequestKey("player", playerId), [playerId]);
   const cacheScopeKey = useMemo(() => buildLeagueCacheScopeKey(league), [league]);
   const fetchProfileData = React.useCallback(async () => {
@@ -527,50 +532,30 @@ export default function PlayerProfile({
     if (fetchedData) setData(fetchedData);
   }, [fetchedData]);
 
-  const [careerJourney, setCareerJourney] = useState([]);
   useEffect(() => {
     let cancelled = false;
     if (!actions?.getTransactions || playerId == null) {
-      setCareerJourney([]);
+      setCareerTransactions([]);
       return () => { cancelled = true; };
     }
-    const acc = data?.player?.accolades;
     actions
       .getTransactions({ playerId: Number(playerId), limit: 100 })
       .then((res) => {
         if (cancelled) return;
         const txs = res?.payload?.transactions ?? [];
-        const sorted = [...txs].sort((a, b) => {
-          const sa = String(b?.seasonId ?? "").localeCompare(String(a?.seasonId ?? ""));
-          if (sa !== 0) return sa;
-          const wa = Number(b?.week ?? 0) - Number(a?.week ?? 0);
-          if (wa !== 0) return wa;
-          return Number(b?.id ?? 0) - Number(a?.id ?? 0);
-        });
-        const hofExtras = (Array.isArray(acc) ? acc : [])
-          .filter((a) => a?.type === "HOF")
-          .map((a, i) => ({
-            id: `hof-${a.year ?? i}-${i}`,
-            typeLabel: "Hall of Fame",
-            headline: `Hall of Fame recognition${a.year != null ? ` (${a.year})` : ""}`,
-            detail: null,
-            seasonId: null,
-            week: null,
-          }));
-        const merged = [...sorted, ...hofExtras].sort((a, b) => {
-          const sa = String(b?.seasonId ?? "").localeCompare(String(a?.seasonId ?? ""));
-          if (sa !== 0) return sa;
-          return Number(b?.week ?? 0) - Number(a?.week ?? 0);
-        });
-        setCareerJourney(merged.slice(0, 12));
+        setCareerTransactions(Array.isArray(txs) ? txs : []);
       })
       .catch(() => {
-        if (!cancelled) setCareerJourney([]);
+        if (!cancelled) setCareerTransactions([]);
       });
     return () => {
       cancelled = true;
     };
-  }, [actions, playerId, data?.player?.accolades]);
+  }, [actions, playerId]);
+
+  useEffect(() => {
+    setShowAllCareerTimeline(false);
+  }, [playerId]);
 
   const fetchedPlayer = data?.player;
   const resolvedProfile = useMemo(() => resolvePlayerForProfile({ playerId, league, context: profileContext ?? {} }), [playerId, league, profileContext]);
@@ -659,6 +644,20 @@ export default function PlayerProfile({
     () => buildPlayerAwardHeaderBadges(mergedAwardTimeline),
     [mergedAwardTimeline],
   );
+  const careerTimelineModel = useMemo(
+    () => buildPlayerCareerTimeline({
+      player: effectivePlayer,
+      league,
+      transactions: careerTransactions,
+      awardRows: mergedAwardTimeline.rows,
+      recordRows: recordBookLines,
+      assumeTransactionsRelevant: true,
+    }),
+    [careerTransactions, effectivePlayer, league, mergedAwardTimeline.rows, recordBookLines],
+  );
+  const careerTimelineRows = showAllCareerTimeline
+    ? careerTimelineModel.rows
+    : careerTimelineModel.rows.slice(0, CAREER_TIMELINE_LIMIT);
   const summaryChips = getPlayerSummaryChips(player, ringCount, nonRing);
   const accoladesByYear = [...accolades].sort((a, b) => (a.year ?? 0) - (b.year ?? 0));
   const mergedProfileSeasonRows = useMemo(
@@ -1357,30 +1356,60 @@ export default function PlayerProfile({
               <EmptyState icon="📊" title="No tracked season stats yet" subtitle="Season stats will appear after this player records tracked stats." />
             )}
           </section>
-          {!loading && careerJourney.length > 0 && (
-            <section className="card-enter" data-testid="player-profile-career-journey">
-              <h3 style={sectionLabelStyle}>Career journey</h3>
-              <div style={{ display: "grid", gap: 8 }}>
-                {careerJourney.map((row, idx) => (
-                  <div
-                    key={row.id ?? idx}
-                    style={{
-                      border: "1px solid var(--hairline)",
-                      borderRadius: 8,
-                      padding: "8px 10px",
-                      fontSize: 13,
-                    }}
-                  >
-                    <div style={{ fontWeight: 700 }}>{row.headline ?? row.typeLabel ?? "Move"}</div>
-                    <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 2 }}>
-                      {row.typeLabel ?? row.type}
-                      {row.week != null ? ` · Week ${row.week}` : ""}
-                      {row.teamAbbr ? ` · ${row.teamAbbr}` : ""}
-                    </div>
-                    {row.detail ? <div style={{ fontSize: 12, color: "var(--text-muted)", marginTop: 4 }}>{row.detail}</div> : null}
-                  </div>
-                ))}
+          {!loading && playerView && (
+            <section className="card-enter" data-testid="player-profile-career-timeline">
+              <h3 style={sectionLabelStyle}>Career Timeline</h3>
+              <div
+                data-testid="player-profile-acquisition-summary"
+                style={{
+                  border: "1px solid var(--hairline)",
+                  borderRadius: "var(--radius-md)",
+                  padding: "10px",
+                  background: "var(--surface-strong)",
+                  marginBottom: 10,
+                }}
+              >
+                <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>How acquired</div>
+                <div style={{ fontSize: "var(--text-sm)", fontWeight: 800, marginTop: 2 }}>{careerTimelineModel.acquisition.summary}</div>
+                {careerTimelineModel.acquisition.detail ? (
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)", marginTop: 2 }}>{careerTimelineModel.acquisition.detail}</div>
+                ) : null}
               </div>
+              {careerTimelineRows.length > 0 ? (
+                <div style={{ display: "grid", gap: 8 }}>
+                  {careerTimelineRows.map((row, idx) => (
+                    <div
+                      key={row.id ?? idx}
+                      data-testid="player-profile-career-timeline-row"
+                      style={{
+                        border: "1px solid var(--hairline)",
+                        borderRadius: 8,
+                        padding: "8px 10px",
+                        fontSize: 13,
+                      }}
+                    >
+                      <div style={{ display: "flex", gap: 6, alignItems: "center", justifyContent: "space-between", flexWrap: "wrap" }}>
+                        <span className="status-chip muted">{row.label ?? row.type ?? "Event"}</span>
+                        <span style={{ fontSize: 11, color: "var(--text-muted)" }}>
+                          {row.season ? `Season ${row.season}` : ""}
+                          {row.week != null ? ` - Week ${row.week}` : ""}
+                          {row.teamAbbr ? ` - ${row.teamAbbr}` : ""}
+                        </span>
+                      </div>
+                      <div style={{ fontWeight: 700, marginTop: 4 }}>{row.summary ?? "Player event"}</div>
+                      {row.detail ? <div style={{ fontSize: 12, color: "var(--text-muted)", marginTop: 4 }}>{row.detail}</div> : null}
+                      {row.source ? <div style={{ fontSize: 10, color: "var(--text-subtle)", marginTop: 4, textTransform: "uppercase" }}>{row.source}</div> : null}
+                    </div>
+                  ))}
+                  {careerTimelineModel.rows.length > CAREER_TIMELINE_LIMIT ? (
+                    <Button size="sm" variant="outline" onClick={() => setShowAllCareerTimeline((value) => !value)}>
+                      {showAllCareerTimeline ? "Show less" : `Show all ${careerTimelineModel.rows.length}`}
+                    </Button>
+                  ) : null}
+                </div>
+              ) : (
+                <EmptyState title="No career timeline recorded yet." subtitle="Legacy players may not have transaction history in older saves." />
+              )}
             </section>
           )}
           {!loading && hasGmContext && (

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -32,6 +32,7 @@ const actions = {
   getAllSeasons: vi.fn(async () => ({ payload: { seasons: [] } })),
   getPlayerDraftContext: vi.fn(async () => ({ payload: { context: { known: false } } })),
   getRecords: vi.fn(async () => ({ payload: { recordBook: null } })),
+  getTransactions: vi.fn(async () => ({ payload: { transactions: [] } })),
 };
 
 describe('PlayerProfile', () => {
@@ -60,8 +61,38 @@ describe('PlayerProfile', () => {
     expect(screen.getByTestId('player-profile')).toBeTruthy();
     await waitFor(() => expect(screen.getByTestId('player-profile-summary').textContent).toContain('Avery Fields'));
     expect(screen.getByTestId('player-profile-season-stats').textContent).toContain('Season stats will appear after this player records tracked stats.');
+    expect(screen.getByTestId('player-profile-career-timeline').textContent).toContain('No career timeline recorded yet.');
     await waitFor(() => expect(screen.getByText('Contract Read')).toBeTruthy());
     expect(screen.getByText('Market tier')).toBeTruthy();
+  });
+
+  it('renders player career timeline and acquisition context from transaction rows', async () => {
+    const timelineActions = {
+      ...actions,
+      getTransactions: vi.fn(async () => ({
+        payload: {
+          transactions: [{
+            id: 8,
+            type: 'signing',
+            typeLabel: 'Signing',
+            season: 2031,
+            seasonId: 's2031',
+            week: 4,
+            teamId: 1,
+            teamAbbr: 'DAL',
+            playerId: 11,
+            playerName: 'Avery Fields',
+            headline: 'DAL signed Avery Fields in free agency',
+            detail: '2y - $24M',
+          }],
+        },
+      })),
+    };
+    render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={timelineActions} teams={league.teams} league={league} />);
+
+    await waitFor(() => expect(screen.getByTestId('player-profile-career-timeline').textContent).toContain('DAL signed Avery Fields in free agency'));
+    expect(screen.getByTestId('player-profile-acquisition-summary').textContent).toContain('Signed in free agency');
+    expect(screen.getAllByTestId('player-profile-career-timeline-row')[0].textContent).toContain('Signing');
   });
 
   it('shows career arc snapshot for active players', async () => {

--- a/src/ui/utils/playerCareerTimeline.js
+++ b/src/ui/utils/playerCareerTimeline.js
@@ -1,0 +1,311 @@
+import { buildActivityLogRows } from './activityLogViewModel.js';
+
+const TYPE_LABELS = {
+  draft: 'Draft',
+  trade: 'Trade',
+  signing: 'Signing',
+  contract: 'Contract',
+  tag: 'Tag',
+  release: 'Release',
+  award: 'Award',
+  record: 'Record',
+  event: 'Event',
+};
+
+const SOURCE_PRIORITY = {
+  chronicle: 0,
+  activity: 1,
+  transaction: 2,
+  news: 3,
+  award: 4,
+  record: 5,
+  player: 6,
+};
+
+function text(value) {
+  if (value == null) return '';
+  return String(value).trim();
+}
+
+function num(value, fallback = null) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function slug(value, fallback = 'row') {
+  const s = text(value).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  return s || fallback;
+}
+
+function sameId(a, b) {
+  return a != null && b != null && String(a) === String(b);
+}
+
+function teamForId(league, teamId) {
+  const id = num(teamId);
+  if (id == null) return null;
+  return (league?.teams ?? []).find((team) => Number(team?.id) === id) ?? null;
+}
+
+function teamLabel(team) {
+  return text(team?.abbr ?? team?.name);
+}
+
+function normalizeTimelineType(type, meta = {}) {
+  const raw = text(type).toLowerCase().replaceAll('-', '_').replace(/\s+/g, '_');
+  if (raw === 'franchise_tag' || text(meta?.source).toLowerCase() === 'franchise_tag') return 'tag';
+  if (raw === 'free_agent_signing' || text(meta?.source).toLowerCase() === 'free_agent_signing') return 'signing';
+  if (raw === 'extension' || raw === 'restructure' || raw === 'contract') return 'contract';
+  if (raw === 'draft_pick' || raw === 'drafted') return 'draft';
+  if (TYPE_LABELS[raw]) return raw;
+  return 'event';
+}
+
+function seasonScore(row) {
+  return (num(row?.season, 0) ?? 0) * 100000 + (num(row?.week, 0) ?? 0) * 1000 + (num(row?.sortDate, 0) ?? 0);
+}
+
+function playerNamesFromMeta(meta = {}) {
+  const out = [];
+  const addPlayer = (player) => {
+    if (!player) return;
+    if (typeof player === 'string') {
+      const name = text(player);
+      if (name) out.push({ name });
+      return;
+    }
+    const name = text(player.name ?? player.playerName);
+    const id = player.id ?? player.playerId ?? null;
+    if (name || id != null) out.push({ id, name });
+  };
+  addPlayer(meta.player);
+  for (const key of ['players', 'incomingPlayers', 'outgoingPlayers', 'acquiredPlayers', 'receivedPlayers', 'sentPlayers', 'tradedPlayers']) {
+    const list = Array.isArray(meta[key]) ? meta[key] : [];
+    list.forEach(addPlayer);
+  }
+  return out;
+}
+
+function rowInvolvesPlayer(row, player, { assumeTransactionRelevant = false } = {}) {
+  if (!row || !player) return false;
+  const playerId = player.id ?? player.playerId;
+  const playerName = text(player.name);
+  if (sameId(row.playerId, playerId)) return true;
+  if (playerName && text(row.playerName).toLowerCase() === playerName.toLowerCase()) return true;
+  const metaPlayers = playerNamesFromMeta(row.meta);
+  if (metaPlayers.some((p) => sameId(p.id, playerId))) return true;
+  if (playerName && metaPlayers.some((p) => text(p.name).toLowerCase() === playerName.toLowerCase())) return true;
+  if (assumeTransactionRelevant && row.source === 'transaction') return true;
+  return false;
+}
+
+function normalizeActivityRow(row) {
+  const type = normalizeTimelineType(row?.type, row?.meta);
+  return {
+    id: `activity:${row?.id ?? slug(row?.summary ?? row?.headline)}`,
+    type,
+    label: TYPE_LABELS[type] ?? TYPE_LABELS.event,
+    season: row?.season ?? row?.year ?? null,
+    week: row?.week ?? null,
+    team: row?.team ?? null,
+    teamId: row?.teamId ?? null,
+    teamAbbr: row?.teamAbbr ?? row?.team?.abbr ?? null,
+    summary: row?.summary ?? row?.headline ?? TYPE_LABELS[type] ?? 'Player event',
+    detail: row?.detail ?? null,
+    source: row?.source ?? 'activity',
+    meta: row?.meta ?? {},
+    sortDate: row?.sortDate ?? seasonScore(row),
+  };
+}
+
+function formatDraftSummary(player, team) {
+  const draft = player?.draft && typeof player.draft === 'object' ? player.draft : {};
+  const round = player?.draftRound ?? draft.round ?? null;
+  const pick = player?.draftPick ?? draft.pick ?? draft.overall ?? null;
+  const year = player?.draftYear ?? draft.year ?? draft.season ?? player?.year ?? null;
+  if (round == null && pick == null && year == null) return null;
+  const parts = [
+    year ? `${year}` : null,
+    round != null ? `Round ${round}` : null,
+    pick != null ? `Pick ${pick}` : null,
+  ].filter(Boolean);
+  return `Drafted${parts.length ? ` ${parts.join(' ')}` : ''}${team ? ` by ${team}` : ''}`;
+}
+
+function buildDraftRowFromPlayer(player, league) {
+  const draft = player?.draft && typeof player.draft === 'object' ? player.draft : {};
+  const teamId = player?.draftTeamId ?? draft.teamId ?? draft.team ?? null;
+  const team = teamForId(league, teamId) ?? null;
+  const teamText = teamLabel(team);
+  const summary = formatDraftSummary(player, teamText);
+  if (!summary) return null;
+  const season = player?.draftYear ?? draft.year ?? draft.season ?? player?.year ?? null;
+  return {
+    id: `player-draft-${player?.id ?? slug(player?.name)}-${season ?? 'unknown'}`,
+    type: 'draft',
+    label: TYPE_LABELS.draft,
+    season,
+    week: null,
+    team,
+    teamId,
+    teamAbbr: team?.abbr ?? null,
+    summary,
+    detail: null,
+    source: 'player',
+    meta: { draft },
+    sortDate: (num(season, 0) ?? 0) * 100000,
+  };
+}
+
+function normalizeAwardRow(row, player) {
+  if (!row || typeof row !== 'object') return null;
+  const season = row.year ?? row.season ?? null;
+  return {
+    id: `award:${player?.id ?? 'player'}:${season ?? 'na'}:${row.canonical ?? slug(row.label)}`,
+    type: 'award',
+    label: TYPE_LABELS.award,
+    season,
+    week: null,
+    team: row.teamAbbr ? { abbr: row.teamAbbr, id: row.teamId ?? null } : null,
+    teamId: row.teamId ?? null,
+    teamAbbr: row.teamAbbr ?? null,
+    summary: row.label ?? 'Award recorded',
+    detail: row.source ? `Source: ${row.source}` : null,
+    source: 'award',
+    meta: { ...row },
+    sortDate: (num(season, 0) ?? 0) * 100000 + 500,
+  };
+}
+
+function normalizeRecordRow(row, player, index) {
+  if (!row || typeof row !== 'object') return null;
+  return {
+    id: `record:${player?.id ?? 'player'}:${row.kind ?? 'record'}:${row.recordKey ?? index}`,
+    type: 'record',
+    label: TYPE_LABELS.record,
+    season: row.year ?? null,
+    week: null,
+    team: null,
+    teamId: null,
+    teamAbbr: null,
+    summary: row.text ?? 'Record book mention',
+    detail: null,
+    source: 'record',
+    meta: { ...row },
+    sortDate: (num(row.year, 0) ?? 0) * 100000,
+  };
+}
+
+function dedupeKey(row) {
+  const season = row?.season ?? '';
+  const week = row?.week ?? '';
+  const team = row?.teamId ?? row?.teamAbbr ?? '';
+  const summary = slug(row?.summary, '');
+  if (['draft', 'trade', 'signing', 'contract', 'tag', 'release'].includes(row?.type)) {
+    return [row?.type ?? 'event', season, week, team].join('|');
+  }
+  return [row?.type ?? 'event', season, week, team, summary].join('|');
+}
+
+function chooseAcquisition(rows) {
+  const candidates = rows.filter((row) => ['draft', 'signing', 'trade', 'contract', 'tag'].includes(row.type));
+  if (!candidates.length) {
+    return {
+      label: 'How acquired',
+      summary: 'Unknown / legacy player',
+      detail: 'No acquisition event is recorded for this save.',
+      source: 'fallback',
+      type: 'event',
+    };
+  }
+  const oldest = [...candidates].sort((a, b) => {
+    const d = seasonScore(a) - seasonScore(b);
+    if (d !== 0) return d;
+    return String(a.id).localeCompare(String(b.id));
+  })[0];
+  const verb = {
+    draft: 'Drafted',
+    signing: 'Signed in free agency',
+    trade: 'Acquired via trade',
+    contract: 'Re-signed / extended',
+    tag: 'Franchise tagged',
+  }[oldest.type] ?? 'Recorded';
+  const when = [
+    oldest.season ? `Season ${oldest.season}` : null,
+    oldest.week != null ? `Week ${oldest.week}` : null,
+    oldest.teamAbbr ?? teamLabel(oldest.team) ?? null,
+  ].filter(Boolean).join(' - ');
+  return {
+    label: 'How acquired',
+    summary: oldest.type === 'draft' ? oldest.summary : verb,
+    detail: when || oldest.summary,
+    source: oldest.source,
+    type: oldest.type,
+  };
+}
+
+export function buildPlayerCareerTimeline({
+  player = null,
+  league = {},
+  activityRows = null,
+  transactions = [],
+  chronicleRows = null,
+  newsRows = null,
+  awardRows = [],
+  recordRows = [],
+  assumeTransactionsRelevant = false,
+} = {}) {
+  if (!player) {
+    return { rows: [], acquisition: chooseAcquisition([]), counts: { total: 0 } };
+  }
+
+  const normalizedActivityRows = Array.isArray(activityRows)
+    ? activityRows
+    : [
+        ...buildActivityLogRows({ league, transactions, chronicleRows: [], newsRows: [] }),
+        ...buildActivityLogRows({ league, transactions: [], chronicleRows: chronicleRows ?? league?.franchiseChronicle, newsRows: [] }),
+        ...buildActivityLogRows({ league, transactions: [], chronicleRows: [], newsRows: newsRows ?? league?.newsItems }),
+      ];
+
+  const playerActivityRows = normalizedActivityRows
+    .filter((row) => rowInvolvesPlayer(row, player, { assumeTransactionRelevant: assumeTransactionsRelevant }))
+    .map(normalizeActivityRow);
+
+  const draftRow = buildDraftRowFromPlayer(player, league);
+  const awardTimelineRows = (Array.isArray(awardRows) ? awardRows : [])
+    .map((row) => normalizeAwardRow(row, player))
+    .filter(Boolean);
+  const recordTimelineRows = (Array.isArray(recordRows) ? recordRows : [])
+    .map((row, index) => normalizeRecordRow(row, player, index))
+    .filter(Boolean);
+
+  const allRows = [
+    ...playerActivityRows,
+    draftRow,
+    ...awardTimelineRows,
+    ...recordTimelineRows,
+  ].filter(Boolean);
+
+  const byKey = new Map();
+  for (const row of allRows) {
+    const key = dedupeKey(row);
+    const current = byKey.get(key);
+    if (!current || (SOURCE_PRIORITY[row.source] ?? 99) < (SOURCE_PRIORITY[current.source] ?? 99)) {
+      byKey.set(key, row);
+    }
+  }
+
+  const rows = [...byKey.values()].sort((a, b) => {
+    const d = seasonScore(b) - seasonScore(a);
+    if (d !== 0) return d;
+    const source = (SOURCE_PRIORITY[a.source] ?? 99) - (SOURCE_PRIORITY[b.source] ?? 99);
+    if (source !== 0) return source;
+    return String(a.id).localeCompare(String(b.id));
+  });
+
+  return {
+    rows,
+    acquisition: chooseAcquisition(rows),
+    counts: { total: rows.length },
+  };
+}

--- a/src/ui/utils/playerCareerTimeline.test.js
+++ b/src/ui/utils/playerCareerTimeline.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { buildPlayerCareerTimeline } from './playerCareerTimeline.js';
+
+const player = {
+  id: 11,
+  name: 'Avery Fields',
+  pos: 'QB',
+  draftYear: 2030,
+  draftRound: 1,
+  draftPick: 7,
+  draftTeamId: 1,
+};
+
+const league = {
+  year: 2033,
+  week: 5,
+  userTeamId: 1,
+  teams: [
+    { id: 1, abbr: 'ALP', name: 'Alphas' },
+    { id: 2, abbr: 'BRV', name: 'Braves' },
+  ],
+};
+
+describe('playerCareerTimeline', () => {
+  it('filters activity rows to events involving the player', () => {
+    const model = buildPlayerCareerTimeline({
+      player,
+      league,
+      activityRows: [
+        { id: 'a', type: 'signing', source: 'transaction', season: 2032, week: 1, playerId: 11, playerName: 'Avery Fields', summary: 'ALP signed Avery Fields' },
+        { id: 'b', type: 'trade', source: 'transaction', season: 2032, week: 2, playerId: 22, playerName: 'Other Player', summary: 'Other player traded' },
+      ],
+    });
+
+    expect(model.rows.some((row) => row.summary === 'ALP signed Avery Fields')).toBe(true);
+    expect(model.rows.some((row) => row.summary === 'Other player traded')).toBe(false);
+  });
+
+  it('normalizes drafted, signed, traded, and contract rows safely', () => {
+    const model = buildPlayerCareerTimeline({
+      player,
+      league,
+      activityRows: [
+        { id: 'sign', type: 'signing', source: 'transaction', season: 2031, week: 3, playerId: 11, summary: 'Signed in free agency' },
+        { id: 'trade', type: 'trade', source: 'chronicle', season: 2032, week: 4, summary: 'Trade completed', meta: { incomingPlayers: [{ id: 11, name: 'Avery Fields' }] } },
+        { id: 'contract', type: 'contract', source: 'chronicle', season: 2033, week: 1, playerId: 11, summary: 'Avery Fields extended' },
+      ],
+    });
+
+    expect(model.rows.map((row) => row.type)).toEqual(expect.arrayContaining(['draft', 'signing', 'trade', 'contract']));
+    expect(model.acquisition.summary).toMatch(/Drafted 2030 Round 1 Pick 7/);
+  });
+
+  it('dedupes duplicate activity and chronicle rows while preferring chronicle detail', () => {
+    const model = buildPlayerCareerTimeline({
+      player: { id: 44, name: 'Dana Moss' },
+      league,
+      activityRows: [
+        { id: 'tx-1', type: 'signing', source: 'transaction', season: 2032, week: 6, teamId: 1, playerId: 44, playerName: 'Dana Moss', summary: 'ALP signed Dana Moss' },
+        { id: 'chron-1', type: 'contract', source: 'chronicle', season: 2032, week: 6, teamId: 1, summary: 'Dana Moss signs in free agency', meta: { source: 'free_agent_signing', player: { id: 44, name: 'Dana Moss' } } },
+      ],
+    });
+
+    expect(model.rows.filter((row) => row.type === 'signing')).toHaveLength(1);
+    expect(model.rows[0]).toMatchObject({ source: 'chronicle', summary: 'Dana Moss signs in free agency' });
+  });
+
+  it('adds award and record rows when supplied', () => {
+    const model = buildPlayerCareerTimeline({
+      player,
+      league,
+      activityRows: [],
+      awardRows: [{ year: 2032, canonical: 'mvp', label: 'Most Valuable Player', teamId: 1, teamAbbr: 'ALP' }],
+      recordRows: [{ kind: 'careerLeader', recordKey: 'passYds', text: 'Career Passing Yards leader (40,000)' }],
+    });
+
+    expect(model.rows.map((row) => row.type)).toEqual(expect.arrayContaining(['award', 'record', 'draft']));
+  });
+
+  it('does not crash for legacy players with no history', () => {
+    const model = buildPlayerCareerTimeline({
+      player: { id: 99, name: 'Legacy Player' },
+      league,
+      activityRows: [],
+    });
+
+    expect(model.rows).toEqual([]);
+    expect(model.acquisition.summary).toBe('Unknown / legacy player');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a pure `playerCareerTimeline` view model that builds player-specific history rows from existing activity/transaction rows, chronicle/news data, player draft fields, awards, and record-book lines.
- Updates `PlayerProfile` with a compact Career Timeline section, How acquired summary, type chips, source labels, empty state, and Show all / Show less behavior.
- Adds regression coverage for player-event filtering, draft/signing/trade/contract normalization, duplicate handling, legacy empty state, and PlayerProfile rendering.

## Data sources
- Existing `actions.getTransactions({ playerId })` response.
- Existing `activityLogViewModel` normalization for transactions, chronicle rows, and transaction-like news.
- Existing player draft fields.
- Existing `buildMergedPlayerAwardTimeline` rows.
- Existing `buildPlayerRecordContext` lines.

## Dedupe behavior
- Timeline rows are deduped by event type, season, week, and team.
- Chronicle rows are preferred over overlapping transaction/news rows when duplicate events exist, because chronicle entries usually carry richer narrative metadata.

## Safety
- No IndexedDB schema or DB version changes.
- No worker protocol changes.
- No persistence mutations from PlayerProfile.
- No fake history generation.
- No simulation outcome changes.

## Validation
- `npm.cmd run test:unit` passed: 196 files, 930 tests.
- `npm.cmd run build` passed, with the existing Vite large chunk warning.
- `git diff --check` passed, with normal Windows line-ending warnings.
- `npm.cmd run test:soak` not run because worker/protocol/simulation/persistence logic was not changed.
- Playwright smoke not run because navigation/routing was not changed.