### PR TITLE
Add simulation strategic responsiveness & executive postgame diagnostics V1

### DIFF
--- a/src/core/__tests__/simStrategicResponsiveness.test.js
+++ b/src/core/__tests__/simStrategicResponsiveness.test.js
@@ -1,0 +1,308 @@
+/**
+ * Simulation Engine Strategic Responsiveness & Executive Postgame Diagnostics
+ * — Invariant Regression Suite (V1)
+ *
+ * Guarantees:
+ *  1. Bounded strategic modifiers never exceed the ±5% schematic execution cap,
+ *     and are derived purely (deterministically) from the selected plan IDs.
+ *  2. Identical tactical setups under matching seeds yield byte-identical
+ *     mathematical outcomes (scores, drive stats, and gameReasoningFlags).
+ *  3. Legacy save states missing dynamic strategies fall back safely to standard
+ *     team-match parameters without crashing, and still emit a flags array.
+ *  4. The diagnostic engine surfaces the documented core tokens and the shared
+ *     token→bullet translator produces polished, attributed prose.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Utils as U } from '../utils.js';
+import { simGameStats } from '../game-simulator.js';
+import { computeStrategicEdge } from '../strategy.js';
+import { deriveGameReasoningFlags, GAME_REASONING_TOKENS } from '../weeklyNarrativeFlags.js';
+import { buildReasoningBullets } from '../gameSummary.js';
+
+// ── Minimal roster factory (mirrors the engine's expected player shape) ─────────
+function makePlayer(id, pos, ovr = 75) {
+  const ratings = {
+    QB: { throwPower: 75, throwAccuracy: 75, awareness: 75, speed: 65, agility: 65 },
+    RB: { speed: 78, trucking: 72, juking: 70, awareness: 65 },
+    WR: { speed: 85, awareness: 72, catching: 80 },
+    TE: { speed: 72, awareness: 70, catching: 74 },
+    OL: { passBlock: 73, runBlock: 74 },
+    DL: { passRushPower: 73, passRushSpeed: 71, tackle: 72, strength: 74 },
+    LB: { tackle: 75, awareness: 72, speed: 72, strength: 70 },
+    CB: { speed: 82, awareness: 72, agility: 78 },
+    S:  { speed: 78, awareness: 75, tackle: 70 },
+    K:  { kickPower: 78, kickAccuracy: 76 },
+    P:  { kickPower: 76 },
+  };
+  return { id: `${id}`, pos, ovr, name: `${pos} ${id}`, ratings: ratings[pos] || {} };
+}
+
+// Fresh team objects each call so no cached non-enumerable props leak between runs.
+function buildTeam(id, strategies = null) {
+  const team = {
+    id,
+    abbr: `T${id}`,
+    name: `Team ${id}`,
+    roster: [
+      makePlayer(`${id}-qb1`, 'QB', 80),
+      makePlayer(`${id}-qb2`, 'QB', 64),
+      makePlayer(`${id}-rb1`, 'RB', 76),
+      makePlayer(`${id}-rb2`, 'RB', 70),
+      makePlayer(`${id}-wr1`, 'WR', 79),
+      makePlayer(`${id}-wr2`, 'WR', 74),
+      makePlayer(`${id}-wr3`, 'WR', 70),
+      makePlayer(`${id}-te1`, 'TE', 74),
+      makePlayer(`${id}-ol1`, 'OL', 74),
+      makePlayer(`${id}-ol2`, 'OL', 72),
+      makePlayer(`${id}-ol3`, 'OL', 71),
+      makePlayer(`${id}-dl1`, 'DL', 76),
+      makePlayer(`${id}-dl2`, 'DL', 72),
+      makePlayer(`${id}-lb1`, 'LB', 74),
+      makePlayer(`${id}-lb2`, 'LB', 71),
+      makePlayer(`${id}-cb1`, 'CB', 75),
+      makePlayer(`${id}-cb2`, 'CB', 72),
+      makePlayer(`${id}-s1`,  'S',  73),
+      makePlayer(`${id}-k1`,  'K',  70),
+      makePlayer(`${id}-p1`,  'P',  70),
+    ],
+  };
+  if (strategies) team.strategies = strategies;
+  return team;
+}
+
+function buildLeague(userTeamId, homeStrats = null, awayStrats = null) {
+  return {
+    week: 1,
+    seasonId: 2030,
+    year: 2030,
+    userTeamId,
+    teams: [buildTeam(1, homeStrats), buildTeam(2, awayStrats)],
+    resultsByWeek: { 0: [] },
+  };
+}
+
+// A clean home counter: AGGRESSIVE_PASSING beats away BLITZ_HEAVY (+1) and
+// DISGUISE_COVERAGE smothers away AGGRESSIVE_PASSING (+1) → net +2 (countered).
+const HOME_COUNTER = { offPlanId: 'AGGRESSIVE_PASSING', defPlanId: 'DISGUISE_COVERAGE', riskId: 'BALANCED' };
+const AWAY_EXPOSED = { offPlanId: 'AGGRESSIVE_PASSING', defPlanId: 'BLITZ_HEAVY', riskId: 'BALANCED' };
+
+function runGame(seed, { homeStrats = null, awayStrats = null } = {}) {
+  const home = buildTeam(1, homeStrats);
+  const away = buildTeam(2, awayStrats);
+  const league = buildLeague(1, homeStrats, awayStrats);
+  // Use the SAME fresh team objects the league references so strategies resolve.
+  league.teams[0] = home;
+  league.teams[1] = away;
+  U.setSeed(seed);
+  return simGameStats(home, away, {
+    generateLogs: true,
+    league,
+    homeAbbr: 'T1',
+    awayAbbr: 'T2',
+  });
+}
+
+// ── 1. Bounded strategic modifiers (pure, deterministic) ────────────────────────
+describe('computeStrategicEdge — bounded, deterministic counters', () => {
+  it('never exceeds the ±5% execution cap for any plan combination', () => {
+    const offPlans = ['BALANCED', 'AGGRESSIVE_PASSING', 'BALL_CONTROL', 'PROTECT_QB', 'FEED_STAR'];
+    const defPlans = ['BALANCED', 'SELL_OUT_RUN', 'DISGUISE_COVERAGE', 'BLITZ_HEAVY', 'TWO_HIGH_SAFE'];
+    const risks = ['CONSERVATIVE', 'BALANCED', 'AGGRESSIVE'];
+    for (const offPlanId of offPlans) {
+      for (const defPlanId of defPlans) {
+        for (const riskId of risks) {
+          const team = { strategies: { offPlanId, defPlanId, riskId } };
+          for (const oOff of offPlans) {
+            for (const oDef of defPlans) {
+              const opp = { strategies: { offPlanId: oOff, defPlanId: oDef, riskId: 'BALANCED' } };
+              const { edge } = computeStrategicEdge(team, opp);
+              expect(Math.abs(edge)).toBeLessThanOrEqual(0.05 + 1e-9);
+              expect(Number.isFinite(edge)).toBe(true);
+            }
+          }
+        }
+      }
+    }
+  });
+
+  it('is a pure function of plan identifiers (repeatable)', () => {
+    const team = { strategies: HOME_COUNTER };
+    const opp = { strategies: AWAY_EXPOSED };
+    const a = computeStrategicEdge(team, opp);
+    const b = computeStrategicEdge(team, opp);
+    expect(a).toEqual(b);
+  });
+
+  it('flags a clean hard counter as a schematic edge', () => {
+    const res = computeStrategicEdge({ strategies: HOME_COUNTER }, { strategies: AWAY_EXPOSED });
+    expect(res.offCounter + res.defCounter).toBeGreaterThanOrEqual(2);
+    expect(res.countered).toBe(true);
+    expect(res.edge).toBeGreaterThan(0);
+  });
+
+  it('returns a neutral zero edge for legacy teams without strategies', () => {
+    // No own strategy → neutral.
+    expect(computeStrategicEdge({}, {})).toEqual({ edge: 0, offCounter: 0, defCounter: 0, countered: false });
+    // Own counter plan but an opponent with no tendency to exploit → still neutral.
+    expect(computeStrategicEdge({ strategies: HOME_COUNTER }, {}).edge).toBe(0);
+    // Own counter plan vs an exposed opponent → a real, non-zero edge.
+    expect(computeStrategicEdge({ strategies: HOME_COUNTER }, { strategies: AWAY_EXPOSED }).edge).toBeGreaterThan(0);
+  });
+});
+
+// ── 2. Identical setups + matching seed → identical math ────────────────────────
+describe('simGameStats — deterministic strategic responsiveness', () => {
+  it('identical tactical setups under matching seeds yield identical outcomes', () => {
+    const opts = { homeStrats: HOME_COUNTER, awayStrats: AWAY_EXPOSED };
+    const r1 = runGame(4242, opts);
+    const r2 = runGame(4242, opts);
+
+    expect(r1).toBeTruthy();
+    expect(r2).toBeTruthy();
+    expect(r1.homeScore).toBe(r2.homeScore);
+    expect(r1.awayScore).toBe(r2.awayScore);
+    expect(r1.teamDriveStats).toEqual(r2.teamDriveStats);
+    expect(r1.gameReasoningFlags).toEqual(r2.gameReasoningFlags);
+  });
+
+  it('a schematic counter shifts outcomes versus a neutral plan under the same seed', () => {
+    // Both runs share the seed; only the home tactical setup changes. Because the
+    // edge is applied without consuming RNG, divergence is purely the bounded
+    // modifier's doing — proving the tactical input maps into the drive loop.
+    let sawDifference = false;
+    for (let i = 0; i < 8 && !sawDifference; i++) {
+      const seed = 9100 + i * 31;
+      const countered = runGame(seed, { homeStrats: HOME_COUNTER, awayStrats: AWAY_EXPOSED });
+      const neutral = runGame(seed, {
+        homeStrats: { offPlanId: 'BALANCED', defPlanId: 'BALANCED', riskId: 'BALANCED' },
+        awayStrats: AWAY_EXPOSED,
+      });
+      if (countered.homeScore !== neutral.homeScore || countered.awayScore !== neutral.awayScore) {
+        sawDifference = true;
+      }
+    }
+    expect(sawDifference).toBe(true);
+  });
+});
+
+// ── 3. Legacy save fallback safety ──────────────────────────────────────────────
+describe('simGameStats — legacy save fallback', () => {
+  it('does not crash when teams have no dynamic strategies', () => {
+    const r = runGame(7001, { homeStrats: null, awayStrats: null });
+    expect(r).toBeTruthy();
+    expect(Number.isFinite(r.homeScore)).toBe(true);
+    expect(Number.isFinite(r.awayScore)).toBe(true);
+    expect(Array.isArray(r.gameReasoningFlags)).toBe(true);
+    // No schematic edge should ever be claimed without a strategy profile.
+    expect(r.gameReasoningFlags.some((f) => f.token === GAME_REASONING_TOKENS.SCHEMATIC_EDGE)).toBe(false);
+  });
+
+  it('produces identical legacy outcomes under matching seeds', () => {
+    const a = runGame(7002, {});
+    const b = runGame(7002, {});
+    expect(a.homeScore).toBe(b.homeScore);
+    expect(a.awayScore).toBe(b.awayScore);
+    expect(a.gameReasoningFlags).toEqual(b.gameReasoningFlags);
+  });
+});
+
+// ── 4. Diagnostic flag engine + bullet translation ──────────────────────────────
+describe('gameReasoningFlags — engine output', () => {
+  it('attaches a gameReasoningFlags array to every simulated game', () => {
+    const r = runGame(8080, { homeStrats: HOME_COUNTER, awayStrats: AWAY_EXPOSED });
+    expect(Array.isArray(r.gameReasoningFlags)).toBe(true);
+    r.gameReasoningFlags.forEach((flag) => {
+      expect(typeof flag.token).toBe('string');
+      expect(flag).toHaveProperty('teamAbbr');
+    });
+  });
+
+  it('surfaces SCHEMATIC_EDGE for a team that hard-counters its opponent', () => {
+    const r = runGame(8081, { homeStrats: HOME_COUNTER, awayStrats: AWAY_EXPOSED });
+    const edgeFlag = r.gameReasoningFlags.find((f) => f.token === GAME_REASONING_TOKENS.SCHEMATIC_EDGE);
+    expect(edgeFlag).toBeTruthy();
+    expect(edgeFlag.teamAbbr).toBe('T1');
+  });
+});
+
+describe('deriveGameReasoningFlags — pure diagnostic derivation', () => {
+  const base = {
+    home: { id: 1, abbr: 'PIT' },
+    away: { id: 2, abbr: 'CLE' },
+    homeScore: 27,
+    awayScore: 17,
+  };
+
+  it('emits TRENCH_DOMINANCE when an OL overmatches the opposing front', () => {
+    const flags = deriveGameReasoningFlags({
+      ...base,
+      trenches: { homeOL: 90, awayDL: 70, awayOL: 72, homeDL: 74 },
+    });
+    const t = flags.find((f) => f.token === GAME_REASONING_TOKENS.TRENCH_DOMINANCE);
+    expect(t).toBeTruthy();
+    expect(t.teamAbbr).toBe('PIT');
+  });
+
+  it('emits RED_ZONE_EFFICIENCY when a team stalls on multiple trips', () => {
+    const flags = deriveGameReasoningFlags({
+      ...base,
+      redZone: { home: { trips: 4, tds: 1 }, away: { trips: 2, tds: 2 } },
+    });
+    const rz = flags.find((f) => f.token === GAME_REASONING_TOKENS.RED_ZONE_EFFICIENCY);
+    expect(rz).toBeTruthy();
+    expect(rz.teamAbbr).toBe('PIT');
+  });
+
+  it('emits TURNOVER_SWING and attributes it to the beneficiary', () => {
+    const flags = deriveGameReasoningFlags({
+      ...base,
+      turnovers: { home: 0, away: 3 }, // CLE gave it away 3 times → PIT benefits
+    });
+    const to = flags.find((f) => f.token === GAME_REASONING_TOKENS.TURNOVER_SWING);
+    expect(to).toBeTruthy();
+    expect(to.teamAbbr).toBe('PIT');
+  });
+
+  it('emits DEPTH_COLLAPSE when attrition forces low backups into key roles', () => {
+    const flags = deriveGameReasoningFlags({
+      ...base,
+      depth: { home: { occurred: true, gap: 14 }, away: { occurred: false } },
+    });
+    const dc = flags.find((f) => f.token === GAME_REASONING_TOKENS.DEPTH_COLLAPSE);
+    expect(dc).toBeTruthy();
+    expect(dc.teamAbbr).toBe('PIT');
+  });
+
+  it('returns an empty array for a featureless game and never throws', () => {
+    expect(deriveGameReasoningFlags({})).toEqual([]);
+    expect(deriveGameReasoningFlags(base)).toEqual([]);
+  });
+});
+
+describe('buildReasoningBullets — shared token translation', () => {
+  it('translates tokens into polished, attributed bullet prose', () => {
+    const bullets = buildReasoningBullets([
+      { token: 'TRENCH_DOMINANCE', teamAbbr: 'Pittsburgh', detail: '' },
+      { token: 'TURNOVER_SWING', teamAbbr: 'Pittsburgh', detail: '' },
+    ]);
+    expect(bullets).toHaveLength(2);
+    expect(bullets[0]).toMatch(/Pittsburgh/);
+    expect(bullets[0].toLowerCase()).toContain('trench');
+    expect(bullets[1].toLowerCase()).toContain('turnover');
+  });
+
+  it('ignores unknown tokens and dedupes identical clauses', () => {
+    const bullets = buildReasoningBullets([
+      { token: 'NONSENSE', teamAbbr: 'X' },
+      { token: 'SCHEMATIC_EDGE', teamAbbr: 'X', detail: '' },
+      { token: 'SCHEMATIC_EDGE', teamAbbr: 'X', detail: '' },
+    ]);
+    expect(bullets).toHaveLength(1);
+  });
+
+  it('is safe with empty / non-array input', () => {
+    expect(buildReasoningBullets()).toEqual([]);
+    expect(buildReasoningBullets(null)).toEqual([]);
+  });
+});

--- a/src/core/game-simulator.js
+++ b/src/core/game-simulator.js
@@ -7,7 +7,8 @@ import { Utils as U } from './utils.js';
 import { Constants as C } from './constants.js';
 import { calculateGamePerformance, getCoachingMods, getHCMods, getMedicalStaffInjuryMod } from './coach-system.js';
 import { updateAdvancedStats, getZeroStats, updatePlayerGameLegacy, calculateMorale } from './player.js';
-import { getStrategyModifiers } from './strategy.js';
+import { getStrategyModifiers, computeStrategicEdge } from './strategy.js';
+import { deriveGameReasoningFlags } from './weeklyNarrativeFlags.js';
 import { getEffectiveRating, canPlayerPlay, generateInjury } from './injury-core.js';
 import { calculateTeamRatingWithSchemeFit } from './scheme-core.js';
 import { TRAITS } from './traits.js';
@@ -126,20 +127,32 @@ function buildDriveBasedSummary({
   homeDef = 75,
   awayDef = 75,
   homeFieldAdv = 0.03,
+  // Bounded ±5% schematic execution edges (per team). Default 0 keeps legacy
+  // save states — which carry no strategy profile — byte-for-byte identical.
+  homeStrategicEdge = 0,
+  awayStrategicEdge = 0,
 }) {
   const seed = hashStringToSeed(`${season}|${week}|${home?.id}|${away?.id}`);
   const rng = mulberry32(seed);
   const randInt = (min, max) => Math.floor(rng() * (max - min + 1)) + min;
   const chance = (p) => rng() < p;
 
+  // Net per-side schematic edge = own leverage minus the opponent's, hard-capped
+  // at ±5 percentage points so roster quality stays the primary driver.
+  const homeNetEdge = U.clamp(homeStrategicEdge - awayStrategicEdge, -0.05, 0.05);
+  const awayNetEdge = U.clamp(awayStrategicEdge - homeStrategicEdge, -0.05, 0.05);
+
   const homeDrives = randInt(10, 14);
   const awayDrives = randInt(10, 14);
   const homeStats = { passYds: 0, passAtt: 0, comp: 0, passTD: 0, INT: 0, rushYds: 0, rushAtt: 0, sacks: 0, turnovers: 0 };
   const awayStats = { passYds: 0, passAtt: 0, comp: 0, passTD: 0, INT: 0, rushYds: 0, rushAtt: 0, sacks: 0, turnovers: 0 };
 
-  const simTeam = (offOvr, defOvr, drives, teamStats, isHome) => {
+  const simTeam = (offOvr, defOvr, drives, teamStats, isHome, netEdge = 0) => {
     let score = 0;
-    const driveSuccessRaw = 0.4 + (offOvr - defOvr) * 0.005 + (isHome ? homeFieldAdv : 0);
+    // The strategic edge nudges drive-conversion probability only; it never
+    // alters the RNG draw count, so a zero edge reproduces prior behavior and
+    // a non-zero edge shifts only the comparison threshold (still deterministic).
+    const driveSuccessRaw = 0.4 + (offOvr - defOvr) * 0.005 + (isHome ? homeFieldAdv : 0) + netEdge;
     const driveSuccess = U.clamp(driveSuccessRaw, 0.15, 0.72);
     for (let i = 0; i < drives; i++) {
       const passHeavy = chance(0.56);
@@ -173,8 +186,8 @@ function buildDriveBasedSummary({
     return score;
   };
 
-  const homeScore = simTeam(homeOff, awayDef, homeDrives, homeStats, true);
-  const awayScore = simTeam(awayOff, homeDef, awayDrives, awayStats, false);
+  const homeScore = simTeam(homeOff, awayDef, homeDrives, homeStats, true, homeNetEdge);
+  const awayScore = simTeam(awayOff, homeDef, awayDrives, awayStats, false, awayNetEdge);
   const homeQbRating = computePasserRating({ comp: homeStats.comp, att: homeStats.passAtt, yds: homeStats.passYds, td: homeStats.passTD, ints: homeStats.INT });
   const awayQbRating = computePasserRating({ comp: awayStats.comp, att: awayStats.passAtt, yds: awayStats.passYds, td: awayStats.passTD, ints: awayStats.INT });
   const homeYpc = homeStats.rushAtt > 0 ? U.round(homeStats.rushYds / homeStats.rushAtt, 2) : null;
@@ -1575,6 +1588,15 @@ export function simGameStats(home, away, options = {}) {
     applyStaffTacticalEdge(home, homeMods);
     applyStaffTacticalEdge(away, awayMods);
 
+    // --- STRATEGIC RESPONSIVENESS (bounded ±5% schematic execution edge) ---
+    // Map each team's weekly tactical inputs against the opponent's strategy
+    // profile into a tightly bounded, fully deterministic execution edge.
+    // Legacy saves without `team.strategies` resolve to a neutral zero edge.
+    const homeStrategicEdge = computeStrategicEdge(home, away);
+    const awayStrategicEdge = computeStrategicEdge(away, home);
+    homeMods.strategicEdge = homeStrategicEdge.edge;
+    awayMods.strategicEdge = awayStrategicEdge.edge;
+
     if (false) console.log(`[SIM-DEBUG] Mods Applied: Home=${JSON.stringify(homeMods)}, Away=${JSON.stringify(awayMods)}`);
     // --- SCHEME FIT IMPACT ---
     let schemeNote = null;
@@ -2010,6 +2032,15 @@ export function simGameStats(home, away, options = {}) {
             }
             // ─────────────────────────────────────────────────────────────
 
+            // ── Strategic Responsiveness: bounded ±5% schematic edge ──────
+            // The offense's schematic leverage minus the defense's, hard-capped
+            // at ±5 percentage points so roster quality stays the primary driver.
+            // Applied AFTER the RNG-free probability build and BEFORE driveRoll
+            // is drawn, so the seeded RNG stream is byte-for-byte unchanged —
+            // only the comparison threshold shifts.
+            const stratEdge = U.clamp((mods.strategicEdge || 0) - (defMods.strategicEdge || 0), -0.05, 0.05);
+            scoreProb = U.clamp(scoreProb + stratEdge, 0.10, 0.65);
+
             const driveRoll = U.random();
 
             // Play-by-play log helper (shared by scoring and non-scoring drives)
@@ -2432,6 +2463,8 @@ export function simGameStats(home, away, options = {}) {
       homeDef: homeDefenseStrength,
       awayDef: awayDefenseStrength,
       homeFieldAdv: 0.03,
+      homeStrategicEdge: homeStrategicEdge.edge,
+      awayStrategicEdge: awayStrategicEdge.edge,
     });
 
     let homeScore = Math.max(0, driveSummary?.homeScore ?? homeRes.score);
@@ -2917,7 +2950,60 @@ export function simGameStats(home, away, options = {}) {
     const driveSummaryRows = buildDriveSummaryFromSimulation(normalizedPlayLogs, summaryContext);
     const quarterScores = buildQuarterScoresFromScoring(scoringSummary, summaryContext);
 
+    // --- EXECUTIVE POSTGAME DIAGNOSTICS (gameReasoningFlags) ---
+    // Detect whether in-game attrition forced a clearly lower-rated backup into
+    // a high-leverage starting role for a given side. Pure & deterministic:
+    // it only reads the already-resolved injury list + position depth charts.
+    const PREMIUM_DEPTH_POS = ['QB', 'RB', 'WR', 'TE', 'OL', 'DL', 'LB', 'CB', 'S'];
+    const computeDepthImpact = (team, groups) => {
+        const teamInjuries = gameInjuries.filter((inj) => inj && inj.teamId === team.id);
+        if (teamInjuries.length === 0) return { occurred: false, gap: 0 };
+        let maxGap = 0;
+        let forced = false;
+        for (const inj of teamInjuries) {
+            for (const pos of PREMIUM_DEPTH_POS) {
+                const pool = groups[pos] || [];
+                const idx = pool.findIndex((p) => p && String(p.id) === String(inj.playerId));
+                if (idx === -1) continue;
+                const starter = pool[idx];
+                const backup = pool[idx + 1] || null;
+                const gap = backup ? (Number(starter?.ovr ?? 0) - Number(backup?.ovr ?? 0)) : Number(starter?.ovr ?? 0) - 60;
+                if (gap >= 8 || !backup) forced = true;
+                if (gap > maxGap) maxGap = gap;
+                break;
+            }
+        }
+        // Two or more in-game injuries is itself a depth event regardless of gap.
+        if (teamInjuries.length >= 2) forced = true;
+        return { occurred: forced, gap: Math.max(0, maxGap) };
+    };
+
+    const gameReasoningFlags = deriveGameReasoningFlags({
+      home: { id: home?.id, abbr: home?.abbr },
+      away: { id: away?.id, abbr: away?.abbr },
+      homeScore,
+      awayScore,
+      trenches: {
+        homeOL: homeProfile.passBlock,
+        awayDL: awayProfile.passRushStrength,
+        awayOL: awayProfile.passBlock,
+        homeDL: homeProfile.passRushStrength,
+      },
+      redZone: {
+        home: { trips: home.stats?.game?.redZoneTrips ?? 0, tds: home.stats?.game?.redZoneTDs ?? 0 },
+        away: { trips: away.stats?.game?.redZoneTrips ?? 0, tds: away.stats?.game?.redZoneTDs ?? 0 },
+      },
+      turnovers: { home: homeTo, away: awayTo },
+      strategicEdge: { home: homeStrategicEdge.edge, away: awayStrategicEdge.edge },
+      schematicCounter: { home: homeStrategicEdge.countered, away: awayStrategicEdge.countered },
+      depth: {
+        home: computeDepthImpact(home, homeGroups),
+        away: computeDepthImpact(away, awayGroups),
+      },
+    });
+
     return {
+      gameReasoningFlags,
       homeScore, awayScore, schemeNote, injuries: gameInjuries,
       weather: weather.id,
       homeDefTDs: homeRes.defensiveTDs || 0,
@@ -3228,6 +3314,7 @@ export function commitGameResult(league, gameData, options = { persist: true }) 
         quarterScores: gameData.quarterScores || null,
         recapText: gameData.recapText || null,
         simSeed: gameData.simSeed ?? null,
+        gameReasoningFlags: Array.isArray(gameData.gameReasoningFlags) ? gameData.gameReasoningFlags : [],
     };
 
     if (scheduledGame) {
@@ -3242,6 +3329,7 @@ export function commitGameResult(league, gameData, options = { persist: true }) 
         scheduledGame.playLogs = resultObj.playLogs;
         scheduledGame.playLog = resultObj.playLogs;
         scheduledGame.recapText = resultObj.recapText;
+        scheduledGame.gameReasoningFlags = resultObj.gameReasoningFlags;
     }
 
     if (gameData.preGameContext) {
@@ -3642,6 +3730,7 @@ export function simulateBatch(games, options = {}) {
                 pair._quarterScores = gameScores.quarterScores || null;
                 pair._recapText = gameScores.recapText || null;
                 pair._simSeed = gameScores.simSeed ?? null;
+                pair._gameReasoningFlags = Array.isArray(gameScores.gameReasoningFlags) ? gameScores.gameReasoningFlags : [];
 
                 // Capture stats for box score.
                 // Always key by String(player.id) so numeric and string IDs
@@ -3768,6 +3857,7 @@ export function simulateBatch(games, options = {}) {
                 quarterScores: pair._quarterScores || null,
                 recapText: pair._recapText || null,
                 simSeed: pair._simSeed ?? null,
+                gameReasoningFlags: pair._gameReasoningFlags || [],
             };
 
             let resultObj;
@@ -3801,6 +3891,7 @@ export function simulateBatch(games, options = {}) {
                     quarterScores: pair._quarterScores || null,
                     recapText: pair._recapText || null,
                     simSeed: pair._simSeed ?? null,
+                    gameReasoningFlags: pair._gameReasoningFlags || [],
                 };
             }
             if (resultObj) {

--- a/src/core/gameArchive.js
+++ b/src/core/gameArchive.js
@@ -202,6 +202,7 @@ export function normalizeArchivedGamePayload(rawGame) {
     eventLog: Array.isArray(rawGame?.eventLog) ? rawGame.eventLog : playLog,
     notablePerformances: Array.isArray(rawGame?.notablePerformances) ? rawGame.notablePerformances : [],
     injuries: Array.isArray(rawGame?.injuries) ? rawGame.injuries : [],
+    gameReasoningFlags: Array.isArray(rawGame?.gameReasoningFlags) ? rawGame.gameReasoningFlags : [],
     archiveQuality: rawGame?.archiveQuality,
     // legacy compatibility fields
     stats: legacyStats ?? (playerStats ? { ...playerStats, playLogs: playLog } : null),

--- a/src/core/gameSummary.js
+++ b/src/core/gameSummary.js
@@ -266,6 +266,56 @@ export function summarizeWhyTeamWon({ winnerAbbr, loserAbbr, teamStats, homeId, 
   return `${winnerAbbr} made enough situational plays to outlast ${loserAbbr}.`;
 }
 
+/**
+ * Translate a single executive diagnostic flag into a polished, attributed
+ * postgame clause (no leading bullet glyph). Returns null for unknown tokens
+ * so callers can simply filter them out.
+ *
+ * @param {{token:string, teamAbbr?:string, detail?:string}} flag
+ * @returns {string|null}
+ */
+export function reasoningFlagToClause(flag) {
+  if (!flag || !flag.token) return null;
+  const team = flag.teamAbbr ?? 'The offense';
+  const detail = flag.detail ? ` ${flag.detail}` : '';
+  switch (flag.token) {
+    case 'TRENCH_DOMINANCE':
+      return `${team} dominated the trenches and controlled the line of scrimmage.${detail}`;
+    case 'RED_ZONE_EFFICIENCY':
+      return `${team} stalled in the red zone and left points on the field.${detail}`;
+    case 'TURNOVER_SWING':
+      return `${team} capitalized heavily on a decisive turnover swing.${detail}`;
+    case 'SCHEMATIC_EDGE':
+      return `${team} won the chess match with a sharp tactical counter.${detail}`;
+    case 'DEPTH_COLLAPSE':
+      return `${team} was forced to lean on thin depth after in-game attrition.${detail}`;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Build a deduplicated array of professional postgame bullet strings from a
+ * `gameReasoningFlags` array. Both the live FinalOverlay and the historical
+ * Game Book parse the identical tokens through this single path so the two
+ * surfaces never diverge.
+ *
+ * @param {Array} flags
+ * @returns {string[]}
+ */
+export function buildReasoningBullets(flags = []) {
+  const list = Array.isArray(flags) ? flags : [];
+  const seen = new Set();
+  const bullets = [];
+  for (const flag of list) {
+    const clause = reasoningFlagToClause(flag);
+    if (!clause || seen.has(clause)) continue;
+    seen.add(clause);
+    bullets.push(clause);
+  }
+  return bullets;
+}
+
 export function buildGameNarrativeSummary({ homeTeam, awayTeam, homeScore, awayScore, gameScript, leaders, whyWon, isPlayoff = false, rivalry = false }) {
   const homeWon = homeScore > awayScore;
   const winner = homeWon ? homeTeam : awayTeam;

--- a/src/core/strategy.js
+++ b/src/core/strategy.js
@@ -162,6 +162,92 @@ export const RISK_PROFILES = {
 };
 
 /**
+ * Strategic counter matrix (offense perspective).
+ *
+ * Maps how a chosen OFFENSIVE plan fares against the opponent's DEFENSIVE plan.
+ * +1 => the call is a clean schematic counter (well leveraged); -1 => the
+ * opponent's look smothers the call. Anything absent is neutral (0).
+ *
+ * These values are intentionally coarse "schematic leverage" units; they are
+ * scaled into a tightly bounded execution modifier by computeStrategicEdge().
+ */
+export const STRATEGIC_OFF_VS_DEF = {
+    AGGRESSIVE_PASSING: { BLITZ_HEAVY: 1, SELL_OUT_RUN: 1, TWO_HIGH_SAFE: -1, DISGUISE_COVERAGE: -1 },
+    BALL_CONTROL:       { TWO_HIGH_SAFE: 1, DISGUISE_COVERAGE: 1, SELL_OUT_RUN: -1, BLITZ_HEAVY: -1 },
+    PROTECT_QB:         { BLITZ_HEAVY: 1, DISGUISE_COVERAGE: 1, SELL_OUT_RUN: -1 },
+    FEED_STAR:          { SELL_OUT_RUN: 1, DISGUISE_COVERAGE: -1, TWO_HIGH_SAFE: -1 },
+    BALANCED:           {},
+};
+
+/**
+ * Strategic counter matrix (defense perspective).
+ *
+ * Maps how a chosen DEFENSIVE plan fares against the opponent's OFFENSIVE plan.
+ * +1 => the defensive call hard-counters the opponent's offensive tendency;
+ * -1 => the offensive tendency exploits the look. Absent => neutral (0).
+ */
+export const STRATEGIC_DEF_VS_OFF = {
+    SELL_OUT_RUN:      { BALL_CONTROL: 1, FEED_STAR: 1, AGGRESSIVE_PASSING: -1 },
+    BLITZ_HEAVY:       { BALL_CONTROL: 1, FEED_STAR: 1, AGGRESSIVE_PASSING: -1, PROTECT_QB: -1 },
+    TWO_HIGH_SAFE:     { AGGRESSIVE_PASSING: 1, FEED_STAR: 1, BALL_CONTROL: -1 },
+    DISGUISE_COVERAGE: { AGGRESSIVE_PASSING: 1, FEED_STAR: 1, BALL_CONTROL: -1 },
+    BALANCED:          {},
+};
+
+// One schematic-leverage unit is worth this much execution probability.
+// Two clean counters (the practical maximum) therefore land exactly on the
+// ±0.05 hard ceiling required by the strategic-responsiveness contract.
+const STRATEGIC_UNIT = 0.02;
+const STRATEGIC_EDGE_CAP = 0.05;
+
+/**
+ * Evaluate a team's weekly tactical inputs against the opponent's strategy
+ * profile and return a tightly bounded, fully deterministic execution edge.
+ *
+ * The edge is derived purely from the selected plan identifiers (no RNG), so
+ * identical setups always yield identical edges. Magnitude is hard-capped at
+ * ±5% so that raw roster quality remains the primary driver of outcomes.
+ *
+ * Legacy save states that predate dynamic strategies (no `team.strategies`)
+ * fall back to a neutral zero edge — callers can treat the result as a no-op.
+ *
+ * @param {object} team      - Team whose game plan is being evaluated.
+ * @param {object} opponent  - Opposing team (for tendency lookup).
+ * @returns {{ edge: number, offCounter: number, defCounter: number, countered: boolean }}
+ */
+export function computeStrategicEdge(team, opponent) {
+    const ts = team?.strategies;
+    const os = opponent?.strategies;
+    // Legacy / unset strategies → neutral, harmless fallback.
+    if (!ts || !ts.offPlanId) {
+        return { edge: 0, offCounter: 0, defCounter: 0, countered: false };
+    }
+
+    const offPlan = ts.offPlanId || 'BALANCED';
+    const defPlan = ts.defPlanId || 'BALANCED';
+    const riskId  = ts.riskId || 'BALANCED';
+    const oppOff  = os?.offPlanId || 'BALANCED';
+    const oppDef  = os?.defPlanId || 'BALANCED';
+
+    const offCounter = (STRATEGIC_OFF_VS_DEF[offPlan] || {})[oppDef] || 0;
+    const defCounter = (STRATEGIC_DEF_VS_OFF[defPlan] || {})[oppOff] || 0;
+
+    // Aggressive risk amplifies the swing (boom/bust); conservative dampens it.
+    const riskMult = riskId === 'AGGRESSIVE' ? 1.25 : riskId === 'CONSERVATIVE' ? 0.8 : 1.0;
+
+    const raw = (offCounter + defCounter) * STRATEGIC_UNIT * riskMult;
+    const edge = Math.max(-STRATEGIC_EDGE_CAP, Math.min(STRATEGIC_EDGE_CAP, raw));
+
+    return {
+        edge,
+        offCounter,
+        defCounter,
+        // A "schematic edge" is a clearly anticipated, hard counter (>= 2 units net).
+        countered: (offCounter + defCounter) >= 2,
+    };
+}
+
+/**
  * Get the combined modifiers for a given game plan and risk profile.
  * @param {string} offPlanId
  * @param {string} defPlanId
@@ -256,6 +342,9 @@ export default {
     DEFENSIVE_PLANS,
     GAME_PLANS,
     RISK_PROFILES,
+    STRATEGIC_OFF_VS_DEF,
+    STRATEGIC_DEF_VS_OFF,
     getStrategyModifiers,
+    computeStrategicEdge,
     updateWeeklyStrategy
 };

--- a/src/core/weeklyNarrativeFlags.js
+++ b/src/core/weeklyNarrativeFlags.js
@@ -173,6 +173,129 @@ export function deriveNarrativeFlags(game, teams = [], opts = {}) {
 }
 
 /**
+ * Canonical set of executive postgame diagnostic tokens.
+ *
+ * These are intentionally terse, high-signal tokens (mirroring the boolean
+ * flag philosophy above) that downstream UI surfaces translate into polished
+ * bullet points. Keeping the vocabulary centralized prevents schema drift.
+ */
+export const GAME_REASONING_TOKENS = Object.freeze({
+  TRENCH_DOMINANCE: 'TRENCH_DOMINANCE',
+  RED_ZONE_EFFICIENCY: 'RED_ZONE_EFFICIENCY',
+  TURNOVER_SWING: 'TURNOVER_SWING',
+  SCHEMATIC_EDGE: 'SCHEMATIC_EDGE',
+  DEPTH_COLLAPSE: 'DEPTH_COLLAPSE',
+});
+
+/**
+ * Derive executive postgame diagnostic flags for a single completed game.
+ *
+ * Pure and deterministic: given identical numeric context, it always returns
+ * identical tokens. It performs no RNG and no I/O. Each entry is a compact
+ * descriptor `{ token, teamId, teamAbbr, detail }` so a UI layer can render a
+ * polished, attributed bullet without re-deriving anything.
+ *
+ * The context shape is engine-agnostic so legacy callers that cannot supply a
+ * field simply omit it (the relevant diagnostic is skipped rather than
+ * crashing). All inputs are coerced defensively.
+ *
+ * @param {object} ctx
+ * @param {{id?:number, abbr?:string}} ctx.home
+ * @param {{id?:number, abbr?:string}} ctx.away
+ * @param {number} [ctx.homeScore]
+ * @param {number} [ctx.awayScore]
+ * @param {{homeOL?:number, awayDL?:number, awayOL?:number, homeDL?:number}} [ctx.trenches]
+ * @param {{home?:{trips:number,tds:number}, away?:{trips:number,tds:number}}} [ctx.redZone]
+ * @param {{home?:number, away?:number}} [ctx.turnovers] - turnovers COMMITTED per side
+ * @param {{home?:number, away?:number}} [ctx.strategicEdge] - bounded edge value per side
+ * @param {{home?:boolean, away?:boolean}} [ctx.schematicCounter] - clean hard-counter per side
+ * @param {{home?:{occurred:boolean,gap?:number}, away?:{occurred:boolean,gap?:number}}} [ctx.depth]
+ * @returns {Array<{token:string, teamId:(number|null), teamAbbr:string, detail:string}>}
+ */
+export function deriveGameReasoningFlags(ctx = {}) {
+  const flags = [];
+  const home = ctx?.home ?? {};
+  const away = ctx?.away ?? {};
+  const homeAbbr = home?.abbr ?? 'HOME';
+  const awayAbbr = away?.abbr ?? 'AWAY';
+  const homeId = home?.id ?? null;
+  const awayId = away?.id ?? null;
+
+  const push = (token, side, detail) => {
+    flags.push({
+      token,
+      teamId: side === 'home' ? homeId : awayId,
+      teamAbbr: side === 'home' ? homeAbbr : awayAbbr,
+      detail,
+    });
+  };
+
+  // ── TRENCH_DOMINANCE ──────────────────────────────────────────────────────
+  // One team's OL completely overmatches the opposing front (pass rush / run stops).
+  const tr = ctx?.trenches ?? {};
+  const TRENCH_GAP = 12;
+  const homeTrench = num(tr.homeOL) - num(tr.awayDL);
+  const awayTrench = num(tr.awayOL) - num(tr.homeDL);
+  if (num(tr.homeOL) > 0 && num(tr.awayDL) > 0 && homeTrench >= TRENCH_GAP) {
+    push(GAME_REASONING_TOKENS.TRENCH_DOMINANCE, 'home', `OL graded out ${Math.round(homeTrench)} pts over the front.`);
+  } else if (num(tr.awayOL) > 0 && num(tr.homeDL) > 0 && awayTrench >= TRENCH_GAP) {
+    push(GAME_REASONING_TOKENS.TRENCH_DOMINANCE, 'away', `OL graded out ${Math.round(awayTrench)} pts over the front.`);
+  }
+
+  // ── RED_ZONE_EFFICIENCY ───────────────────────────────────────────────────
+  // A team failed to convert multiple inside-the-20 possessions into touchdowns.
+  const rz = ctx?.redZone ?? {};
+  const rzCheck = (side, data) => {
+    const trips = num(data?.trips);
+    const tds = num(data?.tds);
+    const misfires = trips - tds;
+    if (trips >= 3 && misfires >= 2) {
+      push(GAME_REASONING_TOKENS.RED_ZONE_EFFICIENCY, side, `Settled for points on ${misfires} of ${trips} red-zone trips.`);
+    }
+  };
+  rzCheck('home', rz.home);
+  rzCheck('away', rz.away);
+
+  // ── TURNOVER_SWING ────────────────────────────────────────────────────────
+  // A side finishes -3 or worse in turnover differential; attribute the swing
+  // to the side that gained the +3-or-better advantage (the narrative driver).
+  const to = ctx?.turnovers ?? {};
+  const homeGiveaways = num(to.home);
+  const awayGiveaways = num(to.away);
+  const homeDifferential = awayGiveaways - homeGiveaways; // takeaways - giveaways
+  if (homeDifferential >= 3) {
+    push(GAME_REASONING_TOKENS.TURNOVER_SWING, 'home', `Won the turnover battle +${homeDifferential}.`);
+  } else if (homeDifferential <= -3) {
+    push(GAME_REASONING_TOKENS.TURNOVER_SWING, 'away', `Won the turnover battle +${-homeDifferential}.`);
+  }
+
+  // ── SCHEMATIC_EDGE ────────────────────────────────────────────────────────
+  // A team successfully anticipated and hard-countered the opponent's tendency.
+  const sc = ctx?.schematicCounter ?? {};
+  const edge = ctx?.strategicEdge ?? {};
+  if (sc.home && num(edge.home) > 0) {
+    push(GAME_REASONING_TOKENS.SCHEMATIC_EDGE, 'home', 'Game plan hard-countered the opponent’s tendencies.');
+  }
+  if (sc.away && num(edge.away) > 0) {
+    push(GAME_REASONING_TOKENS.SCHEMATIC_EDGE, 'away', 'Game plan hard-countered the opponent’s tendencies.');
+  }
+
+  // ── DEPTH_COLLAPSE ────────────────────────────────────────────────────────
+  // In-game injuries forced clearly lower-rated backups into high-leverage roles.
+  const depth = ctx?.depth ?? {};
+  if (depth.home?.occurred) {
+    const gap = num(depth.home?.gap);
+    push(GAME_REASONING_TOKENS.DEPTH_COLLAPSE, 'home', gap > 0 ? `Backups (-${Math.round(gap)} OVR) forced into key snaps.` : 'Backups forced into key snaps.');
+  }
+  if (depth.away?.occurred) {
+    const gap = num(depth.away?.gap);
+    push(GAME_REASONING_TOKENS.DEPTH_COLLAPSE, 'away', gap > 0 ? `Backups (-${Math.round(gap)} OVR) forced into key snaps.` : 'Backups forced into key snaps.');
+  }
+
+  return flags;
+}
+
+/**
  * Summarise narrative flags as a short human-readable label array.
  * Used for headline tagging.
  */

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -169,6 +169,7 @@ function AppContent() {
     promptUserGame,
     userGameLogs,
     userGameLiveStats,
+    userGameReasoningFlags,
     lastWorkerMessageType,
   } = state;
 
@@ -1656,6 +1657,13 @@ function AppContent() {
               awayTeam={awayTeam}
               initialMode={watchMode}
               userTendency={userTendency}
+              gameSummary={{
+                gameReasoningFlags: userGameReasoningFlags || [],
+                homeId: homeTeam?.id,
+                awayId: awayTeam?.id,
+                homeAbbr: homeTeam?.abbr,
+                awayAbbr: awayTeam?.abbr,
+              }}
               onComplete={(scores) => {
                 try {
                   // Belt-and-suspenders save immediately on game completion
@@ -1671,6 +1679,7 @@ function AppContent() {
                     phase: league?.phase,
                     logs: userGameLogs || [],
                     liveStats: userGameLiveStats || null,
+                    gameReasoningFlags: userGameReasoningFlags || [],
                     seasonId: league?.seasonId,
                     gameId: buildCanonicalGameId({
                       seasonId: league?.seasonId,

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -7,6 +7,7 @@ import { getPlayerProfileId, hasValidPlayerProfileId, openPlayerProfile } from "
 import ReplayableGameFlowViewer from "./ReplayableGameFlowViewer.jsx";
 import AdvancedGameStats from "./AdvancedGameStats.jsx";
 import { buildBroadcastGameNotes } from "../../core/broadcastNarrative.js";
+import { buildReasoningBullets } from "../../core/gameSummary.js";
 
 const QUALITY_BADGE_CLASS = {
   "Full detail": "success",
@@ -84,6 +85,9 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
   }
 
   const storyBullets = buildGameBookStory(vm);
+  // Condensed Executive Summary bullets parsed from the identical
+  // gameReasoningFlags tokens the live FinalOverlay uses (single translator).
+  const reasoningBullets = buildReasoningBullets(vm.gameReasoningFlags ?? game?.gameReasoningFlags ?? []);
   const statLeaderCards = vm.statLeaderCards ?? [];
   const gameContextBase = {
     source: "game-book",
@@ -266,6 +270,21 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
         </div>
         {vm.detailWarning ? <p>{vm.detailWarning}</p> : null}
       </section>
+
+      {/* 1b. Executive Summary — condensed reasoning diagnostics, near top */}
+      {reasoningBullets.length > 0 && (
+        <section className="bs-section" data-testid="game-book-executive-summary">
+          <div className="bs-section-header">
+            <h4>Executive Summary</h4>
+            <span className="bs-section-count">Why it played out this way</span>
+          </div>
+          <ul className="bs-list">
+            {reasoningBullets.map((bullet) => (
+              <li key={bullet} className="bs-list-item">{bullet}</li>
+            ))}
+          </ul>
+        </section>
+      )}
 
       {/* 2. Key Performers — always visible near top */}
       <section className="bs-section bs-key-performers" data-testid="game-book-top-performers">

--- a/src/ui/components/GameSimulation.jsx
+++ b/src/ui/components/GameSimulation.jsx
@@ -17,6 +17,7 @@ import React, {
 } from "react";
 import AnimatedField from "./AnimatedField.jsx";
 import PlayerCard, { ovrTier, posColor } from "./PlayerCard.jsx";
+import { buildReasoningBullets } from "../../core/gameSummary.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -639,6 +640,10 @@ export default function GameSimulation({
   userTeamId,
   onComplete,
   offenseScheme = null,  // e.g. "SMASHMOUTH"
+  // Full worker result/summary block (carries gameReasoningFlags). Receiving
+  // the complete object — not just raw play logs — closes the serialization
+  // gap so the post-sim view can render the Executive Summary diagnostics.
+  gameSummary = null,
 }) {
   const [index, setIndex] = useState(0);
   const [playing, setPlaying] = useState(true);
@@ -1042,6 +1047,7 @@ export default function GameSimulation({
           userTeamId={userTeamId}
           onContinue={handleFinish}
           logs={effectiveLogs}
+          gameSummary={gameSummary}
         />
       )}
     </div>
@@ -1050,7 +1056,7 @@ export default function GameSimulation({
 
 // ── Final Score Overlay ───────────────────────────────────────────────────────
 
-function FinalOverlay({ homeTeam, awayTeam, homeScore, awayScore, homeColor, awayColor, userTeamId, onContinue, logs }) {
+function FinalOverlay({ homeTeam, awayTeam, homeScore, awayScore, homeColor, awayColor, userTeamId, onContinue, logs, gameSummary = null }) {
   const homeWon = homeScore > awayScore;
   const tied = homeScore === awayScore;
   const userIsHome = homeTeam?.id === userTeamId;
@@ -1090,6 +1096,14 @@ function FinalOverlay({ homeTeam, awayTeam, homeScore, awayScore, homeColor, awa
     const sorted = Object.values(acc).sort((a, b) => b.score - a.score);
     return sorted[0]?.player || null;
   }, [logs]);
+
+  // Executive Summary — translate the worker's gameReasoningFlags tokens into
+  // polished postgame bullet points through the shared core translator so the
+  // live overlay and the historical Game Book never diverge.
+  const reasoningBullets = useMemo(
+    () => buildReasoningBullets(gameSummary?.gameReasoningFlags ?? []),
+    [gameSummary],
+  );
 
   return (
     <div style={{
@@ -1162,6 +1176,33 @@ function FinalOverlay({ homeTeam, awayTeam, homeScore, awayScore, homeColor, awa
               Game MVP
             </div>
             <PlayerCard player={mvpPlayer} variant="standard" />
+          </div>
+        )}
+
+        {/* Executive Summary — high-density postgame reasoning diagnostics */}
+        {reasoningBullets.length > 0 && (
+          <div
+            data-testid="final-executive-summary"
+            style={{
+              marginBottom: 20,
+              textAlign: "left",
+              background: "rgba(255,255,255,0.05)",
+              border: "1px solid rgba(255,255,255,0.12)",
+              borderRadius: 12,
+              padding: "12px 14px",
+            }}
+          >
+            <div style={{ fontSize: "0.65rem", fontWeight: 800, color: "var(--text-subtle)",
+              textTransform: "uppercase", letterSpacing: "1px", marginBottom: 8 }}>
+              Executive Summary
+            </div>
+            <ul style={{ margin: 0, padding: 0, listStyle: "none", display: "grid", gap: 6 }}>
+              {reasoningBullets.map((bullet) => (
+                <li key={bullet} style={{ fontSize: "0.8rem", lineHeight: 1.4, color: "rgba(255,255,255,0.88)" }}>
+                  • {bullet}
+                </li>
+              ))}
+            </ul>
           </div>
         )}
 

--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -65,6 +65,7 @@ export const INITIAL_WORKER_STATE = {
   promptUserGame: false,
   userGameLogs: null,
   userGameLiveStats: null,
+  userGameReasoningFlags: null,
   lastWorkerMessageType: null,
 };
 
@@ -139,13 +140,13 @@ export function workerReducer(state, action) {
     case 'PROMPT_USER_GAME':
       return { ...state, busy: false, simulating: false, simProgress: 0, promptUserGame: true, userGameLogs: null };
     case 'PLAY_LOGS':
-      return { ...state, busy: false, simulating: false, promptUserGame: false, userGameLogs: action.logs, userGameLiveStats: action.liveStats || null };
+      return { ...state, busy: false, simulating: false, promptUserGame: false, userGameLogs: action.logs, userGameLiveStats: action.liveStats || null, userGameReasoningFlags: action.gameReasoningFlags || [] };
     case 'CLEAR_USER_GAME':
-      return { ...state, promptUserGame: false, userGameLogs: null, userGameLiveStats: null };
+      return { ...state, promptUserGame: false, userGameLogs: null, userGameLiveStats: null, userGameReasoningFlags: null };
     case 'CLEAR_RESULTS':
       return { ...state, lastResults: [], lastSimWeek: null, gameEvents: [] };
     case 'SIM_START':
-      return { ...state, simulating: true, simProgress: 0, gameEvents: [], promptUserGame: false, userGameLogs: null };
+      return { ...state, simulating: true, simProgress: 0, gameEvents: [], promptUserGame: false, userGameLogs: null, userGameReasoningFlags: null };
     case 'BATCH_SIM_START':
       return { ...state, busy: true, batchSim: { currentWeek: 0, phase: '', targetPhase: action.targetPhase, status: 'running' } };
     case 'BATCH_SIM_PROGRESS':
@@ -347,7 +348,7 @@ export function useWorker() {
           dispatch({ type: 'PROMPT_USER_GAME' });
           break;
         case toUI.PLAY_LOGS:
-          dispatch({ type: 'PLAY_LOGS', logs: payload.logs, liveStats: payload.liveStats });
+          dispatch({ type: 'PLAY_LOGS', logs: payload.logs, liveStats: payload.liveStats, gameReasoningFlags: payload.gameReasoningFlags });
           break;
         case toUI.SIM_PROGRESS:
           dispatch({ type: 'SIM_PROGRESS', done: payload.done, total: payload.total });

--- a/src/ui/utils/boxScoreViewModel.js
+++ b/src/ui/utils/boxScoreViewModel.js
@@ -578,6 +578,7 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
       injuries: hasInjuries,
     },
     gameFlowSummary: buildGameFlowSummary(payload),
+    gameReasoningFlags: Array.isArray(payload?.gameReasoningFlags) ? payload.gameReasoningFlags : [],
     prepImpact: Array.isArray(payload?.prepImpact) ? payload.prepImpact : (payload?.prepImpact ? [String(payload.prepImpact)] : []),
     advancedAttribution: normalizeAdvancedAttribution(payload?.advancedAttribution ?? game?.advancedAttribution),
     detailWarning,

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -10836,8 +10836,14 @@ async function handleWatchGame(payload, id) {
     // First flush: persist game result before sending logs to UI
     await flushDirty();
 
-    // Send play-by-play logs to UI so the viewer can render
-    post(toUI.PLAY_LOGS, { logs: res.playLogs || [], liveStats: res.liveStats || {} }, id);
+    // Send play-by-play logs to UI so the viewer can render.
+    // gameReasoningFlags rides along so the live FinalOverlay can render the
+    // Executive Summary without a second round-trip to the worker.
+    post(toUI.PLAY_LOGS, {
+      logs: res.playLogs || [],
+      liveStats: res.liveStats || {},
+      gameReasoningFlags: Array.isArray(res.gameReasoningFlags) ? res.gameReasoningFlags : [],
+    }, id);
 
     // Second flush (belt-and-suspenders): catch any dirty bits set during log building
     try { await flushDirty(); } catch (e) { console.warn('[Worker] secondary flush failed (non-fatal):', e.message); }


### PR DESCRIPTION
Map weekly tactical inputs into bounded modifiers inside the deterministic
drive loop and surface clear postgame reasoning signatures using the existing
narrative structures.

Engine (src/core):
- strategy.js: add computeStrategicEdge() with deterministic offense/defense
  counter matrices, risk scaling, and a hard ±5% execution cap. Legacy teams
  without a strategy profile resolve to a neutral zero edge.
- game-simulator.js: evaluate each team's plan vs the opponent and inject the
  bounded edge into buildDriveBasedSummary's drive-conversion probability
  (without changing the seeded RNG draw count) and into the drive loop scoring
  probability. Derive a gameReasoningFlags array (TRENCH_DOMINANCE,
  RED_ZONE_EFFICIENCY, TURNOVER_SWING, SCHEMATIC_EDGE, DEPTH_COLLAPSE) and
  thread it through simulateBatch and commitGameResult. No raw Math.random().
- weeklyNarrativeFlags.js: add deriveGameReasoningFlags() diagnostic engine and
  GAME_REASONING_TOKENS, building on the existing flag pattern.
- gameSummary.js: add buildReasoningBullets()/reasoningFlagToClause() shared
  token-to-prose translator used by both UI surfaces.
- gameArchive.js: persist gameReasoningFlags in the normalized archive schema.

UI (src/ui):
- worker.js + useWorker.js + App.jsx: serialize gameReasoningFlags through the
  PLAY_LOGS worker payload into view state.
- GameSimulation.jsx: expand signature to receive the full gameSummary block and
  pass it into FinalOverlay, which renders a high-density Executive Summary.
- BoxScore.jsx + boxScoreViewModel.js: render a condensed Executive Summary near
  the top of the historical Game Book from the identical tokens.

Tests:
- src/core/__tests__/simStrategicResponsiveness.test.js: assert ±5% bound,
  deterministic identical-setup outcomes, legacy fallback safety, and the
  diagnostic/translation behavior.

https://claude.ai/code/session_01GUsd8gCE6TMetBjCKXLSTC