### PR TITLE
fix: Wave 2 bug bundle — trade dead cap, playoff seeding, save import, Pro Bowl, atomic flush

### DIFF
--- a/src/core/__tests__/awardsProBowl.test.js
+++ b/src/core/__tests__/awardsProBowl.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { selectProBowlers } from '../awards-logic.js';
+
+// conf: 0 = AFC, 1 = NFC
+const teams = [
+  { id: 0, conf: 0, wins: 12 },
+  { id: 1, conf: 0, wins: 4 },
+  { id: 2, conf: 1, wins: 10 },
+];
+
+function qb(playerId, teamId, passYd, passTD) {
+  return { playerId, pos: 'QB', teamId, totals: { gamesPlayed: 17, passYd, passTD, passAtt: 500, passComp: 350 } };
+}
+
+describe('selectProBowlers', () => {
+  it('selects the top players per position per conference', () => {
+    const entries = [
+      qb(100, 0, 5000, 40), // AFC elite — should make it
+      qb(101, 0, 4200, 30), // AFC good
+      qb(102, 0, 3800, 22), // AFC ok
+      qb(103, 2, 4800, 38), // NFC elite (team 2 = NFC) — should make it
+      qb(104, 0, 1200, 5),  // AFC weak — 4th QB, only 3 AFC slots, excluded
+    ];
+    const pb = selectProBowlers(entries, teams, 2026);
+    const ids = pb.map(p => p.playerId);
+
+    expect(ids).toContain(100);
+    expect(ids).toContain(103);
+    // Only 3 QB slots per conference; the weakest AFC QB (104) is cut.
+    expect(ids).not.toContain(104);
+    // Each selection is stamped with conf + year.
+    const afcQb = pb.find(p => p.playerId === 100);
+    expect(afcQb.conf).toBe(0);
+    expect(afcQb.year).toBe(2026);
+    const nfcQb = pb.find(p => p.playerId === 103);
+    expect(nfcQb.conf).toBe(1);
+  });
+
+  it('excludes players below the minimum games threshold', () => {
+    const entries = [
+      { playerId: 200, pos: 'QB', teamId: 0, totals: { gamesPlayed: 1, passYd: 6000, passTD: 50 } },
+    ];
+    const pb = selectProBowlers(entries, teams, 2026);
+    expect(pb.map(p => p.playerId)).not.toContain(200);
+  });
+
+  it('returns an empty list when there are no eligible entries', () => {
+    expect(selectProBowlers([], teams, 2026)).toEqual([]);
+    expect(selectProBowlers(null, teams, 2026)).toEqual([]);
+  });
+});

--- a/src/core/awards-logic.js
+++ b/src/core/awards-logic.js
@@ -426,3 +426,66 @@ export function calculateAwardRaces(allEntries, playerMap, allTeams, currentYear
 
   return { awards, allPro };
 }
+
+// ── Pro Bowl selection ─────────────────────────────────────────────────────────
+
+/**
+ * Roster slots per conference, keyed by normalisePos() group. Roughly mirrors
+ * an NFL Pro Bowl conference roster (multiple selections per position, unlike
+ * the single-team All-Pro list).
+ */
+const PRO_BOWL_SLOTS = {
+  QB: 3, RB: 3, WR: 4, TE: 2, OL: 7,
+  EDGE: 3, DT: 2, LB: 4, CB: 4, S: 3, K: 1, P: 1,
+};
+
+const PRO_BOWL_DEF_GROUPS = new Set(['EDGE', 'DT', 'LB', 'CB', 'S']);
+
+/**
+ * Select the Pro Bowl roster: the top players at each position in each
+ * conference, ranked by the same scoring functions used for the award races.
+ * Pure and deterministic.
+ *
+ * @param entries  Array of enriched stat entries: { playerId, pos, teamId, totals }
+ * @param teams    Array of team objects with { id, conf, wins }
+ * @param year     Numeric season year (stamped onto each selection)
+ * @returns Array<{ playerId, pos, conf, year }>
+ */
+export function selectProBowlers(entries, teams, year) {
+  const teamById = new Map((teams || []).map(t => [t.id, t]));
+
+  const eligible = (entries || [])
+    .filter(e => (e.totals?.gamesPlayed ?? 0) >= MIN_GAMES_AWARD)
+    .map(e => {
+      const team = teamById.get(e.teamId);
+      return {
+        ...e,
+        conf:     team ? normaliseConf(team.conf) : -1,
+        teamWins: team ? (team.wins ?? 0) : 0,
+        group:    normalisePos(e.pos),
+      };
+    })
+    .filter(e => e.conf === CONF_AFC || e.conf === CONF_NFC);
+
+  const scoreFor = (e) => {
+    if (e.group === 'K') return (e.totals?.fgMade ?? 0) * 2 + (e.totals?.fgAttempts ?? 0) * 0.5;
+    if (e.group === 'P') { const t = e.totals ?? {}; return t.punts ? t.puntYards / t.punts : 0; }
+    if (PRO_BOWL_DEF_GROUPS.has(e.group)) return defensiveScore(e);
+    return offensiveScore(e, e.teamWins);
+  };
+
+  const selections = [];
+  for (const conf of [CONF_AFC, CONF_NFC]) {
+    for (const [group, slots] of Object.entries(PRO_BOWL_SLOTS)) {
+      const picks = eligible
+        .filter(e => e.conf === conf && e.group === group)
+        .map(e => ({ e, score: scoreFor(e) }))
+        .sort((a, b) => b.score - a.score)
+        .slice(0, slots);
+      for (const { e } of picks) {
+        selections.push({ playerId: e.playerId, pos: e.pos, conf, year });
+      }
+    }
+  }
+  return selections;
+}

--- a/src/db/__tests__/cacheRestoreDirty.test.js
+++ b/src/db/__tests__/cacheRestoreDirty.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { cache } from '../cache.js';
+
+describe('cache.restoreDirty', () => {
+  beforeEach(() => {
+    cache.reset();
+    cache.hydrate({
+      meta: { id: 'L1', currentSeasonId: 1 },
+      teams: [{ id: 0, wins: 0 }, { id: 1, wins: 0 }],
+      players: [{ id: 10, teamId: 0 }],
+      draftPicks: [],
+    });
+  });
+
+  it('re-marks a drained snapshot as dirty so a failed flush can retry', () => {
+    cache.updateTeam(0, { wins: 1 });
+    cache.updatePlayer(10, { teamId: 1 });
+    expect(cache.isDirty()).toBe(true);
+
+    // Simulate flushDirty's drain (clears flags) followed by a write failure.
+    const snapshot = cache.drainDirty();
+    expect(cache.isDirty()).toBe(false);
+
+    cache.restoreDirty(snapshot);
+    expect(cache.isDirty()).toBe(true);
+
+    // The restored snapshot must still carry the same ids on the next drain.
+    const redrained = cache.drainDirty();
+    expect(redrained.teams).toContain(0);
+    expect(redrained.players).toContain(10);
+  });
+
+  it('preserves the meta dirty flag through a restore', () => {
+    cache.setMeta({ currentWeek: 5 });
+    const snapshot = cache.drainDirty();
+    expect(snapshot.meta).toBe(true);
+    expect(cache.isDirty()).toBe(false);
+
+    cache.restoreDirty(snapshot);
+    expect(cache.isDirty()).toBe(true);
+    expect(cache.drainDirty().meta).toBe(true);
+  });
+
+  it('is a no-op for an empty or invalid snapshot', () => {
+    expect(cache.isDirty()).toBe(false);
+    cache.restoreDirty(null);
+    cache.restoreDirty({});
+    expect(cache.isDirty()).toBe(false);
+  });
+});

--- a/src/db/cache.js
+++ b/src/db/cache.js
@@ -253,6 +253,23 @@ export const cache = {
     return snapshot;
   },
 
+  /**
+   * Re-mark a previously drained snapshot as dirty. Used when a persist attempt
+   * fails after drainDirty() already cleared the flags — without this, the
+   * drained mutations would be silently lost instead of retried on the next
+   * flush. Safe to merge with any mutations accumulated since the drain
+   * (IndexedDB writes are idempotent puts).
+   */
+  restoreDirty(snapshot) {
+    if (!snapshot || typeof snapshot !== 'object') return;
+    if (snapshot.meta) _dirty.meta = true;
+    (snapshot.teams || []).forEach(id => _dirty.teams.add(id));
+    (snapshot.players || []).forEach(id => _dirty.players.add(id));
+    if (Array.isArray(snapshot.games)) _dirty.games.push(...snapshot.games);
+    (snapshot.seasonStats || []).forEach(id => _dirty.seasonStats.add(id));
+    (snapshot.draftPicks || []).forEach(id => _dirty.draftPicks.add(id));
+  },
+
   isDirty() {
     return (
       _dirty.meta ||

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -109,7 +109,7 @@ import {
 import AiLogic from '../core/ai-logic.js';
 import NewsEngine, { createNewsItem, addNewsItem } from '../core/news-engine.js';
 import { parseWeeklyHeadlines } from '../core/history/NewsEngine.ts';
-import { calculateAwardRaces } from '../core/awards-logic.js';
+import { calculateAwardRaces, selectProBowlers } from '../core/awards-logic.js';
 import { Constants } from '../core/constants.js';
 import { processPlayerProgression } from '../core/progression-logic.js';
 import { getDevelopmentRateModifier } from '../core/coaching-philosophy-effects.js';
@@ -1715,40 +1715,56 @@ async function flushDirty(forceFlush = false) {
       return true;
     });
 
-  // Draft picks are handled separately (small volume, own store not in bulkWrite).
-  if (dirty.draftPicks.length > 0) {
-    const toSave = dirty.draftPicks
-      .map(id => cache.getDraftPick(id))
-      .filter(pk => pk && pk.id != null);
-    if (toSave.length) await DraftPicks.saveBulk(toSave);
-  }
-
-  // Update Global Save Metadata if league meta changed
-  if (dirty.meta) {
-    const meta = ensureDynastyMeta(cache.getMeta());
-    const leagueId = getActiveLeagueId();
-    if (leagueId) {
-      const userTeam = cache.getTeam(meta.userTeamId);
-      await Saves.save({
-        id: leagueId,
-        name: meta.name || `League ${leagueId}`,
-        year: meta.year,
-        teamId: meta.userTeamId,
-        teamAbbr: userTeam?.abbr || '???',
-        lastPlayed: Date.now()
-      });
+  // drainDirty() above already cleared the cache's dirty flags. If any write
+  // below throws (e.g. a transient WebKit IDB error), restore the drained
+  // snapshot so the mutations are retried on the next flush instead of being
+  // silently lost. The draft-pick and Saves writes use their own transactions,
+  // so they are part of the same all-or-restore guard as bulkWrite.
+  try {
+    // Draft picks are handled separately (small volume, own store not in bulkWrite).
+    if (dirty.draftPicks.length > 0) {
+      const toSave = dirty.draftPicks
+        .map(id => cache.getDraftPick(id))
+        .filter(pk => pk && pk.id != null);
+      if (toSave.length) await DraftPicks.saveBulk(toSave);
     }
-  }
 
-  // bulkWrite itself also validates before each put — belt-and-suspenders.
-  await bulkWrite({
-    meta:          dirty.meta ? cache.getMeta() : null,
-    teams,
-    players,
-    playerDeletes,
-    games:         validGames,
-    seasonStats,
-  });
+    // Update Global Save Metadata if league meta changed
+    if (dirty.meta) {
+      const meta = ensureDynastyMeta(cache.getMeta());
+      const leagueId = getActiveLeagueId();
+      if (leagueId) {
+        const userTeam = cache.getTeam(meta.userTeamId);
+        await Saves.save({
+          id: leagueId,
+          name: meta.name || `League ${leagueId}`,
+          year: meta.year,
+          teamId: meta.userTeamId,
+          teamAbbr: userTeam?.abbr || '???',
+          lastPlayed: Date.now()
+        });
+      }
+    }
+
+    // bulkWrite itself also validates before each put — belt-and-suspenders.
+    await bulkWrite({
+      meta:          dirty.meta ? cache.getMeta() : null,
+      teams,
+      players,
+      playerDeletes,
+      games:         validGames,
+      seasonStats,
+    });
+  } catch (writeErr) {
+    // `dirty` is the exact set we attempted to write. On the forceFlush path it
+    // already includes pendingBatchDirty, so fold it back into the cache and
+    // clear pendingBatchDirty to avoid double-retaining. On a normal flush,
+    // pendingBatchDirty was NOT part of this attempt — leave it untouched.
+    cache.restoreDirty(dirty);
+    if (forceFlush) pendingBatchDirty = createEmptyDirtySnapshot();
+    console.error('[Worker] flushDirty: persist failed; dirty state restored for retry.', writeErr);
+    throw writeErr;
+  }
 
   // Heartbeat persistence: post a lightweight save manifest to the UI so it
   // can mirror the save index in localStorage. This protects against iOS Safari
@@ -2529,18 +2545,41 @@ function generatePlayoffWeek19() {
   // playoffSeeds[confId] = [{ teamId, seed, conf }, ...]  (index 0 = #1 seed)
   const playoffSeeds = {};
 
+  // Win% with ties counted as half a win, matching the standings view.
+  const winPct = (t) => {
+    const w = t.wins ?? 0, l = t.losses ?? 0, ti = t.ties ?? 0;
+    const g = w + l + ti;
+    return g > 0 ? (w + 0.5 * ti) / g : 0;
+  };
+  // Sort by record, tiebroken by point differential.
+  const byRecord = (a, b) => {
+    const pDiff = winPct(b) - winPct(a);
+    if (Math.abs(pDiff) > 1e-9) return pDiff > 0 ? 1 : -1;
+    const diffA = (a.ptsFor ?? 0) - (a.ptsAgainst ?? 0);
+    const diffB = (b.ptsFor ?? 0) - (b.ptsAgainst ?? 0);
+    return diffB - diffA;
+  };
+
   const rankConf = (confId) => {
-    const ranked = teams
-      .filter(t => t.conf === confId)
-      .sort((a, b) => {
-        const wDiff = (b.wins ?? 0) - (a.wins ?? 0);
-        if (wDiff !== 0) return wDiff;
-        // Tiebreaker: point differential
-        const diffA = (a.ptsFor ?? 0) - (a.ptsAgainst ?? 0);
-        const diffB = (b.ptsFor ?? 0) - (b.ptsAgainst ?? 0);
-        return diffB - diffA;
-      })
-      .slice(0, SEEDS);
+    const confTeams = teams.filter(t => t.conf === confId);
+
+    // NFL rule: every division winner is seeded ahead of every wild card.
+    // Take the best team in each division as that division's champion, rank the
+    // champions among themselves for the top seeds, then fill the remaining
+    // seeds with the best non-division-winners (wild cards).
+    const divisions = [...new Set(confTeams.map(t => t.div))];
+    const divisionWinners = divisions
+      .map(div => confTeams.filter(t => t.div === div).sort(byRecord)[0])
+      .filter(Boolean)
+      .sort(byRecord);
+    const winnerIds = new Set(divisionWinners.map(t => t.id));
+
+    const wildCards = confTeams
+      .filter(t => !winnerIds.has(t.id))
+      .sort(byRecord)
+      .slice(0, Math.max(0, SEEDS - divisionWinners.length));
+
+    const ranked = [...divisionWinners, ...wildCards].slice(0, SEEDS);
 
     // Store seeds so advancePlayoffBracket can look them up later
     playoffSeeds[confId] = ranked.map((t, i) => ({ teamId: t.id, seed: i + 1, conf: confId }));
@@ -5602,22 +5641,21 @@ async function handleImportSave({ data, saveName }, id) {
     await writeLeagueSnapshot(leagueId, snapshot);
     configureActiveLeague(leagueId);
     await openDB();
-    const rawMeta = await Meta.load();
-    const migration = migrateSaveMetaToCurrent(rawMeta ?? {});
-    if (migration.migratedTo !== migration.migratedFrom) {
-      await Meta.save(migration.migrated);
+    // Hydrate the cache through the same proven path LOAD_SAVE uses. The previous
+    // hand-rolled hydrate called methods that don't exist (cache.load,
+    // Seasons.current, Games.byWeek, DraftPicks.bySeason, News.latest) and threw
+    // on every import. loadSave() reads the snapshot we just wrote to the DB.
+    const found = await loadSave();
+    if (!found) {
+      post(toUI.ERROR, { message: 'Imported save contained no league metadata.' }, id);
+      return;
     }
-    const meta = migration.migrated;
-    cache.load({
-      meta,
-      teams: await Teams.loadAll(),
-      players: await Players.loadAll(),
-      season: await Seasons.current(),
-      weekGames: await Games.byWeek(meta?.currentSeasonId, meta?.currentWeek),
-      draftPicks: await DraftPicks.bySeason(meta?.currentSeasonId),
-      news: await News.latest(200),
-      availableCoaches: meta?.availableCoaches ?? [],
-    });
+    // Apply schema migrations in-cache, mirroring the LOAD_SAVE path.
+    const migration = migrateSaveMetaToCurrent(cache.getMeta() ?? {});
+    if (migration.migratedTo !== migration.migratedFrom) {
+      cache.setMeta(migration.migrated);
+    }
+    const meta = ensureDynastyMeta(cache.getMeta());
     repairRosterAndTeamLinks({ reason: 'import-save' });
     for (const team of cache.getAllTeams()) {
       recalculateTeamCap(team.id);
@@ -6173,6 +6211,41 @@ async function resolvePendingFreeAgencyOffers({ resolutionDay = 7, onlyPlayerId 
 
 // ── Handler: RELEASE_PLAYER ───────────────────────────────────────────────────
 
+/**
+ * Accrue dead cap onto a team when it parts with a player who still has
+ * prorated signing-bonus money on the books. Shared by both the release path
+ * and the trade path so the cap accounting stays identical. Post-June-1 splits
+ * the acceleration between the current year and next year; otherwise the full
+ * remaining proration hits the current year. Returns the total dead cap added.
+ */
+function accrueReleaseDeadCap(teamId, contract, meta) {
+  const team = cache.getTeam(teamId);
+  if (!team || !contract) return 0;
+
+  const yearsRemaining = Math.max(contract.years ?? 1, 1);
+  const yearsTotal     = Math.max(contract.yearsTotal ?? yearsRemaining, 1);
+  const totalBonus     = contract.signingBonus ?? 0;
+  const annualBonus    = totalBonus / yearsTotal;
+  if (annualBonus <= 0) return 0;
+
+  const isPostJune1 = Constants.SALARY_CAP.POST_JUNE1_PHASES.includes(meta?.phase);
+
+  if (isPostJune1 && yearsRemaining > 1) {
+    const currentYearDead = annualBonus;
+    const futureYearsDead = annualBonus * (yearsRemaining - 1);
+    if (currentYearDead > 0) cache.updateTeam(teamId, { deadCap: (team.deadCap ?? 0) + currentYearDead });
+    if (futureYearsDead > 0) {
+      const freshTeam = cache.getTeam(teamId);
+      cache.updateTeam(teamId, { deadMoneyNextYear: (freshTeam.deadMoneyNextYear ?? 0) + futureYearsDead });
+    }
+    return currentYearDead + futureYearsDead;
+  }
+
+  const deadMoney = annualBonus * yearsRemaining;
+  if (deadMoney > 0) cache.updateTeam(teamId, { deadCap: (team.deadCap ?? 0) + deadMoney });
+  return deadMoney;
+}
+
 async function releasePlayerWithValidation({ playerId, teamId }) {
   const player = cache.getPlayer(playerId);
   if (!player) return { ok: false, error: 'Player not found' };
@@ -6181,25 +6254,7 @@ async function releasePlayerWithValidation({ playerId, teamId }) {
   const meta = ensureDynastyMeta(cache.getMeta());
   const team = cache.getTeam(teamId);
   if (team && player.contract) {
-    const yearsRemaining = Math.max(player.contract.years ?? 1, 1);
-    const yearsTotal     = Math.max(player.contract.yearsTotal ?? yearsRemaining, 1);
-    const totalBonus     = player.contract.signingBonus ?? 0;
-    const annualBonus    = totalBonus / yearsTotal;
-
-    const isPostJune1 = Constants.SALARY_CAP.POST_JUNE1_PHASES.includes(meta.phase);
-
-    if (isPostJune1 && yearsRemaining > 1) {
-      const currentYearDead = annualBonus;
-      const futureYearsDead = annualBonus * (yearsRemaining - 1);
-      if (currentYearDead > 0) cache.updateTeam(teamId, { deadCap: (team.deadCap ?? 0) + currentYearDead });
-      if (futureYearsDead > 0) {
-        const freshTeam = cache.getTeam(teamId);
-        cache.updateTeam(teamId, { deadMoneyNextYear: (freshTeam.deadMoneyNextYear ?? 0) + futureYearsDead });
-      }
-    } else {
-      const deadMoney = annualBonus * yearsRemaining;
-      if (deadMoney > 0) cache.updateTeam(teamId, { deadCap: (team.deadCap ?? 0) + deadMoney });
-    }
+    accrueReleaseDeadCap(teamId, player.contract, meta);
   }
 
   markOffseasonRelease(player, teamId, meta);
@@ -7341,10 +7396,19 @@ async function handleTradeOffer({ fromTeamId, toTeamId, offering, receiving }, i
 }
 
 async function executeAcceptedTrade({ fromTeamId, toTeamId, offering, receiving }) {
+  // Trading away a player accelerates his remaining signing-bonus proration onto
+  // the team that gives him up (just like a release). The acquiring team picks up
+  // his cap hit via recalculateTeamCap below. Accrue dead cap BEFORE reassigning
+  // the player's team so the charge lands on the correct (giving) side.
+  const tradeMeta = ensureDynastyMeta(cache.getMeta());
   (offering?.playerIds ?? []).forEach(pid => {
+    const player = cache.getPlayer(Number(pid));
+    if (player?.contract) accrueReleaseDeadCap(Number(fromTeamId), player.contract, tradeMeta);
     cache.updatePlayer(Number(pid), { teamId: Number(toTeamId) });
   });
   (receiving?.playerIds ?? []).forEach(pid => {
+    const player = cache.getPlayer(Number(pid));
+    if (player?.contract) accrueReleaseDeadCap(Number(toTeamId), player.contract, tradeMeta);
     cache.updatePlayer(Number(pid), { teamId: Number(fromTeamId) });
   });
   transferPickOwnership(offering?.pickIds ?? [], Number(fromTeamId), Number(toTeamId));
@@ -9637,6 +9701,19 @@ async function archiveSeason(seasonId) {
     }
     if (awards.dpoy?.playerId != null) {
       await grantAccolade(awards.dpoy.playerId, { type: 'DPOY', year, seasonId });
+    }
+
+    // Pro Bowl: top players per position per conference. Previously these
+    // accolades were consumed (HOF/legacy score, player profile counts) but
+    // never produced — no code selected Pro Bowlers. Now we actually grant them.
+    try {
+      const proBowlers = selectProBowlers(populatedStats, teams, year);
+      for (const sel of proBowlers) {
+        await grantAccolade(sel.playerId, { type: 'PRO_BOWL', year, seasonId, pos: sel.pos, conf: sel.conf });
+      }
+      if (proBowlers.length > 0) awards.proBowl = proBowlers;
+    } catch (proBowlErr) {
+      console.error('[Worker] Pro Bowl selection failed:', proBowlErr);
     }
     if (awards.roty?.playerId != null) {
       await grantAccolade(awards.roty.playerId, { type: 'ROTY', year, seasonId });


### PR DESCRIPTION
Five S-complexity defects in one pass:

1. Dead cap on trades — executeAcceptedTrade moved players and recalculated
   cap but never accelerated remaining signing-bonus proration onto the team
   giving a player up, letting you dump any contract for free. Extracted the
   release dead-cap math into a shared accrueReleaseDeadCap() helper and apply
   it on both sides of a trade (and in the release path, de-duplicated).

2. Playoff seeding ignored division winners — rankConf seeded purely by
   record, so a wild card could outseed a division champion. Now every
   division winner is seeded ahead of every wild card (NFL rule), ranked by
   win% (ties as half-wins) then point differential.

3. JSON save import was dead code — handleImportSave called methods that
   don't exist (cache.load, Seasons.current, Games.byWeek, DraftPicks.bySeason,
   News.latest) and threw on every import. Now hydrates through the same proven
   loadSave() path used by LOAD_SAVE, then applies schema migrations in-cache.

4. Pro Bowl was consumed but never produced — PRO_BOWL accolades fed HOF/legacy
   scoring and profile counts but no code ever selected Pro Bowlers. Added a
   pure selectProBowlers() (top players per position per conference) and grant
   the accolades during archiveSeason.

5. Silent save loss on flush failure — flushDirty drained the dirty set before
   the async write, so a transient IDB error dropped that tick's mutations.
   Added cache.restoreDirty() and wrapped the draft-pick/Saves/bulkWrite
   sequence so a failed write restores the drained snapshot for retry.

Tests: full unit suite (2451) green; added cacheRestoreDirty and awardsProBowl
regression tests. Verified the matchupEngine.ts play-by-play engine compiles
and is bundled into both worker chunks (soak prerequisite) before scoping.