### PR TITLE
feat: add League Leaders / Player Stats Browser V1 to LeagueHistory

### DIFF
--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -6,11 +6,21 @@ import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { buildCompletedGamePresentation, openResolvedBoxScore } from "../utils/boxScoreAccess.js";
 import { AWARD_DISPLAY_NAMES } from '../../core/footballMeta';
-import { buildLeagueHistoryTopPerformers } from '../../core/playerSeasonStatsArchive.js';
+import { buildLeagueHistoryTopPerformers, getArchivedPlayerSeasonRows } from '../../core/playerSeasonStatsArchive.js';
 import { normalizeArchivedMajorTransactions } from '../../core/transactionTimeline.js';
 import { buildShowingLabel, rowMatchesSearch, stableSortRows, uniqueFilterOptions } from "../utils/dataBrowser.js";
 import { buildLeagueRecordsRows, filterRecordRows, SCOPE_OPTIONS, CATEGORY_OPTIONS } from '../utils/leagueRecordsViewModel.js';
 import { normalizeAwardsRows, normalizeHofRows } from '../utils/awardsHallOfFameViewModel.js';
+import {
+  LEADER_CATEGORIES,
+  LEADER_STAT_DEFS,
+  DEFAULT_STAT_KEY,
+  normalizeCurrentSeasonRow,
+  normalizeArchivedLeaderRow,
+  buildLeagueLeadersRows,
+  filterLeaderRows,
+  getTopLeader,
+} from '../utils/leagueLeadersViewModel.js';
 
 const RECORD_LABELS = {
   passYd: "Passing Yards",
@@ -89,6 +99,7 @@ const TAB_GUIDE = [
   { value: "office", label: "League Office", cta: "Search league moves", desc: "Complete trade, signing, draft, and release transaction log." },
   { value: "draft", label: "Draft History", cta: "Draft history", desc: "Draft class archives and pick results by season." },
   { value: "compare", label: "Compare Players", cta: "Compare players", desc: "Side-by-side career stats and context across your player pool." },
+  { value: "leaders", label: "League Leaders", cta: "Browse leaders", desc: "Who leads the league in passing, rushing, receiving, defense, and kicking this season." },
 ];
 
 function buildSeasonArchiveSearchText(season) {
@@ -216,6 +227,7 @@ export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenB
           <TabsTrigger value="office">League Office</TabsTrigger>
           <TabsTrigger value="draft">Draft History</TabsTrigger>
           <TabsTrigger value="compare">Compare Players</TabsTrigger>
+          <TabsTrigger value="leaders">League Leaders</TabsTrigger>
         </TabsList>
 
         <TabsContent value="overview">
@@ -228,6 +240,7 @@ export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenB
             hofClasses={hofClasses}
             setActiveTab={setActiveTab}
             onPlayerSelect={onPlayerSelect}
+            allPlayers={allPlayers}
           />
         </TabsContent>
 
@@ -258,12 +271,16 @@ export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenB
         <TabsContent value="compare">
           <PlayerCompare actions={api} pool={allPlayers} onPlayerSelect={onPlayerSelect} />
         </TabsContent>
+
+        <TabsContent value="leaders">
+          <LeagueLeadersBrowser allPlayers={allPlayers} seasons={seasons} onPlayerSelect={onPlayerSelect} />
+        </TabsContent>
       </Tabs>
     </div>
   );
 }
 
-function OverviewDashboard({ seasons, records, recordBook, transactions, hofPlayers, hofClasses, setActiveTab, onPlayerSelect }) {
+function OverviewDashboard({ seasons, records, recordBook, transactions, hofPlayers, hofClasses, setActiveTab, onPlayerSelect, allPlayers }) {
   const v1RecordRows = useMemo(() => buildLeagueRecordsRows(recordBook), [recordBook]);
   const awardRows = useMemo(() => normalizeAwardsRows(seasons), [seasons]);
   const hofRows = useMemo(() => normalizeHofRows(hofClasses ?? [], hofPlayers ?? []), [hofClasses, hofPlayers]);
@@ -288,6 +305,13 @@ function OverviewDashboard({ seasons, records, recordBook, transactions, hofPlay
     () => (seasons ?? []).some((s) => Array.isArray(s?.draftResults) || Array.isArray(s?.draftClass)),
     [seasons],
   );
+  const statsNormalizedRows = useMemo(
+    () => (allPlayers ?? []).map(normalizeCurrentSeasonRow).filter(Boolean),
+    [allPlayers],
+  );
+  const passLeader = useMemo(() => getTopLeader(statsNormalizedRows, 'passYds'), [statsNormalizedRows]);
+  const rushLeader = useMemo(() => getTopLeader(statsNormalizedRows, 'rushYds'), [statsNormalizedRows]);
+  const recLeader = useMemo(() => getTopLeader(statsNormalizedRows, 'recYds'), [statsNormalizedRows]);
 
   if (!seasons?.length) {
     return (
@@ -513,6 +537,33 @@ function OverviewDashboard({ seasons, records, recordBook, transactions, hofPlay
             <div className="text-[color:var(--text-muted)]">
               {(seasons ?? []).filter((s) => Array.isArray(s?.draftResults) || Array.isArray(s?.draftClass)).length} season(s) with archived draft data.
             </div>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {/* Stats leaders teaser */}
+      {(passLeader || rushLeader || recLeader) ? (
+        <Card className="card-premium" data-testid="overview-stats-leaders-teaser">
+          <CardContent className="p-4">
+            <div className="text-xs font-bold uppercase tracking-wide text-[color:var(--text-subtle)] mb-2">Current Season Leaders</div>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm">
+              {[passLeader, rushLeader, recLeader].filter(Boolean).map((leader) => (
+                <div key={leader.statLabel}>
+                  <div className="text-xs text-[color:var(--text-muted)] uppercase tracking-wide mb-0.5">{leader.statLabel}</div>
+                  {leader.playerId != null ? (
+                    <button type="button" className="font-semibold text-[color:var(--accent)] text-left" onClick={() => onPlayerSelect?.(leader.playerId)}>
+                      {leader.playerName ?? '—'}
+                    </button>
+                  ) : (
+                    <span className="font-semibold">{leader.playerName ?? '—'}</span>
+                  )}
+                  <div className="text-xs text-[color:var(--text-muted)]">{leader.displayValue}{leader.teamAbbr ? ` · ${leader.teamAbbr}` : ''}</div>
+                </div>
+              ))}
+            </div>
+            <button type="button" className="mt-3 text-xs text-[color:var(--accent)]" onClick={() => setActiveTab('leaders')}>
+              See full leaders board →
+            </button>
           </CardContent>
         </Card>
       ) : null}
@@ -1997,4 +2048,153 @@ function formatNumber(v) {
   if (v == null) return "—";
   if (typeof v === "number") return Number.isInteger(v) ? v.toLocaleString() : v.toFixed(1);
   return String(v);
+}
+
+function LeagueLeadersBrowser({ allPlayers, seasons, onPlayerSelect }) {
+  const [category, setCategory] = useState('Passing');
+  const [statKey, setStatKey] = useState(DEFAULT_STAT_KEY.Passing);
+  const [search, setSearch] = useState('');
+  const [sortDir, setSortDir] = useState('desc');
+
+  const normalizedRows = useMemo(() => {
+    if (allPlayers?.length) {
+      return allPlayers.map(normalizeCurrentSeasonRow).filter(Boolean);
+    }
+    const latestSeason = [...(seasons ?? [])].sort((a, b) => (b?.year ?? 0) - (a?.year ?? 0))[0];
+    if (!latestSeason) return [];
+    return getArchivedPlayerSeasonRows(latestSeason).map(normalizeArchivedLeaderRow).filter(Boolean);
+  }, [allPlayers, seasons]);
+
+  const leadersByCategory = useMemo(() => buildLeagueLeadersRows(normalizedRows), [normalizedRows]);
+
+  const statDefs = useMemo(() => LEADER_STAT_DEFS.filter((d) => d.category === category), [category]);
+
+  useEffect(() => {
+    setStatKey(DEFAULT_STAT_KEY[category] ?? statDefs[0]?.statKey ?? '');
+    setSearch('');
+  }, [category, statDefs]);
+
+  const baseRows = leadersByCategory[category]?.[statKey] ?? [];
+  const filteredRows = useMemo(() => filterLeaderRows(baseRows, search), [baseRows, search]);
+  const rows = useMemo(
+    () => (sortDir === 'desc' ? filteredRows : [...filteredRows].reverse()),
+    [filteredRows, sortDir],
+  );
+
+  const currentStatLabel = statDefs.find((d) => d.statKey === statKey)?.statLabel ?? '—';
+
+  if (!normalizedRows.length) {
+    return (
+      <div data-testid="league-leaders-empty" className="py-10 text-center text-[color:var(--text-muted)]">
+        <div className="font-semibold text-[color:var(--text)]">League leaders will populate once games are played.</div>
+        <div className="mt-2 text-sm">Stats build as games complete each week.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3" data-testid="league-leaders-browser">
+      <div className="flex flex-wrap gap-2 items-center" role="group" aria-label="Stat category filter">
+        {LEADER_CATEGORIES.map((cat) => (
+          <button
+            key={cat}
+            type="button"
+            aria-pressed={category === cat}
+            className={`rounded-full px-3 py-1 text-sm border transition-colors ${
+              category === cat
+                ? 'bg-[color:var(--accent)] text-white border-[color:var(--accent)]'
+                : 'border-[color:var(--hairline)] bg-[color:var(--surface)] text-[color:var(--text)]'
+            }`}
+            onClick={() => setCategory(cat)}
+          >
+            {cat}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+        <select
+          aria-label="Select stat"
+          className="h-9 min-w-[160px] rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-2 text-sm"
+          value={statKey}
+          onChange={(e) => setStatKey(e.target.value)}
+        >
+          {statDefs.map((d) => (
+            <option key={d.statKey} value={d.statKey}>{d.statLabel}</option>
+          ))}
+        </select>
+        <input
+          aria-label="Search league leaders"
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search player, team, position…"
+          className="h-9 flex-1 min-w-[180px] rounded-md border border-[color:var(--hairline)] bg-[color:var(--surface)] px-3 text-sm"
+        />
+        {search ? (
+          <button type="button" className="btn btn-secondary h-9 text-sm" onClick={() => setSearch('')}>Clear</button>
+        ) : null}
+      </div>
+
+      <div data-testid="league-leaders-count" className="text-xs text-[color:var(--text-muted)]">
+        {buildShowingLabel(rows.length, baseRows.length, 'leader')}
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="rounded-md border border-[color:var(--hairline)] px-4 py-8 text-center text-sm text-[color:var(--text-muted)]">
+          No players match this filter.
+        </div>
+      ) : (
+        <Card className="card-premium">
+          <CardContent className="p-0">
+            <ScrollArea className="h-[560px]">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="pl-4 w-12">Rank</TableHead>
+                    <TableHead>Player</TableHead>
+                    <TableHead className="hidden sm:table-cell">Pos</TableHead>
+                    <TableHead className="hidden sm:table-cell">Team</TableHead>
+                    <TableHead className="text-right pr-4">
+                      <button
+                        type="button"
+                        onClick={() => setSortDir((d) => (d === 'desc' ? 'asc' : 'desc'))}
+                        aria-label={`Sort by ${currentStatLabel}`}
+                      >
+                        {currentStatLabel}{sortDir === 'desc' ? ' ↓' : ' ↑'}
+                      </button>
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {rows.map((row) => (
+                    <TableRow key={row.id} data-testid={`leader-row-${row.id}`}>
+                      <TableCell className="pl-4 font-semibold tabular-nums">{row.rank}</TableCell>
+                      <TableCell>
+                        {row.playerId != null ? (
+                          <button
+                            type="button"
+                            data-testid={`leader-player-btn-${row.id}`}
+                            className="text-left font-semibold text-[color:var(--accent)] hover:underline"
+                            onClick={() => onPlayerSelect?.(row.playerId)}
+                          >
+                            {row.playerName ?? '—'}
+                          </button>
+                        ) : (
+                          <span className="font-semibold">{row.playerName ?? '—'}</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="hidden sm:table-cell text-xs">{row.pos ?? '—'}</TableCell>
+                      <TableCell className="hidden sm:table-cell text-xs">{row.teamAbbr ?? '—'}</TableCell>
+                      <TableCell className="text-right pr-4 font-semibold tabular-nums">{row.displayValue}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </ScrollArea>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
 }

--- a/src/ui/components/__tests__/LeagueHistory.test.jsx
+++ b/src/ui/components/__tests__/LeagueHistory.test.jsx
@@ -1157,4 +1157,181 @@ describe('Overview Dashboard', () => {
       expect(screen.getByTestId('league-season-button-s1')).toBeTruthy();
     });
   });
+
+  it('League Leaders tab renders and shows leader rows from allPlayers stats', async () => {
+    const onPlayerSelect = vi.fn();
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        onPlayerSelect={onPlayerSelect}
+        onOpenBoxScore={vi.fn()}
+        actions={makeActions({
+          getAllPlayerStats: vi.fn().mockResolvedValue({
+            payload: {
+              stats: [
+                {
+                  id: 101,
+                  name: 'QB Leader',
+                  pos: 'QB',
+                  teamId: 1,
+                  teamAbbr: 'TST',
+                  totals: { passYd: 3200, passTD: 25, interceptions: 8, gamesPlayed: 12 },
+                },
+                {
+                  id: 102,
+                  name: 'RB Leader',
+                  pos: 'RB',
+                  teamId: 2,
+                  teamAbbr: 'RUN',
+                  totals: { rushYd: 1100, rushTD: 9, gamesPlayed: 12 },
+                },
+              ],
+            },
+          }),
+        })}
+      />,
+    );
+
+    const leadersTab = await screen.findByRole('tab', { name: /League Leaders/i });
+    fireEvent.mouseDown(leadersTab);
+    fireEvent.click(leadersTab);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('league-leaders-browser')).toBeTruthy();
+      expect(screen.getByText('QB Leader')).toBeTruthy();
+    });
+  });
+
+  it('League Leaders tab shows empty state when no player stats exist', async () => {
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={makeActions({
+          getAllPlayerStats: vi.fn().mockResolvedValue({ payload: { stats: [] } }),
+          getAllSeasons: vi.fn().mockResolvedValue({ payload: { seasons: [] } }),
+        })}
+      />,
+    );
+
+    const leadersTab = await screen.findByRole('tab', { name: /League Leaders/i });
+    fireEvent.mouseDown(leadersTab);
+    fireEvent.click(leadersTab);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('league-leaders-empty')).toBeTruthy();
+      expect(screen.getByTestId('league-leaders-empty').textContent).toMatch(
+        /League leaders will populate once games are played/i,
+      );
+    });
+  });
+
+  it('clicking a player name in the leaders table calls onPlayerSelect', async () => {
+    const onPlayerSelect = vi.fn();
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        onPlayerSelect={onPlayerSelect}
+        onOpenBoxScore={vi.fn()}
+        actions={makeActions({
+          getAllPlayerStats: vi.fn().mockResolvedValue({
+            payload: {
+              stats: [
+                {
+                  id: 55,
+                  name: 'Click Me',
+                  pos: 'QB',
+                  teamId: 1,
+                  teamAbbr: 'CLK',
+                  totals: { passYd: 4000, passTD: 30, gamesPlayed: 16 },
+                },
+              ],
+            },
+          }),
+        })}
+      />,
+    );
+
+    const leadersTab = await screen.findByRole('tab', { name: /League Leaders/i });
+    fireEvent.mouseDown(leadersTab);
+    fireEvent.click(leadersTab);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('league-leaders-browser')).toBeTruthy();
+    });
+
+    const playerBtn = screen.getByTestId('leader-player-btn-passYds-0');
+    fireEvent.click(playerBtn);
+    expect(onPlayerSelect).toHaveBeenCalledWith(55);
+  });
+
+  it('overview teaser shows current season leaders when allPlayers has stats', async () => {
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={makeActions({
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: { seasons: [{ id: 's1', year: 2030, standings: [], awards: {} }] },
+          }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({
+            payload: {
+              stats: [
+                {
+                  id: 10,
+                  name: 'Pass Leader',
+                  pos: 'QB',
+                  teamId: 1,
+                  teamAbbr: 'PAS',
+                  totals: { passYd: 3500, gamesPlayed: 10 },
+                },
+              ],
+            },
+          }),
+        })}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('overview-stats-leaders-teaser')).toBeTruthy();
+      expect(screen.getByText('Pass Leader')).toBeTruthy();
+    });
+  });
+
+  it('overview CTA for leaders tab switches to leaders view', async () => {
+    render(
+      <LeagueHistory
+        league={{ userTeamId: 1 }}
+        onPlayerSelect={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+        actions={makeActions({
+          getAllSeasons: vi.fn().mockResolvedValue({
+            payload: { seasons: [{ id: 's1', year: 2030, standings: [], awards: {} }] },
+          }),
+          getAllPlayerStats: vi.fn().mockResolvedValue({
+            payload: {
+              stats: [
+                {
+                  id: 20,
+                  name: 'Leaders Player',
+                  pos: 'QB',
+                  teamId: 1,
+                  teamAbbr: 'XYZ',
+                  totals: { passYd: 2800, gamesPlayed: 8 },
+                },
+              ],
+            },
+          }),
+        })}
+      />,
+    );
+
+    const cta = await screen.findByTestId('overview-cta-leaders');
+    fireEvent.click(cta);
+    await waitFor(() => {
+      expect(screen.getByTestId('league-leaders-browser')).toBeTruthy();
+    });
+  });
 });

--- a/src/ui/utils/leagueLeadersViewModel.js
+++ b/src/ui/utils/leagueLeadersViewModel.js
@@ -1,0 +1,190 @@
+/**
+ * leagueLeadersViewModel.js
+ * Builds filterable league leaders / player stats from current-season or
+ * archived player stat rows. Pure helpers; safe on null/partial/legacy data.
+ */
+
+const DEFENSIVE_POS = new Set(['DL', 'DE', 'DT', 'EDGE', 'LB', 'CB', 'S', 'SS', 'FS']);
+
+function num(v) {
+  const n = Number(v ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function readMulti(obj, keys) {
+  if (!obj || typeof obj !== 'object') return 0;
+  for (const k of keys) {
+    const v = num(obj[k]);
+    if (v !== 0) return v;
+  }
+  return 0;
+}
+
+function defIntsFromTotals(pos, totals) {
+  const t = totals ?? {};
+  const p = String(pos ?? '').toUpperCase();
+  const explicit = readMulti(t, ['defInterceptions', 'interceptionsDef', 'interceptionsMade']);
+  if (explicit > 0) return explicit;
+  if (DEFENSIVE_POS.has(p)) return readMulti(t, ['interceptions']);
+  return 0;
+}
+
+export const LEADER_CATEGORIES = ['Passing', 'Rushing', 'Receiving', 'Defense', 'Kicking'];
+
+export const LEADER_STAT_DEFS = [
+  { category: 'Passing',   statKey: 'passYds',    statLabel: 'Pass Yds',   pick: (r) => r.passYds },
+  { category: 'Passing',   statKey: 'passTDs',    statLabel: 'Pass TD',    pick: (r) => r.passTDs },
+  { category: 'Passing',   statKey: 'passInts',   statLabel: 'INT Thrown', pick: (r) => r.passInts },
+  { category: 'Rushing',   statKey: 'rushYds',    statLabel: 'Rush Yds',   pick: (r) => r.rushYds },
+  { category: 'Rushing',   statKey: 'rushTDs',    statLabel: 'Rush TD',    pick: (r) => r.rushTDs },
+  { category: 'Receiving', statKey: 'recYds',     statLabel: 'Rec Yds',    pick: (r) => r.recYds },
+  { category: 'Receiving', statKey: 'recTDs',     statLabel: 'Rec TD',     pick: (r) => r.recTDs },
+  { category: 'Receiving', statKey: 'receptions', statLabel: 'Receptions', pick: (r) => r.receptions },
+  { category: 'Defense',   statKey: 'tackles',    statLabel: 'Tackles',    pick: (r) => r.tackles },
+  { category: 'Defense',   statKey: 'sacks',      statLabel: 'Sacks',      pick: (r) => r.sacks },
+  { category: 'Defense',   statKey: 'defInts',    statLabel: 'INT',        pick: (r) => r.defInts },
+  { category: 'Kicking',   statKey: 'fgMade',     statLabel: 'FG Made',    pick: (r) => r.fgMade },
+  { category: 'Kicking',   statKey: 'xpMade',     statLabel: 'XP Made',    pick: (r) => r.xpMade },
+];
+
+export const DEFAULT_STAT_KEY = {
+  Passing: 'passYds',
+  Rushing: 'rushYds',
+  Receiving: 'recYds',
+  Defense: 'tackles',
+  Kicking: 'fgMade',
+};
+
+/** Normalize a current-season player row (from getAllPlayerStats totals) to shared stat shape. */
+export function normalizeCurrentSeasonRow(player) {
+  if (!player || typeof player !== 'object') return null;
+  const totals = player.totals && typeof player.totals === 'object' ? player.totals : {};
+  const playerId = player.playerId ?? player.id ?? null;
+  if (playerId == null) return null;
+  const pos = String(player.pos ?? '');
+  const isQB = pos.toUpperCase() === 'QB';
+  return {
+    playerId,
+    playerName: player.name ?? player.playerName ?? null,
+    pos,
+    teamId: player.teamId != null ? Number(player.teamId) : null,
+    teamAbbr: player.teamAbbr ?? null,
+    gamesPlayed: num(totals.gamesPlayed),
+    passYds: readMulti(totals, ['passYd', 'passingYards', 'passYds']),
+    passTDs: readMulti(totals, ['passTD', 'passTDs', 'passingTd', 'passingTDs']),
+    passInts: isQB ? readMulti(totals, ['interceptions', 'passInts', 'ints']) : 0,
+    rushYds: readMulti(totals, ['rushYd', 'rushingYards', 'rushYds']),
+    rushTDs: readMulti(totals, ['rushTD', 'rushTDs', 'rushingTd', 'rushingTDs']),
+    recYds: readMulti(totals, ['recYd', 'receivingYards', 'recYds']),
+    recTDs: readMulti(totals, ['recTD', 'recTDs', 'receivingTd', 'receivingTDs']),
+    receptions: readMulti(totals, ['receptions', 'rec', 'catches']),
+    tackles: readMulti(totals, ['tackles', 'totalTackles']),
+    sacks: readMulti(totals, ['sacks']),
+    defInts: defIntsFromTotals(pos, totals),
+    fgMade: readMulti(totals, ['fgMade', 'fieldGoalsMade', 'fgm']),
+    xpMade: readMulti(totals, ['xpMade', 'extraPointsMade', 'patMade', 'xpm']),
+  };
+}
+
+/** Normalize an archived stat row (playerSeasonStatsV1) to shared stat shape. */
+export function normalizeArchivedLeaderRow(row) {
+  if (!row || typeof row !== 'object') return null;
+  if (row.playerId == null) return null;
+  return {
+    playerId: row.playerId,
+    playerName: row.playerName ?? null,
+    pos: String(row.pos ?? ''),
+    teamId: row.teamId != null ? Number(row.teamId) : null,
+    teamAbbr: row.teamAbbr ?? null,
+    gamesPlayed: num(row.gamesPlayed),
+    passYds: num(row.passYds),
+    passTDs: num(row.passTDs),
+    passInts: num(row.passInts),
+    rushYds: num(row.rushYds),
+    rushTDs: num(row.rushTDs),
+    recYds: num(row.recYds),
+    recTDs: num(row.recTDs),
+    receptions: 0,
+    tackles: num(row.tackles),
+    sacks: num(row.sacks),
+    defInts: num(row.defInts),
+    fgMade: num(row.fgMade),
+    xpMade: num(row.xpMade),
+  };
+}
+
+function formatDisplayValue(value) {
+  const n = num(value);
+  return Number.isInteger(n) ? n.toLocaleString() : n.toFixed(1);
+}
+
+/**
+ * Build league leaders by category and stat key.
+ * @param {Array} normalizedRows - Pre-normalized rows
+ * @param {{ topN?: number }} opts
+ * @returns {{ [category]: { [statKey]: leaderRow[] } }}
+ */
+export function buildLeagueLeadersRows(normalizedRows, { topN = 25 } = {}) {
+  const rows = Array.isArray(normalizedRows) ? normalizedRows.filter(Boolean) : [];
+  const result = {};
+  for (const def of LEADER_STAT_DEFS) {
+    const { category, statKey, statLabel, pick } = def;
+    if (!result[category]) result[category] = {};
+    const sorted = rows
+      .filter((r) => num(pick(r)) > 0)
+      .sort((a, b) => {
+        const diff = num(pick(b)) - num(pick(a));
+        if (diff !== 0) return diff;
+        return String(a.playerName ?? '').localeCompare(String(b.playerName ?? ''));
+      });
+    result[category][statKey] = sorted.slice(0, topN).map((r, i) => ({
+      id: `${statKey}-${i}`,
+      playerId: r.playerId,
+      playerName: r.playerName,
+      pos: r.pos,
+      teamId: r.teamId,
+      teamAbbr: r.teamAbbr,
+      category,
+      statKey,
+      statLabel,
+      value: num(pick(r)),
+      displayValue: formatDisplayValue(pick(r)),
+      rank: i + 1,
+    }));
+  }
+  return result;
+}
+
+/** Filter leader rows by free-text search (player name, team abbr, position). */
+export function filterLeaderRows(rows, search = '') {
+  const q = String(search ?? '').trim().toLowerCase();
+  if (!q) return rows ?? [];
+  return (rows ?? []).filter(
+    (r) =>
+      (r.playerName ?? '').toLowerCase().includes(q) ||
+      (r.teamAbbr ?? '').toLowerCase().includes(q) ||
+      (r.pos ?? '').toLowerCase().includes(q),
+  );
+}
+
+/** Return the top leader row for a given statKey, or null if no data. */
+export function getTopLeader(normalizedRows, statKey) {
+  const def = LEADER_STAT_DEFS.find((d) => d.statKey === statKey);
+  if (!def) return null;
+  const { pick } = def;
+  const valid = (Array.isArray(normalizedRows) ? normalizedRows : []).filter(
+    (r) => r && num(pick(r)) > 0,
+  );
+  if (!valid.length) return null;
+  valid.sort((a, b) => num(pick(b)) - num(pick(a)));
+  const r = valid[0];
+  return {
+    playerId: r.playerId,
+    playerName: r.playerName,
+    pos: r.pos,
+    teamAbbr: r.teamAbbr,
+    statLabel: def.statLabel,
+    value: num(pick(r)),
+    displayValue: formatDisplayValue(pick(r)),
+  };
+}

--- a/src/ui/utils/leagueLeadersViewModel.test.js
+++ b/src/ui/utils/leagueLeadersViewModel.test.js
@@ -1,0 +1,304 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildLeagueLeadersRows,
+  normalizeCurrentSeasonRow,
+  normalizeArchivedLeaderRow,
+  filterLeaderRows,
+  getTopLeader,
+  LEADER_CATEGORIES,
+  LEADER_STAT_DEFS,
+} from './leagueLeadersViewModel.js';
+
+function makeNormalized(overrides = {}) {
+  return {
+    playerId: 1,
+    playerName: 'Test Player',
+    pos: 'QB',
+    teamId: 10,
+    teamAbbr: 'TST',
+    gamesPlayed: 10,
+    passYds: 3000,
+    passTDs: 25,
+    passInts: 8,
+    rushYds: 0,
+    rushTDs: 0,
+    recYds: 0,
+    recTDs: 0,
+    receptions: 0,
+    tackles: 0,
+    sacks: 0,
+    defInts: 0,
+    fgMade: 0,
+    xpMade: 0,
+    ...overrides,
+  };
+}
+
+describe('leagueLeadersViewModel', () => {
+  describe('buildLeagueLeadersRows', () => {
+    it('builds passing leaders from normalized rows', () => {
+      const rows = [makeNormalized({ passYds: 3000, passTDs: 25 })];
+      const result = buildLeagueLeadersRows(rows);
+      expect(result.Passing.passYds).toHaveLength(1);
+      expect(result.Passing.passYds[0].value).toBe(3000);
+      expect(result.Passing.passYds[0].rank).toBe(1);
+      expect(result.Passing.passYds[0].statLabel).toBe('Pass Yds');
+    });
+
+    it('skips zero values', () => {
+      const rows = [makeNormalized({ passYds: 0, passTDs: 0 })];
+      const result = buildLeagueLeadersRows(rows);
+      expect(result.Passing.passYds).toHaveLength(0);
+    });
+
+    it('handles null/undefined/empty rows without crashing', () => {
+      expect(() => buildLeagueLeadersRows([null, undefined, {}, { playerId: 1 }])).not.toThrow();
+    });
+
+    it('builds rushing leaders', () => {
+      const rows = [makeNormalized({ playerId: 2, rushYds: 1200, rushTDs: 10, pos: 'RB' })];
+      const result = buildLeagueLeadersRows(rows);
+      expect(result.Rushing.rushYds).toHaveLength(1);
+      expect(result.Rushing.rushYds[0].value).toBe(1200);
+      expect(result.Rushing.rushTDs[0].value).toBe(10);
+    });
+
+    it('builds receiving leaders', () => {
+      const rows = [makeNormalized({ playerId: 3, recYds: 900, recTDs: 7, receptions: 80, pos: 'WR' })];
+      const result = buildLeagueLeadersRows(rows);
+      expect(result.Receiving.recYds[0].value).toBe(900);
+      expect(result.Receiving.recTDs[0].value).toBe(7);
+      expect(result.Receiving.receptions[0].value).toBe(80);
+    });
+
+    it('builds defense leaders', () => {
+      const rows = [makeNormalized({ playerId: 4, tackles: 90, sacks: 12, defInts: 5, pos: 'LB' })];
+      const result = buildLeagueLeadersRows(rows);
+      expect(result.Defense.tackles[0].value).toBe(90);
+      expect(result.Defense.sacks[0].value).toBe(12);
+      expect(result.Defense.defInts[0].value).toBe(5);
+    });
+
+    it('builds kicking leaders', () => {
+      const rows = [makeNormalized({ playerId: 5, fgMade: 25, xpMade: 30, pos: 'K' })];
+      const result = buildLeagueLeadersRows(rows);
+      expect(result.Kicking.fgMade[0].value).toBe(25);
+      expect(result.Kicking.xpMade[0].value).toBe(30);
+    });
+
+    it('sorts deterministically: desc by value then alpha by name', () => {
+      const rows = [
+        makeNormalized({ playerId: 2, playerName: 'B Player', passYds: 2000 }),
+        makeNormalized({ playerId: 1, playerName: 'A Player', passYds: 3000 }),
+      ];
+      const result = buildLeagueLeadersRows(rows);
+      expect(result.Passing.passYds[0].playerName).toBe('A Player');
+      expect(result.Passing.passYds[1].playerName).toBe('B Player');
+    });
+
+    it('tie-breaks alphabetically by player name', () => {
+      const rows = [
+        makeNormalized({ playerId: 2, playerName: 'Zara', passYds: 1000 }),
+        makeNormalized({ playerId: 1, playerName: 'Aaron', passYds: 1000 }),
+      ];
+      const result = buildLeagueLeadersRows(rows);
+      expect(result.Passing.passYds[0].playerName).toBe('Aaron');
+    });
+
+    it('respects topN limit', () => {
+      const rows = Array.from({ length: 30 }, (_, i) =>
+        makeNormalized({ playerId: i, passYds: 1000 + i }),
+      );
+      const result = buildLeagueLeadersRows(rows, { topN: 5 });
+      expect(result.Passing.passYds).toHaveLength(5);
+    });
+
+    it('produces all expected categories', () => {
+      const result = buildLeagueLeadersRows([]);
+      for (const cat of LEADER_CATEGORIES) {
+        expect(result[cat]).toBeDefined();
+      }
+    });
+
+    it('assigns sequential ranks starting at 1', () => {
+      const rows = [
+        makeNormalized({ playerId: 1, passYds: 3000 }),
+        makeNormalized({ playerId: 2, passYds: 2000 }),
+      ];
+      const result = buildLeagueLeadersRows(rows);
+      expect(result.Passing.passYds[0].rank).toBe(1);
+      expect(result.Passing.passYds[1].rank).toBe(2);
+    });
+  });
+
+  describe('normalizeCurrentSeasonRow', () => {
+    it('normalizes player with totals (passYd alias)', () => {
+      const player = {
+        id: 1,
+        name: 'Test QB',
+        pos: 'QB',
+        teamId: 10,
+        teamAbbr: 'TST',
+        totals: { passYd: 4000, passTD: 30, interceptions: 10 },
+      };
+      const row = normalizeCurrentSeasonRow(player);
+      expect(row.passYds).toBe(4000);
+      expect(row.passTDs).toBe(30);
+      expect(row.passInts).toBe(10);
+    });
+
+    it('returns null for player without id', () => {
+      expect(normalizeCurrentSeasonRow({})).toBeNull();
+      expect(normalizeCurrentSeasonRow(null)).toBeNull();
+      expect(normalizeCurrentSeasonRow(undefined)).toBeNull();
+    });
+
+    it('handles missing totals gracefully with zero stats', () => {
+      const row = normalizeCurrentSeasonRow({ id: 1, name: 'X', pos: 'QB' });
+      expect(row).not.toBeNull();
+      expect(row.passYds).toBe(0);
+      expect(row.rushYds).toBe(0);
+    });
+
+    it('non-QB position does not use interceptions as passInts', () => {
+      const player = {
+        id: 2,
+        name: 'LB',
+        pos: 'LB',
+        teamId: 1,
+        teamAbbr: 'X',
+        totals: { interceptions: 5 },
+      };
+      const row = normalizeCurrentSeasonRow(player);
+      expect(row.passInts).toBe(0);
+      expect(row.defInts).toBe(5);
+    });
+
+    it('reads playerId alias fields (playerId vs id)', () => {
+      const row = normalizeCurrentSeasonRow({ playerId: 99, name: 'Y', pos: 'RB', totals: {} });
+      expect(row.playerId).toBe(99);
+    });
+  });
+
+  describe('normalizeArchivedLeaderRow', () => {
+    it('normalizes archived row fields', () => {
+      const row = {
+        playerId: 1,
+        playerName: 'Old Player',
+        pos: 'RB',
+        teamAbbr: 'OAK',
+        passYds: 0,
+        rushYds: 1100,
+        rushTDs: 8,
+        tackles: 0,
+        defInts: 0,
+        fgMade: 0,
+        xpMade: 0,
+      };
+      const normalized = normalizeArchivedLeaderRow(row);
+      expect(normalized.rushYds).toBe(1100);
+      expect(normalized.rushTDs).toBe(8);
+      expect(normalized.receptions).toBe(0);
+      expect(normalized.teamAbbr).toBe('OAK');
+    });
+
+    it('returns null for row without playerId', () => {
+      expect(normalizeArchivedLeaderRow({ playerName: 'X' })).toBeNull();
+    });
+
+    it('handles null/undefined without crashing', () => {
+      expect(normalizeArchivedLeaderRow(null)).toBeNull();
+      expect(normalizeArchivedLeaderRow(undefined)).toBeNull();
+    });
+
+    it('coerces NaN/non-numeric values to 0', () => {
+      const row = { playerId: 1, rushYds: 'bad', tackles: NaN, fgMade: null };
+      const normalized = normalizeArchivedLeaderRow(row);
+      expect(normalized.rushYds).toBe(0);
+      expect(normalized.tackles).toBe(0);
+      expect(normalized.fgMade).toBe(0);
+    });
+  });
+
+  describe('filterLeaderRows', () => {
+    const rows = [
+      { id: '1', playerName: 'Tom Brady', pos: 'QB', teamAbbr: 'NE', value: 5000, rank: 1 },
+      { id: '2', playerName: 'Adrian Peterson', pos: 'RB', teamAbbr: 'MIN', value: 2000, rank: 2 },
+    ];
+
+    it('returns all rows when search is empty', () => {
+      expect(filterLeaderRows(rows, '')).toHaveLength(2);
+      expect(filterLeaderRows(rows)).toHaveLength(2);
+    });
+
+    it('filters by player name (case-insensitive)', () => {
+      expect(filterLeaderRows(rows, 'brady')).toHaveLength(1);
+      expect(filterLeaderRows(rows, 'BRADY')).toHaveLength(1);
+    });
+
+    it('filters by team abbr', () => {
+      expect(filterLeaderRows(rows, 'MIN')).toHaveLength(1);
+    });
+
+    it('filters by position', () => {
+      expect(filterLeaderRows(rows, 'RB')).toHaveLength(1);
+    });
+
+    it('returns empty array when no match', () => {
+      expect(filterLeaderRows(rows, 'zzz')).toHaveLength(0);
+    });
+
+    it('handles null/undefined rows gracefully', () => {
+      expect(() => filterLeaderRows(null, 'x')).not.toThrow();
+      expect(filterLeaderRows(null, 'x')).toEqual([]);
+    });
+  });
+
+  describe('getTopLeader', () => {
+    it('returns the top leader for a stat key', () => {
+      const rows = [
+        makeNormalized({ playerId: 1, playerName: 'A', passYds: 3000 }),
+        makeNormalized({ playerId: 2, playerName: 'B', passYds: 4000 }),
+      ];
+      const leader = getTopLeader(rows, 'passYds');
+      expect(leader.value).toBe(4000);
+      expect(leader.playerName).toBe('B');
+      expect(leader.statLabel).toBe('Pass Yds');
+    });
+
+    it('returns null when no rows have non-zero values', () => {
+      expect(getTopLeader([makeNormalized({ passYds: 0 })], 'passYds')).toBeNull();
+    });
+
+    it('returns null for empty rows array', () => {
+      expect(getTopLeader([], 'passYds')).toBeNull();
+    });
+
+    it('returns null for unknown stat key', () => {
+      expect(getTopLeader([makeNormalized()], 'unknownKey')).toBeNull();
+    });
+
+    it('includes displayValue in result', () => {
+      const rows = [makeNormalized({ passYds: 3500 })];
+      const leader = getTopLeader(rows, 'passYds');
+      expect(leader.displayValue).toBe('3,500');
+    });
+  });
+
+  describe('LEADER_STAT_DEFS coverage', () => {
+    it('covers all expected categories', () => {
+      const cats = new Set(LEADER_STAT_DEFS.map((d) => d.category));
+      for (const expected of ['Passing', 'Rushing', 'Receiving', 'Defense', 'Kicking']) {
+        expect(cats.has(expected)).toBe(true);
+      }
+    });
+
+    it('every def has statKey, statLabel, and pick function', () => {
+      for (const def of LEADER_STAT_DEFS) {
+        expect(typeof def.statKey).toBe('string');
+        expect(typeof def.statLabel).toBe('string');
+        expect(typeof def.pick).toBe('function');
+      }
+    });
+  });
+});


### PR DESCRIPTION
Adds a new League Leaders tab to LeagueHistory with category filter
(Passing/Rushing/Receiving/Defense/Kicking), stat selector, player search,
sortable leader table with onPlayerSelect, and a no-stats empty state.

Overview dashboard gets a compact Current Season Leaders teaser showing
the top pass-yards, rush-yards, and rec-yards leaders when allPlayers data
is available.

New utility: src/ui/utils/leagueLeadersViewModel.js
- normalizeCurrentSeasonRow: converts getAllPlayerStats rows (totals-keyed)
- normalizeArchivedLeaderRow: converts playerSeasonStatsV1 rows
- buildLeagueLeadersRows: top-N leaders per category/stat, zero-skipped
- filterLeaderRows: free-text search on name/team/position
- getTopLeader: single-leader lookup for overview teaser

Data sources: allPlayers (getAllPlayerStats) for current season; falls
back to most recent archived playerSeasonStatsV1.rows when no active
stats exist. No DB schema changes. No fake stats.

Tests: 34 view-model unit tests + 6 LeagueHistory component tests.
All 1038 tests pass; build passes.