### PR TITLE
Streamline FranchiseHQ: remove duplicated League Pulse & add quick league links

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -8,15 +8,13 @@ import AdvanceReadinessGate from './AdvanceReadinessGate.jsx';
 import { selectFranchiseHQViewModel } from '../utils/franchiseCommandCenter.js';
 import { buildWeeklyCommandHub } from '../utils/weeklyCommandHub.js';
 import { buildCommandCenterSummary } from '../utils/weeklyHubLayout.js';
-import { rankLeaguePulseItems } from '../../core/leaguePulse.js';
 import { classifyTeamCulture, buildTeamCultureNarrative, TEAM_CULTURE_DEFAULT } from '../../core/teamCulture.js';
 import { buildRecentCultureEvents } from '../../core/broadcastNarrative.js';
-import { EmptyState, StatusChip, ActionTile, SectionCard, WeeklyAgenda, CompactNewsCard } from './ScreenSystem.jsx';
+import { EmptyState, StatusChip, ActionTile, SectionCard, WeeklyAgenda } from './ScreenSystem.jsx';
 import { getLastGameDisplay, getLatestUserCompletedGame, getNextOpponentDisplay } from '../utils/hqGameDisplay.js';
 import { HQIcon, TeamIdentityBadge } from './HQVisuals.jsx';
 import { buildGameBookDestination } from '../utils/managementScreenRouting.js';
 import ChronicleHeadlineBanner from './ChronicleHeadlineBanner.tsx';
-import LeaguePulseCard from './LeaguePulseCard.jsx';
 
 const BOTTOM_NAV_ITEMS = [
   { label: 'Home', route: 'HQ', icon: 'home', active: true },
@@ -187,11 +185,6 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
   }, [command.leagueNews, command.leaguePulse, command.postGameReview, command.teamRecord, lastGame, lastGameDisplay.overviewLine, nextOpponentDisplay.isHome, nextOpponentDisplay.opponentAbbr]);
 
   const decisionReview = useMemo(() => command.weeklyDecisionImpact ?? null, [command.weeklyDecisionImpact]);
-  const leaguePulseItems = useMemo(
-    () => rankLeaguePulseItems(league?.leaguePulse || command.leaguePulse || [], league?.userTeamId).slice(0, 5),
-    [command.leagueNews, command.leaguePulse],
-  );
-
   const hqTeamBuilder = useMemo(() => {
     const roster = Array.isArray(userTeam?.roster) ? userTeam.roster : [];
     const byPos = ['QB','RB','WR','TE','OL','DL','LB','CB','S'].map((pos) => ({ pos, players: roster.filter((p) => p?.pos === pos).sort((a,b)=>safeNum(b?.ovr)-safeNum(a?.ovr)) }));
@@ -390,6 +383,17 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
 
         <p className="app-hq-hero-footnote">Sim to Sunday • {footerDays} days until kickoff</p>
       </section>
+      <section
+        className="card"
+        style={{ padding: 'var(--space-2)', display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}
+        aria-label="League quick links"
+        data-testid="hq-league-destination-links"
+      >
+        <strong style={{ fontSize: '0.85em', opacity: 0.9 }}>League views:</strong>
+        <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('League Leaders')}>View full stats</button>
+        <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('Standings')}>Open standings</button>
+        <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('News')}>Open league news</button>
+      </section>
 
       {/* ── GM Weekly Loop Hint (early-game guide, weeks 1–4) ──────────── */}
       {safeNum(league?.week, 1) <= 4 ? (
@@ -576,15 +580,6 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
         </article>
       </div>
 
-      {/* ── League Pulse — weekly headlines (prominent, above passive stats) ── */}
-      <LeaguePulseCard
-        headlines={Array.isArray(league?.weeklyHeadlines) ? league.weeklyHeadlines : []}
-        currentWeek={safeNum(league?.week, 1)}
-        currentYear={safeNum(league?.year, 0)}
-        onNavigate={onNavigate}
-        onViewAll={() => onNavigate?.('News')}
-      />
-
       {/* Next Action and Coordinator Brief panels removed — data compressed into hq-twin-grid above */}
 
       <SectionCard title="Season Pulse" subtitle="Pressure, form, and roster leverage at a glance." variant="compact">
@@ -748,25 +743,6 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
             <div><span>News Note</span><strong>{postAdvanceNote.note}</strong></div>
             <div><span>Review Routes</span><div className="app-hq-opponent-chips">{postAdvanceNote.actions.length ? postAdvanceNote.actions.map((action) => <button key={action.targetRoute} type="button" onClick={() => onNavigate?.(action.targetRoute)}>{action.label}</button>) : <em>No review actions</em>}</div></div>
             <div><span>Next 3</span><div className="app-hq-opponent-chips">{nextOpponents.length ? nextOpponents.map((chip) => <em key={chip}>{chip}</em>) : <em>No future games on file</em>}</div></div>
-          </div>
-        </details>
-      </SectionCard>
-
-      {/* ── League Pulse — overflow stories (collapsed background context) ── */}
-      {/* ── League Pulse overflow (collapsed background context) ─────────── */}
-      <SectionCard
-        title="League Pulse"
-        subtitle="Franchise events and league stories this week."
-        variant="compact"
-        actions={<button type="button" className="btn btn-sm" onClick={() => onNavigate?.('League Pulse')}>Open full pulse</button>}
-      >
-        <details className="app-hq-background-section__inner">
-          <summary className="app-hq-section-expand">Show league stories ▾</summary>
-          <div className="app-news-compact-list" style={{ marginTop: 8 }}>
-            {leaguePulseItems.map((item) => (
-              <CompactNewsCard key={item.id} title={item.headline} subtitle={item.detail} />
-            ))}
-            {!leaguePulseItems.length ? <EmptyState title="No league pulse yet." body="Advance to generate weekly stories." /> : null}
           </div>
         </details>
       </SectionCard>

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -105,7 +105,7 @@ describe('FranchiseHQ', () => {
     expect(onNavigate).toHaveBeenCalled();
   });
 
-  it('renders League Pulse preview and opens the full News timeline', () => {
+  it('does not render duplicated passive League Pulse panel and keeps league destination links', () => {
     const onNavigate = vi.fn();
     render(
       <FranchiseHQ
@@ -122,11 +122,13 @@ describe('FranchiseHQ', () => {
       />,
     );
 
-    const pulseSection = screen.getByRole('heading', { name: /league pulse/i }).closest('section');
-    expect(pulseSection).toBeTruthy();
-    expect(within(pulseSection).getByText(/rookie hype is building/i)).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: /open full pulse/i }));
-    expect(onNavigate).toHaveBeenCalledWith('League Pulse');
+    expect(screen.queryByRole('heading', { name: /league pulse/i })).toBeNull();
+    const linkRow = screen.getByTestId('hq-league-destination-links');
+    expect(within(linkRow).getByRole('button', { name: /view full stats/i })).toBeTruthy();
+    expect(within(linkRow).getByRole('button', { name: /open standings/i })).toBeTruthy();
+    expect(within(linkRow).getByRole('button', { name: /open league news/i })).toBeTruthy();
+    fireEvent.click(within(linkRow).getByRole('button', { name: /open league news/i }));
+    expect(onNavigate).toHaveBeenCalledWith('News');
   });
 
   it('renders Review Game Book as the postgame next action and emits a Game Book route', () => {

--- a/src/ui/components/__tests__/weeklyLoopCohesion.test.jsx
+++ b/src/ui/components/__tests__/weeklyLoopCohesion.test.jsx
@@ -253,7 +253,9 @@ describe('FranchiseHQ command center layout', () => {
     );
     // These sections remain as SectionCards (heading preserved) with collapsible inner details
     expect(html).toContain('Operations Snapshot');
-    expect(html).toContain('League Pulse');
+    expect(html).not.toContain('League Pulse');
+    expect(html).toContain('League views:');
+    expect(html).toContain('View full stats');
     // Collapsible summary triggers are present inside section bodies
     expect(html).toContain('app-hq-background-section__inner');
   });


### PR DESCRIPTION
### Motivation
- Franchise HQ still rendered duplicate passive league-reading surfaces (League Pulse prominent card and collapsed overflow) after recent pruning, which increased vertical clutter and distracted from the command-center intent.  
- The goal is to surgically remove duplicated passive content from HQ while keeping command-path controls and ensuring passive data remains discoverable in its dedicated tabs.

### Description
- Removed direct `LeaguePulseCard` rendering and the `rankLeaguePulseItems`/`CompactNewsCard` overflow list from `src/ui/components/FranchiseHQ.jsx`, and deleted the now-unused import from the file.  
- Added a compact HQ “League views” quick-links `section` with small buttons that navigate to `League Leaders`, `Standings`, and `News` so passive content remains discoverable without HQ density.  
- Updated tests to match the streamlined layout: `src/ui/components/__tests__/FranchiseHQ.test.jsx` now asserts the passive League Pulse panel is not duplicated on HQ and the new `hq-league-destination-links` exist, and `src/ui/components/__tests__/weeklyLoopCohesion.test.jsx` expectations were adjusted to reflect the change.  
- Change scope is limited to presentation and tests; no worker, simulation, persistence, or state-freshness code was touched (preserved per constraints).

### Testing
- Ran `npm run test:unit` and the unit suite passed after updating expectations, including the amended `weeklyLoopCohesion` and `FranchiseHQ` tests.  
- Ran `npm run build` and the production build completed successfully (Vite emitted the usual large-chunk warnings but the build succeeded).  
- Attempted `npx playwright test tests/e2e/fresh_franchise_first_week_smoke.spec.js` and the smoke test failed to launch because Chromium is not installed in this environment (error: executable missing); install the browsers with `npx playwright install` to enable E2E runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1664e40650832d95fead9a961053cd)