### PR TITLE
feat(awards): Awards & Honors Expansion V2 — award history ledger, leaders & honor visibility

### DIFF
--- a/src/core/__tests__/awardEngine.test.js
+++ b/src/core/__tests__/awardEngine.test.js
@@ -92,6 +92,34 @@ describe('determineSeasonAwards', () => {
     expect(roty.playerId).toBe(20);
   });
 
+  it('returns split Offensive & Defensive Rookie of the Year (V2)', () => {
+    const players = [
+      { id: 30, year: season, age: 22 }, // rookie QB
+      { id: 31, year: season, age: 22 }, // rookie LB (defense)
+      { id: 32, year: season - 2, age: 25 }, // veteran, ineligible
+    ];
+    const stats = [
+      makeQBStats(30, 1, 3900, 30),
+      makeLBStats(31, 1, 130, 12),
+      makeQBStats(32, 2, 5200, 44),
+    ];
+    const { playerAwards } = determineSeasonAwards(players, teams, season, { stats });
+    const oroy = playerAwards.find(a => a.type === AWARD_TYPES.OFF_ROOKIE_OF_YEAR);
+    const droy = playerAwards.find(a => a.type === AWARD_TYPES.DEF_ROOKIE_OF_YEAR);
+    expect(oroy).toBeTruthy();
+    expect(oroy.playerId).toBe(30); // offensive rookie, not the veteran QB
+    expect(droy).toBeTruthy();
+    expect(droy.playerId).toBe(31); // defensive rookie via defensive production
+  });
+
+  it('omits split rookie awards when no rookies at that side of the ball', () => {
+    const players = [{ id: 40, year: season, age: 22 }]; // lone offensive rookie
+    const stats = [makeQBStats(40, 1, 3800, 29), makeLBStats(41, 2, 100, 9)];
+    const { playerAwards } = determineSeasonAwards(players, teams, season, { stats });
+    expect(playerAwards.find(a => a.type === AWARD_TYPES.OFF_ROOKIE_OF_YEAR)).toBeTruthy();
+    expect(playerAwards.find(a => a.type === AWARD_TYPES.DEF_ROOKIE_OF_YEAR)).toBeFalsy();
+  });
+
   it('emits LEAGUE_CHAMPION franchise award when championTeamId provided', () => {
     const stats = [makeQBStats(1, 1, 4800, 38)];
     const { franchiseAwards } = determineSeasonAwards([], teams, season, { stats, championTeamId: 1 });

--- a/src/core/awards/awardEngine.js
+++ b/src/core/awards/awardEngine.js
@@ -28,6 +28,8 @@ export const AWARD_TYPES = Object.freeze({
   COACH_OF_YEAR: 'COACH_OF_YEAR',
   COMEBACK_PLAYER: 'COMEBACK_PLAYER',
   ROOKIE_OF_YEAR: 'ROOKIE_OF_YEAR',
+  OFF_ROOKIE_OF_YEAR: 'OFF_ROOKIE_OF_YEAR',
+  DEF_ROOKIE_OF_YEAR: 'DEF_ROOKIE_OF_YEAR',
   LEAGUE_CHAMPION: 'LEAGUE_CHAMPION',
   ALL_PRO_QB: 'ALL_PRO_QB',
   ALL_PRO_RB: 'ALL_PRO_RB',
@@ -49,6 +51,8 @@ export const AWARD_LABELS = Object.freeze({
   [AWARD_TYPES.COACH_OF_YEAR]: 'Coach of the Year',
   [AWARD_TYPES.COMEBACK_PLAYER]: 'Comeback Player of the Year',
   [AWARD_TYPES.ROOKIE_OF_YEAR]: 'Rookie of the Year',
+  [AWARD_TYPES.OFF_ROOKIE_OF_YEAR]: 'Offensive Rookie of the Year',
+  [AWARD_TYPES.DEF_ROOKIE_OF_YEAR]: 'Defensive Rookie of the Year',
   [AWARD_TYPES.LEAGUE_CHAMPION]: 'League Champion',
   [AWARD_TYPES.ALL_PRO_QB]: 'First Team All-Pro QB',
   [AWARD_TYPES.ALL_PRO_RB]: 'First Team All-Pro RB',
@@ -336,6 +340,15 @@ export function determineSeasonAwards(players, teams, season, context) {
   const rookieRows = rows.filter(isRookie);
   const rotyWinner = topByScore(rookieRows, r => rotyScore(r, teamById));
 
+  // Offensive / Defensive Rookie of the Year (V2). Only considers true rookies
+  // (player.year === season). Offensive rookies use the offensive production
+  // formula (rotyScore); defensive rookies use defensive production (dpoyScore).
+  // Both are additive — ROOKIE_OF_YEAR above is retained for backward compat.
+  const offRookieRows = rookieRows.filter(r => OFF_SKILL_POS.has(String(r?.pos ?? '').toUpperCase()));
+  const defRookieRows = rookieRows.filter(r => DEF_POS.has(String(r?.pos ?? '').toUpperCase()));
+  const offRotyWinner = topByScore(offRookieRows, r => rotyScore(r, teamById));
+  const defRotyWinner = topByScore(defRookieRows, dpoyScore);
+
   // COMEBACK_PLAYER: age 28+, biggest positive OVR delta from previous season careerStats
   const comebackWinner = (() => {
     const candidates = offRows.filter(r => {
@@ -379,6 +392,8 @@ export function determineSeasonAwards(players, teams, season, context) {
   push(AWARD_TYPES.OFFENSIVE_POY, offpoyWinner);
   push(AWARD_TYPES.DEFENSIVE_POY, dpoyWinner);
   push(AWARD_TYPES.ROOKIE_OF_YEAR, rotyWinner);
+  push(AWARD_TYPES.OFF_ROOKIE_OF_YEAR, offRotyWinner);
+  push(AWARD_TYPES.DEF_ROOKIE_OF_YEAR, defRotyWinner);
   push(AWARD_TYPES.COMEBACK_PLAYER, comebackWinner);
 
   // ── Franchise awards ──────────────────────────────────────────────────────

--- a/src/core/awards/awardHistory.js
+++ b/src/core/awards/awardHistory.js
@@ -1,0 +1,416 @@
+/**
+ * awardHistory.js — Awards & Honors Expansion V2: compact per-season award ledger.
+ *
+ * Pure, deterministic module. No Math.random, no I/O, no UI/worker imports.
+ * It does NOT compute awards — it *composes* the outputs of the existing award
+ * engines (awardEngine.determineSeasonAwards + prestigeEngine selections) into a
+ * compact, serializable, replay-safe season ledger persisted at meta.awardHistory.
+ *
+ * Persisted shape (meta.awardHistory is an array of these, one per season):
+ *   {
+ *     year,                      // numeric season year (stable key)
+ *     seasonId,                  // optional engine season id (e.g. "s7")
+ *     awards: {
+ *       MVP:  { playerId, playerName, teamId, teamAbbr, pos, score } | null,
+ *       OPOY: {…} | null,
+ *       DPOY: {…} | null,
+ *       ORoy: {…} | null,
+ *       DRoy: {…} | null,
+ *       COY:  { teamId, teamAbbr, coachName } | null
+ *     },
+ *     allPro: {
+ *       firstTeam:  [{ playerId, playerName, teamAbbr, pos }],  // positional (11 slots)
+ *       secondTeam: [{ playerId, playerName, teamAbbr, pos }]
+ *     },
+ *     proBowl: [{ playerId, playerName, teamAbbr, pos }],
+ *     leaders: { [statKey]: { playerId, playerName, teamAbbr, pos, value } | null }
+ *   }
+ *
+ * Design notes:
+ *  - Compact: only ids/names/abbrs + a single numeric score/value are stored, so a
+ *    50-season dynasty ledger stays small and serializable.
+ *  - Bounded: appendAwardHistory replaces any existing entry for the same year, so
+ *    re-running a season never duplicates and growth is at most one entry/season.
+ *  - Retire-safe: entries snapshot player/team names at award time, so career honor
+ *    aggregation never needs a live player reference.
+ *
+ * Exported API:
+ *   LEAGUE_LEADER_CATEGORIES
+ *   computeLeagueLeaders(stats, teamResolver) → { [statKey]: leaderEntry|null }
+ *   buildAwardHistoryEntry(params) → entry
+ *   appendAwardHistory(awardHistory, entry) → entry[]
+ *   hydrateAwardHistory(meta) → entry[]
+ *   getCareerHonorCounts(awardHistory, playerId) → counts
+ *   aggregateCareerHonors(awardHistory) → Map<playerId, counts>
+ *   summarizeSeasonAwards(entry) → compact UI rows
+ */
+
+import { AWARD_TYPES } from './awardEngine.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function _num(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Read a stat value from a flat totals object using a list of alias field names. */
+function _stat(totals, keys) {
+  if (!totals || typeof totals !== 'object') return 0;
+  for (const key of keys) {
+    const v = totals[key];
+    if (v != null && Number.isFinite(Number(v))) return Number(v);
+  }
+  return 0;
+}
+
+const OFF_SKILL_POS = new Set(['QB', 'RB', 'FB', 'WR', 'TE']);
+const DEF_POS = new Set(['DL', 'DE', 'DT', 'EDGE', 'NT', 'LB', 'MLB', 'OLB', 'CB', 'S', 'SS', 'FS', 'DB']);
+
+function _isDefPos(pos) {
+  return DEF_POS.has(String(pos ?? '').toUpperCase());
+}
+
+// ── League leaders ────────────────────────────────────────────────────────────
+
+/**
+ * League-leader categories. Each derives a per-player value from a stat row's
+ * `totals`. `posFilter` (optional) restricts which positions are eligible so that,
+ * e.g. QB interceptions-thrown never count toward the defensive INT leader.
+ */
+export const LEAGUE_LEADER_CATEGORIES = Object.freeze([
+  { key: 'passYd', label: 'Passing Yards',    value: (t) => _stat(t, ['passYd', 'passingYards']) },
+  { key: 'passTD', label: 'Passing TDs',      value: (t) => _stat(t, ['passTD', 'passingTd']) },
+  { key: 'rushYd', label: 'Rushing Yards',    value: (t) => _stat(t, ['rushYd', 'rushingYards']) },
+  { key: 'rushTD', label: 'Rushing TDs',      value: (t) => _stat(t, ['rushTD', 'rushingTd']) },
+  { key: 'recYd',  label: 'Receiving Yards',  value: (t) => _stat(t, ['recYd', 'receivingYards']) },
+  { key: 'recTD',  label: 'Receiving TDs',    value: (t) => _stat(t, ['recTD', 'receivingTd']) },
+  { key: 'sacks',  label: 'Sacks',            value: (t) => _stat(t, ['sacks']) },
+  {
+    key: 'defInt',
+    label: 'Interceptions',
+    posFilter: 'def',
+    value: (t) => _stat(t, ['defInterceptions', 'interceptions']),
+  },
+  {
+    key: 'totalTD',
+    label: 'Total Touchdowns',
+    value: (t) =>
+      _stat(t, ['passTD', 'passingTd']) +
+      _stat(t, ['rushTD', 'rushingTd']) +
+      _stat(t, ['recTD', 'receivingTd']),
+  },
+]);
+
+/**
+ * Compute deterministic league leaders for every category.
+ *
+ * Determinism: the highest value wins; ties are broken by ascending playerId
+ * string. A category with no positive value resolves to null.
+ *
+ * @param {Array} stats          — populated season stat rows: { playerId, name, pos, teamId, totals }
+ * @param {Function} [teamResolver] — (teamId) => team | null, for teamAbbr snapshot
+ * @returns {{ [statKey]: { playerId, playerName, teamId, teamAbbr, pos, value }|null }}
+ */
+export function computeLeagueLeaders(stats, teamResolver) {
+  const rows = Array.isArray(stats) ? stats : [];
+  const resolve = typeof teamResolver === 'function' ? teamResolver : () => null;
+  const leaders = {};
+
+  for (const cat of LEAGUE_LEADER_CATEGORIES) {
+    let best = null;
+    for (const row of rows) {
+      if (!row || row.playerId == null) continue;
+      if (cat.posFilter === 'def' && !_isDefPos(row.pos)) continue;
+      const value = cat.value(row.totals ?? {});
+      if (!(value > 0)) continue;
+      if (
+        best == null ||
+        value > best.value ||
+        (value === best.value && String(row.playerId).localeCompare(String(best.playerId)) < 0)
+      ) {
+        best = { row, value };
+      }
+    }
+    if (best == null) {
+      leaders[cat.key] = null;
+    } else {
+      const team = resolve(best.row.teamId);
+      leaders[cat.key] = {
+        playerId: best.row.playerId,
+        playerName: best.row.name ?? '',
+        teamId: best.row.teamId ?? null,
+        teamAbbr: team?.abbr ?? null,
+        pos: best.row.pos ?? '',
+        value: best.value,
+      };
+    }
+  }
+
+  return leaders;
+}
+
+// ── Entry construction ──────────────────────────────────────────────────────
+
+/** Compact a playerAward record into a stable, retire-safe winner snapshot. */
+function _compactWinner(award, teamResolver) {
+  if (!award || award.playerId == null) return null;
+  const team = typeof teamResolver === 'function' ? teamResolver(award.teamId) : null;
+  return {
+    playerId: award.playerId,
+    playerName: award.name ?? '',
+    teamId: award.teamId ?? null,
+    teamAbbr: team?.abbr ?? null,
+    pos: award.pos ?? '',
+    score: Number.isFinite(Number(award.score)) ? Number(award.score) : null,
+  };
+}
+
+/** Compact an All-Pro / Pro Bowl honor record into a stable snapshot. */
+function _compactHonor(rec, teamResolver) {
+  if (!rec || rec.playerId == null) return null;
+  const team = typeof teamResolver === 'function' ? teamResolver(rec.teamId) : null;
+  return {
+    playerId: rec.playerId,
+    playerName: rec.name ?? rec.playerName ?? '',
+    teamAbbr: team?.abbr ?? rec.teamAbbr ?? null,
+    pos: rec.pos ?? '',
+  };
+}
+
+/**
+ * Build a single compact season award-history entry by composing engine outputs.
+ *
+ * @param {Object} params
+ * @param {number} params.year
+ * @param {string} [params.seasonId]
+ * @param {Object} params.awardResults          — output of determineSeasonAwards
+ * @param {Array}  [params.prestigeAssignments] — prestigeEngine All-Pro/Pro Bowl honors
+ * @param {Array}  [params.stats]               — populated stat rows (for league leaders)
+ * @param {Function} [params.teamResolver]
+ * @returns {Object} compact award-history entry
+ */
+export function buildAwardHistoryEntry(params = {}) {
+  const {
+    year,
+    seasonId = null,
+    awardResults = {},
+    prestigeAssignments = [],
+    stats = [],
+    teamResolver,
+  } = params;
+
+  const playerAwards = Array.isArray(awardResults.playerAwards) ? awardResults.playerAwards : [];
+  const franchiseAwards = Array.isArray(awardResults.franchiseAwards) ? awardResults.franchiseAwards : [];
+  const allProTeam = Array.isArray(awardResults.allProTeam) ? awardResults.allProTeam : [];
+  const prestige = Array.isArray(prestigeAssignments) ? prestigeAssignments : [];
+
+  const findAward = (type) => playerAwards.find((a) => a?.type === type) ?? null;
+
+  // Prefer the V2 split rookie awards; fall back to the legacy combined ROY.
+  const offRookie = findAward(AWARD_TYPES.OFF_ROOKIE_OF_YEAR) ?? findAward(AWARD_TYPES.ROOKIE_OF_YEAR);
+  const defRookie = findAward(AWARD_TYPES.DEF_ROOKIE_OF_YEAR);
+
+  const awards = {
+    MVP: _compactWinner(findAward(AWARD_TYPES.MVP), teamResolver),
+    OPOY: _compactWinner(findAward(AWARD_TYPES.OFFENSIVE_POY), teamResolver),
+    DPOY: _compactWinner(findAward(AWARD_TYPES.DEFENSIVE_POY), teamResolver),
+    ORoy: _compactWinner(offRookie, teamResolver),
+    DRoy: _compactWinner(defRookie, teamResolver),
+    COY: (() => {
+      const coy = franchiseAwards.find((a) => a?.type === AWARD_TYPES.COACH_OF_YEAR);
+      if (!coy) return null;
+      const team = typeof teamResolver === 'function' ? teamResolver(coy.teamId) : null;
+      return { teamId: coy.teamId ?? null, teamAbbr: team?.abbr ?? null, coachName: coy.coachName ?? null };
+    })(),
+  };
+
+  // First-team All-Pro: use the positional All-Pro team (covers QB/RB/WR/TE/OL/
+  // DL/LB/CB/S/K/P). Second-team + Pro Bowl reuse the prestige selections.
+  const firstTeam = allProTeam.map((r) => _compactHonor(r, teamResolver)).filter(Boolean);
+  const secondTeam = prestige
+    .filter((h) => h?.type === 'SECOND_TEAM_ALL_PRO')
+    .map((r) => _compactHonor(r, teamResolver))
+    .filter(Boolean);
+  const proBowl = prestige
+    .filter((h) => h?.type === 'PRO_BOWL')
+    .map((r) => _compactHonor(r, teamResolver))
+    .filter(Boolean);
+
+  return {
+    year: _num(year),
+    seasonId: seasonId != null ? String(seasonId) : null,
+    awards,
+    allPro: { firstTeam, secondTeam },
+    proBowl,
+    leaders: computeLeagueLeaders(stats, teamResolver),
+  };
+}
+
+// ── Persistence helpers ────────────────────────────────────────────────────────
+
+/**
+ * Append (or replace) a season entry in the award-history ledger.
+ *
+ * Idempotent + bounded: any existing entry with the same `year` is replaced, so
+ * re-running the same season never duplicates and the ledger grows by at most one
+ * entry per season. Returns a new array sorted chronologically; never mutates input.
+ *
+ * @param {Array} awardHistory
+ * @param {Object} entry
+ * @returns {Array}
+ */
+export function appendAwardHistory(awardHistory, entry) {
+  const arr = Array.isArray(awardHistory) ? awardHistory : [];
+  if (!entry || entry.year == null) return [...arr];
+  const year = _num(entry.year);
+  const filtered = arr.filter((e) => _num(e?.year) !== year);
+  return [...filtered, entry].sort((a, b) => _num(a?.year) - _num(b?.year));
+}
+
+/**
+ * Backward-compatible hydration: returns a safe array for old saves that predate
+ * meta.awardHistory. Filters out malformed entries (missing year) defensively.
+ *
+ * @param {Object} meta
+ * @returns {Array}
+ */
+export function hydrateAwardHistory(meta) {
+  const raw = meta?.awardHistory;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((e) => e && e.year != null);
+}
+
+// ── Career honor aggregation ────────────────────────────────────────────────
+
+function _emptyCounts() {
+  return {
+    mvp: 0,
+    opoy: 0,
+    dpoy: 0,
+    oroy: 0,
+    droy: 0,
+    firstTeamAllPro: 0,
+    secondTeamAllPro: 0,
+    allPro: 0,
+    proBowl: 0,
+  };
+}
+
+function _accumulate(counts, entry, pid) {
+  const a = entry?.awards ?? {};
+  if (a.MVP && String(a.MVP.playerId) === pid) counts.mvp += 1;
+  if (a.OPOY && String(a.OPOY.playerId) === pid) counts.opoy += 1;
+  if (a.DPOY && String(a.DPOY.playerId) === pid) counts.dpoy += 1;
+  if (a.ORoy && String(a.ORoy.playerId) === pid) counts.oroy += 1;
+  if (a.DRoy && String(a.DRoy.playerId) === pid) counts.droy += 1;
+
+  const first = entry?.allPro?.firstTeam ?? [];
+  const second = entry?.allPro?.secondTeam ?? [];
+  const pro = entry?.proBowl ?? [];
+  for (const h of first) if (h && String(h.playerId) === pid) counts.firstTeamAllPro += 1;
+  for (const h of second) if (h && String(h.playerId) === pid) counts.secondTeamAllPro += 1;
+  for (const h of pro) if (h && String(h.playerId) === pid) counts.proBowl += 1;
+}
+
+/**
+ * Aggregate a single player's career honor counts from the award-history ledger.
+ * Retire-safe: reads only the persisted snapshots, never a live player reference.
+ *
+ * @param {Array} awardHistory
+ * @param {string|number} playerId
+ * @returns {{ mvp, opoy, dpoy, oroy, droy, firstTeamAllPro, secondTeamAllPro, allPro, proBowl }}
+ */
+export function getCareerHonorCounts(awardHistory, playerId) {
+  const counts = _emptyCounts();
+  if (playerId == null) return counts;
+  const pid = String(playerId);
+  const arr = Array.isArray(awardHistory) ? awardHistory : [];
+  for (const entry of arr) _accumulate(counts, entry, pid);
+  counts.allPro = counts.firstTeamAllPro + counts.secondTeamAllPro;
+  return counts;
+}
+
+/**
+ * Aggregate career honor counts for every player that appears anywhere in the
+ * ledger. Single pass; returns a Map keyed by stringified playerId.
+ *
+ * @param {Array} awardHistory
+ * @returns {Map<string, object>}
+ */
+export function aggregateCareerHonors(awardHistory) {
+  const arr = Array.isArray(awardHistory) ? awardHistory : [];
+  const map = new Map();
+  const ensure = (pid) => {
+    const key = String(pid);
+    if (!map.has(key)) map.set(key, _emptyCounts());
+    return map.get(key);
+  };
+
+  for (const entry of arr) {
+    const a = entry?.awards ?? {};
+    if (a.MVP?.playerId != null) ensure(a.MVP.playerId).mvp += 1;
+    if (a.OPOY?.playerId != null) ensure(a.OPOY.playerId).opoy += 1;
+    if (a.DPOY?.playerId != null) ensure(a.DPOY.playerId).dpoy += 1;
+    if (a.ORoy?.playerId != null) ensure(a.ORoy.playerId).oroy += 1;
+    if (a.DRoy?.playerId != null) ensure(a.DRoy.playerId).droy += 1;
+    for (const h of entry?.allPro?.firstTeam ?? []) if (h?.playerId != null) ensure(h.playerId).firstTeamAllPro += 1;
+    for (const h of entry?.allPro?.secondTeam ?? []) if (h?.playerId != null) ensure(h.playerId).secondTeamAllPro += 1;
+    for (const h of entry?.proBowl ?? []) if (h?.playerId != null) ensure(h.playerId).proBowl += 1;
+  }
+
+  for (const counts of map.values()) {
+    counts.allPro = counts.firstTeamAllPro + counts.secondTeamAllPro;
+  }
+  return map;
+}
+
+// ── UI summary ──────────────────────────────────────────────────────────────
+
+const _MAJOR_AWARD_ROWS = Object.freeze([
+  { key: 'MVP', label: 'MVP' },
+  { key: 'OPOY', label: 'Offensive POY' },
+  { key: 'DPOY', label: 'Defensive POY' },
+  { key: 'ORoy', label: 'Off. Rookie of the Year' },
+  { key: 'DRoy', label: 'Def. Rookie of the Year' },
+]);
+
+/**
+ * Build compact, render-ready rows for a single season's awards. Degrades safely
+ * when the entry or any field is missing.
+ *
+ * @param {Object} entry — an award-history entry
+ * @returns {{ year, seasonId, majorAwards: Array, firstTeamCount, secondTeamCount, proBowlCount, leaders: Array }}
+ */
+export function summarizeSeasonAwards(entry) {
+  const safe = entry && typeof entry === 'object' ? entry : {};
+  const awards = safe.awards ?? {};
+
+  const majorAwards = _MAJOR_AWARD_ROWS.map(({ key, label }) => {
+    const w = awards[key];
+    return {
+      key,
+      label,
+      playerName: w?.playerName ?? null,
+      pos: w?.pos ?? null,
+      teamAbbr: w?.teamAbbr ?? null,
+    };
+  }).filter((r) => r.playerName);
+
+  const leaders = LEAGUE_LEADER_CATEGORIES.map((cat) => {
+    const l = safe.leaders?.[cat.key];
+    return l
+      ? { key: cat.key, label: cat.label, playerName: l.playerName, teamAbbr: l.teamAbbr, value: l.value }
+      : null;
+  }).filter(Boolean);
+
+  return {
+    year: safe.year ?? null,
+    seasonId: safe.seasonId ?? null,
+    majorAwards,
+    firstTeamCount: Array.isArray(safe.allPro?.firstTeam) ? safe.allPro.firstTeam.length : 0,
+    secondTeamCount: Array.isArray(safe.allPro?.secondTeam) ? safe.allPro.secondTeam.length : 0,
+    proBowlCount: Array.isArray(safe.proBowl) ? safe.proBowl.length : 0,
+    leaders,
+  };
+}

--- a/src/core/awards/awardHistory.unit.test.js
+++ b/src/core/awards/awardHistory.unit.test.js
@@ -1,0 +1,314 @@
+/**
+ * awardHistory.unit.test.js — Awards & Honors Expansion V2 ledger module.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  LEAGUE_LEADER_CATEGORIES,
+  computeLeagueLeaders,
+  buildAwardHistoryEntry,
+  appendAwardHistory,
+  hydrateAwardHistory,
+  getCareerHonorCounts,
+  aggregateCareerHonors,
+  summarizeSeasonAwards,
+} from './awardHistory.js';
+import { AWARD_TYPES } from './awardEngine.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const TEAMS = { 1: { id: 1, abbr: 'AAA' }, 2: { id: 2, abbr: 'BBB' } };
+const teamResolver = (id) => TEAMS[id] ?? null;
+
+function statRow(playerId, pos, totals, name = `P${playerId}`, teamId = 1) {
+  return { playerId, name, pos, teamId, totals };
+}
+
+function award(type, playerId, pos, opts = {}) {
+  return { type, playerId, name: opts.name ?? `P${playerId}`, pos, teamId: opts.teamId ?? 1, score: opts.score ?? 100 };
+}
+
+function honor(type, playerId, pos, opts = {}) {
+  return { type, playerId, playerName: opts.name ?? `P${playerId}`, pos, teamId: opts.teamId ?? 1, prestigePos: opts.prestigePos ?? pos };
+}
+
+// ── computeLeagueLeaders ────────────────────────────────────────────────────
+
+describe('computeLeagueLeaders', () => {
+  it('exposes the documented leader categories', () => {
+    const keys = LEAGUE_LEADER_CATEGORIES.map((c) => c.key);
+    expect(keys).toEqual([
+      'passYd', 'passTD', 'rushYd', 'rushTD', 'recYd', 'recTD', 'sacks', 'defInt', 'totalTD',
+    ]);
+  });
+
+  it('picks the highest value per category with team snapshot', () => {
+    const stats = [
+      statRow('a', 'QB', { passYd: 5000, passTD: 40 }, 'Ace', 1),
+      statRow('b', 'QB', { passYd: 4000, passTD: 45 }, 'Bo', 2),
+    ];
+    const leaders = computeLeagueLeaders(stats, teamResolver);
+    expect(leaders.passYd.playerId).toBe('a');
+    expect(leaders.passYd.value).toBe(5000);
+    expect(leaders.passYd.teamAbbr).toBe('AAA');
+    expect(leaders.passTD.playerId).toBe('b');
+    expect(leaders.passTD.teamAbbr).toBe('BBB');
+  });
+
+  it('breaks ties deterministically by ascending playerId', () => {
+    const stats = [
+      statRow('zeta', 'WR', { recYd: 1200 }),
+      statRow('alpha', 'WR', { recYd: 1200 }),
+    ];
+    const leaders = computeLeagueLeaders(stats, teamResolver);
+    expect(leaders.recYd.playerId).toBe('alpha');
+  });
+
+  it('counts defensive interceptions only for defensive players', () => {
+    const stats = [
+      statRow('qb', 'QB', { interceptions: 18 }),   // INTs thrown — must NOT count
+      statRow('cb', 'CB', { interceptions: 7 }),    // defensive INTs
+    ];
+    const leaders = computeLeagueLeaders(stats, teamResolver);
+    expect(leaders.defInt.playerId).toBe('cb');
+    expect(leaders.defInt.value).toBe(7);
+  });
+
+  it('totalTD sums passing/rushing/receiving touchdowns', () => {
+    const stats = [statRow('rb', 'RB', { rushTD: 12, recTD: 3 })];
+    const leaders = computeLeagueLeaders(stats, teamResolver);
+    expect(leaders.totalTD.value).toBe(15);
+  });
+
+  it('returns null for a category with no positive data and never crashes', () => {
+    expect(() => computeLeagueLeaders(null, teamResolver)).not.toThrow();
+    const leaders = computeLeagueLeaders([statRow('x', 'QB', {})], teamResolver);
+    expect(leaders.passYd).toBeNull();
+    expect(leaders.sacks).toBeNull();
+  });
+
+  it('is deterministic across repeated calls', () => {
+    const stats = [statRow('a', 'QB', { passYd: 4000 }), statRow('b', 'QB', { passYd: 4200 })];
+    expect(computeLeagueLeaders(stats, teamResolver)).toEqual(computeLeagueLeaders(stats, teamResolver));
+  });
+});
+
+// ── buildAwardHistoryEntry ──────────────────────────────────────────────────
+
+describe('buildAwardHistoryEntry', () => {
+  const awardResults = {
+    playerAwards: [
+      award(AWARD_TYPES.MVP, 'qb1', 'QB', { name: 'Star QB', score: 320 }),
+      award(AWARD_TYPES.OFFENSIVE_POY, 'rb1', 'RB', { name: 'Star RB' }),
+      award(AWARD_TYPES.DEFENSIVE_POY, 'dl1', 'DL', { name: 'Star DL' }),
+      award(AWARD_TYPES.OFF_ROOKIE_OF_YEAR, 'wr9', 'WR', { name: 'Rook WR' }),
+      award(AWARD_TYPES.DEF_ROOKIE_OF_YEAR, 'lb9', 'LB', { name: 'Rook LB' }),
+    ],
+    franchiseAwards: [{ type: AWARD_TYPES.COACH_OF_YEAR, teamId: 2, coachName: 'Coach K' }],
+    allProTeam: [
+      { type: AWARD_TYPES.ALL_PRO_QB, playerId: 'qb1', name: 'Star QB', pos: 'QB', teamId: 1 },
+      { type: AWARD_TYPES.ALL_PRO_LB, playerId: 'lb1', name: 'Star LB', pos: 'LB', teamId: 2 },
+    ],
+  };
+  const prestige = [
+    honor('SECOND_TEAM_ALL_PRO', 'qb2', 'QB'),
+    honor('PRO_BOWL', 'qb1', 'QB'),
+    honor('PRO_BOWL', 'qb2', 'QB'),
+  ];
+  const stats = [statRow('qb1', 'QB', { passYd: 5000, passTD: 40 }, 'Star QB')];
+
+  it('builds the documented compact shape', () => {
+    const entry = buildAwardHistoryEntry({ year: 2030, seasonId: 's6', awardResults, prestigeAssignments: prestige, stats, teamResolver });
+    expect(entry.year).toBe(2030);
+    expect(entry.seasonId).toBe('s6');
+    expect(entry.awards.MVP).toEqual({ playerId: 'qb1', playerName: 'Star QB', teamId: 1, teamAbbr: 'AAA', pos: 'QB', score: 320 });
+    expect(entry.awards.OPOY.playerId).toBe('rb1');
+    expect(entry.awards.DPOY.playerId).toBe('dl1');
+    expect(entry.awards.ORoy.playerId).toBe('wr9');
+    expect(entry.awards.DRoy.playerId).toBe('lb9');
+    expect(entry.awards.COY).toEqual({ teamId: 2, teamAbbr: 'BBB', coachName: 'Coach K' });
+  });
+
+  it('sources firstTeam from the positional All-Pro team (expanded positions)', () => {
+    const entry = buildAwardHistoryEntry({ year: 2030, awardResults, prestigeAssignments: prestige, stats, teamResolver });
+    const posSet = entry.allPro.firstTeam.map((h) => h.pos);
+    expect(posSet).toContain('QB');
+    expect(posSet).toContain('LB'); // expanded positional honor surfaced
+    expect(entry.allPro.secondTeam.map((h) => h.playerId)).toEqual(['qb2']);
+    expect(entry.proBowl.map((h) => h.playerId).sort()).toEqual(['qb1', 'qb2']);
+  });
+
+  it('falls back to combined ROOKIE_OF_YEAR for ORoy when split award is absent', () => {
+    const legacy = {
+      playerAwards: [award(AWARD_TYPES.ROOKIE_OF_YEAR, 'r1', 'RB', { name: 'Legacy Rook' })],
+      franchiseAwards: [],
+      allProTeam: [],
+    };
+    const entry = buildAwardHistoryEntry({ year: 2031, awardResults: legacy, prestigeAssignments: [], stats: [], teamResolver });
+    expect(entry.awards.ORoy.playerId).toBe('r1');
+    expect(entry.awards.DRoy).toBeNull();
+  });
+
+  it('degrades safely with empty inputs', () => {
+    const entry = buildAwardHistoryEntry({ year: 2032 });
+    expect(entry.awards.MVP).toBeNull();
+    expect(entry.allPro.firstTeam).toEqual([]);
+    expect(entry.proBowl).toEqual([]);
+    expect(Object.values(entry.leaders).every((v) => v === null)).toBe(true);
+  });
+
+  it('is deterministic', () => {
+    const a = buildAwardHistoryEntry({ year: 2030, awardResults, prestigeAssignments: prestige, stats, teamResolver });
+    const b = buildAwardHistoryEntry({ year: 2030, awardResults, prestigeAssignments: prestige, stats, teamResolver });
+    expect(a).toEqual(b);
+  });
+});
+
+// ── appendAwardHistory ──────────────────────────────────────────────────────
+
+describe('appendAwardHistory', () => {
+  const e = (year) => ({ year, awards: {}, allPro: { firstTeam: [], secondTeam: [] }, proBowl: [], leaders: {} });
+
+  it('appends one entry and keeps chronological order', () => {
+    let h = [];
+    h = appendAwardHistory(h, e(2025));
+    h = appendAwardHistory(h, e(2026));
+    expect(h.map((x) => x.year)).toEqual([2025, 2026]);
+  });
+
+  it('replaces (never duplicates) an entry for the same year', () => {
+    let h = appendAwardHistory([], e(2025));
+    h = appendAwardHistory(h, { ...e(2025), proBowl: [{ playerId: 'x' }] });
+    expect(h).toHaveLength(1);
+    expect(h[0].proBowl).toHaveLength(1);
+  });
+
+  it('does not mutate the input array', () => {
+    const before = [e(2025)];
+    const after = appendAwardHistory(before, e(2026));
+    expect(before).toHaveLength(1);
+    expect(after).toHaveLength(2);
+  });
+
+  it('ignores entries without a year', () => {
+    const h = appendAwardHistory([e(2025)], { awards: {} });
+    expect(h).toHaveLength(1);
+  });
+
+  it('grows by at most one per season over a long run (bounded)', () => {
+    let h = [];
+    for (let y = 2025; y < 2075; y++) h = appendAwardHistory(h, e(y));
+    for (let y = 2025; y < 2075; y++) h = appendAwardHistory(h, e(y)); // replay all
+    expect(h).toHaveLength(50);
+  });
+});
+
+// ── hydrateAwardHistory (backward compatibility) ────────────────────────────
+
+describe('hydrateAwardHistory', () => {
+  it('returns [] for an old save with no awardHistory field', () => {
+    expect(hydrateAwardHistory({ year: 2025 })).toEqual([]);
+    expect(hydrateAwardHistory(null)).toEqual([]);
+    expect(hydrateAwardHistory(undefined)).toEqual([]);
+  });
+
+  it('passes through a valid ledger and filters malformed entries', () => {
+    const meta = { awardHistory: [{ year: 2025, awards: {} }, null, {}, { awards: {} }] };
+    const out = hydrateAwardHistory(meta);
+    expect(out).toHaveLength(1);
+    expect(out[0].year).toBe(2025);
+  });
+});
+
+// ── Career honor aggregation ────────────────────────────────────────────────
+
+describe('career honor aggregation', () => {
+  function mkEntry(year, { mvp, opoy, dpoy, oroy, droy, first = [], second = [], pro = [] } = {}) {
+    return {
+      year,
+      awards: {
+        MVP: mvp ? { playerId: mvp, playerName: mvp } : null,
+        OPOY: opoy ? { playerId: opoy } : null,
+        DPOY: dpoy ? { playerId: dpoy } : null,
+        ORoy: oroy ? { playerId: oroy } : null,
+        DRoy: droy ? { playerId: droy } : null,
+      },
+      allPro: {
+        firstTeam: first.map((id) => ({ playerId: id })),
+        secondTeam: second.map((id) => ({ playerId: id })),
+      },
+      proBowl: pro.map((id) => ({ playerId: id })),
+    };
+  }
+
+  const history = [
+    mkEntry(2025, { mvp: 'star', first: ['star'], pro: ['star', 'role'] }),
+    mkEntry(2026, { mvp: 'star', dpoy: 'dman', second: ['star'], pro: ['star'] }),
+    mkEntry(2027, { opoy: 'star', oroy: 'rook', droy: 'drook', first: ['star'], pro: ['rook'] }),
+  ];
+
+  it('aggregates a single player correctly (retire-safe)', () => {
+    const counts = getCareerHonorCounts(history, 'star');
+    expect(counts.mvp).toBe(2);
+    expect(counts.opoy).toBe(1);
+    expect(counts.firstTeamAllPro).toBe(2);
+    expect(counts.secondTeamAllPro).toBe(1);
+    expect(counts.allPro).toBe(3);
+    expect(counts.proBowl).toBe(2);
+  });
+
+  it('aggregateCareerHonors matches per-player helper for every player', () => {
+    const agg = aggregateCareerHonors(history);
+    for (const [pid, counts] of agg) {
+      expect(getCareerHonorCounts(history, pid)).toEqual(counts);
+    }
+    expect(agg.get('rook').oroy).toBe(1);
+    expect(agg.get('drook').droy).toBe(1);
+  });
+
+  it('handles missing/empty history without crashing', () => {
+    expect(getCareerHonorCounts(null, 'x')).toEqual(getCareerHonorCounts([], 'x'));
+    expect(getCareerHonorCounts(history, null).mvp).toBe(0);
+    expect(aggregateCareerHonors(undefined).size).toBe(0);
+  });
+
+  it('tolerates retired/missing player refs inside entries', () => {
+    const corrupt = [
+      { year: 2025, awards: { MVP: null }, allPro: { firstTeam: [null, { playerId: 'a' }] }, proBowl: [undefined] },
+      { year: 2026 }, // no awards/allPro/proBowl
+    ];
+    expect(() => aggregateCareerHonors(corrupt)).not.toThrow();
+    expect(() => getCareerHonorCounts(corrupt, 'a')).not.toThrow();
+    expect(getCareerHonorCounts(corrupt, 'a').firstTeamAllPro).toBe(1);
+  });
+});
+
+// ── summarizeSeasonAwards (UI helper) ───────────────────────────────────────
+
+describe('summarizeSeasonAwards', () => {
+  it('produces compact major-award + leader rows', () => {
+    const entry = buildAwardHistoryEntry({
+      year: 2040,
+      awardResults: {
+        playerAwards: [award(AWARD_TYPES.MVP, 'q', 'QB', { name: 'Q' })],
+        franchiseAwards: [],
+        allProTeam: [{ type: 'ALL_PRO_QB', playerId: 'q', name: 'Q', pos: 'QB', teamId: 1 }],
+      },
+      prestigeAssignments: [honor('PRO_BOWL', 'q', 'QB')],
+      stats: [statRow('q', 'QB', { passYd: 4800, passTD: 38 }, 'Q')],
+      teamResolver,
+    });
+    const summary = summarizeSeasonAwards(entry);
+    expect(summary.year).toBe(2040);
+    expect(summary.majorAwards.find((r) => r.key === 'MVP').playerName).toBe('Q');
+    expect(summary.firstTeamCount).toBe(1);
+    expect(summary.proBowlCount).toBe(1);
+    expect(summary.leaders.find((l) => l.key === 'passYd').value).toBe(4800);
+  });
+
+  it('returns a safe empty summary for missing entries', () => {
+    const s = summarizeSeasonAwards(undefined);
+    expect(s.majorAwards).toEqual([]);
+    expect(s.leaders).toEqual([]);
+    expect(s.firstTeamCount).toBe(0);
+  });
+});

--- a/src/core/league-memory.js
+++ b/src/core/league-memory.js
@@ -34,6 +34,7 @@ export function createLeagueMemoryDefaults() {
   return {
     leagueHistory: [],
     seasonStorylines: [],
+    awardHistory: [],
     hallOfFame: { schemaVersion: 1, classes: [], index: {} },
     franchiseHistoryByTeam: {},
     recordBook: {
@@ -62,6 +63,7 @@ export function ensureLeagueMemoryMeta(meta = {}) {
     ...meta,
     leagueHistory: Array.isArray(meta.leagueHistory) ? meta.leagueHistory : defaults.leagueHistory,
     seasonStorylines: Array.isArray(meta.seasonStorylines) ? meta.seasonStorylines : defaults.seasonStorylines,
+    awardHistory: Array.isArray(meta.awardHistory) ? meta.awardHistory : defaults.awardHistory,
     hallOfFame: {
       schemaVersion: meta?.hallOfFame?.schemaVersion ?? defaults.hallOfFame.schemaVersion,
       classes: Array.isArray(meta?.hallOfFame?.classes) ? meta.hallOfFame.classes : defaults.hallOfFame.classes,

--- a/src/core/soak/longDynastyStability.test.js
+++ b/src/core/soak/longDynastyStability.test.js
@@ -42,6 +42,11 @@ import {
   buildLegendTimeline,
   buildLegendProfileMetrics,
 } from '../history/legendsBrowserEngine.js';
+import {
+  getCareerHonorCounts,
+  aggregateCareerHonors,
+  summarizeSeasonAwards,
+} from '../awards/awardHistory.js';
 
 // ── Shared invariant assertions ───────────────────────────────────────────────
 
@@ -58,6 +63,11 @@ function assertCoreInvariants(summary, state) {
   expect(summary.duplicateLedgerYears).toBe(0);
   expect(summary.duplicateRetiredNumberKeys).toBe(0);
   expect(summary.duplicateMediaStoryIds).toBe(0);
+  expect(summary.duplicateAwardHistoryYears).toBe(0);
+
+  // award history stays serializable + honor counts finite
+  expect(() => assertSerializable(state.meta.awardHistory, 'awardHistory')).not.toThrow();
+  expect(Number.isFinite(summary.maxCareerHonorCount)).toBe(true);
 
   // every team retains valid owner + persona profiles
   for (const team of state.teams) {
@@ -245,6 +255,86 @@ describe('Long-Dynasty Soak V2 — C. 50-season dynasty integrity', () => {
   it('full 50-season soak passes the core invariant battery', () => {
     const { state, summaries } = runSoak({ seasons: 50 });
     assertCoreInvariants(summaries[summaries.length - 1], state);
+  });
+});
+
+// ── C2. Award history (Awards & Honors Expansion V2) ────────────────────────────
+
+describe('Long-Dynasty Soak V2 — C2. award history bounded & duplicate-free', () => {
+  it('appends exactly one award-history entry per season, no duplicate years', () => {
+    const { state, summaries } = runSoak({ seasons: 50 });
+
+    // grows at most one per season
+    for (let i = 0; i < summaries.length; i++) {
+      expect(summaries[i].awardHistoryCount).toBe(i + 1);
+      expect(summaries[i].duplicateAwardHistoryYears).toBe(0);
+    }
+    expect(state.meta.awardHistory).toHaveLength(50);
+
+    // unique, sorted year keys
+    const years = state.meta.awardHistory.map((e) => e.year);
+    expect(new Set(years).size).toBe(years.length);
+    expect([...years].sort((a, b) => a - b)).toEqual(years);
+  });
+
+  it('award entries are serializable with stable player/team snapshots', () => {
+    const { state } = runSoak({ seasons: 25 });
+    expect(() => assertSerializable(state.meta.awardHistory, 'awardHistory')).not.toThrow();
+
+    for (const entry of state.meta.awardHistory) {
+      expect(entry.awards).toBeTruthy();
+      const mvp = entry.awards.MVP;
+      if (mvp) {
+        expect(mvp.playerId).toBeTruthy();
+        expect(typeof mvp.playerName).toBe('string');
+      }
+      expect(Array.isArray(entry.allPro.firstTeam)).toBe(true);
+      expect(Array.isArray(entry.proBowl)).toBe(true);
+      // league leaders present & finite when set
+      for (const v of Object.values(entry.leaders)) {
+        if (v) expect(Number.isFinite(v.value)).toBe(true);
+      }
+    }
+  });
+
+  it('career honor counts remain finite and serializable', () => {
+    const { state } = runSoak({ seasons: 50 });
+    const agg = aggregateCareerHonors(state.meta.awardHistory);
+    expect(agg.size).toBeGreaterThan(0);
+    for (const [pid, counts] of agg) {
+      expect(() => assertSerializable(counts, `honors_${pid}`)).not.toThrow();
+      for (const v of Object.values(counts)) {
+        expect(Number.isFinite(v)).toBe(true);
+        expect(v).toBeGreaterThanOrEqual(0);
+        expect(v).toBeLessThanOrEqual(50);
+      }
+      // single-player helper agrees with the aggregate
+      expect(getCareerHonorCounts(state.meta.awardHistory, pid)).toEqual(counts);
+    }
+  });
+
+  it('re-running a completed season does not duplicate its award-history entry', () => {
+    const state = createSoakLeague({ seed: SOAK_SEED });
+    advanceSoakSeason(state);
+    const afterOne = jsonClone(state.meta.awardHistory);
+    expect(afterOne).toHaveLength(1);
+
+    // Re-point the year/season back and advance again → replaces, never appends.
+    const replayYear = afterOne[0].year;
+    state.meta.year = replayYear;
+    state.meta.season -= 1;
+    state.meta.currentSeasonId = `s${state.meta.season}`;
+    advanceSoakSeason(state);
+
+    const replayed = state.meta.awardHistory.filter((e) => e.year === replayYear);
+    expect(replayed).toHaveLength(1);
+  });
+
+  it('summaries degrade safely on missing/empty award history', () => {
+    expect(() => summarizeSeasonAwards(undefined)).not.toThrow();
+    expect(summarizeSeasonAwards(undefined).majorAwards).toEqual([]);
+    expect(getCareerHonorCounts([], 'nobody').mvp).toBe(0);
+    expect(aggregateCareerHonors(null).size).toBe(0);
   });
 });
 

--- a/src/testSupport/dynastySoakHarness.js
+++ b/src/testSupport/dynastySoakHarness.js
@@ -69,6 +69,12 @@ import {
   buildSeasonHonorsSummary,
 } from '../core/awards/prestigeEngine.js';
 import {
+  buildAwardHistoryEntry,
+  appendAwardHistory,
+  hydrateAwardHistory,
+  getCareerHonorCounts,
+} from '../core/awards/awardHistory.js';
+import {
   buildMediaNarratives,
   MEDIA_STORY_MAX,
 } from '../core/news/mediaNarrativeEngine.js';
@@ -253,6 +259,7 @@ export function createSoakLeague(opts = {}) {
     weeklyHeadlines: [],
     leaguePulse: [],
     currentSeasonHonors: null,
+    awardHistory: [],
     newsItems: [],
   };
 
@@ -448,6 +455,51 @@ function applyPrestigeHonors(state) {
   meta.currentSeasonHonors = buildSeasonHonorsSummary(allPlayers, assignments, teamResolver);
 }
 
+/**
+ * Award History V2 (currentSeasonHonors' historical companion). Builds a compact
+ * meta.awardHistory entry for the completed season by composing prestige
+ * selections with a synthesized MVP/OPOY/DPOY + league-leader set, and appends it
+ * idempotently (replace-by-year) so the ledger stays bounded and duplicate-free.
+ */
+function applyAwardHistory(state) {
+  const { teams, meta } = state;
+  const allPlayers = [];
+  for (const t of teams) for (const p of t.roster) allPlayers.push({ ...p, teamId: t.id });
+  const teamResolver = (teamId) => teams.find((t) => t.id === teamId) ?? null;
+
+  const ranked = rankPrestigeCandidates(allPlayers, teamResolver, meta.year);
+  const allProAssignments = selectAllProTeams(ranked, meta.year);
+  const proBowlAssignments = selectProBowlTeams(ranked, meta.year);
+  const prestigeAssignments = [...allProAssignments, ...proBowlAssignments];
+
+  const toAward = (type, cand) =>
+    cand
+      ? { type, playerId: cand.player.id, name: cand.player.name, pos: cand.player.pos, teamId: cand.teamId, score: cand.score }
+      : null;
+  const top = (arr) => (Array.isArray(arr) && arr[0] ? arr[0] : null);
+  const skill = [...(ranked.RB ?? []), ...(ranked.WR ?? [])].sort((a, b) => b.score - a.score);
+  const playerAwards = [
+    toAward('MVP', top(ranked.QB)),
+    toAward('OFFENSIVE_POY', top(skill)),
+    toAward('DEFENSIVE_POY', top(ranked.DL)),
+  ].filter(Boolean);
+
+  const allProTeam = allProAssignments.filter((a) => a.type === 'FIRST_TEAM_ALL_PRO');
+  const stats = allPlayers.map((p) => ({
+    playerId: p.id, name: p.name, pos: p.pos, teamId: p.teamId, totals: p.stats?.season ?? {},
+  }));
+
+  const entry = buildAwardHistoryEntry({
+    year: meta.year,
+    seasonId: meta.currentSeasonId,
+    awardResults: { playerAwards, franchiseAwards: [], allProTeam },
+    prestigeAssignments,
+    stats,
+    teamResolver,
+  });
+  meta.awardHistory = appendAwardHistory(hydrateAwardHistory(meta), entry);
+}
+
 /** Append capped weekly headlines + league pulse for the completed season. */
 function applyNewsCaps(state, champion) {
   const { meta } = state;
@@ -510,6 +562,7 @@ export function advanceSoakSeason(state) {
   applyOwnerPressureRollover(state);
   applyHistoryAndLegacy(state, champion);
   applyPrestigeHonors(state);
+  applyAwardHistory(state);
   applyNewsCaps(state, champion);
   rolloverToNextSeason(state);
   return state;
@@ -645,6 +698,24 @@ export function buildInvariantSummary(state) {
     if (e?.championTeamId != null && !teamIds.has(e.championTeamId)) invalidReferences += 1;
   }
 
+  // Award history ledger: bounded, duplicate-free by year, finite honor counts.
+  const awardHistory = Array.isArray(meta.awardHistory) ? meta.awardHistory : [];
+  const awardYears = new Set();
+  let duplicateAwardHistoryYears = 0;
+  let maxCareerHonorCount = 0;
+  for (const e of awardHistory) {
+    if (awardYears.has(e?.year)) duplicateAwardHistoryYears += 1;
+    else awardYears.add(e?.year);
+  }
+  // Spot-check career honor aggregation stays finite for any awarded player.
+  const sampleMvp = awardHistory[awardHistory.length - 1]?.awards?.MVP?.playerId ?? null;
+  if (sampleMvp != null) {
+    const counts = getCareerHonorCounts(awardHistory, sampleMvp);
+    for (const v of Object.values(counts)) {
+      if (Number.isFinite(v)) maxCareerHonorCount = Math.max(maxCareerHonorCount, v);
+    }
+  }
+
   // Playoff seed reference validity
   for (const seeds of Object.values(meta.playoffSeeds ?? {})) {
     if (!Array.isArray(seeds)) continue;
@@ -673,6 +744,9 @@ export function buildInvariantSummary(state) {
     invalidPersonaProfiles,
     historyLedgerCount: ledger.length,
     duplicateLedgerYears,
+    awardHistoryCount: awardHistory.length,
+    duplicateAwardHistoryYears,
+    maxCareerHonorCount,
     retiredNumbersCount,
     ringOfHonorCount,
     prestigeHonorCount: countPrestigeHonors(meta.currentSeasonHonors),

--- a/src/ui/components/AlmanacView.tsx
+++ b/src/ui/components/AlmanacView.tsx
@@ -125,16 +125,21 @@ function ChampionsArchivePane({ seasons, champions, awards }: ChampionsArchivePa
       });
     }
 
-    // Overlay awards
+    // Overlay awards. Tolerates both the legacy SeasonAwardWinner shape
+    // (mvpName/opoyName/dpoyName) and the Awards V2 awardHistory shape
+    // (awards.MVP.playerName, etc.).
     for (const a of awards) {
       const year = num(a.year, 0);
       if (!year) continue;
       const existing = byYear.get(year);
-      if (existing) {
-        if (a.mvpName && existing.mvp === '—') existing.mvp = a.mvpName;
-        if (a.opoyName && existing.opoy === '—') existing.opoy = a.opoyName;
-        if (a.dpoyName && existing.dpoy === '—') existing.dpoy = a.dpoyName;
-      }
+      if (!existing) continue;
+      const v2 = (a as { awards?: { MVP?: { playerName?: string }; OPOY?: { playerName?: string }; DPOY?: { playerName?: string } } }).awards;
+      const mvpName = a.mvpName ?? v2?.MVP?.playerName;
+      const opoyName = a.opoyName ?? v2?.OPOY?.playerName;
+      const dpoyName = a.dpoyName ?? v2?.DPOY?.playerName;
+      if (mvpName && existing.mvp === '—') existing.mvp = mvpName;
+      if (opoyName && existing.opoy === '—') existing.opoy = opoyName;
+      if (dpoyName && existing.dpoy === '—') existing.dpoy = dpoyName;
     }
 
     return [...byYear.values()].sort((a, b) => b.year - a.year);

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -1158,6 +1158,7 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
               pendingRohCandidates={rohCandidates}
               retiredNumbers={retiredNums}
               retiredNumberDisplay={retiredNumDisplay}
+              awardHistory={league?.awardHistory ?? []}
               onInduct={handleInduct}
               onRetireNumber={handleRetireNumber}
             />

--- a/src/ui/components/FranchiseLegacyView.jsx
+++ b/src/ui/components/FranchiseLegacyView.jsx
@@ -325,6 +325,7 @@ export default function FranchiseLegacyView({
   pendingRohCandidates = [],
   retiredNumbers = [],
   retiredNumberDisplay = [],
+  awardHistory = [],
   onInduct,
   onDismissCandidate,
   onRetireNumber,
@@ -367,6 +368,7 @@ export default function FranchiseLegacyView({
           <LegendsBrowser
             ringOfHonor={ringOfHonor}
             retiredNumbers={retiredNumbers}
+            awardHistory={awardHistory}
             onRetireNumber={onRetireNumber}
           />
         ) : (

--- a/src/ui/components/HistoryCenter.awards.test.jsx
+++ b/src/ui/components/HistoryCenter.awards.test.jsx
@@ -1,0 +1,62 @@
+/** @vitest-environment jsdom */
+/**
+ * HistoryCenter.awards.test.jsx — Awards & Honors Expansion V2 awards panel.
+ */
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import HistoryCenter from './HistoryCenter.jsx';
+
+afterEach(cleanup);
+
+const AWARD_HISTORY = [
+  {
+    year: 2025,
+    seasonId: 's1',
+    awards: {
+      MVP: { playerId: 'qb1', playerName: 'Star QB', teamAbbr: 'AAA', pos: 'QB', score: 320 },
+      OPOY: { playerId: 'rb1', playerName: 'Speed RB', teamAbbr: 'BBB', pos: 'RB' },
+      DPOY: { playerId: 'dl1', playerName: 'Edge Pro', teamAbbr: 'AAA', pos: 'DL' },
+      ORoy: null,
+      DRoy: null,
+      COY: null,
+    },
+    allPro: { firstTeam: [{ playerId: 'qb1' }, { playerId: 'dl1' }], secondTeam: [{ playerId: 'qb2' }] },
+    proBowl: [{ playerId: 'qb1' }, { playerId: 'rb1' }],
+    leaders: { passYd: { playerName: 'Star QB', teamAbbr: 'AAA', value: 5100 }, sacks: null },
+  },
+];
+
+function openAwards() {
+  fireEvent.click(screen.getByRole('tab', { name: 'Awards' }));
+}
+
+describe('HistoryCenter — Awards panel', () => {
+  it('renders the awards summary for each recorded season', () => {
+    render(<HistoryCenter league={{ awardHistory: AWARD_HISTORY }} />);
+    openAwards();
+    expect(screen.getByTestId('season-awards-panel')).toBeTruthy();
+    expect(screen.getByTestId('season-awards-2025')).toBeTruthy();
+    expect(screen.getAllByText(/Star QB/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/MVP:/)).toBeTruthy();
+  });
+
+  it('shows a safe empty state when awardHistory is missing', () => {
+    render(<HistoryCenter league={{}} />);
+    openAwards();
+    expect(screen.getByTestId('season-awards-empty')).toBeTruthy();
+  });
+
+  it('does not crash when league is undefined', () => {
+    expect(() => render(<HistoryCenter />)).not.toThrow();
+    openAwards();
+    expect(screen.getByTestId('season-awards-empty')).toBeTruthy();
+  });
+
+  it('tolerates malformed entries without crashing', () => {
+    const messy = [null, {}, { year: 2030, awards: {}, allPro: {}, proBowl: [] }];
+    expect(() => render(<HistoryCenter league={{ awardHistory: messy }} />)).not.toThrow();
+    openAwards();
+    expect(screen.getByTestId('season-awards-2030')).toBeTruthy();
+  });
+});

--- a/src/ui/components/HistoryCenter.jsx
+++ b/src/ui/components/HistoryCenter.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import { ScreenHeader, SectionCard } from './ScreenSystem.jsx';
 import HonorsCenter from './HonorsCenter.jsx';
+import { summarizeSeasonAwards } from '../../core/awards/awardHistory.js';
 
-const TABS = ['Honor Roll', 'Record Book', 'Honors'];
+const TABS = ['Honor Roll', 'Awards', 'Record Book', 'Honors'];
 
 const RECORD_LABELS = {
   passingYards: 'Passing Yards',
@@ -157,6 +158,60 @@ function RecordBookTab({ recordBook }) {
   );
 }
 
+function SeasonAwardsTab({ awardHistory }) {
+  const entries = Array.isArray(awardHistory) ? awardHistory : [];
+  const seasons = [...entries]
+    .map((e) => summarizeSeasonAwards(e))
+    .filter((s) => s.year != null)
+    .sort((a, b) => (b.year ?? 0) - (a.year ?? 0));
+
+  if (seasons.length === 0) {
+    return (
+      <SectionCard title="Season Awards">
+        <p style={{ color: 'var(--text-muted)', fontSize: 'var(--text-sm)' }} data-testid="season-awards-empty">
+          No awards recorded yet. Complete a season to populate the award history.
+        </p>
+      </SectionCard>
+    );
+  }
+
+  return (
+    <SectionCard title="Season Awards">
+      <div data-testid="season-awards-panel" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
+        {seasons.map((s) => (
+          <div
+            key={s.year}
+            data-testid={`season-awards-${s.year}`}
+            style={{ borderBottom: '1px solid var(--border-subtle, var(--border))', paddingBottom: 'var(--space-2)' }}
+          >
+            <div style={{ fontWeight: 700, fontSize: 'var(--text-sm)', marginBottom: 4 }}>{s.year}</div>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-2)', fontSize: 'var(--text-sm)' }}>
+              {s.majorAwards.length === 0 ? (
+                <span style={{ color: 'var(--text-muted)' }}>No major award winners recorded.</span>
+              ) : (
+                s.majorAwards.map((a) => (
+                  <span key={a.key} style={{ color: 'var(--text)' }}>
+                    <strong>{a.label}:</strong> {a.playerName}
+                    {a.pos ? ` (${a.pos}${a.teamAbbr ? ` · ${a.teamAbbr}` : ''})` : ''}
+                  </span>
+                ))
+              )}
+            </div>
+            <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', marginTop: 4 }}>
+              All-Pro: {s.firstTeamCount} 1st · {s.secondTeamCount} 2nd · Pro Bowl: {s.proBowlCount}
+            </div>
+            {s.leaders.length > 0 && (
+              <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', marginTop: 2 }}>
+                Leaders — {s.leaders.map((l) => `${l.label}: ${l.playerName} (${l.value})`).join(' · ')}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </SectionCard>
+  );
+}
+
 export default function HistoryCenter({ league }) {
   const [activeTab, setActiveTab] = useState(TABS[0]);
 
@@ -164,6 +219,7 @@ export default function HistoryCenter({ league }) {
   const recordBook = league?.recordBook ?? null;
   const userTeamId = league?.userTeamId ?? null;
   const currentSeasonHonors = league?.currentSeasonHonors ?? null;
+  const awardHistory = league?.awardHistory ?? [];
 
   return (
     <div className="app-screen-stack">
@@ -175,6 +231,9 @@ export default function HistoryCenter({ league }) {
       <div role="tabpanel">
         {activeTab === 'Honor Roll' && (
           <HonorRollTab historyLedger={historyLedger} userTeamId={userTeamId} />
+        )}
+        {activeTab === 'Awards' && (
+          <SeasonAwardsTab awardHistory={awardHistory} />
         )}
         {activeTab === 'Record Book' && (
           <RecordBookTab recordBook={recordBook} />

--- a/src/ui/components/LegendsBrowser.honors.test.jsx
+++ b/src/ui/components/LegendsBrowser.honors.test.jsx
@@ -1,0 +1,65 @@
+/** @vitest-environment jsdom */
+/**
+ * LegendsBrowser.honors.test.jsx — career honor counts (Awards & Honors V2).
+ */
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import LegendsBrowser from './LegendsBrowser.jsx';
+
+afterEach(() => cleanup());
+
+function makeRoh(overrides = {}) {
+  return {
+    id: 'p1',
+    name: 'Dan Legend',
+    position: 'QB',
+    jerseyNumber: 10,
+    yearsPlayedWithTeam: '2010–2020',
+    totalPassingYards: 45000,
+    accolades: ['MVP (2015)'],
+    inductionYear: 2022,
+    ...overrides,
+  };
+}
+
+const AWARD_HISTORY = [
+  {
+    year: 2015,
+    awards: { MVP: { playerId: 'p1' } },
+    allPro: { firstTeam: [{ playerId: 'p1' }], secondTeam: [] },
+    proBowl: [{ playerId: 'p1' }],
+  },
+  {
+    year: 2016,
+    awards: { MVP: { playerId: 'p1' } },
+    allPro: { firstTeam: [{ playerId: 'p1' }], secondTeam: [] },
+    proBowl: [{ playerId: 'p1' }],
+  },
+];
+
+describe('LegendsBrowser — career honor counts', () => {
+  it('renders honor count badges for the selected legend when award history matches', () => {
+    render(<LegendsBrowser ringOfHonor={[makeRoh()]} awardHistory={AWARD_HISTORY} />);
+    expect(screen.getByTestId('legend-career-honors')).toBeTruthy();
+    // 2× MVP aggregated from the ledger
+    expect(screen.getByTestId('honor-count-mvp').textContent).toContain('2×');
+    expect(screen.getByTestId('honor-count-all-pro')).toBeTruthy();
+    expect(screen.getByTestId('honor-count-pro-bowl')).toBeTruthy();
+  });
+
+  it('omits the honors panel when award history is absent (graceful degrade)', () => {
+    render(<LegendsBrowser ringOfHonor={[makeRoh()]} />);
+    expect(screen.queryByTestId('legend-career-honors')).toBeNull();
+  });
+
+  it('omits the honors panel when the legend earned no tracked honors', () => {
+    render(<LegendsBrowser ringOfHonor={[makeRoh({ id: 'ghost' })]} awardHistory={AWARD_HISTORY} />);
+    expect(screen.queryByTestId('legend-career-honors')).toBeNull();
+  });
+
+  it('does not crash on malformed award history', () => {
+    const messy = [null, {}, { awards: null, allPro: null, proBowl: null }];
+    expect(() => render(<LegendsBrowser ringOfHonor={[makeRoh()]} awardHistory={messy} />)).not.toThrow();
+  });
+});

--- a/src/ui/components/LegendsBrowser.jsx
+++ b/src/ui/components/LegendsBrowser.jsx
@@ -7,6 +7,7 @@ import {
   buildLegendTimeline,
   buildLegendProfileMetrics,
 } from '../../core/history/legendsBrowserEngine.js';
+import { getCareerHonorCounts } from '../../core/awards/awardHistory.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -440,7 +441,65 @@ function AccoladeTimeline({ timeline }) {
   );
 }
 
-function LegendProfile({ legend }) {
+const HONOR_BADGE_DEFS = [
+  { key: 'mvp', label: 'MVP' },
+  { key: 'opoy', label: 'OPOY' },
+  { key: 'dpoy', label: 'DPOY' },
+  { key: 'oroy', label: 'OROY' },
+  { key: 'droy', label: 'DROY' },
+  { key: 'allPro', label: 'All-Pro' },
+  { key: 'proBowl', label: 'Pro Bowl' },
+];
+
+/**
+ * Career honor counts derived from the league award-history ledger. Renders
+ * nothing when the ledger is empty or the legend earned no tracked honors, so the
+ * panel degrades gracefully for old saves and unmatched player refs.
+ */
+function CareerHonors({ honors }) {
+  if (!honors) return null;
+  const badges = HONOR_BADGE_DEFS
+    .map(({ key, label }) => ({ label, count: Number(honors[key] ?? 0) }))
+    .filter((b) => b.count > 0);
+  if (badges.length === 0) return null;
+
+  return (
+    <div data-testid="legend-career-honors">
+      <div
+        style={{
+          fontSize: 'var(--text-xs, 11px)',
+          fontWeight: 700,
+          color: 'var(--text-muted)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+          marginBottom: 6,
+        }}
+      >
+        Career Honors
+      </div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+        {badges.map((b) => (
+          <span
+            key={b.label}
+            data-testid={`honor-count-${b.label.replace(/\s+/g, '-').toLowerCase()}`}
+            style={{
+              fontSize: 'var(--text-xs, 11px)',
+              fontWeight: 700,
+              background: 'var(--chip-bg, rgba(99,102,241,0.10))',
+              color: 'var(--chip-text, var(--primary, #6366f1))',
+              borderRadius: 'var(--radius-sm, 4px)',
+              padding: '2px 8px',
+            }}
+          >
+            {b.count}× {b.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function LegendProfile({ legend, honors }) {
   if (!legend) {
     return (
       <div
@@ -535,6 +594,9 @@ function LegendProfile({ legend }) {
         </div>
       </div>
 
+      {/* Career Honors (from league award history) */}
+      <CareerHonors honors={honors} />
+
       {/* Career Metric Sheet */}
       <MetricSheet metrics={metrics} />
 
@@ -576,8 +638,9 @@ function LegendProfile({ legend }) {
  *   retiredNumbers {number[]}  - Array of retired jersey numbers (for badge display)
  *   onRetireNumber {Function}  - (playerId, jerseyNumber) => void (optional)
  */
-export default function LegendsBrowser({ ringOfHonor = [], retiredNumbers = [], onRetireNumber }) {
+export default function LegendsBrowser({ ringOfHonor = [], retiredNumbers = [], awardHistory = [], onRetireNumber }) {
   const roh = Array.isArray(ringOfHonor) ? ringOfHonor : [];
+  const ledger = Array.isArray(awardHistory) ? awardHistory : [];
 
   const [selectedId, setSelectedId] = useState(null);
   const [activeFilter, setActiveFilter] = useState('ALL');
@@ -599,6 +662,10 @@ export default function LegendsBrowser({ ringOfHonor = [], retiredNumbers = [], 
   }, [filteredLegends]);
 
   const selectedLegend = findLegendById(roh, selectedId);
+  const selectedHonors = useMemo(
+    () => (selectedLegend?.id != null && ledger.length > 0 ? getCareerHonorCounts(ledger, selectedLegend.id) : null),
+    [ledger, selectedLegend],
+  );
 
   if (roh.length === 0) {
     return (
@@ -679,7 +746,7 @@ export default function LegendsBrowser({ ringOfHonor = [], retiredNumbers = [], 
 
       {/* Pane B — Legend Profile */}
       <div data-testid="pane-profile">
-        <LegendProfile legend={selectedLegend} />
+        <LegendProfile legend={selectedLegend} honors={selectedHonors} />
       </div>
     </div>
   );

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -196,6 +196,7 @@ import { calculateAwardRaces, selectProBowlers } from '../core/awards-logic.js';
 import { determineSeasonAwards, applySeasonAwards, checkCareerMilestones, getPlayerAwardSummary, AWARD_TYPES as ENGINE_AWARD_TYPES, AWARD_LABELS as ENGINE_AWARD_LABELS } from '../core/awards/awardEngine.js';
 import { generateHofBallot, resolveHofVote, applyHofInductions, ensureHofMeta } from '../core/awards/hofEngine.js';
 import { rankPrestigeCandidates, selectAllProTeams, selectProBowlTeams, mergeHonorsIntoPlayers, buildSeasonHonorsSummary } from '../core/awards/prestigeEngine.js';
+import { buildAwardHistoryEntry, appendAwardHistory, hydrateAwardHistory } from '../core/awards/awardHistory.js';
 import { buildAllLeaderboards } from '../core/awards/statLeaderboard.js';
 import { Constants } from '../core/constants.js';
 import { processPlayerProgression } from '../core/progression-logic.js';
@@ -1185,6 +1186,7 @@ function buildViewState() {
     historyLedger: Array.isArray(meta?.historyLedger) ? meta.historyLedger : [],
     franchiseAwards: Array.isArray(meta?.franchiseAwards) ? meta.franchiseAwards : [],
     currentSeasonHonors: meta?.currentSeasonHonors ?? null,
+    awardHistory: Array.isArray(meta?.awardHistory) ? meta.awardHistory : [],
     franchiseChronicle: Array.isArray(meta?.franchiseChronicle) ? meta.franchiseChronicle.slice(-340) : [],
     franchiseSeasonReviews: Array.isArray(meta?.franchiseSeasonReviews) ? meta.franchiseSeasonReviews.slice(-40) : [],
     seasonStorylines: Array.isArray(meta?.seasonStorylines) ? meta.seasonStorylines : [],
@@ -12981,6 +12983,11 @@ async function archiveSeason(seasonId) {
     // Flush accolade writes to DB
     await flushDirty();
 
+    // Captured across the award + prestige blocks below to build the compact
+    // meta.awardHistory ledger (Awards & Honors Expansion V2) once both run.
+    let awardResultsForHistory = null;
+    let prestigeAssignmentsForHistory = [];
+
     // ── Awards Engine V1: structured player.awards + meta.franchiseAwards ────
     try {
       const allPlayersForAwards = cache.getAllPlayers();
@@ -12989,6 +12996,7 @@ async function archiveSeason(seasonId) {
         coaches: staffRows,
         championTeamId: championId,
       });
+      awardResultsForHistory = awardResults;
 
       const playerMapForAwards = new Map(allPlayersForAwards.map(p => [String(p.id), p]));
       const currentMeta = cache.getMeta();
@@ -13189,6 +13197,7 @@ async function archiveSeason(seasonId) {
       const allProAssignments = selectAllProTeams(rankedCandidates, year);
       const proBowlAssignments = selectProBowlTeams(rankedCandidates, year);
       const allPrestigeAssignments = [...allProAssignments, ...proBowlAssignments];
+      prestigeAssignmentsForHistory = allPrestigeAssignments;
 
       const updatedPlayersPrestige = mergeHonorsIntoPlayers(allPlayersForPrestige, allPrestigeAssignments, year);
       for (let i = 0; i < updatedPlayersPrestige.length; i++) {
@@ -13204,6 +13213,26 @@ async function archiveSeason(seasonId) {
       cache.setMeta({ currentSeasonHonors: honorsSummary });
     } catch (prestigeErr) {
       console.error('[Worker] Prestige Engine V1 failed (non-fatal):', prestigeErr);
+    }
+
+    // ── Award History V2: compact, replay-safe per-season award ledger ───────
+    try {
+      if (awardResultsForHistory) {
+        const teamResolverForHistory = (teamId) => cache.getTeam(teamId) ?? null;
+        const historyEntry = buildAwardHistoryEntry({
+          year,
+          seasonId,
+          awardResults: awardResultsForHistory,
+          prestigeAssignments: prestigeAssignmentsForHistory,
+          stats: populatedStats,
+          teamResolver: teamResolverForHistory,
+        });
+        const currentAwardHistory = hydrateAwardHistory(cache.getMeta());
+        cache.setMeta({ awardHistory: appendAwardHistory(currentAwardHistory, historyEntry) });
+        await flushDirty();
+      }
+    } catch (awardHistoryErr) {
+      console.error('[Worker] Award History V2 failed (non-fatal):', awardHistoryErr);
     }
 
     // ── Record Book: check for broken single-season & all-time records ──────

--- a/tests/unit/league_memory.test.js
+++ b/tests/unit/league_memory.test.js
@@ -18,6 +18,16 @@ describe('league memory helpers', () => {
     expect(Array.isArray(meta.hallOfFame.classes)).toBe(true);
   });
 
+  it('hydrates awardHistory to a safe array for old saves and preserves existing ledgers', () => {
+    // old save: no awardHistory field
+    expect(ensureLeagueMemoryMeta({ year: 2030 }).awardHistory).toEqual([]);
+    // malformed value coerced to default
+    expect(ensureLeagueMemoryMeta({ awardHistory: 'oops' }).awardHistory).toEqual([]);
+    // existing ledger preserved
+    const existing = [{ year: 2029, awards: {}, allPro: { firstTeam: [], secondTeam: [] }, proBowl: [], leaders: {} }];
+    expect(ensureLeagueMemoryMeta({ awardHistory: existing }).awardHistory).toBe(existing);
+  });
+
   it('persists franchise timeline milestones and totals', () => {
     let meta = ensureLeagueMemoryMeta({});
     const season = buildSeasonArchiveSummary({


### PR DESCRIPTION
Adds a compact, replay-safe per-season award ledger (meta.awardHistory) and
surfaces award fidelity across the football honors layer without touching core
simulation, trade, free-agency, waiver, draft, playoff, standings, owner-pressure,
media, or front-office formulas.

Core
- New src/core/awards/awardHistory.js (pure, deterministic): composes existing
  awardEngine + prestigeEngine outputs into the documented compact entry shape
  { year, seasonId, awards{MVP,OPOY,DPOY,ORoy,DRoy,COY}, allPro{firstTeam,
  secondTeam}, proBowl, leaders }. Provides computeLeagueLeaders (passing/rushing/
  receiving yards & TDs, sacks, defensive INTs, total TDs — deterministic, tie
  broken by playerId), appendAwardHistory (replace-by-year: idempotent, bounded,
  duplicate-free), hydrateAwardHistory (old-save safe), getCareerHonorCounts /
  aggregateCareerHonors (retire-safe career aggregation), summarizeSeasonAwards.
- awardEngine: additive Offensive & Defensive Rookie of the Year (legacy
  ROOKIE_OF_YEAR retained for back-compat).
- league-memory: hydrate awardHistory:[] default for old saves.
- worker: build/append awardHistory after the award + prestige passes; expose
  meta.awardHistory on the league view-state.

UI (degrades gracefully when awardHistory is missing)
- HistoryCenter: new Awards tab with a per-season awards summary panel.
- LegendsBrowser: career honor count badges sourced from the ledger.
- AlmanacView: champions archive tolerates both legacy and V2 award shapes.

Soak (extends #1620 invariants)
- dynastySoakHarness builds awardHistory each season; new invariants assert it
  stays serializable, grows at most one entry/season, has no duplicate year keys,
  and that career honor counts remain finite — across 10/25/50-season soaks.

Tests: +awardHistory unit suite, awardEngine rookie-split cases, HistoryCenter &
LegendsBrowser UI smoke tests, league-memory hydration, and award-history soak
section. Full suite 4778 → 4818 (all green).

Positional honor expansion is delivered through the awardEngine 11-slot All-Pro
team (QB/RB/WR/TE/OL/DL/LB/CB/S/K/P) surfaced in firstTeam; the prestige premium
layer intentionally stays QB/RB/WR/DL to keep free-agency salary determinism
untouched (documented limitation).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KKC7PewDQHBPXW8ara3nEX