### PR TITLE
feat: Weekly Prep / Game Plan Actions V1

### DIFF
--- a/src/ui/components/WeeklyHub.jsx
+++ b/src/ui/components/WeeklyHub.jsx
@@ -244,6 +244,10 @@ export default function WeeklyHub({ league, onNavigate, onAdvanceWeek, busy, sim
               ))}
             </div>
           ) : null}
+          <div className="weekly-hub-prep-ctas" style={{ display: 'flex', gap: 8, marginTop: 12, flexWrap: 'wrap' }}>
+            <Button size="sm" variant="outline" onClick={() => onNavigate?.('Weekly Prep')}>Open weekly prep</Button>
+            <Button size="sm" variant="outline" onClick={() => onNavigate?.('Game Plan')}>Review game plan</Button>
+          </div>
         </div>
       </details>
 

--- a/src/ui/components/WeeklyPrepScreen.jsx
+++ b/src/ui/components/WeeklyPrepScreen.jsx
@@ -3,6 +3,9 @@ import { Button } from '@/components/ui/button';
 import { EmptyState, SectionCard } from './common/UiPrimitives.jsx';
 import { markWeeklyPrepStep } from '../utils/weeklyPrep.js';
 import { buildWeeklyPrepScreenModel } from '../utils/weeklyPrepScreenModel.js';
+import { buildWeeklyIntelligence } from '../utils/weeklyIntelligence.js';
+import { evaluateWeeklyContext } from '../utils/weeklyContext.js';
+import { buildWeeklyPrepActions } from '../utils/weeklyPrepActions.js';
 import { TeamIdentityBadge } from './HQVisuals.jsx';
 
 function TonePill({ tone = 'info', label }) {
@@ -20,9 +23,21 @@ function TonePill({ tone = 'info', label }) {
   );
 }
 
+const TONE_LABEL = { danger: 'Urgent', warning: 'Attention', info: 'Info', ok: 'Ready', success: 'Done' };
+
 export default function WeeklyPrepScreen({ league, onNavigate }) {
   const model = useMemo(() => buildWeeklyPrepScreenModel({ league }), [league]);
   const prep = model.prep;
+
+  const weeklyIntelligence = useMemo(
+    () => buildWeeklyIntelligence({ league, team: prep?.userTeam, nextGame: prep?.nextGame, prep }),
+    [league, prep],
+  );
+  const weeklyContext = useMemo(() => evaluateWeeklyContext(league), [league]);
+  const prepActions = useMemo(
+    () => buildWeeklyPrepActions({ league, weeklyIntelligence, weeklyContext, prep }),
+    [league, weeklyIntelligence, weeklyContext, prep],
+  );
 
   useEffect(() => {
     markWeeklyPrepStep(league, 'opponentScouted', true);
@@ -131,6 +146,38 @@ export default function WeeklyPrepScreen({ league, onNavigate }) {
           <TonePill tone={prep.completion.opponentScouted ? 'success' : 'warning'} label={`Opponent ${prep.completion.opponentScouted ? 'scouted' : 'pending'}`} />
           <TonePill tone={prep.completion.planReviewed ? 'success' : 'warning'} label={`Plan ${prep.completion.planReviewed ? 'reviewed' : 'pending'}`} />
         </div>
+      </SectionCard>
+
+      <SectionCard
+        title="Recommended Prep Actions"
+        subtitle="Intelligence-driven actions for this week."
+        data-testid="recommended-prep-actions"
+      >
+        {prepActions.length > 0 ? (
+          <div className="weekly-prep-action-grid">
+            {prepActions.slice(0, 5).map((action) => (
+              <article key={action.id} className="weekly-prep-action-card" data-testid={`prep-action-card-${action.id}`}>
+                <div className="weekly-prep-action-head">
+                  <strong>{action.title}</strong>
+                  <TonePill tone={action.tone} label={TONE_LABEL[action.tone] ?? 'Info'} />
+                </div>
+                <p>{action.detail}</p>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => onNavigate?.(action.destination)}
+                  data-testid={`prep-action-cta-${action.id}`}
+                >
+                  {action.ctaLabel}
+                </Button>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <p className="weekly-prep-caption" data-testid="prep-actions-empty">
+            No urgent prep actions. You can advance or review your roster.
+          </p>
+        )}
       </SectionCard>
     </div>
   );

--- a/src/ui/components/__tests__/WeeklyPrepScreen.test.jsx
+++ b/src/ui/components/__tests__/WeeklyPrepScreen.test.jsx
@@ -1,8 +1,9 @@
 /** @vitest-environment jsdom */
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import WeeklyPrepScreen from '../WeeklyPrepScreen.jsx';
+import * as weeklyPrepActionsModule from '../../utils/weeklyPrepActions.js';
 
 const league = {
   year: 2027,
@@ -42,6 +43,8 @@ const league = {
 };
 
 describe('WeeklyPrepScreen', () => {
+  afterEach(cleanup);
+
   it('renders war room flow and completion chips', () => {
     render(<WeeklyPrepScreen league={league} onNavigate={vi.fn()} />);
     expect(screen.getByText(/Weekly Prep War Room/i)).toBeTruthy();
@@ -71,5 +74,42 @@ describe('WeeklyPrepScreen', () => {
       />,
     );
     expect(screen.getByText(/Weekly prep unavailable/i)).toBeTruthy();
+  });
+});
+
+describe('WeeklyPrepScreen — Recommended Prep Actions section', () => {
+  afterEach(cleanup);
+
+  it('renders the Recommended Prep Actions section heading', () => {
+    const { container } = render(<WeeklyPrepScreen league={league} onNavigate={vi.fn()} />);
+    expect(within(container).getByRole('heading', { name: /Recommended Prep Actions/i })).toBeTruthy();
+  });
+
+  it('CTA buttons in Recommended Prep Actions call onNavigate with a valid tab', () => {
+    const onNavigate = vi.fn();
+    const { container } = render(<WeeklyPrepScreen league={league} onNavigate={onNavigate} />);
+
+    // Find the Recommended Prep Actions section and query buttons within it
+    const heading = within(container).getByRole('heading', { name: /Recommended Prep Actions/i });
+    const section = heading.closest('section');
+    if (!section) return;
+
+    const ctaButtons = within(section).queryAllByRole('button');
+    if (ctaButtons.length > 0) {
+      fireEvent.click(ctaButtons[0]);
+      expect(onNavigate).toHaveBeenCalledTimes(1);
+      const destination = onNavigate.mock.calls[0][0];
+      expect(typeof destination).toBe('string');
+      expect(destination.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('renders the empty state message when buildWeeklyPrepActions returns no actions', () => {
+    const spy = vi.spyOn(weeklyPrepActionsModule, 'buildWeeklyPrepActions').mockReturnValue([]);
+    const { container } = render(<WeeklyPrepScreen league={league} onNavigate={vi.fn()} />);
+    const heading = within(container).getByRole('heading', { name: /Recommended Prep Actions/i });
+    const section = heading.closest('section');
+    expect(within(section).getByText(/No urgent prep actions/i)).toBeTruthy();
+    spy.mockRestore();
   });
 });

--- a/src/ui/utils/weeklyPrepActions.js
+++ b/src/ui/utils/weeklyPrepActions.js
@@ -1,0 +1,200 @@
+function safeNum(v, d = 0) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : d;
+}
+
+// Destinations confirmed present in navigation layer
+const SAFE_DESTINATION_PREFIXES = [
+  'Team:Injuries',
+  'Team:Roster',
+  'Game Plan',
+  'Weekly Prep',
+  'League',
+  'Roster',
+  'Free Agency',
+  'Trade Center',
+  'Financials',
+  'FA Hub',
+  'Staff',
+  'Standings',
+  'HQ',
+  'Game Book:',
+];
+
+function isSafeDestination(dest) {
+  if (!dest) return false;
+  return SAFE_DESTINATION_PREFIXES.some((prefix) => String(dest).startsWith(prefix));
+}
+
+function getLastResult(league) {
+  const uid = Number(league?.userTeamId);
+  const userTeam = Array.isArray(league?.teams) ? league.teams.find((t) => Number(t.id) === uid) : null;
+  const results = Array.isArray(userTeam?.recentResults) ? userTeam.recentResults : [];
+  if (!results.length) return null;
+  return String(results[results.length - 1] ?? '').toUpperCase();
+}
+
+function getLatestCompletedGameId(league) {
+  const uid = Number(league?.userTeamId);
+  let latestGame = null;
+  let latestWeek = -1;
+  for (const week of league?.schedule?.weeks ?? []) {
+    for (const game of week?.games ?? []) {
+      if (!game?.played) continue;
+      const homeId = Number(game?.home?.id ?? game?.home);
+      const awayId = Number(game?.away?.id ?? game?.away);
+      if (homeId !== uid && awayId !== uid) continue;
+      const wk = safeNum(week?.week, 0);
+      if (wk > latestWeek) {
+        latestWeek = wk;
+        latestGame = game;
+      }
+    }
+  }
+  return latestGame?.id ?? null;
+}
+
+/**
+ * Returns up to 5 actionable prep cards derived from weekly intelligence + context signals.
+ * Conservative: only generates an action when the underlying data signal exists.
+ *
+ * @param {object} opts
+ * @param {object} opts.league
+ * @param {object} opts.weeklyIntelligence - output of buildWeeklyIntelligence
+ * @param {object} opts.weeklyContext     - output of evaluateWeeklyContext
+ * @param {object} opts.prep              - output of deriveWeeklyPrepState
+ * @returns {Array<{id, title, detail, tone, priority, destination, ctaLabel, reason}>}
+ */
+export function buildWeeklyPrepActions({ league, weeklyIntelligence, weeklyContext, prep } = {}) {
+  const actions = [];
+
+  const injuriesCount = safeNum(weeklyContext?.pressurePoints?.injuriesCount, 0);
+  const insights = Array.isArray(weeklyIntelligence?.insights) ? weeklyIntelligence.insights : [];
+  const urgentItems = Array.isArray(weeklyContext?.urgentItems) ? weeklyContext.urgentItems : [];
+  const lineupIssues = Array.isArray(prep?.lineupIssues) ? prep.lineupIssues : [];
+  const incomingOffers = Array.isArray(weeklyContext?.incomingOffers) ? weeklyContext.incomingOffers : [];
+  const hasNextGame = !!(prep?.nextGame);
+  const opponent = prep?.nextGame?.opp ?? null;
+
+  // Guard: opponent has actual stat ratings (not zero or absent)
+  const oppOff = safeNum(opponent?.offenseRating ?? opponent?.offRating ?? opponent?.offense, null);
+  const oppDef = safeNum(opponent?.defenseRating ?? opponent?.defRating ?? opponent?.defense, null);
+  const hasOpponentStats = opponent != null && (Number.isFinite(oppOff) || Number.isFinite(oppDef));
+
+  // --- 1. Review Injuries: only when injury data exists ---
+  if (injuriesCount >= 1) {
+    const injuryItem = urgentItems.find((item) => item.tab === 'Injuries');
+    actions.push({
+      id: 'prep-action-injuries',
+      title: 'Review Injuries',
+      detail: injuryItem?.detail ?? `${injuriesCount} active injur${injuriesCount > 1 ? 'ies' : 'y'} may affect depth this week.`,
+      tone: injuriesCount >= 4 ? 'danger' : injuriesCount >= 2 ? 'warning' : 'info',
+      priority: injuriesCount >= 4 ? 90 : injuriesCount >= 2 ? 70 : 50,
+      destination: 'Team:Injuries',
+      ctaLabel: 'Open Injuries',
+      reason: 'Injury data flagged this week.',
+    });
+  }
+
+  // --- 2. Adjust Depth Chart: only when lineup issues exist ---
+  const urgentLineupIssues = lineupIssues.filter((i) => i.level === 'urgent');
+  if (lineupIssues.length > 0) {
+    const topIssue = urgentLineupIssues[0] ?? lineupIssues[0];
+    actions.push({
+      id: 'prep-action-depth',
+      title: 'Adjust Depth Chart',
+      detail: topIssue?.detail ?? 'Depth chart warnings may affect sim performance this week.',
+      tone: urgentLineupIssues.length > 0 ? 'danger' : 'warning',
+      priority: urgentLineupIssues.length > 0 ? 85 : 65,
+      destination: 'Team:Roster / Depth',
+      ctaLabel: 'Open Depth Chart',
+      reason: 'Lineup issues detected this week.',
+    });
+  }
+
+  // --- 3. Scout Opponent Threat: only when opponent stat context exists AND intel flags a risk ---
+  const hasThreatInsight = insights.some((i) => ['intel-off-risk', 'intel-def-risk'].includes(i.id));
+  if (hasNextGame && hasOpponentStats && hasThreatInsight) {
+    const threatInsight = insights.find((i) => ['intel-off-risk', 'intel-def-risk'].includes(i.id));
+    actions.push({
+      id: 'prep-action-opponent-threat',
+      title: 'Scout Opponent Threat',
+      detail: threatInsight?.text ?? 'Opponent poses a matchup risk this week. Review before advancing.',
+      tone: 'warning',
+      priority: 80,
+      destination: 'Weekly Prep',
+      ctaLabel: 'Open Weekly Prep',
+      reason: 'Intelligence flags an opponent statistical advantage.',
+    });
+  }
+
+  // --- 4. Check Matchup Leaders: only when opponent stat data exists (no threat, user may have edge) ---
+  if (hasNextGame && hasOpponentStats && !hasThreatInsight) {
+    const hasEdge = insights.some((i) => ['intel-off-edge', 'intel-def-edge'].includes(i.id));
+    actions.push({
+      id: 'prep-action-leaders',
+      title: 'Check Matchup Leaders',
+      detail: hasEdge
+        ? `You have a statistical edge vs ${opponent?.abbr ?? 'this opponent'}. Review league leaders to maximize the advantage.`
+        : `Review league leader stats to identify key performers in the ${opponent?.abbr ?? 'upcoming'} matchup.`,
+      tone: 'info',
+      priority: 42,
+      destination: 'League',
+      ctaLabel: 'Open League Leaders',
+      reason: 'Opponent stat data is available for this matchup.',
+    });
+  }
+
+  // --- 5. Roster / FA need: only when weekly context urgentItems supports it ---
+  const ROSTER_TABS = new Set(['Roster', 'Free Agency', 'Financials', 'FA Hub']);
+  const topRosterItem = urgentItems.find((item) => ROSTER_TABS.has(item.tab) && item.tone !== 'ok');
+  if (topRosterItem) {
+    const dest = topRosterItem.tab === 'FA Hub' ? 'Free Agency' : topRosterItem.tab;
+    actions.push({
+      id: 'prep-action-roster-context',
+      title: topRosterItem.label,
+      detail: topRosterItem.detail,
+      tone: topRosterItem.tone,
+      priority: safeNum(topRosterItem.rank, 50) - 5,
+      destination: dest,
+      ctaLabel: `Open ${dest}`,
+      reason: topRosterItem.why ?? 'Weekly context flags a roster or financial need.',
+    });
+  }
+
+  // --- 6. Trade Offer: only when real incoming offers exist ---
+  if (incomingOffers.length > 0) {
+    const tradeItem = urgentItems.find((item) => item.tab === 'Transactions:Offers' || item.tab === 'Trades');
+    actions.push({
+      id: 'prep-action-trade',
+      title: 'Review Trade Offer',
+      detail: tradeItem?.detail ?? `${incomingOffers.length} incoming trade offer${incomingOffers.length > 1 ? 's' : ''} waiting for a response.`,
+      tone: 'info',
+      priority: 75,
+      destination: 'Trade Center',
+      ctaLabel: 'Open Trade Center',
+      reason: 'Incoming trade offers are waiting.',
+    });
+  }
+
+  // --- 7. Review Last Loss: only when coming off a loss AND a game ID exists ---
+  const lastResult = getLastResult(league);
+  const latestGameId = getLatestCompletedGameId(league);
+  if (lastResult === 'L' && latestGameId) {
+    actions.push({
+      id: 'prep-action-game-book',
+      title: 'Review Last Loss',
+      detail: 'Open the Game Book to identify what went wrong and refocus your game plan.',
+      tone: 'warning',
+      priority: 60,
+      destination: `Game Book:${latestGameId}`,
+      ctaLabel: 'Open Game Book',
+      reason: 'Team is coming off a loss.',
+    });
+  }
+
+  return actions
+    .filter((a) => isSafeDestination(a.destination))
+    .sort((a, b) => b.priority - a.priority)
+    .slice(0, 5);
+}

--- a/src/ui/utils/weeklyPrepActions.test.js
+++ b/src/ui/utils/weeklyPrepActions.test.js
@@ -1,0 +1,360 @@
+import { describe, expect, it } from 'vitest';
+import { buildWeeklyPrepActions } from './weeklyPrepActions.js';
+
+const team = {
+  id: 1, abbr: 'CHI', wins: 5, losses: 3, ties: 0,
+  ovr: 84, offenseRating: 82, defenseRating: 83,
+  recentResults: ['W', 'W', 'L', 'W'],
+};
+
+const opponent = {
+  id: 2, abbr: 'DET', wins: 4, losses: 4, ties: 0,
+  ovr: 81, offenseRating: 88, defenseRating: 74,
+};
+
+const baseLeague = {
+  week: 8, year: 2027, seasonId: 's8', userTeamId: 1,
+  teams: [team, opponent],
+  schedule: {
+    weeks: [
+      { week: 7, games: [{ id: 'g7', home: { id: 1 }, away: { id: 2 }, homeScore: 28, awayScore: 14, played: true }] },
+      { week: 8, games: [{ id: 'g8', home: { id: 1 }, away: { id: 2 }, played: false }] },
+    ],
+  },
+};
+
+const emptyContext = { pressurePoints: { injuriesCount: 0 }, urgentItems: [], incomingOffers: [] };
+const emptyIntel = { insights: [] };
+const emptyPrep = { nextGame: null, opponent: null, lineupIssues: [] };
+
+describe('buildWeeklyPrepActions — injury action', () => {
+  it('returns injury action only when injury data exists', () => {
+    const withInjuries = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: { ...emptyContext, pressurePoints: { injuriesCount: 2 } },
+      weeklyIntelligence: emptyIntel,
+      prep: emptyPrep,
+    });
+    expect(withInjuries.some((a) => a.id === 'prep-action-injuries')).toBe(true);
+  });
+
+  it('does NOT return injury action when injuriesCount is 0', () => {
+    const withoutInjuries = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: emptyContext,
+      weeklyIntelligence: emptyIntel,
+      prep: emptyPrep,
+    });
+    expect(withoutInjuries.some((a) => a.id === 'prep-action-injuries')).toBe(false);
+  });
+
+  it('uses danger tone for 4+ injuries and warning for 2-3', () => {
+    const four = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: { ...emptyContext, pressurePoints: { injuriesCount: 4 } },
+      weeklyIntelligence: emptyIntel,
+      prep: emptyPrep,
+    });
+    const injuryAction = four.find((a) => a.id === 'prep-action-injuries');
+    expect(injuryAction?.tone).toBe('danger');
+
+    const two = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: { ...emptyContext, pressurePoints: { injuriesCount: 2 } },
+      weeklyIntelligence: emptyIntel,
+      prep: emptyPrep,
+    });
+    expect(two.find((a) => a.id === 'prep-action-injuries')?.tone).toBe('warning');
+  });
+});
+
+describe('buildWeeklyPrepActions — opponent/stat action', () => {
+  it('returns opponent threat action only when opponent stat context exists AND intel flags risk', () => {
+    const withThreat = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: emptyContext,
+      weeklyIntelligence: {
+        insights: [{ id: 'intel-def-risk', tone: 'warning', text: 'Opponent offense is the pressure point (88 vs 83).' }],
+      },
+      prep: { nextGame: { opp: opponent }, opponent, lineupIssues: [] },
+    });
+    expect(withThreat.some((a) => a.id === 'prep-action-opponent-threat')).toBe(true);
+  });
+
+  it('does NOT return opponent threat action when no next game exists', () => {
+    const withoutGame = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: emptyContext,
+      weeklyIntelligence: {
+        insights: [{ id: 'intel-def-risk', tone: 'warning', text: 'Opponent offense is the pressure point.' }],
+      },
+      prep: emptyPrep,
+    });
+    expect(withoutGame.some((a) => a.id === 'prep-action-opponent-threat')).toBe(false);
+  });
+
+  it('does NOT return opponent threat action when opponent has no stat ratings', () => {
+    const noRatings = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: emptyContext,
+      weeklyIntelligence: emptyIntel,
+      prep: { nextGame: { opp: { id: 2, abbr: 'DET' } }, opponent: { id: 2, abbr: 'DET' }, lineupIssues: [] },
+    });
+    expect(noRatings.some((a) => a.id === 'prep-action-opponent-threat')).toBe(false);
+  });
+
+  it('returns matchup-leaders action when opponent stats exist but no threat insight', () => {
+    const withEdge = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: emptyContext,
+      weeklyIntelligence: {
+        insights: [{ id: 'intel-off-edge', tone: 'ok', text: 'Your offense has the edge (82 vs 74).' }],
+      },
+      prep: { nextGame: { opp: opponent }, opponent, lineupIssues: [] },
+    });
+    expect(withEdge.some((a) => a.id === 'prep-action-leaders')).toBe(true);
+    const leadersAction = withEdge.find((a) => a.id === 'prep-action-leaders');
+    expect(leadersAction?.destination).toBe('League');
+  });
+});
+
+describe('buildWeeklyPrepActions — roster/FA/trade action', () => {
+  it('returns roster action only when weekly context urgentItems supports it', () => {
+    const withRoster = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: {
+        ...emptyContext,
+        urgentItems: [{ tone: 'warning', level: 'recommendation', rank: 65, label: 'Roster pressure point', detail: 'Add OL depth.', tab: 'Roster', why: 'Depth issue.' }],
+      },
+      weeklyIntelligence: emptyIntel,
+      prep: emptyPrep,
+    });
+    expect(withRoster.some((a) => a.id === 'prep-action-roster-context')).toBe(true);
+  });
+
+  it('does NOT return roster action when no urgentItems have roster tabs', () => {
+    const withoutRoster = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: emptyContext,
+      weeklyIntelligence: emptyIntel,
+      prep: emptyPrep,
+    });
+    expect(withoutRoster.some((a) => a.id === 'prep-action-roster-context')).toBe(false);
+  });
+
+  it('maps FA Hub destination to Free Agency', () => {
+    const withFAHub = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: {
+        ...emptyContext,
+        urgentItems: [{ tone: 'danger', level: 'blocker', rank: 88, label: 'Bid Risk', detail: '1 bid at risk.', tab: 'FA Hub', why: 'Bid expires.' }],
+      },
+      weeklyIntelligence: emptyIntel,
+      prep: emptyPrep,
+    });
+    const rosterAction = withFAHub.find((a) => a.id === 'prep-action-roster-context');
+    expect(rosterAction?.destination).toBe('Free Agency');
+  });
+
+  it('returns trade action only when incoming offers exist', () => {
+    const withTrade = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: { ...emptyContext, incomingOffers: [{ id: 'offer1', reason: 'A deal is waiting.' }] },
+      weeklyIntelligence: emptyIntel,
+      prep: emptyPrep,
+    });
+    expect(withTrade.some((a) => a.id === 'prep-action-trade')).toBe(true);
+    expect(withTrade.find((a) => a.id === 'prep-action-trade')?.destination).toBe('Trade Center');
+  });
+
+  it('does NOT return trade action when no incoming offers exist', () => {
+    const withoutTrade = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: emptyContext,
+      weeklyIntelligence: emptyIntel,
+      prep: emptyPrep,
+    });
+    expect(withoutTrade.some((a) => a.id === 'prep-action-trade')).toBe(false);
+  });
+});
+
+describe('buildWeeklyPrepActions — Game Book action', () => {
+  it('returns game-book action when coming off a loss with a completed game ID', () => {
+    const lossLeague = {
+      ...baseLeague,
+      teams: [{ ...team, recentResults: ['W', 'L'] }, opponent],
+    };
+    const actions = buildWeeklyPrepActions({
+      league: lossLeague,
+      weeklyContext: emptyContext,
+      weeklyIntelligence: emptyIntel,
+      prep: emptyPrep,
+    });
+    const gbAction = actions.find((a) => a.id === 'prep-action-game-book');
+    expect(gbAction).toBeDefined();
+    expect(gbAction?.destination).toMatch(/^Game Book:/);
+  });
+
+  it('does NOT return game-book action when last result is a win', () => {
+    const winLeague = {
+      ...baseLeague,
+      teams: [{ ...team, recentResults: ['W', 'W', 'L', 'W'] }, opponent],
+    };
+    const actions = buildWeeklyPrepActions({
+      league: winLeague,
+      weeklyContext: emptyContext,
+      weeklyIntelligence: emptyIntel,
+      prep: emptyPrep,
+    });
+    expect(actions.some((a) => a.id === 'prep-action-game-book')).toBe(false);
+  });
+
+  it('does NOT return game-book action when no completed game exists', () => {
+    const noGameLeague = {
+      ...baseLeague,
+      teams: [{ ...team, recentResults: ['L'] }, opponent],
+      schedule: { weeks: [{ week: 8, games: [{ id: 'g8', home: { id: 1 }, away: { id: 2 }, played: false }] }] },
+    };
+    const actions = buildWeeklyPrepActions({
+      league: noGameLeague,
+      weeklyContext: emptyContext,
+      weeklyIntelligence: emptyIntel,
+      prep: emptyPrep,
+    });
+    expect(actions.some((a) => a.id === 'prep-action-game-book')).toBe(false);
+  });
+});
+
+describe('buildWeeklyPrepActions — caps and structure', () => {
+  it('caps actions at 5', () => {
+    const lossLeague = {
+      ...baseLeague,
+      teams: [{ ...team, recentResults: ['L'] }, opponent],
+    };
+    const actions = buildWeeklyPrepActions({
+      league: lossLeague,
+      weeklyContext: {
+        pressurePoints: { injuriesCount: 4 },
+        urgentItems: [
+          { tone: 'warning', rank: 65, label: 'Roster need', detail: 'Add OL depth.', tab: 'Roster', why: 'Depth issue.' },
+          { tone: 'danger', rank: 88, label: 'Bid Risk', detail: '2 bids at risk.', tab: 'FA Hub', why: 'Bids expire.' },
+        ],
+        incomingOffers: [{ id: 'offer1' }],
+      },
+      weeklyIntelligence: {
+        insights: [{ id: 'intel-def-risk', tone: 'warning', text: 'Opponent offense is the pressure point.' }],
+      },
+      prep: {
+        nextGame: { opp: opponent },
+        opponent,
+        lineupIssues: [{ id: 'x', level: 'urgent', label: 'Depth chart blocker', detail: 'Missing OL starters.' }],
+      },
+    });
+    expect(actions.length).toBeLessThanOrEqual(5);
+  });
+
+  it('returns empty array when no signals exist', () => {
+    const actions = buildWeeklyPrepActions({
+      league: { userTeamId: 1, teams: [{ id: 1, wins: 0, losses: 0, recentResults: [] }], schedule: { weeks: [] } },
+      weeklyContext: emptyContext,
+      weeklyIntelligence: emptyIntel,
+      prep: emptyPrep,
+    });
+    expect(actions).toHaveLength(0);
+  });
+
+  it('returns empty array for empty inputs', () => {
+    expect(buildWeeklyPrepActions()).toHaveLength(0);
+    expect(buildWeeklyPrepActions({})).toHaveLength(0);
+  });
+
+  it('all returned actions have required shape', () => {
+    const actions = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: {
+        pressurePoints: { injuriesCount: 2 },
+        urgentItems: [{ tone: 'warning', rank: 65, label: 'Roster issue', detail: 'Fix OL.', tab: 'Roster', why: 'Thin.' }],
+        incomingOffers: [{ id: 'offer1' }],
+      },
+      weeklyIntelligence: {
+        insights: [{ id: 'intel-def-risk', tone: 'warning', text: 'Opponent offense is the pressure point.' }],
+      },
+      prep: { nextGame: { opp: opponent }, opponent, lineupIssues: [] },
+    });
+    for (const action of actions) {
+      expect(action).toHaveProperty('id');
+      expect(action).toHaveProperty('title');
+      expect(action).toHaveProperty('detail');
+      expect(action).toHaveProperty('tone');
+      expect(action).toHaveProperty('priority');
+      expect(action).toHaveProperty('destination');
+      expect(action).toHaveProperty('ctaLabel');
+      expect(action).toHaveProperty('reason');
+      expect(typeof action.title).toBe('string');
+      expect(typeof action.destination).toBe('string');
+    }
+  });
+
+  it('sorts actions by priority descending', () => {
+    const actions = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: { pressurePoints: { injuriesCount: 4 }, urgentItems: [], incomingOffers: [] },
+      weeklyIntelligence: {
+        insights: [{ id: 'intel-def-risk', tone: 'warning', text: 'Threat.' }],
+      },
+      prep: { nextGame: { opp: opponent }, opponent, lineupIssues: [{ level: 'urgent', detail: 'Missing QB.' }] },
+    });
+    for (let i = 1; i < actions.length; i += 1) {
+      expect(actions[i - 1].priority).toBeGreaterThanOrEqual(actions[i].priority);
+    }
+  });
+
+  it('filters out actions with unknown/unsafe destinations', () => {
+    const actions = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: {
+        pressurePoints: {},
+        urgentItems: [{ tone: 'warning', rank: 55, label: 'Unknown Tab', detail: 'Some issue.', tab: 'SomeUnknownTab', why: 'Reason.' }],
+        incomingOffers: [],
+      },
+      weeklyIntelligence: emptyIntel,
+      prep: emptyPrep,
+    });
+    expect(actions.some((a) => a.destination === 'SomeUnknownTab')).toBe(false);
+  });
+});
+
+describe('buildWeeklyPrepActions — depth chart action', () => {
+  it('returns depth chart action only when lineup issues exist', () => {
+    const withIssues = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: emptyContext,
+      weeklyIntelligence: emptyIntel,
+      prep: { nextGame: null, opponent: null, lineupIssues: [{ id: 'x', level: 'warning', label: 'Thin RB', detail: 'Running Back is thin (1/3).' }] },
+    });
+    expect(withIssues.some((a) => a.id === 'prep-action-depth')).toBe(true);
+    expect(withIssues.find((a) => a.id === 'prep-action-depth')?.destination).toBe('Team:Roster / Depth');
+
+    const withoutIssues = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: emptyContext,
+      weeklyIntelligence: emptyIntel,
+      prep: emptyPrep,
+    });
+    expect(withoutIssues.some((a) => a.id === 'prep-action-depth')).toBe(false);
+  });
+
+  it('uses danger tone for urgent lineup issues', () => {
+    const actions = buildWeeklyPrepActions({
+      league: baseLeague,
+      weeklyContext: emptyContext,
+      weeklyIntelligence: emptyIntel,
+      prep: {
+        nextGame: null,
+        opponent: null,
+        lineupIssues: [{ id: 'x', level: 'urgent', label: 'Depth chart blocker', detail: 'No QB starter assigned.' }],
+      },
+    });
+    expect(actions.find((a) => a.id === 'prep-action-depth')?.tone).toBe('danger');
+  });
+});


### PR DESCRIPTION
Add a conservative, intelligence-driven "Recommended Prep Actions"
layer to WeeklyPrepScreen and WeeklyHub coordinator brief.

- weeklyPrepActions.js: Pure helper that derives up to 5 action cards
  from weekly intelligence signals and context urgentItems. Guards
  ensure injury actions only appear when injury data exists, opponent/
  stat actions only when opponent ratings are present, and roster/FA/
  trade actions only when weeklyContext urgentItems support them.

- WeeklyPrepScreen: New "Recommended Prep Actions" section below Prep
  Checklist. Shows 3-5 intelligence-driven cards with CTAs routed
  through onNavigate. Empty state message when no actions are present.

- WeeklyHub: "Open weekly prep" and "Review game plan" CTAs added at
  the bottom of the Coordinator Brief expandable section.

- weeklyPrepActions.test.js: 23 unit tests covering injury, opponent,
  roster/FA/trade, Game Book, caps, shape, sorting, and safe-dest
  filtering. WeeklyPrepScreen.test.jsx: 3 new component tests.

No DB schema, worker, simulation, or playcalling changes.

https://claude.ai/code/session_01X5pq6MJb6QFz6a2KJYX5BE