### PR TITLE
Add AI trade block generation and incoming offer notifications

### DIFF
--- a/src/ui/components/TradeBlockPanel.jsx
+++ b/src/ui/components/TradeBlockPanel.jsx
@@ -1,23 +1,186 @@
 import React, { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { normalizeManagement } from "../utils/playerManagement.js";
+import { generateAITradeBlock } from "../../core/trades/tradeBlockGenerator.js";
 
-export default function TradeBlockPanel({ roster, onRemove }) {
-  if (!roster || !Array.isArray(roster)) {
-    return null;
-  }
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
-  const [open, setOpen] = useState(true);
-  const blockPlayers = useMemo(
-    () => roster.filter((player) => {
-      const m = normalizeManagement(player);
-      return player?.onTradeBlock === true || m.tradeStatus === 'actively_shopping' || m.contractPlan.includes('trade_candidate');
-    }),
-    [roster],
+function fmtCapHit(player) {
+  const hit = Number(player?.contract?.baseAnnual ?? player?.capHit ?? player?.baseAnnual ?? 0);
+  return Number.isFinite(hit) ? `$${hit.toFixed(1)}M` : "—";
+}
+
+function ovrColorOf(ovr) {
+  if (ovr >= 88) return "var(--success)";
+  if (ovr >= 78) return "#0A84FF";
+  if (ovr >= 68) return "#FF9F0A";
+  return "var(--danger)";
+}
+
+function inferPostureLabel(assets) {
+  const allTags = assets.flatMap((a) => a.reasonTags ?? []);
+  if (allTags.some((t) => t === "cap_burden" || t === "cap_restricted")) return "Cap Strapped";
+  if (allTags.some((t) => t === "rebuilder" || t === "aging_veteran")) return "Rebuilding";
+  if (allTags.some((t) => t === "contender" || t === "redundant_depth")) return "Contending";
+  return "Balanced";
+}
+
+// ── League Block sub-components ───────────────────────────────────────────────
+
+function LeagueBlockRow({ player }) {
+  if (!player) return null;
+  const ovr = player.ovr ?? 0;
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "36px 30px 1fr auto auto",
+        gap: "var(--space-2)",
+        alignItems: "center",
+        padding: "var(--space-2) var(--space-3)",
+        borderBottom: "1px solid var(--hairline)",
+      }}
+    >
+      <span style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 600 }}>
+        {player.pos ?? "—"}
+      </span>
+      <span
+        style={{
+          fontWeight: 800,
+          fontSize: "var(--text-xs)",
+          color: ovrColorOf(ovr),
+          textAlign: "center",
+        }}
+      >
+        {ovr || "—"}
+      </span>
+      <span
+        style={{
+          fontWeight: 600,
+          fontSize: "var(--text-xs)",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {player.name ?? "Unknown"}
+      </span>
+      <span style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", whiteSpace: "nowrap" }}>
+        Age&nbsp;{player.age ?? "—"}
+      </span>
+      <span style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)", whiteSpace: "nowrap" }}>
+        {fmtCapHit(player)}/yr
+      </span>
+    </div>
   );
+}
+
+function LeagueBlockTeamGroup({ team, assets }) {
+  const postureLabel = inferPostureLabel(assets);
+  const playerAssets = assets.filter((a) => a.assetType === "player");
+  const pickAssets = assets.filter((a) => a.assetType === "pick");
+  return (
+    <div
+      style={{
+        border: "1px solid var(--hairline)",
+        borderRadius: "var(--radius-md)",
+        overflow: "hidden",
+        marginBottom: "var(--space-2)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "var(--space-2) var(--space-3)",
+          background: "var(--surface-strong)",
+          fontSize: "var(--text-xs)",
+          fontWeight: 700,
+          gap: "var(--space-2)",
+          flexWrap: "wrap",
+        }}
+      >
+        <span>{team?.name ?? team?.abbr ?? "AI Team"}</span>
+        <span style={{ color: "var(--text-muted)", fontWeight: 400 }}>
+          {postureLabel} · {assets.length} on block
+        </span>
+      </div>
+      {playerAssets.map((asset) => (
+        <LeagueBlockRow key={`player-${asset.playerId}`} player={asset.player} />
+      ))}
+      {pickAssets.map((asset) => (
+        <div
+          key={`pick-${asset.pickId}`}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "var(--space-2)",
+            padding: "var(--space-2) var(--space-3)",
+            borderBottom: "1px solid var(--hairline)",
+            fontSize: "var(--text-xs)",
+          }}
+        >
+          <span style={{ color: "var(--text-muted)", fontWeight: 600 }}>PICK</span>
+          <span style={{ fontWeight: 600 }}>
+            {asset.pick?.season ? `${asset.pick.season} ` : ""}Round {asset.pick?.round ?? "?"}
+          </span>
+          <span style={{ color: "var(--text-subtle)" }}>{asset.reason}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export default function TradeBlockPanel({ roster, onRemove, league, userTeamId }) {
+  const [open, setOpen] = useState(true);
+  const [leagueBlockOpen, setLeagueBlockOpen] = useState(false);
+
+  const blockPlayers = useMemo(() => {
+    if (!Array.isArray(roster)) return [];
+    return roster.filter((player) => {
+      const m = normalizeManagement(player);
+      return (
+        player?.onTradeBlock === true ||
+        m.tradeStatus === "actively_shopping" ||
+        m.contractPlan.includes("trade_candidate")
+      );
+    });
+  }, [roster]);
+
+  const leagueBlockData = useMemo(() => {
+    if (!league || !leagueBlockOpen) return [];
+    const allTeams = Array.isArray(league?.teams) ? league.teams : [];
+    const uid = userTeamId ?? league?.userTeamId;
+    const context = {
+      userTeamId: uid,
+      currentSeason: league?.year ?? league?.season ?? 0,
+      phase: league?.phase ?? "regular",
+    };
+    const result = [];
+    for (const team of allTeams) {
+      if (Number(team?.id) === Number(uid)) continue;
+      const teamRoster = Array.isArray(league?.players)
+        ? league.players.filter((p) => Number(p?.teamId) === Number(team.id))
+        : Array.isArray(team?.roster)
+          ? team.roster
+          : [];
+      const assets = generateAITradeBlock(team, teamRoster, context);
+      if (assets.length > 0) result.push({ team, assets });
+    }
+    return result;
+  }, [league, userTeamId, leagueBlockOpen]);
+
+  if (!Array.isArray(roster)) return null;
 
   return (
-    <div className="card" style={{ marginBottom: "var(--space-4)", padding: "var(--space-4) var(--space-5)" }}>
+    <div
+      className="card"
+      style={{ marginBottom: "var(--space-4)", padding: "var(--space-4) var(--space-5)" }}
+    >
+      {/* ── User's Trade Block ── */}
       <button
         onClick={() => setOpen((prev) => !prev)}
         style={{
@@ -35,13 +198,17 @@ export default function TradeBlockPanel({ roster, onRemove }) {
         }}
       >
         <span>Trade Block ({blockPlayers.length})</span>
-        <span style={{ color: "var(--text-muted)", fontSize: "var(--text-xs)" }}>{open ? "Hide" : "Show"}</span>
+        <span style={{ color: "var(--text-muted)", fontSize: "var(--text-xs)" }}>
+          {open ? "Hide" : "Show"}
+        </span>
       </button>
 
       {open && (
         <div style={{ marginTop: "var(--space-3)" }}>
           {blockPlayers.length === 0 ? (
-            <div style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)" }}>No players on the trade block.</div>
+            <div style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)" }}>
+              No players on the trade block.
+            </div>
           ) : (
             <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2)" }}>
               {blockPlayers.map((player) => (
@@ -58,9 +225,17 @@ export default function TradeBlockPanel({ roster, onRemove }) {
                   }}
                 >
                   <span style={{ fontWeight: 600 }}>{player?.name ?? "Unknown"}</span>
-                  <span style={{ color: "var(--text-muted)", fontSize: "var(--text-xs)" }}>{player?.pos ?? "—"}</span>
-                  <span style={{ color: "var(--text-muted)", fontSize: "var(--text-xs)" }}>OVR {player?.ovr ?? "—"} · Age {player?.age ?? "—"}</span>
-                  <Button className="btn" onClick={() => player?.id && onRemove?.(player.id)} style={{ fontSize: "var(--text-xs)", padding: "2px 8px" }}>
+                  <span style={{ color: "var(--text-muted)", fontSize: "var(--text-xs)" }}>
+                    {player?.pos ?? "—"}
+                  </span>
+                  <span style={{ color: "var(--text-muted)", fontSize: "var(--text-xs)" }}>
+                    OVR {player?.ovr ?? "—"} · Age {player?.age ?? "—"}
+                  </span>
+                  <Button
+                    className="btn"
+                    onClick={() => player?.id && onRemove?.(player.id)}
+                    style={{ fontSize: "var(--text-xs)", padding: "2px 8px" }}
+                  >
                     Remove
                   </Button>
                 </div>
@@ -69,6 +244,65 @@ export default function TradeBlockPanel({ roster, onRemove }) {
           )}
         </div>
       )}
+
+      {/* ── League Trade Block (read-only, generated at read-time) ── */}
+      {league ? (
+        <div style={{ marginTop: "var(--space-3)", borderTop: "1px solid var(--hairline)", paddingTop: "var(--space-3)" }}>
+          <button
+            onClick={() => setLeagueBlockOpen((prev) => !prev)}
+            aria-expanded={leagueBlockOpen}
+            data-testid="league-block-toggle"
+            style={{
+              width: "100%",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              background: "transparent",
+              border: "none",
+              color: "var(--text)",
+              cursor: "pointer",
+              padding: 0,
+              fontWeight: 700,
+              fontSize: "var(--text-sm)",
+            }}
+          >
+            <span>League Block</span>
+            <span style={{ color: "var(--text-muted)", fontSize: "var(--text-xs)" }}>
+              {leagueBlockOpen ? "Hide" : "Show · generated at read-time"}
+            </span>
+          </button>
+
+          {leagueBlockOpen && (
+            <div style={{ marginTop: "var(--space-3)" }} data-testid="league-block-content">
+              {leagueBlockData.length === 0 ? (
+                <div style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)" }}>
+                  No AI teams have assets available on the trade block right now.
+                </div>
+              ) : (
+                <div>
+                  <div
+                    style={{
+                      fontSize: "var(--text-xs)",
+                      color: "var(--text-subtle)",
+                      marginBottom: "var(--space-3)",
+                      display: "flex",
+                      justifyContent: "space-between",
+                      flexWrap: "wrap",
+                      gap: 4,
+                    }}
+                  >
+                    <span>{leagueBlockData.length} team(s) with available assets</span>
+                    <span>OVR · Name · Age · Cap/yr</span>
+                  </div>
+                  {leagueBlockData.map(({ team, assets }) => (
+                    <LeagueBlockTeamGroup key={team.id} team={team} assets={assets} />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/ui/components/TradeCenter.jsx
+++ b/src/ui/components/TradeCenter.jsx
@@ -774,7 +774,7 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
       ) : (
         <>
           {Array.isArray(myRoster) && myRoster.length > 0 && (
-            <TradeBlockPanel roster={myRoster} onRemove={handleTradeBlockRemove} />
+            <TradeBlockPanel roster={myRoster} onRemove={handleTradeBlockRemove} league={league} userTeamId={myTeamId} />
           )}
           {/* Value + cap panel (original) */}
           {hasSelection && (

--- a/src/ui/components/WeeklyHub.jsx
+++ b/src/ui/components/WeeklyHub.jsx
@@ -147,6 +147,7 @@ export default function WeeklyHub({ league, onNavigate, onAdvanceWeek, busy, sim
 
   const topOffer = weeklyContext?.incomingOffers?.[0] ?? null;
   const topOfferSummary = topOffer ? buildIncomingOfferPresentation({ offer: topOffer, league, userTeamId: league?.userTeamId }) : null;
+  const incomingOfferCount = Array.isArray(league?.incomingTradeOffers) ? league.incomingTradeOffers.length : 0;
 
   const handleAdvanceOrGate = () => {
     if (gate.shouldWarn) {
@@ -228,6 +229,34 @@ export default function WeeklyHub({ league, onNavigate, onAdvanceWeek, busy, sim
           <strong>Advance blocked: </strong>
           {gate.riskItems.find((i) => i.severity === "danger")?.label ?? "Resolve blockers before advancing."}
           <Button size="sm" variant="ghost" style={{ marginLeft: 8 }} onClick={() => setShowGate(true)}>Review</Button>
+        </div>
+      ) : null}
+
+      {/* ── Incoming Trade Offer Notification ───────────────────── */}
+      {incomingOfferCount > 0 ? (
+        <div
+          className="weekly-readiness-banner tone-warning"
+          role="status"
+          aria-live="polite"
+          data-testid="trade-offer-banner"
+          style={{ justifyContent: "space-between", flexWrap: "wrap", gap: 8 }}
+        >
+          <span>
+            <strong>
+              {incomingOfferCount === 1
+                ? "You have 1 pending trade offer"
+                : `You have ${incomingOfferCount} pending trade offers`}
+            </strong>
+            {" — review before advancing."}
+          </span>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => onNavigate?.("Trade Center")}
+            style={{ whiteSpace: "nowrap" }}
+          >
+            Open Trade Center
+          </Button>
         </div>
       ) : null}
 

--- a/src/ui/components/__tests__/TradeBlockPanel.test.jsx
+++ b/src/ui/components/__tests__/TradeBlockPanel.test.jsx
@@ -1,0 +1,227 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import TradeBlockPanel from "../TradeBlockPanel.jsx";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makePlayer(id, teamId, pos, ovr, age = 26, baseAnnual = 3, extra = {}) {
+  return {
+    id,
+    teamId,
+    name: `${pos}${id}`,
+    pos,
+    ovr,
+    age,
+    potential: ovr,
+    contract: { baseAnnual, yearsTotal: 2, yearsRemaining: 1 },
+    ...extra,
+  };
+}
+
+function makeLeague({ userTeamId = 1, aiTeams = [], players = [] } = {}) {
+  const userTeam = {
+    id: userTeamId,
+    name: "Bears",
+    abbr: "CHI",
+    wins: 6, losses: 4,
+    capRoom: 20,
+    picks: [],
+    roster: [],
+  };
+  return {
+    year: 2027,
+    season: 2027,
+    phase: "regular",
+    userTeamId,
+    teams: [userTeam, ...aiTeams],
+    players,
+  };
+}
+
+// AI team designed to produce a cap-burden trade block entry:
+// capRoom < 0 (cap-restricted) + player with high contract, age >= 28, OVR < 88
+const capStrappedTeam = {
+  id: 2,
+  name: "Lions",
+  abbr: "DET",
+  wins: 2, losses: 8,
+  capRoom: -3,
+  picks: [],
+  roster: [],
+};
+
+const capBurdenPlayer = makePlayer(201, 2, "WR", 80, 31, 15);
+const youngPlayer = makePlayer(202, 2, "WR", 74, 24, 2);
+
+const leagueWithAIBlock = makeLeague({
+  aiTeams: [capStrappedTeam],
+  players: [
+    makePlayer(101, 1, "QB", 82, 27, 10),
+    capBurdenPlayer,
+    youngPlayer,
+  ],
+});
+
+// ── User block tests ──────────────────────────────────────────────────────────
+
+describe("TradeBlockPanel — user block", () => {
+  afterEach(cleanup);
+
+  it("renders null when roster is not an array", () => {
+    const html = renderToString(<TradeBlockPanel roster={null} onRemove={() => {}} />);
+    expect(html).toBe("");
+  });
+
+  it("shows 'No players on the trade block' when no players qualify", () => {
+    const roster = [makePlayer(1, 1, "QB", 82)];
+    render(<TradeBlockPanel roster={roster} onRemove={() => {}} />);
+    expect(screen.getByText(/no players on the trade block/i)).toBeTruthy();
+  });
+
+  it("renders players flagged onTradeBlock", () => {
+    const roster = [makePlayer(1, 1, "QB", 82, 27, 5, { onTradeBlock: true })];
+    render(<TradeBlockPanel roster={roster} onRemove={() => {}} />);
+    expect(screen.getByText("QB1")).toBeTruthy();
+  });
+
+  it("calls onRemove with correct player id when Remove is clicked", () => {
+    const onRemove = vi.fn();
+    const player = makePlayer(42, 1, "WR", 76, 30, 4, { onTradeBlock: true });
+    render(<TradeBlockPanel roster={[player]} onRemove={onRemove} />);
+    fireEvent.click(screen.getByText("Remove"));
+    expect(onRemove).toHaveBeenCalledWith(42);
+  });
+});
+
+// ── League block tests ────────────────────────────────────────────────────────
+
+describe("TradeBlockPanel — league block", () => {
+  afterEach(cleanup);
+
+  it("does not render league block toggle when league prop is absent", () => {
+    const roster = [makePlayer(1, 1, "QB", 82)];
+    render(<TradeBlockPanel roster={roster} onRemove={() => {}} />);
+    expect(screen.queryByTestId("league-block-toggle")).toBeNull();
+  });
+
+  it("renders league block toggle when league prop is provided", () => {
+    const roster = [makePlayer(101, 1, "QB", 82)];
+    render(
+      <TradeBlockPanel
+        roster={roster}
+        onRemove={() => {}}
+        league={leagueWithAIBlock}
+        userTeamId={1}
+      />,
+    );
+    expect(screen.getByTestId("league-block-toggle")).toBeTruthy();
+    expect(screen.getByText("League Block")).toBeTruthy();
+  });
+
+  it("league block content is hidden by default", () => {
+    const roster = [makePlayer(101, 1, "QB", 82)];
+    render(
+      <TradeBlockPanel
+        roster={roster}
+        onRemove={() => {}}
+        league={leagueWithAIBlock}
+        userTeamId={1}
+      />,
+    );
+    expect(screen.queryByTestId("league-block-content")).toBeNull();
+  });
+
+  it("reveals league block content after clicking the toggle", () => {
+    const roster = [makePlayer(101, 1, "QB", 82)];
+    render(
+      <TradeBlockPanel
+        roster={roster}
+        onRemove={() => {}}
+        league={leagueWithAIBlock}
+        userTeamId={1}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("league-block-toggle"));
+    expect(screen.getByTestId("league-block-content")).toBeTruthy();
+  });
+
+  it("renders AI team name when generator returns block assets", () => {
+    const roster = [makePlayer(101, 1, "QB", 82)];
+    render(
+      <TradeBlockPanel
+        roster={roster}
+        onRemove={() => {}}
+        league={leagueWithAIBlock}
+        userTeamId={1}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("league-block-toggle"));
+    // The cap-strapped Lions should appear with the cap-burden WR
+    expect(screen.getByText("Lions")).toBeTruthy();
+  });
+
+  it("shows cap-strapped posture label for cap-restricted AI team", () => {
+    const roster = [makePlayer(101, 1, "QB", 82)];
+    render(
+      <TradeBlockPanel
+        roster={roster}
+        onRemove={() => {}}
+        league={leagueWithAIBlock}
+        userTeamId={1}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("league-block-toggle"));
+    expect(screen.getByText(/cap strapped/i)).toBeTruthy();
+  });
+
+  it("displays player OVR for AI block assets", () => {
+    const roster = [makePlayer(101, 1, "QB", 82)];
+    render(
+      <TradeBlockPanel
+        roster={roster}
+        onRemove={() => {}}
+        league={leagueWithAIBlock}
+        userTeamId={1}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("league-block-toggle"));
+    // capBurdenPlayer has OVR 80
+    expect(screen.getByText("80")).toBeTruthy();
+  });
+
+  it("shows empty message when no AI teams produce block assets", () => {
+    const emptyLeague = makeLeague({
+      aiTeams: [{ id: 2, name: "Lions", abbr: "DET", wins: 8, losses: 2, capRoom: 30, picks: [], roster: [] }],
+      players: [makePlayer(201, 2, "QB", 88, 26, 12)], // cornerstone, not on block
+    });
+    const roster = [makePlayer(101, 1, "QB", 82)];
+    render(
+      <TradeBlockPanel
+        roster={roster}
+        onRemove={() => {}}
+        league={emptyLeague}
+        userTeamId={1}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("league-block-toggle"));
+    expect(screen.getByText(/no ai teams have assets/i)).toBeTruthy();
+  });
+
+  it("excludes the user's own team from the league block", () => {
+    const roster = [makePlayer(101, 1, "QB", 82)];
+    render(
+      <TradeBlockPanel
+        roster={roster}
+        onRemove={() => {}}
+        league={leagueWithAIBlock}
+        userTeamId={1}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("league-block-toggle"));
+    // Bears (user team id=1) should not appear in league block
+    expect(screen.queryByText("Bears")).toBeNull();
+  });
+});

--- a/src/ui/components/__tests__/WeeklyHub.test.jsx
+++ b/src/ui/components/__tests__/WeeklyHub.test.jsx
@@ -1,0 +1,184 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import WeeklyHub from "../WeeklyHub.jsx";
+
+// ── Fixture ───────────────────────────────────────────────────────────────────
+
+function makeLeague({ incomingTradeOffers = [], week = 5 } = {}) {
+  return {
+    year: 2027,
+    week,
+    seasonId: `s${week}`,
+    phase: "regular",
+    userTeamId: 1,
+    teams: [
+      {
+        id: 1,
+        name: "Bears",
+        abbr: "CHI",
+        conf: 0,
+        div: 0,
+        wins: 3,
+        losses: 2,
+        ties: 0,
+        ovr: 80,
+        offenseRating: 78,
+        defenseRating: 79,
+        recentResults: ["W", "L", "W"],
+        roster: [{ id: 11, pos: "QB", ovr: 80, teamId: 1 }],
+      },
+      {
+        id: 2,
+        name: "Lions",
+        abbr: "DET",
+        conf: 0,
+        div: 1,
+        wins: 2,
+        losses: 3,
+        ties: 0,
+        ovr: 82,
+        offenseRating: 80,
+        defenseRating: 81,
+        roster: [],
+      },
+    ],
+    schedule: {
+      weeks: [
+        {
+          week,
+          games: [
+            { id: `g${week}`, home: { id: 1 }, away: { id: 2 }, played: false },
+          ],
+        },
+      ],
+    },
+    incomingTradeOffers,
+    leaguePulse: [],
+    newsItems: [],
+  };
+}
+
+function makeFakeOffer(id = "offer-1") {
+  return {
+    id,
+    week: 4,
+    season: 2027,
+    offeringTeamId: 2,
+    offeringTeamAbbr: "DET",
+    receivingTeamId: 1,
+    userTeamId: 1,
+    offerType: "proactive_ai_offer",
+    urgency: "low",
+    stance: "Roster balance",
+    reason: "DET floated a conservative trade-block offer.",
+    reasonTags: ["cap_burden"],
+    expiresAfterWeek: 6,
+    offering: { playerIds: [201], pickIds: [] },
+    receiving: { playerIds: [104], pickIds: [] },
+    offeringPlayerSnapshots: [{ id: 201, name: "VetWR", pos: "WR", ovr: 80, age: 31 }],
+    receivingPlayerSnapshots: [{ id: 104, name: "SurplusRB", pos: "RB", ovr: 74, age: 27 }],
+    signature: "sig-1",
+  };
+}
+
+// ── Notification badge tests ──────────────────────────────────────────────────
+
+describe("WeeklyHub — incoming trade offer notification", () => {
+  afterEach(cleanup);
+
+  it("does not show trade offer banner when there are no incoming offers", () => {
+    const league = makeLeague({ incomingTradeOffers: [] });
+    render(
+      <WeeklyHub
+        league={league}
+        onNavigate={vi.fn()}
+        onAdvanceWeek={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("trade-offer-banner")).toBeNull();
+  });
+
+  it("shows trade offer banner when there is 1 incoming offer", () => {
+    const league = makeLeague({ incomingTradeOffers: [makeFakeOffer()] });
+    render(
+      <WeeklyHub
+        league={league}
+        onNavigate={vi.fn()}
+        onAdvanceWeek={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("trade-offer-banner")).toBeTruthy();
+    expect(screen.getByText(/you have 1 pending trade offer/i)).toBeTruthy();
+  });
+
+  it("shows plural wording when there are multiple incoming offers", () => {
+    const league = makeLeague({
+      incomingTradeOffers: [makeFakeOffer("o1"), makeFakeOffer("o2")],
+    });
+    render(
+      <WeeklyHub
+        league={league}
+        onNavigate={vi.fn()}
+        onAdvanceWeek={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/you have 2 pending trade offers/i)).toBeTruthy();
+  });
+
+  it("includes a CTA button inside the banner", () => {
+    const league = makeLeague({ incomingTradeOffers: [makeFakeOffer()] });
+    render(
+      <WeeklyHub
+        league={league}
+        onNavigate={vi.fn()}
+        onAdvanceWeek={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+      />,
+    );
+    const banner = screen.getByTestId("trade-offer-banner");
+    expect(banner.querySelector("button")).toBeTruthy();
+  });
+
+  it("clicking the CTA navigates to Trade Center", () => {
+    const onNavigate = vi.fn();
+    const league = makeLeague({ incomingTradeOffers: [makeFakeOffer()] });
+    render(
+      <WeeklyHub
+        league={league}
+        onNavigate={onNavigate}
+        onAdvanceWeek={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText("Open Trade Center"));
+    expect(onNavigate).toHaveBeenCalledWith("Trade Center");
+  });
+
+  it("banner disappears when incomingTradeOffers becomes empty (re-render)", () => {
+    const offer = makeFakeOffer();
+    const { rerender } = render(
+      <WeeklyHub
+        league={makeLeague({ incomingTradeOffers: [offer] })}
+        onNavigate={vi.fn()}
+        onAdvanceWeek={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("trade-offer-banner")).toBeTruthy();
+
+    rerender(
+      <WeeklyHub
+        league={makeLeague({ incomingTradeOffers: [] })}
+        onNavigate={vi.fn()}
+        onAdvanceWeek={vi.fn()}
+        onOpenBoxScore={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("trade-offer-banner")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
This PR enhances the trade system by adding AI-generated trade blocks visible to the user and implementing incoming trade offer notifications in the weekly hub.

## Key Changes

### TradeBlockPanel Component
- **Expanded functionality** to display both user's trade block and a read-only league-wide trade block
- **Added AI trade block generation** via `generateAITradeBlock()` that intelligently determines which AI team assets should be available based on team context (cap situation, rebuild status, contention level)
- **New sub-components**:
  - `LeagueBlockRow`: Displays individual player assets with position, OVR (color-coded), name, age, and cap hit
  - `LeagueBlockTeamGroup`: Groups assets by team with posture label (Cap Strapped, Rebuilding, Contending, Balanced)
- **Helper functions** for formatting cap hits, OVR color coding, and inferring team posture from asset tags
- **Conditional rendering** of league block section only when `league` prop is provided
- **Lazy evaluation** of league block data (only computed when toggle is opened)

### WeeklyHub Component
- **Added incoming trade offer notification banner** that displays when `league.incomingTradeOffers` array is non-empty
- **Dynamic messaging** showing singular/plural offer count
- **CTA button** to navigate directly to Trade Center
- **Accessible implementation** with proper ARIA attributes (`role="status"`, `aria-live="polite"`)

### Test Coverage
- **TradeBlockPanel tests** (227 lines):
  - User block rendering and removal functionality
  - League block visibility and toggle behavior
  - AI team filtering (excludes user's own team)
  - Posture label inference (cap-strapped, rebuilding, etc.)
  - Empty state handling
  
- **WeeklyHub tests** (184 lines):
  - Trade offer banner visibility based on offer count
  - Singular/plural messaging
  - Navigation callback on CTA click
  - Dynamic re-rendering when offers change

## Implementation Details
- League block data is computed via `useMemo` with dependencies on `[league, userTeamId, leagueBlockOpen]` to avoid unnecessary regeneration
- AI trade block generation respects team context (season, phase, user team ID) to produce contextually appropriate assets
- Player assets are enriched with contract and age information for display
- OVR values are color-coded (green ≥88, blue ≥78, orange ≥68, red <68) for quick visual assessment
- Trade block toggle states are managed independently for user and league sections

https://claude.ai/code/session_015452B95gTqXTMxgXHHakRs