### PR TITLE
feat(history): add League History Ledger & Record Book engine

### DIFF
--- a/src/core/history/historyEngine.js
+++ b/src/core/history/historyEngine.js
@@ -1,0 +1,272 @@
+/**
+ * historyEngine.js — League History Ledger & Record Book Engine
+ *
+ * Pure module: no side effects, no UI/worker imports, no randomness.
+ * All functions are immutable — inputs are never mutated.
+ *
+ * Stored under:
+ *   meta.historyLedger          — year-by-year champion/awards summary rows
+ *   meta.recordBook.singleGame       — all-time single-game record holders (4 metrics)
+ *   meta.recordBook.singleSeasonBests — all-time single-season record holders (4 metrics)
+ *
+ * Record holder entry shape:
+ *   { id, playerName, position, metricValue, yearAchieved, teamNameAtTime }
+ *
+ * Ledger entry shape:
+ *   { year, championTeamId, championName, runnerUpName, superBowlScore,
+ *     mvpName, opoyName, dpoyName }
+ */
+
+// ── Metric definitions ────────────────────────────────────────────────────────
+
+const METRICS = ['passingYards', 'passingTds', 'rushingYards', 'sacks'];
+
+/**
+ * Read a metric value from a flat stats object (handles both alias keys).
+ * Stats object can be flat (passYd, passTD, ...) or nested under .stats.
+ */
+function readMetricFromStats(obj, metric) {
+  const s = obj?.stats ?? obj;
+  switch (metric) {
+    case 'passingYards':  return Number(s?.passYd  ?? s?.passingYards  ?? 0);
+    case 'passingTds':    return Number(s?.passTD  ?? s?.passingTds    ?? 0);
+    case 'rushingYards':  return Number(s?.rushYd  ?? s?.rushingYards  ?? 0);
+    case 'sacks':         return Number(s?.sacks   ?? 0);
+    default:              return 0;
+  }
+}
+
+/**
+ * Build a record holder entry from a stat line + context.
+ * statLine: { playerId|id, playerName|name, position|pos, [stats:{}] }
+ * context:  { season, teamName }
+ */
+function makeHolder(statLine, metricValue, context) {
+  return {
+    id: String(statLine.playerId ?? statLine.id ?? ''),
+    playerName: String(statLine.playerName ?? statLine.name ?? 'Unknown'),
+    position: String(statLine.position ?? statLine.pos ?? '??'),
+    metricValue,
+    yearAchieved: Number(context?.season ?? 0),
+    teamNameAtTime: String(context?.teamName ?? 'Unknown'),
+  };
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Returns the safe initial record book shape.
+ * Null holders indicate no record has been set yet.
+ * Uses singleSeasonBests (not singleSeason) to avoid colliding with the
+ * existing V1 record book's singleSeason key.
+ */
+export function createDefaultRecordBook() {
+  return {
+    singleGame: {
+      passingYards: null,
+      passingTds: null,
+      rushingYards: null,
+      sacks: null,
+    },
+    singleSeasonBests: {
+      passingYards: null,
+      passingTds: null,
+      rushingYards: null,
+      sacks: null,
+    },
+  };
+}
+
+/**
+ * Build a single ledger entry from championship result and awards.
+ *
+ * championshipResult: { championTeamId, championName, runnerUpName,
+ *                       homeScore|scoreHome, awayScore|scoreAway }
+ * awards:            { mvpName, opoyName, dpoyName }
+ *
+ * Gracefully returns 'Unknown' / '—' for any missing field.
+ */
+export function buildLeagueYearSummary({ season, championshipResult, awards } = {}) {
+  const c = championshipResult ?? {};
+  const a = awards ?? {};
+
+  const homeScore = c.homeScore ?? c.scoreHome ?? null;
+  const awayScore = c.awayScore ?? c.scoreAway ?? null;
+  const superBowlScore = (homeScore != null && awayScore != null)
+    ? `${Math.max(Number(homeScore), Number(awayScore))}-${Math.min(Number(homeScore), Number(awayScore))}`
+    : '—';
+
+  return {
+    year: Number(season ?? 0),
+    championTeamId: c.championTeamId ?? null,
+    championName: String(c.championName ?? 'Unknown'),
+    runnerUpName: String(c.runnerUpName ?? 'Unknown'),
+    superBowlScore,
+    mvpName: String(a.mvpName ?? 'Unknown'),
+    opoyName: String(a.opoyName ?? 'Unknown'),
+    dpoyName: String(a.dpoyName ?? 'Unknown'),
+  };
+}
+
+/**
+ * Check one player game stat line against existing single-game records.
+ * Returns a new recordBook if any record was broken, or the same reference.
+ *
+ * statLine: { playerId|id, playerName|name, position|pos, [stats:{}], ...flatStats }
+ * context:  { season, teamName }
+ */
+export function maybeUpdateSingleGameRecord(recordBook, statLine, context) {
+  if (!statLine) return recordBook;
+  const sg = (recordBook?.singleGame) ?? {};
+  let changed = false;
+  const newSg = { ...sg };
+
+  for (const metric of METRICS) {
+    const value = readMetricFromStats(statLine, metric);
+    if (value <= 0) continue;
+    const current = sg[metric];
+    if (!current || value > current.metricValue) {
+      newSg[metric] = makeHolder(statLine, value, context);
+      changed = true;
+    }
+  }
+
+  if (!changed) return recordBook;
+  return { ...recordBook, singleGame: newSg };
+}
+
+/**
+ * Process all stat lines from a completed game/week batch.
+ * contextResolver(statLine) → { season, teamName }
+ */
+export function updateSingleGameRecordsFromBatch(recordBook, completedGameStatLines, contextResolver) {
+  let current = recordBook;
+  for (const statLine of (completedGameStatLines ?? [])) {
+    const context = contextResolver ? contextResolver(statLine) : {};
+    current = maybeUpdateSingleGameRecord(current, statLine, context);
+  }
+  return current;
+}
+
+/**
+ * Check one player's season totals against existing single-season bests.
+ * Returns a new recordBook if any best was beaten.
+ *
+ * playerSeasonTotals: { playerId|id, playerName|name, position|pos, [stats:{}], ...flatStats }
+ * context:  { season, teamName }
+ */
+export function maybeUpdateSingleSeasonRecord(recordBook, playerSeasonTotals, context) {
+  if (!playerSeasonTotals) return recordBook;
+  const ss = (recordBook?.singleSeasonBests) ?? {};
+  let changed = false;
+  const newSs = { ...ss };
+
+  for (const metric of METRICS) {
+    const value = readMetricFromStats(playerSeasonTotals, metric);
+    if (value <= 0) continue;
+    const current = ss[metric];
+    if (!current || value > current.metricValue) {
+      newSs[metric] = makeHolder(playerSeasonTotals, value, context);
+      changed = true;
+    }
+  }
+
+  if (!changed) return recordBook;
+  return { ...recordBook, singleSeasonBests: newSs };
+}
+
+/**
+ * Scan all active players at season transition and update single-season bests.
+ *
+ * players: array of player objects with .id, .name, .pos, .teamId, .stats.season
+ * teamNameResolver(teamId) → string team name
+ */
+export function updateSingleSeasonRecords(recordBook, players, season, teamNameResolver) {
+  let current = recordBook;
+  for (const player of (players ?? [])) {
+    if (!player) continue;
+    const seasonStats = player?.stats?.season ?? {};
+    const teamName = teamNameResolver ? teamNameResolver(player.teamId) : 'Unknown';
+    const statEntry = {
+      playerId: player.id,
+      playerName: player.name,
+      position: player.pos,
+      stats: seasonStats,
+    };
+    current = maybeUpdateSingleSeasonRecord(current, statEntry, { season, teamName });
+  }
+  return current;
+}
+
+/**
+ * Append a year summary to the history ledger in chronological order.
+ * Replaces any existing entry for the same year (idempotent re-runs).
+ * Returns a new array (never mutates input).
+ */
+export function appendHistoryLedger(historyLedger, yearSummary) {
+  const arr = Array.isArray(historyLedger) ? historyLedger : [];
+  const year = yearSummary?.year ?? null;
+  const filtered = year != null ? arr.filter(e => e?.year !== year) : arr;
+  return [...filtered, yearSummary].sort((a, b) => (a?.year ?? 0) - (b?.year ?? 0));
+}
+
+/**
+ * Returns true if a retired player's history should be retained in full.
+ * True for award winners, HOF players, All-Pro recipients, or current record holders.
+ */
+export function shouldRetainRetiredPlayerHistory(player, recordBook) {
+  if (!player) return false;
+
+  // Retain if player holds any award
+  if (Array.isArray(player.awards) && player.awards.length > 0) return true;
+
+  // Retain if HOF nominated or inducted
+  const hofStatus = String(player.hofStatus ?? '');
+  if (player.hof === true || hofStatus === 'inducted' || hofStatus === 'nominee') return true;
+
+  // Retain if marked as a current record holder in the historyEngine record book
+  const pidStr = String(player.id ?? '');
+  if (pidStr) {
+    const sg = recordBook?.singleGame ?? {};
+    const ss = recordBook?.singleSeasonBests ?? {};
+    for (const metric of METRICS) {
+      if (sg[metric] && String(sg[metric].id) === pidStr) return true;
+      if (ss[metric] && String(ss[metric].id) === pidStr) return true;
+    }
+  }
+
+  // Retain if has All-Pro, Pro Bowl, or championship accolades
+  if (Array.isArray(player.accolades)) {
+    for (const a of player.accolades) {
+      const t = String(a?.type ?? '').toLowerCase();
+      if (t.includes('all') || t.includes('pro') || t.includes('hof') || t.includes('champion')) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Strip bulky history payloads from low-impact retired players.
+ * Conservative: only removes gameLogs if present; identity, awards,
+ * contract, and HOF data are always preserved.
+ * Returns a new array (never mutates input).
+ *
+ * The current repo schema does not attach bulky gameLogs to retired players,
+ * so this is mostly a safe no-op; it acts as future-proofing.
+ */
+export function compactRetiredPlayerHistory(players, recordBook) {
+  if (!Array.isArray(players)) return players;
+  return players.map(player => {
+    if (!player) return player;
+    if (shouldRetainRetiredPlayerHistory(player, recordBook)) return player;
+    const ovr = Number(player?.ovr ?? player?.peakOvr ?? 80);
+    if (ovr >= 78) return player;
+    // Only strip genuinely bulky payload arrays that can accumulate
+    if (!player.gameLogs && !player.detailedGameHistory) return player;
+    const { gameLogs, detailedGameHistory, ...rest } = player;
+    return rest;
+  });
+}

--- a/src/core/history/historyEngine.unit.test.js
+++ b/src/core/history/historyEngine.unit.test.js
@@ -1,0 +1,378 @@
+/**
+ * historyEngine.unit.test.js
+ * Pure-function tests for the League History Ledger & Record Book Engine.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createDefaultRecordBook,
+  buildLeagueYearSummary,
+  maybeUpdateSingleGameRecord,
+  updateSingleGameRecordsFromBatch,
+  maybeUpdateSingleSeasonRecord,
+  updateSingleSeasonRecords,
+  appendHistoryLedger,
+  shouldRetainRetiredPlayerHistory,
+  compactRetiredPlayerHistory,
+} from './historyEngine.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeStatLine(overrides = {}) {
+  return {
+    playerId: 'p1',
+    playerName: 'Test Player',
+    position: 'QB',
+    teamId: 1,
+    stats: { passYd: 0, passTD: 0, rushYd: 0, sacks: 0 },
+    ...overrides,
+  };
+}
+
+function makeContext(overrides = {}) {
+  return { season: 2025, teamName: 'Test Team', ...overrides };
+}
+
+// ── createDefaultRecordBook ───────────────────────────────────────────────────
+
+describe('createDefaultRecordBook', () => {
+  it('returns singleGame with null holders for all 4 metrics', () => {
+    const rb = createDefaultRecordBook();
+    expect(rb.singleGame.passingYards).toBeNull();
+    expect(rb.singleGame.passingTds).toBeNull();
+    expect(rb.singleGame.rushingYards).toBeNull();
+    expect(rb.singleGame.sacks).toBeNull();
+  });
+
+  it('returns singleSeasonBests with null holders for all 4 metrics', () => {
+    const rb = createDefaultRecordBook();
+    expect(rb.singleSeasonBests.passingYards).toBeNull();
+    expect(rb.singleSeasonBests.passingTds).toBeNull();
+    expect(rb.singleSeasonBests.rushingYards).toBeNull();
+    expect(rb.singleSeasonBests.sacks).toBeNull();
+  });
+
+  it('returns safe structure even when called multiple times (immutable)', () => {
+    const rb1 = createDefaultRecordBook();
+    const rb2 = createDefaultRecordBook();
+    rb1.singleGame.passingYards = 'mutated';
+    expect(rb2.singleGame.passingYards).toBeNull();
+  });
+});
+
+// ── buildLeagueYearSummary ────────────────────────────────────────────────────
+
+describe('buildLeagueYearSummary', () => {
+  it('builds expected payload from champion + awards', () => {
+    const summary = buildLeagueYearSummary({
+      season: 2025,
+      championshipResult: {
+        championTeamId: 5,
+        championName: 'Eagles',
+        runnerUpName: 'Chiefs',
+        homeScore: 31,
+        awayScore: 17,
+      },
+      awards: {
+        mvpName: 'Top QB',
+        opoyName: 'Best RB',
+        dpoyName: 'Elite CB',
+      },
+    });
+
+    expect(summary.year).toBe(2025);
+    expect(summary.championTeamId).toBe(5);
+    expect(summary.championName).toBe('Eagles');
+    expect(summary.runnerUpName).toBe('Chiefs');
+    expect(summary.superBowlScore).toBe('31-17');
+    expect(summary.mvpName).toBe('Top QB');
+    expect(summary.opoyName).toBe('Best RB');
+    expect(summary.dpoyName).toBe('Elite CB');
+  });
+
+  it('handles missing data with safe fallbacks', () => {
+    const summary = buildLeagueYearSummary({});
+    expect(summary.year).toBe(0);
+    expect(summary.championName).toBe('Unknown');
+    expect(summary.runnerUpName).toBe('Unknown');
+    expect(summary.superBowlScore).toBe('—');
+    expect(summary.mvpName).toBe('Unknown');
+    expect(summary.opoyName).toBe('Unknown');
+    expect(summary.dpoyName).toBe('Unknown');
+  });
+
+  it('handles missing score gracefully', () => {
+    const summary = buildLeagueYearSummary({
+      season: 2026,
+      championshipResult: { championName: 'Bears' },
+    });
+    expect(summary.superBowlScore).toBe('—');
+    expect(summary.championName).toBe('Bears');
+  });
+
+  it('normalises score so higher value is always first', () => {
+    const summary = buildLeagueYearSummary({
+      season: 2025,
+      championshipResult: { homeScore: 14, awayScore: 28 },
+    });
+    expect(summary.superBowlScore).toBe('28-14');
+  });
+});
+
+// ── maybeUpdateSingleGameRecord ───────────────────────────────────────────────
+
+describe('maybeUpdateSingleGameRecord', () => {
+  it('updates passingYards when value exceeds existing record', () => {
+    const rb = createDefaultRecordBook();
+    const line = makeStatLine({ stats: { passYd: 450, passTD: 0, rushYd: 0, sacks: 0 } });
+    const updated = maybeUpdateSingleGameRecord(rb, line, makeContext());
+
+    expect(updated.singleGame.passingYards).not.toBeNull();
+    expect(updated.singleGame.passingYards.metricValue).toBe(450);
+    expect(updated.singleGame.passingYards.playerName).toBe('Test Player');
+    expect(updated.singleGame.passingYards.yearAchieved).toBe(2025);
+  });
+
+  it('does not update when value is lower than existing record', () => {
+    const rb = createDefaultRecordBook();
+    // First set a high record
+    const line1 = makeStatLine({ stats: { passYd: 500 } });
+    const afterFirst = maybeUpdateSingleGameRecord(rb, line1, makeContext({ season: 2024 }));
+
+    // Then try to set a lower value
+    const line2 = makeStatLine({ playerId: 'p2', stats: { passYd: 300 } });
+    const afterSecond = maybeUpdateSingleGameRecord(afterFirst, line2, makeContext({ season: 2025 }));
+
+    expect(afterSecond.singleGame.passingYards.metricValue).toBe(500);
+    expect(afterSecond.singleGame.passingYards.yearAchieved).toBe(2024);
+    expect(afterSecond === afterFirst).toBe(true); // same reference — no allocation
+  });
+
+  it('does not update on zero value', () => {
+    const rb = createDefaultRecordBook();
+    const line = makeStatLine({ stats: { passYd: 0, passTD: 0, rushYd: 0, sacks: 0 } });
+    const updated = maybeUpdateSingleGameRecord(rb, line, makeContext());
+    expect(updated === rb).toBe(true);
+  });
+
+  it('updates sacks metric correctly', () => {
+    const rb = createDefaultRecordBook();
+    const line = makeStatLine({ position: 'DE', stats: { sacks: 4 } });
+    const updated = maybeUpdateSingleGameRecord(rb, line, makeContext());
+    expect(updated.singleGame.sacks.metricValue).toBe(4);
+    expect(updated.singleGame.sacks.position).toBe('DE');
+  });
+
+  it('does not mutate the input recordBook', () => {
+    const rb = createDefaultRecordBook();
+    const frozen = Object.freeze(rb);
+    const line = makeStatLine({ stats: { passYd: 300 } });
+    expect(() => maybeUpdateSingleGameRecord(frozen, line, makeContext())).not.toThrow();
+  });
+});
+
+// ── updateSingleGameRecordsFromBatch ─────────────────────────────────────────
+
+describe('updateSingleGameRecordsFromBatch', () => {
+  it('updates records from multiple stat lines deterministically', () => {
+    const rb = createDefaultRecordBook();
+    const lines = [
+      makeStatLine({ playerId: 'a', playerName: 'A', stats: { passYd: 300 } }),
+      makeStatLine({ playerId: 'b', playerName: 'B', stats: { passYd: 450 } }),
+      makeStatLine({ playerId: 'c', playerName: 'C', stats: { passYd: 200 } }),
+    ];
+    const ctx = (l) => ({ season: 2025, teamName: 'T' });
+    const updated = updateSingleGameRecordsFromBatch(rb, lines, ctx);
+
+    expect(updated.singleGame.passingYards.playerName).toBe('B');
+    expect(updated.singleGame.passingYards.metricValue).toBe(450);
+  });
+
+  it('handles empty batch without error', () => {
+    const rb = createDefaultRecordBook();
+    const updated = updateSingleGameRecordsFromBatch(rb, [], null);
+    expect(updated === rb).toBe(true);
+  });
+
+  it('handles null batch gracefully', () => {
+    const rb = createDefaultRecordBook();
+    const updated = updateSingleGameRecordsFromBatch(rb, null, null);
+    expect(updated === rb).toBe(true);
+  });
+});
+
+// ── maybeUpdateSingleSeasonRecord ────────────────────────────────────────────
+
+describe('maybeUpdateSingleSeasonRecord', () => {
+  it('updates correct metric when season total is exceeded', () => {
+    const rb = createDefaultRecordBook();
+    const totals = makeStatLine({ stats: { rushYd: 1800 } });
+    const updated = maybeUpdateSingleSeasonRecord(rb, totals, makeContext());
+
+    expect(updated.singleSeasonBests.rushingYards.metricValue).toBe(1800);
+  });
+
+  it('does not update when season total is lower than existing best', () => {
+    const rb = createDefaultRecordBook();
+    const first = makeStatLine({ stats: { rushYd: 2000 } });
+    const rb2 = maybeUpdateSingleSeasonRecord(rb, first, makeContext({ season: 2024 }));
+
+    const second = makeStatLine({ playerId: 'p2', stats: { rushYd: 1500 } });
+    const rb3 = maybeUpdateSingleSeasonRecord(rb2, second, makeContext({ season: 2025 }));
+
+    expect(rb3.singleSeasonBests.rushingYards.metricValue).toBe(2000);
+    expect(rb3 === rb2).toBe(true);
+  });
+});
+
+// ── updateSingleSeasonRecords ────────────────────────────────────────────────
+
+describe('updateSingleSeasonRecords', () => {
+  it('scans all players and updates correct record holders', () => {
+    const rb = createDefaultRecordBook();
+    const players = [
+      { id: 'p1', name: 'QB Star', pos: 'QB', teamId: 1, stats: { season: { passYd: 5000, passTD: 40 } } },
+      { id: 'p2', name: 'RB Beast', pos: 'RB', teamId: 2, stats: { season: { rushYd: 1900 } } },
+      { id: 'p3', name: 'Edge Rusher', pos: 'DE', teamId: 1, stats: { season: { sacks: 18 } } },
+    ];
+    const teamNameResolver = (tid) => (tid === 1 ? 'Lions' : 'Bears');
+    const updated = updateSingleSeasonRecords(rb, players, 2025, teamNameResolver);
+
+    expect(updated.singleSeasonBests.passingYards.metricValue).toBe(5000);
+    expect(updated.singleSeasonBests.passingYards.playerName).toBe('QB Star');
+    expect(updated.singleSeasonBests.passingTds.metricValue).toBe(40);
+    expect(updated.singleSeasonBests.rushingYards.metricValue).toBe(1900);
+    expect(updated.singleSeasonBests.rushingYards.teamNameAtTime).toBe('Bears');
+    expect(updated.singleSeasonBests.sacks.metricValue).toBe(18);
+    expect(updated.singleSeasonBests.sacks.teamNameAtTime).toBe('Lions');
+  });
+
+  it('handles empty player list gracefully', () => {
+    const rb = createDefaultRecordBook();
+    const updated = updateSingleSeasonRecords(rb, [], 2025, null);
+    expect(updated === rb).toBe(true);
+  });
+});
+
+// ── appendHistoryLedger ───────────────────────────────────────────────────────
+
+describe('appendHistoryLedger', () => {
+  it('appends a new year entry in chronological order', () => {
+    const existing = [{ year: 2024, championName: 'Old' }];
+    const newEntry = { year: 2025, championName: 'New' };
+    const result = appendHistoryLedger(existing, newEntry);
+
+    expect(result.length).toBe(2);
+    expect(result[0].year).toBe(2024);
+    expect(result[1].year).toBe(2025);
+  });
+
+  it('replaces a duplicate year entry rather than duplicating', () => {
+    const existing = [
+      { year: 2024, championName: 'OldChamp' },
+      { year: 2025, championName: 'OldWinner' },
+    ];
+    const newEntry = { year: 2025, championName: 'RerunWinner' };
+    const result = appendHistoryLedger(existing, newEntry);
+
+    expect(result.length).toBe(2);
+    const entry25 = result.find(r => r.year === 2025);
+    expect(entry25.championName).toBe('RerunWinner');
+  });
+
+  it('handles empty ledger', () => {
+    const result = appendHistoryLedger([], { year: 2025, championName: 'First' });
+    expect(result.length).toBe(1);
+    expect(result[0].year).toBe(2025);
+  });
+
+  it('does not mutate the input array', () => {
+    const original = [{ year: 2024 }];
+    appendHistoryLedger(original, { year: 2025 });
+    expect(original.length).toBe(1);
+  });
+});
+
+// ── shouldRetainRetiredPlayerHistory ─────────────────────────────────────────
+
+describe('shouldRetainRetiredPlayerHistory', () => {
+  it('returns true for an award winner', () => {
+    const player = { id: 'p1', awards: [{ type: 'MVP', season: 2024 }] };
+    expect(shouldRetainRetiredPlayerHistory(player, createDefaultRecordBook())).toBe(true);
+  });
+
+  it('returns true for a HOF player', () => {
+    const player = { id: 'p2', hof: true, awards: [] };
+    expect(shouldRetainRetiredPlayerHistory(player, createDefaultRecordBook())).toBe(true);
+  });
+
+  it('returns true for a record holder', () => {
+    const rb = createDefaultRecordBook();
+    const line = makeStatLine({ playerId: 'record-holder', playerName: 'Record Guy', stats: { passYd: 600 } });
+    const updatedRb = maybeUpdateSingleGameRecord(rb, line, makeContext());
+    const player = { id: 'record-holder', awards: [] };
+    expect(shouldRetainRetiredPlayerHistory(player, updatedRb)).toBe(true);
+  });
+
+  it('returns false for a low-impact retired player', () => {
+    const player = { id: 'p3', ovr: 65, awards: [], accolades: [] };
+    expect(shouldRetainRetiredPlayerHistory(player, createDefaultRecordBook())).toBe(false);
+  });
+
+  it('returns false for null player', () => {
+    expect(shouldRetainRetiredPlayerHistory(null, createDefaultRecordBook())).toBe(false);
+  });
+});
+
+// ── compactRetiredPlayerHistory ───────────────────────────────────────────────
+
+describe('compactRetiredPlayerHistory', () => {
+  it('does not mutate the input array', () => {
+    const players = [
+      { id: 'p1', ovr: 60, awards: [], gameLogs: [1, 2, 3] },
+    ];
+    const original = [...players];
+    compactRetiredPlayerHistory(players, createDefaultRecordBook());
+    expect(players[0]).toBe(original[0]);
+  });
+
+  it('removes gameLogs from low-impact low-OVR retired players', () => {
+    const player = { id: 'p1', ovr: 65, awards: [], accolades: [], gameLogs: [1, 2, 3] };
+    const result = compactRetiredPlayerHistory([player], createDefaultRecordBook());
+    expect(result[0].gameLogs).toBeUndefined();
+  });
+
+  it('does not strip gameLogs from honored players (award winner)', () => {
+    const player = { id: 'p2', ovr: 65, awards: [{ type: 'MVP' }], gameLogs: [1, 2, 3] };
+    const result = compactRetiredPlayerHistory([player], createDefaultRecordBook());
+    expect(result[0].gameLogs).toBeDefined();
+  });
+
+  it('does not strip gameLogs from high-OVR players (ovr >= 78)', () => {
+    const player = { id: 'p3', ovr: 82, awards: [], accolades: [], gameLogs: [1, 2] };
+    const result = compactRetiredPlayerHistory([player], createDefaultRecordBook());
+    expect(result[0].gameLogs).toBeDefined();
+  });
+
+  it('handles players with no bulky fields safely (no-op)', () => {
+    const player = { id: 'p4', ovr: 60, awards: [], accolades: [] };
+    const result = compactRetiredPlayerHistory([player], createDefaultRecordBook());
+    expect(result[0]).toEqual(player);
+  });
+
+  it('handles non-array input without throwing', () => {
+    expect(() => compactRetiredPlayerHistory(null, createDefaultRecordBook())).not.toThrow();
+  });
+});
+
+// ── Guardrail: no Math.random ────────────────────────────────────────────────
+
+describe('module guardrail', () => {
+  it('historyEngine module source does not use Math.random', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const filePath = path.resolve('src/core/history/historyEngine.js');
+    const source = fs.readFileSync(filePath, 'utf8');
+    expect(source).not.toContain('Math.random');
+  });
+});

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -519,6 +519,27 @@ export const State = {
     migrated.ownerGoals = migrated?.ownerGoals ?? [];
     migrated.retiredPlayers = migrated?.retiredPlayers ?? [];
 
+    // ── History Ledger & Record Book (historyEngine schema) ─────────────────
+    // Backward-compatible: old saves hydrate safely with empty/null defaults.
+    migrated.historyLedger = Array.isArray(migrated.historyLedger)
+      ? migrated.historyLedger
+      : [];
+    if (!migrated.recordBook || typeof migrated.recordBook !== 'object') {
+      migrated.recordBook = {};
+    }
+    if (!migrated.recordBook.singleGame || typeof migrated.recordBook.singleGame !== 'object') {
+      migrated.recordBook = {
+        ...migrated.recordBook,
+        singleGame: { passingYards: null, passingTds: null, rushingYards: null, sacks: null },
+      };
+    }
+    if (!migrated.recordBook.singleSeasonBests || typeof migrated.recordBook.singleSeasonBests !== 'object') {
+      migrated.recordBook = {
+        ...migrated.recordBook,
+        singleSeasonBests: { passingYards: null, passingTds: null, rushingYards: null, sacks: null },
+      };
+    }
+
     // Ensure records structure exists
     if (!migrated.records) {
       migrated.records = {};

--- a/src/ui/components/HistoryCenter.jsx
+++ b/src/ui/components/HistoryCenter.jsx
@@ -1,0 +1,183 @@
+import React, { useState } from 'react';
+import { ScreenHeader, SectionCard } from './ScreenSystem.jsx';
+
+const TABS = ['Honor Roll', 'Record Book'];
+
+const RECORD_LABELS = {
+  passingYards: 'Passing Yards',
+  passingTds: 'Passing TDs',
+  rushingYards: 'Rushing Yards',
+  sacks: 'Sacks',
+};
+
+const RECORD_KEYS = ['passingYards', 'passingTds', 'rushingYards', 'sacks'];
+
+function TabBar({ activeTab, onSelect }) {
+  return (
+    <div role="tablist" aria-label="History sections" style={{ display: 'flex', gap: 'var(--space-2)', marginBottom: 'var(--space-3)' }}>
+      {TABS.map((tab) => (
+        <button
+          key={tab}
+          role="tab"
+          aria-selected={activeTab === tab}
+          onClick={() => onSelect(tab)}
+          style={{
+            padding: '6px 16px',
+            borderRadius: 6,
+            border: '1px solid var(--border)',
+            background: activeTab === tab ? 'var(--accent)' : 'transparent',
+            color: activeTab === tab ? '#fff' : 'var(--text)',
+            fontWeight: activeTab === tab ? 700 : 400,
+            cursor: 'pointer',
+            fontSize: 'var(--text-sm)',
+          }}
+        >
+          {tab}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function RecordRow({ label, holder }) {
+  if (!holder) {
+    return (
+      <tr>
+        <td>{label}</td>
+        <td>—</td>
+        <td>—</td>
+        <td>—</td>
+      </tr>
+    );
+  }
+  return (
+    <tr>
+      <td>{label}</td>
+      <td>{holder.metricValue}</td>
+      <td>{holder.playerName} ({holder.teamNameAtTime})</td>
+      <td>{holder.yearAchieved || '—'}</td>
+    </tr>
+  );
+}
+
+function RecordSection({ title, records, testId }) {
+  return (
+    <SectionCard title={title}>
+      <div className="responsive-data-wrap" data-testid={testId} style={{ overflowX: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 'var(--text-sm)' }}>
+          <thead>
+            <tr>
+              <th style={{ textAlign: 'left', paddingBottom: 6 }}>Record</th>
+              <th style={{ textAlign: 'left', paddingBottom: 6 }}>Value</th>
+              <th style={{ textAlign: 'left', paddingBottom: 6 }}>Player (Team)</th>
+              <th style={{ textAlign: 'left', paddingBottom: 6 }}>Year</th>
+            </tr>
+          </thead>
+          <tbody>
+            {RECORD_KEYS.map((k) => (
+              <RecordRow key={k} label={RECORD_LABELS[k]} holder={records?.[k] ?? null} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </SectionCard>
+  );
+}
+
+function HonorRollTab({ historyLedger, userTeamId }) {
+  const rows = Array.isArray(historyLedger) ? [...historyLedger].reverse() : [];
+
+  if (rows.length === 0) {
+    return (
+      <SectionCard title="Honor Roll">
+        <p style={{ color: 'var(--text-muted)', fontSize: 'var(--text-sm)' }} data-testid="honor-roll-empty">
+          No completed seasons archived yet. Complete a season to see the championship history.
+        </p>
+      </SectionCard>
+    );
+  }
+
+  return (
+    <SectionCard title="Honor Roll">
+      <div className="responsive-data-wrap" style={{ overflowX: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 'var(--text-sm)' }}>
+          <thead>
+            <tr>
+              <th style={{ textAlign: 'left', paddingBottom: 6 }}>Year</th>
+              <th style={{ textAlign: 'left', paddingBottom: 6 }}>Champion</th>
+              <th style={{ textAlign: 'left', paddingBottom: 6 }}>Runner-Up</th>
+              <th style={{ textAlign: 'left', paddingBottom: 6 }}>Score</th>
+              <th style={{ textAlign: 'left', paddingBottom: 6 }}>MVP</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const isUserChamp = userTeamId != null && row.championTeamId != null
+                && Number(row.championTeamId) === Number(userTeamId);
+              return (
+                <tr key={row.year}>
+                  <td>{row.year}</td>
+                  <td
+                    data-testid={isUserChamp ? 'user-champion-cell' : undefined}
+                    style={isUserChamp ? { fontWeight: 700, color: 'var(--accent)' } : undefined}
+                  >
+                    {row.championName}
+                  </td>
+                  <td>{row.runnerUpName}</td>
+                  <td>{row.superBowlScore}</td>
+                  <td>{row.mvpName}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </SectionCard>
+  );
+}
+
+function RecordBookTab({ recordBook }) {
+  const singleGame = recordBook?.singleGame ?? {};
+  const singleSeasonBests = recordBook?.singleSeasonBests ?? {};
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
+      <RecordSection
+        title="Single-Game Records"
+        records={singleGame}
+        testId="single-game-records"
+      />
+      <RecordSection
+        title="Single-Season Records"
+        records={singleSeasonBests}
+        testId="single-season-records"
+      />
+    </div>
+  );
+}
+
+export default function HistoryCenter({ league }) {
+  const [activeTab, setActiveTab] = useState(TABS[0]);
+
+  const historyLedger = league?.historyLedger ?? [];
+  const recordBook = league?.recordBook ?? null;
+  const userTeamId = league?.userTeamId ?? null;
+
+  return (
+    <div className="app-screen-stack">
+      <ScreenHeader
+        title="History Center"
+        subtitle="Season champions, award winners, and all-time records."
+      />
+      <TabBar activeTab={activeTab} onSelect={setActiveTab} />
+      <div role="tabpanel">
+        {activeTab === 'Honor Roll' && (
+          <HonorRollTab historyLedger={historyLedger} userTeamId={userTeamId} />
+        )}
+        {activeTab === 'Record Book' && (
+          <RecordBookTab recordBook={recordBook} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/HistoryCenter.test.jsx
+++ b/src/ui/components/HistoryCenter.test.jsx
@@ -1,0 +1,142 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import HistoryCenter from './HistoryCenter.jsx';
+
+afterEach(cleanup);
+
+const LEDGER_ENTRIES = [
+  {
+    year: 2025,
+    championTeamId: 3,
+    championName: 'Eagles',
+    runnerUpName: 'Chiefs',
+    superBowlScore: '31-24',
+    mvpName: 'Star QB',
+    opoyName: 'Speed RB',
+    dpoyName: 'Edge Pro',
+  },
+  {
+    year: 2026,
+    championTeamId: 7,
+    championName: 'Ravens',
+    runnerUpName: 'Packers',
+    superBowlScore: '28-17',
+    mvpName: 'Rifle Arm',
+    opoyName: 'Zoom WR',
+    dpoyName: 'Wall LB',
+  },
+];
+
+const RECORD_BOOK = {
+  singleGame: {
+    passingYards: {
+      id: 'p1', playerName: 'Star QB', position: 'QB',
+      metricValue: 520, yearAchieved: 2025, teamNameAtTime: 'Eagles',
+    },
+    passingTds: null,
+    rushingYards: null,
+    sacks: {
+      id: 'p2', playerName: 'Edge Pro', position: 'DE',
+      metricValue: 4, yearAchieved: 2025, teamNameAtTime: 'Eagles',
+    },
+  },
+  singleSeasonBests: {
+    passingYards: {
+      id: 'p1', playerName: 'Star QB', position: 'QB',
+      metricValue: 5000, yearAchieved: 2025, teamNameAtTime: 'Eagles',
+    },
+    passingTds: null,
+    rushingYards: null,
+    sacks: null,
+  },
+};
+
+describe('HistoryCenter', () => {
+  it('renders the Honor Roll tab by default', () => {
+    render(<HistoryCenter league={{ historyLedger: LEDGER_ENTRIES }} />);
+    expect(screen.getByRole('tab', { name: 'Honor Roll' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'Record Book' })).toBeTruthy();
+    // Honor Roll content visible
+    expect(screen.getByText('Eagles')).toBeTruthy();
+    expect(screen.getByText('Chiefs')).toBeTruthy();
+    expect(screen.getByText('31-24')).toBeTruthy();
+  });
+
+  it('renders ledger rows in the Honor Roll tab (newest first)', () => {
+    render(<HistoryCenter league={{ historyLedger: LEDGER_ENTRIES }} />);
+    const rows = screen.getAllByRole('row');
+    // header + 2 data rows = 3 rows
+    expect(rows.length).toBeGreaterThanOrEqual(3);
+    // Newest first: 2026 should appear before 2025 in DOM
+    const rowTexts = rows.map(r => r.textContent);
+    const idx26 = rowTexts.findIndex(t => t.includes('2026'));
+    const idx25 = rowTexts.findIndex(t => t.includes('2025'));
+    expect(idx26).toBeLessThan(idx25);
+  });
+
+  it('highlights user champion cell when user team won', () => {
+    render(
+      <HistoryCenter
+        league={{
+          historyLedger: LEDGER_ENTRIES,
+          userTeamId: 3, // Eagles 2025
+        }}
+      />,
+    );
+    const champCell = screen.getByTestId('user-champion-cell');
+    expect(champCell).toBeTruthy();
+    expect(champCell.textContent).toBe('Eagles');
+  });
+
+  it('does not highlight user champion cell when user team did not win', () => {
+    render(
+      <HistoryCenter
+        league={{
+          historyLedger: LEDGER_ENTRIES,
+          userTeamId: 99,
+        }}
+      />,
+    );
+    expect(screen.queryByTestId('user-champion-cell')).toBeNull();
+  });
+
+  it('shows empty state when no history exists', () => {
+    render(<HistoryCenter league={{ historyLedger: [] }} />);
+    expect(screen.getByTestId('honor-roll-empty')).toBeTruthy();
+  });
+
+  it('renders Record Book tab when clicked', () => {
+    render(<HistoryCenter league={{ historyLedger: LEDGER_ENTRIES, recordBook: RECORD_BOOK }} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Record Book' }));
+    expect(screen.getByTestId('single-game-records')).toBeTruthy();
+    expect(screen.getByTestId('single-season-records')).toBeTruthy();
+  });
+
+  it('renders single-game record rows in Record Book tab', () => {
+    render(<HistoryCenter league={{ historyLedger: [], recordBook: RECORD_BOOK }} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Record Book' }));
+    expect(screen.getAllByText('Passing Yards').length).toBeGreaterThan(0);
+    expect(screen.getByText('520')).toBeTruthy();
+    expect(screen.getAllByText(/Star QB/).length).toBeGreaterThan(0);
+  });
+
+  it('renders single-season record rows in Record Book tab', () => {
+    render(<HistoryCenter league={{ historyLedger: [], recordBook: RECORD_BOOK }} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Record Book' }));
+    expect(screen.getByText('5000')).toBeTruthy();
+  });
+
+  it('renders safe dash for null record holders in Record Book', () => {
+    render(<HistoryCenter league={{ historyLedger: [], recordBook: RECORD_BOOK }} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Record Book' }));
+    // passingTds has null holder → should show '—' cells
+    const dashCells = screen.getAllByText('—');
+    expect(dashCells.length).toBeGreaterThan(0);
+  });
+
+  it('renders safely when league prop is undefined', () => {
+    expect(() => render(<HistoryCenter />)).not.toThrow();
+  });
+});

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -247,6 +247,14 @@ import {
   POSITION_PAY_SCALARS,
 } from '../core/trades/assetValuation.js';
 import { archiveCompletedSeasonIfNeeded, ensureLeagueHistoryContainer } from '../core/leagueHistory.js';
+import {
+  buildLeagueYearSummary,
+  appendHistoryLedger,
+  updateSingleGameRecordsFromBatch,
+  updateSingleSeasonRecords,
+  compactRetiredPlayerHistory,
+  createDefaultRecordBook,
+} from '../core/history/historyEngine.js';
 import { ensurePersonalityProfile, mentorshipBonusForPlayer, contractPersonalityModifier } from '../core/development/personalitySystem.js';
 import { applyTeamCultureWeek, classifyTeamCulture, buildTeamCultureNarrative, TEAM_CULTURE_DEFAULT } from '../core/teamCulture.js';
 import { selectCultureAlerts } from '../core/broadcastNarrative.js';
@@ -1146,6 +1154,7 @@ function buildViewState() {
     playerSeasonStatsArchive: meta?.playerSeasonStatsArchive ?? {},
     teamCulture: meta?.teamCulture ?? {},
     leagueHistory: Array.isArray(meta?.leagueHistory) ? meta.leagueHistory.slice(-60) : [],
+    historyLedger: Array.isArray(meta?.historyLedger) ? meta.historyLedger : [],
     franchiseAwards: Array.isArray(meta?.franchiseAwards) ? meta.franchiseAwards : [],
     franchiseChronicle: Array.isArray(meta?.franchiseChronicle) ? meta.franchiseChronicle.slice(-340) : [],
     franchiseSeasonReviews: Array.isArray(meta?.franchiseSeasonReviews) ? meta.franchiseSeasonReviews.slice(-40) : [],
@@ -3335,6 +3344,46 @@ async function handleAdvanceWeek(payload, id) {
         teamDriveStats: res.teamDriveStats ?? null,
       });
     }
+  }
+
+  // ── Single-game record tracking (historyEngine) ───────────────────────────
+  // Evaluate completed game stat lines from this week against all-time highs.
+  // Runs after applyGameResultToCache so scores/stats are already committed.
+  try {
+    const currentMeta = cache.getMeta();
+    const existingRb = currentMeta.recordBook ?? {};
+    const defaultRb = createDefaultRecordBook();
+    const rbForHistory = {
+      singleGame: existingRb.singleGame ?? defaultRb.singleGame,
+      singleSeasonBests: existingRb.singleSeasonBests ?? defaultRb.singleSeasonBests,
+    };
+
+    const allStatLines = [];
+    for (const res of results) {
+      const boxScore = res.boxScore ?? {};
+      const rawH = res.home ?? res.homeTeamId;
+      const rawA = res.away ?? res.awayTeamId;
+      const hId = Number(typeof rawH === 'object' ? rawH?.id : rawH);
+      const aId = Number(typeof rawA === 'object' ? rawA?.id : rawA);
+      for (const [pid, entry] of Object.entries(boxScore.home ?? {})) {
+        allStatLines.push({ playerId: pid, playerName: entry.name, position: entry.pos, teamId: hId, stats: entry.stats ?? {} });
+      }
+      for (const [pid, entry] of Object.entries(boxScore.away ?? {})) {
+        allStatLines.push({ playerId: pid, playerName: entry.name, position: entry.pos, teamId: aId, stats: entry.stats ?? {} });
+      }
+    }
+
+    const contextResolver = (statLine) => ({
+      season: currentMeta.year,
+      teamName: cache.getTeam(statLine.teamId)?.name ?? 'Unknown',
+    });
+
+    const updatedRb = updateSingleGameRecordsFromBatch(rbForHistory, allStatLines, contextResolver);
+    if (updatedRb !== rbForHistory) {
+      cache.setMeta({ recordBook: { ...existingRb, ...updatedRb } });
+    }
+  } catch (historyGameErr) {
+    console.warn('[Worker] Single-game record update failed (non-fatal):', historyGameErr.message);
   }
 
   // --- Advance week / phase ---
@@ -12976,6 +13025,59 @@ async function archiveSeason(seasonId) {
     let memoryMeta = { ...meta, leagueHistory: historyRows };
     memoryMeta = updateFranchiseHistory(memoryMeta, seasonSummary, teams);
     memoryMeta = updateRecordBook(memoryMeta, { allPlayers: cache.getAllPlayers() });
+
+    // ── History Ledger & Record Book (historyEngine) ──────────────────────────
+    try {
+      const defaultRb = createDefaultRecordBook();
+      const existingRb = memoryMeta.recordBook ?? {};
+      let historyRb = {
+        singleGame: existingRb.singleGame ?? defaultRb.singleGame,
+        singleSeasonBests: existingRb.singleSeasonBests ?? defaultRb.singleSeasonBests,
+      };
+
+      // 1. Update single-season bests from players before stat reset
+      const allPlayersForHistory = cache.getAllPlayers();
+      const teamNameResolverFn = (tid) => (cache.getTeam(tid)?.name ?? 'Unknown');
+      historyRb = updateSingleSeasonRecords(historyRb, allPlayersForHistory, year, teamNameResolverFn);
+
+      // 2. Build year summary from champion, runner-up, and award winners
+      const champScore = championshipGame
+        ? { homeScore: championshipGame.homeScore, awayScore: championshipGame.awayScore }
+        : {};
+      const yearSummary = buildLeagueYearSummary({
+        season: year,
+        championshipResult: {
+          championTeamId: championId ?? null,
+          championName: champion?.name ?? 'Unknown',
+          runnerUpName: runnerUpTeamFromFinal?.name ?? 'Unknown',
+          ...champScore,
+        },
+        awards: {
+          mvpName: awards?.mvp?.name ?? 'Unknown',
+          opoyName: awards?.opoy?.name ?? 'Unknown',
+          dpoyName: awards?.dpoy?.name ?? 'Unknown',
+        },
+      });
+
+      // 3. Append to ledger (replaces same-year entry if rerun)
+      const updatedLedger = appendHistoryLedger(memoryMeta.historyLedger ?? [], yearSummary);
+
+      // 4. Compact retired non-honored players conservatively
+      const compactedRetired = compactRetiredPlayerHistory(
+        Array.isArray(memoryMeta.retiredPlayers) ? memoryMeta.retiredPlayers : [],
+        historyRb,
+      );
+
+      memoryMeta = {
+        ...memoryMeta,
+        historyLedger: updatedLedger,
+        retiredPlayers: compactedRetired,
+        recordBook: { ...existingRb, ...historyRb },
+      };
+    } catch (historyEngineErr) {
+      console.error('[Worker] History engine season rollover failed (non-fatal):', historyEngineErr);
+    }
+
     const hofArchiveTeamAbbrMap = {};
     teams.forEach((t) => { hofArchiveTeamAbbrMap[t.id] = t.abbr; });
     const hofSync = syncHallOfFameAfterRecordBook(memoryMeta, cache.getAllPlayers(), year, { teams, teamAbbrMap: hofArchiveTeamAbbrMap });
@@ -13056,8 +13158,10 @@ async function archiveSeason(seasonId) {
 
     cache.setMeta({
       leagueHistory: memoryMeta.leagueHistory,
+      historyLedger: Array.isArray(memoryMeta.historyLedger) ? memoryMeta.historyLedger : [],
       franchiseHistoryByTeam: memoryMeta.franchiseHistoryByTeam,
       recordBook: memoryMeta.recordBook,
+      retiredPlayers: Array.isArray(memoryMeta.retiredPlayers) ? memoryMeta.retiredPlayers : [],
       seasonStorylines: memoryMeta.seasonStorylines,
       history: archivedLeagueView.history,
       hallOfFame: memoryMeta.hallOfFame,

--- a/tests/integration/historyLedger.integration.test.js
+++ b/tests/integration/historyLedger.integration.test.js
@@ -1,0 +1,223 @@
+/**
+ * historyLedger.integration.test.js
+ *
+ * Integration tests for the League History Ledger & Record Book engine.
+ * These tests exercise the historyEngine pure functions in scenarios that
+ * mirror the worker's usage patterns.
+ *
+ * Worker wiring requires a full IndexedDB + league boot; these tests mirror
+ * the call sequences rather than booting the full worker.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createDefaultRecordBook,
+  buildLeagueYearSummary,
+  appendHistoryLedger,
+  updateSingleGameRecordsFromBatch,
+  updateSingleSeasonRecords,
+  maybeUpdateSingleGameRecord,
+  compactRetiredPlayerHistory,
+  shouldRetainRetiredPlayerHistory,
+} from '../../src/core/history/historyEngine.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makePlayer(overrides = {}) {
+  return {
+    id: `player-${Math.floor(Math.random() * 9999)}`,
+    name: 'Test Player',
+    pos: 'QB',
+    ovr: 82,
+    teamId: 1,
+    awards: [],
+    accolades: [],
+    stats: { season: { passYd: 0, passTD: 0, rushYd: 0, sacks: 0 } },
+    ...overrides,
+  };
+}
+
+function makeChampionshipResult(overrides = {}) {
+  return {
+    championTeamId: 1,
+    championName: 'Eagles',
+    runnerUpName: 'Chiefs',
+    homeScore: 31,
+    awayScore: 24,
+    ...overrides,
+  };
+}
+
+// ── Hydration: old saves ──────────────────────────────────────────────────────
+
+describe('old save hydration', () => {
+  it('createDefaultRecordBook provides safe historyLedger alternative (empty array)', () => {
+    // Simulates migrateLeague applying defaults to an old save
+    const legacyMeta = { leagueHistory: [], recordBook: {} };
+    const historyLedger = Array.isArray(legacyMeta.historyLedger)
+      ? legacyMeta.historyLedger
+      : [];
+    expect(historyLedger).toEqual([]);
+  });
+
+  it('createDefaultRecordBook initialises null holders on fresh recordBook', () => {
+    const rb = createDefaultRecordBook();
+    expect(rb.singleGame.passingYards).toBeNull();
+    expect(rb.singleSeasonBests.passingYards).toBeNull();
+  });
+
+  it('missing championship/award data does not crash year summary build', () => {
+    expect(() => buildLeagueYearSummary({})).not.toThrow();
+    expect(() => buildLeagueYearSummary({ season: 2025 })).not.toThrow();
+    expect(() => buildLeagueYearSummary({ championshipResult: null, awards: null })).not.toThrow();
+  });
+});
+
+// ── Season rollover: appends ledger entry ────────────────────────────────────
+
+describe('season rollover: appendHistoryLedger', () => {
+  it('appends one ledger entry with champion and awards', () => {
+    const ledger = [];
+    const yearSummary = buildLeagueYearSummary({
+      season: 2025,
+      championshipResult: makeChampionshipResult(),
+      awards: { mvpName: 'Star QB', opoyName: 'Speed RB', dpoyName: 'Edge Pro' },
+    });
+    const updated = appendHistoryLedger(ledger, yearSummary);
+
+    expect(updated.length).toBe(1);
+    expect(updated[0].year).toBe(2025);
+    expect(updated[0].championName).toBe('Eagles');
+    expect(updated[0].mvpName).toBe('Star QB');
+    expect(updated[0].opoyName).toBe('Speed RB');
+    expect(updated[0].dpoyName).toBe('Edge Pro');
+  });
+
+  it('rerunning rollover for same season does not duplicate ledger year', () => {
+    const ledger = [{ year: 2025, championName: 'OldWinner' }];
+    const yearSummary = buildLeagueYearSummary({
+      season: 2025,
+      championshipResult: makeChampionshipResult({ championName: 'NewWinner' }),
+    });
+    const updated = appendHistoryLedger(ledger, yearSummary);
+
+    expect(updated.length).toBe(1);
+    expect(updated[0].championName).toBe('NewWinner');
+  });
+
+  it('preserves chronological order across multiple seasons', () => {
+    let ledger = [];
+    for (const y of [2027, 2025, 2026]) {
+      const summary = buildLeagueYearSummary({ season: y, championshipResult: { championName: `T${y}` } });
+      ledger = appendHistoryLedger(ledger, summary);
+    }
+    expect(ledger.map(e => e.year)).toEqual([2025, 2026, 2027]);
+  });
+});
+
+// ── Season rollover: single-season records updated before stat reset ──────────
+
+describe('season rollover: updateSingleSeasonRecords', () => {
+  it('scans active players and updates single-season records', () => {
+    const rb = createDefaultRecordBook();
+    const players = [
+      makePlayer({ id: 'qb1', name: 'QB1', pos: 'QB', teamId: 1, stats: { season: { passYd: 4800, passTD: 38 } } }),
+      makePlayer({ id: 'rb1', name: 'RB1', pos: 'RB', teamId: 2, stats: { season: { rushYd: 1700 } } }),
+    ];
+    const teamFn = (tid) => (tid === 1 ? 'Lions' : 'Bears');
+    const updated = updateSingleSeasonRecords(rb, players, 2025, teamFn);
+
+    expect(updated.singleSeasonBests.passingYards.metricValue).toBe(4800);
+    expect(updated.singleSeasonBests.passingTds.metricValue).toBe(38);
+    expect(updated.singleSeasonBests.rushingYards.metricValue).toBe(1700);
+    expect(updated.singleSeasonBests.rushingYards.teamNameAtTime).toBe('Bears');
+  });
+});
+
+// ── Weekly advance: single-game records updated ───────────────────────────────
+
+describe('weekly advance: updateSingleGameRecordsFromBatch', () => {
+  it('updates single-game record when a stat line exceeds existing best', () => {
+    const rb = createDefaultRecordBook();
+    const lines = [
+      { playerId: 'qb-a', playerName: 'Elite QB', position: 'QB', teamId: 5, stats: { passYd: 520 } },
+      { playerId: 'qb-b', playerName: 'Average QB', position: 'QB', teamId: 6, stats: { passYd: 280 } },
+    ];
+    const contextResolver = (l) => ({ season: 2025, teamName: 'Team' });
+    const updated = updateSingleGameRecordsFromBatch(rb, lines, contextResolver);
+
+    expect(updated.singleGame.passingYards.playerName).toBe('Elite QB');
+    expect(updated.singleGame.passingYards.metricValue).toBe(520);
+  });
+
+  it('does not update record when no line exceeds the existing holder', () => {
+    let rb = createDefaultRecordBook();
+    const firstLine = { playerId: 'elite', playerName: 'Holder', position: 'QB', teamId: 1, stats: { passYd: 600 } };
+    rb = maybeUpdateSingleGameRecord(rb, firstLine, { season: 2024, teamName: 'Past' });
+
+    const weekLines = [
+      { playerId: 'new1', playerName: 'New QB', position: 'QB', teamId: 1, stats: { passYd: 350 } },
+    ];
+    const afterWeek = updateSingleGameRecordsFromBatch(rb, weekLines, () => ({ season: 2025, teamName: 'Now' }));
+
+    expect(afterWeek === rb).toBe(true);
+    expect(afterWeek.singleGame.passingYards.metricValue).toBe(600);
+  });
+});
+
+// ── Compaction: honored retired players are retained ─────────────────────────
+
+describe('compaction: shouldRetainRetiredPlayerHistory', () => {
+  it('retains a player with an MVP award', () => {
+    const p = makePlayer({ awards: [{ type: 'MVP', season: 2024 }] });
+    expect(shouldRetainRetiredPlayerHistory(p, createDefaultRecordBook())).toBe(true);
+  });
+
+  it('retains a HOF-inducted player', () => {
+    const p = makePlayer({ awards: [], hof: true });
+    expect(shouldRetainRetiredPlayerHistory(p, createDefaultRecordBook())).toBe(true);
+  });
+
+  it('retains a player who holds a record in the historyEngine record book', () => {
+    let rb = createDefaultRecordBook();
+    const holder = makePlayer({ id: 'holder-id', name: 'Record Holder', ovr: 65, awards: [] });
+    const line = { playerId: 'holder-id', playerName: 'Record Holder', position: 'QB', stats: { passYd: 700 } };
+    rb = maybeUpdateSingleGameRecord(rb, line, { season: 2025, teamName: 'T' });
+    expect(shouldRetainRetiredPlayerHistory(holder, rb)).toBe(true);
+  });
+
+  it('does not retain a low-impact depth player', () => {
+    const p = makePlayer({ ovr: 62, awards: [], accolades: [] });
+    expect(shouldRetainRetiredPlayerHistory(p, createDefaultRecordBook())).toBe(false);
+  });
+});
+
+describe('compaction: compactRetiredPlayerHistory', () => {
+  it('is a safe no-op when retired players have no bulky arrays', () => {
+    const players = [
+      makePlayer({ id: 'r1', ovr: 60, awards: [], accolades: [] }),
+    ];
+    const result = compactRetiredPlayerHistory(players, createDefaultRecordBook());
+    expect(result[0]).toEqual(players[0]);
+  });
+
+  it('strips gameLogs from low-impact low-OVR retired players', () => {
+    const players = [
+      makePlayer({ id: 'r2', ovr: 60, awards: [], accolades: [], gameLogs: [1, 2, 3] }),
+    ];
+    const result = compactRetiredPlayerHistory(players, createDefaultRecordBook());
+    expect(result[0].gameLogs).toBeUndefined();
+  });
+
+  it('does not strip gameLogs from honored retired players', () => {
+    const players = [
+      makePlayer({ id: 'r3', ovr: 60, awards: [{ type: 'MVP' }], gameLogs: [1, 2] }),
+    ];
+    const result = compactRetiredPlayerHistory(players, createDefaultRecordBook());
+    expect(result[0].gameLogs).toBeDefined();
+  });
+
+  it('safe no-op when players is null', () => {
+    expect(() => compactRetiredPlayerHistory(null, createDefaultRecordBook())).not.toThrow();
+  });
+});


### PR DESCRIPTION
- Pure historyEngine.js module tracking single-game and single-season
  records for passingYards, passingTds, rushingYards, and sacks
- Year-by-year champion/awards ledger (appendHistoryLedger, buildLeagueYearSummary)
- Retired player history compaction (shouldRetainRetiredPlayerHistory, compactRetiredPlayerHistory)
- Hydration defaults in migrateLeague() for backward-compatible old save support
- Worker wired: single-game records updated each week; season records and
  ledger entry appended at season rollover; historyLedger exposed via buildViewState
- HistoryCenter UI component with Honor Roll and Record Book tabs
- 35 unit tests, integration tests, and 10 UI tests — all 4152 tests pass

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0193fztE5pYtnZjSCmeqYYfY