### PR TITLE
feat: Career Advanced Stats Aggregator V1

### DIFF
--- a/src/core/playerSeasonStatsArchive.js
+++ b/src/core/playerSeasonStatsArchive.js
@@ -287,6 +287,98 @@ const TOP_SORTS = [
   { key: 'defInts', pick: (r) => r.defInts, label: 'Def INT' },
 ];
 
+// ── Advanced Game-Attribution Archive ─────────────────────────────────────────
+
+/** Zero-initialized advanced stats counter bag. */
+export function createEmptyAdvancedStats() {
+  return {
+    targets: 0,
+    receptionsAllowed: 0,
+    coverageTargets: 0,
+    coverageCompletionsAllowed: 0,
+    drops: 0,
+    battedPasses: 0,
+    sacksAllowed: 0,
+    sacksMade: 0,
+  };
+}
+
+/**
+ * Merge the advancedAttribution from one RichGameSummary into the persistent
+ * sparse store.  Purely additive → order-independent (replaying games in any
+ * order always produces the same career totals).
+ *
+ * @param {object} playerStatsStore  Mutable sparse store; mutated in place and returned.
+ *                                   Shape: { [playerId]: { [year]: AdvancedStats } }
+ * @param {object} gameSummary       RichGameSummary (must have advancedAttribution).
+ * @param {number} year              Season year used as the bucket key.
+ * @returns {object}  The same (mutated) playerStatsStore.
+ */
+export function archiveGameStats(playerStatsStore, gameSummary, year) {
+  if (!playerStatsStore || typeof playerStatsStore !== 'object') return playerStatsStore ?? {};
+
+  const attribution = gameSummary?.advancedAttribution;
+  if (!attribution || typeof attribution !== 'object') return playerStatsStore;
+
+  const y = num(year);
+  if (!Number.isFinite(y) || y === 0) return playerStatsStore;
+  const yKey = String(y);
+
+  for (const playerId of Object.keys(attribution)) {
+    if (!playerId) continue;
+    const gameStats = attribution[playerId];
+    if (!gameStats || typeof gameStats !== 'object') continue;
+
+    const pid = String(playerId);
+    if (!Object.prototype.hasOwnProperty.call(playerStatsStore, pid)) {
+      playerStatsStore[pid] = {};
+    }
+    const playerYears = playerStatsStore[pid];
+    const prev = playerYears[yKey] ?? createEmptyAdvancedStats();
+
+    playerYears[yKey] = {
+      targets:                    prev.targets                    + num(gameStats.targets),
+      receptionsAllowed:          prev.receptionsAllowed          + num(gameStats.receptionsAllowed),
+      coverageTargets:            prev.coverageTargets            + num(gameStats.coverageTargets),
+      coverageCompletionsAllowed: prev.coverageCompletionsAllowed + num(gameStats.coverageCompletionsAllowed),
+      drops:                      prev.drops                      + num(gameStats.drops),
+      battedPasses:               prev.battedPasses               + num(gameStats.battedPasses),
+      sacksAllowed:               prev.sacksAllowed               + num(gameStats.sacksAllowed),
+      sacksMade:                  prev.sacksMade                  + num(gameStats.sacksMade),
+    };
+  }
+
+  return playerStatsStore;
+}
+
+/**
+ * Sum all per-season AdvancedStats for a given player into career totals.
+ * Pure function — never mutates the archive.
+ *
+ * @param {string|number} playerId
+ * @param {object} statsArchive  playerStatsStore (sparse)
+ * @returns {object} Career-total AdvancedStats; all fields are zero if player not found.
+ */
+export function getCareerStats(playerId, statsArchive) {
+  const pid = String(playerId ?? '');
+  const playerYears = statsArchive?.[pid];
+  if (!playerYears || typeof playerYears !== 'object') return createEmptyAdvancedStats();
+
+  const career = createEmptyAdvancedStats();
+  for (const yearStats of Object.values(playerYears)) {
+    if (!yearStats || typeof yearStats !== 'object') continue;
+    career.targets                    += num(yearStats.targets);
+    career.receptionsAllowed          += num(yearStats.receptionsAllowed);
+    career.coverageTargets            += num(yearStats.coverageTargets);
+    career.coverageCompletionsAllowed += num(yearStats.coverageCompletionsAllowed);
+    career.drops                      += num(yearStats.drops);
+    career.battedPasses               += num(yearStats.battedPasses);
+    career.sacksAllowed               += num(yearStats.sacksAllowed);
+    career.sacksMade                  += num(yearStats.sacksMade);
+  }
+  return career;
+}
+
 /**
  * Compact buckets for League History "Top performers" (max 2 per bucket, unique players preferred).
  */

--- a/src/core/sim/richGameSimulator.ts
+++ b/src/core/sim/richGameSimulator.ts
@@ -1,6 +1,7 @@
 import { resolveMatchup, DEFAULT_NORMALIZATION_CONSTANT } from './matchupEngine.ts';
 import type { AttributesV2 } from '../../types/player.ts';
 import type { DerivedGamePlanMultipliers } from './gamePlanMultipliers.ts';
+import { archiveGameStats } from '../playerSeasonStatsArchive.js';
 
 export interface SimPlayerRef {
   id: number | string;
@@ -125,6 +126,10 @@ export interface RichMatchupPayload {
   awayPlayers?: SimPlayerRef[];
   homePrepMultipliers?: DerivedGamePlanMultipliers;
   awayPrepMultipliers?: DerivedGamePlanMultipliers;
+  /** Season year; required when playerStatsStore is provided for archival. */
+  year?: number;
+  /** Mutable sparse advanced-stats store; mutated in place when year is also set. */
+  playerStatsStore?: Record<string, Record<string, AdvancedGameStats>>;
 }
 
 function clamp(value: number, min: number, max: number): number {
@@ -716,7 +721,7 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
 
   const recapText = `${state.homeScore > state.awayScore ? 'Home' : 'Away'} wins ${Math.max(state.homeScore, state.awayScore)}-${Math.min(state.homeScore, state.awayScore)}. ${topReasons[0] ?? 'Balanced execution'} set the tone.`;
 
-  return {
+  const summary: RichGameSummary = {
     gameId: payload.gameId,
     homeTeamId: payload.homeTeamId,
     awayTeamId: payload.awayTeamId,
@@ -757,4 +762,10 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
       },
     },
   };
+
+  if (payload.playerStatsStore != null && payload.year != null) {
+    archiveGameStats(payload.playerStatsStore, summary, payload.year);
+  }
+
+  return summary;
 }

--- a/src/types/player.ts
+++ b/src/types/player.ts
@@ -26,3 +26,25 @@ export interface Player {
   ratings?: Record<string, number>;
   attributesV2?: AttributesV2;
 }
+
+/**
+ * Advanced per-play attribution counters for a single season.
+ * Mirrors AdvancedGameStats from richGameSimulator — kept in sync manually.
+ */
+export interface AdvancedSeasonStats {
+  targets: number;
+  receptionsAllowed: number;
+  coverageTargets: number;
+  coverageCompletionsAllowed: number;
+  drops: number;
+  battedPasses: number;
+  sacksAllowed: number;
+  sacksMade: number;
+}
+
+/**
+ * Sparse persistent store for advanced game-attribution counters.
+ * Layout: archive[playerId][year] = AdvancedSeasonStats
+ * Only years in which a player appeared will have an entry.
+ */
+export type PlayerAdvancedStatsStore = Record<string, Record<string, AdvancedSeasonStats>>;

--- a/src/worker/serialization.js
+++ b/src/worker/serialization.js
@@ -148,6 +148,7 @@ const DELTA_OBJECT_FIELDS = [
   'settings', 'economy', 'freeAgencyState', 'contractMarket',
   'tradeDeadline', 'playoffSeeds', 'standingsContext', 'standings',
   'records', 'recordBook',
+  'playerSeasonStatsArchive',
 ];
 
 /**

--- a/tests/unit/careerAdvancedStatsAggregator.test.js
+++ b/tests/unit/careerAdvancedStatsAggregator.test.js
@@ -1,0 +1,343 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createEmptyAdvancedStats,
+  archiveGameStats,
+  getCareerStats,
+} from '../../src/core/playerSeasonStatsArchive.js';
+import { simulateRichGame } from '../../src/core/sim/richGameSimulator.ts';
+import { mapOverallToAttributesV2 } from '../../src/core/migration/attributeMigrator.ts';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeAttribution(overrides = {}) {
+  return { ...createEmptyAdvancedStats(), ...overrides };
+}
+
+function gameSummaryWith(attribution) {
+  return { advancedAttribution: attribution };
+}
+
+// ── createEmptyAdvancedStats ──────────────────────────────────────────────────
+
+describe('createEmptyAdvancedStats', () => {
+  it('returns an object with all 8 counters set to zero', () => {
+    const s = createEmptyAdvancedStats();
+    expect(s.targets).toBe(0);
+    expect(s.receptionsAllowed).toBe(0);
+    expect(s.coverageTargets).toBe(0);
+    expect(s.coverageCompletionsAllowed).toBe(0);
+    expect(s.drops).toBe(0);
+    expect(s.battedPasses).toBe(0);
+    expect(s.sacksAllowed).toBe(0);
+    expect(s.sacksMade).toBe(0);
+    expect(Object.keys(s)).toHaveLength(8);
+  });
+
+  it('each call returns an independent object', () => {
+    const a = createEmptyAdvancedStats();
+    const b = createEmptyAdvancedStats();
+    a.targets = 5;
+    expect(b.targets).toBe(0);
+  });
+});
+
+// ── archiveGameStats – basic accumulation ─────────────────────────────────────
+
+describe('archiveGameStats – accumulation', () => {
+  it('creates a new player entry on first call', () => {
+    const store = {};
+    const summary = gameSummaryWith({
+      'p1': makeAttribution({ targets: 3, drops: 1 }),
+    });
+    archiveGameStats(store, summary, 2025);
+
+    expect(store['p1']['2025'].targets).toBe(3);
+    expect(store['p1']['2025'].drops).toBe(1);
+    expect(store['p1']['2025'].sacksMade).toBe(0);
+  });
+
+  it('accumulates stats additively across multiple games in the same year', () => {
+    const store = {};
+    const game1 = gameSummaryWith({ 'p1': makeAttribution({ targets: 5, drops: 1, sacksMade: 2 }) });
+    const game2 = gameSummaryWith({ 'p1': makeAttribution({ targets: 3, drops: 0, sacksMade: 1 }) });
+
+    archiveGameStats(store, game1, 2025);
+    archiveGameStats(store, game2, 2025);
+
+    expect(store['p1']['2025'].targets).toBe(8);
+    expect(store['p1']['2025'].drops).toBe(1);
+    expect(store['p1']['2025'].sacksMade).toBe(3);
+  });
+
+  it('keeps years separate (sparse representation)', () => {
+    const store = {};
+    archiveGameStats(store, gameSummaryWith({ 'p1': makeAttribution({ targets: 7 }) }), 2024);
+    archiveGameStats(store, gameSummaryWith({ 'p1': makeAttribution({ targets: 4 }) }), 2025);
+
+    expect(store['p1']['2024'].targets).toBe(7);
+    expect(store['p1']['2025'].targets).toBe(4);
+    expect(Object.keys(store['p1'])).toHaveLength(2);
+  });
+
+  it('does not create a year entry for a player with no stats in the summary', () => {
+    const store = {};
+    archiveGameStats(store, gameSummaryWith({ 'p2': makeAttribution({ battedPasses: 2 }) }), 2025);
+    expect(store['p1']).toBeUndefined();
+  });
+});
+
+// ── archiveGameStats – serialization hardening ────────────────────────────────
+
+describe('archiveGameStats – guard clauses', () => {
+  it('returns the store unchanged when gameSummary has no advancedAttribution', () => {
+    const store = { 'p1': { '2024': makeAttribution({ targets: 3 }) } };
+    archiveGameStats(store, { homeScore: 17, awayScore: 14 }, 2025);
+    expect(store['p1']['2025']).toBeUndefined();
+    expect(store['p1']['2024'].targets).toBe(3);
+  });
+
+  it('returns the store unchanged when advancedAttribution is null', () => {
+    const store = {};
+    archiveGameStats(store, { advancedAttribution: null }, 2025);
+    expect(Object.keys(store)).toHaveLength(0);
+  });
+
+  it('ignores entries with falsy player IDs', () => {
+    const store = {};
+    archiveGameStats(store, gameSummaryWith({ '': makeAttribution({ targets: 1 }) }), 2025);
+    expect(Object.keys(store)).toHaveLength(0);
+  });
+
+  it('skips archival when year is 0 or non-finite', () => {
+    const store = {};
+    archiveGameStats(store, gameSummaryWith({ 'p1': makeAttribution({ targets: 5 }) }), 0);
+    archiveGameStats(store, gameSummaryWith({ 'p1': makeAttribution({ targets: 5 }) }), NaN);
+    expect(Object.keys(store)).toHaveLength(0);
+  });
+
+  it('skips archival when gameSummary is null', () => {
+    const store = {};
+    archiveGameStats(store, null, 2025);
+    expect(Object.keys(store)).toHaveLength(0);
+  });
+
+  it('coerces numeric player IDs to strings', () => {
+    const store = {};
+    archiveGameStats(store, gameSummaryWith({ 42: makeAttribution({ sacksMade: 3 }) }), 2025);
+    expect(store['42']['2025'].sacksMade).toBe(3);
+  });
+
+  it('guards against non-finite numeric stats in the source (no NaN bleed)', () => {
+    const store = {};
+    archiveGameStats(
+      store,
+      gameSummaryWith({ 'p1': { targets: NaN, drops: Infinity, sacksMade: 2, receptionsAllowed: undefined } }),
+      2025,
+    );
+    expect(store['p1']['2025'].targets).toBe(0);
+    expect(store['p1']['2025'].drops).toBe(0);
+    expect(store['p1']['2025'].sacksMade).toBe(2);
+    expect(store['p1']['2025'].receptionsAllowed).toBe(0);
+  });
+});
+
+// ── archiveGameStats – determinism / order-independence ───────────────────────
+
+describe('archiveGameStats – order-independence', () => {
+  it('produces the same totals regardless of game order', () => {
+    const games = [
+      gameSummaryWith({ 'p1': makeAttribution({ targets: 5, drops: 1 }) }),
+      gameSummaryWith({ 'p1': makeAttribution({ targets: 3, drops: 0 }) }),
+      gameSummaryWith({ 'p1': makeAttribution({ targets: 7, drops: 2 }) }),
+    ];
+
+    const storeAB = {};
+    archiveGameStats(storeAB, games[0], 2025);
+    archiveGameStats(storeAB, games[1], 2025);
+    archiveGameStats(storeAB, games[2], 2025);
+
+    const storeBA = {};
+    archiveGameStats(storeBA, games[2], 2025);
+    archiveGameStats(storeBA, games[0], 2025);
+    archiveGameStats(storeBA, games[1], 2025);
+
+    expect(storeAB['p1']['2025']).toEqual(storeBA['p1']['2025']);
+  });
+
+  it('replaying the same game twice doubles every counter (pure addition, no dedup)', () => {
+    const store = {};
+    const game = gameSummaryWith({ 'p1': makeAttribution({ targets: 4, sacksMade: 1 }) });
+    archiveGameStats(store, game, 2025);
+    archiveGameStats(store, game, 2025);
+    expect(store['p1']['2025'].targets).toBe(8);
+    expect(store['p1']['2025'].sacksMade).toBe(2);
+  });
+});
+
+// ── getCareerStats ─────────────────────────────────────────────────────────────
+
+describe('getCareerStats', () => {
+  it('sums all seasons for a player into career totals', () => {
+    const archive = {
+      'p1': {
+        '2023': makeAttribution({ targets: 60, drops: 4, sacksMade: 3 }),
+        '2024': makeAttribution({ targets: 72, drops: 5, sacksMade: 5 }),
+        '2025': makeAttribution({ targets: 80, drops: 3, sacksMade: 8 }),
+      },
+    };
+
+    const career = getCareerStats('p1', archive);
+    expect(career.targets).toBe(212);
+    expect(career.drops).toBe(12);
+    expect(career.sacksMade).toBe(16);
+  });
+
+  it('returns all-zero stats for a player who never appeared in any game', () => {
+    const career = getCareerStats('unknown-player', {});
+    expect(career).toEqual(createEmptyAdvancedStats());
+  });
+
+  it('returns all-zero stats when archive is null or undefined', () => {
+    expect(getCareerStats('p1', null)).toEqual(createEmptyAdvancedStats());
+    expect(getCareerStats('p1', undefined)).toEqual(createEmptyAdvancedStats());
+  });
+
+  it('does not mutate the archive', () => {
+    const archive = {
+      'p1': { '2025': makeAttribution({ targets: 10 }) },
+    };
+    const snapshot = JSON.parse(JSON.stringify(archive));
+    getCareerStats('p1', archive);
+    expect(archive).toEqual(snapshot);
+  });
+
+  it('handles a single-season player correctly', () => {
+    const archive = {
+      'rookie': { '2025': makeAttribution({ targets: 30, receptionsAllowed: 20, coverageTargets: 15 }) },
+    };
+    const career = getCareerStats('rookie', archive);
+    expect(career.targets).toBe(30);
+    expect(career.receptionsAllowed).toBe(20);
+    expect(career.coverageTargets).toBe(15);
+  });
+
+  it('coerces numeric playerId to string for lookup', () => {
+    const archive = { '7': { '2025': makeAttribution({ battedPasses: 6 }) } };
+    expect(getCareerStats(7, archive).battedPasses).toBe(6);
+  });
+
+  it('skips malformed year entries without throwing', () => {
+    const archive = {
+      'p1': {
+        '2024': null,
+        '2025': makeAttribution({ drops: 5 }),
+      },
+    };
+    expect(getCareerStats('p1', archive).drops).toBe(5);
+  });
+});
+
+// ── Integration: simulateRichGame populates playerStatsStore when provided ────
+
+describe('simulateRichGame – playerStatsStore integration', () => {
+  const basePayload = {
+    gameId: 'archive-test-1',
+    homeTeamId: 10,
+    awayTeamId: 20,
+    seed: 7777,
+    weather: 'clear',
+    homeOffense: mapOverallToAttributesV2(82, 5.5, 'h-off'),
+    awayOffense: mapOverallToAttributesV2(80, 5.5, 'a-off'),
+    homeDefense: mapOverallToAttributesV2(78, 5.5, 'h-def'),
+    awayDefense: mapOverallToAttributesV2(79, 5.5, 'a-def'),
+    homePlayers: [
+      { id: 'h-wr1', name: 'Home WR', pos: 'WR', ovr: 82 },
+      { id: 'h-qb1', name: 'Home QB', pos: 'QB', ovr: 85 },
+      { id: 'h-ot1', name: 'Home OT', pos: 'OT', ovr: 78 },
+    ],
+    awayPlayers: [
+      { id: 'a-cb1', name: 'Away CB', pos: 'CB', ovr: 80 },
+      { id: 'a-edge1', name: 'Away EDGE', pos: 'EDGE', ovr: 83 },
+    ],
+  };
+
+  it('does NOT populate playerStatsStore when neither year nor store is provided', () => {
+    const summary = simulateRichGame(basePayload);
+    expect(summary.advancedAttribution).toBeDefined();
+  });
+
+  it('populates playerStatsStore with game attribution when year and store are provided', () => {
+    const store = {};
+    simulateRichGame({ ...basePayload, year: 2025, playerStatsStore: store });
+
+    const playerIds = Object.keys(store);
+    expect(playerIds.length).toBeGreaterThan(0);
+
+    for (const pid of playerIds) {
+      expect(store[pid]['2025']).toBeDefined();
+      const s = store[pid]['2025'];
+      expect(typeof s.targets).toBe('number');
+      expect(typeof s.sacksMade).toBe('number');
+      expect(Number.isFinite(s.targets)).toBe(true);
+      expect(Number.isFinite(s.sacksMade)).toBe(true);
+    }
+  });
+
+  it('accumulates correctly across two games in the same year', () => {
+    const store = {};
+    simulateRichGame({ ...basePayload, gameId: 'g1', seed: 1001, year: 2025, playerStatsStore: store });
+    const afterGame1 = JSON.parse(JSON.stringify(store));
+
+    simulateRichGame({ ...basePayload, gameId: 'g2', seed: 1002, year: 2025, playerStatsStore: store });
+
+    for (const pid of Object.keys(store)) {
+      if (!afterGame1[pid]?.['2025']) continue;
+      const before = afterGame1[pid]['2025'];
+      const after = store[pid]['2025'];
+      expect(after.targets).toBeGreaterThanOrEqual(before.targets);
+      expect(after.drops).toBeGreaterThanOrEqual(before.drops);
+      expect(after.sacksMade).toBeGreaterThanOrEqual(before.sacksMade);
+    }
+  });
+
+  it('is deterministic: same seeds produce identical store contents', () => {
+    const store1 = {};
+    const store2 = {};
+    simulateRichGame({ ...basePayload, year: 2025, playerStatsStore: store1 });
+    simulateRichGame({ ...basePayload, year: 2025, playerStatsStore: store2 });
+    expect(store1).toEqual(store2);
+  });
+
+  it('does not mutate the returned summary when archiving into the store', () => {
+    const store = {};
+    const s1 = simulateRichGame({ ...basePayload, year: 2025, playerStatsStore: store });
+    const s2 = simulateRichGame({ ...basePayload, year: 2025, playerStatsStore: {} });
+    expect(s1.advancedAttribution).toEqual(s2.advancedAttribution);
+  });
+
+  it('skips archival when year is omitted even if store is provided', () => {
+    const store = {};
+    simulateRichGame({ ...basePayload, playerStatsStore: store });
+    expect(Object.keys(store)).toHaveLength(0);
+  });
+
+  it('skips archival when store is omitted even if year is provided', () => {
+    const summary = simulateRichGame({ ...basePayload, year: 2025 });
+    expect(summary.advancedAttribution).toBeDefined();
+  });
+
+  it('getCareerStats returns correct totals after two seasons', () => {
+    const store = {};
+    simulateRichGame({ ...basePayload, gameId: 'g-yr1', seed: 3001, year: 2024, playerStatsStore: store });
+    simulateRichGame({ ...basePayload, gameId: 'g-yr2', seed: 3002, year: 2025, playerStatsStore: store });
+
+    for (const pid of Object.keys(store)) {
+      const career = getCareerStats(pid, store);
+      const yr2024 = store[pid]?.['2024'] ?? createEmptyAdvancedStats();
+      const yr2025 = store[pid]?.['2025'] ?? createEmptyAdvancedStats();
+      expect(career.targets).toBe(yr2024.targets + yr2025.targets);
+      expect(career.drops).toBe(yr2024.drops + yr2025.drops);
+      expect(career.sacksMade).toBe(yr2024.sacksMade + yr2025.sacksMade);
+    }
+  });
+});


### PR DESCRIPTION
Rolls up per-game advancedAttribution counters into a persistent
sparse store (playerStatsStore[playerId][year]) so season and career
advanced stats survive across sessions without bloating the schema.

Key changes:
- playerSeasonStatsArchive.js: add createEmptyAdvancedStats,
  archiveGameStats (purely additive, order-independent), and
  getCareerStats (pure read, no mutation)
- richGameSimulator.ts: extend RichMatchupPayload with optional year +
  playerStatsStore; call archiveGameStats after simulation when both
  are present; refactor inline return to named variable for clarity
- player.ts: add AdvancedSeasonStats interface and
  PlayerAdvancedStatsStore type
- serialization.js: include playerSeasonStatsArchive in
  DELTA_OBJECT_FIELDS so it round-trips through the delta pipeline
- tests/unit/careerAdvancedStatsAggregator.test.js: comprehensive
  unit + integration coverage (guard clauses, order-independence,
  determinism, multi-season career totals, null-safety)

https://claude.ai/code/session_0191SR5VhrercKm548cfYRJJ