### PR TITLE
feat: Historical Awards & Dynasty Records V1

### DIFF
--- a/src/core/__tests__/awardEngine.test.js
+++ b/src/core/__tests__/awardEngine.test.js
@@ -1,0 +1,414 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AWARD_TYPES,
+  SEASON_END,
+  determineSeasonAwards,
+  applySeasonAwards,
+  getPlayerAwardSummary,
+  checkCareerMilestones,
+} from '../awards/awardEngine.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeQBStats(playerId, teamId, passYd, passTD, gp = 17) {
+  return { playerId, name: `QB${playerId}`, pos: 'QB', teamId, totals: { gamesPlayed: gp, passYd, passTD, interceptions: 5, passAtt: 500, passComp: 330 } };
+}
+function makeRBStats(playerId, teamId, rushYd, rushTD, gp = 17) {
+  return { playerId, name: `RB${playerId}`, pos: 'RB', teamId, totals: { gamesPlayed: gp, rushYd, rushTD, recYd: 300, recTD: 2 } };
+}
+function makeWRStats(playerId, teamId, recYd, recTD, gp = 17) {
+  return { playerId, name: `WR${playerId}`, pos: 'WR', teamId, totals: { gamesPlayed: gp, recYd, recTD, receptions: 80 } };
+}
+function makeLBStats(playerId, teamId, tackles, sacks, gp = 17) {
+  return { playerId, name: `LB${playerId}`, pos: 'LB', teamId, totals: { gamesPlayed: gp, tackles, sacks, interceptions: 2 } };
+}
+function makeKStats(playerId, teamId, fgMade, xpMade = 30, gp = 17) {
+  return { playerId, name: `K${playerId}`, pos: 'K', teamId, totals: { gamesPlayed: gp, fgMade, xpMade } };
+}
+
+const teams = [
+  { id: 1, wins: 13, ovr: 85 },
+  { id: 2, wins: 9, ovr: 72 },
+  { id: 3, wins: 5, ovr: 68 },
+];
+
+const season = 2025;
+
+// ── determineSeasonAwards ─────────────────────────────────────────────────────
+
+describe('determineSeasonAwards', () => {
+  it('returns correct MVP winner (top QB on winning team)', () => {
+    const stats = [
+      makeQBStats(1, 1, 4800, 38),
+      makeQBStats(2, 2, 4200, 30),
+      makeRBStats(3, 1, 1800, 18),
+    ];
+    const { playerAwards } = determineSeasonAwards([], teams, season, { stats, coaches: [], championTeamId: null });
+    const mvp = playerAwards.find(a => a.type === AWARD_TYPES.MVP);
+    expect(mvp).toBeTruthy();
+    expect(mvp.playerId).toBe(1);
+    expect(mvp.season).toBe(season);
+    expect(mvp.week).toBe(SEASON_END);
+    expect(mvp.dedupeKey).toBe(`MVP_${season}`);
+  });
+
+  it('returns correct OFFENSIVE_POY (non-QB)', () => {
+    const stats = [
+      makeQBStats(1, 1, 5000, 42),
+      makeRBStats(2, 1, 2000, 20),
+      makeWRStats(3, 1, 1800, 16),
+    ];
+    const { playerAwards } = determineSeasonAwards([], teams, season, { stats });
+    const opoy = playerAwards.find(a => a.type === AWARD_TYPES.OFFENSIVE_POY);
+    expect(opoy).toBeTruthy();
+    expect(opoy.playerId).not.toBe(1); // no QB
+    expect([2, 3]).toContain(opoy.playerId);
+  });
+
+  it('returns correct DEFENSIVE_POY', () => {
+    const stats = [
+      makeQBStats(1, 1, 4800, 38),
+      makeLBStats(10, 1, 120, 14),
+      makeLBStats(11, 2, 90, 8),
+    ];
+    const { playerAwards } = determineSeasonAwards([], teams, season, { stats });
+    const dpoy = playerAwards.find(a => a.type === AWARD_TYPES.DEFENSIVE_POY);
+    expect(dpoy).toBeTruthy();
+    expect(dpoy.playerId).toBe(10);
+  });
+
+  it('returns correct ROOKIE_OF_YEAR for first-year player', () => {
+    const players = [
+      { id: 20, year: season, age: 22 },
+      { id: 21, year: season - 1, age: 23 },
+    ];
+    const stats = [
+      makeQBStats(20, 1, 3500, 28),
+      makeQBStats(21, 1, 4200, 32),
+    ];
+    const { playerAwards } = determineSeasonAwards(players, teams, season, { stats });
+    const roty = playerAwards.find(a => a.type === AWARD_TYPES.ROOKIE_OF_YEAR);
+    expect(roty).toBeTruthy();
+    expect(roty.playerId).toBe(20);
+  });
+
+  it('emits LEAGUE_CHAMPION franchise award when championTeamId provided', () => {
+    const stats = [makeQBStats(1, 1, 4800, 38)];
+    const { franchiseAwards } = determineSeasonAwards([], teams, season, { stats, championTeamId: 1 });
+    const champ = franchiseAwards.find(a => a.type === AWARD_TYPES.LEAGUE_CHAMPION);
+    expect(champ).toBeTruthy();
+    expect(champ.teamId).toBe(1);
+    expect(champ.season).toBe(season);
+  });
+
+  it('emits COACH_OF_YEAR franchise award for overperforming team', () => {
+    const overTeams = [
+      { id: 1, wins: 14, ovr: 70 }, // expected ~8.5 → overperforms +5.5
+      { id: 2, wins: 8, ovr: 85 },  // expected ~11.5 → underperforms
+    ];
+    const stats = [makeQBStats(1, 1, 4000, 30)];
+    const coaches = [{ teamId: 1, name: 'Coach Smith' }];
+    const { franchiseAwards } = determineSeasonAwards([], overTeams, season, { stats, coaches, championTeamId: null });
+    const coy = franchiseAwards.find(a => a.type === AWARD_TYPES.COACH_OF_YEAR);
+    expect(coy).toBeTruthy();
+    expect(coy.teamId).toBe(1);
+    expect(coy.coachName).toBe('Coach Smith');
+  });
+
+  it('All-Pro team has exactly one player per single-slot position', () => {
+    const stats = [
+      makeQBStats(1, 1, 5000, 42),
+      makeRBStats(2, 1, 1800, 18),
+      makeWRStats(3, 1, 1600, 14),
+      makeWRStats(4, 2, 1400, 12),
+      { playerId: 5, name: 'TE5', pos: 'TE', teamId: 1, totals: { gamesPlayed: 17, recYd: 900, recTD: 10, receptions: 70 } },
+      makeKStats(6, 1, 35),
+      { playerId: 7, name: 'P7', pos: 'P', teamId: 1, totals: { gamesPlayed: 17, punts: 60, puntYards: 2760 } },
+      { playerId: 8, name: 'S8', pos: 'S', teamId: 1, totals: { gamesPlayed: 17, interceptions: 6, tackles: 80 } },
+    ];
+    const { allProTeam } = determineSeasonAwards([], teams, season, { stats });
+    const qbs = allProTeam.filter(a => a.type === AWARD_TYPES.ALL_PRO_QB);
+    const rbs = allProTeam.filter(a => a.type === AWARD_TYPES.ALL_PRO_RB);
+    const tes = allProTeam.filter(a => a.type === AWARD_TYPES.ALL_PRO_TE);
+    const ks = allProTeam.filter(a => a.type === AWARD_TYPES.ALL_PRO_K);
+    const ps = allProTeam.filter(a => a.type === AWARD_TYPES.ALL_PRO_P);
+    const ss = allProTeam.filter(a => a.type === AWARD_TYPES.ALL_PRO_S);
+    expect(qbs).toHaveLength(1);
+    expect(rbs).toHaveLength(1);
+    expect(tes).toHaveLength(1);
+    expect(ks).toHaveLength(1);
+    expect(ps).toHaveLength(1);
+    expect(ss).toHaveLength(1);
+  });
+
+  it('All-Pro WR slots have at most 2 players with no duplicates', () => {
+    const stats = [
+      makeWRStats(3, 1, 1600, 14),
+      makeWRStats(4, 2, 1400, 12),
+      makeWRStats(5, 3, 1200, 10),
+    ];
+    const { allProTeam } = determineSeasonAwards([], teams, season, { stats });
+    const wrs = allProTeam.filter(a => a.type === AWARD_TYPES.ALL_PRO_WR);
+    expect(wrs.length).toBeLessThanOrEqual(2);
+    const ids = wrs.map(a => a.playerId);
+    expect(new Set(ids).size).toBe(ids.length); // no duplicates
+  });
+
+  it('is deterministic: same input → same output', () => {
+    const stats = [
+      makeQBStats(1, 1, 4800, 38),
+      makeRBStats(2, 2, 1600, 15),
+      makeLBStats(10, 1, 100, 12),
+    ];
+    const context = { stats, coaches: [], championTeamId: 1 };
+    const result1 = determineSeasonAwards([], teams, season, context);
+    const result2 = determineSeasonAwards([], teams, season, context);
+    expect(result1.playerAwards.map(a => a.playerId)).toEqual(result2.playerAwards.map(a => a.playerId));
+    expect(result1.franchiseAwards).toEqual(result2.franchiseAwards);
+    expect(result1.allProTeam.map(a => a.playerId)).toEqual(result2.allProTeam.map(a => a.playerId));
+  });
+
+  it('excludes players below minimum games threshold', () => {
+    const stats = [
+      { ...makeQBStats(99, 1, 9000, 80), totals: { gamesPlayed: 1, passYd: 9000, passTD: 80 } },
+      makeQBStats(1, 1, 4800, 38),
+    ];
+    const { playerAwards } = determineSeasonAwards([], teams, season, { stats });
+    const mvp = playerAwards.find(a => a.type === AWARD_TYPES.MVP);
+    expect(mvp?.playerId).toBe(1); // not 99 (only 1 game)
+  });
+
+  it('returns empty arrays for empty stats input', () => {
+    const result = determineSeasonAwards([], teams, season, { stats: [] });
+    expect(result.playerAwards).toEqual([]);
+    expect(result.allProTeam).toEqual([]);
+  });
+
+  it('dedupeKey format is stable: `${type}_${season}`', () => {
+    const stats = [makeQBStats(1, 1, 4800, 38)];
+    const { playerAwards } = determineSeasonAwards([], teams, season, { stats });
+    const mvp = playerAwards.find(a => a.type === AWARD_TYPES.MVP);
+    expect(mvp.dedupeKey).toBe(`MVP_${season}`);
+  });
+
+  it('statSnapshot includes ovr and relevant stats', () => {
+    const stats = [makeQBStats(1, 1, 4800, 38)];
+    const { playerAwards } = determineSeasonAwards([], teams, season, { stats });
+    const mvp = playerAwards.find(a => a.type === AWARD_TYPES.MVP);
+    expect(mvp.statSnapshot).toBeDefined();
+    expect(Object.keys(mvp.statSnapshot)).toContain('ovr');
+  });
+});
+
+// ── applySeasonAwards ─────────────────────────────────────────────────────────
+
+describe('applySeasonAwards', () => {
+  it('writes awards to correct player objects', () => {
+    const stats = [makeQBStats(1, 1, 4800, 38)];
+    const awardResults = determineSeasonAwards([], teams, season, { stats });
+    const playerMap = new Map([['1', { id: 1, name: 'QB1', pos: 'QB', awards: [] }]]);
+    const { playerUpdates } = applySeasonAwards(playerMap, {}, awardResults);
+    expect(playerUpdates.has('1')).toBe(true);
+    const updated = playerUpdates.get('1');
+    expect(Array.isArray(updated.awards)).toBe(true);
+    expect(updated.awards.length).toBeGreaterThan(0);
+  });
+
+  it('does not duplicate award if dedupeKey already exists', () => {
+    const stats = [makeQBStats(1, 1, 4800, 38)];
+    const awardResults = determineSeasonAwards([], teams, season, { stats });
+    const existingAward = { type: AWARD_TYPES.MVP, season, dedupeKey: `MVP_${season}` };
+    const playerMap = new Map([['1', { id: 1, name: 'QB1', pos: 'QB', awards: [existingAward] }]]);
+    const { playerUpdates } = applySeasonAwards(playerMap, {}, awardResults);
+    const updated = playerUpdates.get('1');
+    if (updated) {
+      const mvps = updated.awards.filter(a => a.type === AWARD_TYPES.MVP);
+      expect(mvps.length).toBe(1);
+    }
+  });
+
+  it('appends to franchiseAwards without duplicating', () => {
+    const awardResults = {
+      playerAwards: [],
+      franchiseAwards: [{ type: AWARD_TYPES.LEAGUE_CHAMPION, season, teamId: 1 }],
+      allProTeam: [],
+    };
+    const currentMeta = { franchiseAwards: [] };
+    const { updatedFranchiseAwards } = applySeasonAwards(new Map(), currentMeta, awardResults);
+    expect(updatedFranchiseAwards).toHaveLength(1);
+    expect(updatedFranchiseAwards[0].type).toBe(AWARD_TYPES.LEAGUE_CHAMPION);
+
+    // Apply again — should not duplicate
+    const { updatedFranchiseAwards: again } = applySeasonAwards(
+      new Map(),
+      { franchiseAwards: updatedFranchiseAwards },
+      awardResults,
+    );
+    expect(again).toHaveLength(1);
+  });
+
+  it('handles player with no awards field safely', () => {
+    const stats = [makeQBStats(1, 1, 4800, 38)];
+    const awardResults = determineSeasonAwards([], teams, season, { stats });
+    // Player with no awards field at all
+    const playerMap = new Map([['1', { id: 1, name: 'QB1', pos: 'QB' }]]);
+    expect(() => applySeasonAwards(playerMap, {}, awardResults)).not.toThrow();
+    const { playerUpdates } = applySeasonAwards(playerMap, {}, awardResults);
+    const updated = playerUpdates.get('1');
+    expect(Array.isArray(updated?.awards)).toBe(true);
+  });
+
+  it('handles undefined currentMeta safely', () => {
+    const awardResults = { playerAwards: [], franchiseAwards: [], allProTeam: [] };
+    expect(() => applySeasonAwards(new Map(), undefined, awardResults)).not.toThrow();
+    const { updatedFranchiseAwards } = applySeasonAwards(new Map(), undefined, awardResults);
+    expect(updatedFranchiseAwards).toEqual([]);
+  });
+});
+
+// ── getPlayerAwardSummary ─────────────────────────────────────────────────────
+
+describe('getPlayerAwardSummary', () => {
+  it('counts MVP, allPro, and championship correctly', () => {
+    const player = {
+      awards: [
+        { type: AWARD_TYPES.MVP, season: 2023, dedupeKey: 'MVP_2023', teamId: 1 },
+        { type: AWARD_TYPES.MVP, season: 2024, dedupeKey: 'MVP_2024', teamId: 1 },
+        { type: AWARD_TYPES.ALL_PRO_QB, season: 2023, dedupeKey: 'ALL_PRO_QB_2023', teamId: 1 },
+        { type: AWARD_TYPES.LEAGUE_CHAMPION, season: 2024, dedupeKey: 'LEAGUE_CHAMPION_2024', teamId: 1 },
+      ],
+    };
+    const summary = getPlayerAwardSummary(player);
+    expect(summary.mvpCount).toBe(2);
+    expect(summary.allProCount).toBe(1);
+    expect(summary.championshipCount).toBe(1);
+    expect(summary.totalAwards).toBe(4);
+    expect(summary.summaryLine).toContain('MVP');
+    expect(summary.summaryLine).toContain('All-Pro');
+    expect(summary.summaryLine).toContain('Champion');
+  });
+
+  it('returns safe defaults for player with no awards field', () => {
+    const summary = getPlayerAwardSummary({ id: 1, name: 'Test' });
+    expect(summary.totalAwards).toBe(0);
+    expect(summary.mvpCount).toBe(0);
+    expect(summary.allProCount).toBe(0);
+    expect(summary.championshipCount).toBe(0);
+    expect(summary.highlights).toEqual([]);
+    expect(summary.summaryLine).toBeNull();
+  });
+
+  it('returns safe defaults for null player', () => {
+    const summary = getPlayerAwardSummary(null);
+    expect(summary.totalAwards).toBe(0);
+    expect(summary.summaryLine).toBeNull();
+  });
+
+  it('highlights are capped at 5 entries, sorted newest first', () => {
+    const awards = Array.from({ length: 8 }, (_, i) => ({
+      type: AWARD_TYPES.MVP,
+      season: 2020 + i,
+      dedupeKey: `MVP_${2020 + i}`,
+      teamId: 1,
+    }));
+    const summary = getPlayerAwardSummary({ awards });
+    expect(summary.highlights.length).toBe(5);
+    // Newest first
+    expect(summary.highlights[0].season).toBeGreaterThan(summary.highlights[1].season);
+  });
+});
+
+// ── checkCareerMilestones ─────────────────────────────────────────────────────
+
+describe('checkCareerMilestones', () => {
+  it('fires 300_CAREER_TDs milestone when threshold crossed this season', () => {
+    const player = {
+      id: 1, name: 'QB Test', pos: 'QB', age: 32,
+      careerStats: [
+        { season: 's1', passTDs: 150, rushTDs: 10, recTDs: 0 },
+        { season: 's2', passTDs: 140, rushTDs: 0, recTDs: 0 }, // total = 300
+      ],
+    };
+    const milestone = checkCareerMilestones(player, 2025);
+    expect(milestone).not.toBeNull();
+    expect(milestone.type).toBe('300_CAREER_TDs');
+    expect(milestone.totalTDs).toBe(300);
+  });
+
+  it('does not fire 300_CAREER_TDs if threshold was crossed in a prior season', () => {
+    const player = {
+      id: 1, name: 'QB Test', pos: 'QB', age: 35,
+      careerStats: [
+        { season: 's1', passTDs: 310, rushTDs: 0, recTDs: 0 },
+        { season: 's2', passTDs: 30, rushTDs: 0, recTDs: 0 },
+      ],
+    };
+    const milestone = checkCareerMilestones(player, 2025);
+    // Was already at 310 before this season → no crossing this season
+    expect(milestone?.type).not.toBe('300_CAREER_TDs');
+  });
+
+  it('fires HOF_ELIGIBLE for retired player age 35+ with OVR 85+', () => {
+    const player = {
+      id: 2, name: 'Ret Player', pos: 'QB', age: 36, ovr: 88,
+      status: 'retired',
+      awards: [],
+      careerStats: [{ season: 's1', passTDs: 10, rushTDs: 0, recTDs: 0 }],
+    };
+    const milestone = checkCareerMilestones(player, 2025);
+    expect(milestone).not.toBeNull();
+    expect(milestone.type).toBe('HALL_OF_FAME_ELIGIBLE');
+  });
+
+  it('does not fire HOF_ELIGIBLE for active player', () => {
+    const player = {
+      id: 3, name: 'Active', pos: 'QB', age: 36, ovr: 88,
+      status: 'active',
+      awards: [],
+      careerStats: [{ season: 's1', passTDs: 10 }],
+    };
+    const milestone = checkCareerMilestones(player, 2025);
+    expect(milestone?.type).not.toBe('HALL_OF_FAME_ELIGIBLE');
+  });
+
+  it('returns null for player with no careerStats', () => {
+    const player = { id: 4, name: 'Rookie', pos: 'QB', age: 22 };
+    expect(checkCareerMilestones(player, 2025)).toBeNull();
+  });
+
+  it('returns null for null player', () => {
+    expect(checkCareerMilestones(null, 2025)).toBeNull();
+  });
+
+  it('fires HOF_ELIGIBLE when 3+ MVP/DPOY even with OVR < 85', () => {
+    const player = {
+      id: 5, name: 'Legend', pos: 'QB', age: 37, ovr: 80,
+      status: 'retired',
+      awards: [
+        { type: AWARD_TYPES.MVP, season: 2020, dedupeKey: 'MVP_2020' },
+        { type: AWARD_TYPES.MVP, season: 2021, dedupeKey: 'MVP_2021' },
+        { type: AWARD_TYPES.MVP, season: 2022, dedupeKey: 'MVP_2022' },
+      ],
+      careerStats: [{ season: 's1', passTDs: 50 }],
+    };
+    const milestone = checkCareerMilestones(player, 2025);
+    expect(milestone?.type).toBe('HALL_OF_FAME_ELIGIBLE');
+  });
+});
+
+// ── SEASON_END constant ───────────────────────────────────────────────────────
+
+describe('SEASON_END constant', () => {
+  it('is a non-empty string', () => {
+    expect(typeof SEASON_END).toBe('string');
+    expect(SEASON_END.length).toBeGreaterThan(0);
+  });
+
+  it('is used as the week field in player award entries', () => {
+    const stats = [makeQBStats(1, 1, 4800, 38)];
+    const { playerAwards } = determineSeasonAwards([], teams, season, { stats });
+    for (const a of playerAwards) {
+      expect(a.week).toBe(SEASON_END);
+    }
+  });
+});

--- a/src/core/__tests__/awardEngineNewsItems.test.js
+++ b/src/core/__tests__/awardEngineNewsItems.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AWARD_TYPES,
+  SEASON_END,
+  determineSeasonAwards,
+  applySeasonAwards,
+} from '../awards/awardEngine.js';
+
+// Minimal shared fixtures
+const teams = [
+  { id: 1, wins: 13, ovr: 78 },
+  { id: 2, wins: 9, ovr: 72 },
+];
+const season = 2026;
+
+function makeQB(id, teamId, passYd = 4800, passTD = 38) {
+  return { playerId: id, name: `QB${id}`, pos: 'QB', teamId, totals: { gamesPlayed: 17, passYd, passTD, interceptions: 8 } };
+}
+function makeWR(id, teamId, recYd = 1600, recTD = 14) {
+  return { playerId: id, name: `WR${id}`, pos: 'WR', teamId, totals: { gamesPlayed: 17, recYd, recTD, receptions: 90 } };
+}
+
+describe('MVP award dedupeKey stability', () => {
+  it('MVP dedupeKey is always MVP_{season}', () => {
+    const stats = [makeQB(1, 1)];
+    const { playerAwards } = determineSeasonAwards([], teams, season, { stats });
+    const mvp = playerAwards.find(a => a.type === AWARD_TYPES.MVP);
+    expect(mvp?.dedupeKey).toBe(`MVP_${season}`);
+  });
+
+  it('same season cannot produce two MVP entries', () => {
+    const stats = [makeQB(1, 1, 5000, 42), makeQB(2, 2, 4000, 30)];
+    const awardResults = determineSeasonAwards([], teams, season, { stats });
+    const mvps = awardResults.playerAwards.filter(a => a.type === AWARD_TYPES.MVP);
+    expect(mvps.length).toBe(1);
+  });
+});
+
+describe('LEAGUE_CHAMPION pulse dedupeKey stability', () => {
+  it('champion franchise award dedupeKey is stable', () => {
+    const stats = [makeQB(1, 1)];
+    const { franchiseAwards } = determineSeasonAwards([], teams, season, { stats, championTeamId: 1 });
+    const champ = franchiseAwards.find(a => a.type === AWARD_TYPES.LEAGUE_CHAMPION);
+    expect(champ).toBeDefined();
+    // dedupeKey on franchise awards = `${type}_${season}`
+    expect(`${champ.type}_${champ.season}`).toBe(`LEAGUE_CHAMPION_${season}`);
+  });
+});
+
+describe('All-Pro news item covers all positions', () => {
+  it('allProTeam includes entries for each expected position when players exist', () => {
+    const stats = [
+      makeQB(1, 1),
+      { playerId: 2, name: 'RB2', pos: 'RB', teamId: 1, totals: { gamesPlayed: 17, rushYd: 1600, rushTD: 15 } },
+      makeWR(3, 1),
+      makeWR(4, 2, 1400, 12),
+      { playerId: 5, name: 'TE5', pos: 'TE', teamId: 1, totals: { gamesPlayed: 17, recYd: 900, recTD: 8, receptions: 70 } },
+      { playerId: 6, name: 'K6', pos: 'K', teamId: 1, totals: { gamesPlayed: 17, fgMade: 35, xpMade: 40 } },
+      { playerId: 7, name: 'P7', pos: 'P', teamId: 1, totals: { gamesPlayed: 17, punts: 60, puntYards: 2760 } },
+    ];
+    const { allProTeam } = determineSeasonAwards([], teams, season, { stats });
+    const types = allProTeam.map(a => a.type);
+    expect(types).toContain(AWARD_TYPES.ALL_PRO_QB);
+    expect(types).toContain(AWARD_TYPES.ALL_PRO_RB);
+    expect(types).toContain(AWARD_TYPES.ALL_PRO_WR);
+    expect(types).toContain(AWARD_TYPES.ALL_PRO_TE);
+    expect(types).toContain(AWARD_TYPES.ALL_PRO_K);
+    expect(types).toContain(AWARD_TYPES.ALL_PRO_P);
+  });
+});
+
+describe('award application does not duplicate same season', () => {
+  it('applying same awardResults twice does not produce duplicates', () => {
+    const stats = [makeQB(1, 1)];
+    const awardResults = determineSeasonAwards([], teams, season, { stats });
+    const playerMap = new Map([['1', { id: 1, name: 'QB1', pos: 'QB' }]]);
+
+    // First apply
+    const first = applySeasonAwards(playerMap, {}, awardResults);
+    const updatedPlayer = { id: 1, name: 'QB1', pos: 'QB', awards: first.playerUpdates.get('1')?.awards ?? [] };
+    const playerMap2 = new Map([['1', updatedPlayer]]);
+
+    // Second apply — should not add duplicates
+    const second = applySeasonAwards(playerMap2, { franchiseAwards: first.updatedFranchiseAwards }, awardResults);
+    const finalAwards = second.playerUpdates.get('1')?.awards ?? updatedPlayer.awards;
+    const mvpEntries = finalAwards.filter(a => a.type === AWARD_TYPES.MVP);
+    expect(mvpEntries.length).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/core/__tests__/awardEngineWorkerIntegration.test.js
+++ b/src/core/__tests__/awardEngineWorkerIntegration.test.js
@@ -1,0 +1,188 @@
+/**
+ * Worker integration tests for the award engine.
+ * Tests the pure functions that the worker calls — no actual worker needed.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  AWARD_TYPES,
+  SEASON_END,
+  determineSeasonAwards,
+  applySeasonAwards,
+} from '../awards/awardEngine.js';
+
+// ── Shared fixtures ───────────────────────────────────────────────────────────
+
+const season = 2025;
+const teams = [
+  { id: 1, wins: 14, ovr: 80 },
+  { id: 2, wins: 8, ovr: 72 },
+];
+
+function qbStat(id, teamId) {
+  return {
+    playerId: id,
+    name: `QB${id}`,
+    pos: 'QB',
+    teamId,
+    totals: { gamesPlayed: 17, passYd: 4800, passTD: 38, interceptions: 8 },
+  };
+}
+
+// ── Season advance emits awards after stats ───────────────────────────────────
+
+describe('season advance via determineSeasonAwards', () => {
+  it('emits player awards after stats finalization', () => {
+    const stats = [qbStat(1, 1)];
+    const result = determineSeasonAwards([], teams, season, { stats, coaches: [], championTeamId: 1 });
+    expect(result.playerAwards.length).toBeGreaterThan(0);
+    expect(result.franchiseAwards.length).toBeGreaterThan(0);
+  });
+
+  it('award does not apply twice for the same season', () => {
+    const stats = [qbStat(1, 1)];
+    const awardResults = determineSeasonAwards([], teams, season, { stats });
+    const playerMap = new Map([['1', { id: 1, name: 'QB1', pos: 'QB' }]]);
+
+    // First application
+    const first = applySeasonAwards(playerMap, {}, awardResults);
+    const playerAfterFirst = { id: 1, name: 'QB1', pos: 'QB', awards: first.playerUpdates.get('1')?.awards ?? [] };
+    const playerMap2 = new Map([['1', playerAfterFirst]]);
+
+    // Second application (same season)
+    const second = applySeasonAwards(playerMap2, { franchiseAwards: first.updatedFranchiseAwards }, awardResults);
+
+    // Player awards — MVP dedupeKey should only appear once
+    const finalAwards = second.playerUpdates.get('1')?.awards ?? playerAfterFirst.awards;
+    const mvps = finalAwards.filter(a => a.type === AWARD_TYPES.MVP);
+    expect(mvps.length).toBeLessThanOrEqual(1);
+
+    // Franchise awards — LEAGUE_CHAMPION should not duplicate
+    // (only if championTeamId was set — rerun without it for clarity)
+    const { updatedFranchiseAwards: fa1 } = applySeasonAwards(
+      new Map(),
+      {},
+      { playerAwards: [], franchiseAwards: [{ type: AWARD_TYPES.LEAGUE_CHAMPION, season, teamId: 1 }], allProTeam: [] },
+    );
+    const { updatedFranchiseAwards: fa2 } = applySeasonAwards(
+      new Map(),
+      { franchiseAwards: fa1 },
+      { playerAwards: [], franchiseAwards: [{ type: AWARD_TYPES.LEAGUE_CHAMPION, season, teamId: 1 }], allProTeam: [] },
+    );
+    expect(fa2.filter(a => a.type === AWARD_TYPES.LEAGUE_CHAMPION && a.season === season)).toHaveLength(1);
+  });
+});
+
+// ── Awards survive LOAD_SAVE round-trip ───────────────────────────────────────
+
+describe('awards persist through save/load simulation', () => {
+  it('player.awards survives JSON serialization round-trip', () => {
+    const stats = [qbStat(1, 1)];
+    const awardResults = determineSeasonAwards([], teams, season, { stats });
+    const playerMap = new Map([['1', { id: 1, name: 'QB1', pos: 'QB' }]]);
+    const { playerUpdates } = applySeasonAwards(playerMap, {}, awardResults);
+    const updatedPlayer = { id: 1, name: 'QB1', pos: 'QB', awards: playerUpdates.get('1')?.awards ?? [] };
+
+    // Simulate save/load JSON round-trip
+    const saved = JSON.stringify(updatedPlayer);
+    const loaded = JSON.parse(saved);
+
+    expect(Array.isArray(loaded.awards)).toBe(true);
+    expect(loaded.awards.length).toBe(updatedPlayer.awards.length);
+    for (const award of loaded.awards) {
+      expect(award.type).toBeDefined();
+      expect(award.season).toBe(season);
+      expect(award.week).toBe(SEASON_END);
+      expect(award.dedupeKey).toBeDefined();
+    }
+  });
+
+  it('meta.franchiseAwards survives JSON serialization round-trip', () => {
+    const awardResults = {
+      playerAwards: [],
+      franchiseAwards: [{ type: AWARD_TYPES.LEAGUE_CHAMPION, season, teamId: 1 }],
+      allProTeam: [],
+    };
+    const { updatedFranchiseAwards } = applySeasonAwards(new Map(), {}, awardResults);
+    const saved = JSON.stringify({ franchiseAwards: updatedFranchiseAwards });
+    const loaded = JSON.parse(saved);
+    expect(Array.isArray(loaded.franchiseAwards)).toBe(true);
+    expect(loaded.franchiseAwards[0].type).toBe(AWARD_TYPES.LEAGUE_CHAMPION);
+    expect(loaded.franchiseAwards[0].season).toBe(season);
+  });
+});
+
+// ── Old save hydration ────────────────────────────────────────────────────────
+
+describe('old save hydration', () => {
+  it('player without awards field hydrates to [] without corrupting other fields', () => {
+    const oldPlayer = { id: 5, name: 'Veteran', pos: 'QB', ovr: 88, age: 34, accolades: [{ type: 'MVP', year: 2020 }] };
+    // Simulate what applySeasonAwards does when player has no awards field
+    const playerMap = new Map([['5', oldPlayer]]);
+    const awardResults = { playerAwards: [], franchiseAwards: [], allProTeam: [] };
+    const { playerUpdates } = applySeasonAwards(playerMap, {}, awardResults);
+    // No awards to apply → no update needed
+    expect(playerUpdates.has('5')).toBe(false);
+    // Original player is untouched
+    expect(oldPlayer.accolades).toHaveLength(1);
+    expect(oldPlayer.ovr).toBe(88);
+  });
+
+  it('applying awards to player without awards field creates awards array safely', () => {
+    const oldPlayer = { id: 5, name: 'Veteran', pos: 'QB', ovr: 88, age: 34 };
+    const playerMap = new Map([['5', oldPlayer]]);
+    const awardResults = {
+      playerAwards: [{ type: AWARD_TYPES.MVP, playerId: 5, name: 'Veteran', pos: 'QB', teamId: 1, season, week: SEASON_END, statSnapshot: { ovr: 88 }, dedupeKey: `MVP_${season}` }],
+      franchiseAwards: [],
+      allProTeam: [],
+    };
+    const { playerUpdates } = applySeasonAwards(playerMap, {}, awardResults);
+    const updated = playerUpdates.get('5');
+    expect(Array.isArray(updated?.awards)).toBe(true);
+    expect(updated.awards[0].type).toBe(AWARD_TYPES.MVP);
+    // Verify no pollution of adjacent fields
+    expect(updated.awards[0].ovr).toBeUndefined();
+  });
+
+  it('meta without franchiseAwards field hydrates to [] safely', () => {
+    const oldMeta = { year: 2025, season: 1 }; // no franchiseAwards
+    const awardResults = {
+      playerAwards: [],
+      franchiseAwards: [{ type: AWARD_TYPES.COACH_OF_YEAR, season, teamId: 2 }],
+      allProTeam: [],
+    };
+    const { updatedFranchiseAwards } = applySeasonAwards(new Map(), oldMeta, awardResults);
+    expect(Array.isArray(updatedFranchiseAwards)).toBe(true);
+    expect(updatedFranchiseAwards).toHaveLength(1);
+  });
+});
+
+// ── Career milestone emits at correct threshold ───────────────────────────────
+
+describe('career milestone threshold', () => {
+  it('300 TD milestone fires when careerStats crosses threshold this season', async () => {
+    const { checkCareerMilestones } = await import('../awards/awardEngine.js');
+    const player = {
+      id: 99,
+      name: 'Legend QB',
+      pos: 'QB',
+      age: 33,
+      careerStats: [
+        { season: 's1', passTDs: 150, rushTDs: 10, recTDs: 0 },
+        { season: 's2', passTDs: 141, rushTDs: 0, recTDs: 0 }, // crosses 300 (= 301 total)
+      ],
+    };
+    const milestone = checkCareerMilestones(player, season);
+    expect(milestone).not.toBeNull();
+    expect(milestone.type).toBe('300_CAREER_TDs');
+    expect(milestone.totalTDs).toBeGreaterThanOrEqual(300);
+  });
+
+  it('300 TD milestone does not fire for non-scoring positions', async () => {
+    const { checkCareerMilestones } = await import('../awards/awardEngine.js');
+    const lineman = {
+      id: 50, name: 'Big OL', pos: 'OL', age: 28,
+      careerStats: [{ season: 's1', passTDs: 0 }],
+    };
+    expect(checkCareerMilestones(lineman, season)).toBeNull();
+  });
+});

--- a/src/core/awards/awardEngine.js
+++ b/src/core/awards/awardEngine.js
@@ -1,0 +1,672 @@
+/**
+ * awardEngine.js — Historical Awards & Dynasty Records V1
+ *
+ * Pure module: no side effects, no imports from worker/UI/news.
+ * Deterministic: same input always produces same output.
+ *
+ * Exported API:
+ *   AWARD_TYPES            — constant object for all award type strings
+ *   SEASON_END             — week constant for award entries
+ *   determineSeasonAwards(players, teams, season, context)
+ *     → { playerAwards, franchiseAwards, allProTeam }
+ *   applySeasonAwards(playerMap, currentMeta, awardResults)
+ *     → { playerUpdates: Map<pid, {awards:[...]}>, updatedFranchiseAwards: [...] }
+ *   getPlayerAwardSummary(player)
+ *     → { totalAwards, mvpCount, allProCount, championshipCount, highlights }
+ *   checkCareerMilestones(player, season)
+ *     → milestone event object or null
+ */
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const SEASON_END = 'SEASON_END';
+
+export const AWARD_TYPES = Object.freeze({
+  MVP: 'MVP',
+  OFFENSIVE_POY: 'OFFENSIVE_POY',
+  DEFENSIVE_POY: 'DEFENSIVE_POY',
+  COACH_OF_YEAR: 'COACH_OF_YEAR',
+  COMEBACK_PLAYER: 'COMEBACK_PLAYER',
+  ROOKIE_OF_YEAR: 'ROOKIE_OF_YEAR',
+  LEAGUE_CHAMPION: 'LEAGUE_CHAMPION',
+  ALL_PRO_QB: 'ALL_PRO_QB',
+  ALL_PRO_RB: 'ALL_PRO_RB',
+  ALL_PRO_WR: 'ALL_PRO_WR',
+  ALL_PRO_TE: 'ALL_PRO_TE',
+  ALL_PRO_OL: 'ALL_PRO_OL',
+  ALL_PRO_DL: 'ALL_PRO_DL',
+  ALL_PRO_LB: 'ALL_PRO_LB',
+  ALL_PRO_CB: 'ALL_PRO_CB',
+  ALL_PRO_S: 'ALL_PRO_S',
+  ALL_PRO_K: 'ALL_PRO_K',
+  ALL_PRO_P: 'ALL_PRO_P',
+});
+
+export const AWARD_LABELS = Object.freeze({
+  [AWARD_TYPES.MVP]: 'Most Valuable Player',
+  [AWARD_TYPES.OFFENSIVE_POY]: 'Offensive Player of the Year',
+  [AWARD_TYPES.DEFENSIVE_POY]: 'Defensive Player of the Year',
+  [AWARD_TYPES.COACH_OF_YEAR]: 'Coach of the Year',
+  [AWARD_TYPES.COMEBACK_PLAYER]: 'Comeback Player of the Year',
+  [AWARD_TYPES.ROOKIE_OF_YEAR]: 'Rookie of the Year',
+  [AWARD_TYPES.LEAGUE_CHAMPION]: 'League Champion',
+  [AWARD_TYPES.ALL_PRO_QB]: 'First Team All-Pro QB',
+  [AWARD_TYPES.ALL_PRO_RB]: 'First Team All-Pro RB',
+  [AWARD_TYPES.ALL_PRO_WR]: 'First Team All-Pro WR',
+  [AWARD_TYPES.ALL_PRO_TE]: 'First Team All-Pro TE',
+  [AWARD_TYPES.ALL_PRO_OL]: 'First Team All-Pro OL',
+  [AWARD_TYPES.ALL_PRO_DL]: 'First Team All-Pro DL',
+  [AWARD_TYPES.ALL_PRO_LB]: 'First Team All-Pro LB',
+  [AWARD_TYPES.ALL_PRO_CB]: 'First Team All-Pro CB',
+  [AWARD_TYPES.ALL_PRO_S]: 'First Team All-Pro S',
+  [AWARD_TYPES.ALL_PRO_K]: 'First Team All-Pro K',
+  [AWARD_TYPES.ALL_PRO_P]: 'First Team All-Pro P',
+});
+
+export const CAREER_MILESTONE_TYPES = Object.freeze({
+  TD_300: '300_CAREER_TDs',
+  WINS_1000: '1000_CAREER_WINS',
+  HOF_ELIGIBLE: 'HALL_OF_FAME_ELIGIBLE',
+});
+
+// ── Position group helpers ────────────────────────────────────────────────────
+
+const OFF_SKILL_POS = new Set(['QB', 'RB', 'WR', 'TE']);
+const OFF_POS = new Set(['QB', 'RB', 'WR', 'TE', 'OL', 'OT', 'OG', 'C', 'G', 'T', 'K', 'P']);
+const DEF_POS = new Set(['DL', 'DE', 'DT', 'EDGE', 'LB', 'CB', 'S', 'SS', 'FS']);
+
+function normPos(pos) {
+  if (!pos) return '';
+  const p = String(pos).toUpperCase();
+  if (['SS', 'FS'].includes(p)) return 'S';
+  if (['OT', 'OG', 'G', 'T', 'C'].includes(p)) return 'OL';
+  if (p === 'DE') return 'DL';
+  return p;
+}
+
+// ── Scoring helpers ───────────────────────────────────────────────────────────
+
+function sv(totals, keys) {
+  for (const key of keys) {
+    const v = Number(totals?.[key] ?? 0);
+    if (Number.isFinite(v) && v !== 0) return v;
+  }
+  return 0;
+}
+
+function teamWins(row, teamById) {
+  return Number(teamById?.get(Number(row?.teamId))?.wins ?? 0);
+}
+
+function mvpScore(row, teamById) {
+  const t = row?.totals ?? {};
+  const tw = teamWins(row, teamById);
+  const pos = String(row?.pos ?? '').toUpperCase();
+  if (pos === 'QB') {
+    return sv(t, ['passYd', 'passingYards']) / 25
+      + sv(t, ['passTD', 'passingTd']) * 6
+      + sv(t, ['rushYd', 'rushingYards']) / 10
+      + sv(t, ['rushTD', 'rushingTd']) * 6
+      - sv(t, ['passInt', 'interceptionsThrown', 'intsThrown', 'interceptions']) * 3
+      + tw * 1.5;
+  }
+  if (pos === 'RB') {
+    return sv(t, ['rushYd', 'rushingYards']) / 10
+      + sv(t, ['rushTD', 'rushingTd']) * 6
+      + sv(t, ['recYd', 'receivingYards']) / 10
+      + sv(t, ['recTD', 'receivingTd']) * 6
+      + tw * 0.8;
+  }
+  if (['WR', 'TE'].includes(pos)) {
+    return sv(t, ['recYd', 'receivingYards']) / 10
+      + sv(t, ['recTD', 'receivingTd']) * 6
+      + Number(t.receptions ?? 0) * 0.15
+      + tw * 0.6;
+  }
+  return 0;
+}
+
+function offpoyScore(row, teamById) {
+  // Same as MVP score but excludes QBs (non-QB offensive POY)
+  const pos = String(row?.pos ?? '').toUpperCase();
+  if (pos === 'QB') return -1;
+  return mvpScore(row, teamById);
+}
+
+function dpoyScore(row) {
+  const t = row?.totals ?? {};
+  const defInts = (() => {
+    const pos = String(row?.pos ?? '').toUpperCase();
+    const isDefPos = DEF_POS.has(pos);
+    return isDefPos ? sv(t, ['defInterceptions', 'interceptions']) : sv(t, ['defInterceptions']);
+  })();
+  return Number(t.tackles ?? 0) * 1
+    + Number(t.sacks ?? 0) * 5.5
+    + defInts * 6.5
+    + Number(t.forcedFumbles ?? 0) * 4;
+}
+
+function rotyScore(row, teamById) {
+  return mvpScore(row, teamById)
+    + sv(row?.totals ?? {}, ['passYd', 'passingYards']) / 30
+    + sv(row?.totals ?? {}, ['rushYd', 'rushingYards']) / 12
+    + sv(row?.totals ?? {}, ['recYd', 'receivingYards']) / 12;
+}
+
+function allProQBScore(row, teamById) {
+  const t = row?.totals ?? {};
+  return sv(t, ['passYd', 'passingYards']) / 23
+    + sv(t, ['passTD', 'passingTd']) * 5.5
+    + sv(t, ['rushYd', 'rushingYards']) / 12
+    - sv(t, ['passInt', 'interceptionsThrown', 'intsThrown', 'interceptions']) * 3
+    + teamWins(row, teamById) * 0.8;
+}
+
+function allProRBScore(row, teamById) {
+  const t = row?.totals ?? {};
+  return sv(t, ['rushYd', 'rushingYards'])
+    + sv(t, ['rushTD', 'rushingTd']) * 80
+    + sv(t, ['recYd', 'receivingYards']) * 0.4
+    + teamWins(row, teamById) * 3;
+}
+
+function allProWRScore(row, teamById) {
+  const t = row?.totals ?? {};
+  return sv(t, ['recYd', 'receivingYards'])
+    + sv(t, ['recTD', 'receivingTd']) * 90
+    + Number(t.receptions ?? 0) * 3;
+}
+
+function allProTEScore(row, teamById) {
+  const t = row?.totals ?? {};
+  return sv(t, ['recYd', 'receivingYards'])
+    + sv(t, ['recTD', 'receivingTd']) * 85
+    + Number(t.receptions ?? 0) * 2.5;
+}
+
+function allProOLScore(row) {
+  const t = row?.totals ?? {};
+  // TODO: OL lacks individual stats; using OVR as proxy from player object
+  return Number(t.gamesPlayed ?? 0) * 2 + Number(row?.ovr ?? 70);
+}
+
+function allProDLScore(row) {
+  const t = row?.totals ?? {};
+  return Number(t.sacks ?? 0) * 5
+    + Number(t.tacklesForLoss ?? 0) * 2
+    + Number(t.pressures ?? 0) * 0.4
+    + Number(t.forcedFumbles ?? 0) * 3
+    + Number(t.tackles ?? 0) * 0.2;
+}
+
+function allProLBScore(row) {
+  const t = row?.totals ?? {};
+  const defInts = sv(t, ['defInterceptions', 'interceptions']);
+  return Number(t.tackles ?? 0) * 0.8
+    + Number(t.sacks ?? 0) * 5
+    + defInts * 6
+    + Number(t.passesDefended ?? 0) * 2
+    + Number(t.forcedFumbles ?? 0) * 3;
+}
+
+function allProCBScore(row) {
+  const t = row?.totals ?? {};
+  const defInts = sv(t, ['defInterceptions', 'interceptions']);
+  return defInts * 7
+    + Number(t.passesDefended ?? 0) * 2.5
+    + Number(t.tackles ?? 0) * 0.4
+    + Number(t.forcedFumbles ?? 0) * 3;
+}
+
+function allProSScore(row) {
+  const t = row?.totals ?? {};
+  const defInts = sv(t, ['defInterceptions', 'interceptions']);
+  return defInts * 6.5
+    + Number(t.passesDefended ?? 0) * 2
+    + Number(t.tackles ?? 0) * 0.6
+    + Number(t.forcedFumbles ?? 0) * 3;
+}
+
+function allProKScore(row) {
+  const t = row?.totals ?? {};
+  return sv(t, ['fgMade', 'fieldGoalsMade']) * 3
+    + sv(t, ['xpMade', 'extraPointsMade']) * 1;
+}
+
+function allProPScore(row) {
+  const t = row?.totals ?? {};
+  const punts = Number(t.punts ?? 0);
+  return punts > 0 ? (sv(t, ['puntYards', 'puntYd']) / punts) : 0;
+}
+
+// ── Selection helpers ─────────────────────────────────────────────────────────
+
+const MIN_GAMES = 2;
+
+function eligible(rows) {
+  return (rows || []).filter(r => (r?.totals?.gamesPlayed ?? 0) >= MIN_GAMES);
+}
+
+function topByScore(rows, scoreFn) {
+  return [...rows]
+    .map(r => ({ row: r, score: scoreFn(r) }))
+    .filter(item => Number.isFinite(item.score) && item.score > 0)
+    .sort((a, b) => b.score - a.score)[0]?.row ?? null;
+}
+
+function topNByScore(rows, scoreFn, n) {
+  return [...rows]
+    .map(r => ({ row: r, score: scoreFn(r) }))
+    .filter(item => Number.isFinite(item.score) && item.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, n)
+    .map(item => item.row);
+}
+
+function statSnapshotFor(row, type) {
+  const t = row?.totals ?? {};
+  const pos = String(row?.pos ?? '').toUpperCase();
+  const base = { ovr: row?.ovr ?? 0 };
+  if (pos === 'QB') return { ...base, passYd: t.passYd ?? 0, passTD: t.passTD ?? 0, interceptions: t.interceptions ?? 0, gamesPlayed: t.gamesPlayed ?? 0 };
+  if (pos === 'RB') return { ...base, rushYd: t.rushYd ?? 0, rushTD: t.rushTD ?? 0, recYd: t.recYd ?? 0, gamesPlayed: t.gamesPlayed ?? 0 };
+  if (['WR', 'TE'].includes(pos)) return { ...base, recYd: t.recYd ?? 0, recTD: t.recTD ?? 0, receptions: t.receptions ?? 0, gamesPlayed: t.gamesPlayed ?? 0 };
+  if (['DL', 'EDGE', 'DT'].includes(pos)) return { ...base, sacks: t.sacks ?? 0, tackles: t.tackles ?? 0, forcedFumbles: t.forcedFumbles ?? 0, gamesPlayed: t.gamesPlayed ?? 0 };
+  if (['LB', 'CB', 'S'].includes(pos)) return { ...base, tackles: t.tackles ?? 0, interceptions: t.interceptions ?? 0, sacks: t.sacks ?? 0, gamesPlayed: t.gamesPlayed ?? 0 };
+  return { ...base, gamesPlayed: t.gamesPlayed ?? 0 };
+}
+
+function makePlayerAward(type, row, season) {
+  if (!row) return null;
+  return {
+    type,
+    season,
+    week: SEASON_END,
+    playerId: row.playerId,
+    name: row.name ?? '',
+    pos: row.pos ?? '',
+    teamId: row.teamId ?? null,
+    statSnapshot: statSnapshotFor(row, type),
+    dedupeKey: `${type}_${season}`,
+  };
+}
+
+// ── Main: determineSeasonAwards ────────────────────────────────────────────────
+
+/**
+ * Determine all season awards. Pure and deterministic.
+ *
+ * @param {Array} players      — All player objects (for age, careerStats, OVR lookups)
+ * @param {Array} teams        — All team objects with { id, wins, ovr }
+ * @param {number} season      — Season year (e.g. 2025)
+ * @param {Object} context     — { stats: populatedStats, coaches: [{teamId, name}], championTeamId }
+ * @returns {{ playerAwards, franchiseAwards, allProTeam }}
+ */
+export function determineSeasonAwards(players, teams, season, context) {
+  const stats = Array.isArray(context?.stats) ? context.stats : [];
+  const coaches = Array.isArray(context?.coaches) ? context.coaches : [];
+  const championTeamId = context?.championTeamId ?? null;
+
+  const teamById = new Map((teams || []).map(t => [Number(t.id), t]));
+  const playerById = new Map((players || []).filter(p => p?.id != null).map(p => [String(p.id), p]));
+
+  const rows = eligible(stats.filter(s => s?.totals));
+
+  const offRows = rows.filter(r => {
+    const p = String(r?.pos ?? '').toUpperCase();
+    return OFF_SKILL_POS.has(p);
+  });
+  const defRows = rows.filter(r => DEF_POS.has(String(r?.pos ?? '').toUpperCase()));
+
+  const isRookie = (row) => {
+    const p = playerById.get(String(row?.playerId));
+    return p?.year != null && Number(p.year) === Number(season);
+  };
+
+  // ── Individual season awards ──────────────────────────────────────────────
+
+  const mvpWinner = topByScore(offRows, r => mvpScore(r, teamById));
+
+  const offpoyWinner = topByScore(
+    offRows.filter(r => String(r?.pos ?? '').toUpperCase() !== 'QB'),
+    r => offpoyScore(r, teamById),
+  );
+
+  const dpoyWinner = topByScore(defRows, dpoyScore);
+
+  const rookieRows = rows.filter(isRookie);
+  const rotyWinner = topByScore(rookieRows, r => rotyScore(r, teamById));
+
+  // COMEBACK_PLAYER: age 28+, biggest positive OVR delta from previous season careerStats
+  const comebackWinner = (() => {
+    const candidates = offRows.filter(r => {
+      const p = playerById.get(String(r?.playerId));
+      return p != null && Number(p?.age ?? 0) >= 28;
+    });
+    if (!candidates.length) return null;
+    return topByScore(candidates, (r) => {
+      const p = playerById.get(String(r?.playerId));
+      const cs = Array.isArray(p?.careerStats) ? p.careerStats : [];
+      if (cs.length < 2) return 0;
+      const curr = Number(cs[cs.length - 1]?.ovr ?? 0);
+      const prev = Number(cs[cs.length - 2]?.ovr ?? 0);
+      const delta = curr - prev;
+      return delta > 0 ? delta : 0;
+    });
+  })();
+
+  // COACH_OF_YEAR: win-count overperformance vs pre-season OVR baseline
+  // TODO: store preseason team OVR at season start for more accurate baseline
+  const coachTeam = (() => {
+    const sorted = [...(teams || [])]
+      .map(t => {
+        const expectedWins = Math.round(((t.ovr ?? 70) - 70) / 5 + 8.5);
+        return { team: t, overperform: (t.wins ?? 0) - expectedWins };
+      })
+      .filter(item => item.overperform > 0)
+      .sort((a, b) => b.overperform - a.overperform);
+    return sorted[0]?.team ?? null;
+  })();
+
+  // ── Build playerAwards list ────────────────────────────────────────────────
+
+  const playerAwards = [];
+  const push = (type, row) => {
+    const entry = makePlayerAward(type, row, season);
+    if (entry) playerAwards.push(entry);
+  };
+
+  push(AWARD_TYPES.MVP, mvpWinner);
+  push(AWARD_TYPES.OFFENSIVE_POY, offpoyWinner);
+  push(AWARD_TYPES.DEFENSIVE_POY, dpoyWinner);
+  push(AWARD_TYPES.ROOKIE_OF_YEAR, rotyWinner);
+  push(AWARD_TYPES.COMEBACK_PLAYER, comebackWinner);
+
+  // ── Franchise awards ──────────────────────────────────────────────────────
+
+  const franchiseAwards = [];
+
+  if (coachTeam != null) {
+    const coachRow = coaches.find(c => Number(c.teamId) === Number(coachTeam.id));
+    franchiseAwards.push({
+      type: AWARD_TYPES.COACH_OF_YEAR,
+      season,
+      teamId: coachTeam.id,
+      coachName: coachRow?.name ?? null,
+    });
+  }
+
+  if (championTeamId != null) {
+    franchiseAwards.push({
+      type: AWARD_TYPES.LEAGUE_CHAMPION,
+      season,
+      teamId: championTeamId,
+      coachName: null,
+    });
+  }
+
+  // ── All-Pro team ──────────────────────────────────────────────────────────
+
+  const allProTeam = [];
+
+  const allProEntry = (type, row) => {
+    const entry = makePlayerAward(type, row, season);
+    if (entry) {
+      entry.dedupeKey = `${type}_${season}`;
+      allProTeam.push(entry);
+    }
+  };
+
+  const qbRows = rows.filter(r => String(r?.pos ?? '').toUpperCase() === 'QB');
+  const rbRows = rows.filter(r => String(r?.pos ?? '').toUpperCase() === 'RB');
+  const wrRows = rows.filter(r => String(r?.pos ?? '').toUpperCase() === 'WR');
+  const teRows = rows.filter(r => String(r?.pos ?? '').toUpperCase() === 'TE');
+  const olRows = rows.filter(r => {
+    const p = String(r?.pos ?? '').toUpperCase();
+    return ['OL', 'OT', 'OG', 'C', 'G', 'T'].includes(p);
+  });
+  const dlRows = rows.filter(r => {
+    const p = String(r?.pos ?? '').toUpperCase();
+    return ['DL', 'DE', 'DT', 'EDGE'].includes(p);
+  });
+  const lbRows = rows.filter(r => String(r?.pos ?? '').toUpperCase() === 'LB');
+  const cbRows = rows.filter(r => String(r?.pos ?? '').toUpperCase() === 'CB');
+  const sRows = rows.filter(r => ['S', 'SS', 'FS'].includes(String(r?.pos ?? '').toUpperCase()));
+  const kRows = rows.filter(r => String(r?.pos ?? '').toUpperCase() === 'K');
+  const pRows = rows.filter(r => String(r?.pos ?? '').toUpperCase() === 'P');
+
+  // 1 QB
+  allProEntry(AWARD_TYPES.ALL_PRO_QB, topByScore(qbRows, r => allProQBScore(r, teamById)));
+
+  // 1 RB
+  allProEntry(AWARD_TYPES.ALL_PRO_RB, topByScore(rbRows, r => allProRBScore(r, teamById)));
+
+  // 2 WR — dedupe by playerId
+  const seenWR = new Set();
+  for (const row of topNByScore(wrRows, r => allProWRScore(r, teamById), 2)) {
+    if (!seenWR.has(row.playerId)) {
+      seenWR.add(row.playerId);
+      allProEntry(AWARD_TYPES.ALL_PRO_WR, row);
+    }
+  }
+
+  // 1 TE
+  allProEntry(AWARD_TYPES.ALL_PRO_TE, topByScore(teRows, allProTEScore));
+
+  // 2 OL — dedupe
+  const seenOL = new Set();
+  for (const row of topNByScore(olRows, allProOLScore, 2)) {
+    if (!seenOL.has(row.playerId)) {
+      seenOL.add(row.playerId);
+      // Each OL entry needs a unique dedupeKey since there are 2 slots
+      const entry = makePlayerAward(AWARD_TYPES.ALL_PRO_OL, row, season);
+      if (entry) {
+        entry.dedupeKey = `${AWARD_TYPES.ALL_PRO_OL}_${season}_${row.playerId}`;
+        allProTeam.push(entry);
+      }
+    }
+  }
+
+  // 2 DL — dedupe
+  const seenDL = new Set();
+  for (const row of topNByScore(dlRows, allProDLScore, 2)) {
+    if (!seenDL.has(row.playerId)) {
+      seenDL.add(row.playerId);
+      const entry = makePlayerAward(AWARD_TYPES.ALL_PRO_DL, row, season);
+      if (entry) {
+        entry.dedupeKey = `${AWARD_TYPES.ALL_PRO_DL}_${season}_${row.playerId}`;
+        allProTeam.push(entry);
+      }
+    }
+  }
+
+  // 2 LB — dedupe
+  const seenLB = new Set();
+  for (const row of topNByScore(lbRows, allProLBScore, 2)) {
+    if (!seenLB.has(row.playerId)) {
+      seenLB.add(row.playerId);
+      const entry = makePlayerAward(AWARD_TYPES.ALL_PRO_LB, row, season);
+      if (entry) {
+        entry.dedupeKey = `${AWARD_TYPES.ALL_PRO_LB}_${season}_${row.playerId}`;
+        allProTeam.push(entry);
+      }
+    }
+  }
+
+  // 2 CB — dedupe
+  const seenCB = new Set();
+  for (const row of topNByScore(cbRows, allProCBScore, 2)) {
+    if (!seenCB.has(row.playerId)) {
+      seenCB.add(row.playerId);
+      const entry = makePlayerAward(AWARD_TYPES.ALL_PRO_CB, row, season);
+      if (entry) {
+        entry.dedupeKey = `${AWARD_TYPES.ALL_PRO_CB}_${season}_${row.playerId}`;
+        allProTeam.push(entry);
+      }
+    }
+  }
+
+  // 1 S
+  allProEntry(AWARD_TYPES.ALL_PRO_S, topByScore(sRows, allProSScore));
+
+  // 1 K
+  allProEntry(AWARD_TYPES.ALL_PRO_K, topByScore(kRows, allProKScore));
+
+  // 1 P
+  allProEntry(AWARD_TYPES.ALL_PRO_P, topByScore(pRows, allProPScore));
+
+  return { playerAwards, franchiseAwards, allProTeam };
+}
+
+// ── applySeasonAwards ─────────────────────────────────────────────────────────
+
+/**
+ * Pure function: merges new award entries into player.awards and meta.franchiseAwards.
+ * Deduplicates by dedupeKey.
+ *
+ * @param {Map} playerMap           — Map<playerId (string), playerObject>
+ * @param {Object} currentMeta      — Current meta object (reads franchiseAwards)
+ * @param {Object} awardResults     — Output of determineSeasonAwards
+ * @returns {{ playerUpdates: Map<string, {awards:[...]}>, updatedFranchiseAwards: [...] }}
+ */
+export function applySeasonAwards(playerMap, currentMeta, awardResults) {
+  const { playerAwards = [], franchiseAwards = [], allProTeam = [] } = awardResults;
+  const allPlayerAwards = [...playerAwards, ...allProTeam];
+
+  const playerUpdates = new Map();
+
+  for (const award of allPlayerAwards) {
+    if (award?.playerId == null) continue;
+    const pidStr = String(award.playerId);
+    const player = playerMap.get(pidStr) ?? playerMap.get(Number(award.playerId));
+    if (!player) continue;
+
+    const existingAwards = Array.isArray(player.awards) ? player.awards : [];
+    if (existingAwards.some(a => a.dedupeKey === award.dedupeKey)) continue;
+
+    const pending = playerUpdates.get(pidStr);
+    const base = pending?.awards ?? existingAwards;
+    playerUpdates.set(pidStr, { awards: [...base, award] });
+  }
+
+  const existingFranchiseAwards = Array.isArray(currentMeta?.franchiseAwards) ? currentMeta.franchiseAwards : [];
+  const seenKeys = new Set(existingFranchiseAwards.map(a => `${a.type}_${a.season}`));
+  const newFranchiseAwards = [];
+  for (const fa of franchiseAwards) {
+    const key = `${fa.type}_${fa.season}`;
+    if (seenKeys.has(key)) continue;
+    seenKeys.add(key);
+    newFranchiseAwards.push(fa);
+  }
+
+  return {
+    playerUpdates,
+    updatedFranchiseAwards: [...existingFranchiseAwards, ...newFranchiseAwards],
+  };
+}
+
+// ── getPlayerAwardSummary ──────────────────────────────────────────────────────
+
+/**
+ * Build a compact summary of a player's career awards from player.awards.
+ * Safe for players with no awards field.
+ */
+export function getPlayerAwardSummary(player) {
+  const awards = Array.isArray(player?.awards) ? player.awards : [];
+  const mvpCount = awards.filter(a => a.type === AWARD_TYPES.MVP).length;
+  const allProCount = awards.filter(a => a.type.startsWith('ALL_PRO_')).length;
+  const championshipCount = awards.filter(a => a.type === AWARD_TYPES.LEAGUE_CHAMPION).length;
+
+  const sortedForHighlights = [...awards].sort((a, b) => (b.season ?? 0) - (a.season ?? 0));
+  const highlights = sortedForHighlights.slice(0, 5).map(a => ({
+    label: AWARD_LABELS[a.type] ?? a.type,
+    season: a.season,
+    teamId: a.teamId,
+    dedupeKey: a.dedupeKey,
+  }));
+
+  // Compact summary line, e.g. "2× All-Pro · 1× MVP · 1× Champion"
+  const parts = [];
+  if (mvpCount > 0) parts.push(`${mvpCount > 1 ? `${mvpCount}× ` : ''}MVP`);
+  if (allProCount > 0) parts.push(`${allProCount > 1 ? `${allProCount}× ` : ''}All-Pro`);
+  if (championshipCount > 0) parts.push(`${championshipCount > 1 ? `${championshipCount}× ` : ''}Champion`);
+
+  const otherTypes = [AWARD_TYPES.OFFENSIVE_POY, AWARD_TYPES.DEFENSIVE_POY, AWARD_TYPES.ROOKIE_OF_YEAR, AWARD_TYPES.COMEBACK_PLAYER];
+  for (const type of otherTypes) {
+    const cnt = awards.filter(a => a.type === type).length;
+    if (cnt > 0) {
+      const short = AWARD_LABELS[type]?.split(' ').map(w => w[0]).join('') ?? type;
+      parts.push(`${cnt > 1 ? `${cnt}× ` : ''}${short}`);
+    }
+  }
+
+  return {
+    totalAwards: awards.length,
+    mvpCount,
+    allProCount,
+    championshipCount,
+    highlights,
+    summaryLine: parts.join(' · ') || null,
+  };
+}
+
+// ── checkCareerMilestones ─────────────────────────────────────────────────────
+
+/**
+ * Check if a player crossed a career milestone this season.
+ * Returns the first milestone crossed, or null.
+ *
+ * Safe for players with no careerStats.
+ */
+export function checkCareerMilestones(player, season) {
+  if (!player) return null;
+  const careerStats = Array.isArray(player.careerStats) ? player.careerStats : [];
+  if (!careerStats.length) return null;
+
+  const pos = String(player?.pos ?? '').toUpperCase();
+
+  // 300 career TDs — QB/WR/TE/RB
+  if (['QB', 'WR', 'TE', 'RB'].includes(pos)) {
+    let total = 0;
+    let prevTotal = 0;
+    for (let i = 0; i < careerStats.length; i++) {
+      const s = careerStats[i];
+      const tds = (s.passTDs ?? s.passTD ?? 0)
+        + (s.rushTDs ?? s.rushTD ?? 0)
+        + (s.recTDs ?? s.recTD ?? 0);
+      if (i < careerStats.length - 1) prevTotal += tds;
+      total += tds;
+    }
+    if (prevTotal < 300 && total >= 300) {
+      return {
+        type: CAREER_MILESTONE_TYPES.TD_300,
+        playerId: player.id,
+        name: player.name,
+        pos,
+        season,
+        totalTDs: total,
+      };
+    }
+  }
+
+  // HOF eligibility: age 35+, retired, OVR 85+ or 3+ MVP/DPOY in player.awards
+  const age = Number(player?.age ?? 0);
+  const ovr = Number(player?.ovr ?? 0);
+  const isRetired = player?.status === 'retired';
+  const awardsArr = Array.isArray(player?.awards) ? player.awards : [];
+  const mvpCount = awardsArr.filter(a => a.type === AWARD_TYPES.MVP).length;
+  const dpoyCount = awardsArr.filter(a => a.type === AWARD_TYPES.DEFENSIVE_POY).length;
+
+  if (isRetired && age >= 35 && (ovr >= 85 || mvpCount + dpoyCount >= 3)) {
+    return {
+      type: CAREER_MILESTONE_TYPES.HOF_ELIGIBLE,
+      playerId: player.id,
+      name: player.name,
+      pos,
+      season,
+      ovr,
+      mvpCount,
+    };
+  }
+
+  return null;
+}

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -755,6 +755,80 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
         </SectionCard>
       </details>
 
+      {/* ── Trophy Case ── */}
+      {(() => {
+        const userTeamId = Number(league?.userTeamId);
+        const franchiseAwards = Array.isArray(league?.franchiseAwards) ? league.franchiseAwards : [];
+        const leagueHistory = Array.isArray(league?.leagueHistory) ? league.leagueHistory : [];
+        const teams = Array.isArray(league?.teams) ? league.teams : [];
+        const teamAbbrById = new Map(teams.map(t => [Number(t.id), t.abbr ?? t.name]));
+
+        // Championships from franchiseAwards
+        const championships = franchiseAwards
+          .filter(a => a.type === 'LEAGUE_CHAMPION' && Number(a.teamId) === userTeamId)
+          .sort((a, b) => (b.season ?? 0) - (a.season ?? 0));
+
+        // Coach of Year from franchiseAwards
+        const coachAwards = franchiseAwards
+          .filter(a => a.type === 'COACH_OF_YEAR' && Number(a.teamId) === userTeamId)
+          .sort((a, b) => (b.season ?? 0) - (a.season ?? 0));
+
+        // Individual awards from leagueHistory for players on user team
+        const indAwards = [];
+        for (const s of leagueHistory) {
+          const yr = s.year ?? s.seasonId;
+          const aw = s.awards ?? {};
+          for (const [key, val] of Object.entries(aw)) {
+            if (!val?.playerId || !val?.teamId) continue;
+            if (Number(val.teamId) !== userTeamId) continue;
+            if (['mvp', 'opoy', 'dpoy', 'roty'].includes(key)) {
+              indAwards.push({ year: yr, key, name: val.name, pos: val.pos });
+            }
+          }
+        }
+        indAwards.sort((a, b) => (b.year ?? 0) - (a.year ?? 0));
+
+        if (championships.length === 0 && coachAwards.length === 0 && indAwards.length === 0) return null;
+
+        const LABELS = { mvp: 'MVP', opoy: 'OPOY', dpoy: 'DPOY', roty: 'ROTY' };
+
+        return (
+          <SectionCard
+            title="Trophy Case"
+            subtitle="Championship seasons and major franchise honors."
+            variant="compact"
+            data-testid="hq-trophy-case"
+          >
+            <details className="app-hq-background-section__inner">
+              <summary className="app-hq-section-expand">Show trophy case ▾</summary>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6, paddingTop: 8, maxHeight: 280, overflowY: 'auto' }}>
+                {championships.map(c => (
+                  <div key={`champ-${c.season}`} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 0', borderBottom: '1px solid var(--hairline)' }}>
+                    <span style={{ fontSize: '1.1rem' }}>🏆</span>
+                    <span style={{ fontWeight: 700, color: 'var(--warning)' }}>{c.season}</span>
+                    <span style={{ color: 'var(--text)', fontSize: 'var(--text-xs)' }}>League Champions</span>
+                  </div>
+                ))}
+                {coachAwards.map(c => (
+                  <div key={`coy-${c.season}`} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 0', borderBottom: '1px solid var(--hairline)' }}>
+                    <span style={{ fontSize: '1.1rem' }}>🎖️</span>
+                    <span style={{ fontWeight: 700, color: 'var(--accent)' }}>{c.season}</span>
+                    <span style={{ color: 'var(--text)', fontSize: 'var(--text-xs)' }}>Coach of the Year{c.coachName ? ` — ${c.coachName}` : ''}</span>
+                  </div>
+                ))}
+                {indAwards.slice(0, 10).map((a, i) => (
+                  <div key={`ind-${i}`} style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 0', borderBottom: '1px solid var(--hairline)' }}>
+                    <span style={{ fontSize: '1.1rem' }}>🥇</span>
+                    <span style={{ fontWeight: 700, color: 'var(--accent)' }}>{a.year}</span>
+                    <span style={{ color: 'var(--text)', fontSize: 'var(--text-xs)' }}>{a.pos} {a.name} — {LABELS[a.key] ?? a.key}</span>
+                  </div>
+                ))}
+              </div>
+            </details>
+          </SectionCard>
+        );
+      })()}
+
       {lineupToast ? <p className="app-inline-toast" role="status" aria-live="polite">{lineupToast}</p> : null}
 
       {showGate ? (

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -982,7 +982,61 @@ export default function LeagueDashboard({
             />
           </TabErrorBoundary>
         )}
-                {activeTab === "League Pulse" && (
+        {activeTab === "League" && (() => {
+          const phase = league?.phase ?? 'regular';
+          const isPostSeason = !['regular', 'preseason', 'playoffs'].includes(phase);
+          if (!isPostSeason) return null;
+          const leagueHistory = Array.isArray(league?.leagueHistory) ? league.leagueHistory : [];
+          const lastSeason = leagueHistory[leagueHistory.length - 1];
+          if (!lastSeason?.awards) return null;
+          const aw = lastSeason.awards;
+          const teams = Array.isArray(league?.teams) ? league.teams : [];
+          const teamAbbrById = new Map(teams.map(t => [Number(t.id), t.abbr ?? t.name]));
+          const AWARD_ROW_DEFS = [
+            { key: 'mvp', label: 'MVP' },
+            { key: 'opoy', label: 'OPOY' },
+            { key: 'dpoy', label: 'DPOY' },
+            { key: 'roty', label: 'ROTY' },
+            { key: 'coachOfTheYear', label: 'Coach of Year', nameField: 'coachName' },
+          ];
+          const rows = AWARD_ROW_DEFS
+            .map(({ key, label, nameField }) => {
+              const entry = aw[key];
+              if (!entry) return null;
+              const name = nameField ? entry[nameField] : entry.name;
+              if (!name && !entry.playerId) return null;
+              const teamAbbr = teamAbbrById.get(Number(entry.teamId)) ?? null;
+              return { label, name, pos: entry.pos, teamAbbr };
+            })
+            .filter(Boolean);
+          if (!rows.length) return null;
+          return (
+            <div
+              data-testid="season-awards-panel"
+              style={{
+                margin: '0 0 var(--space-4)',
+                padding: 'var(--space-3) var(--space-4)',
+                borderRadius: 'var(--radius-md)',
+                border: '1px solid var(--hairline)',
+                background: 'var(--surface-strong)',
+              }}
+            >
+              <div style={{ fontWeight: 700, fontSize: 'var(--text-sm)', color: 'var(--warning)', marginBottom: 8 }}>
+                {lastSeason.year} Season Awards
+              </div>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))', gap: 6 }}>
+                {rows.map(r => (
+                  <div key={r.label} style={{ fontSize: 'var(--text-xs)' }}>
+                    <span style={{ color: 'var(--text-muted)', fontWeight: 700 }}>{r.label} </span>
+                    <span style={{ color: 'var(--text)' }}>{r.pos ? `${r.pos} ` : ''}{r.name}</span>
+                    {r.teamAbbr ? <span style={{ color: 'var(--text-muted)' }}> · {r.teamAbbr}</span> : null}
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })()}
+        {activeTab === "League Pulse" && (
           <LeaguePulseTimeline
             league={league}
             currentTeamId={league?.userTeamId}

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -38,6 +38,7 @@ import { buildProspectScoutingReport } from "../../core/scoutingModel.js";
 import { buildPlayerCareerTimeline } from "../utils/playerCareerTimeline.js";
 import { buildPlayerAdvancedStatsView } from "../utils/playerAdvancedStatsViewModel.js";
 import { getPlayerMoraleSummary } from "../../core/mood/playerMoraleEngine.js";
+import { getPlayerAwardSummary, AWARD_LABELS, AWARD_TYPES } from "../../core/awards/awardEngine.js";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
@@ -1353,6 +1354,55 @@ export default function PlayerProfile({
                           · {moraleSummary.topEvent.reason}
                         </span>
                       )}
+                    </div>
+                  );
+                })()}
+
+                {/* ── Career Awards Trophy Shelf ── */}
+                {playerView && (() => {
+                  const awardSummary = getPlayerAwardSummary(playerView);
+                  if (awardSummary.totalAwards === 0) return null;
+                  const teams = data?.teams ?? [];
+                  const teamAbbrById = new Map(teams.map(t => [String(t.id), t.abbr ?? t.name]));
+                  return (
+                    <div
+                      data-testid="player-profile-career-awards"
+                      style={{
+                        marginTop: 'var(--space-2)',
+                        padding: 'var(--space-3)',
+                        borderRadius: 'var(--radius-md)',
+                        border: '1px solid var(--hairline)',
+                        background: 'var(--surface-strong)',
+                        fontSize: 'var(--text-xs)',
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, textTransform: 'uppercase', letterSpacing: '.07em', color: 'var(--text-muted)', marginBottom: 6 }}>
+                        Career Awards
+                      </div>
+                      {awardSummary.summaryLine && (
+                        <div
+                          data-testid="player-profile-award-summary"
+                          style={{ fontWeight: 700, color: 'var(--warning)', fontSize: 'var(--text-sm)', marginBottom: 6 }}
+                        >
+                          {awardSummary.summaryLine}
+                        </div>
+                      )}
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+                        {awardSummary.highlights.map((h) => (
+                          <div key={h.dedupeKey} style={{ display: 'flex', gap: 8, alignItems: 'baseline' }}>
+                            <span style={{ color: 'var(--text-subtle)', minWidth: 36 }}>{h.season}</span>
+                            <span style={{ color: 'var(--text)' }}>{h.label}</span>
+                            {h.teamId != null && (
+                              <span style={{ color: 'var(--text-muted)' }}>· {teamAbbrById.get(String(h.teamId)) ?? h.teamId}</span>
+                            )}
+                          </div>
+                        ))}
+                        {awardSummary.totalAwards > awardSummary.highlights.length && (
+                          <div style={{ color: 'var(--text-muted)', fontStyle: 'italic' }}>
+                            +{awardSummary.totalAwards - awardSummary.highlights.length} more awards
+                          </div>
+                        )}
+                      </div>
                     </div>
                   );
                 })()}

--- a/src/ui/components/PlayerProfileAwards.test.jsx
+++ b/src/ui/components/PlayerProfileAwards.test.jsx
@@ -1,0 +1,172 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { AWARD_TYPES } from '../../core/awards/awardEngine.js';
+
+// Minimal PlayerProfile stub — we test only the Career Awards shelf block
+// by importing the summary helper directly and testing its rendering contract.
+import { getPlayerAwardSummary } from '../../core/awards/awardEngine.js';
+
+afterEach(cleanup);
+
+function AwardShelf({ player, teams = [] }) {
+  const awardSummary = getPlayerAwardSummary(player);
+  if (awardSummary.totalAwards === 0) return <div data-testid="no-awards" />;
+  const teamAbbrById = new Map((teams ?? []).map(t => [String(t.id), t.abbr]));
+  return (
+    <div data-testid="player-profile-career-awards">
+      {awardSummary.summaryLine && (
+        <div data-testid="player-profile-award-summary">{awardSummary.summaryLine}</div>
+      )}
+      {awardSummary.highlights.map(h => (
+        <div key={h.dedupeKey} data-testid={`award-row-${h.dedupeKey}`}>
+          {h.season} {h.label}
+          {h.teamId != null && <span> · {teamAbbrById.get(String(h.teamId)) ?? h.teamId}</span>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+describe('PlayerProfile career trophy shelf', () => {
+  it('renders award summary when player has awards', () => {
+    const player = {
+      awards: [
+        { type: AWARD_TYPES.MVP, season: 2025, dedupeKey: 'MVP_2025', teamId: 1 },
+        { type: AWARD_TYPES.ALL_PRO_QB, season: 2025, dedupeKey: 'ALL_PRO_QB_2025', teamId: 1 },
+        { type: AWARD_TYPES.LEAGUE_CHAMPION, season: 2025, dedupeKey: 'LEAGUE_CHAMPION_2025', teamId: 1 },
+      ],
+    };
+    const teams = [{ id: 1, abbr: 'KC' }];
+    render(<AwardShelf player={player} teams={teams} />);
+    expect(screen.getByTestId('player-profile-career-awards')).toBeTruthy();
+    expect(screen.getByTestId('player-profile-award-summary').textContent).toContain('MVP');
+    expect(screen.getByTestId('player-profile-award-summary').textContent).toContain('Champion');
+  });
+
+  it('renders nothing meaningful when player has no awards', () => {
+    const player = { id: 1, name: 'No Awards', awards: [] };
+    render(<AwardShelf player={player} />);
+    expect(screen.getByTestId('no-awards')).toBeTruthy();
+    expect(screen.queryByTestId('player-profile-career-awards')).toBeNull();
+  });
+
+  it('renders nothing when player.awards field is absent', () => {
+    const player = { id: 1, name: 'Legacy Player' };
+    render(<AwardShelf player={player} />);
+    expect(screen.getByTestId('no-awards')).toBeTruthy();
+  });
+
+  it('shows team abbreviation next to award', () => {
+    const player = {
+      awards: [
+        { type: AWARD_TYPES.MVP, season: 2025, dedupeKey: 'MVP_2025', teamId: 5 },
+      ],
+    };
+    const teams = [{ id: 5, abbr: 'PHI' }];
+    render(<AwardShelf player={player} teams={teams} />);
+    expect(screen.getByTestId('player-profile-career-awards').textContent).toContain('PHI');
+  });
+});
+
+// ── FranchiseHQ Trophy Case ───────────────────────────────────────────────────
+
+function TrophyCase({ league }) {
+  const userTeamId = Number(league?.userTeamId);
+  const franchiseAwards = Array.isArray(league?.franchiseAwards) ? league.franchiseAwards : [];
+  const championships = franchiseAwards.filter(a => a.type === AWARD_TYPES.LEAGUE_CHAMPION && Number(a.teamId) === userTeamId);
+  if (!championships.length) return <div data-testid="no-trophies" />;
+  return (
+    <div data-testid="hq-trophy-case">
+      {championships.map(c => (
+        <div key={`champ-${c.season}`} data-testid={`trophy-champ-${c.season}`}>
+          {c.season} League Champions
+        </div>
+      ))}
+    </div>
+  );
+}
+
+describe('FranchiseHQ trophy case', () => {
+  it('renders championship entry when franchise has won', () => {
+    const league = {
+      userTeamId: 1,
+      franchiseAwards: [
+        { type: AWARD_TYPES.LEAGUE_CHAMPION, season: 2025, teamId: 1 },
+      ],
+    };
+    render(<TrophyCase league={league} />);
+    expect(screen.getByTestId('hq-trophy-case')).toBeTruthy();
+    expect(screen.getByTestId('trophy-champ-2025')).toBeTruthy();
+  });
+
+  it('renders empty when no championships', () => {
+    const league = { userTeamId: 1, franchiseAwards: [] };
+    render(<TrophyCase league={league} />);
+    expect(screen.getByTestId('no-trophies')).toBeTruthy();
+    expect(screen.queryByTestId('hq-trophy-case')).toBeNull();
+  });
+
+  it('does not show championships from other teams', () => {
+    const league = {
+      userTeamId: 1,
+      franchiseAwards: [
+        { type: AWARD_TYPES.LEAGUE_CHAMPION, season: 2025, teamId: 2 },
+      ],
+    };
+    render(<TrophyCase league={league} />);
+    expect(screen.getByTestId('no-trophies')).toBeTruthy();
+    expect(screen.queryByTestId('hq-trophy-case')).toBeNull();
+  });
+});
+
+// ── Season Awards Panel ───────────────────────────────────────────────────────
+
+function SeasonAwardsPanel({ league }) {
+  const phase = league?.phase ?? 'regular';
+  const isPostSeason = !['regular', 'preseason', 'playoffs'].includes(phase);
+  if (!isPostSeason) return <div data-testid="season-awards-hidden" />;
+  const leagueHistory = Array.isArray(league?.leagueHistory) ? league.leagueHistory : [];
+  const lastSeason = leagueHistory[leagueHistory.length - 1];
+  if (!lastSeason?.awards) return <div data-testid="season-awards-empty" />;
+  const aw = lastSeason.awards;
+  const mvp = aw.mvp;
+  return (
+    <div data-testid="season-awards-panel">
+      {mvp && <div data-testid="season-awards-mvp">{mvp.name} — MVP</div>}
+    </div>
+  );
+}
+
+describe('LeagueDashboard Season Awards panel', () => {
+  it('shows after season end phase', () => {
+    const league = {
+      phase: 'offseason_resign',
+      leagueHistory: [{ year: 2025, awards: { mvp: { playerId: 1, name: 'QB Star', teamId: 1, pos: 'QB' } } }],
+    };
+    render(<SeasonAwardsPanel league={league} />);
+    expect(screen.getByTestId('season-awards-panel')).toBeTruthy();
+    expect(screen.getByTestId('season-awards-mvp').textContent).toContain('QB Star');
+  });
+
+  it('is hidden during active regular season', () => {
+    const league = { phase: 'regular', leagueHistory: [] };
+    render(<SeasonAwardsPanel league={league} />);
+    expect(screen.getByTestId('season-awards-hidden')).toBeTruthy();
+    expect(screen.queryByTestId('season-awards-panel')).toBeNull();
+  });
+
+  it('is hidden during playoffs', () => {
+    const league = { phase: 'playoffs', leagueHistory: [] };
+    render(<SeasonAwardsPanel league={league} />);
+    expect(screen.getByTestId('season-awards-hidden')).toBeTruthy();
+  });
+
+  it('shows empty when no award history', () => {
+    const league = { phase: 'draft', leagueHistory: [] };
+    render(<SeasonAwardsPanel league={league} />);
+    expect(screen.getByTestId('season-awards-empty')).toBeTruthy();
+    expect(screen.queryByTestId('season-awards-panel')).toBeNull();
+  });
+});

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -131,6 +131,7 @@ import AiLogic from '../core/ai-logic.js';
 import NewsEngine, { createNewsItem, addNewsItem } from '../core/news-engine.js';
 import { parseWeeklyHeadlines } from '../core/history/NewsEngine.ts';
 import { calculateAwardRaces, selectProBowlers } from '../core/awards-logic.js';
+import { determineSeasonAwards, applySeasonAwards, checkCareerMilestones, AWARD_TYPES as ENGINE_AWARD_TYPES, AWARD_LABELS as ENGINE_AWARD_LABELS } from '../core/awards/awardEngine.js';
 import { Constants } from '../core/constants.js';
 import { processPlayerProgression } from '../core/progression-logic.js';
 import { getZeroStats as getZeroSeasonStatsSchema } from '../core/state.js';
@@ -1029,6 +1030,7 @@ function buildViewState() {
     playerSeasonStatsArchive: meta?.playerSeasonStatsArchive ?? {},
     teamCulture: meta?.teamCulture ?? {},
     leagueHistory: Array.isArray(meta?.leagueHistory) ? meta.leagueHistory.slice(-60) : [],
+    franchiseAwards: Array.isArray(meta?.franchiseAwards) ? meta.franchiseAwards : [],
     franchiseChronicle: Array.isArray(meta?.franchiseChronicle) ? meta.franchiseChronicle.slice(-340) : [],
     franchiseSeasonReviews: Array.isArray(meta?.franchiseSeasonReviews) ? meta.franchiseSeasonReviews.slice(-40) : [],
     seasonStorylines: Array.isArray(meta?.seasonStorylines) ? meta.seasonStorylines : [],
@@ -10215,6 +10217,136 @@ async function archiveSeason(seasonId) {
 
     // Flush accolade writes to DB
     await flushDirty();
+
+    // ── Awards Engine V1: structured player.awards + meta.franchiseAwards ────
+    try {
+      const allPlayersForAwards = cache.getAllPlayers();
+      const awardResults = determineSeasonAwards(allPlayersForAwards, teams, year, {
+        stats: populatedStats,
+        coaches: staffRows,
+        championTeamId: championId,
+      });
+
+      const playerMapForAwards = new Map(allPlayersForAwards.map(p => [String(p.id), p]));
+      const currentMeta = cache.getMeta();
+      const applyResult = applySeasonAwards(playerMapForAwards, currentMeta, awardResults);
+
+      for (const [pidStr, updates] of applyResult.playerUpdates) {
+        cache.updatePlayer(pidStr, updates);
+      }
+      cache.setMeta({ franchiseAwards: applyResult.updatedFranchiseAwards });
+
+      // Emit news items for individual season award winners
+      const newsAwardPairs = [
+        [ENGINE_AWARD_TYPES.MVP, 'MVP'],
+        [ENGINE_AWARD_TYPES.OFFENSIVE_POY, 'Offensive Player of the Year'],
+        [ENGINE_AWARD_TYPES.DEFENSIVE_POY, 'Defensive Player of the Year'],
+        [ENGINE_AWARD_TYPES.ROOKIE_OF_YEAR, 'Rookie of the Year'],
+        [ENGINE_AWARD_TYPES.COMEBACK_PLAYER, 'Comeback Player of the Year'],
+      ];
+      for (const [type, label] of newsAwardPairs) {
+        const winner = awardResults.playerAwards.find(a => a.type === type);
+        if (!winner) continue;
+        const wTeam = cache.getTeam(winner.teamId);
+        await NewsEngine.logNews(
+          'AWARD',
+          `AWARD: ${winner.pos} ${winner.name} (${wTeam?.abbr ?? 'FA'}) wins the ${label}.`,
+          winner.teamId,
+          { category: 'season_award', awardType: type, playerId: winner.playerId, dedupeKey: `news_${winner.dedupeKey}` },
+        );
+      }
+
+      // Emit news item for All-Pro team
+      if (awardResults.allProTeam.length > 0) {
+        const names = awardResults.allProTeam.slice(0, 4).map(a => a.name).filter(Boolean).join(', ');
+        await NewsEngine.logNews(
+          'AWARD',
+          `First Team All-Pro announced: ${names}${awardResults.allProTeam.length > 4 ? ` and ${awardResults.allProTeam.length - 4} more` : ''}.`,
+          null,
+          { category: 'all_pro_team', season: year, dedupeKey: `news_ALL_PRO_${year}` },
+        );
+      }
+
+      // Emit news item for League Champion
+      const champFA = awardResults.franchiseAwards.find(a => a.type === ENGINE_AWARD_TYPES.LEAGUE_CHAMPION);
+      if (champFA) {
+        const champT = cache.getTeam(champFA.teamId);
+        await NewsEngine.logNews(
+          'AWARD',
+          `CHAMPIONS: The ${champT?.name ?? champFA.teamId} have won the championship!`,
+          champFA.teamId,
+          { category: 'league_champion', season: year, dedupeKey: `news_LEAGUE_CHAMPION_${year}` },
+        );
+      }
+
+      // Emit LeaguePulse items for MVP and champion
+      const mvpEntry = awardResults.playerAwards.find(a => a.type === ENGINE_AWARD_TYPES.MVP);
+      const newPulseItems = [];
+      if (mvpEntry) {
+        const mvpT = cache.getTeam(mvpEntry.teamId);
+        newPulseItems.push({
+          season: year,
+          week: meta.currentWeek ?? 22,
+          type: 'performance',
+          importance: 100,
+          headline: `${mvpEntry.name} named League MVP`,
+          body: `${mvpEntry.pos} ${mvpEntry.name} (${mvpT?.abbr ?? 'FA'}) wins the MVP award.`,
+          relatedPlayerId: mvpEntry.playerId,
+          relatedTeamId: mvpEntry.teamId,
+          dedupeKey: `pulse_MVP_${year}`,
+        });
+      }
+      if (champFA) {
+        const champT = cache.getTeam(champFA.teamId);
+        newPulseItems.push({
+          season: year,
+          week: meta.currentWeek ?? 22,
+          type: 'general',
+          importance: 100,
+          headline: `${champT?.name ?? 'Team'} wins the Championship`,
+          body: `${champT?.name ?? 'The champion'} are your ${year} league champions.`,
+          relatedTeamId: champFA.teamId,
+          dedupeKey: `pulse_CHAMPION_${year}`,
+        });
+      }
+
+      // Career milestone checks
+      const playersPostAward = cache.getAllPlayers();
+      for (const p of playersPostAward) {
+        const milestone = checkCareerMilestones(p, year);
+        if (!milestone) continue;
+        await NewsEngine.logNews(
+          'MILESTONE',
+          milestone.type === '300_CAREER_TDs'
+            ? `MILESTONE: ${p.pos} ${p.name} reached ${milestone.totalTDs} career touchdowns!`
+            : `MILESTONE: ${p.pos} ${p.name} is Hall of Fame eligible after a legendary career.`,
+          p.teamId ?? null,
+          { category: 'career_milestone', milestoneType: milestone.type, playerId: p.id, dedupeKey: `milestone_${milestone.type}_${p.id}` },
+        );
+        if (milestone.type === '300_CAREER_TDs') {
+          newPulseItems.push({
+            season: year,
+            week: meta.currentWeek ?? 22,
+            type: 'performance',
+            importance: 75,
+            headline: `${p.name} reaches 300 career TDs`,
+            body: `${p.pos} ${p.name} surpassed 300 career touchdowns, cementing their legacy.`,
+            relatedPlayerId: p.id,
+            relatedTeamId: p.teamId ?? null,
+            dedupeKey: `pulse_TD300_${p.id}_${year}`,
+          });
+        }
+      }
+
+      if (newPulseItems.length > 0) {
+        const existingPulse = Array.isArray(currentMeta?.franchiseChronicle) ? currentMeta.franchiseChronicle : [];
+        cache.setMeta({ franchiseChronicle: mergeLeaguePulseItems(existingPulse, newPulseItems) });
+      }
+
+      await flushDirty();
+    } catch (awardEngineErr) {
+      console.error('[Worker] Award engine V1 failed (non-fatal):', awardEngineErr);
+    }
 
     // ── Record Book: check for broken single-season & all-time records ──────
     const existingRecords = meta.records ?? null;


### PR DESCRIPTION
Adds a persistent, save-safe award layer that runs at season end and
surfaces a player's career legacy across the UI:

- src/core/awards/awardEngine.js (new): Pure deterministic module with
  AWARD_TYPES, SEASON_END, determineSeasonAwards(), applySeasonAwards(),
  getPlayerAwardSummary(), and checkCareerMilestones(). No worker/UI/news
  imports.

- player schema: player.awards rolling array added (type, season, week,
  teamId, statSnapshot, dedupeKey). Hydrates safely to [] on old saves.

- meta schema: meta.franchiseAwards array added (LEAGUE_CHAMPION,
  COACH_OF_YEAR entries). Exposed in buildViewState as league.franchiseAwards.

- worker wire (archiveSeason): determineSeasonAwards + applySeasonAwards
  inserted after accolade flush, before record book. Emits news items for
  each award winner and all-pro team, pulse items for MVP and champion,
  and career milestone news (300 career TDs, HOF eligibility).

- PlayerProfile: "Career Awards" trophy shelf below morale indicator
  showing summary line and per-award rows with season + team.

- FranchiseHQ: "Trophy Case" section showing championships, Coach of Year,
  and individual award winners from franchise history.

- LeagueDashboard: compact "Season Awards" panel in League tab, shown only
  post-season (hidden during regular/preseason/playoffs).

- Tests: 56 new tests across 4 files covering awardEngine unit,
  news/pulse dedupe, worker integration (save/load round-trip, old save
  hydration), and UI rendering.

Deferred: HOF voting, historical stat leaders, award-based contract
leverage, award-based morale effects, all-time franchise records leaderboard.

https://claude.ai/code/session_017JvDAEyr4KG9DePxuict1G