### PR TITLE
Fix broken Playwright cut player flow

### DIFF
--- a/tests/e2e/daily_regression.spec.js
+++ b/tests/e2e/daily_regression.spec.js
@@ -181,11 +181,8 @@ test.describe('Daily Regression Pass', () => {
             page.on('dialog', d => d.accept());
 
             await page.evaluate(() => {
-                const rows = document.querySelectorAll('.standings-table tbody tr, table tbody tr');
-                for(let row of rows) {
-                    const confirmBtn = Array.from(row.querySelectorAll('button')).find(b => b.innerText === 'Confirm');
-                    if (confirmBtn) { confirmBtn.click(); break; }
-                }
+                const confirmBtn = Array.from(document.querySelectorAll('button')).find(b => b.innerText === 'Confirm Release');
+                if (confirmBtn) { confirmBtn.click(); }
             });
 
             // Wait for release to process


### PR DESCRIPTION
Update daily_regression.spec.js to find "Confirm Release" button inside the ReleasePreviewModal for player cuts, correctly interacting with the current UI to restore test suite passing.

---
*PR created automatically by Jules for task [7575041236162452499](https://jules.google.com/task/7575041236162452499) started by @rbcati*