### PR TITLE
feat: Team Culture & Leadership Narrative V1

### DIFF
--- a/src/core/teamCulture.js
+++ b/src/core/teamCulture.js
@@ -1,0 +1,296 @@
+// src/core/teamCulture.js
+// V1 narrative-only team culture system.
+// Does NOT affect game performance, injuries, player development, FA, or contracts.
+
+export const TEAM_CULTURE_DEFAULT = 70;
+export const TEAM_CULTURE_MIN = 0;
+export const TEAM_CULTURE_MAX = 100;
+export const WEEKLY_SHIFT_CAP = 1.25;
+export const GAME_SHIFT_CAP = 0.75;
+export const TRAIT_SHIFT_CAP = 0.5;
+
+// Ordered highest-to-lowest so first match wins.
+const CULTURE_BANDS = [
+  { min: 85, label: 'United' },
+  { min: 70, label: 'Focused' },
+  { min: 55, label: 'Uneasy' },
+  { min: 40, label: 'Fractured' },
+  { min: 0,  label: 'Toxic' },
+];
+
+function clamp(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return TEAM_CULTURE_DEFAULT;
+  return Math.max(TEAM_CULTURE_MIN, Math.min(TEAM_CULTURE_MAX, n));
+}
+
+function makeCultureEntry(score = TEAM_CULTURE_DEFAULT) {
+  return {
+    score,
+    lastShift: 0,
+    trend: 'flat',
+    reasons: [],
+    updatedWeek: 0,
+    updatedSeason: 0,
+  };
+}
+
+/**
+ * Ensure every team in `teams` has an entry in `existingCulture`.
+ * Missing entries are seeded at the neutral default (70).
+ * Existing entries are preserved unchanged.
+ */
+export function initializeTeamCulture(teams = [], existingCulture = {}) {
+  const result = { ...(existingCulture ?? {}) };
+  for (const team of teams) {
+    const id = String(team?.id ?? team);
+    if (!result[id]) {
+      result[id] = makeCultureEntry();
+    }
+  }
+  return result;
+}
+
+export function getTeamCultureScore(teamCulture, teamId) {
+  const entry = teamCulture?.[String(teamId)];
+  return Number.isFinite(entry?.score) ? entry.score : TEAM_CULTURE_DEFAULT;
+}
+
+export function classifyTeamCulture(score) {
+  const s = clamp(score);
+  for (const band of CULTURE_BANDS) {
+    if (s >= band.min) return band.label;
+  }
+  return 'Focused';
+}
+
+/**
+ * Derive leadership signals from the roster using existing trait and personality data.
+ * Reads player.traits (MENTOR trait id) and player.personalityProfile (leadership, diva).
+ */
+export function calculateLeadershipProfile(roster = []) {
+  let leaderCount = 0;
+  let disruptiveCount = 0;
+  let mentorCount = 0;
+  let youngPlayerCount = 0;
+
+  for (const player of roster) {
+    if (!player) continue;
+    const traits = Array.isArray(player.traits) ? player.traits : [];
+    const pp = player.personalityProfile ?? player.personality?.profile ?? {};
+    const leadership = Number(pp.leadership ?? 55);
+    const diva = Number(pp.diva ?? 35);
+    const age = Number(player.age ?? 25);
+
+    // High personality.leadership counts as a leader voice
+    if (leadership >= 70) leaderCount++;
+    // High diva is a disruptive influence
+    if (diva >= 72) disruptiveCount++;
+    // MENTOR trait + vet age + enough leadership = active mentorship benefit
+    if (traits.includes('MENTOR') && age >= 28 && leadership >= 60) mentorCount++;
+    // Young players benefit most from mentorship
+    if (age <= 23) youngPlayerCount++;
+  }
+
+  return { leaderCount, disruptiveCount, mentorCount, youngPlayerCount };
+}
+
+/**
+ * Calculate one week's culture shift for a single team.
+ * Pure function — no side effects, no randomness.
+ *
+ * @param {object} opts
+ * @param {object} opts.team           - team object with .id
+ * @param {Array}  opts.roster         - array of player objects for this team
+ * @param {object} opts.recentGame     - game result object (or null if bye week)
+ * @param {object} opts.advancedAttribution - optional advanced stats object
+ * @param {number} opts.previousScore  - current culture score before this week
+ * @param {object} opts.context        - { week, seasonId }
+ */
+export function calculateCultureShift({ team, roster = [], recentGame, advancedAttribution, previousScore, context = {} }) {
+  const { week = 0, seasonId = 0 } = context;
+  const reasons = [];
+  let shift = 0;
+
+  // ── Game result base shift ───────────────────────────────────────────────
+  if (recentGame) {
+    const teamId = String(team?.id ?? team);
+    const homeId = String(recentGame.home ?? recentGame.homeTeamId ?? recentGame.homeId ?? '');
+    const awayId = String(recentGame.away ?? recentGame.awayTeamId ?? recentGame.awayId ?? '');
+    const isHome = homeId === teamId;
+    const teamScore = isHome
+      ? (recentGame.scoreHome ?? recentGame.homeScore ?? 0)
+      : (recentGame.scoreAway ?? recentGame.awayScore ?? 0);
+    const oppScore = isHome
+      ? (recentGame.scoreAway ?? recentGame.awayScore ?? 0)
+      : (recentGame.scoreHome ?? recentGame.homeScore ?? 0);
+    const margin = Number(teamScore) - Number(oppScore);
+    const absMargin = Math.abs(margin);
+    const won = margin > 0;
+
+    if (won) {
+      if (absMargin >= 21) {
+        shift += 0.65;
+        reasons.push('Blowout win lifted morale');
+      } else if (absMargin <= 7) {
+        shift += 0.35;
+        reasons.push('Hard-fought win');
+      } else {
+        shift += 0.5;
+        reasons.push('Win builds team confidence');
+      }
+    } else {
+      if (absMargin >= 21) {
+        shift -= 0.65;
+        reasons.push('Blowout loss hurt locker room');
+      } else if (absMargin <= 7) {
+        shift -= 0.25;
+        reasons.push('Close loss stings');
+      } else {
+        shift -= 0.45;
+        reasons.push('Loss dampens team spirit');
+      }
+    }
+  }
+
+  // ── Advanced attribution (tiny secondary influence) ──────────────────────
+  if (advancedAttribution && typeof advancedAttribution === 'object') {
+    const drops = Number(advancedAttribution.drops ?? 0);
+    const sacksAllowed = Number(advancedAttribution.sacksAllowed ?? 0);
+    const sacksMade = Number(advancedAttribution.sacksMade ?? 0);
+    const battedPasses = Number(advancedAttribution.battedPasses ?? 0);
+
+    if (drops >= 4) {
+      shift -= 0.12;
+      reasons.push('Passing game execution struggles');
+    }
+    if (sacksAllowed >= 5) {
+      shift -= 0.12;
+      reasons.push('Offensive line struggles affected morale');
+    }
+    if (sacksMade >= 4 || battedPasses >= 3) {
+      shift += 0.1;
+      reasons.push('Defensive effort lifted the group');
+    }
+  }
+
+  // Clamp game + attribution contribution before trait layer
+  shift = Math.max(-GAME_SHIFT_CAP, Math.min(GAME_SHIFT_CAP, shift));
+
+  // ── Trait & personality layer ────────────────────────────────────────────
+  const profile = calculateLeadershipProfile(roster);
+  let traitShift = 0;
+
+  if (profile.leaderCount > 0) {
+    // Leaders soften negative drift and slightly amplify positive drift
+    const leaderEffect = Math.min(profile.leaderCount, 3) * 0.06;
+    if (shift < 0) {
+      traitShift += leaderEffect;
+      reasons.push('Leadership steadied the group');
+    } else if (shift > 0) {
+      traitShift += leaderEffect * 0.5;
+    }
+  }
+
+  // Disruptive personalities amplify negative drift only during losses/poor results
+  if (profile.disruptiveCount > 0 && shift < 0) {
+    const disruptEffect = Math.min(profile.disruptiveCount, 2) * 0.08;
+    traitShift -= disruptEffect;
+    reasons.push('Locker room friction compounded the loss');
+  }
+
+  // Active mentors with young players provide a small culture floor
+  if (profile.mentorCount > 0 && profile.youngPlayerCount > 0) {
+    traitShift += 0.07;
+    reasons.push('Veteran mentorship maintains culture floor');
+  }
+
+  traitShift = Math.max(-TRAIT_SHIFT_CAP, Math.min(TRAIT_SHIFT_CAP, traitShift));
+  shift += traitShift;
+
+  // Final weekly cap
+  shift = Math.max(-WEEKLY_SHIFT_CAP, Math.min(WEEKLY_SHIFT_CAP, shift));
+
+  const newScore = clamp(previousScore + shift);
+  const trend = shift > 0.05 ? 'up' : shift < -0.05 ? 'down' : 'flat';
+
+  return {
+    newScore,
+    shift,
+    trend,
+    reasons: reasons.slice(0, 3),
+    updatedWeek: week,
+    updatedSeason: seasonId,
+  };
+}
+
+/**
+ * Apply one week of culture drift to all teams.
+ * Skips teams whose entry already reflects this season+week (dedupe guard).
+ *
+ * @param {object} opts
+ * @param {Array}  opts.teams           - all league team objects
+ * @param {object} opts.rostersByTeam   - { [teamId]: player[] }
+ * @param {Array}  opts.games           - this week's game result objects
+ * @param {object} opts.previousCulture - current teamCulture meta object
+ * @param {object} opts.context         - { week, seasonId }
+ * @returns {object} updated teamCulture object
+ */
+export function applyTeamCultureWeek({ teams = [], rostersByTeam = {}, games = [], previousCulture = {}, context = {} }) {
+  const nextCulture = { ...(previousCulture ?? {}) };
+
+  for (const team of teams) {
+    const teamId = String(team?.id ?? team);
+    const existing = nextCulture[teamId] ?? makeCultureEntry();
+
+    // Dedupe: this team already processed for this season+week
+    if (
+      context.week > 0 &&
+      existing.updatedWeek === context.week &&
+      existing.updatedSeason === context.seasonId
+    ) {
+      continue;
+    }
+
+    const teamGame = games.find((g) => {
+      const h = String(g.home ?? g.homeTeamId ?? g.homeId ?? '');
+      const a = String(g.away ?? g.awayTeamId ?? g.awayId ?? '');
+      return h === teamId || a === teamId;
+    }) ?? null;
+
+    const roster = Array.isArray(rostersByTeam[teamId]) ? rostersByTeam[teamId] : [];
+
+    const result = calculateCultureShift({
+      team,
+      roster,
+      recentGame: teamGame,
+      advancedAttribution: teamGame?.advancedAttribution ?? null,
+      previousScore: existing.score,
+      context,
+    });
+
+    nextCulture[teamId] = {
+      score: result.newScore,
+      lastShift: result.shift,
+      trend: result.trend,
+      reasons: result.reasons,
+      updatedWeek: result.updatedWeek,
+      updatedSeason: result.updatedSeason,
+    };
+  }
+
+  return nextCulture;
+}
+
+/**
+ * Build a single-sentence narrative string for display.
+ * @param {number} score
+ * @param {number} shift
+ * @param {string[]} reasons
+ */
+export function buildTeamCultureNarrative(score, shift, reasons = []) {
+  const label = classifyTeamCulture(score);
+  const trendText = shift > 0.1 ? 'trending up' : shift < -0.1 ? 'under pressure' : 'holding steady';
+  const reason = Array.isArray(reasons) && reasons.length > 0 ? reasons[0] : 'No recent change';
+  return `${label} culture, ${trendText}. ${reason}.`;
+}

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -9,6 +9,7 @@ import { selectFranchiseHQViewModel } from '../utils/franchiseCommandCenter.js';
 import { buildWeeklyCommandHub } from '../utils/weeklyCommandHub.js';
 import { buildCommandCenterSummary } from '../utils/weeklyHubLayout.js';
 import { rankLeaguePulseItems } from '../../core/leaguePulse.js';
+import { classifyTeamCulture, buildTeamCultureNarrative, TEAM_CULTURE_DEFAULT } from '../../core/teamCulture.js';
 import { EmptyState, StatusChip, ActionTile, SectionCard, WeeklyAgenda, CompactNewsCard } from './ScreenSystem.jsx';
 import { getLastGameDisplay, getLatestUserCompletedGame, getNextOpponentDisplay } from '../utils/hqGameDisplay.js';
 import { HQIcon, TeamIdentityBadge } from './HQVisuals.jsx';
@@ -250,6 +251,22 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
     lastGameDisplay.heroLine,
     userTeam?.capRoom,
   ]);
+
+  const culturePulse = useMemo(() => {
+    const raw = league?.teamCulture?.[String(league?.userTeamId)] ?? null;
+    const score = Number(raw?.score ?? TEAM_CULTURE_DEFAULT);
+    const shift = Number(raw?.lastShift ?? 0);
+    const trend = raw?.trend ?? 'flat';
+    const reasons = Array.isArray(raw?.reasons) ? raw.reasons : [];
+    return {
+      score,
+      label: classifyTeamCulture(score),
+      trend,
+      trendIcon: trend === 'up' ? '↑' : trend === 'down' ? '↓' : '–',
+      tone: trend === 'up' ? 'ok' : trend === 'down' ? 'warning' : 'info',
+      narrative: buildTeamCultureNarrative(score, shift, reasons),
+    };
+  }, [league?.teamCulture, league?.userTeamId]);
 
   useEffect(() => {
     document.title = `Franchise HQ • ${command.weekLabel} • Football GM Sim`;
@@ -545,6 +562,20 @@ export default function FranchiseHQ({ league, onNavigate, onAdvanceWeek, busy, s
             <button type="button" className="btn btn-sm" onClick={() => onNavigate?.(seasonPulse.filmRoute)}>
               {seasonPulse.filmCta}
             </button>
+          </article>
+
+          <article
+            className={`app-hq-pulse-card tone-${culturePulse.tone}`}
+            style={{ gridColumn: '1 / -1' }}
+            data-testid="culture-pulse-card"
+            aria-label="Team Culture"
+          >
+            <div className="app-hq-pulse-card__head">
+              <span>Team Culture</span>
+              <StatusChip label={`${culturePulse.score.toFixed(0)} ${culturePulse.trendIcon}`} tone={culturePulse.tone} />
+            </div>
+            <strong>{culturePulse.label}</strong>
+            <p style={{ margin: '2px 0 0', fontSize: '0.85em', opacity: 0.9 }}>{culturePulse.narrative}</p>
           </article>
         </div>
       </SectionCard>

--- a/src/worker/serialization.js
+++ b/src/worker/serialization.js
@@ -149,6 +149,7 @@ const DELTA_OBJECT_FIELDS = [
   'tradeDeadline', 'playoffSeeds', 'standingsContext', 'standings',
   'records', 'recordBook',
   'playerSeasonStatsArchive',
+  'teamCulture',
 ];
 
 /**

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -146,6 +146,7 @@ import { migrateSaveMetaToCurrent, CURRENT_SAVE_SCHEMA_VERSION } from '../state/
 import { getTradeWindowSnapshot, isTradeWindowOpen } from '../core/tradeWindow.js';
 import { archiveCompletedSeasonIfNeeded, ensureLeagueHistoryContainer } from '../core/leagueHistory.js';
 import { ensurePersonalityProfile, mentorshipBonusForPlayer, contractPersonalityModifier } from '../core/development/personalitySystem.js';
+import { applyTeamCultureWeek, classifyTeamCulture, buildTeamCultureNarrative, TEAM_CULTURE_DEFAULT } from '../core/teamCulture.js';
 import { buildCanonicalGameId, buildArchivedGame, toTeamId } from '../core/gameIdentity.js';
 import { normalizeArchivedGamePayload, classifyArchiveQuality, validateArchivedGame, recoverArchivedGameFromSchedule, enrichArchivedGamePayload, mergeArchivedGameWithScheduleResult } from '../core/gameArchive.js';
 import {
@@ -977,6 +978,7 @@ function buildViewState() {
     records: meta?.records ?? null,
     recordBook: meta?.recordBook ?? null,
     playerSeasonStatsArchive: meta?.playerSeasonStatsArchive ?? {},
+    teamCulture: meta?.teamCulture ?? {},
     leagueHistory: Array.isArray(meta?.leagueHistory) ? meta.leagueHistory.slice(-60) : [],
     franchiseChronicle: Array.isArray(meta?.franchiseChronicle) ? meta.franchiseChronicle.slice(-340) : [],
     franchiseSeasonReviews: Array.isArray(meta?.franchiseSeasonReviews) ? meta.franchiseSeasonReviews.slice(-40) : [],
@@ -3102,6 +3104,62 @@ async function handleAdvanceWeek(payload, id) {
       if (wonGame) {
         cache.setMeta({ ownerGoals: updateGoalsForWin(meta?.ownerGoals) });
       }
+    }
+  }
+
+  // ── Team Culture: weekly drift (official advance only, all teams) ───────────
+  if (results.length > 0 && ['regular', 'playoffs'].includes(meta.phase)) {
+    try {
+      const cultureTeams = cache.getAllTeams();
+      const cultureRosters = {};
+      for (const t of cultureTeams) {
+        cultureRosters[String(t.id)] = cache.getPlayersByTeam(t.id);
+      }
+      const previousCulture = cache.getMeta().teamCulture ?? {};
+      const nextCulture = applyTeamCultureWeek({
+        teams: cultureTeams,
+        rostersByTeam: cultureRosters,
+        games: results,
+        previousCulture,
+        context: { week, seasonId },
+      });
+
+      // Low-frequency news for meaningful threshold crossings
+      const latestMetaForCulture = cache.getMeta();
+      for (const [tId, entry] of Object.entries(nextCulture)) {
+        const prev = previousCulture[tId];
+        if (!prev) continue;
+        const prevScore = prev.score ?? TEAM_CULTURE_DEFAULT;
+        const newScore = entry.score ?? TEAM_CULTURE_DEFAULT;
+        const absShift = Math.abs(entry.lastShift ?? 0);
+        const crossedBelow55 = prevScore >= 55 && newScore < 55;
+        const crossedAbove85 = prevScore <= 85 && newScore > 85;
+        const largeShift = absShift > 1.0;
+        if (crossedBelow55 || crossedAbove85 || largeShift) {
+          const cTeam = cache.getTeam(Number(tId));
+          if (cTeam) {
+            const direction = newScore > prevScore ? 'improved' : 'declined';
+            const label = classifyTeamCulture(newScore);
+            const narrative = buildTeamCultureNarrative(newScore, entry.lastShift ?? 0, entry.reasons ?? []);
+            const cultureItem = {
+              id: `culture_${tId}_${seasonId}_${week}`,
+              headline: `${cTeam.name}: Culture ${direction} to "${label}"`,
+              body: narrative,
+              week,
+              season: seasonId,
+              type: 'CULTURE',
+              teamId: Number(tId),
+              priority: 'low',
+            };
+            cache.setMeta(addNewsItem(cache.getMeta(), cultureItem));
+          }
+        }
+      }
+
+      cache.setMeta({ teamCulture: nextCulture });
+    } catch (cultureErr) {
+      // Culture update must never crash the week advance
+      console.warn('[Worker] Team culture update error (non-fatal):', cultureErr?.message);
     }
   }
 

--- a/tests/unit/teamCulture.test.js
+++ b/tests/unit/teamCulture.test.js
@@ -1,0 +1,581 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TEAM_CULTURE_DEFAULT,
+  TEAM_CULTURE_MIN,
+  TEAM_CULTURE_MAX,
+  WEEKLY_SHIFT_CAP,
+  initializeTeamCulture,
+  getTeamCultureScore,
+  classifyTeamCulture,
+  calculateLeadershipProfile,
+  calculateCultureShift,
+  applyTeamCultureWeek,
+  buildTeamCultureNarrative,
+} from '../../src/core/teamCulture.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const makeTeam = (id = 1) => ({ id });
+
+const makeGame = (overrides = {}) => ({
+  home: 1,
+  away: 2,
+  scoreHome: 24,
+  scoreAway: 17,
+  ...overrides,
+});
+
+const makeRoster = (overrides = []) => overrides;
+
+const makePlayer = (overrides = {}) => ({
+  id: 'p1',
+  age: 27,
+  traits: [],
+  personalityProfile: { leadership: 55, diva: 35, workEthic: 65 },
+  ...overrides,
+});
+
+// ── initializeTeamCulture ─────────────────────────────────────────────────────
+
+describe('initializeTeamCulture', () => {
+  it('initializes all teams at neutral 70 when no existing culture', () => {
+    const teams = [makeTeam(1), makeTeam(2), makeTeam(3)];
+    const culture = initializeTeamCulture(teams, {});
+    expect(culture['1'].score).toBe(TEAM_CULTURE_DEFAULT);
+    expect(culture['2'].score).toBe(TEAM_CULTURE_DEFAULT);
+    expect(culture['3'].score).toBe(TEAM_CULTURE_DEFAULT);
+  });
+
+  it('preserves existing entries and only fills missing ones', () => {
+    const teams = [makeTeam(1), makeTeam(2)];
+    const existing = { '1': { score: 85, lastShift: 0.5, trend: 'up', reasons: [], updatedWeek: 3, updatedSeason: 1 } };
+    const culture = initializeTeamCulture(teams, existing);
+    expect(culture['1'].score).toBe(85); // preserved
+    expect(culture['2'].score).toBe(TEAM_CULTURE_DEFAULT); // filled
+  });
+
+  it('handles empty teams array gracefully', () => {
+    expect(() => initializeTeamCulture([], {})).not.toThrow();
+  });
+
+  it('handles null/undefined existingCulture gracefully', () => {
+    const teams = [makeTeam(1)];
+    const culture = initializeTeamCulture(teams, null);
+    expect(culture['1'].score).toBe(TEAM_CULTURE_DEFAULT);
+  });
+});
+
+// ── getTeamCultureScore ───────────────────────────────────────────────────────
+
+describe('getTeamCultureScore', () => {
+  it('returns the stored score for a known team', () => {
+    const culture = { '5': { score: 78 } };
+    expect(getTeamCultureScore(culture, 5)).toBe(78);
+  });
+
+  it('returns 70 for a missing team (safe default)', () => {
+    expect(getTeamCultureScore({}, 99)).toBe(TEAM_CULTURE_DEFAULT);
+  });
+
+  it('returns 70 for null/undefined culture object', () => {
+    expect(getTeamCultureScore(null, 1)).toBe(TEAM_CULTURE_DEFAULT);
+    expect(getTeamCultureScore(undefined, 1)).toBe(TEAM_CULTURE_DEFAULT);
+  });
+});
+
+// ── classifyTeamCulture ───────────────────────────────────────────────────────
+
+describe('classifyTeamCulture', () => {
+  it('classifies 100 as United', () => expect(classifyTeamCulture(100)).toBe('United'));
+  it('classifies 85 as United', () => expect(classifyTeamCulture(85)).toBe('United'));
+  it('classifies 84 as Focused', () => expect(classifyTeamCulture(84)).toBe('Focused'));
+  it('classifies 70 as Focused', () => expect(classifyTeamCulture(70)).toBe('Focused'));
+  it('classifies 69 as Uneasy', () => expect(classifyTeamCulture(69)).toBe('Uneasy'));
+  it('classifies 55 as Uneasy', () => expect(classifyTeamCulture(55)).toBe('Uneasy'));
+  it('classifies 54 as Fractured', () => expect(classifyTeamCulture(54)).toBe('Fractured'));
+  it('classifies 40 as Fractured', () => expect(classifyTeamCulture(40)).toBe('Fractured'));
+  it('classifies 39 as Toxic', () => expect(classifyTeamCulture(39)).toBe('Toxic'));
+  it('classifies 0 as Toxic', () => expect(classifyTeamCulture(0)).toBe('Toxic'));
+});
+
+// ── calculateLeadershipProfile ────────────────────────────────────────────────
+
+describe('calculateLeadershipProfile', () => {
+  it('counts leaders with leadership >= 70', () => {
+    const roster = [makePlayer({ personalityProfile: { leadership: 72, diva: 30 } })];
+    const profile = calculateLeadershipProfile(roster);
+    expect(profile.leaderCount).toBe(1);
+  });
+
+  it('does not count players with leadership < 70 as leaders', () => {
+    const roster = [makePlayer({ personalityProfile: { leadership: 65, diva: 30 } })];
+    const profile = calculateLeadershipProfile(roster);
+    expect(profile.leaderCount).toBe(0);
+  });
+
+  it('counts disruptive players with diva >= 72', () => {
+    const roster = [makePlayer({ personalityProfile: { leadership: 50, diva: 80 } })];
+    const profile = calculateLeadershipProfile(roster);
+    expect(profile.disruptiveCount).toBe(1);
+  });
+
+  it('counts MENTOR trait + qualifying age/leadership as mentors', () => {
+    const roster = [makePlayer({ traits: ['MENTOR'], age: 30, personalityProfile: { leadership: 75, diva: 20 } })];
+    const profile = calculateLeadershipProfile(roster);
+    expect(profile.mentorCount).toBe(1);
+  });
+
+  it('does not count MENTOR trait without age/leadership qualification', () => {
+    const roster = [makePlayer({ traits: ['MENTOR'], age: 22, personalityProfile: { leadership: 55, diva: 20 } })];
+    const profile = calculateLeadershipProfile(roster);
+    expect(profile.mentorCount).toBe(0);
+  });
+
+  it('counts young players (age <= 23)', () => {
+    const roster = [makePlayer({ age: 22 }), makePlayer({ age: 25 })];
+    const profile = calculateLeadershipProfile(roster);
+    expect(profile.youngPlayerCount).toBe(1);
+  });
+
+  it('returns zeros for empty roster', () => {
+    const profile = calculateLeadershipProfile([]);
+    expect(profile.leaderCount).toBe(0);
+    expect(profile.disruptiveCount).toBe(0);
+    expect(profile.mentorCount).toBe(0);
+    expect(profile.youngPlayerCount).toBe(0);
+  });
+});
+
+// ── calculateCultureShift ─────────────────────────────────────────────────────
+
+describe('calculateCultureShift — game results', () => {
+  it('produces a positive shift for a win', () => {
+    const result = calculateCultureShift({
+      team: makeTeam(1),
+      roster: [],
+      recentGame: makeGame({ home: 1, away: 2, scoreHome: 28, scoreAway: 14 }),
+      advancedAttribution: null,
+      previousScore: TEAM_CULTURE_DEFAULT,
+      context: { week: 3, seasonId: 1 },
+    });
+    expect(result.shift).toBeGreaterThan(0);
+    expect(result.newScore).toBeGreaterThan(TEAM_CULTURE_DEFAULT);
+  });
+
+  it('produces a negative shift for a loss', () => {
+    const result = calculateCultureShift({
+      team: makeTeam(1),
+      roster: [],
+      recentGame: makeGame({ home: 1, away: 2, scoreHome: 14, scoreAway: 28 }),
+      advancedAttribution: null,
+      previousScore: TEAM_CULTURE_DEFAULT,
+      context: { week: 3, seasonId: 1 },
+    });
+    expect(result.shift).toBeLessThan(0);
+    expect(result.newScore).toBeLessThan(TEAM_CULTURE_DEFAULT);
+  });
+
+  it('blowout loss produces a larger negative shift than close loss', () => {
+    const blowout = calculateCultureShift({
+      team: makeTeam(1),
+      roster: [],
+      recentGame: makeGame({ home: 1, away: 2, scoreHome: 0, scoreAway: 35 }),
+      advancedAttribution: null,
+      previousScore: TEAM_CULTURE_DEFAULT,
+      context: { week: 3, seasonId: 1 },
+    });
+    const close = calculateCultureShift({
+      team: makeTeam(1),
+      roster: [],
+      recentGame: makeGame({ home: 1, away: 2, scoreHome: 17, scoreAway: 20 }),
+      advancedAttribution: null,
+      previousScore: TEAM_CULTURE_DEFAULT,
+      context: { week: 3, seasonId: 1 },
+    });
+    expect(blowout.shift).toBeLessThan(close.shift);
+  });
+
+  it('blowout loss shift is capped and does not exceed GAME_SHIFT_CAP', () => {
+    const result = calculateCultureShift({
+      team: makeTeam(1),
+      roster: [],
+      recentGame: makeGame({ home: 1, away: 2, scoreHome: 0, scoreAway: 63 }),
+      advancedAttribution: null,
+      previousScore: TEAM_CULTURE_DEFAULT,
+      context: { week: 1, seasonId: 1 },
+    });
+    // shift after traits may slightly exceed GAME_SHIFT_CAP due to disruptive layer
+    // but must never exceed WEEKLY_SHIFT_CAP
+    expect(Math.abs(result.shift)).toBeLessThanOrEqual(WEEKLY_SHIFT_CAP);
+  });
+
+  it('bye week (no recentGame) produces zero shift', () => {
+    const result = calculateCultureShift({
+      team: makeTeam(1),
+      roster: [],
+      recentGame: null,
+      advancedAttribution: null,
+      previousScore: TEAM_CULTURE_DEFAULT,
+      context: { week: 5, seasonId: 1 },
+    });
+    expect(result.shift).toBe(0);
+    expect(result.newScore).toBe(TEAM_CULTURE_DEFAULT);
+  });
+});
+
+describe('calculateCultureShift — trait effects', () => {
+  it('Leader trait softens negative drift', () => {
+    const leaderRoster = [makePlayer({ personalityProfile: { leadership: 80, diva: 25 } })];
+    const noLeaderRoster = [];
+
+    const withLeader = calculateCultureShift({
+      team: makeTeam(1),
+      roster: leaderRoster,
+      recentGame: makeGame({ home: 1, away: 2, scoreHome: 10, scoreAway: 28 }),
+      advancedAttribution: null,
+      previousScore: TEAM_CULTURE_DEFAULT,
+      context: { week: 2, seasonId: 1 },
+    });
+    const withoutLeader = calculateCultureShift({
+      team: makeTeam(1),
+      roster: noLeaderRoster,
+      recentGame: makeGame({ home: 1, away: 2, scoreHome: 10, scoreAway: 28 }),
+      advancedAttribution: null,
+      previousScore: TEAM_CULTURE_DEFAULT,
+      context: { week: 2, seasonId: 1 },
+    });
+    expect(withLeader.shift).toBeGreaterThan(withoutLeader.shift);
+  });
+
+  it('Disruptive trait amplifies negative drift during a loss', () => {
+    const disruptiveRoster = [makePlayer({ personalityProfile: { leadership: 40, diva: 80 } })];
+    const neutralRoster = [];
+
+    const withDisruptive = calculateCultureShift({
+      team: makeTeam(1),
+      roster: disruptiveRoster,
+      recentGame: makeGame({ home: 1, away: 2, scoreHome: 10, scoreAway: 28 }),
+      advancedAttribution: null,
+      previousScore: TEAM_CULTURE_DEFAULT,
+      context: { week: 2, seasonId: 1 },
+    });
+    const withNeutral = calculateCultureShift({
+      team: makeTeam(1),
+      roster: neutralRoster,
+      recentGame: makeGame({ home: 1, away: 2, scoreHome: 10, scoreAway: 28 }),
+      advancedAttribution: null,
+      previousScore: TEAM_CULTURE_DEFAULT,
+      context: { week: 2, seasonId: 1 },
+    });
+    expect(withDisruptive.shift).toBeLessThan(withNeutral.shift);
+  });
+
+  it('Disruptive trait does NOT amplify negative drift during a win', () => {
+    const disruptiveRoster = [makePlayer({ personalityProfile: { leadership: 40, diva: 80 } })];
+    const withDisruptive = calculateCultureShift({
+      team: makeTeam(1),
+      roster: disruptiveRoster,
+      recentGame: makeGame({ home: 1, away: 2, scoreHome: 28, scoreAway: 10 }),
+      advancedAttribution: null,
+      previousScore: TEAM_CULTURE_DEFAULT,
+      context: { week: 2, seasonId: 1 },
+    });
+    // Disruptive should not make a win result negative or significantly smaller
+    expect(withDisruptive.shift).toBeGreaterThan(0);
+  });
+
+  it('Mentorship gives tiny positive drift when young players present', () => {
+    const mentorRoster = [
+      makePlayer({ id: 'm1', traits: ['MENTOR'], age: 32, personalityProfile: { leadership: 78, diva: 15 } }),
+      makePlayer({ id: 'r1', age: 21, personalityProfile: { leadership: 45, diva: 25 } }),
+    ];
+    const noMentorRoster = [];
+
+    const withMentor = calculateCultureShift({
+      team: makeTeam(1),
+      roster: mentorRoster,
+      recentGame: null,
+      advancedAttribution: null,
+      previousScore: TEAM_CULTURE_DEFAULT,
+      context: { week: 3, seasonId: 1 },
+    });
+    const withoutMentor = calculateCultureShift({
+      team: makeTeam(1),
+      roster: noMentorRoster,
+      recentGame: null,
+      advancedAttribution: null,
+      previousScore: TEAM_CULTURE_DEFAULT,
+      context: { week: 3, seasonId: 1 },
+    });
+    expect(withMentor.shift).toBeGreaterThan(withoutMentor.shift);
+  });
+});
+
+describe('calculateCultureShift — advanced attribution', () => {
+  it('excessive drops produce a tiny negative contribution', () => {
+    const withDrops = calculateCultureShift({
+      team: makeTeam(1),
+      roster: [],
+      recentGame: makeGame({ home: 1, away: 2, scoreHome: 21, scoreAway: 14 }),
+      advancedAttribution: { drops: 5, sacksAllowed: 0, sacksMade: 0, battedPasses: 0 },
+      previousScore: TEAM_CULTURE_DEFAULT,
+      context: { week: 1, seasonId: 1 },
+    });
+    const withoutDrops = calculateCultureShift({
+      team: makeTeam(1),
+      roster: [],
+      recentGame: makeGame({ home: 1, away: 2, scoreHome: 21, scoreAway: 14 }),
+      advancedAttribution: null,
+      previousScore: TEAM_CULTURE_DEFAULT,
+      context: { week: 1, seasonId: 1 },
+    });
+    // Drops reduce the shift, but both should still be positive (it was a win)
+    expect(withDrops.shift).toBeLessThan(withoutDrops.shift);
+    expect(withDrops.shift).toBeGreaterThan(0);
+  });
+
+  it('strong defensive attribution gives tiny positive contribution', () => {
+    const withDefense = calculateCultureShift({
+      team: makeTeam(1),
+      roster: [],
+      recentGame: makeGame({ home: 1, away: 2, scoreHome: 17, scoreAway: 14 }),
+      advancedAttribution: { drops: 0, sacksAllowed: 0, sacksMade: 5, battedPasses: 0 },
+      previousScore: TEAM_CULTURE_DEFAULT,
+      context: { week: 1, seasonId: 1 },
+    });
+    const withoutDefense = calculateCultureShift({
+      team: makeTeam(1),
+      roster: [],
+      recentGame: makeGame({ home: 1, away: 2, scoreHome: 17, scoreAway: 14 }),
+      advancedAttribution: null,
+      previousScore: TEAM_CULTURE_DEFAULT,
+      context: { week: 1, seasonId: 1 },
+    });
+    expect(withDefense.shift).toBeGreaterThan(withoutDefense.shift);
+  });
+
+  it('attribution influence is tiny relative to game result', () => {
+    const drops = calculateCultureShift({
+      team: makeTeam(1),
+      roster: [],
+      recentGame: makeGame({ home: 1, away: 2, scoreHome: 28, scoreAway: 7 }),
+      advancedAttribution: { drops: 10, sacksAllowed: 10, sacksMade: 0, battedPasses: 0 },
+      previousScore: TEAM_CULTURE_DEFAULT,
+      context: { week: 1, seasonId: 1 },
+    });
+    // Even with extreme attribution negatives, a blowout win still produces positive shift
+    expect(drops.shift).toBeGreaterThan(0);
+  });
+});
+
+describe('calculateCultureShift — score bounds', () => {
+  it('culture score never goes below 0', () => {
+    let score = 2; // near floor
+    for (let i = 0; i < 10; i++) {
+      const result = calculateCultureShift({
+        team: makeTeam(1),
+        roster: [makePlayer({ personalityProfile: { leadership: 20, diva: 90 } })],
+        recentGame: makeGame({ home: 1, away: 2, scoreHome: 0, scoreAway: 42 }),
+        advancedAttribution: { drops: 10, sacksAllowed: 10, sacksMade: 0, battedPasses: 0 },
+        previousScore: score,
+        context: { week: i + 1, seasonId: 1 },
+      });
+      score = result.newScore;
+      expect(score).toBeGreaterThanOrEqual(TEAM_CULTURE_MIN);
+    }
+  });
+
+  it('culture score never exceeds 100', () => {
+    let score = 98; // near ceiling
+    for (let i = 0; i < 10; i++) {
+      const result = calculateCultureShift({
+        team: makeTeam(1),
+        roster: [makePlayer({ traits: ['MENTOR'], age: 34, personalityProfile: { leadership: 95, diva: 5 } })],
+        recentGame: makeGame({ home: 1, away: 2, scoreHome: 42, scoreAway: 0 }),
+        advancedAttribution: { drops: 0, sacksAllowed: 0, sacksMade: 8, battedPasses: 5 },
+        previousScore: score,
+        context: { week: i + 1, seasonId: 1 },
+      });
+      score = result.newScore;
+      expect(score).toBeLessThanOrEqual(TEAM_CULTURE_MAX);
+    }
+  });
+
+  it('same inputs always produce the same output (deterministic)', () => {
+    const opts = {
+      team: makeTeam(3),
+      roster: [makePlayer({ personalityProfile: { leadership: 72, diva: 42 } })],
+      recentGame: makeGame({ home: 3, away: 7, scoreHome: 17, scoreAway: 24 }),
+      advancedAttribution: { drops: 2, sacksAllowed: 3, sacksMade: 1, battedPasses: 1 },
+      previousScore: 65,
+      context: { week: 6, seasonId: 2 },
+    };
+    const r1 = calculateCultureShift(opts);
+    const r2 = calculateCultureShift(opts);
+    expect(r1.newScore).toBe(r2.newScore);
+    expect(r1.shift).toBe(r2.shift);
+    expect(r1.trend).toBe(r2.trend);
+  });
+});
+
+// ── applyTeamCultureWeek ──────────────────────────────────────────────────────
+
+describe('applyTeamCultureWeek', () => {
+  it('processes all teams in a single call', () => {
+    const teams = [makeTeam(1), makeTeam(2)];
+    const games = [
+      makeGame({ home: 1, away: 2, scoreHome: 28, scoreAway: 7 }),
+    ];
+    const culture = applyTeamCultureWeek({
+      teams,
+      rostersByTeam: {},
+      games,
+      previousCulture: {},
+      context: { week: 1, seasonId: 1 },
+    });
+    expect(culture['1']).toBeDefined();
+    expect(culture['2']).toBeDefined();
+    expect(culture['1'].updatedWeek).toBe(1);
+    expect(culture['2'].updatedWeek).toBe(1);
+  });
+
+  it('does not double-apply when called again with same week/season', () => {
+    const teams = [makeTeam(1)];
+    const games = [makeGame({ home: 1, away: 2, scoreHome: 28, scoreAway: 7 })];
+    const context = { week: 3, seasonId: 1 };
+
+    const first = applyTeamCultureWeek({
+      teams,
+      rostersByTeam: {},
+      games,
+      previousCulture: {},
+      context,
+    });
+    const secondScore = first['1'].score;
+
+    const second = applyTeamCultureWeek({
+      teams,
+      rostersByTeam: {},
+      games,
+      previousCulture: first,
+      context, // same week+season → dedupe
+    });
+    expect(second['1'].score).toBe(secondScore);
+  });
+
+  it('re-applies for a new week', () => {
+    const teams = [makeTeam(1)];
+    const games = [makeGame({ home: 1, away: 2, scoreHome: 28, scoreAway: 7 })];
+
+    const week1 = applyTeamCultureWeek({
+      teams,
+      rostersByTeam: {},
+      games,
+      previousCulture: {},
+      context: { week: 1, seasonId: 1 },
+    });
+    const week2 = applyTeamCultureWeek({
+      teams,
+      rostersByTeam: {},
+      games,
+      previousCulture: week1,
+      context: { week: 2, seasonId: 1 }, // different week → should update
+    });
+    // Week 2 should have a different updatedWeek stamp
+    expect(week2['1'].updatedWeek).toBe(2);
+  });
+
+  it('initializes missing culture entries to neutral 70', () => {
+    const teams = [makeTeam(42)];
+    const culture = applyTeamCultureWeek({
+      teams,
+      rostersByTeam: {},
+      games: [],
+      previousCulture: {},
+      context: { week: 1, seasonId: 1 },
+    });
+    // Bye week with no game → shift is 0, score stays at default
+    expect(culture['42'].score).toBe(TEAM_CULTURE_DEFAULT);
+  });
+
+  it('handles empty games array gracefully (bye week for all)', () => {
+    const teams = [makeTeam(1), makeTeam(2)];
+    expect(() =>
+      applyTeamCultureWeek({
+        teams,
+        rostersByTeam: {},
+        games: [],
+        previousCulture: {},
+        context: { week: 5, seasonId: 1 },
+      })
+    ).not.toThrow();
+  });
+});
+
+// ── buildTeamCultureNarrative ─────────────────────────────────────────────────
+
+describe('buildTeamCultureNarrative', () => {
+  it('returns a non-empty string', () => {
+    const text = buildTeamCultureNarrative(72, 0.4, ['Win builds team confidence']);
+    expect(typeof text).toBe('string');
+    expect(text.length).toBeGreaterThan(0);
+  });
+
+  it('includes the culture label', () => {
+    const text = buildTeamCultureNarrative(90, 0.5, []);
+    expect(text).toContain('United');
+  });
+
+  it('mentions trending up for positive shift', () => {
+    const text = buildTeamCultureNarrative(75, 0.5, []);
+    expect(text).toContain('trending up');
+  });
+
+  it('mentions under pressure for negative shift', () => {
+    const text = buildTeamCultureNarrative(60, -0.5, []);
+    expect(text).toContain('under pressure');
+  });
+
+  it('mentions holding steady for near-zero shift', () => {
+    const text = buildTeamCultureNarrative(70, 0.01, []);
+    expect(text).toContain('holding steady');
+  });
+
+  it('does not throw for empty reasons array', () => {
+    expect(() => buildTeamCultureNarrative(70, 0, [])).not.toThrow();
+  });
+
+  it('does not throw for undefined reasons', () => {
+    expect(() => buildTeamCultureNarrative(70, 0, undefined)).not.toThrow();
+  });
+});
+
+// ── legacy save safety ────────────────────────────────────────────────────────
+
+describe('legacy save safety', () => {
+  it('getTeamCultureScore returns 70 for legacy saves with no teamCulture key', () => {
+    // Simulates a save that has no teamCulture at all
+    const legacySaveState = {};
+    expect(getTeamCultureScore(legacySaveState.teamCulture, 1)).toBe(TEAM_CULTURE_DEFAULT);
+  });
+
+  it('initializeTeamCulture does not crash on legacy saves', () => {
+    const teams = [makeTeam(1), makeTeam(2)];
+    expect(() => initializeTeamCulture(teams, undefined)).not.toThrow();
+    expect(() => initializeTeamCulture(teams, null)).not.toThrow();
+    expect(() => initializeTeamCulture(teams, {})).not.toThrow();
+  });
+
+  it('applyTeamCultureWeek does not crash with undefined previousCulture', () => {
+    const teams = [makeTeam(1)];
+    expect(() =>
+      applyTeamCultureWeek({
+        teams,
+        rostersByTeam: {},
+        games: [],
+        previousCulture: undefined,
+        context: { week: 1, seasonId: 1 },
+      })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Adds a deterministic, narrative-only team culture system that reacts
to wins/losses, roster leadership/personality traits, and optional
advanced-attribution signals. No gameplay performance modifiers are
applied in V1 — culture is state/readout only.

New module: src/core/teamCulture.js
- initializeTeamCulture / getTeamCultureScore / classifyTeamCulture
- calculateLeadershipProfile (reads personality.leadership, diva, MENTOR trait)
- calculateCultureShift (pure, no Math.random, WEEKLY_SHIFT_CAP = 1.25)
- applyTeamCultureWeek (with season+week dedupe guard)
- buildTeamCultureNarrative

Worker integration (handleAdvanceWeek only):
- Runs after all game results applied, before pulse/chronicle generation
- Skipped for watch-only sim, box-score replay, and UI refresh
- Low-frequency news items generated only for threshold crossings (< 55,
  > 85, or shift > 1.0)
- teamCulture exposed in buildViewState; added to DELTA_OBJECT_FIELDS
- Legacy saves with no teamCulture field initialise safely to 70

UI: compact culture card added to Season Pulse grid in FranchiseHQ
(full-width 5th card): shows score, label, trend arrow, and narrative.

Tests: 54 unit tests cover all acceptance criteria including bounds,
determinism, trait effects, advanced-attribution influence, dedupe,
legacy safety, and narrative rendering.

https://claude.ai/code/session_01J745F8Rm9SnKfc16rpefC5