### PR TITLE
Add conservative AI team strategic posture (CONTENDER/REBUILDER/NEUTRAL) for read-only trade valuation

### DIFF
--- a/src/core/trades/__tests__/teamStrategicDirection.test.js
+++ b/src/core/trades/__tests__/teamStrategicDirection.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  TEAM_STRATEGIC_POSTURE,
+  applyStrategicValuationModifiers,
+  classifyTeamStrategicPosture,
+  getTeamContextSnapshot,
+} from '../teamStrategicDirection.js';
+
+describe('teamStrategicDirection', () => {
+  it('defaults to NEUTRAL when sample is incomplete', () => {
+    const posture = classifyTeamStrategicPosture({ wins: 2, losses: 1, roster: [{ age: 25 }, { age: 26 }] }, { currentSeason: 2027 });
+    expect(posture).toBe(TEAM_STRATEGIC_POSTURE.NEUTRAL);
+  });
+
+  it('classifies contender with strong record and mature roster', () => {
+    const posture = classifyTeamStrategicPosture(
+      { wins: 9, losses: 3, capRoom: 8, roster: Array.from({ length: 53 }, () => ({ age: 28 })) },
+      { currentSeason: 2027 },
+    );
+    expect(posture).toBe(TEAM_STRATEGIC_POSTURE.CONTENDER);
+  });
+
+  it('classifies rebuilder with poor record and young roster', () => {
+    const posture = classifyTeamStrategicPosture(
+      { wins: 2, losses: 9, capRoom: -9, roster: Array.from({ length: 53 }, () => ({ age: 24 })) },
+      { currentSeason: 2027 },
+    );
+    expect(posture).toBe(TEAM_STRATEGIC_POSTURE.REBUILDER);
+  });
+
+  it('rebuilders value picks above neutral', () => {
+    const pick = { assetType: 'pick', season: 2029, round: 1 };
+    const neutral = applyStrategicValuationModifiers(pick, 200, TEAM_STRATEGIC_POSTURE.NEUTRAL, { currentSeason: 2027 });
+    const rebuilder = applyStrategicValuationModifiers(pick, 200, TEAM_STRATEGIC_POSTURE.REBUILDER, { currentSeason: 2027 });
+    expect(rebuilder).toBeGreaterThan(neutral);
+  });
+
+  it('contenders value immediate high OVR contributors above neutral', () => {
+    const player = { assetType: 'player', age: 27, ovr: 86, potential: 87, salary: 11 };
+    const neutral = applyStrategicValuationModifiers(player, 300, TEAM_STRATEGIC_POSTURE.NEUTRAL, { currentSeason: 2027 });
+    const contender = applyStrategicValuationModifiers(player, 300, TEAM_STRATEGIC_POSTURE.CONTENDER, { currentSeason: 2027 });
+    expect(contender).toBeGreaterThan(neutral);
+  });
+
+  it('rebuilders discount aging expensive veterans', () => {
+    const vet = { assetType: 'player', age: 32, ovr: 82, potential: 82, salary: 18 };
+    const neutral = applyStrategicValuationModifiers(vet, 250, TEAM_STRATEGIC_POSTURE.NEUTRAL, { currentSeason: 2027 });
+    const rebuilder = applyStrategicValuationModifiers(vet, 250, TEAM_STRATEGIC_POSTURE.REBUILDER, { currentSeason: 2027 });
+    expect(rebuilder).toBeLessThan(neutral);
+  });
+
+  it('contenders mildly discount far-future picks', () => {
+    const pick = { assetType: 'pick', season: 2030, round: 1 };
+    const neutral = applyStrategicValuationModifiers(pick, 220, TEAM_STRATEGIC_POSTURE.NEUTRAL, { currentSeason: 2027 });
+    const contender = applyStrategicValuationModifiers(pick, 220, TEAM_STRATEGIC_POSTURE.CONTENDER, { currentSeason: 2027 });
+    expect(contender).toBeLessThan(neutral);
+  });
+
+  it('snapshot/helper calls are deterministic and non-mutating', () => {
+    const team = { wins: 7, losses: 5, roster: [{ age: 26 }], capRoom: 3 };
+    const frozenBefore = JSON.stringify(team);
+    const one = getTeamContextSnapshot(team, { currentSeason: 2027 });
+    const two = getTeamContextSnapshot(team, { currentSeason: 2027 });
+    expect(one).toEqual(two);
+    expect(JSON.stringify(team)).toBe(frozenBefore);
+  });
+});

--- a/src/core/trades/teamStrategicDirection.js
+++ b/src/core/trades/teamStrategicDirection.js
@@ -1,0 +1,134 @@
+export const TEAM_STRATEGIC_POSTURE = Object.freeze({
+  CONTENDER: 'CONTENDER',
+  REBUILDER: 'REBUILDER',
+  NEUTRAL: 'NEUTRAL',
+});
+
+export const TEAM_STRATEGY_DEFAULTS = Object.freeze({
+  minGamesForClassification: 6,
+  contenderWinPctMin: 0.62,
+  rebuilderWinPctMax: 0.38,
+  contenderAvgAgeMin: 26.8,
+  rebuilderAvgAgeMax: 25.6,
+  contenderSignalsRequired: 2,
+  rebuilderSignalsRequired: 2,
+  contenderCapRoomMin: 0,
+  rebuilderCapRoomMax: -5,
+  immediateStarterOvrThreshold: 82,
+  youngPlayerAgeMax: 24,
+  upsideDeltaMin: 4,
+  agingVeteranAgeMin: 30,
+  veteranSalaryBurdenMin: 12,
+  farFuturePickYearsOutMin: 2,
+});
+
+const num = (v, fb = null) => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fb;
+};
+
+export function getTeamContextSnapshot(teamState = {}, leagueContext = {}, options = {}) {
+  const cfg = { ...TEAM_STRATEGY_DEFAULTS, ...options };
+  const wins = num(teamState?.wins ?? teamState?.record?.wins, null);
+  const losses = num(teamState?.losses ?? teamState?.record?.losses, null);
+  const ties = num(teamState?.ties ?? teamState?.record?.ties, 0) ?? 0;
+  const gamesPlayedRaw = num(teamState?.gamesPlayed ?? teamState?.record?.gamesPlayed, null);
+  const gamesPlayed = gamesPlayedRaw ?? ((wins != null && losses != null) ? (wins + losses + ties) : null);
+
+  const roster = Array.isArray(teamState?.roster) ? teamState.roster : [];
+  const rosterAges = roster.map((p) => num(p?.age, null)).filter((age) => age != null);
+  const rosterAvgAge = rosterAges.length
+    ? (rosterAges.reduce((sum, age) => sum + age, 0) / rosterAges.length)
+    : null;
+
+  const capRoom = num(teamState?.capRoom ?? teamState?.cap?.capRoom ?? leagueContext?.capRoom, null);
+  const currentSeason = num(leagueContext?.currentSeason ?? leagueContext?.year, null);
+  const winPct = (gamesPlayed != null && gamesPlayed > 0 && wins != null)
+    ? (wins + (ties * 0.5)) / gamesPlayed
+    : null;
+
+  return Object.freeze({
+    wins,
+    losses,
+    ties,
+    gamesPlayed,
+    winPct,
+    rosterAvgAge,
+    capRoom,
+    currentSeason,
+    isSampleReliable: gamesPlayed != null && gamesPlayed >= cfg.minGamesForClassification,
+  });
+}
+
+export function classifyTeamStrategicPosture(teamState = {}, leagueContext = {}, options = {}) {
+  const cfg = { ...TEAM_STRATEGY_DEFAULTS, ...options };
+  const snapshot = getTeamContextSnapshot(teamState, leagueContext, cfg);
+  if (!snapshot.isSampleReliable || snapshot.winPct == null) {
+    return TEAM_STRATEGIC_POSTURE.NEUTRAL;
+  }
+
+  let contenderSignals = 0;
+  let rebuilderSignals = 0;
+
+  if (snapshot.winPct >= cfg.contenderWinPctMin) contenderSignals += 1;
+  if (snapshot.winPct <= cfg.rebuilderWinPctMax) rebuilderSignals += 1;
+  if (snapshot.rosterAvgAge != null && snapshot.rosterAvgAge >= cfg.contenderAvgAgeMin) contenderSignals += 1;
+  if (snapshot.rosterAvgAge != null && snapshot.rosterAvgAge <= cfg.rebuilderAvgAgeMax) rebuilderSignals += 1;
+  if (snapshot.capRoom != null && snapshot.capRoom >= cfg.contenderCapRoomMin) contenderSignals += 1;
+  if (snapshot.capRoom != null && snapshot.capRoom <= cfg.rebuilderCapRoomMax) rebuilderSignals += 1;
+
+  if (contenderSignals >= cfg.contenderSignalsRequired && contenderSignals > rebuilderSignals) {
+    return TEAM_STRATEGIC_POSTURE.CONTENDER;
+  }
+  if (rebuilderSignals >= cfg.rebuilderSignalsRequired && rebuilderSignals > contenderSignals) {
+    return TEAM_STRATEGIC_POSTURE.REBUILDER;
+  }
+  return TEAM_STRATEGIC_POSTURE.NEUTRAL;
+}
+
+export function applyStrategicValuationModifiers(asset = {}, baseValue = 0, teamPosture = TEAM_STRATEGIC_POSTURE.NEUTRAL, options = {}) {
+  const cfg = { ...TEAM_STRATEGY_DEFAULTS, ...options };
+  const base = Number(baseValue);
+  if (!Number.isFinite(base) || base <= 0) return Math.max(0, base || 0);
+
+  let multiplier = 1;
+  if (teamPosture === TEAM_STRATEGIC_POSTURE.REBUILDER) {
+    if (asset?.assetType === 'pick') multiplier *= 1.12;
+    if (asset?.assetType === 'player') {
+      const age = num(asset?.age, 27);
+      const ovr = num(asset?.ovr, 70);
+      const pot = num(asset?.potential ?? asset?.pot, ovr);
+      const salary = num(asset?.salary ?? asset?.baseAnnual ?? asset?.contract?.baseAnnual, 0);
+      if (age <= cfg.youngPlayerAgeMax && (pot - ovr) >= cfg.upsideDeltaMin) multiplier *= 1.12;
+      if (age >= cfg.agingVeteranAgeMin && salary >= cfg.veteranSalaryBurdenMin) multiplier *= 0.85;
+    }
+  }
+
+  if (teamPosture === TEAM_STRATEGIC_POSTURE.CONTENDER) {
+    if (asset?.assetType === 'pick') {
+      const currentSeason = num(options?.currentSeason, null);
+      const pickSeason = num(asset?.season ?? asset?.year, null);
+      const yearsOut = currentSeason != null && pickSeason != null ? (pickSeason - currentSeason) : 0;
+      if (yearsOut >= cfg.farFuturePickYearsOutMin) multiplier *= 0.92;
+      else multiplier *= 0.98;
+    }
+    if (asset?.assetType === 'player') {
+      const age = num(asset?.age, 27);
+      const ovr = num(asset?.ovr, 70);
+      const pot = num(asset?.potential ?? asset?.pot, ovr);
+      if (ovr >= cfg.immediateStarterOvrThreshold && age <= 30) multiplier *= 1.1;
+      if (age <= 24 && (pot - ovr) >= cfg.upsideDeltaMin + 2 && ovr < cfg.immediateStarterOvrThreshold) multiplier *= 0.95;
+    }
+  }
+
+  return Math.round(base * multiplier);
+}
+
+export function applyStrategicPackageModifiers(packageAssets = [], baseScore = 0, teamPosture = TEAM_STRATEGIC_POSTURE.NEUTRAL, options = {}) {
+  if (!Array.isArray(packageAssets) || packageAssets.length === 0) return Number(baseScore) || 0;
+  const adjusted = packageAssets.reduce((sum, asset) => {
+    const value = Number(asset?.valueScore ?? asset?.value ?? 0);
+    return sum + applyStrategicValuationModifiers(asset, value, teamPosture, options);
+  }, 0);
+  return Number.isFinite(adjusted) && adjusted > 0 ? adjusted : Number(baseScore) || 0;
+}

--- a/src/core/trades/tradeFinderAnalysis.js
+++ b/src/core/trades/tradeFinderAnalysis.js
@@ -6,6 +6,12 @@ import {
   evaluateMultiAssetPackageValue,
   getPickBaseValueFromMatrix,
 } from './tradeValuationModifiers.js';
+import {
+  TEAM_STRATEGIC_POSTURE,
+  applyStrategicValuationModifiers,
+  classifyTeamStrategicPosture,
+  getTeamContextSnapshot,
+} from './teamStrategicDirection.js';
 
 const PICK_VALUE_SCALING = 0.184;
 
@@ -203,9 +209,13 @@ function scorePackageIdea({ need, valueDelta, valueMatch, warnings, capImpact })
   return clamp(score, 1, 99);
 }
 function classifyValueMatchDetail(v){return buildValueDeltaLabel(v);}
-function buildIdea({ need, target, outgoingAssets, targetTeam, cap, packageType }) {
-  const targetValue = getPlayerValueSafe(target);
-  const outgoingValue = evaluateMultiAssetPackageValue(outgoingAssets.map((a) => num(a.valueScore)));
+function buildIdea({ need, target, outgoingAssets, targetTeam, cap, packageType, strategicContext = {} }) {
+  const teamPosture = strategicContext?.teamPosture ?? TEAM_STRATEGIC_POSTURE.NEUTRAL;
+  const currentSeason = strategicContext?.currentSeason ?? null;
+  const targetBaseValue = getPlayerValueSafe(target);
+  const targetValue = applyStrategicValuationModifiers({ assetType: 'player', ...target }, targetBaseValue, teamPosture, { currentSeason });
+  const outgoingStrategicValues = outgoingAssets.map((a) => applyStrategicValuationModifiers(a, num(a.valueScore), teamPosture, { currentSeason }));
+  const outgoingValue = evaluateMultiAssetPackageValue(outgoingStrategicValues);
   const valueDelta = Math.round(targetValue - outgoingValue);
   const valueMatch = classifyValueMatch(valueDelta);
   const capData = calculatePackageCapImpact({ target, outgoingAssets, cap });
@@ -246,17 +256,17 @@ function buildIdea({ need, target, outgoingAssets, targetTeam, cap, packageType 
   };
 }
 
-function generatePackageVariants({ need, target, chipPool, picks, nonStarterIds, targetTeam, cap }) {
+function generatePackageVariants({ need, target, chipPool, picks, nonStarterIds, targetTeam, cap, strategicContext }) {
   const ideas = [];
   const base = chipPool.find((c) => c.pos === target.pos) ?? chipPool[0];
   if (!base) return ideas;
-  const oneForOne = buildIdea({ need, target, outgoingAssets: [base], targetTeam, cap, packageType: 'one_for_one' });
+  const oneForOne = buildIdea({ need, target, outgoingAssets: [base], targetTeam, cap, packageType: 'one_for_one', strategicContext });
   ideas.push(oneForOne);
   const smallestPick = choosePickForPackage({ picks, valueDelta: oneForOne.valueDelta, target, need, baseValueMatch: oneForOne.valueMatch });
-  if (smallestPick && ['expensive', 'unrealistic'].includes(oneForOne.valueMatch)) ideas.push(buildIdea({ need, target, outgoingAssets: [base, smallestPick], targetTeam, cap, packageType: 'player_plus_pick' }));
+  if (smallestPick && ['expensive', 'unrealistic'].includes(oneForOne.valueMatch)) ideas.push(buildIdea({ need, target, outgoingAssets: [base, smallestPick], targetTeam, cap, packageType: 'player_plus_pick', strategicContext }));
   const extra = chipPool.find((c) => c.playerId !== base.playerId && nonStarterIds.has(c.playerId));
-  if (extra && oneForOne.valueMatch === 'unrealistic') ideas.push(buildIdea({ need, target, outgoingAssets: [base, extra], targetTeam, cap, packageType: 'two_players' }));
-  if (Number(base.salary) > Number(getPlayerSalary(target))) ideas.push(buildIdea({ need, target, outgoingAssets: [base], targetTeam, cap, packageType: 'cap_relief' }));
+  if (extra && oneForOne.valueMatch === 'unrealistic') ideas.push(buildIdea({ need, target, outgoingAssets: [base, extra], targetTeam, cap, packageType: 'two_players', strategicContext }));
+  if (Number(base.salary) > Number(getPlayerSalary(target))) ideas.push(buildIdea({ need, target, outgoingAssets: [base], targetTeam, cap, packageType: 'cap_relief', strategicContext }));
   return ideas.filter((i) => i.packageAssetCount <= 3 && (!(target.pos === 'K' || target.pos === 'P') || i.outgoingAssets.every((a)=>a.assetType!=='pick'||a.valueTier!=='premium')));
 }
 
@@ -276,7 +286,13 @@ export function buildTradeFinderAnalysis({ userTeam, league = {}, teams = [], us
   for (const need of targetNeeds.slice(0, 4)) {
     for (const target of getTargetsFromIndex({ need, targetIndex })) {
       const targetTeam = teamMap.get(num(target.teamId));
-      ideas.push(...generatePackageVariants({ need, target, chipPool, picks: userPickChips, nonStarterIds, targetTeam, cap }));
+      const targetRoster = leaguePlayers.filter((p) => num(p?.teamId, -1) === num(targetTeam?.id, -1));
+      const targetContext = getTeamContextSnapshot({
+        ...targetTeam,
+        roster: targetRoster,
+      }, { currentSeason });
+      const teamPosture = classifyTeamStrategicPosture({ ...targetTeam, roster: targetRoster }, { currentSeason });
+      ideas.push(...generatePackageVariants({ need, target, chipPool, picks: userPickChips, nonStarterIds, targetTeam, cap, strategicContext: { teamPosture, targetContext, currentSeason } }));
     }
   }
   const tradeIdeas = sortAndCapTradeIdeas(ideas, userTeamId);

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -1173,6 +1173,8 @@ function awardCompensatoryPicksForUpcomingDraft(metaObj = ensureCompMeta(cache.g
 
 function calcAssetBundleValue({ playerIds = [], pickIds = [] } = {}, context = {}) {
   const isDraftBoardMode = context?.marketMode === 'draft_board';
+  const teamPosture = context?.teamPosture ?? TEAM_STRATEGIC_POSTURE.NEUTRAL;
+  const currentSeason = Number(context?.currentSeason ?? 0) || null;
   const playerVal = playerIds.reduce((sum, pid) => {
     const player = cache.getPlayer(Number(pid));
     let value = _tradeValue(player, context);
@@ -1184,14 +1186,16 @@ function calcAssetBundleValue({ playerIds = [], pickIds = [] } = {}, context = {
       const expiringPenalty = yearsRemaining <= 1 ? 0.78 : 1.0;
       value *= veteranPenalty * lowPremiumPenalty * expiringPenalty;
     }
-    return sum + value;
+    const adjusted = applyStrategicValuationModifiers({ assetType: 'player', ...player }, value, teamPosture, { currentSeason });
+    return sum + adjusted;
   }, 0);
   const pickVal = pickIds.reduce((sum, pid) => {
     const pick = resolvePickById(pid);
     let value = getPickRoundValue(pick?.round, { week: context?.week ?? 1, teamDirection: context?.teamDirection ?? 'balanced', projectedRange: pick?.projectedRange ?? 'mid' });
     if (isDraftBoardMode) value *= 1.2;
     if (pick?.isCompensatory) value *= 0.84;
-    return sum + value;
+    const adjusted = applyStrategicValuationModifiers({ assetType: 'pick', ...pick }, value, teamPosture, { currentSeason });
+    return sum + adjusted;
   }, 0);
   return playerVal + pickVal;
 }
@@ -6865,11 +6869,15 @@ async function handleTradeOffer({ fromTeamId, toTeamId, offering, receiving }, i
     return actualAav > expectedAav * 1.28;
   });
   const lowPremiumIncoming = incomingPlayers.length > 0 && incomingPlayers.every((p) => LOW_PREMIUM_POSITIONS.has(p?.pos));
+  const aiRoster = cache.getPlayersByTeam(Number(toTeamId));
+  const aiPosture = classifyTeamStrategicPosture({ ...to, roster: aiRoster }, { currentSeason: meta?.year, phase: meta?.phase }, { minGamesForClassification: 7 });
   const valuationContext = {
     week,
     teamDirection: aiDirection,
     needPositions: aiNeeds.needs,
     marketMode: isDraftDay ? 'draft_board' : 'normal',
+    teamPosture: aiPosture,
+    currentSeason: meta?.year,
   };
   const offerVal    = calcAssetBundleValue(offering, valuationContext);
   const receiveVal  = calcAssetBundleValue(receiving, valuationContext);


### PR DESCRIPTION
### Motivation
- Trade valuation was unified but lacked team-context sensitivity, causing AI to use a mostly universal baseline instead of valuing assets differently by team goals. 
- Introduce a conservative, deterministic V1 strategic posture classifier to let AI favor picks/youth for rebuilders and starters/fit for contenders without changing final trade execution. 
- Default to `NEUTRAL` when data is incomplete or early-season samples are unreliable to avoid aggressive misclassification.

### Description
- Added a pure helper module `src/core/trades/teamStrategicDirection.js` that exports `TEAM_STRATEGIC_POSTURE`, `getTeamContextSnapshot`, `classifyTeamStrategicPosture`, `applyStrategicValuationModifiers`, and `applyStrategicPackageModifiers`. 
- Classification uses multi-signal, configurable thresholds (record win%, games played sample, roster average age, cap room) and returns one of `CONTENDER` / `REBUILDER` / `NEUTRAL` with safe defaults. 
- Applied posture-aware modifiers only to read-only scoring paths: `src/core/trades/tradeFinderAnalysis.js` (package idea scoring from the target-team perspective) and the worker acceptance valuation in `src/worker/worker.js` (`calcAssetBundleValue` + `handleTradeOffer` valuation context). 
- Added deterministic, non-mutating asset rules (rebuilder premium on picks/young upside, rebuilder discount on aging high-salary vets, contender premium on immediate starters and mild discount on far-future picks). 
- Added focused unit tests at `src/core/trades/__tests__/teamStrategicDirection.test.js` and preserved all ownership/transfer behavior and draft-pick integrity (no changes to finalization, `transferPickOwnership`, or `draftPickIntegrity.js`).

### Testing
- Ran unit tests for the new area with `npm run test:unit -- src/core/trades/__tests__/teamStrategicDirection.test.js src/core/trades/__tests__/tradeFinderAnalysis.test.ts` and they passed. 
- Ran the full unit suite with `npm run test:unit` and it completed successfully (all tests passed in this environment). 
- Built the production bundle with `npm run build` and the build succeeded (standard chunk-size warnings only). 
- Ran the dynasty soak subset with `npm run test:soak` and those soak tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1204853e94832db09faff92cb4d674)