### PR TITLE
[codex] Add career advanced stats UI

### DIFF
--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -36,10 +36,23 @@ import { buildLegacyScoreReport, shouldShowLegacyProfileSection } from "../../co
 import { buildPlayerDevelopmentModel } from "../../core/playerDevelopmentModel.js";
 import { buildProspectScoutingReport } from "../../core/scoutingModel.js";
 import { buildPlayerCareerTimeline } from "../utils/playerCareerTimeline.js";
+import { buildPlayerAdvancedStatsView } from "../utils/playerAdvancedStatsViewModel.js";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
 const CAREER_TIMELINE_LIMIT = 8;
+const ADVANCED_ANALYTICS_EMPTY_TEXT = "Advanced tracking begins with newly simulated rich games.";
+
+const ADVANCED_ANALYTICS_FIELDS = [
+  { key: "targets", label: "Targets", shortLabel: "Tgt" },
+  { key: "drops", label: "Drops", shortLabel: "Drop" },
+  { key: "battedPasses", label: "Batted Passes", shortLabel: "Bat" },
+  { key: "coverageTargets", label: "Coverage Targets", shortLabel: "Cov Tgt" },
+  { key: "coverageCompletionsAllowed", label: "Coverage Completions Allowed", shortLabel: "Cov Cmp" },
+  { key: "receptionsAllowed", label: "Receptions Allowed", shortLabel: "Rec All" },
+  { key: "sacksAllowed", label: "Sacks Allowed", shortLabel: "Sck All" },
+  { key: "sacksMade", label: "Sacks Made", shortLabel: "Sck Made" },
+];
 
 // ── Accolade badge config ─────────────────────────────────────────────────────
 
@@ -394,6 +407,132 @@ const sectionLabelStyle = {
   textTransform: "uppercase",
   letterSpacing: ".08em",
 };
+
+function getAdvancedAnalyticsFocusKeys(position) {
+  const pos = String(position ?? "").toUpperCase();
+  const keys = new Set();
+
+  if (["WR", "TE", "RB", "FB"].includes(pos)) {
+    keys.add("targets");
+    keys.add("drops");
+  }
+  if (["OL", "OT", "OG", "C", "G", "T", "QB"].includes(pos)) {
+    keys.add("sacksAllowed");
+  }
+  if (["EDGE", "DL", "DE", "DT", "NT", "LB", "MLB", "OLB"].includes(pos)) {
+    keys.add("sacksMade");
+    keys.add("battedPasses");
+  }
+  if (["CB", "S", "SS", "FS", "LB", "MLB", "OLB"].includes(pos)) {
+    keys.add("coverageTargets");
+    keys.add("coverageCompletionsAllowed");
+    keys.add("receptionsAllowed");
+  }
+
+  return keys;
+}
+
+function formatAdvancedStat(value) {
+  return Number(value ?? 0).toLocaleString();
+}
+
+function AdvancedAnalyticsSection({ advancedView, player }) {
+  const focusKeys = getAdvancedAnalyticsFocusKeys(player?.pos ?? player?.position);
+
+  return (
+    <section className="card-enter" data-testid="player-profile-advanced-analytics">
+      <h3 style={sectionLabelStyle}>Advanced Analytics</h3>
+      {!advancedView?.hasData ? (
+        <p
+          data-testid="player-profile-advanced-empty"
+          style={{ margin: 0, fontSize: "var(--text-sm)", color: "var(--text-muted)" }}
+        >
+          {ADVANCED_ANALYTICS_EMPTY_TEXT}
+        </p>
+      ) : (
+        <div style={{ display: "grid", gap: "var(--space-3)" }}>
+          <div
+            data-testid="player-profile-advanced-career"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(118px, 1fr))",
+              gap: 8,
+            }}
+          >
+            {ADVANCED_ANALYTICS_FIELDS.map((field) => {
+              const isFocus = focusKeys.has(field.key);
+              return (
+                <div
+                  key={field.key}
+                  className="stat-box"
+                  data-focus={isFocus ? "true" : "false"}
+                  style={{
+                    padding: "8px 10px",
+                    border: isFocus ? "1px solid var(--accent)" : "1px solid var(--hairline)",
+                  }}
+                >
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>
+                    {field.label}
+                  </div>
+                  <div style={{ fontSize: "1.05rem", fontWeight: 900, fontVariantNumeric: "tabular-nums" }}>
+                    {formatAdvancedStat(advancedView.career?.[field.key])}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <div
+            className="table-wrapper player-career-table-wrap"
+            data-testid="player-profile-advanced-ledger-wrap"
+            role="region"
+            aria-label="Player advanced season ledger - scroll horizontally to view all columns"
+            style={{
+              overflowX: "auto",
+              WebkitOverflowScrolling: "touch",
+              border: "1px solid var(--hairline)",
+              borderRadius: "var(--radius-md)",
+              maxWidth: "100%",
+            }}
+          >
+            <Table
+              className="standings-table"
+              data-testid="player-profile-advanced-ledger"
+              style={{
+                width: "100%",
+                minWidth: 780,
+                fontSize: "0.76rem",
+                fontVariantNumeric: "tabular-nums",
+              }}
+            >
+              <TableHeader>
+                <TableRow>
+                  <TableHead style={{ textAlign: "left" }}>Year/Season</TableHead>
+                  {ADVANCED_ANALYTICS_FIELDS.map((field) => (
+                    <TableHead key={field.key} style={{ textAlign: "right" }}>
+                      {field.shortLabel}
+                    </TableHead>
+                  ))}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {advancedView.seasons.map((row) => (
+                  <TableRow key={`advanced-season-${row.season}`}>
+                    <TableCell style={{ fontWeight: 700 }}>{row.season}</TableCell>
+                    {ADVANCED_ANALYTICS_FIELDS.map((field) => (
+                      <TableCell key={`${row.season}-${field.key}`} style={{ textAlign: "right" }}>
+                        {formatAdvancedStat(row[field.key])}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
 
 // ── Main component ────────────────────────────────────────────────────────────
 
@@ -793,6 +932,15 @@ export default function PlayerProfile({
     ],
   }), [devHistory]);
 
+  const playerAdvancedStatsArchive =
+    league?.playerSeasonStatsArchive
+    ?? league?.meta?.playerSeasonStatsArchive
+    ?? data?.meta?.playerSeasonStatsArchive
+    ?? null;
+  const playerAdvancedStatsView = useMemo(
+    () => buildPlayerAdvancedStatsView(effectivePlayer?.id ?? playerId, playerAdvancedStatsArchive),
+    [effectivePlayer?.id, playerId, playerAdvancedStatsArchive],
+  );
   const careerRows = useMemo(() => mergedProfileSeasonRows, [mergedProfileSeasonRows]);
   const careerTotals = useMemo(() => {
     const posU = String(effectivePlayer?.pos ?? effectivePlayer?.position ?? '').toUpperCase();
@@ -2356,6 +2504,8 @@ export default function PlayerProfile({
             </section>
           )}
           {activeProfileTab === "Career Stats" && (
+            <>
+            <AdvancedAnalyticsSection advancedView={playerAdvancedStatsView} player={player} />
             <section className="card-enter">
               {careerRows.length === 0 ? (
                 <EmptyState
@@ -2406,6 +2556,7 @@ export default function PlayerProfile({
                 </div>
               )}
             </section>
+            </>
           )}
         </div>
       </div>

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import React from 'react';
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { renderToString } from 'react-dom/server';
 import PlayerProfile from '../PlayerProfile.jsx';
 
@@ -502,6 +502,69 @@ describe('PlayerProfile', () => {
     await waitFor(() => expect(screen.getByTestId('player-profile-summary').textContent).toContain('Ghost Legend'));
     await waitFor(() => expect(screen.getByTestId('player-profile-legacy-watch')).toBeTruthy());
     expect(screen.getByText(/Hall of Fame inductee/i)).toBeTruthy();
+  });
+
+  it('renders Advanced Analytics career totals and season ledger when archive data exists', async () => {
+    const advancedLeague = {
+      ...league,
+      playerSeasonStatsArchive: {
+        __meta: { archivedGameIds: { '2030:g1': true } },
+        11: {
+          2030: {
+            targets: 42,
+            drops: 4,
+            battedPasses: 1,
+            coverageTargets: 0,
+            coverageCompletionsAllowed: 0,
+            receptionsAllowed: 0,
+            sacksAllowed: 7,
+            sacksMade: 0,
+          },
+          2031: {
+            targets: 51,
+            drops: 3,
+            battedPasses: 2,
+            coverageTargets: 5,
+            coverageCompletionsAllowed: 2,
+            receptionsAllowed: 2,
+            sacksAllowed: 6,
+            sacksMade: 1,
+          },
+        },
+      },
+    };
+
+    render(<PlayerProfile playerId="11" onClose={vi.fn()} actions={actions} teams={advancedLeague.teams} league={advancedLeague} />);
+    await waitFor(() => expect(screen.getByTestId('player-profile-summary').textContent).toContain('Avery Fields'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Career Stats' }));
+
+    const section = screen.getByTestId('player-profile-advanced-analytics');
+    expect(section.textContent).toContain('Advanced Analytics');
+    expect(section.textContent).toContain('Targets');
+    expect(section.textContent).toContain('93');
+    expect(section.textContent).toContain('Sacks Allowed');
+    expect(section.textContent).toContain('13');
+
+    const ledger = screen.getByTestId('player-profile-advanced-ledger');
+    const rows = within(ledger).getAllByRole('row');
+    expect(rows[1].textContent).toContain('2031');
+    expect(rows[2].textContent).toContain('2030');
+
+    const wrapper = screen.getByTestId('player-profile-advanced-ledger-wrap');
+    expect(wrapper.className).toContain('table-wrapper');
+    expect(wrapper.className).toContain('player-career-table-wrap');
+    expect(wrapper.getAttribute('aria-label')).toMatch(/scroll horizontally/i);
+  });
+
+  it('renders the Advanced Analytics empty state for legacy saves without archive data', async () => {
+    render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={actions} teams={league.teams} league={{ ...league, playerSeasonStatsArchive: {} }} />);
+    await waitFor(() => expect(screen.getByTestId('player-profile-summary').textContent).toContain('Avery Fields'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Career Stats' }));
+
+    expect(screen.getByTestId('player-profile-advanced-empty').textContent).toContain('Advanced tracking begins with newly simulated rich games.');
+    expect(screen.queryByTestId('player-profile-advanced-ledger')).toBeNull();
   });
 
   it('shows legacy watch when career stats and accolades justify legacy scoring', async () => {

--- a/src/ui/utils/playerAdvancedStatsViewModel.js
+++ b/src/ui/utils/playerAdvancedStatsViewModel.js
@@ -1,0 +1,104 @@
+const ADVANCED_STAT_KEYS = [
+  'targets',
+  'drops',
+  'battedPasses',
+  'coverageTargets',
+  'coverageCompletionsAllowed',
+  'receptionsAllowed',
+  'sacksAllowed',
+  'sacksMade',
+];
+
+const INTERNAL_KEYS = new Set(['__meta', 'meta', 'archivedGameIds']);
+
+function emptyStats() {
+  return ADVANCED_STAT_KEYS.reduce((acc, key) => {
+    acc[key] = 0;
+    return acc;
+  }, {});
+}
+
+function emptyView() {
+  return {
+    hasData: false,
+    career: null,
+    seasons: [],
+  };
+}
+
+function isRecord(value) {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function num(value) {
+  const n = Number(value ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function normalizeStats(row) {
+  return ADVANCED_STAT_KEYS.reduce((acc, key) => {
+    acc[key] = num(row?.[key]);
+    return acc;
+  }, {});
+}
+
+function addStats(target, source) {
+  for (const key of ADVANCED_STAT_KEYS) {
+    target[key] += num(source?.[key]);
+  }
+  return target;
+}
+
+function isInternalKey(key) {
+  return INTERNAL_KEYS.has(String(key));
+}
+
+function normalizeSeasonLabel(seasonKey) {
+  const numeric = Number(seasonKey);
+  return Number.isFinite(numeric) && String(seasonKey).trim() !== '' ? numeric : String(seasonKey);
+}
+
+function seasonSortValue(row) {
+  const numeric = Number(row?.season);
+  if (Number.isFinite(numeric)) return numeric;
+  const fallback = Number(String(row?.season ?? '').replace(/[^\d.-]/g, ''));
+  return Number.isFinite(fallback) ? fallback : 0;
+}
+
+export function buildPlayerAdvancedStatsView(playerId, archive) {
+  if (playerId == null || playerId === '' || !isRecord(archive)) return emptyView();
+
+  const pid = String(playerId);
+  if (isInternalKey(pid)) return emptyView();
+
+  const playerYears = archive[pid];
+  if (!isRecord(playerYears)) return emptyView();
+
+  const career = emptyStats();
+  const seasons = [];
+
+  for (const [seasonKey, rawStats] of Object.entries(playerYears)) {
+    if (isInternalKey(seasonKey) || !isRecord(rawStats)) continue;
+    const stats = normalizeStats(rawStats);
+    addStats(career, stats);
+    seasons.push({
+      season: normalizeSeasonLabel(seasonKey),
+      ...stats,
+    });
+  }
+
+  if (seasons.length === 0) return emptyView();
+
+  seasons.sort((a, b) => {
+    const bySeason = seasonSortValue(b) - seasonSortValue(a);
+    if (bySeason !== 0) return bySeason;
+    return String(b.season).localeCompare(String(a.season));
+  });
+
+  return {
+    hasData: true,
+    career,
+    seasons,
+  };
+}
+

--- a/tests/unit/playerAdvancedStatsViewModel.test.js
+++ b/tests/unit/playerAdvancedStatsViewModel.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { buildPlayerAdvancedStatsView } from '../../src/ui/utils/playerAdvancedStatsViewModel.js';
+
+describe('buildPlayerAdvancedStatsView', () => {
+  it('returns an empty view when archive is missing', () => {
+    expect(buildPlayerAdvancedStatsView(11, null)).toEqual({
+      hasData: false,
+      career: null,
+      seasons: [],
+    });
+  });
+
+  it('returns an empty view when the player has no archived advanced records', () => {
+    const archive = {
+      12: {
+        2031: { targets: 8 },
+      },
+    };
+
+    expect(buildPlayerAdvancedStatsView(11, archive).hasData).toBe(false);
+  });
+
+  it('resolves string and numeric player ids interchangeably', () => {
+    const archive = {
+      11: {
+        2031: { battedPasses: 3 },
+      },
+    };
+
+    expect(buildPlayerAdvancedStatsView(11, archive).career.battedPasses).toBe(3);
+    expect(buildPlayerAdvancedStatsView('11', archive).career.battedPasses).toBe(3);
+  });
+
+  it('ignores archive metadata and player-year metadata', () => {
+    const archive = {
+      __meta: {
+        archivedGameIds: {
+          '2031:g1': true,
+        },
+      },
+      11: {
+        __meta: { source: 'test' },
+        archivedGameIds: { stray: true },
+        2031: { targets: 4, drops: 1 },
+      },
+    };
+
+    const view = buildPlayerAdvancedStatsView(11, archive);
+    expect(view.hasData).toBe(true);
+    expect(view.seasons).toHaveLength(1);
+    expect(view.career.targets).toBe(4);
+    expect(view.career.drops).toBe(1);
+  });
+
+  it('sums sparse multi-season records into career totals', () => {
+    const archive = {
+      p1: {
+        2029: { targets: 11, drops: 2, sacksMade: 1 },
+        2030: { coverageTargets: 14, coverageCompletionsAllowed: 6 },
+        2031: { targets: 9, drops: 1, sacksAllowed: 3, receptionsAllowed: 5 },
+      },
+    };
+
+    const view = buildPlayerAdvancedStatsView('p1', archive);
+    expect(view.career).toEqual({
+      targets: 20,
+      drops: 3,
+      battedPasses: 0,
+      coverageTargets: 14,
+      coverageCompletionsAllowed: 6,
+      receptionsAllowed: 5,
+      sacksAllowed: 3,
+      sacksMade: 1,
+    });
+  });
+
+  it('sorts season rows newest-first', () => {
+    const archive = {
+      p1: {
+        2029: { targets: 1 },
+        2031: { targets: 3 },
+        2030: { targets: 2 },
+      },
+    };
+
+    const view = buildPlayerAdvancedStatsView('p1', archive);
+    expect(view.seasons.map((row) => row.season)).toEqual([2031, 2030, 2029]);
+  });
+
+  it('does not mutate the archive input', () => {
+    const archive = {
+      p1: {
+        2031: { targets: '6', drops: 2 },
+      },
+      __meta: { archivedGameIds: { '2031:g1': true } },
+    };
+    const snapshot = JSON.parse(JSON.stringify(archive));
+
+    buildPlayerAdvancedStatsView('p1', archive);
+    expect(archive).toEqual(snapshot);
+  });
+
+  it('does not crash on legacy malformed save shapes', () => {
+    expect(buildPlayerAdvancedStatsView('p1', [])).toEqual({
+      hasData: false,
+      career: null,
+      seasons: [],
+    });
+    expect(buildPlayerAdvancedStatsView('p1', { p1: [] })).toEqual({
+      hasData: false,
+      career: null,
+      seasons: [],
+    });
+    expect(buildPlayerAdvancedStatsView('p1', { p1: { 2031: null } })).toEqual({
+      hasData: false,
+      career: null,
+      seasons: [],
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- Adds a pure PlayerProfile advanced-stats view-model for sparse `playerSeasonStatsArchive` records.
- Adds an Advanced Analytics section to PlayerProfile Career Stats with career totals, newest-first season ledger, legacy empty state, and mobile-safe horizontal scrolling.
- Covers string/numeric player IDs, archive metadata, sparse multi-season totals, immutability, malformed legacy shapes, and PlayerProfile render states.

## Audit Notes
- `playerSeasonStatsArchive` is stored on league meta/view state as `{ [playerId]: { [year]: AdvancedSeasonStats }, __meta: { archivedGameIds } }`.
- `getCareerStats(playerId, statsArchive)` expects the sparse store directly and coerces `playerId` through `String(playerId)`.
- `PlayerProfile` receives full league view-state via its `league` prop and already resolves the active player with `playerId` plus `resolvePlayerForProfile(...)`.
- Player IDs can be string or numeric in tests/saves, so the new view model normalizes through string keys.
- Existing PlayerProfile career/season sections and table wrappers were reused; no league-wide browser or sim/archive formulas were changed.

## Validation
- `npm.cmd run test:unit` passed: 241 files, 2,124 tests.
- `npm.cmd run build` passed; Vite emitted the existing large chunk warning.
- Browser preview check at `http://127.0.0.1:4173/` loaded and mobile checks at 375px and 430px reported no page-wide horizontal overflow.
- Optional smoke `npx.cmd playwright test tests/e2e/fresh_franchise_first_week_smoke.spec.js` failed outside this change: Weekly Results rendered Week 2 upcoming games and the test timed out waiting for `user-game-result-card`.

## Scope Guardrails
- Did not modify simulation logic, `archiveGameStats`, `getCareerStats`, schema/versioning, culture, broadcast narrative, development, contracts, trades, free agency, or injuries.
- Did not add PFF grades, EPA, win probability, dependencies, or external AI calls.