### PR TITLE
feat: Weekly Matchup Intelligence — coordinator brief + priority actions

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -330,12 +330,42 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
         </SectionCard>
       ) : null}
 
-      <SectionCard title={command.weeklyIntelligence?.heading ?? 'Coordinator Brief'} subtitle="Matchup intel for this week’s decision loop." variant="compact">
+      <SectionCard title={command.weeklyIntelligence?.heading ?? 'Coordinator Brief'} subtitle="Matchup intel and priority actions for this week." variant="compact">
         <div className="app-hq-intel-list" role="list" aria-label="Weekly intelligence">
           {weeklyIntel.map((insight) => (
             <p key={insight.id} role="listitem" className={`app-hq-intel-item tone-${insight.tone ?? 'info'}`}>{insight.text}</p>
           ))}
         </div>
+        {(command.weeklyAgenda ?? []).length > 0 ? (
+          <div className="app-hq-weekly-priorities" role="list" aria-label="Weekly priorities" style={{ marginTop: 10 }}>
+            {(command.weeklyAgenda ?? []).map((item) => (
+              <article
+                key={item.id}
+                role="listitem"
+                className={`app-hq-impact-card tone-${item.severity === 'warning' ? 'warning' : 'info'}`}
+                style={{ display: 'flex', alignItems: 'flex-start', gap: 10, marginBottom: 8 }}
+              >
+                {item.icon ? <span aria-hidden="true" style={{ fontSize: 18, lineHeight: 1.4 }}>{item.icon}</span> : null}
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div className="app-hq-impact-card__head">
+                    <strong>{item.title}</strong>
+                    {item.severity === 'warning' ? <StatusChip label="Attention" tone="warning" /> : null}
+                  </div>
+                  <p style={{ margin: '2px 0 6px' }}>{item.description}</p>
+                  <button
+                    type="button"
+                    className="btn btn-sm app-hq-impact-card__cta"
+                    onClick={() => item.targetRoute && onNavigate?.(item.targetRoute)}
+                    disabled={!item.targetRoute}
+                    aria-label={`${item.title}: ${item.ctaLabel}`}
+                  >
+                    {item.ctaLabel}
+                  </button>
+                </div>
+              </article>
+            ))}
+          </div>
+        ) : null}
       </SectionCard>
 
 

--- a/src/ui/components/WeeklyHub.jsx
+++ b/src/ui/components/WeeklyHub.jsx
@@ -9,6 +9,8 @@ import { buildIncomingOfferPresentation } from "../utils/tradeOfferPresentation.
 import { buildNeedsAttentionItems, buildPrimaryAction } from "../utils/weeklyHubLayout.js";
 import { findLatestUserCompletedGame } from "../utils/completedGameSelectors.js";
 import { buildCompletedGamePresentation } from "../utils/boxScoreAccess.js";
+import { buildWeeklyIntelligence, buildActionableWeeklyPriorities } from "../utils/weeklyIntelligence.js";
+import { deriveWeeklyPrepState } from "../utils/weeklyPrep.js";
 
 function getUserTeam(league) {
   return league?.teams?.find((t) => t.id === league?.userTeamId) ?? null;
@@ -53,6 +55,9 @@ export default function WeeklyHub({ league, onNavigate, onAdvanceWeek, busy, sim
   const weeklyContext = useMemo(() => evaluateWeeklyContext(league), [league]);
   const latestCompletedGame = useMemo(() => findLatestUserCompletedGame(league), [league]);
   const latestResultPresentation = useMemo(() => buildCompletedGamePresentation(latestCompletedGame?.game ?? null, { seasonId: league?.seasonId, week: latestCompletedGame?.week, source: "weekly_hub_last_game" }), [league?.seasonId, latestCompletedGame]);
+  const prep = useMemo(() => deriveWeeklyPrepState(league), [league]);
+  const matchupIntel = useMemo(() => buildWeeklyIntelligence({ league, team: user, nextGame, prep }), [league, user, nextGame, prep]);
+  const matchupPriorities = useMemo(() => buildActionableWeeklyPriorities({ team: user, nextGame, prep }), [user, nextGame, prep]);
 
   if (!league || !user || !weeklyContext) return null;
 
@@ -206,6 +211,41 @@ export default function WeeklyHub({ league, onNavigate, onAdvanceWeek, busy, sim
           </Card>
         </div>
       </section>
+
+      <details className="weekly-expandable" open>
+        <summary className="weekly-expandable__summary">
+          <div>
+            <h3 className="weekly-section__title">{matchupIntel.heading}</h3>
+            <p className="weekly-section__subtitle">Coordinator brief and priority actions for this week.</p>
+          </div>
+          <span className="weekly-expandable__chevron">▾</span>
+        </summary>
+        <div className="weekly-expandable__body">
+          <div className="weekly-intel-insights" role="list" aria-label="Matchup intelligence insights">
+            {matchupIntel.insights.map((insight) => (
+              <div key={insight.id} role="listitem" className={`weekly-intel-insight tone-${insight.tone ?? 'info'}`}>
+                <span>{insight.text}</span>
+              </div>
+            ))}
+          </div>
+          {matchupPriorities.length > 0 ? (
+            <div className="weekly-intel-priorities" aria-label="Weekly priorities" style={{ marginTop: 8 }}>
+              {matchupPriorities.map((item) => (
+                <div key={item.id} className={`weekly-urgent-item tone-${item.severity === 'warning' ? 'warning' : 'info'}`} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, padding: '10px 12px' }}>
+                  {item.icon ? <span aria-hidden="true" style={{ fontSize: 18, flexShrink: 0 }}>{item.icon}</span> : null}
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <strong style={{ display: 'block' }}>{item.title}</strong>
+                    <span style={{ display: 'block', fontSize: '0.85em', opacity: 0.85, marginBottom: 6 }}>{item.description}</span>
+                    <Button size="sm" variant="outline" onClick={() => item.targetRoute && onNavigate?.(item.targetRoute)} disabled={!item.targetRoute}>
+                      {item.ctaLabel}
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </details>
 
       <section className="weekly-section">
         <SectionHeader title="Results" subtitle="One direct path to the latest completed game." />

--- a/src/ui/utils/weeklyIntelligence.test.js
+++ b/src/ui/utils/weeklyIntelligence.test.js
@@ -55,4 +55,94 @@ describe('buildActionableWeeklyPriorities', () => {
     expect(priorities.some((item) => item.title === 'Game Plan')).toBe(true);
     expect(priorities.some((item) => item.ctaLabel.startsWith('Open'))).toBe(true);
   });
+
+  it('returns at most 5 items', () => {
+    const extra = Array.from({ length: 10 }, (_, i) => ({ id: `extra-${i}`, title: `Extra ${i}`, detail: 'Detail', tab: 'HQ' }));
+    const priorities = buildActionableWeeklyPriorities({ team, nextGame: { opp: opponent }, prep: {}, weeklyAgenda: extra });
+    expect(priorities.length).toBeLessThanOrEqual(5);
+  });
+
+  it('deduplicates items with matching titles', () => {
+    const dupeAgenda = [
+      { id: 'a1', title: 'Training', detail: 'First', tab: 'Training' },
+      { id: 'a2', title: 'Training', detail: 'Duplicate', tab: 'Training' },
+    ];
+    const priorities = buildActionableWeeklyPriorities({ team, nextGame: { opp: opponent }, prep: {}, weeklyAgenda: dupeAgenda });
+    const trainingItems = priorities.filter((item) => item.title === 'Training');
+    expect(trainingItems.length).toBe(1);
+  });
+
+  it('returns base items even without a next game opponent', () => {
+    const priorities = buildActionableWeeklyPriorities({ team, nextGame: null, prep: {} });
+    expect(priorities.length).toBeGreaterThan(0);
+    expect(priorities.every((item) => item.id && item.title && item.ctaLabel)).toBe(true);
+  });
+
+  it('marks Set Lineup as warning severity when starters are missing', () => {
+    const priorities = buildActionableWeeklyPriorities({
+      team: { ...team, missingStarters: 3 },
+      nextGame: { opp: opponent },
+      prep: {},
+    });
+    const lineupItem = priorities.find((item) => item.id === 'priority-lineup');
+    expect(lineupItem).toBeDefined();
+    expect(lineupItem.severity).toBe('warning');
+  });
+});
+
+describe('buildWeeklyIntelligence — additional coverage', () => {
+  it('includes late-season implication insight in week 10+', () => {
+    const intel = buildWeeklyIntelligence({
+      league: { week: 12 },
+      team,
+      nextGame: { isHome: true, opp: opponent },
+      prep: { lineupIssues: [] },
+    });
+    expect(intel.insights.some((item) => item.id === 'intel-implication')).toBe(true);
+  });
+
+  it('includes injury insight when lineup issues contain injury keyword', () => {
+    const intel = buildWeeklyIntelligence({
+      league: { week: 5 },
+      team,
+      nextGame: { isHome: false, opp: opponent },
+      prep: { lineupIssues: [{ label: 'QB injury', level: 'urgent' }, { label: 'RB injury risk', level: 'warning' }] },
+    });
+    expect(intel.insights.some((item) => item.id === 'intel-injuries')).toBe(true);
+  });
+
+  it('includes offensive edge insight when user offense outrates opponent defense', () => {
+    const intel = buildWeeklyIntelligence({
+      league: { week: 6 },
+      team: { ...team, offenseRating: 90 },
+      nextGame: { isHome: true, opp: { ...opponent, defenseRating: 75 } },
+      prep: { lineupIssues: [] },
+    });
+    expect(intel.insights.some((item) => item.id === 'intel-off-edge')).toBe(true);
+  });
+
+  it('caps insights at 5', () => {
+    const intel = buildWeeklyIntelligence({
+      league: { week: 14 },
+      team: { ...team, offenseRating: 90, defenseRating: 92 },
+      nextGame: { isHome: true, opp: { ...opponent, offenseRating: 75, defenseRating: 70, recentResults: ['L'] } },
+      prep: { lineupIssues: [{ label: 'WR injury', level: 'warning' }, { label: 'OL injury', level: 'warning' }] },
+    });
+    expect(intel.insights.length).toBeLessThanOrEqual(5);
+  });
+
+  it('all insights have required fields', () => {
+    const intel = buildWeeklyIntelligence({
+      league: { week: 8 },
+      team,
+      nextGame: { isHome: true, opp: opponent },
+      prep: { lineupIssues: [] },
+    });
+    for (const insight of intel.insights) {
+      expect(insight).toHaveProperty('id');
+      expect(insight).toHaveProperty('tone');
+      expect(insight).toHaveProperty('text');
+      expect(typeof insight.text).toBe('string');
+    }
+  });
 });


### PR DESCRIPTION
- WeeklyHub: add Matchup Intelligence section using buildWeeklyIntelligence
  and buildActionableWeeklyPriorities; shows tone-aware coordinator brief
  insights and priority action cards with CTA navigation
- FranchiseHQ: render weeklyAgenda (buildActionableWeeklyPriorities output)
  as interactive priority cards inside the Coordinator Brief section; also
  fix pre-existing curly-quote syntax errors throughout the file
- weeklyIntelligence.test.js: expand from 5 to 14 tests covering late-season
  implication, injury insights, offensive edge, insight cap, required fields,
  deduplication, no-opponent fallback, and severity escalation