### PR TITLE
feat: add AI positional-needs trade modifier (V1)

### DIFF
--- a/src/core/trades/__tests__/tradePositionalNeeds.test.js
+++ b/src/core/trades/__tests__/tradePositionalNeeds.test.js
@@ -1,0 +1,520 @@
+import { describe, expect, it } from 'vitest';
+import {
+  POSITION_NEED_LEVEL,
+  POSITIONAL_NEED_DEFAULTS,
+  POSITIONAL_NEED_MODIFIER_BOUNDS,
+  applyPositionalNeedModifiers,
+  buildTeamPositionDepthSnapshot,
+  calculateTeamDepthDeficiencies,
+  getNeedLevelForPlayer,
+} from '../tradePositionalNeeds.js';
+import { TEAM_STRATEGIC_POSTURE } from '../teamStrategicDirection.js';
+import { buildTradeFinderAnalysis } from '../tradeFinderAnalysis.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const p = (pos, ovr, age = 26, extras = {}) => ({
+  pos, ovr, age, potential: ovr + 2, ...extras,
+});
+
+/** A well-stocked roster covering all core positions with OVR ≥ 80 starters. */
+const fullStrongRoster = [
+  p('QB', 85), p('QB', 77),
+  p('RB', 82), p('RB', 76), p('RB', 72),
+  p('WR', 84), p('WR', 81), p('WR', 78), p('WR', 75), p('WR', 72),
+  p('TE', 80), p('TE', 74),
+  p('OL', 83), p('OL', 81), p('OL', 80), p('OL', 79), p('OL', 78), p('OL', 75),
+  p('DL', 84), p('DL', 82), p('DL', 80), p('DL', 78), p('DL', 76),
+  p('LB', 82), p('LB', 80), p('LB', 78), p('LB', 75),
+  p('CB', 84), p('CB', 82), p('CB', 80), p('CB', 76), p('CB', 74),
+  p('S',  82), p('S',  80), p('S',  76), p('S',  73),
+  p('K',  78), p('P',  72),
+];
+
+// ── POSITION_NEED_LEVEL ───────────────────────────────────────────────────────
+
+describe('POSITION_NEED_LEVEL enum', () => {
+  it('exports all four levels as strings', () => {
+    expect(POSITION_NEED_LEVEL.CRITICAL).toBe('CRITICAL');
+    expect(POSITION_NEED_LEVEL.MODERATE).toBe('MODERATE');
+    expect(POSITION_NEED_LEVEL.SECURE).toBe('SECURE');
+    expect(POSITION_NEED_LEVEL.UNKNOWN).toBe('UNKNOWN');
+  });
+
+  it('is frozen', () => {
+    expect(Object.isFrozen(POSITION_NEED_LEVEL)).toBe(true);
+  });
+});
+
+// ── buildTeamPositionDepthSnapshot ───────────────────────────────────────────
+
+describe('buildTeamPositionDepthSnapshot', () => {
+  it('returns a frozen map with a key for every position group', () => {
+    const snap = buildTeamPositionDepthSnapshot(fullStrongRoster);
+    expect(Object.isFrozen(snap)).toBe(true);
+    for (const pos of ['QB', 'RB', 'WR', 'TE', 'OL', 'DL', 'LB', 'CB', 'S', 'K', 'P']) {
+      expect(snap).toHaveProperty(pos);
+      expect(Object.isFrozen(snap[pos])).toBe(true);
+    }
+  });
+
+  it('each entry has the expected shape', () => {
+    const snap = buildTeamPositionDepthSnapshot(fullStrongRoster);
+    const qb = snap.QB;
+    expect(typeof qb.starterCount).toBe('number');
+    expect(typeof qb.playersCount).toBe('number');
+    expect(typeof qb.startersCount).toBe('number');
+    expect(typeof qb.depthCount).toBe('number');
+    expect(typeof qb.avgStarterOvr).toBe('number');
+    expect(typeof qb.bestStarterOvr).toBe('number');
+  });
+
+  it('counts starter and depth correctly for QB (1 starter expected)', () => {
+    const snap = buildTeamPositionDepthSnapshot(fullStrongRoster);
+    expect(snap.QB.starterCount).toBe(1);
+    expect(snap.QB.startersCount).toBe(1);
+    expect(snap.QB.bestStarterOvr).toBe(85);
+    expect(snap.QB.avgStarterOvr).toBe(85);
+    expect(snap.QB.depthCount).toBe(1); // second QB is depth
+  });
+
+  it('counts starter and depth correctly for WR (3 starters expected)', () => {
+    const snap = buildTeamPositionDepthSnapshot(fullStrongRoster);
+    expect(snap.WR.starterCount).toBe(3);
+    expect(snap.WR.startersCount).toBe(3);
+    expect(snap.WR.avgStarterOvr).toBeCloseTo((84 + 81 + 78) / 3, 1);
+    expect(snap.WR.depthCount).toBe(2);
+  });
+
+  it('reports 0 avgStarterOvr and 0 playersCount for empty position', () => {
+    const snap = buildTeamPositionDepthSnapshot([]);
+    expect(snap.QB.avgStarterOvr).toBe(0);
+    expect(snap.QB.playersCount).toBe(0);
+    expect(snap.QB.startersCount).toBe(0);
+  });
+
+  it('normalizes position variants before bucketing', () => {
+    const roster = [
+      { pos: 'DE', ovr: 82, age: 27 }, { pos: 'DT', ovr: 78, age: 25 },
+      { pos: 'NT', ovr: 76, age: 26 }, { pos: 'DE', ovr: 74, age: 28 },
+      { pos: 'OT', ovr: 80, age: 27 }, { pos: 'LG', ovr: 78, age: 26 },
+      { pos: 'RG', ovr: 77, age: 25 }, { pos: 'C',  ovr: 76, age: 28 },
+      { pos: 'LT', ovr: 79, age: 27 },
+    ];
+    const snap = buildTeamPositionDepthSnapshot(roster);
+    expect(snap.DL.playersCount).toBe(4);  // DE, DT, NT, DE
+    expect(snap.OL.playersCount).toBe(5);  // OT, LG, RG, C, LT
+  });
+
+  it('does not mutate the input roster array', () => {
+    const roster = [
+      { pos: 'QB', ovr: 82, age: 27 },
+      { pos: 'RB', ovr: 76, age: 24 },
+    ];
+    const before = JSON.stringify(roster);
+    buildTeamPositionDepthSnapshot(roster);
+    expect(JSON.stringify(roster)).toBe(before);
+  });
+
+  it('handles null/undefined/empty-object roster gracefully', () => {
+    expect(() => buildTeamPositionDepthSnapshot(null)).not.toThrow();
+    expect(() => buildTeamPositionDepthSnapshot(undefined)).not.toThrow();
+    expect(() => buildTeamPositionDepthSnapshot({})).not.toThrow();
+    const snap = buildTeamPositionDepthSnapshot(null);
+    expect(snap.QB.playersCount).toBe(0);
+  });
+});
+
+// ── calculateTeamDepthDeficiencies ───────────────────────────────────────────
+
+describe('calculateTeamDepthDeficiencies', () => {
+  it('returns a frozen map', () => {
+    const needs = calculateTeamDepthDeficiencies(fullStrongRoster);
+    expect(Object.isFrozen(needs)).toBe(true);
+  });
+
+  it('classifies well-stocked positions as SECURE', () => {
+    const needs = calculateTeamDepthDeficiencies(fullStrongRoster);
+    expect(needs.QB).toBe(POSITION_NEED_LEVEL.SECURE);
+    expect(needs.WR).toBe(POSITION_NEED_LEVEL.SECURE);
+    expect(needs.OL).toBe(POSITION_NEED_LEVEL.SECURE);
+    expect(needs.CB).toBe(POSITION_NEED_LEVEL.SECURE);
+  });
+
+  it('classifies empty positions as CRITICAL', () => {
+    const needs = calculateTeamDepthDeficiencies([]);
+    expect(needs.QB).toBe(POSITION_NEED_LEVEL.CRITICAL);
+    expect(needs.OL).toBe(POSITION_NEED_LEVEL.CRITICAL);
+    expect(needs.WR).toBe(POSITION_NEED_LEVEL.CRITICAL);
+  });
+
+  it('classifies missing starter slot as CRITICAL', () => {
+    // WR needs 3 starters; only 2 provided
+    const roster = [p('QB', 82), p('WR', 80), p('WR', 78)];
+    const needs = calculateTeamDepthDeficiencies(roster);
+    expect(needs.WR).toBe(POSITION_NEED_LEVEL.CRITICAL);
+  });
+
+  it('classifies weak starter (OVR < criticalOvrThreshold) as CRITICAL', () => {
+    const roster = [p('QB', 70)];  // 70 < 73
+    const needs = calculateTeamDepthDeficiencies(roster);
+    expect(needs.QB).toBe(POSITION_NEED_LEVEL.CRITICAL);
+  });
+
+  it('classifies moderate-quality starter (73–79) as MODERATE', () => {
+    const roster = [p('QB', 76)];  // 73 ≤ 76 < 80
+    const needs = calculateTeamDepthDeficiencies(roster);
+    expect(needs.QB).toBe(POSITION_NEED_LEVEL.MODERATE);
+  });
+
+  it('classifies starter OVR ≥ 80 as SECURE when starter slot is filled', () => {
+    const roster = [p('QB', 81)];
+    const needs = calculateTeamDepthDeficiencies(roster);
+    expect(needs.QB).toBe(POSITION_NEED_LEVEL.SECURE);
+  });
+
+  it('respects the OVR boundary exactly', () => {
+    const atCritBoundary    = calculateTeamDepthDeficiencies([p('QB', 72)]);
+    const aboveCritBoundary = calculateTeamDepthDeficiencies([p('QB', 73)]);
+    const atModBoundary     = calculateTeamDepthDeficiencies([p('QB', 79)]);
+    const aboveModBoundary  = calculateTeamDepthDeficiencies([p('QB', 80)]);
+    expect(atCritBoundary.QB).toBe(POSITION_NEED_LEVEL.CRITICAL);
+    expect(aboveCritBoundary.QB).toBe(POSITION_NEED_LEVEL.MODERATE);
+    expect(atModBoundary.QB).toBe(POSITION_NEED_LEVEL.MODERATE);
+    expect(aboveModBoundary.QB).toBe(POSITION_NEED_LEVEL.SECURE);
+  });
+
+  it('weak CB group (OVR < 73) is CRITICAL', () => {
+    const roster = [p('CB', 70), p('CB', 68), p('CB', 66)];
+    const needs = calculateTeamDepthDeficiencies(roster);
+    expect(needs.CB).toBe(POSITION_NEED_LEVEL.CRITICAL);
+  });
+
+  it('weak OL (avg < 73 across 5 expected starters) is CRITICAL', () => {
+    const roster = [
+      p('OL', 72), p('OL', 70), p('OL', 68), p('OL', 66), p('OL', 65),
+    ];
+    const needs = calculateTeamDepthDeficiencies(roster);
+    expect(needs.OL).toBe(POSITION_NEED_LEVEL.CRITICAL);
+  });
+
+  it('does not mutate the input roster', () => {
+    const roster = [{ pos: 'QB', ovr: 85, age: 26 }];
+    const before = JSON.stringify(roster);
+    calculateTeamDepthDeficiencies(roster);
+    expect(JSON.stringify(roster)).toBe(before);
+  });
+
+  it('handles null/undefined inputs without throwing', () => {
+    expect(() => calculateTeamDepthDeficiencies(null)).not.toThrow();
+    expect(() => calculateTeamDepthDeficiencies(undefined)).not.toThrow();
+  });
+});
+
+// ── getNeedLevelForPlayer ─────────────────────────────────────────────────────
+
+describe('getNeedLevelForPlayer', () => {
+  it('returns UNKNOWN when playerAsset is null or undefined', () => {
+    expect(getNeedLevelForPlayer(null, {})).toBe(POSITION_NEED_LEVEL.UNKNOWN);
+    expect(getNeedLevelForPlayer(undefined, {})).toBe(POSITION_NEED_LEVEL.UNKNOWN);
+  });
+
+  it('returns UNKNOWN when depthNeedsMap is null, undefined, or not an object', () => {
+    expect(getNeedLevelForPlayer({ pos: 'QB' }, null)).toBe(POSITION_NEED_LEVEL.UNKNOWN);
+    expect(getNeedLevelForPlayer({ pos: 'QB' }, undefined)).toBe(POSITION_NEED_LEVEL.UNKNOWN);
+  });
+
+  it('returns UNKNOWN when position is absent from the map', () => {
+    const map = { QB: POSITION_NEED_LEVEL.SECURE };
+    expect(getNeedLevelForPlayer({ pos: 'WR' }, map)).toBe(POSITION_NEED_LEVEL.UNKNOWN);
+  });
+
+  it('returns UNKNOWN when player has no pos field', () => {
+    const map = { QB: POSITION_NEED_LEVEL.CRITICAL };
+    expect(getNeedLevelForPlayer({}, map)).toBe(POSITION_NEED_LEVEL.UNKNOWN);
+    expect(getNeedLevelForPlayer({ pos: null }, map)).toBe(POSITION_NEED_LEVEL.UNKNOWN);
+  });
+
+  it('returns the correct need level when position is in the map', () => {
+    const map = {
+      QB: POSITION_NEED_LEVEL.CRITICAL,
+      WR: POSITION_NEED_LEVEL.MODERATE,
+      OL: POSITION_NEED_LEVEL.SECURE,
+    };
+    expect(getNeedLevelForPlayer({ pos: 'QB' }, map)).toBe(POSITION_NEED_LEVEL.CRITICAL);
+    expect(getNeedLevelForPlayer({ pos: 'WR' }, map)).toBe(POSITION_NEED_LEVEL.MODERATE);
+    expect(getNeedLevelForPlayer({ pos: 'OL' }, map)).toBe(POSITION_NEED_LEVEL.SECURE);
+  });
+
+  it('normalizes position variants before lookup', () => {
+    const map = { DL: POSITION_NEED_LEVEL.CRITICAL, OL: POSITION_NEED_LEVEL.SECURE };
+    expect(getNeedLevelForPlayer({ pos: 'DE' }, map)).toBe(POSITION_NEED_LEVEL.CRITICAL);
+    expect(getNeedLevelForPlayer({ pos: 'DT' }, map)).toBe(POSITION_NEED_LEVEL.CRITICAL);
+    expect(getNeedLevelForPlayer({ pos: 'NT' }, map)).toBe(POSITION_NEED_LEVEL.CRITICAL);
+    expect(getNeedLevelForPlayer({ pos: 'OT' }, map)).toBe(POSITION_NEED_LEVEL.SECURE);
+    expect(getNeedLevelForPlayer({ pos: 'LT' }, map)).toBe(POSITION_NEED_LEVEL.SECURE);
+    expect(getNeedLevelForPlayer({ pos: 'ILB' }, { LB: POSITION_NEED_LEVEL.MODERATE })).toBe(POSITION_NEED_LEVEL.MODERATE);
+  });
+});
+
+// ── applyPositionalNeedModifiers ──────────────────────────────────────────────
+
+describe('applyPositionalNeedModifiers', () => {
+  const { MAX_PREMIUM, MIN_MODIFIER } = POSITIONAL_NEED_MODIFIER_BOUNDS;
+
+  it('returns base value unchanged (1.00×) when need level is UNKNOWN', () => {
+    // No pos in map → UNKNOWN
+    expect(applyPositionalNeedModifiers({ pos: 'QB', ovr: 80 }, 200, {})).toBe(200);
+    // Null map → UNKNOWN
+    expect(applyPositionalNeedModifiers({ pos: 'QB', ovr: 80 }, 200, null)).toBe(200);
+  });
+
+  it('returns 0 for zero, null, or negative base values', () => {
+    const map = { QB: POSITION_NEED_LEVEL.CRITICAL };
+    expect(applyPositionalNeedModifiers({ pos: 'QB' }, 0,   map)).toBe(0);
+    expect(applyPositionalNeedModifiers({ pos: 'QB' }, null, map)).toBe(0);
+    expect(applyPositionalNeedModifiers({ pos: 'QB' }, -50, map)).toBe(0);
+  });
+
+  it('CRITICAL need applies a premium (result > base)', () => {
+    const map = { QB: POSITION_NEED_LEVEL.CRITICAL };
+    const result = applyPositionalNeedModifiers({ pos: 'QB', ovr: 78 }, 200, map);
+    expect(result).toBeGreaterThan(200);
+  });
+
+  it('MODERATE need applies a smaller premium than CRITICAL', () => {
+    const critMap = { QB: POSITION_NEED_LEVEL.CRITICAL };
+    const modMap  = { QB: POSITION_NEED_LEVEL.MODERATE };
+    const player  = { pos: 'QB', ovr: 76 };
+    const critVal = applyPositionalNeedModifiers(player, 200, critMap);
+    const modVal  = applyPositionalNeedModifiers(player, 200, modMap);
+    expect(critVal).toBeGreaterThan(modVal);
+    expect(modVal).toBeGreaterThan(200);
+  });
+
+  it('SECURE need applies a mild discount for ordinary players', () => {
+    const map    = { WR: POSITION_NEED_LEVEL.SECURE };
+    const player = { pos: 'WR', ovr: 74, age: 29, potential: 74 };
+    const result = applyPositionalNeedModifiers(player, 200, map);
+    expect(result).toBeLessThan(200);
+  });
+
+  it('critical need multiplier is strictly greater than secure multiplier (same player)', () => {
+    const critMap = { CB: POSITION_NEED_LEVEL.CRITICAL };
+    const secMap  = { CB: POSITION_NEED_LEVEL.SECURE };
+    const player  = { pos: 'CB', ovr: 75, age: 27 };
+    expect(applyPositionalNeedModifiers(player, 200, critMap))
+      .toBeGreaterThan(applyPositionalNeedModifiers(player, 200, secMap));
+  });
+
+  it('modifier never exceeds MAX_PREMIUM ceiling', () => {
+    const critMap = { QB: POSITION_NEED_LEVEL.CRITICAL };
+    const player  = { pos: 'QB', ovr: 80 };
+    const result  = applyPositionalNeedModifiers(player, 200, critMap, TEAM_STRATEGIC_POSTURE.CONTENDER);
+    expect(result).toBeLessThanOrEqual(Math.round(200 * MAX_PREMIUM));
+  });
+
+  it('modifier never goes below MIN_MODIFIER floor', () => {
+    const secMap = { QB: POSITION_NEED_LEVEL.SECURE };
+    const player = { pos: 'QB', ovr: 60, age: 32, potential: 60 };
+    const result = applyPositionalNeedModifiers(player, 200, secMap, TEAM_STRATEGIC_POSTURE.NEUTRAL);
+    expect(result).toBeGreaterThanOrEqual(Math.round(200 * MIN_MODIFIER));
+  });
+
+  // ── Elite player guard ─────────────────────────────────────────────────────
+
+  it('elite player (OVR ≥ eliteOvrFloor) receives no discount at SECURE positions', () => {
+    const { eliteOvrFloor } = POSITIONAL_NEED_DEFAULTS;
+    const secMap  = { WR: POSITION_NEED_LEVEL.SECURE };
+    const elite   = { pos: 'WR', ovr: eliteOvrFloor, age: 28, potential: eliteOvrFloor };
+    const result  = applyPositionalNeedModifiers(elite, 300, secMap);
+    expect(result).toBeGreaterThanOrEqual(300);
+  });
+
+  it('elite player at SECURE position for a rebuilder is also not discounted', () => {
+    const secMap = { QB: POSITION_NEED_LEVEL.SECURE };
+    const elite  = { pos: 'QB', ovr: 84, age: 30, potential: 84 };
+    const result = applyPositionalNeedModifiers(elite, 300, secMap, TEAM_STRATEGIC_POSTURE.REBUILDER);
+    expect(result).toBeGreaterThanOrEqual(300);
+  });
+
+  // ── Rebuilder posture ─────────────────────────────────────────────────────
+
+  it('rebuilder: young high-upside player at SECURE position receives no discount (1.00×)', () => {
+    const secMap     = { WR: POSITION_NEED_LEVEL.SECURE };
+    const youngUpside = { pos: 'WR', ovr: 72, age: 22, potential: 84 };  // pot − ovr = 12
+    const result     = applyPositionalNeedModifiers(youngUpside, 200, secMap, TEAM_STRATEGIC_POSTURE.REBUILDER);
+    expect(result).toBe(200);  // exactly 1.00× — discount removed
+  });
+
+  it('rebuilder: non-upside veteran at SECURE position still gets mild discount', () => {
+    const secMap = { WR: POSITION_NEED_LEVEL.SECURE };
+    const vet    = { pos: 'WR', ovr: 76, age: 32, potential: 76 };  // pot − ovr = 0
+    const result = applyPositionalNeedModifiers(vet, 200, secMap, TEAM_STRATEGIC_POSTURE.REBUILDER);
+    expect(result).toBeLessThan(200);
+  });
+
+  it('rebuilder: young upside discount guard is not triggered without sufficient potential delta', () => {
+    const secMap        = { WR: POSITION_NEED_LEVEL.SECURE };
+    const youngLowUpside = { pos: 'WR', ovr: 72, age: 22, potential: 73 };  // pot − ovr = 1 < 4
+    const result        = applyPositionalNeedModifiers(youngLowUpside, 200, secMap, TEAM_STRATEGIC_POSTURE.REBUILDER);
+    expect(result).toBeLessThan(200);  // discount still applies
+  });
+
+  // ── Contender posture ─────────────────────────────────────────────────────
+
+  it('contender: CRITICAL need premium is higher than NEUTRAL baseline', () => {
+    const critMap = { QB: POSITION_NEED_LEVEL.CRITICAL };
+    const player  = { pos: 'QB', ovr: 78 };
+    const neutral  = applyPositionalNeedModifiers(player, 200, critMap, TEAM_STRATEGIC_POSTURE.NEUTRAL);
+    const contender = applyPositionalNeedModifiers(player, 200, critMap, TEAM_STRATEGIC_POSTURE.CONTENDER);
+    expect(contender).toBeGreaterThan(neutral);
+  });
+
+  it('contender: MODERATE need premium is higher than NEUTRAL baseline', () => {
+    const modMap  = { CB: POSITION_NEED_LEVEL.MODERATE };
+    const player  = { pos: 'CB', ovr: 77 };
+    const neutral  = applyPositionalNeedModifiers(player, 250, modMap, TEAM_STRATEGIC_POSTURE.NEUTRAL);
+    const contender = applyPositionalNeedModifiers(player, 250, modMap, TEAM_STRATEGIC_POSTURE.CONTENDER);
+    expect(contender).toBeGreaterThan(neutral);
+  });
+
+  it('contender: SECURE position discount is unchanged from NEUTRAL (no additional boost)', () => {
+    const secMap  = { RB: POSITION_NEED_LEVEL.SECURE };
+    const player  = { pos: 'RB', ovr: 75, age: 28, potential: 75 };
+    const neutral  = applyPositionalNeedModifiers(player, 200, secMap, TEAM_STRATEGIC_POSTURE.NEUTRAL);
+    const contender = applyPositionalNeedModifiers(player, 200, secMap, TEAM_STRATEGIC_POSTURE.CONTENDER);
+    expect(contender).toBe(neutral);  // contender posture adds no SECURE-position adjustment
+  });
+
+  // ── No mutation ───────────────────────────────────────────────────────────
+
+  it('does not mutate the player asset object', () => {
+    const map    = { QB: POSITION_NEED_LEVEL.CRITICAL };
+    const player = { pos: 'QB', ovr: 80, age: 26, potential: 84 };
+    const before = JSON.stringify(player);
+    applyPositionalNeedModifiers(player, 200, map);
+    expect(JSON.stringify(player)).toBe(before);
+  });
+
+  it('does not mutate the depth needs map', () => {
+    const map    = { QB: POSITION_NEED_LEVEL.CRITICAL };
+    const before = JSON.stringify(map);
+    applyPositionalNeedModifiers({ pos: 'QB', ovr: 80 }, 200, map);
+    expect(JSON.stringify(map)).toBe(before);
+  });
+
+  // ── Edge cases / safety ───────────────────────────────────────────────────
+
+  it('unknown data does not crash and returns base (1.00×)', () => {
+    expect(() => applyPositionalNeedModifiers({},     200, {})).not.toThrow();
+    expect(() => applyPositionalNeedModifiers(null,   200, {})).not.toThrow();
+    expect(() => applyPositionalNeedModifiers(undefined, 200, {})).not.toThrow();
+    expect(applyPositionalNeedModifiers({},     200, {})).toBe(200);
+    expect(applyPositionalNeedModifiers(null,   200, {})).toBe(200);
+  });
+
+  it('returns a rounded integer result', () => {
+    const map    = { QB: POSITION_NEED_LEVEL.CRITICAL };
+    const result = applyPositionalNeedModifiers({ pos: 'QB', ovr: 78 }, 197, map);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+});
+
+// ── calculateTeamDepthDeficiencies + applyPositionalNeedModifiers round-trip ──
+
+describe('need classification → modifier round-trip', () => {
+  it('player filling a CRITICAL need always receives a higher modifier than SECURE', () => {
+    const critRoster = [];   // no players → every position CRITICAL
+    const secRoster  = fullStrongRoster;
+
+    const critNeeds = calculateTeamDepthDeficiencies(critRoster);
+    const secNeeds  = calculateTeamDepthDeficiencies(secRoster);
+
+    const player = { pos: 'QB', ovr: 78, age: 26 };
+    const critVal = applyPositionalNeedModifiers(player, 200, critNeeds);
+    const secVal  = applyPositionalNeedModifiers(player, 200, secNeeds);
+
+    expect(critVal).toBeGreaterThan(secVal);
+  });
+
+  it('a well-stocked position returns SECURE and applies at most a mild discount', () => {
+    const needs  = calculateTeamDepthDeficiencies(fullStrongRoster);
+    expect(needs.QB).toBe(POSITION_NEED_LEVEL.SECURE);
+
+    const player = { pos: 'QB', ovr: 76, age: 28, potential: 76 };
+    const result = applyPositionalNeedModifiers(player, 200, needs);
+    // Discount must be mild (above MIN_MODIFIER) and not zero-out the value
+    expect(result).toBeGreaterThan(Math.round(200 * POSITIONAL_NEED_MODIFIER_BOUNDS.MIN_MODIFIER));
+    expect(result).toBeLessThanOrEqual(200);
+  });
+});
+
+// ── Integration: tradeFinderAnalysis wiring ──────────────────────────────────
+
+describe('tradePositionalNeeds integration (receiving-team perspective)', () => {
+  const mkP = (id, teamId, pos, ovr, extras = {}) => ({
+    id, teamId, pos, ovr, potential: ovr + 2, age: 26, name: `P${id}`,
+    contract: { baseAnnual: 6, yearsRemaining: 2 }, ...extras,
+  });
+
+  const makeBase = () => {
+    const userRoster = [
+      mkP(1,  1, 'QB', 82), mkP(2,  1, 'RB', 80), mkP(3,  1, 'RB', 75),
+      mkP(4,  1, 'WR', 70), mkP(5,  1, 'WR', 68), mkP(6,  1, 'TE', 74),
+      ...Array.from({ length: 5 }, (_, i) => mkP(10 + i, 1, 'OL', 75 - i)),
+      ...Array.from({ length: 4 }, (_, i) => mkP(20 + i, 1, 'DL', 74 - i)),
+      ...Array.from({ length: 3 }, (_, i) => mkP(30 + i, 1, 'LB', 73 - i)),
+      ...Array.from({ length: 3 }, (_, i) => mkP(40 + i, 1, 'CB', 73 - i)),
+      mkP(50, 1, 'S', 74), mkP(51, 1, 'S', 73),
+      mkP(60, 1, 'K', 70), mkP(61, 1, 'P', 70),
+    ];
+    const teams = [{ id: 1, abbr: 'USR' }, { id: 2, abbr: 'AI1' }, { id: 3, abbr: 'AI2' }];
+    const leaguePlayers = [
+      ...userRoster,
+      mkP(101, 2, 'WR', 89, { potential: 92, age: 23, contract: { baseAnnual: 12, yearsRemaining: 3 } }),
+      mkP(102, 2, 'WR', 84),
+      mkP(103, 3, 'WR', 79, { age: 32, contract: { baseAnnual: 18, yearsRemaining: 2 } }),
+    ];
+    return { userTeam: { id: 1 }, teams, userRoster, leaguePlayers, league: { year: 2027 }, cap: { capRoom: 5 } };
+  };
+
+  it('trade ideas are still generated after positional need wiring', () => {
+    const out = buildTradeFinderAnalysis(makeBase());
+    expect(out.tradeIdeas.length).toBeGreaterThan(0);
+  });
+
+  it('trade ideas remain sorted by fitScore (ordering invariant holds)', () => {
+    const out = buildTradeFinderAnalysis(makeBase());
+    expect(out.tradeIdeas.every((v, idx, arr) => idx === 0 || arr[idx - 1].fitScore >= v.fitScore)).toBe(true);
+  });
+
+  it('output shape is stable — all required fields present on every idea', () => {
+    const out = buildTradeFinderAnalysis(makeBase());
+    expect(Array.isArray(out.tradeIdeas)).toBe(true);
+    for (const idea of out.tradeIdeas) {
+      expect(Array.isArray(idea.confidenceReasons)).toBe(true);
+      expect(Array.isArray(idea.warnings)).toBe(true);
+      expect(Array.isArray(idea.outgoingAssets)).toBe(true);
+      expect(typeof idea.fitScore).toBe('number');
+      expect(typeof idea.valueDelta).toBe('number');
+    }
+  });
+
+  it('ideas list is capped at 15', () => {
+    const out = buildTradeFinderAnalysis(makeBase());
+    expect(out.tradeIdeas.length).toBeLessThanOrEqual(15);
+  });
+
+  it('all ideas target non-user teams', () => {
+    const out = buildTradeFinderAnalysis(makeBase());
+    expect(out.tradeIdeas.every((i) => Number(i.targetTeamId) !== 1)).toBe(true);
+  });
+
+  it('empty input does not throw and returns stable shape', () => {
+    expect(() => buildTradeFinderAnalysis({ userTeam: { id: 1 } })).not.toThrow();
+    const out = buildTradeFinderAnalysis({ userTeam: { id: 1 } });
+    expect(Array.isArray(out.tradeIdeas)).toBe(true);
+    expect(out.tradeIdeas.length).toBe(0);
+  });
+});

--- a/src/core/trades/tradeFinderAnalysis.js
+++ b/src/core/trades/tradeFinderAnalysis.js
@@ -12,6 +12,10 @@ import {
   classifyTeamStrategicPosture,
   getTeamContextSnapshot,
 } from './teamStrategicDirection.js';
+import {
+  applyPositionalNeedModifiers,
+  calculateTeamDepthDeficiencies,
+} from './tradePositionalNeeds.js';
 
 const PICK_VALUE_SCALING = 0.184;
 
@@ -214,7 +218,16 @@ function buildIdea({ need, target, outgoingAssets, targetTeam, cap, packageType,
   const currentSeason = strategicContext?.currentSeason ?? null;
   const targetBaseValue = getPlayerValueSafe(target);
   const targetValue = applyStrategicValuationModifiers({ assetType: 'player', ...target }, targetBaseValue, teamPosture, { currentSeason });
-  const outgoingStrategicValues = outgoingAssets.map((a) => applyStrategicValuationModifiers(a, num(a.valueScore), teamPosture, { currentSeason }));
+  const targetDepthNeeds = strategicContext?.targetDepthNeeds ?? null;
+  const outgoingStrategicValues = outgoingAssets.map((a) => {
+    const strategicValue = applyStrategicValuationModifiers(a, num(a.valueScore), teamPosture, { currentSeason });
+    // Apply positional need modifiers from the receiving (target) team's perspective.
+    // Only for player assets and only when the target team's depth needs are available.
+    if (a.assetType === 'player' && targetDepthNeeds != null) {
+      return applyPositionalNeedModifiers(a, strategicValue, targetDepthNeeds, teamPosture);
+    }
+    return strategicValue;
+  });
   const outgoingValue = evaluateMultiAssetPackageValue(outgoingStrategicValues);
   const valueDelta = Math.round(targetValue - outgoingValue);
   const valueMatch = classifyValueMatch(valueDelta);
@@ -292,7 +305,10 @@ export function buildTradeFinderAnalysis({ userTeam, league = {}, teams = [], us
         roster: targetRoster,
       }, { currentSeason });
       const teamPosture = classifyTeamStrategicPosture({ ...targetTeam, roster: targetRoster }, { currentSeason });
-      ideas.push(...generatePackageVariants({ need, target, chipPool, picks: userPickChips, nonStarterIds, targetTeam, cap, strategicContext: { teamPosture, targetContext, currentSeason } }));
+      // Build the target team's positional depth needs so buildIdea can apply
+      // need-based modifiers from the receiving (target) team's perspective.
+      const targetDepthNeeds = calculateTeamDepthDeficiencies(targetRoster, footballConfig);
+      ideas.push(...generatePackageVariants({ need, target, chipPool, picks: userPickChips, nonStarterIds, targetTeam, cap, strategicContext: { teamPosture, targetContext, currentSeason, targetDepthNeeds } }));
     }
   }
   const tradeIdeas = sortAndCapTradeIdeas(ideas, userTeamId);

--- a/src/core/trades/tradePositionalNeeds.js
+++ b/src/core/trades/tradePositionalNeeds.js
@@ -1,0 +1,313 @@
+/**
+ * tradePositionalNeeds.js
+ *
+ * Pure positional-needs module for AI trade valuation scoring.
+ * Analyzes a receiving team's roster depth quality and applies conservative
+ * need-based multipliers to incoming player trade valuation.
+ *
+ * Architecture:
+ *  - Pure/stateless — no I/O, no cache access, no mutations.
+ *  - Conservative multipliers intentionally kept small in V1.
+ *  - Missing or incomplete data defaults safely to UNKNOWN / 1.00×.
+ *  - Applied only to read-only scoring paths, never to finalization.
+ *  - Perspective: all analysis is from the RECEIVING team's point of view.
+ *
+ * V1 integration scope:
+ *  - tradeFinderAnalysis.js: outgoing asset valuation from target-team perspective.
+ *
+ * Deferred (not implemented here):
+ *  - AI-to-AI acceptance path (trade-logic.js runAIToAITrades).
+ *  - Injury-driven temporary needs (injury data reliability unverified).
+ *  - Scheme-specific positional weighting.
+ *  - Multi-season succession planning.
+ *  - Worker offer scoring path (requires safe perspective identification).
+ */
+
+import { FOOTBALL_ROSTER_CONFIG } from '../sports/footballRosterConfig.js';
+import { TEAM_STRATEGIC_POSTURE } from './teamStrategicDirection.js';
+
+// ── Need Level Enum ────────────────────────────────────────────────────────────
+
+export const POSITION_NEED_LEVEL = Object.freeze({
+  /** Team lacks starter-level quality or has a missing starter slot. */
+  CRITICAL: 'CRITICAL',
+  /** Starter is acceptable but quality is below strong threshold, or aging starter with no depth. */
+  MODERATE: 'MODERATE',
+  /** Team has strong starter-level quality at this position. */
+  SECURE: 'SECURE',
+  /** Insufficient data to classify — callers must treat as 1.00×. */
+  UNKNOWN: 'UNKNOWN',
+});
+
+// ── Classification Thresholds & Defaults ──────────────────────────────────────
+
+export const POSITIONAL_NEED_DEFAULTS = Object.freeze({
+  /** avgStarterOvr below this → CRITICAL. Aligned with trade-logic STARTER_NEED_THRESHOLD − 2. */
+  criticalOvrThreshold: 73,
+  /** avgStarterOvr below this (and ≥ critical) → MODERATE. */
+  moderateOvrThreshold: 80,
+  /** OVR at or above this prevents SECURE discounts; elite players are never penalised. */
+  eliteOvrFloor: 82,
+  /** Max age considered "young" for rebuilder upside protection. */
+  youngPlayerAgeMax: 24,
+  /** Minimum (potential − ovr) to qualify a player as "upside". */
+  upsideDeltaMin: 4,
+});
+
+// ── Need Multipliers ──────────────────────────────────────────────────────────
+
+/**
+ * Base per-need-level multipliers applied to incoming player values.
+ * Intentionally conservative — V1 guardrails.
+ */
+const NEED_MULTIPLIERS = Object.freeze({
+  [POSITION_NEED_LEVEL.CRITICAL]: 1.18,
+  [POSITION_NEED_LEVEL.MODERATE]: 1.08,
+  [POSITION_NEED_LEVEL.SECURE]:   0.95,
+  [POSITION_NEED_LEVEL.UNKNOWN]:  1.00,
+});
+
+/** Hard bounds — no single positional modifier exceeds these in any path. */
+export const POSITIONAL_NEED_MODIFIER_BOUNDS = Object.freeze({
+  MAX_PREMIUM:  1.25,
+  MIN_MODIFIER: 0.82,
+});
+
+// ── Internal Utilities ────────────────────────────────────────────────────────
+
+const _num = (v, fb = null) => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fb;
+};
+
+/**
+ * Map position string variants to FOOTBALL_ROSTER_CONFIG.positionGroups keys.
+ * Handles common positional aliases used in player objects (OT→OL, DE/DT→DL, etc.).
+ * Returns the input unchanged when no variant mapping applies.
+ *
+ * @param {string|null|undefined} pos
+ * @returns {string}
+ */
+function normalizePositionForNeeds(pos) {
+  const p = String(pos ?? '').toUpperCase();
+  if (['OT', 'LT', 'RT', 'OG', 'LG', 'RG', 'C'].includes(p))      return 'OL';
+  if (['DE', 'DT', 'NT', 'EDGE', 'IDL'].includes(p))               return 'DL';
+  if (['DB', 'NCB'].includes(p))                                     return 'CB';
+  if (['ILB', 'OLB', 'MLB'].includes(p))                            return 'LB';
+  if (['HB', 'FB'].includes(p))                                      return 'RB';
+  if (['SS', 'FS'].includes(p))                                      return 'S';
+  if (['FL', 'SE'].includes(p))                                      return 'WR';
+  if (['PK'].includes(p))                                            return 'K';
+  return p;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Build a per-position depth snapshot for a team's roster.
+ *
+ * Returns a frozen map: { [pos]: PositionDepthData }
+ * Each entry describes the starter/depth split and average quality.
+ *
+ * Does NOT mutate the input roster or options.
+ *
+ * @param {object[]} roster  – array of player objects; each needs `pos` and `ovr`.
+ * @param {object}   cfg     – roster config; defaults to FOOTBALL_ROSTER_CONFIG.
+ * @param {object}   options – optional overrides (unused in V1, reserved).
+ * @returns {Readonly<Record<string, Readonly<object>>>}
+ */
+export function buildTeamPositionDepthSnapshot(roster = [], cfg = FOOTBALL_ROSTER_CONFIG, options = {}) {
+  const players = Array.isArray(roster) ? roster : [];
+  const positionGroups = (cfg?.positionGroups ?? FOOTBALL_ROSTER_CONFIG.positionGroups) ?? [];
+  const groupConfig    = cfg?.groupConfig ?? FOOTBALL_ROSTER_CONFIG.groupConfig ?? {};
+
+  const snapshot = {};
+
+  for (const pos of positionGroups) {
+    const expectedStarters = _num(groupConfig[pos]?.starterCountExpected, 1) ?? 1;
+
+    // Extract only ovr/age — avoids holding references into the original array.
+    const playersAtPos = players
+      .filter((p) => p != null && normalizePositionForNeeds(p?.pos) === pos)
+      .map((p) => ({ ovr: _num(p?.ovr, 0), age: _num(p?.age, null) }));
+
+    // Sort copy descending by OVR — does not mutate the original array.
+    playersAtPos.sort((a, b) => b.ovr - a.ovr);
+
+    const starters    = playersAtPos.slice(0, expectedStarters);
+    const depth       = playersAtPos.slice(expectedStarters);
+    const avgStarterOvr = starters.length
+      ? starters.reduce((sum, p) => sum + p.ovr, 0) / starters.length
+      : 0;
+
+    snapshot[pos] = Object.freeze({
+      pos,
+      starterCount:   expectedStarters,
+      playersCount:   playersAtPos.length,
+      startersCount:  starters.length,
+      depthCount:     depth.length,
+      avgStarterOvr,
+      bestStarterOvr: starters.length > 0 ? starters[0].ovr : 0,
+      bestStarterAge: starters.length > 0 ? starters[0].age : null,
+    });
+  }
+
+  return Object.freeze(snapshot);
+}
+
+/**
+ * Classify each position group into a POSITION_NEED_LEVEL using a roster snapshot.
+ *
+ * Classification logic (conservative):
+ *  - CRITICAL: no players, missing starter slot(s), or avgStarterOvr < criticalOvrThreshold.
+ *  - MODERATE: avgStarterOvr in [criticalOvrThreshold, moderateOvrThreshold).
+ *  - SECURE:   avgStarterOvr ≥ moderateOvrThreshold with all starter slots filled.
+ *
+ * Returns a frozen map: { [pos]: POSITION_NEED_LEVEL }.
+ * Missing position data defaults to UNKNOWN.
+ *
+ * Does NOT mutate inputs.
+ *
+ * @param {object[]} roster        – array of player objects.
+ * @param {object}   cfg           – roster config; defaults to FOOTBALL_ROSTER_CONFIG.
+ * @param {object}   leagueContext – reserved for future league-average integration.
+ * @param {object}   options       – optional threshold overrides.
+ * @returns {Readonly<Record<string, string>>}
+ */
+export function calculateTeamDepthDeficiencies(
+  roster = [],
+  cfg = FOOTBALL_ROSTER_CONFIG,
+  leagueContext = {},
+  options = {},
+) {
+  const resolvedCfg = options?.cfg ?? cfg ?? FOOTBALL_ROSTER_CONFIG;
+  const snapshot    = buildTeamPositionDepthSnapshot(roster, resolvedCfg, options);
+  const thresholds  = { ...POSITIONAL_NEED_DEFAULTS, ...options };
+  const deficiencies = {};
+
+  for (const [pos, posData] of Object.entries(snapshot)) {
+    if (!posData) {
+      deficiencies[pos] = POSITION_NEED_LEVEL.UNKNOWN;
+      continue;
+    }
+
+    const missingStarters = Math.max(0, posData.starterCount - posData.startersCount);
+
+    if (
+      posData.playersCount === 0 ||
+      missingStarters > 0 ||
+      posData.avgStarterOvr < thresholds.criticalOvrThreshold
+    ) {
+      deficiencies[pos] = POSITION_NEED_LEVEL.CRITICAL;
+    } else if (posData.avgStarterOvr < thresholds.moderateOvrThreshold) {
+      deficiencies[pos] = POSITION_NEED_LEVEL.MODERATE;
+    } else {
+      deficiencies[pos] = POSITION_NEED_LEVEL.SECURE;
+    }
+  }
+
+  return Object.freeze(deficiencies);
+}
+
+/**
+ * Look up the receiving team's need level for a specific player asset.
+ *
+ * Returns UNKNOWN when:
+ *  - playerAsset is null/undefined.
+ *  - depthNeedsMap is null/not an object.
+ *  - Player position is not found in the needs map.
+ *  - Position cannot be normalized.
+ *
+ * @param {object} playerAsset   – player object with `pos` field.
+ * @param {object} depthNeedsMap – map returned by calculateTeamDepthDeficiencies.
+ * @param {object} options       – reserved.
+ * @returns {string} POSITION_NEED_LEVEL value
+ */
+export function getNeedLevelForPlayer(playerAsset = {}, depthNeedsMap = {}, options = {}) {
+  if (playerAsset == null || depthNeedsMap == null || typeof depthNeedsMap !== 'object') {
+    return POSITION_NEED_LEVEL.UNKNOWN;
+  }
+
+  const pos = normalizePositionForNeeds(playerAsset?.pos);
+  if (!pos) return POSITION_NEED_LEVEL.UNKNOWN;
+
+  const level = depthNeedsMap[pos];
+  return Object.values(POSITION_NEED_LEVEL).includes(level) ? level : POSITION_NEED_LEVEL.UNKNOWN;
+}
+
+/**
+ * Apply a conservative positional need multiplier to a player asset's base value.
+ *
+ * Called from receiving-team scoring paths only. Perspective must be the team
+ * that would receive this player, using that team's depthNeedsMap.
+ *
+ * Key guardrails:
+ *  - UNKNOWN need → returns baseValue unchanged (1.00×).
+ *  - Elite players (OVR ≥ eliteOvrFloor) are never discounted at SECURE positions.
+ *  - Rebuilders protect young/upside players from the SECURE discount.
+ *  - Contenders receive a small additional bonus on CRITICAL and MODERATE premiums.
+ *  - No modifier ever exceeds MAX_PREMIUM (1.25×) or falls below MIN_MODIFIER (0.82×).
+ *
+ * Does NOT mutate inputs.
+ *
+ * @param {object} playerAsset   – player object with pos, ovr, age, potential/pot fields.
+ * @param {number} baseValue     – pre-modifier player value score.
+ * @param {object} depthNeedsMap – receiving team's needs map from calculateTeamDepthDeficiencies.
+ * @param {string} teamPosture   – TEAM_STRATEGIC_POSTURE of the receiving team.
+ * @param {object} options       – optional threshold overrides.
+ * @returns {number} adjusted value, rounded to nearest integer.
+ */
+export function applyPositionalNeedModifiers(
+  playerAsset  = {},
+  baseValue    = 0,
+  depthNeedsMap = {},
+  teamPosture  = TEAM_STRATEGIC_POSTURE.NEUTRAL,
+  options      = {},
+) {
+  const base = _num(baseValue, null);
+  if (base == null || !Number.isFinite(base) || base <= 0) {
+    return Math.max(0, _num(baseValue, 0));
+  }
+
+  const needLevel = getNeedLevelForPlayer(playerAsset, depthNeedsMap, options);
+  // Unknown data → neutral — must not modify the value.
+  if (needLevel === POSITION_NEED_LEVEL.UNKNOWN) return base;
+
+  const ovr = _num(playerAsset?.ovr, 70);
+  const age = _num(playerAsset?.age, 27);
+  const pot = _num(playerAsset?.potential ?? playerAsset?.pot, ovr);
+  const cfg = { ...POSITIONAL_NEED_DEFAULTS, ...options };
+  const { MAX_PREMIUM, MIN_MODIFIER } = POSITIONAL_NEED_MODIFIER_BOUNDS;
+
+  const isElite      = ovr >= cfg.eliteOvrFloor;
+  const isYoungUpside = age <= cfg.youngPlayerAgeMax && (pot - ovr) >= cfg.upsideDeltaMin;
+
+  let multiplier = NEED_MULTIPLIERS[needLevel] ?? 1.00;
+
+  // Contenders care more about immediate roster holes.
+  if (teamPosture === TEAM_STRATEGIC_POSTURE.CONTENDER) {
+    if (needLevel === POSITION_NEED_LEVEL.CRITICAL) {
+      multiplier = Math.min(multiplier * 1.04, MAX_PREMIUM);
+    } else if (needLevel === POSITION_NEED_LEVEL.MODERATE) {
+      multiplier = Math.min(multiplier * 1.02, MAX_PREMIUM);
+    }
+  }
+
+  // Rebuilders care more about youth/upside than positional saturation.
+  // Protect young/upside player values from the SECURE discount.
+  if (teamPosture === TEAM_STRATEGIC_POSTURE.REBUILDER) {
+    if (needLevel === POSITION_NEED_LEVEL.SECURE && isYoungUpside) {
+      multiplier = 1.00; // no discount — young upside is valuable regardless of depth
+    }
+  }
+
+  // Elite players are never penalised simply because a position is well-stocked.
+  if (needLevel === POSITION_NEED_LEVEL.SECURE && isElite) {
+    multiplier = Math.max(multiplier, 1.00);
+  }
+
+  // Hard conservative bounds — V1 safety rails.
+  multiplier = Math.max(MIN_MODIFIER, Math.min(MAX_PREMIUM, multiplier));
+
+  return Math.round(base * multiplier);
+}


### PR DESCRIPTION
Adds a pure, stateless tradePositionalNeeds module that classifies
receiving-team roster depth quality and applies conservative need-based
multipliers to incoming player trade valuation in the trade-finder
scoring path.

Architecture
- POSITION_NEED_LEVEL enum: CRITICAL / MODERATE / SECURE / UNKNOWN
- buildTeamPositionDepthSnapshot: per-position OVR/depth stats from roster
- calculateTeamDepthDeficiencies: classifies each position group by need level
  (CRITICAL < 73 avgStarterOvr or missing starters, MODERATE 73–79, SECURE ≥ 80)
- getNeedLevelForPlayer: looks up need level for an incoming player asset
- applyPositionalNeedModifiers: applies multiplier (CRITICAL 1.18×,
  MODERATE 1.08×, SECURE 0.95×, UNKNOWN 1.00×) with posture interaction

Guardrails
- No modifier exceeds ±25% (MAX_PREMIUM 1.25×, MIN_MODIFIER 0.82×)
- Unknown/missing data always returns 1.00× — no crash, no mutation
- Elite players (OVR ≥ 82) never discounted at SECURE positions
- Rebuilders: young/upside players protected from SECURE discount
- Contenders: small additional premium on CRITICAL (+4%) and MODERATE (+2%)

Integration
- tradeFinderAnalysis.js: target team's depth needs computed per-target
  and passed via strategicContext.targetDepthNeeds; applied to outgoing
  player assets in buildIdea from the receiving AI team's perspective
- Picks are excluded from need-modifier path (pure player logic)
- No changes to: trade finalization, transferPickOwnership,
  draftPickIntegrity, runAIToAITrades, schema, sim, UI, contracts

Tests
- 56 new tests in tradePositionalNeeds.test.js covering:
  enum export, snapshot building, deficiency classification, need lookup,
  modifier application, posture interactions, mutation safety, edge cases,
  and integration invariants (sort order, shape, capping)
- All 1589 existing unit tests pass
- All 85 soak tests pass
- Build passes

Deferred
- AI-to-AI acceptance path (trade-logic.js runAIToAITrades)
- Worker offer-scoring path
- Injury-driven temporary needs
- Scheme-specific positional weighting
- Multi-season succession planning

https://claude.ai/code/session_01WwzTJfpiE9Gd7LcSqxBgNG