### PR TITLE
feat: Game Flow Summary + Compact Drive Context V1

### DIFF
--- a/src/core/sim/gameFlowSummary.js
+++ b/src/core/sim/gameFlowSummary.js
@@ -1,0 +1,137 @@
+// Pure, stateless helper that derives a compact game-flow summary from a
+// completed game/box-score object. Consumes only fields that exist in
+// RichGameSummary and the legacy adapter output — never fabricates values.
+//
+// Deferred (not supported by current sim output):
+//   driveSummary    — no per-drive play count or net-yards tracking
+//   longestDriveYards — same reason
+//   down/distance context per play
+//   win probability chart data
+//   full play-by-play with formation/personnel
+//   SVG drive field visualization
+//   true live simulation mode
+
+export const GAME_FLOW_VERSION = 1;
+
+const TURNING_POINT_TYPES = new Set([
+  'lead_change', 'turnover', 'swing', 'final_takeaway',
+]);
+
+const TURNING_POINT_LABEL = {
+  lead_change: 'Lead Change',
+  turnover: 'Turnover',
+  swing: 'Momentum Swing',
+  final_takeaway: 'Final Takeaway',
+  touchdown: 'Touchdown',
+  field_goal: 'Field Goal',
+  sack: 'Sack',
+  explosive_play: 'Explosive Play',
+};
+
+function safeInt(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.round(n) : 0;
+}
+
+function safeArr(v) {
+  return Array.isArray(v) ? v : [];
+}
+
+function resolveTeamIds(game) {
+  return {
+    homeTeamId: game?.homeTeamId ?? game?.homeId ?? null,
+    awayTeamId: game?.awayTeamId ?? game?.awayId ?? null,
+  };
+}
+
+function deriveScoringTimeline(game) {
+  return safeArr(game?.scoringSummary)
+    .filter((e) => e && typeof e === 'object')
+    .map((e) => ({
+      quarter: safeInt(e.quarter) || 1,
+      teamId: e.teamId ?? null,
+      points: safeInt(e.points),
+      scoreAfter: {
+        home: safeInt(e.scoreAfter?.home ?? e.scoreHomeAfter),
+        away: safeInt(e.scoreAfter?.away ?? e.scoreAwayAfter),
+      },
+      label: String(e.type ?? e.scoreType ?? 'score'),
+      description: String(e.text ?? e.description ?? ''),
+    }));
+}
+
+function deriveTurningPoints(game) {
+  const { homeTeamId, awayTeamId } = resolveTeamIds(game);
+  return safeArr(game?.playDigest)
+    .filter((e) => e && typeof e === 'object' && TURNING_POINT_TYPES.has(e.type))
+    .map((e) => ({
+      quarter: safeInt(e.quarter) || 1,
+      teamId: e.team === 'home' ? homeTeamId : e.team === 'away' ? awayTeamId : null,
+      type: String(e.type ?? 'unknown'),
+      label: TURNING_POINT_LABEL[e.type] ?? String(e.type ?? 'Key Play'),
+      description: String(e.text ?? ''),
+      scoreContext: {
+        home: safeInt(e.homeScore),
+        away: safeInt(e.awayScore),
+      },
+    }));
+}
+
+function buildTeamFlowEntry(stats) {
+  if (!stats || typeof stats !== 'object') return null;
+  return {
+    scoringDrives: safeInt(stats.passTD) + safeInt(stats.rushTD) + safeInt(stats.fieldGoalsMade),
+    turnovers: safeInt(stats.turnovers),
+    redZoneTrips: safeInt(stats.redZoneTrips),
+    redZoneScores: safeInt(stats.redZoneScores),
+    explosivePlays: safeInt(stats.explosivePlays),
+  };
+}
+
+function deriveTeamFlow(game) {
+  const { homeTeamId, awayTeamId } = resolveTeamIds(game);
+  const homeEntry = buildTeamFlowEntry(game?.teamStats?.home);
+  const awayEntry = buildTeamFlowEntry(game?.teamStats?.away);
+
+  if (!homeEntry && !awayEntry) return null;
+
+  const result = {};
+  if (homeTeamId != null && homeEntry) result[String(homeTeamId)] = homeEntry;
+  if (awayTeamId != null && awayEntry) result[String(awayTeamId)] = awayEntry;
+  return Object.keys(result).length ? result : null;
+}
+
+/**
+ * buildGameFlowSummary(game) → GameFlowSummary | null
+ *
+ * Accepts a completed RichGameSummary or legacy game/box-score object.
+ * Returns a compact deterministic summary, or null if data is insufficient.
+ *
+ * Properties:
+ *   - Deterministic: same input always produces identical output.
+ *   - Non-mutating: the input object is never modified.
+ *   - Safe: missing or legacy game data returns null rather than crashing.
+ *   - Serializable: no functions, classes, or circular refs in output.
+ */
+export function buildGameFlowSummary(game) {
+  if (!game || typeof game !== 'object') return null;
+
+  // Require at least one score value to consider the game completed.
+  const homeScore = game?.homeScore ?? game?.finalScore?.home ?? null;
+  const awayScore = game?.awayScore ?? game?.finalScore?.away ?? null;
+  if (homeScore == null && awayScore == null) return null;
+
+  const scoringTimeline = deriveScoringTimeline(game);
+  const turningPoints = deriveTurningPoints(game);
+  const teamFlow = deriveTeamFlow(game);
+
+  if (!scoringTimeline.length && !turningPoints.length && !teamFlow) return null;
+
+  return {
+    version: GAME_FLOW_VERSION,
+    scoringTimeline,
+    // driveSummary intentionally omitted — deferred, no per-drive tracking in sim
+    turningPoints,
+    teamFlow,
+  };
+}

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -108,6 +108,7 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
   ];
 
   const tableSections = buildPlayerStatSections(vm.playerTables, sortState);
+  const gfs = vm.gameFlowSummary ?? null;
   const driveRows = vm.driveSummaryRows ?? [];
   const turningPointRows = vm.turningPointRows ?? [];
   const notablePerformanceRows = vm.notablePerformanceRows ?? [];
@@ -214,6 +215,75 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
         <h4>Why this game was decided</h4>
         {storyBullets.length ? <ul>{storyBullets.map((b) => <li key={b}>{b}</li>)}</ul> : <p>No detailed team/player stats were recorded for this game.</p>}
       </section>
+      {gfs && (
+        <section className="bs-section" data-testid="game-book-game-flow">
+          <div className="bs-section-header">
+            <h4>Game Flow</h4>
+            <span className="bs-section-count">
+              {gfs.scoringTimeline.length ? `${gfs.scoringTimeline.length} scoring plays` : "Derived from sim data"}
+            </span>
+          </div>
+          {gfs.scoringTimeline.length ? (
+            <ul className="bs-list" aria-label="Scoring flow timeline">
+              {gfs.scoringTimeline.map((entry, i) => (
+                <li key={i} className="bs-list-item" data-testid="game-flow-score-entry">
+                  <strong>Q{entry.quarter} · {entry.label}</strong>
+                  <span>{entry.scoreAfter.away}{mdash}{entry.scoreAfter.home}</span>
+                  {entry.description ? <span>{entry.description}</span> : null}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          {gfs.teamFlow && (vm.homeTeam?.id != null || vm.awayTeam?.id != null) ? (() => {
+            const homeFlow = gfs.teamFlow[String(vm.homeTeam?.id)] ?? gfs.teamFlow[vm.homeTeam?.id] ?? null;
+            const awayFlow = gfs.teamFlow[String(vm.awayTeam?.id)] ?? gfs.teamFlow[vm.awayTeam?.id] ?? null;
+            if (!homeFlow && !awayFlow) return null;
+            const flowRows = [
+              ["Scoring Drives", awayFlow?.scoringDrives, homeFlow?.scoringDrives],
+              ["Turnovers", awayFlow?.turnovers, homeFlow?.turnovers],
+              ["Red Zone (Scr/Trips)", awayFlow ? `${awayFlow.redZoneScores}/${awayFlow.redZoneTrips}` : null, homeFlow ? `${homeFlow.redZoneScores}/${homeFlow.redZoneTrips}` : null],
+              ["Explosive Plays", awayFlow?.explosivePlays, homeFlow?.explosivePlays],
+            ].filter(([, a, h]) => a != null || h != null);
+            return (
+              <div className="bs-table-wrap" role="region" aria-label="Team game-flow snapshot" style={{ marginTop: "0.75rem" }}>
+                <table className="box-score-table" data-testid="game-flow-team-snapshot">
+                  <caption className="sr-only">Team game-flow snapshot: scoring drives, turnovers, red zone, and explosive plays</caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Metric</th>
+                      <th scope="col">{vm.awayTeam?.abbr ?? "Away"}</th>
+                      <th scope="col">{vm.homeTeam?.abbr ?? "Home"}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {flowRows.map(([label, away, home]) => (
+                      <tr key={label} data-testid="game-flow-snapshot-row">
+                        <td>{label}</td>
+                        <td>{away ?? mdash}</td>
+                        <td>{home ?? mdash}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            );
+          })() : null}
+          {gfs.turningPoints.length ? (
+            <>
+              <h5 style={{ marginTop: "0.75rem", marginBottom: "0.25rem", fontSize: "0.8rem", color: "var(--text-muted)" }}>Key Turning Points</h5>
+              <ul className="bs-list" aria-label="Game turning points from play digest">
+                {gfs.turningPoints.map((tp, i) => (
+                  <li key={i} className="bs-list-item" data-testid="game-flow-turning-point">
+                    <strong>Q{tp.quarter} · {tp.label}</strong>
+                    <span>{tp.scoreContext.away}{mdash}{tp.scoreContext.home}</span>
+                    {tp.description ? <span>{tp.description}</span> : null}
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : null}
+        </section>
+      )}
       <section className="bs-section" data-testid="game-book-turning-points">
         <div className="bs-section-header">
           <h4>Turning points</h4>

--- a/src/ui/components/PostGameScreen.jsx
+++ b/src/ui/components/PostGameScreen.jsx
@@ -448,20 +448,29 @@ function PostGameScreenInner({
 
           <div style={{ marginBottom: 12, background: "var(--surface)", border: "1px solid var(--hairline)", borderRadius: 12, padding: 12 }}>
             <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
-              <strong style={{ fontSize: "0.8rem" }}>Game Center recap</strong>
-              <button className="btn" style={{ padding: "6px 10px", fontSize: "0.72rem" }} onClick={() => setShowDetails((v) => !v)}>
-                {showDetails ? "Hide details" : "Expand details"}
+              <strong style={{ fontSize: "0.8rem" }}>Game Flow</strong>
+              <button className="btn" style={{ padding: "6px 10px", fontSize: "0.72rem" }} onClick={() => setShowDetails((v) => !v)} data-testid="postgame-flow-toggle">
+                {showDetails ? "Hide" : "Key moments"}
               </button>
             </div>
             {showDetails && (
-              <div style={{ marginTop: 8, display: "grid", gap: 6 }}>
+              <div style={{ marginTop: 8, display: "grid", gap: 6 }} data-testid="postgame-flow-moments">
                 {notableMoments.length === 0 ? (
                   <div style={{ fontSize: "0.74rem", color: "var(--text-muted)" }}>No notable moments logged for this game.</div>
-                ) : notableMoments.map((m, i) => (
-                  <div key={i} style={{ fontSize: "0.74rem", color: "var(--text-muted)", padding: "6px 8px", background: "var(--surface-strong)", borderRadius: 8 }}>
-                    Q{m.quarter ?? "?"} {m.clock ?? ""} · {m.text ?? "Momentum swing"}
-                  </div>
-                ))}
+                ) : notableMoments.map((m, i) => {
+                  const isTD = m?.isTouchdown;
+                  const isTurnover = m?.turnover;
+                  const dot = isTD ? "·" : isTurnover ? "·" : "·";
+                  const typeLabel = isTD ? "TD" : isTurnover ? "Turnover" : "Score";
+                  return (
+                    <div key={i} style={{ fontSize: "0.74rem", color: "var(--text-muted)", padding: "6px 8px", background: "var(--surface-strong)", borderRadius: 8, display: "flex", gap: 6 }}>
+                      <span style={{ fontWeight: 700, color: "var(--text)", whiteSpace: "nowrap" }}>Q{m.quarter ?? "?"}{m.clock ? ` ${m.clock}` : ""}</span>
+                      <span style={{ color: "var(--text-subtle)" }}>{dot}</span>
+                      <span style={{ fontWeight: 600, color: isTD ? "#34C759" : isTurnover ? "#FF453A" : "var(--text)", whiteSpace: "nowrap" }}>{typeLabel}</span>
+                      <span style={{ flex: 1 }}>{m.text ?? "Momentum swing"}</span>
+                    </div>
+                  );
+                })}
               </div>
             )}
           </div>

--- a/src/ui/utils/boxScoreViewModel.js
+++ b/src/ui/utils/boxScoreViewModel.js
@@ -1,5 +1,6 @@
 import { mergeArchivedGameWithScheduleResult, normalizeArchivedGamePayload } from '../../core/gameArchive.js';
 import { isScoringLikeLog, normalizePlayLogEntry } from '../../core/gameEvents.js';
+import { buildGameFlowSummary } from '../../core/sim/gameFlowSummary.js';
 
 const QUALITY = { full: 'Full detail', partial: 'Partial detail', score: 'Score only', missing: 'Missing detail' };
 
@@ -556,6 +557,7 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
       notablePerformances: hasNotablePerformances,
       injuries: hasInjuries,
     },
+    gameFlowSummary: buildGameFlowSummary(payload),
     prepImpact: Array.isArray(payload?.prepImpact) ? payload.prepImpact : (payload?.prepImpact ? [String(payload.prepImpact)] : []),
     detailWarning,
     missingDetailReason: detailWarning,

--- a/tests/unit/gameFlowSummary.test.js
+++ b/tests/unit/gameFlowSummary.test.js
@@ -1,0 +1,413 @@
+import { describe, it, expect } from 'vitest';
+import { buildGameFlowSummary, GAME_FLOW_VERSION } from '../../src/core/sim/gameFlowSummary.js';
+import { simulateRichGame } from '../../src/core/sim/richGameSimulator.ts';
+import { mapOverallToAttributesV2 } from '../../src/core/migration/attributeMigrator.ts';
+
+// ── Minimal game fixtures ────────────────────────────────────────────────────
+
+function makeMinimalGame(overrides = {}) {
+  return {
+    homeScore: 24,
+    awayScore: 17,
+    homeTeamId: 1,
+    awayTeamId: 2,
+    scoringSummary: [
+      { quarter: 1, teamId: 1, points: 7, scoreAfter: { home: 7, away: 0 }, type: 'Touchdown', text: 'Home scores.' },
+      { quarter: 2, teamId: 2, points: 7, scoreAfter: { home: 7, away: 7 }, type: 'Touchdown', text: 'Away ties it.' },
+      { quarter: 3, teamId: 1, points: 3, scoreAfter: { home: 10, away: 7 }, type: 'Field Goal', text: 'Home takes the lead.' },
+      { quarter: 4, teamId: 1, points: 7, scoreAfter: { home: 17, away: 7 }, type: 'Touchdown', text: 'Home extends.' },
+      { quarter: 4, teamId: 2, points: 7, scoreAfter: { home: 17, away: 14 }, type: 'Touchdown', text: 'Away cuts it.' },
+      { quarter: 4, teamId: 1, points: 7, scoreAfter: { home: 24, away: 14 }, type: 'Touchdown', text: 'Home seals it.' },
+      { quarter: 4, teamId: 2, points: 3, scoreAfter: { home: 24, away: 17 }, type: 'Field Goal', text: 'Away final score.' },
+    ],
+    playDigest: [
+      { quarter: 2, clockSec: 420, team: 'away', type: 'turnover', text: 'Interception flips possession.', homeScore: 7, awayScore: 7 },
+      { quarter: 3, clockSec: 600, team: 'home', type: 'lead_change', text: 'Home regains the lead.', homeScore: 10, awayScore: 7 },
+      { quarter: 4, clockSec: 180, team: 'away', type: 'swing', text: 'Away mounts a comeback.', homeScore: 17, awayScore: 14 },
+      { quarter: 4, clockSec: 60, team: 'home', type: 'final_takeaway', text: 'Home defense seals the win.', homeScore: 24, awayScore: 17 },
+    ],
+    teamStats: {
+      home: { passTD: 2, rushTD: 1, fieldGoalsMade: 1, turnovers: 0, redZoneTrips: 4, redZoneScores: 3, explosivePlays: 5 },
+      away: { passTD: 2, rushTD: 0, fieldGoalsMade: 1, turnovers: 1, redZoneTrips: 2, redZoneScores: 2, explosivePlays: 3 },
+    },
+    ...overrides,
+  };
+}
+
+function buildRichPayload(seed = 42) {
+  return {
+    gameId: `gfs-audit-${seed}`,
+    homeTeamId: 10,
+    awayTeamId: 20,
+    seed,
+    weather: 'clear',
+    homeOffense: mapOverallToAttributesV2(82, 5.5, `h-off-${seed}`),
+    awayOffense: mapOverallToAttributesV2(80, 5.5, `a-off-${seed}`),
+    homeDefense: mapOverallToAttributesV2(79, 5.5, `h-def-${seed}`),
+    awayDefense: mapOverallToAttributesV2(78, 5.5, `a-def-${seed}`),
+  };
+}
+
+// ── Core contract tests ──────────────────────────────────────────────────────
+
+describe('buildGameFlowSummary', () => {
+  it('returns null for null input', () => {
+    expect(buildGameFlowSummary(null)).toBeNull();
+    expect(buildGameFlowSummary(undefined)).toBeNull();
+    expect(buildGameFlowSummary(42)).toBeNull();
+    expect(buildGameFlowSummary('string')).toBeNull();
+  });
+
+  it('returns null when no score fields are present', () => {
+    expect(buildGameFlowSummary({})).toBeNull();
+    expect(buildGameFlowSummary({ week: 5 })).toBeNull();
+  });
+
+  it('returns null when score exists but no timeline/digest/teamStats data', () => {
+    expect(buildGameFlowSummary({ homeScore: 14, awayScore: 7 })).toBeNull();
+  });
+
+  it('returns a summary with correct version for a full game', () => {
+    const result = buildGameFlowSummary(makeMinimalGame());
+    expect(result).not.toBeNull();
+    expect(result.version).toBe(GAME_FLOW_VERSION);
+    expect(result.version).toBe(1);
+  });
+
+  it('does not mutate the input object', () => {
+    const game = makeMinimalGame();
+    const frozen = JSON.parse(JSON.stringify(game));
+    buildGameFlowSummary(game);
+    expect(game).toEqual(frozen);
+  });
+
+  it('output is serializable (no functions or circular refs)', () => {
+    const result = buildGameFlowSummary(makeMinimalGame());
+    expect(() => JSON.stringify(result)).not.toThrow();
+    const roundtripped = JSON.parse(JSON.stringify(result));
+    expect(roundtripped.version).toBe(result.version);
+  });
+
+  it('omits driveSummary (deferred — not supported by current sim output)', () => {
+    const result = buildGameFlowSummary(makeMinimalGame());
+    expect(result).not.toHaveProperty('driveSummary');
+  });
+
+  // ── scoringTimeline ──────────────────────────────────────────────────────
+
+  describe('scoringTimeline', () => {
+    it('derives timeline from scoringSummary', () => {
+      const result = buildGameFlowSummary(makeMinimalGame());
+      expect(Array.isArray(result.scoringTimeline)).toBe(true);
+      expect(result.scoringTimeline).toHaveLength(7);
+    });
+
+    it('each entry has required shape', () => {
+      const result = buildGameFlowSummary(makeMinimalGame());
+      for (const entry of result.scoringTimeline) {
+        expect(typeof entry.quarter).toBe('number');
+        expect(typeof entry.points).toBe('number');
+        expect(typeof entry.label).toBe('string');
+        expect(typeof entry.description).toBe('string');
+        expect(typeof entry.scoreAfter).toBe('object');
+        expect(typeof entry.scoreAfter.home).toBe('number');
+        expect(typeof entry.scoreAfter.away).toBe('number');
+      }
+    });
+
+    it('scoring timeline reconciles with final score (last entry scoreAfter matches final)', () => {
+      const game = makeMinimalGame();
+      const result = buildGameFlowSummary(game);
+      const last = result.scoringTimeline[result.scoringTimeline.length - 1];
+      expect(last.scoreAfter.home).toBe(game.homeScore);
+      expect(last.scoreAfter.away).toBe(game.awayScore);
+    });
+
+    it('returns empty timeline when scoringSummary is absent', () => {
+      const game = makeMinimalGame({ scoringSummary: undefined });
+      const result = buildGameFlowSummary(game);
+      // Should still return a non-null summary if playDigest/teamStats have data
+      if (result) {
+        expect(Array.isArray(result.scoringTimeline)).toBe(true);
+        expect(result.scoringTimeline).toHaveLength(0);
+      }
+    });
+
+    it('handles malformed scoringSummary entries gracefully', () => {
+      const game = makeMinimalGame({
+        scoringSummary: [null, undefined, { quarter: 'x', points: null }, { quarter: 2, teamId: 1, points: 7, scoreAfter: { home: 7, away: 0 }, type: 'Touchdown', text: 'TD' }],
+      });
+      const result = buildGameFlowSummary(game);
+      expect(result).not.toBeNull();
+      // null/undefined entries filtered; malformed quarter coerces to 0 then defaults to 1
+      const validEntries = result.scoringTimeline.filter((e) => e.points > 0 || e.label !== 'score');
+      expect(validEntries.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ── turningPoints ────────────────────────────────────────────────────────
+
+  describe('turningPoints', () => {
+    it('derives turning points from playDigest', () => {
+      const result = buildGameFlowSummary(makeMinimalGame());
+      expect(Array.isArray(result.turningPoints)).toBe(true);
+      expect(result.turningPoints.length).toBeGreaterThan(0);
+    });
+
+    it('only includes turning-point event types (lead_change, turnover, swing, final_takeaway)', () => {
+      const result = buildGameFlowSummary(makeMinimalGame());
+      const ALLOWED = new Set(['lead_change', 'turnover', 'swing', 'final_takeaway']);
+      for (const tp of result.turningPoints) {
+        expect(ALLOWED.has(tp.type)).toBe(true);
+      }
+    });
+
+    it('each turning point has required shape', () => {
+      const result = buildGameFlowSummary(makeMinimalGame());
+      for (const tp of result.turningPoints) {
+        expect(typeof tp.quarter).toBe('number');
+        expect(typeof tp.type).toBe('string');
+        expect(typeof tp.label).toBe('string');
+        expect(typeof tp.description).toBe('string');
+        expect(typeof tp.scoreContext).toBe('object');
+        expect(typeof tp.scoreContext.home).toBe('number');
+        expect(typeof tp.scoreContext.away).toBe('number');
+      }
+    });
+
+    it('maps team side to teamId correctly', () => {
+      const game = makeMinimalGame();
+      const result = buildGameFlowSummary(game);
+      const awayTurnover = result.turningPoints.find((tp) => tp.type === 'turnover');
+      expect(awayTurnover).toBeDefined();
+      // 'away' team in digest → awayTeamId = 2
+      expect(awayTurnover.teamId).toBe(game.awayTeamId);
+    });
+
+    it('omits non-turning-point digest events (touchdowns, sacks, explosive_play)', () => {
+      const game = makeMinimalGame({
+        playDigest: [
+          { quarter: 1, clockSec: 800, team: 'home', type: 'touchdown', text: 'TD.', homeScore: 7, awayScore: 0 },
+          { quarter: 2, clockSec: 400, team: 'away', type: 'sack', text: 'Sack!', homeScore: 7, awayScore: 0 },
+          { quarter: 3, clockSec: 600, team: 'home', type: 'turnover', text: 'Fumble.', homeScore: 10, awayScore: 7 },
+        ],
+      });
+      const result = buildGameFlowSummary(game);
+      // Only the turnover is a turning point; touchdown and sack are excluded
+      expect(result.turningPoints).toHaveLength(1);
+      expect(result.turningPoints[0].type).toBe('turnover');
+    });
+
+    it('returns empty array when playDigest is absent', () => {
+      const game = makeMinimalGame({ playDigest: undefined });
+      const result = buildGameFlowSummary(game);
+      if (result) {
+        expect(result.turningPoints).toEqual([]);
+      }
+    });
+  });
+
+  // ── teamFlow ─────────────────────────────────────────────────────────────
+
+  describe('teamFlow', () => {
+    it('derives teamFlow from teamStats', () => {
+      const result = buildGameFlowSummary(makeMinimalGame());
+      expect(result.teamFlow).not.toBeNull();
+    });
+
+    it('teamFlow is keyed by stringified teamId', () => {
+      const game = makeMinimalGame();
+      const result = buildGameFlowSummary(game);
+      expect(result.teamFlow[String(game.homeTeamId)]).toBeDefined();
+      expect(result.teamFlow[String(game.awayTeamId)]).toBeDefined();
+    });
+
+    it('each teamFlow entry has required fields', () => {
+      const result = buildGameFlowSummary(makeMinimalGame());
+      for (const entry of Object.values(result.teamFlow)) {
+        expect(typeof entry.scoringDrives).toBe('number');
+        expect(typeof entry.turnovers).toBe('number');
+        expect(typeof entry.redZoneTrips).toBe('number');
+        expect(typeof entry.redZoneScores).toBe('number');
+        expect(typeof entry.explosivePlays).toBe('number');
+      }
+    });
+
+    it('scoringDrives = passTD + rushTD + fieldGoalsMade', () => {
+      const game = makeMinimalGame();
+      const result = buildGameFlowSummary(game);
+      const homeFlow = result.teamFlow[String(game.homeTeamId)];
+      const { passTD, rushTD, fieldGoalsMade } = game.teamStats.home;
+      expect(homeFlow.scoringDrives).toBe(passTD + rushTD + fieldGoalsMade);
+    });
+
+    it('omits longestDriveYards (deferred — no per-drive tracking)', () => {
+      const result = buildGameFlowSummary(makeMinimalGame());
+      for (const entry of Object.values(result.teamFlow)) {
+        expect(entry).not.toHaveProperty('longestDriveYards');
+      }
+    });
+
+    it('returns null teamFlow when no teamStats', () => {
+      const game = makeMinimalGame({ teamStats: undefined });
+      const result = buildGameFlowSummary(game);
+      if (result) {
+        expect(result.teamFlow).toBeNull();
+      }
+    });
+
+    it('accepts legacy homeId/awayId field names', () => {
+      const game = {
+        homeScore: 14,
+        awayScore: 7,
+        homeId: 5,
+        awayId: 6,
+        teamStats: {
+          home: { passTD: 1, rushTD: 1, fieldGoalsMade: 0, turnovers: 0, redZoneTrips: 2, redZoneScores: 2, explosivePlays: 2 },
+          away: { passTD: 1, rushTD: 0, fieldGoalsMade: 0, turnovers: 1, redZoneTrips: 1, redZoneScores: 1, explosivePlays: 1 },
+        },
+        scoringSummary: [
+          { quarter: 1, teamId: 5, points: 7, scoreAfter: { home: 7, away: 0 }, type: 'Touchdown', text: 'TD' },
+        ],
+      };
+      const result = buildGameFlowSummary(game);
+      expect(result).not.toBeNull();
+      expect(result.teamFlow['5']).toBeDefined();
+      expect(result.teamFlow['6']).toBeDefined();
+    });
+  });
+
+  // ── determinism ──────────────────────────────────────────────────────────
+
+  describe('determinism', () => {
+    it('same input produces identical output', () => {
+      const game = makeMinimalGame();
+      const a = buildGameFlowSummary(game);
+      const b = buildGameFlowSummary(game);
+      expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+    });
+
+    it('different inputs produce different outputs', () => {
+      const game1 = makeMinimalGame();
+      // Different scoringSummary so the timelines differ
+      const game2 = makeMinimalGame({
+        scoringSummary: [
+          { quarter: 1, teamId: 2, points: 7, scoreAfter: { home: 0, away: 7 }, type: 'Touchdown', text: 'Away opens scoring.' },
+          { quarter: 4, teamId: 2, points: 14, scoreAfter: { home: 0, away: 21 }, type: 'Touchdown', text: 'Away runs away with it.' },
+        ],
+      });
+      const a = buildGameFlowSummary(game1);
+      const b = buildGameFlowSummary(game2);
+      expect(JSON.stringify(a)).not.toBe(JSON.stringify(b));
+    });
+
+    it('output from richGameSimulator is stable across two calls with same seed', () => {
+      const payload = buildRichPayload(777);
+      const game1 = simulateRichGame(payload);
+      const game2 = simulateRichGame(payload);
+      const s1 = buildGameFlowSummary(game1);
+      const s2 = buildGameFlowSummary(game2);
+      expect(JSON.stringify(s1)).toBe(JSON.stringify(s2));
+    });
+  });
+
+  // ── richGameSimulator integration ────────────────────────────────────────
+
+  describe('richGameSimulator integration', () => {
+    it('returns a valid summary from real sim output', () => {
+      const result = simulateRichGame(buildRichPayload(1));
+      const summary = buildGameFlowSummary(result);
+      expect(summary).not.toBeNull();
+      expect(summary.version).toBe(GAME_FLOW_VERSION);
+    });
+
+    it('scoringTimeline matches the sim scoringSummary length', () => {
+      const result = simulateRichGame(buildRichPayload(2));
+      const summary = buildGameFlowSummary(result);
+      expect(summary.scoringTimeline.length).toBe(result.scoringSummary.length);
+    });
+
+    it('teamFlow keys match homeTeamId and awayTeamId', () => {
+      const payload = buildRichPayload(3);
+      const result = simulateRichGame(payload);
+      const summary = buildGameFlowSummary(result);
+      if (summary.teamFlow) {
+        expect(summary.teamFlow[String(payload.homeTeamId)]).toBeDefined();
+        expect(summary.teamFlow[String(payload.awayTeamId)]).toBeDefined();
+      }
+    });
+
+    it('richGameSimulator determinism is unaffected by summary derivation', () => {
+      const payload = buildRichPayload(42);
+      const before = simulateRichGame(payload);
+      buildGameFlowSummary(before); // derive and discard
+      const after = simulateRichGame(payload);
+      expect(before.homeScore).toBe(after.homeScore);
+      expect(before.awayScore).toBe(after.awayScore);
+      expect(JSON.stringify(before.quarterScores)).toBe(JSON.stringify(after.quarterScores));
+      expect(JSON.stringify(before.teamStats)).toBe(JSON.stringify(after.teamStats));
+    });
+
+    it('summary does not attach to or modify the sim result object', () => {
+      const payload = buildRichPayload(99);
+      const result = simulateRichGame(payload);
+      const frozen = JSON.parse(JSON.stringify(result));
+      buildGameFlowSummary(result);
+      expect(result).toEqual(frozen);
+    });
+  });
+
+  // ── legacy / partial data safety ─────────────────────────────────────────
+
+  describe('legacy and partial game data safety', () => {
+    it('handles score-only game without crashing', () => {
+      // Minimal legacy-style object with only final scores
+      const game = { homeScore: 21, awayScore: 14, homeId: 1, awayId: 2 };
+      expect(() => buildGameFlowSummary(game)).not.toThrow();
+    });
+
+    it('handles legacy finalScore shape', () => {
+      const game = {
+        finalScore: { home: 21, away: 14 },
+        homeTeamId: 1,
+        awayTeamId: 2,
+        scoringSummary: [
+          { quarter: 1, teamId: 1, points: 7, scoreAfter: { home: 7, away: 0 }, type: 'Touchdown', text: 'TD' },
+        ],
+      };
+      const result = buildGameFlowSummary(game);
+      expect(result).not.toBeNull();
+    });
+
+    it('handles empty arrays gracefully — returns summary with zero-value teamFlow', () => {
+      // teamStats with all zeros still produces a valid teamFlow entry (team played, just 0 stats)
+      // scoringSummary/playDigest empty → empty timelines, but teamFlow is non-null
+      const game = makeMinimalGame({ scoringSummary: [], playDigest: [] });
+      const result = buildGameFlowSummary(game);
+      expect(result).not.toBeNull();
+      expect(result.scoringTimeline).toEqual([]);
+      expect(result.turningPoints).toEqual([]);
+      expect(result.teamFlow).not.toBeNull();
+    });
+
+    it('returns null when game has score but absolutely no derived content', () => {
+      // No scoringSummary, no playDigest, no teamStats at all
+      const game = { homeScore: 14, awayScore: 7, homeTeamId: 1, awayTeamId: 2 };
+      expect(buildGameFlowSummary(game)).toBeNull();
+    });
+
+    it('handles deeply null/undefined nested fields', () => {
+      const game = {
+        homeScore: 10,
+        awayScore: 3,
+        homeTeamId: 1,
+        awayTeamId: 2,
+        teamStats: { home: null, away: null },
+        scoringSummary: [{ quarter: 1, teamId: 1, points: 3, scoreAfter: null, type: null, text: null }],
+      };
+      expect(() => buildGameFlowSummary(game)).not.toThrow();
+      const result = buildGameFlowSummary(game);
+      expect(result?.scoringTimeline[0].scoreAfter).toEqual({ home: 0, away: 0 });
+    });
+  });
+});


### PR DESCRIPTION
Implements a safe, compact, pure utility layer that derives game-flow
details from current game/box-score data without any schema changes,
simulation tuning changes, or payload bloat.

Technical audit summary
-----------------------
Canonical sim path: richGameSimulator.ts → weekSimulationBridge →
worker.js. RichGameSummary carries scoringSummary, playDigest (key
events), teamStats, and quarterScores — all fields used here.

Supported fields used by this PR:
  scoringSummary  → scoringTimeline
  playDigest      → turningPoints (lead_change / turnover / swing /
                    final_takeaway event types only)
  teamStats       → teamFlow (scoringDrives, turnovers, redZoneTrips,
                    redZoneScores, explosivePlays)

Deferred (not fabricated):
  driveSummary         — no per-drive play count or net-yards tracking
  longestDriveYards    — same
  down/distance engine — not tracked per play
  win probability chart
  full play-by-play with formation/personnel
  SVG/canvas drive field
  true live simulation mode

New files
---------
src/core/sim/gameFlowSummary.js
  Pure, stateless helper. buildGameFlowSummary(game) → summary | null.
  Deterministic, non-mutating, serializable. Safe with missing/legacy
  game data. No new dependencies.

tests/unit/gameFlowSummary.test.js
  38 focused tests covering: null/invalid input, non-mutation, output
  shape, scoringTimeline reconciliation, turning-point type filtering,
  teamFlow derivation, legacy field names, richGameSimulator integration,
  determinism (same seed → identical summary), and regression safety.

Changed files
-------------
src/ui/utils/boxScoreViewModel.js
  Imports buildGameFlowSummary; adds gameFlowSummary field to the VM
  returned by buildBoxScoreViewModel. Derived at read-time, never stored.

src/ui/components/BoxScore.jsx
  New "Game Flow" section (data-testid="game-book-game-flow"):
    - Scoring timeline list (Q·label·score·description)
    - Team snapshot table (scoring drives, turnovers, red zone, explosive)
    - Key turning points sub-list (lead changes, turnovers, swings)
  Section renders only when vm.gameFlowSummary is non-null.
  Mobile-safe, text-first, uses existing bs-section/bs-list CSS classes.

src/ui/components/PostGameScreen.jsx
  Renames "Game Center recap" → "Game Flow". Formats notable moments
  with colour-coded TD/Turnover type labels and structured Q+clock+text
  layout. No prop changes; no callers touched.

Persistence / payload safety
-----------------------------
Summary is derived at runtime in BoxScore from the existing archived
game object. Not persisted to IndexedDB. No schema/version change.
No worker protocol change. No simulation tuning constants changed.

Validation
----------
npm run test:unit → 1450/1450 passed (213 files)
npm run build    → clean build, no errors

https://claude.ai/code/session_01Q5i1zHaTuzVW1Xn4VscPsa