### PR TITLE
Fix Daily Regression Tests and Increase Tension

### DIFF
--- a/src/ui/utils/advanceReadinessGate.js
+++ b/src/ui/utils/advanceReadinessGate.js
@@ -66,7 +66,7 @@ export function buildAdvanceReadinessGate({ league, prep, weeklyContext } = {}) 
     riskItems.push({
       id: 'plan-not-reviewed',
       label: 'Game plan has not been reviewed.',
-      detail: 'Review and confirm your tactical script before kickoff.',
+      detail: 'Review and confirm your tactical script before kickoff. Poor execution here can cost you the game.',
       severity: 'warning',
       fixDestination: 'Game Plan',
     });

--- a/tests/e2e/helpers/franchise.js
+++ b/tests/e2e/helpers/franchise.js
@@ -195,6 +195,7 @@ export async function simulateSingleWeek(page) {
       else if (window.handleGlobalAdvance) window.handleGlobalAdvance();
     });
   }
+  await page.getByRole('button', { name: /Advance anyway/i }).click({ timeout: 1000 }).catch(() => {});
   await page.getByRole('button', { name: /Simulate \(Skip\)/i }).click({ timeout: 10000 }).catch(() => {});
   await page.waitForFunction(
     (baseline) => {


### PR DESCRIPTION
1. Re-enabled and clicked the 'Advance anyway' button on the 'Advance Week Readiness Check' dialog during automated tests to avoid Playwright timeout failures.
2. Modified the `plan-not-reviewed` alert detail message in `src/ui/utils/advanceReadinessGate.js` to build more tension and heighten stakes before kickoff.

---
*PR created automatically by Jules for task [10108473366848380974](https://jules.google.com/task/10108473366848380974) started by @rbcati*