### PR TITLE
[codex] Optimize Trade Finder target indexing

### DIFF
--- a/src/core/trades/__tests__/tradeFinderAnalysis.test.ts
+++ b/src/core/trades/__tests__/tradeFinderAnalysis.test.ts
@@ -148,4 +148,37 @@ describe('tradeFinderAnalysis target indexing', () => {
     expect(__internal.getTargetsFromIndex({ need: { pos: 'CB' }, targetIndex: index })).toHaveLength(5);
     expect(__internal.getTargetsFromIndex({ need: { pos: 'OL' }, targetIndex: index })).toHaveLength(5);
   });
+
+  it('legacy target candidate helper can reuse a prebuilt target index', () => {
+    const indexedTarget = makePlayer(301, 2, 'WR', 84);
+    const ignoredFullListTarget = makePlayer(302, 2, 'WR', 99);
+    const targetIndex = {
+      WR: [{ player: indexedTarget, valueScore: 120 }],
+    };
+
+    expect(__internal.getTargetCandidatesForNeed({
+      need: { pos: 'WR' },
+      leaguePlayers: [ignoredFullListTarget],
+      userTeamId: 1,
+      targetIndex,
+    }).map((p:any) => p.id)).toEqual([301]);
+  });
+});
+
+describe('tradeFinderAnalysis team roster indexing', () => {
+  it('groups league players by valid team id and ignores invalid/free-agent ids', () => {
+    const players = [
+      makePlayer(401, 2, 'WR', 80),
+      makePlayer(402, 2, 'CB', 79),
+      makePlayer(403, 3, 'OL', 78),
+      makePlayer(404, -1, 'QB', 99),
+      makePlayer(405, null as any, 'DL', 88),
+    ];
+
+    const index = __internal.buildPlayersByTeamIndex(players);
+
+    expect(__internal.getPlayersForTeamFromIndex(index, 2).map((p:any) => p.id)).toEqual([401, 402]);
+    expect(__internal.getPlayersForTeamFromIndex(index, 3).map((p:any) => p.id)).toEqual([403]);
+    expect(__internal.getPlayersForTeamFromIndex(index, -1)).toEqual([]);
+  });
 });

--- a/src/core/trades/tradeFinderAnalysis.js
+++ b/src/core/trades/tradeFinderAnalysis.js
@@ -153,8 +153,21 @@ function buildExternalTargetIndex({ leaguePlayers = [], userTeamId, getValue = g
 function getTargetsFromIndex({ need, targetIndex, limit = 5 }) {
   return (targetIndex?.[need?.pos] ?? []).slice(0, limit).map((row) => row.player);
 }
-function getTargetCandidatesForNeed({ need, leaguePlayers, userTeamId }) {
-  return getTargetsFromIndex({ need, targetIndex: buildExternalTargetIndex({ leaguePlayers, userTeamId }) });
+function getTargetCandidatesForNeed({ need, leaguePlayers, userTeamId, targetIndex }) {
+  return getTargetsFromIndex({ need, targetIndex: targetIndex ?? buildExternalTargetIndex({ leaguePlayers, userTeamId }) });
+}
+function buildPlayersByTeamIndex(players = []) {
+  const index = new Map();
+  for (const player of Array.isArray(players) ? players : []) {
+    const teamId = player?.teamId == null ? -1 : num(player.teamId, -1);
+    if (teamId < 0) continue;
+    if (!index.has(teamId)) index.set(teamId, []);
+    index.get(teamId).push(player);
+  }
+  return index;
+}
+function getPlayersForTeamFromIndex(playersByTeam, teamId) {
+  return playersByTeam?.get(num(teamId, -1)) ?? [];
 }
 const classifyValueMatch = (delta) => (delta <= -35 ? 'favorable' : delta <= 25 ? 'fair' : delta <= 75 ? 'expensive' : 'unrealistic');
 const buildValueDeltaLabel = (d) => d <= -35 ? 'package may overpay' : d <= 25 ? 'near fair value' : d <= 75 ? 'slightly short on value' : 'far short on value';
@@ -332,6 +345,8 @@ export function buildTradeFinderAnalysis({ userTeam, league = {}, teams = [], us
   const currentSeason = league?.year ?? league?.currentSeason ?? null;
   const userRosterByPosition = groupPlayersByPosition(userRoster);
   const targetIndex = buildExternalTargetIndex({ leaguePlayers, userTeamId });
+  const leaguePlayersByTeam = buildPlayersByTeamIndex(leaguePlayers);
+  const targetContextByTeam = new Map();
   const targetNeeds = Object.values(buildNeedMap(userRoster, footballConfig, userRosterByPosition)).sort((a, b) => b.needScore - a.needScore).slice(0, 6);
   const { userSurplus, chipPool, nonStarterIds } = buildUserSurplus(userRoster, footballConfig, userRosterByPosition);
   const userPickChips = getTeamDraftPicks(userTeam, league).map((p) => buildDraftPickChip(p, userTeamId, currentSeason)).filter((p) => p?.pickId).sort((a,b)=>b.valueScore-a.valueScore);
@@ -340,15 +355,19 @@ export function buildTradeFinderAnalysis({ userTeam, league = {}, teams = [], us
   for (const need of targetNeeds.slice(0, 4)) {
     for (const target of getTargetsFromIndex({ need, targetIndex })) {
       const targetTeam = teamMap.get(num(target.teamId));
-      const targetRoster = leaguePlayers.filter((p) => num(p?.teamId, -1) === num(targetTeam?.id, -1));
-      const targetContext = getTeamContextSnapshot({
-        ...targetTeam,
-        roster: targetRoster,
-      }, { currentSeason });
-      const teamPosture = classifyTeamStrategicPosture({ ...targetTeam, roster: targetRoster }, { currentSeason });
-      // Build the target team's positional depth needs so buildIdea can apply
-      // need-based modifiers from the receiving (target) team's perspective.
-      const targetDepthNeeds = calculateTeamDepthDeficiencies(targetRoster, footballConfig);
+      const targetTeamId = num(targetTeam?.id ?? target.teamId, -1);
+      let cachedContext = targetContextByTeam.get(targetTeamId);
+      if (!cachedContext) {
+        const targetRoster = getPlayersForTeamFromIndex(leaguePlayersByTeam, targetTeamId);
+        const teamWithRoster = { ...targetTeam, roster: targetRoster };
+        cachedContext = {
+          targetContext: getTeamContextSnapshot(teamWithRoster, { currentSeason }),
+          teamPosture: classifyTeamStrategicPosture(teamWithRoster, { currentSeason }),
+          targetDepthNeeds: calculateTeamDepthDeficiencies(targetRoster, footballConfig),
+        };
+        targetContextByTeam.set(targetTeamId, cachedContext);
+      }
+      const { targetContext, teamPosture, targetDepthNeeds } = cachedContext;
       ideas.push(...generatePackageVariants({ need, target, chipPool, picks: userPickChips, nonStarterIds, targetTeam, cap, strategicContext: { teamPosture, targetContext, currentSeason, targetDepthNeeds } }));
     }
   }
@@ -358,6 +377,9 @@ export function buildTradeFinderAnalysis({ userTeam, league = {}, teams = [], us
 
 export const __internal = Object.freeze({
   buildExternalTargetIndex,
+  buildPlayersByTeamIndex,
+  getPlayersForTeamFromIndex,
   getTargetsFromIndex,
+  getTargetCandidatesForNeed,
   groupPlayersByPosition,
 });


### PR DESCRIPTION
## Summary
- Reuses the existing per-call external target index in the legacy target-candidate helper path instead of forcing a rebuild.
- Adds a local `leaguePlayers` by-team index and per-target-team context cache inside `buildTradeFinderAnalysis` so target rosters, strategic posture, and depth deficiencies are not recomputed by scanning the full league for every target.
- Keeps Trade Finder's public return shape unchanged and preserves existing warnings, confidence/feasibility metadata, pick handling, and K/P premium-pick guardrails.

## Why This Is Faster
- Position target buckets are sorted once per analysis call, then reused for needs.
- User roster position buckets remain reused for needs and surplus.
- Target-team roster/context work is now grouped once per team encountered in the generated targets, replacing repeated `leaguePlayers.filter(...)` calls inside the nested need/target loop.
- No global cache or object-identity memoization was added; all indexing is local to one analysis call.

## Tests
- Added regression coverage for reusing a prebuilt target index.
- Added team roster indexing coverage for valid team IDs and invalid/free-agent exclusion.
- Existing tests cover top-level shape, empty/missing arrays, target exclusion, sorted/capped target candidates, and one-value-call-per-eligible-target indexing.

## Validation
- `npm.cmd run test:unit -- src/core/trades/__tests__/tradeFinderAnalysis.test.ts` passed: 17 tests.
- `npm.cmd run test:unit` passed: 241 files, 2,126 tests.
- `npm.cmd run build` passed; Vite emitted the existing large chunk warning.

## Not Run
- Fresh franchise E2E smoke was not run because no trade UI files outside core were touched.
- `npm run test:soak` was not run because no simulation or worker logic was touched.

## Scope Guardrails
- Did not add dependencies, backend assumptions, global caches, worker/sim changes, or final trade execution changes.
- Did not touch `transferPickOwnership`, trade finalization, culture, broadcast narrative, player development, contracts, free agency, injuries, or IndexedDB schema/versioning.