### PR TITLE
Add post-merge offseason FA smoke suite for Market V2

### DIFF
--- a/docs/qa/free-agency-market-v2-release-checklist.md
+++ b/docs/qa/free-agency-market-v2-release-checklist.md
@@ -1,0 +1,27 @@
+# Free Agency Market V2 — release smoke checklist
+
+Manual QA pass for the offseason loop after Market V2 (#1580/#1581). Run on a
+safe starter league advanced into the `free_agency` phase. Automated coverage:
+`tests/e2e/offseasonFaFlow.spec.js` (browser),
+`tests/integration/offseasonFaSmoke.worker.test.js` and
+`tests/integration/freeAgencyMarketV2.worker.test.js` (worker),
+`tests/unit/pendingOffersPanelLayout.test.jsx` (panel layout). Use this list
+when Playwright browsers are unavailable in the environment.
+
+- [ ] **Submit offer** — open Free Agency, bid on a player. "Your offers"
+      panel appears with a Pending row; effective cap badge shows the
+      reservation (`Effective cap = cap room − reserved`).
+- [ ] **Replace offer** — re-bid on the same player. Still exactly one pending
+      row and one reservation (no double-reserve).
+- [ ] **Withdraw offer** — row flips to Withdrawn, badge reads
+      `reserved $0.0M`, cap room is fully available again.
+- [ ] **Advance day** — Advance Day button progresses the FA clock; pending
+      offers age and show feedback lines instead of vanishing.
+- [ ] **Accepted signing** — a clearly above-ask offer resolves to Accepted
+      within a few days; player leaves the FA pool and appears on the roster;
+      reservation releases.
+- [ ] **Weak rejection** — a clearly below-ask offer never force-signs; it
+      resolves Rejected/Expired with feedback and releases its reservation.
+- [ ] **Save/load with pending offer** — save with a pending offer, reload the
+      slot: the offer is still pending and still reserving cap. A pre-#1580
+      save loads with an empty offer ledger and no crash.

--- a/tests/e2e/offseasonFaFlow.spec.js
+++ b/tests/e2e/offseasonFaFlow.spec.js
@@ -1,0 +1,250 @@
+/**
+ * Offseason Free Agency Market V2 — post-merge user-flow smoke.
+ *
+ * Existing e2e coverage (surveyed before adding this spec):
+ *  - simulateWeek.spec.js — mid-season week sim only; never enters offseason.
+ *  - phase_hydration_regression.spec.js — phase pipeline mechanics
+ *    (offseason → free_agency → draft) via gameController, no offer lifecycle.
+ *  - core_flow_reliability.spec.js / daily_regression.spec.js — visit the
+ *    Free Agency tab during the regular season only.
+ *
+ * This spec proves the Market V2 loop works from the user's perspective inside
+ * the real free_agency phase:
+ *   enter offseason → open Free Agency → submit offer → pending panel +
+ *   effective-cap reservation → withdraw (reservation releases) → strong
+ *   offer → advance FA day(s) → accepted player joins roster / leaves the FA
+ *   pool, or the offer stays pending with feedback.
+ */
+import { test, expect } from '@playwright/test';
+import { launchFranchise, goToTab } from './helpers/franchise.js';
+
+const SMOKE_TIMEOUT = 90000;
+
+test.setTimeout(300000);
+
+async function simToPhase(page, targetPhase, timeout = 180000) {
+  await page.evaluate((phase) => {
+    window.gameController.simToPhase(phase);
+  }, targetPhase);
+  await page.waitForFunction(
+    ({ want }) => {
+      const p = window?.state?.league?.phase;
+      if (!p) return false;
+      if (want === 'offseason') return p === 'offseason' || p === 'offseason_resign';
+      return p === want;
+    },
+    { want: targetPhase },
+    { timeout },
+  );
+}
+
+/** Read the FA payload through the same worker action the UI uses. */
+function getFaPayload(page) {
+  return page.evaluate(async () => {
+    const res = await window.gameController.getFreeAgents();
+    return res.payload;
+  });
+}
+
+/** Newest ledger row for a player (worker returns newest-first). */
+function getLedgerRow(page, playerId) {
+  return page.evaluate(async (pid) => {
+    const res = await window.gameController.getFreeAgents();
+    const row = (res.payload.pendingOffers ?? []).find((r) => Number(r.playerId) === Number(pid)) ?? null;
+    return row ? { status: row.status, feedback: row.feedback ?? [] } : null;
+  }, playerId);
+}
+
+/**
+ * Pick FA targets the UI will actually let us bid on (no "Cannot Afford"
+ * gate) and that buildDecisionTiming keeps pending after a submit: players
+ * with live AI bids or elite OVR have patience; cheap low-OVR vets resolve
+ * immediately. Returns up to 3 candidates, best first.
+ */
+function pickCandidates(page) {
+  return page.evaluate(async () => {
+    const res = await window.gameController.getFreeAgents();
+    const p = res.payload;
+    const capRoom = Number(p?.capSummary?.capRoom ?? 0);
+    // Replicate the UI's fallback ask (FreeAgency.jsx suggestedSalary): the
+    // Submit Bid button is replaced by "Cannot Afford" when this exceeds room.
+    const POS_MULT = { QB: 2.2, WR: 1.15, RB: 0.7, TE: 1.0, OL: 1.0, DL: 1.0, LB: 0.9, CB: 1.0, S: 0.85 };
+    const uiAsk = (fa) => {
+      const ovr = fa.ovr ?? 50;
+      const age = fa.age ?? 28;
+      const base = ovr >= 90 ? 25 : ovr >= 80 ? 15 : ovr >= 70 ? 8 : ovr >= 60 ? 3 : 0.8;
+      let raw = base * (POS_MULT[fa.pos] || 1);
+      if (age > 32) raw *= 0.7;
+      else if (age > 29) raw *= 0.85;
+      return Math.max(0.75 + (age > 26 ? 0.25 : 0), Number(raw.toFixed(1)));
+    };
+    const score = (fa) => ((fa.offers?.count ?? 0) > 0 ? 200 : 0) + (fa.ovr ?? 0) + ((fa.age ?? 99) <= 25 ? 5 : 0);
+    const candidates = (p.freeAgents ?? [])
+      .filter((fa) => Number(fa?.demandProfile?.askAnnual) > 0 && (fa.ovr ?? 0) >= 60)
+      .filter((fa) => {
+        const ask = Number(fa.demandProfile.askAnnual);
+        return ask * 1.9 + 1 <= capRoom && uiAsk(fa) <= capRoom;
+      })
+      .sort((a, b) => score(b) - score(a))
+      .slice(0, 3)
+      .map((fa) => ({
+        id: fa.id,
+        name: fa.name,
+        ask: Number(fa.demandProfile.askAnnual),
+        askYears: Math.max(1, Number(fa.demandProfile.askYears ?? 3)),
+      }));
+    return { capRoom, candidates };
+  });
+}
+
+/** Drive the real bid form: search the player, open the inline form, confirm. */
+async function submitBidViaUi(page, target, annual, years) {
+  const search = page.getByPlaceholder('Search players...');
+  await search.fill('');
+  await search.fill(target.name);
+  const row = page.locator('tr', { hasText: target.name }).first();
+  await expect(row.getByRole('button', { name: /Submit Bid|Update Bid/ }).first()).toBeVisible({ timeout: 30000 });
+  await row.getByRole('button', { name: /Submit Bid|Update Bid/ }).first().click();
+
+  const formRow = page.locator('tr', { hasText: `Your bid for ${target.name}` });
+  await expect(formRow).toBeVisible({ timeout: 30000 });
+  const inputs = formRow.locator('input[type="number"]');
+  await inputs.first().fill(String(annual));
+  await inputs.nth(1).fill(String(years));
+  await formRow.getByRole('button', { name: 'Confirm Bid' }).click();
+}
+
+test('offseason FA loop: submit → reserve cap → withdraw → strong offer → advance day → resolution', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await launchFranchise(page);
+  await expect(page.getByTestId('app-shell-ready')).toBeVisible({ timeout: SMOKE_TIMEOUT });
+
+  // ── Reach the real free_agency phase (same path as phase_hydration spec) ──
+  await simToPhase(page, 'offseason');
+  await expect
+    .poll(async () => page.evaluate(() => window?.state?.league?.phase))
+    .toBe('offseason_resign');
+  await page.evaluate(() => window.gameController.advanceOffseason());
+  await page.waitForFunction(() => window?.state?.league?.phase === 'free_agency', { timeout: 120000 });
+
+  // ── Open Free Agency ───────────────────────────────────────────────────────
+  await goToTab(page, 'free-agency');
+  await expect(page.getByRole('button', { name: /Advance Day/ })).toBeVisible({ timeout: SMOKE_TIMEOUT });
+  // No bids yet: the pending offers panel must not render.
+  await expect(page.getByTestId('pending-offers-panel')).toHaveCount(0);
+
+  const { candidates } = await pickCandidates(page);
+  expect(candidates.length, 'no affordable FA targets in the pool').toBeGreaterThan(0);
+
+  // ── Submit a modest offer that stays pending ───────────────────────────────
+  // Some players decide instantly (decision_imminent); try up to 3 targets.
+  let target = null;
+  let modestOffer = 0;
+  for (const candidate of candidates) {
+    const modest = Math.round(candidate.ask * 1.15 * 10) / 10;
+    await submitBidViaUi(page, candidate, modest, candidate.askYears);
+    await expect(page.getByTestId('pending-offers-panel')).toBeVisible({ timeout: 30000 });
+    await expect(page.getByTestId(`pending-offer-${candidate.id}`).first()).toBeVisible({ timeout: 30000 });
+    const row = await getLedgerRow(page, candidate.id);
+    expect(row, `submitted offer for ${candidate.name} missing from ledger`).not.toBeNull();
+    if (row.status === 'pending') {
+      target = candidate;
+      modestOffer = modest;
+      break;
+    }
+  }
+  expect(target, 'no submitted offer stayed pending — cannot exercise the withdraw flow').not.toBeNull();
+
+  // Pending panel row: player name, Pending status, withdraw available.
+  const offerRow = page.getByTestId(`pending-offer-${target.id}`).first();
+  await expect(offerRow).toContainText(target.name);
+  await expect(offerRow.getByText('Pending', { exact: true })).toBeVisible();
+  await expect(offerRow.getByRole('button', { name: 'Withdraw' })).toBeVisible();
+
+  // FA table row shows the pending status chip next to the player name.
+  await expect(
+    page.locator('tr', { hasText: target.name }).first().getByText('Pending', { exact: true }),
+  ).toBeVisible();
+
+  // Effective cap reflects the reservation, in the badge and in the payload.
+  const capBadge = page.getByTestId('effective-cap-badge');
+  await expect(capBadge).toBeVisible();
+  await expect(capBadge).toContainText(`reserved $${modestOffer.toFixed(1)}M`);
+  const capAfterSubmit = (await getFaPayload(page)).capSummary;
+  expect(capAfterSubmit.reservedPendingCap).toBeCloseTo(modestOffer, 1);
+  expect(capAfterSubmit.effectiveCapRoom).toBeCloseTo(capAfterSubmit.capRoom - modestOffer, 1);
+
+  // ── Withdraw: the cap reservation must release ─────────────────────────────
+  await offerRow.getByRole('button', { name: 'Withdraw' }).click();
+  await expect(offerRow.getByText('Withdrawn', { exact: true })).toBeVisible({ timeout: 30000 });
+  await expect(capBadge).toContainText('reserved $0.0M');
+  const capAfterWithdraw = (await getFaPayload(page)).capSummary;
+  expect(capAfterWithdraw.reservedPendingCap).toBe(0);
+  expect(capAfterWithdraw.effectiveCapRoom).toBeCloseTo(capAfterWithdraw.capRoom, 1);
+
+  // ── Strong offer, then advance FA days until the market resolves it ───────
+  const strongOffer = Math.min(
+    Math.round(target.ask * 1.8 * 10) / 10,
+    Math.round((capAfterWithdraw.capRoom - 1) * 10) / 10,
+  );
+  await submitBidViaUi(page, target, strongOffer, target.askYears);
+  await expect(page.getByTestId(`pending-offer-${target.id}`).first()).toBeVisible({ timeout: 30000 });
+
+  let resolution = null;
+  for (let i = 0; i < 3; i += 1) {
+    const advanceBtn = page.getByRole('button', { name: /Advance Day/ });
+    if (!(await advanceBtn.isVisible().catch(() => false))) break;
+    await advanceBtn.click();
+    // GET_FREE_AGENTS queues behind ADVANCE_FREE_AGENCY_DAY in the worker, so
+    // this payload reflects the fully-processed day.
+    resolution = await page.evaluate(async (pid) => {
+      const res = await window.gameController.getFreeAgents();
+      const p = res.payload;
+      const row = (p.pendingOffers ?? []).find((r) => Number(r.playerId) === Number(pid)) ?? null;
+      const league = window?.state?.league;
+      const userTeam = league?.teams?.find((t) => t.id === league.userTeamId);
+      return {
+        status: row?.status ?? null,
+        feedback: row?.feedback ?? [],
+        reserved: Number(p.capSummary?.reservedPendingCap ?? 0),
+        inPool: (p.freeAgents ?? []).some((fa) => Number(fa.id) === Number(pid)),
+        onRoster: Boolean(
+          (userTeam?.roster ?? []).some((rp) => Number(rp?.id) === Number(pid))
+          || (userTeam?.rosterIds ?? []).map(Number).includes(Number(pid)),
+        ),
+        phase: p.phase,
+      };
+    }, target.id);
+    await page.waitForFunction(() => !window?.state?.busy && !window?.state?.simulating, { timeout: SMOKE_TIMEOUT }).catch(() => {});
+    if (resolution.status !== 'pending' || resolution.phase !== 'free_agency') break;
+  }
+
+  expect(resolution, 'advance-day loop never produced an FA payload').not.toBeNull();
+  if (resolution.status === 'accepted') {
+    // Accepted: player left the FA pool, joined the roster, reservation freed.
+    expect(resolution.inPool).toBe(false);
+    expect(resolution.onRoster).toBe(true);
+    expect(resolution.reserved).toBe(0);
+  } else if (resolution.status === 'pending') {
+    // Not resolved yet: the offer must still reserve cap and explain itself.
+    expect(resolution.feedback.length).toBeGreaterThan(0);
+    expect(resolution.reserved).toBeGreaterThan(0);
+  } else {
+    // Market resolved against us (signed elsewhere / expired): the loop must
+    // not wedge — reservation released, player not silently on our roster.
+    expect(['rejected', 'expired']).toContain(resolution.status);
+    expect(resolution.onRoster).toBe(false);
+    expect(resolution.reserved).toBe(0);
+  }
+
+  // ── Re-open Free Agency: the panel survives a remount with the final state ─
+  if (resolution.phase === 'free_agency') {
+    await goToTab(page, 'roster');
+    await goToTab(page, 'free-agency');
+    await expect(page.getByTestId('pending-offers-panel')).toBeVisible({ timeout: SMOKE_TIMEOUT });
+    const finalLabel = { accepted: 'Accepted', pending: 'Pending', rejected: 'Rejected', expired: 'Expired' }[resolution.status];
+    await expect(
+      page.getByTestId(`pending-offer-${target.id}`).first().getByText(finalLabel, { exact: true }),
+    ).toBeVisible({ timeout: 30000 });
+  }
+});

--- a/tests/integration/offseasonFaSmoke.worker.test.js
+++ b/tests/integration/offseasonFaSmoke.worker.test.js
@@ -1,0 +1,268 @@
+/**
+ * Offseason Free Agency Market V2 — post-merge user-flow smoke (worker level).
+ *
+ * Integration fallback for tests/e2e/offseasonFaFlow.spec.js: drives the SAME
+ * user journey through the real worker message path (the harness from
+ * tests/integration/freeAgencyMarketV2.worker.test.js) so the flow stays
+ * covered even when Playwright browsers are unavailable.
+ *
+ * One continuous session against a single player — the sequencing the browser
+ * spec exercises and #1581 does not:
+ *   open FA → submit offer → pending panel payload + effective cap →
+ *   withdraw (reservation releases) → strong offer on the SAME player →
+ *   advance FA day(s) → accepted signing leaves the pool and joins the roster.
+ *
+ * Also pins the payload fields PendingOffersPanel renders (playerName, pos,
+ * years, totalValue, annualCapHit, status, feedback) so a worker refactor
+ * cannot silently blank the panel.
+ */
+import 'fake-indexeddb/auto';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { toWorker, toUI } from '../../src/worker/protocol.js';
+import { cache } from '../../src/db/cache.js';
+import { ensureDynastyMeta } from '../../src/core/dynasty-story.js';
+import { PENDING_OFFER_STATUS } from '../../src/core/freeAgency/pendingOffers.js';
+
+const SLOT_KEY = 'save_slot_1';
+const USER_TEAM_ID = 0;
+const BOOT_TIMEOUT_MS = 180_000;
+const TEST_TIMEOUT_MS = 120_000;
+
+// ── Minimal worker bridge (same as freeAgencyMarketV2.worker.test.js) ─────────
+
+const waiters = new Map();
+let msgSeq = 0;
+
+function installSelfBridge() {
+  globalThis.self = {
+    onmessage: null,
+    postMessage(msg) {
+      if (msg?.id != null && waiters.has(msg.id)) {
+        const resolve = waiters.get(msg.id);
+        waiters.delete(msg.id);
+        resolve(msg);
+      }
+    },
+  };
+}
+
+/** Parse the optional JSON fast-path used by post() for large payloads. */
+function payloadOf(msg) {
+  const p = msg?.payload;
+  if (p && typeof p._jsonPayload === 'string') return JSON.parse(p._jsonPayload);
+  return p;
+}
+
+function send(type, payload = {}, { timeoutMs = 60_000 } = {}) {
+  const id = `fa-smoke-${++msgSeq}`;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      waiters.delete(id);
+      reject(new Error(`Timeout (${timeoutMs}ms) waiting for reply to ${type}`));
+    }, timeoutMs);
+    waiters.set(id, (msg) => {
+      clearTimeout(timer);
+      resolve(msg);
+    });
+    globalThis.self.onmessage({ data: { type, payload, id } });
+  });
+}
+
+async function getFreeAgents() {
+  const reply = await send(toWorker.GET_FREE_AGENTS, {});
+  expect(reply.type).toBe(toUI.FREE_AGENT_DATA);
+  return payloadOf(reply);
+}
+
+/**
+ * ADVANCE_FREE_AGENCY_DAY posts no id-correlated reply; queue a GET_FREE_AGENTS
+ * behind it — the worker's message queue guarantees the advance completes
+ * first — and return the fresh FA payload.
+ */
+async function advanceFaDayAndRefresh() {
+  globalThis.self.onmessage({ data: { type: toWorker.ADVANCE_FREE_AGENCY_DAY, payload: {} } });
+  return getFreeAgents();
+}
+
+function getLedger() {
+  return ensureDynastyMeta(cache.getMeta()).pendingOffers;
+}
+
+// ── League fixtures (same shape as the #1581 harness) ─────────────────────────
+
+function enterFreeAgency() {
+  cache.setMeta({
+    phase: 'free_agency',
+    freeAgencyState: { day: 1, maxDays: 5, complete: false },
+    pendingOffers: [],
+    contractMarketMemory: {},
+    offseasonFaMovements: [],
+  });
+  cache.updateTeam(USER_TEAM_ID, { capRoom: 150 });
+}
+
+/**
+ * Convert a roster player from a donor AI team into a high-leverage free agent.
+ * ovr 92 / age 24 keeps buildDecisionTiming out of the `decision_imminent`
+ * immediate-resolution path so submitted offers stay pending (Market V2 flow).
+ */
+function makeFreeAgentFromTeam(donorTeamId, { ovr = 92, age = 24 } = {}) {
+  const donor = cache.getTeam(donorTeamId);
+  const player = cache.getPlayersByTeam(donorTeamId).find((p) => p?.id != null);
+  expect(player, `donor team ${donorTeamId} has no players`).toBeTruthy();
+  cache.updatePlayer(player.id, {
+    teamId: null,
+    status: 'free_agent',
+    offers: [],
+    ovr,
+    age,
+    morale: 70,
+  });
+  cache.updateTeam(donorTeamId, {
+    rosterIds: (donor.rosterIds ?? []).filter((pid) => pid !== player.id),
+    rosterCount: Math.max(0, Number(donor.rosterCount ?? 1) - 1),
+  });
+  return cache.getPlayer(player.id);
+}
+
+async function getAsk(playerId) {
+  const fa = await getFreeAgents();
+  const row = fa.freeAgents.find((p) => p.id === playerId);
+  expect(row, `player ${playerId} missing from GET_FREE_AGENTS`).toBeTruthy();
+  return { askAnnual: Number(row.demandProfile.askAnnual), askYears: Number(row.demandProfile.askYears) };
+}
+
+function offerCapHit(contract) {
+  return Math.round((contract.baseAnnual + contract.signingBonus / contract.yearsTotal) * 10) / 10;
+}
+
+// ── Boot ───────────────────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  installSelfBridge();
+  await import('../../src/worker/worker.js');
+  const ready = await send(toWorker.INIT, {}, { timeoutMs: BOOT_TIMEOUT_MS });
+  expect(ready.type).toBe(toUI.READY);
+  const boot = await send(
+    toWorker.USE_SAFE_STARTER_LEAGUE,
+    { slotKey: SLOT_KEY, options: { rngSeed: 20260613, userTeamId: USER_TEAM_ID, name: 'Offseason FA Smoke' } },
+    { timeoutMs: BOOT_TIMEOUT_MS },
+  );
+  expect(boot.type).toBe(toUI.FULL_STATE);
+}, BOOT_TIMEOUT_MS);
+
+afterAll(() => {
+  delete globalThis.self;
+});
+
+// ── One continuous user session against a single target player ────────────────
+
+describe('offseason FA smoke: the user loop through worker messages', () => {
+  let fa;
+  let ask;
+  let modest;
+
+  it('opens Free Agency with an empty ledger and an unreserved cap', async () => {
+    enterFreeAgency();
+    fa = makeFreeAgentFromTeam(2);
+    const data = await getFreeAgents();
+    expect(data.phase).toBe('free_agency');
+    expect(data.pendingOffers).toEqual([]);
+    expect(data.capSummary.reservedPendingCap).toBe(0);
+    expect(data.capSummary.effectiveCapRoom).toBeCloseTo(data.capSummary.capRoom, 1);
+  }, TEST_TIMEOUT_MS);
+
+  it('submit: the pending panel payload carries every field the UI renders, and cap is reserved', async () => {
+    ask = await getAsk(fa.id);
+    modest = {
+      baseAnnual: Math.round(ask.askAnnual * 1.15 * 10) / 10,
+      yearsTotal: ask.askYears,
+      signingBonus: 0,
+    };
+    const reply = await send(toWorker.SUBMIT_OFFER, { playerId: fa.id, teamId: USER_TEAM_ID, contract: modest });
+    expect(reply.type).toBe(toUI.STATE_UPDATE);
+
+    const data = await getFreeAgents();
+    expect(data.pendingOffers).toHaveLength(1);
+    const row = data.pendingOffers[0];
+    // Fields rendered by PendingOffersPanel (FreeAgency.jsx). If any of these
+    // go missing the panel renders blanks, so pin them here.
+    expect(row.status).toBe(PENDING_OFFER_STATUS.PENDING);
+    expect(row.playerName).toBe(fa.name);
+    expect(typeof row.pos).toBe('string');
+    expect(row.years).toBe(modest.yearsTotal);
+    expect(row.totalValue).toBeCloseTo(modest.baseAnnual * modest.yearsTotal, 1);
+    expect(row.annualCapHit).toBeCloseTo(offerCapHit(modest), 1);
+    expect(Array.isArray(row.feedback)).toBe(true);
+    expect(row.feedback.length).toBeGreaterThan(0);
+
+    // Effective cap = cap room minus the reservation (the badge's numbers).
+    expect(data.capSummary.reservedPendingCap).toBeCloseTo(offerCapHit(modest), 1);
+    expect(data.capSummary.effectiveCapRoom).toBeCloseTo(
+      data.capSummary.capRoom - data.capSummary.reservedPendingCap,
+      1,
+    );
+  }, TEST_TIMEOUT_MS);
+
+  it('withdraw: the reservation releases and the row reads withdrawn', async () => {
+    const reply = await send(toWorker.WITHDRAW_OFFER, { playerId: fa.id, teamId: USER_TEAM_ID });
+    expect(reply.type).toBe(toUI.STATE_UPDATE);
+
+    const data = await getFreeAgents();
+    const row = data.pendingOffers.find((r) => r.playerId === Number(fa.id));
+    expect(row.status).toBe(PENDING_OFFER_STATUS.WITHDRAWN);
+    expect(data.capSummary.reservedPendingCap).toBe(0);
+    expect(data.capSummary.effectiveCapRoom).toBeCloseTo(data.capSummary.capRoom, 1);
+    // The withdrawn bid no longer sits on the player for the AI pipeline.
+    const playerOffers = cache.getPlayer(fa.id).offers ?? [];
+    expect(playerOffers.some((o) => Number(o.teamId) === USER_TEAM_ID)).toBe(false);
+  }, TEST_TIMEOUT_MS);
+
+  it('re-offer after withdraw: a strong bid on the same player goes pending again', async () => {
+    const strong = {
+      baseAnnual: Math.round(ask.askAnnual * 1.8 * 10) / 10,
+      yearsTotal: ask.askYears,
+      signingBonus: Math.round(ask.askAnnual * 1.5 * 10) / 10,
+    };
+    const reply = await send(toWorker.SUBMIT_OFFER, { playerId: fa.id, teamId: USER_TEAM_ID, contract: strong });
+    expect(reply.type).toBe(toUI.STATE_UPDATE);
+
+    // Withdraw + re-offer leaves two ledger rows for the player; the newest
+    // (returned first by GET_FREE_AGENTS) must be the pending strong bid.
+    const data = await getFreeAgents();
+    const rows = data.pendingOffers.filter((r) => r.playerId === Number(fa.id));
+    expect(rows.length).toBe(2);
+    expect(rows[0].status).toBe(PENDING_OFFER_STATUS.PENDING);
+    expect(rows[0].annualCapHit).toBeCloseTo(offerCapHit(strong), 1);
+    expect(rows[1].status).toBe(PENDING_OFFER_STATUS.WITHDRAWN);
+    // Exactly one reservation — the withdrawn row must not count.
+    expect(data.capSummary.reservedPendingCap).toBeCloseTo(offerCapHit(strong), 1);
+  }, TEST_TIMEOUT_MS);
+
+  it('advance FA day: the strong offer is accepted — roster join, pool removal, cap release', async () => {
+    let data = null;
+    let row = null;
+    for (let i = 0; i < 4; i += 1) {
+      data = await advanceFaDayAndRefresh();
+      row = getLedger().find(
+        (r) => r.playerId === Number(fa.id) && r.teamId === USER_TEAM_ID && r.status !== PENDING_OFFER_STATUS.WITHDRAWN,
+      );
+      if (row.status !== PENDING_OFFER_STATUS.PENDING) break;
+    }
+
+    expect(row.status).toBe(PENDING_OFFER_STATUS.ACCEPTED);
+
+    const player = cache.getPlayer(fa.id);
+    expect(Number(player.teamId)).toBe(USER_TEAM_ID);
+    expect(player.status).toBe('active');
+    expect(data.freeAgents.some((p) => p.id === fa.id)).toBe(false);
+
+    // Resolved offers stop reserving cap; the payload tells the same story
+    // the re-opened Free Agency screen renders.
+    expect(data.capSummary.reservedPendingCap).toBe(0);
+    const payloadRow = data.pendingOffers.find(
+      (r) => r.playerId === Number(fa.id) && r.status !== PENDING_OFFER_STATUS.WITHDRAWN,
+    );
+    expect(payloadRow.status).toBe(PENDING_OFFER_STATUS.ACCEPTED);
+  }, TEST_TIMEOUT_MS);
+});

--- a/tests/unit/pendingOffersPanelLayout.test.jsx
+++ b/tests/unit/pendingOffersPanelLayout.test.jsx
@@ -1,0 +1,171 @@
+/** @vitest-environment jsdom */
+/**
+ * Free Agency Market V2 — pending offer panel layout regression (mobile-safe).
+ *
+ * No visual redesign here; these tests only pin that the structural pieces a
+ * user depends on never drop out of the DOM:
+ *   - the pending offers panel renders long player names,
+ *   - the Withdraw button stays present on pending rows,
+ *   - the effective-cap badge stays present,
+ *   - the FA table row keeps its offer-status chip.
+ */
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { render, screen, within, cleanup } from "@testing-library/react";
+import React from "react";
+import FreeAgency, { PendingOffersPanel } from "../../src/ui/components/FreeAgency.jsx";
+
+// Vitest globals are off in this repo, so testing-library cannot auto-cleanup.
+afterEach(cleanup);
+
+const LONG_NAME = "Maximiliano Bartholomew Featherstonehaugh-Worthington III";
+
+const pendingOffer = {
+  id: "fa-offer-42-0-1-1",
+  playerId: 42,
+  playerName: LONG_NAME,
+  pos: "QB",
+  years: 4,
+  totalValue: 88,
+  annualCapHit: 22,
+  status: "pending",
+  feedback: ["Competitive offer — close to the player’s asking price."],
+  competingTeamIds: [3, 7],
+};
+
+const capSummary = { capRoom: 100, reservedPendingCap: 22, effectiveCapRoom: 78 };
+
+describe("PendingOffersPanel layout", () => {
+  it("renders a long player name without dropping the withdraw button or cap badge", () => {
+    render(
+      <PendingOffersPanel
+        pendingOffers={[pendingOffer]}
+        capSummary={capSummary}
+        onWithdraw={() => {}}
+      />,
+    );
+    const panel = screen.getByTestId("pending-offers-panel");
+    const row = within(panel).getByTestId("pending-offer-42");
+    expect(within(row).getByText(new RegExp(LONG_NAME))).toBeTruthy();
+    expect(within(row).getByRole("button", { name: "Withdraw" })).toBeTruthy();
+    expect(within(row).getByText("Pending")).toBeTruthy();
+    const badge = screen.getByTestId("effective-cap-badge");
+    expect(badge.textContent).toContain("$78.0M");
+    expect(badge.textContent).toContain("reserved $22.0M");
+  });
+
+  it("calls onWithdraw with the playerId", () => {
+    const onWithdraw = vi.fn();
+    render(
+      <PendingOffersPanel
+        pendingOffers={[pendingOffer]}
+        capSummary={capSummary}
+        onWithdraw={onWithdraw}
+      />,
+    );
+    within(screen.getByTestId("pending-offer-42"))
+      .getByRole("button", { name: "Withdraw" })
+      .click();
+    expect(onWithdraw).toHaveBeenCalledWith(42);
+  });
+
+  it("keeps the status badge but hides Withdraw on resolved rows", () => {
+    for (const [status, label] of [
+      ["accepted", "Accepted"],
+      ["rejected", "Rejected"],
+      ["expired", "Expired"],
+      ["withdrawn", "Withdrawn"],
+    ]) {
+      render(
+        <PendingOffersPanel
+          pendingOffers={[{ ...pendingOffer, id: `row-${status}`, status }]}
+          capSummary={{ ...capSummary, reservedPendingCap: 0, effectiveCapRoom: 100 }}
+          onWithdraw={() => {}}
+        />,
+      );
+      const row = screen.getByTestId("pending-offer-42");
+      expect(within(row).getByText(label)).toBeTruthy();
+      expect(within(row).queryByRole("button", { name: "Withdraw" })).toBeNull();
+      cleanup();
+    }
+  });
+
+  it("renders nothing when there are no offers and no reservation", () => {
+    const { container } = render(
+      <PendingOffersPanel pendingOffers={[]} capSummary={{ ...capSummary, reservedPendingCap: 0 }} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("FreeAgency table row status chip", () => {
+  const freeAgent = {
+    id: 42,
+    name: LONG_NAME,
+    pos: "QB",
+    age: 27,
+    ovr: 78,
+    potential: 82,
+    traits: [],
+    contract: null,
+    schemeFit: 60,
+    offers: { count: 1, userOffered: true, userIsTopBidder: true },
+    market: { heat: 1, bidderCount: 1 },
+    demandProfile: { askAnnual: 18, askYears: 3, headline: "Balanced priorities" },
+    playbookKnowledge: { score: 10, label: "Low" },
+  };
+
+  const league = {
+    userTeamId: 0,
+    week: 1,
+    phase: "free_agency",
+    teams: [
+      {
+        id: 0,
+        name: "Test Team",
+        abbr: "TST",
+        capTotal: 255,
+        capUsed: 150,
+        deadCap: 5,
+        capRoom: 100,
+        roster: [],
+        gamePlan: {},
+      },
+    ],
+  };
+
+  const payload = {
+    phase: "free_agency",
+    faDay: 1,
+    faMaxDays: 5,
+    freeAgents: [freeAgent],
+    pendingOffers: [pendingOffer],
+    capSummary,
+  };
+
+  function makeActions() {
+    return {
+      getFreeAgents: vi.fn(async () => ({ payload })),
+      submitOffer: vi.fn(async () => ({})),
+      withdrawOffer: vi.fn(async () => ({})),
+      signPlayer: vi.fn(async () => ({})),
+      advanceFreeAgencyDay: vi.fn(),
+    };
+  }
+
+  it("keeps the pending status chip on the table row, plus panel + badge, with a long name", async () => {
+    render(<FreeAgency userTeamId={0} league={league} actions={makeActions()} />);
+
+    // Wait for the async FA load, then find the player's table row.
+    const cells = await screen.findAllByText(LONG_NAME, undefined, { timeout: 5000 });
+    const tableRow = cells.map((el) => el.closest("tr")).find(Boolean);
+    expect(tableRow, "player row missing from the desktop FA table").toBeTruthy();
+
+    // The status chip sits next to the player name inside the row.
+    expect(within(tableRow).getByText("Pending")).toBeTruthy();
+
+    // Panel structure survives alongside the table: withdraw + cap badge.
+    const panel = screen.getByTestId("pending-offers-panel");
+    expect(within(panel).getByRole("button", { name: "Withdraw" })).toBeTruthy();
+    expect(screen.getByTestId("effective-cap-badge")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Post-#1581 test/audit pass proving the offseason loop works from the
user's perspective after Free Agency Market V2. No gameplay, UI, or
engine changes.

- tests/e2e/offseasonFaFlow.spec.js: new spec (simulateWeek.spec.js is
  mid-season only; phase_hydration covers phase mechanics, not offers).
  Drives the real free_agency phase: submit offer -> pending panel +
  effective-cap reservation -> withdraw releases cap -> strong offer ->
  advance FA day(s) -> accepted player joins roster / leaves pool, or
  stays pending with feedback.
- tests/integration/offseasonFaSmoke.worker.test.js: same user journey
  through the #1581 worker harness as a Playwright-free fallback, incl.
  withdraw -> re-offer same player -> accept (not covered by #1581) and
  pins the GET_FREE_AGENTS payload fields PendingOffersPanel renders.
- tests/unit/pendingOffersPanelLayout.test.jsx: mobile-safe layout
  regression — long player names, Withdraw button, effective-cap badge,
  and the FA table row status chip all stay present.
- docs/qa/free-agency-market-v2-release-checklist.md: short manual
  smoke checklist for environments without Playwright browsers.

https://claude.ai/code/session_01JsZVq4JmrSkSyUZNKHzCks