### PR TITLE
Fix E2E player release regression test

### DIFF
--- a/tests/e2e/daily_regression.spec.js
+++ b/tests/e2e/daily_regression.spec.js
@@ -180,10 +180,11 @@ test.describe('Daily Regression Pass', () => {
             // Register dialog handler BEFORE confirming
             page.on('dialog', d => d.accept());
 
+            // The confirm button is now inside the ReleasePreviewModal
             await page.evaluate(() => {
-                const rows = document.querySelectorAll('.standings-table tbody tr, table tbody tr');
-                for(let row of rows) {
-                    const confirmBtn = Array.from(row.querySelectorAll('button')).find(b => b.innerText === 'Confirm');
+                const dialogs = document.querySelectorAll('[role="dialog"]');
+                for(let dialog of dialogs) {
+                    const confirmBtn = Array.from(dialog.querySelectorAll('button')).find(b => b.innerText === 'Confirm Release');
                     if (confirmBtn) { confirmBtn.click(); break; }
                 }
             });


### PR DESCRIPTION
Fixes the E2E daily regression test which was failing because it could not find the inline player release "Confirm" button. The test now correctly targets the "Confirm Release" button inside the `ReleasePreviewModal` dialog.

---
*PR created automatically by Jules for task [4399219341304421441](https://jules.google.com/task/4399219341304421441) started by @rbcati*