### PR TITLE
Add deterministic advanced box-score event attribution to rich game summaries

### DIFF
--- a/src/core/sim/matchupEngine.ts
+++ b/src/core/sim/matchupEngine.ts
@@ -10,6 +10,15 @@ export interface PlayContext {
   fatigueFactor?: number;
   normalizationConstant?: number;
   playType?: 'pass' | 'run';
+  targetId?: string;
+  defenderId?: string;
+  blockerId?: string;
+  rusherId?: string;
+}
+
+export interface PlayAttributionEvent {
+  event: 'TARGET' | 'RECEPTION_ALLOWED' | 'COVERAGE_TARGET' | 'COVERAGE_COMPLETION_ALLOWED' | 'DROP' | 'BATTED_PASS' | 'SACK_ALLOWED' | 'SACK_MADE';
+  playerId?: string;
 }
 
 export interface PlayResult {
@@ -26,6 +35,7 @@ export interface PlayResult {
   turnoverType: 'interception' | 'fumble' | null;
   isSack: boolean;
   firstDown: boolean;
+  attributionEvents?: PlayAttributionEvent[];
 }
 
 const OFFENSE_WEIGHTS: ReadonlyArray<[keyof AttributesV2, number]> = Object.freeze([
@@ -158,6 +168,12 @@ function nextDownState(ctx: PlayContext, yardsGained: number): Pick<PlayResult, 
   };
 }
 
+
+function maybePushAttribution(events: PlayAttributionEvent[], event: PlayAttributionEvent['event'], playerId?: string) {
+  if (!playerId) return;
+  events.push({ event, playerId });
+}
+
 export function resolveMatchup(
   offense: AttributesV2,
   defense: AttributesV2,
@@ -201,6 +217,25 @@ export function resolveMatchup(
 
   const clockElapsedSec = Math.round(clamp(22 + rng() * (playType === 'run' ? 20 : 16) + (success ? 2 : 0), 18, 45));
   const next = nextDownState(ctx, yardsGained);
+  const attributionEvents: PlayAttributionEvent[] = [];
+  if (playType === 'pass') {
+    maybePushAttribution(attributionEvents, 'TARGET', ctx.targetId);
+    maybePushAttribution(attributionEvents, 'COVERAGE_TARGET', ctx.defenderId);
+    if (success) {
+      maybePushAttribution(attributionEvents, 'RECEPTION_ALLOWED', ctx.targetId);
+      maybePushAttribution(attributionEvents, 'COVERAGE_COMPLETION_ALLOWED', ctx.defenderId);
+    } else if (!isSack) {
+      if (rng() <= 0.34) {
+        maybePushAttribution(attributionEvents, 'DROP', ctx.targetId);
+      } else if (rng() <= 0.26) {
+        maybePushAttribution(attributionEvents, 'BATTED_PASS', ctx.defenderId);
+      }
+    }
+  }
+  if (isSack) {
+    maybePushAttribution(attributionEvents, 'SACK_ALLOWED', ctx.blockerId);
+    maybePushAttribution(attributionEvents, 'SACK_MADE', ctx.rusherId);
+  }
 
   return {
     success,
@@ -213,6 +248,7 @@ export function resolveMatchup(
     turnoverType,
     isSack,
     firstDown: next.nextDown === 1 && next.nextDistance === 10 && next.nextYardLine < 100 && yardsGained >= ctx.distance,
+    attributionEvents,
     ...next,
   };
 }

--- a/src/core/sim/richGameSimulator.ts
+++ b/src/core/sim/richGameSimulator.ts
@@ -53,6 +53,17 @@ export interface GameEventDigestItem {
   awayScore: number;
 }
 
+export interface AdvancedGameStats {
+  targets: number;
+  receptionsAllowed: number;
+  coverageTargets: number;
+  coverageCompletionsAllowed: number;
+  drops: number;
+  battedPasses: number;
+  sacksAllowed: number;
+  sacksMade: number;
+}
+
 export interface RichGameSummary {
   gameId: number | string;
   homeTeamId: number;
@@ -92,6 +103,7 @@ export interface RichGameSummary {
     headlineMoments: string[];
   };
   recapText: string;
+  advancedAttribution?: Record<string, AdvancedGameStats>;
   simFactors: {
     home: { qbRating: number; rushYpc: number; successRate: number; passRate: number };
     away: { qbRating: number; rushYpc: number; successRate: number; passRate: number };
@@ -217,6 +229,13 @@ function defaultPlayers(teamId: number, side: 'home' | 'away'): SimPlayerRef[] {
   ];
 }
 
+
+function pickWeightedPlayer(players: SimPlayerRef[], rng: () => number, weight: (p: SimPlayerRef) => number): SimPlayerRef | null {
+  if (!players.length) return null;
+  const idx = chooseWeightedIndex(players.map((player) => weight(player)), rng);
+  return players[idx] ?? players[0] ?? null;
+}
+
 function chooseWeightedIndex(weights: number[], rng: () => number): number {
   const total = weights.reduce((sum, w) => sum + Math.max(0, w), 0);
   if (total <= 0) return 0;
@@ -307,6 +326,7 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
   const reasonMap = new Map<string, number>();
   const homePrep = payload.homePrepMultipliers ?? NEUTRAL_PREP;
   const awayPrep = payload.awayPrepMultipliers ?? NEUTRAL_PREP;
+  const advancedAttribution = new Map<string, AdvancedGameStats>();
 
   const stats = {
     home: { plays: 0, passAtt: 0, passComp: 0, passYd: 0, passTD: 0, rushAtt: 0, rushYd: 0, rushTD: 0, firstDowns: 0, turnovers: 0, sacksAllowed: 0, sacksMade: 0, interceptions: 0, redZoneTrips: 0, redZoneScores: 0, explosivePlays: 0, success: 0, fieldGoalsMade: 0, fieldGoalsAttempted: 0, extraPointsMade: 0, extraPointsAttempted: 0, punts: 0, puntYards: 0, kickReturns: 0, kickReturnYards: 0, puntReturns: 0, puntReturnYards: 0 },
@@ -324,6 +344,12 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
 
     const offensePrep = state.possession === 'home' ? homePrep : awayPrep;
     const playType = getPlayType(state, rng, offensePrep);
+    const offensePlayers = state.possession === 'home' ? homePlayers : awayPlayers;
+    const defensePlayers = state.possession === 'home' ? awayPlayers : homePlayers;
+    const target = playType === 'pass' ? pickWeightedPlayer(offensePlayers.filter((player) => ['WR', 'TE', 'RB'].includes(player.pos)), rng, (player) => (player.ovr ?? 70) + (player.pos === 'WR' ? 12 : player.pos === 'TE' ? 8 : 5)) : null;
+    const defender = playType === 'pass' ? pickWeightedPlayer(defensePlayers.filter((player) => ['CB', 'S', 'FS', 'SS', 'LB'].includes(player.pos)), rng, (player) => (player.ovr ?? 70) + (player.pos === 'CB' ? 10 : 6)) : null;
+    const blocker = pickWeightedPlayer(offensePlayers.filter((player) => ['OT', 'OG', 'C', 'TE', 'RB', 'QB'].includes(player.pos)), rng, (player) => (player.ovr ?? 70) + (player.pos === 'QB' ? -10 : 0));
+    const rusher = pickWeightedPlayer(defensePlayers.filter((player) => ['EDGE', 'DE', 'DT', 'LB'].includes(player.pos)), rng, (player) => (player.ovr ?? 70) + (player.pos === 'EDGE' ? 12 : 6));
     const tunedOffense = applyPrepToOffenseAttributes(offense, offensePrep, playType, state.yardLine >= 80);
     const fatigueBaseline = (stats.home.plays + stats.away.plays) / 220;
     const result = resolveMatchup(tunedOffense, defense, {
@@ -336,6 +362,10 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
       normalizationConstant: state.normalizationConstant,
       fatigueFactor: clamp(fatigueBaseline - offensePrep.fatigueDisciplineDelta * 0.35, 0, 0.95),
       playType,
+      targetId: target?.id != null ? String(target.id) : undefined,
+      defenderId: defender?.id != null ? String(defender.id) : undefined,
+      blockerId: blocker?.id != null ? String(blocker.id) : undefined,
+      rusherId: rusher?.id != null ? String(rusher.id) : undefined,
     }, rng);
 
     offenseStats.plays += 1;
@@ -356,6 +386,32 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
       defenseStats.sacksMade += 1;
       pushDigest(digest, { quarter: state.quarter, clockSec: state.clockSec, team: state.possession === 'home' ? 'away' : 'home', type: 'sack', text: `${state.possession === 'home' ? 'Away' : 'Home'} defense generated a drive-killing sack.` }, state);
     }
+
+    for (const event of result.attributionEvents ?? []) {
+      if (!event.playerId) continue;
+      const prev = advancedAttribution.get(event.playerId) ?? {
+        targets: 0,
+        receptionsAllowed: 0,
+        coverageTargets: 0,
+        coverageCompletionsAllowed: 0,
+        drops: 0,
+        battedPasses: 0,
+        sacksAllowed: 0,
+        sacksMade: 0,
+      };
+      switch (event.event) {
+        case 'TARGET': prev.targets += 1; break;
+        case 'RECEPTION_ALLOWED': prev.receptionsAllowed += 1; break;
+        case 'COVERAGE_TARGET': prev.coverageTargets += 1; break;
+        case 'COVERAGE_COMPLETION_ALLOWED': prev.coverageCompletionsAllowed += 1; break;
+        case 'DROP': prev.drops += 1; break;
+        case 'BATTED_PASS': prev.battedPasses += 1; break;
+        case 'SACK_ALLOWED': prev.sacksAllowed += 1; break;
+        case 'SACK_MADE': prev.sacksMade += 1; break;
+      }
+      advancedAttribution.set(event.playerId, prev);
+    }
+
     if (Math.abs(result.yardsGained) >= 20 && result.yardsGained > 0) {
       offenseStats.explosivePlays += 1;
       pushDigest(digest, { quarter: state.quarter, clockSec: state.clockSec, team: state.possession, type: 'explosive_play', text: `${state.possession === 'home' ? 'Home' : 'Away'} offense popped an explosive ${result.playType} play.` }, state);
@@ -685,6 +741,7 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
       headlineMoments: digest.slice(0, 3).map((event) => event.text),
     },
     recapText,
+    advancedAttribution: Object.fromEntries(advancedAttribution),
     simFactors: {
       home: {
         qbRating: buildQbRating(homeTeamLine.passComp, homeTeamLine.passAtt, homeTeamLine.passYd, homeTeamLine.passTD, homeTeamLine.turnovers),

--- a/src/ui/utils/boxScoreViewModel.js
+++ b/src/ui/utils/boxScoreViewModel.js
@@ -11,6 +11,20 @@ const toNum = (v) => {
 
 const mdash = '—';
 
+function normalizeAdvancedAttribution(value) {
+  if (!value || typeof value !== 'object') return {};
+  return Object.fromEntries(Object.entries(value).map(([playerId, row]) => [String(playerId), {
+    targets: Number(row?.targets ?? 0),
+    receptionsAllowed: Number(row?.receptionsAllowed ?? 0),
+    coverageTargets: Number(row?.coverageTargets ?? 0),
+    coverageCompletionsAllowed: Number(row?.coverageCompletionsAllowed ?? 0),
+    drops: Number(row?.drops ?? 0),
+    battedPasses: Number(row?.battedPasses ?? 0),
+    sacksAllowed: Number(row?.sacksAllowed ?? 0),
+    sacksMade: Number(row?.sacksMade ?? 0),
+  }]));
+}
+
 function hasValues(obj) {
   return Boolean(obj && typeof obj === 'object' && Object.keys(obj).length > 0);
 }
@@ -559,6 +573,7 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
     },
     gameFlowSummary: buildGameFlowSummary(payload),
     prepImpact: Array.isArray(payload?.prepImpact) ? payload.prepImpact : (payload?.prepImpact ? [String(payload.prepImpact)] : []),
+    advancedAttribution: normalizeAdvancedAttribution(payload?.advancedAttribution),
     detailWarning,
     missingDetailReason: detailWarning,
     hasDetailedStats: archiveQuality === QUALITY.full || archiveQuality === QUALITY.partial,

--- a/tests/unit/eventAttribution.test.js
+++ b/tests/unit/eventAttribution.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { mapOverallToAttributesV2 } from '../../src/core/migration/attributeMigrator.ts';
+import { simulateRichGame } from '../../src/core/sim/richGameSimulator.ts';
+import { buildBoxScoreViewModel } from '../../src/ui/utils/boxScoreViewModel.js';
+
+function buildPayload(seed = 42) {
+  return {
+    gameId: `attr-${seed}`,
+    homeTeamId: 10,
+    awayTeamId: 20,
+    seed,
+    weather: 'clear',
+    homeOffense: mapOverallToAttributesV2(84, 5.5, `ho-${seed}`),
+    awayOffense: mapOverallToAttributesV2(82, 5.5, `ao-${seed}`),
+    homeDefense: mapOverallToAttributesV2(83, 5.5, `hd-${seed}`),
+    awayDefense: mapOverallToAttributesV2(81, 5.5, `ad-${seed}`),
+    homePlayers: [
+      { id: 'h-qb', name: 'HQB', pos: 'QB', ovr: 84 },
+      { id: 'h-wr1', name: 'HWR1', pos: 'WR', ovr: 82 },
+      { id: 'h-te1', name: 'HTE1', pos: 'TE', ovr: 80 },
+      { id: 'h-edge1', name: 'HEDGE1', pos: 'EDGE', ovr: 84 },
+      { id: 'h-cb1', name: 'HCB1', pos: 'CB', ovr: 83 },
+    ],
+    awayPlayers: [
+      { id: 'a-qb', name: 'AQB', pos: 'QB', ovr: 83 },
+      { id: 'a-wr1', name: 'AWR1', pos: 'WR', ovr: 81 },
+      { id: 'a-te1', name: 'ATE1', pos: 'TE', ovr: 79 },
+      { id: 'a-edge1', name: 'AEDGE1', pos: 'EDGE', ovr: 83 },
+      { id: 'a-cb1', name: 'ACB1', pos: 'CB', ovr: 82 },
+    ],
+  };
+}
+
+describe('advanced box score event attribution', () => {
+  it('captures pass-context events in the attribution map', () => {
+    const summary = simulateRichGame(buildPayload(77));
+    const rows = Object.values(summary.advancedAttribution ?? {});
+
+    const totalTargets = rows.reduce((sum, row) => sum + (row.targets ?? 0), 0);
+    const totalDrops = rows.reduce((sum, row) => sum + (row.drops ?? 0), 0);
+    const totalBatted = rows.reduce((sum, row) => sum + (row.battedPasses ?? 0), 0);
+
+    expect(totalTargets).toBeGreaterThan(0);
+    expect(totalDrops + totalBatted).toBeGreaterThanOrEqual(0);
+  });
+
+  it('is deterministic for seeded replays', () => {
+    const one = simulateRichGame(buildPayload(1234));
+    const two = simulateRichGame(buildPayload(1234));
+    expect(one.advancedAttribution).toEqual(two.advancedAttribution);
+  });
+
+  it('keeps legacy summaries render-safe when attribution is absent', () => {
+    const legacySummary = simulateRichGame(buildPayload(88));
+    delete legacySummary.advancedAttribution;
+
+    const vm = buildBoxScoreViewModel({
+      league: { teams: [{ id: 10, abbr: 'HOM', name: 'Home' }, { id: 20, abbr: 'AWY', name: 'Away' }] },
+      game: { ...legacySummary, id: legacySummary.gameId, played: true },
+    });
+
+    expect(vm.advancedAttribution).toEqual({});
+    expect(vm.archiveQuality).toBeTruthy();
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide single-game, transient event attribution (targets, drops, batted passes, coverage targets/completions, sack attribution) so the UI and analytics can surface richer per-play context without changing persistent player schemas. 
- Keep the simulation deterministic and safe for worker-delta JSON serialization by using only the existing seeded RNG and compact per-player counters.
- Ensure backward compatibility so legacy summaries without the new field still render without errors.

### Description
- Extended `PlayContext` with optional participant IDs (`targetId`, `defenderId`, `blockerId`, `rusherId`) and added a compact `PlayAttributionEvent` emitted from `resolveMatchup` for pass/sack contexts in `src/core/sim/matchupEngine.ts`.
- Added an `AdvancedGameStats` interface and an `advancedAttribution` map on `RichGameSummary` and implemented deterministic aggregation (seeded RNG only) in `simulateRichGame` to accumulate per-player counters, with a lightweight `pickWeightedPlayer` helper to choose participants using the same seeded RNG in `src/core/sim/richGameSimulator.ts`.
- Kept all player and persistent stats untouched; attribution is transient, per-game, and returned inside the rich summary payload as a compact `Record<string, AdvancedGameStats>`.
- Added `normalizeAdvancedAttribution` to `src/ui/utils/boxScoreViewModel.js` so the view-model safely normalizes missing or legacy payloads to `{}` and remains render-safe.
- Added unit tests `tests/unit/eventAttribution.test.js` covering attribution emission, deterministic replay for a seed, and legacy-summary render safety.

### Testing
- Ran targeted unit tests: `npx vitest run tests/unit/eventAttribution.test.js src/core/__tests__/richGameSimulator.test.ts` and they passed.
- Ran the full unit suite: `npm run test:unit` and it completed successfully (all tests passed in CI run recorded during development).
- Verified production build with `npm run build` completed successfully and produced expected assets (bundle warnings only, no errors).
- Ran dynasty soak subset with `npm run test:soak` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13e0a4cadc832d8d682136e55e93ab)