### PR TITLE
Implement Broadcast Narrative Commentary V1 (deterministic, presentation-only)

### DIFF
--- a/src/core/broadcastNarrative.js
+++ b/src/core/broadcastNarrative.js
@@ -1,0 +1,92 @@
+function toNum(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function normalizeText(value) {
+  return String(value ?? '').trim();
+}
+
+function makeNote(id, text, score, category = 'game') {
+  const clean = normalizeText(text);
+  if (!clean) return null;
+  return { id: String(id), text: clean, score: toNum(score), category };
+}
+
+export function buildAdvancedAttributionNotes(advancedAttribution, playerLookup = {}, context = {}) {
+  if (!advancedAttribution || typeof advancedAttribution !== 'object') return [];
+  const rows = Object.entries(advancedAttribution);
+  if (!rows.length) return [];
+
+  let dropsLeader = null;
+  let sacksAllowedLeader = null;
+
+  for (const [playerId, row] of rows) {
+    const drops = toNum(row?.drops);
+    const sacksAllowed = toNum(row?.sacksAllowed);
+    if (!dropsLeader || drops > dropsLeader.value) dropsLeader = { playerId, value: drops };
+    if (!sacksAllowedLeader || sacksAllowed > sacksAllowedLeader.value) sacksAllowedLeader = { playerId, value: sacksAllowed };
+  }
+
+  const notes = [];
+  if (sacksAllowedLeader && sacksAllowedLeader.value >= 5) {
+    const name = playerLookup?.[String(sacksAllowedLeader.playerId)]?.name ?? 'Protection unit';
+    notes.push(makeNote('sacks-allowed', `Pressure told the story: ${name} allowed ${sacksAllowedLeader.value} sacks and never found rhythm.`, 90, 'attribution'));
+  }
+  if (dropsLeader && dropsLeader.value >= 3) {
+    notes.push(makeNote('drops', `Drops stalled drives: ${dropsLeader.value} recorded drops kept the offense behind schedule.`, 80, 'attribution'));
+  }
+  return notes.filter(Boolean);
+}
+
+export function buildMomentumBroadcastNotes(gameFlowSummary, context = {}) {
+  if (!gameFlowSummary || typeof gameFlowSummary !== 'object') return [];
+  const turningPoints = Array.isArray(gameFlowSummary.turningPoints) ? gameFlowSummary.turningPoints : [];
+  const leadChanges = turningPoints.filter((point) => point?.type === 'lead_change').length;
+  if (leadChanges >= 2) {
+    return [makeNote('lead-changes', `A fourth-quarter swing flipped momentum in a game with ${leadChanges} lead changes.`, 88, 'momentum')].filter(Boolean);
+  }
+  return [];
+}
+
+export function buildCultureBroadcastNotes(teamCultureChange, context = {}) {
+  if (!teamCultureChange || typeof teamCultureChange !== 'object') return [];
+  const before = toNum(teamCultureChange.previousScore, NaN);
+  const after = toNum(teamCultureChange.newScore, NaN);
+  if (!Number.isFinite(before) || !Number.isFinite(after)) return [];
+  if (before >= 55 && after < 55) {
+    return [makeNote(`culture-down-${teamCultureChange.teamId ?? 'team'}`, `${teamCultureChange.teamName ?? 'Team'} dropped into an uneasy culture band after this week.`, 75, 'culture')].filter(Boolean);
+  }
+  if (before <= 85 && after > 85) {
+    return [makeNote(`culture-up-${teamCultureChange.teamId ?? 'team'}`, `${teamCultureChange.teamName ?? 'Team'} climbed into a united culture band and carried real sideline energy.`, 75, 'culture')].filter(Boolean);
+  }
+  return [];
+}
+
+export function dedupeBroadcastNotes(notes = []) {
+  const seen = new Set();
+  const out = [];
+  for (const note of notes) {
+    if (!note || !note.text) continue;
+    const key = normalizeText(note.text).toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(note);
+  }
+  return out;
+}
+
+export function rankBroadcastNotes(notes = [], options = {}) {
+  const maxNotes = Math.max(0, toNum(options.maxNotes, 3));
+  return [...notes]
+    .sort((a, b) => (toNum(b?.score) - toNum(a?.score)) || String(a?.id ?? '').localeCompare(String(b?.id ?? '')))
+    .slice(0, maxNotes);
+}
+
+export function buildBroadcastGameNotes(gameSummary, context = {}) {
+  if (!gameSummary || typeof gameSummary !== 'object') return [];
+  const playerLookup = context.playerLookup ?? {};
+  const attribution = buildAdvancedAttributionNotes(gameSummary.advancedAttribution, playerLookup, context);
+  const momentum = buildMomentumBroadcastNotes(gameSummary.gameFlowSummary, context);
+  return rankBroadcastNotes(dedupeBroadcastNotes([...attribution, ...momentum]), { maxNotes: context.maxNotes ?? 3 });
+}

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -6,6 +6,7 @@ import { buildGameBookStory } from "../utils/gameBookStory.js";
 import { getPlayerProfileId, hasValidPlayerProfileId, openPlayerProfile } from "../utils/playerProfileNavigation.js";
 import ReplayableGameFlowViewer from "./ReplayableGameFlowViewer.jsx";
 import AdvancedGameStats from "./AdvancedGameStats.jsx";
+import { buildBroadcastGameNotes } from "../../core/broadcastNarrative.js";
 
 const QUALITY_BADGE_CLASS = {
   "Full detail": "success",
@@ -121,6 +122,11 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
   const defaultPlayRows = keyPlayRows.slice(0, 12);
   const visiblePlayRows = showAllPlays ? playRows : defaultPlayRows;
   const canTogglePlays = playRows.length > 0 && (showAllPlays || visiblePlayRows.length < playRows.length || keyPlayRows.length === 0);
+  const broadcastNotes = useMemo(() => buildBroadcastGameNotes({
+    advancedAttribution: vm.advancedAttribution,
+    gameFlowSummary: vm.gameFlowSummary,
+  }, { maxNotes: 3 }), [vm.advancedAttribution, vm.gameFlowSummary]);
+
   const playCountLabel = showAllPlays
     ? `Showing all ${playRows.length} recorded plays`
     : keyPlayRows.length
@@ -218,6 +224,21 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
         <h4>Why this game was decided</h4>
         {storyBullets.length ? <ul>{storyBullets.map((b) => <li key={b}>{b}</li>)}</ul> : <p>No detailed team/player stats were recorded for this game.</p>}
       </section>
+      {broadcastNotes.length ? (
+        <section className="bs-section bs-broadcast-notes" data-testid="game-book-broadcast-notes">
+          <div className="bs-section-header">
+            <h4>Broadcast Notes</h4>
+            <span className="bs-section-count">{broadcastNotes.length} notes</span>
+          </div>
+          <ul className="bs-list" data-testid="game-book-broadcast-notes-list">
+            {broadcastNotes.map((note) => (
+              <li key={note.id} className="bs-list-item">
+                <span>{note.text}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
       {gfs && (
         <section className="bs-section" data-testid="game-book-game-flow">
           <div className="bs-section-header">
@@ -287,7 +308,7 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
           ) : null}
         </section>
       )}
-      {gfs && (
+            {gfs && (
         <section className="bs-section" data-testid="game-book-replay-section">
           <div className="bs-section-header">
             <h4>Replay Game Flow</h4>

--- a/src/ui/components/__tests__/BoxScoreAutoOpen.test.jsx
+++ b/src/ui/components/__tests__/BoxScoreAutoOpen.test.jsx
@@ -156,4 +156,27 @@ describe('BoxScore – opt-in auto-open replay gate', () => {
     // Without isManualSimRun the viewer starts paused
     expect(getByTestId('rgfv-progress').textContent).toBe('Paused');
   });
+
+  it('renders Broadcast Notes when deterministic notes exist', () => {
+    const gameWithBroadcast = {
+      ...gameWithFlow,
+      advancedAttribution: {
+        7: { sacksAllowed: 6, drops: 3 },
+      },
+    };
+    const { getByTestId, getByText, container } = render(
+      <BoxScore gameId="g-broadcast" league={{ ...baseLeague, gameById: { 'g-broadcast': gameWithBroadcast } }} embedded />,
+    );
+    expect(getByTestId('game-book-broadcast-notes')).toBeTruthy();
+    expect(getByText('Broadcast Notes')).toBeTruthy();
+    expect(container.querySelector('.bs-broadcast-notes')).toBeTruthy();
+  });
+
+  it('does not render Broadcast Notes for legacy games without note signals', () => {
+    const { queryByTestId } = render(
+      <BoxScore gameId="g-no-broadcast" league={{ ...baseLeague, gameById: { 'g-no-broadcast': gameWithFlow } }} embedded />,
+    );
+    expect(queryByTestId('game-book-broadcast-notes')).toBeNull();
+  });
+
 });

--- a/tests/unit/broadcastNarrative.test.js
+++ b/tests/unit/broadcastNarrative.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildBroadcastGameNotes,
+  buildAdvancedAttributionNotes,
+  buildCultureBroadcastNotes,
+  buildMomentumBroadcastNotes,
+  rankBroadcastNotes,
+  dedupeBroadcastNotes,
+} from '../../src/core/broadcastNarrative.js';
+
+describe('broadcastNarrative', () => {
+  it('returns empty for missing data', () => {
+    expect(buildBroadcastGameNotes(null)).toEqual([]);
+    expect(buildAdvancedAttributionNotes(null)).toEqual([]);
+  });
+
+  it('creates sacks and drops notes', () => {
+    const notes = buildAdvancedAttributionNotes({
+      10: { sacksAllowed: 6, drops: 4 },
+    }, { 10: { name: 'QB One' } });
+    expect(notes.some((n) => /6 sacks/.test(n.text))).toBe(true);
+    expect(notes.some((n) => /Drops stalled drives/.test(n.text))).toBe(true);
+  });
+
+  it('creates culture threshold notes', () => {
+    expect(buildCultureBroadcastNotes({ previousScore: 60, newScore: 54, teamName: 'Test' }).length).toBe(1);
+    expect(buildCultureBroadcastNotes({ previousScore: 84, newScore: 86, teamName: 'Test' }).length).toBe(1);
+  });
+
+  it('creates momentum note for lead-change-heavy games', () => {
+    const notes = buildMomentumBroadcastNotes({ turningPoints: [{ type: 'lead_change' }, { type: 'lead_change' }] });
+    expect(notes.length).toBe(1);
+  });
+
+  it('dedupes and ranks deterministically with max cap', () => {
+    const notes = [
+      { id: 'b', text: 'Same note', score: 50 },
+      { id: 'a', text: 'same note', score: 90 },
+      { id: 'c', text: 'Other note', score: 60 },
+    ];
+    const deduped = dedupeBroadcastNotes(notes);
+    expect(deduped.length).toBe(2);
+    const ranked = rankBroadcastNotes(deduped, { maxNotes: 1 });
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0].text.toLowerCase()).toContain('other note');
+    const out1 = buildBroadcastGameNotes({ advancedAttribution: { 1: { sacksAllowed: 5 } }, gameFlowSummary: {} });
+    const out2 = buildBroadcastGameNotes({ advancedAttribution: { 1: { sacksAllowed: 5 } }, gameFlowSummary: {} });
+    expect(out1).toEqual(out2);
+  });
+});


### PR DESCRIPTION
### Motivation
- The game now emits richer postgame signals (advanced attribution, game flow turning points, and team culture deltas) but lacked a deterministic, presentation-only layer to surface TV-style context for completed games. 
- The intent is to surface concise broadcast-style commentary without changing any simulation outcomes, ratings, or persistence schema.

### Description
- Added a pure, deterministic helper module `src/core/broadcastNarrative.js` with builders: `buildBroadcastGameNotes`, `buildCultureBroadcastNotes`, `buildAdvancedAttributionNotes`, `buildMomentumBroadcastNotes`, `rankBroadcastNotes`, and `dedupeBroadcastNotes`.
- Integrated `buildBroadcastGameNotes(...)` into the postgame Game Book (`BoxScore`) and added a compact, mobile-safe `Broadcast Notes` card that appears only when notes exist and is capped (default `maxNotes: 3`).
- Kept the feature strictly presentation-only: no simulation, ratings, injury, contract, development, or trade logic was modified and no `Math.random()` or non-deterministic behavior was introduced.
- Added unit tests `tests/unit/broadcastNarrative.test.js` and extended `BoxScore` tests to assert Broadcast Notes rendering behavior and safety for legacy/partial games.

### Testing
- Ran `node --check src/core/broadcastNarrative.js` to validate the helper file syntax and it passed.
- Ran targeted unit tests `npm run test:unit -- tests/unit/broadcastNarrative.test.js src/ui/components/__tests__/BoxScoreAutoOpen.test.jsx` and they passed.
- Ran the full unit suite `npm run test:unit` and all tests passed (`2085` tests across `240` files in this environment).
- Built the production bundle with `npm run build` and the build completed successfully (noting the expected chunk-size warnings only). 
- Skipped `npm run test:soak` and Playwright e2e smoke in this change set (no worker weekly-news pipeline edits), but these should be run if the feature is later extended into weekly/franchise headline generation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1472a62d10832d9b7d4b14f75b683b)