### PR TITLE
feat: Contract Negotiation Depth V2

### DIFF
--- a/src/core/__tests__/negotiationModifiers.test.js
+++ b/src/core/__tests__/negotiationModifiers.test.js
@@ -1,0 +1,455 @@
+/**
+ * negotiationModifiers.test.js — Contract Negotiation Depth V2
+ *
+ * Tests for pure modifier functions: computePlayerLeverage,
+ * computeFranchiseReputation, applyNegotiationModifiers, getNegotiationContext.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  LEVERAGE_MODIFIERS,
+  computePlayerLeverage,
+  computeFranchiseReputation,
+  applyNegotiationModifiers,
+  getNegotiationContext,
+} from '../contracts/negotiationModifiers.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makePlayer(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Test Player',
+    pos: 'QB',
+    ovr: 80,
+    age: 28,
+    morale: 70,
+    moraleEvents: [],
+    awards: [],
+    ...overrides,
+  };
+}
+
+function makeMeta(overrides = {}) {
+  return {
+    season: 2025,
+    userTeamId: 1,
+    franchiseAwards: [],
+    franchiseHistoryByTeam: {},
+    ...overrides,
+  };
+}
+
+function makeMoraleSummary(score = 70) {
+  let label = 'Settled';
+  if (score >= 85) label = 'Thriving';
+  else if (score >= 70) label = 'Settled';
+  else if (score >= 55) label = 'Neutral';
+  else if (score >= 40) label = 'Frustrated';
+  else label = 'Disgruntled';
+  return { score, label, topEvent: null, isLow: score < 40, isAlert: score < 35 };
+}
+
+function makeAwardSummary(overrides = {}) {
+  return { totalAwards: 0, mvpCount: 0, allProCount: 0, championshipCount: 0, highlights: [], summaryLine: null, ...overrides };
+}
+
+// ── computePlayerLeverage ─────────────────────────────────────────────────────
+
+describe('computePlayerLeverage', () => {
+  it('MVP winner in last 2 seasons applies +15% premium', () => {
+    const player = makePlayer({
+      awards: [{ type: 'MVP', season: 2024, dedupeKey: 'MVP_2024' }],
+    });
+    const context = { moraleSummary: makeMoraleSummary(70), awardSummary: makeAwardSummary({ mvpCount: 1 }), currentSeason: 2025 };
+    const result = computePlayerLeverage(player, context);
+    expect(result.multiplier).toBeCloseTo(1 + LEVERAGE_MODIFIERS.MVP_RECENT);
+    expect(result.reasons.length).toBeGreaterThan(0);
+    expect(result.reasons[0]).toMatch(/MVP/i);
+  });
+
+  it('MVP 3 seasons ago does NOT apply recent MVP premium', () => {
+    const player = makePlayer({
+      awards: [{ type: 'MVP', season: 2021, dedupeKey: 'MVP_2021' }],
+    });
+    const context = { moraleSummary: makeMoraleSummary(70), awardSummary: makeAwardSummary({ mvpCount: 1 }), currentSeason: 2025 };
+    const result = computePlayerLeverage(player, context);
+    // No MVP_RECENT premium; only possibly LEAGUE_CHAMPION_HISTORY from past champ (not here)
+    const expectedShift = 0;
+    expect(result.multiplier).toBeCloseTo(1 + expectedShift);
+  });
+
+  it('2+ All-Pro selections apply +10% premium', () => {
+    const player = makePlayer({ awards: [] });
+    const context = { moraleSummary: makeMoraleSummary(70), awardSummary: makeAwardSummary({ allProCount: 3 }), currentSeason: 2025 };
+    const result = computePlayerLeverage(player, context);
+    expect(result.multiplier).toBeCloseTo(1 + LEVERAGE_MODIFIERS.ALL_PRO_MULTIPLE);
+    expect(result.reasons.some((r) => /All-Pro/i.test(r))).toBe(true);
+  });
+
+  it('1 All-Pro selection does NOT trigger the 2+ premium', () => {
+    const player = makePlayer({ awards: [] });
+    const context = { moraleSummary: makeMoraleSummary(70), awardSummary: makeAwardSummary({ allProCount: 1 }), currentSeason: 2025 };
+    const result = computePlayerLeverage(player, context);
+    expect(result.multiplier).toBe(1);
+    expect(result.reasons.length).toBe(0);
+  });
+
+  it('League champion (any season) applies +8% premium', () => {
+    const player = makePlayer({
+      awards: [{ type: 'LEAGUE_CHAMPION', season: 2020, dedupeKey: 'LEAGUE_CHAMPION_2020' }],
+    });
+    const context = { moraleSummary: makeMoraleSummary(70), awardSummary: makeAwardSummary({ championshipCount: 1 }), currentSeason: 2025 };
+    const result = computePlayerLeverage(player, context);
+    expect(result.multiplier).toBeCloseTo(1 + LEVERAGE_MODIFIERS.LEAGUE_CHAMPION_HISTORY);
+    expect(result.reasons.some((r) => /[Cc]hampionship/i.test(r))).toBe(true);
+  });
+
+  it('Disgruntled morale (< 40) applies -10% discount', () => {
+    const player = makePlayer({ morale: 30 });
+    const context = { moraleSummary: makeMoraleSummary(30), awardSummary: makeAwardSummary(), currentSeason: 2025 };
+    const result = computePlayerLeverage(player, context);
+    expect(result.multiplier).toBeCloseTo(1 + LEVERAGE_MODIFIERS.MORALE_DISGRUNTLED);
+    expect(result.reasons.some((r) => /frustrated|discounte/i.test(r))).toBe(true);
+  });
+
+  it('Frustrated morale (40–54) applies -5% discount', () => {
+    const player = makePlayer({ morale: 48 });
+    const context = { moraleSummary: makeMoraleSummary(48), awardSummary: makeAwardSummary(), currentSeason: 2025 };
+    const result = computePlayerLeverage(player, context);
+    expect(result.multiplier).toBeCloseTo(1 + LEVERAGE_MODIFIERS.MORALE_FRUSTRATED);
+  });
+
+  it('Thriving morale (85–100) applies +5% premium', () => {
+    const player = makePlayer({ morale: 90 });
+    const context = { moraleSummary: makeMoraleSummary(90), awardSummary: makeAwardSummary(), currentSeason: 2025 };
+    const result = computePlayerLeverage(player, context);
+    expect(result.multiplier).toBeCloseTo(1 + LEVERAGE_MODIFIERS.MORALE_THRIVING);
+    expect(result.reasons.some((r) => /thriving/i.test(r))).toBe(true);
+  });
+
+  it('Settled morale (70–84) applies no morale modifier', () => {
+    const player = makePlayer({ morale: 75 });
+    const context = { moraleSummary: makeMoraleSummary(75), awardSummary: makeAwardSummary(), currentSeason: 2025 };
+    const result = computePlayerLeverage(player, context);
+    expect(result.multiplier).toBe(1);
+    expect(result.reasons.length).toBe(0);
+  });
+
+  it('Neutral morale (55–69) applies no morale modifier', () => {
+    const player = makePlayer({ morale: 62 });
+    const context = { moraleSummary: makeMoraleSummary(62), awardSummary: makeAwardSummary(), currentSeason: 2025 };
+    const result = computePlayerLeverage(player, context);
+    expect(result.multiplier).toBe(1);
+    expect(result.reasons.length).toBe(0);
+  });
+
+  it('Player with no awards/morale fields returns zero modifier, no crash', () => {
+    const player = { id: 99, name: 'Ghost', pos: 'QB', ovr: 70 };
+    const context = {};
+    const result = computePlayerLeverage(player, context);
+    expect(result.multiplier).toBe(1);
+    expect(Array.isArray(result.reasons)).toBe(true);
+    expect(result.reasons.length).toBe(0);
+  });
+
+  it('Old save (empty awards, no morale) returns zero modifier safely', () => {
+    const player = { id: 5, name: 'Legacy', pos: 'RB', ovr: 78, awards: undefined, morale: undefined };
+    const result = computePlayerLeverage(player, {});
+    expect(result.multiplier).toBe(1);
+    expect(result.reasons.length).toBe(0);
+  });
+
+  it('Modifiers stack correctly: MVP + All-Pro stacks without capping', () => {
+    const player = makePlayer({
+      awards: [{ type: 'MVP', season: 2024, dedupeKey: 'MVP_2024' }],
+    });
+    const context = {
+      moraleSummary: makeMoraleSummary(70),
+      awardSummary: makeAwardSummary({ allProCount: 2 }),
+      currentSeason: 2025,
+    };
+    const result = computePlayerLeverage(player, context);
+    // MVP (+0.15) + All-Pro (+0.10) = +0.25
+    expect(result.multiplier).toBeCloseTo(1 + LEVERAGE_MODIFIERS.MVP_RECENT + LEVERAGE_MODIFIERS.ALL_PRO_MULTIPLE);
+  });
+
+  it('is fully deterministic (same inputs → same output)', () => {
+    const player = makePlayer({ morale: 38, awards: [{ type: 'MVP', season: 2024, dedupeKey: 'MVP_2024' }] });
+    const context = { moraleSummary: makeMoraleSummary(38), awardSummary: makeAwardSummary({ mvpCount: 1 }), currentSeason: 2025 };
+    const r1 = computePlayerLeverage(player, context);
+    const r2 = computePlayerLeverage(player, context);
+    expect(r1.multiplier).toBe(r2.multiplier);
+    expect(r1.reasons).toEqual(r2.reasons);
+  });
+});
+
+// ── computeFranchiseReputation ────────────────────────────────────────────────
+
+describe('computeFranchiseReputation', () => {
+  it('2+ championships in franchise history reduces demand by 5%', () => {
+    const meta = makeMeta({
+      franchiseAwards: [
+        { type: 'LEAGUE_CHAMPION', season: 2022, teamId: 1 },
+        { type: 'LEAGUE_CHAMPION', season: 2023, teamId: 1 },
+      ],
+    });
+    const result = computeFranchiseReputation(meta, { userTeamId: 1, currentSeason: 2025 });
+    expect(result.multiplier).toBeCloseTo(1 + LEVERAGE_MODIFIERS.FRANCHISE_CHAMPION);
+    expect(result.reasons.some((r) => /championship/i.test(r))).toBe(true);
+  });
+
+  it('1 championship does NOT trigger franchise champion discount', () => {
+    const meta = makeMeta({
+      franchiseAwards: [{ type: 'LEAGUE_CHAMPION', season: 2023, teamId: 1 }],
+    });
+    const result = computeFranchiseReputation(meta, { userTeamId: 1, currentSeason: 2025 });
+    expect(result.multiplier).toBe(1);
+  });
+
+  it('0 playoff appearances in 3+ seasons increases demand by 8%', () => {
+    const meta = makeMeta({
+      franchiseHistoryByTeam: {
+        '1': {
+          teamId: 1,
+          seasons: [
+            { year: 2022, wins: 5, losses: 11, madePlayoffs: false },
+            { year: 2023, wins: 6, losses: 11, madePlayoffs: false },
+            { year: 2024, wins: 7, losses: 10, madePlayoffs: false },
+          ],
+        },
+      },
+    });
+    const result = computeFranchiseReputation(meta, { userTeamId: 1, currentSeason: 2025 });
+    expect(result.multiplier).toBeCloseTo(1 + LEVERAGE_MODIFIERS.FRANCHISE_DROUGHT);
+    expect(result.reasons.some((r) => /drought/i.test(r))).toBe(true);
+  });
+
+  it('Only 2 seasons of drought (need 3) does NOT trigger drought modifier', () => {
+    const meta = makeMeta({
+      franchiseHistoryByTeam: {
+        '1': {
+          teamId: 1,
+          seasons: [
+            { year: 2023, wins: 5, losses: 12, madePlayoffs: false },
+            { year: 2024, wins: 6, losses: 11, madePlayoffs: false },
+          ],
+        },
+      },
+    });
+    const result = computeFranchiseReputation(meta, { userTeamId: 1, currentSeason: 2025 });
+    expect(result.multiplier).toBe(1);
+  });
+
+  it('Playoff appearance in last 3 seasons breaks the drought', () => {
+    const meta = makeMeta({
+      franchiseHistoryByTeam: {
+        '1': {
+          teamId: 1,
+          seasons: [
+            { year: 2022, wins: 5, losses: 12, madePlayoffs: false },
+            { year: 2023, wins: 11, losses: 6, madePlayoffs: true },
+            { year: 2024, wins: 7, losses: 10, madePlayoffs: false },
+          ],
+        },
+      },
+    });
+    const result = computeFranchiseReputation(meta, { userTeamId: 1, currentSeason: 2025 });
+    expect(result.multiplier).toBe(1);
+  });
+
+  it('No userTeamId returns no modifier', () => {
+    const meta = makeMeta({ franchiseAwards: [{ type: 'LEAGUE_CHAMPION', season: 2024, teamId: 1 }] });
+    const result = computeFranchiseReputation(meta, {});
+    expect(result.multiplier).toBe(1);
+    expect(result.reasons.length).toBe(0);
+  });
+
+  it('Missing meta fields (old save) returns zero modifier safely', () => {
+    const result = computeFranchiseReputation({}, { userTeamId: 1, currentSeason: 2025 });
+    expect(result.multiplier).toBe(1);
+    expect(result.reasons.length).toBe(0);
+  });
+});
+
+// ── applyNegotiationModifiers ─────────────────────────────────────────────────
+
+describe('applyNegotiationModifiers', () => {
+  it('applies positive multipliers to baseAnnual', () => {
+    const demand = { baseAnnual: 10, yearsTotal: 3, signingBonus: 1 };
+    const playerLev = { multiplier: 1.15 };
+    const franchiseRep = { multiplier: 1 };
+    const result = applyNegotiationModifiers(demand, playerLev, franchiseRep);
+    expect(result.baseAnnual).toBeCloseTo(10 * 1.15, 1);
+  });
+
+  it('applies negative multipliers to baseAnnual', () => {
+    const demand = { baseAnnual: 10, yearsTotal: 3, signingBonus: 1 };
+    const playerLev = { multiplier: 0.9 }; // -10% disgruntled
+    const franchiseRep = { multiplier: 1 };
+    const result = applyNegotiationModifiers(demand, playerLev, franchiseRep);
+    expect(result.baseAnnual).toBeCloseTo(10 * 0.9, 1);
+  });
+
+  it('cap prevents shift exceeding +25%', () => {
+    const demand = { baseAnnual: 10 };
+    // MVP (+0.15) + All-Pro (+0.10) + Champion (+0.08) + Thriving (+0.05) = +0.38 → capped at +0.25
+    const playerLev = { multiplier: 1.38 };
+    const franchiseRep = { multiplier: 1 };
+    const result = applyNegotiationModifiers(demand, playerLev, franchiseRep);
+    expect(result.baseAnnual).toBeCloseTo(10 * 1.25, 1);
+    expect(result._negotiationShift).toBeCloseTo(0.25, 3);
+  });
+
+  it('cap prevents shift exceeding -25%', () => {
+    const demand = { baseAnnual: 10 };
+    const playerLev = { multiplier: 0.6 }; // -40% — capped at -25%
+    const franchiseRep = { multiplier: 1 };
+    const result = applyNegotiationModifiers(demand, playerLev, franchiseRep);
+    expect(result.baseAnnual).toBeCloseTo(10 * 0.75, 1);
+    expect(result._negotiationShift).toBeCloseTo(-0.25, 3);
+  });
+
+  it('stacks player and franchise shifts before capping', () => {
+    const demand = { baseAnnual: 20 };
+    const playerLev = { multiplier: 1.15 };     // +0.15
+    const franchiseRep = { multiplier: 1.08 };   // +0.08 drought — combined = +0.23
+    const result = applyNegotiationModifiers(demand, playerLev, franchiseRep);
+    expect(result.baseAnnual).toBeCloseTo(20 * (1 + 0.23), 1);
+  });
+
+  it('preserves yearsTotal, signingBonus, and other fields unchanged', () => {
+    const demand = { baseAnnual: 10, yearsTotal: 4, signingBonus: 2, guaranteedPct: 0.5 };
+    const result = applyNegotiationModifiers(demand, { multiplier: 1.1 }, { multiplier: 1 });
+    expect(result.yearsTotal).toBe(4);
+    expect(result.signingBonus).toBe(2);
+    expect(result.guaranteedPct).toBe(0.5);
+  });
+
+  it('zero baseAnnual stays zero', () => {
+    const demand = { baseAnnual: 0 };
+    const result = applyNegotiationModifiers(demand, { multiplier: 1.2 }, { multiplier: 1 });
+    expect(result.baseAnnual).toBe(0);
+  });
+
+  it('null leverage inputs apply no modifier', () => {
+    const demand = { baseAnnual: 10 };
+    const result = applyNegotiationModifiers(demand, null, null);
+    expect(result.baseAnnual).toBe(10);
+  });
+});
+
+// ── getNegotiationContext ─────────────────────────────────────────────────────
+
+describe('getNegotiationContext', () => {
+  it('returns "High Leverage" label for positive modifiers', () => {
+    const player = makePlayer({
+      awards: [{ type: 'MVP', season: 2024, dedupeKey: 'MVP_2024' }],
+    });
+    const meta = makeMeta();
+    const ctx = getNegotiationContext(player, meta, {
+      moraleSummary: makeMoraleSummary(70),
+      awardSummary: makeAwardSummary({ mvpCount: 1 }),
+      currentSeason: 2025,
+      userTeamId: 1,
+    });
+    expect(ctx.leverageLabel).toBe('High Leverage');
+    expect(ctx.feedbackLine).toBeTruthy();
+  });
+
+  it('returns "Discount" label for negative modifiers', () => {
+    const player = makePlayer({ morale: 30 });
+    const meta = makeMeta();
+    const ctx = getNegotiationContext(player, meta, {
+      moraleSummary: makeMoraleSummary(30),
+      awardSummary: makeAwardSummary(),
+      currentSeason: 2025,
+      userTeamId: 1,
+    });
+    expect(ctx.leverageLabel).toBe('Discount');
+  });
+
+  it('returns "Standard" for neutral player with no modifiers', () => {
+    const player = makePlayer({ morale: 70 });
+    const meta = makeMeta();
+    const ctx = getNegotiationContext(player, meta, {
+      moraleSummary: makeMoraleSummary(70),
+      awardSummary: makeAwardSummary(),
+      currentSeason: 2025,
+      userTeamId: 1,
+    });
+    expect(ctx.leverageLabel).toBe('Standard');
+    expect(ctx.feedbackLine).toBeNull();
+  });
+
+  it('includes franchise reputation reason when applicable', () => {
+    const player = makePlayer({ morale: 70 });
+    const meta = makeMeta({
+      franchiseAwards: [
+        { type: 'LEAGUE_CHAMPION', season: 2022, teamId: 1 },
+        { type: 'LEAGUE_CHAMPION', season: 2023, teamId: 1 },
+      ],
+    });
+    const ctx = getNegotiationContext(player, meta, {
+      moraleSummary: makeMoraleSummary(70),
+      awardSummary: makeAwardSummary(),
+      currentSeason: 2025,
+      userTeamId: 1,
+    });
+    expect(ctx.reputationLabel).toContain('Championship');
+    expect(ctx.leverageLabel).toBe('Discount');
+  });
+
+  it('is deterministic (same inputs → same output)', () => {
+    const player = makePlayer({ morale: 88 });
+    const meta = makeMeta();
+    const ctx1 = getNegotiationContext(player, meta, { moraleSummary: makeMoraleSummary(88), awardSummary: makeAwardSummary(), currentSeason: 2025, userTeamId: 1 });
+    const ctx2 = getNegotiationContext(player, meta, { moraleSummary: makeMoraleSummary(88), awardSummary: makeAwardSummary(), currentSeason: 2025, userTeamId: 1 });
+    expect(ctx1.leverageLabel).toBe(ctx2.leverageLabel);
+    expect(ctx1.feedbackLine).toBe(ctx2.feedbackLine);
+    expect(ctx1.reputationLabel).toBe(ctx2.reputationLabel);
+  });
+
+  it('handles missing meta gracefully (old save)', () => {
+    const player = makePlayer();
+    expect(() => getNegotiationContext(player, undefined, {})).not.toThrow();
+    expect(() => getNegotiationContext(player, null, {})).not.toThrow();
+  });
+});
+
+// ── Integration: stack and cap scenarios ─────────────────────────────────────
+
+describe('modifier stacking and cap', () => {
+  it('stacked positive modifiers are capped at +25%', () => {
+    // MVP (+15) + All-Pro (+10) = +25% — hits cap exactly
+    const player = makePlayer({
+      morale: 90, // +5% thriving
+      awards: [
+        { type: 'MVP', season: 2024, dedupeKey: 'MVP_2024' },
+        { type: 'LEAGUE_CHAMPION', season: 2023, dedupeKey: 'LC_2023' },
+      ],
+    });
+    const context = {
+      moraleSummary: makeMoraleSummary(90),
+      awardSummary: makeAwardSummary({ mvpCount: 1, allProCount: 3, championshipCount: 1 }),
+      currentSeason: 2025,
+    };
+    // Total: +15 (MVP) + +10 (All-Pro) + +8 (Champ) + +5 (Thriving) = +38% → capped at +25%
+    const leverage = computePlayerLeverage(player, context);
+    const combined = applyNegotiationModifiers({ baseAnnual: 10 }, leverage, { multiplier: 1 });
+    expect(combined._negotiationShift).toBeCloseTo(0.25, 3);
+    expect(combined.baseAnnual).toBeCloseTo(12.5, 1);
+  });
+
+  it('stacked negative modifiers are capped at -25%', () => {
+    // Disgruntled (-10) + franchise drought (+8) = -2% net... but with all negatives:
+    // Disgruntled (-10) + franchise drought (+8) = -2% ... let's construct a -25% cap case
+    const player = makePlayer({ morale: 30 }); // -10%
+    const franchiseRep = { multiplier: 1 - 0.20 }; // hypothetical franchise -20%
+    const demand = { baseAnnual: 10 };
+    const leverage = computePlayerLeverage(player, { moraleSummary: makeMoraleSummary(30), awardSummary: makeAwardSummary(), currentSeason: 2025 });
+    const result = applyNegotiationModifiers(demand, leverage, franchiseRep);
+    // (-10) + (-20) = -30% → capped at -25%
+    expect(result._negotiationShift).toBeCloseTo(-0.25, 3);
+  });
+});

--- a/src/core/__tests__/negotiationModifiersIntegration.test.js
+++ b/src/core/__tests__/negotiationModifiersIntegration.test.js
@@ -1,0 +1,235 @@
+/**
+ * negotiationModifiersIntegration.test.js
+ *
+ * Integration tests for V2 negotiation modifiers:
+ *  - demand calc wiring (modifier changes demand in expected direction)
+ *  - disgruntled player demand < neutral baseline
+ *  - MVP player demand > neutral baseline
+ *  - championship franchise lowers demand vs non-championship baseline
+ *  - playoff drought franchise raises demand vs standard baseline
+ *  - fairness guard / offer feedback still runs after modifiers
+ *  - old save (no award/morale fields) applies zero modifier safely
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  LEVERAGE_MODIFIERS,
+  computePlayerLeverage,
+  computeFranchiseReputation,
+  applyNegotiationModifiers,
+  getNegotiationContext,
+} from '../contracts/negotiationModifiers.js';
+import { buildOfferFeedback } from '../freeAgency/pendingOffers.js';
+import { getPlayerMoraleSummary } from '../mood/playerMoraleEngine.js';
+import { getPlayerAwardSummary } from '../awards/awardEngine.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const BASE_DEMAND = { baseAnnual: 15, yearsTotal: 3, signingBonus: 5, guaranteedPct: 0.5 };
+
+function neutralPlayer() {
+  return { id: 1, name: 'Neutral Player', pos: 'QB', ovr: 80, age: 27, morale: 70, moraleEvents: [], awards: [] };
+}
+
+function disgruntledPlayer() {
+  return { ...neutralPlayer(), morale: 28 };
+}
+
+function mvpPlayer(currentSeason = 2025) {
+  return {
+    ...neutralPlayer(),
+    morale: 70,
+    awards: [{ type: 'MVP', season: currentSeason - 1, dedupeKey: `MVP_${currentSeason - 1}` }],
+  };
+}
+
+function standardMeta() {
+  return { season: 2025, userTeamId: 1, franchiseAwards: [], franchiseHistoryByTeam: {} };
+}
+
+function championshipMeta(teamId = 1) {
+  return {
+    ...standardMeta(),
+    franchiseAwards: [
+      { type: 'LEAGUE_CHAMPION', season: 2023, teamId },
+      { type: 'LEAGUE_CHAMPION', season: 2024, teamId },
+    ],
+  };
+}
+
+function droughtMeta(teamId = 1) {
+  return {
+    ...standardMeta(),
+    franchiseHistoryByTeam: {
+      [String(teamId)]: {
+        teamId,
+        seasons: [
+          { year: 2022, wins: 5, losses: 12, madePlayoffs: false },
+          { year: 2023, wins: 6, losses: 11, madePlayoffs: false },
+          { year: 2024, wins: 7, losses: 10, madePlayoffs: false },
+        ],
+      },
+    },
+  };
+}
+
+function computeAdjustedDemand(player, meta, season = 2025, teamId = 1) {
+  const moraleSummary = getPlayerMoraleSummary(player);
+  const awardSummary = getPlayerAwardSummary(player);
+  const leverage = computePlayerLeverage(player, { moraleSummary, awardSummary, currentSeason: season });
+  const franchise = computeFranchiseReputation(meta, { userTeamId: teamId, currentSeason: season });
+  return applyNegotiationModifiers(BASE_DEMAND, leverage, franchise);
+}
+
+// ── Demand direction tests ────────────────────────────────────────────────────
+
+describe('FA demand calculation integrates negotiation modifiers', () => {
+  it('disgruntled player demand is lower than neutral baseline', () => {
+    const neutral = computeAdjustedDemand(neutralPlayer(), standardMeta());
+    const disgruntled = computeAdjustedDemand(disgruntledPlayer(), standardMeta());
+    expect(disgruntled.baseAnnual).toBeLessThan(neutral.baseAnnual);
+    // Exact delta: MORALE_DISGRUNTLED = -0.10
+    expect(disgruntled.baseAnnual).toBeCloseTo(BASE_DEMAND.baseAnnual * (1 + LEVERAGE_MODIFIERS.MORALE_DISGRUNTLED), 1);
+  });
+
+  it('MVP player demand is higher than neutral baseline', () => {
+    const neutral = computeAdjustedDemand(neutralPlayer(), standardMeta());
+    const mvp = computeAdjustedDemand(mvpPlayer(2025), standardMeta());
+    expect(mvp.baseAnnual).toBeGreaterThan(neutral.baseAnnual);
+    expect(mvp._negotiationShift).toBeCloseTo(LEVERAGE_MODIFIERS.MVP_RECENT, 3);
+  });
+
+  it('championship franchise lowers demand vs non-championship baseline', () => {
+    const standardDemand = computeAdjustedDemand(neutralPlayer(), standardMeta());
+    const champDemand = computeAdjustedDemand(neutralPlayer(), championshipMeta());
+    expect(champDemand.baseAnnual).toBeLessThan(standardDemand.baseAnnual);
+    expect(champDemand._negotiationShift).toBeCloseTo(LEVERAGE_MODIFIERS.FRANCHISE_CHAMPION, 3);
+  });
+
+  it('playoff drought franchise raises demand vs standard baseline', () => {
+    const standardDemand = computeAdjustedDemand(neutralPlayer(), standardMeta());
+    const droughtDemand = computeAdjustedDemand(neutralPlayer(), droughtMeta());
+    expect(droughtDemand.baseAnnual).toBeGreaterThan(standardDemand.baseAnnual);
+    expect(droughtDemand.baseAnnual).toBeCloseTo(BASE_DEMAND.baseAnnual * (1 + LEVERAGE_MODIFIERS.FRANCHISE_DROUGHT), 1);
+  });
+
+  it('player awards and franchise rep stack to produce correct combined shift', () => {
+    // MVP (+0.15) + championship franchise (-0.05) = +0.10
+    const demand = computeAdjustedDemand(mvpPlayer(2025), championshipMeta());
+    const expectedShift = LEVERAGE_MODIFIERS.MVP_RECENT + LEVERAGE_MODIFIERS.FRANCHISE_CHAMPION;
+    expect(demand.baseAnnual).toBeCloseTo(BASE_DEMAND.baseAnnual * (1 + expectedShift), 1);
+    expect(demand._negotiationShift).toBeCloseTo(expectedShift, 3);
+  });
+
+  it('modifiers from old save (no awards, no morale) apply zero change', () => {
+    const legacyPlayer = { id: 99, name: 'Legacy', pos: 'RB', ovr: 72 };
+    const demand = computeAdjustedDemand(legacyPlayer, standardMeta());
+    expect(demand.baseAnnual).toBe(BASE_DEMAND.baseAnnual);
+    expect(demand._negotiationShift ?? 0).toBe(0);
+  });
+});
+
+// ── Offer feedback still runs after modifiers ─────────────────────────────────
+
+describe('existing fairness guard still runs after negotiation modifiers', () => {
+  it('buildOfferFeedback still marks weak offer as "weak" after MVP modifier raises demand', () => {
+    // After MVP modifier, demand goes up 15% → previously-ok offer now looks weak
+    const adjustedDemand = computeAdjustedDemand(mvpPlayer(2025), standardMeta());
+    // Submit a contract at original base (before modifier) — now below the adjusted ask
+    const contract = { baseAnnual: BASE_DEMAND.baseAnnual, yearsTotal: 3, signingBonus: 0 };
+    const feedback = buildOfferFeedback({
+      contract,
+      demand: adjustedDemand,
+      playerAge: 27,
+      competingOfferCount: 0,
+    });
+    // The offer is now at ~87% of adjusted demand ($15M / $17.25M ≈ 0.87) — "competitive" or below
+    expect(feedback.verdict).not.toBe('strong');
+    expect(feedback.score).toBeLessThanOrEqual(90);
+  });
+
+  it('buildOfferFeedback marks "strong" offer as strong even with disgruntled player discount', () => {
+    // Disgruntled drops demand by 10% — a previously-strong offer should still look strong
+    const adjustedDemand = computeAdjustedDemand(disgruntledPlayer(), standardMeta());
+    // Offer exactly at the ORIGINAL demand (above the adjusted lower demand)
+    const contract = { baseAnnual: BASE_DEMAND.baseAnnual, yearsTotal: 3, signingBonus: 5 };
+    const feedback = buildOfferFeedback({
+      contract,
+      demand: adjustedDemand,
+      playerAge: 27,
+      competingOfferCount: 0,
+    });
+    // Offer at $15M vs adjusted demand $13.5M → offer is above demand → "strong"
+    expect(feedback.verdict).toBe('strong');
+  });
+
+  it('negotiation shift is deterministic across multiple calls', () => {
+    const player = mvpPlayer(2025);
+    const meta = standardMeta();
+    const d1 = computeAdjustedDemand(player, meta);
+    const d2 = computeAdjustedDemand(player, meta);
+    expect(d1.baseAnnual).toBe(d2.baseAnnual);
+    expect(d1._negotiationShift).toBe(d2._negotiationShift);
+  });
+});
+
+// ── Morale events still work after V2 wiring ─────────────────────────────────
+
+describe('morale engine still functions correctly alongside V2 modifiers', () => {
+  it('getPlayerMoraleSummary reads morale from player correctly', () => {
+    const summary = getPlayerMoraleSummary(disgruntledPlayer());
+    expect(summary.score).toBe(28);
+    expect(summary.label).toBe('Disgruntled');
+    expect(summary.isLow).toBe(true);
+  });
+
+  it('getPlayerAwardSummary reads awards from player correctly', () => {
+    const player = mvpPlayer(2025);
+    const summary = getPlayerAwardSummary(player);
+    expect(summary.mvpCount).toBe(1);
+    expect(summary.totalAwards).toBe(1);
+  });
+
+  it('modifiers use morale summary score, not raw engine (pass-through contract)', () => {
+    // If moraleSummary is passed with score = 30, it uses that regardless of player.morale
+    const player = { ...neutralPlayer(), morale: 70 };
+    const overrideSummary = { score: 30, label: 'Disgruntled', topEvent: null, isLow: true, isAlert: false };
+    const leverage = computePlayerLeverage(player, { moraleSummary: overrideSummary, awardSummary: {}, currentSeason: 2025 });
+    expect(leverage.multiplier).toBeCloseTo(1 + LEVERAGE_MODIFIERS.MORALE_DISGRUNTLED);
+  });
+});
+
+// ── getNegotiationContext end-to-end ──────────────────────────────────────────
+
+describe('getNegotiationContext end-to-end', () => {
+  it('combines player and franchise context into correct labels', () => {
+    const player = neutralPlayer(); // morale 70, no awards
+    const meta = droughtMeta();
+    const moraleSummary = getPlayerMoraleSummary(player);
+    const awardSummary = getPlayerAwardSummary(player);
+    const ctx = getNegotiationContext(player, meta, { moraleSummary, awardSummary, currentSeason: 2025, userTeamId: 1 });
+    expect(ctx.leverageLabel).toBe('High Leverage'); // drought +8% makes it positive
+    expect(ctx.reputationLabel).toContain('drought');
+    expect(ctx.feedbackLine).toBeTruthy();
+  });
+
+  it('championship franchise overrides drought and applies discount', () => {
+    const player = neutralPlayer();
+    const meta = championshipMeta();
+    const moraleSummary = getPlayerMoraleSummary(player);
+    const awardSummary = getPlayerAwardSummary(player);
+    const ctx = getNegotiationContext(player, meta, { moraleSummary, awardSummary, currentSeason: 2025, userTeamId: 1 });
+    expect(ctx.leverageLabel).toBe('Discount'); // champ -5%
+    expect(ctx.reputationLabel).toContain('Championship');
+  });
+
+  it('no modifiers → Standard label with null feedbackLine', () => {
+    const player = neutralPlayer();
+    const meta = standardMeta();
+    const moraleSummary = getPlayerMoraleSummary(player);
+    const awardSummary = getPlayerAwardSummary(player);
+    const ctx = getNegotiationContext(player, meta, { moraleSummary, awardSummary, currentSeason: 2025, userTeamId: 1 });
+    expect(ctx.leverageLabel).toBe('Standard');
+    expect(ctx.feedbackLine).toBeNull();
+  });
+});

--- a/src/core/contracts/negotiationModifiers.js
+++ b/src/core/contracts/negotiationModifiers.js
@@ -1,0 +1,251 @@
+/**
+ * negotiationModifiers.js — Contract Negotiation Depth V2
+ *
+ * Pure, deterministic negotiation-modifier module.
+ * Computes demand multipliers from player morale, award history,
+ * and franchise reputation. Applied after base demand is established,
+ * before offer comparison.
+ *
+ * Design constraints:
+ *  - Pure functions only. No side effects.
+ *  - No imports from worker, UI, or news modules.
+ *  - No imports from playerMoraleEngine or awardEngine — receive their
+ *    output as arguments via the context parameter.
+ *  - No Math.random — fully deterministic.
+ *  - Total demand shift bounded at ±MAX_SHIFT (25%).
+ */
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const LEVERAGE_MODIFIERS = Object.freeze({
+  /** MVP in the last 2 seasons → +15% demand premium */
+  MVP_RECENT: 0.15,
+  /** 2+ All-Pro selections (career) → +10% demand premium */
+  ALL_PRO_MULTIPLE: 0.10,
+  /** League champion in any season → +8% demand premium */
+  LEAGUE_CHAMPION_HISTORY: 0.08,
+  /** Disgruntled morale (< 40) → −10% demand */
+  MORALE_DISGRUNTLED: -0.10,
+  /** Frustrated morale (40–54) → −5% demand */
+  MORALE_FRUSTRATED: -0.05,
+  /** Thriving morale (85–100) → +5% demand */
+  MORALE_THRIVING: 0.05,
+  /** Franchise has 2+ championships → −5% demand from FAs */
+  FRANCHISE_CHAMPION: -0.05,
+  /** Franchise had 0 playoff appearances in 3+ seasons → +8% demand */
+  FRANCHISE_DROUGHT: 0.08,
+  /** Maximum total demand shift in either direction */
+  MAX_SHIFT: 0.25,
+});
+
+// Award type string constant — duplicated here to avoid importing from awardEngine.
+const AWARD_TYPE_MVP = 'MVP';
+const AWARD_TYPE_LEAGUE_CHAMPION = 'LEAGUE_CHAMPION';
+const ALL_PRO_PREFIX = 'ALL_PRO_';
+
+// Morale score thresholds (mirrored from playerMoraleEngine constants).
+const MORALE_DISGRUNTLED_MAX = 40;
+const MORALE_FRUSTRATED_MAX = 55;
+const MORALE_THRIVING_MIN = 85;
+const MORALE_DEFAULT = 70;
+
+function safeNum(v, fallback = 0) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function clampShift(shift) {
+  return Math.max(-LEVERAGE_MODIFIERS.MAX_SHIFT, Math.min(LEVERAGE_MODIFIERS.MAX_SHIFT, shift));
+}
+
+// ── computePlayerLeverage ─────────────────────────────────────────────────────
+
+/**
+ * Compute player-specific leverage modifiers.
+ *
+ * @param {object} player       – player data (reads player.awards, player.morale)
+ * @param {object} context      – {
+ *   moraleSummary?: object,   – output of getPlayerMoraleSummary(player) (optional)
+ *   awardSummary?: object,    – output of getPlayerAwardSummary(player) (optional)
+ *   currentSeason?: number,   – current season year (used for MVP recency check)
+ * }
+ * @returns {{ multiplier: number, reasons: string[] }}
+ */
+export function computePlayerLeverage(player, context = {}) {
+  const { moraleSummary = {}, awardSummary = {}, currentSeason = 0 } = context;
+
+  const reasons = [];
+  let shift = 0;
+
+  // ── Award modifiers ──────────────────────────────────────────────────────
+
+  const awards = Array.isArray(player?.awards) ? player.awards : [];
+
+  // MVP in last 2 seasons
+  const hasMVPRecent = awards.some((a) => {
+    if (a?.type !== AWARD_TYPE_MVP) return false;
+    if (!currentSeason) return false;
+    const seasonDiff = currentSeason - safeNum(a?.season);
+    return seasonDiff >= 0 && seasonDiff <= 2;
+  });
+  if (hasMVPRecent) {
+    shift += LEVERAGE_MODIFIERS.MVP_RECENT;
+    reasons.push('Recent MVP award increases his market value');
+  }
+
+  // 2+ All-Pro selections — prefer awardSummary if provided, fall back to raw count
+  const allProCount = safeNum(
+    awardSummary?.allProCount ?? awards.filter((a) => String(a?.type ?? '').startsWith(ALL_PRO_PREFIX)).length,
+  );
+  if (allProCount >= 2) {
+    shift += LEVERAGE_MODIFIERS.ALL_PRO_MULTIPLE;
+    reasons.push('Multiple All-Pro selections raise his leverage');
+  }
+
+  // League champion (any season)
+  const championshipCount = safeNum(
+    awardSummary?.championshipCount ?? awards.filter((a) => a?.type === AWARD_TYPE_LEAGUE_CHAMPION).length,
+  );
+  if (championshipCount >= 1) {
+    shift += LEVERAGE_MODIFIERS.LEAGUE_CHAMPION_HISTORY;
+    reasons.push('Championship pedigree commands a premium');
+  }
+
+  // ── Morale modifiers ─────────────────────────────────────────────────────
+
+  const moraleScore = safeNum(moraleSummary?.score ?? player?.morale, MORALE_DEFAULT);
+
+  if (moraleScore < MORALE_DISGRUNTLED_MAX) {
+    shift += LEVERAGE_MODIFIERS.MORALE_DISGRUNTLED;
+    reasons.push('Player is frustrated — open to discounted deal');
+  } else if (moraleScore < MORALE_FRUSTRATED_MAX) {
+    shift += LEVERAGE_MODIFIERS.MORALE_FRUSTRATED;
+    reasons.push('Player is unhappy — slightly open to discount');
+  } else if (moraleScore >= MORALE_THRIVING_MIN) {
+    shift += LEVERAGE_MODIFIERS.MORALE_THRIVING;
+    reasons.push('Player is thriving — expects premium to stay');
+  }
+  // Settled (55–84): no modifier
+
+  return { multiplier: 1 + shift, reasons };
+}
+
+// ── computeFranchiseReputation ────────────────────────────────────────────────
+
+/**
+ * Compute franchise-level reputation modifiers (applied to all negotiations).
+ *
+ * Reads from:
+ *   meta.franchiseAwards           – { type, season, teamId }[]
+ *   meta.franchiseHistoryByTeam    – keyed by teamId string
+ *
+ * @param {object} meta      – game meta (reads franchiseAwards + franchiseHistoryByTeam)
+ * @param {object} context   – { userTeamId: number|string, currentSeason?: number }
+ * @returns {{ multiplier: number, reasons: string[] }}
+ */
+export function computeFranchiseReputation(meta, context = {}) {
+  const { userTeamId = null, currentSeason = 0 } = context;
+
+  const reasons = [];
+  let shift = 0;
+
+  if (!userTeamId) return { multiplier: 1, reasons };
+
+  // 2+ championships in franchise history
+  const franchiseAwards = Array.isArray(meta?.franchiseAwards) ? meta.franchiseAwards : [];
+  const teamChampionships = franchiseAwards.filter(
+    (a) => a?.type === 'LEAGUE_CHAMPION' && Number(a?.teamId) === Number(userTeamId),
+  ).length;
+
+  if (teamChampionships >= 2) {
+    shift += LEVERAGE_MODIFIERS.FRANCHISE_CHAMPION;
+    reasons.push('Franchise championship history attracts top talent');
+  }
+
+  // Playoff drought: 0 playoff appearances in most recent 3+ completed seasons
+  const teamHistory = meta?.franchiseHistoryByTeam?.[String(userTeamId)];
+  if (teamHistory?.seasons) {
+    const completedSeasons = (teamHistory.seasons)
+      .filter((s) => !currentSeason || safeNum(s?.year) < currentSeason)
+      .sort((a, b) => safeNum(b?.year) - safeNum(a?.year))
+      .slice(0, 3);
+
+    if (completedSeasons.length >= 3 && completedSeasons.every((s) => !s.madePlayoffs)) {
+      shift += LEVERAGE_MODIFIERS.FRANCHISE_DROUGHT;
+      reasons.push('Franchise playoff drought raises free agent skepticism');
+    }
+  }
+
+  return { multiplier: 1 + shift, reasons };
+}
+
+// ── applyNegotiationModifiers ─────────────────────────────────────────────────
+
+/**
+ * Apply combined player + franchise modifiers to a base demand object.
+ * Total shift is capped at ±MAX_SHIFT (25%).
+ *
+ * Only baseAnnual is adjusted; years and signingBonus are preserved.
+ *
+ * @param {object} baseDemand            – demand snapshot ({ baseAnnual, ... })
+ * @param {{ multiplier: number }} playerLeverage
+ * @param {{ multiplier: number }} franchiseReputation
+ * @returns {object} – adjusted demand with updated baseAnnual and _negotiationShift
+ */
+export function applyNegotiationModifiers(baseDemand, playerLeverage, franchiseReputation) {
+  const playerShift = safeNum(playerLeverage?.multiplier, 1) - 1;
+  const franchiseShift = safeNum(franchiseReputation?.multiplier, 1) - 1;
+  const totalShift = playerShift + franchiseShift;
+  const clamped = clampShift(totalShift);
+
+  const baseAnnual = safeNum(baseDemand?.baseAnnual);
+  const adjustedAnnual = baseAnnual > 0 ? Math.round(baseAnnual * (1 + clamped) * 10) / 10 : 0;
+
+  return {
+    ...baseDemand,
+    baseAnnual: adjustedAnnual,
+    _negotiationShift: Math.round(clamped * 1000) / 1000,
+  };
+}
+
+// ── getNegotiationContext ─────────────────────────────────────────────────────
+
+/**
+ * Build human-readable negotiation context for the UI.
+ *
+ * @param {object} player   – player data
+ * @param {object} meta     – game meta
+ * @param {object} context  – {
+ *   moraleSummary?: object,
+ *   awardSummary?: object,
+ *   currentSeason?: number,
+ *   userTeamId?: number|string,
+ * }
+ * @returns {{ leverageLabel: string, reputationLabel: string, feedbackLine: string|null }}
+ */
+export function getNegotiationContext(player, meta, context = {}) {
+  const { moraleSummary = {}, awardSummary = {}, currentSeason = 0, userTeamId = null } = context;
+
+  const playerLeverage = computePlayerLeverage(player, { moraleSummary, awardSummary, currentSeason });
+  const franchiseRep = computeFranchiseReputation(meta, { userTeamId, currentSeason });
+
+  const playerShift = playerLeverage.multiplier - 1;
+  const franchiseShift = franchiseRep.multiplier - 1;
+  const totalClamped = clampShift(playerShift + franchiseShift);
+
+  let leverageLabel;
+  if (totalClamped > 0.005) leverageLabel = 'High Leverage';
+  else if (totalClamped < -0.005) leverageLabel = 'Discount';
+  else leverageLabel = 'Standard';
+
+  let reputationLabel;
+  if (franchiseShift < -0.005) reputationLabel = 'Championship franchise';
+  else if (franchiseShift > 0.005) reputationLabel = 'Franchise in drought';
+  else reputationLabel = 'Standard franchise';
+
+  // Primary feedback line: most impactful reason (player first, franchise second)
+  const allReasons = [...playerLeverage.reasons, ...franchiseRep.reasons];
+  const feedbackLine = allReasons[0] ?? null;
+
+  return { leverageLabel, reputationLabel, feedbackLine };
+}

--- a/src/ui/components/ContractNegotiation.jsx
+++ b/src/ui/components/ContractNegotiation.jsx
@@ -6,6 +6,9 @@
 
 import React, { useState, useMemo } from "react";
 import PlayerCard from "./PlayerCard.jsx";
+import { getNegotiationContext } from "../../core/contracts/negotiationModifiers.js";
+import { getPlayerMoraleSummary } from "../../core/mood/playerMoraleEngine.js";
+import { getPlayerAwardSummary } from "../../core/awards/awardEngine.js";
 
 const CAP_TOTAL = 301.2; // hard cap in $M
 
@@ -259,6 +262,20 @@ export default function ContractNegotiation({
           <div style={{ fontSize: "var(--text-xs)", marginTop: 8, color: schemeFit === "Excellent" ? "var(--success)" : "var(--warning)" }}>
             Scheme Fit: <strong>{schemeFit}</strong>
           </div>
+          {(() => {
+            const feedbackLine = player?.demandProfile?.feedbackLine
+              ?? (() => {
+                  const ms = getPlayerMoraleSummary(player);
+                  const as = getPlayerAwardSummary(player);
+                  return getNegotiationContext(player, {}, { moraleSummary: ms, awardSummary: as }).feedbackLine;
+                })();
+            if (!feedbackLine) return null;
+            return (
+              <div data-testid="contract-negotiation-v2-feedback" style={{ fontSize: "var(--text-xs)", marginTop: 6, color: "var(--text-subtle)", fontStyle: "italic", borderTop: "1px solid var(--hairline)", paddingTop: 6 }}>
+                {feedbackLine}
+              </div>
+            );
+          })()}
           <CapImpactBar capRoom={capRoom} capHitThisYear={capHitThisYear} />
         </div>
 

--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -1804,6 +1804,24 @@ export default function FreeAgency({
                             ${(player?.demandProfile?.askAnnual ?? player._ask ?? 0).toFixed(1)}M{" "}
                             <span style={{ color: "var(--text-muted)" }}>/ {askYrs}y</span>
                           </div>
+                          {(() => {
+                            const leverageLabel = player?.demandProfile?.leverageLabel;
+                            if (!leverageLabel || leverageLabel === 'Standard') return null;
+                            const leverageColor = leverageLabel === 'High Leverage' ? 'var(--warning)' : 'var(--success)';
+                            const feedbackLine = player?.demandProfile?.feedbackLine;
+                            return (
+                              <div data-testid="fa-leverage-indicator" style={{ marginBottom: 4 }}>
+                                <span style={{ fontSize: 10, fontWeight: 700, color: leverageColor, border: `1px solid ${leverageColor}`, borderRadius: 999, padding: "0 5px" }}>
+                                  {leverageLabel}
+                                </span>
+                                {feedbackLine && (
+                                  <div data-testid="fa-leverage-reason" style={{ fontSize: 10, color: "var(--text-subtle)", marginTop: 2 }}>
+                                    {feedbackLine}
+                                  </div>
+                                )}
+                              </div>
+                            );
+                          })()}
                           <div style={{ fontSize: "10px", color: "var(--text-muted)", marginBottom: 4 }}>
                             {player?.demandProfile?.headline ?? "Balanced priorities"}{market.riskLabel ? ` · ${market.riskLabel}` : ""}
                           </div>
@@ -1816,6 +1834,11 @@ export default function FreeAgency({
                           <div style={{ fontSize: "10px", color: "var(--text-muted)", marginBottom: 4 }}>
                             Playbook: {formatPlaybookKnowledge(player?.playbookKnowledge)}
                           </div>
+                          {player?.demandProfile?.feedbackLine && player?.demandProfile?.leverageLabel === 'Standard' && (
+                            <div style={{ fontSize: 10, color: "var(--text-subtle)", marginBottom: 4 }}>
+                              {player.demandProfile.feedbackLine}
+                            </div>
+                          )}
                           {!canAfford ? (
                             <span style={{ color: "var(--danger)", fontSize: "var(--text-xs)" }}>
                               Cannot Afford

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -39,6 +39,7 @@ import { buildPlayerCareerTimeline } from "../utils/playerCareerTimeline.js";
 import { buildPlayerAdvancedStatsView } from "../utils/playerAdvancedStatsViewModel.js";
 import { getPlayerMoraleSummary } from "../../core/mood/playerMoraleEngine.js";
 import { getPlayerAwardSummary, AWARD_LABELS, AWARD_TYPES } from "../../core/awards/awardEngine.js";
+import { getNegotiationContext } from "../../core/contracts/negotiationModifiers.js";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
@@ -1403,6 +1404,47 @@ export default function PlayerProfile({
                           </div>
                         )}
                       </div>
+                    </div>
+                  );
+                })()}
+
+                {/* ── Negotiation Profile ── */}
+                {playerView && (() => {
+                  const moraleSummary = getPlayerMoraleSummary(playerView);
+                  const awardSummary = getPlayerAwardSummary(playerView);
+                  const currentSeason = Number(data?.meta?.season ?? 0);
+                  const userTeamId = Number(data?.meta?.userTeamId ?? 0);
+                  const negCtx = getNegotiationContext(playerView, data?.meta ?? {}, { moraleSummary, awardSummary, currentSeason, userTeamId });
+                  if (!negCtx.feedbackLine && negCtx.leverageLabel === 'Standard') return null;
+                  const leverageColor = negCtx.leverageLabel === 'High Leverage' ? 'var(--warning)'
+                                       : negCtx.leverageLabel === 'Discount' ? 'var(--success)'
+                                       : 'var(--text-muted)';
+                  return (
+                    <div
+                      data-testid="player-profile-negotiation"
+                      style={{
+                        marginTop: 'var(--space-2)',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 8,
+                        flexWrap: 'wrap',
+                      }}
+                    >
+                      <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-subtle)', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '.07em' }}>Negotiation</span>
+                      <span
+                        data-testid="player-profile-leverage-label"
+                        style={{ fontSize: 'var(--text-xs)', fontWeight: 700, color: leverageColor }}
+                      >
+                        {negCtx.leverageLabel}
+                      </span>
+                      {negCtx.feedbackLine && (
+                        <span
+                          data-testid="player-profile-negotiation-reason"
+                          style={{ fontSize: 'var(--text-xs)', color: 'var(--text-subtle)', fontStyle: 'italic' }}
+                        >
+                          · {negCtx.feedbackLine}
+                        </span>
+                      )}
                     </div>
                   );
                 })()}

--- a/src/ui/components/negotiationModifiersUI.test.jsx
+++ b/src/ui/components/negotiationModifiersUI.test.jsx
@@ -1,0 +1,236 @@
+/** @vitest-environment jsdom */
+/**
+ * negotiationModifiersUI.test.jsx — Contract Negotiation Depth V2 UI tests
+ *
+ * Tests for:
+ *  - FreeAgency leverage label and reason rendering
+ *  - PlayerProfile negotiation profile rendering
+ *  - Edge cases: no modifiers, missing fields
+ */
+
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { getNegotiationContext } from '../../core/contracts/negotiationModifiers.js';
+import { getPlayerMoraleSummary } from '../../core/mood/playerMoraleEngine.js';
+import { getPlayerAwardSummary } from '../../core/awards/awardEngine.js';
+
+afterEach(cleanup);
+
+// ── Minimal FreeAgency leverage indicator ─────────────────────────────────────
+// Mirrors the inline rendering added to FreeAgency.jsx's player row,
+// isolated so we can test it without the full FA component tree.
+
+function FaLeverageIndicator({ player }) {
+  const leverageLabel = player?.demandProfile?.leverageLabel;
+  if (!leverageLabel || leverageLabel === 'Standard') return <div data-testid="no-leverage" />;
+  const leverageColor = leverageLabel === 'High Leverage' ? 'var(--warning)' : 'var(--success)';
+  const feedbackLine = player?.demandProfile?.feedbackLine;
+  return (
+    <div data-testid="fa-leverage-indicator">
+      <span
+        data-testid="fa-leverage-label"
+        style={{ color: leverageColor }}
+      >
+        {leverageLabel}
+      </span>
+      {feedbackLine && (
+        <div data-testid="fa-leverage-reason">{feedbackLine}</div>
+      )}
+    </div>
+  );
+}
+
+// ── Minimal PlayerProfile negotiation profile ─────────────────────────────────
+// Mirrors the negotiation profile block added to PlayerProfile.jsx.
+
+function NegotiationProfile({ player, meta = {}, season = 2025, userTeamId = 1 }) {
+  const moraleSummary = getPlayerMoraleSummary(player);
+  const awardSummary = getPlayerAwardSummary(player);
+  const negCtx = getNegotiationContext(player, meta, { moraleSummary, awardSummary, currentSeason: season, userTeamId });
+  if (!negCtx.feedbackLine && negCtx.leverageLabel === 'Standard') return <div data-testid="no-negotiation-profile" />;
+  return (
+    <div data-testid="player-profile-negotiation">
+      <span data-testid="player-profile-leverage-label">{negCtx.leverageLabel}</span>
+      {negCtx.feedbackLine && (
+        <span data-testid="player-profile-negotiation-reason">{negCtx.feedbackLine}</span>
+      )}
+    </div>
+  );
+}
+
+// ── FreeAgency panel leverage label tests ─────────────────────────────────────
+
+describe('FreeAgency panel leverage indicator', () => {
+  it('renders "High Leverage" label for MVP player', () => {
+    const player = {
+      id: 1,
+      demandProfile: {
+        leverageLabel: 'High Leverage',
+        feedbackLine: 'Recent MVP award increases his market value',
+      },
+    };
+    render(<FaLeverageIndicator player={player} />);
+    expect(screen.getByTestId('fa-leverage-indicator')).toBeTruthy();
+    expect(screen.getByTestId('fa-leverage-label').textContent).toBe('High Leverage');
+  });
+
+  it('renders reason line alongside leverage label', () => {
+    const player = {
+      id: 2,
+      demandProfile: {
+        leverageLabel: 'High Leverage',
+        feedbackLine: 'Recent MVP award increases his market value',
+      },
+    };
+    render(<FaLeverageIndicator player={player} />);
+    expect(screen.getByTestId('fa-leverage-reason').textContent).toContain('MVP');
+  });
+
+  it('renders "Discount" label for disgruntled player', () => {
+    const player = {
+      id: 3,
+      demandProfile: {
+        leverageLabel: 'Discount',
+        feedbackLine: 'Player is frustrated — open to discounted deal',
+      },
+    };
+    render(<FaLeverageIndicator player={player} />);
+    expect(screen.getByTestId('fa-leverage-label').textContent).toBe('Discount');
+  });
+
+  it('leverage label absent (Standard) shows nothing', () => {
+    const player = {
+      id: 4,
+      demandProfile: {
+        leverageLabel: 'Standard',
+        feedbackLine: null,
+      },
+    };
+    render(<FaLeverageIndicator player={player} />);
+    expect(screen.getByTestId('no-leverage')).toBeTruthy();
+    expect(screen.queryByTestId('fa-leverage-indicator')).toBeNull();
+  });
+
+  it('leverage label absent when demandProfile missing', () => {
+    const player = { id: 5 };
+    render(<FaLeverageIndicator player={player} />);
+    expect(screen.getByTestId('no-leverage')).toBeTruthy();
+  });
+
+  it('renders no reason line when feedbackLine is null', () => {
+    const player = {
+      id: 6,
+      demandProfile: {
+        leverageLabel: 'High Leverage',
+        feedbackLine: null,
+      },
+    };
+    render(<FaLeverageIndicator player={player} />);
+    expect(screen.getByTestId('fa-leverage-label').textContent).toBe('High Leverage');
+    expect(screen.queryByTestId('fa-leverage-reason')).toBeNull();
+  });
+});
+
+// ── PlayerProfile negotiation profile tests ───────────────────────────────────
+
+describe('PlayerProfile negotiation profile', () => {
+  it('renders negotiation profile with multiplier label for MVP player', () => {
+    const player = {
+      id: 10,
+      name: 'Star Player',
+      pos: 'QB',
+      ovr: 85,
+      age: 28,
+      morale: 70,
+      moraleEvents: [],
+      awards: [{ type: 'MVP', season: 2024, dedupeKey: 'MVP_2024' }],
+    };
+    render(<NegotiationProfile player={player} season={2025} />);
+    expect(screen.getByTestId('player-profile-negotiation')).toBeTruthy();
+    expect(screen.getByTestId('player-profile-leverage-label').textContent).toBe('High Leverage');
+  });
+
+  it('renders reason for disgruntled player', () => {
+    const player = {
+      id: 11,
+      name: 'Upset Player',
+      pos: 'RB',
+      ovr: 75,
+      age: 27,
+      morale: 25,
+      moraleEvents: [],
+      awards: [],
+    };
+    render(<NegotiationProfile player={player} season={2025} />);
+    expect(screen.getByTestId('player-profile-leverage-label').textContent).toBe('Discount');
+    expect(screen.getByTestId('player-profile-negotiation-reason').textContent).toMatch(/frustrated/i);
+  });
+
+  it('renders nothing for neutral player with no modifiers', () => {
+    const player = {
+      id: 12,
+      name: 'Average Joe',
+      pos: 'WR',
+      ovr: 72,
+      age: 26,
+      morale: 70,
+      moraleEvents: [],
+      awards: [],
+    };
+    render(<NegotiationProfile player={player} season={2025} />);
+    expect(screen.getByTestId('no-negotiation-profile')).toBeTruthy();
+    expect(screen.queryByTestId('player-profile-negotiation')).toBeNull();
+  });
+
+  it('renders safely when player.awards is absent (old save)', () => {
+    const player = { id: 13, name: 'Legacy', pos: 'TE', ovr: 70, age: 30 };
+    expect(() => render(<NegotiationProfile player={player} />)).not.toThrow();
+    expect(screen.getByTestId('no-negotiation-profile')).toBeTruthy();
+  });
+
+  it('renders safely when player.morale is absent (old save)', () => {
+    const player = { id: 14, name: 'Morale-Free', pos: 'CB', ovr: 71, age: 29, awards: [] };
+    expect(() => render(<NegotiationProfile player={player} />)).not.toThrow();
+  });
+
+  it('renders franchise reputation reason when championship franchise', () => {
+    const player = {
+      id: 15,
+      name: 'Ring Chaser',
+      pos: 'WR',
+      ovr: 80,
+      age: 27,
+      morale: 70,
+      moraleEvents: [],
+      awards: [],
+    };
+    const meta = {
+      season: 2025,
+      userTeamId: 1,
+      franchiseAwards: [
+        { type: 'LEAGUE_CHAMPION', season: 2023, teamId: 1 },
+        { type: 'LEAGUE_CHAMPION', season: 2024, teamId: 1 },
+      ],
+    };
+    render(<NegotiationProfile player={player} meta={meta} season={2025} userTeamId={1} />);
+    expect(screen.getByTestId('player-profile-leverage-label').textContent).toBe('Discount');
+    expect(screen.getByTestId('player-profile-negotiation-reason').textContent).toMatch(/championship/i);
+  });
+
+  it('thriving player shows High Leverage label', () => {
+    const player = {
+      id: 16,
+      name: 'Happy Player',
+      pos: 'QB',
+      ovr: 82,
+      age: 29,
+      morale: 92,
+      moraleEvents: [],
+      awards: [],
+    };
+    render(<NegotiationProfile player={player} season={2025} />);
+    expect(screen.getByTestId('player-profile-leverage-label').textContent).toBe('High Leverage');
+    expect(screen.getByTestId('player-profile-negotiation-reason').textContent).toMatch(/thriving/i);
+  });
+});

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -105,7 +105,14 @@ import {
   MORALE_DELTAS,
   applyMoraleEvent,
   applyWeeklyMoraleEffects,
+  getPlayerMoraleSummary,
 } from '../core/mood/playerMoraleEngine.js';
+import {
+  computePlayerLeverage,
+  computeFranchiseReputation,
+  applyNegotiationModifiers,
+  getNegotiationContext,
+} from '../core/contracts/negotiationModifiers.js';
 import { classifyDeadlinePosture, DEADLINE_POSTURE } from '../core/trades/tradeDeadlinePressure.js';
 import { getFreeAgencyDecisionState } from '../core/freeAgency/decisionState.js';
 import {
@@ -131,7 +138,7 @@ import AiLogic from '../core/ai-logic.js';
 import NewsEngine, { createNewsItem, addNewsItem } from '../core/news-engine.js';
 import { parseWeeklyHeadlines } from '../core/history/NewsEngine.ts';
 import { calculateAwardRaces, selectProBowlers } from '../core/awards-logic.js';
-import { determineSeasonAwards, applySeasonAwards, checkCareerMilestones, AWARD_TYPES as ENGINE_AWARD_TYPES, AWARD_LABELS as ENGINE_AWARD_LABELS } from '../core/awards/awardEngine.js';
+import { determineSeasonAwards, applySeasonAwards, checkCareerMilestones, getPlayerAwardSummary, AWARD_TYPES as ENGINE_AWARD_TYPES, AWARD_LABELS as ENGINE_AWARD_LABELS } from '../core/awards/awardEngine.js';
 import { Constants } from '../core/constants.js';
 import { processPlayerProgression } from '../core/progression-logic.js';
 import { getZeroStats as getZeroSeasonStatsSchema } from '../core/state.js';
@@ -6006,19 +6013,38 @@ function buildDemandSnapshotForOffer(player, team) {
   const losses = Number(team?.losses ?? 0);
   const ties = Number(team?.ties ?? 0);
   const games = wins + losses + ties;
-  const ask = inflateContract(buildDemandFromProfile(player, profile, {
+  const baseAsk = inflateContract(buildDemandFromProfile(player, profile, {
     marketHeat: heat,
     morale: player.morale ?? 68,
     fit: Number(player?.schemeFit ?? 65),
     teamSuccess: games > 0 ? (wins + ties * 0.5) / games : 0.5,
   }), getSalaryInflationMultiplier(meta?.economy ?? {}));
+
+  // V2: apply negotiation modifiers (morale, awards, franchise reputation)
+  const moraleSummary = getPlayerMoraleSummary(player);
+  const awardSummary = getPlayerAwardSummary(player);
+  const currentSeason = Number(meta?.season ?? 0);
+  const userTeamId = Number(meta?.userTeamId ?? 0);
+
+  const playerLeverage = computePlayerLeverage(player, { moraleSummary, awardSummary, currentSeason });
+  const franchiseRep = computeFranchiseReputation(meta, { userTeamId, currentSeason });
+  const ask = applyNegotiationModifiers(baseAsk, playerLeverage, franchiseRep);
+  const negCtx = getNegotiationContext(player, meta, { moraleSummary, awardSummary, currentSeason, userTeamId });
+
   return {
     baseAnnual: ask.baseAnnual,
-    yearsTotal: ask.yearsTotal,
-    signingBonus: ask.signingBonus,
-    guaranteedPct: ask.guaranteedPct,
-    willingness: ask.willingness,
+    yearsTotal: baseAsk.yearsTotal,
+    signingBonus: baseAsk.signingBonus,
+    guaranteedPct: baseAsk.guaranteedPct,
+    willingness: baseAsk.willingness,
     marketHeat: Math.round(heat * 100) / 100,
+    // V2 negotiation context
+    leverageLabel: negCtx.leverageLabel,
+    reputationLabel: negCtx.reputationLabel,
+    feedbackLine: negCtx.feedbackLine,
+    leverageReasons: playerLeverage.reasons,
+    franchiseReasons: franchiseRep.reasons,
+    negotiationShift: ask._negotiationShift ?? 0,
   };
 }
 
@@ -6763,12 +6789,20 @@ async function handleGetFreeAgents(payload, id) {
         const userOffer = offers.find(o => o.teamId === userTeamId);
         const profile = buildContractProfile(p);
         const heat = computeMarketHeat(p.pos, allFreeAgents);
-        const ask = inflateContract(buildDemandFromProfile(p, profile, {
+        const baseAsk = inflateContract(buildDemandFromProfile(p, profile, {
           marketHeat: heat,
           morale: p.morale ?? 68,
           fit: Number(p?.schemeFit ?? 65),
           teamSuccess: userWinPct,
         }), inflationMult);
+        // V2: apply negotiation modifiers (morale, awards, franchise reputation)
+        const pMoraleSummary = getPlayerMoraleSummary(p);
+        const pAwardSummary = getPlayerAwardSummary(p);
+        const faCurrentSeason = Number(meta?.season ?? 0);
+        const pLeverage = computePlayerLeverage(p, { moraleSummary: pMoraleSummary, awardSummary: pAwardSummary, currentSeason: faCurrentSeason });
+        const fReputation = computeFranchiseReputation(meta, { userTeamId: Number(userTeamId ?? 0), currentSeason: faCurrentSeason });
+        const ask = applyNegotiationModifiers(baseAsk, pLeverage, fReputation);
+        const pNegCtx = getNegotiationContext(p, meta, { moraleSummary: pMoraleSummary, awardSummary: pAwardSummary, currentSeason: faCurrentSeason, userTeamId: Number(userTeamId ?? 0) });
         const reSignInsight = evaluateReSignPriority(p, {
           marketHeat: heat,
           teamDirection: userDirection,
@@ -6913,6 +6947,11 @@ async function handleGetFreeAgents(payload, id) {
             negotiationStance: userOfferEval.negotiationStance,
             fitScore: userOfferEval.score,
             explanationSummary: userOfferEval.explanationSummary,
+            // V2 negotiation modifier context
+            leverageLabel: pNegCtx.leverageLabel,
+            reputationLabel: pNegCtx.reputationLabel,
+            feedbackLine: pNegCtx.feedbackLine,
+            negotiationShift: ask._negotiationShift ?? 0,
           },
           playbookKnowledge: {
             score: Math.round(playbookKnowledgeScore),
@@ -7298,7 +7337,7 @@ async function handleGetExtensionAsk({ playerId }, id) {
     teamSuccess: ((team?.wins ?? 0) + (team?.ties ?? 0) * 0.5) / Math.max(1, (team?.wins ?? 0) + (team?.losses ?? 0) + (team?.ties ?? 0)),
   }), inflationMult);
   const baselineAsk = inflateContract(calculateExtensionDemand(player, meta?.difficulty ?? 'Normal') ?? {}, inflationMult);
-  const ask = {
+  const baseAsk = {
     ...baselineAsk,
     baseAnnual: Math.max(baselineAsk?.baseAnnual ?? 0, demandFromProfile.baseAnnual),
     signingBonus: Math.max(baselineAsk?.signingBonus ?? 0, demandFromProfile.signingBonus),
@@ -7309,6 +7348,21 @@ async function handleGetExtensionAsk({ playerId }, id) {
     profileHeadline: profile.headline,
     marketHeat: Math.round(marketHeat * 100) / 100,
     marketHeatLabel: marketHeatLabel(marketHeat),
+  };
+  // V2: apply negotiation modifiers
+  const extMoraleSummary = getPlayerMoraleSummary(player);
+  const extAwardSummary = getPlayerAwardSummary(player);
+  const extSeason = Number(meta?.season ?? 0);
+  const extTeamId = Number(meta?.userTeamId ?? 0);
+  const extLeverage = computePlayerLeverage(player, { moraleSummary: extMoraleSummary, awardSummary: extAwardSummary, currentSeason: extSeason });
+  const extFranchiseRep = computeFranchiseReputation(meta, { userTeamId: extTeamId, currentSeason: extSeason });
+  const modifiedAsk = applyNegotiationModifiers(baseAsk, extLeverage, extFranchiseRep);
+  const extNegCtx = getNegotiationContext(player, meta, { moraleSummary: extMoraleSummary, awardSummary: extAwardSummary, currentSeason: extSeason, userTeamId: extTeamId });
+  const ask = {
+    ...modifiedAsk,
+    leverageLabel: extNegCtx.leverageLabel,
+    reputationLabel: extNegCtx.reputationLabel,
+    feedbackLine: extNegCtx.feedbackLine,
   };
   post(toUI.EXTENSION_ASK, { ask }, id);
 }


### PR DESCRIPTION
Adds negotiationModifiers.js — a pure, deterministic module that shifts
player demand based on morale, award history, and franchise reputation.
Wires modifiers into the FA demand snapshot, extension ask, and
GET_FREE_AGENTS view. Adds leverage badges and feedback lines to
FreeAgency.jsx, PlayerProfile.jsx, and ContractNegotiation.jsx.

Modifier logic (all bounded ±25%):
  Player leverage: MVP recent (+15%), 2+ All-Pro (+10%), champion (+8%),
    disgruntled morale (+(-10%)), frustrated (-5%), thriving (+5%)
  Franchise rep: 2+ titles (-5%), playoff drought 3+ seasons (+8%)

Wire points:
  - buildDemandSnapshotForOffer (SUBMIT_OFFER path)
  - handleGetExtensionAsk (extension ask)
  - handleGetFreeAgents (FA browser demandProfile)

UI additions (compact, no redesign):
  - FreeAgency.jsx: leverage badge + reason on player row
  - PlayerProfile.jsx: negotiation profile line below awards section
  - ContractNegotiation.jsx: V2 feedback line in live preview

Tests: 65 new (37 unit, 15 integration, 13 UI); all 2977 pass.

Guardrails:
  - No sim engine changes
  - No morale/award engine internals modified
  - No FA V2 patience/expiry/ledger logic changed
  - No new dependencies
  - No holdouts, arbitration, or multi-year structure

https://claude.ai/code/session_01Sv5PzH9uuYpn6Gwxh3fKtU