### PR TITLE
feat(history): Jersey Retirement Numbers & Championship Wall Engine

### DIFF
--- a/src/core/history/teamIdentity.integration.test.js
+++ b/src/core/history/teamIdentity.integration.test.js
@@ -1,0 +1,259 @@
+/**
+ * teamIdentity.integration.test.js
+ * Integration tests for jersey retirement & championship wall engine wiring.
+ * Tests are pure-JS (no worker/DOM) — they operate directly on engine functions
+ * and the migrateLeague schema from state.js.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  retireJerseyNumber,
+  appendChampionshipYear,
+  isRetiredNumber,
+  findAvailableJerseyNumber,
+  buildRetiredNumberDisplay,
+  createDefaultTeamIdentity,
+} from './teamIdentityEngine.js';
+import { State } from '../../core/state.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeTeam(overrides = {}) {
+  return {
+    id: 1,
+    abbr: 'PIT',
+    name: 'Pittsburgh',
+    ringOfHonor: [],
+    retiredNumbers: [],
+    championshipYears: [],
+    roster: [],
+    picks: [],
+    ...overrides,
+  };
+}
+
+function makePlayer(overrides = {}) {
+  return {
+    id: 'p1',
+    name: 'Dan Legend',
+    pos: 'QB',
+    jerseyNumber: 12,
+    teamId: 1,
+    ...overrides,
+  };
+}
+
+function makeLegacyTeam(overrides = {}) {
+  return {
+    id: 1,
+    abbr: 'PIT',
+    name: 'Pittsburgh',
+    ringOfHonor: [],
+    roster: [],
+    picks: [],
+    // deliberately missing retiredNumbers and championshipYears
+    ...overrides,
+  };
+}
+
+// ── Old saves hydration ───────────────────────────────────────────────────────
+
+describe('Schema hydration — old saves', () => {
+  it('migrateLeague adds retiredNumbers to teams that lack it', () => {
+    const league = {
+      teams: [makeLegacyTeam(), makeLegacyTeam({ id: 2, abbr: 'GB' })],
+      historyLedger: [],
+      recordBook: {},
+    };
+    const migrated = State.migrateLeague(league);
+    migrated.teams.forEach((t) => {
+      expect(Array.isArray(t.retiredNumbers)).toBe(true);
+    });
+  });
+
+  it('migrateLeague adds championshipYears to teams that lack it', () => {
+    const league = {
+      teams: [makeLegacyTeam(), makeLegacyTeam({ id: 2, abbr: 'GB' })],
+      historyLedger: [],
+      recordBook: {},
+    };
+    const migrated = State.migrateLeague(league);
+    migrated.teams.forEach((t) => {
+      expect(Array.isArray(t.championshipYears)).toBe(true);
+    });
+  });
+
+  it('migrateLeague preserves existing retiredNumbers without clearing them', () => {
+    const league = {
+      teams: [{ ...makeLegacyTeam(), retiredNumbers: [12, 32] }],
+      historyLedger: [],
+      recordBook: {},
+    };
+    const migrated = State.migrateLeague(league);
+    expect(migrated.teams[0].retiredNumbers).toEqual([12, 32]);
+  });
+
+  it('migrateLeague preserves existing championshipYears without clearing them', () => {
+    const league = {
+      teams: [{ ...makeLegacyTeam(), championshipYears: [2024, 2026] }],
+      historyLedger: [],
+      recordBook: {},
+    };
+    const migrated = State.migrateLeague(league);
+    expect(migrated.teams[0].championshipYears).toEqual([2024, 2026]);
+  });
+
+  it('does not crash when teams array is empty', () => {
+    const league = { teams: [], historyLedger: [], recordBook: {} };
+    expect(() => State.migrateLeague(league)).not.toThrow();
+  });
+});
+
+// ── Championship year harvesting ──────────────────────────────────────────────
+
+describe('appendChampionshipYear — season rollover semantics', () => {
+  it('appends the current year once on first championship', () => {
+    const team = makeTeam();
+    const result = appendChampionshipYear(team, 2025);
+    expect(result.championshipYears).toEqual([2025]);
+  });
+
+  it('does not duplicate year if called again for same year (idempotent re-run)', () => {
+    const team = makeTeam({ championshipYears: [2025] });
+    const result = appendChampionshipYear(team, 2025);
+    expect(result.championshipYears).toEqual([2025]);
+    expect(result).toBe(team); // same reference = no mutation needed
+  });
+
+  it('records multiple championships in ascending order', () => {
+    let team = makeTeam();
+    team = appendChampionshipYear(team, 2026);
+    team = appendChampionshipYear(team, 2024);
+    team = appendChampionshipYear(team, 2028);
+    expect(team.championshipYears).toEqual([2024, 2026, 2028]);
+  });
+
+  it('does not affect other teams (isolated)', () => {
+    const teamA = makeTeam({ id: 1 });
+    const teamB = makeTeam({ id: 2 });
+    const updatedA = appendChampionshipYear(teamA, 2025);
+    expect(teamB.championshipYears).toHaveLength(0);
+    expect(updatedA.championshipYears).toContain(2025);
+  });
+});
+
+// ── RETIRE_JERSEY_NUMBER semantics ─────────────────────────────────────────────
+
+describe('retireJerseyNumber — handler semantics', () => {
+  it('adds number to correct team', () => {
+    const team = makeTeam({ id: 1 });
+    const player = makePlayer({ jerseyNumber: 12 });
+    const updated = retireJerseyNumber(team, player);
+    expect(updated.retiredNumbers).toContain(12);
+  });
+
+  it('prevents duplicate retirement', () => {
+    const team = makeTeam({ retiredNumbers: [12] });
+    const player = makePlayer({ jerseyNumber: 12 });
+    const updated = retireJerseyNumber(team, player);
+    expect(updated.retiredNumbers.filter((n) => n === 12)).toHaveLength(1);
+  });
+
+  it('does not crash with legacy player missing jerseyNumber', () => {
+    const team = makeTeam();
+    const player = makePlayer({ jerseyNumber: undefined });
+    expect(() => retireJerseyNumber(team, player)).not.toThrow();
+    expect(team.retiredNumbers).toHaveLength(0); // no mutation
+  });
+});
+
+// ── Jersey assignment guard — drafted players ─────────────────────────────────
+
+describe('jersey assignment guard — draft path', () => {
+  it('returns preferred number when available', () => {
+    const team = makeTeam();
+    const assigned = findAvailableJerseyNumber(12, team.retiredNumbers, []);
+    expect(assigned).toBe(12);
+  });
+
+  it('skips retired number and assigns next available', () => {
+    const team = makeTeam({ retiredNumbers: [12] });
+    const rosterNums = [13, 14];
+    const assigned = findAvailableJerseyNumber(12, team.retiredNumbers, rosterNums);
+    expect(assigned).toBe(1);
+  });
+
+  it('active roster players keep existing numbers (no retroactive change)', () => {
+    // Guard only applies when assigning a new number — existing active players
+    // are not passed through findAvailableJerseyNumber again.
+    const team = makeTeam({ retiredNumbers: [12] });
+    const existingActivePlayer = makePlayer({ jerseyNumber: 12 });
+    // The guard would only run on draft/sign path, not on retirement of a number.
+    // Verify that retireJerseyNumber doesn't touch the active roster.
+    const updated = retireJerseyNumber(team, existingActivePlayer);
+    expect(updated.retiredNumbers).toContain(12);
+    // The existing active player's jerseyNumber is not changed by the engine
+    expect(existingActivePlayer.jerseyNumber).toBe(12);
+  });
+});
+
+// ── Jersey assignment guard — FA signing path ─────────────────────────────────
+
+describe('jersey assignment guard — free agency path', () => {
+  it('assigns a new number when FA existing number is retired', () => {
+    const team = makeTeam({ retiredNumbers: [88] });
+    const faPlayer = makePlayer({ jerseyNumber: 88, pos: 'WR' });
+    const rosterNums = [80, 81];
+    const preferred = Number(faPlayer.jerseyNumber);
+    const assigned = findAvailableJerseyNumber(preferred, team.retiredNumbers, rosterNums);
+    expect(assigned).not.toBe(88);
+    expect(team.retiredNumbers).not.toContain(assigned);
+  });
+
+  it('keeps FA existing number when not retired', () => {
+    const team = makeTeam({ retiredNumbers: [12] });
+    const faPlayer = makePlayer({ jerseyNumber: 32 });
+    const assigned = findAvailableJerseyNumber(32, team.retiredNumbers, []);
+    expect(assigned).toBe(32);
+  });
+});
+
+// ── buildRetiredNumberDisplay — UI integration ────────────────────────────────
+
+describe('buildRetiredNumberDisplay — UI display integration', () => {
+  it('links surname to ROH member when jerseyNumber matches', () => {
+    const team = makeTeam({ retiredNumbers: [12] });
+    const roh = [{ id: 'p1', name: 'Dan Legend', jerseyNumber: 12 }];
+    const display = buildRetiredNumberDisplay(team, roh);
+    expect(display[0].surname).toBe('Legend');
+    expect(display[0].jerseyNumber).toBe(12);
+  });
+
+  it('returns null surname when no ROH member matches', () => {
+    const team = makeTeam({ retiredNumbers: [99] });
+    const roh = [{ id: 'p1', name: 'Dan Legend', jerseyNumber: 12 }];
+    const display = buildRetiredNumberDisplay(team, roh);
+    expect(display[0].jerseyNumber).toBe(99);
+    expect(display[0].surname).toBeNull();
+  });
+
+  it('returns empty array when no numbers are retired', () => {
+    const team = makeTeam();
+    const display = buildRetiredNumberDisplay(team, []);
+    expect(display).toHaveLength(0);
+  });
+});
+
+// ── createDefaultTeamIdentity integration ─────────────────────────────────────
+
+describe('createDefaultTeamIdentity — hydration compatibility', () => {
+  it('fills missing fields on a legacy team object', () => {
+    const legacy = makeLegacyTeam();
+    const identity = createDefaultTeamIdentity();
+    const hydrated = { ...legacy, ...identity };
+    expect(Array.isArray(hydrated.retiredNumbers)).toBe(true);
+    expect(Array.isArray(hydrated.championshipYears)).toBe(true);
+    expect(hydrated.retiredNumbers).toHaveLength(0);
+    expect(hydrated.championshipYears).toHaveLength(0);
+  });
+});

--- a/src/core/history/teamIdentityEngine.js
+++ b/src/core/history/teamIdentityEngine.js
@@ -1,0 +1,171 @@
+/**
+ * teamIdentityEngine.js — Per-team Jersey Retirement & Championship Wall engine
+ *
+ * Pure module: no side effects, no UI/worker/DOM imports, no Math.random.
+ * All functions are immutable — inputs are never mutated.
+ *
+ * Stored under:
+ *   team.retiredNumbers     — array of jersey numbers retired by the franchise
+ *   team.championshipYears  — array of years the franchise won the championship
+ */
+
+/**
+ * Returns the default team identity fields for new or migrated teams.
+ */
+export function createDefaultTeamIdentity() {
+  return {
+    retiredNumbers: [],
+    championshipYears: [],
+  };
+}
+
+/**
+ * Retire a jersey number for a franchise.
+ * Validates number is in 1–99 range and is an integer.
+ * Ignores duplicate entries.
+ * Sorts ascending for stable display.
+ * Returns new team object — never mutates input.
+ *
+ * @param {Object} team   - { retiredNumbers: number[] }
+ * @param {Object} player - { jerseyNumber: number }
+ * @returns {Object} new team with updated retiredNumbers
+ */
+export function retireJerseyNumber(team, player) {
+  const num = Number(player?.jerseyNumber);
+  if (!Number.isFinite(num) || !Number.isInteger(num) || num < 1 || num > 99) {
+    return team;
+  }
+
+  const current = Array.isArray(team?.retiredNumbers) ? team.retiredNumbers : [];
+  if (current.includes(num)) return team;
+
+  const updated = [...current, num].sort((a, b) => a - b);
+  return { ...team, retiredNumbers: updated };
+}
+
+/**
+ * Append a championship year to the franchise history.
+ * Ignores duplicate years.
+ * Sorted ascending (oldest to newest) for stable display.
+ * Returns new team object — never mutates input.
+ *
+ * @param {Object} team - { championshipYears: number[] }
+ * @param {number} year
+ * @returns {Object} new team with updated championshipYears
+ */
+export function appendChampionshipYear(team, year) {
+  const y = Number(year);
+  if (!Number.isFinite(y) || !Number.isInteger(y)) return team;
+
+  const current = Array.isArray(team?.championshipYears) ? team.championshipYears : [];
+  if (current.includes(y)) return team;
+
+  const updated = [...current, y].sort((a, b) => a - b);
+  return { ...team, championshipYears: updated };
+}
+
+/**
+ * Returns true if the given jerseyNumber is in the team's retiredNumbers list.
+ *
+ * @param {Object} team         - { retiredNumbers: number[] }
+ * @param {number} jerseyNumber
+ * @returns {boolean}
+ */
+export function isRetiredNumber(team, jerseyNumber) {
+  const num = Number(jerseyNumber);
+  if (!Number.isFinite(num)) return false;
+  return Array.isArray(team?.retiredNumbers) && team.retiredNumbers.includes(num);
+}
+
+/**
+ * Find an available jersey number that is neither retired nor already used.
+ * Returns `preferredNumber` if it is valid (1–99 integer) and available.
+ * Otherwise scans 1–99 deterministically and returns the first available.
+ * Returns null only if all 99 numbers are somehow taken.
+ *
+ * No Math.random — fully deterministic.
+ *
+ * @param {number}   preferredNumber
+ * @param {number[]} retiredNumbers  - Numbers retired by the franchise
+ * @param {number[]} usedNumbers     - Numbers already in use on the current roster
+ * @returns {number|null}
+ */
+export function findAvailableJerseyNumber(preferredNumber, retiredNumbers = [], usedNumbers = []) {
+  const retired = new Set(retiredNumbers.map(Number).filter((n) => Number.isFinite(n)));
+  const used    = new Set(usedNumbers.map(Number).filter((n) => Number.isFinite(n)));
+
+  const pref = Number(preferredNumber);
+  if (
+    Number.isFinite(pref) &&
+    Number.isInteger(pref) &&
+    pref >= 1 &&
+    pref <= 99 &&
+    !retired.has(pref) &&
+    !used.has(pref)
+  ) {
+    return pref;
+  }
+
+  for (let n = 1; n <= 99; n++) {
+    if (!retired.has(n) && !used.has(n)) return n;
+  }
+
+  return null;
+}
+
+/**
+ * Build UI-ready display objects for retired numbers, linking each number
+ * to a Ring of Honor member's surname when a matching jerseyNumber is found.
+ * Always returns an entry per number; surname is null when no ROH match exists.
+ *
+ * @param {Object}   team        - { retiredNumbers: number[] }
+ * @param {Object[]} ringOfHonor - Array of ROH member objects { jerseyNumber, name }
+ * @returns {Array<{ jerseyNumber: number, surname: string|null }>}
+ */
+export function buildRetiredNumberDisplay(team, ringOfHonor = []) {
+  const retiredNumbers = Array.isArray(team?.retiredNumbers) ? team.retiredNumbers : [];
+  const roh = Array.isArray(ringOfHonor) ? ringOfHonor : [];
+
+  return retiredNumbers.map((num) => {
+    const match = roh.find((m) => Number(m?.jerseyNumber) === num);
+    let surname = null;
+    if (match?.name) {
+      const parts = String(match.name).trim().split(/\s+/);
+      surname = parts.length > 0 ? (parts[parts.length - 1] ?? null) : null;
+    }
+    return { jerseyNumber: num, surname };
+  });
+}
+
+/**
+ * Deterministically derive a preferred jersey number for a position+id combo.
+ * Used when generating jersey numbers for drafted/signed players.
+ * Position ranges follow loose NFL convention:
+ *   QB/K/P: 1–19  |  RB/DB/CB/S: 20–49  |  LB/OL: 50–79  |  DL: 50–79  |  WR/TE: 80–89
+ * Falls back to 1–99 for unknown positions.
+ *
+ * @param {string} pos  - Position string
+ * @param {string|number} playerId
+ * @returns {number}   1–99 integer
+ */
+export function derivePreferredJerseyNumber(pos, playerId) {
+  const RANGES = {
+    QB: [1,  19],
+    K:  [1,  19],
+    P:  [1,  19],
+    RB: [20, 49],
+    CB: [20, 49],
+    S:  [20, 49],
+    LB: [50, 79],
+    OL: [50, 79],
+    DL: [50, 79],
+    WR: [80, 89],
+    TE: [80, 89],
+  };
+  const range = RANGES[String(pos).toUpperCase()] ?? [1, 99];
+  const [lo, hi] = range;
+  const span = hi - lo + 1;
+  // Derive a stable offset from the playerId without Math.random
+  const seed = String(playerId ?? '').split('').reduce((acc, ch) => acc + ch.charCodeAt(0), 0);
+  return lo + (seed % span);
+}

--- a/src/core/history/teamIdentityEngine.unit.test.js
+++ b/src/core/history/teamIdentityEngine.unit.test.js
@@ -1,0 +1,363 @@
+/**
+ * teamIdentityEngine.unit.test.js
+ * Pure-function unit tests for the Jersey Retirement & Championship Wall engine.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createDefaultTeamIdentity,
+  retireJerseyNumber,
+  appendChampionshipYear,
+  isRetiredNumber,
+  findAvailableJerseyNumber,
+  buildRetiredNumberDisplay,
+  derivePreferredJerseyNumber,
+} from './teamIdentityEngine.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeTeam(overrides = {}) {
+  return { id: 1, abbr: 'PIT', name: 'Pittsburgh', retiredNumbers: [], championshipYears: [], ...overrides };
+}
+
+function makePlayer(overrides = {}) {
+  return { id: 'p1', name: 'Test Player', pos: 'QB', jerseyNumber: 12, ...overrides };
+}
+
+// ── createDefaultTeamIdentity ─────────────────────────────────────────────────
+
+describe('createDefaultTeamIdentity', () => {
+  it('returns empty retiredNumbers array', () => {
+    const identity = createDefaultTeamIdentity();
+    expect(Array.isArray(identity.retiredNumbers)).toBe(true);
+    expect(identity.retiredNumbers).toHaveLength(0);
+  });
+
+  it('returns empty championshipYears array', () => {
+    const identity = createDefaultTeamIdentity();
+    expect(Array.isArray(identity.championshipYears)).toBe(true);
+    expect(identity.championshipYears).toHaveLength(0);
+  });
+
+  it('returns a fresh object on each call', () => {
+    const a = createDefaultTeamIdentity();
+    const b = createDefaultTeamIdentity();
+    expect(a).not.toBe(b);
+    a.retiredNumbers.push(1);
+    expect(b.retiredNumbers).toHaveLength(0);
+  });
+});
+
+// ── retireJerseyNumber ────────────────────────────────────────────────────────
+
+describe('retireJerseyNumber', () => {
+  it('appends a valid jersey number to retiredNumbers', () => {
+    const team = makeTeam();
+    const player = makePlayer({ jerseyNumber: 12 });
+    const result = retireJerseyNumber(team, player);
+    expect(result.retiredNumbers).toContain(12);
+  });
+
+  it('does not mutate the original team object', () => {
+    const team = makeTeam();
+    const player = makePlayer({ jerseyNumber: 12 });
+    retireJerseyNumber(team, player);
+    expect(team.retiredNumbers).toHaveLength(0);
+  });
+
+  it('ignores duplicate numbers — no duplication', () => {
+    const team = makeTeam({ retiredNumbers: [12] });
+    const player = makePlayer({ jerseyNumber: 12 });
+    const result = retireJerseyNumber(team, player);
+    expect(result.retiredNumbers.filter((n) => n === 12)).toHaveLength(1);
+  });
+
+  it('returns same reference when duplicate found', () => {
+    const team = makeTeam({ retiredNumbers: [12] });
+    const player = makePlayer({ jerseyNumber: 12 });
+    const result = retireJerseyNumber(team, player);
+    expect(result).toBe(team);
+  });
+
+  it('rejects jersey number 0', () => {
+    const team = makeTeam();
+    const result = retireJerseyNumber(team, makePlayer({ jerseyNumber: 0 }));
+    expect(result.retiredNumbers).toHaveLength(0);
+  });
+
+  it('rejects jersey number 100', () => {
+    const team = makeTeam();
+    const result = retireJerseyNumber(team, makePlayer({ jerseyNumber: 100 }));
+    expect(result.retiredNumbers).toHaveLength(0);
+  });
+
+  it('rejects negative numbers', () => {
+    const team = makeTeam();
+    const result = retireJerseyNumber(team, makePlayer({ jerseyNumber: -5 }));
+    expect(result.retiredNumbers).toHaveLength(0);
+  });
+
+  it('rejects fractional numbers', () => {
+    const team = makeTeam();
+    const result = retireJerseyNumber(team, makePlayer({ jerseyNumber: 12.5 }));
+    expect(result.retiredNumbers).toHaveLength(0);
+  });
+
+  it('rejects null jerseyNumber', () => {
+    const team = makeTeam();
+    const result = retireJerseyNumber(team, makePlayer({ jerseyNumber: null }));
+    expect(result.retiredNumbers).toHaveLength(0);
+  });
+
+  it('rejects undefined jerseyNumber', () => {
+    const team = makeTeam();
+    const result = retireJerseyNumber(team, makePlayer({ jerseyNumber: undefined }));
+    expect(result.retiredNumbers).toHaveLength(0);
+  });
+
+  it('sorts retiredNumbers ascending', () => {
+    const team = makeTeam({ retiredNumbers: [80, 12] });
+    const result = retireJerseyNumber(team, makePlayer({ jerseyNumber: 32 }));
+    expect(result.retiredNumbers).toEqual([12, 32, 80]);
+  });
+
+  it('accepts boundary value 1', () => {
+    const team = makeTeam();
+    const result = retireJerseyNumber(team, makePlayer({ jerseyNumber: 1 }));
+    expect(result.retiredNumbers).toContain(1);
+  });
+
+  it('accepts boundary value 99', () => {
+    const team = makeTeam();
+    const result = retireJerseyNumber(team, makePlayer({ jerseyNumber: 99 }));
+    expect(result.retiredNumbers).toContain(99);
+  });
+});
+
+// ── appendChampionshipYear ────────────────────────────────────────────────────
+
+describe('appendChampionshipYear', () => {
+  it('appends a valid year to championshipYears', () => {
+    const team = makeTeam();
+    const result = appendChampionshipYear(team, 2026);
+    expect(result.championshipYears).toContain(2026);
+  });
+
+  it('does not mutate the original team object', () => {
+    const team = makeTeam();
+    appendChampionshipYear(team, 2026);
+    expect(team.championshipYears).toHaveLength(0);
+  });
+
+  it('ignores duplicate years', () => {
+    const team = makeTeam({ championshipYears: [2026] });
+    const result = appendChampionshipYear(team, 2026);
+    expect(result.championshipYears.filter((y) => y === 2026)).toHaveLength(1);
+  });
+
+  it('returns same reference when duplicate year found', () => {
+    const team = makeTeam({ championshipYears: [2026] });
+    const result = appendChampionshipYear(team, 2026);
+    expect(result).toBe(team);
+  });
+
+  it('sorts years ascending (oldest first)', () => {
+    const team = makeTeam({ championshipYears: [2030, 2024] });
+    const result = appendChampionshipYear(team, 2027);
+    expect(result.championshipYears).toEqual([2024, 2027, 2030]);
+  });
+
+  it('handles team with no existing championshipYears gracefully', () => {
+    const team = { id: 1, name: 'Test' }; // no championshipYears key
+    const result = appendChampionshipYear(team, 2025);
+    expect(result.championshipYears).toContain(2025);
+  });
+});
+
+// ── isRetiredNumber ───────────────────────────────────────────────────────────
+
+describe('isRetiredNumber', () => {
+  it('returns true when number is in retiredNumbers', () => {
+    const team = makeTeam({ retiredNumbers: [12, 32] });
+    expect(isRetiredNumber(team, 12)).toBe(true);
+  });
+
+  it('returns false when number is not in retiredNumbers', () => {
+    const team = makeTeam({ retiredNumbers: [12, 32] });
+    expect(isRetiredNumber(team, 88)).toBe(false);
+  });
+
+  it('returns false when retiredNumbers is empty', () => {
+    const team = makeTeam();
+    expect(isRetiredNumber(team, 12)).toBe(false);
+  });
+
+  it('returns false for non-finite input', () => {
+    const team = makeTeam({ retiredNumbers: [12] });
+    expect(isRetiredNumber(team, NaN)).toBe(false);
+  });
+
+  it('handles team without retiredNumbers property', () => {
+    expect(isRetiredNumber({}, 12)).toBe(false);
+  });
+});
+
+// ── findAvailableJerseyNumber ─────────────────────────────────────────────────
+
+describe('findAvailableJerseyNumber', () => {
+  it('returns preferredNumber when valid and not retired or used', () => {
+    const result = findAvailableJerseyNumber(12, [], []);
+    expect(result).toBe(12);
+  });
+
+  it('skips retired numbers and scans from 1 for first available', () => {
+    // 12 is retired → falls back to scan from 1 → 1 is available
+    const result = findAvailableJerseyNumber(12, [12], []);
+    expect(result).toBe(1);
+  });
+
+  it('skips used numbers and scans from 1 for first available', () => {
+    // 12 is used → falls back to scan from 1 → 1 is available
+    const result = findAvailableJerseyNumber(12, [], [12]);
+    expect(result).toBe(1);
+  });
+
+  it('skips both retired and used numbers scanning from 1', () => {
+    // 12 retired, 1 used → return 2 (first scan from 1 that avoids both)
+    const result = findAvailableJerseyNumber(12, [12], [1]);
+    expect(result).toBe(2);
+  });
+
+  it('scans from 1 when preferred is invalid (0)', () => {
+    const result = findAvailableJerseyNumber(0, [], []);
+    expect(result).toBe(1);
+  });
+
+  it('returns null only when all 99 numbers are taken', () => {
+    const all = Array.from({ length: 99 }, (_, i) => i + 1);
+    const result = findAvailableJerseyNumber(1, all, []);
+    expect(result).toBeNull();
+  });
+
+  it('handles empty arrays as defaults', () => {
+    const result = findAvailableJerseyNumber(55);
+    expect(result).toBe(55);
+  });
+
+  it('result is always deterministic — same input same output', () => {
+    const r1 = findAvailableJerseyNumber(12, [12, 13, 14], [15]);
+    const r2 = findAvailableJerseyNumber(12, [12, 13, 14], [15]);
+    expect(r1).toBe(r2);
+    expect(r1).toBe(1);
+  });
+
+  it('preferred number 99 is accepted when available', () => {
+    expect(findAvailableJerseyNumber(99, [], [])).toBe(99);
+  });
+
+  it('preferred number 100 is invalid, falls back to scan from 1', () => {
+    const result = findAvailableJerseyNumber(100, [], []);
+    expect(result).toBe(1);
+  });
+});
+
+// ── buildRetiredNumberDisplay ─────────────────────────────────────────────────
+
+describe('buildRetiredNumberDisplay', () => {
+  it('returns empty array when retiredNumbers is empty', () => {
+    const team = makeTeam();
+    const result = buildRetiredNumberDisplay(team, []);
+    expect(result).toHaveLength(0);
+  });
+
+  it('links surname when ROH member jerseyNumber matches', () => {
+    const team = makeTeam({ retiredNumbers: [12] });
+    const roh = [{ id: 'p1', name: 'Dan Legend', jerseyNumber: 12 }];
+    const result = buildRetiredNumberDisplay(team, roh);
+    expect(result).toHaveLength(1);
+    expect(result[0].jerseyNumber).toBe(12);
+    expect(result[0].surname).toBe('Legend');
+  });
+
+  it('returns null surname when no ROH match found', () => {
+    const team = makeTeam({ retiredNumbers: [88] });
+    const roh = [{ id: 'p1', name: 'Dan Legend', jerseyNumber: 12 }];
+    const result = buildRetiredNumberDisplay(team, roh);
+    expect(result[0].jerseyNumber).toBe(88);
+    expect(result[0].surname).toBeNull();
+  });
+
+  it('handles team without retiredNumbers property', () => {
+    const result = buildRetiredNumberDisplay({}, []);
+    expect(result).toHaveLength(0);
+  });
+
+  it('handles empty ringOfHonor array', () => {
+    const team = makeTeam({ retiredNumbers: [12] });
+    const result = buildRetiredNumberDisplay(team, []);
+    expect(result[0].surname).toBeNull();
+  });
+
+  it('handles missing name on ROH member gracefully', () => {
+    const team = makeTeam({ retiredNumbers: [12] });
+    const roh = [{ id: 'p1', jerseyNumber: 12 }]; // no name
+    const result = buildRetiredNumberDisplay(team, roh);
+    expect(result[0].surname).toBeNull();
+  });
+
+  it('extracts last name correctly from multi-part name', () => {
+    const team = makeTeam({ retiredNumbers: [32] });
+    const roh = [{ id: 'p2', name: 'John Michael Smith', jerseyNumber: 32 }];
+    const [entry] = buildRetiredNumberDisplay(team, roh);
+    expect(entry.surname).toBe('Smith');
+  });
+
+  it('returns an entry for every retired number', () => {
+    const team = makeTeam({ retiredNumbers: [12, 32, 80] });
+    const result = buildRetiredNumberDisplay(team, []);
+    expect(result).toHaveLength(3);
+  });
+});
+
+// ── No Math.random guard ──────────────────────────────────────────────────────
+
+describe('teamIdentityEngine — no Math.random usage', () => {
+  it('module exports are deterministic (calling twice gives same result)', () => {
+    const team = makeTeam();
+    const r1 = retireJerseyNumber(team, makePlayer({ jerseyNumber: 12 }));
+    const r2 = retireJerseyNumber(team, makePlayer({ jerseyNumber: 12 }));
+    expect(r1.retiredNumbers).toEqual(r2.retiredNumbers);
+
+    const y1 = appendChampionshipYear(team, 2026);
+    const y2 = appendChampionshipYear(team, 2026);
+    expect(y1.championshipYears).toEqual(y2.championshipYears);
+
+    const n1 = findAvailableJerseyNumber(12, [12], [13]);
+    const n2 = findAvailableJerseyNumber(12, [12], [13]);
+    expect(n1).toBe(n2);
+  });
+});
+
+// ── derivePreferredJerseyNumber ───────────────────────────────────────────────
+
+describe('derivePreferredJerseyNumber', () => {
+  it('returns a number in 1–99 range for known positions', () => {
+    ['QB', 'RB', 'WR', 'TE', 'OL', 'DL', 'LB', 'CB', 'S', 'K', 'P'].forEach((pos) => {
+      const n = derivePreferredJerseyNumber(pos, 'player_1');
+      expect(n).toBeGreaterThanOrEqual(1);
+      expect(n).toBeLessThanOrEqual(99);
+    });
+  });
+
+  it('returns a number in 1–99 for unknown position', () => {
+    const n = derivePreferredJerseyNumber('UNKNOWN', 'player_1');
+    expect(n).toBeGreaterThanOrEqual(1);
+    expect(n).toBeLessThanOrEqual(99);
+  });
+
+  it('is deterministic for the same inputs', () => {
+    expect(derivePreferredJerseyNumber('QB', 'player_abc')).toBe(
+      derivePreferredJerseyNumber('QB', 'player_abc')
+    );
+  });
+});

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -538,6 +538,16 @@ export const State = {
       return t;
     });
 
+    // ── Team Identity — Retired Numbers & Championship Years ─────────────────
+    // Backward-compatible: old saves hydrate safely with empty arrays.
+    migrated.teams = migrated.teams.map((team) => {
+      if (!team) return team;
+      const t = { ...team };
+      if (!Array.isArray(t.retiredNumbers)) t.retiredNumbers = [];
+      if (!Array.isArray(t.championshipYears)) t.championshipYears = [];
+      return t;
+    });
+
     // ── History Ledger & Record Book (historyEngine schema) ─────────────────
     // Backward-compatible: old saves hydrate safely with empty/null defaults.
     migrated.historyLedger = Array.isArray(migrated.historyLedger)

--- a/src/ui/components/FranchiseBrandHQ.jsx
+++ b/src/ui/components/FranchiseBrandHQ.jsx
@@ -1,0 +1,104 @@
+/** @jsxImportSource react */
+import React from 'react';
+
+// ── Championship Wall ─────────────────────────────────────────────────────────
+
+function ChampionshipBadge({ year }) {
+  return (
+    <span
+      data-testid="championship-badge"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        padding: '4px 12px',
+        borderRadius: '8px',
+        background: 'rgba(245, 158, 11, 0.10)',
+        border: '1px solid rgba(245, 158, 11, 0.20)',
+        color: 'var(--warning, #f59e0b)',
+        fontSize: 'var(--text-sm, 13px)',
+        fontWeight: 700,
+        letterSpacing: '0.04em',
+        gap: 4,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <span aria-hidden="true">🏆</span>
+      {year}
+    </span>
+  );
+}
+
+function ChampionshipWall({ championshipYears }) {
+  const years = Array.isArray(championshipYears) ? championshipYears : [];
+
+  return (
+    <div data-testid="championship-wall">
+      <div
+        style={{
+          fontSize: 'var(--text-xs, 11px)',
+          fontWeight: 600,
+          color: 'var(--text-muted)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+          marginBottom: 6,
+        }}
+      >
+        Championship Wall
+      </div>
+      {years.length > 0 ? (
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 6,
+          }}
+        >
+          {years.map((year) => (
+            <ChampionshipBadge key={year} year={year} />
+          ))}
+        </div>
+      ) : (
+        <p
+          data-testid="championship-wall-empty"
+          style={{
+            margin: 0,
+            color: 'var(--text-muted)',
+            fontSize: 'var(--text-xs, 12px)',
+            fontStyle: 'italic',
+          }}
+        >
+          No championships yet.
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ── Main FranchiseBrandHQ ─────────────────────────────────────────────────────
+
+/**
+ * FranchiseBrandHQ — Championship wall for the top of Franchise HQ.
+ *
+ * Props:
+ *   championshipYears  {number[]} - Seasons the franchise won the title
+ */
+export default function FranchiseBrandHQ({ championshipYears = [] }) {
+  const years = Array.isArray(championshipYears) ? championshipYears : [];
+
+  if (years.length === 0) return null;
+
+  return (
+    <div
+      data-testid="franchise-brand-hq"
+      style={{
+        padding: '10px 16px',
+        borderRadius: '10px',
+        background: 'rgba(245, 158, 11, 0.04)',
+        border: '1px solid rgba(245, 158, 11, 0.12)',
+        marginBottom: 4,
+      }}
+    >
+      <ChampionshipWall championshipYears={years} />
+    </div>
+  );
+}

--- a/src/ui/components/FranchiseBrandHQ.test.jsx
+++ b/src/ui/components/FranchiseBrandHQ.test.jsx
@@ -1,0 +1,228 @@
+/** @vitest-environment jsdom */
+/**
+ * FranchiseBrandHQ.test.jsx
+ * UI tests for the Championship Wall and Retired Numbers panel.
+ */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import FranchiseBrandHQ from './FranchiseBrandHQ.jsx';
+import FranchiseLegacyView from './FranchiseLegacyView.jsx';
+
+afterEach(() => cleanup());
+
+// ── FranchiseBrandHQ — Championship Wall ─────────────────────────────────────
+
+describe('FranchiseBrandHQ — championship wall', () => {
+  it('renders trophy badges for each championship year', () => {
+    render(<FranchiseBrandHQ championshipYears={[2024, 2026]} />);
+    const badges = screen.getAllByTestId('championship-badge');
+    expect(badges).toHaveLength(2);
+    expect(screen.getByText('2024')).toBeTruthy();
+    expect(screen.getByText('2026')).toBeTruthy();
+  });
+
+  it('renders the championship wall container', () => {
+    render(<FranchiseBrandHQ championshipYears={[2025]} />);
+    expect(screen.getByTestId('championship-wall')).toBeTruthy();
+  });
+
+  it('renders the root franchise-brand-hq container when years exist', () => {
+    render(<FranchiseBrandHQ championshipYears={[2025]} />);
+    expect(screen.getByTestId('franchise-brand-hq')).toBeTruthy();
+  });
+
+  it('renders nothing when championshipYears is empty', () => {
+    const { container } = render(<FranchiseBrandHQ championshipYears={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when championshipYears is not provided', () => {
+    const { container } = render(<FranchiseBrandHQ />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('does not crash with null as prop', () => {
+    expect(() => render(<FranchiseBrandHQ championshipYears={null} />)).not.toThrow();
+  });
+
+  it('renders multiple trophy badges in order', () => {
+    render(<FranchiseBrandHQ championshipYears={[2020, 2022, 2025]} />);
+    const badges = screen.getAllByTestId('championship-badge');
+    expect(badges).toHaveLength(3);
+  });
+});
+
+// ── FranchiseLegacyView — Retired Numbers panel ──────────────────────────────
+
+describe('FranchiseLegacyView — retired numbers panel', () => {
+  it('renders the retired numbers section', () => {
+    render(<FranchiseLegacyView />);
+    expect(screen.getByText('Retired Numbers')).toBeTruthy();
+  });
+
+  it('shows empty state when no numbers are retired', () => {
+    render(<FranchiseLegacyView retiredNumberDisplay={[]} />);
+    expect(screen.getByTestId('retired-numbers-empty')).toBeTruthy();
+    expect(screen.getByText(/No retired numbers yet/i)).toBeTruthy();
+  });
+
+  it('renders number/surname badges for each retired number', () => {
+    const display = [
+      { jerseyNumber: 12, surname: 'VANCE' },
+      { jerseyNumber: 80, surname: 'MILLER' },
+    ];
+    render(<FranchiseLegacyView retiredNumberDisplay={display} />);
+    const badges = screen.getAllByTestId('retired-number-badge');
+    expect(badges).toHaveLength(2);
+    expect(screen.getByText(/#12 VANCE/i)).toBeTruthy();
+    expect(screen.getByText(/#80 MILLER/i)).toBeTruthy();
+  });
+
+  it('renders number-only badge when surname is null', () => {
+    const display = [{ jerseyNumber: 55, surname: null }];
+    render(<FranchiseLegacyView retiredNumberDisplay={display} />);
+    expect(screen.getByText('#55')).toBeTruthy();
+  });
+
+  it('retired numbers panel container has correct testid', () => {
+    render(<FranchiseLegacyView retiredNumberDisplay={[{ jerseyNumber: 12, surname: 'JONES' }]} />);
+    expect(screen.getByTestId('retired-numbers-panel')).toBeTruthy();
+  });
+});
+
+// ── FranchiseLegacyView — Retire Number action ───────────────────────────────
+
+describe('FranchiseLegacyView — retire number button on ROH cards', () => {
+  function makeRohMember(overrides = {}) {
+    return {
+      id: 'p-legend',
+      name: 'Dan Legend',
+      position: 'QB',
+      jerseyNumber: 10,
+      yearsPlayedWithTeam: '2018–2026',
+      careerGamesWithTeam: 128,
+      totalPassingYards: 35000,
+      totalRushingYards: null,
+      totalReceivingYards: null,
+      totalSacks: null,
+      accolades: [],
+      inductionYear: 2027,
+      ...overrides,
+    };
+  }
+
+  it('renders retire button on ROH card when onRetireNumber is provided', () => {
+    const onRetire = vi.fn();
+    render(
+      <FranchiseLegacyView
+        ringOfHonor={[makeRohMember()]}
+        retiredNumbers={[]}
+        onRetireNumber={onRetire}
+      />
+    );
+    expect(screen.getByTestId('retire-number-button')).toBeTruthy();
+  });
+
+  it('retire button shows the jersey number', () => {
+    const onRetire = vi.fn();
+    render(
+      <FranchiseLegacyView
+        ringOfHonor={[makeRohMember({ jerseyNumber: 10 })]}
+        retiredNumbers={[]}
+        onRetireNumber={onRetire}
+      />
+    );
+    expect(screen.getByText('Retire #10')).toBeTruthy();
+  });
+
+  it('calls onRetireNumber with (playerId, jerseyNumber) when clicked', () => {
+    const onRetire = vi.fn();
+    render(
+      <FranchiseLegacyView
+        ringOfHonor={[makeRohMember({ id: 'p-legend', jerseyNumber: 10 })]}
+        retiredNumbers={[]}
+        onRetireNumber={onRetire}
+      />
+    );
+    fireEvent.click(screen.getByTestId('retire-number-button'));
+    expect(onRetire).toHaveBeenCalledOnce();
+    expect(onRetire).toHaveBeenCalledWith('p-legend', 10);
+  });
+
+  it('does not render retire button when number is already retired', () => {
+    const onRetire = vi.fn();
+    render(
+      <FranchiseLegacyView
+        ringOfHonor={[makeRohMember({ jerseyNumber: 10 })]}
+        retiredNumbers={[10]}
+        onRetireNumber={onRetire}
+      />
+    );
+    expect(screen.queryByTestId('retire-number-button')).toBeNull();
+  });
+
+  it('shows retired badge instead when number is already retired', () => {
+    render(
+      <FranchiseLegacyView
+        ringOfHonor={[makeRohMember({ jerseyNumber: 10 })]}
+        retiredNumbers={[10]}
+        onRetireNumber={vi.fn()}
+      />
+    );
+    expect(screen.getByTestId('jersey-retired-badge')).toBeTruthy();
+    expect(screen.getByText(/10 Retired/i)).toBeTruthy();
+  });
+
+  it('does not render retire button when onRetireNumber is not provided', () => {
+    render(
+      <FranchiseLegacyView
+        ringOfHonor={[makeRohMember()]}
+        retiredNumbers={[]}
+      />
+    );
+    expect(screen.queryByTestId('retire-number-button')).toBeNull();
+  });
+
+  it('does not render retire button when ROH member has no jerseyNumber', () => {
+    const onRetire = vi.fn();
+    render(
+      <FranchiseLegacyView
+        ringOfHonor={[makeRohMember({ jerseyNumber: null })]}
+        retiredNumbers={[]}
+        onRetireNumber={onRetire}
+      />
+    );
+    expect(screen.queryByTestId('retire-number-button')).toBeNull();
+  });
+});
+
+// ── Empty state safety ────────────────────────────────────────────────────────
+
+describe('FranchiseLegacyView — combined empty states render safely', () => {
+  it('renders without crash when all props are empty/default', () => {
+    expect(() =>
+      render(
+        <FranchiseLegacyView
+          ringOfHonor={[]}
+          allTimeLeaders={null}
+          pendingRohCandidates={[]}
+          retiredNumbers={[]}
+          retiredNumberDisplay={[]}
+        />
+      )
+    ).not.toThrow();
+  });
+
+  it('shows empty state for retired numbers section', () => {
+    render(<FranchiseLegacyView retiredNumberDisplay={[]} />);
+    expect(screen.getByTestId('retired-numbers-empty')).toBeTruthy();
+  });
+
+  it('still renders other sections when retiredNumbers is empty', () => {
+    render(<FranchiseLegacyView retiredNumberDisplay={[]} />);
+    expect(screen.getByTestId('franchise-legacy-view')).toBeTruthy();
+    expect(screen.getByText('Ring of Honor')).toBeTruthy();
+    expect(screen.getByText('Retired Numbers')).toBeTruthy();
+  });
+});

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -16,6 +16,7 @@ import { buildGameBookDestination } from '../utils/managementScreenRouting.js';
 import ChronicleHeadlineBanner from './ChronicleHeadlineBanner.tsx';
 import CombineDashboard from './CombineDashboard.jsx';
 import FranchiseLegacyView from './FranchiseLegacyView.jsx';
+import FranchiseBrandHQ from './FranchiseBrandHQ.jsx';
 
 const BOTTOM_NAV_ITEMS = [
   { label: 'Home', route: 'HQ', icon: 'home', active: true },
@@ -1085,16 +1086,36 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
         );
       })()}
 
-      {/* ── Franchise Legacy: Ring of Honor & All-Time Leaders ── */}
+      {/* ── Championship Wall ── */}
       {(() => {
-        const rohMembers   = Array.isArray(league?.ringOfHonor) ? league.ringOfHonor : [];
-        const atLeaders    = league?.allTimeLeaders ?? null;
-        const rohCandidates = Array.isArray(league?.pendingRohCandidates) ? league.pendingRohCandidates : [];
-        const hasLegacyData = rohMembers.length > 0 || rohCandidates.length > 0;
+        const champYears = Array.isArray(league?.championshipYears) ? league.championshipYears : [];
+        if (champYears.length === 0) return null;
+        return (
+          <div style={{ padding: '0 12px', marginBottom: 4 }}>
+            <FranchiseBrandHQ championshipYears={champYears} />
+          </div>
+        );
+      })()}
+
+      {/* ── Franchise Legacy: Ring of Honor, Retired Numbers & All-Time Leaders ── */}
+      {(() => {
+        const rohMembers         = Array.isArray(league?.ringOfHonor) ? league.ringOfHonor : [];
+        const atLeaders          = league?.allTimeLeaders ?? null;
+        const rohCandidates      = Array.isArray(league?.pendingRohCandidates) ? league.pendingRohCandidates : [];
+        const retiredNums        = Array.isArray(league?.retiredNumbers) ? league.retiredNumbers : [];
+        const retiredNumDisplay  = Array.isArray(league?.retiredNumberDisplay) ? league.retiredNumberDisplay : [];
+        const hasLegacyData = rohMembers.length > 0 || rohCandidates.length > 0 || retiredNums.length > 0;
 
         const handleInduct = (playerId, teamId) => {
           if (actions?.send) {
             actions.send('INDUCT_PLAYER_TO_ROH', { playerId, teamId });
+          }
+        };
+
+        const handleRetireNumber = (playerId, jerseyNumber) => {
+          if (actions?.send) {
+            const userTeamId = league?.userTeamId ?? league?.teams?.[0]?.id;
+            actions.send('RETIRE_JERSEY_NUMBER', { teamId: userTeamId, playerId });
           }
         };
 
@@ -1106,7 +1127,10 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
               ringOfHonor={rohMembers}
               allTimeLeaders={atLeaders}
               pendingRohCandidates={rohCandidates}
+              retiredNumbers={retiredNums}
+              retiredNumberDisplay={retiredNumDisplay}
               onInduct={handleInduct}
+              onRetireNumber={handleRetireNumber}
             />
           </div>
         );

--- a/src/ui/components/FranchiseLegacyView.jsx
+++ b/src/ui/components/FranchiseLegacyView.jsx
@@ -14,11 +14,13 @@ function formatStatValue(v) {
 
 // ── Ring of Honor gallery ─────────────────────────────────────────────────────
 
-function RohCard({ member }) {
+function RohCard({ member, onRetireNumber, retiredNumbers = [] }) {
   const { name, position, jerseyNumber, yearsPlayedWithTeam, accolades, inductionYear,
           totalPassingYards, totalRushingYards, totalReceivingYards, totalSacks } = member;
 
   const hasStats = totalPassingYards || totalRushingYards || totalReceivingYards || totalSacks;
+  const numRetired = jerseyNumber != null && Array.isArray(retiredNumbers) && retiredNumbers.includes(Number(jerseyNumber));
+  const canRetire  = jerseyNumber != null && !numRetired && typeof onRetireNumber === 'function';
 
   return (
     <div
@@ -93,6 +95,92 @@ function RohCard({ member }) {
             </li>
           ))}
         </ul>
+      )}
+
+      {numRetired && (
+        <span
+          data-testid="jersey-retired-badge"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 3,
+            fontSize: 'var(--text-xs, 11px)',
+            color: 'var(--warning, #f59e0b)',
+            fontWeight: 700,
+          }}
+        >
+          ★ #{jerseyNumber} Retired
+        </span>
+      )}
+
+      {canRetire && (
+        <button
+          data-testid="retire-number-button"
+          type="button"
+          onClick={() => onRetireNumber(member.id, member.jerseyNumber)}
+          style={{
+            marginTop: 2,
+            padding: '4px 10px',
+            borderRadius: 'var(--radius-sm, 4px)',
+            background: 'transparent',
+            color: 'var(--warning, #f59e0b)',
+            border: '1px solid rgba(245, 158, 11, 0.35)',
+            fontSize: 'var(--text-xs, 11px)',
+            fontWeight: 600,
+            cursor: 'pointer',
+            alignSelf: 'flex-start',
+          }}
+        >
+          Retire #{jerseyNumber}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── Retired Numbers panel ─────────────────────────────────────────────────────
+
+function RetiredNumbersPanel({ retiredNumberDisplay }) {
+  const items = Array.isArray(retiredNumberDisplay) ? retiredNumberDisplay : [];
+
+  return (
+    <div data-testid="retired-numbers-panel">
+      {items.length > 0 ? (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+          {items.map(({ jerseyNumber, surname }) => (
+            <span
+              key={jerseyNumber}
+              data-testid="retired-number-badge"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                padding: '3px 10px',
+                borderRadius: '6px',
+                background: 'rgba(245, 158, 11, 0.08)',
+                border: '1px solid rgba(245, 158, 11, 0.25)',
+                color: 'var(--warning, #f59e0b)',
+                fontSize: 'var(--text-sm, 13px)',
+                fontWeight: 700,
+                letterSpacing: '0.03em',
+              }}
+            >
+              #{jerseyNumber}{surname ? ` ${surname.toUpperCase()}` : ''}
+            </span>
+          ))}
+        </div>
+      ) : (
+        <p
+          data-testid="retired-numbers-empty"
+          style={{
+            margin: 0,
+            color: 'var(--text-muted)',
+            fontSize: 'var(--text-sm, 13px)',
+            textAlign: 'center',
+            padding: 'var(--space-4, 16px) 0',
+          }}
+        >
+          No retired numbers yet.
+        </p>
       )}
     </div>
   );
@@ -218,21 +306,27 @@ function InductionPromptCard({ candidate, onInduct, onDismiss }) {
 // ── Main FranchiseLegacyView ───────────────────────────────────────────────────
 
 /**
- * FranchiseLegacyView — Ring of Honor gallery + franchise leaders panel.
+ * FranchiseLegacyView — Ring of Honor gallery + franchise leaders + retired numbers.
  *
  * Props:
  *   ringOfHonor          {Object[]} - Array of ROH members
  *   allTimeLeaders       {Object}   - { passingYards, rushingYards, receivingYards, sacks }
  *   pendingRohCandidates {Object[]} - Pending induction notifications
+ *   retiredNumbers       {number[]} - Array of retired jersey numbers
+ *   retiredNumberDisplay {Object[]} - Display objects: { jerseyNumber, surname }
  *   onInduct             {Function} - (playerId, teamId) => void
  *   onDismissCandidate   {Function} - (playerId) => void (optional)
+ *   onRetireNumber       {Function} - (playerId, jerseyNumber) => void (optional)
  */
 export default function FranchiseLegacyView({
   ringOfHonor = [],
   allTimeLeaders = null,
   pendingRohCandidates = [],
+  retiredNumbers = [],
+  retiredNumberDisplay = [],
   onInduct,
   onDismissCandidate,
+  onRetireNumber,
 }) {
   const hasCandidates = Array.isArray(pendingRohCandidates) && pendingRohCandidates.length > 0;
   const hasMembers    = Array.isArray(ringOfHonor) && ringOfHonor.length > 0;
@@ -277,7 +371,12 @@ export default function FranchiseLegacyView({
             }}
           >
             {ringOfHonor.map((member) => (
-              <RohCard key={member.id ?? member.name} member={member} />
+              <RohCard
+                key={member.id ?? member.name}
+                member={member}
+                onRetireNumber={onRetireNumber}
+                retiredNumbers={retiredNumbers}
+              />
             ))}
           </div>
         ) : (
@@ -294,6 +393,16 @@ export default function FranchiseLegacyView({
             No members yet. Legends earn their place here after retirement.
           </p>
         )}
+      </SectionCard>
+
+      {/* Retired Numbers panel */}
+      <SectionCard
+        title="Retired Numbers"
+        subtitle="Jersey numbers retired by this franchise."
+        variant="compact"
+        data-testid="retired-numbers-section"
+      >
+        <RetiredNumbersPanel retiredNumberDisplay={retiredNumberDisplay} />
       </SectionCard>
 
       {/* All-time franchise leaders */}

--- a/src/worker/protocol.js
+++ b/src/worker/protocol.js
@@ -194,6 +194,9 @@ export const toWorker = Object.freeze({
 
   /** Franchise Legacy — Ring of Honor */
   INDUCT_PLAYER_TO_ROH:         'INDUCT_PLAYER_TO_ROH',         // { playerId, teamId }
+
+  /** Franchise Legacy — Jersey Retirement */
+  RETIRE_JERSEY_NUMBER:         'RETIRE_JERSEY_NUMBER',         // { teamId, playerId }
 });
 
 // ─────────────────────────────────────────────

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -261,6 +261,14 @@ import {
   updateLeagueTeamAllTimeLeaders,
   buildRingOfHonorNotification,
 } from '../core/history/legacyEngine.js';
+import {
+  appendChampionshipYear,
+  retireJerseyNumber,
+  isRetiredNumber,
+  findAvailableJerseyNumber,
+  buildRetiredNumberDisplay,
+  derivePreferredJerseyNumber,
+} from '../core/history/teamIdentityEngine.js';
 import { ensurePersonalityProfile, mentorshipBonusForPlayer, contractPersonalityModifier } from '../core/development/personalitySystem.js';
 import { applyTeamCultureWeek, classifyTeamCulture, buildTeamCultureNarrative, TEAM_CULTURE_DEFAULT } from '../core/teamCulture.js';
 import { selectCultureAlerts } from '../core/broadcastNarrative.js';
@@ -1244,6 +1252,20 @@ function buildViewState() {
       return t?.allTimeLeaders ?? { passingYards: null, rushingYards: null, receivingYards: null, sacks: null };
     })(),
     pendingRohCandidates: Array.isArray(meta?.pendingRohCandidates) ? meta.pendingRohCandidates : [],
+    // ── Team Identity — Retired Numbers & Championship Wall ──────────────────
+    retiredNumbers: (() => {
+      const t = cache.getTeam(meta?.userTeamId);
+      return Array.isArray(t?.retiredNumbers) ? t.retiredNumbers : [];
+    })(),
+    championshipYears: (() => {
+      const t = cache.getTeam(meta?.userTeamId);
+      return Array.isArray(t?.championshipYears) ? t.championshipYears : [];
+    })(),
+    retiredNumberDisplay: (() => {
+      const t = cache.getTeam(meta?.userTeamId);
+      const roh = Array.isArray(t?.ringOfHonor) ? t.ringOfHonor : [];
+      return buildRetiredNumberDisplay(t ?? {}, roh);
+    })(),
   };
 }
 
@@ -3450,6 +3472,14 @@ async function handleAdvanceWeek(payload, id) {
         post(toUI.NOTIFICATION, { level: 'info', message: `🏆 ${champ.name} win the Super Bowl! Season complete.` });
         await NewsEngine.logAward('SUPER_BOWL', champ);
         const titleNews = createNewsItem('championship_won', { teamName: champ?.name, season: meta?.season, teamId: champ?.id }, week, meta?.season);
+        // ── Championship Wall: record title year on the winning team ────────────
+        const champYear = Number(meta?.year ?? meta?.season ?? 0);
+        if (champYear > 0 && Number.isFinite(wId)) {
+          const champUpdated = appendChampionshipYear(champ, champYear);
+          if (champUpdated !== champ) {
+            cache.updateTeam(wId, { championshipYears: champUpdated.championshipYears });
+          }
+        }
         cache.setMeta(addNewsItem(cache.getMeta(), titleNews));
       }
     }
@@ -6801,6 +6831,62 @@ async function handleInductPlayerToRoh({ playerId, teamId }, id) {
   post(toUI.STATE_UPDATE, buildViewState(), id);
 }
 
+// ── Handler: RETIRE_JERSEY_NUMBER ─────────────────────────────────────────────
+
+async function handleRetireJerseyNumber({ teamId, playerId }, id) {
+  const meta = getSafeMeta();
+  if (!meta) { post(toUI.ERROR, { message: 'No league loaded' }, id); return; }
+
+  const numTeamId = Number(teamId);
+  const team = cache.getTeam(numTeamId);
+  if (!team) {
+    post(toUI.ERROR, { message: 'Team not found for jersey retirement.' }, id);
+    return;
+  }
+
+  // Find the player in the Ring of Honor or retired pool
+  let player = cache.getPlayer(playerId);
+  if (!player) {
+    // Check retiredPlayers in meta
+    const retired = Array.isArray(meta?.retiredPlayers) ? meta.retiredPlayers : [];
+    player = retired.find((p) => String(p?.id) === String(playerId)) ?? null;
+  }
+  if (!player) {
+    try { player = await Players.load(playerId); } catch (_) { player = null; }
+  }
+  if (!player) {
+    post(toUI.ERROR, { message: 'Player not found for jersey retirement.' }, id);
+    return;
+  }
+
+  const jerseyNum = Number(player?.jerseyNumber);
+  if (!Number.isFinite(jerseyNum) || jerseyNum < 1 || jerseyNum > 99) {
+    post(toUI.ERROR, { message: `Player does not have a valid jersey number (got ${player?.jerseyNumber ?? 'none'}).` }, id);
+    return;
+  }
+
+  // Check for duplicate
+  if (isRetiredNumber(team, jerseyNum)) {
+    post(toUI.ERROR, { message: `#${jerseyNum} is already retired by this franchise.` }, id);
+    return;
+  }
+
+  const updatedTeam = retireJerseyNumber(team, player);
+  cache.updateTeam(numTeamId, { retiredNumbers: updatedTeam.retiredNumbers });
+
+  try {
+    await NewsEngine.logNews(
+      'FRANCHISE',
+      `The ${team.name} retire #${jerseyNum} in honor of ${player.name}.`,
+      numTeamId,
+      { category: 'jersey_retirement', playerId: String(playerId), jerseyNumber: jerseyNum },
+    );
+  } catch (_) { /* non-fatal */ }
+
+  await flushDirty();
+  post(toUI.STATE_UPDATE, buildViewState(), id);
+}
+
 async function handleResetLeague(payload, id) {
   _saveIsExplicitlyLoaded = false;
   await clearAllData();
@@ -6856,6 +6942,19 @@ async function handleSignPlayer({ playerId, teamId, contract }, id) {
 
   const oldTeamId = player.teamId;
   const continuity = getOffseasonReturnSnapshot(player.id, resolvedTeamId, meta);
+
+  // ── Jersey number guard: avoid retired numbers on sign ────────────────────
+  const signTeam = cache.getTeam(resolvedTeamId);
+  const signRetiredNums = Array.isArray(signTeam?.retiredNumbers) ? signTeam.retiredNumbers : [];
+  const signRosterNums = cache.getPlayersByTeam(resolvedTeamId)
+    .map((p) => Number(p.jerseyNumber))
+    .filter((n) => Number.isFinite(n));
+  const signExistingNum = Number(player.jerseyNumber);
+  const signPreferred = (Number.isFinite(signExistingNum) && signExistingNum >= 1 && signExistingNum <= 99)
+    ? signExistingNum
+    : derivePreferredJerseyNumber(player.pos ?? '', player.id ?? '');
+  const signAssignedNum = findAvailableJerseyNumber(signPreferred, signRetiredNums, signRosterNums);
+
   cache.updatePlayer(player.id, {
     teamId: resolvedTeamId,
     contract,
@@ -6868,6 +6967,7 @@ async function handleSignPlayer({ playerId, teamId, contract }, id) {
       teamId: Number(resolvedTeamId),
       season: Number(meta?.year ?? 0),
     } : player?.chemistryContinuity,
+    ...(signAssignedNum != null ? { jerseyNumber: signAssignedNum } : {}),
   });
   recordOffseasonFaMovement({
     player,
@@ -10174,10 +10274,24 @@ function _executeDraftPick(pickIndex, playerId, teamId) {
   // Sign player to slotted rookie contract — value determined by overall pick position
   const overallPick = pk?.overall ?? (pickIndex + 1);
   const draftYear = meta?.year ?? 2025;
+
+  // ── Jersey number guard: avoid retired numbers ────────────────────────────
+  const draftTeam = cache.getTeam(teamId);
+  const retiredNums = Array.isArray(draftTeam?.retiredNumbers) ? draftTeam.retiredNumbers : [];
+  const rosterNums = cache.getPlayersByTeam(teamId)
+    .map((p) => Number(p.jerseyNumber))
+    .filter((n) => Number.isFinite(n));
+  const existingNum = Number(player.jerseyNumber);
+  const preferredNum = (Number.isFinite(existingNum) && existingNum >= 1 && existingNum <= 99)
+    ? existingNum
+    : derivePreferredJerseyNumber(player.pos ?? '', player.id ?? '');
+  const assignedNum = findAvailableJerseyNumber(preferredNum, retiredNums, rosterNums);
+
   cache.updatePlayer(playerId, {
     teamId,
     status: 'active',
     contract: generateSlottedRookieContract(overallPick, draftYear),
+    ...(assignedNum != null ? { jerseyNumber: assignedNum } : {}),
   });
 
   recalculateTeamCap(teamId);
@@ -14290,6 +14404,7 @@ async function handleMessage(event) {
       case toWorker.RELOCATE_TEAM:        return await handleRelocateTeam(payload, id);
       case toWorker.GET_BOX_SCORE:        return await handleGetBoxScore(payload, id);
       case toWorker.INDUCT_PLAYER_TO_ROH: return await handleInductPlayerToRoh(payload, id);
+      case toWorker.RETIRE_JERSEY_NUMBER: return await handleRetireJerseyNumber(payload, id);
       case toWorker.UPDATE_STRATEGY:    return await handleUpdateStrategy(payload, id);
 
       // ── Draft & Offseason ──────────────────────────────────────────────────


### PR DESCRIPTION
Add per-team retiredNumbers and championshipYears fields with backward-compatible
hydration for old saves, a pure teamIdentityEngine module with deterministic jersey
assignment (no Math.random), RETIRE_JERSEY_NUMBER worker action, championship year
harvesting at Super Bowl rollover, jersey-assignment guards on draft and FA signing
paths, FranchiseBrandHQ championship wall component, and a retired numbers panel
with retire-number buttons in FranchiseLegacyView.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XXAj94pRY9DnrVDwxSmCLt