### PR TITLE
feat(awards): Pro Bowl & All-Pro Prestige Engine

### DIFF
--- a/src/core/awards/prestigeEngine.integration.test.js
+++ b/src/core/awards/prestigeEngine.integration.test.js
@@ -1,0 +1,496 @@
+/**
+ * prestigeEngine.integration.test.js
+ *
+ * Integration-level tests for the Pro Bowl & All-Pro Prestige Engine.
+ * Tests the full pipeline (rankPrestigeCandidates → select* → merge → summary)
+ * without touching Web Worker or IndexedDB.
+ *
+ * Coverage:
+ *  - Old saves hydrate missing honorsHistory safely
+ *  - End-of-season flow assigns honors exactly once per player
+ *  - Replaying the pipeline does not duplicate honors (rerun-safe)
+ *  - mergeHonorsIntoPlayers persists accolade objects to retired-player path
+ *  - buildSeasonHonorsSummary populates grouped view data
+ *  - Prior-season prestige changes agent negotiation demand
+ *  - Shark + prior-season All-Pro gets extra premium over non-Shark
+ *  - Legends browser timeline receives honor accolade strings without regression
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  rankPrestigeCandidates,
+  selectAllProTeams,
+  selectProBowlTeams,
+  mergeHonorsIntoPlayers,
+  buildSeasonHonorsSummary,
+  getPriorSeasonPrestigePremium,
+  PRESTIGE_QUOTAS,
+} from './prestigeEngine.js';
+import {
+  computeAgentExpectedSalary,
+  generateDeterministicAgentProfile,
+  AGENT_ARCHETYPES,
+} from '../contracts/agentNegotiationEngine.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const SEASON = 2025;
+
+function makePlayer(overrides = {}) {
+  return {
+    id: String(Math.random()),
+    name: 'Player',
+    pos: 'QB',
+    ovr: 80,
+    teamId: 1,
+    honorsHistory: [],
+    accolades: [],
+    careerStats: [],
+    stats: { season: {} },
+    ...overrides,
+  };
+}
+
+function makeCareerStats(season, statOverrides = {}) {
+  return {
+    season,
+    passYds: 0, passTDs: 0, ints: 0,
+    rushYds: 0, rushTDs: 0,
+    recYds: 0, recTDs: 0, receptions: 0,
+    sacks: 0, tackles: 0,
+    ...statOverrides,
+  };
+}
+
+function makeTeam(id, conf, overrides = {}) {
+  return { id, conf, name: `Team${id}`, abbr: `T${id}`, ...overrides };
+}
+
+function teamResolver(teamMap) {
+  return (id) => teamMap[id] ?? null;
+}
+
+// Build a pool of players that will fill all slots with clear ordering.
+function buildPlayerPool() {
+  const teams = {
+    1: makeTeam(1, 0, { name: 'Eagles', abbr: 'PHI' }),   // AFC
+    2: makeTeam(2, 1, { name: 'Cowboys', abbr: 'DAL' }),   // NFC
+    3: makeTeam(3, 0, { name: 'Ravens', abbr: 'BAL' }),    // AFC
+    4: makeTeam(4, 1, { name: 'Packers', abbr: 'GB' }),    // NFC
+    5: makeTeam(5, 0),
+    6: makeTeam(6, 1),
+    7: makeTeam(7, 0),
+    8: makeTeam(8, 1),
+  };
+
+  // 6 QBs: 3 AFC, 3 NFC (need 4 per conf for Pro Bowl)
+  const qbs = [];
+  for (let i = 0; i < 3; i++) {
+    qbs.push(makePlayer({
+      id: `qb_afc_${i}`, name: `AFC QB ${i}`, pos: 'QB', teamId: 1,
+      ovr: 90 - i,
+      careerStats: [makeCareerStats(SEASON, { passYds: 4500 - i * 200, passTDs: 35 - i * 2, ints: 8 })],
+    }));
+  }
+  for (let i = 0; i < 3; i++) {
+    qbs.push(makePlayer({
+      id: `qb_nfc_${i}`, name: `NFC QB ${i}`, pos: 'QB', teamId: 2,
+      ovr: 88 - i,
+      careerStats: [makeCareerStats(SEASON, { passYds: 4300 - i * 200, passTDs: 33 - i * 2, ints: 9 })],
+    }));
+  }
+
+  // 6 RBs: 3 AFC, 3 NFC
+  const rbs = [];
+  for (let i = 0; i < 3; i++) {
+    rbs.push(makePlayer({
+      id: `rb_afc_${i}`, name: `AFC RB ${i}`, pos: 'RB', teamId: 3,
+      ovr: 88 - i,
+      careerStats: [makeCareerStats(SEASON, { rushYds: 1400 - i * 100, rushTDs: 12 - i, receptions: 40 })],
+    }));
+  }
+  for (let i = 0; i < 3; i++) {
+    rbs.push(makePlayer({
+      id: `rb_nfc_${i}`, name: `NFC RB ${i}`, pos: 'RB', teamId: 4,
+      ovr: 86 - i,
+      careerStats: [makeCareerStats(SEASON, { rushYds: 1300 - i * 100, rushTDs: 11 - i, receptions: 35 })],
+    }));
+  }
+
+  // 8 WRs: 4 AFC, 4 NFC
+  const wrs = [];
+  for (let i = 0; i < 4; i++) {
+    wrs.push(makePlayer({
+      id: `wr_afc_${i}`, name: `AFC WR ${i}`, pos: 'WR', teamId: 5,
+      ovr: 88 - i,
+      careerStats: [makeCareerStats(SEASON, { recYds: 1400 - i * 100, recTDs: 12 - i, receptions: 100 - i * 5 })],
+    }));
+  }
+  for (let i = 0; i < 4; i++) {
+    wrs.push(makePlayer({
+      id: `wr_nfc_${i}`, name: `NFC WR ${i}`, pos: 'WR', teamId: 6,
+      ovr: 86 - i,
+      careerStats: [makeCareerStats(SEASON, { recYds: 1300 - i * 100, recTDs: 11 - i, receptions: 95 - i * 5 })],
+    }));
+  }
+
+  // 8 DLs: 4 AFC, 4 NFC
+  const dls = [];
+  for (let i = 0; i < 4; i++) {
+    dls.push(makePlayer({
+      id: `dl_afc_${i}`, name: `AFC DL ${i}`, pos: 'DL', teamId: 7,
+      ovr: 88 - i,
+      careerStats: [makeCareerStats(SEASON, { sacks: 18 - i, tackles: 40 - i * 2 })],
+    }));
+  }
+  for (let i = 0; i < 4; i++) {
+    dls.push(makePlayer({
+      id: `dl_nfc_${i}`, name: `NFC DL ${i}`, pos: 'DL', teamId: 8,
+      ovr: 86 - i,
+      careerStats: [makeCareerStats(SEASON, { sacks: 16 - i, tackles: 35 - i * 2 })],
+    }));
+  }
+
+  return { players: [...qbs, ...rbs, ...wrs, ...dls], teams };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Prestige Engine — integration', () => {
+
+  describe('old save hydration', () => {
+    it('player missing honorsHistory gets empty array (no crash)', () => {
+      const player = makePlayer({ honorsHistory: undefined });
+      const hydrated = Array.isArray(player?.honorsHistory) ? player.honorsHistory : [];
+      expect(hydrated).toEqual([]);
+    });
+
+    it('mergeHonorsIntoPlayers handles player with no honorsHistory field', () => {
+      const player = { id: 'p1', name: 'Old Player', pos: 'QB' };
+      const ha = { playerId: 'p1', playerName: 'Old Player', pos: 'QB', prestigePos: 'QB',
+        teamId: 1, teamName: 'Eagles', teamAbbr: 'PHI', type: 'FIRST_TEAM_ALL_PRO',
+        year: SEASON, score: 500 };
+      const result = mergeHonorsIntoPlayers([player], [ha], SEASON);
+      expect(result[0].honorsHistory).toHaveLength(1);
+      expect(result[0].honorsHistory[0].type).toBe('FIRST_TEAM_ALL_PRO');
+    });
+  });
+
+  describe('end-of-season flow', () => {
+    it('assigns All-Pro honors to top performers per position', () => {
+      const { players, teams } = buildPlayerPool();
+      const ranked = rankPrestigeCandidates(players, teamResolver(teams), SEASON);
+      const allPro = selectAllProTeams(ranked, SEASON);
+
+      // Should have 2 first-team + 2 second-team per position × 4 positions = 16
+      expect(allPro).toHaveLength(16);
+
+      const firstTeam = allPro.filter(a => a.type === 'FIRST_TEAM_ALL_PRO');
+      const secondTeam = allPro.filter(a => a.type === 'SECOND_TEAM_ALL_PRO');
+      expect(firstTeam).toHaveLength(8); // 2 per pos × 4 pos
+      expect(secondTeam).toHaveLength(8);
+    });
+
+    it('assigns Pro Bowl honors per conference within quota', () => {
+      const { players, teams } = buildPlayerPool();
+      const ranked = rankPrestigeCandidates(players, teamResolver(teams), SEASON);
+      const proBowl = selectProBowlTeams(ranked, SEASON);
+
+      // QB: 4 per conf, but only 3 per conf available → 6 total QBs
+      const qbPB = proBowl.filter(a => a.prestigePos === 'QB');
+      expect(qbPB).toHaveLength(6); // 3 AFC + 3 NFC
+
+      // RB: 4 per conf, 3 per conf available → 6 total RBs
+      const rbPB = proBowl.filter(a => a.prestigePos === 'RB');
+      expect(rbPB).toHaveLength(6);
+
+      // WR: 6 per conf, 4 per conf available → 8 total WRs
+      const wrPB = proBowl.filter(a => a.prestigePos === 'WR');
+      expect(wrPB).toHaveLength(8);
+
+      // DL: 6 per conf, 4 per conf available → 8 total DLs
+      const dlPB = proBowl.filter(a => a.prestigePos === 'DL');
+      expect(dlPB).toHaveLength(8);
+    });
+
+    it('players with unknown conference (conf=-1) are skipped for Pro Bowl', () => {
+      const unknownTeam = { id: 99, conf: 'UNKNOWN', name: 'Unknown', abbr: 'UNK' };
+      const unknownPlayer = makePlayer({
+        id: 'qb_unk', name: 'Unknown QB', pos: 'QB', teamId: 99, ovr: 99,
+        careerStats: [makeCareerStats(SEASON, { passYds: 9999, passTDs: 99, ints: 0 })],
+      });
+      const { players, teams } = buildPlayerPool();
+      const allPlayers = [...players, unknownPlayer];
+      const allTeams = { ...teams, 99: unknownTeam };
+      const ranked = rankPrestigeCandidates(allPlayers, teamResolver(allTeams), SEASON);
+      const proBowl = selectProBowlTeams(ranked, SEASON);
+      const unknownEntry = proBowl.find(a => a.playerId === 'qb_unk');
+      expect(unknownEntry).toBeUndefined();
+    });
+
+    it('top-ranked player appears as FIRST_TEAM_ALL_PRO at their position', () => {
+      const { players, teams } = buildPlayerPool();
+      const ranked = rankPrestigeCandidates(players, teamResolver(teams), SEASON);
+      const allPro = selectAllProTeams(ranked, SEASON);
+      const firstQB = allPro.find(a => a.prestigePos === 'QB' && a.type === 'FIRST_TEAM_ALL_PRO');
+      expect(firstQB?.playerId).toBe('qb_afc_0'); // highest score
+    });
+  });
+
+  describe('rerun safety', () => {
+    it('replaying merge does not duplicate honors', () => {
+      const { players, teams } = buildPlayerPool();
+      const ranked = rankPrestigeCandidates(players, teamResolver(teams), SEASON);
+      const allPro = selectAllProTeams(ranked, SEASON);
+      const proBowl = selectProBowlTeams(ranked, SEASON);
+      const allAssignments = [...allPro, ...proBowl];
+
+      // First merge
+      const merged1 = mergeHonorsIntoPlayers(players, allAssignments, SEASON);
+      // Second merge (replay)
+      const merged2 = mergeHonorsIntoPlayers(merged1, allAssignments, SEASON);
+
+      // Player with honors should not have duplicates
+      const honored = merged2.find(p => p.honorsHistory?.length > 0);
+      if (honored) {
+        const keys = honored.honorsHistory.map(h => `${h.year}_${h.type}`);
+        const unique = new Set(keys);
+        expect(unique.size).toBe(keys.length);
+      }
+    });
+
+    it('unchanged players return same object reference', () => {
+      const noHonorPlayer = makePlayer({ id: 'nobody', pos: 'QB', teamId: 1 });
+      const result = mergeHonorsIntoPlayers([noHonorPlayer], [], SEASON);
+      expect(result[0]).toBe(noHonorPlayer);
+    });
+
+    it('honors are idempotent across two identical runs', () => {
+      const { players, teams } = buildPlayerPool();
+      const ranked = rankPrestigeCandidates(players, teamResolver(teams), SEASON);
+      const allPro = selectAllProTeams(ranked, SEASON);
+
+      const merged1 = mergeHonorsIntoPlayers(players, allPro, SEASON);
+      const merged2 = mergeHonorsIntoPlayers(merged1, allPro, SEASON);
+
+      for (let i = 0; i < players.length; i++) {
+        const h1 = merged1[i].honorsHistory?.length ?? 0;
+        const h2 = merged2[i].honorsHistory?.length ?? 0;
+        expect(h2).toBe(h1);
+      }
+    });
+  });
+
+  describe('accolades for retired-player path', () => {
+    it('mergeHonorsIntoPlayers writes accolade objects to player.accolades', () => {
+      const player = makePlayer({ id: 'ret1', pos: 'DL', teamId: 1 });
+      const ha = {
+        playerId: 'ret1', playerName: 'Ret DL', pos: 'DL', prestigePos: 'DL',
+        teamId: 1, teamName: 'Eagles', teamAbbr: 'PHI',
+        type: 'PRO_BOWL', year: SEASON, score: 120,
+      };
+      const [updated] = mergeHonorsIntoPlayers([player], [ha], SEASON);
+      expect(updated.accolades).toHaveLength(1);
+      expect(updated.accolades[0]).toMatchObject({ type: 'PRO_BOWL', year: SEASON, seasonId: SEASON });
+    });
+
+    it('does not overwrite existing accolades of different type', () => {
+      const existing = { type: 'MVP', year: SEASON - 1, seasonId: SEASON - 1 };
+      const player = makePlayer({ id: 'ret2', pos: 'QB', teamId: 1, accolades: [existing] });
+      const ha = {
+        playerId: 'ret2', playerName: 'Vet QB', pos: 'QB', prestigePos: 'QB',
+        teamId: 1, teamName: 'Eagles', teamAbbr: 'PHI',
+        type: 'FIRST_TEAM_ALL_PRO', year: SEASON, score: 500,
+      };
+      const [updated] = mergeHonorsIntoPlayers([player], [ha], SEASON);
+      expect(updated.accolades).toHaveLength(2);
+      expect(updated.accolades.some(a => a.type === 'MVP')).toBe(true);
+      expect(updated.accolades.some(a => a.type === 'FIRST_TEAM_ALL_PRO')).toBe(true);
+    });
+  });
+
+  describe('buildSeasonHonorsSummary', () => {
+    it('populates grouped view data for each honor type', () => {
+      const { players, teams } = buildPlayerPool();
+      const ranked = rankPrestigeCandidates(players, teamResolver(teams), SEASON);
+      const allPro = selectAllProTeams(ranked, SEASON);
+      const proBowl = selectProBowlTeams(ranked, SEASON);
+      const all = [...allPro, ...proBowl];
+
+      const summary = buildSeasonHonorsSummary(players, all, teamResolver(teams));
+
+      expect(summary).toHaveProperty('FIRST_TEAM_ALL_PRO');
+      expect(summary).toHaveProperty('SECOND_TEAM_ALL_PRO');
+      expect(summary).toHaveProperty('PRO_BOWL');
+
+      // Each position group should have entries
+      expect(summary.FIRST_TEAM_ALL_PRO.QB).toBeTruthy();
+      expect(summary.FIRST_TEAM_ALL_PRO.QB.length).toBe(PRESTIGE_QUOTAS.allPro.QB);
+    });
+
+    it('returns empty position groups for missing assignment types', () => {
+      const summary = buildSeasonHonorsSummary([], [], () => null);
+      expect(summary.FIRST_TEAM_ALL_PRO).toEqual({});
+      expect(summary.PRO_BOWL).toEqual({});
+    });
+  });
+
+  describe('contract leverage — prior-season prestige premium', () => {
+    it('prior First-Team All-Pro adds multiplier to expected salary', () => {
+      const base = 10_000_000;
+      const player = makePlayer({
+        id: 'star_qb',
+        pos: 'QB',
+        honorsHistory: [{ year: SEASON - 1, type: 'FIRST_TEAM_ALL_PRO', teamId: 1 }],
+      });
+      // Force a LOYALIST agent (no archetype modifier, isolates prestige)
+      Object.defineProperty(player, 'agent', {
+        value: { archetype: AGENT_ARCHETYPES.LOYALIST, greed: 0, aggressiveness: 0, patience: 0.5 },
+        writable: true,
+      });
+      player.negotiationState = { negotiationsFrozenUntilSeason: null };
+
+      const result = computeAgentExpectedSalary({
+        player,
+        baseFairMarketValue: base,
+        teamContext: { currentSeason: SEASON },
+      });
+
+      // FIRST_TEAM_ALL_PRO → 1.12 multiplier → +12%
+      expect(result.expectedSalary).toBeCloseTo(base * 1.12, 0);
+    });
+
+    it('prior Pro Bowl adds smaller multiplier', () => {
+      const base = 8_000_000;
+      const player = makePlayer({
+        id: 'pb_rb',
+        pos: 'RB',
+        honorsHistory: [{ year: SEASON - 1, type: 'PRO_BOWL', teamId: 1 }],
+      });
+      Object.defineProperty(player, 'agent', {
+        value: { archetype: AGENT_ARCHETYPES.LOYALIST, greed: 0, aggressiveness: 0, patience: 0.5 },
+        writable: true,
+      });
+      player.negotiationState = { negotiationsFrozenUntilSeason: null };
+
+      const result = computeAgentExpectedSalary({
+        player,
+        baseFairMarketValue: base,
+        teamContext: { currentSeason: SEASON },
+      });
+
+      // PRO_BOWL → 1.04 → +4%
+      expect(result.expectedSalary).toBeCloseTo(base * 1.04, 0);
+    });
+
+    it('no prior honors → no prestige premium', () => {
+      const base = 5_000_000;
+      const player = makePlayer({ id: 'nobody_rb', pos: 'RB', honorsHistory: [] });
+      Object.defineProperty(player, 'agent', {
+        value: { archetype: AGENT_ARCHETYPES.LOYALIST, greed: 0, aggressiveness: 0, patience: 0.5 },
+        writable: true,
+      });
+      player.negotiationState = { negotiationsFrozenUntilSeason: null };
+
+      const result = computeAgentExpectedSalary({
+        player,
+        baseFairMarketValue: base,
+        teamContext: { currentSeason: SEASON },
+      });
+
+      expect(result.expectedSalary).toBeCloseTo(base, 0);
+    });
+  });
+
+  describe('Shark + All-Pro extra premium', () => {
+    it('Shark agent with FIRST_TEAM_ALL_PRO gets extra +5% on top of prestige bonus', () => {
+      const base = 10_000_000;
+      const player = makePlayer({
+        id: 'shark_allpro',
+        pos: 'DL',
+        honorsHistory: [{ year: SEASON - 1, type: 'FIRST_TEAM_ALL_PRO', teamId: 1 }],
+      });
+      // Force SHARK with greed=0 so we isolate the prestige bonus
+      Object.defineProperty(player, 'agent', {
+        value: { archetype: AGENT_ARCHETYPES.SHARK, greed: 0, aggressiveness: 0, patience: 0.5 },
+        writable: true,
+      });
+      player.negotiationState = { negotiationsFrozenUntilSeason: null };
+
+      const result = computeAgentExpectedSalary({
+        player,
+        baseFairMarketValue: base,
+        teamContext: { currentSeason: SEASON },
+      });
+
+      // SHARK base with greed=0: modifier=0; FIRST_TEAM_ALL_PRO: +0.12; Shark+AllPro extra: +0.05 → total 1.17×
+      expect(result.expectedSalary).toBeCloseTo(base * 1.17, 0);
+    });
+
+    it('non-Shark agent with FIRST_TEAM_ALL_PRO does NOT get +5% extra', () => {
+      const base = 10_000_000;
+      const player = makePlayer({
+        id: 'loyalist_allpro',
+        pos: 'DL',
+        honorsHistory: [{ year: SEASON - 1, type: 'FIRST_TEAM_ALL_PRO', teamId: 1 }],
+      });
+      Object.defineProperty(player, 'agent', {
+        value: { archetype: AGENT_ARCHETYPES.LOYALIST, greed: 0, aggressiveness: 0, patience: 0.5 },
+        writable: true,
+      });
+      player.negotiationState = { negotiationsFrozenUntilSeason: null };
+
+      const result = computeAgentExpectedSalary({
+        player,
+        baseFairMarketValue: base,
+        teamContext: { currentSeason: SEASON },
+      });
+
+      // LOYALIST: no archetype modifier; FIRST_TEAM_ALL_PRO: +0.12 only → 1.12×
+      expect(result.expectedSalary).toBeCloseTo(base * 1.12, 0);
+    });
+  });
+
+  describe('legends browser / accolade timeline regression', () => {
+    it('honor accolades written by mergeHonorsIntoPlayers have expected shape for timeline', () => {
+      const player = makePlayer({ id: 'legend_qb', pos: 'QB', teamId: 1 });
+      const ha = {
+        playerId: 'legend_qb', playerName: 'Legend QB', pos: 'QB', prestigePos: 'QB',
+        teamId: 1, teamName: 'Eagles', teamAbbr: 'PHI',
+        type: 'FIRST_TEAM_ALL_PRO', year: SEASON, score: 600,
+      };
+      const [updated] = mergeHonorsIntoPlayers([player], [ha], SEASON);
+      const accolade = updated.accolades[0];
+      expect(accolade).toHaveProperty('type', 'FIRST_TEAM_ALL_PRO');
+      expect(accolade).toHaveProperty('year', SEASON);
+      expect(accolade).toHaveProperty('seasonId', SEASON);
+    });
+
+    it('honorsHistory entry has expected shape for legacy export', () => {
+      const player = makePlayer({ id: 'hist_qb', pos: 'QB', teamId: 1 });
+      const ha = {
+        playerId: 'hist_qb', playerName: 'History QB', pos: 'QB', prestigePos: 'QB',
+        teamId: 1, teamName: 'Eagles', teamAbbr: 'PHI',
+        type: 'PRO_BOWL', year: SEASON, score: 200,
+      };
+      const [updated] = mergeHonorsIntoPlayers([player], [ha], SEASON);
+      const h = updated.honorsHistory[0];
+      expect(h).toHaveProperty('year', SEASON);
+      expect(h).toHaveProperty('type', 'PRO_BOWL');
+      expect(h).toHaveProperty('teamId', 1);
+    });
+
+    it('existing non-prestige accolades are preserved', () => {
+      const priorAcc = { type: 'HOF_INDUCTEE', year: SEASON - 2, seasonId: SEASON - 2 };
+      const player = makePlayer({ id: 'hof_legend', pos: 'DL', teamId: 1, accolades: [priorAcc] });
+      const ha = {
+        playerId: 'hof_legend', playerName: 'HOF Legend', pos: 'DL', prestigePos: 'DL',
+        teamId: 1, teamName: 'Ravens', teamAbbr: 'BAL',
+        type: 'SECOND_TEAM_ALL_PRO', year: SEASON, score: 140,
+      };
+      const [updated] = mergeHonorsIntoPlayers([player], [ha], SEASON);
+      expect(updated.accolades.some(a => a.type === 'HOF_INDUCTEE')).toBe(true);
+      expect(updated.accolades.some(a => a.type === 'SECOND_TEAM_ALL_PRO')).toBe(true);
+    });
+  });
+});

--- a/src/core/awards/prestigeEngine.js
+++ b/src/core/awards/prestigeEngine.js
@@ -1,0 +1,385 @@
+/**
+ * prestigeEngine.js — Pro Bowl & All-Pro Prestige Layer
+ *
+ * Pure, deterministic module. No Math.random, no UI imports, no worker imports.
+ * All outputs are immutable new objects.
+ *
+ * Exported API:
+ *   PRESTIGE_QUOTAS                     — per-position slot counts
+ *   mapPlayerToPrestigePosition(player) → string|null
+ *   computePrestigeScore(player)        → number|null
+ *   rankPrestigeCandidates(players, teamResolver) → { QB, RB, WR, DL }
+ *   selectAllProTeams(rankedCandidates, season) → honor[]
+ *   selectProBowlTeams(rankedCandidates, season) → honor[]
+ *   mergeHonorsIntoPlayers(players, assignments, season) → player[]
+ *   buildSeasonHonorsSummary(players, assignments, teamResolver) → grouped UI data
+ *   getPriorSeasonPrestigePremium(player, currentSeason) → { hasPremium, multiplier, type, priorSeason }
+ */
+
+export const PRESTIGE_QUOTAS = Object.freeze({
+  allPro: Object.freeze({ QB: 2, RB: 2, WR: 2, DL: 2 }),
+  proBowlPerConference: Object.freeze({ QB: 4, RB: 4, WR: 6, DL: 6 }),
+});
+
+const _HONOR_ACCOLADE_LABELS = Object.freeze({
+  FIRST_TEAM_ALL_PRO: 'First-Team All-Pro',
+  SECOND_TEAM_ALL_PRO: 'Second-Team All-Pro',
+  PRO_BOWL: 'Pro Bowl Selection',
+});
+
+// ── Position mapping ──────────────────────────────────────────────────────────
+
+/**
+ * Map a player's raw position to a normalized prestige group.
+ * Returns null for positions not covered in v1.
+ *
+ * @param {Object} player
+ * @returns {'QB'|'RB'|'WR'|'DL'|null}
+ */
+export function mapPlayerToPrestigePosition(player) {
+  const pos = String(player?.pos ?? '').toUpperCase();
+  if (pos === 'QB') return 'QB';
+  if (pos === 'RB' || pos === 'FB') return 'RB';
+  if (pos === 'WR') return 'WR';
+  if (pos === 'DL' || pos === 'DE' || pos === 'DT' || pos === 'EDGE') return 'DL';
+  return null;
+}
+
+// ── Score computation ─────────────────────────────────────────────────────────
+
+function _n(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Compute a stat-based prestige score for a player.
+ *
+ * Uses player.careerStats (most-recent or season-matched entry) for season
+ * totals. Falls back to player.stats.season for unit-test fixtures that
+ * don't carry a full careerStats array.
+ *
+ * careerStats keys: passYds, passTDs, ints, rushYds, rushTDs, recYds, recTDs,
+ *                   receptions, sacks, tackles
+ * stats.season keys: passYd, passTD, interceptions, rushYd, rushTD, recYd,
+ *                    recTD, receptions, sacks, tackles
+ *
+ * @param {Object} player
+ * @param {number|string} [seasonYear] - Match careerStats by season field if provided
+ * @returns {number|null} Score, or null for unsupported positions
+ */
+export function computePrestigeScore(player, seasonYear) {
+  const pos = mapPlayerToPrestigePosition(player);
+  if (!pos) return null;
+
+  const careerStats = Array.isArray(player?.careerStats) ? player.careerStats : [];
+
+  let statLine = null;
+  if (seasonYear != null && careerStats.length > 0) {
+    statLine = careerStats.find(l => String(l.season) === String(seasonYear)) ?? null;
+  }
+  if (!statLine && careerStats.length > 0) {
+    statLine = careerStats[careerStats.length - 1];
+  }
+
+  const raw = statLine ?? player?.stats?.season ?? {};
+
+  const passYds = _n(raw.passYds ?? raw.passYd);
+  const passTDs = _n(raw.passTDs ?? raw.passTD);
+  const ints    = _n(raw.ints ?? raw.interceptions);
+  const rushYds = _n(raw.rushYds ?? raw.rushYd);
+  const rushTDs = _n(raw.rushTDs ?? raw.rushTD);
+  const recYds  = _n(raw.recYds ?? raw.recYd);
+  const recTDs  = _n(raw.recTDs ?? raw.recTD);
+  const recs    = _n(raw.receptions);
+  const tackles = _n(raw.tackles);
+  const sacks   = _n(raw.sacks);
+
+  if (pos === 'QB') {
+    return (passYds * 0.1) + (passTDs * 4) - (ints * 2) + (rushYds * 0.1) + (rushTDs * 4);
+  }
+  if (pos === 'RB' || pos === 'WR') {
+    const scrimmageYds = rushYds + recYds;
+    const tds = rushTDs + recTDs;
+    return (scrimmageYds * 0.1) + (tds * 6) + (recs * 0.5);
+  }
+  if (pos === 'DL') {
+    return (sacks * 8) + (tackles * 0.5) + (ints * 6);
+  }
+  return null;
+}
+
+// ── Ranking ───────────────────────────────────────────────────────────────────
+
+function _confNorm(conf) {
+  if (conf === 0 || conf === 'AFC') return 0;
+  if (conf === 1 || conf === 'NFC') return 1;
+  return -1;
+}
+
+/**
+ * Produce deterministic ranked candidate lists per prestige position group.
+ * Sort order: score desc → OVR desc → id asc (string, for ties).
+ *
+ * @param {Object[]} players
+ * @param {Function} teamResolver  (teamId) => team | null
+ * @param {number|string} [seasonYear]
+ * @returns {{ QB: Object[], RB: Object[], WR: Object[], DL: Object[] }}
+ */
+export function rankPrestigeCandidates(players, teamResolver, seasonYear) {
+  const byPos = { QB: [], RB: [], WR: [], DL: [] };
+
+  for (const player of (players ?? [])) {
+    const presPos = mapPlayerToPrestigePosition(player);
+    if (!presPos) continue;
+
+    const score = computePrestigeScore(player, seasonYear);
+    if (score === null) continue;
+
+    const team = teamResolver ? teamResolver(player.teamId) : null;
+    byPos[presPos].push({
+      player,
+      score,
+      conf: _confNorm(team?.conf ?? null),
+      teamId: player.teamId,
+      teamName: team?.name ?? null,
+      teamAbbr: team?.abbr ?? null,
+    });
+  }
+
+  const _cmp = (a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    const oA = Number(a.player.ovr ?? 0);
+    const oB = Number(b.player.ovr ?? 0);
+    if (oB !== oA) return oB - oA;
+    return String(a.player.id).localeCompare(String(b.player.id));
+  };
+
+  for (const pos of Object.keys(byPos)) {
+    byPos[pos] = [...byPos[pos]].sort(_cmp);
+  }
+
+  return byPos;
+}
+
+// ── All-Pro selection ─────────────────────────────────────────────────────────
+
+/**
+ * Select First-Team and Second-Team All-Pro from ranked candidates.
+ * Positions ranked by score: top quota → FIRST_TEAM, next quota → SECOND_TEAM.
+ *
+ * @param {{ QB: Object[], RB: Object[], WR: Object[], DL: Object[] }} rankedCandidates
+ * @param {number} season
+ * @returns {Object[]} Honor assignment records
+ */
+export function selectAllProTeams(rankedCandidates, season) {
+  const assignments = [];
+
+  for (const [pos, quota] of Object.entries(PRESTIGE_QUOTAS.allPro)) {
+    const candidates = rankedCandidates[pos] ?? [];
+    const total = quota * 2;
+
+    for (let i = 0; i < Math.min(candidates.length, total); i++) {
+      const c = candidates[i];
+      const type = i < quota ? 'FIRST_TEAM_ALL_PRO' : 'SECOND_TEAM_ALL_PRO';
+      assignments.push({
+        playerId: c.player.id,
+        playerName: c.player.name,
+        pos: c.player.pos,
+        prestigePos: pos,
+        teamId: c.teamId,
+        teamName: c.teamName,
+        teamAbbr: c.teamAbbr,
+        type,
+        year: season,
+        score: c.score,
+      });
+    }
+  }
+
+  return assignments;
+}
+
+// ── Pro Bowl selection ────────────────────────────────────────────────────────
+
+/**
+ * Select Pro Bowl teams by conference and quota.
+ * Uses the conf value from rankPrestigeCandidates (0=AFC, 1=NFC, -1=unknown).
+ * Players with unknown conference are skipped.
+ *
+ * @param {{ QB: Object[], RB: Object[], WR: Object[], DL: Object[] }} rankedCandidates
+ * @param {number} season
+ * @returns {Object[]} Honor assignment records
+ */
+export function selectProBowlTeams(rankedCandidates, season) {
+  const assignments = [];
+  const seen = new Set();
+
+  for (const [pos, quota] of Object.entries(PRESTIGE_QUOTAS.proBowlPerConference)) {
+    const candidates = rankedCandidates[pos] ?? [];
+
+    for (const confValue of [0, 1]) {
+      const confLabel = confValue === 0 ? 'AFC' : 'NFC';
+      const confCandidates = candidates.filter(c => c.conf === confValue);
+      let filled = 0;
+
+      for (const c of confCandidates) {
+        if (filled >= quota) break;
+        const key = `${String(c.player.id)}_${confValue}_PB`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        assignments.push({
+          playerId: c.player.id,
+          playerName: c.player.name,
+          pos: c.player.pos,
+          prestigePos: pos,
+          teamId: c.teamId,
+          teamName: c.teamName,
+          teamAbbr: c.teamAbbr,
+          type: 'PRO_BOWL',
+          year: season,
+          conf: confValue,
+          confLabel,
+          score: c.score,
+        });
+        filled++;
+      }
+    }
+  }
+
+  return assignments;
+}
+
+// ── Honor merging ─────────────────────────────────────────────────────────────
+
+/**
+ * Append honor records and accolade objects to players.
+ * Returns the same object reference when no changes needed (safe for ref-equality diff).
+ * Rerun-safe: deduplicates by year+type.
+ *
+ * @param {Object[]} players
+ * @param {Object[]} honorAssignments
+ * @param {number} season
+ * @returns {Object[]}
+ */
+export function mergeHonorsIntoPlayers(players, honorAssignments, season) {
+  const honorsByPid = new Map();
+  for (const ha of (honorAssignments ?? [])) {
+    const pid = String(ha.playerId);
+    if (!honorsByPid.has(pid)) honorsByPid.set(pid, []);
+    honorsByPid.get(pid).push(ha);
+  }
+
+  return (players ?? []).map(player => {
+    const pid = String(player.id);
+    const newHonors = honorsByPid.get(pid);
+    if (!newHonors?.length) return player;
+
+    const existingHistory = Array.isArray(player.honorsHistory) ? player.honorsHistory : [];
+    const historyKeys = new Set(existingHistory.map(h => `${h.year}_${h.type}`));
+
+    const existingAccolades = Array.isArray(player.accolades) ? player.accolades : [];
+    const accoladeKeys = new Set(existingAccolades.map(a => `${a?.type}_${a?.year}`));
+
+    const addedHistory = [];
+    const addedAccolades = [];
+
+    for (const ha of newHonors) {
+      const histKey = `${ha.year}_${ha.type}`;
+      if (!historyKeys.has(histKey)) {
+        historyKeys.add(histKey);
+        addedHistory.push({ year: Number(ha.year), type: ha.type, teamId: ha.teamId });
+      }
+
+      const accKey = `${ha.type}_${ha.year}`;
+      if (!accoladeKeys.has(accKey)) {
+        accoladeKeys.add(accKey);
+        addedAccolades.push({ type: ha.type, year: Number(ha.year), seasonId: ha.year });
+      }
+    }
+
+    if (addedHistory.length === 0 && addedAccolades.length === 0) return player;
+
+    return {
+      ...player,
+      honorsHistory: [...existingHistory, ...addedHistory],
+      accolades: [...existingAccolades, ...addedAccolades],
+    };
+  });
+}
+
+// ── UI summary ────────────────────────────────────────────────────────────────
+
+/**
+ * Build a UI-friendly honor summary grouped by honor type and prestige position.
+ *
+ * @param {Object[]} players
+ * @param {Object[]} honorAssignments
+ * @param {Function} teamResolver
+ * @returns {{ FIRST_TEAM_ALL_PRO: {[pos]: Object[]}, SECOND_TEAM_ALL_PRO: {}, PRO_BOWL: {} }}
+ */
+export function buildSeasonHonorsSummary(players, honorAssignments, teamResolver) {
+  const playerById = new Map((players ?? []).map(p => [String(p.id), p]));
+
+  const summary = { FIRST_TEAM_ALL_PRO: {}, SECOND_TEAM_ALL_PRO: {}, PRO_BOWL: {} };
+
+  for (const ha of (honorAssignments ?? [])) {
+    if (!summary[ha.type]) continue;
+
+    const p = playerById.get(String(ha.playerId));
+    const team = teamResolver ? teamResolver(ha.teamId) : null;
+    const entry = {
+      playerId: ha.playerId,
+      playerName: p?.name ?? ha.playerName ?? 'Unknown',
+      teamName: team?.name ?? ha.teamName ?? 'Unknown',
+      teamAbbr: team?.abbr ?? ha.teamAbbr ?? null,
+      pos: p?.pos ?? ha.pos ?? '',
+      prestigePos: ha.prestigePos,
+      score: ha.score,
+    };
+
+    const pp = ha.prestigePos;
+    if (!summary[ha.type][pp]) summary[ha.type][pp] = [];
+    summary[ha.type][pp].push(entry);
+  }
+
+  return summary;
+}
+
+// ── Contract leverage ─────────────────────────────────────────────────────────
+
+/**
+ * Returns a prestige premium descriptor for agent negotiation.
+ *
+ * Multipliers (applied to base fair-market salary):
+ *   First-Team All-Pro  →  1.12  (+12%)
+ *   Second-Team All-Pro →  1.06  (+6%)
+ *   Pro Bowl            →  1.04  (+4%)
+ *
+ * @param {Object} player
+ * @param {number} currentSeason
+ * @returns {{ hasPremium: boolean, multiplier: number, type: string|null, priorSeason: number }}
+ */
+export function getPriorSeasonPrestigePremium(player, currentSeason) {
+  const history = Array.isArray(player?.honorsHistory) ? player.honorsHistory : [];
+  const priorSeason = Number(currentSeason) - 1;
+
+  const priorHonors = history.filter(h => Number(h.year) === priorSeason);
+  if (!priorHonors.length) {
+    return { hasPremium: false, multiplier: 1.0, type: null, priorSeason };
+  }
+
+  const types = new Set(priorHonors.map(h => h.type));
+
+  if (types.has('FIRST_TEAM_ALL_PRO')) {
+    return { hasPremium: true, multiplier: 1.12, type: 'FIRST_TEAM_ALL_PRO', priorSeason };
+  }
+  if (types.has('SECOND_TEAM_ALL_PRO')) {
+    return { hasPremium: true, multiplier: 1.06, type: 'SECOND_TEAM_ALL_PRO', priorSeason };
+  }
+  if (types.has('PRO_BOWL')) {
+    return { hasPremium: true, multiplier: 1.04, type: 'PRO_BOWL', priorSeason };
+  }
+
+  return { hasPremium: false, multiplier: 1.0, type: null, priorSeason };
+}

--- a/src/core/awards/prestigeEngine.unit.test.js
+++ b/src/core/awards/prestigeEngine.unit.test.js
@@ -1,0 +1,567 @@
+/**
+ * prestigeEngine.unit.test.js — Pro Bowl & All-Pro Prestige Engine
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  PRESTIGE_QUOTAS,
+  mapPlayerToPrestigePosition,
+  computePrestigeScore,
+  rankPrestigeCandidates,
+  selectAllProTeams,
+  selectProBowlTeams,
+  mergeHonorsIntoPlayers,
+  getPriorSeasonPrestigePremium,
+  buildSeasonHonorsSummary,
+} from './prestigeEngine.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeQB(overrides = {}) {
+  return {
+    id: 'qb1',
+    name: 'Test QB',
+    pos: 'QB',
+    ovr: 85,
+    teamId: 1,
+    stats: { season: { passYd: 4000, passTD: 30, interceptions: 10, rushYd: 200, rushTD: 2 } },
+    ...overrides,
+  };
+}
+
+function makeRB(overrides = {}) {
+  return {
+    id: 'rb1',
+    name: 'Test RB',
+    pos: 'RB',
+    ovr: 82,
+    teamId: 1,
+    stats: { season: { rushYd: 1200, rushTD: 12, recYd: 300, recTD: 2, receptions: 40 } },
+    ...overrides,
+  };
+}
+
+function makeWR(overrides = {}) {
+  return {
+    id: 'wr1',
+    name: 'Test WR',
+    pos: 'WR',
+    ovr: 80,
+    teamId: 2,
+    stats: { season: { recYd: 1300, recTD: 10, receptions: 100, rushYd: 0, rushTD: 0 } },
+    ...overrides,
+  };
+}
+
+function makeDL(overrides = {}) {
+  return {
+    id: 'dl1',
+    name: 'Test DL',
+    pos: 'DL',
+    ovr: 88,
+    teamId: 1,
+    stats: { season: { sacks: 15, tackles: 40, interceptions: 2 } },
+    ...overrides,
+  };
+}
+
+function makeTeam(id, conf) {
+  return { id, conf, name: `Team ${id}`, abbr: `T${id}` };
+}
+
+// ── mapPlayerToPrestigePosition ───────────────────────────────────────────────
+
+describe('mapPlayerToPrestigePosition', () => {
+  it('maps QB correctly', () => {
+    expect(mapPlayerToPrestigePosition({ pos: 'QB' })).toBe('QB');
+  });
+
+  it('maps RB correctly', () => {
+    expect(mapPlayerToPrestigePosition({ pos: 'RB' })).toBe('RB');
+  });
+
+  it('maps FB to RB', () => {
+    expect(mapPlayerToPrestigePosition({ pos: 'FB' })).toBe('RB');
+  });
+
+  it('maps WR correctly', () => {
+    expect(mapPlayerToPrestigePosition({ pos: 'WR' })).toBe('WR');
+  });
+
+  it('maps DL correctly', () => {
+    expect(mapPlayerToPrestigePosition({ pos: 'DL' })).toBe('DL');
+  });
+
+  it('maps DE to DL', () => {
+    expect(mapPlayerToPrestigePosition({ pos: 'DE' })).toBe('DL');
+  });
+
+  it('maps DT to DL', () => {
+    expect(mapPlayerToPrestigePosition({ pos: 'DT' })).toBe('DL');
+  });
+
+  it('maps EDGE to DL', () => {
+    expect(mapPlayerToPrestigePosition({ pos: 'EDGE' })).toBe('DL');
+  });
+
+  it('returns null for unsupported positions', () => {
+    expect(mapPlayerToPrestigePosition({ pos: 'LB' })).toBeNull();
+    expect(mapPlayerToPrestigePosition({ pos: 'CB' })).toBeNull();
+    expect(mapPlayerToPrestigePosition({ pos: 'OL' })).toBeNull();
+    expect(mapPlayerToPrestigePosition({ pos: 'TE' })).toBeNull();
+    expect(mapPlayerToPrestigePosition({ pos: 'K' })).toBeNull();
+  });
+
+  it('handles null/undefined player gracefully', () => {
+    expect(mapPlayerToPrestigePosition(null)).toBeNull();
+    expect(mapPlayerToPrestigePosition({})).toBeNull();
+    expect(mapPlayerToPrestigePosition({ pos: null })).toBeNull();
+  });
+});
+
+// ── computePrestigeScore ──────────────────────────────────────────────────────
+
+describe('computePrestigeScore — QB formula', () => {
+  it('computes QB score correctly using stats.season', () => {
+    const qb = makeQB();
+    // (4000*0.1) + (30*4) - (10*2) + (200*0.1) + (2*4)
+    // = 400 + 120 - 20 + 20 + 8 = 528
+    expect(computePrestigeScore(qb)).toBe(528);
+  });
+
+  it('subtracts interceptions from QB score', () => {
+    const low = makeQB({ stats: { season: { passYd: 0, passTD: 0, interceptions: 5, rushYd: 0, rushTD: 0 } } });
+    expect(computePrestigeScore(low)).toBe(-10);
+  });
+
+  it('uses careerStats over stats.season when available', () => {
+    const qb = {
+      pos: 'QB',
+      careerStats: [
+        { season: 2025, passYds: 3000, passTDs: 20, ints: 5, rushYds: 100, rushTDs: 1 },
+      ],
+      stats: { season: { passYd: 9999, passTD: 99 } },
+    };
+    // careerStats: (3000*0.1) + (20*4) - (5*2) + (100*0.1) + (1*4)
+    // = 300 + 80 - 10 + 10 + 4 = 384
+    expect(computePrestigeScore(qb)).toBe(384);
+  });
+});
+
+describe('computePrestigeScore — RB formula', () => {
+  it('computes RB score correctly', () => {
+    const rb = makeRB();
+    // scrimmageYds = 1200+300 = 1500; tds = 12+2 = 14; recs = 40
+    // (1500*0.1) + (14*6) + (40*0.5) = 150 + 84 + 20 = 254
+    expect(computePrestigeScore(rb)).toBe(254);
+  });
+});
+
+describe('computePrestigeScore — WR formula', () => {
+  it('computes WR score correctly', () => {
+    const wr = makeWR();
+    // scrimmageYds = 0+1300 = 1300; tds = 0+10 = 10; recs = 100
+    // (1300*0.1) + (10*6) + (100*0.5) = 130 + 60 + 50 = 240
+    expect(computePrestigeScore(wr)).toBe(240);
+  });
+});
+
+describe('computePrestigeScore — DL formula', () => {
+  it('computes DL score correctly', () => {
+    const dl = makeDL();
+    // (15*8) + (40*0.5) + (2*6) = 120 + 20 + 12 = 152
+    expect(computePrestigeScore(dl)).toBe(152);
+  });
+});
+
+describe('computePrestigeScore — edge cases', () => {
+  it('returns null for unsupported positions', () => {
+    expect(computePrestigeScore({ pos: 'LB', stats: { season: {} } })).toBeNull();
+    expect(computePrestigeScore({ pos: 'TE', stats: { season: {} } })).toBeNull();
+  });
+
+  it('missing stats do not produce NaN — returns 0 for all-zero stats', () => {
+    const qb = makeQB({ stats: { season: {} } });
+    const score = computePrestigeScore(qb);
+    expect(Number.isFinite(score)).toBe(true);
+    expect(score).toBe(0);
+  });
+
+  it('null/undefined stat fields treated as 0, no NaN', () => {
+    const dl = { pos: 'DL', stats: { season: { sacks: null, tackles: undefined } } };
+    const score = computePrestigeScore(dl);
+    expect(Number.isNaN(score)).toBe(false);
+    expect(score).toBe(0);
+  });
+
+  it('missing stats.season falls back to 0 score', () => {
+    const rb = { pos: 'RB' };
+    const score = computePrestigeScore(rb);
+    expect(Number.isFinite(score)).toBe(true);
+  });
+
+  it('careerStats plural keys (passYds/passTDs/ints) are used correctly', () => {
+    const qb = {
+      pos: 'QB',
+      careerStats: [{ passYds: 5000, passTDs: 40, ints: 8, rushYds: 0, rushTDs: 0 }],
+    };
+    // (5000*0.1)+(40*4)-(8*2) = 500+160-16 = 644
+    expect(computePrestigeScore(qb)).toBe(644);
+  });
+});
+
+// ── rankPrestigeCandidates ────────────────────────────────────────────────────
+
+describe('rankPrestigeCandidates', () => {
+  it('sorts by score descending', () => {
+    const qb1 = makeQB({ id: 'qb1', stats: { season: { passYd: 4000, passTD: 30, interceptions: 10, rushYd: 200, rushTD: 2 } } });
+    const qb2 = makeQB({ id: 'qb2', stats: { season: { passYd: 5000, passTD: 40, interceptions: 5, rushYd: 0, rushTD: 0 } } });
+
+    const ranked = rankPrestigeCandidates([qb1, qb2], () => null);
+    expect(ranked.QB[0].player.id).toBe('qb2');
+    expect(ranked.QB[1].player.id).toBe('qb1');
+  });
+
+  it('breaks score ties by OVR desc', () => {
+    const qb1 = makeQB({ id: 'qb_low', ovr: 80, stats: { season: { passYd: 0, passTD: 0, interceptions: 0, rushYd: 0, rushTD: 0 } } });
+    const qb2 = makeQB({ id: 'qb_hi', ovr: 90, stats: { season: { passYd: 0, passTD: 0, interceptions: 0, rushYd: 0, rushTD: 0 } } });
+
+    const ranked = rankPrestigeCandidates([qb1, qb2], () => null);
+    expect(ranked.QB[0].player.id).toBe('qb_hi');
+    expect(ranked.QB[1].player.id).toBe('qb_low');
+  });
+
+  it('breaks OVR ties by id asc (deterministic)', () => {
+    const qb1 = makeQB({ id: 'b', ovr: 85, stats: { season: { passYd: 0, passTD: 0, interceptions: 0, rushYd: 0, rushTD: 0 } } });
+    const qb2 = makeQB({ id: 'a', ovr: 85, stats: { season: { passYd: 0, passTD: 0, interceptions: 0, rushYd: 0, rushTD: 0 } } });
+
+    const ranked = rankPrestigeCandidates([qb1, qb2], () => null);
+    // 'a' < 'b' alphabetically → id 'a' first
+    expect(ranked.QB[0].player.id).toBe('a');
+    expect(ranked.QB[1].player.id).toBe('b');
+  });
+
+  it('groups by position correctly', () => {
+    const players = [makeQB(), makeRB(), makeWR(), makeDL()];
+    const ranked = rankPrestigeCandidates(players, () => null);
+    expect(ranked.QB).toHaveLength(1);
+    expect(ranked.RB).toHaveLength(1);
+    expect(ranked.WR).toHaveLength(1);
+    expect(ranked.DL).toHaveLength(1);
+  });
+
+  it('excludes unsupported positions', () => {
+    const lb = { id: 'lb1', pos: 'LB', stats: { season: {} } };
+    const ranked = rankPrestigeCandidates([lb], () => null);
+    expect(ranked.QB).toHaveLength(0);
+    expect(ranked.DL).toHaveLength(0);
+  });
+
+  it('is immutable — original array not mutated', () => {
+    const players = [makeQB(), makeQB({ id: 'qb2' })];
+    const before = [...players];
+    rankPrestigeCandidates(players, () => null);
+    expect(players[0]).toBe(before[0]);
+  });
+
+  it('attaches conf from teamResolver', () => {
+    const qb = makeQB({ teamId: 5 });
+    const resolver = (id) => makeTeam(id, 'AFC');
+    const ranked = rankPrestigeCandidates([qb], resolver);
+    expect(ranked.QB[0].conf).toBe(0);
+  });
+});
+
+// ── selectAllProTeams ─────────────────────────────────────────────────────────
+
+describe('selectAllProTeams', () => {
+  function makeRanked(players) {
+    return rankPrestigeCandidates(players, () => null);
+  }
+
+  it('picks correct first and second team by quota', () => {
+    const qbs = Array.from({ length: 5 }, (_, i) =>
+      makeQB({ id: `qb${i}`, stats: { season: { passYd: (5 - i) * 1000, passTD: (5 - i) * 5, interceptions: 0, rushYd: 0, rushTD: 0 } } }),
+    );
+    const ranked = makeRanked(qbs);
+    const assignments = selectAllProTeams(ranked, 2025);
+
+    const firstTeam = assignments.filter(a => a.type === 'FIRST_TEAM_ALL_PRO' && a.prestigePos === 'QB');
+    const secondTeam = assignments.filter(a => a.type === 'SECOND_TEAM_ALL_PRO' && a.prestigePos === 'QB');
+
+    // PRESTIGE_QUOTAS.allPro.QB = 2 → 2 on first team, 2 on second team
+    expect(firstTeam).toHaveLength(PRESTIGE_QUOTAS.allPro.QB);
+    expect(secondTeam).toHaveLength(PRESTIGE_QUOTAS.allPro.QB);
+  });
+
+  it('first team has higher score than second team', () => {
+    const qbs = [
+      makeQB({ id: 'top1', stats: { season: { passYd: 5000, passTD: 40, interceptions: 5, rushYd: 0, rushTD: 0 } } }),
+      makeQB({ id: 'top2', stats: { season: { passYd: 4000, passTD: 30, interceptions: 5, rushYd: 0, rushTD: 0 } } }),
+      makeQB({ id: 'sec1', stats: { season: { passYd: 3000, passTD: 20, interceptions: 5, rushYd: 0, rushTD: 0 } } }),
+      makeQB({ id: 'sec2', stats: { season: { passYd: 2000, passTD: 10, interceptions: 5, rushYd: 0, rushTD: 0 } } }),
+    ];
+    const ranked = makeRanked(qbs);
+    const assignments = selectAllProTeams(ranked, 2025);
+    const firstIds = assignments.filter(a => a.type === 'FIRST_TEAM_ALL_PRO').map(a => a.playerId);
+    expect(firstIds).toContain('top1');
+    expect(firstIds).toContain('top2');
+  });
+
+  it('returns empty for position with no candidates', () => {
+    const ranked = { QB: [], RB: [], WR: [], DL: [] };
+    const assignments = selectAllProTeams(ranked, 2025);
+    expect(assignments).toHaveLength(0);
+  });
+
+  it('stamps year on each assignment', () => {
+    const ranked = makeRanked([makeQB(), makeWR()]);
+    const assignments = selectAllProTeams(ranked, 2026);
+    assignments.forEach(a => expect(a.year).toBe(2026));
+  });
+});
+
+// ── selectProBowlTeams ────────────────────────────────────────────────────────
+
+describe('selectProBowlTeams', () => {
+  function makeRankedWithConf(confMap) {
+    const byPos = { QB: [], RB: [], WR: [], DL: [] };
+    for (const [id, { pos, conf, score }] of Object.entries(confMap)) {
+      const pPos = mapPlayerToPrestigePosition({ pos });
+      if (!pPos) continue;
+      byPos[pPos].push({
+        player: { id, name: `P${id}`, pos, ovr: 80 },
+        score,
+        conf,
+        teamId: null,
+        teamName: null,
+        teamAbbr: null,
+      });
+    }
+    for (const pos of Object.keys(byPos)) {
+      byPos[pos].sort((a, b) => b.score - a.score);
+    }
+    return byPos;
+  }
+
+  it('respects per-conference quota for QB (4 per conf)', () => {
+    const ranked = makeRankedWithConf({
+      qb1: { pos: 'QB', conf: 0, score: 100 },
+      qb2: { pos: 'QB', conf: 0, score: 90 },
+      qb3: { pos: 'QB', conf: 0, score: 80 },
+      qb4: { pos: 'QB', conf: 0, score: 70 },
+      qb5: { pos: 'QB', conf: 0, score: 60 },
+      qb6: { pos: 'QB', conf: 1, score: 100 },
+      qb7: { pos: 'QB', conf: 1, score: 90 },
+      qb8: { pos: 'QB', conf: 1, score: 80 },
+      qb9: { pos: 'QB', conf: 1, score: 70 },
+      qb10: { pos: 'QB', conf: 1, score: 60 },
+    });
+    const assignments = selectProBowlTeams(ranked, 2025);
+    const afcQBs = assignments.filter(a => a.prestigePos === 'QB' && a.conf === 0);
+    const nfcQBs = assignments.filter(a => a.prestigePos === 'QB' && a.conf === 1);
+    expect(afcQBs).toHaveLength(PRESTIGE_QUOTAS.proBowlPerConference.QB);
+    expect(nfcQBs).toHaveLength(PRESTIGE_QUOTAS.proBowlPerConference.QB);
+  });
+
+  it('skips players with unknown conference (-1)', () => {
+    const ranked = makeRankedWithConf({
+      qb1: { pos: 'QB', conf: -1, score: 100 },
+    });
+    const assignments = selectProBowlTeams(ranked, 2025);
+    expect(assignments.filter(a => a.prestigePos === 'QB')).toHaveLength(0);
+  });
+
+  it('does not exceed conference quota even with many candidates', () => {
+    const qbs = {};
+    for (let i = 0; i < 20; i++) qbs[`qb${i}`] = { pos: 'QB', conf: 0, score: 100 - i };
+    const ranked = makeRankedWithConf(qbs);
+    const afcQBs = selectProBowlTeams(ranked, 2025).filter(a => a.prestigePos === 'QB' && a.conf === 0);
+    expect(afcQBs).toHaveLength(PRESTIGE_QUOTAS.proBowlPerConference.QB);
+  });
+
+  it('stamps PRO_BOWL type on all assignments', () => {
+    const ranked = makeRankedWithConf({ qb1: { pos: 'QB', conf: 0, score: 100 } });
+    const assignments = selectProBowlTeams(ranked, 2025);
+    assignments.forEach(a => expect(a.type).toBe('PRO_BOWL'));
+  });
+});
+
+// ── mergeHonorsIntoPlayers ────────────────────────────────────────────────────
+
+describe('mergeHonorsIntoPlayers', () => {
+  const SEASON = 2025;
+
+  const assignment = {
+    playerId: 'qb1',
+    playerName: 'Test QB',
+    pos: 'QB',
+    prestigePos: 'QB',
+    teamId: 1,
+    teamName: 'Team 1',
+    type: 'FIRST_TEAM_ALL_PRO',
+    year: SEASON,
+    score: 500,
+  };
+
+  it('appends to honorsHistory', () => {
+    const player = makeQB({ id: 'qb1' });
+    const [updated] = mergeHonorsIntoPlayers([player], [assignment], SEASON);
+    expect(updated.honorsHistory).toHaveLength(1);
+    expect(updated.honorsHistory[0].type).toBe('FIRST_TEAM_ALL_PRO');
+    expect(updated.honorsHistory[0].year).toBe(SEASON);
+  });
+
+  it('appends accolade object', () => {
+    const player = makeQB({ id: 'qb1' });
+    const [updated] = mergeHonorsIntoPlayers([player], [assignment], SEASON);
+    const hasAccolade = (updated.accolades ?? []).some(a => a.type === 'FIRST_TEAM_ALL_PRO' && a.year === SEASON);
+    expect(hasAccolade).toBe(true);
+  });
+
+  it('is rerun-safe — no duplicate honors on second merge', () => {
+    const player = makeQB({ id: 'qb1' });
+    const firstPass = mergeHonorsIntoPlayers([player], [assignment], SEASON)[0];
+    const secondPass = mergeHonorsIntoPlayers([firstPass], [assignment], SEASON)[0];
+    expect(secondPass.honorsHistory).toHaveLength(1);
+    expect((secondPass.accolades ?? []).filter(a => a.type === 'FIRST_TEAM_ALL_PRO' && a.year === SEASON)).toHaveLength(1);
+  });
+
+  it('preserves existing honorsHistory entries', () => {
+    const player = makeQB({
+      id: 'qb1',
+      honorsHistory: [{ year: 2024, type: 'PRO_BOWL', teamId: 1 }],
+    });
+    const [updated] = mergeHonorsIntoPlayers([player], [assignment], SEASON);
+    expect(updated.honorsHistory).toHaveLength(2);
+    expect(updated.honorsHistory[0].year).toBe(2024);
+    expect(updated.honorsHistory[1].year).toBe(SEASON);
+  });
+
+  it('returns same reference for unchanged player', () => {
+    const player = makeQB({ id: 'other' });
+    const [unchanged] = mergeHonorsIntoPlayers([player], [assignment], SEASON);
+    expect(unchanged).toBe(player);
+  });
+
+  it('initializes honorsHistory: [] for old save without the field', () => {
+    const oldPlayer = { id: 'qb1', name: 'Old QB', pos: 'QB', ovr: 80, teamId: 1 };
+    const [updated] = mergeHonorsIntoPlayers([oldPlayer], [assignment], SEASON);
+    expect(Array.isArray(updated.honorsHistory)).toBe(true);
+    expect(updated.honorsHistory).toHaveLength(1);
+  });
+
+  it('does not mutate input player objects', () => {
+    const player = makeQB({ id: 'qb1' });
+    mergeHonorsIntoPlayers([player], [assignment], SEASON);
+    expect(player.honorsHistory).toBeUndefined();
+  });
+
+  it('preserves existing accolades from other systems', () => {
+    const player = makeQB({
+      id: 'qb1',
+      accolades: [{ type: 'MVP', year: 2025, seasonId: 2025 }],
+    });
+    const [updated] = mergeHonorsIntoPlayers([player], [assignment], SEASON);
+    const mvp = (updated.accolades ?? []).find(a => a.type === 'MVP');
+    expect(mvp).toBeTruthy();
+  });
+});
+
+// ── getPriorSeasonPrestigePremium ─────────────────────────────────────────────
+
+describe('getPriorSeasonPrestigePremium', () => {
+  it('returns First-Team All-Pro premium (1.12)', () => {
+    const player = {
+      honorsHistory: [{ year: 2024, type: 'FIRST_TEAM_ALL_PRO', teamId: 1 }],
+    };
+    const result = getPriorSeasonPrestigePremium(player, 2025);
+    expect(result.hasPremium).toBe(true);
+    expect(result.multiplier).toBe(1.12);
+    expect(result.type).toBe('FIRST_TEAM_ALL_PRO');
+  });
+
+  it('returns Second-Team All-Pro premium (1.06)', () => {
+    const player = {
+      honorsHistory: [{ year: 2024, type: 'SECOND_TEAM_ALL_PRO', teamId: 1 }],
+    };
+    const result = getPriorSeasonPrestigePremium(player, 2025);
+    expect(result.multiplier).toBe(1.06);
+    expect(result.type).toBe('SECOND_TEAM_ALL_PRO');
+  });
+
+  it('returns Pro Bowl premium (1.04)', () => {
+    const player = {
+      honorsHistory: [{ year: 2024, type: 'PRO_BOWL', teamId: 1 }],
+    };
+    const result = getPriorSeasonPrestigePremium(player, 2025);
+    expect(result.multiplier).toBe(1.04);
+    expect(result.type).toBe('PRO_BOWL');
+  });
+
+  it('returns no premium when no prior-season honors', () => {
+    const player = { honorsHistory: [] };
+    const result = getPriorSeasonPrestigePremium(player, 2025);
+    expect(result.hasPremium).toBe(false);
+    expect(result.multiplier).toBe(1.0);
+    expect(result.type).toBeNull();
+  });
+
+  it('ignores honors from seasons other than priorSeason', () => {
+    const player = {
+      honorsHistory: [{ year: 2022, type: 'FIRST_TEAM_ALL_PRO', teamId: 1 }],
+    };
+    const result = getPriorSeasonPrestigePremium(player, 2025);
+    expect(result.hasPremium).toBe(false);
+  });
+
+  it('handles missing honorsHistory gracefully', () => {
+    const player = {};
+    const result = getPriorSeasonPrestigePremium(player, 2025);
+    expect(result.hasPremium).toBe(false);
+    expect(result.multiplier).toBe(1.0);
+  });
+
+  it('prefers First-Team over Second-Team when both present', () => {
+    const player = {
+      honorsHistory: [
+        { year: 2024, type: 'SECOND_TEAM_ALL_PRO', teamId: 1 },
+        { year: 2024, type: 'FIRST_TEAM_ALL_PRO', teamId: 1 },
+      ],
+    };
+    const result = getPriorSeasonPrestigePremium(player, 2025);
+    expect(result.type).toBe('FIRST_TEAM_ALL_PRO');
+    expect(result.multiplier).toBe(1.12);
+  });
+
+  it('sets priorSeason to currentSeason - 1', () => {
+    const player = { honorsHistory: [] };
+    const result = getPriorSeasonPrestigePremium(player, 2026);
+    expect(result.priorSeason).toBe(2025);
+  });
+});
+
+// ── No Math.random ────────────────────────────────────────────────────────────
+
+describe('prestige engine determinism', () => {
+  it('same inputs always produce same output for computePrestigeScore', () => {
+    const qb = makeQB();
+    expect(computePrestigeScore(qb)).toBe(computePrestigeScore(qb));
+  });
+
+  it('same inputs always produce same output for rankPrestigeCandidates', () => {
+    const players = [makeQB(), makeQB({ id: 'qb2', ovr: 90 })];
+    const r1 = rankPrestigeCandidates(players, () => null);
+    const r2 = rankPrestigeCandidates(players, () => null);
+    expect(r1.QB.map(c => c.player.id)).toEqual(r2.QB.map(c => c.player.id));
+  });
+
+  it('selectAllProTeams is deterministic', () => {
+    const qbs = Array.from({ length: 6 }, (_, i) =>
+      makeQB({ id: `qb${i}`, stats: { season: { passYd: (6 - i) * 1000, passTD: 20, interceptions: 5, rushYd: 0, rushTD: 0 } } }),
+    );
+    const ranked = rankPrestigeCandidates(qbs, () => null);
+    const a1 = selectAllProTeams(ranked, 2025);
+    const a2 = selectAllProTeams(ranked, 2025);
+    expect(a1.map(a => a.playerId)).toEqual(a2.map(a => a.playerId));
+  });
+});

--- a/src/core/contracts/agentNegotiationEngine.js
+++ b/src/core/contracts/agentNegotiationEngine.js
@@ -5,6 +5,8 @@
  * All outputs are immutable new objects.
  */
 
+import { getPriorSeasonPrestigePremium } from '../awards/prestigeEngine.js';
+
 // ── Archetype constants ───────────────────────────────────────────────────────
 
 export const AGENT_ARCHETYPES = Object.freeze({
@@ -170,6 +172,22 @@ export function computeAgentExpectedSalary({ player, baseFairMarketValue, teamCo
     } else {
       modifier  = 0;
       rationale = 'Ring Chaser open to negotiation at fair market value';
+    }
+  }
+
+  // Apply prior-season prestige premium (Pro Bowl / All-Pro leverage)
+  const currentSeason = teamContext?.currentSeason;
+  if (currentSeason != null) {
+    const { hasPremium, multiplier, type } = getPriorSeasonPrestigePremium(hydrated, currentSeason);
+    if (hasPremium) {
+      const prestigeBonus = multiplier - 1.0;
+      const extraSharkAllPro =
+        archetype === AGENT_ARCHETYPES.SHARK &&
+        (type === 'FIRST_TEAM_ALL_PRO' || type === 'SECOND_TEAM_ALL_PRO')
+          ? 0.05
+          : 0;
+      modifier += prestigeBonus + extraSharkAllPro;
+      rationale += `; prestige premium +${((prestigeBonus + extraSharkAllPro) * 100).toFixed(1)}% (${type})`;
     }
   }
 

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -467,6 +467,7 @@ traits: generateTraits(pos, playerOvr),
         offers: [], // FA offers
         onTradeBlock: false,
         awards: [],
+        honorsHistory: [],
         personality: generatePersonality(),
         personalityProfile,
         mentorship: { mentorId: null, menteeIds: [], maxMentees: 2 },

--- a/src/ui/components/HistoryCenter.jsx
+++ b/src/ui/components/HistoryCenter.jsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { ScreenHeader, SectionCard } from './ScreenSystem.jsx';
+import HonorsCenter from './HonorsCenter.jsx';
 
-const TABS = ['Honor Roll', 'Record Book'];
+const TABS = ['Honor Roll', 'Record Book', 'Honors'];
 
 const RECORD_LABELS = {
   passingYards: 'Passing Yards',
@@ -162,6 +163,7 @@ export default function HistoryCenter({ league }) {
   const historyLedger = league?.historyLedger ?? [];
   const recordBook = league?.recordBook ?? null;
   const userTeamId = league?.userTeamId ?? null;
+  const currentSeasonHonors = league?.currentSeasonHonors ?? null;
 
   return (
     <div className="app-screen-stack">
@@ -176,6 +178,9 @@ export default function HistoryCenter({ league }) {
         )}
         {activeTab === 'Record Book' && (
           <RecordBookTab recordBook={recordBook} />
+        )}
+        {activeTab === 'Honors' && (
+          <HonorsCenter honors={currentSeasonHonors} />
         )}
       </div>
     </div>

--- a/src/ui/components/HonorsCenter.jsx
+++ b/src/ui/components/HonorsCenter.jsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { SectionCard } from './ScreenSystem.jsx';
+
+const PRESTIGE_POSITIONS = ['QB', 'RB', 'WR', 'DL'];
+
+const HONOR_LABELS = {
+  FIRST_TEAM_ALL_PRO: 'First-Team All-Pro',
+  SECOND_TEAM_ALL_PRO: 'Second-Team All-Pro',
+  PRO_BOWL: 'Pro Bowl',
+};
+
+const BADGE_STYLES = {
+  FIRST_TEAM_ALL_PRO: {
+    background: 'var(--accent)',
+    color: '#fff',
+    border: '1px solid var(--accent)',
+    fontWeight: 700,
+  },
+  SECOND_TEAM_ALL_PRO: {
+    background: 'transparent',
+    color: 'var(--accent)',
+    border: '1px solid var(--accent)',
+    fontWeight: 600,
+  },
+  PRO_BOWL: {
+    background: 'transparent',
+    color: 'var(--text-muted)',
+    border: '1px solid var(--border)',
+    fontWeight: 400,
+  },
+};
+
+function HonorBadge({ type }) {
+  const style = BADGE_STYLES[type] ?? BADGE_STYLES.PRO_BOWL;
+  return (
+    <span
+      data-testid={`honor-badge-${type}`}
+      style={{
+        ...style,
+        display: 'inline-block',
+        padding: '2px 8px',
+        borderRadius: 4,
+        fontSize: 'var(--text-xs, 11px)',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {HONOR_LABELS[type] ?? type}
+    </span>
+  );
+}
+
+function HonorTable({ entries, honorType }) {
+  const hasEntries = entries && PRESTIGE_POSITIONS.some(pos => (entries[pos]?.length ?? 0) > 0);
+  if (!hasEntries) return null;
+  return (
+    <div style={{ marginBottom: 'var(--space-3)' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)', marginBottom: 'var(--space-2)' }}>
+        <HonorBadge type={honorType} />
+      </div>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 'var(--text-sm)' }}>
+        <thead>
+          <tr>
+            <th style={{ textAlign: 'left', paddingBottom: 4 }}>Pos</th>
+            <th style={{ textAlign: 'left', paddingBottom: 4 }}>Player</th>
+            <th style={{ textAlign: 'left', paddingBottom: 4 }}>Team</th>
+            <th style={{ textAlign: 'right', paddingBottom: 4 }}>Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          {PRESTIGE_POSITIONS.flatMap(pos => {
+            const posEntries = entries[pos] ?? [];
+            return posEntries.map((e, i) => (
+              <tr key={`${pos}-${i}`} data-testid={`honor-row-${honorType}-${pos}`}>
+                <td style={{ paddingRight: 8, color: 'var(--text-muted)' }}>{pos}</td>
+                <td>{e.playerName}</td>
+                <td style={{ color: 'var(--text-muted)' }}>{e.teamAbbr ?? e.teamName ?? '—'}</td>
+                <td style={{ textAlign: 'right', color: 'var(--text-muted)' }}>
+                  {typeof e.score === 'number' ? e.score.toFixed(1) : '—'}
+                </td>
+              </tr>
+            ));
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function HonorsCenter({ honors }) {
+  if (!honors) {
+    return (
+      <SectionCard title="Pro Bowl & All-Pro Honors">
+        <p
+          style={{ color: 'var(--text-muted)', fontSize: 'var(--text-sm)' }}
+          data-testid="honors-empty"
+        >
+          No honors awarded yet. Complete a season to see Pro Bowl & All-Pro selections.
+        </p>
+      </SectionCard>
+    );
+  }
+
+  return (
+    <SectionCard title="Pro Bowl & All-Pro Honors">
+      <div data-testid="honors-center">
+        <HonorTable honorType="FIRST_TEAM_ALL_PRO" entries={honors.FIRST_TEAM_ALL_PRO} />
+        <HonorTable honorType="SECOND_TEAM_ALL_PRO" entries={honors.SECOND_TEAM_ALL_PRO} />
+        <HonorTable honorType="PRO_BOWL" entries={honors.PRO_BOWL} />
+      </div>
+    </SectionCard>
+  );
+}

--- a/src/ui/components/HonorsCenter.test.jsx
+++ b/src/ui/components/HonorsCenter.test.jsx
@@ -1,0 +1,142 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import HonorsCenter from './HonorsCenter.jsx';
+import HistoryCenter from './HistoryCenter.jsx';
+
+afterEach(cleanup);
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const MOCK_HONORS = {
+  FIRST_TEAM_ALL_PRO: {
+    QB: [{ playerId: 'p1', playerName: 'Star QB', teamAbbr: 'PHI', teamName: 'Eagles', pos: 'QB', prestigePos: 'QB', score: 600 }],
+    RB: [{ playerId: 'p2', playerName: 'Speed RB', teamAbbr: 'BAL', teamName: 'Ravens', pos: 'RB', prestigePos: 'RB', score: 300 }],
+    WR: [{ playerId: 'p3', playerName: 'Deep WR', teamAbbr: 'DAL', teamName: 'Cowboys', pos: 'WR', prestigePos: 'WR', score: 280 }],
+    DL: [{ playerId: 'p4', playerName: 'Pass Rush DL', teamAbbr: 'GB', teamName: 'Packers', pos: 'DL', prestigePos: 'DL', score: 160 }],
+  },
+  SECOND_TEAM_ALL_PRO: {
+    QB: [{ playerId: 'p5', playerName: 'Backup QB', teamAbbr: 'LAR', teamName: 'Rams', pos: 'QB', prestigePos: 'QB', score: 500 }],
+    RB: [],
+    WR: [],
+    DL: [],
+  },
+  PRO_BOWL: {
+    QB: [
+      { playerId: 'p1', playerName: 'Star QB', teamAbbr: 'PHI', pos: 'QB', prestigePos: 'QB', score: 600 },
+      { playerId: 'p6', playerName: 'Steady QB', teamAbbr: 'SF', pos: 'QB', prestigePos: 'QB', score: 400 },
+    ],
+    RB: [],
+    WR: [],
+    DL: [],
+  },
+};
+
+// ── HonorsCenter unit tests ───────────────────────────────────────────────────
+
+describe('HonorsCenter', () => {
+  it('renders empty state when honors is null', () => {
+    render(<HonorsCenter honors={null} />);
+    expect(screen.getByTestId('honors-empty')).toBeTruthy();
+  });
+
+  it('renders empty state when honors is undefined', () => {
+    render(<HonorsCenter />);
+    expect(screen.getByTestId('honors-empty')).toBeTruthy();
+  });
+
+  it('renders honors center container when honors provided', () => {
+    render(<HonorsCenter honors={MOCK_HONORS} />);
+    expect(screen.getByTestId('honors-center')).toBeTruthy();
+  });
+
+  it('renders FIRST_TEAM_ALL_PRO badge', () => {
+    render(<HonorsCenter honors={MOCK_HONORS} />);
+    expect(screen.getByTestId('honor-badge-FIRST_TEAM_ALL_PRO')).toBeTruthy();
+  });
+
+  it('renders SECOND_TEAM_ALL_PRO badge', () => {
+    render(<HonorsCenter honors={MOCK_HONORS} />);
+    expect(screen.getByTestId('honor-badge-SECOND_TEAM_ALL_PRO')).toBeTruthy();
+  });
+
+  it('renders PRO_BOWL badge', () => {
+    render(<HonorsCenter honors={MOCK_HONORS} />);
+    expect(screen.getByTestId('honor-badge-PRO_BOWL')).toBeTruthy();
+  });
+
+  it('renders player names for First-Team All-Pro', () => {
+    render(<HonorsCenter honors={MOCK_HONORS} />);
+    expect(screen.getAllByText('Star QB').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Speed RB').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Deep WR').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Pass Rush DL').length).toBeGreaterThan(0);
+  });
+
+  it('renders team abbreviation for each honored player', () => {
+    render(<HonorsCenter honors={MOCK_HONORS} />);
+    expect(screen.getAllByText('PHI').length).toBeGreaterThan(0);
+    expect(screen.getByText('BAL')).toBeTruthy();
+  });
+
+  it('renders rows for first-team QB position group', () => {
+    render(<HonorsCenter honors={MOCK_HONORS} />);
+    const qbRows = screen.getAllByTestId('honor-row-FIRST_TEAM_ALL_PRO-QB');
+    expect(qbRows).toHaveLength(1);
+  });
+
+  it('renders score values', () => {
+    render(<HonorsCenter honors={MOCK_HONORS} />);
+    expect(screen.getAllByText('600.0').length).toBeGreaterThan(0);
+  });
+
+  it('does not crash with empty position groups', () => {
+    const sparseHonors = { FIRST_TEAM_ALL_PRO: {}, SECOND_TEAM_ALL_PRO: {}, PRO_BOWL: {} };
+    expect(() => render(<HonorsCenter honors={sparseHonors} />)).not.toThrow();
+  });
+});
+
+// ── HistoryCenter + Honors tab integration ────────────────────────────────────
+
+describe('HistoryCenter — Honors tab', () => {
+  it('renders the Honors tab button', () => {
+    render(<HistoryCenter league={{ historyLedger: [], currentSeasonHonors: MOCK_HONORS }} />);
+    expect(screen.getByRole('tab', { name: 'Honors' })).toBeTruthy();
+  });
+
+  it('Honors tab is not active by default', () => {
+    render(<HistoryCenter league={{ historyLedger: [], currentSeasonHonors: MOCK_HONORS }} />);
+    const honorsTab = screen.getByRole('tab', { name: 'Honors' });
+    expect(honorsTab.getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('clicking Honors tab shows HonorsCenter content', () => {
+    render(<HistoryCenter league={{ historyLedger: [], currentSeasonHonors: MOCK_HONORS }} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Honors' }));
+    expect(screen.getByTestId('honors-center')).toBeTruthy();
+  });
+
+  it('clicking Honors tab with null honors shows empty state', () => {
+    render(<HistoryCenter league={{ historyLedger: [], currentSeasonHonors: null }} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Honors' }));
+    expect(screen.getByTestId('honors-empty')).toBeTruthy();
+  });
+
+  it('Honor Roll and Record Book tabs still work after Honors tab added', () => {
+    const ledger = [{ year: 2025, championTeamId: 1, championName: 'Eagles', runnerUpName: 'Chiefs', superBowlScore: '31-24', mvpName: 'QB1' }];
+    render(<HistoryCenter league={{ historyLedger: ledger, currentSeasonHonors: MOCK_HONORS }} />);
+    // Honor Roll active by default
+    expect(screen.getByText('Eagles')).toBeTruthy();
+    // Switch to Honors
+    fireEvent.click(screen.getByRole('tab', { name: 'Honors' }));
+    expect(screen.getByTestId('honors-center')).toBeTruthy();
+    // Switch back to Honor Roll
+    fireEvent.click(screen.getByRole('tab', { name: 'Honor Roll' }));
+    expect(screen.getByText('Eagles')).toBeTruthy();
+  });
+
+  it('renders safely when currentSeasonHonors is missing from league prop', () => {
+    expect(() => render(<HistoryCenter league={{ historyLedger: [] }} />)).not.toThrow();
+  });
+});

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -194,6 +194,7 @@ import { parseWeeklyHeadlines } from '../core/history/NewsEngine.ts';
 import { calculateAwardRaces, selectProBowlers } from '../core/awards-logic.js';
 import { determineSeasonAwards, applySeasonAwards, checkCareerMilestones, getPlayerAwardSummary, AWARD_TYPES as ENGINE_AWARD_TYPES, AWARD_LABELS as ENGINE_AWARD_LABELS } from '../core/awards/awardEngine.js';
 import { generateHofBallot, resolveHofVote, applyHofInductions, ensureHofMeta } from '../core/awards/hofEngine.js';
+import { rankPrestigeCandidates, selectAllProTeams, selectProBowlTeams, mergeHonorsIntoPlayers, buildSeasonHonorsSummary } from '../core/awards/prestigeEngine.js';
 import { buildAllLeaderboards } from '../core/awards/statLeaderboard.js';
 import { Constants } from '../core/constants.js';
 import { processPlayerProgression } from '../core/progression-logic.js';
@@ -1170,6 +1171,7 @@ function buildViewState() {
     leagueHistory: Array.isArray(meta?.leagueHistory) ? meta.leagueHistory.slice(-60) : [],
     historyLedger: Array.isArray(meta?.historyLedger) ? meta.historyLedger : [],
     franchiseAwards: Array.isArray(meta?.franchiseAwards) ? meta.franchiseAwards : [],
+    currentSeasonHonors: meta?.currentSeasonHonors ?? null,
     franchiseChronicle: Array.isArray(meta?.franchiseChronicle) ? meta.franchiseChronicle.slice(-340) : [],
     franchiseSeasonReviews: Array.isArray(meta?.franchiseSeasonReviews) ? meta.franchiseSeasonReviews.slice(-40) : [],
     seasonStorylines: Array.isArray(meta?.seasonStorylines) ? meta.seasonStorylines : [],
@@ -1806,7 +1808,8 @@ function hydratePlayerDevelopmentFields(player = {}) {
   };
   const developmentHistory = Array.isArray(player?.developmentHistory) ? player.developmentHistory : [];
   const injuryHistory = Array.isArray(player?.injuryHistory) ? player.injuryHistory : [];
-  return { personalityProfile: profile, mentorship, developmentHistory, injuryHistory };
+  const honorsHistory = Array.isArray(player?.honorsHistory) ? player.honorsHistory : [];
+  return { personalityProfile: profile, mentorship, developmentHistory, injuryHistory, honorsHistory };
 }
 
 function hydrateAllPlayersForDevelopment() {
@@ -13136,6 +13139,31 @@ async function archiveSeason(seasonId) {
       }
     } catch (hofErr) {
       console.error('[Worker] HOF Engine V1 failed (non-fatal):', hofErr);
+    }
+
+    // ── Prestige Engine V1: Pro Bowl & All-Pro honor selection ───────────────
+    try {
+      const allPlayersForPrestige = cache.getAllPlayers();
+      const teamResolverForPrestige = (teamId) => cache.getTeam(teamId) ?? null;
+      const rankedCandidates = rankPrestigeCandidates(allPlayersForPrestige, teamResolverForPrestige, year);
+      const allProAssignments = selectAllProTeams(rankedCandidates, year);
+      const proBowlAssignments = selectProBowlTeams(rankedCandidates, year);
+      const allPrestigeAssignments = [...allProAssignments, ...proBowlAssignments];
+
+      const updatedPlayersPrestige = mergeHonorsIntoPlayers(allPlayersForPrestige, allPrestigeAssignments, year);
+      for (let i = 0; i < updatedPlayersPrestige.length; i++) {
+        if (updatedPlayersPrestige[i] !== allPlayersForPrestige[i]) {
+          cache.updatePlayer(updatedPlayersPrestige[i].id, {
+            honorsHistory: updatedPlayersPrestige[i].honorsHistory,
+            accolades: updatedPlayersPrestige[i].accolades,
+          });
+        }
+      }
+
+      const honorsSummary = buildSeasonHonorsSummary(updatedPlayersPrestige, allPrestigeAssignments, teamResolverForPrestige);
+      cache.setMeta({ currentSeasonHonors: honorsSummary });
+    } catch (prestigeErr) {
+      console.error('[Worker] Prestige Engine V1 failed (non-fatal):', prestigeErr);
     }
 
     // ── Record Book: check for broken single-season & all-time records ──────


### PR DESCRIPTION
Adds a deterministic, once-per-season prestige layer that selects
First-Team All-Pro, Second-Team All-Pro, and Pro Bowl honorees by
stat-based scoring across QB/RB/WR/DL position groups.

- New pure module src/core/awards/prestigeEngine.js with 9 exports:
  PRESTIGE_QUOTAS, mapPlayerToPrestigePosition, computePrestigeScore,
  rankPrestigeCandidates, selectAllProTeams, selectProBowlTeams,
  mergeHonorsIntoPlayers, buildSeasonHonorsSummary,
  getPriorSeasonPrestigePremium

- player.honorsHistory[] schema field added to makePlayer() with
  backward-compatible hydration in hydratePlayerDevelopmentFields()

- Worker wiring: import, hydration, archiveSeason() prestige block
  (runs after HOF), currentSeasonHonors exposed via buildViewState()

- Contract leverage: getPriorSeasonPrestigePremium integrated into
  computeAgentExpectedSalary(); Shark + All-Pro gets +5% extra

- UI: HonorsCenter.jsx with badge styles grouped by position;
  'Honors' tab added to HistoryCenter.jsx

- 93 new tests across unit, integration, and UI suites; all 4498
  tests pass, build clean

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ph4PcxmRhDQzjYTZTMqSdV