### PR TITLE
Add read-only Staff Philosophy audit foundation (V1-safe)

### DIFF
--- a/src/core/__tests__/staffPhilosophy.test.js
+++ b/src/core/__tests__/staffPhilosophy.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  OFFENSIVE_PHILOSOPHY,
+  buildStaffPhilosophySummary,
+  createDefaultStaffForTeam,
+  getStaffPhilosophyLabel,
+  normalizeStaffMember,
+  normalizeTeamStaff,
+} from '../staff/staffPhilosophy.js';
+
+describe('staffPhilosophy', () => {
+  it('normalizes missing staff to safe defaults', () => {
+    const summary = buildStaffPhilosophySummary({ id: 7, name: 'Bears' });
+    expect(summary.headCoachName).toContain('Interim Staff');
+    expect(summary.offensivePhilosophy).toBe('BALANCED');
+    expect(summary.defensivePhilosophy).toBe('BALANCED');
+  });
+
+  it('creates default legacy fallback staff for empty teams', () => {
+    const staff = createDefaultStaffForTeam({ id: 2, name: 'Jets' });
+    expect(staff.headCoach.roleKey).toBe('headCoach');
+    expect(staff.headCoach.offensivePhilosophy).toBe(OFFENSIVE_PHILOSOPHY.BALANCED);
+  });
+
+  it('handles malformed staff input without crashing', () => {
+    const malformed = normalizeStaffMember({ name: null, traits: ['scheme_teacher', 'bad', 'scheme_teacher'], offensivePhilosophy: '???' });
+    expect(malformed.name).toBe('Interim Staff');
+    expect(malformed.offensivePhilosophy).toBe('BALANCED');
+    expect(malformed.traits).toEqual(['SCHEME_TEACHER']);
+  });
+
+  it('has deterministic philosophy labels', () => {
+    expect(getStaffPhilosophyLabel('offense', 'WEST_COAST')).toBe('West Coast timing offense');
+    expect(getStaffPhilosophyLabel('defense', 'COVER_2')).toBe('Cover 2 shell defense');
+  });
+
+  it('summary avoids gameplay bonus language', () => {
+    const summary = buildStaffPhilosophySummary({
+      staff: { headCoach: { name: 'Alex Reed', offensivePhilosophy: 'SPREAD', defensivePhilosophy: 'MAN_COVERAGE', traits: ['PLAYER_FRIENDLY'] } },
+    });
+    expect(summary.flavor).toContain('leans');
+    expect(summary.flavor).not.toMatch(/bonus|boost|modifier|improve/i);
+  });
+
+  it('normalizes coordinator aliases from legacy keys', () => {
+    const normalized = normalizeTeamStaff({ staff: { offCoord: { name: 'OC', schemePreference: 'spread' }, defCoord: { name: 'DC', schemePreference: 'cover 2' } } });
+    expect(normalized.offCoordinator.offensivePhilosophy).toBe('SPREAD');
+    expect(normalized.defCoordinator.defensivePhilosophy).toBe('COVER_2');
+  });
+});

--- a/src/core/staff/staffPhilosophy.js
+++ b/src/core/staff/staffPhilosophy.js
@@ -1,0 +1,144 @@
+const OFFENSIVE_PHILOSOPHY = Object.freeze({
+  BALANCED: 'BALANCED',
+  WEST_COAST: 'WEST_COAST',
+  POWER_RUN: 'POWER_RUN',
+  SPREAD: 'SPREAD',
+  VERTICAL: 'VERTICAL',
+});
+
+const DEFENSIVE_PHILOSOPHY = Object.freeze({
+  BALANCED: 'BALANCED',
+  BLITZ_HEAVY: 'BLITZ_HEAVY',
+  COVER_2: 'COVER_2',
+  MAN_COVERAGE: 'MAN_COVERAGE',
+  HYBRID: 'HYBRID',
+});
+
+const STAFF_TRAITS = Object.freeze({
+  DEVELOPMENTAL: 'DEVELOPMENTAL',
+  DISCIPLINARIAN: 'DISCIPLINARIAN',
+  PLAYER_FRIENDLY: 'PLAYER_FRIENDLY',
+  SCHEME_TEACHER: 'SCHEME_TEACHER',
+  VETERAN_MANAGER: 'VETERAN_MANAGER',
+});
+
+const OFFENSE_LABELS = Object.freeze({
+  BALANCED: 'Balanced offense',
+  WEST_COAST: 'West Coast timing offense',
+  POWER_RUN: 'Power run offense',
+  SPREAD: 'Spread offense',
+  VERTICAL: 'Vertical passing offense',
+});
+
+const DEFENSE_LABELS = Object.freeze({
+  BALANCED: 'Balanced defense',
+  BLITZ_HEAVY: 'Blitz-heavy defense',
+  COVER_2: 'Cover 2 shell defense',
+  MAN_COVERAGE: 'Man coverage defense',
+  HYBRID: 'Hybrid multiple defense',
+});
+
+const TRAIT_LABELS = Object.freeze({
+  DEVELOPMENTAL: 'Developmental',
+  DISCIPLINARIAN: 'Disciplinarian',
+  PLAYER_FRIENDLY: 'Player-friendly',
+  SCHEME_TEACHER: 'Scheme teacher',
+  VETERAN_MANAGER: 'Veteran manager',
+});
+
+const BASELINE_STAFF_NAME = 'Interim Staff';
+
+function normalizeEnum(value, allowed, fallback) {
+  return allowed[value] ? value : fallback;
+}
+
+function normalizeTraits(rawTraits) {
+  if (!Array.isArray(rawTraits)) return [];
+  return rawTraits
+    .map((trait) => String(trait || '').trim().toUpperCase())
+    .filter((trait, index, list) => STAFF_TRAITS[trait] && list.indexOf(trait) === index)
+    .slice(0, 2);
+}
+
+function inferOffensivePhilosophy(member) {
+  const raw = String(member?.offensivePhilosophy ?? member?.offensePhilosophy ?? '').toUpperCase();
+  if (OFFENSIVE_PHILOSOPHY[raw]) return raw;
+  const pref = String(member?.schemePreference ?? member?.offScheme ?? '').toLowerCase();
+  if (pref.includes('west')) return OFFENSIVE_PHILOSOPHY.WEST_COAST;
+  if (pref.includes('spread')) return OFFENSIVE_PHILOSOPHY.SPREAD;
+  if (pref.includes('vertical')) return OFFENSIVE_PHILOSOPHY.VERTICAL;
+  if (pref.includes('smash') || pref.includes('power') || pref.includes('run')) return OFFENSIVE_PHILOSOPHY.POWER_RUN;
+  return OFFENSIVE_PHILOSOPHY.BALANCED;
+}
+
+function inferDefensivePhilosophy(member) {
+  const raw = String(member?.defensivePhilosophy ?? member?.defensePhilosophy ?? '').toUpperCase();
+  if (DEFENSIVE_PHILOSOPHY[raw]) return raw;
+  const pref = String(member?.schemePreference ?? member?.defScheme ?? '').toLowerCase();
+  if (pref.includes('blitz')) return DEFENSIVE_PHILOSOPHY.BLITZ_HEAVY;
+  if (pref.includes('cover 2') || pref.includes('cover2')) return DEFENSIVE_PHILOSOPHY.COVER_2;
+  if (pref.includes('man')) return DEFENSIVE_PHILOSOPHY.MAN_COVERAGE;
+  if (pref.includes('3-4') || pref.includes('4-3') || pref.includes('hybrid') || pref.includes('multiple')) return DEFENSIVE_PHILOSOPHY.HYBRID;
+  return DEFENSIVE_PHILOSOPHY.BALANCED;
+}
+
+export function createDefaultStaffForTeam(team = {}) {
+  const city = String(team?.name ?? team?.abbr ?? 'Team');
+  return {
+    headCoach: {
+      id: `staff-default-hc-${team?.id ?? '0'}`,
+      name: `${city} ${BASELINE_STAFF_NAME}`,
+      roleKey: 'headCoach',
+      offensivePhilosophy: OFFENSIVE_PHILOSOPHY.BALANCED,
+      defensivePhilosophy: DEFENSIVE_PHILOSOPHY.BALANCED,
+      traits: [],
+    },
+  };
+}
+
+export function normalizeStaffMember(member = {}, fallbackRole = 'headCoach') {
+  const normalized = { ...member };
+  normalized.roleKey = String(member?.roleKey ?? fallbackRole);
+  normalized.name = String(member?.name ?? BASELINE_STAFF_NAME);
+  normalized.offensivePhilosophy = normalizeEnum(inferOffensivePhilosophy(member), OFFENSIVE_PHILOSOPHY, OFFENSIVE_PHILOSOPHY.BALANCED);
+  normalized.defensivePhilosophy = normalizeEnum(inferDefensivePhilosophy(member), DEFENSIVE_PHILOSOPHY, DEFENSIVE_PHILOSOPHY.BALANCED);
+  normalized.traits = normalizeTraits(member?.traits);
+  return normalized;
+}
+
+export function normalizeTeamStaff(team = {}) {
+  const rawStaff = team?.staff && typeof team.staff === 'object' ? team.staff : createDefaultStaffForTeam(team);
+  const headCoach = normalizeStaffMember(rawStaff.headCoach ?? {}, 'headCoach');
+  const offCoordinator = normalizeStaffMember(rawStaff.offCoordinator ?? rawStaff.offCoord ?? {}, 'offCoordinator');
+  const defCoordinator = normalizeStaffMember(rawStaff.defCoordinator ?? rawStaff.defCoord ?? {}, 'defCoordinator');
+  return { ...rawStaff, headCoach, offCoordinator, defCoordinator };
+}
+
+export function getStaffPhilosophyLabel(type, value) {
+  const key = String(value ?? '').toUpperCase();
+  if (type === 'offense') return OFFENSE_LABELS[key] ?? OFFENSE_LABELS.BALANCED;
+  if (type === 'defense') return DEFENSE_LABELS[key] ?? DEFENSE_LABELS.BALANCED;
+  return TRAIT_LABELS[key] ?? 'Balanced';
+}
+
+export function buildStaffPhilosophySummary(team = {}) {
+  const staff = normalizeTeamStaff(team);
+  const headCoach = staff.headCoach;
+  const traits = Array.isArray(headCoach?.traits) ? headCoach.traits.slice(0, 2) : [];
+  const traitLabels = traits.map((trait) => getStaffPhilosophyLabel('trait', trait));
+  const offenseLabel = getStaffPhilosophyLabel('offense', headCoach.offensivePhilosophy);
+  const defenseLabel = getStaffPhilosophyLabel('defense', headCoach.defensivePhilosophy);
+  const flavor = `${headCoach.name} leans ${offenseLabel.toLowerCase()} with a ${defenseLabel.toLowerCase()} identity.`;
+  return {
+    headCoachName: headCoach.name,
+    offensivePhilosophy: headCoach.offensivePhilosophy,
+    defensivePhilosophy: headCoach.defensivePhilosophy,
+    offensiveLabel: offenseLabel,
+    defensiveLabel: defenseLabel,
+    traits,
+    traitLabels,
+    flavor,
+  };
+}
+
+export { OFFENSIVE_PHILOSOPHY, DEFENSIVE_PHILOSOPHY, STAFF_TRAITS };

--- a/src/ui/components/TeamHub.jsx
+++ b/src/ui/components/TeamHub.jsx
@@ -8,6 +8,7 @@ import { derivePlayerContractFinancials } from '../utils/contractFormatting.js';
 import { deriveTeamCapSnapshot, formatMoneyM } from '../utils/numberFormatting.js';
 import { summarizeRosterDevelopment } from '../utils/playerDevelopmentSignals.js';
 import { TeamIdentityBadge } from './HQVisuals.jsx';
+import { buildStaffPhilosophySummary } from '../../core/staff/staffPhilosophy.js';
 
 const TEAM_SECTIONS = ['Overview', 'Roster / Depth', 'Contracts', 'Development', 'Injuries'];
 const CRITICAL_POSITION_MIN = { QB: 2, RB: 3, WR: 5, TE: 3, OL: 8, DL: 8, LB: 6, CB: 5, S: 4, K: 1, P: 1 };
@@ -66,6 +67,7 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
   const injuredPlayers = useMemo(() => roster.filter((p) => Number(p?.injury?.gamesRemaining ?? p?.injuryWeeksRemaining ?? 0) > 0), [roster]);
   const developmentSummary = useMemo(() => summarizeRosterDevelopment(roster, new Map()), [roster]);
   const pressureGroups = useMemo(() => getPositionGroupPressure(roster), [roster]);
+  const staffPhilosophy = useMemo(() => buildStaffPhilosophySummary(team ?? {}), [team]);
 
   useEffect(() => {
     const next = normalizeSection(initialSection);
@@ -164,6 +166,22 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
                   <button type="button" className="btn btn-sm btn-secondary" onClick={() => setSubtab('Roster / Depth')}>Open depth</button>
                 </CompactListRow>
               ))}
+            </div>
+          </SectionCard>
+
+
+          <SectionCard title="Staff philosophy" subtitle="Read-only coaching identity snapshot." variant="compact">
+            <div className="app-row-stack">
+              <CompactListRow
+                title={staffPhilosophy.headCoachName}
+                subtitle={`${staffPhilosophy.offensiveLabel} · ${staffPhilosophy.defensiveLabel}`}
+                meta={<StatusChip label="Read-only" tone="info" />}
+              />
+              <CompactInsightCard
+                title={staffPhilosophy.traitLabels.length ? staffPhilosophy.traitLabels.join(' · ') : 'No tagged traits'}
+                subtitle={staffPhilosophy.flavor}
+                tone="team"
+              />
             </div>
           </SectionCard>
 

--- a/src/ui/components/__tests__/TeamHub.staffPhilosophy.test.jsx
+++ b/src/ui/components/__tests__/TeamHub.staffPhilosophy.test.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import TeamHub from '../TeamHub.jsx';
+
+const baseLeague = {
+  week: 1,
+  year: 2026,
+  phase: 'regular',
+  userTeamId: 1,
+  teams: [{ id: 1, name: 'User Team', abbr: 'USR', wins: 0, losses: 0, capRoom: 25, roster: [] }],
+  schedule: [],
+};
+
+describe('TeamHub staff philosophy card', () => {
+  it('renders compact staff philosophy card for staffed team', () => {
+    const league = {
+      ...baseLeague,
+      teams: [{ ...baseLeague.teams[0], staff: { headCoach: { name: 'Jordan Shaw', offensivePhilosophy: 'VERTICAL', defensivePhilosophy: 'HYBRID', traits: ['SCHEME_TEACHER'] } } }],
+    };
+    const html = renderToString(<TeamHub league={league} actions={{}} />);
+    expect(html).toContain('Staff philosophy');
+    expect(html).toContain('Jordan Shaw');
+    expect(html).toContain('Vertical passing offense');
+  });
+
+  it('renders safe fallback when staff is missing', () => {
+    const html = renderToString(<TeamHub league={baseLeague} actions={{}} />);
+    expect(html).toContain('Staff philosophy');
+    expect(html).toContain('Interim Staff');
+    expect(html).toContain('Balanced offense');
+  });
+});


### PR DESCRIPTION
### Motivation
- Audit the existing coaching/staff architecture and provide a safe, legacy-compatible read model for staff philosophy without touching simulation or persistence concerns.
- Surface a compact, read-only coaching identity snapshot in the TeamHub UI to support future UI/feature work while preserving gameplay integrity.

### Description
- Added a pure helper module `src/core/staff/staffPhilosophy.js` providing `createDefaultStaffForTeam`, `normalizeStaffMember`, `normalizeTeamStaff`, `getStaffPhilosophyLabel`, and `buildStaffPhilosophySummary` with deterministic enums/labels and legacy key handling.
- Made a small, read-only UI addition to the TeamHub overview to render a compact "Staff philosophy" card using `buildStaffPhilosophySummary` that shows head coach name, offensive/defensive identity, up to two traits, and a short flavor line.
- Added targeted tests: `src/core/__tests__/staffPhilosophy.test.js` for normalization/labels/malformed inputs and `src/ui/components/__tests__/TeamHub.staffPhilosophy.test.jsx` for UI rendering and fallback behavior.
- Preserved safety constraints: no gameplay modifiers, no teamCulture/sim/development/contract/schema changes, and no AI/hiring/bidding flows were added.

### Testing
- Ran targeted unit tests `npm run test:unit -- src/core/__tests__/staffPhilosophy.test.js src/ui/components/__tests__/TeamHub.staffPhilosophy.test.jsx` and they passed.
- Ran full unit test suite with `npm run test:unit` and all tests passed (248 files, 2244 tests passed in the environment used).
- Built the production bundle with `npm run build` and the build completed successfully (chunk size warning only).
- Ran the Playwright E2E smoke `npx playwright test tests/e2e/fresh_franchise_first_week_smoke.spec.js`, which failed in this environment due to missing Playwright browser binaries and requires `npx playwright install` to run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a166c19926c832da43df7d7c84865c5)