### PR TITLE
feat(hq): V4 compact home screen — Season Pulse collapsed, no-blockers row, league links repositioned

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -142,7 +142,6 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
   );
   const lastGame = useMemo(() => getLatestUserCompletedGame(league) ?? recentLastGame ?? command.lastGameSummary ?? null, [league, recentLastGame, command.lastGameSummary]);
   const lastGameDisplay = useMemo(() => getLastGameDisplay(lastGame, league?.userTeamId), [lastGame, league?.userTeamId]);
-  const footerDays = Math.max(0, 7 - ((safeNum(league?.week, 1) - 1) % 7));
   const heroMeta = useMemo(() => {
     const homeAwayVerb = command.nextGame?.isHome ? 'vs' : '@';
     const divisionRows = command.divisionMiniStandings ?? [];
@@ -331,12 +330,11 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
         onViewAll={() => onNavigate?.('News')}
       />
 
-      <section className="app-hq-matchup-hero card" aria-label="Weekly Hero" aria-live="polite">
+      <section className="app-hq-matchup-hero card" aria-label="Weekly Hero" aria-live="polite" data-testid="hq-matchup-hero">
         <div className="app-hq-matchup-main">
           <div className="app-hq-hero-copy">
-            <span className="app-hq-matchup-hero__eyebrow">Week Command • {command.weekLabel}</span>
             <h1 className="app-hq-hero-title">{heroMeta.operationHeading}</h1>
-            <p>{nextOpponentDisplay.detail} • {heroMeta.nextOppSummary}</p>
+            <p>{nextOpponentDisplay.detail}</p>
           </div>
           <div className="app-hq-team app-hq-team--opp">
             <TeamIdentityBadge team={opponent} size={112} variant="circle" />
@@ -364,18 +362,6 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
           </div>
         </div>
 
-        <p className="app-hq-hero-footnote">Sim to Sunday • {footerDays} days until kickoff</p>
-      </section>
-      <section
-        className="card"
-        style={{ padding: 'var(--space-2)', display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center' }}
-        aria-label="League quick links"
-        data-testid="hq-league-destination-links"
-      >
-        <strong style={{ fontSize: '0.85em', opacity: 0.9 }}>League views:</strong>
-        <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('League Leaders')}>View full stats</button>
-        <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('Standings')}>Open standings</button>
-        <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('News')}>Open league news</button>
       </section>
 
       {/* ── Actions Required ─────────────────────────────────────────── */}
@@ -422,14 +408,15 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
           </div>
         </section>
       ) : (
-        <section
-          className="card app-hq-actions-required tone-ok"
+        <div
+          className="app-hq-actions-required hq-ready-status"
           aria-label="Actions Required"
           data-testid="hq-actions-required"
-          style={{ padding: 'var(--space-2)', marginBottom: 8 }}
+          data-ready="true"
         >
-          <span className="app-hq-intel-item tone-ok" style={{ margin: 0 }}>No blockers — ready to advance.</span>
-        </section>
+          <StatusChip label="Ready" tone="ok" />
+          <span style={{ fontSize: '0.85em', opacity: 0.8 }}>No blockers — ready to advance</span>
+        </div>
       )}
 
       <div
@@ -452,6 +439,18 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
             onClick={tile.onClick}
           />
         ))}
+      </div>
+
+      <div
+        className="hq-league-links"
+        style={{ display: 'flex', flexWrap: 'wrap', gap: 6, alignItems: 'center', padding: '0 var(--space-2)', marginBottom: 8 }}
+        aria-label="League quick links"
+        data-testid="hq-league-destination-links"
+      >
+        <strong style={{ fontSize: '0.8em', opacity: 0.7 }}>League views:</strong>
+        <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('League Leaders')}>View full stats</button>
+        <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('Standings')}>Open standings</button>
+        <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('News')}>Open league news</button>
       </div>
 
       {/* ── Roster Health / Office Status (twin parallel status cards) ─────── */}
@@ -534,6 +533,10 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
           {weeklyIntel.length > 1 ? (
             <p className="hq-twin-card__detail hq-intel-text--clamp">{weeklyIntel[1].text}</p>
           ) : null}
+          <p className="hq-twin-card__detail hq-twin-card__divider" style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+            <span style={{ fontSize: '0.78em', opacity: 0.65 }}>Culture</span>
+            <StatusChip label={`${culturePulse.label} ${culturePulse.trendIcon}`} tone={culturePulse.tone} />
+          </p>
           <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('Team:Front Office')}>
             Front Office
           </button>
@@ -542,6 +545,8 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
 
       {/* Next Action and Coordinator Brief panels removed — data compressed into hq-twin-grid above */}
 
+      <details className="hq-more-drawer" data-testid="hq-more-drawer">
+        <summary className="hq-more-drawer__trigger">Season Pulse &amp; More ▾</summary>
       <SectionCard title="Season Pulse" subtitle="Pressure, form, and roster leverage at a glance." variant="compact">
         <div className="app-hq-pulse-grid" data-testid="season-pulse">
           <article className={`app-hq-pulse-card tone-${seasonPulse.mandateTone}`}>
@@ -609,6 +614,7 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
           </article>
         </div>
       </SectionCard>
+      </details>
 
       {lineupToast ? <p className="app-inline-toast" role="status" aria-live="polite">{lineupToast}</p> : null}
 

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -221,6 +221,109 @@ describe('FranchiseHQ', () => {
   });
 });
 
+describe('FranchiseHQ V4 compact home screen', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders compact home structure — Season Pulse in More drawer, core elements at top level', () => {
+    render(
+      <FranchiseHQ
+        league={baseLeague}
+        onNavigate={vi.fn()}
+        onAdvanceWeek={vi.fn()}
+        busy={false}
+        simulating={false}
+      />,
+    );
+    // Top-level command elements present
+    expect(screen.getByTestId('franchise-hq')).toBeTruthy();
+    expect(screen.getByTestId('hq-actions-required')).toBeTruthy();
+    expect(screen.getByTestId('advance-week-cta')).toBeTruthy();
+    expect(screen.getByTestId('hq-matchup-hero')).toBeTruthy();
+    // Season Pulse is inside the More drawer (still reachable via testid)
+    expect(screen.getByTestId('hq-more-drawer')).toBeTruthy();
+    expect(screen.getByTestId('season-pulse')).toBeTruthy();
+  });
+
+  it('shows compact ready div — not a section card — when there are no blockers', () => {
+    const offseasonLeague = { ...baseLeague, phase: 'offseason_resign', schedule: { weeks: [] } };
+    render(
+      <FranchiseHQ
+        league={offseasonLeague}
+        onNavigate={vi.fn()}
+        onAdvanceWeek={vi.fn()}
+        busy={false}
+        simulating={false}
+      />,
+    );
+    const actionsRequired = screen.getByTestId('hq-actions-required');
+    // Must be a plain div, not a section card
+    expect(actionsRequired.tagName.toLowerCase()).toBe('div');
+    expect(actionsRequired.classList.contains('card')).toBe(false);
+    // Shows ready-state text
+    expect(actionsRequired.textContent).toMatch(/ready|no blocker/i);
+  });
+
+  it('matchup card shows last result and next opponent when available', () => {
+    render(
+      <FranchiseHQ
+        league={baseLeague}
+        onNavigate={vi.fn()}
+        onAdvanceWeek={vi.fn()}
+        busy={false}
+        simulating={false}
+      />,
+    );
+    const hero = screen.getByTestId('hq-matchup-hero');
+    // Opponent abbreviation (DET) shown in hero
+    expect(hero.textContent).toContain('DET');
+    // Last result from game g-9: W 23-20
+    const lastResultEl = document.querySelector('[data-testid="hq-last-result"]');
+    expect(lastResultEl).not.toBeNull();
+    expect(lastResultEl.textContent).toMatch(/W.*23|23.*W/i);
+  });
+
+  it('Actions Required renders with blockers when criticalCount > 0', () => {
+    // baseLeague has week 10 regular season — evaluate gate to see if it generates blockers
+    render(
+      <FranchiseHQ
+        league={baseLeague}
+        onNavigate={vi.fn()}
+        onAdvanceWeek={vi.fn()}
+        busy={false}
+        simulating={false}
+      />,
+    );
+    // hq-actions-required always renders (either blocker card or compact ready row)
+    expect(screen.getByTestId('hq-actions-required')).toBeTruthy();
+  });
+
+  it('league quick links appear after quick action tiles — not between hero and actions required', () => {
+    render(
+      <FranchiseHQ
+        league={baseLeague}
+        onNavigate={vi.fn()}
+        onAdvanceWeek={vi.fn()}
+        busy={false}
+        simulating={false}
+      />,
+    );
+    const root = screen.getByTestId('franchise-hq');
+    const html = root.innerHTML;
+    // Quick action tiles appear before league links in DOM order
+    const tilesPos = html.indexOf('app-hq-action-tiles');
+    const linksPos = html.indexOf('hq-league-destination-links');
+    expect(tilesPos).toBeGreaterThan(-1);
+    expect(linksPos).toBeGreaterThan(-1);
+    expect(tilesPos).toBeLessThan(linksPos);
+    // Hero is before actions-required in DOM
+    const heroPos = html.indexOf('hq-matchup-hero');
+    const actionsPos = html.indexOf('hq-actions-required');
+    expect(heroPos).toBeLessThan(actionsPos);
+  });
+});
+
 describe('FranchiseHQ V3 command hierarchy cleanup', () => {
   afterEach(() => {
     cleanup();

--- a/src/ui/styles/hub.css
+++ b/src/ui/styles/hub.css
@@ -712,6 +712,51 @@
   margin-top: 4px;
 }
 
+/* Compact ready status — replaces full card when no blockers */
+.hq-ready-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px var(--space-2);
+  margin-bottom: 6px;
+}
+
+/* More drawer — collapsed Season Pulse & secondary context */
+.hq-more-drawer {
+  margin-bottom: 8px;
+}
+
+.hq-more-drawer__trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px var(--space-2);
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--text-muted);
+  user-select: none;
+  list-style: none;
+  margin-bottom: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.hq-more-drawer__trigger::-webkit-details-marker {
+  display: none;
+}
+
+/* League links row — compact chip bar */
+.hq-league-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
 /* Mobile Adjustments */
 @media (max-width: 768px) {
   .team-summary-nav-card {
@@ -766,7 +811,11 @@
   }
 
   .hq-twin-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr 1fr; /* keep 2-col on mobile — tighter summary row */
+  }
+  .hq-twin-card .hq-game-plan-accordion,
+  .hq-twin-card .hq-intel-text--clamp {
+    display: none; /* hide non-essential in compact 2-col mobile view */
   }
 }
 


### PR DESCRIPTION
- Wrap Season Pulse (5 cards) in a collapsed <details hq-more-drawer> so it no longer
  contributes vertical height on first load; all navigation targets remain accessible.
- Change the "no blockers" Actions Required branch from a full <section class="card"> to a
  compact <div class="hq-ready-status"> with a single Ready chip + one-liner — per spec.
- Move league quick links (View full stats / Standings / News) from between the matchup hero
  and Actions Required to after the Quick Action tiles, improving command-screen flow.
- Add Team Culture chip (label + trend icon) inline inside the Office Status twin card so
  culture state is visible without opening Season Pulse.
- Add data-testid="hq-matchup-hero" to the matchup hero section for test targeting.
- Remove matchup hero eyebrow span and footnote line to reduce hero vertical height.
- Fix twin-grid mobile CSS: keep 2-column at ≤768 px (was 1-col stacking) and hide
  non-essential intel/accordion content in compact mobile view.
- Add CSS classes: .hq-ready-status, .hq-more-drawer, .hq-more-drawer__trigger, .hq-league-links.
- Add 5 new tests in FranchiseHQ V4 compact home screen suite covering: compact structure,
  compact ready div (not a card), matchup card result/opponent, DOM order assertion,
  and blockers-always-present invariant.

No changes to sim logic, worker, box score modal, name resolver, or save schema.
Tests: 250 files, 2304 tests, all pass. Build: clean.

https://claude.ai/code/session_01R4FJb81awDjq76a2CLSAdc