### PR TITLE
feat: awards/HOF presentation V1

### DIFF
--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -10,6 +10,7 @@ import { buildLeagueHistoryTopPerformers } from '../../core/playerSeasonStatsArc
 import { normalizeArchivedMajorTransactions } from '../../core/transactionTimeline.js';
 import { buildShowingLabel, rowMatchesSearch, stableSortRows, uniqueFilterOptions } from "../utils/dataBrowser.js";
 import { buildLeagueRecordsRows, filterRecordRows, SCOPE_OPTIONS, CATEGORY_OPTIONS } from '../utils/leagueRecordsViewModel.js';
+import { normalizeAwardsRows, normalizeHofRows } from '../utils/awardsHallOfFameViewModel.js';
 
 const RECORD_LABELS = {
   passYd: "Passing Yards",
@@ -144,6 +145,8 @@ export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenB
   const [recordBook, setRecordBook] = useState(null);
   const [allPlayers, setAllPlayers] = useState([]);
   const [transactions, setTransactions] = useState([]);
+  const [hofPlayers, setHofPlayers] = useState([]);
+  const [hofClasses, setHofClasses] = useState([]);
   const [activeTab, setActiveTab] = useState("seasons");
   const [loading, setLoading] = useState(true);
 
@@ -154,18 +157,25 @@ export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenB
       ? api.getTransactions({ mode: "recent", limit: 300 }).catch(() => ({ payload: { transactions: [] } }))
       : Promise.resolve({ payload: { transactions: [] } });
 
+    const hofPromise = api.getHallOfFame
+      ? api.getHallOfFame().catch(() => ({ payload: { players: [], classes: [] } }))
+      : Promise.resolve({ payload: { players: [], classes: [] } });
+
     Promise.all([
       api.getAllSeasons ? api.getAllSeasons().catch(() => ({ payload: { seasons: [] } })) : Promise.resolve({ payload: { seasons: [] } }),
       api.getRecords ? api.getRecords().catch(() => ({ payload: { records: null } })) : Promise.resolve({ payload: { records: null } }),
       api.getAllPlayerStats ? api.getAllPlayerStats({}).catch(() => ({ payload: { stats: [] } })) : Promise.resolve({ payload: { stats: [] } }),
       txPromise,
-    ]).then(([seasonsRes, recordsRes, playersRes, txRes]) => {
+      hofPromise,
+    ]).then(([seasonsRes, recordsRes, playersRes, txRes, hofRes]) => {
       if (!mounted) return;
       setSeasons(seasonsRes?.payload?.seasons ?? seasonsRes?.seasons ?? []);
       setRecords(recordsRes?.payload?.records ?? null);
       setRecordBook(recordsRes?.payload?.recordBook ?? null);
       setAllPlayers(playersRes?.payload?.stats ?? []);
       setTransactions(txRes?.payload?.transactions ?? []);
+      setHofPlayers(hofRes?.payload?.players ?? []);
+      setHofClasses(hofRes?.payload?.classes ?? []);
       setLoading(false);
     });
 
@@ -191,6 +201,7 @@ export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenB
           <TabsTrigger value="seasons">Season Archive</TabsTrigger>
           <TabsTrigger value="records">Record Book</TabsTrigger>
           <TabsTrigger value="awards">Awards History</TabsTrigger>
+          <TabsTrigger value="hof">Hall of Fame</TabsTrigger>
           <TabsTrigger value="office">League Office</TabsTrigger>
           <TabsTrigger value="draft">Draft History</TabsTrigger>
           <TabsTrigger value="compare">Compare Players</TabsTrigger>
@@ -206,6 +217,10 @@ export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenB
 
         <TabsContent value="awards">
           <AwardsHistory seasons={seasons} onPlayerSelect={onPlayerSelect} />
+        </TabsContent>
+
+        <TabsContent value="hof">
+          <HallOfFameSection hofClasses={hofClasses} hofPlayers={hofPlayers} onPlayerSelect={onPlayerSelect} />
         </TabsContent>
 
         <TabsContent value="office">
@@ -1094,41 +1109,269 @@ function RecordRow({ row, onPlayerSelect }) {
   );
 }
 
+const AWARD_FILTER_OPTIONS = [
+  { value: 'ALL', label: 'All' },
+  { value: 'mvp', label: 'MVP' },
+  { value: 'opoy', label: 'OPOY' },
+  { value: 'dpoy', label: 'DPOY' },
+  { value: 'roty', label: 'ROTY' },
+  { value: 'sbMvp', label: 'Finals MVP' },
+  { value: 'champion', label: 'Champion' },
+];
+
 function AwardsHistory({ seasons, onPlayerSelect }) {
-  if (!seasons?.length) return <div className="py-8 text-center text-[color:var(--text-muted)]">No award history yet.</div>;
+  const [filterKey, setFilterKey] = useState('ALL');
+  const [search, setSearch] = useState('');
+
+  const rows = useMemo(() => normalizeAwardsRows(seasons), [seasons]);
+
+  const filtered = useMemo(() => {
+    return rows.filter((row) => {
+      if (filterKey !== 'ALL' && row.awardKey !== filterKey) return false;
+      if (search) {
+        const q = search.toLowerCase();
+        return (
+          String(row.year ?? '').includes(q) ||
+          (row.playerName ?? '').toLowerCase().includes(q) ||
+          (row.teamAbbr ?? '').toLowerCase().includes(q) ||
+          (row.awardLabel ?? '').toLowerCase().includes(q) ||
+          (row.position ?? '').toLowerCase().includes(q)
+        );
+      }
+      return true;
+    });
+  }, [rows, filterKey, search]);
+
+  if (!seasons?.length) {
+    return (
+      <div data-testid="awards-empty-state" className="py-8 text-center text-[color:var(--text-muted)]">
+        Awards will populate as seasons are archived.
+      </div>
+    );
+  }
 
   return (
-    <Card className="card-premium">
-      <CardHeader><CardTitle>Awards by Season</CardTitle></CardHeader>
-      <CardContent className="p-0">
-        <ScrollArea className="h-[560px]">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="pl-5">Year</TableHead>
-                <TableHead>Champion</TableHead>
-                <TableHead>MVP</TableHead>
-                <TableHead>{AWARD_DISPLAY_NAMES.opoy}</TableHead>
-                <TableHead>{AWARD_DISPLAY_NAMES.dpoy}</TableHead>
-                <TableHead>{AWARD_DISPLAY_NAMES.roty}</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {seasons.map((s) => (
-                <TableRow key={s.id}>
-                  <TableCell className="pl-5 font-bold">{s.year}</TableCell>
-                  <TableCell>{s.champion?.abbr ?? "—"}</TableCell>
-                  <TableCell><AwardCell award={s.awards?.mvp} onPlayerSelect={onPlayerSelect} /></TableCell>
-                  <TableCell><AwardCell award={s.awards?.opoy} onPlayerSelect={onPlayerSelect} /></TableCell>
-                  <TableCell><AwardCell award={s.awards?.dpoy} onPlayerSelect={onPlayerSelect} /></TableCell>
-                  <TableCell><AwardCell award={s.awards?.roty} onPlayerSelect={onPlayerSelect} /></TableCell>
-                </TableRow>
+    <div className="space-y-3" data-testid="awards-history-section">
+      <Card className="card-premium">
+        <CardContent className="p-3 space-y-3">
+          <div className="flex flex-wrap gap-2 items-center">
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search player, team, year…"
+              aria-label="Search awards"
+              className="h-9 w-full sm:w-64 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-sm"
+            />
+            {search ? (
+              <button
+                onClick={() => setSearch('')}
+                className="text-xs text-[color:var(--text-muted)] border border-[color:var(--hairline)] rounded px-2 py-1"
+              >
+                Clear
+              </button>
+            ) : null}
+          </div>
+          <div className="flex flex-wrap gap-2" role="group" aria-label="Filter awards by type">
+            {AWARD_FILTER_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                onClick={() => setFilterKey(opt.value)}
+                aria-pressed={filterKey === opt.value}
+                className={`rounded-full px-3 py-1 text-xs border transition-colors ${
+                  filterKey === opt.value
+                    ? 'bg-[color:var(--accent)] text-white border-[color:var(--accent)]'
+                    : 'border-[color:var(--hairline)] text-[color:var(--text-muted)]'
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+          <div className="text-xs text-[color:var(--text-muted)]" data-testid="awards-count">
+            Showing {filtered.length} of {rows.length} awards
+          </div>
+        </CardContent>
+      </Card>
+
+      {filtered.length === 0 ? (
+        <div className="py-8 text-center text-[color:var(--text-muted)]">No awards match this filter.</div>
+      ) : (
+        <Card className="card-premium">
+          <CardContent className="p-0">
+            <ScrollArea className="h-[520px]">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="pl-5">Year</TableHead>
+                    <TableHead>Award</TableHead>
+                    <TableHead>Recipient</TableHead>
+                    <TableHead className="hidden sm:table-cell">Pos</TableHead>
+                    <TableHead className="hidden sm:table-cell">Team</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filtered.map((row) => (
+                    <TableRow key={row.id} data-testid={`award-row-${row.id}`}>
+                      <TableCell className="pl-5 font-bold tabular-nums">{row.year}</TableCell>
+                      <TableCell className="text-xs text-[color:var(--text-muted)]">{row.awardLabel}</TableCell>
+                      <TableCell>
+                        {row.playerId != null ? (
+                          <button
+                            className="text-left font-semibold text-[color:var(--accent)]"
+                            data-testid={`award-player-btn-${row.id}`}
+                            onClick={() => onPlayerSelect?.(row.playerId)}
+                          >
+                            {row.playerName ?? '—'}
+                          </button>
+                        ) : (
+                          <span className="font-semibold">{row.playerName ?? '—'}</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="hidden sm:table-cell text-xs">{row.position ?? '—'}</TableCell>
+                      <TableCell className="hidden sm:table-cell text-xs">{row.teamAbbr ?? '—'}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </ScrollArea>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function HallOfFameSection({ hofClasses, hofPlayers, onPlayerSelect }) {
+  const [search, setSearch] = useState('');
+  const [filterPos, setFilterPos] = useState('ALL');
+  const [filterYear, setFilterYear] = useState('ALL');
+
+  const rows = useMemo(() => normalizeHofRows(hofClasses ?? [], hofPlayers ?? []), [hofClasses, hofPlayers]);
+
+  const positions = useMemo(() => {
+    const posSet = new Set(rows.map((r) => r.position).filter(Boolean));
+    return ['ALL', ...[...posSet].sort()];
+  }, [rows]);
+
+  const years = useMemo(() => {
+    const yrSet = new Set(rows.map((r) => r.inductionYear).filter((y) => y != null));
+    return ['ALL', ...[...yrSet].sort((a, b) => b - a)];
+  }, [rows]);
+
+  const filtered = useMemo(() => {
+    return rows.filter((row) => {
+      if (filterPos !== 'ALL' && row.position !== filterPos) return false;
+      if (filterYear !== 'ALL' && String(row.inductionYear ?? '') !== String(filterYear)) return false;
+      if (search) {
+        const q = search.toLowerCase();
+        return (
+          (row.playerName ?? '').toLowerCase().includes(q) ||
+          (row.position ?? '').toLowerCase().includes(q) ||
+          (row.teamAbbr ?? '').toLowerCase().includes(q) ||
+          String(row.inductionYear ?? '').includes(q)
+        );
+      }
+      return true;
+    });
+  }, [rows, filterPos, filterYear, search]);
+
+  if (!rows.length) {
+    return (
+      <div data-testid="hof-empty-state" className="py-8 text-center text-[color:var(--text-muted)]">
+        Hall of Fame classes will appear after long-term careers are archived.
+      </div>
+    );
+  }
+
+  const hasFilter = search || filterPos !== 'ALL' || filterYear !== 'ALL';
+
+  return (
+    <div className="space-y-3" data-testid="hof-section">
+      <Card className="card-premium">
+        <CardContent className="p-3 space-y-3">
+          <div className="flex flex-wrap gap-2 items-center">
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search inductee, team, year…"
+              aria-label="Search Hall of Fame"
+              className="h-9 w-full sm:w-64 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-sm"
+            />
+            <select
+              value={filterPos}
+              onChange={(e) => setFilterPos(e.target.value)}
+              aria-label="Filter Hall of Fame by position"
+              className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-sm"
+            >
+              {positions.map((p) => (
+                <option key={p} value={p}>{p === 'ALL' ? 'All positions' : p}</option>
               ))}
-            </TableBody>
-          </Table>
-        </ScrollArea>
-      </CardContent>
-    </Card>
+            </select>
+            <select
+              value={filterYear}
+              onChange={(e) => setFilterYear(e.target.value)}
+              aria-label="Filter Hall of Fame by class year"
+              className="h-9 rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-sm"
+            >
+              {years.map((y) => (
+                <option key={y} value={String(y)}>{y === 'ALL' ? 'All classes' : `Class of ${y}`}</option>
+              ))}
+            </select>
+            {hasFilter ? (
+              <button
+                onClick={() => { setSearch(''); setFilterPos('ALL'); setFilterYear('ALL'); }}
+                className="text-xs text-[color:var(--text-muted)] border border-[color:var(--hairline)] rounded px-2 py-1"
+              >
+                Reset filters
+              </button>
+            ) : null}
+          </div>
+          <div className="text-xs text-[color:var(--text-muted)]" data-testid="hof-count">
+            Showing {filtered.length} of {rows.length} inductees
+          </div>
+        </CardContent>
+      </Card>
+
+      {filtered.length === 0 ? (
+        <div className="py-6 text-center text-[color:var(--text-muted)]">No inductees match this filter.</div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+          {filtered.map((row) => (
+            <Card key={row.id} className="card-premium" data-testid={`hof-card-${row.playerId}`}>
+              <CardContent className="p-3 space-y-1">
+                <div className="flex justify-between items-start gap-2">
+                  <div>
+                    {row.playerId != null ? (
+                      <button
+                        className="font-bold text-sm text-[color:var(--accent)] text-left"
+                        data-testid={`hof-player-btn-${row.playerId}`}
+                        onClick={() => onPlayerSelect?.(row.playerId)}
+                      >
+                        {row.playerName ?? 'Unknown'}
+                      </button>
+                    ) : (
+                      <span className="font-bold text-sm">{row.playerName ?? 'Unknown'}</span>
+                    )}
+                    <div className="text-xs text-[color:var(--text-muted)]">
+                      {[row.position, row.teamAbbr].filter(Boolean).join(' · ')}
+                    </div>
+                  </div>
+                  <Badge variant="secondary" className="text-xs shrink-0">{row.classLabel}</Badge>
+                </div>
+                {row.careerSummary ? (
+                  <div className="text-xs text-[color:var(--text-muted)] line-clamp-2">{row.careerSummary}</div>
+                ) : null}
+                {row.tier ? (
+                  <div className="text-xs font-semibold capitalize text-[color:var(--text-muted)]">{row.tier}</div>
+                ) : null}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/src/ui/components/__tests__/LeagueHistory.test.jsx
+++ b/src/ui/components/__tests__/LeagueHistory.test.jsx
@@ -498,3 +498,341 @@ describe('LeagueHistory', () => {
     });
   });
 });
+
+// ─── Awards History & Hall of Fame ───────────────────────────────────────────
+
+const MINIMAL_ACTIONS = {
+  getAllSeasons: vi.fn().mockResolvedValue({ payload: { seasons: [] } }),
+  getRecords: vi.fn().mockResolvedValue({ payload: { records: null } }),
+  getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+  getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+  getHallOfFame: vi.fn().mockResolvedValue({ payload: { players: [], classes: [] } }),
+};
+
+function makeActions(overrides = {}) {
+  return { ...MINIMAL_ACTIONS, ...overrides };
+}
+
+describe('AwardsHistory tab', () => {
+  afterEach(cleanup);
+
+  async function openAwardsTab(actions) {
+    render(<LeagueHistory league={{ userTeamId: 1 }} onPlayerSelect={vi.fn()} onOpenBoxScore={vi.fn()} actions={actions} />);
+    const tab = await screen.findByRole('tab', { name: /Awards History/i });
+    fireEvent.mouseDown(tab);
+    fireEvent.click(tab);
+  }
+
+  it('shows awards empty state when no seasons are archived', async () => {
+    await openAwardsTab(makeActions());
+    await waitFor(() => {
+      expect(screen.getByTestId('awards-empty-state')).toBeTruthy();
+      expect(screen.getByTestId('awards-empty-state').textContent).toMatch(/Awards will populate as seasons are archived/i);
+    });
+  });
+
+  it('renders award rows for archived seasons', async () => {
+    const actions = makeActions({
+      getAllSeasons: vi.fn().mockResolvedValue({
+        payload: {
+          seasons: [{
+            id: 's1',
+            year: 2030,
+            champion: { name: 'Dallas', abbr: 'DAL' },
+            awards: {
+              mvp: { playerId: 1, name: 'Star QB', pos: 'QB', teamAbbr: 'DAL' },
+              opoy: { playerId: 2, name: 'Speedy WR', pos: 'WR', teamAbbr: 'DAL' },
+            },
+          }],
+        },
+      }),
+    });
+    await openAwardsTab(actions);
+    await waitFor(() => {
+      expect(screen.getByTestId('awards-history-section')).toBeTruthy();
+      const section = screen.getByTestId('awards-history-section');
+      expect(section.textContent).toMatch(/Star QB/);
+      expect(section.textContent).toMatch(/Speedy WR/);
+    });
+  });
+
+  it('filters awards by type when clicking a filter chip', async () => {
+    const actions = makeActions({
+      getAllSeasons: vi.fn().mockResolvedValue({
+        payload: {
+          seasons: [{
+            id: 's1',
+            year: 2031,
+            awards: {
+              mvp: { playerId: 1, name: 'MVP Man', pos: 'QB' },
+              dpoy: { playerId: 2, name: 'DPOY Man', pos: 'LB' },
+            },
+          }],
+        },
+      }),
+    });
+    await openAwardsTab(actions);
+    await waitFor(() => expect(screen.getByTestId('awards-history-section')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: /^DPOY$/i }));
+    await waitFor(() => {
+      const section = screen.getByTestId('awards-history-section');
+      expect(section.textContent).toMatch(/DPOY Man/);
+      expect(section.textContent).not.toMatch(/MVP Man/);
+    });
+  });
+
+  it('filters awards by search query', async () => {
+    const actions = makeActions({
+      getAllSeasons: vi.fn().mockResolvedValue({
+        payload: {
+          seasons: [{
+            id: 's1',
+            year: 2031,
+            awards: {
+              mvp: { playerId: 1, name: 'Alpha Back', pos: 'RB', teamAbbr: 'PHI' },
+              roty: { playerId: 2, name: 'Beta Rook', pos: 'WR', teamAbbr: 'NYG' },
+            },
+          }],
+        },
+      }),
+    });
+    await openAwardsTab(actions);
+    await waitFor(() => expect(screen.getByTestId('awards-history-section')).toBeTruthy());
+
+    fireEvent.change(screen.getByLabelText(/Search awards/i), { target: { value: 'Alpha' } });
+    await waitFor(() => {
+      const section = screen.getByTestId('awards-history-section');
+      expect(section.textContent).toMatch(/Alpha Back/);
+      expect(section.textContent).not.toMatch(/Beta Rook/);
+    });
+  });
+
+  it('calls onPlayerSelect when clicking an award player name', async () => {
+    const onPlayerSelect = vi.fn();
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        onPlayerSelect={onPlayerSelect}
+        onOpenBoxScore={vi.fn()}
+        actions={makeActions({
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: {
+              seasons: [{
+                id: 's1',
+                year: 2030,
+                awards: { mvp: { playerId: 42, name: 'Clickable MVP', pos: 'QB', teamAbbr: 'DAL' } },
+              }],
+            },
+          }),
+        })}
+      />,
+    );
+
+    const tab = await screen.findByRole('tab', { name: /Awards History/i });
+    fireEvent.mouseDown(tab);
+    fireEvent.click(tab);
+
+    await waitFor(() => expect(screen.getByTestId('award-player-btn-2030-mvp')).toBeTruthy());
+    fireEvent.click(screen.getByTestId('award-player-btn-2030-mvp'));
+    expect(onPlayerSelect).toHaveBeenCalledWith(42);
+  });
+
+  it('shows count row with total and filtered awards', async () => {
+    const actions = makeActions({
+      getAllSeasons: vi.fn().mockResolvedValue({
+        payload: {
+          seasons: [{
+            id: 's1',
+            year: 2030,
+            awards: {
+              mvp: { playerId: 1, name: 'A', pos: 'QB' },
+              dpoy: { playerId: 2, name: 'B', pos: 'LB' },
+            },
+          }],
+        },
+      }),
+    });
+    await openAwardsTab(actions);
+    await waitFor(() => {
+      const count = screen.getByTestId('awards-count');
+      expect(count.textContent).toMatch(/Showing 2 of 2 awards/i);
+    });
+  });
+});
+
+describe('Hall of Fame tab', () => {
+  afterEach(cleanup);
+
+  async function openHofTab(actions) {
+    render(<LeagueHistory league={{ userTeamId: 1 }} onPlayerSelect={vi.fn()} onOpenBoxScore={vi.fn()} actions={actions} />);
+    const tab = await screen.findByRole('tab', { name: /Hall of Fame/i });
+    fireEvent.mouseDown(tab);
+    fireEvent.click(tab);
+  }
+
+  it('shows HOF empty state when no classes exist', async () => {
+    await openHofTab(makeActions());
+    await waitFor(() => {
+      expect(screen.getByTestId('hof-empty-state')).toBeTruthy();
+      expect(screen.getByTestId('hof-empty-state').textContent).toMatch(/Hall of Fame classes will appear/i);
+    });
+  });
+
+  it('renders HOF inductee cards from classes', async () => {
+    const actions = makeActions({
+      getHallOfFame: vi.fn().mockResolvedValue({
+        payload: {
+          players: [],
+          classes: [{
+            year: 2035,
+            classId: 'hof-2035',
+            inductees: [{
+              playerId: 'qb1',
+              name: 'Legend QB',
+              pos: 'QB',
+              primaryTeamAbbr: 'DAL',
+              legacyScore: 90,
+              tier: 'gold',
+              careerSummary: '3x MVP, 2 titles',
+            }],
+          }],
+        },
+      }),
+    });
+    await openHofTab(actions);
+    await waitFor(() => {
+      expect(screen.getByTestId('hof-section')).toBeTruthy();
+      expect(screen.getByTestId('hof-section').textContent).toMatch(/Legend QB/);
+      expect(screen.getByTestId('hof-section').textContent).toMatch(/Class of 2035/);
+      expect(screen.getByTestId('hof-section').textContent).toMatch(/3x MVP/);
+    });
+  });
+
+  it('calls onPlayerSelect when clicking an HOF inductee name', async () => {
+    const onPlayerSelect = vi.fn();
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        onPlayerSelect={onPlayerSelect}
+        onOpenBoxScore={vi.fn()}
+        actions={makeActions({
+          getHallOfFame: vi.fn().mockResolvedValue({
+            payload: {
+              players: [],
+              classes: [{
+                year: 2036,
+                classId: 'hof-2036',
+                inductees: [{ playerId: 'rb9', name: 'HOF Runner', pos: 'RB', primaryTeamAbbr: 'PHI', legacyScore: 82 }],
+              }],
+            },
+          }),
+        })}
+      />,
+    );
+    const tab = await screen.findByRole('tab', { name: /Hall of Fame/i });
+    fireEvent.mouseDown(tab);
+    fireEvent.click(tab);
+
+    await waitFor(() => expect(screen.getByTestId('hof-player-btn-rb9')).toBeTruthy());
+    fireEvent.click(screen.getByTestId('hof-player-btn-rb9'));
+    expect(onPlayerSelect).toHaveBeenCalledWith('rb9');
+  });
+
+  it('filters HOF inductees by position', async () => {
+    const actions = makeActions({
+      getHallOfFame: vi.fn().mockResolvedValue({
+        payload: {
+          players: [],
+          classes: [{
+            year: 2040,
+            inductees: [
+              { playerId: 'p1', name: 'QB Legend', pos: 'QB', legacyScore: 90 },
+              { playerId: 'p2', name: 'RB Legend', pos: 'RB', legacyScore: 85 },
+            ],
+          }],
+        },
+      }),
+    });
+    await openHofTab(actions);
+    await waitFor(() => expect(screen.getByTestId('hof-section')).toBeTruthy());
+
+    fireEvent.change(screen.getByLabelText(/Filter Hall of Fame by position/i), { target: { value: 'RB' } });
+    await waitFor(() => {
+      const section = screen.getByTestId('hof-section');
+      expect(section.textContent).toMatch(/RB Legend/);
+      expect(section.textContent).not.toMatch(/QB Legend/);
+    });
+  });
+
+  it('filters HOF inductees by search query', async () => {
+    const actions = makeActions({
+      getHallOfFame: vi.fn().mockResolvedValue({
+        payload: {
+          players: [],
+          classes: [{
+            year: 2041,
+            inductees: [
+              { playerId: 'x1', name: 'Alpha WR', pos: 'WR', legacyScore: 80 },
+              { playerId: 'x2', name: 'Beta LB', pos: 'LB', legacyScore: 78 },
+            ],
+          }],
+        },
+      }),
+    });
+    await openHofTab(actions);
+    await waitFor(() => expect(screen.getByTestId('hof-section')).toBeTruthy());
+
+    fireEvent.change(screen.getByLabelText(/Search Hall of Fame/i), { target: { value: 'Beta' } });
+    await waitFor(() => {
+      const section = screen.getByTestId('hof-section');
+      expect(section.textContent).toMatch(/Beta LB/);
+      expect(section.textContent).not.toMatch(/Alpha WR/);
+    });
+  });
+
+  it('shows count row with total and filtered inductees', async () => {
+    const actions = makeActions({
+      getHallOfFame: vi.fn().mockResolvedValue({
+        payload: {
+          players: [],
+          classes: [{
+            year: 2042,
+            inductees: [
+              { playerId: 'a', name: 'A', pos: 'QB', legacyScore: 90 },
+              { playerId: 'b', name: 'B', pos: 'RB', legacyScore: 80 },
+            ],
+          }],
+        },
+      }),
+    });
+    await openHofTab(actions);
+    await waitFor(() => {
+      const count = screen.getByTestId('hof-count');
+      expect(count.textContent).toMatch(/Showing 2 of 2 inductees/i);
+    });
+  });
+
+  it('works gracefully when getHallOfFame is not present in actions', async () => {
+    const actionsWithoutHof = {
+      getAllSeasons: vi.fn().mockResolvedValue({ payload: { seasons: [] } }),
+      getRecords: vi.fn().mockResolvedValue({ payload: { records: null } }),
+      getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+      getTransactions: vi.fn().mockResolvedValue({ payload: { transactions: [] } }),
+    };
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={actionsWithoutHof}
+      />,
+    );
+    const tab = await screen.findByRole('tab', { name: /Hall of Fame/i });
+    fireEvent.mouseDown(tab);
+    fireEvent.click(tab);
+    await waitFor(() => {
+      expect(screen.getByTestId('hof-empty-state')).toBeTruthy();
+    });
+  });
+});

--- a/src/ui/utils/awardsHallOfFameViewModel.js
+++ b/src/ui/utils/awardsHallOfFameViewModel.js
@@ -1,0 +1,136 @@
+const AWARD_KEYS_ALL = [
+  'mvp', 'opoy', 'dpoy', 'roty', 'sbMvp',
+  'oroy', 'droy', 'bestQB', 'bestRB', 'bestWrTe', 'bestDefensivePlayer', 'bestKicker',
+];
+
+const AWARD_LABEL_MAP = {
+  mvp: 'Most Valuable Player',
+  opoy: 'Offensive Player of the Year',
+  dpoy: 'Defensive Player of the Year',
+  roty: 'Rookie of the Year',
+  oroy: 'Offensive Rookie of the Year',
+  droy: 'Defensive Rookie of the Year',
+  sbMvp: 'Finals MVP',
+  bestQB: 'Best QB',
+  bestRB: 'Best RB',
+  bestWrTe: 'Best WR/TE',
+  bestDefensivePlayer: 'Best Defensive Player',
+  bestKicker: 'Best Kicker',
+};
+
+/**
+ * Flatten archived seasons into a deterministic list of award rows.
+ * Sorted newest-first, then by canonical award key order within a year.
+ */
+export function normalizeAwardsRows(archivedSeasons) {
+  if (!Array.isArray(archivedSeasons)) return [];
+  const rows = [];
+
+  for (const season of archivedSeasons) {
+    if (!season) continue;
+    const year = season.year;
+    if (year == null) continue;
+
+    if (season.champion?.abbr || season.champion?.name) {
+      rows.push({
+        id: `${year}-champion`,
+        year,
+        awardKey: 'champion',
+        awardLabel: 'Champion',
+        playerId: null,
+        playerName: season.champion.name ?? season.champion.abbr,
+        position: null,
+        team: season.champion.name ?? season.champion.abbr,
+        teamAbbr: season.champion.abbr ?? null,
+        summary: null,
+      });
+    }
+
+    for (let i = 0; i < AWARD_KEYS_ALL.length; i++) {
+      const key = AWARD_KEYS_ALL[i];
+      const award = season.awards?.[key];
+      if (!award?.name) continue;
+      rows.push({
+        id: `${year}-${key}`,
+        year,
+        awardKey: key,
+        awardLabel: AWARD_LABEL_MAP[key] ?? key,
+        playerId: award.playerId ?? null,
+        playerName: award.name,
+        position: award.pos ?? null,
+        team: award.teamName ?? award.teamAbbr ?? null,
+        teamAbbr: award.teamAbbr ?? null,
+        summary: null,
+      });
+    }
+  }
+
+  return rows.sort((a, b) => {
+    const yearDiff = b.year - a.year;
+    if (yearDiff !== 0) return yearDiff;
+    const ai = a.awardKey === 'champion' ? -1 : AWARD_KEYS_ALL.indexOf(a.awardKey);
+    const bi = b.awardKey === 'champion' ? -1 : AWARD_KEYS_ALL.indexOf(b.awardKey);
+    return ai - bi;
+  });
+}
+
+/**
+ * Flatten HOF classes + players array into a deduplicated list of inductee rows.
+ * Classes take priority for dedup; players array fills in any not already seen.
+ * Sorted newest class first, then by legacyScore descending.
+ */
+export function normalizeHofRows(hofClasses, hofPlayers) {
+  const rows = [];
+  const seen = new Set();
+
+  for (const cls of hofClasses ?? []) {
+    if (!cls) continue;
+    const year = cls.year ?? null;
+    for (const inductee of cls.inductees ?? []) {
+      if (!inductee?.playerId) continue;
+      const key = String(inductee.playerId);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      rows.push({
+        id: `hof-cls-${inductee.playerId}`,
+        inductionYear: year,
+        playerId: inductee.playerId,
+        playerName: inductee.name ?? null,
+        position: inductee.pos ?? null,
+        team: inductee.primaryTeamAbbr ?? null,
+        teamAbbr: inductee.primaryTeamAbbr ?? null,
+        classLabel: year != null ? `Class of ${year}` : 'Hall of Fame',
+        legacyScore: inductee.legacyScore ?? inductee.score ?? null,
+        tier: inductee.tier ?? null,
+        careerSummary: inductee.careerSummary ?? inductee.awardsSummary ?? null,
+      });
+    }
+  }
+
+  for (const player of hofPlayers ?? []) {
+    if (!player?.playerId) continue;
+    const key = String(player.playerId);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const year = player.inductionYear ?? null;
+    rows.push({
+      id: `hof-pl-${player.playerId}`,
+      inductionYear: year,
+      playerId: player.playerId,
+      playerName: player.name ?? null,
+      position: player.pos ?? null,
+      team: player.primaryTeamAbbr ?? null,
+      teamAbbr: player.primaryTeamAbbr ?? null,
+      classLabel: year != null ? `Class of ${year}` : 'Hall of Fame',
+      legacyScore: player.legacyScore ?? player.score ?? null,
+      tier: player.tier ?? null,
+      careerSummary: player.careerSummary ?? null,
+    });
+  }
+
+  return rows.sort((a, b) => {
+    const yearDiff = (b.inductionYear ?? 0) - (a.inductionYear ?? 0);
+    if (yearDiff !== 0) return yearDiff;
+    return (b.legacyScore ?? 0) - (a.legacyScore ?? 0);
+  });
+}

--- a/src/ui/utils/awardsHallOfFameViewModel.test.js
+++ b/src/ui/utils/awardsHallOfFameViewModel.test.js
@@ -1,0 +1,209 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeAwardsRows, normalizeHofRows } from './awardsHallOfFameViewModel.js';
+
+describe('normalizeAwardsRows', () => {
+  it('returns empty array for null, undefined, and empty input', () => {
+    expect(normalizeAwardsRows(null)).toEqual([]);
+    expect(normalizeAwardsRows(undefined)).toEqual([]);
+    expect(normalizeAwardsRows([])).toEqual([]);
+  });
+
+  it('normalizes an MVP award row with all fields', () => {
+    const seasons = [{
+      year: 2030,
+      awards: { mvp: { playerId: 1, name: 'Star QB', pos: 'QB', teamAbbr: 'DAL' } },
+    }];
+    const rows = normalizeAwardsRows(seasons);
+    const mvp = rows.find((r) => r.awardKey === 'mvp');
+    expect(mvp).toBeTruthy();
+    expect(mvp.playerName).toBe('Star QB');
+    expect(mvp.playerId).toBe(1);
+    expect(mvp.year).toBe(2030);
+    expect(mvp.awardLabel).toBe('Most Valuable Player');
+    expect(mvp.position).toBe('QB');
+    expect(mvp.teamAbbr).toBe('DAL');
+    expect(mvp.id).toBe('2030-mvp');
+  });
+
+  it('includes a champion row when season has a champion', () => {
+    const seasons = [{
+      year: 2031,
+      champion: { name: 'Dallas Cowboys', abbr: 'DAL' },
+      awards: {},
+    }];
+    const rows = normalizeAwardsRows(seasons);
+    const champ = rows.find((r) => r.awardKey === 'champion');
+    expect(champ).toBeTruthy();
+    expect(champ.teamAbbr).toBe('DAL');
+    expect(champ.playerId).toBeNull();
+  });
+
+  it('skips award entries without a name field', () => {
+    const seasons = [{
+      year: 2030,
+      awards: { mvp: { playerId: 1 } },
+    }];
+    const rows = normalizeAwardsRows(seasons);
+    expect(rows.filter((r) => r.awardKey === 'mvp')).toHaveLength(0);
+  });
+
+  it('sorts newest year first within same award key', () => {
+    const seasons = [
+      { year: 2030, awards: { mvp: { playerId: 1, name: 'A' } } },
+      { year: 2032, awards: { mvp: { playerId: 2, name: 'B' } } },
+      { year: 2031, awards: { mvp: { playerId: 3, name: 'C' } } },
+    ];
+    const rows = normalizeAwardsRows(seasons).filter((r) => r.awardKey === 'mvp');
+    expect(rows[0].year).toBe(2032);
+    expect(rows[1].year).toBe(2031);
+    expect(rows[2].year).toBe(2030);
+  });
+
+  it('handles sparse legacy data safely without throwing', () => {
+    const seasons = [
+      { year: 2030, awards: null },
+      { year: 2031 },
+      { year: 2032, awards: { mvp: null } },
+      null,
+      undefined,
+    ];
+    expect(() => normalizeAwardsRows(seasons)).not.toThrow();
+  });
+
+  it('normalizes V1 extra awards like bestQB', () => {
+    const seasons = [{
+      year: 2033,
+      awards: { bestQB: { playerId: 5, name: 'Ace', pos: 'QB', teamAbbr: 'PHI' } },
+    }];
+    const rows = normalizeAwardsRows(seasons);
+    const best = rows.find((r) => r.awardKey === 'bestQB');
+    expect(best).toBeTruthy();
+    expect(best.awardLabel).toBe('Best QB');
+    expect(best.playerName).toBe('Ace');
+  });
+
+  it('normalizes OPOY, DPOY, ROTY with correct labels', () => {
+    const seasons = [{
+      year: 2034,
+      awards: {
+        opoy: { playerId: 10, name: 'OPOY Guy', pos: 'WR' },
+        dpoy: { playerId: 11, name: 'DPOY Guy', pos: 'LB' },
+        roty: { playerId: 12, name: 'ROTY Kid', pos: 'RB' },
+      },
+    }];
+    const rows = normalizeAwardsRows(seasons);
+    expect(rows.find((r) => r.awardKey === 'opoy')?.awardLabel).toBe('Offensive Player of the Year');
+    expect(rows.find((r) => r.awardKey === 'dpoy')?.awardLabel).toBe('Defensive Player of the Year');
+    expect(rows.find((r) => r.awardKey === 'roty')?.awardLabel).toBe('Rookie of the Year');
+  });
+
+  it('normalizes sbMvp to Finals MVP label', () => {
+    const seasons = [{
+      year: 2035,
+      awards: { sbMvp: { playerId: 7, name: 'Finals Hero', pos: 'QB' } },
+    }];
+    const rows = normalizeAwardsRows(seasons);
+    const sbMvp = rows.find((r) => r.awardKey === 'sbMvp');
+    expect(sbMvp?.awardLabel).toBe('Finals MVP');
+  });
+});
+
+describe('normalizeHofRows', () => {
+  it('returns empty array for null and empty inputs', () => {
+    expect(normalizeHofRows([], [])).toEqual([]);
+    expect(normalizeHofRows(null, null)).toEqual([]);
+    expect(normalizeHofRows(undefined, undefined)).toEqual([]);
+  });
+
+  it('normalizes an HOF inductee from classes with all fields', () => {
+    const hofClasses = [{
+      year: 2035,
+      classId: 'hof-2035',
+      inductees: [{
+        playerId: 'qb1',
+        name: 'Legend QB',
+        pos: 'QB',
+        primaryTeamAbbr: 'DAL',
+        legacyScore: 90,
+        tier: 'gold',
+        careerSummary: '3x MVP, 2 titles',
+      }],
+    }];
+    const rows = normalizeHofRows(hofClasses, []);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].playerName).toBe('Legend QB');
+    expect(rows[0].inductionYear).toBe(2035);
+    expect(rows[0].classLabel).toBe('Class of 2035');
+    expect(rows[0].legacyScore).toBe(90);
+    expect(rows[0].teamAbbr).toBe('DAL');
+    expect(rows[0].tier).toBe('gold');
+    expect(rows[0].careerSummary).toBe('3x MVP, 2 titles');
+  });
+
+  it('deduplicates a player appearing in both classes and players array', () => {
+    const hofClasses = [{
+      year: 2035,
+      classId: 'hof-2035',
+      inductees: [{ playerId: 'p1', name: 'Dual', pos: 'RB', legacyScore: 80 }],
+    }];
+    const hofPlayers = [{ playerId: 'p1', name: 'Dual', pos: 'RB' }];
+    const rows = normalizeHofRows(hofClasses, hofPlayers);
+    expect(rows.filter((r) => r.playerId === 'p1')).toHaveLength(1);
+  });
+
+  it('picks up players from hofPlayers array not in any class', () => {
+    const hofPlayers = [{ playerId: 'solo', name: 'Solo Star', pos: 'S', inductionYear: 2030 }];
+    const rows = normalizeHofRows([], hofPlayers);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].playerName).toBe('Solo Star');
+    expect(rows[0].classLabel).toBe('Class of 2030');
+  });
+
+  it('sorts newest class first, then by legacyScore descending within same year', () => {
+    const hofClasses = [
+      { year: 2030, inductees: [{ playerId: 'a', name: 'A', legacyScore: 70 }] },
+      {
+        year: 2035,
+        inductees: [
+          { playerId: 'b', name: 'B', legacyScore: 85 },
+          { playerId: 'c', name: 'C', legacyScore: 75 },
+        ],
+      },
+    ];
+    const rows = normalizeHofRows(hofClasses, []);
+    expect(rows[0].inductionYear).toBe(2035);
+    expect(rows[0].legacyScore).toBe(85);
+    expect(rows[1].legacyScore).toBe(75);
+    expect(rows[2].inductionYear).toBe(2030);
+  });
+
+  it('handles sparse inductee data without crashing', () => {
+    const hofClasses = [{ year: 2030, inductees: [{ playerId: 'x' }] }];
+    const rows = normalizeHofRows(hofClasses, []);
+    expect(rows[0].playerName).toBeNull();
+    expect(rows[0].position).toBeNull();
+    expect(rows[0].careerSummary).toBeNull();
+    expect(rows[0].classLabel).toBe('Class of 2030');
+  });
+
+  it('handles classes with no inductees array', () => {
+    const hofClasses = [{ year: 2032 }, { year: 2033, inductees: [] }];
+    expect(() => normalizeHofRows(hofClasses, [])).not.toThrow();
+    expect(normalizeHofRows(hofClasses, [])).toEqual([]);
+  });
+
+  it('uses score as fallback when legacyScore is absent', () => {
+    const hofClasses = [{
+      year: 2040,
+      inductees: [{ playerId: 'y', name: 'Score Fallback', pos: 'DE', score: 77 }],
+    }];
+    const rows = normalizeHofRows(hofClasses, []);
+    expect(rows[0].legacyScore).toBe(77);
+  });
+
+  it('produces classLabel Hall of Fame when inductionYear is null', () => {
+    const hofPlayers = [{ playerId: 'z', name: 'Ageless', pos: 'QB' }];
+    const rows = normalizeHofRows([], hofPlayers);
+    expect(rows[0].classLabel).toBe('Hall of Fame');
+  });
+});


### PR DESCRIPTION
- Add awardsHallOfFameViewModel.js: normalizeAwardsRows flattens
  archived season awards into sortable/filterable rows; normalizeHofRows
  flattens HOF classes + players into deduplicated inductee rows

- Upgrade AwardsHistory in LeagueHistory.jsx:
  - Filter chips: All / MVP / OPOY / DPOY / ROTY / Finals MVP / Champion
  - Search by player, team, year, position
  - Clickable player names call onPlayerSelect when playerId exists
  - Mobile-safe table (pos/team columns hidden on xs)
  - Clean empty state when no seasons archived

- Add HallOfFameSection tab in LeagueHistory.jsx:
  - Fetch getHallOfFame() alongside existing data loads; absent handler
    resolves to empty arrays so old saves and stub action objects are safe
  - Card grid with inductee name, pos, team, class year badge, tier, and
    career summary when available
  - Filter by position, class year, free-text search
  - Clickable inductee names call onPlayerSelect

- Add awardsHallOfFameViewModel.test.js: 17 unit tests covering
  normalizeAwardsRows and normalizeHofRows (sparse data, dedup, sorting,
  label mapping, empty/null inputs)

- Extend LeagueHistory.test.jsx: 14 new integration tests for the
  enhanced awards tab and HOF tab (filters, search, clicks, counts,
  empty states, graceful fallback without getHallOfFame)

No DB schema changes. No simulation logic changes.