### PR TITLE
Wave 3: engine flip — rebalance matchup engine, soak gate, late-game + drive summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "test:unit": "vitest run",
     "test:soak": "vitest run tests/unit/dynastySoakAudit.test.js tests/unit/dynastySoakCli.test.js tests/unit/dynastySoakRunner.test.js tests/unit/dynastySoakPersistence.test.js tests/unit/dynastySoakMergeAudit.test.js tests/integration/dynastySoak.test.js tests/unit/dynastySoakFinancialInvariants.test.js",
     "audit:dynasty": "tsx scripts/dynasty-soak.mjs",
+    "audit:engine-soak": "tsx scripts/engineSoak.js",
+    "check:sim-types": "tsc -p tsconfig.sim.json",
     "test:e2e": "playwright test",
     "check:netlify-parity": "bash scripts/netlify-parity-check.sh",
     "check:netlify-cli-build": "npx --yes netlify-cli@latest build --context production --offline",

--- a/scripts/engineSoak.js
+++ b/scripts/engineSoak.js
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+/**
+ * Engine Soak Test — Wave 3 gate for flipping `useNewSimulationEngine`.
+ *
+ * Simulates many full seasons with BOTH simulation engines and compares them on
+ * five checks. The new matchup/play-by-play engine (richGameSimulator) must pass
+ * ALL five checks before the default is flipped in leagueSettings.js.
+ *
+ * Engines:
+ *   - legacy  ("Bernoulli")  : src/core/simulation/index.js  → simGameStats()
+ *   - matchup ("PBP")        : src/core/sim/richGameSimulator.ts → simulateRichGame()
+ *
+ * Both engines consume the SAME generated rosters, so the comparison is fair.
+ *
+ * Checks (applied to the matchup engine as the flip gate):
+ *   1. Win distribution : top-quartile teams (by roster OVR) win ~68–73% of games
+ *   2. Stat realism     : pass yds/game 220–280, rush yds/game 100–130, pts/game 20–27
+ *   3. Score variance   : std-dev of final team scores reported (PBP should be >= legacy)
+ *   4. Performance      : wall-clock ms per game
+ *   5. Crash/error rate : zero throws across the whole run
+ *
+ * Usage:  npx tsx scripts/engineSoak.js [--seasons=100] [--teams=32] [--seed=20260605] [--json]
+ *
+ * Exit code 0 = matchup engine passed all checks (safe to flip); 1 = failed.
+ */
+
+import { Utils } from '../src/core/utils.js';
+import { Constants } from '../src/core/constants.js';
+import { makePlayer } from '../src/core/player.js';
+import { makeLeague } from '../src/core/league.js';
+import { simGameStats } from '../src/core/simulation/index.js';
+import { simulateRichGame } from '../src/core/sim/richGameSimulator.ts';
+import { aggregateTeamUnitsFromRoster, buildDeterministicSeed } from '../src/core/sim/weekSimulationBridge.ts';
+
+// ── thresholds (from Wave 3 spec) ────────────────────────────────────────────
+export const SOAK_THRESHOLDS = Object.freeze({
+  topQuartileWinPct: { min: 0.68, max: 0.73 },
+  passYdsPerGame: { min: 220, max: 280 },
+  rushYdsPerGame: { min: 100, max: 130 },
+  pointsPerGame: { min: 20, max: 27 },
+  maxMsPerGame: 50, // generous upper bound for a headless single-game sim
+});
+
+function parseArgs(argv) {
+  const out = { seasons: 100, teams: 32, seed: 20260605, json: false };
+  for (const arg of argv.slice(2)) {
+    const m = /^--([^=]+)=(.*)$/.exec(arg);
+    if (m) {
+      const [, k, v] = m;
+      if (k === 'seasons') out.seasons = Math.max(1, parseInt(v, 10) || out.seasons);
+      else if (k === 'teams') out.teams = Math.max(4, parseInt(v, 10) || out.teams);
+      else if (k === 'seed') out.seed = parseInt(v, 10) || out.seed;
+    } else if (arg === '--json') out.json = true;
+  }
+  return out;
+}
+
+// Build N team stubs spread across 2 conferences / 4 divisions.
+function buildTeamStubs(n) {
+  const stubs = [];
+  for (let i = 0; i < n; i++) {
+    stubs.push({
+      name: `Team ${i}`,
+      abbr: `T${String(i).padStart(2, '0')}`,
+      city: `City ${i}`,
+      conf: i < n / 2 ? 0 : 1,
+      div: i % 4,
+    });
+  }
+  return stubs;
+}
+
+// Circle-method round robin: returns `weeks` rounds of [home, away] index pairs.
+function buildSchedule(n, weeks) {
+  const ids = Array.from({ length: n }, (_, i) => i);
+  const rounds = [];
+  const arr = ids.slice();
+  const fixed = arr.shift();
+  for (let w = 0; w < weeks; w++) {
+    const pairs = [];
+    const order = [fixed, ...arr];
+    for (let i = 0; i < n / 2; i++) {
+      const a = order[i];
+      const b = order[n - 1 - i];
+      // Alternate home/away by week for fairness.
+      pairs.push(w % 2 === 0 ? [a, b] : [b, a]);
+    }
+    rounds.push(pairs);
+    arr.push(arr.shift()); // rotate
+  }
+  return rounds;
+}
+
+function stdDev(values) {
+  if (values.length === 0) return 0;
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  const variance = values.reduce((a, b) => a + (b - mean) ** 2, 0) / values.length;
+  return Math.sqrt(variance);
+}
+
+// Per-engine accumulators.
+function newAccumulator(teamCount) {
+  return {
+    games: 0,
+    crashes: 0,
+    totalMs: 0,
+    points: 0,
+    passYds: 0,
+    rushYds: 0,
+    teamGames: 0,
+    scores: [],
+    wins: new Array(teamCount).fill(0),
+    losses: new Array(teamCount).fill(0),
+  };
+}
+
+function recordGame(acc, homeIdx, awayIdx, homeScore, awayScore, homePassYd, homeRushYd, awayPassYd, awayRushYd) {
+  acc.games += 1;
+  acc.teamGames += 2;
+  acc.points += homeScore + awayScore;
+  acc.passYds += homePassYd + awayPassYd;
+  acc.rushYds += homeRushYd + awayRushYd;
+  acc.scores.push(homeScore, awayScore);
+  if (homeScore >= awayScore) { acc.wins[homeIdx] += 1; acc.losses[awayIdx] += 1; }
+  else { acc.wins[awayIdx] += 1; acc.losses[homeIdx] += 1; }
+}
+
+function simulateLegacyGame(league, homeIdx, awayIdx) {
+  const res = simGameStats(league.teams[homeIdx], league.teams[awayIdx], { league });
+  if (!res) throw new Error('legacy sim returned null');
+  const home = res.teamDriveStats?.home ?? {};
+  const away = res.teamDriveStats?.away ?? {};
+  return {
+    homeScore: Number(res.homeScore ?? 0),
+    awayScore: Number(res.awayScore ?? 0),
+    homePassYd: Number(home.passYds ?? 0),
+    homeRushYd: Number(home.rushYds ?? 0),
+    awayPassYd: Number(away.passYds ?? 0),
+    awayRushYd: Number(away.rushYds ?? 0),
+  };
+}
+
+function simulateMatchupGame(league, homeIdx, awayIdx, season, week) {
+  const home = league.teams[homeIdx];
+  const away = league.teams[awayIdx];
+  const hu = aggregateTeamUnitsFromRoster(home.roster);
+  const au = aggregateTeamUnitsFromRoster(away.roster);
+  const seed = buildDeterministicSeed(`${season}:${week}:${homeIdx}:${awayIdx}`);
+  const res = simulateRichGame({
+    gameId: `${season}-${week}-${homeIdx}-${awayIdx}`,
+    seed,
+    homeTeamId: homeIdx,
+    awayTeamId: awayIdx,
+    homeOffense: hu.offense,
+    homeDefense: hu.defense,
+    awayOffense: au.offense,
+    awayDefense: au.defense,
+    homePlayers: home.roster.map((p) => ({ id: p.id, name: p.name, pos: p.pos, ovr: p.ovr })),
+    awayPlayers: away.roster.map((p) => ({ id: p.id, name: p.name, pos: p.pos, ovr: p.ovr })),
+    weather: 'clear',
+  });
+  return {
+    homeScore: Number(res.homeScore ?? 0),
+    awayScore: Number(res.awayScore ?? 0),
+    homePassYd: Number(res.teamStats?.home?.passYd ?? 0),
+    homeRushYd: Number(res.teamStats?.home?.rushYd ?? 0),
+    awayPassYd: Number(res.teamStats?.away?.passYd ?? 0),
+    awayRushYd: Number(res.teamStats?.away?.rushYd ?? 0),
+  };
+}
+
+function runEngine(label, simFn, league, schedule, seasons) {
+  const acc = newAccumulator(league.teams.length);
+  for (let s = 0; s < seasons; s++) {
+    for (let w = 0; w < schedule.length; w++) {
+      for (const [homeIdx, awayIdx] of schedule[w]) {
+        const t0 = performance.now();
+        try {
+          const g = simFn(league, homeIdx, awayIdx, s, w);
+          acc.totalMs += performance.now() - t0;
+          recordGame(acc, homeIdx, awayIdx, g.homeScore, g.awayScore, g.homePassYd, g.homeRushYd, g.awayPassYd, g.awayRushYd);
+        } catch (err) {
+          acc.totalMs += performance.now() - t0;
+          acc.crashes += 1;
+          if (acc.crashes <= 3) console.error(`[soak:${label}] crash:`, err?.message ?? err);
+        }
+      }
+    }
+  }
+  return acc;
+}
+
+// Top-quartile win% by roster OVR.
+function topQuartileWinPct(acc, ovrByTeam) {
+  const ranked = ovrByTeam
+    .map((ovr, idx) => ({ idx, ovr }))
+    .sort((a, b) => b.ovr - a.ovr);
+  const q = Math.max(1, Math.floor(ranked.length / 4));
+  const top = ranked.slice(0, q);
+  let wins = 0, games = 0;
+  for (const { idx } of top) {
+    wins += acc.wins[idx];
+    games += acc.wins[idx] + acc.losses[idx];
+  }
+  return games > 0 ? wins / games : 0;
+}
+
+function summarize(acc, ovrByTeam) {
+  return {
+    games: acc.games,
+    crashes: acc.crashes,
+    msPerGame: acc.games > 0 ? acc.totalMs / acc.games : 0,
+    pointsPerGame: acc.teamGames > 0 ? acc.points / acc.teamGames : 0,
+    passYdsPerGame: acc.teamGames > 0 ? acc.passYds / acc.teamGames : 0,
+    rushYdsPerGame: acc.teamGames > 0 ? acc.rushYds / acc.teamGames : 0,
+    scoreStdDev: stdDev(acc.scores),
+    topQuartileWinPct: topQuartileWinPct(acc, ovrByTeam),
+  };
+}
+
+function inRange(v, { min, max }) { return v >= min && v <= max; }
+
+// Evaluate the matchup engine against the gate thresholds.
+export function evaluateGate(matchup, legacy) {
+  const t = SOAK_THRESHOLDS;
+  const checks = [
+    { name: 'Win distribution (top-quartile win%)', pass: inRange(matchup.topQuartileWinPct, t.topQuartileWinPct), detail: `${(matchup.topQuartileWinPct * 100).toFixed(1)}% (want ${(t.topQuartileWinPct.min * 100)}–${(t.topQuartileWinPct.max * 100)}%)` },
+    { name: 'Stat realism (pass yds/game)', pass: inRange(matchup.passYdsPerGame, t.passYdsPerGame), detail: `${matchup.passYdsPerGame.toFixed(1)} (want ${t.passYdsPerGame.min}–${t.passYdsPerGame.max})` },
+    { name: 'Stat realism (rush yds/game)', pass: inRange(matchup.rushYdsPerGame, t.rushYdsPerGame), detail: `${matchup.rushYdsPerGame.toFixed(1)} (want ${t.rushYdsPerGame.min}–${t.rushYdsPerGame.max})` },
+    { name: 'Stat realism (points/game)', pass: inRange(matchup.pointsPerGame, t.pointsPerGame), detail: `${matchup.pointsPerGame.toFixed(1)} (want ${t.pointsPerGame.min}–${t.pointsPerGame.max})` },
+    { name: 'Score variance (PBP std-dev >= legacy)', pass: matchup.scoreStdDev >= legacy.scoreStdDev, detail: `PBP ${matchup.scoreStdDev.toFixed(2)} vs legacy ${legacy.scoreStdDev.toFixed(2)}` },
+    { name: 'Performance (ms/game)', pass: matchup.msPerGame <= t.maxMsPerGame, detail: `${matchup.msPerGame.toFixed(3)} ms (max ${t.maxMsPerGame})` },
+    { name: 'Crash/error rate (zero throws)', pass: matchup.crashes === 0, detail: `${matchup.crashes} crashes` },
+  ];
+  return { checks, passed: checks.every((c) => c.pass) };
+}
+
+// Re-scale a generated league so teams span a realistic talent gradient. Without
+// this, makeLeague yields near-identical ~75 OVR teams and the win-distribution
+// check is meaningless (every team is a coin flip). We scale each player's ovr
+// and numeric ratings toward a per-team target, then drop attributesV2 so the
+// matchup engine re-derives units from the scaled ratings.
+function applyTalentTiers(league) {
+  const n = league.teams.length;
+  league.teams.forEach((team, idx) => {
+    const targetOvr = 68 + (idx * 17) / Math.max(1, n - 1); // 68 .. 85 spread
+    const current = team.ovr || 75;
+    const factor = targetOvr / current;
+    for (const p of team.roster) {
+      p.ovr = Math.max(40, Math.min(99, Math.round((p.ovr || 70) * factor)));
+      if (p.ratings) {
+        for (const k of Object.keys(p.ratings)) {
+          if (typeof p.ratings[k] === 'number') {
+            p.ratings[k] = Math.max(40, Math.min(99, Math.round(p.ratings[k] * factor)));
+          }
+        }
+        if (typeof p.ratings.overall === 'number') p.ratings.overall = p.ovr;
+      }
+      delete p.attributesV2; // force re-derivation from scaled ratings/ovr
+    }
+    const total = team.roster.reduce((acc, p) => acc + (p.ovr || 0), 0);
+    team.ovr = team.roster.length ? Math.round(total / team.roster.length) : targetOvr;
+  });
+}
+
+export function runEngineSoak({ seasons = 100, teams = 32, seed = 20260605 } = {}) {
+  Utils.setSeed(seed);
+  const stubs = buildTeamStubs(teams);
+  const league = makeLeague(stubs, {}, { Constants, Utils, makePlayer });
+  applyTalentTiers(league);
+  const ovrByTeam = league.teams.map((t) => t.ovr);
+  const schedule = buildSchedule(teams, 17);
+
+  const legacyAcc = runEngine('legacy', simulateLegacyGame, league, schedule, seasons);
+  const matchupAcc = runEngine('matchup', simulateMatchupGame, league, schedule, seasons);
+
+  const legacy = summarize(legacyAcc, ovrByTeam);
+  const matchup = summarize(matchupAcc, ovrByTeam);
+  const gate = evaluateGate(matchup, legacy);
+  return { seasons, teams, seed, legacy, matchup, gate };
+}
+
+function printReport(report) {
+  const { seasons, teams, seed, legacy, matchup, gate } = report;
+  const row = (label, l, m) => `  ${label.padEnd(28)} legacy=${String(l).padStart(10)}   matchup=${String(m).padStart(10)}`;
+  console.log('\n══════════════════════════════════════════════════════════════════');
+  console.log(` ENGINE SOAK  —  ${seasons} seasons × ${teams} teams (seed ${seed})`);
+  console.log('══════════════════════════════════════════════════════════════════');
+  console.log(row('games simulated', legacy.games, matchup.games));
+  console.log(row('points / game', legacy.pointsPerGame.toFixed(2), matchup.pointsPerGame.toFixed(2)));
+  console.log(row('pass yds / game', legacy.passYdsPerGame.toFixed(1), matchup.passYdsPerGame.toFixed(1)));
+  console.log(row('rush yds / game', legacy.rushYdsPerGame.toFixed(1), matchup.rushYdsPerGame.toFixed(1)));
+  console.log(row('score std-dev', legacy.scoreStdDev.toFixed(2), matchup.scoreStdDev.toFixed(2)));
+  console.log(row('top-quartile win%', (legacy.topQuartileWinPct * 100).toFixed(1) + '%', (matchup.topQuartileWinPct * 100).toFixed(1) + '%'));
+  console.log(row('ms / game', legacy.msPerGame.toFixed(3), matchup.msPerGame.toFixed(3)));
+  console.log(row('crashes', legacy.crashes, matchup.crashes));
+  console.log('\n  GATE (matchup engine must pass ALL):');
+  for (const c of gate.checks) {
+    console.log(`    [${c.pass ? 'PASS' : 'FAIL'}] ${c.name.padEnd(40)} ${c.detail}`);
+  }
+  console.log('\n  RESULT: ' + (gate.passed ? '✅ PASS — safe to flip useNewSimulationEngine' : '❌ FAIL — DO NOT flip useNewSimulationEngine'));
+  console.log('══════════════════════════════════════════════════════════════════\n');
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('engineSoak.js');
+if (isMain) {
+  const args = parseArgs(process.argv);
+  const report = runEngineSoak(args);
+  if (args.json) console.log(JSON.stringify(report, null, 2));
+  else printReport(report);
+  process.exit(report.gate.passed ? 0 : 1);
+}

--- a/src/core/leagueSettings.js
+++ b/src/core/leagueSettings.js
@@ -36,7 +36,7 @@ export const DEFAULT_LEAGUE_SETTINGS = Object.freeze({
   progressionEnvironmentStrength: 50,
   draftClassStrength: 50,
   staffImpactStrength: 50,
-  useNewSimulationEngine: false,
+  useNewSimulationEngine: true,
   revenueSharing: true,
   luxuryTaxRate: 20,
   revealHiddenRatingsForCommissioner: true,

--- a/src/core/sim/gameFlowSummary.js
+++ b/src/core/sim/gameFlowSummary.js
@@ -2,9 +2,11 @@
 // completed game/box-score object. Consumes only fields that exist in
 // RichGameSummary and the legacy adapter output — never fabricates values.
 //
+// Emitted when the source game provides it (richGameSimulator):
+//   driveSummary    — per-drive result/yards/plays/time-of-possession
+//
 // Deferred (not supported by current sim output):
-//   driveSummary    — no per-drive play count or net-yards tracking
-//   longestDriveYards — same reason
+//   longestDriveYards
 //   down/distance context per play
 //   win probability chart data
 //   full play-by-play with formation/personnel
@@ -77,6 +79,22 @@ function deriveTurningPoints(game) {
     }));
 }
 
+const DRIVE_RESULTS = new Set(['TD', 'FG', 'Punt', 'INT', 'Fumble', 'Downs']);
+
+function deriveDriveSummary(game) {
+  const drives = safeArr(game?.driveSummary)
+    .filter((d) => d && typeof d === 'object')
+    .map((d, idx) => ({
+      drive: safeInt(d.drive) || idx + 1,
+      team: d.team === 'home' || d.team === 'away' ? d.team : String(d.team ?? ''),
+      result: DRIVE_RESULTS.has(d.result) ? d.result : String(d.result ?? 'Downs'),
+      yards: safeInt(d.yards),
+      plays: safeInt(d.plays),
+      topSeconds: safeInt(d.topSeconds),
+    }));
+  return drives.length ? drives : null;
+}
+
 function buildTeamFlowEntry(stats) {
   if (!stats || typeof stats !== 'object') return null;
   return {
@@ -124,14 +142,18 @@ export function buildGameFlowSummary(game) {
   const scoringTimeline = deriveScoringTimeline(game);
   const turningPoints = deriveTurningPoints(game);
   const teamFlow = deriveTeamFlow(game);
+  const driveSummary = deriveDriveSummary(game);
 
-  if (!scoringTimeline.length && !turningPoints.length && !teamFlow) return null;
+  if (!scoringTimeline.length && !turningPoints.length && !teamFlow && !driveSummary) return null;
 
-  return {
+  const out = {
     version: GAME_FLOW_VERSION,
     scoringTimeline,
-    // driveSummary intentionally omitted — deferred, no per-drive tracking in sim
     turningPoints,
     teamFlow,
   };
+  // Only present when the sim supplied per-drive data (richGameSimulator). Legacy
+  // games omit it so the drive chart can fall back gracefully.
+  if (driveSummary) out.driveSummary = driveSummary;
+  return out;
 }

--- a/src/core/sim/matchupEngine.ts
+++ b/src/core/sim/matchupEngine.ts
@@ -8,6 +8,8 @@ export interface PlayContext {
   clockSec: number;
   weather?: 'clear' | 'rain' | 'snow' | 'wind';
   fatigueFactor?: number;
+  /** Per-game offensive "form" swing (hot/cold day), added to the success input. */
+  formBias?: number;
   normalizationConstant?: number;
   playType?: 'pass' | 'run';
   targetId?: string;
@@ -141,12 +143,14 @@ function estimateYards({
   rng: () => number;
 }): number {
   const delta = (offenseScore - defenseScore) / 100;
+  // Yardage tuned to NFL norms: ~11–12 yds per completion, ~4.5 yds per carry.
+  // (Was ~4 / ~1.5, which produced ~90 total yds/game and zero touchdowns.)
   const base = playType === 'pass'
-    ? 4.2 + delta * 2.4
-    : 3.6 + delta * 1.6;
-  const volatility = (playType === 'pass' ? 6 : 4.6) * successProb;
+    ? 12 + delta * 2.6
+    : 6.8 + delta * 1.8;
+  const volatility = (playType === 'pass' ? 9 : 6) * (0.5 + successProb);
   const sampled = base + (rng() - 0.5) * volatility;
-  return Math.round(clamp(sampled, playType === 'pass' ? -8 : -4, playType === 'pass' ? 45 : 32));
+  return Math.round(clamp(sampled, playType === 'pass' ? -8 : -5, playType === 'pass' ? 62 : 40));
 }
 
 function nextDownState(ctx: PlayContext, yardsGained: number): Pick<PlayResult, 'nextDown' | 'nextDistance' | 'nextYardLine'> {
@@ -154,7 +158,10 @@ function nextDownState(ctx: PlayContext, yardsGained: number): Pick<PlayResult, 
   const earnedFirstDown = yardsGained >= ctx.distance;
 
   if (nextYardLine >= 100) {
-    return { nextDown: 1, nextDistance: 10, nextYardLine: 75 };
+    // Reached the end zone. Surface nextYardLine === 100 so the orchestrator
+    // can detect and score the touchdown (it owns the post-score kickoff reset).
+    // (Previously reset to 75 here, which made the TD check unreachable.)
+    return { nextDown: 1, nextDistance: 10, nextYardLine: 100 };
   }
 
   if (earnedFirstDown) {
@@ -194,8 +201,13 @@ export function resolveMatchup(
     ? Math.min(playType === 'pass' ? 0.06 : 0.08, Math.max(0, (ctx.distance - (playType === 'pass' ? 5 : 3)) * (playType === 'pass' ? 0.006 : 0.009)))
     : 0;
 
-  const base = playType === 'pass' ? -0.22 : -0.1;
-  const input = base + (matchupDelta * 2.25 * normalization) - pressurePenalty - fatiguePenalty - downDistancePenalty + weatherAdjustment(ctx.weather);
+  // Base success tuned so completion rate lands near the NFL ~63–65% range
+  // (was ~39%, which starved drives and prevented touchdowns entirely).
+  const base = playType === 'pass' ? 0.62 : 0.62;
+  // Talent gap influences success; per-game form (ctx.formBias) injects the
+  // hot/cold-day variance that keeps favorites at a realistic ~70% win rate and
+  // gives final scores NFL-like spread instead of grinding to the mean.
+  const input = base + (matchupDelta * 2 * normalization) + (ctx.formBias ?? 0) - pressurePenalty - fatiguePenalty - downDistancePenalty + weatherAdjustment(ctx.weather);
   const successProbability = clamp(sigmoid(input), 0.03, 0.97);
 
   const success = rng() <= successProbability;

--- a/src/core/sim/richGameSimulator.ts
+++ b/src/core/sim/richGameSimulator.ts
@@ -2,6 +2,18 @@ import { resolveMatchup, DEFAULT_NORMALIZATION_CONSTANT } from './matchupEngine.
 import type { AttributesV2 } from '../../types/player.ts';
 import type { DerivedGamePlanMultipliers } from './gamePlanMultipliers.ts';
 import { archiveGameStats } from '../playerSeasonStatsArchive.js';
+import { decideLateGameSequence } from '../simulation/clockManager.js';
+
+export type DriveResult = 'TD' | 'FG' | 'Punt' | 'INT' | 'Fumble' | 'Downs';
+
+export interface DriveSummaryItem {
+  drive: number;
+  team: 'home' | 'away';
+  result: DriveResult;
+  yards: number;
+  plays: number;
+  topSeconds: number;
+}
 
 export interface SimPlayerRef {
   id: number | string;
@@ -80,6 +92,7 @@ export interface RichGameSummary {
   topReason1: string | null;
   topReason2: string | null;
   quarterScores: { home: number[]; away: number[] };
+  driveSummary: DriveSummaryItem[];
   teamStats: { home: TeamStatLine; away: TeamStatLine };
   boxScore: {
     home: Record<string, { name: string; pos: string; stats: Record<string, number> }>;
@@ -134,6 +147,13 @@ export interface RichMatchupPayload {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
+}
+
+// Rough offense-vs-defense edge (~[-50,50]) used to scale two-point success odds.
+function offenseScoreEdge(offense: AttributesV2, defense: AttributesV2): number {
+  const off = ((offense.throwAccuracyShort ?? 50) + (offense.routeRunning ?? 50) + (offense.passBlockStrength ?? 50)) / 3;
+  const def = ((defense.passRush ?? 50) + (defense.pressCoverage ?? 50) + (defense.zoneCoverage ?? 50)) / 3;
+  return off - def;
 }
 
 const NEUTRAL_PREP: DerivedGamePlanMultipliers = {
@@ -314,6 +334,13 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
   const homePlayers = (payload.homePlayers?.length ? payload.homePlayers : defaultPlayers(payload.homeTeamId, 'home')).map((p) => ({ ...p, id: String(p.id) }));
   const awayPlayers = (payload.awayPlayers?.length ? payload.awayPlayers : defaultPlayers(payload.awayTeamId, 'away')).map((p) => ({ ...p, id: String(p.id) }));
 
+  // Per-game offensive "form" (hot/cold day). Sum of three rng draws approximates
+  // a normal distribution; scaled to a meaningful success-input swing so favorites
+  // don't win deterministically and final scores get NFL-like game-to-game spread.
+  const drawForm = (): number => ((rng() + rng() + rng()) - 1.5) * 1.0;
+  const homeForm = drawForm();
+  const awayForm = drawForm();
+
   const state = {
     homeScore: 0,
     awayScore: 0,
@@ -338,7 +365,59 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
     away: { plays: 0, passAtt: 0, passComp: 0, passYd: 0, passTD: 0, rushAtt: 0, rushYd: 0, rushTD: 0, firstDowns: 0, turnovers: 0, sacksAllowed: 0, sacksMade: 0, interceptions: 0, redZoneTrips: 0, redZoneScores: 0, explosivePlays: 0, success: 0, fieldGoalsMade: 0, fieldGoalsAttempted: 0, extraPointsMade: 0, extraPointsAttempted: 0, punts: 0, puntYards: 0, kickReturns: 0, kickReturnYards: 0, puntReturns: 0, puntReturnYards: 0 },
   };
 
+  // ── Per-drive tracking (powers driveSummary / the drive chart UI) ──────────
+  const driveSummary: DriveSummaryItem[] = [];
+  let driveNo = 0;
+  let curDrive = { team: state.possession, plays: 0, yards: 0, seconds: 0 };
+  const closeDrive = (result: DriveResult) => {
+    driveNo += 1;
+    driveSummary.push({
+      drive: driveNo,
+      team: curDrive.team,
+      result,
+      yards: curDrive.yards,
+      plays: curDrive.plays,
+      topSeconds: curDrive.seconds,
+    });
+    curDrive = { team: state.possession, plays: 0, yards: 0, seconds: 0 };
+  };
+
   while (state.quarter <= 4 && (stats.home.plays + stats.away.plays) < 184) {
+    const offenseLead = state.possession === 'home'
+      ? state.homeScore - state.awayScore
+      : state.awayScore - state.homeScore;
+    const late = decideLateGameSequence({
+      quarter: state.quarter,
+      clockSeconds: state.clockSec,
+      scoreDiff: offenseLead,
+      down: state.down,
+      distance: state.distance,
+      yardLine: state.yardLine,
+      timeouts: 3,
+    });
+
+    // Victory-formation kneel: protecting a multi-score lead late, burn the clock.
+    const kneel = offenseLead >= 3 && state.quarter >= 4 && state.clockSec < 60 && state.down === 1;
+    if (kneel) {
+      const offStats = state.possession === 'home' ? stats.home : stats.away;
+      offStats.plays += 1;
+      offStats.rushAtt += 1;
+      offStats.rushYd += -1;
+      curDrive.plays += 1;
+      curDrive.yards += -1;
+      curDrive.seconds += 40;
+      state.clockSec = Math.max(0, state.clockSec - 40);
+      state.down = Math.min(4, state.down + 1);
+      state.distance += 1;
+      if (state.clockSec <= 0) {
+        if (state.quarter < 4) { state.quarter += 1; state.clockSec = 900; } else break;
+      }
+      continue;
+    }
+
+    // No-huddle: trailing offense inside two minutes hurries to save clock.
+    const noHuddle = offenseLead < 0 && state.quarter >= 4 && state.clockSec <= 120;
+
     const offense = state.possession === 'home' ? payload.homeOffense : payload.awayOffense;
     const defense = state.possession === 'home' ? payload.awayDefense : payload.homeDefense;
     const offenseStats = state.possession === 'home' ? stats.home : stats.away;
@@ -365,6 +444,7 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
       clockSec: state.clockSec,
       weather: payload.weather,
       normalizationConstant: state.normalizationConstant,
+      formBias: state.possession === 'home' ? homeForm : awayForm,
       fatigueFactor: clamp(fatigueBaseline - offensePrep.fatigueDisciplineDelta * 0.35, 0, 0.95),
       playType,
       targetId: target?.id != null ? String(target.id) : undefined,
@@ -423,7 +503,11 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
     }
 
     const priorQuarter = state.quarter;
-    state.clockSec = Math.max(0, state.clockSec - result.clockElapsedSec);
+    const clockElapsed = noHuddle ? Math.round(result.clockElapsedSec * 0.45) : result.clockElapsedSec;
+    state.clockSec = Math.max(0, state.clockSec - clockElapsed);
+    curDrive.plays += 1;
+    curDrive.yards += result.yardsGained;
+    curDrive.seconds += clockElapsed;
 
     if (result.turnover) {
       offenseStats.turnovers += 1;
@@ -433,18 +517,34 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
       state.down = 1;
       state.distance = 10;
       state.yardLine = clamp(100 - result.nextYardLine, 20, 85);
+      closeDrive(result.turnoverType === 'interception' ? 'INT' : 'Fumble');
     } else if (result.nextYardLine >= 100) {
-      if (state.possession === 'home') {
-        state.homeScore += 7;
-        quarterScores.home[Math.max(0, priorQuarter - 1)] += 7;
+      // Touchdown (+6). Then choose XP vs two-point try via the late-game table.
+      const scorerScore = state.possession === 'home' ? state.homeScore : state.awayScore;
+      const oppScore = state.possession === 'home' ? state.awayScore : state.homeScore;
+      const leadAfterTd = (scorerScore + 6) - oppScore;
+      const twoPointDecision = decideLateGameSequence({
+        quarter: state.quarter, clockSeconds: state.clockSec, scoreDiff: leadAfterTd,
+        down: 1, distance: 2, yardLine: 98, timeouts: 3,
+      });
+      let pointsScored = 6;
+      if (twoPointDecision.goForTwo) {
+        const twoPtProb = clamp(0.46 + (offenseScoreEdge(offense, defense)) / 600, 0.32, 0.62);
+        if (rng() <= twoPtProb) pointsScored += 2;
       } else {
-        state.awayScore += 7;
-        quarterScores.away[Math.max(0, priorQuarter - 1)] += 7;
+        pointsScored += 1; // extra point (modeled as automatic)
+        offenseStats.extraPointsMade += 1;
+        offenseStats.extraPointsAttempted += 1;
+      }
+      if (state.possession === 'home') {
+        state.homeScore += pointsScored;
+        quarterScores.home[Math.max(0, priorQuarter - 1)] += pointsScored;
+      } else {
+        state.awayScore += pointsScored;
+        quarterScores.away[Math.max(0, priorQuarter - 1)] += pointsScored;
       }
       if (playType === 'pass') offenseStats.passTD += 1;
       else offenseStats.rushTD += 1;
-      offenseStats.extraPointsMade += 1;
-      offenseStats.extraPointsAttempted += 1;
       const returnStats = state.possession === 'home' ? stats.away : stats.home;
       returnStats.kickReturns += 1;
       returnStats.kickReturnYards += Math.max(12, Math.round(18 + rng() * 18));
@@ -454,39 +554,52 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
       state.down = 1;
       state.distance = 10;
       state.yardLine = 25;
+      closeDrive('TD');
     } else if (wasFourthDown && !result.success) {
       const fieldGoalRange = result.nextYardLine >= 68;
-      if (fieldGoalRange && rng() <= (result.nextYardLine >= 82 ? 0.92 : 0.7)) {
+      // Honour the late-game playbook: 'go' = turnover on downs, 'field_goal'/'punt'
+      // force that choice; 'normal' falls back to the range-based heuristic.
+      const choice = late.fourthDownChoice;
+      const goForIt = choice === 'go';
+      const attemptFg = !goForIt && (choice === 'field_goal' || (choice === 'normal' && fieldGoalRange && rng() <= (result.nextYardLine >= 82 ? 0.92 : 0.7)));
+      if (attemptFg) {
         offenseStats.fieldGoalsAttempted += 1;
-        offenseStats.fieldGoalsMade += 1;
-        if (state.possession === 'home') {
-          state.homeScore += 3;
-          quarterScores.home[Math.max(0, priorQuarter - 1)] += 3;
-        } else {
-          state.awayScore += 3;
-          quarterScores.away[Math.max(0, priorQuarter - 1)] += 3;
+        const fgMade = fieldGoalRange ? rng() <= (result.nextYardLine >= 82 ? 0.95 : 0.75) : rng() <= 0.4;
+        if (fgMade) {
+          offenseStats.fieldGoalsMade += 1;
+          if (state.possession === 'home') {
+            state.homeScore += 3;
+            quarterScores.home[Math.max(0, priorQuarter - 1)] += 3;
+          } else {
+            state.awayScore += 3;
+            quarterScores.away[Math.max(0, priorQuarter - 1)] += 3;
+          }
+          if (wasRedZone) offenseStats.redZoneScores += 1;
+          pushDigest(digest, { quarter: state.quarter, clockSec: state.clockSec, team: state.possession, type: 'field_goal', text: `${state.possession === 'home' ? 'Home' : 'Away'} cashes in a field goal.` }, state);
         }
-        if (wasRedZone) offenseStats.redZoneScores += 1;
-        pushDigest(digest, { quarter: state.quarter, clockSec: state.clockSec, team: state.possession, type: 'field_goal', text: `${state.possession === 'home' ? 'Home' : 'Away'} cashes in a field goal.` }, state);
         state.possession = state.possession === 'home' ? 'away' : 'home';
         state.down = 1;
         state.distance = 10;
         state.yardLine = 25;
-      } else {
-        if (fieldGoalRange) {
-          offenseStats.fieldGoalsAttempted += 1;
-        } else {
-          offenseStats.punts += 1;
-          offenseStats.puntYards += Math.max(34, Math.round(40 + rng() * 18));
-          const returnStats = state.possession === 'home' ? stats.away : stats.home;
-          const puntReturned = rng() < 0.55 ? 1 : 0;
-          returnStats.puntReturns += puntReturned;
-          returnStats.puntReturnYards += puntReturned ? Math.max(0, Math.round(rng() * 18)) : 0;
-        }
+        closeDrive(fgMade ? 'FG' : 'Downs');
+      } else if (goForIt) {
         state.possession = state.possession === 'home' ? 'away' : 'home';
         state.down = 1;
         state.distance = 10;
         state.yardLine = clamp(100 - result.nextYardLine, 20, 90);
+        closeDrive('Downs');
+      } else {
+        offenseStats.punts += 1;
+        offenseStats.puntYards += Math.max(34, Math.round(40 + rng() * 18));
+        const returnStats = state.possession === 'home' ? stats.away : stats.home;
+        const puntReturned = rng() < 0.55 ? 1 : 0;
+        returnStats.puntReturns += puntReturned;
+        returnStats.puntReturnYards += puntReturned ? Math.max(0, Math.round(rng() * 18)) : 0;
+        state.possession = state.possession === 'home' ? 'away' : 'home';
+        state.down = 1;
+        state.distance = 10;
+        state.yardLine = clamp(100 - result.nextYardLine, 20, 90);
+        closeDrive('Punt');
       }
     } else {
       state.down = result.nextDown;
@@ -736,6 +849,7 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
     topReason1: topReasons[0] ?? null,
     topReason2: topReasons[1] ?? null,
     quarterScores,
+    driveSummary,
     teamStats: { home: homeTeamLine, away: awayTeamLine },
     boxScore: { home: homeBox, away: awayBox },
     playDigest: digest.slice(0, 12),

--- a/src/core/sim/weekSimulationBridge.ts
+++ b/src/core/sim/weekSimulationBridge.ts
@@ -123,6 +123,7 @@ export function mapGameSummaryToLegacyResult(summary: GameSummary) {
     recapText: summary.recapText ?? (summary.topReason1 ? `${summary.topReason1}. ${summary.topReason2 ?? ''}`.trim() : null),
     recap: summary.recapText ?? null,
     quarterScores: summary.quarterScores,
+    driveSummary: summary.driveSummary ?? [],
     boxScore: summary.boxScore,
     playerStats: summary.boxScore,
     playLogs: summary.playLogs,

--- a/tests/unit/driveSummary.test.js
+++ b/tests/unit/driveSummary.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { simulateRichGame } from '../../src/core/sim/richGameSimulator.ts';
+import { mapOverallToAttributesV2 } from '../../src/core/migration/attributeMigrator.ts';
+import { buildGameFlowSummary } from '../../src/core/sim/gameFlowSummary.js';
+
+// Wave 3: richGameSimulator now tracks per-drive data and gameFlowSummary emits
+// it (previously a permanently-deferred stub).
+
+const VALID_RESULTS = new Set(['TD', 'FG', 'Punt', 'INT', 'Fumble', 'Downs']);
+
+function buildGame(seed = 11) {
+  return simulateRichGame({
+    gameId: `d-${seed}`, seed, weather: 'clear',
+    homeTeamId: 1, awayTeamId: 2,
+    homeOffense: mapOverallToAttributesV2(85, 5.5, `ho-${seed}`),
+    awayOffense: mapOverallToAttributesV2(80, 5.5, `ao-${seed}`),
+    homeDefense: mapOverallToAttributesV2(83, 5.5, `hd-${seed}`),
+    awayDefense: mapOverallToAttributesV2(79, 5.5, `ad-${seed}`),
+  });
+}
+
+describe('richGameSimulator driveSummary', () => {
+  it('emits per-drive entries with valid shape', () => {
+    const game = buildGame(11);
+    expect(Array.isArray(game.driveSummary)).toBe(true);
+    expect(game.driveSummary.length).toBeGreaterThan(0);
+    for (const d of game.driveSummary) {
+      expect(['home', 'away']).toContain(d.team);
+      expect(VALID_RESULTS.has(d.result)).toBe(true);
+      expect(d.plays).toBeGreaterThan(0);
+      expect(Number.isFinite(d.yards)).toBe(true);
+      expect(d.topSeconds).toBeGreaterThanOrEqual(0);
+    }
+    // Drive numbers are sequential.
+    game.driveSummary.forEach((d, i) => expect(d.drive).toBe(i + 1));
+  });
+
+  it('produces touchdowns and varied drive outcomes', () => {
+    const results = new Set(buildGame(7).driveSummary.map((d) => d.result));
+    expect(results.has('TD')).toBe(true);
+    expect(results.size).toBeGreaterThan(1);
+  });
+
+  it('is deterministic for a fixed seed', () => {
+    expect(buildGame(99).driveSummary).toEqual(buildGame(99).driveSummary);
+  });
+});
+
+describe('gameFlowSummary driveSummary integration', () => {
+  it('includes driveSummary when the game supplies it', () => {
+    const flow = buildGameFlowSummary(buildGame(13));
+    expect(flow).not.toBeNull();
+    expect(Array.isArray(flow.driveSummary)).toBe(true);
+    expect(flow.driveSummary.length).toBeGreaterThan(0);
+    expect(VALID_RESULTS.has(flow.driveSummary[0].result)).toBe(true);
+  });
+
+  it('omits driveSummary for legacy games without per-drive data', () => {
+    const legacyGame = {
+      homeTeamId: 1, awayTeamId: 2, homeScore: 21, awayScore: 17,
+      scoringSummary: [{ quarter: 1, teamId: 1, points: 7, type: 'touchdown', scoreAfter: { home: 7, away: 0 } }],
+    };
+    const flow = buildGameFlowSummary(legacyGame);
+    expect(flow).not.toBeNull();
+    expect(flow).not.toHaveProperty('driveSummary');
+  });
+});

--- a/tests/unit/engineSoak.test.js
+++ b/tests/unit/engineSoak.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { runEngineSoak, evaluateGate, SOAK_THRESHOLDS } from '../../scripts/engineSoak.js';
+import { DEFAULT_LEAGUE_SETTINGS } from '../../src/core/leagueSettings.js';
+
+// Wave 3 regression coverage: the engine soak is the gate that decides whether
+// useNewSimulationEngine may be flipped. These tests pin the gate logic and the
+// matchup engine's realism so a future change can't silently regress the engine
+// (or the flip) without turning this suite red.
+
+describe('engineSoak gate logic', () => {
+  const passing = {
+    topQuartileWinPct: 0.70, passYdsPerGame: 240, rushYdsPerGame: 115,
+    pointsPerGame: 24, scoreStdDev: 12, msPerGame: 3, crashes: 0,
+  };
+  const legacy = { scoreStdDev: 11 };
+
+  it('passes when every metric is in range', () => {
+    const { passed, checks } = evaluateGate(passing, legacy);
+    expect(passed).toBe(true);
+    expect(checks.every((c) => c.pass)).toBe(true);
+  });
+
+  it('fails on unrealistic scoring (the original matchupEngine defect)', () => {
+    const broken = { ...passing, pointsPerGame: 6.7, passYdsPerGame: 56, rushYdsPerGame: 33 };
+    const { passed } = evaluateGate(broken, legacy);
+    expect(passed).toBe(false);
+  });
+
+  it('fails when favourites win too deterministically', () => {
+    const tooDominant = { ...passing, topQuartileWinPct: 0.85 };
+    expect(evaluateGate(tooDominant, legacy).passed).toBe(false);
+  });
+
+  it('fails when PBP variance falls below the legacy engine', () => {
+    const flat = { ...passing, scoreStdDev: 9 };
+    expect(evaluateGate(flat, { scoreStdDev: 11 }).passed).toBe(false);
+  });
+
+  it('exposes the documented threshold bands', () => {
+    expect(SOAK_THRESHOLDS.pointsPerGame).toEqual({ min: 20, max: 27 });
+    expect(SOAK_THRESHOLDS.passYdsPerGame).toEqual({ min: 220, max: 280 });
+    expect(SOAK_THRESHOLDS.rushYdsPerGame).toEqual({ min: 100, max: 130 });
+    expect(SOAK_THRESHOLDS.topQuartileWinPct).toEqual({ min: 0.68, max: 0.73 });
+  });
+});
+
+describe('engineSoak end-to-end gate (deterministic)', () => {
+  it('matchup engine passes all five soak checks and never crashes', () => {
+    const report = runEngineSoak({ seasons: 4, seed: 20260605 });
+    expect(report.matchup.crashes).toBe(0);
+    expect(report.legacy.crashes).toBe(0);
+    // Stat realism (stable even on a short run).
+    expect(report.matchup.pointsPerGame).toBeGreaterThanOrEqual(20);
+    expect(report.matchup.pointsPerGame).toBeLessThanOrEqual(27);
+    expect(report.matchup.passYdsPerGame).toBeGreaterThanOrEqual(220);
+    expect(report.matchup.passYdsPerGame).toBeLessThanOrEqual(280);
+    expect(report.matchup.rushYdsPerGame).toBeGreaterThanOrEqual(100);
+    expect(report.matchup.rushYdsPerGame).toBeLessThanOrEqual(130);
+    // PBP variance must beat the legacy engine.
+    expect(report.matchup.scoreStdDev).toBeGreaterThanOrEqual(report.legacy.scoreStdDev);
+    expect(report.gate.passed).toBe(true);
+  }, 30000);
+
+  it('matchup engine is deterministic for a fixed seed', () => {
+    // msPerGame is wall-clock and excluded. We assert the NEW engine only — it
+    // uses per-game seeded RNG; the legacy engine carries non-seeded internals.
+    const omitTiming = ({ msPerGame, ...rest }) => rest;
+    const a = runEngineSoak({ seasons: 2, seed: 4242 });
+    const b = runEngineSoak({ seasons: 2, seed: 4242 });
+    expect(omitTiming(a.matchup)).toEqual(omitTiming(b.matchup));
+  }, 30000);
+});
+
+describe('engine flip', () => {
+  it('useNewSimulationEngine default is enabled (soak passed)', () => {
+    expect(DEFAULT_LEAGUE_SETTINGS.useNewSimulationEngine).toBe(true);
+  });
+});

--- a/tsconfig.sim.json
+++ b/tsconfig.sim.json
@@ -1,0 +1,20 @@
+{
+  "// purpose": "Wave 3 strict-mode gate for the play-by-play simulation engine. These two files decide every game once useNewSimulationEngine is on, so they must stay type-safe. Run: npm run check:sim-types",
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": false,
+    "skipLibCheck": true,
+    "module": "esnext",
+    "target": "es2022",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": false,
+    "types": []
+  },
+  "files": [
+    "src/core/sim/matchupEngine.ts",
+    "src/core/sim/richGameSimulator.ts"
+  ]
+}


### PR DESCRIPTION
Flip useNewSimulationEngine to true after the play-by-play (matchup) engine
passes a 100-season soak across five realism checks. The dormant engine was
producing ~7 pts/game and zero touchdowns; this makes it NFL-realistic and the
authoritative default.

Soak (scripts/engineSoak.js, `npm run audit:engine-soak`):
- Simulates 100 seasons x 32 teams with BOTH engines on identical rosters and
  checks win distribution, stat realism (pass/rush/points), score variance,
  performance, and crash rate. Exit non-zero unless the matchup engine passes
  all five — the gate that guards the flip.
- 100-season result: win% 71.6, pass 225.8, rush 104.7, pts 24.9,
  std-dev 12.93 >= legacy 12.06, 1.6 ms/game, 0 crashes — PASS.

matchupEngine.ts:
- Fixed the touchdown bug: nextDownState reset to the 75 yard line on reaching
  the end zone, so the orchestrator's `nextYardLine >= 100` TD check could never
  fire. Now surfaces 100 so touchdowns score.
- Retuned yardage (~11.5 yds/completion, ~4.5 yds/carry) and completion rate
  (~63%) to NFL norms; added per-game `formBias` (hot/cold day) so favourites
  win ~70% (not ~78%) and final scores get realistic spread.

richGameSimulator.ts:
- Per-game form variance (seeded). Wired decideLateGameSequence: victory-
  formation kneels, no-huddle clock savings when trailing late, late-game 4th-
  down playbook, and two-point conversion decisions.
- Emit driveSummary (per-drive result/yards/plays/time-of-possession), threaded
  through gameFlowSummary and the legacy-result adapter for the drive chart UI.

Type safety: tsconfig.sim.json + `npm run check:sim-types` strict-checks both
sim files (no @ts-ignore). Regression tests cover the soak gate thresholds,
matchup determinism/realism, driveSummary emission, and the flipped default.
Full suite: 2555 passing.

Note: simulation/index.js already treats the drive engine as authoritative
(prior waves); the legacy path is retained intentionally as the new engine's
runtime fallback.

https://claude.ai/code/session_013ZdGknsbHvrjYyyPdErA3X