### PR TITLE
Add Advanced Game Stats UI section to Game Book

### DIFF
--- a/src/ui/components/AdvancedGameStats.jsx
+++ b/src/ui/components/AdvancedGameStats.jsx
@@ -1,0 +1,88 @@
+import React, { useMemo } from "react";
+import { PlayerButton } from "./BoxScore.jsx";
+
+const FIELDS = [
+  { key: "targets", label: "Tgt" },
+  { key: "drops", label: "Drop", tone: "negative" },
+  { key: "battedPasses", label: "Bat", tone: "positive" },
+  { key: "coverageTargets", label: "Cov Tgt" },
+  { key: "coverageCompletionsAllowed", label: "Cov Comp", tone: "negative" },
+  { key: "receptionsAllowed", label: "Rec All" },
+  { key: "sacksAllowed", label: "Sck All", tone: "negative" },
+  { key: "sacksMade", label: "Sck Made", tone: "positive" },
+];
+
+function asSafeNumber(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function hasAnyAdvancedValue(row = {}) {
+  return FIELDS.some(({ key }) => asSafeNumber(row?.[key]) !== 0);
+}
+
+function buildPlayerMap(playerTables = {}) {
+  const players = [...(playerTables?.away ?? []), ...(playerTables?.home ?? [])];
+  return players.reduce((acc, player) => {
+    if (player?.playerId == null) return acc;
+    acc[String(player.playerId)] = player;
+    return acc;
+  }, {});
+}
+
+export default function AdvancedGameStats({ advancedAttribution, playerTables, onPlayerSelect, context }) {
+  const rows = useMemo(() => {
+    if (!advancedAttribution || typeof advancedAttribution !== "object") return [];
+    const playerMap = buildPlayerMap(playerTables);
+    return Object.entries(advancedAttribution)
+      .map(([playerId, raw]) => {
+        const safe = FIELDS.reduce((acc, { key }) => {
+          acc[key] = asSafeNumber(raw?.[key]);
+          return acc;
+        }, {});
+        return { playerId: String(playerId), player: playerMap[String(playerId)] ?? null, stats: safe };
+      })
+      .filter((row) => hasAnyAdvancedValue(row.stats))
+      .sort((a, b) => Number(a.playerId) - Number(b.playerId));
+  }, [advancedAttribution, playerTables]);
+
+  if (!rows.length) return null;
+
+  return (
+    <section className="bs-section" data-testid="game-book-advanced-stats">
+      <div className="bs-section-header">
+        <h4>Advanced Game Stats</h4>
+        <span className="bs-section-count">{rows.length} players</span>
+      </div>
+      <div className="bs-table-wrap bs-table-wrap--compact" role="region" aria-label="Advanced game stats — scroll horizontally to view all columns">
+        <table className="box-score-table" data-testid="advanced-game-stats-table">
+          <thead>
+            <tr>
+              <th scope="col">Player</th>
+              <th scope="col">Pos</th>
+              {FIELDS.map((field) => <th key={field.key} scope="col">{field.label}</th>)}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const displayPlayer = row.player ?? { playerId: row.playerId, name: `#${row.playerId}` };
+              return (
+                <tr key={`advanced-${row.playerId}`}>
+                  <td>
+                    {row.player ? <PlayerButton player={row.player} onSelect={onPlayerSelect} context={context} /> : `#${row.playerId}`}
+                  </td>
+                  <td>{displayPlayer?.position ?? displayPlayer?.pos ?? "—"}</td>
+                  {FIELDS.map((field) => (
+                    <td key={`${row.playerId}-${field.key}`} className={field.tone === "negative" && row.stats[field.key] > 0 ? "status-chip warning" : field.tone === "positive" && row.stats[field.key] > 0 ? "status-chip success" : undefined}>
+                      {row.stats[field.key]}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -5,6 +5,7 @@ import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 import { buildGameBookStory } from "../utils/gameBookStory.js";
 import { getPlayerProfileId, hasValidPlayerProfileId, openPlayerProfile } from "../utils/playerProfileNavigation.js";
 import ReplayableGameFlowViewer from "./ReplayableGameFlowViewer.jsx";
+import AdvancedGameStats from "./AdvancedGameStats.jsx";
 
 const QUALITY_BADGE_CLASS = {
   "Full detail": "success",
@@ -512,6 +513,14 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
       {vm.prepImpact?.length ? (
         <section className="bs-section"><h4>Game-plan impact</h4><ul>{vm.prepImpact.map((item, i) => <li key={`${i}-${item}`}>{item}</li>)}</ul></section>
       ) : null}
+      <AdvancedGameStats
+        advancedAttribution={vm.advancedAttribution}
+        playerTables={vm.playerTables}
+        awayTeam={vm.awayTeam}
+        homeTeam={vm.homeTeam}
+        onPlayerSelect={onPlayerSelect}
+        context={{ ...gameContextBase, role: "Advanced Game Stats", returnTo: "game-book" }}
+      />
       {tableSections.length ? tableSections.map(renderTable) : (
         <section className="bs-section" data-testid="game-book-player-stats-empty">
           <h4>Player stat tables</h4>

--- a/src/ui/components/__tests__/AdvancedGameStats.test.jsx
+++ b/src/ui/components/__tests__/AdvancedGameStats.test.jsx
@@ -1,0 +1,61 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import AdvancedGameStats from '../AdvancedGameStats.jsx';
+
+const basePlayerTables = {
+  away: [{ playerId: 12, name: 'WR Alpha', position: 'WR' }],
+  home: [{ playerId: 34, name: 'CB Beta', position: 'CB' }],
+};
+
+describe('AdvancedGameStats', () => {
+  afterEach(() => cleanup());
+  it('renders null when advancedAttribution is missing', () => {
+    const { container } = render(<AdvancedGameStats />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders rows and all advanced labels', () => {
+    render(
+      <AdvancedGameStats
+        advancedAttribution={{
+          12: { targets: 5, drops: 1, battedPasses: 0, coverageTargets: 0, coverageCompletionsAllowed: 0, receptionsAllowed: 0, sacksAllowed: 2, sacksMade: 0 },
+          34: { targets: 0, drops: 0, battedPasses: 2, coverageTargets: 7, coverageCompletionsAllowed: 3, receptionsAllowed: 3, sacksAllowed: 0, sacksMade: 1 },
+        }}
+        playerTables={basePlayerTables}
+      />,
+    );
+
+    expect(screen.getByTestId('game-book-advanced-stats')).toBeTruthy();
+    expect(screen.getByText('Tgt')).toBeTruthy();
+    expect(screen.getByText('Drop')).toBeTruthy();
+    expect(screen.getByText('Bat')).toBeTruthy();
+    expect(screen.getByText('Cov Tgt')).toBeTruthy();
+    expect(screen.getByText('Cov Comp')).toBeTruthy();
+    expect(screen.getByText('Sck All')).toBeTruthy();
+    expect(screen.getByText('Sck Made')).toBeTruthy();
+    expect(screen.getByText('WR Alpha')).toBeTruthy();
+    expect(screen.getByText('CB Beta')).toBeTruthy();
+  });
+
+  it('falls back to player id for unknown players and preserves mobile wrappers', () => {
+    render(<AdvancedGameStats advancedAttribution={{ 999: { targets: 1 } }} playerTables={basePlayerTables} />);
+    expect(screen.getByText('#999')).toBeTruthy();
+    const wrapper = screen.getAllByRole('region', { name: /advanced game stats/i }).at(-1);
+    expect(wrapper?.className).toContain('bs-table-wrap');
+  });
+
+  it('does not mutate input objects', () => {
+    const advancedAttribution = Object.freeze({ 12: Object.freeze({ targets: '3', drops: '1' }) });
+    const spy = vi.fn();
+    render(<AdvancedGameStats advancedAttribution={advancedAttribution} playerTables={basePlayerTables} onPlayerSelect={spy} />);
+    expect(advancedAttribution[12].targets).toBe('3');
+  });
+
+  it('handles legacy empty object without crashing', () => {
+    const { container } = render(<AdvancedGameStats advancedAttribution={{}} playerTables={basePlayerTables} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/ui/components/__tests__/BoxScoreAutoOpen.test.jsx
+++ b/src/ui/components/__tests__/BoxScoreAutoOpen.test.jsx
@@ -106,6 +106,44 @@ describe('BoxScore – opt-in auto-open replay gate', () => {
     expect(getByTestId('rgfv-progress').textContent).toBe('Playing…');
   });
 
+
+  it('renders advanced game stats section when advancedAttribution exists', () => {
+    const gameWithAdvanced = {
+      ...gameWithFlow,
+      advancedAttribution: {
+        12: { targets: 4, drops: 1, battedPasses: 0, coverageTargets: 0, coverageCompletionsAllowed: 0, receptionsAllowed: 0, sacksAllowed: 1, sacksMade: 0 },
+      },
+      playerStats: {
+        away: { 12: { name: 'WR Alpha', position: 'WR', stats: { targets: 4, receptions: 2 } } },
+        home: {},
+      },
+    };
+    const { getByTestId, getByText } = render(
+      <BoxScore
+        gameId="g-advanced"
+        league={{ ...baseLeague, gameById: { 'g-advanced': gameWithAdvanced } }}
+        embedded
+      />,
+    );
+
+    expect(getByTestId('game-book-advanced-stats')).toBeTruthy();
+    expect(getByText('Advanced Game Stats')).toBeTruthy();
+    expect(getByTestId('game-book-team-comparison')).toBeTruthy();
+  });
+
+  it('does not render advanced game stats for legacy games without advancedAttribution', () => {
+    const { queryByTestId, getByTestId } = render(
+      <BoxScore
+        gameId="g-legacy"
+        league={{ ...baseLeague, gameById: { 'g-legacy': gameWithFlow } }}
+        embedded
+      />,
+    );
+
+    expect(queryByTestId('game-book-advanced-stats')).toBeNull();
+    expect(getByTestId('game-book-team-comparison')).toBeTruthy();
+  });
+
   it('passes initialMode="paused" when viewer opened manually via toggle', () => {
     const { getByTestId } = render(
       <BoxScore

--- a/src/ui/utils/boxScoreViewModel.js
+++ b/src/ui/utils/boxScoreViewModel.js
@@ -573,7 +573,7 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
     },
     gameFlowSummary: buildGameFlowSummary(payload),
     prepImpact: Array.isArray(payload?.prepImpact) ? payload.prepImpact : (payload?.prepImpact ? [String(payload.prepImpact)] : []),
-    advancedAttribution: normalizeAdvancedAttribution(payload?.advancedAttribution),
+    advancedAttribution: normalizeAdvancedAttribution(payload?.advancedAttribution ?? game?.advancedAttribution),
     detailWarning,
     missingDetailReason: detailWarning,
     hasDetailedStats: archiveQuality === QUALITY.full || archiveQuality === QUALITY.partial,


### PR DESCRIPTION
### Motivation
- Surface single-game `advancedAttribution` returned by rich summaries so users can inspect transient advanced attribution in the Game Book without changing simulation, persistence, or player objects.  

### Description
- Added a new presentational component `src/ui/components/AdvancedGameStats.jsx` that renders a compact, mobile-safe advanced stats table and reuses existing `bs-section` / `bs-table-wrap` / `box-score-table` wrappers and `PlayerButton` navigation.  
- Integrated the component into `BoxScore.jsx` (inline section insertion, no new tab system) and passed `vm.advancedAttribution`, `vm.playerTables`, and existing player navigation context.  
- Ensured the view-model exposes normalized data via `vm.advancedAttribution` and added a safe fallback to read `game?.advancedAttribution` for alternate load paths in `src/ui/utils/boxScoreViewModel.js`.  
- Defensive behavior: empty/missing `advancedAttribution` renders null, numeric values normalized defensively, unknown players fall back to `#playerId`, rows with only zeros are omitted, and props are not mutated.  
- Tests added/updated: `src/ui/components/__tests__/AdvancedGameStats.test.jsx` (unit tests for missing data, full rendering, unknown-player fallback, immutability, legacy empty object) and a BoxScore integration assertion added to `src/ui/components/__tests__/BoxScoreAutoOpen.test.jsx` to assert the Advanced section appears only when present.  
- No simulation logic, worker serialization, IndexedDB schema/version, or player persistence changes were made.

### Testing
- Ran focused unit tests: `npm run test:unit -- src/ui/components/__tests__/AdvancedGameStats.test.jsx src/ui/components/__tests__/BoxScoreAutoOpen.test.jsx` — passed.  
- Ran full unit suite: `npm run test:unit` — all unit tests passed (local run completed successfully).  
- Production build: `npm run build` — build succeeded (vite produced bundles; large-chunk warnings expected).  
- E2E smoke: `npx playwright test tests/e2e/fresh_franchise_first_week_smoke.spec.js` — failed to run in this environment due to missing Playwright browser binaries; the tests require `npx playwright install` to be executed before running E2E.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13e611db18832dbc6643650fa0c837)