### PR TITLE
Sync cap-burden valuation in worker/trade finder and surface cap warning in Trade Explanation

### DIFF
--- a/src/core/trades/tradeFinderAnalysis.js
+++ b/src/core/trades/tradeFinderAnalysis.js
@@ -18,6 +18,8 @@ import {
   getNeedLevelForPlayer,
   POSITION_NEED_LEVEL,
 } from './tradePositionalNeeds.js';
+import { getActiveCapHit } from '../contracts/contractObligations.js';
+import { applyContractCapBurdenModifiers } from './tradeFinancialModifiers.js';
 
 const PICK_VALUE_SCALING = 0.184;
 
@@ -221,14 +223,22 @@ function buildIdea({ need, target, outgoingAssets, targetTeam, cap, packageType,
   const targetBaseValue = getPlayerValueSafe(target);
   const targetValue = applyStrategicValuationModifiers({ assetType: 'player', ...target }, targetBaseValue, teamPosture, { currentSeason });
   const targetDepthNeeds = strategicContext?.targetDepthNeeds ?? null;
+  const effectiveIncomingCapRoom = Number(targetTeam?.capRoom ?? 0) + Number(getActiveCapHit(target));
+  let capBurdenApplied = false;
   const outgoingStrategicValues = outgoingAssets.map((a) => {
     const strategicValue = applyStrategicValuationModifiers(a, num(a.valueScore), teamPosture, { currentSeason });
     // Apply positional need modifiers from the receiving (target) team's perspective.
     // Only for player assets and only when the target team's depth needs are available.
+    let adjustedValue = strategicValue;
     if (a.assetType === 'player' && targetDepthNeeds != null) {
-      return applyPositionalNeedModifiers(a, strategicValue, targetDepthNeeds, teamPosture);
+      adjustedValue = applyPositionalNeedModifiers(a, adjustedValue, targetDepthNeeds, teamPosture);
     }
-    return strategicValue;
+    if (a.assetType === 'player') {
+      const capAdjustedValue = applyContractCapBurdenModifiers(a, adjustedValue, effectiveIncomingCapRoom, teamPosture);
+      if (capAdjustedValue !== adjustedValue) capBurdenApplied = true;
+      adjustedValue = capAdjustedValue;
+    }
+    return adjustedValue;
   });
   const outgoingValue = evaluateMultiAssetPackageValue(outgoingStrategicValues);
   const valueDelta = Math.round(targetValue - outgoingValue);
@@ -277,6 +287,7 @@ function buildIdea({ need, target, outgoingAssets, targetTeam, cap, packageType,
     diminishingReturnsApplied: outgoingAssets.length > 1,
     decayedPicks,
     positionalContexts,
+    capBurdenApplied,
   });
 
   return {

--- a/src/ui/components/TradeExplanationPanel.jsx
+++ b/src/ui/components/TradeExplanationPanel.jsx
@@ -87,7 +87,7 @@ export default function TradeExplanationPanel({ idea = null }) {
   const meta = idea?.explanationMeta;
   if (!meta) return null;
 
-  const { posture, outgoingScore, incomingScore, verdict, diminishingReturnsApplied, decayedPicks, positionalContexts } = meta;
+  const { posture, outgoingScore, incomingScore, verdict, diminishingReturnsApplied, decayedPicks, positionalContexts, capBurdenApplied } = meta;
   const hasPickDecay = Array.isArray(decayedPicks) && decayedPicks.length > 0;
   const hasPositionalContext = Array.isArray(positionalContexts) && positionalContexts.length > 0;
 
@@ -110,6 +110,12 @@ export default function TradeExplanationPanel({ idea = null }) {
       {diminishingReturnsApplied && (
         <div style={{ fontSize: 11, color: 'var(--text-muted)', fontStyle: 'italic' }}>
           Multi-asset package: diminishing returns applied.
+        </div>
+      )}
+
+      {capBurdenApplied && (
+        <div style={{ fontSize: 11, color: 'var(--color-danger, var(--danger))', fontWeight: 700 }} className="burden-warning">
+          ⚠️ Cap Burden Penalty Applied
         </div>
       )}
 

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -188,6 +188,7 @@ import {
   calculateTeamDepthDeficiencies,
   applyPositionalNeedModifiers,
 } from '../core/trades/tradePositionalNeeds.js';
+import { applyContractCapBurdenModifiers } from '../core/trades/tradeFinancialModifiers.js';
 
 
 // ── DB Reload Guard ───────────────────────────────────────────────────────────
@@ -1185,6 +1186,9 @@ function calcAssetBundleValue({ playerIds = [], pickIds = [] } = {}, context = {
   const teamPosture = context?.teamPosture ?? TEAM_STRATEGIC_POSTURE.NEUTRAL;
   const currentSeason = Number(context?.currentSeason ?? 0) || null;
   const depthNeedsMap = context?.depthNeedsMap ?? null;
+  const effectiveIncomingCapRoom = Number.isFinite(Number(context?.effectiveIncomingCapRoom))
+    ? Number(context.effectiveIncomingCapRoom)
+    : null;
   const adjustedAssetValues = [];
   const playerVal = playerIds.reduce((sum, pid) => {
     const player = cache.getPlayer(Number(pid));
@@ -1201,6 +1205,9 @@ function calcAssetBundleValue({ playerIds = [], pickIds = [] } = {}, context = {
     let adjusted = applyStrategicValuationModifiers(playerAsset, value, teamPosture, { currentSeason });
     if (depthNeedsMap && player) {
       adjusted = applyPositionalNeedModifiers(playerAsset, adjusted, depthNeedsMap, teamPosture);
+    }
+    if (effectiveIncomingCapRoom != null && player) {
+      adjusted = applyContractCapBurdenModifiers(playerAsset, adjusted, effectiveIncomingCapRoom, teamPosture);
     }
     adjustedAssetValues.push(adjusted);
     return sum + adjusted;
@@ -6897,6 +6904,7 @@ async function handleTradeOffer({ fromTeamId, toTeamId, offering, receiving }, i
     teamPosture: aiPosture,
     currentSeason: meta?.year,
     depthNeedsMap: aiDepthNeeds,
+    effectiveIncomingCapRoom: Number(to?.capRoom ?? 0) + capHitOf(receiving?.playerIds ?? []),
   };
   const offerVal    = calcAssetBundleValue(offering, valuationContext);
   const receiveVal  = calcAssetBundleValue(receiving, valuationContext);
@@ -7182,6 +7190,7 @@ async function handleCounterIncomingTrade({ offerId, offering, receiving }, id) 
     teamPosture: counterAiPosture,
     currentSeason: latestMeta?.year,
     depthNeedsMap: counterAiDepthNeeds,
+    effectiveIncomingCapRoom: Number(aiTeam?.capRoom ?? 0) + capHitOf(aiBundle?.playerIds ?? []),
   };
   const aiReceivesValue = calcAssetBundleValue(userBundle, counterValuationContext);
   const aiGivesValue = calcAssetBundleValue(aiBundle, counterValuationContext);

--- a/tests/unit/tradeAcceptanceSync.test.js
+++ b/tests/unit/tradeAcceptanceSync.test.js
@@ -25,6 +25,7 @@ import {
   evaluateMultiAssetPackageValue,
   calculateTotalPackageScore,
 } from '../../src/core/trades/tradeValuationModifiers.js';
+import { applyContractCapBurdenModifiers } from '../../src/core/trades/tradeFinancialModifiers.js';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -390,5 +391,37 @@ describe('Assertion 6 — diminishing returns blocks low-value asset spam', () =
     // The same five players without discount
     const undiscountedPile = evaluateMultiAssetPackageValue([60, 60, 60, 60, 60]);
     expect(pile).toBeLessThan(undiscountedPile);
+  });
+});
+
+describe('Assertion 7 — cap burden sync devalues expensive incoming contracts on tight-cap AI teams', () => {
+  it('applies financial burden penalty when effective incoming cap room is tight', () => {
+    const aiPosture = TEAM_STRATEGIC_POSTURE.NEUTRAL;
+    const expensiveIncoming = makePlayer('WR', 84, 30, {
+      contract: { baseAnnual: 14, signingBonus: 0, yearsTotal: 3, yearsRemaining: 2 },
+    });
+    const cheapOutgoing = makePlayer('RB', 73, 25, {
+      contract: { baseAnnual: 2, signingBonus: 0, yearsTotal: 2, yearsRemaining: 1 },
+    });
+    const expensiveBase = 210;
+    const cheapBase = 95;
+    const effectiveIncomingCapRoom = 8 + 2; // ai cap room + outgoing cap hit
+
+    const expensiveAdjusted = applyContractCapBurdenModifiers(
+      { ...expensiveIncoming, assetType: 'player' },
+      expensiveBase,
+      effectiveIncomingCapRoom,
+      aiPosture,
+    );
+    const cheapAdjusted = applyContractCapBurdenModifiers(
+      { ...cheapOutgoing, assetType: 'player' },
+      cheapBase,
+      effectiveIncomingCapRoom,
+      aiPosture,
+    );
+
+    expect(expensiveAdjusted).toBeLessThan(expensiveBase);
+    expect(cheapAdjusted).toBeGreaterThanOrEqual(cheapBase);
+    expect(expensiveAdjusted).toBeLessThan(cheapAdjusted * 2);
   });
 });


### PR DESCRIPTION
### Motivation
- PR #1507 added `applyContractCapBurdenModifiers` for AI↔AI trades but the worker's custom-slider valuation and Trade Finder package builder did not apply the same modifier, creating an exploitable asymmetry where human proposals could evade financial penalties.
- The change aims to make valuation symmetric across AI-to-AI, AI acceptance of user offers, and trade-finder idea construction, and to expose when the cap penalty influenced the recommendation.

### Description
- Worker valuation: `calcAssetBundleValue` in `src/worker/worker.js` now accepts `context.effectiveIncomingCapRoom` and applies `applyContractCapBurdenModifiers` to incoming player assets before package evaluation.
- Worker wiring: `handleTradeOffer` and `handleCounterIncomingTrade` now compute and pass `effectiveIncomingCapRoom` (receiving team's `capRoom` plus freed cap from outgoing players) into the valuation context so slider/counter proposals are evaluated with cap burden parity.
- Trade Finder parity: `buildIdea` in `src/core/trades/tradeFinderAnalysis.js` now applies `applyContractCapBurdenModifiers` to outgoing player assets from the target team's receiving perspective and computes `effectiveIncomingCapRoom` using `targetTeam.capRoom + getActiveCapHit(target)`.
- UI metadata and rendering: `explanationMeta` now includes `capBurdenApplied` when any outgoing asset was adjusted, and `src/ui/components/TradeExplanationPanel.jsx` reads this flag and renders a warning-styled note (`⚠️ Cap Burden Penalty Applied`) that degrades safely if the flag is missing.

### Testing
- Ran unit tests with `npm run test:unit` and all unit tests passed (1759 tests across 223 files all green).
- Built the production bundle with `npm run build` and the build completed successfully (Vite emitted expected large-chunk warning only).
- Ran dynasty soak subset with `npm run test:soak` and the soak tests passed (85 tests across 7 files all green).
- Added a focused assertion in `tests/unit/tradeAcceptanceSync.test.js` validating that `applyContractCapBurdenModifiers` devalues expensive incoming contracts under tight effective cap room and that test passed as part of the unit suite.
- Note: `node --check` for `.jsx` files is unsupported in this environment, so `src/ui/components/TradeExplanationPanel.jsx` was not checked by `node --check`, but it was exercised by the unit test suite that covers the Trade Explanation panel.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a133dfbe15c832d868c351b310ede2e)