### PR TITLE
Add Bulk Roster Cutdown Assistant with Preview and Safe Batch Release

### DIFF
--- a/src/ui/components/BulkReleasePreviewModal.jsx
+++ b/src/ui/components/BulkReleasePreviewModal.jsx
@@ -1,0 +1,96 @@
+import React, { useMemo, useState } from "react";
+import {
+  calculateReleaseDeadCap,
+  getActiveCapHit,
+  getAnnualBaseSalary,
+  getAnnualBonusProration,
+} from "../../core/contracts/contractObligations.js";
+import { formatMoneyM } from "../utils/numberFormatting.js";
+
+function metricLabelStyle() {
+  return { fontSize: "var(--text-xs)", color: "var(--text-subtle)", textTransform: "uppercase", letterSpacing: "0.06em" };
+}
+
+export default function BulkReleasePreviewModal({ open, players = [], rosterCount = 0, onCancel, onConfirm }) {
+  const [submitting, setSubmitting] = useState(false);
+  const dedupedPlayers = useMemo(() => {
+    const seen = new Set();
+    return players.filter((p) => {
+      const id = Number(p?.id);
+      if (!Number.isFinite(id) || seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
+  }, [players]);
+
+  const totals = useMemo(() => dedupedPlayers.reduce((acc, player) => {
+    const activeCapHit = getActiveCapHit(player);
+    const deadCap = calculateReleaseDeadCap(player)?.total ?? 0;
+    acc.active += activeCapHit;
+    acc.dead += deadCap;
+    return acc;
+  }, { active: 0, dead: 0 }), [dedupedPlayers]);
+
+  if (!open) return null;
+
+  const projectedRosterCount = Math.max(0, rosterCount - dedupedPlayers.length);
+  const warnings = dedupedPlayers.flatMap((player) => {
+    const tags = [];
+    const deadCap = calculateReleaseDeadCap(player)?.total ?? 0;
+    if (Number(player?.ovr ?? 0) >= 82) tags.push("High OVR cut");
+    if (Number(player?.depthOrder ?? 99) <= 1) tags.push("Projected starter");
+    if (deadCap >= 7) tags.push("Large dead cap");
+    if (Number(player?.age ?? 99) <= 24 && Number(player?.contract?.yearsTotal ?? player?.contract?.years ?? 0) >= 3) tags.push("Young/rookie-scale window");
+    return tags.length ? [{ id: player.id, name: player.name, tags }] : [];
+  });
+
+  const handleConfirm = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      await onConfirm?.(dedupedPlayers);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div role="dialog" aria-modal="true" aria-label="Bulk release preview" style={{ position: "fixed", inset: 0, background: "rgba(5,10,20,0.72)", zIndex: 9000, display: "flex", alignItems: "center", justifyContent: "center", padding: "var(--space-3)" }}>
+      <div style={{ width: "min(760px, 100%)", maxHeight: "90vh", overflowY: "auto", background: "var(--surface-2)", border: "1px solid var(--hairline)", borderRadius: "var(--radius-lg)", padding: "var(--space-4)" }}>
+        <h2 style={{ marginBottom: "var(--space-2)", fontSize: "var(--text-lg)", fontWeight: 800 }}>Bulk Release Preview (Estimate)</h2>
+        <div className="bulk-release-preview-grid" style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: "var(--space-2)", marginBottom: "var(--space-3)" }}>
+          <div><div style={metricLabelStyle()}>Selected players</div><div>{dedupedPlayers.length}</div></div>
+          <div><div style={metricLabelStyle()}>Current roster</div><div>{rosterCount}</div></div>
+          <div><div style={metricLabelStyle()}>Projected roster</div><div>{projectedRosterCount}</div></div>
+          <div><div style={metricLabelStyle()}>Active cap removed</div><div>{formatMoneyM(totals.active)}</div></div>
+          <div><div style={metricLabelStyle()}>Estimated dead cap</div><div>{formatMoneyM(totals.dead)}</div></div>
+          <div><div style={metricLabelStyle()}>Est. cap savings</div><div>{formatMoneyM(Math.max(0, totals.active - totals.dead))}</div></div>
+        </div>
+
+        {warnings.length > 0 && (
+          <div style={{ marginBottom: "var(--space-3)", border: "1px solid var(--warning)", borderRadius: 8, padding: "var(--space-2)" }}>
+            <div style={{ fontWeight: 700, marginBottom: 4 }}>Risk warnings</div>
+            {warnings.map((row) => <div key={row.id} style={{ fontSize: "var(--text-sm)" }}>{row.name}: {row.tags.join(", ")}</div>)}
+          </div>
+        )}
+
+        <div style={{ display: "grid", gap: "var(--space-1)", marginBottom: "var(--space-3)" }}>
+          {dedupedPlayers.map((player) => (
+            <div key={player.id} style={{ display: "grid", gridTemplateColumns: "1.3fr repeat(4, minmax(80px, 1fr))", gap: 8, fontSize: "var(--text-sm)", borderBottom: "1px solid var(--hairline)", padding: "6px 0" }}>
+              <div>{player.name} ({player.pos ?? "—"})</div>
+              <div>{formatMoneyM(getAnnualBaseSalary(player))}</div>
+              <div>{formatMoneyM(getAnnualBonusProration(player))}</div>
+              <div>{formatMoneyM(getActiveCapHit(player))}</div>
+              <div>{formatMoneyM(calculateReleaseDeadCap(player)?.total ?? 0)}</div>
+            </div>
+          ))}
+        </div>
+
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: "var(--space-2)", flexWrap: "wrap" }}>
+          <button className="btn" onClick={onCancel} disabled={submitting}>Cancel</button>
+          <button className="btn btn-danger" onClick={handleConfirm} disabled={submitting}>{submitting ? "Releasing..." : "Confirm Bulk Release"}</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -36,6 +36,7 @@ import PlayerProfile from "./PlayerProfile.jsx";
 import PlayerProfileModalBoundary from "./PlayerProfileModalBoundary.jsx";
 import ExtensionNegotiationModal from "./ExtensionNegotiationModal.jsx";
 import ReleasePreviewModal from "./ReleasePreviewModal.jsx";
+import BulkReleasePreviewModal from "./BulkReleasePreviewModal.jsx";
 import { teamColor } from "../../data/team-utils.js";
 import { OFFENSIVE_SCHEMES, DEFENSIVE_SCHEMES } from "../../core/scheme-core.js";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
@@ -489,6 +490,9 @@ function RosterTable({
   const [sortKey, setSortKey] = useState("ovr");
   const [sortDir, setSortDir] = useState("desc");
   const [releaseCandidate, setReleaseCandidate] = useState(null);
+  const [bulkMode, setBulkMode] = useState(false);
+  const [bulkSelectedIds, setBulkSelectedIds] = useState([]);
+  const [bulkPreviewOpen, setBulkPreviewOpen] = useState(false);
   const [extending, setExtending] = useState(null);
   const [advancedFilters, setAdvancedFilters] = useState([]);
   const [search, setSearch] = useState("");
@@ -565,6 +569,24 @@ function RosterTable({
     setReleaseCandidate(null);
     onRefetch?.();
   };
+  const toggleBulkPlayer = (playerId) => {
+    setBulkSelectedIds((prev) => prev.includes(playerId) ? prev.filter((id) => id !== playerId) : [...prev, playerId]);
+  };
+  const selectedPlayers = useMemo(() => {
+    const seen = new Set();
+    return players.filter((p) => bulkSelectedIds.includes(p.id) && !seen.has(p.id) && seen.add(p.id));
+  }, [players, bulkSelectedIds]);
+  const confirmBulkRelease = async (dedupedPlayers) => {
+    const ids = [...new Set((dedupedPlayers ?? []).map((p) => p?.id).filter(Boolean))];
+    if (!ids.length || !actions?.bulkReleasePlayers) return;
+    const result = await actions.bulkReleasePlayers(teamId, ids);
+    if (!result?.ok) {
+      window.alert(`Bulk release stopped after ${result?.released?.length ?? 0} release(s): ${result?.error ?? "Unknown error"}`);
+    }
+    setBulkPreviewOpen(false);
+    setBulkSelectedIds([]);
+    onRefetch?.();
+  };
 
   const handleTradeBlockToggle = async (playerId) => {
     if (!playerId || !actions?.toggleTradeBlock) return;
@@ -608,6 +630,13 @@ function RosterTable({
         capRoomNow={releasePreviewCapRoom}
         onCancel={cancelReleasePreview}
         onConfirm={confirmRelease}
+      />
+      <BulkReleasePreviewModal
+        open={bulkPreviewOpen}
+        players={selectedPlayers}
+        rosterCount={players.length}
+        onCancel={() => setBulkPreviewOpen(false)}
+        onConfirm={confirmBulkRelease}
       />
       {/* Player comparison modal */}
       {showComparison && comparePlayerA && comparePlayerB && (
@@ -681,6 +710,18 @@ function RosterTable({
         <Button variant={evaluationMode ? "default" : "outline"} onClick={() => setEvaluationMode((v) => !v)}>
           {evaluationMode ? "Evaluation view on" : "Evaluation view off"}
         </Button>
+        <Button variant={bulkMode ? "default" : "outline"} onClick={() => { setBulkMode((v) => !v); if (bulkMode) setBulkSelectedIds([]); }} style={{ marginLeft: 8 }}>
+          {bulkMode ? "Bulk cut mode on" : "Bulk cut mode off"}
+        </Button>
+        {bulkMode && (
+          <>
+            <Button variant="outline" onClick={() => setBulkSelectedIds(displayed.map((p) => p.id))} style={{ marginLeft: 8 }}>Select visible</Button>
+            <Button variant="outline" onClick={() => setBulkSelectedIds([])} style={{ marginLeft: 8 }}>Clear</Button>
+            <Button variant="destructive" onClick={() => setBulkPreviewOpen(true)} disabled={bulkSelectedIds.length === 0} style={{ marginLeft: 8 }}>
+              Preview bulk release ({bulkSelectedIds.length})
+            </Button>
+          </>
+        )}
       </div>
 
       {/* Table */}
@@ -699,6 +740,11 @@ function RosterTable({
           >
             <TableHeader>
               <TableRow>
+                <TableHead
+                  style={{ textAlign: "center", width: bulkMode ? 36 : 0 }}
+                >
+                  {bulkMode ? "Sel" : ""}
+                </TableHead>
                 <TableHead
                   style={{
                     paddingLeft: "var(--space-2)",
@@ -832,7 +878,7 @@ function RosterTable({
             <TableBody>
               {displayed.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={12} style={{ padding: 0 }}>
+                  <TableCell colSpan={bulkMode ? 13 : 12} style={{ padding: 0 }}>
                     <EmptyState
                       icon="🧾"
                       title="No players match this filter"
@@ -871,6 +917,9 @@ function RosterTable({
 
                 return (
                   <TableRow key={player.id} style={rowStyle}>
+                    <TableCell style={{ textAlign: "center", padding: "0 var(--space-1)" }}>
+                      {bulkMode ? <input aria-label={`Select ${player.name}`} type="checkbox" checked={bulkSelectedIds.includes(player.id)} onChange={() => toggleBulkPlayer(player.id)} /> : null}
+                    </TableCell>
                     {/* # */}
                     <TableCell
                       style={{

--- a/src/ui/components/__tests__/BulkReleasePreviewModal.test.jsx
+++ b/src/ui/components/__tests__/BulkReleasePreviewModal.test.jsx
@@ -1,0 +1,45 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import BulkReleasePreviewModal from '../BulkReleasePreviewModal.jsx';
+
+afterEach(() => cleanup());
+
+describe('BulkReleasePreviewModal', () => {
+  const players = [
+    { id: 1, name: 'Starter WR', pos: 'WR', ovr: 84, depthOrder: 1, age: 26, contract: { baseAnnual: 10, signingBonus: 6, yearsTotal: 3, yearsRemaining: 2 } },
+    { id: 2, name: 'Depth LB', pos: 'LB', ovr: 71, depthOrder: 3, age: 29, contract: { baseAnnual: 3, signingBonus: 0, yearsTotal: 1, yearsRemaining: 1 } },
+    { id: 1, name: 'Starter WR duplicate', pos: 'WR', ovr: 84, depthOrder: 1, age: 26, contract: { baseAnnual: 10, signingBonus: 6, yearsTotal: 3, yearsRemaining: 2 } },
+  ];
+
+  it('renders selected players and deduped totals', () => {
+    render(<BulkReleasePreviewModal open players={players} rosterCount={53} onCancel={vi.fn()} onConfirm={vi.fn()} />);
+    expect(screen.getByRole('dialog', { name: /bulk release preview/i })).toBeTruthy();
+    expect(screen.getByText('Projected roster')).toBeTruthy();
+    expect(screen.getByText('51')).toBeTruthy();
+    expect(screen.getByText(/\$15.0M/)).toBeTruthy();
+    expect(screen.getAllByText(/\$4.0M/).length).toBeGreaterThan(0);
+  });
+
+  it('cancel is safe and confirm is single-call with deduped players', async () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    render(<BulkReleasePreviewModal open players={players} rosterCount={53} onCancel={onCancel} onConfirm={onConfirm} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledTimes(0);
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm bulk release/i }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm.mock.calls[0][0]).toHaveLength(2);
+  });
+
+  it('renders risk warnings for high-risk cuts and handles sparse contracts', () => {
+    render(<BulkReleasePreviewModal open players={[{ id: 4, name: 'Rookie QB', pos: 'QB', ovr: 83, depthOrder: 1, age: 22, contract: {} }]} rosterCount={53} onCancel={vi.fn()} onConfirm={vi.fn()} />);
+    expect(screen.getByText(/risk warnings/i)).toBeTruthy();
+    expect(screen.getByText(/high ovr cut/i)).toBeTruthy();
+    expect(screen.getByText(/projected starter/i)).toBeTruthy();
+  });
+});

--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -615,6 +615,8 @@ export function useWorker() {
     /** Release a player. */
     releasePlayer: (playerId, teamId) =>
       send(toWorker.RELEASE_PLAYER, { playerId, teamId }),
+    bulkReleasePlayers: (teamId, playerIds) =>
+      request(toWorker.BULK_RELEASE_PLAYERS, { teamId, playerIds }),
 
     /** Fetch a team's roster (returns a Promise — does NOT set busy). */
     getRoster: (teamId) => request(toWorker.GET_ROSTER, { teamId }, { silent: true }),

--- a/src/worker/protocol.js
+++ b/src/worker/protocol.js
@@ -55,6 +55,7 @@ export const toWorker = Object.freeze({
   SUBMIT_OFFER:       'SUBMIT_OFFER',      // { playerId, teamId, contract }
   ADVANCE_FREE_AGENCY_DAY: 'ADVANCE_FREE_AGENCY_DAY', // {}
   RELEASE_PLAYER:     'RELEASE_PLAYER',    // { playerId, teamId }
+  BULK_RELEASE_PLAYERS: 'BULK_RELEASE_PLAYERS', // { teamId, playerIds: number[] }
   PROCESS_FA_WAVE:    'PROCESS_FA_WAVE',   // AI teams act in FA
 
   /** Trades */

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -6027,62 +6027,71 @@ async function resolvePendingFreeAgencyOffers({ resolutionDay = 7, onlyPlayerId 
 
 // ── Handler: RELEASE_PLAYER ───────────────────────────────────────────────────
 
-async function handleReleasePlayer({ playerId, teamId }, id) {
-  let player = cache.getPlayer(playerId);
-  if (!player) { post(toUI.ERROR, { message: 'Player not found' }, id); return; }
+async function releasePlayerWithValidation({ playerId, teamId }) {
+  const player = cache.getPlayer(playerId);
+  if (!player) return { ok: false, error: 'Player not found' };
+  if (Number(player.teamId) !== Number(teamId)) return { ok: false, error: 'Player is not on selected roster' };
 
-  // ── June 1st Dead Money Rule ────────────────────────────────────────────────
-  // Pre-June-1 phases (offseason_resign): ALL remaining prorated bonus accelerates
-  //   to the current year's dead cap.
-  // Post-June-1 phases (free_agency, draft, preseason, regular, playoffs):
-  //   This year's prorated bonus hits current dead cap; future years defer to
-  //   deadMoneyNextYear (carries into next season's cap).
   const meta = ensureDynastyMeta(cache.getMeta());
   const team = cache.getTeam(teamId);
   if (team && player.contract) {
     const yearsRemaining = Math.max(player.contract.years ?? 1, 1);
     const yearsTotal     = Math.max(player.contract.yearsTotal ?? yearsRemaining, 1);
     const totalBonus     = player.contract.signingBonus ?? 0;
-    const annualBonus    = totalBonus / yearsTotal;   // prorated share per year
+    const annualBonus    = totalBonus / yearsTotal;
 
     const isPostJune1 = Constants.SALARY_CAP.POST_JUNE1_PHASES.includes(meta.phase);
 
     if (isPostJune1 && yearsRemaining > 1) {
-      // Current-year prorated bonus → dead cap now
       const currentYearDead = annualBonus;
-      // Future years' prorated bonus → deferred to next season
       const futureYearsDead = annualBonus * (yearsRemaining - 1);
-
-      if (currentYearDead > 0) {
-        cache.updateTeam(teamId, { deadCap: (team.deadCap ?? 0) + currentYearDead });
-      }
+      if (currentYearDead > 0) cache.updateTeam(teamId, { deadCap: (team.deadCap ?? 0) + currentYearDead });
       if (futureYearsDead > 0) {
         const freshTeam = cache.getTeam(teamId);
         cache.updateTeam(teamId, { deadMoneyNextYear: (freshTeam.deadMoneyNextYear ?? 0) + futureYearsDead });
       }
     } else {
-      // Pre-June-1: all remaining prorated bonus hits current year
       const deadMoney = annualBonus * yearsRemaining;
-      if (deadMoney > 0) {
-        cache.updateTeam(teamId, { deadCap: (team.deadCap ?? 0) + deadMoney });
-      }
+      if (deadMoney > 0) cache.updateTeam(teamId, { deadCap: (team.deadCap ?? 0) + deadMoney });
     }
   }
 
-  // Use player.id (the canonical key from the cache) for all subsequent writes.
   markOffseasonRelease(player, teamId, meta);
   cache.updatePlayer(player.id, { teamId: null, status: 'free_agent', offers: [] });
   recalculateTeamCap(teamId);
-
-  // meta is already declared above
   await Transactions.add({
     type: 'RELEASE', seasonId: meta.currentSeasonId,
     week: meta.currentWeek, teamId, details: { playerId: player.id },
   });
   await NewsEngine.logTransaction('RELEASE', { teamId, playerId: player.id });
+  return { ok: true, playerId: player.id };
+}
 
+async function handleReleasePlayer({ playerId, teamId }, id) {
+  let player = cache.getPlayer(playerId);
+  if (!player) { post(toUI.ERROR, { message: 'Player not found' }, id); return; }
+
+  await releasePlayerWithValidation({ playerId, teamId });
   await flushDirty();
   post(toUI.STATE_UPDATE, { roster: buildRosterView(teamId), ...buildViewState() }, id);
+}
+
+async function handleBulkReleasePlayers({ teamId, playerIds }, id) {
+  const uniquePlayerIds = [...new Set((Array.isArray(playerIds) ? playerIds : []).map(Number).filter(Number.isFinite))];
+  const released = [];
+  for (const playerId of uniquePlayerIds) {
+    const outcome = await releasePlayerWithValidation({ playerId, teamId });
+    if (!outcome.ok) {
+      await flushDirty();
+      post(toUI.ERROR, { message: `Bulk release stopped: ${outcome.error}` }, id);
+      post(toUI.STATE_UPDATE, { roster: buildRosterView(teamId), ...buildViewState() }, id);
+      return post(toUI.SUCCESS, { ok: false, released, failedPlayerId: playerId, error: outcome.error }, id);
+    }
+    released.push(playerId);
+  }
+  await flushDirty();
+  post(toUI.STATE_UPDATE, { roster: buildRosterView(teamId), ...buildViewState() }, id);
+  post(toUI.SUCCESS, { ok: true, released }, id);
 }
 
 // ── Handler: GET_ROSTER ───────────────────────────────────────────────────────
@@ -10567,6 +10576,7 @@ async function handleMessage(event) {
       case toWorker.SIGN_PLAYER:        return await handleSignPlayer(payload, id);
       case toWorker.SUBMIT_OFFER:       return await handleSubmitOffer(payload, id);
       case toWorker.RELEASE_PLAYER:     return await handleReleasePlayer(payload, id);
+      case toWorker.BULK_RELEASE_PLAYERS: return await handleBulkReleasePlayers(payload, id);
       case toWorker.UPDATE_SETTINGS:    return await handleUpdateSettings(payload, id);
       case toWorker.TOGGLE_COMMISSIONER_MODE: return await handleToggleCommissionerMode(payload, id);
       case toWorker.APPLY_COMMISSIONER_ACTIONS: return await handleApplyCommissionerActions(payload, id);


### PR DESCRIPTION
### Motivation
- Long preseason/roster cutdown flows required dozens of repeated single-player confirmations; GMs need an optional bulk assistant to preview financial/roster impact and confirm safely. 
- The implementation must reuse existing release/contract helpers and never bypass release validation, dead-cap or roster rules.

### Description
- Add UI bulk-cut mode in `Roster.jsx` with per-row selection checkboxes, `Select visible` / `Clear` controls, a selected-count CTA and mobile-safe layout toggled by a new bulk mode button. 
- New `BulkReleasePreviewModal.jsx` shows deduped selected players, current/projected roster count, aggregated `active cap removed`, `estimated dead cap`, `estimated cap savings`, and conservative risk warnings (starter / high OVR / large dead-cap / young/rookie window) using existing helpers `getActiveCapHit`, `calculateReleaseDeadCap`, `getAnnualBaseSalary`, and `getAnnualBonusProration`. 
- Worker/protocol changes: add `toWorker.BULK_RELEASE_PLAYERS` and `useWorker().bulkReleasePlayers(...)`, factor release logic into `releasePlayerWithValidation(...)` reused by the original `handleReleasePlayer` and new `handleBulkReleasePlayers`, where bulk releases dedupe IDs, run sequentially, stop on first failure and surface partial-failure details. 
- Files changed/added: `src/ui/components/BulkReleasePreviewModal.jsx`, `src/ui/components/Roster.jsx`, `src/ui/hooks/useWorker.js`, `src/worker/protocol.js`, `src/worker/worker.js`, and tests `src/ui/components/__tests__/BulkReleasePreviewModal.test.jsx`.

### Testing
- Ran unit tests with `npm run test:unit` and all tests passed (new modal tests included). 
- Built production bundle with `npm run build` which completed successfully (build chunk-size warnings are unchanged). 
- Attempted E2E smoke test `npx playwright test tests/e2e/fresh_franchise_first_week_smoke.spec.js`, which failed in this environment because Playwright browsers are not installed (error: please run `npx playwright install`), so full Playwright validation was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13d9b72784832d9c4cf717a970b517)