### PR TITLE
feat: trade explanation panel and valuation UI alignment

### DIFF
--- a/src/core/trades/tradeFinderAnalysis.js
+++ b/src/core/trades/tradeFinderAnalysis.js
@@ -15,6 +15,8 @@ import {
 import {
   applyPositionalNeedModifiers,
   calculateTeamDepthDeficiencies,
+  getNeedLevelForPlayer,
+  POSITION_NEED_LEVEL,
 } from './tradePositionalNeeds.js';
 
 const PICK_VALUE_SCALING = 0.184;
@@ -250,6 +252,33 @@ function buildIdea({ need, target, outgoingAssets, targetTeam, cap, packageType,
   confidenceReasons.push(...realismReasons);
   if (valueMatch === 'expensive' || valueMatch === 'unrealistic') confidenceReasons.push('Package remains short on value.');
   const confidence = feasibilityLabel === 'likely_reasonable' && !warnings.includes(PREMIUM_PICK_WARNING) ? 'high' : feasibilityLabel === 'long_shot' || feasibilityLabel === 'cap_constrained' || feasibilityLabel === 'overpay_risk' ? 'low' : 'medium';
+
+  // Derived explanation block — strictly read-only, no formula changes.
+  const decayedPicks = outgoingAssets
+    .filter((a) => a.assetType === 'pick')
+    .map((a) => ({
+      label: a.label,
+      round: a.round,
+      year: a.year,
+      baseValue: getNormalizedPickValueFromUnifiedMatrix(a),
+      decayedValue: num(a.valueScore),
+    }));
+  const positionalContexts = targetDepthNeeds != null
+    ? outgoingAssets
+        .filter((a) => a.assetType === 'player')
+        .map((a) => ({ pos: a.pos, needLevel: getNeedLevelForPlayer(a, targetDepthNeeds) }))
+    : null;
+  const verdictKey = valueDelta <= -35 ? 'FAVORABLE' : valueDelta <= 25 ? 'FAIR' : valueDelta <= 75 ? 'NEEDS_MORE_VALUE' : 'UNFAVORABLE';
+  const explanationMeta = Object.freeze({
+    posture: teamPosture,
+    outgoingScore: outgoingValue,
+    incomingScore: targetValue,
+    verdict: verdictKey,
+    diminishingReturnsApplied: outgoingAssets.length > 1,
+    decayedPicks,
+    positionalContexts,
+  });
+
   return {
     id: `${need.pos}-${target.id}-${outgoingAssets.map((a) => a.playerId ?? a.pickId).join('-')}`,
     targetPlayerId: target.id, targetPlayerName: target.name, targetTeamId: target.teamId,
@@ -266,6 +295,7 @@ function buildIdea({ need, target, outgoingAssets, targetTeam, cap, packageType,
     needFitTag: need.needLevel === 'urgent' ? 'urgent_need' : 'team_need',
     recommendation: valueMatch === 'unrealistic' ? 'avoid' : 'consider',
     reason: `Possible package to address ${need.pos}.`,
+    explanationMeta,
   };
 }
 

--- a/src/ui/components/TradeCenter.jsx
+++ b/src/ui/components/TradeCenter.jsx
@@ -21,6 +21,7 @@ import { buildTradeAssetDisplay } from "../utils/tradeAssetDisplay.js";
 import { getTradeLockReason } from "../utils/tradeLockReason.js";
 import { getBudgetLabel, toneToCssColor } from "../utils/transactionMarket.js";
 import { logCompletedTradeAction, persistFranchiseChronicle } from "../utils/franchiseChronicle.js";
+import { getPickBaseValueFromMatrix } from "../../core/trades/tradeValuationModifiers.js";
 
 // ── Original helpers (kept exactly as you had) ─────────────────────────────────
 
@@ -43,7 +44,6 @@ function playerTradeValue(player) {
   return Math.round(Math.pow(ovr, 1.8) * pMult * ageF);
 }
 
-const PICK_VALUES = [0, 800, 300, 150, 60, 25, 10, 3];
 
 function fmtSalary(annual) {
   if (annual == null) return "—";
@@ -394,8 +394,8 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
     setTheirPicks((source?.offering?.pickIds ?? []).map((id) => theirAvailablePicksMap.get(String(id)) ?? { id }));
   }, [counterOfferId, incomingOffers, myAvailablePicksMap, theirAvailablePicksMap]);
 
-  const myOfferValue = useMemo(() => [...offering].reduce((s, id) => s + playerTradeValue(myRosterMap.get(toAssetId(id))), 0) + myPicks.reduce((s, pk) => s + (PICK_VALUES[pk.round] ?? 10), 0), [offering, myRosterMap, myPicks]);
-  const theirOfferValue = useMemo(() => [...receiving].reduce((s, id) => s + playerTradeValue(theirRosterMap.get(toAssetId(id))), 0) + theirPicks.reduce((s, pk) => s + (PICK_VALUES[pk.round] ?? 10), 0), [receiving, theirRosterMap, theirPicks]);
+  const myOfferValue = useMemo(() => [...offering].reduce((s, id) => s + playerTradeValue(myRosterMap.get(toAssetId(id))), 0) + myPicks.reduce((s, pk) => s + getPickBaseValueFromMatrix(pk.round), 0), [offering, myRosterMap, myPicks]);
+  const theirOfferValue = useMemo(() => [...receiving].reduce((s, id) => s + playerTradeValue(theirRosterMap.get(toAssetId(id))), 0) + theirPicks.reduce((s, pk) => s + getPickBaseValueFromMatrix(pk.round), 0), [receiving, theirRosterMap, theirPicks]);
 
   const myCapAfter = useMemo(() => {
     const base = liveMyTeam?.capRoom ?? 0;

--- a/src/ui/components/TradeExplanationPanel.jsx
+++ b/src/ui/components/TradeExplanationPanel.jsx
@@ -1,0 +1,124 @@
+import React from 'react';
+
+const POSTURE_STYLE = {
+  CONTENDER: { background: 'rgba(255,214,10,0.12)', color: '#FFD60A', border: '1px solid rgba(255,214,10,0.3)', label: 'Contender' },
+  REBUILDER:  { background: 'rgba(10,132,255,0.12)', color: '#0A84FF', border: '1px solid rgba(10,132,255,0.3)', label: 'Rebuilder' },
+  NEUTRAL:    { background: 'var(--surface)', color: 'var(--text-muted)', border: '1px solid var(--hairline)', label: 'Neutral' },
+};
+
+const VERDICT_STYLE = {
+  FAVORABLE:        { color: 'var(--success)',  label: 'Favorable for you' },
+  FAIR:             { color: 'var(--success)',  label: 'Fair value' },
+  NEEDS_MORE_VALUE: { color: 'var(--warning)',  label: 'Needs more value' },
+  UNFAVORABLE:      { color: 'var(--danger)',   label: 'Unfavorable' },
+};
+
+const NEED_STYLE = {
+  CRITICAL: { color: 'var(--danger)',  label: 'Critical need' },
+  MODERATE: { color: 'var(--warning)', label: 'Moderate need' },
+  SECURE:   { color: 'var(--success)', label: 'Secure depth' },
+  UNKNOWN:  { color: 'var(--text-muted)', label: 'Unknown' },
+};
+
+function PostureBadge({ posture }) {
+  const s = POSTURE_STYLE[posture] ?? POSTURE_STYLE.NEUTRAL;
+  return (
+    <span style={{ display: 'inline-block', padding: '2px 8px', borderRadius: 12, fontSize: 11, fontWeight: 700, background: s.background, color: s.color, border: s.border }}>
+      {s.label}
+    </span>
+  );
+}
+
+function ScoreRow({ outgoingScore, incomingScore, verdict }) {
+  const vs = VERDICT_STYLE[verdict] ?? VERDICT_STYLE.FAIR;
+  return (
+    <div style={{ display: 'flex', gap: 8, alignItems: 'center', fontSize: 12 }}>
+      <span style={{ color: 'var(--text-muted)' }}>Send <strong style={{ color: 'var(--text)' }}>{outgoingScore}</strong></span>
+      <span style={{ color: 'var(--text-muted)' }}>↔</span>
+      <span style={{ color: 'var(--text-muted)' }}>Get <strong style={{ color: 'var(--text)' }}>{incomingScore}</strong></span>
+      <span style={{ fontWeight: 700, color: vs.color }}>{vs.label}</span>
+    </div>
+  );
+}
+
+function PickDecayRows({ decayedPicks }) {
+  if (!Array.isArray(decayedPicks) || decayedPicks.length === 0) return null;
+  return (
+    <div style={{ display: 'grid', gap: 2 }}>
+      {decayedPicks.map((pk, i) => {
+        const decayPct = pk.baseValue > 0 ? Math.round((1 - pk.decayedValue / pk.baseValue) * 100) : 0;
+        return (
+          <div key={i} style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11, color: 'var(--text-muted)' }}>
+            <span>{pk.label ?? `R${pk.round}`}</span>
+            <span>
+              base {pk.baseValue} → {pk.decayedValue}
+              {decayPct > 0 ? <span style={{ color: 'var(--warning)', marginLeft: 4 }}>−{decayPct}% decay</span> : null}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function PositionalContextRows({ positionalContexts }) {
+  if (!Array.isArray(positionalContexts) || positionalContexts.length === 0) return null;
+  return (
+    <div style={{ display: 'grid', gap: 2 }}>
+      {positionalContexts.map((ctx, i) => {
+        const ns = NEED_STYLE[ctx.needLevel] ?? NEED_STYLE.UNKNOWN;
+        return (
+          <div key={i} style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11 }}>
+            <span style={{ color: 'var(--text-muted)' }}>{`Their ${ctx.pos} depth`}</span>
+            <span style={{ color: ns.color, fontWeight: 600 }}>{ns.label}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Read-only trade explanation panel.
+ * Displays AI reasoning derived from tradeFinderAnalysis buildIdea() explanationMeta.
+ * Never calls worker actions, never modifies state, never submits trades.
+ */
+export default function TradeExplanationPanel({ idea = null }) {
+  const meta = idea?.explanationMeta;
+  if (!meta) return null;
+
+  const { posture, outgoingScore, incomingScore, verdict, diminishingReturnsApplied, decayedPicks, positionalContexts } = meta;
+  const hasPickDecay = Array.isArray(decayedPicks) && decayedPicks.length > 0;
+  const hasPositionalContext = Array.isArray(positionalContexts) && positionalContexts.length > 0;
+
+  return (
+    <div style={{ marginTop: 6, padding: '8px 10px', borderRadius: 6, background: 'var(--surface)', border: '1px solid var(--hairline)', display: 'grid', gap: 6 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, justifyContent: 'space-between' }}>
+        <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.5px' }}>AI Reasoning</span>
+        <PostureBadge posture={posture} />
+      </div>
+
+      <ScoreRow outgoingScore={outgoingScore} incomingScore={incomingScore} verdict={verdict} />
+
+      {hasPickDecay && (
+        <div>
+          <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 2, fontWeight: 600 }}>Pick Decay</div>
+          <PickDecayRows decayedPicks={decayedPicks} />
+        </div>
+      )}
+
+      {diminishingReturnsApplied && (
+        <div style={{ fontSize: 11, color: 'var(--text-muted)', fontStyle: 'italic' }}>
+          Multi-asset package: diminishing returns applied.
+        </div>
+      )}
+
+      {hasPositionalContext && (
+        <div>
+          <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 2, fontWeight: 600 }}>Their Positional Needs</div>
+          <PositionalContextRows positionalContexts={positionalContexts} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/TradeFinder.jsx
+++ b/src/ui/components/TradeFinder.jsx
@@ -9,6 +9,7 @@ import { normalizeManagement, CONTRACT_PLAN_LABELS, TRADE_STATUS_LABELS } from '
 import { buildAskOfferOutcome } from '../utils/tradeFinderOffers.js';
 import { buildTradeFinderAnalysis } from '../../core/trades/tradeFinderAnalysis.js';
 import { buildTradeFinderProfileContext } from '../utils/playerProfileContext.js';
+import TradeExplanationPanel from './TradeExplanationPanel.jsx';
 
 function money(v) { return `$${Number(v ?? 0).toFixed(1)}M`; }
 
@@ -297,6 +298,7 @@ export default function TradeFinder({ league, actions, onPlayerSelect, onOpenTra
                 {Array.isArray(idea.confidenceReasons) && idea.confidenceReasons.length ? <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{idea.confidenceReasons.join(' · ')}</div> : null}
                 <div style={{ fontSize: 12 }}>{idea.recommendation}: {idea.reason}</div>
                 {Array.isArray(idea.warnings) && idea.warnings.length ? <div style={{ fontSize: 12, color: 'var(--warning)' }}>Warnings: {idea.warnings.join(' · ')}</div> : null}
+                <TradeExplanationPanel idea={idea} />
                 <div style={{ display: 'flex', gap: 6 }}>
                   <Button className="btn" onClick={() => onPlayerSelect?.(idea.targetPlayerId, buildTradeFinderProfileContext(idea, 'target'))}>Open Player</Button>
                   <Button className="btn" style={{ minHeight: 44 }} onClick={() => handleUseFramework(idea)}>Use Framework</Button>

--- a/src/ui/components/__tests__/TradeExplanationPanel.test.jsx
+++ b/src/ui/components/__tests__/TradeExplanationPanel.test.jsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import TradeExplanationPanel from '../TradeExplanationPanel.jsx';
+
+const BASE_META = {
+  posture: 'NEUTRAL',
+  outgoingScore: 120,
+  incomingScore: 140,
+  verdict: 'NEEDS_MORE_VALUE',
+  diminishingReturnsApplied: false,
+  decayedPicks: [],
+  positionalContexts: null,
+};
+
+function makeIdea(overrides = {}) {
+  return { explanationMeta: { ...BASE_META, ...overrides } };
+}
+
+describe('TradeExplanationPanel', () => {
+  it('renders null when idea is null', () => {
+    const html = renderToString(<TradeExplanationPanel idea={null} />);
+    expect(html).toBe('');
+  });
+
+  it('renders null when idea has no explanationMeta', () => {
+    const html = renderToString(<TradeExplanationPanel idea={{ id: 'x' }} />);
+    expect(html).toBe('');
+  });
+
+  it('renders AI Reasoning header', () => {
+    const html = renderToString(<TradeExplanationPanel idea={makeIdea()} />);
+    expect(html).toContain('AI Reasoning');
+  });
+
+  it('displays outgoing and incoming scores', () => {
+    const html = renderToString(<TradeExplanationPanel idea={makeIdea({ outgoingScore: 155, incomingScore: 200 })} />);
+    expect(html).toContain('155');
+    expect(html).toContain('200');
+  });
+
+  it('shows Favorable verdict for FAVORABLE', () => {
+    const html = renderToString(<TradeExplanationPanel idea={makeIdea({ verdict: 'FAVORABLE' })} />);
+    expect(html).toContain('Favorable for you');
+  });
+
+  it('shows Fair value verdict for FAIR', () => {
+    const html = renderToString(<TradeExplanationPanel idea={makeIdea({ verdict: 'FAIR' })} />);
+    expect(html).toContain('Fair value');
+  });
+
+  it('shows Needs more value verdict for NEEDS_MORE_VALUE', () => {
+    const html = renderToString(<TradeExplanationPanel idea={makeIdea({ verdict: 'NEEDS_MORE_VALUE' })} />);
+    expect(html).toContain('Needs more value');
+  });
+
+  it('shows Unfavorable verdict for UNFAVORABLE', () => {
+    const html = renderToString(<TradeExplanationPanel idea={makeIdea({ verdict: 'UNFAVORABLE' })} />);
+    expect(html).toContain('Unfavorable');
+  });
+
+  it('renders CONTENDER posture badge', () => {
+    const html = renderToString(<TradeExplanationPanel idea={makeIdea({ posture: 'CONTENDER' })} />);
+    expect(html).toContain('Contender');
+  });
+
+  it('renders REBUILDER posture badge', () => {
+    const html = renderToString(<TradeExplanationPanel idea={makeIdea({ posture: 'REBUILDER' })} />);
+    expect(html).toContain('Rebuilder');
+  });
+
+  it('renders NEUTRAL posture badge', () => {
+    const html = renderToString(<TradeExplanationPanel idea={makeIdea({ posture: 'NEUTRAL' })} />);
+    expect(html).toContain('Neutral');
+  });
+
+  it('renders pick decay rows when picks are present', () => {
+    const decayedPicks = [
+      { label: '2026 Round 1', round: 1, year: 2026, baseValue: 175, decayedValue: 161 },
+    ];
+    const html = renderToString(<TradeExplanationPanel idea={makeIdea({ decayedPicks })} />);
+    expect(html).toContain('Pick Decay');
+    expect(html).toContain('2026 Round 1');
+    expect(html).toContain('175');
+    expect(html).toContain('161');
+    expect(html).toContain('decay');
+  });
+
+  it('does not render pick decay section when no picks', () => {
+    const html = renderToString(<TradeExplanationPanel idea={makeIdea({ decayedPicks: [] })} />);
+    expect(html).not.toContain('Pick Decay');
+  });
+
+  it('does not show decay percentage when baseValue is 0', () => {
+    const decayedPicks = [{ label: 'R1', round: 1, year: 2026, baseValue: 0, decayedValue: 0 }];
+    const html = renderToString(<TradeExplanationPanel idea={makeIdea({ decayedPicks })} />);
+    expect(html).not.toContain('decay');
+  });
+
+  it('renders diminishing returns note when flag is true', () => {
+    const html = renderToString(<TradeExplanationPanel idea={makeIdea({ diminishingReturnsApplied: true })} />);
+    expect(html).toContain('diminishing returns');
+  });
+
+  it('does not render diminishing returns note when false', () => {
+    const html = renderToString(<TradeExplanationPanel idea={makeIdea({ diminishingReturnsApplied: false })} />);
+    expect(html).not.toContain('diminishing returns');
+  });
+
+  it('renders positional context when present', () => {
+    const positionalContexts = [
+      { pos: 'QB', needLevel: 'CRITICAL' },
+      { pos: 'WR', needLevel: 'SECURE' },
+    ];
+    const html = renderToString(<TradeExplanationPanel idea={makeIdea({ positionalContexts })} />);
+    expect(html).toContain('Their Positional Needs');
+    expect(html).toContain('Their QB depth');
+    expect(html).toContain('Critical need');
+    expect(html).toContain('Their WR depth');
+    expect(html).toContain('Secure depth');
+  });
+
+  it('does not render positional context section when null', () => {
+    const html = renderToString(<TradeExplanationPanel idea={makeIdea({ positionalContexts: null })} />);
+    expect(html).not.toContain('Their Positional Needs');
+  });
+
+  it('handles unknown need level gracefully', () => {
+    const positionalContexts = [{ pos: 'K', needLevel: 'UNKNOWN' }];
+    const html = renderToString(<TradeExplanationPanel idea={makeIdea({ positionalContexts })} />);
+    expect(html).toContain('Their K depth');
+    expect(html).toContain('Unknown');
+  });
+
+  it('handles missing posture gracefully by defaulting to Neutral', () => {
+    const html = renderToString(<TradeExplanationPanel idea={makeIdea({ posture: undefined })} />);
+    expect(html).toContain('Neutral');
+  });
+
+  it('does not mutate the idea prop', () => {
+    const idea = makeIdea({ outgoingScore: 100 });
+    const before = JSON.stringify(idea);
+    renderToString(<TradeExplanationPanel idea={idea} />);
+    expect(JSON.stringify(idea)).toBe(before);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a user-facing trade explanation panel and aligns visible trade pick values with the unified trade valuation matrix.

## Changes
- Adds `TradeExplanationPanel.jsx` for read-only trade reasoning display.
- Wires the explanation panel into `TradeFinder.jsx` idea cards.
- Adds `explanationMeta` to `tradeFinderAnalysis.js` derived from existing computed values.
- Replaces stale local `PICK_VALUES` usage in `TradeCenter.jsx` with `getPickBaseValueFromMatrix`.
- Adds focused `TradeExplanationPanel` tests.

## Safety notes
- No trade finalization changes.
- No ownership transfer changes.
- No worker protocol changes.
- No schema/persistence/sim changes.
- Panel is display-only.

## Validation reported by Claude
- `npm run test:unit` → 1610/1610 passed
- `npm run build` → passed
- `npm run test:soak` → 85/85 passed
- Playwright smoke blocked by environment network policy when downloading browser binary.