### PR TITLE
Add League Records / Historical Search V1

### DIFF
--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -9,6 +9,7 @@ import { AWARD_DISPLAY_NAMES } from '../../core/footballMeta';
 import { buildLeagueHistoryTopPerformers } from '../../core/playerSeasonStatsArchive.js';
 import { normalizeArchivedMajorTransactions } from '../../core/transactionTimeline.js';
 import { buildShowingLabel, rowMatchesSearch, stableSortRows, uniqueFilterOptions } from "../utils/dataBrowser.js";
+import { buildLeagueRecordsRows, filterRecordRows, SCOPE_OPTIONS, CATEGORY_OPTIONS } from '../utils/leagueRecordsViewModel.js';
 
 const RECORD_LABELS = {
   passYd: "Passing Yards",
@@ -862,22 +863,23 @@ function SeasonExplorer({ seasons, actions, onPlayerSelect, onOpenBoxScore, leag
 }
 
 function RecordsExplorer({ records, recordBook, seasons, onPlayerSelect }) {
-  const [scope, setScope] = useState("singleSeason");
+  // V1 state — always declared before any conditional returns
+  const v1Rows = useMemo(() => buildLeagueRecordsRows(recordBook), [recordBook]);
+  const [v1Scope, setV1Scope] = useState('all');
+  const [v1Category, setV1Category] = useState('all');
+  const [v1Search, setV1Search] = useState('');
+  const filteredV1Rows = useMemo(
+    () => filterRecordRows(v1Rows, { scope: v1Scope, category: v1Category, search: v1Search }),
+    [v1Rows, v1Scope, v1Category, v1Search],
+  );
 
-  if (!records) return <div className="py-8 text-center text-[color:var(--text-muted)]">No records tracked yet.</div>;
-
-  const source = scope === "singleSeason"
-    ? (recordBook?.singleSeason ?? records.singleSeason)
-    : scope === "game"
-      ? (recordBook?.singleGame ?? records.singleGame)
-      : (recordBook?.career ?? records.allTime);
-
-  const teamSeasonRecords = useMemo(() => {
+  // Legacy state — always declared
+  const [legacyScope, setLegacyScope] = useState('singleSeason');
+  const legacyTeamSeasonRecords = useMemo(() => {
     const bestWins = { year: null, team: null, value: -1 };
     const worstWins = { year: null, team: null, value: 999 };
     const bestPF = { year: null, team: null, value: -1 };
     const worstPA = { year: null, team: null, value: -1 };
-
     (seasons ?? []).forEach((season) => {
       (season.standings ?? []).forEach((team) => {
         if ((team.wins ?? 0) > bestWins.value) Object.assign(bestWins, { year: season.year, team: team.abbr, value: team.wins ?? 0 });
@@ -886,13 +888,109 @@ function RecordsExplorer({ records, recordBook, seasons, onPlayerSelect }) {
         if ((team.pa ?? 0) > worstPA.value) Object.assign(worstPA, { year: season.year, team: team.abbr, value: team.pa ?? 0 });
       });
     });
-
     return { bestWins, worstWins, bestPF, worstPA };
   }, [seasons]);
 
+  const hasV1Data = v1Rows.length > 0;
+  const hasV1Filters = v1Scope !== 'all' || v1Category !== 'all' || Boolean(v1Search.trim());
+
+  // ── V1 path ─────────────────────────────────────────────────────────────────
+  if (hasV1Data) {
+    return (
+      <div className="space-y-4" data-testid="records-v1-view">
+        <div className="space-y-2">
+          <div className="flex flex-wrap gap-2 items-center" role="group" aria-label="Scope filter">
+            {SCOPE_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                aria-pressed={v1Scope === opt.value}
+                className={`rounded-full px-3 py-1 text-sm border transition-colors ${
+                  v1Scope === opt.value
+                    ? 'bg-[color:var(--accent)] text-white border-[color:var(--accent)]'
+                    : 'border-[color:var(--hairline)] bg-[color:var(--surface)] text-[color:var(--text)]'
+                }`}
+                onClick={() => setV1Scope(opt.value)}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+            <input
+              aria-label="Search records"
+              type="search"
+              value={v1Search}
+              onChange={(e) => setV1Search(e.target.value)}
+              placeholder="Search player, team, year…"
+              className="h-9 flex-1 min-w-[180px] rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-sm"
+            />
+            <select
+              aria-label="Filter records by category"
+              className="h-9 min-w-[160px] rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-sm"
+              value={v1Category}
+              onChange={(e) => setV1Category(e.target.value)}
+            >
+              {CATEGORY_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+            {hasV1Filters ? (
+              <button
+                type="button"
+                className="btn btn-secondary h-9 text-sm"
+                onClick={() => { setV1Scope('all'); setV1Category('all'); setV1Search(''); }}
+              >
+                Reset filters
+              </button>
+            ) : null}
+          </div>
+          <div data-testid="records-count" className="text-xs text-[color:var(--text-muted)]">
+            {buildShowingLabel(filteredV1Rows.length, v1Rows.length, 'record')}
+          </div>
+        </div>
+
+        {filteredV1Rows.length === 0 ? (
+          <div className="rounded-md border border-[color:var(--hairline)] px-4 py-8 text-center text-sm text-[color:var(--text-muted)]">
+            No records match these filters.
+          </div>
+        ) : (
+          <Card className="card-premium">
+            <CardContent className="p-0">
+              <ScrollArea className="h-[560px]">
+                <div className="divide-y divide-[color:var(--hairline)]">
+                  {filteredV1Rows.map((row) => (
+                    <RecordRow key={row.id} row={row} onPlayerSelect={onPlayerSelect} />
+                  ))}
+                </div>
+              </ScrollArea>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    );
+  }
+
+  // ── Empty state ──────────────────────────────────────────────────────────────
+  if (!records) {
+    return (
+      <div data-testid="records-empty-state" className="py-10 text-center text-[color:var(--text-muted)]">
+        <div className="font-semibold text-[color:var(--text)]">Records will populate as seasons are archived.</div>
+        <div className="mt-2 text-sm">Complete seasons to build your league's historical record book.</div>
+      </div>
+    );
+  }
+
+  // ── Legacy path (pre-V1 saves) ───────────────────────────────────────────────
+  const legacySource = legacyScope === 'singleSeason'
+    ? (recordBook?.singleSeason ?? records.singleSeason)
+    : legacyScope === 'game'
+      ? (recordBook?.singleGame ?? records.singleGame)
+      : (recordBook?.career ?? records.allTime);
+
   return (
     <div className="space-y-4">
-      <Tabs value={scope} onValueChange={setScope}>
+      <Tabs value={legacyScope} onValueChange={setLegacyScope}>
         <TabsList>
           <TabsTrigger value="game">Single-game</TabsTrigger>
           <TabsTrigger value="singleSeason">Single-season</TabsTrigger>
@@ -901,13 +999,13 @@ function RecordsExplorer({ records, recordBook, seasons, onPlayerSelect }) {
       </Tabs>
 
       <div className="text-xs text-[color:var(--text-muted)]">
-        {scope === "game" ? "Highest one-game outputs in archive." : scope === "singleSeason" ? "Best one-season marks and team highs." : "All-time career records and long-run leaders."}
+        {legacyScope === 'game' ? 'Highest one-game outputs in archive.' : legacyScope === 'singleSeason' ? 'Best one-season marks and team highs.' : 'All-time career records and long-run leaders.'}
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-        {Object.entries(scope === "singleSeason" ? (recordBook?.singleSeason ?? RECORD_LABELS) : (source ?? {})).map(([key, raw]) => {
-          const label = typeof raw === "string" ? raw : RECORD_LABELS[key] ?? key;
-          const rec = source?.[key];
+        {Object.entries(legacyScope === 'singleSeason' ? (recordBook?.singleSeason ?? RECORD_LABELS) : (legacySource ?? {})).map(([key, raw]) => {
+          const label = typeof raw === 'string' ? raw : RECORD_LABELS[key] ?? key;
+          const rec = legacySource?.[key];
           if (!rec?.playerId) return null;
           return (
             <Card key={key} className="card-premium cursor-pointer" onClick={() => onPlayerSelect?.(rec.playerId)}>
@@ -915,7 +1013,7 @@ function RecordsExplorer({ records, recordBook, seasons, onPlayerSelect }) {
                 <div className="text-xs uppercase tracking-wide text-[color:var(--text-muted)]">{label}</div>
                 <div className="text-2xl font-black text-[color:var(--accent)]">{Number(rec.value ?? 0).toLocaleString()}</div>
                 <div className="text-sm font-semibold">{rec.name} ({rec.pos})</div>
-                <div className="text-xs text-[color:var(--text-muted)]">{rec.team} · {rec.year ?? rec.lastYear ?? "—"}</div>
+                <div className="text-xs text-[color:var(--text-muted)]">{rec.team} · {rec.year ?? rec.lastYear ?? '—'}</div>
               </CardContent>
             </Card>
           );
@@ -925,10 +1023,10 @@ function RecordsExplorer({ records, recordBook, seasons, onPlayerSelect }) {
       <Card className="card-premium">
         <CardHeader><CardTitle>Team & Franchise Season Records</CardTitle></CardHeader>
         <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm">
-          <RecordLine label="Most wins" record={teamSeasonRecords.bestWins} />
-          <RecordLine label="Fewest wins" record={teamSeasonRecords.worstWins} />
-          <RecordLine label="Most points for" record={teamSeasonRecords.bestPF} />
-          <RecordLine label="Most points allowed" record={teamSeasonRecords.worstPA} />
+          <RecordLine label="Most wins" record={legacyTeamSeasonRecords.bestWins} />
+          <RecordLine label="Fewest wins" record={legacyTeamSeasonRecords.worstWins} />
+          <RecordLine label="Most points for" record={legacyTeamSeasonRecords.bestPF} />
+          <RecordLine label="Most points allowed" record={legacyTeamSeasonRecords.worstPA} />
         </CardContent>
       </Card>
 
@@ -947,6 +1045,51 @@ function RecordsExplorer({ records, recordBook, seasons, onPlayerSelect }) {
           </CardContent>
         </Card>
       )}
+    </div>
+  );
+}
+
+function RecordRow({ row, onPlayerSelect }) {
+  const canOpenPlayer = row.playerId != null && onPlayerSelect != null;
+  const scopeLabel = row.scope === 'singleSeason'
+    ? 'Season record'
+    : row.scope === 'career'
+      ? `Career · #${row.rank}`
+      : 'Team record';
+  const categoryLabel = String(row.category ?? '').charAt(0).toUpperCase() + String(row.category ?? '').slice(1);
+
+  return (
+    <div className="px-4 py-3" data-testid={`record-row-${row.id}`}>
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-2 text-xs text-[color:var(--text-muted)] mb-0.5">
+            <span className="font-semibold">{scopeLabel}</span>
+            <span>·</span>
+            <span>{categoryLabel}</span>
+          </div>
+          <div className="text-sm font-semibold text-[color:var(--text)] truncate">{row.label}</div>
+          <div className="text-xs text-[color:var(--text-muted)] mt-0.5">
+            {canOpenPlayer ? (
+              <button
+                type="button"
+                className="text-[color:var(--accent)] font-semibold hover:underline"
+                onClick={() => onPlayerSelect(row.playerId)}
+                data-testid={`record-row-player-btn-${row.id}`}
+              >
+                {row.playerName ?? 'Player'}
+              </button>
+            ) : row.playerName ? (
+              <span className="font-semibold">{row.playerName}</span>
+            ) : null}
+            {row.position ? ` (${row.position})` : ''}
+            {(row.teamAbbr ?? row.teamName) ? ` · ${row.teamAbbr ?? row.teamName}` : ''}
+            {row.year ? ` · ${row.year}` : ''}
+          </div>
+        </div>
+        <div className="text-xl font-black text-[color:var(--accent)] tabular-nums shrink-0">
+          {row.displayValue}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/ui/components/__tests__/LeagueHistory.test.jsx
+++ b/src/ui/components/__tests__/LeagueHistory.test.jsx
@@ -321,4 +321,180 @@ describe('LeagueHistory', () => {
       expect(screen.getAllByTestId(/league-office-row-/)[0].textContent).toContain('2032');
     });
   });
+
+  it('renders V1 records view with player record data', async () => {
+    const recordBook = {
+      schemaVersion: 1,
+      singleSeasonV1: {
+        passingYards: {
+          recordKey: 'passingYards',
+          label: 'Passing yards',
+          value: 5100,
+          playerId: 'qb1',
+          playerName: 'Star QB',
+          position: 'QB',
+          teamAbbr: 'DAL',
+          year: 2030,
+          source: 'archivedSeason',
+        },
+      },
+      careerLeadersV1: {},
+      teamSeasonV1: {},
+    };
+
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({ payload: { seasons: [] } }),
+          getRecords: vi.fn().mockResolvedValue({ payload: { records: null, recordBook } }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+        }}
+      />,
+    );
+
+    const recordsTab = await screen.findByRole('tab', { name: /Record Book/i });
+    fireEvent.mouseDown(recordsTab);
+    fireEvent.click(recordsTab);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('records-v1-view')).toBeTruthy();
+      expect(screen.getByTestId('records-v1-view').textContent).toMatch(/Star QB/);
+      expect(screen.getByTestId('records-v1-view').textContent).toMatch(/5,100/);
+    });
+  });
+
+  it('shows records empty state when no record book data exists', async () => {
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({ payload: { seasons: [] } }),
+          getRecords: vi.fn().mockResolvedValue({ payload: { records: null, recordBook: null } }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+        }}
+      />,
+    );
+
+    const recordsTab = await screen.findByRole('tab', { name: /Record Book/i });
+    fireEvent.mouseDown(recordsTab);
+    fireEvent.click(recordsTab);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('records-empty-state')).toBeTruthy();
+      expect(screen.getByTestId('records-empty-state').textContent).toMatch(
+        /Records will populate as seasons are archived/i,
+      );
+    });
+  });
+
+  it('calls onPlayerSelect when clicking a player name in the records view', async () => {
+    const onPlayerSelect = vi.fn();
+    const recordBook = {
+      schemaVersion: 1,
+      singleSeasonV1: {
+        rushingYards: {
+          recordKey: 'rushingYards',
+          label: 'Rushing yards',
+          value: 2200,
+          playerId: 'rb9',
+          playerName: 'Speed Back',
+          position: 'RB',
+          teamAbbr: 'PHI',
+          year: 2031,
+          source: 'archivedSeason',
+        },
+      },
+      careerLeadersV1: {},
+      teamSeasonV1: {},
+    };
+
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        onPlayerSelect={onPlayerSelect}
+        onOpenBoxScore={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({ payload: { seasons: [] } }),
+          getRecords: vi.fn().mockResolvedValue({ payload: { records: null, recordBook } }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+        }}
+      />,
+    );
+
+    const recordsTab = await screen.findByRole('tab', { name: /Record Book/i });
+    fireEvent.mouseDown(recordsTab);
+    fireEvent.click(recordsTab);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('records-v1-view')).toBeTruthy();
+    });
+
+    const playerBtn = screen.getByTestId('record-row-player-btn-ss-rushingYards');
+    fireEvent.click(playerBtn);
+    expect(onPlayerSelect).toHaveBeenCalledWith('rb9');
+  });
+
+  it('V1 records scope and category filters narrow down results', async () => {
+    const recordBook = {
+      schemaVersion: 1,
+      singleSeasonV1: {
+        passingYards: { value: 5000, playerId: 'qb1', playerName: 'Gunslinger', position: 'QB', label: 'Passing yards', teamAbbr: 'DAL', year: 2030, source: 'archivedSeason' },
+        rushingYards: { value: 1800, playerId: 'rb1', playerName: 'Speedster', position: 'RB', label: 'Rushing yards', teamAbbr: 'NYG', year: 2030, source: 'archivedSeason' },
+      },
+      careerLeadersV1: {
+        passingYards: [
+          { value: 40000, playerId: 'qb9', playerName: 'Veteran QB', position: 'QB', label: 'Passing yards', source: 'careerStats' },
+        ],
+      },
+      teamSeasonV1: {},
+    };
+
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={{
+          getAllSeasons: vi.fn().mockResolvedValue({ payload: { seasons: [] } }),
+          getRecords: vi.fn().mockResolvedValue({ payload: { records: null, recordBook } }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+          getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+        }}
+      />,
+    );
+
+    const recordsTab = await screen.findByRole('tab', { name: /Record Book/i });
+    fireEvent.mouseDown(recordsTab);
+    fireEvent.click(recordsTab);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('records-count').textContent).toMatch(/Showing 3 of 3 records/i);
+    });
+
+    // Filter to single-season scope
+    fireEvent.click(screen.getByRole('button', { name: /Single-season/i, pressed: false }));
+    await waitFor(() => {
+      expect(screen.getByTestId('records-count').textContent).toMatch(/Showing 2 of 3 records/i);
+    });
+
+    // Reset
+    fireEvent.click(screen.getByRole('button', { name: /Reset filters/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('records-count').textContent).toMatch(/Showing 3 of 3 records/i);
+    });
+
+    // Filter by category
+    fireEvent.change(screen.getByLabelText(/Filter records by category/i), { target: { value: 'rushing' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('records-count').textContent).toMatch(/Showing 1 of 3 records/i);
+    });
+  });
 });

--- a/src/ui/utils/leagueRecordsViewModel.js
+++ b/src/ui/utils/leagueRecordsViewModel.js
@@ -1,0 +1,174 @@
+/**
+ * leagueRecordsViewModel.js
+ * Normalizes V1 record book data into flat, filterable view-model rows.
+ * Pure helpers; safe on null/partial/legacy record books.
+ */
+import { RECORD_BOOK_PLAYER_KEYS, RECORD_KEYS } from '../../core/recordBookV1.js';
+
+export const RECORD_KEY_CATEGORY = {
+  [RECORD_KEYS.passingYards]: 'passing',
+  [RECORD_KEYS.passingTD]: 'passing',
+  [RECORD_KEYS.rushingYards]: 'rushing',
+  [RECORD_KEYS.rushingTD]: 'rushing',
+  [RECORD_KEYS.receivingYards]: 'receiving',
+  [RECORD_KEYS.receivingTD]: 'receiving',
+  [RECORD_KEYS.tackles]: 'defense',
+  [RECORD_KEYS.sacks]: 'defense',
+  [RECORD_KEYS.interceptions]: 'defense',
+  [RECORD_KEYS.fieldGoalsMade]: 'kicking',
+};
+
+const TEAM_RECORD_KEYS = [
+  'wins',
+  'winPct',
+  'pointsFor',
+  'pointsAllowed',
+  'pointDifferential',
+  'pointsPerGame',
+  'pointsAllowedPerGame',
+];
+
+function num(v) {
+  const n = Number(v ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function formatValue(value, recordKey) {
+  const n = num(value);
+  if (recordKey === 'winPct') return n.toFixed(3);
+  if (recordKey === 'pointsPerGame' || recordKey === 'pointsAllowedPerGame') return n.toFixed(1);
+  return n.toLocaleString();
+}
+
+function buildSingleSeasonRows(singleSeasonV1) {
+  const rows = [];
+  for (const key of RECORD_BOOK_PLAYER_KEYS) {
+    const row = singleSeasonV1?.[key];
+    if (!row || num(row.value) <= 0) continue;
+    rows.push({
+      id: `ss-${key}`,
+      scope: 'singleSeason',
+      category: RECORD_KEY_CATEGORY[key] ?? 'other',
+      recordKey: key,
+      label: row.label ?? key,
+      value: num(row.value),
+      displayValue: formatValue(row.value, key),
+      rank: null,
+      playerId: row.playerId ?? null,
+      playerName: row.playerName ?? null,
+      position: row.position ?? null,
+      teamId: row.teamId ?? null,
+      teamName: row.teamName ?? null,
+      teamAbbr: row.teamAbbr ?? null,
+      year: row.year ?? null,
+      source: row.source ?? 'archivedSeason',
+    });
+  }
+  return rows;
+}
+
+function buildCareerRows(careerLeadersV1) {
+  const rows = [];
+  for (const key of RECORD_BOOK_PLAYER_KEYS) {
+    const list = careerLeadersV1?.[key];
+    if (!Array.isArray(list)) continue;
+    for (let i = 0; i < list.length; i++) {
+      const row = list[i];
+      if (!row || num(row.value) <= 0) continue;
+      rows.push({
+        id: `career-${key}-${i}`,
+        scope: 'career',
+        category: RECORD_KEY_CATEGORY[key] ?? 'other',
+        recordKey: key,
+        label: row.label ?? key,
+        value: num(row.value),
+        displayValue: formatValue(row.value, key),
+        rank: i + 1,
+        playerId: row.playerId ?? null,
+        playerName: row.playerName ?? null,
+        position: row.position ?? null,
+        teamId: row.teamId ?? null,
+        teamName: row.teamName ?? null,
+        teamAbbr: row.teamAbbr ?? null,
+        year: row.year ?? null,
+        source: row.source ?? 'careerStats',
+      });
+    }
+  }
+  return rows;
+}
+
+function buildTeamRows(teamSeasonV1) {
+  const rows = [];
+  for (const key of TEAM_RECORD_KEYS) {
+    const row = teamSeasonV1?.[key];
+    if (!row || num(row.value) <= 0) continue;
+    rows.push({
+      id: `team-${key}`,
+      scope: 'team',
+      category: 'team',
+      recordKey: key,
+      label: row.label ?? key,
+      value: num(row.value),
+      displayValue: formatValue(row.value, key),
+      rank: null,
+      playerId: null,
+      playerName: null,
+      position: null,
+      teamId: row.teamId ?? null,
+      teamName: row.teamName ?? null,
+      teamAbbr: row.teamAbbr ?? null,
+      year: row.year ?? null,
+      source: row.source ?? 'archivedSeason',
+    });
+  }
+  return rows;
+}
+
+/** Normalize a V1 record book into a flat list of filterable rows. */
+export function buildLeagueRecordsRows(recordBook) {
+  return [
+    ...buildSingleSeasonRows(recordBook?.singleSeasonV1),
+    ...buildCareerRows(recordBook?.careerLeadersV1),
+    ...buildTeamRows(recordBook?.teamSeasonV1),
+  ];
+}
+
+export const SCOPE_OPTIONS = [
+  { value: 'all', label: 'All' },
+  { value: 'singleSeason', label: 'Single-season' },
+  { value: 'career', label: 'Career' },
+  { value: 'team', label: 'Team' },
+];
+
+export const CATEGORY_OPTIONS = [
+  { value: 'all', label: 'All categories' },
+  { value: 'passing', label: 'Passing' },
+  { value: 'rushing', label: 'Rushing' },
+  { value: 'receiving', label: 'Receiving' },
+  { value: 'defense', label: 'Defense' },
+  { value: 'kicking', label: 'Kicking' },
+  { value: 'team', label: 'Team' },
+];
+
+/** Filter rows by scope, category, and free-text search. */
+export function filterRecordRows(rows, { scope = 'all', category = 'all', search = '' } = {}) {
+  const q = String(search ?? '').trim().toLowerCase();
+  return (rows ?? []).filter((row) => {
+    if (scope !== 'all' && row.scope !== scope) return false;
+    if (category !== 'all' && row.category !== category) return false;
+    if (q) {
+      const haystack = [
+        row.playerName,
+        row.teamName,
+        row.teamAbbr,
+        row.label,
+        row.category,
+        row.position,
+        row.year != null ? String(row.year) : null,
+      ].filter(Boolean).join(' ').toLowerCase();
+      if (!haystack.includes(q)) return false;
+    }
+    return true;
+  });
+}

--- a/tests/unit/leagueRecordsViewModel.test.js
+++ b/tests/unit/leagueRecordsViewModel.test.js
@@ -1,0 +1,320 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildLeagueRecordsRows,
+  filterRecordRows,
+  SCOPE_OPTIONS,
+  CATEGORY_OPTIONS,
+} from '../../src/ui/utils/leagueRecordsViewModel.js';
+
+describe('leagueRecordsViewModel', () => {
+  // ── buildLeagueRecordsRows ──────────────────────────────────────────────────
+
+  it('normalizes single-season rows from V1 record book', () => {
+    const recordBook = {
+      singleSeasonV1: {
+        passingYards: {
+          recordKey: 'passingYards',
+          label: 'Passing yards',
+          value: 5100,
+          playerId: 'qb1',
+          playerName: 'Air Raid',
+          position: 'QB',
+          teamId: 1,
+          teamAbbr: 'DAL',
+          year: 2030,
+          source: 'archivedSeason',
+        },
+      },
+    };
+
+    const rows = buildLeagueRecordsRows(recordBook);
+    const ssRow = rows.find((r) => r.scope === 'singleSeason' && r.recordKey === 'passingYards');
+
+    expect(ssRow).toBeDefined();
+    expect(ssRow.scope).toBe('singleSeason');
+    expect(ssRow.category).toBe('passing');
+    expect(ssRow.value).toBe(5100);
+    expect(ssRow.playerId).toBe('qb1');
+    expect(ssRow.playerName).toBe('Air Raid');
+    expect(ssRow.teamAbbr).toBe('DAL');
+    expect(ssRow.year).toBe(2030);
+    expect(ssRow.rank).toBeNull();
+    expect(ssRow.id).toBe('ss-passingYards');
+  });
+
+  it('normalizes career leader rows with rank from V1 record book', () => {
+    const recordBook = {
+      careerLeadersV1: {
+        rushingYards: [
+          { recordKey: 'rushingYards', label: 'Rushing yards', value: 15000, playerId: 'rb1', playerName: 'Thunder', position: 'RB', source: 'careerStats' },
+          { recordKey: 'rushingYards', label: 'Rushing yards', value: 12000, playerId: 'rb2', playerName: 'Bolt', position: 'RB', source: 'careerStats' },
+        ],
+      },
+    };
+
+    const rows = buildLeagueRecordsRows(recordBook);
+    const careerRows = rows.filter((r) => r.scope === 'career' && r.recordKey === 'rushingYards');
+
+    expect(careerRows).toHaveLength(2);
+    expect(careerRows[0].rank).toBe(1);
+    expect(careerRows[0].playerId).toBe('rb1');
+    expect(careerRows[0].value).toBe(15000);
+    expect(careerRows[0].category).toBe('rushing');
+    expect(careerRows[0].id).toBe('career-rushingYards-0');
+    expect(careerRows[1].rank).toBe(2);
+    expect(careerRows[1].playerId).toBe('rb2');
+  });
+
+  it('normalizes team record rows from V1 record book', () => {
+    const recordBook = {
+      teamSeasonV1: {
+        wins: {
+          recordKey: 'wins',
+          label: 'Most wins in a season',
+          value: 15,
+          teamId: 1,
+          teamName: 'High',
+          teamAbbr: 'HI',
+          year: 2028,
+          source: 'archivedSeason',
+        },
+        pointsFor: {
+          recordKey: 'pointsFor',
+          label: 'Most points scored (season)',
+          value: 500,
+          teamId: 2,
+          teamAbbr: 'SC',
+          year: 2027,
+          source: 'archivedSeason',
+        },
+      },
+    };
+
+    const rows = buildLeagueRecordsRows(recordBook);
+    const teamRows = rows.filter((r) => r.scope === 'team');
+
+    expect(teamRows.length).toBeGreaterThanOrEqual(2);
+    const winsRow = teamRows.find((r) => r.recordKey === 'wins');
+    expect(winsRow).toBeDefined();
+    expect(winsRow.value).toBe(15);
+    expect(winsRow.teamAbbr).toBe('HI');
+    expect(winsRow.category).toBe('team');
+    expect(winsRow.playerId).toBeNull();
+    expect(winsRow.id).toBe('team-wins');
+  });
+
+  it('formats winPct to 3 decimal places', () => {
+    const recordBook = {
+      teamSeasonV1: {
+        winPct: { value: 0.882, teamAbbr: 'HI', label: 'Best win percentage', source: 'archivedSeason' },
+      },
+    };
+    const rows = buildLeagueRecordsRows(recordBook);
+    const row = rows.find((r) => r.recordKey === 'winPct');
+    expect(row).toBeDefined();
+    expect(row.displayValue).toBe('0.882');
+  });
+
+  it('does not crash on null or undefined record book', () => {
+    expect(() => buildLeagueRecordsRows(null)).not.toThrow();
+    expect(() => buildLeagueRecordsRows(undefined)).not.toThrow();
+    expect(() => buildLeagueRecordsRows({})).not.toThrow();
+    expect(buildLeagueRecordsRows(null)).toEqual([]);
+    expect(buildLeagueRecordsRows(undefined)).toEqual([]);
+    expect(buildLeagueRecordsRows({})).toEqual([]);
+  });
+
+  it('does not crash on sparse legacy record book (missing keys)', () => {
+    const sparse = {
+      singleSeasonV1: {
+        passingYards: null,
+        rushingYards: undefined,
+      },
+      careerLeadersV1: {
+        passingYards: null,
+        rushingYards: [null, undefined, { value: 0, playerId: 'x' }],
+      },
+      teamSeasonV1: {
+        wins: { value: null },
+        winPct: {},
+      },
+    };
+    expect(() => buildLeagueRecordsRows(sparse)).not.toThrow();
+    const rows = buildLeagueRecordsRows(sparse);
+    expect(Array.isArray(rows)).toBe(true);
+  });
+
+  it('skips rows with zero or negative values', () => {
+    const recordBook = {
+      singleSeasonV1: {
+        passingYards: { value: 0, playerId: 'qb1', playerName: 'None', label: 'Passing yards', source: 'archivedSeason' },
+        rushingYards: { value: -5, playerId: 'rb1', playerName: 'Neg', label: 'Rushing yards', source: 'archivedSeason' },
+      },
+      teamSeasonV1: {
+        wins: { value: 0, teamAbbr: 'XX', label: 'Wins' },
+      },
+    };
+    const rows = buildLeagueRecordsRows(recordBook);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('produces rows from a full V1 book with all three scopes', () => {
+    const recordBook = {
+      singleSeasonV1: {
+        passingYards: { value: 5000, playerId: 'qb1', playerName: 'QB', label: 'Passing yards', source: 'archivedSeason' },
+      },
+      careerLeadersV1: {
+        passingYards: [{ value: 40000, playerId: 'qb2', playerName: 'Legend', label: 'Passing yards', source: 'careerStats' }],
+      },
+      teamSeasonV1: {
+        wins: { value: 14, teamId: 1, teamAbbr: 'HI', label: 'Most wins in a season', source: 'archivedSeason' },
+      },
+    };
+    const rows = buildLeagueRecordsRows(recordBook);
+    expect(rows.some((r) => r.scope === 'singleSeason')).toBe(true);
+    expect(rows.some((r) => r.scope === 'career')).toBe(true);
+    expect(rows.some((r) => r.scope === 'team')).toBe(true);
+  });
+
+  // ── filterRecordRows ────────────────────────────────────────────────────────
+
+  it('filters rows by scope', () => {
+    const recordBook = {
+      singleSeasonV1: {
+        passingYards: { value: 5000, playerId: 'qb1', playerName: 'QB', label: 'Passing yards', source: 'archivedSeason' },
+      },
+      careerLeadersV1: {
+        passingYards: [{ value: 40000, playerId: 'qb2', playerName: 'Legend', label: 'Passing yards', source: 'careerStats' }],
+      },
+      teamSeasonV1: {
+        wins: { value: 14, teamId: 1, teamAbbr: 'HI', label: 'Most wins', source: 'archivedSeason' },
+      },
+    };
+    const rows = buildLeagueRecordsRows(recordBook);
+
+    const ssOnly = filterRecordRows(rows, { scope: 'singleSeason' });
+    expect(ssOnly.length).toBeGreaterThan(0);
+    expect(ssOnly.every((r) => r.scope === 'singleSeason')).toBe(true);
+
+    const careerOnly = filterRecordRows(rows, { scope: 'career' });
+    expect(careerOnly.length).toBeGreaterThan(0);
+    expect(careerOnly.every((r) => r.scope === 'career')).toBe(true);
+
+    const teamOnly = filterRecordRows(rows, { scope: 'team' });
+    expect(teamOnly.length).toBeGreaterThan(0);
+    expect(teamOnly.every((r) => r.scope === 'team')).toBe(true);
+
+    const all = filterRecordRows(rows, { scope: 'all' });
+    expect(all.length).toBe(rows.length);
+  });
+
+  it('filters rows by category', () => {
+    const recordBook = {
+      singleSeasonV1: {
+        passingYards: { value: 5000, playerId: 'qb1', playerName: 'QB', label: 'Passing yards', source: 'archivedSeason' },
+        rushingYards: { value: 2000, playerId: 'rb1', playerName: 'RB', label: 'Rushing yards', source: 'archivedSeason' },
+        fieldGoalsMade: { value: 30, playerId: 'k1', playerName: 'Kicker', label: 'FG made', source: 'archivedSeason' },
+      },
+    };
+    const rows = buildLeagueRecordsRows(recordBook);
+
+    const passing = filterRecordRows(rows, { category: 'passing' });
+    expect(passing.every((r) => r.category === 'passing')).toBe(true);
+    expect(passing.length).toBeGreaterThan(0);
+
+    const rushing = filterRecordRows(rows, { category: 'rushing' });
+    expect(rushing.every((r) => r.category === 'rushing')).toBe(true);
+
+    const kicking = filterRecordRows(rows, { category: 'kicking' });
+    expect(kicking.every((r) => r.category === 'kicking')).toBe(true);
+  });
+
+  it('search works for player name', () => {
+    const recordBook = {
+      singleSeasonV1: {
+        passingYards: { value: 5000, playerId: 'qb1', playerName: 'Air Raid', label: 'Passing yards', teamAbbr: 'DAL', year: 2030, source: 'archivedSeason' },
+        rushingYards: { value: 2000, playerId: 'rb1', playerName: 'Thunder Bolt', label: 'Rushing yards', teamAbbr: 'NYG', year: 2028, source: 'archivedSeason' },
+      },
+    };
+    const rows = buildLeagueRecordsRows(recordBook);
+
+    const result = filterRecordRows(rows, { search: 'Air' });
+    expect(result.some((r) => r.playerName === 'Air Raid')).toBe(true);
+    expect(result.every((r) => r.playerName !== 'Thunder Bolt')).toBe(true);
+  });
+
+  it('search works for team abbreviation', () => {
+    const recordBook = {
+      singleSeasonV1: {
+        passingYards: { value: 5000, playerId: 'qb1', playerName: 'QB', label: 'Passing yards', teamAbbr: 'DAL', year: 2030, source: 'archivedSeason' },
+        rushingYards: { value: 2000, playerId: 'rb1', playerName: 'RB', label: 'Rushing yards', teamAbbr: 'NYG', year: 2028, source: 'archivedSeason' },
+      },
+    };
+    const rows = buildLeagueRecordsRows(recordBook);
+
+    const dal = filterRecordRows(rows, { search: 'DAL' });
+    expect(dal.every((r) => r.teamAbbr === 'DAL')).toBe(true);
+  });
+
+  it('search works for year', () => {
+    const recordBook = {
+      singleSeasonV1: {
+        passingYards: { value: 5000, playerId: 'qb1', playerName: 'QB', label: 'Passing yards', year: 2030, source: 'archivedSeason' },
+        rushingYards: { value: 2000, playerId: 'rb1', playerName: 'RB', label: 'Rushing yards', year: 2028, source: 'archivedSeason' },
+      },
+    };
+    const rows = buildLeagueRecordsRows(recordBook);
+
+    const y2028 = filterRecordRows(rows, { search: '2028' });
+    expect(y2028.every((r) => r.year === 2028)).toBe(true);
+    expect(y2028.length).toBeGreaterThan(0);
+  });
+
+  it('search returns empty for non-matching query', () => {
+    const recordBook = {
+      singleSeasonV1: {
+        passingYards: { value: 5000, playerId: 'qb1', playerName: 'QB', label: 'Passing yards', source: 'archivedSeason' },
+      },
+    };
+    const rows = buildLeagueRecordsRows(recordBook);
+    expect(filterRecordRows(rows, { search: 'zzz-not-found' })).toHaveLength(0);
+  });
+
+  it('empty search / no filters returns all rows', () => {
+    const recordBook = {
+      singleSeasonV1: {
+        passingYards: { value: 5000, playerId: 'qb1', playerName: 'QB', label: 'Passing yards', source: 'archivedSeason' },
+      },
+    };
+    const rows = buildLeagueRecordsRows(recordBook);
+    expect(filterRecordRows(rows)).toHaveLength(rows.length);
+    expect(filterRecordRows(rows, {})).toHaveLength(rows.length);
+    expect(filterRecordRows(rows, { scope: 'all', category: 'all', search: '' })).toHaveLength(rows.length);
+  });
+
+  it('filterRecordRows handles null/empty rows safely', () => {
+    expect(() => filterRecordRows(null)).not.toThrow();
+    expect(filterRecordRows(null)).toEqual([]);
+    expect(filterRecordRows([])).toEqual([]);
+  });
+
+  // ── SCOPE_OPTIONS / CATEGORY_OPTIONS ─────────────────────────────────────────
+
+  it('SCOPE_OPTIONS includes all expected scope values', () => {
+    const values = SCOPE_OPTIONS.map((o) => o.value);
+    expect(values).toContain('all');
+    expect(values).toContain('singleSeason');
+    expect(values).toContain('career');
+    expect(values).toContain('team');
+  });
+
+  it('CATEGORY_OPTIONS includes all expected category values', () => {
+    const values = CATEGORY_OPTIONS.map((o) => o.value);
+    expect(values).toContain('passing');
+    expect(values).toContain('rushing');
+    expect(values).toContain('receiving');
+    expect(values).toContain('defense');
+    expect(values).toContain('kicking');
+    expect(values).toContain('team');
+  });
+});


### PR DESCRIPTION
- src/ui/utils/leagueRecordsViewModel.js: new pure utility that normalizes
  recordBook.singleSeasonV1, careerLeadersV1, and teamSeasonV1 into flat,
  filterable view-model rows (scope, category, label, value, playerId, etc.)
- RecordsExplorer in LeagueHistory.jsx upgraded to V1: scope filter pills
  (All / Single-season / Career / Team), category dropdown (Passing / Rushing /
  Receiving / Defense / Kicking / Team), free-text search, row count label,
  clickable player names that call onPlayerSelect, and "Records will populate
  as seasons are archived." empty state; legacy saves fall through to the
  previous record-card view untouched
- 17 new tests in leagueRecordsViewModel.test.js (normalizes SS / career /
  team rows, filters by scope/category/search, handles null/sparse saves, skips
  zero values, verifies SCOPE_OPTIONS / CATEGORY_OPTIONS)
- 4 new tests in LeagueHistory.test.jsx (V1 view renders, empty state, player
  click calls onPlayerSelect, scope+category filter counts)
- No DB schema change, no new dependencies, no worker/protocol changes

https://claude.ai/code/session_01HshBY4XEeX4S9qBtMMajbV