### PR TITLE
Wave 4: gameplay depth — draft bands, career retention, ovrHistory, tiebreakers

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -18,6 +18,30 @@ const CONTRACT_DEFAULT = {
 
 const DEV_TRAITS = ['Normal', 'Star', 'Superstar', 'XFactor'];
 
+// Weighted dev-trait roll. Replaces the old flat U.choice (25% each), which made
+// 25% of every draft class a Superstar/X-Factor and flooded the league with
+// elites. The six talent bands collapse onto the four engine dev traits:
+//   X-Factor 2% → XFactor | Superstar 8% → Superstar | Star 20% → Star
+//   Solid 35% + Backup 25% + Bust 10% (70%) → Normal
+function rollDevTrait() {
+  const r = U.random();
+  if (r < 0.02) return 'XFactor';
+  if (r < 0.10) return 'Superstar';
+  if (r < 0.30) return 'Star';
+  return 'Normal';
+}
+
+// Target OVR + potential bands by draft slot (1-based rank within the sorted
+// class). Tiers the class so top picks are genuinely scarce blue-chips and the
+// talent tapers realistically by round, instead of a flat uniform roll.
+function draftTargetForRank(rank) {
+  if (rank <= 5)   return { ovrMin: 78, ovrMax: 85, potMin: 85, potMax: 99 }; // picks 1–5
+  if (rank <= 32)  return { ovrMin: 72, ovrMax: 80, potMin: 78, potMax: 92 }; // picks 6–32
+  if (rank <= 96)  return { ovrMin: 65, ovrMax: 74, potMin: 70, potMax: 85 }; // rounds 2–3
+  if (rank <= 160) return { ovrMin: 58, ovrMax: 68, potMin: 62, potMax: 78 }; // rounds 4–5
+  return { ovrMin: 50, ovrMax: 62, potMin: 55, potMax: 72 };                  // round 6+ / UDFA
+}
+
 // ============================================================================
 // PLAYER PROGRESSION & SKILL TREES
 // ============================================================================
@@ -427,7 +451,7 @@ function makePlayer(pos, age = null, ovr = null, eliteNames = null) {
         morale: U.rand(70, 95),
         negotiationStatus: 'OPEN',
         lockoutWeeks: 0,
-        devTrait: U.choice(DEV_TRAITS),
+        devTrait: rollDevTrait(),
         xp: 0,
         ovrHistory: [],
         potential: playerPotential,
@@ -513,7 +537,11 @@ function generateDraftClass(year, options = {}) {
 
     for (let i = 0; i < classSize; i++) {
         const pos = U.choice(posKeys);
-        const rookie = makePlayer(pos, 21, null, eliteNames); // Rookies are young
+        // Tier target OVR/potential by draft slot so the class isn't a flat roll.
+        const band = draftTargetForRank(i + 1);
+        const targetOvr = U.rand(band.ovrMin, band.ovrMax);
+        const rookie = makePlayer(pos, 21, targetOvr, eliteNames); // Rookies are young
+        rookie.potential = U.clamp(U.rand(band.potMin, band.potMax), rookie.ovr, 99);
         rookie.year = year;
         rookie.draftId = i + 1;
         rookie.age = U.choice([21, 22, 23]);
@@ -527,7 +555,7 @@ function generateDraftClass(year, options = {}) {
         });
         rookie.scoutedOvr = scoutingRange.estimated;
         rookie.scoutingReport = scoutingRange;
-        rookie.devTrait = U.choice(DEV_TRAITS);
+        rookie.devTrait = rollDevTrait();
         rookie.projectedRound = U.clamp(Math.ceil((100 - rookie.scoutedOvr) / 10), 1, 7);
         rookie.combineResults = simulateCombineResults(rookie.pos, rookie.ratings);
         rookie.collegeStats = generateCollegeStats(rookie.pos, rookie.trueOvr, rookie.potential);

--- a/src/core/progression-logic.js
+++ b/src/core/progression-logic.js
@@ -377,6 +377,17 @@ export function processPlayerProgression(players, options = {}) {
 
     player.ovr = ovrAfter;
     player.progressionDelta = progressionDelta;
+
+    // ── Year-over-year OVR history (powers progression charts) ─────────────
+    // Rolling 20-season window; idempotent so re-running a rollover can't double
+    // an entry. season comes from options or the season stamped on the player.
+    const ovrSeason = options?.season ?? player?.season ?? null;
+    const ovrHistory = Array.isArray(player.ovrHistory) ? player.ovrHistory : [];
+    if (!ovrHistory.length || ovrHistory[ovrHistory.length - 1]?.season !== ovrSeason) {
+      ovrHistory.push({ season: ovrSeason, ovr: player.ovr, age });
+    }
+    player.ovrHistory = ovrHistory.slice(-20);
+
     player.developmentContext = {
       baseAgeCurve: age <= 25 ? 'growth' : age <= 29 ? 'prime' : 'decline',
       trainingFocus: org?.trainingFocus ?? 'balanced',

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -76,7 +76,10 @@ const LAST_NAMES = (typeof window !== 'undefined' && window.EXPANDED_LAST_NAMES)
  * Returns an object with common stats initialized to 0.
  * @returns {Object} Zeroed stats object
  */
-function getZeroStats() {
+// Exported as the single source of truth for the full per-season stat schema.
+// Season archival (worker.archiveSeason) reads these keys so no tracked field is
+// silently dropped from career history. Do not prune fields here.
+export function getZeroStats() {
   return {
     // General
     gamesPlayed: 0,

--- a/src/views/standingsView.js
+++ b/src/views/standingsView.js
@@ -35,11 +35,141 @@ function normalizeTeam(team, userTeamId) {
   };
 }
 
-const byRecord = (a, b) => {
-  if (b.winPct !== a.winPct) return b.winPct - a.winPct;
-  if (b.pointDiff !== a.pointDiff) return b.pointDiff - a.pointDiff;
-  return b.ptsFor - a.ptsFor;
-};
+function pctOf(w, l, t) {
+  const g = w + l + t;
+  return g > 0 ? (w + t * 0.5) / g : 0;
+}
+
+// Deterministic, seed-based coin-flip key (no Math.random). Derived from the
+// league seed and team id so the final tiebreak is reproducible across runs.
+function seededCoinKey(seed, teamId) {
+  let h = (Number(seed) || 0) >>> 0;
+  const idStr = String(teamId ?? '');
+  for (let i = 0; i < idStr.length; i += 1) {
+    h ^= idStr.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  h ^= h >>> 15;
+  return (h >>> 0) / 4294967296;
+}
+
+/**
+ * Build the NFL tiebreaker context from played games. Returns per-team:
+ *   h2h           Map<oppId,{w,l,t}>  head-to-head records
+ *   opponents     Map<oppId,{w,l,t}>  record vs each opponent (for common games)
+ *   divRecord     win% within division
+ *   confRecord    win% within conference
+ *   sos           average opponent win%
+ * Falls back to empty context (every step ties) when no game data is present,
+ * which preserves the simple win% ordering for minimal/preseason states.
+ */
+function buildTiebreakContext(teams, schedule) {
+  const teamById = new Map(teams.map((t) => [Number(t.id), t]));
+  const winPctById = new Map(teams.map((t) => [Number(t.id), t.winPct]));
+  const ctx = new Map();
+  for (const t of teams) {
+    ctx.set(Number(t.id), {
+      h2h: new Map(), opponents: new Map(),
+      divW: 0, divL: 0, divT: 0, confW: 0, confL: 0, confT: 0,
+      sos: 0.5,
+    });
+  }
+
+  const readId = (side) => Number(side?.id ?? side);
+  const bump = (rec, key, outcome) => {
+    const cur = rec.get(key) ?? { w: 0, l: 0, t: 0 };
+    cur[outcome] += 1;
+    rec.set(key, cur);
+  };
+
+  for (const week of (schedule?.weeks ?? [])) {
+    for (const game of (week?.games ?? [])) {
+      const homeId = readId(game?.home ?? game?.homeId);
+      const awayId = readId(game?.away ?? game?.awayId);
+      const hs = Number(game?.homeScore ?? game?.scoreHome);
+      const as = Number(game?.awayScore ?? game?.scoreAway);
+      if (!ctx.has(homeId) || !ctx.has(awayId)) continue;
+      if (!Number.isFinite(hs) || !Number.isFinite(as)) continue; // unplayed
+      const home = teamById.get(homeId);
+      const away = teamById.get(awayId);
+      const homeOutcome = hs > as ? 'w' : hs < as ? 'l' : 't';
+      const awayOutcome = hs > as ? 'l' : hs < as ? 'w' : 't';
+      const hctx = ctx.get(homeId);
+      const actx = ctx.get(awayId);
+      bump(hctx.h2h, awayId, homeOutcome);
+      bump(actx.h2h, homeId, awayOutcome);
+      bump(hctx.opponents, awayId, homeOutcome);
+      bump(actx.opponents, homeId, awayOutcome);
+      if (Number(home.conf) === Number(away.conf)) {
+        if (homeOutcome === 'w') hctx.confW++; else if (homeOutcome === 'l') hctx.confL++; else hctx.confT++;
+        if (awayOutcome === 'w') actx.confW++; else if (awayOutcome === 'l') actx.confL++; else actx.confT++;
+        if (Number(home.div) === Number(away.div)) {
+          if (homeOutcome === 'w') hctx.divW++; else if (homeOutcome === 'l') hctx.divL++; else hctx.divT++;
+          if (awayOutcome === 'w') actx.divW++; else if (awayOutcome === 'l') actx.divL++; else actx.divT++;
+        }
+      }
+    }
+  }
+
+  for (const [id, c] of ctx) {
+    const opps = [...c.opponents.keys()];
+    c.sos = opps.length
+      ? opps.reduce((acc, oid) => acc + (winPctById.get(oid) ?? 0.5), 0) / opps.length
+      : 0.5;
+  }
+  return ctx;
+}
+
+// Pairwise NFL tiebreaker comparator. For teams tied on win%, walks the chain:
+// head-to-head → division record → common games (min 4) → conference record →
+// SOS → point diff/points (deterministic fallbacks) → seeded coin-flip.
+// Note: 3+-way ties are resolved pairwise rather than via full mini-leagues — a
+// pragmatic approximation that still honours the documented chain order.
+function makeStandingsComparator(ctx, seed) {
+  return (a, b) => {
+    if (b.winPct !== a.winPct) return b.winPct - a.winPct;
+    const ca = ctx.get(Number(a.id));
+    const cb = ctx.get(Number(b.id));
+    if (ca && cb) {
+      // 1. Head-to-head.
+      const ah = ca.h2h.get(Number(b.id));
+      const bh = cb.h2h.get(Number(a.id));
+      if (ah || bh) {
+        const aPct = pctOf(ah?.w ?? 0, ah?.l ?? 0, ah?.t ?? 0);
+        const bPct = pctOf(bh?.w ?? 0, bh?.l ?? 0, bh?.t ?? 0);
+        if (aPct !== bPct) return bPct - aPct;
+      }
+      // 2. Division record (only meaningful within the same division).
+      if (Number(a.div) === Number(b.div) && Number(a.conf) === Number(b.conf)) {
+        const aDiv = pctOf(ca.divW, ca.divL, ca.divT);
+        const bDiv = pctOf(cb.divW, cb.divL, cb.divT);
+        if (aDiv !== bDiv) return bDiv - aDiv;
+      }
+      // 3. Common games (min 4 shared opponents).
+      const common = [...ca.opponents.keys()].filter((oid) => cb.opponents.has(oid));
+      if (common.length >= 4) {
+        const tally = (c) => common.reduce((acc, oid) => {
+          const r = c.opponents.get(oid) ?? { w: 0, l: 0, t: 0 };
+          acc.w += r.w; acc.l += r.l; acc.t += r.t; return acc;
+        }, { w: 0, l: 0, t: 0 });
+        const at = tally(ca); const bt = tally(cb);
+        const aPct = pctOf(at.w, at.l, at.t);
+        const bPct = pctOf(bt.w, bt.l, bt.t);
+        if (aPct !== bPct) return bPct - aPct;
+      }
+      // 4. Conference record.
+      const aConf = pctOf(ca.confW, ca.confL, ca.confT);
+      const bConf = pctOf(cb.confW, cb.confL, cb.confT);
+      if (aConf !== bConf) return bConf - aConf;
+      // 5. Strength of schedule.
+      if (ca.sos !== cb.sos) return cb.sos - ca.sos;
+    }
+    // Deterministic fallbacks, then a seeded coin-flip.
+    if (b.pointDiff !== a.pointDiff) return b.pointDiff - a.pointDiff;
+    if (b.ptsFor !== a.ptsFor) return b.ptsFor - a.ptsFor;
+    return seededCoinKey(seed, a.id) - seededCoinKey(seed, b.id);
+  };
+}
 
 /**
  * @param {object} state - the raw league state (uses `standings` if present,
@@ -58,6 +188,12 @@ export function prepareStandingsView(state) {
     ? league.standings
     : (Array.isArray(league.teams) ? league.teams : []);
   const teams = source.map((t) => normalizeTeam(t, userTeamId));
+
+  // NFL tiebreaker chain (head-to-head → division → common → conference → SOS →
+  // seeded coin-flip), derived from played games when a schedule is present.
+  const tiebreakCtx = buildTiebreakContext(teams, league.schedule);
+  const seed = Number(league.globalSeed ?? league.seed ?? 0) || 0;
+  const byRecord = makeStandingsComparator(tiebreakCtx, seed);
 
   // Group into divisions keyed by conf|div.
   const divMap = new Map();

--- a/src/worker/modding/ruleEngine.js
+++ b/src/worker/modding/ruleEngine.js
@@ -1,11 +1,71 @@
-export function buildDraftOrder(teams = [], settings = {}, championTeamId = null, rng = Math.random) {
+// Win% helper (ties count as half a win).
+function teamWinPct(team) {
+  const w = Number(team?.wins ?? 0);
+  const l = Number(team?.losses ?? 0);
+  const t = Number(team?.ties ?? 0);
+  const g = w + l + t;
+  return g > 0 ? (w + t * 0.5) / g : 0.5;
+}
+
+/**
+ * Strength of Schedule: each team's average opponent win%, derived from the
+ * regular-season schedule. Opponents are read from schedule.weeks[].games[]
+ * (home/away may be ids or {id} objects). Teams with no resolved opponents
+ * default to 0.5 (neutral).
+ * @returns {Map<number, number>} teamId → average opponent win%
+ */
+export function computeStrengthOfSchedule(teams = [], schedule = null) {
+  const winPctById = new Map();
+  for (const t of teams) winPctById.set(Number(t?.id), teamWinPct(t));
+
+  const opponents = new Map();
+  for (const t of teams) opponents.set(Number(t?.id), []);
+
+  const readId = (side) => Number(side?.id ?? side);
+  for (const week of (schedule?.weeks ?? [])) {
+    for (const game of (week?.games ?? [])) {
+      const homeId = readId(game?.home ?? game?.homeId);
+      const awayId = readId(game?.away ?? game?.awayId);
+      if (!Number.isFinite(homeId) || !Number.isFinite(awayId)) continue;
+      if (opponents.has(homeId)) opponents.get(homeId).push(awayId);
+      if (opponents.has(awayId)) opponents.get(awayId).push(homeId);
+    }
+  }
+
+  const sos = new Map();
+  for (const [id, opps] of opponents) {
+    if (!opps.length) { sos.set(id, 0.5); continue; }
+    const avg = opps.reduce((acc, oppId) => acc + (winPctById.get(oppId) ?? 0.5), 0) / opps.length;
+    sos.set(id, avg);
+  }
+  return sos;
+}
+
+export function buildDraftOrder(teams = [], settings = {}, championTeamId = null, rng = Math.random, opts = {}) {
   const method = String(settings?.draftOrderLogic ?? 'reverse_standings');
+
+  // Strength of Schedule replaces point differential as the tiebreaker so that
+  // tanking (losing by 1 vs 30) no longer manipulates draft position. SoS is
+  // computed from the schedule when supplied (or passed in precomputed).
+  const sos = opts?.sosByTeamId instanceof Map
+    ? opts.sosByTeamId
+    : (opts?.schedule ? computeStrengthOfSchedule(teams, opts.schedule) : null);
+  const sosFor = (team) => (sos ? (sos.get(Number(team?.id)) ?? 0.5) : 0);
+
+  // Seeded, deterministic coin-flip key per team (assigned in id order so the
+  // sequence is independent of input ordering). Used only when wins AND SoS tie.
+  const coinFlip = new Map();
+  for (const t of [...teams].sort((a, b) => Number(a?.id ?? 0) - Number(b?.id ?? 0))) {
+    coinFlip.set(Number(t?.id), rng());
+  }
+
   const sorted = [...teams].sort((a, b) => {
     const wDiff = Number(a?.wins ?? 0) - Number(b?.wins ?? 0);
     if (wDiff !== 0) return wDiff;
-    const diffA = Number(a?.ptsFor ?? 0) - Number(a?.ptsAgainst ?? 0);
-    const diffB = Number(b?.ptsFor ?? 0) - Number(b?.ptsAgainst ?? 0);
-    return diffA - diffB;
+    // Weaker schedule (lower SoS) drafts earlier.
+    const sosDiff = sosFor(a) - sosFor(b);
+    if (Math.abs(sosDiff) > 1e-9) return sosDiff;
+    return (coinFlip.get(Number(a?.id)) ?? 0) - (coinFlip.get(Number(b?.id)) ?? 0);
   });
 
   if (method === 'random') {

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -112,6 +112,7 @@ import { parseWeeklyHeadlines } from '../core/history/NewsEngine.ts';
 import { calculateAwardRaces, selectProBowlers } from '../core/awards-logic.js';
 import { Constants } from '../core/constants.js';
 import { processPlayerProgression } from '../core/progression-logic.js';
+import { getZeroStats as getZeroSeasonStatsSchema } from '../core/state.js';
 import { getDevelopmentRateModifier } from '../core/coaching-philosophy-effects.js';
 import { processOffseasonEvolution, processWeeklyEvolution } from '../core/progression/evolutionEngine.ts';
 import { buildTeamDevelopmentFocusMap as buildCanonicalDevelopmentFocusMap } from './developmentFocus.js';
@@ -8463,7 +8464,9 @@ async function handleStartDraft(payload, id) {
   });
 
   const champId  = meta.championTeamId ?? null;
-  const draftOrder = buildDraftOrder(teams, settings, champId);
+  // Seeded RNG (mulberry32) + schedule so the SoS tiebreaker and any coin-flip
+  // are reproducible from the save seed rather than Math.random.
+  const draftOrder = buildDraftOrder(teams, settings, champId, Utils.random, { schedule: meta?.schedule });
 
   // Build full pick table
   const compPicksByRound = {};
@@ -9306,8 +9309,20 @@ async function handleAdvanceOffseason(payload, id) {
   const wallHits = [...evolvedLeaders.wallHits, ...legacyProgression.wallHits];
 
   // Flush progression mutations (ratings, ovr, progressionDelta, potential)
+  // and append the year-over-year ovrHistory snapshot. Legacy players already
+  // had the entry pushed by processPlayerProgression; attributesV2 players get
+  // it here. Idempotent on season so it never double-writes. Runs before aging,
+  // so player.age is the age during the season just completed.
+  const ovrHistorySeason = Number(meta?.year ?? 2025);
   for (const player of allPlayers) {
     if (player.status === 'draft_eligible' || player.status === 'retired') continue;
+    const existingOvrHistory = Array.isArray(player.ovrHistory) ? player.ovrHistory : [];
+    const hasSeasonEntry = existingOvrHistory.length > 0
+      && existingOvrHistory[existingOvrHistory.length - 1]?.season === ovrHistorySeason;
+    const ovrHistory = hasSeasonEntry
+      ? existingOvrHistory
+      : [...existingOvrHistory, { season: ovrHistorySeason, ovr: player.ovr, age: player.age }].slice(-20);
+    player.ovrHistory = ovrHistory;
     cache.updatePlayer(player.id, {
       ratings:          player.ratings,
       ovr:              player.ovr,
@@ -9316,6 +9331,7 @@ async function handleAdvanceOffseason(payload, id) {
       developmentContext: player.developmentContext ?? null,
       personalityProfile: player.personalityProfile ?? ensurePersonalityProfile(player),
       developmentHistory: player.developmentHistory ?? [],
+      ovrHistory,
     });
   }
 
@@ -9636,9 +9652,19 @@ async function archiveSeason(seasonId) {
         || (['DL', 'DE', 'DT', 'EDGE', 'LB', 'CB', 'S', 'SS', 'FS'].includes(posForDef)
           ? Number(totals.interceptions ?? 0)
           : 0);
+      // Archive EVERY tracked per-season field (full getZeroStats schema) so HOF
+      // scoring, career records and historical views never silently lose data.
+      // Legacy display aliases (passYds/passTDs/…) are layered on top so existing
+      // career/HOF consumers keep working.
+      const fullSeasonStats = {};
+      for (const key of Object.keys(getZeroSeasonStatsSchema())) {
+        fullSeasonStats[key] = Number(totals[key] ?? 0);
+      }
       const line = {
         season:      seasonId,
         team:        teamAbbrMap[s.teamId] ?? (s.teamId != null ? String(s.teamId) : 'FA'),
+        ...fullSeasonStats,
+        // Legacy display aliases (kept for backward compatibility):
         gamesPlayed: totals.gamesPlayed ?? 0,
         passYds:     totals.passYd      ?? 0,
         passTDs:     totals.passTD      ?? 0,

--- a/tests/unit/ovrHistory.test.js
+++ b/tests/unit/ovrHistory.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Utils } from '../../src/core/utils.js';
+import { makePlayer } from '../../src/core/player.js';
+import { processPlayerProgression } from '../../src/core/progression-logic.js';
+
+// Wave 4 Fix 3: player.ovrHistory must be written at each season rollover,
+// capped at a rolling 20-entry window.
+
+describe('player.ovrHistory write at rollover', () => {
+  beforeEach(() => Utils.setSeed(123));
+
+  function freshPlayer() {
+    const p = makePlayer('QB', 24, 75);
+    p.teamId = 0;
+    p.status = 'active';
+    return p;
+  }
+
+  it('appends an {season, ovr, age} entry on progression', () => {
+    const p = freshPlayer();
+    expect(p.ovrHistory).toEqual([]);
+    processPlayerProgression([p], { season: 2026 });
+    expect(p.ovrHistory).toHaveLength(1);
+    expect(p.ovrHistory[0]).toMatchObject({ season: 2026, age: 24 });
+    expect(typeof p.ovrHistory[0].ovr).toBe('number');
+    expect(p.ovrHistory[0].ovr).toBe(p.ovr);
+  });
+
+  it('is idempotent for the same season', () => {
+    const p = freshPlayer();
+    processPlayerProgression([p], { season: 2026 });
+    processPlayerProgression([p], { season: 2026 });
+    expect(p.ovrHistory).toHaveLength(1);
+  });
+
+  it('accumulates one entry per distinct season', () => {
+    const p = freshPlayer();
+    for (let yr = 2026; yr <= 2030; yr++) processPlayerProgression([p], { season: yr });
+    expect(p.ovrHistory.map((h) => h.season)).toEqual([2026, 2027, 2028, 2029, 2030]);
+  });
+
+  it('caps the rolling window at 20 entries', () => {
+    const p = freshPlayer();
+    for (let yr = 2000; yr < 2030; yr++) processPlayerProgression([p], { season: yr });
+    expect(p.ovrHistory).toHaveLength(20);
+    expect(p.ovrHistory[0].season).toBe(2010); // oldest 10 dropped
+    expect(p.ovrHistory[19].season).toBe(2029);
+  });
+});

--- a/tests/unit/sosTiebreaker.test.js
+++ b/tests/unit/sosTiebreaker.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { buildDraftOrder, computeStrengthOfSchedule } from '../../src/worker/modding/ruleEngine.js';
+import { getZeroStats } from '../../src/core/state.js';
+
+// Wave 4 Fix 4: draft-order tiebreaker uses Strength of Schedule (not point
+// differential), with a seeded coin-flip fallback.
+
+const teams = [
+  { id: 0, wins: 2, losses: 15, ptsFor: 200, ptsAgainst: 480 }, // weak team, tough schedule
+  { id: 1, wins: 2, losses: 15, ptsFor: 320, ptsAgainst: 360 }, // weak team, soft schedule
+  { id: 2, wins: 14, losses: 3 },
+  { id: 3, wins: 13, losses: 4 },
+];
+
+// Team 0 plays the strong teams (2 & 3); team 1 plays nobody strong (each other / 0).
+const schedule = {
+  weeks: [
+    { games: [{ home: 0, away: 2 }, { home: 1, away: 3 }] },
+    { games: [{ home: 0, away: 3 }, { home: 1, away: 0 }] },
+    { games: [{ home: 2, away: 0 }, { home: 3, away: 1 }] },
+  ],
+};
+
+describe('SOS draft tiebreaker', () => {
+  it('computes average opponent win% per team', () => {
+    const sos = computeStrengthOfSchedule(teams, schedule);
+    // Team 0 faced 2 (.82) and 3 (.76) repeatedly → high SOS; team 1 faced weak/0 → lower.
+    expect(sos.get(0)).toBeGreaterThan(sos.get(1));
+  });
+
+  it('breaks a win-tie by SOS so the softer schedule drafts earlier', () => {
+    const order = buildDraftOrder(teams, { draftOrderLogic: 'reverse_standings' }, null, () => 0.5, { schedule });
+    // Teams 0 and 1 both have 2 wins; team 1 (softer schedule, lower SOS) picks first.
+    expect(order.indexOf(1)).toBeLessThan(order.indexOf(0));
+  });
+
+  it('ignores point differential as a tiebreaker (anti-tank)', () => {
+    // Team 0 has a far worse point diff but a TOUGHER schedule: it must NOT pick
+    // ahead of team 1 just for losing by more.
+    const order = buildDraftOrder(teams, { draftOrderLogic: 'reverse_standings' }, null, () => 0.5, { schedule });
+    expect(order[0]).toBe(1);
+  });
+
+  it('falls back to a seeded coin-flip when wins and SOS tie', () => {
+    const tied = [{ id: 5, wins: 4, losses: 13 }, { id: 6, wins: 4, losses: 13 }];
+    // rng assigns keys in id order: id5 → 0.9, id6 → 0.1 ⇒ id6 (lower key) drafts first.
+    const seq = [0.9, 0.1];
+    let i = 0;
+    const order = buildDraftOrder(tied, { draftOrderLogic: 'reverse_standings' }, null, () => seq[i++]);
+    expect(order).toEqual([6, 5]);
+  });
+});
+
+describe('career stat schema (Fix 2 source of truth)', () => {
+  it('exposes the full per-season schema with fields the old archive dropped', () => {
+    const schema = getZeroStats();
+    // Fields that the old ~16-field career line silently dropped:
+    for (const key of ['yardsAfterCatch', 'pressures', 'passesDefended', 'tacklesForLoss', 'longestPass', 'puntYards']) {
+      expect(schema).toHaveProperty(key);
+    }
+    expect(Object.keys(schema).length).toBeGreaterThan(40);
+  });
+});

--- a/tests/unit/standingsTiebreaker.test.js
+++ b/tests/unit/standingsTiebreaker.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { prepareStandingsView } from '../../src/views/standingsView.js';
+
+// Wave 4 Fix 5: standings apply the NFL tiebreaker chain (head-to-head,
+// division record, common games, conference record, SOS, seeded coin-flip).
+
+describe('standings NFL tiebreaker chain', () => {
+  it('still orders strictly by win% when records differ', () => {
+    const league = {
+      teams: [
+        { id: 1, abbr: 'A', conf: 0, div: 0, wins: 12, losses: 5 },
+        { id: 2, abbr: 'B', conf: 0, div: 0, wins: 8, losses: 9 },
+      ],
+    };
+    const v = prepareStandingsView(league);
+    expect(v.divisions[0].teams[0].abbr).toBe('A');
+  });
+
+  it('breaks an equal record by head-to-head result', () => {
+    const league = {
+      globalSeed: 42,
+      teams: [
+        { id: 1, abbr: 'A', conf: 0, div: 0, wins: 10, losses: 7 },
+        { id: 2, abbr: 'B', conf: 0, div: 0, wins: 10, losses: 7 },
+      ],
+      // A beat B in both head-to-head meetings.
+      schedule: {
+        weeks: [
+          { games: [{ home: 1, away: 2, homeScore: 24, awayScore: 17 }] },
+          { games: [{ home: 2, away: 1, homeScore: 13, awayScore: 20 }] },
+        ],
+      },
+    };
+    const div = prepareStandingsView(league).divisions[0];
+    expect(div.teams.map((t) => t.abbr)).toEqual(['A', 'B']);
+  });
+
+  it('falls back to division record when head-to-head is split', () => {
+    const league = {
+      globalSeed: 7,
+      teams: [
+        { id: 1, abbr: 'A', conf: 0, div: 0, wins: 10, losses: 7 },
+        { id: 2, abbr: 'B', conf: 0, div: 0, wins: 10, losses: 7 },
+        { id: 3, abbr: 'C', conf: 0, div: 0, wins: 4, losses: 13 },
+      ],
+      schedule: {
+        weeks: [
+          // Head-to-head split 1-1.
+          { games: [{ home: 1, away: 2, homeScore: 21, awayScore: 14 }] },
+          { games: [{ home: 2, away: 1, homeScore: 21, awayScore: 14 }] },
+          // A sweeps division rival C; B loses to C → A has better division record.
+          { games: [{ home: 1, away: 3, homeScore: 30, awayScore: 10 }] },
+          { games: [{ home: 3, away: 2, homeScore: 24, awayScore: 20 }] },
+        ],
+      },
+    };
+    const div = prepareStandingsView(league).divisions[0];
+    const [first, second] = div.teams.filter((t) => t.abbr !== 'C').map((t) => t.abbr);
+    expect([first, second]).toEqual(['A', 'B']);
+  });
+
+  it('is deterministic (seeded coin-flip) when everything ties', () => {
+    const make = () => prepareStandingsView({
+      globalSeed: 99,
+      teams: [
+        { id: 1, abbr: 'A', conf: 0, div: 0, wins: 8, losses: 9 },
+        { id: 2, abbr: 'B', conf: 0, div: 0, wins: 8, losses: 9 },
+      ],
+    });
+    expect(make().divisions[0].teams.map((t) => t.id))
+      .toEqual(make().divisions[0].teams.map((t) => t.id));
+  });
+});

--- a/tests/unit/tieredDraft.test.js
+++ b/tests/unit/tieredDraft.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Utils } from '../../src/core/utils.js';
+import { generateDraftClass } from '../../src/core/player.js';
+
+// Wave 4 Fix 1: draft classes must use weighted dev-trait bands (not 25% each)
+// and tier target OVR/potential by draft slot.
+
+describe('tiered draft talent distribution', () => {
+  beforeEach(() => Utils.setSeed(20260605));
+
+  it('weights dev traits toward the bottom of the talent pyramid', () => {
+    const draft = generateDraftClass(2026, { classSize: 2000 });
+    const counts = { Normal: 0, Star: 0, Superstar: 0, XFactor: 0 };
+    for (const p of draft) counts[p.devTrait] = (counts[p.devTrait] ?? 0) + 1;
+    const pct = (k) => counts[k] / draft.length;
+
+    // Elite traits must be rare; Normal must dominate. (Old flat roll = 25% each.)
+    expect(pct('XFactor')).toBeLessThan(0.05);
+    expect(pct('Superstar')).toBeLessThan(0.14);
+    expect(pct('Star')).toBeGreaterThan(0.12);
+    expect(pct('Star')).toBeLessThan(0.28);
+    expect(pct('Normal')).toBeGreaterThan(0.6);
+    // Sanity: not the old uniform distribution.
+    expect(pct('XFactor')).toBeLessThan(pct('Normal'));
+  });
+
+  it('tiers OVR and potential by draft position', () => {
+    const draft = generateDraftClass(2026, { classSize: 250 });
+    // Class is sorted best-first.
+    const top5 = draft.slice(0, 5);
+    const late = draft.slice(150, 200);
+
+    const avg = (arr, key) => arr.reduce((s, p) => s + p[key], 0) / arr.length;
+    expect(avg(top5, 'ovr')).toBeGreaterThan(avg(late, 'ovr') + 10);
+    // Blue-chip picks carry real ceilings.
+    expect(avg(top5, 'potential')).toBeGreaterThan(82);
+    // Potential never below current OVR.
+    expect(draft.every((p) => p.potential >= p.ovr)).toBe(true);
+  });
+});


### PR DESCRIPTION
Five independent gameplay-depth fixes (no engine-flip dependency):

1. Draft talent bands (player.js): replace the flat uniform dev-trait roll
   (25% each → 25% of every class a Superstar/X-Factor) with weighted bands
   (X-Factor 2%, Superstar 8%, Star 20%, Normal 70%) and tier target OVR /
   potential by draft slot (picks 1–5: 78–85/85–99 … round 6+: 50–62/55–72).

2. Career stat retention (worker.js archiveSeason): archive the FULL per-season
   schema (every getZeroStats field) instead of ~16 cherry-picked fields, so HOF
   scoring, career records and historical views stop silently degrading. Legacy
   display aliases are kept for existing consumers. getZeroStats is now exported
   from state.js as the single source of truth (schema unchanged).

3. player.ovrHistory (progression-logic.js + worker.js): write
   {season, ovr, age} at each season rollover, rolling 20-entry cap, idempotent
   per season. Covered for both legacy and attributesV2 players.

4. SOS draft tiebreaker (ruleEngine.js): replace point-differential — which made
   tanking deterministic — with Strength of Schedule (average opponent win%),
   computed from the schedule, falling back to a seeded coin-flip. Worker passes
   the seeded mulberry32 RNG + schedule.

5. Standings tiebreaker chain (standingsView.js): implement the NFL chain —
   head-to-head, division record, common games (min 4), conference record, SOS,
   then a seeded coin-flip — derived from played games, with a graceful win%
   fallback when no schedule is present.

Regression tests added for tiered draft distribution, ovrHistory writes, the SOS
tiebreaker (incl. anti-tank + coin-flip), career schema breadth, and the
standings chain. Full suite: 2557 passing.

https://claude.ai/code/session_013ZdGknsbHvrjYyyPdErA3X