### PR TITLE
Integrate depth-assignment positional penalties into weekly sim aggregation

### DIFF
--- a/src/core/__tests__/positionalMultipliers.test.js
+++ b/src/core/__tests__/positionalMultipliers.test.js
@@ -5,6 +5,8 @@ import {
   getPositionCompatibility,
   getPositionalPenaltyProfile,
   calculateEffectiveAttributes,
+  inferAssignedPositionFromDepthSlot,
+  getEffectivePlayerForRole,
 } from '../sim/positionalMultipliers.js';
 
 describe('positionalMultipliers', () => {
@@ -47,5 +49,19 @@ describe('positionalMultipliers', () => {
     expect(result.pass).toBeLessThan(player.pass);
     expect(result.speed).toBeGreaterThan(result.pass);
     expect(result.ratings.pass).toBeLessThan(player.ratings.pass);
+  });
+
+  it('maps depth slot roles into canonical assigned positions safely', () => {
+    expect(inferAssignedPositionFromDepthSlot('LT')).toBe('OT');
+    expect(inferAssignedPositionFromDepthSlot('RG')).toBe('OG');
+    expect(inferAssignedPositionFromDepthSlot('CB')).toBe('CB');
+    expect(inferAssignedPositionFromDepthSlot(null)).toBe(null);
+  });
+
+  it('defaults safely when assigned role is unknown', () => {
+    const player = { pos: 'WR', routeRunning: 87 };
+    const result = getEffectivePlayerForRole(player, undefined);
+    expect(result).not.toBe(player);
+    expect(result.routeRunning).toBe(87);
   });
 });

--- a/src/core/__tests__/weekSimulationBridge.test.ts
+++ b/src/core/__tests__/weekSimulationBridge.test.ts
@@ -34,6 +34,21 @@ describe('weekSimulationBridge', () => {
     expect(units.defense.zoneCoverage).toBeGreaterThan(0);
   });
 
+  it('applies severe out-of-position penalties when depth assignment is known', () => {
+    const qbAttrs = mapOverallToAttributesV2(90, 5.5, 'qb');
+    const wrAttrs = mapOverallToAttributesV2(90, 5.5, 'wr');
+    const roster = [
+      { id: 1, name: 'Natural QB', pos: 'QB', attributesV2: qbAttrs, depthChart: { rowKey: 'QB', order: 1 } },
+      { id: 2, name: 'Wrong QB', pos: 'WR', attributesV2: wrAttrs, depthChart: { rowKey: 'QB', order: 1 } },
+    ];
+
+    const natural = aggregateTeamUnitsFromRoster([roster[0]] as any);
+    const mismatch = aggregateTeamUnitsFromRoster([roster[1]] as any);
+
+    expect(mismatch.offense.throwAccuracyShort).toBeLessThanOrEqual(natural.offense.throwAccuracyShort);
+    expect(mismatch.offense.throwPower).toBeLessThan(natural.offense.throwPower);
+  });
+
   it('falls back to legacy simulation when new path throws', async () => {
     const legacySimulate = vi.fn(async () => [{ scoreHome: 14, scoreAway: 10 }]);
     const manager = {

--- a/src/core/sim/positionalMultipliers.js
+++ b/src/core/sim/positionalMultipliers.js
@@ -6,6 +6,31 @@ const POSITION_ALIASES = Object.freeze({
   SS: 'S', FS: 'S', PK: 'K',
 });
 
+const DEPTH_SLOT_POSITION_MAP = Object.freeze({
+  QB: 'QB',
+  RB: 'RB',
+  WR: 'WR',
+  TE: 'TE',
+  OL: 'OL',
+  LT: 'OT',
+  LG: 'OG',
+  C: 'C',
+  RG: 'OG',
+  RT: 'OT',
+  EDGE: 'EDGE',
+  IDL: 'IDL',
+  DL: 'IDL',
+  LB: 'LB',
+  CB: 'CB',
+  S: 'S',
+  FS: 'S',
+  SS: 'S',
+  DB: 'CB',
+  K: 'K',
+  P: 'P',
+  RS: 'RS',
+});
+
 const POSITION_GROUPS = Object.freeze({
   QB: 'QB', RB: 'RB_FB', WR: 'WR', TE: 'TE',
   OT: 'OL', OG: 'OL', C: 'OL', OL: 'OL',
@@ -102,4 +127,20 @@ export function calculateEffectiveAttributes(player = {}, assignedPosition, opti
   clone.effectiveProfile = profile;
   clone.effectivePosition = normalizePosition(assignedPosition) ?? normalizePosition(naturalPosition);
   return mapRecord(clone, profile);
+}
+
+export function inferAssignedPositionFromDepthSlot(slotName) {
+  const normalizedSlot = normalizePosition(slotName);
+  if (!normalizedSlot) return null;
+  return DEPTH_SLOT_POSITION_MAP[normalizedSlot] ?? normalizedSlot;
+}
+
+export function normalizeAssignedRole(roleOrSlot) {
+  return inferAssignedPositionFromDepthSlot(roleOrSlot);
+}
+
+export function getEffectivePlayerForRole(player = {}, roleOrPosition, options = {}) {
+  const assignedPosition = normalizeAssignedRole(roleOrPosition);
+  if (!assignedPosition) return { ...player };
+  return calculateEffectiveAttributes(player, assignedPosition, options);
 }

--- a/src/core/sim/weekSimulationBridge.ts
+++ b/src/core/sim/weekSimulationBridge.ts
@@ -1,5 +1,6 @@
 import type { AttributesV2, Player } from '../../types/player.ts';
 import { ensureAttributesV2 } from '../migration/attributeMigrator.ts';
+import { getEffectivePlayerForRole } from './positionalMultipliers.js';
 import type { GameSummary, Matchup, SimulationManager } from '../../worker/WorkerPool.ts';
 
 const OFFENSE_KEYS: Array<keyof AttributesV2> = [
@@ -70,10 +71,19 @@ export function aggregateTeamUnitsFromRoster(roster: Player[] = []): AggregatedT
   const upgradedRoster = roster
     .map((player) => {
       const upgraded = ensureAttributesV2(player);
+      const assignedSlot = player?.depthChart?.rowKey;
+      const effective = getEffectivePlayerForRole(upgraded, assignedSlot);
+      const merged = {
+        ...upgraded,
+        attributesV2: {
+          ...upgraded.attributesV2,
+          ...(effective.attributesV2 ?? {}),
+        },
+      };
       if (!player.attributesV2 && player.id != null) {
         migratedPlayers.push({ id: player.id, attributesV2: upgraded.attributesV2 });
       }
-      return upgraded as Player & { attributesV2: AttributesV2 };
+      return merged as Player & { attributesV2: AttributesV2 };
     })
     .sort(stablePlayerSort);
 


### PR DESCRIPTION
### Motivation
- The sim path accepted positional-penalty helpers from PR #1492 but still fed raw `attributesV2` into the weekly/new-engine matchup pipeline, so out-of-position starter warnings did not affect game outcomes. 
- The intent is to apply runtime-only effective attributes so out-of-position starters influence simulation results only where the sim can reliably see the assigned slot. 
- Changes must be conservative: no saved-data/schema/worker-protocol changes, no mutation of player records, no broad retuning, and determinism preserved.

### Description
- Added a small role-to-position adapter and safe helpers in `src/core/sim/positionalMultipliers.js`: `DEPTH_SLOT_POSITION_MAP`, `inferAssignedPositionFromDepthSlot`, `normalizeAssignedRole`, and `getEffectivePlayerForRole`, which compute runtime-only effective attributes using the existing penalty profile. 
- Narrowly wired effective attributes into the canonical weekly aggregation in `src/core/sim/weekSimulationBridge.ts` by merging the computed `effective.attributesV2` into the transient `attributesV2` used to build offense/defense vectors (no persistence, no player record mutation). 
- Audited and documented the canonical sim flow used for weekly games: `src/worker/worker.js` → `buildWeekMatchupsFromLeague` → `aggregateTeamUnitsFromRoster` (bridge) → `simulateRichGame`/`SimulationManager.simWeekParallel` → `src/core/sim/richGameSimulator.ts` → `resolveMatchup` → `src/core/sim/matchupEngine.ts`, and confirmed `player.depthChart.rowKey` is available at aggregation time so integration is safe. 
- Added focused tests and small test adjustments: slot-to-position mapping and unknown-role safety in `src/core/__tests__/positionalMultipliers.test.js`, and an out-of-position degradation check in `src/core/__tests__/weekSimulationBridge.test.ts` that asserts non-brittle, expected attribute degradation.

### Testing
- Ran unit tests with `npm run test:unit` and the full suite passed (all tests green). 
- Built the app with `npm run build` and the production build completed successfully (bundle warnings only). 
- Ran soak/dynasty subset with `npm run test:soak` and all soak tests passed. 
- No automated test failed after the change; determinism preserved and no schema/persistence changes were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11530f3ebc832d88abc4aed8453f71)