### PR TITLE
Add Career Advanced Stats League Leaders V1

### DIFF
--- a/src/ui/components/LeagueLeaders.jsx
+++ b/src/ui/components/LeagueLeaders.jsx
@@ -3,8 +3,9 @@ import EmptyState from "./EmptyState.jsx";
 import { getSafeLeagueLeaderCategories } from "../../state/selectors.js";
 import { buildLeagueStatsHubModel } from "../utils/leagueStatsHub.js";
 import { buildShowingLabel, rowMatchesSearch, stableSortRows, uniqueFilterOptions } from "../utils/dataBrowser.js";
+import { buildAdvancedStatsLeadersView, ADVANCED_LEADER_DEFS } from "../utils/advancedStatsLeadersViewModel.js";
 
-const TABS = ["Passing", "Rushing", "Receiving", "Tackles", "Sacks", "Interceptions", "Kicking"];
+const TABS = ["Passing", "Rushing", "Receiving", "Tackles", "Sacks", "Interceptions", "Kicking", "Advanced"];
 
 const CATEGORY_CONFIG = {
   Passing: {
@@ -111,6 +112,113 @@ const API_TAB_MAP = Object.freeze({
   Interceptions: { category: "defense", primaryKey: "interceptions", secondaryKey: "passesDefended" },
   // Kicking leaders currently come from local aggregation only.
 });
+
+function AdvancedLeadersPanel({ league, onPlayerSelect }) {
+  const [selectedMetric, setSelectedMetric] = useState(ADVANCED_LEADER_DEFS[0].statKey);
+
+  const archive = league?.playerSeasonStatsArchive ?? league?.meta?.playerSeasonStatsArchive ?? {};
+  const teams = useMemo(() => (Array.isArray(league?.teams) ? league.teams : []), [league?.teams]);
+  const allPlayers = useMemo(
+    () => teams.flatMap((t) => (Array.isArray(t?.roster) ? t.roster : []).map((p) => ({ ...p, teamId: p.teamId ?? t.id, teamAbbr: p.teamAbbr ?? t.abbr }))),
+    [teams],
+  );
+
+  const view = useMemo(
+    () => buildAdvancedStatsLeadersView({ archive, players: allPlayers, teams }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [archive, allPlayers, teams],
+  );
+
+  const currentDef = ADVANCED_LEADER_DEFS.find((d) => d.statKey === selectedMetric) ?? ADVANCED_LEADER_DEFS[0];
+  const rows = view.leaderboards[selectedMetric] ?? [];
+
+  if (!view.hasData) {
+    return (
+      <EmptyState
+        icon="📡"
+        title="No advanced leaders yet"
+        subtitle="Advanced leaderboards populate after rich games are simulated."
+      />
+    );
+  }
+
+  return (
+    <div style={{ display: "grid", gap: "var(--space-3)" }}>
+      <div
+        role="group"
+        aria-label="Select advanced metric"
+        style={{ display: "flex", gap: 6, flexWrap: "wrap" }}
+      >
+        {ADVANCED_LEADER_DEFS.map(({ statKey, statLabel }) => (
+          <button
+            key={statKey}
+            type="button"
+            role="radio"
+            aria-checked={selectedMetric === statKey}
+            className={`standings-tab${selectedMetric === statKey ? " active" : ""}`}
+            onClick={() => setSelectedMetric(statKey)}
+            style={{ fontSize: 11, padding: "5px 10px" }}
+          >
+            {statLabel}
+          </button>
+        ))}
+      </div>
+
+      {rows.length === 0 ? (
+        <div style={{ color: "var(--text-muted)", fontSize: "var(--text-sm)", padding: "var(--space-4) 0" }}>
+          No players have recorded {currentDef.statLabel} yet.
+        </div>
+      ) : (
+        <div
+          className="table-wrapper"
+          style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}
+        >
+          <table
+            className="standings-table"
+            aria-label={`${currentDef.statLabel} leaders`}
+            style={{ width: "100%", minWidth: 420 }}
+          >
+            <thead>
+              <tr>
+                <th style={{ width: 48 }}>Rank</th>
+                <th>Player</th>
+                <th>Pos</th>
+                <th>Team</th>
+                <th style={{ textAlign: "right" }}>{currentDef.statLabel}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((entry) => (
+                <tr key={`${entry.playerId}-${entry.statKey}-${entry.rank}`} className="card-enter">
+                  <td>{entry.rank}</td>
+                  <td>
+                    <button
+                      className="btn btn-link"
+                      style={{ padding: 0, minHeight: 0 }}
+                      onClick={() =>
+                        onPlayerSelect?.({
+                          id: entry.playerId,
+                          name: entry.playerName,
+                          pos: entry.pos,
+                          teamName: entry.teamAbbr,
+                        })
+                      }
+                    >
+                      {entry.playerName}
+                    </button>
+                  </td>
+                  <td>{entry.pos}</td>
+                  <td>{entry.teamAbbr}</td>
+                  <td style={{ textAlign: "right" }}>{entry.value.toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
 
 export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavigate }) {
   const [activeTab, setActiveTab] = useState("Passing");
@@ -248,69 +356,76 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
           </button>
         ))}
       </div>
-      <div style={{ color: "var(--text-muted)", fontSize: "var(--text-xs)" }}>{sourceLabel}</div>
-      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
-        <input aria-label="Search league leaders" value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search player/team" style={{ minHeight: 32, flex: "1 1 180px" }} />
-        <select aria-label="Filter leaders by position" value={positionFilter} onChange={(e) => setPositionFilter(e.target.value)} style={{ minHeight: 32 }}>
-          <option value="ALL">All positions</option>
-          {positionOptions.map((pos) => <option key={pos} value={pos}>{pos}</option>)}
-        </select>
-        <select aria-label="Filter leaders by team" value={teamFilter} onChange={(e) => setTeamFilter(e.target.value)} style={{ minHeight: 32 }}>
-          <option value="ALL">All teams</option>
-          {teamOptions.map((team) => <option key={team} value={team}>{team}</option>)}
-        </select>
-        {hasActiveFilters ? <button type="button" onClick={resetFilters} style={{ minHeight: 32 }}>Reset filters</button> : null}
-      </div>
-      <div style={{ color: "var(--text-muted)", fontSize: "var(--text-xs)" }}>{buildShowingLabel(visibleRows.length, rows.length, "leader")}</div>
-      <div className="table-wrapper" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
-        <table className="standings-table" style={{ width: "100%", minWidth: 680 }}>
-          <thead>
-            <tr>
-              <th style={{ width: 70 }}>Rank</th>
-              <th><button type="button" onClick={() => handleSort("name")}>Player{sort.key === "name" ? (sort.dir === "asc" ? " ↑" : " ↓") : ""}</button></th>
-              <th><button type="button" onClick={() => handleSort("team")}>Team{sort.key === "team" ? (sort.dir === "asc" ? " ↑" : " ↓") : ""}</button></th>
-              <th style={{ textAlign: "right" }}><button type="button" onClick={() => handleSort("primary")}>{config.primaryLabel}{sort.key === "primary" ? (sort.dir === "asc" ? " ↑" : " ↓") : ""}</button></th>
-              <th style={{ textAlign: "right" }}>{config.secondaryLabel}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {visibleRows.map((entry, index) => (
-              <tr
-                key={`${entry.player?.id ?? entry.player?.name ?? "player"}-${index}`}
-                className="card-enter"
-                style={entry.player?.isUserTeam ? { background: "color-mix(in srgb, var(--accent) 10%, transparent)" } : undefined}
-              >
-                <td>{index + 1}</td>
-                <td>
-                  <button
-                    className="btn btn-link"
-                    style={{ padding: 0, minHeight: 0 }}
-                    onClick={() => onPlayerSelect?.(entry.player)}
+
+      {activeTab === "Advanced" ? (
+        <AdvancedLeadersPanel league={league} onPlayerSelect={onPlayerSelect} />
+      ) : (
+        <>
+          <div style={{ color: "var(--text-muted)", fontSize: "var(--text-xs)" }}>{sourceLabel}</div>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+            <input aria-label="Search league leaders" value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search player/team" style={{ minHeight: 32, flex: "1 1 180px" }} />
+            <select aria-label="Filter leaders by position" value={positionFilter} onChange={(e) => setPositionFilter(e.target.value)} style={{ minHeight: 32 }}>
+              <option value="ALL">All positions</option>
+              {positionOptions.map((pos) => <option key={pos} value={pos}>{pos}</option>)}
+            </select>
+            <select aria-label="Filter leaders by team" value={teamFilter} onChange={(e) => setTeamFilter(e.target.value)} style={{ minHeight: 32 }}>
+              <option value="ALL">All teams</option>
+              {teamOptions.map((team) => <option key={team} value={team}>{team}</option>)}
+            </select>
+            {hasActiveFilters ? <button type="button" onClick={resetFilters} style={{ minHeight: 32 }}>Reset filters</button> : null}
+          </div>
+          <div style={{ color: "var(--text-muted)", fontSize: "var(--text-xs)" }}>{buildShowingLabel(visibleRows.length, rows.length, "leader")}</div>
+          <div className="table-wrapper" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
+            <table className="standings-table" style={{ width: "100%", minWidth: 680 }}>
+              <thead>
+                <tr>
+                  <th style={{ width: 70 }}>Rank</th>
+                  <th><button type="button" onClick={() => handleSort("name")}>Player{sort.key === "name" ? (sort.dir === "asc" ? " ↑" : " ↓") : ""}</button></th>
+                  <th><button type="button" onClick={() => handleSort("team")}>Team{sort.key === "team" ? (sort.dir === "asc" ? " ↑" : " ↓") : ""}</button></th>
+                  <th style={{ textAlign: "right" }}><button type="button" onClick={() => handleSort("primary")}>{config.primaryLabel}{sort.key === "primary" ? (sort.dir === "asc" ? " ↑" : " ↓") : ""}</button></th>
+                  <th style={{ textAlign: "right" }}>{config.secondaryLabel}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleRows.map((entry, index) => (
+                  <tr
+                    key={`${entry.player?.id ?? entry.player?.name ?? "player"}-${index}`}
+                    className="card-enter"
+                    style={entry.player?.isUserTeam ? { background: "color-mix(in srgb, var(--accent) 10%, transparent)" } : undefined}
                   >
-                    {entry.player?.name ?? "—"}
-                  </button>
-                </td>
-                <td>{entry.player?.teamName ?? "—"}</td>
-                <td style={{ textAlign: "right" }}>{displayNumber(entry.primary)}</td>
-                <td style={{ textAlign: "right" }}>{entry.secondary ?? "—"}</td>
-              </tr>
-            ))}
-            {visibleRows.length === 0 && (
-              <tr>
-                <td colSpan={5} style={{ padding: 0 }}>
-                  <EmptyState
-                    icon="📊"
-                    title="No league leaders yet"
-                    subtitle="No players have logged enough stats this season."
-                    action="Open league"
-                    onAction={() => onNavigate?.("League")}
-                  />
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
+                    <td>{index + 1}</td>
+                    <td>
+                      <button
+                        className="btn btn-link"
+                        style={{ padding: 0, minHeight: 0 }}
+                        onClick={() => onPlayerSelect?.(entry.player)}
+                      >
+                        {entry.player?.name ?? "—"}
+                      </button>
+                    </td>
+                    <td>{entry.player?.teamName ?? "—"}</td>
+                    <td style={{ textAlign: "right" }}>{displayNumber(entry.primary)}</td>
+                    <td style={{ textAlign: "right" }}>{entry.secondary ?? "—"}</td>
+                  </tr>
+                ))}
+                {visibleRows.length === 0 && (
+                  <tr>
+                    <td colSpan={5} style={{ padding: 0 }}>
+                      <EmptyState
+                        icon="📊"
+                        title="No league leaders yet"
+                        subtitle="No players have logged enough stats this season."
+                        action="Open league"
+                        onAction={() => onNavigate?.("League")}
+                      />
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/ui/components/__tests__/LeagueLeaders.test.jsx
+++ b/src/ui/components/__tests__/LeagueLeaders.test.jsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import React from 'react';
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { cleanup, render, screen, fireEvent } from '@testing-library/react';
 import LeagueLeaders from '../LeagueLeaders.jsx';
 
 describe('LeagueLeaders', () => {
@@ -65,6 +65,170 @@ describe('LeagueLeaders', () => {
 
     // Wait for initial render using a simple presence check; the top leader should be our QB
     expect(screen.getByText('QB Leader')).toBeTruthy();
+  });
+});
+
+// ── Advanced Tab ──────────────────────────────────────────────────────────────
+
+const BASE_ACTIONS = {
+  getLeagueLeaders: () => Promise.resolve({ payload: { categories: null, source: null, phase: null } }),
+};
+
+const BASE_LEAGUE = {
+  userTeamId: 1,
+  teams: [
+    { id: 1, abbr: 'AAA', roster: [] },
+    { id: 2, abbr: 'BBB', roster: [] },
+  ],
+};
+
+function renderLeagueLeaders(leagueOverrides = {}, onPlayerSelect = () => {}) {
+  const league = { ...BASE_LEAGUE, ...leagueOverrides };
+  return render(
+    <LeagueLeaders
+      league={league}
+      actions={BASE_ACTIONS}
+      onPlayerSelect={onPlayerSelect}
+      onNavigate={() => {}}
+    />,
+  );
+}
+
+describe('LeagueLeaders — Advanced tab', () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  it('renders the Advanced tab button', () => {
+    renderLeagueLeaders();
+    expect(screen.getByRole('tab', { name: 'Advanced' })).toBeTruthy();
+  });
+
+  it('shows the empty state when no archive data exists', () => {
+    renderLeagueLeaders({ playerSeasonStatsArchive: {} });
+    fireEvent.click(screen.getByRole('tab', { name: 'Advanced' }));
+    expect(screen.getByText(/Advanced leaderboards populate after rich games are simulated/i)).toBeTruthy();
+  });
+
+  it('shows the empty state when archive is missing entirely', () => {
+    renderLeagueLeaders({ playerSeasonStatsArchive: undefined });
+    fireEvent.click(screen.getByRole('tab', { name: 'Advanced' }));
+    expect(screen.getByText(/Advanced leaderboards populate after rich games are simulated/i)).toBeTruthy();
+  });
+
+  it('renders a leaderboard row for a player with targets data', () => {
+    const league = {
+      ...BASE_LEAGUE,
+      teams: [
+        {
+          id: 1,
+          abbr: 'AAA',
+          roster: [{ id: 10, name: 'Top Target', pos: 'WR', teamId: 1 }],
+        },
+        { id: 2, abbr: 'BBB', roster: [] },
+      ],
+      playerSeasonStatsArchive: {
+        '10': { 2031: { targets: 42 } },
+      },
+    };
+    renderLeagueLeaders(league);
+    fireEvent.click(screen.getByRole('tab', { name: 'Advanced' }));
+    expect(screen.getByText('Top Target')).toBeTruthy();
+    expect(screen.getByText('42')).toBeTruthy();
+  });
+
+  it('switches metric when a chip is clicked', () => {
+    const league = {
+      ...BASE_LEAGUE,
+      teams: [
+        {
+          id: 1,
+          abbr: 'AAA',
+          roster: [{ id: 10, name: 'Sack Leader', pos: 'DE', teamId: 1 }],
+        },
+      ],
+      playerSeasonStatsArchive: {
+        '10': { 2031: { sacksMade: 9 } },
+      },
+    };
+    renderLeagueLeaders(league);
+    fireEvent.click(screen.getByRole('tab', { name: 'Advanced' }));
+    // Click the "Sacks Made" chip
+    fireEvent.click(screen.getByRole('radio', { name: 'Sacks Made' }));
+    expect(screen.getByText('Sack Leader')).toBeTruthy();
+    expect(screen.getByText('9')).toBeTruthy();
+  });
+
+  it('calls onPlayerSelect with player object when a name is clicked', () => {
+    const onPlayerSelect = vi.fn();
+    const league = {
+      ...BASE_LEAGUE,
+      teams: [
+        {
+          id: 1,
+          abbr: 'AAA',
+          roster: [{ id: 10, name: 'Clickable Player', pos: 'WR', teamId: 1 }],
+        },
+      ],
+      playerSeasonStatsArchive: {
+        '10': { 2031: { targets: 5 } },
+      },
+    };
+    render(
+      <LeagueLeaders
+        league={league}
+        actions={BASE_ACTIONS}
+        onPlayerSelect={onPlayerSelect}
+        onNavigate={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole('tab', { name: 'Advanced' }));
+    fireEvent.click(screen.getByText('Clickable Player'));
+    expect(onPlayerSelect).toHaveBeenCalledTimes(1);
+    const arg = onPlayerSelect.mock.calls[0][0];
+    expect(arg.id).toBe('10');
+    expect(arg.name).toBe('Clickable Player');
+  });
+
+  it('renders the table with overflow-x-auto wrapper (mobile-safe)', () => {
+    const league = {
+      ...BASE_LEAGUE,
+      teams: [
+        {
+          id: 1,
+          abbr: 'AAA',
+          roster: [{ id: 10, name: 'Mobile Player', pos: 'TE', teamId: 1 }],
+        },
+      ],
+      playerSeasonStatsArchive: {
+        '10': { 2031: { targets: 3 } },
+      },
+    };
+    const { container } = renderLeagueLeaders(league);
+    fireEvent.click(screen.getByRole('tab', { name: 'Advanced' }));
+    // The table-wrapper div uses overflowX: 'auto'
+    const wrapper = container.querySelector('.table-wrapper');
+    expect(wrapper).toBeTruthy();
+    expect(wrapper.style.overflowX).toBe('auto');
+  });
+
+  it('shows the correct aria-label on the leaders table', () => {
+    const league = {
+      ...BASE_LEAGUE,
+      teams: [
+        {
+          id: 1,
+          abbr: 'AAA',
+          roster: [{ id: 7, name: 'Aria Player', pos: 'CB', teamId: 1 }],
+        },
+      ],
+      playerSeasonStatsArchive: {
+        '7': { 2031: { targets: 11 } },
+      },
+    };
+    renderLeagueLeaders(league);
+    fireEvent.click(screen.getByRole('tab', { name: 'Advanced' }));
+    // Default metric is 'targets' → label should be "Targets leaders"
+    expect(screen.getByRole('table', { name: /Targets leaders/i })).toBeTruthy();
   });
 });
 

--- a/src/ui/utils/advancedStatsLeadersViewModel.js
+++ b/src/ui/utils/advancedStatsLeadersViewModel.js
@@ -1,0 +1,148 @@
+/**
+ * advancedStatsLeadersViewModel.js
+ * Pure helper: build league-wide Advanced Stats leaderboards from
+ * playerSeasonStatsArchive.  Never mutates inputs.
+ */
+
+const ADVANCED_STAT_KEYS = [
+  'targets',
+  'drops',
+  'battedPasses',
+  'coverageTargets',
+  'coverageCompletionsAllowed',
+  'receptionsAllowed',
+  'sacksAllowed',
+  'sacksMade',
+];
+
+const INTERNAL_KEYS = new Set(['__meta', 'meta', 'archivedGameIds']);
+
+export const ADVANCED_LEADER_DEFS = [
+  { statKey: 'targets',                   statLabel: 'Targets' },
+  { statKey: 'drops',                     statLabel: 'Drops' },
+  { statKey: 'battedPasses',              statLabel: 'Batted Passes' },
+  { statKey: 'coverageTargets',           statLabel: 'Coverage Targets' },
+  { statKey: 'coverageCompletionsAllowed', statLabel: 'Cov Comp Allowed' },
+  { statKey: 'receptionsAllowed',         statLabel: 'Receptions Allowed' },
+  { statKey: 'sacksAllowed',              statLabel: 'Sacks Allowed' },
+  { statKey: 'sacksMade',                 statLabel: 'Sacks Made' },
+];
+
+function num(value) {
+  const n = Number(value ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function isRecord(v) {
+  return v != null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function isInternalKey(key) {
+  return INTERNAL_KEYS.has(String(key));
+}
+
+function resolveTeamAbbr(teams, teamId) {
+  if (teamId == null || !Array.isArray(teams)) return null;
+  const team = teams.find((t) => Number(t?.id) === Number(teamId));
+  return team?.abbr ?? null;
+}
+
+function buildPlayerLookup(players, teams) {
+  const map = new Map();
+  const playerList = Array.isArray(players) ? players : [];
+  for (const p of playerList) {
+    if (!p) continue;
+    const pid = p.id ?? p.playerId;
+    if (pid == null) continue;
+    const teamId = p.teamId != null ? Number(p.teamId) : null;
+    const teamAbbr = p.teamAbbr ?? resolveTeamAbbr(teams, teamId);
+    map.set(String(pid), {
+      name: p.name ?? p.playerName ?? null,
+      pos: p.pos ?? p.position ?? null,
+      teamId,
+      teamAbbr,
+    });
+  }
+  return map;
+}
+
+/**
+ * Build league-wide advanced stats leaderboards from playerSeasonStatsArchive.
+ *
+ * @param {{ archive: object, players?: object[], teams?: object[], season?: string|number|null, maxRows?: number }} opts
+ * @returns {{ hasData: boolean, leaderboards: { [statKey]: LeaderRow[] } }}
+ */
+export function buildAdvancedStatsLeadersView({
+  archive,
+  players = [],
+  teams = [],
+  season = null,
+  maxRows = 10,
+} = {}) {
+  if (!isRecord(archive)) return { hasData: false, leaderboards: {} };
+
+  const playerLookup = buildPlayerLookup(players, teams);
+  const teamList = Array.isArray(teams) ? teams : [];
+  const cap = Math.max(1, Number.isFinite(Number(maxRows)) ? Number(maxRows) : 10);
+  const seasonFilter = season != null ? String(season) : null;
+
+  // Accumulate career (or single-season) totals per player — no mutation of archive.
+  const careerMap = new Map();
+
+  for (const [rawPid, playerYears] of Object.entries(archive)) {
+    if (isInternalKey(rawPid)) continue;
+    if (!isRecord(playerYears)) continue;
+
+    const pid = String(rawPid);
+    const info = playerLookup.get(pid) ?? { name: null, pos: null, teamId: null, teamAbbr: null };
+
+    const stats = {};
+    for (const key of ADVANCED_STAT_KEYS) stats[key] = 0;
+
+    for (const [seasonKey, rawStats] of Object.entries(playerYears)) {
+      if (isInternalKey(seasonKey)) continue;
+      if (!isRecord(rawStats)) continue;
+      if (seasonFilter !== null && String(seasonKey) !== seasonFilter) continue;
+
+      for (const key of ADVANCED_STAT_KEYS) {
+        stats[key] += num(rawStats[key]);
+      }
+    }
+
+    careerMap.set(pid, { pid, ...info, ...stats });
+  }
+
+  if (careerMap.size === 0) return { hasData: false, leaderboards: {} };
+
+  const leaderboards = {};
+  let anyNonZero = false;
+
+  for (const { statKey, statLabel } of ADVANCED_LEADER_DEFS) {
+    const sorted = [...careerMap.values()]
+      .filter((entry) => num(entry[statKey]) > 0)
+      .sort((a, b) => {
+        const diff = num(b[statKey]) - num(a[statKey]);
+        if (diff !== 0) return diff;
+        // Deterministic tie-break: alphabetical by name, then by pid
+        const nameDiff = String(a.name ?? a.pid).localeCompare(String(b.name ?? b.pid));
+        if (nameDiff !== 0) return nameDiff;
+        return String(a.pid).localeCompare(String(b.pid));
+      });
+
+    if (sorted.length > 0) anyNonZero = true;
+
+    leaderboards[statKey] = sorted.slice(0, cap).map((entry, i) => ({
+      rank: i + 1,
+      playerId: entry.pid,
+      playerName: entry.name ?? '—',
+      pos: entry.pos ?? '—',
+      teamAbbr: entry.teamAbbr ?? (entry.teamId != null ? resolveTeamAbbr(teamList, entry.teamId) : null) ?? '—',
+      teamId: entry.teamId ?? null,
+      statKey,
+      statLabel,
+      value: num(entry[statKey]),
+    }));
+  }
+
+  return { hasData: anyNonZero, leaderboards };
+}

--- a/tests/unit/advancedStatsLeadersViewModel.test.js
+++ b/tests/unit/advancedStatsLeadersViewModel.test.js
@@ -1,0 +1,302 @@
+import { describe, it, expect } from 'vitest';
+import { buildAdvancedStatsLeadersView, ADVANCED_LEADER_DEFS } from '../../src/ui/utils/advancedStatsLeadersViewModel.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeArchive(entries) {
+  const archive = {};
+  for (const { pid, seasons } of entries) {
+    archive[pid] = {};
+    for (const [year, stats] of Object.entries(seasons)) {
+      archive[pid][year] = stats;
+    }
+  }
+  return archive;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('buildAdvancedStatsLeadersView', () => {
+
+  // 1. Missing / falsy archive returns empty state
+  it('returns hasData=false when archive is null', () => {
+    const result = buildAdvancedStatsLeadersView({ archive: null });
+    expect(result.hasData).toBe(false);
+    expect(result.leaderboards).toEqual({});
+  });
+
+  it('returns hasData=false when archive is an array (malformed)', () => {
+    expect(buildAdvancedStatsLeadersView({ archive: [] }).hasData).toBe(false);
+  });
+
+  it('returns hasData=false when called with no arguments', () => {
+    expect(buildAdvancedStatsLeadersView().hasData).toBe(false);
+  });
+
+  it('returns hasData=false when archive is a non-empty object with only zero stats', () => {
+    const archive = { 11: { 2031: { targets: 0, drops: 0 } } };
+    const result = buildAdvancedStatsLeadersView({ archive });
+    expect(result.hasData).toBe(false);
+    for (const def of ADVANCED_LEADER_DEFS) {
+      expect(result.leaderboards[def.statKey] ?? []).toHaveLength(0);
+    }
+  });
+
+  // 2. __meta / archivedGameIds are ignored at top level and player level
+  it('ignores top-level __meta and archivedGameIds keys', () => {
+    const archive = {
+      __meta: { version: 1 },
+      archivedGameIds: { 'g1': true },
+      11: { 2031: { targets: 7 } },
+    };
+    const result = buildAdvancedStatsLeadersView({ archive });
+    expect(result.hasData).toBe(true);
+    expect(result.leaderboards.targets).toHaveLength(1);
+    expect(result.leaderboards.targets[0].value).toBe(7);
+  });
+
+  it('ignores player-level __meta and archivedGameIds seasons', () => {
+    const archive = {
+      11: {
+        __meta: { source: 'test' },
+        archivedGameIds: { g1: true },
+        2031: { targets: 5, drops: 2 },
+      },
+    };
+    const result = buildAdvancedStatsLeadersView({ archive });
+    expect(result.leaderboards.targets[0].value).toBe(5);
+    expect(result.leaderboards.drops[0].value).toBe(2);
+    expect(result.leaderboards.targets).toHaveLength(1);
+  });
+
+  // 3. String and numeric player IDs both work
+  it('resolves string and numeric player IDs from archive and players list', () => {
+    const archive = {
+      11: { 2031: { sacksMade: 4 } },
+      '22': { 2031: { sacksMade: 6 } },
+    };
+    const players = [
+      { id: 11, name: 'Alice', pos: 'DL', teamId: 1 },
+      { id: '22', name: 'Bob', pos: 'EDGE', teamId: 2 },
+    ];
+    const teams = [
+      { id: 1, abbr: 'AAA' },
+      { id: 2, abbr: 'BBB' },
+    ];
+    const result = buildAdvancedStatsLeadersView({ archive, players, teams });
+    const rows = result.leaderboards.sacksMade;
+    expect(rows[0].playerName).toBe('Bob');
+    expect(rows[0].teamAbbr).toBe('BBB');
+    expect(rows[1].playerName).toBe('Alice');
+    expect(rows[1].teamAbbr).toBe('AAA');
+  });
+
+  // 4. Career totals are summed correctly across seasons
+  it('sums career totals across multiple seasons', () => {
+    const archive = makeArchive([{
+      pid: 'p1',
+      seasons: {
+        2029: { targets: 11, drops: 2, sacksMade: 1 },
+        2030: { coverageTargets: 14, coverageCompletionsAllowed: 6 },
+        2031: { targets: 9, drops: 1, sacksAllowed: 3, receptionsAllowed: 5 },
+      },
+    }]);
+    const result = buildAdvancedStatsLeadersView({ archive });
+    const lb = result.leaderboards;
+    expect(lb.targets[0].value).toBe(20);
+    expect(lb.drops[0].value).toBe(3);
+    expect(lb.sacksMade[0].value).toBe(1);
+    expect(lb.coverageTargets[0].value).toBe(14);
+    expect(lb.coverageCompletionsAllowed[0].value).toBe(6);
+    expect(lb.sacksAllowed[0].value).toBe(3);
+    expect(lb.receptionsAllowed[0].value).toBe(5);
+  });
+
+  // 5. Leaderboard sorts descending by value
+  it('returns rows sorted descending', () => {
+    const archive = makeArchive([
+      { pid: 'a', seasons: { 2031: { targets: 5 } } },
+      { pid: 'b', seasons: { 2031: { targets: 15 } } },
+      { pid: 'c', seasons: { 2031: { targets: 10 } } },
+    ]);
+    const rows = buildAdvancedStatsLeadersView({ archive }).leaderboards.targets;
+    expect(rows.map((r) => r.value)).toEqual([15, 10, 5]);
+  });
+
+  it('assigns ranks 1, 2, 3 in descending order', () => {
+    const archive = makeArchive([
+      { pid: 'x', seasons: { 2031: { drops: 8 } } },
+      { pid: 'y', seasons: { 2031: { drops: 3 } } },
+    ]);
+    const rows = buildAdvancedStatsLeadersView({ archive }).leaderboards.drops;
+    expect(rows[0].rank).toBe(1);
+    expect(rows[1].rank).toBe(2);
+  });
+
+  // 6. maxRows cap enforced
+  it('caps the leaderboard at maxRows', () => {
+    const entries = Array.from({ length: 15 }, (_, i) => ({
+      pid: String(i + 1),
+      seasons: { 2031: { battedPasses: 20 - i } },
+    }));
+    const archive = makeArchive(entries);
+    const rows = buildAdvancedStatsLeadersView({ archive, maxRows: 5 }).leaderboards.battedPasses;
+    expect(rows).toHaveLength(5);
+    expect(rows[0].value).toBe(20);
+    expect(rows[4].value).toBe(16);
+  });
+
+  it('defaults to 10 rows when maxRows is not provided', () => {
+    const entries = Array.from({ length: 20 }, (_, i) => ({
+      pid: String(i + 1),
+      seasons: { 2031: { sacksMade: 30 - i } },
+    }));
+    const archive = makeArchive(entries);
+    const rows = buildAdvancedStatsLeadersView({ archive }).leaderboards.sacksMade;
+    expect(rows).toHaveLength(10);
+  });
+
+  // 7. Ties are deterministic (alphabetical name, then pid)
+  it('breaks ties alphabetically by player name', () => {
+    const archive = {
+      '1': { 2031: { coverageTargets: 10 } },
+      '2': { 2031: { coverageTargets: 10 } },
+    };
+    const players = [
+      { id: '1', name: 'Zara', pos: 'CB' },
+      { id: '2', name: 'Aaron', pos: 'CB' },
+    ];
+    const rows = buildAdvancedStatsLeadersView({ archive, players }).leaderboards.coverageTargets;
+    expect(rows[0].playerName).toBe('Aaron');
+    expect(rows[1].playerName).toBe('Zara');
+  });
+
+  it('breaks ties by pid when both names are missing', () => {
+    const archive = {
+      '100': { 2031: { receptionsAllowed: 7 } },
+      '20': { 2031: { receptionsAllowed: 7 } },
+    };
+    const rows = buildAdvancedStatsLeadersView({ archive }).leaderboards.receptionsAllowed;
+    // pid "100" < "20" lexicographically → "100" should come first
+    expect(rows[0].playerId).toBe('100');
+    expect(rows[1].playerId).toBe('20');
+  });
+
+  // 8. Player/team labels resolve safely from players and teams arrays
+  it('resolves player name and position from players list', () => {
+    const archive = { '5': { 2031: { sacksAllowed: 3 } } };
+    const players = [{ id: 5, name: 'Charlie', pos: 'OT', teamId: 10 }];
+    const teams = [{ id: 10, abbr: 'CHI' }];
+    const rows = buildAdvancedStatsLeadersView({ archive, players, teams }).leaderboards.sacksAllowed;
+    expect(rows[0].playerName).toBe('Charlie');
+    expect(rows[0].pos).toBe('OT');
+    expect(rows[0].teamAbbr).toBe('CHI');
+    expect(rows[0].teamId).toBe(10);
+  });
+
+  it('resolves teamAbbr via teamId when player does not carry abbr directly', () => {
+    const archive = { '7': { 2031: { drops: 4 } } };
+    const players = [{ id: 7, name: 'Dan', pos: 'WR', teamId: 3 }];
+    const teams = [{ id: 3, abbr: 'DEN' }];
+    const rows = buildAdvancedStatsLeadersView({ archive, players, teams }).leaderboards.drops;
+    expect(rows[0].teamAbbr).toBe('DEN');
+  });
+
+  // 9. Missing player/team falls back safely
+  it('falls back to "—" for missing player name, pos, and teamAbbr', () => {
+    const archive = { '99': { 2031: { targets: 5 } } };
+    const rows = buildAdvancedStatsLeadersView({ archive }).leaderboards.targets;
+    expect(rows[0].playerName).toBe('—');
+    expect(rows[0].pos).toBe('—');
+    expect(rows[0].teamAbbr).toBe('—');
+    expect(rows[0].teamId).toBeNull();
+  });
+
+  it('does not crash when teams array is missing', () => {
+    const archive = { '1': { 2031: { sacksMade: 2 } } };
+    expect(() => buildAdvancedStatsLeadersView({ archive, teams: null })).not.toThrow();
+  });
+
+  // 10. No mutation of archive, players, or teams
+  it('does not mutate archive', () => {
+    const archive = {
+      p1: { 2031: { targets: '6', drops: 2 } },
+      __meta: { v: 1 },
+    };
+    const snapshot = JSON.parse(JSON.stringify(archive));
+    buildAdvancedStatsLeadersView({ archive });
+    expect(archive).toEqual(snapshot);
+  });
+
+  it('does not mutate players or teams arrays', () => {
+    const players = [{ id: 1, name: 'Eve', pos: 'WR', teamId: 1 }];
+    const teams = [{ id: 1, abbr: 'EVE' }];
+    const playersCopy = JSON.parse(JSON.stringify(players));
+    const teamsCopy = JSON.parse(JSON.stringify(teams));
+    const archive = { '1': { 2031: { targets: 3 } } };
+    buildAdvancedStatsLeadersView({ archive, players, teams });
+    expect(players).toEqual(playersCopy);
+    expect(teams).toEqual(teamsCopy);
+  });
+
+  // 11. Season filter works
+  it('filters to a specific season when season is provided', () => {
+    const archive = makeArchive([{
+      pid: 'p1',
+      seasons: {
+        2030: { targets: 20 },
+        2031: { targets: 5 },
+      },
+    }]);
+    const rows = buildAdvancedStatsLeadersView({ archive, season: 2031 }).leaderboards.targets;
+    expect(rows[0].value).toBe(5);
+  });
+
+  it('returns hasData=false when season filter matches no data', () => {
+    const archive = makeArchive([{ pid: 'p1', seasons: { 2031: { targets: 5 } } }]);
+    const result = buildAdvancedStatsLeadersView({ archive, season: 1999 });
+    expect(result.hasData).toBe(false);
+  });
+
+  // 12. ADVANCED_LEADER_DEFS has exactly 8 metrics
+  it('exports exactly 8 ADVANCED_LEADER_DEFS with unique statKeys', () => {
+    expect(ADVANCED_LEADER_DEFS).toHaveLength(8);
+    const keys = new Set(ADVANCED_LEADER_DEFS.map((d) => d.statKey));
+    expect(keys.size).toBe(8);
+  });
+
+  // 13. Each leaderboard row has the expected shape
+  it('each leaderboard row has the correct shape', () => {
+    const archive = { '42': { 2031: { sacksMade: 7 } } };
+    const players = [{ id: 42, name: 'Frank', pos: 'DE', teamId: 5 }];
+    const teams = [{ id: 5, abbr: 'FRK' }];
+    const rows = buildAdvancedStatsLeadersView({ archive, players, teams }).leaderboards.sacksMade;
+    const row = rows[0];
+    expect(row).toMatchObject({
+      rank: 1,
+      playerId: '42',
+      playerName: 'Frank',
+      pos: 'DE',
+      teamAbbr: 'FRK',
+      teamId: 5,
+      statKey: 'sacksMade',
+      statLabel: 'Sacks Made',
+      value: 7,
+    });
+  });
+
+  // 14. Players not in archive do not appear in any leaderboard
+  it('players not in archive do not appear in any leaderboard', () => {
+    const archive = { '1': { 2031: { targets: 8 } } };
+    const players = [
+      { id: 1, name: 'Alice', pos: 'WR', teamId: 1 },
+      { id: 2, name: 'NotInArchive', pos: 'TE', teamId: 1 },
+    ];
+    const teams = [{ id: 1, abbr: 'TST' }];
+    const result = buildAdvancedStatsLeadersView({ archive, players, teams });
+    for (const def of ADVANCED_LEADER_DEFS) {
+      const lb = result.leaderboards[def.statKey] ?? [];
+      expect(lb.every((r) => r.playerName !== 'NotInArchive')).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
- New pure helper advancedStatsLeadersViewModel.js:
  buildAdvancedStatsLeadersView({ archive, players, teams, season, maxRows })
  reads playerSeasonStatsArchive, sums career totals, resolves player/team
  labels, returns sorted leaderboards for 8 advanced metrics.

- Add "Advanced" tab to LeagueLeaders; AdvancedLeadersPanel renders metric
  chips (Targets, Drops, Batted Passes, Coverage Targets, Cov Comp Allowed,
  Receptions Allowed, Sacks Allowed, Sacks Made), a mobile-safe overflow-x
  table, and an empty state when no rich-game data exists.

- 25 unit tests for the view-model (missing archive, meta ignored, string/
  numeric IDs, career sum, descending sort, maxRows cap, tie-breaking,
  label fallbacks, no mutation, season filter).

- 8 component tests for the Advanced tab (empty state, leaderboard render,
  metric chip switch, player click callback, mobile wrapper, aria-label).

No sim/archive/culture/broadcast formulas changed.

https://claude.ai/code/session_01NWT9f6CMA2HrfVjyp5YCa8