### PR TITLE
[codex] Add deterministic AI inbound trade offers

### DIFF
--- a/src/core/trades/tradeBlockGenerator.js
+++ b/src/core/trades/tradeBlockGenerator.js
@@ -1,0 +1,646 @@
+import { getTradeWindowSnapshot } from '../tradeWindow.js';
+import { getActiveCapHit } from '../contracts/contractObligations.js';
+import {
+  TEAM_STRATEGIC_POSTURE,
+  classifyTeamStrategicPosture,
+} from './teamStrategicDirection.js';
+
+const STARTER_COUNTS = Object.freeze({
+  QB: 1,
+  RB: 2,
+  WR: 3,
+  TE: 1,
+  OL: 5,
+  DL: 4,
+  LB: 3,
+  CB: 2,
+  S: 2,
+  K: 1,
+  P: 1,
+});
+
+const POSITION_WEIGHT = Object.freeze({
+  QB: 1.45,
+  EDGE: 1.24,
+  DE: 1.18,
+  DL: 1.08,
+  OT: 1.18,
+  OL: 1.04,
+  WR: 1.12,
+  CB: 1.1,
+  S: 0.92,
+  LB: 0.92,
+  TE: 0.84,
+  RB: 0.72,
+  K: 0.28,
+  P: 0.25,
+});
+
+const DEFAULT_OPTIONS = Object.freeze({
+  maxBlockAssets: 3,
+  veteranAgeMin: 30,
+  expensiveCapHitMin: 12,
+  neutralCapHitMin: 16,
+  eliteOvrMin: 88,
+  cornerstoneOvrMin: 90,
+  youngUpsideAgeMax: 24,
+  upsideDeltaMin: 5,
+  userSurplusOvrMin: 68,
+  maxActiveOffers: 5,
+  maxGeneratedOffersPerWeek: 1,
+  rngGateChance: 0.075,
+  seed: 'trade_block_v1',
+});
+
+const num = (value, fallback = 0) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const normalizePosition = (pos) => {
+  const value = String(pos ?? '').toUpperCase();
+  if (['OT', 'LT', 'RT', 'OG', 'LG', 'RG', 'C'].includes(value)) return 'OL';
+  if (['EDGE', 'DE', 'DT', 'NT', 'IDL'].includes(value)) return 'DL';
+  if (['SS', 'FS'].includes(value)) return 'S';
+  if (['ILB', 'OLB', 'MLB'].includes(value)) return 'LB';
+  if (['HB', 'FB'].includes(value)) return 'RB';
+  return value;
+};
+
+function stableHash(input = '') {
+  let hash = 2166136261;
+  const str = String(input);
+  for (let i = 0; i < str.length; i += 1) {
+    hash ^= str.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function tradeWindowAllowsOffers(snapshot) {
+  return !snapshot?.isLocked || !!snapshot?.canOverride;
+}
+
+function seededRoll(seedInput) {
+  let seed = stableHash(seedInput);
+  seed = (seed + 0x6D2B79F5) | 0;
+  let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+  t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+  return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+}
+
+function capHit(player) {
+  try {
+    const active = getActiveCapHit(player);
+    if (Number.isFinite(active)) return active;
+  } catch {
+    // Fall through to legacy fields.
+  }
+  return num(player?.capHit ?? player?.contract?.baseAnnual ?? player?.baseAnnual ?? player?.salary, 0);
+}
+
+function playerValue(player) {
+  const ovr = num(player?.ovr, 60);
+  const potential = num(player?.potential ?? player?.pot, ovr);
+  const age = num(player?.age, 27);
+  const pos = normalizePosition(player?.pos);
+  const posWeight = POSITION_WEIGHT[player?.pos] ?? POSITION_WEIGHT[pos] ?? 1;
+  const agePenalty = age >= 30 ? Math.pow(1.1, age - 29) * 7 : age <= 24 ? -4 : 0;
+  const upsideBonus = Math.max(0, potential - ovr) * (age <= 25 ? 3.2 : 1.1);
+  const contractPenalty = capHit(player) * 2.8;
+  return Math.max(0, Math.round((ovr * 1.45 + potential * 0.55 + upsideBonus - agePenalty - contractPenalty) * posWeight));
+}
+
+function pickValue(pick, currentSeason) {
+  const round = Math.max(1, Math.min(7, num(pick?.round, 7)));
+  const base = { 1: 320, 2: 210, 3: 135, 4: 85, 5: 52, 6: 30, 7: 18 }[round] ?? 18;
+  const season = num(pick?.season ?? pick?.year, currentSeason);
+  const yearsOut = Math.max(0, season - num(currentSeason, season));
+  return Math.round(base * Math.pow(0.86, yearsOut));
+}
+
+function isInjured(player) {
+  return num(player?.injuryWeeksRemaining ?? player?.injuredWeeks ?? player?.injury?.gamesRemaining, 0) > 0;
+}
+
+function isYoungUpside(player, cfg) {
+  const ovr = num(player?.ovr, 0);
+  const potential = num(player?.potential ?? player?.pot, ovr);
+  return num(player?.age, 99) <= cfg.youngUpsideAgeMax && (potential - ovr) >= cfg.upsideDeltaMin;
+}
+
+function isCornerstone(player, cfg) {
+  const ovr = num(player?.ovr, 0);
+  if (ovr >= cfg.cornerstoneOvrMin) return true;
+  if (String(player?.pos ?? '').toUpperCase() === 'QB' && ovr >= 84 && num(player?.age, 99) <= 30) return true;
+  return isYoungUpside(player, cfg) && ovr >= 76;
+}
+
+function buildPositionRanks(roster = []) {
+  const byPos = new Map();
+  for (const player of roster) {
+    if (!player) continue;
+    const pos = normalizePosition(player?.pos);
+    if (!byPos.has(pos)) byPos.set(pos, []);
+    byPos.get(pos).push(player);
+  }
+  const ranks = new Map();
+  for (const [pos, players] of byPos.entries()) {
+    players
+      .slice()
+      .sort((a, b) => num(b?.ovr, 0) - num(a?.ovr, 0) || num(a?.age, 99) - num(b?.age, 99) || String(a?.id).localeCompare(String(b?.id)))
+      .forEach((player, index) => {
+        ranks.set(player?.id, {
+          pos,
+          rank: index,
+          count: players.length,
+          starterCount: STARTER_COUNTS[pos] ?? 1,
+        });
+      });
+  }
+  return ranks;
+}
+
+function assetId(asset) {
+  if (asset?.assetType === 'pick') return `pick:${asset?.pick?.id ?? asset?.pickId}`;
+  return `player:${asset?.player?.id ?? asset?.playerId}`;
+}
+
+function isTeamPick(pick, teamId) {
+  const owner = pick?.currentOwner ?? pick?.ownerTeamId ?? pick?.teamId;
+  return owner == null || Number(owner) === Number(teamId);
+}
+
+function summarizePlayer(player) {
+  if (!player) return null;
+  return {
+    id: player.id,
+    name: player.name,
+    pos: player.pos,
+    ovr: player.ovr,
+    age: player.age,
+    potential: player.potential ?? player.pot,
+    contract: {
+      baseAnnual: num(player?.contract?.baseAnnual ?? player?.baseAnnual, 0),
+      signingBonus: num(player?.contract?.signingBonus ?? player?.signingBonus, 0),
+      yearsTotal: num(player?.contract?.yearsTotal ?? player?.yearsTotal, 1),
+      yearsRemaining: num(player?.contract?.yearsRemaining ?? player?.years, 1),
+    },
+  };
+}
+
+function pickLabel(pick) {
+  const season = pick?.season ?? pick?.year;
+  return `${season ? `${season} ` : ''}R${pick?.round ?? '?'}`;
+}
+
+function summarizePick(pick, teamsById = new Map()) {
+  if (!pick) return null;
+  const originalOwner = num(pick?.originalOwner ?? pick?.sourceTeamId ?? pick?.teamId, NaN);
+  const currentOwner = num(pick?.currentOwner ?? pick?.ownerTeamId, NaN);
+  return {
+    id: pick.id,
+    round: pick.round,
+    season: pick.season ?? pick.year,
+    originalOwner: Number.isFinite(originalOwner) ? originalOwner : null,
+    currentOwner: Number.isFinite(currentOwner) ? currentOwner : null,
+    originalOwnerAbbr: Number.isFinite(originalOwner) ? (teamsById.get(originalOwner)?.abbr ?? null) : null,
+    currentOwnerAbbr: Number.isFinite(currentOwner) ? (teamsById.get(currentOwner)?.abbr ?? null) : null,
+    label: pickLabel(pick),
+  };
+}
+
+function buildOfferSignature(offer) {
+  const givePlayers = [...(offer?.offering?.playerIds ?? [])].sort().join(',');
+  const getPlayers = [...(offer?.receiving?.playerIds ?? [])].sort().join(',');
+  const givePicks = [...(offer?.offering?.pickIds ?? [])].sort().join(',');
+  const getPicks = [...(offer?.receiving?.pickIds ?? [])].sort().join(',');
+  return `${offer?.offeringTeamId}|${offer?.offerType ?? 'market'}|${givePlayers}|${getPlayers}|${givePicks}|${getPicks}`;
+}
+
+export function classifyTradeBlockReason(playerOrPick, team = {}, roster = [], context = {}, options = {}) {
+  const cfg = { ...DEFAULT_OPTIONS, ...options };
+  const asset = playerOrPick?.assetType ? playerOrPick : { assetType: playerOrPick?.round ? 'pick' : 'player', player: playerOrPick };
+  const posture = context?.teamPosture ?? classifyTeamStrategicPosture(
+    { ...team, roster },
+    { currentSeason: context?.currentSeason ?? context?.year, phase: context?.phase },
+    context?.postureOptions ?? {},
+  );
+  const capRoom = num(team?.capRoom ?? context?.capRoom, 0);
+  const capRestricted = capRoom < 5 || context?.financialPosture === 'INSOLVENT' || context?.financialPosture === 'CAP_RESTRICTED';
+
+  if (asset.assetType === 'pick') {
+    const pick = asset.pick ?? asset;
+    const round = num(pick?.round, 7);
+    if (posture === TEAM_STRATEGIC_POSTURE.CONTENDER && round >= 4) {
+      return { key: 'surplus_pick', label: 'surplus pick', score: 48, tags: ['surplus_pick', 'contender_depth'] };
+    }
+    return null;
+  }
+
+  const player = asset.player ?? playerOrPick;
+  if (!player) return null;
+  const ranks = context?.positionRanks ?? buildPositionRanks(roster);
+  const rank = ranks.get(player.id);
+  const isStarter = rank ? rank.rank < rank.starterCount : false;
+  const isSurplus = rank ? rank.rank >= rank.starterCount : false;
+  const hit = capHit(player);
+  const age = num(player?.age, 27);
+  const ovr = num(player?.ovr, 0);
+
+  if (isCornerstone(player, cfg)) return null;
+  if (isInjured(player) && ovr >= 80 && !isSurplus) return null;
+
+  if (capRestricted && hit >= cfg.expensiveCapHitMin && age >= 28 && ovr < cfg.eliteOvrMin) {
+    return { key: 'cap_burden', label: 'cap burden', score: 88 + hit - Math.max(0, ovr - 78), tags: ['cap_burden', 'cap_restricted'] };
+  }
+
+  if (posture === TEAM_STRATEGIC_POSTURE.REBUILDER && age >= cfg.veteranAgeMin && hit >= cfg.expensiveCapHitMin && ovr < cfg.eliteOvrMin) {
+    return { key: 'aging_veteran', label: 'aging expensive veteran', score: 82 + hit + age - Math.max(0, ovr - 78), tags: ['aging_veteran', 'rebuilder'] };
+  }
+
+  if (posture === TEAM_STRATEGIC_POSTURE.CONTENDER && isSurplus && ovr < 80) {
+    return { key: 'redundant_depth', label: 'redundant depth', score: 58 + Math.max(0, ovr - 68), tags: ['redundant_depth', 'contender'] };
+  }
+
+  if (posture === TEAM_STRATEGIC_POSTURE.NEUTRAL && isSurplus && age >= 31 && hit >= cfg.neutralCapHitMin && ovr < cfg.eliteOvrMin) {
+    return { key: 'obvious_surplus_contract', label: 'obvious surplus contract', score: 64 + hit, tags: ['surplus_contract', 'neutral'] };
+  }
+
+  if (!isStarter && hit >= cfg.neutralCapHitMin && age >= 30 && ovr < cfg.eliteOvrMin) {
+    return { key: 'contract_surplus', label: 'contract surplus', score: 62 + hit, tags: ['contract_surplus'] };
+  }
+
+  return null;
+}
+
+export function rankTradeBlockAssets(assets = [], context = {}) {
+  const currentSeason = num(context?.currentSeason ?? context?.year, 0);
+  return (Array.isArray(assets) ? assets : [])
+    .filter(Boolean)
+    .slice()
+    .sort((a, b) => {
+      const scoreDiff = num(b?.score, 0) - num(a?.score, 0);
+      if (scoreDiff !== 0) return scoreDiff;
+      const valueA = a.assetType === 'pick' ? pickValue(a.pick, currentSeason) : playerValue(a.player);
+      const valueB = b.assetType === 'pick' ? pickValue(b.pick, currentSeason) : playerValue(b.player);
+      if (valueA !== valueB) return valueB - valueA;
+      return assetId(a).localeCompare(assetId(b));
+    });
+}
+
+export function capTradeBlockAssets(assets = [], limit = 3) {
+  return (Array.isArray(assets) ? assets : []).slice(0, Math.max(0, num(limit, 3)));
+}
+
+export function generateAITradeBlock(team, roster, context = {}, options = {}) {
+  const cfg = { ...DEFAULT_OPTIONS, ...options };
+  if (!team || !Array.isArray(roster) || roster.length === 0) return [];
+  if (context?.userTeamId != null && Number(team?.id) === Number(context.userTeamId)) return [];
+
+  const ranks = buildPositionRanks(roster);
+  const posture = context?.teamPosture ?? classifyTeamStrategicPosture(
+    { ...team, roster },
+    { currentSeason: context?.currentSeason ?? context?.year, phase: context?.phase },
+    context?.postureOptions ?? {},
+  );
+  const sharedContext = { ...context, teamPosture: posture, positionRanks: ranks };
+  const assets = [];
+
+  for (const player of roster) {
+    if (!player || Number(player?.teamId ?? team?.id) !== Number(team?.id)) continue;
+    const reason = classifyTradeBlockReason(player, team, roster, sharedContext, cfg);
+    if (!reason) continue;
+    assets.push({
+      assetType: 'player',
+      player,
+      playerId: player.id,
+      teamId: team.id,
+      reason: reason.label,
+      reasonKey: reason.key,
+      reasonTags: reason.tags,
+      score: reason.score,
+      value: playerValue(player),
+    });
+  }
+
+  const picks = Array.isArray(team?.picks) ? team.picks : [];
+  for (const pick of picks) {
+    if (!pick || pick.id == null || !isTeamPick(pick, team.id)) continue;
+    const reason = classifyTradeBlockReason({ assetType: 'pick', pick }, team, roster, sharedContext, cfg);
+    if (!reason) continue;
+    assets.push({
+      assetType: 'pick',
+      pick,
+      pickId: pick.id,
+      teamId: team.id,
+      reason: reason.label,
+      reasonKey: reason.key,
+      reasonTags: reason.tags,
+      score: reason.score,
+      value: pickValue(pick, context?.currentSeason ?? context?.year),
+    });
+  }
+
+  return capTradeBlockAssets(rankTradeBlockAssets(assets, context), cfg.maxBlockAssets);
+}
+
+function buildLeagueInput(leagueState = {}) {
+  const meta = leagueState?.meta ?? leagueState;
+  const teams = Array.isArray(leagueState?.teams) ? leagueState.teams : [];
+  const players = Array.isArray(leagueState?.players) ? leagueState.players : [];
+  return { meta, teams, players };
+}
+
+function rosterForTeam(players = [], teamId) {
+  return players.filter((player) => Number(player?.teamId) === Number(teamId));
+}
+
+function buildUserRequestCandidates(userTeam, userRoster, context, cfg) {
+  if (!userTeam || !Array.isArray(userRoster) || userRoster.length === 0) return [];
+  const ranks = buildPositionRanks(userRoster);
+  const candidates = [];
+  for (const player of userRoster) {
+    const rank = ranks.get(player?.id);
+    const isSurplus = rank ? rank.rank >= rank.starterCount : false;
+    if (!isSurplus) continue;
+    if (isCornerstone(player, cfg)) continue;
+    if (isInjured(player) && num(player?.ovr, 0) >= 80) continue;
+    if (num(player?.ovr, 0) < cfg.userSurplusOvrMin) continue;
+    candidates.push({
+      assetType: 'player',
+      player,
+      playerId: player.id,
+      pos: normalizePosition(player?.pos),
+      value: playerValue(player),
+      score: playerValue(player),
+    });
+  }
+  return rankTradeBlockAssets(candidates, context);
+}
+
+function selectUserAssetForAI(aiTeam, aiRoster, userCandidates, context) {
+  if (!aiTeam || !Array.isArray(aiRoster) || !Array.isArray(userCandidates)) return null;
+  const aiRanks = buildPositionRanks(aiRoster);
+  const needPositions = new Set();
+  for (const [pos, starterCount] of Object.entries(STARTER_COUNTS)) {
+    const playersAtPos = aiRoster
+      .filter((player) => normalizePosition(player?.pos) === pos)
+      .sort((a, b) => num(b?.ovr, 0) - num(a?.ovr, 0));
+    const starters = playersAtPos.slice(0, starterCount);
+    const avgStarter = starters.length
+      ? starters.reduce((sum, player) => sum + num(player?.ovr, 0), 0) / starters.length
+      : 0;
+    if (starters.length < starterCount || avgStarter < 74) needPositions.add(pos);
+  }
+
+  const needFit = userCandidates.find((candidate) => needPositions.has(candidate.pos));
+  if (needFit) return needFit;
+
+  return userCandidates.find((candidate) => {
+    const rank = aiRanks.get(candidate.playerId);
+    return !rank || rank.rank >= rank.starterCount || num(candidate?.player?.ovr, 0) >= 72;
+  }) ?? userCandidates[0] ?? null;
+}
+
+function pickSweetenerForTeam(team, currentSeason, targetGap) {
+  const picks = (Array.isArray(team?.picks) ? team.picks : [])
+    .filter((pick) => pick?.id != null && isTeamPick(pick, team?.id) && num(pick?.round, 8) >= 3)
+    .sort((a, b) => {
+      const valueDiff = pickValue(a, currentSeason) - pickValue(b, currentSeason);
+      if (valueDiff !== 0) return valueDiff;
+      return String(a.id).localeCompare(String(b.id));
+    });
+  return picks.find((pick) => pickValue(pick, currentSeason) >= targetGap * 0.65) ?? picks[0] ?? null;
+}
+
+function makeOffer({ aiTeam, userTeam, aiAsset, userAsset, week, season, currentSeason, teamsById, seed }) {
+  const offering = { playerIds: [], pickIds: [] };
+  const receiving = { playerIds: [], pickIds: [] };
+  const offeringPlayerSnapshots = [];
+  const receivingPlayerSnapshots = [];
+  const offeringPickSnapshots = [];
+  const receivingPickSnapshots = [];
+  const reasonTags = [...(aiAsset?.reasonTags ?? []), 'proactive_ai_offer'];
+
+  if (aiAsset.assetType === 'pick') {
+    offering.pickIds.push(aiAsset.pick.id);
+    const snapshot = summarizePick(aiAsset.pick, teamsById);
+    if (snapshot) offeringPickSnapshots.push(snapshot);
+  } else {
+    offering.playerIds.push(aiAsset.player.id);
+    const snapshot = summarizePlayer(aiAsset.player);
+    if (snapshot) offeringPlayerSnapshots.push(snapshot);
+  }
+
+  receiving.playerIds.push(userAsset.player.id);
+  const requestedSnapshot = summarizePlayer(userAsset.player);
+  if (requestedSnapshot) receivingPlayerSnapshots.push(requestedSnapshot);
+
+  const offer = {
+    id: `offer_${season}_${week}_${aiTeam.id}_${assetId(aiAsset).replace(':', '_')}_${userAsset.player.id}_${stableHash(seed).toString(36)}`,
+    week,
+    createdWeek: week,
+    season,
+    offeringTeamId: aiTeam.id,
+    offeringTeamAbbr: aiTeam.abbr,
+    offeringTeamName: aiTeam.name,
+    receivingTeamId: userTeam.id,
+    userTeamId: userTeam.id,
+    offeringDirection: aiAsset?.contextDirection ?? 'balanced',
+    offerType: 'proactive_ai_offer',
+    generatedBy: 'trade_block_v1',
+    urgency: reasonTags.includes('cap_burden') ? 'medium' : 'low',
+    stance: reasonTags.includes('cap_burden') ? 'Cap flexibility' : 'Roster balance',
+    reason: `${aiTeam.abbr ?? 'AI'} floated a conservative trade-block offer around ${aiAsset.reason ?? 'roster surplus'}.`,
+    reasonTags,
+    context: {
+      source: 'trade_block_v1',
+      aiAssetReason: aiAsset.reasonKey,
+      requestedUserAsset: userAsset.pos,
+    },
+    offering,
+    receiving,
+    offeringPickSnapshots,
+    receivingPickSnapshots,
+    offeringPlayerSnapshots,
+    receivingPlayerSnapshots,
+    offeringPlayerId: offering.playerIds[0] ?? null,
+    offeringPlayerName: offeringPlayerSnapshots[0]?.name ?? offeringPickSnapshots[0]?.label ?? 'Draft pick',
+    receivingPlayerId: userAsset.player.id,
+    receivingPlayerName: userAsset.player.name,
+    expiresAfterWeek: week + 2,
+    expiresPhase: 'regular',
+  };
+  offer.signature = buildOfferSignature(offer);
+  return offer;
+}
+
+function offerAssetIds(offer) {
+  return [
+    ...(offer?.offering?.playerIds ?? []).map((id) => `p:${id}`),
+    ...(offer?.offering?.pickIds ?? []).map((id) => `k:${id}`),
+    ...(offer?.receiving?.playerIds ?? []).map((id) => `p:${id}`),
+    ...(offer?.receiving?.pickIds ?? []).map((id) => `k:${id}`),
+  ];
+}
+
+export function pruneStaleInboundOffers(offers = [], leagueState = {}, userTeamId = null, options = {}) {
+  const { meta, teams, players } = buildLeagueInput(leagueState);
+  const week = num(meta?.currentWeek ?? meta?.week, 1);
+  const season = num(meta?.season ?? meta?.year, 1);
+  const phase = String(meta?.phase ?? 'regular');
+  const windowSnapshot = getTradeWindowSnapshot({
+    currentWeek: week,
+    week,
+    phase,
+    settings: meta?.settings,
+    commissionerMode: meta?.commissionerMode,
+  });
+  if (phase !== 'regular' || !tradeWindowAllowsOffers(windowSnapshot)) return [];
+
+  const teamsById = new Map((Array.isArray(teams) ? teams : []).map((team) => [Number(team?.id), team]));
+  const playersById = new Map((Array.isArray(players) ? players : []).map((player) => [Number(player?.id), player]));
+  const picksById = new Map();
+  for (const team of teamsById.values()) {
+    for (const pick of Array.isArray(team?.picks) ? team.picks : []) {
+      if (pick?.id != null) picksById.set(String(pick.id), pick);
+    }
+  }
+
+  const keep = [];
+  const seenIds = new Set();
+  const seenSignatures = new Set();
+  for (const offer of Array.isArray(offers) ? offers : []) {
+    if (!offer) continue;
+    if (offer.season != null && num(offer.season, season) !== season) continue;
+    if (offer.expiresPhase && String(offer.expiresPhase) !== phase) continue;
+    const expiresAfterWeek = num(offer.expiresAfterWeek ?? (offer.week ?? week) + 2, week + 2);
+    if (expiresAfterWeek < week) continue;
+
+    const aiTeamId = num(offer.offeringTeamId, NaN);
+    const userId = num(userTeamId ?? offer.userTeamId ?? offer.receivingTeamId, NaN);
+    if (!Number.isFinite(aiTeamId) || !Number.isFinite(userId)) continue;
+    if (!teamsById.has(aiTeamId) || !teamsById.has(userId)) continue;
+
+    const aiPlayersValid = (offer?.offering?.playerIds ?? []).every((id) => Number(playersById.get(Number(id))?.teamId) === aiTeamId);
+    const userPlayersValid = (offer?.receiving?.playerIds ?? []).every((id) => Number(playersById.get(Number(id))?.teamId) === userId);
+    const aiPicksValid = (offer?.offering?.pickIds ?? []).every((id) => Number(picksById.get(String(id))?.currentOwner ?? aiTeamId) === aiTeamId);
+    const userPicksValid = (offer?.receiving?.pickIds ?? []).every((id) => Number(picksById.get(String(id))?.currentOwner ?? userId) === userId);
+    if (!aiPlayersValid || !userPlayersValid || !aiPicksValid || !userPicksValid) continue;
+
+    const signature = offer.signature ?? buildOfferSignature(offer);
+    const stableId = offer.id ?? `offer_${signature}_${offer.week ?? week}`;
+    if (seenIds.has(stableId) || seenSignatures.has(signature)) continue;
+    seenIds.add(stableId);
+    seenSignatures.add(signature);
+    keep.push({ ...offer, id: stableId, signature });
+  }
+
+  return keep.slice(0, Math.max(0, num(options.maxActiveOffers ?? 6, 6)));
+}
+
+export function generateInboundOffersToUser(leagueState = {}, userTeamId, options = {}) {
+  const cfg = { ...DEFAULT_OPTIONS, ...options };
+  const { meta, teams, players } = buildLeagueInput(leagueState);
+  const userId = num(userTeamId ?? meta?.userTeamId, NaN);
+  const week = num(meta?.currentWeek ?? meta?.week, 1);
+  const season = num(meta?.season ?? meta?.year, 1);
+  const phase = String(meta?.phase ?? 'regular');
+  if (!Number.isFinite(userId) || phase !== 'regular') return [];
+
+  const windowSnapshot = getTradeWindowSnapshot({
+    currentWeek: week,
+    week,
+    phase,
+    settings: meta?.settings,
+    commissionerMode: meta?.commissionerMode,
+  });
+  if (!tradeWindowAllowsOffers(windowSnapshot)) return [];
+
+  const existingOffers = pruneStaleInboundOffers(
+    options.existingOffers ?? meta?.incomingTradeOffers ?? [],
+    { meta, teams, players },
+    userId,
+    { maxActiveOffers: 6 },
+  );
+  if (existingOffers.length >= cfg.maxActiveOffers) return [];
+
+  const teamsById = new Map(teams.map((team) => [Number(team?.id), team]));
+  const userTeam = teamsById.get(userId);
+  if (!userTeam) return [];
+
+  const currentSeason = num(meta?.year ?? meta?.season, season);
+  const context = { userTeamId: userId, currentSeason, year: currentSeason, week, phase };
+  const userRoster = rosterForTeam(players, userId);
+  const userCandidates = buildUserRequestCandidates(userTeam, userRoster, context, cfg);
+  if (userCandidates.length === 0) return [];
+
+  const usedAssets = new Set(existingOffers.flatMap(offerAssetIds));
+  const existingSignatures = new Set(existingOffers.map((offer) => offer.signature ?? buildOfferSignature(offer)));
+  const offers = [];
+  const sortedAiTeams = teams
+    .filter((team) => Number(team?.id) !== userId)
+    .slice()
+    .sort((a, b) => Number(a?.id) - Number(b?.id));
+
+  for (const aiTeam of sortedAiTeams) {
+    if (offers.length >= cfg.maxGeneratedOffersPerWeek) break;
+    const gateSeed = `${cfg.seed}|${season}|${week}|${aiTeam?.id}|gate`;
+    if (seededRoll(gateSeed) >= cfg.rngGateChance) continue;
+
+    const aiRoster = rosterForTeam(players, aiTeam.id);
+    const block = generateAITradeBlock(aiTeam, aiRoster, context, cfg)
+      .filter((asset) => !usedAssets.has(asset.assetType === 'pick' ? `k:${asset.pickId}` : `p:${asset.playerId}`));
+    if (block.length === 0) continue;
+
+    for (const aiAsset of block) {
+      const userAsset = selectUserAssetForAI(aiTeam, aiRoster, userCandidates, context);
+      if (!userAsset || usedAssets.has(`p:${userAsset.playerId}`)) continue;
+      if (Number(userAsset?.player?.teamId) !== userId) continue;
+      if (aiAsset.assetType !== 'pick' && Number(aiAsset?.player?.teamId) !== Number(aiTeam.id)) continue;
+
+      const aiValue = aiAsset.value ?? (aiAsset.assetType === 'pick' ? pickValue(aiAsset.pick, currentSeason) : playerValue(aiAsset.player));
+      const userValue = userAsset.value ?? playerValue(userAsset.player);
+      let adjustedAiAsset = aiAsset;
+      if (aiValue < userValue * 0.82) {
+        const sweetener = pickSweetenerForTeam(aiTeam, currentSeason, userValue - aiValue);
+        if (!sweetener) continue;
+        adjustedAiAsset = {
+          ...aiAsset,
+          value: aiValue + pickValue(sweetener, currentSeason),
+          extraPick: sweetener,
+          reasonTags: [...(aiAsset.reasonTags ?? []), 'pick_sweetener'],
+        };
+      }
+      if ((adjustedAiAsset.value ?? aiValue) < userValue * 0.82 || (adjustedAiAsset.value ?? aiValue) > userValue * 1.45) continue;
+
+      const offer = makeOffer({
+        aiTeam,
+        userTeam,
+        aiAsset: adjustedAiAsset,
+        userAsset,
+        week,
+        season,
+        currentSeason,
+        teamsById,
+        seed: `${cfg.seed}|${season}|${week}|${aiTeam.id}|${assetId(aiAsset)}|${userAsset.playerId}`,
+      });
+      if (adjustedAiAsset.extraPick?.id != null && !offer.offering.pickIds.includes(adjustedAiAsset.extraPick.id)) {
+        offer.offering.pickIds.push(adjustedAiAsset.extraPick.id);
+        const snapshot = summarizePick(adjustedAiAsset.extraPick, teamsById);
+        if (snapshot) offer.offeringPickSnapshots.push(snapshot);
+        offer.signature = buildOfferSignature(offer);
+      }
+      if (existingSignatures.has(offer.signature)) continue;
+      offers.push(offer);
+      usedAssets.add(`p:${userAsset.playerId}`);
+      if (aiAsset.assetType === 'pick') usedAssets.add(`k:${aiAsset.pickId}`);
+      else usedAssets.add(`p:${aiAsset.playerId}`);
+      existingSignatures.add(offer.signature);
+      break;
+    }
+  }
+
+  return offers.slice(0, Math.max(0, cfg.maxGeneratedOffersPerWeek));
+}

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -115,7 +115,8 @@ import { processOffseasonEvolution, processWeeklyEvolution } from '../core/progr
 import { buildTeamDevelopmentFocusMap as buildCanonicalDevelopmentFocusMap } from './developmentFocus.js';
 import { derivePlayerVisibleRatingsPatch } from './playerDerivedRatings.js';
 import { evaluateRetirements }     from '../core/retirement-system.js';
-import { runAIToAITrades, generateAITradeProposalsForUser, evaluateCounterOffer } from '../core/trade-logic.js';
+import { runAIToAITrades, evaluateCounterOffer } from '../core/trade-logic.js';
+import { generateInboundOffersToUser } from '../core/trades/tradeBlockGenerator.js';
 import { processSeasonRecords, createEmptyRecords, getMostPlayedTeam } from '../core/records.js';
 import { ensureLeagueMemoryMeta, buildSeasonArchiveSummary, updateFranchiseHistory, updateRecordBook, evaluateHallOfFameCandidate, addHallOfFameClass, buildSeasonStorylineSnapshot, buildHallOfFameInducteeRow, syncHallOfFameAfterRecordBook } from '../core/league-memory.js';
 import { buildPlayerSeasonStatsArchiveRows } from '../core/playerSeasonStatsArchive.js';
@@ -929,12 +930,20 @@ function pruneIncomingTradeOffers(metaObj) {
   const week = Number(metaObj?.currentWeek ?? 1);
   const season = Number(metaObj?.season ?? metaObj?.year ?? 1);
   const offers = Array.isArray(metaObj?.incomingTradeOffers) ? metaObj.incomingTradeOffers : [];
+  const deadline = getTradeDeadlineSnapshot(metaObj);
+  if (
+    String(metaObj?.phase ?? 'regular') !== 'regular' ||
+    !isTradeWindowOpen({ week: deadline.currentWeek, phase: deadline.phase, settings: metaObj?.settings, commissionerMode: deadline.canOverride })
+  ) {
+    return [];
+  }
   const normalized = [];
   const seenIds = new Set();
   const seenSignatures = new Set();
   for (const offer of offers) {
     if (!offer) continue;
     if (offer.season != null && Number(offer.season) !== season) continue;
+    if (offer.expiresPhase != null && String(offer.expiresPhase) !== String(metaObj?.phase ?? 'regular')) continue;
     const expiresAfterWeek = Number(offer.expiresAfterWeek ?? (offer.week ?? week) + 2);
     if (expiresAfterWeek < week) continue;
     if (!isOfferStillValid(offer, metaObj?.userTeamId)) continue;
@@ -2890,13 +2899,15 @@ async function handleAdvanceWeek(payload, id) {
     try {
       await runAIToAITrades();
 
-      // Also generate trade proposals for the user
+      // Low-frequency proactive AI inbound offers. This is bounded to one
+      // pass over AI teams per weekly advance and never runs from view-state builds.
       const latestMeta = ensureDynastyMeta(cache.getMeta());
       const existingOffers = pruneIncomingTradeOffers(latestMeta);
-      const tradeProposals = generateAITradeProposalsForUser({
-        existingOffers,
-        offerMemory: latestMeta?.tradeOfferMemory ?? {},
-      });
+      const tradeProposals = generateInboundOffersToUser({
+        meta: latestMeta,
+        teams: cache.getAllTeams(),
+        players: cache.getAllPlayers(),
+      }, latestMeta?.userTeamId, { existingOffers });
       if (tradeProposals.length > 0) {
         const freshOffers = tradeProposals.filter((offer) => {
           const sig = buildOfferSignature(offer);

--- a/tests/unit/tradeBlockAndInboundOffers.test.js
+++ b/tests/unit/tradeBlockAndInboundOffers.test.js
@@ -1,0 +1,235 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  capTradeBlockAssets,
+  classifyTradeBlockReason,
+  generateAITradeBlock,
+  generateInboundOffersToUser,
+  pruneStaleInboundOffers,
+  rankTradeBlockAssets,
+} from '../../src/core/trades/tradeBlockGenerator.js';
+import { TEAM_STRATEGIC_POSTURE } from '../../src/core/trades/teamStrategicDirection.js';
+
+const p = (id, teamId, pos, ovr, age = 26, baseAnnual = 3, extra = {}) => ({
+  id,
+  teamId,
+  name: `${pos}${id}`,
+  pos,
+  ovr,
+  potential: extra.potential ?? ovr,
+  age,
+  contract: { baseAnnual, yearsTotal: 2, yearsRemaining: 1 },
+  ...extra,
+});
+
+const team = (id, abbr, extra = {}) => ({
+  id,
+  abbr,
+  name: `${abbr} Team`,
+  wins: 2,
+  losses: 8,
+  ties: 0,
+  capRoom: 10,
+  picks: [],
+  ...extra,
+});
+
+function makeLeague(overrides = {}) {
+  const userTeam = team(1, 'USR', {
+    wins: 7,
+    losses: 3,
+    capRoom: 18,
+    picks: [{ id: 'u-4', round: 4, season: 2027, currentOwner: 1, originalOwner: 1 }],
+  });
+  const aiTeam = team(2, 'AI', {
+    wins: 2,
+    losses: 8,
+    capRoom: -2,
+    picks: [{ id: 'ai-4', round: 4, season: 2027, currentOwner: 2, originalOwner: 2 }],
+  });
+  const players = [
+    p(101, 1, 'QB', 82, 27, 10),
+    p(102, 1, 'RB', 82, 25, 6),
+    p(103, 1, 'RB', 78, 26, 5),
+    p(104, 1, 'RB', 74, 27, 4),
+    p(105, 1, 'WR', 82, 26, 7),
+    p(201, 2, 'QB', 74, 29, 8),
+    p(202, 2, 'WR', 78, 31, 14),
+    p(203, 2, 'WR', 72, 25, 2),
+  ];
+  return {
+    meta: {
+      phase: 'regular',
+      currentWeek: 4,
+      year: 2027,
+      season: 2027,
+      userTeamId: 1,
+      settings: { tradeDeadlineWeek: 9 },
+      incomingTradeOffers: [],
+      ...overrides.meta,
+    },
+    teams: overrides.teams ?? [userTeam, aiTeam],
+    players: overrides.players ?? players,
+  };
+}
+
+describe('trade block generation', () => {
+  it('rebuilder blocks an aging expensive veteran', () => {
+    const roster = [p(1, 2, 'WR', 80, 31, 15), p(2, 2, 'WR', 76, 24, 2), p(3, 2, 'QB', 75, 27, 8)];
+    const block = generateAITradeBlock(team(2, 'AI'), roster, {
+      userTeamId: 1,
+      phase: 'regular',
+      currentSeason: 2027,
+      teamPosture: TEAM_STRATEGIC_POSTURE.REBUILDER,
+    });
+    expect(block.map((asset) => asset.playerId)).toContain(1);
+    expect(block[0].reasonTags).toContain('rebuilder');
+  });
+
+  it('rebuilder protects young upside players', () => {
+    const roster = [p(1, 2, 'WR', 78, 23, 2, { potential: 88 }), p(2, 2, 'WR', 74, 31, 13)];
+    const block = generateAITradeBlock(team(2, 'AI'), roster, {
+      userTeamId: 1,
+      phase: 'regular',
+      currentSeason: 2027,
+      teamPosture: TEAM_STRATEGIC_POSTURE.REBUILDER,
+    });
+    expect(block.map((asset) => asset.playerId)).not.toContain(1);
+  });
+
+  it('contender does not block a key starter', () => {
+    const roster = [p(1, 2, 'WR', 84, 27, 9), p(2, 2, 'WR', 82, 27, 8), p(3, 2, 'WR', 80, 26, 7)];
+    const reason = classifyTradeBlockReason(roster[0], team(2, 'AI', { wins: 8, losses: 2 }), roster, {
+      userTeamId: 1,
+      teamPosture: TEAM_STRATEGIC_POSTURE.CONTENDER,
+    });
+    const block = generateAITradeBlock(team(2, 'AI', { wins: 8, losses: 2 }), roster, {
+      userTeamId: 1,
+      teamPosture: TEAM_STRATEGIC_POSTURE.CONTENDER,
+    });
+    expect(reason).toBeNull();
+    expect(block.map((asset) => asset.playerId)).not.toContain(1);
+  });
+
+  it('cap-restricted team identifies high cap-hit burden', () => {
+    const roster = [p(1, 2, 'TE', 77, 29, 15), p(2, 2, 'TE', 74, 24, 2)];
+    const block = generateAITradeBlock(team(2, 'AI', { capRoom: -4 }), roster, {
+      userTeamId: 1,
+      financialPosture: 'INSOLVENT',
+      teamPosture: TEAM_STRATEGIC_POSTURE.NEUTRAL,
+    });
+    expect(block[0]?.playerId).toBe(1);
+    expect(block[0]?.reasonTags).toContain('cap_burden');
+  });
+
+  it('caps and ranks at three assets', () => {
+    const assets = rankTradeBlockAssets([
+      { assetType: 'player', player: p(1, 2, 'WR', 74), playerId: 1, score: 20 },
+      { assetType: 'player', player: p(2, 2, 'WR', 75), playerId: 2, score: 90 },
+      { assetType: 'player', player: p(3, 2, 'WR', 76), playerId: 3, score: 60 },
+      { assetType: 'player', player: p(4, 2, 'WR', 77), playerId: 4, score: 50 },
+    ]);
+    expect(capTradeBlockAssets(assets, 3).map((asset) => asset.playerId)).toEqual([2, 3, 4]);
+  });
+
+  it('returns empty safely for missing data and does not mutate inputs', () => {
+    const roster = [p(1, 2, 'WR', 80, 31, 15), p(2, 2, 'WR', 76, 24, 2)];
+    const teamInput = team(2, 'AI');
+    const before = JSON.stringify({ roster, teamInput });
+    expect(generateAITradeBlock(null, roster)).toEqual([]);
+    generateAITradeBlock(teamInput, roster, { userTeamId: 1, teamPosture: TEAM_STRATEGIC_POSTURE.REBUILDER });
+    expect(JSON.stringify({ roster, teamInput })).toBe(before);
+  });
+});
+
+describe('proactive inbound offers', () => {
+  it('deterministic RNG gate limits generated attempts', () => {
+    const league = makeLeague();
+    const closedGate = generateInboundOffersToUser(league, 1, { rngGateChance: 0, maxGeneratedOffersPerWeek: 2 });
+    const openGateA = generateInboundOffersToUser(league, 1, { rngGateChance: 1, maxGeneratedOffersPerWeek: 2 });
+    const openGateB = generateInboundOffersToUser(league, 1, { rngGateChance: 1, maxGeneratedOffersPerWeek: 2 });
+    expect(closedGate).toEqual([]);
+    expect(openGateA).toEqual(openGateB);
+    expect(openGateA.length).toBeGreaterThan(0);
+  });
+
+  it('enforces max generated offers per week', () => {
+    const extraTeam = team(3, 'AI3', { capRoom: -3 });
+    const league = makeLeague({
+      teams: [...makeLeague().teams, extraTeam],
+      players: [...makeLeague().players, p(301, 3, 'WR', 78, 31, 14), p(302, 3, 'QB', 74, 29, 8)],
+    });
+    const offers = generateInboundOffersToUser(league, 1, { rngGateChance: 1, maxGeneratedOffersPerWeek: 1 });
+    expect(offers).toHaveLength(1);
+  });
+
+  it('does not generate when deadline is closed or inbox is full', () => {
+    const deadlineClosed = makeLeague({ meta: { currentWeek: 10 } });
+    expect(generateInboundOffersToUser(deadlineClosed, 1, { rngGateChance: 1 })).toEqual([]);
+
+    const fullInboxLeague = makeLeague();
+    const existing = generateInboundOffersToUser(fullInboxLeague, 1, { rngGateChance: 1 })[0];
+    const withInbox = { ...fullInboxLeague, meta: { ...fullInboxLeague.meta, incomingTradeOffers: [existing] } };
+    expect(generateInboundOffersToUser(withInbox, 1, { rngGateChance: 1, maxActiveOffers: 1 })).toEqual([]);
+  });
+
+  it('uses the existing incoming-offer shape and correct asset ownership', () => {
+    const league = makeLeague();
+    const [offer] = generateInboundOffersToUser(league, 1, { rngGateChance: 1 });
+    expect(offer).toMatchObject({
+      offeringTeamId: 2,
+      receivingTeamId: 1,
+      userTeamId: 1,
+      offerType: 'proactive_ai_offer',
+      generatedBy: 'trade_block_v1',
+      offering: expect.any(Object),
+      receiving: expect.any(Object),
+      createdWeek: 4,
+      expiresAfterWeek: 6,
+    });
+    expect(offer.offering.playerIds).toContain(202);
+    expect(offer.receiving.playerIds).toContain(104);
+    for (const id of offer.offering.playerIds) {
+      expect(league.players.find((player) => player.id === id)?.teamId).toBe(2);
+    }
+    for (const id of offer.receiving.playerIds) {
+      expect(league.players.find((player) => player.id === id)?.teamId).toBe(1);
+    }
+  });
+
+  it('prunes stale invalid asset offers and duplicate ids', () => {
+    const league = makeLeague();
+    const [offer] = generateInboundOffersToUser(league, 1, { rngGateChance: 1 });
+    const invalid = { ...offer, id: 'invalid', offering: { ...offer.offering, playerIds: [999] } };
+    const duplicate = { ...offer };
+    const pruned = pruneStaleInboundOffers([offer, duplicate, invalid], league, 1);
+    expect(pruned).toHaveLength(1);
+    expect(pruned[0].id).toBe(offer.id);
+  });
+
+  it('does not assign user assets to the AI side', () => {
+    const league = makeLeague();
+    const [offer] = generateInboundOffersToUser(league, 1, { rngGateChance: 1 });
+    expect(offer.offering.playerIds).not.toContain(104);
+    expect(offer.receiving.playerIds).not.toContain(202);
+  });
+
+  it('appends safely, avoids duplicate regeneration, and clears at deadline or phase transition', () => {
+    const league = makeLeague();
+    const generated = generateInboundOffersToUser(league, 1, { rngGateChance: 1 });
+    const incomingTradeOffers = [...generated, ...league.meta.incomingTradeOffers].slice(0, 6);
+    expect(incomingTradeOffers).toHaveLength(1);
+
+    const withExisting = { ...league, meta: { ...league.meta, incomingTradeOffers } };
+    expect(generateInboundOffersToUser(withExisting, 1, { rngGateChance: 1 })).toEqual([]);
+    expect(pruneStaleInboundOffers(incomingTradeOffers, { ...league, meta: { ...league.meta, currentWeek: 10 } }, 1)).toEqual([]);
+    expect(pruneStaleInboundOffers(incomingTradeOffers, { ...league, meta: { ...league.meta, phase: 'offseason' } }, 1)).toEqual([]);
+  });
+
+  it('does not use raw Math.random in the new module', () => {
+    const modulePath = path.resolve(process.cwd(), 'src/core/trades/tradeBlockGenerator.js');
+    const source = fs.readFileSync(modulePath, 'utf8');
+    expect(source).not.toContain('Math.random');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `tradeBlockGenerator.js` with conservative AI trade-block asset selection and deterministic proactive inbound offer generation.
- Reuse existing `meta.incomingTradeOffers` storage and incoming-offer shape; no schema/version, protocol, trade execution, pick ownership, or UI changes.
- Wire weekly generation after the AI-to-AI trade pass only during regular-season trade windows, with inbox caps, deterministic gating, duplicate suppression, and stale-offer pruning.

## Audit Notes
- Existing storage is `meta.incomingTradeOffers`, normalized by `saveSchema` and consumed by Trade Center / Trade Workspace.
- Existing handlers are `handleAcceptIncomingTrade`, `handleRejectIncomingTrade`, and `handleCounterIncomingTrade` in the worker.
- Existing stale cleanup was `pruneIncomingTradeOffers`; this PR tightens it for phase/deadline expiry and `expiresPhase`.

## Validation
- `npm.cmd run test:unit` passed: 225 files, 1820 tests.
- `npm.cmd run build` passed with the existing Vite large-chunk warning.
- `npm.cmd run test:soak` passed: 7 files, 85 tests.
- `npx.cmd playwright test tests/e2e/fresh_franchise_first_week_smoke.spec.js` passed: 1 test.
