### PR TITLE
feat: add player agent representation & negotiation friction engine

### DIFF
--- a/src/core/contracts/agentNegotiationEngine.js
+++ b/src/core/contracts/agentNegotiationEngine.js
@@ -1,0 +1,377 @@
+/**
+ * agentNegotiationEngine.js — Player Agent Persona & Negotiation Friction
+ *
+ * Pure, deterministic module. No Math.random, no UI imports, no worker imports.
+ * All outputs are immutable new objects.
+ */
+
+// ── Archetype constants ───────────────────────────────────────────────────────
+
+export const AGENT_ARCHETYPES = Object.freeze({
+  SHARK:       'SHARK',
+  LOYALIST:    'LOYALIST',
+  RING_CHASER: 'RING_CHASER',
+});
+
+// ── FNV-1a 32-bit hash (no Math.random) ──────────────────────────────────────
+
+function _hash(input) {
+  const str = String(input);
+  let h = 2166136261; // FNV offset basis (unsigned 32-bit)
+  for (let i = 0; i < str.length; i++) {
+    h = Math.imul(h ^ str.charCodeAt(i), 16777619);
+    h = h >>> 0; // keep unsigned
+  }
+  return h;
+}
+
+// ── Agent name tables ─────────────────────────────────────────────────────────
+
+const _FIRST = [
+  'Drew', 'Marcus', 'David', 'James', 'Scott', 'Michael', 'Andre', 'Leon',
+  'Chris', 'Tyler', 'Evan', 'Grant', 'Victor', 'Nathan', 'Blake', 'Aaron',
+  'Jordan', 'Brandon', 'Keith', 'Ryan',
+];
+
+const _LAST = [
+  'Collier', 'Tanaka', 'Barnes', 'Ross', 'Winters', 'Fields', 'Church',
+  'Harmon', 'Preston', 'Vaughn', 'Lowe', 'Drake', 'Silva', 'Mercer',
+  'Holland', 'Cross', 'Stone', 'Sharp', 'Wells', 'Grant',
+];
+
+// ── generateDeterministicAgentProfile ────────────────────────────────────────
+
+/**
+ * Deterministic from player id / name seed.
+ * Archetype distribution: SHARK 30%, LOYALIST 40%, RING_CHASER 30%.
+ * No Math.random.
+ *
+ * @param {object} player
+ * @returns {object} Frozen agent profile
+ */
+export function generateDeterministicAgentProfile(player) {
+  const seed        = _hash(String(player?.id ?? '') + String(player?.name ?? ''));
+  const archetypeN  = seed % 100;
+
+  let archetype;
+  if (archetypeN < 30)      archetype = AGENT_ARCHETYPES.SHARK;
+  else if (archetypeN < 70) archetype = AGENT_ARCHETYPES.LOYALIST;
+  else                       archetype = AGENT_ARCHETYPES.RING_CHASER;
+
+  const greed          = (_hash(String(player?.id ?? '') + 'greed')   % 100) / 100;
+  const aggressiveness = (_hash(String(player?.id ?? '') + 'aggr')    % 100) / 100;
+  const patience       = (_hash(String(player?.id ?? '') + 'patience')% 100) / 100;
+
+  const firstIdx  = _hash(String(player?.id ?? '') + 'fn') % _FIRST.length;
+  const lastIdx   = _hash(String(player?.id ?? '') + 'ln') % _LAST.length;
+  const agentName = `${_FIRST[firstIdx]} ${_LAST[lastIdx]}`;
+
+  return Object.freeze({
+    id:            `agent_${_hash(agentName)}`,
+    name:          agentName,
+    archetype,
+    aggressiveness,
+    greed,
+    patience,
+  });
+}
+
+// ── hydratePlayerAgent ────────────────────────────────────────────────────────
+
+/**
+ * If player.agent exists, return player unchanged.
+ * Otherwise attach a generated deterministic profile.
+ * Immutable — returns a new object.
+ *
+ * @param {object} player
+ * @returns {object}
+ */
+export function hydratePlayerAgent(player) {
+  if (!player) return player;
+
+  const hasAgent = Boolean(player.agent);
+  const hasState = Boolean(player.negotiationState);
+
+  if (hasAgent && hasState) return player;
+
+  const agent           = hasAgent ? player.agent : generateDeterministicAgentProfile(player);
+  const negotiationState = hasState
+    ? player.negotiationState
+    : { negotiationsFrozenUntilSeason: null };
+
+  return { ...player, agent, negotiationState };
+}
+
+// ── isNegotiationFrozen ───────────────────────────────────────────────────────
+
+/**
+ * @param {object} player
+ * @param {number} currentSeason
+ * @returns {boolean}
+ */
+export function isNegotiationFrozen(player, currentSeason) {
+  const frozen = player?.negotiationState?.negotiationsFrozenUntilSeason;
+  return frozen != null && frozen === currentSeason;
+}
+
+// ── internal: derive power-rank position from teamContext ─────────────────────
+
+function _teamRank(teamContext) {
+  const explicit = teamContext?.teamPowerRankPosition;
+  if (typeof explicit === 'number' && explicit >= 1 && explicit <= 32) return explicit;
+  const score = teamContext?.contenderScore;
+  if (typeof score === 'number') {
+    const clamped = Math.max(0, Math.min(100, score));
+    return Math.round(1 + (100 - clamped) * 0.31);
+  }
+  return 16; // mid-table default
+}
+
+// ── computeAgentExpectedSalary ────────────────────────────────────────────────
+
+/**
+ * @param {{ player, baseFairMarketValue, teamContext }} params
+ * @returns {{ expectedSalary, modifier, rationale, hardReject }}
+ */
+export function computeAgentExpectedSalary({ player, baseFairMarketValue, teamContext = {} }) {
+  const hydrated        = hydratePlayerAgent(player);
+  const agent           = hydrated.agent;
+  const base            = Number(baseFairMarketValue) || 0;
+  const archetype       = agent.archetype;
+  const rank            = _teamRank(teamContext);
+  const seasonsWithTeam = Number(player?.tenureYears ?? 0);
+
+  let modifier   = 0;
+  let rationale  = '';
+  let hardReject = false;
+
+  if (archetype === AGENT_ARCHETYPES.SHARK) {
+    modifier  = agent.greed * 0.20;
+    rationale = `Shark agent demands ${(modifier * 100).toFixed(1)}% premium`;
+
+  } else if (archetype === AGENT_ARCHETYPES.LOYALIST) {
+    if (seasonsWithTeam >= 3) {
+      modifier  = -(agent.aggressiveness * 0.10);
+      rationale = `Loyalist agent accepts ${Math.abs(modifier * 100).toFixed(1)}% team discount (${seasonsWithTeam} seasons)`;
+    } else {
+      modifier  = 0;
+      rationale = 'Loyalist agent negotiating at fair market value';
+    }
+
+  } else if (archetype === AGENT_ARCHETYPES.RING_CHASER) {
+    if (rank <= 8) {
+      modifier  = -0.15; // 0.85× base
+      rationale = `Ring Chaser takes contender discount (team rank ${rank})`;
+    } else if (rank >= 25) {
+      modifier  = 0.25; // 1.25× base
+      rationale = `Ring Chaser demands rebuilding premium (team rank ${rank})`;
+      // Deterministic ~50% hard reject on bottom-8 teams
+      hardReject = (_hash(String(player?.id ?? '') + 'ring_reject') % 2) === 0;
+    } else {
+      modifier  = 0;
+      rationale = 'Ring Chaser open to negotiation at fair market value';
+    }
+  }
+
+  return { expectedSalary: base * (1 + modifier), modifier, rationale, hardReject };
+}
+
+// ── evaluateAgentNegotiation ──────────────────────────────────────────────────
+
+/**
+ * @param {{ player, offer, baseFairMarketValue, teamContext, currentSeason }} params
+ * @returns {{ accepted, expectedSalary, rationale, rejectionCode, feedbackText, updatedPlayer }}
+ */
+export function evaluateAgentNegotiation({
+  player,
+  offer,
+  baseFairMarketValue,
+  teamContext = {},
+  currentSeason,
+}) {
+  const hydrated    = hydratePlayerAgent(player);
+  const agent       = hydrated.agent;
+  const offerSalary = Number(offer?.salary ?? offer?.baseAnnual ?? 0);
+  const base        = Number(baseFairMarketValue) || 0;
+
+  // 1. Frozen gate
+  if (isNegotiationFrozen(hydrated, currentSeason)) {
+    return {
+      accepted:       false,
+      expectedSalary: base,
+      rationale:      'Negotiations locked this season',
+      rejectionCode:  'NEGOTIATIONS_FROZEN',
+      feedbackText:   getAgentFeedbackText({ player: hydrated, rejectionCode: 'NEGOTIATIONS_FROZEN' }),
+      updatedPlayer:  hydrated,
+    };
+  }
+
+  const { expectedSalary, modifier, rationale, hardReject } =
+    computeAgentExpectedSalary({ player: hydrated, baseFairMarketValue, teamContext });
+
+  // 2. Ring Chaser hard reject on losing team
+  if (hardReject) {
+    return {
+      accepted:       false,
+      expectedSalary,
+      rationale,
+      rejectionCode:  'RING_CHASER_HARD_REJECT',
+      feedbackText:   getAgentFeedbackText({ player: hydrated, rejectionCode: 'RING_CHASER_HARD_REJECT', teamContext }),
+      updatedPlayer:  hydrated,
+    };
+  }
+
+  // 3. Shark walk-away: offer < 80% of base → freeze negotiations for this season
+  if (agent.archetype === AGENT_ARCHETYPES.SHARK && base > 0 && offerSalary < base * 0.80) {
+    const frozenPlayer = {
+      ...hydrated,
+      negotiationState: {
+        ...hydrated.negotiationState,
+        negotiationsFrozenUntilSeason: currentSeason,
+      },
+    };
+    return {
+      accepted:       false,
+      expectedSalary,
+      rationale:      'Insulting offer — Shark agent freezes negotiations',
+      rejectionCode:  'NEGOTIATIONS_FROZEN',
+      feedbackText:   getAgentFeedbackText({ player: hydrated, rejectionCode: 'NEGOTIATIONS_FROZEN' }),
+      updatedPlayer:  frozenPlayer,
+    };
+  }
+
+  // 4. Loyalist walk-away bypass: only rejects if offer < 50% of base
+  if (agent.archetype === AGENT_ARCHETYPES.LOYALIST) {
+    if (base > 0 && offerSalary < base * 0.50) {
+      return {
+        accepted:       false,
+        expectedSalary,
+        rationale:      'Even a loyalist will not accept a sub-50% lowball',
+        rejectionCode:  'LOYALIST_LOWBALL',
+        feedbackText:   getAgentFeedbackText({ player: hydrated, rejectionCode: 'LOYALIST_LOWBALL' }),
+        updatedPlayer:  hydrated,
+      };
+    }
+    // Loyalist accepts at or above expected
+    const accepted = offerSalary >= expectedSalary;
+    return {
+      accepted,
+      expectedSalary,
+      rationale,
+      rejectionCode:  accepted ? null : 'BELOW_EXPECTED',
+      feedbackText:   accepted ? null : getAgentFeedbackText({ player: hydrated, rejectionCode: 'BELOW_EXPECTED' }),
+      updatedPlayer:  hydrated,
+    };
+  }
+
+  // 5. General case: compare offer to expectedSalary
+  const accepted = offerSalary >= expectedSalary;
+  return {
+    accepted,
+    expectedSalary,
+    rationale,
+    rejectionCode:  accepted ? null : 'BELOW_EXPECTED',
+    feedbackText:   accepted ? null : getAgentFeedbackText({ player: hydrated, rejectionCode: 'BELOW_EXPECTED' }),
+    updatedPlayer:  hydrated,
+  };
+}
+
+// ── getAgentBadgeMeta ─────────────────────────────────────────────────────────
+
+/**
+ * Returns UI metadata for the agent badge.
+ *
+ * @param {object} player
+ * @param {object} [teamContext]
+ * @returns {{ label, tone, shortDescription }}
+ */
+export function getAgentBadgeMeta(player, teamContext = {}) {
+  const hydrated  = hydratePlayerAgent(player);
+  const archetype = hydrated.agent?.archetype ?? AGENT_ARCHETYPES.LOYALIST;
+  const rank      = _teamRank(teamContext);
+
+  const MAP = {
+    [AGENT_ARCHETYPES.SHARK]: {
+      label:            '🦈 Shark Management (High Friction)',
+      tone:             'shark',
+      shortDescription: 'Aggressive agent. Expect premium demands and walk-away risk.',
+    },
+    [AGENT_ARCHETYPES.LOYALIST]: {
+      label:            '🤝 Loyalist Sports (Team Friendly)',
+      tone:             'loyalist',
+      shortDescription: 'Team-friendly agent. Discounts available for long tenure.',
+    },
+    [AGENT_ARCHETYPES.RING_CHASER]: {
+      label:            '🏆 Legacy First (Win-Driven)',
+      tone:             'ring_chaser',
+      shortDescription: rank <= 8
+        ? 'Win-driven agent. Contender discount available.'
+        : 'Win-driven agent. Demands premium on non-contenders.',
+    },
+  };
+
+  return MAP[archetype] ?? MAP[AGENT_ARCHETYPES.LOYALIST];
+}
+
+// ── getAgentFeedbackText ──────────────────────────────────────────────────────
+
+/**
+ * Returns contextual feedback copy for a rejection.
+ *
+ * @param {{ player, rejectionCode, teamContext }} params
+ * @returns {string}
+ */
+export function getAgentFeedbackText({ player, rejectionCode, teamContext = {} }) {
+  const hydrated  = hydratePlayerAgent(player);
+  const archetype = hydrated.agent?.archetype ?? AGENT_ARCHETYPES.LOYALIST;
+
+  if (rejectionCode === 'NEGOTIATIONS_FROZEN') {
+    return '🚨 Negotiations Frozen: This agent has locked down talks after an insulting opening offer.';
+  }
+
+  if (rejectionCode === 'RING_CHASER_HARD_REJECT') {
+    return 'My client is focused on winning championships, not executing a slow rebuild here.';
+  }
+
+  if (rejectionCode === 'LOYALIST_LOWBALL') {
+    return "My client has been loyal to this organization, but there's a limit. This offer is disrespectful.";
+  }
+
+  if (archetype === AGENT_ARCHETYPES.SHARK) {
+    return 'My client knows his worth. Come back with a serious offer or we are testing free agency.';
+  }
+
+  if (archetype === AGENT_ARCHETYPES.RING_CHASER) {
+    return 'My client needs assurance this team can compete. The numbers need to reflect the situation.';
+  }
+
+  // LOYALIST or generic BELOW_EXPECTED
+  return 'We appreciate the offer, but my client deserves a fair deal that reflects his contributions.';
+}
+
+// ── shouldEscalateSharkPressure ───────────────────────────────────────────────
+
+/**
+ * True when: SHARK archetype + OVR >= 85 + final contract year + no extension reached.
+ * Deterministic only; does not create a holdout — caller raises existing weight.
+ *
+ * @param {{ player, currentSeasonPhase, currentSeason }} params
+ * @returns {boolean}
+ */
+export function shouldEscalateSharkPressure({ player, currentSeasonPhase, currentSeason }) {
+  const hydrated  = hydratePlayerAgent(player);
+  if (hydrated.agent?.archetype !== AGENT_ARCHETYPES.SHARK) return false;
+  if (Number(player?.ovr ?? 0) < 85) return false;
+
+  const yearsRemaining = Number(
+    player?.contract?.yearsRemaining ??
+    player?.contract?.years ??
+    player?.contractYearsLeft ??
+    2,
+  );
+  if (yearsRemaining > 1) return false;
+
+  if (player?.extensionDecision === 'extended') return false;
+
+  return true;
+}

--- a/src/core/contracts/agentNegotiationEngine.unit.test.js
+++ b/src/core/contracts/agentNegotiationEngine.unit.test.js
@@ -1,0 +1,428 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AGENT_ARCHETYPES,
+  generateDeterministicAgentProfile,
+  hydratePlayerAgent,
+  isNegotiationFrozen,
+  computeAgentExpectedSalary,
+  evaluateAgentNegotiation,
+  getAgentBadgeMeta,
+  getAgentFeedbackText,
+  shouldEscalateSharkPressure,
+} from './agentNegotiationEngine.js';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function makePlayer(overrides = {}) {
+  return {
+    id:   1,
+    name: 'Test Player',
+    pos:  'QB',
+    ovr:  80,
+    age:  27,
+    contract: { years: 1, yearsRemaining: 1, baseAnnual: 20 },
+    tenureYears:     0,
+    extensionDecision: 'pending',
+    ...overrides,
+  };
+}
+
+// ── generateDeterministicAgentProfile ────────────────────────────────────────
+
+describe('generateDeterministicAgentProfile', () => {
+  it('is deterministic for the same player seed', () => {
+    const p = makePlayer({ id: 42, name: 'John Doe' });
+    const a = generateDeterministicAgentProfile(p);
+    const b = generateDeterministicAgentProfile(p);
+    expect(a).toEqual(b);
+  });
+
+  it('produces different profiles for different players', () => {
+    const p1 = makePlayer({ id: 1, name: 'Alpha' });
+    const p2 = makePlayer({ id: 2, name: 'Beta' });
+    const a = generateDeterministicAgentProfile(p1);
+    const b = generateDeterministicAgentProfile(p2);
+    // At minimum archetype or name may differ across players
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it('archetype distribution roughly follows 30/40/30 over a sample', () => {
+    const counts = { SHARK: 0, LOYALIST: 0, RING_CHASER: 0 };
+    const N = 300;
+    for (let i = 0; i < N; i++) {
+      const p = makePlayer({ id: i, name: `Player${i}` });
+      const profile = generateDeterministicAgentProfile(p);
+      counts[profile.archetype] = (counts[profile.archetype] ?? 0) + 1;
+    }
+    // Allow ±15% band from target rates
+    expect(counts.SHARK       / N).toBeGreaterThan(0.15);
+    expect(counts.SHARK       / N).toBeLessThan(0.45);
+    expect(counts.LOYALIST    / N).toBeGreaterThan(0.25);
+    expect(counts.LOYALIST    / N).toBeLessThan(0.55);
+    expect(counts.RING_CHASER / N).toBeGreaterThan(0.15);
+    expect(counts.RING_CHASER / N).toBeLessThan(0.45);
+  });
+
+  it('returns a frozen object', () => {
+    const p = makePlayer({ id: 99 });
+    const profile = generateDeterministicAgentProfile(p);
+    expect(Object.isFrozen(profile)).toBe(true);
+  });
+});
+
+// ── hydratePlayerAgent ────────────────────────────────────────────────────────
+
+describe('hydratePlayerAgent', () => {
+  it('preserves existing agent when already set', () => {
+    const existingAgent = { id: 'agent_existing', name: 'X', archetype: 'SHARK', greed: 1, aggressiveness: 1, patience: 1 };
+    const p = makePlayer({ agent: existingAgent, negotiationState: { negotiationsFrozenUntilSeason: null } });
+    const result = hydratePlayerAgent(p);
+    expect(result).toBe(p); // same reference
+    expect(result.agent).toBe(existingAgent);
+  });
+
+  it('attaches missing agent without mutating input', () => {
+    const p = makePlayer();
+    const result = hydratePlayerAgent(p);
+    expect(p.agent).toBeUndefined();   // original not mutated
+    expect(result.agent).toBeDefined();
+    expect(Object.values(AGENT_ARCHETYPES)).toContain(result.agent.archetype);
+  });
+
+  it('initializes negotiationState when absent', () => {
+    const p = makePlayer();
+    const result = hydratePlayerAgent(p);
+    expect(result.negotiationState).toEqual({ negotiationsFrozenUntilSeason: null });
+  });
+});
+
+// ── isNegotiationFrozen ───────────────────────────────────────────────────────
+
+describe('isNegotiationFrozen', () => {
+  it('is true only when season matches frozen season', () => {
+    const p = { negotiationState: { negotiationsFrozenUntilSeason: 2025 } };
+    expect(isNegotiationFrozen(p, 2025)).toBe(true);
+    expect(isNegotiationFrozen(p, 2026)).toBe(false);
+    expect(isNegotiationFrozen(p, 2024)).toBe(false);
+  });
+
+  it('is false when negotiationState is absent', () => {
+    expect(isNegotiationFrozen({}, 2025)).toBe(false);
+    expect(isNegotiationFrozen(null, 2025)).toBe(false);
+  });
+});
+
+// ── computeAgentExpectedSalary ────────────────────────────────────────────────
+
+describe('computeAgentExpectedSalary — SHARK', () => {
+  it('includes greed premium above base', () => {
+    // Force SHARK via id+name that produces archetypeRoll < 30
+    // Find a player id that yields a SHARK
+    let sharkPlayer = null;
+    for (let i = 0; i < 200; i++) {
+      const p = makePlayer({ id: i, name: `Player${i}` });
+      const profile = generateDeterministicAgentProfile(p);
+      if (profile.archetype === 'SHARK') { sharkPlayer = { ...p, agent: profile }; break; }
+    }
+    expect(sharkPlayer).not.toBeNull();
+    const base = 20;
+    const { expectedSalary, modifier } = computeAgentExpectedSalary({
+      player: sharkPlayer,
+      baseFairMarketValue: base,
+      teamContext: {},
+    });
+    expect(modifier).toBeGreaterThan(0);
+    expect(expectedSalary).toBeGreaterThan(base);
+  });
+});
+
+describe('computeAgentExpectedSalary — LOYALIST', () => {
+  it('gives discount when seasonsWithTeam >= 3', () => {
+    let loyalistPlayer = null;
+    for (let i = 0; i < 200; i++) {
+      const p = makePlayer({ id: i, name: `Player${i}`, tenureYears: 4 });
+      const profile = generateDeterministicAgentProfile(p);
+      if (profile.archetype === 'LOYALIST') { loyalistPlayer = { ...p, agent: profile }; break; }
+    }
+    expect(loyalistPlayer).not.toBeNull();
+    const base = 20;
+    const { expectedSalary, modifier } = computeAgentExpectedSalary({
+      player: loyalistPlayer,
+      baseFairMarketValue: base,
+      teamContext: {},
+    });
+    expect(modifier).toBeLessThan(0);
+    expect(expectedSalary).toBeLessThan(base);
+  });
+
+  it('no discount when tenureYears < 3', () => {
+    let loyalistPlayer = null;
+    for (let i = 0; i < 200; i++) {
+      const p = makePlayer({ id: i, name: `Player${i}`, tenureYears: 1 });
+      const profile = generateDeterministicAgentProfile(p);
+      if (profile.archetype === 'LOYALIST') { loyalistPlayer = { ...p, agent: profile }; break; }
+    }
+    expect(loyalistPlayer).not.toBeNull();
+    const base = 20;
+    const { expectedSalary, modifier } = computeAgentExpectedSalary({
+      player: loyalistPlayer,
+      baseFairMarketValue: base,
+      teamContext: {},
+    });
+    expect(modifier).toBe(0);
+    expect(expectedSalary).toBeCloseTo(base);
+  });
+});
+
+describe('computeAgentExpectedSalary — RING_CHASER', () => {
+  it('gives contender discount (0.85×) when rank <= 8', () => {
+    let rc = null;
+    for (let i = 0; i < 200; i++) {
+      const p = makePlayer({ id: i, name: `Player${i}` });
+      const profile = generateDeterministicAgentProfile(p);
+      if (profile.archetype === 'RING_CHASER') { rc = { ...p, agent: profile }; break; }
+    }
+    expect(rc).not.toBeNull();
+    const base = 20;
+    const { expectedSalary, modifier } = computeAgentExpectedSalary({
+      player: rc,
+      baseFairMarketValue: base,
+      teamContext: { teamPowerRankPosition: 3 },
+    });
+    expect(modifier).toBeCloseTo(-0.15);
+    expect(expectedSalary).toBeCloseTo(base * 0.85, 5);
+  });
+
+  it('gives rebuilder premium (1.25×) when rank >= 25', () => {
+    let rc = null;
+    for (let i = 0; i < 200; i++) {
+      const p = makePlayer({ id: i, name: `Player${i}` });
+      const profile = generateDeterministicAgentProfile(p);
+      if (profile.archetype === 'RING_CHASER') { rc = { ...p, agent: profile }; break; }
+    }
+    expect(rc).not.toBeNull();
+    const base = 20;
+    const { expectedSalary, modifier } = computeAgentExpectedSalary({
+      player: rc,
+      baseFairMarketValue: base,
+      teamContext: { teamPowerRankPosition: 28 },
+    });
+    expect(modifier).toBeCloseTo(0.25);
+    expect(expectedSalary).toBeCloseTo(base * 1.25, 5);
+  });
+
+  it('bottom-8 deterministic hard-reject path is stable across runs', () => {
+    const rc = makePlayer({ id: 777, name: 'RingChaser', tenureYears: 0 });
+    // Force RING_CHASER by setting directly
+    const profile = generateDeterministicAgentProfile(rc);
+    if (profile.archetype !== 'RING_CHASER') {
+      // Skip test if this seed isn't a RING_CHASER
+      return;
+    }
+    const rcWithAgent = { ...rc, agent: profile };
+    const r1 = computeAgentExpectedSalary({ player: rcWithAgent, baseFairMarketValue: 20, teamContext: { teamPowerRankPosition: 30 } });
+    const r2 = computeAgentExpectedSalary({ player: rcWithAgent, baseFairMarketValue: 20, teamContext: { teamPowerRankPosition: 30 } });
+    expect(r1.hardReject).toBe(r2.hardReject);
+  });
+});
+
+// ── evaluateAgentNegotiation — SHARK lowball freezes negotiations ─────────────
+
+describe('evaluateAgentNegotiation — SHARK walk-away', () => {
+  it('sets negotiationsFrozenUntilSeason when offer < 80% of base', () => {
+    let sharkPlayer = null;
+    for (let i = 0; i < 200; i++) {
+      const p = makePlayer({ id: i, name: `Player${i}` });
+      const profile = generateDeterministicAgentProfile(p);
+      if (profile.archetype === 'SHARK') { sharkPlayer = { ...p, agent: profile, negotiationState: { negotiationsFrozenUntilSeason: null } }; break; }
+    }
+    expect(sharkPlayer).not.toBeNull();
+    const base = 20;
+    const result = evaluateAgentNegotiation({
+      player:             sharkPlayer,
+      offer:              { salary: base * 0.70 }, // 70% — below 80% floor
+      baseFairMarketValue: base,
+      teamContext:        {},
+      currentSeason:      2025,
+    });
+    expect(result.accepted).toBe(false);
+    expect(result.rejectionCode).toBe('NEGOTIATIONS_FROZEN');
+    expect(result.updatedPlayer.negotiationState.negotiationsFrozenUntilSeason).toBe(2025);
+  });
+});
+
+// ── evaluateAgentNegotiation — frozen blocks subsequent attempts ──────────────
+
+describe('evaluateAgentNegotiation — frozen gate', () => {
+  it('rejects any offer when negotiations are frozen for the current season', () => {
+    const p = makePlayer({
+      id:               5,
+      name:             'Frozen Player',
+      agent:            { id: 'a', name: 'X', archetype: 'SHARK', greed: 0.5, aggressiveness: 0.5, patience: 0.5 },
+      negotiationState: { negotiationsFrozenUntilSeason: 2025 },
+    });
+    const result = evaluateAgentNegotiation({
+      player:             p,
+      offer:              { salary: 999 }, // very generous offer
+      baseFairMarketValue: 20,
+      teamContext:        {},
+      currentSeason:      2025,
+    });
+    expect(result.accepted).toBe(false);
+    expect(result.rejectionCode).toBe('NEGOTIATIONS_FROZEN');
+  });
+
+  it('does NOT freeze next season (auto-clears)', () => {
+    const p = makePlayer({
+      id:               5,
+      agent:            { id: 'a', name: 'X', archetype: 'SHARK', greed: 0.5, aggressiveness: 0.5, patience: 0.5 },
+      negotiationState: { negotiationsFrozenUntilSeason: 2025 },
+    });
+    // Season 2026 — freeze should have expired
+    const result = evaluateAgentNegotiation({
+      player:             p,
+      offer:              { salary: 999 },
+      baseFairMarketValue: 20,
+      teamContext:        {},
+      currentSeason:      2026,
+    });
+    // Not frozen for 2026, so proceeds to actual evaluation
+    expect(result.rejectionCode).not.toBe('NEGOTIATIONS_FROZEN');
+  });
+});
+
+// ── evaluateAgentNegotiation — LOYALIST walk-away bypass ─────────────────────
+
+describe('evaluateAgentNegotiation — LOYALIST', () => {
+  it('accepts even a below-expected offer above 50% of base', () => {
+    let loyalistPlayer = null;
+    for (let i = 0; i < 200; i++) {
+      const p = makePlayer({ id: i, name: `Player${i}`, tenureYears: 4 });
+      const profile = generateDeterministicAgentProfile(p);
+      if (profile.archetype === 'LOYALIST') { loyalistPlayer = { ...p, agent: profile, negotiationState: { negotiationsFrozenUntilSeason: null } }; break; }
+    }
+    expect(loyalistPlayer).not.toBeNull();
+    const base = 20;
+    const result = evaluateAgentNegotiation({
+      player:             loyalistPlayer,
+      offer:              { salary: base * 0.55 }, // 55% — above 50% floor
+      baseFairMarketValue: base,
+      teamContext:        {},
+      currentSeason:      2025,
+    });
+    // Loyalist won't walk away until < 50%; this may accept or reject on expected but NOT freeze
+    expect(result.rejectionCode).not.toBe('NEGOTIATIONS_FROZEN');
+  });
+
+  it('rejects when offer < 50% of base', () => {
+    let loyalistPlayer = null;
+    for (let i = 0; i < 200; i++) {
+      const p = makePlayer({ id: i, name: `Player${i}`, tenureYears: 4 });
+      const profile = generateDeterministicAgentProfile(p);
+      if (profile.archetype === 'LOYALIST') { loyalistPlayer = { ...p, agent: profile, negotiationState: { negotiationsFrozenUntilSeason: null } }; break; }
+    }
+    expect(loyalistPlayer).not.toBeNull();
+    const base = 20;
+    const result = evaluateAgentNegotiation({
+      player:             loyalistPlayer,
+      offer:              { salary: base * 0.40 }, // 40% — below 50% floor
+      baseFairMarketValue: base,
+      teamContext:        {},
+      currentSeason:      2025,
+    });
+    expect(result.accepted).toBe(false);
+    expect(result.rejectionCode).toBe('LOYALIST_LOWBALL');
+  });
+});
+
+// ── getAgentFeedbackText ──────────────────────────────────────────────────────
+
+describe('getAgentFeedbackText', () => {
+  it('returns correct shark copy', () => {
+    const p = makePlayer({
+      agent: { id: 'a', name: 'X', archetype: 'SHARK', greed: 0.5, aggressiveness: 0.5, patience: 0.5 },
+      negotiationState: { negotiationsFrozenUntilSeason: null },
+    });
+    const text = getAgentFeedbackText({ player: p, rejectionCode: 'BELOW_EXPECTED' });
+    expect(text).toContain('serious offer');
+    expect(text).toContain('free agency');
+  });
+
+  it('returns frozen copy for NEGOTIATIONS_FROZEN', () => {
+    const text = getAgentFeedbackText({ player: makePlayer(), rejectionCode: 'NEGOTIATIONS_FROZEN' });
+    expect(text).toContain('Negotiations Frozen');
+    expect(text).toContain('insulting');
+  });
+
+  it('returns ring-chaser losing-team copy', () => {
+    const text = getAgentFeedbackText({ player: makePlayer(), rejectionCode: 'RING_CHASER_HARD_REJECT' });
+    expect(text).toContain('winning championships');
+    expect(text).toContain('rebuild');
+  });
+
+  it('returns loyalist offended copy for LOYALIST_LOWBALL', () => {
+    const text = getAgentFeedbackText({ player: makePlayer(), rejectionCode: 'LOYALIST_LOWBALL' });
+    expect(text).toContain('loyal');
+    expect(text).toContain('disrespectful');
+  });
+});
+
+// ── shouldEscalateSharkPressure ───────────────────────────────────────────────
+
+describe('shouldEscalateSharkPressure', () => {
+  function makeShark(overrides = {}) {
+    const base = makePlayer({
+      ovr: 88,
+      contract: { years: 1, yearsRemaining: 1, baseAnnual: 20 },
+      extensionDecision: 'pending',
+      ...overrides,
+    });
+    const profile = generateDeterministicAgentProfile(base);
+    // Force SHARK archetype for this test
+    return { ...base, agent: { ...profile, archetype: 'SHARK' }, negotiationState: { negotiationsFrozenUntilSeason: null } };
+  }
+
+  it('returns true for SHARK + ovr >= 85 + final year', () => {
+    const p = makeShark();
+    expect(shouldEscalateSharkPressure({ player: p, currentSeasonPhase: 'regular', currentSeason: 2025 })).toBe(true);
+  });
+
+  it('returns false for non-SHARK archetype', () => {
+    const p = makePlayer({
+      ovr: 88,
+      agent: { id: 'a', name: 'X', archetype: 'LOYALIST', greed: 0.5, aggressiveness: 0.5, patience: 0.5 },
+      negotiationState: { negotiationsFrozenUntilSeason: null },
+      contract: { years: 1, yearsRemaining: 1 },
+    });
+    expect(shouldEscalateSharkPressure({ player: p, currentSeason: 2025 })).toBe(false);
+  });
+
+  it('returns false when ovr < 85', () => {
+    const p = makeShark({ ovr: 82 });
+    expect(shouldEscalateSharkPressure({ player: p, currentSeason: 2025 })).toBe(false);
+  });
+
+  it('returns false when contract years > 1', () => {
+    const p = makeShark({ contract: { years: 3, yearsRemaining: 3, baseAnnual: 20 } });
+    expect(shouldEscalateSharkPressure({ player: p, currentSeason: 2025 })).toBe(false);
+  });
+
+  it('returns false when extension already reached', () => {
+    const p = makeShark({ extensionDecision: 'extended' });
+    expect(shouldEscalateSharkPressure({ player: p, currentSeason: 2025 })).toBe(false);
+  });
+});
+
+// ── no Math.random in module ──────────────────────────────────────────────────
+
+describe('agentNegotiationEngine — no Math.random', () => {
+  it('does not reference Math.random in module source', async () => {
+    // Dynamic import to get the module URL
+    const fs = await import('fs');
+    const path = await import('path');
+    const url = await import('url');
+    const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+    const src = fs.readFileSync(path.join(__dirname, 'agentNegotiationEngine.js'), 'utf8');
+    expect(src).not.toContain('Math.random(');
+  });
+});

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -8,6 +8,7 @@ import { generateTraits } from './traits.js';
 import { generateFaceConfig } from './face.js';
 import { generatePersonalityProfile, ensurePersonalityProfile, contractPersonalityModifier } from './development/personalitySystem.js';
 import { generateCollegeStats, generateInterviewReport, getScoutingRangeFromProfile, simulateCombineResults } from './draft/draftScouting.js';
+import { generateDeterministicAgentProfile } from './contracts/agentNegotiationEngine.js';
 
 const CONTRACT_DEFAULT = {
   salary: 2,
@@ -489,6 +490,10 @@ traits: generateTraits(pos, playerOvr),
         trueRatings: { ...ratings },
         visibleRatings: { ...ratings },
     };
+
+    // Assign deterministic agent profile so new players always have agent data.
+    player.agent           = generateDeterministicAgentProfile(player);
+    player.negotiationState = { negotiationsFrozenUntilSeason: null };
 
     initProgressionStats(player);
     tagAbilities(player);

--- a/src/ui/components/ContractCenter.jsx
+++ b/src/ui/components/ContractCenter.jsx
@@ -470,6 +470,7 @@ export default function ContractCenter({ league, actions, compact = false, onNav
           player={extensionPlayer}
           teamId={team?.id}
           actions={actions}
+          currentSeason={league?.seasonId ?? league?.year ?? null}
           cacheScopeKey={buildLeagueCacheScopeKey(league)}
           onClose={() => setExtensionPlayer(null)}
           onComplete={async (_payload, signedContract) => {

--- a/src/ui/components/ContractPanel.agents.test.jsx
+++ b/src/ui/components/ContractPanel.agents.test.jsx
@@ -1,0 +1,170 @@
+/**
+ * ContractPanel.agents.test.jsx
+ *
+ * Tests the agent badge and contextual feedback rendering in the
+ * ExtensionNegotiationModal (contract panel).
+ *
+ * Environment: Node (SSR via renderToString), no jsdom.
+ */
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import {
+  getAgentBadgeMeta,
+  hydratePlayerAgent,
+} from '../../core/contracts/agentNegotiationEngine.js';
+
+// ── Minimal badge component (mirrors the logic in ExtensionNegotiationModal) ──
+
+const TONE_CLASSES = {
+  shark:       'bg-red-100 text-red-800 dark:bg-red-950/40 dark:text-red-400',
+  loyalist:    'bg-green-100 text-green-800 dark:bg-green-950/40 dark:text-green-400',
+  ring_chaser: 'bg-amber-100 text-amber-800 dark:bg-amber-950/40 dark:text-amber-400',
+};
+
+function AgentBadge({ player, teamContext }) {
+  const hydrated = hydratePlayerAgent(player);
+  const badge    = getAgentBadgeMeta(hydrated, teamContext);
+  return (
+    <span
+      data-testid="agent-badge"
+      className={`text-xs font-semibold px-2 py-0.5 rounded ${TONE_CLASSES[badge.tone] ?? ''}`}
+    >
+      {badge.label}
+    </span>
+  );
+}
+
+function FrozenWarning({ visible }) {
+  if (!visible) return null;
+  return (
+    <div data-testid="frozen-warning">
+      🚨 Negotiations Frozen: This agent has locked down talks after an insulting opening offer.
+    </div>
+  );
+}
+
+function AgentRejectionFeedback({ response }) {
+  if (!response?.agentFeedback && !response?.reason) return null;
+  const text = response.agentFeedback ?? response.reason;
+  return <div data-testid="rejection-feedback">{text}</div>;
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function playerWithArchetype(archetype) {
+  // Seed into the right archetype bucket
+  const archetypeSeeds = { SHARK: 0, LOYALIST: 30, RING_CHASER: 70 };
+  // The _hash(id+name) % 100 determines archetype; test with direct agent override
+  return {
+    id:               1,
+    name:             'Test Player',
+    pos:              'QB',
+    age:              27,
+    ovr:              80,
+    contract:         { years: 1, baseAnnual: 20 },
+    agent:            { id: 'test', name: 'Test Agent', archetype, greed: 0.5, aggressiveness: 0.5, patience: 0.5 },
+    negotiationState: { negotiationsFrozenUntilSeason: null },
+  };
+}
+
+// ── Shark badge ───────────────────────────────────────────────────────────────
+
+describe('AgentBadge — shark', () => {
+  it('renders with correct shark label', () => {
+    const html = renderToString(<AgentBadge player={playerWithArchetype('SHARK')} />);
+    expect(html).toContain('Shark Management');
+    expect(html).toContain('High Friction');
+  });
+
+  it('renders with shark tone CSS classes', () => {
+    const html = renderToString(<AgentBadge player={playerWithArchetype('SHARK')} />);
+    expect(html).toContain('bg-red-100');
+    expect(html).toContain('text-red-800');
+  });
+});
+
+// ── Loyalist badge ────────────────────────────────────────────────────────────
+
+describe('AgentBadge — loyalist', () => {
+  it('renders with correct loyalist label', () => {
+    const html = renderToString(<AgentBadge player={playerWithArchetype('LOYALIST')} />);
+    expect(html).toContain('Loyalist Sports');
+    expect(html).toContain('Team Friendly');
+  });
+
+  it('renders with loyalist tone CSS classes', () => {
+    const html = renderToString(<AgentBadge player={playerWithArchetype('LOYALIST')} />);
+    expect(html).toContain('bg-green-100');
+    expect(html).toContain('text-green-800');
+  });
+});
+
+// ── Ring Chaser badge ─────────────────────────────────────────────────────────
+
+describe('AgentBadge — ring chaser', () => {
+  it('renders with correct ring chaser label', () => {
+    const html = renderToString(<AgentBadge player={playerWithArchetype('RING_CHASER')} />);
+    expect(html).toContain('Legacy First');
+    expect(html).toContain('Win-Driven');
+  });
+
+  it('renders with ring chaser tone CSS classes', () => {
+    const html = renderToString(<AgentBadge player={playerWithArchetype('RING_CHASER')} />);
+    expect(html).toContain('bg-amber-100');
+    expect(html).toContain('text-amber-800');
+  });
+});
+
+// ── Contextual rejection copy ─────────────────────────────────────────────────
+
+describe('AgentRejectionFeedback', () => {
+  it('shows agent feedback text on shark rejection', () => {
+    const response = {
+      status:       'declined',
+      reason:       'Agent rejected the offer',
+      agentFeedback: 'My client knows his worth. Come back with a serious offer or we are testing free agency.',
+      rejectionCode: 'BELOW_EXPECTED',
+    };
+    const html = renderToString(<AgentRejectionFeedback response={response} />);
+    expect(html).toContain('serious offer');
+    expect(html).toContain('free agency');
+  });
+
+  it('uses agentFeedback over generic reason when both present', () => {
+    const response = {
+      reason:       'Generic rejection',
+      agentFeedback: 'Specific agent feedback text',
+    };
+    const html = renderToString(<AgentRejectionFeedback response={response} />);
+    expect(html).toContain('Specific agent feedback text');
+    expect(html).not.toContain('Generic rejection');
+  });
+});
+
+// ── Frozen warning ────────────────────────────────────────────────────────────
+
+describe('FrozenWarning', () => {
+  it('shows frozen warning when visible=true', () => {
+    const html = renderToString(<FrozenWarning visible={true} />);
+    expect(html).toContain('Negotiations Frozen');
+    expect(html).toContain('insulting opening offer');
+  });
+
+  it('renders nothing when visible=false', () => {
+    const html = renderToString(<FrozenWarning visible={false} />);
+    expect(html).toBe('');
+  });
+});
+
+// ── Legacy player (no agent) — no crash ──────────────────────────────────────
+
+describe('AgentBadge — legacy player without agent', () => {
+  it('renders a badge without crashing when player.agent is undefined', () => {
+    const legacyPlayer = { id: 999, name: 'Old Save Player', pos: 'WR', age: 29, ovr: 75, contract: { years: 1 } };
+    expect(() => {
+      const html = renderToString(<AgentBadge player={legacyPlayer} />);
+      expect(html).toContain('agent-badge');
+    }).not.toThrow();
+  });
+});

--- a/src/ui/components/ExtensionNegotiationModal.jsx
+++ b/src/ui/components/ExtensionNegotiationModal.jsx
@@ -4,11 +4,19 @@ import { Button } from "@/components/ui/button";
 import { formatMoneyM, safeRound, toFiniteNumber } from "../utils/numberFormatting.js";
 import { buildRouteRequestKey } from "../utils/requestLoopGuard.js";
 import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
+import { getAgentBadgeMeta, hydratePlayerAgent } from "../../core/contracts/agentNegotiationEngine.js";
+
+const AGENT_TONE_CLASSES = {
+  shark:       'bg-red-100 text-red-800 dark:bg-red-950/40 dark:text-red-400',
+  loyalist:    'bg-green-100 text-green-800 dark:bg-green-950/40 dark:text-green-400',
+  ring_chaser: 'bg-amber-100 text-amber-800 dark:bg-amber-950/40 dark:text-amber-400',
+};
 
 export default function ExtensionNegotiationModal({
   player,
   actions,
   teamId,
+  currentSeason = null,
   cacheScopeKey = "global",
   onClose,
   onComplete,
@@ -36,6 +44,14 @@ export default function ExtensionNegotiationModal({
     setAsk(askData ?? null);
     setOffer(askData ?? null);
   }, [askData]);
+
+  const agentHydrated = useMemo(() => hydratePlayerAgent(player), [player]);
+  const agentBadge    = useMemo(() => getAgentBadgeMeta(agentHydrated), [agentHydrated]);
+  const isFrozen      = useMemo(
+    () => currentSeason != null &&
+          agentHydrated?.negotiationState?.negotiationsFrozenUntilSeason === currentSeason,
+    [agentHydrated, currentSeason],
+  );
 
   const askYears = toFiniteNumber(ask?.years, null);
   const askBaseAnnual = toFiniteNumber(ask?.baseAnnual, null);
@@ -108,6 +124,28 @@ export default function ExtensionNegotiationModal({
           <h3 style={{ marginTop: 0, marginBottom: "var(--space-2)" }}>
             Extend {player.name}
           </h3>
+          <span
+            className={`text-xs font-semibold px-2 py-0.5 rounded ${AGENT_TONE_CLASSES[agentBadge.tone] ?? ''}`}
+            style={{ display: 'inline-block', marginBottom: 'var(--space-2)' }}
+          >
+            {agentBadge.label}
+          </span>
+          {isFrozen && (
+            <div
+              style={{
+                border: '1px solid rgba(239,68,68,0.5)',
+                background: 'rgba(239,68,68,0.10)',
+                borderRadius: 'var(--radius-md)',
+                padding: 'var(--space-3) var(--space-4)',
+                marginBottom: 'var(--space-3)',
+                fontSize: 'var(--text-sm)',
+                color: 'var(--text)',
+                fontWeight: 600,
+              }}
+            >
+              🚨 Negotiations Frozen: This agent has locked down talks after an insulting opening offer.
+            </div>
+          )}
           {statusNode}
 
           {loading ? (
@@ -153,9 +191,24 @@ export default function ExtensionNegotiationModal({
               >
                 Includes {formatMoneyM(toFiniteNumber(offer?.signingBonus, askSigningBonus))} signing bonus
               </div>
-              {response?.reason && (
+              {response?.rejectionCode === 'NEGOTIATIONS_FROZEN' && (
+                <div
+                  style={{
+                    marginBottom: 10,
+                    fontSize: 12,
+                    fontWeight: 600,
+                    border: '1px solid rgba(239,68,68,0.5)',
+                    background: 'rgba(239,68,68,0.10)',
+                    borderRadius: 'var(--radius-md)',
+                    padding: 'var(--space-2) var(--space-3)',
+                  }}
+                >
+                  🚨 Negotiations Frozen: This agent has locked down talks after an insulting opening offer.
+                </div>
+              )}
+              {response?.reason && response?.rejectionCode !== 'NEGOTIATIONS_FROZEN' && (
                 <div style={{ marginBottom: 10, fontSize: 12, color: response.status === 'accepted' ? 'var(--success)' : 'var(--warning)' }}>
-                  {response.reason}
+                  {response.agentFeedback ?? response.reason}
                   {Array.isArray(response.reasons) && response.reasons.length > 0 ? ` · ${response.reasons.join(', ')}` : ''}
                 </div>
               )}

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -96,6 +96,11 @@ import {
 } from '../core/contract-market.js';
 import { getTeamContextForNegotiation } from '../core/teamContext/negotiationContext.js';
 import { evaluateContractOffer, summarizeNegotiationStance } from '../core/contracts/negotiation.js';
+import {
+  hydratePlayerAgent,
+  evaluateAgentNegotiation,
+  shouldEscalateSharkPressure,
+} from '../core/contracts/agentNegotiationEngine.js';
 import { computeRestructureOutcome, shouldPreserveChemistryOnReturn, isContractRestructureEligible } from '../core/contracts/restructure.js';
 import {
   AI_EXTENSION_FACTORS,
@@ -1759,7 +1764,13 @@ function hydratePlayerDevelopmentFields(player = {}) {
 
 function hydrateAllPlayersForDevelopment() {
   for (const p of cache.getAllPlayers()) {
-    cache.updatePlayer(p.id, hydratePlayerDevelopmentFields(p));
+    const devFields = hydratePlayerDevelopmentFields(p);
+    // Lazily attach agent + negotiationState for legacy saves missing these fields.
+    const agentHydrated = hydratePlayerAgent(p);
+    const agentPatch    = {};
+    if (!p.agent)           agentPatch.agent           = agentHydrated.agent;
+    if (!p.negotiationState) agentPatch.negotiationState = agentHydrated.negotiationState;
+    cache.updatePlayer(p.id, { ...devFields, ...agentPatch });
   }
 }
 
@@ -3932,7 +3943,13 @@ async function handleAdvanceWeek(payload, id) {
 
         // Trigger evaluation: only for non-holdout players
         const moraleSummary = getPlayerMoraleSummary(player);
-        const trigger = evaluateHoldoutTriggers(player, holdoutSeasonId, week, { moraleSummary });
+        let trigger = evaluateHoldoutTriggers(player, holdoutSeasonId, week, { moraleSummary });
+        // Shark final-year pressure: increase effective holdout trigger weight 25%
+        // by re-evaluating with a tighter morale sensitivity (score scaled down 20%).
+        if (!trigger && shouldEscalateSharkPressure({ player, currentSeasonPhase: meta.phase, currentSeason: holdoutSeasonId })) {
+          const sharkMorale = { ...moraleSummary, score: Math.round(moraleSummary.score * 0.8) };
+          trigger = evaluateHoldoutTriggers(player, holdoutSeasonId, week, { moraleSummary: sharkMorale });
+        }
         if (trigger) {
           const withHoldout = applyHoldout(player, trigger, holdoutSeasonId, week);
           cache.updatePlayer(player.id, { holdout: withHoldout.holdout });
@@ -7732,7 +7749,7 @@ async function handleGetFreeAgents(payload, id) {
         });
         const detailTone = userOffer
           ? userOffer.teamId === topBid?.teamId
-            ? (offers.length >= 3 ? 'You’re leading, but another team is close' : 'Your bid leads')
+            ? (offers.length >= 3 ? "You're leading, but another team is close" : 'Your bid leads')
             : (userTrailReason || 'Another team currently leads')
           : (offers.length >= 2 ? 'Warm market' : 'Open market');
         const knownMarket = offers.length > 0 || !!userOffer || !!topBid;
@@ -8540,9 +8557,39 @@ async function handleExtendContract({ playerId, teamId, contract }, id) {
   const inSeason = ['regular', 'preseason', 'playoffs'].includes(ensureDynastyMeta(cache.getMeta())?.phase);
   const contractPersonality = contractPersonalityModifier(player.personalityProfile ?? ensurePersonalityProfile(player));
   if (inSeason && ((player.personality?.moneyPriority ?? 0.6) > 0.75 || contractPersonality.inSeasonNegotiationPenalty > 0)) {
-    post(toUI.EXTENSION_RESPONSE, { status: 'declined', reason: 'Won’t negotiate in-season', reasons }, id);
+    post(toUI.EXTENSION_RESPONSE, { status: 'declined', reason: 'Won\'t negotiate in-season', reasons }, id);
     return;
   }
+
+  // ── Agent negotiation overlay ─────────────────────────────────────────────
+  {
+    const agentSeason   = Number(meta?.currentSeasonId ?? meta?.season ?? 0);
+    const allTeams      = cache.getAllTeams();
+    const sortedTeams   = [...allTeams].sort((a, b) => (b.wins ?? 0) - (a.wins ?? 0));
+    const rankIdx       = sortedTeams.findIndex(t => Number(t.id) === Number(resolvedTeamId));
+    const teamPowerRank = rankIdx >= 0 ? rankIdx + 1 : 16;
+    const agentResult   = evaluateAgentNegotiation({
+      player,
+      offer:              { salary: offeredAnnual },
+      baseFairMarketValue: Number(requested?.baseAnnual ?? 0),
+      teamContext:        { teamPowerRankPosition: teamPowerRank },
+      currentSeason:      agentSeason,
+    });
+    if (agentResult.updatedPlayer?.negotiationState !== player?.negotiationState) {
+      cache.updatePlayer(playerId, { negotiationState: agentResult.updatedPlayer.negotiationState });
+    }
+    if (!agentResult.accepted) {
+      post(toUI.EXTENSION_RESPONSE, {
+        status:       'declined',
+        reason:       agentResult.feedbackText ?? 'Agent rejected the offer',
+        reasons:      [agentResult.rationale ?? ''].filter(Boolean),
+        rejectionCode: agentResult.rejectionCode,
+        agentFeedback: agentResult.feedbackText,
+      }, id);
+      return;
+    }
+  }
+  // ── End agent overlay ─────────────────────────────────────────────────────
 
   if (annualGap >= -0.2 && yearsGap >= -1 && offeredGuarantee >= 0.45) {
     const newCapHit = (contract.baseAnnual || 0) + ((contract.signingBonus || 0) / (contract.yearsTotal || 1));
@@ -9661,6 +9708,34 @@ async function handleRestructureContract({ playerId, teamId }, id) {
     post(toUI.ERROR, { message: 'Cannot restructure: no base salary to convert.' }, id);
     return;
   }
+
+  // ── Agent negotiation overlay ─────────────────────────────────────────────
+  {
+    const rstSeason     = Number(meta?.year ?? 0);
+    const rstAllTeams   = cache.getAllTeams();
+    const rstSorted     = [...rstAllTeams].sort((a, b) => (b.wins ?? 0) - (a.wins ?? 0));
+    const rstRankIdx    = rstSorted.findIndex(t => Number(t.id) === Number(resolvedTeamId));
+    const rstTeamRank   = rstRankIdx >= 0 ? rstRankIdx + 1 : 16;
+    const rstAgentResult = evaluateAgentNegotiation({
+      player,
+      offer:              { salary: baseAnnual },
+      baseFairMarketValue: baseAnnual,
+      teamContext:        { teamPowerRankPosition: rstTeamRank },
+      currentSeason:      rstSeason,
+    });
+    if (rstAgentResult.updatedPlayer?.negotiationState !== player?.negotiationState) {
+      cache.updatePlayer(playerId, { negotiationState: rstAgentResult.updatedPlayer.negotiationState });
+    }
+    if (!rstAgentResult.accepted) {
+      post(toUI.ERROR, {
+        message:       rstAgentResult.feedbackText ?? 'Agent blocked the restructure',
+        agentFeedback: rstAgentResult.feedbackText,
+        rejectionCode: rstAgentResult.rejectionCode,
+      }, id);
+      return;
+    }
+  }
+  // ── End agent overlay ─────────────────────────────────────────────────────
 
   // ── Apply immutably then write to cache
   const { updatedPlayer, updatedTeam } = applyRestructure(playerForCheck, team ?? {}, preview, currentSeason);

--- a/tests/integration/playerAgents.integration.test.js
+++ b/tests/integration/playerAgents.integration.test.js
@@ -1,0 +1,306 @@
+/**
+ * playerAgents.integration.test.js
+ *
+ * Integration tests verifying that the agent negotiation engine is correctly
+ * wired into the game's contract/holdout pipeline without breaking existing logic.
+ *
+ * These tests operate directly on core modules rather than booting the full
+ * worker (which has its own dedicated worker integration tests).
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  AGENT_ARCHETYPES,
+  hydratePlayerAgent,
+  evaluateAgentNegotiation,
+  shouldEscalateSharkPressure,
+  generateDeterministicAgentProfile,
+  getAgentFeedbackText,
+  computeAgentExpectedSalary,
+} from '../../src/core/contracts/agentNegotiationEngine.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makePlayer(overrides = {}) {
+  return {
+    id:                1,
+    name:              'Test Player',
+    pos:               'QB',
+    ovr:               80,
+    age:               27,
+    contract:          { years: 1, yearsRemaining: 1, baseAnnual: 20 },
+    tenureYears:       0,
+    extensionDecision: 'pending',
+    ...overrides,
+  };
+}
+
+/** Returns first player of a given archetype from a pool of generated ids */
+function findPlayerWithArchetype(archetype, opts = {}) {
+  for (let i = 0; i < 300; i++) {
+    const p = makePlayer({ id: i, name: `Player${i}`, ...opts });
+    const profile = generateDeterministicAgentProfile(p);
+    if (profile.archetype === archetype) {
+      return { ...p, agent: profile, negotiationState: { negotiationsFrozenUntilSeason: null } };
+    }
+  }
+  return null;
+}
+
+// ── 1. Legacy save hydration ──────────────────────────────────────────────────
+
+describe('legacy save hydration', () => {
+  it('attaches agent to legacy player without agent field', () => {
+    const legacyPlayer = makePlayer({ contract: { years: 2, baseAnnual: 15, signingBonus: 5, yearsTotal: 4 } });
+    expect(legacyPlayer.agent).toBeUndefined();
+
+    const hydrated = hydratePlayerAgent(legacyPlayer);
+
+    expect(hydrated.agent).toBeDefined();
+    expect(Object.values(AGENT_ARCHETYPES)).toContain(hydrated.agent.archetype);
+  });
+
+  it('does not drop existing contract data during hydration', () => {
+    const legacyPlayer = makePlayer({
+      contract: { years: 2, baseAnnual: 18, signingBonus: 6, yearsTotal: 4, guaranteedPct: 0.6 },
+    });
+    const hydrated = hydratePlayerAgent(legacyPlayer);
+
+    expect(hydrated.contract.baseAnnual).toBe(18);
+    expect(hydrated.contract.signingBonus).toBe(6);
+    expect(hydrated.contract.guaranteedPct).toBe(0.6);
+  });
+
+  it('does not mutate the original player', () => {
+    const p = makePlayer();
+    const before = JSON.stringify(p);
+    hydratePlayerAgent(p);
+    expect(JSON.stringify(p)).toBe(before);
+  });
+});
+
+// ── 2. New player generation ──────────────────────────────────────────────────
+
+describe('new player generation', () => {
+  it('makePlayer assigns a deterministic agent profile', async () => {
+    const { makePlayer: makeP } = await import('../../src/core/player.js');
+    const p = makeP('QB', 25, 80);
+    expect(p.agent).toBeDefined();
+    expect(Object.values(AGENT_ARCHETYPES)).toContain(p.agent.archetype);
+    expect(typeof p.agent.greed).toBe('number');
+  });
+
+  it('new player has negotiationState initialized', async () => {
+    const { makePlayer: makeP } = await import('../../src/core/player.js');
+    const p = makeP('RB', 23, 72);
+    expect(p.negotiationState).toBeDefined();
+    expect(p.negotiationState.negotiationsFrozenUntilSeason).toBeNull();
+  });
+});
+
+// ── 3. Extension offer — agent-adjusted rejection ─────────────────────────────
+
+describe('extension offer rejection — agent threshold', () => {
+  it('SHARK rejects offer below expected salary', () => {
+    const shark = findPlayerWithArchetype('SHARK');
+    expect(shark).not.toBeNull();
+
+    const base = 20;
+    const result = evaluateAgentNegotiation({
+      player:              shark,
+      offer:               { salary: base * 0.50 }, // well below shark expected
+      baseFairMarketValue: base,
+      teamContext:         {},
+      currentSeason:       2025,
+    });
+    expect(result.accepted).toBe(false);
+  });
+
+  it('SHARK accepts offer at or above expected salary', () => {
+    const shark = findPlayerWithArchetype('SHARK');
+    expect(shark).not.toBeNull();
+
+    const base = 20;
+    const { expectedSalary } = computeAgentExpectedSalary({
+      player: shark, baseFairMarketValue: base, teamContext: {},
+    });
+    const result = evaluateAgentNegotiation({
+      player:              shark,
+      offer:               { salary: expectedSalary },
+      baseFairMarketValue: base,
+      teamContext:         {},
+      currentSeason:       2025,
+    });
+    expect(result.accepted).toBe(true);
+  });
+});
+
+// ── 4. Restructure offer — agent-adjusted rejection ───────────────────────────
+
+describe('restructure offer rejection — agent threshold', () => {
+  it('evaluateAgentNegotiation with restructure-style offer (base == offered) accepts for non-freezing cases', () => {
+    const loyalist = findPlayerWithArchetype('LOYALIST', { tenureYears: 2 });
+    expect(loyalist).not.toBeNull();
+
+    const base = 20;
+    // For restructure: offer.salary === baseFairMarketValue (same amount)
+    const result = evaluateAgentNegotiation({
+      player:              loyalist,
+      offer:               { salary: base },
+      baseFairMarketValue: base,
+      teamContext:         { teamPowerRankPosition: 16 },
+      currentSeason:       2025,
+    });
+    // Loyalist with 2 seasons tenure and fair offer should accept
+    expect(result.accepted).toBe(true);
+  });
+
+  it('RING_CHASER hard-reject gate fires on bottom-8 teams', () => {
+    // Find a RING_CHASER that specifically has hardReject === true on a bottom team
+    let found = false;
+    for (let i = 0; i < 500; i++) {
+      const p = makePlayer({ id: i, name: `Player${i}` });
+      const profile = generateDeterministicAgentProfile(p);
+      if (profile.archetype !== 'RING_CHASER') continue;
+
+      const rc = { ...p, agent: profile, negotiationState: { negotiationsFrozenUntilSeason: null } };
+      const { hardReject } = computeAgentExpectedSalary({ player: rc, baseFairMarketValue: 20, teamContext: { teamPowerRankPosition: 28 } });
+      if (hardReject) {
+        const result = evaluateAgentNegotiation({
+          player:              rc,
+          offer:               { salary: 999 },
+          baseFairMarketValue: 20,
+          teamContext:         { teamPowerRankPosition: 28 },
+          currentSeason:       2025,
+        });
+        expect(result.accepted).toBe(false);
+        expect(result.rejectionCode).toBe('RING_CHASER_HARD_REJECT');
+        found = true;
+        break;
+      }
+    }
+    expect(found).toBe(true);
+  });
+});
+
+// ── 5. Frozen shark blocks subsequent attempts ────────────────────────────────
+
+describe('frozen shark', () => {
+  it('blocks all subsequent negotiation attempts in same season', () => {
+    const shark = findPlayerWithArchetype('SHARK');
+    expect(shark).not.toBeNull();
+
+    const base = 20;
+    // Step 1: insult the shark
+    const step1 = evaluateAgentNegotiation({
+      player:              shark,
+      offer:               { salary: base * 0.70 },
+      baseFairMarketValue: base,
+      teamContext:         {},
+      currentSeason:       2025,
+    });
+    expect(step1.rejectionCode).toBe('NEGOTIATIONS_FROZEN');
+
+    // Step 2: try again in same season with generous offer — should still be blocked
+    const frozenPlayer = step1.updatedPlayer;
+    const step2 = evaluateAgentNegotiation({
+      player:              frozenPlayer,
+      offer:               { salary: base * 2 }, // extremely generous
+      baseFairMarketValue: base,
+      teamContext:         {},
+      currentSeason:       2025,
+    });
+    expect(step2.accepted).toBe(false);
+    expect(step2.rejectionCode).toBe('NEGOTIATIONS_FROZEN');
+  });
+});
+
+// ── 6. Frozen state clears next season ───────────────────────────────────────
+
+describe('frozen state expiry', () => {
+  it('auto-clears in next season without explicit reset (season mismatch)', () => {
+    const frozenPlayer = makePlayer({
+      agent:            { id: 'a', name: 'X', archetype: 'SHARK', greed: 0.5, aggressiveness: 0.5, patience: 0.5 },
+      negotiationState: { negotiationsFrozenUntilSeason: 2025 },
+    });
+
+    // Season 2026: freeze has expired by definition
+    const result = evaluateAgentNegotiation({
+      player:              frozenPlayer,
+      offer:               { salary: 30 }, // generous offer
+      baseFairMarketValue: 20,
+      teamContext:         {},
+      currentSeason:       2026,
+    });
+    expect(result.rejectionCode).not.toBe('NEGOTIATIONS_FROZEN');
+  });
+});
+
+// ── 7. Ring Chaser losing-team contextual feedback ───────────────────────────
+
+describe('ring chaser on losing team', () => {
+  it('returns contextual rejection copy mentioning winning championships', () => {
+    const text = getAgentFeedbackText({ player: makePlayer(), rejectionCode: 'RING_CHASER_HARD_REJECT' });
+    expect(text).toContain('winning championships');
+  });
+});
+
+// ── 8. Shark pressure increases holdout/trade-request escalation weight ───────
+
+describe('shark pressure holdout escalation', () => {
+  it('shouldEscalateSharkPressure returns true for qualifying shark player', () => {
+    const sharkElite = makePlayer({
+      ovr:               90,
+      extensionDecision: 'pending',
+      contract:          { years: 1, yearsRemaining: 1, baseAnnual: 25 },
+      agent:             { id: 'a', name: 'X', archetype: 'SHARK', greed: 0.8, aggressiveness: 0.8, patience: 0.2 },
+      negotiationState:  { negotiationsFrozenUntilSeason: null },
+    });
+    expect(shouldEscalateSharkPressure({ player: sharkElite, currentSeasonPhase: 'regular', currentSeason: 2025 })).toBe(true);
+  });
+
+  it('returns false for a non-shark player even if elite', () => {
+    const loyalistElite = makePlayer({
+      ovr:    90,
+      agent:  { id: 'a', name: 'X', archetype: 'LOYALIST', greed: 0.5, aggressiveness: 0.5, patience: 0.5 },
+      contract: { years: 1, yearsRemaining: 1, baseAnnual: 25 },
+    });
+    expect(shouldEscalateSharkPressure({ player: loyalistElite, currentSeason: 2025 })).toBe(false);
+  });
+});
+
+// ── 9. No regression in baseline extension acceptance ────────────────────────
+
+describe('baseline extension acceptance regression', () => {
+  it('LOYALIST with fair offer (at or above expected) should accept', () => {
+    const loyalist = findPlayerWithArchetype('LOYALIST', { tenureYears: 4 });
+    expect(loyalist).not.toBeNull();
+
+    const base = 20;
+    const { expectedSalary } = computeAgentExpectedSalary({ player: loyalist, baseFairMarketValue: base, teamContext: {} });
+
+    const result = evaluateAgentNegotiation({
+      player:              loyalist,
+      offer:               { salary: expectedSalary + 1 },
+      baseFairMarketValue: base,
+      teamContext:         {},
+      currentSeason:       2025,
+    });
+    expect(result.accepted).toBe(true);
+  });
+
+  it('neutral offer at 100% of base should not be rejected by ring chaser on a contender', () => {
+    const rc = findPlayerWithArchetype('RING_CHASER');
+    expect(rc).not.toBeNull();
+
+    const base = 20;
+    // Contender discount makes expectedSalary = 0.85 × base = 17
+    const result = evaluateAgentNegotiation({
+      player:              rc,
+      offer:               { salary: base }, // base is above 0.85× so it should satisfy
+      baseFairMarketValue: base,
+      teamContext:         { teamPowerRankPosition: 4 }, // contender
+      currentSeason:       2025,
+    });
+    expect(result.accepted).toBe(true);
+  });
+});


### PR DESCRIPTION
Introduces SHARK, LOYALIST, and RING_CHASER agent archetypes that
modulate contract acceptance thresholds, generate contextual rejection
copy, and escalate holdout pressure — all without touching the existing
fair-market-value calculation, sim engine, or draft/waiver/trade pipelines.

Key additions:
- src/core/contracts/agentNegotiationEngine.js: pure deterministic module
  (FNV-1a hash, no Math.random) with archetype generation, expected-salary
  computation, negotiation evaluation, frozen-negotiation state, and
  SHARK holdout-escalation guard
- src/core/player.js: attach agent profile + negotiationState on creation
- src/worker/worker.js: wire hydration for legacy saves, agent overlay in
  handleExtendContract / handleRestructureContract, shark pressure boost
  in holdout evaluator
- src/ui/components/ExtensionNegotiationModal.jsx: agent badge (tone-coded
  pill), frozen-negotiation warning, contextual agentFeedback rejection copy
- src/ui/components/ContractCenter.jsx: pass currentSeason to modal
- Three new test files: unit (agentNegotiationEngine), integration
  (playerAgents pipeline), and UI (ContractPanel SSR badge rendering)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WmxFmnemfJzqWbevh5NZWG