### PR TITLE
feat(free-agency): negotiation market v2 — pending offer ledger, cap reservation, daily resolution, offer feedback

### DIFF
--- a/src/core/__tests__/aiFreeAgencyOffers.test.js
+++ b/src/core/__tests__/aiFreeAgencyOffers.test.js
@@ -59,6 +59,8 @@ vi.mock('../retention/reSigning.js', () => ({
 }));
 
 const { default: AiLogic } = await import('../ai-logic.js');
+const { Transactions } = await import('../../db/index.js');
+const { default: NewsEngine } = await import('../news-engine.js');
 
 describe('AiLogic.makeFreeAgencyOffers stale contract handling', () => {
   beforeEach(() => {
@@ -466,5 +468,85 @@ describe('AiLogic.makeFreeAgencyOffers stale contract handling', () => {
     const needs = AiLogic.calculateTeamNeeds(1);
     expect(needs.QB).toBeGreaterThanOrEqual(1.05);
     expect(needs.QB).toBeGreaterThan(needs.WR);
+  });
+
+  it('evaluateOffers holds out instead of signing a clearly-below-demand offer when patience runs out', () => {
+    // Mocked ask: baseAnnual 1 / 1 year → askTotal = 1. A 0.5 total offer is
+    // clearly below demand, so even at day 3 (the old force-sign fallback)
+    // the player keeps waiting and the ledger rejects/expires the bid.
+    const player = {
+      id: 51,
+      name: 'Holdout WR',
+      pos: 'WR',
+      status: 'free_agent',
+      teamId: null,
+      ovr: 76,
+      age: 27,
+      offers: [{ teamId: 1, contract: { baseAnnual: 0.5, yearsTotal: 1, signingBonus: 0 } }],
+    };
+    mockCache.getAllPlayers.mockReturnValue([player]);
+    mockCache.getTeam.mockReturnValue({ id: 1, name: 'Lowball Team', capRoom: 30 });
+
+    const decision = AiLogic.evaluateOffers(player, 3);
+    expect(decision.signed).toBe(false);
+    expect(decision.heldOutWeak).toBe(true);
+
+    // A fair offer (meets the ask) still signs once patience runs out.
+    const fairPlayer = {
+      ...player,
+      id: 52,
+      offers: [{ teamId: 1, contract: { baseAnnual: 1, yearsTotal: 1, signingBonus: 0 } }],
+    };
+    mockCache.getAllPlayers.mockReturnValue([fairPlayer]);
+    expect(AiLogic.evaluateOffers(fairPlayer, 3).signed).toBe(true);
+  });
+
+  it('processFreeAgencyDay logs a transaction and news item when an offer is accepted', async () => {
+    const fa = {
+      id: 61,
+      name: 'Signable QB',
+      pos: 'QB',
+      status: 'free_agent',
+      teamId: null,
+      ovr: 77,
+      age: 33,
+      contract: { baseAnnual: 36, years: 1, yearsTotal: 1, signingBonus: 0 },
+      offers: [],
+    };
+    const team = { id: 1, name: 'Signing Team', capRoom: 15 };
+    const userTeam = { id: 99, name: 'User Team', capRoom: 15 };
+    mockCache.getMeta.mockReturnValue({ year: 2026, userTeamId: 99, currentSeasonId: 's1', currentWeek: 1, phase: 'free_agency' });
+    mockCache.getAllPlayers.mockReturnValue([fa]);
+    mockCache.getAllTeams.mockReturnValue([team, userTeam]);
+    mockCache.getTeam.mockImplementation((id) => (Number(id) === 1 ? team : userTeam));
+    mockCalculateExtensionDemand.mockReturnValue({ years: 2, yearsTotal: 2, baseAnnual: 5, signingBonus: 2 });
+    mockBuildFreeAgencyMarketAnalysis.mockImplementation(({ freeAgents }) => ({
+      marketRows: freeAgents.map((p) => ({
+        pos: p.pos,
+        recommendation: 'pursue',
+        capFit: 'expensive',
+        costSource: 'staleContract',
+        fitScore: 90,
+        _player: p,
+      })),
+    }));
+
+    await AiLogic.processFreeAgencyDay(2);
+
+    // The signing moved the player onto the roster and out of free agency…
+    expect(mockCache.updatePlayer).toHaveBeenCalledWith(
+      61,
+      expect.objectContaining({ teamId: 1, status: 'active', offers: [] }),
+    );
+    // …and produced a transaction log entry plus a news item.
+    expect(Transactions.add).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SIGN', teamId: 1, details: expect.objectContaining({ playerId: 61 }) }),
+    );
+    expect(NewsEngine.logNews).toHaveBeenCalledWith(
+      'TRANSACTION',
+      expect.stringContaining('Signable QB signs'),
+      1,
+      expect.objectContaining({ playerId: 61 }),
+    );
   });
 });

--- a/src/core/ai-logic.js
+++ b/src/core/ai-logic.js
@@ -1113,6 +1113,10 @@ class AiLogic {
         }
 
         if (timing.atWaitCap || day >= 3) {
+            // Market V2: clearly-below-demand offers no longer auto-sign when
+            // patience runs out — the player keeps waiting and the offer is
+            // rejected/expired by the pending-offer ledger instead.
+            if (weakOffer) return { signed: false, offer: bestOffer, heldOutWeak: true };
             return { signed: true, offer: bestOffer };
         }
 

--- a/src/core/dynasty-story.js
+++ b/src/core/dynasty-story.js
@@ -6,6 +6,7 @@ export const ensureDynastyMeta = (meta) => ensureLeagueMemoryMeta({
   socialFeedEntries: Array.isArray(meta?.socialFeedEntries) ? meta.socialFeedEntries : [],
   ownerGoals: Array.isArray(meta?.ownerGoals) ? meta.ownerGoals : [],
   retiredPlayers: Array.isArray(meta?.retiredPlayers) ? meta.retiredPlayers : [],
+  pendingOffers: Array.isArray(meta?.pendingOffers) ? meta.pendingOffers : [],
   records: meta?.records ?? {
     mostPassingYardsSeason: null,
     mostRushingYardsSeason: null,

--- a/src/core/freeAgency/__tests__/pendingOffers.test.js
+++ b/src/core/freeAgency/__tests__/pendingOffers.test.js
@@ -1,0 +1,300 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PENDING_OFFER_STATUS,
+  WEAK_OFFER_REJECT_DAYS,
+  MAX_OFFER_PENDING_DAYS,
+  ensurePendingOffersList,
+  ensurePendingOffersMeta,
+  computeOfferFinancials,
+  createPendingOffer,
+  upsertPendingOffer,
+  computeReservedPendingCap,
+  computeEffectiveCapRoom,
+  validateOfferAgainstReservedCap,
+  buildOfferFeedback,
+  agePendingOffers,
+  markOfferResolved,
+  reconcilePendingOffers,
+  expireAllPendingOffers,
+  prunePendingOffers,
+} from '../pendingOffers.js';
+
+const CONTRACT = { baseAnnual: 10, yearsTotal: 3, signingBonus: 6 };
+const DEMAND = { baseAnnual: 10, yearsTotal: 3, signingBonus: 6 };
+
+function makeOffer(overrides = {}) {
+  return createPendingOffer({
+    playerId: 21,
+    playerName: 'Test FA',
+    pos: 'WR',
+    ovr: 80,
+    teamId: 5,
+    teamName: 'Testers',
+    contract: CONTRACT,
+    day: 1,
+    demandSnapshot: DEMAND,
+    createdAt: 1000,
+    ...overrides,
+  });
+}
+
+describe('pending offer creation', () => {
+  it('creates a pending record with derived financials', () => {
+    const offer = makeOffer();
+    expect(offer.status).toBe(PENDING_OFFER_STATUS.PENDING);
+    expect(offer.playerId).toBe(21);
+    expect(offer.teamId).toBe(5);
+    expect(offer.years).toBe(3);
+    expect(offer.signingBonus).toBe(6);
+    expect(offer.annualCapHit).toBe(12); // 10 + 6/3
+    expect(offer.totalValue).toBe(36);   // 10*3 + 6
+    expect(offer.daySubmitted).toBe(1);
+    expect(offer.daysPending).toBe(0);
+    expect(offer.playerDemandSnapshot).toEqual(DEMAND);
+    expect(offer.id).toContain('fa-offer-21-5');
+  });
+
+  it('computeOfferFinancials handles 1-year defaults', () => {
+    expect(computeOfferFinancials({ baseAnnual: 4 })).toEqual({
+      years: 1, baseAnnual: 4, signingBonus: 0, annualCapHit: 4, totalValue: 4,
+    });
+  });
+});
+
+describe('duplicate offer prevention', () => {
+  it('replaces an existing pending offer from the same team for the same player', () => {
+    const first = makeOffer();
+    const second = makeOffer({ contract: { baseAnnual: 14, yearsTotal: 2, signingBonus: 0 }, createdAt: 2000 });
+    const afterFirst = upsertPendingOffer([], first);
+    expect(afterFirst.replaced).toBe(false);
+    const afterSecond = upsertPendingOffer(afterFirst.list, second);
+    expect(afterSecond.replaced).toBe(true);
+    const pending = afterSecond.list.filter((row) => row.status === 'pending');
+    expect(pending).toHaveLength(1);
+    expect(pending[0].annualCapHit).toBe(14);
+  });
+
+  it('keeps resolved history rows when a new offer is submitted', () => {
+    const rejected = { ...makeOffer(), status: PENDING_OFFER_STATUS.REJECTED };
+    const fresh = makeOffer({ createdAt: 2000 });
+    const { list } = upsertPendingOffer([rejected], fresh);
+    expect(list).toHaveLength(2);
+    expect(list.filter((row) => row.status === 'pending')).toHaveLength(1);
+  });
+});
+
+describe('cap reservation math', () => {
+  it('reserves the first-year cap hit of every pending offer for the team', () => {
+    const a = makeOffer(); // cap hit 12
+    const b = makeOffer({ playerId: 22, contract: { baseAnnual: 5, yearsTotal: 2, signingBonus: 2 } }); // 6
+    const other = makeOffer({ playerId: 23, teamId: 9 });
+    const ledger = [a, b, other];
+    expect(computeReservedPendingCap(ledger, 5)).toBe(18);
+    expect(computeEffectiveCapRoom(40, ledger, 5)).toBe(22);
+  });
+
+  it('releases the reservation when an offer resolves', () => {
+    const a = makeOffer();
+    const b = makeOffer({ playerId: 22, contract: { baseAnnual: 5, yearsTotal: 2, signingBonus: 2 } });
+    let ledger = [a, b];
+    ledger = markOfferResolved(ledger, { playerId: 22, teamId: 5, status: PENDING_OFFER_STATUS.REJECTED, day: 2 });
+    expect(computeReservedPendingCap(ledger, 5)).toBe(12);
+    ledger = markOfferResolved(ledger, { playerId: 21, teamId: 5, status: PENDING_OFFER_STATUS.EXPIRED, day: 3 });
+    expect(computeReservedPendingCap(ledger, 5)).toBe(0);
+  });
+
+  it('does not double-count a replaced offer for the same player', () => {
+    const ledger = [makeOffer()];
+    const check = validateOfferAgainstReservedCap({
+      capRoom: 13, annualCapHit: 13, pendingOffers: ledger, teamId: 5, playerId: 21,
+    });
+    expect(check.ok).toBe(true); // existing 12M reservation excluded for same player
+    expect(check.reserved).toBe(0);
+  });
+
+  it('blocks an offer that exceeds effective cap room', () => {
+    const ledger = [makeOffer()]; // reserves 12 of 20
+    const check = validateOfferAgainstReservedCap({
+      capRoom: 20, annualCapHit: 10, pendingOffers: ledger, teamId: 5, playerId: 99,
+    });
+    expect(check.ok).toBe(false);
+    expect(check.effectiveCapRoom).toBe(8);
+    expect(check.message).toContain('Withdraw a pending offer');
+  });
+
+  it('blocks an offer larger than total cap room outright', () => {
+    const check = validateOfferAgainstReservedCap({ capRoom: 5, annualCapHit: 9, pendingOffers: [], teamId: 5 });
+    expect(check.ok).toBe(false);
+    expect(check.message).toContain('Not enough cap room');
+  });
+});
+
+describe('daily resolution (reconcile)', () => {
+  const signedPlayer = (teamId) => ({ id: 21, teamId, status: 'active', offers: [] });
+
+  it('marks the offer accepted when the player signed with the offering team', () => {
+    const { list, accepted } = reconcilePendingOffers({
+      pendingOffers: [makeOffer()],
+      resolvePlayer: () => signedPlayer(5),
+      day: 2,
+    });
+    expect(accepted).toHaveLength(1);
+    expect(list[0].status).toBe(PENDING_OFFER_STATUS.ACCEPTED);
+    expect(list[0].feedback[0]).toContain('Accepted');
+    expect(list[0].resolvedDay).toBe(2);
+  });
+
+  it('marks the offer rejected when the player signed elsewhere', () => {
+    const { list, rejected } = reconcilePendingOffers({
+      pendingOffers: [makeOffer()],
+      resolvePlayer: () => signedPlayer(9),
+      resolveTeamName: () => 'Rivals',
+      day: 2,
+    });
+    expect(rejected).toHaveLength(1);
+    expect(list[0].status).toBe(PENDING_OFFER_STATUS.REJECTED);
+    expect(list[0].feedback[0]).toContain('Rivals');
+  });
+
+  it('rejects a clearly-below-demand offer after the short review window and removes the bid', () => {
+    const weak = makeOffer({ contract: { baseAnnual: 4, yearsTotal: 2, signingBonus: 0 } }); // 8 vs ask 36
+    weak.daysPending = WEAK_OFFER_REJECT_DAYS;
+    const player = { id: 21, teamId: null, status: 'free_agent', offers: [{ teamId: 5 }] };
+    const { list, rejected, offerRemovals } = reconcilePendingOffers({
+      pendingOffers: [weak],
+      resolvePlayer: () => player,
+      day: 3,
+    });
+    expect(rejected).toHaveLength(1);
+    expect(list[0].status).toBe(PENDING_OFFER_STATUS.REJECTED);
+    expect(offerRemovals).toEqual([{ playerId: 21, teamId: 5 }]);
+  });
+
+  it('expires a fair offer that stays pending past the max window', () => {
+    const stale = makeOffer();
+    stale.daysPending = MAX_OFFER_PENDING_DAYS;
+    const player = { id: 21, teamId: null, status: 'free_agent', offers: [{ teamId: 5 }] };
+    const { list, expired, offerRemovals } = reconcilePendingOffers({
+      pendingOffers: [stale],
+      resolvePlayer: () => player,
+      day: 5,
+    });
+    expect(expired).toHaveLength(1);
+    expect(list[0].status).toBe(PENDING_OFFER_STATUS.EXPIRED);
+    expect(offerRemovals).toHaveLength(1);
+  });
+
+  it('rejects when the bid was dropped from the player offer list (cap room disappeared)', () => {
+    const player = { id: 21, teamId: null, status: 'free_agent', offers: [] };
+    const { list, rejected } = reconcilePendingOffers({
+      pendingOffers: [makeOffer()],
+      resolvePlayer: () => player,
+      day: 2,
+    });
+    expect(rejected).toHaveLength(1);
+    expect(list[0].feedback[0]).toContain('cap room');
+  });
+
+  it('keeps a competitive offer pending and refreshes competing teams', () => {
+    const fair = makeOffer();
+    fair.daysPending = 1;
+    const player = { id: 21, teamId: null, status: 'free_agent', offers: [{ teamId: 5 }, { teamId: 8 }, { teamId: 12 }] };
+    const { list, accepted, rejected, expired } = reconcilePendingOffers({
+      pendingOffers: [fair],
+      resolvePlayer: () => player,
+      day: 2,
+    });
+    expect(accepted).toHaveLength(0);
+    expect(rejected).toHaveLength(0);
+    expect(expired).toHaveLength(0);
+    expect(list[0].status).toBe(PENDING_OFFER_STATUS.PENDING);
+    expect(list[0].competingTeamIds).toEqual([8, 12]);
+  });
+
+  it('ages pending offers by one day and leaves resolved rows alone', () => {
+    const pending = makeOffer();
+    const done = { ...makeOffer({ playerId: 22 }), status: PENDING_OFFER_STATUS.ACCEPTED, daysPending: 1 };
+    const aged = agePendingOffers([pending, done]);
+    expect(aged[0].daysPending).toBe(1);
+    expect(aged[1].daysPending).toBe(1);
+  });
+
+  it('expires every remaining pending offer when the market closes', () => {
+    const { list, expired } = expireAllPendingOffers([makeOffer(), makeOffer({ playerId: 22 })], { day: 6 });
+    expect(expired).toHaveLength(2);
+    expect(list.every((row) => row.status === PENDING_OFFER_STATUS.EXPIRED)).toBe(true);
+  });
+});
+
+describe('save/load migration', () => {
+  it('migrates saves without pendingOffers to an empty array', () => {
+    expect(ensurePendingOffersMeta({}).pendingOffers).toEqual([]);
+    expect(ensurePendingOffersMeta({ pendingOffers: null }).pendingOffers).toEqual([]);
+    expect(ensurePendingOffersMeta({ pendingOffers: 'junk' }).pendingOffers).toEqual([]);
+  });
+
+  it('preserves an existing ledger untouched', () => {
+    const ledger = [makeOffer()];
+    const meta = { pendingOffers: ledger };
+    expect(ensurePendingOffersMeta(meta)).toBe(meta);
+    expect(ensurePendingOffersMeta(meta).pendingOffers).toBe(ledger);
+  });
+
+  it('drops malformed rows when normalizing a list', () => {
+    expect(ensurePendingOffersList([null, undefined, makeOffer()])).toHaveLength(1);
+    expect(ensurePendingOffersList(undefined)).toEqual([]);
+  });
+
+  it('prunes old resolved rows but never pending ones', () => {
+    const old = { ...makeOffer(), status: PENDING_OFFER_STATUS.REJECTED, resolvedDay: -20 };
+    const pending = makeOffer({ playerId: 22 });
+    const pruned = prunePendingOffers([old, pending], { day: 5 });
+    expect(pruned).toHaveLength(1);
+    expect(pruned[0].playerId).toBe(22);
+  });
+});
+
+describe('offer feedback', () => {
+  it('is deterministic for identical inputs', () => {
+    const input = { contract: CONTRACT, demand: DEMAND, playerAge: 27, competingOfferCount: 2, capRoomAfter: 4 };
+    expect(buildOfferFeedback(input)).toEqual(buildOfferFeedback(input));
+  });
+
+  it('praises an offer that meets demand', () => {
+    const fb = buildOfferFeedback({ contract: CONTRACT, demand: DEMAND, playerAge: 27 });
+    expect(fb.verdict).toBe('strong');
+    expect(fb.feedback[0]).toContain('Strong offer');
+  });
+
+  it('flags low annual value on a lowball offer', () => {
+    const fb = buildOfferFeedback({
+      contract: { baseAnnual: 4, yearsTotal: 2, signingBonus: 0 },
+      demand: DEMAND,
+      playerAge: 27,
+    });
+    expect(fb.verdict).toBe('weak');
+    expect(fb.feedback[0]).toContain('Low annual value');
+  });
+
+  it('flags a term mismatch for veterans asked to sign long deals', () => {
+    const fb = buildOfferFeedback({
+      contract: { baseAnnual: 12, yearsTotal: 5, signingBonus: 6 },
+      demand: { baseAnnual: 10, yearsTotal: 2, signingBonus: 2 },
+      playerAge: 32,
+    });
+    expect(fb.feedback.join(' ')).toContain('veteran prefers shorter commitment');
+  });
+
+  it('warns about cap risk and competing offers', () => {
+    const fb = buildOfferFeedback({
+      contract: CONTRACT,
+      demand: DEMAND,
+      playerAge: 27,
+      competingOfferCount: 3,
+      capRoomAfter: -2,
+    });
+    const text = fb.feedback.join(' ');
+    expect(text).toContain('Cap risk');
+    expect(text).toContain('Competing offers');
+  });
+});

--- a/src/core/freeAgency/pendingOffers.js
+++ b/src/core/freeAgency/pendingOffers.js
@@ -1,0 +1,385 @@
+/**
+ * pendingOffers.js
+ *
+ * League-level pending free-agency offer ledger (Free Agency Market V2).
+ *
+ * The operational bid list still lives on each player (`player.offers`) so the
+ * existing AI bidding + decision pipeline keeps working unchanged. This module
+ * adds a persistent, league-level record of submitted offers (user bids first
+ * and foremost) so that:
+ *   - pending offers reserve cap room before they resolve,
+ *   - duplicate active offers from one team to one player are impossible,
+ *   - every offer carries deterministic feedback explaining its quality,
+ *   - resolutions (accepted / rejected / expired / withdrawn) survive the
+ *     moment the player's own offer list is cleared, so the UI can explain
+ *     what happened after the fact.
+ *
+ * All functions are pure: they take the ledger array (stored on
+ * `meta.pendingOffers`) and return a new array. The worker owns persistence.
+ */
+
+export const PENDING_OFFER_STATUS = Object.freeze({
+  PENDING: 'pending',
+  ACCEPTED: 'accepted',
+  REJECTED: 'rejected',
+  EXPIRED: 'expired',
+  WITHDRAWN: 'withdrawn',
+});
+
+/** Resolved entries older than this many FA days get pruned from the ledger. */
+const RESOLVED_RETENTION_DAYS = 14;
+/** Hard ceiling on ledger size so saves never balloon. */
+const MAX_LEDGER_ENTRIES = 200;
+/** Pending offers clearly below demand reject after this many days pending. */
+export const WEAK_OFFER_REJECT_DAYS = 2;
+/** Any offer still pending after this many days expires. */
+export const MAX_OFFER_PENDING_DAYS = 5;
+/** Offers worth less than this fraction of the ask are "clearly below demand". */
+export const WEAK_OFFER_VALUE_RATIO = 0.75;
+
+function toNum(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function roundMoney(value) {
+  return Math.round(toNum(value) * 10) / 10;
+}
+
+/** Migration: any non-array value (missing field on old saves) becomes []. */
+export function ensurePendingOffersList(value) {
+  return Array.isArray(value) ? value.filter((row) => row && typeof row === 'object') : [];
+}
+
+/** Normalize a meta object so `meta.pendingOffers` is always a valid array. */
+export function ensurePendingOffersMeta(meta = {}) {
+  if (Array.isArray(meta?.pendingOffers)) return meta;
+  return { ...meta, pendingOffers: ensurePendingOffersList(meta?.pendingOffers) };
+}
+
+/** First-year cap hit, total value, etc. for a contract offer. */
+export function computeOfferFinancials(contract = {}) {
+  const years = Math.max(1, Math.round(toNum(contract.yearsTotal ?? contract.years, 1)));
+  const baseAnnual = toNum(contract.baseAnnual ?? contract.annualSalary ?? contract.salary, 0);
+  const signingBonus = toNum(contract.signingBonus, 0);
+  return {
+    years,
+    baseAnnual: roundMoney(baseAnnual),
+    signingBonus: roundMoney(signingBonus),
+    annualCapHit: roundMoney(baseAnnual + signingBonus / years),
+    totalValue: roundMoney(baseAnnual * years + signingBonus),
+  };
+}
+
+function demandTotals(demand = {}) {
+  const askYears = Math.max(1, Math.round(toNum(demand.yearsTotal ?? demand.years, 1)));
+  const askAnnual = toNum(demand.baseAnnual, 0);
+  const askBonus = toNum(demand.signingBonus, 0);
+  return { askYears, askAnnual, askTotal: roundMoney(askAnnual * askYears + askBonus) };
+}
+
+/**
+ * Deterministic offer quality + feedback. Same inputs always produce the same
+ * score and lines (no randomness), so identical saves/seeds replay identically.
+ */
+export function buildOfferFeedback({
+  contract = {},
+  demand = {},
+  playerAge = 27,
+  competingOfferCount = 0,
+  capRoomAfter = null,
+} = {}) {
+  const fin = computeOfferFinancials(contract);
+  const { askYears, askAnnual, askTotal } = demandTotals(demand);
+  const valueRatio = askTotal > 0 ? fin.totalValue / askTotal : 1;
+  const annualRatio = askAnnual > 0 ? fin.baseAnnual / askAnnual : 1;
+  const bonusShare = fin.totalValue > 0 ? fin.signingBonus / fin.totalValue : 0;
+
+  const lines = [];
+  let verdict = 'competitive';
+
+  if (valueRatio >= 1 && annualRatio >= 0.95) {
+    verdict = 'strong';
+    lines.push('Strong offer — meets demand and gives starter-level security.');
+  } else if (valueRatio >= 0.88) {
+    verdict = 'competitive';
+    lines.push('Competitive offer — close to the player’s asking price.');
+  } else if (valueRatio >= WEAK_OFFER_VALUE_RATIO) {
+    verdict = 'borderline';
+    lines.push('Below asking price — the player will weigh it against other bids.');
+  } else {
+    verdict = 'weak';
+    lines.push('Low annual value — player is waiting for a better market.');
+  }
+
+  if (playerAge >= 30 && fin.years > askYears) {
+    lines.push('Term mismatch — veteran prefers shorter commitment.');
+  } else if (playerAge <= 26 && fin.years < Math.max(1, askYears - 1)) {
+    lines.push('Term mismatch — young player wants longer-term security.');
+  }
+
+  if (verdict !== 'weak' && bonusShare < 0.05 && toNum(demand.signingBonus, 0) > 0) {
+    lines.push('Light guarantees — a stronger signing bonus would help the bid.');
+  }
+
+  if (capRoomAfter != null && toNum(capRoomAfter) < 0) {
+    lines.push('Cap risk — offer is pending but may be rejected if room disappears.');
+  }
+
+  if (competingOfferCount >= 2) {
+    lines.push(`Competing offers in play (${competingOfferCount} other team${competingOfferCount === 1 ? '' : 's'}) — expect a bidding war.`);
+  }
+
+  return {
+    verdict,
+    score: Math.max(0, Math.min(100, Math.round(valueRatio * 80 + (annualRatio >= 0.95 ? 10 : 0) + bonusShare * 25))),
+    valueRatio: Math.round(valueRatio * 100) / 100,
+    feedback: lines,
+  };
+}
+
+/** Build a ledger record for a submitted offer. */
+export function createPendingOffer({
+  playerId,
+  playerName = null,
+  pos = null,
+  ovr = null,
+  teamId,
+  teamName = null,
+  contract = {},
+  day = 1,
+  demandSnapshot = null,
+  competingTeamIds = [],
+  feedback = null,
+  score = null,
+  createdAt = Date.now(),
+} = {}) {
+  const fin = computeOfferFinancials(contract);
+  return {
+    id: `fa-offer-${playerId}-${teamId}-${day}-${createdAt}`,
+    playerId: Number(playerId),
+    playerName,
+    pos,
+    ovr,
+    teamId: Number(teamId),
+    teamName,
+    contract: { ...contract },
+    annualCapHit: fin.annualCapHit,
+    totalValue: fin.totalValue,
+    years: fin.years,
+    signingBonus: fin.signingBonus,
+    status: PENDING_OFFER_STATUS.PENDING,
+    daySubmitted: toNum(day, 1),
+    daysPending: 0,
+    resolvedDay: null,
+    playerDemandSnapshot: demandSnapshot ? { ...demandSnapshot } : null,
+    score,
+    feedback: Array.isArray(feedback) ? feedback : feedback ? [feedback] : [],
+    competingTeamIds: (Array.isArray(competingTeamIds) ? competingTeamIds : [])
+      .map(Number)
+      .filter((id) => Number.isFinite(id) && id !== Number(teamId)),
+    createdAt,
+  };
+}
+
+function isPending(row) {
+  return row?.status === PENDING_OFFER_STATUS.PENDING;
+}
+
+function matches(row, playerId, teamId) {
+  return Number(row?.playerId) === Number(playerId) && Number(row?.teamId) === Number(teamId);
+}
+
+/**
+ * Insert or replace an offer. A team can never hold two active pending offers
+ * on the same player — re-submitting replaces the previous bid.
+ * Returns { list, replaced }.
+ */
+export function upsertPendingOffer(list, record) {
+  const ledger = ensurePendingOffersList(list);
+  const replaced = ledger.some((row) => isPending(row) && matches(row, record.playerId, record.teamId));
+  const next = ledger.filter((row) => !(isPending(row) && matches(row, record.playerId, record.teamId)));
+  next.push(record);
+  return { list: next, replaced };
+}
+
+export function getActivePendingOffers(list, teamId = null) {
+  return ensurePendingOffersList(list).filter(
+    (row) => isPending(row) && (teamId == null || Number(row.teamId) === Number(teamId)),
+  );
+}
+
+export function findPendingOffer(list, playerId, teamId) {
+  return ensurePendingOffersList(list).find((row) => isPending(row) && matches(row, playerId, teamId)) ?? null;
+}
+
+/**
+ * Cap reserved by a team's pending offers (sum of first-year cap hits).
+ * `excludePlayerId` lets a replacement offer not double-count against itself.
+ */
+export function computeReservedPendingCap(list, teamId, { excludePlayerId = null } = {}) {
+  return roundMoney(
+    getActivePendingOffers(list, teamId)
+      .filter((row) => excludePlayerId == null || Number(row.playerId) !== Number(excludePlayerId))
+      .reduce((sum, row) => sum + toNum(row.annualCapHit), 0),
+  );
+}
+
+export function computeEffectiveCapRoom(capRoom, list, teamId, opts = {}) {
+  return roundMoney(toNum(capRoom) - computeReservedPendingCap(list, teamId, opts));
+}
+
+/**
+ * Validate a new offer against cap room net of existing pending reservations.
+ * Pure so the worker handler stays thin and this stays unit-testable.
+ */
+export function validateOfferAgainstReservedCap({
+  capRoom = 0,
+  annualCapHit = 0,
+  pendingOffers = [],
+  teamId,
+  playerId = null,
+} = {}) {
+  const reserved = computeReservedPendingCap(pendingOffers, teamId, { excludePlayerId: playerId });
+  const effectiveCapRoom = roundMoney(toNum(capRoom) - reserved);
+  const roomAfter = roundMoney(effectiveCapRoom - toNum(annualCapHit));
+  if (toNum(annualCapHit) > toNum(capRoom)) {
+    return {
+      ok: false, reserved, effectiveCapRoom, roomAfter,
+      message: `Not enough cap room: this offer carries a $${roundMoney(annualCapHit)}M cap hit against $${roundMoney(capRoom)}M of room.`,
+    };
+  }
+  if (roomAfter < 0) {
+    return {
+      ok: false, reserved, effectiveCapRoom, roomAfter,
+      message: `Pending offers already reserve $${reserved}M of cap. This bid would exceed your effective room ($${effectiveCapRoom}M) by $${Math.abs(roomAfter)}M. Withdraw a pending offer first.`,
+    };
+  }
+  return { ok: true, reserved, effectiveCapRoom, roomAfter, message: null };
+}
+
+/** Age every pending offer by one free-agency day. */
+export function agePendingOffers(list) {
+  return ensurePendingOffersList(list).map((row) =>
+    isPending(row) ? { ...row, daysPending: toNum(row.daysPending) + 1 } : row,
+  );
+}
+
+/** Resolve one offer's status (releases its cap reservation by leaving 'pending'). */
+export function markOfferResolved(list, { playerId, teamId, status, feedback = null, day = null }) {
+  return ensurePendingOffersList(list).map((row) => {
+    if (!isPending(row) || !matches(row, playerId, teamId)) return row;
+    return {
+      ...row,
+      status,
+      resolvedDay: day,
+      feedback: feedback ? (Array.isArray(feedback) ? feedback : [feedback]) : row.feedback,
+    };
+  });
+}
+
+/**
+ * Reconcile the ledger against current player state after a market pass
+ * (AI day processing or week-advance resolution). For each pending entry:
+ *   - player signed with the offering team        → accepted
+ *   - player signed elsewhere                     → rejected (signed elsewhere)
+ *   - still FA but team's bid vanished            → rejected (bid dropped, e.g. cap)
+ *   - still FA, clearly weak, past reject window  → rejected (below market)
+ *   - still FA, pending too long                  → expired
+ *   - otherwise                                   → stays pending, competing list refreshed
+ *
+ * `resolvePlayer(playerId)` returns the live player (or null).
+ * Returns { list, accepted, rejected, expired, offerRemovals } where
+ * `offerRemovals` are {playerId, teamId} pairs the caller must strip from
+ * `player.offers` so dead bids stop influencing decisions.
+ */
+export function reconcilePendingOffers({
+  pendingOffers,
+  resolvePlayer,
+  resolveTeamName = () => null,
+  day = 1,
+  weakRejectDays = WEAK_OFFER_REJECT_DAYS,
+  maxPendingDays = MAX_OFFER_PENDING_DAYS,
+} = {}) {
+  const accepted = [];
+  const rejected = [];
+  const expired = [];
+  const offerRemovals = [];
+
+  const list = ensurePendingOffersList(pendingOffers).map((row) => {
+    if (!isPending(row)) return row;
+    const player = typeof resolvePlayer === 'function' ? resolvePlayer(row.playerId) : null;
+
+    if (!player) {
+      const next = { ...row, status: PENDING_OFFER_STATUS.EXPIRED, resolvedDay: day, feedback: ['Player is no longer available.'] };
+      expired.push(next);
+      return next;
+    }
+
+    const signedTeamId = player.teamId != null && player.status !== 'free_agent' ? Number(player.teamId) : null;
+    if (signedTeamId != null && signedTeamId === Number(row.teamId)) {
+      const next = { ...row, status: PENDING_OFFER_STATUS.ACCEPTED, resolvedDay: day, feedback: ['Accepted — best current offer after day advanced.'] };
+      accepted.push(next);
+      return next;
+    }
+    if (signedTeamId != null) {
+      const teamName = resolveTeamName(signedTeamId) ?? 'another team';
+      const next = { ...row, status: PENDING_OFFER_STATUS.REJECTED, resolvedDay: day, feedback: [`Rejected — signed with ${teamName} instead.`] };
+      rejected.push(next);
+      return next;
+    }
+
+    // Still a free agent.
+    const stillListed = Array.isArray(player.offers)
+      && player.offers.some((o) => Number(o?.teamId) === Number(row.teamId));
+    if (!stillListed) {
+      const next = { ...row, status: PENDING_OFFER_STATUS.REJECTED, resolvedDay: day, feedback: ['Rejected — the bid is no longer on the table (cap room disappeared).'] };
+      rejected.push(next);
+      return next;
+    }
+
+    const ask = demandTotals(row.playerDemandSnapshot ?? {});
+    const isWeak = ask.askTotal > 0 && toNum(row.totalValue) < ask.askTotal * WEAK_OFFER_VALUE_RATIO;
+    if (isWeak && toNum(row.daysPending) >= weakRejectDays) {
+      const next = { ...row, status: PENDING_OFFER_STATUS.REJECTED, resolvedDay: day, feedback: ['Rejected — offer stayed well below the player’s market and he moved on.'] };
+      rejected.push(next);
+      offerRemovals.push({ playerId: Number(row.playerId), teamId: Number(row.teamId) });
+      return next;
+    }
+    if (toNum(row.daysPending) >= maxPendingDays) {
+      const next = { ...row, status: PENDING_OFFER_STATUS.EXPIRED, resolvedDay: day, feedback: ['Expired — the negotiation window closed without a deal.'] };
+      expired.push(next);
+      offerRemovals.push({ playerId: Number(row.playerId), teamId: Number(row.teamId) });
+      return next;
+    }
+
+    const competingTeamIds = (player.offers ?? [])
+      .map((o) => Number(o?.teamId))
+      .filter((id) => Number.isFinite(id) && id !== Number(row.teamId));
+    return { ...row, competingTeamIds };
+  });
+
+  return { list, accepted, rejected, expired, offerRemovals };
+}
+
+/** Expire every still-pending offer (used when the FA period closes). */
+export function expireAllPendingOffers(list, { day = null, reason = 'Expired — free agency period ended.' } = {}) {
+  const expired = [];
+  const next = ensurePendingOffersList(list).map((row) => {
+    if (!isPending(row)) return row;
+    const out = { ...row, status: PENDING_OFFER_STATUS.EXPIRED, resolvedDay: day, feedback: [reason] };
+    expired.push(out);
+    return out;
+  });
+  return { list: next, expired };
+}
+
+/** Drop ancient resolved entries and cap ledger size so saves stay small. */
+export function prunePendingOffers(list, { day = 1 } = {}) {
+  const ledger = ensurePendingOffersList(list).filter((row) => {
+    if (isPending(row)) return true;
+    const resolvedDay = toNum(row.resolvedDay, toNum(row.daySubmitted, 0));
+    return day - resolvedDay <= RESOLVED_RETENTION_DAYS;
+  });
+  return ledger.length > MAX_LEDGER_ENTRIES ? ledger.slice(-MAX_LEDGER_ENTRIES) : ledger;
+}

--- a/src/ui/components/CapManager.jsx
+++ b/src/ui/components/CapManager.jsx
@@ -32,6 +32,14 @@ export default function CapManager({ league, actions }) {
   const deadCap = userTeam?.deadCap ?? 0;
   const used = useMemo(() => roster.reduce((sum, p) => sum + (safeContract(p)?.salary ?? 2), 0), [roster]);
   const capSpace = calcCapSpace(roster) - deadCap;
+  // Pending free agency offers reserve cap room until they resolve.
+  const reservedPendingCap = useMemo(
+    () => (Array.isArray(league?.pendingOffers) ? league.pendingOffers : [])
+      .filter((row) => row?.status === 'pending')
+      .reduce((sum, row) => sum + (Number(row?.annualCapHit) || 0), 0),
+    [league?.pendingOffers],
+  );
+  const effectiveCapSpace = capSpace - reservedPendingCap;
   const [ext, setExt] = useState(null);
   const [offer, setOffer] = useState({ years: 3, salary: 8, guaranteedPct: 50 });
 
@@ -43,7 +51,12 @@ export default function CapManager({ league, actions }) {
       <div style={{ height: 10, background: '#1f2937', borderRadius: 999, overflow: 'hidden', marginBottom: 8 }}>
         <div style={{ width: `${Math.min(100, (used / SALARY_CAP_AMOUNT) * 100)}%`, height: '100%', background: usageColor }} />
       </div>
-      <div style={{ marginBottom: 16 }}>Dead Cap: ${Number(deadCap).toFixed(1)}M</div>
+      <div style={{ marginBottom: reservedPendingCap > 0 ? 4 : 16 }}>Dead Cap: ${Number(deadCap).toFixed(1)}M</div>
+      {reservedPendingCap > 0 && (
+        <div style={{ marginBottom: 16 }}>
+          Pending FA offers reserve ${reservedPendingCap.toFixed(1)}M · Effective cap space: ${effectiveCapSpace.toFixed(1)}M
+        </div>
+      )}
 
       <table style={{ width: '100%', fontSize: 13 }}>
         <thead><tr><th>Name</th><th>Pos</th><th>OVR</th><th>Age</th><th>Salary ($M)</th><th>Yrs</th><th>Actions</th></tr></thead>

--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -394,6 +394,76 @@ export function PendingCapImpactPanel({ reservation }) {
   );
 }
 
+// ── Pending offers (negotiation market) ──────────────────────────────────────
+
+const OFFER_STATUS_TONE = Object.freeze({
+  pending: 'var(--accent)',
+  accepted: 'var(--success)',
+  rejected: 'var(--danger)',
+  expired: 'var(--text-muted)',
+  withdrawn: 'var(--text-muted)',
+});
+
+const OFFER_STATUS_LABEL = Object.freeze({
+  pending: 'Pending',
+  accepted: 'Accepted',
+  rejected: 'Rejected',
+  expired: 'Expired',
+  withdrawn: 'Withdrawn',
+});
+
+export function PendingOffersPanel({ pendingOffers = [], capSummary = null, onWithdraw }) {
+  const offers = Array.isArray(pendingOffers) ? pendingOffers : [];
+  if (offers.length === 0 && !capSummary?.reservedPendingCap) return null;
+  return (
+    <Card className="card-premium" style={{ marginBottom: "var(--space-4)" }} data-testid="pending-offers-panel">
+      <CardContent style={{ padding: "var(--space-4)", display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 10, flexWrap: "wrap" }}>
+          <div>
+            <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: "0.7px", fontWeight: 800 }}>Your offers</div>
+            <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginTop: 3 }}>Offers stay pending until the player decides. Pending bids reserve cap room.</div>
+          </div>
+          {capSummary ? (
+            <Badge variant="outline" data-testid="effective-cap-badge">
+              Effective cap: {formatCapValue(capSummary.effectiveCapRoom)} (reserved {formatCapValue(capSummary.reservedPendingCap)})
+            </Badge>
+          ) : null}
+        </div>
+        <div style={{ display: "grid", gap: 6 }}>
+          {offers.map((offer) => {
+            const status = OFFER_STATUS_LABEL[offer.status] ? offer.status : 'pending';
+            const tone = OFFER_STATUS_TONE[status];
+            return (
+              <div key={offer.id} data-testid={`pending-offer-${offer.playerId}`} style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "8px 10px", background: "var(--surface)", display: "grid", gap: 4 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+                  <div style={{ fontWeight: 700, fontSize: "var(--text-sm)" }}>
+                    {offer.playerName ?? `Player ${offer.playerId}`}{offer.pos ? ` · ${offer.pos}` : ''}
+                    <span style={{ color: "var(--text-muted)", fontWeight: 500 }}>
+                      {' '}— {offer.years}y / ${Number(offer.totalValue ?? 0).toFixed(1)}M (${Number(offer.annualCapHit ?? 0).toFixed(1)}M cap/yr)
+                    </span>
+                  </div>
+                  <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+                    <Badge variant="outline" style={{ color: tone, borderColor: tone, background: `${tone}14` }}>{OFFER_STATUS_LABEL[status]}</Badge>
+                    {status === 'pending' && typeof onWithdraw === 'function' ? (
+                      <Button size="sm" variant="outline" onClick={() => onWithdraw(offer.playerId)}>Withdraw</Button>
+                    ) : null}
+                  </div>
+                </div>
+                {(offer.feedback ?? []).slice(0, 2).map((line) => (
+                  <div key={line} style={{ fontSize: "var(--text-xs)", color: status === 'rejected' ? "var(--danger)" : "var(--text-muted)" }}>{line}</div>
+                ))}
+                {status === 'pending' && (offer.competingTeamIds ?? []).length > 0 ? (
+                  <div style={{ fontSize: "10px", color: "var(--warning)" }}>{offer.competingTeamIds.length} competing team{offer.competingTeamIds.length === 1 ? '' : 's'} bidding</div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 // ── Cap banner ────────────────────────────────────────────────────────────────
 
 function CapBanner({ userTeam }) {
@@ -910,6 +980,15 @@ export default function FreeAgency({
     () => evaluatePendingOfferCapReservation(pendingCapContext),
     [pendingCapContext],
   );
+  // Latest ledger record per player (worker returns newest-first) so rows can
+  // show pending/accepted/rejected/expired status next to the player name.
+  const offerStatusByPlayer = useMemo(() => {
+    const map = new Map();
+    for (const offer of faState?.pendingOffers ?? []) {
+      if (!map.has(offer.playerId)) map.set(offer.playerId, offer);
+    }
+    return map;
+  }, [faState?.pendingOffers]);
 
   const displayed = useMemo(() => {
     const base = filterFreeAgentsForView(evaluatedFaPool, {
@@ -984,6 +1063,26 @@ export default function FreeAgency({
     }
   };
 
+  const refreshFreeAgents = async () => {
+    try {
+      const res = await actions.getFreeAgents();
+      setFaState(res.payload);
+    } catch (err) {
+      console.error("FA refresh error:", err);
+    }
+  };
+
+  const handleWithdrawOffer = async (playerId) => {
+    if (activeTeamId == null) return;
+    try {
+      await actions.withdrawOffer(playerId, activeTeamId);
+      showFlash("Offer withdrawn — cap reservation released.");
+      await refreshFreeAgents();
+    } catch (err) {
+      alert("Withdraw failed: " + err.message);
+    }
+  };
+
   const handleSign = async (playerId, contract) => {
     setSigningPlayerId(null);
     if (activeTeamId == null) {
@@ -993,6 +1092,7 @@ export default function FreeAgency({
     try {
         await actions.submitOffer(playerId, activeTeamId, contract);
         showFlash(`Offer submitted.`);
+        await refreshFreeAgents();
         // Optimistic update for test
         setFaState(prev => {
             if (!prev) return prev;
@@ -1053,6 +1153,9 @@ export default function FreeAgency({
         subtitle="Scan market pressure, filter targets, and place bids quickly."
         metadata={[
           { label: "Cap Room", value: `$${capRoom.toFixed(1)}M` },
+          ...(faState?.capSummary && faState.capSummary.reservedPendingCap > 0
+            ? [{ label: "Effective Cap", value: `$${Number(faState.capSummary.effectiveCapRoom).toFixed(1)}M` }]
+            : []),
           { label: "Pool", value: sortedAgents.length },
           { label: "Phase", value: faState?.phase ?? "loading" },
         ]}
@@ -1196,6 +1299,11 @@ export default function FreeAgency({
       )}
 
       <CapBanner userTeam={userTeam} />
+      <PendingOffersPanel
+        pendingOffers={faState?.pendingOffers}
+        capSummary={faState?.capSummary}
+        onWithdraw={handleWithdrawOffer}
+      />
       <PendingCapImpactPanel reservation={pendingCapReservation} />
 
       {flash && (
@@ -1664,6 +1772,16 @@ export default function FreeAgency({
                         <TableCell><PosBadge pos={player.pos} /></TableCell>
                         <TableCell onClick={() => onPlayerSelect && onPlayerSelect(player.id, buildFreeAgencyProfileContext(player.market ?? player))} style={{ fontWeight: 600, color: "var(--text)", cursor: onPlayerSelect ? "pointer" : "default" }}>
                           <span style={{ borderBottom: onPlayerSelect ? "1px dotted var(--text-muted)" : "none" }}>{player.name}</span>
+                          {(() => {
+                            const offerStatus = offerStatusByPlayer.get(player.id);
+                            if (!offerStatus) return null;
+                            const tone = OFFER_STATUS_TONE[offerStatus.status] ?? "var(--text-muted)";
+                            return (
+                              <span style={{ marginLeft: 6, fontSize: 10, fontWeight: 700, color: tone, border: `1px solid ${tone}`, borderRadius: 999, padding: "0 6px" }}>
+                                {OFFER_STATUS_LABEL[offerStatus.status] ?? "Pending"}
+                              </span>
+                            );
+                          })()}
                           <div style={{ fontSize: 10, color: "var(--text-subtle)", marginTop: 2 }}>
                             {player?._eval?.archetype?.archetype ?? "Balanced"} · {player?._eval?.roleProjection?.replaceContext ?? "Depth option"}
                           </div>

--- a/src/ui/components/FreeAgency.pendingOffers.test.jsx
+++ b/src/ui/components/FreeAgency.pendingOffers.test.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import { PendingOffersPanel } from './FreeAgency.jsx';
+
+const baseOffer = {
+  id: 'fa-offer-1-5-1-1000',
+  playerId: 1,
+  playerName: 'Pending WR',
+  pos: 'WR',
+  teamId: 5,
+  years: 3,
+  totalValue: 36,
+  annualCapHit: 12,
+  status: 'pending',
+  feedback: ['Competitive offer — close to the player’s asking price.'],
+  competingTeamIds: [8, 12],
+};
+
+const offers = [
+  baseOffer,
+  { ...baseOffer, id: 'o2', playerId: 2, playerName: 'Accepted QB', pos: 'QB', status: 'accepted', feedback: ['Accepted — best current offer after day advanced.'], competingTeamIds: [] },
+  { ...baseOffer, id: 'o3', playerId: 3, playerName: 'Rejected RB', pos: 'RB', status: 'rejected', feedback: ['Rejected — signed with Rivals instead.'], competingTeamIds: [] },
+  { ...baseOffer, id: 'o4', playerId: 4, playerName: 'Expired TE', pos: 'TE', status: 'expired', feedback: ['Expired — the negotiation window closed without a deal.'], competingTeamIds: [] },
+];
+
+const capSummary = { capRoom: 40, reservedPendingCap: 12, effectiveCapRoom: 28 };
+
+// renderToString inserts `<!-- -->` markers between text segments; strip them
+// so assertions can match user-visible strings.
+const renderHtml = (node) => renderToString(node).replace(/<!-- -->/g, '');
+
+describe('PendingOffersPanel', () => {
+  it('shows each offer with its pending/accepted/rejected/expired status and feedback', () => {
+    const html = renderHtml(
+      <PendingOffersPanel pendingOffers={offers} capSummary={capSummary} onWithdraw={() => {}} />,
+    );
+    expect(html).toContain('Pending WR');
+    expect(html).toContain('>Pending<');
+    expect(html).toContain('Accepted QB');
+    expect(html).toContain('>Accepted<');
+    expect(html).toContain('Rejected RB');
+    expect(html).toContain('>Rejected<');
+    expect(html).toContain('Expired TE');
+    expect(html).toContain('>Expired<');
+    expect(html).toContain('Accepted — best current offer after day advanced.');
+    expect(html).toContain('Rejected — signed with Rivals instead.');
+    expect(html).toContain('2 competing teams bidding');
+  });
+
+  it('shows effective cap room net of pending reservations', () => {
+    const html = renderHtml(
+      <PendingOffersPanel pendingOffers={offers} capSummary={capSummary} />,
+    );
+    expect(html).toContain('Effective cap: $28.0M (reserved $12.0M)');
+  });
+
+  it('offers a withdraw action only for pending offers', () => {
+    const html = renderHtml(
+      <PendingOffersPanel pendingOffers={offers} capSummary={capSummary} onWithdraw={() => {}} />,
+    );
+    expect((html.match(/Withdraw/g) ?? []).length).toBe(1);
+  });
+
+  it('renders nothing when there are no offers and no reserved cap', () => {
+    const html = renderHtml(
+      <PendingOffersPanel pendingOffers={[]} capSummary={{ capRoom: 40, reservedPendingCap: 0, effectiveCapRoom: 40 }} />,
+    );
+    expect(html).toBe('');
+  });
+});

--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -616,6 +616,10 @@ export function useWorker() {
     submitOffer: (playerId, teamId, contract) =>
       request(toWorker.SUBMIT_OFFER, { playerId, teamId, contract }),
 
+    /** Withdraw a pending free agency offer (releases its cap reservation). */
+    withdrawOffer: (playerId, teamId) =>
+      request(toWorker.WITHDRAW_OFFER, { playerId, teamId }),
+
     /** Release a player. */
     releasePlayer: (playerId, teamId) =>
       send(toWorker.RELEASE_PLAYER, { playerId, teamId }),

--- a/src/worker/protocol.js
+++ b/src/worker/protocol.js
@@ -53,6 +53,7 @@ export const toWorker = Object.freeze({
   /** Free agency */
   SIGN_PLAYER:        'SIGN_PLAYER',       // { playerId, teamId, contract }
   SUBMIT_OFFER:       'SUBMIT_OFFER',      // { playerId, teamId, contract }
+  WITHDRAW_OFFER:     'WITHDRAW_OFFER',    // { playerId, teamId }
   ADVANCE_FREE_AGENCY_DAY: 'ADVANCE_FREE_AGENCY_DAY', // {}
   RELEASE_PLAYER:     'RELEASE_PLAYER',    // { playerId, teamId }
   BULK_RELEASE_PLAYERS: 'BULK_RELEASE_PLAYERS', // { teamId, playerIds: number[] }

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -102,6 +102,20 @@ import { generateSlottedRookieContract } from '../core/contracts/rookieWageScale
 import { summarizePlayerMood } from '../core/mood/playerMood.js';
 import { getFreeAgencyDecisionState } from '../core/freeAgency/decisionState.js';
 import {
+  PENDING_OFFER_STATUS,
+  ensurePendingOffersList,
+  createPendingOffer,
+  upsertPendingOffer,
+  computeReservedPendingCap,
+  validateOfferAgainstReservedCap,
+  buildOfferFeedback,
+  agePendingOffers,
+  markOfferResolved,
+  reconcilePendingOffers,
+  expireAllPendingOffers,
+  prunePendingOffers,
+} from '../core/freeAgency/pendingOffers.js';
+import {
   calculateOffensiveSchemeFit, calculateDefensiveSchemeFit,
   computeTeamSchemeFits, schemeOvrBonus, recalcTeamSchemeFit,
   OFFENSIVE_SCHEMES, DEFENSIVE_SCHEMES,
@@ -987,6 +1001,8 @@ function buildViewState() {
     schedule:   meta?.schedule    ?? null,
     offseasonProgressionDone: meta?.offseasonProgressionDone ?? false,
     freeAgencyState: meta?.freeAgencyState ?? null,
+    pendingOffers: ensurePendingOffersList(meta?.pendingOffers)
+      .filter((row) => Number(row.teamId) === Number(meta?.userTeamId)),
     draftStarted: !!(meta?.draftState),
     draftLifecycleStatus: resolveDraftLifecycleStatus(meta),
     nextGameStakes,
@@ -3163,6 +3179,10 @@ async function handleAdvanceWeek(payload, id) {
   if (meta.phase === 'regular' || meta.phase === 'preseason') {
     try {
       await resolvePendingFreeAgencyOffers({ resolutionDay: 7, emitNotifications: true });
+      // In-season, each week counts as one "day" for pending offer aging so
+      // lowball bids still reject/expire instead of reserving cap forever.
+      savePendingOffersLedger(agePendingOffers(getPendingOffersLedger()));
+      syncPendingOfferLedger({ emitNotifications: true });
     } catch (faErr) {
       console.warn('[Worker] in-season FA offer resolution error (non-fatal):', faErr.message);
     }
@@ -5855,6 +5875,89 @@ async function handleSignPlayer({ playerId, teamId, contract }, id) {
 
 // ── Handler: SUBMIT_OFFER ─────────────────────────────────────────────────────
 
+// ── Pending offer ledger (Free Agency Market V2) ─────────────────────────────
+// League-level record of submitted offers, persisted on meta.pendingOffers.
+// Pending entries reserve cap room; resolved entries keep their feedback so
+// the UI can explain why an offer was accepted, rejected, or expired.
+
+function getPendingOffersLedger() {
+  return ensurePendingOffersList(cache.getMeta()?.pendingOffers);
+}
+
+function savePendingOffersLedger(list, { day = null } = {}) {
+  const faDay = day ?? Number(cache.getMeta()?.freeAgencyState?.day ?? 1);
+  cache.setMeta({ pendingOffers: prunePendingOffers(list, { day: faDay }) });
+}
+
+/** Demand snapshot used for offer feedback + weak-offer detection. Mirrors the ask shown in GET_FREE_AGENTS. */
+function buildDemandSnapshotForOffer(player, team) {
+  const meta = ensureDynastyMeta(cache.getMeta());
+  const allFreeAgents = cache.getAllPlayers().filter((p) => !p.teamId || p.status === 'free_agent');
+  const heat = computeMarketHeat(player.pos, allFreeAgents);
+  const profile = buildContractProfile(player);
+  const wins = Number(team?.wins ?? 0);
+  const losses = Number(team?.losses ?? 0);
+  const ties = Number(team?.ties ?? 0);
+  const games = wins + losses + ties;
+  const ask = inflateContract(buildDemandFromProfile(player, profile, {
+    marketHeat: heat,
+    morale: player.morale ?? 68,
+    fit: Number(player?.schemeFit ?? 65),
+    teamSuccess: games > 0 ? (wins + ties * 0.5) / games : 0.5,
+  }), getSalaryInflationMultiplier(meta?.economy ?? {}));
+  return {
+    baseAnnual: ask.baseAnnual,
+    yearsTotal: ask.yearsTotal,
+    signingBonus: ask.signingBonus,
+    guaranteedPct: ask.guaranteedPct,
+    willingness: ask.willingness,
+    marketHeat: Math.round(heat * 100) / 100,
+  };
+}
+
+/**
+ * Reconcile the pending offer ledger against live player state: mark offers
+ * accepted/rejected/expired, refresh competing-team snapshots, and strip dead
+ * bids from player.offers so they stop influencing decisions. Idempotent.
+ */
+function syncPendingOfferLedger({ day = null, emitNotifications = false } = {}) {
+  const meta = ensureDynastyMeta(cache.getMeta());
+  const ledger = ensurePendingOffersList(meta.pendingOffers);
+  if (ledger.length === 0) return { accepted: [], rejected: [], expired: [] };
+  const faDay = day ?? Number(meta?.freeAgencyState?.day ?? 1);
+
+  const { list, accepted, rejected, expired, offerRemovals } = reconcilePendingOffers({
+    pendingOffers: ledger,
+    resolvePlayer: (pid) => cache.getPlayer(pid),
+    resolveTeamName: (tid) => cache.getTeam(tid)?.name ?? null,
+    day: faDay,
+  });
+
+  for (const removal of offerRemovals) {
+    const player = cache.getPlayer(removal.playerId);
+    if (!player || !Array.isArray(player.offers)) continue;
+    cache.updatePlayer(player.id, {
+      offers: player.offers.filter((o) => Number(o?.teamId) !== Number(removal.teamId)),
+    });
+  }
+
+  savePendingOffersLedger(list, { day: faDay });
+
+  if (emitNotifications) {
+    const userTeamId = Number(meta?.userTeamId);
+    for (const row of accepted) {
+      if (Number(row.teamId) !== userTeamId) continue;
+      post(toUI.NOTIFICATION, { level: 'info', message: `${row.playerName ?? 'Free agent'} accepted your ${row.years}-year, $${row.totalValue}M offer.` });
+    }
+    for (const row of [...rejected, ...expired]) {
+      if (Number(row.teamId) !== userTeamId) continue;
+      post(toUI.NOTIFICATION, { level: 'warn', message: `${row.playerName ?? 'Free agent'}: ${row.feedback?.[0] ?? 'Offer is off the table.'}` });
+    }
+  }
+
+  return { accepted, rejected, expired };
+}
+
 async function handleSubmitOffer({ playerId, teamId, contract }, id) {
   const teamCtx = resolveTeamContext(teamId);
   if (!teamCtx.ok) { post(toUI.ERROR, { message: teamCtx.message }, id); return; }
@@ -5863,11 +5966,20 @@ async function handleSubmitOffer({ playerId, teamId, contract }, id) {
   const player = cache.getPlayer(playerId);
   if (!player) { post(toUI.ERROR, { message: 'Player not found' }, id); return; }
 
-  // Cap check
+  // Cap check: the offer must fit inside cap room net of what other pending
+  // offers from this team already reserve.
   const capHit = contract.baseAnnual + (contract.signingBonus / contract.yearsTotal);
-  if (team.capRoom < capHit) {
-      post(toUI.ERROR, { message: 'Not enough cap room' }, id);
-      return;
+  const ledger = getPendingOffersLedger();
+  const capCheck = validateOfferAgainstReservedCap({
+    capRoom: team.capRoom ?? 0,
+    annualCapHit: capHit,
+    pendingOffers: ledger,
+    teamId: resolvedTeamId,
+    playerId: player.id,
+  });
+  if (!capCheck.ok) {
+    post(toUI.ERROR, { message: capCheck.message }, id);
+    return;
   }
 
   // Add/Update offer
@@ -5891,6 +6003,36 @@ async function handleSubmitOffer({ playerId, teamId, contract }, id) {
   cache.updatePlayer(playerId, { offers: player.offers });
 
   const liveMeta = ensureDynastyMeta(cache.getMeta());
+
+  // Record the bid in the league-level pending offer ledger (replaces any
+  // previous pending offer from this team on this player).
+  const faDay = Number(liveMeta?.freeAgencyState?.day ?? 1);
+  const demandSnapshot = buildDemandSnapshotForOffer(player, team);
+  const competingTeamIds = player.offers
+    .map((o) => Number(o?.teamId))
+    .filter((tid) => Number.isFinite(tid) && tid !== Number(resolvedTeamId));
+  const quality = buildOfferFeedback({
+    contract,
+    demand: demandSnapshot,
+    playerAge: player.age,
+    competingOfferCount: competingTeamIds.length,
+    capRoomAfter: capCheck.roomAfter,
+  });
+  const offerRecord = createPendingOffer({
+    playerId: player.id,
+    playerName: player.name,
+    pos: player.pos,
+    ovr: player.ovr,
+    teamId: resolvedTeamId,
+    teamName: team.name,
+    contract,
+    day: faDay,
+    demandSnapshot,
+    competingTeamIds,
+    feedback: quality.feedback,
+    score: quality.score,
+  });
+  savePendingOffersLedger(upsertPendingOffer(ledger, offerRecord).list, { day: faDay });
   const allFreeAgents = cache.getAllPlayers().filter((p) => !p.teamId || p.status === 'free_agent');
   const heat = computeMarketHeat(player.pos, allFreeAgents);
   const marketMemory = liveMeta?.contractMarketMemory?.[String(playerId)] ?? {};
@@ -5904,6 +6046,9 @@ async function handleSubmitOffer({ playerId, teamId, contract }, id) {
       onlyPlayerId: playerId,
       emitNotifications: false,
     });
+    // Mirror any immediate resolution into the ledger so the offer's status
+    // reads accepted/rejected instead of dangling as pending.
+    syncPendingOfferLedger({ day: faDay });
   }
 
   await flushDirty();
@@ -5911,7 +6056,8 @@ async function handleSubmitOffer({ playerId, teamId, contract }, id) {
   // Return updated FA data view so UI reflects the offer immediately
   // Also state update
   await handleGetFreeAgents({}, null); // Broadcast FA update if needed, but easier to just reply success
-  post(toUI.STATE_UPDATE, buildViewState(), id);
+  const submittedOffer = getPendingOffersLedger().find((row) => row.id === offerRecord.id) ?? offerRecord;
+  post(toUI.STATE_UPDATE, { ...buildViewState(), submittedOffer }, id);
 
   if (immediateOutcome?.signedCount > 0) {
     const resolved = immediateOutcome.results?.[0];
@@ -5928,6 +6074,35 @@ async function handleSubmitOffer({ playerId, teamId, contract }, id) {
   } else if (!immediateOutcome) {
     post(toUI.NOTIFICATION, { level: 'info', message: `${player.name} logged your bid. ${decisionTiming.reason}.` });
   }
+}
+
+// ── Handler: WITHDRAW_OFFER ───────────────────────────────────────────────────
+
+async function handleWithdrawOffer({ playerId, teamId }, id) {
+  const teamCtx = resolveTeamContext(teamId);
+  if (!teamCtx.ok) { post(toUI.ERROR, { message: teamCtx.message }, id); return; }
+  const { teamId: resolvedTeamId } = teamCtx;
+
+  const player = cache.getPlayer(playerId);
+  if (player && Array.isArray(player.offers)) {
+    const nextOffers = player.offers.filter((o) => Number(o?.teamId) !== Number(resolvedTeamId));
+    if (nextOffers.length !== player.offers.length) {
+      cache.updatePlayer(player.id, { offers: nextOffers });
+    }
+  }
+
+  const faDay = Number(cache.getMeta()?.freeAgencyState?.day ?? 1);
+  savePendingOffersLedger(markOfferResolved(getPendingOffersLedger(), {
+    playerId,
+    teamId: resolvedTeamId,
+    status: PENDING_OFFER_STATUS.WITHDRAWN,
+    feedback: 'Offer withdrawn — cap reservation released.',
+    day: faDay,
+  }), { day: faDay });
+
+  await flushDirty();
+  await handleGetFreeAgents({}, null);
+  post(toUI.STATE_UPDATE, buildViewState(), id);
 }
 
 async function finalizeFreeAgencySigning(player, offer, liveMeta) {
@@ -6067,6 +6242,27 @@ function evaluatePlayerOfferDecision(player, offers = [], liveMeta, memory = {})
     timing.eliteMarket
       || ((player?.ovr ?? 0) >= 84 && offers.length >= 2 && heat >= 1.08 && moneyGapRatio >= minimumGapForWait)
   );
+
+  // Market V2: a best offer clearly below the asking price never auto-signs.
+  // The player holds out; the pending-offer ledger rejects/expires the bid
+  // after its short review window instead.
+  if (topValue < askTotalValue * 0.75) {
+    return {
+      status: 'pending',
+      reason: 'Low annual value — waiting for a better market',
+      bestOffer,
+      topValue,
+      askTotalValue,
+      timing,
+      marketHeat: heat,
+      bidderCount: offers.length,
+      userBidValue,
+      moneyGapRatio,
+      state: 'holding_for_improvement',
+      urgency: timing.risk,
+      negotiation: bestOffer?._evaluation ?? null,
+    };
+  }
 
   if (!timing.resolveNow && shouldWaitForMoney && canUseWaitState) {
     return {
@@ -6638,7 +6834,20 @@ async function handleGetFreeAgents(payload, id) {
   const faDay = meta.freeAgencyState?.day ?? 1;
   const faMaxDays = meta.freeAgencyState?.maxDays ?? 5;
 
-  post(toUI.FREE_AGENT_DATA, { freeAgents, faDay, faMaxDays, phase: meta.phase }, id);
+  // Market V2: the user team's pending offer ledger + cap reservation summary.
+  const offerLedger = ensurePendingOffersList(meta.pendingOffers);
+  const pendingOffers = offerLedger
+    .filter((row) => Number(row.teamId) === Number(userTeamId))
+    .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+  const reservedPendingCap = computeReservedPendingCap(offerLedger, userTeamId);
+  const userCapRoom = Math.round(Number(userTeam?.capRoom ?? 0) * 10) / 10;
+  const capSummary = {
+    capRoom: userCapRoom,
+    reservedPendingCap,
+    effectiveCapRoom: Math.round((userCapRoom - reservedPendingCap) * 10) / 10,
+  };
+
+  post(toUI.FREE_AGENT_DATA, { freeAgents, faDay, faMaxDays, phase: meta.phase, pendingOffers, capSummary }, id);
 }
 
 // ── Handler: COACHING ACTIONS ────────────────────────────────────────────────
@@ -9486,6 +9695,7 @@ async function handleAdvanceOffseason(payload, id) {
     freeAgencyState: { day: 1, maxDays: 5, complete: false },
     contractMarketMemory: {},
     offseasonFaMovements: [],
+    pendingOffers: [],
   });
 
   // AUTO-SAVE: phase transition — flush all progression/retirement changes before notifying UI.
@@ -9515,6 +9725,12 @@ async function handleAdvanceFreeAgencyDay(payload, id) {
 
     const { day, maxDays } = meta.freeAgencyState;
 
+    // ── Market V2 pre-pass ──────────────────────────────────────────────────
+    // Every pending offer ages by one day, then clearly-weak or stale bids
+    // reject/expire BEFORE the market acts so players can't sign a dead bid.
+    savePendingOffersLedger(agePendingOffers(getPendingOffersLedger()), { day });
+    syncPendingOfferLedger({ day, emitNotifications: true });
+
     if (day > maxDays) {
         // FA is already over — ensure the phase advanced correctly (idempotent).
         if (meta.phase === 'free_agency') {
@@ -9528,6 +9744,12 @@ async function handleAdvanceFreeAgencyDay(payload, id) {
 
     // Process Day
     await AiLogic.processFreeAgencyDay(day);
+
+    // ── Market V2 post-pass ─────────────────────────────────────────────────
+    // Reconcile the ledger against today's signings: mark accepted offers,
+    // reject offers for players who signed elsewhere, refresh competition.
+    syncPendingOfferLedger({ day, emitNotifications: true });
+
     const faEvents = generateDynamicEvents({
       players: cache.getAllPlayers(),
       teams: cache.getAllTeams(),
@@ -9560,6 +9782,21 @@ async function handleAdvanceFreeAgencyDay(payload, id) {
     };
 
     if (isComplete) {
+        // Close the negotiation market: any offer still pending expires and
+        // releases its cap reservation, and unresolved bids on players come
+        // off the table so they don't linger into the draft/season.
+        const closed = expireAllPendingOffers(getPendingOffersLedger(), { day: nextDay });
+        savePendingOffersLedger(closed.list, { day: nextDay });
+        const userTeamIdNum = Number(meta?.userTeamId);
+        for (const row of closed.expired) {
+            if (Number(row.teamId) !== userTeamIdNum) continue;
+            post(toUI.NOTIFICATION, { level: 'warn', message: `${row.playerName ?? 'Free agent'}: offer expired — free agency period ended.` });
+        }
+        for (const fa of cache.getAllPlayers()) {
+            if ((!fa.teamId || fa.status === 'free_agent') && Array.isArray(fa.offers) && fa.offers.length > 0) {
+                cache.updatePlayer(fa.id, { offers: [] });
+            }
+        }
         const compAwards = awardCompensatoryPicksForUpcomingDraft(ensureCompMeta(cache.getMeta()));
         if (compAwards.length > 0) {
             const preview = compAwards.slice(0, 4)
@@ -10866,6 +11103,7 @@ async function handleMessage(event) {
       case toWorker.SET_USER_TEAM:      return await handleSetUserTeam(payload, id);
       case toWorker.SIGN_PLAYER:        return await handleSignPlayer(payload, id);
       case toWorker.SUBMIT_OFFER:       return await handleSubmitOffer(payload, id);
+      case toWorker.WITHDRAW_OFFER:     return await handleWithdrawOffer(payload, id);
       case toWorker.RELEASE_PLAYER:     return await handleReleasePlayer(payload, id);
       case toWorker.BULK_RELEASE_PLAYERS: return await handleBulkReleasePlayers(payload, id);
       case toWorker.UPDATE_SETTINGS:    return await handleUpdateSettings(payload, id);


### PR DESCRIPTION
- Add league-level pending offer ledger (meta.pendingOffers) with statuses
  pending/accepted/rejected/expired/withdrawn; persists in saves and old
  saves migrate to [] via ensureDynastyMeta.
- Pending offers reserve first-year cap hit; SUBMIT_OFFER now validates
  against effective cap room (cap room minus reserved pending cap) and
  returns deterministic offer feedback vs the player's demand snapshot.
- New WITHDRAW_OFFER worker action (protocol + useWorker) releases a
  pending offer's cap reservation.
- ADVANCE_FREE_AGENCY_DAY ages offers, rejects clearly-below-demand bids
  after a short window, expires stale ones, reconciles accepted/rejected
  outcomes after the AI market acts, and closes all remaining offers when
  the FA period ends.
- Players no longer auto-sign clearly-below-ask offers when patience runs
  out (worker decision + AiLogic.evaluateOffers).
- FreeAgency UI: 'Your offers' panel with status chips, feedback lines,
  withdraw action and effective-cap badge; per-row offer status chip;
  CapManager shows reserved pending cap + effective cap space.
- GET_FREE_AGENTS now returns the user's pendingOffers + capSummary.

https://claude.ai/code/session_01789mG3sHeRULvnpu8WSfXF