### PR TITLE
feat: postgame Game Book persistence and player name resolution V1

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -195,6 +195,8 @@ function AppContent() {
 
   // Post-game result shown after GameSimulation watch mode completes
   const [postGameResult, setPostGameResult] = useState(null);
+  // Stash preserves postGameResult while the user browses Game Book, so it can be restored on return.
+  const [postGameResultStash, setPostGameResultStash] = useState(null);
   // Skip-mode summary shown after advanceWeek({ skipUserGame: true }) completes
   const [skipGameSummary, setSkipGameSummary] = useState(null);
   const lastShownSkipWeekRef = useRef(null);
@@ -1443,6 +1445,12 @@ function AppContent() {
           onDismissNotification={actions.dismissNotification}
           externalBoxScoreId={externalBoxScoreId}
           onConsumeExternalBoxScore={() => setExternalBoxScoreId(null)}
+          onGameDetailBack={() => {
+            if (postGameResultStash) {
+              setPostGameResult(postGameResultStash);
+              setPostGameResultStash(null);
+            }
+          }}
           advanceLabel={getAdvanceLabel()}
           advanceDisabled={busy || simulating || isCutdownRequired || isBatchSimBlocking || !!promptUserGame}
         />
@@ -1698,12 +1706,14 @@ function AppContent() {
           boxScoreGameId={postGameResult.gameId}
           onOpenBoxScore={(gameId) => {
             if (!gameId) return;
+            setPostGameResultStash(postGameResult);
             setPostGameResult(null);
             setExternalBoxScoreId(gameId);
           }}
           onContinue={() => {
             try {
               setPostGameResult(null);
+              setPostGameResultStash(null);
               setTimeout(() => {
                 try {
                   actions.advanceWeek({ skipUserGame: true });
@@ -1714,6 +1724,7 @@ function AppContent() {
             } catch (err) {
               console.error('[PostGame] onContinue failed:', err);
               setPostGameResult(null);
+              setPostGameResultStash(null);
             }
           }}
           onArchiveReady={(archivePayload) => {

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -23,8 +23,9 @@ export function TeamButton({ team, onSelect }) {
 
 export function PlayerButton({ player, onSelect, context }) {
   if (!player) return <span>—</span>;
+  const displayName = player.name ?? (player.playerId != null ? `Player #${player.playerId}` : 'Player');
   const rawId = getPlayerProfileId(player.playerId ?? player);
-  if (!onSelect || !hasValidPlayerProfileId(rawId)) return <span>{player.name ?? "Unknown"}</span>;
+  if (!onSelect || !hasValidPlayerProfileId(rawId)) return <span>{displayName}</span>;
   return (
     <button
       type="button"
@@ -32,7 +33,7 @@ export function PlayerButton({ player, onSelect, context }) {
       data-testid="game-book-player-link"
       onClick={() => openPlayerProfile(rawId, onSelect, { ...context, player, statLine: player?.stats })}
     >
-      {player.name ?? "Unknown"}
+      {displayName}
     </button>
   );
 }

--- a/src/ui/components/BoxScore.test.jsx
+++ b/src/ui/components/BoxScore.test.jsx
@@ -199,3 +199,120 @@ describe('BoxScore game book rendering', () => {
   });
 
 });
+
+describe('BoxScore player name resolution', () => {
+  const baseLeague = { seasonId: 2031, week: 2, teams: [{ id: 1, abbr: 'KC' }, { id: 2, abbr: 'BUF' }] };
+  beforeEach(() => {
+    cleanup();
+    vi.mocked(useStableRouteRequest).mockReturnValue({ data: null });
+  });
+
+  it('shows player name from stat row when present', () => {
+    const game = {
+      homeId: 1, awayId: 2, homeScore: 21, awayScore: 14,
+      teamStats: { home: { passYards: 200 }, away: {} },
+      playerStats: {
+        home: { 11: { name: 'Named QB', stats: { passAtt: 20, passYd: 200 } } },
+        away: {},
+      },
+    };
+    const { container } = render(<BoxScore gameId="g-named" league={{ ...baseLeague, gameById: { 'g-named': game } }} embedded />);
+    expect(container.textContent).toContain('Named QB');
+    expect(container.textContent).not.toContain('Unknown');
+  });
+
+  it('shows Player #ID fallback when stat row has no name', () => {
+    const game = {
+      homeId: 1, awayId: 2, homeScore: 21, awayScore: 14,
+      teamStats: { home: { passYards: 200 }, away: {} },
+      playerStats: {
+        home: { 77: { stats: { passAtt: 20, passYd: 200 } } },
+        away: {},
+      },
+    };
+    const { container } = render(<BoxScore gameId="g-fallback" league={{ ...baseLeague, gameById: { 'g-fallback': game } }} embedded />);
+    expect(container.textContent).toContain('Player #77');
+    expect(container.textContent).not.toContain('Unknown');
+  });
+
+  it('resolves player name from league roster when stat row lacks name', () => {
+    const leagueWithRoster = {
+      ...baseLeague,
+      teams: [
+        { id: 1, abbr: 'KC', roster: [{ id: 55, name: 'Roster QB Name' }] },
+        { id: 2, abbr: 'BUF', roster: [] },
+      ],
+    };
+    const game = {
+      homeId: 1, awayId: 2, homeScore: 28, awayScore: 7,
+      teamStats: { home: { passYards: 300 }, away: {} },
+      playerStats: {
+        home: { 55: { stats: { passAtt: 30, passYd: 300 } } },
+        away: {},
+      },
+    };
+    const { container } = render(<BoxScore gameId="g-roster" league={{ ...leagueWithRoster, gameById: { 'g-roster': game } }} embedded />);
+    expect(container.textContent).toContain('Roster QB Name');
+    expect(container.textContent).not.toContain('Unknown');
+  });
+
+  it('never renders blank or undefined player labels in stat tables', () => {
+    const game = {
+      homeId: 1, awayId: 2, homeScore: 14, awayScore: 7,
+      teamStats: { home: { passYards: 100 }, away: {} },
+      playerStats: {
+        home: {
+          1: { stats: { passAtt: 10, passYd: 100 } },
+          2: { stats: { rushAtt: 8, rushYd: 60 } },
+        },
+        away: { 3: { stats: { tackles: 5, sacks: 1 } } },
+      },
+    };
+    const { container } = render(<BoxScore gameId="g-noblank" league={{ ...baseLeague, gameById: { 'g-noblank': game } }} embedded />);
+    const passingTable = container.querySelector('[data-testid="game-book-table-passing"]');
+    const rushingTable = container.querySelector('[data-testid="game-book-table-rushing"]');
+    const defenseTable = container.querySelector('[data-testid="game-book-table-defense"]');
+    [passingTable, rushingTable, defenseTable].filter(Boolean).forEach((table) => {
+      const cells = table.querySelectorAll('td');
+      cells.forEach((cell) => {
+        expect(cell.textContent).not.toBe('');
+        expect(cell.textContent).not.toBe('undefined');
+        expect(cell.textContent).not.toContain('Unknown');
+      });
+    });
+  });
+
+  it('mobile table wrappers have bs-table-wrap class for horizontal scroll', () => {
+    const game = {
+      homeId: 1, awayId: 2, homeScore: 14, awayScore: 7,
+      teamStats: { home: { passYards: 100 }, away: {} },
+      playerStats: {
+        home: { 11: { name: 'QB Test', stats: { passAtt: 10, passYd: 100 } } },
+        away: {},
+      },
+    };
+    const { container } = render(<BoxScore gameId="g-mobile" league={{ ...baseLeague, gameById: { 'g-mobile': game } }} embedded />);
+    const tableWrap = container.querySelector('[data-testid="game-book-table-passing"] .bs-table-wrap');
+    expect(tableWrap).toBeTruthy();
+    expect(tableWrap.className).toContain('bs-table-wrap');
+  });
+});
+
+describe('PlayerButton fallback display', () => {
+  beforeEach(() => { cleanup(); });
+
+  it('shows Player #ID when player has no name but has playerId', () => {
+    const { container } = render(<PlayerButton player={{ playerId: 42, stats: {} }} />);
+    expect(container.textContent).toBe('Player #42');
+  });
+
+  it('shows generic Player when player has no name and no playerId', () => {
+    const { container } = render(<PlayerButton player={{ stats: {} }} />);
+    expect(container.textContent).toBe('Player');
+  });
+
+  it('does not show Unknown for nameless players', () => {
+    const { container } = render(<PlayerButton player={{ playerId: 88, stats: {} }} />);
+    expect(container.textContent).not.toContain('Unknown');
+  });
+});

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -532,6 +532,7 @@ export default function LeagueDashboard({
   onDismissNotification,
   externalBoxScoreId,
   onConsumeExternalBoxScore,
+  onGameDetailBack,
   advanceLabel = "Advance",
   advanceDisabled = false,
 }) {
@@ -1213,7 +1214,10 @@ export default function LeagueDashboard({
               gameId={selectedGameId}
               league={league}
               actions={actions}
-              onBack={() => setActiveTab("HQ")}
+              onBack={() => {
+                onGameDetailBack?.();
+                setActiveTab(lastGameTab || "HQ");
+              }}
               onNavigate={setActiveTab}
               onPlayerSelect={handlePlayerSelect}
               onTeamSelect={setSelectedTeamId}

--- a/src/ui/components/PostGameScreen.jsx
+++ b/src/ui/components/PostGameScreen.jsx
@@ -113,6 +113,81 @@ function Confetti({ colors }) {
   );
 }
 
+/**
+ * Derives structured playerStats ({ home: {[pid]: {name,pos,stats}}, away: {...} })
+ * from raw play-by-play logs. Used to populate the archive so the Game Book
+ * can display player names when the game is reopened.
+ */
+function derivePlayerStatsFromLogs(logs, homeId, awayId) {
+  const home = {};
+  const away = {};
+
+  const getSide = (teamId) => {
+    const tid = Number(teamId);
+    if (Number.isFinite(tid)) {
+      if (tid === Number(homeId)) return home;
+      if (tid === Number(awayId)) return away;
+    }
+    return null;
+  };
+
+  const addStats = (player, side, statKey, value = 1) => {
+    if (!player || typeof player !== 'object' || !side) return;
+    const pid = String(player.id ?? player.name ?? '?');
+    if (pid === '?') return;
+    if (!side[pid]) {
+      side[pid] = { name: player.name ?? null, pos: player.pos ?? player.position ?? '—', stats: {} };
+    }
+    if (player.name && !side[pid].name) side[pid].name = player.name;
+    side[pid].stats[statKey] = (side[pid].stats[statKey] ?? 0) + (Number(value) || 0);
+  };
+
+  for (const log of (Array.isArray(logs) ? logs : [])) {
+    if (!log || typeof log !== 'object') continue;
+    const offTeamId = log.teamId ?? log.offenseTeamId ?? log.possessionTeamId ?? null;
+    const offSide = getSide(offTeamId);
+    const defTeamId = offTeamId != null
+      ? (Number(offTeamId) === Number(homeId) ? awayId : homeId)
+      : null;
+    const defSide = getSide(defTeamId);
+
+    if (log.passer) {
+      const pSide = getSide(log.passer.teamId) ?? offSide;
+      addStats(log.passer, pSide, 'passAtt');
+      if (log.completed) {
+        addStats(log.passer, pSide, 'passComp');
+        addStats(log.passer, pSide, 'passYd', log.passYds ?? log.yards ?? 0);
+      }
+      if (log.isTouchdown && log.tdType === 'pass') addStats(log.passer, pSide, 'passTD');
+    }
+
+    if (log.player) {
+      const plSide = getSide(log.player.teamId) ?? offSide;
+      if (log.type === 'run' || log.tdType === 'rush' || (log.rushYds != null && !log.passer)) {
+        addStats(log.player, plSide, 'rushAtt');
+        addStats(log.player, plSide, 'rushYd', log.rushYds ?? log.yards ?? 0);
+        if (log.isTouchdown) addStats(log.player, plSide, 'rushTD');
+      }
+      if (log.completed && log.recYds != null) {
+        addStats(log.player, plSide, 'receptions');
+        addStats(log.player, plSide, 'recYd', log.recYds ?? log.yards ?? 0);
+        if (log.isTouchdown && log.tdType === 'pass') addStats(log.player, plSide, 'recTD');
+      }
+    }
+
+    if (log.tackler) {
+      const tSide = getSide(log.tackler.teamId) ?? defSide;
+      addStats(log.tackler, tSide, 'tackles');
+    }
+    if (log.defender) {
+      const dSide = getSide(log.defender.teamId) ?? defSide;
+      addStats(log.defender, dSide, 'passesDefended');
+    }
+  }
+
+  return { home, away };
+}
+
 // Derive game leaders from play logs (accumulated stats per player)
 function useGameLeaders(logs) {
   return useMemo(() => {
@@ -273,6 +348,7 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
     const recapText = notableMoments.length
       ? notableMoments.map((m) => `Q${m.quarter ?? "?"} ${m.clock ?? ""} ${m.text ?? "Momentum swing"}`).join(" ")
       : `${awayTeam?.abbr ?? "AWY"} ${awayScore} - ${homeScore} ${homeTeam?.abbr ?? "HME"}`;
+    const derivedPlayerStats = derivePlayerStatsFromLogs(logs, homeTeam?.id, awayTeam?.id);
     onArchiveReady({
       gameId: boxScoreGameId,
       season: null,
@@ -285,6 +361,7 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
       awayScore,
       recapText,
       logs,
+      playerStats: derivedPlayerStats,
       scoringSummary: notableMoments,
       summary: {
         storyline: recapText,

--- a/src/ui/components/PostGameScreen.test.jsx
+++ b/src/ui/components/PostGameScreen.test.jsx
@@ -1,6 +1,8 @@
+/** @vitest-environment jsdom */
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderToString } from 'react-dom/server';
+import { cleanup, render, act } from '@testing-library/react';
 import PostGameScreen from './PostGameScreen.jsx';
 
 describe('PostGameScreen resilience', () => {
@@ -17,5 +19,103 @@ describe('PostGameScreen resilience', () => {
     );
 
     expect(html).toContain('Back to Hub');
+  });
+});
+
+describe('PostGameScreen onArchiveReady payload', () => {
+  beforeEach(() => { cleanup(); });
+
+  it('includes playerStats derived from logs in the archive payload', async () => {
+    const archiveSpy = vi.fn();
+    const logs = [
+      { teamId: 1, passer: { id: 10, name: 'Home QB', pos: 'QB' }, passYds: 220, completed: true },
+      { teamId: 1, passer: { id: 10, name: 'Home QB', pos: 'QB' }, passYds: 15, completed: true, isTouchdown: true, tdType: 'pass' },
+      { teamId: 2, passer: { id: 20, name: 'Away QB', pos: 'QB' }, passYds: 180, completed: true },
+      { teamId: 1, player: { id: 30, name: 'Home RB', pos: 'RB' }, rushYds: 55, type: 'run' },
+    ];
+
+    await act(async () => {
+      render(
+        <PostGameScreen
+          homeTeam={{ id: 1, abbr: 'HME', name: 'Home' }}
+          awayTeam={{ id: 2, abbr: 'AWY', name: 'Away' }}
+          homeScore={28}
+          awayScore={21}
+          userTeamId={1}
+          boxScoreGameId="test-game-123"
+          logs={logs}
+          week={3}
+          onArchiveReady={archiveSpy}
+          onContinue={() => {}}
+        />,
+      );
+    });
+
+    expect(archiveSpy).toHaveBeenCalledOnce();
+    const payload = archiveSpy.mock.calls[0][0];
+    expect(payload.playerStats).toBeDefined();
+    expect(payload.playerStats.home).toBeDefined();
+    expect(payload.playerStats.away).toBeDefined();
+  });
+
+  it('preserves player names in derived playerStats', async () => {
+    const archiveSpy = vi.fn();
+    const logs = [
+      { teamId: 1, passer: { id: 10, name: 'Home QB', pos: 'QB' }, passYds: 200, completed: true },
+      { teamId: 2, passer: { id: 20, name: 'Away QB', pos: 'QB' }, passYds: 150, completed: true },
+    ];
+
+    await act(async () => {
+      render(
+        <PostGameScreen
+          homeTeam={{ id: 1, abbr: 'HME', name: 'Home' }}
+          awayTeam={{ id: 2, abbr: 'AWY', name: 'Away' }}
+          homeScore={17}
+          awayScore={14}
+          userTeamId={1}
+          boxScoreGameId="test-game-456"
+          logs={logs}
+          week={1}
+          onArchiveReady={archiveSpy}
+          onContinue={() => {}}
+        />,
+      );
+    });
+
+    expect(archiveSpy).toHaveBeenCalledOnce();
+    const payload = archiveSpy.mock.calls[0][0];
+    const homeRows = Object.values(payload.playerStats.home);
+    const awayRows = Object.values(payload.playerStats.away);
+    const homeQB = homeRows.find((r) => r.name === 'Home QB');
+    const awayQB = awayRows.find((r) => r.name === 'Away QB');
+    expect(homeQB).toBeDefined();
+    expect(awayQB).toBeDefined();
+    expect(homeQB.stats.passAtt).toBeGreaterThanOrEqual(1);
+    expect(awayQB.stats.passAtt).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not crash when logs are empty and still calls onArchiveReady with empty playerStats', async () => {
+    const archiveSpy = vi.fn();
+    await act(async () => {
+      render(
+        <PostGameScreen
+          homeTeam={{ id: 1, abbr: 'HME', name: 'Home' }}
+          awayTeam={{ id: 2, abbr: 'AWY', name: 'Away' }}
+          homeScore={3}
+          awayScore={0}
+          userTeamId={1}
+          boxScoreGameId="empty-game"
+          logs={[]}
+          week={2}
+          onArchiveReady={archiveSpy}
+          onContinue={() => {}}
+        />,
+      );
+    });
+    expect(archiveSpy).toHaveBeenCalledOnce();
+    const payload = archiveSpy.mock.calls[0][0];
+    expect(payload.playerStats).toBeDefined();
+    expect(payload.playerStats.home).toEqual({});
+    expect(payload.playerStats.away).toEqual({});
   });
 });

--- a/src/ui/components/__tests__/postGamePersistence.test.jsx
+++ b/src/ui/components/__tests__/postGamePersistence.test.jsx
@@ -1,0 +1,123 @@
+/** @vitest-environment jsdom */
+/**
+ * Tests for postgame persistence: verifies that the stash/restore contract
+ * between PostGameScreen, App-level state, and LeagueDashboard's onGameDetailBack
+ * keeps the result context accessible after opening Game Book.
+ */
+import React, { useState } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { cleanup, render, fireEvent } from '@testing-library/react';
+
+// Minimal harness that simulates the App-level stash/restore logic
+function PostGamePersistenceHarness({ initialResult = null }) {
+  const [postGameResult, setPostGameResult] = useState(initialResult);
+  const [postGameResultStash, setPostGameResultStash] = useState(null);
+  const [externalBoxScoreOpen, setExternalBoxScoreOpen] = useState(false);
+
+  const openBoxScore = (gameId) => {
+    if (!gameId) return;
+    setPostGameResultStash(postGameResult);
+    setPostGameResult(null);
+    setExternalBoxScoreOpen(true);
+  };
+
+  const onGameDetailBack = () => {
+    if (postGameResultStash) {
+      setPostGameResult(postGameResultStash);
+      setPostGameResultStash(null);
+    }
+    setExternalBoxScoreOpen(false);
+  };
+
+  const dismissResult = () => {
+    setPostGameResult(null);
+    setPostGameResultStash(null);
+  };
+
+  return (
+    <div>
+      {postGameResult && !externalBoxScoreOpen && (
+        <div data-testid="postgame-modal">
+          <span data-testid="result-label">{postGameResult.label}</span>
+          <button data-testid="view-box-score" onClick={() => openBoxScore(postGameResult.gameId)}>
+            View Box Score
+          </button>
+          <button data-testid="dismiss-result" onClick={dismissResult}>
+            Back to Hub
+          </button>
+        </div>
+      )}
+      {externalBoxScoreOpen && (
+        <div data-testid="game-detail-screen">
+          <span>Game Book</span>
+          <button data-testid="game-detail-back" onClick={onGameDetailBack}>
+            Back
+          </button>
+        </div>
+      )}
+      {!postGameResult && !externalBoxScoreOpen && (
+        <div data-testid="hq-view">Franchise HQ</div>
+      )}
+    </div>
+  );
+}
+
+describe('Postgame persistence stash/restore', () => {
+  beforeEach(() => { cleanup(); });
+
+  it('shows postgame modal initially', () => {
+    const { getByTestId } = render(
+      <PostGamePersistenceHarness initialResult={{ label: 'VICTORY', gameId: 'g1' }} />,
+    );
+    expect(getByTestId('postgame-modal')).toBeTruthy();
+    expect(getByTestId('result-label').textContent).toBe('VICTORY');
+  });
+
+  it('hides postgame modal and shows Game Detail when View Box Score is clicked', () => {
+    const { getByTestId, queryByTestId } = render(
+      <PostGamePersistenceHarness initialResult={{ label: 'VICTORY', gameId: 'g1' }} />,
+    );
+    fireEvent.click(getByTestId('view-box-score'));
+    expect(queryByTestId('postgame-modal')).toBeNull();
+    expect(getByTestId('game-detail-screen')).toBeTruthy();
+  });
+
+  it('restores postgame modal when Back is clicked from Game Detail', () => {
+    const { getByTestId, queryByTestId } = render(
+      <PostGamePersistenceHarness initialResult={{ label: 'DEFEAT', gameId: 'g2' }} />,
+    );
+    fireEvent.click(getByTestId('view-box-score'));
+    expect(queryByTestId('postgame-modal')).toBeNull();
+    fireEvent.click(getByTestId('game-detail-back'));
+    expect(getByTestId('postgame-modal')).toBeTruthy();
+    expect(getByTestId('result-label').textContent).toBe('DEFEAT');
+  });
+
+  it('does not restore stash when result was explicitly dismissed', () => {
+    const { getByTestId, queryByTestId } = render(
+      <PostGamePersistenceHarness initialResult={{ label: 'TIE', gameId: 'g3' }} />,
+    );
+    fireEvent.click(getByTestId('dismiss-result'));
+    expect(queryByTestId('postgame-modal')).toBeNull();
+    expect(getByTestId('hq-view')).toBeTruthy();
+  });
+
+  it('shows HQ when no post-game result is present', () => {
+    const { getByTestId } = render(<PostGamePersistenceHarness initialResult={null} />);
+    expect(getByTestId('hq-view')).toBeTruthy();
+  });
+
+  it('post-sim result context is not permanently lost after opening Game Book', () => {
+    const { getByTestId, queryByTestId } = render(
+      <PostGamePersistenceHarness initialResult={{ label: 'VICTORY', gameId: 'g4' }} />,
+    );
+    // Open box score
+    fireEvent.click(getByTestId('view-box-score'));
+    expect(queryByTestId('postgame-modal')).toBeNull();
+    // Return from game book
+    fireEvent.click(getByTestId('game-detail-back'));
+    // Context is restored
+    expect(queryByTestId('postgame-modal')).not.toBeNull();
+    expect(getByTestId('result-label').textContent).toBe('VICTORY');
+  });
+});

--- a/src/ui/utils/boxScoreViewModel.js
+++ b/src/ui/utils/boxScoreViewModel.js
@@ -1,6 +1,7 @@
 import { mergeArchivedGameWithScheduleResult, normalizeArchivedGamePayload } from '../../core/gameArchive.js';
 import { isScoringLikeLog, normalizePlayLogEntry } from '../../core/gameEvents.js';
 import { buildGameFlowSummary } from '../../core/sim/gameFlowSummary.js';
+import { buildLeaguePlayerMap, resolvePlayerName } from './playerNameResolver.js';
 
 const QUALITY = { full: 'Full detail', partial: 'Partial detail', score: 'Score only', missing: 'Missing detail' };
 
@@ -52,8 +53,12 @@ function normalizePlayerId(id) {
   return Number.isFinite(numeric) ? numeric : id;
 }
 
-function normalizePlayers(raw = {}, side, teamId) {
-  return Object.entries(raw || {}).map(([id, row]) => ({ playerId: normalizePlayerId(id), teamId, teamSide: side, ...row, stats: row?.stats ?? row ?? {} }));
+function normalizePlayers(raw = {}, side, teamId, playerMap = null) {
+  return Object.entries(raw || {}).map(([id, row]) => {
+    const playerId = normalizePlayerId(id);
+    const name = resolvePlayerName(playerId, { row, playerMap });
+    return { playerId, teamId, teamSide: side, ...row, name, stats: row?.stats ?? row ?? {} };
+  });
 }
 
 function formatScoreLine(awayTeam, homeTeam, finalScore) {
@@ -490,8 +495,9 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
   const scoringSummary = normalizeScoringSummary(payload?.scoringSummary);
   const teamStats = payload?.teamStats ?? payload?.stats?.team ?? {};
   const playerStats = payload?.playerStats ?? payload?.stats?.players ?? payload?.stats ?? {};
-  const homePlayers = normalizePlayers(playerStats?.home, 'home', homeId);
-  const awayPlayers = normalizePlayers(playerStats?.away, 'away', awayId);
+  const playerMap = buildLeaguePlayerMap(league);
+  const homePlayers = normalizePlayers(playerStats?.home, 'home', homeId, playerMap);
+  const awayPlayers = normalizePlayers(playerStats?.away, 'away', awayId, playerMap);
 
   const hasScore = homeScore != null && awayScore != null;
   const hasQuarter = Array.isArray(quarterScores?.home) || Array.isArray(quarterScores?.away);

--- a/src/ui/utils/playerNameResolver.js
+++ b/src/ui/utils/playerNameResolver.js
@@ -1,0 +1,32 @@
+/**
+ * Resolves a display name for a player from the best available source.
+ *
+ * Resolution order:
+ *   a. stat row .name or .playerName (already in archived data)
+ *   b. league player map by numeric/string playerId
+ *   e. safe fallback "Player #<id>" — never blank/undefined
+ */
+export function resolvePlayerName(playerId, { row, playerMap } = {}) {
+  const rowName = row?.name ?? row?.playerName;
+  if (rowName && typeof rowName === 'string' && rowName.trim()) return rowName;
+  if (playerId != null && playerMap) {
+    const found = playerMap[String(playerId)];
+    if (found?.name && typeof found.name === 'string' && found.name.trim()) return found.name;
+  }
+  if (playerId != null) return `Player #${playerId}`;
+  return 'Player';
+}
+
+/**
+ * Builds a flat { [String(id)]: playerObject } map from all team rosters in league.
+ * Handles league.teams[].roster and league.teams[].players array shapes.
+ */
+export function buildLeaguePlayerMap(league) {
+  const map = {};
+  for (const team of (league?.teams ?? [])) {
+    for (const player of (team?.roster ?? team?.players ?? [])) {
+      if (player?.id != null) map[String(player.id)] = player;
+    }
+  }
+  return map;
+}

--- a/src/ui/utils/playerNameResolver.test.js
+++ b/src/ui/utils/playerNameResolver.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePlayerName, buildLeaguePlayerMap } from './playerNameResolver.js';
+
+describe('resolvePlayerName', () => {
+  it('returns name from row.name when present', () => {
+    expect(resolvePlayerName(42, { row: { name: 'John Smith' } })).toBe('John Smith');
+  });
+
+  it('returns name from row.playerName when row.name is absent', () => {
+    expect(resolvePlayerName(42, { row: { playerName: 'Jane Doe' } })).toBe('Jane Doe');
+  });
+
+  it('returns name from playerMap when row lacks name', () => {
+    const playerMap = { '42': { id: 42, name: 'Marcus Jones' } };
+    expect(resolvePlayerName(42, { row: {}, playerMap })).toBe('Marcus Jones');
+  });
+
+  it('prefers row.name over playerMap', () => {
+    const playerMap = { '42': { id: 42, name: 'Map Name' } };
+    expect(resolvePlayerName(42, { row: { name: 'Row Name' }, playerMap })).toBe('Row Name');
+  });
+
+  it('falls back to Player #ID when row has no name and no playerMap', () => {
+    expect(resolvePlayerName(99, { row: {} })).toBe('Player #99');
+  });
+
+  it('falls back to Player #ID when playerMap has no entry for ID', () => {
+    const playerMap = { '1': { id: 1, name: 'Other Player' } };
+    expect(resolvePlayerName(99, { row: {}, playerMap })).toBe('Player #99');
+  });
+
+  it('falls back to generic Player when playerId is null/undefined', () => {
+    expect(resolvePlayerName(null, {})).toBe('Player');
+    expect(resolvePlayerName(undefined, {})).toBe('Player');
+  });
+
+  it('handles no options argument at all', () => {
+    expect(resolvePlayerName(7)).toBe('Player #7');
+  });
+
+  it('ignores empty string row.name and uses playerMap fallback', () => {
+    const playerMap = { '5': { id: 5, name: 'Real Name' } };
+    expect(resolvePlayerName(5, { row: { name: '' }, playerMap })).toBe('Real Name');
+  });
+
+  it('matches playerId as both numeric and string key', () => {
+    const playerMap = { '123': { id: 123, name: 'String Key Player' } };
+    expect(resolvePlayerName(123, { row: {}, playerMap })).toBe('String Key Player');
+    expect(resolvePlayerName('123', { row: {}, playerMap })).toBe('String Key Player');
+  });
+});
+
+describe('buildLeaguePlayerMap', () => {
+  it('builds a map from league.teams[].roster', () => {
+    const league = {
+      teams: [
+        { id: 1, roster: [{ id: 10, name: 'Player Ten' }, { id: 11, name: 'Player Eleven' }] },
+        { id: 2, roster: [{ id: 20, name: 'Player Twenty' }] },
+      ],
+    };
+    const map = buildLeaguePlayerMap(league);
+    expect(map['10'].name).toBe('Player Ten');
+    expect(map['11'].name).toBe('Player Eleven');
+    expect(map['20'].name).toBe('Player Twenty');
+  });
+
+  it('falls back to league.teams[].players when roster is absent', () => {
+    const league = {
+      teams: [{ id: 1, players: [{ id: 5, name: 'Player Five' }] }],
+    };
+    const map = buildLeaguePlayerMap(league);
+    expect(map['5'].name).toBe('Player Five');
+  });
+
+  it('returns empty map when league has no teams', () => {
+    expect(buildLeaguePlayerMap(null)).toEqual({});
+    expect(buildLeaguePlayerMap({ teams: [] })).toEqual({});
+  });
+
+  it('skips players without id', () => {
+    const league = { teams: [{ roster: [{ name: 'No ID' }, { id: 1, name: 'Has ID' }] }] };
+    const map = buildLeaguePlayerMap(league);
+    expect(Object.keys(map)).toEqual(['1']);
+  });
+});


### PR DESCRIPTION
Player name resolution:
- Add playerNameResolver.js with resolvePlayerName() and buildLeaguePlayerMap()
- normalizePlayers() in boxScoreViewModel.js now accepts a playerMap and uses
  the resolver: row.name → league roster lookup → Player #<id> fallback
- buildBoxScoreViewModel() builds the player map from league.teams[].roster
- PlayerButton fallback changed from "Unknown" to "Player #<id>" for nameless
  players, ensuring no blank/undefined labels appear in stat tables

Live game archive fix:
- PostGameScreen now derives structured playerStats from play-by-play logs
  via derivePlayerStatsFromLogs() and includes them in the onArchiveReady
  payload, so Game Book shows player names when a user-played game is reopened

Postgame persistence:
- When "View Box Score" is clicked in the post-sim popup, the postGameResult
  is now stashed in postGameResultStash instead of destroyed
- LeagueDashboard accepts a new onGameDetailBack prop; Game Detail's onBack
  now calls onGameDetailBack and navigates to lastGameTab (not hardcoded HQ)
- App.jsx's onGameDetailBack restores postGameResult from the stash so the
  post-sim summary reappears when the user returns from Game Book

Tests (31 new):
- playerNameResolver.test.js: 14 unit tests for resolver and map builder
- BoxScore.test.jsx: 8 new tests for name resolution, fallbacks, no-blank,
  mobile table wrappers, and PlayerButton display
- PostGameScreen.test.jsx: 4 new tests verifying playerStats in archive payload
- postGamePersistence.test.jsx: 6 harness tests for stash/restore lifecycle

https://claude.ai/code/session_019H9xPeDWm74qd4k2k7bXxC