### PR TITLE
feat(mobile): responsive dense data views V1

### DIFF
--- a/src/ui/components/AdvancedPlayerSearch.jsx
+++ b/src/ui/components/AdvancedPlayerSearch.jsx
@@ -96,7 +96,7 @@ export default function AdvancedPlayerSearch({ filters, onChange, title = 'Advan
         const operatorOptions = OPERATORS[selectedField.valueType] ?? OPERATORS.string;
 
         return (
-          <div key={row.id} style={{ display: 'grid', gridTemplateColumns: '140px 1fr 120px 1fr auto', gap: 'var(--space-2)', marginTop: 'var(--space-2)' }}>
+          <div key={row.id} className="advanced-filter-row" style={{ display: 'grid', gridTemplateColumns: '140px 1fr 120px 1fr auto', gap: 'var(--space-2)', marginTop: 'var(--space-2)' }}>
             <select
               value={selectedField.category}
               onChange={(event) => {

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -141,14 +141,15 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
           <h4>{spec.title}</h4>
           <span className="bs-section-count">{spec.showingLabel}</span>
         </div>
-        <div className="bs-table-wrap bs-table-wrap--compact">
+        <div className="bs-table-wrap bs-table-wrap--compact" role="region" aria-label={`${spec.title} player stats — scroll horizontally to view all columns`}>
           <table className="box-score-table">
+            <caption className="sr-only">{spec.title} statistics for both teams</caption>
             <thead>
               <tr>
-                <th>Team</th>
-                <th>Player</th>
+                <th scope="col">Team</th>
+                <th scope="col">Player</th>
                 {spec.cols.map(([key, label]) => (
-                  <th key={label}>
+                  <th key={label} scope="col">
                     <button type="button" className="btn-link" onClick={() => setSortState((prev) => ({ ...prev, [spec.title]: { key, dir: prev?.[spec.title]?.key === key && prev?.[spec.title]?.dir === desc ? "asc" : desc } }))}>{label}</button>
                   </th>
                 ))}
@@ -286,9 +287,10 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
           <span className="bs-section-count">{driveRows.length ? `${driveRows.length} drives` : "Not recorded"}</span>
         </div>
         {driveRows.length ? (
-          <div className="bs-table-wrap">
+          <div className="bs-table-wrap" role="region" aria-label="Drive summary — scroll horizontally to view all columns">
             <table className="box-score-table">
-              <thead><tr><th>Qtr</th><th>Team</th><th>Start</th><th>End</th><th>Result</th><th>Plays</th><th>Yards</th><th>Pts</th></tr></thead>
+              <caption className="sr-only">Drive summary: quarter, team, field position, result, plays, yards, and points per drive</caption>
+              <thead><tr><th scope="col">Qtr</th><th scope="col">Team</th><th scope="col">Start</th><th scope="col">End</th><th scope="col">Result</th><th scope="col">Plays</th><th scope="col">Yards</th><th scope="col">Pts</th></tr></thead>
               <tbody>
                 {driveRows.map((row) => (
                   <tr key={row.id} data-testid="game-book-drive-row">
@@ -337,10 +339,11 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
       <section className="bs-section" data-testid="game-book-quarter-scores">
         <h4>Score by quarter</h4>
         {hasQuarter ? (
-          <div className="bs-table-wrap">
+          <div className="bs-table-wrap" role="region" aria-label="Score by quarter — scroll horizontally for overtime columns">
             <table className="box-score-table">
+              <caption className="sr-only">Linescore: quarter-by-quarter scoring for both teams</caption>
               <thead>
-                <tr><th>Team</th>{headers.map((h) => <th key={h}>{h}</th>)}<th>Final</th></tr>
+                <tr><th scope="row">Team</th>{headers.map((h) => <th key={h} scope="col">{h}</th>)}<th scope="col">Final</th></tr>
               </thead>
               <tbody>
                 <tr>
@@ -362,9 +365,10 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
       <section className="bs-section" data-testid="game-book-team-comparison">
         <h4>Team comparison</h4>
         {teamRows.length ? (
-          <div className="bs-table-wrap">
+          <div className="bs-table-wrap" role="region" aria-label="Team stat comparison">
             <table className="box-score-table">
-              <thead><tr><th>Stat</th><th>{vm.awayTeam.abbr}</th><th>{vm.homeTeam.abbr}</th></tr></thead>
+              <caption className="sr-only">Side-by-side team statistics: {vm.awayTeam.abbr} vs {vm.homeTeam.abbr}</caption>
+              <thead><tr><th scope="col">Stat</th><th scope="col">{vm.awayTeam.abbr}</th><th scope="col">{vm.homeTeam.abbr}</th></tr></thead>
               <tbody>{teamRows.map((row) => <tr key={row.key ?? row.label}><td>{row.label}</td><td className={row.winner === "away" ? "bs-compare-value--winner" : undefined}>{row.away ?? mdash}</td><td className={row.winner === "home" ? "bs-compare-value--winner" : undefined}>{row.home ?? mdash}</td></tr>)}</tbody>
             </table>
           </div>
@@ -374,9 +378,10 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
       <section className="bs-section" data-testid="game-book-scoring-summary">
         <h4>Scoring summary</h4>
         {vm.scoringSummary?.length ? (
-          <div className="bs-table-wrap">
+          <div className="bs-table-wrap" role="region" aria-label="Scoring summary — scroll horizontally to view all columns">
             <table className="box-score-table">
-              <thead><tr><th>Qtr</th><th>Time</th><th>Team</th><th>Type</th><th>Description</th><th>Score</th></tr></thead>
+              <caption className="sr-only">Scoring plays: quarter, time, team, score type, description, and running score</caption>
+              <thead><tr><th scope="col">Qtr</th><th scope="col">Time</th><th scope="col">Team</th><th scope="col">Type</th><th scope="col">Description</th><th scope="col">Score</th></tr></thead>
               <tbody>
                 {vm.scoringSummary.map((r, i) => (
                   <tr key={i}>

--- a/src/ui/components/LeagueHistory.jsx
+++ b/src/ui/components/LeagueHistory.jsx
@@ -218,17 +218,19 @@ export default function LeagueHistory({ onPlayerSelect, actions, league, onOpenB
       </div>
 
       <Tabs value={activeTab} onValueChange={setActiveTab}>
-        <TabsList>
-          <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="seasons">Season Archive</TabsTrigger>
-          <TabsTrigger value="records">Record Book</TabsTrigger>
-          <TabsTrigger value="awards">Awards History</TabsTrigger>
-          <TabsTrigger value="hof">Hall of Fame</TabsTrigger>
-          <TabsTrigger value="office">League Office</TabsTrigger>
-          <TabsTrigger value="draft">Draft History</TabsTrigger>
-          <TabsTrigger value="compare">Compare Players</TabsTrigger>
-          <TabsTrigger value="leaders">League Leaders</TabsTrigger>
-        </TabsList>
+        <div className="tabs-scroll-wrap" role="region" aria-label="League history navigation tabs">
+          <TabsList>
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="seasons">Season Archive</TabsTrigger>
+            <TabsTrigger value="records">Record Book</TabsTrigger>
+            <TabsTrigger value="awards">Awards History</TabsTrigger>
+            <TabsTrigger value="hof">Hall of Fame</TabsTrigger>
+            <TabsTrigger value="office">League Office</TabsTrigger>
+            <TabsTrigger value="draft">Draft History</TabsTrigger>
+            <TabsTrigger value="compare">Compare Players</TabsTrigger>
+            <TabsTrigger value="leaders">League Leaders</TabsTrigger>
+          </TabsList>
+        </div>
 
         <TabsContent value="overview">
           <OverviewDashboard

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -1885,7 +1885,7 @@ export default function PlayerProfile({
               No career stats recorded yet.
             </p>
           ) : (
-            <div className="table-wrapper" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
+            <div className="table-wrapper player-career-table-wrap" style={{ overflowX: "auto", WebkitOverflowScrolling: "touch", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
               <Table
                 className="standings-table"
                 style={{ width: "100%", minWidth: 540, fontSize: "0.76rem", lineHeight: 1.3 }}
@@ -1895,7 +1895,7 @@ export default function PlayerProfile({
                     <TableHead
                       style={{
                         paddingLeft: "var(--space-4)",
-                        textAlign: "left", position: "sticky", left: 0, background: "var(--surface)",
+                        textAlign: "left", position: "sticky", left: 0, zIndex: 2, background: "var(--surface)",
                       }}
                     >
                       Year
@@ -2128,7 +2128,7 @@ export default function PlayerProfile({
               {seasonLogRows.length === 0 ? (
                 <EmptyState title="No season rows match this filter." subtitle="Reset filters to show the full archived season log." />
               ) : null}
-              <div className="table-wrapper" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
+              <div className="table-wrapper player-career-table-wrap" role="region" aria-label="Player season log — scroll horizontally to view all stat columns" style={{ overflowX: "auto", WebkitOverflowScrolling: "touch", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
                 <Table
                   className="standings-table"
                   style={{

--- a/src/ui/components/ResponsiveDataTable.jsx
+++ b/src/ui/components/ResponsiveDataTable.jsx
@@ -1,0 +1,68 @@
+/**
+ * ResponsiveDataTable.jsx
+ *
+ * Thin wrapper that gives any dense <table> or data surface:
+ *  - Contained horizontal scroll (never leaks to body)
+ *  - iOS momentum scrolling (-webkit-overflow-scrolling)
+ *  - An accessible region label so screen readers announce the scrollable area
+ *  - Optional sticky first column via the stickyFirstColumn prop
+ *  - Safe empty state (children may be null / undefined)
+ *
+ * No third-party dependencies. No new CSS variables.
+ * Existing project classes (responsive-data-wrap, sticky-identity-cell) are
+ * defined in src/ui/styles/mobile.css.
+ *
+ * Usage:
+ *   <ResponsiveDataTable label="League leaders">
+ *     <table>…</table>
+ *   </ResponsiveDataTable>
+ *
+ *   <ResponsiveDataTable label="Career stats" stickyFirstColumn caption="Career statistics by season">
+ *     <table>…</table>
+ *   </ResponsiveDataTable>
+ */
+
+import React from "react";
+
+export default function ResponsiveDataTable({
+  children,
+  label,
+  caption,
+  stickyFirstColumn = false,
+  className = "",
+  style,
+  emptyState = null,
+  "data-testid": testId,
+}) {
+  const hasContent = React.Children.count(children) > 0 && children != null;
+
+  if (!hasContent) {
+    return emptyState ?? null;
+  }
+
+  const wrapClass = [
+    "responsive-data-wrap",
+    stickyFirstColumn ? "responsive-data-wrap--sticky-col" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      className={wrapClass}
+      role="region"
+      aria-label={label ?? "Data table — scroll horizontally to view all columns"}
+      tabIndex={0}
+      style={style}
+      data-testid={testId}
+    >
+      {caption ? (
+        <span className="sr-only" aria-hidden="false">
+          {caption}
+        </span>
+      ) : null}
+      {children}
+    </div>
+  );
+}

--- a/src/ui/styles/mobile.css
+++ b/src/ui/styles/mobile.css
@@ -1153,3 +1153,127 @@ html, body {
 }
 
 /* Game is now 100% stable with no freezing; all modal buttons respond instantly on iOS Safari/mobile Chrome; scheme fit updates live and feels meaningful. */
+
+/* ============================================================================
+   RESPONSIVE DENSE DATA UTILITIES
+   Mobile Dense Data Views V1 — layout + accessibility helpers
+   ============================================================================ */
+
+/*
+ * Generic scrollable data region.
+ * Use for any table or dense grid that must scroll horizontally on narrow screens.
+ * Always contains the scroll within this element so body overflow is never triggered.
+ */
+.responsive-data-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  max-width: 100%;
+  position: relative;
+}
+
+/* Table inside a responsive wrapper — stays at its natural width. */
+.responsive-data-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+/*
+ * Sticky identity cell for first-column row identity (player name, team name, etc.).
+ * Apply to both <th> and <td> in the first column when the table scrolls horizontally.
+ */
+.sticky-identity-cell {
+  position: sticky;
+  left: 0;
+  z-index: 2;
+  background: var(--surface);
+}
+
+/* When the wrapper itself requests sticky first column, auto-apply to child table cells. */
+.responsive-data-wrap--sticky-col table th:first-child,
+.responsive-data-wrap--sticky-col table td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 2;
+  background: var(--surface);
+}
+
+/* Dense list row — baseline-aligned flex with wrapping for card/list surfaces. */
+.dense-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: baseline;
+  padding: var(--space-2) var(--space-3);
+}
+
+/* ── AdvancedPlayerSearch filter rows: stack on narrow screens ──────────────── */
+@media (max-width: 600px) {
+  .advanced-filter-row {
+    grid-template-columns: 1fr 1fr !important;
+    grid-template-rows: auto auto;
+  }
+
+  .advanced-filter-row select:first-child {
+    grid-column: 1 / 2;
+  }
+
+  .advanced-filter-row select:nth-child(2) {
+    grid-column: 2 / 3;
+  }
+
+  .advanced-filter-row select:nth-child(3) {
+    grid-column: 1 / 2;
+  }
+
+  .advanced-filter-row input {
+    grid-column: 2 / 3;
+  }
+
+  .advanced-filter-row button {
+    grid-column: 1 / 3;
+    justify-self: end;
+  }
+}
+
+/* ── LeagueHistory / dense tab-list: allow scroll on narrow viewports ──────── */
+.tabs-scroll-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  max-width: 100%;
+  /* Fade hint at right edge when overflowing */
+  mask-image: linear-gradient(to right, black 85%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to right, black 85%, transparent 100%);
+}
+
+/* Remove mask when not overflowing — JS would be needed; safe to keep always. */
+@media (max-width: 768px) {
+  .tabs-scroll-wrap {
+    padding-bottom: var(--space-1);
+  }
+}
+
+/* ── BoxScore table regions: reinforce contained scroll ─────────────────────── */
+@media (max-width: 480px) {
+  .box-score-table {
+    font-size: 0.72rem;
+  }
+
+  .box-score-table th,
+  .box-score-table td {
+    padding: 4px 6px;
+    white-space: nowrap;
+  }
+}
+
+/* ── PlayerProfile career/season-log tables ─────────────────────────────────── */
+@media (max-width: 768px) {
+  /* Ensure the table wrapper never leaks outside the card */
+  .player-career-table-wrap {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    max-width: 100%;
+    position: relative;
+    border: 1px solid var(--hairline);
+    border-radius: var(--radius-md);
+  }
+}

--- a/src/ui/styles/style.css
+++ b/src/ui/styles/style.css
@@ -7597,7 +7597,7 @@ details[open] .nav-summary::after {
 .bs-compare-row { display: grid; grid-template-columns: 1fr auto 1fr; text-align: center; gap: 8px; padding: 8px; background: var(--surface-strong); border-radius: 8px; }
 .bs-compare-value--winner { font-weight: 700; color: var(--accent, var(--text-primary)); }
 .bs-compare-label { font-size: 11px; color: var(--text-subtle); text-transform: uppercase; letter-spacing: .06em; }
-.bs-table-wrap { overflow-x: auto; }
+.bs-table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; max-width: 100%; position: relative; }
 .bs-list { display: grid; gap: 6px; }
 .bs-list-item { display: grid; gap: 4px; background: var(--surface-strong); border-radius: 8px; padding: 8px; font-size: 12px; }
 .bs-quick-nav { position: sticky; top: 66px; z-index: 1; display: flex; gap: 8px; overflow-x: auto; padding: 4px 0 10px; margin-bottom: 8px; }

--- a/tests/unit/responsiveDataTable.test.jsx
+++ b/tests/unit/responsiveDataTable.test.jsx
@@ -1,0 +1,107 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import ResponsiveDataTable from "../../src/ui/components/ResponsiveDataTable.jsx";
+
+describe("ResponsiveDataTable", () => {
+  it("renders children inside a scrollable region", () => {
+    render(
+      <ResponsiveDataTable label="Test table">
+        <table>
+          <tbody>
+            <tr>
+              <td data-testid="cell">Hello</td>
+            </tr>
+          </tbody>
+        </table>
+      </ResponsiveDataTable>
+    );
+    expect(screen.getByTestId("cell")).toBeTruthy();
+  });
+
+  it("sets role=region and the provided aria-label", () => {
+    render(
+      <ResponsiveDataTable label="League leaders">
+        <table><tbody><tr><td>row</td></tr></tbody></table>
+      </ResponsiveDataTable>
+    );
+    const region = screen.getByRole("region", { name: "League leaders" });
+    expect(region).toBeTruthy();
+  });
+
+  it("renders an accessible caption when provided", () => {
+    render(
+      <ResponsiveDataTable label="Career stats" caption="Career statistics by season">
+        <table><tbody><tr><td>row</td></tr></tbody></table>
+      </ResponsiveDataTable>
+    );
+    expect(screen.getByText("Career statistics by season")).toBeTruthy();
+  });
+
+  it("adds sticky-column class when stickyFirstColumn is true", () => {
+    const { container } = render(
+      <ResponsiveDataTable label="Sticky table" stickyFirstColumn>
+        <table><tbody><tr><td>row</td></tr></tbody></table>
+      </ResponsiveDataTable>
+    );
+    const wrap = container.firstChild;
+    expect(wrap.className).toContain("responsive-data-wrap--sticky-col");
+  });
+
+  it("does not add sticky-column class when stickyFirstColumn is false (default)", () => {
+    const { container } = render(
+      <ResponsiveDataTable label="No sticky">
+        <table><tbody><tr><td>row</td></tr></tbody></table>
+      </ResponsiveDataTable>
+    );
+    const wrap = container.firstChild;
+    expect(wrap.className).not.toContain("sticky-col");
+  });
+
+  it("returns the emptyState fallback when children is null", () => {
+    render(
+      <ResponsiveDataTable label="Empty" emptyState={<p data-testid="empty">No data</p>}>
+        {null}
+      </ResponsiveDataTable>
+    );
+    expect(screen.getByTestId("empty")).toBeTruthy();
+  });
+
+  it("returns null when no children and no emptyState", () => {
+    const { container } = render(
+      <ResponsiveDataTable label="Empty">{null}</ResponsiveDataTable>
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("is keyboard-focusable (tabIndex=0)", () => {
+    const { container } = render(
+      <ResponsiveDataTable label="Focusable">
+        <table><tbody><tr><td>row</td></tr></tbody></table>
+      </ResponsiveDataTable>
+    );
+    const wrap = container.firstChild;
+    expect(wrap.tabIndex).toBe(0);
+  });
+
+  it("passes data-testid through", () => {
+    render(
+      <ResponsiveDataTable label="Testable" data-testid="my-wrap">
+        <table><tbody><tr><td>row</td></tr></tbody></table>
+      </ResponsiveDataTable>
+    );
+    expect(screen.getByTestId("my-wrap")).toBeTruthy();
+  });
+
+  it("accepts extra className without overwriting base class", () => {
+    const { container } = render(
+      <ResponsiveDataTable label="Extra class" className="my-extra-class">
+        <table><tbody><tr><td>row</td></tr></tbody></table>
+      </ResponsiveDataTable>
+    );
+    const wrap = container.firstChild;
+    expect(wrap.className).toContain("responsive-data-wrap");
+    expect(wrap.className).toContain("my-extra-class");
+  });
+});


### PR DESCRIPTION
Audit and improve dense data surfaces for mobile readability at 375–430px.

Surfaces audited:
- BoxScore.jsx: drive summary, quarter scores, team comparison, scoring
  summary, and player stat tables (all <table> via bs-table-wrap)
- LeagueHistory.jsx: League Leaders, Awards History, Draft History,
  Player Compare tables; TabsList overflows at 375px
- PlayerProfile.jsx: career stats table and season-log table
- FreeAgencyPanel.jsx: standings-table inside table-wrapper (already safe)
- AdvancedPlayerSearch.jsx: fixed-grid filter rows overflow on 375px
- AdvancedPlayerSearch.jsx: fixed-grid filter rows overflow on 375px

Changes:
- style.css: add -webkit-overflow-scrolling, max-width:100%, position:relative
  to .bs-table-wrap so contained scroll works on iOS and never leaks to body
- mobile.css: new responsive-data-wrap / sticky-identity-cell / dense-row
  utilities; tabs-scroll-wrap for horizontal tab-bar overflow; advanced-filter-row
  stacking at ≤600px; tighter box-score-table cell padding at ≤480px;
  player-career-table-wrap mobile reinforcement
- BoxScore.jsx: add role="region" + aria-label + <caption class="sr-only"> to
  all five scrollable table containers; add scope attrs to th elements
- LeagueHistory.jsx: wrap TabsList in .tabs-scroll-wrap so 9 tabs scroll
  on 375px instead of overflowing the viewport
- PlayerProfile.jsx: add z-index:2 to sticky Year column header so scrolling
  content passes beneath it; add WebkitOverflowScrolling:touch and
  player-career-table-wrap class to both career-stats and season-log wrappers
- AdvancedPlayerSearch.jsx: add advanced-filter-row class to filter grid rows
  so the ≤600px rule can stack them to 2-column layout
- ResponsiveDataTable.jsx: new reusable wrapper (role=region, aria-label,
  caption, optional stickyFirstColumn, safe empty state, no deps)
- tests/unit/responsiveDataTable.test.jsx: 10 focused unit tests covering
  render, accessible label, caption, sticky class, empty state, keyboard
  focus, data-testid passthrough, and extra className forwarding

No backend / worker / sim / contract / trade / persistence / schema changes.
1412 unit tests pass. Build passes. Fresh franchise first-week smoke passes.

https://claude.ai/code/session_01WeXou38DPwgA5oEMoczMC3