### PR TITLE
feat(trades): Trade Requests V1 — player-initiated trade demands with GM decision tree

### DIFF
--- a/src/core/mood/playerMoraleEngine.js
+++ b/src/core/mood/playerMoraleEngine.js
@@ -55,6 +55,12 @@ export const MORALE_EVENTS = Object.freeze({
   // Contract system V1
   EXTENSION_SIGNED:          'EXTENSION_SIGNED',
   RESTRUCTURE_RESOLVED:      'RESTRUCTURE_RESOLVED',
+  // Trade Request V1
+  TRADE_REQUESTED:                   'TRADE_REQUESTED',
+  TRADE_REQUEST_HONORED:             'TRADE_REQUEST_HONORED',
+  TRADE_REQUEST_WITHDRAWN_EXTENSION: 'TRADE_REQUEST_WITHDRAWN_EXTENSION',
+  TRADE_REQUEST_STONEWALLED:         'TRADE_REQUEST_STONEWALLED',
+  TEAMMATE_TRADE_REQUEST:            'TEAMMATE_TRADE_REQUEST',
 });
 
 // ── Delta constants ────────────────────────────────────────────────────────────
@@ -77,6 +83,12 @@ export const MORALE_DELTAS = Object.freeze({
   // Contract system V1
   [MORALE_EVENTS.EXTENSION_SIGNED]:            5,
   [MORALE_EVENTS.RESTRUCTURE_RESOLVED]:        8,
+  // Trade Request V1
+  [MORALE_EVENTS.TRADE_REQUESTED]:                   -5,
+  [MORALE_EVENTS.TRADE_REQUEST_HONORED]:             +6,
+  [MORALE_EVENTS.TRADE_REQUEST_WITHDRAWN_EXTENSION]: +4,
+  [MORALE_EVENTS.TRADE_REQUEST_STONEWALLED]:         -4,
+  [MORALE_EVENTS.TEAMMATE_TRADE_REQUEST]:            -2,
 });
 
 // ── Morale label thresholds ────────────────────────────────────────────────────

--- a/src/core/news-engine.js
+++ b/src/core/news-engine.js
@@ -307,6 +307,26 @@ export const createNewsItem = (type, data, week, season) => {
             body: (d) => `${d?.teamName ?? 'The team'} refused to deal ${d?.playerName ?? 'the player'}, leaving them frustrated.`,
             priority: 'medium',
         },
+        trade_request: {
+            headline: (d) => `${d?.playerName ?? 'Player'} has requested a trade`,
+            body: (d) => `${d?.playerName ?? 'A player'} (${d?.teamAbbr ?? 'FA'}) formally requested a trade. Reason: ${d?.reasonLabel ?? 'undisclosed'}.`,
+            priority: 'high',
+        },
+        trade_request_honored: {
+            headline: (d) => `${d?.teamName ?? 'Team'} lists ${d?.playerName ?? 'Player'} on the trade block`,
+            body: (d) => `${d?.teamName ?? 'The team'} has agreed to honor ${d?.playerName ?? 'the player'}’s trade request and is actively seeking a deal.`,
+            priority: 'medium',
+        },
+        trade_request_resolved: {
+            headline: (d) => `${d?.playerName ?? 'Player'} withdraws trade request after extension talks`,
+            body: (d) => `${d?.playerName ?? 'A player'} will remain with ${d?.teamName ?? 'the team'} after an extension offer was put on the table.`,
+            priority: 'medium',
+        },
+        trade_stonewall_boiling: {
+            headline: (d) => `${d?.playerName ?? 'Player'}’s trade situation is getting uncomfortable`,
+            body: (d) => `${d?.playerName ?? 'A player'} (${d?.teamAbbr ?? 'FA'}) has had an unresolved trade request for ${d?.weeks ?? 0} weeks. Locker room morale is at risk.`,
+            priority: 'high',
+        },
         holdout_declared: {
             headline: (d) => `${d?.playerName ?? 'Player'} declares holdout`,
             body: (d) => `${d?.playerName ?? 'A player'} has declared a holdout. Morale: ${d?.morale ?? '?'}.`,

--- a/src/core/trade-logic.js
+++ b/src/core/trade-logic.js
@@ -52,6 +52,7 @@ import {
 } from './trades/tradePositionalNeeds.js';
 import { getActiveCapHit } from './contracts/contractObligations.js';
 import { applyContractCapBurdenModifiers } from './trades/tradeFinancialModifiers.js';
+import { computeTradeValueModifier } from './trades/tradeRequestEngine.js';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -103,7 +104,15 @@ export function calculatePlayerValue(player) {
   // consumer mixing the two valued a R1 pick at ~5× an elite player. Routing
   // through getAssetValue puts players and picks on the SAME scale. The strong
   // contract penalty now lives inside getAssetValue.
-  return adjustTradeValueForMarketRealism(player, getAssetValue(player));
+  const baseValue = adjustTradeValueForMarketRealism(player, getAssetValue(player));
+
+  // Apply trade request modifier outside the ±25% negotiationModifiers cap.
+  // Stonewall/block penalty makes the player cheaper for acquiring teams.
+  const trMod = computeTradeValueModifier(player);
+  if (trMod && trMod.modifier !== 0) {
+    return Math.max(0, baseValue * (1 + trMod.modifier));
+  }
+  return baseValue;
 }
 
 // ── Roster Analysis ───────────────────────────────────────────────────────────

--- a/src/core/trades/tradeRequestEngine.js
+++ b/src/core/trades/tradeRequestEngine.js
@@ -1,0 +1,378 @@
+/**
+ * tradeRequestEngine.js — Trade Requests V1
+ *
+ * Pure, deterministic trade-request module.
+ *
+ * Design constraints:
+ *  - No I/O, no cache access, no side effects.
+ *  - No imports from worker, UI, news, morale engine, holdout engine,
+ *    HOF engine, coaching engine, FA, scouting, or sim engine.
+ *  - No Math.random — seeded LCG only.
+ *  - Receives depthRank, isPositionMisfitForScheme, moraleSummary,
+ *    hofStatus as arguments — does not import those engines.
+ *  - Returns updated objects — no mutation of inputs.
+ *  - Fully deterministic given same inputs.
+ */
+
+// ── Reason definitions ─────────────────────────────────────────────────────────
+
+export const TRADE_REQUEST_REASONS = Object.freeze({
+  playing_time: {
+    label: 'Wants more playing time',
+  },
+  scheme_fit: {
+    label: 'Does not fit offensive/defensive scheme',
+  },
+  contract: {
+    label: 'Seeking better contract opportunity',
+  },
+  personal: {
+    label: 'Personal reasons',
+  },
+});
+
+// ── Stonewall thresholds ───────────────────────────────────────────────────────
+
+export const STONEWALL_THRESHOLDS = Object.freeze({
+  weeks_1_3:   Object.freeze({ moraleHit: 0,  teamMoraleHit: 0  }),
+  weeks_4_6:   Object.freeze({ moraleHit: -4, teamMoraleHit: -2 }),
+  weeks_7plus: Object.freeze({ moraleHit: -8, teamMoraleHit: -4 }),
+});
+
+// ── Trade value modifiers ──────────────────────────────────────────────────────
+
+export const TRADE_VALUE_MODIFIERS = Object.freeze({
+  onTradeBlock:        -0.08,
+  stonewalledRequest:  -0.12,
+  honoredRequest:       0.00,
+  withdrawn:           +0.05,
+});
+
+// ── Morale event type strings ─────────────────────────────────────────────────
+// Defined inline so this module imports nothing from playerMoraleEngine.
+
+export const TRADE_REQUEST_MORALE_EVENTS = Object.freeze({
+  TRADE_REQUESTED:                   'TRADE_REQUESTED',
+  TRADE_REQUEST_HONORED:             'TRADE_REQUEST_HONORED',
+  TRADE_REQUEST_WITHDRAWN_EXTENSION: 'TRADE_REQUEST_WITHDRAWN_EXTENSION',
+  TRADE_REQUEST_STONEWALLED:         'TRADE_REQUEST_STONEWALLED',
+  TEAMMATE_TRADE_REQUEST:            'TEAMMATE_TRADE_REQUEST',
+});
+
+export const TRADE_REQUEST_MORALE_DELTAS = Object.freeze({
+  TRADE_REQUESTED:                   -5,
+  TRADE_REQUEST_HONORED:             +6,
+  TRADE_REQUEST_WITHDRAWN_EXTENSION: +4,
+  TRADE_REQUEST_STONEWALLED:         -4,  // overridden by threshold band
+  TEAMMATE_TRADE_REQUEST:            -2,
+});
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function safeNum(v, fallback = 0) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function getContractYearsLeft(player) {
+  const explicit = player?.contractYearsLeft;
+  if (explicit != null) return safeNum(explicit, 1);
+  return safeNum(player?.contract?.yearsRemaining, 1);
+}
+
+// ── Seeded LCG ────────────────────────────────────────────────────────────────
+// Numerical Recipes LCG; returns float in [0, 1).
+
+function lcgRandom(seed) {
+  const a = 1664525;
+  const c = 1013904223;
+  const next = ((a * (seed >>> 0) + c) >>> 0);
+  return next / 0x100000000;
+}
+
+// ── Core: getTradeRequestReason ───────────────────────────────────────────────
+
+/**
+ * Evaluate which trade request reason applies for this player, or null.
+ * Checks triggers in order: playing_time → scheme_fit → contract → personal.
+ *
+ * @param {object} player   – player data object
+ * @param {object} team     – team data object
+ * @param {object} context  – { depthRank, isPositionMisfitForScheme }
+ * @param {number} season   – current season id (for LCG seed)
+ * @returns {string|null}   – reason key or null
+ */
+export function getTradeRequestReason(player, team, context = {}, season = 0) {
+  if (!player) return null;
+
+  const morale = safeNum(player.morale, 70);
+  const {
+    depthRank              = 0,
+    isPositionMisfitForScheme = false,
+  } = context;
+
+  // playing_time: depthRank >= 2 AND morale < 45
+  if (depthRank >= 2 && morale < 45) {
+    return 'playing_time';
+  }
+
+  // scheme_fit: isPositionMisfitForScheme AND morale < 55
+  if (isPositionMisfitForScheme && morale < 55) {
+    return 'scheme_fit';
+  }
+
+  // contract: contractYearsLeft === 1 AND extensionOffered === false AND morale < 50
+  const yearsLeft = getContractYearsLeft(player);
+  const extensionOffered = player.extensionOfferedThisSeason === true;
+  if (yearsLeft === 1 && !extensionOffered && morale < 50) {
+    return 'contract';
+  }
+
+  // personal: seeded 3% per season for morale < 35
+  if (morale < 35) {
+    const seedInput = (safeNum(player.id, 0) * 1000 + safeNum(season, 0)) >>> 0;
+    if (lcgRandom(seedInput) < 0.03) {
+      return 'personal';
+    }
+  }
+
+  return null;
+}
+
+// ── Core: shouldPlayerRequestTrade ────────────────────────────────────────────
+
+/**
+ * Determine if a player should initiate a trade request this week.
+ * Returns false if they are already in a request, on active holdout, or a UFA.
+ *
+ * @param {object} player   – player data object
+ * @param {object} team     – team data object
+ * @param {number} season   – current season id
+ * @param {number} week     – current week
+ * @param {object} context  – { depthRank, isPositionMisfitForScheme }
+ * @returns {boolean}
+ */
+export function shouldPlayerRequestTrade(player, team, season, week, context = {}) {
+  if (!player) return false;
+
+  // Already has any trade request (pending, honored, withdrawn)
+  if (player.tradeRequest != null) return false;
+
+  // UFA — they just leave in free agency
+  if (getContractYearsLeft(player) === 0) return false;
+
+  // Already in active holdout
+  if (player.holdout?.active === true) return false;
+
+  return getTradeRequestReason(player, team, context, season) !== null;
+}
+
+// ── Core: computeTradeValueModifier ───────────────────────────────────────────
+
+/**
+ * Compute the trade value modifier for a player based on their trade request
+ * status and on-block status.
+ *
+ * Modifiers apply outside the ±25% negotiationModifiers cap — trade value
+ * is separate from FA demand.
+ *
+ * @param {object} player
+ * @returns {{ modifier: number, reason: string }|null}
+ */
+export function computeTradeValueModifier(player) {
+  if (!player) return null;
+
+  const req = player.tradeRequest;
+
+  // Stonewall penalty: pending AND stonewalledWeeks >= 4
+  // Everyone in the league knows this team needs to move him
+  if (req != null && safeNum(req.stonewalledWeeks, 0) >= 4) {
+    return {
+      modifier: TRADE_VALUE_MODIFIERS.stonewalledRequest,
+      reason: 'Trade request stonewalled 4+ weeks — leverage lost',
+    };
+  }
+
+  // Withdrawn recovery (player re-engaged — slight positive signal)
+  if (req?.status === 'withdrawn') {
+    return {
+      modifier: TRADE_VALUE_MODIFIERS.withdrawn,
+      reason: 'Player withdrew trade request after extension talks',
+    };
+  }
+
+  // On trade block (publicly listed)
+  if (player.onTradeBlock) {
+    return {
+      modifier: TRADE_VALUE_MODIFIERS.onTradeBlock,
+      reason: 'Player publicly listed on trade block',
+    };
+  }
+
+  return null;
+}
+
+// ── Core: resolveTradeRequest ─────────────────────────────────────────────────
+
+/**
+ * Apply a GM action to an active trade request.
+ * Returns a new player object and morale events — no mutation.
+ *
+ * @param {object} player   – player data object
+ * @param {string} action   – 'honor' | 'extend' | 'stonewall' | 'traded'
+ * @param {object} context  – { season, week }
+ * @returns {{ updatedPlayer: object, moraleEvents: object[] }}
+ */
+export function resolveTradeRequest(player, action, context = {}) {
+  if (!player) return { updatedPlayer: player, moraleEvents: [] };
+
+  const { season = 0, week = 0 } = context;
+  const req = player.tradeRequest ?? {
+    status: 'pending',
+    requestedSeason: season,
+    requestedWeek:   week,
+    stonewalledWeeks: 0,
+    reason:          'personal',
+  };
+
+  let updatedPlayer = { ...player };
+  const moraleEvents = [];
+
+  switch (action) {
+    case 'honor': {
+      updatedPlayer = {
+        ...player,
+        onTradeBlock:  true,
+        tradeRequest:  { ...req, status: 'honored' },
+      };
+      moraleEvents.push({
+        type:      TRADE_REQUEST_MORALE_EVENTS.TRADE_REQUEST_HONORED,
+        delta:     TRADE_REQUEST_MORALE_DELTAS.TRADE_REQUEST_HONORED,
+        season,
+        week,
+        reason:    'GM honored trade request and listed player on block',
+        source:    'trade_request_engine',
+        dedupeKey: `trade_honored_${player.id}_${season}`,
+      });
+      break;
+    }
+
+    case 'extend': {
+      updatedPlayer = {
+        ...player,
+        tradeRequest: { ...req, status: 'withdrawn' },
+      };
+      moraleEvents.push({
+        type:      TRADE_REQUEST_MORALE_EVENTS.TRADE_REQUEST_WITHDRAWN_EXTENSION,
+        delta:     TRADE_REQUEST_MORALE_DELTAS.TRADE_REQUEST_WITHDRAWN_EXTENSION,
+        season,
+        week,
+        reason:    'Extension offered — player withdrew trade request',
+        source:    'trade_request_engine',
+        dedupeKey: `trade_withdrawn_ext_${player.id}_${season}`,
+      });
+      break;
+    }
+
+    case 'stonewall': {
+      const prevWeeks = safeNum(req.stonewalledWeeks, 0);
+      const stonewalledWeeks = prevWeeks + 1;
+
+      const threshold = _getStonewall(stonewalledWeeks);
+
+      updatedPlayer = {
+        ...player,
+        tradeRequest: {
+          ...req,
+          status: 'pending',
+          stonewalledWeeks,
+        },
+      };
+
+      if (threshold.moraleHit !== 0) {
+        moraleEvents.push({
+          type:      TRADE_REQUEST_MORALE_EVENTS.TRADE_REQUEST_STONEWALLED,
+          delta:     threshold.moraleHit,
+          season,
+          week,
+          reason:    'GM ignored trade request',
+          source:    'trade_request_engine',
+          dedupeKey: `trade_stonewalled_${player.id}_${season}_${week}`,
+        });
+      }
+      break;
+    }
+
+    case 'traded': {
+      // The actual move is handled by existing trade logic — just update status
+      updatedPlayer = {
+        ...player,
+        tradeRequest: { ...req, status: 'honored' },
+      };
+      break;
+    }
+
+    default:
+      break;
+  }
+
+  return { updatedPlayer, moraleEvents };
+}
+
+// ── Core: evaluateWeeklyStonewall ─────────────────────────────────────────────
+
+/**
+ * Return the morale hit and team morale hit for this week's stonewall,
+ * based on how many weeks the request has been outstanding.
+ *
+ * @param {object} player   – player with player.tradeRequest.stonewalledWeeks
+ * @returns {{ moraleHit: number, teamMoraleHit: number }}
+ */
+export function evaluateWeeklyStonewall(player) {
+  const weeks = safeNum(player?.tradeRequest?.stonewalledWeeks, 0);
+  return _getStonewall(weeks);
+}
+
+function _getStonewall(weeks) {
+  if (weeks >= 7) return STONEWALL_THRESHOLDS.weeks_7plus;
+  if (weeks >= 4) return STONEWALL_THRESHOLDS.weeks_4_6;
+  return STONEWALL_THRESHOLDS.weeks_1_3;
+}
+
+// ── Core: getActiveTradeRequests ──────────────────────────────────────────────
+
+/**
+ * Return all active (pending) trade request alerts for a team.
+ *
+ * @param {object}   team    – team data object
+ * @param {object[]} players – all players array
+ * @returns {object[]}       – TradeRequestAlert[]
+ */
+export function getActiveTradeRequests(team, players) {
+  if (!team || !Array.isArray(players)) return [];
+
+  const teamId = team.id;
+  const alerts = [];
+
+  for (const player of players) {
+    if (Number(player?.teamId) !== Number(teamId)) continue;
+    const req = player.tradeRequest;
+    if (!req) continue;
+    // Only surface pending requests (honored and withdrawn are resolved)
+    if (req.status === 'honored' || req.status === 'withdrawn') continue;
+
+    alerts.push({
+      playerId:        player.id,
+      playerName:      player.name    ?? 'Unknown',
+      pos:             player.pos     ?? '??',
+      ovr:             player.ovr     ?? 70,
+      reason:          req.reason,
+      requestedWeek:   req.requestedWeek   ?? 0,
+      requestedSeason: req.requestedSeason ?? 0,
+      status:          req.status,
+      stonewalledWeeks: safeNum(req.stonewalledWeeks, 0),
+    });
+  }
+
+  return alerts;
+}

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -530,6 +530,86 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
         ))}
       </div>
 
+      {/* ── TRADE REQUEST ALERTS ─────────────────────────────────────────── */}
+      {(() => {
+        const alerts = Array.isArray(userTeam?.tradeRequestAlerts) ? userTeam.tradeRequestAlerts : [];
+        if (alerts.length === 0) return null;
+        return (
+          <section data-testid="hq-trade-request-alerts" aria-label="Trade request alerts">
+            {alerts.map((alert) => {
+              const isBoiling = safeNum(alert.stonewalledWeeks, 0) >= 4;
+              return (
+                <div
+                  key={alert.playerId}
+                  className="card"
+                  data-testid={`trade-request-alert-${alert.playerId}`}
+                  style={{
+                    margin: '4px 12px',
+                    padding: 'var(--space-3) var(--space-4)',
+                    border: `1px solid ${isBoiling ? '#FF453A44' : '#FF9F0A44'}`,
+                    background: isBoiling ? '#FF453A0E' : '#FF9F0A0E',
+                    borderRadius: 'var(--radius-md)',
+                    fontSize: 'var(--text-xs)',
+                  }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+                    <span style={{ fontWeight: 900, color: isBoiling ? '#FF453A' : '#FF9F0A', textTransform: 'uppercase', letterSpacing: '.07em' }}>
+                      Trade Request
+                    </span>
+                    <span style={{ color: 'var(--text-muted)' }}>
+                      — {alert.playerName} ({alert.pos} · OVR {alert.ovr})
+                    </span>
+                    {isBoiling && (
+                      <span style={{ color: '#FF453A', fontWeight: 700 }}>
+                        · Week {alert.stonewalledWeeks} unresolved
+                      </span>
+                    )}
+                  </div>
+                  <div style={{ color: 'var(--text-muted)', marginBottom: 6 }}>
+                    Reason: {alert.reason?.replace(/_/g, ' ') ?? 'undisclosed'}
+                    {alert.stonewalledWeeks > 0 ? ` · ${alert.stonewalledWeeks}w unresolved` : ''}
+                  </div>
+                  {isBoiling && (
+                    <div style={{ color: '#FF453A', fontWeight: 600, marginBottom: 6 }}>
+                      Warning: locker room morale at risk
+                    </div>
+                  )}
+                  <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                    <button
+                      type="button"
+                      className="btn btn-sm"
+                      style={{ color: '#34C759', borderColor: '#34C759', fontSize: 'var(--text-xs)', padding: '2px 8px' }}
+                      onClick={() => actions?.honorTradeRequest?.(alert.playerId)}
+                      data-testid={`honor-trade-request-${alert.playerId}`}
+                    >
+                      Honor — List on Block
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-sm"
+                      style={{ color: '#0A84FF', borderColor: '#0A84FF', fontSize: 'var(--text-xs)', padding: '2px 8px' }}
+                      onClick={() => actions?.offerExtensionToWithdraw?.(alert.playerId)}
+                      data-testid={`offer-extension-${alert.playerId}`}
+                    >
+                      Offer Extension
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-sm"
+                      style={{ color: isBoiling ? '#FF453A' : 'var(--text-muted)', borderColor: isBoiling ? '#FF453A' : 'var(--hairline)', fontSize: 'var(--text-xs)', padding: '2px 8px' }}
+                      onClick={() => actions?.stonewallTradeRequest?.(alert.playerId)}
+                      data-testid={`stonewall-trade-request-${alert.playerId}`}
+                    >
+                      Stonewall
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </section>
+        );
+      })()}
+
       {/* ── COLLAPSED DRAWER: secondary content ─────────────────────────── */}
       <details className="hq-more-drawer" data-testid="hq-more-drawer">
         <summary className="hq-more-drawer__trigger">Season Pulse &amp; More ▾</summary>

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -1543,6 +1543,60 @@ export default function PlayerProfile({
                   </div>
                 )}
 
+                {/* ── Trade Request Status ── */}
+                {playerView?.tradeRequest && (
+                  <div
+                    data-testid="player-profile-trade-request"
+                    style={{
+                      marginTop: 'var(--space-2)',
+                      padding: 'var(--space-3)',
+                      borderRadius: 'var(--radius-md)',
+                      border: '1px solid #FF9F0A44',
+                      background: '#FF9F0A0E',
+                      fontSize: 'var(--text-xs)',
+                    }}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
+                      <span style={{ fontWeight: 900, color: '#FF9F0A', textTransform: 'uppercase', letterSpacing: '.07em', fontSize: 'var(--text-xs)' }}>
+                        Trade Requested
+                      </span>
+                      <span style={{ color: 'var(--text-muted)', fontSize: 'var(--text-xs)' }}>
+                        — {playerView.tradeRequest.reason?.replace(/_/g, ' ') ?? 'undisclosed'}
+                      </span>
+                    </div>
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                      <span style={{ color: 'var(--text-subtle)' }}>Status: {playerView.tradeRequest.status}</span>
+                      {(playerView.tradeRequest.stonewalledWeeks ?? 0) > 0 && (
+                        <span style={{ color: '#FF9F0A', fontWeight: 700 }}>{playerView.tradeRequest.stonewalledWeeks}w unresolved</span>
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                {/* ── On Trade Block Badge ── */}
+                {playerView?.onTradeBlock && (
+                  <div
+                    data-testid="player-profile-trade-block"
+                    style={{
+                      marginTop: 'var(--space-2)',
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 4,
+                      padding: '3px 10px',
+                      borderRadius: 'var(--radius-pill)',
+                      background: '#0A84FF22',
+                      border: '1px solid #0A84FF55',
+                      color: '#0A84FF',
+                      fontWeight: 700,
+                      fontSize: 'var(--text-xs)',
+                      textTransform: 'uppercase',
+                      letterSpacing: '.07em',
+                    }}
+                  >
+                    On Trade Block
+                  </div>
+                )}
+
                 {!isProspect && playerView && (
                   <div
                     data-testid="player-profile-dev-arc"

--- a/src/ui/components/RosterManager.jsx
+++ b/src/ui/components/RosterManager.jsx
@@ -606,6 +606,46 @@ export default function RosterManager({ league, actions }) {
                         }}
                       >
                         {player.name}
+                        {player.onTradeBlock && (
+                          <span
+                            data-testid={`trade-block-badge-${player.id}`}
+                            style={{
+                              marginLeft: 5,
+                              display: 'inline-block',
+                              padding: '1px 6px',
+                              borderRadius: 'var(--radius-pill)',
+                              background: '#0A84FF22',
+                              color: '#0A84FF',
+                              fontWeight: 700,
+                              fontSize: '0.7em',
+                              textTransform: 'uppercase',
+                              letterSpacing: '.05em',
+                              verticalAlign: 'middle',
+                            }}
+                          >
+                            Block
+                          </span>
+                        )}
+                        {player.tradeRequest?.status === 'pending' && (
+                          <span
+                            data-testid={`trade-request-badge-${player.id}`}
+                            style={{
+                              marginLeft: 5,
+                              display: 'inline-block',
+                              padding: '1px 6px',
+                              borderRadius: 'var(--radius-pill)',
+                              background: '#FF9F0A22',
+                              color: '#FF9F0A',
+                              fontWeight: 700,
+                              fontSize: '0.7em',
+                              textTransform: 'uppercase',
+                              letterSpacing: '.05em',
+                              verticalAlign: 'middle',
+                            }}
+                          >
+                            Wants Out
+                          </span>
+                        )}
                       </td>
                       <td
                         style={{

--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -667,6 +667,12 @@ export function useWorker() {
       request(toWorker.TOGGLE_TRADE_BLOCK, { playerId, teamId }),
     updatePlayerManagement: (playerId, teamId, updates) =>
       request(toWorker.UPDATE_PLAYER_MANAGEMENT, { playerId, teamId, updates }),
+    honorTradeRequest: (playerId) =>
+      request(toWorker.HONOR_TRADE_REQUEST, { playerId }),
+    stonewallTradeRequest: (playerId) =>
+      request(toWorker.STONEWALL_TRADE_REQUEST, { playerId }),
+    offerExtensionToWithdraw: (playerId) =>
+      request(toWorker.OFFER_EXTENSION_TO_WITHDRAW, { playerId }),
     assignMentor: (mentorId, menteeId, teamId) =>
       request(toWorker.ASSIGN_MENTOR, { mentorId, menteeId, teamId }, { silent: true }),
 

--- a/src/worker/protocol.js
+++ b/src/worker/protocol.js
@@ -67,6 +67,10 @@ export const toWorker = Object.freeze({
   RESPOND_TRADE:      'RESPOND_TRADE',     // { tradeId, accepted }
   TOGGLE_TRADE_BLOCK: 'TOGGLE_TRADE_BLOCK', // { playerId, teamId }
   UPDATE_PLAYER_MANAGEMENT: 'UPDATE_PLAYER_MANAGEMENT', // { playerId, teamId, updates }
+  // Trade Requests V1
+  HONOR_TRADE_REQUEST:          'HONOR_TRADE_REQUEST',          // { playerId }
+  STONEWALL_TRADE_REQUEST:      'STONEWALL_TRADE_REQUEST',      // { playerId }
+  OFFER_EXTENSION_TO_WITHDRAW:  'OFFER_EXTENSION_TO_WITHDRAW',  // { playerId }
   ASSIGN_MENTOR: 'ASSIGN_MENTOR', // { mentorId, menteeId, teamId }
 
   /** Contracts */

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -129,6 +129,17 @@ import {
   getPlayerMoraleSummary,
 } from '../core/mood/playerMoraleEngine.js';
 import {
+  TRADE_REQUEST_REASONS,
+  TRADE_REQUEST_MORALE_EVENTS,
+  TRADE_REQUEST_MORALE_DELTAS,
+  shouldPlayerRequestTrade,
+  getTradeRequestReason,
+  computeTradeValueModifier,
+  resolveTradeRequest,
+  evaluateWeeklyStonewall,
+  getActiveTradeRequests,
+} from '../core/trades/tradeRequestEngine.js';
+import {
   HOLDOUT_TRIGGERS,
   HOLDOUT_RESOLUTION,
   HOLDOUT_RETURNED_DELTA,
@@ -997,6 +1008,7 @@ function buildViewState() {
     coachHotSeat: t?.coach?.headCoach?.hotSeat ?? false,
     coachHCName: t?.coach?.headCoach?.name ?? null,
     coachHCRating: t?.coach?.headCoach?.overallRating ?? null,
+    tradeRequestAlerts: getActiveTradeRequests(t, roster),
     picks: Array.isArray(t?.picks)
       ? t.picks.map((pk) => ({
         id: pk.id,
@@ -3518,6 +3530,221 @@ async function handleAdvanceWeek(payload, id) {
       }
     } catch (holdoutErr) {
       console.warn('[Worker] Holdout evaluation error (non-fatal):', holdoutErr?.message);
+    }
+  }
+
+  // ── Trade Request Evaluation (regular season only) ───────────────────────────
+  if (meta.phase === 'regular') {
+    try {
+      const trSeasonId  = meta.currentSeasonId ?? meta.season ?? 0;
+      const trAllPlayers = cache.getAllPlayers();
+      const trAllTeams   = cache.getAllTeams();
+      const trUserTeamId = Number(meta.userTeamId ?? -1);
+
+      // Build per-team position depth maps (position → sorted player ids)
+      const teamDepthMaps = {};
+      for (const team of trAllTeams) {
+        const teamPlayers = trAllPlayers.filter((p) => Number(p?.teamId) === Number(team.id));
+        const byPos = {};
+        for (const p of teamPlayers) {
+          if (!byPos[p.pos]) byPos[p.pos] = [];
+          byPos[p.pos].push(p);
+        }
+        for (const pos of Object.keys(byPos)) {
+          byPos[pos].sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0));
+        }
+        teamDepthMaps[String(team.id)] = byPos;
+      }
+
+      // Evaluate each player for new trade requests and stonewall progression
+      for (const player of trAllPlayers) {
+        if (!player?.id || player.teamId == null) continue;
+        const team = cache.getTeam(player.teamId);
+        if (!team) continue;
+
+        const teamIdStr = String(team.id);
+        const byPos = teamDepthMaps[teamIdStr] ?? {};
+        const posGroup = byPos[player.pos] ?? [];
+        const depthRank = posGroup.findIndex((p) => Number(p.id) === Number(player.id));
+        const teamScheme = team?.coach?.headCoach?.scheme ?? team?.strategies?.offense ?? 'BALANCED';
+        const isMisfit   = isPositionMisfitForScheme(player?.pos, teamScheme);
+
+        const context = { depthRank: depthRank >= 0 ? depthRank : 0, isPositionMisfitForScheme: isMisfit };
+        const isUserTeam = Number(team.id) === trUserTeamId;
+
+        // ── Stonewall progression for existing pending requests ─────────────
+        if (player.tradeRequest?.status === 'pending') {
+          const { updatedPlayer: swPlayer, moraleEvents: swEvents } = resolveTradeRequest(
+            player, 'stonewall', { season: trSeasonId, week },
+          );
+          cache.updatePlayer(player.id, { tradeRequest: swPlayer.tradeRequest });
+
+          // Apply any morale hits to the player
+          let moralePlayer = cache.getPlayer(player.id) ?? player;
+          for (const evt of swEvents) {
+            moralePlayer = applyMoraleEvent(moralePlayer, evt, { season: trSeasonId, week });
+          }
+          if (swEvents.length > 0) {
+            cache.updatePlayer(player.id, { morale: moralePlayer.morale, moraleEvents: moralePlayer.moraleEvents });
+          }
+
+          // Apply TEAMMATE_TRADE_REQUEST to starters on the same team
+          const stonewalledWeeks = swPlayer.tradeRequest?.stonewalledWeeks ?? 0;
+          const { teamMoraleHit } = evaluateWeeklyStonewall(swPlayer);
+          if (teamMoraleHit !== 0) {
+            const STARTERS_COUNT = { QB: 1, RB: 2, WR: 3, TE: 1, OL: 5, DL: 4, LB: 3, CB: 2, S: 2, K: 1, P: 1 };
+            for (const teammate of trAllPlayers) {
+              if (Number(teammate?.teamId) !== Number(team.id)) continue;
+              if (Number(teammate.id) === Number(player.id)) continue;
+              const tPos = teammate.pos;
+              const tRank = (byPos[tPos] ?? []).findIndex((p) => Number(p.id) === Number(teammate.id));
+              const starterSlots = STARTERS_COUNT[tPos] ?? 1;
+              if (tRank < 0 || tRank >= starterSlots) continue; // only starters
+              const dedupeKey = `teammate_trade_request_${team.id}_${trSeasonId}_${week}`;
+              let tUpdated = cache.getPlayer(teammate.id) ?? teammate;
+              tUpdated = applyMoraleEvent(tUpdated, {
+                type:      TRADE_REQUEST_MORALE_EVENTS.TEAMMATE_TRADE_REQUEST,
+                delta:     teamMoraleHit,
+                season:    trSeasonId,
+                week,
+                reason:    `Teammate ${player.name ?? 'a player'} has an unresolved trade request`,
+                source:    'trade_request_engine',
+                dedupeKey,
+              }, { season: trSeasonId, week });
+              cache.updatePlayer(teammate.id, { morale: tUpdated.morale, moraleEvents: tUpdated.moraleEvents });
+            }
+          }
+
+          // Emit news at week 4 and 7 milestones
+          if (stonewalledWeeks === 4 || stonewalledWeeks === 7) {
+            const boilingItem = {
+              id:       `trade-stonewall-boiling-${player.id}-${trSeasonId}-${stonewalledWeeks}`,
+              headline: `${player.name ?? 'Player'}'s trade situation is getting uncomfortable — ${stonewalledWeeks} weeks unresolved`,
+              body:     `${player.name ?? 'A player'} (${team?.abbr ?? 'FA'}) has had an unresolved trade request for ${stonewalledWeeks} weeks. Locker room morale at risk.`,
+              week,
+              season:   trSeasonId,
+              type:     'TRADE_DRAMA',
+              teamId:   team.id,
+              priority: 'high',
+              dedupeKey: `trade-stonewall-boiling-${player.id}-${trSeasonId}-${stonewalledWeeks}`,
+            };
+            cache.setMeta(addNewsItem(cache.getMeta(), boilingItem));
+
+            // Pulse item at week 4
+            if (stonewalledWeeks === 4) {
+              const pulseMeta2 = cache.getMeta();
+              const tradeDramaPulse = {
+                id:            `trade_drama_${player.id}_${trSeasonId}`,
+                season:        trSeasonId,
+                week,
+                type:          'TRANSACTION',
+                headline:      `${player.name ?? 'Player'} trade situation heating up`,
+                body:          `${player.name ?? 'A player'} (${team?.abbr ?? 'FA'}) has been asking for a trade for ${stonewalledWeeks} weeks with no resolution.`,
+                importance:    80,
+                relatedTeamId: team.id,
+                relatedPlayerId: player.id,
+                source:        'trade_request_engine',
+                dedupeKey:     `trade_drama_${player.id}_${trSeasonId}`,
+              };
+              const updatedPulse = mergeLeaguePulseItems(
+                pulseMeta2.leaguePulse ?? [],
+                [tradeDramaPulse],
+                { maxTimelineLength: 200 },
+              );
+              cache.setMeta({ leaguePulse: updatedPulse });
+            }
+          }
+          continue; // already has a request — don't evaluate new one
+        }
+
+        // ── Check for new trade request ──────────────────────────────────────
+        if (!shouldPlayerRequestTrade(player, team, trSeasonId, week, context)) continue;
+        const reason = getTradeRequestReason(player, team, context, trSeasonId);
+        if (!reason) continue;
+
+        const reasonLabel = TRADE_REQUEST_REASONS[reason]?.label ?? reason;
+        const newRequest = {
+          status:          'pending',
+          requestedSeason: trSeasonId,
+          requestedWeek:   week,
+          stonewalledWeeks: 0,
+          reason,
+        };
+
+        // Apply TRADE_REQUESTED morale event to the player
+        let requestingPlayer = cache.getPlayer(player.id) ?? player;
+        requestingPlayer = applyMoraleEvent(requestingPlayer, {
+          type:      TRADE_REQUEST_MORALE_EVENTS.TRADE_REQUESTED,
+          delta:     TRADE_REQUEST_MORALE_DELTAS.TRADE_REQUESTED,
+          season:    trSeasonId,
+          week,
+          reason:    reasonLabel,
+          source:    'trade_request_engine',
+          dedupeKey: `trade_requested_${player.id}_${trSeasonId}`,
+        }, { season: trSeasonId, week });
+
+        cache.updatePlayer(player.id, {
+          tradeRequest:  newRequest,
+          morale:        requestingPlayer.morale,
+          moraleEvents:  requestingPlayer.moraleEvents,
+        });
+
+        // News item
+        const trNewsItem = {
+          id:       `trade-request-${player.id}-${trSeasonId}-${week}`,
+          headline: `${player.name ?? 'Player'} has requested a trade`,
+          body:     `${player.name ?? 'A player'} (${team?.abbr ?? 'FA'}) formally requested a trade. Reason: ${reasonLabel}.`,
+          week,
+          season:   trSeasonId,
+          type:     'TRADE_REQUEST',
+          teamId:   team.id,
+          priority: 'high',
+          dedupeKey: `trade-request-${player.id}-${trSeasonId}-${week}`,
+        };
+        cache.setMeta(addNewsItem(cache.getMeta(), trNewsItem));
+
+        // AI team auto-resolution
+        if (!isUserTeam) {
+          const ovr = player.ovr ?? 70;
+          if (ovr >= 75) {
+            // Auto-honor: list on trade block
+            cache.updatePlayer(player.id, { tradeRequest: { ...newRequest, status: 'honored' }, onTradeBlock: true });
+          } else if (ovr < 65) {
+            // Auto-stonewall: not worth the drama
+            // Status stays pending, stonewall progression happens next week
+          } else {
+            // Mid-range: try extension if contract reason
+            if (reason === 'contract') {
+              cache.updatePlayer(player.id, { tradeRequest: { ...newRequest, status: 'withdrawn' } });
+            }
+          }
+        }
+
+        // Apply TEAMMATE_TRADE_REQUEST to starters on same team (on request)
+        const STARTERS_COUNT = { QB: 1, RB: 2, WR: 3, TE: 1, OL: 5, DL: 4, LB: 3, CB: 2, S: 2, K: 1, P: 1 };
+        for (const teammate of trAllPlayers) {
+          if (Number(teammate?.teamId) !== Number(team.id)) continue;
+          if (Number(teammate.id) === Number(player.id)) continue;
+          const tPos = teammate.pos;
+          const tRank = (byPos[tPos] ?? []).findIndex((p) => Number(p.id) === Number(teammate.id));
+          const starterSlots = STARTERS_COUNT[tPos] ?? 1;
+          if (tRank < 0 || tRank >= starterSlots) continue;
+          const dedupeKey = `teammate_trade_request_init_${team.id}_${trSeasonId}_${week}`;
+          let tUpdated = cache.getPlayer(teammate.id) ?? teammate;
+          tUpdated = applyMoraleEvent(tUpdated, {
+            type:      TRADE_REQUEST_MORALE_EVENTS.TEAMMATE_TRADE_REQUEST,
+            delta:     TRADE_REQUEST_MORALE_DELTAS.TEAMMATE_TRADE_REQUEST,
+            season:    trSeasonId,
+            week,
+            reason:    `Teammate ${player.name ?? 'a player'} requested a trade`,
+            source:    'trade_request_engine',
+            dedupeKey,
+          }, { season: trSeasonId, week });
+          cache.updatePlayer(teammate.id, { morale: tUpdated.morale, moraleEvents: tUpdated.moraleEvents });
+        }
+      }
+    } catch (trErr) {
+      console.warn('[Worker] Trade request evaluation error (non-fatal):', trErr?.message);
     }
   }
 
@@ -9485,6 +9712,127 @@ async function handleUpdatePlayerManagement({ playerId, teamId, updates = {} }, 
   post(toUI.STATE_UPDATE, buildViewState(), id);
 }
 
+// ── Handler: HONOR_TRADE_REQUEST ──────────────────────────────────────────────
+
+async function handleHonorTradeRequest({ playerId }, id) {
+  const numericId = Number(playerId);
+  const player    = cache.getPlayer(numericId);
+  if (!player) { post(toUI.ERROR, { message: 'Player not found' }, id); return; }
+  if (!player.tradeRequest) { post(toUI.ERROR, { message: 'No active trade request' }, id); return; }
+
+  const meta     = ensureDynastyMeta(cache.getMeta());
+  const season   = meta.currentSeasonId ?? meta.season ?? 0;
+  const week     = meta.currentWeek ?? 0;
+  const team     = cache.getTeam(player.teamId);
+
+  const { updatedPlayer, moraleEvents } = resolveTradeRequest(player, 'honor', { season, week });
+
+  let p = updatedPlayer;
+  for (const evt of moraleEvents) {
+    p = applyMoraleEvent(p, evt, { season, week });
+  }
+  cache.updatePlayer(player.id, {
+    tradeRequest:  p.tradeRequest,
+    onTradeBlock:  p.onTradeBlock,
+    morale:        p.morale,
+    moraleEvents:  p.moraleEvents,
+  });
+
+  const newsItem = {
+    id:       `trade-honored-${player.id}-${season}-${week}`,
+    headline: `${team?.name ?? 'Team'} lists ${player.name ?? 'Player'} on the trade block`,
+    body:     `${team?.name ?? 'The team'} has agreed to honor ${player.name ?? 'the player'}'s trade request.`,
+    week,
+    season,
+    type:     'TRADE_REQUEST',
+    teamId:   team?.id ?? null,
+    priority: 'medium',
+    dedupeKey: `trade-honored-${player.id}-${season}-${week}`,
+  };
+  cache.setMeta(addNewsItem(cache.getMeta(), newsItem));
+
+  await flushDirty();
+  post(toUI.STATE_UPDATE, buildViewState(), id);
+}
+
+// ── Handler: STONEWALL_TRADE_REQUEST ─────────────────────────────────────────
+
+async function handleStonewallTradeRequest({ playerId }, id) {
+  const numericId = Number(playerId);
+  const player    = cache.getPlayer(numericId);
+  if (!player) { post(toUI.ERROR, { message: 'Player not found' }, id); return; }
+  if (!player.tradeRequest) { post(toUI.ERROR, { message: 'No active trade request' }, id); return; }
+
+  const meta   = ensureDynastyMeta(cache.getMeta());
+  const season = meta.currentSeasonId ?? meta.season ?? 0;
+  const week   = meta.currentWeek ?? 0;
+
+  const { updatedPlayer, moraleEvents } = resolveTradeRequest(player, 'stonewall', { season, week });
+
+  let p = updatedPlayer;
+  for (const evt of moraleEvents) {
+    p = applyMoraleEvent(p, evt, { season, week });
+  }
+  cache.updatePlayer(player.id, {
+    tradeRequest:  p.tradeRequest,
+    morale:        p.morale,
+    moraleEvents:  p.moraleEvents,
+  });
+
+  await flushDirty();
+  post(toUI.STATE_UPDATE, buildViewState(), id);
+}
+
+// ── Handler: OFFER_EXTENSION_TO_WITHDRAW ─────────────────────────────────────
+
+async function handleOfferExtensionToWithdraw({ playerId }, id) {
+  const numericId = Number(playerId);
+  const player    = cache.getPlayer(numericId);
+  if (!player) { post(toUI.ERROR, { message: 'Player not found' }, id); return; }
+  if (!player.tradeRequest) { post(toUI.ERROR, { message: 'No active trade request' }, id); return; }
+
+  // Extension eligibility: must have <= 2 contract years remaining
+  const yearsLeft = Number(player.contractYearsLeft ?? player.contract?.yearsRemaining ?? 1);
+  if (yearsLeft > 2) {
+    post(toUI.ERROR, { message: 'Player is not eligible for extension (> 2 years remaining)' }, id);
+    return;
+  }
+
+  const meta   = ensureDynastyMeta(cache.getMeta());
+  const season = meta.currentSeasonId ?? meta.season ?? 0;
+  const week   = meta.currentWeek ?? 0;
+  const team   = cache.getTeam(player.teamId);
+
+  const { updatedPlayer, moraleEvents } = resolveTradeRequest(player, 'extend', { season, week });
+
+  let p = updatedPlayer;
+  for (const evt of moraleEvents) {
+    p = applyMoraleEvent(p, evt, { season, week });
+  }
+  cache.updatePlayer(player.id, {
+    tradeRequest:  p.tradeRequest,
+    morale:        p.morale,
+    moraleEvents:  p.moraleEvents,
+  });
+
+  const newsItem = {
+    id:       `trade-withdrawn-ext-${player.id}-${season}-${week}`,
+    headline: `${player.name ?? 'Player'} withdraws trade request after extension talks`,
+    body:     `${player.name ?? 'A player'} will remain with ${team?.name ?? 'the team'} after an extension offer was tabled.`,
+    week,
+    season,
+    type:     'TRADE_REQUEST',
+    teamId:   team?.id ?? null,
+    priority: 'medium',
+    dedupeKey: `trade-withdrawn-ext-${player.id}-${season}-${week}`,
+  };
+  cache.setMeta(addNewsItem(cache.getMeta(), newsItem));
+
+  await flushDirty();
+  // Signal to UI that extension flow should be initiated
+  post(toUI.STATE_UPDATE, { ...buildViewState(), extensionRedirect: { playerId: numericId } }, id);
+}
+
 
 async function handleAssignMentor({ mentorId, menteeId, teamId }, id) {
   const team = cache.getTeam(teamId);
@@ -12701,6 +13049,9 @@ async function handleMessage(event) {
       case toWorker.COUNTER_INCOMING_TRADE: return await handleCounterIncomingTrade(payload, id);
       case toWorker.TOGGLE_TRADE_BLOCK: return await handleToggleTradeBlock(payload, id);
       case toWorker.UPDATE_PLAYER_MANAGEMENT: return await handleUpdatePlayerManagement(payload, id);
+      case toWorker.HONOR_TRADE_REQUEST:         return await handleHonorTradeRequest(payload, id);
+      case toWorker.STONEWALL_TRADE_REQUEST:     return await handleStonewallTradeRequest(payload, id);
+      case toWorker.OFFER_EXTENSION_TO_WITHDRAW: return await handleOfferExtensionToWithdraw(payload, id);
       case toWorker.ASSIGN_MENTOR: return await handleAssignMentor(payload, id);
       case toWorker.GET_EXTENSION_ASK:  return await handleGetExtensionAsk(payload, id);
       case toWorker.EXTEND_CONTRACT:      return await handleExtendContract(payload, id);

--- a/tests/unit/tradeRequestEngine.test.js
+++ b/tests/unit/tradeRequestEngine.test.js
@@ -1,0 +1,436 @@
+/**
+ * tradeRequestEngine.test.js — Trade Requests V1 unit tests
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  TRADE_REQUEST_REASONS,
+  STONEWALL_THRESHOLDS,
+  TRADE_VALUE_MODIFIERS,
+  TRADE_REQUEST_MORALE_EVENTS,
+  TRADE_REQUEST_MORALE_DELTAS,
+  shouldPlayerRequestTrade,
+  getTradeRequestReason,
+  computeTradeValueModifier,
+  resolveTradeRequest,
+  evaluateWeeklyStonewall,
+  getActiveTradeRequests,
+} from '../../src/core/trades/tradeRequestEngine.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const mkPlayer = (overrides = {}) => ({
+  id: 101,
+  name: 'Test Player',
+  pos: 'WR',
+  ovr: 80,
+  age: 27,
+  morale: 70,
+  teamId: 1,
+  contract: { baseAnnual: 8, yearsRemaining: 2, yearsTotal: 4 },
+  holdout: { active: false },
+  tradeRequest: null,
+  onTradeBlock: false,
+  ...overrides,
+});
+
+const mkTeam = (overrides = {}) => ({
+  id: 1,
+  name: 'Test Team',
+  abbr: 'TST',
+  ...overrides,
+});
+
+// ── TRADE_REQUEST_REASONS sanity ──────────────────────────────────────────────
+
+describe('TRADE_REQUEST_REASONS', () => {
+  it('contains all four reason keys', () => {
+    expect(Object.keys(TRADE_REQUEST_REASONS)).toEqual(
+      expect.arrayContaining(['playing_time', 'scheme_fit', 'contract', 'personal']),
+    );
+  });
+});
+
+// ── shouldPlayerRequestTrade ──────────────────────────────────────────────────
+
+describe('shouldPlayerRequestTrade', () => {
+  it('returns true for playing_time trigger (depthRank >= 2 AND morale < 45)', () => {
+    const player = mkPlayer({ morale: 40 });
+    const result = shouldPlayerRequestTrade(player, mkTeam(), 1, 5, { depthRank: 2 });
+    expect(result).toBe(true);
+  });
+
+  it('returns true for scheme_fit trigger (misfit AND morale < 55)', () => {
+    const player = mkPlayer({ morale: 50 });
+    const result = shouldPlayerRequestTrade(player, mkTeam(), 1, 5, {
+      depthRank: 0,
+      isPositionMisfitForScheme: true,
+    });
+    expect(result).toBe(true);
+  });
+
+  it('returns true for contract trigger (yearsRemaining === 1, no extension, morale < 50)', () => {
+    const player = mkPlayer({
+      morale: 45,
+      contract: { baseAnnual: 8, yearsRemaining: 1, yearsTotal: 3 },
+      extensionOfferedThisSeason: false,
+    });
+    const result = shouldPlayerRequestTrade(player, mkTeam(), 1, 5, { depthRank: 0 });
+    expect(result).toBe(true);
+  });
+
+  it('returns false when contractYearsLeft === 0 (UFA)', () => {
+    const player = mkPlayer({
+      morale: 30,
+      contract: { baseAnnual: 8, yearsRemaining: 0, yearsTotal: 3 },
+    });
+    const result = shouldPlayerRequestTrade(player, mkTeam(), 1, 5, { depthRank: 3 });
+    expect(result).toBe(false);
+  });
+
+  it('returns false when trade request already exists', () => {
+    const player = mkPlayer({
+      morale: 30,
+      tradeRequest: { status: 'pending', requestedSeason: 1, requestedWeek: 1, stonewalledWeeks: 0, reason: 'personal' },
+    });
+    const result = shouldPlayerRequestTrade(player, mkTeam(), 1, 5, { depthRank: 3 });
+    expect(result).toBe(false);
+  });
+
+  it('returns false when on active holdout', () => {
+    const player = mkPlayer({
+      morale: 30,
+      holdout: { active: true, reason: 'extension_rejected' },
+    });
+    const result = shouldPlayerRequestTrade(player, mkTeam(), 1, 5, { depthRank: 3 });
+    expect(result).toBe(false);
+  });
+
+  it('returns false when morale is too high for playing_time trigger', () => {
+    const player = mkPlayer({ morale: 60 });
+    const result = shouldPlayerRequestTrade(player, mkTeam(), 1, 5, { depthRank: 2 });
+    expect(result).toBe(false);
+  });
+
+  it('personal reason fires at approximately 3% rate (seeded)', () => {
+    // Run many iterations with different player ids
+    let fired = 0;
+    const total = 1000;
+    for (let i = 0; i < total; i++) {
+      const player = mkPlayer({ id: i, morale: 30 });
+      // No other triggers apply
+      const result = shouldPlayerRequestTrade(player, mkTeam(), 1, 5, { depthRank: 0, isPositionMisfitForScheme: false });
+      if (result) fired++;
+    }
+    // Expect roughly 3% (allow 1-6% range for deterministic LCG)
+    expect(fired / total).toBeGreaterThan(0.01);
+    expect(fired / total).toBeLessThan(0.08);
+  });
+});
+
+// ── getTradeRequestReason ─────────────────────────────────────────────────────
+
+describe('getTradeRequestReason', () => {
+  it('returns playing_time when depthRank >= 2 AND morale < 45', () => {
+    const player = mkPlayer({ morale: 40 });
+    expect(getTradeRequestReason(player, mkTeam(), { depthRank: 2 }, 1)).toBe('playing_time');
+  });
+
+  it('returns scheme_fit when misfit AND morale < 55', () => {
+    const player = mkPlayer({ morale: 50 });
+    expect(
+      getTradeRequestReason(player, mkTeam(), { depthRank: 0, isPositionMisfitForScheme: true }, 1),
+    ).toBe('scheme_fit');
+  });
+
+  it('returns contract when 1yr left, no extension, morale < 50', () => {
+    const player = mkPlayer({
+      morale: 45,
+      contract: { baseAnnual: 8, yearsRemaining: 1, yearsTotal: 3 },
+    });
+    expect(getTradeRequestReason(player, mkTeam(), { depthRank: 0 }, 1)).toBe('contract');
+  });
+
+  it('returns null when no triggers match', () => {
+    const player = mkPlayer({ morale: 80 });
+    expect(getTradeRequestReason(player, mkTeam(), { depthRank: 0 }, 1)).toBeNull();
+  });
+
+  it('returns null when extension was offered for contract trigger', () => {
+    const player = mkPlayer({
+      morale: 45,
+      contract: { baseAnnual: 8, yearsRemaining: 1, yearsTotal: 3 },
+      extensionOfferedThisSeason: true,
+    });
+    expect(getTradeRequestReason(player, mkTeam(), { depthRank: 0 }, 1)).toBeNull();
+  });
+});
+
+// ── computeTradeValueModifier ─────────────────────────────────────────────────
+
+describe('computeTradeValueModifier', () => {
+  it('returns stonewall penalty when stonewalledWeeks >= 4', () => {
+    const player = mkPlayer({
+      tradeRequest: { status: 'pending', stonewalledWeeks: 4, reason: 'playing_time', requestedSeason: 1, requestedWeek: 2 },
+    });
+    const mod = computeTradeValueModifier(player);
+    expect(mod).not.toBeNull();
+    expect(mod.modifier).toBe(TRADE_VALUE_MODIFIERS.stonewalledRequest);
+    expect(mod.modifier).toBe(-0.12);
+  });
+
+  it('returns stonewall penalty at 7 weeks too', () => {
+    const player = mkPlayer({
+      tradeRequest: { status: 'pending', stonewalledWeeks: 7, reason: 'personal', requestedSeason: 1, requestedWeek: 1 },
+    });
+    const mod = computeTradeValueModifier(player);
+    expect(mod.modifier).toBe(-0.12);
+  });
+
+  it('returns onTradeBlock penalty when listed', () => {
+    const player = mkPlayer({ onTradeBlock: true });
+    const mod = computeTradeValueModifier(player);
+    expect(mod).not.toBeNull();
+    expect(mod.modifier).toBe(TRADE_VALUE_MODIFIERS.onTradeBlock);
+    expect(mod.modifier).toBe(-0.08);
+  });
+
+  it('returns withdrawn recovery when request was withdrawn', () => {
+    const player = mkPlayer({
+      tradeRequest: { status: 'withdrawn', stonewalledWeeks: 1, reason: 'contract', requestedSeason: 1, requestedWeek: 3 },
+    });
+    const mod = computeTradeValueModifier(player);
+    expect(mod).not.toBeNull();
+    expect(mod.modifier).toBe(TRADE_VALUE_MODIFIERS.withdrawn);
+    expect(mod.modifier).toBe(0.05);
+  });
+
+  it('returns null when no trade request and not on block', () => {
+    const player = mkPlayer();
+    expect(computeTradeValueModifier(player)).toBeNull();
+  });
+
+  it('returns null for less than 4 stonewall weeks', () => {
+    const player = mkPlayer({
+      tradeRequest: { status: 'pending', stonewalledWeeks: 3, reason: 'playing_time', requestedSeason: 1, requestedWeek: 1 },
+    });
+    const mod = computeTradeValueModifier(player);
+    // No stonewall penalty below 4 weeks, and not on block
+    expect(mod).toBeNull();
+  });
+});
+
+// ── resolveTradeRequest ───────────────────────────────────────────────────────
+
+describe('resolveTradeRequest', () => {
+  const baseRequest = {
+    status: 'pending',
+    requestedSeason: 1,
+    requestedWeek: 3,
+    stonewalledWeeks: 0,
+    reason: 'playing_time',
+  };
+
+  it('honor: sets status to honored and onTradeBlock = true', () => {
+    const player = mkPlayer({ tradeRequest: baseRequest });
+    const { updatedPlayer, moraleEvents } = resolveTradeRequest(player, 'honor', { season: 1, week: 5 });
+
+    expect(updatedPlayer.tradeRequest.status).toBe('honored');
+    expect(updatedPlayer.onTradeBlock).toBe(true);
+    expect(moraleEvents).toHaveLength(1);
+    expect(moraleEvents[0].type).toBe(TRADE_REQUEST_MORALE_EVENTS.TRADE_REQUEST_HONORED);
+    expect(moraleEvents[0].delta).toBe(TRADE_REQUEST_MORALE_DELTAS.TRADE_REQUEST_HONORED);
+  });
+
+  it('extend: sets status to withdrawn and returns correct morale event', () => {
+    const player = mkPlayer({ tradeRequest: baseRequest });
+    const { updatedPlayer, moraleEvents } = resolveTradeRequest(player, 'extend', { season: 1, week: 5 });
+
+    expect(updatedPlayer.tradeRequest.status).toBe('withdrawn');
+    expect(updatedPlayer.onTradeBlock).toBe(false);
+    expect(moraleEvents).toHaveLength(1);
+    expect(moraleEvents[0].type).toBe(TRADE_REQUEST_MORALE_EVENTS.TRADE_REQUEST_WITHDRAWN_EXTENSION);
+    expect(moraleEvents[0].delta).toBe(TRADE_REQUEST_MORALE_DELTAS.TRADE_REQUEST_WITHDRAWN_EXTENSION);
+  });
+
+  it('stonewall: increments stonewalledWeeks and keeps status pending', () => {
+    const player = mkPlayer({ tradeRequest: { ...baseRequest, stonewalledWeeks: 2 } });
+    const { updatedPlayer } = resolveTradeRequest(player, 'stonewall', { season: 1, week: 6 });
+
+    expect(updatedPlayer.tradeRequest.status).toBe('pending');
+    expect(updatedPlayer.tradeRequest.stonewalledWeeks).toBe(3);
+  });
+
+  it('stonewall at week 4 emits morale hit event', () => {
+    const player = mkPlayer({ tradeRequest: { ...baseRequest, stonewalledWeeks: 3 } });
+    const { moraleEvents } = resolveTradeRequest(player, 'stonewall', { season: 1, week: 7 });
+
+    expect(moraleEvents).toHaveLength(1);
+    expect(moraleEvents[0].type).toBe(TRADE_REQUEST_MORALE_EVENTS.TRADE_REQUEST_STONEWALLED);
+    expect(moraleEvents[0].delta).toBe(STONEWALL_THRESHOLDS.weeks_4_6.moraleHit); // -4
+  });
+
+  it('stonewall at week 1-3 emits no morale events', () => {
+    const player = mkPlayer({ tradeRequest: { ...baseRequest, stonewalledWeeks: 0 } });
+    const { moraleEvents } = resolveTradeRequest(player, 'stonewall', { season: 1, week: 4 });
+
+    expect(moraleEvents).toHaveLength(0);
+  });
+
+  it('does not mutate input player', () => {
+    const player = mkPlayer({ tradeRequest: baseRequest });
+    const original = JSON.parse(JSON.stringify(player));
+    resolveTradeRequest(player, 'honor', { season: 1, week: 5 });
+    expect(player).toEqual(original);
+  });
+
+  it('does not mutate input tradeRequest', () => {
+    const req = { ...baseRequest };
+    const player = mkPlayer({ tradeRequest: req });
+    resolveTradeRequest(player, 'stonewall', { season: 1, week: 5 });
+    expect(req.stonewalledWeeks).toBe(0);
+  });
+});
+
+// ── evaluateWeeklyStonewall ───────────────────────────────────────────────────
+
+describe('evaluateWeeklyStonewall', () => {
+  it('returns zero hits for weeks 1-3', () => {
+    const player = mkPlayer({ tradeRequest: { stonewalledWeeks: 2 } });
+    const result = evaluateWeeklyStonewall(player);
+    expect(result.moraleHit).toBe(0);
+    expect(result.teamMoraleHit).toBe(0);
+  });
+
+  it('returns -4/-2 hits for weeks 4-6', () => {
+    const player = mkPlayer({ tradeRequest: { stonewalledWeeks: 5 } });
+    const result = evaluateWeeklyStonewall(player);
+    expect(result.moraleHit).toBe(-4);
+    expect(result.teamMoraleHit).toBe(-2);
+  });
+
+  it('returns -8/-4 hits for weeks 7+', () => {
+    const player = mkPlayer({ tradeRequest: { stonewalledWeeks: 9 } });
+    const result = evaluateWeeklyStonewall(player);
+    expect(result.moraleHit).toBe(-8);
+    expect(result.teamMoraleHit).toBe(-4);
+  });
+
+  it('returns zero hits for week 0 (no stonewall)', () => {
+    const player = mkPlayer({ tradeRequest: { stonewalledWeeks: 0 } });
+    const result = evaluateWeeklyStonewall(player);
+    expect(result.moraleHit).toBe(0);
+  });
+
+  it('returns zero hits when no tradeRequest', () => {
+    const player = mkPlayer({ tradeRequest: null });
+    const result = evaluateWeeklyStonewall(player);
+    expect(result.moraleHit).toBe(0);
+  });
+
+  it('returns correct threshold at exact boundary (4)', () => {
+    const player = mkPlayer({ tradeRequest: { stonewalledWeeks: 4 } });
+    expect(evaluateWeeklyStonewall(player)).toEqual(STONEWALL_THRESHOLDS.weeks_4_6);
+  });
+
+  it('returns correct threshold at exact boundary (7)', () => {
+    const player = mkPlayer({ tradeRequest: { stonewalledWeeks: 7 } });
+    expect(evaluateWeeklyStonewall(player)).toEqual(STONEWALL_THRESHOLDS.weeks_7plus);
+  });
+});
+
+// ── getActiveTradeRequests ────────────────────────────────────────────────────
+
+describe('getActiveTradeRequests', () => {
+  it('returns alerts for players with pending requests on the team', () => {
+    const players = [
+      mkPlayer({ id: 1, teamId: 1, tradeRequest: { status: 'pending', stonewalledWeeks: 0, reason: 'playing_time', requestedWeek: 3, requestedSeason: 1 } }),
+      mkPlayer({ id: 2, teamId: 1, tradeRequest: null }),
+      mkPlayer({ id: 3, teamId: 2, tradeRequest: { status: 'pending', stonewalledWeeks: 0, reason: 'contract', requestedWeek: 2, requestedSeason: 1 } }),
+    ];
+    const alerts = getActiveTradeRequests(mkTeam({ id: 1 }), players);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].playerId).toBe(1);
+    expect(alerts[0].reason).toBe('playing_time');
+  });
+
+  it('excludes honored and withdrawn requests', () => {
+    const players = [
+      mkPlayer({ id: 1, teamId: 1, tradeRequest: { status: 'honored', stonewalledWeeks: 0, reason: 'contract', requestedWeek: 1, requestedSeason: 1 } }),
+      mkPlayer({ id: 2, teamId: 1, tradeRequest: { status: 'withdrawn', stonewalledWeeks: 1, reason: 'personal', requestedWeek: 2, requestedSeason: 1 } }),
+    ];
+    const alerts = getActiveTradeRequests(mkTeam({ id: 1 }), players);
+    expect(alerts).toHaveLength(0);
+  });
+
+  it('returns empty array for team with no players', () => {
+    expect(getActiveTradeRequests(mkTeam({ id: 99 }), [])).toEqual([]);
+  });
+
+  it('returns empty array for null team', () => {
+    expect(getActiveTradeRequests(null, [])).toEqual([]);
+  });
+
+  it('includes stonewalledWeeks in alerts', () => {
+    const players = [
+      mkPlayer({ id: 1, teamId: 1, tradeRequest: { status: 'pending', stonewalledWeeks: 5, reason: 'scheme_fit', requestedWeek: 1, requestedSeason: 1 } }),
+    ];
+    const alerts = getActiveTradeRequests(mkTeam({ id: 1 }), players);
+    expect(alerts[0].stonewalledWeeks).toBe(5);
+  });
+});
+
+// ── Determinism ───────────────────────────────────────────────────────────────
+
+describe('Determinism', () => {
+  it('same inputs always produce same shouldPlayerRequestTrade output', () => {
+    const player = mkPlayer({ id: 42, morale: 30 });
+    const team = mkTeam();
+    const r1 = shouldPlayerRequestTrade(player, team, 3, 5, { depthRank: 0 });
+    const r2 = shouldPlayerRequestTrade(player, team, 3, 5, { depthRank: 0 });
+    expect(r1).toBe(r2);
+  });
+
+  it('same inputs always produce same resolveTradeRequest output', () => {
+    const player = mkPlayer({
+      tradeRequest: { status: 'pending', stonewalledWeeks: 0, reason: 'contract', requestedSeason: 1, requestedWeek: 3 },
+    });
+    const r1 = resolveTradeRequest(player, 'honor', { season: 1, week: 5 });
+    const r2 = resolveTradeRequest(player, 'honor', { season: 1, week: 5 });
+    expect(r1.updatedPlayer).toEqual(r2.updatedPlayer);
+    expect(r1.moraleEvents).toEqual(r2.moraleEvents);
+  });
+
+  it('same inputs always produce same computeTradeValueModifier output', () => {
+    const player = mkPlayer({
+      tradeRequest: { status: 'pending', stonewalledWeeks: 6, reason: 'playing_time', requestedSeason: 1, requestedWeek: 1 },
+    });
+    expect(computeTradeValueModifier(player)).toEqual(computeTradeValueModifier(player));
+  });
+});
+
+// ── Old save hydration ────────────────────────────────────────────────────────
+
+describe('Old save hydration (missing fields)', () => {
+  it('shouldPlayerRequestTrade handles player without tradeRequest field', () => {
+    const player = { id: 1, morale: 80, teamId: 1, contract: { yearsRemaining: 2 } };
+    expect(() => shouldPlayerRequestTrade(player, mkTeam(), 1, 5, {})).not.toThrow();
+  });
+
+  it('computeTradeValueModifier returns null for player without tradeRequest', () => {
+    const player = { id: 1, morale: 80, teamId: 1 };
+    expect(computeTradeValueModifier(player)).toBeNull();
+  });
+
+  it('evaluateWeeklyStonewall handles missing tradeRequest field gracefully', () => {
+    const player = { id: 1 };
+    const result = evaluateWeeklyStonewall(player);
+    expect(result.moraleHit).toBe(0);
+  });
+
+  it('getActiveTradeRequests handles players without tradeRequest field', () => {
+    const players = [{ id: 1, teamId: 1, name: 'Old Player', pos: 'QB', ovr: 80 }];
+    expect(() => getActiveTradeRequests(mkTeam({ id: 1 }), players)).not.toThrow();
+    expect(getActiveTradeRequests(mkTeam({ id: 1 }), players)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Players with low morale can request trades based on playing time, scheme fit,
contract pressure, or personal reasons. GMs choose to honor (list on block),
stonewall (weekly morale penalty after week 3), or offer extension to withdraw.

- Pure deterministic tradeRequestEngine.js with LCG seeding (no Math.random)
- Status machine: pending → honored | withdrawn; stonewalledWeeks counter
- Trade value modifier applied on top of getAssetValue (−8% block, −12% stonewall, +5% withdrawn)
- Worker handlers for HONOR/STONEWALL/OFFER_EXTENSION_TO_WITHDRAW with morale events and news
- buildViewState exposes tradeRequestAlerts per team
- FranchiseHQ alert cards, PlayerProfile banner/badge, RosterManager badges
- 46 new unit tests (3510 → 3556); all 9 engine soak gates pass

Co-Authored-By: Claude <noreply@anthropic.com>