### PR TITLE
Salary Cap / Contract Obligation Audit + Dead Cap Foundation V1

### DIFF
--- a/src/core/__tests__/contractObligations.test.js
+++ b/src/core/__tests__/contractObligations.test.js
@@ -1,0 +1,291 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeContract,
+  getContractYearsRemaining,
+  getAnnualBaseSalary,
+  getAnnualBonusProration,
+  getActiveCapHit,
+  calculateReleaseDeadCap,
+  calculateTeamCapObligations,
+  canTeamAffordContract,
+} from '../contracts/contractObligations.js';
+
+// ── normalizeContract ─────────────────────────────────────────────────────────
+
+describe('normalizeContract', () => {
+  it('handles a nested player.contract correctly', () => {
+    const player = {
+      id: 1,
+      baseAnnual: 99, // should be ignored — nested contract wins
+      contract: { yearsTotal: 4, yearsRemaining: 3, baseAnnual: 22, signingBonus: 8 },
+    };
+    const c = normalizeContract(player);
+    expect(c.baseAnnual).toBe(22);
+    expect(c.signingBonus).toBe(8);
+    expect(c.yearsTotal).toBe(4);
+    expect(c.yearsRemaining).toBe(3);
+  });
+
+  it('handles a legacy flat player with no nested contract', () => {
+    const player = { id: 2, baseAnnual: 14, years: 2, yearsTotal: 2 };
+    const c = normalizeContract(player);
+    expect(c.baseAnnual).toBe(14);
+    expect(c.yearsTotal).toBe(2);
+    expect(c.signingBonus).toBe(0);
+  });
+
+  it('handles a bare contract object (no player wrapper)', () => {
+    const c = normalizeContract({ yearsTotal: 3, baseAnnual: 18, signingBonus: 6 });
+    expect(c.baseAnnual).toBe(18);
+    expect(c.signingBonus).toBe(6);
+  });
+
+  it('defaults missing fields to zero / one safely', () => {
+    const c = normalizeContract({});
+    expect(c.baseAnnual).toBe(0);
+    expect(c.signingBonus).toBe(0);
+    expect(c.yearsTotal).toBe(1);
+    expect(c.yearsRemaining).toBe(1);
+    expect(c.guaranteedPct).toBe(0);
+  });
+});
+
+// ── getContractYearsRemaining ─────────────────────────────────────────────────
+
+describe('getContractYearsRemaining', () => {
+  it('returns yearsRemaining from nested contract', () => {
+    const player = { contract: { yearsTotal: 5, yearsRemaining: 2, baseAnnual: 20 } };
+    expect(getContractYearsRemaining(player)).toBe(2);
+  });
+
+  it('defaults to 1 when no years info present', () => {
+    expect(getContractYearsRemaining({})).toBe(1);
+  });
+});
+
+// ── getAnnualBaseSalary ───────────────────────────────────────────────────────
+
+describe('getAnnualBaseSalary', () => {
+  it('returns baseAnnual from nested contract', () => {
+    const player = { contract: { yearsTotal: 3, baseAnnual: 16, signingBonus: 0 } };
+    expect(getAnnualBaseSalary(player)).toBe(16);
+  });
+
+  it('returns 0 for a player with no contract info', () => {
+    expect(getAnnualBaseSalary({})).toBe(0);
+  });
+});
+
+// ── getAnnualBonusProration ───────────────────────────────────────────────────
+
+describe('getAnnualBonusProration', () => {
+  it('prorates signing bonus evenly across contract years', () => {
+    const player = { contract: { yearsTotal: 4, baseAnnual: 20, signingBonus: 12 } };
+    // 12 / 4 = 3 per year
+    expect(getAnnualBonusProration(player)).toBe(3);
+  });
+
+  it('returns 0 when there is no signing bonus', () => {
+    const player = { contract: { yearsTotal: 3, baseAnnual: 10, signingBonus: 0 } };
+    expect(getAnnualBonusProration(player)).toBe(0);
+  });
+
+  it('returns 0 for a legacy flat-salary player with no bonus fields', () => {
+    const player = { baseAnnual: 8, years: 2 };
+    expect(getAnnualBonusProration(player)).toBe(0);
+  });
+
+  it('prorates correctly for a 1-year deal', () => {
+    const player = { contract: { yearsTotal: 1, baseAnnual: 5, signingBonus: 2 } };
+    expect(getAnnualBonusProration(player)).toBe(2);
+  });
+});
+
+// ── getActiveCapHit ───────────────────────────────────────────────────────────
+
+describe('getActiveCapHit', () => {
+  it('legacy flat-salary player: cap hit equals baseAnnual (no bonus)', () => {
+    const player = { contract: { yearsTotal: 3, baseAnnual: 18, signingBonus: 0 } };
+    expect(getActiveCapHit(player)).toBe(18);
+  });
+
+  it('adds prorated bonus to baseAnnual', () => {
+    // 24 base + 8/4 = 24 + 2 = 26
+    const player = { contract: { yearsTotal: 4, baseAnnual: 24, signingBonus: 8 } };
+    expect(getActiveCapHit(player)).toBe(26);
+  });
+
+  it('matches calculateContractCapHit directly for a known contract', () => {
+    const player = { contract: { yearsTotal: 5, baseAnnual: 30, signingBonus: 20 } };
+    // 30 + 20/5 = 30 + 4 = 34
+    expect(getActiveCapHit(player)).toBe(34);
+  });
+
+  it('returns 0 for a player with no contract fields', () => {
+    expect(getActiveCapHit({})).toBe(0);
+  });
+});
+
+// ── calculateReleaseDeadCap ───────────────────────────────────────────────────
+
+describe('calculateReleaseDeadCap', () => {
+  it('computes remaining prorated bonus as dead cap', () => {
+    // signingBonus=12, yearsTotal=4 → proration=3/yr; yearsRemaining=3 → dead=9
+    const player = { contract: { yearsTotal: 4, yearsRemaining: 3, baseAnnual: 20, signingBonus: 12 } };
+    const result = calculateReleaseDeadCap(player);
+    expect(result.yearlyProration).toBe(3);
+    expect(result.deadCapThisYear).toBe(9);
+    expect(result.total).toBe(9);
+    expect(result.deadCapDeferred).toBe(0);
+  });
+
+  it('returns zero dead cap for a player with no signing bonus', () => {
+    const player = { contract: { yearsTotal: 3, yearsRemaining: 2, baseAnnual: 10, signingBonus: 0 } };
+    const result = calculateReleaseDeadCap(player);
+    expect(result.yearlyProration).toBe(0);
+    expect(result.total).toBe(0);
+  });
+
+  it('equals full signing bonus when releasing in year 1 of the deal', () => {
+    // All years remain → dead cap = full bonus
+    const player = { contract: { yearsTotal: 3, yearsRemaining: 3, baseAnnual: 15, signingBonus: 9 } };
+    const result = calculateReleaseDeadCap(player);
+    expect(result.total).toBe(9);
+  });
+
+  it('equals one-year proration when one year remains', () => {
+    const player = { contract: { yearsTotal: 4, yearsRemaining: 1, baseAnnual: 20, signingBonus: 8 } };
+    const result = calculateReleaseDeadCap(player);
+    // 8/4 = 2 proration; 1 year remains → total = 2
+    expect(result.total).toBe(2);
+    expect(result.yearlyProration).toBe(2);
+  });
+
+  it('handles legacy player with no contract object (no dead cap)', () => {
+    const player = { baseAnnual: 8, years: 1 };
+    const result = calculateReleaseDeadCap(player);
+    expect(result.total).toBe(0);
+  });
+});
+
+// ── calculateTeamCapObligations ───────────────────────────────────────────────
+
+describe('calculateTeamCapObligations', () => {
+  const makePlayer = (baseAnnual, signingBonus = 0, yearsTotal = 3) => ({
+    contract: { yearsTotal, yearsRemaining: yearsTotal, baseAnnual, signingBonus },
+  });
+
+  it('sums player cap hits correctly', () => {
+    const players = [
+      makePlayer(20, 8, 4),  // cap hit = 20 + 2 = 22
+      makePlayer(12, 0, 2),  // cap hit = 12
+    ];
+    const team = { capTotal: 200, deadCap: 0, staffPayroll: 0 };
+    const result = calculateTeamCapObligations(team, players);
+    expect(result.playerPayroll).toBe(34);
+    expect(result.totalCapUsed).toBe(34);
+    expect(result.capRoom).toBe(166);
+    expect(result.overCap).toBe(false);
+  });
+
+  it('includes dead cap in totalCapUsed', () => {
+    const players = [makePlayer(20, 0, 3)];
+    const team = { capTotal: 200, deadCap: 10, staffPayroll: 0 };
+    const result = calculateTeamCapObligations(team, players);
+    expect(result.playerPayroll).toBe(20);
+    expect(result.deadCap).toBe(10);
+    expect(result.totalCapUsed).toBe(30);
+  });
+
+  it('uses leagueSettings.salaryCap when team.capTotal is absent', () => {
+    const result = calculateTeamCapObligations({}, [], { salaryCap: 250 });
+    expect(result.capTotal).toBe(250);
+  });
+
+  it('defaults capTotal to 301.2 when no settings provided', () => {
+    const result = calculateTeamCapObligations({}, []);
+    expect(result.capTotal).toBe(301.2);
+  });
+
+  it('flags overCap when totalCapUsed exceeds capTotal', () => {
+    const players = [makePlayer(150, 0, 1), makePlayer(200, 0, 1)];
+    const team = { capTotal: 300 };
+    const result = calculateTeamCapObligations(team, players);
+    expect(result.overCap).toBe(true);
+  });
+
+  it('returns zero payroll for an empty roster', () => {
+    const team = { capTotal: 250, deadCap: 5 };
+    const result = calculateTeamCapObligations(team, []);
+    expect(result.playerPayroll).toBe(0);
+    expect(result.deadCap).toBe(5);
+    expect(result.totalCapUsed).toBe(5);
+  });
+});
+
+// ── canTeamAffordContract ─────────────────────────────────────────────────────
+
+describe('canTeamAffordContract', () => {
+  const makePlayer = (baseAnnual, signingBonus = 0, yearsTotal = 3) => ({
+    contract: { yearsTotal, yearsRemaining: yearsTotal, baseAnnual, signingBonus },
+  });
+
+  it('returns ok=true for an affordable deal with cap room remaining', () => {
+    const team = { capTotal: 200, deadCap: 0, staffPayroll: 0 };
+    const players = [makePlayer(20), makePlayer(15)];
+    // current used = 35; new contract = 10 → projected = 45 < 200
+    const result = canTeamAffordContract(team, players, { baseAnnual: 10, yearsTotal: 2, signingBonus: 0 });
+    expect(result.ok).toBe(true);
+    expect(result.capRoom).toBeGreaterThan(0);
+    expect(result.projectedCap).toBe(45);
+  });
+
+  it('returns ok=false when the new contract pushes over the cap', () => {
+    const team = { capTotal: 100, deadCap: 0, staffPayroll: 0 };
+    const players = [makePlayer(80)];
+    // current used = 80; new contract = 25 → projected = 105 > 100
+    const result = canTeamAffordContract(team, players, { baseAnnual: 25, yearsTotal: 3, signingBonus: 0 });
+    expect(result.ok).toBe(false);
+    expect(result.capRoom).toBeLessThan(0);
+    expect(result.reason).toMatch(/over cap/i);
+  });
+
+  it('accounts for prorated signing bonus in the new contract cap hit', () => {
+    const team = { capTotal: 200, deadCap: 0, staffPayroll: 0 };
+    const players = [makePlayer(150)];
+    // current used = 150; new = 30 base + 20/4 bonus = 35 → projected = 185
+    const result = canTeamAffordContract(team, players, { baseAnnual: 30, signingBonus: 20, yearsTotal: 4 });
+    expect(result.ok).toBe(true);
+    expect(result.projectedCap).toBe(185);
+  });
+
+  it('includes dead cap from the team in the affordability calc', () => {
+    const team = { capTotal: 100, deadCap: 20, staffPayroll: 0 };
+    const players = [makePlayer(60)];
+    // used = 60 + 20 dead = 80; new = 25 → projected = 105 > 100
+    const result = canTeamAffordContract(team, players, { baseAnnual: 25, yearsTotal: 1, signingBonus: 0 });
+    expect(result.ok).toBe(false);
+  });
+
+  it('legacy flat salary player (no bonus): same affordability as before V1', () => {
+    const team = { capTotal: 200 };
+    const legacyPlayer = { baseAnnual: 10, years: 2, yearsTotal: 2 };
+    // cap hit = 10 (no bonus); new deal = 5 → projected = 15
+    const result = canTeamAffordContract(team, [legacyPlayer], { baseAnnual: 5, yearsTotal: 1 });
+    expect(result.ok).toBe(true);
+    expect(result.projectedCap).toBe(15);
+  });
+
+  it('reason string is informative for affordable deals', () => {
+    const team = { capTotal: 200 };
+    const result = canTeamAffordContract(team, [], { baseAnnual: 10, yearsTotal: 2 });
+    expect(result.reason).toMatch(/fits/i);
+    expect(result.reason).toMatch(/10\.0M/);
+  });
+
+  it('reason string is informative for over-cap rejections', () => {
+    const team = { capTotal: 50 };
+    const result = canTeamAffordContract(team, [], { baseAnnual: 60, yearsTotal: 1 });
+    expect(result.reason).toMatch(/over cap/i);
+  });
+});

--- a/src/core/contracts/contractObligations.js
+++ b/src/core/contracts/contractObligations.js
@@ -1,0 +1,194 @@
+/**
+ * contractObligations.js
+ *
+ * Pure helper layer for salary-cap and contract-obligation calculations.
+ * All functions are stateless and side-effect-free — safe to call from
+ * UI components, tests, or worker logic without touching IndexedDB.
+ *
+ * Dead-cap PERSISTENCE is not the responsibility of this module.
+ * Persistence already lives on team.deadCap / team.deadMoneyNextYear
+ * and is updated by worker.js handleReleasePlayer.
+ *
+ * Post-June-1 split logic (deferred vs current-year dead cap) is
+ * implemented in worker.js and is NOT duplicated here.
+ * calculateReleaseDeadCap returns the pre-June-1 total for display/preview.
+ */
+
+import {
+  normalizeContractDetails,
+  calculateContractCapHit,
+} from './realisticContracts.js';
+
+function n(v, d = 0) {
+  const x = Number(v);
+  return Number.isFinite(x) ? x : d;
+}
+
+function round2(v) {
+  return Math.round(n(v, 0) * 100) / 100;
+}
+
+/**
+ * Normalize a contract OR a player-with-contract into the canonical
+ * ContractDetails shape from realisticContracts.js.
+ *
+ * Accepts either:
+ *   - A player object with a nested `contract` field
+ *   - A plain contract object (with baseAnnual / signingBonus / yearsTotal / …)
+ *   - A legacy flat player object (with baseAnnual / salary / years at root)
+ */
+export function normalizeContract(contractOrPlayer = {}) {
+  if (contractOrPlayer?.contract && typeof contractOrPlayer.contract === 'object') {
+    return normalizeContractDetails(contractOrPlayer.contract, contractOrPlayer);
+  }
+  return normalizeContractDetails(contractOrPlayer, {});
+}
+
+/**
+ * Returns the number of years remaining on the player's contract.
+ * Falls back safely: yearsRemaining → years → yearsTotal → 1.
+ */
+export function getContractYearsRemaining(player = {}) {
+  return normalizeContract(player).yearsRemaining;
+}
+
+/**
+ * Returns the annual base salary for the player, excluding bonus proration.
+ * Legacy saves that stored total value in `salary` are handled by
+ * normalizeContractDetails' deriveAnnualFromLegacy path.
+ */
+export function getAnnualBaseSalary(player = {}) {
+  return normalizeContract(player).baseAnnual;
+}
+
+/**
+ * Returns the per-year prorated signing bonus.
+ *   proratedBonus = signingBonus / yearsTotal
+ *
+ * Returns 0 if the player has no signing bonus.
+ * Missing fields default to 0 / 1 so legacy saves are unaffected.
+ */
+export function getAnnualBonusProration(player = {}) {
+  const c = normalizeContract(player);
+  return round2(c.signingBonus / Math.max(1, c.yearsTotal));
+}
+
+/**
+ * Returns the active cap hit for the player in the current season.
+ *   capHit = baseAnnual + proratedBonus + likely incentives
+ *
+ * Delegates to calculateContractCapHit, which already handles incentives.
+ * Legacy flat-salary players (no bonus) produce the same result as before.
+ */
+export function getActiveCapHit(player = {}) {
+  const c = normalizeContract(player);
+  return calculateContractCapHit(c);
+}
+
+/**
+ * Computes the dead cap that would result from releasing this player
+ * using simple linear proration (pre-June-1 assumption):
+ *
+ *   yearlyProration = signingBonus / yearsTotal
+ *   deadCapTotal    = yearlyProration × yearsRemaining
+ *
+ * Returns:
+ *   yearlyProration  — prorated bonus per year
+ *   deadCapThisYear  — current-year dead cap (pre-June-1 = full remaining)
+ *   deadCapDeferred  — always 0 here; post-June-1 split is in worker.js
+ *   total            — alias for deadCapThisYear
+ *
+ * Post-June-1 note: when releasing in free_agency / draft / regular / playoffs
+ * phases, worker.js handleReleasePlayer already splits the dead cap correctly
+ * using Constants.SALARY_CAP.POST_JUNE1_PHASES.  This helper is for display
+ * previews and unit tests — it returns the conservative (worst-case) total.
+ */
+export function calculateReleaseDeadCap(player = {}) {
+  const c = normalizeContract(player);
+  const yearlyProration = round2(c.signingBonus / Math.max(1, c.yearsTotal));
+  const total = round2(yearlyProration * Math.max(0, c.yearsRemaining));
+  return {
+    yearlyProration,
+    deadCapThisYear: total,
+    deadCapDeferred: 0,
+    total,
+  };
+}
+
+/**
+ * Aggregates all cap obligations for a team.
+ *
+ * Inputs:
+ *   team           — team object (team.deadCap, team.staffPayroll, team.capTotal)
+ *   players        — array of player objects on this team's roster
+ *   leagueSettings — optional { salaryCap | currentSalaryCap } override
+ *
+ * Returns:
+ *   playerPayroll  — sum of active cap hits across the roster
+ *   deadCap        — current-year dead cap from team record (defaults to 0)
+ *   staffPayroll   — coaching/staff payroll from team record (defaults to 0)
+ *   totalCapUsed   — playerPayroll + deadCap + staffPayroll
+ *   capTotal       — hard cap ceiling
+ *   capRoom        — capTotal - totalCapUsed
+ *   overCap        — boolean
+ */
+export function calculateTeamCapObligations(team = {}, players = [], leagueSettings = {}) {
+  const capTotal = n(
+    team?.capTotal
+      ?? leagueSettings?.salaryCap
+      ?? leagueSettings?.currentSalaryCap,
+    301.2,
+  );
+  const deadCap = n(team?.deadCap, 0);
+  const staffPayroll = n(team?.staffPayroll, 0);
+
+  const playerPayroll = round2(
+    players.reduce((sum, p) => sum + getActiveCapHit(p), 0),
+  );
+
+  const totalCapUsed = round2(playerPayroll + deadCap + staffPayroll);
+  const capRoom = round2(capTotal - totalCapUsed);
+
+  return {
+    playerPayroll,
+    deadCap,
+    staffPayroll,
+    totalCapUsed,
+    capTotal,
+    capRoom,
+    overCap: totalCapUsed > capTotal,
+  };
+}
+
+/**
+ * Pure cap-affordability check for a proposed new contract.
+ * Does NOT mutate state.
+ *
+ * Parameters:
+ *   team           — team object (capTotal, deadCap, staffPayroll)
+ *   players        — current roster array
+ *   contract       — proposed contract { baseAnnual, signingBonus, yearsTotal, … }
+ *   leagueSettings — optional { salaryCap | currentSalaryCap }
+ *
+ * Returns { ok, capRoom, projectedCap, capTotal, reason }
+ *   ok          — true if the deal fits under the cap
+ *   capRoom     — remaining cap after the deal (negative = over cap)
+ *   projectedCap — total cap used after adding this contract
+ *   reason      — human-readable explanation string
+ *
+ * Legacy saves without bonus/deadCap fields default to 0 via
+ * normalizeContractDetails, so behaviour is identical to the pre-V1 system.
+ */
+export function canTeamAffordContract(team = {}, players = [], contract = {}, leagueSettings = {}) {
+  const obligations = calculateTeamCapObligations(team, players, leagueSettings);
+  const newHit = calculateContractCapHit(normalizeContractDetails(contract));
+  const projectedCap = round2(obligations.totalCapUsed + newHit);
+  const capRoom = round2(obligations.capTotal - projectedCap);
+  const ok = projectedCap <= obligations.capTotal;
+
+  const reason = ok
+    ? `Contract fits. Projected cap used: $${projectedCap.toFixed(1)}M / $${obligations.capTotal.toFixed(1)}M ($${capRoom.toFixed(1)}M remaining).`
+    : `Over cap by $${Math.abs(capRoom).toFixed(1)}M. Projected: $${projectedCap.toFixed(1)}M / $${obligations.capTotal.toFixed(1)}M.`;
+
+  return { ok, capRoom, projectedCap, capTotal: obligations.capTotal, reason };
+}


### PR DESCRIPTION
Adds a pure, stateless contract-obligation helper layer on top of the
existing realisticContracts.js infrastructure.  Nothing is rewritten;
the helpers delegate to already-tested normalizers and only add the
callable surface that was missing.

## What was audited

### Player contract shape (existing)
- contract.baseAnnual / signingBonus / yearsTotal / yearsRemaining
- contract.guaranteedPct / guaranteedMoney
- contract.incentives[] with capTreatment ('likely'|'unlikely')
- contract.tagType, rookieScale, restructureCount, optionBonus
- No per-player deadCap field — dead cap is a team-level field only

### Team cap model (existing)
- team.capTotal / capUsed / capRoom / capFloor / capStatus
- team.deadCap — current-year dead cap (persisted in IndexedDB)
- team.deadMoneyNextYear — post-June-1 deferred dead cap (persisted)
- team.staffPayroll / playerPayroll / financials

### Dead cap on release (existing, worker.js)
- handleReleasePlayer already computes and persists dead cap using
  the June-1 rule via Constants.SALARY_CAP.POST_JUNE1_PHASES
- deadMoneyNextYear rolls into deadCap at year advancement (line 9480)
- recalculateTeamCap already includes deadCap in totalPayroll

### Cap enforcement (existing)
- finalizeFreeAgencySigning: hard cap check at signing time
- validateLeagueTeamLegality: cap + roster limit checks
- evaluatePendingOfferCapReservation: pending-offer cap reservation

### Gap filled by this PR
- No importable pure helper for release dead-cap preview
- No importable canTeamAffordContract for UI/logic consumers
- No single normalizeContract entry-point that handles both
  nested player.contract and legacy flat-field shapes

## New file: src/core/contracts/contractObligations.js

Pure helpers (no DB access, no side effects):
- normalizeContract(contractOrPlayer)
- getContractYearsRemaining(player)
- getAnnualBaseSalary(player)
- getAnnualBonusProration(player)  — signingBonus / yearsTotal
- getActiveCapHit(player)          — base + proration + likely incentives
- calculateReleaseDeadCap(player)  — pre-June-1 dead cap for previews
- calculateTeamCapObligations(team, players, leagueSettings)
- canTeamAffordContract(team, players, contract, leagueSettings)
  → { ok, capRoom, projectedCap, capTotal, reason }

## New file: src/core/__tests__/contractObligations.test.js

34 focused unit tests covering:
- normalizeContract: nested, flat legacy, bare contract, empty object
- getAnnualBonusProration: even proration, no-bonus, legacy, 1-year
- getActiveCapHit: no-bonus legacy parity, bonus + base, empty
- calculateReleaseDeadCap: proration math, no-bonus, year-1, year-N
- calculateTeamCapObligations: sum, dead cap, league settings, overCap
- canTeamAffordContract: ok/reject, prorated new deal, dead cap impact,
  legacy flat-salary player backward compatibility, reason strings

## Backward compatibility

Legacy saves with only baseAnnual/salary/years at player root:
- normalizeContractDetails' deriveAnnualFromLegacy path handles them
- signingBonus defaults to 0 → zero dead cap → same cap hit as before
- No IndexedDB schema/version change

## Deferred

- Post-June-1 dead-cap split in release preview (worker.js handles it)
- Signing bonus UI labels
- Rookie wage scale enforcement
- AI cap planning / long-term projection
- Dead cap persistence for newly released players via UI helper
  (worker.js already persists it; this helper is for read-only previews)

https://claude.ai/code/session_012bGzB2mip2hVfywDfhQFjr