### PR TITLE
FranchiseHQ V2: prune Weekly Command Hub & Game Plan Impact trailing panels

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -6,11 +6,10 @@ import { evaluateWeeklyContext } from '../utils/weeklyContext.js';
 import { buildAdvanceReadinessGate } from '../utils/advanceReadinessGate.js';
 import AdvanceReadinessGate from './AdvanceReadinessGate.jsx';
 import { selectFranchiseHQViewModel } from '../utils/franchiseCommandCenter.js';
-import { buildWeeklyCommandHub } from '../utils/weeklyCommandHub.js';
 import { buildCommandCenterSummary } from '../utils/weeklyHubLayout.js';
 import { classifyTeamCulture, buildTeamCultureNarrative, TEAM_CULTURE_DEFAULT } from '../../core/teamCulture.js';
 import { buildRecentCultureEvents } from '../../core/broadcastNarrative.js';
-import { EmptyState, StatusChip, ActionTile, SectionCard, WeeklyAgenda } from './ScreenSystem.jsx';
+import { EmptyState, StatusChip, ActionTile, SectionCard } from './ScreenSystem.jsx';
 import { getLastGameDisplay, getLatestUserCompletedGame, getNextOpponentDisplay } from '../utils/hqGameDisplay.js';
 import { HQIcon, TeamIdentityBadge } from './HQVisuals.jsx';
 import { buildGameBookDestination } from '../utils/managementScreenRouting.js';
@@ -168,7 +167,6 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
 
   const capSpace = command.teamOverview?.find((item) => item.label === 'Cap Space')?.value ?? '—';
   const weeklyIntel = useMemo(() => command.weeklyIntelligence?.insights ?? [], [command.weeklyIntelligence?.insights]);
-  const gamePlanImpactCards = useMemo(() => command.gamePlanImpact?.recommendedAdjustments ?? [], [command.gamePlanImpact?.recommendedAdjustments]);
   const postAdvanceNote = useMemo(() => {
     const review = command.postGameReview ?? null;
     const recordDelta = lastGame ? `Record now ${formatRecordInline(command.teamRecord)}` : 'Advance to generate game feedback';
@@ -196,21 +194,6 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
       nextAction: weakest ? `Review ${weakest.pos} starter/depth plan` : 'Review roster needs',
     };
   }, [userTeam]);
-
-
-
-  const weeklyCommandHub = useMemo(() => buildWeeklyCommandHub({
-    league,
-    userTeam,
-    command,
-    teamBuilder: hqTeamBuilder,
-    weeklyDecisionImpact: decisionReview,
-    gamePlanImpact: command.gamePlanImpact,
-    weeklyIntelligence: command.weeklyIntelligence,
-    nextGame: command.nextGame,
-    lastGame,
-  }), [league, userTeam, command, hqTeamBuilder, decisionReview, lastGame]);
-
 
   const hqNextAction = useMemo(() => {
     const roster = Array.isArray(userTeam?.roster) ? userTeam.roster : [];
@@ -649,51 +632,6 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
           </article>
         </div>
       </SectionCard>
-
-      <SectionCard title="Weekly Command Hub" subtitle="Ranked actions for this week before you advance." variant="compact">
-        <div className="app-hq-intel-list">
-          {(weeklyCommandHub.sections ?? []).map((section) => (
-            <div key={section.key} className="app-hq-impact-card" style={{ marginBottom: 8 }}>
-              <div className="app-hq-impact-card__head">
-                <strong>{section.title}</strong>
-                <StatusChip label={`${section.actions.length} action${section.actions.length === 1 ? '' : 's'}`} tone={section.tone === 'danger' ? 'warning' : 'info'} />
-              </div>
-              {section.actions.length ? section.actions.map((action) => (
-                <button
-                  key={action.id}
-                  type="button"
-                  className="btn btn-sm app-hq-impact-card__cta"
-                  style={{ width: '100%', minHeight: 44, textAlign: 'left', marginTop: 6 }}
-                  disabled={!action.route}
-                  onClick={() => action.route && onNavigate?.(action.route)}
-                  aria-label={`${section.title}: ${action.label}`}
-                >
-                  <strong>{action.label}</strong>
-                  <span style={{ display: 'block', opacity: 0.85 }}>{action.detail}</span>
-                </button>
-              )) : <p className="app-hq-intel-item tone-info">No actions right now.</p>}
-            </div>
-          ))}
-        </div>
-      </SectionCard>
-
-      <SectionCard title={command.gamePlanImpact?.heading ?? 'Game Plan Impact'} subtitle={command.gamePlanImpact?.summary ?? 'Translate coordinator intel into fast football actions.'} variant="compact">
-        <div className="app-hq-impact-list" role="list" aria-label="Game plan impact recommendations">
-          {gamePlanImpactCards.map((item) => (
-            <article key={item.id} role="listitem" className={`app-hq-impact-card tone-${item.tag?.tone ?? 'info'}`}>
-              <div className="app-hq-impact-card__head">
-                <strong>{item.title}</strong>
-                <StatusChip label={item.tag?.label ?? `${item.confidenceLevel ?? 'medium'} confidence`} tone={item.tag?.tone ?? 'warning'} />
-              </div>
-              <p>{item.explanation}</p>
-              <button type="button" className="btn btn-sm app-hq-impact-card__cta" onClick={() => onNavigate?.(item.targetRoute)} aria-label={`${item.title}: ${item.ctaLabel}`}>
-                {item.ctaLabel}
-              </button>
-            </article>
-          ))}
-        </div>
-      </SectionCard>
-
 
       {lineupToast ? <p className="app-inline-toast" role="status" aria-live="polite">{lineupToast}</p> : null}
 

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -60,9 +60,9 @@ describe('FranchiseHQ', () => {
     expect(screen.getByRole('heading', { name: /week 10/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /advance week/i })).toBeTruthy();
     expect(screen.getAllByRole('button', { name: /advance week/i })).toHaveLength(1);
-    expect(screen.getByRole('heading', { name: /weekly command hub/i })).toBeTruthy();
-    expect(screen.getByText(/must handle/i)).toBeTruthy();
-    expect(screen.getByText(/tactical edge/i)).toBeTruthy();
+    // Weekly Command Hub and Game Plan Impact pruned from HQ command deck
+    expect(screen.queryByRole('heading', { name: /weekly command hub/i })).toBeNull();
+    expect(screen.queryByRole('heading', { name: /game plan impact/i })).toBeNull();
     // "Coordinator Brief" section removed — intel is compressed into Roster Health & Office Status cards
     expect(document.querySelector('[data-testid="roster-health-card"]')).not.toBeNull();
     expect(document.querySelector('[data-testid="office-status-card"]')).not.toBeNull();
@@ -71,18 +71,25 @@ describe('FranchiseHQ', () => {
     expect(seasonPulse.getByText(/momentum/i)).toBeTruthy();
     expect(seasonPulse.getByText(/roster lever/i)).toBeTruthy();
     expect(seasonPulse.getByText(/film room/i)).toBeTruthy();
-    expect(screen.getAllByRole('heading', { name: /game plan impact/i }).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/home matchup vs det/i).length).toBeGreaterThan(0);
-    expect(screen.getByText(/ratings are tightly clustered/i)).toBeTruthy();
-    expect(screen.getByRole('button', { name: /tactical edge: review game plan/i })).toBeTruthy();
+    // League Views quick links present
+    const linkRow = screen.getByTestId('hq-league-destination-links');
+    expect(within(linkRow).getByRole('button', { name: /view full stats/i })).toBeTruthy();
+    expect(within(linkRow).getByRole('button', { name: /open standings/i })).toBeTruthy();
+    expect(within(linkRow).getByRole('button', { name: /open league news/i })).toBeTruthy();
   });
 
-  it('routes weekly command hub action through onNavigate', () => {
+  it('does not render pruned Weekly Command Hub or Game Plan Impact sections', () => {
     const onNavigate = vi.fn();
-    const view = render(<FranchiseHQ league={baseLeague} onNavigate={onNavigate} onAdvanceWeek={() => {}} busy={false} simulating={false} />);
+    render(<FranchiseHQ league={baseLeague} onNavigate={onNavigate} onAdvanceWeek={() => {}} busy={false} simulating={false} />);
 
-    fireEvent.click(within(view.container).getAllByRole('button', { name: /tactical edge: review game plan/i })[0]);
-    expect(onNavigate).toHaveBeenCalledWith('Game Plan');
+    // Weekly Command Hub removed — purpose covered by Actions Required + Quick Actions
+    expect(screen.queryByRole('heading', { name: /weekly command hub/i })).toBeNull();
+    // Game Plan Impact removed — strategy details belong in Game Plan / Weekly Prep tabs
+    expect(screen.queryByRole('heading', { name: /game plan impact/i })).toBeNull();
+    // Quick Actions (action tiles) still present for the key navigation paths
+    expect(screen.getByTestId('hq-league-destination-links')).toBeTruthy();
+    expect(screen.getByTestId('hq-actions-required')).toBeTruthy();
+    expect(screen.getByTestId('advance-week-cta')).toBeTruthy();
   });
 
   it('routes season pulse roster action through onNavigate', () => {
@@ -207,7 +214,8 @@ describe('FranchiseHQ', () => {
 
     expect(screen.getByText(/no completed game yet/i)).toBeTruthy();
     expect(screen.getByText(/no opponent is locked yet/i)).toBeTruthy();
-    expect(screen.getAllByRole('heading', { name: /game plan impact/i }).length).toBeGreaterThan(0);
+    // Game Plan Impact pruned — no longer rendered on HQ
+    expect(screen.queryByRole('heading', { name: /game plan impact/i })).toBeNull();
     expect(screen.getByText(/no future games on file/i)).toBeTruthy();
     expect(screen.getAllByText(/0-0 · 0 0/i).length).toBeGreaterThan(0);
   });

--- a/src/ui/components/__tests__/weeklyLoopCohesion.test.jsx
+++ b/src/ui/components/__tests__/weeklyLoopCohesion.test.jsx
@@ -247,7 +247,7 @@ describe('FranchiseHQ command center layout', () => {
     expect(html).toContain('Season Pulse');
   });
 
-  it('renders background sections with collapsible inner bodies', () => {
+  it('renders background sections with collapsible inner bodies; Weekly Command Hub and Game Plan Impact absent', () => {
     const html = renderToString(
       <FranchiseHQ league={league} onNavigate={() => {}} onAdvanceWeek={() => {}} />,
     );
@@ -258,6 +258,10 @@ describe('FranchiseHQ command center layout', () => {
     expect(html).toContain('View full stats');
     // Collapsible summary triggers are present inside section bodies
     expect(html).toContain('app-hq-background-section__inner');
+    // Weekly Command Hub and Game Plan Impact pruned — passive deep panels removed from HQ
+    expect(html).not.toContain('Weekly Command Hub');
+    expect(html).not.toContain('Game Plan Impact');
+    expect(html).not.toContain('Translate coordinator intel');
   });
 
   it('renders advance-week-cta data-testid', () => {


### PR DESCRIPTION
- Remove Weekly Command Hub SectionCard — its ranked-action purpose is
  fully covered by Actions Required (commandSummary.primaryActions) and
  the four Quick Actions tiles (Game Plan, Set Lineup, Training, Scout).
- Remove Game Plan Impact SectionCard — strategy cards belong in the
  Game Plan / Weekly Prep / Strategy tabs, not the HQ command deck.
- Drop unused import: buildWeeklyCommandHub (weeklyCommandHub.js).
- Drop unused useMemo: weeklyCommandHub, gamePlanImpactCards.
- Drop unused import: WeeklyAgenda from ScreenSystem (was imported but
  never rendered in FranchiseHQ).
- All kept sections intact: Actions Required, Quick Actions, Roster Health,
  Office Status, Season Pulse (Owner Mandate/Momentum/Roster Lever/Film
  Room/Team Culture), Decision Review (collapsed), Operations Snapshot
  (collapsed), League Views quick links, Advance Week CTA, bottom nav.
- No navigation path lost: Game Plan tile navigates to 'Game Plan';
  Season Pulse Film Room navigates to Game Book or Weekly Prep.

Tests updated:
- FranchiseHQ.test.jsx: test-1 strips WHC/GPI assertions, adds null checks
  for both pruned sections; adds League Views link assertions.
- FranchiseHQ.test.jsx: test-2 repurposed from 'routes WHC action' to
  'does not render pruned Weekly Command Hub or Game Plan Impact sections'.
- FranchiseHQ.test.jsx: test-10 replaces GPI presence assertion with
  absence assertion.
- weeklyLoopCohesion.test.jsx: background-section test extended with
  explicit not-toContain assertions for both pruned sections.

Validation: npm run test:unit → 2244/2244 pass; npm run build → clean.

https://claude.ai/code/session_016hhXChwpkcLL7NTPMcSNKJ