### PR TITLE
Wire career advanced stats archive into production week simulation

### DIFF
--- a/src/core/playerSeasonStatsArchive.js
+++ b/src/core/playerSeasonStatsArchive.js
@@ -323,6 +323,18 @@ export function archiveGameStats(playerStatsStore, gameSummary, year) {
   const y = num(year);
   if (!Number.isFinite(y) || y === 0) return playerStatsStore;
   const yKey = String(y);
+  const gameId = gameSummary?.gameId != null ? String(gameSummary.gameId) : '';
+  if (gameId) {
+    const meta = (playerStatsStore.__meta && typeof playerStatsStore.__meta === 'object')
+      ? playerStatsStore.__meta
+      : (playerStatsStore.__meta = { archivedGameIds: {} });
+    const archivedGameIds = (meta.archivedGameIds && typeof meta.archivedGameIds === 'object')
+      ? meta.archivedGameIds
+      : (meta.archivedGameIds = {});
+    const dedupeKey = `${yKey}:${gameId}`;
+    if (archivedGameIds[dedupeKey]) return playerStatsStore;
+    archivedGameIds[dedupeKey] = true;
+  }
 
   for (const playerId of Object.keys(attribution)) {
     if (!playerId) continue;

--- a/src/worker/WorkerPool.ts
+++ b/src/worker/WorkerPool.ts
@@ -21,6 +21,8 @@ export interface Matchup {
   awayPlayers?: SimPlayerRef[];
   homePrepMultipliers?: DerivedGamePlanMultipliers;
   awayPrepMultipliers?: DerivedGamePlanMultipliers;
+  year?: number;
+  playerStatsStore?: Record<string, Record<string, unknown>>;
 }
 
 export type GameSummary = RichGameSummary;

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -976,6 +976,7 @@ function buildViewState() {
     retiredPlayers: Array.isArray(meta?.retiredPlayers) ? meta.retiredPlayers : [],
     records: meta?.records ?? null,
     recordBook: meta?.recordBook ?? null,
+    playerSeasonStatsArchive: meta?.playerSeasonStatsArchive ?? {},
     leagueHistory: Array.isArray(meta?.leagueHistory) ? meta.leagueHistory.slice(-60) : [],
     franchiseChronicle: Array.isArray(meta?.franchiseChronicle) ? meta.franchiseChronicle.slice(-340) : [],
     franchiseSeasonReviews: Array.isArray(meta?.franchiseSeasonReviews) ? meta.franchiseSeasonReviews.slice(-40) : [],
@@ -2794,7 +2795,16 @@ async function handleAdvanceWeek(payload, id) {
 
   post(toUI.SIM_PROGRESS, { done: 0, total: league._weekGames.length }, id);
   const gamesToSim = [...league._weekGames];
-  const { matchups, migratedPlayers } = buildWeekMatchupsFromLeague(league, meta, week);
+  const playerSeasonStatsArchive = (meta?.playerSeasonStatsArchive && typeof meta.playerSeasonStatsArchive === 'object')
+    ? meta.playerSeasonStatsArchive
+    : {};
+  if (!meta?.playerSeasonStatsArchive || typeof meta.playerSeasonStatsArchive !== 'object') {
+    cache.setMeta({ playerSeasonStatsArchive });
+  }
+  const { matchups, migratedPlayers } = buildWeekMatchupsFromLeague(league, meta, week, {
+    year: Number(meta?.year ?? 0),
+    playerStatsStore: playerSeasonStatsArchive,
+  });
   const useNewSimulationEngine = Boolean(getLeagueSetting('useNewSimulationEngine', false)) && matchups.length === gamesToSim.length;
 
   if (migratedPlayers.length > 0) {
@@ -3272,7 +3282,7 @@ function buildLeagueForSim(schedule, week, seasonId) {
   return leagueObj;
 }
 
-function buildWeekMatchupsFromLeague(league, meta, week) {
+function buildWeekMatchupsFromLeague(league, meta, week, opts = {}) {
   const matchups = [];
   const migratedPlayers = [];
 
@@ -3350,6 +3360,8 @@ function buildWeekMatchupsFromLeague(league, meta, week) {
       })),
       seed: buildDeterministicSeed(`${meta?.currentSeasonId ?? 1}:${week}:${game?.home?.id}:${game?.away?.id}`),
       weather: 'clear',
+      year: opts.year,
+      playerStatsStore: opts.playerStatsStore,
     });
   }
 

--- a/tests/unit/careerAdvancedStatsAggregator.test.js
+++ b/tests/unit/careerAdvancedStatsAggregator.test.js
@@ -164,13 +164,13 @@ describe('archiveGameStats – order-independence', () => {
     expect(storeAB['p1']['2025']).toEqual(storeBA['p1']['2025']);
   });
 
-  it('replaying the same game twice doubles every counter (pure addition, no dedup)', () => {
+  it('does not re-archive the same game twice in the same year', () => {
     const store = {};
-    const game = gameSummaryWith({ 'p1': makeAttribution({ targets: 4, sacksMade: 1 }) });
+    const game = { gameId: 'same-game-1', ...gameSummaryWith({ 'p1': makeAttribution({ targets: 4, sacksMade: 1 }) }) };
     archiveGameStats(store, game, 2025);
     archiveGameStats(store, game, 2025);
-    expect(store['p1']['2025'].targets).toBe(8);
-    expect(store['p1']['2025'].sacksMade).toBe(2);
+    expect(store['p1']['2025'].targets).toBe(4);
+    expect(store['p1']['2025'].sacksMade).toBe(1);
   });
 });
 
@@ -270,7 +270,7 @@ describe('simulateRichGame – playerStatsStore integration', () => {
     const store = {};
     simulateRichGame({ ...basePayload, year: 2025, playerStatsStore: store });
 
-    const playerIds = Object.keys(store);
+    const playerIds = Object.keys(store).filter((pid) => pid !== '__meta');
     expect(playerIds.length).toBeGreaterThan(0);
 
     for (const pid of playerIds) {


### PR DESCRIPTION
### Motivation

- The rich-game archival helper existed but production weekly simulation sometimes called `simulateRichGame` without `year` and `playerStatsStore`, so career advanced attribution remained unpopulated for official simulated games.
- The change aims to safely wire career advanced stats archival into the real production simulation path without adding schema bumps, UI, or simulation-balance changes.

### Description

- Threaded `year` and `playerStatsStore` through production matchup construction so `simulateRichGame` receives `year` and the persistent archive when run during an `ADVANCE_WEEK` production simulation. (`buildWeekMatchupsFromLeague` / weekly engine wiring.)
- Initialize legacy-missing archive safely using the existing `meta.playerSeasonStatsArchive` field and persist the empty object if absent, avoiding any save schema change.
- Expose `playerSeasonStatsArchive` from `buildViewState()` so `serializeLeagueDelta` can include it in deltas only when it changes (preserves delta behaviour).
- Add per-game dedupe guard in `archiveGameStats` using `year + gameId` stored in an internal `__meta.archivedGameIds` map to prevent double-counting the same official game.
- Update types/signatures in `WorkerPool` to accept optional `year` and `playerStatsStore`, and adjust tests to account for the new internal `__meta` key.

### Testing

- Ran unit tests with `npm run test:unit` and all unit tests passed: 2024 tests passed (including updated `tests/unit/careerAdvancedStatsAggregator.test.js`).
- Built the production bundle with `npm run build` and it completed successfully (build emits expected chunk-size warnings but no errors).
- Ran dynasty soak subset with `npm run test:soak` and it passed (85 soak tests passed).
- Playwright E2E smoke `npx playwright test tests/e2e/fresh_franchise_first_week_smoke.spec.js` was not completed in this environment due to missing Chromium; the command requires `npx playwright install --with-deps chromium` to run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a145d98aa2c832d90084a365cbe839c)