### PR TITLE
feat: AI Contract Extensions & Retention Prioritization V1

### DIFF
--- a/src/core/ai-logic.js
+++ b/src/core/ai-logic.js
@@ -21,6 +21,7 @@ import { buildContractFromMarket, evaluateContractMarket } from './contractModel
 import { evaluatePendingOfferCapReservation } from './pendingOfferCapModel.js';
 import { evaluatePlayerMarketRealism, normalizePositionGroup } from './marketRealismModel.js';
 import { executeAIOffseasonCuts } from './roster/aiRosterCuts.js';
+import { executeAIOffseasonExtensions } from './retention/aiRetentionLogic.js';
 
 class AiLogic {
     static NEED_GROUP_TO_POS = Object.freeze({
@@ -350,84 +351,52 @@ class AiLogic {
     }
 
     /**
-     * Process contract extensions for a team's core players.
+     * Process contract extensions for a team's core players during offseason_resign.
+     * Delegates prioritization and cap math to the pure executeAIOffseasonExtensions
+     * utility, then applies each accepted extension to cache.
      * Call this before Free Agency / Draft.
      */
     static async processExtensions(teamId) {
         const team = cache.getTeam(teamId);
         if (!team) return;
 
-        // Re-calc cap first to be safe
         this.updateTeamCap(teamId);
 
         const roster = cache.getPlayersByTeam(teamId);
-        const expiring = roster.filter(p => p.contract && p.contract.years === 1);
+        const meta   = cache.getMeta();
+        const allPlayers = cache.getAllPlayers();
+        const freeAgents = allPlayers.filter((p) => !p.teamId || p.status === 'free_agent');
 
-        for (const p of expiring) {
-            // Extension Criteria:
-            // 1. High OVR (> 80)
-            // 2. Core Age (< 30) or QB (< 32)
-            // 3. Not already negotiated (check negotiationStatus if exists, otherwise assume open)
+        const extensions = executeAIOffseasonExtensions(
+            team,
+            roster,
+            { freeAgents, phase: meta?.phase, season: meta?.year },
+        );
 
-            const isQB = p.pos === 'QB';
-            const maxAge = isQB ? 32 : 30;
+        for (const { player, contract } of extensions) {
+            const newContract = { ...contract, startYear: meta?.year };
 
-            const retention = evaluateReSigningPriority(p, team, { players: roster, phase: cache.getMeta()?.phase, week: cache.getMeta()?.currentWeek });
-            const shouldPrioritize = ['cornerstone_priority', 'strong_keep', 'extension_candidate'].includes(retention.recommendation);
+            cache.updatePlayer(player.id, {
+                contract: newContract,
+                negotiationStatus: 'SIGNED',
+                extensionDecision: 'extended',
+            });
 
-            if ((p.ovr ?? 0) >= 76 && (p.age ?? 25) <= maxAge && shouldPrioritize) {
-                const demand = calculateExtensionDemand(p);
-                if (!demand) continue;
+            this.updateTeamCap(teamId);
 
-                // Check affordability
-                // New Cap Hit = Base + (Bonus / Years)
-                // We need to check if this fits into NEXT year's cap, but for simplicity
-                // we check current cap room buffer. A strict check would project next year.
-                // Let's assume we need at least 5M + new hit in room.
+            await Transactions.add({
+                type: 'EXTEND',
+                seasonId: meta?.currentSeasonId,
+                week: meta?.currentWeek,
+                teamId,
+                details: { playerId: player.id, contract: newContract },
+            });
 
-                const newCapHit = demand.baseAnnual + (demand.signingBonus / demand.yearsTotal);
-                const currentCapHit = (p.contract.baseAnnual || 0) + ((p.contract.signingBonus || 0) / (p.contract.yearsTotal || 1));
-                const netChange = newCapHit - currentCapHit;
-
-                // Allow if we have room for the increase + 2M buffer
-                if (team.capRoom > (netChange + 2)) {
-                    // EXTEND PLAYER
-                    const newContract = {
-                        ...demand,
-                        years: demand.years,
-                        yearsTotal: demand.yearsTotal,
-                        startYear: cache.getMeta().year
-                    };
-
-                    cache.updatePlayer(p.id, {
-                        contract: newContract,
-                        negotiationStatus: 'SIGNED'
-                    });
-
-                    // Update Cap
-                    this.updateTeamCap(teamId);
-
-                    // Add Transaction
-                    await Transactions.add({
-                        type: 'SIGN',
-                        seasonId: cache.getMeta().currentSeasonId,
-                        week: cache.getMeta().currentWeek,
-                        teamId,
-                        details: { playerId: p.id, contract: newContract }
-                    });
-
-                    // Log News
-                    await NewsEngine.logTransaction('SIGN', {
-                        teamId,
-                        playerId: p.id,
-                        contract: newContract
-                    });
-
-                    // Refresh team object for next iteration
-                    const updatedTeam = cache.getTeam(teamId);
-                    team.capRoom = updatedTeam.capRoom;
-                }
-            }
+            await NewsEngine.logTransaction('EXTEND', {
+                teamId,
+                playerId: player.id,
+                contract: newContract,
+            });
         }
     }
 

--- a/src/core/retention/aiRetentionLogic.js
+++ b/src/core/retention/aiRetentionLogic.js
@@ -1,0 +1,297 @@
+/**
+ * aiRetentionLogic.js
+ *
+ * Pure evaluation layer for AI offseason contract extensions.
+ * All exports are stateless and side-effect-free — safe to call from
+ * tests or worker logic without touching IndexedDB.
+ *
+ * Actual cache mutations (contract writes, cap recalculation, transaction logs)
+ * live in AiLogic.processExtensions() in ai-logic.js.
+ */
+
+import {
+  buildContractProfile,
+  buildDemandFromProfile,
+  computeMarketHeat,
+} from '../contract-market.js';
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+export const AI_RETENTION_CONFIG = Object.freeze({
+  /** Minimum cap buffer to preserve after all extensions ($M). */
+  MIN_CAP_BUFFER_M: 5,
+
+  /** OVR floor: players below this threshold are not offered extensions. */
+  MIN_OVR_FOR_EXTENSION: 76,
+
+  /** Age ceilings by position group. */
+  MAX_AGE_STANDARD: 32,
+  MAX_AGE_QB: 36,
+  MAX_AGE_RB: 28,
+
+  /**
+   * Positional value multipliers applied to the priority score.
+   * Higher values push a position up the retention board.
+   * Mirrors the position multiplier hierarchy used in worker.js and contract-market.js.
+   */
+  POSITIONAL_VALUE: Object.freeze({
+    QB:   1.45,
+    EDGE: 1.20,
+    DE:   1.16,
+    OT:   1.18,
+    LT:   1.18,
+    WR:   1.12,
+    CB:   1.08,
+    DL:   0.94,
+    OL:   0.95,
+    LB:   0.86,
+    S:    0.78,
+    TE:   0.76,
+    RB:   0.66,
+    K:    0.40,
+    P:    0.40,
+  }),
+
+  /** Minimum acceptance score (0–100) for a player to agree to the AI's offer. */
+  ACCEPT_SCORE_THRESHOLD: 72,
+});
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+function safeNum(v, d = 0) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : d;
+}
+
+function round2(v) {
+  return Math.round(safeNum(v) * 100) / 100;
+}
+
+/**
+ * Deterministic per-player hash used to add consistent, reproducible variance
+ * to the acceptance simulation without touching Math.random().
+ * Identical to the `seeded()` implementation in contract-market.js.
+ */
+function seededHash(id, salt = 0x1a3f) {
+  const raw = String(id ?? '0');
+  let h = 2166136261 ^ salt;
+  for (let i = 0; i < raw.length; i += 1) {
+    h ^= raw.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return Math.abs(h % 100);
+}
+
+/** True when the player has ≤1 contract year remaining (expiring this offseason). */
+function isExpiring(player) {
+  const years = safeNum(
+    player?.contract?.years ??
+    player?.contract?.yearsRemaining ??
+    player?.contract?.yearsLeft,
+    1,
+  );
+  return years <= 1;
+}
+
+/** Whether a player's age is within the allowed extension window for their position. */
+function isWithinAgeLimit(pos, age, config) {
+  if (pos === 'RB') return age <= config.MAX_AGE_RB;
+  if (pos === 'QB') return age <= config.MAX_AGE_QB;
+  return age <= config.MAX_AGE_STANDARD;
+}
+
+/**
+ * Compute the priority score used to rank players on the retention board.
+ *
+ * Formula:
+ *   base  = OVR × positionalMultiplier
+ *   bonus = upside for young developing players
+ *   penalty = age drag beyond position-specific soft ceilings
+ *
+ * Higher-OVR players at premium positions (QB, EDGE, OT) naturally float to
+ * the top. Aging RBs receive the steepest penalty due to their low positional
+ * multiplier and aggressive age ceiling.
+ */
+function computePriorityScore(player, config) {
+  const ovr = safeNum(player?.ovr, 65);
+  const pot = safeNum(player?.potential, ovr);
+  const age = safeNum(player?.age, 26);
+  const pos = String(player?.pos ?? 'OL');
+  const posMult = config.POSITIONAL_VALUE[pos] ?? 0.90;
+
+  let score = ovr * posMult;
+
+  // Young-player upside bump (ascending development trajectory)
+  if (age <= 26 && pot > ovr) score += (pot - ovr) * 0.5;
+
+  // Age drag: applied beyond soft ceilings even for eligible players,
+  // so veterans who barely qualify still rank below prime-age alternatives.
+  if (pos === 'RB') {
+    if (age > config.MAX_AGE_RB) score -= (age - config.MAX_AGE_RB) * 8;
+  } else if (pos === 'QB') {
+    if (age > 32) score -= (age - 32) * 3;
+  } else {
+    if (age > 30) score -= (age - 30) * 6;
+  }
+
+  return score;
+}
+
+/**
+ * Calculate the net change to the team's annual cap hit when a player is extended.
+ *
+ *   capHit = baseAnnual + (signingBonus / yearsTotal)
+ *   delta  = newCapHit − currentCapHit
+ *
+ * Because we are in the offseason, the player's current contract may still
+ * carry proration. We honour those obligations in the delta calculation.
+ */
+function computeCapHitDelta(player, newContract) {
+  const curAnnual  = safeNum(player?.contract?.baseAnnual, 0);
+  const curYears   = Math.max(1, safeNum(player?.contract?.yearsTotal ?? player?.contract?.years, 1));
+  const curBonus   = safeNum(player?.contract?.signingBonus, 0);
+  const currentHit = round2(curAnnual + curBonus / curYears);
+
+  const newAnnual = safeNum(newContract?.baseAnnual, 0);
+  const newYears  = Math.max(1, safeNum(newContract?.yearsTotal ?? newContract?.years, 1));
+  const newBonus  = safeNum(newContract?.signingBonus, 0);
+  const newHit    = round2(newAnnual + newBonus / newYears);
+
+  return round2(newHit - currentHit);
+}
+
+/**
+ * Deterministic acceptance simulation.
+ *
+ * Scores the quality of the offer on a 0–100 scale, then adds a small
+ * per-player variance term derived from a hash of the player's ID so the
+ * result is reproducible across multiple calls with the same input.
+ *
+ * Accept when score >= AI_RETENTION_CONFIG.ACCEPT_SCORE_THRESHOLD (72).
+ *
+ * Key properties:
+ * - A fair-market offer (annualRatio ≈ 1.0) yields a base score of 85.
+ * - Even with maximum downward variance (−5) and neutral morale/success,
+ *   a matched offer scores 80 — safely above the threshold.
+ * - Players with below-market offers or poor morale can fall below 72 and
+ *   decline, simulating realistic hold-outs or departures.
+ */
+function simulateAcceptance(player, demand, offer, teamSuccessRate, config) {
+  const annualRatio = offer.baseAnnual / Math.max(0.01, demand.baseAnnual);
+  const morale = safeNum(player?.morale, 70);
+
+  let score = Math.min(85, annualRatio * 85);      // 85 for fair-market offer
+  score += (morale - 70) * 0.3;                    // ±3 for morale
+  score += (teamSuccessRate - 0.5) * 10;           // ±5 for team success
+
+  // Deterministic per-player variance in [−5, +5]
+  score += (seededHash(player?.id) % 11) - 5;
+
+  return score >= config.ACCEPT_SCORE_THRESHOLD;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Determine which expiring players an AI team should extend during the
+ * `offseason_resign` phase, respecting cap-space constraints.
+ * Pure function — no cache access, no side effects.
+ *
+ * Algorithm:
+ *  1. Filter roster to players with ≤1 contract year remaining who pass
+ *     the OVR floor and positional age ceiling.
+ *  2. Sort into a Priority Retention Board (OVR × positional multiplier,
+ *     age penalty, youth upside bonus).
+ *  3. Iterate in priority order:
+ *     a. Generate a fair-market offer via buildDemandFromProfile.
+ *     b. Skip if extending this player would drop available cap below
+ *        MIN_CAP_BUFFER_M (insolvency guard).
+ *     c. Simulate player acceptance deterministically.
+ *     d. Deduct the cap-hit delta from the running available pool so later
+ *        iterations see an accurate budget.
+ *  4. Return only accepted extensions.
+ *
+ * @param {object} teamState        - team record: { id, capRoom, wins, losses, ties, … }
+ * @param {Array}  roster           - all player objects currently on this team
+ * @param {object} marketConstants  - { freeAgents?: [], phase?: string, season?: number }
+ * @returns {Array<{ player, contract, capHitDelta, priorityScore }>}
+ */
+export function executeAIOffseasonExtensions(teamState, roster = [], marketConstants = {}) {
+  const config = AI_RETENTION_CONFIG;
+  const freeAgents = Array.isArray(marketConstants?.freeAgents) ? marketConstants.freeAgents : [];
+
+  const wins   = safeNum(teamState?.wins, 0);
+  const losses = safeNum(teamState?.losses, 0);
+  const ties   = safeNum(teamState?.ties, 0);
+  const played = wins + losses + ties;
+  const teamSuccessRate = played > 0 ? (wins + ties * 0.5) / played : 0.5;
+
+  // Derive available cap from whichever fields the caller provides.
+  let availableCap =
+    typeof teamState?.capRoom === 'number'
+      ? teamState.capRoom
+      : round2(
+          safeNum(teamState?.capTotal, 255) -
+          safeNum(teamState?.capUsed, 0) -
+          safeNum(teamState?.deadCap, 0),
+        );
+
+  // Step 1 ── Filter to expiring, eligible players ───────────────────────────
+  const eligible = (roster ?? []).filter((p) => {
+    if (!isExpiring(p)) return false;
+    const ovr = safeNum(p?.ovr, 0);
+    const age = safeNum(p?.age, 26);
+    const pos = String(p?.pos ?? 'OL');
+    if (ovr < config.MIN_OVR_FOR_EXTENSION) return false;
+    if (!isWithinAgeLimit(pos, age, config)) return false;
+    return true;
+  });
+
+  // Step 2 ── Build Priority Retention Board (highest score first) ──────────
+  const board = eligible
+    .map((player) => ({ player, priorityScore: computePriorityScore(player, config) }))
+    .sort((a, b) => b.priorityScore - a.priorityScore);
+
+  // Step 3 ── Iterate and offer extensions ──────────────────────────────────
+  const extensions = [];
+
+  for (const { player, priorityScore } of board) {
+    const pos       = String(player?.pos ?? 'OL');
+    const morale    = safeNum(player?.morale, 70);
+    const schemeFit = safeNum(player?.schemeFit, 65);
+    const marketHeat = computeMarketHeat(pos, freeAgents);
+
+    // Generate market-based demand using the shared contract-market helpers.
+    const profile = buildContractProfile(player, {
+      tenureYears: safeNum(player?.tenureYears, 0),
+    });
+    const demand = buildDemandFromProfile(player, profile, {
+      marketHeat,
+      morale,
+      fit: schemeFit,
+      teamSuccess: teamSuccessRate,
+    });
+
+    // AI offers exactly at market value — fair, not desperate.
+    const offer = {
+      baseAnnual:   demand.baseAnnual,
+      years:        demand.years,
+      yearsTotal:   demand.yearsTotal,
+      signingBonus: demand.signingBonus,
+      guaranteedPct: Math.max(0.45, safeNum(demand.guaranteedPct, 0.45)),
+    };
+
+    const capHitDelta = computeCapHitDelta(player, offer);
+
+    // Cap-space guard: skip this player if extending them would violate the buffer.
+    if (availableCap - capHitDelta < config.MIN_CAP_BUFFER_M) continue;
+
+    // Deterministic acceptance simulation.
+    if (!simulateAcceptance(player, demand, offer, teamSuccessRate, config)) continue;
+
+    availableCap = round2(availableCap - capHitDelta);
+    extensions.push({ player, contract: offer, capHitDelta, priorityScore });
+  }
+
+  return extensions;
+}

--- a/tests/unit/aiRetentionLogic.test.js
+++ b/tests/unit/aiRetentionLogic.test.js
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest';
+import {
+  executeAIOffseasonExtensions,
+  AI_RETENTION_CONFIG,
+} from '../../src/core/retention/aiRetentionLogic.js';
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+let _seq = 0;
+function makePlayer({
+  id,
+  pos,
+  ovr,
+  potential,
+  age,
+  morale = 70,
+  schemeFit = 65,
+  years = 1,
+  baseAnnual = 5,
+  signingBonus = 0,
+  yearsTotal = 1,
+} = {}) {
+  _seq += 1;
+  return {
+    id: id ?? `p-${_seq}`,
+    pos,
+    ovr,
+    potential: potential ?? ovr,
+    age,
+    morale,
+    schemeFit,
+    status: 'active',
+    tenureYears: 3,
+    contract: {
+      years,
+      yearsRemaining: years,
+      yearsTotal,
+      baseAnnual,
+      signingBonus,
+      guaranteedPct: 0.5,
+    },
+  };
+}
+
+// Minimal team state; capRoom is the key field for all cap-space tests.
+function makeTeam({ capRoom = 30, wins = 8, losses = 9, ties = 0 } = {}) {
+  return { id: 1, capRoom, wins, losses, ties };
+}
+
+// ── Test 1: Elite young QB is prioritized and extended ─────────────────────
+
+describe('executeAIOffseasonExtensions — elite young QB extension', () => {
+  it('extends a 25-year-old 90 OVR QB when cap space is available', () => {
+    const qb = makePlayer({ id: 'p-qb-star', pos: 'QB', ovr: 90, age: 25, years: 1 });
+    const team = makeTeam({ capRoom: 40 });
+
+    const extensions = executeAIOffseasonExtensions(team, [qb], { freeAgents: [] });
+
+    expect(extensions).toHaveLength(1);
+    expect(extensions[0].player).toBe(qb);
+    // The AI generates a fair-market contract — verify the shape.
+    expect(extensions[0].contract.baseAnnual).toBeGreaterThan(0);
+    expect(extensions[0].contract.years).toBeGreaterThan(0);
+    expect(extensions[0].contract.guaranteedPct).toBeGreaterThanOrEqual(0.45);
+    // Priority score must reflect the QB positional multiplier (1.45).
+    expect(extensions[0].priorityScore).toBeGreaterThan(qb.ovr);
+  });
+
+  it('places the QB at the top of the board ahead of a lower-priority player', () => {
+    const qb = makePlayer({ id: 'p-qb-top', pos: 'QB', ovr: 88, age: 26, years: 1 });
+    const rb = makePlayer({ id: 'p-rb-mid', pos: 'RB', ovr: 82, age: 24, years: 1 });
+    const team = makeTeam({ capRoom: 50 });
+
+    const extensions = executeAIOffseasonExtensions(team, [rb, qb], { freeAgents: [] });
+
+    // QB should appear first (highest priorityScore).
+    const positions = extensions.map((e) => e.player.pos);
+    const qbIdx = positions.indexOf('QB');
+    const rbIdx = positions.indexOf('RB');
+    if (qbIdx !== -1 && rbIdx !== -1) {
+      expect(qbIdx).toBeLessThan(rbIdx);
+    }
+  });
+});
+
+// ── Test 2: Aging low-OVR RB is not offered an extension ──────────────────
+
+describe('executeAIOffseasonExtensions — aging RB walks into free agency', () => {
+  it('does NOT offer an extension to a 32-year-old 74 OVR running back', () => {
+    // Fails two independent eligibility checks:
+    //   (a) age 32 > MAX_AGE_RB (28)
+    //   (b) ovr 74 < MIN_OVR_FOR_EXTENSION (76)
+    const rb = makePlayer({ id: 'p-rb-old', pos: 'RB', ovr: 74, age: 32, years: 1 });
+    const team = makeTeam({ capRoom: 50 });
+
+    const extensions = executeAIOffseasonExtensions(team, [rb], { freeAgents: [] });
+
+    expect(extensions).toHaveLength(0);
+  });
+
+  it('does NOT offer an extension to a RB at exactly the age ceiling (age 28 + 1 = 29)', () => {
+    const rb = makePlayer({ id: 'p-rb-aged', pos: 'RB', ovr: 82, age: 29, years: 1 });
+    const team = makeTeam({ capRoom: 50 });
+
+    const extensions = executeAIOffseasonExtensions(team, [rb], { freeAgents: [] });
+
+    expect(extensions).toHaveLength(0);
+  });
+
+  it('does NOT offer an extension to any player below the OVR floor', () => {
+    const bench = makePlayer({ id: 'p-bench', pos: 'QB', ovr: 75, age: 24, years: 1 });
+    const team = makeTeam({ capRoom: 50 });
+
+    const extensions = executeAIOffseasonExtensions(team, [bench], { freeAgents: [] });
+
+    expect(extensions).toHaveLength(0);
+  });
+});
+
+// ── Test 3: Extensions halt when projected cap space runs out ─────────────
+
+describe('executeAIOffseasonExtensions — cap exhaustion guard', () => {
+  it('stops committing cap once the MIN_CAP_BUFFER_M floor would be breached', () => {
+    // Team has $20M available. MIN_CAP_BUFFER = $5M → at most $15M can be committed.
+    // Each player will demand roughly 12–18M (elite OVR) so at most 1 extension fits.
+    const team = makeTeam({ capRoom: 20 });
+
+    // Three elite starters all with expiring contracts.
+    const p1 = makePlayer({ id: 'p-ext-1', pos: 'QB', ovr: 92, age: 25, years: 1, baseAnnual: 3 });
+    const p2 = makePlayer({ id: 'p-ext-2', pos: 'WR', ovr: 88, age: 24, years: 1, baseAnnual: 3 });
+    const p3 = makePlayer({ id: 'p-ext-3', pos: 'CB', ovr: 85, age: 26, years: 1, baseAnnual: 3 });
+
+    const extensions = executeAIOffseasonExtensions(team, [p1, p2, p3], { freeAgents: [] });
+
+    // After each accepted extension the running cap balance decreases.
+    // The loop must stop (skip remaining players) before cap < MIN_CAP_BUFFER_M.
+    const totalDelta = extensions.reduce((sum, e) => sum + e.capHitDelta, 0);
+    expect(team.capRoom - totalDelta).toBeGreaterThanOrEqual(AI_RETENTION_CONFIG.MIN_CAP_BUFFER_M);
+
+    // Not all three should be extended (the third cannot fit in $5M remaining headroom).
+    expect(extensions.length).toBeLessThan(3);
+  });
+
+  it('extends zero players when the team is already at the cap floor', () => {
+    // capRoom exactly equals the buffer → no room to commit.
+    const team = makeTeam({ capRoom: AI_RETENTION_CONFIG.MIN_CAP_BUFFER_M });
+    const elite = makePlayer({ id: 'p-no-room', pos: 'QB', ovr: 90, age: 25, years: 1 });
+
+    const extensions = executeAIOffseasonExtensions(team, [elite], { freeAgents: [] });
+
+    expect(extensions).toHaveLength(0);
+  });
+
+  it('derives cap room from capTotal/capUsed/deadCap when capRoom is absent', () => {
+    // capTotal 255 − capUsed 240 − deadCap 0 = $15M available
+    // MIN_BUFFER = $5M → $10M to work with; one elite player should fit.
+    const team = { id: 1, capTotal: 255, capUsed: 240, deadCap: 0, wins: 8, losses: 9 };
+    const qb = makePlayer({ id: 'p-derived-cap', pos: 'QB', ovr: 90, age: 25, years: 1, baseAnnual: 1 });
+
+    const extensions = executeAIOffseasonExtensions(team, [qb], { freeAgents: [] });
+
+    // With $10M to work with and a low current salary, extension should be affordable.
+    // (Demand for a 90 OVR QB will be ~10–15M; this may or may not fit — just verify no crash.)
+    expect(Array.isArray(extensions)).toBe(true);
+  });
+});
+
+// ── Additional boundary / regression cases ────────────────────────────────
+
+describe('executeAIOffseasonExtensions — eligibility edge cases', () => {
+  it('ignores players with more than 1 year remaining on their contract', () => {
+    const secured = makePlayer({ id: 'p-secured', pos: 'QB', ovr: 90, age: 25, years: 3 });
+    const team = makeTeam({ capRoom: 50 });
+
+    const extensions = executeAIOffseasonExtensions(team, [secured], { freeAgents: [] });
+
+    expect(extensions).toHaveLength(0);
+  });
+
+  it('returns an empty array for an empty roster', () => {
+    expect(executeAIOffseasonExtensions(makeTeam(), [], {})).toEqual([]);
+  });
+
+  it('returns an empty array when called with no arguments', () => {
+    expect(executeAIOffseasonExtensions({}, [], {})).toEqual([]);
+  });
+
+  it('does NOT extend a QB over the QB age ceiling', () => {
+    const oldQb = makePlayer({
+      id: 'p-qb-old', pos: 'QB', ovr: 82, age: 37, years: 1,
+    });
+    const team = makeTeam({ capRoom: 50 });
+
+    const extensions = executeAIOffseasonExtensions(team, [oldQb], { freeAgents: [] });
+
+    expect(extensions).toHaveLength(0);
+  });
+});
+
+// ── Config surface tests ──────────────────────────────────────────────────
+
+describe('AI_RETENTION_CONFIG', () => {
+  it('exposes QB as the highest-priority positional value', () => {
+    expect(AI_RETENTION_CONFIG.POSITIONAL_VALUE.QB).toBeGreaterThan(
+      AI_RETENTION_CONFIG.POSITIONAL_VALUE.RB,
+    );
+    expect(AI_RETENTION_CONFIG.POSITIONAL_VALUE.QB).toBeGreaterThan(
+      AI_RETENTION_CONFIG.POSITIONAL_VALUE.OL,
+    );
+  });
+
+  it('has RB as the lowest non-specialist positional value', () => {
+    const nonSpecialist = ['QB', 'EDGE', 'OT', 'WR', 'CB', 'DL', 'OL', 'LB', 'S', 'TE'];
+    for (const pos of nonSpecialist) {
+      expect(AI_RETENTION_CONFIG.POSITIONAL_VALUE.RB).toBeLessThanOrEqual(
+        AI_RETENTION_CONFIG.POSITIONAL_VALUE[pos],
+      );
+    }
+  });
+
+  it('is frozen (immutable)', () => {
+    expect(Object.isFrozen(AI_RETENTION_CONFIG)).toBe(true);
+    expect(Object.isFrozen(AI_RETENTION_CONFIG.POSITIONAL_VALUE)).toBe(true);
+  });
+});


### PR DESCRIPTION
Introduces a deterministic offseason sweep that executes during
offseason_resign, so AI teams proactively extend their own expiring
stars before those players flood free agency.

Key changes:
- src/core/retention/aiRetentionLogic.js (new)
  Pure utility: executeAIOffseasonExtensions(teamState, roster,
  marketConstants). Filters expiring players, ranks them on a Priority
  Retention Board (OVR × positional multiplier + youth upside bonus −
  age penalty), generates fair-market offers via the existing
  buildDemandFromProfile helper, and simulates acceptance with a
  seeded-deterministic acceptance score. The running available-cap pool
  is decremented after each accepted extension, preventing insolvency.
  QB/EDGE/OT receive the highest positional weight; RBs and aging
  veterans are penalized or disqualified by position-specific age
  ceilings (RB≤28, standard≤32, QB≤36).

- src/core/ai-logic.js
  AiLogic.processExtensions() now delegates to
  executeAIOffseasonExtensions and applies the returned extensions to
  cache (contract write, cap recalc, EXTEND transaction, news log).
  Human-controlled teams are excluded upstream in worker.js
  handleAdvanceOffseason which already gates on team.id !== userTeamId.

- tests/unit/aiRetentionLogic.test.js (new, 15 tests)
  Explicitly asserts:
    • 25-year-old 90 OVR QB is extended when cap is available
    • 32-year-old 74 OVR RB walks without an offer (dual eligibility
      failure: age > MAX_AGE_RB and OVR < MIN_OVR_FOR_EXTENSION)
    • Extensions halt before the MIN_CAP_BUFFER_M floor is breached
    • Config surface properties (frozen, QB > RB positional value, etc.)

All 1905 existing unit tests and all 85 soak tests pass cleanly.

https://claude.ai/code/session_01XvQuN4wLSymhTtWzSzpcct