### PR TITLE
feat(transactions): add pure waiverEngine.js module

### DIFF
--- a/src/core/news-engine.js
+++ b/src/core/news-engine.js
@@ -434,4 +434,27 @@ export const buildMoraleDropDedupeKey = (playerId, season, week) =>
 export const buildTradeRequestDeniedDedupeKey = (playerId, season, week) =>
     `trade-request-denied-${playerId}-${season}-${week}`;
 
+// ── Waiver Wire News Methods ─────────────────────────────────────────────────
+
+/**
+ * Log a waiver claim award news item.
+ */
+NewsEngine.logWaiverAward = async function logWaiverAward(teamName, playerName, teamId) {
+    await NewsEngine.logNews('TRANSACTION', `WAIVER CLAIM: ${teamName} awarded ${playerName}.`, teamId, { priority: 'medium' });
+};
+
+/**
+ * Log a waiver clearance news item (player cleared to free agency).
+ */
+NewsEngine.logWaiverClear = async function logWaiverClear(playerName) {
+    await NewsEngine.logNews('TRANSACTION', `${playerName} cleared waivers and is now a free agent.`, null, { priority: 'low' });
+};
+
+/**
+ * Log a waiver outbid news item (user was bypassed by higher priority team).
+ */
+NewsEngine.logWaiverOutbid = async function logWaiverOutbid(playerName, teamName, teamId) {
+    await NewsEngine.logNews('TRANSACTION', `You were bypassed on a waiver claim for ${playerName}; ${teamName} held higher priority.`, teamId, { priority: 'medium' });
+};
+
 export default NewsEngine;

--- a/src/core/transactions/__tests__/waiverEngine.unit.test.js
+++ b/src/core/transactions/__tests__/waiverEngine.unit.test.js
@@ -1,0 +1,813 @@
+/**
+ * waiverEngine.unit.test.js — Comprehensive unit tests for waiverEngine.js
+ *
+ * No Math.random usage. All tests are deterministic.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isWaiverWindowOpen,
+  buildWaiverPriorityList,
+  sendPlayerToWaivers,
+  canTeamClaimWaiverPlayer,
+  submitWaiverClaim,
+  findHighestPriorityClaim,
+  processWaivers,
+  shouldAIClaimWaiverPlayer,
+  generateAIWaiverClaims,
+} from '../waiverEngine.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeTeam(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Test Team',
+    wins: 5,
+    losses: 5,
+    ties: 0,
+    ptsFor: 200,
+    ptsAgainst: 200,
+    capUsed: 150,
+    capRoom: 50,
+    capTotal: 200,
+    ...overrides,
+  };
+}
+
+function makePlayer(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Test Player',
+    pos: 'WR',
+    ovr: 75,
+    age: 26,
+    teamId: 1,
+    status: 'active',
+    contract: {
+      baseAnnual: 5,
+      signingBonus: 10,
+      yearsTotal: 2,
+      years: 2,
+    },
+    ...overrides,
+  };
+}
+
+function makeClaim(overrides = {}) {
+  return {
+    playerId: '1',
+    teamId: 1,
+    submittedWeek: 11,
+    origin: 'user',
+    ...overrides,
+  };
+}
+
+// ── isWaiverWindowOpen ────────────────────────────────────────────────────────
+
+describe('isWaiverWindowOpen', () => {
+  it('returns true for week 11', () => {
+    expect(isWaiverWindowOpen(11)).toBe(true);
+  });
+
+  it('returns true for week 12', () => {
+    expect(isWaiverWindowOpen(12)).toBe(true);
+  });
+
+  it('returns true for week 13', () => {
+    expect(isWaiverWindowOpen(13)).toBe(true);
+  });
+
+  it('returns true for week 14', () => {
+    expect(isWaiverWindowOpen(14)).toBe(true);
+  });
+
+  it('returns false for week 10', () => {
+    expect(isWaiverWindowOpen(10)).toBe(false);
+  });
+
+  it('returns false for week 15', () => {
+    expect(isWaiverWindowOpen(15)).toBe(false);
+  });
+
+  it('returns false for week 1', () => {
+    expect(isWaiverWindowOpen(1)).toBe(false);
+  });
+
+  it('returns false for week 0', () => {
+    expect(isWaiverWindowOpen(0)).toBe(false);
+  });
+
+  it('handles null/undefined gracefully', () => {
+    expect(isWaiverWindowOpen(null)).toBe(false);
+    expect(isWaiverWindowOpen(undefined)).toBe(false);
+  });
+});
+
+// ── buildWaiverPriorityList ───────────────────────────────────────────────────
+
+describe('buildWaiverPriorityList', () => {
+  it('returns empty array for empty teams', () => {
+    expect(buildWaiverPriorityList([])).toEqual([]);
+  });
+
+  it('sorts worst record first', () => {
+    const teams = [
+      makeTeam({ id: 1, wins: 8, losses: 2, ties: 0 }),
+      makeTeam({ id: 2, wins: 2, losses: 8, ties: 0 }),
+      makeTeam({ id: 3, wins: 5, losses: 5, ties: 0 }),
+    ];
+    const list = buildWaiverPriorityList(teams);
+    expect(list[0]).toBe(2); // worst record first
+    expect(list[1]).toBe(3);
+    expect(list[2]).toBe(1); // best record last
+  });
+
+  it('uses point differential as tiebreaker', () => {
+    const teams = [
+      makeTeam({ id: 1, wins: 5, losses: 5, ties: 0, ptsFor: 200, ptsAgainst: 180 }),
+      makeTeam({ id: 2, wins: 5, losses: 5, ties: 0, ptsFor: 150, ptsAgainst: 200 }),
+    ];
+    const list = buildWaiverPriorityList(teams);
+    // Team 2 has worse point diff (-50 vs +20), so goes first
+    expect(list[0]).toBe(2);
+    expect(list[1]).toBe(1);
+  });
+
+  it('uses team id as final stable tiebreaker', () => {
+    const teams = [
+      makeTeam({ id: 10, wins: 5, losses: 5, ties: 0, ptsFor: 200, ptsAgainst: 200 }),
+      makeTeam({ id: 2, wins: 5, losses: 5, ties: 0, ptsFor: 200, ptsAgainst: 200 }),
+      makeTeam({ id: 5, wins: 5, losses: 5, ties: 0, ptsFor: 200, ptsAgainst: 200 }),
+    ];
+    const list = buildWaiverPriorityList(teams);
+    // String sort: "10" < "2" < "5"
+    expect(list[0]).toBe(10);
+    expect(list[1]).toBe(2);
+    expect(list[2]).toBe(5);
+  });
+
+  it('counts ties as 0.5 win in win percentage', () => {
+    const teams = [
+      makeTeam({ id: 1, wins: 4, losses: 4, ties: 2, ptsFor: 200, ptsAgainst: 200 }), // pct = (4+1)/10 = 0.5
+      makeTeam({ id: 2, wins: 3, losses: 7, ties: 0, ptsFor: 200, ptsAgainst: 200 }), // pct = 3/10 = 0.3
+    ];
+    const list = buildWaiverPriorityList(teams);
+    expect(list[0]).toBe(2); // worse record first
+    expect(list[1]).toBe(1);
+  });
+
+  it('handles 0-0-0 record gracefully', () => {
+    const teams = [
+      makeTeam({ id: 1, wins: 0, losses: 0, ties: 0 }),
+      makeTeam({ id: 2, wins: 0, losses: 0, ties: 0 }),
+    ];
+    const list = buildWaiverPriorityList(teams);
+    expect(list.length).toBe(2);
+    // Should be stable via id tiebreaker
+    expect(list[0]).toBe(1);
+    expect(list[1]).toBe(2);
+  });
+
+  it('returns IDs in same type as team.id', () => {
+    const teams = [
+      makeTeam({ id: 5, wins: 3, losses: 7, ties: 0 }),
+    ];
+    const list = buildWaiverPriorityList(teams);
+    expect(list[0]).toBe(5);
+  });
+});
+
+// ── sendPlayerToWaivers ───────────────────────────────────────────────────────
+
+describe('sendPlayerToWaivers', () => {
+  it('sets waiverStatus to ACTIVE', () => {
+    const player = makePlayer();
+    const result = sendPlayerToWaivers(player, 11, 3);
+    expect(result.waiverStatus).toBe('ACTIVE');
+  });
+
+  it('sets waiverWeekExpires to currentWeek + 1', () => {
+    const player = makePlayer();
+    const result = sendPlayerToWaivers(player, 11, 3);
+    expect(result.waiverWeekExpires).toBe(12);
+  });
+
+  it('shallow copies contract to waiverContract', () => {
+    const player = makePlayer();
+    const result = sendPlayerToWaivers(player, 11, 3);
+    expect(result.waiverContract).toEqual(player.contract);
+    expect(result.waiverContract).not.toBe(player.contract); // different reference
+  });
+
+  it('sets previousTeamId', () => {
+    const player = makePlayer();
+    const result = sendPlayerToWaivers(player, 11, 7);
+    expect(result.previousTeamId).toBe(7);
+  });
+
+  it('sets waiverContract to null if player has no contract', () => {
+    const player = makePlayer({ contract: null });
+    const result = sendPlayerToWaivers(player, 11, 3);
+    expect(result.waiverContract).toBeNull();
+  });
+
+  it('does not mutate the original player', () => {
+    const player = makePlayer();
+    const original = { ...player };
+    sendPlayerToWaivers(player, 11, 3);
+    expect(player).toEqual(original);
+  });
+
+  it('preserves all other player fields', () => {
+    const player = makePlayer({ ovr: 85, pos: 'QB' });
+    const result = sendPlayerToWaivers(player, 11, 3);
+    expect(result.ovr).toBe(85);
+    expect(result.pos).toBe('QB');
+    expect(result.name).toBe(player.name);
+  });
+
+  it('sets previousTeamId to null when not provided', () => {
+    const player = makePlayer();
+    const result = sendPlayerToWaivers(player, 11, null);
+    expect(result.previousTeamId).toBeNull();
+  });
+});
+
+// ── canTeamClaimWaiverPlayer ──────────────────────────────────────────────────
+
+describe('canTeamClaimWaiverPlayer', () => {
+  it('returns true when team has enough cap room', () => {
+    const team = makeTeam({ capRoom: 20 });
+    const player = makePlayer({
+      waiverContract: { baseAnnual: 5, signingBonus: 10, yearsTotal: 2 },
+    });
+    // capHit = 5 + 10/2 = 10
+    expect(canTeamClaimWaiverPlayer(team, player)).toBe(true);
+  });
+
+  it('returns false when team lacks cap room', () => {
+    const team = makeTeam({ capRoom: 5 });
+    const player = makePlayer({
+      waiverContract: { baseAnnual: 5, signingBonus: 10, yearsTotal: 2 },
+    });
+    // capHit = 5 + 10/2 = 10, room is 5
+    expect(canTeamClaimWaiverPlayer(team, player)).toBe(false);
+  });
+
+  it('returns true when team has exactly enough cap room', () => {
+    const team = makeTeam({ capRoom: 10 });
+    const player = makePlayer({
+      waiverContract: { baseAnnual: 5, signingBonus: 10, yearsTotal: 2 },
+    });
+    // capHit = 10
+    expect(canTeamClaimWaiverPlayer(team, player)).toBe(true);
+  });
+
+  it('returns true when player has no waiverContract', () => {
+    const team = makeTeam({ capRoom: 0 });
+    const player = makePlayer({ waiverContract: null });
+    expect(canTeamClaimWaiverPlayer(team, player)).toBe(true);
+  });
+
+  it('returns true when player has undefined waiverContract', () => {
+    const team = makeTeam({ capRoom: 0 });
+    const player = makePlayer();
+    delete player.waiverContract;
+    expect(canTeamClaimWaiverPlayer(team, player)).toBe(true);
+  });
+
+  it('handles team with null capRoom as 0', () => {
+    const team = makeTeam({ capRoom: null });
+    const player = makePlayer({
+      waiverContract: { baseAnnual: 1, signingBonus: 0, yearsTotal: 1 },
+    });
+    expect(canTeamClaimWaiverPlayer(team, player)).toBe(false);
+  });
+
+  it('handles missing baseAnnual/signingBonus in contract', () => {
+    const team = makeTeam({ capRoom: 100 });
+    const player = makePlayer({
+      waiverContract: { yearsTotal: 2 }, // no baseAnnual or signingBonus
+    });
+    // capHit = 0 + 0/2 = 0
+    expect(canTeamClaimWaiverPlayer(team, player)).toBe(true);
+  });
+});
+
+// ── submitWaiverClaim ────────────────────────────────────────────────────────
+
+describe('submitWaiverClaim', () => {
+  it('adds a new claim to empty array', () => {
+    const result = submitWaiverClaim([], makeClaim());
+    expect(result.length).toBe(1);
+  });
+
+  it('adds a new claim without duplicates', () => {
+    const existing = [makeClaim({ playerId: '1', teamId: 1 })];
+    const newClaim = makeClaim({ playerId: '2', teamId: 1 });
+    const result = submitWaiverClaim(existing, newClaim);
+    expect(result.length).toBe(2);
+  });
+
+  it('does not add a duplicate (same playerId + teamId)', () => {
+    const existing = [makeClaim({ playerId: '1', teamId: 1 })];
+    const dup = makeClaim({ playerId: '1', teamId: 1 });
+    const result = submitWaiverClaim(existing, dup);
+    expect(result.length).toBe(1);
+  });
+
+  it('compares playerId and teamId as strings', () => {
+    const existing = [makeClaim({ playerId: '1', teamId: 1 })];
+    const dup = makeClaim({ playerId: 1, teamId: '1' }); // different types, same values
+    const result = submitWaiverClaim(existing, dup);
+    expect(result.length).toBe(1); // still a duplicate
+  });
+
+  it('does not mutate the original array', () => {
+    const existing = [makeClaim()];
+    const newClaim = makeClaim({ playerId: '99' });
+    submitWaiverClaim(existing, newClaim);
+    expect(existing.length).toBe(1); // unchanged
+  });
+
+  it('handles null/undefined claims array gracefully', () => {
+    const result = submitWaiverClaim(null, makeClaim());
+    expect(result.length).toBe(1);
+  });
+});
+
+// ── findHighestPriorityClaim ──────────────────────────────────────────────────
+
+describe('findHighestPriorityClaim', () => {
+  it('returns null for empty claims', () => {
+    expect(findHighestPriorityClaim([], [1, 2, 3])).toBeNull();
+  });
+
+  it('returns null for empty priority list', () => {
+    expect(findHighestPriorityClaim([makeClaim()], [])).toBeNull();
+  });
+
+  it('returns the claim with lowest priority list index', () => {
+    const claims = [
+      makeClaim({ teamId: 3, playerId: '1' }),
+      makeClaim({ teamId: 1, playerId: '1' }),
+      makeClaim({ teamId: 2, playerId: '1' }),
+    ];
+    const priorityList = [1, 2, 3]; // team 1 has highest priority (index 0)
+    const result = findHighestPriorityClaim(claims, priorityList);
+    expect(result.teamId).toBe(1);
+  });
+
+  it('skips teams not in priority list', () => {
+    const claims = [
+      makeClaim({ teamId: 99, playerId: '1' }), // not in priority list
+      makeClaim({ teamId: 2, playerId: '1' }),
+    ];
+    const priorityList = [1, 2, 3];
+    const result = findHighestPriorityClaim(claims, priorityList);
+    expect(result.teamId).toBe(2);
+  });
+
+  it('returns null when no claims are in priority list', () => {
+    const claims = [makeClaim({ teamId: 99 })];
+    const priorityList = [1, 2, 3];
+    const result = findHighestPriorityClaim(claims, priorityList);
+    expect(result).toBeNull();
+  });
+
+  it('handles string vs number teamId comparison', () => {
+    const claims = [makeClaim({ teamId: '2', playerId: '1' })];
+    const priorityList = [1, 2, 3]; // teamId 2 is at index 1
+    const result = findHighestPriorityClaim(claims, priorityList);
+    expect(String(result.teamId)).toBe('2');
+  });
+});
+
+// ── processWaivers ───────────────────────────────────────────────────────────
+
+describe('processWaivers', () => {
+  function makeLeagueState(overrides = {}) {
+    const teams = [
+      makeTeam({ id: 1, name: 'Team A', capRoom: 50 }),
+      makeTeam({ id: 2, name: 'Team B', capRoom: 50 }),
+      makeTeam({ id: 3, name: 'Team C', capRoom: 50 }),
+    ];
+    const player = makePlayer({
+      id: 10,
+      name: 'Waiver Player',
+      waiverStatus: 'ACTIVE',
+      waiverWeekExpires: 12,
+      waiverContract: { baseAnnual: 5, signingBonus: 0, yearsTotal: 1 },
+      teamId: null,
+      status: 'waiver',
+    });
+    return {
+      players: [player],
+      teams,
+      activeWaiverClaims: [],
+      waiverPriorityList: [1, 2, 3],
+      currentWeek: 12,
+      ...overrides,
+    };
+  }
+
+  it('awards player to highest priority claimant', () => {
+    const state = makeLeagueState({
+      activeWaiverClaims: [
+        makeClaim({ playerId: '10', teamId: 2 }),
+        makeClaim({ playerId: '10', teamId: 1 }),
+      ],
+    });
+    const result = processWaivers(state);
+    const awarded = result.players.find(p => p.id === 10);
+    expect(awarded.teamId).toBe(1); // team 1 is highest priority
+    expect(awarded.status).toBe('active');
+    expect(result.awards.length).toBe(1);
+    expect(result.awards[0].teamId).toBe(1);
+  });
+
+  it('clears player to free agent when no claims', () => {
+    const state = makeLeagueState({ activeWaiverClaims: [] });
+    const result = processWaivers(state);
+    const cleared = result.players.find(p => p.id === 10);
+    expect(cleared.teamId).toBeNull();
+    expect(cleared.status).toBe('free_agent');
+    expect(result.clearances.length).toBe(1);
+  });
+
+  it('skips claimants who fail cap check', () => {
+    const state = makeLeagueState({
+      teams: [
+        makeTeam({ id: 1, name: 'Team A', capRoom: 0 }), // can't afford
+        makeTeam({ id: 2, name: 'Team B', capRoom: 50 }),
+      ],
+      waiverPriorityList: [1, 2],
+      activeWaiverClaims: [
+        makeClaim({ playerId: '10', teamId: 1 }),
+        makeClaim({ playerId: '10', teamId: 2 }),
+      ],
+    });
+    const result = processWaivers(state);
+    const awarded = result.players.find(p => p.id === 10);
+    expect(awarded.teamId).toBe(2); // team 1 skipped, team 2 wins
+  });
+
+  it('moves winning team to bottom of priority list', () => {
+    const state = makeLeagueState({
+      waiverPriorityList: [1, 2, 3],
+      activeWaiverClaims: [makeClaim({ playerId: '10', teamId: 1 })],
+    });
+    const result = processWaivers(state);
+    expect(result.waiverPriorityList[0]).toBe(2);
+    expect(result.waiverPriorityList[result.waiverPriorityList.length - 1]).toBe(1);
+  });
+
+  it('sets contract from waiverContract when awarding', () => {
+    const waiverContract = { baseAnnual: 8, signingBonus: 4, yearsTotal: 2, years: 2 };
+    const state = makeLeagueState({
+      players: [makePlayer({
+        id: 10,
+        waiverStatus: 'ACTIVE',
+        waiverWeekExpires: 12,
+        waiverContract,
+        teamId: null,
+        status: 'waiver',
+      })],
+      activeWaiverClaims: [makeClaim({ playerId: '10', teamId: 1 })],
+    });
+    const result = processWaivers(state);
+    const awarded = result.players.find(p => p.id === 10);
+    expect(awarded.contract).toEqual(waiverContract);
+  });
+
+  it('clears waiverStatus/waiverWeekExpires/waiverContract/previousTeamId on award', () => {
+    const state = makeLeagueState({
+      activeWaiverClaims: [makeClaim({ playerId: '10', teamId: 1 })],
+    });
+    const result = processWaivers(state);
+    const awarded = result.players.find(p => p.id === 10);
+    expect(awarded.waiverStatus).toBeUndefined();
+    expect(awarded.waiverWeekExpires).toBeUndefined();
+    expect(awarded.waiverContract).toBeUndefined();
+    expect(awarded.previousTeamId).toBeUndefined();
+  });
+
+  it('only processes players with waiverStatus ACTIVE', () => {
+    const state = makeLeagueState({
+      players: [
+        makePlayer({ id: 10, waiverStatus: 'ACTIVE', waiverWeekExpires: 12, waiverContract: { baseAnnual: 5, yearsTotal: 1 }, teamId: null, status: 'waiver' }),
+        makePlayer({ id: 11, waiverStatus: null, status: 'active', teamId: 1 }), // not on waivers
+      ],
+      activeWaiverClaims: [
+        makeClaim({ playerId: '10', teamId: 1 }),
+      ],
+    });
+    const result = processWaivers(state);
+    const p11 = result.players.find(p => p.id === 11);
+    expect(p11.teamId).toBe(1); // unchanged
+    expect(p11.status).toBe('active'); // unchanged
+  });
+
+  it('only processes players where waiverWeekExpires <= currentWeek', () => {
+    const state = makeLeagueState({
+      players: [
+        makePlayer({ id: 10, waiverStatus: 'ACTIVE', waiverWeekExpires: 13, waiverContract: { baseAnnual: 5, yearsTotal: 1 }, teamId: null, status: 'waiver' }),
+      ],
+      currentWeek: 12, // expires next week
+      activeWaiverClaims: [makeClaim({ playerId: '10', teamId: 1 })],
+    });
+    const result = processWaivers(state);
+    const p = result.players.find(p => p.id === 10);
+    // Not yet processed
+    expect(p.waiverStatus).toBe('ACTIVE');
+    expect(result.awards.length).toBe(0);
+  });
+
+  it('removes processed claims from activeWaiverClaims', () => {
+    const state = makeLeagueState({
+      activeWaiverClaims: [
+        makeClaim({ playerId: '10', teamId: 1 }),
+        makeClaim({ playerId: '10', teamId: 2 }),
+        makeClaim({ playerId: '99', teamId: 1 }), // different player, should remain
+      ],
+    });
+    const result = processWaivers(state);
+    // Claims for player 10 should be removed
+    const remainingForP10 = result.activeWaiverClaims.filter(c => c.playerId === '10');
+    expect(remainingForP10.length).toBe(0);
+    // Claim for player 99 should remain
+    const remainingForP99 = result.activeWaiverClaims.filter(c => c.playerId === '99');
+    expect(remainingForP99.length).toBe(1);
+  });
+
+  it('does not mutate input arrays', () => {
+    const state = makeLeagueState({
+      activeWaiverClaims: [makeClaim({ playerId: '10', teamId: 1 })],
+    });
+    const originalPlayers = [...state.players];
+    const originalClaims = [...state.activeWaiverClaims];
+    processWaivers(state);
+    expect(state.players).toEqual(originalPlayers);
+    expect(state.activeWaiverClaims).toEqual(originalClaims);
+  });
+
+  it('returns proper playerName and teamName in awards', () => {
+    const state = makeLeagueState({
+      activeWaiverClaims: [makeClaim({ playerId: '10', teamId: 1 })],
+    });
+    const result = processWaivers(state);
+    expect(result.awards[0].playerName).toBe('Waiver Player');
+    expect(result.awards[0].teamName).toBe('Team A');
+  });
+
+  it('handles empty inputs gracefully', () => {
+    const result = processWaivers({
+      players: [],
+      teams: [],
+      activeWaiverClaims: [],
+      waiverPriorityList: [],
+      currentWeek: 12,
+    });
+    expect(result.players).toEqual([]);
+    expect(result.awards).toEqual([]);
+    expect(result.clearances).toEqual([]);
+  });
+
+  it('processes multiple players in one call', () => {
+    const state = {
+      players: [
+        makePlayer({ id: 10, name: 'Player A', waiverStatus: 'ACTIVE', waiverWeekExpires: 12, waiverContract: { baseAnnual: 5, yearsTotal: 1 }, teamId: null, status: 'waiver' }),
+        makePlayer({ id: 11, name: 'Player B', waiverStatus: 'ACTIVE', waiverWeekExpires: 12, waiverContract: { baseAnnual: 5, yearsTotal: 1 }, teamId: null, status: 'waiver' }),
+      ],
+      teams: [
+        makeTeam({ id: 1, name: 'Team A', capRoom: 100 }),
+        makeTeam({ id: 2, name: 'Team B', capRoom: 100 }),
+      ],
+      activeWaiverClaims: [
+        makeClaim({ playerId: '10', teamId: 1 }),
+        makeClaim({ playerId: '11', teamId: 2 }),
+      ],
+      waiverPriorityList: [1, 2],
+      currentWeek: 12,
+    };
+    const result = processWaivers(state);
+    expect(result.awards.length).toBe(2);
+    expect(result.clearances.length).toBe(0);
+  });
+});
+
+// ── shouldAIClaimWaiverPlayer ─────────────────────────────────────────────────
+
+describe('shouldAIClaimWaiverPlayer', () => {
+  function makeLeagueState(overrides = {}) {
+    return {
+      players: [],
+      teams: [],
+      activeWaiverClaims: [],
+      ...overrides,
+    };
+  }
+
+  it('returns false when player is null', () => {
+    const team = makeTeam();
+    expect(shouldAIClaimWaiverPlayer(team, null, makeLeagueState())).toBe(false);
+  });
+
+  it('returns false when team is null', () => {
+    const player = makePlayer({ ovr: 80 });
+    expect(shouldAIClaimWaiverPlayer(null, player, makeLeagueState())).toBe(false);
+  });
+
+  it('returns false when team lacks cap room', () => {
+    const team = makeTeam({ capRoom: 0 });
+    const player = makePlayer({
+      ovr: 80,
+      pos: 'WR',
+      waiverContract: { baseAnnual: 10, signingBonus: 0, yearsTotal: 1 },
+    });
+    expect(shouldAIClaimWaiverPlayer(team, player, makeLeagueState())).toBe(false);
+  });
+
+  it('returns false when team already has a claim for this player', () => {
+    const team = makeTeam({ id: 1, capRoom: 100 });
+    const player = makePlayer({ id: 5, ovr: 80, pos: 'WR', waiverContract: null });
+    const leagueState = makeLeagueState({
+      activeWaiverClaims: [makeClaim({ playerId: '5', teamId: 1 })],
+    });
+    expect(shouldAIClaimWaiverPlayer(team, player, leagueState)).toBe(false);
+  });
+
+  it('returns true when player OVR is greater than starter OVR minus 3', () => {
+    const team = makeTeam({ id: 1, capRoom: 100 });
+    const player = makePlayer({ id: 5, ovr: 80, pos: 'WR', waiverContract: null });
+    const leagueState = makeLeagueState({
+      players: [
+        makePlayer({ id: 10, teamId: 1, pos: 'WR', ovr: 75 }), // starter at 75
+      ],
+    });
+    // player.ovr (80) > starterOvr (75) - 3 = 72 → true
+    expect(shouldAIClaimWaiverPlayer(team, player, leagueState)).toBe(true);
+  });
+
+  it('returns false when player OVR is not better enough than starter', () => {
+    const team = makeTeam({ id: 1, capRoom: 100 });
+    const player = makePlayer({ id: 5, ovr: 70, pos: 'WR', waiverContract: null });
+    const leagueState = makeLeagueState({
+      players: [
+        makePlayer({ id: 10, teamId: 1, pos: 'WR', ovr: 85 }), // high OVR starter
+      ],
+    });
+    // player.ovr (70) > starterOvr (85) - 3 = 82 → false
+    expect(shouldAIClaimWaiverPlayer(team, player, leagueState)).toBe(false);
+  });
+
+  it('returns true when team has no player at that position (starterOvr = 0)', () => {
+    const team = makeTeam({ id: 1, capRoom: 100 });
+    const player = makePlayer({ id: 5, ovr: 60, pos: 'K', waiverContract: null });
+    const leagueState = makeLeagueState({
+      players: [], // no kicker
+    });
+    // player.ovr (60) > starterOvr (0) - 3 = -3 → true
+    expect(shouldAIClaimWaiverPlayer(team, player, leagueState)).toBe(true);
+  });
+
+  it('uses highest OVR player at position as starter', () => {
+    const team = makeTeam({ id: 1, capRoom: 100 });
+    const player = makePlayer({ id: 5, ovr: 80, pos: 'QB', waiverContract: null });
+    const leagueState = makeLeagueState({
+      players: [
+        makePlayer({ id: 10, teamId: 1, pos: 'QB', ovr: 75 }),
+        makePlayer({ id: 11, teamId: 1, pos: 'QB', ovr: 90 }), // best QB
+        makePlayer({ id: 12, teamId: 1, pos: 'QB', ovr: 60 }),
+      ],
+    });
+    // player.ovr (80) > starterOvr (90) - 3 = 87 → false
+    expect(shouldAIClaimWaiverPlayer(team, player, leagueState)).toBe(false);
+  });
+});
+
+// ── generateAIWaiverClaims ────────────────────────────────────────────────────
+
+describe('generateAIWaiverClaims', () => {
+  it('returns unchanged claims when no waiver players', () => {
+    const result = generateAIWaiverClaims({
+      teams: [makeTeam({ id: 1 })],
+      players: [makePlayer({ id: 1, status: 'active', waiverStatus: null })],
+      waiverPriorityList: [1],
+      activeWaiverClaims: [],
+      currentWeek: 11,
+      userTeamId: 99,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('skips user team', () => {
+    const userTeam = makeTeam({ id: 1, capRoom: 100 });
+    const waiverPlayer = makePlayer({
+      id: 5,
+      ovr: 80,
+      pos: 'WR',
+      waiverStatus: 'ACTIVE',
+      teamId: null,
+      waiverContract: null,
+    });
+    const result = generateAIWaiverClaims({
+      teams: [userTeam],
+      players: [waiverPlayer],
+      waiverPriorityList: [1],
+      activeWaiverClaims: [],
+      currentWeek: 11,
+      userTeamId: 1, // skip this team
+    });
+    expect(result.length).toBe(0);
+  });
+
+  it('generates claims for eligible AI teams', () => {
+    const aiTeam = makeTeam({ id: 2, capRoom: 100 });
+    const waiverPlayer = makePlayer({
+      id: 5,
+      ovr: 80,
+      pos: 'WR',
+      waiverStatus: 'ACTIVE',
+      teamId: null,
+      waiverContract: null,
+    });
+    const result = generateAIWaiverClaims({
+      teams: [aiTeam],
+      players: [waiverPlayer],
+      waiverPriorityList: [2],
+      activeWaiverClaims: [],
+      currentWeek: 11,
+      userTeamId: 1,
+    });
+    expect(result.length).toBe(1);
+    expect(result[0].teamId).toBe(2);
+    expect(String(result[0].playerId)).toBe('5');
+    expect(result[0].origin).toBe('ai');
+  });
+
+  it('does not add duplicate claims', () => {
+    const aiTeam = makeTeam({ id: 2, capRoom: 100 });
+    const waiverPlayer = makePlayer({
+      id: 5,
+      ovr: 80,
+      pos: 'WR',
+      waiverStatus: 'ACTIVE',
+      teamId: null,
+      waiverContract: null,
+    });
+    const existingClaims = [
+      { playerId: '5', teamId: 2, submittedWeek: 11, origin: 'ai' },
+    ];
+    const result = generateAIWaiverClaims({
+      teams: [aiTeam],
+      players: [waiverPlayer],
+      waiverPriorityList: [2],
+      activeWaiverClaims: existingClaims,
+      currentWeek: 11,
+      userTeamId: 1,
+    });
+    // Should not add another claim for same player+team
+    const claimsForP5 = result.filter(c => String(c.playerId) === '5' && String(c.teamId) === '2');
+    expect(claimsForP5.length).toBe(1);
+  });
+
+  it('processes teams in waiverPriorityList order', () => {
+    const teams = [
+      makeTeam({ id: 1, capRoom: 100 }),
+      makeTeam({ id: 2, capRoom: 100 }),
+    ];
+    const waiverPlayer = makePlayer({
+      id: 5,
+      ovr: 50,
+      pos: 'WR',
+      waiverStatus: 'ACTIVE',
+      teamId: null,
+      waiverContract: null,
+    });
+    const result = generateAIWaiverClaims({
+      teams,
+      players: [waiverPlayer],
+      waiverPriorityList: [2, 1], // team 2 first
+      activeWaiverClaims: [],
+      currentWeek: 11,
+      userTeamId: 99, // neither team is user
+    });
+    // Both teams should claim (player is better than no starter)
+    expect(result.length).toBe(2);
+  });
+
+  it('handles empty inputs gracefully', () => {
+    const result = generateAIWaiverClaims({
+      teams: [],
+      players: [],
+      waiverPriorityList: [],
+      activeWaiverClaims: [],
+      currentWeek: 11,
+      userTeamId: 1,
+    });
+    expect(result).toEqual([]);
+  });
+});

--- a/src/core/transactions/waiverEngine.js
+++ b/src/core/transactions/waiverEngine.js
@@ -205,6 +205,9 @@ export function processWaivers({ players, teams, activeWaiverClaims, waiverPrior
 
     const winner = findHighestPriorityClaim(validClaims, priorityList);
 
+    // Fields to delete (remove from player object) after waiver processing
+    const WAIVER_CLEAR_FIELDS = ['waiverStatus', 'waiverWeekExpires', 'waiverContract', 'previousTeamId'];
+
     if (winner) {
       // Award player to winning team
       const winningTeam = allTeams.find(t => String(t.id) === String(winner.teamId));
@@ -212,10 +215,7 @@ export function processWaivers({ players, teams, activeWaiverClaims, waiverPrior
         teamId: winner.teamId,
         status: 'active',
         contract: player.waiverContract ? { ...player.waiverContract } : player.contract,
-        waiverStatus: null,
-        waiverWeekExpires: null,
-        waiverContract: null,
-        previousTeamId: null,
+        _clearFields: WAIVER_CLEAR_FIELDS,
       });
 
       awards.push({
@@ -236,10 +236,7 @@ export function processWaivers({ players, teams, activeWaiverClaims, waiverPrior
       playerUpdates.set(playerId, {
         teamId: null,
         status: 'free_agent',
-        waiverStatus: null,
-        waiverWeekExpires: null,
-        waiverContract: null,
-        previousTeamId: null,
+        _clearFields: WAIVER_CLEAR_FIELDS,
       });
 
       clearances.push({
@@ -253,13 +250,13 @@ export function processWaivers({ players, teams, activeWaiverClaims, waiverPrior
   const newPlayers = allPlayers.map(p => {
     const patch = playerUpdates.get(p.id);
     if (!patch) return p;
-    // Merge patch, removing null-valued keys to keep objects clean
-    const merged = { ...p };
-    for (const [key, val] of Object.entries(patch)) {
-      if (val === null) {
+    const { _clearFields, ...fieldPatch } = patch;
+    // Merge regular field updates
+    const merged = { ...p, ...fieldPatch };
+    // Delete waiver-specific fields that should be removed from the player object
+    if (Array.isArray(_clearFields)) {
+      for (const key of _clearFields) {
         delete merged[key];
-      } else {
-        merged[key] = val;
       }
     }
     return merged;

--- a/src/core/transactions/waiverEngine.js
+++ b/src/core/transactions/waiverEngine.js
@@ -1,0 +1,370 @@
+/**
+ * waiverEngine.js — Post-Deadline Waiver Wire System
+ *
+ * Pure module: no UI imports, no worker imports, no Math.random.
+ * All functions are deterministic and immutable (no mutation of inputs).
+ *
+ * Waiver window: weeks 11-14 inclusive (post-trade deadline).
+ */
+
+// ── Helper ──────────────────────────────────────────────────────────────────
+
+/**
+ * Compute the cap hit for a contract.
+ * capHit = baseAnnual + signingBonus / yearsTotal
+ */
+function capHit(contract) {
+  if (!contract) return 0;
+  const base = contract.baseAnnual ?? 0;
+  const bonus = contract.signingBonus ?? 0;
+  const years = contract.yearsTotal || 1;
+  return base + bonus / years;
+}
+
+// ── isWaiverWindowOpen ───────────────────────────────────────────────────────
+
+/**
+ * Returns true if the waiver wire is open (weeks 11-14 inclusive).
+ * @param {number} currentWeek
+ * @returns {boolean}
+ */
+export function isWaiverWindowOpen(currentWeek) {
+  const week = Number(currentWeek ?? 0);
+  return week >= 11 && week <= 14;
+}
+
+// ── buildWaiverPriorityList ──────────────────────────────────────────────────
+
+/**
+ * Sort teams worst-to-best by:
+ *  1. win percentage ascending (ties count as 0.5 win)
+ *  2. tiebreaker: (ptsFor - ptsAgainst) ascending
+ *  3. final stable tiebreaker: String(team.id) ascending
+ *
+ * Returns array of team IDs (same type as team.id).
+ * @param {Array} teams
+ * @returns {Array}
+ */
+export function buildWaiverPriorityList(teams) {
+  if (!Array.isArray(teams) || teams.length === 0) return [];
+
+  const sorted = [...teams].sort((a, b) => {
+    const winsA = (a.wins ?? 0) + (a.ties ?? 0) * 0.5;
+    const winsB = (b.wins ?? 0) + (b.ties ?? 0) * 0.5;
+    const gamesA = (a.wins ?? 0) + (a.losses ?? 0) + (a.ties ?? 0);
+    const gamesB = (b.wins ?? 0) + (b.losses ?? 0) + (b.ties ?? 0);
+    const pctA = gamesA > 0 ? winsA / gamesA : 0;
+    const pctB = gamesB > 0 ? winsB / gamesB : 0;
+
+    if (pctA !== pctB) return pctA - pctB; // ascending (worst first)
+
+    const diffA = (a.ptsFor ?? 0) - (a.ptsAgainst ?? 0);
+    const diffB = (b.ptsFor ?? 0) - (b.ptsAgainst ?? 0);
+    if (diffA !== diffB) return diffA - diffB; // ascending (worst first)
+
+    return String(a.id) < String(b.id) ? -1 : String(a.id) > String(b.id) ? 1 : 0;
+  });
+
+  return sorted.map(t => t.id);
+}
+
+// ── sendPlayerToWaivers ──────────────────────────────────────────────────────
+
+/**
+ * Immutably update a player to go on waivers.
+ * Sets waiverStatus, waiverWeekExpires, waiverContract, previousTeamId.
+ * @param {Object} player
+ * @param {number} currentWeek
+ * @param {number|null} previousTeamId
+ * @returns {Object} updated player (shallow copy)
+ */
+export function sendPlayerToWaivers(player, currentWeek, previousTeamId) {
+  return {
+    ...player,
+    waiverStatus: 'ACTIVE',
+    waiverWeekExpires: Number(currentWeek) + 1,
+    waiverContract: player.contract ? { ...player.contract } : null,
+    previousTeamId: previousTeamId ?? null,
+  };
+}
+
+// ── canTeamClaimWaiverPlayer ─────────────────────────────────────────────────
+
+/**
+ * Returns true if the team has enough cap room to absorb the player's waiver contract.
+ * If no waiverContract, always returns true.
+ * @param {Object} team
+ * @param {Object} player
+ * @returns {boolean}
+ */
+export function canTeamClaimWaiverPlayer(team, player) {
+  if (!player.waiverContract) return true;
+  const hit = capHit(player.waiverContract);
+  const room = team?.capRoom ?? 0;
+  return room >= hit;
+}
+
+// ── submitWaiverClaim ────────────────────────────────────────────────────────
+
+/**
+ * Immutably add a claim to the claims array, unless a duplicate exists
+ * (same playerId + teamId).
+ * @param {Array} claims
+ * @param {Object} claim — { playerId, teamId, ... }
+ * @returns {Array} new claims array
+ */
+export function submitWaiverClaim(claims, claim) {
+  const existing = Array.isArray(claims) ? claims : [];
+  const dup = existing.some(
+    c => String(c.playerId) === String(claim.playerId) && String(c.teamId) === String(claim.teamId)
+  );
+  if (dup) return existing;
+  return [...existing, claim];
+}
+
+// ── findHighestPriorityClaim ─────────────────────────────────────────────────
+
+/**
+ * Find the claim whose teamId has the lowest index in waiverPriorityList.
+ * Skip teams not in the priority list.
+ * @param {Array} claims
+ * @param {Array} waiverPriorityList — ordered array of team IDs
+ * @returns {Object|null}
+ */
+export function findHighestPriorityClaim(claims, waiverPriorityList) {
+  if (!Array.isArray(claims) || claims.length === 0) return null;
+  if (!Array.isArray(waiverPriorityList) || waiverPriorityList.length === 0) return null;
+
+  let bestClaim = null;
+  let bestIndex = Infinity;
+
+  for (const claim of claims) {
+    const idx = waiverPriorityList.findIndex(id => String(id) === String(claim.teamId));
+    if (idx === -1) continue; // not in priority list, skip
+    if (idx < bestIndex) {
+      bestIndex = idx;
+      bestClaim = claim;
+    }
+  }
+
+  return bestClaim;
+}
+
+// ── processWaivers ───────────────────────────────────────────────────────────
+
+/**
+ * Process all eligible waiver players (waiverStatus === 'ACTIVE' AND waiverWeekExpires <= currentWeek).
+ * Immutable: returns new arrays, does not mutate inputs.
+ *
+ * @param {Object} params
+ * @param {Array} params.players
+ * @param {Array} params.teams
+ * @param {Array} params.activeWaiverClaims
+ * @param {Array} params.waiverPriorityList
+ * @param {number} params.currentWeek
+ * @returns {{ players, teams, waiverPriorityList, activeWaiverClaims, awards, clearances }}
+ */
+export function processWaivers({ players, teams, activeWaiverClaims, waiverPriorityList, currentWeek }) {
+  const allPlayers = Array.isArray(players) ? players : [];
+  const allTeams = Array.isArray(teams) ? teams : [];
+  const claims = Array.isArray(activeWaiverClaims) ? activeWaiverClaims : [];
+  const priorityList = Array.isArray(waiverPriorityList) ? [...waiverPriorityList] : [];
+  const week = Number(currentWeek ?? 0);
+
+  const awards = [];
+  const clearances = [];
+  const processedPlayerIds = new Set();
+  const claimsToRemove = new Set();
+
+  // Build a mutable map for player updates
+  const playerUpdates = new Map(); // playerId -> patch
+
+  // Identify eligible players
+  const eligiblePlayers = allPlayers.filter(
+    p => p.waiverStatus === 'ACTIVE' && Number(p.waiverWeekExpires ?? 0) <= week
+  );
+
+  for (const player of eligiblePlayers) {
+    const playerId = player.id;
+    processedPlayerIds.add(playerId);
+
+    // Gather claims for this player
+    const playerClaims = claims.filter(c => String(c.playerId) === String(playerId));
+
+    // Mark all claims for this player as to-be-removed
+    for (const c of playerClaims) {
+      claimsToRemove.add(c);
+    }
+
+    // Find highest priority valid claimant
+    const validClaims = playerClaims.filter(c => {
+      const team = allTeams.find(t => String(t.id) === String(c.teamId));
+      if (!team) return false;
+      return canTeamClaimWaiverPlayer(team, player);
+    });
+
+    const winner = findHighestPriorityClaim(validClaims, priorityList);
+
+    if (winner) {
+      // Award player to winning team
+      const winningTeam = allTeams.find(t => String(t.id) === String(winner.teamId));
+      playerUpdates.set(playerId, {
+        teamId: winner.teamId,
+        status: 'active',
+        contract: player.waiverContract ? { ...player.waiverContract } : player.contract,
+        waiverStatus: null,
+        waiverWeekExpires: null,
+        waiverContract: null,
+        previousTeamId: null,
+      });
+
+      awards.push({
+        playerId,
+        teamId: winner.teamId,
+        playerName: player.name ?? String(playerId),
+        teamName: winningTeam?.name ?? String(winner.teamId),
+      });
+
+      // Move winning team to bottom of priority list
+      const winnerIdx = priorityList.findIndex(id => String(id) === String(winner.teamId));
+      if (winnerIdx !== -1) {
+        priorityList.splice(winnerIdx, 1);
+        priorityList.push(winner.teamId);
+      }
+    } else {
+      // Clear to free agent
+      playerUpdates.set(playerId, {
+        teamId: null,
+        status: 'free_agent',
+        waiverStatus: null,
+        waiverWeekExpires: null,
+        waiverContract: null,
+        previousTeamId: null,
+      });
+
+      clearances.push({
+        playerId,
+        playerName: player.name ?? String(playerId),
+      });
+    }
+  }
+
+  // Build new players array (immutable)
+  const newPlayers = allPlayers.map(p => {
+    const patch = playerUpdates.get(p.id);
+    if (!patch) return p;
+    // Merge patch, removing null-valued keys to keep objects clean
+    const merged = { ...p };
+    for (const [key, val] of Object.entries(patch)) {
+      if (val === null) {
+        delete merged[key];
+      } else {
+        merged[key] = val;
+      }
+    }
+    return merged;
+  });
+
+  // Remove processed claims
+  const newClaims = claims.filter(c => !claimsToRemove.has(c));
+
+  return {
+    players: newPlayers,
+    teams: allTeams,
+    waiverPriorityList: priorityList,
+    activeWaiverClaims: newClaims,
+    awards,
+    clearances,
+  };
+}
+
+// ── shouldAIClaimWaiverPlayer ────────────────────────────────────────────────
+
+/**
+ * Returns true if an AI team should claim a waiver player.
+ * Criteria:
+ *  - player.ovr > starterOvr - 3 (player is better than current starter minus threshold)
+ *  - canTeamClaimWaiverPlayer returns true
+ *  - No existing claim from this team for this player
+ *
+ * Starter OVR = highest OVR player on team at same position, or 0 if none.
+ *
+ * @param {Object} team
+ * @param {Object} player
+ * @param {Object} leagueState — { players, teams, activeWaiverClaims }
+ * @returns {boolean}
+ */
+export function shouldAIClaimWaiverPlayer(team, player, leagueState) {
+  if (!team || !player) return false;
+
+  // Check cap
+  if (!canTeamClaimWaiverPlayer(team, player)) return false;
+
+  // Check no existing claim
+  const existingClaims = Array.isArray(leagueState?.activeWaiverClaims) ? leagueState.activeWaiverClaims : [];
+  const hasClaim = existingClaims.some(
+    c => String(c.playerId) === String(player.id) && String(c.teamId) === String(team.id)
+  );
+  if (hasClaim) return false;
+
+  // Find starter OVR at player's position for this team
+  const allPlayers = Array.isArray(leagueState?.players) ? leagueState.players : [];
+  const teamPlayers = allPlayers.filter(p => String(p.teamId) === String(team.id) && p.pos === player.pos);
+  const starterOvr = teamPlayers.reduce((best, p) => Math.max(best, p.ovr ?? 0), 0);
+
+  // Player must be better than starter minus 3
+  return (player.ovr ?? 0) > starterOvr - 3;
+}
+
+// ── generateAIWaiverClaims ───────────────────────────────────────────────────
+
+/**
+ * Deterministically generate AI waiver claims.
+ * For each team in waiverPriorityList order (skip user team),
+ * for each active waiver player: if shouldAIClaimWaiverPlayer, add claim.
+ *
+ * @param {Object} params
+ * @param {Array} params.teams
+ * @param {Array} params.players
+ * @param {Array} params.waiverPriorityList
+ * @param {Array} params.activeWaiverClaims
+ * @param {number} params.currentWeek
+ * @param {number|string} params.userTeamId
+ * @returns {Array} new activeWaiverClaims array
+ */
+export function generateAIWaiverClaims({ teams, players, waiverPriorityList, activeWaiverClaims, currentWeek, userTeamId }) {
+  const allPlayers = Array.isArray(players) ? players : [];
+  const allTeams = Array.isArray(teams) ? teams : [];
+  const priorityList = Array.isArray(waiverPriorityList) ? waiverPriorityList : [];
+  let claims = Array.isArray(activeWaiverClaims) ? [...activeWaiverClaims] : [];
+
+  // Get active waiver players
+  const waiverPlayers = allPlayers.filter(p => p.waiverStatus === 'ACTIVE');
+  if (waiverPlayers.length === 0) return claims;
+
+  const leagueState = { players: allPlayers, teams: allTeams, activeWaiverClaims: claims };
+
+  for (const teamId of priorityList) {
+    // Skip user team
+    if (String(teamId) === String(userTeamId)) continue;
+
+    const team = allTeams.find(t => String(t.id) === String(teamId));
+    if (!team) continue;
+
+    for (const waiverPlayer of waiverPlayers) {
+      // Use updated claims state for each check
+      const currentLeagueState = { ...leagueState, activeWaiverClaims: claims };
+      if (shouldAIClaimWaiverPlayer(team, waiverPlayer, currentLeagueState)) {
+        const newClaim = {
+          playerId: String(waiverPlayer.id),
+          teamId: team.id,
+          submittedWeek: Number(currentWeek),
+          origin: 'ai',
+        };
+        claims = submitWaiverClaim(claims, newClaim);
+      }
+    }
+  }
+
+  return claims;
+}

--- a/src/ui/components/WaiverCenter.jsx
+++ b/src/ui/components/WaiverCenter.jsx
@@ -1,0 +1,221 @@
+/**
+ * WaiverCenter.jsx — Post-Deadline Waiver Wire UI
+ *
+ * Displays active waiver players, user's priority position, and claim controls.
+ * Props:
+ *   league: { waiverWindowOpen, waiverPlayers, waiverPriorityPosition, userWaiverClaims, userTeamId, teams }
+ *   actions: { submitWaiverClaim, cancelWaiverClaim }
+ */
+
+import React from 'react';
+
+function capHit(contract) {
+  if (!contract) return 0;
+  const base = contract.baseAnnual ?? 0;
+  const bonus = contract.signingBonus ?? 0;
+  const years = contract.yearsTotal || 1;
+  return base + bonus / years;
+}
+
+function formatContract(contract) {
+  if (!contract) return 'No Contract';
+  const hit = capHit(contract);
+  const years = contract.yearsTotal ?? contract.years ?? 1;
+  return `$${hit.toFixed(1)}M/yr (${years}yr)`;
+}
+
+export default function WaiverCenter({ league, actions }) {
+  const waiverWindowOpen = league?.waiverWindowOpen ?? false;
+  const waiverPlayers = Array.isArray(league?.waiverPlayers) ? league.waiverPlayers : [];
+  const waiverPriorityPosition = league?.waiverPriorityPosition ?? null;
+  const userWaiverClaims = Array.isArray(league?.userWaiverClaims) ? league.userWaiverClaims : [];
+  const teams = Array.isArray(league?.teams) ? league.teams : [];
+  const userTeamId = league?.userTeamId ?? null;
+
+  // Don't render if no active waiver window and no waiver players
+  if (!waiverWindowOpen && waiverPlayers.length === 0) return null;
+
+  const userTeam = teams.find(t => String(t.id) === String(userTeamId));
+  const userCapRoom = userTeam?.capRoom ?? 0;
+
+  const getPreviousTeamName = (previousTeamId) => {
+    if (previousTeamId == null) return 'FA';
+    const team = teams.find(t => String(t.id) === String(previousTeamId));
+    return team?.abbr ?? team?.name ?? String(previousTeamId);
+  };
+
+  const canAfford = (player) => {
+    const hit = capHit(player.waiverContract);
+    return userCapRoom >= hit;
+  };
+
+  const handleClaim = (playerId) => {
+    if (actions?.submitWaiverClaim) {
+      actions.submitWaiverClaim(playerId);
+    }
+  };
+
+  const handleCancel = (playerId) => {
+    if (actions?.cancelWaiverClaim) {
+      actions.cancelWaiverClaim(playerId);
+    }
+  };
+
+  return (
+    <div style={{ padding: 16 }}>
+      <div style={{ marginBottom: 12 }}>
+        <h3 style={{ margin: '0 0 4px 0', fontSize: 18 }}>Waiver Wire</h3>
+        {!waiverWindowOpen && (
+          <div style={{ color: '#FF9F0A', fontSize: 13 }}>Waiver window is closed</div>
+        )}
+        {waiverWindowOpen && (
+          <div style={{ color: '#34C759', fontSize: 13 }}>
+            Waiver window open (Weeks 11-14)
+            {waiverPriorityPosition != null && (
+              <span style={{ marginLeft: 12, color: '#fff' }}>
+                Your Waiver Priority: <strong>#{waiverPriorityPosition} / 32</strong>
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {waiverPlayers.length === 0 ? (
+        <div style={{ color: '#9ca3af', fontStyle: 'italic' }}>No players currently on waivers.</div>
+      ) : (
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+            <thead>
+              <tr style={{ borderBottom: '1px solid #374151', color: '#9ca3af', textAlign: 'left' }}>
+                <th style={{ padding: '6px 8px' }}>Name</th>
+                <th style={{ padding: '6px 8px' }}>Pos</th>
+                <th style={{ padding: '6px 8px' }}>OVR</th>
+                <th style={{ padding: '6px 8px' }}>Age</th>
+                <th style={{ padding: '6px 8px' }}>Contract</th>
+                <th style={{ padding: '6px 8px' }}>Prev. Team</th>
+                <th style={{ padding: '6px 8px' }}>Expires</th>
+                <th style={{ padding: '6px 8px' }}>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {waiverPlayers.map(player => {
+                const playerIdStr = String(player.id);
+                const hasClaim = userWaiverClaims.includes(playerIdStr);
+                const affordable = canAfford(player);
+
+                return (
+                  <tr
+                    key={player.id}
+                    style={{
+                      borderBottom: '1px solid #1f2937',
+                      background: hasClaim ? 'rgba(52, 199, 89, 0.08)' : 'transparent',
+                    }}
+                  >
+                    <td style={{ padding: '8px 8px', fontWeight: 500 }}>{player.name}</td>
+                    <td style={{ padding: '8px 8px', color: '#9ca3af' }}>{player.pos}</td>
+                    <td style={{ padding: '8px 8px' }}>
+                      <span style={{
+                        display: 'inline-block',
+                        minWidth: 32,
+                        textAlign: 'center',
+                        borderRadius: 4,
+                        padding: '1px 6px',
+                        fontWeight: 600,
+                        background: (player.ovr ?? 0) >= 85 ? '#4ade80' : (player.ovr ?? 0) >= 75 ? '#facc15' : '#6b7280',
+                        color: (player.ovr ?? 0) >= 85 ? '#14532d' : (player.ovr ?? 0) >= 75 ? '#713f12' : '#fff',
+                      }}>
+                        {player.ovr ?? '??'}
+                      </span>
+                    </td>
+                    <td style={{ padding: '8px 8px', color: '#9ca3af' }}>{player.age ?? '??'}</td>
+                    <td style={{ padding: '8px 8px', fontFamily: 'monospace', fontSize: 12 }}>
+                      {formatContract(player.waiverContract)}
+                    </td>
+                    <td style={{ padding: '8px 8px', color: '#9ca3af' }}>
+                      {getPreviousTeamName(player.previousTeamId)}
+                    </td>
+                    <td style={{ padding: '8px 8px', color: '#9ca3af', fontSize: 12 }}>
+                      Wk {player.waiverWeekExpires ?? '??'}
+                    </td>
+                    <td style={{ padding: '8px 8px' }}>
+                      {hasClaim ? (
+                        <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                          <span style={{
+                            padding: '2px 8px',
+                            borderRadius: 4,
+                            background: 'rgba(52, 199, 89, 0.15)',
+                            color: '#34C759',
+                            fontSize: 11,
+                            fontWeight: 600,
+                          }}>
+                            Claim Pending
+                          </span>
+                          <button
+                            onClick={() => handleCancel(player.id)}
+                            disabled={!waiverWindowOpen}
+                            style={{
+                              padding: '2px 8px',
+                              borderRadius: 4,
+                              border: '1px solid #FF453A',
+                              background: 'transparent',
+                              color: '#FF453A',
+                              cursor: waiverWindowOpen ? 'pointer' : 'not-allowed',
+                              fontSize: 11,
+                              opacity: waiverWindowOpen ? 1 : 0.5,
+                            }}
+                          >
+                            Cancel
+                          </button>
+                        </span>
+                      ) : affordable ? (
+                        <button
+                          onClick={() => handleClaim(player.id)}
+                          disabled={!waiverWindowOpen}
+                          style={{
+                            padding: '4px 12px',
+                            borderRadius: 4,
+                            border: 'none',
+                            background: waiverWindowOpen ? '#3b82f6' : '#374151',
+                            color: '#fff',
+                            cursor: waiverWindowOpen ? 'pointer' : 'not-allowed',
+                            fontSize: 12,
+                            fontWeight: 500,
+                            opacity: waiverWindowOpen ? 1 : 0.7,
+                          }}
+                        >
+                          Claim Player
+                        </button>
+                      ) : (
+                        <button
+                          disabled
+                          style={{
+                            padding: '4px 12px',
+                            borderRadius: 4,
+                            border: 'none',
+                            background: '#374151',
+                            color: '#6b7280',
+                            cursor: 'not-allowed',
+                            fontSize: 12,
+                          }}
+                        >
+                          Insufficient cap space
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {waiverWindowOpen && (
+        <div style={{ marginTop: 12, padding: '8px 12px', background: '#1f2937', borderRadius: 6, fontSize: 12, color: '#9ca3af' }}>
+          Claims are processed at the start of each advance. Higher priority teams (worse record) claim first.
+          If awarded, the winning team moves to the bottom of the priority list.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/WaiverCenter.test.jsx
+++ b/src/ui/components/WaiverCenter.test.jsx
@@ -1,0 +1,304 @@
+/**
+ * WaiverCenter.test.jsx — React component tests for WaiverCenter
+ *
+ * Uses renderToString for SSR-style testing (no jsdom required).
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import WaiverCenter from './WaiverCenter.jsx';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeLeague(overrides = {}) {
+  return {
+    waiverWindowOpen: true,
+    waiverPlayers: [],
+    waiverPriorityPosition: 15,
+    userWaiverClaims: [],
+    userTeamId: 1,
+    teams: [
+      { id: 1, name: 'My Team', abbr: 'MYT', capRoom: 50 },
+      { id: 2, name: 'Other Team', abbr: 'OTH', capRoom: 30 },
+    ],
+    ...overrides,
+  };
+}
+
+function makeWaiverPlayer(overrides = {}) {
+  return {
+    id: 10,
+    name: 'Test Player',
+    pos: 'WR',
+    ovr: 78,
+    age: 26,
+    waiverContract: { baseAnnual: 5, signingBonus: 4, yearsTotal: 2, years: 2 },
+    previousTeamId: 2,
+    waiverWeekExpires: 12,
+    ...overrides,
+  };
+}
+
+function makeActions(overrides = {}) {
+  return {
+    submitWaiverClaim: vi.fn(),
+    cancelWaiverClaim: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('WaiverCenter — render conditions', () => {
+  it('renders nothing when waiver window is closed and no players', () => {
+    const html = renderToString(
+      <WaiverCenter
+        league={makeLeague({ waiverWindowOpen: false, waiverPlayers: [] })}
+        actions={makeActions()}
+      />
+    );
+    expect(html).toBe('');
+  });
+
+  it('renders when waiver window is open', () => {
+    const html = renderToString(
+      <WaiverCenter
+        league={makeLeague({ waiverWindowOpen: true, waiverPlayers: [] })}
+        actions={makeActions()}
+      />
+    );
+    expect(html).toContain('Waiver Wire');
+  });
+
+  it('renders when window is closed but there are waiver players', () => {
+    const html = renderToString(
+      <WaiverCenter
+        league={makeLeague({ waiverWindowOpen: false, waiverPlayers: [makeWaiverPlayer()] })}
+        actions={makeActions()}
+      />
+    );
+    expect(html).toContain('Waiver Wire');
+  });
+});
+
+describe('WaiverCenter — priority display', () => {
+  it('displays waiver priority position when window is open', () => {
+    const html = renderToString(
+      <WaiverCenter
+        league={makeLeague({ waiverWindowOpen: true, waiverPriorityPosition: 8 })}
+        actions={makeActions()}
+      />
+    );
+    // React SSR may inject comment nodes between adjacent text/numbers
+    expect(html).toContain('Your Waiver Priority:');
+    expect(html).toMatch(/8.*\/.*32/);
+  });
+
+  it('shows open window message', () => {
+    const html = renderToString(
+      <WaiverCenter
+        league={makeLeague({ waiverWindowOpen: true })}
+        actions={makeActions()}
+      />
+    );
+    expect(html).toContain('Waiver window open');
+  });
+
+  it('shows closed window message', () => {
+    const html = renderToString(
+      <WaiverCenter
+        league={makeLeague({ waiverWindowOpen: false, waiverPlayers: [makeWaiverPlayer()] })}
+        actions={makeActions()}
+      />
+    );
+    expect(html).toContain('Waiver window is closed');
+  });
+});
+
+describe('WaiverCenter — player table', () => {
+  it('renders player name, pos, ovr', () => {
+    const html = renderToString(
+      <WaiverCenter
+        league={makeLeague({ waiverPlayers: [makeWaiverPlayer({ name: 'John Doe', pos: 'QB', ovr: 85 })] })}
+        actions={makeActions()}
+      />
+    );
+    expect(html).toContain('John Doe');
+    expect(html).toContain('QB');
+    expect(html).toContain('85');
+  });
+
+  it('renders contract information', () => {
+    const html = renderToString(
+      <WaiverCenter
+        league={makeLeague({
+          waiverPlayers: [makeWaiverPlayer({
+            waiverContract: { baseAnnual: 6, signingBonus: 4, yearsTotal: 2 }
+          })]
+        })}
+        actions={makeActions()}
+      />
+    );
+    // capHit = 6 + 4/2 = 8.0
+    expect(html).toContain('$8.0M/yr');
+  });
+
+  it('renders previous team abbreviation', () => {
+    const html = renderToString(
+      <WaiverCenter
+        league={makeLeague({
+          waiverPlayers: [makeWaiverPlayer({ previousTeamId: 2 })],
+          teams: [
+            { id: 1, name: 'My Team', abbr: 'MYT', capRoom: 50 },
+            { id: 2, name: 'Other Team', abbr: 'OTH', capRoom: 30 },
+          ],
+        })}
+        actions={makeActions()}
+      />
+    );
+    expect(html).toContain('OTH');
+  });
+
+  it('renders waiver expiry week', () => {
+    const html = renderToString(
+      <WaiverCenter
+        league={makeLeague({ waiverPlayers: [makeWaiverPlayer({ waiverWeekExpires: 13 })] })}
+        actions={makeActions()}
+      />
+    );
+    // React SSR may inject comment nodes adjacent to numbers
+    expect(html).toContain('Wk');
+    expect(html).toContain('13');
+  });
+
+  it('shows empty state when no waiver players', () => {
+    const html = renderToString(
+      <WaiverCenter
+        league={makeLeague({ waiverPlayers: [] })}
+        actions={makeActions()}
+      />
+    );
+    expect(html).toContain('No players currently on waivers');
+  });
+});
+
+describe('WaiverCenter — action buttons', () => {
+  it('shows Claim Player button when user can afford and has no claim', () => {
+    const html = renderToString(
+      <WaiverCenter
+        league={makeLeague({
+          waiverWindowOpen: true,
+          waiverPlayers: [makeWaiverPlayer({ id: 10, waiverContract: { baseAnnual: 5, signingBonus: 0, yearsTotal: 1 } })],
+          userWaiverClaims: [], // no claim
+          teams: [{ id: 1, name: 'My Team', abbr: 'MYT', capRoom: 50 }], // enough cap
+        })}
+        actions={makeActions()}
+      />
+    );
+    expect(html).toContain('Claim Player');
+  });
+
+  it('shows Insufficient cap space when user cannot afford', () => {
+    const html = renderToString(
+      <WaiverCenter
+        league={makeLeague({
+          waiverWindowOpen: true,
+          waiverPlayers: [makeWaiverPlayer({ id: 10, waiverContract: { baseAnnual: 40, signingBonus: 20, yearsTotal: 1 } })],
+          userWaiverClaims: [],
+          teams: [{ id: 1, name: 'My Team', abbr: 'MYT', capRoom: 5 }], // not enough cap
+        })}
+        actions={makeActions()}
+      />
+    );
+    expect(html).toContain('Insufficient cap space');
+  });
+
+  it('shows Claim Pending badge when user has an active claim', () => {
+    const html = renderToString(
+      <WaiverCenter
+        league={makeLeague({
+          waiverWindowOpen: true,
+          waiverPlayers: [makeWaiverPlayer({ id: 10 })],
+          userWaiverClaims: ['10'], // has claim for player 10
+          teams: [{ id: 1, name: 'My Team', abbr: 'MYT', capRoom: 50 }],
+        })}
+        actions={makeActions()}
+      />
+    );
+    expect(html).toContain('Claim Pending');
+    expect(html).toContain('Cancel');
+  });
+
+  it('shows Cancel button alongside claim pending badge', () => {
+    const html = renderToString(
+      <WaiverCenter
+        league={makeLeague({
+          waiverWindowOpen: true,
+          waiverPlayers: [makeWaiverPlayer({ id: 10 })],
+          userWaiverClaims: ['10'],
+          teams: [{ id: 1, name: 'My Team', abbr: 'MYT', capRoom: 50 }],
+        })}
+        actions={makeActions()}
+      />
+    );
+    expect(html).toContain('Cancel');
+  });
+});
+
+describe('WaiverCenter — edge cases', () => {
+  it('handles null league prop gracefully', () => {
+    // Should not throw
+    const html = renderToString(
+      <WaiverCenter league={null} actions={makeActions()} />
+    );
+    // With null league, waiverWindowOpen=false and waiverPlayers=[], renders nothing
+    expect(html).toBe('');
+  });
+
+  it('handles player with no waiverContract', () => {
+    const html = renderToString(
+      <WaiverCenter
+        league={makeLeague({
+          waiverWindowOpen: true,
+          waiverPlayers: [makeWaiverPlayer({ waiverContract: null })],
+          teams: [{ id: 1, name: 'My Team', abbr: 'MYT', capRoom: 50 }],
+        })}
+        actions={makeActions()}
+      />
+    );
+    expect(html).toContain('No Contract');
+  });
+
+  it('handles player with unknown previous team', () => {
+    const html = renderToString(
+      <WaiverCenter
+        league={makeLeague({
+          waiverWindowOpen: true,
+          waiverPlayers: [makeWaiverPlayer({ previousTeamId: null })],
+          teams: [{ id: 1, name: 'My Team', abbr: 'MYT', capRoom: 50 }],
+        })}
+        actions={makeActions()}
+      />
+    );
+    expect(html).toContain('FA');
+  });
+
+  it('renders multiple players', () => {
+    const html = renderToString(
+      <WaiverCenter
+        league={makeLeague({
+          waiverWindowOpen: true,
+          waiverPlayers: [
+            makeWaiverPlayer({ id: 10, name: 'Player Alpha', pos: 'QB' }),
+            makeWaiverPlayer({ id: 11, name: 'Player Beta', pos: 'RB' }),
+          ],
+          teams: [{ id: 1, name: 'My Team', abbr: 'MYT', capRoom: 50 }],
+        })}
+        actions={makeActions()}
+      />
+    );
+    expect(html).toContain('Player Alpha');
+    expect(html).toContain('Player Beta');
+  });
+});

--- a/src/worker/__tests__/waiverEngine.integration.test.js
+++ b/src/worker/__tests__/waiverEngine.integration.test.js
@@ -1,0 +1,143 @@
+/**
+ * waiverEngine.integration.test.js — Structural integration tests for waiver wire wiring in worker.js
+ *
+ * Uses readFileSync pattern to validate structural correctness of worker.js changes.
+ * No actual worker execution needed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const workerSource = readFileSync(resolve(process.cwd(), 'src/worker/worker.js'), 'utf8');
+const protocolSource = readFileSync(resolve(process.cwd(), 'src/worker/protocol.js'), 'utf8');
+
+describe('Waiver Wire — protocol.js integration', () => {
+  it('exports SUBMIT_WAIVER_CLAIM in toWorker', () => {
+    expect(protocolSource.includes("SUBMIT_WAIVER_CLAIM:          'SUBMIT_WAIVER_CLAIM'")).toBe(true);
+  });
+
+  it('exports CANCEL_WAIVER_CLAIM in toWorker', () => {
+    expect(protocolSource.includes("CANCEL_WAIVER_CLAIM:          'CANCEL_WAIVER_CLAIM'")).toBe(true);
+  });
+
+  it('exports WAIVER_DATA in toUI', () => {
+    expect(protocolSource.includes("WAIVER_DATA:        'WAIVER_DATA'")).toBe(true);
+  });
+});
+
+describe('Waiver Wire — worker.js imports', () => {
+  it('imports isWaiverWindowOpen from waiverEngine', () => {
+    expect(workerSource.includes('isWaiverWindowOpen')).toBe(true);
+  });
+
+  it('imports buildWaiverPriorityList from waiverEngine', () => {
+    expect(workerSource.includes('buildWaiverPriorityList')).toBe(true);
+  });
+
+  it('imports sendPlayerToWaivers from waiverEngine', () => {
+    expect(workerSource.includes('sendPlayerToWaivers')).toBe(true);
+  });
+
+  it('imports canTeamClaimWaiverPlayer from waiverEngine', () => {
+    expect(workerSource.includes('canTeamClaimWaiverPlayer')).toBe(true);
+  });
+
+  it('imports submitWaiverClaim from waiverEngine', () => {
+    expect(workerSource.includes('submitWaiverClaim')).toBe(true);
+  });
+
+  it('imports processWaivers from waiverEngine', () => {
+    expect(workerSource.includes('processWaivers')).toBe(true);
+  });
+
+  it('imports generateAIWaiverClaims from waiverEngine', () => {
+    expect(workerSource.includes('generateAIWaiverClaims')).toBe(true);
+  });
+});
+
+describe('Waiver Wire — worker.js handler functions', () => {
+  it('defines handleSubmitWaiverClaim function', () => {
+    expect(workerSource.includes('async function handleSubmitWaiverClaim')).toBe(true);
+  });
+
+  it('defines handleCancelWaiverClaim function', () => {
+    expect(workerSource.includes('async function handleCancelWaiverClaim')).toBe(true);
+  });
+
+  it('dispatches SUBMIT_WAIVER_CLAIM in switch statement', () => {
+    expect(workerSource.includes('case toWorker.SUBMIT_WAIVER_CLAIM: return await handleSubmitWaiverClaim')).toBe(true);
+  });
+
+  it('dispatches CANCEL_WAIVER_CLAIM in switch statement', () => {
+    expect(workerSource.includes('case toWorker.CANCEL_WAIVER_CLAIM: return await handleCancelWaiverClaim')).toBe(true);
+  });
+});
+
+describe('Waiver Wire — buildViewState includes waiver fields', () => {
+  it('includes waiverWindowOpen in buildViewState return', () => {
+    expect(workerSource.includes('waiverWindowOpen: isWaiverWindowOpen')).toBe(true);
+  });
+
+  it('includes waiverPriorityPosition in buildViewState return', () => {
+    expect(workerSource.includes('waiverPriorityPosition:')).toBe(true);
+  });
+
+  it('includes waiverPlayers in buildViewState return', () => {
+    expect(workerSource.includes('waiverPlayers: cache.getAllPlayers()')).toBe(true);
+  });
+
+  it('includes userWaiverClaims in buildViewState return', () => {
+    expect(workerSource.includes('userWaiverClaims: (meta?.activeWaiverClaims ?? [])')).toBe(true);
+  });
+});
+
+describe('Waiver Wire — releasePlayerWithValidation sends to waivers', () => {
+  it('checks isWaiverWindowOpen in release path', () => {
+    expect(workerSource.includes('if (isWaiverWindowOpen(meta.currentWeek ?? 0))')).toBe(true);
+  });
+
+  it('calls sendPlayerToWaivers on release during waiver window', () => {
+    expect(workerSource.includes('const waiverPlayer = sendPlayerToWaivers')).toBe(true);
+  });
+
+  it('sets status to waiver for released players during waiver window', () => {
+    expect(workerSource.includes("status: 'waiver'")).toBe(true);
+  });
+});
+
+describe('Waiver Wire — handleAdvanceWeek processes waivers', () => {
+  it('calls generateAIWaiverClaims in advance week', () => {
+    expect(workerSource.includes('const claimsAfterAI = generateAIWaiverClaims')).toBe(true);
+  });
+
+  it('calls processWaivers in advance week', () => {
+    expect(workerSource.includes('const waiverResult = processWaivers')).toBe(true);
+  });
+
+  it('calls buildWaiverPriorityList when priority list is empty', () => {
+    expect(workerSource.includes('const priority = buildWaiverPriorityList')).toBe(true);
+  });
+
+  it('emits news for waiver awards', () => {
+    expect(workerSource.includes('await NewsEngine.logWaiverAward')).toBe(true);
+  });
+
+  it('emits news for waiver clearances', () => {
+    expect(workerSource.includes('await NewsEngine.logWaiverClear')).toBe(true);
+  });
+
+  it('checks outbid scenario and logs it', () => {
+    expect(workerSource.includes('await NewsEngine.logWaiverOutbid')).toBe(true);
+  });
+});
+
+describe('Waiver Wire — meta hydration on load', () => {
+  it('hydrates waiverPriorityList on load-save', () => {
+    expect(workerSource.includes('waiverPriorityList: meta?.waiverPriorityList ?? []')).toBe(true);
+  });
+
+  it('hydrates activeWaiverClaims on load-save', () => {
+    expect(workerSource.includes('activeWaiverClaims: meta?.activeWaiverClaims ?? []')).toBe(true);
+  });
+});

--- a/src/worker/protocol.js
+++ b/src/worker/protocol.js
@@ -187,6 +187,10 @@ export const toWorker = Object.freeze({
   /** Draft Combine */
   RUN_COMBINE_WORKOUT:          'RUN_COMBINE_WORKOUT',          // { prospectId }
   ADVANCE_COMBINE_WEEK:         'ADVANCE_COMBINE_WEEK',         // {} — transition draft_combine → draft
+
+  /** Waiver Wire */
+  SUBMIT_WAIVER_CLAIM:          'SUBMIT_WAIVER_CLAIM',          // { playerId }
+  CANCEL_WAIVER_CLAIM:          'CANCEL_WAIVER_CLAIM',          // { playerId }
 });
 
 // ─────────────────────────────────────────────
@@ -309,6 +313,9 @@ export const toUI = Object.freeze({
    * window.location.reload() directly, so they post this message instead.
    */
   RELOAD_REQUIRED:    'RELOAD_REQUIRED',     // { reason }
+
+  /** Waiver Wire */
+  WAIVER_DATA:        'WAIVER_DATA',         // { waiverPlayers, userWaiverClaims, waiverWindowOpen, waiverPriorityPosition }
 });
 
 /**

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -319,6 +319,17 @@ import {
   buildScheduleBuffer,
 } from './serialization.js';
 import { sortStandingsRows } from '../views/standingsView.js';
+import {
+  isWaiverWindowOpen,
+  buildWaiverPriorityList,
+  sendPlayerToWaivers,
+  canTeamClaimWaiverPlayer,
+  submitWaiverClaim,
+  findHighestPriorityClaim,
+  processWaivers,
+  shouldAIClaimWaiverPlayer,
+  generateAIWaiverClaims,
+} from '../core/transactions/waiverEngine.js';
 
 // ── DB Reload Guard ───────────────────────────────────────────────────────────
 // Register a callback with db/index.js so that when IDB fires onblocked or
@@ -1181,6 +1192,28 @@ function buildViewState() {
     ...(typeof globalThis !== 'undefined' && globalThis.__DYNASTY_SOAK_PROFILE__ && globalThis.__DYNASTY_SOAK_LAST_BATCH__
       ? { dynastySoakSimBatch: { ...globalThis.__DYNASTY_SOAK_LAST_BATCH__ } }
       : {}),
+    // ── Waiver Wire ──────────────────────────────────────────────────────────
+    waiverWindowOpen: isWaiverWindowOpen(meta?.currentWeek ?? 0),
+    waiverPriorityPosition: (() => {
+      const list = meta?.waiverPriorityList ?? [];
+      const idx = list.findIndex(id => String(id) === String(meta?.userTeamId));
+      return idx >= 0 ? idx + 1 : null;
+    })(),
+    waiverPlayers: cache.getAllPlayers()
+      .filter(p => p.waiverStatus === 'ACTIVE')
+      .map(p => ({
+        id: p.id,
+        name: p.name,
+        pos: p.pos,
+        ovr: p.ovr,
+        age: p.age,
+        waiverContract: p.waiverContract ?? null,
+        previousTeamId: p.previousTeamId ?? null,
+        waiverWeekExpires: p.waiverWeekExpires ?? null,
+      })),
+    userWaiverClaims: (meta?.activeWaiverClaims ?? [])
+      .filter(c => String(c.teamId) === String(meta?.userTeamId))
+      .map(c => String(c.playerId)),
   };
 }
 
@@ -2123,6 +2156,9 @@ async function handleLoadSave({ leagueId }, id) {
         commissionerMode: !!meta?.commissionerMode,
         commissionerEverEnabled: !!meta?.commissionerEverEnabled,
         commissionerLog: Array.isArray(meta?.commissionerLog) ? meta.commissionerLog : [],
+        // Waiver wire meta hydration (safe defaults for older saves)
+        waiverPriorityList: meta?.waiverPriorityList ?? [],
+        activeWaiverClaims: meta?.activeWaiverClaims ?? [],
       });
 
       if (meta?.simSession?.status === 'running') {
@@ -2981,6 +3017,89 @@ async function handleAdvanceWeek(payload, id) {
 
   const week        = meta.currentWeek;
   const seasonId    = meta.currentSeasonId;
+
+  // ── Waiver Wire Processing (Weeks 11-14) ──────────────────────────────────
+  if (meta.phase === 'regular' && isWaiverWindowOpen(week)) {
+    // Initialize priority list once at start of week 11 (or if missing)
+    if (!meta.waiverPriorityList || meta.waiverPriorityList.length === 0) {
+      const allTeamsForWaiver = cache.getAllTeams();
+      const priority = buildWaiverPriorityList(allTeamsForWaiver);
+      cache.setMeta({ waiverPriorityList: priority });
+      meta.waiverPriorityList = priority;
+    }
+    const waiverActiveWaiverClaims = meta.activeWaiverClaims ?? [];
+    const waiverPriorityList = meta.waiverPriorityList ?? [];
+    const waiverAllPlayers = cache.getAllPlayers();
+    const waiverAllTeams = cache.getAllTeams();
+
+    // Generate AI claims for this week
+    const claimsAfterAI = generateAIWaiverClaims({
+      teams: waiverAllTeams,
+      players: waiverAllPlayers,
+      waiverPriorityList,
+      activeWaiverClaims: waiverActiveWaiverClaims,
+      currentWeek: week,
+      userTeamId: meta.userTeamId,
+    });
+
+    // Process waivers (award expired waiver players)
+    const waiverResult = processWaivers({
+      players: waiverAllPlayers,
+      teams: waiverAllTeams,
+      activeWaiverClaims: claimsAfterAI,
+      waiverPriorityList,
+      currentWeek: week,
+    });
+
+    // Apply player changes to cache for processed waiver players
+    const processedPlayerIds = new Set([
+      ...waiverResult.awards.map(a => a.playerId),
+      ...waiverResult.clearances.map(c => c.playerId),
+    ]);
+    for (const p of waiverResult.players) {
+      if (!processedPlayerIds.has(p.id)) continue;
+      const orig = waiverAllPlayers.find(ap => ap.id === p.id);
+      if (!orig) continue;
+      // Build the patch: only changed fields
+      const patch = {};
+      for (const key of Object.keys(p)) {
+        if (p[key] !== orig[key]) patch[key] = p[key];
+      }
+      // Also clear fields that were deleted
+      for (const key of ['waiverStatus', 'waiverWeekExpires', 'waiverContract', 'previousTeamId']) {
+        if (key in orig && !(key in p)) patch[key] = null;
+      }
+      if (Object.keys(patch).length > 0) {
+        cache.updatePlayer(p.id, patch);
+        // Recalculate cap for teams affected by waiver awards
+        if (patch.teamId != null) {
+          recalculateTeamCap(patch.teamId);
+        }
+      }
+    }
+
+    // Emit news for awards and clearances
+    for (const award of waiverResult.awards) {
+      await NewsEngine.logWaiverAward(award.teamName, award.playerName, award.teamId);
+      // Check if user was outbid on this player
+      const userClaim = waiverActiveWaiverClaims.find(
+        c => String(c.playerId) === String(award.playerId) && String(c.teamId) === String(meta.userTeamId)
+      );
+      if (userClaim && String(award.teamId) !== String(meta.userTeamId)) {
+        await NewsEngine.logWaiverOutbid(award.playerName, award.teamName, award.teamId);
+      }
+    }
+    for (const clearance of waiverResult.clearances) {
+      await NewsEngine.logWaiverClear(clearance.playerName);
+    }
+
+    // Update meta with new priority list and remaining claims
+    cache.setMeta({
+      waiverPriorityList: waiverResult.waiverPriorityList,
+      activeWaiverClaims: waiverResult.activeWaiverClaims,
+    });
+  }
+
   const schedule    = expandSchedule(meta.schedule);
   const tradeDeadline = getTradeDeadlineSnapshot(meta);
 
@@ -7288,6 +7407,30 @@ async function releasePlayerWithValidation({ playerId, teamId }) {
   const holdoutReleasePlayer = player.holdout?.active
     ? resolveHoldout(player, HOLDOUT_RESOLUTION.GM_RELEASED, meta.currentSeasonId ?? meta.season ?? 0, meta.currentWeek ?? 0)
     : player;
+
+  // ── Waiver Wire: send to waivers instead of immediate FA during weeks 11-14 ──
+  if (isWaiverWindowOpen(meta.currentWeek ?? 0)) {
+    const waiverPlayer = sendPlayerToWaivers(holdoutReleasePlayer, meta.currentWeek, teamId);
+    cache.updatePlayer(player.id, {
+      teamId: null,
+      status: 'waiver',
+      offers: [],
+      holdout: holdoutReleasePlayer.holdout,
+      waiverStatus: waiverPlayer.waiverStatus,
+      waiverWeekExpires: waiverPlayer.waiverWeekExpires,
+      waiverContract: waiverPlayer.waiverContract,
+      previousTeamId: waiverPlayer.previousTeamId,
+    });
+    recalculateTeamCap(teamId);
+    ensureTeamDepthChart(teamId, { phase: cache.getPhase() });
+    await Transactions.add({
+      type: 'RELEASE', seasonId: meta.currentSeasonId,
+      week: meta.currentWeek, teamId, details: { playerId: player.id, toWaivers: true },
+    });
+    await NewsEngine.logTransaction('RELEASE', { teamId, playerId: player.id });
+    return { ok: true, playerId: player.id };
+  }
+
   cache.updatePlayer(player.id, { teamId: null, status: 'free_agent', offers: [], holdout: holdoutReleasePlayer.holdout });
   recalculateTeamCap(teamId);
   // Repair the depth chart so the released player's ID is stripped from any
@@ -7350,6 +7493,53 @@ async function handleBulkReleasePlayers({ teamId, playerIds }, id) {
   await flushDirty();
   post(toUI.STATE_UPDATE, { roster: buildRosterView(teamId), ...buildViewState() }, id);
   post(toUI.SUCCESS, { ok: true, released }, id);
+}
+
+// ── Handler: SUBMIT_WAIVER_CLAIM ──────────────────────────────────────────────
+
+async function handleSubmitWaiverClaim({ playerId }, id) {
+  const meta = ensureDynastyMeta(cache.getMeta());
+  const week = meta.currentWeek ?? 0;
+  if (!isWaiverWindowOpen(week)) {
+    post(toUI.ERROR, { message: 'WAIVERS_CLOSED' }, id);
+    return;
+  }
+  const player = cache.getPlayer(Number(playerId));
+  if (!player || player.waiverStatus !== 'ACTIVE') {
+    post(toUI.ERROR, { message: 'PLAYER_NOT_ON_WAIVERS' }, id);
+    return;
+  }
+  const userTeam = cache.getTeam(meta.userTeamId);
+  if (!canTeamClaimWaiverPlayer(userTeam, player)) {
+    post(toUI.ERROR, { message: 'INSUFFICIENT_CAP_SPACE' }, id);
+    return;
+  }
+  const existingClaims = meta.activeWaiverClaims ?? [];
+  const dup = existingClaims.find(
+    c => String(c.playerId) === String(playerId) && String(c.teamId) === String(meta.userTeamId)
+  );
+  if (dup) {
+    post(toUI.ERROR, { message: 'CLAIM_ALREADY_EXISTS' }, id);
+    return;
+  }
+  const newClaim = { playerId: String(playerId), teamId: meta.userTeamId, submittedWeek: week, origin: 'user' };
+  const updatedClaims = submitWaiverClaim(existingClaims, newClaim);
+  cache.setMeta({ activeWaiverClaims: updatedClaims });
+  await flushDirty();
+  post(toUI.STATE_UPDATE, buildViewState(), id);
+}
+
+// ── Handler: CANCEL_WAIVER_CLAIM ──────────────────────────────────────────────
+
+async function handleCancelWaiverClaim({ playerId }, id) {
+  const meta = ensureDynastyMeta(cache.getMeta());
+  const existingClaims = meta.activeWaiverClaims ?? [];
+  const updated = existingClaims.filter(
+    c => !(String(c.playerId) === String(playerId) && String(c.teamId) === String(meta.userTeamId))
+  );
+  cache.setMeta({ activeWaiverClaims: updated });
+  await flushDirty();
+  post(toUI.STATE_UPDATE, buildViewState(), id);
 }
 
 // ── Handler: GET_ROSTER ───────────────────────────────────────────────────────
@@ -13765,6 +13955,8 @@ async function handleMessage(event) {
       case toWorker.WITHDRAW_OFFER:     return await handleWithdrawOffer(payload, id);
       case toWorker.RELEASE_PLAYER:     return await handleReleasePlayer(payload, id);
       case toWorker.BULK_RELEASE_PLAYERS: return await handleBulkReleasePlayers(payload, id);
+      case toWorker.SUBMIT_WAIVER_CLAIM: return await handleSubmitWaiverClaim(payload, id);
+      case toWorker.CANCEL_WAIVER_CLAIM: return await handleCancelWaiverClaim(payload, id);
       case toWorker.UPDATE_SETTINGS:    return await handleUpdateSettings(payload, id);
       case toWorker.TOGGLE_COMMISSIONER_MODE: return await handleToggleCommissionerMode(payload, id);
       case toWorker.APPLY_COMMISSIONER_ACTIONS: return await handleApplyCommissionerActions(payload, id);


### PR DESCRIPTION
Implements deterministic waiver wire engine for weeks 11-14:
- isWaiverWindowOpen, buildWaiverPriorityList, sendPlayerToWaivers
- canTeamClaimWaiverPlayer, submitWaiverClaim, findHighestPriorityClaim
- processWaivers (immutable, awards/clearances), shouldAIClaimWaiverPlayer
- generateAIWaiverClaims (deterministic, no Math.random)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PFxBPC6SDgtWzmeWhu9jJb