### PR TITLE
Fix E2E test regressions for Franchise HQ drawer and readiness gate

### DIFF
--- a/tests/e2e/fresh_franchise_first_week_smoke.spec.js
+++ b/tests/e2e/fresh_franchise_first_week_smoke.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { goToTab, launchFranchise } from './helpers/franchise.js';
+import { launchFranchise, goToTab, ensureLeagueLoaded } from './helpers/franchise.js';
 
 const SMOKE_TIMEOUT = 90000;
 
@@ -223,6 +223,7 @@ test('fresh franchise first week smoke', async ({ page, context }) => {
   }
 
   // Season Pulse momentum should update after the game
+  await page.getByTestId('hq-more-drawer').click();
   const seasonPulse = page.getByTestId('season-pulse');
   await expect(seasonPulse).toBeVisible({ timeout: SMOKE_TIMEOUT });
 
@@ -240,6 +241,7 @@ test('fresh franchise first week smoke', async ({ page, context }) => {
 
   // ── Reload: HQ should persist Last Result from IndexedDB ────────────────────
   await page.reload();
+  await ensureLeagueLoaded(page);
   await expect(page.getByTestId('app-bootstrap-loading')).toBeHidden({ timeout: SMOKE_TIMEOUT });
   await expect(page.getByTestId('app-shell-ready')).toBeVisible({ timeout: SMOKE_TIMEOUT });
   await expect(page.getByTestId('franchise-hq')).toBeVisible({ timeout: SMOKE_TIMEOUT });

--- a/tests/e2e/helpers/franchise.js
+++ b/tests/e2e/helpers/franchise.js
@@ -186,6 +186,35 @@ export async function selectScheduleWeekTab(page, weekNumber) {
 export async function simulateSingleWeek(page, options = {}) {
   const { advanceAnyway = false } = options;
   const startWeek = await page.evaluate(() => window?.state?.league?.week ?? 1);
+
+  if (advanceAnyway) {
+    await page.evaluate(() => {
+      try {
+        const PREP_KEY = 'footballgm_weekly_prep_v1';
+        const league = window?.state?.league ?? {};
+        const seasonId = league?.seasonId ?? league?.year ?? 'season';
+        const week = league?.week ?? 1;
+        const userTeamId = league?.userTeamId ?? 'user';
+        const slotKey = `${seasonId}:${week}:${userTeamId}`;
+        const stored = JSON.parse(window.localStorage.getItem(PREP_KEY) ?? '{}');
+        stored[slotKey] = {
+          lineupChecked: true,
+          injuriesReviewed: true,
+          opponentScouted: true,
+          planReviewed: true,
+          ...(stored[slotKey] ?? {}),
+          planReviewed: true,
+        };
+        window.localStorage.setItem(PREP_KEY, JSON.stringify(stored));
+      } catch (_e) { /* non-fatal */ }
+    });
+    // Wait for the button to become enabled if it's rendered
+    const advanceCta = page.getByTestId('advance-week-cta');
+    if (await advanceCta.isVisible().catch(() => false)) {
+      await expect(advanceCta).toBeEnabled({ timeout: 5000 }).catch(() => {});
+    }
+  }
+
   const advanceCta = page.getByTestId('advance-week-cta');
   if (await advanceCta.isVisible().catch(() => false)) {
     await advanceCta.click();


### PR DESCRIPTION
Fix E2E regression: Ensure Playwright expands HQ drawer and bypasses readiness gate properly

---
*PR created automatically by Jules for task [6189001473543556198](https://jules.google.com/task/6189001473543556198) started by @rbcati*