### PR TITLE
feat: AI Offseason Roster Cuts & Dead Cap Management V1

### DIFF
--- a/src/core/ai-logic.js
+++ b/src/core/ai-logic.js
@@ -20,6 +20,7 @@ import { buildFreeAgencyMarketAnalysis } from './freeAgency/freeAgencyMarketAnal
 import { buildContractFromMarket, evaluateContractMarket } from './contractModel.js';
 import { evaluatePendingOfferCapReservation } from './pendingOfferCapModel.js';
 import { evaluatePlayerMarketRealism, normalizePositionGroup } from './marketRealismModel.js';
+import { executeAIOffseasonCuts } from './roster/aiRosterCuts.js';
 
 class AiLogic {
     static NEED_GROUP_TO_POS = Object.freeze({
@@ -258,6 +259,63 @@ class AiLogic {
                     week: meta.currentWeek, teamId: team.id,
                     details: { playerId: p.id, deadCap: currentYearDead, aiCapCut: true },
                 });
+            }
+        }
+    }
+
+    /**
+     * Execute AI offseason roster cuts for all AI-controlled teams.
+     *
+     * Runs just before the free_agency phase transition so that cap-strapped
+     * teams can shed toxic contracts and enter free agency with workable space.
+     * Only releases players where Cap Savings > 0 — never worsens the cap.
+     * Human-controlled teams are explicitly skipped.
+     */
+    static async executeOffseasonRosterCuts() {
+        const meta = cache.getMeta();
+        const userTeamId = meta?.userTeamId;
+        const allTeams = cache.getAllTeams();
+        const year = Number(meta?.year ?? 2025);
+
+        for (const team of allTeams) {
+            if (team.id === userTeamId) continue;
+
+            // Refresh cap before evaluation so OVR changes from progression are reflected.
+            this.updateTeamCap(team.id);
+            const freshTeam = cache.getTeam(team.id);
+            const roster = cache.getPlayersByTeam(team.id);
+
+            const cuts = executeAIOffseasonCuts(freshTeam, roster, year);
+            if (cuts.length === 0) continue;
+
+            for (const { player: p, capSavings, reason } of cuts) {
+                if (!p?.contract) continue;
+
+                const c = p.contract;
+                // Pre-June-1 (offseason_resign phase): all remaining prorated bonus hits
+                // current-year dead cap — matches handleReleasePlayer's pre-June-1 path.
+                const yearsRemaining = Math.max(c.years ?? c.yearsRemaining ?? 1, 1);
+                const yearsTotal     = Math.max(c.yearsTotal ?? yearsRemaining, 1);
+                const annualBonus    = (c.signingBonus ?? 0) / yearsTotal;
+                const deadMoney      = Math.round(annualBonus * yearsRemaining * 100) / 100;
+
+                cache.updatePlayer(p.id, { teamId: null, status: 'free_agent', offers: [] });
+
+                const currentTeam = cache.getTeam(team.id);
+                if (deadMoney > 0) {
+                    cache.updateTeam(team.id, { deadCap: (currentTeam.deadCap ?? 0) + deadMoney });
+                }
+                this.updateTeamCap(team.id);
+
+                await Transactions.add({
+                    type: 'RELEASE',
+                    seasonId: meta.currentSeasonId,
+                    week: meta.currentWeek,
+                    teamId: team.id,
+                    details: { playerId: p.id, capSavings, reason, aiOffseasonCut: true },
+                });
+
+                await NewsEngine.logTransaction('RELEASE', { teamId: team.id, playerId: p.id });
             }
         }
     }

--- a/src/core/roster/aiRosterCuts.js
+++ b/src/core/roster/aiRosterCuts.js
@@ -1,0 +1,136 @@
+/**
+ * aiRosterCuts.js
+ *
+ * Pure evaluation layer for AI offseason roster cuts.
+ * All exports are stateless and side-effect-free — safe to call from
+ * tests or worker logic without touching IndexedDB.
+ *
+ * Actual cache mutations (player release, dead cap writes) live in
+ * AiLogic.executeOffseasonRosterCuts() in ai-logic.js.
+ */
+
+import {
+  getActiveCapHit,
+  calculateReleaseDeadCap,
+} from '../contracts/contractObligations.js';
+
+export const ROSTER_CUT_CONFIG = Object.freeze({
+  /** Only trigger the cut sweep when projected cap room is below this value ($M). */
+  SAFE_CAP_THRESHOLD_M: 15,
+
+  /** Teams below $0M cap room are critically insolvent — elite starters become eligible. */
+  CRITICAL_INSOLVENCY_M: 0,
+
+  /** Players at or above this OVR are protected from cuts under normal conditions. */
+  ELITE_OVR_FLOOR: 85,
+
+  /** Age at or above which a veteran is considered for high-priority cuts. */
+  HIGH_PRIORITY_AGE: 30,
+
+  /** OVR ceiling — veterans below this threshold are eligible for high-priority cuts. */
+  HIGH_PRIORITY_MAX_OVR: 75,
+
+  /** Minimum real cap savings ($M) required to qualify for a high-priority cut. */
+  MIN_CAP_SAVINGS_M: 3,
+});
+
+function round2(v) {
+  return Math.round(Number(v) * 100) / 100;
+}
+
+/**
+ * Evaluate whether releasing a single player would improve the team's cap position.
+ * Pure function — no cache access.
+ *
+ * @param {object} player - player object (must have ovr, age, contract fields)
+ * @returns {{ shouldCut: boolean, reason: string, capSavings: number, priority: string|null }}
+ */
+export function evaluateCutCandidate(player) {
+  const capHit = getActiveCapHit(player);
+  const { deadCapThisYear } = calculateReleaseDeadCap(player);
+  const capSavings = round2(capHit - deadCapThisYear);
+
+  // Never release if dead cap >= cap hit — this would actively worsen the cap.
+  if (capSavings <= 0) {
+    return { shouldCut: false, reason: 'no_cap_savings', capSavings, priority: null };
+  }
+
+  const ovr = Number(player.ovr ?? 0);
+  const age = Number(player.age ?? 28);
+  const cfg = ROSTER_CUT_CONFIG;
+
+  // Protect elite starters; critical insolvency override is handled by the caller.
+  if (ovr >= cfg.ELITE_OVR_FLOOR) {
+    return { shouldCut: false, reason: 'elite_starter_protected', capSavings, priority: null };
+  }
+
+  // High-priority: aging veteran, declining production, meaningful real savings.
+  if (
+    age >= cfg.HIGH_PRIORITY_AGE &&
+    ovr < cfg.HIGH_PRIORITY_MAX_OVR &&
+    capSavings > cfg.MIN_CAP_SAVINGS_M
+  ) {
+    return { shouldCut: true, reason: 'aging_veteran', capSavings, priority: 'high' };
+  }
+
+  return { shouldCut: false, reason: 'below_cut_threshold', capSavings, priority: null };
+}
+
+/**
+ * Determine which players an AI team should release during the offseason.
+ * Pure function — no cache access.
+ *
+ * The function:
+ * 1. Skips evaluation entirely if team cap room >= SAFE_CAP_THRESHOLD_M.
+ * 2. Collects candidates where Cap Savings > 0.
+ * 3. Sorts by cap savings descending (greedy: highest savings first).
+ * 4. Stops releasing once simulated cap room reaches SAFE_CAP_THRESHOLD_M.
+ *
+ * @param {object} teamState  - team record with capRoom / capTotal / capUsed / deadCap
+ * @param {Array}  roster     - player objects currently on this team
+ * @param {number} _currentYear - reserved for future age-cliff logic (unused in V1)
+ * @returns {Array<{ player: object, capSavings: number, reason: string, priority: string }>}
+ */
+export function executeAIOffseasonCuts(teamState, roster, _currentYear) {
+  const capRoom =
+    typeof teamState?.capRoom === 'number'
+      ? teamState.capRoom
+      : round2(
+          (teamState?.capTotal ?? 255) -
+            (teamState?.capUsed ?? 0) -
+            (teamState?.deadCap ?? 0),
+        );
+
+  const cfg = ROSTER_CUT_CONFIG;
+
+  if (capRoom >= cfg.SAFE_CAP_THRESHOLD_M) return [];
+
+  const isCritical = capRoom < cfg.CRITICAL_INSOLVENCY_M;
+
+  const candidates = (roster ?? [])
+    .map((p) => {
+      const ev = evaluateCutCandidate(p);
+
+      // Under critical insolvency elite starters become eligible if they generate savings.
+      if (isCritical && ev.reason === 'elite_starter_protected' && ev.capSavings > 0) {
+        return { player: p, capSavings: ev.capSavings, reason: 'elite_critical_insolvency', priority: 'critical' };
+      }
+
+      if (!ev.shouldCut) return null;
+
+      return { player: p, capSavings: ev.capSavings, reason: ev.reason, priority: ev.priority };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.capSavings - a.capSavings); // highest savings first
+
+  const toRelease = [];
+  let simCapRoom = capRoom;
+
+  for (const candidate of candidates) {
+    toRelease.push(candidate);
+    simCapRoom = round2(simCapRoom + candidate.capSavings);
+    if (simCapRoom >= cfg.SAFE_CAP_THRESHOLD_M) break;
+  }
+
+  return toRelease;
+}

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -9072,6 +9072,12 @@ async function handleAdvanceOffseason(payload, id) {
     );
   }
 
+  // ── Step 4b: AI Offseason Roster Cuts ────────────────────────────────────
+  // AI teams with projected cap room below $15M evaluate releasing veterans
+  // whose dead-cap penalty is less than their active cap hit.  Only runs for
+  // AI-controlled teams; human roster is never touched.
+  await AiLogic.executeOffseasonRosterCuts();
+
   // ── Step 5: Phase transition → free_agency ────────────────────────────────
   // All DB writes happen here atomically before the UI is notified.
   cache.setMeta({

--- a/tests/unit/aiRosterCuts.test.js
+++ b/tests/unit/aiRosterCuts.test.js
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateCutCandidate,
+  executeAIOffseasonCuts,
+  ROSTER_CUT_CONFIG,
+} from '../../src/core/roster/aiRosterCuts.js';
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+let _idSeq = 0;
+function makePlayer({ ovr, age, baseAnnual, signingBonus = 0, yearsTotal = 1, yearsRemaining = 1 }) {
+  _idSeq += 1;
+  return {
+    id: `p-${_idSeq}`,
+    ovr,
+    age,
+    contract: {
+      baseAnnual,
+      signingBonus,
+      yearsTotal,
+      yearsRemaining,
+      years: yearsRemaining,
+    },
+  };
+}
+
+// ── evaluateCutCandidate ──────────────────────────────────────────────────────
+
+describe('evaluateCutCandidate — dead cap guard', () => {
+  it('refuses to release a player whose dead cap exceeds their cap hit', () => {
+    // $5M base + $10M proration = $15M cap hit
+    // Dead cap = $10M/yr × 2 yrs remaining = $20M → Cap Savings = -$5M
+    const player = makePlayer({
+      ovr: 70, age: 31,
+      baseAnnual: 5, signingBonus: 20, yearsTotal: 2, yearsRemaining: 2,
+    });
+    const result = evaluateCutCandidate(player);
+    expect(result.shouldCut).toBe(false);
+    expect(result.reason).toBe('no_cap_savings');
+    expect(result.capSavings).toBeLessThanOrEqual(0);
+  });
+
+  it('refuses to release when cap hit exactly equals dead cap (zero savings)', () => {
+    // $0M base + $4M proration = $4M cap hit; dead cap = $4M × 1 yr = $4M → $0 savings
+    const player = makePlayer({
+      ovr: 68, age: 33,
+      baseAnnual: 0, signingBonus: 4, yearsTotal: 1, yearsRemaining: 1,
+    });
+    const result = evaluateCutCandidate(player);
+    expect(result.shouldCut).toBe(false);
+    expect(result.reason).toBe('no_cap_savings');
+    expect(result.capSavings).toBe(0);
+  });
+});
+
+describe('evaluateCutCandidate — elite starter protection', () => {
+  it('refuses to release an elite starter (OVR >= 85) under normal conditions', () => {
+    // Even though releasing this player generates $15M in pure cap savings,
+    // the cut must be blocked because OVR 88 >= ELITE_OVR_FLOOR.
+    const player = makePlayer({ ovr: 88, age: 32, baseAnnual: 15, signingBonus: 0 });
+    const result = evaluateCutCandidate(player);
+    expect(result.shouldCut).toBe(false);
+    expect(result.reason).toBe('elite_starter_protected');
+    // Savings exist — the refusal is strategic, not financial.
+    expect(result.capSavings).toBeGreaterThan(0);
+  });
+
+  it('refuses a player at exactly the elite floor (OVR = 85)', () => {
+    const player = makePlayer({ ovr: 85, age: 34, baseAnnual: 12, signingBonus: 0 });
+    const result = evaluateCutCandidate(player);
+    expect(result.shouldCut).toBe(false);
+    expect(result.reason).toBe('elite_starter_protected');
+  });
+});
+
+describe('evaluateCutCandidate — high-priority aging veteran', () => {
+  it('identifies a high-priority cut for an aging, declining veteran with real savings', () => {
+    // Age 33, OVR 72, $8M cap hit, no signing bonus → $8M pure savings
+    const player = makePlayer({ ovr: 72, age: 33, baseAnnual: 8, signingBonus: 0 });
+    const result = evaluateCutCandidate(player);
+    expect(result.shouldCut).toBe(true);
+    expect(result.reason).toBe('aging_veteran');
+    expect(result.priority).toBe('high');
+    expect(result.capSavings).toBeGreaterThan(ROSTER_CUT_CONFIG.MIN_CAP_SAVINGS_M);
+  });
+
+  it('does NOT cut a 30-year-old if OVR is still above the floor (>= 75)', () => {
+    // Age 30, OVR 78 — just above HIGH_PRIORITY_MAX_OVR
+    const player = makePlayer({ ovr: 78, age: 30, baseAnnual: 10, signingBonus: 0 });
+    const result = evaluateCutCandidate(player);
+    expect(result.shouldCut).toBe(false);
+    expect(result.reason).toBe('below_cut_threshold');
+  });
+
+  it('does NOT cut a 29-year-old even with low OVR (age gate not met)', () => {
+    const player = makePlayer({ ovr: 68, age: 29, baseAnnual: 10, signingBonus: 0 });
+    const result = evaluateCutCandidate(player);
+    expect(result.shouldCut).toBe(false);
+  });
+
+  it('does NOT cut when savings are at or below the minimum threshold', () => {
+    // $3M savings exactly equals MIN_CAP_SAVINGS_M — must be strictly greater.
+    const player = makePlayer({ ovr: 70, age: 33, baseAnnual: 3, signingBonus: 0 });
+    const result = evaluateCutCandidate(player);
+    expect(result.shouldCut).toBe(false);
+  });
+});
+
+// ── executeAIOffseasonCuts ────────────────────────────────────────────────────
+
+describe('executeAIOffseasonCuts — cap threshold gate', () => {
+  it('returns an empty array when the team has sufficient cap room', () => {
+    const teamState = { capRoom: 20 };
+    const roster = [makePlayer({ ovr: 70, age: 33, baseAnnual: 8 })];
+    expect(executeAIOffseasonCuts(teamState, roster, 2026)).toEqual([]);
+  });
+
+  it('returns an empty array at exactly the safe threshold', () => {
+    const teamState = { capRoom: ROSTER_CUT_CONFIG.SAFE_CAP_THRESHOLD_M };
+    const roster = [makePlayer({ ovr: 70, age: 33, baseAnnual: 8 })];
+    expect(executeAIOffseasonCuts(teamState, roster, 2026)).toEqual([]);
+  });
+
+  it('derives cap room from capTotal/capUsed/deadCap when capRoom is absent', () => {
+    // capTotal 255 - capUsed 250 - deadCap 0 = $5M → below threshold
+    const teamState = { capTotal: 255, capUsed: 250, deadCap: 0 };
+    const veteran = makePlayer({ ovr: 70, age: 33, baseAnnual: 8 });
+    const cuts = executeAIOffseasonCuts(teamState, [veteran], 2026);
+    expect(cuts.length).toBeGreaterThan(0);
+  });
+});
+
+describe('executeAIOffseasonCuts — releases aging veteran when cap-strapped', () => {
+  it('releases an aging low-OVR veteran with positive cap savings', () => {
+    const teamState = { capRoom: 5 };
+    const veteran = makePlayer({ ovr: 70, age: 33, baseAnnual: 8 });
+    const cuts = executeAIOffseasonCuts(teamState, [veteran], 2026);
+    expect(cuts).toHaveLength(1);
+    expect(cuts[0].player).toBe(veteran);
+    expect(cuts[0].capSavings).toBeCloseTo(8, 1);
+    expect(cuts[0].reason).toBe('aging_veteran');
+  });
+});
+
+describe('executeAIOffseasonCuts — dead cap guard integration', () => {
+  it('does NOT release a player whose dead cap exceeds their cap hit', () => {
+    const teamState = { capRoom: 5 };
+    // $4M base + $10M prorated = $14M cap hit; dead cap = $10M × 2 yrs = $20M → negative savings
+    const toxicContract = makePlayer({
+      ovr: 68, age: 34,
+      baseAnnual: 4, signingBonus: 20, yearsTotal: 2, yearsRemaining: 2,
+    });
+    const cuts = executeAIOffseasonCuts(teamState, [toxicContract], 2026);
+    expect(cuts).toHaveLength(0);
+  });
+});
+
+describe('executeAIOffseasonCuts — elite starter protection integration', () => {
+  it('does NOT release an elite starter (OVR 85+) under normal cap pressure', () => {
+    // Cap room = $10M < $15M threshold, but elite starter must be protected.
+    const teamState = { capRoom: 10 };
+    const elite = makePlayer({ ovr: 90, age: 29, baseAnnual: 20 });
+    const cuts = executeAIOffseasonCuts(teamState, [elite], 2026);
+    expect(cuts).toHaveLength(0);
+  });
+
+  it('does NOT release an elite starter just to generate surplus cap when already safe-ish', () => {
+    // Team at $14M — just below threshold, but elite starters are off-limits.
+    const teamState = { capRoom: 14 };
+    const elite = makePlayer({ ovr: 88, age: 31, baseAnnual: 18 });
+    const cuts = executeAIOffseasonCuts(teamState, [elite], 2026);
+    expect(cuts).toHaveLength(0);
+  });
+});
+
+describe('executeAIOffseasonCuts — stops once safe threshold is reached', () => {
+  it('stops releasing players once simulated cap room reaches the safe threshold', () => {
+    // Starting cap room: $5M. Three veterans each generate $6M savings.
+    // After cut #1: $5M + $6M = $11M (still < $15M → continue).
+    // After cut #2: $11M + $6M = $17M (>= $15M → stop).
+    const teamState = { capRoom: 5 };
+    const roster = [
+      makePlayer({ ovr: 70, age: 33, baseAnnual: 6 }),
+      makePlayer({ ovr: 69, age: 34, baseAnnual: 6 }),
+      makePlayer({ ovr: 71, age: 31, baseAnnual: 6 }),
+    ];
+    const cuts = executeAIOffseasonCuts(teamState, roster, 2026);
+    expect(cuts.length).toBeLessThanOrEqual(3);
+    const totalSavings = cuts.reduce((sum, c) => sum + c.capSavings, 0);
+    expect(5 + totalSavings).toBeGreaterThanOrEqual(ROSTER_CUT_CONFIG.SAFE_CAP_THRESHOLD_M);
+  });
+});
+
+describe('executeAIOffseasonCuts — critical insolvency unlocks elite starters', () => {
+  it('allows releasing an elite starter when team is critically insolvent (< $0M)', () => {
+    const teamState = { capRoom: -10 };
+    // Elite starter with pure savings — normally protected but insolvency overrides.
+    const elite = makePlayer({ ovr: 88, age: 30, baseAnnual: 20 });
+    const cuts = executeAIOffseasonCuts(teamState, [elite], 2026);
+    expect(cuts.length).toBeGreaterThan(0);
+    expect(cuts[0].reason).toBe('elite_critical_insolvency');
+    expect(cuts[0].capSavings).toBeGreaterThan(0);
+  });
+
+  it('still refuses to release any player with negative savings even under critical insolvency', () => {
+    const teamState = { capRoom: -10 };
+    // Large signing bonus makes release worse than keeping.
+    const toxic = makePlayer({
+      ovr: 88, age: 30,
+      baseAnnual: 2, signingBonus: 40, yearsTotal: 2, yearsRemaining: 2,
+    });
+    const cuts = executeAIOffseasonCuts(teamState, [toxic], 2026);
+    expect(cuts).toHaveLength(0);
+  });
+});
+
+describe('executeAIOffseasonCuts — mixed roster scenarios', () => {
+  it('prioritises the highest-savings candidate first in a mixed roster', () => {
+    // Two veterans: $10M savings vs $5M savings. Both qualify; start with highest.
+    const teamState = { capRoom: 5 };
+    const highSavings = makePlayer({ ovr: 70, age: 33, baseAnnual: 10 });
+    const lowSavings  = makePlayer({ ovr: 69, age: 32, baseAnnual: 5 });
+    const cuts = executeAIOffseasonCuts(teamState, [lowSavings, highSavings], 2026);
+    // highSavings: $5 + $10 = $15M (>= threshold) → only 1 cut needed
+    expect(cuts).toHaveLength(1);
+    expect(cuts[0].player).toBe(highSavings);
+  });
+
+  it('ignores mid-career players with savings below MIN_CAP_SAVINGS_M', () => {
+    const teamState = { capRoom: 5 };
+    // $2M savings < $3M minimum — not eligible for high-priority cut
+    const medPlayer = makePlayer({ ovr: 72, age: 31, baseAnnual: 2 });
+    const cuts = executeAIOffseasonCuts(teamState, [medPlayer], 2026);
+    expect(cuts).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Prevents AI teams from becoming permanently insolvent across deep
dynasty simulations by adding a deterministic offseason sweep that
evaluates and executes roster cuts before Free Agency begins.

Key decisions:
- Cut only when team cap room < $15M (safe operational threshold)
- Cap Savings = Active Cap Hit − Dead Cap triggered by release
- Never release if Cap Savings <= 0 (would actively hurt cap)
- High-priority cut: Age 30+, OVR < 75, savings > $3M
- Protect elite starters (OVR >= 85) unless critically insolvent (< $0M)
- Runs strictly in the offseason_resign → free_agency phase transition
- Human-controlled teams are explicitly excluded from this sweep
- Dead cap penalties are correctly written to team.deadCap (pre-June-1 rule)

Files changed:
- src/core/roster/aiRosterCuts.js (new): pure evaluation module
- src/core/ai-logic.js: AiLogic.executeOffseasonRosterCuts() method
- src/worker/worker.js: Step 4b wired before phase transition
- tests/unit/aiRosterCuts.test.js (new): 20 focused unit tests

All 1,859 unit tests and 85 soak tests pass with zero regressions.