### PR TITLE
feat(news): League Media Desk V1 — deterministic media narrative engine

### DIFF
--- a/src/core/news/mediaNarrative.integration.test.js
+++ b/src/core/news/mediaNarrative.integration.test.js
@@ -1,0 +1,330 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildMediaNarratives,
+  MEDIA_STORY_TYPES,
+  MEDIA_STORY_MAX,
+} from './mediaNarrativeEngine.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeOwnerProfile(overrides = {}) {
+  return {
+    mandate:          'MAKE_PLAYOFFS',
+    hotSeatRating:    25,
+    seasonsUnderGoal: 0,
+    ...overrides,
+  };
+}
+
+function makeTeam(id, overrides = {}) {
+  return {
+    id,
+    name:   `Team ${id}`,
+    abbr:   `T${id}`,
+    conf:   id < 16 ? 0 : 1,
+    div:    id % 4,
+    wins:   8,
+    losses: 4,
+    ties:   0,
+    ovr:    78,
+    owner:  makeOwnerProfile(),
+    ...overrides,
+  };
+}
+
+function makeStandingsRows(teams) {
+  return teams.map((t) => ({
+    tid:  t.id,
+    w:    t.wins  ?? 0,
+    l:    t.losses ?? 0,
+    t:    t.ties  ?? 0,
+    abbr: t.abbr,
+    conf: t.conf,
+  }));
+}
+
+function makeLeagueContext(overrides = {}) {
+  const teams = Array.from({ length: 8 }, (_, i) => makeTeam(i + 1));
+  return {
+    year:               2026,
+    week:               10,
+    season:             2026,
+    userTeamId:         1,
+    teams,
+    standings:          makeStandingsRows(teams),
+    newsItems:          [],
+    currentSeasonHonors: null,
+    leaguePulse:        [],
+    ...overrides,
+  };
+}
+
+// ── View-state exposure ───────────────────────────────────────────────────────
+
+describe('view-state exposure', () => {
+  it('buildMediaNarratives returns an array (safe view-state output)', () => {
+    const result = buildMediaNarratives(makeLeagueContext());
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it('each story in the result has the required card fields', () => {
+    const ctx = makeLeagueContext({
+      teams: [makeTeam(1, { owner: makeOwnerProfile({ hotSeatRating: 75, seasonsUnderGoal: 1 }) })],
+    });
+    const stories = buildMediaNarratives(ctx);
+    for (const s of stories) {
+      expect(typeof s.id).toBe('string');
+      expect(typeof s.type).toBe('string');
+      expect(typeof s.priority).toBe('number');
+      expect(typeof s.headline).toBe('string');
+      expect(typeof s.dek).toBe('string');
+      expect(Array.isArray(s.tags)).toBe(true);
+      expect(Array.isArray(s.sourceEventIds)).toBe(true);
+    }
+  });
+
+  it('output is safe for JSON serialization (no circular refs, no undefined)', () => {
+    const ctx = makeLeagueContext({
+      teams: [makeTeam(1, { owner: makeOwnerProfile({ hotSeatRating: 80, seasonsUnderGoal: 2 }) })],
+    });
+    const stories = buildMediaNarratives(ctx);
+    expect(() => JSON.stringify(stories)).not.toThrow();
+  });
+});
+
+// ── Owner pressure → story cards ──────────────────────────────────────────────
+
+describe('owner pressure data can produce story cards', () => {
+  it('a single team with hotSeatRating 80+ produces an OWNER_PRESSURE card', () => {
+    const ctx = makeLeagueContext({
+      teams: [makeTeam(5, { owner: makeOwnerProfile({ hotSeatRating: 82, seasonsUnderGoal: 2 }) })],
+    });
+    const stories = buildMediaNarratives(ctx);
+    expect(stories.some((s) => s.type === MEDIA_STORY_TYPES.OWNER_PRESSURE)).toBe(true);
+  });
+
+  it('teams with hotSeatRating < 60 do not generate OWNER_PRESSURE cards', () => {
+    const ctx = makeLeagueContext({
+      teams: Array.from({ length: 8 }, (_, i) =>
+        makeTeam(i + 1, { owner: makeOwnerProfile({ hotSeatRating: 30 + i * 3 }) }),
+      ),
+    });
+    const stories = buildMediaNarratives(ctx);
+    expect(stories.some((s) => s.type === MEDIA_STORY_TYPES.OWNER_PRESSURE)).toBe(false);
+  });
+
+  it('OWNER_PRESSURE story priority is higher for higher hotSeatRating', () => {
+    const ctx = makeLeagueContext({
+      teams: [
+        makeTeam(1, { owner: makeOwnerProfile({ hotSeatRating: 92, seasonsUnderGoal: 3 }) }),
+        makeTeam(2, { owner: makeOwnerProfile({ hotSeatRating: 65, seasonsUnderGoal: 1 }) }),
+      ],
+    });
+    const stories = buildMediaNarratives(ctx);
+    const pressureStories = stories.filter((s) => s.type === MEDIA_STORY_TYPES.OWNER_PRESSURE);
+    expect(pressureStories.length).toBeGreaterThan(0);
+    // Higher hotSeat team should have higher priority
+    const team1 = pressureStories.find((s) => s.teamId === 1);
+    const team2 = pressureStories.find((s) => s.teamId === 2);
+    if (team1 && team2) {
+      expect(team1.priority).toBeGreaterThan(team2.priority);
+    }
+  });
+});
+
+// ── Trade/history inputs → story cards ───────────────────────────────────────
+
+describe('trade and history inputs can produce story cards', () => {
+  it('leaguePulse transaction item produces a BLOCKBUSTER_TRADE card', () => {
+    const ctx = makeLeagueContext({
+      leaguePulse: [
+        {
+          id:            'pulse-trade-2026-9',
+          type:          'transaction',
+          source:        'transaction',
+          headline:      'Elite QB Shakes Up the League',
+          body:          'The trade reshapes conference power dynamics.',
+          importance:    80,
+          relatedTeamId: 3,
+          season:        2026,
+          week:          9,
+        },
+      ],
+    });
+    const stories = buildMediaNarratives(ctx);
+    expect(stories.some((s) => s.type === MEDIA_STORY_TYPES.BLOCKBUSTER_TRADE)).toBe(true);
+  });
+
+  it('newsItems trade entry produces a BLOCKBUSTER_TRADE card', () => {
+    const ctx = makeLeagueContext({
+      newsItems: [
+        {
+          id:     'news-trade-1',
+          type:   'TRANSACTION',
+          text:   'WR traded to gain cap flexibility.',
+          teamId: 4,
+          week:   8,
+          year:   2026,
+          extraData: { fromTeamId: 4, toTeamId: 7 },
+        },
+      ],
+    });
+    const stories = buildMediaNarratives(ctx);
+    expect(stories.some((s) => s.type === MEDIA_STORY_TYPES.BLOCKBUSTER_TRADE)).toBe(true);
+  });
+
+  it('honors (First-Team All-Pro) produce a PRESTIGE_HONOR card', () => {
+    const ctx = makeLeagueContext({
+      currentSeasonHonors: [
+        {
+          type:       'FIRST_TEAM_ALL_PRO',
+          playerId:   99,
+          playerName: 'Elite QB',
+          pos:        'QB',
+          teamId:     6,
+          teamAbbr:   'KC',
+          year:       2026,
+          score:      145,
+        },
+      ],
+    });
+    const stories = buildMediaNarratives(ctx);
+    expect(stories.some((s) => s.type === MEDIA_STORY_TYPES.PRESTIGE_HONOR)).toBe(true);
+  });
+});
+
+// ── No gameplay mutations ─────────────────────────────────────────────────────
+
+describe('no gameplay mutations occur during media generation', () => {
+  it('does not modify any team objects in the input', () => {
+    const teams = Array.from({ length: 4 }, (_, i) =>
+      makeTeam(i + 1, { owner: makeOwnerProfile({ hotSeatRating: 70, seasonsUnderGoal: 1 }) }),
+    );
+    const before = JSON.parse(JSON.stringify(teams));
+    const ctx = makeLeagueContext({ teams });
+    buildMediaNarratives(ctx);
+    expect(JSON.parse(JSON.stringify(ctx.teams))).toEqual(before);
+  });
+
+  it('does not modify newsItems array', () => {
+    const newsItems = [
+      { id: 'n1', type: 'TRANSACTION', text: 'Player traded.', teamId: 2, week: 8, year: 2026, extraData: { fromTeamId: 2, toTeamId: 5 } },
+    ];
+    const before = JSON.stringify(newsItems);
+    buildMediaNarratives(makeLeagueContext({ newsItems }));
+    expect(JSON.stringify(newsItems)).toBe(before);
+  });
+
+  it('does not modify leaguePulse array', () => {
+    const leaguePulse = [
+      { id: 'p1', type: 'transaction', headline: 'Trade', body: 'Trade body', importance: 75, relatedTeamId: 1, season: 2026, week: 9 },
+    ];
+    const before = JSON.stringify(leaguePulse);
+    buildMediaNarratives(makeLeagueContext({ leaguePulse }));
+    expect(JSON.stringify(leaguePulse)).toBe(before);
+  });
+
+  it('does not modify the standings array', () => {
+    const teams = Array.from({ length: 4 }, (_, i) => makeTeam(i + 1));
+    const standings = makeStandingsRows(teams);
+    const before = JSON.stringify(standings);
+    buildMediaNarratives(makeLeagueContext({ teams, standings }));
+    expect(JSON.stringify(standings)).toBe(before);
+  });
+
+  it('does not modify the root context object', () => {
+    const ctx = makeLeagueContext({
+      teams: [makeTeam(1, { owner: makeOwnerProfile({ hotSeatRating: 85, seasonsUnderGoal: 2 }) })],
+    });
+    const before = JSON.stringify(ctx);
+    buildMediaNarratives(ctx);
+    expect(JSON.stringify(ctx)).toBe(before);
+  });
+});
+
+// ── Old saves remain safe ─────────────────────────────────────────────────────
+
+describe('old saves remain safe', () => {
+  it('handles league context with no owner data on any team', () => {
+    const ctx = makeLeagueContext({
+      teams: Array.from({ length: 4 }, (_, i) => ({
+        id:     i + 1,
+        name:   `Team ${i + 1}`,
+        abbr:   `T${i}`,
+        wins:   5,
+        losses: 5,
+        ties:   0,
+        // no owner field at all
+      })),
+    });
+    expect(() => buildMediaNarratives(ctx)).not.toThrow();
+    expect(Array.isArray(buildMediaNarratives(ctx))).toBe(true);
+  });
+
+  it('handles completely empty league context', () => {
+    expect(() => buildMediaNarratives({})).not.toThrow();
+    expect(buildMediaNarratives({})).toEqual([]);
+  });
+
+  it('handles missing week/year fields', () => {
+    const ctx = { teams: [makeTeam(1)], standings: [] };
+    expect(() => buildMediaNarratives(ctx)).not.toThrow();
+  });
+
+  it('handles null/undefined newsItems, standings, leaguePulse', () => {
+    const ctx = {
+      year:               2026,
+      week:               8,
+      teams:              [makeTeam(1, { owner: makeOwnerProfile({ hotSeatRating: 70, seasonsUnderGoal: 1 }) })],
+      newsItems:          null,
+      standings:          undefined,
+      leaguePulse:        null,
+      currentSeasonHonors: undefined,
+    };
+    expect(() => buildMediaNarratives(ctx)).not.toThrow();
+    expect(Array.isArray(buildMediaNarratives(ctx))).toBe(true);
+  });
+
+  it('handles teams with partial owner profiles', () => {
+    const ctx = makeLeagueContext({
+      teams: [
+        { id: 1, abbr: 'TST', wins: 3, losses: 9, owner: {} },
+        { id: 2, abbr: 'OK', wins: 7, losses: 5, owner: { hotSeatRating: 70 } },
+      ],
+    });
+    expect(() => buildMediaNarratives(ctx)).not.toThrow();
+  });
+
+  it('max story count is always respected regardless of data volume', () => {
+    const teams = Array.from({ length: 32 }, (_, i) =>
+      makeTeam(i + 1, { owner: makeOwnerProfile({ hotSeatRating: 60 + i, seasonsUnderGoal: 2 }) }),
+    );
+    const ctx = makeLeagueContext({
+      teams,
+      standings: makeStandingsRows(teams),
+      leaguePulse: Array.from({ length: 20 }, (_, i) => ({
+        id: `p${i}`, type: 'transaction', headline: `Trade ${i}`, body: 'Body', importance: 75, relatedTeamId: i + 1, season: 2026, week: 8,
+      })),
+    });
+    const stories = buildMediaNarratives(ctx);
+    expect(stories.length).toBeLessThanOrEqual(MEDIA_STORY_MAX);
+  });
+});
+
+// ── No Math.random usage ──────────────────────────────────────────────────────
+
+describe('determinism guarantee', () => {
+  it('produces identical output on 10 repeated calls with same input', () => {
+    const ctx = makeLeagueContext({
+      teams: [
+        makeTeam(1, { owner: makeOwnerProfile({ hotSeatRating: 80, seasonsUnderGoal: 2 }) }),
+        makeTeam(2, { wins: 10, losses: 2, owner: makeOwnerProfile({ hotSeatRating: 15 }) }),
+      ],
+      leaguePulse: [
+        { id: 'p1', type: 'transaction', headline: 'Trade', body: 'X', importance: 75, relatedTeamId: 3, season: 2026, week: 9 },
+      ],
+    });
+    const outputs = Array.from({ length: 10 }, () => JSON.stringify(buildMediaNarratives(ctx)));
+    expect(new Set(outputs).size).toBe(1);
+  });
+});

--- a/src/core/news/mediaNarrativeEngine.js
+++ b/src/core/news/mediaNarrativeEngine.js
@@ -1,0 +1,534 @@
+/**
+ * mediaNarrativeEngine.js — League Media Desk V1
+ *
+ * Pure, deterministic module. No Math.random, no UI imports, no worker imports.
+ * All outputs are immutable new objects. Inputs are never mutated.
+ *
+ * Exported API:
+ *   MEDIA_STORY_TYPES           — story type constants
+ *   MEDIA_STORY_MAX             — default max story count
+ *   buildMediaNarratives(league, options) → story[]  — top-level entry point
+ *   selectMediaStories(context)           → story[]  — gather + dedup candidates
+ *   rankMediaStories(stories, options)    → story[]  — deterministic ranking
+ *   buildMediaHeadline(story)             → { headline, dek }
+ *   getMediaStoryTypeLabel(type)          → string
+ *   makeStableStoryId(...parts)           → string
+ *   dedupeMediaStories(stories)           → story[]
+ *   extractHotSeatStories(league)         → story[]
+ *   extractBlockbusterTradeStories(league) → story[]
+ *   extractMandateStories(league)         → story[]
+ *   extractPrestigeStories(league)        → story[]
+ *   extractPlayoffPushStories(league)     → story[]
+ */
+
+// ── Story type constants ───────────────────────────────────────────────────────
+
+export const MEDIA_STORY_TYPES = Object.freeze({
+  OWNER_PRESSURE:    'OWNER_PRESSURE',
+  BLOCKBUSTER_TRADE: 'BLOCKBUSTER_TRADE',
+  MANDATE_SURGE:     'MANDATE_SURGE',
+  MANDATE_SLIP:      'MANDATE_SLIP',
+  PRESTIGE_HONOR:    'PRESTIGE_HONOR',
+  WAIVER_MOVE:       'WAIVER_MOVE',
+  PLAYOFF_PUSH:      'PLAYOFF_PUSH',
+  LEGACY_MILESTONE:  'LEGACY_MILESTONE',
+});
+
+const _TYPE_LABELS = Object.freeze({
+  OWNER_PRESSURE:    'Owner Pressure',
+  BLOCKBUSTER_TRADE: 'Blockbuster Trade',
+  MANDATE_SURGE:     'Surging',
+  MANDATE_SLIP:      'Under Pressure',
+  PRESTIGE_HONOR:    'League Honor',
+  WAIVER_MOVE:       'Waiver Wire',
+  PLAYOFF_PUSH:      'Playoff Race',
+  LEGACY_MILESTONE:  'Legacy',
+});
+
+export const MEDIA_STORY_MAX = 8;
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+function _n(v, fallback = 0) {
+  const n = Number(v ?? fallback);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function _titleCase(str) {
+  return String(str ?? '')
+    .replace(/_/g, ' ')
+    .toLowerCase()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// ── Public utilities ──────────────────────────────────────────────────────────
+
+/**
+ * Returns a stable deterministic ID from a list of string/number parts.
+ * @param {...(string|number)} parts
+ * @returns {string}
+ */
+export function makeStableStoryId(...parts) {
+  return parts.map(String).join('-');
+}
+
+/**
+ * Removes duplicate stories by id, preserving first occurrence.
+ * @param {Object[]} stories
+ * @returns {Object[]}
+ */
+export function dedupeMediaStories(stories) {
+  const seen = new Set();
+  return stories.filter((s) => {
+    if (!s?.id || seen.has(s.id)) return false;
+    seen.add(s.id);
+    return true;
+  });
+}
+
+/**
+ * Returns a short UI label for a story type.
+ * @param {string} type
+ * @returns {string}
+ */
+export function getMediaStoryTypeLabel(type) {
+  return _TYPE_LABELS[type] ?? (type ? _titleCase(type) : 'Update');
+}
+
+// ── Story extractors ──────────────────────────────────────────────────────────
+
+/**
+ * Generate OWNER_PRESSURE stories from teams with elevated hot-seat ratings.
+ * Only surfaces teams with hotSeatRating >= 60 to avoid noise.
+ * @param {Object} league
+ * @returns {Object[]}
+ */
+export function extractHotSeatStories(league) {
+  const teams = Array.isArray(league?.teams) ? league.teams : [];
+  const season = _n(league?.year ?? league?.season);
+  const week = _n(league?.week);
+  const stories = [];
+
+  for (const team of teams) {
+    const owner = team?.owner;
+    if (!owner) continue;
+
+    const rating = _n(owner.hotSeatRating, 25);
+    if (rating < 60) continue;
+
+    const mandate = owner.mandate ?? 'MAKE_PLAYOFFS';
+    const mandateLabel = _titleCase(mandate);
+    const seasonsUnder = _n(owner.seasonsUnderGoal);
+    const tone = rating >= 80 ? 'urgent' : 'warning';
+    const teamAbbr = team.abbr ?? team.name ?? 'Team';
+
+    const id = makeStableStoryId(
+      'owner-pressure',
+      team.id ?? teamAbbr,
+      season,
+      rating >= 80 ? 'high' : 'mid',
+    );
+
+    const headline = rating >= 80
+      ? `${teamAbbr} Front Office on Hot Seat`
+      : `Pressure Mounting on ${teamAbbr}`;
+
+    let dek = `Mandate: ${mandateLabel}. Job-security index at ${rating}/100`;
+    if (seasonsUnder > 0) {
+      dek += ` — ${seasonsUnder} consecutive season${seasonsUnder === 1 ? '' : 's'} below expectations`;
+    }
+    dek += '.';
+
+    stories.push({
+      id,
+      type:            MEDIA_STORY_TYPES.OWNER_PRESSURE,
+      priority:        Math.min(95, rating),
+      week,
+      season,
+      teamId:          team.id ?? null,
+      secondaryTeamId: null,
+      playerId:        null,
+      headline,
+      dek,
+      tone,
+      tags:            ['owner-pressure'],
+      sourceEventIds:  [],
+    });
+  }
+
+  return stories.sort(
+    (a, b) => b.priority - a.priority || String(a.teamId).localeCompare(String(b.teamId)),
+  );
+}
+
+/**
+ * Generate MANDATE_SLIP and MANDATE_SURGE stories from team win/loss records
+ * cross-referenced with owner expectations.
+ * @param {Object} league
+ * @returns {Object[]}
+ */
+export function extractMandateStories(league) {
+  const teams = Array.isArray(league?.teams) ? league.teams : [];
+  const season = _n(league?.year ?? league?.season);
+  const week = _n(league?.week);
+  const stories = [];
+
+  for (const team of teams) {
+    const owner = team?.owner;
+    if (!owner?.mandate) continue;
+
+    const wins   = _n(team.wins);
+    const losses = _n(team.losses);
+    const ties   = _n(team.ties);
+    const total  = wins + losses + ties;
+    if (total < 4) continue;
+
+    const hotSeatRating = _n(owner.hotSeatRating, 25);
+    const seasonsUnder  = _n(owner.seasonsUnderGoal);
+    const mandate       = owner.mandate;
+    const mandateLabel  = _titleCase(mandate);
+    const teamAbbr      = team.abbr ?? team.name ?? 'Team';
+
+    // MANDATE_SLIP: losing teams with consecutive underperformance
+    if (losses > wins && seasonsUnder >= 1) {
+      const id = makeStableStoryId('mandate-slip', team.id ?? teamAbbr, season);
+      stories.push({
+        id,
+        type:            MEDIA_STORY_TYPES.MANDATE_SLIP,
+        priority:        Math.min(80, 55 + seasonsUnder * 5),
+        week,
+        season,
+        teamId:          team.id ?? null,
+        secondaryTeamId: null,
+        playerId:        null,
+        headline:        `${teamAbbr} Falling Short of ${mandateLabel} Mandate`,
+        dek:             `At ${wins}-${losses}, ${teamAbbr} trails expectations for a ${seasonsUnder + 1}-season stretch. Front-office security at ${hotSeatRating}/100.`,
+        tone:            'warning',
+        tags:            ['mandate', 'pressure'],
+        sourceEventIds:  [],
+      });
+    }
+
+    // MANDATE_SURGE: significantly overachieving with low owner pressure
+    if (wins > losses + 2 && hotSeatRating < 35) {
+      const id = makeStableStoryId('mandate-surge', team.id ?? teamAbbr, season);
+      stories.push({
+        id,
+        type:            MEDIA_STORY_TYPES.MANDATE_SURGE,
+        priority:        50,
+        week,
+        season,
+        teamId:          team.id ?? null,
+        secondaryTeamId: null,
+        playerId:        null,
+        headline:        `${teamAbbr} Exceeding ${mandateLabel} Mandate`,
+        dek:             `At ${wins}-${losses}, ${teamAbbr} is ahead of owner expectations heading into Week ${week}.`,
+        tone:            'positive',
+        tags:            ['mandate', 'surge'],
+        sourceEventIds:  [],
+      });
+    }
+  }
+
+  return stories.sort(
+    (a, b) => b.priority - a.priority || String(a.teamId).localeCompare(String(b.teamId)),
+  );
+}
+
+/**
+ * Generate BLOCKBUSTER_TRADE stories from leaguePulse transaction items and
+ * newsItems that carry clear trade signals.
+ * @param {Object} league
+ * @returns {Object[]}
+ */
+export function extractBlockbusterTradeStories(league) {
+  const season = _n(league?.year ?? league?.season);
+  const week   = _n(league?.week);
+  const stories = [];
+  const seenIds = new Set();
+
+  // Primary source: leaguePulse transaction items
+  const pulseItems = Array.isArray(league?.leaguePulse) ? league.leaguePulse : [];
+  const tradePulse = pulseItems.filter(
+    (p) => p?.type === 'transaction' || p?.source === 'transaction',
+  );
+
+  for (const pulse of tradePulse.slice(0, 2)) {
+    const id = makeStableStoryId(
+      'blockbuster-trade',
+      pulse.relatedTeamId ?? 'unk',
+      _n(pulse.season, season),
+      _n(pulse.week, week),
+    );
+    if (seenIds.has(id)) continue;
+    seenIds.add(id);
+
+    stories.push({
+      id,
+      type:            MEDIA_STORY_TYPES.BLOCKBUSTER_TRADE,
+      priority:        _n(pulse.importance, 60),
+      week:            _n(pulse.week, week),
+      season:          _n(pulse.season, season),
+      teamId:          pulse.relatedTeamId ?? null,
+      secondaryTeamId: null,
+      playerId:        null,
+      headline:        pulse.headline ?? 'Blockbuster Trade',
+      dek:             pulse.body ?? 'A significant roster move reshapes the league landscape.',
+      tone:            'neutral',
+      tags:            ['trade'],
+      sourceEventIds:  pulse.id ? [pulse.id] : [],
+    });
+  }
+
+  // Secondary source: newsItems with clear trade signals
+  const newsItems = Array.isArray(league?.newsItems) ? league.newsItems : [];
+  const tradeNews = newsItems.filter((n) => {
+    if (n?.type !== 'TRANSACTION') return false;
+    const text = String(n.text ?? '').toLowerCase();
+    return (
+      text.includes('trade') ||
+      text.includes('traded') ||
+      (n.extraData?.fromTeamId != null &&
+        n.extraData?.toTeamId != null &&
+        n.extraData.fromTeamId !== n.extraData.toTeamId)
+    );
+  });
+
+  for (const news of tradeNews.slice(0, 2)) {
+    const id = makeStableStoryId(
+      'trade-news',
+      news.id ?? news.teamId ?? 'unk',
+      _n(news.week, week),
+    );
+    if (seenIds.has(id)) continue;
+    seenIds.add(id);
+
+    stories.push({
+      id,
+      type:            MEDIA_STORY_TYPES.BLOCKBUSTER_TRADE,
+      priority:        60,
+      week:            _n(news.week, week),
+      season:          _n(news.year, season),
+      teamId:          news.teamId ?? null,
+      secondaryTeamId: news.extraData?.toTeamId ?? news.extraData?.fromTeamId ?? null,
+      playerId:        news.playerId ?? null,
+      headline:        'Trade Activity',
+      dek:             news.text ?? 'A roster transaction changes the league landscape.',
+      tone:            'neutral',
+      tags:            ['trade'],
+      sourceEventIds:  news.id ? [news.id] : [],
+    });
+  }
+
+  return stories.sort((a, b) => b.priority - a.priority);
+}
+
+/**
+ * Generate PRESTIGE_HONOR stories from currentSeasonHonors.
+ * Handles both flat assignment array and grouped summary object shapes.
+ * Only surfaces First-Team All-Pro selections to keep volume low.
+ * @param {Object} league
+ * @returns {Object[]}
+ */
+export function extractPrestigeStories(league) {
+  const honors = league?.currentSeasonHonors;
+  if (!honors) return [];
+
+  const season = _n(league?.year ?? league?.season);
+  const week   = _n(league?.week);
+
+  // Normalize to flat array regardless of input shape
+  let flatHonors = [];
+  if (Array.isArray(honors)) {
+    flatHonors = honors;
+  } else if (honors && typeof honors === 'object') {
+    for (const [type, byPos] of Object.entries(honors)) {
+      if (byPos && typeof byPos === 'object' && !Array.isArray(byPos)) {
+        for (const entries of Object.values(byPos)) {
+          if (Array.isArray(entries)) {
+            flatHonors.push(...entries.map((e) => ({ ...e, type })));
+          }
+        }
+      } else if (Array.isArray(byPos)) {
+        flatHonors.push(...byPos.map((e) => ({ ...e, type })));
+      }
+    }
+  }
+
+  // Surface only First-Team All-Pro selections
+  const firstTeam = flatHonors.filter((h) => h.type === 'FIRST_TEAM_ALL_PRO');
+  if (firstTeam.length === 0) return [];
+
+  // Group by team (stable key: teamId if available, else teamAbbr)
+  const byTeam = new Map();
+  for (const h of firstTeam) {
+    const key = String(h.teamId ?? h.teamAbbr ?? 'unk');
+    if (!byTeam.has(key)) byTeam.set(key, []);
+    byTeam.get(key).push(h);
+  }
+
+  const stories = [];
+  for (const [, hs] of [...byTeam.entries()].slice(0, 2)) {
+    const abbr   = hs[0]?.teamAbbr ?? String(hs[0]?.teamId ?? 'Team');
+    const teamId = hs[0]?.teamId ?? null;
+    const count  = hs.length;
+    const firstName = hs[0]?.playerName ?? 'A player';
+    const pos = hs[0]?.pos ?? '';
+
+    const id = makeStableStoryId('prestige-honor', teamId ?? abbr, season);
+
+    const headline = count > 1
+      ? `${abbr} Places ${count} on First-Team All-Pro`
+      : `${firstName} Named First-Team All-Pro`;
+
+    const dek = count > 1
+      ? `${abbr} earns ${count} First-Team All-Pro selections this season.`
+      : `${firstName}${pos ? ` (${pos})` : ''} of ${abbr} claims the league's top individual honor.`;
+
+    stories.push({
+      id,
+      type:            MEDIA_STORY_TYPES.PRESTIGE_HONOR,
+      priority:        70,
+      week,
+      season,
+      teamId,
+      secondaryTeamId: null,
+      playerId:        hs[0]?.playerId ?? null,
+      headline,
+      dek,
+      tone:            'positive',
+      tags:            ['prestige', 'all-pro'],
+      sourceEventIds:  [],
+    });
+  }
+
+  return stories;
+}
+
+/**
+ * Generate PLAYOFF_PUSH stories from standings for teams in active contention.
+ * Only runs after Week 6 to avoid early-season noise.
+ * @param {Object} league
+ * @returns {Object[]}
+ */
+export function extractPlayoffPushStories(league) {
+  const standings = Array.isArray(league?.standings) ? league.standings : [];
+  const season    = _n(league?.year ?? league?.season);
+  const week      = _n(league?.week);
+  const stories   = [];
+
+  if (standings.length === 0 || week < 6) return stories;
+
+  // Normalize standing rows (support both tid/id/teamId keys)
+  const rows = standings
+    .map((s) => ({
+      tid:  s.tid ?? s.id ?? s.teamId,
+      w:    _n(s.w ?? s.wins),
+      l:    _n(s.l ?? s.losses),
+      t:    _n(s.t ?? s.ties),
+      abbr: s.abbr ?? s.name ?? s.teamName,
+      conf: s.conf,
+    }))
+    .filter((s) => s.tid != null && s.w > s.l);
+
+  if (rows.length < 3) return stories;
+
+  // Sort by win percentage (stable: then by tid string for ties)
+  const sorted = [...rows].sort((a, b) => {
+    const totA = a.w + a.l + a.t || 1;
+    const totB = b.w + b.l + b.t || 1;
+    const wpA  = (a.w + a.t * 0.5) / totA;
+    const wpB  = (b.w + b.t * 0.5) / totB;
+    if (wpB !== wpA) return wpB - wpA;
+    return String(a.tid).localeCompare(String(b.tid));
+  });
+
+  // Pick the "bubble" contender — team at ~40th percentile of winning teams
+  const bubbleIdx  = Math.floor(sorted.length * 0.4);
+  const bubbleTeam = sorted[bubbleIdx];
+
+  if (bubbleTeam && bubbleTeam.w >= 4) {
+    const id = makeStableStoryId('playoff-push', bubbleTeam.tid, season, week);
+    stories.push({
+      id,
+      type:            MEDIA_STORY_TYPES.PLAYOFF_PUSH,
+      priority:        55,
+      week,
+      season,
+      teamId:          bubbleTeam.tid,
+      secondaryTeamId: null,
+      playerId:        null,
+      headline:        `${bubbleTeam.abbr ?? 'Team'} Alive in Playoff Picture`,
+      dek:             `At ${bubbleTeam.w}-${bubbleTeam.l}, ${bubbleTeam.abbr ?? 'the team'} is firmly in the postseason picture entering Week ${week}.`,
+      tone:            'positive',
+      tags:            ['playoff', 'race'],
+      sourceEventIds:  [],
+    });
+  }
+
+  return stories;
+}
+
+// ── Core pipeline ─────────────────────────────────────────────────────────────
+
+/**
+ * Synthesize candidate stories from all available signals.
+ * No mutation of the input context.
+ * @param {Object} context  — league/view-state slice
+ * @returns {Object[]}      — deduped candidate stories
+ */
+export function selectMediaStories(context) {
+  const league = context ?? {};
+  const candidates = [
+    ...extractHotSeatStories(league),
+    ...extractMandateStories(league),
+    ...extractBlockbusterTradeStories(league),
+    ...extractPrestigeStories(league),
+    ...extractPlayoffPushStories(league),
+  ];
+  return dedupeMediaStories(candidates);
+}
+
+/**
+ * Rank stories deterministically by priority, then recency, then id.
+ * Returns at most maxCount stories (default MEDIA_STORY_MAX).
+ * @param {Object[]} stories
+ * @param {{ maxCount?: number }} [options]
+ * @returns {Object[]}
+ */
+export function rankMediaStories(stories, options = {}) {
+  const maxCount = _n(options.maxCount, MEDIA_STORY_MAX);
+  return [...stories]
+    .sort((a, b) => {
+      if (b.priority !== a.priority) return b.priority - a.priority;
+      if (b.week !== a.week) return b.week - a.week;
+      return String(a.id).localeCompare(String(b.id));
+    })
+    .slice(0, maxCount);
+}
+
+/**
+ * Convert a structured story into a concise headline/dek pair.
+ * @param {Object} story
+ * @returns {{ headline: string, dek: string }}
+ */
+export function buildMediaHeadline(story) {
+  return {
+    headline: story?.headline ?? '',
+    dek:      story?.dek ?? '',
+  };
+}
+
+/**
+ * Top-level entry point. Returns a compact, ranked array of media story cards
+ * derived purely from existing league state. Immutable and deterministic.
+ *
+ * @param {Object} league   — league/view-state object (not mutated)
+ * @param {{ maxCount?: number }} [options]
+ * @returns {Object[]}      — ranked media story cards
+ */
+export function buildMediaNarratives(league, options = {}) {
+  if (!league || typeof league !== 'object') return [];
+  const candidates = selectMediaStories(league);
+  return rankMediaStories(candidates, options);
+}

--- a/src/core/news/mediaNarrativeEngine.unit.test.js
+++ b/src/core/news/mediaNarrativeEngine.unit.test.js
@@ -1,0 +1,726 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MEDIA_STORY_TYPES,
+  MEDIA_STORY_MAX,
+  buildMediaNarratives,
+  selectMediaStories,
+  rankMediaStories,
+  buildMediaHeadline,
+  getMediaStoryTypeLabel,
+  makeStableStoryId,
+  dedupeMediaStories,
+  extractHotSeatStories,
+  extractMandateStories,
+  extractBlockbusterTradeStories,
+  extractPrestigeStories,
+  extractPlayoffPushStories,
+} from './mediaNarrativeEngine.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeTeam(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Test Team',
+    abbr: 'TST',
+    conf: 0,
+    div: 0,
+    wins: 8,
+    losses: 4,
+    ties: 0,
+    ovr: 80,
+    owner: {
+      mandate: 'MAKE_PLAYOFFS',
+      hotSeatRating: 25,
+      seasonsUnderGoal: 0,
+    },
+    ...overrides,
+  };
+}
+
+function makeAllTeams(count = 4) {
+  return Array.from({ length: count }, (_, i) => makeTeam({
+    id: i + 1,
+    abbr: `T${i + 1}`,
+    wins: 5 + i,
+    losses: 4 - (i % 3),
+    owner: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 20 + i * 10, seasonsUnderGoal: i % 2 },
+  }));
+}
+
+function makeLeague(overrides = {}) {
+  return {
+    year: 2026,
+    week: 10,
+    userTeamId: 1,
+    teams: [makeTeam()],
+    standings: [],
+    newsItems: [],
+    currentSeasonHonors: null,
+    leaguePulse: [],
+    ...overrides,
+  };
+}
+
+// ── MEDIA_STORY_TYPES constants ───────────────────────────────────────────────
+
+describe('MEDIA_STORY_TYPES', () => {
+  it('exports all expected story type keys as frozen constants', () => {
+    expect(MEDIA_STORY_TYPES.OWNER_PRESSURE).toBe('OWNER_PRESSURE');
+    expect(MEDIA_STORY_TYPES.BLOCKBUSTER_TRADE).toBe('BLOCKBUSTER_TRADE');
+    expect(MEDIA_STORY_TYPES.MANDATE_SURGE).toBe('MANDATE_SURGE');
+    expect(MEDIA_STORY_TYPES.MANDATE_SLIP).toBe('MANDATE_SLIP');
+    expect(MEDIA_STORY_TYPES.PRESTIGE_HONOR).toBe('PRESTIGE_HONOR');
+    expect(MEDIA_STORY_TYPES.WAIVER_MOVE).toBe('WAIVER_MOVE');
+    expect(MEDIA_STORY_TYPES.PLAYOFF_PUSH).toBe('PLAYOFF_PUSH');
+    expect(MEDIA_STORY_TYPES.LEGACY_MILESTONE).toBe('LEGACY_MILESTONE');
+    expect(Object.isFrozen(MEDIA_STORY_TYPES)).toBe(true);
+  });
+});
+
+// ── makeStableStoryId ─────────────────────────────────────────────────────────
+
+describe('makeStableStoryId', () => {
+  it('joins parts with dashes', () => {
+    expect(makeStableStoryId('owner-pressure', 1, 2026)).toBe('owner-pressure-1-2026');
+  });
+
+  it('converts numbers to strings', () => {
+    expect(makeStableStoryId(42, 'foo', 0)).toBe('42-foo-0');
+  });
+
+  it('is stable across calls with same arguments', () => {
+    const a = makeStableStoryId('prestige', 10, 2026);
+    const b = makeStableStoryId('prestige', 10, 2026);
+    expect(a).toBe(b);
+  });
+});
+
+// ── dedupeMediaStories ────────────────────────────────────────────────────────
+
+describe('dedupeMediaStories', () => {
+  it('removes stories with duplicate ids', () => {
+    const stories = [
+      { id: 'a', type: 'OWNER_PRESSURE', priority: 80 },
+      { id: 'b', type: 'MANDATE_SLIP', priority: 60 },
+      { id: 'a', type: 'OWNER_PRESSURE', priority: 50 },
+    ];
+    const result = dedupeMediaStories(stories);
+    expect(result).toHaveLength(2);
+    expect(result.map((s) => s.id)).toEqual(['a', 'b']);
+  });
+
+  it('keeps first occurrence when there is a duplicate', () => {
+    const stories = [
+      { id: 'x', priority: 90 },
+      { id: 'x', priority: 10 },
+    ];
+    const result = dedupeMediaStories(stories);
+    expect(result[0].priority).toBe(90);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(dedupeMediaStories([])).toEqual([]);
+  });
+
+  it('filters stories missing an id', () => {
+    const stories = [{ id: null }, { id: 'valid' }];
+    const result = dedupeMediaStories(stories);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('valid');
+  });
+});
+
+// ── getMediaStoryTypeLabel ────────────────────────────────────────────────────
+
+describe('getMediaStoryTypeLabel', () => {
+  it('returns human-readable labels for known types', () => {
+    expect(getMediaStoryTypeLabel('OWNER_PRESSURE')).toBe('Owner Pressure');
+    expect(getMediaStoryTypeLabel('BLOCKBUSTER_TRADE')).toBe('Blockbuster Trade');
+    expect(getMediaStoryTypeLabel('MANDATE_SURGE')).toBe('Surging');
+    expect(getMediaStoryTypeLabel('MANDATE_SLIP')).toBe('Under Pressure');
+    expect(getMediaStoryTypeLabel('PRESTIGE_HONOR')).toBe('League Honor');
+    expect(getMediaStoryTypeLabel('PLAYOFF_PUSH')).toBe('Playoff Race');
+  });
+
+  it('falls back gracefully for unknown type', () => {
+    const label = getMediaStoryTypeLabel('SOME_NEW_TYPE');
+    expect(typeof label).toBe('string');
+    expect(label.length).toBeGreaterThan(0);
+  });
+
+  it('handles null/undefined type', () => {
+    expect(getMediaStoryTypeLabel(null)).toBe('Update');
+    expect(getMediaStoryTypeLabel(undefined)).toBe('Update');
+  });
+});
+
+// ── extractHotSeatStories ─────────────────────────────────────────────────────
+
+describe('extractHotSeatStories', () => {
+  it('generates OWNER_PRESSURE story for team with rating >= 60', () => {
+    const league = makeLeague({
+      teams: [makeTeam({ id: 5, abbr: 'HOT', owner: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 70, seasonsUnderGoal: 1 } })],
+    });
+    const stories = extractHotSeatStories(league);
+    expect(stories).toHaveLength(1);
+    expect(stories[0].type).toBe(MEDIA_STORY_TYPES.OWNER_PRESSURE);
+    expect(stories[0].teamId).toBe(5);
+    expect(stories[0].tone).toBe('warning');
+  });
+
+  it('uses urgent tone for rating >= 80', () => {
+    const league = makeLeague({
+      teams: [makeTeam({ owner: { mandate: 'WIN_DIVISION', hotSeatRating: 85, seasonsUnderGoal: 2 } })],
+    });
+    const stories = extractHotSeatStories(league);
+    expect(stories[0].tone).toBe('urgent');
+  });
+
+  it('does not generate story for teams with rating < 60', () => {
+    const league = makeLeague({
+      teams: [makeTeam({ owner: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 40, seasonsUnderGoal: 0 } })],
+    });
+    expect(extractHotSeatStories(league)).toHaveLength(0);
+  });
+
+  it('returns empty array when no teams have an owner profile', () => {
+    const league = makeLeague({
+      teams: [{ id: 1, abbr: 'TST', wins: 5, losses: 5 }],
+    });
+    expect(extractHotSeatStories(league)).toHaveLength(0);
+  });
+
+  it('does not mutate the input league', () => {
+    const league = makeLeague({
+      teams: [makeTeam({ owner: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 75, seasonsUnderGoal: 1 } })],
+    });
+    const originalTeams = JSON.stringify(league.teams);
+    extractHotSeatStories(league);
+    expect(JSON.stringify(league.teams)).toBe(originalTeams);
+  });
+
+  it('produces stable ids across repeated calls', () => {
+    const league = makeLeague({
+      teams: [makeTeam({ id: 7, owner: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 65, seasonsUnderGoal: 0 } })],
+    });
+    const r1 = extractHotSeatStories(league);
+    const r2 = extractHotSeatStories(league);
+    expect(r1[0].id).toBe(r2[0].id);
+  });
+
+  it('includes seasonsUnderGoal context in dek', () => {
+    const league = makeLeague({
+      teams: [makeTeam({ owner: { mandate: 'WIN_DIVISION', hotSeatRating: 70, seasonsUnderGoal: 3 } })],
+    });
+    const stories = extractHotSeatStories(league);
+    expect(stories[0].dek).toMatch(/3.*season/i);
+  });
+
+  it('returns empty array for empty teams list', () => {
+    expect(extractHotSeatStories(makeLeague({ teams: [] }))).toEqual([]);
+  });
+
+  it('returns empty array for null/undefined league', () => {
+    expect(extractHotSeatStories(null)).toEqual([]);
+    expect(extractHotSeatStories(undefined)).toEqual([]);
+  });
+});
+
+// ── extractMandateStories ─────────────────────────────────────────────────────
+
+describe('extractMandateStories', () => {
+  it('generates MANDATE_SLIP for a team with losing record and consecutive misses', () => {
+    const league = makeLeague({
+      teams: [makeTeam({ id: 3, abbr: 'SLP', wins: 3, losses: 9, owner: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 60, seasonsUnderGoal: 2 } })],
+    });
+    const stories = extractMandateStories(league);
+    const slip = stories.find((s) => s.type === MEDIA_STORY_TYPES.MANDATE_SLIP);
+    expect(slip).toBeTruthy();
+    expect(slip.teamId).toBe(3);
+    expect(slip.tone).toBe('warning');
+  });
+
+  it('generates MANDATE_SURGE for a team significantly overachieving', () => {
+    const league = makeLeague({
+      teams: [makeTeam({ id: 4, abbr: 'SRG', wins: 10, losses: 2, owner: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 20, seasonsUnderGoal: 0 } })],
+    });
+    const stories = extractMandateStories(league);
+    const surge = stories.find((s) => s.type === MEDIA_STORY_TYPES.MANDATE_SURGE);
+    expect(surge).toBeTruthy();
+    expect(surge.tone).toBe('positive');
+  });
+
+  it('does not generate mandate stories when fewer than 4 games played', () => {
+    const league = makeLeague({
+      teams: [makeTeam({ wins: 0, losses: 3, owner: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 60, seasonsUnderGoal: 1 } })],
+    });
+    expect(extractMandateStories(league)).toHaveLength(0);
+  });
+
+  it('does not generate MANDATE_SURGE for a team with too-close win margin', () => {
+    const league = makeLeague({
+      teams: [makeTeam({ wins: 5, losses: 4, owner: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 20, seasonsUnderGoal: 0 } })],
+    });
+    const surge = extractMandateStories(league).filter((s) => s.type === MEDIA_STORY_TYPES.MANDATE_SURGE);
+    expect(surge).toHaveLength(0);
+  });
+
+  it('does not mutate the input league', () => {
+    const league = makeLeague({
+      teams: [makeTeam({ wins: 2, losses: 8, owner: { mandate: 'WIN_DIVISION', hotSeatRating: 70, seasonsUnderGoal: 1 } })],
+    });
+    const snapshot = JSON.stringify(league);
+    extractMandateStories(league);
+    expect(JSON.stringify(league)).toBe(snapshot);
+  });
+
+  it('returns empty array when no teams have mandate', () => {
+    const league = makeLeague({
+      teams: [{ id: 1, abbr: 'TST', wins: 2, losses: 8, owner: {} }],
+    });
+    expect(extractMandateStories(league)).toEqual([]);
+  });
+});
+
+// ── extractBlockbusterTradeStories ────────────────────────────────────────────
+
+describe('extractBlockbusterTradeStories', () => {
+  it('generates BLOCKBUSTER_TRADE from leaguePulse transaction items', () => {
+    const league = makeLeague({
+      leaguePulse: [
+        {
+          id: 'pulse-trade-1',
+          type: 'transaction',
+          source: 'transaction',
+          headline: 'Blockbuster Trade',
+          body: 'A star QB was traded across the league.',
+          importance: 80,
+          relatedTeamId: 5,
+          season: 2026,
+          week: 9,
+        },
+      ],
+    });
+    const stories = extractBlockbusterTradeStories(league);
+    expect(stories).toHaveLength(1);
+    expect(stories[0].type).toBe(MEDIA_STORY_TYPES.BLOCKBUSTER_TRADE);
+    expect(stories[0].sourceEventIds).toContain('pulse-trade-1');
+  });
+
+  it('generates BLOCKBUSTER_TRADE from newsItems with trade text', () => {
+    const league = makeLeague({
+      newsItems: [
+        {
+          id: 'n-trade-1',
+          type: 'TRANSACTION',
+          text: 'QB Smith was traded to the Eagles.',
+          teamId: 2,
+          week: 8,
+          year: 2026,
+        },
+      ],
+    });
+    const stories = extractBlockbusterTradeStories(league);
+    expect(stories).toHaveLength(1);
+    expect(stories[0].type).toBe(MEDIA_STORY_TYPES.BLOCKBUSTER_TRADE);
+  });
+
+  it('generates trade story from newsItems with fromTeamId/toTeamId cross-team signal', () => {
+    const league = makeLeague({
+      newsItems: [
+        {
+          id: 'n-trade-2',
+          type: 'TRANSACTION',
+          text: 'Player acquired.',
+          teamId: 3,
+          week: 7,
+          year: 2026,
+          extraData: { fromTeamId: 3, toTeamId: 7 },
+        },
+      ],
+    });
+    const stories = extractBlockbusterTradeStories(league);
+    expect(stories.some((s) => s.type === MEDIA_STORY_TYPES.BLOCKBUSTER_TRADE)).toBe(true);
+  });
+
+  it('deduplicates between leaguePulse and newsItems', () => {
+    const league = makeLeague({
+      leaguePulse: [
+        { id: 'p1', type: 'transaction', headline: 'Trade', body: 'X', importance: 75, relatedTeamId: 1, season: 2026, week: 9 },
+        { id: 'p2', type: 'transaction', headline: 'Trade2', body: 'Y', importance: 75, relatedTeamId: 2, season: 2026, week: 9 },
+      ],
+    });
+    const stories = extractBlockbusterTradeStories(league);
+    // Max 2 from pulse
+    expect(stories.length).toBeLessThanOrEqual(4);
+    const ids = stories.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('returns empty array for empty inputs', () => {
+    expect(extractBlockbusterTradeStories(makeLeague())).toEqual([]);
+  });
+
+  it('does not include TRANSACTION newsItems that are just signings (no trade signal)', () => {
+    const league = makeLeague({
+      newsItems: [
+        { id: 'sign-1', type: 'TRANSACTION', text: 'Player signed a 3-year contract.', teamId: 1, week: 5, year: 2026 },
+      ],
+    });
+    const stories = extractBlockbusterTradeStories(league);
+    expect(stories).toHaveLength(0);
+  });
+});
+
+// ── extractPrestigeStories ────────────────────────────────────────────────────
+
+describe('extractPrestigeStories', () => {
+  it('generates PRESTIGE_HONOR from flat array of honors', () => {
+    const league = makeLeague({
+      currentSeasonHonors: [
+        { type: 'FIRST_TEAM_ALL_PRO', playerId: 10, playerName: 'Joe Star', pos: 'QB', teamId: 5, teamAbbr: 'DAL', year: 2026, score: 110 },
+      ],
+    });
+    const stories = extractPrestigeStories(league);
+    expect(stories).toHaveLength(1);
+    expect(stories[0].type).toBe(MEDIA_STORY_TYPES.PRESTIGE_HONOR);
+    expect(stories[0].headline).toContain('Joe Star');
+  });
+
+  it('generates PRESTIGE_HONOR from grouped summary object', () => {
+    const league = makeLeague({
+      currentSeasonHonors: {
+        FIRST_TEAM_ALL_PRO: {
+          QB: [{ playerId: 1, playerName: 'Tom Ace', pos: 'QB', teamId: 3, teamAbbr: 'GNB', score: 120 }],
+        },
+      },
+    });
+    const stories = extractPrestigeStories(league);
+    expect(stories).toHaveLength(1);
+    expect(stories[0].type).toBe(MEDIA_STORY_TYPES.PRESTIGE_HONOR);
+  });
+
+  it('returns empty array when currentSeasonHonors is null', () => {
+    expect(extractPrestigeStories(makeLeague({ currentSeasonHonors: null }))).toEqual([]);
+  });
+
+  it('returns empty array when no FIRST_TEAM_ALL_PRO entries exist', () => {
+    const league = makeLeague({
+      currentSeasonHonors: [
+        { type: 'PRO_BOWL', playerId: 2, playerName: 'B Player', teamId: 4, teamAbbr: 'SF', year: 2026 },
+      ],
+    });
+    expect(extractPrestigeStories(league)).toHaveLength(0);
+  });
+
+  it('caps at 2 stories even with many teams having honors', () => {
+    const honors = Array.from({ length: 5 }, (_, i) => ({
+      type: 'FIRST_TEAM_ALL_PRO',
+      playerId: i,
+      playerName: `Player ${i}`,
+      pos: 'WR',
+      teamId: i + 1,
+      teamAbbr: `T${i}`,
+      year: 2026,
+      score: 100 - i,
+    }));
+    const league = makeLeague({ currentSeasonHonors: honors });
+    expect(extractPrestigeStories(league).length).toBeLessThanOrEqual(2);
+  });
+
+  it('groups multiple honors for the same team into one story', () => {
+    const league = makeLeague({
+      currentSeasonHonors: [
+        { type: 'FIRST_TEAM_ALL_PRO', playerId: 1, playerName: 'P1', pos: 'QB', teamId: 5, teamAbbr: 'KC', year: 2026 },
+        { type: 'FIRST_TEAM_ALL_PRO', playerId: 2, playerName: 'P2', pos: 'WR', teamId: 5, teamAbbr: 'KC', year: 2026 },
+      ],
+    });
+    const stories = extractPrestigeStories(league);
+    expect(stories).toHaveLength(1);
+    expect(stories[0].headline).toMatch(/2/);
+  });
+});
+
+// ── extractPlayoffPushStories ─────────────────────────────────────────────────
+
+describe('extractPlayoffPushStories', () => {
+  it('generates PLAYOFF_PUSH story when enough contenders exist after week 6', () => {
+    const standings = [
+      { tid: 1, w: 8, l: 2, t: 0, abbr: 'A', conf: 0 },
+      { tid: 2, w: 6, l: 4, t: 0, abbr: 'B', conf: 0 },
+      { tid: 3, w: 5, l: 5, t: 0, abbr: 'C', conf: 0 },
+      { tid: 4, w: 7, l: 3, t: 0, abbr: 'D', conf: 1 },
+    ];
+    const league = makeLeague({ week: 8, standings });
+    const stories = extractPlayoffPushStories(league);
+    expect(stories.some((s) => s.type === MEDIA_STORY_TYPES.PLAYOFF_PUSH)).toBe(true);
+  });
+
+  it('returns empty array before week 6', () => {
+    const standings = [
+      { tid: 1, w: 4, l: 1, t: 0, abbr: 'A' },
+      { tid: 2, w: 3, l: 2, t: 0, abbr: 'B' },
+      { tid: 3, w: 2, l: 3, t: 0, abbr: 'C' },
+    ];
+    const league = makeLeague({ week: 4, standings });
+    expect(extractPlayoffPushStories(league)).toHaveLength(0);
+  });
+
+  it('returns empty array with no standings data', () => {
+    expect(extractPlayoffPushStories(makeLeague({ week: 10, standings: [] }))).toHaveLength(0);
+  });
+
+  it('handles standings rows using wins/losses keys instead of w/l', () => {
+    const standings = [
+      { tid: 1, wins: 7, losses: 3, ties: 0, abbr: 'ALT' },
+      { tid: 2, wins: 6, losses: 4, ties: 0, abbr: 'ALT2' },
+      { tid: 3, wins: 5, losses: 5, ties: 0, abbr: 'ALT3' },
+    ];
+    const league = makeLeague({ week: 9, standings });
+    const stories = extractPlayoffPushStories(league);
+    // Should still produce something (no crash)
+    expect(Array.isArray(stories)).toBe(true);
+  });
+});
+
+// ── selectMediaStories ────────────────────────────────────────────────────────
+
+describe('selectMediaStories', () => {
+  it('deduplicates stories across extractors', () => {
+    const league = makeLeague({
+      teams: [makeTeam({ owner: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 70, seasonsUnderGoal: 1 } })],
+    });
+    const stories = selectMediaStories(league);
+    const ids = stories.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('returns empty array for empty/null league', () => {
+    expect(selectMediaStories(null)).toEqual([]);
+    expect(selectMediaStories({})).toEqual([]);
+  });
+
+  it('returns an array even when all data is missing', () => {
+    expect(Array.isArray(selectMediaStories({ year: 2026, week: 5 }))).toBe(true);
+  });
+
+  it('does not mutate the input context', () => {
+    const league = makeLeague({
+      teams: [makeTeam({ owner: { mandate: 'WIN_DIVISION', hotSeatRating: 80, seasonsUnderGoal: 2 } })],
+    });
+    const snapshot = JSON.stringify(league);
+    selectMediaStories(league);
+    expect(JSON.stringify(league)).toBe(snapshot);
+  });
+});
+
+// ── rankMediaStories ──────────────────────────────────────────────────────────
+
+describe('rankMediaStories', () => {
+  it('sorts by priority descending', () => {
+    const stories = [
+      { id: 'a', type: 'MANDATE_SLIP', priority: 55, week: 10, season: 2026 },
+      { id: 'b', type: 'OWNER_PRESSURE', priority: 90, week: 10, season: 2026 },
+      { id: 'c', type: 'PLAYOFF_PUSH', priority: 55, week: 10, season: 2026 },
+    ];
+    const ranked = rankMediaStories(stories);
+    expect(ranked[0].id).toBe('b');
+  });
+
+  it('uses week as stable tiebreaker (newer first)', () => {
+    const stories = [
+      { id: 'a', priority: 60, week: 7 },
+      { id: 'b', priority: 60, week: 10 },
+    ];
+    const ranked = rankMediaStories(stories);
+    expect(ranked[0].id).toBe('b');
+  });
+
+  it('uses id as final stable tiebreaker', () => {
+    const stories = [
+      { id: 'z-story', priority: 60, week: 10 },
+      { id: 'a-story', priority: 60, week: 10 },
+    ];
+    const ranked = rankMediaStories(stories);
+    expect(ranked[0].id).toBe('a-story');
+  });
+
+  it('respects maxCount option', () => {
+    const stories = Array.from({ length: 20 }, (_, i) => ({ id: `s${i}`, priority: i, week: 10 }));
+    const ranked = rankMediaStories(stories, { maxCount: 3 });
+    expect(ranked).toHaveLength(3);
+  });
+
+  it('defaults to MEDIA_STORY_MAX when no maxCount is given', () => {
+    const stories = Array.from({ length: 20 }, (_, i) => ({ id: `s${i}`, priority: i, week: 10 }));
+    const ranked = rankMediaStories(stories);
+    expect(ranked.length).toBeLessThanOrEqual(MEDIA_STORY_MAX);
+  });
+
+  it('does not mutate the input array', () => {
+    const stories = [
+      { id: 'a', priority: 60, week: 10 },
+      { id: 'b', priority: 90, week: 10 },
+    ];
+    const original = [...stories];
+    rankMediaStories(stories);
+    expect(stories).toEqual(original);
+  });
+
+  it('is deterministic — same input always produces same order', () => {
+    const stories = [
+      { id: 'a', priority: 60, week: 10 },
+      { id: 'b', priority: 75, week: 9 },
+      { id: 'c', priority: 60, week: 8 },
+    ];
+    const r1 = rankMediaStories(stories).map((s) => s.id);
+    const r2 = rankMediaStories(stories).map((s) => s.id);
+    expect(r1).toEqual(r2);
+  });
+});
+
+// ── buildMediaHeadline ────────────────────────────────────────────────────────
+
+describe('buildMediaHeadline', () => {
+  it('returns headline and dek from a story', () => {
+    const story = { id: 'x', headline: 'Owner on Hot Seat', dek: 'Under serious pressure.' };
+    const result = buildMediaHeadline(story);
+    expect(result.headline).toBe('Owner on Hot Seat');
+    expect(result.dek).toBe('Under serious pressure.');
+  });
+
+  it('returns empty strings when story fields are missing', () => {
+    const result = buildMediaHeadline({});
+    expect(result.headline).toBe('');
+    expect(result.dek).toBe('');
+  });
+
+  it('returns empty strings for null story', () => {
+    const result = buildMediaHeadline(null);
+    expect(result.headline).toBe('');
+    expect(result.dek).toBe('');
+  });
+});
+
+// ── buildMediaNarratives (top-level) ─────────────────────────────────────────
+
+describe('buildMediaNarratives', () => {
+  it('returns an array', () => {
+    expect(Array.isArray(buildMediaNarratives(makeLeague()))).toBe(true);
+  });
+
+  it('returns empty array for null/non-object input', () => {
+    expect(buildMediaNarratives(null)).toEqual([]);
+    expect(buildMediaNarratives('string')).toEqual([]);
+    expect(buildMediaNarratives(42)).toEqual([]);
+  });
+
+  it('is fully deterministic — same inputs produce same outputs', () => {
+    const league = makeLeague({
+      teams: makeAllTeams(4),
+      week: 10,
+    });
+    const r1 = buildMediaNarratives(league);
+    const r2 = buildMediaNarratives(league);
+    expect(JSON.stringify(r1)).toBe(JSON.stringify(r2));
+  });
+
+  it('does not mutate the input league object', () => {
+    const league = makeLeague({
+      teams: [
+        makeTeam({ owner: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 80, seasonsUnderGoal: 2 } }),
+      ],
+    });
+    const before = JSON.stringify(league);
+    buildMediaNarratives(league);
+    expect(JSON.stringify(league)).toBe(before);
+  });
+
+  it('enforces max story count', () => {
+    const teams = Array.from({ length: 32 }, (_, i) =>
+      makeTeam({ id: i + 1, abbr: `T${i}`, owner: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 60 + i, seasonsUnderGoal: 1 } }),
+    );
+    const league = makeLeague({ teams });
+    const stories = buildMediaNarratives(league);
+    expect(stories.length).toBeLessThanOrEqual(MEDIA_STORY_MAX);
+  });
+
+  it('returns output with stable id field on every story', () => {
+    const league = makeLeague({
+      teams: [makeTeam({ owner: { mandate: 'WIN_DIVISION', hotSeatRating: 70, seasonsUnderGoal: 1 } })],
+    });
+    const stories = buildMediaNarratives(league);
+    for (const s of stories) {
+      expect(typeof s.id).toBe('string');
+      expect(s.id.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('hot-seat story from a team with high hotSeatRating is generated', () => {
+    const league = makeLeague({
+      teams: [makeTeam({ id: 99, abbr: 'HTS', owner: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 85, seasonsUnderGoal: 2 } })],
+    });
+    const stories = buildMediaNarratives(league);
+    const pressureStory = stories.find((s) => s.type === MEDIA_STORY_TYPES.OWNER_PRESSURE);
+    expect(pressureStory).toBeTruthy();
+    expect(pressureStory.teamId).toBe(99);
+  });
+
+  it('mandate slip story appears in output for underperforming team', () => {
+    const league = makeLeague({
+      teams: [makeTeam({ wins: 2, losses: 9, owner: { mandate: 'WIN_DIVISION', hotSeatRating: 65, seasonsUnderGoal: 2 } })],
+      week: 11,
+    });
+    const stories = buildMediaNarratives(league);
+    expect(stories.some((s) => s.type === MEDIA_STORY_TYPES.MANDATE_SLIP)).toBe(true);
+  });
+
+  it('does not use Math.random (output is same on 10 repeated calls)', () => {
+    const league = makeLeague({
+      teams: makeAllTeams(8),
+      week: 8,
+    });
+    const outputs = Array.from({ length: 10 }, () =>
+      JSON.stringify(buildMediaNarratives(league)),
+    );
+    expect(new Set(outputs).size).toBe(1);
+  });
+
+  it('respects maxCount option passed in options', () => {
+    const teams = Array.from({ length: 20 }, (_, i) =>
+      makeTeam({ id: i + 1, owner: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 65 + i, seasonsUnderGoal: 1 } }),
+    );
+    const stories = buildMediaNarratives(makeLeague({ teams }), { maxCount: 3 });
+    expect(stories.length).toBeLessThanOrEqual(3);
+  });
+
+  it('highest-priority story appears first', () => {
+    const league = makeLeague({
+      teams: [
+        makeTeam({ id: 1, abbr: 'HIGH', wins: 10, losses: 2, owner: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 92, seasonsUnderGoal: 3 } }),
+        makeTeam({ id: 2, abbr: 'LOW', wins: 8, losses: 4, owner: { mandate: 'MAKE_PLAYOFFS', hotSeatRating: 62, seasonsUnderGoal: 0 } }),
+      ],
+    });
+    const stories = buildMediaNarratives(league);
+    expect(stories.length).toBeGreaterThan(0);
+    // The team with hotSeatRating 92 should produce highest-priority story
+    expect(stories[0].priority).toBeGreaterThanOrEqual(stories[stories.length - 1].priority);
+  });
+
+  it('handles league with no owners/news/standings gracefully', () => {
+    const bareLeague = { year: 2026, week: 8, userTeamId: 1, teams: [{ id: 1, abbr: 'TST', wins: 5, losses: 3 }] };
+    expect(() => buildMediaNarratives(bareLeague)).not.toThrow();
+    expect(Array.isArray(buildMediaNarratives(bareLeague))).toBe(true);
+  });
+
+  it('prestige honors appear when currentSeasonHonors is provided', () => {
+    const league = makeLeague({
+      currentSeasonHonors: [
+        { type: 'FIRST_TEAM_ALL_PRO', playerId: 5, playerName: 'Star WR', pos: 'WR', teamId: 3, teamAbbr: 'KC', year: 2026 },
+      ],
+    });
+    const stories = buildMediaNarratives(league);
+    expect(stories.some((s) => s.type === MEDIA_STORY_TYPES.PRESTIGE_HONOR)).toBe(true);
+  });
+});

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -14,6 +14,7 @@ import { getLastGameDisplay, getLatestUserCompletedGame, getNextOpponentDisplay 
 import { HQIcon, TeamIdentityBadge } from './HQVisuals.jsx';
 import { buildGameBookDestination } from '../utils/managementScreenRouting.js';
 import ChronicleHeadlineBanner from './ChronicleHeadlineBanner.tsx';
+import MediaDesk from './MediaDesk.jsx';
 import CombineDashboard from './CombineDashboard.jsx';
 import FranchiseLegacyView from './FranchiseLegacyView.jsx';
 import FranchiseBrandHQ from './FranchiseBrandHQ.jsx';
@@ -718,6 +719,8 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
           currentYear={safeNum(league?.year, 0)}
           onViewAll={() => onNavigate?.('News')}
         />
+
+        <MediaDesk stories={Array.isArray(league?.mediaStories) ? league.mediaStories : []} />
 
         {/* Twin status cards */}
         <div className="hq-twin-grid" aria-label="Team status overview" data-testid="hq-twin-status-grid">

--- a/src/ui/components/MediaDesk.jsx
+++ b/src/ui/components/MediaDesk.jsx
@@ -1,0 +1,250 @@
+/**
+ * MediaDesk — League Media section for Franchise HQ.
+ *
+ * Renders up to 8 deterministic media story cards derived from existing
+ * league state. Display-only: no gameplay consequences, no mutations.
+ */
+
+import React from 'react';
+import { getMediaStoryTypeLabel } from '../../core/news/mediaNarrativeEngine.js';
+
+// ── Visual config per story type ──────────────────────────────────────────────
+
+const TYPE_STYLE = {
+  OWNER_PRESSURE: {
+    accent: '#FF453A',
+    bg:     'rgba(255,69,58,0.07)',
+    border: 'rgba(255,69,58,0.35)',
+  },
+  BLOCKBUSTER_TRADE: {
+    accent: '#0A84FF',
+    bg:     'rgba(10,132,255,0.07)',
+    border: 'rgba(10,132,255,0.3)',
+  },
+  MANDATE_SLIP: {
+    accent: '#FF9F0A',
+    bg:     'rgba(255,159,10,0.07)',
+    border: 'rgba(255,159,10,0.3)',
+  },
+  MANDATE_SURGE: {
+    accent: '#30D158',
+    bg:     'rgba(48,209,88,0.07)',
+    border: 'rgba(48,209,88,0.3)',
+  },
+  PRESTIGE_HONOR: {
+    accent: '#FFD60A',
+    bg:     'rgba(255,214,10,0.07)',
+    border: 'rgba(255,214,10,0.3)',
+  },
+  WAIVER_MOVE: {
+    accent: '#64D2FF',
+    bg:     'rgba(100,210,255,0.07)',
+    border: 'rgba(100,210,255,0.3)',
+  },
+  PLAYOFF_PUSH: {
+    accent: '#BF5AF2',
+    bg:     'rgba(191,90,242,0.07)',
+    border: 'rgba(191,90,242,0.3)',
+  },
+  LEGACY_MILESTONE: {
+    accent: '#FF375F',
+    bg:     'rgba(255,55,95,0.07)',
+    border: 'rgba(255,55,95,0.3)',
+  },
+};
+
+const FALLBACK_STYLE = {
+  accent: '#8E8E93',
+  bg:     'rgba(142,142,147,0.07)',
+  border: 'rgba(142,142,147,0.3)',
+};
+
+const TONE_ACCENT = {
+  urgent:   '#FF453A',
+  warning:  '#FF9F0A',
+  positive: '#30D158',
+  neutral:  '#8E8E93',
+};
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function TypeBadge({ type }) {
+  const style = TYPE_STYLE[type] ?? FALLBACK_STYLE;
+  const label = getMediaStoryTypeLabel(type);
+  return (
+    <span
+      style={{
+        display:        'inline-block',
+        fontSize:       '0.65rem',
+        fontWeight:     700,
+        letterSpacing:  '0.3px',
+        textTransform:  'uppercase',
+        background:     style.bg,
+        color:          style.accent,
+        border:         `1px solid ${style.border}`,
+        borderRadius:   4,
+        padding:        '1px 6px',
+        whiteSpace:     'nowrap',
+        flexShrink:     0,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function MediaStoryCard({ story, isTop }) {
+  const style  = TYPE_STYLE[story.type] ?? FALLBACK_STYLE;
+  const tone   = story.tone ?? 'neutral';
+  const left   = story.priority >= 80 ? style.accent : (TONE_ACCENT[tone] ?? style.accent);
+
+  return (
+    <div
+      data-testid="media-story-card"
+      data-story-type={story.type}
+      data-story-id={story.id}
+      style={{
+        borderLeft:   `3px solid ${left}`,
+        background:   isTop ? style.bg : 'transparent',
+        borderRadius: isTop ? '0 8px 8px 0' : 0,
+        padding:      isTop ? '10px 12px 10px 10px' : '8px 4px 8px 10px',
+        marginBottom: isTop ? 8 : 0,
+      }}
+    >
+      {/* Meta row */}
+      <div
+        style={{
+          display:    'flex',
+          alignItems: 'center',
+          gap:        6,
+          marginBottom: 3,
+          flexWrap:   'wrap',
+        }}
+      >
+        <TypeBadge type={story.type} />
+        {story.week ? (
+          <span style={{ fontSize: '0.65rem', color: 'var(--text-muted)', opacity: 0.65 }}>
+            Wk {story.week}
+          </span>
+        ) : null}
+      </div>
+
+      {/* Headline */}
+      <div
+        style={{
+          fontWeight: isTop ? 700 : 600,
+          fontSize:   isTop ? 'var(--text-sm, 0.85rem)' : 'var(--text-xs, 0.78rem)',
+          lineHeight: 1.35,
+          color:      'var(--text)',
+        }}
+      >
+        {story.headline}
+      </div>
+
+      {/* Dek (top story only) */}
+      {isTop && story.dek ? (
+        <div
+          style={{
+            fontSize:   'var(--text-xs, 0.75rem)',
+            color:      'var(--text-muted)',
+            marginTop:  4,
+            lineHeight: 1.4,
+          }}
+        >
+          {story.dek}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// ── Main export ───────────────────────────────────────────────────────────────
+
+/**
+ * @param {object}   props
+ * @param {Array}    props.stories      — media story cards from league.mediaStories
+ * @param {number}   [props.maxVisible] — max cards to render (default 6)
+ */
+export default function MediaDesk({ stories, maxVisible = 6 }) {
+  const safeStories = Array.isArray(stories) ? stories : [];
+  const visible     = safeStories.slice(0, maxVisible);
+
+  return (
+    <section
+      data-testid="media-desk"
+      aria-label="League Media Desk"
+      className="card"
+      style={{ padding: 'var(--space-2)', marginBottom: 12 }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display:        'flex',
+          alignItems:     'center',
+          justifyContent: 'space-between',
+          marginBottom:   10,
+        }}
+      >
+        <div>
+          <h2
+            style={{
+              fontSize:        'var(--text-sm, 0.85rem)',
+              fontWeight:      800,
+              letterSpacing:   '0.5px',
+              textTransform:   'uppercase',
+              margin:          0,
+            }}
+          >
+            League Media
+          </h2>
+          <p
+            style={{
+              fontSize: 'var(--text-xs, 0.72rem)',
+              color:    'var(--text-muted)',
+              margin:   '2px 0 0',
+            }}
+          >
+            What the league is talking about
+          </p>
+        </div>
+      </div>
+
+      {/* Empty state */}
+      {visible.length === 0 ? (
+        <p
+          data-testid="media-desk-empty"
+          style={{
+            fontSize:  'var(--text-xs, 0.78rem)',
+            color:     'var(--text-muted)',
+            fontStyle: 'italic',
+            margin:    0,
+          }}
+        >
+          No league media stories this week.
+        </p>
+      ) : (
+        <>
+          {/* Top story */}
+          <MediaStoryCard story={visible[0]} isTop />
+
+          {/* Secondary stories */}
+          {visible.length > 1 ? (
+            <div
+              style={{
+                borderTop:      '1px solid var(--hairline)',
+                paddingTop:     8,
+                display:        'flex',
+                flexDirection:  'column',
+                gap:            6,
+              }}
+            >
+              {visible.slice(1).map((story) => (
+                <MediaStoryCard key={story.id} story={story} isTop={false} />
+              ))}
+            </div>
+          ) : null}
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/ui/components/__tests__/MediaDesk.test.jsx
+++ b/src/ui/components/__tests__/MediaDesk.test.jsx
@@ -1,0 +1,210 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import MediaDesk from '../MediaDesk.jsx';
+
+afterEach(() => { cleanup(); });
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeStory(overrides = {}) {
+  return {
+    id:              'owner-pressure-1-2026-high',
+    type:            'OWNER_PRESSURE',
+    priority:        90,
+    week:            10,
+    season:          2026,
+    teamId:          1,
+    secondaryTeamId: null,
+    playerId:        null,
+    headline:        'CHI Front Office on Hot Seat',
+    dek:             'Mandate: Make The Playoffs. Job-security index at 85/100 — 2 consecutive seasons below expectations.',
+    tone:            'urgent',
+    tags:            ['owner-pressure'],
+    sourceEventIds:  [],
+    ...overrides,
+  };
+}
+
+// ── Render tests ──────────────────────────────────────────────────────────────
+
+describe('MediaDesk — empty state', () => {
+  it('renders the section element even with no stories', () => {
+    render(<MediaDesk stories={[]} />);
+    expect(screen.getByTestId('media-desk')).toBeTruthy();
+  });
+
+  it('shows empty state text when stories is an empty array', () => {
+    render(<MediaDesk stories={[]} />);
+    expect(screen.getByTestId('media-desk-empty')).toBeTruthy();
+    expect(screen.getByText(/no league media stories this week/i)).toBeTruthy();
+  });
+
+  it('shows empty state when stories prop is null', () => {
+    render(<MediaDesk stories={null} />);
+    expect(screen.getByTestId('media-desk-empty')).toBeTruthy();
+  });
+
+  it('shows empty state when stories prop is undefined', () => {
+    render(<MediaDesk />);
+    expect(screen.getByTestId('media-desk-empty')).toBeTruthy();
+  });
+
+  it('does not crash when stories is a non-array value', () => {
+    render(<MediaDesk stories="invalid" />);
+    expect(screen.getByTestId('media-desk')).toBeTruthy();
+  });
+});
+
+describe('MediaDesk — stories present', () => {
+  it('renders the section with accessible label', () => {
+    render(<MediaDesk stories={[makeStory()]} />);
+    expect(screen.getByRole('region', { name: /league media desk/i })).toBeTruthy();
+  });
+
+  it('renders League Media heading', () => {
+    render(<MediaDesk stories={[makeStory()]} />);
+    expect(screen.getByRole('heading', { name: /league media/i })).toBeTruthy();
+  });
+
+  it('does NOT show empty state when stories are present', () => {
+    render(<MediaDesk stories={[makeStory()]} />);
+    expect(screen.queryByTestId('media-desk-empty')).toBeNull();
+  });
+
+  it('renders at least one story card', () => {
+    render(<MediaDesk stories={[makeStory()]} />);
+    const cards = screen.getAllByTestId('media-story-card');
+    expect(cards.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders the headline text of the top story', () => {
+    const story = makeStory({ headline: 'CHI Front Office on Hot Seat' });
+    render(<MediaDesk stories={[story]} />);
+    expect(screen.getByText('CHI Front Office on Hot Seat')).toBeTruthy();
+  });
+
+  it('renders the dek of the top story', () => {
+    const story = makeStory({ dek: 'Job security index at 85/100.' });
+    render(<MediaDesk stories={[story]} />);
+    expect(screen.getByText('Job security index at 85/100.')).toBeTruthy();
+  });
+
+  it('displays the week number in the top story', () => {
+    render(<MediaDesk stories={[makeStory({ week: 9 })]} />);
+    expect(screen.getByText('Wk 9')).toBeTruthy();
+  });
+
+  it('attaches data-story-type attribute to card', () => {
+    render(<MediaDesk stories={[makeStory({ type: 'OWNER_PRESSURE' })]} />);
+    const card = screen.getByTestId('media-story-card');
+    expect(card.getAttribute('data-story-type')).toBe('OWNER_PRESSURE');
+  });
+
+  it('attaches data-story-id attribute to card', () => {
+    const story = makeStory({ id: 'test-story-id' });
+    render(<MediaDesk stories={[story]} />);
+    const card = screen.getByTestId('media-story-card');
+    expect(card.getAttribute('data-story-id')).toBe('test-story-id');
+  });
+});
+
+describe('MediaDesk — high-priority owner pressure story', () => {
+  it('renders OWNER_PRESSURE story correctly', () => {
+    const story = makeStory({
+      type:     'OWNER_PRESSURE',
+      headline: 'DAL Front Office on Hot Seat',
+      dek:      'Mandate: Win The Division. Job-security index at 88/100 — 3 consecutive seasons below expectations.',
+      tone:     'urgent',
+      teamId:   5,
+      week:     11,
+    });
+    render(<MediaDesk stories={[story]} />);
+    expect(screen.getByText('DAL Front Office on Hot Seat')).toBeTruthy();
+    expect(screen.getByText(/job-security index at 88\/100/i)).toBeTruthy();
+  });
+
+  it('shows type badge label for OWNER_PRESSURE', () => {
+    render(<MediaDesk stories={[makeStory({ type: 'OWNER_PRESSURE' })]} />);
+    expect(screen.getByText(/owner pressure/i)).toBeTruthy();
+  });
+});
+
+describe('MediaDesk — multiple stories', () => {
+  it('renders multiple story cards when multiple stories provided', () => {
+    const stories = [
+      makeStory({ id: 's1', type: 'OWNER_PRESSURE', headline: 'Story One' }),
+      makeStory({ id: 's2', type: 'MANDATE_SLIP',   headline: 'Story Two' }),
+      makeStory({ id: 's3', type: 'PLAYOFF_PUSH',   headline: 'Story Three' }),
+    ];
+    render(<MediaDesk stories={stories} />);
+    const cards = screen.getAllByTestId('media-story-card');
+    expect(cards.length).toBe(3);
+  });
+
+  it('caps at maxVisible (default 6)', () => {
+    const stories = Array.from({ length: 10 }, (_, i) =>
+      makeStory({ id: `s${i}`, headline: `Story ${i}` }),
+    );
+    render(<MediaDesk stories={stories} />);
+    const cards = screen.getAllByTestId('media-story-card');
+    expect(cards.length).toBeLessThanOrEqual(6);
+  });
+
+  it('respects custom maxVisible prop', () => {
+    const stories = Array.from({ length: 10 }, (_, i) =>
+      makeStory({ id: `s${i}`, headline: `Story ${i}` }),
+    );
+    render(<MediaDesk stories={stories} maxVisible={3} />);
+    const cards = screen.getAllByTestId('media-story-card');
+    expect(cards.length).toBeLessThanOrEqual(3);
+  });
+});
+
+describe('MediaDesk — missing team/player references', () => {
+  it('does not crash when teamId is null', () => {
+    const story = makeStory({ teamId: null });
+    expect(() => render(<MediaDesk stories={[story]} />)).not.toThrow();
+  });
+
+  it('does not crash when playerId is null', () => {
+    const story = makeStory({ playerId: null });
+    expect(() => render(<MediaDesk stories={[story]} />)).not.toThrow();
+  });
+
+  it('does not crash when week is missing', () => {
+    const story = makeStory({ week: null });
+    expect(() => render(<MediaDesk stories={[story]} />)).not.toThrow();
+  });
+
+  it('does not crash when headline is empty string', () => {
+    const story = makeStory({ headline: '', dek: '' });
+    expect(() => render(<MediaDesk stories={[story]} />)).not.toThrow();
+  });
+
+  it('renders type badge for an unknown story type gracefully', () => {
+    const story = makeStory({ type: 'UNKNOWN_FUTURE_TYPE' });
+    expect(() => render(<MediaDesk stories={[story]} />)).not.toThrow();
+  });
+});
+
+describe('MediaDesk — different story types render without crash', () => {
+  const types = [
+    'OWNER_PRESSURE',
+    'BLOCKBUSTER_TRADE',
+    'MANDATE_SURGE',
+    'MANDATE_SLIP',
+    'PRESTIGE_HONOR',
+    'WAIVER_MOVE',
+    'PLAYOFF_PUSH',
+    'LEGACY_MILESTONE',
+  ];
+  for (const type of types) {
+    it(`renders ${type} without crashing`, () => {
+      const story = makeStory({ id: `s-${type}`, type });
+      expect(() => render(<MediaDesk stories={[story]} />)).not.toThrow();
+      cleanup();
+    });
+  }
+});

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -61,6 +61,7 @@ import {
 } from './dirtyFlushAccumulator.js';
 import { cache }          from '../db/cache.js';
 import { generateLeaguePulseItems, mergeLeaguePulseItems } from '../core/leaguePulse.js';
+import { buildMediaNarratives } from '../core/news/mediaNarrativeEngine.js';
 import {
   Meta, Teams, Players, Rosters, Games,
   Seasons, PlayerStats, Transactions, DraftPicks,
@@ -1191,6 +1192,7 @@ function buildViewState() {
     hofRoster: Array.isArray(meta?.hofRoster) ? meta.hofRoster.slice(-100) : [],
     hofBallot: meta?.hofBallot ?? null,
     weeklyHeadlines: Array.isArray(meta?.weeklyHeadlines) ? meta.weeklyHeadlines.slice(-40) : [],
+    leaguePulse: Array.isArray(meta?.leaguePulse) ? meta.leaguePulse.slice(-100) : [],
     settings: normalizeLeagueSettings(meta?.settings ?? {}),
     economy: normalizeLeagueEconomy(meta?.economy ?? {}, { year: meta?.year }),
     tradeDeadline,
@@ -1278,6 +1280,20 @@ function buildViewState() {
       return t?.allTimeLeaders ?? { passingYards: null, rushingYards: null, receivingYards: null, sacks: null };
     })(),
     pendingRohCandidates: Array.isArray(meta?.pendingRohCandidates) ? meta.pendingRohCandidates : [],
+    mediaStories: (() => {
+      const leagueCtx = {
+        teams,
+        standings: standingsRows,
+        week: meta?.currentWeek ?? 1,
+        year: meta?.year,
+        season: meta?.year,
+        newsItems: Array.isArray(meta?.newsItems) ? meta.newsItems : [],
+        currentSeasonHonors: meta?.currentSeasonHonors ?? null,
+        leaguePulse: Array.isArray(meta?.leaguePulse) ? meta.leaguePulse.slice(-100) : [],
+        userTeamId: meta?.userTeamId,
+      };
+      return buildMediaNarratives(leagueCtx);
+    })(),
     // ── Team Identity — Retired Numbers & Championship Wall ──────────────────
     retiredNumbers: (() => {
       const t = cache.getTeam(meta?.userTeamId);


### PR DESCRIPTION
Adds a pure, deterministic media/news layer that converts existing league
state into weekly narrative cards. Display-only with no gameplay consequences.

- New module: src/core/news/mediaNarrativeEngine.js
  Pure engine with no Math.random, no mutations, no LLM calls.
  Exports: buildMediaNarratives, selectMediaStories, rankMediaStories,
  buildMediaHeadline, getMediaStoryTypeLabel, makeStableStoryId,
  dedupeMediaStories, and per-type extractors.

  Story types: OWNER_PRESSURE, BLOCKBUSTER_TRADE, MANDATE_SLIP,
  MANDATE_SURGE, PRESTIGE_HONOR, PLAYOFF_PUSH. Sources: team owner
  profiles, leaguePulse transaction items, newsItems, standings,
  currentSeasonHonors.

- wire: buildViewState now exposes leaguePulse (was stored in meta but
  not returned) and mediaStories (derived view-state, never persisted).

- UI: src/ui/components/MediaDesk.jsx — compact card section placed
  inside the existing HQ "Season Pulse & More" drawer. Renders top story
  with dek + secondary cards. Empty state: "No league media stories this
  week."

- Tests:
  - mediaNarrativeEngine.unit.test.js — 48 unit tests covering
    determinism, immutability, each extractor, deduplication, ranking,
    graceful empty/null handling, no Math.random
  - mediaNarrative.integration.test.js — 21 integration tests covering
    view-state safety, mutation guards, old-save compatibility
  - MediaDesk.test.jsx — 28 UI smoke tests covering render, empty state,
    all story types, missing references

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BPtdabLW9i2492soConpMP