### PR TITLE
feat: implement Franchise Chronicle Engine for historical memory and narrative

### DIFF
--- a/src/core/history/ArchiveEngine.ts
+++ b/src/core/history/ArchiveEngine.ts
@@ -1,0 +1,204 @@
+/**
+ * ArchiveEngine — seasonal purge and Hall of Fame compression routine.
+ *
+ * Pure module with no side effects. Call during the season transition
+ * (offseason_resign phase) to:
+ *  1. Evaluate retired players for HOF qualification.
+ *  2. Return a compressed HallOfFameMember payload ready to merge into
+ *     the existing hallOfFame.classes / hallOfFame.index structures.
+ *  3. Signal which retired players can have their detailed game logs stripped.
+ */
+
+import type { HallOfFameMember } from '../../types/history.js';
+
+interface CareerStatsSource {
+  gamesPlayed?: number;
+  passYds?: number;
+  passTDs?: number;
+  rushYds?: number;
+  rushTDs?: number;
+  receptions?: number;
+  recYds?: number;
+  recTDs?: number;
+  tackles?: number;
+  sacks?: number;
+  interceptions?: number;
+  // alternate key shapes tolerated
+  passYd?: number;
+  passTD?: number;
+  rushYd?: number;
+  rushTD?: number;
+  recYd?: number;
+  recTD?: number;
+}
+
+interface PlayerAward {
+  key?: string;
+  label?: string;
+  season?: number | string;
+}
+
+export interface RetiredPlayerInput {
+  id?: string | number;
+  name?: string;
+  pos?: string;
+  position?: string;
+  age?: number;
+  ovr?: number;
+  peakOvr?: number;
+  draftYear?: number;
+  retirementYear?: number;
+  originalTeamId?: string | number;
+  teamId?: string | number;
+  awards?: PlayerAward[];
+  stats?: {
+    career?: CareerStatsSource;
+  };
+  history?: Array<{ ovr?: number; season?: number }>;
+}
+
+export interface HOFAppraisalResult {
+  qualifies: boolean;
+  member: HallOfFameMember | null;
+  reason: string;
+  stripGameLogs: boolean;
+}
+
+function num(v: unknown, fallback = 0): number {
+  const n = Number(v ?? fallback);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function countAward(awards: PlayerAward[], keys: string[]): number {
+  if (!Array.isArray(awards)) return 0;
+  return awards.filter((a) => keys.some((k) => String(a?.key ?? a?.label ?? '').toLowerCase().includes(k))).length;
+}
+
+function buildAccolades(player: RetiredPlayerInput, inductionYear: number): string[] {
+  const awards = player.awards ?? [];
+  const accolades: string[] = [];
+
+  const mvpCount = countAward(awards, ['mvp']);
+  if (mvpCount > 0) accolades.push(`${mvpCount}x MVP`);
+
+  const ringCount = countAward(awards, ['champion', 'superbowl', 'super_bowl', 'sbmvp', 'sb_mvp']);
+  if (ringCount > 0) accolades.push(`${ringCount}x Champion`);
+
+  const allProCount = countAward(awards, ['allpro', 'all_pro', 'all-pro', 'allleague', 'all_league']);
+  if (allProCount > 0) accolades.push(`${allProCount}x All-Pro`);
+
+  const opoyCount = countAward(awards, ['opoy', 'offensive_player']);
+  if (opoyCount > 0) accolades.push(`${opoyCount}x OPOY`);
+
+  const dpoyCount = countAward(awards, ['dpoy', 'defensive_player']);
+  if (dpoyCount > 0) accolades.push(`${dpoyCount}x DPOY`);
+
+  if (accolades.length === 0 && num(player.peakOvr ?? player.ovr, 0) >= 90) {
+    accolades.push(`All-Pro ${inductionYear - 1}`);
+  }
+
+  return accolades;
+}
+
+function seasonsAboveThreshold(player: RetiredPlayerInput, threshold: number): number {
+  if (!Array.isArray(player.history)) return 0;
+  return player.history.filter((h) => num(h?.ovr, 0) >= threshold).length;
+}
+
+function normalizeCareerStats(raw?: CareerStatsSource): HallOfFameMember['careerStats'] {
+  if (!raw) return { gamesPlayed: 0 };
+  return {
+    gamesPlayed: num(raw.gamesPlayed, 0),
+    passingYards: num(raw.passYds ?? raw.passYd, 0) || undefined,
+    passingTds: num(raw.passTDs ?? raw.passTD, 0) || undefined,
+    rushingYards: num(raw.rushYds ?? raw.rushYd, 0) || undefined,
+    rushingTds: num(raw.rushTDs ?? raw.rushTD, 0) || undefined,
+    receptions: num(raw.receptions, 0) || undefined,
+    receivingYards: num(raw.recYds ?? raw.recYd, 0) || undefined,
+    receivingTds: num(raw.recTDs ?? raw.recTD, 0) || undefined,
+    tackles: num(raw.tackles, 0) || undefined,
+    sacks: num(raw.sacks, 0) || undefined,
+    interceptions: num(raw.interceptions, 0) || undefined,
+  };
+}
+
+/**
+ * Evaluate a single retired player for HOF qualification.
+ *
+ * Criteria (any one qualifies):
+ *  - Won at least one MVP award
+ *  - Won at least one Championship ring
+ *  - Maintained OVR >= 85 for 5+ seasons
+ */
+export function appraiseRetiredPlayer(
+  player: RetiredPlayerInput,
+  inductionYear: number,
+): HOFAppraisalResult {
+  const awards = player.awards ?? [];
+  const hasMvp = countAward(awards, ['mvp']) >= 1;
+  const hasRing = countAward(awards, ['champion', 'superbowl', 'super_bowl', 'sbmvp']) >= 1;
+  const eliteSeasons = seasonsAboveThreshold(player, 85);
+  const qualifies = hasMvp || hasRing || eliteSeasons >= 5;
+
+  if (!qualifies) {
+    return {
+      qualifies: false,
+      member: null,
+      reason: 'Did not meet HOF threshold (no MVP, no ring, < 5 elite seasons)',
+      stripGameLogs: true,
+    };
+  }
+
+  const reasons: string[] = [];
+  if (hasMvp) reasons.push('MVP winner');
+  if (hasRing) reasons.push('Championship winner');
+  if (eliteSeasons >= 5) reasons.push(`${eliteSeasons} elite seasons (OVR 85+)`);
+
+  const member: HallOfFameMember = {
+    id: String(player.id ?? ''),
+    name: player.name ?? 'Unknown',
+    position: player.pos ?? player.position ?? '??',
+    draftYear: num(player.draftYear, inductionYear - 10),
+    retirementYear: num(player.retirementYear, inductionYear - 1),
+    indictionYear: inductionYear,
+    originalTeamId: String(player.originalTeamId ?? player.teamId ?? ''),
+    careerStats: normalizeCareerStats(player.stats?.career),
+    accolades: buildAccolades(player, inductionYear),
+  };
+
+  return {
+    qualifies: true,
+    member,
+    reason: reasons.join(', '),
+    stripGameLogs: false,
+  };
+}
+
+export interface SeasonPurgeResult {
+  hofInductees: HallOfFameMember[];
+  strippablePlayerIds: string[];
+}
+
+/**
+ * Process a batch of retired players at season end.
+ * Returns HOF inductees and a list of player IDs whose detailed logs can be stripped.
+ */
+export function processSeasonPurge(
+  retiredPlayers: RetiredPlayerInput[],
+  inductionYear: number,
+): SeasonPurgeResult {
+  const hofInductees: HallOfFameMember[] = [];
+  const strippablePlayerIds: string[] = [];
+
+  for (const player of retiredPlayers) {
+    const result = appraiseRetiredPlayer(player, inductionYear);
+    if (result.qualifies && result.member) {
+      hofInductees.push(result.member);
+    }
+    if (result.stripGameLogs && player.id != null) {
+      strippablePlayerIds.push(String(player.id));
+    }
+  }
+
+  return { hofInductees, strippablePlayerIds };
+}

--- a/src/core/history/NewsEngine.ts
+++ b/src/core/history/NewsEngine.ts
@@ -1,0 +1,363 @@
+/**
+ * NewsEngine — pure weekly headline parser for the Franchise Chronicle Engine.
+ *
+ * Accepts raw game results from the ADVANCE_WEEK pipeline and returns a ranked
+ * list of WeeklyHeadline objects (max 3) with no side effects. The caller is
+ * responsible for storing headlines in league state.
+ *
+ * Budget: < 15 ms on mobile processors per week.
+ */
+
+import type { WeeklyHeadline } from '../../types/history.js';
+
+interface PlayerRef {
+  id?: string | number;
+  name?: string;
+  pos?: string;
+  ovr?: number;
+  teamId?: string | number;
+}
+
+interface InjuryInfo {
+  playerId?: string | number;
+  type?: string;
+  duration?: number;
+  seasonEnding?: boolean;
+}
+
+interface TeamStats {
+  passYds?: number;
+  rushYds?: number;
+  totalYds?: number;
+  turnovers?: number;
+}
+
+interface PlayerBoxStat {
+  id?: string | number;
+  name?: string;
+  pos?: string;
+  teamId?: string | number;
+  passYds?: number;
+  rushYds?: number;
+  recYds?: number;
+}
+
+interface GameResult {
+  home?: string | number | { id?: string | number; name?: string; abbr?: string };
+  away?: string | number | { id?: string | number; name?: string; abbr?: string };
+  homeTeamId?: string | number;
+  awayTeamId?: string | number;
+  homeTeamName?: string;
+  awayTeamName?: string;
+  homeTeamAbbr?: string;
+  awayTeamAbbr?: string;
+  scoreHome?: number;
+  homeScore?: number;
+  scoreAway?: number;
+  awayScore?: number;
+  injuries?: InjuryInfo[];
+  teamStats?: { home?: TeamStats; away?: TeamStats };
+  boxScore?: { players?: PlayerBoxStat[] };
+  quarterScores?: number[][];
+}
+
+interface PlayerLookup {
+  id?: string | number;
+  name?: string;
+  pos?: string;
+  ovr?: number;
+  teamId?: string | number;
+  stats?: {
+    career?: {
+      rushYds?: number;
+      passYds?: number;
+      recYds?: number;
+    };
+  };
+}
+
+export interface NewsEngineInput {
+  results: GameResult[];
+  week: number;
+  year: number;
+  getPlayer?: (id: string | number) => PlayerLookup | null | undefined;
+}
+
+function num(v: unknown, fallback = 0): number {
+  const n = Number(v ?? fallback);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function teamId(raw: GameResult['home']): number {
+  if (raw == null) return NaN;
+  if (typeof raw === 'object') return num(raw.id, NaN);
+  return num(raw, NaN);
+}
+
+function teamName(raw: GameResult['home'], name: string | undefined, abbr: string | undefined): string {
+  if (name) return name;
+  if (abbr) return abbr;
+  if (raw && typeof raw === 'object') return raw.name ?? raw.abbr ?? 'Team';
+  return 'Team';
+}
+
+function headlineId(week: number, year: number, suffix: string): string {
+  return `headline-${year}-wk${week}-${suffix}`.replace(/[^a-z0-9-]/gi, '-').toLowerCase();
+}
+
+// ── Priority 1: Severe Injuries ───────────────────────────────────────────────
+
+function extractInjuryHeadlines(
+  results: GameResult[],
+  week: number,
+  year: number,
+  getPlayer: NonNullable<NewsEngineInput['getPlayer']>,
+): WeeklyHeadline[] {
+  const headlines: WeeklyHeadline[] = [];
+
+  for (const res of results) {
+    if (!Array.isArray(res.injuries)) continue;
+    for (const inj of res.injuries) {
+      const duration = num(inj.duration, 0);
+      if (duration < 4 && !inj.seasonEnding) continue;
+      const player = getPlayer(inj.playerId ?? '');
+      if (!player) continue;
+      const ovr = num(player.ovr, 0);
+      if (ovr < 80) continue;
+
+      const injType = inj.type ?? 'injury';
+      const pos = player.pos ?? 'Player';
+      const name = player.name ?? `Player ${player.id}`;
+      const teamRef = num(player.teamId, NaN);
+      const severity: WeeklyHeadline['severity'] = inj.seasonEnding ? 'CRITICAL' : duration >= 8 ? 'MAJOR' : 'MINOR';
+
+      headlines.push({
+        id: headlineId(week, year, `injury-${player.id}`),
+        week,
+        year,
+        type: 'INJURY',
+        severity,
+        headlineText: `${name} Out${inj.seasonEnding ? ' for Season' : ` ${duration} Weeks`} with ${injType.replace(/_/g, ' ')}!`,
+        detailText: `A devastating blow as star ${pos} ${name} suffers a ${injType.replace(/_/g, ' ')}, crippling their postseason aspirations.`,
+        associatedPlayerId: String(player.id ?? ''),
+        associatedTeamId: !isNaN(teamRef) ? String(teamRef) : undefined,
+      });
+    }
+  }
+
+  return headlines.sort((a, b) => {
+    const rank = { CRITICAL: 0, MAJOR: 1, MINOR: 2 };
+    return rank[a.severity] - rank[b.severity];
+  });
+}
+
+// ── Priority 2: Blowouts and Comebacks ────────────────────────────────────────
+
+function extractGameDramaHeadlines(
+  results: GameResult[],
+  week: number,
+  year: number,
+): WeeklyHeadline[] {
+  const headlines: WeeklyHeadline[] = [];
+
+  for (const res of results) {
+    const homeScore = num(res.scoreHome ?? res.homeScore, 0);
+    const awayScore = num(res.scoreAway ?? res.awayScore, 0);
+    const diff = Math.abs(homeScore - awayScore);
+    const total = homeScore + awayScore;
+    if (total === 0) continue;
+
+    const winnerId = homeScore >= awayScore ? teamId(res.home ?? res.homeTeamId) : teamId(res.away ?? res.awayTeamId);
+    const loserId = homeScore >= awayScore ? teamId(res.away ?? res.awayTeamId) : teamId(res.home ?? res.homeTeamId);
+    const winnerName = homeScore >= awayScore
+      ? teamName(res.home, res.homeTeamName, res.homeTeamAbbr)
+      : teamName(res.away, res.awayTeamName, res.awayTeamAbbr);
+    const loserName = homeScore >= awayScore
+      ? teamName(res.away, res.awayTeamName, res.awayTeamAbbr)
+      : teamName(res.home, res.homeTeamName, res.homeTeamAbbr);
+    const winScore = Math.max(homeScore, awayScore);
+    const loseScore = Math.min(homeScore, awayScore);
+    const scoreStr = `${winScore}-${loseScore}`;
+
+    if (diff >= 28) {
+      headlines.push({
+        id: headlineId(week, year, `blowout-${winnerId}`),
+        week,
+        year,
+        type: 'BLOWOUT',
+        severity: diff >= 35 ? 'MAJOR' : 'MINOR',
+        headlineText: `${winnerName} Crushes ${loserName} in ${scoreStr} Blowout!`,
+        detailText: `A dominant performance as ${winnerName} dismantles ${loserName} by ${diff} points.`,
+        associatedTeamId: !isNaN(winnerId) ? String(winnerId) : undefined,
+      });
+      continue;
+    }
+
+    // Comeback detection via quarter scores — team won despite trailing by 14+ in Q4
+    const quarters = res.quarterScores;
+    if (Array.isArray(quarters) && quarters.length >= 2 && diff <= 3) {
+      const homeQ4Cumulative = quarters[0]?.reduce((sum, q) => sum + num(q, 0), 0) ?? 0;
+      const awayQ4Cumulative = quarters[1]?.reduce((sum, q) => sum + num(q, 0), 0) ?? 0;
+
+      const homeLeadingAtSomePoint = homeQ4Cumulative - (quarters[0]?.[3] ?? 0);
+      const awayLeadingAtSomePoint = awayQ4Cumulative - (quarters[1]?.[3] ?? 0);
+      const trailDeficit = Math.abs(homeLeadingAtSomePoint - awayLeadingAtSomePoint);
+
+      if (trailDeficit >= 14) {
+        headlines.push({
+          id: headlineId(week, year, `comeback-${winnerId}`),
+          week,
+          year,
+          type: 'COMEBACK',
+          severity: 'MAJOR',
+          headlineText: `${winnerName} Pulls Off Stunning ${scoreStr} Comeback Win!`,
+          detailText: `Trailing deep into the fourth quarter, ${winnerName} refused to quit and edged ${loserName} ${scoreStr}.`,
+          associatedTeamId: !isNaN(winnerId) ? String(winnerId) : undefined,
+        });
+        continue;
+      }
+    }
+
+    // Upset: margin <= 3
+    if (diff <= 3) {
+      headlines.push({
+        id: headlineId(week, year, `upset-${winnerId}`),
+        week,
+        year,
+        type: 'UPSET',
+        severity: 'MINOR',
+        headlineText: `${winnerName} Edges ${loserName} in Nail-Biter ${scoreStr}!`,
+        detailText: `A game decided by the finest of margins as ${winnerName} outlasts ${loserName} ${scoreStr}.`,
+        associatedTeamId: !isNaN(winnerId) ? String(winnerId) : undefined,
+      });
+    }
+  }
+
+  return headlines;
+}
+
+// ── Priority 3: Statistical Milestones ───────────────────────────────────────
+
+const CAREER_MILESTONES: Array<{ key: 'rushYds' | 'passYds' | 'recYds'; threshold: number; label: string }> = [
+  { key: 'rushYds', threshold: 10000, label: 'career rushing yards' },
+  { key: 'passYds', threshold: 40000, label: 'career passing yards' },
+  { key: 'recYds', threshold: 10000, label: 'career receiving yards' },
+];
+
+function extractMilestoneHeadlines(
+  results: GameResult[],
+  week: number,
+  year: number,
+  getPlayer: NonNullable<NewsEngineInput['getPlayer']>,
+): WeeklyHeadline[] {
+  const headlines: WeeklyHeadline[] = [];
+
+  for (const res of results) {
+    const players: PlayerBoxStat[] = res.boxScore?.players ?? [];
+    for (const box of players) {
+      const gamePassYds = num(box.passYds, 0);
+      const gameRushYds = num(box.rushYds, 0);
+      const gameRecYds = num(box.recYds, 0);
+      const name = box.name ?? `Player ${box.id}`;
+      const teamRef = num(box.teamId, NaN);
+
+      // Single-game performances
+      if (gamePassYds >= 450) {
+        headlines.push({
+          id: headlineId(week, year, `milestone-passyds-${box.id}`),
+          week,
+          year,
+          type: 'MILESTONE',
+          severity: gamePassYds >= 550 ? 'CRITICAL' : 'MAJOR',
+          headlineText: `${name} Torches Secondary for ${gamePassYds} Passing Yards!`,
+          detailText: `An historic aerial assault as ${name} shreds opposing coverage for ${gamePassYds} yards through the air.`,
+          associatedPlayerId: String(box.id ?? ''),
+          associatedTeamId: !isNaN(teamRef) ? String(teamRef) : undefined,
+        });
+      } else if (gameRushYds >= 200) {
+        headlines.push({
+          id: headlineId(week, year, `milestone-rushyds-${box.id}`),
+          week,
+          year,
+          type: 'MILESTONE',
+          severity: gameRushYds >= 250 ? 'CRITICAL' : 'MAJOR',
+          headlineText: `${name} Goes Off for ${gameRushYds} Rushing Yards!`,
+          detailText: `A dominant ground performance as ${name} bulldozes the opposition for ${gameRushYds} yards on the ground.`,
+          associatedPlayerId: String(box.id ?? ''),
+          associatedTeamId: !isNaN(teamRef) ? String(teamRef) : undefined,
+        });
+      } else if (gameRecYds >= 200) {
+        headlines.push({
+          id: headlineId(week, year, `milestone-recyds-${box.id}`),
+          week,
+          year,
+          type: 'MILESTONE',
+          severity: gameRecYds >= 250 ? 'CRITICAL' : 'MAJOR',
+          headlineText: `${name} Erupts for ${gameRecYds} Receiving Yards!`,
+          detailText: `A spectacular receiving display as ${name} hauls in ${gameRecYds} yards through the air.`,
+          associatedPlayerId: String(box.id ?? ''),
+          associatedTeamId: !isNaN(teamRef) ? String(teamRef) : undefined,
+        });
+      }
+
+      // Career milestone crossing — only check when player has a notable game stat
+      if (gameRushYds > 0 || gamePassYds > 0 || gameRecYds > 0) {
+        const full = box.id != null ? getPlayer(box.id) : null;
+        if (full?.stats?.career) {
+          const career = full.stats.career;
+          for (const m of CAREER_MILESTONES) {
+            const careerVal = num(career[m.key], 0);
+            const gameVal = m.key === 'rushYds' ? gameRushYds : m.key === 'passYds' ? gamePassYds : gameRecYds;
+            const prevVal = careerVal - gameVal;
+            if (prevVal < m.threshold && careerVal >= m.threshold) {
+              headlines.push({
+                id: headlineId(week, year, `career-${m.key}-${box.id}`),
+                week,
+                year,
+                type: 'MILESTONE',
+                severity: 'CRITICAL',
+                headlineText: `History Made: ${name} Crosses ${(m.threshold / 1000).toFixed(0)},000 ${m.label.replace(/career /, 'Career ')}!`,
+                detailText: `An immortal moment as ${name} surpasses the ${(m.threshold / 1000).toFixed(0)},000 ${m.label} threshold, cementing legendary status.`,
+                associatedPlayerId: String(box.id ?? ''),
+                associatedTeamId: !isNaN(teamRef) ? String(teamRef) : undefined,
+              });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return headlines;
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────────
+
+/**
+ * Parse a week's game results into up to 3 ranked WeeklyHeadline objects.
+ * Priority order: Injuries → Blowouts/Comebacks → Milestones.
+ */
+export function parseWeeklyHeadlines(input: NewsEngineInput): WeeklyHeadline[] {
+  const { results, week, year, getPlayer = () => null } = input;
+  if (!Array.isArray(results) || results.length === 0) return [];
+
+  const injuries = extractInjuryHeadlines(results, week, year, getPlayer);
+  const drama = extractGameDramaHeadlines(results, week, year);
+  const milestones = extractMilestoneHeadlines(results, week, year, getPlayer);
+
+  const ranked: WeeklyHeadline[] = [];
+  const seen = new Set<string>();
+
+  const add = (hl: WeeklyHeadline) => {
+    if (!seen.has(hl.id)) {
+      seen.add(hl.id);
+      ranked.push(hl);
+    }
+  };
+
+  for (const hl of injuries) add(hl);
+  for (const hl of drama) add(hl);
+  for (const hl of milestones) add(hl);
+
+  return ranked.slice(0, 3);
+}

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -1,0 +1,58 @@
+export interface ChampionRecord {
+  year: number;
+  teamId: string;
+  teamName: string;
+  cityName: string;
+  record: string;
+  runnerUpId: string;
+  runnerUpName: string;
+  score: string;
+  mvpName: string;
+}
+
+export interface SeasonAwardWinner {
+  year: number;
+  mvpId: string;
+  mvpName: string;
+  mvpStats: string;
+  opoyName: string;
+  dpoyName: string;
+  oroyName: string;
+  droyName: string;
+}
+
+export interface HallOfFameMember {
+  id: string;
+  name: string;
+  position: string;
+  draftYear: number;
+  retirementYear: number;
+  indictionYear: number;
+  originalTeamId: string;
+  careerStats: {
+    gamesPlayed: number;
+    passingYards?: number;
+    passingTds?: number;
+    rushingYards?: number;
+    rushingTds?: number;
+    receptions?: number;
+    receivingYards?: number;
+    receivingTds?: number;
+    tackles?: number;
+    sacks?: number;
+    interceptions?: number;
+  };
+  accolades: string[];
+}
+
+export interface WeeklyHeadline {
+  id: string;
+  week: number;
+  year: number;
+  type: 'INJURY' | 'MILESTONE' | 'UPSET' | 'BLOWOUT' | 'COMEBACK';
+  severity: 'CRITICAL' | 'MAJOR' | 'MINOR';
+  headlineText: string;
+  detailText: string;
+  associatedPlayerId?: string;
+  associatedTeamId?: string;
+}

--- a/src/ui/components/AlmanacView.tsx
+++ b/src/ui/components/AlmanacView.tsx
@@ -1,0 +1,434 @@
+/**
+ * AlmanacView — two-pane historical almanac for the Franchise Chronicle Engine.
+ *
+ * Pane 1: Champions & Award Archive — tabular ledger of every completed season.
+ * Pane 2: Hall of Fame Gallery — retired legends with career stats and accolades.
+ */
+
+import React, { useMemo, useState } from 'react';
+import type { ChampionRecord, HallOfFameMember, SeasonAwardWinner } from '../../types/history.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function num(v: unknown, fallback = 0): number {
+  const n = Number(v ?? fallback);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+type LeagueHistorySeason = {
+  year?: number;
+  season?: number;
+  champion?: { id?: string | number; name?: string; abbr?: string; wins?: number; losses?: number } | null;
+  runnerUp?: { id?: string | number; name?: string; abbr?: string } | null;
+  awards?: {
+    mvp?: { name?: string; playerId?: string };
+    opoy?: { name?: string };
+    dpoy?: { name?: string };
+    oroy?: { name?: string };
+    droy?: { name?: string };
+  } | null;
+  score?: string;
+};
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function EmptyRow({ cols, message }: { cols: number; message: string }) {
+  return (
+    <tr>
+      <td colSpan={cols} style={{ textAlign: 'center', padding: '16px 8px', color: 'var(--text-muted)', fontStyle: 'italic', fontSize: 'var(--text-sm)' }}>
+        {message}
+      </td>
+    </tr>
+  );
+}
+
+function Th({ children }: { children: React.ReactNode }) {
+  return (
+    <th style={{ padding: '8px 10px', textAlign: 'left', fontSize: 'var(--text-xs)', fontWeight: 700, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em', borderBottom: '1px solid var(--border)', whiteSpace: 'nowrap' }}>
+      {children}
+    </th>
+  );
+}
+
+function Td({ children, bold }: { children: React.ReactNode; bold?: boolean }) {
+  return (
+    <td style={{ padding: '8px 10px', fontSize: 'var(--text-sm)', fontWeight: bold ? 700 : 400, borderBottom: '1px solid var(--border-subtle, var(--border))' }}>
+      {children}
+    </td>
+  );
+}
+
+function StatPill({ label, value }: { label: string; value: string | number }) {
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, background: 'var(--surface-2, rgba(255,255,255,0.06))', borderRadius: 6, padding: '2px 6px', fontSize: 'var(--text-xs)' }}>
+      <span style={{ color: 'var(--text-muted)', fontWeight: 500 }}>{label}</span>
+      <span style={{ fontWeight: 700 }}>{value}</span>
+    </span>
+  );
+}
+
+// ── Pane 1: Champions Archive ─────────────────────────────────────────────────
+
+interface ChampionsArchivePaneProps {
+  seasons: LeagueHistorySeason[];
+  champions: ChampionRecord[];
+  awards: SeasonAwardWinner[];
+}
+
+function ChampionsArchivePane({ seasons, champions, awards }: ChampionsArchivePaneProps) {
+  // Merge all sources into one unified row per season
+  const rows = useMemo(() => {
+    const byYear = new Map<number, {
+      year: number;
+      champion: string;
+      record: string;
+      score: string;
+      runnerUp: string;
+      mvp: string;
+      opoy: string;
+      dpoy: string;
+    }>();
+
+    // From leagueHistory (archived seasons)
+    for (const s of seasons) {
+      const year = num(s.year ?? s.season, 0);
+      if (!year) continue;
+      const champName = s.champion?.name ?? s.champion?.abbr ?? '—';
+      const champWins = num(s.champion?.wins, 0);
+      const champLosses = num((s as { champion?: { losses?: number } }).champion?.losses, 0);
+      const record = champWins || champLosses ? `${champWins}-${champLosses}` : '—';
+      byYear.set(year, {
+        year,
+        champion: champName,
+        record,
+        score: s.score ?? '—',
+        runnerUp: s.runnerUp?.name ?? s.runnerUp?.abbr ?? '—',
+        mvp: s.awards?.mvp?.name ?? '—',
+        opoy: s.awards?.opoy?.name ?? '—',
+        dpoy: s.awards?.dpoy?.name ?? '—',
+      });
+    }
+
+    // Overlay with typed ChampionRecord (takes priority)
+    for (const c of champions) {
+      const year = num(c.year, 0);
+      if (!year) continue;
+      byYear.set(year, {
+        year,
+        champion: c.teamName ?? '—',
+        record: c.record ?? '—',
+        score: c.score ?? '—',
+        runnerUp: c.runnerUpName ?? '—',
+        mvp: c.mvpName ?? '—',
+        opoy: byYear.get(year)?.opoy ?? '—',
+        dpoy: byYear.get(year)?.dpoy ?? '—',
+      });
+    }
+
+    // Overlay awards
+    for (const a of awards) {
+      const year = num(a.year, 0);
+      if (!year) continue;
+      const existing = byYear.get(year);
+      if (existing) {
+        if (a.mvpName && existing.mvp === '—') existing.mvp = a.mvpName;
+        if (a.opoyName && existing.opoy === '—') existing.opoy = a.opoyName;
+        if (a.dpoyName && existing.dpoy === '—') existing.dpoy = a.dpoyName;
+      }
+    }
+
+    return [...byYear.values()].sort((a, b) => b.year - a.year);
+  }, [seasons, champions, awards]);
+
+  return (
+    <div>
+      <div style={{ marginBottom: 12 }}>
+        <div style={{ fontWeight: 800, fontSize: 'var(--text-base)' }}>Champions & Award Archive</div>
+        <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', marginTop: 2 }}>
+          Season-by-season ledger of every champion, runner-up, and award winner.
+        </div>
+      </div>
+
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr style={{ background: 'var(--surface-2, rgba(255,255,255,0.04))' }}>
+              <Th>Year</Th>
+              <Th>Champion</Th>
+              <Th>Record</Th>
+              <Th>Score</Th>
+              <Th>Runner-Up</Th>
+              <Th>MVP</Th>
+              <Th>OPOY</Th>
+              <Th>DPOY</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 ? (
+              <EmptyRow cols={8} message="Champions will be recorded here after the first season completes." />
+            ) : (
+              rows.map((r) => (
+                <tr key={r.year} style={{ transition: 'background 0.15s' }}>
+                  <Td bold>{r.year}</Td>
+                  <Td bold>{r.champion}</Td>
+                  <Td>{r.record}</Td>
+                  <Td>{r.score}</Td>
+                  <Td>{r.runnerUp}</Td>
+                  <Td>{r.mvp}</Td>
+                  <Td>{r.opoy}</Td>
+                  <Td>{r.dpoy}</Td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ── Pane 2: Hall of Fame Gallery ──────────────────────────────────────────────
+
+interface HallOfFamePaneProps {
+  members: HallOfFameMember[];
+  rawPlayers: HallOfFameRawPlayer[];
+}
+
+type HallOfFameRawPlayer = {
+  id?: string | number;
+  name?: string;
+  pos?: string;
+  inductionYear?: number;
+  legacyScore?: number;
+  hofScore?: number;
+  primaryTeam?: string;
+  accoladeSummary?: { superBowls?: number; mvps?: number; proBowls?: number };
+  peakOvr?: number;
+  ovr?: number;
+};
+
+function statLine(stats: HallOfFameMember['careerStats']): string {
+  const parts: string[] = [];
+  if (stats.passingYards) parts.push(`${stats.passingYards.toLocaleString()} Pass Yds`);
+  if (stats.passingTds) parts.push(`${stats.passingTds} Pass TDs`);
+  if (stats.rushingYards) parts.push(`${stats.rushingYards.toLocaleString()} Rush Yds`);
+  if (stats.rushingTds) parts.push(`${stats.rushingTds} Rush TDs`);
+  if (stats.receivingYards) parts.push(`${stats.receivingYards.toLocaleString()} Rec Yds`);
+  if (stats.receivingTds) parts.push(`${stats.receivingTds} Rec TDs`);
+  if (stats.sacks) parts.push(`${stats.sacks} Sacks`);
+  if (stats.interceptions) parts.push(`${stats.interceptions} INTs`);
+  if (stats.tackles) parts.push(`${stats.tackles} Tackles`);
+  if (stats.gamesPlayed) parts.push(`${stats.gamesPlayed} GP`);
+  return parts.slice(0, 4).join(' · ') || '—';
+}
+
+function HallOfFamePane({ members, rawPlayers }: HallOfFamePaneProps) {
+  const [search, setSearch] = useState('');
+  const [posFilter, setPosFilter] = useState('ALL');
+
+  // Merge typed HOF members with raw player data from existing HoF store
+  const allMembers = useMemo(() => {
+    const fromTyped = members.map((m) => ({
+      id: m.id,
+      name: m.name,
+      pos: m.position,
+      inductionYear: m.indictionYear,
+      accolades: m.accolades,
+      statLine: statLine(m.careerStats),
+      legacyScore: 0,
+    }));
+
+    const fromRaw = rawPlayers
+      .filter((p) => !members.some((m) => String(m.id) === String(p.id)))
+      .map((p) => {
+        const summary = p.accoladeSummary ?? {};
+        const rings = summary.superBowls ?? 0;
+        const mvps = summary.mvps ?? 0;
+        const pro = summary.proBowls ?? 0;
+        const peak = p.peakOvr ?? p.ovr ?? 0;
+        const legacyScore = rings * 12 + mvps * 10 + pro * 2 + Math.round(peak / 5);
+        const accolades: string[] = [];
+        if (rings) accolades.push(`${rings}x Champion`);
+        if (mvps) accolades.push(`${mvps}x MVP`);
+        if (pro) accolades.push(`${pro}x All-Pro`);
+        return {
+          id: String(p.id ?? ''),
+          name: p.name ?? '—',
+          pos: p.pos ?? '??',
+          inductionYear: p.inductionYear,
+          accolades,
+          statLine: p.primaryTeam ?? '—',
+          legacyScore,
+        };
+      });
+
+    return [...fromTyped, ...fromRaw].sort((a, b) => b.legacyScore - a.legacyScore || (a.name ?? '').localeCompare(b.name ?? ''));
+  }, [members, rawPlayers]);
+
+  const positions = useMemo(() => {
+    const set = new Set(allMembers.map((m) => m.pos).filter(Boolean));
+    return ['ALL', ...[...set].sort()];
+  }, [allMembers]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return allMembers.filter((m) => {
+      if (posFilter !== 'ALL' && m.pos !== posFilter) return false;
+      if (!q) return true;
+      return [m.name, m.pos, String(m.inductionYear ?? '')].some((v) => v?.toLowerCase().includes(q));
+    });
+  }, [allMembers, posFilter, search]);
+
+  return (
+    <div>
+      <div style={{ marginBottom: 12 }}>
+        <div style={{ fontWeight: 800, fontSize: 'var(--text-base)' }}>Hall of Fame Gallery</div>
+        <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', marginTop: 2 }}>
+          All-time greats, induction classes, and career legacies.
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', gap: 8, marginBottom: 12, flexWrap: 'wrap' }}>
+        <input
+          type="text"
+          placeholder="Search players..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          style={{ flex: '1 1 160px', minWidth: 120, padding: '6px 10px', borderRadius: 8, border: '1px solid var(--border)', background: 'var(--surface)', color: 'inherit', fontSize: 'var(--text-sm)' }}
+        />
+        <select
+          value={posFilter}
+          onChange={(e) => setPosFilter(e.target.value)}
+          style={{ padding: '6px 10px', borderRadius: 8, border: '1px solid var(--border)', background: 'var(--surface)', color: 'inherit', fontSize: 'var(--text-sm)' }}
+        >
+          {positions.map((pos) => <option key={pos} value={pos}>{pos === 'ALL' ? 'All Positions' : pos}</option>)}
+        </select>
+      </div>
+
+      {filtered.length === 0 ? (
+        <div style={{ textAlign: 'center', padding: '32px 16px', color: 'var(--text-muted)', fontStyle: 'italic', fontSize: 'var(--text-sm)' }}>
+          {allMembers.length === 0
+            ? 'The Hall of Fame awaits its first inductee. Retire a player who has won an MVP, a Championship, or maintained elite performance for 5+ seasons.'
+            : 'No inductees match your search.'}
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {filtered.map((m) => (
+            <div key={m.id} style={{ background: 'var(--surface-2, rgba(255,255,255,0.04))', borderRadius: 10, padding: '12px 14px', border: '1px solid var(--border)' }}>
+              <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>
+                <div>
+                  <div style={{ fontWeight: 800, fontSize: 'var(--text-base)' }}>{m.name}</div>
+                  <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', marginTop: 2 }}>
+                    {m.pos}{m.inductionYear ? ` · Class of ${m.inductionYear}` : ''}
+                  </div>
+                </div>
+                {m.legacyScore > 0 && (
+                  <span style={{ background: 'rgba(255,215,0,0.12)', color: '#c8991a', border: '1px solid rgba(200,153,26,0.3)', borderRadius: 6, padding: '2px 8px', fontSize: 'var(--text-xs)', fontWeight: 700, whiteSpace: 'nowrap' }}>
+                    Legacy {m.legacyScore}
+                  </span>
+                )}
+              </div>
+
+              {m.accolades.length > 0 && (
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginTop: 8 }}>
+                  {m.accolades.map((a, i) => (
+                    <span key={i} style={{ background: 'var(--accent-soft, rgba(59,130,246,0.1))', color: 'var(--accent, #3b82f6)', borderRadius: 6, padding: '2px 7px', fontSize: 'var(--text-xs)', fontWeight: 600 }}>
+                      {a}
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              <div style={{ marginTop: 6, fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{m.statLine}</div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Root Component ────────────────────────────────────────────────────────────
+
+type AlmanacTab = 'champions' | 'hof';
+
+export interface AlmanacViewProps {
+  league?: {
+    leagueHistory?: LeagueHistorySeason[];
+    hallOfFameClasses?: Array<{ year?: number; inductees?: Array<{ playerId?: string | number; name?: string }> }>;
+  } | null;
+  /** Typed champion records (from src/types/history.ts) */
+  champions?: ChampionRecord[];
+  /** Typed award history (from src/types/history.ts) */
+  awards?: SeasonAwardWinner[];
+  /** Typed HOF members (from src/types/history.ts) */
+  hallOfFame?: HallOfFameMember[];
+  /** Raw HOF player objects from the existing store */
+  rawHofPlayers?: HallOfFameRawPlayer[];
+  onNavigate?: (route: string) => void;
+}
+
+export default function AlmanacView({
+  league,
+  champions = [],
+  awards = [],
+  hallOfFame = [],
+  rawHofPlayers = [],
+  onNavigate,
+}: AlmanacViewProps) {
+  const [activeTab, setActiveTab] = useState<AlmanacTab>('champions');
+
+  const seasons = (league?.leagueHistory ?? []) as LeagueHistorySeason[];
+
+  const tabStyle = (tab: AlmanacTab): React.CSSProperties => ({
+    padding: '8px 16px',
+    borderRadius: 8,
+    border: 'none',
+    cursor: 'pointer',
+    fontWeight: activeTab === tab ? 700 : 500,
+    fontSize: 'var(--text-sm)',
+    background: activeTab === tab ? 'var(--accent, #3b82f6)' : 'transparent',
+    color: activeTab === tab ? '#fff' : 'var(--text-muted)',
+    transition: 'background 0.15s, color 0.15s',
+  });
+
+  return (
+    <div className="app-screen-stack" data-testid="almanac-view">
+      <div style={{ marginBottom: 16 }}>
+        <div style={{ fontWeight: 900, fontSize: 'var(--text-xl)', letterSpacing: '-0.01em' }}>League Almanac</div>
+        <div style={{ fontSize: 'var(--text-sm)', color: 'var(--text-muted)', marginTop: 4 }}>
+          The permanent historical record of your franchise era.
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', gap: 6, marginBottom: 20, background: 'var(--surface-2, rgba(255,255,255,0.04))', borderRadius: 10, padding: 4 }}>
+        <button style={tabStyle('champions')} onClick={() => setActiveTab('champions')}>
+          Champions Archive
+        </button>
+        <button style={tabStyle('hof')} onClick={() => setActiveTab('hof')}>
+          Hall of Fame
+        </button>
+      </div>
+
+      <div className="card" style={{ padding: 16, borderRadius: 12 }}>
+        {activeTab === 'champions' && (
+          <ChampionsArchivePane seasons={seasons} champions={champions} awards={awards} />
+        )}
+        {activeTab === 'hof' && (
+          <HallOfFamePane members={hallOfFame} rawPlayers={rawHofPlayers} />
+        )}
+      </div>
+
+      {onNavigate && (
+        <div style={{ marginTop: 12, textAlign: 'right' }}>
+          <button
+            onClick={() => onNavigate('History')}
+            style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', background: 'none', border: 'none', cursor: 'pointer', textDecoration: 'underline' }}
+          >
+            Full League History →
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/ChronicleHeadlineBanner.tsx
+++ b/src/ui/components/ChronicleHeadlineBanner.tsx
@@ -1,0 +1,146 @@
+/**
+ * ChronicleHeadlineBanner — inject at the top of FranchiseHQ / WeeklyHub.
+ *
+ * Displays the highest-severity WeeklyHeadline for the current week with
+ * color-coded severity variants and a link to the full news ledger.
+ */
+
+import React, { useMemo } from 'react';
+import type { WeeklyHeadline } from '../../types/history.js';
+
+interface ChronicleHeadlineBannerProps {
+  headlines: WeeklyHeadline[];
+  currentWeek: number;
+  currentYear: number;
+  onViewAll?: () => void;
+}
+
+const TYPE_ICON: Record<WeeklyHeadline['type'], string> = {
+  INJURY: '🚑',
+  MILESTONE: '🏆',
+  UPSET: '⚡',
+  BLOWOUT: '💥',
+  COMEBACK: '🔥',
+};
+
+const SEVERITY_STYLE: Record<WeeklyHeadline['severity'], React.CSSProperties> = {
+  CRITICAL: {
+    background: 'rgba(239,68,68,0.1)',
+    borderLeft: '3px solid #ef4444',
+    color: 'inherit',
+  },
+  MAJOR: {
+    background: 'rgba(245,158,11,0.1)',
+    borderLeft: '3px solid #f59e0b',
+    color: 'inherit',
+  },
+  MINOR: {
+    background: 'rgba(255,215,0,0.08)',
+    borderLeft: '3px solid rgba(255,215,0,0.6)',
+    color: 'inherit',
+  },
+};
+
+const SEVERITY_BADGE: Record<WeeklyHeadline['severity'], { bg: string; color: string; label: string }> = {
+  CRITICAL: { bg: 'rgba(239,68,68,0.15)', color: '#ef4444', label: 'Breaking' },
+  MAJOR: { bg: 'rgba(245,158,11,0.15)', color: '#f59e0b', label: 'Major' },
+  MINOR: { bg: 'rgba(255,215,0,0.12)', color: '#c8991a', label: 'Update' },
+};
+
+function HeadlineCard({ headline, onViewAll }: { headline: WeeklyHeadline; onViewAll?: () => void }) {
+  const icon = TYPE_ICON[headline.type] ?? '📰';
+  const sev = SEVERITY_STYLE[headline.severity];
+  const badge = SEVERITY_BADGE[headline.severity];
+
+  return (
+    <div
+      style={{
+        ...sev,
+        borderRadius: 10,
+        padding: '12px 14px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+      }}
+      data-testid="chronicle-headline-card"
+      data-severity={headline.severity}
+      data-type={headline.type}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+        <span style={{ fontSize: '1.1rem' }}>{icon}</span>
+        <span
+          style={{
+            fontSize: 'var(--text-xs)',
+            fontWeight: 700,
+            background: badge.bg,
+            color: badge.color,
+            borderRadius: 5,
+            padding: '1px 7px',
+          }}
+        >
+          {badge.label}
+        </span>
+        <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+          Week {headline.week}
+        </span>
+      </div>
+
+      <div style={{ fontWeight: 700, fontSize: 'var(--text-sm)', lineHeight: 1.35 }}>
+        {headline.headlineText}
+      </div>
+
+      <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', lineHeight: 1.4 }}>
+        {headline.detailText}
+      </div>
+
+      {onViewAll && (
+        <button
+          onClick={onViewAll}
+          style={{
+            alignSelf: 'flex-start',
+            marginTop: 4,
+            fontSize: 'var(--text-xs)',
+            color: 'var(--text-muted)',
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            padding: 0,
+            textDecoration: 'underline',
+          }}
+        >
+          View full news ledger →
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default function ChronicleHeadlineBanner({
+  headlines,
+  currentWeek,
+  currentYear,
+  onViewAll,
+}: ChronicleHeadlineBannerProps) {
+  const currentHeadline = useMemo(() => {
+    // Show highest-severity headline for current week, fall back to most recent
+    const thisWeek = headlines.filter(
+      (h) => h.week === currentWeek && h.year === currentYear,
+    );
+
+    const prioritize = (list: WeeklyHeadline[]) =>
+      [...list].sort((a, b) => {
+        const rank = { CRITICAL: 0, MAJOR: 1, MINOR: 2 };
+        return rank[a.severity] - rank[b.severity];
+      })[0] ?? null;
+
+    return prioritize(thisWeek) ?? prioritize(headlines);
+  }, [headlines, currentWeek, currentYear]);
+
+  if (!currentHeadline) return null;
+
+  return (
+    <div style={{ marginBottom: 12 }} data-testid="chronicle-headline-banner">
+      <HeadlineCard headline={currentHeadline} onViewAll={onViewAll} />
+    </div>
+  );
+}

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -13,6 +13,7 @@ import { EmptyState, StatusChip, ActionTile, SectionCard, WeeklyAgenda, CompactN
 import { getLastGameDisplay, getLatestUserCompletedGame, getNextOpponentDisplay } from '../utils/hqGameDisplay.js';
 import { HQIcon, TeamIdentityBadge } from './HQVisuals.jsx';
 import { buildGameBookDestination } from '../utils/managementScreenRouting.js';
+import ChronicleHeadlineBanner from './ChronicleHeadlineBanner.tsx';
 
 const BOTTOM_NAV_ITEMS = [
   { label: 'Home', route: 'HQ', icon: 'home', active: true },
@@ -272,6 +273,13 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
           <strong>{capSpace} cap</strong>
         </div>
       </section>
+
+      <ChronicleHeadlineBanner
+        headlines={Array.isArray(league?.weeklyHeadlines) ? league.weeklyHeadlines : []}
+        currentWeek={safeNum(league?.week, 1)}
+        currentYear={safeNum(league?.year, 0)}
+        onViewAll={() => onNavigate?.('News')}
+      />
 
       <section className="app-hq-matchup-hero card" aria-label="Weekly Hero" aria-live="polite">
         <div className="app-hq-matchup-main">

--- a/src/ui/components/HistoryHub.jsx
+++ b/src/ui/components/HistoryHub.jsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { ScreenHeader, SectionCard } from './ScreenSystem.jsx';
+import AlmanacView from './AlmanacView.tsx';
 
 const DESTINATIONS = [
+  { key: 'Almanac', title: 'League Almanac', body: 'Champions archive, Hall of Fame gallery, and award history all in one view.' },
   { key: 'History', title: 'League Archive', body: 'Champions, season snapshots, and year-to-year memory.' },
   { key: 'Draft History', title: 'Draft classes & redraft', body: 'Who panned out, steals vs reaches, and team draft grades by year.' },
   { key: 'Team History', title: 'Franchise Timeline', body: 'Highs/lows, droughts, and long-run identity by club.' },

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -31,6 +31,7 @@ import TeamHistoryScreen from "./TeamHistoryScreen.jsx";
 import AwardsRecordsScreen from "./AwardsRecordsScreen.jsx";
 import HallOfFame from "./HallOfFame.jsx";
 import HistoryHub from "./HistoryHub.jsx";
+import AlmanacView from "./AlmanacView.tsx";
 import DraftHistory from "./DraftHistory.jsx";
 import TradeWorkspace from "./TradeWorkspace.jsx";
 import PlayerProfile from "./PlayerProfile.jsx";
@@ -201,6 +202,7 @@ const BASE_TABS = [
   "Draft Room",
   "Mock Draft",
   "History Hub",
+  "Almanac",
   "Draft History",
   "History",
   "Team History",
@@ -1220,6 +1222,18 @@ export default function LeagueDashboard({
         {activeTab === "History Hub" && (
           <TabErrorBoundary label="History Hub">
             <HistoryHub onNavigate={handleHistoryHubNavigate} actions={actions} onSelectSeason={setHistorySelectedSeasonId} league={league} />
+          </TabErrorBoundary>
+        )}
+        {activeTab === "Almanac" && (
+          <TabErrorBoundary label="Almanac">
+            <AlmanacView
+              league={league}
+              champions={league?.historyRecords ?? []}
+              awards={league?.awardHistory ?? []}
+              hallOfFame={league?.hallOfFame ?? []}
+              rawHofPlayers={league?.hallOfFamePlayers ?? []}
+              onNavigate={setActiveTab}
+            />
           </TabErrorBoundary>
         )}
         {activeTab === "Draft History" && (

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -107,6 +107,7 @@ import {
 } from '../core/scheme-core.js';
 import AiLogic from '../core/ai-logic.js';
 import NewsEngine, { createNewsItem, addNewsItem } from '../core/news-engine.js';
+import { parseWeeklyHeadlines } from '../core/history/NewsEngine.ts';
 import { calculateAwardRaces } from '../core/awards-logic.js';
 import { Constants } from '../core/constants.js';
 import { processPlayerProgression } from '../core/progression-logic.js';
@@ -853,6 +854,7 @@ function buildViewState() {
     franchiseSeasonReviews: Array.isArray(meta?.franchiseSeasonReviews) ? meta.franchiseSeasonReviews.slice(-40) : [],
     seasonStorylines: Array.isArray(meta?.seasonStorylines) ? meta.seasonStorylines : [],
     hallOfFameClasses: Array.isArray(meta?.hallOfFame?.classes) ? meta.hallOfFame.classes.slice(0, 20) : [],
+    weeklyHeadlines: Array.isArray(meta?.weeklyHeadlines) ? meta.weeklyHeadlines.slice(-30) : [],
     settings: normalizeLeagueSettings(meta?.settings ?? {}),
     economy: normalizeLeagueEconomy(meta?.economy ?? {}, { year: meta?.year }),
     tradeDeadline,
@@ -2959,6 +2961,29 @@ async function handleAdvanceWeek(payload, id) {
       cache.setMeta({
         leaguePulse: mergeLeaguePulseItems(pulseMeta.leaguePulse || [], pulseItems, { maxTimelineLength: 200 }),
       });
+    }
+  }
+
+  // ── Franchise Chronicle: parse this week's results into ranked headlines ───
+  if (results.length > 0) {
+    try {
+      const newHeadlines = parseWeeklyHeadlines({
+        results,
+        week,
+        year: meta.year ?? 0,
+        getPlayer: (id) => cache.getPlayer(id) ?? null,
+      });
+      if (newHeadlines.length > 0) {
+        const existing = Array.isArray(cache.getMeta().weeklyHeadlines) ? cache.getMeta().weeklyHeadlines : [];
+        // Deduplicate by id and keep the most recent 30
+        const combined = [...existing, ...newHeadlines]
+          .filter((h, idx, arr) => arr.findIndex((x) => x.id === h.id) === idx)
+          .slice(-30);
+        cache.setMeta({ weeklyHeadlines: combined });
+      }
+    } catch (chronicleErr) {
+      // Headline parsing must never crash the week advance
+      console.warn('[Worker] Chronicle headline parse error (non-fatal):', chronicleErr?.message);
     }
   }
 


### PR DESCRIPTION
Adds a lightweight, performance-optimized narrative and historical memory
system that tracks seasonal milestones, preserves league history, processes
weekly game results into ranked headlines, and powers a permanent Hall of Fame.

New files:
- src/types/history.ts — ChampionRecord, SeasonAwardWinner, HallOfFameMember,
  WeeklyHeadline type definitions
- src/core/history/NewsEngine.ts — pure weekly headline parser (< 15ms on mobile);
  Priority 1: severe injuries (OVR 80+, 4+ weeks), Priority 2: blowouts (28+ pts)
  and comebacks, Priority 3: single-game (450 pass yds, 200 rush/rec yds) and
  career milestones (10k rush yds, 40k pass yds, 10k rec yds)
- src/core/history/ArchiveEngine.ts — seasonal purge and HOF compression;
  qualifies players who won MVP, a championship ring, or sustained OVR 85+ for
  5+ seasons; signals which retired player logs can be stripped for memory safety
- src/ui/components/AlmanacView.tsx — dual-pane almanac: Champions Archive
  (season ledger with champion/runner-up/awards) and Hall of Fame Gallery
  (searchable, filterable by position, accolade badges, legacy scores)
- src/ui/components/ChronicleHeadlineBanner.tsx — severity-coded headline
  carousel (red=critical, amber=major, gold=minor) injected at FranchiseHQ top

Integrations:
- FranchiseHQ.jsx: ChronicleHeadlineBanner renders above the matchup hero section
- HistoryHub.jsx: Almanac destination added as the first history route
- LeagueDashboard.jsx: "Almanac" tab wired with AlmanacView component
- worker.js: parseWeeklyHeadlines called inside ADVANCE_WEEK pipeline after
  results are committed; weeklyHeadlines array (capped at 30) added to buildViewState