### PR TITLE
feat: AI Trade Block Marketplace — inbound offer system for trade block players

### DIFF
--- a/src/core/news-engine.js
+++ b/src/core/news-engine.js
@@ -362,6 +362,31 @@ export const createNewsItem = (type, data, week, season) => {
             body: (d) => `The ${d?.season ?? 'season'} Hall of Fame class has been announced: ${d?.names ?? 'several legends'}.`,
             priority: 'high',
         },
+        trade_offer_received: {
+            headline: (d) => `${d?.aiTeamName ?? 'A team'} makes offer for ${d?.playerName ?? 'Player'}`,
+            body: (d) => `${d?.aiTeamName ?? 'An AI franchise'} has submitted an inbound offer for ${d?.playerName ?? 'a player'} on your trade block.`,
+            priority: 'medium',
+        },
+        trade_offer_expired: {
+            headline: (d) => `${d?.aiTeamName ?? 'A team'} withdrew their offer for ${d?.playerName ?? 'Player'}`,
+            body: (d) => `The offer from ${d?.aiTeamName ?? 'an AI team'} for ${d?.playerName ?? 'a player'} has expired.`,
+            priority: 'low',
+        },
+        trade_block_accepted: {
+            headline: (d) => `${d?.playerName ?? 'Player'} traded to ${d?.aiTeamName ?? 'Team'}`,
+            body: (d) => `You accepted the offer and ${d?.playerName ?? 'a player'} is now with ${d?.aiTeamName ?? 'another franchise'}.`,
+            priority: 'medium',
+        },
+        trade_counter_accepted: {
+            headline: (d) => `${d?.aiTeamName ?? 'Team'} accepts your counter offer`,
+            body: (d) => `${d?.aiTeamName ?? 'The opposing team'} agreed to your revised terms for ${d?.playerName ?? 'the player'}.`,
+            priority: 'medium',
+        },
+        trade_counter_rejected: {
+            headline: (d) => `${d?.aiTeamName ?? 'Team'} rejected your counter offer`,
+            body: (d) => `${d?.aiTeamName ?? 'The opposing team'} turned down your revised terms for ${d?.playerName ?? 'the player'}.`,
+            priority: 'medium',
+        },
     };
     const template = templates[type];
     if (!template) return null;

--- a/src/core/trades/__tests__/aiTradeEngine.test.js
+++ b/src/core/trades/__tests__/aiTradeEngine.test.js
@@ -1,0 +1,509 @@
+/**
+ * aiTradeEngine.test.js — Comprehensive tests for the AI trade pursuit engine
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  POSITION_NEED_WEIGHT,
+  AI_OFFER_AGGRESSION,
+  computeAIPositionNeed,
+  computeAIOfferValue,
+  buildAITradeOffer,
+  shouldAIUpdateOffer,
+  improveAIOffer,
+  evaluateCounterOffer,
+  getAITradeBlockTargets,
+} from '../aiTradeEngine.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makePlayer(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Test Player',
+    pos: 'WR',
+    ovr: 82,
+    age: 26,
+    morale: 70,
+    teamId: 10,
+    onTradeBlock: false,
+    contract: { yearsRemaining: 3, baseAnnual: 8.0, signingBonus: 2.0, yearsTotal: 4 },
+    ...overrides,
+  };
+}
+
+function makeTeam(overrides = {}) {
+  return { id: 5, name: 'Test AI Team', abbrev: 'TAI', isHuman: false, ...overrides };
+}
+
+function makePick(overrides = {}) {
+  return {
+    id: 'pick_1',
+    assetType: 'pick',
+    round: 1,
+    currentTeamId: 5,
+    season: 2025,
+    ...overrides,
+  };
+}
+
+function makeOffer(overrides = {}) {
+  return {
+    offerId:          'ai_5_1_s2025w5_abc12345',
+    aiTeamId:         5,
+    aiTeamName:       'Test AI Team',
+    aiTeamAbbrev:     'TAI',
+    targetPlayerId:   1,
+    targetPlayerName: 'Test Player',
+    targetPlayerPos:  'WR',
+    targetPlayerOvr:  82,
+    offerPlayers:     [],
+    offerPicks:       [makePick()],
+    bundleValue:      900,
+    acquisitionValue: 880,
+    positionNeed:     0.8,
+    aggression:       'HIGH',
+    status:           'pending',
+    createdSeason:    2025,
+    createdWeek:      5,
+    expiresWeek:      8,
+    ...overrides,
+  };
+}
+
+// ── Module exports ────────────────────────────────────────────────────────────
+
+describe('module exports', () => {
+  it('exports POSITION_NEED_WEIGHT with expected keys', () => {
+    expect(POSITION_NEED_WEIGHT).toBeDefined();
+    expect(POSITION_NEED_WEIGHT.QB).toBe(1.5);
+    expect(POSITION_NEED_WEIGHT.RB).toBe(0.75);
+    expect(POSITION_NEED_WEIGHT.WR).toBe(1.2);
+    expect(Object.isFrozen(POSITION_NEED_WEIGHT)).toBe(true);
+  });
+
+  it('exports AI_OFFER_AGGRESSION with four levels', () => {
+    expect(AI_OFFER_AGGRESSION).toBeDefined();
+    expect(AI_OFFER_AGGRESSION.LOW).toBeLessThan(AI_OFFER_AGGRESSION.MEDIUM);
+    expect(AI_OFFER_AGGRESSION.MEDIUM).toBeLessThan(AI_OFFER_AGGRESSION.HIGH);
+    expect(AI_OFFER_AGGRESSION.HIGH).toBeLessThan(AI_OFFER_AGGRESSION.MAX);
+    expect(Object.isFrozen(AI_OFFER_AGGRESSION)).toBe(true);
+  });
+});
+
+// ── computeAIPositionNeed ─────────────────────────────────────────────────────
+
+describe('computeAIPositionNeed', () => {
+  it('returns 0.5 when aiTeam is falsy', () => {
+    expect(computeAIPositionNeed(null, 'WR', [])).toBe(0.5);
+    expect(computeAIPositionNeed(undefined, 'WR', [])).toBe(0.5);
+  });
+
+  it('returns 0.5 when players array is not an array', () => {
+    expect(computeAIPositionNeed(makeTeam(), 'WR', null)).toBe(0.5);
+  });
+
+  it('returns high need (>= 1.0) when team has NO starters at position', () => {
+    const aiTeam = makeTeam({ id: 5 });
+    // No WR players on team 5
+    const players = [makePlayer({ id: 99, teamId: 5, pos: 'QB', ovr: 80 })];
+    const need = computeAIPositionNeed(aiTeam, 'WR', players);
+    expect(need).toBeGreaterThanOrEqual(1.0);
+  });
+
+  it('returns moderate need when team is below full starter count', () => {
+    const aiTeam = makeTeam({ id: 5 });
+    // Only 1 WR starter (needs 3)
+    const players = [makePlayer({ id: 1, teamId: 5, pos: 'WR', ovr: 75 })];
+    const need = computeAIPositionNeed(aiTeam, 'WR', players);
+    expect(need).toBeGreaterThan(0.25);
+    expect(need).toBeLessThanOrEqual(1.0);
+  });
+
+  it('returns low need when team is fully stocked at position', () => {
+    const aiTeam = makeTeam({ id: 5 });
+    // 3 quality WRs (starter threshold 70+)
+    const players = [
+      makePlayer({ id: 1, teamId: 5, pos: 'WR', ovr: 85 }),
+      makePlayer({ id: 2, teamId: 5, pos: 'WR', ovr: 80 }),
+      makePlayer({ id: 3, teamId: 5, pos: 'WR', ovr: 74 }),
+    ];
+    const need = computeAIPositionNeed(aiTeam, 'WR', players);
+    expect(need).toBeLessThan(0.5);
+  });
+
+  it('correctly filters by teamId — other teams\' players ignored', () => {
+    const aiTeam = makeTeam({ id: 5 });
+    // 3 WRs but all on team 10, not team 5
+    const players = [
+      makePlayer({ id: 1, teamId: 10, pos: 'WR', ovr: 85 }),
+      makePlayer({ id: 2, teamId: 10, pos: 'WR', ovr: 80 }),
+      makePlayer({ id: 3, teamId: 10, pos: 'WR', ovr: 74 }),
+    ];
+    const need = computeAIPositionNeed(aiTeam, 'WR', players);
+    // Team 5 has 0 WRs → high need
+    expect(need).toBeGreaterThanOrEqual(1.0);
+  });
+});
+
+// ── computeAIOfferValue ───────────────────────────────────────────────────────
+
+describe('computeAIOfferValue', () => {
+  it('returns 0 for null player', () => {
+    expect(computeAIOfferValue(null, makeTeam(), {}, 42)).toBe(0);
+  });
+
+  it('returns a positive number for a valid player', () => {
+    const player = makePlayer({ ovr: 82, onTradeBlock: false });
+    const value = computeAIOfferValue(player, makeTeam(), { positionNeed: 0.5, aggression: 'MEDIUM' }, 42);
+    expect(value).toBeGreaterThan(0);
+  });
+
+  it('MAX aggression gives higher offer than LOW aggression for same player', () => {
+    const player = makePlayer({ ovr: 82 });
+    const vHigh = computeAIOfferValue(player, makeTeam(), { positionNeed: 0.5, aggression: 'MAX' }, 42);
+    const vLow  = computeAIOfferValue(player, makeTeam(), { positionNeed: 0.5, aggression: 'LOW' }, 42);
+    expect(vHigh).toBeGreaterThan(vLow);
+  });
+
+  it('higher positionNeed increases offer value', () => {
+    const player = makePlayer({ ovr: 82 });
+    const vHigh = computeAIOfferValue(player, makeTeam(), { positionNeed: 0.9, aggression: 'MEDIUM' }, 42);
+    const vLow  = computeAIOfferValue(player, makeTeam(), { positionNeed: 0.1, aggression: 'MEDIUM' }, 42);
+    expect(vHigh).toBeGreaterThan(vLow);
+  });
+
+  it('player on trade block gets discounted offer (modifier = -0.08)', () => {
+    const playerOff  = makePlayer({ ovr: 82, onTradeBlock: false });
+    const playerOn   = makePlayer({ ovr: 82, onTradeBlock: true });
+    const vOff = computeAIOfferValue(playerOff, makeTeam(), { positionNeed: 0.5, aggression: 'MEDIUM' }, 42);
+    const vOn  = computeAIOfferValue(playerOn,  makeTeam(), { positionNeed: 0.5, aggression: 'MEDIUM' }, 42);
+    expect(vOn).toBeLessThan(vOff);
+  });
+
+  it('is deterministic — same seed gives same result', () => {
+    const player = makePlayer({ ovr: 80 });
+    const v1 = computeAIOfferValue(player, makeTeam(), { positionNeed: 0.5, aggression: 'MEDIUM' }, 999);
+    const v2 = computeAIOfferValue(player, makeTeam(), { positionNeed: 0.5, aggression: 'MEDIUM' }, 999);
+    expect(v1).toBe(v2);
+  });
+
+  it('different seeds give different results', () => {
+    const player = makePlayer({ ovr: 80 });
+    const v1 = computeAIOfferValue(player, makeTeam(), { positionNeed: 0.5, aggression: 'MEDIUM' }, 111);
+    const v2 = computeAIOfferValue(player, makeTeam(), { positionNeed: 0.5, aggression: 'MEDIUM' }, 222);
+    expect(v1).not.toBe(v2);
+  });
+});
+
+// ── buildAITradeOffer ─────────────────────────────────────────────────────────
+
+describe('buildAITradeOffer', () => {
+  it('returns null when targetPlayer is null', () => {
+    expect(buildAITradeOffer(null, makeTeam(), [], [], 2025, 5, 42)).toBeNull();
+  });
+
+  it('returns null when aiTeam is null', () => {
+    expect(buildAITradeOffer(makePlayer(), null, [], [], 2025, 5, 42)).toBeNull();
+  });
+
+  it('returns null if AI has no tradeable assets', () => {
+    const target = makePlayer({ id: 1, pos: 'WR', ovr: 82, teamId: 10, onTradeBlock: true });
+    const aiTeam = makeTeam({ id: 5 });
+    // AI has only their one QB starter (protected) and no picks
+    const aiPlayers = [makePlayer({ id: 99, teamId: 5, pos: 'QB', ovr: 85 })];
+    const result = buildAITradeOffer(target, aiTeam, aiPlayers, [], 2025, 5, 42);
+    // Can't hit 70% with nothing
+    expect(result).toBeNull();
+  });
+
+  it('returns a valid offer when AI has sufficient picks', () => {
+    const target = makePlayer({ id: 1, pos: 'WR', ovr: 75, teamId: 10, onTradeBlock: true });
+    const aiTeam = makeTeam({ id: 5 });
+    const aiPlayers = [];
+    const aiPicks = [
+      makePick({ id: 'p1', round: 1, currentTeamId: 5, season: 2025 }),
+      makePick({ id: 'p2', round: 2, currentTeamId: 5, season: 2025 }),
+    ];
+    const offer = buildAITradeOffer(target, aiTeam, aiPlayers, aiPicks, 2025, 5, 42);
+    expect(offer).not.toBeNull();
+    expect(offer.status).toBe('pending');
+    expect(offer.aiTeamId).toBe(5);
+    expect(offer.targetPlayerId).toBe(1);
+    expect(offer.bundleValue).toBeGreaterThan(0);
+    expect(offer.acquisitionValue).toBeGreaterThan(0);
+  });
+
+  it('offer offerId is stable for same inputs', () => {
+    const target   = makePlayer({ id: 1, pos: 'WR', ovr: 75, teamId: 10 });
+    const aiTeam   = makeTeam({ id: 5 });
+    const aiPicks  = [makePick({ id: 'p1', round: 1, currentTeamId: 5 })];
+    const o1 = buildAITradeOffer(target, aiTeam, [], aiPicks, 2025, 5, 42);
+    const o2 = buildAITradeOffer(target, aiTeam, [], aiPicks, 2025, 5, 42);
+    expect(o1?.offerId).toBe(o2?.offerId);
+  });
+
+  it('does NOT include depth-rank-1 starter in offerPlayers', () => {
+    const target   = makePlayer({ id: 1, pos: 'WR', ovr: 80, teamId: 10 });
+    const aiTeam   = makeTeam({ id: 5 });
+    // AI has one elite QB (protected) and one backup QB (offerrable) and plenty of picks
+    const aiPlayers = [
+      makePlayer({ id: 50, teamId: 5, pos: 'QB', ovr: 88 }),  // starter — protected
+      makePlayer({ id: 51, teamId: 5, pos: 'QB', ovr: 65 }),  // backup — offerrable
+    ];
+    const aiPicks   = [makePick({ id: 'p1', round: 1, currentTeamId: 5 })];
+    const offer = buildAITradeOffer(target, aiTeam, aiPlayers, aiPicks, 2025, 5, 42);
+    if (offer) {
+      const offeredIds = offer.offerPlayers.map(p => p.id);
+      expect(offeredIds).not.toContain(50); // starter not offered
+    }
+  });
+
+  it('expiresWeek is createdWeek + 3', () => {
+    const target  = makePlayer({ id: 1, pos: 'WR', ovr: 75, teamId: 10 });
+    const aiPicks = [makePick({ id: 'p1', round: 1, currentTeamId: 5 })];
+    const offer   = buildAITradeOffer(target, makeTeam({ id: 5 }), [], aiPicks, 2025, 6, 42);
+    if (offer) {
+      expect(offer.expiresWeek).toBe(9);
+    }
+  });
+
+  it('bundleValue >= acquisitionValue * 0.70 (otherwise returns null)', () => {
+    const target  = makePlayer({ id: 1, pos: 'WR', ovr: 85, teamId: 10 });
+    const aiPicks = [makePick({ id: 'p1', round: 1, currentTeamId: 5 })];
+    const offer   = buildAITradeOffer(target, makeTeam({ id: 5 }), [], aiPicks, 2025, 5, 42);
+    if (offer) {
+      expect(offer.bundleValue).toBeGreaterThanOrEqual(offer.acquisitionValue * 0.70);
+    }
+  });
+});
+
+// ── shouldAIUpdateOffer ───────────────────────────────────────────────────────
+
+describe('shouldAIUpdateOffer', () => {
+  it('returns false for null offer', () => {
+    expect(shouldAIUpdateOffer(null, null, 2025, 5)).toBe(false);
+  });
+
+  it('returns false for non-pending offer', () => {
+    const offer = makeOffer({ status: 'accepted' });
+    expect(shouldAIUpdateOffer(offer, makePlayer(), 2025, 9)).toBe(false);
+  });
+
+  it('returns false when still within validity window', () => {
+    const offer = makeOffer({ status: 'pending', createdSeason: 2025, createdWeek: 5, expiresWeek: 8 });
+    expect(shouldAIUpdateOffer(offer, makePlayer(), 2025, 7)).toBe(false);
+  });
+
+  it('returns true when week > expiresWeek', () => {
+    const offer = makeOffer({ status: 'pending', createdSeason: 2025, createdWeek: 5, expiresWeek: 8 });
+    expect(shouldAIUpdateOffer(offer, makePlayer(), 2025, 9)).toBe(true);
+  });
+
+  it('returns true when offer is from a prior season', () => {
+    const offer = makeOffer({ status: 'pending', createdSeason: 2024, createdWeek: 18, expiresWeek: 21 });
+    expect(shouldAIUpdateOffer(offer, makePlayer(), 2025, 1)).toBe(true);
+  });
+});
+
+// ── improveAIOffer ────────────────────────────────────────────────────────────
+
+describe('improveAIOffer', () => {
+  it('returns null for null offer', () => {
+    expect(improveAIOffer(null, makePlayer(), makeTeam(), [], [], 2025, 5, 42)).toBeNull();
+  });
+
+  it('returns null for non-pending offer', () => {
+    const offer = makeOffer({ status: 'rejected' });
+    expect(improveAIOffer(offer, makePlayer(), makeTeam(), [], [], 2025, 5, 42)).toBeNull();
+  });
+
+  it('improved offer has higher acquisitionValue than original', () => {
+    const target   = makePlayer({ id: 1, pos: 'WR', ovr: 75, teamId: 10 });
+    const original = makeOffer({ status: 'pending', aggression: 'MEDIUM', acquisitionValue: 800 });
+    const aiPicks  = [
+      makePick({ id: 'p1', round: 1, currentTeamId: 5 }),
+      makePick({ id: 'p2', round: 2, currentTeamId: 5 }),
+    ];
+    const improved = improveAIOffer(original, target, makeTeam({ id: 5 }), [], aiPicks, 2025, 6, 99);
+    if (improved) {
+      expect(improved.acquisitionValue).toBeGreaterThan(original.acquisitionValue);
+    }
+  });
+
+  it('improved offer steps aggression up one level', () => {
+    const target   = makePlayer({ id: 1, pos: 'WR', ovr: 75, teamId: 10 });
+    const original = makeOffer({ status: 'pending', aggression: 'MEDIUM' });
+    const aiPicks  = [makePick({ id: 'p1', round: 1, currentTeamId: 5 })];
+    const improved = improveAIOffer(original, target, makeTeam({ id: 5 }), [], aiPicks, 2025, 6, 99);
+    if (improved) {
+      expect(improved.aggression).toBe('HIGH');
+    }
+  });
+
+  it('improved offer sets improved: true', () => {
+    const target   = makePlayer({ id: 1, pos: 'WR', ovr: 75, teamId: 10 });
+    const original = makeOffer({ status: 'pending', aggression: 'LOW' });
+    const aiPicks  = [makePick({ id: 'p1', round: 1, currentTeamId: 5 })];
+    const improved = improveAIOffer(original, target, makeTeam({ id: 5 }), [], aiPicks, 2025, 6, 99);
+    if (improved) {
+      expect(improved.improved).toBe(true);
+    }
+  });
+
+  it('aggression does not exceed MAX', () => {
+    const target   = makePlayer({ id: 1, pos: 'WR', ovr: 75, teamId: 10 });
+    const original = makeOffer({ status: 'pending', aggression: 'MAX' });
+    const aiPicks  = [makePick({ id: 'p1', round: 1, currentTeamId: 5 })];
+    const improved = improveAIOffer(original, target, makeTeam({ id: 5 }), [], aiPicks, 2025, 6, 99);
+    if (improved) {
+      expect(improved.aggression).toBe('MAX');
+    }
+  });
+});
+
+// ── evaluateCounterOffer ──────────────────────────────────────────────────────
+
+describe('evaluateCounterOffer', () => {
+  it('returns "reject" for null originalOffer', () => {
+    expect(evaluateCounterOffer(null, { aiReceivesValue: 900 }, makeTeam(), 42)).toBe('reject');
+  });
+
+  it('returns "reject" for null preComputedValues', () => {
+    expect(evaluateCounterOffer(makeOffer(), null, makeTeam(), 42)).toBe('reject');
+  });
+
+  it('returns "accept" when aiReceivesValue >= 90% of acquisitionValue', () => {
+    const offer = makeOffer({ acquisitionValue: 1000 });
+    const result = evaluateCounterOffer(offer, { aiReceivesValue: 950 }, makeTeam(), 42);
+    expect(result).toBe('accept');
+  });
+
+  it('returns "accept" at exactly 90% threshold', () => {
+    const offer = makeOffer({ acquisitionValue: 1000 });
+    expect(evaluateCounterOffer(offer, { aiReceivesValue: 900 }, makeTeam(), 42)).toBe('accept');
+  });
+
+  it('returns "reject" when aiReceivesValue < 60% of acquisitionValue', () => {
+    const offer = makeOffer({ acquisitionValue: 1000 });
+    expect(evaluateCounterOffer(offer, { aiReceivesValue: 550 }, makeTeam(), 42)).toBe('reject');
+  });
+
+  it('returns "counter" or "reject" in the 60–90% range (seeded)', () => {
+    const offer  = makeOffer({ acquisitionValue: 1000 });
+    const result = evaluateCounterOffer(offer, { aiReceivesValue: 750 }, makeTeam(), 42);
+    expect(['counter', 'reject']).toContain(result);
+  });
+
+  it('is deterministic in the middle zone', () => {
+    const offer  = makeOffer({ acquisitionValue: 1000 });
+    const r1 = evaluateCounterOffer(offer, { aiReceivesValue: 750 }, makeTeam(), 12345);
+    const r2 = evaluateCounterOffer(offer, { aiReceivesValue: 750 }, makeTeam(), 12345);
+    expect(r1).toBe(r2);
+  });
+
+  it('returns "reject" when acquisitionValue is 0', () => {
+    const offer = makeOffer({ acquisitionValue: 0 });
+    expect(evaluateCounterOffer(offer, { aiReceivesValue: 0 }, makeTeam(), 42)).toBe('reject');
+  });
+});
+
+// ── getAITradeBlockTargets ────────────────────────────────────────────────────
+
+describe('getAITradeBlockTargets', () => {
+  it('returns [] when userTeam is null', () => {
+    expect(getAITradeBlockTargets(null, [], [], 2025, 5)).toEqual([]);
+  });
+
+  it('returns [] when no block players', () => {
+    const userTeam = makeTeam({ id: 10, isHuman: true });
+    const players  = [makePlayer({ id: 1, teamId: 10, onTradeBlock: false })];
+    const teams    = [userTeam, makeTeam({ id: 5 })];
+    expect(getAITradeBlockTargets(userTeam, players, teams, 2025, 5)).toEqual([]);
+  });
+
+  it('returns [] when no AI teams exist', () => {
+    const userTeam = makeTeam({ id: 10, isHuman: true });
+    const players  = [makePlayer({ id: 1, teamId: 10, onTradeBlock: true })];
+    const teams    = [userTeam]; // no AI teams
+    expect(getAITradeBlockTargets(userTeam, players, teams, 2025, 5)).toEqual([]);
+  });
+
+  it('returns up to 3 AI teams per block player', () => {
+    const userTeam = makeTeam({ id: 10, isHuman: true });
+    const players  = [makePlayer({ id: 1, teamId: 10, onTradeBlock: true })];
+    const aiTeams  = [1, 2, 3, 4, 5].map(id => makeTeam({ id }));
+    const targets  = getAITradeBlockTargets(userTeam, players, [userTeam, ...aiTeams], 2025, 5);
+    expect(targets.length).toBeLessThanOrEqual(3);
+    expect(targets.length).toBeGreaterThan(0);
+  });
+
+  it('each result has { aiTeam, targetPlayerId }', () => {
+    const userTeam = makeTeam({ id: 10 });
+    const players  = [makePlayer({ id: 1, teamId: 10, onTradeBlock: true })];
+    const teams    = [userTeam, makeTeam({ id: 5 }), makeTeam({ id: 6 })];
+    const targets  = getAITradeBlockTargets(userTeam, players, teams, 2025, 5);
+    for (const t of targets) {
+      expect(t).toHaveProperty('aiTeam');
+      expect(t).toHaveProperty('targetPlayerId');
+      expect(t.targetPlayerId).toBe(1);
+    }
+  });
+
+  it('does not include the user\'s own team as a pursuer', () => {
+    const userTeam = makeTeam({ id: 10, isHuman: true });
+    const players  = [makePlayer({ id: 1, teamId: 10, onTradeBlock: true })];
+    const teams    = [userTeam, makeTeam({ id: 5 })];
+    const targets  = getAITradeBlockTargets(userTeam, players, teams, 2025, 5);
+    for (const t of targets) {
+      expect(Number(t.aiTeam.id)).not.toBe(10);
+    }
+  });
+
+  it('is deterministic — same inputs produce same output', () => {
+    const userTeam = makeTeam({ id: 10 });
+    const players  = [makePlayer({ id: 1, teamId: 10, onTradeBlock: true })];
+    const teams    = [userTeam, makeTeam({ id: 5 }), makeTeam({ id: 6 }), makeTeam({ id: 7 })];
+    const r1 = getAITradeBlockTargets(userTeam, players, teams, 2025, 5);
+    const r2 = getAITradeBlockTargets(userTeam, players, teams, 2025, 5);
+    expect(r1.map(t => t.aiTeam.id)).toEqual(r2.map(t => t.aiTeam.id));
+  });
+
+  it('handles multiple block players independently', () => {
+    const userTeam = makeTeam({ id: 10 });
+    const players  = [
+      makePlayer({ id: 1, teamId: 10, pos: 'WR', onTradeBlock: true }),
+      makePlayer({ id: 2, teamId: 10, pos: 'QB', onTradeBlock: true }),
+    ];
+    const teams    = [userTeam, makeTeam({ id: 5 }), makeTeam({ id: 6 }), makeTeam({ id: 7 })];
+    const targets  = getAITradeBlockTargets(userTeam, players, teams, 2025, 5);
+    const ids1     = targets.filter(t => t.targetPlayerId === 1);
+    const ids2     = targets.filter(t => t.targetPlayerId === 2);
+    expect(ids1.length).toBeGreaterThan(0);
+    expect(ids2.length).toBeGreaterThan(0);
+  });
+});
+
+// ── No Math.random guardrail ──────────────────────────────────────────────────
+
+describe('No Math.random guardrail', () => {
+  it('computeAIOfferValue produces consistent values without Math.random', () => {
+    const player = makePlayer({ ovr: 80 });
+    const calls  = Array.from({ length: 10 }, () =>
+      computeAIOfferValue(player, makeTeam(), { positionNeed: 0.5, aggression: 'MEDIUM' }, 42),
+    );
+    expect(new Set(calls).size).toBe(1);
+  });
+
+  it('getAITradeBlockTargets produces consistent ordering without Math.random', () => {
+    const userTeam = makeTeam({ id: 10 });
+    const players  = [makePlayer({ id: 1, teamId: 10, onTradeBlock: true })];
+    const teams    = [userTeam, makeTeam({ id: 5 }), makeTeam({ id: 6 }), makeTeam({ id: 7 })];
+    const results  = Array.from({ length: 5 }, () =>
+      getAITradeBlockTargets(userTeam, players, teams, 2025, 5).map(t => t.aiTeam.id),
+    );
+    const first = JSON.stringify(results[0]);
+    expect(results.every(r => JSON.stringify(r) === first)).toBe(true);
+  });
+});

--- a/src/core/trades/aiTradeEngine.js
+++ b/src/core/trades/aiTradeEngine.js
@@ -1,0 +1,463 @@
+/**
+ * aiTradeEngine.js — AI Trade Block Pursuit Engine
+ *
+ * Pure, deterministic AI trade-pursuit module for players on the user's
+ * trade block (onTradeBlock === true, set by GM or via trade request).
+ *
+ * Design constraints:
+ *  - No I/O, no cache access, no side effects.
+ *  - No imports from worker, UI, news, morale engine, holdout engine,
+ *    HOF engine, coaching engine, FA, scouting, or sim engine.
+ *  - No Math.random — seeded LCG only.
+ *  - Returns new objects — no mutation of inputs.
+ *  - Fully deterministic given same inputs.
+ */
+
+import { getAssetValue } from './assetValuation.js';
+import { computeTradeValueModifier } from './tradeRequestEngine.js';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/**
+ * Base positional need weight used to calibrate how aggressively AI teams
+ * pursue each position. Mirrors POSITION_MARKET_WEIGHTS from assetValuation.js
+ * but scoped to roster-need signals.
+ */
+export const POSITION_NEED_WEIGHT = Object.freeze({
+  QB: 1.5, EDGE: 1.3, DE: 1.25, OT: 1.25, WR: 1.2, CB: 1.2,
+  DL: 1.0, OL: 1.0,  LB: 0.95, S:  0.9,  TE: 0.85, RB: 0.75,
+});
+
+/**
+ * Aggression multipliers — applied to the AI's acquisition target value.
+ * HIGH/MAX cause the AI to outbid the raw market value.
+ */
+export const AI_OFFER_AGGRESSION = Object.freeze({
+  LOW:    0.85,
+  MEDIUM: 0.92,
+  HIGH:   1.02,
+  MAX:    1.10,
+});
+
+// Expected starter count per position (used for depth-gap calculation)
+const STARTERS_COUNT = Object.freeze({
+  QB: 1, WR: 3, TE: 1, RB: 2,
+  OT: 2, OL: 3, OG: 2,
+  DE: 2, DL: 2, EDGE: 2, LB: 3,
+  CB: 2, S: 2,
+});
+
+const STARTER_OVR_THRESHOLD = 70;    // OVR floor for a quality starter
+const BACKUP_OVR_THRESHOLD  = 58;    // Minimum OVR for an AI to include in an offer
+const OFFER_VALIDITY_WEEKS  = 3;     // Offers expire after this many weeks
+const MAX_PURSUERS_PER_PLAYER = 3;   // Max AI teams that can bid on the same player
+
+// Counter-offer decision thresholds
+const COUNTER_ACCEPT_THRESHOLD = 0.90;   // AI accepts if they receive >= 90% of target
+const COUNTER_REJECT_THRESHOLD = 0.60;   // AI hard-rejects below 60%
+const MIN_BUNDLE_FRACTION      = 0.70;   // Don't make an offer if can't hit 70% of target
+
+// ── Seeded LCG ────────────────────────────────────────────────────────────────
+// Numerical Recipes LCG — identical to tradeRequestEngine.js implementation.
+
+function lcgRandom(seed) {
+  const a = 1664525;
+  const c = 1013904223;
+  return ((a * (seed >>> 0) + c) >>> 0) / 0x100000000;
+}
+
+function lcgStep(seed) {
+  return ((1664525 * (seed >>> 0) + 1013904223) >>> 0);
+}
+
+// ── Core: computeAIPositionNeed ───────────────────────────────────────────────
+
+/**
+ * Compute how much an AI team needs a specific position (0–1 scale).
+ * 1.0 = desperate need, 0.1 = already well-stocked.
+ *
+ * @param {object}   aiTeam    – AI team object
+ * @param {string}   targetPos – position string (e.g. 'WR')
+ * @param {object[]} aiPlayers – all players in the league
+ * @returns {number}           – 0–1 need score
+ */
+export function computeAIPositionNeed(aiTeam, targetPos, aiPlayers) {
+  if (!aiTeam || !targetPos || !Array.isArray(aiPlayers)) return 0.5;
+
+  const teamId = Number(aiTeam.id);
+  const posPlayers = aiPlayers.filter(
+    p => Number(p?.teamId) === teamId && p?.pos === targetPos,
+  );
+
+  const starterCount    = posPlayers.filter(p => Number(p.ovr ?? 0) >= STARTER_OVR_THRESHOLD).length;
+  const startersNeeded  = STARTERS_COUNT[targetPos] ?? 1;
+  const baseWeight      = POSITION_NEED_WEIGHT[targetPos] ?? 1.0;
+
+  if (starterCount === 0)              return Math.min(1.0, baseWeight * 1.20);
+  if (starterCount < startersNeeded)   return Math.min(1.0, baseWeight * 0.85);
+  // Has sufficient starters — still interested in upgrading but at a discount
+  return Math.max(0.10, baseWeight * 0.30);
+}
+
+// ── Core: computeAIOfferValue ─────────────────────────────────────────────────
+
+/**
+ * How much value (on the unified scale) is the AI team willing to give up
+ * to acquire targetPlayer?
+ *
+ * The trade block / stonewall modifier is applied first so players on the
+ * block (discounted) attract slightly lower offers.
+ *
+ * @param {object} targetPlayer – player being targeted
+ * @param {object} _aiTeam      – AI team (reserved for future team-direction use)
+ * @param {object} context      – { positionNeed: number, aggression: string }
+ * @param {number} seed         – LCG seed for ±4% variance
+ * @returns {number}
+ */
+export function computeAIOfferValue(targetPlayer, _aiTeam, context = {}, seed = 0) {
+  if (!targetPlayer) return 0;
+
+  const baseValue = getAssetValue(targetPlayer, null, {});
+
+  // Market discount: if player is on block or stonewalled, they cost less
+  const modifier   = computeTradeValueModifier(targetPlayer);
+  const modFactor  = modifier ? (1 + modifier.modifier) : 1.0;
+  const discounted = baseValue * modFactor;
+
+  const positionNeed    = context.positionNeed ?? 0.5;
+  const aggressionKey   = context.aggression   ?? 'MEDIUM';
+  const aggressionFactor = AI_OFFER_AGGRESSION[aggressionKey] ?? AI_OFFER_AGGRESSION.MEDIUM;
+
+  // Need factor: 0.80 at zero need → 1.02 at max need
+  const needFactor = 0.80 + positionNeed * 0.22;
+
+  // Seeded variance: ±4%
+  const variance = 0.96 + lcgRandom(seed) * 0.08;
+
+  return discounted * needFactor * aggressionFactor * variance;
+}
+
+// ── Core: buildAITradeOffer ───────────────────────────────────────────────────
+
+/**
+ * Build a concrete AI trade offer for a player on the user's trade block.
+ *
+ * The AI never offers their depth-rank-1 starter at any position.
+ * Picks are preferred over players (roster-neutral); players fill the gap.
+ * Returns null if the AI cannot assemble a bundle worth ≥ 70% of target.
+ *
+ * @param {object}   targetPlayer – player to acquire
+ * @param {object}   aiTeam       – AI team making the offer
+ * @param {object[]} aiPlayers    – all league players
+ * @param {object[]} aiPicks      – all league draft picks
+ * @param {number}   season       – current season
+ * @param {number}   week         – current week
+ * @param {number}   seed         – deterministic LCG seed
+ * @returns {object|null}         – offer object or null
+ */
+export function buildAITradeOffer(targetPlayer, aiTeam, aiPlayers, aiPicks, season, week, seed) {
+  if (!targetPlayer || !aiTeam) return null;
+
+  const aiTeamId      = Number(aiTeam.id);
+  const allPlayers    = Array.isArray(aiPlayers) ? aiPlayers : [];
+  const aiTeamPlayers = allPlayers.filter(p => Number(p?.teamId) === aiTeamId);
+
+  // Positional need drives aggression
+  const positionNeed = computeAIPositionNeed(aiTeam, targetPlayer.pos, allPlayers);
+
+  let aggressionKey = 'MEDIUM';
+  if      (positionNeed >= 0.90) aggressionKey = 'MAX';
+  else if (positionNeed >= 0.75) aggressionKey = 'HIGH';
+  else if (positionNeed <= 0.25) aggressionKey = 'LOW';
+
+  const acquisitionValue = computeAIOfferValue(targetPlayer, aiTeam, {
+    positionNeed,
+    aggression: aggressionKey,
+  }, seed);
+
+  // Identify non-negotiable starters (best OVR at each position on AI's roster)
+  const bestByPos = {};
+  for (const p of aiTeamPlayers) {
+    const pos = p.pos ?? '';
+    if (!bestByPos[pos] || Number(p.ovr ?? 0) > Number(bestByPos[pos].ovr ?? 0)) {
+      bestByPos[pos] = p;
+    }
+  }
+  const protectedIds = new Set(Object.values(bestByPos).map(p => p.id));
+  protectedIds.add(targetPlayer.id);
+
+  const offerablePlayers = aiTeamPlayers
+    .filter(p => !protectedIds.has(p.id) && Number(p.ovr ?? 0) >= BACKUP_OVR_THRESHOLD)
+    .map(p => ({ ...p, _value: getAssetValue(p, null, {}) }));
+
+  const allPicks     = Array.isArray(aiPicks) ? aiPicks : [];
+  const aiTeamPicks  = allPicks
+    .filter(pk => Number(pk?.currentTeamId ?? pk?.teamId ?? -1) === aiTeamId)
+    .map(pk => ({ ...pk, _value: getAssetValue(pk, null, { currentSeason: season }) }));
+
+  // Build bundle: picks first (best picks), then players (lowest-value first)
+  const sortedPicks   = [...aiTeamPicks].sort((a, b) => b._value - a._value);
+  const sortedPlayers = [...offerablePlayers].sort((a, b) => a._value - b._value);
+
+  let lcgSeed    = lcgStep(seed);
+  const bundlePicks   = [];
+  const bundlePlayers = [];
+  let bundleValue = 0;
+
+  for (const pk of sortedPicks) {
+    if (bundleValue >= acquisitionValue) break;
+    bundlePicks.push(pk);
+    bundleValue += pk._value;
+    lcgSeed = lcgStep(lcgSeed);
+  }
+
+  if (bundleValue < acquisitionValue) {
+    for (const pl of sortedPlayers) {
+      if (bundleValue >= acquisitionValue) break;
+      bundlePlayers.push(pl);
+      bundleValue += pl._value;
+      lcgSeed = lcgStep(lcgSeed);
+    }
+  }
+
+  if (bundleValue < acquisitionValue * MIN_BUNDLE_FRACTION) return null;
+
+  const seedHex = (seed >>> 0).toString(16).padStart(8, '0');
+  const offerId = `ai_${aiTeamId}_${targetPlayer.id}_s${season}w${week}_${seedHex}`;
+
+  return {
+    offerId,
+    aiTeamId,
+    aiTeamName:       aiTeam.name     ?? `Team ${aiTeamId}`,
+    aiTeamAbbrev:     aiTeam.abbrev   ?? aiTeam.name?.slice(0, 3)?.toUpperCase() ?? 'AI',
+    targetPlayerId:   targetPlayer.id,
+    targetPlayerName: targetPlayer.name ?? 'Unknown',
+    targetPlayerPos:  targetPlayer.pos  ?? '??',
+    targetPlayerOvr:  targetPlayer.ovr  ?? 70,
+    offerPlayers:     bundlePlayers.map(({ _value: _v, ...rest }) => rest),
+    offerPicks:       bundlePicks.map(({ _value: _v, ...rest }) => rest),
+    bundleValue:      Math.round(bundleValue),
+    acquisitionValue: Math.round(acquisitionValue),
+    positionNeed,
+    aggression:       aggressionKey,
+    status:           'pending',
+    createdSeason:    season,
+    createdWeek:      week,
+    expiresWeek:      week + OFFER_VALIDITY_WEEKS,
+  };
+}
+
+// ── Core: shouldAIUpdateOffer ─────────────────────────────────────────────────
+
+/**
+ * Returns true if the AI's existing offer should be expired or refreshed
+ * this week (offer is past its expiry window, or from a prior season).
+ *
+ * @param {object} existingOffer – offer from meta.inboundTradeOffers
+ * @param {object} _targetPlayer – reserved for future player-state check
+ * @param {number} season
+ * @param {number} week
+ * @returns {boolean}
+ */
+export function shouldAIUpdateOffer(existingOffer, _targetPlayer, season, week) {
+  if (!existingOffer) return false;
+  if (existingOffer.status !== 'pending') return false;
+
+  // Different season → always expire
+  if (existingOffer.createdSeason !== season) return true;
+
+  const expiry = existingOffer.expiresWeek ?? (existingOffer.createdWeek + OFFER_VALIDITY_WEEKS);
+  return week > expiry;
+}
+
+// ── Core: improveAIOffer ──────────────────────────────────────────────────────
+
+/**
+ * Build an improved version of an existing offer.
+ * Steps aggression up by one level and applies an additional 8% premium
+ * on the acquisition target, then rebuilds the asset bundle.
+ * Returns null if the AI still cannot assemble a sufficient bundle.
+ *
+ * @param {object}   existingOffer
+ * @param {object}   targetPlayer
+ * @param {object}   aiTeam
+ * @param {object[]} aiPlayers
+ * @param {object[]} aiPicks
+ * @param {number}   season
+ * @param {number}   week
+ * @param {number}   seed
+ * @returns {object|null}
+ */
+export function improveAIOffer(existingOffer, targetPlayer, aiTeam, aiPlayers, aiPicks, season, week, seed) {
+  if (!existingOffer || !targetPlayer || !aiTeam) return null;
+  if (existingOffer.status !== 'pending') return null;
+
+  const aiTeamId      = Number(aiTeam.id);
+  const allPlayers    = Array.isArray(aiPlayers) ? aiPlayers : [];
+  const aiTeamPlayers = allPlayers.filter(p => Number(p?.teamId) === aiTeamId);
+
+  const positionNeed = computeAIPositionNeed(aiTeam, targetPlayer.pos, allPlayers);
+
+  // Step up aggression one level
+  const aggressionOrder = ['LOW', 'MEDIUM', 'HIGH', 'MAX'];
+  const prevIdx         = aggressionOrder.indexOf(existingOffer.aggression ?? 'MEDIUM');
+  const newAggressionKey = aggressionOrder[Math.min(prevIdx + 1, aggressionOrder.length - 1)];
+
+  // Base value with improved aggression, then add 8% premium
+  const baseAcq       = computeAIOfferValue(targetPlayer, aiTeam, {
+    positionNeed,
+    aggression: newAggressionKey,
+  }, seed);
+  const acquisitionValue = baseAcq * 1.08;
+
+  // Re-build protected set
+  const bestByPos = {};
+  for (const p of aiTeamPlayers) {
+    const pos = p.pos ?? '';
+    if (!bestByPos[pos] || Number(p.ovr ?? 0) > Number(bestByPos[pos].ovr ?? 0)) {
+      bestByPos[pos] = p;
+    }
+  }
+  const protectedIds = new Set(Object.values(bestByPos).map(p => p.id));
+  protectedIds.add(targetPlayer.id);
+
+  const offerablePlayers = aiTeamPlayers
+    .filter(p => !protectedIds.has(p.id) && Number(p.ovr ?? 0) >= BACKUP_OVR_THRESHOLD)
+    .map(p => ({ ...p, _value: getAssetValue(p, null, {}) }));
+
+  const allPicks    = Array.isArray(aiPicks) ? aiPicks : [];
+  const aiTeamPicks = allPicks
+    .filter(pk => Number(pk?.currentTeamId ?? pk?.teamId ?? -1) === aiTeamId)
+    .map(pk => ({ ...pk, _value: getAssetValue(pk, null, { currentSeason: season }) }));
+
+  const sortedPicks   = [...aiTeamPicks].sort((a, b) => b._value - a._value);
+  const sortedPlayers = [...offerablePlayers].sort((a, b) => a._value - b._value);
+
+  let lcgSeed         = lcgStep(seed);
+  const bundlePicks   = [];
+  const bundlePlayers = [];
+  let bundleValue     = 0;
+
+  for (const pk of sortedPicks) {
+    if (bundleValue >= acquisitionValue) break;
+    bundlePicks.push(pk);
+    bundleValue += pk._value;
+    lcgSeed = lcgStep(lcgSeed);
+  }
+
+  if (bundleValue < acquisitionValue) {
+    for (const pl of sortedPlayers) {
+      if (bundleValue >= acquisitionValue) break;
+      bundlePlayers.push(pl);
+      bundleValue += pl._value;
+      lcgSeed = lcgStep(lcgSeed);
+    }
+  }
+
+  if (bundleValue < acquisitionValue * MIN_BUNDLE_FRACTION) return null;
+
+  const seedHex = (seed >>> 0).toString(16).padStart(8, '0');
+  const offerId = `ai_${aiTeamId}_${targetPlayer.id}_s${season}w${week}_${seedHex}_imp`;
+
+  return {
+    ...existingOffer,
+    offerId,
+    offerPlayers:     bundlePlayers.map(({ _value: _v, ...rest }) => rest),
+    offerPicks:       bundlePicks.map(({ _value: _v, ...rest }) => rest),
+    bundleValue:      Math.round(bundleValue),
+    acquisitionValue: Math.round(acquisitionValue),
+    positionNeed,
+    aggression:       newAggressionKey,
+    status:           'pending',
+    createdSeason:    season,
+    createdWeek:      week,
+    expiresWeek:      week + OFFER_VALIDITY_WEEKS,
+    improved:         true,
+  };
+}
+
+// ── Core: evaluateCounterOffer ────────────────────────────────────────────────
+
+/**
+ * Evaluate a GM's counter offer from the AI team's perspective.
+ *
+ * The worker pre-computes aiReceivesValue and aiGivesValue using
+ * calcAssetBundleValue before calling this — keeps the engine pure.
+ *
+ * Decision logic:
+ *  - accept  if aiReceivesValue >= acquisitionValue × 0.90
+ *  - reject  if aiReceivesValue <  acquisitionValue × 0.60
+ *  - counter otherwise (70% chance), reject (30% chance) — seeded
+ *
+ * @param {object} originalOffer     – the original AI offer object
+ * @param {object} preComputedValues – { aiReceivesValue, aiGivesValue }
+ * @param {object} _aiTeam           – AI team (reserved)
+ * @param {number} seed              – LCG seed
+ * @returns {'accept'|'reject'|'counter'}
+ */
+export function evaluateCounterOffer(originalOffer, preComputedValues, _aiTeam, seed) {
+  if (!originalOffer || !preComputedValues) return 'reject';
+
+  const { aiReceivesValue = 0 } = preComputedValues;
+  const targetValue = originalOffer.acquisitionValue ?? 0;
+
+  if (targetValue <= 0) return 'reject';
+
+  if (aiReceivesValue >= targetValue * COUNTER_ACCEPT_THRESHOLD) return 'accept';
+  if (aiReceivesValue <  targetValue * COUNTER_REJECT_THRESHOLD)  return 'reject';
+
+  // Middle zone: 70% counter, 30% reject
+  return lcgRandom(seed >>> 0) < 0.70 ? 'counter' : 'reject';
+}
+
+// ── Core: getAITradeBlockTargets ──────────────────────────────────────────────
+
+/**
+ * Return AI team / target-player pairings for block pursuit this week.
+ * Up to MAX_PURSUERS_PER_PLAYER AI teams per block player, seeded so the
+ * same week always yields the same pursuit list.
+ *
+ * @param {object}   userTeam    – user's team object
+ * @param {object[]} userPlayers – all league players (filtered internally)
+ * @param {object[]} allTeams    – all league teams
+ * @param {number}   season
+ * @param {number}   week
+ * @returns {{ aiTeam: object, targetPlayerId: number|string }[]}
+ */
+export function getAITradeBlockTargets(userTeam, userPlayers, allTeams, season, week) {
+  if (!userTeam || !Array.isArray(userPlayers) || !Array.isArray(allTeams)) return [];
+
+  const userTeamId  = Number(userTeam.id);
+  const blockPlayers = userPlayers.filter(
+    p => Number(p?.teamId) === userTeamId && p?.onTradeBlock === true,
+  );
+
+  if (blockPlayers.length === 0) return [];
+
+  const aiTeams = allTeams.filter(t => Number(t.id) !== userTeamId && t.isHuman !== true);
+  if (aiTeams.length === 0) return [];
+
+  const results = [];
+
+  for (const player of blockPlayers) {
+    // Unique seed per player × season × week
+    let lcgSeed = ((Number(player.id ?? 0) * 1000 + Number(season ?? 0) * 100 + Number(week ?? 0)) >>> 0);
+
+    // Fisher-Yates shuffle of AI teams using seeded LCG
+    const shuffled = [...aiTeams];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      lcgSeed   = lcgStep(lcgSeed);
+      const j   = Math.floor(lcgRandom(lcgSeed) * (i + 1));
+      const tmp = shuffled[i];
+      shuffled[i] = shuffled[j];
+      shuffled[j] = tmp;
+    }
+
+    const count = Math.min(MAX_PURSUERS_PER_PLAYER, shuffled.length);
+    for (let k = 0; k < count; k++) {
+      results.push({ aiTeam: shuffled[k], targetPlayerId: player.id });
+    }
+  }
+
+  return results;
+}

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -610,6 +610,43 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
         );
       })()}
 
+      {/* ── INBOUND TRADE BLOCK OFFERS badge ────────────────────────────── */}
+      {(() => {
+        const inboundOffers = Array.isArray(league?.inboundTradeOffers) ? league.inboundTradeOffers : [];
+        if (inboundOffers.length === 0) return null;
+        return (
+          <div
+            style={{
+              margin: '4px 12px',
+              padding: '6px var(--space-4)',
+              border: '1px solid rgba(10,132,255,0.35)',
+              background: 'rgba(10,132,255,0.07)',
+              borderRadius: 'var(--radius-md)',
+              fontSize: 'var(--text-xs)',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+            }}
+            data-testid="hq-inbound-trade-offers-badge"
+          >
+            <span style={{ fontWeight: 700, color: '#0A84FF' }}>Trade Block</span>
+            <span style={{ color: 'var(--text-muted)' }}>
+              {inboundOffers.length} inbound {inboundOffers.length === 1 ? 'offer' : 'offers'} — review in Trade Center
+            </span>
+            {typeof onNavigate === 'function' && (
+              <button
+                type="button"
+                className="btn btn-sm"
+                style={{ marginLeft: 'auto', color: '#0A84FF', borderColor: 'rgba(10,132,255,0.35)', fontSize: 'var(--text-xs)', padding: '2px 8px' }}
+                onClick={() => onNavigate('Trade')}
+              >
+                View
+              </button>
+            )}
+          </div>
+        );
+      })()}
+
       {/* ── COLLAPSED DRAWER: secondary content ─────────────────────────── */}
       <details className="hq-more-drawer" data-testid="hq-more-drawer">
         <summary className="hq-more-drawer__trigger">Season Pulse &amp; More ▾</summary>

--- a/src/ui/components/TradeCenter.jsx
+++ b/src/ui/components/TradeCenter.jsx
@@ -417,6 +417,10 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
   const [previewPlayer, setPreviewPlayer] = useState(null);
   const [showSavedToast, setShowSavedToast] = useState(false);
   const incomingOffers = useMemo(() => Array.isArray(league?.incomingTradeOffers) ? league.incomingTradeOffers : [], [league?.incomingTradeOffers]);
+  const inboundOffers  = useMemo(() => Array.isArray(league?.inboundTradeOffers)  ? league.inboundTradeOffers  : [], [league?.inboundTradeOffers]);
+  const [blockCounterOfferId, setBlockCounterOfferId] = useState(null);
+  const [blockCounterResult, setBlockCounterResult]   = useState(null);
+  const [blockAction, setBlockAction]                 = useState(null); // 'accepting' | 'countering' | null
   const lastAppliedSeedRef = useRef(null);
 
   const otherTeams = useMemo(() => (league?.teams ?? []).filter(t => t.id !== myTeamId).sort((a, b) => a.name.localeCompare(b.name)), [league?.teams, myTeamId]);
@@ -680,6 +684,59 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
     await fetchRosters(targetId);
   };
 
+  const handleAcceptBlockOffer = async (offer) => {
+    if (!offer?.offerId || tradeLocked || !actions?.acceptTradeOffer) return;
+    if (blockAction) return;
+    setBlockAction('accepting');
+    try {
+      const resp = await actions.acceptTradeOffer(offer.offerId);
+      setBlockCounterResult(resp?.payload ?? { accepted: true });
+      setBlockCounterOfferId(null);
+    } catch (e) {
+      console.error(e);
+      setBlockCounterResult({ accepted: false, reason: 'Trade failed.' });
+    } finally {
+      setBlockAction(null);
+    }
+  };
+
+  const handleRejectBlockOffer = async (offer) => {
+    if (!offer?.offerId || !actions?.rejectTradeOffer) return;
+    setBlockAction('rejecting_' + offer.offerId);
+    try {
+      await actions.rejectTradeOffer(offer.offerId);
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setBlockAction(null);
+    }
+  };
+
+  const handleCounterBlockOffer = async (offer) => {
+    if (!offer?.offerId || tradeLocked) return;
+    setBlockCounterOfferId(offer.offerId);
+    setBlockCounterResult(null);
+  };
+
+  const handleSubmitBlockCounter = async (offer) => {
+    if (!offer?.offerId || !actions?.counterTradeOffer) return;
+    setBlockAction('countering');
+    try {
+      // Counter: user keeps target player, but offers a different bundle
+      // For simplicity in the counter flow we send the same original bundle back
+      // (the full counter UI with asset pickers is in the dedicated counter modal)
+      const counterPlayerIds = [Number(offer.targetPlayerId)];
+      const resp = await actions.counterTradeOffer(offer.offerId, counterPlayerIds, []);
+      setBlockCounterResult(resp?.payload ?? { accepted: false, counterStatus: 'unknown' });
+      setBlockCounterOfferId(null);
+    } catch (e) {
+      console.error(e);
+      setBlockCounterResult({ accepted: false, reason: 'Counter failed.' });
+    } finally {
+      setBlockAction(null);
+    }
+  };
+
   return (
     <div className="app-screen-stack">
     <ScreenHeader
@@ -815,6 +872,71 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
                 );
               })()
             ))}
+          </div>
+        </div>
+      )}
+      {/* ── Inbound Trade Block Offers ── */}
+      {inboundOffers.length > 0 && (
+        <div className="card" style={{ marginBottom: "var(--space-4)", padding: "var(--space-4) var(--space-5)" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+            <strong style={{ fontSize: "var(--text-sm)" }}>Trade block offers</strong>
+            <Badge variant="outline" style={{ background: "rgba(10,132,255,0.12)", borderColor: "rgba(10,132,255,0.4)", color: "var(--accent)" }}>
+              {inboundOffers.length} inbound
+            </Badge>
+          </div>
+          {blockCounterResult && (
+            <div style={{ marginBottom: 8, padding: "8px 10px", borderRadius: "var(--radius-md)", fontSize: "var(--text-xs)", background: blockCounterResult.accepted ? "rgba(52,199,89,0.1)" : "rgba(255,69,58,0.08)", border: `1px solid ${blockCounterResult.accepted ? "rgba(52,199,89,0.4)" : "rgba(255,69,58,0.4)"}`, color: blockCounterResult.accepted ? "var(--success)" : "var(--danger)" }}>
+              {blockCounterResult.accepted
+                ? `Trade completed! ${blockCounterResult.reason ?? ''}`
+                : `${blockCounterResult.counterStatus === 'counter' ? 'Team improved their offer — check below.' : blockCounterResult.reason ?? 'Offer rejected.'}`}
+              <button style={{ marginLeft: 8, background: "none", border: "none", cursor: "pointer", color: "var(--text-muted)", fontSize: "var(--text-xs)" }} onClick={() => setBlockCounterResult(null)}>✕</button>
+            </div>
+          )}
+          <div style={{ display: "grid", gap: 8 }}>
+            {inboundOffers.slice(0, 5).map(offer => {
+              const isCountering = blockCounterOfferId === offer.offerId;
+              return (
+                <div key={offer.offerId} style={{ border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "10px 12px", display: "grid", gap: 6 }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                    <strong style={{ fontSize: "var(--text-sm)" }}>
+                      {offer.aiTeamName} — {offer.targetPlayerName} ({offer.targetPlayerPos}, {offer.targetPlayerOvr} OVR)
+                    </strong>
+                    <Badge variant="outline" style={{ fontSize: 10 }}>{offer.aggression}</Badge>
+                  </div>
+                  <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
+                    They offer: {[
+                      ...(offer.offerPlayers ?? []).map(p => `${p.name ?? 'Player'} (${p.pos ?? '?'}, ${p.ovr ?? '?'})`),
+                      ...(offer.offerPicks ?? []).map(pk => `Rd ${pk.round ?? '?'} pick`),
+                    ].join(', ') || 'No assets listed'}
+                  </div>
+                  <div style={{ display: "flex", gap: "var(--space-2)", fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>
+                    <span>Bundle value: <strong>{(offer.bundleValue ?? 0).toLocaleString()}</strong></span>
+                    <span>·</span>
+                    <span>Offer value: <strong>{(offer.acquisitionValue ?? 0).toLocaleString()}</strong></span>
+                    <span>·</span>
+                    <span>Wk {offer.createdWeek} → Wk {offer.expiresWeek}</span>
+                  </div>
+                  {isCountering && (
+                    <div style={{ padding: "8px 10px", border: "1px solid var(--accent)", borderRadius: "var(--radius-md)", background: "rgba(10,132,255,0.06)", fontSize: "var(--text-xs)" }}>
+                      <div style={{ marginBottom: 6, color: "var(--text-muted)" }}>Counter mode — submit with current target player for a quick counter, or open Trade Builder to customize your bundle.</div>
+                      <div style={{ display: "flex", gap: 6 }}>
+                        <Button size="sm" disabled={blockAction === 'countering'} onClick={() => handleSubmitBlockCounter(offer)}>{blockAction === 'countering' ? "Sending…" : "Quick Counter"}</Button>
+                        <Button size="sm" variant="outline" onClick={() => { setTargetId(Number(offer.aiTeamId)); setBlockCounterOfferId(null); }}>Open Builder</Button>
+                        <Button size="sm" variant="ghost" onClick={() => setBlockCounterOfferId(null)}>Cancel</Button>
+                      </div>
+                    </div>
+                  )}
+                  {!isCountering && (
+                    <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+                      <Button size="sm" disabled={tradeLocked || blockAction === 'accepting'} onClick={() => handleAcceptBlockOffer(offer)}>{blockAction === 'accepting' ? "Accepting…" : "Accept"}</Button>
+                      <Button size="sm" variant="secondary" disabled={!!blockAction} onClick={() => handleRejectBlockOffer(offer)}>Reject</Button>
+                      <Button size="sm" variant="outline" disabled={tradeLocked} onClick={() => handleCounterBlockOffer(offer)}>Counter</Button>
+                      <Button size="sm" variant="outline" onClick={() => setTargetId(Number(offer.aiTeamId))}>Open Team</Button>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
           </div>
         </div>
       )}

--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -673,6 +673,17 @@ export function useWorker() {
       request(toWorker.STONEWALL_TRADE_REQUEST, { playerId }),
     offerExtensionToWithdraw: (playerId) =>
       request(toWorker.OFFER_EXTENSION_TO_WITHDRAW, { playerId }),
+    // AI Trade Block Marketplace
+    acceptTradeOffer: (offerId) =>
+      request(toWorker.ACCEPT_TRADE_OFFER, { offerId }),
+    rejectTradeOffer: (offerId) =>
+      request(toWorker.REJECT_TRADE_OFFER, { offerId }),
+    counterTradeOffer: (offerId, counterPlayers, counterPicks) =>
+      request(toWorker.COUNTER_TRADE_OFFER, { offerId, counterPlayers, counterPicks }),
+    initiateTradeBlock: (playerId) =>
+      request(toWorker.INITIATE_TRADE_BLOCK, { playerId }),
+    removeFromTradeBlock: (playerId) =>
+      request(toWorker.REMOVE_FROM_TRADE_BLOCK, { playerId }),
     assignMentor: (mentorId, menteeId, teamId) =>
       request(toWorker.ASSIGN_MENTOR, { mentorId, menteeId, teamId }, { silent: true }),
 

--- a/src/worker/protocol.js
+++ b/src/worker/protocol.js
@@ -72,6 +72,12 @@ export const toWorker = Object.freeze({
   STONEWALL_TRADE_REQUEST:      'STONEWALL_TRADE_REQUEST',      // { playerId }
   OFFER_EXTENSION_TO_WITHDRAW:  'OFFER_EXTENSION_TO_WITHDRAW',  // { playerId }
   ASSIGN_MENTOR: 'ASSIGN_MENTOR', // { mentorId, menteeId, teamId }
+  // AI Trade Block Marketplace
+  ACCEPT_TRADE_OFFER:      'ACCEPT_TRADE_OFFER',      // { offerId }
+  REJECT_TRADE_OFFER:      'REJECT_TRADE_OFFER',      // { offerId }
+  COUNTER_TRADE_OFFER:     'COUNTER_TRADE_OFFER',     // { offerId, counterPlayers, counterPicks }
+  INITIATE_TRADE_BLOCK:    'INITIATE_TRADE_BLOCK',    // { playerId }
+  REMOVE_FROM_TRADE_BLOCK: 'REMOVE_FROM_TRADE_BLOCK', // { playerId }
 
   /** Contracts */
   GET_EXTENSION_ASK:  'GET_EXTENSION_ASK', // { playerId }

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -200,6 +200,13 @@ import { derivePlayerVisibleRatingsPatch } from './playerDerivedRatings.js';
 import { evaluateRetirements }     from '../core/retirement-system.js';
 import { runAIToAITrades, evaluateCounterOffer } from '../core/trade-logic.js';
 import { generateInboundOffersToUser } from '../core/trades/tradeBlockGenerator.js';
+import {
+  buildAITradeOffer,
+  getAITradeBlockTargets,
+  shouldAIUpdateOffer,
+  improveAIOffer,
+  evaluateCounterOffer as evaluateAIBlockCounterOffer,
+} from '../core/trades/aiTradeEngine.js';
 import { processSeasonRecords, createEmptyRecords, getMostPlayedTeam } from '../core/records.js';
 import { ensureLeagueMemoryMeta, buildSeasonArchiveSummary, updateFranchiseHistory, updateRecordBook, evaluateHallOfFameCandidate, addHallOfFameClass, buildSeasonStorylineSnapshot, buildHallOfFameInducteeRow, syncHallOfFameAfterRecordBook } from '../core/league-memory.js';
 import { buildPlayerSeasonStatsArchiveRows } from '../core/playerSeasonStatsArchive.js';
@@ -1102,6 +1109,7 @@ function buildViewState() {
     newsItems: Array.isArray(meta?.newsItems) ? meta.newsItems : [],
     ownerGoals: Array.isArray(meta?.ownerGoals) ? meta.ownerGoals : [],
     incomingTradeOffers: Array.isArray(meta?.incomingTradeOffers) ? meta.incomingTradeOffers : [],
+    inboundTradeOffers: (Array.isArray(meta?.inboundTradeOffers) ? meta.inboundTradeOffers : []).filter(o => o?.status === 'pending'),
     lastTradeActivityWeek: Number(meta?.lastTradeActivityWeek ?? 0),
     retiredPlayers: Array.isArray(meta?.retiredPlayers) ? meta.retiredPlayers : [],
     records: meta?.records ?? null,
@@ -3278,6 +3286,103 @@ async function handleAdvanceWeek(payload, id) {
     } catch (tradeErr) {
       // Trade engine errors should never crash the week advance.
       console.warn('[Worker] AI trade engine error (non-fatal):', tradeErr.message);
+    }
+
+    // ── AI Trade Block Marketplace pursuit ──────────────────────────────────
+    // Generate / refresh inbound offers for user's trade-block players.
+    try {
+      const blockMeta      = ensureDynastyMeta(cache.getMeta());
+      const blockSeason    = blockMeta.currentSeasonId ?? blockMeta.season ?? 0;
+      const blockWeek      = Number(blockMeta.currentWeek ?? 0);
+      const allTeams       = cache.getAllTeams();
+      const allPlayers     = cache.getAllPlayers();
+      const userTeamId     = Number(blockMeta.userTeamId);
+      const userTeam       = cache.getTeam(userTeamId);
+
+      if (userTeam) {
+        const allPicks      = Array.isArray(blockMeta.draftPicks) ? blockMeta.draftPicks : [];
+        const existingOffers = Array.isArray(blockMeta.inboundTradeOffers) ? blockMeta.inboundTradeOffers : [];
+
+        // Expire stale pending offers
+        const liveOffers = existingOffers.filter(o => {
+          if (o.status !== 'pending') return true; // keep non-pending (accepted/rejected)
+          return !shouldAIUpdateOffer(o, null, blockSeason, blockWeek);
+        });
+
+        // Get AI teams that should pursue block players this week
+        const pursuits = getAITradeBlockTargets(userTeam, allPlayers, allTeams, blockSeason, blockWeek);
+
+        const newOffers   = [];
+        const pulseItems  = [];
+
+        for (const { aiTeam, targetPlayerId } of pursuits) {
+          const targetPlayer = cache.getPlayer(Number(targetPlayerId));
+          if (!targetPlayer?.onTradeBlock) continue;
+
+          // Check if this AI team already has a pending offer for this player
+          const existing = liveOffers.find(
+            o => o.status === 'pending' && Number(o.aiTeamId) === Number(aiTeam.id) && Number(o.targetPlayerId) === Number(targetPlayerId),
+          );
+
+          const seed = ((Number(aiTeam.id) * 9973 + Number(targetPlayerId) * 1009 + blockSeason * 17 + blockWeek * 3) >>> 0);
+
+          if (existing) {
+            // Optionally improve the offer
+            const improved = improveAIOffer(existing, targetPlayer, aiTeam, allPlayers, allPicks, blockSeason, blockWeek, seed);
+            if (improved) {
+              const idx = liveOffers.indexOf(existing);
+              liveOffers[idx] = improved;
+            }
+          } else {
+            const offer = buildAITradeOffer(targetPlayer, aiTeam, allPlayers, allPicks, blockSeason, blockWeek, seed);
+            if (offer) newOffers.push(offer);
+          }
+        }
+
+        // Add new offers (cap at 12 pending total)
+        const combined = [...liveOffers, ...newOffers];
+        const pendingCount = combined.filter(o => o.status === 'pending').length;
+        const capped = pendingCount > 12
+          ? [...combined.filter(o => o.status !== 'pending'), ...combined.filter(o => o.status === 'pending').slice(0, 12)]
+          : combined;
+
+        if (newOffers.length > 0) {
+          for (const offer of newOffers) {
+            NewsEngine.logNews(
+              'TRADE_BLOCK_OFFER',
+              `${offer.aiTeamAbbrev} interested in ${offer.targetPlayerName} — inbound offer received`,
+              userTeamId,
+              { offerId: offer.offerId, aiTeamId: offer.aiTeamId, playerId: offer.targetPlayerId },
+            );
+          }
+
+          // League pulse: buzz when 2+ teams are pursuing the same player
+          const blockPlayers = allPlayers.filter(p => Number(p?.teamId) === userTeamId && p?.onTradeBlock);
+          for (const bp of blockPlayers) {
+            const pursuersCount = capped.filter(o => o.status === 'pending' && Number(o.targetPlayerId) === Number(bp.id)).length;
+            if (pursuersCount >= 2) {
+              pulseItems.push({
+                id:       `trade_buzz_${bp.id}_s${blockSeason}w${blockWeek}`,
+                type:     'trade_market',
+                headline: `${pursuersCount} teams pursuing ${bp.name ?? 'trade block player'}`,
+                body:     `Multiple franchises have submitted offers for ${bp.name ?? 'a trade block player'} (${bp.pos ?? '??'}, OVR ${bp.ovr ?? '?'}).`,
+                week:     blockWeek,
+                season:   blockSeason,
+                teamId:   userTeamId,
+              });
+            }
+          }
+        }
+
+        const metaUpdate = { inboundTradeOffers: capped };
+        if (pulseItems.length > 0) {
+          const freshMeta   = ensureDynastyMeta(cache.getMeta());
+          metaUpdate.leaguePulse = mergeLeaguePulseItems(freshMeta.leaguePulse ?? [], pulseItems);
+        }
+        cache.setMeta(metaUpdate);
+      }
+    } catch (blockErr) {
+      console.warn('[Worker] AI trade block marketplace error (non-fatal):', blockErr.message);
     }
   }
 
@@ -9833,6 +9938,244 @@ async function handleOfferExtensionToWithdraw({ playerId }, id) {
   post(toUI.STATE_UPDATE, { ...buildViewState(), extensionRedirect: { playerId: numericId } }, id);
 }
 
+// ── Handler: INITIATE_TRADE_BLOCK ─────────────────────────────────────────────
+
+async function handleInitiateTradeBlock({ playerId }, id) {
+  const numericId = Number(playerId);
+  const player    = cache.getPlayer(numericId);
+  if (!player) { post(toUI.ERROR, { message: 'Player not found' }, id); return; }
+
+  const meta    = ensureDynastyMeta(cache.getMeta());
+  const userTeamId = Number(meta.userTeamId);
+  if (Number(player.teamId) !== userTeamId) {
+    post(toUI.ERROR, { message: 'Player is not on your roster' }, id);
+    return;
+  }
+
+  cache.updatePlayer(numericId, { onTradeBlock: true });
+  await flushDirty();
+  post(toUI.STATE_UPDATE, buildViewState(), id);
+}
+
+// ── Handler: REMOVE_FROM_TRADE_BLOCK ─────────────────────────────────────────
+
+async function handleRemoveFromTradeBlock({ playerId }, id) {
+  const numericId = Number(playerId);
+  const player    = cache.getPlayer(numericId);
+  if (!player) { post(toUI.ERROR, { message: 'Player not found' }, id); return; }
+
+  const meta    = ensureDynastyMeta(cache.getMeta());
+  const userTeamId = Number(meta.userTeamId);
+  if (Number(player.teamId) !== userTeamId) {
+    post(toUI.ERROR, { message: 'Player is not on your roster' }, id);
+    return;
+  }
+
+  cache.updatePlayer(numericId, { onTradeBlock: false });
+
+  // Expire any pending inbound offers for this player
+  const existing = Array.isArray(meta.inboundTradeOffers) ? meta.inboundTradeOffers : [];
+  const updated  = existing.map(o =>
+    o.status === 'pending' && Number(o.targetPlayerId) === numericId
+      ? { ...o, status: 'expired' }
+      : o,
+  );
+  cache.setMeta({ inboundTradeOffers: updated });
+
+  await flushDirty();
+  post(toUI.STATE_UPDATE, buildViewState(), id);
+}
+
+// ── Handler: ACCEPT_TRADE_OFFER ───────────────────────────────────────────────
+
+async function handleAcceptTradeOffer({ offerId }, id) {
+  const latestMeta = ensureDynastyMeta(cache.getMeta());
+
+  const deadline = getTradeDeadlineSnapshot(latestMeta);
+  if (!isTradeWindowOpen({ week: deadline.currentWeek, phase: deadline.phase, settings: latestMeta?.settings, commissionerMode: deadline.canOverride })) {
+    post(toUI.TRADE_RESPONSE, { accepted: false, rejectionType: 'deadline', reason: `Trade deadline passed after Week ${deadline.deadlineWeek}.` }, id);
+    return;
+  }
+
+  const offers  = Array.isArray(latestMeta.inboundTradeOffers) ? latestMeta.inboundTradeOffers : [];
+  const offer   = offers.find(o => o?.offerId === offerId && o?.status === 'pending');
+  if (!offer) {
+    post(toUI.TRADE_RESPONSE, { accepted: false, reason: 'Offer expired or no longer available.' }, id);
+    return;
+  }
+
+  const userTeamId  = Number(latestMeta.userTeamId);
+  const aiTeamId    = Number(offer.aiTeamId);
+
+  // Build offering/receiving bundles
+  const offerPlayerIds = (offer.offerPlayers ?? []).map(p => Number(p.id));
+  const offerPickIds   = (offer.offerPicks   ?? []).map(p => String(p.id));
+
+  const offering  = { playerIds: offerPlayerIds,           pickIds: offerPickIds };           // AI gives
+  const receiving = { playerIds: [Number(offer.targetPlayerId)], pickIds: [] };                // AI gets
+
+  const legality = evaluateTradeLegality({
+    fromTeamId: userTeamId,
+    toTeamId:   aiTeamId,
+    offering:   receiving,   // user gives target player
+    receiving:  offering,    // user gets AI's bundle
+    phase:      latestMeta?.phase,
+  });
+  if (!legality.ok) {
+    post(toUI.TRADE_RESPONSE, { accepted: false, rejectionType: 'cap', reason: legality.reason }, id);
+    return;
+  }
+
+  // Execute: user gives the target player, receives the AI bundle
+  await executeAcceptedTrade({
+    fromTeamId: userTeamId,
+    toTeamId:   aiTeamId,
+    offering:   receiving,    // user gives
+    receiving:  offering,     // user gets
+  });
+
+  // Mark offer accepted
+  const updatedOffers = offers.map(o => o.offerId === offerId ? { ...o, status: 'accepted' } : o);
+  cache.setMeta({ inboundTradeOffers: updatedOffers });
+
+  await flushDirty();
+  post(toUI.TRADE_RESPONSE, { accepted: true, reason: 'Trade completed.' }, id);
+  post(toUI.STATE_UPDATE, buildViewState(), id);
+}
+
+// ── Handler: REJECT_TRADE_OFFER ───────────────────────────────────────────────
+
+async function handleRejectTradeOffer({ offerId }, id) {
+  const latestMeta = ensureDynastyMeta(cache.getMeta());
+  const offers     = Array.isArray(latestMeta.inboundTradeOffers) ? latestMeta.inboundTradeOffers : [];
+  const offer      = offers.find(o => o?.offerId === offerId && o?.status === 'pending');
+  if (!offer) {
+    post(toUI.TRADE_RESPONSE, { accepted: false, reason: 'Offer not found.' }, id);
+    return;
+  }
+
+  const updatedOffers = offers.map(o => o.offerId === offerId ? { ...o, status: 'rejected' } : o);
+  cache.setMeta({ inboundTradeOffers: updatedOffers });
+  await flushDirty();
+  post(toUI.TRADE_RESPONSE, { accepted: false, reason: 'Offer rejected.' }, id);
+  post(toUI.STATE_UPDATE, buildViewState(), id);
+}
+
+// ── Handler: COUNTER_TRADE_OFFER ──────────────────────────────────────────────
+
+async function handleCounterTradeOffer({ offerId, counterPlayers, counterPicks }, id) {
+  const latestMeta = ensureDynastyMeta(cache.getMeta());
+
+  const deadline = getTradeDeadlineSnapshot(latestMeta);
+  if (!isTradeWindowOpen({ week: deadline.currentWeek, phase: deadline.phase, settings: latestMeta?.settings, commissionerMode: deadline.canOverride })) {
+    post(toUI.TRADE_RESPONSE, { accepted: false, rejectionType: 'deadline', reason: `Trade deadline passed after Week ${deadline.deadlineWeek}.` }, id);
+    return;
+  }
+
+  const offers = Array.isArray(latestMeta.inboundTradeOffers) ? latestMeta.inboundTradeOffers : [];
+  const offer  = offers.find(o => o?.offerId === offerId && o?.status === 'pending');
+  if (!offer) {
+    post(toUI.TRADE_RESPONSE, { accepted: false, reason: 'Offer expired or no longer available.' }, id);
+    return;
+  }
+
+  const userTeamId = Number(latestMeta.userTeamId);
+  const aiTeamId   = Number(offer.aiTeamId);
+  const aiTeam     = cache.getTeam(aiTeamId);
+
+  // What the AI receives in the counter (user's proposed bundle)
+  const counterPlayerIds = Array.isArray(counterPlayers) ? counterPlayers.map(Number) : [Number(offer.targetPlayerId)];
+  const counterPickIds   = Array.isArray(counterPicks)   ? counterPicks.map(String)  : [];
+  const userBundle = { playerIds: counterPlayerIds, pickIds: counterPickIds };
+
+  // What the AI gives in the original offer
+  const aiBundle = {
+    playerIds: (offer.offerPlayers ?? []).map(p => Number(p.id)),
+    pickIds:   (offer.offerPicks   ?? []).map(p => String(p.id)),
+  };
+
+  // Pre-compute values for the pure evaluator
+  const valContext = {
+    week:          Number(latestMeta?.currentWeek ?? 1),
+    currentSeason: latestMeta?.year ?? latestMeta?.currentSeasonId ?? 0,
+  };
+  const aiReceivesValue = calcAssetBundleValue(userBundle, valContext);
+  const aiGivesValue    = calcAssetBundleValue(aiBundle,   valContext);
+
+  const seed   = ((Number(aiTeamId) * 7001 + Number(offer.targetPlayerId) * 3017 + Number(latestMeta?.currentWeek ?? 0)) >>> 0);
+  const result = evaluateAIBlockCounterOffer(offer, { aiReceivesValue, aiGivesValue }, aiTeam, seed);
+
+  if (result === 'accept') {
+    const legality = evaluateTradeLegality({
+      fromTeamId: userTeamId,
+      toTeamId:   aiTeamId,
+      offering:   userBundle,
+      receiving:  aiBundle,
+      phase:      latestMeta?.phase,
+    });
+    if (!legality.ok) {
+      post(toUI.TRADE_RESPONSE, { accepted: false, rejectionType: 'cap', reason: legality.reason }, id);
+      return;
+    }
+
+    await executeAcceptedTrade({
+      fromTeamId: userTeamId,
+      toTeamId:   aiTeamId,
+      offering:   userBundle,
+      receiving:  aiBundle,
+    });
+    const updatedOffers = offers.map(o => o.offerId === offerId ? { ...o, status: 'accepted' } : o);
+    cache.setMeta({ inboundTradeOffers: updatedOffers });
+    await flushDirty();
+    post(toUI.TRADE_RESPONSE, { accepted: true, counterStatus: 'accept', reason: 'Counter accepted — trade completed.' }, id);
+    post(toUI.STATE_UPDATE, buildViewState(), id);
+    return;
+  }
+
+  if (result === 'counter') {
+    // Build an improved offer as the AI's counter-counter
+    const allPlayers = cache.getAllPlayers();
+    const allPicks   = Array.isArray(latestMeta.draftPicks) ? latestMeta.draftPicks : [];
+    const season     = latestMeta.currentSeasonId ?? latestMeta.season ?? 0;
+    const week       = Number(latestMeta.currentWeek ?? 0);
+    const targetPlayer = cache.getPlayer(Number(offer.targetPlayerId));
+
+    const improved = aiTeam && targetPlayer
+      ? improveAIOffer(offer, targetPlayer, aiTeam, allPlayers, allPicks, season, week, seed)
+      : null;
+
+    const updatedOffers = offers.map(o => {
+      if (o.offerId !== offerId) return o;
+      return improved
+        ? { ...improved, offerId: o.offerId }   // keep same offerId so UI can track it
+        : { ...o, lastCounterResponse: 'counter', counterWeek: week };
+    });
+    cache.setMeta({ inboundTradeOffers: updatedOffers });
+    await flushDirty();
+    post(toUI.TRADE_RESPONSE, {
+      accepted: false,
+      counterStatus: 'counter',
+      reason: 'The team came back with an improved offer.',
+      offerValue:   Math.round(aiReceivesValue),
+      receiveValue: Math.round(aiGivesValue),
+    }, id);
+    post(toUI.STATE_UPDATE, buildViewState(), id);
+    return;
+  }
+
+  // reject
+  const updatedOffers = offers.map(o => o.offerId === offerId ? { ...o, status: 'rejected' } : o);
+  cache.setMeta({ inboundTradeOffers: updatedOffers });
+  await flushDirty();
+  post(toUI.TRADE_RESPONSE, {
+    accepted: false,
+    counterStatus: 'reject',
+    reason: 'The team rejected the counter offer.',
+    offerValue: Math.round(aiReceivesValue),
+  }, id);
+  post(toUI.STATE_UPDATE, buildViewState(), id);
+}
+
 
 async function handleAssignMentor({ mentorId, menteeId, teamId }, id) {
   const team = cache.getTeam(teamId);
@@ -13055,6 +13398,12 @@ async function handleMessage(event) {
       case toWorker.STONEWALL_TRADE_REQUEST:     return await handleStonewallTradeRequest(payload, id);
       case toWorker.OFFER_EXTENSION_TO_WITHDRAW: return await handleOfferExtensionToWithdraw(payload, id);
       case toWorker.ASSIGN_MENTOR: return await handleAssignMentor(payload, id);
+      // AI Trade Block Marketplace
+      case toWorker.ACCEPT_TRADE_OFFER:      return await handleAcceptTradeOffer(payload, id);
+      case toWorker.REJECT_TRADE_OFFER:      return await handleRejectTradeOffer(payload, id);
+      case toWorker.COUNTER_TRADE_OFFER:     return await handleCounterTradeOffer(payload, id);
+      case toWorker.INITIATE_TRADE_BLOCK:    return await handleInitiateTradeBlock(payload, id);
+      case toWorker.REMOVE_FROM_TRADE_BLOCK: return await handleRemoveFromTradeBlock(payload, id);
       case toWorker.GET_EXTENSION_ASK:  return await handleGetExtensionAsk(payload, id);
       case toWorker.EXTEND_CONTRACT:      return await handleExtendContract(payload, id);
       case toWorker.RESTRUCTURE_CONTRACT:     return await handleRestructureContract(payload, id);


### PR DESCRIPTION
Adds a full AI-driven trade pursuit engine that generates inbound offers
for any player the GM places on the trade block (GM-initiated or via
trade request honor).

Core engine (aiTradeEngine.js):
- Pure deterministic module — seeded LCG only, no Math.random, no I/O
- computeAIPositionNeed: depth-gap analysis per position (0–1 scale)
- computeAIOfferValue: unified asset scale with block/stonewall discounts
- buildAITradeOffer: assembles picks-first bundle, protects rank-1 starters
- evaluateCounterOffer: accept/reject/counter with pre-computed values
- getAITradeBlockTargets: seeded Fisher-Yates, up to 3 pursuers per player
- shouldAIUpdateOffer / improveAIOffer: offer refresh/improvement lifecycle

Worker wiring:
- Weekly AI pursuit pass in handleAdvanceWeek (regular season only)
- meta.inboundTradeOffers schema (separate from existing incomingTradeOffers)
- 5 new message handlers: ACCEPT/REJECT/COUNTER_TRADE_OFFER, INITIATE/REMOVE_FROM_TRADE_BLOCK
- League pulse items when 2+ teams pursue same block player
- inboundTradeOffers (pending only) exposed in buildViewState

UI:
- TradeCenter: Inbound Trade Block Offers panel with accept/reject/counter
- FranchiseHQ: inbound offer count badge linking to Trade Center
- useWorker: 5 new action methods wired to new protocol types

Tests: 52 new unit tests covering all engine functions + guardrails