### PR TITLE
feat: Advance Week Readiness Gate V1

### DIFF
--- a/src/ui/components/AdvanceReadinessGate.jsx
+++ b/src/ui/components/AdvanceReadinessGate.jsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { Button } from '@/components/ui/button';
+
+const TONE_CLASS = { danger: 'tone-danger', warning: 'tone-warning', info: 'tone-info' };
+
+/**
+ * Compact inline confirmation panel shown before advancing the week
+ * when unresolved prep risks are detected.
+ *
+ * Props:
+ *   gate           — output of buildAdvanceReadinessGate
+ *   onAdvanceAnyway — called when user overrides and advances anyway
+ *   onReview        — called with primaryFixDestination when user chooses to fix
+ *   onCancel        — called when user dismisses the panel
+ */
+export default function AdvanceReadinessGate({ gate, onAdvanceAnyway, onReview, onCancel }) {
+  if (!gate?.shouldWarn) return null;
+
+  const warningItems = (gate.riskItems ?? []).filter((item) => item.severity !== 'info');
+
+  return (
+    <div
+      className={`advance-readiness-gate ${TONE_CLASS[gate.severity ?? 'warning']}`}
+      role="dialog"
+      aria-modal="false"
+      aria-label="Advance Week Readiness Check"
+      data-testid="advance-readiness-gate"
+      style={{
+        padding: '14px 16px',
+        borderRadius: 10,
+        border: '1.5px solid currentColor',
+        marginBottom: 10,
+        background: 'var(--surface-2, #1a1a2e)',
+      }}
+    >
+      <strong
+        className="advance-readiness-gate__title"
+        style={{ display: 'block', marginBottom: 8, fontSize: '0.97em' }}
+      >
+        {gate.title}
+      </strong>
+
+      {warningItems.length > 0 ? (
+        <ul
+          className="advance-readiness-gate__risks"
+          aria-label="Unresolved prep items"
+          role="list"
+          style={{ listStyle: 'none', padding: 0, margin: '0 0 8px 0' }}
+        >
+          {warningItems.map((item) => (
+            <li
+              key={item.id}
+              className={`advance-readiness-gate__risk-item ${TONE_CLASS[item.severity ?? 'warning']}`}
+              role="listitem"
+              style={{ marginBottom: 4, fontSize: '0.88em' }}
+            >
+              <strong>{item.label}</strong>
+              {item.detail ? <span style={{ opacity: 0.8 }}> {item.detail}</span> : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      <p
+        className="advance-readiness-gate__summary"
+        style={{ margin: '0 0 12px 0', fontSize: '0.88em', opacity: 0.9 }}
+      >
+        {gate.summary}
+      </p>
+
+      <div
+        className="advance-readiness-gate__actions"
+        style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}
+      >
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => onReview?.(gate.primaryFixDestination)}
+          data-testid="gate-review-btn"
+        >
+          Review weekly prep
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={onAdvanceAnyway}
+          data-testid="gate-advance-anyway-btn"
+        >
+          {gate.advanceAnywayLabel ?? 'Advance anyway'}
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={onCancel}
+          data-testid="gate-cancel-btn"
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { autoBuildDepthChart, depthWarnings } from '../../core/depthChart.js';
-import { markWeeklyPrepStep } from '../utils/weeklyPrep.js';
+import { markWeeklyPrepStep, deriveWeeklyPrepState } from '../utils/weeklyPrep.js';
+import { evaluateWeeklyContext } from '../utils/weeklyContext.js';
+import { buildAdvanceReadinessGate } from '../utils/advanceReadinessGate.js';
+import AdvanceReadinessGate from './AdvanceReadinessGate.jsx';
 import { selectFranchiseHQViewModel } from '../utils/franchiseCommandCenter.js';
 import { buildWeeklyCommandHub } from '../utils/weeklyCommandHub.js';
 import { rankLeaguePulseItems } from '../../core/leaguePulse.js';
@@ -30,7 +33,14 @@ function formatRecordInline(record) {
 
 export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, simulating }) {
   const [lineupToast, setLineupToast] = useState(null);
+  const [showGate, setShowGate] = useState(false);
   const command = useMemo(() => selectFranchiseHQViewModel(league), [league]);
+  const hqPrep = useMemo(() => deriveWeeklyPrepState(league), [league]);
+  const hqWeeklyContext = useMemo(() => evaluateWeeklyContext(league), [league]);
+  const gate = useMemo(
+    () => buildAdvanceReadinessGate({ league, prep: hqPrep, weeklyContext: hqWeeklyContext }),
+    [league, hqPrep, hqWeeklyContext],
+  );
 
   if (command.readyState !== 'ready') {
     return <EmptyState title="HQ loading" body="Team context is still loading or this save is missing team ownership metadata." />;
@@ -39,6 +49,24 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
   const userTeam = (league?.teams ?? []).find((t) => Number(t?.id) === Number(league?.userTeamId));
   const opponent = command.nextGame?.opp ?? null;
   const nextOpponentDisplay = useMemo(() => getNextOpponentDisplay(command.nextGame), [command.nextGame]);
+
+  const handleAdvanceOrGate = () => {
+    if (gate.shouldWarn) {
+      setShowGate(true);
+    } else {
+      onAdvanceWeek?.();
+    }
+  };
+
+  const handleGateAdvanceAnyway = () => {
+    setShowGate(false);
+    onAdvanceWeek?.();
+  };
+
+  const handleGateReview = (dest) => {
+    setShowGate(false);
+    onNavigate?.(dest);
+  };
 
   const handleSetLineup = () => {
     const team = (league?.teams ?? []).find((t) => Number(t?.id) === Number(league?.userTeamId));
@@ -323,7 +351,7 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
               {hqNextAction.route ? (
                 <button type="button" className="btn btn-sm" onClick={() => onNavigate?.(hqNextAction.route)}>{hqNextAction.label}</button>
               ) : (
-                <button type="button" className="btn btn-sm" onClick={onAdvanceWeek} disabled={busy || simulating}>{busy || simulating ? 'Advancing…' : 'Advance Week'}</button>
+                <button type="button" className="btn btn-sm" onClick={handleAdvanceOrGate} disabled={busy || simulating}>{busy || simulating ? 'Advancing…' : 'Advance Week'}</button>
               )}
             </article>
           </div>
@@ -536,8 +564,18 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
         ) : null}
       </section>
 
+      {showGate ? (
+        <div style={{ padding: '0 var(--space-2)', marginBottom: 8 }}>
+          <AdvanceReadinessGate
+            gate={gate}
+            onAdvanceAnyway={handleGateAdvanceAnyway}
+            onReview={handleGateReview}
+            onCancel={() => setShowGate(false)}
+          />
+        </div>
+      ) : null}
       <div className="app-hq-sticky-advance">
-        <Button className="app-command-advance app-command-advance-gold" data-testid="advance-week-cta" onClick={onAdvanceWeek} disabled={busy || simulating} aria-label={`Advance Week — move from ${command.weekLabel} to next week`} title="Advance Week">
+        <Button className="app-command-advance app-command-advance-gold" data-testid="advance-week-cta" onClick={handleAdvanceOrGate} disabled={busy || simulating} aria-label={`Advance Week — move from ${command.weekLabel} to next week`} title="Advance Week">
           {busy || simulating ? 'Advancing…' : 'Advance Week'}
           <HQIcon name="arrowRight" size={16} />
         </Button>

--- a/src/ui/components/WeeklyHub.jsx
+++ b/src/ui/components/WeeklyHub.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -11,6 +11,8 @@ import { findLatestUserCompletedGame } from "../utils/completedGameSelectors.js"
 import { buildCompletedGamePresentation } from "../utils/boxScoreAccess.js";
 import { buildWeeklyIntelligence, buildActionableWeeklyPriorities } from "../utils/weeklyIntelligence.js";
 import { deriveWeeklyPrepState } from "../utils/weeklyPrep.js";
+import { buildAdvanceReadinessGate } from "../utils/advanceReadinessGate.js";
+import AdvanceReadinessGate from "./AdvanceReadinessGate.jsx";
 
 function getUserTeam(league) {
   return league?.teams?.find((t) => t.id === league?.userTeamId) ?? null;
@@ -58,6 +60,12 @@ export default function WeeklyHub({ league, onNavigate, onAdvanceWeek, busy, sim
   const prep = useMemo(() => deriveWeeklyPrepState(league), [league]);
   const matchupIntel = useMemo(() => buildWeeklyIntelligence({ league, team: user, nextGame, prep }), [league, user, nextGame, prep]);
   const matchupPriorities = useMemo(() => buildActionableWeeklyPriorities({ team: user, nextGame, prep }), [user, nextGame, prep]);
+
+  const gate = useMemo(
+    () => buildAdvanceReadinessGate({ league, prep, weeklyContext }),
+    [league, prep, weeklyContext],
+  );
+  const [showGate, setShowGate] = useState(false);
 
   if (!league || !user || !weeklyContext) return null;
 
@@ -125,10 +133,28 @@ export default function WeeklyHub({ league, onNavigate, onAdvanceWeek, busy, sim
 
   const topOfferSummary = topOffer ? buildIncomingOfferPresentation({ offer: topOffer, league, userTeamId: league?.userTeamId }) : null;
 
+  const handleAdvanceOrGate = () => {
+    if (gate.shouldWarn) {
+      setShowGate(true);
+    } else {
+      onAdvanceWeek?.();
+    }
+  };
+
+  const handleGateAdvanceAnyway = () => {
+    setShowGate(false);
+    onAdvanceWeek?.();
+  };
+
+  const handleGateReview = (dest) => {
+    setShowGate(false);
+    onNavigate?.(dest);
+  };
+
   const handlePrimaryAction = () => {
     if (primaryAction.type === "boxscore" && primaryAction.gameId) return onOpenBoxScore?.(primaryAction.gameId);
     if (primaryAction.type === "navigate") return onNavigate?.(primaryAction.tab);
-    return onAdvanceWeek?.();
+    return handleAdvanceOrGate();
   };
 
   return (
@@ -167,9 +193,17 @@ export default function WeeklyHub({ league, onNavigate, onAdvanceWeek, busy, sim
             <Button size="lg" className="weekly-hero__action-main" disabled={busy || simulating} onClick={handlePrimaryAction}>
               {busy || simulating ? ACTION_LABELS.working : primaryAction.cta}
             </Button>
-            <Button size="sm" variant="secondary" onClick={onAdvanceWeek} disabled={busy || simulating}>{simulating ? ACTION_LABELS.simulating : ACTION_LABELS.advanceWeek}</Button>
+            <Button size="sm" variant="secondary" onClick={handleAdvanceOrGate} disabled={busy || simulating}>{simulating ? ACTION_LABELS.simulating : ACTION_LABELS.advanceWeek}</Button>
           </CardContent>
         </Card>
+        {showGate ? (
+          <AdvanceReadinessGate
+            gate={gate}
+            onAdvanceAnyway={handleGateAdvanceAnyway}
+            onReview={handleGateReview}
+            onCancel={() => setShowGate(false)}
+          />
+        ) : null}
         {allAttentionItems.length > 0 ? (
           <div className="weekly-urgent-list" style={{ marginTop: 8 }}>
             {allAttentionItems.slice(0, 3).map((item, idx) => (

--- a/src/ui/components/__tests__/advanceReadinessGate.test.jsx
+++ b/src/ui/components/__tests__/advanceReadinessGate.test.jsx
@@ -1,0 +1,361 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { buildAdvanceReadinessGate } from '../../utils/advanceReadinessGate.js';
+import AdvanceReadinessGate from '../AdvanceReadinessGate.jsx';
+import WeeklyHub from '../WeeklyHub.jsx';
+import { markWeeklyPrepStep } from '../../utils/weeklyPrep.js';
+
+// ─── shared fixtures ──────────────────────────────────────────────────────────
+
+function makeLeague({ phase = 'regular', injuries = false, noNextGame = false } = {}) {
+  const roster = [
+    { id: 11, pos: 'QB', ovr: 80, teamId: 1, depthChart: { rowKey: 'QB' } },
+  ];
+  if (injuries) {
+    roster.push({ id: 12, pos: 'WR', ovr: 75, teamId: 1, injuryWeeksRemaining: 3 });
+  }
+  return {
+    year: 2027,
+    week: 5,
+    seasonId: 's5',
+    phase,
+    userTeamId: 1,
+    teams: [
+      {
+        id: 1, name: 'Bears', abbr: 'CHI', conf: 0, div: 0,
+        wins: 2, losses: 2, ovr: 80, offenseRating: 78, defenseRating: 79,
+        recentResults: ['W', 'L', 'W', 'L'],
+        roster,
+      },
+      {
+        id: 2, name: 'Lions', abbr: 'DET', conf: 0, div: 1,
+        wins: 3, losses: 1, ovr: 82, offenseRating: 80, defenseRating: 81,
+        roster: [],
+      },
+    ],
+    schedule: {
+      weeks: noNextGame
+        ? []
+        : [{ week: 5, games: [{ id: 'g5', home: { id: 1 }, away: { id: 2 }, played: false }] }],
+    },
+    incomingTradeOffers: [],
+    leaguePulse: [],
+    newsItems: [],
+  };
+}
+
+// Minimal prep objects for unit-testing buildAdvanceReadinessGate in isolation
+function makeCleanPrep() {
+  return {
+    lineupIssues: [],
+    completion: { lineupChecked: true, injuriesReviewed: true, opponentScouted: true, planReviewed: true },
+    nextGame: { week: 5, isHome: true },
+    userTeam: { roster: [] },
+    prepSummary: { severity: 'ok', reasons: [] },
+    readinessTier: 'ok',
+  };
+}
+
+function makePrepWithDepthBlocker() {
+  return {
+    lineupIssues: [{
+      id: 'depth-QB',
+      level: 'urgent',
+      label: 'Depth chart blocker',
+      detail: 'QB slot has no assigned starter.',
+      actionTab: 'Roster:depth|ALL',
+    }],
+    completion: { lineupChecked: false, injuriesReviewed: true, opponentScouted: true, planReviewed: true },
+    nextGame: { week: 5, isHome: true },
+    userTeam: { roster: [] },
+    prepSummary: { severity: 'minor_risk', reasons: [] },
+    readinessTier: 'minor_risk',
+  };
+}
+
+function makePrepWithInjuries(reviewed = false) {
+  return {
+    lineupIssues: [],
+    completion: { lineupChecked: true, injuriesReviewed: reviewed, opponentScouted: true, planReviewed: true },
+    nextGame: { week: 5, isHome: true },
+    userTeam: { roster: [{ id: 11, pos: 'QB', ovr: 80, injuryWeeksRemaining: 2 }] },
+    prepSummary: { severity: 'minor_risk', reasons: [] },
+    readinessTier: 'minor_risk',
+  };
+}
+
+function makePrepWithPlanNotReviewed() {
+  return {
+    lineupIssues: [],
+    completion: { lineupChecked: true, injuriesReviewed: true, opponentScouted: true, planReviewed: false },
+    nextGame: { week: 5, isHome: true },
+    userTeam: { roster: [] },
+    prepSummary: { severity: 'minor_risk', reasons: [] },
+    readinessTier: 'minor_risk',
+  };
+}
+
+function makePrepWithMajorRisk() {
+  return {
+    lineupIssues: [],
+    completion: { lineupChecked: true, injuriesReviewed: true, opponentScouted: true, planReviewed: true },
+    nextGame: { week: 5, isHome: true },
+    userTeam: { roster: [] },
+    prepSummary: { severity: 'major_risk', reasons: ['Opponent defense is significantly stronger than your offense.'] },
+    readinessTier: 'major_risk',
+  };
+}
+
+// ─── buildAdvanceReadinessGate unit tests ────────────────────────────────────
+
+describe('buildAdvanceReadinessGate — core logic', () => {
+  it('returns no warning when prep is fully clean', () => {
+    const result = buildAdvanceReadinessGate({
+      league: makeLeague(),
+      prep: makeCleanPrep(),
+    });
+    expect(result.shouldWarn).toBe(false);
+    expect(result.riskItems.filter((i) => i.severity !== 'info')).toHaveLength(0);
+  });
+
+  it('returns warning when game plan has not been reviewed', () => {
+    const result = buildAdvanceReadinessGate({
+      league: makeLeague(),
+      prep: makePrepWithPlanNotReviewed(),
+    });
+    expect(result.shouldWarn).toBe(true);
+    expect(result.riskItems.some((i) => i.id === 'plan-not-reviewed')).toBe(true);
+    expect(result.riskItems.find((i) => i.id === 'plan-not-reviewed')?.label).toMatch(/game plan has not been reviewed/i);
+  });
+
+  it('returns warning when injuries exist and injuriesReviewed is false', () => {
+    const result = buildAdvanceReadinessGate({
+      league: makeLeague(),
+      prep: makePrepWithInjuries(false),
+    });
+    expect(result.shouldWarn).toBe(true);
+    expect(result.riskItems.some((i) => i.id === 'injuries-pending')).toBe(true);
+    expect(result.riskItems.find((i) => i.id === 'injuries-pending')?.label).toMatch(/injuries have not been reviewed/i);
+  });
+
+  it('returns no injury warning when injuries exist but injuriesReviewed is true', () => {
+    const result = buildAdvanceReadinessGate({
+      league: makeLeague(),
+      prep: makePrepWithInjuries(true),
+    });
+    const injuryItem = result.riskItems.find((i) => i.id === 'injuries-pending');
+    expect(injuryItem).toBeUndefined();
+  });
+
+  it('returns warning when depth chart blocker exists', () => {
+    const result = buildAdvanceReadinessGate({
+      league: makeLeague(),
+      prep: makePrepWithDepthBlocker(),
+    });
+    expect(result.shouldWarn).toBe(true);
+    expect(result.severity).toBe('danger');
+    expect(result.riskItems.some((i) => i.id === 'depth-blocker')).toBe(true);
+    expect(result.riskItems.find((i) => i.id === 'depth-blocker')?.label).toMatch(/depth chart blocker/i);
+  });
+
+  it('returns warning when prep impact is major_risk', () => {
+    const result = buildAdvanceReadinessGate({
+      league: makeLeague(),
+      prep: makePrepWithMajorRisk(),
+    });
+    expect(result.shouldWarn).toBe(true);
+    expect(result.riskItems.some((i) => i.id === 'major-prep-risk')).toBe(true);
+    expect(result.riskItems.find((i) => i.id === 'major-prep-risk')?.label).toMatch(/projected prep impact is negative/i);
+  });
+
+  it('returns no warning during offseason phases', () => {
+    for (const phase of ['offseason_resign', 'free_agency', 'draft']) {
+      const result = buildAdvanceReadinessGate({
+        league: makeLeague({ phase }),
+        prep: makePrepWithPlanNotReviewed(),
+      });
+      expect(result.shouldWarn).toBe(false);
+    }
+  });
+
+  it('opponent-not-scouted alone does not trigger shouldWarn (info only)', () => {
+    const prep = {
+      ...makeCleanPrep(),
+      completion: { lineupChecked: true, injuriesReviewed: true, opponentScouted: false, planReviewed: true },
+    };
+    const result = buildAdvanceReadinessGate({ league: makeLeague(), prep });
+    expect(result.shouldWarn).toBe(false);
+    expect(result.riskItems.find((i) => i.id === 'opponent-not-scouted')?.severity).toBe('info');
+  });
+
+  it('uses correct title copy when shouldWarn is true', () => {
+    const result = buildAdvanceReadinessGate({
+      league: makeLeague(),
+      prep: makePrepWithPlanNotReviewed(),
+    });
+    expect(result.title).toMatch(/advance with unresolved prep/i);
+    expect(result.summary).toMatch(/setup is not clean/i);
+  });
+
+  it('primaryFixDestination points to the most critical issue', () => {
+    const result = buildAdvanceReadinessGate({
+      league: makeLeague(),
+      prep: makePrepWithDepthBlocker(),
+    });
+    expect(result.primaryFixDestination).toBe('Team:Roster / Depth');
+  });
+
+  it('handles undefined/missing inputs without throwing', () => {
+    expect(() => buildAdvanceReadinessGate()).not.toThrow();
+    expect(() => buildAdvanceReadinessGate({ league: null, prep: null })).not.toThrow();
+    expect(buildAdvanceReadinessGate({ league: null }).shouldWarn).toBe(false);
+  });
+});
+
+// ─── AdvanceReadinessGate component tests ────────────────────────────────────
+
+describe('AdvanceReadinessGate component', () => {
+  afterEach(cleanup);
+
+  it('renders nothing when shouldWarn is false', () => {
+    const gate = buildAdvanceReadinessGate({ league: makeLeague(), prep: makeCleanPrep() });
+    const { container } = render(
+      <AdvanceReadinessGate gate={gate} onAdvanceAnyway={vi.fn()} onReview={vi.fn()} onCancel={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders gate panel with risk items when shouldWarn is true', () => {
+    const gate = buildAdvanceReadinessGate({ league: makeLeague(), prep: makePrepWithPlanNotReviewed() });
+    render(
+      <AdvanceReadinessGate gate={gate} onAdvanceAnyway={vi.fn()} onReview={vi.fn()} onCancel={vi.fn()} />,
+    );
+    expect(screen.getByTestId('advance-readiness-gate')).toBeTruthy();
+    expect(screen.getByText(/advance with unresolved prep/i)).toBeTruthy();
+    expect(screen.getByText(/game plan has not been reviewed/i)).toBeTruthy();
+  });
+
+  it('clicking Advance Anyway calls onAdvanceAnyway', () => {
+    const onAdvanceAnyway = vi.fn();
+    const gate = buildAdvanceReadinessGate({ league: makeLeague(), prep: makePrepWithPlanNotReviewed() });
+    render(
+      <AdvanceReadinessGate gate={gate} onAdvanceAnyway={onAdvanceAnyway} onReview={vi.fn()} onCancel={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByTestId('gate-advance-anyway-btn'));
+    expect(onAdvanceAnyway).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking Review Weekly Prep calls onReview with primaryFixDestination', () => {
+    const onReview = vi.fn();
+    // major-prep-risk → primaryFixDestination is 'Weekly Prep'
+    const gate = buildAdvanceReadinessGate({ league: makeLeague(), prep: makePrepWithMajorRisk() });
+    render(
+      <AdvanceReadinessGate gate={gate} onAdvanceAnyway={vi.fn()} onReview={onReview} onCancel={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByTestId('gate-review-btn'));
+    expect(onReview).toHaveBeenCalledTimes(1);
+    expect(onReview).toHaveBeenCalledWith('Weekly Prep');
+  });
+
+  it('clicking Cancel calls onCancel and does not call onAdvanceAnyway', () => {
+    const onCancel = vi.fn();
+    const onAdvanceAnyway = vi.fn();
+    const gate = buildAdvanceReadinessGate({ league: makeLeague(), prep: makePrepWithInjuries() });
+    render(
+      <AdvanceReadinessGate gate={gate} onAdvanceAnyway={onAdvanceAnyway} onReview={vi.fn()} onCancel={onCancel} />,
+    );
+    fireEvent.click(screen.getByTestId('gate-cancel-btn'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onAdvanceAnyway).not.toHaveBeenCalled();
+  });
+
+  it('shows the "Advance anyway" label from gate model', () => {
+    const gate = buildAdvanceReadinessGate({ league: makeLeague(), prep: makePrepWithPlanNotReviewed() });
+    render(
+      <AdvanceReadinessGate gate={gate} onAdvanceAnyway={vi.fn()} onReview={vi.fn()} onCancel={vi.fn()} />,
+    );
+    expect(screen.getByTestId('gate-advance-anyway-btn').textContent).toMatch(/advance anyway/i);
+  });
+});
+
+// ─── WeeklyHub advance gate integration tests ────────────────────────────────
+
+describe('WeeklyHub — advance gate integration', () => {
+  beforeEach(() => {
+    if (typeof window !== 'undefined' && window.localStorage) {
+      window.localStorage.clear();
+    }
+  });
+  afterEach(cleanup);
+
+  it('clicking Advance Week with prep risks shows the gate panel instead of advancing', () => {
+    const onAdvanceWeek = vi.fn();
+    const league = makeLeague({ injuries: true });
+    render(<WeeklyHub league={league} onNavigate={vi.fn()} onAdvanceWeek={onAdvanceWeek} busy={false} simulating={false} onOpenBoxScore={vi.fn()} />);
+
+    const advanceBtn = screen.getByRole('button', { name: /advance week/i });
+    fireEvent.click(advanceBtn);
+
+    expect(screen.getByTestId('advance-readiness-gate')).toBeTruthy();
+    expect(onAdvanceWeek).not.toHaveBeenCalled();
+  });
+
+  it('clicking Advance Week with fully clean prep advances immediately without gate', () => {
+    const onAdvanceWeek = vi.fn();
+    const league = makeLeague();
+    // Mark all prep steps complete in localStorage
+    markWeeklyPrepStep(league, 'lineupChecked', true);
+    markWeeklyPrepStep(league, 'injuriesReviewed', true);
+    markWeeklyPrepStep(league, 'opponentScouted', true);
+    markWeeklyPrepStep(league, 'planReviewed', true);
+    render(<WeeklyHub league={league} onNavigate={vi.fn()} onAdvanceWeek={onAdvanceWeek} busy={false} simulating={false} onOpenBoxScore={vi.fn()} />);
+
+    const advanceBtn = screen.getByRole('button', { name: /advance week/i });
+    fireEvent.click(advanceBtn);
+
+    // Gate should not appear since prep is clean; onAdvanceWeek called directly
+    expect(screen.queryByTestId('advance-readiness-gate')).toBeNull();
+    expect(onAdvanceWeek).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking Advance Anyway in gate calls onAdvanceWeek', () => {
+    const onAdvanceWeek = vi.fn();
+    const league = makeLeague({ injuries: true });
+    render(<WeeklyHub league={league} onNavigate={vi.fn()} onAdvanceWeek={onAdvanceWeek} busy={false} simulating={false} onOpenBoxScore={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /advance week/i }));
+    expect(screen.getByTestId('advance-readiness-gate')).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('gate-advance-anyway-btn'));
+    expect(onAdvanceWeek).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking Cancel in gate closes the panel without advancing', () => {
+    const onAdvanceWeek = vi.fn();
+    const league = makeLeague({ injuries: true });
+    render(<WeeklyHub league={league} onNavigate={vi.fn()} onAdvanceWeek={onAdvanceWeek} busy={false} simulating={false} onOpenBoxScore={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /advance week/i }));
+    expect(screen.getByTestId('advance-readiness-gate')).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('gate-cancel-btn'));
+    expect(screen.queryByTestId('advance-readiness-gate')).toBeNull();
+    expect(onAdvanceWeek).not.toHaveBeenCalled();
+  });
+
+  it('clicking Review Weekly Prep in gate navigates without advancing', () => {
+    const onAdvanceWeek = vi.fn();
+    const onNavigate = vi.fn();
+    const league = makeLeague({ injuries: true });
+    render(<WeeklyHub league={league} onNavigate={onNavigate} onAdvanceWeek={onAdvanceWeek} busy={false} simulating={false} onOpenBoxScore={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /advance week/i }));
+    fireEvent.click(screen.getByTestId('gate-review-btn'));
+
+    expect(onNavigate).toHaveBeenCalled();
+    expect(onAdvanceWeek).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('advance-readiness-gate')).toBeNull();
+  });
+});

--- a/src/ui/utils/advanceReadinessGate.js
+++ b/src/ui/utils/advanceReadinessGate.js
@@ -1,0 +1,145 @@
+const IN_SEASON_PHASES = new Set(['regular', 'playoffs', 'preseason']);
+
+function isPlayerInjured(player) {
+  return (
+    Number(player?.injuryWeeksRemaining ?? player?.injuredWeeks ?? player?.injuryDuration ?? 0) > 0 ||
+    ['injured', 'ir'].includes(String(player?.status ?? '').toLowerCase())
+  );
+}
+
+/**
+ * Builds a readiness gate view model for the Advance Week action.
+ *
+ * @param {{ league: object, prep: object, weeklyContext?: object }} input
+ * @returns {{ shouldWarn: boolean, severity: 'info'|'warning'|'danger', title: string,
+ *             summary: string, riskItems: Array, primaryFixDestination: string,
+ *             advanceAnywayLabel: string }}
+ */
+export function buildAdvanceReadinessGate({ league, prep, weeklyContext } = {}) {
+  const emptyResult = {
+    shouldWarn: false,
+    severity: 'info',
+    title: 'Advance to next week?',
+    summary: 'No prep blockers detected.',
+    riskItems: [],
+    primaryFixDestination: 'Weekly Prep',
+    advanceAnywayLabel: 'Advance anyway',
+  };
+
+  if (!IN_SEASON_PHASES.has(String(league?.phase ?? ''))) return emptyResult;
+
+  const riskItems = [];
+
+  // 1. Depth chart blocker (urgent-level lineup issue)
+  const depthBlocker = (prep?.lineupIssues ?? []).find(
+    (issue) => issue.level === 'urgent' && String(issue.label).toLowerCase().includes('depth chart blocker'),
+  );
+  if (depthBlocker) {
+    riskItems.push({
+      id: 'depth-blocker',
+      label: 'Depth chart blocker is still active.',
+      detail: depthBlocker.detail ?? 'A starter slot has no assigned player.',
+      severity: 'danger',
+      fixDestination: 'Team:Roster / Depth',
+    });
+  }
+
+  // 2. Injuries exist but have not been reviewed
+  const roster = Array.isArray(prep?.userTeam?.roster) ? prep.userTeam.roster : [];
+  const hasInjuries =
+    roster.some(isPlayerInjured) ||
+    (prep?.lineupIssues ?? []).some((issue) => issue.actionTab === 'Injuries');
+  const injuriesReviewed = prep?.completion?.injuriesReviewed ?? false;
+  if (hasInjuries && !injuriesReviewed) {
+    riskItems.push({
+      id: 'injuries-pending',
+      label: 'Injuries have not been reviewed.',
+      detail: 'Active injuries may affect depth chart readiness.',
+      severity: 'warning',
+      fixDestination: 'Team:Injuries',
+    });
+  }
+
+  // 3. Game plan not reviewed (only when an upcoming game exists)
+  const planReviewed = prep?.completion?.planReviewed ?? false;
+  if (prep?.nextGame && !planReviewed) {
+    riskItems.push({
+      id: 'plan-not-reviewed',
+      label: 'Game plan has not been reviewed.',
+      detail: 'Review and confirm your tactical script before kickoff.',
+      severity: 'warning',
+      fixDestination: 'Game Plan',
+    });
+  }
+
+  // 4. Opponent not scouted — info only; does not trigger shouldWarn alone
+  const opponentScouted = prep?.completion?.opponentScouted ?? false;
+  if (prep?.nextGame && !opponentScouted) {
+    riskItems.push({
+      id: 'opponent-not-scouted',
+      label: 'Opponent has not been scouted.',
+      detail: 'Review matchup intel before advancing.',
+      severity: 'info',
+      fixDestination: 'Weekly Prep',
+    });
+  }
+
+  // 5. Major negative prep impact from game plan / synergy evaluation
+  const prepSeverity = prep?.prepSummary?.severity ?? prep?.readinessTier;
+  if (prepSeverity === 'major_risk') {
+    riskItems.push({
+      id: 'major-prep-risk',
+      label: 'Projected prep impact is negative.',
+      detail:
+        prep?.prepSummary?.reasons?.[0] ??
+        'Game plan and prep state are working against this matchup.',
+      severity: 'danger',
+      fixDestination: 'Weekly Prep',
+    });
+  }
+
+  // 6. Cap/roster issue already flagged as danger-level by weeklyContext
+  const capIssueItem = (weeklyContext?.urgentItems ?? []).find(
+    (item) => item?.tab === 'Financials' && item?.tone === 'danger',
+  );
+  if (capIssueItem) {
+    riskItems.push({
+      id: 'cap-issue',
+      label: capIssueItem.label ?? 'Cap issue requires attention.',
+      detail: capIssueItem.detail ?? 'Review your cap situation before advancing.',
+      severity: 'danger',
+      fixDestination: 'Financials',
+    });
+  }
+
+  // Only warning/danger items trigger shouldWarn
+  const shouldWarn = riskItems.some(
+    (item) => item.severity === 'warning' || item.severity === 'danger',
+  );
+
+  const hasDanger = riskItems.some((item) => item.severity === 'danger');
+  const hasWarning = riskItems.some((item) => item.severity === 'warning');
+  const gateSeverity = hasDanger ? 'danger' : hasWarning ? 'warning' : 'info';
+
+  const title = shouldWarn ? 'Advance with unresolved prep?' : 'Advance to next week?';
+  const summary = shouldWarn
+    ? "You can still advance, but this week's setup is not clean."
+    : 'No prep blockers detected. Ready to advance.';
+
+  // primaryFixDestination: most critical item first
+  const primaryItem =
+    riskItems.find((item) => item.severity === 'danger') ??
+    riskItems.find((item) => item.severity === 'warning') ??
+    riskItems[0];
+  const primaryFixDestination = primaryItem?.fixDestination ?? 'Weekly Prep';
+
+  return {
+    shouldWarn,
+    severity: gateSeverity,
+    title,
+    summary,
+    riskItems,
+    primaryFixDestination,
+    advanceAnywayLabel: 'Advance anyway',
+  };
+}


### PR DESCRIPTION
Non-destructive pre-advance gate that warns when unresolved weekly prep
risks are detected and offers Review / Advance Anyway / Cancel paths.

- src/ui/utils/advanceReadinessGate.js: pure view-model helper
  Evaluates depth chart blockers, injury review status, game plan state,
  major-risk prep impact, and danger-level cap issues from weeklyContext.
  Returns shouldWarn, severity, riskItems, and primaryFixDestination.
  No-ops during offseason phases (resign / FA / draft).

- src/ui/components/AdvanceReadinessGate.jsx: compact inline panel
  Renders when shouldWarn is true; surfaces warning items, summary text,
  and three actions: Review weekly prep / Advance anyway / Cancel.

- WeeklyHub.jsx: both advance paths wired through the gate
  handlePrimaryAction (advance fallback) and secondary Advance Week
  button now call handleAdvanceOrGate; gate panel rendered inline below
  the primary action card.

- FranchiseHQ.jsx: both advance buttons wired through the gate
  Sticky gold Advance Week CTA and the Next Action panel Advance button
  call handleAdvanceOrGate; gate panel renders above sticky bar.
  Derives prep state and weeklyContext locally to reflect localStorage-
  backed game plan without a page reload.

- advanceReadinessGate.test.jsx: 22 new tests covering
  clean-prep no-warning, game-plan warning, injury warning, depth-blocker
  warning, major-risk warning, offseason bypass, Advance Anyway callback,
  Review navigation, Cancel without advance, WeeklyHub integration.

No DB schema change. No worker/protocol change. No sim tuning change.
Gate is never a hard blocker — Advance Anyway always available.

https://claude.ai/code/session_01J9cakSTmzmjoJeXccJPeUm