### PR TITLE
Harden worker delta hydration and serialization recovery paths

### DIFF
--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -20,6 +20,7 @@ import { useEffect, useRef, useCallback, useReducer, useMemo } from 'react';
 import { __invalidateStableRouteRequestCache } from "./useStableRouteRequest.js";
 import { buildLeagueCacheScopeKey } from "../utils/requestLoopGuard.js";
 import { toWorker, toUI, send as buildMsg } from '../../worker/protocol.js';
+import { applyLeagueDelta } from '../../worker/serialization.js';
 
 const WORKER_REQUEST_TIMEOUT_MS = 20000;
 const WORKER_TIMEOUT_BY_TYPE = Object.freeze({
@@ -221,6 +222,7 @@ export function useWorker() {
   });
   const activeBootRequestIdRef = useRef(null);
   const ignoredBootRequestIdsRef = useRef(new Set());
+  const hasFullStateBaselineRef = useRef(false);
 
   // ── Spawn worker once ──────────────────────────────────────────────────────
   useEffect(() => {
@@ -277,11 +279,22 @@ export function useWorker() {
           if (payload?.bootRequestId && activeBootRequestIdRef.current === payload.bootRequestId) {
             activeBootRequestIdRef.current = null;
           }
+          hasFullStateBaselineRef.current = true;
           dispatch({ type: 'FULL_STATE', payload, messageType: type });
           break;
-        case toUI.STATE_UPDATE:
-          dispatch({ type: 'STATE_UPDATE', payload, messageType: type });
+        case toUI.STATE_UPDATE: {
+          if (!hasFullStateBaselineRef.current && payload?._isDelta) {
+            worker.postMessage(buildMsg(toWorker.REQUEST_FULL_STATE));
+            break;
+          }
+          const merged = applyLeagueDelta(leagueRef.current ?? {}, payload);
+          if (merged?._requiresFullState) {
+            worker.postMessage(buildMsg(toWorker.REQUEST_FULL_STATE));
+            break;
+          }
+          dispatch({ type: 'STATE_UPDATE', payload: merged, messageType: type });
           break;
+        }
         case toUI.PROMPT_USER_GAME:
           dispatch({ type: 'PROMPT_USER_GAME' });
           break;

--- a/src/worker/protocol.js
+++ b/src/worker/protocol.js
@@ -158,6 +158,9 @@ export const toWorker = Object.freeze({
   GET_DRAFT_CLASSES:    'GET_DRAFT_CLASSES',    // {} — seasons with logged DRAFT picks
   GET_DRAFT_CLASS:      'GET_DRAFT_CLASS',      // { seasonId } — full redraft model for one class
   GET_PLAYER_DRAFT_CONTEXT: 'GET_PLAYER_DRAFT_CONTEXT', // { playerId } — profile strip + optional class hook
+
+  /** Recovery */
+  REQUEST_FULL_STATE: 'REQUEST_FULL_STATE', // {} — force full hydration snapshot
 });
 
 // ─────────────────────────────────────────────

--- a/src/worker/serialization.js
+++ b/src/worker/serialization.js
@@ -254,9 +254,11 @@ export function serializeLeagueDelta(fullState, previousState) {
  */
 export function applyLeagueDelta(currentState, delta) {
   if (!delta) return currentState;
-  if (!delta._isDelta) {
-    // Full hydration path — replace wholesale
-    return { ...delta };
+  if (typeof delta !== "object" || Array.isArray(delta)) {
+    return { ...currentState, _requiresFullState: true };
+  }
+  if (delta._isDelta !== true) {
+    return { ...currentState, _requiresFullState: true };
   }
   const patched = { ...currentState };
   for (const [key, value] of Object.entries(delta)) {

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -214,6 +214,19 @@ let _lastSentViewState = null;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+
+function shouldForceFreshBaseline(nextPayload, prevPayload) {
+  if (!prevPayload || !nextPayload) return false;
+  if (nextPayload.phase !== prevPayload.phase) return true;
+
+  const prevDraftOpen = Boolean(prevPayload.draftStarted) || ['active', 'in_progress', 'started'].includes(String(prevPayload.draftLifecycleStatus ?? ''));
+  const nextDraftClosed = !Boolean(nextPayload.draftStarted) && ['complete', 'completed', 'idle', 'finalized', 'not_available'].includes(String(nextPayload.draftLifecycleStatus ?? ''));
+  if (prevDraftOpen && nextDraftClosed) return true;
+
+  return false;
+}
+
+
 /**
  * Send a typed message to the UI thread with delta-serialization and binary
  * Transferable optimizations.
@@ -243,18 +256,24 @@ function post(type, payload = {}, id = null) {
   const transferList = [];
 
   if (type === toUI.STATE_UPDATE) {
+    const forceFreshBaseline = shouldForceFreshBaseline(payload, _lastSentViewState);
+    const previousState = forceFreshBaseline ? null : _lastSentViewState;
+    if (forceFreshBaseline) _lastSentViewState = null;
+
     const { delta, ratingMatrix, scheduleBuffer } = serializeLeagueDelta(
       payload,
-      _lastSentViewState,
+      previousState,
     );
 
     if (ratingMatrix && ratingMatrix.buffer.buffer.byteLength > 0) {
       delta._ratingMatrix = { buffer: ratingMatrix.buffer, playerIds: ratingMatrix.playerIds };
       transferList.push(ratingMatrix.buffer.buffer);
+      delta._ratingMatrix.buffer = null;
     }
     if (scheduleBuffer && scheduleBuffer.buffer.byteLength > 0) {
       delta._scheduleBuffer = scheduleBuffer;
       transferList.push(scheduleBuffer.buffer);
+      delta._scheduleBuffer = null;
     }
 
     // Save full payload (not the delta) as the new baseline BEFORE transfer
@@ -272,11 +291,13 @@ function post(type, payload = {}, id = null) {
       const rm = buildRatingMatrix(allPlayers);
       data = { ...payload, _ratingMatrix: { buffer: rm.buffer, playerIds: rm.playerIds } };
       transferList.push(rm.buffer.buffer);
+      data._ratingMatrix.buffer = null;
     }
     if (payload.schedule) {
       const sb = buildScheduleBuffer(payload.schedule);
       data = data === payload ? { ...payload, _scheduleBuffer: sb } : { ...data, _scheduleBuffer: sb };
       transferList.push(sb.buffer);
+      data._scheduleBuffer = null;
     }
 
   } else {
@@ -10594,6 +10615,7 @@ async function handleMessage(event) {
       case toWorker.GET_DRAFT_CLASSES:  return await handleGetDraftClasses(payload, id);
       case toWorker.GET_DRAFT_CLASS:    return await handleGetDraftClass(payload, id);
       case toWorker.GET_PLAYER_DRAFT_CONTEXT: return await handleGetPlayerDraftContext(payload, id);
+      case toWorker.REQUEST_FULL_STATE:  return post(toUI.FULL_STATE, buildViewState(), id);
 
       default:
         console.warn(`[Worker] Unknown message type: ${type}`);

--- a/tests/unit/workerMessaging.test.js
+++ b/tests/unit/workerMessaging.test.js
@@ -367,14 +367,38 @@ describe('applyLeagueDelta', () => {
     expect(prev.week).toBe(1); // original unchanged
   });
 
-  it('falls back to full-state replace when _isDelta is absent', () => {
+  it('rejects malformed patch when _isDelta is absent and requests full reload', () => {
     const prev = makeViewState({ week: 1 });
-    const fullState = makeViewState({ week: 9 });
+    const malformed = { week: 9 };
 
-    const next = applyLeagueDelta(prev, fullState);
+    const next = applyLeagueDelta(prev, malformed);
 
-    expect(next.week).toBe(9);
-    expect(next).not.toBe(fullState); // new object, not the same reference
+    expect(next.week).toBe(1);
+    expect(next._requiresFullState).toBe(true);
+  });
+
+
+
+  it('preserves history arrays across multi-tick deltas unless changed', () => {
+    const history = [{ year: 2024, champ: 'A' }];
+    const chronicle = [{ id: 'c1', text: 'Started franchise' }];
+    let state = makeViewState({ leagueHistory: history, franchiseChronicle: chronicle, week: 1 });
+
+    state = applyLeagueDelta(state, { _isDelta: true, week: 2 });
+    expect(state.leagueHistory).toBe(history);
+    expect(state.franchiseChronicle).toBe(chronicle);
+
+    const nextHistory = [...history, { year: 2025, champ: 'B' }];
+    state = applyLeagueDelta(state, { _isDelta: true, week: 3, leagueHistory: nextHistory });
+    expect(state.leagueHistory).toEqual(nextHistory);
+    expect(state.franchiseChronicle).toBe(chronicle);
+  });
+
+  it('flags non-object deltas for full reload', () => {
+    const prev = makeViewState({ week: 1 });
+    const next = applyLeagueDelta(prev, 'bad_payload');
+    expect(next._requiresFullState).toBe(true);
+    expect(next.week).toBe(1);
   });
 
   it('returns currentState unchanged when delta is null', () => {


### PR DESCRIPTION
### Motivation
- Delta/transferable serialization assumed a stable FULL_STATE baseline and treated non-delta payloads as full replacements, which risks UI state corruption during load/new-league races, phase transitions, or long-dynasty drift. 
- There was no explicit recovery path for the UI to request a fresh FULL_STATE when the baseline was missing or a malformed patch arrived. 
- Transferable buffers risked accidental reuse after being queued for transfer and needed defensive cleanup to avoid accidental access after detach.

### Description
- Added a new protocol command `REQUEST_FULL_STATE` so the UI can explicitly ask the worker to resend a full hydration snapshot. (protocol update)
- Implemented `shouldForceFreshBaseline()` in the worker and use it to force a fresh baseline across phase/draft-lifecycle transitions so deltas are never applied against stale baselines. (worker serialization flow)
- Defensive transfer handling: null out binary buffer references on outbound payload objects immediately after adding them to the transfer list to ensure sender-side code cannot reuse detached buffers. (worker post() changes)
- Hardened `applyLeagueDelta` to reject malformed or non-delta payloads by returning a state marked with `_requiresFullState` instead of silently treating them as full replacements. (serialization.js)
- Updated `useWorker` hook to track whether a FULL_STATE baseline has been established, route incoming STATE_UPDATE messages through `applyLeagueDelta`, request `REQUEST_FULL_STATE` when a delta arrives without a baseline or when a malformed patch is detected, and avoid applying patches that require a full reload. (UI hook changes)
- Extended unit tests in `tests/unit/workerMessaging.test.js` to cover malformed-delta rejection, multi-tick history/chronicle preservation, and non-object delta rejection. (tests added/adjusted)

### Testing
- Ran focused worker messaging tests with `npm run test:unit -- tests/unit/workerMessaging.test.js` and they passed. (37 tests passed)
- Ran the full unit suite with `npm run test:unit` and observed all unit tests pass. (1944 tests passed)
- Built the production bundle with `npm run build`, which completed successfully (Vite build; chunk size warning expected). (build succeeded)
- Ran the dynasty soak suite with `npm run test:soak` and the soak tests passed. (7 soak test files, 85 tests passed)
- Attempted Playwright E2E smoke with `npx playwright test tests/e2e/fresh_franchise_first_week_smoke.spec.js` but it failed in this environment because Chromium is not installed; error recommends running `npx playwright install`. (E2E blocked by missing browser binary)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13bb571030832d92f1b0257b122aa2)