### PR TITLE
feat(coaching): implement Coaching Carousel V1

### DIFF
--- a/src/core/coaching-philosophy-effects.js
+++ b/src/core/coaching-philosophy-effects.js
@@ -1,6 +1,7 @@
 /**
  * coaching-philosophy-effects.js
  * Single source of truth for coaching philosophy → simulation modifier math.
+ * Also applies V1 coach overall-rating scheme multiplier (Coaching Carousel).
  * All functions are pure (no side effects, no imports from game-simulator).
  *
  * AUDIT FINDINGS (feat/coaching-philosophy-effects)
@@ -37,6 +38,8 @@
  * via getCoachingMods(team.staff). applyCoachingModifiers() layers philosophy mods
  * on top of those mods before stat generation runs. Single callsite per team.
  */
+
+import { getCoachSchemeMultiplier } from './coaching/coachingEngine.js';
 
 // ── Philosophy enum mirrors (kept local; no runtime dependency on staffPhilosophy.js) ─
 const OFF = Object.freeze({
@@ -351,15 +354,30 @@ export function applyCoachingModifiers(teamRatings, coach, staff) {
   const offMods = getOffensivePhilosophyModifiers(coach, staff);
   const defMods = getDefensivePhilosophyModifiers(coach, staff);
 
+  // V1 Coaching Carousel: overall-rating scheme multiplier.
+  // Reads overallRating from HC and coordinator objects if present.
+  // Falls back to 1.0 for old saves without V1 data.
+  const hcRating  = hc?.overallRating ?? hc?.rating ?? null;
+  const hcMult    = hcRating != null ? getCoachSchemeMultiplier(hcRating) : 1.0;
+
+  const oc = extractOC(staff);
+  const dc = extractDC(staff);
+  const ocRating  = oc?.overallRating ?? oc?.rating ?? null;
+  const ocMult    = ocRating != null ? getCoachSchemeMultiplier(ocRating) : 1.0;
+  const dcRating  = dc?.overallRating ?? dc?.rating ?? null;
+  const dcMult    = dcRating != null ? getCoachSchemeMultiplier(dcRating) : 1.0;
+
   const base = teamRatings ?? {};
   return {
     ...base,
-    passVolume:   (base.passVolume   ?? 1) * offMods.passingMod,
-    runVolume:    (base.runVolume    ?? 1) * offMods.rushingMod,
-    passAccuracy: (base.passAccuracy ?? 1) * offMods.tempoMod,
-    redZoneMod:   (base.redZoneMod   ?? 1) * offMods.redZoneMod,
-    sackChance:   (base.sackChance    ?? 1) * defMods.pressureMod,
-    defIntChance: (base.defIntChance ?? 1) * defMods.coverageMod,
-    runStop:      (base.runStop      ?? 1) * defMods.runStopMod,
+    // Offensive weights: HC × OC multipliers
+    passVolume:   (base.passVolume   ?? 1) * offMods.passingMod  * hcMult * ocMult,
+    runVolume:    (base.runVolume    ?? 1) * offMods.rushingMod  * hcMult * ocMult,
+    passAccuracy: (base.passAccuracy ?? 1) * offMods.tempoMod    * hcMult * ocMult,
+    redZoneMod:   (base.redZoneMod   ?? 1) * offMods.redZoneMod  * hcMult * ocMult,
+    // Defensive weights: HC × DC multipliers
+    sackChance:   (base.sackChance   ?? 1) * defMods.pressureMod * hcMult * dcMult,
+    defIntChance: (base.defIntChance ?? 1) * defMods.coverageMod * hcMult * dcMult,
+    runStop:      (base.runStop      ?? 1) * defMods.runStopMod  * hcMult * dcMult,
   };
 }

--- a/src/core/coaching/__tests__/coachingEngine.test.js
+++ b/src/core/coaching/__tests__/coachingEngine.test.js
@@ -1,0 +1,288 @@
+import { describe, it, expect } from 'vitest';
+import {
+  COACH_ROLES,
+  SCHEME_TYPES,
+  generateCoachingMarket,
+  evaluateHotSeat,
+  getCoachSchemeMultiplier,
+  getCoachingInstabilityPenalty,
+  isPositionMisfitForScheme,
+  ensureCoachSchema,
+} from '../coachingEngine.js';
+
+// ── COACH_ROLES ───────────────────────────────────────────────────────────────
+
+describe('COACH_ROLES', () => {
+  it('exports expected role keys', () => {
+    expect(COACH_ROLES.HEAD_COACH).toBe('headCoach');
+    expect(COACH_ROLES.OC).toBe('offensiveCoordinator');
+    expect(COACH_ROLES.DC).toBe('defensiveCoordinator');
+  });
+});
+
+// ── generateCoachingMarket ────────────────────────────────────────────────────
+
+describe('generateCoachingMarket', () => {
+  it('produces 8–12 fresh coaches per season', () => {
+    const market = generateCoachingMarket(2025, []);
+    expect(market.length).toBeGreaterThanOrEqual(8);
+    expect(market.length).toBeLessThanOrEqual(12);
+  });
+
+  it('is deterministic — same season produces identical market', () => {
+    const a = generateCoachingMarket(2025, []);
+    const b = generateCoachingMarket(2025, []);
+    expect(a).toEqual(b);
+  });
+
+  it('produces different market for different seasons', () => {
+    const a = generateCoachingMarket(2025, []);
+    const b = generateCoachingMarket(2026, []);
+    expect(a).not.toEqual(b);
+  });
+
+  it('includes at least 2 elite coaches (overallRating ≥ 75)', () => {
+    const market = generateCoachingMarket(2025, []);
+    const elites = market.filter((c) => c.overallRating >= 75);
+    expect(elites.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('re-enters fired coaches with rating − 5 (min 30)', () => {
+    const fired = [{ id: 'old_1', name: 'Bob Smith', scheme: 'SPREAD', overallRating: 70, yearsExperience: 12, formerTeamId: 1 }];
+    const market = generateCoachingMarket(2026, fired);
+    const reEntered = market.find((c) => c.name === 'Bob Smith');
+    expect(reEntered).toBeDefined();
+    expect(reEntered.overallRating).toBe(65);
+    expect(reEntered.firedPrevSeason).toBe(true);
+  });
+
+  it('clamps re-entered coach rating to minimum 30', () => {
+    const fired = [{ id: 'old_2', name: 'Jane Doe', scheme: 'HYBRID', overallRating: 30 }];
+    const market = generateCoachingMarket(2027, fired);
+    const reEntered = market.find((c) => c.name === 'Jane Doe');
+    expect(reEntered.overallRating).toBe(30);
+  });
+
+  it('ignores fired coach entries without a name', () => {
+    const fired = [{ id: 'x1', overallRating: 60 }];
+    const market = generateCoachingMarket(2028, fired);
+    const firedCoaches = market.filter((c) => c.firedPrevSeason);
+    expect(firedCoaches.length).toBe(0);
+  });
+
+  it('all coaches have required fields', () => {
+    const market = generateCoachingMarket(2029, []);
+    for (const c of market) {
+      expect(c).toHaveProperty('id');
+      expect(c).toHaveProperty('name');
+      expect(c).toHaveProperty('scheme');
+      expect(c).toHaveProperty('overallRating');
+      expect(typeof c.overallRating).toBe('number');
+    }
+  });
+});
+
+// ── evaluateHotSeat ───────────────────────────────────────────────────────────
+
+describe('evaluateHotSeat', () => {
+  function makeTeam(hiredSeason) {
+    return { coach: { headCoach: { hiredSeason } } };
+  }
+
+  it('returns true when win% < 0.35 and tenure ≥ 2', () => {
+    const team = makeTeam(2021);
+    expect(evaluateHotSeat(team, { w: 4, l: 13 }, 2023)).toBe(true);
+  });
+
+  it('returns false when win% ≥ 0.50 regardless of tenure', () => {
+    const team = makeTeam(2019);
+    expect(evaluateHotSeat(team, { w: 9, l: 8 }, 2023)).toBe(false);
+  });
+
+  it('returns false when tenure < 2 seasons', () => {
+    const team = makeTeam(2023);
+    expect(evaluateHotSeat(team, { w: 3, l: 14 }, 2024)).toBe(false);
+  });
+
+  it('returns false when team has no head coach', () => {
+    expect(evaluateHotSeat({ coach: {} }, { w: 2, l: 15 }, 2024)).toBe(false);
+    expect(evaluateHotSeat(null, { w: 2, l: 15 }, 2024)).toBe(false);
+  });
+
+  it('returns false when season record totals 0 games', () => {
+    const team = makeTeam(2021);
+    expect(evaluateHotSeat(team, { w: 0, l: 0 }, 2023)).toBe(false);
+  });
+});
+
+// ── getCoachSchemeMultiplier ──────────────────────────────────────────────────
+
+describe('getCoachSchemeMultiplier', () => {
+  it('returns 1.08 for rating ≥ 80', () => {
+    expect(getCoachSchemeMultiplier(80)).toBe(1.08);
+    expect(getCoachSchemeMultiplier(90)).toBe(1.08);
+    expect(getCoachSchemeMultiplier(100)).toBe(1.08);
+  });
+
+  it('returns 1.00 for rating 65–79', () => {
+    expect(getCoachSchemeMultiplier(65)).toBe(1.00);
+    expect(getCoachSchemeMultiplier(72)).toBe(1.00);
+    expect(getCoachSchemeMultiplier(79)).toBe(1.00);
+  });
+
+  it('returns 0.94 for rating 50–64', () => {
+    expect(getCoachSchemeMultiplier(50)).toBe(0.94);
+    expect(getCoachSchemeMultiplier(60)).toBe(0.94);
+    expect(getCoachSchemeMultiplier(64)).toBe(0.94);
+  });
+
+  it('returns 0.88 for rating < 50', () => {
+    expect(getCoachSchemeMultiplier(49)).toBe(0.88);
+    expect(getCoachSchemeMultiplier(30)).toBe(0.88);
+    expect(getCoachSchemeMultiplier(1)).toBe(0.88);
+  });
+
+  it('handles null/undefined by falling back to baseline (65)', () => {
+    expect(getCoachSchemeMultiplier(null)).toBe(1.00);
+    expect(getCoachSchemeMultiplier(undefined)).toBe(1.00);
+  });
+});
+
+// ── getCoachingInstabilityPenalty ─────────────────────────────────────────────
+
+describe('getCoachingInstabilityPenalty', () => {
+  it('returns null for empty or missing history', () => {
+    expect(getCoachingInstabilityPenalty([])).toBeNull();
+    expect(getCoachingInstabilityPenalty(null)).toBeNull();
+    expect(getCoachingInstabilityPenalty(undefined)).toBeNull();
+  });
+
+  it('returns null when fewer than 3 changes in lookback window', () => {
+    const history = [
+      { season: 2022 },
+      { season: 2023 },
+    ];
+    expect(getCoachingInstabilityPenalty(history, 3)).toBeNull();
+  });
+
+  it('returns penalty object when 3+ changes in lookback window', () => {
+    const history = [
+      { season: 2021 },
+      { season: 2022 },
+      { season: 2023 },
+    ];
+    const result = getCoachingInstabilityPenalty(history, 3);
+    expect(result).not.toBeNull();
+    expect(result.penalty).toBe(0.06);
+    expect(typeof result.reason).toBe('string');
+  });
+
+  it('ignores changes outside the lookback window', () => {
+    // max season is 2024, cutoff = 2024 - 3 + 1 = 2022; only one change in [2022,2024]
+    const history = [
+      { season: 2018 },
+      { season: 2019 },
+      { season: 2024 },
+    ];
+    expect(getCoachingInstabilityPenalty(history, 3)).toBeNull();
+  });
+});
+
+// ── isPositionMisfitForScheme ─────────────────────────────────────────────────
+
+describe('isPositionMisfitForScheme', () => {
+  it('returns false for BALANCED scheme (no misfits)', () => {
+    expect(isPositionMisfitForScheme('RB', 'BALANCED')).toBe(false);
+    expect(isPositionMisfitForScheme('CB', 'BALANCED')).toBe(false);
+  });
+
+  it('returns false for HYBRID scheme (no misfits)', () => {
+    expect(isPositionMisfitForScheme('LB', 'HYBRID')).toBe(false);
+    expect(isPositionMisfitForScheme('QB', 'HYBRID')).toBe(false);
+  });
+
+  it('returns true for RB in a pass-heavy scheme (SPREAD)', () => {
+    expect(isPositionMisfitForScheme('RB', 'SPREAD')).toBe(true);
+  });
+
+  it('returns false for QB in SPREAD (good fit)', () => {
+    expect(isPositionMisfitForScheme('QB', 'SPREAD')).toBe(false);
+  });
+
+  it('returns false for defensive player in offensive scheme (SPREAD)', () => {
+    expect(isPositionMisfitForScheme('CB', 'SPREAD')).toBe(false);
+  });
+
+  it('returns false for offensive player in defensive scheme (BLITZ_HEAVY)', () => {
+    expect(isPositionMisfitForScheme('QB', 'BLITZ_HEAVY')).toBe(false);
+  });
+
+  it('returns true for CB in BLITZ_HEAVY (LBs are the fit, not DBs)', () => {
+    expect(isPositionMisfitForScheme('CB', 'BLITZ_HEAVY')).toBe(true);
+  });
+
+  it('returns false for unknown positions', () => {
+    expect(isPositionMisfitForScheme('K', 'SPREAD')).toBe(false);
+    expect(isPositionMisfitForScheme(null, 'SPREAD')).toBe(false);
+    expect(isPositionMisfitForScheme('QB', null)).toBe(false);
+  });
+});
+
+// ── ensureCoachSchema ─────────────────────────────────────────────────────────
+
+describe('ensureCoachSchema', () => {
+  it('returns same reference when passed null/undefined', () => {
+    expect(ensureCoachSchema(null)).toBeNull();
+    expect(ensureCoachSchema(undefined)).toBeUndefined();
+  });
+
+  it('adds default coach schema to a team without V1 data', () => {
+    const team = { id: 1, name: 'Bears' };
+    const result = ensureCoachSchema(team);
+    expect(result.coach).toBeDefined();
+    expect(result.coach.headCoach).toBeDefined();
+    expect(result.coach.offensiveCoordinator).toBeDefined();
+    expect(result.coach.defensiveCoordinator).toBeDefined();
+    expect(result.coachHistory).toEqual([]);
+  });
+
+  it('does not overwrite existing V1 coach data', () => {
+    const team = {
+      id: 2,
+      coach: {
+        headCoach: { id: 'hc1', name: 'Tom Landry', overallRating: 88, scheme: 'WEST_COAST', contractYearsLeft: 2, hotSeat: false, hiredSeason: 2022, firedSeason: null },
+      },
+    };
+    const result = ensureCoachSchema(team);
+    expect(result.coach.headCoach.name).toBe('Tom Landry');
+    expect(result.coach.headCoach.overallRating).toBe(88);
+    expect(result.coach.headCoach.contractYearsLeft).toBe(2);
+  });
+
+  it('merges defaults into partially filled coach data', () => {
+    const team = {
+      id: 3,
+      coach: {
+        headCoach: { name: 'Partial Coach' },
+      },
+    };
+    const result = ensureCoachSchema(team);
+    expect(result.coach.headCoach.name).toBe('Partial Coach');
+    expect(result.coach.headCoach.overallRating).toBe(65);
+    expect(result.coach.headCoach.scheme).toBe('BALANCED');
+  });
+
+  it('preserves existing coachHistory array', () => {
+    const history = [{ season: 2022, name: 'Old Coach', role: 'headCoach' }];
+    const team = { id: 4, coachHistory: history };
+    const result = ensureCoachSchema(team);
+    expect(result.coachHistory).toEqual(history);
+  });
+
+  it('is pure — does not mutate the input team', () => {
+    const team = { id: 5, name: 'Test Team' };
+    const original = JSON.stringify(team);
+    ensureCoachSchema(team);
+    expect(JSON.stringify(team)).toBe(original);
+  });
+});

--- a/src/core/coaching/coachingEngine.js
+++ b/src/core/coaching/coachingEngine.js
@@ -1,0 +1,350 @@
+/**
+ * coachingEngine.js — Coaching Carousel V1
+ *
+ * Pure, deterministic coaching module. GM decision layer for hiring, firing,
+ * and coordinator management. Produces visible, persistent footprints on
+ * player morale, team culture, and negotiation leverage.
+ *
+ * Design constraints:
+ *  - Pure functions only. No side effects.
+ *  - No imports from worker, UI, news, morale, holdout, HOF, or sim engine.
+ *  - No Math.random — seeded determinism only.
+ *  - Fully deterministic given same inputs.
+ */
+
+// ── Role constants ─────────────────────────────────────────────────────────────
+
+export const COACH_ROLES = Object.freeze({
+  HEAD_COACH: 'headCoach',
+  OC: 'offensiveCoordinator',
+  DC: 'defensiveCoordinator',
+});
+
+// ── Scheme types (mirrors coaching-philosophy-effects.js enums) ───────────────
+
+export const SCHEME_TYPES = Object.freeze({
+  // Offensive
+  SPREAD:       'SPREAD',
+  WEST_COAST:   'WEST_COAST',
+  VERTICAL:     'VERTICAL',
+  POWER_RUN:    'POWER_RUN',
+  BALANCED:     'BALANCED',
+  // Defensive
+  BLITZ_HEAVY:  'BLITZ_HEAVY',
+  COVER_2:      'COVER_2',
+  MAN_COVERAGE: 'MAN_COVERAGE',
+  HYBRID:       'HYBRID',
+});
+
+const ALL_SCHEMES = [
+  'SPREAD', 'WEST_COAST', 'VERTICAL', 'POWER_RUN', 'BALANCED',
+  'BLITZ_HEAVY', 'COVER_2', 'MAN_COVERAGE', 'HYBRID',
+];
+
+const ELITE_SCHEMES = ['SPREAD', 'WEST_COAST', 'BLITZ_HEAVY', 'MAN_COVERAGE'];
+
+// ── Seeded LCG — no Math.random ───────────────────────────────────────────────
+
+function makeLCG(seed) {
+  let s = ((seed | 0) >>> 0) || 1;
+  return {
+    next() {
+      s = ((1664525 * s + 1013904223) | 0) >>> 0;
+      return s / 0x100000000;
+    },
+    nextInt(min, max) {
+      return Math.floor(this.next() * (max - min + 1)) + min;
+    },
+    choice(arr) {
+      return arr[Math.floor(this.next() * arr.length)];
+    },
+  };
+}
+
+// ── Name pools ────────────────────────────────────────────────────────────────
+
+const FIRST_NAMES = [
+  'Mike', 'John', 'Bill', 'Tom', 'Jim', 'Dave', 'Steve', 'Dan', 'Ron', 'Joe',
+  'Matt', 'Kyle', 'Sean', 'Andy', 'Rex', 'Gary', 'Bob', 'Ray', 'Ken', 'Hal',
+  'Art', 'Don', 'Ted', 'Vic', 'Al', 'Sam', 'Pat', 'Chip', 'Wade', 'Doug',
+  'Frank', 'Hank', 'Clint', 'Bud', 'Earl', 'Norm', 'Russ', 'Gus', 'Fritz', 'Wes',
+];
+
+const LAST_NAMES = [
+  'Smith', 'Johnson', 'Williams', 'Brown', 'Jones', 'Davis', 'Miller', 'Wilson',
+  'Moore', 'Taylor', 'Anderson', 'Jackson', 'White', 'Harris', 'Martin', 'Garcia',
+  'Martinez', 'Clark', 'Lewis', 'Lee', 'Walker', 'Hall', 'Allen', 'Young', 'King',
+  'Wright', 'Scott', 'Hill', 'Green', 'Adams', 'Baker', 'Rivera', 'Campbell',
+  'Roberts', 'Carter', 'Phillips', 'Evans', 'Turner', 'Torres', 'Parker',
+];
+
+// ── generateCoachingMarket ────────────────────────────────────────────────────
+
+/**
+ * Generate the coaching market for a new season.
+ * Deterministic: same season + firedCoaches inputs always produce the same market.
+ *
+ * Rating distribution: 2 elite (75–90), 4 solid (55–74), remainder average (35–54).
+ * Total coaches: 8–12.
+ * Fired coaches from previous season re-enter with overallRating − 5 (min 30).
+ *
+ * @param {number} season        - Current season number (used as seed base)
+ * @param {Array}  firedCoaches  - Fired coaches: [{ id, name, scheme, overallRating, yearsExperience, formerTeamId }]
+ * @returns {Array<CoachProfile>}
+ */
+export function generateCoachingMarket(season, firedCoaches = []) {
+  const rng = makeLCG(Number(season) * 7919 + 31337);
+
+  // Pick a count of 8–12 fresh coaches
+  const freshCount = rng.nextInt(8, 12);
+  const market = [];
+
+  // 1. Two elite coaches
+  for (let i = 0; i < 2; i++) {
+    market.push({
+      id:               `cch_${season}_${i}`,
+      name:             `${rng.choice(FIRST_NAMES)} ${rng.choice(LAST_NAMES)}`,
+      scheme:           rng.choice(ELITE_SCHEMES),
+      overallRating:    rng.nextInt(75, 90),
+      yearsExperience:  rng.nextInt(10, 25),
+      formerTeamId:     null,
+    });
+  }
+
+  // 2. Four solid coaches
+  for (let i = 2; i < 6; i++) {
+    market.push({
+      id:               `cch_${season}_${i}`,
+      name:             `${rng.choice(FIRST_NAMES)} ${rng.choice(LAST_NAMES)}`,
+      scheme:           rng.choice(ALL_SCHEMES),
+      overallRating:    rng.nextInt(55, 74),
+      yearsExperience:  rng.nextInt(5, 15),
+      formerTeamId:     null,
+    });
+  }
+
+  // 3. Fill remainder with average coaches (up to freshCount)
+  for (let i = 6; i < freshCount; i++) {
+    market.push({
+      id:               `cch_${season}_${i}`,
+      name:             `${rng.choice(FIRST_NAMES)} ${rng.choice(LAST_NAMES)}`,
+      scheme:           rng.choice(ALL_SCHEMES),
+      overallRating:    rng.nextInt(35, 54),
+      yearsExperience:  rng.nextInt(1, 10),
+      formerTeamId:     null,
+    });
+  }
+
+  // 4. Re-enter fired coaches from previous season
+  const safeFired = Array.isArray(firedCoaches) ? firedCoaches : [];
+  for (const fired of safeFired) {
+    if (!fired?.name) continue;
+    market.push({
+      id:               fired.id ?? `cch_fired_${season}_${String(fired.name).replace(/\s/g, '_')}`,
+      name:             fired.name,
+      scheme:           fired.scheme ?? 'BALANCED',
+      overallRating:    Math.max(30, (Number(fired.overallRating) || 50) - 5),
+      yearsExperience:  Number(fired.yearsExperience) || 5,
+      formerTeamId:     fired.formerTeamId ?? null,
+      firedPrevSeason:  true,
+    });
+  }
+
+  return market;
+}
+
+// ── evaluateHotSeat ───────────────────────────────────────────────────────────
+
+/**
+ * Evaluate whether the head coach should be on the hot seat.
+ *
+ * Hot seat: win% < 0.35 AND coach has been with team >= 2 seasons.
+ * Resets to false if win% >= 0.500.
+ *
+ * @param {object} team         - team data; reads team.coach.headCoach.hiredSeason
+ * @param {object} seasonRecord - { w: number, l: number } for the completed season
+ * @param {number} currentSeason
+ * @returns {boolean}
+ */
+export function evaluateHotSeat(team, seasonRecord, currentSeason) {
+  const hc = team?.coach?.headCoach;
+  if (!hc) return false;
+
+  const w = Number(seasonRecord?.w ?? 0);
+  const l = Number(seasonRecord?.l ?? 0);
+  const total = w + l;
+  if (total === 0) return false;
+
+  const winPct = w / total;
+
+  // Always reset hot seat if win% >= 0.500
+  if (winPct >= 0.500) return false;
+
+  const hiredSeason = Number(hc.hiredSeason ?? 0);
+  const season      = Number(currentSeason ?? 0);
+  const tenure      = season > 0 && hiredSeason > 0 ? season - hiredSeason : 0;
+
+  return winPct < 0.35 && tenure >= 2;
+}
+
+// ── getCoachSchemeMultiplier ──────────────────────────────────────────────────
+
+/**
+ * Return the scheme execution multiplier for a coach's overall rating.
+ *
+ * rating >= 80 → ×1.08
+ * rating 65–79 → ×1.00 (baseline)
+ * rating 50–64 → ×0.94
+ * rating < 50  → ×0.88
+ *
+ * @param {number} coachRating - 1–100
+ * @returns {number}
+ */
+export function getCoachSchemeMultiplier(coachRating) {
+  const r = Number(coachRating ?? 65);
+  if (r >= 80) return 1.08;
+  if (r >= 65) return 1.00;
+  if (r >= 50) return 0.94;
+  return 0.88;
+}
+
+// ── getCoachingInstabilityPenalty ─────────────────────────────────────────────
+
+/**
+ * Return the coaching instability penalty for FA negotiations, or null.
+ *
+ * Fires if team.coachHistory has >= 3 coaching changes in the last `lookbackSeasons` seasons.
+ * Stacks with existing franchise reputation modifiers (subject to ±25% cap in caller).
+ *
+ * @param {Array}  coachHistory    - team.coachHistory entries: [{ season, ... }]
+ * @param {number} lookbackSeasons - how many past seasons to inspect (default 3)
+ * @returns {{ penalty: number, reason: string } | null}
+ */
+export function getCoachingInstabilityPenalty(coachHistory, lookbackSeasons = 3) {
+  if (!Array.isArray(coachHistory) || coachHistory.length === 0) return null;
+
+  const maxSeason = coachHistory.reduce(
+    (max, e) => Math.max(max, Number(e?.season ?? 0)),
+    0,
+  );
+  const cutoff = maxSeason - Number(lookbackSeasons) + 1;
+
+  const recentChanges = coachHistory.filter(
+    (e) => Number(e?.season ?? 0) >= cutoff,
+  ).length;
+
+  if (recentChanges < 3) return null;
+
+  return {
+    penalty: 0.06,
+    reason:  'Franchise instability — frequent coaching changes',
+  };
+}
+
+// ── Position-scheme fit ────────────────────────────────────────────────────────
+
+const OFFENSIVE_POS = new Set([
+  'QB', 'RB', 'FB', 'HB', 'WR', 'TE',
+  'OL', 'OT', 'OG', 'C', 'G', 'T', 'LT', 'RT', 'LG', 'RG',
+]);
+
+const DEFENSIVE_POS = new Set([
+  'DL', 'DE', 'DT', 'NT', 'EDGE',
+  'LB', 'ILB', 'OLB', 'MLB',
+  'CB', 'DB', 'S', 'FS', 'SS',
+]);
+
+// Positions that are a GOOD FIT for each scheme
+const SCHEME_FIT = {
+  SPREAD:       new Set(['QB', 'WR', 'TE']),
+  WEST_COAST:   new Set(['QB', 'WR', 'TE']),
+  VERTICAL:     new Set(['QB', 'WR', 'TE']),
+  POWER_RUN:    new Set(['RB', 'FB', 'HB', 'OL', 'OT', 'OG', 'C', 'G', 'T', 'LT', 'RT', 'LG', 'RG']),
+  BALANCED:     null, // everyone fits
+  BLITZ_HEAVY:  new Set(['DL', 'DE', 'DT', 'NT', 'EDGE', 'LB', 'ILB', 'OLB', 'MLB']),
+  COVER_2:      new Set(['CB', 'DB', 'S', 'FS', 'SS']),
+  MAN_COVERAGE: new Set(['CB', 'DB', 'S', 'FS', 'SS']),
+  HYBRID:       null, // everyone fits
+};
+
+/**
+ * True if a player's position does NOT fit the given scheme.
+ * Only evaluates offensive and defensive players; special teams / nulls are never misfits.
+ *
+ * @param {string} position
+ * @param {string} scheme
+ * @returns {boolean}
+ */
+export function isPositionMisfitForScheme(position, scheme) {
+  if (!position || !scheme) return false;
+  const pos = String(position).toUpperCase();
+
+  // ST and unknown positions — not affected by scheme changes
+  if (!OFFENSIVE_POS.has(pos) && !DEFENSIVE_POS.has(pos)) return false;
+
+  // BALANCED and HYBRID — no misfits
+  const fitSet = SCHEME_FIT[scheme];
+  if (!fitSet) return false;
+
+  const isOffScheme = OFFENSIVE_POS.has(pos) && !DEFENSIVE_POS.has(pos);
+  const isDefScheme = DEFENSIVE_POS.has(pos) && !OFFENSIVE_POS.has(pos);
+
+  const schemeIsOffensive = ['SPREAD', 'WEST_COAST', 'VERTICAL', 'POWER_RUN'].includes(scheme);
+  const schemeIsDefensive = ['BLITZ_HEAVY', 'COVER_2', 'MAN_COVERAGE'].includes(scheme);
+
+  // Defensive players are unaffected by offensive scheme changes (and vice versa)
+  if (schemeIsOffensive && !isOffScheme) return false;
+  if (schemeIsDefensive && !isDefScheme) return false;
+
+  return !fitSet.has(pos);
+}
+
+// ── ensureCoachSchema ─────────────────────────────────────────────────────────
+
+const DEFAULT_HC = Object.freeze({
+  id:               null,
+  name:             null,
+  scheme:           'BALANCED',
+  contractYearsLeft: 3,
+  overallRating:    65,
+  hotSeat:          false,
+  firedSeason:      null,
+  hiredSeason:      null,
+});
+
+const DEFAULT_COORD = Object.freeze({
+  id:               null,
+  name:             null,
+  scheme:           'BALANCED',
+  contractYearsLeft: 3,
+  overallRating:    65,
+});
+
+/**
+ * Hydrate a team with the V1 coach schema if not already present.
+ * Safe on old saves — never overwrites existing data.
+ *
+ * @param {object} team
+ * @returns {object} team with coach schema defaults applied (new reference)
+ */
+export function ensureCoachSchema(team) {
+  if (!team) return team;
+
+  const existing = team.coach ?? {};
+
+  return {
+    ...team,
+    coach: {
+      headCoach: existing.headCoach
+        ? { ...DEFAULT_HC, ...existing.headCoach }
+        : { ...DEFAULT_HC },
+      offensiveCoordinator: existing.offensiveCoordinator
+        ? { ...DEFAULT_COORD, ...existing.offensiveCoordinator }
+        : { ...DEFAULT_COORD },
+      defensiveCoordinator: existing.defensiveCoordinator
+        ? { ...DEFAULT_COORD, ...existing.defensiveCoordinator }
+        : { ...DEFAULT_COORD },
+    },
+    coachHistory: Array.isArray(team.coachHistory) ? team.coachHistory : [],
+  };
+}

--- a/src/core/contracts/negotiationModifiers.js
+++ b/src/core/contracts/negotiationModifiers.js
@@ -34,6 +34,8 @@ export const LEVERAGE_MODIFIERS = Object.freeze({
   FRANCHISE_CHAMPION: -0.05,
   /** Franchise had 0 playoff appearances in 3+ seasons → +8% demand */
   FRANCHISE_DROUGHT: 0.08,
+  /** Franchise instability — 3+ coaching changes in 3 seasons → +6% demand */
+  COACHING_INSTABILITY: 0.06,
   /** Maximum total demand shift in either direction */
   MAX_SHIFT: 0.25,
 });
@@ -140,11 +142,15 @@ export function computePlayerLeverage(player, context = {}) {
  *   meta.franchiseHistoryByTeam    – keyed by teamId string
  *
  * @param {object} meta      – game meta (reads franchiseAwards + franchiseHistoryByTeam)
- * @param {object} context   – { userTeamId: number|string, currentSeason?: number }
+ * @param {object} context   – {
+ *   userTeamId: number|string,
+ *   currentSeason?: number,
+ *   coachingInstabilityPenalty?: { penalty: number, reason: string } | null
+ * }
  * @returns {{ multiplier: number, reasons: string[] }}
  */
 export function computeFranchiseReputation(meta, context = {}) {
-  const { userTeamId = null, currentSeason = 0 } = context;
+  const { userTeamId = null, currentSeason = 0, coachingInstabilityPenalty = null } = context;
 
   const reasons = [];
   let shift = 0;
@@ -174,6 +180,12 @@ export function computeFranchiseReputation(meta, context = {}) {
       shift += LEVERAGE_MODIFIERS.FRANCHISE_DROUGHT;
       reasons.push('Franchise playoff drought raises free agent skepticism');
     }
+  }
+
+  // Coaching instability: 3+ changes in last 3 seasons → +6% demand premium
+  if (coachingInstabilityPenalty?.penalty) {
+    shift += LEVERAGE_MODIFIERS.COACHING_INSTABILITY;
+    reasons.push(coachingInstabilityPenalty.reason ?? 'Franchise instability — frequent coaching changes');
   }
 
   return { multiplier: 1 + shift, reasons };

--- a/src/core/mood/playerMoraleEngine.js
+++ b/src/core/mood/playerMoraleEngine.js
@@ -47,6 +47,11 @@ export const MORALE_EVENTS = Object.freeze({
   HOLDOUT_RETURNED:          'HOLDOUT_RETURNED',
   VETERAN_LEADER_BONUS:      'VETERAN_LEADER_BONUS',
   DEADLINE_SELL_FRUSTRATION: 'DEADLINE_SELL_FRUSTRATION',
+  // Coaching Carousel V1
+  COACH_FIRED_HC:            'COACH_FIRED_HC',
+  COACH_FIRED_OC:            'COACH_FIRED_OC',
+  COACH_FIRED_DC:            'COACH_FIRED_DC',
+  SCHEME_CHANGE:             'SCHEME_CHANGE',
 });
 
 // ── Delta constants ────────────────────────────────────────────────────────────
@@ -61,6 +66,11 @@ export const MORALE_DELTAS = Object.freeze({
   [MORALE_EVENTS.HOLDOUT_RETURNED]:           -8,
   [MORALE_EVENTS.VETERAN_LEADER_BONUS]:        3,
   [MORALE_EVENTS.DEADLINE_SELL_FRUSTRATION]:  -3,
+  // Coaching Carousel V1
+  [MORALE_EVENTS.COACH_FIRED_HC]:             -6,
+  [MORALE_EVENTS.COACH_FIRED_OC]:             -4,
+  [MORALE_EVENTS.COACH_FIRED_DC]:             -4,
+  [MORALE_EVENTS.SCHEME_CHANGE]:              -3,
 });
 
 // ── Morale label thresholds ────────────────────────────────────────────────────

--- a/src/ui/components/CoachingScreen.jsx
+++ b/src/ui/components/CoachingScreen.jsx
@@ -1,43 +1,410 @@
-import React from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 
-const OFFENSIVE_SCHEMES = ['Air Raid', 'West Coast', 'Run Heavy', 'Spread', 'Pro Style'];
-const DEFENSIVE_SCHEMES = ['4-3', '3-4', 'Cover 2', 'Man Press', 'Zone Blitz'];
+const ROLE_HEAD_COACH = 'headCoach';
+const ROLE_OC = 'offensiveCoordinator';
+const ROLE_DC = 'defensiveCoordinator';
 
-const FIT = {
-  QB: ['Air Raid', 'Spread'], RB: ['Run Heavy', 'Pro Style'], WR: ['Air Raid', 'West Coast'], TE: ['Pro Style', 'West Coast'], OL: ['Run Heavy', 'Pro Style'],
-  DL: ['4-3', 'Zone Blitz'], LB: ['3-4', 'Zone Blitz'], CB: ['Man Press', 'Cover 2'], S: ['Cover 2', 'Zone Blitz'],
+const ROLE_LABELS = {
+  [ROLE_HEAD_COACH]: 'Head Coach',
+  [ROLE_OC]: 'Offensive Coordinator',
+  [ROLE_DC]: 'Defensive Coordinator',
 };
 
-export default function CoachingScreen({ league }) {
-  const userTeam = (Array.isArray(league?.teams) ? league?.teams : []).find((t) => t?.id === league?.userTeamId) ?? {};
-  const roster = Array.isArray(userTeam?.roster) ? userTeam?.roster : [];
-  const offScheme = userTeam?.offScheme ?? 'Pro Style';
-  const defScheme = userTeam?.defScheme ?? '4-3';
-  const staff = userTeam?.coachingStaff ?? {
-    headCoach: { name: 'Interim HC', offenseMind: 70, defenseMind: 70, morale: 75 },
-    offCoord: { name: 'Interim OC', scheme: offScheme, rating: 70 },
-    defCoord: { name: 'Interim DC', scheme: defScheme, rating: 70 },
+const ROLE_KEYS = {
+  [ROLE_HEAD_COACH]: 'headCoach',
+  [ROLE_OC]: 'OC',
+  [ROLE_DC]: 'DC',
+};
+
+function ratingColor(r) {
+  if (r >= 80) return 'var(--success, #34c759)';
+  if (r >= 65) return 'var(--accent, #007aff)';
+  if (r >= 50) return 'var(--warning, #ff9f0a)';
+  return 'var(--danger, #ff453a)';
+}
+
+function ratingTier(r) {
+  if (r >= 80) return 'Elite';
+  if (r >= 65) return 'Solid';
+  if (r >= 50) return 'Average';
+  return 'Poor';
+}
+
+function schemeMultiplierLabel(r) {
+  if (r >= 80) return '+8% sim boost';
+  if (r >= 65) return 'Neutral';
+  if (r >= 50) return '−6% sim penalty';
+  return '−12% sim penalty';
+}
+
+function CoachStaffCard({ role, coachData, onFire, onExtend, canFire, canExtend, phase }) {
+  const name = coachData?.name ?? '(Vacant)';
+  const rating = Number(coachData?.overallRating ?? coachData?.rating ?? 0);
+  const scheme = coachData?.scheme ?? '—';
+  const yearsLeft = Number(coachData?.contractYearsLeft ?? 0);
+  const isHotSeat = !!coachData?.hotSeat;
+  const hasCoach = !!coachData?.id || !!coachData?.name;
+
+  const fireAllowed = canFire && hasCoach;
+  const extendAllowed = canExtend && hasCoach && yearsLeft <= 1;
+
+  return (
+    <div
+      className="card padding-md"
+      style={{ marginBottom: 'var(--space-3)', position: 'relative' }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+        <div>
+          <div style={{ fontSize: 'var(--text-xs)', fontWeight: 700, color: 'var(--text-subtle)', textTransform: 'uppercase', marginBottom: 2 }}>
+            {ROLE_LABELS[role]}
+          </div>
+          <div style={{ fontSize: 'var(--text-lg)', fontWeight: 700, display: 'flex', alignItems: 'center', gap: 8 }}>
+            {name}
+            {isHotSeat && (
+              <span
+                style={{ fontSize: 'var(--text-xs)', background: 'var(--danger, #ff453a)', color: '#fff', padding: '2px 6px', borderRadius: 4, fontWeight: 700 }}
+                title="Hot seat: poor win% for 2+ seasons"
+              >
+                HOT SEAT
+              </span>
+            )}
+          </div>
+          {hasCoach && (
+            <div style={{ fontSize: 'var(--text-sm)', color: 'var(--text-muted)', marginTop: 2 }}>
+              Scheme: {scheme} · Contract: {yearsLeft} yr{yearsLeft !== 1 ? 's' : ''} left
+            </div>
+          )}
+        </div>
+        {hasCoach && (
+          <div style={{ textAlign: 'right' }}>
+            <div style={{ fontSize: 'var(--text-2xl)', fontWeight: 800, color: ratingColor(rating) }}>{rating}</div>
+            <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', textTransform: 'uppercase' }}>{ratingTier(rating)}</div>
+          </div>
+        )}
+      </div>
+
+      {hasCoach && (
+        <div style={{ marginTop: 'var(--space-3)', fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+          Sim effect: {schemeMultiplierLabel(rating)}
+        </div>
+      )}
+
+      {!hasCoach && (
+        <div style={{ marginTop: 'var(--space-2)', fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}>
+          No coach assigned — hire from the market below.
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: 8, marginTop: 'var(--space-4)', justifyContent: 'flex-end' }}>
+        {extendAllowed && (
+          <button
+            className="btn btn-sm btn-secondary"
+            onClick={() => onExtend(role, coachData)}
+            title="Extend contract by 1–3 years (available when ≤1 year left)"
+          >
+            Extend Contract
+          </button>
+        )}
+        {fireAllowed && (
+          <button
+            className="btn btn-sm btn-danger"
+            onClick={() => onFire(role, coachData)}
+          >
+            Fire
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MarketCoachRow({ coach, onHire, targetRole, disabled }) {
+  const rating = Number(coach?.overallRating ?? coach?.rating ?? 0);
+  const scheme = coach?.scheme ?? '—';
+  const salary  = coach?.salary ?? '—';
+
+  return (
+    <tr>
+      <td style={{ fontWeight: 600, paddingLeft: 'var(--space-4)' }}>{coach.name}</td>
+      <td style={{ color: ratingColor(rating), fontWeight: 700 }}>{rating}</td>
+      <td>{scheme}</td>
+      <td>{typeof salary === 'number' ? `$${salary}M` : salary}</td>
+      <td style={{ textAlign: 'right', paddingRight: 'var(--space-4)' }}>
+        <button
+          className="btn btn-sm btn-primary"
+          onClick={() => onHire(coach, targetRole)}
+          disabled={disabled}
+        >
+          Hire
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+function CoachHistoryLog({ history }) {
+  if (!Array.isArray(history) || history.length === 0) {
+    return <div style={{ color: 'var(--text-muted)', fontSize: 'var(--text-sm)' }}>No coaching history yet.</div>;
+  }
+  const recent = [...history].reverse().slice(0, 5);
+  return (
+    <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+      {recent.map((entry, i) => (
+        <li key={i} style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', padding: '3px 0', borderBottom: '1px solid var(--border-subtle, rgba(255,255,255,0.06))' }}>
+          <span style={{ fontWeight: 600, color: 'var(--text-secondary)' }}>{entry.name ?? '?'}</span>
+          {' '}({ROLE_LABELS[entry.role] ?? entry.role ?? '?'}) — Season {entry.firedSeason ?? entry.season ?? '?'}
+          {entry.reason ? ` · ${entry.reason}` : ''}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// ── ExtendModal ─────────────────────────────────────────────────────────────
+
+function ExtendModal({ role, coachData, onConfirm, onCancel }) {
+  const [years, setYears] = useState(2);
+  return (
+    <div
+      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.55)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000 }}
+      onClick={onCancel}
+    >
+      <div
+        className="card padding-md"
+        style={{ maxWidth: 360, width: '100%', margin: 'var(--space-4)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 style={{ marginTop: 0 }}>Extend Contract</h3>
+        <p style={{ fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}>
+          Extend <strong>{coachData?.name ?? 'coach'}</strong> ({ROLE_LABELS[role]}) contract by:
+        </p>
+        <div style={{ display: 'flex', gap: 8, marginBottom: 'var(--space-4)' }}>
+          {[1, 2, 3].map((y) => (
+            <button
+              key={y}
+              className={`btn btn-sm ${years === y ? 'btn-primary' : 'btn-secondary'}`}
+              onClick={() => setYears(y)}
+            >
+              {y} yr
+            </button>
+          ))}
+        </div>
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <button className="btn btn-sm btn-secondary" onClick={onCancel}>Cancel</button>
+          <button className="btn btn-sm btn-primary" onClick={() => onConfirm(years)}>Confirm</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Main: CoachingScreen ────────────────────────────────────────────────────
+
+export default function CoachingScreen({ league, actions }) {
+  const userTeamId = league?.userTeamId;
+  const phase = league?.phase ?? 'regular';
+
+  const [coachState, setCoachState] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+  const [activeHireRole, setActiveHireRole] = useState(null);
+  const [extendTarget, setExtendTarget] = useState(null);
+
+  const loadCoachingState = useCallback(async () => {
+    if (!userTeamId || !actions?.getCoachingState) return;
+    setLoading(true);
+    try {
+      const resp = await actions.getCoachingState(userTeamId);
+      if (resp?.payload) setCoachState(resp.payload);
+      setError(null);
+    } catch (e) {
+      setError(e?.message ?? 'Could not load coaching data.');
+    } finally {
+      setLoading(false);
+    }
+  }, [userTeamId, actions]);
+
+  useEffect(() => { loadCoachingState(); }, [loadCoachingState]);
+
+  const handleFire = async (role, coachData) => {
+    if (!window.confirm(`Fire ${coachData?.name ?? 'this coach'}? This will trigger morale events for players and cannot be undone this season.`)) return;
+    setBusy(true);
+    try {
+      const roleKey = ROLE_KEYS[role] ?? role;
+      const resp = await actions.fireCoach({ teamId: userTeamId, role: roleKey });
+      if (resp?.payload) setCoachState(resp.payload);
+      setError(null);
+    } catch (e) {
+      setError(e?.message ?? 'Could not fire coach.');
+    } finally {
+      setBusy(false);
+    }
   };
 
-  const fitCounts = roster.reduce((acc, p) => {
-    const pref = FIT[p?.pos] ?? [];
-    const scheme = ['QB', 'RB', 'WR', 'TE', 'OL'].includes(p?.pos) ? offScheme : defScheme;
-    if (pref.includes(scheme)) acc.good += 1;
-    else acc.bad += 1;
-    return acc;
-  }, { good: 0, bad: 0 });
+  const handleHire = async (coach, role) => {
+    if (!window.confirm(`Hire ${coach?.name} as ${ROLE_LABELS[role]}?`)) return;
+    setBusy(true);
+    try {
+      const roleKey = ROLE_KEYS[role] ?? role;
+      const resp = await actions.hireCoach({ teamId: userTeamId, coachId: coach.id, role: roleKey });
+      if (resp?.payload) setCoachState(resp.payload);
+      setActiveHireRole(null);
+      setError(null);
+    } catch (e) {
+      setError(e?.message ?? 'Could not hire coach.');
+    } finally {
+      setBusy(false);
+    }
+  };
 
-  return <div className="card-premium" style={{ padding: 16 }}>
-    <h3>Coaching Staff</h3>
-    <div>HC: {staff?.headCoach?.name} ({staff?.headCoach?.offenseMind}/{staff?.headCoach?.defenseMind}) morale {staff?.headCoach?.morale}</div>
-    <div>OC: {staff?.offCoord?.name} · {staff?.offCoord?.scheme} · {staff?.offCoord?.rating}</div>
-    <div>DC: {staff?.defCoord?.name} · {staff?.defCoord?.scheme} · {staff?.defCoord?.rating}</div>
-    <div style={{ marginTop: 8 }}>
-      Offensive Scheme: <select defaultValue={offScheme}>{OFFENSIVE_SCHEMES.map((s) => <option key={s}>{s}</option>)}</select>
+  const handleExtendConfirm = async (years) => {
+    if (!extendTarget) return;
+    setBusy(true);
+    try {
+      const roleKey = ROLE_KEYS[extendTarget.role] ?? extendTarget.role;
+      const resp = await actions.contractExtensionCoach({ teamId: userTeamId, role: roleKey, years });
+      if (resp?.payload) setCoachState(resp.payload);
+      setExtendTarget(null);
+      setError(null);
+    } catch (e) {
+      setError(e?.message ?? 'Could not extend contract.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Determine which phases allow firing (offseason phases only per spec)
+  const offseasonPhases = ['offseason', 'offseason_resign', 'offseason_draft', 'free_agency', 'preseason'];
+  const canFire = offseasonPhases.includes(phase);
+
+  const coach = coachState?.coach ?? {};
+  const coachHistory = coachState?.coachHistory ?? [];
+  const coachingMarket = coachState?.coachingMarket ?? [];
+
+  const marketForRole = (role) => {
+    if (!Array.isArray(coachingMarket)) return [];
+    // Filter by role if coaches have a role property, otherwise show all
+    return coachingMarket.filter((c) => {
+      if (!c?.role || c.role === 'any') return true;
+      if (role === ROLE_HEAD_COACH) return c.role === 'HC' || c.role === ROLE_HEAD_COACH;
+      if (role === ROLE_OC) return c.role === 'OC' || c.role === ROLE_OC;
+      if (role === ROLE_DC) return c.role === 'DC' || c.role === ROLE_DC;
+      return true;
+    });
+  };
+
+  if (loading && !coachState) {
+    return <div className="card padding-md text-muted">Loading coaching staff…</div>;
+  }
+
+  const roles = [ROLE_HEAD_COACH, ROLE_OC, ROLE_DC];
+
+  return (
+    <div style={{ maxWidth: 900, margin: '0 auto' }}>
+      <h2 style={{ marginBottom: 'var(--space-4)' }}>Coaching Staff</h2>
+
+      {error && (
+        <div role="alert" className="card padding-md" style={{ marginBottom: 'var(--space-4)', border: '1.5px solid var(--danger)', color: 'var(--danger)' }}>
+          {error}
+        </div>
+      )}
+
+      {!canFire && (
+        <div className="card padding-md" style={{ marginBottom: 'var(--space-4)', background: 'var(--surface)', fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}>
+          Coaching changes are only available during the offseason.
+        </div>
+      )}
+
+      {roles.map((role) => (
+        <CoachStaffCard
+          key={role}
+          role={role}
+          coachData={coach[role]}
+          phase={phase}
+          canFire={canFire && !busy}
+          canExtend={!busy}
+          onFire={handleFire}
+          onExtend={(r, d) => setExtendTarget({ role: r, coachData: d })}
+        />
+      ))}
+
+      {/* Hire panel */}
+      {canFire && coachingMarket.length > 0 && (
+        <div style={{ marginTop: 'var(--space-6)' }}>
+          <h3 style={{ marginBottom: 'var(--space-3)' }}>Coaching Market</h3>
+          <div style={{ display: 'flex', gap: 8, marginBottom: 'var(--space-3)' }}>
+            {roles.map((role) => (
+              <button
+                key={role}
+                className={`btn btn-sm ${activeHireRole === role ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => setActiveHireRole(activeHireRole === role ? null : role)}
+              >
+                {ROLE_LABELS[role]}
+              </button>
+            ))}
+          </div>
+
+          {activeHireRole && (
+            <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+              <div className="table-wrapper">
+                <table className="standings-table" style={{ width: '100%' }}>
+                  <thead>
+                    <tr>
+                      <th style={{ textAlign: 'left', paddingLeft: 'var(--space-4)' }}>Name</th>
+                      <th style={{ textAlign: 'left' }}>OVR</th>
+                      <th style={{ textAlign: 'left' }}>Scheme</th>
+                      <th style={{ textAlign: 'left' }}>Salary</th>
+                      <th style={{ textAlign: 'right', paddingRight: 'var(--space-4)' }}>Action</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {marketForRole(activeHireRole).length === 0 ? (
+                      <tr><td colSpan={5} style={{ padding: 20, textAlign: 'center', color: 'var(--text-muted)' }}>No coaches available for this role.</td></tr>
+                    ) : (
+                      marketForRole(activeHireRole).map((coach) => (
+                        <MarketCoachRow
+                          key={coach.id}
+                          coach={coach}
+                          targetRole={activeHireRole}
+                          onHire={handleHire}
+                          disabled={busy}
+                        />
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {canFire && coachingMarket.length === 0 && (
+        <div className="card padding-md" style={{ marginTop: 'var(--space-4)', color: 'var(--text-muted)', fontSize: 'var(--text-sm)' }}>
+          No coaches available in the market this offseason. Advance to a new season to refresh the market.
+        </div>
+      )}
+
+      {/* Coaching history */}
+      {coachHistory.length > 0 && (
+        <div style={{ marginTop: 'var(--space-6)' }}>
+          <h3 style={{ marginBottom: 'var(--space-2)' }}>Coaching History</h3>
+          <div className="card padding-md">
+            <CoachHistoryLog history={coachHistory} />
+          </div>
+        </div>
+      )}
+
+      {/* Extend modal */}
+      {extendTarget && (
+        <ExtendModal
+          role={extendTarget.role}
+          coachData={extendTarget.coachData}
+          onConfirm={handleExtendConfirm}
+          onCancel={() => setExtendTarget(null)}
+        />
+      )}
     </div>
-    <div>
-      Defensive Scheme: <select defaultValue={defScheme}>{DEFENSIVE_SCHEMES.map((s) => <option key={s}>{s}</option>)}</select>
-    </div>
-    <div style={{ marginTop: 8 }}>Fit impact: {fitCounts.good} players benefit, {fitCounts.bad} players mismatched</div>
-  </div>;
+  );
 }

--- a/src/ui/components/LeagueHub.jsx
+++ b/src/ui/components/LeagueHub.jsx
@@ -7,7 +7,7 @@ import { buildWeeklyLeagueRecap } from '../utils/weeklyLeagueRecap.js';
 import { CompactListRow, StatusChip, HeroCard, SectionCard, StatStrip, CompactInsightCard } from './ScreenSystem.jsx';
 import { openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 
-const LEAGUE_SECTIONS = ['Overview', 'Results', 'Standings', 'News', 'Leaders'];
+const LEAGUE_SECTIONS = ['Overview', 'Results', 'Standings', 'News', 'Leaders', 'Coaching'];
 
 function normalizeSection(section) {
   if (typeof section !== 'string') return 'Overview';
@@ -147,6 +147,82 @@ export default function LeagueHub({
           <SectionCard title="League leaders" subtitle="Season production and race snapshots." variant="compact" />
           <LeagueLeaders league={league} actions={actions} onPlayerSelect={onPlayerSelect} />
         </div>
+      )}
+
+      {section === 'Coaching' && (
+        <CoachingCarouselPanel league={league} />
+      )}
+    </div>
+  );
+}
+
+function CoachingCarouselPanel({ league }) {
+  const phase = league?.phase ?? 'regular';
+  const teams = Array.isArray(league?.teams) ? league.teams : [];
+  const coachingMarket = Array.isArray(league?.coachingMarket) ? league.coachingMarket : [];
+
+  const offseasonPhases = ['offseason', 'offseason_resign', 'offseason_draft', 'free_agency', 'preseason', 'draft'];
+  const isOffseason = offseasonPhases.includes(phase);
+
+  const hotSeatTeams = teams.filter((t) => t?.coachHotSeat);
+
+  return (
+    <div className="app-screen-stack">
+      <SectionCard
+        title="Coaching Carousel"
+        subtitle={isOffseason ? 'Hot seats and coaching market this offseason.' : 'Coaching carousel data available during the offseason.'}
+        variant="compact"
+      >
+        {!isOffseason && (
+          <div style={{ color: 'var(--text-muted)', fontSize: 'var(--text-sm)', padding: 'var(--space-2) 0' }}>
+            Coaching changes are processed at the end of each season.
+          </div>
+        )}
+      </SectionCard>
+
+      {hotSeatTeams.length > 0 && (
+        <SectionCard title="Hot seat coaches" subtitle="Coaches at risk of being fired." variant="compact">
+          <div className="app-row-stack">
+            {hotSeatTeams.map((team) => (
+              <CompactListRow
+                key={team.id}
+                title={`${team.name ?? team.abbr}`}
+                subtitle={team.coachHCName ? `HC: ${team.coachHCName}` : 'Head Coach'}
+                meta={
+                  <StatusChip
+                    label={`OVR ${team.coachHCRating ?? '—'}`}
+                    tone={team.coachHCRating >= 65 ? 'info' : 'warning'}
+                  />
+                }
+              >
+                <StatusChip label="HOT SEAT" tone="danger" />
+              </CompactListRow>
+            ))}
+          </div>
+        </SectionCard>
+      )}
+
+      {hotSeatTeams.length === 0 && isOffseason && (
+        <SectionCard title="Hot seat coaches" variant="compact">
+          <div style={{ color: 'var(--text-muted)', fontSize: 'var(--text-sm)', padding: 'var(--space-2) 0' }}>
+            No coaches currently on the hot seat.
+          </div>
+        </SectionCard>
+      )}
+
+      {isOffseason && coachingMarket.length > 0 && (
+        <SectionCard title="Coaching market" subtitle={`${coachingMarket.length} coaches available`} variant="compact">
+          <div className="app-row-stack">
+            {coachingMarket.slice(0, 6).map((coach) => (
+              <CompactInsightCard
+                key={coach.id ?? coach.name}
+                title={coach.name ?? 'Unknown'}
+                subtitle={`OVR ${coach.overallRating ?? coach.rating ?? '—'} · ${coach.scheme ?? '—'}`}
+                tone={coach.overallRating >= 75 ? 'ok' : coach.overallRating >= 60 ? 'info' : 'neutral'}
+              />
+            ))}
+          </div>
+        </SectionCard>
       )}
     </div>
   );

--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -642,11 +642,17 @@ export function useWorker() {
     negotiateStaffContract: (payload) => request(toWorker.NEGOTIATE_STAFF_CONTRACT, payload, { silent: true }),
     updateDraftBoard: (payload) => send(toWorker.UPDATE_DRAFT_BOARD, payload),
 
-    /** Hire a coach (replaces existing). */
-    hireCoach: (payload) => send(toWorker.HIRE_COACH, payload),
+    /** Fetch V1 coaching state for a team (returns a Promise). */
+    getCoachingState: (teamId) => request(toWorker.GET_COACHING_STATE, teamId != null ? { teamId } : {}, { silent: true }),
 
-    /** Fire a coach. */
-    fireCoach: (payload) => send(toWorker.FIRE_COACH, payload),
+    /** Hire a coach (returns a Promise with COACHING_STATE payload). */
+    hireCoach: (payload) => request(toWorker.HIRE_COACH, payload),
+
+    /** Fire a coach (returns a Promise with COACHING_STATE payload). */
+    fireCoach: (payload) => request(toWorker.FIRE_COACH, payload),
+
+    /** Extend a coach's contract (returns a Promise with COACHING_STATE payload). */
+    contractExtensionCoach: (payload) => request(toWorker.CONTRACT_EXTENSION_COACH, payload),
 
     /** Submit a trade offer to an AI team (returns a Promise). */
     submitTrade: (fromTeamId, toTeamId, offering, receiving) =>

--- a/src/worker/protocol.js
+++ b/src/worker/protocol.js
@@ -124,6 +124,8 @@ export const toWorker = Object.freeze({
   OPTIMIZE_ROSTER:    'OPTIMIZE_ROSTER',  // { teamId, mode?: 'optimize'|'best_available' }
   HIRE_COACH:         'HIRE_COACH',           // { teamId, coachId, role }
   FIRE_COACH:         'FIRE_COACH',           // { teamId, role }
+  CONTRACT_EXTENSION_COACH: 'CONTRACT_EXTENSION_COACH', // { teamId, role, years }
+  GET_COACHING_STATE: 'GET_COACHING_STATE',   // { teamId? } — fetch V1 coaching state
   GET_AVAILABLE_COACHES: 'GET_AVAILABLE_COACHES', // {}
   GET_STAFF_STATE: 'GET_STAFF_STATE',
   HIRE_STAFF_MEMBER: 'HIRE_STAFF_MEMBER',
@@ -230,6 +232,7 @@ export const toUI = Object.freeze({
   /** Coaching Data */
   AVAILABLE_COACHES:  'AVAILABLE_COACHES',    // { coaches[] }
   STAFF_STATE: 'STAFF_STATE',
+  COACHING_STATE: 'COACHING_STATE',           // { team.coach, coachHistory, coachingMarket }
 
   /** Box score response */
   BOX_SCORE:          'BOX_SCORE',            // { gameId, game }

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -75,6 +75,14 @@ import { Utils }          from '../core/utils.js';
 import { makeAccurateSchedule, Scheduler } from '../core/schedule.js';
 import { makePlayer, generateDraftClass, calculateMorale, calculateExtensionDemand, buildPlayerGuid }  from '../core/player.js';
 import { makeCoach, generateInitialStaff } from '../core/coach-system.js';
+import {
+  COACH_ROLES,
+  generateCoachingMarket,
+  evaluateHotSeat,
+  getCoachingInstabilityPenalty,
+  ensureCoachSchema,
+  isPositionMisfitForScheme,
+} from '../core/coaching/coachingEngine.js';
 import { ensureTeamStaff, computeStaffTeamBonuses, buildStaffMarket, buildScoutingSnapshot, negotiateContract } from '../core/staff-system.js';
 import {
   inferTeamDirection,
@@ -272,6 +280,12 @@ let _lastSentViewState = null;
 // payloads so the UI can detect and drop STATE_UPDATE packets that pre-date the
 // last accepted FULL_STATE baseline (stale-packet guard).
 let _stateEpoch = 0;
+
+// ── Coaching Carousel V1 constants ───────────────────────────────────────────
+const DEFAULT_HC_STUB = Object.freeze({
+  id: null, name: null, scheme: 'BALANCED', contractYearsLeft: 0,
+  overallRating: 65, hotSeat: false, firedSeason: null, hiredSeason: null,
+});
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -949,6 +963,9 @@ function buildViewState() {
     fanApproval: t?.fanApproval ?? 50,
     franchiseInvestments: normalizeFranchiseInvestments(t?.franchiseInvestments),
     rivalTeamId: t?.rivalTeamId ?? null,
+    coachHotSeat: t?.coach?.headCoach?.hotSeat ?? false,
+    coachHCName: t?.coach?.headCoach?.name ?? null,
+    coachHCRating: t?.coach?.headCoach?.overallRating ?? null,
     picks: Array.isArray(t?.picks)
       ? t.picks.map((pk) => ({
         id: pk.id,
@@ -1066,6 +1083,7 @@ function buildViewState() {
     commissionerLog: Array.isArray(meta?.commissionerLog) ? meta.commissionerLog.slice(-100) : [],
     standings: standingsRows,
     standingsContext,
+    coachingMarket: Array.isArray(meta?.coachingMarket) ? meta.coachingMarket : [],
     teams,
     ...(typeof globalThis !== 'undefined' && globalThis.__DYNASTY_SOAK_PROFILE__ && globalThis.__DYNASTY_SOAK_LAST_BATCH__
       ? { dynastySoakSimBatch: { ...globalThis.__DYNASTY_SOAK_LAST_BATCH__ } }
@@ -2817,8 +2835,9 @@ async function handleAdvanceWeek(payload, id) {
       }
     }
 
-    // Set phase to Regular Season, keep Week 1
-    cache.setMeta({ phase: 'regular', currentWeek: 1 });
+    // Set phase to Regular Season, keep Week 1.
+    // V1 Coaching Carousel: clear the coaching market at end of preseason.
+    cache.setMeta({ phase: 'regular', currentWeek: 1, coachingMarket: [] });
     await flushDirty();
 
     // Return state update (no simulation)
@@ -6113,7 +6132,9 @@ function buildDemandSnapshotForOffer(player, team) {
   const userTeamId = Number(meta?.userTeamId ?? 0);
 
   const playerLeverage = computePlayerLeverage(player, { moraleSummary, awardSummary, currentSeason });
-  const franchiseRep = computeFranchiseReputation(meta, { userTeamId, currentSeason });
+  const userTeamForCoach = cache.getTeam(userTeamId);
+  const instabilityPenalty = getCoachingInstabilityPenalty(userTeamForCoach?.coachHistory ?? [], 3);
+  const franchiseRep = computeFranchiseReputation(meta, { userTeamId, currentSeason, coachingInstabilityPenalty: instabilityPenalty });
   const ask = applyNegotiationModifiers(baseAsk, playerLeverage, franchiseRep);
   const negCtx = getNegotiationContext(player, meta, { moraleSummary, awardSummary, currentSeason, userTeamId });
 
@@ -6890,7 +6911,9 @@ async function handleGetFreeAgents(payload, id) {
         const pAwardSummary = getPlayerAwardSummary(p);
         const faCurrentSeason = Number(meta?.season ?? 0);
         const pLeverage = computePlayerLeverage(p, { moraleSummary: pMoraleSummary, awardSummary: pAwardSummary, currentSeason: faCurrentSeason });
-        const fReputation = computeFranchiseReputation(meta, { userTeamId: Number(userTeamId ?? 0), currentSeason: faCurrentSeason });
+        const faUserTeam = cache.getTeam(Number(userTeamId ?? 0));
+        const faInstability = getCoachingInstabilityPenalty(faUserTeam?.coachHistory ?? [], 3);
+        const fReputation = computeFranchiseReputation(meta, { userTeamId: Number(userTeamId ?? 0), currentSeason: faCurrentSeason, coachingInstabilityPenalty: faInstability });
         const ask = applyNegotiationModifiers(baseAsk, pLeverage, fReputation);
         const pNegCtx = getNegotiationContext(p, meta, { moraleSummary: pMoraleSummary, awardSummary: pAwardSummary, currentSeason: faCurrentSeason, userTeamId: Number(userTeamId ?? 0) });
         const reSignInsight = evaluateReSignPriority(p, {
@@ -7104,43 +7127,298 @@ async function handleGetAvailableCoaches(payload, id) {
     post(toUI.AVAILABLE_COACHES, { coaches }, id);
 }
 
-async function handleHireCoach({ teamId, coach, role }, id) {
-    const team = cache.getTeam(Number(teamId));
-    if (!team) {
-        post(toUI.ERROR, { message: 'Team not found' }, id);
-        return;
-    }
+// ── Coaching Carousel V1 helpers ──────────────────────────────────────────────
 
-    if (!team.staff) team.staff = {};
-
-    // Assign coach to slot
-    if (role === 'HC') team.staff.headCoach = coach;
-    else if (role === 'OC') team.staff.offCoordinator = coach;
-    else if (role === 'DC') team.staff.defCoordinator = coach;
-
-    // If HC, update strategies to match their schemes
-    if (role === 'HC') {
-        if (!team.strategies) team.strategies = {};
-        team.strategies.offense = coach.offScheme;
-        team.strategies.defense = coach.defScheme;
-    }
-
-    await flushDirty(); // Should trigger update of team record
-
-    // Return updated roster data which includes staff
-    await handleGetRoster({ teamId }, id);
+function getCoachV1Role(role) {
+  if (role === 'headCoach' || role === 'HC') return COACH_ROLES.HEAD_COACH;
+  if (role === 'OC' || role === 'offensiveCoordinator') return COACH_ROLES.OC;
+  if (role === 'DC' || role === 'defensiveCoordinator') return COACH_ROLES.DC;
+  return null;
 }
 
+function buildCoachFireMoraleEvent(v1Role, teamId, season) {
+  if (v1Role === COACH_ROLES.HEAD_COACH) {
+    return { type: MORALE_EVENTS.COACH_FIRED_HC, delta: MORALE_DELTAS[MORALE_EVENTS.COACH_FIRED_HC], dedupeKey: `coach_fired_hc_${teamId}_${season}` };
+  }
+  if (v1Role === COACH_ROLES.OC) {
+    return { type: MORALE_EVENTS.COACH_FIRED_OC, delta: MORALE_DELTAS[MORALE_EVENTS.COACH_FIRED_OC], dedupeKey: `coach_fired_oc_${teamId}_${season}` };
+  }
+  if (v1Role === COACH_ROLES.DC) {
+    return { type: MORALE_EVENTS.COACH_FIRED_DC, delta: MORALE_DELTAS[MORALE_EVENTS.COACH_FIRED_DC], dedupeKey: `coach_fired_dc_${teamId}_${season}` };
+  }
+  return null;
+}
+
+function isOffensivePosition(pos) {
+  const p = String(pos ?? '').toUpperCase();
+  return ['QB', 'RB', 'FB', 'HB', 'WR', 'TE', 'OL', 'OT', 'OG', 'C', 'G', 'T', 'LT', 'RT', 'LG', 'RG'].includes(p);
+}
+
+function isDefensivePosition(pos) {
+  const p = String(pos ?? '').toUpperCase();
+  return ['DL', 'DE', 'DT', 'NT', 'EDGE', 'LB', 'ILB', 'OLB', 'MLB', 'CB', 'DB', 'S', 'FS', 'SS'].includes(p);
+}
+
+function getStartersForRole(players, v1Role) {
+  if (v1Role === COACH_ROLES.HEAD_COACH) {
+    return players.filter((p) => p?.depthChartPosition === 1 || p?.isStarter);
+  }
+  if (v1Role === COACH_ROLES.OC) {
+    return players.filter((p) => isOffensivePosition(p?.pos) && (p?.depthChartPosition === 1 || p?.isStarter));
+  }
+  if (v1Role === COACH_ROLES.DC) {
+    return players.filter((p) => isDefensivePosition(p?.pos) && (p?.depthChartPosition === 1 || p?.isStarter));
+  }
+  return [];
+}
+
+function postCoachingState(team, meta, msgId) {
+  const coachingMarket = Array.isArray(meta?.coachingMarket) ? meta.coachingMarket : [];
+  post(toUI.COACHING_STATE, {
+    teamId:        team.id,
+    coach:         team.coach ?? {},
+    coachHistory:  Array.isArray(team.coachHistory) ? team.coachHistory : [],
+    coachingMarket,
+  }, msgId);
+}
+
+// ── Handler: GET_COACHING_STATE ───────────────────────────────────────────────
+
+async function handleGetCoachingState({ teamId } = {}, id) {
+  const meta = ensureDynastyMeta(cache.getMeta());
+  const resolvedId = Number(teamId ?? meta?.userTeamId);
+  const team = cache.getTeam(resolvedId);
+  if (!team) { post(toUI.ERROR, { message: 'Team not found' }, id); return; }
+  const teamWithSchema = ensureCoachSchema(team);
+  postCoachingState(teamWithSchema, meta, id);
+}
+
+// ── Handler: FIRE_COACH (V1) ──────────────────────────────────────────────────
+
 async function handleFireCoach({ teamId, role }, id) {
-    const team = cache.getTeam(Number(teamId));
-    if (!team || !team.staff) return;
+  const meta = ensureDynastyMeta(cache.getMeta());
+  const team = cache.getTeam(Number(teamId));
+  if (!team) { post(toUI.ERROR, { message: 'Team not found' }, id); return; }
 
-    if (role === 'HC') team.staff.headCoach = null;
-    else if (role === 'OC') team.staff.offCoordinator = null;
-    else if (role === 'DC') team.staff.defCoordinator = null;
+  const phase   = meta?.phase ?? 'regular';
+  const season  = Number(meta?.year ?? 0);
+  const week    = Number(meta?.currentWeek ?? 0);
 
-    await flushDirty();
-    await handleGetRoster({ teamId }, id);
+  const allowedPhases = ['offseason_resign', 'free_agency', 'draft', 'offseason', 'preseason'];
+  if (!allowedPhases.includes(phase)) {
+    post(toUI.ERROR, { message: 'Coaches can only be fired during the offseason or preseason.' }, id);
+    return;
+  }
+
+  const v1Role = getCoachV1Role(role);
+  if (!v1Role) { post(toUI.ERROR, { message: `Invalid coach role: ${role}` }, id); return; }
+
+  // Ensure V1 schema
+  const teamWithSchema = ensureCoachSchema(team);
+  const coachData      = teamWithSchema.coach?.[v1Role] ?? {};
+  const coachName      = coachData.name ?? 'Unknown Coach';
+  const coachScheme    = coachData.scheme ?? 'BALANCED';
+  const coachRating    = coachData.overallRating ?? 65;
+
+  // Archive to coachHistory
+  const historyEntry = {
+    role:         v1Role,
+    name:         coachName,
+    scheme:       coachScheme,
+    overallRating: coachRating,
+    seasons:      coachData.hiredSeason ? season - coachData.hiredSeason : 0,
+    record:       { w: 0, l: 0 },
+    firedReason:  coachData.hotSeat ? 'hotseat' : 'gm_decision',
+    season,
+  };
+
+  const coachHistory = [...(Array.isArray(teamWithSchema.coachHistory) ? teamWithSchema.coachHistory : []), historyEntry];
+
+  // Update V1 coach slot to null equivalent
+  const updatedCoach = {
+    ...teamWithSchema.coach,
+    [v1Role]: { id: null, name: null, scheme: 'BALANCED', contractYearsLeft: 0, overallRating: 65,
+      ...(v1Role === COACH_ROLES.HEAD_COACH ? { hotSeat: false, firedSeason: season, hiredSeason: null } : {}) },
+  };
+
+  // Also clear legacy staff slot
+  if (!team.staff) team.staff = {};
+  if (v1Role === COACH_ROLES.HEAD_COACH) team.staff.headCoach      = null;
+  if (v1Role === COACH_ROLES.OC)         team.staff.offCoordinator  = null;
+  if (v1Role === COACH_ROLES.DC)         team.staff.defCoordinator  = null;
+
+  cache.updateTeam(team.id, { coach: updatedCoach, coachHistory, staff: team.staff });
+
+  // Fire morale events for affected starters
+  const moraleEvent = buildCoachFireMoraleEvent(v1Role, team.id, season);
+  if (moraleEvent) {
+    const players = cache.getPlayersByTeam(team.id);
+    const starters = getStartersForRole(players, v1Role);
+    for (const player of starters) {
+      const updated = applyMoraleEvent(player, { ...moraleEvent, season, week, reason: `${coachName} was fired` }, { season, week });
+      if (updated !== player) cache.updatePlayer(player.id, { morale: updated.morale, moraleEvents: updated.moraleEvents });
+    }
+  }
+
+  // News item
+  const roleLabel = v1Role === COACH_ROLES.HEAD_COACH ? 'head coach' : v1Role === COACH_ROLES.OC ? 'offensive coordinator' : 'defensive coordinator';
+  const hotSeatNote = coachData.hotSeat ? ' (expected firing after two poor seasons)' : '';
+  await NewsEngine.logNews(
+    'TRANSACTION',
+    `${team.abbr ?? 'Team'} fires ${roleLabel} ${coachName}${hotSeatNote}.`,
+    team.id,
+    { category: 'coach_fired', coachName, role: v1Role, teamId: team.id, dedupeKey: `coach_fired_${v1Role}_${team.id}_${season}` },
+  );
+
+  await flushDirty();
+  const refreshed = cache.getTeam(Number(teamId));
+  postCoachingState(refreshed ?? team, cache.getMeta(), id);
+  await handleGetRoster({ teamId }, id);
+}
+
+// ── Handler: HIRE_COACH (V1) ──────────────────────────────────────────────────
+
+async function handleHireCoach({ teamId, coachId, coach: legacyCoach, role }, id) {
+  const meta = ensureDynastyMeta(cache.getMeta());
+  const team = cache.getTeam(Number(teamId));
+  if (!team) { post(toUI.ERROR, { message: 'Team not found' }, id); return; }
+
+  const phase  = meta?.phase ?? 'regular';
+  const season = Number(meta?.year ?? 0);
+  const week   = Number(meta?.currentWeek ?? 0);
+
+  const v1Role = getCoachV1Role(role);
+  if (!v1Role) { post(toUI.ERROR, { message: `Invalid coach role: ${role}` }, id); return; }
+
+  // Resolve the coach from the market or legacy payload
+  const coachingMarket = Array.isArray(meta?.coachingMarket) ? meta.coachingMarket : [];
+  let marketCoach = coachId ? coachingMarket.find((c) => c.id === coachId) : null;
+  // Fall back to legacy coach object for backward compatibility
+  const coachToHire = marketCoach ?? legacyCoach;
+  if (!coachToHire) { post(toUI.ERROR, { message: 'Coach not found in coaching market' }, id); return; }
+
+  if (marketCoach && !coachingMarket.some((c) => c.id === coachId)) {
+    post(toUI.ERROR, { message: 'This coach is no longer available' }, id);
+    return;
+  }
+
+  // Ensure V1 schema
+  const teamWithSchema = ensureCoachSchema(team);
+  const prevCoach      = teamWithSchema.coach?.[v1Role] ?? {};
+  const prevScheme     = prevCoach.scheme ?? 'BALANCED';
+  const newScheme      = coachToHire.scheme ?? 'BALANCED';
+
+  const newV1CoachData = {
+    id:               coachToHire.id ?? null,
+    name:             coachToHire.name ?? 'Unknown Coach',
+    scheme:           newScheme,
+    contractYearsLeft: 3,
+    overallRating:    coachToHire.overallRating ?? 65,
+    ...(v1Role === COACH_ROLES.HEAD_COACH ? { hotSeat: false, firedSeason: null, hiredSeason: season } : {}),
+  };
+
+  const updatedCoach = { ...teamWithSchema.coach, [v1Role]: newV1CoachData };
+
+  // Also sync to legacy staff object for sim engine compatibility
+  if (!team.staff) team.staff = {};
+  const legacyStaffCoach = {
+    ...coachToHire,
+    overallRating: coachToHire.overallRating ?? 65,
+    position: v1Role === COACH_ROLES.HEAD_COACH ? 'HC' : v1Role === COACH_ROLES.OC ? 'OC' : 'DC',
+  };
+  if (v1Role === COACH_ROLES.HEAD_COACH) {
+    team.staff.headCoach = legacyStaffCoach;
+    if (!team.strategies) team.strategies = {};
+    team.strategies.offense = coachToHire.offScheme ?? coachToHire.scheme;
+    team.strategies.defense = coachToHire.defScheme ?? coachToHire.scheme;
+  } else if (v1Role === COACH_ROLES.OC) {
+    team.staff.offCoordinator = legacyStaffCoach;
+  } else if (v1Role === COACH_ROLES.DC) {
+    team.staff.defCoordinator = legacyStaffCoach;
+  }
+
+  cache.updateTeam(team.id, { coach: updatedCoach, staff: team.staff });
+
+  // Fire morale events for scheme-misfit players (HC scheme change only)
+  const schemeChanged = newScheme !== prevScheme && prevCoach.name != null;
+  if (schemeChanged && v1Role === COACH_ROLES.HEAD_COACH) {
+    const players = cache.getPlayersByTeam(team.id);
+    for (const player of players) {
+      if (!isPositionMisfitForScheme(player?.pos, newScheme)) continue;
+      const dedupeKey = `scheme_change_${player.id}_${team.id}_${season}`;
+      const updated = applyMoraleEvent(player, {
+        type:      MORALE_EVENTS.SCHEME_CHANGE,
+        delta:     MORALE_DELTAS[MORALE_EVENTS.SCHEME_CHANGE],
+        season,
+        week,
+        reason:    `New scheme (${newScheme}) doesn't suit their position`,
+        dedupeKey,
+      }, { season, week });
+      if (updated !== player) cache.updatePlayer(player.id, { morale: updated.morale, moraleEvents: updated.moraleEvents });
+    }
+  }
+
+  // Remove coach from market
+  if (marketCoach) {
+    const updatedMarket = coachingMarket.filter((c) => c.id !== coachId);
+    cache.setMeta({ coachingMarket: updatedMarket });
+  }
+
+  // News item
+  const hireRoleLabel = v1Role === COACH_ROLES.HEAD_COACH ? 'head coach' : v1Role === COACH_ROLES.OC ? 'offensive coordinator' : 'defensive coordinator';
+  await NewsEngine.logNews(
+    'TRANSACTION',
+    `${team.abbr ?? 'Team'} hires ${coachToHire.name} as ${hireRoleLabel}.`,
+    team.id,
+    { category: 'coach_hired', coachName: coachToHire.name, role: v1Role, teamId: team.id, dedupeKey: `coach_hired_${v1Role}_${team.id}_${season}` },
+  );
+
+  await flushDirty();
+  const refreshed = cache.getTeam(Number(teamId));
+  postCoachingState(refreshed ?? team, cache.getMeta(), id);
+  await handleGetRoster({ teamId }, id);
+}
+
+// ── Handler: CONTRACT_EXTENSION_COACH ────────────────────────────────────────
+
+async function handleContractExtensionCoach({ teamId, role, years }, id) {
+  const meta   = ensureDynastyMeta(cache.getMeta());
+  const team   = cache.getTeam(Number(teamId));
+  if (!team) { post(toUI.ERROR, { message: 'Team not found' }, id); return; }
+
+  const v1Role = getCoachV1Role(role);
+  if (!v1Role) { post(toUI.ERROR, { message: `Invalid coach role: ${role}` }, id); return; }
+
+  const teamWithSchema = ensureCoachSchema(team);
+  const coachData      = teamWithSchema.coach?.[v1Role] ?? {};
+
+  if ((coachData.contractYearsLeft ?? 0) > 1) {
+    post(toUI.ERROR, { message: 'Contract extensions are only available when contractYearsLeft is 1 or fewer.' }, id);
+    return;
+  }
+
+  const extensionYears = Math.min(3, Math.max(1, Number(years ?? 1)));
+  const newYearsLeft   = (coachData.contractYearsLeft ?? 0) + extensionYears;
+
+  const updatedCoach = {
+    ...teamWithSchema.coach,
+    [v1Role]: { ...coachData, contractYearsLeft: newYearsLeft },
+  };
+  cache.updateTeam(team.id, { coach: updatedCoach });
+
+  const season = Number(meta?.year ?? 0);
+  const week   = Number(meta?.currentWeek ?? 0);
+
+  await NewsEngine.logNews(
+    'TRANSACTION',
+    `${team.abbr ?? 'Team'} extends ${coachData.name ?? 'coach'} by ${extensionYears} year${extensionYears !== 1 ? 's' : ''}.`,
+    team.id,
+    { category: 'coach_extended', coachName: coachData.name ?? 'coach', role: v1Role, extensionYears, teamId: team.id, dedupeKey: `coach_extended_${v1Role}_${team.id}_${season}` },
+  );
+
+  await flushDirty();
+  const refreshed = cache.getTeam(Number(teamId));
+  postCoachingState(refreshed ?? team, cache.getMeta(), id);
 }
 
 async function handleGetStaffState(payload, id) {
@@ -7445,7 +7723,9 @@ async function handleGetExtensionAsk({ playerId }, id) {
   const extSeason = Number(meta?.season ?? 0);
   const extTeamId = Number(meta?.userTeamId ?? 0);
   const extLeverage = computePlayerLeverage(player, { moraleSummary: extMoraleSummary, awardSummary: extAwardSummary, currentSeason: extSeason });
-  const extFranchiseRep = computeFranchiseReputation(meta, { userTeamId: extTeamId, currentSeason: extSeason });
+  const extUserTeam = cache.getTeam(extTeamId);
+  const extInstability = getCoachingInstabilityPenalty(extUserTeam?.coachHistory ?? [], 3);
+  const extFranchiseRep = computeFranchiseReputation(meta, { userTeamId: extTeamId, currentSeason: extSeason, coachingInstabilityPenalty: extInstability });
   const modifiedAsk = applyNegotiationModifiers(baseAsk, extLeverage, extFranchiseRep);
   const extNegCtx = getNegotiationContext(player, meta, { moraleSummary: extMoraleSummary, awardSummary: extAwardSummary, currentSeason: extSeason, userTeamId: extTeamId });
   const ask = {
@@ -10803,6 +11083,63 @@ async function archiveSeason(seasonId) {
       }
     }
     memoryMeta.seasonStorylines = buildSeasonStorylineSnapshot(memoryMeta, teams, meta.userTeamId);
+    // ── V1 Coaching Carousel: hot-seat evaluation + AI auto-fire ─────────────
+    try {
+      const allTeamsForCoaching = cache.getAllTeams();
+      const userTeamId = Number(meta?.userTeamId ?? -1);
+      // Build a seeded RNG for AI auto-fire (deterministic per season)
+      const autoFireSeed = Number(year) * 1009 + 7;
+      let autoFireRng = autoFireSeed;
+      function nextAutoFireRng() {
+        autoFireRng = ((1664525 * autoFireRng + 1013904223) | 0) >>> 0;
+        return autoFireRng / 0x100000000;
+      }
+
+      for (const t of allTeamsForCoaching) {
+        const teamWithCoach = ensureCoachSchema(t);
+        const hc = teamWithCoach.coach?.headCoach;
+        if (!hc?.name) continue;
+
+        const teamStanding = standingsRows.find((s) => Number(s.id) === Number(t.id));
+        const w = Number(teamStanding?.wins ?? t.wins ?? 0);
+        const l = Number(teamStanding?.losses ?? t.losses ?? 0);
+        const seasonRecord = { w, l };
+
+        const onHotSeat = evaluateHotSeat(teamWithCoach, seasonRecord, year);
+        const updatedHC = { ...hc, hotSeat: onHotSeat };
+        const updatedCoach = { ...teamWithCoach.coach, headCoach: updatedHC };
+        cache.updateTeam(t.id, { coach: updatedCoach });
+
+        // AI teams: auto-fire hot-seat coaches at 60% probability
+        if (Number(t.id) !== userTeamId && onHotSeat) {
+          const roll = nextAutoFireRng();
+          if (roll < 0.60) {
+            const historyEntry = {
+              role:         COACH_ROLES.HEAD_COACH,
+              name:         hc.name,
+              scheme:       hc.scheme ?? 'BALANCED',
+              overallRating: hc.overallRating ?? 65,
+              seasons:      hc.hiredSeason ? year - hc.hiredSeason : 0,
+              record:       seasonRecord,
+              firedReason:  'hotseat_ai_autfire',
+              season:       year,
+            };
+            const coachHistory = [...(Array.isArray(t.coachHistory) ? t.coachHistory : []), historyEntry];
+            const clearedHC = { ...DEFAULT_HC_STUB, firedSeason: year, hotSeat: false };
+            cache.updateTeam(t.id, {
+              coachHistory,
+              coach: { ...updatedCoach, headCoach: clearedHC },
+            });
+            if (!t.staff) t.staff = {};
+            t.staff.headCoach = null;
+            cache.updateTeam(t.id, { staff: t.staff });
+          }
+        }
+      }
+    } catch (coachingCarouselErr) {
+      console.error('[Worker] Coaching Carousel V1 season-end failed (non-fatal):', coachingCarouselErr);
+    }
+
     cache.setMeta({
       leagueHistory: memoryMeta.leagueHistory,
       franchiseHistoryByTeam: memoryMeta.franchiseHistoryByTeam,
@@ -10873,7 +11210,27 @@ async function handleStartNewSeason(payload, id) {
   const rawSchedule  = makeScheduleFn(teamDefs);
   const slimSchedule = slimifySchedule(rawSchedule, teamDefs);
 
-    cache.setMeta({
+  // V1 Coaching Carousel: generate coaching market at season start.
+  // Collect coaches fired last season from all teams' coachHistory.
+  const firedLastSeason = [];
+  for (const t of cache.getAllTeams()) {
+    const hist = Array.isArray(t.coachHistory) ? t.coachHistory : [];
+    for (const entry of hist) {
+      if (Number(entry?.season) === Number(meta?.year ?? 0)) {
+        firedLastSeason.push({
+          id:              entry.id ?? null,
+          name:            entry.name,
+          scheme:          entry.scheme,
+          overallRating:   entry.overallRating ?? 65,
+          yearsExperience: entry.seasons ?? 1,
+          formerTeamId:    t.id,
+        });
+      }
+    }
+  }
+  const freshCoachingMarket = generateCoachingMarket(newSeason, firedLastSeason);
+
+  cache.setMeta({
     year:                    newYear,
     season:                  newSeason,
     currentSeasonId:         newSeasonId,
@@ -10890,6 +11247,7 @@ async function handleStartNewSeason(payload, id) {
     ownerGoals: generateOwnerGoals(),
     offseasonReleaseMap: {},
     economy: nextEconomy,
+    coachingMarket:          freshCoachingMarket,
     settings: normalizeLeagueSettings({
       ...(meta?.settings ?? {}),
       salaryCap: nextEconomy.currentSalaryCap,
@@ -11770,8 +12128,10 @@ async function handleMessage(event) {
       case toWorker.FIRE_STAFF_MEMBER:  return await handleFireStaffMember(payload, id);
       case toWorker.NEGOTIATE_STAFF_CONTRACT: return await handleNegotiateStaffContract(payload, id);
       case toWorker.UPDATE_DRAFT_BOARD: return await handleUpdateDraftBoard(payload, id);
+      case toWorker.GET_COACHING_STATE: return await handleGetCoachingState(payload, id);
       case toWorker.HIRE_COACH:         return await handleHireCoach(payload, id);
       case toWorker.FIRE_COACH:         return await handleFireCoach(payload, id);
+      case toWorker.CONTRACT_EXTENSION_COACH: return await handleContractExtensionCoach(payload, id);
       case toWorker.CONDUCT_DRILL:      return await handleConductDrill(payload, id);
       case toWorker.UPDATE_MEDICAL_STAFF: return await handleUpdateMedicalStaff(payload, id);
       case toWorker.UPDATE_FRANCHISE_INVESTMENTS: return await handleUpdateFranchiseInvestments(payload, id);


### PR DESCRIPTION
Adds a full GM-side coaching system with hire/fire/extension workflows,
deterministic coaching market generation, hot-seat evaluation, and
downstream consequences on player morale and FA negotiation leverage.

## Core engine (src/core/coaching/coachingEngine.js) — new file
- COACH_ROLES (headCoach / offensiveCoordinator / defensiveCoordinator)
- generateCoachingMarket(season, firedCoaches) — LCG-seeded, 8–12 coaches,
  2 elite (75–90), 4 solid (55–74), balance average (35–54); fired coaches
  re-enter with rating − 5 (min 30)
- evaluateHotSeat(team, seasonRecord, currentSeason) — hot seat when win% < 0.35
  AND tenure ≥ 2 seasons; resets at win% ≥ 0.500
- getCoachSchemeMultiplier(rating) — ×1.08/×1.00/×0.94/×0.88 tiers
- getCoachingInstabilityPenalty(history, lookback) — +6% FA demand if 3+
  changes in lookback window
- isPositionMisfitForScheme(pos, scheme) — position/scheme fit helper
- ensureCoachSchema(team) — safe old-save hydration, never overwrites

## Morale events (playerMoraleEngine.js)
- COACH_FIRED_HC (−6), COACH_FIRED_OC (−4), COACH_FIRED_DC (−4),
  SCHEME_CHANGE (−3) added to MORALE_EVENTS and MORALE_DELTAS

## Negotiation modifiers (negotiationModifiers.js)
- COACHING_INSTABILITY: 0.06 in LEVERAGE_MODIFIERS
- computeFranchiseReputation accepts coachingInstabilityPenalty context
  and applies the instability shift with reason string

## Coaching philosophy effects (coaching-philosophy-effects.js)
- applyCoachingModifiers now reads overallRating from HC/OC/DC objects
  and multiplies through getCoachSchemeMultiplier for all sim weights

## Worker (worker.js)
- GET_COACHING_STATE / FIRE_COACH / HIRE_COACH / CONTRACT_EXTENSION_COACH
  handlers with phase guard, coachHistory archival, morale events, news items
- handleStartNewSeason generates coaching market for the new season
- archiveSeason evaluates hot seats and AI auto-fires (60% probability) with
  seeded RNG per season
- buildViewState includes coachHotSeat, coachHCName, coachHCRating per team
  and coachingMarket in league-level state

## UI
- CoachingScreen.jsx fully rewritten: HC/OC/DC staff cards with rating/scheme/
  hot-seat badge, Fire/Extend buttons, coaching market hire table, coaching
  history log, contract extend modal
- LeagueHub.jsx: new Coaching section showing hot-seat coaches and market
- useWorker.js: getCoachingState, hireCoach/fireCoach (now Promises via
  request()), contractExtensionCoach actions
- protocol.js: GET_COACHING_STATE in toWorker, COACHING_STATE in toUI

## Tests
- 37 unit tests for coachingEngine.js — all pass
- Full suite: 314 files / 3237 tests — all pass
- Engine soak: all 9 gates pass

https://claude.ai/code/session_01M6q8KVkqqZR7x8hvhjMBR2