### PR TITLE
Add positional compatibility penalty foundation and depth-chart fit warnings

### DIFF
--- a/src/core/__tests__/depth-chart.test.js
+++ b/src/core/__tests__/depth-chart.test.js
@@ -20,6 +20,19 @@ describe('depth chart auto population', () => {
     expect(qb2.depthChart.order).toBe(1);
   });
 
+
+
+  it('flags severe and moderate out-of-position depth assignments', () => {
+    const players = [
+      { id: 1, name: 'Arm Punt', pos: 'QB', ovr: 80, teamId: 1, status: 'active' },
+      { id: 2, name: 'Coverage Ace', pos: 'CB', ovr: 82, teamId: 1, status: 'active' },
+      { id: 3, name: 'Free Safety', pos: 'S', ovr: 79, teamId: 1, status: 'active' },
+    ];
+    const warnings = depthWarnings({ OL: [1], S: [2], CB: [3] }, players);
+    expect(warnings.some((w) => w.message.includes('severe out-of-position'))).toBe(true);
+    expect(warnings.some((w) => w.message.includes('moderate role fit penalty'))).toBe(true);
+  });
+
   it('emits warnings for thin groups', () => {
     const players = [{ id: 10, pos: 'QB', ovr: 80, teamId: 1, status: 'active' }];
     const assignments = autoBuildDepthChart(players, {});

--- a/src/core/__tests__/positionalMultipliers.test.js
+++ b/src/core/__tests__/positionalMultipliers.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizePosition,
+  getPositionGroup,
+  getPositionCompatibility,
+  getPositionalPenaltyProfile,
+  calculateEffectiveAttributes,
+} from '../sim/positionalMultipliers.js';
+
+describe('positionalMultipliers', () => {
+  it('keeps same-position assignments at no penalty', () => {
+    expect(normalizePosition('hb')).toBe('RB');
+    expect(getPositionGroup('RG')).toBe('OL');
+    expect(getPositionCompatibility('QB', 'QB')).toBe('same');
+    expect(getPositionalPenaltyProfile('QB', 'QB').technicalMultiplier).toBe(1);
+  });
+
+  it('applies lighter penalty for related moves than cross-family moves', () => {
+    const wrToTe = getPositionalPenaltyProfile('WR', 'TE');
+    const wrToDt = getPositionalPenaltyProfile('WR', 'DT');
+    expect(wrToTe.technicalMultiplier).toBeGreaterThan(wrToDt.technicalMultiplier);
+
+    const cbToS = getPositionalPenaltyProfile('CB', 'S');
+    const cbToOl = getPositionalPenaltyProfile('CB', 'OL');
+    expect(cbToS.technicalMultiplier).toBeGreaterThan(cbToOl.technicalMultiplier);
+  });
+
+  it('severely penalizes specialists in non-specialist roles and handles unknown safely', () => {
+    expect(getPositionCompatibility('K', 'QB')).toBe('cross');
+    expect(getPositionalPenaltyProfile('QB', null).technicalMultiplier).toBe(1);
+  });
+
+  it('calculates effective attributes without mutating player source', () => {
+    const player = {
+      pos: 'QB',
+      ovr: 90,
+      pass: 92,
+      block: 34,
+      speed: 78,
+      awareness: 88,
+      ratings: { pass: 95, speed: 80, awareness: 90 },
+    };
+    const result = calculateEffectiveAttributes(player, 'OT');
+
+    expect(result).not.toBe(player);
+    expect(player.pass).toBe(92);
+    expect(result.pass).toBeLessThan(player.pass);
+    expect(result.speed).toBeGreaterThan(result.pass);
+    expect(result.ratings.pass).toBeLessThan(player.ratings.pass);
+  });
+});

--- a/src/core/depthChart.js
+++ b/src/core/depthChart.js
@@ -14,6 +14,8 @@ export const DEPTH_CHART_ROWS = [
   { group: 'SPECIAL', key: 'RS', label: 'Return Specialist', match: ['WR', 'RB', 'CB', 'S'], slots: 2, min: 1 },
 ];
 
+import { getPositionalPenaltyProfile } from './sim/positionalMultipliers.js';
+
 const SLOT_ROLES = ['starter', 'backup', 'rotation', 'specialist'];
 
 export function getDepthRows() {
@@ -138,6 +140,17 @@ export function depthWarnings(assignments = {}, players = []) {
       const eligible = players.some((p) => row.match.includes(p?.pos));
       if (eligible) warnings.push({ rowKey: row.key, severity: 'error', message: `${row.label} has no assignment despite eligible players.` });
     }
+
+    ids.forEach((id, idx) => {
+      const assigned = byId.get(Number(id));
+      if (!assigned) return;
+      const profile = getPositionalPenaltyProfile(assigned?.pos, row.key);
+      if (profile.compatibility === 'cross') {
+        warnings.push({ rowKey: row.key, severity: 'warn', message: `${assigned?.name ?? 'Player'} has a severe out-of-position assignment at ${row.label}${idx === 0 ? ' (starter)' : ''}.` });
+      } else if (idx === 0 && (profile.compatibility === 'minor' || profile.compatibility === 'family')) {
+        warnings.push({ rowKey: row.key, severity: 'info', message: `${assigned?.name ?? 'Player'} has a moderate role fit penalty at ${row.label}.` });
+      }
+    });
 
     const injuredStarter = byId.get(Number(ids[0]));
     if (injuredStarter && (injuredStarter?.injuryWeeksRemaining ?? 0) > 0) {

--- a/src/core/sim/positionalMultipliers.js
+++ b/src/core/sim/positionalMultipliers.js
@@ -1,0 +1,105 @@
+const POSITION_ALIASES = Object.freeze({
+  HB: 'RB', FB: 'RB', FL: 'WR', SE: 'WR',
+  LT: 'OT', RT: 'OT', LG: 'OG', RG: 'OG',
+  DE: 'EDGE', OLB: 'LB', MLB: 'LB', ILB: 'LB',
+  DT: 'IDL', NT: 'IDL', DL: 'IDL', DB: 'CB', NCB: 'CB',
+  SS: 'S', FS: 'S', PK: 'K',
+});
+
+const POSITION_GROUPS = Object.freeze({
+  QB: 'QB', RB: 'RB_FB', WR: 'WR', TE: 'TE',
+  OT: 'OL', OG: 'OL', C: 'OL', OL: 'OL',
+  EDGE: 'DL_EDGE', IDL: 'DL_EDGE',
+  LB: 'LB', CB: 'CB_S', S: 'CB_S',
+  K: 'K_P', P: 'K_P', RS: 'SKILL',
+});
+
+const TECHNICAL_KEYS = Object.freeze([
+  'pass', 'passing', 'throwAccuracyShort', 'throwAccuracyDeep', 'throwPower', 'release', 'decisionMaking',
+  'routeRunning', 'separation', 'catch', 'hands', 'catchInTraffic', 'ballTracking',
+  'block', 'passBlockFootwork', 'passBlockStrength', 'runBlock', 'passRush', 'tackle', 'coverage', 'zoneCoverage', 'pressCoverage',
+]);
+
+const PHYSICAL_KEYS = Object.freeze(['speed', 'acceleration', 'agility', 'strength', 'stamina', 'durability', 'injury']);
+
+export function normalizePosition(pos) {
+  const raw = String(pos ?? '').trim().toUpperCase();
+  if (!raw) return null;
+  return POSITION_ALIASES[raw] ?? raw;
+}
+
+export function getPositionGroup(pos) {
+  const normalized = normalizePosition(pos);
+  if (!normalized) return 'UNKNOWN';
+  return POSITION_GROUPS[normalized] ?? 'UNKNOWN';
+}
+
+export function getPositionCompatibility(naturalPosition, assignedPosition) {
+  const natural = normalizePosition(naturalPosition);
+  const assigned = normalizePosition(assignedPosition);
+  if (!natural || !assigned) return 'unknown';
+  if (natural === assigned) return 'same';
+
+  const ng = getPositionGroup(natural);
+  const ag = getPositionGroup(assigned);
+  if (ng === 'UNKNOWN' || ag === 'UNKNOWN') return 'unknown';
+  if (ng === ag) return 'family';
+
+  const nearPairs = new Set(['WR|TE', 'TE|WR', 'CB|S', 'S|CB', 'EDGE|LB', 'LB|EDGE', 'RB|WR', 'WR|RB']);
+  if (nearPairs.has(`${natural}|${assigned}`)) return 'minor';
+
+  return 'cross';
+}
+
+export function getPositionalPenaltyProfile(naturalPosition, assignedPosition) {
+  const compatibility = getPositionCompatibility(naturalPosition, assignedPosition);
+  if (compatibility === 'same' || compatibility === 'unknown') {
+    return { compatibility, technicalMultiplier: 1, physicalMultiplier: 1, awarenessMultiplier: 1, ovrMultiplier: 1 };
+  }
+  if (compatibility === 'family' || compatibility === 'minor') {
+    return { compatibility, technicalMultiplier: 0.88, physicalMultiplier: 0.96, awarenessMultiplier: 0.9, ovrMultiplier: 0.92 };
+  }
+  return { compatibility, technicalMultiplier: 0.58, physicalMultiplier: 0.84, awarenessMultiplier: 0.72, ovrMultiplier: 0.7 };
+}
+
+function scaledValue(value, multiplier) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return value;
+  return Math.max(0, Math.min(99, Math.round(num * multiplier)));
+}
+
+function mapRecord(record, profile) {
+  const out = { ...record };
+  for (const [key, value] of Object.entries(record ?? {})) {
+    const keyLower = String(key).toLowerCase();
+    const technical = TECHNICAL_KEYS.some((k) => k.toLowerCase() === keyLower);
+    const physical = PHYSICAL_KEYS.some((k) => k.toLowerCase() === keyLower);
+    const isAware = keyLower === 'awareness' || keyLower === 'iq';
+    const isOvr = keyLower === 'ovr';
+
+    const multiplier = isOvr
+      ? profile.ovrMultiplier
+      : isAware
+        ? profile.awarenessMultiplier
+        : technical
+          ? profile.technicalMultiplier
+          : physical
+            ? profile.physicalMultiplier
+            : 1;
+    out[key] = scaledValue(value, multiplier);
+  }
+  return out;
+}
+
+export function calculateEffectiveAttributes(player = {}, assignedPosition, options = {}) {
+  const naturalPosition = options.naturalPosition ?? player?.primaryPosition ?? player?.position ?? player?.pos;
+  const profile = getPositionalPenaltyProfile(naturalPosition, assignedPosition);
+  const clone = { ...player };
+
+  if (clone.ratings && typeof clone.ratings === 'object') clone.ratings = mapRecord(clone.ratings, profile);
+  if (clone.attributes && typeof clone.attributes === 'object') clone.attributes = mapRecord(clone.attributes, profile);
+
+  clone.effectiveProfile = profile;
+  clone.effectivePosition = normalizePosition(assignedPosition) ?? normalizePosition(naturalPosition);
+  return mapRecord(clone, profile);
+}


### PR DESCRIPTION
### Motivation
- The depth-chart system only used match-tier heuristics and lacked a reusable, deterministic effective-attribute layer to penalize out-of-position assignments without touching player generation or sim tuning.
- A small, safe V1 foundation is needed so future sim integration can apply meaningful technical vs physical penalties while preserving determinism and existing behavior.

### Description
- Added a pure compatibility and penalty module `src/core/sim/positionalMultipliers.js` providing `normalizePosition`, `getPositionGroup`, `getPositionCompatibility`, `getPositionalPenaltyProfile`, and `calculateEffectiveAttributes` (non-mutating). 
- Introduced a conservative penalty profile that distinguishes same, family/minor, and cross-family assignments with separate technical/physical/awareness/ovr multipliers and safe fallbacks for unknowns. 
- Wired a narrow, read-only integration into `src/core/depthChart.js::depthWarnings` so severe and moderate out-of-position assignments are surfaced as lineup warnings (no depth-chart repair, player generation, chemistry, or simulation constants were altered). 
- Added focused unit tests `src/core/__tests__/positionalMultipliers.test.js` and extended `src/core/__tests__/depth-chart.test.js` to validate same-position, related-position, cross-family, specialist mismatches, non-mutation guarantees, and the new warning messages.

### Testing
- Ran targeted unit tests for the new module and depth-chart changes with `npm run test:unit -- src/core/__tests__/positionalMultipliers.test.js src/core/__tests__/depth-chart.test.js` and they passed. 
- Ran full unit suite with `npm run test:unit` and all tests passed (214 files, 1455 tests in this environment). 
- Built the production bundle with `npm run build` and the build completed successfully (noting expected chunk-size warnings). 
- Ran dynasty soak subset with `npm run test:soak` and the soak tests passed; deterministic sim tests continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11298829dc832d9cbc63f5957afad7)