### PR TITLE
feat(meta): Owner Expectations & Job Security Engine

### DIFF
--- a/src/core/meta/ownerPressure.integration.test.js
+++ b/src/core/meta/ownerPressure.integration.test.js
@@ -1,0 +1,244 @@
+/**
+ * Integration tests for the owner pressure layer.
+ *
+ * Covers: state hydration, rollover evaluation semantics, threshold behaviour,
+ * AI reset/persona drift integration, user termination flag, and TradeCenter
+ * view-state exposure.  Worker internals are exercised through state structures
+ * and the engine functions used by the worker rollover path.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  OWNER_MANDATES,
+  buildOwnerProfile,
+  determineInitialMandate,
+  evaluateMandate,
+  applyHotSeatDelta,
+  shouldFireFrontOffice,
+  buildAIFiringOutcome,
+  getHotSeatStatus,
+} from './ownerPressureEngine.js';
+import { State } from '../state.js';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function makeTeam(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Test Team',
+    abbr: 'TST',
+    conf: 0,
+    div: 0,
+    ovr: 78,
+    wins: 9,
+    losses: 8,
+    ties: 0,
+    capUsed: 200_000_000,
+    capTotal: 255_000_000,
+    roster: [],
+    picks: [],
+    ringOfHonor: [],
+    allTimeLeaders: { passingYards: null, rushingYards: null, receivingYards: null, sacks: null },
+    retiredNumbers: [],
+    championshipYears: [],
+    ...overrides,
+  };
+}
+
+function makeLeague(teamOverrides = []) {
+  const defaultTeams = Array.from({ length: 32 }, (_, i) => makeTeam({
+    id: i,
+    name: `Team ${i}`,
+    abbr: `T${i}`,
+    conf: i < 16 ? 0 : 1,
+    div: Math.floor(i / 4) % 4,
+    ovr: 70 + (i % 15),
+    wins: 8,
+    losses: 9,
+    capUsed: 180_000_000 + i * 500_000,
+  }));
+  const teams = defaultTeams.map((t, i) =>
+    i < teamOverrides.length ? { ...t, ...teamOverrides[i] } : t
+  );
+  return {
+    teams,
+    newsItems: [],
+    ownerGoals: [],
+    retiredPlayers: [],
+    historyLedger: [],
+    recordBook: {},
+  };
+}
+
+// ── old saves hydrate owner safely ───────────────────────────────────────────
+
+describe('old saves hydrate owner safely', () => {
+  it('migrateLeague adds owner to all teams that lack it', () => {
+    const league = makeLeague();
+    league.teams.forEach(t => delete t.owner);
+    const migrated = State.migrateLeague(league);
+    for (const team of migrated.teams) {
+      expect(team.owner).toBeDefined();
+      expect(typeof team.owner.mandate).toBe('string');
+      expect(typeof team.owner.hotSeatRating).toBe('number');
+      expect(typeof team.owner.seasonsUnderGoal).toBe('number');
+    }
+  });
+
+  it('migrateLeague does not overwrite an existing owner profile', () => {
+    const existingOwner = buildOwnerProfile(OWNER_MANDATES.WIN_DIVISION, { hotSeatRating: 70 });
+    const league = makeLeague();
+    league.teams[0] = { ...league.teams[0], owner: existingOwner };
+    const migrated = State.migrateLeague(league);
+    expect(migrated.teams[0].owner.mandate).toBe(OWNER_MANDATES.WIN_DIVISION);
+    expect(migrated.teams[0].owner.hotSeatRating).toBe(70);
+  });
+
+  it('migrateLeague hydrates userFranchiseTerminated with false default', () => {
+    const league = makeLeague();
+    delete league.userFranchiseTerminated;
+    const migrated = State.migrateLeague(league);
+    expect(migrated.userFranchiseTerminated).toBe(false);
+  });
+
+  it('migrateLeague preserves an existing userFranchiseTerminated value', () => {
+    const league = { ...makeLeague(), userFranchiseTerminated: true };
+    const migrated = State.migrateLeague(league);
+    expect(migrated.userFranchiseTerminated).toBe(true);
+  });
+});
+
+// ── rollover evaluation semantics ─────────────────────────────────────────────
+
+describe('rollover mandate evaluation', () => {
+  it('success lowers hot seat and resets under-goal streak', () => {
+    const ownerProfile = buildOwnerProfile(OWNER_MANDATES.MAKE_PLAYOFFS, {
+      hotSeatRating: 55,
+      seasonsUnderGoal: 2,
+    });
+    const team = makeTeam({ id: 1, owner: ownerProfile });
+    const evaluation = evaluateMandate(team, { playoffTeamIds: new Set([1]) });
+    const updated = applyHotSeatDelta(ownerProfile, evaluation);
+
+    expect(evaluation.achieved).toBe(true);
+    expect(updated.hotSeatRating).toBe(40);
+    expect(updated.seasonsUnderGoal).toBe(0);
+  });
+
+  it('failure raises hot seat and increments streak', () => {
+    const ownerProfile = buildOwnerProfile(OWNER_MANDATES.MAKE_PLAYOFFS, {
+      hotSeatRating: 40,
+      seasonsUnderGoal: 1,
+    });
+    const team = makeTeam({ id: 1, owner: ownerProfile });
+    const evaluation = evaluateMandate(team, { playoffTeamIds: new Set([99]) });
+    const updated = applyHotSeatDelta(ownerProfile, evaluation);
+
+    expect(evaluation.achieved).toBe(false);
+    expect(updated.hotSeatRating).toBe(60);
+    expect(updated.seasonsUnderGoal).toBe(2);
+  });
+
+  it('severe miss (WIN_DIVISION + missed playoffs) adds extra penalty', () => {
+    const ownerProfile = buildOwnerProfile(OWNER_MANDATES.WIN_DIVISION, { hotSeatRating: 30 });
+    const team = makeTeam({ id: 1, wins: 4, losses: 13, conf: 0, div: 0, owner: ownerProfile });
+    const rival = makeTeam({ id: 2, wins: 14, losses: 3, conf: 0, div: 0 });
+    const evaluation = evaluateMandate(team, {
+      allTeams: [team, rival],
+      playoffTeamIds: new Set([2]),
+    });
+    expect(evaluation.severity).toBe('severe');
+    const updated = applyHotSeatDelta(ownerProfile, evaluation);
+    expect(updated.hotSeatRating).toBe(65); // 30 + 20 + 15
+  });
+});
+
+// ── AI team firing threshold behaviour ───────────────────────────────────────
+
+describe('AI team hitting threshold', () => {
+  it('shouldFireFrontOffice triggers at hotSeatRating >= 100', () => {
+    const atThreshold = buildOwnerProfile(OWNER_MANDATES.MAKE_PLAYOFFS, { hotSeatRating: 100 });
+    expect(shouldFireFrontOffice(atThreshold)).toBe(true);
+    const below = buildOwnerProfile(OWNER_MANDATES.MAKE_PLAYOFFS, { hotSeatRating: 99 });
+    expect(shouldFireFrontOffice(below)).toBe(false);
+  });
+
+  it('buildAIFiringOutcome returns reset persona and new mandate', () => {
+    const team = makeTeam({ capUsed: 235_000_000, wins: 3, losses: 14 });
+    const outcome = buildAIFiringOutcome(team, { allTeams: [team] });
+    expect(outcome.newOwnerProfile.hotSeatRating).toBe(30);
+    expect(outcome.newOwnerProfile.seasonsUnderGoal).toBe(0);
+    expect(outcome.newPersona).toBe('CAP_HOARDER');
+  });
+
+  it('buildAIFiringOutcome uses PATIENT_BUILDER for non-cap-stressed losing team', () => {
+    const team = makeTeam({ capUsed: 150_000_000, wins: 2, losses: 15 });
+    const outcome = buildAIFiringOutcome(team, { allTeams: [team] });
+    expect(outcome.newPersona).toBe('PATIENT_BUILDER');
+  });
+});
+
+// ── user team hitting threshold ───────────────────────────────────────────────
+
+describe('user team hitting threshold', () => {
+  it('reaching hotSeatRating >= 100 signals termination', () => {
+    const ownerProfile = buildOwnerProfile(OWNER_MANDATES.MAKE_PLAYOFFS, { hotSeatRating: 80 });
+    const team = makeTeam({ id: 0, owner: ownerProfile });
+    const evaluation = evaluateMandate(team, { playoffTeamIds: new Set([99]) }); // missed playoffs
+    const updated = applyHotSeatDelta(ownerProfile, evaluation);
+    expect(shouldFireFrontOffice(updated)).toBe(true);
+  });
+});
+
+// ── TradeCenter view-state exposure ──────────────────────────────────────────
+
+describe('TradeCenter view-state exposes high-pressure opponent hint data', () => {
+  it('getHotSeatStatus returns high-risk for opponent at 80+', () => {
+    const opponentOwner = buildOwnerProfile(OWNER_MANDATES.MAKE_PLAYOFFS, { hotSeatRating: 85 });
+    expect(getHotSeatStatus(opponentOwner)).toBe('high-risk');
+  });
+
+  it('getHotSeatStatus returns unstable for opponent at 50–79', () => {
+    const opponentOwner = buildOwnerProfile(OWNER_MANDATES.MAKE_PLAYOFFS, { hotSeatRating: 65 });
+    expect(getHotSeatStatus(opponentOwner)).toBe('unstable');
+  });
+
+  it('getHotSeatStatus returns secure for opponent below 50', () => {
+    const opponentOwner = buildOwnerProfile(OWNER_MANDATES.MAKE_PLAYOFFS, { hotSeatRating: 30 });
+    expect(getHotSeatStatus(opponentOwner)).toBe('secure');
+  });
+});
+
+// ── rerun-safe: same rollover does not double-apply deltas ────────────────────
+
+describe('rerun-safe rollover', () => {
+  it('applying delta once vs. twice produces different results (confirms guard is needed)', () => {
+    const ownerProfile = buildOwnerProfile(OWNER_MANDATES.MAKE_PLAYOFFS, { hotSeatRating: 30 });
+    const evaluation = { achieved: false, severity: 'normal' };
+
+    const afterOne = applyHotSeatDelta(ownerProfile, evaluation);
+    const afterTwo = applyHotSeatDelta(afterOne, evaluation);
+
+    expect(afterOne.hotSeatRating).toBe(50);
+    expect(afterTwo.hotSeatRating).toBe(70); // double-apply would give this
+    // The worker guards against re-entry via ownerPressureEvaluatedForSeason
+    // so only afterOne is the correct post-rollover state.
+    expect(afterOne.hotSeatRating).not.toBe(afterTwo.hotSeatRating);
+  });
+
+  it('a successful season resets streak regardless of prior consecutive failures', () => {
+    let profile = buildOwnerProfile(OWNER_MANDATES.MAKE_PLAYOFFS, { hotSeatRating: 25 });
+    const fail = { achieved: false, severity: 'normal' };
+    const pass = { achieved: true,  severity: 'normal' };
+
+    // 3 failures then success
+    profile = applyHotSeatDelta(profile, fail);
+    profile = applyHotSeatDelta(profile, fail);
+    profile = applyHotSeatDelta(profile, fail);
+    expect(profile.seasonsUnderGoal).toBe(3);
+
+    profile = applyHotSeatDelta(profile, pass);
+    expect(profile.seasonsUnderGoal).toBe(0);
+    expect(profile.hotSeatRating).toBeLessThan(80);
+  });
+});

--- a/src/core/meta/ownerPressureEngine.js
+++ b/src/core/meta/ownerPressureEngine.js
@@ -1,0 +1,302 @@
+/**
+ * ownerPressureEngine.js — Owner Expectations & Job Security Engine
+ *
+ * Pure, deterministic module. No Math.random, no UI imports, no worker imports.
+ * All outputs are immutable new objects. Inputs are never mutated.
+ */
+
+// ── Mandate constants ─────────────────────────────────────────────────────────
+
+export const OWNER_MANDATES = Object.freeze({
+  MAKE_PLAYOFFS:      'MAKE_PLAYOFFS',
+  WIN_DIVISION:       'WIN_DIVISION',
+  DEVELOP_YOUNG_CORE: 'DEVELOP_YOUNG_CORE',
+  REDUCE_PAYROLL:     'REDUCE_PAYROLL',
+});
+
+const MANDATE_LABELS = Object.freeze({
+  MAKE_PLAYOFFS:      'Make the Playoffs',
+  WIN_DIVISION:       'Win the Division',
+  DEVELOP_YOUNG_CORE: 'Develop Young Core',
+  REDUCE_PAYROLL:     'Reduce Payroll',
+});
+
+// ── Profile builder ───────────────────────────────────────────────────────────
+
+/**
+ * Returns a safe owner profile with baseline values.
+ *
+ * @param {string} mandate - One of OWNER_MANDATES keys
+ * @param {object} [overrides] - Optional overrides (hotSeatRating, seasonsUnderGoal, …)
+ * @returns {object}
+ */
+export function buildOwnerProfile(mandate, overrides = {}) {
+  const safeMandate = OWNER_MANDATES[mandate] ? mandate : OWNER_MANDATES.MAKE_PLAYOFFS;
+  return {
+    mandate: safeMandate,
+    hotSeatRating: 25,
+    seasonsUnderGoal: 0,
+    ...overrides,
+  };
+}
+
+// ── determineInitialMandate ───────────────────────────────────────────────────
+
+/**
+ * Deterministically derive the initial owner mandate from team state.
+ * No Math.random. Same inputs always produce the same mandate.
+ *
+ * Priority (evaluated in order):
+ *  1. Cap-stressed (capPct >= 0.92) → REDUCE_PAYROLL
+ *  2. Weak OVR percentile (≤ 0.35) or very young roster → DEVELOP_YOUNG_CORE
+ *  3. Top-tier percentile (≥ 0.65) → WIN_DIVISION
+ *  4. Default → MAKE_PLAYOFFS
+ *
+ * @param {object} team
+ * @param {object} [context] - { allTeams }
+ * @returns {string} One of OWNER_MANDATES
+ */
+export function determineInitialMandate(team, context = {}) {
+  const allTeams = context.allTeams ?? [];
+  const capUsed  = Number(team?.capUsed  ?? 0);
+  const capTotal = Number(team?.capTotal ?? 255_000_000);
+  const capPct   = capTotal > 0 ? capUsed / capTotal : 0;
+
+  const roster = Array.isArray(team?.roster) ? team.roster : [];
+  const avgAge  = roster.length > 0
+    ? roster.reduce((s, p) => s + Number(p?.age ?? 25), 0) / roster.length
+    : 25;
+
+  // Power-rank percentile (1.0 = best team in league)
+  let pctile = 0.5;
+  if (allTeams.length > 0) {
+    const sorted = [...allTeams].sort(
+      (a, b) => Number(b.ovr ?? b.overallRating ?? 0) - Number(a.ovr ?? a.overallRating ?? 0),
+    );
+    const idx = sorted.findIndex(t => t.id === team.id);
+    pctile = idx >= 0 ? 1 - idx / allTeams.length : 0.5;
+  }
+
+  // Rule 1: Cap-stressed → REDUCE_PAYROLL
+  if (capPct >= 0.92) return OWNER_MANDATES.REDUCE_PAYROLL;
+
+  // Rule 2: Weak or very young → DEVELOP_YOUNG_CORE
+  if (pctile <= 0.35 || avgAge < 24) return OWNER_MANDATES.DEVELOP_YOUNG_CORE;
+
+  // Rule 3: Top-tier → WIN_DIVISION
+  if (pctile >= 0.65) return OWNER_MANDATES.WIN_DIVISION;
+
+  // Rule 4: Solid middle → MAKE_PLAYOFFS
+  return OWNER_MANDATES.MAKE_PLAYOFFS;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function _winPct(t) {
+  const wins   = Number(t?.wins   ?? 0);
+  const ties   = Number(t?.ties   ?? 0);
+  const losses = Number(t?.losses ?? 0);
+  const total  = wins + losses + ties;
+  return total > 0 ? (wins + ties * 0.5) / total : 0;
+}
+
+// ── evaluateMandate ───────────────────────────────────────────────────────────
+
+/**
+ * Evaluate whether a team fulfilled its owner mandate this season.
+ *
+ * @param {object} team         - Team object with `owner.mandate`, win/loss, capUsed, conf, div
+ * @param {object} [context]    - { allTeams, playoffTeamIds, teamRoster }
+ * @returns {{ achieved: boolean, reason: string, severity: 'normal'|'severe' }}
+ */
+export function evaluateMandate(team, context = {}) {
+  const mandate = team?.owner?.mandate;
+  if (!mandate) return { achieved: false, reason: 'No mandate set', severity: 'normal' };
+
+  const allTeams = context.allTeams ?? [];
+  const rawIds   = context.playoffTeamIds;
+  const playoffTeamIds = rawIds instanceof Set
+    ? rawIds
+    : new Set(Array.isArray(rawIds) ? rawIds : []);
+  const teamRoster = Array.isArray(context.teamRoster)
+    ? context.teamRoster
+    : Array.isArray(team?.roster) ? team.roster : [];
+
+  const madePlayoffs = playoffTeamIds.has(team.id);
+
+  switch (mandate) {
+    case OWNER_MANDATES.MAKE_PLAYOFFS: {
+      if (madePlayoffs) return { achieved: true, reason: 'Qualified for postseason', severity: 'normal' };
+      return { achieved: false, reason: 'Missed the playoffs', severity: 'normal' };
+    }
+
+    case OWNER_MANDATES.WIN_DIVISION: {
+      const sameDiv = allTeams.filter(t => t.conf === team.conf && t.div === team.div);
+      const teamWP  = _winPct(team);
+      const teamW   = Number(team?.wins ?? 0);
+      const isDivWinner = sameDiv.length === 0 || sameDiv.every(
+        t => t.id === team.id ||
+          teamWP > _winPct(t) ||
+          (Math.abs(teamWP - _winPct(t)) < 1e-9 && teamW >= Number(t?.wins ?? 0)),
+      );
+      if (isDivWinner) return { achieved: true, reason: 'Won the division', severity: 'normal' };
+      const severity = !madePlayoffs ? 'severe' : 'normal';
+      return { achieved: false, reason: 'Did not win the division', severity };
+    }
+
+    case OWNER_MANDATES.DEVELOP_YOUNG_CORE: {
+      const young = teamRoster.filter(p => Number(p?.age ?? 30) < 25 && Number(p?.ovr ?? 0) >= 78);
+      if (young.length >= 4) {
+        return { achieved: true, reason: `${young.length} young contributors (U25, OVR 78+)`, severity: 'normal' };
+      }
+      return {
+        achieved: false,
+        reason: `Only ${young.length} young contributor${young.length === 1 ? '' : 's'} (U25, OVR 78+) — need 4`,
+        severity: 'normal',
+      };
+    }
+
+    case OWNER_MANDATES.REDUCE_PAYROLL: {
+      const allCapUsed = allTeams.map(t => Number(t?.capUsed ?? 0)).sort((a, b) => a - b);
+      const medianIdx  = Math.floor(allCapUsed.length / 2);
+      const median     = allCapUsed.length > 0 ? allCapUsed[medianIdx] : 0;
+      const teamCap    = Number(team?.capUsed ?? 0);
+      if (teamCap <= median) {
+        return { achieved: true, reason: 'Cap obligations in bottom half of league', severity: 'normal' };
+      }
+      return { achieved: false, reason: 'Cap obligations above league median', severity: 'normal' };
+    }
+
+    default:
+      return { achieved: false, reason: `Unknown mandate: ${mandate}`, severity: 'normal' };
+  }
+}
+
+// ── applyHotSeatDelta ─────────────────────────────────────────────────────────
+
+/**
+ * Apply a hot-seat rating change based on mandate evaluation.
+ * Immutable — returns a new profile object.
+ *
+ * Success:
+ *   hotSeatRating −15 (floor 0), seasonsUnderGoal reset to 0.
+ * Failure:
+ *   hotSeatRating +20; severe miss adds +15 more.
+ *   seasonsUnderGoal incremented.
+ *
+ * @param {object} ownerProfile
+ * @param {{ achieved: boolean, severity: string }} evaluation
+ * @returns {object} Updated owner profile (new object)
+ */
+export function applyHotSeatDelta(ownerProfile, evaluation) {
+  if (!ownerProfile) return ownerProfile;
+
+  const current    = Number(ownerProfile.hotSeatRating ?? 25);
+  const underGoal  = Number(ownerProfile.seasonsUnderGoal ?? 0);
+
+  if (evaluation.achieved) {
+    return {
+      ...ownerProfile,
+      hotSeatRating:    Math.max(0, current - 15),
+      seasonsUnderGoal: 0,
+    };
+  }
+
+  let delta = 20;
+  if (evaluation.severity === 'severe') delta += 15;
+
+  return {
+    ...ownerProfile,
+    hotSeatRating:    current + delta,
+    seasonsUnderGoal: underGoal + 1,
+  };
+}
+
+// ── shouldFireFrontOffice ─────────────────────────────────────────────────────
+
+/**
+ * Returns true when the hot-seat rating has reached the firing threshold (>= 100).
+ *
+ * @param {object} ownerProfile
+ * @returns {boolean}
+ */
+export function shouldFireFrontOffice(ownerProfile) {
+  return Number(ownerProfile?.hotSeatRating ?? 0) >= 100;
+}
+
+// ── buildAIFiringOutcome ──────────────────────────────────────────────────────
+
+/**
+ * Returns a deterministic reset plan for AI teams whose front office is fired.
+ * No Math.random.
+ *
+ * Persona signal:
+ *   Expensive failing roster (capPct ≥ 0.85 AND winPct < 0.5) → CAP_HOARDER
+ *   Otherwise (weak/losing team)                               → PATIENT_BUILDER
+ *
+ * @param {object} team
+ * @param {object} [context] - { allTeams }
+ * @returns {{ newPersona: string, newMandate: string, newOwnerProfile: object }}
+ */
+export function buildAIFiringOutcome(team, context = {}) {
+  const allTeams = context.allTeams ?? [];
+  const capUsed  = Number(team?.capUsed  ?? 0);
+  const capTotal = Number(team?.capTotal ?? 255_000_000);
+  const capPct   = capTotal > 0 ? capUsed / capTotal : 0;
+  const wins     = Number(team?.wins   ?? 0);
+  const losses   = Number(team?.losses ?? 0);
+  const winPct   = (wins + losses) > 0 ? wins / (wins + losses) : 0;
+
+  const newPersona = (capPct >= 0.85 && winPct < 0.5) ? 'CAP_HOARDER' : 'PATIENT_BUILDER';
+
+  // New mandate derived from post-firing team state
+  let pctile = 0.5;
+  if (allTeams.length > 0) {
+    const sorted = [...allTeams].sort((a, b) => Number(b.ovr ?? 0) - Number(a.ovr ?? 0));
+    const idx = sorted.findIndex(t => t.id === team.id);
+    pctile = idx >= 0 ? 1 - idx / allTeams.length : 0.5;
+  }
+
+  const newMandate = capPct >= 0.92
+    ? OWNER_MANDATES.REDUCE_PAYROLL
+    : pctile <= 0.40
+      ? OWNER_MANDATES.DEVELOP_YOUNG_CORE
+      : OWNER_MANDATES.MAKE_PLAYOFFS;
+
+  return {
+    newPersona,
+    newMandate,
+    newOwnerProfile: buildOwnerProfile(newMandate, { hotSeatRating: 30, seasonsUnderGoal: 0 }),
+  };
+}
+
+// ── getHotSeatStatus ──────────────────────────────────────────────────────────
+
+/**
+ * Returns a UI-friendly band string for the hot-seat rating.
+ *
+ * secure:    hotSeatRating  < 50
+ * unstable:  hotSeatRating 50–79
+ * high-risk: hotSeatRating >= 80
+ *
+ * @param {object} ownerProfile
+ * @returns {'secure'|'unstable'|'high-risk'}
+ */
+export function getHotSeatStatus(ownerProfile) {
+  const rating = Number(ownerProfile?.hotSeatRating ?? 25);
+  if (rating < 50) return 'secure';
+  if (rating < 80) return 'unstable';
+  return 'high-risk';
+}
+
+// ── getMandateLabel ───────────────────────────────────────────────────────────
+
+/**
+ * Returns a human-readable label for a mandate key.
+ *
+ * @param {string} mandate
+ * @returns {string}
+ */
+export function getMandateLabel(mandate) {
+  return MANDATE_LABELS[mandate] ?? (mandate ? String(mandate).replace(/_/g, ' ') : 'Unknown');
+}

--- a/src/core/meta/ownerPressureEngine.unit.test.js
+++ b/src/core/meta/ownerPressureEngine.unit.test.js
@@ -1,0 +1,361 @@
+import { describe, expect, it } from 'vitest';
+import {
+  OWNER_MANDATES,
+  buildOwnerProfile,
+  determineInitialMandate,
+  evaluateMandate,
+  applyHotSeatDelta,
+  shouldFireFrontOffice,
+  buildAIFiringOutcome,
+  getHotSeatStatus,
+  getMandateLabel,
+} from './ownerPressureEngine.js';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function makeTeam(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Test Team',
+    abbr: 'TST',
+    conf: 0,
+    div: 0,
+    ovr: 78,
+    wins: 8,
+    losses: 9,
+    ties: 0,
+    capUsed: 200_000_000,
+    capTotal: 255_000_000,
+    roster: [],
+    ...overrides,
+  };
+}
+
+function makeAllTeams(count = 32, baseOvr = 75) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: i,
+    ovr: baseOvr + (i % 20),
+    capUsed: 180_000_000 + i * 1_000_000,
+    capTotal: 255_000_000,
+    conf: i < 16 ? 0 : 1,
+    div: Math.floor(i / 4) % 4,
+    wins: i % 17,
+    losses: 17 - (i % 17),
+    ties: 0,
+    roster: [],
+  }));
+}
+
+// ── OWNER_MANDATES constants ──────────────────────────────────────────────────
+
+describe('OWNER_MANDATES', () => {
+  it('exports all four mandate keys as frozen constants', () => {
+    expect(OWNER_MANDATES.MAKE_PLAYOFFS).toBe('MAKE_PLAYOFFS');
+    expect(OWNER_MANDATES.WIN_DIVISION).toBe('WIN_DIVISION');
+    expect(OWNER_MANDATES.DEVELOP_YOUNG_CORE).toBe('DEVELOP_YOUNG_CORE');
+    expect(OWNER_MANDATES.REDUCE_PAYROLL).toBe('REDUCE_PAYROLL');
+    expect(Object.isFrozen(OWNER_MANDATES)).toBe(true);
+  });
+});
+
+// ── buildOwnerProfile ─────────────────────────────────────────────────────────
+
+describe('buildOwnerProfile', () => {
+  it('returns safe baseline with MAKE_PLAYOFFS mandate', () => {
+    const profile = buildOwnerProfile(OWNER_MANDATES.MAKE_PLAYOFFS);
+    expect(profile.mandate).toBe('MAKE_PLAYOFFS');
+    expect(profile.hotSeatRating).toBe(25);
+    expect(profile.seasonsUnderGoal).toBe(0);
+  });
+
+  it('accepts overrides', () => {
+    const profile = buildOwnerProfile(OWNER_MANDATES.WIN_DIVISION, { hotSeatRating: 60 });
+    expect(profile.mandate).toBe('WIN_DIVISION');
+    expect(profile.hotSeatRating).toBe(60);
+  });
+
+  it('falls back to MAKE_PLAYOFFS for unknown mandate', () => {
+    const profile = buildOwnerProfile('INVALID_MANDATE');
+    expect(profile.mandate).toBe('MAKE_PLAYOFFS');
+  });
+});
+
+// ── determineInitialMandate ───────────────────────────────────────────────────
+
+describe('determineInitialMandate', () => {
+  it('is deterministic for the same inputs', () => {
+    const allTeams = makeAllTeams();
+    const team = { ...allTeams[0], ovr: 90, capUsed: 180_000_000 };
+    const r1 = determineInitialMandate(team, { allTeams });
+    const r2 = determineInitialMandate(team, { allTeams });
+    expect(r1).toBe(r2);
+  });
+
+  it('maps a top-tier team (high OVR, top percentile) to WIN_DIVISION', () => {
+    const allTeams = makeAllTeams(32, 70);
+    // Force this team to be the best
+    const team = { ...allTeams[0], id: 999, ovr: 100, capUsed: 180_000_000, capTotal: 255_000_000 };
+    const allWithBest = [...allTeams, team];
+    expect(determineInitialMandate(team, { allTeams: allWithBest })).toBe(OWNER_MANDATES.WIN_DIVISION);
+  });
+
+  it('maps a bottom-percentile team to DEVELOP_YOUNG_CORE', () => {
+    const allTeams = makeAllTeams(32, 75);
+    // Worst team in league
+    const worst = { ...allTeams[0], id: 99, ovr: 50, capUsed: 150_000_000, capTotal: 255_000_000, roster: [] };
+    const allWithWorst = [worst, ...allTeams];
+    expect(determineInitialMandate(worst, { allTeams: allWithWorst })).toBe(OWNER_MANDATES.DEVELOP_YOUNG_CORE);
+  });
+
+  it('maps a cap-stressed team to REDUCE_PAYROLL', () => {
+    const allTeams = makeAllTeams();
+    // Cap stressed: capUsed >= 92% of cap
+    const stressed = {
+      ...allTeams[10], id: 55, ovr: 80, capUsed: 236_000_000, capTotal: 255_000_000,
+    };
+    const result = determineInitialMandate(stressed, { allTeams: [...allTeams, stressed] });
+    expect(result).toBe(OWNER_MANDATES.REDUCE_PAYROLL);
+  });
+
+  it('maps a mid-pack team to MAKE_PLAYOFFS', () => {
+    // Build a controlled 32-team array where the target team is exactly middle
+    // OVR rank (16th of 32) so it is clearly neither top nor bottom quartile.
+    const allTeams = Array.from({ length: 32 }, (_, i) => ({
+      id: i, ovr: 60 + i, capUsed: 180_000_000, capTotal: 255_000_000,
+      conf: 0, div: 0, wins: 8, losses: 9, ties: 0, roster: [],
+    }));
+    // This team has OVR 76 (rank ~16/32 = 50th percentile, i = 16)
+    const midTeam = { ...allTeams[16], id: 16 };
+    const result = determineInitialMandate(midTeam, { allTeams });
+    expect(result).toBe(OWNER_MANDATES.MAKE_PLAYOFFS);
+  });
+});
+
+// ── evaluateMandate ───────────────────────────────────────────────────────────
+
+describe('evaluateMandate', () => {
+  it('MAKE_PLAYOFFS: passes for a playoff team', () => {
+    const team = makeTeam({ owner: { mandate: OWNER_MANDATES.MAKE_PLAYOFFS } });
+    const result = evaluateMandate(team, { playoffTeamIds: new Set([team.id]) });
+    expect(result.achieved).toBe(true);
+    expect(result.severity).toBe('normal');
+  });
+
+  it('MAKE_PLAYOFFS: fails for a non-playoff team', () => {
+    const team = makeTeam({ owner: { mandate: OWNER_MANDATES.MAKE_PLAYOFFS } });
+    const result = evaluateMandate(team, { playoffTeamIds: new Set([99]) });
+    expect(result.achieved).toBe(false);
+  });
+
+  it('WIN_DIVISION: passes for the division leader by record', () => {
+    const team = makeTeam({ id: 1, wins: 13, losses: 4, owner: { mandate: OWNER_MANDATES.WIN_DIVISION } });
+    const rival = makeTeam({ id: 2, wins: 9, losses: 8 });
+    const allTeams = [team, rival];
+    const result = evaluateMandate(team, { allTeams, playoffTeamIds: new Set([1]) });
+    expect(result.achieved).toBe(true);
+  });
+
+  it('WIN_DIVISION: fails for a non-division-leader', () => {
+    const team = makeTeam({ id: 1, wins: 7, losses: 10, owner: { mandate: OWNER_MANDATES.WIN_DIVISION } });
+    const leader = makeTeam({ id: 2, wins: 12, losses: 5 });
+    const allTeams = [team, leader];
+    const result = evaluateMandate(team, { allTeams, playoffTeamIds: new Set([2]) });
+    expect(result.achieved).toBe(false);
+  });
+
+  it('WIN_DIVISION: severe miss when team also missed playoffs', () => {
+    const team = makeTeam({ id: 1, wins: 5, losses: 12, owner: { mandate: OWNER_MANDATES.WIN_DIVISION } });
+    const leader = makeTeam({ id: 2, wins: 14, losses: 3 });
+    const allTeams = [team, leader];
+    const result = evaluateMandate(team, { allTeams, playoffTeamIds: new Set([2]) });
+    expect(result.achieved).toBe(false);
+    expect(result.severity).toBe('severe');
+  });
+
+  it('DEVELOP_YOUNG_CORE: passes when team has >= 4 U25 players with OVR 78+', () => {
+    const youngStarters = Array.from({ length: 5 }, (_, i) => ({ id: i, age: 23, ovr: 80 }));
+    const team = makeTeam({ owner: { mandate: OWNER_MANDATES.DEVELOP_YOUNG_CORE } });
+    const result = evaluateMandate(team, { playoffTeamIds: new Set(), teamRoster: youngStarters });
+    expect(result.achieved).toBe(true);
+  });
+
+  it('DEVELOP_YOUNG_CORE: fails when team has < 4 qualifying young players', () => {
+    const youngStarters = [{ id: 1, age: 23, ovr: 79 }]; // only 1
+    const team = makeTeam({ owner: { mandate: OWNER_MANDATES.DEVELOP_YOUNG_CORE } });
+    const result = evaluateMandate(team, { playoffTeamIds: new Set(), teamRoster: youngStarters });
+    expect(result.achieved).toBe(false);
+  });
+
+  it('REDUCE_PAYROLL: passes when team capUsed is at or below league median', () => {
+    const allTeams = Array.from({ length: 10 }, (_, i) => ({
+      id: i, capUsed: 200_000_000 + i * 5_000_000, capTotal: 255_000_000,
+    }));
+    const team = { ...allTeams[0], id: 0, capUsed: 200_000_000, owner: { mandate: OWNER_MANDATES.REDUCE_PAYROLL } };
+    const result = evaluateMandate(team, { allTeams, playoffTeamIds: new Set() });
+    expect(result.achieved).toBe(true);
+  });
+
+  it('REDUCE_PAYROLL: fails when team capUsed is above league median', () => {
+    const allTeams = Array.from({ length: 10 }, (_, i) => ({
+      id: i, capUsed: 150_000_000 + i * 5_000_000, capTotal: 255_000_000,
+    }));
+    const highCapTeam = { ...allTeams[9], id: 9, capUsed: 195_000_000, owner: { mandate: OWNER_MANDATES.REDUCE_PAYROLL } };
+    const result = evaluateMandate(highCapTeam, { allTeams, playoffTeamIds: new Set() });
+    expect(result.achieved).toBe(false);
+  });
+});
+
+// ── applyHotSeatDelta ─────────────────────────────────────────────────────────
+
+describe('applyHotSeatDelta', () => {
+  it('lowers hotSeatRating on success', () => {
+    const profile = buildOwnerProfile(OWNER_MANDATES.MAKE_PLAYOFFS, { hotSeatRating: 60 });
+    const updated = applyHotSeatDelta(profile, { achieved: true, severity: 'normal' });
+    expect(updated.hotSeatRating).toBe(45);
+    expect(updated.seasonsUnderGoal).toBe(0);
+  });
+
+  it('floors hotSeatRating at 0 on success', () => {
+    const profile = buildOwnerProfile(OWNER_MANDATES.MAKE_PLAYOFFS, { hotSeatRating: 5 });
+    const updated = applyHotSeatDelta(profile, { achieved: true, severity: 'normal' });
+    expect(updated.hotSeatRating).toBe(0);
+  });
+
+  it('raises hotSeatRating on failure', () => {
+    const profile = buildOwnerProfile(OWNER_MANDATES.MAKE_PLAYOFFS, { hotSeatRating: 30 });
+    const updated = applyHotSeatDelta(profile, { achieved: false, severity: 'normal' });
+    expect(updated.hotSeatRating).toBe(50);
+    expect(updated.seasonsUnderGoal).toBe(1);
+  });
+
+  it('adds extra penalty for severe miss', () => {
+    const profile = buildOwnerProfile(OWNER_MANDATES.WIN_DIVISION, { hotSeatRating: 30 });
+    const updated = applyHotSeatDelta(profile, { achieved: false, severity: 'severe' });
+    expect(updated.hotSeatRating).toBe(65); // 30 + 20 + 15
+    expect(updated.seasonsUnderGoal).toBe(1);
+  });
+
+  it('does not mutate the input profile', () => {
+    const profile = buildOwnerProfile(OWNER_MANDATES.MAKE_PLAYOFFS, { hotSeatRating: 40 });
+    const originalRating = profile.hotSeatRating;
+    applyHotSeatDelta(profile, { achieved: false, severity: 'normal' });
+    expect(profile.hotSeatRating).toBe(originalRating);
+  });
+});
+
+// ── shouldFireFrontOffice ─────────────────────────────────────────────────────
+
+describe('shouldFireFrontOffice', () => {
+  it('returns false below threshold', () => {
+    expect(shouldFireFrontOffice({ hotSeatRating: 99 })).toBe(false);
+  });
+
+  it('returns true at exactly 100', () => {
+    expect(shouldFireFrontOffice({ hotSeatRating: 100 })).toBe(true);
+  });
+
+  it('returns true above 100', () => {
+    expect(shouldFireFrontOffice({ hotSeatRating: 120 })).toBe(true);
+  });
+
+  it('returns false with null profile', () => {
+    expect(shouldFireFrontOffice(null)).toBe(false);
+  });
+});
+
+// ── buildAIFiringOutcome ──────────────────────────────────────────────────────
+
+describe('buildAIFiringOutcome', () => {
+  it('returns deterministic persona reset plan', () => {
+    const team = makeTeam({ capUsed: 230_000_000, wins: 3, losses: 14 });
+    const outcome = buildAIFiringOutcome(team, { allTeams: makeAllTeams() });
+    expect(['CAP_HOARDER', 'PATIENT_BUILDER']).toContain(outcome.newPersona);
+    expect(Object.values(OWNER_MANDATES)).toContain(outcome.newMandate);
+    expect(typeof outcome.newOwnerProfile).toBe('object');
+    expect(outcome.newOwnerProfile.hotSeatRating).toBe(30);
+    expect(outcome.newOwnerProfile.seasonsUnderGoal).toBe(0);
+  });
+
+  it('expensive failing roster → CAP_HOARDER', () => {
+    const team = makeTeam({ capUsed: 235_000_000, capTotal: 255_000_000, wins: 3, losses: 14 });
+    const outcome = buildAIFiringOutcome(team, { allTeams: [] });
+    expect(outcome.newPersona).toBe('CAP_HOARDER');
+  });
+
+  it('weak roster without cap stress → PATIENT_BUILDER', () => {
+    const team = makeTeam({ capUsed: 150_000_000, capTotal: 255_000_000, wins: 2, losses: 15 });
+    const outcome = buildAIFiringOutcome(team, { allTeams: [] });
+    expect(outcome.newPersona).toBe('PATIENT_BUILDER');
+  });
+
+  it('is deterministic (same inputs = same outputs)', () => {
+    const team = makeTeam({ capUsed: 220_000_000, wins: 5, losses: 12 });
+    const allTeams = makeAllTeams();
+    const r1 = buildAIFiringOutcome(team, { allTeams });
+    const r2 = buildAIFiringOutcome(team, { allTeams });
+    expect(r1.newPersona).toBe(r2.newPersona);
+    expect(r1.newMandate).toBe(r2.newMandate);
+  });
+});
+
+// ── getHotSeatStatus ──────────────────────────────────────────────────────────
+
+describe('getHotSeatStatus', () => {
+  it('returns secure for rating < 50', () => {
+    expect(getHotSeatStatus({ hotSeatRating: 0 })).toBe('secure');
+    expect(getHotSeatStatus({ hotSeatRating: 25 })).toBe('secure');
+    expect(getHotSeatStatus({ hotSeatRating: 49 })).toBe('secure');
+  });
+
+  it('returns unstable for rating 50–79', () => {
+    expect(getHotSeatStatus({ hotSeatRating: 50 })).toBe('unstable');
+    expect(getHotSeatStatus({ hotSeatRating: 65 })).toBe('unstable');
+    expect(getHotSeatStatus({ hotSeatRating: 79 })).toBe('unstable');
+  });
+
+  it('returns high-risk for rating >= 80', () => {
+    expect(getHotSeatStatus({ hotSeatRating: 80 })).toBe('high-risk');
+    expect(getHotSeatStatus({ hotSeatRating: 100 })).toBe('high-risk');
+    expect(getHotSeatStatus({ hotSeatRating: 120 })).toBe('high-risk');
+  });
+
+  it('returns secure for null/missing profile', () => {
+    expect(getHotSeatStatus(null)).toBe('secure');
+    expect(getHotSeatStatus({})).toBe('secure');
+  });
+});
+
+// ── no Math.random in module ──────────────────────────────────────────────────
+
+describe('no Math.random in ownerPressureEngine', () => {
+  it('determineInitialMandate produces same result on repeated calls', () => {
+    const allTeams = makeAllTeams(32, 78);
+    const team = { ...allTeams[5], id: 5 };
+    const results = Array.from({ length: 10 }, () => determineInitialMandate(team, { allTeams }));
+    expect(new Set(results).size).toBe(1);
+  });
+
+  it('buildAIFiringOutcome produces same result on repeated calls', () => {
+    const team = makeTeam({ capUsed: 220_000_000, wins: 4, losses: 13 });
+    const allTeams = makeAllTeams();
+    const outcomes = Array.from({ length: 5 }, () => buildAIFiringOutcome(team, { allTeams }));
+    const personas = outcomes.map(o => o.newPersona);
+    expect(new Set(personas).size).toBe(1);
+  });
+});
+
+// ── getMandateLabel ───────────────────────────────────────────────────────────
+
+describe('getMandateLabel', () => {
+  it('returns human-readable labels for all mandates', () => {
+    expect(getMandateLabel(OWNER_MANDATES.MAKE_PLAYOFFS)).toBe('Make the Playoffs');
+    expect(getMandateLabel(OWNER_MANDATES.WIN_DIVISION)).toBe('Win the Division');
+    expect(getMandateLabel(OWNER_MANDATES.DEVELOP_YOUNG_CORE)).toBe('Develop Young Core');
+    expect(getMandateLabel(OWNER_MANDATES.REDUCE_PAYROLL)).toBe('Reduce Payroll');
+  });
+
+  it('handles unknown mandate gracefully', () => {
+    expect(getMandateLabel('UNKNOWN')).toBe('UNKNOWN');
+    expect(getMandateLabel(null)).toBe('Unknown');
+  });
+});

--- a/src/core/state.js
+++ b/src/core/state.js
@@ -5,6 +5,10 @@
 import { Constants } from './constants.js';
 import { ensureFaceConfig } from './face.js';
 import { determineInitialPersona } from './ai/frontOfficePersonaEngine.js';
+import {
+  buildOwnerProfile,
+  determineInitialMandate,
+} from './meta/ownerPressureEngine.js';
 
 export let state = null;
 
@@ -548,6 +552,19 @@ export const State = {
       if (!Array.isArray(t.championshipYears)) t.championshipYears = [];
       return t;
     });
+
+    // ── Owner Mandate — deterministic hydration for old saves ────────────────
+    // Backward-compatible: old saves get a safe owner profile derived from real
+    // team signals. Same save always derives the same initial mandate.
+    migrated.teams = migrated.teams.map((team) => {
+      if (!team) return team;
+      if (team.owner && typeof team.owner === 'object' && team.owner.mandate) return team;
+      const mandate = determineInitialMandate(team, { allTeams: migrated.teams });
+      return { ...team, owner: buildOwnerProfile(mandate) };
+    });
+
+    // ── User franchise termination flag — backward-compatible default ────────
+    migrated.userFranchiseTerminated = migrated.userFranchiseTerminated ?? false;
 
     // ── Front Office Persona — deterministic hydration for old saves ──────────
     // Never random-assigned; same save always derives the same initial persona.

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -17,6 +17,7 @@ import ChronicleHeadlineBanner from './ChronicleHeadlineBanner.tsx';
 import CombineDashboard from './CombineDashboard.jsx';
 import FranchiseLegacyView from './FranchiseLegacyView.jsx';
 import FranchiseBrandHQ from './FranchiseBrandHQ.jsx';
+import JobSecurityCard from './JobSecurityCard.jsx';
 
 const BOTTOM_NAV_ITEMS = [
   { label: 'Home', route: 'HQ', icon: 'home', active: true },
@@ -799,7 +800,32 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
               Front Office
             </button>
           </article>
+
+          <JobSecurityCard ownerProfile={league?.userOwnerPressure} />
         </div>
+
+        {/* Franchise termination notice (blocking, shown when user is fired) */}
+        {league?.userFranchiseTerminated && (
+          <div
+            data-testid="franchise-terminated-notice"
+            role="alert"
+            style={{
+              margin: '8px 12px',
+              padding: 'var(--space-4)',
+              border: '2px solid var(--danger, #FF453A)',
+              background: 'rgba(255,69,58,0.10)',
+              borderRadius: 'var(--radius-md)',
+            }}
+          >
+            <strong style={{ display: 'block', color: 'var(--danger, #FF453A)', marginBottom: 4 }}>
+              🚨 Franchise Dismissed
+            </strong>
+            <p style={{ color: 'var(--text-muted)', fontSize: 'var(--text-sm)', margin: 0 }}>
+              The ownership group has terminated your tenure as General Manager due to repeated failure
+              to meet the team mandate. Load a previous save or start a new franchise to continue.
+            </p>
+          </div>
+        )}
 
         {/* League quick navigation */}
         <nav

--- a/src/ui/components/JobSecurityCard.jsx
+++ b/src/ui/components/JobSecurityCard.jsx
@@ -1,0 +1,102 @@
+/**
+ * JobSecurityCard.jsx — Owner mandate & hot-seat widget for Franchise HQ
+ *
+ * Compact card that shows the current owner mandate, hot-seat status, and
+ * a 0–100 fill bar. Color-coded by risk band.
+ */
+
+import React from 'react';
+import { getHotSeatStatus, getMandateLabel } from '../../core/meta/ownerPressureEngine.js';
+
+const BAND_COLORS = Object.freeze({
+  secure:     { fill: 'var(--success, #34C759)', label: '✅ Secure',         accent: 'rgba(52,199,89,0.15)' },
+  unstable:   { fill: 'var(--warning, #FF9F0A)', label: '⚠️ Unstable',       accent: 'rgba(255,159,10,0.15)' },
+  'high-risk':{ fill: 'var(--danger,  #FF453A)', label: '🚨 Hot Seat — High Risk', accent: 'rgba(255,69,58,0.15)' },
+});
+
+/**
+ * @param {{ ownerProfile: { mandate: string, hotSeatRating: number, seasonsUnderGoal: number }|null }} props
+ */
+export default function JobSecurityCard({ ownerProfile }) {
+  if (!ownerProfile || !ownerProfile.mandate) return null;
+
+  const status  = getHotSeatStatus(ownerProfile);
+  const band    = BAND_COLORS[status] ?? BAND_COLORS.secure;
+  const rating  = Math.max(0, Math.min(100, Number(ownerProfile.hotSeatRating ?? 25)));
+  const mandate = getMandateLabel(ownerProfile.mandate);
+  const isHighRisk = status === 'high-risk';
+
+  return (
+    <article
+      className="hq-twin-card card"
+      data-testid="job-security-card"
+      aria-label="Job Security"
+      style={{ borderColor: isHighRisk ? 'rgba(255,69,58,0.45)' : undefined }}
+    >
+      <div className="hq-twin-card__head">
+        <strong>Job Security</strong>
+        <span
+          data-testid="hot-seat-status-label"
+          style={{
+            fontSize: 'var(--text-xs)',
+            fontWeight: 700,
+            color: band.fill,
+            animation: isHighRisk ? 'hq-deadline-pulse 2.5s ease-in-out infinite' : 'none',
+          }}
+          aria-label={`Status: ${band.label}`}
+        >
+          {band.label}
+        </span>
+      </div>
+
+      <p
+        className="hq-twin-card__stat"
+        data-testid="job-security-mandate"
+        style={{ margin: '4px 0 2px', fontSize: 'var(--text-sm)' }}
+      >
+        {mandate}
+      </p>
+
+      {/* Progress / fill bar */}
+      <div
+        role="progressbar"
+        aria-valuenow={rating}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`Hot seat pressure: ${rating} out of 100`}
+        data-testid="hot-seat-progress-bar"
+        style={{
+          position:     'relative',
+          height:       6,
+          borderRadius: 3,
+          background:   'var(--hairline, rgba(255,255,255,0.12))',
+          overflow:     'hidden',
+          margin:       '6px 0',
+        }}
+      >
+        <div
+          style={{
+            position:     'absolute',
+            left:         0,
+            top:          0,
+            height:       '100%',
+            width:        `${rating}%`,
+            background:   band.fill,
+            borderRadius: 3,
+            transition:   'width 0.3s ease',
+          }}
+        />
+      </div>
+
+      <p
+        className="hq-twin-card__detail"
+        style={{ color: 'var(--text-muted)', fontSize: 'var(--text-xs)', margin: 0 }}
+      >
+        {rating}/100 pressure
+        {ownerProfile.seasonsUnderGoal > 0
+          ? ` · ${ownerProfile.seasonsUnderGoal} season${ownerProfile.seasonsUnderGoal > 1 ? 's' : ''} under goal`
+          : ''}
+      </p>
+    </article>
+  );
+}

--- a/src/ui/components/JobSecurityCard.test.jsx
+++ b/src/ui/components/JobSecurityCard.test.jsx
@@ -1,0 +1,279 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import JobSecurityCard from './JobSecurityCard.jsx';
+
+function makeOwnerProfile(overrides = {}) {
+  return {
+    mandate: 'MAKE_PLAYOFFS',
+    hotSeatRating: 25,
+    seasonsUnderGoal: 0,
+    ...overrides,
+  };
+}
+
+describe('JobSecurityCard', () => {
+  it('renders mandate label', () => {
+    const html = renderToString(
+      <JobSecurityCard ownerProfile={makeOwnerProfile({ mandate: 'WIN_DIVISION' })} />,
+    );
+    expect(html).toContain('Win the Division');
+  });
+
+  it('renders mandate label for MAKE_PLAYOFFS', () => {
+    const html = renderToString(
+      <JobSecurityCard ownerProfile={makeOwnerProfile({ mandate: 'MAKE_PLAYOFFS' })} />,
+    );
+    expect(html).toContain('Make the Playoffs');
+  });
+
+  it('renders DEVELOP_YOUNG_CORE label', () => {
+    const html = renderToString(
+      <JobSecurityCard ownerProfile={makeOwnerProfile({ mandate: 'DEVELOP_YOUNG_CORE' })} />,
+    );
+    expect(html).toContain('Develop Young Core');
+  });
+
+  it('renders REDUCE_PAYROLL label', () => {
+    const html = renderToString(
+      <JobSecurityCard ownerProfile={makeOwnerProfile({ mandate: 'REDUCE_PAYROLL' })} />,
+    );
+    expect(html).toContain('Reduce Payroll');
+  });
+
+  it('renders secure status for low hot-seat rating', () => {
+    const html = renderToString(
+      <JobSecurityCard ownerProfile={makeOwnerProfile({ hotSeatRating: 20 })} />,
+    );
+    expect(html).toContain('Secure');
+    expect(html).toContain('data-testid="hot-seat-status-label"');
+  });
+
+  it('renders unstable status for mid hot-seat rating', () => {
+    const html = renderToString(
+      <JobSecurityCard ownerProfile={makeOwnerProfile({ hotSeatRating: 65 })} />,
+    );
+    expect(html).toContain('Unstable');
+  });
+
+  it('renders high-risk status for high hot-seat rating', () => {
+    const html = renderToString(
+      <JobSecurityCard ownerProfile={makeOwnerProfile({ hotSeatRating: 85 })} />,
+    );
+    expect(html).toContain('Hot Seat');
+    expect(html).toContain('High Risk');
+  });
+
+  it('renders progress bar with correct aria attributes', () => {
+    const html = renderToString(
+      <JobSecurityCard ownerProfile={makeOwnerProfile({ hotSeatRating: 50 })} />,
+    );
+    expect(html).toContain('role="progressbar"');
+    expect(html).toContain('aria-valuenow="50"');
+    expect(html).toContain('aria-valuemin="0"');
+    expect(html).toContain('aria-valuemax="100"');
+  });
+
+  it('shows seasons under goal when > 0', () => {
+    const html = renderToString(
+      <JobSecurityCard ownerProfile={makeOwnerProfile({ hotSeatRating: 60, seasonsUnderGoal: 2 })} />,
+    );
+    expect(html).toContain('2 seasons under goal');
+  });
+
+  it('returns null for null ownerProfile', () => {
+    const html = renderToString(<JobSecurityCard ownerProfile={null} />);
+    expect(html).toBe('');
+  });
+
+  it('returns null for ownerProfile without mandate', () => {
+    const html = renderToString(<JobSecurityCard ownerProfile={{ hotSeatRating: 25 }} />);
+    expect(html).toBe('');
+  });
+});
+
+// ── TradeCenter hint rendering ────────────────────────────────────────────────
+
+import TradeCenter from './TradeCenter.jsx';
+
+const baseLeague = {
+  phase: 'regular',
+  week: 5,
+  userTeamId: 0,
+  teams: [
+    {
+      id: 0,
+      name: 'My Team',
+      abbr: 'MY',
+      wins: 4,
+      losses: 3,
+      ties: 0,
+      capRoom: 20,
+      capUsed: 200_000_000,
+      capTotal: 255_000_000,
+      ovr: 78,
+      roster: [],
+      picks: [],
+      frontOffice: { persona: 'WIN_NOW' },
+      owner: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 30, seasonsUnderGoal: 0 },
+    },
+    {
+      id: 1,
+      name: 'High Pressure Team',
+      abbr: 'HPT',
+      wins: 2,
+      losses: 5,
+      ties: 0,
+      capRoom: 5,
+      capUsed: 240_000_000,
+      capTotal: 255_000_000,
+      ovr: 70,
+      roster: [],
+      picks: [],
+      frontOffice: { persona: 'PATIENT_BUILDER' },
+      owner: { mandate: 'WIN_DIVISION', hotSeatRating: 85, seasonsUnderGoal: 3 },
+    },
+    {
+      id: 2,
+      name: 'Stable Team',
+      abbr: 'STB',
+      wins: 6,
+      losses: 1,
+      ties: 0,
+      capRoom: 30,
+      capUsed: 150_000_000,
+      capTotal: 255_000_000,
+      ovr: 88,
+      roster: [],
+      picks: [],
+      frontOffice: { persona: 'WIN_NOW' },
+      owner: { mandate: 'WIN_DIVISION', hotSeatRating: 20, seasonsUnderGoal: 0 },
+    },
+  ],
+  schedule: { weeks: [] },
+  tradeOffers: [],
+  incomingTradeOffers: [],
+  inboundTradeOffers: [],
+  tradeDeadline: null,
+  settings: {},
+};
+
+describe('TradeCenter opponent pressure hint', () => {
+  it('renders high-pressure hint for high-risk opponent', () => {
+    const html = renderToString(
+      <TradeCenter
+        league={baseLeague}
+        actions={{}}
+        onNavigate={() => {}}
+        initialTradeContext={{ partnerTeamId: 1 }}
+      />,
+    );
+    expect(html).toContain('data-testid="trade-opponent-pressure-hint"');
+    expect(html).toContain('Front Office Pressure: High');
+  });
+
+  it('does not render hint for secure-status opponent', () => {
+    const html = renderToString(
+      <TradeCenter
+        league={baseLeague}
+        actions={{}}
+        onNavigate={() => {}}
+        initialTradeContext={{ partnerTeamId: 2 }}
+      />,
+    );
+    expect(html).not.toContain('Front Office Pressure: High');
+  });
+});
+
+// ── Franchise terminated state ────────────────────────────────────────────────
+
+import FranchiseHQ from './FranchiseHQ.jsx';
+
+const baseFranchiseLeague = {
+  year: 2026,
+  season: 3,
+  week: 1,
+  phase: 'regular',
+  userTeamId: 0,
+  teams: [
+    {
+      id: 0,
+      name: 'My Team',
+      abbr: 'MY',
+      conf: 0,
+      div: 0,
+      wins: 0,
+      losses: 0,
+      ties: 0,
+      ovr: 75,
+      capRoom: 20,
+      capUsed: 200_000_000,
+      capTotal: 255_000_000,
+      roster: [],
+      picks: [],
+      fanApproval: 50,
+      franchiseInvestments: {},
+      frontOffice: { persona: 'MAKE_PLAYOFFS' },
+      owner: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 30, seasonsUnderGoal: 0 },
+      ringOfHonor: [],
+      allTimeLeaders: {},
+      retiredNumbers: [],
+      championshipYears: [],
+    },
+  ],
+  schedule: { weeks: [] },
+  userOwnerPressure: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 30, seasonsUnderGoal: 0, status: 'secure' },
+  userFranchiseTerminated: false,
+  newsItems: [],
+  ownerGoals: [],
+  tradeOffers: [],
+  incomingTradeOffers: [],
+  inboundTradeOffers: [],
+  tradeDeadline: null,
+  settings: {},
+  weeklyHeadlines: [],
+};
+
+describe('FranchiseHQ terminated user state', () => {
+  it('renders terminated notice when userFranchiseTerminated is true', () => {
+    const terminatedLeague = { ...baseFranchiseLeague, userFranchiseTerminated: true };
+    const html = renderToString(
+      <FranchiseHQ
+        league={terminatedLeague}
+        lastResults={[]}
+        onNavigate={() => {}}
+        onAdvanceWeek={() => {}}
+        actions={{}}
+      />,
+    );
+    expect(html).toContain('data-testid="franchise-terminated-notice"');
+    expect(html).toContain('Franchise Dismissed');
+  });
+
+  it('does not render terminated notice when flag is false', () => {
+    const html = renderToString(
+      <FranchiseHQ
+        league={baseFranchiseLeague}
+        lastResults={[]}
+        onNavigate={() => {}}
+        onAdvanceWeek={() => {}}
+        actions={{}}
+      />,
+    );
+    expect(html).not.toContain('data-testid="franchise-terminated-notice"');
+  });
+
+  it('JobSecurityCard renders in HQ when userOwnerPressure is provided', () => {
+    const html = renderToString(
+      <FranchiseHQ
+        league={baseFranchiseLeague}
+        lastResults={[]}
+        onNavigate={() => {}}
+        onAdvanceWeek={() => {}}
+        actions={{}}
+      />,
+    );
+    expect(html).toContain('data-testid="job-security-card"');
+    expect(html).toContain('Make the Playoffs');
+  });
+});

--- a/src/ui/components/TradeCenter.jsx
+++ b/src/ui/components/TradeCenter.jsx
@@ -29,6 +29,7 @@ import { getBudgetLabel, toneToCssColor } from "../utils/transactionMarket.js";
 import { logCompletedTradeAction, persistFranchiseChronicle } from "../utils/franchiseChronicle.js";
 import { getPickBaseValueFromMatrix } from "../../core/trades/tradeValuationModifiers.js";
 import FrontOfficeBadge from "./FrontOfficeBadge.jsx";
+import { getHotSeatStatus } from "../../core/meta/ownerPressureEngine.js";
 
 // ── Original helpers (kept exactly as you had) ─────────────────────────────────
 
@@ -969,6 +970,14 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
               <span>{liveTheirTeam.wins ?? 0}-{liveTheirTeam.losses ?? 0}{(liveTheirTeam.ties ?? 0) ? `-${liveTheirTeam.ties}` : ""} · OVR {liveTheirTeam.ovr ?? "—"}</span>
               {liveTheirTeam.frontOffice?.persona && (
                 <FrontOfficeBadge persona={liveTheirTeam.frontOffice.persona} />
+              )}
+              {liveTheirTeam.owner && getHotSeatStatus(liveTheirTeam.owner) === 'high-risk' && (
+                <span
+                  data-testid="trade-opponent-pressure-hint"
+                  style={{ fontSize: 'var(--text-xs)', color: 'var(--danger, #FF453A)', fontWeight: 600 }}
+                >
+                  🔥 Front Office Pressure: High
+                </span>
               )}
             </div>
           )}

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -349,6 +349,15 @@ import {
 import { sortStandingsRows } from '../views/standingsView.js';
 import { determineInitialPersona, maybeDriftPersona } from '../core/ai/frontOfficePersonaEngine.js';
 import {
+  buildOwnerProfile,
+  determineInitialMandate,
+  evaluateMandate,
+  applyHotSeatDelta,
+  shouldFireFrontOffice,
+  buildAIFiringOutcome,
+  getHotSeatStatus,
+} from '../core/meta/ownerPressureEngine.js';
+import {
   isWaiverWindowOpen,
   buildWaiverPriorityList,
   sendPlayerToWaivers,
@@ -1067,6 +1076,7 @@ function buildViewState() {
     coachHCName: t?.coach?.headCoach?.name ?? null,
     coachHCRating: t?.coach?.headCoach?.overallRating ?? null,
     frontOffice: t?.frontOffice ?? null,
+    owner: t?.owner ?? null,
     tradeRequestAlerts: getActiveTradeRequests(t, roster),
     picks: Array.isArray(t?.picks)
       ? t.picks.map((pk) => ({
@@ -1205,6 +1215,18 @@ function buildViewState() {
     scoutingBudget: (() => {
       const uTeam = cache.getTeam(meta?.userTeamId);
       return uTeam?.scoutingBudget ?? null;
+    })(),
+    userFranchiseTerminated: !!(meta?.userFranchiseTerminated),
+    userOwnerPressure: (() => {
+      const uTeam = cache.getTeam(meta?.userTeamId);
+      const ownerProfile = uTeam?.owner ?? null;
+      if (!ownerProfile) return null;
+      return {
+        mandate:          ownerProfile.mandate,
+        hotSeatRating:    ownerProfile.hotSeatRating ?? 25,
+        seasonsUnderGoal: ownerProfile.seasonsUnderGoal ?? 0,
+        status:           getHotSeatStatus(ownerProfile),
+      };
     })(),
     godMode: !!meta?.commissionerMode,
     commissionerMode: !!meta?.commissionerMode,
@@ -13469,6 +13491,62 @@ async function handleStartNewSeason(payload, id) {
     }
   } catch (personaDriftErr) {
     console.error('[Worker] Front office persona drift failed (non-fatal):', personaDriftErr);
+  }
+
+  // ── Owner mandate evaluation (once per season, before records reset) ────────
+  // Guard: skip if already evaluated for this completed season to prevent
+  // double-application on save reload or handleStartNewSeason re-entry.
+  try {
+    const completedSeasonId = meta.currentSeasonId;
+    const alreadyEvaluated = meta.ownerPressureEvaluatedForSeason === completedSeasonId;
+
+    if (!alreadyEvaluated && completedSeasonId) {
+      const playoffTeamIdsForOwner = new Set(
+        Object.values(meta.playoffSeeds ?? {}).flatMap(seeds =>
+          Array.isArray(seeds) ? seeds.map(s => s.teamId) : [],
+        ),
+      );
+      const allTeamsSnapshot = cache.getAllTeams();
+
+      for (const team of allTeamsSnapshot) {
+        // Hydrate owner profile if missing
+        if (!team.owner?.mandate) {
+          const mandate = determineInitialMandate(team, { allTeams: allTeamsSnapshot });
+          cache.updateTeam(team.id, { owner: buildOwnerProfile(mandate) });
+        }
+        const hydratedTeam = cache.getTeam(team.id);
+        if (!hydratedTeam?.owner?.mandate) continue;
+
+        const teamRoster = cache.getPlayersByTeam(team.id);
+        const evaluation = evaluateMandate(hydratedTeam, {
+          allTeams: allTeamsSnapshot,
+          playoffTeamIds: playoffTeamIdsForOwner,
+          teamRoster,
+        });
+        const updatedOwner = applyHotSeatDelta(hydratedTeam.owner, evaluation);
+
+        if (shouldFireFrontOffice(updatedOwner)) {
+          if (team.id === meta.userTeamId) {
+            // User team fired: set termination flag
+            cache.updateTeam(team.id, { owner: updatedOwner });
+            cache.setMeta({ userFranchiseTerminated: true });
+          } else {
+            // AI team fired: reset owner pressure and drift persona
+            const firingOutcome = buildAIFiringOutcome(hydratedTeam, { allTeams: allTeamsSnapshot });
+            cache.updateTeam(team.id, {
+              owner: firingOutcome.newOwnerProfile,
+              frontOffice: { persona: firingOutcome.newPersona, missedPostseasonStreak: 0 },
+            });
+          }
+        } else {
+          cache.updateTeam(team.id, { owner: updatedOwner });
+        }
+      }
+
+      cache.setMeta({ ownerPressureEvaluatedForSeason: completedSeasonId });
+    }
+  } catch (ownerPressureErr) {
+    console.error('[Worker] Owner pressure evaluation failed (non-fatal):', ownerPressureErr);
   }
 
   // Reset team records and roll dead money forward


### PR DESCRIPTION
Adds a deterministic, once-per-season owner pressure overlay:

New Module
- src/core/meta/ownerPressureEngine.js: OWNER_MANDATES, buildOwnerProfile,
  determineInitialMandate, evaluateMandate, applyHotSeatDelta,
  shouldFireFrontOffice, buildAIFiringOutcome, getHotSeatStatus,
  getMandateLabel — pure, no Math.random, no UI/worker imports.

Schema / Hydration
- team.owner: { mandate, hotSeatRating, seasonsUnderGoal } added to all teams
  via State.migrateLeague() (src/core/state.js:554); old saves hydrate safely
  and deterministically.
- meta.userFranchiseTerminated hydrated with false default
  (src/core/state.js:563); old saves safe.

Engine Integrations
- handleStartNewSeason evaluates owner mandates once per year before records
  reset (src/worker/worker.js:13495); once-per-season guard via
  meta.ownerPressureEvaluatedForSeason prevents double-application on replay.
- AI firing/reset integrates with frontOffice persona drift: fired AI teams
  get CAP_HOARDER or PATIENT_BUILDER based on roster signals
  (src/worker/worker.js:13528).
- User franchise termination flag set when user team hits threshold
  (src/worker/worker.js:13523).
- buildViewState exposes userOwnerPressure, userFranchiseTerminated, and
  owner on each team for TradeCenter access (src/worker/worker.js:1219).

UI
- JobSecurityCard.jsx added to Franchise HQ twin-grid inside Season Pulse
  drawer: shows mandate label, secure/unstable/high-risk band, fill bar
  (src/ui/components/JobSecurityCard.jsx).
- TradeCenter high-pressure hint renders next to FrontOfficeBadge when
  opponent hot-seat is high-risk (src/ui/components/TradeCenter.jsx:972).
- Franchise termination notice renders in FranchiseHQ when
  userFranchiseTerminated is true (src/ui/components/FranchiseHQ.jsx:800).

Tests Added
- unit: 39 (ownerPressureEngine.unit.test.js)
- integration: 16 (ownerPressure.integration.test.js)
- UI: 16 (JobSecurityCard.test.jsx)
- Total: 4572 → 4643 (+71)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TNxgfGoHrRvL5kvyjRhhET