### PR TITLE
fix: wire advancedAttribution/shutoutFloorApplied end-to-end, add rich-engine feat news, wire upset alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.11.0",
     "@playwright/test": "^1.59.1",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",
     "@vitejs/plugin-react": "^5.1.4",
     "fake-indexeddb": "^6.2.5",

--- a/scripts/engineSoak.js
+++ b/scripts/engineSoak.js
@@ -13,7 +13,7 @@
  * Both engines consume the SAME generated rosters, so the comparison is fair.
  *
  * Checks (applied to the matchup engine as the flip gate):
- *   1. Win distribution : top-quartile teams (by roster OVR) win ~68–73% of games
+ *   1. Win distribution : top-quartile teams (by roster OVR) win ~68–76% of games
  *   2. Stat realism     : pass yds/game 220–280, rush yds/game 100–130, pts/game 20–27
  *   3. Score variance   : std-dev of final team scores reported (PBP should be >= legacy)
  *   4. Performance      : wall-clock ms per game

--- a/src/core/__tests__/featDerivation.test.js
+++ b/src/core/__tests__/featDerivation.test.js
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import { deriveFeatsFromRichGame } from '../sim/featDerivation.js';
+
+function makeResult(overrides = {}) {
+  return {
+    boxScore: {
+      home: {},
+      away: {},
+    },
+    ...overrides,
+  };
+}
+
+describe('deriveFeatsFromRichGame', () => {
+  it('returns empty array when result has no boxScore', () => {
+    expect(deriveFeatsFromRichGame({})).toEqual([]);
+    expect(deriveFeatsFromRichGame(null)).toEqual([]);
+    expect(deriveFeatsFromRichGame(undefined)).toEqual([]);
+  });
+
+  it('returns empty array when no player meets a threshold', () => {
+    const result = makeResult({
+      boxScore: {
+        home: {
+          'qb-1': { name: 'Home QB', pos: 'QB', stats: { passYd: 299, rushYd: 0 } },
+        },
+        away: {
+          'rb-1': { name: 'Away RB', pos: 'RB', stats: { rushYd: 99, recYd: 0 } },
+        },
+      },
+    });
+    expect(deriveFeatsFromRichGame(result)).toEqual([]);
+  });
+
+  it('derives a passing-yard feat at exactly 300 yards (boundary)', () => {
+    const result = makeResult({
+      boxScore: {
+        home: {
+          'qb-1': { name: 'Home QB', pos: 'QB', stats: { passYd: 300 } },
+        },
+        away: {},
+      },
+    });
+    const feats = deriveFeatsFromRichGame(result);
+    expect(feats).toHaveLength(1);
+    expect(feats[0]).toMatchObject({
+      playerId: 'qb-1',
+      name: 'Home QB',
+      teamSide: 'home',
+      statValue: '300',
+      featDescription: 'passing yards',
+    });
+  });
+
+  it('derives a rushing-yard feat at exactly 100 yards (boundary)', () => {
+    const result = makeResult({
+      boxScore: {
+        home: {},
+        away: {
+          'rb-2': { name: 'Away RB', pos: 'RB', stats: { rushYd: 100 } },
+        },
+      },
+    });
+    const feats = deriveFeatsFromRichGame(result);
+    expect(feats).toHaveLength(1);
+    expect(feats[0]).toMatchObject({
+      playerId: 'rb-2',
+      name: 'Away RB',
+      teamSide: 'away',
+      statValue: '100',
+      featDescription: 'rushing yards',
+    });
+  });
+
+  it('derives a receiving-yard feat at exactly 100 yards (boundary)', () => {
+    const result = makeResult({
+      boxScore: {
+        home: {
+          'wr-1': { name: 'Home WR', pos: 'WR', stats: { recYd: 100 } },
+        },
+        away: {},
+      },
+    });
+    const feats = deriveFeatsFromRichGame(result);
+    expect(feats).toHaveLength(1);
+    expect(feats[0]).toMatchObject({
+      playerId: 'wr-1',
+      name: 'Home WR',
+      teamSide: 'home',
+      statValue: '100',
+      featDescription: 'receiving yards',
+    });
+  });
+
+  it('can derive multiple feat types for a single player (e.g. QB with 300+ pass and 100+ rush)', () => {
+    const result = makeResult({
+      boxScore: {
+        home: {
+          'qb-1': { name: 'Home QB', pos: 'QB', stats: { passYd: 350, rushYd: 112 } },
+        },
+        away: {},
+      },
+    });
+    const feats = deriveFeatsFromRichGame(result);
+    expect(feats).toHaveLength(2);
+    const types = feats.map((f) => f.featDescription);
+    expect(types).toContain('passing yards');
+    expect(types).toContain('rushing yards');
+  });
+
+  it('derives feats from both home and away sides independently', () => {
+    const result = makeResult({
+      boxScore: {
+        home: { 'qb-1': { name: 'H QB', pos: 'QB', stats: { passYd: 320 } } },
+        away: { 'rb-1': { name: 'A RB', pos: 'RB', stats: { rushYd: 130 } } },
+      },
+    });
+    const feats = deriveFeatsFromRichGame(result);
+    expect(feats).toHaveLength(2);
+    expect(feats.find((f) => f.teamSide === 'home')?.name).toBe('H QB');
+    expect(feats.find((f) => f.teamSide === 'away')?.name).toBe('A RB');
+  });
+
+  it('is deterministic — same input produces identical output', () => {
+    const result = makeResult({
+      boxScore: {
+        home: {
+          'qb-1': { name: 'QB1', pos: 'QB', stats: { passYd: 302 } },
+          'rb-1': { name: 'RB1', pos: 'RB', stats: { rushYd: 105 } },
+        },
+        away: {
+          'wr-1': { name: 'WR1', pos: 'WR', stats: { recYd: 120 } },
+        },
+      },
+    });
+    expect(deriveFeatsFromRichGame(result)).toEqual(deriveFeatsFromRichGame(result));
+  });
+
+  it('does not generate feat news from rich-engine result when no threshold is met (no-fake-output guard)', () => {
+    // Simulates a standard low-scoring defensive game — no player crests a feat threshold
+    const result = makeResult({
+      boxScore: {
+        home: {
+          'qb-1': { name: 'QB1', pos: 'QB', stats: { passYd: 180, rushYd: 12 } },
+          'rb-1': { name: 'RB1', pos: 'RB', stats: { rushYd: 68 } },
+          'wr-1': { name: 'WR1', pos: 'WR', stats: { recYd: 55 } },
+        },
+        away: {
+          'qb-2': { name: 'QB2', pos: 'QB', stats: { passYd: 201, rushYd: 0 } },
+          'rb-2': { name: 'RB2', pos: 'RB', stats: { rushYd: 71 } },
+        },
+      },
+    });
+    expect(deriveFeatsFromRichGame(result)).toHaveLength(0);
+  });
+
+  it('handles missing or malformed player entries gracefully', () => {
+    const result = makeResult({
+      boxScore: {
+        home: {
+          'p-null': null,
+          'p-no-stats': { name: 'NoStats', pos: 'LB' },
+          'p-good': { name: 'Good QB', pos: 'QB', stats: { passYd: 305 } },
+        },
+        away: null,
+      },
+    });
+    const feats = deriveFeatsFromRichGame(result);
+    expect(feats).toHaveLength(1);
+    expect(feats[0].name).toBe('Good QB');
+  });
+});

--- a/src/core/__tests__/gameArchive.test.js
+++ b/src/core/__tests__/gameArchive.test.js
@@ -190,6 +190,77 @@ describe('gameArchive helpers', () => {
   });
 });
 
+describe('advancedAttribution and shutoutFloorApplied survive normalizeArchivedGamePayload', () => {
+  it('preserves advancedAttribution through normalizeArchivedGamePayload whitelist', () => {
+    const advancedAttribution = {
+      'qb-1': { targets: 0, receptionsAllowed: 0, coverageTargets: 0, coverageCompletionsAllowed: 0, drops: 2, battedPasses: 1, sacksAllowed: 3, sacksMade: 0 },
+      'cb-1': { targets: 7, receptionsAllowed: 4, coverageTargets: 7, coverageCompletionsAllowed: 4, drops: 0, battedPasses: 0, sacksAllowed: 0, sacksMade: 0 },
+    };
+    const normalized = normalizeArchivedGamePayload({
+      id: '2031_w5_1_2',
+      seasonId: '2031',
+      week: 5,
+      homeId: 1,
+      awayId: 2,
+      homeScore: 28,
+      awayScore: 14,
+      advancedAttribution,
+    });
+    expect(normalized.advancedAttribution).toEqual(advancedAttribution);
+  });
+
+  it('advancedAttribution is null when not provided', () => {
+    const normalized = normalizeArchivedGamePayload({
+      id: '2031_w5_3_4',
+      seasonId: '2031',
+      week: 5,
+      homeId: 3,
+      awayId: 4,
+      homeScore: 17,
+      awayScore: 14,
+    });
+    expect(normalized.advancedAttribution).toBeNull();
+  });
+
+  it('preserves advancedAttribution through a JSON round-trip normalization', () => {
+    const advancedAttribution = { 'wr-1': { targets: 8, drops: 1, battedPasses: 0, coverageTargets: 0, coverageCompletionsAllowed: 0, receptionsAllowed: 0, sacksAllowed: 0, sacksMade: 0 } };
+    const first = normalizeArchivedGamePayload({
+      id: '2031_w6_1_2', seasonId: '2031', week: 6, homeId: 1, awayId: 2,
+      homeScore: 24, awayScore: 21, advancedAttribution,
+    });
+    const reloaded = normalizeArchivedGamePayload(JSON.parse(JSON.stringify(first)));
+    expect(reloaded.advancedAttribution).toEqual(advancedAttribution);
+  });
+
+  it('preserves shutoutFloorApplied through normalizeArchivedGamePayload whitelist', () => {
+    const shutoutFloorApplied = { home: false, away: true };
+    const normalized = normalizeArchivedGamePayload({
+      id: '2031_w7_5_6',
+      seasonId: '2031',
+      week: 7,
+      homeId: 5,
+      awayId: 6,
+      homeScore: 17,
+      awayScore: 3,
+      shutoutFloorApplied,
+    });
+    expect(normalized.shutoutFloorApplied).toEqual(shutoutFloorApplied);
+  });
+
+  it('shutoutFloorApplied is null when not provided', () => {
+    const normalized = normalizeArchivedGamePayload({
+      id: '2031_w8_7_8',
+      seasonId: '2031',
+      week: 8,
+      homeId: 7,
+      awayId: 8,
+      homeScore: 21,
+      awayScore: 14,
+    });
+    expect(normalized.shutoutFloorApplied).toBeNull();
+  });
+});
+
 describe('canonical rich-engine teamStats hydration', () => {
   it('survives archive normalization + enrichment without being re-derived or zeroed', () => {
     const richSide = {

--- a/src/core/__tests__/weekSimulationBridge.test.ts
+++ b/src/core/__tests__/weekSimulationBridge.test.ts
@@ -121,4 +121,84 @@ describe('weekSimulationBridge', () => {
   it('builds deterministic seeds', () => {
     expect(buildDeterministicSeed('2026:4:1:2')).toBe(buildDeterministicSeed('2026:4:1:2'));
   });
+
+  it('carries advancedAttribution from rich summary into bridge result', () => {
+    const advancedAttribution = {
+      'qb-1': { targets: 0, receptionsAllowed: 0, coverageTargets: 0, coverageCompletionsAllowed: 0, drops: 2, battedPasses: 1, sacksAllowed: 3, sacksMade: 0 },
+    };
+    const mapped = mapGameSummaryToLegacyResult({
+      gameId: 'g-adv',
+      homeTeamId: 1,
+      awayTeamId: 2,
+      homeScore: 21,
+      awayScore: 14,
+      totalPlays: 110,
+      homePassYards: 240,
+      awayPassYards: 200,
+      homeSuccessRate: 0.55,
+      awaySuccessRate: 0.50,
+      normalizationConstant: 0.74,
+      topReason1: null,
+      topReason2: null,
+      quarterScores: { home: [7, 0, 7, 7], away: [7, 7, 0, 0] },
+      teamStats: {
+        home: { plays: 60, passAtt: 30, passComp: 20, passYd: 240, rushAtt: 30, rushYd: 110, passTD: 1, rushTD: 2, totalYards: 350, yardsPerPlay: 5.8, turnovers: 0, sacksAllowed: 1, sacksMade: 2, interceptions: 0, redZoneTrips: 3, redZoneScores: 2, explosivePlays: 3, successRate: 0.55, firstDowns: 18, fieldGoalsMade: 0, fieldGoalsAttempted: 0, extraPointsMade: 3, extraPointsAttempted: 3, punts: 4, puntYards: 160, kickReturns: 3, kickReturnYards: 60, puntReturns: 2, puntReturnYards: 18 },
+        away: { plays: 58, passAtt: 28, passComp: 18, passYd: 200, rushAtt: 30, rushYd: 90, passTD: 1, rushTD: 1, totalYards: 290, yardsPerPlay: 5.0, turnovers: 1, sacksAllowed: 2, sacksMade: 1, interceptions: 1, redZoneTrips: 2, redZoneScores: 1, explosivePlays: 2, successRate: 0.50, firstDowns: 15, fieldGoalsMade: 1, fieldGoalsAttempted: 1, extraPointsMade: 2, extraPointsAttempted: 2, punts: 5, puntYards: 200, kickReturns: 2, kickReturnYards: 44, puntReturns: 1, puntReturnYards: 8 },
+      },
+      boxScore: { home: {}, away: {} },
+      playDigest: [],
+      scoringSummary: [],
+      playLogs: [],
+      summary: { storyline: 'Solid win.', headlineMoments: [] },
+      recapText: 'Home holds on.',
+      regulationTied: false,
+      overtime: { played: false, periods: 0, decidedBy: null },
+      shutoutFloorApplied: { home: false, away: false },
+      advancedAttribution,
+      simFactors: {
+        home: { qbRating: 95.0, rushYpc: 3.67, successRate: 0.55, passRate: 0.5 },
+        away: { qbRating: 85.0, rushYpc: 3.0, successRate: 0.50, passRate: 0.483 },
+      },
+    } as any);
+
+    expect(mapped.advancedAttribution).toEqual(advancedAttribution);
+  });
+
+  it('carries shutoutFloorApplied from rich summary into bridge result', () => {
+    const mapped = mapGameSummaryToLegacyResult({
+      gameId: 'g-shutout',
+      homeTeamId: 10,
+      awayTeamId: 20,
+      homeScore: 17,
+      awayScore: 3,
+      totalPlays: 100,
+      homePassYards: 200,
+      awayPassYards: 150,
+      homeSuccessRate: 0.52,
+      awaySuccessRate: 0.44,
+      normalizationConstant: 0.74,
+      topReason1: null,
+      topReason2: null,
+      quarterScores: { home: [7, 0, 10, 0], away: [0, 0, 0, 3] },
+      teamStats: {
+        home: { plays: 55, passAtt: 25, passComp: 15, passYd: 200, rushAtt: 30, rushYd: 120, passTD: 1, rushTD: 2, totalYards: 320, yardsPerPlay: 5.8, turnovers: 0, sacksAllowed: 1, sacksMade: 3, interceptions: 0, redZoneTrips: 3, redZoneScores: 3, explosivePlays: 2, successRate: 0.52, firstDowns: 16, fieldGoalsMade: 0, fieldGoalsAttempted: 0, extraPointsMade: 3, extraPointsAttempted: 3, punts: 3, puntYards: 120, kickReturns: 2, kickReturnYards: 40, puntReturns: 1, puntReturnYards: 6 },
+        away: { plays: 52, passAtt: 24, passComp: 14, passYd: 150, rushAtt: 28, rushYd: 70, passTD: 0, rushTD: 0, totalYards: 220, yardsPerPlay: 4.2, turnovers: 2, sacksAllowed: 3, sacksMade: 1, interceptions: 2, redZoneTrips: 1, redZoneScores: 0, explosivePlays: 1, successRate: 0.44, firstDowns: 11, fieldGoalsMade: 1, fieldGoalsAttempted: 1, extraPointsMade: 0, extraPointsAttempted: 0, punts: 6, puntYards: 252, kickReturns: 3, kickReturnYards: 63, puntReturns: 2, puntReturnYards: 12 },
+      },
+      boxScore: { home: {}, away: {} },
+      playDigest: [],
+      scoringSummary: [],
+      playLogs: [],
+      summary: { storyline: 'Home dominates.', headlineMoments: [] },
+      recapText: 'Home wins big.',
+      regulationTied: false,
+      overtime: { played: false, periods: 0, decidedBy: null },
+      shutoutFloorApplied: { home: false, away: true },
+      simFactors: {
+        home: { qbRating: 92.0, rushYpc: 4.0, successRate: 0.52, passRate: 0.455 },
+        away: { qbRating: 72.0, rushYpc: 2.5, successRate: 0.44, passRate: 0.462 },
+      },
+    } as any);
+
+    expect(mapped.shutoutFloorApplied).toEqual({ home: false, away: true });
+  });
 });

--- a/src/core/gameArchive.js
+++ b/src/core/gameArchive.js
@@ -204,6 +204,8 @@ export function normalizeArchivedGamePayload(rawGame) {
     injuries: Array.isArray(rawGame?.injuries) ? rawGame.injuries : [],
     gameReasoningFlags: Array.isArray(rawGame?.gameReasoningFlags) ? rawGame.gameReasoningFlags : [],
     archiveQuality: rawGame?.archiveQuality,
+    advancedAttribution: rawGame?.advancedAttribution ?? null,
+    shutoutFloorApplied: rawGame?.shutoutFloorApplied ?? null,
     // legacy compatibility fields
     stats: legacyStats ?? (playerStats ? { ...playerStats, playLogs: playLog } : null),
     drives: Array.isArray(rawGame?.drives) ? rawGame.drives : (Array.isArray(rawGame?.driveSummary) ? rawGame.driveSummary : []),

--- a/src/core/sim/featDerivation.js
+++ b/src/core/sim/featDerivation.js
@@ -1,0 +1,60 @@
+/**
+ * Pure adapter: derives feat entries from a rich-engine game result.
+ *
+ * Called at the same site in worker.js where result.feats is consumed for
+ * legacy-engine results. Kept out of both the engine and the worker main loop
+ * so it remains independently unit-testable.
+ *
+ * Thresholds: NFL "game-ball" tier — 300+ passing yards, 100+ rushing yards,
+ * 100+ receiving yards.
+ */
+
+const PASS_YARD_THRESHOLD = 300;
+const RUSH_YARD_THRESHOLD = 100;
+const REC_YARD_THRESHOLD = 100;
+
+/**
+ * Derive feat entries from a rich-engine game result.
+ *
+ * Input: the mapped legacy result (from mapGameSummaryToLegacyResult).
+ * The boxScore shape is { home: Record<pid, { name, pos, stats }>, away: ... }.
+ *
+ * Returns an array of feat objects that mirror the shape consumed by the
+ * existing feat-processing loop in applyGameResultToCache, augmented with a
+ * `teamSide` field so the caller can resolve teamAbbr / opponentAbbr from cache.
+ *
+ * @param {{ boxScore?: { home?: Record<string,{name:string,stats:Record<string,number>}>, away?: Record<string,{name:string,stats:Record<string,number>}> } }} result
+ * @returns {{ playerId: string, name: string, teamSide: 'home'|'away', statValue: string, featDescription: string }[]}
+ */
+export function deriveFeatsFromRichGame(result) {
+  if (!result?.boxScore) return [];
+  const feats = [];
+
+  for (const side of ['home', 'away']) {
+    const box = result.boxScore[side];
+    if (!box || typeof box !== 'object') continue;
+
+    for (const [pid, entry] of Object.entries(box)) {
+      if (!entry || typeof entry !== 'object') continue;
+      const stats = entry.stats ?? {};
+      const name = entry.name ?? String(pid);
+
+      const passYd = Number(stats.passYd ?? 0);
+      if (passYd >= PASS_YARD_THRESHOLD) {
+        feats.push({ playerId: pid, name, teamSide: side, statValue: String(passYd), featDescription: 'passing yards' });
+      }
+
+      const rushYd = Number(stats.rushYd ?? 0);
+      if (rushYd >= RUSH_YARD_THRESHOLD) {
+        feats.push({ playerId: pid, name, teamSide: side, statValue: String(rushYd), featDescription: 'rushing yards' });
+      }
+
+      const recYd = Number(stats.recYd ?? 0);
+      if (recYd >= REC_YARD_THRESHOLD) {
+        feats.push({ playerId: pid, name, teamSide: side, statValue: String(recYd), featDescription: 'receiving yards' });
+      }
+    }
+  }
+
+  return feats;
+}

--- a/src/core/sim/weekSimulationBridge.ts
+++ b/src/core/sim/weekSimulationBridge.ts
@@ -160,6 +160,8 @@ export function mapGameSummaryToLegacyResult(summary: GameSummary) {
         passRate: summary.simFactors?.away?.passRate ?? awayPassRate,
       },
     },
+    advancedAttribution: summary.advancedAttribution,
+    shutoutFloorApplied: summary.shutoutFloorApplied,
   };
 }
 

--- a/src/ui/utils/boxScoreViewModel.js
+++ b/src/ui/utils/boxScoreViewModel.js
@@ -129,6 +129,8 @@ function buildTeamComparisonRows(teamTotals = {}) {
 
 const PLAYER_SECTION_SPECS = [
   { key: 'passing', title: 'Passing', defaultSort: 'passYd', countLabel: 'passers', cols: [['passComp', 'Cmp'], ['passAtt', 'Att'], ['passYd', 'Yds'], ['passTD', 'TD'], ['interceptions', 'INT'], ['sacked', 'Sck'], ['passerRating', 'Rate']], include: (s) => toNum(s.passAtt) > 0 },
+  // TODO(rushLong/recLong): rich engine does not track per-play max yards; columns always blank.
+  //   Requires play-level stat modeling (out of scope). Deferred — see post-engine-flip-verification.md.
   { key: 'rushing', title: 'Rushing', defaultSort: 'rushYd', countLabel: 'rushers', cols: [['rushAtt', 'Att'], ['rushYd', 'Yds'], ['rushTD', 'TD'], ['fumbles', 'Fum'], ['rushLong', 'Long']], include: (s) => toNum(s.rushAtt) > 0 },
   { key: 'receiving', title: 'Receiving', defaultSort: 'recYd', countLabel: 'receivers', cols: [['targets', 'Tgt'], ['receptions', 'Rec'], ['recYd', 'Yds'], ['recTD', 'TD'], ['drops', 'Drop'], ['recLong', 'Long']], include: (s) => toNum(s.receptions) > 0 || toNum(s.targets) > 0 },
   { key: 'defense', title: 'Defense', defaultSort: 'tackles', countLabel: 'defenders', cols: [['tackles', 'Tkl'], ['sacks', 'Sack'], ['tfl', 'TFL'], ['interceptions', 'INT'], ['passesDefended', 'PD'], ['forcedFumbles', 'FF'], ['fumbleRecoveries', 'FR'], ['defTD', 'TD']], include: (s) => toNum(s.tackles) > 0 || toNum(s.sacks) > 0 || toNum(s.interceptions) > 0 || toNum(s.passesDefended) > 0 || toNum(s.forcedFumbles) > 0 },

--- a/src/ui/utils/boxScoreViewModel.test.js
+++ b/src/ui/utils/boxScoreViewModel.test.js
@@ -257,4 +257,35 @@ describe('buildBoxScoreViewModel', () => {
     expect(vm.playByPlayRows[0]).toMatchObject({ teamAbbr: 'AWY', clock: '1:29', text: 'Late interception seals it' });
     expect(vm.playByPlayRows[0].tags).toContain('turnover');
   });
+
+  it('passes advancedAttribution through to view-model from archived (non-watched-game) data', () => {
+    const advancedAttribution = {
+      'qb-1': { targets: 0, receptionsAllowed: 0, coverageTargets: 0, coverageCompletionsAllowed: 0, drops: 2, battedPasses: 1, sacksAllowed: 3, sacksMade: 0 },
+      'cb-1': { targets: 7, receptionsAllowed: 4, coverageTargets: 7, coverageCompletionsAllowed: 4, drops: 0, battedPasses: 0, sacksAllowed: 0, sacksMade: 1 },
+    };
+    // Simulate archived week-sim data that has gone through normalizeArchivedGamePayload
+    // (i.e. the non-watched-game path where game.advancedAttribution fallback must not be needed)
+    const vm = buildBoxScoreViewModel({
+      game: {
+        homeId: 1,
+        awayId: 2,
+        homeScore: 28,
+        awayScore: 17,
+        advancedAttribution,
+      },
+    });
+    // advancedAttribution should be normalised and available without relying on the
+    // watched-game fallback (game?.advancedAttribution)
+    expect(vm.advancedAttribution).toBeDefined();
+    expect(Object.keys(vm.advancedAttribution)).toHaveLength(2);
+    expect(vm.advancedAttribution['qb-1']).toMatchObject({ drops: 2, battedPasses: 1, sacksAllowed: 3 });
+    expect(vm.advancedAttribution['cb-1']).toMatchObject({ coverageTargets: 7, coverageCompletionsAllowed: 4, sacksMade: 1 });
+  });
+
+  it('advancedAttribution is empty object when not in archived data (no phantom output)', () => {
+    const vm = buildBoxScoreViewModel({
+      game: { homeId: 1, awayId: 2, homeScore: 14, awayScore: 10 },
+    });
+    expect(vm.advancedAttribution).toEqual({});
+  });
 });

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -202,6 +202,7 @@ import {
   buildDeterministicSeed,
   simulateWithOptionalNewEngine,
 } from '../core/sim/weekSimulationBridge.ts';
+import { deriveFeatsFromRichGame } from '../core/sim/featDerivation.js';
 import { deriveGamePlanMultipliers } from '../core/sim/gamePlanMultipliers.ts';
 import { buildGamePlanNarrative } from '../core/narrative.js';
 import { buildRosterBuildingAnalysis } from '../core/rosterBuildingAnalysis.js';
@@ -3880,7 +3881,7 @@ function applyGameResultToCache(result, week, seasonId) {
 
   // ── 4. Queue game record for DB flush ─────────────────────────────────────
 
-  // Process feats
+  // Process feats (legacy engine: result.feats populated by engine)
   if (result.feats && result.feats.length > 0) {
     for (const feat of result.feats) {
       if (feat.playerId) {
@@ -3893,6 +3894,28 @@ function applyGameResultToCache(result, week, seasonId) {
       }
     }
   }
+
+  // Rich-engine feat news: derived from boxScore when engine does not emit result.feats
+  if (!result.feats && result.boxScore) {
+    const richFeats = deriveFeatsFromRichGame(result);
+    if (richFeats.length > 0) {
+      const homeAbbr = cache.getTeam(hId)?.abbr ?? 'HME';
+      const awayAbbr = cache.getTeam(aId)?.abbr ?? 'AWY';
+      for (const feat of richFeats) {
+        const teamAbbr = feat.teamSide === 'home' ? homeAbbr : awayAbbr;
+        const opponentAbbr = feat.teamSide === 'home' ? awayAbbr : homeAbbr;
+        const teamId = feat.teamSide === 'home' ? hId : aId;
+        const p = cache.getPlayer(feat.playerId);
+        NewsEngine.logFeat(
+          p || { id: feat.playerId, name: feat.name, teamId },
+          teamAbbr, opponentAbbr, feat.featDescription, feat.statValue ?? '',
+        );
+      }
+    }
+  }
+
+  // Upset alert: fires when the lower-OVR team wins by more than 5 OVR points
+  NewsEngine.logGameEvent({ homeId: hId, awayId: aId, homeScore: scoreHome, awayScore: scoreAway });
 
   const archivedGame = normalizeArchivedGamePayload(buildArchivedGame({
     seasonId,
@@ -3938,6 +3961,8 @@ function applyGameResultToCache(result, week, seasonId) {
     notablePerformances: playerLeaders?.standouts ?? [],
     playerLeaders,
     archiveQuality,
+    advancedAttribution: result.advancedAttribution ?? null,
+    shutoutFloorApplied: result.shutoutFloorApplied ?? null,
   }));
   const archiveValidation = validateArchivedGame(archivedGame);
   if (!archiveValidation.valid) {


### PR DESCRIPTION
Closes five secondary-field gaps found in the post-engine-flip audit
(docs/qa/post-engine-flip-verification.md).

## What Changed

### Fix 1 — advancedAttribution wiring (three drop points)
- weekSimulationBridge.ts: carry `advancedAttribution` and `shutoutFloorApplied`
  from RichGameSummary into the mapped legacy result (drop point 1)
- worker.js buildArchivedGame call: pass both fields into the payload (drop point 2)
- gameArchive.js normalizeArchivedGamePayload: add both fields to the whitelist
  so they survive normalization before cache.addGame (drop point 3)

### Fix 2 — shutoutFloorApplied preserved
Same three drop points as Fix 1 (carried alongside advancedAttribution).

### Fix 3 — Post-game feat/upset news
- New pure adapter src/core/sim/featDerivation.js derives feat entries from
  existing rich-engine boxScore (300+ pass yds, 100+ rush yds, 100+ rec yds).
  Not inside the engine or worker main loop — unit-testable in isolation.
- worker.js: rich-engine feat news wired at the same site as result.feats
  processing; only fires when result.feats is absent (rich-engine path).
- worker.js: NewsEngine.logGameEvent wired for upset-alert news using hId/aId
  and game scores; the function was previously dead code (never called).

### Fix 4 — rushLong/recLong deferred
Added TODO comment at boxScoreViewModel.js:132-133 documenting that per-play
max-yard tracking requires new play-level modeling (out of scope for this PR).

### Fix 5 — Housekeeping
- package.json: @testing-library/dom added to devDependencies at ^10.4.1
  (previously peer-only via @testing-library/react, creating install fragility)
- scripts/engineSoak.js: spec comment updated from "~68-73%" to "~68-76%"
  to match the actual gate cap of 0.76

## Tests Added (19 new tests across 4 files)
- src/core/__tests__/featDerivation.test.js (9 tests): boundary conditions,
  multi-feat players, both sides, determinism, no-fake-output guard
- src/core/__tests__/weekSimulationBridge.test.ts (2 tests): advancedAttribution
  and shutoutFloorApplied carried through bridge result
- src/core/__tests__/gameArchive.test.js (5 tests): advancedAttribution and
  shutoutFloorApplied survive normalizeArchivedGamePayload and JSON round-trip
- src/ui/utils/boxScoreViewModel.test.js (3 tests): advancedAttribution present
  in view-model from archived (non-watched-game) data; empty when absent

https://claude.ai/code/session_01UeRGd6mWjUzQ8LvXqAzep7