### PR TITLE
feat: auto-open replay panel on manual game simulation (opt-in gate)

### DIFF
--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -48,7 +48,7 @@ function leaderProfileRole(card) {
   return `${card?.label ?? "Box score"} leader`;
 }
 
-function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, onTeamSelect, embedded = false, scheduleGame = null }) {
+function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, onTeamSelect, embedded = false, scheduleGame = null, isManualSimRun = false }) {
   const canLoadArchive = Boolean(gameId && typeof actions?.getBoxScore === "function");
   const { data: archiveGame } = useStableRouteRequest({
     requestKey: canLoadArchive ? `boxscore:${gameId}` : null,
@@ -62,7 +62,7 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
   const vm = useMemo(() => buildBoxScoreViewModel({ league, game, gameId, scheduleGame: fallbackGame, context: { season: league?.seasonId, week: league?.week } }), [league, game, gameId, fallbackGame]);
   const [sortState, setSortState] = useState({});
   const [showAllPlays, setShowAllPlays] = useState(false);
-  const [showReplay, setShowReplay] = useState(false);
+  const [showReplay, setShowReplay] = useState(Boolean(isManualSimRun));
 
   if (!vm || vm.status === "unavailable") {
     return <EmptyState title="Game Book unavailable" body="Game data missing." />;
@@ -301,12 +301,27 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
             </button>
           </div>
           {showReplay && (
-            <ReplayableGameFlowViewer
-              gameFlowSummary={gfs}
-              homeTeam={vm.homeTeam}
-              awayTeam={vm.awayTeam}
-              finalScore={vm.finalScore}
-            />
+            <>
+              {isManualSimRun && (
+                <div style={{ marginBottom: "0.5rem" }}>
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-primary"
+                    data-testid="game-book-skip-to-box-score"
+                    onClick={() => setShowReplay(false)}
+                  >
+                    Instant Skip to Box Score
+                  </button>
+                </div>
+              )}
+              <ReplayableGameFlowViewer
+                gameFlowSummary={gfs}
+                homeTeam={vm.homeTeam}
+                awayTeam={vm.awayTeam}
+                finalScore={vm.finalScore}
+                initialMode={isManualSimRun ? "playing" : "paused"}
+              />
+            </>
           )}
         </section>
       )}

--- a/src/ui/components/__tests__/BoxScoreAutoOpen.test.jsx
+++ b/src/ui/components/__tests__/BoxScoreAutoOpen.test.jsx
@@ -1,0 +1,121 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import BoxScore from '../BoxScore.jsx';
+
+vi.mock('../../hooks/useStableRouteRequest.js', () => ({ default: vi.fn(() => ({ data: null })) }));
+
+const baseLeague = {
+  seasonId: 2031,
+  week: 5,
+  teams: [{ id: 1, abbr: 'KC' }, { id: 2, abbr: 'BUF' }],
+};
+
+// Game with scoringSummary so buildGameFlowSummary produces a non-null gfs,
+// which is required for the replay section to render at all.
+const gameWithFlow = {
+  homeId: 1,
+  awayId: 2,
+  homeScore: 28,
+  awayScore: 14,
+  scoringSummary: [
+    { quarter: 1, teamId: 1, type: 'TD', scoreAfter: { home: 7, away: 0 }, text: 'QB sneak TD' },
+    { quarter: 3, teamId: 2, type: 'TD', scoreAfter: { home: 7, away: 7 }, text: 'Passing TD' },
+  ],
+};
+
+// Fake timers prevent the ReplayableGameFlowViewer setInterval (started when
+// initialMode="playing") from firing real ticks and causing act() warnings.
+describe('BoxScore – opt-in auto-open replay gate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it('auto-opens the replay panel on mount when isManualSimRun is true', () => {
+    const { getByTestId } = render(
+      <BoxScore
+        gameId="g-manual"
+        league={{ ...baseLeague, gameById: { 'g-manual': gameWithFlow } }}
+        isManualSimRun
+        embedded
+      />,
+    );
+    expect(getByTestId('rgfv-root')).toBeTruthy();
+    expect(getByTestId('game-book-replay-toggle').textContent).toBe('Hide');
+  });
+
+  it('defaults to collapsed replay panel for standard history / archive loads', () => {
+    const { queryByTestId, getByTestId } = render(
+      <BoxScore
+        gameId="g-history"
+        league={{ ...baseLeague, gameById: { 'g-history': gameWithFlow } }}
+        embedded
+      />,
+    );
+    expect(queryByTestId('rgfv-root')).toBeNull();
+    expect(getByTestId('game-book-replay-toggle').textContent).toBe('Replay');
+  });
+
+  it('clicking Instant Skip to Box Score immediately collapses the viewer', () => {
+    const { getByTestId, queryByTestId } = render(
+      <BoxScore
+        gameId="g-skip"
+        league={{ ...baseLeague, gameById: { 'g-skip': gameWithFlow } }}
+        isManualSimRun
+        embedded
+      />,
+    );
+    expect(getByTestId('rgfv-root')).toBeTruthy();
+
+    fireEvent.click(getByTestId('game-book-skip-to-box-score'));
+
+    expect(queryByTestId('rgfv-root')).toBeNull();
+    expect(getByTestId('game-book-replay-toggle').textContent).toBe('Replay');
+  });
+
+  it('skip button is absent when replay was opened via the manual toggle (not auto-opened)', () => {
+    const { queryByTestId, getByTestId } = render(
+      <BoxScore
+        gameId="g-toggle-open"
+        league={{ ...baseLeague, gameById: { 'g-toggle-open': gameWithFlow } }}
+        embedded
+      />,
+    );
+    // Manually expand the replay section via the toggle
+    fireEvent.click(getByTestId('game-book-replay-toggle'));
+    expect(getByTestId('rgfv-root')).toBeTruthy();
+    // Skip button should NOT be present when isManualSimRun is false
+    expect(queryByTestId('game-book-skip-to-box-score')).toBeNull();
+  });
+
+  it('passes initialMode="playing" to the viewer on manual sim launch', () => {
+    const { getByTestId } = render(
+      <BoxScore
+        gameId="g-autoplay"
+        league={{ ...baseLeague, gameById: { 'g-autoplay': gameWithFlow } }}
+        isManualSimRun
+        embedded
+      />,
+    );
+    // The viewer renders in playing state — progress label reads "Playing…"
+    expect(getByTestId('rgfv-progress').textContent).toBe('Playing…');
+  });
+
+  it('passes initialMode="paused" when viewer opened manually via toggle', () => {
+    const { getByTestId } = render(
+      <BoxScore
+        gameId="g-paused"
+        league={{ ...baseLeague, gameById: { 'g-paused': gameWithFlow } }}
+        embedded
+      />,
+    );
+    fireEvent.click(getByTestId('game-book-replay-toggle'));
+    // Without isManualSimRun the viewer starts paused
+    expect(getByTestId('rgfv-progress').textContent).toBe('Paused');
+  });
+});


### PR DESCRIPTION
Introduces isManualSimRun prop to BoxScore that seeds showReplay state
true on mount, wires initialMode="playing" into ReplayableGameFlowViewer,
and surfaces a persistent "Instant Skip to Box Score" button for immediate
escape. Archive/history loads default cleanly to collapsed. Six targeted
tests in BoxScoreAutoOpen.test.jsx cover auto-open, default-collapsed,
skip-collapse, toggle-only-open, and initialMode variants.

https://claude.ai/code/session_017oj9i8GwT341GTaGAJNxPu