### PR TITLE
refactor(draft): decompose ProspectTable.jsx (1539→269 lines) into focused modules

### DIFF
--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -37,7 +37,9 @@ const actions = {
 
 describe('PlayerProfile', () => {
   beforeEach(() => {
-    global.IntersectionObserver = vi.fn(() => ({ observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() }));
+    // vitest 4: Mock now calls `new impl()` for constructor mocks; arrow functions
+    // cannot be constructors, so use a regular function here.
+    global.IntersectionObserver = vi.fn(function () { return { observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() }; });
   });
   afterEach(() => cleanup());
   it('renders safe unavailable state when no player id is provided', () => {

--- a/src/ui/draft/DraftBadges.jsx
+++ b/src/ui/draft/DraftBadges.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Badge } from "@/components/ui/badge";
 import { ovrColor } from "./draftShared.js";
 
 export function OvrBadge({ ovr }) {

--- a/src/ui/draft/DraftLeftPanel.jsx
+++ b/src/ui/draft/DraftLeftPanel.jsx
@@ -1,0 +1,160 @@
+import React from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { OvrBadge } from "./DraftBadges.jsx";
+import { DRAFT_ROOM_PHASES, formatClock } from "./draftShared.js";
+import { TradeUpModal } from "./TradeUpModal.jsx";
+
+export function DraftLeftPanel({
+  isDraftComplete,
+  isUserPick,
+  currentPick,
+  draftPhase,
+  pickClock,
+  userAutoPick,
+  onAutoPickChange,
+  simming,
+  disabled,
+  onSimToMyPick,
+  actions,
+  showTradeUp,
+  onShowTradeUp,
+  onHideTradeUp,
+  upcomingPicks,
+  completedPicks,
+  activeRound,
+  league,
+}) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+      <Card className="card-premium" style={{ overflow: "hidden" }}>
+        <CardContent style={{ padding: "var(--space-4)" }}>
+          {isDraftComplete ? (
+            <div style={{ textAlign: "center", padding: "var(--space-3)" }}>
+              <div style={{ fontSize: "1.4rem", marginBottom: 4 }}>🏈</div>
+              <div style={{ fontWeight: 800, color: "var(--success)" }}>Draft Complete</div>
+            </div>
+          ) : (
+            <>
+              <div style={{ fontSize: "var(--text-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: "var(--text-muted)", marginBottom: "var(--space-2)" }}>
+                On the Clock
+              </div>
+              <div style={{ fontWeight: 800, fontSize: "var(--text-xl)", color: "var(--text)", marginBottom: 4, display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
+                <span style={{ width: 26, height: 26, borderRadius: "50%", background: "var(--surface-strong)", border: "1px solid var(--hairline)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 10 }}>
+                  {currentPick?.teamAbbr?.slice(0, 2) ?? "TM"}
+                </span>
+                {currentPick?.teamAbbr ?? "???"}
+              </div>
+              <div style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)", marginBottom: "var(--space-3)" }}>
+                {currentPick?.teamName ?? "—"}
+              </div>
+              <div style={{ padding: "2px 8px", borderRadius: "var(--radius-pill)", background: isUserPick ? "var(--accent)22" : "var(--surface-strong)", border: `1px solid ${isUserPick ? "var(--accent)" : "var(--hairline)"}`, color: isUserPick ? "var(--accent)" : "var(--text-muted)", fontWeight: 700, fontSize: "var(--text-xs)", display: "inline-block", marginBottom: "var(--space-3)" }}>
+                {isUserPick ? "★ YOUR PICK" : "AI PICKING"}
+              </div>
+              <div style={{ fontSize: "var(--text-sm)", color: "var(--text)", display: "flex", justifyContent: "space-between" }}>
+                <span>Round {currentPick?.round}</span>
+                <span style={{ color: "var(--text-muted)" }}>Overall #{currentPick?.overall}</span>
+              </div>
+              {draftPhase === DRAFT_ROOM_PHASES.ON_THE_CLOCK && (
+                <div style={{ marginTop: 6, fontSize: "var(--text-xs)", color: "var(--warning, #FF9F0A)", fontWeight: 700 }}>
+                  Clock: {formatClock(pickClock)}
+                </div>
+              )}
+              <div style={{ marginTop: 6, fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>
+                Phase: {draftPhase.replaceAll("_", " ")}
+              </div>
+              {currentPick?.isCompensatory && (
+                <div style={{ marginTop: 6, fontSize: "var(--text-xs)", color: "var(--warning, #FF9F0A)", fontWeight: 700 }}>
+                  Compensatory pick · {currentPick?.compensatoryForName ? `for loss of ${currentPick.compensatoryForName}` : "NFL comp selection"}
+                </div>
+              )}
+              <label style={{ display: "flex", alignItems: "center", gap: 8, marginTop: "var(--space-3)", fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
+                <input type="checkbox" checked={userAutoPick} onChange={(e) => onAutoPickChange(e.target.checked)} />
+                Enable Auto-Pick (BPA)
+              </label>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {!isDraftComplete && !isUserPick && (
+        <Button className="btn btn-primary" disabled={simming || disabled} onClick={onSimToMyPick} style={{ width: "100%" }}>
+          {simming ? "Simulating…" : "Sim to My Pick"}
+        </Button>
+      )}
+
+      {!isDraftComplete && !isUserPick && actions && (
+        <Button className="btn" onClick={onShowTradeUp} style={{ width: "100%" }}>
+          Trade for this Pick
+        </Button>
+      )}
+
+      {showTradeUp && currentPick && !isUserPick && !isDraftComplete && (
+        <TradeUpModal
+          currentPick={currentPick}
+          league={league}
+          actions={actions}
+          onClose={onHideTradeUp}
+          onTradeComplete={() => onSimToMyPick()}
+        />
+      )}
+
+      {!isDraftComplete && upcomingPicks.length > 0 && (
+        <Card className="card-premium" style={{ padding: 0, overflow: "hidden" }}>
+          <CardHeader style={{ padding: "var(--space-2) var(--space-3)", background: "var(--surface-strong)", borderBottom: "1px solid var(--hairline)" }}>
+            <CardTitle style={{ fontSize: "var(--text-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: "var(--text-muted)" }}>
+              Pick Order
+            </CardTitle>
+          </CardHeader>
+          <CardContent style={{ padding: 0 }}>
+            <ScrollArea style={{ maxHeight: 320 }}>
+              {upcomingPicks.map((pk, i) => (
+                <div key={pk.overall} style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", padding: "var(--space-2) var(--space-3)", borderBottom: "1px solid var(--hairline)", background: i === 0 ? (pk.isUser ? "var(--accent)11" : "var(--surface-strong)") : "transparent", fontWeight: i === 0 ? 700 : 400 }}>
+                  <span style={{ minWidth: 24, textAlign: "center", fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>{pk.overall}</span>
+                  <span style={{ flex: 1, fontSize: "var(--text-xs)", color: pk.isUser ? "var(--accent)" : "var(--text)", fontWeight: pk.isUser ? 700 : 400 }}>
+                    {pk.teamAbbr}{pk.isUser && <span style={{ marginLeft: 4 }}>★</span>}
+                  </span>
+                  <span style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>R{pk.round}{pk.isCompensatory ? " · COMP" : ""}</span>
+                </div>
+              ))}
+            </ScrollArea>
+          </CardContent>
+        </Card>
+      )}
+
+      {completedPicks.length > 0 && (
+        <Card className="card-premium" style={{ padding: 0, overflow: "hidden" }}>
+          <CardHeader style={{ padding: "var(--space-2) var(--space-3)", background: "var(--surface-strong)", borderBottom: "1px solid var(--hairline)" }}>
+            <CardTitle style={{ fontSize: "var(--text-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: "var(--text-muted)" }}>
+              Recent Picks
+            </CardTitle>
+          </CardHeader>
+          <CardContent style={{ padding: 0 }}>
+            <ScrollArea style={{ maxHeight: 240 }}>
+              {[...completedPicks]
+                .reverse()
+                .filter((pk) => Number(pk.round) === Number(activeRound))
+                .slice(0, 8)
+                .map((pk) => (
+                  <div key={pk.overall} style={{ padding: "var(--space-2) var(--space-3)", borderBottom: "1px solid var(--hairline)", fontSize: "var(--text-xs)" }}>
+                    <div style={{ color: "var(--text-muted)", marginBottom: 1 }}>
+                      #{pk.overall} {pk.teamAbbr}{pk.isCompensatory ? " · COMP" : ""}
+                    </div>
+                    <div style={{ fontWeight: 600, color: "var(--text)" }}>
+                      {pk.playerName}
+                      <span style={{ marginLeft: 6, color: "var(--text-subtle)" }}>
+                        {pk.playerPos} · <OvrBadge ovr={pk.playerOvr ?? 0} />
+                      </span>
+                    </div>
+                  </div>
+                ))}
+            </ScrollArea>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+export default DraftLeftPanel;

--- a/src/ui/draft/DraftLeftPanel.test.jsx
+++ b/src/ui/draft/DraftLeftPanel.test.jsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { renderToString } from "react-dom/server";
+import { DraftLeftPanel } from "./DraftLeftPanel.jsx";
+import { DRAFT_ROOM_PHASES } from "./draftShared.js";
+
+const pick = { teamAbbr: "KC", teamName: "Kansas City Chiefs", round: 2, overall: 35 };
+
+const baseProps = {
+  isDraftComplete: false,
+  isUserPick: false,
+  currentPick: pick,
+  draftPhase: DRAFT_ROOM_PHASES.CPU_PICKING,
+  pickClock: 90,
+  userAutoPick: false,
+  onAutoPickChange: vi.fn(),
+  simming: false,
+  disabled: false,
+  onSimToMyPick: vi.fn(),
+  actions: { getRoster: vi.fn(), submitTrade: vi.fn() },
+  showTradeUp: false,
+  onShowTradeUp: vi.fn(),
+  onHideTradeUp: vi.fn(),
+  upcomingPicks: [],
+  completedPicks: [],
+  activeRound: 1,
+  league: { year: 2025, userTeamId: 1, teams: [] },
+};
+
+describe("DraftLeftPanel", () => {
+  it("renders pick clock and team info without crashing", () => {
+    const html = renderToString(<DraftLeftPanel {...baseProps} />);
+    expect(html).toContain("On the Clock");
+    expect(html).toContain("KC");
+    expect(html).toContain("Kansas City Chiefs");
+  });
+
+  it("shows Sim to My Pick button when AI is picking", () => {
+    const html = renderToString(<DraftLeftPanel {...baseProps} />);
+    expect(html).toContain("Sim to My Pick");
+  });
+
+  it("hides Sim button when user is on the clock", () => {
+    const html = renderToString(<DraftLeftPanel {...baseProps} isUserPick />);
+    expect(html).not.toContain("Sim to My Pick");
+  });
+
+  it("shows Draft Complete when draft is finished", () => {
+    const html = renderToString(<DraftLeftPanel {...baseProps} isDraftComplete />);
+    expect(html).toContain("Draft Complete");
+  });
+
+  it("renders upcoming picks when provided", () => {
+    const upcomingPicks = [{ overall: 35, teamAbbr: "KC", round: 2, isUser: false }];
+    const html = renderToString(<DraftLeftPanel {...baseProps} upcomingPicks={upcomingPicks} />);
+    expect(html).toContain("Pick Order");
+  });
+});

--- a/src/ui/draft/DraftTicker.jsx
+++ b/src/ui/draft/DraftTicker.jsx
@@ -1,0 +1,43 @@
+import React, { useMemo } from "react";
+import { ovrColor } from "./draftShared.js";
+
+export function DraftTicker({ completedPicks }) {
+  const lastPicks = useMemo(
+    () => [...completedPicks].reverse().slice(0, 5),
+    [completedPicks],
+  );
+
+  if (lastPicks.length === 0) return null;
+
+  return (
+    <div
+      className="draft-ticker"
+      style={{ background: "var(--surface-strong)", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "var(--space-2) var(--space-3)", marginBottom: "var(--space-4)", overflow: "hidden" }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
+        <span style={{ fontSize: 10, fontWeight: 800, color: "var(--accent)", textTransform: "uppercase", letterSpacing: "1px", flexShrink: 0, marginRight: "var(--space-2)" }}>
+          LATEST
+        </span>
+        <div style={{ display: "flex", gap: "var(--space-4)", overflowX: "auto", whiteSpace: "nowrap", flex: 1, scrollbarWidth: "none", msOverflowStyle: "none" }}>
+          {lastPicks.map((pk) => (
+            <span
+              key={pk.overall}
+              style={{ display: "inline-flex", alignItems: "center", gap: "var(--space-2)", fontSize: "var(--text-xs)", color: "var(--text)", animation: "tickerSlideIn 0.4s ease-out" }}
+            >
+              <span style={{ fontWeight: 800, color: "var(--text-muted)", fontSize: 10, minWidth: 18 }}>#{pk.overall}</span>
+              <span style={{ fontWeight: 700, color: "var(--accent)" }}>{pk.teamAbbr}</span>
+              <span style={{ color: "var(--text-muted)" }}>{pk.playerPos}</span>
+              <span style={{ fontWeight: 600 }}>{pk.playerName}</span>
+              <span style={{ padding: "0 4px", borderRadius: "var(--radius-pill)", background: `${ovrColor(pk.playerOvr ?? 0)}22`, color: ovrColor(pk.playerOvr ?? 0), fontWeight: 700, fontSize: 10 }}>
+                {pk.playerOvr}
+              </span>
+            </span>
+          ))}
+        </div>
+      </div>
+      <style>{`@keyframes tickerSlideIn { from { opacity: 0; transform: translateX(20px); } to { opacity: 1; transform: translateX(0); } }`}</style>
+    </div>
+  );
+}
+
+export default DraftTicker;

--- a/src/ui/draft/DraftTicker.test.jsx
+++ b/src/ui/draft/DraftTicker.test.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { renderToString } from "react-dom/server";
+import { DraftTicker } from "./DraftTicker.jsx";
+
+const pick = (n) => ({ overall: n, teamAbbr: "KC", playerPos: "QB", playerName: `Player${n}`, playerOvr: 72 });
+
+describe("DraftTicker", () => {
+  it("renders nothing when completedPicks is empty", () => {
+    const html = renderToString(<DraftTicker completedPicks={[]} />);
+    expect(html).toBe("");
+  });
+
+  it("renders LATEST label and pick info when picks exist", () => {
+    const html = renderToString(<DraftTicker completedPicks={[pick(1), pick(2)]} />);
+    expect(html).toContain("LATEST");
+    expect(html).toContain("KC");
+    expect(html).toContain("QB");
+    expect(html).toContain("Player1");
+    expect(html).toContain("Player2");
+  });
+
+  it("shows at most 5 picks from a 7-pick list (most recent first)", () => {
+    const picks = [1, 2, 3, 4, 5, 6, 7].map(pick);
+    const html = renderToString(<DraftTicker completedPicks={picks} />);
+    // Last 5 reversed: players 7,6,5,4,3 should appear; 2 and 1 should not
+    expect(html).toContain("Player7");
+    expect(html).toContain("Player3");
+    expect(html).not.toContain("Player2");
+    expect(html).not.toContain("Player1");
+  });
+});

--- a/src/ui/draft/DraftTradeDownPanel.jsx
+++ b/src/ui/draft/DraftTradeDownPanel.jsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+
+export function DraftTradeDownPanel({
+  pendingTradeProposal,
+  processing,
+  onAccept,
+  onDecline,
+  onClose,
+}) {
+  return (
+    <div
+      style={{
+        padding: "var(--space-4)",
+        background: "var(--surface-strong)",
+        border: "1px solid var(--warning, #FF9F0A)",
+        borderRadius: "var(--radius-md)",
+        marginBottom: "var(--space-3)",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "var(--space-3)" }}>
+        <div style={{ fontWeight: 800, color: "var(--text)" }}>
+          Trade Offer from {pendingTradeProposal.aiTeamAbbr}
+        </div>
+        <Button
+          className="btn"
+          onClick={onClose}
+          style={{ background: "none", border: "none", fontSize: 16, color: "var(--text-muted)", cursor: "pointer", lineHeight: 1 }}
+        >
+          ×
+        </Button>
+      </div>
+      <div style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)", marginBottom: "var(--space-3)", lineHeight: 1.5 }}>
+        The{" "}
+        <strong style={{ color: "var(--text)" }}>{pendingTradeProposal.aiTeamName}</strong>{" "}
+        are offering to trade up for your pick #{pendingTradeProposal.userPickOverall}.
+        They want to draft{" "}
+        <strong style={{ color: "var(--text)" }}>
+          {pendingTradeProposal.targetProspect?.name} ({pendingTradeProposal.targetProspect?.pos},{" "}
+          {pendingTradeProposal.targetProspect?.ovr} OVR)
+        </strong>.
+      </div>
+      <div style={{ fontSize: "var(--text-sm)", color: "var(--text)", marginBottom: "var(--space-3)", fontWeight: 600 }}>
+        You receive: their pick #{pendingTradeProposal.aiPickOverall} (Round{" "}
+        {pendingTradeProposal.aiPickRound}) + a later pick swap in this draft.
+      </div>
+      <div style={{ display: "flex", gap: "var(--space-3)" }}>
+        <Button
+          className="btn btn-primary"
+          disabled={processing}
+          onClick={onAccept}
+          style={{ fontWeight: 600, fontSize: "var(--text-sm)", padding: "var(--space-2) var(--space-4)" }}
+        >
+          {processing ? "Processing…" : "Accept Trade"}
+        </Button>
+        <Button
+          className="btn"
+          onClick={onDecline}
+          style={{ fontWeight: 600, fontSize: "var(--text-sm)", padding: "var(--space-2) var(--space-4)" }}
+        >
+          Decline
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default DraftTradeDownPanel;

--- a/src/ui/draft/DraftTradeDownPanel.test.jsx
+++ b/src/ui/draft/DraftTradeDownPanel.test.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { renderToString } from "react-dom/server";
+import { DraftTradeDownPanel } from "./DraftTradeDownPanel.jsx";
+
+const proposal = {
+  aiTeamAbbr: "DAL",
+  aiTeamName: "Dallas Cowboys",
+  userPickOverall: 8,
+  targetProspect: { name: "Joe Smith", pos: "QB", ovr: 82 },
+  aiPickOverall: 15,
+  aiPickRound: 1,
+};
+
+describe("DraftTradeDownPanel", () => {
+  it("renders trade offer details without crashing", () => {
+    const html = renderToString(
+      <DraftTradeDownPanel
+        pendingTradeProposal={proposal}
+        processing={false}
+        onAccept={vi.fn()}
+        onDecline={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    // React 18 SSR: "Trade Offer from <!-- -->DAL"
+    expect(html).toContain("Trade Offer from");
+    expect(html).toContain("Dallas Cowboys");
+    expect(html).toContain("Joe Smith");
+    expect(html).toContain("Accept Trade");
+    expect(html).toContain("Decline");
+  });
+
+  it("shows Processing… when processing is true", () => {
+    const html = renderToString(
+      <DraftTradeDownPanel
+        pendingTradeProposal={proposal}
+        processing
+        onAccept={vi.fn()}
+        onDecline={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(html).toContain("Processing…");
+  });
+});

--- a/src/ui/draft/DraftWarRoomBanner.jsx
+++ b/src/ui/draft/DraftWarRoomBanner.jsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { POS_COLORS } from "../constants/positionColors.js";
+
+export function DraftWarRoomBanner({ isUserPick, currentPick, isDraftComplete }) {
+  if (isDraftComplete) return null;
+
+  return (
+    <div
+      style={{
+        marginBottom: "var(--space-4)",
+        borderRadius: "var(--radius-md)",
+        overflow: "hidden",
+        background: isUserPick
+          ? "linear-gradient(135deg, #0f0c29 0%, #302b63 60%, #24243e 100%)"
+          : "var(--surface-strong)",
+        border: `1px solid ${isUserPick ? "var(--accent)" : "var(--hairline)"}`,
+        padding: "var(--space-3) var(--space-5)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: "var(--space-4)",
+      }}
+    >
+      <div>
+        <div style={{ fontSize: 10, fontWeight: 800, letterSpacing: "2px", textTransform: "uppercase", color: isUserPick ? "var(--accent)" : "var(--text-muted)", marginBottom: 2 }}>
+          {isUserPick ? "★ You Are On The Clock" : "War Room — AI Picking"}
+        </div>
+        <div style={{ fontWeight: 800, fontSize: "var(--text-lg)", color: "var(--text)" }}>
+          {currentPick?.teamName ?? "—"}
+          <span style={{ marginLeft: 10, fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 400 }}>
+            Round {currentPick?.round} · Pick #{currentPick?.overall}
+          </span>
+        </div>
+      </div>
+      <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", justifyContent: "flex-end" }}>
+        {Object.entries(POS_COLORS)
+          .filter(([pos]) => !["default", "DB", "CB", "S"].includes(pos))
+          .map(([pos, color]) => (
+            <span
+              key={pos}
+              style={{ padding: "1px 6px", borderRadius: "var(--radius-pill)", background: `${color}22`, color, fontSize: 10, fontWeight: 700, border: `1px solid ${color}44`, fontFamily: "var(--font-mono)" }}
+            >
+              {pos}
+            </span>
+          ))}
+      </div>
+    </div>
+  );
+}
+
+export default DraftWarRoomBanner;

--- a/src/ui/draft/DraftWarRoomBanner.test.jsx
+++ b/src/ui/draft/DraftWarRoomBanner.test.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { renderToString } from "react-dom/server";
+import { DraftWarRoomBanner } from "./DraftWarRoomBanner.jsx";
+
+const pick = { teamName: "Kansas City Chiefs", teamAbbr: "KC", round: 1, overall: 5 };
+
+describe("DraftWarRoomBanner", () => {
+  it("renders nothing when draft is complete", () => {
+    const html = renderToString(<DraftWarRoomBanner isUserPick={false} currentPick={pick} isDraftComplete />);
+    expect(html).toBe("");
+  });
+
+  it("shows AI picking label when not user pick", () => {
+    const html = renderToString(<DraftWarRoomBanner isUserPick={false} currentPick={pick} isDraftComplete={false} />);
+    expect(html).toContain("War Room");
+    expect(html).toContain("Kansas City Chiefs");
+  });
+
+  it("shows on-the-clock label for user pick", () => {
+    const html = renderToString(<DraftWarRoomBanner isUserPick currentPick={pick} isDraftComplete={false} />);
+    expect(html).toContain("On The Clock");
+  });
+});

--- a/src/ui/draft/ProspectFilters.jsx
+++ b/src/ui/draft/ProspectFilters.jsx
@@ -1,0 +1,86 @@
+import React from "react";
+import AdvancedPlayerSearch from "../components/AdvancedPlayerSearch.jsx";
+import PlayerComparison from "../components/PlayerComparison.jsx";
+import PlayerCompareTray from "../components/PlayerCompareTray.jsx";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export function ProspectFilters({
+  nameFilter,
+  onNameFilterChange,
+  filterPos,
+  onFilterPosChange,
+  posOptions,
+  prospectCount,
+  showAdvancedFilters,
+  onToggleAdvancedFilters,
+  advancedFilters,
+  onAdvancedFiltersChange,
+  draftAdvancedFields,
+  compareIds,
+  showComparison,
+  comparePlayerA,
+  comparePlayerB,
+  onCloseComparison,
+  onToggleCompare,
+  onOpenCompare,
+  onClearCompare,
+  resolvePlayer,
+}) {
+  return (
+    <>
+      <div style={{ display: "flex", gap: "var(--space-3)", flexWrap: "wrap", alignItems: "center" }}>
+        <Input
+          type="text"
+          placeholder="Search name…"
+          value={nameFilter}
+          onChange={(e) => onNameFilterChange(e.target.value)}
+          style={{ padding: "5px 10px", background: "var(--surface-strong)", border: "1px solid var(--hairline)", borderRadius: "var(--radius-sm)", color: "var(--text)", fontSize: "var(--text-sm)", width: 180 }}
+        />
+        <select
+          value={filterPos}
+          onChange={(e) => onFilterPosChange(e.target.value)}
+          style={{ padding: "5px 10px", background: "var(--surface-strong)", border: "1px solid var(--hairline)", borderRadius: "var(--radius-sm)", color: "var(--text)", fontSize: "var(--text-sm)" }}
+        >
+          <option value="">All Positions</option>
+          {posOptions.map((p) => (
+            <option key={p} value={p}>{p}</option>
+          ))}
+        </select>
+        <span style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginLeft: "auto" }}>
+          {prospectCount} prospect{prospectCount !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      <div style={{ marginTop: 8, marginBottom: 8 }}>
+        <Button className="btn" onClick={onToggleAdvancedFilters} style={{ fontSize: "var(--text-xs)" }}>
+          {showAdvancedFilters ? "Hide advanced filters" : "Show advanced filters"}
+        </Button>
+      </div>
+
+      {showAdvancedFilters && (
+        <AdvancedPlayerSearch
+          filters={advancedFilters}
+          onChange={onAdvancedFiltersChange}
+          title="Draft advanced search"
+          allowedFields={draftAdvancedFields}
+          presetKeys={["youngHighPotential", "day1Starters", "developmentalUpside", "bestAthletes", "valuePicks", "qbUpside", "skillUpside"]}
+        />
+      )}
+
+      {showComparison && comparePlayerA && comparePlayerB && (
+        <PlayerComparison playerA={comparePlayerA} playerB={comparePlayerB} onClose={onCloseComparison} />
+      )}
+
+      <PlayerCompareTray
+        compareIds={compareIds}
+        resolvePlayer={resolvePlayer}
+        onRemove={onToggleCompare}
+        onOpenCompare={onOpenCompare}
+        onClear={onClearCompare}
+      />
+    </>
+  );
+}
+
+export default ProspectFilters;

--- a/src/ui/draft/ProspectFilters.test.jsx
+++ b/src/ui/draft/ProspectFilters.test.jsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { renderToString } from "react-dom/server";
+import { ProspectFilters } from "./ProspectFilters.jsx";
+
+const baseProps = {
+  nameFilter: "",
+  onNameFilterChange: vi.fn(),
+  filterPos: "",
+  onFilterPosChange: vi.fn(),
+  posOptions: ["QB", "WR", "RB"],
+  prospectCount: 42,
+  showAdvancedFilters: false,
+  onToggleAdvancedFilters: vi.fn(),
+  advancedFilters: [],
+  onAdvancedFiltersChange: vi.fn(),
+  draftAdvancedFields: [],
+  compareIds: [],
+  showComparison: false,
+  comparePlayerA: null,
+  comparePlayerB: null,
+  onCloseComparison: vi.fn(),
+  onToggleCompare: vi.fn(),
+  onOpenCompare: vi.fn(),
+  onClearCompare: vi.fn(),
+  resolvePlayer: vi.fn(),
+};
+
+describe("ProspectFilters", () => {
+  it("renders search input and position options without crashing", () => {
+    const html = renderToString(<ProspectFilters {...baseProps} />);
+    expect(html).toContain("Search name");
+    expect(html).toContain("All Positions");
+    expect(html).toContain("QB");
+    // React 18 SSR: "42 prospects" renders as "42<!-- --> prospects"
+    expect(html).toContain("42");
+    expect(html).toContain("prospect");
+  });
+
+  it("shows advanced filters button text", () => {
+    const html = renderToString(<ProspectFilters {...baseProps} />);
+    expect(html).toContain("Show advanced filters");
+  });
+});

--- a/src/ui/draft/ProspectRow.jsx
+++ b/src/ui/draft/ProspectRow.jsx
@@ -1,0 +1,122 @@
+import React from "react";
+import TraitBadge from "../components/TraitBadge";
+import PlayerPreview from "../components/PlayerPreview";
+import { TableRow, TableCell } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { POS_COLORS } from "../constants/positionColors.js";
+import { ScoutBadge, ProspectScoutingChips } from "./ScoutBadge.jsx";
+import { OvrBadge } from "./DraftBadges.jsx";
+import { DRAFT_ROOM_PHASES } from "./draftShared.js";
+
+export function ProspectRow({
+  prospect: p,
+  rank,
+  boardRank,
+  isUserPick,
+  isDraftComplete,
+  draftPhase,
+  onDraftPlayer,
+  onPlayerClick,
+  compareIds,
+  onToggleCompare,
+  onMoveUp,
+  onMoveDown,
+  disabled,
+  userTeam,
+  isRecommended,
+  isTopByPos,
+}) {
+  const rowStyle = isRecommended
+    ? { background: "rgba(52,199,89,0.1)" }
+    : isTopByPos
+    ? { background: "rgba(10,132,255,0.08)" }
+    : undefined;
+
+  const canDraft = draftPhase === DRAFT_ROOM_PHASES.ON_THE_CLOCK && isUserPick;
+
+  return (
+    <TableRow style={rowStyle}>
+      <TableCell style={{ textAlign: "center", fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
+        {boardRank}
+      </TableCell>
+      <TableCell style={{ textAlign: "center", color: "var(--text-subtle)", paddingLeft: "var(--space-3)", fontSize: "var(--text-xs)", fontWeight: 700 }}>
+        {rank}
+      </TableCell>
+      <TableCell>
+        <Badge
+          variant="outline"
+          style={{ display: "inline-block", padding: "1px 6px", borderRadius: "var(--radius-pill)", background: `${POS_COLORS[p.pos] ?? "#666"}22`, fontSize: "var(--text-xs)", fontWeight: 700, color: POS_COLORS[p.pos] ?? "var(--text-muted)", border: `1px solid ${POS_COLORS[p.pos] ?? "#666"}55`, fontFamily: "var(--font-mono)" }}
+        >
+          {p.pos}
+        </Badge>
+      </TableCell>
+      <TableCell
+        style={{ fontWeight: 600, color: onPlayerClick ? "var(--accent)" : "var(--text)", cursor: onPlayerClick ? "pointer" : "default" }}
+        onClick={() => onPlayerClick && onPlayerClick(p.id)}
+        title={onPlayerClick ? `View ${p.name}'s profile` : undefined}
+      >
+        <PlayerPreview player={p}>
+          <span style={{ textDecoration: onPlayerClick ? "underline" : "none", textDecorationStyle: "dotted", textUnderlineOffset: 3 }}>
+            {p.name}
+          </span>
+        </PlayerPreview>
+      </TableCell>
+      <TableCell style={{ textAlign: "center", whiteSpace: "nowrap" }}>
+        {(p.traits || []).map((t) => <TraitBadge key={t} traitId={t} />)}
+      </TableCell>
+      <TableCell style={{ color: "var(--text-muted)" }}>{p.age}</TableCell>
+      <TableCell style={{ textAlign: "center" }}>
+        <Button
+          title={compareIds.includes(p.id) ? "Remove from compare" : "Add to compare"}
+          onClick={() => onToggleCompare(p)}
+          style={{ width: 22, height: 22, borderRadius: "var(--radius-sm)", border: `1.5px solid ${compareIds.includes(p.id) ? "var(--accent)" : "var(--hairline)"}`, background: compareIds.includes(p.id) ? "var(--accent-muted)" : "transparent", fontSize: 12, color: compareIds.includes(p.id) ? "var(--accent)" : "var(--text-subtle)" }}
+        >
+          {compareIds.includes(p.id) ? "✓" : "⊕"}
+        </Button>
+      </TableCell>
+      <TableCell>
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 2 }}>
+          {isDraftComplete ? (
+            <OvrBadge ovr={p.ovr} />
+          ) : (
+            <>
+              <ScoutBadge player={p} team={userTeam} />
+              <ProspectScoutingChips prospect={p} team={userTeam} />
+            </>
+          )}
+        </div>
+      </TableCell>
+      <TableCell style={{ color: "var(--text-subtle)", fontSize: "var(--text-xs)" }}>
+        {isDraftComplete ? (p.potential ?? "—") : "??"}
+      </TableCell>
+      <TableCell style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }} title="40-yard dash (seconds). Lower is better.">
+        {p?.combineResults?.fortyTime ?? "—"}
+      </TableCell>
+      <TableCell style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }} title="Bench press reps at 225 lbs. Higher is better.">
+        {p?.combineResults?.benchPress ?? "—"}
+      </TableCell>
+      <TableCell style={{ color: "var(--text-muted)", fontSize: "var(--text-xs)", maxWidth: 160, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {p.college ?? p.origin ?? "—"}
+      </TableCell>
+      {isUserPick && !isDraftComplete && (
+        <TableCell style={{ textAlign: "right", paddingRight: "var(--space-3)" }}>
+          <Button
+            className="btn btn-primary"
+            disabled={!canDraft || disabled}
+            style={{ padding: "3px 12px", fontSize: "var(--text-xs)" }}
+            onClick={() => onDraftPlayer(p.id)}
+          >
+            {disabled ? "Drafting…" : "Draft"}
+          </Button>
+          <div style={{ display: "inline-flex", marginLeft: 8, gap: 4 }}>
+            <Button className="btn" title="Move up board" onClick={onMoveUp} style={{ padding: "2px 6px", fontSize: 10 }}>↑</Button>
+            <Button className="btn" title="Move down board" onClick={onMoveDown} style={{ padding: "2px 6px", fontSize: 10 }}>↓</Button>
+          </div>
+        </TableCell>
+      )}
+    </TableRow>
+  );
+}
+
+export default ProspectRow;

--- a/src/ui/draft/ProspectRow.test.jsx
+++ b/src/ui/draft/ProspectRow.test.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { renderToString } from "react-dom/server";
+import { ProspectRow } from "./ProspectRow.jsx";
+import { DRAFT_ROOM_PHASES } from "./draftShared.js";
+
+const prospect = {
+  id: 1,
+  name: "Tom Brady",
+  pos: "QB",
+  age: 22,
+  ovr: 75,
+  potential: "A",
+  traits: [],
+  combineResults: { fortyTime: "4.8", benchPress: 20 },
+  college: "Michigan",
+};
+
+const baseProps = {
+  prospect,
+  rank: 1,
+  boardRank: 1,
+  isUserPick: false,
+  isDraftComplete: false,
+  draftPhase: DRAFT_ROOM_PHASES.CPU_PICKING,
+  onDraftPlayer: vi.fn(),
+  onPlayerClick: vi.fn(),
+  compareIds: [],
+  onToggleCompare: vi.fn(),
+  onMoveUp: vi.fn(),
+  onMoveDown: vi.fn(),
+  disabled: false,
+  userTeam: null,
+  isRecommended: false,
+  isTopByPos: false,
+};
+
+describe("ProspectRow", () => {
+  it("renders prospect name and position without crashing", () => {
+    const html = renderToString(<table><tbody><ProspectRow {...baseProps} /></tbody></table>);
+    expect(html).toContain("Tom Brady");
+    expect(html).toContain("QB");
+    expect(html).toContain("Michigan");
+  });
+
+  it("hides Draft button when not user pick", () => {
+    const html = renderToString(<table><tbody><ProspectRow {...baseProps} isUserPick={false} /></tbody></table>);
+    expect(html).not.toContain(">Draft<");
+  });
+
+  it("shows Draft button when user is on the clock", () => {
+    const html = renderToString(
+      <table><tbody>
+        <ProspectRow {...baseProps} isUserPick draftPhase={DRAFT_ROOM_PHASES.ON_THE_CLOCK} />
+      </tbody></table>,
+    );
+    expect(html).toContain("Draft");
+  });
+
+  it("shows scout grade before draft completes (potential hidden)", () => {
+    const html = renderToString(<table><tbody><ProspectRow {...baseProps} isDraftComplete={false} /></tbody></table>);
+    expect(html).toContain("??");
+  });
+
+  it("shows true OVR value after draft completes", () => {
+    const html = renderToString(<table><tbody><ProspectRow {...baseProps} isDraftComplete /></tbody></table>);
+    // After draft, OvrBadge shows the numeric OVR (75) and potential ("A")
+    expect(html).toContain("75");
+    expect(html).not.toContain("??");
+  });
+});

--- a/src/ui/draft/ProspectTable.jsx
+++ b/src/ui/draft/ProspectTable.jsx
@@ -1,472 +1,26 @@
-import React, { useState, useEffect, useMemo, useCallback } from "react";
-import TraitBadge from "../components/TraitBadge";
-import PlayerPreview from "../components/PlayerPreview";
-import AdvancedPlayerSearch from "../components/AdvancedPlayerSearch.jsx";
-import PlayerComparison from "../components/PlayerComparison.jsx";
-import PlayerCompareTray from "../components/PlayerCompareTray.jsx";
+import React, { useCallback } from "react";
 import EmptyState from "../components/EmptyState.jsx";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from "@/components/ui/table";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { applyAdvancedPlayerFilters, allFilters } from "../../core/footballAdvancedFilters";
-import { usePlayerCompare } from "../utils/playerCompare.js";
-import { POS_COLORS } from "../constants/positionColors.js";
-import { ScoutBadge, ProspectScoutingChips } from "./ScoutBadge.jsx";
-import { OvrBadge, SortIcon } from "./DraftBadges.jsx";
-import { DRAFT_ROOM_PHASES, formatClock, buildPickOrder, ovrColor, filterDraftProspectsForView } from "./draftShared.js";
+import { SortIcon } from "./DraftBadges.jsx";
+import { DRAFT_ROOM_PHASES } from "./draftShared.js";
+import { useDraftBoard } from "./useDraftBoard.js";
+import { DraftTicker } from "./DraftTicker.jsx";
+import { DraftWarRoomBanner } from "./DraftWarRoomBanner.jsx";
+import { DraftLeftPanel } from "./DraftLeftPanel.jsx";
+import { DraftTradeDownPanel } from "./DraftTradeDownPanel.jsx";
+import { ProspectFilters } from "./ProspectFilters.jsx";
+import { ProspectRow } from "./ProspectRow.jsx";
 
-function DraftTicker({ completedPicks }) {
-  const lastPicks = useMemo(
-    () => [...completedPicks].reverse().slice(0, 5),
-    [completedPicks],
-  );
-
-  if (lastPicks.length === 0) return null;
-
-  return (
-    <div
-      className="draft-ticker"
-      style={{
-        background: "var(--surface-strong)",
-        border: "1px solid var(--hairline)",
-        borderRadius: "var(--radius-md)",
-        padding: "var(--space-2) var(--space-3)",
-        marginBottom: "var(--space-4)",
-        overflow: "hidden",
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "var(--space-2)",
-        }}
-      >
-        <span
-          style={{
-            fontSize: 10,
-            fontWeight: 800,
-            color: "var(--accent)",
-            textTransform: "uppercase",
-            letterSpacing: "1px",
-            flexShrink: 0,
-            marginRight: "var(--space-2)",
-          }}
-        >
-          LATEST
-        </span>
-        <div
-          style={{
-            display: "flex",
-            gap: "var(--space-4)",
-            overflowX: "auto",
-            whiteSpace: "nowrap",
-            flex: 1,
-            scrollbarWidth: "none",
-            msOverflowStyle: "none",
-          }}
-        >
-          {lastPicks.map((pk) => (
-            <span
-              key={pk.overall}
-              style={{
-                display: "inline-flex",
-                alignItems: "center",
-                gap: "var(--space-2)",
-                fontSize: "var(--text-xs)",
-                color: "var(--text)",
-                animation: "tickerSlideIn 0.4s ease-out",
-              }}
-            >
-              <span
-                style={{
-                  fontWeight: 800,
-                  color: "var(--text-muted)",
-                  fontSize: 10,
-                  minWidth: 18,
-                }}
-              >
-                #{pk.overall}
-              </span>
-              <span style={{ fontWeight: 700, color: "var(--accent)" }}>
-                {pk.teamAbbr}
-              </span>
-              <span style={{ color: "var(--text-muted)" }}>{pk.playerPos}</span>
-              <span style={{ fontWeight: 600 }}>{pk.playerName}</span>
-              <span
-                style={{
-                  padding: "0 4px",
-                  borderRadius: "var(--radius-pill)",
-                  background: `${ovrColor(pk.playerOvr ?? 0)}22`,
-                  color: ovrColor(pk.playerOvr ?? 0),
-                  fontWeight: 700,
-                  fontSize: 10,
-                }}
-              >
-                {pk.playerOvr}
-              </span>
-            </span>
-          ))}
-        </div>
-      </div>
-      <style>{`
-        @keyframes tickerSlideIn { from { opacity: 0; transform: translateX(20px); } to { opacity: 1; transform: translateX(0); } }
-      `}</style>
-    </div>
-  );
-}
-
-function TradeUpModal({
-  currentPick,
-  league,
-  actions,
-  onClose,
-  onTradeComplete,
-}) {
-  const [loading, setLoading] = useState(false);
-  const [myRoster, setMyRoster] = useState([]);
-  const [offering, setOffering] = useState(new Set());
-  const [myPicks, setMyPicks] = useState([]);
-  const [result, setResult] = useState(null);
-
-  const targetTeamId = currentPick?.teamId;
-  const userTeamId = league?.userTeamId;
-
-  // Fetch user roster on open
-  useEffect(() => {
-    if (!actions?.getRoster || userTeamId == null) return;
-    (async () => {
-      setLoading(true);
-      try {
-        const res = await actions.getRoster(userTeamId);
-        if (res?.payload) setMyRoster(res.payload.players ?? []);
-      } catch (e) {
-        console.error(e);
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, [actions, userTeamId]);
-
-  const togglePlayer = (id) => {
-    setOffering((prev) => {
-      const s = new Set(prev);
-      s.has(id) ? s.delete(id) : s.add(id);
-      return s;
-    });
-  };
-
-  const addPick = (round) => {
-    setMyPicks((prev) => [
-      ...prev,
-      {
-        id: `up_${round}_${Date.now()}`,
-        round,
-        year: (league?.year ?? 2025) + 1,
-      },
-    ]);
-  };
-
-  const removePick = (id) => {
-    setMyPicks((prev) => prev.filter((p) => p.id !== id));
-  };
-
-  const handlePropose = async () => {
-    if (targetTeamId == null || (offering.size === 0 && myPicks.length === 0))
-      return;
-    setLoading(true);
-    setResult(null);
-    try {
-      const resp = await actions.submitTrade(
-        userTeamId,
-        targetTeamId,
-        { playerIds: [...offering], pickIds: myPicks.map((p) => p.id) },
-        { playerIds: [], pickIds: [] },
-      );
-      if (resp?.payload) {
-        setResult(resp.payload);
-        if (resp.payload.accepted) {
-          setTimeout(() => {
-            onTradeComplete?.();
-            onClose();
-          }, 1500);
-        }
-      }
-    } catch (e) {
-      setResult({ accepted: false, reason: "Error: " + e.message });
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const hasSelection = offering.size > 0 || myPicks.length > 0;
-
-  return (
-    <div
-      onClick={onClose}
-      style={{
-        position: "fixed",
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        background: "rgba(0,0,0,0.75)",
-        zIndex: 10000,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: "var(--space-4)",
-      }}
-    >
-      <div
-        onClick={(e) => e.stopPropagation()}
-        style={{
-          background: "var(--surface)",
-          borderRadius: "var(--radius-lg)",
-          padding: "var(--space-5)",
-          maxWidth: 480,
-          width: "100%",
-          maxHeight: "85vh",
-          overflowY: "auto",
-        }}
-      >
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            marginBottom: "var(--space-4)",
-          }}
-        >
-          <div>
-            <div
-              style={{
-                fontWeight: 800,
-                fontSize: "var(--text-lg)",
-                color: "var(--text)",
-              }}
-            >
-              Trade for Pick #{currentPick?.overall}
-            </div>
-            <div
-              style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}
-            >
-              Currently owned by {currentPick?.teamAbbr} · Round{" "}
-              {currentPick?.round}
-            </div>
-          </div>
-          <Button
-            className="btn"
-            onClick={onClose}
-            style={{
-              background: "none",
-              border: "none",
-              color: "var(--text-muted)",
-              fontSize: 20,
-              cursor: "pointer",
-            }}
-          >
-            x
-          </Button>
-        </div>
-
-        {/* Result banner */}
-        {result && (
-          <div
-            style={{
-              padding: "var(--space-3)",
-              borderRadius: "var(--radius-md)",
-              border: `1px solid ${result.accepted ? "var(--success)" : "var(--danger)"}`,
-              background: result.accepted
-                ? "rgba(52,199,89,0.1)"
-                : "rgba(255,69,58,0.1)",
-              marginBottom: "var(--space-4)",
-              fontWeight: 700,
-              fontSize: "var(--text-sm)",
-              color: result.accepted ? "var(--success)" : "var(--danger)",
-            }}
-          >
-            {result.accepted
-              ? "Trade Accepted! Pick is yours."
-              : `Rejected: ${result.reason}`}
-          </div>
-        )}
-
-        {/* Offer picks */}
-        <div style={{ marginBottom: "var(--space-3)" }}>
-          <div
-            style={{
-              fontSize: "var(--text-xs)",
-              fontWeight: 700,
-              color: "var(--text-muted)",
-              marginBottom: "var(--space-2)",
-              textTransform: "uppercase",
-            }}
-          >
-            Offer Draft Picks
-          </div>
-          <div
-            style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}
-          >
-            {[1, 2, 3, 4, 5].map((r) => (
-              <Button
-                key={r}
-                className="btn"
-                style={{ fontSize: "var(--text-xs)", padding: "2px 8px" }}
-                onClick={() => addPick(r)}
-              >
-                + R{r}
-              </Button>
-            ))}
-          </div>
-          {myPicks.length > 0 && (
-            <div
-              style={{
-                display: "flex",
-                gap: "var(--space-1)",
-                flexWrap: "wrap",
-                marginTop: "var(--space-2)",
-              }}
-            >
-              {myPicks.map((pk) => (
-                <span
-                  key={pk.id}
-                  style={{
-                    fontSize: "var(--text-xs)",
-                    padding: "1px 6px",
-                    borderRadius: "var(--radius-pill)",
-                    background: "var(--accent)22",
-                    color: "var(--accent)",
-                    display: "inline-flex",
-                    alignItems: "center",
-                    gap: 4,
-                  }}
-                >
-                  {pk.year} R{pk.round}{pk.isCompensatory ? " COMP" : ""}
-                  <Button
-                    className="btn"
-                    onClick={() => removePick(pk.id)}
-                    style={{
-                      background: "none",
-                      border: "none",
-                      color: "inherit",
-                      cursor: "pointer",
-                      padding: 0,
-                      fontSize: 11,
-                    }}
-                  >
-                    x
-                  </Button>
-                </span>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Offer players */}
-        <div style={{ marginBottom: "var(--space-3)" }}>
-          <div
-            style={{
-              fontSize: "var(--text-xs)",
-              fontWeight: 700,
-              color: "var(--text-muted)",
-              marginBottom: "var(--space-2)",
-              textTransform: "uppercase",
-            }}
-          >
-            Offer Players
-          </div>
-          <div
-            style={{
-              maxHeight: 200,
-              overflowY: "auto",
-              border: "1px solid var(--hairline)",
-              borderRadius: "var(--radius-md)",
-            }}
-          >
-            {loading && (
-              <div
-                style={{
-                  padding: "var(--space-3)",
-                  color: "var(--text-muted)",
-                  textAlign: "center",
-                  fontSize: "var(--text-sm)",
-                }}
-              >
-                Loading roster...
-              </div>
-            )}
-            {myRoster
-              .sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0))
-              .map((p) => (
-                <label
-                  key={p.id}
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "var(--space-2)",
-                    padding: "var(--space-1) var(--space-2)",
-                    borderBottom: "1px solid var(--hairline)",
-                    cursor: "pointer",
-                    fontSize: "var(--text-xs)",
-                    background: offering.has(p.id)
-                      ? "var(--accent)11"
-                      : "transparent",
-                  }}
-                >
-                  <Input
-                    type="checkbox"
-                    checked={offering.has(p.id)}
-                    onChange={() => togglePlayer(p.id)}
-                    style={{
-                      accentColor: "var(--accent)",
-                      width: 12,
-                      height: 12,
-                    }}
-                  />
-                  <Badge
-                    variant="outline"
-                    style={{
-                      padding: "0 3px",
-                      borderRadius: "var(--radius-pill)",
-                      background: `${ovrColor(p.ovr)}22`,
-                      color: ovrColor(p.ovr),
-                      fontWeight: 700,
-                      fontSize: 10,
-                    }}
-                  >
-                    {p.ovr}
-                  </Badge>
-                  <span style={{ fontWeight: 600, color: "var(--text-muted)" }}>
-                    {p.pos}
-                  </span>
-                  <span
-                    style={{ flex: 1, fontWeight: 600, color: "var(--text)" }}
-                  >
-                    {p.name}
-                  </span>
-                </label>
-              ))}
-          </div>
-        </div>
-
-        {/* Propose */}
-        <Button
-          className="btn btn-primary"
-          onClick={handlePropose}
-          disabled={!hasSelection || loading}
-          style={{ width: "100%", fontWeight: 700 }}
-        >
-          {loading ? "Evaluating..." : "Propose Trade"}
-        </Button>
-      </div>
-    </div>
-  );
-}
+const PROSPECT_COLUMNS = [
+  { key: "boardRank", label: "BOARD" },
+  { key: "pos", label: "POS" },
+  { key: "name", label: "NAME" },
+  { key: "traits", label: "TRAITS" },
+  { key: "age", label: "AGE" },
+  { key: "compare", label: "CMP" },
+];
 
 function DraftBoard({
   draftState,
@@ -479,283 +33,54 @@ function DraftBoard({
   actions,
   disabled = false,
 }) {
-  const [sortKey, setSortKey] = useState("ovr");
-  const [sortDir, setSortDir] = useState(-1); // -1 = descending
-  const [filterPos, setFilterPos] = useState("");
-  const [nameFilter, setNameFilter] = useState("");
-  const [advancedFilters, setAdvancedFilters] = useState([]);
-  const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
-  const [showTradeUp, setShowTradeUp] = useState(false);
-  const [showTradeDown, setShowTradeDown] = useState(false);
-  const [tradeDownProcessing, setTradeDownProcessing] = useState(false);
-  const [manualBoard, setManualBoard] = useState([]);
-  const [pickClock, setPickClock] = useState(90);
-  const [userAutoPick, setUserAutoPick] = useState(false);
-  const [draftPhase, setDraftPhase] = useState(DRAFT_ROOM_PHASES.PRE_DRAFT);
-  const [pickFlash, setPickFlash] = useState(null);
-  const [cpuPending, setCpuPending] = useState(false);
-  const [activeRound, setActiveRound] = useState(1);
+  const board = useDraftBoard({ draftState, onDraftPlayer, onSimToMyPick, league });
 
-  const {
-    currentPick,
-    isUserPick,
-    isDraftComplete,
-    prospects = [],
-    completedPicks = [],
-    upcomingPicks = [],
-    pendingTradeProposal = null,
-    recommendedPick = null,
-    userBigBoard = [],
-  } = draftState;
+  const userTeam = (league?.teams ?? []).find((t) => t.id === league?.userTeamId);
 
-  useEffect(() => {
-    setManualBoard((userBigBoard ?? []).map((entry) => String(entry.playerId)));
-  }, [userBigBoard]);
-  useEffect(() => {
-    setPickClock(90);
-  }, [currentPick?.overall]);
-  useEffect(() => {
-    if (currentPick?.round) setActiveRound(currentPick.round);
-  }, [currentPick?.round]);
-
-  useEffect(() => {
-    if (isDraftComplete) {
-      setDraftPhase(DRAFT_ROOM_PHASES.DRAFT_COMPLETE);
-      return;
-    }
-    if (!currentPick) {
-      setDraftPhase(DRAFT_ROOM_PHASES.PRE_DRAFT);
-      return;
-    }
-    if (isUserPick) setDraftPhase(DRAFT_ROOM_PHASES.ON_THE_CLOCK);
-    else setDraftPhase(DRAFT_ROOM_PHASES.CPU_PICKING);
-  }, [currentPick, isUserPick, isDraftComplete]);
-
-  useEffect(() => {
-    if (!completedPicks.length) return;
-    const lastPick = completedPicks[completedPicks.length - 1];
-    if (!lastPick || lastPick.overall === pickFlash?.overall) return;
-    setPickFlash(lastPick);
-    setDraftPhase(DRAFT_ROOM_PHASES.PICK_MADE);
-    const timer = setTimeout(() => {
-      setPickFlash(null);
-      if (isDraftComplete) setDraftPhase(DRAFT_ROOM_PHASES.DRAFT_COMPLETE);
-      else if (isUserPick) setDraftPhase(DRAFT_ROOM_PHASES.ON_THE_CLOCK);
-      else setDraftPhase(DRAFT_ROOM_PHASES.CPU_PICKING);
-    }, 700);
-    return () => clearTimeout(timer);
-  }, [completedPicks, isDraftComplete, isUserPick, pickFlash?.overall]);
-
-  const sortedByOvr = useMemo(
-    () => [...prospects].sort((a, b) => (b?.ovr ?? 0) - (a?.ovr ?? 0)),
-    [prospects],
-  );
-
-  useEffect(() => {
-    if (draftPhase !== DRAFT_ROOM_PHASES.ON_THE_CLOCK || !isUserPick || isDraftComplete) return undefined;
-    if (!userAutoPick) return undefined;
-    const bestProspect = sortedByOvr[0];
-    if (bestProspect) onDraftPlayer(bestProspect.id);
-    return undefined;
-  }, [draftPhase, isUserPick, isDraftComplete, userAutoPick, sortedByOvr, onDraftPlayer]);
-
-  useEffect(() => {
-    if (draftPhase !== DRAFT_ROOM_PHASES.ON_THE_CLOCK || !isUserPick || userAutoPick || isDraftComplete) return undefined;
-    const timer = setInterval(() => {
-      setPickClock((prev) => {
-        if (prev <= 1) {
-          const bestProspect = sortedByOvr[0];
-          if (bestProspect) onDraftPlayer(bestProspect.id);
-          return 0;
-        }
-        return prev - 1;
-      });
-    }, 1000);
-    return () => clearInterval(timer);
-  }, [draftPhase, isUserPick, isDraftComplete, userAutoPick, sortedByOvr, onDraftPlayer]);
-
-  useEffect(() => {
-    if (draftPhase !== DRAFT_ROOM_PHASES.CPU_PICKING || isUserPick || isDraftComplete || cpuPending) return undefined;
-    setCpuPending(true);
-    const delay = 400 + Math.random() * 800;
-    const timer = setTimeout(async () => {
-      try {
-        await onSimToMyPick();
-      } finally {
-        setCpuPending(false);
+  const handleAcceptTradeDown = useCallback(async () => {
+    board.setTradeDownProcessing(true);
+    try {
+      const res = await actions.acceptDraftTrade(board.pendingTradeProposal);
+      if (res?.payload) {
+        board.setShowTradeDown(false);
+        onSimToMyPick();
       }
-    }, delay);
-    return () => {
-      clearTimeout(timer);
-      setCpuPending(false);
-    };
-  }, [draftPhase, isUserPick, isDraftComplete, cpuPending, onSimToMyPick]);
-
-  const toggleSort = (key) => {
-    if (sortKey === key) setSortDir((d) => -d);
-    else {
-      setSortKey(key);
-      setSortDir(-1);
+    } catch (e) {
+      console.error("[Draft] acceptDraftTrade failed:", e);
+    } finally {
+      board.setTradeDownProcessing(false);
     }
-  };
+  }, [actions, board, onSimToMyPick]);
 
-  const draftAdvancedFields = useMemo(() => allFilters.filter((field) => {
-    if (field.category === 'bio') {
-      return !['contractAmount', 'contractExp'].includes(field.key);
-    }
-    if (field.category === 'stats') {
-      return ['passing', 'rushing', 'receiving', 'defense'].includes(field.statGroup ?? '');
-    }
-    return true;
-  }), []);
+  const handleDeclineTradeDown = useCallback(async () => {
+    await actions.rejectDraftTrade?.();
+    board.setShowTradeDown(false);
+  }, [actions, board]);
 
-  const sortedProspects = useMemo(() => {
-    const filtered = filterDraftProspectsForView(prospects, { filterPos, nameFilter, advancedFilters });
-    const list = [...filtered];
-    list.sort((a, b) => {
-      const av = a[sortKey] ?? 0;
-      const bv = b[sortKey] ?? 0;
-      if (typeof av === "string") return sortDir * av.localeCompare(bv);
-      return sortDir * ((bv ?? 0) - (av ?? 0));
-    });
-    if (sortKey === 'boardRank' && manualBoard.length) {
-      const orderMap = new Map(manualBoard.map((id, idx) => [String(id), idx + 1]));
-      list.sort((a, b) => ((orderMap.get(String(a.id)) ?? 999) - (orderMap.get(String(b.id)) ?? 999)) * (sortDir === -1 ? 1 : -1));
-    }
-    return list;
-  }, [prospects, filterPos, nameFilter, sortKey, sortDir, advancedFilters, manualBoard]);
+  const ovrLabel = board.isDraftComplete ? "OVR" : "GRADE";
+  const potLabel = board.isDraftComplete ? "POT" : "???";
 
-  const {
-    compareIds,
-    setCompareIds,
-    showComparison,
-    setShowComparison,
-    toggleCompare,
-    comparePlayerA,
-    comparePlayerB,
-  } = usePlayerCompare(sortedProspects, 2);
+  const gradeColumns = [
+    { key: "ovr", label: ovrLabel },
+    { key: "potential", label: potLabel },
+    { key: "fortyTime", label: "40Y" },
+    { key: "benchPress", label: "BENCH" },
+    { key: "college", label: "COLLEGE" },
+  ];
 
-  const posOptions = useMemo(
-    () => [...new Set(prospects.map((p) => p.pos))].sort(),
-    [prospects],
-  );
-  const pickOrder = useMemo(
-    () => buildPickOrder(league?.teams ?? [], 7, league?.userTeamId),
-    [league?.teams, league?.userTeamId],
-  );
-  const topProspectByPos = useMemo(() => {
-    const map = new Map();
-    sortedByOvr.forEach((prospect) => {
-      if (!map.has(prospect.pos)) map.set(prospect.pos, String(prospect.id));
-    });
-    return map;
-  }, [sortedByOvr]);
-  const userPickCountsByRound = useMemo(() => {
-    const counts = new Map();
-    completedPicks.forEach((pk) => {
-      if (pk.teamId !== userTeamId) return;
-      counts.set(pk.round, (counts.get(pk.round) ?? 0) + 1);
-    });
-    return counts;
-  }, [completedPicks, userTeamId]);
+  const allColumns = [...PROSPECT_COLUMNS, ...gradeColumns];
 
   return (
     <div>
-      {/* ── War Room Banner ── */}
-      {!isDraftComplete && (
-        <div
-          style={{
-            marginBottom: "var(--space-4)",
-            borderRadius: "var(--radius-md)",
-            overflow: "hidden",
-            background: isUserPick
-              ? "linear-gradient(135deg, #0f0c29 0%, #302b63 60%, #24243e 100%)"
-              : "var(--surface-strong)",
-            border: `1px solid ${isUserPick ? "var(--accent)" : "var(--hairline)"}`,
-            padding: "var(--space-3) var(--space-5)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            gap: "var(--space-4)",
-          }}
-        >
-          <div>
-            <div
-              style={{
-                fontSize: 10,
-                fontWeight: 800,
-                letterSpacing: "2px",
-                textTransform: "uppercase",
-                color: isUserPick ? "var(--accent)" : "var(--text-muted)",
-                marginBottom: 2,
-              }}
-            >
-              {isUserPick ? "★ You Are On The Clock" : "War Room — AI Picking"}
-            </div>
-            <div
-              style={{
-                fontWeight: 800,
-                fontSize: "var(--text-lg)",
-                color: "var(--text)",
-              }}
-            >
-              {currentPick?.teamName ?? "—"}
-              <span
-                style={{
-                  marginLeft: 10,
-                  fontSize: "var(--text-xs)",
-                  color: "var(--text-muted)",
-                  fontWeight: 400,
-                }}
-              >
-                Round {currentPick?.round} · Pick #{currentPick?.overall}
-              </span>
-            </div>
-          </div>
-          {/* Position colour legend */}
-          <div
-            style={{
-              display: "flex",
-              gap: "var(--space-2)",
-              flexWrap: "wrap",
-              justifyContent: "flex-end",
-            }}
-          >
-            {Object.entries(POS_COLORS).filter(([pos]) => !["default", "DB", "CB", "S"].includes(pos)).map(([pos, color]) => (
-              <span
-                key={pos}
-                style={{
-                  padding: "1px 6px",
-                  borderRadius: "var(--radius-pill)",
-                  background: `${color}22`,
-                  color,
-                  fontSize: 10,
-                  fontWeight: 700,
-                  border: `1px solid ${color}44`,
-                  fontFamily: "var(--font-mono)",
-                }}
-              >
-                {pos}
-              </span>
-            ))}
-          </div>
-        </div>
-      )}
+      <DraftWarRoomBanner
+        isUserPick={board.isUserPick}
+        currentPick={board.currentPick}
+        isDraftComplete={board.isDraftComplete}
+      />
 
-      {/* ── Draft Ticker — last 5 picks ── */}
-      <DraftTicker completedPicks={completedPicks} />
+      <DraftTicker completedPicks={board.completedPicks} />
 
-      {/* ── Trade Up Modal ── */}
-      {showTradeUp && currentPick && !isUserPick && !isDraftComplete && (
-        <TradeUpModal
-          currentPick={currentPick}
-          league={league}
-          actions={actions}
-          onClose={() => setShowTradeUp(false)}
-          onTradeComplete={() => onSimToMyPick()}
-        />
-      )}
-      {pickOrder.length === 0 && (
+      {board.pickOrder.length === 0 && (
         <div style={{ marginBottom: "var(--space-4)", padding: "var(--space-3)", borderRadius: "var(--radius-md)", background: "rgba(255,69,58,0.1)", border: "1px solid var(--danger)", color: "var(--danger)", fontSize: "var(--text-sm)" }}>
           Draft cannot start — no teams found.
         </div>
@@ -763,765 +88,171 @@ function DraftBoard({
 
       <div
         className="draft-layout"
-        style={{
-          display: "grid",
-          gridTemplateColumns: "minmax(0, 260px) minmax(0, 1fr)",
-          gap: "var(--space-5)",
-          alignItems: "start",
-        }}
+        style={{ display: "grid", gridTemplateColumns: "minmax(0, 260px) minmax(0, 1fr)", gap: "var(--space-5)", alignItems: "start" }}
       >
-        <style>{`
-          @media (max-width: 900px) {
-            .draft-layout {
-              grid-template-columns: minmax(0, 1fr);
-            }
-          }
-        `}</style>
-        {/* ── Left Panel: Draft Board ── */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "var(--space-4)",
-          }}
-        >
-          {/* Current pick clock */}
-          <Card className="card-premium" style={{ overflow: "hidden" }}>
-          <CardContent style={{ padding: "var(--space-4)" }}>
-            {isDraftComplete ? (
-              <div style={{ textAlign: "center", padding: "var(--space-3)" }}>
-                <div style={{ fontSize: "1.4rem", marginBottom: 4 }}>🏈</div>
-                <div style={{ fontWeight: 800, color: "var(--success)" }}>
-                  Draft Complete
-                </div>
-              </div>
-            ) : (
-              <>
-                <div
-                  style={{
-                    fontSize: "var(--text-xs)",
-                    fontWeight: 700,
-                    textTransform: "uppercase",
-                    letterSpacing: "1px",
-                    color: "var(--text-muted)",
-                    marginBottom: "var(--space-2)",
-                  }}
-                >
-                  On the Clock
-                </div>
-                <div
-                  style={{
-                    fontWeight: 800,
-                    fontSize: "var(--text-xl)",
-                    color: "var(--text)",
-                    marginBottom: 4,
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "var(--space-2)",
-                  }}
-                >
-                  <span style={{ width: 26, height: 26, borderRadius: "50%", background: "var(--surface-strong)", border: "1px solid var(--hairline)", display: "inline-flex", alignItems: "center", justifyContent: "center", fontSize: 10 }}>
-                    {currentPick?.teamAbbr?.slice(0, 2) ?? "TM"}
-                  </span>
-                  {currentPick?.teamAbbr ?? "???"}
-                </div>
-                <div
-                  style={{
-                    fontSize: "var(--text-sm)",
-                    color: "var(--text-muted)",
-                    marginBottom: "var(--space-3)",
-                  }}
-                >
-                  {currentPick?.teamName ?? "—"}
-                </div>
-                <div
-                  style={{
-                    padding: "2px 8px",
-                    borderRadius: "var(--radius-pill)",
-                    background: isUserPick
-                      ? "var(--accent)22"
-                      : "var(--surface-strong)",
-                    border: `1px solid ${isUserPick ? "var(--accent)" : "var(--hairline)"}`,
-                    color: isUserPick ? "var(--accent)" : "var(--text-muted)",
-                    fontWeight: 700,
-                    fontSize: "var(--text-xs)",
-                    display: "inline-block",
-                    marginBottom: "var(--space-3)",
-                  }}
-                >
-                  {isUserPick ? "★ YOUR PICK" : "AI PICKING"}
-                </div>
-                <div
-                  style={{
-                    fontSize: "var(--text-sm)",
-                    color: "var(--text)",
-                    display: "flex",
-                    justifyContent: "space-between",
-                  }}
-                >
-                  <span>Round {currentPick?.round}</span>
-                  <span style={{ color: "var(--text-muted)" }}>
-                    Overall #{currentPick?.overall}
-                  </span>
-                </div>
-                {draftPhase === DRAFT_ROOM_PHASES.ON_THE_CLOCK && (
-                  <div style={{ marginTop: 6, fontSize: "var(--text-xs)", color: "var(--warning, #FF9F0A)", fontWeight: 700 }}>
-                    Clock: {formatClock(pickClock)}
-                  </div>
-                )}
-                <div style={{ marginTop: 6, fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>
-                  Phase: {draftPhase.replaceAll("_", " ")}
-                </div>
-                {currentPick?.isCompensatory && (
-                  <div style={{ marginTop: 6, fontSize: "var(--text-xs)", color: "var(--warning, #FF9F0A)", fontWeight: 700 }}>
-                    Compensatory pick · {currentPick?.compensatoryForName ? `for loss of ${currentPick.compensatoryForName}` : "NFL comp selection"}
-                  </div>
-                )}
-                <label style={{ display: "flex", alignItems: "center", gap: 8, marginTop: "var(--space-3)", fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
-                  <input
-                    type="checkbox"
-                    checked={userAutoPick}
-                    onChange={(e) => setUserAutoPick(e.target.checked)}
-                  />
-                  Enable Auto-Pick (BPA)
-                </label>
-              </>
-            )}
-          </CardContent>
-          </Card>
+        <style>{`@media (max-width: 900px) { .draft-layout { grid-template-columns: minmax(0, 1fr); } }`}</style>
 
-          {/* Sim button (only when AI is picking) */}
-          {!isDraftComplete && !isUserPick && (
-            <Button
-              className="btn btn-primary"
-              disabled={simming || disabled}
-              onClick={onSimToMyPick}
-              style={{ width: "100%" }}
-            >
-              {simming ? "Simulating…" : "Sim to My Pick"}
-            </Button>
-          )}
+        <DraftLeftPanel
+          isDraftComplete={board.isDraftComplete}
+          isUserPick={board.isUserPick}
+          currentPick={board.currentPick}
+          draftPhase={board.draftPhase}
+          pickClock={board.pickClock}
+          userAutoPick={board.userAutoPick}
+          onAutoPickChange={board.setUserAutoPick}
+          simming={simming}
+          disabled={disabled}
+          onSimToMyPick={onSimToMyPick}
+          actions={actions}
+          showTradeUp={board.showTradeUp}
+          onShowTradeUp={() => board.setShowTradeUp(true)}
+          onHideTradeUp={() => board.setShowTradeUp(false)}
+          upcomingPicks={board.upcomingPicks}
+          completedPicks={board.completedPicks}
+          activeRound={board.activeRound}
+          league={league}
+        />
 
-          {/* Trade for this Pick button (only when AI is picking and we have actions) */}
-          {!isDraftComplete && !isUserPick && actions && (
-            <Button
-              className="btn"
-              onClick={() => setShowTradeUp(true)}
-              disabled={simming || disabled}
-              style={{
-                width: "100%",
-                fontSize: "var(--text-xs)",
-                border: "1px solid var(--accent)",
-                color: "var(--accent)",
-                fontWeight: 700,
-              }}
-            >
-              Trade for Pick #{currentPick?.overall}
-            </Button>
-          )}
-
-          {/* Upcoming order */}
-          {!isDraftComplete && upcomingPicks.length > 0 && (
-            <Card className="card-premium" style={{ padding: 0, overflow: "hidden" }}>
-              <CardHeader style={{ padding: "var(--space-2) var(--space-3)", background: "var(--surface-strong)", borderBottom: "1px solid var(--hairline)" }}>
-                <CardTitle style={{ fontSize: "var(--text-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: "var(--text-muted)" }}>
-                  Pick Order
-                </CardTitle>
-              </CardHeader>
-              <CardContent style={{ padding: 0 }}>
-              <ScrollArea style={{ maxHeight: 320 }}>
-                {upcomingPicks.map((pk, i) => (
-                  <div
-                    key={pk.overall}
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "var(--space-2)",
-                      padding: "var(--space-2) var(--space-3)",
-                      borderBottom: "1px solid var(--hairline)",
-                      background:
-                        i === 0
-                          ? pk.isUser
-                            ? "var(--accent)11"
-                            : "var(--surface-strong)"
-                          : "transparent",
-                      fontWeight: i === 0 ? 700 : 400,
-                    }}
-                  >
-                    <span
-                      style={{
-                        minWidth: 24,
-                        textAlign: "center",
-                        fontSize: "var(--text-xs)",
-                        color: "var(--text-subtle)",
-                      }}
-                    >
-                      {pk.overall}
-                    </span>
-                    <span
-                      style={{
-                        flex: 1,
-                        fontSize: "var(--text-xs)",
-                        color: pk.isUser ? "var(--accent)" : "var(--text)",
-                        fontWeight: pk.isUser ? 700 : 400,
-                      }}
-                    >
-                      {pk.teamAbbr}
-                      {pk.isUser && <span style={{ marginLeft: 4 }}>★</span>}
-                    </span>
-                    <span
-                      style={{
-                        fontSize: "var(--text-xs)",
-                        color: "var(--text-subtle)",
-                      }}
-                    >
-                      R{pk.round}{pk.isCompensatory ? " · COMP" : ""}
-                    </span>
-                  </div>
-                ))}
-              </ScrollArea>
-              </CardContent>
-            </Card>
-          )}
-
-          {/* Recently completed (last 8) */}
-          {completedPicks.length > 0 && (
-            <Card className="card-premium" style={{ padding: 0, overflow: "hidden" }}>
-              <CardHeader style={{ padding: "var(--space-2) var(--space-3)", background: "var(--surface-strong)", borderBottom: "1px solid var(--hairline)" }}>
-                <CardTitle style={{ fontSize: "var(--text-xs)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: "var(--text-muted)" }}>
-                  Recent Picks
-                </CardTitle>
-              </CardHeader>
-              <CardContent style={{ padding: 0 }}>
-              <ScrollArea style={{ maxHeight: 240 }}>
-                {[...completedPicks]
-                  .reverse()
-                  .filter((pk) => Number(pk.round) === Number(activeRound))
-                  .slice(0, 8)
-                  .map((pk) => (
-                    <div
-                      key={pk.overall}
-                      style={{
-                        padding: "var(--space-2) var(--space-3)",
-                        borderBottom: "1px solid var(--hairline)",
-                        fontSize: "var(--text-xs)",
-                      }}
-                    >
-                      <div
-                        style={{ color: "var(--text-muted)", marginBottom: 1 }}
-                      >
-                        #{pk.overall} {pk.teamAbbr}{pk.isCompensatory ? " · COMP" : ""}
-                      </div>
-                      <div style={{ fontWeight: 600, color: "var(--text)" }}>
-                        {pk.playerName}
-                        <span
-                          style={{ marginLeft: 6, color: "var(--text-subtle)" }}
-                        >
-                          {pk.playerPos} · <OvrBadge ovr={pk.playerOvr ?? 0} />
-                        </span>
-                      </div>
-                    </div>
-                  ))}
-              </ScrollArea>
-              </CardContent>
-            </Card>
-          )}
-        </div>
-
-        {/* ── Main Panel: Prospects Table ── */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "var(--space-4)",
-          }}
-        >
-          {/* User pick banner */}
-          {isUserPick && !isDraftComplete && (
-            <div
-              style={{
-                padding: "var(--space-3) var(--space-4)",
-                background: "var(--accent)18",
-                border: "1px solid var(--accent)",
-                borderRadius: "var(--radius-md)",
-                fontWeight: 700,
-                color: "var(--accent)",
-                display: "flex",
-                alignItems: "center",
-                gap: "var(--space-3)",
-              }}
-            >
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-4)" }}>
+          {board.isUserPick && !board.isDraftComplete && (
+            <div style={{ padding: "var(--space-3) var(--space-4)", background: "var(--accent)18", border: "1px solid var(--accent)", borderRadius: "var(--radius-md)", fontWeight: 700, color: "var(--accent)", display: "flex", alignItems: "center", gap: "var(--space-3)" }}>
               <span style={{ fontSize: "1.1rem" }}>★</span>
               <span style={{ flex: 1 }}>
-                You're on the clock! Round {currentPick?.round}, Pick #
-                {currentPick?.overall} — select a prospect below.
+                You're on the clock! Round {board.currentPick?.round}, Pick #{board.currentPick?.overall} — select a prospect below.
               </span>
-              {pendingTradeProposal && (
+              {board.pendingTradeProposal && (
                 <Button
                   className="btn"
-                  onClick={() => setShowTradeDown(true)}
-                  style={{
-                    flexShrink: 0,
-                    fontSize: "var(--text-xs)",
-                    fontWeight: 700,
-                    border: "1px solid var(--warning, #FF9F0A)",
-                    color: "var(--warning, #FF9F0A)",
-                    background: "rgba(255,159,10,0.12)",
-                    padding: "var(--space-1) var(--space-3)",
-                    borderRadius: "var(--radius-sm)",
-                    animation: "pulse 2s infinite",
-                  }}
+                  onClick={() => board.setShowTradeDown(true)}
+                  style={{ flexShrink: 0, fontSize: "var(--text-xs)", fontWeight: 700, border: "1px solid var(--warning, #FF9F0A)", color: "var(--warning, #FF9F0A)", background: "rgba(255,159,10,0.12)", padding: "var(--space-1) var(--space-3)", borderRadius: "var(--radius-sm)", animation: "pulse 2s infinite" }}
                 >
                   Trade Down / View Offers
                 </Button>
               )}
             </div>
           )}
-          {recommendedPick && !isDraftComplete && (
+
+          {board.recommendedPick && !board.isDraftComplete && (
             <div style={{ padding: "var(--space-3)", borderRadius: "var(--radius-md)", background: "rgba(52,199,89,0.12)", border: "1px solid rgba(52,199,89,0.45)", color: "var(--text)" }}>
               <div style={{ fontSize: "var(--text-xs)", textTransform: "uppercase", letterSpacing: 1, color: "var(--success)" }}>Recommended pick</div>
               <div style={{ fontWeight: 700 }}>
-                #{recommendedPick.rank ?? 1} on your board · {sortedProspects.find((p) => String(p.id) === String(recommendedPick.playerId))?.name ?? "Top option"}
+                #{board.recommendedPick.rank ?? 1} on your board · {board.sortedProspects.find((p) => String(p.id) === String(board.recommendedPick.playerId))?.name ?? "Top option"}
               </div>
-              <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>{recommendedPick.reason}</div>
+              <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>{board.recommendedPick.reason}</div>
             </div>
           )}
 
-          {/* AI Trade-Up Proposal popup */}
-          {isUserPick && !isDraftComplete && pendingTradeProposal && showTradeDown && (
-            <div
-              style={{
-                padding: "var(--space-4)",
-                background: "var(--surface-strong)",
-                border: "1px solid var(--warning, #FF9F0A)",
-                borderRadius: "var(--radius-md)",
-                marginBottom: "var(--space-3)",
-              }}
-            >
-              <div
-                style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "center",
-                  marginBottom: "var(--space-3)",
-                }}
-              >
-                <div style={{ fontWeight: 800, color: "var(--text)" }}>
-                  Trade Offer from {pendingTradeProposal.aiTeamAbbr}
-                </div>
-                <Button
-                  className="btn"
-                  onClick={() => setShowTradeDown(false)}
-                  style={{
-                    background: "none",
-                    border: "none",
-                    fontSize: 16,
-                    color: "var(--text-muted)",
-                    cursor: "pointer",
-                    lineHeight: 1,
-                  }}
-                >
-                  ×
-                </Button>
-              </div>
-              <div
-                style={{
-                  fontSize: "var(--text-sm)",
-                  color: "var(--text-muted)",
-                  marginBottom: "var(--space-3)",
-                  lineHeight: 1.5,
-                }}
-              >
-                The <strong style={{ color: "var(--text)" }}>{pendingTradeProposal.aiTeamName}</strong> are
-                offering to trade up for your pick #{pendingTradeProposal.userPickOverall}.
-                They want to draft <strong style={{ color: "var(--text)" }}>
-                  {pendingTradeProposal.targetProspect?.name} ({pendingTradeProposal.targetProspect?.pos},{" "}
-                  {pendingTradeProposal.targetProspect?.ovr} OVR)
-                </strong>.
-              </div>
-              <div
-                style={{
-                  fontSize: "var(--text-sm)",
-                  color: "var(--text)",
-                  marginBottom: "var(--space-3)",
-                  fontWeight: 600,
-                }}
-              >
-                You receive: their pick #{pendingTradeProposal.aiPickOverall} (Round{" "}
-                {pendingTradeProposal.aiPickRound}) + a later pick swap in this draft.
-              </div>
-              <div style={{ display: "flex", gap: "var(--space-3)" }}>
-                <Button
-                  className="btn btn-primary"
-                  disabled={tradeDownProcessing}
-                  onClick={async () => {
-                    setTradeDownProcessing(true);
-                    try {
-                      const res = await actions.acceptDraftTrade(pendingTradeProposal);
-                      if (res?.payload) {
-                        setShowTradeDown(false);
-                        // After trade, sim to next user pick
-                        onSimToMyPick();
-                      }
-                    } catch (e) {
-                      console.error("[Draft] acceptDraftTrade failed:", e);
-                    } finally {
-                      setTradeDownProcessing(false);
-                    }
-                  }}
-                  style={{
-                    fontWeight: 700,
-                    fontSize: "var(--text-sm)",
-                    padding: "var(--space-2) var(--space-4)",
-                  }}
-                >
-                  {tradeDownProcessing ? "Processing…" : "Accept Trade"}
-                </Button>
-                <Button
-                  className="btn"
-                  onClick={async () => {
-                    await actions.rejectDraftTrade?.();
-                    setShowTradeDown(false);
-                  }}
-                  style={{
-                    fontWeight: 600,
-                    fontSize: "var(--text-sm)",
-                    padding: "var(--space-2) var(--space-4)",
-                  }}
-                >
-                  Decline
-                </Button>
-              </div>
-            </div>
-          )}
-
-          {/* Filters */}
-          <div
-            style={{
-              display: "flex",
-              gap: "var(--space-3)",
-              flexWrap: "wrap",
-              alignItems: "center",
-            }}
-          >
-            <Input
-              type="text"
-              placeholder="Search name…"
-              value={nameFilter}
-              onChange={(e) => setNameFilter(e.target.value)}
-              style={{
-                padding: "5px 10px",
-                background: "var(--surface-strong)",
-                border: "1px solid var(--hairline)",
-                borderRadius: "var(--radius-sm)",
-                color: "var(--text)",
-                fontSize: "var(--text-sm)",
-                width: 180,
-              }}
-            />
-            <select
-              value={filterPos}
-              onChange={(e) => setFilterPos(e.target.value)}
-              style={{
-                padding: "5px 10px",
-                background: "var(--surface-strong)",
-                border: "1px solid var(--hairline)",
-                borderRadius: "var(--radius-sm)",
-                color: "var(--text)",
-                fontSize: "var(--text-sm)",
-              }}
-            >
-              <option value="">All Positions</option>
-              {posOptions.map((p) => (
-                <option key={p} value={p}>
-                  {p}
-                </option>
-              ))}
-            </select>
-            <span
-              style={{
-                fontSize: "var(--text-xs)",
-                color: "var(--text-muted)",
-                marginLeft: "auto",
-              }}
-            >
-              {sortedProspects.length} prospect
-              {sortedProspects.length !== 1 ? "s" : ""}
-            </span>
-          </div>
-
-          <div style={{ marginTop: 8, marginBottom: 8 }}>
-            <Button className="btn" onClick={() => setShowAdvancedFilters((v) => !v)} style={{ fontSize: 'var(--text-xs)' }}>
-              {showAdvancedFilters ? 'Hide advanced filters' : 'Show advanced filters'}
-            </Button>
-          </div>
-          {showAdvancedFilters && (
-            <AdvancedPlayerSearch
-              filters={advancedFilters}
-              onChange={setAdvancedFilters}
-              title="Draft advanced search"
-              allowedFields={draftAdvancedFields}
-              presetKeys={["youngHighPotential", "day1Starters", "developmentalUpside", "bestAthletes", "valuePicks", "qbUpside", "skillUpside"]}
+          {board.isUserPick && !board.isDraftComplete && board.pendingTradeProposal && board.showTradeDown && (
+            <DraftTradeDownPanel
+              pendingTradeProposal={board.pendingTradeProposal}
+              processing={board.tradeDownProcessing}
+              onAccept={handleAcceptTradeDown}
+              onDecline={handleDeclineTradeDown}
+              onClose={() => board.setShowTradeDown(false)}
             />
           )}
-          {showComparison && comparePlayerA && comparePlayerB && (
-            <PlayerComparison playerA={comparePlayerA} playerB={comparePlayerB} onClose={() => setShowComparison(false)} />
-          )}
-          <PlayerCompareTray
-            compareIds={compareIds}
-            resolvePlayer={(id) => sortedProspects.find((p) => p.id === id)}
-            onRemove={toggleCompare}
-            onOpenCompare={() => setShowComparison(true)}
-            onClear={() => setCompareIds([])}
+
+          <ProspectFilters
+            nameFilter={board.nameFilter}
+            onNameFilterChange={board.setNameFilter}
+            filterPos={board.filterPos}
+            onFilterPosChange={board.setFilterPos}
+            posOptions={board.posOptions}
+            prospectCount={board.sortedProspects.length}
+            showAdvancedFilters={board.showAdvancedFilters}
+            onToggleAdvancedFilters={() => board.setShowAdvancedFilters((v) => !v)}
+            advancedFilters={board.advancedFilters}
+            onAdvancedFiltersChange={board.setAdvancedFilters}
+            draftAdvancedFields={board.draftAdvancedFields}
+            compareIds={board.compareIds}
+            showComparison={board.showComparison}
+            comparePlayerA={board.comparePlayerA}
+            comparePlayerB={board.comparePlayerB}
+            onCloseComparison={() => board.setShowComparison(false)}
+            onToggleCompare={board.toggleCompare}
+            onOpenCompare={() => board.setShowComparison(true)}
+            onClearCompare={() => board.setCompareIds([])}
+            resolvePlayer={(id) => board.sortedProspects.find((p) => p.id === id)}
           />
 
-          {/* Prospects table */}
           <Card className="card-premium" style={{ padding: 0, overflow: "hidden" }}>
             <CardContent style={{ padding: 0 }}>
-            <div className="table-wrapper" style={{ overflowX: "auto" }}>
-              <Table
-                className="standings-table"
-                style={{ width: "100%", fontSize: "var(--text-sm)" }}
-              >
-                <TableHeader>
-                  <TableRow>
-                    <TableHead
-                      style={{
-                        width: 36,
-                        textAlign: "center",
-                        paddingLeft: "var(--space-3)",
-                      }}
-                    >
-                      #
-                    </TableHead>
-                    {[
-                      { key: "boardRank", label: "BOARD" },
-                      { key: "pos", label: "POS" },
-                      { key: "name", label: "NAME" },
-                      { key: "traits", label: "TRAITS" },
-                      { key: "age", label: "AGE" },
-                      { key: "compare", label: "CMP" },
-                      { key: "ovr", label: isDraftComplete ? "OVR" : "GRADE" },
-                      { key: "potential", label: isDraftComplete ? "POT" : "???" },
-                      { key: "fortyTime", label: "40Y" },
-                      { key: "benchPress", label: "BENCH" },
-                      { key: "college", label: "COLLEGE" },
-                    ].map((col) => (
-                      <TableHead
-                        key={col.key}
-                        onClick={() => toggleSort(col.key)}
-                        style={{
-                          cursor: "pointer",
-                          userSelect: "none",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        {col.label}
-                        <SortIcon active={sortKey === col.key} dir={sortDir} />
-                      </TableHead>
-                    ))}
-                    {isUserPick && !isDraftComplete && (
-                      <TableHead
-                        style={{
-                          textAlign: "right",
-                          paddingRight: "var(--space-4)",
-                        }}
-                      >
-                        ACTION
-                      </TableHead>
-                    )}
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {sortedProspects.length === 0 && (
+              <div className="table-wrapper" style={{ overflowX: "auto" }}>
+                <Table className="standings-table" style={{ width: "100%", fontSize: "var(--text-sm)" }}>
+                  <TableHeader>
                     <TableRow>
-                      <TableCell colSpan={isUserPick ? 12 : 11} style={{ padding: 0 }}>
-                        <EmptyState
-                          icon="🎯"
-                          title={isDraftComplete ? "No prospects remain" : "No prospects match"}
-                          subtitle={isDraftComplete ? "All prospects have been drafted." : "Adjust your filters to broaden the board."}
-                        />
-                      </TableCell>
-                    </TableRow>
-                  )}
-                  {sortedProspects.map((p, i) => (
-                    <TableRow
-                      key={p.id}
-                      style={
-                        String(p.id) === String(recommendedPick?.playerId ?? '')
-                          ? { background: "rgba(52,199,89,0.1)" }
-                          : (topProspectByPos.get(p.pos) === String(p.id)
-                            ? { background: "rgba(10,132,255,0.08)" }
-                            : undefined)
-                      }
-                    >
-                      <TableCell style={{ textAlign: "center", fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
-                        {Math.max(1, manualBoard.indexOf(String(p.id)) + 1)}
-                      </TableCell>
-                      <TableCell
-                        style={{
-                          textAlign: "center",
-                          color: "var(--text-subtle)",
-                          paddingLeft: "var(--space-3)",
-                          fontSize: "var(--text-xs)",
-                          fontWeight: 700,
-                        }}
-                      >
-                        {i + 1}
-                      </TableCell>
-                      <TableCell>
-                        <Badge
-                          variant="outline"
-                          style={{
-                            display: "inline-block",
-                            padding: "1px 6px",
-                            borderRadius: "var(--radius-pill)",
-                            background: `${POS_COLORS[p.pos] ?? "#666"}22`,
-                            fontSize: "var(--text-xs)",
-                            fontWeight: 700,
-                            color: POS_COLORS[p.pos] ?? "var(--text-muted)",
-                            border: `1px solid ${POS_COLORS[p.pos] ?? "#666"}55`,
-                            fontFamily: "var(--font-mono)",
-                          }}
-                        >
-                          {p.pos}
-                        </Badge>
-                      </TableCell>
-                      <TableCell
-                        style={{
-                          fontWeight: 600,
-                          color: onPlayerClick ? "var(--accent)" : "var(--text)",
-                          cursor: onPlayerClick ? "pointer" : "default",
-                        }}
-                        onClick={() => onPlayerClick && onPlayerClick(p.id)}
-                        title={
-                          onPlayerClick ? `View ${p.name}'s profile` : undefined
-                        }
-                      >
-                        <PlayerPreview player={p}>
-                          <span
-                            style={{
-                              textDecoration: onPlayerClick ? "underline" : "none",
-                              textDecorationStyle: "dotted",
-                              textUnderlineOffset: 3,
-                            }}
-                          >
-                            {p.name}
-                          </span>
-                        </PlayerPreview>
-                      </TableCell>
-                      <TableCell style={{ textAlign: "center", whiteSpace: "nowrap" }}>
-                        {(p.traits || []).map((t) => (
-                          <TraitBadge key={t} traitId={t} />
-                        ))}
-                      </TableCell>
-                      <TableCell style={{ color: "var(--text-muted)" }}>{p.age}</TableCell>
-                      <TableCell style={{ textAlign: "center" }}><Button title={compareIds.includes(p.id) ? "Remove from compare" : "Add to compare"} onClick={() => toggleCompare(p)} style={{ width: 22, height: 22, borderRadius: "var(--radius-sm)", border: `1.5px solid ${compareIds.includes(p.id) ? "var(--accent)" : "var(--hairline)"}`, background: compareIds.includes(p.id) ? "var(--accent-muted)" : "transparent", fontSize: 12, color: compareIds.includes(p.id) ? "var(--accent)" : "var(--text-subtle)" }}>{compareIds.includes(p.id) ? "✓" : "⊕"}</Button></TableCell>
-                      <TableCell>
-                        <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 2 }}>
-                          {/* Fog of War: show scout grade before drafted, true OVR after */}
-                          {isDraftComplete ? (
-                            <OvrBadge ovr={p.ovr} />
-                          ) : (
-                            <>
-                              <ScoutBadge player={p} team={(league?.teams ?? []).find((t) => t.id === league?.userTeamId)} />
-                              <ProspectScoutingChips
-                                prospect={p}
-                                team={(league?.teams ?? []).find((t) => t.id === league?.userTeamId)}
-                              />
-                            </>
-                          )}
-                        </div>
-                      </TableCell>
-                      <TableCell
-                        style={{
-                          color: "var(--text-subtle)",
-                          fontSize: "var(--text-xs)",
-                        }}
-                      >
-                        {/* Hide potential until draft is complete */}
-                        {isDraftComplete ? (p.potential ?? "—") : "??"}
-                      </TableCell>
-                      <TableCell style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }} title="40-yard dash (seconds). Lower is better.">
-                        {p?.combineResults?.fortyTime ?? "—"}
-                      </TableCell>
-                      <TableCell style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }} title="Bench press reps at 225 lbs. Higher is better.">
-                        {p?.combineResults?.benchPress ?? "—"}
-                      </TableCell>
-                      <TableCell
-                        style={{
-                          color: "var(--text-muted)",
-                          fontSize: "var(--text-xs)",
-                          maxWidth: 160,
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        {p.college ?? p.origin ?? "—"}
-                      </TableCell>
-                      {isUserPick && !isDraftComplete && (
-                        <TableCell
-                          style={{
-                            textAlign: "right",
-                            paddingRight: "var(--space-3)",
-                          }}
-                        >
-                          <Button
-                            className="btn btn-primary"
-                            disabled={!(draftPhase === DRAFT_ROOM_PHASES.ON_THE_CLOCK && isUserPick) || disabled}
-                            style={{
-                              padding: "3px 12px",
-                              fontSize: "var(--text-xs)",
-                            }}
-                            onClick={() => onDraftPlayer(p.id)}
-                          >
-                            {disabled ? "Drafting…" : "Draft"}
-                          </Button>
-                          <div style={{ display: "inline-flex", marginLeft: 8, gap: 4 }}>
-                            <Button className="btn" title="Move up board" onClick={() => setManualBoard((prev) => {
-                              const next = [...prev];
-                              const idx = next.indexOf(String(p.id));
-                              if (idx > 0) [next[idx - 1], next[idx]] = [next[idx], next[idx - 1]];
-                              return next;
-                            })} style={{ padding: "2px 6px", fontSize: 10 }}>↑</Button>
-                            <Button className="btn" title="Move down board" onClick={() => setManualBoard((prev) => {
-                              const next = [...prev];
-                              const idx = next.indexOf(String(p.id));
-                              if (idx > -1 && idx < next.length - 1) [next[idx + 1], next[idx]] = [next[idx], next[idx + 1]];
-                              return next;
-                            })} style={{ padding: "2px 6px", fontSize: 10 }}>↓</Button>
-                          </div>
-                        </TableCell>
+                      <TableHead style={{ width: 36, textAlign: "center", paddingLeft: "var(--space-3)" }}>#</TableHead>
+                      {allColumns.map((col) => (
+                        <TableHead key={col.key} onClick={() => board.toggleSort(col.key)} style={{ cursor: "pointer", userSelect: "none", whiteSpace: "nowrap" }}>
+                          {col.label}
+                          <SortIcon active={board.sortKey === col.key} dir={board.sortDir} />
+                        </TableHead>
+                      ))}
+                      {board.isUserPick && !board.isDraftComplete && (
+                        <TableHead style={{ textAlign: "right", paddingRight: "var(--space-4)" }}>ACTION</TableHead>
                       )}
                     </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </div>
+                  </TableHeader>
+                  <TableBody>
+                    {board.sortedProspects.length === 0 && (
+                      <TableRow>
+                        <TableCell colSpan={board.isUserPick ? 12 : 11} style={{ padding: 0 }}>
+                          <EmptyState
+                            icon="🎯"
+                            title={board.isDraftComplete ? "No prospects remain" : "No prospects match"}
+                            subtitle={board.isDraftComplete ? "All prospects have been drafted." : "Adjust your filters to broaden the board."}
+                          />
+                        </TableCell>
+                      </TableRow>
+                    )}
+                    {board.sortedProspects.map((p, i) => (
+                      <ProspectRow
+                        key={p.id}
+                        prospect={p}
+                        rank={i + 1}
+                        boardRank={Math.max(1, board.manualBoard.indexOf(String(p.id)) + 1)}
+                        isUserPick={board.isUserPick}
+                        isDraftComplete={board.isDraftComplete}
+                        draftPhase={board.draftPhase}
+                        onDraftPlayer={onDraftPlayer}
+                        onPlayerClick={onPlayerClick}
+                        compareIds={board.compareIds}
+                        onToggleCompare={board.toggleCompare}
+                        onMoveUp={() => board.setManualBoard((prev) => {
+                          const next = [...prev];
+                          const idx = next.indexOf(String(p.id));
+                          if (idx > 0) [next[idx - 1], next[idx]] = [next[idx], next[idx - 1]];
+                          return next;
+                        })}
+                        onMoveDown={() => board.setManualBoard((prev) => {
+                          const next = [...prev];
+                          const idx = next.indexOf(String(p.id));
+                          if (idx > -1 && idx < next.length - 1) [next[idx + 1], next[idx]] = [next[idx], next[idx + 1]];
+                          return next;
+                        })}
+                        disabled={disabled}
+                        userTeam={userTeam}
+                        isRecommended={String(p.id) === String(board.recommendedPick?.playerId ?? "")}
+                        isTopByPos={board.topProspectByPos.get(p.pos) === String(p.id)}
+                      />
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
             </CardContent>
           </Card>
         </div>
       </div>
+
       <Card className="card-premium" style={{ marginTop: "var(--space-4)" }}>
         <CardContent style={{ padding: "var(--space-3)" }}>
           <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap", alignItems: "center" }}>
             <span style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700, marginRight: 6 }}>Round Navigator</span>
             {Array.from({ length: 7 }).map((_, idx) => {
               const round = idx + 1;
-              const userPicksInRound = userPickCountsByRound.get(round) ?? 0;
+              const userPicksInRound = board.userPickCountsByRound.get(round) ?? 0;
               return (
-                <button
-                  key={round}
-                  className="btn"
-                  onClick={() => setActiveRound(round)}
-                  style={{
-                    fontSize: "var(--text-xs)",
-                    padding: "3px 8px",
-                    borderColor: activeRound === round ? "var(--accent)" : "var(--hairline)",
-                    color: activeRound === round ? "var(--accent)" : "var(--text-muted)",
-                  }}
-                >
+                <button key={round} className="btn" onClick={() => board.setActiveRound(round)} style={{ fontSize: "var(--text-xs)", padding: "3px 8px", borderColor: board.activeRound === round ? "var(--accent)" : "var(--hairline)", color: board.activeRound === round ? "var(--accent)" : "var(--text-muted)" }}>
                   R{round}: {userPicksInRound > 0 ? "✓" : "—"} {userPicksInRound} pick{userPicksInRound === 1 ? "" : "s"}
                 </button>
               );
@@ -1533,7 +264,6 @@ function DraftBoard({
   );
 }
 
-// Memoized sortable/filterable prospect list (formerly the inline DraftBoard).
 const ProspectTable = React.memo(DraftBoard);
 export { ProspectTable, DraftBoard };
 export default ProspectTable;

--- a/src/ui/draft/TradeUpModal.jsx
+++ b/src/ui/draft/TradeUpModal.jsx
@@ -1,0 +1,133 @@
+import React, { useState, useEffect } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ovrColor } from "./draftShared.js";
+
+export function TradeUpModal({ currentPick, league, actions, onClose, onTradeComplete }) {
+  const [loading, setLoading] = useState(false);
+  const [myRoster, setMyRoster] = useState([]);
+  const [offering, setOffering] = useState(new Set());
+  const [myPicks, setMyPicks] = useState([]);
+  const [result, setResult] = useState(null);
+
+  const targetTeamId = currentPick?.teamId;
+  const userTeamId = league?.userTeamId;
+
+  useEffect(() => {
+    if (!actions?.getRoster || userTeamId == null) return;
+    (async () => {
+      setLoading(true);
+      try {
+        const res = await actions.getRoster(userTeamId);
+        if (res?.payload) setMyRoster(res.payload.players ?? []);
+      } catch (e) {
+        console.error(e);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [actions, userTeamId]);
+
+  const togglePlayer = (id) => {
+    setOffering((prev) => {
+      const s = new Set(prev);
+      s.has(id) ? s.delete(id) : s.add(id);
+      return s;
+    });
+  };
+
+  const addPick = (round) => {
+    setMyPicks((prev) => [...prev, { id: `up_${round}_${Date.now()}`, round, year: (league?.year ?? 2025) + 1 }]);
+  };
+
+  const removePick = (id) => setMyPicks((prev) => prev.filter((p) => p.id !== id));
+
+  const handlePropose = async () => {
+    if (targetTeamId == null || (offering.size === 0 && myPicks.length === 0)) return;
+    setLoading(true);
+    setResult(null);
+    try {
+      const resp = await actions.submitTrade(
+        userTeamId,
+        targetTeamId,
+        { playerIds: [...offering], pickIds: myPicks.map((p) => p.id) },
+        { playerIds: [], pickIds: [] },
+      );
+      if (resp?.payload) {
+        setResult(resp.payload);
+        if (resp.payload.accepted) {
+          setTimeout(() => { onTradeComplete?.(); onClose(); }, 1500);
+        }
+      }
+    } catch (e) {
+      setResult({ accepted: false, reason: "Error: " + e.message });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const hasSelection = offering.size > 0 || myPicks.length > 0;
+
+  return (
+    <div onClick={onClose} style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0, background: "rgba(0,0,0,0.75)", zIndex: 10000, display: "flex", alignItems: "center", justifyContent: "center", padding: "var(--space-4)" }}>
+      <div onClick={(e) => e.stopPropagation()} style={{ background: "var(--surface)", borderRadius: "var(--radius-lg)", padding: "var(--space-5)", maxWidth: 480, width: "100%", maxHeight: "85vh", overflowY: "auto" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "var(--space-4)" }}>
+          <div>
+            <div style={{ fontWeight: 800, fontSize: "var(--text-lg)", color: "var(--text)" }}>Trade for Pick #{currentPick?.overall}</div>
+            <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>Currently owned by {currentPick?.teamAbbr} · Round {currentPick?.round}</div>
+          </div>
+          <Button className="btn" onClick={onClose} style={{ background: "none", border: "none", color: "var(--text-muted)", fontSize: 20, cursor: "pointer" }}>x</Button>
+        </div>
+
+        {result && (
+          <div style={{ padding: "var(--space-3)", borderRadius: "var(--radius-md)", border: `1px solid ${result.accepted ? "var(--success)" : "var(--danger)"}`, background: result.accepted ? "rgba(52,199,89,0.1)" : "rgba(255,69,58,0.1)", marginBottom: "var(--space-4)", fontWeight: 700, fontSize: "var(--text-sm)", color: result.accepted ? "var(--success)" : "var(--danger)" }}>
+            {result.accepted ? "Trade Accepted! Pick is yours." : `Rejected: ${result.reason}`}
+          </div>
+        )}
+
+        <div style={{ marginBottom: "var(--space-3)" }}>
+          <div style={{ fontSize: "var(--text-xs)", fontWeight: 700, color: "var(--text-muted)", marginBottom: "var(--space-2)", textTransform: "uppercase" }}>Offer Draft Picks</div>
+          <div style={{ display: "flex", gap: "var(--space-2)", flexWrap: "wrap" }}>
+            {[1, 2, 3, 4, 5].map((r) => (
+              <Button key={r} className="btn" style={{ fontSize: "var(--text-xs)", padding: "2px 8px" }} onClick={() => addPick(r)}>+ R{r}</Button>
+            ))}
+          </div>
+          {myPicks.length > 0 && (
+            <div style={{ display: "flex", gap: "var(--space-1)", flexWrap: "wrap", marginTop: "var(--space-2)" }}>
+              {myPicks.map((pk) => (
+                <span key={pk.id} style={{ fontSize: "var(--text-xs)", padding: "1px 6px", borderRadius: "var(--radius-pill)", background: "var(--accent)22", color: "var(--accent)", display: "inline-flex", alignItems: "center", gap: 4 }}>
+                  {pk.year} R{pk.round}{pk.isCompensatory ? " COMP" : ""}
+                  <Button className="btn" onClick={() => removePick(pk.id)} style={{ background: "none", border: "none", color: "inherit", cursor: "pointer", padding: 0, fontSize: 11 }}>x</Button>
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div style={{ marginBottom: "var(--space-3)" }}>
+          <div style={{ fontSize: "var(--text-xs)", fontWeight: 700, color: "var(--text-muted)", marginBottom: "var(--space-2)", textTransform: "uppercase" }}>Offer Players</div>
+          <div style={{ maxHeight: 200, overflowY: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
+            {loading && <div style={{ padding: "var(--space-3)", color: "var(--text-muted)", textAlign: "center", fontSize: "var(--text-sm)" }}>Loading roster...</div>}
+            {myRoster
+              .sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0))
+              .map((p) => (
+                <label key={p.id} style={{ display: "flex", alignItems: "center", gap: "var(--space-2)", padding: "var(--space-1) var(--space-2)", borderBottom: "1px solid var(--hairline)", cursor: "pointer", fontSize: "var(--text-xs)", background: offering.has(p.id) ? "var(--accent)11" : "transparent" }}>
+                  <Input type="checkbox" checked={offering.has(p.id)} onChange={() => togglePlayer(p.id)} style={{ accentColor: "var(--accent)", width: 12, height: 12 }} />
+                  <Badge variant="outline" style={{ padding: "0 3px", borderRadius: "var(--radius-pill)", background: `${ovrColor(p.ovr)}22`, color: ovrColor(p.ovr), fontWeight: 700, fontSize: 10 }}>{p.ovr}</Badge>
+                  <span style={{ fontWeight: 600, color: "var(--text-muted)" }}>{p.pos}</span>
+                  <span style={{ flex: 1, fontWeight: 600, color: "var(--text)" }}>{p.name}</span>
+                </label>
+              ))}
+          </div>
+        </div>
+
+        <Button className="btn btn-primary" onClick={handlePropose} disabled={!hasSelection || loading} style={{ width: "100%", fontWeight: 700 }}>
+          {loading ? "Evaluating..." : "Propose Trade"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default TradeUpModal;

--- a/src/ui/draft/TradeUpModal.test.jsx
+++ b/src/ui/draft/TradeUpModal.test.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { renderToString } from "react-dom/server";
+import { TradeUpModal } from "./TradeUpModal.jsx";
+
+const currentPick = { overall: 12, teamAbbr: "SF", teamId: 2, round: 1 };
+const league = { year: 2025, userTeamId: 1 };
+const actions = { getRoster: vi.fn(async () => ({ payload: { players: [] } })), submitTrade: vi.fn() };
+
+describe("TradeUpModal", () => {
+  it("renders trade modal header without crashing", () => {
+    const html = renderToString(
+      <TradeUpModal currentPick={currentPick} league={league} actions={actions} onClose={() => {}} onTradeComplete={() => {}} />,
+    );
+    // React 18 SSR adds <!-- --> between adjacent text and expression nodes
+    expect(html).toContain("Trade for Pick");
+    expect(html).toContain("SF");
+    expect(html).toContain("Propose Trade");
+    expect(html).toContain("Offer Draft Picks");
+  });
+
+  it("renders round picker buttons R1–R5", () => {
+    const html = renderToString(
+      <TradeUpModal currentPick={currentPick} league={league} actions={actions} onClose={() => {}} />,
+    );
+    expect(html).toContain("+ R");
+    expect(html).toContain("Offer Players");
+  });
+});

--- a/src/ui/draft/useDraftBoard.js
+++ b/src/ui/draft/useDraftBoard.js
@@ -1,0 +1,191 @@
+import { useState, useEffect, useMemo, useCallback } from "react";
+import { applyAdvancedPlayerFilters, allFilters } from "../../core/footballAdvancedFilters";
+import { usePlayerCompare } from "../utils/playerCompare.js";
+import { DRAFT_ROOM_PHASES, buildPickOrder, filterDraftProspectsForView } from "./draftShared.js";
+
+/**
+ * Owns all DraftBoard display state, effects, and derived data.
+ * Extracted from ProspectTable.jsx (DraftBoard) — behavior unchanged.
+ */
+export function useDraftBoard({ draftState, onDraftPlayer, onSimToMyPick, league }) {
+  const [sortKey, setSortKey] = useState("ovr");
+  const [sortDir, setSortDir] = useState(-1);
+  const [filterPos, setFilterPos] = useState("");
+  const [nameFilter, setNameFilter] = useState("");
+  const [advancedFilters, setAdvancedFilters] = useState([]);
+  const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
+  const [showTradeUp, setShowTradeUp] = useState(false);
+  const [showTradeDown, setShowTradeDown] = useState(false);
+  const [tradeDownProcessing, setTradeDownProcessing] = useState(false);
+  const [manualBoard, setManualBoard] = useState([]);
+  const [pickClock, setPickClock] = useState(90);
+  const [userAutoPick, setUserAutoPick] = useState(false);
+  const [draftPhase, setDraftPhase] = useState(DRAFT_ROOM_PHASES.PRE_DRAFT);
+  const [pickFlash, setPickFlash] = useState(null);
+  const [cpuPending, setCpuPending] = useState(false);
+  const [activeRound, setActiveRound] = useState(1);
+
+  const {
+    currentPick,
+    isUserPick,
+    isDraftComplete,
+    prospects = [],
+    completedPicks = [],
+    upcomingPicks = [],
+    pendingTradeProposal = null,
+    recommendedPick = null,
+    userBigBoard = [],
+  } = draftState ?? {};
+
+  useEffect(() => {
+    setManualBoard((userBigBoard ?? []).map((entry) => String(entry.playerId)));
+  }, [userBigBoard]);
+
+  useEffect(() => {
+    setPickClock(90);
+  }, [currentPick?.overall]);
+
+  useEffect(() => {
+    if (currentPick?.round) setActiveRound(currentPick.round);
+  }, [currentPick?.round]);
+
+  useEffect(() => {
+    if (isDraftComplete) { setDraftPhase(DRAFT_ROOM_PHASES.DRAFT_COMPLETE); return; }
+    if (!currentPick) { setDraftPhase(DRAFT_ROOM_PHASES.PRE_DRAFT); return; }
+    if (isUserPick) setDraftPhase(DRAFT_ROOM_PHASES.ON_THE_CLOCK);
+    else setDraftPhase(DRAFT_ROOM_PHASES.CPU_PICKING);
+  }, [currentPick, isUserPick, isDraftComplete]);
+
+  useEffect(() => {
+    if (!completedPicks.length) return;
+    const lastPick = completedPicks[completedPicks.length - 1];
+    if (!lastPick || lastPick.overall === pickFlash?.overall) return;
+    setPickFlash(lastPick);
+    setDraftPhase(DRAFT_ROOM_PHASES.PICK_MADE);
+    const timer = setTimeout(() => {
+      setPickFlash(null);
+      if (isDraftComplete) setDraftPhase(DRAFT_ROOM_PHASES.DRAFT_COMPLETE);
+      else if (isUserPick) setDraftPhase(DRAFT_ROOM_PHASES.ON_THE_CLOCK);
+      else setDraftPhase(DRAFT_ROOM_PHASES.CPU_PICKING);
+    }, 700);
+    return () => clearTimeout(timer);
+  }, [completedPicks, isDraftComplete, isUserPick, pickFlash?.overall]);
+
+  const sortedByOvr = useMemo(
+    () => [...prospects].sort((a, b) => (b?.ovr ?? 0) - (a?.ovr ?? 0)),
+    [prospects],
+  );
+
+  useEffect(() => {
+    if (draftPhase !== DRAFT_ROOM_PHASES.ON_THE_CLOCK || !isUserPick || isDraftComplete) return undefined;
+    if (!userAutoPick) return undefined;
+    const bestProspect = sortedByOvr[0];
+    if (bestProspect) onDraftPlayer(bestProspect.id);
+    return undefined;
+  }, [draftPhase, isUserPick, isDraftComplete, userAutoPick, sortedByOvr, onDraftPlayer]);
+
+  useEffect(() => {
+    if (draftPhase !== DRAFT_ROOM_PHASES.ON_THE_CLOCK || !isUserPick || userAutoPick || isDraftComplete) return undefined;
+    const timer = setInterval(() => {
+      setPickClock((prev) => {
+        if (prev <= 1) {
+          const bestProspect = sortedByOvr[0];
+          if (bestProspect) onDraftPlayer(bestProspect.id);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [draftPhase, isUserPick, isDraftComplete, userAutoPick, sortedByOvr, onDraftPlayer]);
+
+  useEffect(() => {
+    if (draftPhase !== DRAFT_ROOM_PHASES.CPU_PICKING || isUserPick || isDraftComplete || cpuPending) return undefined;
+    setCpuPending(true);
+    const delay = 400 + Math.random() * 800;
+    const timer = setTimeout(async () => {
+      try { await onSimToMyPick(); } finally { setCpuPending(false); }
+    }, delay);
+    return () => { clearTimeout(timer); setCpuPending(false); };
+  }, [draftPhase, isUserPick, isDraftComplete, cpuPending, onSimToMyPick]);
+
+  const toggleSort = useCallback((key) => {
+    if (sortKey === key) setSortDir((d) => -d);
+    else { setSortKey(key); setSortDir(-1); }
+  }, [sortKey]);
+
+  const draftAdvancedFields = useMemo(() => allFilters.filter((field) => {
+    if (field.category === "bio") return !["contractAmount", "contractExp"].includes(field.key);
+    if (field.category === "stats") return ["passing", "rushing", "receiving", "defense"].includes(field.statGroup ?? "");
+    return true;
+  }), []);
+
+  const sortedProspects = useMemo(() => {
+    const filtered = filterDraftProspectsForView(prospects, { filterPos, nameFilter, advancedFilters });
+    const list = [...filtered];
+    list.sort((a, b) => {
+      const av = a[sortKey] ?? 0;
+      const bv = b[sortKey] ?? 0;
+      if (typeof av === "string") return sortDir * av.localeCompare(bv);
+      return sortDir * ((bv ?? 0) - (av ?? 0));
+    });
+    if (sortKey === "boardRank" && manualBoard.length) {
+      const orderMap = new Map(manualBoard.map((id, idx) => [String(id), idx + 1]));
+      list.sort((a, b) => ((orderMap.get(String(a.id)) ?? 999) - (orderMap.get(String(b.id)) ?? 999)) * (sortDir === -1 ? 1 : -1));
+    }
+    return list;
+  }, [prospects, filterPos, nameFilter, sortKey, sortDir, advancedFilters, manualBoard]);
+
+  const { compareIds, setCompareIds, showComparison, setShowComparison, toggleCompare, comparePlayerA, comparePlayerB } = usePlayerCompare(sortedProspects, 2);
+
+  const posOptions = useMemo(() => [...new Set(prospects.map((p) => p.pos))].sort(), [prospects]);
+
+  const pickOrder = useMemo(
+    () => buildPickOrder(league?.teams ?? [], 7, league?.userTeamId),
+    [league?.teams, league?.userTeamId],
+  );
+
+  const topProspectByPos = useMemo(() => {
+    const map = new Map();
+    sortedByOvr.forEach((prospect) => {
+      if (!map.has(prospect.pos)) map.set(prospect.pos, String(prospect.id));
+    });
+    return map;
+  }, [sortedByOvr]);
+
+  const userPickCountsByRound = useMemo(() => {
+    const counts = new Map();
+    completedPicks.forEach((pk) => {
+      if (pk.teamId !== (league?.userTeamId)) return;
+      counts.set(pk.round, (counts.get(pk.round) ?? 0) + 1);
+    });
+    return counts;
+  }, [completedPicks, league?.userTeamId]);
+
+  return {
+    sortKey, setSortKey, sortDir, setSortDir, toggleSort,
+    filterPos, setFilterPos,
+    nameFilter, setNameFilter,
+    advancedFilters, setAdvancedFilters,
+    showAdvancedFilters, setShowAdvancedFilters,
+    showTradeUp, setShowTradeUp,
+    showTradeDown, setShowTradeDown,
+    tradeDownProcessing, setTradeDownProcessing,
+    manualBoard, setManualBoard,
+    pickClock,
+    userAutoPick, setUserAutoPick,
+    draftPhase,
+    pickFlash,
+    activeRound, setActiveRound,
+    currentPick, isUserPick, isDraftComplete,
+    prospects, completedPicks, upcomingPicks,
+    pendingTradeProposal, recommendedPick,
+    sortedByOvr, sortedProspects,
+    compareIds, setCompareIds, showComparison, setShowComparison,
+    toggleCompare, comparePlayerA, comparePlayerB,
+    posOptions, pickOrder, topProspectByPos, userPickCountsByRound,
+    draftAdvancedFields,
+  };
+}
+
+export default useDraftBoard;

--- a/src/ui/draft/useDraftBoard.test.js
+++ b/src/ui/draft/useDraftBoard.test.js
@@ -1,0 +1,81 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDraftBoard } from "./useDraftBoard.js";
+import { DRAFT_ROOM_PHASES } from "./draftShared.js";
+
+vi.mock("../utils/playerCompare.js", () => ({
+  usePlayerCompare: () => ({
+    compareIds: [],
+    setCompareIds: vi.fn(),
+    showComparison: false,
+    setShowComparison: vi.fn(),
+    toggleCompare: vi.fn(),
+    comparePlayerA: null,
+    comparePlayerB: null,
+  }),
+}));
+
+const emptyDraftState = {
+  currentPick: null,
+  isUserPick: false,
+  isDraftComplete: false,
+  prospects: [],
+  completedPicks: [],
+  upcomingPicks: [],
+  pendingTradeProposal: null,
+  recommendedPick: null,
+  userBigBoard: [],
+};
+
+describe("useDraftBoard", () => {
+  it("initializes with PRE_DRAFT phase when no currentPick", () => {
+    const { result } = renderHook(() =>
+      useDraftBoard({
+        draftState: emptyDraftState,
+        onDraftPlayer: vi.fn(),
+        onSimToMyPick: vi.fn(),
+        league: { userTeamId: 1, teams: [] },
+      }),
+    );
+    expect(result.current.draftPhase).toBe(DRAFT_ROOM_PHASES.PRE_DRAFT);
+  });
+
+  it("returns empty sortedProspects when prospects array is empty", () => {
+    const { result } = renderHook(() =>
+      useDraftBoard({
+        draftState: emptyDraftState,
+        onDraftPlayer: vi.fn(),
+        onSimToMyPick: vi.fn(),
+        league: { userTeamId: 1, teams: [] },
+      }),
+    );
+    expect(result.current.sortedProspects).toEqual([]);
+  });
+
+  it("toggleSort flips sortDir when called with the same key twice", () => {
+    const { result } = renderHook(() =>
+      useDraftBoard({
+        draftState: emptyDraftState,
+        onDraftPlayer: vi.fn(),
+        onSimToMyPick: vi.fn(),
+        league: { userTeamId: 1, teams: [] },
+      }),
+    );
+    const initialDir = result.current.sortDir; // -1
+    act(() => { result.current.toggleSort("ovr"); });
+    expect(result.current.sortDir).toBe(-initialDir); // 1
+  });
+
+  it("initializes with DRAFT_COMPLETE phase when isDraftComplete is true", () => {
+    const { result } = renderHook(() =>
+      useDraftBoard({
+        draftState: { ...emptyDraftState, isDraftComplete: true },
+        onDraftPlayer: vi.fn(),
+        onSimToMyPick: vi.fn(),
+        league: { userTeamId: 1, teams: [] },
+      }),
+    );
+    expect(result.current.draftPhase).toBe(DRAFT_ROOM_PHASES.DRAFT_COMPLETE);
+  });
+});


### PR DESCRIPTION
Extract DraftBoard's internal sub-components and state into separate files
under src/ui/draft/. Zero behavior changes; every extracted unit is under
300 lines and gets a co-located smoke-render test.

New components:
- DraftTicker         — last-5-picks horizontal ticker
- DraftWarRoomBanner  — war-room header with position color legend
- DraftLeftPanel      — pick clock card + sim/trade buttons + pick-order panels
- TradeUpModal        — trade-up for a pick modal (state + async logic)
- DraftTradeDownPanel — AI trade-down offer display
- ProspectFilters     — name/pos/advanced filter controls + compare tray
- ProspectRow         — single row in the sortable prospects table

New hook:
- useDraftBoard       — all DraftBoard state, effects, and memos

Also fixes a pre-existing missing Badge import in DraftBadges.jsx.

https://claude.ai/code/session_01LnYvMXAXaoD7qCJg9vs4bK