### PR TITLE
feat(hof): implement Hall of Fame Voting V1

### DIFF
--- a/src/core/awards/hofEngine.js
+++ b/src/core/awards/hofEngine.js
@@ -1,0 +1,432 @@
+/**
+ * hofEngine.js — Hall of Fame Voting V1
+ *
+ * Pure module: no side effects, no imports from worker/UI/news/holdout/morale/sim.
+ * Deterministic: same input always produces same output. No Math.random.
+ *
+ * Exported API:
+ *   HOF_THRESHOLDS
+ *   computeHofScore(player, careerStats, awardSummary) → number
+ *   isHofEligible(player, currentSeason, stats, awardSummary) → boolean
+ *   generateHofBallot(allPlayers, allCareerStats, meta, season) → { nominees[], autoInducted[] }
+ *   resolveHofVote(ballot, allPlayers) → { inducted[], remaining[] }
+ *   applyHofInductions(meta, inductedEntries, allNominees, allPlayers, season) → meta fragment
+ *   getHofSummary(meta) → { totalInducted, byPosition, recentClass[] }
+ *   ensureHofMeta(meta) → meta with hofRoster/hofBallot defaults
+ */
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const HOF_THRESHOLDS = Object.freeze({
+  ELIGIBLE_SCORE: 120,
+  INDUCTION_SCORE: 160,
+  MVP_SHORTCUT_SCORE: 120,
+  MVP_SHORTCUT_COUNT: 2,
+  MAX_BALLOT_SIZE: 10,
+  MAX_INDUCTIONS: 5,
+  MAX_BALLOT_APPEARANCES: 3,
+  LONGEVITY_BONUS_10: 25,
+  LONGEVITY_BONUS_14: 50,
+  SEASONS_REQUIREMENT: 12,
+});
+
+// ── Position normalization ────────────────────────────────────────────────────
+
+function normPos(pos) {
+  if (!pos) return '';
+  const p = String(pos).toUpperCase();
+  if (p === 'FB') return 'RB';
+  if (['SS', 'FS'].includes(p)) return 'S';
+  if (['OT', 'OG', 'G', 'T', 'C'].includes(p)) return 'OL';
+  if (['DE', 'DT', 'EDGE', 'NT'].includes(p)) return 'DL';
+  if (['MLB', 'OLB'].includes(p)) return 'LB';
+  return p;
+}
+
+// ── Season year resolver ──────────────────────────────────────────────────────
+
+function resolveSeasonYear(seasonToken) {
+  if (seasonToken == null) return 0;
+  const n = Number(seasonToken);
+  if (Number.isFinite(n) && n > 1000) return n;
+  const s = String(seasonToken);
+  if (s.startsWith('s')) {
+    const idx = parseInt(s.slice(1), 10);
+    if (Number.isFinite(idx)) return 2024 + idx;
+  }
+  const parsed = parseInt(s, 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+// ── Career stats aggregation ──────────────────────────────────────────────────
+
+function aggregateCareerStats(player) {
+  const lines = Array.isArray(player?.careerStats) ? player.careerStats : [];
+  return lines.reduce((acc, s) => {
+    acc.passTD += Number(s.passTD ?? s.passTDs ?? 0);
+    acc.passYd += Number(s.passYd ?? s.passYds ?? 0);
+    acc.rushTD += Number(s.rushTD ?? s.rushTDs ?? 0);
+    acc.rushYd += Number(s.rushYd ?? s.rushYds ?? 0);
+    acc.recTD += Number(s.recTD ?? s.recTDs ?? 0);
+    acc.recYd += Number(s.recYd ?? s.recYds ?? 0);
+    acc.receptions += Number(s.receptions ?? 0);
+    acc.sacks += Number(s.sacks ?? 0);
+    acc.interceptions += Number(s.defInts ?? s.interceptions ?? 0);
+    acc.tackles += Number(s.tackles ?? 0);
+    acc.fgMade += Number(s.fgMade ?? 0);
+    acc.fgAttempted += Number(s.fgAttempts ?? s.fgAttempted ?? 0);
+    return acc;
+  }, {
+    passTD: 0, passYd: 0, rushTD: 0, rushYd: 0, recTD: 0, recYd: 0,
+    receptions: 0, sacks: 0, interceptions: 0, tackles: 0, fgMade: 0, fgAttempted: 0,
+  });
+}
+
+function getCareerSeasons(player) {
+  return Array.isArray(player?.careerStats) ? player.careerStats.length : 0;
+}
+
+// ── HOF Score Formula ─────────────────────────────────────────────────────────
+
+/**
+ * Compute a deterministic HOF score. No Math.random.
+ *
+ * @param {Object} player      — Player object (pos, careerStats)
+ * @param {Object|null} stats  — Pre-aggregated career stat totals, or null to aggregate from player.careerStats
+ * @param {Object} awardSummary — { mvpCount, allProCount, championshipCount }
+ * @returns {number}
+ */
+export function computeHofScore(player, stats, awardSummary) {
+  const pos = normPos(player?.pos ?? '');
+  const cs = stats ?? aggregateCareerStats(player);
+  const seasons = getCareerSeasons(player);
+
+  const mvpCount = Number(awardSummary?.mvpCount ?? 0);
+  const allProCount = Number(awardSummary?.allProCount ?? 0);
+  const championshipCount = Number(awardSummary?.championshipCount ?? 0);
+
+  let base = 0;
+
+  if (pos === 'QB') {
+    base = cs.passTD * 3 + cs.passYd / 250 + cs.rushTD * 2;
+  } else if (pos === 'RB') {
+    base = cs.rushTD * 4 + cs.rushYd / 60 + cs.recTD * 3;
+  } else if (['WR', 'TE'].includes(pos)) {
+    base = cs.recTD * 4 + cs.recYd / 60 + cs.receptions / 5;
+  } else if (['DL', 'LB', 'CB', 'S'].includes(pos)) {
+    base = cs.sacks * 5 + cs.interceptions * 6 + cs.tackles / 20;
+  } else if (pos === 'OL') {
+    // proWins = All-Pro selections (proxy for OL excellence; no direct stat)
+    base = seasons * 8 + allProCount * 10;
+  } else if (pos === 'K') {
+    const fgAtt = Math.max(cs.fgAttempted, 1);
+    base = cs.fgMade * 2 + (cs.fgMade / fgAtt) * 50;
+  }
+
+  const awardBonus = mvpCount * 40 + allProCount * 15 + championshipCount * 20;
+
+  let longevityBonus = 0;
+  if (seasons >= 14) {
+    longevityBonus = HOF_THRESHOLDS.LONGEVITY_BONUS_10 + HOF_THRESHOLDS.LONGEVITY_BONUS_14;
+  } else if (seasons >= 10) {
+    longevityBonus = HOF_THRESHOLDS.LONGEVITY_BONUS_10;
+  }
+
+  return base + awardBonus + longevityBonus;
+}
+
+// ── Eligibility Check ─────────────────────────────────────────────────────────
+
+/**
+ * Check if a player is eligible for the HOF ballot.
+ *
+ * Rules:
+ *  1. Not already inducted
+ *  2. Retired (no active contract) OR seasons >= 12
+ *  3. hofScore >= 120
+ *  4. At least 1 season since their last active season (no active player inductions in V1)
+ *
+ * @param {Object} player        — Player object
+ * @param {number} currentSeason — Current season year (numeric)
+ * @param {Object|null} stats    — Pre-aggregated career stats (optional)
+ * @param {Object|null} awardSummary — { mvpCount, allProCount, championshipCount } (optional)
+ * @returns {boolean}
+ */
+export function isHofEligible(player, currentSeason, stats, awardSummary) {
+  // Rule 1: Not already inducted
+  if (player?.hofStatus === 'inducted') return false;
+  if (player?.hof === true) return false;
+
+  const seasons = getCareerSeasons(player);
+  const isRetired = player?.status === 'retired';
+
+  // Rule 2: Retired OR seasons >= 12
+  if (!isRetired && seasons < HOF_THRESHOLDS.SEASONS_REQUIREMENT) return false;
+
+  // Rule 4: No active player inductions in V1 — must be retired
+  if (!isRetired) return false;
+
+  // Rule 4 continued: at least 1 season gap since last active season
+  const careerLines = Array.isArray(player?.careerStats) ? player.careerStats : [];
+  if (careerLines.length > 0) {
+    const lastLine = careerLines[careerLines.length - 1];
+    const lastYear = resolveSeasonYear(lastLine?.season ?? lastLine?.year ?? lastLine?.seasonId);
+    if (lastYear >= currentSeason) return false;
+  }
+
+  // Rule 3: score threshold
+  const aw = awardSummary ?? { mvpCount: 0, allProCount: 0, championshipCount: 0 };
+  const score = computeHofScore(player, stats, aw);
+  return score >= HOF_THRESHOLDS.ELIGIBLE_SCORE;
+}
+
+// ── HOF Ballot ────────────────────────────────────────────────────────────────
+
+function buildHofReasons(score, awardSummary, seasons) {
+  const reasons = [];
+  if (awardSummary.mvpCount > 0) reasons.push(`${awardSummary.mvpCount}× MVP`);
+  if (awardSummary.allProCount > 0) reasons.push(`${awardSummary.allProCount}× All-Pro`);
+  if (awardSummary.championshipCount > 0) reasons.push(`${awardSummary.championshipCount}× Champion`);
+  if (seasons >= 14) reasons.push('14+ season career');
+  else if (seasons >= 10) reasons.push('10+ season career');
+  return reasons;
+}
+
+/**
+ * Generate the HOF ballot for a season. Pure and deterministic.
+ *
+ * @param {Array} allPlayers    — All player objects
+ * @param {Object|null} allCareerStats — Map<playerId, stats> or null (uses player.careerStats)
+ * @param {Object} meta         — Current meta (hofRoster, hofBallot for prior ballot tracking)
+ * @param {number} season       — Current season year
+ * @returns {{ nominees: Array, autoInducted: Array }}
+ */
+export function generateHofBallot(allPlayers, allCareerStats, meta, season) {
+  const hofRoster = Array.isArray(meta?.hofRoster) ? meta.hofRoster : [];
+  const inductedIds = new Set(hofRoster.map(r => String(r.playerId)));
+
+  // Track prior ballot appearance counts (for lapse rule)
+  const priorBallot = meta?.hofBallot ?? null;
+  const priorBallotMap = new Map();
+  if (Array.isArray(priorBallot?.nominees)) {
+    for (const n of priorBallot.nominees) {
+      const pidStr = String(n.playerId);
+      if (!inductedIds.has(pidStr)) {
+        priorBallotMap.set(pidStr, Number(n.ballotCount ?? 0));
+      }
+    }
+  }
+
+  const candidates = [];
+
+  for (const player of allPlayers) {
+    if (!player?.id) continue;
+    const pidStr = String(player.id);
+
+    // Skip already inducted (new schema or legacy)
+    if (inductedIds.has(pidStr)) continue;
+    if (player?.hofStatus === 'inducted') continue;
+    if (player?.hof === true) continue;
+
+    // Resolve stats
+    const extStats = allCareerStats
+      ? (allCareerStats.get ? allCareerStats.get(pidStr) : allCareerStats[pidStr]) ?? null
+      : null;
+    const resolvedStats = extStats ?? aggregateCareerStats(player);
+
+    // Inline award summary (avoid importing awardEngine)
+    const awards = Array.isArray(player?.awards) ? player.awards : [];
+    const mvpCount = awards.filter(a => a.type === 'MVP').length;
+    const allProCount = awards.filter(a => typeof a.type === 'string' && a.type.startsWith('ALL_PRO_')).length;
+    const championshipCount = awards.filter(a => a.type === 'LEAGUE_CHAMPION').length;
+    const awardSummary = { mvpCount, allProCount, championshipCount };
+
+    const score = computeHofScore(player, resolvedStats, awardSummary);
+    if (score < HOF_THRESHOLDS.ELIGIBLE_SCORE) continue;
+    if (!isHofEligible(player, season, resolvedStats, awardSummary)) continue;
+
+    // Ballot appearance count
+    const priorCount = priorBallotMap.get(pidStr) ?? 0;
+    // Lapse: skip if already appeared MAX_BALLOT_APPEARANCES times without induction
+    if (priorCount >= HOF_THRESHOLDS.MAX_BALLOT_APPEARANCES) continue;
+    const ballotCount = priorCount + 1;
+
+    const pos = normPos(player?.pos ?? '');
+    const seasons = getCareerSeasons(player);
+    const reasons = buildHofReasons(score, awardSummary, seasons);
+
+    candidates.push({
+      playerId: player.id,
+      playerName: player.name ?? '',
+      pos,
+      score,
+      reasons,
+      mvpCount,
+      allProCount,
+      ballotCount,
+    });
+  }
+
+  // Deterministic sort: score desc, then playerId string asc as tiebreaker
+  candidates.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return String(a.playerId).localeCompare(String(b.playerId));
+  });
+
+  const nominees = candidates.slice(0, HOF_THRESHOLDS.MAX_BALLOT_SIZE);
+  const autoInducted = nominees.filter(n => n.score >= HOF_THRESHOLDS.INDUCTION_SCORE);
+
+  return { nominees, autoInducted };
+}
+
+// ── Resolve HOF Vote ─────────────────────────────────────────────────────────
+
+/**
+ * Resolve the HOF vote. Pure and deterministic.
+ *
+ * Auto-inducts score >= 160. Also inducts score 120-159 with 2+ MVPs.
+ * Caps at 5 inductees per season.
+ *
+ * @param {Object} ballot    — Output of generateHofBallot
+ * @param {Array} _allPlayers — Unused in V1 (reserved for future voter simulation)
+ * @returns {{ inducted: Array, remaining: Array }}
+ */
+export function resolveHofVote(ballot, _allPlayers) {
+  const { nominees = [], autoInducted = [] } = ballot;
+
+  const inductedIds = new Set(autoInducted.map(n => String(n.playerId)));
+  const inducted = [...autoInducted];
+
+  // MVP shortcut: score 120-159 with 2+ MVPs
+  for (const nominee of nominees) {
+    const pidStr = String(nominee.playerId);
+    if (inductedIds.has(pidStr)) continue;
+    if (
+      nominee.score >= HOF_THRESHOLDS.MVP_SHORTCUT_SCORE &&
+      nominee.score < HOF_THRESHOLDS.INDUCTION_SCORE &&
+      nominee.mvpCount >= HOF_THRESHOLDS.MVP_SHORTCUT_COUNT
+    ) {
+      inducted.push(nominee);
+      inductedIds.add(pidStr);
+    }
+  }
+
+  // Cap at MAX_INDUCTIONS per season
+  const inductedCapped = inducted.slice(0, HOF_THRESHOLDS.MAX_INDUCTIONS);
+  const cappedIds = new Set(inductedCapped.map(n => String(n.playerId)));
+
+  // Remaining nominees (not inducted this season, still on ballot)
+  const remaining = nominees.filter(n => !cappedIds.has(String(n.playerId)));
+
+  // Deduplicate inducted list (safety guard)
+  const seen = new Set();
+  const deduped = [];
+  for (const entry of inductedCapped) {
+    const key = String(entry.playerId);
+    if (!seen.has(key)) {
+      seen.add(key);
+      deduped.push(entry);
+    }
+  }
+
+  return { inducted: deduped, remaining };
+}
+
+// ── Apply HOF Inductions ─────────────────────────────────────────────────────
+
+/**
+ * Apply HOF inductions to meta. Returns the meta fragment to merge.
+ *
+ * @param {Object} meta           — Current meta
+ * @param {Array} inductedEntries — Nominee entries from resolveHofVote.inducted
+ * @param {Array} allNominees     — Full ballot nominee list (for ballot record)
+ * @param {Array} allPlayers      — All player objects (for snapshot data)
+ * @param {number} season         — Current season year
+ * @returns {{ hofRoster: Array, hofBallot: Object }}
+ */
+export function applyHofInductions(meta, inductedEntries, allNominees, allPlayers, season) {
+  const hofRoster = Array.isArray(meta?.hofRoster) ? [...meta.hofRoster] : [];
+  const alreadyInducted = new Set(hofRoster.map(r => String(r.playerId)));
+
+  const playerById = new Map((allPlayers || []).map(p => [String(p.id), p]));
+
+  for (const entry of inductedEntries) {
+    const pidStr = String(entry.playerId);
+    if (alreadyInducted.has(pidStr)) continue;
+
+    const player = playerById.get(pidStr);
+    const careerLines = Array.isArray(player?.careerStats) ? player.careerStats : [];
+    // Team abbreviations from career history (exclude FA)
+    const teamAbbrs = [...new Set(
+      careerLines.map(l => l.team ?? null).filter(t => t && t !== 'FA'),
+    )];
+
+    hofRoster.push({
+      playerId: entry.playerId,
+      playerName: entry.playerName ?? player?.name ?? '',
+      position: entry.pos ?? normPos(player?.pos ?? ''),
+      seasons: careerLines.length,
+      teamIds: teamAbbrs,
+      inductionSeason: season,
+      awards: Array.isArray(player?.awards) ? [...player.awards] : [],
+      careerStats: aggregateCareerStats(player ?? {}),
+      hofScore: entry.score,
+    });
+
+    alreadyInducted.add(pidStr);
+  }
+
+  return {
+    hofRoster,
+    hofBallot: {
+      season,
+      nominees: allNominees.map(n => ({
+        playerId: n.playerId,
+        score: n.score,
+        reasons: n.reasons ?? [],
+        ballotCount: n.ballotCount ?? 1,
+      })),
+      inducted: inductedEntries.map(e => e.playerId),
+      resolved: true,
+    },
+  };
+}
+
+// ── HOF Summary ──────────────────────────────────────────────────────────────
+
+/**
+ * Build a summary of the HOF roster for display.
+ *
+ * @param {Object} meta
+ * @returns {{ totalInducted: number, byPosition: Object, recentClass: Array }}
+ */
+export function getHofSummary(meta) {
+  const hofRoster = Array.isArray(meta?.hofRoster) ? meta.hofRoster : [];
+
+  const byPosition = {};
+  for (const entry of hofRoster) {
+    const pos = entry.position ?? 'UNK';
+    byPosition[pos] = (byPosition[pos] ?? 0) + 1;
+  }
+
+  const recentClass = [...hofRoster]
+    .sort((a, b) => Number(b.inductionSeason ?? 0) - Number(a.inductionSeason ?? 0))
+    .slice(0, 5);
+
+  return { totalInducted: hofRoster.length, byPosition, recentClass };
+}
+
+// ── Safe hydration ───────────────────────────────────────────────────────────
+
+/**
+ * Ensure meta has the required HOF fields. Safe for old saves without these fields.
+ */
+export function ensureHofMeta(meta) {
+  if (!meta) return meta;
+  const out = { ...meta };
+  if (!Array.isArray(out.hofRoster)) out.hofRoster = [];
+  if (out.hofBallot == null) {
+    out.hofBallot = { season: null, nominees: [], inducted: [], resolved: false };
+  }
+  return out;
+}

--- a/src/core/news-engine.js
+++ b/src/core/news-engine.js
@@ -292,6 +292,21 @@ export const createNewsItem = (type, data, week, season) => {
             body: (d) => `${d?.playerName ?? 'A player'} has been moved to backup.`,
             priority: 'low',
         },
+        hof_inducted: {
+            headline: (d) => `${d?.playerName ?? 'Player'} inducted into the Hall of Fame`,
+            body: (d) => `${d?.playerName ?? 'Player'} has been inducted into the Hall of Fame.`,
+            priority: 'high',
+        },
+        hof_eligible: {
+            headline: (d) => `${d?.playerName ?? 'Player'} is now HOF eligible`,
+            body: (d) => `${d?.playerName ?? 'Player'} is now eligible for Hall of Fame consideration.`,
+            priority: 'medium',
+        },
+        hof_class: {
+            headline: (d) => `${d?.season ?? 'This year'}'s Hall of Fame class announced`,
+            body: (d) => `The ${d?.season ?? 'season'} Hall of Fame class has been announced: ${d?.names ?? 'several legends'}.`,
+            priority: 'high',
+        },
     };
     const template = templates[type];
     if (!template) return null;

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -829,6 +829,47 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
         );
       })()}
 
+      {/* ── Hall of Famers ── */}
+      {(() => {
+        const userTeamId = Number(league?.userTeamId);
+        const userTeam = (league?.teams ?? []).find((t) => Number(t?.id) === userTeamId);
+        const userTeamAbbr = userTeam?.abbr ?? null;
+        const hofRoster = Array.isArray(league?.hofRoster) ? league.hofRoster : [];
+        const franchiseLegends = hofRoster.filter((h) =>
+          Array.isArray(h.teamIds) && userTeamAbbr && h.teamIds.includes(userTeamAbbr),
+        ).sort((a, b) => Number(b.inductionSeason ?? 0) - Number(a.inductionSeason ?? 0));
+        if (franchiseLegends.length === 0) return null;
+        return (
+          <SectionCard
+            title="Hall of Famers"
+            subtitle="Legends who wore your franchise's colors."
+            variant="compact"
+            data-testid="hq-hall-of-famers"
+          >
+            <details className="app-hq-background-section__inner">
+              <summary className="app-hq-section-expand">Show Hall of Famers ▾</summary>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 6, paddingTop: 8, maxHeight: 260, overflowY: 'auto' }}>
+                {franchiseLegends.map((h) => (
+                  <div
+                    key={`hof-${h.playerId}`}
+                    style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '4px 0', borderBottom: '1px solid var(--hairline)' }}
+                  >
+                    <span style={{ fontSize: '1.1rem' }}>★</span>
+                    <span style={{ fontWeight: 700, color: 'var(--warning)' }}>{h.inductionSeason}</span>
+                    <span style={{ color: 'var(--text)', fontSize: 'var(--text-xs)' }}>
+                      {h.position} {h.playerName}
+                    </span>
+                    <span style={{ color: 'var(--text-muted)', fontSize: 'var(--text-xs)', marginLeft: 'auto' }}>
+                      Score {Math.round(h.hofScore ?? 0)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </details>
+          </SectionCard>
+        );
+      })()}
+
       {lineupToast ? <p className="app-inline-toast" role="status" aria-live="polite">{lineupToast}</p> : null}
 
       {showGate ? (

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -1036,6 +1036,42 @@ export default function LeagueDashboard({
             </div>
           );
         })()}
+        {activeTab === "League" && (() => {
+          const phase = league?.phase ?? 'regular';
+          const isPostSeason = !['regular', 'preseason', 'playoffs'].includes(phase);
+          if (!isPostSeason) return null;
+          const hofBallot = league?.hofBallot ?? null;
+          const hofRoster = Array.isArray(league?.hofRoster) ? league.hofRoster : [];
+          if (!hofBallot?.resolved) return null;
+          const inductedIds = new Set((hofBallot.inducted ?? []).map(String));
+          const inductees = hofRoster.filter((h) => inductedIds.has(String(h.playerId)) && Number(h.inductionSeason) === Number(hofBallot.season));
+          if (inductees.length === 0) return null;
+          return (
+            <div
+              data-testid="hof-class-panel"
+              style={{
+                margin: '0 0 var(--space-4)',
+                padding: 'var(--space-3) var(--space-4)',
+                borderRadius: 'var(--radius-md)',
+                border: '1px solid var(--hairline)',
+                background: 'var(--surface-strong)',
+              }}
+            >
+              <div style={{ fontWeight: 700, fontSize: 'var(--text-sm)', color: 'var(--warning)', marginBottom: 8 }}>
+                ★ {hofBallot.season} Hall of Fame Class
+              </div>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))', gap: 6 }}>
+                {inductees.map((h) => (
+                  <div key={`hof-class-${h.playerId}`} style={{ fontSize: 'var(--text-xs)' }}>
+                    <span style={{ color: 'var(--text-muted)', fontWeight: 700 }}>{h.position} </span>
+                    <span style={{ color: 'var(--text)' }}>{h.playerName}</span>
+                    <span style={{ color: 'var(--text-muted)' }}> · {Math.round(h.hofScore ?? 0)}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })()}
         {activeTab === "League Pulse" && (
           <LeaguePulseTimeline
             league={league}

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -1408,6 +1408,43 @@ export default function PlayerProfile({
                   );
                 })()}
 
+                {/* ── HOF Status Badge ── */}
+                {playerView && (() => {
+                  const hofStatus = playerView.hofStatus ?? (playerView.hof ? 'inducted' : 'none');
+                  if (hofStatus === 'none') return null;
+                  const isInducted = hofStatus === 'inducted';
+                  const isNominee = hofStatus === 'nominee';
+                  const badgeLabel = isInducted ? 'Hall of Famer' : isNominee ? 'HOF Nominee' : 'HOF Eligible';
+                  const badgeColor = isInducted ? 'var(--warning)' : isNominee ? '#a8a8a8' : 'var(--text-subtle)';
+                  const badgeBorder = isInducted ? '#b8860b' : isNominee ? '#888' : 'var(--hairline)';
+                  return (
+                    <div
+                      data-testid="player-profile-hof-badge"
+                      style={{
+                        marginTop: 'var(--space-2)',
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 6,
+                        padding: '3px 10px',
+                        borderRadius: 'var(--radius-pill)',
+                        border: `1px solid ${badgeBorder}`,
+                        background: isInducted ? 'rgba(184,134,11,0.1)' : 'transparent',
+                        fontSize: 'var(--text-xs)',
+                        fontWeight: 700,
+                        color: badgeColor,
+                      }}
+                    >
+                      {isInducted ? '★' : isNominee ? '◈' : '○'} {badgeLabel}
+                      {isInducted && playerView.hofInductionSeason && (
+                        <span style={{ fontWeight: 400, opacity: 0.75 }}>· {playerView.hofInductionSeason}</span>
+                      )}
+                      {isInducted && playerView.hofScore != null && (
+                        <span style={{ fontWeight: 400, opacity: 0.75 }}>· Score {Math.round(playerView.hofScore)}</span>
+                      )}
+                    </div>
+                  );
+                })()}
+
                 {/* ── Negotiation Profile ── */}
                 {playerView && (() => {
                   const moraleSummary = getPlayerMoraleSummary(playerView);

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -150,6 +150,7 @@ import NewsEngine, { createNewsItem, addNewsItem } from '../core/news-engine.js'
 import { parseWeeklyHeadlines } from '../core/history/NewsEngine.ts';
 import { calculateAwardRaces, selectProBowlers } from '../core/awards-logic.js';
 import { determineSeasonAwards, applySeasonAwards, checkCareerMilestones, getPlayerAwardSummary, AWARD_TYPES as ENGINE_AWARD_TYPES, AWARD_LABELS as ENGINE_AWARD_LABELS } from '../core/awards/awardEngine.js';
+import { generateHofBallot, resolveHofVote, applyHofInductions, ensureHofMeta } from '../core/awards/hofEngine.js';
 import { Constants } from '../core/constants.js';
 import { processPlayerProgression } from '../core/progression-logic.js';
 import { getZeroStats as getZeroSeasonStatsSchema } from '../core/state.js';
@@ -1053,6 +1054,8 @@ function buildViewState() {
     franchiseSeasonReviews: Array.isArray(meta?.franchiseSeasonReviews) ? meta.franchiseSeasonReviews.slice(-40) : [],
     seasonStorylines: Array.isArray(meta?.seasonStorylines) ? meta.seasonStorylines : [],
     hallOfFameClasses: Array.isArray(meta?.hallOfFame?.classes) ? meta.hallOfFame.classes.slice(0, 20) : [],
+    hofRoster: Array.isArray(meta?.hofRoster) ? meta.hofRoster.slice(-100) : [],
+    hofBallot: meta?.hofBallot ?? null,
     weeklyHeadlines: Array.isArray(meta?.weeklyHeadlines) ? meta.weeklyHeadlines.slice(-40) : [],
     settings: normalizeLeagueSettings(meta?.settings ?? {}),
     economy: normalizeLeagueEconomy(meta?.economy ?? {}, { year: meta?.year }),
@@ -10604,6 +10607,76 @@ async function archiveSeason(seasonId) {
       await flushDirty();
     } catch (awardEngineErr) {
       console.error('[Worker] Award engine V1 failed (non-fatal):', awardEngineErr);
+    }
+
+    // ── HOF Engine V1: ballot generation, voting, inductions ──────────────────
+    try {
+      const allPlayersForHof = cache.getAllPlayers();
+      const metaForHof = ensureHofMeta(cache.getMeta());
+
+      const ballot = generateHofBallot(allPlayersForHof, null, metaForHof, year);
+      const { inducted, remaining } = resolveHofVote(ballot, allPlayersForHof);
+
+      if (ballot.nominees.length > 0 || inducted.length > 0) {
+        const hofUpdates = applyHofInductions(
+          metaForHof,
+          inducted,
+          ballot.nominees,
+          allPlayersForHof,
+          year,
+        );
+        cache.setMeta(hofUpdates);
+
+        // Update player.hofStatus for nominees and inductees
+        const inductedSet = new Set(inducted.map(e => String(e.playerId)));
+        const nomineeSet = new Set(ballot.nominees.map(n => String(n.playerId)));
+        for (const p of allPlayersForHof) {
+          const pidStr = String(p.id);
+          if (inductedSet.has(pidStr)) {
+            cache.updatePlayer(p.id, { hofStatus: 'inducted', hofScore: (inducted.find(e => String(e.playerId) === pidStr))?.score ?? p.hofScore, hofInductionSeason: year });
+          } else if (nomineeSet.has(pidStr) && p.hofStatus !== 'inducted') {
+            cache.updatePlayer(p.id, { hofStatus: 'nominee' });
+          }
+        }
+
+        // News: individual inductee items
+        for (const entry of inducted) {
+          await NewsEngine.logNews(
+            'HOF',
+            `HALL OF FAME: ${entry.pos} ${entry.playerName} has been inducted into the Hall of Fame!`,
+            null,
+            { category: 'hof_inducted', playerId: entry.playerId, season: year, hofScore: entry.score, dedupeKey: `news_hof_inducted_${entry.playerId}_${year}` },
+          );
+        }
+
+        // News: HOF class announcement
+        if (inducted.length > 0) {
+          const names = inducted.map(e => e.playerName).filter(Boolean).join(', ');
+          await NewsEngine.logNews(
+            'HOF',
+            `The ${year} Hall of Fame class has been announced: ${names}.`,
+            null,
+            { category: 'hof_class', season: year, inducteeCount: inducted.length, dedupeKey: `news_hof_class_${year}` },
+          );
+
+          // Pulse item for HOF induction class
+          const currentPulse = Array.isArray(cache.getMeta()?.franchiseChronicle) ? cache.getMeta().franchiseChronicle : [];
+          const hofPulseItem = {
+            season: year,
+            week: meta.currentWeek ?? 22,
+            type: 'general',
+            importance: 85,
+            headline: `${year} Hall of Fame Class Announced`,
+            body: `${inducted.length} player${inducted.length === 1 ? '' : 's'} inducted into the Hall of Fame this season.`,
+            dedupeKey: `hof_class_${year}`,
+          };
+          cache.setMeta({ franchiseChronicle: mergeLeaguePulseItems(currentPulse, [hofPulseItem]) });
+        }
+
+        await flushDirty();
+      }
+    } catch (hofErr) {
+      console.error('[Worker] HOF Engine V1 failed (non-fatal):', hofErr);
     }
 
     // ── Record Book: check for broken single-season & all-time records ──────

--- a/tests/unit/hofEngine.test.js
+++ b/tests/unit/hofEngine.test.js
@@ -1,0 +1,510 @@
+/**
+ * hofEngine.test.js — Hall of Fame Voting V1 unit tests
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  HOF_THRESHOLDS,
+  computeHofScore,
+  isHofEligible,
+  generateHofBallot,
+  resolveHofVote,
+  applyHofInductions,
+  getHofSummary,
+  ensureHofMeta,
+} from '../../src/core/awards/hofEngine.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makePlayer(overrides = {}) {
+  return {
+    id: 'p1',
+    name: 'Test Player',
+    pos: 'QB',
+    status: 'retired',
+    hofStatus: 'none',
+    awards: [],
+    careerStats: [],
+    ...overrides,
+  };
+}
+
+function makeCareerStats(seasons, careerTotals = {}) {
+  // Stats go into the FIRST entry only so aggregate == careerTotals.
+  // Remaining entries are zeroed. careerStats.length == seasons (for longevity).
+  return Array.from({ length: seasons }, (_, i) => ({
+    season: `s${i + 1}`,
+    team: 'KC',
+    passTD: i === 0 ? (careerTotals.passTD ?? 0) : 0,
+    passYd: i === 0 ? (careerTotals.passYd ?? 0) : 0,
+    rushTD: i === 0 ? (careerTotals.rushTD ?? 0) : 0,
+    rushYd: i === 0 ? (careerTotals.rushYd ?? 0) : 0,
+    recTD: i === 0 ? (careerTotals.recTD ?? 0) : 0,
+    recYd: i === 0 ? (careerTotals.recYd ?? 0) : 0,
+    receptions: i === 0 ? (careerTotals.receptions ?? 0) : 0,
+    sacks: i === 0 ? (careerTotals.sacks ?? 0) : 0,
+    interceptions: i === 0 ? (careerTotals.interceptions ?? 0) : 0,
+    tackles: i === 0 ? (careerTotals.tackles ?? 0) : 0,
+    fgMade: i === 0 ? (careerTotals.fgMade ?? 0) : 0,
+    fgAttempts: i === 0 ? (careerTotals.fgAttempts ?? 0) : 0,
+  }));
+}
+
+function makeAwardSummary(overrides = {}) {
+  return { mvpCount: 0, allProCount: 0, championshipCount: 0, ...overrides };
+}
+
+// ── computeHofScore ───────────────────────────────────────────────────────────
+
+describe('computeHofScore — position formulas', () => {
+  it('QB: passTd×3 + passYd/250 + rushTd×2', () => {
+    const player = makePlayer({ pos: 'QB', careerStats: makeCareerStats(8, { passTD: 40, passYd: 5000, rushTD: 5 }) });
+    // base = 40×3 + 5000/250 + 5×2 = 120 + 20 + 10 = 150
+    expect(computeHofScore(player, null, makeAwardSummary())).toBeCloseTo(150);
+  });
+
+  it('RB: rushTd×4 + rushYd/60 + recTd×3', () => {
+    const player = makePlayer({ pos: 'RB', careerStats: makeCareerStats(8, { rushTD: 20, rushYd: 9000, recTD: 5 }) });
+    // base = 20×4 + 9000/60 + 5×3 = 80 + 150 + 15 = 245
+    expect(computeHofScore(player, null, makeAwardSummary())).toBeCloseTo(245);
+  });
+
+  it('WR: recTd×4 + recYd/60 + receptions/5', () => {
+    const player = makePlayer({ pos: 'WR', careerStats: makeCareerStats(8, { recTD: 25, recYd: 9000, receptions: 600 }) });
+    // base = 25×4 + 9000/60 + 600/5 = 100 + 150 + 120 = 370
+    expect(computeHofScore(player, null, makeAwardSummary())).toBeCloseTo(370);
+  });
+
+  it('TE: same formula as WR', () => {
+    const player = makePlayer({ pos: 'TE', careerStats: makeCareerStats(8, { recTD: 10, recYd: 5000, receptions: 400 }) });
+    // base = 10×4 + 5000/60 + 400/5 = 40 + 83.33 + 80 = 203.33
+    expect(computeHofScore(player, null, makeAwardSummary())).toBeCloseTo(203.33, 0);
+  });
+
+  it('DB (CB): sacks×5 + int×6 + tackles/20', () => {
+    const player = makePlayer({ pos: 'CB', careerStats: makeCareerStats(8, { sacks: 0, interceptions: 30, tackles: 400 }) });
+    // base = 0 + 30×6 + 400/20 = 0 + 180 + 20 = 200
+    expect(computeHofScore(player, null, makeAwardSummary())).toBeCloseTo(200);
+  });
+
+  it('OL: seasons×8 + allProCount×10', () => {
+    const player = makePlayer({ pos: 'OL', careerStats: makeCareerStats(12) });
+    const aw = makeAwardSummary({ allProCount: 5 });
+    // base = 12×8 + 5×10 = 96 + 50 = 146; longevity = 25 (10 seasons); award bonus = 5×15 = 75
+    // total = 146 + 25 + 75 = 246
+    expect(computeHofScore(player, null, aw)).toBeCloseTo(246);
+  });
+
+  it('K: fgMade×2 + (fgMade/fgAttempted)×50', () => {
+    const player = makePlayer({ pos: 'K', careerStats: makeCareerStats(10, { fgMade: 300, fgAttempts: 350 }) });
+    // base = 300×2 + (300/350)×50 = 600 + 42.86 = 642.86
+    // longevity = 25 (10 seasons); award bonus = 0
+    const score = computeHofScore(player, null, makeAwardSummary());
+    expect(score).toBeCloseTo(667.86, 0);
+  });
+
+  it('DL: sacks×5 + int×6 + tackles/20', () => {
+    const player = makePlayer({ pos: 'DL', careerStats: makeCareerStats(8, { sacks: 120, interceptions: 2, tackles: 300 }) });
+    // base = 120×5 + 2×6 + 300/20 = 600 + 12 + 15 = 627
+    expect(computeHofScore(player, null, makeAwardSummary())).toBeCloseTo(627);
+  });
+
+  it('S (Safety): sacks×5 + int×6 + tackles/20', () => {
+    const player = makePlayer({ pos: 'S', careerStats: makeCareerStats(10, { sacks: 5, interceptions: 40, tackles: 800 }) });
+    // base = 5×5 + 40×6 + 800/20 = 25 + 240 + 40 = 305
+    // longevity = 25
+    expect(computeHofScore(player, null, makeAwardSummary())).toBeCloseTo(330);
+  });
+});
+
+describe('computeHofScore — longevity bonus', () => {
+  it('no bonus below 10 seasons', () => {
+    const player = makePlayer({ pos: 'QB', careerStats: makeCareerStats(9, { passTD: 10, passYd: 1000 }) });
+    const score = computeHofScore(player, null, makeAwardSummary());
+    // base = 10×3 + 1000/250 = 34; no longevity bonus
+    expect(score).toBeCloseTo(34);
+  });
+
+  it('+25 bonus at exactly 10 seasons', () => {
+    const player = makePlayer({ pos: 'QB', careerStats: makeCareerStats(10, { passTD: 10, passYd: 1000 }) });
+    const score = computeHofScore(player, null, makeAwardSummary());
+    expect(score).toBeCloseTo(59); // 34 + 25
+  });
+
+  it('+75 cumulative bonus at 14+ seasons (25+50)', () => {
+    const player = makePlayer({ pos: 'QB', careerStats: makeCareerStats(14, { passTD: 10, passYd: 1000 }) });
+    const score = computeHofScore(player, null, makeAwardSummary());
+    expect(score).toBeCloseTo(109); // 34 + 75
+  });
+});
+
+describe('computeHofScore — award bonuses', () => {
+  it('MVP adds +40 per award', () => {
+    const player = makePlayer({ pos: 'QB', careerStats: makeCareerStats(8, { passTD: 40, passYd: 5000 }) });
+    const aw = makeAwardSummary({ mvpCount: 2 });
+    // base = 40×3 + 5000/250 = 140; award = 2×40 = 80
+    expect(computeHofScore(player, null, aw)).toBeCloseTo(220);
+  });
+
+  it('All-Pro adds +15 per selection', () => {
+    const player = makePlayer({ pos: 'QB', careerStats: makeCareerStats(8, { passTD: 40, passYd: 5000 }) });
+    const aw = makeAwardSummary({ allProCount: 3 });
+    // base = 140; award = 3×15 = 45
+    expect(computeHofScore(player, null, aw)).toBeCloseTo(185);
+  });
+
+  it('LEAGUE_CHAMPION adds +20 per championship', () => {
+    const player = makePlayer({ pos: 'QB', careerStats: makeCareerStats(8, { passTD: 40, passYd: 5000 }) });
+    const aw = makeAwardSummary({ championshipCount: 2 });
+    // base = 140; award = 2×20 = 40
+    expect(computeHofScore(player, null, aw)).toBeCloseTo(180);
+  });
+});
+
+// ── isHofEligible ─────────────────────────────────────────────────────────────
+
+describe('isHofEligible', () => {
+  it('false for already-inducted player (hofStatus = inducted)', () => {
+    const player = makePlayer({
+      hofStatus: 'inducted',
+      status: 'retired',
+      careerStats: makeCareerStats(12, { passTD: 60, passYd: 15000 }),
+    });
+    expect(isHofEligible(player, 2030)).toBe(false);
+  });
+
+  it('false for legacy hof=true player', () => {
+    const player = makePlayer({
+      hof: true,
+      status: 'retired',
+      careerStats: makeCareerStats(12, { passTD: 60, passYd: 15000 }),
+    });
+    expect(isHofEligible(player, 2030)).toBe(false);
+  });
+
+  it('false for active player (V1 rule: no active inductions)', () => {
+    const player = makePlayer({
+      status: 'active',
+      careerStats: makeCareerStats(8, { passTD: 60, passYd: 15000 }),
+    });
+    expect(isHofEligible(player, 2030)).toBe(false);
+  });
+
+  it('false for active player even with 12+ seasons', () => {
+    const player = makePlayer({
+      status: 'active',
+      careerStats: makeCareerStats(13, { passTD: 60, passYd: 15000 }),
+    });
+    expect(isHofEligible(player, 2030)).toBe(false);
+  });
+
+  it('false for score < 120', () => {
+    const player = makePlayer({
+      status: 'retired',
+      careerStats: makeCareerStats(5, { passTD: 5, passYd: 500 }),
+    });
+    // score << 120
+    expect(isHofEligible(player, 2030)).toBe(false);
+  });
+
+  it('false when last careerStats season equals currentSeason (just retired)', () => {
+    const player = makePlayer({
+      status: 'retired',
+      careerStats: [...makeCareerStats(11, { passTD: 60, passYd: 15000 }), { season: 2030, team: 'KC', passTD: 5, passYd: 500 }],
+    });
+    expect(isHofEligible(player, 2030)).toBe(false);
+  });
+
+  it('true when retired with 1+ season gap and score >= 120', () => {
+    const player = makePlayer({
+      status: 'retired',
+      careerStats: makeCareerStats(12, { passTD: 40, passYd: 5000 }),
+    });
+    // All career seasons are s1-s12 (2025-2036); checking in 2040
+    const score = computeHofScore(player, null, makeAwardSummary());
+    if (score >= 120) {
+      expect(isHofEligible(player, 2040)).toBe(true);
+    }
+  });
+});
+
+// ── generateHofBallot ─────────────────────────────────────────────────────────
+
+describe('generateHofBallot', () => {
+  function makeRetiredLegend(id, overrides = {}) {
+    return makePlayer({
+      id,
+      name: `Legend ${id}`,
+      pos: 'QB',
+      status: 'retired',
+      hofStatus: 'none',
+      // Last career season is s5 = 2029, checking 2035 (6-season gap)
+      careerStats: makeCareerStats(5, { passTD: 40, passYd: 5000 }),
+      ...overrides,
+    });
+  }
+
+  it('is deterministic (same inputs → same output)', () => {
+    const players = Array.from({ length: 5 }, (_, i) => makeRetiredLegend(`p${i}`));
+    const meta = ensureHofMeta({});
+    const r1 = generateHofBallot(players, null, meta, 2035);
+    const r2 = generateHofBallot(players, null, meta, 2035);
+    expect(r1.nominees.map(n => n.playerId)).toEqual(r2.nominees.map(n => n.playerId));
+  });
+
+  it('caps ballot at MAX_BALLOT_SIZE (10)', () => {
+    const players = Array.from({ length: 15 }, (_, i) => makeRetiredLegend(`p${i}`));
+    const meta = ensureHofMeta({});
+    const { nominees } = generateHofBallot(players, null, meta, 2035);
+    expect(nominees.length).toBeLessThanOrEqual(HOF_THRESHOLDS.MAX_BALLOT_SIZE);
+  });
+
+  it('auto-inducts players with score >= 160', () => {
+    const bigLegend = makeRetiredLegend('elite', {
+      // 10 seasons → last = s10 = 2034 < 2035; score = 100×3+30000/250+25 = 445 ≥ 160
+      careerStats: makeCareerStats(10, { passTD: 100, passYd: 30000 }),
+    });
+    const meta = ensureHofMeta({});
+    const { autoInducted } = generateHofBallot([bigLegend], null, meta, 2035);
+    expect(autoInducted.length).toBeGreaterThan(0);
+    expect(autoInducted[0].score).toBeGreaterThanOrEqual(HOF_THRESHOLDS.INDUCTION_SCORE);
+  });
+
+  it('skips already-inducted players from hofRoster', () => {
+    const player = makeRetiredLegend('p1');
+    const meta = ensureHofMeta({
+      hofRoster: [{ playerId: 'p1', playerName: 'Legend p1', position: 'QB', inductionSeason: 2034, hofScore: 200 }],
+    });
+    const { nominees } = generateHofBallot([player], null, meta, 2035);
+    expect(nominees.find(n => String(n.playerId) === 'p1')).toBeUndefined();
+  });
+
+  it('enforces 3-ballot lapse rule', () => {
+    const player = makeRetiredLegend('p1', {
+      // Score is between 120-159 and doesn't qualify for MVP shortcut
+      careerStats: makeCareerStats(10, { passTD: 30, passYd: 5000 }),
+      awards: [],
+    });
+    // Simulate 3 prior ballot appearances without induction
+    const meta = ensureHofMeta({
+      hofBallot: {
+        season: 2034,
+        nominees: [{ playerId: 'p1', score: 130, reasons: [], ballotCount: 3 }],
+        inducted: [],
+        resolved: true,
+      },
+    });
+    const { nominees } = generateHofBallot([player], null, meta, 2035);
+    expect(nominees.find(n => String(n.playerId) === 'p1')).toBeUndefined();
+  });
+});
+
+// ── resolveHofVote ────────────────────────────────────────────────────────────
+
+describe('resolveHofVote', () => {
+  it('auto-inducts nominees with score >= 160', () => {
+    const ballot = {
+      nominees: [{ playerId: 'p1', playerName: 'A', pos: 'QB', score: 200, reasons: [], mvpCount: 0, ballotCount: 1 }],
+      autoInducted: [{ playerId: 'p1', playerName: 'A', pos: 'QB', score: 200, reasons: [], mvpCount: 0, ballotCount: 1 }],
+    };
+    const { inducted } = resolveHofVote(ballot, []);
+    expect(inducted.some(i => String(i.playerId) === 'p1')).toBe(true);
+  });
+
+  it('MVP shortcut inducts score 120-159 with 2+ MVPs', () => {
+    const ballot = {
+      nominees: [{ playerId: 'p2', playerName: 'B', pos: 'QB', score: 135, reasons: [], mvpCount: 3, ballotCount: 1 }],
+      autoInducted: [],
+    };
+    const { inducted } = resolveHofVote(ballot, []);
+    expect(inducted.some(i => String(i.playerId) === 'p2')).toBe(true);
+  });
+
+  it('does NOT induct via MVP shortcut if score < 120', () => {
+    const ballot = {
+      nominees: [],
+      autoInducted: [],
+    };
+    const { inducted } = resolveHofVote(ballot, []);
+    expect(inducted.length).toBe(0);
+  });
+
+  it('caps inductions at MAX_INDUCTIONS (5) per season', () => {
+    const nominees = Array.from({ length: 8 }, (_, i) => ({
+      playerId: `p${i}`, playerName: `Player ${i}`, pos: 'QB', score: 200, reasons: [], mvpCount: 0, ballotCount: 1,
+    }));
+    const ballot = { nominees, autoInducted: nominees };
+    const { inducted } = resolveHofVote(ballot, []);
+    expect(inducted.length).toBeLessThanOrEqual(HOF_THRESHOLDS.MAX_INDUCTIONS);
+  });
+
+  it('produces no duplicate inductees', () => {
+    const entry = { playerId: 'p1', playerName: 'A', pos: 'QB', score: 200, reasons: [], mvpCount: 3, ballotCount: 1 };
+    const ballot = { nominees: [entry], autoInducted: [entry] };
+    const { inducted } = resolveHofVote(ballot, []);
+    const ids = inducted.map(i => String(i.playerId));
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('remaining contains nominees not inducted', () => {
+    const nominees = [
+      { playerId: 'p1', playerName: 'A', pos: 'QB', score: 200, reasons: [], mvpCount: 0, ballotCount: 1 },
+      { playerId: 'p2', playerName: 'B', pos: 'RB', score: 125, reasons: [], mvpCount: 0, ballotCount: 1 },
+    ];
+    const ballot = { nominees, autoInducted: [nominees[0]] };
+    const { inducted, remaining } = resolveHofVote(ballot, []);
+    const inductedIds = new Set(inducted.map(i => String(i.playerId)));
+    const remainingIds = remaining.map(r => String(r.playerId));
+    for (const rid of remainingIds) {
+      expect(inductedIds.has(rid)).toBe(false);
+    }
+  });
+});
+
+// ── applyHofInductions ────────────────────────────────────────────────────────
+
+describe('applyHofInductions', () => {
+  it('adds inductees to hofRoster', () => {
+    const player = makePlayer({ id: 'p1', name: 'Star', pos: 'QB', careerStats: makeCareerStats(12, { passTD: 40, passYd: 5000 }) });
+    const entry = { playerId: 'p1', playerName: 'Star', pos: 'QB', score: 200 };
+    const meta = ensureHofMeta({});
+    const { hofRoster } = applyHofInductions(meta, [entry], [entry], [player], 2035);
+    expect(hofRoster.length).toBe(1);
+    expect(String(hofRoster[0].playerId)).toBe('p1');
+    expect(hofRoster[0].inductionSeason).toBe(2035);
+    expect(hofRoster[0].hofScore).toBe(200);
+  });
+
+  it('does not double-add players already in hofRoster', () => {
+    const player = makePlayer({ id: 'p1', name: 'Star', pos: 'QB', careerStats: makeCareerStats(12) });
+    const entry = { playerId: 'p1', playerName: 'Star', pos: 'QB', score: 180 };
+    const meta = ensureHofMeta({
+      hofRoster: [{ playerId: 'p1', playerName: 'Star', position: 'QB', inductionSeason: 2034, hofScore: 180 }],
+    });
+    const { hofRoster } = applyHofInductions(meta, [entry], [entry], [player], 2035);
+    expect(hofRoster.filter(r => String(r.playerId) === 'p1').length).toBe(1);
+  });
+
+  it('sets resolved=true on hofBallot', () => {
+    const player = makePlayer({ id: 'p1', careerStats: makeCareerStats(10) });
+    const entry = { playerId: 'p1', playerName: 'P', pos: 'QB', score: 170 };
+    const meta = ensureHofMeta({});
+    const { hofBallot } = applyHofInductions(meta, [entry], [entry], [player], 2035);
+    expect(hofBallot.resolved).toBe(true);
+    expect(hofBallot.season).toBe(2035);
+  });
+
+  it('updates player hofStatus to inducted correctly (via player updates in worker)', () => {
+    // This test validates the hofRoster entry contains expected data
+    const player = makePlayer({ id: 'p1', name: 'QB Legend', pos: 'QB', careerStats: makeCareerStats(14, { passTD: 50 }) });
+    const entry = { playerId: 'p1', playerName: 'QB Legend', pos: 'QB', score: 185 };
+    const meta = ensureHofMeta({});
+    const { hofRoster } = applyHofInductions(meta, [entry], [entry], [player], 2036);
+    expect(hofRoster[0].seasons).toBe(14);
+    expect(hofRoster[0].hofScore).toBe(185);
+  });
+});
+
+// ── getHofSummary ─────────────────────────────────────────────────────────────
+
+describe('getHofSummary', () => {
+  it('returns correct totalInducted count', () => {
+    const meta = {
+      hofRoster: [
+        { playerId: 'a', position: 'QB', inductionSeason: 2030, hofScore: 200 },
+        { playerId: 'b', position: 'RB', inductionSeason: 2031, hofScore: 180 },
+      ],
+    };
+    expect(getHofSummary(meta).totalInducted).toBe(2);
+  });
+
+  it('groups byPosition correctly', () => {
+    const meta = {
+      hofRoster: [
+        { playerId: 'a', position: 'QB', inductionSeason: 2030, hofScore: 200 },
+        { playerId: 'b', position: 'QB', inductionSeason: 2031, hofScore: 180 },
+        { playerId: 'c', position: 'RB', inductionSeason: 2031, hofScore: 160 },
+      ],
+    };
+    const { byPosition } = getHofSummary(meta);
+    expect(byPosition.QB).toBe(2);
+    expect(byPosition.RB).toBe(1);
+  });
+
+  it('returns empty summary for empty hofRoster', () => {
+    const { totalInducted, byPosition, recentClass } = getHofSummary({ hofRoster: [] });
+    expect(totalInducted).toBe(0);
+    expect(Object.keys(byPosition).length).toBe(0);
+    expect(recentClass.length).toBe(0);
+  });
+});
+
+// ── ensureHofMeta (hydration) ─────────────────────────────────────────────────
+
+describe('ensureHofMeta — old save hydration', () => {
+  it('hydrates hofRoster to [] on old saves', () => {
+    const meta = ensureHofMeta({ year: 2025 });
+    expect(Array.isArray(meta.hofRoster)).toBe(true);
+    expect(meta.hofRoster.length).toBe(0);
+  });
+
+  it('hydrates hofBallot to default on old saves', () => {
+    const meta = ensureHofMeta({ year: 2025 });
+    expect(meta.hofBallot).toBeTruthy();
+    expect(meta.hofBallot.resolved).toBe(false);
+    expect(Array.isArray(meta.hofBallot.nominees)).toBe(true);
+    expect(Array.isArray(meta.hofBallot.inducted)).toBe(true);
+  });
+
+  it('preserves existing hofRoster when present', () => {
+    const existing = [{ playerId: 'x', hofScore: 200 }];
+    const meta = ensureHofMeta({ hofRoster: existing });
+    expect(meta.hofRoster).toBe(existing);
+  });
+
+  it('player without hofStatus field hydrates safely to "none" via nullish coalescing', () => {
+    const player = { id: 'p1', name: 'Old', pos: 'QB' };
+    // hofStatus is undefined; UI uses: player.hofStatus ?? 'none'
+    expect(player.hofStatus ?? 'none').toBe('none');
+  });
+});
+
+// ── Full ballot → vote → induct pipeline ─────────────────────────────────────
+
+describe('end-to-end ballot pipeline', () => {
+  it('full pipeline: generate ballot → resolve vote → apply inductions', () => {
+    const players = [
+      makePlayer({
+        id: 'elite1',
+        name: 'Top Quarterback',
+        pos: 'QB',
+        status: 'retired',
+        // Last season = s10 (2034), checking in season 2035
+        careerStats: makeCareerStats(10, { passTD: 80, passYd: 25000, rushTD: 15 }),
+        awards: [
+          { type: 'MVP', season: 2025, dedupeKey: 'MVP_2025' },
+          { type: 'MVP', season: 2027, dedupeKey: 'MVP_2027' },
+        ],
+      }),
+      makePlayer({
+        id: 'borderline1',
+        name: 'Good RB',
+        pos: 'RB',
+        status: 'retired',
+        careerStats: makeCareerStats(10, { rushTD: 15, rushYd: 8000 }),
+        awards: [],
+      }),
+    ];
+
+    const meta = ensureHofMeta({});
+    const ballot = generateHofBallot(players, null, meta, 2035);
+    expect(ballot.nominees.length).toBeGreaterThan(0);
+
+    const { inducted, remaining } = resolveHofVote(ballot, players);
+    expect(inducted.length).toBeLessThanOrEqual(HOF_THRESHOLDS.MAX_INDUCTIONS);
+
+    const updates = applyHofInductions(meta, inducted, ballot.nominees, players, 2035);
+    expect(Array.isArray(updates.hofRoster)).toBe(true);
+    expect(updates.hofBallot.season).toBe(2035);
+  });
+});


### PR DESCRIPTION
Adds a deterministic Hall of Fame pipeline that runs at end-of-season
during archiveSeason, tracking eligible players, generating annual
ballots, simulating votes, and persisting inductions to meta.

New files:
- src/core/awards/hofEngine.js — pure HOF engine (no Math.random,
  no worker/UI/news imports). Exports: HOF_THRESHOLDS, computeHofScore,
  isHofEligible, generateHofBallot, resolveHofVote, applyHofInductions,
  getHofSummary, ensureHofMeta.
- tests/unit/hofEngine.test.js — 45 unit tests covering score formulas,
  longevity/award bonuses, eligibility rules, ballot generation, vote
  resolution, induction, and full end-to-end pipeline.

Modified files:
- src/worker/worker.js: import hofEngine functions; expose hofRoster +
  hofBallot in buildViewState; add HOF processing block in archiveSeason
  after applySeasonAwards (non-fatal try/catch).
- src/core/news-engine.js: add hof_inducted, hof_eligible, hof_class
  news templates to createNewsItem.
- src/ui/components/PlayerProfile.jsx: HOF status badge (Hall of Famer /
  HOF Nominee / HOF Eligible) with data-testid="player-profile-hof-badge".
- src/ui/components/FranchiseHQ.jsx: Hall of Famers section filtered to
  user franchise with data-testid="hq-hall-of-famers".
- src/ui/components/LeagueDashboard.jsx: HOF Class panel (post-season
  only) with data-testid="hof-class-panel".

Schema additions (backward-compatible):
- meta.hofRoster = [] — all-time inductees
- meta.hofBallot = { season, nominees, inducted, resolved } — annual ballot
- player.hofStatus: 'none' | 'eligible' | 'nominee' | 'inducted'
  (old saves hydrate to 'none' via ensureHofMeta / nullish coalescing)

Verification:
- npm run test:unit  → 3156/3156 tests pass (312 files)
- npm run build      → clean Vite build
- node scripts/engineSoak.js → all 9 gates PASS
- E2E Playwright skipped (chromium v1217 not available in sandbox)