### PR TITLE
feat(draft): Draft Combine & Prospect Discovery Engine

### DIFF
--- a/src/core/draft/__tests__/combineEngine.unit.test.js
+++ b/src/core/draft/__tests__/combineEngine.unit.test.js
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  getPositionGroup,
+  generateCombineMetrics,
+  computeCombineGrade,
+  generateCombineMetricsForClass,
+  applyPrivateWorkout,
+  getAIDraftBoardAdjustment,
+  COMBINE_GRADE_THRESHOLDS,
+} from '../combineEngine.js';
+
+function makeProspect(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Test Player',
+    pos: 'WR',
+    age: 22,
+    ovr: 75,
+    trueOvr: 75,
+    scoutedRanges: {},
+    combineMetrics: null,
+    workoutCompleted: false,
+    ratings: {
+      speed: 70,
+      agility: 70,
+      acceleration: 70,
+      runBlock: 50,
+      passRushPower: 50,
+      trucking: 50,
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getPositionGroup
+// ---------------------------------------------------------------------------
+describe('getPositionGroup', () => {
+  it('returns "speed" for WR', () => {
+    expect(getPositionGroup('WR')).toBe('speed');
+  });
+
+  it('returns "speed" for CB', () => {
+    expect(getPositionGroup('CB')).toBe('speed');
+  });
+
+  it('returns "big_skill" for QB', () => {
+    expect(getPositionGroup('QB')).toBe('big_skill');
+  });
+
+  it('returns "linemen" for OL', () => {
+    expect(getPositionGroup('OL')).toBe('linemen');
+  });
+
+  it('returns "linemen" for DE', () => {
+    expect(getPositionGroup('DE')).toBe('linemen');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateCombineMetrics
+// ---------------------------------------------------------------------------
+describe('generateCombineMetrics', () => {
+  it('forty time in [4.28, 4.38] for WR with speed >= 90 (elite tier)', () => {
+    const prospect = makeProspect({
+      pos: 'WR',
+      ratings: { speed: 92, agility: 70, acceleration: 70, runBlock: 50, passRushPower: 50, trucking: 50 },
+    });
+    const metrics = generateCombineMetrics(prospect, 2024);
+    expect(metrics.fortyYardDash).toBeGreaterThanOrEqual(4.28);
+    expect(metrics.fortyYardDash).toBeLessThanOrEqual(4.38);
+  });
+
+  it('forty time in [5.25, 5.55] for OL with speed < 40 (below tier for linemen)', () => {
+    const prospect = makeProspect({
+      pos: 'OL',
+      ratings: { speed: 30, agility: 30, acceleration: 30, runBlock: 50, passRushPower: 50, trucking: 50 },
+    });
+    const metrics = generateCombineMetrics(prospect, 2024);
+    expect(metrics.fortyYardDash).toBeGreaterThanOrEqual(5.25);
+    expect(metrics.fortyYardDash).toBeLessThanOrEqual(5.55);
+  });
+
+  it('bench reps in [30, 40] for OL with strength (runBlock) >= 90 (elite)', () => {
+    const prospect = makeProspect({
+      pos: 'OL',
+      ratings: { speed: 50, agility: 50, acceleration: 50, runBlock: 92, passRushPower: 60, trucking: 60 },
+    });
+    const metrics = generateCombineMetrics(prospect, 2024);
+    expect(metrics.benchPressReps).toBeGreaterThanOrEqual(30);
+    expect(metrics.benchPressReps).toBeLessThanOrEqual(40);
+  });
+
+  it('bench reps in [5, 12] for WR with all strength attrs < 50 (below tier)', () => {
+    const prospect = makeProspect({
+      pos: 'WR',
+      ratings: { speed: 70, agility: 70, acceleration: 70, runBlock: 40, passRushPower: 40, trucking: 40 },
+    });
+    const metrics = generateCombineMetrics(prospect, 2024);
+    expect(metrics.benchPressReps).toBeGreaterThanOrEqual(5);
+    expect(metrics.benchPressReps).toBeLessThanOrEqual(12);
+  });
+
+  it('is deterministic — same prospect + same season yields identical metrics', () => {
+    const prospect = makeProspect({ id: 42, trueOvr: 80 });
+    const first  = generateCombineMetrics(prospect, 2025);
+    const second = generateCombineMetrics(prospect, 2025);
+    expect(first).toEqual(second);
+  });
+
+  it('does not call Math.random', () => {
+    const spy = vi.spyOn(Math, 'random');
+    const prospect = makeProspect({ id: 7, trueOvr: 77 });
+    generateCombineMetrics(prospect, 2025);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeCombineGrade
+// ---------------------------------------------------------------------------
+describe('computeCombineGrade', () => {
+  it('returns a value in [0, 10] for speed group metrics', () => {
+    const metrics = { fortyYardDash: 4.50, threeCone: 6.90, benchPressReps: 15, verticalJump: 32 };
+    const grade = computeCombineGrade(metrics, 'WR');
+    expect(grade).toBeGreaterThanOrEqual(0);
+    expect(grade).toBeLessThanOrEqual(10);
+  });
+
+  it('returns a value in [0, 10] for big_skill group metrics', () => {
+    const metrics = { fortyYardDash: 4.75, threeCone: 7.10, benchPressReps: 18, verticalJump: 30 };
+    const grade = computeCombineGrade(metrics, 'QB');
+    expect(grade).toBeGreaterThanOrEqual(0);
+    expect(grade).toBeLessThanOrEqual(10);
+  });
+
+  it('returns a value in [0, 10] for linemen group metrics', () => {
+    const metrics = { fortyYardDash: 5.00, threeCone: 7.60, benchPressReps: 25, verticalJump: 28 };
+    const grade = computeCombineGrade(metrics, 'OL');
+    expect(grade).toBeGreaterThanOrEqual(0);
+    expect(grade).toBeLessThanOrEqual(10);
+  });
+
+  it('returns a higher grade for elite metrics than below metrics for the same position', () => {
+    const eliteMetrics = { fortyYardDash: 4.28, threeCone: 6.45, benchPressReps: 40, verticalJump: 45 };
+    const belowMetrics = { fortyYardDash: 4.78, threeCone: 7.50, benchPressReps: 5,  verticalJump: 18 };
+    const eliteGrade = computeCombineGrade(eliteMetrics, 'WR');
+    const belowGrade = computeCombineGrade(belowMetrics, 'WR');
+    expect(eliteGrade).toBeGreaterThan(belowGrade);
+  });
+
+  it('returns >= 9.5 when all metrics are at elite tier top for WR', () => {
+    const eliteMetricsWR = { fortyYardDash: 4.28, threeCone: 6.45, benchPressReps: 40, verticalJump: 45 };
+    expect(computeCombineGrade(eliteMetricsWR, 'WR')).toBeGreaterThanOrEqual(9.5);
+  });
+
+  it('returns <= 0.5 when all metrics are at below tier bottom for WR', () => {
+    const belowMetricsWR = { fortyYardDash: 4.78, threeCone: 7.50, benchPressReps: 5, verticalJump: 18 };
+    expect(computeCombineGrade(belowMetricsWR, 'WR')).toBeLessThanOrEqual(0.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateCombineMetricsForClass
+// ---------------------------------------------------------------------------
+describe('generateCombineMetricsForClass', () => {
+  it('does not re-generate metrics for a prospect that already has combineMetrics', () => {
+    const existingMetrics = {
+      fortyYardDash: 4.40,
+      threeCone: 6.70,
+      benchPressReps: 22,
+      verticalJump: 35,
+      combineGrade: 7.5,
+      generatedAt: 'combine_week',
+    };
+    const prospect = makeProspect({ combineMetrics: existingMetrics });
+    const [result] = generateCombineMetricsForClass([prospect], 2025);
+    expect(result.combineMetrics).toBe(existingMetrics); // strict reference equality — not re-created
+  });
+
+  it('does not mutate the input array', () => {
+    const prospect = makeProspect({ combineMetrics: null });
+    const original = [prospect];
+    const copy = [...original];
+    generateCombineMetricsForClass(original, 2025);
+    expect(original).toHaveLength(copy.length);
+    expect(original[0]).toBe(prospect); // original element reference unchanged
+    expect(prospect.combineMetrics).toBeNull(); // original prospect object not mutated
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyPrivateWorkout
+// ---------------------------------------------------------------------------
+describe('applyPrivateWorkout', () => {
+  it('sets workoutCompleted to true', () => {
+    const prospect = makeProspect({ trueOvr: 80 });
+    const result = applyPrivateWorkout(prospect, 'team_1', 2025);
+    expect(result.workoutCompleted).toBe(true);
+  });
+
+  it('sets scoutedRange with low === high === trueOvr, confidence === 1.0, label === "Verified"', () => {
+    const prospect = makeProspect({ trueOvr: 82 });
+    const result = applyPrivateWorkout(prospect, 'team_2', 2025);
+    const range = result.scoutedRanges['team_2'];
+    expect(range).toBeDefined();
+    expect(range.low).toBe(82);
+    expect(range.high).toBe(82);
+    expect(range.confidence).toBe(1.0);
+    expect(range.label).toBe('Verified');
+  });
+
+  it('does not mutate the input prospect', () => {
+    const prospect = makeProspect({ trueOvr: 78 });
+    const originalWorkoutCompleted = prospect.workoutCompleted;
+    const originalScoutedRanges = { ...prospect.scoutedRanges };
+    applyPrivateWorkout(prospect, 'team_3', 2025);
+    expect(prospect.workoutCompleted).toBe(originalWorkoutCompleted);
+    expect(prospect.scoutedRanges).toEqual(originalScoutedRanges);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAIDraftBoardAdjustment
+// ---------------------------------------------------------------------------
+describe('getAIDraftBoardAdjustment', () => {
+  it('returns { slots: 15, reason: "athletic_freak" } for combineGrade > 8.5', () => {
+    const prospect = makeProspect({ combineMetrics: { combineGrade: 9.0 } });
+    expect(getAIDraftBoardAdjustment(prospect)).toEqual({ slots: 15, reason: 'athletic_freak' });
+  });
+
+  it('returns { slots: -15, reason: "combine_bust" } for combineGrade < 4.0', () => {
+    const prospect = makeProspect({ combineMetrics: { combineGrade: 3.0 } });
+    expect(getAIDraftBoardAdjustment(prospect)).toEqual({ slots: -15, reason: 'combine_bust' });
+  });
+
+  it('returns { slots: 0, reason: "none" } for combineGrade in [4.0, 8.5]', () => {
+    const prospect = makeProspect({ combineMetrics: { combineGrade: 6.0 } });
+    expect(getAIDraftBoardAdjustment(prospect)).toEqual({ slots: 0, reason: 'none' });
+  });
+
+  it('returns { slots: 0, reason: "none" } when combineMetrics is null', () => {
+    const prospect = makeProspect({ combineMetrics: null });
+    expect(getAIDraftBoardAdjustment(prospect)).toEqual({ slots: 0, reason: 'none' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// COMBINE_GRADE_THRESHOLDS — exported constant sanity check
+// ---------------------------------------------------------------------------
+describe('COMBINE_GRADE_THRESHOLDS', () => {
+  it('exports athletic_freak threshold of 8.5', () => {
+    expect(COMBINE_GRADE_THRESHOLDS.athletic_freak).toBe(8.5);
+  });
+
+  it('exports bust threshold of 4.0', () => {
+    expect(COMBINE_GRADE_THRESHOLDS.bust).toBe(4.0);
+  });
+});

--- a/src/core/draft/combineEngine.js
+++ b/src/core/draft/combineEngine.js
@@ -1,0 +1,218 @@
+/**
+ * combineEngine.js
+ * Pure, deterministic combine and private workout simulation for the NFL Draft.
+ * Uses LCG-based seeding — no Math.random.
+ */
+
+export const POSITION_ATHLETIC_PROFILES = {
+  speed: {
+    positions: ['WR', 'CB', 'RB', 'S'],
+    fortyYardDash: {
+      elite:   { attr_min: 90, range: [4.28, 4.38] },
+      good:    { attr_min: 75, range: [4.38, 4.50] },
+      average: { attr_min: 55, range: [4.50, 4.62] },
+      below:   { attr_min: 0,  range: [4.62, 4.78] },
+    },
+    threeCone: {
+      elite:   { attr_min: 90, range: [6.45, 6.65] },
+      good:    { attr_min: 75, range: [6.65, 6.90] },
+      average: { attr_min: 55, range: [6.90, 7.15] },
+      below:   { attr_min: 0,  range: [7.15, 7.50] },
+    },
+  },
+  big_skill: {
+    positions: ['QB', 'TE', 'LB', 'OLB'],
+    fortyYardDash: {
+      elite:   { attr_min: 85, range: [4.50, 4.62] },
+      good:    { attr_min: 70, range: [4.62, 4.75] },
+      average: { attr_min: 50, range: [4.75, 4.90] },
+      below:   { attr_min: 0,  range: [4.90, 5.10] },
+    },
+    threeCone: {
+      elite:   { attr_min: 85, range: [6.70, 6.90] },
+      good:    { attr_min: 70, range: [6.90, 7.10] },
+      average: { attr_min: 50, range: [7.10, 7.35] },
+      below:   { attr_min: 0,  range: [7.35, 7.70] },
+    },
+  },
+  linemen: {
+    positions: ['OL', 'DL', 'DE', 'NT', 'C', 'G', 'T'],
+    fortyYardDash: {
+      elite:   { attr_min: 75, range: [4.78, 4.92] },
+      good:    { attr_min: 60, range: [4.92, 5.08] },
+      average: { attr_min: 40, range: [5.08, 5.25] },
+      below:   { attr_min: 0,  range: [5.25, 5.55] },
+    },
+    threeCone: {
+      elite:   { attr_min: 75, range: [7.20, 7.50] },
+      good:    { attr_min: 60, range: [7.50, 7.80] },
+      average: { attr_min: 40, range: [7.80, 8.20] },
+      below:   { attr_min: 0,  range: [8.20, 8.70] },
+    },
+  },
+};
+
+export const BENCH_PRESS_PROFILE = {
+  elite:   { attr_min: 90, range: [30, 40] },
+  good:    { attr_min: 70, range: [20, 30] },
+  average: { attr_min: 50, range: [12, 20] },
+  below:   { attr_min: 0,  range: [5, 12] },
+};
+
+export const VERTICAL_JUMP_PROFILE = {
+  elite:   { attr_min: 90, range: [38, 45] },
+  good:    { attr_min: 70, range: [32, 38] },
+  average: { attr_min: 50, range: [26, 32] },
+  below:   { attr_min: 0,  range: [18, 26] },
+};
+
+export const COMBINE_GRADE_THRESHOLDS = {
+  athletic_freak: 8.5,
+  bust: 4.0,
+};
+
+function lcgStep(seed) {
+  const next = (seed * 1664525 + 1013904223) >>> 0;
+  return { value: next / 0x100000000, nextSeed: next };
+}
+
+function combineSeed(a, b, c) {
+  return ((a * 2654435761 + b * 40503 + c * 12345) >>> 0);
+}
+
+export function getPositionGroup(position) {
+  const pos = String(position).toUpperCase();
+  if (['WR', 'CB', 'RB', 'S'].includes(pos)) return 'speed';
+  if (['QB', 'TE', 'LB', 'OLB'].includes(pos)) return 'big_skill';
+  return 'linemen';
+}
+
+function pickTierValue(attr, profile, lcgValue) {
+  const tiers = ['elite', 'good', 'average', 'below'];
+  for (const tier of tiers) {
+    if (attr >= profile[tier].attr_min) {
+      const [lo, hi] = profile[tier].range;
+      return lo + lcgValue * (hi - lo);
+    }
+  }
+  const [lo, hi] = profile.below.range;
+  return lo + lcgValue * (hi - lo);
+}
+
+export function generateCombineMetrics(prospect, season) {
+  const group = getPositionGroup(prospect.pos);
+  const profile = POSITION_ATHLETIC_PROFILES[group];
+
+  const speedAttr     = prospect.ratings?.speed ?? 70;
+  const agilityAttr   = prospect.ratings?.agility ?? 70;
+  const strengthAttr  = prospect.ratings?.runBlock ?? prospect.ratings?.passRushPower ?? prospect.ratings?.trucking ?? 50;
+  const explosionAttr = prospect.ratings?.agility ?? prospect.ratings?.acceleration ?? 60;
+
+  const prospectId = Number(prospect.id) || 0;
+  const trueOvr    = prospect.trueOvr ?? prospect.ovr ?? 60;
+  const baseSeed   = combineSeed(prospectId, trueOvr, season);
+
+  const { value: v0 } = lcgStep((baseSeed ^ 0) >>> 0);
+  const { value: v1 } = lcgStep((baseSeed ^ 1) >>> 0);
+  const { value: v2 } = lcgStep((baseSeed ^ 2) >>> 0);
+  const { value: v3 } = lcgStep((baseSeed ^ 3) >>> 0);
+
+  const fortyRaw   = pickTierValue(speedAttr, profile.fortyYardDash, v0);
+  const threeConeRaw = pickTierValue(agilityAttr, profile.threeCone, v1);
+  const benchRaw   = pickTierValue(strengthAttr, BENCH_PRESS_PROFILE, v2);
+  const verticalRaw = pickTierValue(explosionAttr, VERTICAL_JUMP_PROFILE, v3);
+
+  const fortyYardDash  = Math.round(fortyRaw * 100) / 100;
+  const threeCone      = Math.round(threeConeRaw * 100) / 100;
+  const benchPressReps = Math.round(benchRaw);
+  const verticalJump   = Math.round(verticalRaw * 10) / 10;
+
+  const metrics = { fortyYardDash, threeCone, benchPressReps, verticalJump };
+  const combineGrade = computeCombineGrade(metrics, prospect.pos);
+
+  return {
+    fortyYardDash,
+    threeCone,
+    benchPressReps,
+    verticalJump,
+    combineGrade,
+    generatedAt: 'combine_week',
+  };
+}
+
+export function computeCombineGrade(metrics, position) {
+  const group = getPositionGroup(position);
+
+  const fortyFullRanges = {
+    speed:     { worst: 4.78, best: 4.28 },
+    big_skill: { worst: 5.10, best: 4.50 },
+    linemen:   { worst: 5.55, best: 4.78 },
+  };
+  const threeConeFullRanges = {
+    speed:     { worst: 7.50, best: 6.45 },
+    big_skill: { worst: 7.70, best: 6.70 },
+    linemen:   { worst: 8.70, best: 7.20 },
+  };
+
+  const fortyRange     = fortyFullRanges[group];
+  const threeConeRange = threeConeFullRanges[group];
+
+  const fortyPct     = Math.min(1, Math.max(0, (fortyRange.worst - metrics.fortyYardDash) / (fortyRange.worst - fortyRange.best)));
+  const threeConePct = Math.min(1, Math.max(0, (threeConeRange.worst - metrics.threeCone) / (threeConeRange.worst - threeConeRange.best)));
+  const benchPct     = Math.min(1, Math.max(0, (metrics.benchPressReps - 5) / (40 - 5)));
+  const verticalPct  = Math.min(1, Math.max(0, (metrics.verticalJump - 18) / (45 - 18)));
+
+  let weights;
+  if (group === 'speed') {
+    weights = { forty: 0.40, threeCone: 0.30, vertical: 0.20, bench: 0.10 };
+  } else if (group === 'big_skill') {
+    weights = { forty: 0.30, threeCone: 0.30, vertical: 0.25, bench: 0.15 };
+  } else {
+    weights = { bench: 0.40, forty: 0.25, threeCone: 0.20, vertical: 0.15 };
+  }
+
+  const grade =
+    fortyPct     * weights.forty +
+    threeConePct * weights.threeCone +
+    verticalPct  * weights.vertical +
+    benchPct     * weights.bench;
+
+  return Math.min(10, Math.max(0, grade * 10));
+}
+
+export function generateCombineMetricsForClass(prospects, season) {
+  return prospects.map((prospect) => {
+    if (prospect.combineMetrics !== null && prospect.combineMetrics !== undefined) {
+      return prospect;
+    }
+    const combineMetrics = generateCombineMetrics(prospect, season);
+    return { ...prospect, combineMetrics };
+  });
+}
+
+export function applyPrivateWorkout(prospect, teamId, season) {
+  const trueOvr = prospect.trueOvr ?? prospect.ovr ?? 60;
+  const existingRanges = prospect.scoutedRanges ?? {};
+  return {
+    ...prospect,
+    workoutCompleted: true,
+    scoutedRanges: {
+      ...existingRanges,
+      [teamId]: { low: trueOvr, high: trueOvr, confidence: 1.0, label: 'Verified' },
+    },
+  };
+}
+
+export function getAIDraftBoardAdjustment(prospect) {
+  if (prospect.combineMetrics === null || prospect.combineMetrics === undefined) {
+    return { slots: 0, reason: 'none' };
+  }
+  const grade = prospect.combineMetrics.combineGrade;
+  if (grade > COMBINE_GRADE_THRESHOLDS.athletic_freak) {
+    return { slots: 15, reason: 'athletic_freak' };
+  }
+  if (grade < COMBINE_GRADE_THRESHOLDS.bust) {
+    return { slots: -15, reason: 'combine_bust' };
+  }
+  return { slots: 0, reason: 'none' };
+}

--- a/src/ui/components/CombineDashboard.jsx
+++ b/src/ui/components/CombineDashboard.jsx
@@ -1,0 +1,356 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { toWorker } from '../../worker/protocol.js';
+
+const NUM_TEAMS = 32;
+const MAX_ROUND = 7;
+
+function computePercentileCutoffs(prospects, metric, higherIsBetter) {
+  const values = prospects
+    .map((p) => p.combineMetrics?.[metric])
+    .filter((v) => v != null && Number.isFinite(Number(v)))
+    .map(Number)
+    .sort((a, b) => a - b);
+
+  if (values.length === 0) return { top: null, bottom: null };
+
+  const cutoffIndex = Math.max(0, Math.ceil(values.length * 0.1) - 1);
+
+  if (higherIsBetter) {
+    return {
+      top: values[values.length - 1 - cutoffIndex],
+      bottom: values[cutoffIndex],
+    };
+  } else {
+    return {
+      top: values[cutoffIndex],
+      bottom: values[values.length - 1 - cutoffIndex],
+    };
+  }
+}
+
+function getMetricColor(value, cutoffs, higherIsBetter) {
+  if (value == null || cutoffs.top == null) return undefined;
+  const v = Number(value);
+  if (higherIsBetter) {
+    if (v >= cutoffs.top) return 'var(--color-success, #34C759)';
+    if (v <= cutoffs.bottom) return 'var(--danger, #FF453A)';
+  } else {
+    if (v <= cutoffs.top) return 'var(--color-success, #34C759)';
+    if (v >= cutoffs.bottom) return 'var(--danger, #FF453A)';
+  }
+  return undefined;
+}
+
+function gradeColor(grade) {
+  if (grade == null) return undefined;
+  if (grade > 8.5) return 'rgba(52,199,89,0.1)';
+  if (grade < 4.0) return 'rgba(255,69,58,0.1)';
+  return undefined;
+}
+
+function gradeHighlight(grade) {
+  if (grade == null) return 'normal';
+  if (grade > 8.5) return 'freak';
+  if (grade < 4.0) return 'bust';
+  return 'normal';
+}
+
+function projRound(rankIndex) {
+  return Math.min(MAX_ROUND, Math.max(1, Math.ceil((rankIndex + 1) / NUM_TEAMS)));
+}
+
+const SORT_COLS = ['name', 'pos', 'projRound', 'fortyYardDash', 'benchPressReps', 'combineGrade'];
+
+function getSortValue(prospect, rankIndex, col) {
+  switch (col) {
+    case 'name': return prospect.name ?? '';
+    case 'pos': return prospect.pos ?? '';
+    case 'projRound': return rankIndex;
+    case 'fortyYardDash': return prospect.combineMetrics?.fortyYardDash ?? Infinity;
+    case 'benchPressReps': return prospect.combineMetrics?.benchPressReps ?? -Infinity;
+    case 'combineGrade': return prospect.combineMetrics?.combineGrade ?? -Infinity;
+    default: return 0;
+  }
+}
+
+export default function CombineDashboard({ prospects = [], combineInvitesLeft = 0, lastWorkoutCard = null, actions }) {
+  const [sortBy, setSortBy] = useState('combineGrade');
+  const [sortDir, setSortDir] = useState('desc');
+  const [showCard, setShowCard] = useState(false);
+  const [cardText, setCardText] = useState('');
+
+  useEffect(() => {
+    if (!lastWorkoutCard) return;
+    setCardText(lastWorkoutCard);
+    setShowCard(true);
+    const timer = window.setTimeout(() => setShowCard(false), 6000);
+    return () => window.clearTimeout(timer);
+  }, [lastWorkoutCard]);
+
+  const fortyCutoffs = useMemo(() => computePercentileCutoffs(prospects, 'fortyYardDash', false), [prospects]);
+  const benchCutoffs = useMemo(() => computePercentileCutoffs(prospects, 'benchPressReps', true), [prospects]);
+  const gradeCutoffs = useMemo(() => computePercentileCutoffs(prospects, 'combineGrade', true), [prospects]);
+
+  const indexedProspects = useMemo(
+    () => prospects.map((p, i) => ({ prospect: p, originalIndex: i })),
+    [prospects],
+  );
+
+  const sorted = useMemo(() => {
+    const copy = [...indexedProspects];
+    copy.sort((a, b) => {
+      const av = getSortValue(a.prospect, a.originalIndex, sortBy);
+      const bv = getSortValue(b.prospect, b.originalIndex, sortBy);
+      if (typeof av === 'string') {
+        return sortDir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av);
+      }
+      return sortDir === 'asc' ? av - bv : bv - av;
+    });
+    return copy;
+  }, [indexedProspects, sortBy, sortDir]);
+
+  function handleSort(col) {
+    if (sortBy === col) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortBy(col);
+      setSortDir(col === 'fortyYardDash' ? 'asc' : 'desc');
+    }
+  }
+
+  async function handleInvite(prospectId) {
+    if (actions?.runCombineWorkout) {
+      try {
+        const result = await actions.runCombineWorkout(prospectId);
+        const card = result?.payload?.performanceCard;
+        if (card) {
+          setCardText(card);
+          setShowCard(true);
+          window.setTimeout(() => setShowCard(false), 6000);
+        }
+      } catch (_e) { /* error already surfaced by worker */ }
+    } else {
+      actions?.send?.(toWorker.RUN_COMBINE_WORKOUT, { prospectId });
+    }
+  }
+
+  const invitesLeft = Number.isFinite(combineInvitesLeft) ? combineInvitesLeft : 0;
+  const hasInvites = invitesLeft > 0;
+
+  const headerAmber = hasInvites;
+  const headerBg = headerAmber ? 'rgba(255,159,10,0.07)' : 'rgba(142,142,147,0.07)';
+  const headerBorder = headerAmber ? '1px solid rgba(255,159,10,0.5)' : '1px solid rgba(142,142,147,0.3)';
+  const headerLeftBorder = headerAmber ? '3px solid var(--warning, #FF9F0A)' : '3px solid var(--text-muted)';
+  const headerColor = headerAmber ? 'var(--warning, #FF9F0A)' : 'var(--text-muted)';
+
+  const thStyle = {
+    padding: '6px var(--space-3)',
+    fontSize: 'var(--text-xs)',
+    color: 'var(--text-muted)',
+    fontWeight: 600,
+    textAlign: 'left',
+    cursor: 'pointer',
+    userSelect: 'none',
+    whiteSpace: 'nowrap',
+    borderBottom: '1px solid var(--hairline)',
+    background: 'none',
+    border: 'none',
+    width: '100%',
+  };
+
+  return (
+    <div style={{ padding: '0 12px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {/* Header status card */}
+      <div
+        data-testid={headerAmber ? 'combine-header-amber' : 'combine-header-muted'}
+        style={{
+          padding: 'var(--space-3) var(--space-4)',
+          background: headerBg,
+          border: headerBorder,
+          borderLeft: headerLeftBorder,
+          borderRadius: 'var(--radius-md)',
+          fontSize: 'var(--text-sm)',
+        }}
+      >
+        <strong style={{ display: 'block', color: headerColor, marginBottom: 2 }}>
+          Draft Combine Week is Active
+        </strong>
+        <span style={{ color: 'var(--text-muted)', fontSize: 'var(--text-xs)' }}>
+          Invites Remaining: {invitesLeft} / 6
+        </span>
+      </div>
+
+      {/* Performance card toast */}
+      {showCard && (
+        <div
+          data-testid="combine-performance-card"
+          style={{
+            padding: 'var(--space-3) var(--space-4)',
+            background: 'rgba(52,199,89,0.08)',
+            border: '1px solid rgba(52,199,89,0.3)',
+            borderRadius: 'var(--radius-md)',
+            fontSize: 'var(--text-sm)',
+          }}
+        >
+          ✅ {cardText}
+        </div>
+      )}
+
+      {/* Prospect combine table */}
+      <div
+        data-testid="combine-prospect-table"
+        style={{
+          overflowX: 'auto',
+          borderRadius: 'var(--radius-md)',
+          border: '1px solid var(--hairline)',
+        }}
+      >
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 'var(--text-xs)' }}>
+          <thead>
+            <tr>
+              {[
+                { col: 'name', label: 'Name' },
+                { col: 'pos', label: 'Pos' },
+                { col: 'projRound', label: 'Proj. Round' },
+                { col: 'fortyYardDash', label: '40-Yard' },
+                { col: 'benchPressReps', label: 'Bench Reps' },
+                { col: 'combineGrade', label: 'Grade' },
+                { col: null, label: 'Action' },
+              ].map(({ col, label }) => (
+                <th
+                  key={label}
+                  style={{
+                    padding: '6px var(--space-3)',
+                    fontSize: 'var(--text-xs)',
+                    color: col && sortBy === col ? 'var(--text)' : 'var(--text-muted)',
+                    fontWeight: 600,
+                    textAlign: 'left',
+                    whiteSpace: 'nowrap',
+                    borderBottom: '1px solid var(--hairline)',
+                    cursor: col ? 'pointer' : 'default',
+                    userSelect: 'none',
+                    background: 'var(--surface, transparent)',
+                  }}
+                  onClick={col ? () => handleSort(col) : undefined}
+                >
+                  {label}
+                  {col && sortBy === col ? (sortDir === 'asc' ? ' ▲' : ' ▼') : ''}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map(({ prospect, originalIndex }, sortedIndex) => {
+              const m = prospect.combineMetrics;
+              const grade = m?.combineGrade ?? null;
+              const forty = m?.fortyYardDash ?? null;
+              const bench = m?.benchPressReps ?? null;
+              const rowBg = gradeColor(grade);
+              const highlight = gradeHighlight(grade);
+              const round = projRound(originalIndex);
+
+              const fortyColor = forty != null ? getMetricColor(forty, fortyCutoffs, false) : undefined;
+              const benchColor = bench != null ? getMetricColor(bench, benchCutoffs, true) : undefined;
+
+              return (
+                <tr
+                  key={prospect.id}
+                  data-testid={`combine-row-${prospect.id}`}
+                  data-highlight={highlight}
+                  style={{
+                    background: rowBg,
+                    borderBottom: '1px solid var(--hairline)',
+                  }}
+                >
+                  <td style={{ padding: '5px var(--space-3)', color: 'var(--text)', fontWeight: 500 }}>
+                    {prospect.name ?? '—'}
+                  </td>
+                  <td style={{ padding: '5px var(--space-3)', color: 'var(--text-muted)' }}>
+                    {prospect.pos ?? '—'}
+                  </td>
+                  <td style={{ padding: '5px var(--space-3)', color: 'var(--text-muted)' }}>
+                    R{round}
+                  </td>
+                  <td style={{ padding: '5px var(--space-3)', color: fortyColor ?? 'var(--text)' }}>
+                    {forty != null ? forty : '—'}
+                  </td>
+                  <td style={{ padding: '5px var(--space-3)', color: benchColor ?? 'var(--text)' }}>
+                    {bench != null ? bench : '—'}
+                  </td>
+                  <td style={{ padding: '5px var(--space-3)', color: 'var(--text)' }}>
+                    {grade != null ? grade.toFixed(1) : '—'}
+                  </td>
+                  <td
+                    data-testid={`combine-action-${prospect.id}`}
+                    style={{ padding: '5px var(--space-3)', whiteSpace: 'nowrap' }}
+                  >
+                    {prospect.workoutCompleted ? (
+                      <span
+                        data-testid={`combine-verified-${prospect.id}`}
+                        style={{
+                          color: 'var(--color-success, #34C759)',
+                          fontWeight: 600,
+                          fontSize: 'var(--text-xs)',
+                        }}
+                      >
+                        Verified (OVR: {prospect.trueOvr})
+                      </span>
+                    ) : hasInvites ? (
+                      <button
+                        type="button"
+                        data-testid={`combine-invite-btn-${prospect.id}`}
+                        onClick={() => handleInvite(prospect.id)}
+                        style={{
+                          fontSize: 'var(--text-xs)',
+                          padding: '3px 8px',
+                          borderRadius: 'var(--radius-sm, 4px)',
+                          border: '1px solid rgba(10,132,255,0.5)',
+                          background: 'rgba(10,132,255,0.08)',
+                          color: '#0A84FF',
+                          cursor: 'pointer',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        Invite to Private Workout
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        data-testid={`combine-invite-disabled-${prospect.id}`}
+                        disabled
+                        title="No invites remaining"
+                        style={{
+                          fontSize: 'var(--text-xs)',
+                          padding: '3px 8px',
+                          borderRadius: 'var(--radius-sm, 4px)',
+                          border: '1px solid var(--hairline)',
+                          background: 'transparent',
+                          color: 'var(--text-muted)',
+                          cursor: 'not-allowed',
+                          opacity: 0.5,
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        Invite to Private Workout
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+            {sorted.length === 0 && (
+              <tr>
+                <td
+                  colSpan={7}
+                  style={{ padding: 'var(--space-3)', color: 'var(--text-muted)', textAlign: 'center', fontSize: 'var(--text-xs)' }}
+                >
+                  No prospects available.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/CombineDashboard.test.jsx
+++ b/src/ui/components/CombineDashboard.test.jsx
@@ -1,0 +1,211 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import CombineDashboard from './CombineDashboard.jsx';
+
+function makeProspect(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Test Player',
+    pos: 'WR',
+    workoutCompleted: false,
+    combineMetrics: {
+      fortyYardDash: 4.45,
+      benchPressReps: 18,
+      combineGrade: 6.5,
+      threeCone: 6.85,
+      verticalJump: 34,
+    },
+    ...overrides,
+  };
+}
+
+function makeActions(overrides = {}) {
+  return {
+    send: vi.fn(),
+    runCombineWorkout: vi.fn(),
+    ...overrides,
+  };
+}
+
+afterEach(cleanup);
+
+// ── 1. Header shows amber styling when invites remain ─────────────────────────
+
+describe('CombineDashboard header', () => {
+  it('shows amber header when combineInvitesLeft > 0', () => {
+    render(
+      <CombineDashboard
+        prospects={[makeProspect()]}
+        combineInvitesLeft={6}
+        actions={makeActions()}
+      />,
+    );
+    expect(screen.queryByTestId('combine-header-amber')).not.toBeNull();
+    expect(screen.queryByTestId('combine-header-muted')).toBeNull();
+  });
+
+  // ── 2. Header shows muted styling when no invites remain ─────────────────
+
+  it('shows muted header when combineInvitesLeft = 0', () => {
+    render(
+      <CombineDashboard
+        prospects={[makeProspect()]}
+        combineInvitesLeft={0}
+        actions={makeActions()}
+      />,
+    );
+    expect(screen.queryByTestId('combine-header-muted')).not.toBeNull();
+    expect(screen.queryByTestId('combine-header-amber')).toBeNull();
+  });
+
+  // ── 3. Header displays invite count ──────────────────────────────────────
+
+  it('displays remaining invite count in header', () => {
+    render(
+      <CombineDashboard
+        prospects={[makeProspect()]}
+        combineInvitesLeft={4}
+        actions={makeActions()}
+      />,
+    );
+    const header = screen.queryByTestId('combine-header-amber');
+    expect(header.textContent).toMatch(/Invites Remaining: 4 \/ 6/);
+  });
+});
+
+// ── 4. Prospect table renders ────────────────────────────────────────────────
+
+describe('CombineDashboard prospect table', () => {
+  it('renders the prospect table with prospect name', () => {
+    render(
+      <CombineDashboard
+        prospects={[makeProspect({ name: 'John Speed', pos: 'WR' })]}
+        combineInvitesLeft={3}
+        actions={makeActions()}
+      />,
+    );
+    expect(screen.queryByTestId('combine-prospect-table')).not.toBeNull();
+    expect(screen.getByText('John Speed')).toBeTruthy();
+  });
+
+  // ── 5. Empty state when no prospects ─────────────────────────────────────
+
+  it('shows empty state when no prospects are provided', () => {
+    render(
+      <CombineDashboard
+        prospects={[]}
+        combineInvitesLeft={0}
+        actions={makeActions()}
+      />,
+    );
+    expect(screen.getByText(/No prospects available/i)).toBeTruthy();
+  });
+
+  // ── 6. Row has correct data-highlight for freak ───────────────────────────
+
+  it('marks freak prospects with data-highlight="freak"', () => {
+    const freak = makeProspect({
+      id: 99,
+      combineMetrics: { combineGrade: 9.0, fortyYardDash: 4.30, benchPressReps: 32, threeCone: 6.50, verticalJump: 40 },
+    });
+    render(<CombineDashboard prospects={[freak]} combineInvitesLeft={3} actions={makeActions()} />);
+    const row = screen.queryByTestId('combine-row-99');
+    expect(row).not.toBeNull();
+    expect(row.getAttribute('data-highlight')).toBe('freak');
+  });
+
+  // ── 7. Row has correct data-highlight for bust ────────────────────────────
+
+  it('marks bust prospects with data-highlight="bust"', () => {
+    const bust = makeProspect({
+      id: 88,
+      combineMetrics: { combineGrade: 2.5, fortyYardDash: 4.76, benchPressReps: 8, threeCone: 7.48, verticalJump: 20 },
+    });
+    render(<CombineDashboard prospects={[bust]} combineInvitesLeft={3} actions={makeActions()} />);
+    const row = screen.queryByTestId('combine-row-88');
+    expect(row).not.toBeNull();
+    expect(row.getAttribute('data-highlight')).toBe('bust');
+  });
+});
+
+// ── 8. Invite button with invites available ───────────────────────────────────
+
+describe('CombineDashboard invite action', () => {
+  it('shows active invite button when invites remain and workout not completed', () => {
+    const prospect = makeProspect({ id: 5, workoutCompleted: false });
+    render(<CombineDashboard prospects={[prospect]} combineInvitesLeft={3} actions={makeActions()} />);
+    const btn = screen.queryByTestId('combine-invite-btn-5');
+    expect(btn).not.toBeNull();
+    expect(btn.disabled).toBe(false);
+  });
+
+  // ── 9. Invite button disabled when no invites remain ─────────────────────
+
+  it('shows disabled invite button when no invites remain', () => {
+    const prospect = makeProspect({ id: 6, workoutCompleted: false });
+    render(<CombineDashboard prospects={[prospect]} combineInvitesLeft={0} actions={makeActions()} />);
+    const btn = screen.queryByTestId('combine-invite-disabled-6');
+    expect(btn).not.toBeNull();
+    expect(btn.disabled).toBe(true);
+  });
+
+  // ── 10. Clicking invite calls actions.runCombineWorkout ──────────────────
+
+  it('clicking invite button calls actions.runCombineWorkout with prospectId', async () => {
+    const actions = makeActions({
+      runCombineWorkout: vi.fn().mockResolvedValue({ payload: { performanceCard: 'Great workout!' } }),
+    });
+    const prospect = makeProspect({ id: 7 });
+    render(<CombineDashboard prospects={[prospect]} combineInvitesLeft={3} actions={actions} />);
+    fireEvent.click(screen.getByTestId('combine-invite-btn-7'));
+    await waitFor(() => expect(actions.runCombineWorkout).toHaveBeenCalledWith(7));
+  });
+
+  // ── 11. Verified badge shown for completed workouts ───────────────────────
+
+  it('shows Verified badge when workoutCompleted is true', () => {
+    const prospect = makeProspect({ id: 10, workoutCompleted: true, trueOvr: 82 });
+    render(<CombineDashboard prospects={[prospect]} combineInvitesLeft={3} actions={makeActions()} />);
+    const badge = screen.queryByTestId('combine-verified-10');
+    expect(badge).not.toBeNull();
+    expect(badge.textContent).toMatch(/Verified/);
+  });
+});
+
+// ── 12. Performance card toast ────────────────────────────────────────────────
+
+describe('CombineDashboard performance card toast', () => {
+  it('shows toast when lastWorkoutCard prop is set', () => {
+    const { rerender } = render(
+      <CombineDashboard prospects={[makeProspect()]} combineInvitesLeft={3} lastWorkoutCard={null} actions={makeActions()} />,
+    );
+    expect(screen.queryByTestId('combine-performance-card')).toBeNull();
+
+    rerender(
+      <CombineDashboard prospects={[makeProspect()]} combineInvitesLeft={3} lastWorkoutCard="Player X ran a 4.38 forty." actions={makeActions()} />,
+    );
+    const card = screen.queryByTestId('combine-performance-card');
+    expect(card).not.toBeNull();
+    expect(card.textContent).toMatch(/Player X ran a 4.38 forty/);
+  });
+
+  it('shows toast with performanceCard from runCombineWorkout Promise response', async () => {
+    const actions = makeActions({
+      runCombineWorkout: vi.fn().mockResolvedValue({ payload: { performanceCard: 'Incredible workout. 4.29 forty!' } }),
+    });
+    const prospect = makeProspect({ id: 20 });
+    render(<CombineDashboard prospects={[prospect]} combineInvitesLeft={6} actions={actions} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('combine-invite-btn-20'));
+    });
+
+    await waitFor(() => {
+      const card = screen.queryByTestId('combine-performance-card');
+      expect(card).not.toBeNull();
+    });
+    expect(screen.queryByTestId('combine-performance-card').textContent).toMatch(/Incredible workout\. 4\.29 forty!/);
+  });
+});

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -14,6 +14,7 @@ import { getLastGameDisplay, getLatestUserCompletedGame, getNextOpponentDisplay 
 import { HQIcon, TeamIdentityBadge } from './HQVisuals.jsx';
 import { buildGameBookDestination } from '../utils/managementScreenRouting.js';
 import ChronicleHeadlineBanner from './ChronicleHeadlineBanner.tsx';
+import CombineDashboard from './CombineDashboard.jsx';
 
 const BOTTOM_NAV_ITEMS = [
   { label: 'Home', route: 'HQ', icon: 'home', active: true },
@@ -694,6 +695,15 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
 
       {/* ── TRADE DEADLINE BANNER ─────────────────────────────────────────── */}
       <HQDeadlineBanner week={safeNum(league?.week, 1)} />
+
+      {/* ── DRAFT COMBINE DASHBOARD ─────────────────────────────────────── */}
+      {league?.phase === 'draft_combine' && Array.isArray(league?.combineProspects) && (
+        <CombineDashboard
+          prospects={league.combineProspects}
+          combineInvitesLeft={league.combineInvitesLeft ?? 0}
+          actions={actions}
+        />
+      )}
 
       {/* ── COLLAPSED DRAWER: secondary content ─────────────────────────── */}
       <details className="hq-more-drawer" data-testid="hq-more-drawer">

--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -790,6 +790,14 @@ export function useWorker() {
     advanceFreeAgencyDay: () =>
       send(toWorker.ADVANCE_FREE_AGENCY_DAY),
 
+    /** Run a private combine workout for a prospect. Returns a Promise. */
+    runCombineWorkout: (prospectId) =>
+      request(toWorker.RUN_COMBINE_WORKOUT, { prospectId }),
+
+    /** Advance past combine week into the draft phase. */
+    advanceCombineWeek: () =>
+      send(toWorker.ADVANCE_COMBINE_WEEK),
+
     /** Finalise offseason → generate new schedule → Week 1. */
     startNewSeason: () => send(toWorker.START_NEW_SEASON),
 

--- a/src/worker/__tests__/combineWorker.integration.test.js
+++ b/src/worker/__tests__/combineWorker.integration.test.js
@@ -1,0 +1,208 @@
+/**
+ * combineWorker.integration.test.js
+ * Integration tests for the combine engine functions that worker handlers use.
+ * Tests are engine-level (pure functions), matching the pattern of scoutingWorker.test.js.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  generateCombineMetrics,
+  generateCombineMetricsForClass,
+  applyPrivateWorkout,
+  getAIDraftBoardAdjustment,
+  computeCombineGrade,
+  getPositionGroup,
+  COMBINE_GRADE_THRESHOLDS,
+} from '../../core/draft/combineEngine.js';
+
+function makeProspect(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Test Player',
+    pos: 'WR',
+    age: 22,
+    ovr: 75,
+    trueOvr: 75,
+    status: 'draft_eligible',
+    ratings: { speed: 85, agility: 80, acceleration: 75 },
+    scoutedRanges: {},
+    ...overrides,
+  };
+}
+
+// ── 1. generateCombineMetricsForClass populates all prospects during init ─────
+
+describe('worker integration — combine engine: class generation', () => {
+  it('generates combine metrics for all draft_eligible prospects', () => {
+    const prospects = [
+      makeProspect({ id: 1, pos: 'WR' }),
+      makeProspect({ id: 2, pos: 'QB', ratings: { speed: 65, agility: 70 } }),
+      makeProspect({ id: 3, pos: 'OL', ratings: { speed: 50, agility: 55, runBlock: 80 } }),
+    ];
+    const result = generateCombineMetricsForClass(prospects, 2025);
+    expect(result).toHaveLength(3);
+    result.forEach((p) => {
+      expect(p.combineMetrics).not.toBeNull();
+      expect(p.combineMetrics.fortyYardDash).toBeTypeOf('number');
+      expect(p.combineMetrics.benchPressReps).toBeTypeOf('number');
+      expect(p.combineMetrics.combineGrade).toBeTypeOf('number');
+    });
+  });
+
+  // ── 2. Prospects with existing metrics are not overwritten ─────────────────
+
+  it('skips prospects that already have combineMetrics', () => {
+    const existingMetrics = { fortyYardDash: 4.30, benchPressReps: 35, combineGrade: 9.0, threeCone: 6.55, verticalJump: 40 };
+    const prospect = makeProspect({ id: 10, combineMetrics: existingMetrics });
+    const result = generateCombineMetricsForClass([prospect], 2025);
+    expect(result[0].combineMetrics).toEqual(existingMetrics);
+  });
+
+  // ── 3. Empty class returns empty array ────────────────────────────────────
+
+  it('handles an empty draft class', () => {
+    expect(generateCombineMetricsForClass([], 2025)).toEqual([]);
+  });
+
+  // ── 4. Determinism: same inputs produce identical metrics ─────────────────
+
+  it('generateCombineMetrics is deterministic across calls', () => {
+    const prospect = makeProspect({ id: 42, trueOvr: 80 });
+    const first = generateCombineMetrics(prospect, 2025);
+    const second = generateCombineMetrics(prospect, 2025);
+    expect(first).toEqual(second);
+  });
+
+  // ── 5. Different seasons produce different metrics ────────────────────────
+
+  it('different seasons yield different combine metrics', () => {
+    const prospect = makeProspect({ id: 5, trueOvr: 75 });
+    const season1 = generateCombineMetrics(prospect, 2024);
+    const season2 = generateCombineMetrics(prospect, 2025);
+    expect(season1.fortyYardDash).not.toBe(season2.fortyYardDash);
+  });
+});
+
+// ── AI draft board adjustment ─────────────────────────────────────────────────
+
+describe('worker integration — combine engine: AI board adjustment', () => {
+  // ── 6. Athletic freak (+15 slots) ────────────────────────────────────────
+
+  it('returns +15 slots for a grade above athletic_freak threshold', () => {
+    const prospect = makeProspect({ combineMetrics: { combineGrade: COMBINE_GRADE_THRESHOLDS.athletic_freak + 0.1 } });
+    const adj = getAIDraftBoardAdjustment(prospect);
+    expect(adj.slots).toBe(15);
+    expect(adj.reason).toBe('athletic_freak');
+  });
+
+  // ── 7. Combine bust (-15 slots) ──────────────────────────────────────────
+
+  it('returns -15 slots for a grade below bust threshold', () => {
+    const prospect = makeProspect({ combineMetrics: { combineGrade: COMBINE_GRADE_THRESHOLDS.bust - 0.1 } });
+    const adj = getAIDraftBoardAdjustment(prospect);
+    expect(adj.slots).toBe(-15);
+    expect(adj.reason).toBe('combine_bust');
+  });
+
+  // ── 8. Normal range → no adjustment ─────────────────────────────────────
+
+  it('returns 0 slots for a normal combine grade', () => {
+    const prospect = makeProspect({ combineMetrics: { combineGrade: 6.0 } });
+    const adj = getAIDraftBoardAdjustment(prospect);
+    expect(adj.slots).toBe(0);
+    expect(adj.reason).toBe('none');
+  });
+
+  // ── 9. Null metrics → no adjustment ─────────────────────────────────────
+
+  it('returns 0 slots when combineMetrics is null', () => {
+    const prospect = makeProspect({ combineMetrics: null });
+    const adj = getAIDraftBoardAdjustment(prospect);
+    expect(adj.slots).toBe(0);
+    expect(adj.reason).toBe('none');
+  });
+
+  // ── 10. Missing combineMetrics property → no adjustment ─────────────────
+
+  it('returns 0 slots when combineMetrics is undefined', () => {
+    const prospect = makeProspect();
+    delete prospect.combineMetrics;
+    const adj = getAIDraftBoardAdjustment(prospect);
+    expect(adj.slots).toBe(0);
+  });
+});
+
+// ── applyPrivateWorkout ───────────────────────────────────────────────────────
+
+describe('worker integration — combine engine: private workout', () => {
+  // ── 11. Sets workoutCompleted flag ────────────────────────────────────────
+
+  it('marks the prospect as workoutCompleted', () => {
+    const prospect = makeProspect({ id: 7, trueOvr: 82 });
+    const result = applyPrivateWorkout(prospect, 3, 2025);
+    expect(result.workoutCompleted).toBe(true);
+  });
+
+  // ── 12. Reveals trueOvr in scoutedRanges with Verified label ─────────────
+
+  it('adds Verified scouted range with trueOvr for the requesting team', () => {
+    const prospect = makeProspect({ id: 7, trueOvr: 82 });
+    const result = applyPrivateWorkout(prospect, 3, 2025);
+    expect(result.scoutedRanges[3]).toEqual({
+      low: 82,
+      high: 82,
+      confidence: 1.0,
+      label: 'Verified',
+    });
+  });
+
+  // ── 13. Preserves existing scoutedRanges for other teams ─────────────────
+
+  it('preserves existing scouted ranges from other teams', () => {
+    const prospect = makeProspect({
+      id: 8,
+      trueOvr: 78,
+      scoutedRanges: { 5: { low: 70, high: 80, confidence: 0.6, label: 'Decent' } },
+    });
+    const result = applyPrivateWorkout(prospect, 3, 2025);
+    expect(result.scoutedRanges[5]).toEqual({ low: 70, high: 80, confidence: 0.6, label: 'Decent' });
+    expect(result.scoutedRanges[3].low).toBe(78);
+  });
+
+  // ── 14. Does not mutate the original prospect ─────────────────────────────
+
+  it('returns a new object without mutating the original', () => {
+    const prospect = makeProspect({ id: 9, trueOvr: 70 });
+    const result = applyPrivateWorkout(prospect, 1, 2025);
+    expect(result).not.toBe(prospect);
+    expect(prospect.workoutCompleted).toBeUndefined();
+  });
+});
+
+// ── computeCombineGrade coverage ─────────────────────────────────────────────
+
+describe('worker integration — combine engine: grade computation', () => {
+  // ── 15. Speed group grade is weighted towards forty ───────────────────────
+
+  it('speed group: elite forty boosts grade significantly', () => {
+    const elite = { fortyYardDash: 4.28, threeCone: 6.90, benchPressReps: 15, verticalJump: 35 };
+    const slow  = { fortyYardDash: 4.78, threeCone: 6.90, benchPressReps: 15, verticalJump: 35 };
+    const eliteGrade = computeCombineGrade(elite, 'WR');
+    const slowGrade  = computeCombineGrade(slow,  'WR');
+    expect(eliteGrade).toBeGreaterThan(slowGrade + 2);
+  });
+
+  it('linemen group: elite bench press boosts grade significantly', () => {
+    const strongMan = { fortyYardDash: 5.10, threeCone: 7.80, benchPressReps: 38, verticalJump: 26 };
+    const weakMan   = { fortyYardDash: 5.10, threeCone: 7.80, benchPressReps: 8,  verticalJump: 26 };
+    const strongGrade = computeCombineGrade(strongMan, 'OL');
+    const weakGrade   = computeCombineGrade(weakMan,   'OL');
+    expect(strongGrade).toBeGreaterThan(weakGrade + 2);
+  });
+
+  it('grade is clamped between 0 and 10', () => {
+    const worst = { fortyYardDash: 5.60, threeCone: 9.00, benchPressReps: 4,  verticalJump: 17 };
+    const best  = { fortyYardDash: 4.28, threeCone: 6.45, benchPressReps: 41, verticalJump: 46 };
+    expect(computeCombineGrade(worst, 'WR')).toBeGreaterThanOrEqual(0);
+    expect(computeCombineGrade(best,  'WR')).toBeLessThanOrEqual(10);
+  });
+});

--- a/src/worker/protocol.js
+++ b/src/worker/protocol.js
@@ -183,6 +183,10 @@ export const toWorker = Object.freeze({
   /** Scouting */
   GET_SCOUTING_BOARD:           'GET_SCOUTING_BOARD',           // {} — get team-specific draft board
   UPDATE_SCOUTING_ALLOCATION:   'UPDATE_SCOUTING_ALLOCATION',   // { allocations: { [target]: points } }
+
+  /** Draft Combine */
+  RUN_COMBINE_WORKOUT:          'RUN_COMBINE_WORKOUT',          // { prospectId }
+  ADVANCE_COMBINE_WEEK:         'ADVANCE_COMBINE_WEEK',         // {} — transition draft_combine → draft
 });
 
 // ─────────────────────────────────────────────
@@ -294,6 +298,10 @@ export const toUI = Object.freeze({
   /** Scouting */
   SCOUTING_BOARD:               'SCOUTING_BOARD',               // { board: RankedProspect[] }
   SCOUTING_ALLOCATION_RESULT:   'SCOUTING_ALLOCATION_RESULT',   // { valid, errors, allocations }
+
+  /** Draft Combine */
+  COMBINE_WORKOUT_RESULT:       'COMBINE_WORKOUT_RESULT',       // { success, combineInvitesLeft, prospect, performanceCard }
+  COMBINE_WEEK_OPEN:            'COMBINE_WEEK_OPEN',            // { prospectCount }
 
   /**
    * IndexedDB version conflict / blocked event — the UI must reload the page

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -257,6 +257,11 @@ import {
   allocateScoutingPoints,
   REGIONS as SCOUTING_REGIONS,
 } from '../core/draft/scoutingEngine.js';
+import {
+  generateCombineMetricsForClass,
+  applyPrivateWorkout,
+  getAIDraftBoardAdjustment,
+} from '../core/draft/combineEngine.js';
 import { normalizeArchivedGamePayload, classifyArchiveQuality, validateArchivedGame, recoverArchivedGameFromSchedule, enrichArchivedGamePayload, mergeArchivedGameWithScheduleResult } from '../core/gameArchive.js';
 import {
   DEFAULT_LEAGUE_ECONOMY,
@@ -1132,6 +1137,23 @@ function buildViewState() {
     economy: normalizeLeagueEconomy(meta?.economy ?? {}, { year: meta?.year }),
     tradeDeadline,
     scoutingWeeksRemaining: meta?.scoutingWeeksRemaining ?? null,
+    combineInvitesLeft: meta?.combineInvitesLeft ?? 0,
+    combineProspectsReady: meta?.combineProspectsReady ?? false,
+    combineProspects: (() => {
+      if (meta?.phase !== 'draft_combine') return null;
+      const userTeamId = meta.userTeamId;
+      return cache.getAllPlayers()
+        .filter(p => p.status === 'draft_eligible')
+        .sort((a, b) => (b.combineMetrics?.combineGrade ?? 0) - (a.combineMetrics?.combineGrade ?? 0))
+        .map(p => ({
+          id: p.id,
+          name: p.name,
+          pos: p.pos,
+          combineMetrics: p.combineMetrics ?? null,
+          workoutCompleted: p.workoutCompleted ?? false,
+          verifiedOvr: p.workoutCompleted ? (p.scoutedRanges?.[userTeamId]?.low ?? null) : null,
+        }));
+    })(),
     scoutingBudget: (() => {
       const uTeam = cache.getTeam(meta?.userTeamId);
       return uTeam?.scoutingBudget ?? null;
@@ -5007,6 +5029,8 @@ async function handleSimToPhase({ targetPhase }, id) {
       } else if (currentMeta.phase === 'free_agency') {
         validateLeagueFlowState({ stage: 'free_agency' });
         await handleAdvanceFreeAgencyDay({}, null);
+      } else if (currentMeta.phase === 'draft_combine') {
+        await handleAdvanceCombineWeek({}, null);
       } else if (currentMeta.phase === 'draft') {
         // Auto-sim all draft picks. The draft pipeline itself is responsible
         // for transitioning into the next season (handleSimDraftPick and
@@ -10395,8 +10419,8 @@ async function handleStartDraft(payload, id) {
     return;
   }
 
-  // Accept 'draft' (new pipeline) and 'offseason' (legacy saves).
-  if (!['draft', 'offseason'].includes(meta.phase)) {
+  // Accept 'draft' (new pipeline), 'draft_combine' (combine→draft transition), and 'offseason' (legacy saves).
+  if (!['draft', 'draft_combine', 'offseason'].includes(meta.phase)) {
     post(toUI.DRAFT_STATE, { notStarted: true }, id);
     return;
   }
@@ -10650,7 +10674,9 @@ async function handleSimDraftPick(payload, id) {
         const hoardPenalty = dupDepth > 0
           ? Math.min(3.6, dupDepth * 1.75) * (eliteProspectReduction < 0.95 ? 0.42 : 1)
           : 0;
-        const val = Number(boardScore?.score ?? 0) + (needBoost * eliteProspectReduction) - hoardPenalty;
+        const combineAdj = getAIDraftBoardAdjustment(p);
+        const combineBonus = combineAdj.slots * 0.1;
+        const val = Number(boardScore?.score ?? 0) + (needBoost * eliteProspectReduction) - hoardPenalty + combineBonus;
 
         if (val > bestValue) {
             bestValue = val;
@@ -11832,7 +11858,8 @@ async function handleAdvanceFreeAgencyDay(payload, id) {
     if (day > maxDays) {
         // FA is already over — ensure the phase advanced correctly (idempotent).
         if (meta.phase === 'free_agency') {
-            cache.setMeta({ phase: 'draft' });
+            cache.setMeta({ phase: 'draft_combine', combineInvitesLeft: 6, combineProspectsReady: false });
+            _initCombineWeek();
             await flushDirty();
         }
         post(toUI.NOTIFICATION, { level: 'info', message: 'Free Agency period is over.' });
@@ -11971,24 +11998,93 @@ async function handleAdvanceFreeAgencyDay(payload, id) {
               .join(', ');
             post(toUI.NOTIFICATION, { level: 'info', message: `Comp picks awarded for ${meta.year} draft: ${preview}${compAwards.length > 4 ? '…' : ''}.` });
         }
-        updates.phase = 'draft';
+        updates.phase = 'draft_combine';
+        updates.combineInvitesLeft = 6;
+        updates.combineProspectsReady = false;
     }
 
     cache.setMeta(updates);
+
+    if (isComplete) {
+        _initCombineWeek();
+    }
 
     await flushDirty();
 
     post(toUI.NOTIFICATION, { level: 'info', message: `Free Agency Day ${day} Complete.` });
 
     if (isComplete) {
-        // Explicitly signal phase change so UI can redirect
-        post(toUI.OFFSEASON_PHASE, { phase: 'draft', message: 'Free Agency Complete. Draft is now open.' });
+        post(toUI.OFFSEASON_PHASE, { phase: 'draft_combine', message: 'Free Agency Complete. Draft Combine Week is now open.' });
     }
 
     // Refresh views
     post(toUI.STATE_UPDATE, buildViewState());
     // Also trigger FA list refresh
     await handleGetFreeAgents({}, null);
+}
+
+function _initCombineWeek() {
+    try {
+        const combineMeta = cache.getMeta();
+        if (combineMeta.combineProspectsReady) return;
+        const draftProspects = cache.getAllPlayers().filter(p => p.status === 'draft_eligible');
+        if (draftProspects.length === 0) {
+            cache.setMeta({ phase: 'draft' });
+            return;
+        }
+        const combineSeason = Number(combineMeta.year ?? combineMeta.season ?? 2025);
+        const updated = generateCombineMetricsForClass(draftProspects, combineSeason);
+        for (const p of updated) {
+            if (p.combineMetrics !== null) {
+                cache.updatePlayer(p.id, { combineMetrics: p.combineMetrics, workoutCompleted: p.workoutCompleted ?? false });
+            }
+        }
+        cache.setMeta({ combineProspectsReady: true });
+        const freshMeta = cache.getMeta();
+        const prospectCount = draftProspects.length;
+        let metaWithNews = addNewsItem(freshMeta, {
+            id: `combine_week_open_${combineSeason}`,
+            headline: `Draft Combine Week is underway. ${prospectCount} prospects are being evaluated.`,
+            body: `${prospectCount} draft prospects have completed combine testing. Evaluators are releasing results.`,
+            week: freshMeta.currentWeek ?? 1,
+            season: combineSeason,
+            type: 'combine_week_open',
+            category: 'MILESTONE',
+            priority: 80,
+        });
+        for (const p of updated) {
+            if (!p.combineMetrics) continue;
+            const grade = p.combineMetrics.combineGrade;
+            if (grade > 8.5) {
+                metaWithNews = addNewsItem(metaWithNews, {
+                    id: `combine_freak_${p.id}_${combineSeason}`,
+                    headline: `${p.name} posts elite combine numbers (grade: ${grade.toFixed(1)}).`,
+                    body: `Expect teams to reach for him on draft day.`,
+                    week: freshMeta.currentWeek ?? 1,
+                    season: combineSeason,
+                    type: 'combine_athletic_freak',
+                    category: 'SCOUTING',
+                    priority: 75,
+                    playerId: p.id,
+                });
+            } else if (grade < 4.0) {
+                metaWithNews = addNewsItem(metaWithNews, {
+                    id: `combine_bust_${p.id}_${combineSeason}`,
+                    headline: `${p.name}'s combine raises questions (grade: ${grade.toFixed(1)}).`,
+                    body: `Could slide on draft day.`,
+                    week: freshMeta.currentWeek ?? 1,
+                    season: combineSeason,
+                    type: 'combine_bust',
+                    category: 'SCOUTING',
+                    priority: 65,
+                    playerId: p.id,
+                });
+            }
+        }
+        cache.setMeta({ newsItems: metaWithNews.newsItems });
+    } catch (err) {
+        console.warn('[Worker] Combine init error (non-fatal):', err.message);
+    }
 }
 
 /**
@@ -13629,6 +13725,10 @@ async function handleMessage(event) {
       case toWorker.GET_SCOUTING_BOARD:          return await handleGetScoutingBoard(payload, id);
       case toWorker.UPDATE_SCOUTING_ALLOCATION:  return await handleUpdateScoutingAllocation(payload, id);
 
+      // ── Draft Combine ──────────────────────────────────────────────────────
+      case toWorker.RUN_COMBINE_WORKOUT:    return await handleRunCombineWorkout(payload, id);
+      case toWorker.ADVANCE_COMBINE_WEEK:   return await handleAdvanceCombineWeek(payload, id);
+
       default:
         console.warn(`[Worker] Unknown message type: ${type}`);
         post(toUI.ERROR, { message: `Unknown message type: ${type}` }, id);
@@ -13671,6 +13771,107 @@ async function handleUpdateScoutingAllocation({ allocations }, id) {
   }
 
   post(toUI.SCOUTING_ALLOCATION_RESULT, { valid: result.valid, errors: result.errors, allocations: result.valid ? allocations : budget.allocations }, id);
+}
+
+// ── Handler: RUN_COMBINE_WORKOUT ─────────────────────────────────────────────
+
+async function handleRunCombineWorkout({ prospectId }, id) {
+  const meta = ensureDynastyMeta(cache.getMeta());
+  if (!meta) return post(toUI.ERROR, { message: 'No league loaded' }, id);
+
+  if (meta.phase !== 'draft_combine') {
+    return post(toUI.COMBINE_WORKOUT_RESULT, { success: false, error: 'WRONG_STAGE' }, id);
+  }
+  const invitesLeft = Number(meta.combineInvitesLeft ?? 0);
+  if (invitesLeft <= 0) {
+    return post(toUI.COMBINE_WORKOUT_RESULT, { success: false, error: 'NO_INVITES_LEFT' }, id);
+  }
+  const prospect = cache.getPlayer(prospectId);
+  if (!prospect || prospect.status !== 'draft_eligible') {
+    return post(toUI.COMBINE_WORKOUT_RESULT, { success: false, error: 'PROSPECT_NOT_FOUND' }, id);
+  }
+  if (prospect.workoutCompleted) {
+    return post(toUI.COMBINE_WORKOUT_RESULT, { success: false, error: 'ALREADY_COMPLETED' }, id);
+  }
+
+  const userTeamId = meta.userTeamId;
+  const season = Number(meta.year ?? meta.season ?? 2025);
+  const updatedProspect = applyPrivateWorkout(prospect, userTeamId, season);
+  cache.updatePlayer(prospect.id, {
+    workoutCompleted: updatedProspect.workoutCompleted,
+    scoutedRanges: updatedProspect.scoutedRanges,
+  });
+  cache.setMeta({ combineInvitesLeft: invitesLeft - 1 });
+
+  const metrics = updatedProspect.combineMetrics ?? prospect.combineMetrics ?? {};
+  const trueOvr = updatedProspect.trueOvr ?? updatedProspect.ovr ?? 60;
+  const forty = metrics.fortyYardDash ?? '—';
+  const bench = metrics.benchPressReps ?? '—';
+  const grade = metrics.combineGrade ?? 5;
+  const speedNote = typeof forty === 'number'
+    ? forty <= 4.38 ? 'elite speed'
+    : forty <= 4.50 ? 'above-average speed'
+    : forty <= 4.65 ? 'adequate athleticism' : 'below-average speed'
+    : 'unknown athleticism';
+  const gradeNote = grade >= 8.5 ? 'Evaluators flagged as an athletic freak.'
+    : grade >= 7.0 ? 'Strong overall athletic profile.'
+    : grade >= 5.0 ? 'Solid combine showing.'
+    : grade >= 4.0 ? 'Below expectations.'
+    : 'Evaluators have concerns about athleticism.';
+  const performanceCard = `${prospect.name} completed private drills. Posted a ${forty}s forty and ${bench} bench reps. Showed ${speedNote}. ${gradeNote} True OVR confirmed at ${trueOvr}.`;
+
+  const workoutNews = {
+    id: `combine_workout_${prospect.id}_${season}`,
+    headline: `${prospect.name} completes a private workout. True OVR confirmed at ${trueOvr}.`,
+    body: performanceCard,
+    week: meta.currentWeek ?? 1,
+    season,
+    type: 'combine_private_workout',
+    category: 'SCOUTING',
+    priority: 60,
+    playerId: prospect.id,
+  };
+  cache.setMeta(addNewsItem(cache.getMeta(), workoutNews));
+
+  const userTeam = cache.getTeam(userTeamId);
+  if (userTeam) {
+    const scoutLog = Array.isArray(userTeam.scoutingLog) ? userTeam.scoutingLog : [];
+    cache.updateTeam(userTeamId, {
+      scoutingLog: [...scoutLog, { type: 'combine_workout', playerId: prospect.id, playerName: prospect.name, season, trueOvr }].slice(-100),
+    });
+  }
+
+  await flushDirty();
+  post(toUI.COMBINE_WORKOUT_RESULT, {
+    success: true,
+    combineInvitesLeft: invitesLeft - 1,
+    prospect: {
+      name: updatedProspect.name,
+      position: updatedProspect.pos,
+      trueOvr,
+      combineMetrics: updatedProspect.combineMetrics ?? prospect.combineMetrics,
+      workoutCompleted: true,
+    },
+    performanceCard,
+  }, id);
+  post(toUI.STATE_UPDATE, buildViewState());
+}
+
+// ── Handler: ADVANCE_COMBINE_WEEK ────────────────────────────────────────────
+
+async function handleAdvanceCombineWeek(payload, id) {
+  const meta = ensureDynastyMeta(cache.getMeta());
+  if (!meta) return post(toUI.ERROR, { message: 'No league loaded' }, id);
+
+  if (meta.phase !== 'draft_combine') {
+    return post(toUI.ERROR, { message: 'Not in draft combine phase' }, id);
+  }
+
+  cache.setMeta({ phase: 'draft' });
+  await flushDirty();
+
+  post(toUI.OFFSEASON_PHASE, { phase: 'draft', message: 'Combine Week complete. Draft is now open.' });
+  post(toUI.STATE_UPDATE, buildViewState());
 }
 
 // ── Boot ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds a deterministic combine simulation phase between free agency and the draft:

- combineEngine.js: pure LCG-seeded engine with position athletic profiles
  (speed/big_skill/linemen groups), bench press, vertical jump, grade
  computation, private workout logic, and AI board adjustment
- New draft_combine phase in offseason calendar; combineInvitesLeft=6
  initialized on FA→combine transition
- worker.js: RUN_COMBINE_WORKOUT and ADVANCE_COMBINE_WEEK handlers with full
  validation (WRONG_STAGE, NO_INVITES_LEFT, PROSPECT_NOT_FOUND,
  ALREADY_COMPLETED); performanceCard text built from verified metrics
- buildViewState: exposes combineProspects (phase-gated) with verifiedOvr via
  scoutedRanges rather than exposing trueOvr directly
- CombineDashboard.jsx: sortable prospect table, amber/muted header, invite
  buttons, verified badges, and toast via actions.runCombineWorkout() Promise
- useWorker.js: runCombineWorkout() and advanceCombineWeek() added to actions
- Tests: 28 unit + 17 integration + 13 UI = 58 new tests; full suite 3843/3843
- Build clean; engine soak 9/9 gates passing

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NuKguhjrFVduLPFBX914vs