### PR TITLE
fix(engine): post-engine-flip stabilization — OT/tie resolution, standings tiebreakers, archive/score fidelity

### DIFF
--- a/scripts/engineSoak.js
+++ b/scripts/engineSoak.js
@@ -39,6 +39,9 @@ export const SOAK_THRESHOLDS = Object.freeze({
   rushYdsPerGame: { min: 100, max: 130 },
   pointsPerGame: { min: 20, max: 27 },
   maxMsPerGame: 50, // generous upper bound for a headless single-game sim
+  // OT must resolve ties: the rich engine should essentially never return a
+  // tied final (downstream playoff code cannot represent ties).
+  maxFinalTieRate: 0.01,
 });
 
 function parseArgs(argv) {
@@ -112,17 +115,32 @@ function newAccumulator(teamCount) {
     wins: new Array(teamCount).fill(0),
     losses: new Array(teamCount).fill(0),
     minTeamScore: Infinity,
+    // Tie / shutout-floor observability (FIX 1 / FIX 6). regulationTies and
+    // floorTeamGames are only reported by the matchup engine; tracksOvertime
+    // stays false for engines that don't expose the flags so summarize() can
+    // report n/a instead of a misleading 0.
+    finalTies: 0,
+    regulationTies: 0,
+    floorTeamGames: 0,
+    tracksOvertime: false,
   };
 }
 
-function recordGame(acc, homeIdx, awayIdx, homeScore, awayScore, homePassYd, homeRushYd, awayPassYd, awayRushYd) {
+function recordGame(acc, homeIdx, awayIdx, g) {
+  const { homeScore, awayScore } = g;
   acc.games += 1;
   acc.teamGames += 2;
   acc.points += homeScore + awayScore;
-  acc.passYds += homePassYd + awayPassYd;
-  acc.rushYds += homeRushYd + awayRushYd;
+  acc.passYds += g.homePassYd + g.awayPassYd;
+  acc.rushYds += g.homeRushYd + g.awayRushYd;
   acc.scores.push(homeScore, awayScore);
   acc.minTeamScore = Math.min(acc.minTeamScore, homeScore, awayScore);
+  if (homeScore === awayScore) acc.finalTies += 1;
+  if (g.regulationTied != null) {
+    acc.tracksOvertime = true;
+    if (g.regulationTied) acc.regulationTies += 1;
+    acc.floorTeamGames += Number(g.floorCount ?? 0);
+  }
   if (homeScore >= awayScore) { acc.wins[homeIdx] += 1; acc.losses[awayIdx] += 1; }
   else { acc.wins[awayIdx] += 1; acc.losses[homeIdx] += 1; }
 }
@@ -139,6 +157,10 @@ function simulateLegacyGame(league, homeIdx, awayIdx) {
     homeRushYd: Number(home.rushYds ?? 0),
     awayPassYd: Number(away.passYds ?? 0),
     awayRushYd: Number(away.rushYds ?? 0),
+    // The legacy engine resolves OT internally and does not expose
+    // regulation-tie or shutout-floor flags.
+    regulationTied: null,
+    floorCount: null,
   };
 }
 
@@ -168,6 +190,8 @@ function simulateMatchupGame(league, homeIdx, awayIdx, season, week) {
     homeRushYd: Number(res.teamStats?.home?.rushYd ?? 0),
     awayPassYd: Number(res.teamStats?.away?.passYd ?? 0),
     awayRushYd: Number(res.teamStats?.away?.rushYd ?? 0),
+    regulationTied: Boolean(res.regulationTied),
+    floorCount: Number(res.shutoutFloorApplied?.home ? 1 : 0) + Number(res.shutoutFloorApplied?.away ? 1 : 0),
   };
 }
 
@@ -180,7 +204,7 @@ function runEngine(label, simFn, league, schedule, seasons) {
         try {
           const g = simFn(league, homeIdx, awayIdx, s, w);
           acc.totalMs += performance.now() - t0;
-          recordGame(acc, homeIdx, awayIdx, g.homeScore, g.awayScore, g.homePassYd, g.homeRushYd, g.awayPassYd, g.awayRushYd);
+          recordGame(acc, homeIdx, awayIdx, g);
         } catch (err) {
           acc.totalMs += performance.now() - t0;
           acc.crashes += 1;
@@ -218,6 +242,14 @@ function summarize(acc, ovrByTeam) {
     scoreStdDev: stdDev(acc.scores),
     topQuartileWinPct: topQuartileWinPct(acc, ovrByTeam),
     minTeamScore: acc.minTeamScore === Infinity ? 0 : acc.minTeamScore,
+    // Tie/floor observability. finalTieRate is gated; regulationTieRate is
+    // reported (not gated) so the engine's underlying tie tendency stays
+    // visible even though OT resolves it. preFloorShutoutRate is per
+    // team-game: the floor fires exactly when a side's pre-floor score is 0,
+    // so this doubles as the floor trigger rate.
+    finalTieRate: acc.games > 0 ? acc.finalTies / acc.games : 0,
+    regulationTieRate: acc.tracksOvertime && acc.games > 0 ? acc.regulationTies / acc.games : null,
+    preFloorShutoutRate: acc.tracksOvertime && acc.teamGames > 0 ? acc.floorTeamGames / acc.teamGames : null,
   };
 }
 
@@ -231,7 +263,12 @@ export function evaluateGate(matchup, legacy) {
     { name: 'Stat realism (pass yds/game)', pass: inRange(matchup.passYdsPerGame, t.passYdsPerGame), detail: `${matchup.passYdsPerGame.toFixed(1)} (want ${t.passYdsPerGame.min}–${t.passYdsPerGame.max})` },
     { name: 'Stat realism (rush yds/game)', pass: inRange(matchup.rushYdsPerGame, t.rushYdsPerGame), detail: `${matchup.rushYdsPerGame.toFixed(1)} (want ${t.rushYdsPerGame.min}–${t.rushYdsPerGame.max})` },
     { name: 'Stat realism (points/game)', pass: inRange(matchup.pointsPerGame, t.pointsPerGame), detail: `${matchup.pointsPerGame.toFixed(1)} (want ${t.pointsPerGame.min}–${t.pointsPerGame.max})` },
-    { name: 'Score floor — no team should score fewer than 3 pts in any game', pass: matchup.minTeamScore >= 3, detail: `min individual team score: ${matchup.minTeamScore}` },
+    // FLOOR REGRESSION CHECK ONLY: the end-of-game shutout floor guarantees
+    // minTeamScore >= 3 by construction, so this no longer measures scoring
+    // health — it just trips if the floor itself regresses. The underlying
+    // scoring tail is reported separately as preFloorShutoutRate.
+    { name: 'Floor regression check (shutout floor guarantees >= 3; not a scoring-health gate)', pass: matchup.minTeamScore >= 3, detail: `min individual team score: ${matchup.minTeamScore}` },
+    { name: 'Final tie rate (OT must resolve ties)', pass: Number(matchup.finalTieRate ?? 0) <= t.maxFinalTieRate, detail: `${((matchup.finalTieRate ?? 0) * 100).toFixed(2)}% of games (max ${(t.maxFinalTieRate * 100).toFixed(0)}%)` },
     { name: 'Score variance (PBP std-dev >= legacy)', pass: matchup.scoreStdDev >= legacy.scoreStdDev, detail: `PBP ${matchup.scoreStdDev.toFixed(2)} vs legacy ${legacy.scoreStdDev.toFixed(2)}` },
     { name: 'Performance (ms/game)', pass: matchup.msPerGame <= t.maxMsPerGame, detail: `${matchup.msPerGame.toFixed(3)} ms (max ${t.maxMsPerGame})` },
     { name: 'Crash/error rate (zero throws)', pass: matchup.crashes === 0, detail: `${matchup.crashes} crashes` },
@@ -271,6 +308,12 @@ export function runEngineSoak({ seasons = 100, teams = 32, seed = 20260605 } = {
   Utils.setSeed(seed);
   const stubs = buildTeamStubs(teams);
   const league = makeLeague(stubs, {}, { Constants, Utils, makePlayer });
+  // makeLeague seeds per-save entropy from Math.random (league.globalSeed) and
+  // the legacy drive engine mixes it into its per-game seeds, which made the
+  // legacy comparison baseline — and therefore the comparative variance gate —
+  // nondeterministic across identical soak invocations. Pin it to the CLI seed
+  // so the whole soak is reproducible.
+  league.globalSeed = seed >>> 0;
   applyTalentTiers(league);
   const ovrByTeam = league.teams.map((t) => t.ovr);
   const schedule = buildSchedule(teams, 17);
@@ -296,6 +339,10 @@ function printReport(report) {
   console.log(row('rush yds / game', legacy.rushYdsPerGame.toFixed(1), matchup.rushYdsPerGame.toFixed(1)));
   console.log(row('score std-dev', legacy.scoreStdDev.toFixed(2), matchup.scoreStdDev.toFixed(2)));
   console.log(row('min team score', legacy.minTeamScore, matchup.minTeamScore));
+  const pct = (v) => (v == null ? 'n/a' : `${(v * 100).toFixed(2)}%`);
+  console.log(row('regulation tie rate', pct(legacy.regulationTieRate), pct(matchup.regulationTieRate)));
+  console.log(row('final tie rate', pct(legacy.finalTieRate), pct(matchup.finalTieRate)));
+  console.log(row('pre-floor shutout rate', pct(legacy.preFloorShutoutRate), pct(matchup.preFloorShutoutRate)));
   console.log(row('top-quartile win%', (legacy.topQuartileWinPct * 100).toFixed(1) + '%', (matchup.topQuartileWinPct * 100).toFixed(1) + '%'));
   console.log(row('ms / game', legacy.msPerGame.toFixed(3), matchup.msPerGame.toFixed(3)));
   console.log(row('crashes', legacy.crashes, matchup.crashes));

--- a/src/core/__tests__/gameArchive.test.js
+++ b/src/core/__tests__/gameArchive.test.js
@@ -189,3 +189,42 @@ describe('gameArchive helpers', () => {
     expect(game.archiveQuality).toBe('full');
   });
 });
+
+describe('canonical rich-engine teamStats hydration', () => {
+  it('survives archive normalization + enrichment without being re-derived or zeroed', () => {
+    const richSide = {
+      plays: 64, firstDowns: 22, passYd: 251, passYards: 251, rushYd: 104, rushYards: 104,
+      totalYards: 355, yardsPerPlay: 5.55, turnovers: 1, sacksAllowed: 2, sacksMade: 3,
+      redZoneTrips: 4, redZoneScores: 2, fieldGoalsMade: 2, fieldGoalsAttempted: 3,
+      extraPointsMade: 2, extraPointsAttempted: 2,
+    };
+    const archived = normalizeArchivedGamePayload({
+      id: '2031_w3_1_2',
+      seasonId: '2031',
+      week: 3,
+      homeId: 1,
+      awayId: 2,
+      homeScore: 23,
+      awayScore: 20,
+      quarterScores: { home: [3, 7, 3, 10], away: [7, 3, 7, 3] },
+      teamStats: { home: richSide, away: { ...richSide, totalYards: 330 } },
+      playerStats: {
+        home: { 10: { name: 'Home QB', pos: 'QB', stats: { passAtt: 31, passYd: 251, interceptions: 1 } } },
+        away: { 20: { name: 'Away QB', pos: 'QB', stats: { passAtt: 29, passYd: 240, interceptions: 2 } } },
+      },
+      scoringSummary: [{ id: 'score_0', quarter: 1, teamId: 1, points: 3, text: 'FG' }],
+    });
+    const hydrated = enrichArchivedGamePayload(JSON.parse(JSON.stringify(archived)));
+    // Canonical engine line is preserved verbatim — firstDowns / plays /
+    // yardsPerPlay / red-zone data must not be zeroed or re-derived from rows.
+    expect(hydrated.teamStats.home.plays).toBe(64);
+    expect(hydrated.teamStats.home.firstDowns).toBe(22);
+    expect(hydrated.teamStats.home.yardsPerPlay).toBe(5.55);
+    expect(hydrated.teamStats.home.redZoneTrips).toBe(4);
+    expect(hydrated.teamStats.home.redZoneScores).toBe(2);
+    expect(hydrated.teamStats.home.turnovers).toBe(1);
+    expect(hydrated.teamStats.away.totalYards).toBe(330);
+    expect(hydrated.homeScore).toBe(23);
+    expect(hydrated.awayScore).toBe(20);
+  });
+});

--- a/src/core/__tests__/gameSummary.test.js
+++ b/src/core/__tests__/gameSummary.test.js
@@ -4,6 +4,8 @@ import {
   buildDriveSummaryFromSimulation,
   buildQuarterScoresFromScoring,
   buildScoringSummaryFromSimulation,
+  buildTeamStatComparisonFromArchive,
+  resolveCanonicalTeamStats,
 } from '../gameSummary.js';
 
 describe('game summary pipeline', () => {
@@ -45,5 +47,66 @@ describe('game summary pipeline', () => {
       result: expect.any(String),
       points: expect.any(Number),
     }));
+  });
+});
+
+describe('archived team stats (post-engine-flip stabilization)', () => {
+  const context = { homeId: 1, awayId: 2, homeAbbr: 'HME', awayAbbr: 'AWY' };
+  // Rich-engine box-score shape: the QB row's `interceptions` are INTs THROWN
+  // (set to total offensive turnovers), defender rows' are INTs MADE.
+  const boxScore = {
+    home: {
+      hqb: { name: 'Home QB', pos: 'QB', stats: { passAtt: 30, passYd: 250, interceptions: 2 } },
+      hrb: { name: 'Home RB', pos: 'RB', stats: { rushAtt: 18, rushYd: 80, fumblesLost: 1 } },
+      hcb: { name: 'Home CB', pos: 'CB', stats: { interceptions: 1, tackles: 6 } },
+      hedge: { name: 'Home EDGE', pos: 'EDGE', stats: { sacks: 2, tackles: 4 } },
+    },
+    away: {
+      aqb: { name: 'Away QB', pos: 'QB', stats: { passAtt: 28, passYd: 210, interceptions: 1 } },
+      as: { name: 'Away S', pos: 'S', stats: { interceptions: 2, tackles: 5 } },
+    },
+  };
+
+  it('does not count defensive INTs made as offensive turnovers (fallback derivation)', () => {
+    const derived = buildTeamStatComparisonFromArchive(boxScore, context);
+    // Home giveaways: 2 thrown INTs + 1 lost fumble — NOT the CB's pick.
+    expect(derived.home.turnovers).toBe(3);
+    // Away giveaways: 1 thrown INT — NOT the safety's 2 picks.
+    expect(derived.away.turnovers).toBe(1);
+    expect(derived.home.sacks).toBe(2);
+  });
+
+  it('prefers the simulator canonical teamStats and preserves the full line', () => {
+    const richLine = (over) => ({
+      plays: 62, firstDowns: 21, passAtt: 33, passComp: 21, passYd: 245, passYards: 245,
+      passTD: 2, rushAtt: 26, rushYd: 110, rushYards: 110, rushTD: 1, totalYards: 355,
+      yardsPerPlay: 5.73, turnovers: 1, sacksAllowed: 2, sacksMade: 3, interceptions: 1,
+      redZoneTrips: 4, redZoneScores: 3, explosivePlays: 5, successRate: 0.47,
+      fieldGoalsMade: 1, fieldGoalsAttempted: 2, extraPointsMade: 3, extraPointsAttempted: 3,
+      punts: 4, puntYards: 180, kickReturns: 2, kickReturnYards: 44, puntReturns: 1, puntReturnYards: 8,
+      ...over,
+    });
+    const canonical = resolveCanonicalTeamStats(
+      { home: richLine({}), away: richLine({ passYd: 200, passYards: 200, totalYards: 310 }) },
+      boxScore,
+      context,
+    );
+    // The engine's full line survives — not zeroed/dropped by box-row re-derivation.
+    expect(canonical.home.plays).toBe(62);
+    expect(canonical.home.firstDowns).toBe(21);
+    expect(canonical.home.yardsPerPlay).toBe(5.73);
+    expect(canonical.home.redZoneTrips).toBe(4);
+    expect(canonical.home.redZoneScores).toBe(3);
+    expect(canonical.home.turnovers).toBe(1);
+    // Alias keys the Game Book comparison rows read.
+    expect(canonical.home.sacks).toBe(3);
+    expect(canonical.home.passYards).toBe(245);
+    expect(canonical.away.passYards).toBe(200);
+  });
+
+  it('falls back to box-row derivation when the result has no team stats', () => {
+    const fallback = resolveCanonicalTeamStats(null, boxScore, context);
+    expect(fallback.home.passYards).toBe(250);
+    expect(fallback.home.turnovers).toBe(3);
   });
 });

--- a/src/core/__tests__/leaguePulse.test.js
+++ b/src/core/__tests__/leaguePulse.test.js
@@ -63,7 +63,7 @@ describe('leaguePulse.js', () => {
       expect(items).toEqual([]);
     });
 
-    it('generates game result stories', () => {
+    it('generates game result stories (legacy score-object shape)', () => {
       const meta = { season: 1, week: 3, userTeamId: '10' };
       const data = {
         games: [{ home: '10', away: '11', played: true, score: { home: 24, away: 10 } }]
@@ -72,6 +72,48 @@ describe('leaguePulse.js', () => {
       expect(items.length).toBe(1);
       expect(items[0].headline).toBe('Statement Victory');
       expect(items[0].type).toBe(PULSE_TYPES.GAME_RESULT);
+    });
+
+    it('generates game result stories from the worker result shape', () => {
+      // Actual shape produced by mapGameSummaryToLegacyResult / commitGameResult:
+      // scoreHome/homeScore pairs, no `played` flag, no nested `score`.
+      const meta = { season: 1, week: 3, userTeamId: '10' };
+      const data = {
+        games: [{
+          home: '10', away: '11',
+          scoreHome: 27, scoreAway: 24,
+          homeScore: 27, awayScore: 24,
+        }],
+      };
+      const items = generateLeaguePulseItems(meta, data);
+      expect(items.length).toBe(1);
+      expect(items[0].headline).toBe('Nail-Biter Win');
+      expect(items[0].type).toBe(PULSE_TYPES.GAME_RESULT);
+    });
+
+    it('prefers canonical scores over a stale legacy score object', () => {
+      const meta = { season: 1, week: 3, userTeamId: '10' };
+      const data = {
+        games: [{
+          home: '10', away: '11',
+          scoreHome: 13, scoreAway: 31,
+          // Stale legacy object disagreeing with the canonical fields.
+          played: true, score: { home: 99, away: 0 },
+        }],
+      };
+      const items = generateLeaguePulseItems(meta, data);
+      expect(items.length).toBe(1);
+      // 13-31 is an 18-point loss → blowout-loss copy, not a 99-0 win.
+      expect(items[0].headline).toBe('Tough Blowout Loss');
+      expect(items[0].body).toContain('13-31');
+    });
+
+    it('skips games with no recorded score (unplayed schedule rows)', () => {
+      const meta = { season: 1, week: 3, userTeamId: '10' };
+      const data = {
+        games: [{ home: '10', away: '11', played: false }],
+      };
+      expect(generateLeaguePulseItems(meta, data)).toEqual([]);
     });
 
     it('generates standings pressure stories', () => {

--- a/src/core/__tests__/richGameSimulatorOvertime.test.ts
+++ b/src/core/__tests__/richGameSimulatorOvertime.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { mapOverallToAttributesV2 } from '../migration/attributeMigrator.ts';
+import { simulateRichGame } from '../sim/richGameSimulator.ts';
+import type { RichGameSummary } from '../sim/richGameSimulator.ts';
+
+// Post-engine-flip stabilization coverage (audit at 9e5de0a):
+// 1. The rich engine must never return a tied final score — downstream playoff
+//    code resolves homeScore >= awayScore as a silent home win.
+// 2. scoringSummary points must come from score deltas, not a hardcoded 7,
+//    so two-point conversions reconcile with the final score.
+
+function buildPayload(seed: number) {
+  return {
+    gameId: `ot-${seed}`,
+    homeTeamId: 1,
+    awayTeamId: 2,
+    seed,
+    weather: 'clear' as const,
+    // Evenly matched units maximise the chance of regulation ties so the OT
+    // path gets real coverage inside the seed sweep below.
+    homeOffense: mapOverallToAttributesV2(80, 5.5, `h-off-${seed}`),
+    awayOffense: mapOverallToAttributesV2(80, 5.5, `a-off-${seed}`),
+    homeDefense: mapOverallToAttributesV2(80, 5.5, `h-def-${seed}`),
+    awayDefense: mapOverallToAttributesV2(80, 5.5, `a-def-${seed}`),
+  };
+}
+
+const SEED_SWEEP = Array.from({ length: 400 }, (_, i) => i + 1);
+
+function sumQuarterScores(summary: RichGameSummary, side: 'home' | 'away'): number {
+  return summary.quarterScores[side].reduce((acc, q) => acc + q, 0);
+}
+
+function sumScoringSummary(summary: RichGameSummary, teamId: number): number {
+  return summary.scoringSummary
+    .filter((event) => event.teamId === teamId)
+    .reduce((acc, event) => acc + event.points, 0);
+}
+
+describe('simulateRichGame overtime', () => {
+  const games = SEED_SWEEP.map((seed) => simulateRichGame(buildPayload(seed)));
+  const overtimeGames = games.filter((g) => g.overtime.played);
+
+  it('never returns a tied final score', () => {
+    for (const game of games) {
+      expect(game.homeScore).not.toBe(game.awayScore);
+    }
+  });
+
+  it('the seed sweep actually exercises regulation ties and OT', () => {
+    expect(games.some((g) => g.regulationTied)).toBe(true);
+    expect(overtimeGames.length).toBeGreaterThan(0);
+  });
+
+  it('resolves every regulation tie through overtime (or the explicit seeded fallback)', () => {
+    for (const game of games.filter((g) => g.regulationTied)) {
+      expect(game.overtime.played || game.overtime.decidedBy === 'deadlock_fg').toBe(true);
+      expect(game.overtime.decidedBy).not.toBeNull();
+    }
+  });
+
+  it('emits the OT winner digest event and extends quarterScores per OT period', () => {
+    for (const game of overtimeGames) {
+      expect(game.quarterScores.home).toHaveLength(4 + game.overtime.periods);
+      expect(game.quarterScores.away).toHaveLength(4 + game.overtime.periods);
+      // playDigest is capped at the first 12 digest events, so the OT winner
+      // event may fall outside it — but a score-decided OT always leaves a
+      // quarter > 4 row in scoringSummary, and the fallback marks decidedBy.
+      const winnerText = `OT — ${game.homeScore > game.awayScore ? 'Home' : 'Away'} wins in overtime`;
+      const inDigest = game.playDigest.some((e) => e.text.startsWith(winnerText));
+      const otScore = game.scoringSummary.some((e) => e.quarter > 4);
+      expect(inDigest || otScore || game.overtime.decidedBy === 'deadlock_fg').toBe(true);
+    }
+  });
+
+  it('keeps quarterScores, teamStats, and final score internally consistent in every game', () => {
+    for (const game of games) {
+      expect(sumQuarterScores(game, 'home')).toBe(game.homeScore);
+      expect(sumQuarterScores(game, 'away')).toBe(game.awayScore);
+      for (const side of ['home', 'away'] as const) {
+        const line = game.teamStats[side];
+        const score = side === 'home' ? game.homeScore : game.awayScore;
+        const tds = line.passTD + line.rushTD;
+        const base = tds * 6 + line.fieldGoalsMade * 3 + line.extraPointsMade;
+        const residual = score - base;
+        // Residual is the two-point conversions: even, non-negative, at most 2/TD.
+        expect(residual).toBeGreaterThanOrEqual(0);
+        expect(residual % 2).toBe(0);
+        expect(residual).toBeLessThanOrEqual(2 * tds);
+      }
+    }
+  });
+
+  it('is deterministic for a fixed seed, including OT games', () => {
+    const otSeed = SEED_SWEEP.find((seed, idx) => games[idx].overtime.played);
+    expect(otSeed).toBeDefined();
+    const one = simulateRichGame(buildPayload(otSeed as number));
+    const two = simulateRichGame(buildPayload(otSeed as number));
+    expect(one).toEqual(two);
+  });
+});
+
+describe('simulateRichGame scoringSummary points', () => {
+  const games = SEED_SWEEP.map((seed) => simulateRichGame(buildPayload(seed)));
+
+  it('reconciles scoringSummary points with the final score in every game', () => {
+    for (const game of games) {
+      expect(sumScoringSummary(game, 1)).toBe(game.homeScore);
+      expect(sumScoringSummary(game, 2)).toBe(game.awayScore);
+    }
+  });
+
+  it('covers the two-point path (a TD row worth 6 or 8, not the old hardcoded 7)', () => {
+    const tdRows = games.flatMap((g) => g.scoringSummary.filter((e) => e.scoreType === 'touchdown'));
+    expect(tdRows.some((row) => row.points === 8 || row.points === 6)).toBe(true);
+    for (const row of tdRows) {
+      expect([6, 7, 8]).toContain(row.points);
+    }
+  });
+
+  it('keeps every field goal row at 3 points', () => {
+    for (const game of games) {
+      for (const row of game.scoringSummary.filter((e) => e.scoreType === 'field_goal')) {
+        expect(row.points).toBe(3);
+      }
+    }
+  });
+});

--- a/src/core/gameSummary.js
+++ b/src/core/gameSummary.js
@@ -221,6 +221,7 @@ export function buildTeamStatComparisonFromArchive(boxScore = {}, context = {}) 
     byTeam[row.teamId].push(row);
   });
   const sum = (teamRows, key) => teamRows.reduce((acc, row) => acc + asNum(row.stats?.[key]), 0);
+  const sumIf = (teamRows, key, predicate) => teamRows.reduce((acc, row) => (predicate(row.stats ?? {}) ? acc + asNum(row.stats?.[key]) : acc), 0);
   const buildSide = (teamId) => {
     const teamRows = byTeam[teamId] ?? [];
     const passYards = sum(teamRows, 'passYd');
@@ -230,8 +231,12 @@ export function buildTeamStatComparisonFromArchive(boxScore = {}, context = {}) 
       passYards,
       rushYards,
       firstDowns: sum(teamRows, 'firstDowns'),
-      turnovers: sum(teamRows, 'interceptions') + sum(teamRows, 'fumblesLost'),
-      sacks: sum(teamRows, 'sacks'),
+      // Offensive turnovers only: 'interceptions' on a passer row (passAtt > 0)
+      // means INTs thrown; on a defender row it means INTs made — summing both
+      // double-counted takeaways into the team's giveaway column. Same filter
+      // as gameArchive.deriveTeamStatsFromPlayerRows.
+      turnovers: sumIf(teamRows, 'interceptions', (stats) => asNum(stats?.passAtt) > 0) + sum(teamRows, 'fumblesLost'),
+      sacks: sumIf(teamRows, 'sacks', (stats) => asNum(stats?.passAtt) === 0),
       thirdDownMade: sum(teamRows, 'thirdDownMade'),
       thirdDownAtt: sum(teamRows, 'thirdDownAtt'),
       redZoneMade: sum(teamRows, 'redZoneMade'),
@@ -241,6 +246,30 @@ export function buildTeamStatComparisonFromArchive(boxScore = {}, context = {}) 
     };
   };
   return { home: buildSide(Number(context.homeId)), away: buildSide(Number(context.awayId)) };
+}
+
+/**
+ * Canonical team-comparison stats for the archive. Prefers the simulator's own
+ * result.teamStats (the rich engine and the legacy commit path both emit a
+ * full canonical line with plays / yardsPerPlay / firstDowns / red-zone data —
+ * re-deriving from box-score rows dropped all of those and inflated turnovers)
+ * and falls back to the box-score derivation only for results that carry no
+ * team stats at all. Pass-through adds the alias keys the Game Book comparison
+ * reads (`sacks`, `passYards`/`rushYards`).
+ */
+export function resolveCanonicalTeamStats(resultTeamStats, boxScore = {}, context = {}) {
+  const hasSide = (side) => Boolean(side && typeof side === 'object' && Object.keys(side).length > 0);
+  if (hasSide(resultTeamStats?.home) && hasSide(resultTeamStats?.away)) {
+    const withAliases = (side) => ({
+      ...side,
+      sacks: side.sacks ?? side.sacksMade,
+      passYards: side.passYards ?? side.passYd,
+      rushYards: side.rushYards ?? side.rushYd,
+      totalYards: side.totalYards ?? (asNum(side.passYd ?? side.passYards) + asNum(side.rushYd ?? side.rushYards)),
+    });
+    return { home: withAliases(resultTeamStats.home), away: withAliases(resultTeamStats.away) };
+  }
+  return buildTeamStatComparisonFromArchive(boxScore, context);
 }
 
 export function classifyGameScript({ homeScore = 0, awayScore = 0, isPlayoff = false, wentOvertime = false, wasUpset = false }) {

--- a/src/core/leaguePulse.js
+++ b/src/core/leaguePulse.js
@@ -112,17 +112,29 @@ export function generateLeaguePulseItems(meta, data = {}) {
   if (!userTeamId) return items;
 
   // 1. GAME RESULT STORY
-  // Only process if games exist for the exact week
+  // Only process if games exist for the exact week. The worker feeds completed
+  // result objects shaped { scoreHome/homeScore, scoreAway/awayScore }; the
+  // legacy { played, score: { home, away } } shape is a fallback only, and the
+  // canonical fields always win over it. A finite score pair IS the
+  // completed-game signal — result objects never carried a `played` flag,
+  // which is why this story never fired.
+  const readScore = (g, side) => {
+    const canonical = side === 'home'
+      ? (g?.scoreHome ?? g?.homeScore)
+      : (g?.scoreAway ?? g?.awayScore);
+    const value = Number(canonical ?? (side === 'home' ? g?.score?.home : g?.score?.away));
+    return Number.isFinite(value) ? value : null;
+  };
   const userGame = games.find(g =>
     (String(g.home) === String(userTeamId) || String(g.away) === String(userTeamId)) &&
-    g.played === true &&
-    g.score != null
+    readScore(g, 'home') != null &&
+    readScore(g, 'away') != null
   );
 
   if (userGame) {
     const isHome = String(userGame.home) === String(userTeamId);
-    const userScore = isHome ? userGame.score.home : userGame.score.away;
-    const oppScore = isHome ? userGame.score.away : userGame.score.home;
+    const userScore = isHome ? readScore(userGame, 'home') : readScore(userGame, 'away');
+    const oppScore = isHome ? readScore(userGame, 'away') : readScore(userGame, 'home');
     const oppTeamId = isHome ? userGame.away : userGame.home;
     const won = userScore > oppScore;
     const diff = Math.abs(userScore - oppScore);

--- a/src/core/sim/richGameSimulator.ts
+++ b/src/core/sim/richGameSimulator.ts
@@ -60,7 +60,7 @@ export interface GameEventDigestItem {
   quarter: number;
   clockSec: number;
   team: 'home' | 'away' | 'neutral';
-  type: 'touchdown' | 'field_goal' | 'turnover' | 'sack' | 'explosive_play' | 'lead_change' | 'swing' | 'final_takeaway';
+  type: 'touchdown' | 'field_goal' | 'turnover' | 'sack' | 'explosive_play' | 'lead_change' | 'swing' | 'final_takeaway' | 'overtime';
   text: string;
   homeScore: number;
   awayScore: number;
@@ -117,6 +117,17 @@ export interface RichGameSummary {
     headlineMoments: string[];
   };
   recapText: string;
+  /** True when regulation (4 quarters) ended with the score level. */
+  regulationTied: boolean;
+  /**
+   * Overtime outcome. The rich engine never returns a tied final score:
+   * downstream playoff code resolves `homeScore >= awayScore` as a silent home
+   * win, so every tie is resolved here — by sudden-death OT play, or (after
+   * capped OT periods) by a seeded walk-off field goal.
+   */
+  overtime: { played: boolean; periods: number; decidedBy: 'score' | 'deadlock_fg' | null };
+  /** Which sides received the end-of-game shutout floor FG (pre-floor score was 0). */
+  shutoutFloorApplied: { home: boolean; away: boolean };
   advancedAttribution?: Record<string, AdvancedGameStats>;
   simFactors: {
     home: { qbRating: number; rushYpc: number; successRate: number; passRate: number };
@@ -399,20 +410,75 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
 
   // Late-game scoring floor: NFL shutouts are vanishingly rare (<0.5% of games
   // since 1990), so a team still scoreless at the final whistle is credited a
-  // late FG. Applied only at game end so the floor lifts the 0-point tail
-  // without compressing overall score variance.
+  // late FG. Applied only at the end of regulation so the floor lifts the
+  // 0-point tail without compressing overall score variance.
+  const shutoutFloorApplied = { home: false, away: false };
   const applyShutoutFloor = (team: 'home' | 'away') => {
     if ((team === 'home' ? state.homeScore : state.awayScore) !== 0) return;
     if (team === 'home') state.homeScore += 3;
     else state.awayScore += 3;
     quarterScores[team][3] += 3;
+    shutoutFloorApplied[team] = true;
     const teamStats = team === 'home' ? stats.home : stats.away;
     teamStats.fieldGoalsAttempted += 1;
     teamStats.fieldGoalsMade += 1;
     pushDigest(digest, { quarter: 4, clockSec: state.clockSec, team, type: 'field_goal', text: `Late FG — ${team === 'home' ? 'Home' : 'Away'} avoids shutout.` }, state);
   };
 
-  while (state.quarter <= 4 && (stats.home.plays + stats.away.plays) < 184) {
+  // ── Overtime ────────────────────────────────────────────────────────────────
+  // Phase context (regular season vs playoff) is not available in this payload,
+  // so the safe default is applied: EVERY tie is resolved in OT — sudden death,
+  // first lead wins. Downstream code (advancePlayoffBracket, Super Bowl
+  // announcement) silently treats homeScore >= awayScore as a home win, so a
+  // tied final from this engine would crown a winner the box score contradicts.
+  // Regular-season ties can be reintroduced only once that worker logic is
+  // phase-aware (out of scope here — see audit at 9e5de0a).
+  const MAX_OT_PERIODS = 4;
+  const OT_PERIOD_SECONDS = 600;
+  let regulationTied = false;
+  let otPeriods = 0;
+  let otDecidedBy: 'score' | 'deadlock_fg' | null = null;
+  const startOvertimePeriod = () => {
+    otPeriods += 1;
+    state.quarter += 1;
+    state.clockSec = OT_PERIOD_SECONDS;
+    quarterScores.home.push(0);
+    quarterScores.away.push(0);
+    // Seeded coin toss for first OT possession; fresh drive from the 25.
+    state.possession = rng() <= 0.5 ? 'home' : 'away';
+    state.down = 1;
+    state.distance = 10;
+    state.yardLine = 25;
+    if (curDrive.plays > 0) closeDrive('Downs');
+    else curDrive = { team: state.possession, plays: 0, yards: 0, seconds: 0 };
+    pushDigest(digest, { quarter: state.quarter, clockSec: state.clockSec, team: 'neutral', type: 'overtime', text: `Tied after ${state.quarter - 1 === 4 ? 'regulation' : 'overtime'} — OT period ${otPeriods} begins.` }, state);
+  };
+
+  // Shared end-of-period transition. Returns true when the game is over.
+  // At the end of Q4 the shutout floor is applied BEFORE the tie check, so a
+  // floored 3-3 (or a 3-0 kneel-out floored to 3-3) goes to OT instead of
+  // ending tied or being re-tied after the fact.
+  const handlePeriodEnd = (): boolean => {
+    if (state.quarter < 4) {
+      state.quarter += 1;
+      state.clockSec = 900;
+      return false;
+    }
+    if (state.quarter === 4) {
+      applyShutoutFloor('home');
+      applyShutoutFloor('away');
+      regulationTied = state.homeScore === state.awayScore;
+    }
+    if (state.homeScore !== state.awayScore) return true;
+    if (otPeriods >= MAX_OT_PERIODS) return true;
+    startOvertimePeriod();
+    return false;
+  };
+
+  // Hard play-cap safety: regulation budget plus one period's worth per OT.
+  const playCap = () => 184 + otPeriods * 46;
+
+  while ((stats.home.plays + stats.away.plays) < playCap()) {
     const offenseLead = state.possession === 'home'
       ? state.homeScore - state.awayScore
       : state.awayScore - state.homeScore;
@@ -440,7 +506,7 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
       state.down = Math.min(4, state.down + 1);
       state.distance += 1;
       if (state.clockSec <= 0) {
-        if (state.quarter < 4) { state.quarter += 1; state.clockSec = 900; } else break;
+        if (handlePeriodEnd()) break;
       }
       continue;
     }
@@ -650,20 +716,43 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
       pushDigest(digest, { quarter: state.quarter, clockSec: state.clockSec, team: 'neutral', type: 'swing', text: 'Late-game swing tightened the finish.' }, state);
     }
 
+    // Sudden-death overtime: OT periods start level, so the first lead wins.
+    if (state.quarter > 4 && state.homeScore !== state.awayScore) {
+      const otWinner = state.homeScore > state.awayScore ? 'home' : 'away';
+      otDecidedBy = 'score';
+      pushDigest(digest, { quarter: state.quarter, clockSec: state.clockSec, team: otWinner, type: 'overtime', text: `OT — ${otWinner === 'home' ? 'Home' : 'Away'} wins in overtime.` }, state);
+      break;
+    }
+
     if (state.clockSec <= 0) {
-      if (state.quarter < 4) {
-        state.quarter += 1;
-        state.clockSec = 900;
-      } else {
-        break;
-      }
+      if (handlePeriodEnd()) break;
     }
   }
 
+  // Covers exits that never reach a Q4 clock expiry (play-cap safety valve);
+  // no-ops when the floor already ran inside handlePeriodEnd.
   applyShutoutFloor('home');
   applyShutoutFloor('away');
 
-  pushDigest(digest, { quarter: 4, clockSec: 0, team: 'neutral', type: 'final_takeaway', text: `${state.homeScore === state.awayScore ? 'Game ends level' : `${state.homeScore > state.awayScore ? 'Home' : 'Away'} closes it out`} in a ${Math.abs(state.homeScore - state.awayScore)}-point game.` }, state);
+  // Deadlock fallback: only reachable when the play cap tripped or all capped
+  // OT periods ended level. Seeded, deterministic walk-off FG — never an
+  // OVR-based award — with an explicit digest event. Guarantees a non-tied
+  // final score (downstream playoff code cannot represent ties).
+  if (state.homeScore === state.awayScore) {
+    if (otPeriods === 0) regulationTied = true;
+    const fallbackWinner: 'home' | 'away' = rng() <= 0.5 ? 'home' : 'away';
+    if (fallbackWinner === 'home') state.homeScore += 3;
+    else state.awayScore += 3;
+    quarterScores[fallbackWinner][quarterScores[fallbackWinner].length - 1] += 3;
+    const fallbackStats = fallbackWinner === 'home' ? stats.home : stats.away;
+    fallbackStats.fieldGoalsAttempted += 1;
+    fallbackStats.fieldGoalsMade += 1;
+    otDecidedBy = 'deadlock_fg';
+    pushDigest(digest, { quarter: state.quarter, clockSec: 0, team: fallbackWinner, type: 'field_goal', text: `Walk-off FG — ${fallbackWinner === 'home' ? 'Home' : 'Away'} ends the deadlock.` }, state);
+    pushDigest(digest, { quarter: state.quarter, clockSec: 0, team: fallbackWinner, type: 'overtime', text: `OT — ${fallbackWinner === 'home' ? 'Home' : 'Away'} wins in overtime (seeded deadlock resolution).` }, state);
+  }
+
+  pushDigest(digest, { quarter: Math.max(4, state.quarter), clockSec: 0, team: 'neutral', type: 'final_takeaway', text: `${state.homeScore === state.awayScore ? 'Game ends level' : `${state.homeScore > state.awayScore ? 'Home' : 'Away'} closes it out`} in a ${Math.abs(state.homeScore - state.awayScore)}-point game.` }, state);
 
   const topReasons = [...reasonMap.entries()].sort((a, b) => b[1] - a[1]).map(([reason]) => reason).slice(0, 2);
 
@@ -850,20 +939,31 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
     scoreHomeAfter: event.homeScore,
     scoreAwayAfter: event.awayScore,
   }));
+  // Points per scoring event come from the digest's running score snapshots
+  // (delta between consecutive scoring events), never from the event type:
+  // touchdowns are worth 6, 7, or 8 depending on the XP / two-point outcome,
+  // and a hardcoded 7 made summaries contradict the final score.
+  let scoredHomeSoFar = 0;
+  let scoredAwaySoFar = 0;
   const scoringSummary = digest
     .filter((event) => event.type === 'touchdown' || event.type === 'field_goal')
-    .map((event, idx) => ({
-      id: `score_${idx}`,
-      quarter: event.quarter,
-      clock: formatClock(event.clockSec),
-      teamId: event.team === 'home' ? payload.homeTeamId : payload.awayTeamId,
-      teamAbbr: event.team === 'home' ? 'Home' : 'Away',
-      type: event.type === 'touchdown' ? 'Touchdown' : 'Field Goal',
-      scoreType: event.type,
-      points: event.type === 'touchdown' ? 7 : 3,
-      text: event.text,
-      scoreAfter: { home: event.homeScore, away: event.awayScore },
-    }));
+    .map((event, idx) => {
+      const points = Math.max(0, (event.homeScore - scoredHomeSoFar) + (event.awayScore - scoredAwaySoFar));
+      scoredHomeSoFar = event.homeScore;
+      scoredAwaySoFar = event.awayScore;
+      return {
+        id: `score_${idx}`,
+        quarter: event.quarter,
+        clock: formatClock(event.clockSec),
+        teamId: event.team === 'home' ? payload.homeTeamId : payload.awayTeamId,
+        teamAbbr: event.team === 'home' ? 'Home' : 'Away',
+        type: event.type === 'touchdown' ? 'Touchdown' : 'Field Goal',
+        scoreType: event.type,
+        points,
+        text: event.text,
+        scoreAfter: { home: event.homeScore, away: event.awayScore },
+      };
+    });
 
   const recapText = `${state.homeScore > state.awayScore ? 'Home' : 'Away'} wins ${Math.max(state.homeScore, state.awayScore)}-${Math.min(state.homeScore, state.awayScore)}. ${topReasons[0] ?? 'Balanced execution'} set the tone.`;
 
@@ -893,6 +993,9 @@ export function simulateRichGame(payload: RichMatchupPayload): RichGameSummary {
       headlineMoments: digest.slice(0, 3).map((event) => event.text),
     },
     recapText,
+    regulationTied,
+    overtime: { played: otPeriods > 0, periods: otPeriods, decidedBy: otDecidedBy },
+    shutoutFloorApplied: { home: shutoutFloorApplied.home, away: shutoutFloorApplied.away },
     advancedAttribution: Object.fromEntries(advancedAttribution),
     simFactors: {
       home: {

--- a/src/core/sim/weekSimulationBridge.ts
+++ b/src/core/sim/weekSimulationBridge.ts
@@ -122,6 +122,8 @@ export function mapGameSummaryToLegacyResult(summary: GameSummary) {
     awayScore: summary.awayScore,
     recapText: summary.recapText ?? (summary.topReason1 ? `${summary.topReason1}. ${summary.topReason2 ?? ''}`.trim() : null),
     recap: summary.recapText ?? null,
+    overtime: summary.overtime ?? null,
+    regulationTied: summary.regulationTied ?? false,
     quarterScores: summary.quarterScores,
     driveSummary: summary.driveSummary ?? [],
     boxScore: summary.boxScore,

--- a/src/views/standingsView.js
+++ b/src/views/standingsView.js
@@ -63,7 +63,7 @@ function seededCoinKey(seed, teamId) {
  * Falls back to empty context (every step ties) when no game data is present,
  * which preserves the simple win% ordering for minimal/preseason states.
  */
-function buildTiebreakContext(teams, schedule) {
+export function buildTiebreakContext(teams, schedule) {
   const teamById = new Map(teams.map((t) => [Number(t.id), t]));
   const winPctById = new Map(teams.map((t) => [Number(t.id), t.winPct]));
   const ctx = new Map();
@@ -125,7 +125,7 @@ function buildTiebreakContext(teams, schedule) {
 // SOS → point diff/points (deterministic fallbacks) → seeded coin-flip.
 // Note: 3+-way ties are resolved pairwise rather than via full mini-leagues — a
 // pragmatic approximation that still honours the documented chain order.
-function makeStandingsComparator(ctx, seed) {
+export function makeStandingsComparator(ctx, seed) {
   return (a, b) => {
     if (b.winPct !== a.winPct) return b.winPct - a.winPct;
     const ca = ctx.get(Number(a.id));
@@ -169,6 +169,35 @@ function makeStandingsComparator(ctx, seed) {
     if (b.ptsFor !== a.ptsFor) return b.ptsFor - a.ptsFor;
     return seededCoinKey(seed, a.id) - seededCoinKey(seed, b.id);
   };
+}
+
+/**
+ * Sort flat standings rows with the full NFL tiebreaker chain. This is the
+ * worker's entry point (its rows use `pct`/`pf`/`pa`): rows are enriched with
+ * the comparator's field names, the tiebreak context is derived from the
+ * played games in the slim schedule, and ordering is fully deterministic for
+ * a given save (seeded coin-flip is the only post-SOS step).
+ *
+ * @param {Array<object>} rows - standings rows ({ id, conf, div, wins, losses,
+ *   ties } plus `pct`/`pf`/`pa` or `winPct`/`ptsFor`/`ptsAgainst`)
+ * @param {object|null} schedule - slim schedule ({ weeks: [{ games }] }) with
+ *   homeScore/awayScore written on played games
+ * @param {number} seed - per-save seed for the final deterministic coin-flip
+ */
+export function sortStandingsRows(rows = [], schedule = null, seed = 0) {
+  const enriched = rows.map((row) => {
+    const ptsFor = Number(row?.ptsFor ?? row?.pf ?? 0);
+    const ptsAgainst = Number(row?.ptsAgainst ?? row?.pa ?? 0);
+    return {
+      ...row,
+      winPct: Number(row?.winPct ?? row?.pct ?? 0),
+      ptsFor,
+      ptsAgainst,
+      pointDiff: ptsFor - ptsAgainst,
+    };
+  });
+  const ctx = buildTiebreakContext(enriched, schedule);
+  return [...enriched].sort(makeStandingsComparator(ctx, Number(seed) || 0));
 }
 
 /**

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -171,9 +171,9 @@ import {
   buildGameNarrativeSummary,
   buildPlayerLeadersFromArchive,
   buildScoringSummaryFromSimulation,
-  buildTeamStatComparisonFromArchive,
   buildTurningPointsFromGameEvents,
   classifyGameScript,
+  resolveCanonicalTeamStats,
   summarizeWhyTeamWon,
 } from '../core/gameSummary.js';
 import { getScoutingRangeFromProfile, scoreDraftBoardEntry } from '../core/draft/draftScouting.js';
@@ -208,6 +208,7 @@ import {
   buildRatingMatrix,
   buildScheduleBuffer,
 } from './serialization.js';
+import { sortStandingsRows } from '../views/standingsView.js';
 
 // ── DB Reload Guard ───────────────────────────────────────────────────────────
 // Register a callback with db/index.js so that when IDB fires onblocked or
@@ -3683,7 +3684,10 @@ function applyGameResultToCache(result, week, seasonId) {
       ? result.drives
       : buildDriveSummaryFromSimulation(playLogs, archiveContext));
   const turningPoints = buildTurningPointsFromGameEvents(playLogs, archiveContext);
-  const teamStats = buildTeamStatComparisonFromArchive(result.boxScore ?? {}, archiveContext);
+  // Prefer the simulator's canonical team stats (full line incl. plays,
+  // yardsPerPlay, firstDowns, red-zone data); re-derive from box-score rows
+  // only when the result carries none.
+  const teamStats = resolveCanonicalTeamStats(result.teamStats, result.boxScore ?? {}, archiveContext);
   const playerLeaders = buildPlayerLeadersFromArchive(result.boxScore ?? {}, archiveContext);
   const getRating = (team, key) => Number(team?.[key] ?? team?.[`${key}Rating`] ?? team?.[`${key}Ovr`] ?? team?.ovr ?? 0);
   const countInjured = (roster = []) => roster.filter((player) => {
@@ -3732,7 +3736,9 @@ function applyGameResultToCache(result, week, seasonId) {
     topReceiver: normalizeLeaderForTeam(playerLeaders?.categories?.receiving, aId),
     teamStats: teamStats?.away,
   });
-  const wentOvertime = playLogs.some((log) => Number(log?.quarter) > 4);
+  // Rich-engine results carry an explicit overtime flag (playLogs are capped at
+  // the first 20 digest events, so OT entries near the end may not appear there).
+  const wentOvertime = result?.overtime?.played === true || playLogs.some((log) => Number(log?.quarter) > 4);
   const rivalryGame = Boolean(homeTeamSnapshot?.conf && awayTeamSnapshot?.conf && homeTeamSnapshot?.conf === awayTeamSnapshot?.conf && homeTeamSnapshot?.div === awayTeamSnapshot?.div);
   const gameScript = classifyGameScript({
     homeScore: scoreHome,
@@ -3928,9 +3934,17 @@ function markWeekPlayed(slimSchedule, week) {
   cache.setMeta({ schedule: slimSchedule });
 }
 
-/** Build a standings array sorted by win% for the current state. */
+/**
+ * Build the standings array for the current state, ordered by the full NFL
+ * tiebreaker chain (win% → head-to-head → division → common games →
+ * conference → SOS → point diff → seeded coin-flip) via
+ * standingsView.makeStandingsComparator. The tiebreak context comes from the
+ * played scores in the slim schedule; the seeded coin-flip keys off the
+ * save's globalSeed, so ordering is deterministic for identical saves.
+ */
 function buildStandings() {
-  return cache.getAllTeams()
+  const meta = cache.getMeta() ?? {};
+  const rows = cache.getAllTeams()
     .map(t => ({
       id:      t.id,
       name:    t.name,
@@ -3943,8 +3957,8 @@ function buildStandings() {
       pf:      t.ptsFor  ?? 0,
       pa:      t.ptsAgainst ?? 0,
       pct:     winPct(t),
-    }))
-    .sort((a, b) => b.pct - a.pct || b.pf - a.pf);
+    }));
+  return sortStandingsRows(rows, meta?.schedule ?? null, Number(meta?.globalSeed ?? 0));
 }
 
 function winPct(t) {
@@ -10963,7 +10977,18 @@ async function handleWatchGame(payload, id) {
 
   const userGame = league._weekGames[userGameIndex];
 
-  // Simulate JUST the user game, passing options to generate logs
+  // Simulate JUST the user game, passing options to generate logs.
+  //
+  // ENGINE ROUTING — INTENTIONAL: watched games run the LEGACY simulator even
+  // when useNewSimulationEngine is on. The LiveGameViewer streams the granular
+  // per-play logs that only simulateBatch({ generateLogs: true }) produces;
+  // the rich engine (simulateRichGame) emits a capped post-game digest, not a
+  // live play feed, so routing it here would break the viewer. Known trade-off
+  // until then: the watched game uses legacy scoring/OT behavior while the
+  // rest of the week runs the rich engine.
+  // TODO(rich-engine live viewer): switch this to the rich engine once it can
+  // emit a full play-by-play stream the LiveGameViewer can consume (and the
+  // e2e watch-game flow covers it).
   const batchResults = simulateBatch([userGame], {
     league,
     isPlayoff: meta.phase === 'playoffs',

--- a/tests/unit/engineSoak.test.js
+++ b/tests/unit/engineSoak.test.js
@@ -11,6 +11,7 @@ describe('engineSoak gate logic', () => {
   const passing = {
     topQuartileWinPct: 0.70, passYdsPerGame: 240, rushYdsPerGame: 115,
     pointsPerGame: 24, scoreStdDev: 12, msPerGame: 3, crashes: 0, minTeamScore: 3,
+    finalTieRate: 0,
   };
   const legacy = { scoreStdDev: 11 };
 
@@ -36,11 +37,26 @@ describe('engineSoak gate logic', () => {
     expect(evaluateGate(flat, { scoreStdDev: 11 }).passed).toBe(false);
   });
 
+  it('fails when the rich engine still returns tied finals (OT must resolve ties)', () => {
+    const tying = { ...passing, finalTieRate: 0.045 };
+    const { passed, checks } = evaluateGate(tying, legacy);
+    expect(passed).toBe(false);
+    expect(checks.find((c) => c.name.includes('Final tie rate'))?.pass).toBe(false);
+  });
+
+  it('labels the minTeamScore check as a floor regression check, not a scoring-health gate', () => {
+    const { checks } = evaluateGate(passing, legacy);
+    const floorCheck = checks.find((c) => c.name.includes('Floor regression check'));
+    expect(floorCheck).toBeDefined();
+    expect(floorCheck.name).toContain('not a scoring-health gate');
+  });
+
   it('exposes the documented threshold bands', () => {
     expect(SOAK_THRESHOLDS.pointsPerGame).toEqual({ min: 20, max: 27 });
     expect(SOAK_THRESHOLDS.passYdsPerGame).toEqual({ min: 220, max: 280 });
     expect(SOAK_THRESHOLDS.rushYdsPerGame).toEqual({ min: 100, max: 130 });
     expect(SOAK_THRESHOLDS.topQuartileWinPct).toEqual({ min: 0.68, max: 0.76 });
+    expect(SOAK_THRESHOLDS.maxFinalTieRate).toBe(0.01);
   });
 });
 
@@ -58,17 +74,24 @@ describe('engineSoak end-to-end gate (deterministic)', () => {
     expect(report.matchup.rushYdsPerGame).toBeLessThanOrEqual(130);
     // PBP variance must beat the legacy engine.
     expect(report.matchup.scoreStdDev).toBeGreaterThanOrEqual(report.legacy.scoreStdDev);
+    // OT resolves every tie; the underlying regulation tie tendency stays visible.
+    expect(report.matchup.finalTieRate).toBe(0);
+    expect(report.matchup.regulationTieRate).not.toBeNull();
+    expect(report.matchup.preFloorShutoutRate).not.toBeNull();
     // All gate checks must pass — no documented open defects remain.
     expect(report.gate.passed).toBe(true);
   }, 30000);
 
-  it('matchup engine is deterministic for a fixed seed', () => {
-    // msPerGame is wall-clock and excluded. We assert the NEW engine only — it
-    // uses per-game seeded RNG; the legacy engine carries non-seeded internals.
+  it('soak is deterministic for a fixed seed (globalSeed pinned for the legacy engine)', () => {
+    // msPerGame is wall-clock and excluded. Both engines must reproduce: the
+    // matchup engine via per-game seeded RNG, the legacy engine because the
+    // soak now pins league.globalSeed (previously Math.random per-save entropy,
+    // which made the comparative variance gate flaky across identical runs).
     const omitTiming = ({ msPerGame, ...rest }) => rest;
     const a = runEngineSoak({ seasons: 2, seed: 4242 });
     const b = runEngineSoak({ seasons: 2, seed: 4242 });
     expect(omitTiming(a.matchup)).toEqual(omitTiming(b.matchup));
+    expect(omitTiming(a.legacy)).toEqual(omitTiming(b.legacy));
   }, 30000);
 });
 

--- a/tests/unit/standingsTiebreaker.test.js
+++ b/tests/unit/standingsTiebreaker.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { prepareStandingsView } from '../../src/views/standingsView.js';
+import {
+  buildTiebreakContext,
+  makeStandingsComparator,
+  prepareStandingsView,
+  sortStandingsRows,
+} from '../../src/views/standingsView.js';
 
 // Wave 4 Fix 5: standings apply the NFL tiebreaker chain (head-to-head,
 // division record, common games, conference record, SOS, seeded coin-flip).
@@ -69,5 +74,56 @@ describe('standings NFL tiebreaker chain', () => {
     });
     expect(make().divisions[0].teams.map((t) => t.id))
       .toEqual(make().divisions[0].teams.map((t) => t.id));
+  });
+});
+
+// Post-engine-flip stabilization: the worker's buildStandings() previously
+// sorted by win% + points-for only. It now routes through sortStandingsRows,
+// which must apply the exact ordering of makeStandingsComparator.
+describe('sortStandingsRows (worker standings path)', () => {
+  // Worker row shape: pct/pf/pa, not winPct/ptsFor/ptsAgainst.
+  const workerRows = [
+    { id: 1, name: 'Alphas', abbr: 'A', conf: 0, div: 0, wins: 10, losses: 7, ties: 0, pf: 410, pa: 330, pct: 10 / 17 },
+    { id: 2, name: 'Bravos', abbr: 'B', conf: 0, div: 0, wins: 10, losses: 7, ties: 0, pf: 380, pa: 300, pct: 10 / 17 },
+    { id: 3, name: 'Charlies', abbr: 'C', conf: 0, div: 1, wins: 12, losses: 5, ties: 0, pf: 400, pa: 280, pct: 12 / 17 },
+  ];
+  // B swept A head-to-head, but A has more points-for: the old win%+PF sort
+  // put A first; the NFL chain must put B first.
+  const schedule = {
+    weeks: [
+      { games: [{ home: 2, away: 1, homeScore: 27, awayScore: 13 }] },
+      { games: [{ home: 1, away: 2, homeScore: 10, awayScore: 24 }] },
+    ],
+  };
+
+  it('applies head-to-head ahead of points-for, unlike the old worker sort', () => {
+    const sorted = sortStandingsRows(workerRows, schedule, 42);
+    expect(sorted.map((r) => r.abbr)).toEqual(['C', 'B', 'A']);
+  });
+
+  it('produces exactly the ordering of makeStandingsComparator', () => {
+    const enriched = workerRows.map((r) => ({
+      ...r, winPct: r.pct, ptsFor: r.pf, ptsAgainst: r.pa, pointDiff: r.pf - r.pa,
+    }));
+    const expected = [...enriched]
+      .sort(makeStandingsComparator(buildTiebreakContext(enriched, schedule), 42))
+      .map((r) => r.id);
+    expect(sortStandingsRows(workerRows, schedule, 42).map((r) => r.id)).toEqual(expected);
+  });
+
+  it('is deterministic for the same rows/schedule/seed', () => {
+    const a = sortStandingsRows(workerRows, schedule, 7).map((r) => r.id);
+    const b = sortStandingsRows(workerRows, schedule, 7).map((r) => r.id);
+    expect(a).toEqual(b);
+  });
+
+  it('preserves the worker row fields the UI reads (pf/pa/pct)', () => {
+    const sorted = sortStandingsRows(workerRows, schedule, 42);
+    for (const row of sorted) {
+      expect(row).toEqual(expect.objectContaining({
+        pf: expect.any(Number), pa: expect.any(Number), pct: expect.any(Number),
+        name: expect.any(String), abbr: expect.any(String),
+      }));
+    }
   });
 });


### PR DESCRIPTION
Closes out the confirmed defects from the post-engine-flip audit at 9e5de0a:

- richGameSimulator: add overtime. A game tied after Q4 plays sudden-death
  OT periods (seeded coin-toss possession, fresh drive, 10-min clock, up to
  4 periods); first lead wins and emits an 'OT — wins in overtime' digest
  event. After capped OT a seeded walk-off FG resolves the deadlock with an
  explicit event — the engine can no longer return a tied final score, which
  downstream playoff code silently resolved as a home win. The shutout floor
  now applies at the END of regulation (before the tie check), so a floored
  3-3 — or a 3-0 kneel-out the old post-loop floor re-tied to 3-3 — goes to
  OT. quarterScores grow one bucket per OT period; summary exposes
  regulationTied / overtime / shutoutFloorApplied.

- richGameSimulator: scoringSummary points now derive from consecutive
  digest score snapshots instead of a hardcoded 7 per TD, so two-point
  conversions (6/8-point TDs) reconcile with the final score (previously
  contradicted it in ~3.6% of games). FGs remain 3.

- worker/gameSummary: archive the simulator's canonical result.teamStats
  (plays, yardsPerPlay, firstDowns, red-zone data survive) instead of
  re-deriving from box-score rows; box-row derivation remains only as a
  fallback and no longer counts defensive INTs made as offensive turnovers
  (passAtt filter, mirroring gameArchive.deriveTeamStatsFromPlayerRows).

- worker/standingsView: worker standings now use the full NFL tiebreaker
  chain (head-to-head, division, common games, conference, SOS, seeded
  coin-flip) via the new sortStandingsRows entry point instead of
  win% + points-for.

- leaguePulse: completed-game story reads canonical scoreHome/homeScore
  fields (legacy score object is fallback only), so the user game-result
  pulse story fires again — the old played === true && score != null check
  never matched worker result objects.

- engineSoak: report regulationTieRate / finalTieRate / preFloorShutoutRate;
  gate finalTieRate <= 0.01; relabel the minTeamScore check as a floor
  regression check (the floor guarantees >= 3 by construction). Pin
  league.globalSeed to the CLI seed — makeLeague drew it from Math.random
  and the legacy drive engine mixes it into per-game seeds, which made the
  comparative variance gate flaky across identical runs.

- worker: document that WATCH_GAME intentionally stays on the legacy
  simulator (LiveGameViewer needs its per-play log stream) with a TODO for
  the rich-engine migration condition.

Soak (100 seasons, seed 20260605, now reproducible): all 9 gates PASS —
pts/game 24.74, top-quartile win% 74.3%, std-dev 11.57 vs legacy 11.39,
minTeamScore 3, final tie rate 0.00% (regulation 4.50% still reported),
0 crashes. Unit: 2592/2592. Sim types: clean.

https://claude.ai/code/session_01MhsibgJJroYPmcRi8Vqpdj