### PR TITLE
feat: wire scheme-fit multiplier and morale bonus into player progression

### DIFF
--- a/src/core/__tests__/progression-logic.test.js
+++ b/src/core/__tests__/progression-logic.test.js
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { processPlayerProgression } from '../progression-logic.js';
+import {
+  processPlayerProgression,
+  resolveSchemeMultiplier,
+  computeProgressionFinalDelta,
+} from '../progression-logic.js';
 import { Utils } from '../utils.js';
 
 function buildPlayer(overrides = {}) {
@@ -14,10 +18,12 @@ function buildPlayer(overrides = {}) {
     devTrait: 'Normal',
     ratings: {
       throwPower: 75,
+      throwAccuracy: 75,
       accuracyShort: 75,
       accuracyMedium: 75,
       accuracyDeep: 75,
       awareness: 75,
+      intelligence: 75,
       speed: 75,
       agility: 75,
       acceleration: 75,
@@ -25,6 +31,117 @@ function buildPlayer(overrides = {}) {
     ...overrides,
   };
 }
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeSpreadTeam(overallRating = 85) {
+  return { coach: { headCoach: { scheme: 'SPREAD', overallRating } } };
+}
+
+function makePowerRunTeam(overallRating = 85) {
+  return { coach: { headCoach: { scheme: 'POWER_RUN', overallRating } } };
+}
+
+// ── resolveSchemeMultiplier ───────────────────────────────────────────────────
+
+describe('resolveSchemeMultiplier', () => {
+  it('returns 1.0 when team is null (old-save fallback)', () => {
+    expect(resolveSchemeMultiplier({ pos: 'QB' }, null)).toBe(1.0);
+  });
+
+  it('returns 1.0 when team.coach is null', () => {
+    expect(resolveSchemeMultiplier({ pos: 'QB' }, { coach: null })).toBe(1.0);
+  });
+
+  it('returns 1.0 when team.coach.headCoach is absent', () => {
+    expect(resolveSchemeMultiplier({ pos: 'QB' }, { coach: {} })).toBe(1.0);
+  });
+
+  it('returns 1.08 (>1.0) for scheme-fit player with elite coach', () => {
+    // QB fits SPREAD → uses coach quality tier (rating 85 → 1.08)
+    const mult = resolveSchemeMultiplier({ pos: 'QB' }, makeSpreadTeam(85));
+    expect(mult).toBe(1.08);
+    expect(mult).toBeGreaterThan(1.0);
+  });
+
+  it('returns 0.90 (<1.0) for scheme-misfit player', () => {
+    // QB is an offensive skill player; POWER_RUN favours RB/OL → QB is a misfit
+    const mult = resolveSchemeMultiplier({ pos: 'QB' }, makePowerRunTeam(85));
+    expect(mult).toBe(0.90);
+    expect(mult).toBeLessThan(1.0);
+  });
+
+  it('fit multiplier is strictly greater than misfit multiplier', () => {
+    const fit    = resolveSchemeMultiplier({ pos: 'QB' }, makeSpreadTeam(85));
+    const misfit = resolveSchemeMultiplier({ pos: 'QB' }, makePowerRunTeam(85));
+    expect(fit).toBeGreaterThan(misfit);
+  });
+
+  it('BALANCED scheme never produces a misfit (returns coach quality mult)', () => {
+    const team = { coach: { headCoach: { scheme: 'BALANCED', overallRating: 85 } } };
+    expect(resolveSchemeMultiplier({ pos: 'QB' }, team)).toBe(1.08);
+    expect(resolveSchemeMultiplier({ pos: 'RB' }, team)).toBe(1.08);
+    expect(resolveSchemeMultiplier({ pos: 'CB' }, team)).toBe(1.08);
+  });
+});
+
+// ── computeProgressionFinalDelta ─────────────────────────────────────────────
+
+describe('computeProgressionFinalDelta', () => {
+  it('scheme fit multiplier (>1.0) increases finalDelta vs misfit (<1.0)', () => {
+    // Same base + same morale; only multiplier differs
+    const fit    = computeProgressionFinalDelta(3, 1.08, 70); // round(3.74) = 4
+    const misfit = computeProgressionFinalDelta(3, 0.90, 70); // round(3.20) = 3
+    expect(fit).toBeGreaterThan(misfit);
+  });
+
+  it('scheme misfit multiplier (<1.0) decreases finalDelta vs neutral (1.0)', () => {
+    // round(3 * 1.0  − 0.5) = round(2.5) = 3  (neutral scheme, low morale)
+    // round(3 * 0.90 − 0.5) = round(2.2) = 2  (misfit, low morale)
+    const neutral = computeProgressionFinalDelta(3, 1.0,  25);
+    const misfit  = computeProgressionFinalDelta(3, 0.90, 25);
+    expect(misfit).toBeLessThan(neutral);
+  });
+
+  it('multiplier = 1.0 produces unchanged delta (null-coach fallback)', () => {
+    // resolveSchemeMultiplier returns 1.0 for null team → same as no scheme
+    expect(computeProgressionFinalDelta(3, 1.0, 50)).toBe(3);
+    expect(computeProgressionFinalDelta(-2, 1.0, 50)).toBe(-2);
+  });
+
+  it('moraleBonus +0.5 applied when morale >= 70', () => {
+    // round(2 * 1.0 + 0.5) = round(2.5) = 3  vs  round(2 * 1.0 + 0) = 2
+    expect(computeProgressionFinalDelta(2, 1.0, 70)).toBe(3);
+    expect(computeProgressionFinalDelta(2, 1.0, 69)).toBe(2); // boundary: 69 → no bonus
+    expect(computeProgressionFinalDelta(2, 1.0, 100)).toBe(3);
+  });
+
+  it('moraleBonus -0.5 applied when morale <= 30', () => {
+    // round(3 * 0.90 − 0.5) = round(2.2) = 2  vs  round(3 * 0.90 + 0) = round(2.7) = 3
+    expect(computeProgressionFinalDelta(3, 0.90, 30)).toBe(2);
+    expect(computeProgressionFinalDelta(3, 0.90, 31)).toBe(3); // boundary: 31 → no penalty
+    expect(computeProgressionFinalDelta(3, 0.90, 0)).toBe(2);
+  });
+
+  it('moraleBonus 0 applied when morale is between 31 and 69', () => {
+    expect(computeProgressionFinalDelta(3, 1.0, 50)).toBe(3);
+    expect(computeProgressionFinalDelta(3, 1.0, 31)).toBe(3);
+    expect(computeProgressionFinalDelta(3, 1.0, 69)).toBe(3);
+  });
+
+  it('finalDelta clamped to +5 upper bound', () => {
+    // Large positive input would exceed 5 without the clamp
+    expect(computeProgressionFinalDelta(10, 1.08, 70)).toBe(5);
+    expect(computeProgressionFinalDelta(5,  1.08, 70)).toBe(5);
+  });
+
+  it('finalDelta clamped to -5 lower bound', () => {
+    expect(computeProgressionFinalDelta(-10, 0.90, 25)).toBe(-5);
+    expect(computeProgressionFinalDelta(-5,  0.90, 25)).toBe(-5);
+  });
+});
+
+// ── processPlayerProgression (existing + regression) ─────────────────────────
 
 describe('processPlayerProgression', () => {
   afterEach(() => {
@@ -77,5 +194,43 @@ describe('processPlayerProgression', () => {
     const allRatings = Object.values(veteran.ratings);
     expect(Math.min(...allRatings)).toBeGreaterThanOrEqual(40);
     expect(Math.max(...allRatings)).toBeLessThanOrEqual(99);
+  });
+
+  it('scheme fit (>1.0) produces higher rating nudge than scheme misfit (<1.0)', () => {
+    // Two growth-phase QBs with identical setup; one has fit scheme, one misfit.
+    // Utils.rand mocked so growth ovrDelta = 3 for both (after 6 personality rand calls).
+    // fit  team: SPREAD (QB fits) + coach 85 → multiplier 1.08, morale 70 (+0.5 bonus)
+    //   → computeProgressionFinalDelta(3, 1.08, 70) = round(3.74) = 4 → throwPower 79
+    // misfit team: POWER_RUN (QB misfit) → multiplier 0.90, morale 70 (+0.5 bonus)
+    //   → computeProgressionFinalDelta(3, 0.90, 70) = round(3.20) = 3 → throwPower 78
+    vi.spyOn(Utils, 'random').mockReturnValue(0.5);
+    vi.spyOn(Utils, 'rand').mockImplementation((min, max) => max);
+
+    const fitPlayer    = buildPlayer({ id: 10, teamId: 10, morale: 70 });
+    const misfitPlayer = buildPlayer({ id: 11, teamId: 11, morale: 70 });
+
+    processPlayerProgression([fitPlayer, misfitPlayer], {
+      teams: {
+        10: makeSpreadTeam(85),
+        11: makePowerRunTeam(85),
+      },
+    });
+
+    expect(fitPlayer.ratings.throwPower).toBeGreaterThan(misfitPlayer.ratings.throwPower);
+  });
+
+  it('null team.coach leaves progression unchanged from no-team baseline', () => {
+    vi.spyOn(Utils, 'random').mockReturnValue(0.5);
+    vi.spyOn(Utils, 'rand').mockImplementation((min, max) => max);
+
+    const noTeam   = buildPlayer({ id: 20, teamId: 99, morale: 50 });
+    const nullCoach = buildPlayer({ id: 21, teamId: 98, morale: 50 });
+
+    processPlayerProgression([noTeam, nullCoach], {
+      teams: { 98: { coach: null } },
+    });
+
+    // Both fall back to multiplier 1.0 → identical throwPower nudges
+    expect(noTeam.ratings.throwPower).toBe(nullCoach.ratings.throwPower);
   });
 });

--- a/src/core/progression-logic.js
+++ b/src/core/progression-logic.js
@@ -25,6 +25,7 @@ import { calculateOvr } from './player.js';
 import { Constants } from './constants.js';
 import { ensurePersonalityProfile, mentorshipBonusForPlayer } from './development/personalitySystem.js';
 import { getDevelopmentRateModifier } from './coaching-philosophy-effects.js';
+import { getCoachSchemeMultiplier, isPositionMisfitForScheme } from './coaching/coachingEngine.js';
 
 // ── Progression probability constants (Task 10) ───────────────────────────────
 // Defined here so they can be tuned without hunting for magic numbers inline.
@@ -98,6 +99,32 @@ const PHYSICAL_TRAITS = {
 // deep into his decline phase. Mental traits (awareness, route running, etc.)
 // always retain the 40 floor — an old player loses a step, not his football IQ.
 const AGE_FLOOR_TRAITS = new Set(['speed', 'acceleration', 'agility', 'jumping']);
+
+/**
+ * Resolve the scheme-fit development multiplier for a player on a team.
+ *
+ * - team.coach.headCoach absent (old saves or no coach hired) → 1.0 safe fallback
+ * - Position is a scheme misfit → 0.90  (development slowed)
+ * - Position fits or is unaffected by the scheme → coach-quality multiplier
+ *   from getCoachSchemeMultiplier (1.08 / 1.00 / 0.94 / 0.88 by rating tier)
+ */
+export function resolveSchemeMultiplier(player, team) {
+  const hc = team?.coach?.headCoach;
+  if (!hc) return 1.0;
+  if (isPositionMisfitForScheme(player.pos, hc.scheme)) return 0.90;
+  return getCoachSchemeMultiplier(hc.overallRating);
+}
+
+/**
+ * Apply scheme multiplier and morale bonus to a base OVR delta, clamped to [-5, +5].
+ *
+ * moraleBonus: +0.5 if morale >= 70, -0.5 if morale <= 30, 0 otherwise.
+ * finalDelta = round(baseOvrDelta * schemeMultiplier + moraleBonus), clamped [-5, +5].
+ */
+export function computeProgressionFinalDelta(baseOvrDelta, schemeMultiplier, moraleScore) {
+  const moraleBonus = moraleScore >= 70 ? 0.5 : moraleScore <= 30 ? -0.5 : 0;
+  return Math.max(-5, Math.min(5, Math.round(baseOvrDelta * schemeMultiplier + moraleBonus)));
+}
 
 /**
  * Build a per-trait minimum-rating function for a player's age. For physical
@@ -207,6 +234,8 @@ export function processPlayerProgression(players, options = {}) {
   const teamRosters = options?.teamRosters ?? {};
   // teamCoaches: map of teamId → team.staff (for coaching philosophy dev modifier)
   const teamCoaches = options?.teamCoaches ?? {};
+  // teams: map of teamId → full team object (for scheme-fit multiplier via team.coach)
+  const teams = options?.teams ?? {};
   const gainers    = []; // players with progressionDelta >= +4
   const regressors = []; // players with progressionDelta <= -3
   const breakouts  = []; // explicit Breakout Season events (for news)
@@ -352,6 +381,11 @@ export function processPlayerProgression(players, options = {}) {
             : ovrDelta + (damp * direction);
         }
       }
+      // ── Scheme-fit multiplier + morale bonus (applied last, hard cap ±5) ─────
+      const team = teams[player.teamId] ?? null;
+      const schemeMultiplier = resolveSchemeMultiplier(player, team);
+      const moraleScore = player.morale ?? 70;
+      ovrDelta = computeProgressionFinalDelta(ovrDelta, schemeMultiplier, moraleScore);
       nudgeRatingsBy(player, ovrDelta);
     }
 

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -10914,8 +10914,10 @@ async function handleAdvanceOffseason(payload, id) {
       const teamId = Number(team.id);
       teamRosters[teamId] = playersByTeamId.get(teamId) || [];
     }
+    const teamsById = {};
+    for (const team of allTeams) teamsById[Number(team.id)] = team;
     for (const player of legacyPlayers) player.season = Number(meta?.year ?? 2025);
-    legacyProgression = processPlayerProgression(legacyPlayers, { teamEnvironments, teamRosters, teamCoaches });
+    legacyProgression = processPlayerProgression(legacyPlayers, { teamEnvironments, teamRosters, teamCoaches, teams: teamsById });
   }
 
   const evolvedLeaders = summarizeOffseasonEvolutionLeaders(offseasonEvolution, playersById);


### PR DESCRIPTION
Scheme-fit now accelerates or slows legacy player development each offseason.
QBs in SPREAD grow faster (×1.08 with elite coach), while positional misfits
regress slower (×0.90). High morale (≥70) adds +0.5, low morale (≤30) adds
−0.5 to the final delta before clamping to [−5, +5]. Old saves with no coach
data fall back silently to multiplier 1.0.

- Add resolveSchemeMultiplier(player, team) and computeProgressionFinalDelta
  as exported helpers in progression-logic.js (testable in isolation)
- Wire scheme+morale step into the !cliffEvent && !wallEvent block, after
  rookie/volatility mods, before nudgeRatingsBy
- Build teamsById map in worker.js and pass teams: teamsById to
  processPlayerProgression so each player's team is available
- Rewrite progression-logic.test.js with 20 tests covering all 8 required
  cases: null-team fallback, BALANCED never-misfit, fit>misfit delta,
  morale boundaries (69/70/30/31), ±5 clamp, integration fit vs misfit,
  null-coach equality baseline