### PR TITLE
Add roster release financial preview modal before player cuts

### DIFF
--- a/src/ui/components/ReleasePreviewModal.jsx
+++ b/src/ui/components/ReleasePreviewModal.jsx
@@ -1,0 +1,79 @@
+import React from "react";
+import {
+  calculateReleaseDeadCap,
+  getActiveCapHit,
+  getAnnualBaseSalary,
+  getAnnualBonusProration,
+  getContractYearsRemaining,
+} from "../../core/contracts/contractObligations.js";
+import { formatMoneyM } from "../utils/numberFormatting.js";
+
+function metricLabelStyle() {
+  return { fontSize: "var(--text-xs)", color: "var(--text-subtle)", textTransform: "uppercase", letterSpacing: "0.06em" };
+}
+
+export default function ReleasePreviewModal({
+  open,
+  player,
+  capRoomNow = 0,
+  onCancel,
+  onConfirm,
+}) {
+  if (!open || !player) return null;
+
+  const yearsRemaining = getContractYearsRemaining(player);
+  const baseSalary = getAnnualBaseSalary(player);
+  const annualBonus = getAnnualBonusProration(player);
+  const activeCapHit = getActiveCapHit(player);
+  const deadCap = calculateReleaseDeadCap(player)?.total ?? 0;
+  const projectedCapRoom = capRoomNow + Math.max(0, activeCapHit - deadCap);
+
+  return (
+    <div role="dialog" aria-modal="true" aria-label={`Release preview for ${player.name}`} style={{
+      position: "fixed",
+      inset: 0,
+      background: "rgba(5,10,20,0.72)",
+      zIndex: 9000,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      padding: "var(--space-3)",
+    }}>
+      <div style={{
+        width: "min(520px, 100%)",
+        maxHeight: "90vh",
+        overflowY: "auto",
+        background: "var(--surface-2)",
+        border: "1px solid var(--hairline)",
+        borderRadius: "var(--radius-lg)",
+        padding: "var(--space-4)",
+      }}>
+        <h2 style={{ marginBottom: "var(--space-2)", fontSize: "var(--text-lg)", fontWeight: 800 }}>Release Preview (Estimate)</h2>
+        <p style={{ marginBottom: "var(--space-3)", color: "var(--text-muted)", fontSize: "var(--text-sm)" }}>
+          Exact processing follows league release rules. This is an estimated cap-impact preview.
+        </p>
+
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: "var(--space-2)", marginBottom: "var(--space-3)" }}>
+          <div><div style={metricLabelStyle()}>Player</div><div style={{ fontWeight: 700 }}>{player.name ?? "Unknown"}</div></div>
+          <div><div style={metricLabelStyle()}>Position</div><div style={{ fontWeight: 700 }}>{player.pos ?? "—"}</div></div>
+          <div><div style={metricLabelStyle()}>OVR</div><div style={{ fontWeight: 700 }}>{Number(player.ovr ?? 0)}</div></div>
+          <div><div style={metricLabelStyle()}>Years Left</div><div style={{ fontWeight: 700 }}>{Math.max(0, yearsRemaining)}</div></div>
+        </div>
+
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: "var(--space-2)", marginBottom: "var(--space-3)" }}>
+          <div><div style={metricLabelStyle()}>Current Base Salary</div><div>{formatMoneyM(baseSalary)}</div></div>
+          <div><div style={metricLabelStyle()}>Annual Signing Bonus Proration</div><div>{formatMoneyM(annualBonus)}</div></div>
+          <div><div style={metricLabelStyle()}>Active Cap Hit</div><div>{formatMoneyM(activeCapHit)}</div></div>
+          <div><div style={metricLabelStyle()}>Estimated Dead Cap</div><div>{formatMoneyM(deadCap)}</div></div>
+          <div><div style={metricLabelStyle()}>Active Cap Room</div><div>{formatMoneyM(capRoomNow)}</div></div>
+          <div><div style={metricLabelStyle()}>Projected Cap Room Preview</div><div>{formatMoneyM(projectedCapRoom)}</div></div>
+        </div>
+
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: "var(--space-2)", flexWrap: "wrap" }}>
+          <button className="btn" onClick={onCancel}>Cancel</button>
+          <button className="btn btn-danger" onClick={onConfirm}>Confirm Release</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -35,6 +35,7 @@ import PlayerCompareTray from "./PlayerCompareTray.jsx";
 import PlayerProfile from "./PlayerProfile.jsx";
 import PlayerProfileModalBoundary from "./PlayerProfileModalBoundary.jsx";
 import ExtensionNegotiationModal from "./ExtensionNegotiationModal.jsx";
+import ReleasePreviewModal from "./ReleasePreviewModal.jsx";
 import { teamColor } from "../../data/team-utils.js";
 import { OFFENSIVE_SCHEMES, DEFENSIVE_SCHEMES } from "../../core/scheme-core.js";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
@@ -487,7 +488,7 @@ function RosterTable({
   const [posFilter, setPosFilter] = useState(initialFilter || (isResignPhase ? "EXPIRING" : "ALL"));
   const [sortKey, setSortKey] = useState("ovr");
   const [sortDir, setSortDir] = useState("desc");
-  const [releasing, setReleasing] = useState(null);
+  const [releaseCandidate, setReleaseCandidate] = useState(null);
   const [extending, setExtending] = useState(null);
   const [advancedFilters, setAdvancedFilters] = useState([]);
   const [search, setSearch] = useState("");
@@ -554,31 +555,15 @@ function RosterTable({
       }
   };
 
-  const handleRelease = async (player) => {
-    if (releasing !== player.id) {
-      setReleasing(player.id);
-      return;
-    }
-
-    // Check dead cap
-    const c = player.contract;
-    const annualBonus = (c?.signingBonus ?? 0) / (c?.yearsTotal || 1);
-    const deadCap = annualBonus * (c?.years || 1);
-
-    if (deadCap > 0.5) {
-      if (
-        !window.confirm(
-          `Release ${player.name}?\n\nThis will accelerate ${formatMoneyM(deadCap)} of dead cap against your budget.`,
-        )
-      ) {
-        setReleasing(null);
-        return;
-      }
-    }
-
-    setReleasing(null);
-    actions.releasePlayer(player.id, teamId);
-    onRefetch();
+  const openReleasePreview = (player) => {
+    setReleaseCandidate(player ?? null);
+  };
+  const cancelReleasePreview = () => setReleaseCandidate(null);
+  const confirmRelease = () => {
+    if (!releaseCandidate?.id) return;
+    actions.releasePlayer(releaseCandidate.id, teamId);
+    setReleaseCandidate(null);
+    onRefetch?.();
   };
 
   const handleTradeBlockToggle = async (playerId) => {
@@ -597,6 +582,7 @@ function RosterTable({
       console.error('[Roster] updatePlayerManagement failed', e);
     }
   };
+  const releasePreviewCapRoom = toFiniteNumber(team?.capRoom, 0);
 
 
 
@@ -616,6 +602,13 @@ function RosterTable({
           }}
         />
       )}
+      <ReleasePreviewModal
+        open={Boolean(releaseCandidate)}
+        player={releaseCandidate}
+        capRoomNow={releasePreviewCapRoom}
+        onCancel={cancelReleasePreview}
+        onConfirm={confirmRelease}
+      />
       {/* Player comparison modal */}
       {showComparison && comparePlayerA && comparePlayerB && (
         <PlayerComparison
@@ -851,7 +844,7 @@ function RosterTable({
                 </TableRow>
               )}
                   {evaluatedDisplayed.map(({ player, eval: playerEval }, idx) => {
-                const isReleasing = releasing === player.id;
+                const isReleasing = releaseCandidate?.id === player.id;
                 const isExpiring = (player.contract?.years || 0) <= 1;
                 const yearsLeft =
                   player.contract?.yearsRemaining ??
@@ -1148,7 +1141,7 @@ function RosterTable({
                               fontSize: "var(--text-xs)",
                               padding: "2px 10px",
                             }}
-                            onClick={() => handleRelease(player)}
+                            onClick={() => openReleasePreview(player)}
                           >
                             Confirm
                           </Button>
@@ -1158,7 +1151,7 @@ function RosterTable({
                               fontSize: "var(--text-xs)",
                               padding: "2px 8px",
                             }}
-                            onClick={() => setReleasing(null)}
+                            onClick={cancelReleasePreview}
                           >
                             Cancel
                           </Button>
@@ -1202,7 +1195,7 @@ function RosterTable({
                               color: "var(--danger)",
                               borderColor: "var(--danger)",
                             }}
-                            onClick={() => handleRelease(player)}
+                            onClick={() => openReleasePreview(player)}
                           >
                             Cut
                           </Button>

--- a/src/ui/components/__tests__/ReleasePreviewModal.test.jsx
+++ b/src/ui/components/__tests__/ReleasePreviewModal.test.jsx
@@ -1,0 +1,69 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import ReleasePreviewModal from '../ReleasePreviewModal.jsx';
+
+afterEach(() => cleanup());
+
+describe('ReleasePreviewModal', () => {
+  it('renders estimated contract/dead-cap breakdown for bonus contracts', () => {
+    render(
+      <ReleasePreviewModal
+        open
+        capRoomNow={32}
+        player={{
+          id: 7,
+          name: 'Marcus Vale',
+          pos: 'WR',
+          ovr: 84,
+          contract: { baseAnnual: 12, signingBonus: 9, yearsTotal: 3, yearsRemaining: 2 },
+        }}
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('dialog', { name: /release preview for marcus vale/i })).toBeTruthy();
+    expect(screen.getByText('Estimated Dead Cap')).toBeTruthy();
+    expect(screen.getByText('$6.0M')).toBeTruthy();
+    expect(screen.getByText('Projected Cap Room Preview')).toBeTruthy();
+    expect(screen.getByText(/exact processing follows league release rules/i)).toBeTruthy();
+  });
+
+  it('supports legacy flat contracts with zeroed bonus/dead-cap values', () => {
+    render(
+      <ReleasePreviewModal
+        open
+        capRoomNow={14}
+        player={{ id: 8, name: 'Legacy Lineman', pos: 'OL', ovr: 68, contract: { baseAnnual: 4, years: 1 } }}
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText('Annual Signing Bonus Proration').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('$0.0M').length).toBeGreaterThan(0);
+  });
+
+  it('cancel and confirm handlers are isolated and called exactly once', () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+    render(
+      <ReleasePreviewModal
+        open
+        capRoomNow={18}
+        player={{ id: 9, name: 'Callback Test', pos: 'LB', ovr: 77, contract: { baseAnnual: 7, yearsRemaining: 2 } }}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledTimes(0);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Release' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### Motivation
- GMs could cut players without seeing the contract/dead-cap consequences in the UI; the worker already enforces release penalties but the UI lacked a preflight estimate.  
- Provide an honest, mobile-first preview that maps directly to the pure helpers in `src/core/contracts/contractObligations.js` while avoiding any changes to worker, persistence, or simulation logic.  
- Ensure legacy/flat-contract saves render safely (zero signing bonus / zero dead cap) and that canceling the preview makes no worker calls or state mutations.  

### Description
- Added a new `ReleasePreviewModal` component (`src/ui/components/ReleasePreviewModal.jsx`) that uses `getAnnualBaseSalary`, `getAnnualBonusProration`, `getActiveCapHit`, and `calculateReleaseDeadCap` from `contractObligations.js` to render player metadata, current base salary, annual bonus proration, active cap hit, estimated dead cap, active cap room, and a projected post-release cap-room preview; copy is explicit that values are estimates.  
- Wired the roster cut flow in `src/ui/components/Roster.jsx` to open the preview (`openReleasePreview` → `ReleasePreviewModal`) and only execute the background transaction via `actions.releasePlayer(playerId, teamId)` when the user clicks Confirm, while Cancel only closes the modal with zero worker messaging.  
- Kept all simulation/worker behavior unchanged (no edits to `src/worker/worker.js`), and added safe fallbacks so legacy contracts without bonuses show `$0.0M` for bonus/dead-cap fields.  
- Added unit tests `src/ui/components/__tests__/ReleasePreviewModal.test.jsx` to verify rendering for bonus-bearing contracts and legacy flat contracts, that Cancel is non-mutating, and that Confirm invokes the provided handler exactly once; modal includes `role=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a115805053c832d8438edf0ee5e1f4c)