### PR TITLE
feat: Player Morale Causality V1

### DIFF
--- a/src/core/__tests__/leaguePulseMorale.test.js
+++ b/src/core/__tests__/leaguePulseMorale.test.js
@@ -1,0 +1,169 @@
+/**
+ * leaguePulseMorale.test.js
+ *
+ * Tests for morale-related League Pulse items:
+ *  - Locker Room Watch (player morale < 35)
+ *  - Veteran Presence (VETERAN_LEADER_BONUS applied this week)
+ * Also tests deduplication behaviour.
+ */
+import { describe, it, expect } from 'vitest';
+import { generateLeaguePulseItems } from '../leaguePulse.js';
+import { MORALE_EVENTS } from '../mood/playerMoraleEngine.js';
+
+function makeMeta(overrides = {}) {
+  return {
+    season: 2,
+    week: 7,
+    phase: 'regular',
+    userTeamId: '10',
+    ...overrides,
+  };
+}
+
+function makePlayer(overrides = {}) {
+  return {
+    id: 99,
+    name: 'Test Player',
+    teamId: 10,
+    morale: 70,
+    moraleEvents: [],
+    ...overrides,
+  };
+}
+
+describe('LeaguePulse — Morale: Locker Room Watch', () => {
+  it('emits Locker Room Watch when player morale < 35', () => {
+    const players = [makePlayer({ morale: 30 })];
+    const items = generateLeaguePulseItems(makeMeta(), { players });
+    const watch = items.find((i) => i.headline === 'Locker Room Watch');
+    expect(watch).toBeDefined();
+    expect(watch.source).toBe('morale');
+    expect(watch.relatedPlayerId).toBe('99');
+  });
+
+  it('does NOT emit Locker Room Watch when morale is exactly 35', () => {
+    const players = [makePlayer({ morale: 35 })];
+    const items = generateLeaguePulseItems(makeMeta(), { players });
+    expect(items.find((i) => i.headline === 'Locker Room Watch')).toBeUndefined();
+  });
+
+  it('does NOT emit Locker Room Watch when morale >= 40', () => {
+    const players = [makePlayer({ morale: 40 }), makePlayer({ id: 100, morale: 70 })];
+    const items = generateLeaguePulseItems(makeMeta(), { players });
+    expect(items.find((i) => i.headline === 'Locker Room Watch')).toBeUndefined();
+  });
+
+  it('Locker Room Watch has deterministic dedupeKey', () => {
+    const players = [makePlayer({ morale: 20 })];
+    const items1 = generateLeaguePulseItems(makeMeta({ season: 2, week: 7 }), { players });
+    const items2 = generateLeaguePulseItems(makeMeta({ season: 2, week: 7 }), { players });
+    const k1 = items1.find((i) => i.headline === 'Locker Room Watch')?.dedupeKey;
+    const k2 = items2.find((i) => i.headline === 'Locker Room Watch')?.dedupeKey;
+    expect(k1).toBeDefined();
+    expect(k1).toBe(k2);
+  });
+
+  it('Locker Room Watch dedupeKey includes season + week + playerId', () => {
+    const players = [makePlayer({ id: 55, morale: 10 })];
+    const items = generateLeaguePulseItems(makeMeta({ season: 3, week: 9 }), { players });
+    const item = items.find((i) => i.headline === 'Locker Room Watch');
+    expect(item.dedupeKey).toContain('55');
+    expect(item.dedupeKey).toContain('3');
+    expect(item.dedupeKey).toContain('9');
+  });
+
+  it('repeated refresh does not duplicate Locker Room Watch items', () => {
+    const players = [makePlayer({ morale: 25 })];
+    const meta = makeMeta();
+    const items1 = generateLeaguePulseItems(meta, { players });
+    const items2 = generateLeaguePulseItems(meta, { players });
+    // Both calls produce 1 item each (deduplication happens in mergeLeaguePulseItems)
+    const watches1 = items1.filter((i) => i.headline === 'Locker Room Watch');
+    const watches2 = items2.filter((i) => i.headline === 'Locker Room Watch');
+    expect(watches1).toHaveLength(1);
+    expect(watches2).toHaveLength(1);
+    // dedupeKeys match
+    expect(watches1[0].dedupeKey).toBe(watches2[0].dedupeKey);
+  });
+});
+
+describe('LeaguePulse — Morale: Veteran Presence', () => {
+  const veteranPlayer = makePlayer({
+    id: 77,
+    name: 'Veteran Leader',
+    teamId: 10,
+    morale: 73,
+    moraleEvents: [
+      {
+        type:      MORALE_EVENTS.VETERAN_LEADER_BONUS,
+        delta:     3,
+        season:    2,
+        week:      7,
+        reason:    'Veteran leader on a winning team',
+        source:    'weekly_advance',
+        dedupeKey: 'VLB-77-2-7',
+      },
+    ],
+  });
+
+  it('emits Veteran Presence when veteran bonus was applied this week', () => {
+    const items = generateLeaguePulseItems(makeMeta({ season: 2, week: 7 }), { players: [veteranPlayer] });
+    const presence = items.find((i) => i.headline === 'Veteran Presence');
+    expect(presence).toBeDefined();
+    expect(presence.source).toBe('morale');
+    expect(presence.relatedPlayerId).toBe('77');
+  });
+
+  it('does NOT emit Veteran Presence for a different week', () => {
+    const items = generateLeaguePulseItems(makeMeta({ season: 2, week: 6 }), { players: [veteranPlayer] });
+    expect(items.find((i) => i.headline === 'Veteran Presence')).toBeUndefined();
+  });
+
+  it('does NOT emit Veteran Presence for a different season', () => {
+    const items = generateLeaguePulseItems(makeMeta({ season: 1, week: 7 }), { players: [veteranPlayer] });
+    expect(items.find((i) => i.headline === 'Veteran Presence')).toBeUndefined();
+  });
+
+  it('Veteran Presence has deterministic dedupeKey', () => {
+    const meta = makeMeta({ season: 2, week: 7 });
+    const items1 = generateLeaguePulseItems(meta, { players: [veteranPlayer] });
+    const items2 = generateLeaguePulseItems(meta, { players: [veteranPlayer] });
+    const k1 = items1.find((i) => i.headline === 'Veteran Presence')?.dedupeKey;
+    const k2 = items2.find((i) => i.headline === 'Veteran Presence')?.dedupeKey;
+    expect(k1).toBeDefined();
+    expect(k1).toBe(k2);
+  });
+
+  it('Veteran Presence item is deterministic regardless of call order', () => {
+    const meta = makeMeta({ season: 2, week: 7 });
+    const items = generateLeaguePulseItems(meta, { players: [veteranPlayer] });
+    const presence = items.find((i) => i.headline === 'Veteran Presence');
+    expect(presence?.importance).toBeDefined();
+    expect(presence?.type).toBe('general');
+  });
+});
+
+describe('LeaguePulse — Morale: News dedupeKey patterns', () => {
+  it('buildMoraleDropDedupeKey is stable and includes playerId/season/week', async () => {
+    const { buildMoraleDropDedupeKey } = await import('../news-engine.js');
+    const k1 = buildMoraleDropDedupeKey(42, 2, 7);
+    const k2 = buildMoraleDropDedupeKey(42, 2, 7);
+    expect(k1).toBe(k2);
+    expect(k1).toContain('42');
+    expect(k1).toContain('2');
+    expect(k1).toContain('7');
+  });
+
+  it('buildTradeRequestDeniedDedupeKey is stable', async () => {
+    const { buildTradeRequestDeniedDedupeKey } = await import('../news-engine.js');
+    const k1 = buildTradeRequestDeniedDedupeKey(55, 3, 10);
+    const k2 = buildTradeRequestDeniedDedupeKey(55, 3, 10);
+    expect(k1).toBe(k2);
+    expect(k1).toContain('trade-request-denied');
+  });
+
+  it('two different players produce different dedupeKeys', async () => {
+    const { buildMoraleDropDedupeKey } = await import('../news-engine.js');
+    expect(buildMoraleDropDedupeKey(1, 2, 7)).not.toBe(buildMoraleDropDedupeKey(2, 2, 7));
+  });
+});

--- a/src/core/__tests__/playerMoraleUI.test.js
+++ b/src/core/__tests__/playerMoraleUI.test.js
@@ -1,0 +1,105 @@
+/**
+ * playerMoraleUI.test.js
+ *
+ * Unit tests for morale-driven UI logic:
+ *  - PlayerProfile morale label / defaults
+ *  - Roster low-morale flag threshold
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  getPlayerMoraleSummary,
+  MORALE_DEFAULT,
+  MORALE_LOW_THRESHOLD,
+  MORALE_ALERT_THRESHOLD,
+} from '../mood/playerMoraleEngine.js';
+
+// ── PlayerProfile morale indicator logic ──────────────────────────────────────
+
+describe('PlayerProfile — morale indicator', () => {
+  it('renders correct label when morale is present', () => {
+    expect(getPlayerMoraleSummary({ morale: 90 }).label).toBe('Thriving');
+    expect(getPlayerMoraleSummary({ morale: 75 }).label).toBe('Settled');
+    expect(getPlayerMoraleSummary({ morale: 60 }).label).toBe('Neutral');
+    expect(getPlayerMoraleSummary({ morale: 45 }).label).toBe('Frustrated');
+    expect(getPlayerMoraleSummary({ morale: 20 }).label).toBe('Disgruntled');
+  });
+
+  it('defaults to Settled / score 70 when morale is absent (undefined)', () => {
+    const result = getPlayerMoraleSummary({ id: 1 });
+    expect(result.score).toBe(MORALE_DEFAULT);
+    expect(result.label).toBe('Settled');
+  });
+
+  it('defaults to Settled / score 70 when player is null-ish', () => {
+    const result = getPlayerMoraleSummary(null);
+    expect(result.score).toBe(MORALE_DEFAULT);
+    expect(result.label).toBe('Settled');
+  });
+
+  it('defaults to Settled / score 70 when morale is null', () => {
+    const result = getPlayerMoraleSummary({ morale: null });
+    expect(result.score).toBe(MORALE_DEFAULT);
+    expect(result.label).toBe('Settled');
+  });
+
+  it('provides topEvent reason for display when events exist', () => {
+    const events = [
+      {
+        type: 'CONTRACT_EXTENDED',
+        delta: 10,
+        season: 1,
+        week: 3,
+        reason: 'Contract extension signed',
+        source: 'contract',
+        dedupeKey: 'CE-1-1-3',
+      },
+    ];
+    const result = getPlayerMoraleSummary({ morale: 80, moraleEvents: events });
+    expect(result.topEvent?.reason).toBe('Contract extension signed');
+  });
+
+  it('topEvent is null when there are no events', () => {
+    expect(getPlayerMoraleSummary({ morale: 70 }).topEvent).toBeNull();
+  });
+
+  it('returns isLow=false for morale >= 40', () => {
+    expect(getPlayerMoraleSummary({ morale: 40 }).isLow).toBe(false);
+    expect(getPlayerMoraleSummary({ morale: 70 }).isLow).toBe(false);
+  });
+
+  it('returns isLow=true for morale < 40', () => {
+    expect(getPlayerMoraleSummary({ morale: 39 }).isLow).toBe(true);
+    expect(getPlayerMoraleSummary({ morale: 0 }).isLow).toBe(true);
+  });
+});
+
+// ── Roster low-morale flag threshold ─────────────────────────────────────────
+
+describe('Roster — low-morale flag', () => {
+  it('flag appears for morale < 40', () => {
+    const cases = [0, 10, 20, 30, 39];
+    for (const m of cases) {
+      expect(getPlayerMoraleSummary({ morale: m }).isLow).toBe(true);
+    }
+  });
+
+  it('flag is absent for morale >= 40', () => {
+    const cases = [40, 50, 60, 70, 80, 90, 100];
+    for (const m of cases) {
+      expect(getPlayerMoraleSummary({ morale: m }).isLow).toBe(false);
+    }
+  });
+
+  it('MORALE_LOW_THRESHOLD constant is 40', () => {
+    expect(MORALE_LOW_THRESHOLD).toBe(40);
+  });
+
+  it('MORALE_ALERT_THRESHOLD constant is 35', () => {
+    expect(MORALE_ALERT_THRESHOLD).toBe(35);
+  });
+
+  it('boundary: morale 39 → LOW flag, morale 40 → no flag', () => {
+    expect(getPlayerMoraleSummary({ morale: 39 }).isLow).toBe(true);
+    expect(getPlayerMoraleSummary({ morale: 40 }).isLow).toBe(false);
+  });
+});

--- a/src/core/leaguePulse.js
+++ b/src/core/leaguePulse.js
@@ -308,6 +308,60 @@ export function generateLeaguePulseItems(meta, data = {}) {
     }
   }
 
+  // 7. MORALE: Locker Room Watch (player crossed below 35)
+  // 8. MORALE: Veteran Presence (veteran leader bonus applied this week)
+  if (Array.isArray(players) && players.length > 0) {
+    const ALERT_THRESHOLD = 35;
+    for (const player of players) {
+      if (!player?.id || player?.teamId == null) continue;
+      const morale = Number(player.morale ?? 70);
+      const events = Array.isArray(player.moraleEvents) ? player.moraleEvents : [];
+
+      // 7. Locker Room Watch: player is disgruntled (below alert threshold)
+      if (morale < ALERT_THRESHOLD) {
+        const dedupeKey = `morale-alert-${player.id}-${season}-${week}`;
+        if (!items.some((i) => i.dedupeKey === dedupeKey)) {
+          items.push({
+            id:            dedupeKey,
+            season,
+            week,
+            type:          PULSE_TYPES.GENERAL,
+            headline:      'Locker Room Watch',
+            body:          `${player.name ?? 'A player'} (morale ${morale}) is showing signs of discontent.`,
+            importance:    PULSE_IMPORTANCE.MEDIUM,
+            relatedTeamId: String(player.teamId),
+            relatedPlayerId: String(player.id),
+            source:        'morale',
+            dedupeKey,
+          });
+        }
+      }
+
+      // 8. Veteran Presence: veteran leader bonus applied this exact week
+      const hasVeteranBonusThisWeek = events.some(
+        (e) => e.type === 'VETERAN_LEADER_BONUS' && e.season === season && e.week === week,
+      );
+      if (hasVeteranBonusThisWeek) {
+        const dedupeKey = `veteran-presence-${player.id}-${season}-${week}`;
+        if (!items.some((i) => i.dedupeKey === dedupeKey)) {
+          items.push({
+            id:            dedupeKey,
+            season,
+            week,
+            type:          PULSE_TYPES.GENERAL,
+            headline:      'Veteran Presence',
+            body:          `${player.name ?? 'A veteran'} is providing leadership and raising team morale.`,
+            importance:    PULSE_IMPORTANCE.LOW,
+            relatedTeamId: String(player.teamId),
+            relatedPlayerId: String(player.id),
+            source:        'morale',
+            dedupeKey,
+          });
+        }
+      }
+    }
+  }
+
   // Build the dedupe keys
   return items.map(item => ({
     ...item,

--- a/src/core/mood/__tests__/playerMoraleEngine.test.js
+++ b/src/core/mood/__tests__/playerMoraleEngine.test.js
@@ -1,0 +1,427 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MORALE_EVENTS,
+  MORALE_DELTAS,
+  MORALE_LABELS,
+  MORALE_DEFAULT,
+  MORALE_MIN,
+  MORALE_MAX,
+  MORALE_EVENTS_CAP,
+  MORALE_LOW_THRESHOLD,
+  MORALE_ALERT_THRESHOLD,
+  DEADLINE_FRUSTRATION_SEASON_CAP,
+  applyMoraleEvent,
+  getPlayerMoraleSummary,
+  applyWeeklyMoraleEffects,
+} from '../playerMoraleEngine.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makePlayer(overrides = {}) {
+  return {
+    id: 42,
+    name: 'Test Player',
+    age: 27,
+    ovr: 78,
+    morale: 70,
+    teamId: 1,
+    traits: [],
+    ...overrides,
+  };
+}
+
+function makeEvent(overrides = {}) {
+  return {
+    type:  MORALE_EVENTS.TRADED_TO_CONTENDER,
+    delta: MORALE_DELTAS[MORALE_EVENTS.TRADED_TO_CONTENDER],
+    season: 1,
+    week:   3,
+    reason: 'Traded to a contender',
+    source: 'trade',
+    dedupeKey: 'TRADED_TO_CONTENDER-42-1-3-2',
+    ...overrides,
+  };
+}
+
+// ── MORALE_DELTAS sanity ───────────────────────────────────────────────────────
+
+describe('MORALE_DELTAS', () => {
+  it('defines correct delta for each event type', () => {
+    expect(MORALE_DELTAS[MORALE_EVENTS.TRADED_TO_CONTENDER]).toBe(10);
+    expect(MORALE_DELTAS[MORALE_EVENTS.TRADED_TO_REBUILDER]).toBe(-6);
+    expect(MORALE_DELTAS[MORALE_EVENTS.CONTRACT_EXTENDED]).toBe(10);
+    expect(MORALE_DELTAS[MORALE_EVENTS.TRADE_REQUEST_DENIED]).toBe(-12);
+    expect(MORALE_DELTAS[MORALE_EVENTS.STARTER_ROLE_LOST]).toBe(-6);
+    expect(MORALE_DELTAS[MORALE_EVENTS.VETERAN_LEADER_BONUS]).toBe(3);
+    expect(MORALE_DELTAS[MORALE_EVENTS.DEADLINE_SELL_FRUSTRATION]).toBe(-3);
+  });
+
+  it('TRADED_TO_CONTENDER raises morale', () => {
+    expect(MORALE_DELTAS[MORALE_EVENTS.TRADED_TO_CONTENDER]).toBeGreaterThan(0);
+  });
+
+  it('TRADED_TO_REBUILDER lowers morale', () => {
+    expect(MORALE_DELTAS[MORALE_EVENTS.TRADED_TO_REBUILDER]).toBeLessThan(0);
+  });
+
+  it('CONTRACT_EXTENDED raises morale', () => {
+    expect(MORALE_DELTAS[MORALE_EVENTS.CONTRACT_EXTENDED]).toBeGreaterThan(0);
+  });
+
+  it('DEADLINE_SELL_FRUSTRATION lowers morale', () => {
+    expect(MORALE_DELTAS[MORALE_EVENTS.DEADLINE_SELL_FRUSTRATION]).toBeLessThan(0);
+  });
+});
+
+// ── applyMoraleEvent ──────────────────────────────────────────────────────────
+
+describe('applyMoraleEvent', () => {
+  it('returns same reference when player or event is null', () => {
+    const p = makePlayer();
+    expect(applyMoraleEvent(null, makeEvent())).toBeNull();
+    expect(applyMoraleEvent(p, null)).toBe(p);
+    expect(applyMoraleEvent(p, {})).toBe(p);
+  });
+
+  it('applies TRADED_TO_CONTENDER: raises morale by correct delta', () => {
+    const p = makePlayer({ morale: 70 });
+    const updated = applyMoraleEvent(p, makeEvent({
+      type: MORALE_EVENTS.TRADED_TO_CONTENDER,
+      delta: MORALE_DELTAS[MORALE_EVENTS.TRADED_TO_CONTENDER],
+      dedupeKey: 'TC-42-1-3-2',
+    }), { season: 1, week: 3 });
+    expect(updated.morale).toBe(70 + 10);
+    expect(updated).not.toBe(p);
+  });
+
+  it('applies TRADED_TO_REBUILDER: lowers morale by correct delta', () => {
+    const p = makePlayer({ morale: 70 });
+    const updated = applyMoraleEvent(p, makeEvent({
+      type: MORALE_EVENTS.TRADED_TO_REBUILDER,
+      delta: MORALE_DELTAS[MORALE_EVENTS.TRADED_TO_REBUILDER],
+      dedupeKey: 'TR-42-1-3-2',
+    }), { season: 1, week: 3 });
+    expect(updated.morale).toBe(70 - 6);
+  });
+
+  it('applies CONTRACT_EXTENDED: raises morale', () => {
+    const p = makePlayer({ morale: 70 });
+    const updated = applyMoraleEvent(p, makeEvent({
+      type: MORALE_EVENTS.CONTRACT_EXTENDED,
+      delta: MORALE_DELTAS[MORALE_EVENTS.CONTRACT_EXTENDED],
+      dedupeKey: 'CE-42-1-0',
+    }), {});
+    expect(updated.morale).toBe(80);
+  });
+
+  it('applies TRADE_REQUEST_DENIED: lowers morale significantly', () => {
+    const p = makePlayer({ morale: 70 });
+    const updated = applyMoraleEvent(p, makeEvent({
+      type: MORALE_EVENTS.TRADE_REQUEST_DENIED,
+      delta: MORALE_DELTAS[MORALE_EVENTS.TRADE_REQUEST_DENIED],
+      dedupeKey: 'TRD-42-1-3',
+    }), { season: 1, week: 3 });
+    expect(updated.morale).toBe(70 - 12);
+  });
+
+  it('applies VETERAN_LEADER_BONUS: raises morale by 3', () => {
+    const p = makePlayer({ morale: 70 });
+    const updated = applyMoraleEvent(p, makeEvent({
+      type: MORALE_EVENTS.VETERAN_LEADER_BONUS,
+      delta: MORALE_DELTAS[MORALE_EVENTS.VETERAN_LEADER_BONUS],
+      dedupeKey: 'VLB-42-1-3',
+    }), {});
+    expect(updated.morale).toBe(73);
+  });
+
+  it('clamps morale to [0, 100] — upper bound', () => {
+    const p = makePlayer({ morale: 95 });
+    const updated = applyMoraleEvent(p, makeEvent({
+      type: MORALE_EVENTS.TRADED_TO_CONTENDER,
+      delta: 10,
+      dedupeKey: 'clamped-hi-1',
+    }), {});
+    expect(updated.morale).toBe(MORALE_MAX);
+    expect(updated.morale).toBeLessThanOrEqual(100);
+  });
+
+  it('clamps morale to [0, 100] — lower bound', () => {
+    const p = makePlayer({ morale: 5 });
+    const updated = applyMoraleEvent(p, makeEvent({
+      type: MORALE_EVENTS.TRADE_REQUEST_DENIED,
+      delta: -12,
+      dedupeKey: 'clamped-lo-1',
+    }), {});
+    expect(updated.morale).toBe(MORALE_MIN);
+    expect(updated.morale).toBeGreaterThanOrEqual(0);
+  });
+
+  it('defaults morale to MORALE_DEFAULT (70) when absent', () => {
+    const p = { id: 1, name: 'No Morale' };
+    const updated = applyMoraleEvent(p, makeEvent({
+      type: MORALE_EVENTS.VETERAN_LEADER_BONUS,
+      delta: 3,
+      dedupeKey: 'default-morale-1',
+    }), {});
+    expect(updated.morale).toBe(MORALE_DEFAULT + 3);
+  });
+
+  it('deduplicate: same dedupeKey never applies twice', () => {
+    const p = makePlayer({ morale: 70 });
+    const event = makeEvent({ dedupeKey: 'UNIQUE-KEY-1' });
+    const ctx = { season: 1, week: 1 };
+    const first  = applyMoraleEvent(p, event, ctx);
+    const second = applyMoraleEvent(first, event, ctx);
+    expect(first.morale).toBe(80);
+    expect(second.morale).toBe(80);        // unchanged
+    expect(second).toBe(first);            // same reference returned
+    expect(second.moraleEvents).toHaveLength(1);
+  });
+
+  it('enforces rolling cap of MORALE_EVENTS_CAP (10) entries', () => {
+    let p = makePlayer({ morale: 70 });
+    for (let i = 0; i < 15; i++) {
+      p = applyMoraleEvent(p, makeEvent({
+        type: MORALE_EVENTS.VETERAN_LEADER_BONUS,
+        delta: 1,
+        dedupeKey: `vl-${i}`,
+      }), {});
+    }
+    expect(p.moraleEvents).toHaveLength(MORALE_EVENTS_CAP);
+  });
+
+  it('event entries include all required fields', () => {
+    const p = makePlayer({ morale: 70 });
+    const updated = applyMoraleEvent(p, makeEvent({
+      type: MORALE_EVENTS.CONTRACT_EXTENDED,
+      delta: 10,
+      season: 2,
+      week: 5,
+      reason: 'Deal done',
+      source: 'contract',
+      dedupeKey: 'CE-full-fields',
+    }), { season: 2, week: 5 });
+    const entry = updated.moraleEvents[0];
+    expect(entry).toMatchObject({
+      type:     MORALE_EVENTS.CONTRACT_EXTENDED,
+      delta:    10,
+      season:   2,
+      week:     5,
+      reason:   'Deal done',
+      source:   'contract',
+      dedupeKey: 'CE-full-fields',
+    });
+  });
+
+  it('DEADLINE_SELL_FRUSTRATION: caps total per season at DEADLINE_FRUSTRATION_SEASON_CAP (12)', () => {
+    let p = makePlayer({ morale: 70 });
+    // Apply 5 events of -3 each = 15 total delta, but cap is 12
+    for (let week = 7; week <= 11; week++) {
+      p = applyMoraleEvent(p, {
+        type:  MORALE_EVENTS.DEADLINE_SELL_FRUSTRATION,
+        delta: MORALE_DELTAS[MORALE_EVENTS.DEADLINE_SELL_FRUSTRATION],
+        season: 1,
+        week,
+        reason: 'Seller team',
+        source: 'weekly_advance',
+        dedupeKey: `DSF-42-1-${week}`,
+      }, { season: 1, week });
+    }
+    // Accumulated applied delta must not exceed -12
+    const totalDelta = p.moraleEvents
+      .filter((e) => e.type === MORALE_EVENTS.DEADLINE_SELL_FRUSTRATION)
+      .reduce((sum, e) => sum + e.delta, 0);
+    expect(totalDelta).toBeGreaterThanOrEqual(-DEADLINE_FRUSTRATION_SEASON_CAP);
+    expect(p.morale).toBeGreaterThanOrEqual(70 - DEADLINE_FRUSTRATION_SEASON_CAP);
+  });
+
+  it('generates a stable dedupeKey from context when none is provided', () => {
+    const p = makePlayer({ morale: 70 });
+    const event = { type: MORALE_EVENTS.VETERAN_LEADER_BONUS, delta: 3, source: 'weekly_advance' };
+    const ctx = { season: 2, week: 4 };
+    const updated = applyMoraleEvent(p, event, ctx);
+    const entry = updated.moraleEvents[0];
+    expect(entry.dedupeKey).toBe(`${MORALE_EVENTS.VETERAN_LEADER_BONUS}-weekly_advance-2-4`);
+  });
+});
+
+// ── getPlayerMoraleSummary ────────────────────────────────────────────────────
+
+describe('getPlayerMoraleSummary', () => {
+  it('returns Thriving label at 85+', () => {
+    expect(getPlayerMoraleSummary({ morale: 85 }).label).toBe('Thriving');
+    expect(getPlayerMoraleSummary({ morale: 100 }).label).toBe('Thriving');
+  });
+
+  it('returns Settled label at 70–84', () => {
+    expect(getPlayerMoraleSummary({ morale: 70 }).label).toBe('Settled');
+    expect(getPlayerMoraleSummary({ morale: 84 }).label).toBe('Settled');
+  });
+
+  it('returns Neutral label at 55–69', () => {
+    expect(getPlayerMoraleSummary({ morale: 55 }).label).toBe('Neutral');
+    expect(getPlayerMoraleSummary({ morale: 69 }).label).toBe('Neutral');
+  });
+
+  it('returns Frustrated label at 40–54', () => {
+    expect(getPlayerMoraleSummary({ morale: 40 }).label).toBe('Frustrated');
+    expect(getPlayerMoraleSummary({ morale: 54 }).label).toBe('Frustrated');
+  });
+
+  it('returns Disgruntled label below 40', () => {
+    expect(getPlayerMoraleSummary({ morale: 39 }).label).toBe('Disgruntled');
+    expect(getPlayerMoraleSummary({ morale: 0 }).label).toBe('Disgruntled');
+  });
+
+  it('defaults to Settled/70 when morale is absent', () => {
+    const result = getPlayerMoraleSummary({});
+    expect(result.score).toBe(MORALE_DEFAULT);
+    expect(result.label).toBe('Settled');
+  });
+
+  it('returns null topEvent when no events', () => {
+    expect(getPlayerMoraleSummary({ morale: 70 }).topEvent).toBeNull();
+  });
+
+  it('returns the most recent event as topEvent', () => {
+    const events = [
+      { type: 'OLDER', dedupeKey: 'a' },
+      { type: MORALE_EVENTS.CONTRACT_EXTENDED, dedupeKey: 'b' },
+    ];
+    const result = getPlayerMoraleSummary({ morale: 80, moraleEvents: events });
+    expect(result.topEvent.type).toBe(MORALE_EVENTS.CONTRACT_EXTENDED);
+  });
+
+  it('flags isLow correctly at boundary (39 vs 40)', () => {
+    expect(getPlayerMoraleSummary({ morale: 39 }).isLow).toBe(true);
+    expect(getPlayerMoraleSummary({ morale: 40 }).isLow).toBe(false);
+  });
+
+  it('flags isAlert correctly below MORALE_ALERT_THRESHOLD (35)', () => {
+    expect(getPlayerMoraleSummary({ morale: 34 }).isAlert).toBe(true);
+    expect(getPlayerMoraleSummary({ morale: 35 }).isAlert).toBe(false);
+  });
+});
+
+// ── applyWeeklyMoraleEffects ──────────────────────────────────────────────────
+
+describe('applyWeeklyMoraleEffects', () => {
+  const ctx = {
+    season: 1,
+    week: 7,
+    deadlineWeek: 9,
+    phase: 'regular',
+    teamPostureMap: { '1': 'contender', '2': 'seller', '3': 'playoff_hunt', '4': 'middle' },
+  };
+
+  it('returns same array reference for non-regular phase', () => {
+    const players = [makePlayer()];
+    const result = applyWeeklyMoraleEffects(players, { ...ctx, phase: 'playoffs' });
+    expect(result).toBe(players);
+  });
+
+  it('returns same array when input is not an array', () => {
+    expect(applyWeeklyMoraleEffects(null, ctx)).toBeNull();
+  });
+
+  it('applies VETERAN_LEADER_BONUS to veteran leader on contender team', () => {
+    const player = makePlayer({ id: 1, age: 32, teamId: 1, traits: ['mentor'], morale: 70 });
+    const [updated] = applyWeeklyMoraleEffects([player], ctx);
+    expect(updated.morale).toBe(73);
+    expect(updated.moraleEvents[0].type).toBe(MORALE_EVENTS.VETERAN_LEADER_BONUS);
+  });
+
+  it('applies VETERAN_LEADER_BONUS to veteran with loyal trait on playoff_hunt team', () => {
+    const player = makePlayer({ id: 2, age: 31, teamId: 3, traits: ['loyal'], morale: 70 });
+    const [updated] = applyWeeklyMoraleEffects([player], ctx);
+    expect(updated.morale).toBe(73);
+  });
+
+  it('applies VETERAN_LEADER_BONUS via leadership score >= 65', () => {
+    const player = makePlayer({
+      id: 3, age: 30, teamId: 1, traits: [],
+      personalityProfile: { leadership: 70 },
+      morale: 70,
+    });
+    const [updated] = applyWeeklyMoraleEffects([player], ctx);
+    expect(updated.morale).toBe(73);
+  });
+
+  it('does NOT apply VETERAN_LEADER_BONUS on seller team', () => {
+    const player = makePlayer({ id: 4, age: 32, teamId: 2, traits: ['mentor'], morale: 70 });
+    // Only deadline frustration may apply, not veteran bonus
+    const [updated] = applyWeeklyMoraleEffects([player], ctx);
+    expect(updated.moraleEvents.filter((e) => e.type === MORALE_EVENTS.VETERAN_LEADER_BONUS)).toHaveLength(0);
+  });
+
+  it('does NOT apply VETERAN_LEADER_BONUS for player under 30', () => {
+    const player = makePlayer({ id: 5, age: 29, teamId: 1, traits: ['mentor'], morale: 70 });
+    const [updated] = applyWeeklyMoraleEffects([player], ctx);
+    expect((updated.moraleEvents ?? []).filter((e) => e.type === MORALE_EVENTS.VETERAN_LEADER_BONUS)).toHaveLength(0);
+  });
+
+  it('applies DEADLINE_SELL_FRUSTRATION to seller team player near deadline', () => {
+    // week 7, deadline 9 → weeksToDeadline 2 → in window
+    const player = makePlayer({ id: 10, age: 28, teamId: 2, morale: 70 });
+    const [updated] = applyWeeklyMoraleEffects([player], ctx);
+    expect(updated.morale).toBe(67);
+    expect(updated.moraleEvents[0].type).toBe(MORALE_EVENTS.DEADLINE_SELL_FRUSTRATION);
+  });
+
+  it('does NOT apply DEADLINE_SELL_FRUSTRATION outside the deadline window', () => {
+    // week 4, deadline 9 → weeksToDeadline 5 → outside window
+    const player = makePlayer({ id: 11, teamId: 2, morale: 70 });
+    const [updated] = applyWeeklyMoraleEffects([player], { ...ctx, week: 4 });
+    // No change expected — same reference returned
+    expect(updated).toBe(player);
+    expect((updated.moraleEvents ?? [])).toHaveLength(0);
+  });
+
+  it('does NOT apply DEADLINE_SELL_FRUSTRATION to middle-of-pack team', () => {
+    const player = makePlayer({ id: 12, teamId: 4, morale: 70 });
+    const [updated] = applyWeeklyMoraleEffects([player], ctx);
+    expect((updated.moraleEvents ?? []).filter((e) => e.type === MORALE_EVENTS.DEADLINE_SELL_FRUSTRATION)).toHaveLength(0);
+  });
+
+  it('weekly advance does not double-apply events (same dedupeKey)', () => {
+    const player = makePlayer({ id: 20, age: 32, teamId: 1, traits: ['mentor'], morale: 70 });
+    const [first] = applyWeeklyMoraleEffects([player], ctx);
+    const [second] = applyWeeklyMoraleEffects([first], ctx);
+    expect(second.morale).toBe(first.morale);
+    expect(second.moraleEvents).toHaveLength(first.moraleEvents.length);
+  });
+
+  it('DEADLINE_SELL_FRUSTRATION weekly cap: stops accumulating after DEADLINE_FRUSTRATION_SEASON_CAP', () => {
+    let player = makePlayer({ id: 30, teamId: 2, morale: 70 });
+    // Apply 5 weeks of frustration (5 × -3 = -15), cap is -12
+    for (let w = 7; w <= 11; w++) {
+      [player] = applyWeeklyMoraleEffects([player], { ...ctx, week: w });
+    }
+    const totalFrustration = player.moraleEvents
+      .filter((e) => e.type === MORALE_EVENTS.DEADLINE_SELL_FRUSTRATION)
+      .reduce((sum, e) => sum + e.delta, 0);
+    expect(totalFrustration).toBeGreaterThanOrEqual(-DEADLINE_FRUSTRATION_SEASON_CAP);
+    expect(player.morale).toBeGreaterThanOrEqual(70 - DEADLINE_FRUSTRATION_SEASON_CAP);
+  });
+
+  it('returns unchanged reference for players with no matching conditions', () => {
+    // Young player on middle team, week 4 (no deadline window)
+    const player = makePlayer({ id: 99, age: 22, teamId: 4, morale: 70 });
+    const [result] = applyWeeklyMoraleEffects([player], { ...ctx, week: 4 });
+    expect(result).toBe(player);
+  });
+
+  it('TRADE_REQUEST_DENIED dedupeKey follows stable pattern', () => {
+    const dedupeKey = `${MORALE_EVENTS.TRADE_REQUEST_DENIED}-42-1-5`;
+    const p = makePlayer({ morale: 70 });
+    const updated = applyMoraleEvent(p, {
+      type: MORALE_EVENTS.TRADE_REQUEST_DENIED,
+      delta: MORALE_DELTAS[MORALE_EVENTS.TRADE_REQUEST_DENIED],
+      season: 1,
+      week: 5,
+      source: '42',
+      dedupeKey,
+    }, { season: 1, week: 5 });
+    expect(updated.moraleEvents[0].dedupeKey).toBe(dedupeKey);
+  });
+});

--- a/src/core/mood/playerMoraleEngine.js
+++ b/src/core/mood/playerMoraleEngine.js
@@ -1,0 +1,253 @@
+/**
+ * playerMoraleEngine.js — Player Morale Causality V1
+ *
+ * Pure, deterministic morale-causality module.
+ * Extends the existing mood system (playerMood.js) with causal events.
+ *
+ * Design constraints:
+ *  - No I/O, no cache access, no mutations.
+ *  - No Math.random — all output is deterministic for same inputs.
+ *  - Morale score bounded [0, 100]. Default: 70.
+ *  - moraleEvents: rolling array, capped at MORALE_EVENTS_CAP entries.
+ *  - Deduplication via dedupeKey: same key never applies twice.
+ *  - No simulation performance impact.
+ *  - V1: morale does NOT feed back into game simulation outcomes.
+ */
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const MORALE_MIN = 0;
+export const MORALE_MAX = 100;
+export const MORALE_DEFAULT = 70;
+export const MORALE_EVENTS_CAP = 10;
+
+// Per-season cap on total DEADLINE_SELL_FRUSTRATION delta magnitude.
+export const DEADLINE_FRUSTRATION_SEASON_CAP = 12;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function clampMorale(v) {
+  return Math.max(MORALE_MIN, Math.min(MORALE_MAX, v));
+}
+
+function safeNum(v, fallback) {
+  if (v == null) return fallback;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+// ── Event type constants ───────────────────────────────────────────────────────
+
+export const MORALE_EVENTS = Object.freeze({
+  TRADED_TO_CONTENDER:       'TRADED_TO_CONTENDER',
+  TRADED_TO_REBUILDER:       'TRADED_TO_REBUILDER',
+  CONTRACT_EXTENDED:         'CONTRACT_EXTENDED',
+  TRADE_REQUEST_DENIED:      'TRADE_REQUEST_DENIED',
+  STARTER_ROLE_LOST:         'STARTER_ROLE_LOST',
+  VETERAN_LEADER_BONUS:      'VETERAN_LEADER_BONUS',
+  DEADLINE_SELL_FRUSTRATION: 'DEADLINE_SELL_FRUSTRATION',
+});
+
+// ── Delta constants ────────────────────────────────────────────────────────────
+// Centralised so tests can import and verify exact values.
+
+export const MORALE_DELTAS = Object.freeze({
+  [MORALE_EVENTS.TRADED_TO_CONTENDER]:        10,
+  [MORALE_EVENTS.TRADED_TO_REBUILDER]:        -6,
+  [MORALE_EVENTS.CONTRACT_EXTENDED]:          10,
+  [MORALE_EVENTS.TRADE_REQUEST_DENIED]:       -12,
+  [MORALE_EVENTS.STARTER_ROLE_LOST]:          -6,
+  [MORALE_EVENTS.VETERAN_LEADER_BONUS]:        3,
+  [MORALE_EVENTS.DEADLINE_SELL_FRUSTRATION]:  -3,
+});
+
+// ── Morale label thresholds ────────────────────────────────────────────────────
+
+export const MORALE_LABELS = [
+  { min: 85, label: 'Thriving' },
+  { min: 70, label: 'Settled' },
+  { min: 55, label: 'Neutral' },
+  { min: 40, label: 'Frustrated' },
+  { min:  0, label: 'Disgruntled' },
+];
+
+// Threshold below which a player is flagged for roster-watch items.
+export const MORALE_LOW_THRESHOLD = 40;
+
+// Threshold that triggers "Locker Room Watch" pulse/news events.
+export const MORALE_ALERT_THRESHOLD = 35;
+
+// ── Core: applyMoraleEvent ─────────────────────────────────────────────────────
+
+/**
+ * Apply a morale event to a player object.
+ * Returns a new player object (pure — no mutation).
+ *
+ * @param {object} player   – current player data ({ id, morale?, moraleEvents? })
+ * @param {object} event    – { type, delta?, season?, week?, reason?, source?, dedupeKey? }
+ * @param {object} context  – { season, week } (fallback values for event fields)
+ * @returns {object}        – updated player object, or same reference if no change
+ */
+export function applyMoraleEvent(player, event, context = {}) {
+  if (!player || !event?.type) return player;
+
+  const currentMorale = safeNum(player.morale, MORALE_DEFAULT);
+  const existingEvents = Array.isArray(player.moraleEvents) ? player.moraleEvents : [];
+
+  // Stable dedupeKey: same event never applied twice per player
+  const dedupeKey = event.dedupeKey
+    ?? `${event.type}-${event.source ?? 'X'}-${context.season ?? 0}-${context.week ?? 0}`;
+
+  if (existingEvents.some((e) => e.dedupeKey === dedupeKey)) {
+    return player;
+  }
+
+  // DEADLINE_SELL_FRUSTRATION is additionally capped per season
+  if (event.type === MORALE_EVENTS.DEADLINE_SELL_FRUSTRATION) {
+    const eventSeason = event.season ?? context.season ?? 0;
+    const seasonAccumulated = existingEvents
+      .filter((e) => e.type === MORALE_EVENTS.DEADLINE_SELL_FRUSTRATION && e.season === eventSeason)
+      .reduce((sum, e) => sum + Math.abs(safeNum(e.delta, 0)), 0);
+    if (seasonAccumulated >= DEADLINE_FRUSTRATION_SEASON_CAP) {
+      return player;
+    }
+  }
+
+  const delta = safeNum(event.delta ?? MORALE_DELTAS[event.type] ?? 0, 0);
+  const newMorale = clampMorale(currentMorale + delta);
+
+  const entry = {
+    type:      String(event.type),
+    delta,
+    season:    event.season ?? context.season ?? 0,
+    week:      event.week   ?? context.week   ?? 0,
+    reason:    event.reason ?? '',
+    source:    event.source ?? '',
+    dedupeKey,
+  };
+
+  // Rolling cap: keep only the most recent MORALE_EVENTS_CAP entries
+  const nextEvents = [...existingEvents, entry].slice(-MORALE_EVENTS_CAP);
+
+  return {
+    ...player,
+    morale:       newMorale,
+    moraleEvents: nextEvents,
+  };
+}
+
+// ── getPlayerMoraleSummary ─────────────────────────────────────────────────────
+
+/**
+ * Return a human-readable morale summary for display.
+ *
+ * @param {object} player
+ * @returns {{ score: number, label: string, topEvent: object|null, isLow: boolean, isAlert: boolean }}
+ */
+export function getPlayerMoraleSummary(player) {
+  const score = safeNum(player?.morale, MORALE_DEFAULT);
+  const entry = MORALE_LABELS.find((l) => score >= l.min) ?? MORALE_LABELS[MORALE_LABELS.length - 1];
+  const events = Array.isArray(player?.moraleEvents) ? player.moraleEvents : [];
+  const topEvent = events.length > 0 ? events[events.length - 1] : null;
+
+  return {
+    score,
+    label:    entry.label,
+    topEvent,
+    isLow:    score < MORALE_LOW_THRESHOLD,
+    isAlert:  score < MORALE_ALERT_THRESHOLD,
+  };
+}
+
+// ── applyWeeklyMoraleEffects ───────────────────────────────────────────────────
+
+/**
+ * Apply recurring weekly morale effects to all players.
+ *
+ * Effects applied in V1:
+ *  - VETERAN_LEADER_BONUS: veterans (age ≥ 30) with mentor/loyal trait or high
+ *    leadership, on contender or playoff-hunt teams — once per week per player.
+ *  - DEADLINE_SELL_FRUSTRATION: players on seller/rebuild teams within 3 weeks of
+ *    the trade deadline — once per week per player, capped at
+ *    DEADLINE_FRUSTRATION_SEASON_CAP total per season.
+ *
+ * NOTE: DEADLINE_SELL_FRUSTRATION is driven by current posture + week because
+ * buildDeadlineMemoryEvent() events from #1586 are not yet persisted through
+ * league-memory.js. When deadline memory persistence is added, switch to reading
+ * from that store instead.
+ * TODO: wire to league-memory deadline events when persistence is added.
+ *
+ * @param {object[]} players       – array of player data objects
+ * @param {object}   context       – {
+ *   season: number,
+ *   week: number,
+ *   deadlineWeek: number,
+ *   phase: string,
+ *   teamPostureMap: Record<string, string>  – DEADLINE_POSTURE value per teamId
+ * }
+ * @returns {object[]}             – updated player array (new refs only for changed players)
+ */
+export function applyWeeklyMoraleEffects(players, context = {}) {
+  if (!Array.isArray(players)) return players;
+
+  const {
+    season       = 0,
+    week         = 0,
+    deadlineWeek = 9,
+    phase        = 'regular',
+    teamPostureMap = {},
+  } = context;
+
+  if (phase !== 'regular') return players;
+
+  const weeksToDeadline = deadlineWeek - week;
+  const isDeadlineWindow = weeksToDeadline >= 0 && weeksToDeadline <= 3;
+
+  return players.map((player) => {
+    if (!player?.id) return player;
+
+    const posture = teamPostureMap[String(player.teamId)] ?? null;
+    const isContenderOrHunt = posture === 'contender' || posture === 'playoff_hunt';
+    const isSellerOrRebuild = posture === 'seller'    || posture === 'rebuild';
+
+    const age    = safeNum(player.age, 26);
+    const traits = Array.isArray(player.traits)
+      ? player.traits.map((t) => String(t).toLowerCase())
+      : [];
+    const leadership = safeNum(player?.personalityProfile?.leadership, 0);
+
+    const isVeteranLeader = age >= 30 && (
+      traits.includes('mentor') ||
+      traits.includes('loyal') ||
+      leadership >= 65
+    );
+
+    let updated = player;
+
+    if (isVeteranLeader && isContenderOrHunt) {
+      updated = applyMoraleEvent(updated, {
+        type:      MORALE_EVENTS.VETERAN_LEADER_BONUS,
+        delta:     MORALE_DELTAS[MORALE_EVENTS.VETERAN_LEADER_BONUS],
+        season,
+        week,
+        reason:    'Veteran leader on a winning team',
+        source:    'weekly_advance',
+        dedupeKey: `${MORALE_EVENTS.VETERAN_LEADER_BONUS}-${player.id}-${season}-${week}`,
+      }, { season, week });
+    }
+
+    if (isSellerOrRebuild && isDeadlineWindow) {
+      updated = applyMoraleEvent(updated, {
+        type:      MORALE_EVENTS.DEADLINE_SELL_FRUSTRATION,
+        delta:     MORALE_DELTAS[MORALE_EVENTS.DEADLINE_SELL_FRUSTRATION],
+        season,
+        week,
+        reason:    'On a seller team near the trade deadline',
+        source:    'weekly_advance',
+        dedupeKey: `${MORALE_EVENTS.DEADLINE_SELL_FRUSTRATION}-${player.id}-${season}-${week}`,
+      }, { season, week });
+    }
+
+    return updated;
+  });
+}

--- a/src/core/news-engine.js
+++ b/src/core/news-engine.js
@@ -262,6 +262,16 @@ export const createNewsItem = (type, data, week, season) => {
             body: () => 'A deal was reached between the two franchises.',
             priority: 'low',
         },
+        morale_drop: {
+            headline: (d) => `Locker Room Watch: ${d?.playerName ?? 'Player'} disgruntled`,
+            body: (d) => `${d?.playerName ?? 'A player'} (${d?.teamAbbr ?? 'FA'}) morale has collapsed to ${d?.morale ?? 0}. A volatile situation worth monitoring.`,
+            priority: 'medium',
+        },
+        trade_request_denied: {
+            headline: (d) => `${d?.playerName ?? 'Player'} trade request denied`,
+            body: (d) => `${d?.teamName ?? 'The team'} refused to deal ${d?.playerName ?? 'the player'}, leaving them frustrated.`,
+            priority: 'medium',
+        },
     };
     const template = templates[type];
     if (!template) return null;
@@ -285,5 +295,18 @@ export const addNewsItem = (leagueState, item) => {
         newsItems: [item, ...news].slice(0, 200),
     };
 };
+
+/**
+ * Build a stable dedupeKey for a morale-drop news item.
+ * Deterministic: same playerId + season + week → same key.
+ */
+export const buildMoraleDropDedupeKey = (playerId, season, week) =>
+    `morale-drop-${playerId}-${season}-${week}`;
+
+/**
+ * Build a stable dedupeKey for a trade-request-denied news item.
+ */
+export const buildTradeRequestDeniedDedupeKey = (playerId, season, week) =>
+    `trade-request-denied-${playerId}-${season}-${week}`;
 
 export default NewsEngine;

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -37,6 +37,7 @@ import { buildPlayerDevelopmentModel } from "../../core/playerDevelopmentModel.j
 import { buildProspectScoutingReport } from "../../core/scoutingModel.js";
 import { buildPlayerCareerTimeline } from "../utils/playerCareerTimeline.js";
 import { buildPlayerAdvancedStatsView } from "../utils/playerAdvancedStatsViewModel.js";
+import { getPlayerMoraleSummary } from "../../core/mood/playerMoraleEngine.js";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
@@ -1316,6 +1317,45 @@ export default function PlayerProfile({
                     { label: ageCurve.label, tone: ageCurve.tone },
                   ]}
                 />
+
+                {/* ── Morale Indicator ── */}
+                {playerView && (() => {
+                  const moraleSummary = getPlayerMoraleSummary(playerView);
+                  const moraleColor = moraleSummary.score >= 85 ? 'var(--success)'
+                                    : moraleSummary.score >= 70 ? 'var(--text-muted)'
+                                    : moraleSummary.score >= 55 ? 'var(--text-subtle)'
+                                    : moraleSummary.score >= 40 ? 'var(--warning)'
+                                    : 'var(--danger)';
+                  return (
+                    <div
+                      data-testid="player-profile-morale"
+                      style={{
+                        marginTop: 'var(--space-2)',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 8,
+                        flexWrap: 'wrap',
+                      }}
+                    >
+                      <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-subtle)', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '.07em' }}>Morale</span>
+                      <span
+                        data-testid="player-profile-morale-label"
+                        style={{ fontSize: 'var(--text-xs)', fontWeight: 700, color: moraleColor }}
+                      >
+                        {moraleSummary.label}
+                      </span>
+                      <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-subtle)' }}>({moraleSummary.score})</span>
+                      {moraleSummary.topEvent?.reason && (
+                        <span
+                          data-testid="player-profile-morale-reason"
+                          style={{ fontSize: 'var(--text-xs)', color: 'var(--text-subtle)', fontStyle: 'italic' }}
+                        >
+                          · {moraleSummary.topEvent.reason}
+                        </span>
+                      )}
+                    </div>
+                  );
+                })()}
 
                 {!isProspect && playerView && (
                   <div

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -1460,6 +1460,24 @@ function RosterTable({
                         >
                           {morale}
                         </span>
+                        {morale < 40 && (
+                          <span
+                            data-testid="roster-low-morale-flag"
+                            title="Low morale — player is disgruntled"
+                            style={{
+                              display: 'inline-block',
+                              padding: '1px 4px',
+                              borderRadius: 'var(--radius-pill)',
+                              background: '#FF453A',
+                              color: '#fff',
+                              fontSize: 9,
+                              fontWeight: 800,
+                              letterSpacing: '0.4px',
+                            }}
+                          >
+                            LOW
+                          </span>
+                        )}
                         {moraleContext?.reasons?.[0] && (
                           <span style={{ fontSize: 9, color: "var(--text-subtle)", maxWidth: 120, lineHeight: 1.2, textAlign: "center" }}>
                             {moraleContext.reasons[0]}

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -100,6 +100,13 @@ import {
 } from '../core/contracts/realisticContracts.js';
 import { generateSlottedRookieContract } from '../core/contracts/rookieWageScale.js';
 import { summarizePlayerMood } from '../core/mood/playerMood.js';
+import {
+  MORALE_EVENTS,
+  MORALE_DELTAS,
+  applyMoraleEvent,
+  applyWeeklyMoraleEffects,
+} from '../core/mood/playerMoraleEngine.js';
+import { classifyDeadlinePosture, DEADLINE_POSTURE } from '../core/trades/tradeDeadlinePressure.js';
 import { getFreeAgencyDecisionState } from '../core/freeAgency/decisionState.js';
 import {
   PENDING_OFFER_STATUS,
@@ -3287,6 +3294,79 @@ async function handleAdvanceWeek(payload, id) {
     } catch (cultureErr) {
       // Culture update must never crash the week advance
       console.warn('[Worker] Team culture update error (non-fatal):', cultureErr?.message);
+    }
+  }
+
+  // ── Player Morale Causality: weekly effects ────────────────────────────────
+  // Applies VETERAN_LEADER_BONUS and DEADLINE_SELL_FRUSTRATION once per week per player.
+  // NOTE: DEADLINE_SELL_FRUSTRATION is driven by current posture/week because
+  // buildDeadlineMemoryEvent() events are not yet persisted through league-memory.js.
+  // TODO: switch to league-memory deadline events once persistence is wired.
+  if (meta.phase === 'regular') {
+    try {
+      const moraleAllPlayers = cache.getAllPlayers();
+      const moraleAllTeams   = cache.getAllTeams();
+      const moraleDeadline   = getTradeDeadlineSnapshot(cache.getMeta());
+      const moraleSeasonId   = meta.currentSeasonId ?? meta.season ?? 0;
+
+      // Build a posture map for every team so applyWeeklyMoraleEffects is pure
+      const teamPostureMap = {};
+      for (const team of moraleAllTeams) {
+        teamPostureMap[String(team.id)] = classifyDeadlinePosture(
+          {
+            wins:   team.wins   ?? 0,
+            losses: team.losses ?? 0,
+            ties:   team.ties   ?? 0,
+            roster: cache.getPlayersByTeam(team.id),
+          },
+          { numTeams: moraleAllTeams.length },
+        );
+      }
+
+      const moraleUpdatedPlayers = applyWeeklyMoraleEffects(moraleAllPlayers, {
+        season:        moraleSeasonId,
+        week,
+        deadlineWeek:  moraleDeadline.deadlineWeek ?? 9,
+        phase:         meta.phase,
+        teamPostureMap,
+      });
+
+      // Persist only players whose morale or events changed
+      for (let i = 0; i < moraleUpdatedPlayers.length; i++) {
+        const orig    = moraleAllPlayers[i];
+        const updated = moraleUpdatedPlayers[i];
+        if (updated !== orig) {
+          cache.updatePlayer(updated.id, { morale: updated.morale, moraleEvents: updated.moraleEvents });
+        }
+      }
+
+      // Emit LeaguePulse items and news for notable morale threshold crossings
+      const currentMoraleNewsItems = cache.getMeta().newsItems;
+      for (let i = 0; i < moraleUpdatedPlayers.length; i++) {
+        const orig    = moraleAllPlayers[i];
+        const updated = moraleUpdatedPlayers[i];
+        if (updated === orig) continue;
+        const prevMorale = Number(orig.morale ?? 70);
+        const newMorale  = Number(updated.morale ?? 70);
+        // News: significant morale drop crossing below 35
+        if (prevMorale >= 35 && newMorale < 35) {
+          const teamForMorale = cache.getTeam(updated.teamId);
+          const moraleDropNews = {
+            id:       `morale-drop-${updated.id}-${moraleSeasonId}-${week}`,
+            headline: `Locker Room Watch: ${updated.name ?? 'Player'} disgruntled`,
+            body:     `${updated.name ?? 'A player'} (${teamForMorale?.abbr ?? 'FA'}) morale has dropped to ${newMorale} — a situation worth monitoring.`,
+            week,
+            season:   moraleSeasonId,
+            type:     'MORALE',
+            teamId:   updated.teamId ?? null,
+            priority: 'medium',
+            dedupeKey: `morale-drop-${updated.id}-${moraleSeasonId}-${week}`,
+          };
+          cache.setMeta(addNewsItem(cache.getMeta(), moraleDropNews));
+        }
+      }
+    } catch (moraleWeeklyErr) {
+      console.warn('[Worker] Player morale weekly effects error (non-fatal):', moraleWeeklyErr?.message);
     }
   }
 
@@ -7280,6 +7360,30 @@ async function handleExtendContract({ playerId, teamId, contract }, id) {
       details: { playerId, contract, reasons },
     });
     await NewsEngine.logTransaction('EXTEND', { teamId: resolvedTeamId, playerId, contract });
+
+    // ── Morale causality: contract extension ──────────────────────────────────
+    try {
+      const extPlayer = cache.getPlayer(playerId);
+      if (extPlayer) {
+        const moraleSeasonId = meta.currentSeasonId ?? meta.season ?? 0;
+        const moraleWeek = meta.currentWeek ?? 0;
+        const extUpdated = applyMoraleEvent(extPlayer, {
+          type:      MORALE_EVENTS.CONTRACT_EXTENDED,
+          delta:     MORALE_DELTAS[MORALE_EVENTS.CONTRACT_EXTENDED],
+          season:    moraleSeasonId,
+          week:      moraleWeek,
+          reason:    'Contract extension signed',
+          source:    'contract',
+          dedupeKey: `${MORALE_EVENTS.CONTRACT_EXTENDED}-${playerId}-${moraleSeasonId}`,
+        }, { season: moraleSeasonId, week: moraleWeek });
+        if (extUpdated !== extPlayer) {
+          cache.updatePlayer(playerId, { morale: extUpdated.morale, moraleEvents: extUpdated.moraleEvents });
+        }
+      }
+    } catch (moraleErr) {
+      console.warn('[Worker] Contract extension morale event error (non-fatal):', moraleErr?.message);
+    }
+
     await flushDirty();
     post(toUI.EXTENSION_RESPONSE, { status: 'accepted', reason: 'Offer accepted', reasons }, id);
     post(toUI.STATE_UPDATE, { roster: buildRosterView(resolvedTeamId), ...buildViewState() });
@@ -7684,6 +7788,59 @@ async function executeAcceptedTrade({ fromTeamId, toTeamId, offering, receiving 
   };
   await Transactions.add(tradeRecord);
   await NewsEngine.logTransaction('TRADE', { fromTeamId, toTeamId });
+
+  // ── Morale causality: apply trade morale events ───────────────────────────
+  try {
+    const moraleSeasonId = latestMeta.currentSeasonId ?? latestMeta.season ?? 0;
+    const moraleWeek = latestMeta.currentWeek ?? 0;
+    const allTeamsForMorale = cache.getAllTeams();
+    const numTeams = allTeamsForMorale.length;
+
+    const applyTradeMorale = (playerIds, receivingTeamId) => {
+      const recTeam = cache.getTeam(Number(receivingTeamId));
+      if (!recTeam) return;
+      const posture = classifyDeadlinePosture(
+        {
+          wins:   recTeam.wins   ?? recTeam.record?.wins   ?? 0,
+          losses: recTeam.losses ?? recTeam.record?.losses ?? 0,
+          roster: cache.getPlayersByTeam(Number(receivingTeamId)),
+        },
+        { numTeams },
+      );
+      const isContenderOrHunt = posture === DEADLINE_POSTURE.CONTENDER || posture === DEADLINE_POSTURE.PLAYOFF_HUNT;
+      const isSellerOrRebuild = posture === DEADLINE_POSTURE.SELLER    || posture === DEADLINE_POSTURE.REBUILD;
+      const eventType = isContenderOrHunt ? MORALE_EVENTS.TRADED_TO_CONTENDER
+                      : isSellerOrRebuild ? MORALE_EVENTS.TRADED_TO_REBUILDER
+                      : null;
+      if (!eventType) return;
+      for (const pid of (playerIds ?? [])) {
+        const player = cache.getPlayer(Number(pid));
+        if (!player) continue;
+        const updated = applyMoraleEvent(player, {
+          type:      eventType,
+          delta:     MORALE_DELTAS[eventType],
+          season:    moraleSeasonId,
+          week:      moraleWeek,
+          reason:    eventType === MORALE_EVENTS.TRADED_TO_CONTENDER
+            ? 'Traded to a contender'
+            : 'Traded to a rebuilding team',
+          source:    'trade',
+          dedupeKey: `${eventType}-${player.id}-${moraleSeasonId}-${moraleWeek}-${receivingTeamId}`,
+        }, { season: moraleSeasonId, week: moraleWeek });
+        if (updated !== player) {
+          cache.updatePlayer(player.id, { morale: updated.morale, moraleEvents: updated.moraleEvents });
+        }
+      }
+    };
+
+    // Players in `offering` moved from fromTeam → toTeam
+    applyTradeMorale(offering?.playerIds ?? [], toTeamId);
+    // Players in `receiving` moved from toTeam → fromTeam
+    applyTradeMorale(receiving?.playerIds ?? [], fromTeamId);
+  } catch (moraleErr) {
+    console.warn('[Worker] Trade morale event error (non-fatal):', moraleErr?.message);
+  }
+
   await flushDirty();
 }
 


### PR DESCRIPTION
Adds a pure, deterministic morale system that makes roster decisions feel
personal — trades, extensions, and deadline posture now leave visible,
persistent morale footprints on each player.

What Changed:
- src/core/mood/playerMoraleEngine.js (new): pure morale engine with
  applyMoraleEvent, getPlayerMoraleSummary, applyWeeklyMoraleEffects;
  score bounded [0,100], default 70, rolling moraleEvents cap of 10,
  deduplication via stable dedupeKey strings.
- worker.js: wires trade completion (TRADED_TO_CONTENDER / TRADED_TO_REBUILDER),
  contract extension (CONTRACT_EXTENDED), and weekly advance
  (VETERAN_LEADER_BONUS + DEADLINE_SELL_FRUSTRATION) to applyMoraleEvent;
  emits morale-drop news items for players crossing below the alert threshold.
- leaguePulse.js: adds "Locker Room Watch" (morale < 35) and "Veteran Presence"
  (VETERAN_LEADER_BONUS this week) pulse items.
- news-engine.js: adds morale_drop and trade_request_denied templates plus
  buildMoraleDropDedupeKey / buildTradeRequestDeniedDedupeKey exports.
- PlayerProfile.jsx: morale label + score + most-recent event reason.
- Roster.jsx: LOW badge for players with morale < 40.

Tests Added (70 new tests, 2797 total):
- src/core/mood/__tests__/playerMoraleEngine.test.js (43 tests)
- src/core/__tests__/leaguePulseMorale.test.js (14 tests)
- src/core/__tests__/playerMoraleUI.test.js (13 tests)

Guardrails Confirmed:
- No Math.random — fully deterministic.
- Morale does NOT feed back into game simulation outcomes (V1 constraint).
- DEADLINE_SELL_FRUSTRATION driven by live team posture (not league-memory,
  which does not yet persist deadline events).
- STARTER_ROLE_LOST and TRADE_REQUEST_DENIED defined in engine but not wired
  (no clear handler exists in V1 codebase).

https://claude.ai/code/session_01UzzEdw8cqddDSnnzNoj5iq