### PR TITLE
Add Advanced Player Search / Stat Finder V1

### DIFF
--- a/src/ui/components/PlayerSearchPanel.jsx
+++ b/src/ui/components/PlayerSearchPanel.jsx
@@ -1,0 +1,284 @@
+import React, { useState, useMemo, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { filterPlayerPool } from '../utils/playerSearchFilterEngine';
+
+const FILTER_SECTIONS = [
+  {
+    label: 'Receiving',
+    fields: [
+      { key: 'minTargets', label: 'Targets ≥' },
+      { key: 'maxTargets', label: 'Targets ≤' },
+      { key: 'minDrops', label: 'Drops ≥' },
+      { key: 'maxDrops', label: 'Drops ≤' },
+    ],
+  },
+  {
+    label: 'Pass Protection',
+    fields: [
+      { key: 'minSacksAllowed', label: 'Sacks Allowed ≥' },
+      { key: 'maxSacksAllowed', label: 'Sacks Allowed ≤' },
+    ],
+  },
+  {
+    label: 'Pass Rush',
+    fields: [
+      { key: 'minSacksMade', label: 'Sacks Made ≥' },
+      { key: 'maxSacksMade', label: 'Sacks Made ≤' },
+      { key: 'minBattedPasses', label: 'Batted Passes ≥' },
+      { key: 'maxBattedPasses', label: 'Batted Passes ≤' },
+    ],
+  },
+  {
+    label: 'Coverage',
+    fields: [
+      { key: 'minCoverageTargets', label: 'Coverage Targets ≥' },
+      { key: 'maxCoverageTargets', label: 'Coverage Targets ≤' },
+      { key: 'minReceptionsAllowed', label: 'Receptions Allowed ≥' },
+      { key: 'maxReceptionsAllowed', label: 'Receptions Allowed ≤' },
+      { key: 'minCoverageCompletionsAllowed', label: 'Completions Allowed ≥' },
+      { key: 'maxCoverageCompletionsAllowed', label: 'Completions Allowed ≤' },
+    ],
+  },
+];
+
+const RESULT_COLS = [
+  { key: 'name',  label: 'Name',    get: (p) => p.name  ?? '—' },
+  { key: 'pos',   label: 'Pos',     get: (p) => p.pos   ?? '—' },
+  { key: 'ovr',   label: 'OVR',     get: (p) => p.ovr   ?? '—' },
+  { key: 'team',  label: 'Team',    get: (p) => p.teamAbbr ?? p.team?.abbr ?? '—' },
+];
+
+/** Extract season keys from the sparse archive, sorted newest-first. */
+function extractSeasonKeys(archive) {
+  const keys = new Set();
+  if (!archive || typeof archive !== 'object') return [];
+  for (const [pid, playerYears] of Object.entries(archive)) {
+    if (pid === '__meta' || !playerYears || typeof playerYears !== 'object') continue;
+    for (const yearKey of Object.keys(playerYears)) {
+      if (yearKey !== '__meta') keys.add(yearKey);
+    }
+  }
+  return [...keys].sort((a, b) => Number(b) - Number(a));
+}
+
+const inputStyle = {
+  width: '100%',
+  fontSize: 'var(--text-sm)',
+  padding: '4px 8px',
+  border: '1px solid var(--hairline)',
+  borderRadius: 'var(--radius-sm)',
+  background: 'var(--surface)',
+};
+
+const sectionLabelStyle = {
+  fontSize: 'var(--text-xs)',
+  fontWeight: 600,
+  color: 'var(--muted)',
+  marginBottom: 'var(--space-1)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+};
+
+/**
+ * Collapsible panel for filtering a player pool by advanced stat thresholds.
+ *
+ * Props:
+ *   players   – array of player objects (must have id/playerId)
+ *   archive   – sparse advanced stats store { [playerId]: { [year]: AdvancedStats } }
+ *   seasons   – optional explicit season-key list; extracted from archive when omitted
+ *   title     – panel heading (default "Advanced Stat Finder")
+ *   maxResults – cap on displayed rows (default 100)
+ */
+export default function PlayerSearchPanel({
+  players = [],
+  archive = {},
+  seasons,
+  title = 'Advanced Stat Finder',
+  maxResults = 100,
+}) {
+  const [open, setOpen] = useState(false);
+  const [seasonMode, setSeasonMode] = useState('career');
+  const [selectedSeason, setSelectedSeason] = useState('');
+  const [inputs, setInputs] = useState({});
+
+  const availableSeasons = useMemo(
+    () => (Array.isArray(seasons) ? seasons : extractSeasonKeys(archive)),
+    [seasons, archive],
+  );
+
+  const criteria = useMemo(() => {
+    const c = { seasonMode };
+    if (seasonMode === 'season' && selectedSeason) c.season = selectedSeason;
+    for (const [k, v] of Object.entries(inputs)) {
+      if (v === '' || v == null) continue;
+      const n = Number(v);
+      if (Number.isFinite(n)) c[k] = n;
+    }
+    return c;
+  }, [seasonMode, selectedSeason, inputs]);
+
+  const results = useMemo(
+    () => filterPlayerPool(players, archive, criteria),
+    [players, archive, criteria],
+  );
+
+  const activeCount = useMemo(
+    () => Object.values(inputs).filter((v) => v !== '' && v != null).length,
+    [inputs],
+  );
+
+  const handleInput = useCallback((key, value) => {
+    setInputs((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setInputs({});
+    setSeasonMode('career');
+    setSelectedSeason('');
+  }, []);
+
+  const displayResults = results.slice(0, maxResults);
+
+  return (
+    <div style={{ border: '1px solid var(--hairline)', borderRadius: 'var(--radius-md)', marginBottom: 'var(--space-4)' }}>
+
+      {/* ── Collapsible header ── */}
+      <button
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        style={{
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 'var(--space-2)',
+          padding: 'var(--space-3)',
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          textAlign: 'left',
+        }}
+      >
+        <span style={{ fontWeight: 600, fontSize: 'var(--text-sm)' }}>{title}</span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)', flexShrink: 0 }}>
+          {activeCount > 0 && (
+            <span style={{ fontSize: 'var(--text-xs)', padding: '2px 8px', borderRadius: 999, background: 'var(--surface-strong)' }}>
+              {activeCount} filter{activeCount !== 1 ? 's' : ''}
+            </span>
+          )}
+          <span style={{ fontSize: 'var(--text-xs)', color: 'var(--muted)' }} aria-hidden>
+            {open ? '▲' : '▼'}
+          </span>
+        </div>
+      </button>
+
+      {/* ── Filter drawer ── */}
+      {open && (
+        <div style={{ padding: 'var(--space-3)', borderTop: '1px solid var(--hairline)' }}>
+
+          {/* Season mode row */}
+          <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 'var(--space-2)', marginBottom: 'var(--space-3)' }}>
+            <label style={{ fontSize: 'var(--text-xs)', fontWeight: 600 }}>Mode</label>
+            <select
+              value={seasonMode}
+              onChange={(e) => { setSeasonMode(e.target.value); setSelectedSeason(''); }}
+              style={{ fontSize: 'var(--text-sm)', padding: '4px 8px', border: '1px solid var(--hairline)', borderRadius: 'var(--radius-sm)', background: 'var(--surface)' }}
+            >
+              <option value="career">Career Totals</option>
+              <option value="season">Single Season</option>
+            </select>
+
+            {seasonMode === 'season' && (
+              <select
+                value={selectedSeason}
+                onChange={(e) => setSelectedSeason(e.target.value)}
+                style={{ fontSize: 'var(--text-sm)', padding: '4px 8px', border: '1px solid var(--hairline)', borderRadius: 'var(--radius-sm)', background: 'var(--surface)' }}
+              >
+                <option value="">— All seasons —</option>
+                {availableSeasons.map((s) => (
+                  <option key={s} value={String(s)}>{s}</option>
+                ))}
+              </select>
+            )}
+          </div>
+
+          {/* Threshold inputs — flex-wrap for ≥375 px safety */}
+          {FILTER_SECTIONS.map((section) => (
+            <div key={section.label} style={{ marginBottom: 'var(--space-3)' }}>
+              <div style={sectionLabelStyle}>{section.label}</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-2)' }}>
+                {section.fields.map(({ key, label }) => (
+                  <label
+                    key={key}
+                    style={{ display: 'flex', flexDirection: 'column', flex: '1 1 120px', minWidth: 120, maxWidth: 180 }}
+                  >
+                    <span style={{ fontSize: 'var(--text-xs)', marginBottom: 2 }}>{label}</span>
+                    <input
+                      type="number"
+                      min={0}
+                      value={inputs[key] ?? ''}
+                      onChange={(e) => handleInput(key, e.target.value)}
+                      placeholder="—"
+                      style={inputStyle}
+                    />
+                  </label>
+                ))}
+              </div>
+            </div>
+          ))}
+
+          {/* Actions row */}
+          <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 'var(--space-2)' }}>
+            <Button
+              variant="ghost"
+              onClick={clearAll}
+              disabled={activeCount === 0 && seasonMode === 'career'}
+            >
+              Clear filters
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* ── Results ── */}
+      {open && (
+        <div style={{ padding: 'var(--space-3)', borderTop: '1px solid var(--hairline)' }}>
+          <div style={{ fontSize: 'var(--text-xs)', color: 'var(--muted)', marginBottom: 'var(--space-2)' }}>
+            {results.length} player{results.length !== 1 ? 's' : ''} match{results.length === 1 ? 'es' : ''}
+            {results.length > maxResults && ` · showing first ${maxResults}`}
+          </div>
+
+          {displayResults.length > 0 && (
+            <div style={{ overflowX: 'auto', WebkitOverflowScrolling: 'touch' }}>
+              <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 'var(--text-xs)' }}>
+                <thead>
+                  <tr>
+                    {RESULT_COLS.map((col) => (
+                      <th
+                        key={col.key}
+                        style={{ textAlign: 'left', padding: '4px 8px', borderBottom: '1px solid var(--hairline)', fontWeight: 600, whiteSpace: 'nowrap' }}
+                      >
+                        {col.label}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {displayResults.map((player, i) => (
+                    <tr key={player.id ?? player.playerId ?? i}>
+                      {RESULT_COLS.map((col) => (
+                        <td key={col.key} style={{ padding: '4px 8px', borderBottom: '1px solid var(--hairline)' }}>
+                          {col.get(player)}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/utils/playerSearchFilterEngine.js
+++ b/src/ui/utils/playerSearchFilterEngine.js
@@ -1,0 +1,168 @@
+// buildPlayerAdvancedStatsView is the public view-model getter for UI rendering.
+// Internally we use a leaner aggregation to keep the hot filter loop tight (O(N) goal).
+export { buildPlayerAdvancedStatsView } from './playerAdvancedStatsViewModel.js';
+
+const ADVANCED_STAT_KEYS = [
+  'targets',
+  'drops',
+  'battedPasses',
+  'coverageTargets',
+  'coverageCompletionsAllowed',
+  'receptionsAllowed',
+  'sacksAllowed',
+  'sacksMade',
+];
+
+// Maps each public criteria key → [archiveStatKey, comparison operator]
+const CRITERIA_MAP = {
+  minTargets:                    ['targets',                    '>='],
+  maxTargets:                    ['targets',                    '<='],
+  minDrops:                      ['drops',                      '>='],
+  maxDrops:                      ['drops',                      '<='],
+  minBattedPasses:               ['battedPasses',               '>='],
+  maxBattedPasses:               ['battedPasses',               '<='],
+  minCoverageTargets:            ['coverageTargets',            '>='],
+  maxCoverageTargets:            ['coverageTargets',            '<='],
+  minReceptionsAllowed:          ['receptionsAllowed',          '>='],
+  maxReceptionsAllowed:          ['receptionsAllowed',          '<='],
+  minSacksAllowed:               ['sacksAllowed',               '>='],
+  maxSacksAllowed:               ['sacksAllowed',               '<='],
+  minSacksMade:                  ['sacksMade',                  '>='],
+  maxSacksMade:                  ['sacksMade',                  '<='],
+  minCoverageCompletionsAllowed: ['coverageCompletionsAllowed', '>='],
+  maxCoverageCompletionsAllowed: ['coverageCompletionsAllowed', '<='],
+};
+
+/** All supported criteria keys, exported for form generation. */
+export const CRITERIA_KEYS = Object.keys(CRITERIA_MAP);
+
+function emptyStats() {
+  const s = {};
+  for (const k of ADVANCED_STAT_KEYS) s[k] = 0;
+  return s;
+}
+
+function safeNum(v) {
+  const n = Number(v ?? 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Convert raw criteria object into a pre-compiled array of threshold checks.
+ * Only entries with finite numeric values are included, keeping the hot loop tight.
+ */
+function compileThresholds(criteria) {
+  const thresholds = [];
+  for (const [criterionKey, [statKey, op]] of Object.entries(CRITERIA_MAP)) {
+    const val = criteria[criterionKey];
+    if (val == null || val === '') continue;
+    const threshold = Number(val);
+    if (!Number.isFinite(threshold)) continue;
+    thresholds.push({ statKey, op, threshold });
+  }
+  return thresholds;
+}
+
+/**
+ * Read a single season's advanced stats for a player without mutating the archive.
+ * Falls back to all-zero stats when the player or season is absent (sparse saves, rookies).
+ */
+function getSeasonStats(playerId, archive, season) {
+  const pid = String(playerId ?? '');
+  const playerYears = archive[pid];
+  if (!playerYears || typeof playerYears !== 'object') return emptyStats();
+  const raw = playerYears[String(season)];
+  if (!raw || typeof raw !== 'object') return emptyStats();
+  const out = emptyStats();
+  for (const k of ADVANCED_STAT_KEYS) out[k] = safeNum(raw[k]);
+  return out;
+}
+
+// Internal keys on the sparse store that are not season buckets.
+const INTERNAL_KEYS = new Set(['__meta', 'meta', 'archivedGameIds']);
+
+/**
+ * Aggregate all seasons into career totals directly from the archive.
+ * Avoids the overhead of buildPlayerAdvancedStatsView (seasons array, sort, spread),
+ * which matters when scanning 2,000+ players in the filter loop.
+ * Falls back to all-zero stats for players absent from the archive.
+ */
+function getCareerStats(playerId, archive) {
+  const pid = String(playerId ?? '');
+  const playerYears = archive[pid];
+  if (!playerYears || typeof playerYears !== 'object') return emptyStats();
+
+  const career = emptyStats();
+  // eslint-disable-next-line guard-for-in
+  for (const key in playerYears) {
+    if (INTERNAL_KEYS.has(key)) continue;
+    const y = playerYears[key];
+    if (!y || typeof y !== 'object') continue;
+    career.targets                    += safeNum(y.targets);
+    career.drops                      += safeNum(y.drops);
+    career.battedPasses               += safeNum(y.battedPasses);
+    career.coverageTargets            += safeNum(y.coverageTargets);
+    career.coverageCompletionsAllowed += safeNum(y.coverageCompletionsAllowed);
+    career.receptionsAllowed          += safeNum(y.receptionsAllowed);
+    career.sacksAllowed               += safeNum(y.sacksAllowed);
+    career.sacksMade                  += safeNum(y.sacksMade);
+  }
+  return career;
+}
+
+function passesThresholds(stats, thresholds) {
+  for (const { statKey, op, threshold } of thresholds) {
+    const val = stats[statKey] ?? 0;
+    if (op === '>=' && val < threshold) return false;
+    if (op === '<=' && val > threshold) return false;
+  }
+  return true;
+}
+
+/**
+ * Filter a player pool using advanced stat thresholds from the sparse archive.
+ *
+ * Time complexity: O(N) where N = players.length.
+ * Each player is visited once; per-player season aggregation is bounded by
+ * career length (S ≤ ~25 seasons), making it effectively constant per player.
+ *
+ * The archive is never mutated — all reads are purely structural.
+ *
+ * @param {any[]} players  Player objects. Each must have an `id` or `playerId` field.
+ * @param {object} archive Sparse advanced-stats store: { [playerId]: { [year]: AdvancedStats } }
+ * @param {object} [criteria] Filter criteria object. Supported keys:
+ *   - seasonMode: 'career' (default) | 'season'
+ *   - season: string or number — used when seasonMode = 'season'
+ *   - minTargets, maxTargets, minDrops, maxDrops
+ *   - minBattedPasses, maxBattedPasses
+ *   - minCoverageTargets, maxCoverageTargets
+ *   - minReceptionsAllowed, maxReceptionsAllowed
+ *   - minSacksAllowed, maxSacksAllowed
+ *   - minSacksMade, maxSacksMade
+ *   - minCoverageCompletionsAllowed, maxCoverageCompletionsAllowed
+ * @returns {any[]} Filtered subset of the players array (new array, same object references).
+ */
+export function filterPlayerPool(players, archive, criteria = {}) {
+  if (!Array.isArray(players)) return [];
+
+  const safeArchive = archive && typeof archive === 'object' ? archive : {};
+  const thresholds = compileThresholds(criteria);
+
+  // No active thresholds — return original array reference unchanged.
+  if (thresholds.length === 0) return players;
+
+  const seasonMode = criteria.seasonMode ?? 'career';
+  const season = criteria.season;
+  const useSeasonMode = seasonMode === 'season' && season != null && season !== '';
+
+  const result = [];
+  for (const player of players) {
+    if (player == null) continue;
+    const playerId = player.id ?? player.playerId;
+    const stats = useSeasonMode
+      ? getSeasonStats(playerId, safeArchive, season)
+      : getCareerStats(playerId, safeArchive);
+    if (passesThresholds(stats, thresholds)) result.push(player);
+  }
+  return result;
+}

--- a/tests/unit/playerSearchFilterEngine.test.js
+++ b/tests/unit/playerSearchFilterEngine.test.js
@@ -1,0 +1,355 @@
+import { describe, it, expect } from 'vitest';
+import { filterPlayerPool, CRITERIA_KEYS } from '../../src/ui/utils/playerSearchFilterEngine.js';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function player(id, overrides = {}) {
+  return { id, name: `Player ${id}`, pos: 'WR', ovr: 75, ...overrides };
+}
+
+const ZERO_STATS = {
+  targets: 0, drops: 0, battedPasses: 0,
+  coverageTargets: 0, coverageCompletionsAllowed: 0,
+  receptionsAllowed: 0, sacksAllowed: 0, sacksMade: 0,
+};
+
+function stats(overrides) {
+  return { ...ZERO_STATS, ...overrides };
+}
+
+/** Build a sparse archive from a flat list of { playerId, year, stats } entries. */
+function makeArchive(entries) {
+  const arc = {};
+  for (const { playerId, year, ...s } of entries) {
+    const pid = String(playerId);
+    if (!arc[pid]) arc[pid] = {};
+    arc[pid][String(year)] = s.stats ?? s;
+  }
+  return arc;
+}
+
+// ─── fixture data ────────────────────────────────────────────────────────────
+
+const P1 = player(1);
+const P2 = player(2);
+const P3 = player(3);
+const PLAYERS = [P1, P2, P3];
+
+const ARCHIVE = makeArchive([
+  { playerId: 1, year: 2024, stats: stats({ targets: 100, drops: 5, sacksAllowed: 2 }) },
+  { playerId: 2, year: 2024, stats: stats({ targets: 50,  drops: 2, sacksAllowed: 8 }) },
+  { playerId: 3, year: 2024, stats: stats({ targets: 0,   sacksMade: 5, battedPasses: 3, coverageTargets: 40, receptionsAllowed: 30, coverageCompletionsAllowed: 25 }) },
+]);
+
+// ─── basic behaviour ─────────────────────────────────────────────────────────
+
+describe('filterPlayerPool – basic', () => {
+  it('returns empty array for null players', () => {
+    expect(filterPlayerPool(null, ARCHIVE)).toEqual([]);
+  });
+
+  it('returns empty array for undefined players', () => {
+    expect(filterPlayerPool(undefined, ARCHIVE)).toEqual([]);
+  });
+
+  it('returns original array reference when no criteria are provided', () => {
+    const result = filterPlayerPool(PLAYERS, ARCHIVE, {});
+    expect(result).toBe(PLAYERS);
+  });
+
+  it('returns original array reference when all criteria values are empty strings', () => {
+    const result = filterPlayerPool(PLAYERS, ARCHIVE, { minTargets: '', maxDrops: '' });
+    expect(result).toBe(PLAYERS);
+  });
+
+  it('skips null entries inside the players array', () => {
+    const result = filterPlayerPool([null, P1, null], ARCHIVE, { minTargets: 1 });
+    expect(result).toEqual([P1]);
+  });
+});
+
+// ─── single-threshold filtering ──────────────────────────────────────────────
+
+describe('filterPlayerPool – single threshold', () => {
+  it('minTargets keeps only players meeting the floor', () => {
+    const result = filterPlayerPool(PLAYERS, ARCHIVE, { minTargets: 60 });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(P1);
+  });
+
+  it('maxTargets keeps only players at or below the ceiling', () => {
+    const result = filterPlayerPool(PLAYERS, ARCHIVE, { maxTargets: 50 });
+    expect(result).toHaveLength(2); // P2 (50) and P3 (0)
+    expect(result.map((p) => p.id)).toContain(2);
+    expect(result.map((p) => p.id)).toContain(3);
+  });
+
+  it('maxSacksAllowed keeps players at or below the ceiling', () => {
+    const result = filterPlayerPool(PLAYERS, ARCHIVE, { maxSacksAllowed: 3 });
+    expect(result).toHaveLength(2); // P1 (2) and P3 (0)
+    expect(result.map((p) => p.id)).toContain(1);
+    expect(result.map((p) => p.id)).toContain(3);
+  });
+
+  it('minSacksMade keeps only defenders with enough sacks', () => {
+    const result = filterPlayerPool(PLAYERS, ARCHIVE, { minSacksMade: 4 });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(P3);
+  });
+
+  it('minBattedPasses keeps only players meeting the floor', () => {
+    const result = filterPlayerPool(PLAYERS, ARCHIVE, { minBattedPasses: 2 });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(P3);
+  });
+
+  it('minCoverageTargets keeps only corners/safeties with enough coverage snaps', () => {
+    const result = filterPlayerPool(PLAYERS, ARCHIVE, { minCoverageTargets: 20 });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(P3);
+  });
+});
+
+// ─── compound queries ─────────────────────────────────────────────────────────
+
+describe('filterPlayerPool – compound criteria', () => {
+  it('minTargets AND maxDrops narrows to the correct subset', () => {
+    // P1: targets=100, drops=5  → fails maxDrops=3
+    // P2: targets=50,  drops=2  → passes both
+    // P3: targets=0,   drops=0  → fails minTargets=30
+    const result = filterPlayerPool(PLAYERS, ARCHIVE, { minTargets: 30, maxDrops: 3 });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(P2);
+  });
+
+  it('maxSacksAllowed AND minTargets produce an empty set when no player qualifies', () => {
+    const result = filterPlayerPool(PLAYERS, ARCHIVE, { maxSacksAllowed: 1, minTargets: 40 });
+    expect(result).toHaveLength(0);
+  });
+
+  it('all thresholds satisfied returns the matching player', () => {
+    // P3: sacksMade=5, battedPasses=3, coverageTargets=40
+    const result = filterPlayerPool(PLAYERS, ARCHIVE, {
+      minSacksMade: 3,
+      minBattedPasses: 2,
+      minCoverageTargets: 30,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(P3);
+  });
+
+  it('min AND max on same stat works as a range gate', () => {
+    // targets: P1=100, P2=50, P3=0 → only P2 lands in [40, 60]
+    const result = filterPlayerPool(PLAYERS, ARCHIVE, { minTargets: 40, maxTargets: 60 });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(P2);
+  });
+});
+
+// ─── sparse archive fallback ─────────────────────────────────────────────────
+
+describe('filterPlayerPool – sparse archive handling', () => {
+  it('players absent from the archive default to 0 for every stat', () => {
+    const rookie = player(99);
+    // With minTargets=1, rookie (no archive entry) should be excluded
+    const result = filterPlayerPool([P1, rookie], ARCHIVE, { minTargets: 1 });
+    expect(result.map((p) => p.id)).not.toContain(99);
+  });
+
+  it('null archive is treated as an empty store', () => {
+    const result = filterPlayerPool(PLAYERS, null, { minTargets: 1 });
+    expect(result).toHaveLength(0);
+  });
+
+  it('undefined archive is treated as an empty store', () => {
+    const result = filterPlayerPool(PLAYERS, undefined, { maxSacksAllowed: 0 });
+    // all players have 0 sacks allowed, so all pass the ≤0 threshold
+    expect(result).toHaveLength(3);
+  });
+
+  it('players with partially missing season keys default missing stats to 0', () => {
+    const sparseArchive = makeArchive([
+      { playerId: 1, year: 2024, stats: { targets: 80 } }, // drops missing from raw
+    ]);
+    const result = filterPlayerPool([P1], sparseArchive, { maxDrops: 0 });
+    expect(result).toHaveLength(1); // drops should default to 0, passing ≤0
+  });
+});
+
+// ─── season mode ─────────────────────────────────────────────────────────────
+
+describe('filterPlayerPool – season mode', () => {
+  const MULTI = makeArchive([
+    { playerId: 1, year: 2022, stats: stats({ targets: 30 }) },
+    { playerId: 1, year: 2023, stats: stats({ targets: 120 }) },
+    { playerId: 1, year: 2024, stats: stats({ targets: 80 }) },
+    { playerId: 2, year: 2023, stats: stats({ targets: 60 }) },
+    { playerId: 2, year: 2024, stats: stats({ targets: 30 }) },
+  ]);
+
+  it('filters against the specified season only', () => {
+    const result = filterPlayerPool([P1, P2], MULTI, {
+      seasonMode: 'season',
+      season: '2023',
+      minTargets: 100,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(P1);
+  });
+
+  it('different season produces a different result set', () => {
+    const result2024 = filterPlayerPool([P1, P2], MULTI, {
+      seasonMode: 'season',
+      season: '2024',
+      minTargets: 50,
+    });
+    expect(result2024).toHaveLength(1);
+    expect(result2024[0]).toBe(P1);
+  });
+
+  it('season with no data for a player excludes them', () => {
+    // P2 has no 2022 entry
+    const result = filterPlayerPool([P1, P2], MULTI, {
+      seasonMode: 'season',
+      season: '2022',
+      minTargets: 1,
+    });
+    expect(result.map((p) => p.id)).not.toContain(2);
+  });
+
+  it('omitting season while in season mode behaves like career mode', () => {
+    // season='', so falls back to career aggregation
+    const result = filterPlayerPool([P1, P2], MULTI, {
+      seasonMode: 'season',
+      season: '',
+      minTargets: 200, // P1 career = 230, P2 career = 90
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(P1);
+  });
+});
+
+// ─── career aggregation ──────────────────────────────────────────────────────
+
+describe('filterPlayerPool – career aggregation', () => {
+  const MULTI = makeArchive([
+    { playerId: 1, year: 2022, stats: stats({ targets: 30 }) },
+    { playerId: 1, year: 2023, stats: stats({ targets: 40 }) },
+    { playerId: 1, year: 2024, stats: stats({ targets: 35 }) },
+    { playerId: 2, year: 2024, stats: stats({ targets: 90 }) },
+  ]);
+
+  it('sums all seasons into career totals', () => {
+    // P1 career targets: 30+40+35 = 105, P2: 90 → only P1 ≥ 100
+    const result = filterPlayerPool([P1, P2], MULTI, { minTargets: 100 });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(P1);
+  });
+
+  it('defaults to career mode when seasonMode is absent', () => {
+    const result = filterPlayerPool([P1, P2], MULTI, { minTargets: 100 });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(P1);
+  });
+});
+
+// ─── immutability ────────────────────────────────────────────────────────────
+
+describe('filterPlayerPool – immutability', () => {
+  it('does not mutate the archive', () => {
+    const arc = makeArchive([
+      { playerId: 1, year: 2024, stats: stats({ targets: 100 }) },
+    ]);
+    const snapshot = JSON.parse(JSON.stringify(arc));
+    filterPlayerPool([P1], arc, { minTargets: 50 });
+    expect(arc).toEqual(snapshot);
+  });
+
+  it('does not add keys to the archive', () => {
+    const arc = makeArchive([
+      { playerId: 1, year: 2024, stats: stats({ targets: 100 }) },
+    ]);
+    const keysBefore = Object.keys(arc);
+    filterPlayerPool([P1, player(99)], arc, { minTargets: 1 });
+    expect(Object.keys(arc)).toEqual(keysBefore);
+  });
+
+  it('does not mutate the players array', () => {
+    const arr = [P1, P2, P3];
+    const snapshot = [...arr];
+    filterPlayerPool(arr, ARCHIVE, { minTargets: 60 });
+    expect(arr).toEqual(snapshot);
+  });
+});
+
+// ─── CRITERIA_KEYS export ────────────────────────────────────────────────────
+
+describe('CRITERIA_KEYS', () => {
+  it('is an array', () => {
+    expect(Array.isArray(CRITERIA_KEYS)).toBe(true);
+  });
+
+  it('contains all expected threshold keys', () => {
+    const expected = [
+      'minTargets', 'maxTargets',
+      'minDrops', 'maxDrops',
+      'minBattedPasses', 'maxBattedPasses',
+      'minSacksAllowed', 'maxSacksAllowed',
+      'minSacksMade', 'maxSacksMade',
+      'minCoverageTargets', 'maxCoverageTargets',
+      'minReceptionsAllowed', 'maxReceptionsAllowed',
+      'minCoverageCompletionsAllowed', 'maxCoverageCompletionsAllowed',
+    ];
+    for (const key of expected) {
+      expect(CRITERIA_KEYS).toContain(key);
+    }
+  });
+});
+
+// ─── performance ─────────────────────────────────────────────────────────────
+
+describe('filterPlayerPool – performance', () => {
+  it('processes 2048 players with 2 seasons each in under 15 ms', () => {
+    const COUNT = 2048;
+    const bigPlayers = Array.from({ length: COUNT }, (_, i) => player(1000 + i));
+
+    // Deterministic values via linear congruential sequence to avoid flakiness
+    let seed = 0xdeadbeef;
+    const rng = () => { seed = (seed * 1664525 + 1013904223) & 0xffffffff; return (seed >>> 0) / 0xffffffff; };
+
+    const bigArchive = {};
+    for (const p of bigPlayers) {
+      const pid = String(p.id);
+      bigArchive[pid] = {
+        '2023': stats({
+          targets:             Math.floor(rng() * 150),
+          drops:               Math.floor(rng() * 10),
+          sacksAllowed:        Math.floor(rng() * 15),
+          sacksMade:           Math.floor(rng() * 8),
+          battedPasses:        Math.floor(rng() * 6),
+          coverageTargets:     Math.floor(rng() * 60),
+          receptionsAllowed:   Math.floor(rng() * 40),
+          coverageCompletionsAllowed: Math.floor(rng() * 35),
+        }),
+        '2024': stats({
+          targets:             Math.floor(rng() * 150),
+          drops:               Math.floor(rng() * 10),
+          sacksAllowed:        Math.floor(rng() * 15),
+          sacksMade:           Math.floor(rng() * 8),
+          battedPasses:        Math.floor(rng() * 6),
+          coverageTargets:     Math.floor(rng() * 60),
+          receptionsAllowed:   Math.floor(rng() * 40),
+          coverageCompletionsAllowed: Math.floor(rng() * 35),
+        }),
+      };
+    }
+
+    const start = performance.now();
+    const result = filterPlayerPool(bigPlayers, bigArchive, { minTargets: 50, maxDrops: 8 });
+    const elapsed = performance.now() - start;
+
+    expect(elapsed).toBeLessThan(15);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.length).toBeLessThan(COUNT);
+  });
+});


### PR DESCRIPTION
- playerSearchFilterEngine.js: pure O(N) filter utility that applies
  advanced stat thresholds (minTargets, maxSacksAllowed, minBattedPasses,
  etc.) against the sparse playerStatsStore. Supports career-aggregate
  and single-season modes; safely falls back to zero for players absent
  from the archive; never mutates the incoming archive.

- PlayerSearchPanel.jsx: collapsible filter drawer component with
  threshold inputs grouped by stat category (Receiving, Pass Protection,
  Pass Rush, Coverage), season-mode selector, active-filter badge, and
  a flex-wrap layout that degrades safely to 375 px viewports.

- tests/unit/playerSearchFilterEngine.test.js: 31 tests covering
  single/compound thresholds, career vs season modes, sparse-archive
  fallback, immutability, and a performance assertion (2048 players
  processed in < 15 ms).

https://claude.ai/code/session_01AVW7CBDijcZRMZ7mbuLYrS