### PR TITLE
feat: live game player identity & match center presentation V1

### DIFF
--- a/src/core/__tests__/liveGamePlayerIdentity.test.js
+++ b/src/core/__tests__/liveGamePlayerIdentity.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { buildDefaultLeague } from '../../data/defaultLeague.ts';
+import { buildLeaguePlayerMap, resolvePlayerName } from '../../ui/utils/playerNameResolver.js';
+
+// ─── defaultLeague name generation ───────────────────────────────────────────
+
+describe('buildDefaultLeague — player names', () => {
+  const league = buildDefaultLeague({ userTeamId: 0 });
+
+  it('generates non-placeholder names for all roster players', () => {
+    const STARTER_RE = /\bstarter\b/i;
+    for (const team of league.teams) {
+      for (const player of team.roster) {
+        expect(player.name, `Team ${team.id} player id=${player.id}`).toBeTruthy();
+        expect(STARTER_RE.test(player.name), `Starter placeholder found: "${player.name}"`).toBe(false);
+      }
+    }
+  });
+
+  it('names look like "FirstName LastName" (two words, no position prefix)', () => {
+    for (const team of league.teams) {
+      for (const player of team.roster) {
+        const parts = player.name.trim().split(/\s+/);
+        expect(parts.length, `Expected 2 name parts, got "${player.name}"`).toBe(2);
+        // First part should not be a position abbreviation
+        expect(parts[0]).not.toMatch(/^(QB|RB|WR|TE|OL|DL|LB|CB|S|K|P|EDGE|DE|DT)$/i);
+      }
+    }
+  });
+
+  it('name generation is deterministic — same league produces identical names', () => {
+    const league2 = buildDefaultLeague({ userTeamId: 0 });
+    for (let t = 0; t < league.teams.length; t++) {
+      for (let p = 0; p < league.teams[t].roster.length; p++) {
+        expect(league.teams[t].roster[p].name).toBe(league2.teams[t].roster[p].name);
+      }
+    }
+  });
+
+  it('player IDs, ratings, pos, depthOrder are unchanged by name generation', () => {
+    // Spot-check: first QB on team 0 should be id=1, pos=QB, depthOrder=1
+    const team0 = league.teams[0];
+    const qbs = team0.roster.filter((p) => p.pos === 'QB');
+    expect(qbs.length).toBeGreaterThanOrEqual(1);
+    expect(qbs[0].pos).toBe('QB');
+    expect(typeof qbs[0].ovr).toBe('number');
+    expect(qbs[0].ovr).toBeGreaterThan(0);
+    expect(qbs[0].teamId).toBe(0);
+  });
+
+  it('buildLeaguePlayerMap treats generated names as real (not placeholder)', () => {
+    const playerMap = buildLeaguePlayerMap(league);
+    // All roster players should be in the map and their names should resolve
+    const firstPlayer = league.teams[0].roster[0];
+    const resolved = resolvePlayerName(firstPlayer.id, { playerMap });
+    expect(resolved).toBe(firstPlayer.name);
+    expect(resolved).not.toMatch(/^Player #/);
+    expect(resolved).not.toMatch(/\bstarter\b/i);
+  });
+});
+
+// ─── Live play-log text sanity ────────────────────────────────────────────────
+
+describe('simGameStats play logs — no placeholder names in text', () => {
+  it('play logs with defaultLeague players use clean names (no "Starter", no double-pos)', async () => {
+    const { simGameStats } = await import('../../core/game-simulator.js').catch(() =>
+      import('../game-simulator.js'),
+    );
+    const league = buildDefaultLeague({ userTeamId: 0 });
+    const home = league.teams[0];
+    const away = league.teams[1];
+
+    const result = simGameStats(home, away, { league, generateLogs: true });
+    expect(result).toBeTruthy();
+
+    const logs = result?.playLogs ?? [];
+    expect(logs.length).toBeGreaterThan(0);
+
+    for (const log of logs) {
+      const text = String(log.text || log.playText || '');
+      expect(text, `Play log contains "Starter": "${text}"`).not.toMatch(/\bStarter\b/);
+      // Reject double-position patterns like "QB QB" or "WR WR"
+      expect(text, `Play log has double pos prefix: "${text}"`).not.toMatch(/\b(QB|RB|WR|TE|DL|LB|CB|S)\s+\1\b/i);
+    }
+  });
+});

--- a/src/core/game-simulator.js
+++ b/src/core/game-simulator.js
@@ -1915,8 +1915,20 @@ export function simGameStats(home, away, options = {}) {
             for (let i = 0; i < pool.length; i++) { r -= weights[i]; if (r <= 0) return pool[i]; }
             return pool[0];
         };
-        // Format: "QB Patrick Mahomes" → pos + full name
-        const _n = (p) => p ? `${p.pos || ''} ${p.name || '?'}`.trim() : null;
+        // Format compact display name; guards against double position prefix and placeholder names.
+        const _n = (p) => {
+          if (!p) return null;
+          const name = String(p.name || '').trim();
+          const pos = String(p.pos || '').trim();
+          const isPlaceholder = !name
+            || /\bstarter\b/i.test(name)
+            || /^[HA]\s+(QB|RB|WR|TE|OL|DL|LB|CB|S|K|P|EDGE|DE|DT|FS|SS|FB|OT|OG|C)\d+$/i.test(name)
+            || /^player\s*#?\s*\d+$/i.test(name)
+            || /^unknown(\s+player)?$/i.test(name);
+          if (isPlaceholder) return pos ? `${pos} #${p.id ?? '?'}` : `#${p.id ?? '?'}`;
+          const parts = name.split(/\s+/);
+          return parts.length >= 2 ? `${parts[0][0]}. ${parts[parts.length - 1]}` : name;
+        };
 
         // Live per-play stat fields (accumulated over logs for live display)
         const liveStats = {};

--- a/src/data/defaultLeague.ts
+++ b/src/data/defaultLeague.ts
@@ -39,6 +39,43 @@ const RATING_KEYS = [
   'kickAccuracy',
 ];
 
+// Deterministic name generation — names are stable for a given (teamId, index) seed.
+const FIRST_NAMES = [
+  'Aaron','Andre','Austin','Blake','Brandon','Brett','Brian','Cameron','Carlos','Chase',
+  'Christian','Colin','Curtis','Damon','Darren','Derek','Devon','Dillon','Dominic','Dylan',
+  'Elijah','Ethan','Evan','Fabian','Felix','Finn','Frank','Grant','Greg','Hunter',
+  'Isaiah','Ivan','Jared','Jason','Jordan','Justin','Kevin','Kyle','Landon','Liam',
+  'Logan','Lucas','Malik','Marcus','Mason','Matt','Mike','Nathan','Nick','Noah',
+  'Omar','Parker','Patrick','Quinn','Ramon','Ryan','Sam','Sean','Trey','Tyler',
+  'Victor','Wesley','Xavier','Zach',
+] as const;
+
+const LAST_NAMES = [
+  'Adams','Allen','Anderson','Baker','Barnes','Bell','Bennett','Black','Boyd','Brown',
+  'Butler','Campbell','Carter','Clark','Cole','Collins','Cook','Cooper','Cox','Cruz',
+  'Davis','Dixon','Edwards','Elliott','Ellis','Evans','Fisher','Fletcher','Ford','Foster',
+  'Garcia','Gonzalez','Green','Griffin','Hall','Harris','Hayes','Hernandez','Hill','Howard',
+  'Ingram','Jackson','James','Johnson','Jones','Jordan','Kelly','King','Knight','Lawrence',
+  'Lee','Lewis','Long','Lopez','Lynch','Martin','Martinez','Miller','Mitchell','Moore',
+  'Morgan','Morris','Murphy','Murray','Nelson','Ortiz','Parker','Perez','Perry','Phillips',
+  'Price','Reid','Rivera','Roberts','Robinson','Rodriguez','Ross','Russell','Sanchez','Sanders',
+  'Scott','Shaw','Smith','Taylor','Thomas','Thompson','Turner','Walker','Ward','Washington',
+  'White','Williams','Wilson','Wood','Wright','Young',
+] as const;
+
+function seededPick<T extends readonly string[]>(arr: T, seed: number): T[number] {
+  let t = ((seed * 2654435761) >>> 0);
+  t = (t + 0x6D2B79F5) | 0;
+  let r = Math.imul(t ^ (t >>> 15), 1 | t);
+  r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+  return arr[((r ^ (r >>> 14)) >>> 0) % arr.length];
+}
+
+function generatePlayerName(teamId: number, index: number): string {
+  const seed = (teamId * 997 + index) * 1000003;
+  return `${seededPick(FIRST_NAMES, seed)} ${seededPick(LAST_NAMES, seed + 499979)}`;
+}
+
 function buildRatings(pos: string, ovr: number) {
   const ratings = Object.fromEntries(RATING_KEYS.map((key) => [key, Math.max(45, Math.min(90, ovr - 2))]));
   const boost = (keys: string[], amount = 8) => {
@@ -67,7 +104,7 @@ function makePlayer(teamId: number, index: number, pos: string, depthOrder: numb
   const id = teamId * 1000 + index + 1;
   return {
     id,
-    name: `${pos} Starter ${teamId + 1}-${depthOrder}`,
+    name: generatePlayerName(teamId, index),
     pos,
     age: 23 + ((teamId + index) % 10),
     ratings,

--- a/src/ui/components/GameEventFeed/GameEventFeed.jsx
+++ b/src/ui/components/GameEventFeed/GameEventFeed.jsx
@@ -1,33 +1,56 @@
 import React from 'react';
 import { getEventTags } from '../../utils/liveGamePresentation.js';
 
+const TAG_CLASS = {
+  TD:         'feed-tag-td',
+  INT:        'feed-tag-turnover',
+  FUM:        'feed-tag-turnover',
+  SACK:       'feed-tag-sack',
+  'BIG PLAY': 'feed-tag-bigplay',
+  'RED ZONE': 'feed-tag-redzone',
+  CLUTCH:     'feed-tag-clutch',
+};
+
 export default function GameEventFeed({ events = [], activeIndex = 0 }) {
   const visible = events.slice(Math.max(0, activeIndex - 20), activeIndex + 1);
   let previousQuarter = null;
+  let previousPossession = null;
   return (
     <div className="live-feed">
       {visible.map((event, idx) => {
         const tags = getEventTags(event);
         const isLatest = idx === visible.length - 1;
-        const scoreText = event.score ? `${event.score.away}-${event.score.home}` : '';
+        const scoreText = event.score ? `${event.score.away}–${event.score.home}` : '';
         const isMajor = ['touchdown', 'field_goal', 'turnover', 'sack', 'explosive_play', 'game_end', 'turning_point'].includes(event.eventType);
         const showQuarterMarker = previousQuarter !== null && previousQuarter !== event.quarter;
+        const showPossessionDivider = !showQuarterMarker
+          && previousPossession !== null
+          && event.possessionTeamId != null
+          && previousPossession !== event.possessionTeamId
+          && !['halftime', 'quarter_end', 'game_end'].includes(event.eventType);
         previousQuarter = event.quarter;
+        previousPossession = event.possessionTeamId ?? previousPossession;
         return (
           <React.Fragment key={event.id || idx}>
             {showQuarterMarker ? (
               <div className="feed-quarter-marker" aria-hidden="true">
-                Start Q{event.quarter}
+                {event.eventType === 'halftime' ? 'Halftime' : `Q${event.quarter}`}
               </div>
+            ) : showPossessionDivider ? (
+              <div className="feed-possession-divider" aria-hidden="true" />
             ) : null}
-            <article className={`feed-row ${isLatest ? 'latest' : ''} ${isMajor ? 'major' : 'routine'}`}>
-              <div className="feed-time">Q{event.quarter} {event.clock}</div>
+            <article className={`feed-row${isLatest ? ' latest' : ''}${isMajor ? ' major' : ' routine'}`}>
+              <div className="feed-time">Q{event.quarter} <span className="feed-clock">{event.clock}</span></div>
               <div className="feed-body">
                 <div className="feed-headline">{event.headline}</div>
-                <div className="feed-meta">
-                  {scoreText ? <span className="feed-score">{scoreText}</span> : null}
-                  {tags.map((tag) => <span key={tag} className="feed-tag">{tag}</span>)}
-                </div>
+                {(scoreText || tags.length > 0) ? (
+                  <div className="feed-meta">
+                    {scoreText ? <span className="feed-score">{scoreText}</span> : null}
+                    {tags.map((tag) => (
+                      <span key={tag} className={`feed-tag ${TAG_CLASS[tag] || 'feed-tag-default'}`}>{tag}</span>
+                    ))}
+                  </div>
+                ) : null}
               </div>
             </article>
           </React.Fragment>

--- a/src/ui/components/LiveGameViewer.jsx
+++ b/src/ui/components/LiveGameViewer.jsx
@@ -5,15 +5,15 @@ import { mapArchiveEventsToLiveFeed, getNextImportantEvent } from '../../core/li
 import { getCurrentStandoutPlayers, summarizeGameSwing } from '../utils/liveGamePresentation.js';
 
 const SPEED_STEPS = [
-  { key: 'slow', label: 'Slow', ms: 1400 },
-  { key: 'normal', label: 'Normal', ms: 850 },
-  { key: 'fast', label: 'Fast', ms: 350 },
-  { key: 'veryFast', label: 'Very Fast', ms: 140 },
+  { key: 'slow',     label: 'Slow',      ms: 1400 },
+  { key: 'normal',   label: 'Normal',    ms: 850  },
+  { key: 'fast',     label: 'Fast',      ms: 350  },
+  { key: 'veryFast', label: '2×',        ms: 140  },
 ];
 
 const TENDENCY_CONFIG = {
-  AGGRESSIVE:   { label: 'Aggressive',   chipClass: 'aggressive' },
-  BALANCED:     { label: 'Balanced',     chipClass: 'balanced' },
+  AGGRESSIVE:   { label: 'Aggressive',   chipClass: 'aggressive'   },
+  BALANCED:     { label: 'Balanced',     chipClass: 'balanced'     },
   CONSERVATIVE: { label: 'Conservative', chipClass: 'conservative' },
 };
 
@@ -107,36 +107,52 @@ export default function LiveGameViewer({ logs = [], homeTeam, awayTeam, onComple
         <section className="watch-panel">
           <div className={`momentum ${swing.tone}`}>Momentum: {swing.label}</div>
           <div className="jump-row">
-            <JumpBtn label="Scoring Plays" onClick={() => setIndex(getNextImportantEvent(events, index, 'score'))} />
+            <JumpBtn label="Scores" onClick={() => setIndex(getNextImportantEvent(events, index, 'score'))} />
             <JumpBtn label="Red Zone" onClick={() => setIndex(getNextImportantEvent(events, index, 'redZone'))} />
             <JumpBtn label="Turnovers" onClick={() => setIndex(getNextImportantEvent(events, index, 'turnover'))} />
-            <JumpBtn label="Final Minutes" onClick={() => setIndex(getNextImportantEvent(events, index, 'finalMinutes'))} />
+            <JumpBtn label="Late Game" onClick={() => setIndex(getNextImportantEvent(events, index, 'finalMinutes'))} />
             <JumpBtn label="End" onClick={() => setIndex(events.length - 1)} />
           </div>
           <GameEventFeed events={events} activeIndex={index} />
         </section>
 
         <aside className="watch-side">
-          <h3>Standouts</h3>
-          <ul>
-            <li>QB: {formatQb(standout.qb)}</li>
-            <li>Rush: {formatRush(standout.rusher)}</li>
-            <li>Rec: {formatRec(standout.receiver)}</li>
-            <li>Sacks: {standout.sacks ? `${standout.sacks.player} (${standout.sacks.sacks})` : '—'}</li>
-            <li>INT: {standout.picks ? `${standout.picks.player} (${standout.picks.picks})` : '—'}</li>
+          <h3 className="watch-side-title">Standouts</h3>
+          <ul className="standout-list">
+            <li><span className="standout-pos">QB</span>{formatQb(standout.qb)}</li>
+            <li><span className="standout-pos">Rush</span>{formatRush(standout.rusher)}</li>
+            <li><span className="standout-pos">Rec</span>{formatRec(standout.receiver)}</li>
+            <li><span className="standout-pos">Sacks</span>{standout.sacks ? `${standout.sacks.player} (${standout.sacks.sacks})` : '—'}</li>
+            <li><span className="standout-pos">INT</span>{standout.picks ? `${standout.picks.player} (${standout.picks.picks})` : '—'}</li>
           </ul>
+
           <div className="controls">
-            <button onClick={() => setPaused((prev) => !prev)}>{paused ? 'Resume' : 'Pause'}</button>
-            {SPEED_STEPS.map((step) => (
-              <button key={step.key} className={speed === step.key ? 'active' : ''} onClick={() => { setSpeed(step.key); setPaused(false); }}>{step.label}</button>
-            ))}
-            <button title="Lean run on next drive." onClick={() => onPlaycallOverride?.({ type: 'run_heavy' })}>Run Heavy</button>
-            <button title="Lean pass on next drive." onClick={() => onPlaycallOverride?.({ type: 'pass_heavy' })}>Pass Heavy</button>
-            <button title="Request a timeout for your team." onClick={() => onPlaycallOverride?.({ type: 'timeout' })}>Timeout</button>
-            <button onClick={() => setIndex(getNextImportantEvent(events, index, 'score'))}>Skip to Next Score</button>
-            <button onClick={() => setIndex(getNextImportantEvent(events, index, 'keyPlay'))}>Skip to Key Play</button>
-            <button onClick={() => setIndex(events.length - 1)}>Sim to End</button>
+            <div className="controls-label">Speed</div>
+            <div className="speed-row">
+              <button className="ctrl-btn pause-btn" onClick={() => setPaused((prev) => !prev)}>{paused ? '▶' : '⏸'}</button>
+              {SPEED_STEPS.map((step) => (
+                <button key={step.key} className={`ctrl-btn${speed === step.key && !paused ? ' active' : ''}`}
+                  onClick={() => { setSpeed(step.key); setPaused(false); }}>{step.label}</button>
+              ))}
+            </div>
+            <div className="controls-label">Skip</div>
+            <div className="skip-row">
+              <button className="ctrl-btn" onClick={() => setIndex(getNextImportantEvent(events, index, 'score'))}>Next Score</button>
+              <button className="ctrl-btn" onClick={() => setIndex(getNextImportantEvent(events, index, 'keyPlay'))}>Key Play</button>
+              <button className="ctrl-btn" onClick={() => setIndex(events.length - 1)}>Sim End</button>
+            </div>
+            {onPlaycallOverride ? (
+              <>
+                <div className="controls-label">Playcall</div>
+                <div className="playcall-row">
+                  <button className="ctrl-btn" title="Lean run on next drive." onClick={() => onPlaycallOverride?.({ type: 'run_heavy' })}>Run Heavy</button>
+                  <button className="ctrl-btn" title="Lean pass on next drive." onClick={() => onPlaycallOverride?.({ type: 'pass_heavy' })}>Pass Heavy</button>
+                  <button className="ctrl-btn" title="Request a timeout." onClick={() => onPlaycallOverride?.({ type: 'timeout' })}>Timeout</button>
+                </div>
+              </>
+            ) : null}
           </div>
+
           {finished ? (
             <div className="watch-final-card">
               <div className="watch-final-label">Final</div>
@@ -165,57 +181,94 @@ function ordinal(n) {
 }
 
 function formatQb(v) { return v ? `${v.player} ${v.comp}/${v.att} ${v.yds}y ${v.td}TD` : '—'; }
-function formatRush(v) { return v ? `${v.player} ${v.yds}y (${v.att} att)` : '—'; }
-function formatRec(v) { return v ? `${v.player} ${v.rec} rec, ${v.yds}y` : '—'; }
+function formatRush(v) { return v ? `${v.player} ${v.yds}y (${v.att})` : '—'; }
+function formatRec(v) { return v ? `${v.player} ${v.rec} rec ${v.yds}y` : '—'; }
 
 const styles = `
-.watch-overlay { position: fixed; inset: 0; background: #071021; color: #f3f6ff; z-index: 7000; display:flex; flex-direction:column; }
-.watch-header { position: sticky; top: 0; z-index: 2; padding: 10px; background: #071021; border-bottom: 1px solid #253149; }
-.watch-state-strip { display:flex; align-items:center; gap: 6px; margin-top: 8px; flex-wrap: wrap; }
-.watch-mode-chip { font-size: 11px; border-radius: 999px; padding: 3px 9px; border: 1px solid #3d4d6d; background: #12213b; color: #d9e7ff; }
-.watch-mode-chip.clutch { border-color: #d6a94f; color: #ffd88f; }
-.watch-mode-chip.final { border-color: #56b58a; color: #91f0c3; }
-.watch-mode-chip.tendency-aggressive { border-color: #ff453a; color: #ffb3b0; background: rgba(255,69,58,0.15); }
-.watch-mode-chip.tendency-balanced { border-color: #0a84ff; color: #a8d4ff; background: rgba(10,132,255,0.12); }
-.watch-mode-chip.tendency-conservative { border-color: #34c759; color: #a3f0b8; background: rgba(52,199,89,0.12); }
-.watch-moment-banner { margin-top: 8px; font-size: 12px; font-weight: 800; border-radius: 9px; padding: 7px 10px; letter-spacing: .01em; }
-.watch-moment-banner.score { background: rgba(95, 190, 130, 0.22); color: #b8f5cb; border: 1px solid rgba(95, 190, 130, 0.45); }
-.watch-moment-banner.turnover { background: rgba(255, 95, 95, 0.2); color: #ffd1d1; border: 1px solid rgba(255, 95, 95, 0.45); }
-.watch-moment-banner.lead { background: rgba(124, 196, 255, 0.2); color: #d5ebff; border: 1px solid rgba(124, 196, 255, 0.45); }
-.watch-moment-banner.final { background: rgba(255, 215, 100, 0.2); color: #ffeec6; border: 1px solid rgba(255, 215, 100, 0.5); }
-.live-scorebug { display:grid; grid-template-columns: 1fr auto 1fr; gap: 8px; align-items:center; }
-.sb-team { display:flex; justify-content:space-between; align-items:center; background:#111c33; border:1px solid #30405f; padding:8px 10px; border-radius:10px; }
-.sb-team.has-ball { border-color:#fbbf24; box-shadow: inset 0 0 0 1px #fbbf24; }
+/* ── Layout ─────────────────────────────────────────────────────────── */
+.watch-overlay { position:fixed; inset:0; background:#071021; color:#f3f6ff; z-index:7000; display:flex; flex-direction:column; overflow:hidden; }
+.watch-header { position:sticky; top:0; z-index:2; padding:8px 10px; background:#071021; border-bottom:1px solid #253149; }
+.watch-state-strip { display:flex; align-items:center; gap:5px; margin-top:6px; flex-wrap:wrap; }
+.watch-main { display:grid; grid-template-columns:minmax(0,1fr); gap:8px; padding:8px; flex:1; overflow:hidden; min-height:0; }
+@media (min-width:960px) { .watch-main { grid-template-columns:2fr 1fr; } }
+.watch-panel, .watch-side { background:#0f172b; border:1px solid #2d3a55; border-radius:12px; padding:10px; overflow:auto; }
+
+/* ── Mode chips ──────────────────────────────────────────────────────── */
+.watch-mode-chip { font-size:11px; border-radius:999px; padding:3px 8px; border:1px solid #3d4d6d; background:#12213b; color:#d9e7ff; }
+.watch-mode-chip.clutch { border-color:#d6a94f; color:#ffd88f; }
+.watch-mode-chip.final { border-color:#56b58a; color:#91f0c3; }
+.watch-mode-chip.tendency-aggressive { border-color:#ff453a; color:#ffb3b0; background:rgba(255,69,58,.15); }
+.watch-mode-chip.tendency-balanced { border-color:#0a84ff; color:#a8d4ff; background:rgba(10,132,255,.12); }
+.watch-mode-chip.tendency-conservative { border-color:#34c759; color:#a3f0b8; background:rgba(52,199,89,.12); }
+
+/* ── Moment banner ───────────────────────────────────────────────────── */
+.watch-moment-banner { margin-top:6px; font-size:12px; font-weight:800; border-radius:8px; padding:5px 10px; }
+.watch-moment-banner.score { background:rgba(95,190,130,.22); color:#b8f5cb; border:1px solid rgba(95,190,130,.45); }
+.watch-moment-banner.turnover { background:rgba(255,95,95,.2); color:#ffd1d1; border:1px solid rgba(255,95,95,.45); }
+.watch-moment-banner.lead { background:rgba(124,196,255,.2); color:#d5ebff; border:1px solid rgba(124,196,255,.45); }
+.watch-moment-banner.final { background:rgba(255,215,100,.2); color:#ffeec6; border:1px solid rgba(255,215,100,.5); }
+
+/* ── Scorebug ────────────────────────────────────────────────────────── */
+.live-scorebug { display:grid; grid-template-columns:1fr auto 1fr; gap:8px; align-items:center; }
+.sb-team { display:flex; justify-content:space-between; align-items:center; background:#111c33; border:1px solid #30405f; padding:7px 10px; border-radius:9px; }
+.sb-team.has-ball { border-color:#fbbf24; box-shadow:inset 0 0 0 1px #fbbf24; }
 .sb-center { text-align:center; font-size:12px; color:#d0dbf5; }
 .sb-flags { display:flex; justify-content:center; gap:4px; margin-top:4px; flex-wrap:wrap; }
-.sb-flag { font-size: 9px; font-weight: 800; letter-spacing: .05em; border-radius: 999px; padding: 2px 6px; background: #1c2f4d; border: 1px solid #3d5b88; }
-.sb-flag.redzone { border-color: #8a3e3e; background: #3c1d28; color: #ffb9b9; }
-.sb-flag.clutch { border-color: #8f6f2b; background: #3a2f18; color: #ffe4a3; }
-.sb-flag.overtime { border-color: #5377b0; background: #1c335d; color: #c6ddff; }
-.watch-main { display:grid; grid-template-columns: minmax(0, 1fr); gap: 10px; padding: 10px; height: 100%; overflow: hidden; }
-.watch-panel, .watch-side { background:#0f172b; border:1px solid #2d3a55; border-radius:12px; padding:10px; overflow:auto; }
-.momentum { font-size:12px; margin-bottom:8px; padding:6px 8px; border-radius:8px; font-weight:700; }
-.momentum.offense { background:#173b2f; } .momentum.defense { background:#3d2527; } .momentum.swing { background:#3b2f18; } .momentum.neutral { background:#253149; }
-.jump-row { display:flex; gap:6px; overflow:auto; padding-bottom:6px; }
-.jump-btn { white-space:nowrap; background:#182741; color:#d8e6ff; border:1px solid #37527d; border-radius:999px; padding:6px 10px; font-size:12px; }
-.live-feed { display:grid; gap:8px; }
-.feed-quarter-marker { font-size: 10px; color: #90a7cf; text-transform: uppercase; letter-spacing: .08em; border-top: 1px dashed #334866; padding-top: 8px; margin-top: 2px; }
-.feed-row { display:grid; grid-template-columns:auto 1fr; gap:8px; border-left:2px solid #344766; padding:6px 0 6px 8px; border-radius: 8px; }
-.feed-row.routine { background: rgba(18,31,53,0.4); }
-.feed-row.major { background: rgba(33,54,88,0.62); border-left-color: #6ca3df; }
-.feed-row.latest { border-left-color:#7cc4ff; background:#13213a; box-shadow: inset 0 0 0 1px rgba(124, 196, 255, 0.2); }
-.feed-time { font-size:11px; color:#9fb4d8; }
-.feed-headline { font-size:13px; font-weight: 600; }
-.feed-meta { display:flex; gap:6px; flex-wrap:wrap; font-size:11px; color:#9fb4d8; }
-.feed-score { font-weight: 700; color: #d8e8ff; }
-.feed-tag { background:#1b2f4f; border:1px solid #415d89; border-radius:999px; padding:1px 6px; }
-.watch-side ul { margin: 0; padding-left: 16px; display:grid; gap:4px; }
-.controls { display:grid; gap:6px; margin-top:10px; }
-.controls button, .finish { background:#1c2e4d; color:white; border:1px solid #456596; border-radius:8px; padding:8px; }
-.controls .active { border-color:#7cc4ff; }
-.watch-final-card { border: 1px solid #3d5378; border-radius: 10px; margin-top: 12px; padding: 10px; background: #13203a; }
-.watch-final-label { text-transform: uppercase; font-size: 11px; letter-spacing: .08em; color: #98b4dd; margin-bottom: 4px; }
-.watch-final-score { display:flex; flex-direction: column; gap:4px; font-size: 15px; font-weight: 800; color: #ecf4ff; }
-.finish { margin-top:10px; width:100%; background:#1d4ed8; font-weight: 800; }
-@media (min-width: 960px) { .watch-main { grid-template-columns: 2fr 1fr; } }
+.sb-flag { font-size:9px; font-weight:800; letter-spacing:.05em; border-radius:999px; padding:2px 6px; background:#1c2f4d; border:1px solid #3d5b88; }
+.sb-flag.redzone { border-color:#8a3e3e; background:#3c1d28; color:#ffb9b9; }
+.sb-flag.clutch { border-color:#8f6f2b; background:#3a2f18; color:#ffe4a3; }
+.sb-flag.overtime { border-color:#5377b0; background:#1c335d; color:#c6ddff; }
+
+/* ── Momentum / jump row ─────────────────────────────────────────────── */
+.momentum { font-size:11px; margin-bottom:7px; padding:5px 8px; border-radius:7px; font-weight:700; }
+.momentum.offense { background:#173b2f; }
+.momentum.defense { background:#3d2527; }
+.momentum.swing { background:#3b2f18; }
+.momentum.neutral { background:#253149; }
+.jump-row { display:flex; gap:5px; overflow-x:auto; padding-bottom:5px; -webkit-overflow-scrolling:touch; }
+.jump-btn { white-space:nowrap; background:#182741; color:#d8e6ff; border:1px solid #37527d; border-radius:999px; padding:5px 10px; font-size:11px; cursor:pointer; flex-shrink:0; }
+
+/* ── Live feed ───────────────────────────────────────────────────────── */
+.live-feed { display:grid; gap:5px; }
+.feed-quarter-marker { font-size:10px; color:#90a7cf; text-transform:uppercase; letter-spacing:.08em; border-top:1px dashed #334866; padding-top:6px; margin-top:2px; }
+.feed-possession-divider { height:1px; background:rgba(61,77,109,.5); margin:2px 0; }
+.feed-row { display:grid; grid-template-columns:42px 1fr; gap:6px; border-left:2px solid #344766; padding:5px 0 5px 7px; border-radius:6px; }
+.feed-row.routine { background:rgba(18,31,53,.4); }
+.feed-row.major { background:rgba(33,54,88,.62); border-left-color:#6ca3df; }
+.feed-row.latest { border-left-color:#7cc4ff; background:#13213a; box-shadow:inset 0 0 0 1px rgba(124,196,255,.2); }
+.feed-time { font-size:10px; color:#9fb4d8; line-height:1.3; }
+.feed-clock { display:block; font-size:9px; color:#6b84aa; }
+.feed-headline { font-size:13px; font-weight:600; line-height:1.35; word-break:break-word; }
+.feed-meta { display:flex; gap:4px; flex-wrap:wrap; font-size:10px; margin-top:3px; align-items:center; }
+.feed-score { font-weight:700; color:#d8e8ff; }
+/* Impact badges */
+.feed-tag { border-radius:999px; padding:1px 6px; font-size:9px; font-weight:800; letter-spacing:.04em; white-space:nowrap; }
+.feed-tag-td { background:rgba(56,161,105,.25); color:#68d391; border:1px solid rgba(56,161,105,.5); }
+.feed-tag-turnover { background:rgba(229,62,62,.2); color:#fc8181; border:1px solid rgba(229,62,62,.45); }
+.feed-tag-sack { background:rgba(214,169,79,.2); color:#fbd38d; border:1px solid rgba(214,169,79,.4); }
+.feed-tag-bigplay { background:rgba(99,179,237,.2); color:#90cdf4; border:1px solid rgba(99,179,237,.4); }
+.feed-tag-redzone { background:rgba(197,48,48,.2); color:#feb2b2; border:1px solid rgba(197,48,48,.4); }
+.feed-tag-clutch { background:rgba(159,122,234,.2); color:#d6bcfa; border:1px solid rgba(159,122,234,.4); }
+.feed-tag-default { background:#1b2f4f; color:#a0aec0; border:1px solid #415d89; }
+
+/* ── Standouts ───────────────────────────────────────────────────────── */
+.watch-side-title { margin:0 0 8px; font-size:13px; font-weight:700; color:#c8d8f5; }
+.standout-list { margin:0; padding:0; list-style:none; display:grid; gap:4px; }
+.standout-list li { display:flex; align-items:baseline; gap:6px; font-size:12px; line-height:1.4; }
+.standout-pos { font-size:9px; font-weight:800; text-transform:uppercase; letter-spacing:.06em; color:#6a87b8; min-width:32px; flex-shrink:0; }
+
+/* ── Controls ────────────────────────────────────────────────────────── */
+.controls { margin-top:10px; display:grid; gap:4px; }
+.controls-label { font-size:9px; font-weight:700; text-transform:uppercase; letter-spacing:.07em; color:#4d6a96; margin-top:4px; }
+.speed-row, .skip-row, .playcall-row { display:flex; gap:4px; flex-wrap:wrap; }
+.ctrl-btn { background:#1c2e4d; color:#c8d8f5; border:1px solid #456596; border-radius:7px; padding:5px 9px; font-size:11px; cursor:pointer; white-space:nowrap; }
+.ctrl-btn.active { border-color:#7cc4ff; color:#b8e0ff; background:#182948; }
+.ctrl-btn:hover { background:#233660; }
+.pause-btn { font-size:13px; padding:5px 8px; }
+
+/* ── Final card ──────────────────────────────────────────────────────── */
+.watch-final-card { border:1px solid #3d5378; border-radius:10px; margin-top:12px; padding:10px; background:#13203a; }
+.watch-final-label { text-transform:uppercase; font-size:10px; letter-spacing:.08em; color:#98b4dd; margin-bottom:4px; }
+.watch-final-score { display:flex; flex-direction:column; gap:4px; font-size:15px; font-weight:800; color:#ecf4ff; }
+.finish { margin-top:10px; width:100%; background:#1d4ed8; color:#fff; font-weight:800; border:none; border-radius:8px; padding:9px; cursor:pointer; font-size:13px; }
 `;

--- a/src/ui/utils/liveGamePresentation.js
+++ b/src/ui/utils/liveGamePresentation.js
@@ -1,5 +1,23 @@
+function isPlaceholderName(name) {
+  if (!name || typeof name !== 'string') return true;
+  const t = name.trim();
+  if (!t) return true;
+  return /\bstarter\b/i.test(t)
+    || /^[HA]\s+(QB|RB|WR|TE|OL|DL|LB|CB|S|K|P|EDGE|DE|DT|FS|SS|FB|OT|OG|C)\d+$/i.test(t)
+    || /^player\s*#?\s*\d+$/i.test(t)
+    || /^unknown(\s+player)?$/i.test(t);
+}
+
 function playerName(player) {
-  return player?.name || 'Unknown';
+  const raw = player?.name;
+  if (isPlaceholderName(raw)) {
+    const pos = player?.pos || '';
+    const id = player?.id;
+    return id != null ? `${pos}${pos ? ' ' : ''}#${id}` : (pos || 'Player');
+  }
+  const name = String(raw).trim();
+  const parts = name.split(/\s+/);
+  return parts.length >= 2 ? `${parts[0][0]}. ${parts[parts.length - 1]}` : name;
 }
 
 export function getCurrentStandoutPlayers(events = [], visibleCount = events.length) {

--- a/src/ui/utils/liveGamePresentation.test.js
+++ b/src/ui/utils/liveGamePresentation.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { getCurrentStandoutPlayers, summarizeGameSwing, getEventTags } from './liveGamePresentation.js';
+
+// Helper to build a minimal log entry with a player object
+function makeLog(type, player, extras = {}) {
+  return {
+    raw: { type, player, passer: extras.passer ?? null, ...extras },
+    eventType: type,
+    headline: extras.headline ?? '',
+    score: { home: 0, away: 0 },
+  };
+}
+
+describe('getCurrentStandoutPlayers — placeholder name filtering', () => {
+  it('does not show raw starter names in standout QB slot', () => {
+    const passerPlaceholder = { id: 1, name: 'QB Starter 7-2', pos: 'QB' };
+    const events = [
+      { raw: { type: 'pass', passer: passerPlaceholder, passYds: 120, passAtt: 1, completed: true } },
+    ];
+    const result = getCurrentStandoutPlayers(events, events.length);
+    if (result.qb) {
+      expect(result.qb.player).not.toMatch(/Starter/i);
+      expect(result.qb.player).not.toMatch(/QB QB/i);
+    }
+  });
+
+  it('does not show raw starter names in standout rusher slot', () => {
+    const runner = { id: 5, name: 'RB Starter 2-1', pos: 'RB' };
+    const events = [
+      { raw: { type: 'run', player: runner, rushYds: 80 } },
+    ];
+    const result = getCurrentStandoutPlayers(events, events.length);
+    if (result.rusher) {
+      expect(result.rusher.player).not.toMatch(/Starter/i);
+    }
+  });
+
+  it('does not show H QB1-style fallback names in standout slots', () => {
+    const passer = { id: 2, name: 'H QB1', pos: 'QB' };
+    const events = [
+      { raw: { type: 'pass', passer, passYds: 200, passAtt: 2, completed: true } },
+    ];
+    const result = getCurrentStandoutPlayers(events, events.length);
+    if (result.qb) {
+      expect(result.qb.player).not.toMatch(/^H QB1$/);
+    }
+  });
+
+  it('uses compact F. LastName format for real player names', () => {
+    const passer = { id: 10, name: 'Patrick Mahomes', pos: 'QB' };
+    const events = [
+      { raw: { type: 'pass', passer, passYds: 300, passAtt: 3, completed: true } },
+    ];
+    const result = getCurrentStandoutPlayers(events, events.length);
+    expect(result.qb).not.toBeNull();
+    expect(result.qb.player).toBe('P. Mahomes');
+  });
+
+  it('falls back to "QB #id" for placeholder-named passer', () => {
+    const passer = { id: 99, name: 'QB Starter 1-1', pos: 'QB' };
+    const events = [
+      { raw: { type: 'pass', passer, passYds: 150, passAtt: 2, completed: true } },
+    ];
+    const result = getCurrentStandoutPlayers(events, events.length);
+    if (result.qb) {
+      expect(result.qb.player).toMatch(/QB\s*#99/);
+    }
+  });
+});
+
+describe('getEventTags', () => {
+  it('returns TD tag for touchdown event', () => {
+    expect(getEventTags({ eventType: 'touchdown' })).toContain('TD');
+  });
+
+  it('returns SACK tag for sack event', () => {
+    expect(getEventTags({ eventType: 'sack' })).toContain('SACK');
+  });
+
+  it('returns INT tag for interception turnover', () => {
+    expect(getEventTags({ eventType: 'turnover', headline: 'interception' })).toContain('INT');
+  });
+
+  it('returns FUM tag for fumble turnover', () => {
+    expect(getEventTags({ eventType: 'turnover', headline: 'fumble' })).toContain('FUM');
+  });
+
+  it('returns BIG PLAY for explosive_play events', () => {
+    expect(getEventTags({ eventType: 'explosive_play' })).toContain('BIG PLAY');
+  });
+
+  it('returns RED ZONE for red_zone_entry events', () => {
+    expect(getEventTags({ eventType: 'red_zone_entry' })).toContain('RED ZONE');
+  });
+});
+
+describe('summarizeGameSwing', () => {
+  it('returns neutral label when events are empty', () => {
+    expect(summarizeGameSwing([])).toEqual({ label: 'Game still in balance', tone: 'neutral' });
+  });
+
+  it('returns offense tone when multiple recent scores', () => {
+    const events = [
+      { eventType: 'touchdown' },
+      { eventType: 'touchdown' },
+      { eventType: 'field_goal' },
+    ];
+    expect(summarizeGameSwing(events, events.length).tone).toBe('offense');
+  });
+
+  it('returns defense tone when multiple recent turnovers', () => {
+    const events = [
+      { eventType: 'turnover' },
+      { eventType: 'turnover' },
+    ];
+    expect(summarizeGameSwing(events, events.length).tone).toBe('defense');
+  });
+});

--- a/src/ui/utils/playerNameResolver.js
+++ b/src/ui/utils/playerNameResolver.js
@@ -6,7 +6,17 @@
  *   b. league player map by numeric/string playerId
  *   e. safe fallback "Player #<id>" — never blank/undefined
  */
-const PLACEHOLDER_PATTERNS = [/^player\s*#?\s*\d+$/i, /^unknown$/i, /^unknown player$/i, /^n\/?a$/i, /^--+$/];
+const PLACEHOLDER_PATTERNS = [
+  /^player\s*#?\s*\d+$/i,
+  /^unknown$/i,
+  /^unknown player$/i,
+  /^n\/?a$/i,
+  /^--+$/,
+  // "QB Starter 7-2", "WR Starter 7-3", "DL Starter 8-3", etc.
+  /\bstarter\b/i,
+  // defaultPlayers fallback names: "H QB1", "A WR2", "H EDGE1"
+  /^[HA]\s+(QB|RB|WR|TE|OL|DL|LB|CB|S|K|P|EDGE|DE|DT|FS|SS|FB|OT|OG|C)\d+$/i,
+];
 
 function isRealName(value) {
   if (typeof value !== 'string') return false;

--- a/src/ui/utils/playerNameResolver.test.js
+++ b/src/ui/utils/playerNameResolver.test.js
@@ -32,3 +32,65 @@ describe('buildLeaguePlayerMap', () => {
     expect(map['55'].name).toBe('Archived Name');
   });
 });
+
+describe('isRealName — starter placeholder rejection', () => {
+  const STARTER_NAMES = [
+    'QB Starter 7-2',
+    'WR WR Starter 7-3',
+    'DL Starter 8-3',
+    'QB Starter 1-1',
+    'OL Starter 3-5',
+    'LB Starter 12-4',
+  ];
+  const FALLBACK_NAMES = [
+    'H QB1',
+    'A WR2',
+    'H EDGE1',
+    'A LB3',
+  ];
+
+  for (const name of STARTER_NAMES) {
+    it(`rejects starter placeholder: "${name}"`, () => {
+      // resolvePlayerName should NOT use the starter name; fallback should be Player #<id>
+      const result = resolvePlayerName(7, { row: { name } });
+      expect(result).toBe('Player #7');
+      expect(result).not.toContain('Starter');
+    });
+  }
+
+  for (const name of FALLBACK_NAMES) {
+    it(`rejects defaultPlayers fallback: "${name}"`, () => {
+      const result = resolvePlayerName(5, { row: { name } });
+      expect(result).toBe('Player #5');
+    });
+  }
+
+  it('does not reject legitimate names that contain unrelated words', () => {
+    // "Starterfield" would incorrectly match a naive substring check — word boundary matters
+    const mapWithReal = { '10': { id: 10, name: 'Jake Harris' } };
+    expect(resolvePlayerName(10, { row: { name: 'Jake Harris' }, playerMap: mapWithReal })).toBe('Jake Harris');
+  });
+
+  it('prefers map real name over placeholder row name', () => {
+    const playerMap = { '12': { id: 12, name: 'Marcus Carter' } };
+    expect(resolvePlayerName(12, { row: { name: 'QB Starter 2-1' }, playerMap })).toBe('Marcus Carter');
+  });
+
+  it('buildLeaguePlayerMap excludes starter-named players from map (they are not real names)', () => {
+    const league = {
+      teams: [{
+        id: 0,
+        roster: [
+          { id: 1, name: 'QB Starter 1-1', pos: 'QB' },
+          { id: 2, name: 'Marcus Williams', pos: 'RB' },
+        ],
+      }],
+    };
+    const map = buildLeaguePlayerMap(league);
+    // Placeholder should not be considered "real" and should not override a subsequent real entry
+    // But the map still stores the object — the real-name guard in putPlayer prevents overwrite
+    // Since id=1 has a placeholder name, resolvePlayerName should fall back to Player #1
+    expect(resolvePlayerName(1, { playerMap: map })).toBe('Player #1');
+    expect(resolvePlayerName(2, { playerMap: map })).toBe('Marcus Williams');
+  });
+});


### PR DESCRIPTION
Audit summary
- Placeholder names like "QB Starter 7-2" originated in defaultLeague.ts:70
  where makePlayer() baked `${pos} Starter ${teamId+1}-${depthOrder}` as the
  player's actual .name field in the Safe Starter League fallback.
- isRealName() in playerNameResolver.js had no pattern to detect the Starter
  template so those names were accepted as real.
- _n() in game-simulator.js prefixed every name with p.pos, producing
  "QB QB Starter 7-2" double-prefix strings in live play logs.
- liveGamePresentation.js passed player.name straight to the standouts panel
  with no filtering.

Part A — Player identity integrity
- defaultLeague.ts: add seededPick() + generatePlayerName() — deterministic
  mulberry32-seeded name generator draws from 64 first-names × 96 last-names
  (stable for a given teamId/index seed, no schema change).
  makePlayer() now emits "Marcus Carter" instead of "QB Starter 7-2".
- playerNameResolver.js: extend PLACEHOLDER_PATTERNS with \bstarter\b (covers
  all "Pos Starter X-Y" variants) and the defaultPlayers fallback pattern
  /^[HA]\s+(QB|RB|…)\d+$/ ("H QB1", "A WR2").  Legacy saves with placeholder
  names now fall back cleanly to "Player #id" rather than showing raw template.

Part B — Live play-log name resolution
- game-simulator.js: replace _n() with a safe compact formatter that:
  (a) detects placeholder names via inline regex guards,
  (b) returns "POS #id" for placeholders instead of "QB QB Starter 7-2",
  (c) returns "F. LastName" compact format for real names ("P. Mahomes").
  No simulation math, play outcomes, or stats changed.
- liveGamePresentation.js: add isPlaceholderName() guard and rewrite
  playerName() to use compact "F. LastName" display for real names and
  "POS #id" for placeholders — standouts panel now shows clean names.

Part C — Live viewer presentation
- GameEventFeed.jsx: add TAG_CLASS map for coloured impact badges
  (TD=green, INT/FUM=red, SACK=amber, BIG PLAY=blue, RED ZONE=red,
  CLUTCH=purple); add possession-change dividers between drives.
- LiveGameViewer.jsx: reorganise controls into labelled compact rows
  (Speed / Skip / Playcall), tighten all spacing for mobile, add
  standout-pos label chips, remove vertical bloat from control buttons,
  preserve all existing functionality and prop contracts.

Tests
- playerNameResolver.test.js: 13 new assertions covering all Starter
  template variants, defaultPlayers fallback names, edge cases, and
  buildLeaguePlayerMap integration.
- liveGamePresentation.test.js (new): 13 tests for placeholder filtering,
  compact name display, getEventTags impact badges, summarizeGameSwing.
- liveGamePlayerIdentity.test.js (new): 6 tests verifying defaultLeague
  generates non-placeholder names, deterministic output, unchanged ratings/
  IDs, and that simGameStats play logs contain no "Starter" or double-pos.

Results: 2337/2337 unit tests pass; production build clean.

https://claude.ai/code/session_012HCXxFY4A3Z3fqEXpcDA1W