### PR TITLE
feat(draft): Draft-Day Blockbuster Trade-Up Engine

### DIFF
--- a/src/core/draft/__tests__/draftTradeEngine.integration.test.js
+++ b/src/core/draft/__tests__/draftTradeEngine.integration.test.js
@@ -1,0 +1,595 @@
+/**
+ * draftTradeEngine.integration.test.js
+ *
+ * Integration tests: verify the engine functions interact correctly as a system.
+ * Tests combine metrics persistence, pick ownership transfers, trade record
+ * creation, user-offer flow, decline guard, and legacy-save compatibility.
+ *
+ * No cache, no worker, no DB — pure function calls only.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DRAFT_TRADE_CONFIG,
+  isCombineStandout,
+  findDraftTradeUpOpportunity,
+  applyDraftTradeUp,
+} from '../draftTradeEngine.js';
+import {
+  generateCombineMetricsForClass,
+} from '../combineEngine.js';
+
+// ── Shared fixtures ────────────────────────────────────────────────────────────
+
+function makeTeam(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Default Team',
+    abbr: 'DFT',
+    ovr: 75,
+    capSpace: 25.0,
+    capRoom: 25.0,
+    wins: 8,
+    losses: 8,
+    ...overrides,
+  };
+}
+
+function makePlayer(overrides = {}) {
+  return {
+    id: 100,
+    name: 'Roster Player',
+    pos: 'WR',
+    ovr: 80,
+    status: 'active',
+    teamId: 1,
+    ...overrides,
+  };
+}
+
+function makePick(overrides = {}) {
+  return {
+    overall: 1,
+    round: 1,
+    pick: 1,
+    teamId: 1,
+    playerId: null,
+    ...overrides,
+  };
+}
+
+function makeFuturePick(overrides = {}) {
+  return {
+    id: 'fp1',
+    round: 2,
+    season: 2026,
+    currentOwner: 20,
+    teamId: 20,
+    ...overrides,
+  };
+}
+
+function buildMinimalState({
+  picks = [],
+  currentPickIndex = 0,
+  draftPool = [],
+  teams = [],
+  rosters = [],
+  futurePicks = [],
+  userTeamId = 99,
+  year = 2025,
+  extraMeta = {},
+} = {}) {
+  return {
+    meta: {
+      userTeamId,
+      year,
+      draftState: { picks, currentPickIndex },
+      tradeOffers: [],
+      ...extraMeta,
+    },
+    teams,
+    rosters,
+    draftPool,
+    futurePicks,
+  };
+}
+
+// ── 1. Combine metrics persisted onto draft prospects before draft stage ────────
+
+describe('integration — combine metrics on draft prospects', () => {
+  it('generateCombineMetricsForClass attaches combineGrade to each draft_eligible prospect', () => {
+    const prospects = [
+      { id: 1, name: 'A', pos: 'WR', age: 22, ovr: 85, trueOvr: 85, status: 'draft_eligible',
+        ratings: { speed: 92, agility: 88, acceleration: 85 }, scoutedRanges: {} },
+      { id: 2, name: 'B', pos: 'QB', age: 21, ovr: 78, trueOvr: 78, status: 'draft_eligible',
+        ratings: { speed: 72, agility: 68 }, scoutedRanges: {} },
+    ];
+
+    const result = generateCombineMetricsForClass(prospects, 2025);
+
+    expect(result).toHaveLength(2);
+    result.forEach((p) => {
+      expect(p.combineMetrics).not.toBeNull();
+      expect(p.combineMetrics).not.toBeUndefined();
+      expect(p.combineMetrics.combineGrade).toBeTypeOf('number');
+      expect(p.combineMetrics.fortyYardDash).toBeTypeOf('number');
+      expect(p.combineMetrics.benchPressReps).toBeTypeOf('number');
+    });
+  });
+
+  it('a prospect with combineGrade >= 8.5 passes isCombineStandout', () => {
+    const base = { id: 1, name: 'A', pos: 'WR', age: 22, ovr: 90, trueOvr: 90, status: 'draft_eligible',
+      ratings: { speed: 95, agility: 92, acceleration: 90 }, scoutedRanges: {} };
+    const [withMetrics] = generateCombineMetricsForClass([base], 2025);
+
+    // Whether or not this specific seed yields >= 8.5, isCombineStandout must not throw
+    expect(() => isCombineStandout(withMetrics)).not.toThrow();
+    // A prospect with explicitly high grade is a standout
+    const highGrade = { ...withMetrics, combineMetrics: { combineGrade: 9.5 } };
+    expect(isCombineStandout(highGrade)).toBe(true);
+  });
+});
+
+// ── 2. AI-to-AI trade-up swaps pick ownership correctly ───────────────────────
+
+describe('integration — AI-to-AI pick ownership swap', () => {
+  it('applyDraftTradeUp transfers currentPick.teamId to buyer and buyer later pick to seller', () => {
+    // capSpace=50 clears round-1 rookie contract at pick #3 (~$33.3M from ROOKIE_SCALE max=35).
+    const seller = makeTeam({ id: 5, name: 'Sellers', abbr: 'SEL', wins: 5, losses: 11, capSpace: 50 });
+    const buyer  = makeTeam({ id: 10, name: 'Buyers', abbr: 'BUY', wins: 5, losses: 11, capSpace: 50 });
+    const allTeams = [seller, buyer];
+
+    const picks = [
+      makePick({ overall: 3, round: 1, pick: 3, teamId: 5 }),   // current — seller
+      makePick({ overall: 8, round: 1, pick: 8, teamId: 10 }),  // buyer's later pick
+    ];
+
+    const standout = {
+      id: 77, name: 'Speedy', pos: 'WR', ovr: 88, projectedRound: 1,
+      combineMetrics: { combineGrade: 9.0 },
+    };
+
+    // Seller has a WR starter (ovr>=75) → isSellerWillingToMoveDown returns true (already covered).
+    // Buyer has a weak WR → severe need → buyer wants to trade up.
+    const rosters = [
+      makePlayer({ id: 200, pos: 'WR', ovr: 68, teamId: 10, status: 'active' }),
+      makePlayer({ id: 201, pos: 'WR', ovr: 80, teamId: 5,  status: 'active' }),
+    ];
+
+    const futurePick = makeFuturePick({ id: 'fp1', round: 2, currentOwner: 10, teamId: 10 });
+
+    const state = buildMinimalState({
+      picks,
+      currentPickIndex: 0,
+      draftPool: [standout],
+      teams: allTeams,
+      rosters,
+      futurePicks: [futurePick],
+      userTeamId: 99,
+    });
+
+    const opportunity = findDraftTradeUpOpportunity(state);
+    expect(opportunity).not.toBeNull();
+    expect(opportunity.type).toBe('ai_to_ai');
+
+    const result = applyDraftTradeUp(opportunity, state);
+    const newPicks = result.state.meta.draftState.picks;
+
+    // Pick #3 (overall=3) should now belong to buyer (10)
+    expect(newPicks[0].teamId).toBe(10);
+    // Pick #8 (overall=8, buyer's later pick) should now belong to seller (5)
+    expect(newPicks[1].teamId).toBe(5);
+  });
+});
+
+// ── 3. Transferred future pick remains indexed to buyer/seller correctly ────────
+
+describe('integration — future pick transfer', () => {
+  it('applyDraftTradeUp updates currentOwner of future pick to sellerTeamId', () => {
+    const seller = makeTeam({ id: 5, abbr: 'SEL', wins: 5, losses: 11, capSpace: 50 });
+    const buyer  = makeTeam({ id: 10, abbr: 'BUY', wins: 5, losses: 11, capSpace: 50 });
+
+    const picks = [
+      makePick({ overall: 3, round: 1, teamId: 5 }),
+      makePick({ overall: 8, round: 1, teamId: 10 }),
+    ];
+
+    const standout = {
+      id: 77, name: 'Speedy', pos: 'WR', ovr: 88, projectedRound: 1,
+      combineMetrics: { combineGrade: 9.2 },
+    };
+
+    const rosters = [
+      makePlayer({ id: 200, pos: 'WR', ovr: 68, teamId: 10, status: 'active' }),
+      makePlayer({ id: 201, pos: 'WR', ovr: 80, teamId: 5,  status: 'active' }),
+    ];
+
+    const futurePick = makeFuturePick({ id: 'fp_future', round: 2, season: 2026, currentOwner: 10, teamId: 10 });
+
+    const state = buildMinimalState({
+      picks, currentPickIndex: 0,
+      draftPool: [standout], teams: [seller, buyer],
+      rosters, futurePicks: [futurePick],
+      userTeamId: 99,
+    });
+
+    const opp = findDraftTradeUpOpportunity(state);
+    expect(opp).not.toBeNull();
+
+    const result = applyDraftTradeUp(opp, state);
+
+    const movedFp = result.state.futurePicks.find((fp) => fp.id === 'fp_future');
+    expect(movedFp).toBeDefined();
+    // Future pick should now be owned by seller (5)
+    expect(movedFp.currentOwner).toBe(5);
+    expect(movedFp.teamId).toBe(5);
+  });
+});
+
+// ── 4. AI-to-AI trade-up emits formatted milestone headline ───────────────────
+
+describe('integration — headline format', () => {
+  it('headline text matches the DRAFT SHOCK format with buyer team name and prospect', () => {
+    const seller = makeTeam({ id: 5, name: 'Coastal Sharks', abbr: 'COS', wins: 5, losses: 11, capSpace: 50 });
+    const buyer  = makeTeam({ id: 10, name: 'Mountain Lions', abbr: 'MTN', wins: 5, losses: 11, capSpace: 50 });
+
+    const picks = [
+      makePick({ overall: 5, round: 1, teamId: 5 }),
+      makePick({ overall: 12, round: 1, teamId: 10 }),
+    ];
+
+    const standout = {
+      id: 33, name: 'Flash Gordon', pos: 'WR', ovr: 90, projectedRound: 1,
+      combineMetrics: { combineGrade: 9.5 },
+    };
+
+    const rosters = [
+      makePlayer({ id: 200, pos: 'WR', ovr: 60, teamId: 10, status: 'active' }),
+      makePlayer({ id: 201, pos: 'WR', ovr: 80, teamId: 5,  status: 'active' }),
+    ];
+
+    const futurePick = makeFuturePick({ id: 'fp1', round: 3, currentOwner: 10, teamId: 10 });
+
+    const state = buildMinimalState({
+      picks, currentPickIndex: 0,
+      draftPool: [standout], teams: [seller, buyer],
+      rosters, futurePicks: [futurePick],
+      userTeamId: 99,
+    });
+
+    const opp = findDraftTradeUpOpportunity(state);
+    expect(opp).not.toBeNull();
+
+    const result = applyDraftTradeUp(opp, state);
+    expect(result.headline).not.toBeNull();
+    expect(result.headline.text).toContain('DRAFT SHOCK');
+    expect(result.headline.text).toContain('Mountain Lions');
+    expect(result.headline.text).toContain('Flash Gordon');
+    expect(result.headline.category).toBe('MILESTONE');
+  });
+});
+
+// ── 5. AI-to-AI trade-up creates draft ticker payload ─────────────────────────
+
+describe('integration — ticker payload', () => {
+  it('ticker text contains TRADE-UP and buyer abbr and pick number', () => {
+    const seller = makeTeam({ id: 5, name: 'Coastal Sharks', abbr: 'COS', wins: 5, losses: 11, capSpace: 50 });
+    const buyer  = makeTeam({ id: 10, name: 'Mountain Lions', abbr: 'MTN', wins: 5, losses: 11, capSpace: 50 });
+
+    const picks = [
+      makePick({ overall: 5, round: 1, teamId: 5 }),
+      makePick({ overall: 12, round: 1, teamId: 10 }),
+    ];
+
+    const standout = {
+      id: 33, name: 'Flash Gordon', pos: 'WR', ovr: 90, projectedRound: 1,
+      combineMetrics: { combineGrade: 9.5 },
+    };
+
+    const rosters = [
+      makePlayer({ id: 200, pos: 'WR', ovr: 60, teamId: 10, status: 'active' }),
+      makePlayer({ id: 201, pos: 'WR', ovr: 80, teamId: 5,  status: 'active' }),
+    ];
+
+    const futurePick = makeFuturePick({ id: 'fp1', round: 3, currentOwner: 10, teamId: 10 });
+
+    const state = buildMinimalState({
+      picks, currentPickIndex: 0,
+      draftPool: [standout], teams: [seller, buyer],
+      rosters, futurePicks: [futurePick],
+      userTeamId: 99,
+    });
+
+    const opp = findDraftTradeUpOpportunity(state);
+    expect(opp).not.toBeNull();
+
+    const result = applyDraftTradeUp(opp, state);
+    expect(result.ticker).not.toBeNull();
+    expect(result.ticker.text).toContain('TRADE-UP');
+    expect(result.ticker.text).toContain('MTN');
+    expect(result.ticker.text).toContain('5');
+    expect(result.ticker.type).toBe('draft_trade_up');
+    expect(result.state.meta.draftLastTradeUp).toEqual(result.ticker);
+  });
+});
+
+// ── 6. Trade-up blocked when buyer cap insufficient for rookie slot ─────────────
+
+describe('integration — cap gate', () => {
+  it('findDraftTradeUpOpportunity returns null when buyer has no cap space', () => {
+    const seller = makeTeam({ id: 5, abbr: 'SEL', wins: 5, losses: 11, capSpace: 50 });
+    const buyer  = makeTeam({
+      id: 10, abbr: 'BUY', wins: 5, losses: 11,
+      capSpace: 0,   // broke — intentionally 0 to verify the cap gate
+      capRoom: 0,
+    });
+
+    const picks = [
+      makePick({ overall: 3, round: 1, teamId: 5 }),
+      makePick({ overall: 9, round: 1, teamId: 10 }),
+    ];
+
+    const standout = {
+      id: 77, name: 'Speedy', pos: 'WR', ovr: 88, projectedRound: 1,
+      combineMetrics: { combineGrade: 9.0 },
+    };
+
+    // Seller has a WR starter → isSellerWillingToMoveDown returns true (ensures we reach the cap check).
+    const rosters = [
+      makePlayer({ id: 200, pos: 'WR', ovr: 60, teamId: 10, status: 'active' }),
+      makePlayer({ id: 201, pos: 'WR', ovr: 80, teamId: 5,  status: 'active' }),
+    ];
+
+    const futurePick = makeFuturePick({ id: 'fp1', round: 2, currentOwner: 10, teamId: 10 });
+
+    const state = buildMinimalState({
+      picks, currentPickIndex: 0,
+      draftPool: [standout], teams: [seller, buyer],
+      rosters, futurePicks: [futurePick],
+      userTeamId: 99,
+    });
+
+    const opp = findDraftTradeUpOpportunity(state);
+    expect(opp).toBeNull();
+  });
+});
+
+// ── 7. When user holds pick, type is 'ai_to_user' ─────────────────────────────
+
+describe('integration — ai_to_user offer', () => {
+  it('returns type ai_to_user when seller is the user team', () => {
+    const userTeamId = 1;
+    const seller = makeTeam({ id: userTeamId, abbr: 'USR', wins: 8, losses: 8, capSpace: 50 });
+    const buyer  = makeTeam({ id: 10, abbr: 'BUY', wins: 5, losses: 11, capSpace: 50 });
+
+    const picks = [
+      makePick({ overall: 4, round: 1, teamId: userTeamId }),
+      makePick({ overall: 11, round: 1, teamId: 10 }),
+    ];
+
+    const standout = {
+      id: 55, name: 'JetSpeed', pos: 'WR', ovr: 89, projectedRound: 1,
+      combineMetrics: { combineGrade: 9.1 },
+    };
+
+    // Seller (user team) already has a WR starter → willing to move down (sell the pick).
+    const rosters = [
+      makePlayer({ id: 300, pos: 'WR', ovr: 65, teamId: 10,         status: 'active' }),
+      makePlayer({ id: 301, pos: 'WR', ovr: 80, teamId: userTeamId, status: 'active' }),
+    ];
+
+    const futurePick = makeFuturePick({ id: 'fp1', round: 2, currentOwner: 10, teamId: 10 });
+
+    const state = buildMinimalState({
+      picks, currentPickIndex: 0,
+      draftPool: [standout], teams: [seller, buyer],
+      rosters, futurePicks: [futurePick],
+      userTeamId,
+    });
+
+    const opp = findDraftTradeUpOpportunity(state);
+    expect(opp).not.toBeNull();
+    expect(opp.type).toBe('ai_to_user');
+    expect(opp.sellerTeamId).toBe(userTeamId);
+    expect(opp.buyerTeamId).toBe(10);
+  });
+
+  it('applyDraftTradeUp returns pausedForUserOffer=true for ai_to_user type', () => {
+    const userTeamId = 1;
+    const seller = makeTeam({ id: userTeamId, abbr: 'USR', wins: 8, losses: 8, capSpace: 50 });
+    const buyer  = makeTeam({ id: 10, abbr: 'BUY', wins: 5, losses: 11, capSpace: 50 });
+
+    const picks = [
+      makePick({ overall: 4, round: 1, teamId: userTeamId }),
+      makePick({ overall: 11, round: 1, teamId: 10 }),
+    ];
+
+    const standout = {
+      id: 55, name: 'JetSpeed', pos: 'WR', ovr: 89, projectedRound: 1,
+      combineMetrics: { combineGrade: 9.1 },
+    };
+
+    const rosters = [
+      makePlayer({ id: 300, pos: 'WR', ovr: 65, teamId: 10,         status: 'active' }),
+      makePlayer({ id: 301, pos: 'WR', ovr: 80, teamId: userTeamId, status: 'active' }),
+    ];
+
+    const futurePick = makeFuturePick({ id: 'fp1', round: 2, currentOwner: 10, teamId: 10 });
+
+    const state = buildMinimalState({
+      picks, currentPickIndex: 0,
+      draftPool: [standout], teams: [seller, buyer],
+      rosters, futurePicks: [futurePick],
+      userTeamId,
+    });
+
+    const opp = findDraftTradeUpOpportunity(state);
+    const result = applyDraftTradeUp(opp, state);
+    expect(result.pausedForUserOffer).toBe(true);
+  });
+});
+
+// ── 8. User offer stored in meta.tradeOffers with origin 'draft_trade_up' ──────
+
+describe('integration — trade offer record', () => {
+  it('applyDraftTradeUp appends a record with origin: draft_trade_up to tradeOffers', () => {
+    const seller = makeTeam({ id: 5, abbr: 'SEL', wins: 5, losses: 11, capSpace: 50 });
+    const buyer  = makeTeam({ id: 10, abbr: 'BUY', wins: 5, losses: 11, capSpace: 50 });
+
+    const picks = [
+      makePick({ overall: 3, round: 1, teamId: 5 }),
+      makePick({ overall: 8, round: 1, teamId: 10 }),
+    ];
+
+    const standout = {
+      id: 77, name: 'Speedy', pos: 'WR', ovr: 88, projectedRound: 1,
+      combineMetrics: { combineGrade: 9.0 },
+    };
+
+    const rosters = [
+      makePlayer({ id: 200, pos: 'WR', ovr: 68, teamId: 10, status: 'active' }),
+      makePlayer({ id: 201, pos: 'WR', ovr: 80, teamId: 5,  status: 'active' }),
+    ];
+
+    const futurePick = makeFuturePick({ id: 'fp1', round: 2, currentOwner: 10, teamId: 10 });
+
+    const state = buildMinimalState({
+      picks, currentPickIndex: 0,
+      draftPool: [standout], teams: [seller, buyer],
+      rosters, futurePicks: [futurePick],
+      userTeamId: 99,
+    });
+
+    const opp = findDraftTradeUpOpportunity(state);
+    const result = applyDraftTradeUp(opp, state);
+
+    const offers = result.state.meta.tradeOffers;
+    expect(Array.isArray(offers)).toBe(true);
+    expect(offers.length).toBe(1);
+
+    const offer = offers[0];
+    expect(offer.origin).toBe('draft_trade_up');
+    expect(offer.offerId).toMatch(/^dtup_/);
+    expect(offer.buyerTeamId).toBe(10);
+    expect(offer.sellerTeamId).toBe(5);
+    expect(offer.pickNumber).toBe(3);
+  });
+});
+
+// ── 9. Draft loop does not double-evaluate same pick after decline ──────────────
+
+describe('integration — double-evaluation guard', () => {
+  it('findDraftTradeUpOpportunity returns null when draftTradeUpEvaluatedPickIdx matches currentPickIndex', () => {
+    const seller = makeTeam({ id: 5, abbr: 'SEL', wins: 5, losses: 11, capSpace: 50 });
+    const buyer  = makeTeam({ id: 10, abbr: 'BUY', wins: 5, losses: 11, capSpace: 50 });
+
+    const picks = [
+      makePick({ overall: 3, round: 1, teamId: 5 }),
+      makePick({ overall: 8, round: 1, teamId: 10 }),
+    ];
+
+    const standout = {
+      id: 77, name: 'Speedy', pos: 'WR', ovr: 88, projectedRound: 1,
+      combineMetrics: { combineGrade: 9.0 },
+    };
+
+    const rosters = [
+      makePlayer({ id: 200, pos: 'WR', ovr: 68, teamId: 10, status: 'active' }),
+      makePlayer({ id: 201, pos: 'WR', ovr: 80, teamId: 5,  status: 'active' }),
+    ];
+
+    const futurePick = makeFuturePick({ id: 'fp1', round: 2, currentOwner: 10, teamId: 10 });
+
+    // Simulate: pick index 0 was already evaluated
+    const state = buildMinimalState({
+      picks, currentPickIndex: 0,
+      draftPool: [standout], teams: [seller, buyer],
+      rosters, futurePicks: [futurePick],
+      userTeamId: 99,
+      extraMeta: { draftTradeUpEvaluatedPickIdx: 0 },
+    });
+
+    const opp = findDraftTradeUpOpportunity(state);
+    expect(opp).toBeNull();
+  });
+
+  it('applyDraftTradeUp sets draftTradeUpEvaluatedPickIdx on the returned state', () => {
+    const seller = makeTeam({ id: 5, abbr: 'SEL', wins: 5, losses: 11, capSpace: 50 });
+    const buyer  = makeTeam({ id: 10, abbr: 'BUY', wins: 5, losses: 11, capSpace: 50 });
+
+    const picks = [
+      makePick({ overall: 3, round: 1, teamId: 5 }),
+      makePick({ overall: 8, round: 1, teamId: 10 }),
+    ];
+
+    const standout = {
+      id: 77, name: 'Speedy', pos: 'WR', ovr: 88, projectedRound: 1,
+      combineMetrics: { combineGrade: 9.0 },
+    };
+
+    const rosters = [
+      makePlayer({ id: 200, pos: 'WR', ovr: 68, teamId: 10, status: 'active' }),
+      makePlayer({ id: 201, pos: 'WR', ovr: 80, teamId: 5,  status: 'active' }),
+    ];
+
+    const futurePick = makeFuturePick({ id: 'fp1', round: 2, currentOwner: 10, teamId: 10 });
+
+    const state = buildMinimalState({
+      picks, currentPickIndex: 0,
+      draftPool: [standout], teams: [seller, buyer],
+      rosters, futurePicks: [futurePick],
+      userTeamId: 99,
+    });
+
+    const opp = findDraftTradeUpOpportunity(state);
+    expect(opp).not.toBeNull();
+
+    const result = applyDraftTradeUp(opp, state);
+    expect(result.state.meta.draftTradeUpEvaluatedPickIdx).toBe(0);
+  });
+});
+
+// ── 10. Legacy save without combineMetrics does not crash ──────────────────────
+
+describe('integration — legacy save graceful handling', () => {
+  it('findDraftTradeUpOpportunity returns null when no prospects have combineMetrics', () => {
+    const seller = makeTeam({ id: 5, abbr: 'SEL', wins: 5, losses: 11, capSpace: 30 });
+    const buyer  = makeTeam({ id: 10, abbr: 'BUY', wins: 5, losses: 11, capSpace: 30 });
+
+    const picks = [
+      makePick({ overall: 3, round: 1, teamId: 5 }),
+      makePick({ overall: 8, round: 1, teamId: 10 }),
+    ];
+
+    // No combineMetrics — old save format
+    const legacyProspects = [
+      { id: 1, name: 'OldSave Player A', pos: 'WR', ovr: 88, projectedRound: 1 },
+      { id: 2, name: 'OldSave Player B', pos: 'QB', ovr: 85, projectedRound: 1 },
+    ];
+
+    const state = buildMinimalState({
+      picks, currentPickIndex: 0,
+      draftPool: legacyProspects,
+      teams: [seller, buyer],
+      rosters: [],
+      futurePicks: [],
+      userTeamId: 99,
+    });
+
+    let result;
+    expect(() => { result = findDraftTradeUpOpportunity(state); }).not.toThrow();
+    expect(result).toBeNull();
+  });
+
+  it('isCombineStandout returns false (not throws) when combineMetrics is undefined', () => {
+    const legacyProspect = { id: 1, name: 'OldSave', pos: 'WR', ovr: 90 };
+    expect(() => isCombineStandout(legacyProspect)).not.toThrow();
+    expect(isCombineStandout(legacyProspect)).toBe(false);
+  });
+
+  it('isCombineStandout returns false when combineMetrics exists but combineGrade is null', () => {
+    const prospect = { id: 1, name: 'Partial', pos: 'WR', ovr: 88, combineMetrics: { combineGrade: null } };
+    expect(isCombineStandout(prospect)).toBe(false);
+  });
+});

--- a/src/core/draft/__tests__/draftTradeEngine.unit.test.js
+++ b/src/core/draft/__tests__/draftTradeEngine.unit.test.js
@@ -1,0 +1,563 @@
+/**
+ * draftTradeEngine.unit.test.js
+ *
+ * Pure unit tests for draftTradeEngine.js helpers.
+ * No cache, no worker, no DB.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DRAFT_TRADE_CONFIG,
+  isCombineStandout,
+  isProspectWithinTradeUpWindow,
+  getStarterNeedAtPosition,
+  teamCanAffordRookie,
+  buildTradeUpPackage,
+  isSellerWillingToMoveDown,
+  evaluateDraftTradeUp,
+  findDraftTradeUpOpportunity,
+  applyDraftTradeUp,
+} from '../draftTradeEngine.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeProspect(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Speedy McFast',
+    pos: 'WR',
+    ovr: 82,
+    trueOvr: 82,
+    projectedRound: 1,
+    combineMetrics: { combineGrade: 9.2 },
+    ...overrides,
+  };
+}
+
+function makeTeam(overrides = {}) {
+  return {
+    id: 10,
+    name: 'Buyers FC',
+    abbr: 'BUY',
+    ovr: 75,
+    capSpace: 20.0,
+    capRoom: 20.0,
+    picks: [],
+    ...overrides,
+  };
+}
+
+function makePlayer(overrides = {}) {
+  return {
+    id: 100,
+    name: 'Starter Vet',
+    pos: 'WR',
+    ovr: 70,
+    teamId: 10,
+    status: 'active',
+    ...overrides,
+  };
+}
+
+function makePick(overrides = {}) {
+  return {
+    id: 'pk1',
+    overall: 15,
+    round: 1,
+    pickInRound: 15,
+    teamId: 10,
+    playerId: null,
+    ...overrides,
+  };
+}
+
+function makeFuturePick(overrides = {}) {
+  return {
+    id: 'fp1',
+    round: 2,
+    season: 2026,
+    currentOwner: 10,
+    teamId: 10,
+    ...overrides,
+  };
+}
+
+// ── isCombineStandout ─────────────────────────────────────────────────────────
+
+describe('isCombineStandout', () => {
+  it('returns true when combineGrade >= 8.5', () => {
+    expect(isCombineStandout(makeProspect({ combineMetrics: { combineGrade: 8.5 } }))).toBe(true);
+    expect(isCombineStandout(makeProspect({ combineMetrics: { combineGrade: 9.9 } }))).toBe(true);
+  });
+
+  it('returns false when combineGrade < 8.5', () => {
+    expect(isCombineStandout(makeProspect({ combineMetrics: { combineGrade: 8.4 } }))).toBe(false);
+    expect(isCombineStandout(makeProspect({ combineMetrics: { combineGrade: 0 } }))).toBe(false);
+  });
+
+  it('returns false when combineMetrics is null', () => {
+    expect(isCombineStandout(makeProspect({ combineMetrics: null }))).toBe(false);
+  });
+
+  it('returns false when combineMetrics is undefined', () => {
+    const p = { id: 1, pos: 'WR', ovr: 80 };
+    expect(isCombineStandout(p)).toBe(false);
+  });
+
+  it('returns false when prospect is null', () => {
+    expect(isCombineStandout(null)).toBe(false);
+  });
+});
+
+// ── isProspectWithinTradeUpWindow ─────────────────────────────────────────────
+
+describe('isProspectWithinTradeUpWindow', () => {
+  it('returns true within 15 picks (round 1, pick #10)', () => {
+    // estimatedSlot = (1-1)*32 + 16 = 16; diff = |16 - 10| = 6 ≤ 15
+    const p = makeProspect({ projectedRound: 1 });
+    expect(isProspectWithinTradeUpWindow(p, 10)).toBe(true);
+  });
+
+  it('returns false outside 15 picks (round 3, pick #10)', () => {
+    // estimatedSlot = (3-1)*32 + 16 = 80; diff = |80 - 10| = 70 > 15
+    const p = makeProspect({ projectedRound: 3 });
+    expect(isProspectWithinTradeUpWindow(p, 10)).toBe(false);
+  });
+
+  it('returns false when not a standout even if within window', () => {
+    const p = makeProspect({ combineMetrics: { combineGrade: 6.0 }, projectedRound: 1 });
+    expect(isProspectWithinTradeUpWindow(p, 10)).toBe(false);
+  });
+
+  it('returns true when projectedRound is absent (assume in window)', () => {
+    const p = makeProspect({ projectedRound: undefined, mockRound: undefined });
+    expect(isProspectWithinTradeUpWindow(p, 50)).toBe(true);
+  });
+
+  it('handles round 2 boundary correctly', () => {
+    // estimatedSlot = (2-1)*32 + 16 = 48; currentPickNumber = 35; diff = 13 ≤ 15
+    const p = makeProspect({ projectedRound: 2 });
+    expect(isProspectWithinTradeUpWindow(p, 35)).toBe(true);
+  });
+});
+
+// ── getStarterNeedAtPosition ──────────────────────────────────────────────────
+
+describe('getStarterNeedAtPosition', () => {
+  it('reports severe need when team has no players at position', () => {
+    const team = makeTeam();
+    const rosters = [makePlayer({ teamId: 99, pos: 'WR', ovr: 85 })]; // different team
+    const { severeNeed, bestOvr } = getStarterNeedAtPosition(team, 'WR', rosters);
+    expect(severeNeed).toBe(true);
+    expect(bestOvr).toBe(0);
+  });
+
+  it('reports severe need when best OVR at position < 75', () => {
+    const team = makeTeam({ id: 10 });
+    const rosters = [makePlayer({ teamId: 10, pos: 'WR', ovr: 68 })];
+    const { severeNeed } = getStarterNeedAtPosition(team, 'WR', rosters);
+    expect(severeNeed).toBe(true);
+  });
+
+  it('reports no severe need when team has starter OVR >= 75', () => {
+    const team = makeTeam({ id: 10 });
+    const rosters = [makePlayer({ teamId: 10, pos: 'WR', ovr: 80 })];
+    const { severeNeed } = getStarterNeedAtPosition(team, 'WR', rosters);
+    expect(severeNeed).toBe(false);
+  });
+});
+
+// ── teamCanAffordRookie ───────────────────────────────────────────────────────
+
+describe('teamCanAffordRookie', () => {
+  it('returns false when cap would go negative after rookie signing', () => {
+    const team = makeTeam({ capSpace: 0.5, capRoom: 0.5 });
+    // Pick #1 rookie salary is well above $0.5M
+    expect(teamCanAffordRookie(team, 1)).toBe(false);
+  });
+
+  it('returns true when team has sufficient cap space', () => {
+    const team = makeTeam({ capSpace: 50.0, capRoom: 50.0 });
+    expect(teamCanAffordRookie(team, 1)).toBe(true);
+  });
+
+  it('returns false when capSpace is exactly 0', () => {
+    const team = makeTeam({ capSpace: 0, capRoom: 0 });
+    expect(teamCanAffordRookie(team, 100)).toBe(false);
+  });
+});
+
+// ── buildTradeUpPackage ───────────────────────────────────────────────────────
+
+describe('buildTradeUpPackage', () => {
+  it('returns null when buyerPick is absent', () => {
+    const team = makeTeam();
+    const currentPick = makePick({ round: 1, overall: 5 });
+    expect(buildTradeUpPackage(team, currentPick, null, [])).toBeNull();
+  });
+
+  it('returns null when round-1 move has no future pick available', () => {
+    const team = makeTeam({ id: 10 });
+    const currentPick = makePick({ round: 1, overall: 5 });
+    const buyerPick   = makePick({ id: 'pk2', overall: 20, round: 1, teamId: 10 });
+    const futurePicks = []; // no future picks
+    expect(buildTradeUpPackage(team, currentPick, buyerPick, futurePicks)).toBeNull();
+  });
+
+  it('includes buyer current pick + future 2nd/3rd for round-1 move', () => {
+    const team = makeTeam({ id: 10 });
+    const currentPick = makePick({ round: 1, overall: 5 });
+    const buyerPick   = makePick({ id: 'pk2', overall: 20, round: 1, teamId: 10 });
+    const future2nd   = makeFuturePick({ id: 'fp2', round: 2, currentOwner: 10 });
+    const pkg = buildTradeUpPackage(team, currentPick, buyerPick, [future2nd]);
+    expect(pkg).not.toBeNull();
+    expect(pkg.currentPickPackage).toBe(buyerPick);
+    expect(pkg.futurePick).toBe(future2nd);
+  });
+
+  it('round-2 move requires no future pick', () => {
+    const team = makeTeam({ id: 10 });
+    const currentPick = makePick({ round: 2, overall: 40 });
+    const buyerPick   = makePick({ id: 'pk2', overall: 55, round: 2, teamId: 10 });
+    const pkg = buildTradeUpPackage(team, currentPick, buyerPick, []);
+    expect(pkg).not.toBeNull();
+    expect(pkg.futurePick).toBeNull();
+  });
+});
+
+// ── isSellerWillingToMoveDown ─────────────────────────────────────────────────
+
+describe('isSellerWillingToMoveDown', () => {
+  const allTeams = [
+    makeTeam({ id: 1, ovr: 90 }), // contender
+    makeTeam({ id: 2, ovr: 90 }),
+    makeTeam({ id: 3, ovr: 90 }),
+    makeTeam({ id: 4, ovr: 90 }),
+    makeTeam({ id: 5, ovr: 90 }),
+    makeTeam({ id: 6, ovr: 90 }),
+    makeTeam({ id: 7, ovr: 90 }),
+    makeTeam({ id: 8, ovr: 90 }),
+    makeTeam({ id: 9, ovr: 90 }),
+    makeTeam({ id: 10, ovr: 90 }),
+    makeTeam({ id: 11, ovr: 90 }),
+    makeTeam({ id: 12, ovr: 90 }),
+    makeTeam({ id: 13, ovr: 90 }),
+    makeTeam({ id: 14, ovr: 90 }),
+    makeTeam({ id: 15, ovr: 90 }),
+    makeTeam({ id: 16, ovr: 90 }),
+    makeTeam({ id: 17, ovr: 90 }),
+    makeTeam({ id: 18, ovr: 90 }),
+    makeTeam({ id: 19, ovr: 90 }),
+    makeTeam({ id: 20, ovr: 90 }),
+    makeTeam({ id: 21, ovr: 30 }), // rebuilder
+    makeTeam({ id: 22, ovr: 30 }),
+    makeTeam({ id: 23, ovr: 30 }),
+    makeTeam({ id: 24, ovr: 30 }),
+    makeTeam({ id: 25, ovr: 30 }),
+    makeTeam({ id: 26, ovr: 30 }),
+    makeTeam({ id: 27, ovr: 30 }),
+    makeTeam({ id: 28, ovr: 30 }),
+    makeTeam({ id: 29, ovr: 30 }),
+    makeTeam({ id: 30, ovr: 30 }),
+    makeTeam({ id: 31, ovr: 30 }),
+    makeTeam({ id: 32, ovr: 30 }),
+  ];
+
+  it('returns true when seller is rebuilding (low rank)', () => {
+    const sellerTeam = makeTeam({ id: 32, ovr: 30 });
+    const rosters = [];
+    const result = isSellerWillingToMoveDown(sellerTeam, 'WR', { teams: allTeams, rosters });
+    expect(result).toBe(true);
+  });
+
+  it('returns true when seller has no immediate starter need (bestOvr >= 75)', () => {
+    const sellerTeam = makeTeam({ id: 1, ovr: 90 }); // contender
+    const rosters = [makePlayer({ teamId: 1, pos: 'WR', ovr: 82 })];
+    const result = isSellerWillingToMoveDown(sellerTeam, 'WR', { teams: allTeams, rosters });
+    expect(result).toBe(true);
+  });
+
+  it('returns false when contender has severe need at target position', () => {
+    const sellerTeam = makeTeam({ id: 1, ovr: 90 }); // contender
+    const rosters = [makePlayer({ teamId: 1, pos: 'WR', ovr: 60 })]; // weak starter
+    const result = isSellerWillingToMoveDown(sellerTeam, 'WR', { teams: allTeams, rosters });
+    expect(result).toBe(false);
+  });
+});
+
+// ── evaluateDraftTradeUp ──────────────────────────────────────────────────────
+
+describe('evaluateDraftTradeUp', () => {
+  function makeEvalState(overrides = {}) {
+    const picks = [
+      makePick({ id: 'pk0', overall: 5,  round: 1, teamId: 20, playerId: null }), // current (seller)
+      makePick({ id: 'pk1', overall: 10, round: 1, teamId: 10, playerId: null }), // buyer later pick
+    ];
+    return {
+      meta: {
+        draftState: { picks, currentPickIndex: 0 },
+        userTeamId: 99,
+        year: 2025,
+        tradeOffers: [],
+      },
+      // 3 teams required: with only 2, the weakest team (ovr:30) lands at percentile=0.5 → 'mid'.
+      // A 3rd mid-tier team pushes id:20 (ovr:30) to percentile=0.33 → 'rebuilder' → willing to move down.
+      // Buyer capSpace=50 to clear the round-1 rookie contract at pick #5 (~$31.5M).
+      teams:   [makeTeam({ id: 10, ovr: 90, capSpace: 50 }), makeTeam({ id: 20, ovr: 30 }), makeTeam({ id: 99, ovr: 75 })],
+      rosters: [],
+      draftPool: [makeProspect()],
+      futurePicks: [makeFuturePick({ id: 'fp2', round: 2, currentOwner: 10, teamId: 10 })],
+      ...overrides,
+    };
+  }
+
+  it('rejects when cap insufficient for rookie', () => {
+    const state = makeEvalState();
+    state.teams[0] = { ...state.teams[0], capSpace: 0, capRoom: 0 };
+    const buyerTeam  = state.teams[0];
+    const sellerTeam = state.teams[1];
+    const result = evaluateDraftTradeUp({
+      buyerTeam, sellerTeam,
+      currentPick: state.meta.draftState.picks[0],
+      targetProspect: makeProspect(),
+      state,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('cap_insufficient');
+  });
+
+  it('rejects when no need alignment (buyer has strong starter)', () => {
+    const state = makeEvalState();
+    state.rosters = [makePlayer({ teamId: 10, pos: 'WR', ovr: 85 })]; // strong starter
+    const buyerTeam  = state.teams[0];
+    const sellerTeam = state.teams[1];
+    const result = evaluateDraftTradeUp({
+      buyerTeam, sellerTeam,
+      currentPick: state.meta.draftState.picks[0],
+      targetProspect: makeProspect(),
+      state,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('no_need_alignment');
+  });
+
+  it('accepts when all conditions met', () => {
+    const state = makeEvalState();
+    const buyerTeam  = state.teams[0];
+    const sellerTeam = state.teams[1];
+    // No roster → severe need; seller is rebuilder → willing
+    const result = evaluateDraftTradeUp({
+      buyerTeam, sellerTeam,
+      currentPick: state.meta.draftState.picks[0],
+      targetProspect: makeProspect(),
+      state,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe('ok');
+    expect(result.package).not.toBeNull();
+  });
+});
+
+// ── findDraftTradeUpOpportunity ───────────────────────────────────────────────
+
+describe('findDraftTradeUpOpportunity', () => {
+  function makeMinimalState(overrides = {}) {
+    const picks = [
+      makePick({ id: 'pk0', overall: 5,  round: 1, teamId: 20, playerId: null }),
+      makePick({ id: 'pk1', overall: 10, round: 1, teamId: 10, playerId: null }),
+    ];
+    return {
+      meta: {
+        draftState: { picks, currentPickIndex: 0 },
+        userTeamId: 99,
+        year: 2025,
+        tradeOffers: [],
+        draftTradeUpEvaluatedPickIdx: -1,
+      },
+      teams: [
+        makeTeam({ id: 10, ovr: 90, capSpace: 50 }), // capSpace=50 clears round-1 rookie cost at pick #5 (~$31.5M)
+        makeTeam({ id: 20, ovr: 30 }),
+        makeTeam({ id: 99, ovr: 75 }),
+      ],
+      rosters: [],
+      draftPool: [makeProspect({ id: 1, ovr: 82, projectedRound: 1 })],
+      futurePicks: [makeFuturePick({ id: 'fp2', round: 2, currentOwner: 10, teamId: 10 })],
+      ...overrides,
+    };
+  }
+
+  it('returns null when no standout in pool', () => {
+    const state = makeMinimalState();
+    state.draftPool = [makeProspect({ combineMetrics: { combineGrade: 5.0 } })];
+    expect(findDraftTradeUpOpportunity(state)).toBeNull();
+  });
+
+  it('returns null when no draft state', () => {
+    const state = makeMinimalState();
+    state.meta.draftState = null;
+    expect(findDraftTradeUpOpportunity(state)).toBeNull();
+  });
+
+  it('returns null when pick already evaluated (guard)', () => {
+    const state = makeMinimalState();
+    state.meta.draftTradeUpEvaluatedPickIdx = 0; // same as currentPickIndex
+    expect(findDraftTradeUpOpportunity(state)).toBeNull();
+  });
+
+  it('returns ai_to_ai when AI seller, AI buyer, and conditions met', () => {
+    const state = makeMinimalState();
+    // team 20 (seller/AI) holds pick 0; team 10 (buyer/AI) holds pick 1
+    const opp = findDraftTradeUpOpportunity(state);
+    expect(opp).not.toBeNull();
+    expect(opp.type).toBe('ai_to_ai');
+    expect(opp.buyerTeamId).toBe(10);
+    expect(opp.sellerTeamId).toBe(20);
+    expect(opp.targetProspect.id).toBe(1);
+  });
+
+  it('returns ai_to_user when user holds current pick', () => {
+    const state = makeMinimalState();
+    // Make user team the current pick holder
+    state.meta.draftState.picks[0].teamId = 99; // user team
+    state.meta.userTeamId = 99;
+    // User team (id:99) classified as 'contender' with 3 teams; needs a WR starter so they are
+    // willing to move down (bestOvr >= 75 → isSellerWillingToMoveDown returns true).
+    state.rosters = [makePlayer({ id: 300, teamId: 99, pos: 'WR', ovr: 80 })];
+    const opp = findDraftTradeUpOpportunity(state);
+    expect(opp).not.toBeNull();
+    expect(opp.type).toBe('ai_to_user');
+    expect(opp.sellerTeamId).toBe(99);
+    expect(opp.buyerTeamId).toBe(10);
+  });
+
+  it('is deterministic — same state returns same opportunity', () => {
+    const state  = makeMinimalState();
+    const opp1   = findDraftTradeUpOpportunity({ ...state, meta: { ...state.meta, draftTradeUpEvaluatedPickIdx: -1 } });
+    const state2 = makeMinimalState();
+    const opp2   = findDraftTradeUpOpportunity({ ...state2, meta: { ...state2.meta, draftTradeUpEvaluatedPickIdx: -1 } });
+    expect(opp1?.type).toBe(opp2?.type);
+    expect(opp1?.buyerTeamId).toBe(opp2?.buyerTeamId);
+  });
+
+  it('no Math.random usage in module', () => {
+    // Verify determinism by checking the module source doesn't call Math.random
+    // (This is a guardrail check via the function outputs being consistent across calls)
+    const state = makeMinimalState();
+    const results = Array.from({ length: 5 }, () =>
+      findDraftTradeUpOpportunity({ ...state, meta: { ...state.meta, draftTradeUpEvaluatedPickIdx: -1 } }),
+    );
+    const types = results.map((r) => r?.type);
+    expect(types.every((t) => t === types[0])).toBe(true);
+  });
+});
+
+// ── applyDraftTradeUp ─────────────────────────────────────────────────────────
+
+describe('applyDraftTradeUp', () => {
+  function makeOpportunity(overrides = {}) {
+    const currentPick = makePick({ id: 'pk0', overall: 5, round: 1, teamId: 20 });
+    const buyerLaterPick = makePick({ id: 'pk1', overall: 10, round: 1, teamId: 10 });
+    const futurePick = makeFuturePick({ id: 'fp1', round: 2, currentOwner: 10, teamId: 10 });
+    return {
+      type: 'ai_to_ai',
+      buyerTeamId: 10,
+      sellerTeamId: 20,
+      targetProspectId: 1,
+      targetProspect: makeProspect({ id: 1, combineMetrics: { combineGrade: 9.2 } }),
+      currentPick,
+      package: { currentPickPackage: buyerLaterPick, futurePick },
+      ...overrides,
+    };
+  }
+
+  function makeApplyState(opp) {
+    const picks = [
+      { ...opp.currentPick },
+      { ...opp.package.currentPickPackage },
+    ];
+    return {
+      meta: {
+        draftState: { picks, currentPickIndex: 0 },
+        userTeamId: 99,
+        year: 2025,
+        tradeOffers: [],
+      },
+      teams: [
+        makeTeam({ id: 10, name: 'Buyers FC', abbr: 'BUY' }),
+        makeTeam({ id: 20, name: 'Sellers FC', abbr: 'SEL' }),
+      ],
+      rosters: [],
+      draftPool: [],
+      futurePicks: [{ ...opp.package.futurePick }],
+    };
+  }
+
+  it('swaps current pick ownership to buyer', () => {
+    const opp   = makeOpportunity();
+    const state = makeApplyState(opp);
+    const result = applyDraftTradeUp(opp, state);
+    const newPicks = result.state.meta.draftState.picks;
+    expect(newPicks[0].teamId).toBe(10); // current pick now belongs to buyer
+  });
+
+  it('transfers buyer later pick to seller', () => {
+    const opp   = makeOpportunity();
+    const state = makeApplyState(opp);
+    const result = applyDraftTradeUp(opp, state);
+    const newPicks = result.state.meta.draftState.picks;
+    expect(newPicks[1].teamId).toBe(20); // buyer's later pick now belongs to seller
+  });
+
+  it('transfers future pick to seller', () => {
+    const opp   = makeOpportunity();
+    const state = makeApplyState(opp);
+    const result = applyDraftTradeUp(opp, state);
+    const updatedFuture = result.state.futurePicks.find((fp) => fp.id === 'fp1');
+    expect(updatedFuture?.currentOwner).toBe(20); // seller now owns future pick
+  });
+
+  it('appends trade record to tradeOffers with draft_trade_up origin', () => {
+    const opp   = makeOpportunity();
+    const state = makeApplyState(opp);
+    const result = applyDraftTradeUp(opp, state);
+    const record = result.state.meta.tradeOffers.find((o) => o.origin === 'draft_trade_up');
+    expect(record).toBeDefined();
+    expect(record.buyerTeamId).toBe(10);
+    expect(record.sellerTeamId).toBe(20);
+    expect(record.combineGrade).toBeCloseTo(9.2);
+  });
+
+  it('returns formatted headline payload', () => {
+    const opp   = makeOpportunity();
+    const state = makeApplyState(opp);
+    const result = applyDraftTradeUp(opp, state);
+    expect(result.headline).not.toBeNull();
+    expect(result.headline.text).toContain('DRAFT SHOCK');
+    expect(result.headline.text).toContain('Speedy McFast');
+    expect(result.headline.category).toBe('MILESTONE');
+  });
+
+  it('returns ticker with amber-style text', () => {
+    const opp   = makeOpportunity();
+    const state = makeApplyState(opp);
+    const result = applyDraftTradeUp(opp, state);
+    expect(result.ticker.type).toBe('draft_trade_up');
+    expect(result.ticker.text).toContain('TRADE-UP');
+    expect(result.ticker.pickNumber).toBe(5);
+  });
+
+  it('marks draftTradeUpEvaluatedPickIdx in new state', () => {
+    const opp   = makeOpportunity();
+    const state = makeApplyState(opp);
+    const result = applyDraftTradeUp(opp, state);
+    expect(result.state.meta.draftTradeUpEvaluatedPickIdx).toBe(0);
+  });
+
+  it('does not mutate input state', () => {
+    const opp   = makeOpportunity();
+    const state = makeApplyState(opp);
+    const originalTeamId = state.meta.draftState.picks[0].teamId;
+    applyDraftTradeUp(opp, state);
+    expect(state.meta.draftState.picks[0].teamId).toBe(originalTeamId);
+  });
+});

--- a/src/core/draft/draftTradeEngine.js
+++ b/src/core/draft/draftTradeEngine.js
@@ -1,0 +1,451 @@
+/**
+ * draftTradeEngine.js
+ *
+ * Pure, deterministic draft-day trade-up coordinator.
+ * Runs only during the 'draft' stage.
+ *
+ * Design constraints:
+ *  - No imports from UI, worker, cache, or DB.
+ *  - No Math.random — uses same LCG pattern as combineEngine / aiToAiTradeEngine.
+ *  - Returns new objects — no mutation of inputs.
+ *  - Fully deterministic given the same inputs.
+ *
+ * State shape expected by findDraftTradeUpOpportunity / applyDraftTradeUp:
+ *   state = {
+ *     meta:        { draftState: { picks, currentPickIndex }, userTeamId, year, tradeOffers },
+ *     teams:       Array<team>,          // all teams in league
+ *     rosters:     Array<player>,        // all active (non-draft-eligible) players
+ *     draftPool:   Array<player>,        // draft-eligible players, sorted by OVR desc
+ *     futurePicks: Array<pick>,          // future-season draft picks (with currentOwner)
+ *   }
+ */
+
+import { classifyTeam, findStarterGap } from '../trades/aiToAiTradeEngine.js';
+import { generateSlottedRookieContract } from '../contracts/rookieWageScale.js';
+
+// ── Constants ──────────────────────────────────────────────────────────────────
+
+export const DRAFT_TRADE_CONFIG = Object.freeze({
+  standoutThreshold:        8.5,
+  proximityWindow:          15,
+  maxSearchAttempts:        4,
+  firstRoundFuturePickCost: ['2', '3'],
+  tickerPriority:           85,
+});
+
+// ── LCG (same params as combineEngine / aiToAiTradeEngine) ────────────────────
+
+function lcgStep(seed) {
+  return ((1664525 * (seed >>> 0) + 1013904223) >>> 0);
+}
+
+// ── isCombineStandout ─────────────────────────────────────────────────────────
+
+/**
+ * True if the prospect's combine grade meets the standout threshold.
+ * Safe to call when combineMetrics is null/undefined (returns false).
+ */
+export function isCombineStandout(prospect) {
+  const grade = prospect?.combineMetrics?.combineGrade;
+  if (grade === null || grade === undefined) return false;
+  return Number(grade) >= DRAFT_TRADE_CONFIG.standoutThreshold;
+}
+
+// ── isProspectWithinTradeUpWindow ─────────────────────────────────────────────
+
+/**
+ * True if the prospect is a combine standout AND their projected draft slot
+ * is within proximityWindow picks of currentPickNumber.
+ *
+ * Uses prospect.projectedRound (or mockRound) as the source of the projected
+ * slot — both are real fields already used by draftBoardAnalysis.js.
+ * When neither is present, falls back to treating the prospect as within
+ * window (let other guards handle qualification).
+ *
+ * Estimated slot = midpoint of projected round = (round − 1) × 32 + 16.
+ */
+export function isProspectWithinTradeUpWindow(prospect, currentPickNumber) {
+  if (!isCombineStandout(prospect)) return false;
+  const round = Number(prospect.projectedRound ?? prospect.mockRound ?? 0);
+  if (round === 0) return true; // no projection info — assume in window
+  const estimatedSlot = (round - 1) * 32 + 16;
+  return Math.abs(estimatedSlot - currentPickNumber) <= DRAFT_TRADE_CONFIG.proximityWindow;
+}
+
+// ── getStarterNeedAtPosition ──────────────────────────────────────────────────
+
+/**
+ * Returns starter OVR and whether the team has a severe starter need at the
+ * given position.  Severe need = best OVR at position < 75.
+ *
+ * @param {object} team
+ * @param {string} position
+ * @param {Array}  allRosters  – all active (non-draft-eligible) players
+ * @returns {{ severeNeed: boolean, bestOvr: number }}
+ */
+export function getStarterNeedAtPosition(team, position, allRosters) {
+  const gap = findStarterGap(team, allRosters ?? [], position);
+  // findStarterGap returns bestOvr = 0 when no players at position → severe need
+  return {
+    severeNeed: gap.bestOvr < 75 || gap.gapSeverity === 'severe',
+    bestOvr:    gap.bestOvr,
+  };
+}
+
+// ── teamCanAffordRookie ───────────────────────────────────────────────────────
+
+/**
+ * Returns true if the team can absorb the projected rookie cap hit after the
+ * pick at projectedSlot, without going negative on the cap.
+ *
+ * Uses generateSlottedRookieContract (the canonical scale) to compute the hit.
+ */
+export function teamCanAffordRookie(team, projectedSlot) {
+  const capSpace = Number(team?.capSpace ?? team?.capRoom ?? 0);
+  const contract = generateSlottedRookieContract(Math.max(1, Number(projectedSlot) || 1));
+  const rookieHit = Number(contract?.baseAnnual ?? 1.5);
+  return capSpace - rookieHit >= 0;
+}
+
+// ── buildTradeUpPackage ───────────────────────────────────────────────────────
+
+/**
+ * Builds the pick package the buyer offers the seller.
+ *
+ * Round 1 move-up: buyer's later current-draft pick + a future 2nd or 3rd.
+ * Rounds 2/3 move-up: buyer's later current-draft pick only.
+ *
+ * @param {object} buyerTeam
+ * @param {object} currentPick   – the pick the buyer wants (seller's current pick)
+ * @param {object} buyerPick     – buyer's later pick in this draft they're giving up
+ * @param {Array}  futurePicks   – future-season picks with currentOwner field
+ * @returns {{ currentPickPackage: object, futurePick: object|null } | null}
+ */
+export function buildTradeUpPackage(buyerTeam, currentPick, buyerPick, futurePicks) {
+  if (!buyerPick) return null;
+
+  const isFirstRoundMove = Number(currentPick?.round ?? 0) === 1;
+
+  const pkg = {
+    currentPickPackage: buyerPick,
+    futurePick:         null,
+  };
+
+  if (isFirstRoundMove) {
+    const costRounds = DRAFT_TRADE_CONFIG.firstRoundFuturePickCost.map(Number);
+    const buyerFuture = (futurePicks ?? []).find((fp) => {
+      const owner = Number(fp?.currentOwner ?? fp?.teamId ?? -1);
+      if (owner !== Number(buyerTeam?.id)) return false;
+      return costRounds.includes(Number(fp?.round));
+    });
+    if (!buyerFuture) return null; // can't afford round-1 move without future pick
+    pkg.futurePick = buyerFuture;
+  }
+
+  return pkg;
+}
+
+// ── isSellerWillingToMoveDown ─────────────────────────────────────────────────
+
+/**
+ * True if the seller would rationally accept moving down.
+ *
+ * Sellers are willing when:
+ *  - They are classified as a rebuilder (want more picks, not the player), OR
+ *  - They have no immediate starter need at the target position (bestOvr >= 75)
+ *
+ * Uses the same classifyTeam as aiToAiTradeEngine so there is only one classifier.
+ *
+ * @param {object} sellerTeam
+ * @param {string} targetPosition  – position of the standout prospect
+ * @param {object} leagueState     – { teams, rosters }
+ */
+export function isSellerWillingToMoveDown(sellerTeam, targetPosition, leagueState) {
+  const { teams = [], rosters = [] } = leagueState;
+  const role = classifyTeam(sellerTeam, teams);
+  if (role === 'rebuilder') return true;
+
+  const { bestOvr } = getStarterNeedAtPosition(sellerTeam, targetPosition, rosters);
+  return bestOvr >= 75; // already has a starter → willing to move down
+}
+
+// ── evaluateDraftTradeUp ──────────────────────────────────────────────────────
+
+/**
+ * Pure validator that returns whether a draft trade-up is feasible.
+ *
+ * Checks (in order):
+ *  1. Prospect is a combine standout.
+ *  2. Buyer has a severe starter need at the target position.
+ *  3. Seller is willing to move down.
+ *  4. Buyer has a legal pick to offer in this draft.
+ *  5. Buyer can absorb the rookie cap hit.
+ *  6. Package can be assembled (future pick available for round-1 moves).
+ *
+ * @param {{ buyerTeam, sellerTeam, currentPick, targetProspect, state }} params
+ * @returns {{ ok: boolean, package: object|null, reason: string }}
+ */
+export function evaluateDraftTradeUp({ buyerTeam, sellerTeam, currentPick, targetProspect, state }) {
+  const { teams = [], rosters = [], futurePicks = [] } = state;
+  const picks         = state.meta?.draftState?.picks ?? [];
+  const currentIdx    = state.meta?.draftState?.currentPickIndex ?? 0;
+
+  if (!isCombineStandout(targetProspect)) {
+    return { ok: false, package: null, reason: 'not_standout' };
+  }
+
+  const { severeNeed } = getStarterNeedAtPosition(buyerTeam, targetProspect.pos, rosters);
+  if (!severeNeed) {
+    return { ok: false, package: null, reason: 'no_need_alignment' };
+  }
+
+  if (!isSellerWillingToMoveDown(sellerTeam, targetProspect.pos, { teams, rosters })) {
+    return { ok: false, package: null, reason: 'seller_unwilling' };
+  }
+
+  // Buyer must have a later pick in this draft to offer
+  const buyerLaterPick = picks.find(
+    (pk, idx) => idx > currentIdx && Number(pk.teamId) === Number(buyerTeam.id) && !pk.playerId,
+  );
+  if (!buyerLaterPick) {
+    return { ok: false, package: null, reason: 'no_buyer_pick' };
+  }
+
+  if (!teamCanAffordRookie(buyerTeam, currentPick.overall)) {
+    return { ok: false, package: null, reason: 'cap_insufficient' };
+  }
+
+  const tradePackage = buildTradeUpPackage(buyerTeam, currentPick, buyerLaterPick, futurePicks);
+  if (!tradePackage) {
+    return { ok: false, package: null, reason: 'package_unavailable' };
+  }
+
+  return { ok: true, package: tradePackage, reason: 'ok' };
+}
+
+// ── findDraftTradeUpOpportunity ───────────────────────────────────────────────
+
+/**
+ * Scans the current pick context for a valid draft trade-up opportunity.
+ *
+ * Returns one of:
+ *   { type: 'ai_to_ai',   buyerTeamId, sellerTeamId, targetProspectId, package, targetProspect, currentPick }
+ *   { type: 'ai_to_user', buyerTeamId, sellerTeamId, targetProspectId, package, targetProspect, currentPick }
+ *   null
+ *
+ * Rules:
+ *  - Seller = team currently on the clock (owner of currentPick).
+ *  - If the seller is the user team, type is 'ai_to_user' (not auto-executed).
+ *  - Buyer must be an AI team with a later pick in this draft.
+ *  - Searches up to maxSearchAttempts buyer candidates deterministically.
+ *  - Returns null when no standout is near or no willing buyer exists.
+ *  - Guards against re-evaluation of the same pick via meta.draftTradeUpEvaluatedPickIdx.
+ *
+ * @param {object} state  – { meta, teams, rosters, draftPool, futurePicks }
+ * @returns {object|null}
+ */
+export function findDraftTradeUpOpportunity(state) {
+  const { meta, teams = [], rosters = [], draftPool = [], futurePicks = [] } = state;
+  if (!meta?.draftState) return null;
+
+  const { picks, currentPickIndex } = meta.draftState;
+  if (!picks || currentPickIndex >= picks.length) return null;
+
+  const currentPick = picks[currentPickIndex];
+  if (!currentPick || currentPick.playerId) return null;
+
+  // Guard: one evaluation per pick slot
+  if (Number(meta.draftTradeUpEvaluatedPickIdx ?? -1) === Number(currentPickIndex)) return null;
+
+  const userTeamId = meta.userTeamId;
+  const sellerTeamId = currentPick.teamId;
+  const sellerTeam = teams.find((t) => Number(t.id) === Number(sellerTeamId));
+  if (!sellerTeam) return null;
+
+  // Find combine standouts within the proximity window
+  const standouts = draftPool.filter(
+    (p) => isCombineStandout(p) && isProspectWithinTradeUpWindow(p, currentPick.overall),
+  );
+  if (standouts.length === 0) return null;
+
+  // Best standout (pool assumed sorted by OVR desc by caller)
+  const targetProspect = standouts[0];
+
+  // Build deterministic seed from pick context
+  const baseSeed = ((Number(currentPick.overall) * 2654435761 +
+                     Number(currentPick.teamId)  * 40503 +
+                     Number(meta.year ?? 2025)   * 12345) >>> 0);
+
+  // Collect buyer candidates: AI teams with picks AFTER the current pick
+  const seenTeams = new Set([Number(sellerTeamId)]);
+  const buyerCandidates = [];
+
+  for (
+    let i = currentPickIndex + 1;
+    i < picks.length && buyerCandidates.length < DRAFT_TRADE_CONFIG.maxSearchAttempts;
+    i++
+  ) {
+    const pk = picks[i];
+    if (pk.playerId) continue;
+    const tid = Number(pk.teamId);
+    if (tid === Number(userTeamId)) continue; // user team is never the buyer in this scan
+    if (seenTeams.has(tid)) continue;
+    const team = teams.find((t) => Number(t.id) === tid);
+    if (team) {
+      seenTeams.add(tid);
+      buyerCandidates.push({ team, pick: pk });
+    }
+  }
+
+  if (buyerCandidates.length === 0) return null;
+
+  // Deterministic ordering of candidates by LCG-derived key
+  const orderedCandidates = [...buyerCandidates].sort((a, b) => {
+    const ka = lcgStep((Number(a.team.id) ^ baseSeed) >>> 0);
+    const kb = lcgStep((Number(b.team.id) ^ baseSeed) >>> 0);
+    return ka - kb;
+  });
+
+  const evalState = { meta, teams, rosters, draftPool, futurePicks };
+
+  for (const { team: buyerTeam } of orderedCandidates) {
+    const result = evaluateDraftTradeUp({
+      buyerTeam,
+      sellerTeam,
+      currentPick,
+      targetProspect,
+      state: evalState,
+    });
+    if (!result.ok) continue;
+
+    // Determine type: if the seller is the user, the trade must be offered to them
+    const type = Number(sellerTeamId) === Number(userTeamId) ? 'ai_to_user' : 'ai_to_ai';
+
+    return {
+      type,
+      buyerTeamId:      buyerTeam.id,
+      sellerTeamId,
+      targetProspectId: targetProspect.id,
+      package:          result.package,
+      targetProspect,
+      currentPick,
+    };
+  }
+
+  return null;
+}
+
+// ── applyDraftTradeUp ─────────────────────────────────────────────────────────
+
+/**
+ * Executes a draft trade-up by transferring pick ownership and recording the trade.
+ *
+ * For type 'ai_to_ai':  executes immediately, returns updated state.
+ * For type 'ai_to_user': returns updated state with pausedForUserOffer = true
+ *   (the caller is responsible for creating the pending proposal and pausing the loop).
+ *
+ * Pick transfer:
+ *  - currentPick.teamId → buyerTeamId
+ *  - buyer's later pick.teamId → sellerTeamId
+ *  - futurePick.currentOwner → sellerTeamId  (when package includes a future pick)
+ *
+ * @param {object} opportunity  – result of findDraftTradeUpOpportunity
+ * @param {object} state        – same shape as findDraftTradeUpOpportunity state
+ * @returns {{ state: object, headline: object|null, ticker: object|null, pausedForUserOffer: boolean }}
+ */
+export function applyDraftTradeUp(opportunity, state) {
+  const { buyerTeamId, sellerTeamId, currentPick, package: pkg, targetProspect } = opportunity;
+
+  // ── Clone draftState picks (immutable pattern) ────────────────────────────
+  const draftState     = state.meta?.draftState;
+  const currentIdx     = Number(draftState?.currentPickIndex ?? 0);
+  const picks          = (draftState?.picks ?? []).map((pk) => ({ ...pk }));
+
+  // Transfer current pick to buyer
+  const cpIdx = picks.findIndex((pk, i) => i === currentIdx);
+  if (cpIdx !== -1) picks[cpIdx] = { ...picks[cpIdx], teamId: buyerTeamId };
+
+  // Transfer buyer's later pick to seller
+  if (pkg?.currentPickPackage) {
+    const bpOverall = Number(pkg.currentPickPackage.overall);
+    const bpIdx = picks.findIndex(
+      (pk, i) => i > currentIdx && Number(pk.teamId) === Number(buyerTeamId) &&
+                 !pk.playerId && Number(pk.overall) === bpOverall,
+    );
+    if (bpIdx !== -1) picks[bpIdx] = { ...picks[bpIdx], teamId: sellerTeamId };
+  }
+
+  // ── Transfer future pick (round-1 moves) ──────────────────────────────────
+  let futurePicks = state.futurePicks ?? [];
+  if (pkg?.futurePick) {
+    const fpId = pkg.futurePick.id;
+    futurePicks = futurePicks.map((fp) =>
+      fp.id === fpId
+        ? { ...fp, currentOwner: sellerTeamId, teamId: sellerTeamId }
+        : fp,
+    );
+  }
+
+  // ── Trade record ──────────────────────────────────────────────────────────
+  const offerId     = `dtup_${buyerTeamId}_${sellerTeamId}_p${currentPick.overall}_y${state.meta?.year ?? 2025}`;
+  const tradeRecord = {
+    offerId,
+    origin:            'draft_trade_up',
+    fromTeamId:        buyerTeamId,
+    status:            'accepted',
+    isBlockOffer:      false,
+    pickNumber:        currentPick.overall,
+    buyerTeamId,
+    sellerTeamId,
+    targetProspectId:  targetProspect.id,
+    targetProspectName: targetProspect.name,
+    targetProspectPos:  targetProspect.pos,
+    combineGrade:       targetProspect.combineMetrics?.combineGrade ?? null,
+  };
+
+  const existingOffers = Array.isArray(state.meta?.tradeOffers) ? state.meta.tradeOffers : [];
+
+  // ── Build headline & ticker payloads ──────────────────────────────────────
+  const buyerTeam  = (state.teams ?? []).find((t) => Number(t.id) === Number(buyerTeamId));
+  const sellerTeam = (state.teams ?? []).find((t) => Number(t.id) === Number(sellerTeamId));
+  const gradeStr   = (targetProspect.combineMetrics?.combineGrade ?? 0).toFixed(1);
+
+  const headline = {
+    type:     'TRANSACTION',
+    text:     `DRAFT SHOCK: ${buyerTeam?.name ?? `Team ${buyerTeamId}`} trades up to grab athletic freak ${targetProspect.name}!`,
+    detail:   `The ${buyerTeam?.name ?? `Team ${buyerTeamId}`} executed a blockbuster draft-day trade with the ${sellerTeam?.name ?? `Team ${sellerTeamId}`}, moving up to pick #${currentPick.overall} to secure ${targetProspect.name} (${targetProspect.pos}) after a ${gradeStr} combine grade.`,
+    category: 'MILESTONE',
+    priority: DRAFT_TRADE_CONFIG.tickerPriority,
+    buyerTeamId,
+    sellerTeamId,
+  };
+
+  const ticker = {
+    type:          'draft_trade_up',
+    text:          `📢 TRADE-UP: ${buyerTeam?.abbr ?? buyerTeam?.name ?? `Team ${buyerTeamId}`} acquired Pick #${currentPick.overall}!`,
+    pickNumber:    currentPick.overall,
+    buyerTeam:     buyerTeam?.name ?? null,
+    buyerTeamAbbr: buyerTeam?.abbr ?? null,
+  };
+
+  // ── Build updated state ───────────────────────────────────────────────────
+  const newMeta = {
+    ...state.meta,
+    draftState: {
+      ...draftState,
+      picks,
+    },
+    tradeOffers:               [...existingOffers, tradeRecord],
+    draftLastTradeUp:          ticker,
+    draftTradeUpEvaluatedPickIdx: currentIdx,
+  };
+
+  const newState = { ...state, meta: newMeta, futurePicks };
+
+  return {
+    state:              newState,
+    headline,
+    ticker,
+    pausedForUserOffer: opportunity.type === 'ai_to_user',
+  };
+}

--- a/src/ui/draft/DraftRoom.tradeUp.test.jsx
+++ b/src/ui/draft/DraftRoom.tradeUp.test.jsx
@@ -1,0 +1,263 @@
+/**
+ * DraftRoom.tradeUp.test.jsx
+ *
+ * UI-level tests for the Draft-Day Trade-Up Engine surface area:
+ *  - DraftTicker trade-up amber badge
+ *  - DraftTradeDownPanel 'draft_trade_up' origin branch
+ */
+
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { renderToString } from "react-dom/server";
+import { DraftTicker } from "./DraftTicker.jsx";
+import { DraftTradeDownPanel } from "./DraftTradeDownPanel.jsx";
+
+// ── DraftTicker — trade-up event rendering ─────────────────────────────────────
+
+describe("DraftTicker — tradeUpTicker prop", () => {
+  it("renders the amber badge when tradeUpTicker is provided", () => {
+    const tradeUpTicker = {
+      type: "draft_trade_up",
+      text: "📢 TRADE-UP: MTN acquired Pick #5!",
+      pickNumber: 5,
+      buyerTeam: "Mountain Lions",
+      buyerTeamAbbr: "MTN",
+    };
+
+    const html = renderToString(
+      <DraftTicker completedPicks={[]} tradeUpTicker={tradeUpTicker} />,
+    );
+
+    expect(html).toContain("TRADE-UP");
+    expect(html).toContain("MTN acquired Pick #5");
+  });
+
+  it("renders the correct trade-up text from ticker payload", () => {
+    const tradeUpTicker = {
+      type: "draft_trade_up",
+      text: "📢 TRADE-UP: BUY acquired Pick #3!",
+      pickNumber: 3,
+      buyerTeam: "Buyers FC",
+      buyerTeamAbbr: "BUY",
+    };
+
+    const html = renderToString(
+      <DraftTicker completedPicks={[]} tradeUpTicker={tradeUpTicker} />,
+    );
+
+    expect(html).toContain("BUY acquired Pick #3");
+  });
+
+  it("uses amber badge styling (amber background and border color values)", () => {
+    const tradeUpTicker = {
+      type: "draft_trade_up",
+      text: "📢 TRADE-UP: TST acquired Pick #7!",
+      pickNumber: 7,
+      buyerTeamAbbr: "TST",
+    };
+
+    const html = renderToString(
+      <DraftTicker completedPicks={[]} tradeUpTicker={tradeUpTicker} />,
+    );
+
+    // Amber color values from DraftTicker.jsx styles
+    expect(html).toMatch(/rgba\(251,191,36,0\.15\)/);
+    expect(html).toMatch(/rgba\(251,191,36,0\.4\)/);
+  });
+
+  it("is hidden (returns empty) when both completedPicks and tradeUpTicker are absent", () => {
+    const html = renderToString(<DraftTicker completedPicks={[]} />);
+    expect(html).toBe("");
+  });
+
+  it("shows ticker when tradeUpTicker present but completedPicks is empty", () => {
+    const tradeUpTicker = { type: "draft_trade_up", text: "📢 TRADE-UP: AAA acquired Pick #1!" };
+    const html = renderToString(
+      <DraftTicker completedPicks={[]} tradeUpTicker={tradeUpTicker} />,
+    );
+    expect(html).not.toBe("");
+    expect(html).toContain("TRADE-UP");
+  });
+
+  it("shows both ticker sections when completedPicks and tradeUpTicker both present", () => {
+    const pick = { overall: 1, teamAbbr: "KC", playerPos: "QB", playerName: "Player1", playerOvr: 75 };
+    const tradeUpTicker = { type: "draft_trade_up", text: "📢 TRADE-UP: MTN acquired Pick #5!" };
+
+    const html = renderToString(
+      <DraftTicker completedPicks={[pick]} tradeUpTicker={tradeUpTicker} />,
+    );
+
+    expect(html).toContain("LATEST");
+    expect(html).toContain("Player1");
+    expect(html).toContain("TRADE-UP");
+    expect(html).toContain("MTN acquired Pick #5");
+  });
+
+  it("has aria-live polite on the amber badge for accessibility", () => {
+    const tradeUpTicker = { type: "draft_trade_up", text: "📢 TRADE-UP: AAA acquired Pick #2!" };
+    const html = renderToString(
+      <DraftTicker completedPicks={[]} tradeUpTicker={tradeUpTicker} />,
+    );
+    expect(html).toContain('aria-live="polite"');
+  });
+});
+
+// ── DraftTradeDownPanel — draft_trade_up origin branch ────────────────────────
+
+describe("DraftTradeDownPanel — origin: draft_trade_up", () => {
+  const tradeUpProposal = {
+    origin: "draft_trade_up",
+    aiTeamName: "Mountain Lions",
+    aiTeamAbbr: "MTN",
+    userPickOverall: 4,
+    aiPickOverall: 11,
+    targetProspect: {
+      name: "JetSpeed Jones",
+      pos: "WR",
+      combineGrade: 9.1,
+    },
+    sweetenerRound: 0,
+    futurePkLabel: null,
+  };
+
+  it("renders Trade-Up Offer title for origin: draft_trade_up", () => {
+    const html = renderToString(
+      <DraftTradeDownPanel
+        pendingTradeProposal={tradeUpProposal}
+        processing={false}
+        onAccept={vi.fn()}
+        onDecline={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(html).toContain("Trade-Up Offer");
+  });
+
+  it("renders correct offer body text describing the trade-up", () => {
+    const html = renderToString(
+      <DraftTradeDownPanel
+        pendingTradeProposal={tradeUpProposal}
+        processing={false}
+        onAccept={vi.fn()}
+        onDecline={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    // React SSR inserts <!-- --> between JSX text and expression nodes, so
+    // "Pick #{value}" renders as "Pick #<!-- -->11<!-- -->". Check pieces separately.
+    expect(html).toContain("Mountain Lions");
+    expect(html).toContain("Pick #");
+    expect(html).toContain(">11<");   // aiPickOverall in its own text node
+    expect(html).toContain(">4<");    // userPickOverall in its own text node
+    expect(html).toContain("JetSpeed Jones");
+    expect(html).toContain("WR");
+  });
+
+  it("shows combine grade in the offer body", () => {
+    const html = renderToString(
+      <DraftTradeDownPanel
+        pendingTradeProposal={tradeUpProposal}
+        processing={false}
+        onAccept={vi.fn()}
+        onDecline={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(html).toContain("9.1");
+  });
+
+  it("shows 'Accept and Trade Down' button label for trade-up offers", () => {
+    const html = renderToString(
+      <DraftTradeDownPanel
+        pendingTradeProposal={tradeUpProposal}
+        processing={false}
+        onAccept={vi.fn()}
+        onDecline={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(html).toContain("Accept and Trade Down");
+  });
+
+  it("shows 'Decline and Keep Pick' button label for trade-up offers", () => {
+    const html = renderToString(
+      <DraftTradeDownPanel
+        pendingTradeProposal={tradeUpProposal}
+        processing={false}
+        onAccept={vi.fn()}
+        onDecline={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(html).toContain("Decline and Keep Pick");
+  });
+
+  it("only shows the trade-up branch for origin: draft_trade_up (not the legacy text)", () => {
+    const html = renderToString(
+      <DraftTradeDownPanel
+        pendingTradeProposal={tradeUpProposal}
+        processing={false}
+        onAccept={vi.fn()}
+        onDecline={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    // Legacy text should NOT appear
+    expect(html).not.toContain("are offering to trade up");
+    expect(html).not.toContain("You receive: their pick");
+  });
+
+  it("does NOT show trade-up title for legacy proposals (no origin field)", () => {
+    const legacyProposal = {
+      aiTeamName: "Dallas Cowboys",
+      aiTeamAbbr: "DAL",
+      userPickOverall: 8,
+      aiPickOverall: 15,
+      aiPickRound: 1,
+      targetProspect: { name: "Joe Smith", pos: "QB", ovr: 82 },
+    };
+
+    const html = renderToString(
+      <DraftTradeDownPanel
+        pendingTradeProposal={legacyProposal}
+        processing={false}
+        onAccept={vi.fn()}
+        onDecline={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(html).toContain("Trade Offer from");
+    expect(html).not.toContain("Trade-Up Offer");
+    expect(html).toContain("Accept Trade");
+  });
+
+  it("shows Processing… on accept button when processing=true", () => {
+    const html = renderToString(
+      <DraftTradeDownPanel
+        pendingTradeProposal={tradeUpProposal}
+        processing
+        onAccept={vi.fn()}
+        onDecline={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(html).toContain("Processing…");
+  });
+
+  it("renders future pick label in offer body when futurePkLabel is set", () => {
+    const withFuture = {
+      ...tradeUpProposal,
+      futurePkLabel: "2026 Round 2",
+    };
+    const html = renderToString(
+      <DraftTradeDownPanel
+        pendingTradeProposal={withFuture}
+        processing={false}
+        onAccept={vi.fn()}
+        onDecline={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(html).toContain("2026 Round 2");
+  });
+});

--- a/src/ui/draft/DraftTicker.jsx
+++ b/src/ui/draft/DraftTicker.jsx
@@ -1,41 +1,72 @@
 import React, { useMemo } from "react";
 import { ovrColor } from "./draftShared.js";
 
-export function DraftTicker({ completedPicks }) {
+export function DraftTicker({ completedPicks, tradeUpTicker = null }) {
   const lastPicks = useMemo(
     () => [...completedPicks].reverse().slice(0, 5),
     [completedPicks],
   );
 
-  if (lastPicks.length === 0) return null;
+  const showTicker = lastPicks.length > 0 || tradeUpTicker;
+  if (!showTicker) return null;
 
   return (
     <div
       className="draft-ticker"
       style={{ background: "var(--surface-strong)", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)", padding: "var(--space-2) var(--space-3)", marginBottom: "var(--space-4)", overflow: "hidden" }}
     >
-      <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
-        <span style={{ fontSize: 10, fontWeight: 800, color: "var(--accent)", textTransform: "uppercase", letterSpacing: "1px", flexShrink: 0, marginRight: "var(--space-2)" }}>
-          LATEST
-        </span>
-        <div style={{ display: "flex", gap: "var(--space-4)", overflowX: "auto", whiteSpace: "nowrap", flex: 1, scrollbarWidth: "none", msOverflowStyle: "none" }}>
-          {lastPicks.map((pk) => (
-            <span
-              key={pk.overall}
-              style={{ display: "inline-flex", alignItems: "center", gap: "var(--space-2)", fontSize: "var(--text-xs)", color: "var(--text)", animation: "tickerSlideIn 0.4s ease-out" }}
-            >
-              <span style={{ fontWeight: 800, color: "var(--text-muted)", fontSize: 10, minWidth: 18 }}>#{pk.overall}</span>
-              <span style={{ fontWeight: 700, color: "var(--accent)" }}>{pk.teamAbbr}</span>
-              <span style={{ color: "var(--text-muted)" }}>{pk.playerPos}</span>
-              <span style={{ fontWeight: 600 }}>{pk.playerName}</span>
-              <span style={{ padding: "0 4px", borderRadius: "var(--radius-pill)", background: `${ovrColor(pk.playerOvr ?? 0)}22`, color: ovrColor(pk.playerOvr ?? 0), fontWeight: 700, fontSize: 10 }}>
-                {pk.playerOvr}
-              </span>
-            </span>
-          ))}
+      {tradeUpTicker && (
+        <div style={{ marginBottom: lastPicks.length > 0 ? "var(--space-2)" : 0 }}>
+          <span
+            className="inline-flex items-center px-2 py-1 rounded text-sm font-semibold bg-amber-100 text-amber-900 dark:bg-amber-950/40 dark:text-amber-300 border border-amber-200 dark:border-amber-800 animate-bounce"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              padding: "2px 8px",
+              borderRadius: 6,
+              fontSize: "var(--text-xs)",
+              fontWeight: 700,
+              background: "rgba(251,191,36,0.15)",
+              color: "#92400e",
+              border: "1px solid rgba(251,191,36,0.4)",
+              animation: "var(--motion-safe, tradeUpBounce 1s infinite)",
+            }}
+            aria-live="polite"
+          >
+            {tradeUpTicker.text}
+          </span>
         </div>
-      </div>
-      <style>{`@keyframes tickerSlideIn { from { opacity: 0; transform: translateX(20px); } to { opacity: 1; transform: translateX(0); } }`}</style>
+      )}
+
+      {lastPicks.length > 0 && (
+        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-2)" }}>
+          <span style={{ fontSize: 10, fontWeight: 800, color: "var(--accent)", textTransform: "uppercase", letterSpacing: "1px", flexShrink: 0, marginRight: "var(--space-2)" }}>
+            LATEST
+          </span>
+          <div style={{ display: "flex", gap: "var(--space-4)", overflowX: "auto", whiteSpace: "nowrap", flex: 1, scrollbarWidth: "none", msOverflowStyle: "none" }}>
+            {lastPicks.map((pk) => (
+              <span
+                key={pk.overall}
+                style={{ display: "inline-flex", alignItems: "center", gap: "var(--space-2)", fontSize: "var(--text-xs)", color: "var(--text)", animation: "tickerSlideIn 0.4s ease-out" }}
+              >
+                <span style={{ fontWeight: 800, color: "var(--text-muted)", fontSize: 10, minWidth: 18 }}>#{pk.overall}</span>
+                <span style={{ fontWeight: 700, color: "var(--accent)" }}>{pk.teamAbbr}</span>
+                <span style={{ color: "var(--text-muted)" }}>{pk.playerPos}</span>
+                <span style={{ fontWeight: 600 }}>{pk.playerName}</span>
+                <span style={{ padding: "0 4px", borderRadius: "var(--radius-pill)", background: `${ovrColor(pk.playerOvr ?? 0)}22`, color: ovrColor(pk.playerOvr ?? 0), fontWeight: 700, fontSize: 10 }}>
+                  {pk.playerOvr}
+                </span>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <style>{`
+        @keyframes tickerSlideIn { from { opacity: 0; transform: translateX(20px); } to { opacity: 1; transform: translateX(0); } }
+        @keyframes tradeUpBounce { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-3px); } }
+        @media (prefers-reduced-motion: reduce) { .animate-bounce, [style*="tradeUpBounce"] { animation: none !important; } }
+      `}</style>
     </div>
   );
 }

--- a/src/ui/draft/DraftTradeDownPanel.jsx
+++ b/src/ui/draft/DraftTradeDownPanel.jsx
@@ -1,6 +1,51 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 
+function TradeUpOfferBody({ proposal }) {
+  const prospect  = proposal.targetProspect ?? {};
+  const futureLbl = proposal.futurePkLabel
+    ? ` ${proposal.futurePkLabel}`
+    : proposal.sweetenerRound > 0
+      ? ` + a future Round ${proposal.sweetenerRound} pick`
+      : '';
+  const gradeStr  = prospect.combineGrade != null ? ` (combine grade ${Number(prospect.combineGrade).toFixed(1)})` : '';
+
+  return (
+    <>
+      <div style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)", marginBottom: "var(--space-3)", lineHeight: 1.5 }}>
+        The{" "}
+        <strong style={{ color: "var(--text)" }}>{proposal.aiTeamName}</strong>{" "}
+        is offering Pick #{proposal.aiPickOverall}{futureLbl} in exchange for your current Pick #{proposal.userPickOverall}.
+        They are targeting{" "}
+        <strong style={{ color: "var(--text)" }}>
+          {prospect.pos} {prospect.name}{gradeStr}
+        </strong>.
+      </div>
+    </>
+  );
+}
+
+function LegacyOfferBody({ proposal }) {
+  return (
+    <>
+      <div style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)", marginBottom: "var(--space-3)", lineHeight: 1.5 }}>
+        The{" "}
+        <strong style={{ color: "var(--text)" }}>{proposal.aiTeamName}</strong>{" "}
+        are offering to trade up for your pick #{proposal.userPickOverall}.
+        They want to draft{" "}
+        <strong style={{ color: "var(--text)" }}>
+          {proposal.targetProspect?.name} ({proposal.targetProspect?.pos},{" "}
+          {proposal.targetProspect?.ovr} OVR)
+        </strong>.
+      </div>
+      <div style={{ fontSize: "var(--text-sm)", color: "var(--text)", marginBottom: "var(--space-3)", fontWeight: 600 }}>
+        You receive: their pick #{proposal.aiPickOverall} (Round{" "}
+        {proposal.aiPickRound}) + a later pick swap in this draft.
+      </div>
+    </>
+  );
+}
+
 export function DraftTradeDownPanel({
   pendingTradeProposal,
   processing,
@@ -8,19 +53,24 @@ export function DraftTradeDownPanel({
   onDecline,
   onClose,
 }) {
+  const isDraftTradeUp = pendingTradeProposal?.origin === 'draft_trade_up';
+  const title          = isDraftTradeUp ? 'Trade-Up Offer' : `Trade Offer from ${pendingTradeProposal.aiTeamAbbr}`;
+  const acceptLabel    = isDraftTradeUp ? 'Accept and Trade Down' : 'Accept Trade';
+  const declineLabel   = isDraftTradeUp ? 'Decline and Keep Pick' : 'Decline';
+
   return (
     <div
       style={{
         padding: "var(--space-4)",
         background: "var(--surface-strong)",
-        border: "1px solid var(--warning, #FF9F0A)",
+        border: `1px solid ${isDraftTradeUp ? 'rgba(251,191,36,0.5)' : 'var(--warning, #FF9F0A)'}`,
         borderRadius: "var(--radius-md)",
         marginBottom: "var(--space-3)",
       }}
     >
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "var(--space-3)" }}>
         <div style={{ fontWeight: 800, color: "var(--text)" }}>
-          Trade Offer from {pendingTradeProposal.aiTeamAbbr}
+          {title}
         </div>
         <Button
           className="btn"
@@ -30,20 +80,12 @@ export function DraftTradeDownPanel({
           ×
         </Button>
       </div>
-      <div style={{ fontSize: "var(--text-sm)", color: "var(--text-muted)", marginBottom: "var(--space-3)", lineHeight: 1.5 }}>
-        The{" "}
-        <strong style={{ color: "var(--text)" }}>{pendingTradeProposal.aiTeamName}</strong>{" "}
-        are offering to trade up for your pick #{pendingTradeProposal.userPickOverall}.
-        They want to draft{" "}
-        <strong style={{ color: "var(--text)" }}>
-          {pendingTradeProposal.targetProspect?.name} ({pendingTradeProposal.targetProspect?.pos},{" "}
-          {pendingTradeProposal.targetProspect?.ovr} OVR)
-        </strong>.
-      </div>
-      <div style={{ fontSize: "var(--text-sm)", color: "var(--text)", marginBottom: "var(--space-3)", fontWeight: 600 }}>
-        You receive: their pick #{pendingTradeProposal.aiPickOverall} (Round{" "}
-        {pendingTradeProposal.aiPickRound}) + a later pick swap in this draft.
-      </div>
+
+      {isDraftTradeUp
+        ? <TradeUpOfferBody proposal={pendingTradeProposal} />
+        : <LegacyOfferBody  proposal={pendingTradeProposal} />
+      }
+
       <div style={{ display: "flex", gap: "var(--space-3)" }}>
         <Button
           className="btn btn-primary"
@@ -51,14 +93,14 @@ export function DraftTradeDownPanel({
           onClick={onAccept}
           style={{ fontWeight: 600, fontSize: "var(--text-sm)", padding: "var(--space-2) var(--space-4)" }}
         >
-          {processing ? "Processing…" : "Accept Trade"}
+          {processing ? "Processing…" : acceptLabel}
         </Button>
         <Button
           className="btn"
           onClick={onDecline}
           style={{ fontWeight: 600, fontSize: "var(--text-sm)", padding: "var(--space-2) var(--space-4)" }}
         >
-          Decline
+          {declineLabel}
         </Button>
       </div>
     </div>

--- a/src/ui/draft/ProspectTable.jsx
+++ b/src/ui/draft/ProspectTable.jsx
@@ -78,7 +78,7 @@ function DraftBoard({
         isDraftComplete={board.isDraftComplete}
       />
 
-      <DraftTicker completedPicks={board.completedPicks} />
+      <DraftTicker completedPicks={board.completedPicks} tradeUpTicker={board.lastTradeUpTicker} />
 
       {board.pickOrder.length === 0 && (
         <div style={{ marginBottom: "var(--space-4)", padding: "var(--space-3)", borderRadius: "var(--radius-md)", background: "rgba(255,69,58,0.1)", border: "1px solid var(--danger)", color: "var(--danger)", fontSize: "var(--text-sm)" }}>

--- a/src/ui/draft/useDraftBoard.js
+++ b/src/ui/draft/useDraftBoard.js
@@ -35,6 +35,7 @@ export function useDraftBoard({ draftState, onDraftPlayer, onSimToMyPick, league
     pendingTradeProposal = null,
     recommendedPick = null,
     userBigBoard = [],
+    lastTradeUpTicker = null,
   } = draftState ?? {};
 
   useEffect(() => {
@@ -180,6 +181,7 @@ export function useDraftBoard({ draftState, onDraftPlayer, onSimToMyPick, league
     currentPick, isUserPick, isDraftComplete,
     prospects, completedPicks, upcomingPicks,
     pendingTradeProposal, recommendedPick,
+    lastTradeUpTicker,
     sortedByOvr, sortedProspects,
     compareIds, setCompareIds, showComparison, setShowComparison,
     toggleCompare, comparePlayerA, comparePlayerB,

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -262,6 +262,11 @@ import {
   applyPrivateWorkout,
   getAIDraftBoardAdjustment,
 } from '../core/draft/combineEngine.js';
+import {
+  findDraftTradeUpOpportunity,
+  applyDraftTradeUp,
+  DRAFT_TRADE_CONFIG,
+} from '../core/draft/draftTradeEngine.js';
 import { normalizeArchivedGamePayload, classifyArchiveQuality, validateArchivedGame, recoverArchivedGameFromSchedule, enrichArchivedGamePayload, mergeArchivedGameWithScheduleResult } from '../core/gameArchive.js';
 import {
   DEFAULT_LEAGUE_ECONOMY,
@@ -9759,6 +9764,7 @@ function buildDraftStateView() {
       rank: recommended.rank,
     } : null,
     pendingTradeProposal: meta.pendingDraftTradeProposal ?? null,
+    lastTradeUpTicker:    meta.draftLastTradeUp ?? null,
   };
 }
 
@@ -10627,6 +10633,65 @@ async function handleSimDraftPick(payload, id) {
     // Pause at user's pick
     if (pick.teamId === userTeamId) break;
 
+    // ── Draft trade-up: AI-to-AI ─────────────────────────────────────────────
+    // Before the AI makes its pick, check whether another AI team wants to trade
+    // up for this slot.  Evaluates once per pick (guarded by draftTradeUpEvaluatedPickIdx).
+    try {
+      const allActivePlayers = cache.getAllPlayers();
+      const tuState = {
+        meta:        ensureDynastyMeta(cache.getMeta()),
+        teams:       cache.getAllTeams(),
+        rosters:     allActivePlayers.filter((p) => p.status !== 'draft_eligible'),
+        draftPool:   allActivePlayers.filter((p) => p.status === 'draft_eligible').sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0)),
+        futurePicks: cache.getAllDraftPicks(),
+      };
+      const tuOpportunity = findDraftTradeUpOpportunity(tuState);
+      if (tuOpportunity?.type === 'ai_to_ai') {
+        const tuResult = applyDraftTradeUp(tuOpportunity, tuState);
+        // Apply swapped picks back into the live draftState
+        const liveMeta = cache.getMeta();
+        const liveDS = liveMeta?.draftState;
+        if (liveDS) {
+          tuResult.state.meta.draftState.picks.forEach((pk, idx) => {
+            if (liveDS.picks[idx] && liveDS.picks[idx].teamId !== pk.teamId) {
+              liveDS.picks[idx].teamId = pk.teamId;
+            }
+          });
+          // Mark evaluated, store ticker, persist trade record
+          const existingOffers3 = Array.isArray(liveMeta.tradeOffers) ? liveMeta.tradeOffers : [];
+          const tuRecord = tuResult.state.meta.tradeOffers[tuResult.state.meta.tradeOffers.length - 1];
+          cache.setMeta({
+            draftState: liveDS,
+            tradeOffers: tuRecord ? [...existingOffers3, tuRecord] : existingOffers3,
+            draftLastTradeUp: tuResult.ticker,
+            draftTradeUpEvaluatedPickIdx: currentPickIndex,
+          });
+          // Transfer any future pick ownership
+          if (tuOpportunity.package?.futurePick) {
+            const fp = tuOpportunity.package.futurePick;
+            const existing = cache.getDraftPick(fp.id);
+            if (existing) {
+              cache.updateDraftPick(fp.id, { ...existing, currentOwner: tuOpportunity.sellerTeamId, teamId: tuOpportunity.sellerTeamId });
+            }
+          }
+          // Emit news headline
+          if (tuResult.headline) {
+            await NewsEngine.logNews(
+              tuResult.headline.type,
+              tuResult.headline.text,
+              null,
+              { category: tuResult.headline.category, priority: tuResult.headline.priority, detail: tuResult.headline.detail, buyerTeamId: tuOpportunity.buyerTeamId, sellerTeamId: tuOpportunity.sellerTeamId },
+            );
+          }
+          // After trade: pick.teamId has changed — refresh local reference
+          pick.teamId = tuOpportunity.buyerTeamId;
+        }
+      }
+    } catch (tuErr) {
+      console.warn('[Worker] Draft trade-up evaluation error (non-fatal):', tuErr.message);
+    }
+    // ── End draft trade-up ────────────────────────────────────────────────────
+
     // AI selects by weighted board value (need, scheme fit, upside, combine/interview risk).
     const team = cache.getTeam(pick.teamId);
     const strategy = buildAiTeamStrategy({
@@ -10737,9 +10802,56 @@ async function handleSimDraftPick(payload, id) {
   if (postSimDraft) {
     const nextPick = postSimDraft.picks[postSimDraft.currentPickIndex];
     if (nextPick && nextPick.teamId === postSimMeta.userTeamId) {
-      const proposal = generateDraftTradeUpProposal();
-      if (proposal) {
-        post(toUI.DRAFT_TRADE_OFFER, { proposal });
+      // First, try the combine-grade based trade-up engine (new, richer logic)
+      let userProposal = null;
+      if (!postSimMeta.pendingDraftTradeProposal) {
+        try {
+          const allActivePlayers2 = cache.getAllPlayers();
+          const tuState2 = {
+            meta:        ensureDynastyMeta(cache.getMeta()),
+            teams:       cache.getAllTeams(),
+            rosters:     allActivePlayers2.filter((p) => p.status !== 'draft_eligible'),
+            draftPool:   allActivePlayers2.filter((p) => p.status === 'draft_eligible').sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0)),
+            futurePicks: cache.getAllDraftPicks(),
+          };
+          const tuOpp2 = findDraftTradeUpOpportunity(tuState2);
+          if (tuOpp2?.type === 'ai_to_user') {
+            const buyerT = cache.getTeam(tuOpp2.buyerTeamId);
+            const futurePkLabel = tuOpp2.package?.futurePick
+              ? ` + a future Round ${tuOpp2.package.futurePick.round} pick`
+              : '';
+            userProposal = {
+              origin:          'draft_trade_up',
+              aiTeamId:        tuOpp2.buyerTeamId,
+              aiTeamName:      buyerT?.name  ?? `Team ${tuOpp2.buyerTeamId}`,
+              aiTeamAbbr:      buyerT?.abbr  ?? '???',
+              aiPickOverall:   tuOpp2.package?.currentPickPackage?.overall ?? null,
+              aiPickRound:     tuOpp2.package?.currentPickPackage?.round   ?? null,
+              sweetenerRound:  tuOpp2.package?.futurePick?.round           ?? 0,
+              futurePkLabel,
+              tradeMode:       'draft_trade_up',
+              targetProspect: {
+                id:          tuOpp2.targetProspect.id,
+                name:        tuOpp2.targetProspect.name,
+                pos:         tuOpp2.targetProspect.pos,
+                ovr:         tuOpp2.targetProspect.ovr,
+                combineGrade: tuOpp2.targetProspect.combineMetrics?.combineGrade ?? null,
+              },
+              userPickOverall: nextPick.overall,
+              userPickRound:   nextPick.round,
+            };
+            cache.setMeta({ pendingDraftTradeProposal: userProposal, draftTradeUpEvaluatedPickIdx: postSimDraft.currentPickIndex });
+          }
+        } catch (tuErr2) {
+          console.warn('[Worker] Draft trade-up user offer error (non-fatal):', tuErr2.message);
+        }
+      }
+      // Fall back to legacy simple proposal (OVR-based, no combine grade check)
+      if (!userProposal && !postSimMeta.pendingDraftTradeProposal) {
+        userProposal = generateDraftTradeUpProposal();
+      }
+      if (userProposal) {
+        post(toUI.DRAFT_TRADE_OFFER, { proposal: userProposal });
       }
     }
   }
@@ -10826,7 +10938,13 @@ async function handleAcceptDraftTrade({ proposal }, id) {
 // ── Handler: REJECT_DRAFT_TRADE ─────────────────────────────────────────────
 
 async function handleRejectDraftTrade(payload, id) {
-  cache.setMeta({ pendingDraftTradeProposal: null });
+  // Mark current pick as evaluated so the engine won't re-propose after decline
+  const rejectMeta = cache.getMeta();
+  const currentIdx = rejectMeta?.draftState?.currentPickIndex ?? -1;
+  cache.setMeta({
+    pendingDraftTradeProposal: null,
+    draftTradeUpEvaluatedPickIdx: currentIdx,
+  });
   post(toUI.DRAFT_TRADE_RESULT, { accepted: false }, id);
 }
 


### PR DESCRIPTION
Adds a deterministic AI-driven draft-day trade-up system that triggers
when a combine standout (grade >= 8.5) is within 15 picks of the current
slot and a needy AI team can assemble a legal trade package.

New module `draftTradeEngine.js`:
- Pure functions, no Math.random — LCG seeded from pick context
- isCombineStandout, isProspectWithinTradeUpWindow, getStarterNeedAtPosition
- teamCanAffordRookie, buildTradeUpPackage, isSellerWillingToMoveDown
- evaluateDraftTradeUp, findDraftTradeUpOpportunity, applyDraftTradeUp
- Immutable state pattern — returns new objects, never mutates inputs
- Double-evaluation guard via meta.draftTradeUpEvaluatedPickIdx

Worker wiring (worker.js):
- Evaluates trade-up opportunity before each AI pick in handleSimDraftPick
- ai_to_ai: executes immediately, swaps pick ownership, emits headline+ticker
- ai_to_user: pauses draft and presents pending offer to user
- handleRejectDraftTrade sets evaluated guard to prevent re-offer after decline
- buildDraftStateView exposes lastTradeUpTicker for UI consumption

UI updates:
- DraftTicker: amber animated badge for trade-up events with aria-live
- DraftTradeDownPanel: TradeUpOfferBody branch for origin:'draft_trade_up'
- useDraftBoard: forwards lastTradeUpTicker from draftState
- ProspectTable: passes tradeUpTicker prop to DraftTicker

Tests: 3915 passing (340 test files) | build clean | soak 9/9

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011obiQWjA65jbit6NVzXpmr