### PR TITLE
test(free-agency): post-merge hardening for Market V2 — worker lifecycle, withdraw, resolution sequencing, migration, UI smoke

### DIFF
--- a/src/core/__tests__/dynastyMetaPendingOffersMigration.test.js
+++ b/src/core/__tests__/dynastyMetaPendingOffersMigration.test.js
@@ -1,0 +1,74 @@
+/**
+ * Pre-#1580 save migration — ensureDynastyMeta must hydrate the Market V2
+ * pending-offer ledger on old saves without corrupting adjacent meta fields.
+ * (The worker-path companion lives in
+ * tests/integration/freeAgencyMarketV2.worker.test.js, which round-trips a
+ * stripped meta through the real LOAD_SAVE pipeline.)
+ */
+import { describe, expect, it } from 'vitest';
+import { ensureDynastyMeta } from '../dynasty-story.js';
+
+/** A meta object shaped like a save written before Free Agency Market V2. */
+function buildPreMarketV2Meta() {
+  return {
+    id: 'league',
+    name: 'Legacy Dynasty',
+    userTeamId: 0,
+    year: 2028,
+    season: 3,
+    currentSeasonId: 's3',
+    currentWeek: 1,
+    phase: 'free_agency',
+    freeAgencyState: { day: 3, maxDays: 5, complete: false },
+    contractMarketMemory: { 17: { waitCycles: 2 }, 88: { waitCycles: 0 } },
+    offseasonFaMovements: [
+      { id: 'mv-1', playerId: 17, playerName: 'Legacy Corner', pos: 'CB', prevTeamId: 4, newTeamId: 11 },
+    ],
+    newsItems: [{ id: 'n1', type: 'TRANSACTION', text: 'Legacy Corner signs.' }],
+    socialFeedEntries: [{ id: 'sf1', text: 'Big signing!' }],
+    ownerGoals: [
+      { id: 'g1', type: 'win_games', description: 'Win 10 games', target: 10, current: 4, complete: false, reward: 'Scout budget +$2M' },
+    ],
+    retiredPlayers: [{ id: 901, name: 'Old Guard', pos: 'OL' }],
+    leagueHistory: [{ id: 's2', year: 2027 }],
+    // No pendingOffers key — this save predates the ledger entirely.
+  };
+}
+
+describe('pre-Market-V2 meta migration through ensureDynastyMeta', () => {
+  it('hydrates a missing pendingOffers field to an empty array', () => {
+    const meta = ensureDynastyMeta(buildPreMarketV2Meta());
+    expect(meta.pendingOffers).toEqual([]);
+  });
+
+  it('hydrates non-array pendingOffers corruption to an empty array', () => {
+    for (const bad of [null, 'nope', 42, { 0: {} }]) {
+      const meta = ensureDynastyMeta({ ...buildPreMarketV2Meta(), pendingOffers: bad });
+      expect(meta.pendingOffers).toEqual([]);
+    }
+  });
+
+  it('keeps an existing ledger untouched', () => {
+    const ledger = [{ id: 'fa-offer-1-0-1-1', playerId: 1, teamId: 0, status: 'pending' }];
+    const meta = ensureDynastyMeta({ ...buildPreMarketV2Meta(), pendingOffers: ledger });
+    expect(meta.pendingOffers).toBe(ledger);
+  });
+
+  it('does not corrupt adjacent FA / dynasty / user-team fields', () => {
+    const original = buildPreMarketV2Meta();
+    const meta = ensureDynastyMeta(original);
+
+    expect(meta.userTeamId).toBe(original.userTeamId);
+    expect(meta.phase).toBe('free_agency');
+    expect(meta.freeAgencyState).toEqual(original.freeAgencyState);
+    expect(meta.contractMarketMemory).toEqual(original.contractMarketMemory);
+    expect(meta.offseasonFaMovements).toEqual(original.offseasonFaMovements);
+    expect(meta.newsItems).toEqual(original.newsItems);
+    expect(meta.socialFeedEntries).toEqual(original.socialFeedEntries);
+    expect(meta.ownerGoals).toEqual(original.ownerGoals);
+    expect(meta.retiredPlayers).toEqual(original.retiredPlayers);
+    expect(meta.leagueHistory).toEqual(original.leagueHistory);
+    expect(meta.year).toBe(2028);
+    expect(meta.currentSeasonId).toBe('s3');
+  });
+});

--- a/src/core/freeAgency/__tests__/pendingOffers.test.js
+++ b/src/core/freeAgency/__tests__/pendingOffers.test.js
@@ -219,6 +219,25 @@ describe('daily resolution (reconcile)', () => {
     expect(aged[1].daysPending).toBe(1);
   });
 
+  it('never increments daysPending on any resolved status, even across repeated days', () => {
+    const resolvedStatuses = [
+      PENDING_OFFER_STATUS.ACCEPTED,
+      PENDING_OFFER_STATUS.REJECTED,
+      PENDING_OFFER_STATUS.EXPIRED,
+      PENDING_OFFER_STATUS.WITHDRAWN,
+    ];
+    let ledger = resolvedStatuses.map((status, i) => ({
+      ...makeOffer({ playerId: 100 + i }),
+      status,
+      daysPending: 2,
+      resolvedDay: 3,
+    }));
+    ledger = agePendingOffers(agePendingOffers(agePendingOffers(ledger)));
+    for (const row of ledger) {
+      expect(row.daysPending).toBe(2);
+    }
+  });
+
   it('expires every remaining pending offer when the market closes', () => {
     const { list, expired } = expireAllPendingOffers([makeOffer(), makeOffer({ playerId: 22 })], { day: 6 });
     expect(expired).toHaveLength(2);

--- a/src/ui/components/CapManager.pendingCap.test.jsx
+++ b/src/ui/components/CapManager.pendingCap.test.jsx
@@ -1,0 +1,46 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import CapManager from './CapManager.jsx';
+
+const baseLeague = (pendingOffers) => ({
+  userTeamId: 0,
+  teams: [
+    {
+      id: 0,
+      deadCap: 0,
+      roster: [
+        { id: 1, name: 'Cap QB', pos: 'QB', ovr: 80, age: 27, contract: { salary: 20, years: 3, guaranteed: 10 } },
+      ],
+    },
+  ],
+  pendingOffers,
+});
+
+describe('CapManager pending-offer cap display', () => {
+  afterEach(cleanup);
+
+  it('shows reserved pending cap and effective cap space, counting only pending rows', () => {
+    const { container } = render(
+      <CapManager
+        league={baseLeague([
+          { id: 'o1', status: 'pending', annualCapHit: 12.5 },
+          { id: 'o2', status: 'pending', annualCapHit: 2.5 },
+          // Resolved rows must not reserve cap.
+          { id: 'o3', status: 'accepted', annualCapHit: 40 },
+          { id: 'o4', status: 'withdrawn', annualCapHit: 40 },
+        ])}
+        actions={{}}
+      />,
+    );
+    expect(container.textContent).toContain('Pending FA offers reserve $15.0M');
+    expect(container.textContent).toContain('Effective cap space: $165.0M');
+  });
+
+  it('hides the reserved line when no offers are pending', () => {
+    const { container } = render(<CapManager league={baseLeague([])} actions={{}} />);
+    expect(container.textContent).not.toContain('Pending FA offers reserve');
+    expect(container.textContent).toContain('Dead Cap');
+  });
+});

--- a/src/ui/components/CapManager.pendingCap.test.jsx
+++ b/src/ui/components/CapManager.pendingCap.test.jsx
@@ -3,6 +3,14 @@ import React from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { cleanup, render } from '@testing-library/react';
 import CapManager from './CapManager.jsx';
+import { SALARY_CAP_AMOUNT } from '../../core/constants.js';
+
+const ROSTER_SALARY = 20; // single QB at $20M in the test fixture
+const PENDING_RESERVED = 15; // two pending offers: $12.5M + $2.5M
+// Expected effective cap: SALARY_CAP_AMOUNT - ROSTER_SALARY - PENDING_RESERVED
+// Uses the real cap constant so a league-ceiling change produces a clear
+// failure here rather than a misleading pending-cap math message.
+const EXPECTED_EFFECTIVE = SALARY_CAP_AMOUNT - ROSTER_SALARY - PENDING_RESERVED;
 
 const baseLeague = (pendingOffers) => ({
   userTeamId: 0,
@@ -11,7 +19,7 @@ const baseLeague = (pendingOffers) => ({
       id: 0,
       deadCap: 0,
       roster: [
-        { id: 1, name: 'Cap QB', pos: 'QB', ovr: 80, age: 27, contract: { salary: 20, years: 3, guaranteed: 10 } },
+        { id: 1, name: 'Cap QB', pos: 'QB', ovr: 80, age: 27, contract: { salary: ROSTER_SALARY, years: 3, guaranteed: 10 } },
       ],
     },
   ],
@@ -34,8 +42,8 @@ describe('CapManager pending-offer cap display', () => {
         actions={{}}
       />,
     );
-    expect(container.textContent).toContain('Pending FA offers reserve $15.0M');
-    expect(container.textContent).toContain('Effective cap space: $165.0M');
+    expect(container.textContent).toContain(`Pending FA offers reserve $${PENDING_RESERVED.toFixed(1)}M`);
+    expect(container.textContent).toContain(`Effective cap space: $${EXPECTED_EFFECTIVE.toFixed(1)}M`);
   });
 
   it('hides the reserved line when no offers are pending', () => {

--- a/src/ui/components/FreeAgency.pendingOffers.test.jsx
+++ b/src/ui/components/FreeAgency.pendingOffers.test.jsx
@@ -1,6 +1,8 @@
+/** @vitest-environment jsdom */
 import React from 'react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { renderToString } from 'react-dom/server';
+import { cleanup, render, fireEvent } from '@testing-library/react';
 import { PendingOffersPanel } from './FreeAgency.jsx';
 
 const baseOffer = {
@@ -31,6 +33,8 @@ const capSummary = { capRoom: 40, reservedPendingCap: 12, effectiveCapRoom: 28 }
 const renderHtml = (node) => renderToString(node).replace(/<!-- -->/g, '');
 
 describe('PendingOffersPanel', () => {
+  afterEach(cleanup);
+
   it('shows each offer with its pending/accepted/rejected/expired status and feedback', () => {
     const html = renderHtml(
       <PendingOffersPanel pendingOffers={offers} capSummary={capSummary} onWithdraw={() => {}} />,
@@ -67,5 +71,37 @@ describe('PendingOffersPanel', () => {
       <PendingOffersPanel pendingOffers={[]} capSummary={{ capRoom: 40, reservedPendingCap: 0, effectiveCapRoom: 40 }} />,
     );
     expect(html).toBe('');
+  });
+
+  it('renders the panel with the effective-cap badge when pending offers exist', () => {
+    const { getByTestId } = render(
+      <PendingOffersPanel pendingOffers={offers} capSummary={capSummary} onWithdraw={() => {}} />,
+    );
+    expect(getByTestId('pending-offers-panel')).toBeTruthy();
+    expect(getByTestId('effective-cap-badge').textContent).toContain('Effective cap: $28.0M (reserved $12.0M)');
+    expect(getByTestId(`pending-offer-${baseOffer.playerId}`)).toBeTruthy();
+  });
+
+  it('clicking Withdraw invokes the withdraw action with the offer playerId', () => {
+    const onWithdraw = vi.fn();
+    const { getByText } = render(
+      <PendingOffersPanel pendingOffers={[baseOffer]} capSummary={capSummary} onWithdraw={onWithdraw} />,
+    );
+    fireEvent.click(getByText('Withdraw'));
+    expect(onWithdraw).toHaveBeenCalledTimes(1);
+    expect(onWithdraw).toHaveBeenCalledWith(baseOffer.playerId);
+  });
+
+  it('keeps the Withdraw button in the DOM for very long player names', () => {
+    const longName = 'Bartholomew Maximiliano Featherstonehaugh-Cholmondeley von Hohenzollern III';
+    const { getByText } = render(
+      <PendingOffersPanel
+        pendingOffers={[{ ...baseOffer, playerName: longName }]}
+        capSummary={capSummary}
+        onWithdraw={() => {}}
+      />,
+    );
+    expect(getByText(new RegExp(longName.slice(0, 30)))).toBeTruthy();
+    expect(getByText('Withdraw')).toBeTruthy();
   });
 });

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -5892,7 +5892,7 @@ function savePendingOffersLedger(list, { day = null } = {}) {
 /** Demand snapshot used for offer feedback + weak-offer detection. Mirrors the ask shown in GET_FREE_AGENTS. */
 function buildDemandSnapshotForOffer(player, team) {
   const meta = ensureDynastyMeta(cache.getMeta());
-  const allFreeAgents = cache.getAllPlayers().filter((p) => !p.teamId || p.status === 'free_agent');
+  const allFreeAgents = cache.getAllPlayers().filter((p) => p.teamId == null || p.status === 'free_agent');
   const heat = computeMarketHeat(player.pos, allFreeAgents);
   const profile = buildContractProfile(player);
   const wins = Number(team?.wins ?? 0);
@@ -6626,7 +6626,9 @@ async function handleGetFreeAgents(payload, id) {
   const meta = ensureDynastyMeta(cache.getMeta());
   const inflationMult = getSalaryInflationMultiplier(meta?.economy ?? {});
   const userTeamId = meta.userTeamId;
-  const allFreeAgents = cache.getAllPlayers().filter((p) => !p.teamId || p.status === 'free_agent');
+  // teamId 0 is a valid franchise (the default user team) — only a null/undefined
+  // teamId means unsigned, so accepted players never linger in the FA pool.
+  const allFreeAgents = cache.getAllPlayers().filter((p) => p.teamId == null || p.status === 'free_agent');
   const userTeam = cache.getTeam(userTeamId);
   const userDirection = inferTeamDirection(userTeam, Number(meta?.currentWeek ?? 1));
   const userWinPct = Math.max(0, Math.min(1, (() => {
@@ -9793,7 +9795,7 @@ async function handleAdvanceFreeAgencyDay(payload, id) {
             post(toUI.NOTIFICATION, { level: 'warn', message: `${row.playerName ?? 'Free agent'}: offer expired — free agency period ended.` });
         }
         for (const fa of cache.getAllPlayers()) {
-            if ((!fa.teamId || fa.status === 'free_agent') && Array.isArray(fa.offers) && fa.offers.length > 0) {
+            if ((fa.teamId == null || fa.status === 'free_agent') && Array.isArray(fa.offers) && fa.offers.length > 0) {
                 cache.updatePlayer(fa.id, { offers: [] });
             }
         }

--- a/tests/integration/freeAgencyMarketV2.worker.test.js
+++ b/tests/integration/freeAgencyMarketV2.worker.test.js
@@ -1,0 +1,418 @@
+/**
+ * Free Agency Market V2 — worker lifecycle integration tests (post-merge hardening).
+ *
+ * Drives the REAL worker message path (self.onmessage → handleMessage) against a
+ * full safe-starter league in Node with fake IndexedDB, the same way
+ * src/testSupport/dynastySoakRunner.js boots the worker. Covers:
+ *   - SUBMIT_OFFER → meta.pendingOffers ledger row + player.offers + cap reservation
+ *   - GET_FREE_AGENTS pendingOffers / capSummary payload
+ *   - WITHDRAW_OFFER releases the reservation and strips the player bid
+ *   - ADVANCE_FREE_AGENCY_DAY sequencing: age → reject/expire → market → reconcile
+ *   - strong offers accept (roster join, FA pool removal), weak offers never
+ *     force-sign through the old day-3 patience behavior
+ *   - save/load preserves pending offers; pre-#1580 saves hydrate pendingOffers: []
+ */
+import 'fake-indexeddb/auto';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { toWorker, toUI } from '../../src/worker/protocol.js';
+import { cache } from '../../src/db/cache.js';
+import { Meta } from '../../src/db/index.js';
+import { ensureDynastyMeta } from '../../src/core/dynasty-story.js';
+import { PENDING_OFFER_STATUS } from '../../src/core/freeAgency/pendingOffers.js';
+
+const SLOT_KEY = 'save_slot_1';
+const USER_TEAM_ID = 0;
+const BOOT_TIMEOUT_MS = 180_000;
+const TEST_TIMEOUT_MS = 120_000;
+
+// ── Minimal worker bridge (modeled on dynastySoakRunner.ensureSelfBridge) ──────
+
+const allMessages = [];
+const waiters = new Map();
+let msgSeq = 0;
+
+function installSelfBridge() {
+  globalThis.self = {
+    onmessage: null,
+    postMessage(msg) {
+      allMessages.push(msg);
+      if (msg?.id != null && waiters.has(msg.id)) {
+        const resolve = waiters.get(msg.id);
+        waiters.delete(msg.id);
+        resolve(msg);
+      }
+    },
+  };
+}
+
+/** Parse the optional JSON fast-path used by post() for large payloads. */
+function payloadOf(msg) {
+  const p = msg?.payload;
+  if (p && typeof p._jsonPayload === 'string') return JSON.parse(p._jsonPayload);
+  return p;
+}
+
+/**
+ * Send a worker message and resolve with the id-correlated reply. The worker
+ * serializes all messages through its internal promise queue, so awaiting each
+ * send keeps the test deterministic.
+ */
+function send(type, payload = {}, { timeoutMs = 60_000 } = {}) {
+  const id = `fa-v2-test-${++msgSeq}`;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      waiters.delete(id);
+      reject(new Error(`Timeout (${timeoutMs}ms) waiting for reply to ${type}`));
+    }, timeoutMs);
+    waiters.set(id, (msg) => {
+      clearTimeout(timer);
+      resolve(msg);
+    });
+    globalThis.self.onmessage({ data: { type, payload, id } });
+  });
+}
+
+/**
+ * ADVANCE_FREE_AGENCY_DAY posts no id-correlated reply; queue a GET_FREE_AGENTS
+ * behind it — the worker's message queue guarantees the advance fully completes
+ * first — and return the fresh FA payload.
+ */
+async function advanceFaDayAndRefresh() {
+  globalThis.self.onmessage({ data: { type: toWorker.ADVANCE_FREE_AGENCY_DAY, payload: {} } });
+  const reply = await send(toWorker.GET_FREE_AGENTS, {});
+  expect(reply.type).toBe(toUI.FREE_AGENT_DATA);
+  return payloadOf(reply);
+}
+
+async function getFreeAgents() {
+  const reply = await send(toWorker.GET_FREE_AGENTS, {});
+  expect(reply.type).toBe(toUI.FREE_AGENT_DATA);
+  return payloadOf(reply);
+}
+
+function getLedger() {
+  return ensureDynastyMeta(cache.getMeta()).pendingOffers;
+}
+
+// ── League fixtures ────────────────────────────────────────────────────────────
+
+/**
+ * Put the league into a fresh free-agency state. Each scenario resets the
+ * ledger and the FA day clock so prior scenarios cannot leak into it.
+ */
+function enterFreeAgency() {
+  cache.setMeta({
+    phase: 'free_agency',
+    freeAgencyState: { day: 1, maxDays: 5, complete: false },
+    pendingOffers: [],
+    contractMarketMemory: {},
+    offseasonFaMovements: [],
+  });
+  cache.updateTeam(USER_TEAM_ID, { capRoom: 150 });
+}
+
+/**
+ * Convert a roster player from a donor AI team into a high-leverage free agent.
+ * ovr 92 / age 24 keeps buildDecisionTiming out of the `decision_imminent`
+ * immediate-resolution path so submitted offers stay pending (Market V2 flow).
+ */
+function makeFreeAgentFromTeam(donorTeamId, { ovr = 92, age = 24 } = {}) {
+  const donor = cache.getTeam(donorTeamId);
+  const player = cache.getPlayersByTeam(donorTeamId).find((p) => p?.id != null);
+  expect(player, `donor team ${donorTeamId} has no players`).toBeTruthy();
+  cache.updatePlayer(player.id, {
+    teamId: null,
+    status: 'free_agent',
+    offers: [],
+    ovr,
+    age,
+    morale: 70,
+  });
+  cache.updateTeam(donorTeamId, {
+    rosterIds: (donor.rosterIds ?? []).filter((pid) => pid !== player.id),
+    rosterCount: Math.max(0, Number(donor.rosterCount ?? 1) - 1),
+  });
+  return cache.getPlayer(player.id);
+}
+
+/** Read the player's current asking price from the real GET_FREE_AGENTS payload. */
+async function getAsk(playerId) {
+  const fa = await getFreeAgents();
+  const row = fa.freeAgents.find((p) => p.id === playerId);
+  expect(row, `player ${playerId} missing from GET_FREE_AGENTS`).toBeTruthy();
+  return { askAnnual: Number(row.demandProfile.askAnnual), askYears: Number(row.demandProfile.askYears) };
+}
+
+function offerCapHit(contract) {
+  return Math.round((contract.baseAnnual + contract.signingBonus / contract.yearsTotal) * 10) / 10;
+}
+
+// ── Boot ───────────────────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  installSelfBridge();
+  await import('../../src/worker/worker.js');
+  const ready = await send(toWorker.INIT, {}, { timeoutMs: BOOT_TIMEOUT_MS });
+  expect(ready.type).toBe(toUI.READY);
+  const boot = await send(
+    toWorker.USE_SAFE_STARTER_LEAGUE,
+    { slotKey: SLOT_KEY, options: { rngSeed: 20260612, userTeamId: USER_TEAM_ID, name: 'FA Market V2 Hardening' } },
+    { timeoutMs: BOOT_TIMEOUT_MS },
+  );
+  expect(boot.type).toBe(toUI.FULL_STATE);
+}, BOOT_TIMEOUT_MS);
+
+afterAll(() => {
+  delete globalThis.self;
+});
+
+// ── TASK 1: submit through the real worker path ────────────────────────────────
+
+describe('SUBMIT_OFFER worker lifecycle', () => {
+  let fa;
+  let contract;
+
+  it('records a pending ledger row, the player bid, and the cap reservation', async () => {
+    enterFreeAgency();
+    fa = makeFreeAgentFromTeam(2);
+    const { askAnnual, askYears } = await getAsk(fa.id);
+    contract = {
+      baseAnnual: Math.round(askAnnual * 1.2 * 10) / 10,
+      yearsTotal: askYears,
+      signingBonus: Math.round(askAnnual * 10) / 10,
+    };
+
+    const reply = await send(toWorker.SUBMIT_OFFER, { playerId: fa.id, teamId: USER_TEAM_ID, contract });
+    expect(reply.type).toBe(toUI.STATE_UPDATE);
+
+    // League-level ledger holds exactly one pending row for this bid.
+    const ledger = getLedger();
+    expect(ledger).toHaveLength(1);
+    const row = ledger[0];
+    expect(row.status).toBe(PENDING_OFFER_STATUS.PENDING);
+    expect(row.playerId).toBe(Number(fa.id));
+    expect(row.teamId).toBe(USER_TEAM_ID);
+    expect(row.annualCapHit).toBeCloseTo(offerCapHit(contract), 1);
+    expect(Array.isArray(row.feedback)).toBe(true);
+    expect(row.feedback.length).toBeGreaterThan(0);
+    expect(row.playerDemandSnapshot).toBeTruthy();
+
+    // The operational bid lives on the player for the AI decision pipeline.
+    const playerOffers = cache.getPlayer(fa.id).offers ?? [];
+    expect(playerOffers.some((o) => Number(o.teamId) === USER_TEAM_ID)).toBe(true);
+
+    // GET_FREE_AGENTS reflects the pending offer + reserved/effective cap.
+    const faData = await getFreeAgents();
+    expect(faData.pendingOffers).toHaveLength(1);
+    expect(faData.pendingOffers[0].id).toBe(row.id);
+    expect(faData.pendingOffers[0].status).toBe(PENDING_OFFER_STATUS.PENDING);
+    expect(faData.capSummary.reservedPendingCap).toBeCloseTo(row.annualCapHit, 1);
+    expect(faData.capSummary.effectiveCapRoom).toBeCloseTo(
+      faData.capSummary.capRoom - faData.capSummary.reservedPendingCap,
+      1,
+    );
+  }, TEST_TIMEOUT_MS);
+
+  it('replaces a re-submitted offer for the same player instead of double-reserving', async () => {
+    const replacement = {
+      baseAnnual: contract.baseAnnual + 2,
+      yearsTotal: contract.yearsTotal,
+      signingBonus: contract.signingBonus,
+    };
+    const reply = await send(toWorker.SUBMIT_OFFER, { playerId: fa.id, teamId: USER_TEAM_ID, contract: replacement });
+    expect(reply.type).toBe(toUI.STATE_UPDATE);
+
+    const pendingRows = getLedger().filter(
+      (r) => r.status === PENDING_OFFER_STATUS.PENDING && r.playerId === Number(fa.id),
+    );
+    expect(pendingRows).toHaveLength(1);
+    expect(pendingRows[0].annualCapHit).toBeCloseTo(offerCapHit(replacement), 1);
+
+    // Only one bid from the user team on the player, and only one reservation.
+    const userBids = (cache.getPlayer(fa.id).offers ?? []).filter((o) => Number(o.teamId) === USER_TEAM_ID);
+    expect(userBids).toHaveLength(1);
+    const faData = await getFreeAgents();
+    expect(faData.capSummary.reservedPendingCap).toBeCloseTo(offerCapHit(replacement), 1);
+  }, TEST_TIMEOUT_MS);
+
+  // ── TASK 2: withdraw releases cap and cleans player offers ──────────────────
+
+  it('WITHDRAW_OFFER marks the row withdrawn, releases cap, and strips the bid', async () => {
+    expect(getLedger().some((r) => r.status === PENDING_OFFER_STATUS.PENDING)).toBe(true);
+
+    const reply = await send(toWorker.WITHDRAW_OFFER, { playerId: fa.id, teamId: USER_TEAM_ID });
+    expect(reply.type).toBe(toUI.STATE_UPDATE);
+
+    const ledger = getLedger();
+    const row = ledger.find((r) => r.playerId === Number(fa.id) && r.teamId === USER_TEAM_ID);
+    expect(row.status).toBe(PENDING_OFFER_STATUS.WITHDRAWN);
+    expect(ledger.some((r) => r.status === PENDING_OFFER_STATUS.PENDING)).toBe(false);
+
+    const playerOffers = cache.getPlayer(fa.id).offers ?? [];
+    expect(playerOffers.some((o) => Number(o.teamId) === USER_TEAM_ID)).toBe(false);
+
+    const faData = await getFreeAgents();
+    expect(faData.capSummary.reservedPendingCap).toBe(0);
+    expect(faData.capSummary.effectiveCapRoom).toBeCloseTo(faData.capSummary.capRoom, 1);
+    const withdrawnRow = faData.pendingOffers.find((r) => r.playerId === Number(fa.id));
+    expect(withdrawnRow.status).toBe(PENDING_OFFER_STATUS.WITHDRAWN);
+  }, TEST_TIMEOUT_MS);
+});
+
+// ── TASK 3: daily resolution sequencing ────────────────────────────────────────
+
+describe('ADVANCE_FREE_AGENCY_DAY resolution', () => {
+  it('accepts a strong above-demand offer: roster join, FA-pool removal, cap release', async () => {
+    enterFreeAgency();
+    const fa = makeFreeAgentFromTeam(3);
+    const { askAnnual, askYears } = await getAsk(fa.id);
+    const contract = {
+      baseAnnual: Math.round(askAnnual * 1.8 * 10) / 10,
+      yearsTotal: askYears,
+      signingBonus: Math.round(askAnnual * 1.5 * 10) / 10,
+    };
+    const submit = await send(toWorker.SUBMIT_OFFER, { playerId: fa.id, teamId: USER_TEAM_ID, contract });
+    expect(submit.type).toBe(toUI.STATE_UPDATE);
+    expect(getLedger().find((r) => r.playerId === Number(fa.id)).status).toBe(PENDING_OFFER_STATUS.PENDING);
+
+    let faData = null;
+    let row = null;
+    for (let i = 0; i < 4; i += 1) {
+      faData = await advanceFaDayAndRefresh();
+      row = getLedger().find((r) => r.playerId === Number(fa.id) && r.teamId === USER_TEAM_ID);
+      if (row.status !== PENDING_OFFER_STATUS.PENDING) break;
+    }
+
+    // Ledger row reconciled to accepted after the market acted.
+    expect(row.status).toBe(PENDING_OFFER_STATUS.ACCEPTED);
+
+    // Accepted player joined the user roster and left the FA pool.
+    const player = cache.getPlayer(fa.id);
+    expect(Number(player.teamId)).toBe(USER_TEAM_ID);
+    expect(player.status).toBe('active');
+    expect(faData.freeAgents.some((p) => p.id === fa.id)).toBe(false);
+
+    // Resolved offers stop reserving cap, and the FA payload reflects the
+    // final ledger state.
+    expect(faData.capSummary.reservedPendingCap).toBe(0);
+    const payloadRow = faData.pendingOffers.find((r) => r.playerId === Number(fa.id));
+    expect(payloadRow.status).toBe(PENDING_OFFER_STATUS.ACCEPTED);
+  }, TEST_TIMEOUT_MS);
+
+  it('rejects/expires a clearly-below-demand offer without the old day-3 force-sign', async () => {
+    enterFreeAgency();
+    const fa = makeFreeAgentFromTeam(4);
+    const { askAnnual, askYears } = await getAsk(fa.id);
+    const lowball = {
+      baseAnnual: Math.max(0.5, Math.round(askAnnual * 0.35 * 10) / 10),
+      yearsTotal: Math.max(1, askYears - 1),
+      signingBonus: 0,
+    };
+    const submit = await send(toWorker.SUBMIT_OFFER, { playerId: fa.id, teamId: USER_TEAM_ID, contract: lowball });
+    expect(submit.type).toBe(toUI.STATE_UPDATE);
+
+    let faData = null;
+    let row = null;
+    for (let i = 0; i < 4; i += 1) {
+      faData = await advanceFaDayAndRefresh();
+      row = getLedger().find((r) => r.playerId === Number(fa.id) && r.teamId === USER_TEAM_ID);
+      if (row.status !== PENDING_OFFER_STATUS.PENDING) break;
+    }
+
+    // The lowball must never sign with the user team (old day-3 patience
+    // behavior force-signed clearly-below-ask offers).
+    const player = cache.getPlayer(fa.id);
+    expect(Number(player?.teamId ?? -1)).not.toBe(USER_TEAM_ID);
+
+    // Ledger resolves to rejected (below market / signed elsewhere) or expired.
+    expect([PENDING_OFFER_STATUS.REJECTED, PENDING_OFFER_STATUS.EXPIRED]).toContain(row.status);
+
+    // Dead bid removed from player.offers; reservation released; payload final.
+    const offers = cache.getPlayer(fa.id)?.offers ?? [];
+    expect(offers.some((o) => Number(o.teamId) === USER_TEAM_ID)).toBe(false);
+    expect(faData.capSummary.reservedPendingCap).toBe(0);
+    const payloadRow = faData.pendingOffers.find((r) => r.playerId === Number(fa.id));
+    expect([PENDING_OFFER_STATUS.REJECTED, PENDING_OFFER_STATUS.EXPIRED]).toContain(payloadRow.status);
+  }, TEST_TIMEOUT_MS);
+});
+
+// ── TASK 4 + TASK 6.10: save/load round-trip and old-save migration ───────────
+
+describe('save/load and pre-#1580 meta migration', () => {
+  it('preserves pending offer state across a real save → load round-trip', async () => {
+    enterFreeAgency();
+    const fa = makeFreeAgentFromTeam(5);
+    const { askAnnual, askYears } = await getAsk(fa.id);
+    const contract = {
+      baseAnnual: Math.round(askAnnual * 1.1 * 10) / 10,
+      yearsTotal: askYears,
+      signingBonus: 1,
+    };
+    const submit = await send(toWorker.SUBMIT_OFFER, { playerId: fa.id, teamId: USER_TEAM_ID, contract });
+    expect(submit.type).toBe(toUI.STATE_UPDATE);
+    const pendingRowId = getLedger().find((r) => r.playerId === Number(fa.id)).id;
+
+    // SUBMIT_OFFER already flushed meta to the (fake) IndexedDB save. Reload
+    // the save through the real LOAD_SAVE pipeline.
+    cache.reset();
+    const load = await send(toWorker.LOAD_SAVE, { leagueId: SLOT_KEY }, { timeoutMs: BOOT_TIMEOUT_MS });
+    expect(load.type).toBe(toUI.FULL_STATE);
+
+    const ledger = getLedger();
+    const restored = ledger.find((r) => r.id === pendingRowId);
+    expect(restored).toBeTruthy();
+    expect(restored.status).toBe(PENDING_OFFER_STATUS.PENDING);
+
+    const faData = await getFreeAgents();
+    expect(faData.pendingOffers.some((r) => r.id === pendingRowId)).toBe(true);
+    expect(faData.capSummary.reservedPendingCap).toBeCloseTo(restored.annualCapHit, 1);
+  }, TEST_TIMEOUT_MS);
+
+  it('hydrates a pre-#1580 save (no meta.pendingOffers) without corrupting adjacent fields', async () => {
+    // Simulate an old save: persist the current meta with the Market V2 field
+    // removed and sentinel values on the adjacent fields that must survive.
+    const sentinelFaState = { day: 2, maxDays: 5, complete: false };
+    const sentinelMemory = { 4242: { waitCycles: 1 } };
+    const sentinelMovements = [
+      { id: 'mv-sentinel', playerId: 4242, playerName: 'Sentinel Back', pos: 'RB', prevTeamId: 7, newTeamId: 9 },
+    ];
+    const sentinelGoals = [
+      { id: 'goal-sentinel', type: 'win_games', description: 'Win 10 games', target: 10, current: 3, complete: false, reward: 'Fan approval +15' },
+    ];
+
+    const oldMeta = {
+      ...cache.getMeta(),
+      phase: 'free_agency',
+      freeAgencyState: sentinelFaState,
+      contractMarketMemory: sentinelMemory,
+      offseasonFaMovements: sentinelMovements,
+      ownerGoals: sentinelGoals,
+    };
+    delete oldMeta.pendingOffers;
+    await Meta.save(oldMeta);
+
+    cache.reset();
+    const load = await send(toWorker.LOAD_SAVE, { leagueId: SLOT_KEY }, { timeoutMs: BOOT_TIMEOUT_MS });
+    expect(load.type).toBe(toUI.FULL_STATE);
+
+    // Missing pendingOffers hydrates to [] through ensureDynastyMeta.
+    const meta = ensureDynastyMeta(cache.getMeta());
+    expect(meta.pendingOffers).toEqual([]);
+
+    // Adjacent FA / dynasty / user-team fields survive unchanged.
+    expect(meta.freeAgencyState).toEqual(sentinelFaState);
+    expect(meta.contractMarketMemory).toEqual(sentinelMemory);
+    expect(meta.offseasonFaMovements).toEqual(sentinelMovements);
+    expect(meta.ownerGoals).toEqual(sentinelGoals);
+    expect(Number(meta.userTeamId)).toBe(USER_TEAM_ID);
+    expect(Array.isArray(meta.newsItems)).toBe(true);
+    expect(Array.isArray(meta.retiredPlayers)).toBe(true);
+
+    // The loaded old save serves GET_FREE_AGENTS without crashing, with an
+    // empty ledger and a zeroed reservation.
+    const faData = await getFreeAgents();
+    expect(faData.pendingOffers).toEqual([]);
+    expect(faData.capSummary.reservedPendingCap).toBe(0);
+    expect(faData.capSummary.effectiveCapRoom).toBeCloseTo(faData.capSummary.capRoom, 1);
+  }, TEST_TIMEOUT_MS);
+});

--- a/tests/unit/freeAgencyMarketV2Wiring.test.js
+++ b/tests/unit/freeAgencyMarketV2Wiring.test.js
@@ -1,0 +1,70 @@
+/**
+ * Free Agency Market V2 — wiring + sequencing regression guards.
+ *
+ * Source-level guards in the style of src/worker/__tests__/loadPipelineRegression.test.js:
+ * behavioral coverage lives in tests/integration/freeAgencyMarketV2.worker.test.js;
+ * these pin the wiring and the ADVANCE_FREE_AGENCY_DAY ordering so a refactor
+ * cannot silently drop or reorder them.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { toWorker } from '../../src/worker/protocol.js';
+
+const read = (rel) => readFileSync(resolve(process.cwd(), rel), 'utf8');
+
+describe('WITHDRAW_OFFER wiring', () => {
+  it('exists in the protocol', () => {
+    expect(toWorker.WITHDRAW_OFFER).toBe('WITHDRAW_OFFER');
+  });
+
+  it('is exposed by useWorker as actions.withdrawOffer', () => {
+    const src = read('src/ui/hooks/useWorker.js');
+    expect(src).toMatch(/withdrawOffer:\s*\(playerId,\s*teamId\)\s*=>\s*\n?\s*request\(toWorker\.WITHDRAW_OFFER/);
+  });
+
+  it('is routed to handleWithdrawOffer in the worker', () => {
+    const src = read('src/worker/worker.js');
+    expect(src).toContain('case toWorker.WITHDRAW_OFFER:     return await handleWithdrawOffer(payload, id);');
+    expect(src).toContain('async function handleWithdrawOffer(');
+  });
+
+  it('is wired from the FreeAgency pending-offers panel to actions.withdrawOffer', () => {
+    const src = read('src/ui/components/FreeAgency.jsx');
+    expect(src).toContain('await actions.withdrawOffer(playerId, activeTeamId);');
+    expect(src).toMatch(/<PendingOffersPanel[\s\S]{0,200}onWithdraw=/);
+  });
+});
+
+describe('ADVANCE_FREE_AGENCY_DAY sequencing', () => {
+  it('ages offers, rejects/expires stale bids, runs the market, then reconciles', () => {
+    const src = read('src/worker/worker.js');
+    const handlerStart = src.indexOf('async function handleAdvanceFreeAgencyDay(');
+    expect(handlerStart).toBeGreaterThan(-1);
+    const handler = src.slice(handlerStart, src.indexOf('async function archiveSeason', handlerStart));
+
+    const ageIdx = handler.indexOf('agePendingOffers(getPendingOffersLedger())');
+    const preSyncIdx = handler.indexOf('syncPendingOfferLedger({ day, emitNotifications: true })');
+    const marketIdx = handler.indexOf('AiLogic.processFreeAgencyDay(day)');
+    const postSyncIdx = handler.indexOf('syncPendingOfferLedger({ day, emitNotifications: true })', marketIdx);
+    const closeIdx = handler.indexOf('expireAllPendingOffers(getPendingOffersLedger()');
+
+    // 1. age → 2. weak/stale reject-expire (pre-market sync) → 3. market acts
+    // → 4. ledger reconciles outcomes → (on completion) close remaining offers.
+    expect(ageIdx).toBeGreaterThan(-1);
+    expect(preSyncIdx).toBeGreaterThan(ageIdx);
+    expect(marketIdx).toBeGreaterThan(preSyncIdx);
+    expect(postSyncIdx).toBeGreaterThan(marketIdx);
+    expect(closeIdx).toBeGreaterThan(postSyncIdx);
+  });
+
+  it('the FA pool filters treat team id 0 as a signed team, not a free agent', () => {
+    const workerSrc = read('src/worker/worker.js');
+    const getFreeAgentsStart = workerSrc.indexOf('async function handleGetFreeAgents(');
+    const getFreeAgentsBody = workerSrc.slice(getFreeAgentsStart, getFreeAgentsStart + 2000);
+    // Regression: `!p.teamId` treated the default user team (id 0) as unsigned,
+    // so players it signed stayed in the GET_FREE_AGENTS pool.
+    expect(getFreeAgentsBody).toContain("p.teamId == null || p.status === 'free_agent'");
+    expect(getFreeAgentsBody).not.toContain('!p.teamId');
+  });
+});


### PR DESCRIPTION
Hardening coverage for PR #1580 (Free Agency Market V2), plus one scoped
fix the new integration test exposed:

- tests/integration/freeAgencyMarketV2.worker.test.js: drives the REAL
  worker message path (INIT → USE_SAFE_STARTER_LEAGUE → SUBMIT_OFFER /
  WITHDRAW_OFFER / ADVANCE_FREE_AGENCY_DAY / GET_FREE_AGENTS / LOAD_SAVE)
  in Node with fake IndexedDB. Covers: pending ledger row + player bid +
  cap reservation on submit, offer replacement without double-reserving,
  withdraw releasing cap and stripping the bid, strong above-demand offers
  accepting (roster join + FA-pool removal + reservation release), weak
  offers rejecting/expiring without the old day-3 force-sign, save→load
  round-trip preserving pending offers, and pre-#1580 saves (no
  meta.pendingOffers) hydrating to [] through the real LOAD_SAVE pipeline
  without corrupting adjacent meta fields.
- src/core/__tests__/dynastyMetaPendingOffersMigration.test.js: pure
  ensureDynastyMeta migration coverage for old saves (missing/corrupt
  pendingOffers, adjacent FA/dynasty/user-team fields preserved).
- tests/unit/freeAgencyMarketV2Wiring.test.js: source-level guards that
  WITHDRAW_OFFER stays wired through protocol → useWorker → worker →
  FreeAgency panel, and that ADVANCE_FREE_AGENCY_DAY keeps the
  age → reject/expire → market → reconcile → close ordering.
- FreeAgency.pendingOffers.test.jsx: interactive jsdom smoke — withdraw
  click invokes the action with the playerId, effective-cap badge renders,
  long player names keep the withdraw button in the DOM.
- pendingOffers.test.js: agePendingOffers never increments daysPending on
  accepted/rejected/expired/withdrawn rows (implementation already
  guarded; test now pins all four statuses).

Fix exposed by the integration test: the FA-pool filters used `!p.teamId`,
which treats team id 0 (the default user franchise) as unsigned — players
accepted by team 0 stayed in the GET_FREE_AGENTS pool. The three filters
on the Market V2 path (GET_FREE_AGENTS, buildDemandSnapshotForOffer, FA
period close cleanup) now use `teamId == null`, matching the semantics
pendingOffers.js already uses. Other pre-existing `!p.teamId` call sites
outside the FA market path are intentionally untouched.

https://claude.ai/code/session_015Cfr7AgbGJ9yt44c9w5QgT