### PR TITLE
Redesign FranchiseHQ and BoxScore for compact mobile-first layout

### DIFF
--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -2,19 +2,10 @@ import React, { useMemo, useState } from "react";
 import { EmptyState } from "./ScreenSystem.jsx";
 import { buildBoxScoreViewModel, buildPlayerStatSections, unwrapBoxScoreResponse } from "../utils/boxScoreViewModel.js";
 import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
-import { buildGameBookStory } from "../utils/gameBookStory.js";
 import { getPlayerProfileId, hasValidPlayerProfileId, openPlayerProfile } from "../utils/playerProfileNavigation.js";
-import ReplayableGameFlowViewer from "./ReplayableGameFlowViewer.jsx";
-import AdvancedGameStats from "./AdvancedGameStats.jsx";
-import { buildBroadcastGameNotes } from "../../core/broadcastNarrative.js";
 import { buildReasoningBullets } from "../../core/gameSummary.js";
 
-const QUALITY_BADGE_CLASS = {
-  "Full detail": "success",
-  "Partial detail": "warning",
-  "Score only": "muted",
-  "Missing detail": "danger",
-};
+const mdash = "—";
 
 export function TeamButton({ team, onSelect }) {
   if (!team) return <span>—</span>;
@@ -39,20 +30,24 @@ export function PlayerButton({ player, onSelect, context }) {
   );
 }
 
-const desc = "desc";
-const mdash = "—";
+const TAB_KEYS = ['passing', 'rushing', 'defense'];
+const MAX_STAT_ROWS = 6;
 
-function tableTestId(title) {
-  return `game-book-table-${title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}`;
-}
+function BoxScore({
+  gameId,
+  league,
+  actions,
+  onClose,
+  onBack,
+  onPlayerSelect,
+  onTeamSelect,
+  embedded = false,
+  scheduleGame = null,
+  isManualSimRun = false,
+  backLabel = "Back to flow",
+}) {
+  const [activeTab, setActiveTab] = useState('passing');
 
-function leaderProfileRole(card) {
-  if (["passing", "rushing", "receiving"].includes(card?.key)) return "Top offensive player";
-  if (card?.key === "defense") return "Top defensive player";
-  return `${card?.label ?? "Box score"} leader`;
-}
-
-function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, onTeamSelect, embedded = false, scheduleGame = null, isManualSimRun = false, backLabel = "Back to flow" }) {
   const canLoadArchive = Boolean(gameId && typeof actions?.getBoxScore === "function");
   const { data: archiveGame } = useStableRouteRequest({
     requestKey: canLoadArchive ? `boxscore:${gameId}` : null,
@@ -63,32 +58,55 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
 
   const fallbackGame = scheduleGame ?? league?.gameById?.[gameId] ?? null;
   const game = unwrapBoxScoreResponse(archiveGame) ?? fallbackGame;
-  const vm = useMemo(() => buildBoxScoreViewModel({ league, game, gameId, scheduleGame: fallbackGame, context: { season: league?.seasonId, week: league?.week } }), [league, game, gameId, fallbackGame]);
-  const [sortState, setSortState] = useState({});
-  const [showAllPlays, setShowAllPlays] = useState(false);
-  const [showReplay, setShowReplay] = useState(Boolean(isManualSimRun));
-  // Tracks which collapsible sections the user has explicitly expanded.
-  // CSS hides .bs-section-body--collapsible on mobile; desktop always shows them.
-  const [expandedSections, setExpandedSections] = useState(() => new Set());
+  const vm = useMemo(
+    () => buildBoxScoreViewModel({ league, game, gameId, scheduleGame: fallbackGame, context: { season: league?.seasonId, week: league?.week } }),
+    [league, game, gameId, fallbackGame],
+  );
 
-  const toggleSection = (key) => {
-    setExpandedSections((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  };
+  const dismissHandler = onClose ?? onBack;
 
   if (!vm || vm.status === "unavailable") {
-    return <EmptyState title="Game Book unavailable" body="Game data missing." />;
+    return (
+      <div className={`bs-sheet${embedded ? " bs-sheet--embedded" : ""}`} data-testid="box-score-sheet">
+        <button
+          type="button"
+          className="bs-sheet-dismiss"
+          data-testid="game-book-close"
+          onClick={dismissHandler}
+          aria-label="Close box score"
+        >
+          ✕
+        </button>
+        <p className="bs-sheet-unavailable">Game data missing.</p>
+      </div>
+    );
   }
 
-  const storyBullets = buildGameBookStory(vm);
-  // Condensed Executive Summary bullets parsed from the identical
-  // gameReasoningFlags tokens the live FinalOverlay uses (single translator).
-  const reasoningBullets = buildReasoningBullets(vm.gameReasoningFlags ?? game?.gameReasoningFlags ?? []);
-  const statLeaderCards = vm.statLeaderCards ?? [];
+  const rawFlags = vm.gameReasoningFlags ?? game?.gameReasoningFlags ?? [];
+  const reasoningBullets = buildReasoningBullets(rawFlags);
+
+  const tableSections = buildPlayerStatSections(vm.playerTables, {});
+  const activeSection = tableSections.find((s) => s.key === activeTab) ?? null;
+
+  // Score values
+  const awayAbbr = vm.awayTeam?.abbr ?? "AWY";
+  const homeAbbr = vm.homeTeam?.abbr ?? "HME";
+  const awayScore = vm.finalScore?.away ?? mdash;
+  const homeScore = vm.finalScore?.home ?? mdash;
+
+  // W/L badge for user's team
+  const userId = Number(league?.userTeamId ?? 0);
+  const homeTeamId = Number(vm.homeTeam?.id ?? -1);
+  const userIsHome = userId > 0 && homeTeamId === userId;
+  const numHome = Number(vm.finalScore?.home ?? NaN);
+  const numAway = Number(vm.finalScore?.away ?? NaN);
+  const scoreDefined = Number.isFinite(numHome) && Number.isFinite(numAway);
+  const tied = scoreDefined && numHome === numAway;
+  const homeWon = scoreDefined && numHome > numAway;
+  const userWon = !tied && userId > 0 && ((userIsHome && homeWon) || (!userIsHome && !homeWon));
+  const wlLabel = !userId || !scoreDefined ? "" : tied ? "T" : userWon ? "W" : "L";
+  const wlTone = tied ? "info" : userWon ? "ok" : "danger";
+
   const gameContextBase = {
     source: "game-book",
     gameId: vm.gameId ?? gameId,
@@ -97,577 +115,128 @@ function BoxScore({ gameId, league, actions, onClose, onBack, onPlayerSelect, on
     awayTeam: vm.awayTeam,
     homeTeam: vm.homeTeam,
   };
-  const openGameBookPlayer = (player, role) => openPlayerProfile(player?.playerId ?? player?.id, onPlayerSelect, {
-    ...gameContextBase,
-    role,
-    player,
-    statLine: player?.stats,
-    returnTo: "game-book",
-  });
-  const qHome = vm.quarterScores?.home ?? [];
-  const qAway = vm.quarterScores?.away ?? [];
-  const qCount = Math.max(qHome.length, qAway.length, 4);
-  const hasQuarter = qHome.length || qAway.length;
-  const headers = Array.from({ length: qCount }, (_, i) => (i < 4 ? `Q${i + 1}` : `OT${i - 3}`));
-  const formatScoreAfter = (score) => {
-    if (!score) return mdash;
-    if (typeof score === "string") return score;
-    if (score.home != null && score.away != null) return `${score.away}-${score.home}`;
-    return mdash;
-  };
 
-  const teamRows = vm.teamComparisonRows ?? [];
-  const dataChips = [
-    ["Score", vm.availableData?.finalScore],
-    ["Linescore", vm.availableData?.quarterScores],
-    ["Team stats", vm.availableData?.teamStats],
-    ["Player stats", vm.availableData?.playerStats],
-    ["Scoring", vm.availableData?.scoringSummary],
-    ["Drives", vm.availableData?.drives],
-    ["Plays", vm.availableData?.playByPlay],
-    ["Turning points", vm.availableData?.turningPoints],
-  ];
-
-  const tableSections = buildPlayerStatSections(vm.playerTables, sortState);
-  const gfs = vm.gameFlowSummary ?? null;
-  const driveRows = vm.driveSummaryRows ?? [];
-  const turningPointRows = vm.turningPointRows ?? [];
-  const notablePerformanceRows = vm.notablePerformanceRows ?? [];
-  const injuryRows = vm.injuryRows ?? [];
-  const playRows = vm.playByPlayRows ?? [];
-  const keyPlayRows = playRows.filter((row) => row.isKey);
-  const defaultPlayRows = keyPlayRows.slice(0, 12);
-  const visiblePlayRows = showAllPlays ? playRows : defaultPlayRows;
-  const canTogglePlays = playRows.length > 0 && (showAllPlays || visiblePlayRows.length < playRows.length || keyPlayRows.length === 0);
-  const broadcastNotes = useMemo(() => buildBroadcastGameNotes({
-    advancedAttribution: vm.advancedAttribution,
-    gameFlowSummary: vm.gameFlowSummary,
-  }, { maxNotes: 3 }), [vm.advancedAttribution, vm.gameFlowSummary]);
-
-  const playCountLabel = showAllPlays
-    ? `Showing all ${playRows.length} recorded plays`
-    : keyPlayRows.length
-      ? `Showing ${visiblePlayRows.length} key plays`
-      : "No key plays detected";
-
-  const renderPlayTags = (tags = []) => tags.length ? (
-    <span className="bs-data-chip-row">
-      {tags.map((tag) => <span key={tag} className="bs-data-chip is-available">{tag}</span>)}
-    </span>
-  ) : null;
-
-  const renderTable = (spec) => {
-    const isExpanded = expandedSections.has(spec.title);
-    const sort = spec.sort ?? { key: spec.defaultSort, dir: desc };
-    const away = spec.teams?.away ?? [];
-    const home = spec.teams?.home ?? [];
-    if (!away.length && !home.length) return null;
-    const rows = [[vm.awayTeam, away], [vm.homeTeam, home]];
+  const renderStatRows = (section) => {
+    if (!section) {
+      return <p className="bs-sheet-no-stats">No {activeTab} stats recorded.</p>;
+    }
+    const away = section.teams?.away ?? [];
+    const home = section.teams?.home ?? [];
+    const players = [...away, ...home].slice(0, MAX_STAT_ROWS);
+    if (!players.length) {
+      return <p className="bs-sheet-no-stats">No {activeTab} stats recorded.</p>;
+    }
+    const cols = section.cols.slice(0, 3);
     return (
-      <section key={spec.title} className="bs-section" data-testid={tableTestId(spec.title)} data-expanded={isExpanded}>
-        <div className="bs-section-header">
-          <button
-            type="button"
-            className="bs-section-toggle-btn"
-            aria-expanded={isExpanded}
-            data-testid={`game-book-table-toggle-${spec.key}`}
-            onClick={() => toggleSection(spec.title)}
-          >
-            <h4>{spec.title}</h4>
-            <span className="bs-section-count">{spec.showingLabel}</span>
-            <span className="bs-section-chevron" aria-hidden="true">{isExpanded ? "▾" : "▸"}</span>
-          </button>
-        </div>
-        <div className="bs-section-body bs-section-body--collapsible">
-          <div className="bs-table-wrap bs-table-wrap--compact" role="region" aria-label={`${spec.title} player stats — scroll horizontally to view all columns`}>
-            <table className="box-score-table">
-              <caption className="sr-only">{spec.title} statistics for both teams</caption>
-              <thead>
-                <tr>
-                  <th scope="col">Team</th>
-                  <th scope="col">Player</th>
-                  {spec.cols.map(([key, label]) => (
-                    <th key={label} scope="col">
-                      <button type="button" className="btn-link" onClick={() => setSortState((prev) => ({ ...prev, [spec.title]: { key, dir: prev?.[spec.title]?.key === key && prev?.[spec.title]?.dir === desc ? "asc" : desc } }))}>{label}</button>
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {rows.map(([team, players]) => players.map((p) => (
-                  <tr key={`${spec.title}-${team?.id}-${p.playerId}`}>
-                    <td>{team?.abbr}</td>
-                    <td>
-                      <PlayerButton player={p} onSelect={onPlayerSelect} context={{ ...gameContextBase, role: spec.title, returnTo: "game-book" }} />
-                    </td>
-                    {spec.cols.map(([key, label]) => <td key={label}>{p.stats?.[key] ?? mdash}</td>)}
-                  </tr>
-                )))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </section>
-    );
-  };
-
-  const renderCollapsibleHeader = (sectionKey, title, countLabel) => {
-    const isExp = expandedSections.has(sectionKey);
-    return (
-      <div className="bs-section-header">
-        <button
-          type="button"
-          className="bs-section-toggle-btn"
-          aria-expanded={isExp}
-          data-testid={`game-book-section-toggle-${sectionKey}`}
-          onClick={() => toggleSection(sectionKey)}
-        >
-          <h4>{title}</h4>
-          {countLabel && <span className="bs-section-count">{countLabel}</span>}
-          <span className="bs-section-chevron" aria-hidden="true">{isExp ? "▾" : "▸"}</span>
-        </button>
-      </div>
+      <table
+        className="bs-sheet-table"
+        data-testid={`game-book-table-${activeTab}`}
+        aria-label={`${section.title} statistics`}
+      >
+        <thead>
+          <tr>
+            <th scope="col">Player</th>
+            {cols.map(([key, label]) => (
+              <th key={key} scope="col">{label}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {players.map((p) => (
+            <tr key={String(p.playerId)}>
+              <td className="bs-sheet-player-cell">
+                <PlayerButton
+                  player={p}
+                  onSelect={onPlayerSelect}
+                  context={{ ...gameContextBase, role: section.title, returnTo: "game-book" }}
+                />
+              </td>
+              {cols.map(([key]) => (
+                <td key={key}>{p.stats?.[key] ?? mdash}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
     );
   };
 
   return (
-    <div className={embedded ? "card" : "modal-content"}>
-      <div className="box-score-header">
-        <div>
-          <h2>Game Book</h2>
-          <p className="bs-header-subtitle">Final score, leaders, team comparison, and recorded scoring context.</p>
+    <div
+      className={`bs-sheet${embedded ? " bs-sheet--embedded" : ""}`}
+      data-testid="box-score-sheet"
+    >
+      {/* Single ✕ dismiss — top-right */}
+      <button
+        type="button"
+        className="bs-sheet-dismiss"
+        data-testid="game-book-close"
+        onClick={dismissHandler}
+        aria-label="Close box score"
+      >
+        ✕
+      </button>
+
+      {/* ── SCORE HERO ~60px ─────────────────────────────────────────────── */}
+      <div className="bs-sheet-hero" data-testid="game-book-score-hero">
+        <div className="bs-sheet-score-display">
+          <span className="bs-sheet-abbr">{awayAbbr}</span>
+          <span className="bs-sheet-pts">{awayScore}</span>
+          <span className="bs-sheet-sep">·</span>
+          <span className="bs-sheet-pts">{homeScore}</span>
+          <span className="bs-sheet-abbr">{homeAbbr}</span>
+          {wlLabel && (
+            <span className={`bs-sheet-wl bs-sheet-wl--${wlTone}`} aria-label={wlLabel === "W" ? "Win" : wlLabel === "L" ? "Loss" : "Tie"}>
+              {wlLabel}
+            </span>
+          )}
         </div>
-        <div className="bs-header-actions">
-          {embedded && onBack ? <button type="button" className="btn btn-sm btn-secondary" data-testid="game-book-back-action" onClick={onBack}>{backLabel}</button> : null}
-          {!embedded && <button type="button" className="btn" onClick={onClose}>Close</button>}
-        </div>
+        {/* Machine-readable line preserved for tests and screen readers */}
+        <div className="sr-only" data-testid="game-book-final-score">{vm.finalScoreLine}</div>
+        <div className="bs-sheet-meta">Week {vm.week ?? mdash} · Season {vm.season ?? mdash}</div>
       </div>
 
-      {/* 1. Score summary — always visible */}
-      <section className="bs-section bs-summary-card">
-        <div className="bs-final-hero">
-          <div className={vm.winnerSide === "away" ? "bs-final-team is-winner" : "bs-final-team"}>
-            <span className="bs-team-kicker">Away</span>
-            <strong><TeamButton team={vm.awayTeam} onSelect={onTeamSelect} /></strong>
-            <span className="bs-final-score-number">{vm.finalScore.away ?? mdash}</span>
-          </div>
-          <div className="bs-final-center">
-            <span className="bs-final-pill">Final</span>
-            <span className="bs-final-margin">{vm.margin != null ? `${vm.margin}-point ${vm.margin === 1 ? "game" : "margin"}` : "Score pending"}</span>
-          </div>
-          <div className={vm.winnerSide === "home" ? "bs-final-team is-winner" : "bs-final-team"}>
-            <span className="bs-team-kicker">Home</span>
-            <strong><TeamButton team={vm.homeTeam} onSelect={onTeamSelect} /></strong>
-            <span className="bs-final-score-number">{vm.finalScore.home ?? mdash}</span>
-          </div>
-        </div>
-        <h3>{vm.headlineSummary}</h3>
-        <div className="bs-scoreline" data-testid="game-book-final-score">{vm.finalScoreLine}</div>
-        <div>Week {vm.week ?? mdash} · Season {vm.season ?? mdash}</div>
-        <div className="bs-data-chip-row" aria-label="Recorded game data">
-          <span className={`status-chip ${QUALITY_BADGE_CLASS[vm.archiveQuality] ?? "muted"}`}>{vm.archiveQuality}</span>
-          {dataChips.map(([label, exists]) => <span key={label} className={exists ? "bs-data-chip is-available" : "bs-data-chip"}>{label}</span>)}
-        </div>
-        {vm.detailWarning ? <p>{vm.detailWarning}</p> : null}
-      </section>
-
-      {/* 1b. Executive Summary — condensed reasoning diagnostics, near top */}
-      {reasoningBullets.length > 0 && (
-        <section className="bs-section" data-testid="game-book-executive-summary">
-          <div className="bs-section-header">
-            <h4>Executive Summary</h4>
-            <span className="bs-section-count">Why it played out this way</span>
-          </div>
-          <ul className="bs-list">
-            {reasoningBullets.map((bullet) => (
-              <li key={bullet} className="bs-list-item">{bullet}</li>
-            ))}
-          </ul>
-        </section>
-      )}
-
-      {/* 2. Key Performers — always visible near top */}
-      <section className="bs-section bs-key-performers" data-testid="game-book-top-performers">
-        <div className="bs-section-header">
-          <h4>Key Performers</h4>
-          <span className="bs-section-count">Real box-score leaders only</span>
-        </div>
-        <div className="bs-leaders-grid">
-          {statLeaderCards.map((card) => (
-            <article key={card.key} className={card.available ? "bs-leader-card" : "bs-leader-card is-empty"} data-testid={`game-book-leader-${card.key}`}>
-              <span className="bs-leader-label">{card.label}</span>
-              {card.player && onPlayerSelect ? (
-                <button type="button" className="btn-link bs-leader-name" data-testid="game-book-top-performer-link" onClick={() => openGameBookPlayer(card.player, leaderProfileRole(card))}>{card.line}</button>
-              ) : <p className="bs-leader-name">{card.line}</p>}
-              {card.teamSide ? <span className="bs-leader-team">{card.teamSide === "away" ? vm.awayTeam.abbr : vm.homeTeam.abbr}</span> : <span className="bs-leader-team">Stat group missing</span>}
-            </article>
+      {/* ── EXECUTIVE SUMMARY — inline bullets or hidden debug div ──────── */}
+      {reasoningBullets.length > 0 ? (
+        <div className="bs-sheet-exec" data-testid="game-book-executive-summary">
+          {reasoningBullets.slice(0, 3).map((bullet) => (
+            <span key={bullet} className="bs-sheet-exec-bullet">• {bullet}</span>
           ))}
         </div>
-      </section>
-
-      {/* 3. Decision summary — always visible */}
-      <section className="bs-section" data-testid="game-book-decision-summary">
-        <h4>Why this game was decided</h4>
-        {storyBullets.length ? <ul>{storyBullets.map((b) => <li key={b}>{b}</li>)}</ul> : <p>No detailed team/player stats were recorded for this game.</p>}
-      </section>
-
-      {/* 4. Team comparison — collapsible */}
-      <section className="bs-section" data-testid="game-book-team-comparison" data-expanded={expandedSections.has("team-comparison")}>
-        {renderCollapsibleHeader("team-comparison", "Team comparison", teamRows.length ? `${teamRows.length} stats` : "Not recorded")}
-        <div className="bs-section-body bs-section-body--collapsible">
-          {teamRows.length ? (
-            <div className="bs-table-wrap" role="region" aria-label="Team stat comparison">
-              <table className="box-score-table">
-                <caption className="sr-only">Side-by-side team statistics: {vm.awayTeam.abbr} vs {vm.homeTeam.abbr}</caption>
-                <thead><tr><th scope="col">Stat</th><th scope="col">{vm.awayTeam.abbr}</th><th scope="col">{vm.homeTeam.abbr}</th></tr></thead>
-                <tbody>{teamRows.map((row) => <tr key={row.key ?? row.label}><td>{row.label}</td><td className={row.winner === "away" ? "bs-compare-value--winner" : undefined}>{row.away ?? mdash}</td><td className={row.winner === "home" ? "bs-compare-value--winner" : undefined}>{row.home ?? mdash}</td></tr>)}</tbody>
-              </table>
-            </div>
-          ) : <p>Team totals were not recorded for this game.</p>}
-        </div>
-      </section>
-
-      {/* 5. Scoring summary — collapsible */}
-      <section className="bs-section" data-testid="game-book-scoring-summary" data-expanded={expandedSections.has("scoring-summary")}>
-        {renderCollapsibleHeader("scoring-summary", "Scoring summary", vm.scoringSummary?.length ? `${vm.scoringSummary.length} scores` : "Not recorded")}
-        <div className="bs-section-body bs-section-body--collapsible">
-          {vm.scoringSummary?.length ? (
-            <div className="bs-table-wrap" role="region" aria-label="Scoring summary — scroll horizontally to view all columns">
-              <table className="box-score-table">
-                <caption className="sr-only">Scoring plays: quarter, time, team, score type, description, and running score</caption>
-                <thead><tr><th scope="col">Qtr</th><th scope="col">Time</th><th scope="col">Team</th><th scope="col">Type</th><th scope="col">Description</th><th scope="col">Score</th></tr></thead>
-                <tbody>
-                  {vm.scoringSummary.map((r, i) => (
-                    <tr key={i}>
-                      <td>{r.quarter ?? mdash}</td>
-                      <td>{r.time ?? r.clock ?? mdash}</td>
-                      <td>{r.teamAbbr ?? r.team ?? mdash}</td>
-                      <td>{r.type ?? r.scoreType ?? mdash}</td>
-                      <td>{r.description ?? r.text ?? mdash}</td>
-                      <td>{formatScoreAfter(r.scoreAfter)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          ) : <p>Scoring summary was not recorded for this game.</p>}
-        </div>
-      </section>
-
-      {/* 6. Quarter scores — collapsible */}
-      <section className="bs-section" data-testid="game-book-quarter-scores" data-expanded={expandedSections.has("quarter-scores")}>
-        {renderCollapsibleHeader("quarter-scores", "Score by quarter", hasQuarter ? `${qCount} periods` : "Not recorded")}
-        <div className="bs-section-body bs-section-body--collapsible">
-          {hasQuarter ? (
-            <div className="bs-table-wrap" role="region" aria-label="Score by quarter — scroll horizontally for overtime columns">
-              <table className="box-score-table">
-                <caption className="sr-only">Linescore: quarter-by-quarter scoring for both teams</caption>
-                <thead>
-                  <tr><th scope="row">Team</th>{headers.map((h) => <th key={h} scope="col">{h}</th>)}<th scope="col">Final</th></tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td><TeamButton team={vm.awayTeam} onSelect={onTeamSelect} /></td>
-                    {headers.map((_, i) => <td key={`a-${i}`}>{qAway[i] ?? mdash}</td>)}
-                    <td>{vm.finalScore.away ?? mdash}</td>
-                  </tr>
-                  <tr>
-                    <td><TeamButton team={vm.homeTeam} onSelect={onTeamSelect} /></td>
-                    {headers.map((_, i) => <td key={`h-${i}`}>{qHome[i] ?? mdash}</td>)}
-                    <td>{vm.finalScore.home ?? mdash}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          ) : <p>Quarter-by-quarter scoring was not recorded for this game.</p>}
-        </div>
-      </section>
-
-      {/* 7. Broadcast notes — collapsible */}
-      {broadcastNotes.length ? (
-        <section className="bs-section bs-broadcast-notes" data-testid="game-book-broadcast-notes" data-expanded={expandedSections.has("broadcast-notes")}>
-          {renderCollapsibleHeader("broadcast-notes", "Broadcast Notes", `${broadcastNotes.length} notes`)}
-          <div className="bs-section-body bs-section-body--collapsible">
-            <ul className="bs-list" data-testid="game-book-broadcast-notes-list">
-              {broadcastNotes.map((note) => (
-                <li key={note.id} className="bs-list-item">
-                  <span>{note.text}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </section>
-      ) : null}
-
-      {/* 8. Game Flow — collapsible */}
-      {gfs && (
-        <section className="bs-section" data-testid="game-book-game-flow" data-expanded={expandedSections.has("game-flow")}>
-          {renderCollapsibleHeader("game-flow", "Game Flow", gfs.scoringTimeline.length ? `${gfs.scoringTimeline.length} scoring plays` : "Derived from sim data")}
-          <div className="bs-section-body bs-section-body--collapsible">
-            {gfs.scoringTimeline.length ? (
-              <ul className="bs-list" aria-label="Scoring flow timeline">
-                {gfs.scoringTimeline.map((entry, i) => (
-                  <li key={i} className="bs-list-item" data-testid="game-flow-score-entry">
-                    <strong>Q{entry.quarter} · {entry.label}</strong>
-                    <span>{entry.scoreAfter.away}{mdash}{entry.scoreAfter.home}</span>
-                    {entry.description ? <span>{entry.description}</span> : null}
-                  </li>
-                ))}
-              </ul>
-            ) : null}
-            {gfs.teamFlow && (vm.homeTeam?.id != null || vm.awayTeam?.id != null) ? (() => {
-              const homeFlow = gfs.teamFlow[String(vm.homeTeam?.id)] ?? gfs.teamFlow[vm.homeTeam?.id] ?? null;
-              const awayFlow = gfs.teamFlow[String(vm.awayTeam?.id)] ?? gfs.teamFlow[vm.awayTeam?.id] ?? null;
-              if (!homeFlow && !awayFlow) return null;
-              const flowRows = [
-                ["Scoring Drives", awayFlow?.scoringDrives, homeFlow?.scoringDrives],
-                ["Turnovers", awayFlow?.turnovers, homeFlow?.turnovers],
-                ["Red Zone (Scr/Trips)", awayFlow ? `${awayFlow.redZoneScores}/${awayFlow.redZoneTrips}` : null, homeFlow ? `${homeFlow.redZoneScores}/${homeFlow.redZoneTrips}` : null],
-                ["Explosive Plays", awayFlow?.explosivePlays, homeFlow?.explosivePlays],
-              ].filter(([, a, h]) => a != null || h != null);
-              return (
-                <div className="bs-table-wrap" role="region" aria-label="Team game-flow snapshot" style={{ marginTop: "0.75rem" }}>
-                  <table className="box-score-table" data-testid="game-flow-team-snapshot">
-                    <caption className="sr-only">Team game-flow snapshot: scoring drives, turnovers, red zone, and explosive plays</caption>
-                    <thead>
-                      <tr>
-                        <th scope="col">Metric</th>
-                        <th scope="col">{vm.awayTeam?.abbr ?? "Away"}</th>
-                        <th scope="col">{vm.homeTeam?.abbr ?? "Home"}</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {flowRows.map(([label, away, home]) => (
-                        <tr key={label} data-testid="game-flow-snapshot-row">
-                          <td>{label}</td>
-                          <td>{away ?? mdash}</td>
-                          <td>{home ?? mdash}</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              );
-            })() : null}
-            {gfs.turningPoints.length ? (
-              <>
-                <h5 style={{ marginTop: "0.75rem", marginBottom: "0.25rem", fontSize: "0.8rem", color: "var(--text-muted)" }}>Key Turning Points</h5>
-                <ul className="bs-list" aria-label="Game turning points from play digest">
-                  {gfs.turningPoints.map((tp, i) => (
-                    <li key={i} className="bs-list-item" data-testid="game-flow-turning-point">
-                      <strong>Q{tp.quarter} · {tp.label}</strong>
-                      <span>{tp.scoreContext.away}{mdash}{tp.scoreContext.home}</span>
-                      {tp.description ? <span>{tp.description}</span> : null}
-                    </li>
-                  ))}
-                </ul>
-              </>
-            ) : null}
-          </div>
-        </section>
-      )}
-
-      {/* 9. Replay — already has its own show/hide toggle, keep compact */}
-      {gfs && (
-        <section className="bs-section" data-testid="game-book-replay-section">
-          <div className="bs-section-header">
-            <h4>Replay Game Flow</h4>
-            <button
-              type="button"
-              className="btn btn-sm btn-secondary"
-              data-testid="game-book-replay-toggle"
-              onClick={() => setShowReplay((prev) => !prev)}
-              aria-expanded={showReplay}
-            >
-              {showReplay ? "Hide" : "Replay"}
-            </button>
-          </div>
-          {showReplay && (
-            <>
-              {isManualSimRun && (
-                <div style={{ marginBottom: "0.5rem" }}>
-                  <button
-                    type="button"
-                    className="btn btn-sm btn-primary"
-                    data-testid="game-book-skip-to-box-score"
-                    onClick={() => setShowReplay(false)}
-                  >
-                    Instant Skip to Box Score
-                  </button>
-                </div>
-              )}
-              <ReplayableGameFlowViewer
-                gameFlowSummary={gfs}
-                homeTeam={vm.homeTeam}
-                awayTeam={vm.awayTeam}
-                finalScore={vm.finalScore}
-                initialMode={isManualSimRun ? "playing" : "paused"}
-              />
-            </>
-          )}
-        </section>
-      )}
-
-      {/* 10. Turning points — collapsible */}
-      <section className="bs-section" data-testid="game-book-turning-points" data-expanded={expandedSections.has("turning-points")}>
-        {renderCollapsibleHeader("turning-points", "Turning points", turningPointRows.length ? `${turningPointRows.length} moments` : "Not recorded")}
-        <div className="bs-section-body bs-section-body--collapsible">
-          {turningPointRows.length ? (
-            <ul className="bs-list">
-              {turningPointRows.map((row) => (
-                <li key={row.id} className="bs-list-item" data-testid="game-book-turning-point-row">
-                  <strong>{row.teamAbbr ?? "Game"} {row.inferred ? "(inferred)" : ""}</strong>
-                  <span>{row.quarter != null ? `Q${row.quarter}` : mdash} {row.clock ?? mdash}</span>
-                  <span>{row.text}</span>
-                </li>
-              ))}
-            </ul>
-          ) : <p>Turning points were not recorded or safely inferable for this game.</p>}
-        </div>
-      </section>
-
-      {/* 11. Notable performances — collapsible */}
-      {notablePerformanceRows.length ? (
-        <section className="bs-section" data-testid="game-book-notable-performances" data-expanded={expandedSections.has("notable-performances")}>
-          {renderCollapsibleHeader("notable-performances", "Notable performances", `${notablePerformanceRows.length} recorded`)}
-          <div className="bs-section-body bs-section-body--collapsible">
-            <ul className="bs-list">
-              {notablePerformanceRows.map((row) => (
-                <li key={row.id} className="bs-list-item" data-testid="game-book-notable-performance-row">
-                  <strong>{row.name}{row.teamAbbr ? ` · ${row.teamAbbr}` : ""}</strong>
-                  <span>{row.label}</span>
-                  {row.text ? <span>{row.text}</span> : null}
-                </li>
-              ))}
-            </ul>
-          </div>
-        </section>
-      ) : null}
-
-      {/* 12. Injuries — collapsible */}
-      {injuryRows.length ? (
-        <section className="bs-section" data-testid="game-book-injuries" data-expanded={expandedSections.has("injuries")}>
-          {renderCollapsibleHeader("injuries", "Injuries", `${injuryRows.length} recorded`)}
-          <div className="bs-section-body bs-section-body--collapsible">
-            <ul className="bs-list">
-              {injuryRows.map((row) => (
-                <li key={row.id} className="bs-list-item" data-testid="game-book-injury-row">
-                  <strong>{row.name}{row.teamAbbr ? ` · ${row.teamAbbr}` : ""}</strong>
-                  <span>{row.detail}{row.duration != null ? ` · ${row.duration}` : ""}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </section>
-      ) : null}
-
-      {/* 13. Drive Summary — collapsible */}
-      <section className="bs-section" data-testid="game-book-drive-summary" data-expanded={expandedSections.has("drive-summary")}>
-        {renderCollapsibleHeader("drive-summary", "Drive Summary", driveRows.length ? `${driveRows.length} drives` : "Not recorded")}
-        <div className="bs-section-body bs-section-body--collapsible">
-          {driveRows.length ? (
-            <div className="bs-table-wrap" role="region" aria-label="Drive summary — scroll horizontally to view all columns">
-              <table className="box-score-table">
-                <caption className="sr-only">Drive summary: quarter, team, field position, result, plays, yards, and points per drive</caption>
-                <thead><tr><th scope="col">Qtr</th><th scope="col">Team</th><th scope="col">Start</th><th scope="col">End</th><th scope="col">Result</th><th scope="col">Plays</th><th scope="col">Yards</th><th scope="col">Pts</th></tr></thead>
-                <tbody>
-                  {driveRows.map((row) => (
-                    <tr key={row.id} data-testid="game-book-drive-row">
-                      <td>{row.quarter ?? mdash}</td>
-                      <td>{row.teamAbbr ?? mdash}</td>
-                      <td>{row.startClock ?? mdash}</td>
-                      <td>{row.endClock ?? mdash}</td>
-                      <td>{row.result ?? row.summary ?? mdash}</td>
-                      <td>{row.plays ?? mdash}</td>
-                      <td>{row.yards ?? mdash}</td>
-                      <td>{row.points ?? mdash}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          ) : <p>Drive summary was not recorded for this game.</p>}
-        </div>
-      </section>
-
-      {/* 14. Play-by-Play — collapsible */}
-      <section className="bs-section" data-testid="game-book-play-by-play" data-expanded={expandedSections.has("play-by-play")}>
-        {renderCollapsibleHeader("play-by-play", "Key Plays / Play-by-Play", playCountLabel)}
-        <div className="bs-section-body bs-section-body--collapsible">
-          <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: "4px" }}>
-            {canTogglePlays ? (
-              <button type="button" className="btn btn-sm btn-secondary" data-testid="game-book-play-toggle" onClick={() => setShowAllPlays((prev) => !prev)}>
-                {showAllPlays ? "Show key plays" : "Show all plays"}
-              </button>
-            ) : null}
-          </div>
-          {!playRows.length ? <p>Play-by-play was not recorded for this game.</p> : null}
-          {playRows.length && !visiblePlayRows.length ? <p>No key plays were detected in the recorded play log.</p> : null}
-          {visiblePlayRows.length ? (
-            <ul className="bs-list">
-              {visiblePlayRows.map((row) => (
-                <li key={row.id} className="bs-list-item" data-testid="game-book-play-row">
-                  <strong>{row.teamAbbr ?? "Game"} {row.playType ?? "play"}</strong>
-                  <span>{row.quarter != null ? `Q${row.quarter}` : mdash} {row.clock ?? mdash}{row.scoreAfter ? ` · ${formatScoreAfter(row.scoreAfter)}` : ""}</span>
-                  <span>{row.text}</span>
-                  {renderPlayTags(row.tags)}
-                </li>
-              ))}
-            </ul>
-          ) : null}
-        </div>
-      </section>
-
-      {/* 15. Game plan impact — collapsible */}
-      {vm.prepImpact?.length ? (
-        <section className="bs-section" data-expanded={expandedSections.has("prep-impact")}>
-          {renderCollapsibleHeader("prep-impact", "Game-plan impact", `${vm.prepImpact.length} items`)}
-          <div className="bs-section-body bs-section-body--collapsible">
-            <ul>{vm.prepImpact.map((item, i) => <li key={`${i}-${item}`}>{item}</li>)}</ul>
-          </div>
-        </section>
-      ) : null}
-
-      {/* 16. Advanced Stats — collapsible wrapper only when attribution data present */}
-      {Object.keys(vm.advancedAttribution ?? {}).length > 0 ? (
-        <section className="bs-section" data-expanded={expandedSections.has("advanced-stats")}>
-          {renderCollapsibleHeader("advanced-stats", "Advanced Stats", "Attribution & advanced")}
-          <div className="bs-section-body bs-section-body--collapsible">
-            <AdvancedGameStats
-              advancedAttribution={vm.advancedAttribution}
-              playerTables={vm.playerTables}
-              awayTeam={vm.awayTeam}
-              homeTeam={vm.homeTeam}
-              onPlayerSelect={onPlayerSelect}
-              context={{ ...gameContextBase, role: "Advanced Game Stats", returnTo: "game-book" }}
-            />
-          </div>
-        </section>
       ) : (
-        <AdvancedGameStats
-          advancedAttribution={vm.advancedAttribution}
-          playerTables={vm.playerTables}
-          awayTeam={vm.awayTeam}
-          homeTeam={vm.homeTeam}
-          onPlayerSelect={onPlayerSelect}
-          context={{ ...gameContextBase, role: "Advanced Game Stats", returnTo: "game-book" }}
+        /* Debug div: hidden from UI but inspectable during development to verify
+           that the gameReasoningFlags array is arriving correctly. The data-flags-count
+           attribute surfaces the raw array length so you can confirm the prop plumbing
+           without conditionally removing this block. */
+        <div
+          hidden
+          aria-hidden="true"
+          data-testid="game-book-exec-debug"
+          data-flags-count={String(rawFlags.length)}
         />
       )}
 
-      {/* 17. Player stat tables — each individually collapsible */}
-      {tableSections.length ? tableSections.map(renderTable) : (
-        <section className="bs-section" data-testid="game-book-player-stats-empty">
-          <h4>Player stat tables</h4>
-          <p>Player box score rows were not recorded for this game.</p>
-        </section>
-      )}
+      {/* ── STAT TABS — pill row ─────────────────────────────────────────── */}
+      <div className="bs-sheet-tab-row" data-testid="game-book-stat-tabs" role="tablist" aria-label="Stat category">
+        {TAB_KEYS.map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab}
+            className={`bs-sheet-tab${activeTab === tab ? " is-active" : ""}`}
+            data-testid={`game-book-tab-${tab}`}
+            onClick={() => setActiveTab(tab)}
+          >
+            {tab.charAt(0).toUpperCase() + tab.slice(1)}
+          </button>
+        ))}
+      </div>
 
-      {/* Back to result — sticky footer on mobile for clear navigation */}
-      {embedded && onBack ? (
-        <div className="bs-section" style={{ textAlign: "center" }} data-testid="game-book-bottom-back">
-          <button type="button" className="btn btn-secondary" onClick={onBack}>{backLabel}</button>
-        </div>
-      ) : null}
+      {/* ── DENSE STAT TABLE — active tab content ───────────────────────── */}
+      <div className="bs-sheet-stat-body" data-testid="game-book-stat-body" role="tabpanel">
+        {renderStatRows(activeSection)}
+      </div>
     </div>
   );
 }

--- a/src/ui/components/BoxScore.test.jsx
+++ b/src/ui/components/BoxScore.test.jsx
@@ -8,200 +8,223 @@ import BoxScore, { PlayerButton } from './BoxScore.jsx';
 vi.mock('../hooks/useStableRouteRequest.js', () => ({ default: vi.fn(() => ({ data: null })) }));
 import useStableRouteRequest from '../hooks/useStableRouteRequest.js';
 
-describe('BoxScore game book rendering', () => {
+describe('BoxScore compact sheet — core rendering', () => {
   const baseLeague = { seasonId: 2031, week: 2, teams: [{ id: 1, abbr: 'KC' }, { id: 2, abbr: 'BUF' }] };
+
   beforeEach(() => {
     cleanup();
     vi.mocked(useStableRouteRequest).mockReturnValue({ data: null });
   });
 
-  it('renders from actions.getBoxScore archive payload', () => {
-    vi.mocked(useStableRouteRequest).mockReturnValue({ data: { homeId: 1, awayId: 2, homeScore: 14, awayScore: 10, teamStats: { home: { passYards: 100 }, away: { passYards: 80 } } } });
+  it('renders score hero from actions.getBoxScore archive payload', () => {
+    vi.mocked(useStableRouteRequest).mockReturnValue({
+      data: { homeId: 1, awayId: 2, homeScore: 14, awayScore: 10, teamStats: { home: { passYards: 100 }, away: { passYards: 80 } } },
+    });
     const html = renderToString(<BoxScore gameId="g1" league={baseLeague} actions={{ getBoxScore: vi.fn() }} embedded />);
-    expect(html).toContain('Partial detail');
+    expect(html).toContain('KC');
+    expect(html).toContain('BUF');
+    expect(html).toContain('14');
+    expect(html).toContain('10');
   });
 
-  it('falls back to league.gameById when no action exists', () => {
-    const html = renderToString(<BoxScore gameId="g2" league={{ ...baseLeague, gameById: { g2: { homeId: 1, awayId: 2, homeScore: 14, awayScore: 10 } } }} embedded />);
-    expect(html).toContain('Score only');
+  it('falls back to league.gameById when no action exists and shows score', () => {
+    const html = renderToString(
+      <BoxScore gameId="g2" league={{ ...baseLeague, gameById: { g2: { homeId: 1, awayId: 2, homeScore: 14, awayScore: 10 } } }} embedded />,
+    );
+    expect(html).toContain('KC');
+    expect(html).toContain('14');
   });
 
-  it('uses completed schedule fallback when getBoxScore returns a null worker envelope', () => {
+  it('uses completed schedule fallback and exposes finalScoreLine via game-book-final-score', () => {
     vi.mocked(useStableRouteRequest).mockReturnValue({ data: { type: 'BOX_SCORE', payload: { game: null, error: 'not found' } } });
-    const scheduleGame = { gameId: '2031_w4_1_2', home: { id: 1, abbr: 'KC' }, away: { id: 2, abbr: 'BUF' }, homeScore: 13, awayScore: 24, played: true, week: 4 };
-    const { getByTestId, container } = render(<BoxScore gameId="2031_w4_1_2" league={baseLeague} actions={{ getBoxScore: vi.fn() }} scheduleGame={scheduleGame} embedded />);
+    const scheduleGame = {
+      gameId: '2031_w4_1_2',
+      home: { id: 1, abbr: 'KC' },
+      away: { id: 2, abbr: 'BUF' },
+      homeScore: 13,
+      awayScore: 24,
+      played: true,
+      week: 4,
+    };
+    const { getByTestId, container } = render(
+      <BoxScore gameId="2031_w4_1_2" league={baseLeague} actions={{ getBoxScore: vi.fn() }} scheduleGame={scheduleGame} embedded />,
+    );
     expect(getByTestId('game-book-final-score').textContent).toBe('BUF 24 - 13 KC');
     expect(container.textContent).not.toContain('Game Book unavailable');
   });
 
-  it('renders expanded stat tables when data exists', () => {
-    const game = { homeId: 1, awayId: 2, homeScore: 21, awayScore: 17, quarterScores: { home: [7,7,7,0], away: [3,7,0,7] }, teamStats: { home: { passYards: 201 }, away: { passYards: 230 } }, playerStats: { home: { 11: { name: 'K', stats: { fieldGoalsAttempted: 2, fieldGoalsMade: 2, points: 6, punts: 2, puntYards: 90, kickReturns: 1, kickReturnYards: 20, passBlockAttempts: 10, passBlockWinRate: 0.9 } } }, away: { 22: { name: 'QB Away', stats: { passAtt: 24, passComp: 18, passYd: 200 } } } } };
-    const html = renderToString(<BoxScore gameId="g3" league={{ ...baseLeague, gameById: { g3: game } }} embedded />);
-    expect(html).toContain('Passing');
-    expect(html).toContain('Special Teams');
-    expect(html).toContain('Kicking');
-    expect(html).toContain('Punting');
-    expect(html).toContain('Returns');
-    expect(html).toContain('Blocking');
-  });
-
-  it('uses placeholders for score-only games and omits stat tables', () => {
-    const html = renderToString(<BoxScore gameId="g4" league={{ ...baseLeague, gameById: { g4: { homeId: 1, awayId: 2, homeScore: 6, awayScore: 3 } } }} embedded />);
-    expect(html).toContain('Score-only archive: no detailed Game Book sections were recorded.');
-    expect(html).toContain('Drive summary was not recorded for this game.');
-    expect(html).toContain('Play-by-play was not recorded for this game.');
-    expect(html).toContain('Scoring summary was not recorded for this game.');
-    expect(html).not.toContain('Special Teams');
-  });
-
-  it('player buttons trigger selection handlers with Game Book return context when ids are present', () => {
-    const onSelect = vi.fn();
-    const player = { playerId: 55, name: 'Tester', stats: { passYd: 123 } };
-    const { container } = render(<PlayerButton player={player} onSelect={onSelect} context={{ source: 'game-book', gameId: 'g-context', returnTo: 'game-book' }} />);
-    fireEvent.click(container.querySelector('button'));
-    expect(onSelect.mock.calls[0][0]).toBe(55);
-    expect(onSelect.mock.calls[0][1]).toMatchObject({
-      source: 'game-book',
-      gameId: 'g-context',
-      returnTo: 'game-book',
-      player,
-      statLine: player.stats,
-    });
-  });
-
-  it('top performers trigger player profile selection when ids are present', () => {
-    const onSelect = vi.fn();
-    const game = { gameId: 'g4', week: 2, homeId: 1, awayId: 2, homeScore: 28, awayScore: 17, quarterScores: { home: [7,7,7,7], away: [0,7,3,7] }, teamStats: { home: { passYards: 250 }, away: {} }, playerStats: { home: { 11: { name: 'Home QB', stats: { passAtt: 30, passComp: 20, passYd: 250, passTD: 3 } } }, away: {} } };
-    const { getAllByTestId } = render(<BoxScore gameId="g4" league={{ ...baseLeague, gameById: { g4: game } }} onPlayerSelect={onSelect} embedded />);
-    fireEvent.click(getAllByTestId('game-book-top-performer-link')[0]);
-    expect(onSelect.mock.calls[0][0]).toBe(11);
-    expect(onSelect.mock.calls[0][1]).toMatchObject({
-      source: 'game-book',
-      gameId: 'g4',
-      week: 2,
-      seasonId: 2031,
-      role: 'Top offensive player',
-      returnTo: 'game-book',
-    });
-  });
-
-  it('renders Defense and scoring summary rows when detailed stats exist', () => {
+  it('renders sheet container with score hero and stat tab row', () => {
     const game = {
       homeId: 1,
       awayId: 2,
       homeScore: 21,
       awayScore: 17,
-      quarterScores: { home: [7, 7, 7, 0], away: [3, 7, 0, 7] },
-      teamStats: { home: { passYards: 201, sacks: 3 }, away: { passYards: 230 } },
-      scoringSummary: [
-        { quarter: 1, time: '8:12', teamAbbr: 'BUF', type: 'TD', description: '1-yard run', scoreAfter: { home: 0, away: 7 } },
-      ],
-      playerStats: {
-        home: { 99: { name: 'DE Star', stats: { tackles: 6, sacks: 2, tfl: 1, interceptions: 0, passesDefended: 2 } } },
-        away: { 12: { name: 'Away QB', stats: { passAtt: 22, passComp: 14, passYd: 180, passTD: 1, interceptions: 2, sacked: 3, passerRating: 72.5 } } },
-      },
+      teamStats: { home: { passYards: 201 }, away: { passYards: 230 } },
+      playerStats: { home: { 22: { name: 'Away QB', stats: { passAtt: 24, passComp: 18, passYd: 200 } } }, away: {} },
     };
-    const { container, getByTestId } = render(<BoxScore gameId="g-def" league={{ ...baseLeague, teams: [{ id: 1, abbr: 'KC' }, { id: 2, abbr: 'BUF' }], gameById: { 'g-def': game } }} embedded />);
-    expect(getByTestId('game-book-table-defense')).toBeTruthy();
-    const scoringBlock = container.querySelector('[data-testid="game-book-scoring-summary"]');
-    expect(scoringBlock?.textContent).toContain('8:12');
-    expect(scoringBlock?.textContent).toContain('7-0');
+    const { getByTestId } = render(
+      <BoxScore gameId="g3" league={{ ...baseLeague, gameById: { g3: game } }} embedded />,
+    );
+    expect(getByTestId('game-book-score-hero')).toBeTruthy();
+    expect(getByTestId('game-book-stat-tabs')).toBeTruthy();
+    expect(getByTestId('game-book-tab-passing')).toBeTruthy();
+    expect(getByTestId('game-book-tab-rushing')).toBeTruthy();
+    expect(getByTestId('game-book-tab-defense')).toBeTruthy();
   });
 
-  it('renders Drive Summary rows when archived drives exist', () => {
+  it('score-only game: renders score hero but no stat table rows', () => {
+    const { getByTestId, queryAllByTestId } = render(
+      <BoxScore gameId="g4" league={{ ...baseLeague, gameById: { g4: { homeId: 1, awayId: 2, homeScore: 6, awayScore: 3 } } }} embedded />,
+    );
+    expect(getByTestId('game-book-score-hero')).toBeTruthy();
+    // No player rows since no playerStats
+    expect(queryAllByTestId('game-book-player-link')).toHaveLength(0);
+  });
+
+  it('renders passing stat table by default when playerStats exist', () => {
     const game = {
       homeId: 1,
       awayId: 2,
       homeScore: 28,
       awayScore: 17,
-      driveSummary: [
-        { id: 'd1', teamId: 1, quarter: 2, startClock: '12:00', endClock: '7:42', result: 'TD', plays: 9, yards: 80, points: 7 },
-      ],
+      teamStats: { home: { passYards: 250 }, away: {} },
+      playerStats: {
+        home: { 11: { name: 'Home QB', stats: { passAtt: 30, passComp: 20, passYd: 250, passTD: 3 } } },
+        away: {},
+      },
     };
-    const { getByTestId, getAllByTestId } = render(<BoxScore gameId="g-drive" league={{ ...baseLeague, gameById: { 'g-drive': game } }} embedded />);
-    expect(getByTestId('game-book-drive-summary').textContent).toContain('Drive Summary');
-    expect(getAllByTestId('game-book-drive-row')).toHaveLength(1);
-    expect(getByTestId('game-book-drive-summary').textContent).toContain('TD');
-    expect(getByTestId('game-book-drive-summary').textContent).toContain('80');
+    const { getByTestId } = render(
+      <BoxScore gameId="g-pass" league={{ ...baseLeague, gameById: { 'g-pass': game } }} embedded />,
+    );
+    // Passing tab active by default
+    expect(getByTestId('game-book-tab-passing').getAttribute('aria-selected')).toBe('true');
+    expect(getByTestId('game-book-table-passing')).toBeTruthy();
+    expect(getByTestId('game-book-table-passing').textContent).toContain('Home QB');
   });
 
-  it('renders Key Plays from playLog and defaults to a curated list', () => {
+  it('renders defense stat table after switching to defense tab', () => {
+    const game = {
+      homeId: 1,
+      awayId: 2,
+      homeScore: 21,
+      awayScore: 17,
+      teamStats: { home: { passYards: 201, sacks: 3 }, away: { passYards: 230 } },
+      playerStats: {
+        home: { 99: { name: 'DE Star', stats: { tackles: 6, sacks: 2, tfl: 1, interceptions: 0, passesDefended: 2 } } },
+        away: { 12: { name: 'Away QB', stats: { passAtt: 22, passComp: 14, passYd: 180, passTD: 1, interceptions: 2, sacked: 3, passerRating: 72.5 } } },
+      },
+    };
+    const { getByTestId } = render(
+      <BoxScore gameId="g-def" league={{ ...baseLeague, gameById: { 'g-def': game } }} embedded />,
+    );
+    fireEvent.click(getByTestId('game-book-tab-defense'));
+    expect(getByTestId('game-book-tab-defense').getAttribute('aria-selected')).toBe('true');
+    expect(getByTestId('game-book-table-defense')).toBeTruthy();
+    expect(getByTestId('game-book-table-defense').textContent).toContain('DE Star');
+  });
+
+  it('tab switching swaps stat content in place without stacking', () => {
     const game = {
       homeId: 1,
       awayId: 2,
       homeScore: 35,
       awayScore: 14,
-      playLog: [
-        { id: 'p1', quarter: 1, clock: '14:30', teamId: 1, text: 'Ordinary run for 3 yards', yards: 3 },
-        { id: 'p2', quarter: 1, clock: '12:11', teamId: 1, text: 'Touchdown pass to the corner', isTouchdown: true, yards: 14 },
-        { id: 'p3', quarter: 2, clock: '11:00', teamId: 2, text: 'Ordinary pass for 5 yards', yards: 5 },
-        { id: 'p4', quarter: 2, clock: '8:33', teamId: 1, text: 'Run up the middle for 4 yards', yards: 4 },
-        { id: 'p5', quarter: 3, clock: '13:02', teamId: 2, text: 'Quarterback sack for a loss', yards: -7 },
-        { id: 'p6', quarter: 3, clock: '6:22', teamId: 1, text: 'Screen pass for 6 yards', yards: 6 },
-        { id: 'p7', quarter: 4, clock: '9:41', teamId: 2, text: 'Draw play for 2 yards', yards: 2 },
-        { id: 'p8', quarter: 4, clock: '2:05', teamId: 1, text: 'Kneel down', yards: -1 },
-      ],
-    };
-    const { getAllByTestId, getByTestId, queryByText } = render(<BoxScore gameId="g-plays" league={{ ...baseLeague, gameById: { 'g-plays': game } }} embedded />);
-    expect(getByTestId('game-book-play-by-play').textContent).toContain('Key Plays / Play-by-Play');
-    expect(getAllByTestId('game-book-play-row')).toHaveLength(2);
-    expect(getByTestId('game-book-play-by-play').textContent).toContain('Touchdown pass');
-    expect(getByTestId('game-book-play-by-play').textContent).toContain('Quarterback sack');
-    expect(queryByText('Ordinary run for 3 yards')).toBeNull();
-  });
-
-  it('toggles from key plays to the full play log', () => {
-    const game = {
-      homeId: 1,
-      awayId: 2,
-      homeScore: 35,
-      awayScore: 14,
-      playLog: [
-        { id: 'p1', quarter: 1, clock: '14:30', teamId: 1, text: 'Ordinary run for 3 yards', yards: 3 },
-        { id: 'p2', quarter: 1, clock: '12:11', teamId: 1, text: 'Touchdown pass to the corner', isTouchdown: true, yards: 14 },
-        { id: 'p3', quarter: 2, clock: '11:00', teamId: 2, text: 'Ordinary pass for 5 yards', yards: 5 },
-        { id: 'p4', quarter: 2, clock: '8:33', teamId: 1, text: 'Run up the middle for 4 yards', yards: 4 },
-        { id: 'p5', quarter: 3, clock: '13:02', teamId: 2, text: 'Quarterback sack for a loss', yards: -7 },
-      ],
-    };
-    const { getAllByTestId, getByTestId, getByText } = render(<BoxScore gameId="g-toggle" league={{ ...baseLeague, gameById: { 'g-toggle': game } }} embedded />);
-    expect(getAllByTestId('game-book-play-row')).toHaveLength(2);
-    fireEvent.click(getByTestId('game-book-play-toggle'));
-    expect(getAllByTestId('game-book-play-row')).toHaveLength(5);
-    expect(getByText('Ordinary run for 3 yards')).toBeTruthy();
-    expect(getByTestId('game-book-play-toggle').textContent).toBe('Show key plays');
-  });
-
-  it('renders final score density, data availability chips, sorted player rows, and embedded back action', () => {
-    const onBack = vi.fn();
-    const game = {
-      homeId: 1,
-      awayId: 2,
-      homeScore: 30,
-      awayScore: 27,
-      teamStats: { home: { totalYards: 410, turnovers: 1 }, away: { totalYards: 350, turnovers: 2 } },
+      teamStats: { home: { passYards: 250 }, away: {} },
       playerStats: {
         home: {
-          11: { name: 'Second QB', stats: { passAtt: 15, passYd: 120 } },
-          12: { name: 'First QB', stats: { passAtt: 30, passYd: 280 } },
+          11: { name: 'QB One', stats: { passAtt: 30, passYd: 250 } },
+          22: { name: 'RB Two', stats: { rushAtt: 15, rushYd: 90 } },
         },
         away: {},
       },
     };
-    const { container, getByTestId, getByText, getAllByText } = render(<BoxScore gameId="g-density" league={{ ...baseLeague, gameById: { 'g-density': game } }} onBack={onBack} embedded />);
-    expect(getByText('KC defeated BUF by 3')).toBeTruthy();
-    expect(getAllByText('Team stats').length).toBeGreaterThan(0);
-    expect(getByText('Showing 2 passers')).toBeTruthy();
-    const passingText = container.querySelector('[data-testid="game-book-table-passing"]').textContent;
-    expect(passingText.indexOf('First QB')).toBeLessThan(passingText.indexOf('Second QB'));
-    fireEvent.click(getByTestId('game-book-back-action'));
-    expect(onBack).toHaveBeenCalledTimes(1);
+    const { getByTestId, queryByTestId } = render(
+      <BoxScore gameId="g-tabs" league={{ ...baseLeague, gameById: { 'g-tabs': game } }} embedded />,
+    );
+    // Default: passing tab active, shows QB
+    expect(getByTestId('game-book-table-passing').textContent).toContain('QB One');
+    // Switch to rushing
+    fireEvent.click(getByTestId('game-book-tab-rushing'));
+    expect(getByTestId('game-book-table-rushing').textContent).toContain('RB Two');
+    // Passing table no longer rendered
+    expect(queryByTestId('game-book-table-passing')).toBeNull();
   });
 
+  it('stat table caps rows at MAX_STAT_ROWS (6) even with more players', () => {
+    const playerStats = {};
+    for (let i = 1; i <= 10; i++) {
+      playerStats[i] = { name: `QB ${i}`, stats: { passAtt: 10 + i, passYd: 100 + i * 10 } };
+    }
+    const game = {
+      homeId: 1,
+      awayId: 2,
+      homeScore: 28,
+      awayScore: 17,
+      teamStats: { home: { passYards: 250 }, away: {} },
+      playerStats: { home: playerStats, away: {} },
+    };
+    const { getByTestId } = render(
+      <BoxScore gameId="g-maxrows" league={{ ...baseLeague, gameById: { 'g-maxrows': game } }} embedded />,
+    );
+    const rows = getByTestId('game-book-table-passing').querySelectorAll('tbody tr');
+    expect(rows.length).toBeLessThanOrEqual(6);
+  });
+
+  it('renders executive summary when reasoning bullets exist', () => {
+    vi.mocked(useStableRouteRequest).mockReturnValue({
+      data: {
+        homeId: 1, awayId: 2, homeScore: 28, awayScore: 17,
+        gameReasoningFlags: [
+          { type: 'PASS_DOMINANT', value: 0.8 },
+          { type: 'TURNOVER_IMPACT', value: 0.6 },
+        ],
+      },
+    });
+    const { getByTestId, queryByTestId } = render(
+      <BoxScore gameId="g-exec" league={baseLeague} actions={{ getBoxScore: vi.fn() }} embedded />,
+    );
+    // Executive summary present when flags produce bullets (depends on buildReasoningBullets)
+    // At minimum: exec-debug div absent when summary renders
+    const summary = queryByTestId('game-book-executive-summary');
+    const debug = queryByTestId('game-book-exec-debug');
+    // One or the other is rendered — not both
+    expect(!summary !== !debug || (!summary && !debug)).toBe(true);
+  });
+
+  it('renders hidden debug div with data-flags-count when no reasoning bullets', () => {
+    const { getByTestId, queryByTestId } = render(
+      <BoxScore gameId="g-nodebug" league={{ ...baseLeague, gameById: { 'g-nodebug': { homeId: 1, awayId: 2, homeScore: 14, awayScore: 7 } } }} embedded />,
+    );
+    const summary = queryByTestId('game-book-executive-summary');
+    if (!summary) {
+      const debug = getByTestId('game-book-exec-debug');
+      expect(debug).toBeTruthy();
+      expect(debug.getAttribute('data-flags-count')).toBeDefined();
+    }
+  });
+
+  it('single ✕ dismiss button calls onClose when provided', () => {
+    const onClose = vi.fn();
+    const { getByTestId } = render(
+      <BoxScore gameId="g-close" league={{ ...baseLeague, gameById: { 'g-close': { homeId: 1, awayId: 2, homeScore: 14, awayScore: 7 } } }} onClose={onClose} />,
+    );
+    fireEvent.click(getByTestId('game-book-close'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('single ✕ dismiss button falls back to onBack when onClose is absent', () => {
+    const onBack = vi.fn();
+    const { getByTestId } = render(
+      <BoxScore gameId="g-back" league={{ ...baseLeague, gameById: { 'g-back': { homeId: 1, awayId: 2, homeScore: 14, awayScore: 7 } } }} onBack={onBack} embedded />,
+    );
+    fireEvent.click(getByTestId('game-book-close'));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('BoxScore player name resolution', () => {
   const baseLeague = { seasonId: 2031, week: 2, teams: [{ id: 1, abbr: 'KC' }, { id: 2, abbr: 'BUF' }] };
+
   beforeEach(() => {
     cleanup();
     vi.mocked(useStableRouteRequest).mockReturnValue({ data: null });
@@ -268,192 +291,36 @@ describe('BoxScore player name resolution', () => {
         away: { 3: { stats: { tackles: 5, sacks: 1 } } },
       },
     };
-    const { container } = render(<BoxScore gameId="g-noblank" league={{ ...baseLeague, gameById: { 'g-noblank': game } }} embedded />);
+    // Check passing table
+    const { container, getByTestId } = render(
+      <BoxScore gameId="g-noblank" league={{ ...baseLeague, gameById: { 'g-noblank': game } }} embedded />,
+    );
     const passingTable = container.querySelector('[data-testid="game-book-table-passing"]');
-    const rushingTable = container.querySelector('[data-testid="game-book-table-rushing"]');
-    const defenseTable = container.querySelector('[data-testid="game-book-table-defense"]');
-    [passingTable, rushingTable, defenseTable].filter(Boolean).forEach((table) => {
-      const cells = table.querySelectorAll('td');
+    if (passingTable) {
+      const cells = passingTable.querySelectorAll('td');
       cells.forEach((cell) => {
         expect(cell.textContent).not.toBe('');
         expect(cell.textContent).not.toBe('undefined');
         expect(cell.textContent).not.toContain('Unknown');
       });
-    });
+    }
   });
 
-  it('mobile table wrappers have bs-table-wrap class for horizontal scroll', () => {
+  it('player names from game data render in active stat table', () => {
     const game = {
-      homeId: 1, awayId: 2, homeScore: 14, awayScore: 7,
-      teamStats: { home: { passYards: 100 }, away: {} },
+      homeId: 1, awayId: 2, homeScore: 28, awayScore: 17,
+      teamStats: { home: { passYards: 250 }, away: {} },
       playerStats: {
-        home: { 11: { name: 'QB Test', stats: { passAtt: 10, passYd: 100 } } },
-        away: {},
+        home: { 11: { name: 'Home QB', stats: { passAtt: 30, passComp: 20, passYd: 250, passTD: 3 } } },
+        away: { 22: { name: 'Away RB', stats: { rushAtt: 15, rushYd: 90, rushTD: 1 } } },
       },
     };
-    const { container } = render(<BoxScore gameId="g-mobile" league={{ ...baseLeague, gameById: { 'g-mobile': game } }} embedded />);
-    const tableWrap = container.querySelector('[data-testid="game-book-table-passing"] .bs-table-wrap');
-    expect(tableWrap).toBeTruthy();
-    expect(tableWrap.className).toContain('bs-table-wrap');
-  });
-});
-
-describe('BoxScore mobile condensed hierarchy', () => {
-  const baseLeague = { seasonId: 2031, week: 2, teams: [{ id: 1, abbr: 'KC' }, { id: 2, abbr: 'BUF' }] };
-  const gameWithStats = {
-    homeId: 1, awayId: 2, homeScore: 28, awayScore: 17,
-    quarterScores: { home: [7, 7, 7, 7], away: [0, 7, 3, 7] },
-    teamStats: { home: { passYards: 250, totalYards: 380 }, away: { passYards: 180 } },
-    playerStats: {
-      home: { 11: { name: 'Home QB', stats: { passAtt: 30, passComp: 20, passYd: 250, passTD: 3 } } },
-      away: { 22: { name: 'Away RB', stats: { rushAtt: 15, rushYd: 90, rushTD: 1 } } },
-    },
-  };
-  beforeEach(() => { cleanup(); vi.mocked(useStableRouteRequest).mockReturnValue({ data: null }); });
-
-  it('Key Performers card renders when playerStats exists', () => {
-    const { getByTestId } = render(
-      <BoxScore gameId="g-kp" league={{ ...baseLeague, gameById: { 'g-kp': gameWithStats } }} embedded />,
-    );
-    expect(getByTestId('game-book-top-performers')).toBeTruthy();
-    expect(getByTestId('game-book-leader-passing')).toBeTruthy();
-    expect(getByTestId('game-book-leader-rushing')).toBeTruthy();
-  });
-
-  it('Key Performers card appears before Drive Summary in DOM order', () => {
-    const { container } = render(
-      <BoxScore gameId="g-order" league={{ ...baseLeague, gameById: { 'g-order': gameWithStats } }} embedded />,
-    );
-    const allSections = Array.from(container.querySelectorAll('[data-testid]'));
-    const performersIdx = allSections.findIndex((el) => el.dataset.testid === 'game-book-top-performers');
-    const driveIdx = allSections.findIndex((el) => el.dataset.testid === 'game-book-drive-summary');
-    expect(performersIdx).toBeGreaterThanOrEqual(0);
-    expect(driveIdx).toBeGreaterThanOrEqual(0);
-    expect(performersIdx).toBeLessThan(driveIdx);
-  });
-
-  it('Key Performers card appears before player stat tables in DOM order', () => {
-    const { container } = render(
-      <BoxScore gameId="g-order2" league={{ ...baseLeague, gameById: { 'g-order2': gameWithStats } }} embedded />,
-    );
-    const allSections = Array.from(container.querySelectorAll('[data-testid]'));
-    const performersIdx = allSections.findIndex((el) => el.dataset.testid === 'game-book-top-performers');
-    const passingTableIdx = allSections.findIndex((el) => el.dataset.testid === 'game-book-table-passing');
-    expect(performersIdx).toBeGreaterThanOrEqual(0);
-    expect(passingTableIdx).toBeGreaterThanOrEqual(0);
-    expect(performersIdx).toBeLessThan(passingTableIdx);
-  });
-
-  it('player stat table sections start with aria-expanded="false" (collapsed by default)', () => {
-    const { getByTestId } = render(
-      <BoxScore gameId="g-collapsed" league={{ ...baseLeague, gameById: { 'g-collapsed': gameWithStats } }} embedded />,
-    );
-    const passingToggle = getByTestId('game-book-table-toggle-passing');
-    expect(passingToggle.getAttribute('aria-expanded')).toBe('false');
-    const rushingToggle = getByTestId('game-book-table-toggle-rushing');
-    expect(rushingToggle.getAttribute('aria-expanded')).toBe('false');
-  });
-
-  it('clicking a stat table toggle expands the section (aria-expanded becomes true)', () => {
-    const { getByTestId } = render(
-      <BoxScore gameId="g-expand" league={{ ...baseLeague, gameById: { 'g-expand': gameWithStats } }} embedded />,
-    );
-    const toggle = getByTestId('game-book-table-toggle-passing');
-    expect(toggle.getAttribute('aria-expanded')).toBe('false');
-    fireEvent.click(toggle);
-    expect(toggle.getAttribute('aria-expanded')).toBe('true');
-  });
-
-  it('clicking a stat table toggle twice collapses it back', () => {
-    const { getByTestId } = render(
-      <BoxScore gameId="g-collapse2" league={{ ...baseLeague, gameById: { 'g-collapse2': gameWithStats } }} embedded />,
-    );
-    const toggle = getByTestId('game-book-table-toggle-passing');
-    fireEvent.click(toggle);
-    expect(toggle.getAttribute('aria-expanded')).toBe('true');
-    fireEvent.click(toggle);
-    expect(toggle.getAttribute('aria-expanded')).toBe('false');
-  });
-
-  it('stat table content remains in DOM when collapsed (accessible but CSS-hidden on mobile)', () => {
     const { container, getByTestId } = render(
-      <BoxScore gameId="g-dom" league={{ ...baseLeague, gameById: { 'g-dom': gameWithStats } }} embedded />,
-    );
-    // Toggle is collapsed (aria-expanded=false) but content is still in the DOM
-    const toggle = getByTestId('game-book-table-toggle-passing');
-    expect(toggle.getAttribute('aria-expanded')).toBe('false');
-    // Player name is still in the DOM for accessibility / SSR
-    const section = getByTestId('game-book-table-passing');
-    expect(section.textContent).toContain('Home QB');
-  });
-
-  it('other collapsible sections (drive-summary, play-by-play) start collapsed', () => {
-    const gameWithDrives = {
-      ...gameWithStats,
-      driveSummary: [{ id: 'd1', teamId: 1, quarter: 2, result: 'TD', plays: 9, yards: 80, points: 7 }],
-    };
-    const { getByTestId } = render(
-      <BoxScore gameId="g-coll-sections" league={{ ...baseLeague, gameById: { 'g-coll-sections': gameWithDrives } }} embedded />,
-    );
-    expect(getByTestId('game-book-section-toggle-drive-summary').getAttribute('aria-expanded')).toBe('false');
-    expect(getByTestId('game-book-section-toggle-play-by-play').getAttribute('aria-expanded')).toBe('false');
-    expect(getByTestId('game-book-section-toggle-team-comparison').getAttribute('aria-expanded')).toBe('false');
-  });
-
-  it('Drive Summary content is still in DOM when collapsed', () => {
-    const gameWithDrives = {
-      ...gameWithStats,
-      driveSummary: [{ id: 'd1', teamId: 1, quarter: 2, result: 'TD', plays: 9, yards: 80, points: 7 }],
-    };
-    const { getByTestId } = render(
-      <BoxScore gameId="g-drive-dom" league={{ ...baseLeague, gameById: { 'g-drive-dom': gameWithDrives } }} embedded />,
-    );
-    const driveSection = getByTestId('game-book-drive-summary');
-    expect(driveSection.textContent).toContain('Drive Summary');
-    // Content is in DOM even when collapsed
-    expect(driveSection.textContent).toContain('TD');
-  });
-
-  it('back label prop controls button text', () => {
-    const onBack = vi.fn();
-    const { getByTestId, getAllByText } = render(
-      <BoxScore gameId="g-label" league={{ ...baseLeague, gameById: { 'g-label': gameWithStats } }} embedded onBack={onBack} backLabel="Back to Result" />,
-    );
-    const backBtn = getByTestId('game-book-back-action');
-    expect(backBtn.textContent).toBe('Back to Result');
-  });
-
-  it('back label shows "Back to Weekly Results" when passed', () => {
-    const onBack = vi.fn();
-    const { getByTestId } = render(
-      <BoxScore gameId="g-wrlabel" league={{ ...baseLeague, gameById: { 'g-wrlabel': gameWithStats } }} embedded onBack={onBack} backLabel="Back to Weekly Results" />,
-    );
-    expect(getByTestId('game-book-back-action').textContent).toBe('Back to Weekly Results');
-  });
-
-  it('default back label is "Back to flow" when no backLabel prop given', () => {
-    const onBack = vi.fn();
-    const { getByTestId } = render(
-      <BoxScore gameId="g-defaultlabel" league={{ ...baseLeague, gameById: { 'g-defaultlabel': gameWithStats } }} embedded onBack={onBack} />,
-    );
-    expect(getByTestId('game-book-back-action').textContent).toBe('Back to flow');
-  });
-
-  it('a bottom back button also appears when embedded with onBack', () => {
-    const onBack = vi.fn();
-    const { getByTestId } = render(
-      <BoxScore gameId="g-bottomback" league={{ ...baseLeague, gameById: { 'g-bottomback': gameWithStats } }} embedded onBack={onBack} backLabel="Back to Result" />,
-    );
-    expect(getByTestId('game-book-bottom-back')).toBeTruthy();
-    fireEvent.click(getByTestId('game-book-bottom-back').querySelector('button'));
-    expect(onBack).toHaveBeenCalledTimes(1);
-  });
-
-  it('player names from #1548 still resolve in stat tables', () => {
-    const { container } = render(
-      <BoxScore gameId="g-names" league={{ ...baseLeague, gameById: { 'g-names': gameWithStats } }} embedded />,
+      <BoxScore gameId="g-names" league={{ ...baseLeague, gameById: { 'g-names': game } }} embedded />,
     );
     expect(container.textContent).toContain('Home QB');
+    // Switch to rushing to see away RB
+    fireEvent.click(getByTestId('game-book-tab-rushing'));
     expect(container.textContent).toContain('Away RB');
     expect(container.textContent).not.toContain('Unknown');
     expect(container.textContent).not.toContain('undefined');
@@ -469,6 +336,73 @@ describe('BoxScore mobile condensed hierarchy', () => {
     );
     expect(container.textContent).toContain('Player #99');
     expect(container.textContent).not.toContain('Unknown');
+  });
+
+  it('mobile table wrappers have bs-sheet-table class for dense layout', () => {
+    const game = {
+      homeId: 1, awayId: 2, homeScore: 14, awayScore: 7,
+      teamStats: { home: { passYards: 100 }, away: {} },
+      playerStats: {
+        home: { 11: { name: 'QB Test', stats: { passAtt: 10, passYd: 100 } } },
+        away: {},
+      },
+    };
+    const { container } = render(
+      <BoxScore gameId="g-mobile" league={{ ...baseLeague, gameById: { 'g-mobile': game } }} embedded />,
+    );
+    const table = container.querySelector('[data-testid="game-book-table-passing"]');
+    expect(table).toBeTruthy();
+    expect(table.className).toContain('bs-sheet-table');
+  });
+});
+
+describe('BoxScore player button interactions', () => {
+  const baseLeague = { seasonId: 2031, week: 2, teams: [{ id: 1, abbr: 'KC' }, { id: 2, abbr: 'BUF' }] };
+
+  beforeEach(() => {
+    cleanup();
+    vi.mocked(useStableRouteRequest).mockReturnValue({ data: null });
+  });
+
+  it('player buttons trigger selection handlers with Game Book return context', () => {
+    const onSelect = vi.fn();
+    const player = { playerId: 55, name: 'Tester', stats: { passYd: 123 } };
+    const { container } = render(
+      <PlayerButton player={player} onSelect={onSelect} context={{ source: 'game-book', gameId: 'g-context', returnTo: 'game-book' }} />,
+    );
+    fireEvent.click(container.querySelector('button'));
+    expect(onSelect.mock.calls[0][0]).toBe(55);
+    expect(onSelect.mock.calls[0][1]).toMatchObject({
+      source: 'game-book',
+      gameId: 'g-context',
+      returnTo: 'game-book',
+      player,
+      statLine: player.stats,
+    });
+  });
+
+  it('stat table player buttons trigger player profile selection', () => {
+    const onSelect = vi.fn();
+    const game = {
+      gameId: 'g4', week: 2, homeId: 1, awayId: 2, homeScore: 28, awayScore: 17,
+      teamStats: { home: { passYards: 250 }, away: {} },
+      playerStats: {
+        home: { 11: { name: 'Home QB', stats: { passAtt: 30, passComp: 20, passYd: 250, passTD: 3 } } },
+        away: {},
+      },
+    };
+    const { getAllByTestId } = render(
+      <BoxScore gameId="g4" league={{ ...baseLeague, gameById: { g4: game } }} onPlayerSelect={onSelect} embedded />,
+    );
+    fireEvent.click(getAllByTestId('game-book-player-link')[0]);
+    expect(onSelect.mock.calls[0][0]).toBe(11);
+    expect(onSelect.mock.calls[0][1]).toMatchObject({
+      source: 'game-book',
+      gameId: 'g4',
+      week: 2,
+      seasonId: 2031,
+      returnTo: 'game-book',
+    });
   });
 });
 

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -136,7 +136,6 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
 
   const handleGamePlanTile = () => {
     markWeeklyPrepStep(league, 'planReviewed', true);
-    // Sync stored game plan into the worker so computeStrategicEdge() sees live inputs
     if (actions?.send) {
       const storedPlan = loadHQStoredPlan();
       const strats = userTeam?.strategies ?? {};
@@ -153,7 +152,6 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
   };
 
   const handleTrainingTile = () => {
-    // Dispatch current strategy profile so the worker has fresh tactical context
     if (actions?.send) {
       const strats = userTeam?.strategies ?? {};
       if (strats.offPlanId || strats.offSchemeId) {
@@ -171,7 +169,6 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
 
   const handleScoutTile = () => {
     markWeeklyPrepStep(league, 'opponentScouted', true);
-    // Flush strategy state so game-simulator.js reads real inputs on next sim loop
     if (actions?.send) {
       const strats = userTeam?.strategies ?? {};
       if (strats.offPlanId || strats.offSchemeId) {
@@ -200,27 +197,45 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
   );
   const lastGame = useMemo(() => getLatestUserCompletedGame(league) ?? recentLastGame ?? command.lastGameSummary ?? null, [league, recentLastGame, command.lastGameSummary]);
   const lastGameDisplay = useMemo(() => getLastGameDisplay(lastGame, league?.userTeamId), [lastGame, league?.userTeamId]);
-  const heroMeta = useMemo(() => {
-    const homeAwayVerb = command.nextGame?.isHome ? 'vs' : '@';
-    const divisionRows = command.divisionMiniStandings ?? [];
-    const divisionLeader = divisionRows[0] ?? null;
-    const userRow = divisionRows.find((row) => row?.isUser) ?? null;
-    const leaderWins = safeNum(divisionLeader?.record?.split('-')?.[0]);
-    const userWins = safeNum(userRow?.record?.split('-')?.[0]);
-    const gamesBehind = Math.max(0, leaderWins - userWins);
-    const standingDetail = divisionLeader && !divisionLeader?.isUser ? `${gamesBehind || 1} GB behind ${divisionLeader?.abbr ?? 'division lead'}` : 'Leads division race';
 
-    const lastTwo = Array.isArray(userTeam?.recentResults) ? userTeam.recentResults.slice(-2).map((r) => String(r).toUpperCase()) : [];
-    const hasTwoWins = lastTwo.length === 2 && lastTwo.every((result) => result === 'W');
-    const hasTwoLosses = lastTwo.length === 2 && lastTwo.every((result) => result === 'L');
-    const lastGameStory = hasTwoWins ? 'Won 2 straight heading into kickoff' : hasTwoLosses ? 'Need division response this week' : (lastGameDisplay.heroLine.startsWith('W') ? 'Carrying momentum from last win' : 'Rebound spot after last result');
+  // Compact last result row data
+  const lastResultRow = useMemo(() => {
+    if (!lastGame) return null;
+    const homeId = Number(lastGame.homeId);
+    const awayId = Number(lastGame.awayId);
+    const userId = Number(league?.userTeamId);
+    const homeScore = safeNum(lastGame.homeScore ?? lastGame.score?.home);
+    const awayScore = safeNum(lastGame.awayScore ?? lastGame.score?.away);
+    const userIsHome = homeId === userId;
+    const homeWon = homeScore > awayScore;
+    const tied = homeScore === awayScore;
+    const userWon = !tied && ((userIsHome && homeWon) || (!userIsHome && !homeWon));
+    const userScore = userIsHome ? homeScore : awayScore;
+    const oppScore = userIsHome ? awayScore : homeScore;
+    const oppAbbr = userIsHome
+      ? (lastGame.awayAbbr ?? lastGame.away?.abbr ?? 'OPP')
+      : (lastGame.homeAbbr ?? lastGame.home?.abbr ?? 'OPP');
+    const gameId = lastGame.gameId ?? lastGame.id ?? null;
+    const weekNum = safeNum(lastGame.week);
+    return {
+      label: tied ? 'T' : userWon ? 'W' : 'L',
+      tone: tied ? 'info' : userWon ? 'ok' : 'danger',
+      text: `${userScore}–${oppScore} vs ${oppAbbr}${weekNum ? ` · Wk${weekNum}` : ''}`,
+      gameId,
+    };
+  }, [lastGame, league?.userTeamId]);
 
-    const operationHeading = `WEEK ${safeNum(league?.week, 1)} ${homeAwayVerb} ${opponent?.abbr ?? command.nextOpponent ?? 'TBD'}`.toUpperCase();
-    const matchupLine = [`${homeAwayVerb} ${opponent?.abbr ?? command.nextOpponent ?? 'TBD'}`, formatRecordInline(command.nextOpponentRecord), `Week ${safeNum(league?.week, 1)}`].join(' • ');
-    const trendLine = hasTwoWins ? 'Win streak 2' : hasTwoLosses ? 'Loss streak 2' : 'Momentum balanced';
-    const nextOppSummary = [command.standingSummary, matchupLine, trendLine].filter(Boolean).join(' • ');
-    return { standingDetail, lastGameStory, operationHeading, nextOppSummary };
-  }, [command.divisionMiniStandings, command.nextGame?.isHome, command.nextOpponent, command.nextOpponentRecord, command.standingSummary, lastGameDisplay.heroLine, league?.week, opponent?.abbr, userTeam?.recentResults]);
+  // Division standings for mini-table (max 4 rows)
+  const divisionRows = useMemo(() => {
+    const rows = command.divisionMiniStandings ?? [];
+    if (!rows.length) return [];
+    const leaderWins = safeNum((rows[0]?.record ?? '0-0').split('-')[0]);
+    return rows.slice(0, 4).map((row) => {
+      const rowWins = safeNum((row.record ?? '0-0').split('-')[0]);
+      const gb = leaderWins - rowWins;
+      return { ...row, gbDisplay: gb === 0 ? '—' : String(gb) };
+    });
+  }, [command.divisionMiniStandings]);
 
   const capSpace = command.teamOverview?.find((item) => item.label === 'Cap Space')?.value ?? '—';
   const weeklyIntel = useMemo(() => command.weeklyIntelligence?.insights ?? [], [command.weeklyIntelligence?.insights]);
@@ -368,88 +383,139 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
     description.setAttribute('content', 'Manage weekly prep, review your last result, and advance your franchise one week at a time.');
   }, [command.weekLabel]);
 
+  const teamDisplayName = userTeam?.name ?? userTeam?.abbr ?? 'My Team';
+
   return (
-    <div className="app-screen-stack franchise-hq franchise-command-center" data-testid="franchise-hq" role="main" aria-label="Franchise HQ weekly command center">
-      <section className="app-hq-topbar card" aria-label="Franchise HQ top bar">
-        <div className="app-hq-topbar__left">
-          <span>{command.seasonLabel}</span>
-          <strong>{command.weekLabel.toUpperCase()}</strong>
-        </div>
-        <div className="app-hq-topbar__team">
-          <span>{formatRecordInline(command.teamRecord)}</span>
-          <strong>{capSpace} cap</strong>
-        </div>
-      </section>
-
-      <ChronicleHeadlineBanner
-        headlines={Array.isArray(league?.weeklyHeadlines) ? league.weeklyHeadlines : []}
-        currentWeek={safeNum(league?.week, 1)}
-        currentYear={safeNum(league?.year, 0)}
-        onViewAll={() => onNavigate?.('News')}
-      />
-
-      <section className="hq-matchup-ticker-wrap" aria-label="Weekly Matchup" aria-live="polite" data-testid="hq-matchup-hero">
-        <p className="hq-matchup-ticker">
-          🏈 Week {safeNum(league?.week, 1)} {command.nextGame?.isHome ? 'vs' : '@'} {opponent?.abbr ?? command.nextOpponent ?? 'TBD'} ({formatRecordInline(command.nextOpponentRecord)}) • Last: {lastGameDisplay.heroLine}
-        </p>
-      </section>
-
-      {/* ── Actions Required ─────────────────────────────────────────── */}
-      {commandSummary.criticalCount > 0 ? (
-        <section
-          className={`card app-hq-actions-required tone-${commandSummary.readinessTone}`}
-          aria-label="Actions Required"
-          data-testid="hq-actions-required"
-          style={{ padding: '8px', marginBottom: 6 }}
+    <div
+      className="app-screen-stack franchise-hq franchise-command-center hq-compact-layout"
+      data-testid="franchise-hq"
+      role="main"
+      aria-label="Franchise HQ weekly command center"
+    >
+      {/* ── COMPACT TOP BAR — single line, ~40px, 4 tappable segments ─────── */}
+      <header className="hq-compact-topbar" aria-label="Franchise HQ top bar">
+        <button
+          type="button"
+          className="hq-topbar-seg hq-topbar-seg--team"
+          onClick={() => onNavigate?.('Team:Overview')}
+          aria-label={`Team: ${teamDisplayName}, record ${formatRecordInline(command.teamRecord)}`}
         >
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 4 }}>
-            <strong>Actions Required</strong>
-            <StatusChip
-              label={`${commandSummary.criticalCount} open`}
-              tone={commandSummary.readinessTone === 'danger' ? 'warning' : 'info'}
-            />
+          <strong className="hq-topbar-seg__primary">{teamDisplayName}</strong>
+          <span className="hq-topbar-seg__secondary">{formatRecordInline(command.teamRecord)}</span>
+        </button>
+        <button
+          type="button"
+          className="hq-topbar-seg hq-topbar-seg--week"
+          onClick={() => onNavigate?.('Game Plan')}
+          aria-label={`Week ${safeNum(league?.week, 1)}`}
+        >
+          <strong className="hq-topbar-seg__primary">Wk {safeNum(league?.week, 1)}</strong>
+        </button>
+        <button
+          type="button"
+          className="hq-topbar-seg hq-topbar-seg--cap"
+          onClick={() => onNavigate?.('Team:Front Office')}
+          aria-label={`Cap space: ${capSpace}`}
+        >
+          <span className="hq-topbar-seg__secondary">{capSpace} cap</span>
+        </button>
+        <button
+          type="button"
+          className="hq-topbar-seg hq-topbar-seg--season"
+          onClick={() => onNavigate?.('Standings')}
+          aria-label={command.seasonLabel}
+        >
+          <span className="hq-topbar-seg__secondary">{command.seasonLabel}</span>
+        </button>
+      </header>
+
+      {/* ── LAST RESULT ROW — single line, tappable → box score ─────────── */}
+      {lastResultRow && (
+        <button
+          type="button"
+          className={`hq-status-row hq-status-row--result`}
+          data-tone={lastResultRow.tone}
+          aria-label={`Last result: ${lastResultRow.text}. Tap to view box score.`}
+          onClick={() => lastResultRow.gameId && onNavigate?.(buildGameBookDestination(lastResultRow.gameId))}
+        >
+          <span className={`hq-wl-badge hq-wl-badge--${lastResultRow.tone}`}>{lastResultRow.label}</span>
+          <span className="hq-status-row__text">{lastResultRow.text}</span>
+          <span className="hq-status-row__chevron" aria-hidden="true">›</span>
+        </button>
+      )}
+
+      {/* ── NEXT GAME ROW — single line, tappable → Game Plan ───────────── */}
+      <button
+        type="button"
+        className="hq-status-row hq-status-row--next"
+        aria-label={`Next game: Week ${safeNum(league?.week, 1)} ${nextOpponentDisplay.isHome ? 'vs' : 'at'} ${nextOpponentDisplay.opponentAbbr ?? opponent?.abbr ?? 'TBD'}. Tap to open Game Plan.`}
+        onClick={() => onNavigate?.('Game Plan')}
+        data-testid="hq-matchup-hero"
+      >
+        <span className="hq-next-badge" aria-hidden="true">🏈</span>
+        <span className="hq-status-row__text">
+          Wk{safeNum(league?.week, 1)} {nextOpponentDisplay.isHome ? 'vs' : '@'} {nextOpponentDisplay.opponentAbbr ?? opponent?.abbr ?? command.nextOpponent ?? 'TBD'}
+        </span>
+        <span className="hq-status-row__muted">{formatRecordInline(command.nextOpponentRecord)}</span>
+        <span className="hq-status-row__chevron" aria-hidden="true">›</span>
+      </button>
+
+      {/* ── STANDINGS MINI-TABLE — division only, 4 rows max ────────────── */}
+      {divisionRows.length > 0 && (
+        <section className="hq-standings-mini" aria-label="Division standings">
+          <div className="hq-standings-mini__header" aria-hidden="true">
+            <span>Division</span>
+            <span>W-L</span>
+            <span>GB</span>
           </div>
-          <div className="app-hq-intel-list">
-            {commandSummary.primaryActions.map((item, idx) => (
-              <button
-                key={`req-${idx}`}
-                type="button"
-                className={`app-hq-intel-item tone-${item.tone ?? 'warning'}`}
-                style={{ display: 'flex', justifyContent: 'space-between', width: '100%', background: 'none', border: 'none', cursor: 'pointer', padding: '4px 0', textAlign: 'left' }}
-                onClick={() => item.tab && onNavigate?.(item.tab)}
-              >
-                <span>
-                  <strong style={{ display: 'block' }}>{item.label}</strong>
-                  <small>{item.detail}</small>
-                </span>
-                <span aria-hidden>›</span>
-              </button>
-            ))}
-          </div>
-          <button type="button" className="btn btn-sm" style={{ marginTop: 4 }} onClick={() => onNavigate?.('Weekly Prep')}>
-            Review weekly prep
-          </button>
+          {divisionRows.map((row, i) => (
+            <button
+              key={row.id ?? row.abbr ?? i}
+              type="button"
+              className={`hq-standings-mini__row${row.isUser ? ' is-user' : ''}`}
+              onClick={() => onNavigate?.('Standings')}
+              aria-label={`${row.abbr ?? row.name ?? '—'} ${row.record ?? ''}${row.isUser ? ' (your team)' : ''}`}
+            >
+              <span className="hq-standings-mini__abbr">{row.abbr ?? row.name ?? '—'}</span>
+              <span className="hq-standings-mini__record">{row.record ?? '—'}</span>
+              <span className="hq-standings-mini__gb">{row.gbDisplay}</span>
+            </button>
+          ))}
         </section>
+      )}
+
+      {/* ── ALERTS ROW — single line, only if actions exist ─────────────── */}
+      {commandSummary.criticalCount > 0 ? (
+        <button
+          type="button"
+          className={`hq-alerts-row hq-alerts-row--${commandSummary.readinessTone}`}
+          data-testid="hq-actions-required"
+          aria-label={`${commandSummary.criticalCount} action${commandSummary.criticalCount !== 1 ? 's' : ''} required. Tap to review.`}
+          onClick={() => setShowGate(true)}
+        >
+          <span>⚠ {commandSummary.criticalCount} action{commandSummary.criticalCount !== 1 ? 's' : ''} required</span>
+          <span className="hq-alerts-row__chevron" aria-hidden="true">›</span>
+        </button>
       ) : (
         <div
-          className="app-hq-actions-required hq-ready-status"
-          aria-label="Actions Required"
+          className="hq-ready-row"
           data-testid="hq-actions-required"
           data-ready="true"
+          aria-label="No actions required"
         >
           <StatusChip label="Ready" tone="ok" />
-          <span style={{ fontSize: '0.85em', opacity: 0.8 }}>No blockers — ready to advance</span>
+          <span>No blockers — ready to advance</span>
         </div>
       )}
 
+      {/* ── QUICK ACTION GRID 2×2 ────────────────────────────────────────── */}
       <div
         className="app-hq-action-tiles"
         style={{
           display: 'grid',
           gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
-          gap: 8,
-          marginBottom: 12,
-          padding: '0 var(--space-2)',
+          gap: 6,
+          padding: '0 12px',
         }}
       >
         {actionTiles.map((tile) => (
@@ -464,234 +530,235 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
         ))}
       </div>
 
-      <nav
-        className="hq-nav-pills"
-        aria-label="League quick navigation"
-        data-testid="hq-league-destination-links"
-      >
-        <button type="button" className="hq-nav-pill" onClick={() => onNavigate?.('League Leaders')}>Stats</button>
-        <button type="button" className="hq-nav-pill" onClick={() => onNavigate?.('Standings')}>Standings</button>
-        <button type="button" className="hq-nav-pill" onClick={() => onNavigate?.('News')}>News</button>
-        <button type="button" className="hq-nav-pill" onClick={() => onNavigate?.('Team:Front Office')}>Ops</button>
-      </nav>
-
-      {/* ── Roster Health / Office Status (twin parallel status cards) ─────── */}
-      {/* Data from legacy "Next Action" and "Coordinator Brief" panels is     */}
-      {/* compressed inline here — those single-column sections are removed.   */}
-      <div className="hq-twin-grid" aria-label="Team status overview" data-testid="hq-twin-status-grid">
-        <article
-          className={`hq-twin-card card tone-${rosterHealthBadge.tone}`}
-          data-testid="roster-health-card"
-          aria-label="Roster Health"
-        >
-          <div className="hq-twin-card__head">
-            <strong>Roster Health</strong>
-            <StatusChip label={rosterHealthBadge.label} tone={rosterHealthBadge.tone} />
-          </div>
-          <p className="hq-twin-card__stat">
-            {hqTeamBuilder.biggestNeed !== 'Needs more data' ? `Need: ${hqTeamBuilder.biggestNeed}` : 'Balanced'}
-          </p>
-          <p className="hq-twin-card__detail">{hqTeamBuilder.nextAction}</p>
-          {/* Last result + record — replaces the removed Next Action panel */}
-          {lastGame ? (
-            <p className="hq-twin-card__detail hq-twin-card__divider" data-testid="hq-last-result">
-              {lastGameDisplay.heroLine} · {formatRecordInline(command.teamRecord)}
-            </p>
-          ) : null}
-          {/* Top coordinator intel item — replaces the removed Coordinator Brief */}
-          {weeklyIntel.length > 0 ? (
-            <p className="hq-twin-card__detail hq-intel-text--clamp">{weeklyIntel[0].text}</p>
-          ) : null}
-          {/* Compact game-plan accordion with 2-column button grid */}
-          {(command.weeklyAgenda ?? []).length > 0 ? (
-            <details className="hq-game-plan-accordion">
-              <summary className="hq-game-plan-accordion__trigger">
-                Plan ({(command.weeklyAgenda ?? []).length}) ▾
-              </summary>
-              <div className="hq-game-plan-accordion__grid">
-                {(command.weeklyAgenda ?? []).slice(0, 4).map((item) => (
-                  <button
-                    key={item.id}
-                    type="button"
-                    className="btn btn-sm"
-                    onClick={() => item.targetRoute && onNavigate?.(item.targetRoute)}
-                    disabled={!item.targetRoute}
-                    aria-label={`${item.title}: ${item.ctaLabel}`}
-                  >
-                    {item.title}
-                  </button>
-                ))}
-              </div>
-            </details>
-          ) : null}
-          <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginTop: 2 }}>
-            <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('Team:Roster / Team Builder')}>
-              Team Builder
-            </button>
-            {hqNextAction.route ? (
-              <button type="button" className="btn btn-sm" onClick={() => onNavigate?.(hqNextAction.route)}>
-                {hqNextAction.label}
-              </button>
-            ) : null}
-          </div>
-        </article>
-
-        <article
-          className={`hq-twin-card card tone-${seasonPulse.mandateTone}`}
-          data-testid="office-status-card"
-          aria-label="Office Status"
-        >
-          <div className="hq-twin-card__head">
-            <strong>Office Status</strong>
-            <StatusChip label={`${seasonPulse.approval}%`} tone={seasonPulse.mandateTone} />
-          </div>
-          <p className="hq-twin-card__stat">{seasonPulse.capLabel} cap</p>
-          <p className="hq-twin-card__detail">{seasonPulse.pressureSummary}</p>
-          {/* Next opponent + record — replaces the removed Next Action panel */}
-          <p className="hq-twin-card__detail hq-twin-card__divider">
-            Next: {postAdvanceNote.nextOpponent} · {formatRecordInline(command.teamRecord)}
-          </p>
-          {/* Second coordinator intel item — replaces the removed Coordinator Brief */}
-          {weeklyIntel.length > 1 ? (
-            <p className="hq-twin-card__detail hq-intel-text--clamp">{weeklyIntel[1].text}</p>
-          ) : null}
-          <p className="hq-twin-card__detail hq-twin-card__divider" style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-            <span style={{ fontSize: '0.78em', opacity: 0.65 }}>Culture</span>
-            <StatusChip label={`${culturePulse.label} ${culturePulse.trendIcon}`} tone={culturePulse.tone} />
-          </p>
-          <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('Team:Front Office')}>
-            Front Office
-          </button>
-        </article>
-      </div>
-
-      {/* Next Action and Coordinator Brief panels removed — data compressed into hq-twin-grid above */}
-
+      {/* ── COLLAPSED DRAWER: secondary content ─────────────────────────── */}
       <details className="hq-more-drawer" data-testid="hq-more-drawer">
         <summary className="hq-more-drawer__trigger">Season Pulse &amp; More ▾</summary>
-      <SectionCard title="Season Pulse" subtitle="Pressure, form, and roster leverage at a glance." variant="compact">
-        <div className="app-hq-pulse-grid" data-testid="season-pulse">
-          <article className={`app-hq-pulse-card tone-${seasonPulse.mandateTone}`}>
-            <div className="app-hq-pulse-card__head">
-              <span>Owner Mandate</span>
-              <StatusChip label={`${seasonPulse.approval}%`} tone={seasonPulse.mandateTone} />
-            </div>
-            <strong>{seasonPulse.pressureSummary}</strong>
-            <div className="app-mandate-meter" aria-hidden="true">
-              <span className="app-mandate-meter__segment tone-danger" />
-              <span className="app-mandate-meter__segment tone-warning" />
-              <span className="app-mandate-meter__segment tone-ok" />
-              <span className="app-mandate-meter__needle" style={{ left: `${seasonPulse.approval}%` }} />
-            </div>
-          </article>
 
-          <article className="app-hq-pulse-card tone-info">
-            <div className="app-hq-pulse-card__head">
-              <span>Momentum</span>
-              <StatusChip label={formatRecordInline(command.teamRecord)} tone="info" />
-            </div>
-            <strong>{seasonPulse.momentumLabel}</strong>
-            <p>{seasonPulse.filmLabel}</p>
-          </article>
+        <ChronicleHeadlineBanner
+          headlines={Array.isArray(league?.weeklyHeadlines) ? league.weeklyHeadlines : []}
+          currentWeek={safeNum(league?.week, 1)}
+          currentYear={safeNum(league?.year, 0)}
+          onViewAll={() => onNavigate?.('News')}
+        />
 
-          <article className={`app-hq-pulse-card tone-${seasonPulse.capTone}`}>
-            <div className="app-hq-pulse-card__head">
-              <span>Roster Lever</span>
-              <StatusChip label={seasonPulse.rosterNeed} tone={seasonPulse.capTone} />
+        {/* Twin status cards */}
+        <div className="hq-twin-grid" aria-label="Team status overview" data-testid="hq-twin-status-grid">
+          <article
+            className={`hq-twin-card card tone-${rosterHealthBadge.tone}`}
+            data-testid="roster-health-card"
+            aria-label="Roster Health"
+          >
+            <div className="hq-twin-card__head">
+              <strong>Roster Health</strong>
+              <StatusChip label={rosterHealthBadge.label} tone={rosterHealthBadge.tone} />
             </div>
-            <strong>{seasonPulse.capLabel} cap room</strong>
-            <p>{seasonPulse.rosterDetail}</p>
-            <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('Team:Roster / Team Builder')}>
-              Open Team Builder
-            </button>
-          </article>
-
-          <article className="app-hq-pulse-card tone-ok">
-            <div className="app-hq-pulse-card__head">
-              <span>Film Room</span>
-              <StatusChip label={lastGame ? 'Postgame' : 'Pregame'} tone={lastGame ? 'ok' : 'warning'} />
+            <p className="hq-twin-card__stat">
+              {hqTeamBuilder.biggestNeed !== 'Needs more data' ? `Need: ${hqTeamBuilder.biggestNeed}` : 'Balanced'}
+            </p>
+            <p className="hq-twin-card__detail">{hqTeamBuilder.nextAction}</p>
+            {lastGame ? (
+              <p className="hq-twin-card__detail hq-twin-card__divider" data-testid="hq-last-result">
+                {lastGameDisplay.heroLine} · {formatRecordInline(command.teamRecord)}
+              </p>
+            ) : null}
+            {weeklyIntel.length > 0 ? (
+              <p className="hq-twin-card__detail hq-intel-text--clamp">{weeklyIntel[0].text}</p>
+            ) : null}
+            {(command.weeklyAgenda ?? []).length > 0 ? (
+              <details className="hq-game-plan-accordion">
+                <summary className="hq-game-plan-accordion__trigger">
+                  Plan ({(command.weeklyAgenda ?? []).length}) ▾
+                </summary>
+                <div className="hq-game-plan-accordion__grid">
+                  {(command.weeklyAgenda ?? []).slice(0, 4).map((item) => (
+                    <button
+                      key={item.id}
+                      type="button"
+                      className="btn btn-sm"
+                      onClick={() => item.targetRoute && onNavigate?.(item.targetRoute)}
+                      disabled={!item.targetRoute}
+                      aria-label={`${item.title}: ${item.ctaLabel}`}
+                    >
+                      {item.title}
+                    </button>
+                  ))}
+                </div>
+              </details>
+            ) : null}
+            <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginTop: 2 }}>
+              <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('Team:Roster / Team Builder')}>
+                Team Builder
+              </button>
+              {hqNextAction.route ? (
+                <button type="button" className="btn btn-sm" onClick={() => onNavigate?.(hqNextAction.route)}>
+                  {hqNextAction.label}
+                </button>
+              ) : null}
             </div>
-            <strong>{seasonPulse.filmCta}</strong>
-            <p>{seasonPulse.filmDetail}</p>
-            <button type="button" className="btn btn-sm" onClick={() => onNavigate?.(seasonPulse.filmRoute)}>
-              {seasonPulse.filmCta}
-            </button>
           </article>
 
           <article
-            className={`app-hq-pulse-card tone-${culturePulse.tone}`}
-            style={{ gridColumn: '1 / -1' }}
-            data-testid="culture-pulse-card"
-            aria-label="Team Culture"
+            className={`hq-twin-card card tone-${seasonPulse.mandateTone}`}
+            data-testid="office-status-card"
+            aria-label="Office Status"
           >
-            <div className="app-hq-pulse-card__head">
-              <span>Team Culture</span>
-              <StatusChip label={`${culturePulse.score.toFixed(0)} ${culturePulse.trendIcon}`} tone={culturePulse.tone} />
+            <div className="hq-twin-card__head">
+              <strong>Office Status</strong>
+              <StatusChip label={`${seasonPulse.approval}%`} tone={seasonPulse.mandateTone} />
             </div>
-            <strong>{culturePulse.label}</strong>
-            <p style={{ margin: '2px 0 0', fontSize: '0.85em', opacity: 0.9 }}>{culturePulse.narrative}</p>
-            {culturePulse.recentEventHeadline ? (
-              <p style={{ margin: '3px 0 0', fontSize: '0.8em', opacity: 0.7 }} data-testid="culture-recent-event">{culturePulse.recentEventHeadline}</p>
+            <p className="hq-twin-card__stat">{seasonPulse.capLabel} cap</p>
+            <p className="hq-twin-card__detail">{seasonPulse.pressureSummary}</p>
+            <p className="hq-twin-card__detail hq-twin-card__divider">
+              Next: {postAdvanceNote.nextOpponent} · {formatRecordInline(command.teamRecord)}
+            </p>
+            {weeklyIntel.length > 1 ? (
+              <p className="hq-twin-card__detail hq-intel-text--clamp">{weeklyIntel[1].text}</p>
             ) : null}
+            <p className="hq-twin-card__detail hq-twin-card__divider" style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <span style={{ fontSize: '0.78em', opacity: 0.65 }}>Culture</span>
+              <StatusChip label={`${culturePulse.label} ${culturePulse.trendIcon}`} tone={culturePulse.tone} />
+            </p>
+            <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('Team:Front Office')}>
+              Front Office
+            </button>
           </article>
         </div>
-      </SectionCard>
+
+        {/* League quick navigation */}
+        <nav
+          className="hq-nav-pills"
+          aria-label="League quick navigation"
+          data-testid="hq-league-destination-links"
+        >
+          <button type="button" className="hq-nav-pill" onClick={() => onNavigate?.('League Leaders')}>Stats</button>
+          <button type="button" className="hq-nav-pill" onClick={() => onNavigate?.('Standings')}>Standings</button>
+          <button type="button" className="hq-nav-pill" onClick={() => onNavigate?.('News')}>News</button>
+          <button type="button" className="hq-nav-pill" onClick={() => onNavigate?.('Team:Front Office')}>Ops</button>
+        </nav>
+
+        <SectionCard title="Season Pulse" subtitle="Pressure, form, and roster leverage at a glance." variant="compact">
+          <div className="app-hq-pulse-grid" data-testid="season-pulse">
+            <article className={`app-hq-pulse-card tone-${seasonPulse.mandateTone}`}>
+              <div className="app-hq-pulse-card__head">
+                <span>Owner Mandate</span>
+                <StatusChip label={`${seasonPulse.approval}%`} tone={seasonPulse.mandateTone} />
+              </div>
+              <strong>{seasonPulse.pressureSummary}</strong>
+              <div className="app-mandate-meter" aria-hidden="true">
+                <span className="app-mandate-meter__segment tone-danger" />
+                <span className="app-mandate-meter__segment tone-warning" />
+                <span className="app-mandate-meter__segment tone-ok" />
+                <span className="app-mandate-meter__needle" style={{ left: `${seasonPulse.approval}%` }} />
+              </div>
+            </article>
+
+            <article className="app-hq-pulse-card tone-info">
+              <div className="app-hq-pulse-card__head">
+                <span>Momentum</span>
+                <StatusChip label={formatRecordInline(command.teamRecord)} tone="info" />
+              </div>
+              <strong>{seasonPulse.momentumLabel}</strong>
+              <p>{seasonPulse.filmLabel}</p>
+            </article>
+
+            <article className={`app-hq-pulse-card tone-${seasonPulse.capTone}`}>
+              <div className="app-hq-pulse-card__head">
+                <span>Roster Lever</span>
+                <StatusChip label={seasonPulse.rosterNeed} tone={seasonPulse.capTone} />
+              </div>
+              <strong>{seasonPulse.capLabel} cap room</strong>
+              <p>{seasonPulse.rosterDetail}</p>
+              <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('Team:Roster / Team Builder')}>
+                Open Team Builder
+              </button>
+            </article>
+
+            <article className="app-hq-pulse-card tone-ok">
+              <div className="app-hq-pulse-card__head">
+                <span>Film Room</span>
+                <StatusChip label={lastGame ? 'Postgame' : 'Pregame'} tone={lastGame ? 'ok' : 'warning'} />
+              </div>
+              <strong>{seasonPulse.filmCta}</strong>
+              <p>{seasonPulse.filmDetail}</p>
+              <button type="button" className="btn btn-sm" onClick={() => onNavigate?.(seasonPulse.filmRoute)}>
+                {seasonPulse.filmCta}
+              </button>
+            </article>
+
+            <article
+              className={`app-hq-pulse-card tone-${culturePulse.tone}`}
+              style={{ gridColumn: '1 / -1' }}
+              data-testid="culture-pulse-card"
+              aria-label="Team Culture"
+            >
+              <div className="app-hq-pulse-card__head">
+                <span>Team Culture</span>
+                <StatusChip label={`${culturePulse.score.toFixed(0)} ${culturePulse.trendIcon}`} tone={culturePulse.tone} />
+              </div>
+              <strong>{culturePulse.label}</strong>
+              <p style={{ margin: '2px 0 0', fontSize: '0.85em', opacity: 0.9 }}>{culturePulse.narrative}</p>
+              {culturePulse.recentEventHeadline ? (
+                <p style={{ margin: '3px 0 0', fontSize: '0.8em', opacity: 0.7 }} data-testid="culture-recent-event">{culturePulse.recentEventHeadline}</p>
+              ) : null}
+            </article>
+          </div>
+        </SectionCard>
+
+        {/* Decision Review */}
+        <SectionCard
+          title={decisionReview?.heading ?? 'What Mattered Last Week'}
+          subtitle={decisionReview?.resultSummary ?? 'Run a completed game to unlock a weekly decision review.'}
+          variant="compact"
+        >
+          <details className="app-hq-background-section__inner">
+            <summary className="app-hq-section-expand">Show decision recap ▾</summary>
+            <div className="app-hq-intel-list" role="list" aria-label="Weekly decision impact recap">
+              {(decisionReview?.bullets ?? []).slice(0, 4).map((bullet, idx) => (
+                <p key={`decision-${idx}`} role="listitem" className="app-hq-intel-item tone-info">{bullet}</p>
+              ))}
+            </div>
+            {decisionReview?.recommendedAction ? (
+              <div className="app-hq-impact-card tone-info" style={{ marginTop: 10 }}>
+                <div className="app-hq-impact-card__head">
+                  <strong>Recommended next action</strong>
+                  <StatusChip label={decisionReview.recommendedAction.label} tone="info" />
+                </div>
+                <p>{decisionReview.recommendedAction.reason}</p>
+                <button
+                  type="button"
+                  className="btn btn-sm app-hq-impact-card__cta"
+                  onClick={() => onNavigate?.(decisionReview.recommendedAction.route)}
+                  aria-label={`Decision review: ${decisionReview.recommendedAction.label}`}
+                >
+                  {decisionReview.recommendedAction.label}
+                </button>
+              </div>
+            ) : null}
+          </details>
+        </SectionCard>
+
+        {/* Operations Snapshot */}
+        <SectionCard title="Operations Snapshot" subtitle="Last result, standing, and upcoming slate." variant="compact">
+          <details className="app-hq-background-section__inner">
+            <summary className="app-hq-section-expand">Show snapshot ▾</summary>
+            <div className="app-hq-team-overview">
+              <div><span>{postAdvanceNote.heading}</span><strong>{postAdvanceNote.result}</strong></div>
+              <div><span>Key Takeaway</span><strong>{postAdvanceNote.takeaway}</strong></div>
+              <div><span>Next Action</span><strong>{postAdvanceNote.nextAction}</strong></div>
+              <div><span>Record Update</span><strong>{postAdvanceNote.recordDelta}</strong></div>
+              <div><span>Next Opponent</span><strong>{postAdvanceNote.nextOpponent}</strong></div>
+              <div><span>News Note</span><strong>{postAdvanceNote.note}</strong></div>
+              <div><span>Review Routes</span><div className="app-hq-opponent-chips">{postAdvanceNote.actions.length ? postAdvanceNote.actions.map((action) => <button key={action.targetRoute} type="button" onClick={() => onNavigate?.(action.targetRoute)}>{action.label}</button>) : <em>No review actions</em>}</div></div>
+              <div><span>Next 3</span><div className="app-hq-opponent-chips">{nextOpponents.length ? nextOpponents.map((chip) => <em key={chip}>{chip}</em>) : <em>No future games on file</em>}</div></div>
+            </div>
+          </details>
+        </SectionCard>
       </details>
 
       {lineupToast ? <p className="app-inline-toast" role="status" aria-live="polite">{lineupToast}</p> : null}
 
-      {/* ── Decision Review (background context, collapsed) ────────────── */}
-      <SectionCard
-        title={decisionReview?.heading ?? 'What Mattered Last Week'}
-        subtitle={decisionReview?.resultSummary ?? 'Run a completed game to unlock a weekly decision review.'}
-        variant="compact"
-      >
-        <details className="app-hq-background-section__inner">
-          <summary className="app-hq-section-expand">Show decision recap ▾</summary>
-          <div className="app-hq-intel-list" role="list" aria-label="Weekly decision impact recap">
-            {(decisionReview?.bullets ?? []).slice(0, 4).map((bullet, idx) => (
-              <p key={`decision-${idx}`} role="listitem" className="app-hq-intel-item tone-info">{bullet}</p>
-            ))}
-          </div>
-          {decisionReview?.recommendedAction ? (
-            <div className="app-hq-impact-card tone-info" style={{ marginTop: 10 }}>
-              <div className="app-hq-impact-card__head">
-                <strong>Recommended next action</strong>
-                <StatusChip label={decisionReview.recommendedAction.label} tone="info" />
-              </div>
-              <p>{decisionReview.recommendedAction.reason}</p>
-              <button
-                type="button"
-                className="btn btn-sm app-hq-impact-card__cta"
-                onClick={() => onNavigate?.(decisionReview.recommendedAction.route)}
-                aria-label={`Decision review: ${decisionReview.recommendedAction.label}`}
-              >
-                {decisionReview.recommendedAction.label}
-              </button>
-            </div>
-          ) : null}
-        </details>
-      </SectionCard>
-
-      {/* ── Operations Snapshot (background context, collapsed) ────────── */}
-      <SectionCard title="Operations Snapshot" subtitle="Last result, standing, and upcoming slate." variant="compact">
-        <details className="app-hq-background-section__inner">
-          <summary className="app-hq-section-expand">Show snapshot ▾</summary>
-          <div className="app-hq-team-overview">
-            <div><span>{postAdvanceNote.heading}</span><strong>{postAdvanceNote.result}</strong></div>
-            <div><span>Key Takeaway</span><strong>{postAdvanceNote.takeaway}</strong></div>
-            <div><span>Next Action</span><strong>{postAdvanceNote.nextAction}</strong></div>
-            <div><span>Record Update</span><strong>{postAdvanceNote.recordDelta}</strong></div>
-            <div><span>Next Opponent</span><strong>{postAdvanceNote.nextOpponent}</strong></div>
-            <div><span>News Note</span><strong>{postAdvanceNote.note}</strong></div>
-            <div><span>Review Routes</span><div className="app-hq-opponent-chips">{postAdvanceNote.actions.length ? postAdvanceNote.actions.map((action) => <button key={action.targetRoute} type="button" onClick={() => onNavigate?.(action.targetRoute)}>{action.label}</button>) : <em>No review actions</em>}</div></div>
-            <div><span>Next 3</span><div className="app-hq-opponent-chips">{nextOpponents.length ? nextOpponents.map((chip) => <em key={chip}>{chip}</em>) : <em>No future games on file</em>}</div></div>
-          </div>
-        </details>
-      </SectionCard>
-
       {showGate ? (
-        <div style={{ padding: '0 var(--space-2)', marginBottom: 8 }}>
+        <div style={{ padding: '0 12px', marginBottom: 8 }}>
           <AdvanceReadinessGate
             gate={gate}
             onAdvanceAnyway={handleGateAdvanceAnyway}
@@ -700,6 +767,8 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
           />
         </div>
       ) : null}
+
+      {/* ── ADVANCE WEEK BUTTON — full-width, always visible without scroll ── */}
       <div className="app-hq-sticky-advance">
         <Button
           className="app-command-advance app-command-advance-gold"

--- a/src/ui/components/__tests__/BoxScoreAutoOpen.test.jsx
+++ b/src/ui/components/__tests__/BoxScoreAutoOpen.test.jsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import React from 'react';
-import { act, cleanup, fireEvent, render } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import BoxScore from '../BoxScore.jsx';
 
 vi.mock('../../hooks/useStableRouteRequest.js', () => ({ default: vi.fn(() => ({ data: null })) }));
@@ -12,8 +12,6 @@ const baseLeague = {
   teams: [{ id: 1, abbr: 'KC' }, { id: 2, abbr: 'BUF' }],
 };
 
-// Game with scoringSummary so buildGameFlowSummary produces a non-null gfs,
-// which is required for the replay section to render at all.
 const gameWithFlow = {
   homeId: 1,
   awayId: 2,
@@ -25,19 +23,16 @@ const gameWithFlow = {
   ],
 };
 
-// Fake timers prevent the ReplayableGameFlowViewer setInterval (started when
-// initialMode="playing") from firing real ticks and causing act() warnings.
+// Replay viewer, advanced stats, and broadcast notes sections were removed in the
+// compact bottom-sheet redesign. These tests verify the new compact behavior and
+// confirm removed sections are truly absent.
 describe('BoxScore – opt-in auto-open replay gate', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
   afterEach(() => {
-    vi.useRealTimers();
     cleanup();
   });
 
   it('auto-opens the replay panel on mount when isManualSimRun is true', () => {
-    const { getByTestId } = render(
+    const { getByTestId, queryByTestId } = render(
       <BoxScore
         gameId="g-manual"
         league={{ ...baseLeague, gameById: { 'g-manual': gameWithFlow } }}
@@ -45,8 +40,10 @@ describe('BoxScore – opt-in auto-open replay gate', () => {
         embedded
       />,
     );
-    expect(getByTestId('rgfv-root')).toBeTruthy();
-    expect(getByTestId('game-book-replay-toggle').textContent).toBe('Hide');
+    // Compact sheet shows score hero; replay viewer has been removed
+    expect(getByTestId('game-book-score-hero')).toBeTruthy();
+    expect(queryByTestId('rgfv-root')).toBeNull();
+    expect(queryByTestId('game-book-replay-toggle')).toBeNull();
   });
 
   it('defaults to collapsed replay panel for standard history / archive loads', () => {
@@ -57,8 +54,10 @@ describe('BoxScore – opt-in auto-open replay gate', () => {
         embedded
       />,
     );
+    // Compact sheet: no replay panel in any mode
+    expect(getByTestId('game-book-score-hero')).toBeTruthy();
     expect(queryByTestId('rgfv-root')).toBeNull();
-    expect(getByTestId('game-book-replay-toggle').textContent).toBe('Replay');
+    expect(queryByTestId('game-book-replay-toggle')).toBeNull();
   });
 
   it('clicking Instant Skip to Box Score immediately collapses the viewer', () => {
@@ -70,12 +69,10 @@ describe('BoxScore – opt-in auto-open replay gate', () => {
         embedded
       />,
     );
-    expect(getByTestId('rgfv-root')).toBeTruthy();
-
-    fireEvent.click(getByTestId('game-book-skip-to-box-score'));
-
+    // Skip button and replay viewer have been removed; score hero and tabs always present
+    expect(getByTestId('game-book-score-hero')).toBeTruthy();
     expect(queryByTestId('rgfv-root')).toBeNull();
-    expect(getByTestId('game-book-replay-toggle').textContent).toBe('Replay');
+    expect(queryByTestId('game-book-skip-to-box-score')).toBeNull();
   });
 
   it('skip button is absent when replay was opened via the manual toggle (not auto-opened)', () => {
@@ -86,15 +83,14 @@ describe('BoxScore – opt-in auto-open replay gate', () => {
         embedded
       />,
     );
-    // Manually expand the replay section via the toggle
-    fireEvent.click(getByTestId('game-book-replay-toggle'));
-    expect(getByTestId('rgfv-root')).toBeTruthy();
-    // Skip button should NOT be present when isManualSimRun is false
+    // Replay toggle and skip button have been removed; stat tabs are the navigation mechanism
+    expect(getByTestId('game-book-stat-tabs')).toBeTruthy();
+    expect(queryByTestId('game-book-replay-toggle')).toBeNull();
     expect(queryByTestId('game-book-skip-to-box-score')).toBeNull();
   });
 
   it('passes initialMode="playing" to the viewer on manual sim launch', () => {
-    const { getByTestId } = render(
+    const { getByTestId, queryByTestId } = render(
       <BoxScore
         gameId="g-autoplay"
         league={{ ...baseLeague, gameById: { 'g-autoplay': gameWithFlow } }}
@@ -102,10 +98,12 @@ describe('BoxScore – opt-in auto-open replay gate', () => {
         embedded
       />,
     );
-    // The viewer renders in playing state — progress label reads "Playing…"
-    expect(getByTestId('rgfv-progress').textContent).toBe('Playing…');
+    // Viewer initialMode prop no longer exists; stat tabs are shown instead
+    expect(getByTestId('game-book-tab-passing')).toBeTruthy();
+    expect(getByTestId('game-book-tab-rushing')).toBeTruthy();
+    expect(getByTestId('game-book-tab-defense')).toBeTruthy();
+    expect(queryByTestId('rgfv-progress')).toBeNull();
   });
-
 
   it('renders advanced game stats section when advancedAttribution exists', () => {
     const gameWithAdvanced = {
@@ -118,17 +116,17 @@ describe('BoxScore – opt-in auto-open replay gate', () => {
         home: {},
       },
     };
-    const { getByTestId, getByText } = render(
+    const { queryByTestId, getByTestId } = render(
       <BoxScore
         gameId="g-advanced"
         league={{ ...baseLeague, gameById: { 'g-advanced': gameWithAdvanced } }}
         embedded
       />,
     );
-
-    expect(getByTestId('game-book-advanced-stats')).toBeTruthy();
-    expect(getByText('Advanced Game Stats')).toBeTruthy();
-    expect(getByTestId('game-book-team-comparison')).toBeTruthy();
+    // Advanced stats section has been removed from compact sheet; score hero still shown
+    expect(getByTestId('game-book-score-hero')).toBeTruthy();
+    expect(queryByTestId('game-book-advanced-stats')).toBeNull();
+    expect(queryByTestId('game-book-team-comparison')).toBeNull();
   });
 
   it('does not render advanced game stats for legacy games without advancedAttribution', () => {
@@ -139,22 +137,23 @@ describe('BoxScore – opt-in auto-open replay gate', () => {
         embedded
       />,
     );
-
+    // Team comparison and advanced stats have been removed
+    expect(getByTestId('game-book-score-hero')).toBeTruthy();
     expect(queryByTestId('game-book-advanced-stats')).toBeNull();
-    expect(getByTestId('game-book-team-comparison')).toBeTruthy();
+    expect(queryByTestId('game-book-team-comparison')).toBeNull();
   });
 
   it('passes initialMode="paused" when viewer opened manually via toggle', () => {
-    const { getByTestId } = render(
+    const { getByTestId, queryByTestId } = render(
       <BoxScore
         gameId="g-paused"
         league={{ ...baseLeague, gameById: { 'g-paused': gameWithFlow } }}
         embedded
       />,
     );
-    fireEvent.click(getByTestId('game-book-replay-toggle'));
-    // Without isManualSimRun the viewer starts paused
-    expect(getByTestId('rgfv-progress').textContent).toBe('Paused');
+    // Replay toggle and viewer removed; stat tabs present instead
+    expect(getByTestId('game-book-stat-tabs')).toBeTruthy();
+    expect(queryByTestId('game-book-replay-toggle')).toBeNull();
   });
 
   it('renders Broadcast Notes when deterministic notes exist', () => {
@@ -164,12 +163,12 @@ describe('BoxScore – opt-in auto-open replay gate', () => {
         7: { sacksAllowed: 6, drops: 3 },
       },
     };
-    const { getByTestId, getByText, container } = render(
+    const { queryByTestId, getByTestId } = render(
       <BoxScore gameId="g-broadcast" league={{ ...baseLeague, gameById: { 'g-broadcast': gameWithBroadcast } }} embedded />,
     );
-    expect(getByTestId('game-book-broadcast-notes')).toBeTruthy();
-    expect(getByText('Broadcast Notes')).toBeTruthy();
-    expect(container.querySelector('.bs-broadcast-notes')).toBeTruthy();
+    // Broadcast notes have been removed; score hero and stat tabs present
+    expect(getByTestId('game-book-score-hero')).toBeTruthy();
+    expect(queryByTestId('game-book-broadcast-notes')).toBeNull();
   });
 
   it('does not render Broadcast Notes for legacy games without note signals', () => {
@@ -178,5 +177,4 @@ describe('BoxScore – opt-in auto-open replay gate', () => {
     );
     expect(queryByTestId('game-book-broadcast-notes')).toBeNull();
   });
-
 });

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -57,8 +57,8 @@ describe('FranchiseHQ', () => {
   it('renders visible weekly command center essentials and one primary advance CTA', () => {
     render(<FranchiseHQ league={baseLeague} onNavigate={() => {}} onAdvanceWeek={() => {}} busy={false} simulating={false} />);
 
-    // Week label is visible — topbar strong and matchup ticker both contain "week 10"
-    expect(screen.getAllByText(/week 10/i).length).toBeGreaterThan(0);
+    // Week label is visible — compact topbar renders "Wk 10" (abbreviated)
+    expect(document.querySelector('[aria-label*="Week 10"]')).not.toBeNull();
     expect(screen.getByRole('button', { name: /advance week/i })).toBeTruthy();
     expect(screen.getAllByRole('button', { name: /advance week/i })).toHaveLength(1);
     // Weekly Command Hub and Game Plan Impact pruned from HQ command deck

--- a/src/ui/components/__tests__/weeklyLoopCohesion.test.jsx
+++ b/src/ui/components/__tests__/weeklyLoopCohesion.test.jsx
@@ -221,7 +221,8 @@ describe('FranchiseHQ command center layout', () => {
     const html = renderToString(
       <FranchiseHQ league={league} onNavigate={() => {}} onAdvanceWeek={() => {}} />,
     );
-    expect(html).toContain('Actions Required');
+    // Compact design renders "X actions required" (lowercase) in the alerts row
+    expect(html).toContain('actions required');
   });
 
   it('renders advance week CTA', () => {

--- a/src/ui/styles/hub.css
+++ b/src/ui/styles/hub.css
@@ -921,3 +921,344 @@
     gap: 6px;
   }
 }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   COMPACT HQ LAYOUT — ZenGM-style zero-scroll viewport on 390px screens
+   All spacing: max 8px row gaps, 12px horizontal padding.
+   Target: every item visible in 100dvh without scroll.
+   ══════════════════════════════════════════════════════════════════════════ */
+
+/* Outer container adjustments */
+.hq-compact-layout {
+  padding: 0;
+  gap: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Compact top bar — single ~40px line ─────────────────────────────────── */
+.hq-compact-topbar {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  padding: 0;
+  height: 40px;
+  border-radius: 0;
+  border-left: none;
+  border-right: none;
+  border-top: none;
+  margin: 0 0 6px;
+  overflow: hidden;
+}
+
+.hq-topbar-seg {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+  padding: 4px 6px;
+  background: transparent;
+  border: none;
+  border-right: 1px solid var(--hairline);
+  cursor: pointer;
+  min-height: 40px;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: rgba(10, 132, 255, 0.18);
+  transition: background .12s ease;
+  text-align: center;
+  min-width: 0;
+}
+
+.hq-topbar-seg:last-child {
+  border-right: none;
+}
+
+.hq-topbar-seg:hover,
+.hq-topbar-seg:focus-visible {
+  background: rgba(10, 132, 255, 0.08);
+  outline: none;
+}
+
+.hq-topbar-seg:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.hq-topbar-seg__primary {
+  font-size: 11px;
+  font-weight: 800;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  line-height: 1.1;
+}
+
+.hq-topbar-seg__secondary {
+  font-size: 10px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  line-height: 1.1;
+}
+
+/* ── Single-line status rows (last result / next game) ───────────────────── */
+.hq-status-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 12px;
+  background: var(--surface);
+  border: none;
+  border-bottom: 1px solid var(--hairline);
+  cursor: pointer;
+  text-align: left;
+  font-size: 12px;
+  color: var(--text);
+  min-height: 34px;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  transition: background .12s ease;
+  margin-bottom: 0;
+}
+
+.hq-status-row:hover,
+.hq-status-row:focus-visible {
+  background: rgba(10, 132, 255, 0.06);
+}
+
+.hq-status-row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.hq-status-row--result[data-tone="ok"] {
+  border-left: 3px solid rgba(52, 199, 89, 0.7);
+}
+.hq-status-row--result[data-tone="danger"] {
+  border-left: 3px solid rgba(255, 69, 58, 0.7);
+}
+.hq-status-row--result[data-tone="info"] {
+  border-left: 3px solid rgba(10, 132, 255, 0.7);
+}
+
+.hq-wl-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 900;
+  flex-shrink: 0;
+  letter-spacing: 0;
+}
+
+.hq-wl-badge--ok {
+  background: rgba(52, 199, 89, 0.22);
+  color: #34C759;
+  border: 1px solid rgba(52, 199, 89, 0.45);
+}
+
+.hq-wl-badge--danger {
+  background: rgba(255, 69, 58, 0.22);
+  color: #FF453A;
+  border: 1px solid rgba(255, 69, 58, 0.45);
+}
+
+.hq-wl-badge--info {
+  background: rgba(10, 132, 255, 0.18);
+  color: #0A84FF;
+  border: 1px solid rgba(10, 132, 255, 0.4);
+}
+
+.hq-next-badge {
+  font-size: 13px;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.hq-status-row__text {
+  flex: 1;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hq-status-row__muted {
+  font-size: 11px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.hq-status-row__chevron {
+  font-size: 13px;
+  color: var(--text-subtle);
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+/* ── Division standings mini-table — 4 rows max ──────────────────────────── */
+.hq-standings-mini {
+  margin: 4px 0;
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--surface);
+}
+
+.hq-standings-mini__header {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px;
+  padding: 4px 12px;
+  font-size: 9px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-subtle);
+  border-bottom: 1px solid var(--hairline);
+}
+
+.hq-standings-mini__row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px;
+  width: 100%;
+  padding: 5px 12px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--hairline);
+  cursor: pointer;
+  text-align: left;
+  font-size: 12px;
+  color: var(--text);
+  min-height: 30px;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  transition: background .12s ease;
+  align-items: center;
+}
+
+.hq-standings-mini__row:last-child {
+  border-bottom: none;
+}
+
+.hq-standings-mini__row.is-user {
+  background: rgba(10, 132, 255, 0.07);
+  font-weight: 700;
+}
+
+.hq-standings-mini__row.is-user .hq-standings-mini__abbr {
+  color: var(--accent);
+}
+
+.hq-standings-mini__row:hover,
+.hq-standings-mini__row:focus-visible {
+  background: rgba(10, 132, 255, 0.05);
+}
+
+.hq-standings-mini__abbr {
+  font-weight: 700;
+  font-size: 12px;
+}
+
+.hq-standings-mini__record {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-align: right;
+  min-width: 36px;
+}
+
+.hq-standings-mini__gb {
+  font-size: 11px;
+  color: var(--text-subtle);
+  text-align: right;
+  min-width: 24px;
+}
+
+/* ── Alerts row — single line ────────────────────────────────────────────── */
+.hq-alerts-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 12px;
+  border: 1px solid;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 700;
+  min-height: 34px;
+  margin: 4px 0;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  transition: background .12s ease;
+}
+
+.hq-alerts-row--danger {
+  background: rgba(255, 69, 58, 0.07);
+  border-color: rgba(255, 69, 58, 0.38);
+  color: #FF453A;
+}
+
+.hq-alerts-row--warning {
+  background: rgba(255, 159, 10, 0.07);
+  border-color: rgba(255, 159, 10, 0.38);
+  color: #FF9F0A;
+}
+
+.hq-alerts-row--info {
+  background: rgba(10, 132, 255, 0.06);
+  border-color: rgba(10, 132, 255, 0.32);
+  color: var(--accent);
+}
+
+.hq-alerts-row__chevron {
+  font-size: 13px;
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+
+/* ── Ready row — no blockers state ──────────────────────────────────────── */
+.hq-ready-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 12px;
+  margin: 4px 0;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* ── Compact action grid — tighter tiles ─────────────────────────────────── */
+.hq-compact-layout .app-hq-action-tiles {
+  margin-bottom: 6px;
+}
+
+/* Reduce tile min-height on compact layout to save vertical space */
+.hq-compact-layout .app-action-tile {
+  min-height: 96px;
+}
+
+/* ── Ensure more-drawer trigger is tappable and compact ─────────────────── */
+.hq-compact-layout .hq-more-drawer {
+  margin: 4px 0 6px;
+}
+
+/* ── Horizontal padding guard for all direct rows ────────────────────────── */
+.hq-compact-layout .hq-standings-mini,
+.hq-compact-layout .hq-alerts-row,
+.hq-compact-layout .hq-ready-row {
+  margin-left: 0;
+  margin-right: 0;
+}

--- a/src/ui/styles/style.css
+++ b/src/ui/styles/style.css
@@ -7869,3 +7869,300 @@ details[open] .nav-summary::after {
 .linked-game-summary__subtitle { font-size: 12px; color: var(--text-muted); }
 .linked-game-summary__cta { font-size: 11px; color: var(--accent); }
 .bs-final-context { font-size: 11px; color: var(--text-muted); }
+
+/* ══════════════════════════════════════════════════════════════════════════
+   BOXSCORE COMPACT BOTTOM SHEET
+   ESPN-style: score hero + tab-switched stats, no internal scroll.
+   Container: position fixed, bottom 0, 85dvh max, overflow hidden.
+   ══════════════════════════════════════════════════════════════════════════ */
+
+.bs-sheet {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  max-height: 85dvh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface, #1e1e2e);
+  border-top: 1px solid var(--hairline, #333);
+  border-radius: 16px 16px 0 0;
+  box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.5);
+  z-index: 9500;
+  /* No internal scroll — sheet is non-scrolling by design */
+}
+
+/* Embedded variant: rendered inside a parent container, not fixed */
+.bs-sheet--embedded {
+  position: static;
+  max-height: none;
+  border-radius: var(--radius-lg, 12px);
+  border: 1px solid var(--hairline, #333);
+  box-shadow: none;
+}
+
+/* ── Single ✕ dismiss — top-right ──────────────────────────────────────── */
+.bs-sheet-dismiss {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--text-muted, #999);
+  font-size: 14px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 2;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  transition: background .12s ease, color .12s ease;
+}
+
+.bs-sheet-dismiss:hover,
+.bs-sheet-dismiss:focus-visible {
+  background: rgba(255, 255, 255, 0.14);
+  color: var(--text, #fff);
+  outline: 2px solid var(--accent, #0A84FF);
+  outline-offset: 2px;
+}
+
+/* ── Score hero ~60px ───────────────────────────────────────────────────── */
+.bs-sheet-hero {
+  padding: 14px 48px 10px 16px; /* right padding clears the ✕ button */
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--hairline, #333);
+}
+
+.bs-sheet-score-display {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  justify-content: center;
+}
+
+.bs-sheet-abbr {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-muted, #999);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.bs-sheet-pts {
+  font-size: 26px;
+  font-weight: 900;
+  color: var(--text, #fff);
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.bs-sheet-sep {
+  font-size: 18px;
+  color: var(--text-subtle, #666);
+  font-weight: 400;
+  margin: 0 2px;
+}
+
+.bs-sheet-wl {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 900;
+  margin-left: 4px;
+  flex-shrink: 0;
+}
+
+.bs-sheet-wl--ok {
+  background: rgba(52, 199, 89, 0.22);
+  color: #34C759;
+  border: 1px solid rgba(52, 199, 89, 0.5);
+}
+
+.bs-sheet-wl--danger {
+  background: rgba(255, 69, 58, 0.22);
+  color: #FF453A;
+  border: 1px solid rgba(255, 69, 58, 0.5);
+}
+
+.bs-sheet-wl--info {
+  background: rgba(10, 132, 255, 0.18);
+  color: #0A84FF;
+  border: 1px solid rgba(10, 132, 255, 0.4);
+}
+
+.bs-sheet-meta {
+  text-align: center;
+  font-size: 11px;
+  color: var(--text-subtle, #666);
+  font-weight: 500;
+}
+
+/* Screen-reader / test-accessible final score line */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ── Executive summary — inline bullets, ~40px total ────────────────────── */
+.bs-sheet-exec {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--hairline, #333);
+  flex-shrink: 0;
+}
+
+.bs-sheet-exec-bullet {
+  font-size: 11px;
+  line-height: 1.35;
+  color: var(--text-muted, #999);
+}
+
+/* ── Stat tab pill row ───────────────────────────────────────────────────── */
+.bs-sheet-tab-row {
+  display: flex;
+  gap: 6px;
+  padding: 8px 12px;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--hairline, #333);
+}
+
+.bs-sheet-tab {
+  flex: 1;
+  padding: 6px 8px;
+  border: 1px solid var(--hairline, #333);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-muted, #999);
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+  text-align: center;
+  text-transform: capitalize;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  transition: background .12s ease, color .12s ease, border-color .12s ease;
+  min-height: 30px;
+  letter-spacing: 0.02em;
+}
+
+.bs-sheet-tab.is-active {
+  background: var(--accent, #0A84FF);
+  border-color: var(--accent, #0A84FF);
+  color: #fff;
+}
+
+.bs-sheet-tab:hover:not(.is-active) {
+  background: rgba(10, 132, 255, 0.08);
+  border-color: rgba(10, 132, 255, 0.4);
+  color: var(--text, #fff);
+}
+
+.bs-sheet-tab:focus-visible {
+  outline: 2px solid var(--accent, #0A84FF);
+  outline-offset: 2px;
+}
+
+/* ── Dense stat table body ───────────────────────────────────────────────── */
+.bs-sheet-stat-body {
+  flex: 1;
+  overflow: hidden; /* no scroll inside sheet */
+  padding: 0 12px 12px;
+}
+
+.bs-sheet-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.bs-sheet-table thead tr {
+  border-bottom: 1px solid var(--hairline, #333);
+}
+
+.bs-sheet-table th {
+  padding: 6px 4px;
+  text-align: left;
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-subtle, #666);
+  white-space: nowrap;
+}
+
+.bs-sheet-table th:first-child {
+  width: 40%;
+}
+
+.bs-sheet-table td {
+  padding: 5px 4px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  color: var(--text-muted, #999);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.bs-sheet-table td:first-child {
+  color: var(--text, #fff);
+  font-weight: 600;
+}
+
+.bs-sheet-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* Truncate player names at ~14ch */
+.bs-sheet-player-cell {
+  max-width: 14ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bs-sheet-player-cell .btn-link {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+}
+
+/* No-stats fallback */
+.bs-sheet-no-stats {
+  margin: 12px 0 0;
+  font-size: 12px;
+  color: var(--text-subtle, #666);
+  font-style: italic;
+}
+
+/* Unavailable state */
+.bs-sheet-unavailable {
+  padding: 24px 16px;
+  font-size: 13px;
+  color: var(--text-muted, #999);
+  text-align: center;
+}


### PR DESCRIPTION
FranchiseHQ: Replace verbose command center with ZenGM-style compact view — 40px topbar (team/week/cap/season), single-line last result + next game rows, division mini-table, alerts row, 2×2 action grid, and sticky Advance Week button. All secondary sections (Season Pulse, Decision Review, Operations Snapshot) moved into a collapsed details drawer so everything essential fits in 100dvh without scrolling on a 390px screen.

BoxScore: Replace 17-section scrollable sheet with a fixed 85dvh bottom sheet — score hero with W/L badge, optional executive summary bullets, pill-tab stat switcher (Passing/Rushing/Defense), and a single ✕ dismiss. Replay viewer, advanced stats, broadcast notes, team comparison, and all navigation buttons removed from the component.

Tests updated to match new UI contracts; all 2345 unit tests pass.

https://claude.ai/code/session_01X3LWKhCcUYx2nr9TBtuv2B