### PR TITLE
feat(mobile-ux): Mobile UX Foundation & Live Game Polish V1

### DIFF
--- a/docs/mobile-ux-live-game-polish-v1.md
+++ b/docs/mobile-ux-live-game-polish-v1.md
@@ -1,0 +1,76 @@
+# Mobile UX Foundation & Live Game Polish V1
+
+Focused UI/UX polish for the core mobile loop: **advance week → view week results →
+watch/sim game → view postgame result.** No gameplay systems were added or changed.
+
+## Screens touched
+- **Franchise HQ** (`FranchiseHQ.jsx`) — compact activity strip for roster/sim notices.
+- **Live game / week-results panel** (`LiveGame.jsx`) — critical bug fix + gamecast polish.
+- **Postgame result screen** (`PostGameScreen.jsx`) — tighter cards, empty-state Game Flow.
+- **Mobile shell** (`base.css`, `components.css`) — mobile spacing tokens + safe-area vars.
+
+## Files changed
+- `src/ui/components/LiveGame.jsx` — fix week-results integrity bug; add `MobileScorebug`,
+  `LiveFinalCard`, `KeyMomentsStrip`; partial-results warning; play-feed hierarchy.
+- `src/ui/components/PostGameScreen.jsx` — tighten top card, box-score affordance, leader
+  spacing; hide empty Game Flow behind a compact useful empty state.
+- `src/ui/components/FranchiseHQ.jsx` — collapse roster/simulation notices into the new
+  `ActivityToastStack`.
+- `src/ui/components/ActivityToastStack.jsx` — **new** reusable compact activity strip.
+- `src/ui/styles/base.css` — new mobile UX tokens (card padding, compact button height,
+  safe-area insets, sticky-footer gap, mobile type scale).
+- `src/ui/styles/components.css` — styles for scorebug, final card, key moments, play
+  highlights, and the activity toast stack.
+- Tests: `ActivityToastStack.test.jsx`, `LiveGameMobilePolish.test.jsx`,
+  `PostGameMobilePolish.test.jsx`, `FranchiseHQMobileShell.test.jsx`.
+
+## Critical data bug fixed
+HQ/live panel could simultaneously show **"Week complete"**, **"Games resolved: 15 / 16"**,
+and **"No games to display."** Root cause: the header counted *all* resolved games while the
+scoreboard only rendered the *user's* game, so a bye week / late skip / data mismatch left the
+panel empty despite completed games existing.
+
+Now:
+- The user's resolved game is shown when present.
+- If the user has no game but other games resolved, those completed games are surfaced.
+- A compact partial-results warning appears when resolved games < scheduled games.
+- The empty state only renders when there genuinely is no completed game data, and never
+  contradicts the resolved-count line.
+
+## Before / after UX behavior
+| Area | Before | After |
+|------|--------|-------|
+| Week results | Empty "No games to display" despite resolved games | Always renders completed games; partial warning when incomplete |
+| Live game | Debug-style play log, weak "final whistle" | Sticky mobile scorebug, prominent FINAL card with winner emphasis + "View Box Score", classified play feed (scoring/sack/turnover/latest), Key Moments strip |
+| Postgame | Tall cards, empty Game Flow toggles | Tighter score card, prominent box-score button, Game Flow hidden/replaced by useful empty state, compact leaders |
+| HQ notices | Stacked full-width alert cards | Single compact activity strip (toast stack) |
+| Mobile shell | Ad-hoc spacing | Shared tokens for card padding, compact button height, safe-area insets, sticky-footer gap, mobile type scale |
+
+## Tests added (15, all passing)
+1. Week-results panel renders resolved games when available.
+2. Panel does not show "No games to display" when completed games exist.
+3. Partial-completion shows a compact warning when resolved < total.
+4. Activity strip/toast stack renders roster/simulation messages (unit + HQ integration).
+5. Live final state renders FINAL, final score, winner emphasis, box-score action.
+6. Live play feed highlights scoring events (`data-play-kind`).
+7. Live game handles missing/empty play log without crashing.
+8. Postgame hides/improves empty Game Flow state.
+9. Postgame leaders render compactly with partial leader data.
+10. Mobile bottom nav/safe-area: primary Advance Week control sits outside the bottom nav.
+
+Full suite: **4834 unit/integration tests passing**; production build succeeds.
+
+## No gameplay logic changed
+No changes to simulation math, play-by-play generation, awards, trades, free agency,
+waivers, draft, playoffs/standings, owner pressure, media/front-office formulas, progression,
+or the save schema. Changes are limited to UI components and stylesheets.
+
+## Known remaining UX limitations
+- The live week-advance panel (`LiveGame.jsx`) still uses *synthetic* play text and a
+  synthetic clock/possession in the scorebug — real down/distance/ball-spot are only available
+  in the dedicated watch overlay (`LiveGameViewer.jsx`), which already has a real `Scorebug`.
+- The scorebug uses `position: sticky` inside an `overflow: hidden` panel, so it renders inline
+  rather than truly pinning during long feeds.
+- Desktop layout intentionally left unchanged; improvements target mobile-sized viewports.
+- The richer "watch a single game" overlay (`LiveGameViewer.jsx`) was left as-is to limit risk;
+  its speed controls and final card were already reasonably polished.

--- a/src/ui/components/ActivityToastStack.jsx
+++ b/src/ui/components/ActivityToastStack.jsx
@@ -1,0 +1,54 @@
+/**
+ * ActivityToastStack.jsx — compact mobile activity strip
+ *
+ * Collapses transient roster / simulation notices (lineup validity, depth-chart
+ * warnings, "week advanced", auto-save confirmations, etc.) into a single tight
+ * stack instead of stacking full-width alert cards that eat vertical space.
+ *
+ * Pure presentational primitive — no gameplay logic. Each message:
+ *   { id, text, tone? } where tone ∈ 'info' | 'ok' | 'warning' | 'danger'
+ */
+
+import React from 'react';
+
+const TONE_COLOR = {
+  ok: 'var(--success)',
+  warning: 'var(--warning)',
+  danger: 'var(--danger)',
+  info: 'var(--accent)',
+};
+
+export default function ActivityToastStack({ messages, max = 4 }) {
+  const list = (Array.isArray(messages) ? messages : [])
+    .filter((m) => m && (m.text ?? '').toString().trim().length > 0)
+    .slice(-max);
+
+  if (list.length === 0) return null;
+
+  return (
+    <div
+      className="activity-toast-stack"
+      data-testid="activity-toast-stack"
+      role="status"
+      aria-live="polite"
+      aria-label="Recent franchise activity"
+    >
+      {list.map((m) => {
+        const tone = TONE_COLOR[m.tone] ? m.tone : 'info';
+        const color = TONE_COLOR[tone];
+        return (
+          <div
+            key={m.id ?? m.text}
+            className={`activity-toast activity-toast--${tone}`}
+            data-testid="activity-toast"
+            data-tone={tone}
+            style={{ borderLeftColor: color }}
+          >
+            <span className="activity-toast__dot" style={{ background: color }} aria-hidden="true" />
+            <span className="activity-toast__text">{m.text}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -19,6 +19,7 @@ import CombineDashboard from './CombineDashboard.jsx';
 import FranchiseLegacyView from './FranchiseLegacyView.jsx';
 import FranchiseBrandHQ from './FranchiseBrandHQ.jsx';
 import JobSecurityCard from './JobSecurityCard.jsx';
+import ActivityToastStack from './ActivityToastStack.jsx';
 
 const BOTTOM_NAV_ITEMS = [
   { label: 'Home', route: 'HQ', icon: 'home', active: true },
@@ -434,6 +435,20 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
   }, [command.weekLabel]);
 
   const teamDisplayName = userTeam?.name ?? userTeam?.abbr ?? 'My Team';
+
+  // Collapse transient roster / simulation notices into one compact strip
+  // instead of stacking oversized full-width alert cards.
+  const activityMessages = useMemo(() => {
+    const out = [];
+    if (busy || simulating) out.push({ id: 'sim', text: 'Simulating week — resolving games…', tone: 'info' });
+    const roster = Array.isArray(userTeam?.roster) ? userTeam.roster : [];
+    const injuredCount = roster.filter((p) => safeNum(p?.injuryWeeksRemaining, 0) > 0).length;
+    if (injuredCount > 0) {
+      out.push({ id: 'inj', text: `${injuredCount} player${injuredCount === 1 ? '' : 's'} on the injury report`, tone: injuredCount > 2 ? 'warning' : 'info' });
+    }
+    if (lineupToast) out.push({ id: 'lineup', text: lineupToast, tone: lineupToast.includes('valid') ? 'ok' : 'warning' });
+    return out;
+  }, [busy, simulating, userTeam?.roster, lineupToast]);
 
   return (
     <div
@@ -1166,7 +1181,7 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
         );
       })()}
 
-      {lineupToast ? <p className="app-inline-toast" role="status" aria-live="polite">{lineupToast}</p> : null}
+      <ActivityToastStack messages={activityMessages} />
 
       {showGate ? (
         <div style={{ padding: '0 12px', marginBottom: 8 }}>

--- a/src/ui/components/LiveGame.jsx
+++ b/src/ui/components/LiveGame.jsx
@@ -134,6 +134,13 @@ function QuarterScores({ homeAbbr, awayAbbr, quarterScores }) {
   );
 }
 
+// ── Numeric helper ─────────────────────────────────────────────────────────────
+
+function safeScore(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
 // ── Palette helper ─────────────────────────────────────────────────────────────
 
 function teamColor(abbr = "") {
@@ -361,6 +368,90 @@ function PendingCard({ game, teamById, userTeamId }) {
         {away.abbr} @ {home.abbr}
       </div>
       <TeamBadge abbr={home.abbr} size={32} isUser={Number(home.id) === numericUserTeamId} />
+    </div>
+  );
+}
+
+// ── Mobile sticky scorebug ────────────────────────────────────────────────────
+// Compact broadcast-style score strip for the user's in-progress game.
+
+function MobileScorebug({ awayAbbr, homeAbbr, awayScore, homeScore, quarter, homeHasBall }) {
+  const awayColor = teamColor(awayAbbr);
+  const homeColor = teamColor(homeAbbr);
+  const possessor = homeHasBall ? homeAbbr : awayAbbr;
+  return (
+    <div className="lg-scorebug" data-testid="live-scorebug">
+      <div className={`lg-scorebug__team${homeHasBall ? '' : ' has-ball'}`}>
+        <span className="lg-scorebug__abbr" style={{ color: awayColor }}>{awayAbbr}</span>
+        <span className="lg-scorebug__score">{awayScore}</span>
+      </div>
+      <div className="lg-scorebug__center">
+        <span className="lg-scorebug__clock">Q{quarter}</span>
+        <span className="lg-scorebug__poss" aria-label={`Possession: ${possessor}`}>
+          {homeHasBall ? '◄' : '►'} {possessor} ball
+        </span>
+      </div>
+      <div className={`lg-scorebug__team${homeHasBall ? ' has-ball' : ''}`}>
+        <span className="lg-scorebug__score">{homeScore}</span>
+        <span className="lg-scorebug__abbr" style={{ color: homeColor }}>{homeAbbr}</span>
+      </div>
+    </div>
+  );
+}
+
+// ── Final result card (broadcast "FINAL" framing) ─────────────────────────────
+
+function LiveFinalCard({ framing, recapGame, recapText, onOpenBoxScore }) {
+  if (!framing) return null;
+  const toneColor =
+    framing.tone === 'win' ? 'var(--success)' : framing.tone === 'loss' ? 'var(--danger)' : 'var(--warning)';
+  const awayWinner = !framing.tied && !framing.homeWon;
+  const homeWinner = !framing.tied && framing.homeWon;
+  return (
+    <div className="lg-final-card" data-testid="live-final-card" style={{ borderColor: `${toneColor}55` }}>
+      <div className="lg-final-card__badge" style={{ color: toneColor, borderColor: `${toneColor}66` }}>
+        {framing.label}
+      </div>
+      <div className="lg-final-card__score">
+        <div className={`lg-final-card__team${awayWinner ? ' is-winner' : ''}`}>
+          <span className="lg-final-card__abbr">{recapGame.awayAbbr}</span>
+          <span className="lg-final-card__pts">{framing.awayScore}</span>
+        </div>
+        <span className="lg-final-card__sep">–</span>
+        <div className={`lg-final-card__team${homeWinner ? ' is-winner' : ''}`}>
+          <span className="lg-final-card__pts">{framing.homeScore}</span>
+          <span className="lg-final-card__abbr">{recapGame.homeAbbr}</span>
+        </div>
+      </div>
+      {recapText ? <div className="lg-final-card__recap">{recapText}</div> : null}
+      {framing.gameId != null ? (
+        <button
+          type="button"
+          className="lg-final-card__cta"
+          data-testid="live-final-boxscore"
+          onClick={() => onOpenBoxScore?.(framing.gameId)}
+        >
+          View Box Score ›
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+// ── Key moments strip ─────────────────────────────────────────────────────────
+
+function KeyMomentsStrip({ moments }) {
+  if (!moments?.length) return null;
+  return (
+    <div className="lg-key-moments" data-testid="live-key-moments">
+      <div className="lg-key-moments__label">Key Moments</div>
+      <div className="lg-key-moments__list">
+        {moments.map((m) => (
+          <span key={m.id} className={`lg-key-moments__item lg-key-moments__item--${m.tone}`}>
+            {m.quarter ? `Q${m.quarter} ` : ''}{m.text}
+          </span>
+        ))}
+      </div>
     </div>
   );
 }
@@ -706,6 +797,79 @@ export default function LiveGame({
   const recapScoring = Array.isArray(recapGame?.scoringSummary) ? recapGame.scoringSummary.slice(-2) : [];
   const recapDrives = Array.isArray(recapGame?.driveSummary) ? recapGame.driveSummary.slice(-2) : [];
 
+  // ── Week-results integrity ────────────────────────────────────────────────
+  // Critical fix: the header counts ALL resolved games, but the scoreboard only
+  // rendered the user's own game. When the user's game had no event/result (bye
+  // week, late skip, or a data mismatch) the panel showed "No games to display"
+  // even though other games had resolved. We now surface the resolved games we
+  // DO have so the count and the scoreboard never contradict each other.
+  const userHasResolved = userResolvedEvents.length > 0;
+  const userHasLastResult = userLastResults.length > 0;
+  const otherResolvedEvents = resolvedEvents.filter(
+    (e) => Number(e.homeId) !== numericUserTeamId && Number(e.awayId) !== numericUserTeamId,
+  );
+  // Only fall back to league-wide results when the user has nothing of their own.
+  const showOtherResolvedFallback =
+    !simulating && !userHasResolved && !userHasLastResult && otherResolvedEvents.length > 0;
+  const hasAnyResults = userHasResolved || userHasLastResult || showOtherResolvedFallback;
+  const showEmptyState =
+    !simulating && !hasAnyResults && userPendingGames.length === 0 && resolvedCount === 0;
+  // Partial completion: some — but not all — of the week's games have resolved.
+  const partialResults =
+    !simulating && totalWeekGames > 0 && resolvedCount > 0 && resolvedCount < totalWeekGames;
+
+  // ── Final-result framing for the user's game ──────────────────────────────
+  const finalFraming = (() => {
+    if (simulating || !recapGame) return null;
+    const homeScore = safeScore(recapGame.homeScore);
+    const awayScore = safeScore(recapGame.awayScore);
+    const tied = homeScore === awayScore;
+    const homeWon = homeScore > awayScore;
+    const userIsHome = Number(recapGame.homeId) === numericUserTeamId;
+    const userInGame = userIsHome || Number(recapGame.awayId) === numericUserTeamId;
+    const userWon = userInGame && !tied && (userIsHome ? homeWon : !homeWon);
+    const userLost = userInGame && !tied && !userWon;
+    return {
+      homeScore,
+      awayScore,
+      tied,
+      homeWon,
+      userWon,
+      userLost,
+      tone: userWon ? 'win' : userLost ? 'loss' : 'neutral',
+      label: userWon ? 'FINAL · W' : userLost ? 'FINAL · L' : tied ? 'FINAL · T' : 'FINAL',
+      gameId: recapGame.gameId ?? recapGame.id ?? null,
+      winnerAbbr: tied ? null : homeWon ? recapGame.homeAbbr : recapGame.awayAbbr,
+    };
+  })();
+
+  // ── Key Moments — distilled from the synthetic scoring run or recap data ──
+  const keyMoments = (() => {
+    const fromRecap = Array.isArray(recapGame?.scoringSummary) ? recapGame.scoringSummary : [];
+    if (fromRecap.length) {
+      return fromRecap.slice(-4).map((s, i) => ({
+        id: `recap-${i}`,
+        quarter: s.quarter ?? null,
+        text: `${s.teamId === recapGame.homeId ? recapGame.homeAbbr : recapGame.awayAbbr} ${s.type ?? s.scoreType ?? 'Score'}`,
+        tone: 'score',
+      }));
+    }
+    // Live fallback: pull the scoring drive lines we already rendered in the feed.
+    return plays
+      .filter((p) => p.isDrive && (p.driveType === 'td' || p.driveType === 'fg'))
+      .slice(-4)
+      .map((p) => ({ id: `live-${p.id}`, quarter: null, text: p.label.replace(/^Drive:\s*/, ''), tone: 'score' }));
+  })();
+
+  // ── Live scorebug state (synthetic, mobile-first) ─────────────────────────
+  const liveHomeScore = quarterScores.home.reduce((s, v) => s + v, 0);
+  const liveAwayScore = quarterScores.away.reduce((s, v) => s + v, 0);
+  const liveQuarter = Math.min(4, Math.floor(playCountRef.current / 8) + 1);
+  const lastPlayText = plays.length ? plays[plays.length - 1].text : '';
+  const homeHasBall = lastPlayText.toLowerCase().startsWith((userHomeAbbr || '').toLowerCase());
+  const showScorebug =
+    simulating && !skipping && (userGame || userEvent) && userHomeAbbr !== '???';
+
   if (!visible) return null;
 
   return (
@@ -820,12 +984,32 @@ export default function LiveGame({
         <div style={{ fontSize: "var(--text-xs)", color: "var(--text-subtle)" }}>
           Games resolved: <strong style={{ color: "var(--text)" }}>{resolvedCount}</strong> / {totalWeekGames || "—"}
         </div>
+        {partialResults ? (
+          <div
+            data-testid="live-partial-results"
+            style={{ fontSize: "var(--text-xs)", color: "var(--warning)", fontWeight: 600 }}
+          >
+            ⚠ {totalWeekGames - resolvedCount} game{totalWeekGames - resolvedCount === 1 ? '' : 's'} still finishing — showing completed results.
+          </div>
+        ) : null}
         {error ? (
           <div style={{ fontSize: "var(--text-xs)", color: "var(--danger)" }}>
             Sim warning: {error}
           </div>
         ) : null}
       </div>
+
+      {/* ── Sticky mobile scorebug (user's live game) ── */}
+      {showScorebug && (
+        <MobileScorebug
+          awayAbbr={userAwayAbbr}
+          homeAbbr={userHomeAbbr}
+          awayScore={liveAwayScore}
+          homeScore={liveHomeScore}
+          quarter={liveQuarter}
+          homeHasBall={homeHasBall}
+        />
+      )}
 
       {/* ── Progress bar ── */}
       {simulating && (
@@ -890,6 +1074,17 @@ export default function LiveGame({
             Scoreboard — Week {simContextWeek ?? ""}
           </div>
 
+          {/* Prominent FINAL framing for the user's completed game */}
+          <LiveFinalCard
+            framing={finalFraming}
+            recapGame={recapGame}
+            recapText={recapText}
+            onOpenBoxScore={onOpenBoxScore}
+          />
+
+          {/* Key moments distilled from the game's scoring */}
+          {!simulating && <KeyMomentsStrip moments={keyMoments} />}
+
           <div
             style={{
               display: "grid",
@@ -939,15 +1134,32 @@ export default function LiveGame({
                 />
               ))}
 
-            {userResolvedEvents.length === 0 && userLastResults.length === 0 && !simulating && (
+            {/* Bug fix: the user has no game data this week (bye / skip / mismatch)
+                but other games resolved — surface those so the panel never reads
+                "No games to display" while completed games exist. */}
+            {showOtherResolvedFallback &&
+              otherResolvedEvents.slice(0, 8).map((ev, i) => (
+                <MatchupCard
+                  key={ev.gameId ?? `other_${i}`}
+                  event={ev}
+                  userTeamId={userTeamId}
+                  pending={false}
+                  onOpenBoxScore={onOpenBoxScore}
+                />
+              ))}
+
+            {showEmptyState && (
               <p
+                data-testid="live-scoreboard-empty"
                 style={{
                   color: "var(--text-subtle)",
                   fontSize: "var(--text-xs)",
                   margin: 0,
                 }}
               >
-                No games to display.
+                {userPendingGames.length === 0 && (userGame || userEvent)
+                  ? "Waiting for this week's results…"
+                  : "Your team is on a bye this week — no game to display."}
               </p>
             )}
           </div>
@@ -1103,37 +1315,51 @@ export default function LiveGame({
                 Simulation complete. Open the week recap above for final notes.
               </p>
             )}
-            {plays.map((p) => (
-              p.isDrive ? (
+            {plays.map((p) => {
+              const isLatest = p.id === plays[plays.length - 1]?.id;
+              if (p.isDrive) {
+                return (
+                  <div
+                    key={p.id}
+                    className={`drive-summary ${p.driveType ?? ""}`}
+                    data-testid="live-play"
+                    data-play-kind="drive"
+                    style={{
+                      animation: isLatest ? "lgFadeIn 0.22s ease" : "none",
+                    }}
+                  >
+                    {p.label}
+                  </div>
+                );
+              }
+              // Classify the play so scoring / sacks / turnovers stand out without chips.
+              const lower = p.text.toLowerCase();
+              let kind = "routine";
+              if (/touchdown|field goal|safety/.test(lower)) kind = "scoring";
+              else if (/interception|fumble/.test(lower)) kind = "turnover";
+              else if (/sack/.test(lower)) kind = "sack";
+              const highlighted = kind !== "routine";
+              return (
                 <div
                   key={p.id}
-                  className={`drive-summary ${p.driveType ?? ""}`}
+                  data-testid="live-play"
+                  data-play-kind={kind}
+                  className={`lg-play lg-play--${kind}${isLatest ? " lg-play--latest" : ""}`}
                   style={{
-                    animation: p.id === plays[plays.length - 1]?.id ? "lgFadeIn 0.22s ease" : "none",
-                  }}
-                >
-                  {p.label}
-                </div>
-              ) : (
-                <div
-                  key={p.id}
-                  style={{
-                    fontSize: "var(--text-xs)",
-                    color: /touchdown|interception|fumble|sack|field goal/i.test(p.text) ? "var(--text)" : "var(--text-muted)",
-                    lineHeight: 1.45,
+                    fontSize: isLatest ? "var(--text-sm)" : "var(--text-xs)",
+                    color: highlighted || isLatest ? "var(--text)" : "var(--text-muted)",
+                    lineHeight: 1.4,
                     borderBottom: "1px solid var(--hairline)",
                     paddingBottom: "var(--space-1)",
-                    fontWeight: /touchdown|interception|fumble|field goal/i.test(p.text) ? 700 : 500,
-                    animation:
-                      p.id === plays[plays.length - 1]?.id
-                        ? "lgFadeIn 0.22s ease"
-                        : "none",
+                    fontWeight: highlighted ? 700 : isLatest ? 600 : 500,
+                    opacity: highlighted || isLatest ? 1 : 0.82,
+                    animation: isLatest ? "lgFadeIn 0.22s ease" : "none",
                   }}
                 >
                   {p.text}
                 </div>
-              )
-            ))}
+              );
+            })}
             <style>{`@keyframes lgFadeIn{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:translateY(0)}}`}</style>
             </div>
           )}

--- a/src/ui/components/PostGameScreen.jsx
+++ b/src/ui/components/PostGameScreen.jsx
@@ -247,11 +247,11 @@ function LeaderCard({ label, statLine, player, color }) {
   return (
     <div style={{
       background: "var(--surface)", border: "1px solid var(--hairline)",
-      borderRadius: 12, padding: "12px 14px",
-      display: "flex", alignItems: "center", gap: 12,
+      borderRadius: 10, padding: "8px 12px",
+      display: "flex", alignItems: "center", gap: 10,
     }}>
       <div style={{
-        width: 40, height: 40, borderRadius: "50%", flexShrink: 0,
+        width: 34, height: 34, borderRadius: "50%", flexShrink: 0,
         background: `${color}20`, border: `2px solid ${color}`,
         display: "flex", alignItems: "center", justifyContent: "center",
         fontSize: "0.68rem", fontWeight: 900, color,
@@ -321,6 +321,8 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
     .filter((l) => l?.isTouchdown || l?.turnover || /field goal|sack|interception|fumble/i.test(l?.text ?? ""))
     .slice(-5)
     .reverse();
+  // Only render the interactive Game Flow card when it has real content.
+  const hasGameFlow = Boolean(gfs) || notableMoments.length > 0;
 
   // Build leader stat lines
   const qbLine = qb
@@ -395,7 +397,7 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
 
           {/* Result banner */}
           <div style={{
-            textAlign: "center", marginBottom: 24,
+            textAlign: "center", marginBottom: 16,
             animation: "fadeSlideIn 0.4s ease-out",
           }}>
             <style>{`
@@ -404,9 +406,9 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
                 to   { opacity: 1; transform: translateY(0); }
               }
             `}</style>
-            <div style={{ fontSize: "3.5rem", lineHeight: 1, marginBottom: 10 }}>{resultEmoji}</div>
+            <div style={{ fontSize: "2.6rem", lineHeight: 1, marginBottom: 6 }}>{resultEmoji}</div>
             <div style={{
-              fontSize: "2rem", fontWeight: 900, letterSpacing: "2px",
+              fontSize: "1.7rem", fontWeight: 900, letterSpacing: "2px",
               color: resultColor, marginBottom: 4,
             }}>
               {resultLabel}
@@ -443,8 +445,8 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
             background: "var(--surface)",
             border: "1.5px solid var(--hairline)",
             borderRadius: 16,
-            padding: "20px 24px",
-            marginBottom: 16,
+            padding: "14px 18px",
+            marginBottom: 12,
           }}>
             <div style={{
               display: "flex", alignItems: "center", justifyContent: "space-between",
@@ -500,14 +502,23 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
                 </div>
               </div>
             </div>
-            <div style={{ marginTop: 10, display: "flex", justifyContent: "center" }}>
+            <div style={{ marginTop: 12, display: "flex", justifyContent: "center" }}>
               <button
-                className="btn-link"
                 type="button"
                 data-testid="box-score-trigger"
                 onClick={() => boxScoreGameId && onOpenBoxScore?.(boxScoreGameId)}
                 disabled={!boxScoreGameId}
-                style={{ cursor: boxScoreGameId ? "pointer" : "not-allowed", fontWeight: 700 }}
+                style={{
+                  cursor: boxScoreGameId ? "pointer" : "not-allowed",
+                  fontWeight: 800,
+                  fontSize: "0.8rem",
+                  padding: "8px 20px",
+                  borderRadius: 999,
+                  border: `1px solid ${boxScoreGameId ? "var(--accent)" : "var(--hairline)"}`,
+                  background: boxScoreGameId ? "var(--accent-muted)" : "transparent",
+                  color: boxScoreGameId ? "var(--accent)" : "var(--text-subtle)",
+                  minHeight: "var(--mobile-btn-h-compact, 38px)",
+                }}
               >
                 {boxScoreGameId ? "View Box Score ›" : "Box score unavailable"}
               </button>
@@ -536,6 +547,21 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
             </div>
           )}
 
+          {/* Game Flow — hide the toggle card entirely when there's nothing to show,
+              and surface a compact, useful empty state instead of dead space. */}
+          {!hasGameFlow ? (
+            <div
+              data-testid="postgame-flow-empty"
+              style={{
+                marginBottom: 12, background: "var(--surface)", border: "1px solid var(--hairline)",
+                borderRadius: 12, padding: "10px 12px", fontSize: "0.74rem", color: "var(--text-muted)",
+                display: "flex", alignItems: "center", gap: 8,
+              }}
+            >
+              <strong style={{ fontSize: "0.78rem", color: "var(--text)" }}>Game Flow</strong>
+              <span style={{ color: "var(--text-subtle)" }}>· Open the box score for the full drive chart.</span>
+            </div>
+          ) : (
           <div style={{ marginBottom: 12, background: "var(--surface)", border: "1px solid var(--hairline)", borderRadius: 12, padding: 12 }}>
             <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
               <strong style={{ fontSize: "0.8rem" }}>Game Flow</strong>
@@ -545,9 +571,11 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
                     {showReplay ? "Hide Replay" : "Replay"}
                   </button>
                 )}
-                <button className="btn" style={{ padding: "6px 10px", fontSize: "0.72rem" }} onClick={() => setShowDetails((v) => !v)} data-testid="postgame-flow-toggle">
-                  {showDetails ? "Hide" : "Key moments"}
-                </button>
+                {notableMoments.length > 0 && (
+                  <button className="btn" style={{ padding: "6px 10px", fontSize: "0.72rem" }} onClick={() => setShowDetails((v) => !v)} data-testid="postgame-flow-toggle">
+                    {showDetails ? "Hide" : "Key moments"}
+                  </button>
+                )}
               </div>
             </div>
             {showReplay && gfs && (
@@ -581,6 +609,7 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
               </div>
             )}
           </div>
+          )}
 
           {/* ── Tab switcher (Leaders / Grades) ── */}
           {(showLeaders || logs.length > 0) && (
@@ -609,8 +638,8 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
 
           {/* ── Game Leaders ── */}
           {activeTab === "leaders" && showLeaders && (
-            <div style={{ marginBottom: 16 }}>
-              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <div style={{ marginBottom: 12 }}>
+              <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
                 {qb && qbLine && (
                   <LeaderCard label="Passing" statLine={qbLine} player={qb} color="#FF9F0A" />
                 )}

--- a/src/ui/components/__tests__/ActivityToastStack.test.jsx
+++ b/src/ui/components/__tests__/ActivityToastStack.test.jsx
@@ -1,0 +1,55 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import ActivityToastStack from '../ActivityToastStack.jsx';
+
+describe('ActivityToastStack (compact activity strip)', () => {
+  afterEach(() => cleanup());
+
+  it('renders roster and simulation messages in a single compact stack', () => {
+    render(
+      <ActivityToastStack
+        messages={[
+          { id: 'sim', text: 'Simulating week — resolving games…', tone: 'info' },
+          { id: 'inj', text: '2 players on the injury report', tone: 'warning' },
+          { id: 'lineup', text: 'Lineup is valid. Opening depth chart.', tone: 'ok' },
+        ]}
+      />,
+    );
+
+    const stack = screen.getByTestId('activity-toast-stack');
+    const toasts = within(stack).getAllByTestId('activity-toast');
+    expect(toasts).toHaveLength(3);
+    expect(stack.textContent).toMatch(/Simulating week/);
+    expect(stack.textContent).toMatch(/injury report/);
+    expect(stack.textContent).toMatch(/Lineup is valid/);
+  });
+
+  it('renders nothing when there are no messages', () => {
+    const { container } = render(<ActivityToastStack messages={[]} />);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId('activity-toast-stack')).toBeNull();
+  });
+
+  it('ignores blank/invalid messages and caps the number shown', () => {
+    render(
+      <ActivityToastStack
+        max={2}
+        messages={[
+          null,
+          { id: 'a', text: '   ' },
+          { id: 'b', text: 'First' },
+          { id: 'c', text: 'Second' },
+          { id: 'd', text: 'Third' },
+        ]}
+      />,
+    );
+    const toasts = screen.getAllByTestId('activity-toast');
+    expect(toasts).toHaveLength(2);
+    const stack = screen.getByTestId('activity-toast-stack');
+    expect(stack.textContent).toMatch(/Second/);
+    expect(stack.textContent).toMatch(/Third/);
+    expect(stack.textContent).not.toMatch(/First/);
+  });
+});

--- a/src/ui/components/__tests__/FranchiseHQMobileShell.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQMobileShell.test.jsx
@@ -1,0 +1,73 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import FranchiseHQ from '../FranchiseHQ.jsx';
+
+const baseLeague = {
+  year: 2026,
+  week: 10,
+  seasonId: 's10',
+  phase: 'regular',
+  userTeamId: 10,
+  ownerApproval: 58,
+  teams: [
+    {
+      id: 10, city: 'Chicago', name: 'Bears', abbr: 'CHI', conf: 1, div: 0,
+      wins: 6, losses: 3, ties: 0, ovr: 84, offenseRating: 82, defenseRating: 83,
+      capRoom: 7,
+      roster: [
+        { id: 1, pos: 'QB', ovr: 88 },
+        { id: 2, pos: 'RB', ovr: 80, injuryWeeksRemaining: 2 },
+      ],
+      recentResults: ['W', 'W', 'L', 'W'],
+    },
+    { id: 11, city: 'Detroit', name: 'Lions', abbr: 'DET', conf: 1, div: 0, wins: 5, losses: 4, ties: 0, ovr: 83, offenseRating: 86, defenseRating: 80, capRoom: 11, roster: [] },
+  ],
+  schedule: {
+    weeks: [
+      { week: 9, games: [{ id: 'g-9', home: { id: 11, abbr: 'DET' }, away: { id: 10, abbr: 'CHI' }, homeId: 11, awayId: 10, homeAbbr: 'DET', awayAbbr: 'CHI', homeScore: 20, awayScore: 23, played: true }] },
+      { week: 10, games: [{ id: 'g-10', home: { id: 10, abbr: 'CHI' }, away: { id: 11, abbr: 'DET' }, played: false }] },
+    ],
+  },
+  gameById: {
+    'g-9': { id: 'g-9', home: 11, away: 10, homeId: 11, awayId: 10, week: 9, played: true, homeScore: 20, awayScore: 23 },
+  },
+  incomingTradeOffers: [],
+  newsItems: [{ id: 'n1', teamId: 10, headline: 'Starter upgraded to probable status.' }],
+};
+
+describe('FranchiseHQ — mobile shell & safe-area layout', () => {
+  afterEach(() => cleanup());
+
+  it('keeps the primary Advance Week control outside the bottom nav so the nav cannot obscure it', () => {
+    render(<FranchiseHQ league={baseLeague} onNavigate={() => {}} onAdvanceWeek={() => {}} busy={false} simulating={false} />);
+
+    const advance = screen.getByTestId('advance-week-cta');
+    expect(advance).toBeTruthy();
+
+    // The advance CTA lives in its own sticky footer container...
+    const stickyFooter = document.querySelector('.app-hq-sticky-advance');
+    expect(stickyFooter).toBeTruthy();
+    expect(stickyFooter.contains(advance)).toBe(true);
+
+    // ...which is a separate element from the bottom navigation bar.
+    const bottomNav = document.querySelector('.app-hq-bottom-nav');
+    expect(bottomNav).toBeTruthy();
+    expect(bottomNav.contains(advance)).toBe(false);
+  });
+
+  it('exposes exactly one primary Advance Week action', () => {
+    render(<FranchiseHQ league={baseLeague} onNavigate={() => {}} onAdvanceWeek={() => {}} busy={false} simulating={false} />);
+    expect(screen.getAllByRole('button', { name: /advance week/i })).toHaveLength(1);
+  });
+
+  it('collapses roster/simulation notices into the compact activity strip while simulating', () => {
+    render(<FranchiseHQ league={baseLeague} onNavigate={() => {}} onAdvanceWeek={() => {}} busy={false} simulating={true} />);
+    const strip = screen.getByTestId('activity-toast-stack');
+    expect(strip).toBeTruthy();
+    // Simulation + roster (injury) notices are surfaced compactly.
+    expect(strip.textContent).toMatch(/Simulating week/);
+    expect(strip.textContent).toMatch(/injury report/);
+  });
+});

--- a/src/ui/components/__tests__/LiveGameMobilePolish.test.jsx
+++ b/src/ui/components/__tests__/LiveGameMobilePolish.test.jsx
@@ -1,0 +1,154 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import LiveGame from '../LiveGame.jsx';
+
+// LiveGame only becomes visible when a simulation starts. To exercise the
+// finished/results state we render with simulating=true first, then re-render
+// with simulating=false — mirroring the real advance-week flow.
+function renderFinished(props) {
+  const view = render(<LiveGame simulating simProgress={10} {...props} />);
+  view.rerender(<LiveGame simulating={false} simProgress={100} {...props} />);
+  return view;
+}
+
+const USER_ID = 10;
+const OPP_ID = 11;
+
+const baseTeams = [
+  { id: USER_ID, abbr: 'CHI', name: 'Bears' },
+  { id: OPP_ID, abbr: 'DET', name: 'Lions' },
+  { id: 12, abbr: 'GB', name: 'Packers' },
+  { id: 13, abbr: 'MIN', name: 'Vikings' },
+];
+
+function leagueWith(weekGames) {
+  return {
+    week: 9,
+    seasonId: 's9',
+    userTeamId: USER_ID,
+    teams: baseTeams,
+    schedule: { weeks: [{ week: 9, games: weekGames }] },
+  };
+}
+
+describe('LiveGame — week results integrity', () => {
+  afterEach(() => cleanup());
+
+  it('renders the resolved user game when game results are available', () => {
+    const league = leagueWith([
+      { home: USER_ID, away: OPP_ID },
+      { home: 12, away: 13 },
+    ]);
+    const userEvent = { gameId: 's9_w9_10_11', homeId: USER_ID, awayId: OPP_ID, homeAbbr: 'CHI', awayAbbr: 'DET', homeScore: 27, awayScore: 17 };
+    renderFinished({
+      league,
+      gameEvents: [userEvent],
+      lastResults: [{ homeId: USER_ID, awayId: OPP_ID, homeName: 'Bears', awayName: 'Lions', homeScore: 27, awayScore: 17 }],
+      simulatedWeek: 9,
+    });
+
+    // The final card surfaces the user's result.
+    expect(screen.getByTestId('live-final-card')).toBeTruthy();
+    expect(screen.queryByTestId('live-scoreboard-empty')).toBeNull();
+    expect(document.body.textContent).toMatch(/27/);
+    expect(document.body.textContent).toMatch(/17/);
+  });
+
+  it('does NOT show "No games to display" when other games have resolved but the user has none', () => {
+    // User is on a bye (no user game in the schedule) but the league has results.
+    const league = leagueWith([{ home: 12, away: 13 }]);
+    const otherEvent = { gameId: 's9_w9_12_13', homeId: 12, awayId: 13, homeAbbr: 'GB', awayAbbr: 'MIN', homeScore: 21, awayScore: 14 };
+    renderFinished({
+      league,
+      gameEvents: [otherEvent],
+      lastResults: [{ homeId: 12, awayId: 13, homeName: 'Packers', awayName: 'Vikings', homeScore: 21, awayScore: 14 }],
+      simulatedWeek: 9,
+    });
+
+    expect(document.body.textContent).not.toMatch(/No games to display/);
+    // The completed game is surfaced instead of an empty panel.
+    expect(document.body.textContent).toMatch(/GB|MIN/);
+  });
+
+  it('shows a compact partial-results warning when resolved games are fewer than total', () => {
+    const league = leagueWith([
+      { home: 12, away: 13 },
+      { home: USER_ID, away: OPP_ID },
+    ]);
+    const otherEvent = { gameId: 's9_w9_12_13', homeId: 12, awayId: 13, homeAbbr: 'GB', awayAbbr: 'MIN', homeScore: 21, awayScore: 14 };
+    renderFinished({
+      league,
+      gameEvents: [otherEvent], // 1 resolved of 2 scheduled
+      lastResults: [{ homeId: 12, awayId: 13, homeName: 'Packers', awayName: 'Vikings', homeScore: 21, awayScore: 14 }],
+      simulatedWeek: 9,
+    });
+
+    const warning = screen.getByTestId('live-partial-results');
+    expect(warning).toBeTruthy();
+    expect(warning.textContent).toMatch(/still finishing/i);
+  });
+});
+
+describe('LiveGame — final state presentation', () => {
+  afterEach(() => cleanup());
+
+  it('renders a FINAL badge, the final score, winner emphasis and a box-score action', () => {
+    const onOpenBoxScore = vi.fn();
+    const league = leagueWith([{ home: USER_ID, away: OPP_ID }]);
+    const userEvent = { gameId: 'game-abc', homeId: USER_ID, awayId: OPP_ID, homeAbbr: 'CHI', awayAbbr: 'DET', homeScore: 30, awayScore: 13 };
+    renderFinished({
+      league,
+      gameEvents: [userEvent],
+      lastResults: [{ homeId: USER_ID, awayId: OPP_ID, homeName: 'Bears', awayName: 'Lions', homeScore: 30, awayScore: 13 }],
+      simulatedWeek: 9,
+      onOpenBoxScore,
+    });
+
+    const card = screen.getByTestId('live-final-card');
+    expect(card.textContent).toMatch(/FINAL/);
+    expect(card.textContent).toMatch(/30/);
+    expect(card.textContent).toMatch(/13/);
+    // Winner emphasis: the home team won and is marked as winner.
+    expect(card.querySelector('.is-winner')).toBeTruthy();
+
+    const cta = within(card).getByTestId('live-final-boxscore');
+    fireEvent.click(cta);
+    expect(onOpenBoxScore).toHaveBeenCalledWith('game-abc');
+  });
+});
+
+describe('LiveGame — play feed highlighting', () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('highlights scoring plays distinctly while simulating', () => {
+    vi.useFakeTimers();
+    const league = leagueWith([{ home: USER_ID, away: OPP_ID }]);
+    render(<LiveGame simulating simProgress={20} league={league} gameEvents={[]} lastResults={[]} simulatedWeek={9} />);
+
+    // Drive the synthetic play ticker enough to produce a scoring play.
+    act(() => { vi.advanceTimersByTime(700 * 12); });
+
+    const plays = screen.getAllByTestId('live-play');
+    expect(plays.length).toBeGreaterThan(0);
+    const scoring = plays.filter((el) => el.getAttribute('data-play-kind') === 'scoring');
+    expect(scoring.length).toBeGreaterThan(0);
+  });
+});
+
+describe('LiveGame — resilience', () => {
+  afterEach(() => cleanup());
+
+  it('handles a missing/empty play log and no game data without crashing', () => {
+    const league = { week: 9, seasonId: 's9', userTeamId: USER_ID, teams: baseTeams, schedule: { weeks: [] } };
+    expect(() =>
+      renderFinished({ league, gameEvents: [], lastResults: [], simulatedWeek: 9 }),
+    ).not.toThrow();
+    // Empty state is shown rather than a crash or a contradictory message.
+    expect(screen.queryByTestId('live-scoreboard-empty')).toBeTruthy();
+  });
+});

--- a/src/ui/components/__tests__/PostGameMobilePolish.test.jsx
+++ b/src/ui/components/__tests__/PostGameMobilePolish.test.jsx
@@ -1,0 +1,70 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import PostGameScreen from '../PostGameScreen.jsx';
+
+const baseProps = {
+  homeTeam: { id: 1, abbr: 'HME', name: 'Home' },
+  awayTeam: { id: 2, abbr: 'AWY', name: 'Away' },
+  homeScore: 24,
+  awayScore: 20,
+  userTeamId: 1,
+  onContinue: () => {},
+};
+
+describe('PostGameScreen — Game Flow empty state', () => {
+  afterEach(() => cleanup());
+
+  it('hides the interactive Game Flow card and shows a compact empty state when no flow data exists', async () => {
+    await act(async () => {
+      render(<PostGameScreen {...baseProps} logs={[]} />);
+    });
+
+    // The empty, useful state is shown...
+    expect(screen.queryByTestId('postgame-flow-empty')).toBeTruthy();
+    // ...and the interactive moments toggle / list are not rendered.
+    expect(screen.queryByTestId('postgame-flow-toggle')).toBeNull();
+    expect(screen.queryByTestId('postgame-flow-moments')).toBeNull();
+  });
+
+  it('renders the interactive Game Flow card when notable moments exist', async () => {
+    const logs = [
+      { teamId: 1, player: { id: 30, name: 'RB', pos: 'RB' }, rushYds: 4, type: 'run', isTouchdown: true, quarter: 2, text: 'RB rushes for a touchdown' },
+    ];
+    await act(async () => {
+      render(<PostGameScreen {...baseProps} logs={logs} boxScoreGameId="g1" week={4} />);
+    });
+
+    expect(screen.queryByTestId('postgame-flow-empty')).toBeNull();
+    expect(screen.queryByTestId('postgame-flow-toggle')).toBeTruthy();
+  });
+});
+
+describe('PostGameScreen — compact leaders with partial data', () => {
+  afterEach(() => cleanup());
+
+  it('renders available leaders compactly and omits missing ones without crashing', async () => {
+    // Only a passing leader is derivable from these logs.
+    const logs = [
+      { teamId: 1, passer: { id: 10, name: 'Home QB', pos: 'QB' }, passYds: 240, completed: true },
+      { teamId: 1, passer: { id: 10, name: 'Home QB', pos: 'QB' }, passYds: 18, completed: true, isTouchdown: true, tdType: 'pass' },
+    ];
+
+    let container;
+    await act(async () => {
+      ({ container } = render(
+        <PostGameScreen {...baseProps} logs={logs} boxScoreGameId="g2" week={5} />,
+      ));
+    });
+
+    // Passing leader renders.
+    expect(container.textContent).toMatch(/Passing/);
+    expect(container.textContent).toMatch(/Home QB/);
+    // No receiving/rushing leader fabricated from the partial data.
+    expect(container.textContent).not.toMatch(/Receiving/);
+    expect(container.textContent).not.toMatch(/Rushing/);
+    // Box score affordance is present and points at the game.
+    expect(screen.getByTestId('box-score-trigger')).toBeTruthy();
+  });
+});

--- a/src/ui/styles/base.css
+++ b/src/ui/styles/base.css
@@ -114,6 +114,24 @@
   --modal-bg: rgba(10, 12, 16, 0.95);
   --modal-backdrop: rgba(0, 0, 0, 0.7);
 
+  /* ── Mobile UX tokens (compact, sports-native, safe-area aware) ──────────
+     Used by HQ, live game and postgame screens to keep mobile spacing tight
+     and to keep primary controls clear of iOS Safari / PWA chrome.          */
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-top: env(safe-area-inset-top, 0px);
+  --mobile-card-pad-x: 14px;
+  --mobile-card-pad-y: 12px;
+  --mobile-btn-h: 44px;
+  --mobile-btn-h-compact: 38px;
+  /* Height reserved for the in-app bottom nav so sticky footers clear it. */
+  --bottom-nav-h: 64px;
+  --sticky-footer-gap: calc(var(--bottom-nav-h) + var(--safe-bottom) + 8px);
+  /* Mobile type scale (slightly tighter than desktop). */
+  --m-text-xs: 0.72rem;
+  --m-text-sm: 0.82rem;
+  --m-text-base: 0.9rem;
+  --m-text-lg: 1.05rem;
+
   /* shadcn/ui CSS variable mappings */
   --background: 222 47% 6%;
   --foreground: 213 31% 91%;

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -1259,3 +1259,111 @@ details[open] .app-hq-background-section__summary span { transform: rotate(180de
 .profile-tab-row::-webkit-scrollbar, .roster-tab-row::-webkit-scrollbar { display: none; }
 .profile-tab-row .standings-tab.active, .roster-tab-row .standings-tab.active { color: var(--accent); font-weight: 700; border-bottom: 2px solid var(--accent); }
 .profile-tab-row .standings-tab:not(.active), .roster-tab-row .standings-tab:not(.active) { color: var(--text-muted); border-bottom: 2px solid transparent; }
+
+/* ── Live Game gamecast primitives (LiveGame.jsx) ───────────────────────────
+   Compact, broadcast-style polish for the week-advance simulation panel.     */
+.lg-scorebug {
+  position: sticky;
+  top: 0;
+  z-index: 4;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 8px var(--mobile-card-pad-x, var(--space-4));
+  background: linear-gradient(180deg, var(--surface-strong), var(--surface));
+  border-bottom: 1px solid var(--hairline-strong);
+  box-shadow: var(--shadow-sm);
+}
+.lg-scorebug__team { display: flex; align-items: center; gap: 8px; min-width: 0; }
+.lg-scorebug__team:last-child { justify-content: flex-end; }
+.lg-scorebug__team.has-ball .lg-scorebug__abbr::after {
+  content: "•"; margin-left: 4px; color: var(--warning);
+}
+.lg-scorebug__abbr { font-weight: 800; font-size: var(--text-sm); letter-spacing: -0.3px; }
+.lg-scorebug__score { font-weight: 900; font-size: var(--text-xl); color: var(--text); font-variant-numeric: tabular-nums; }
+.lg-scorebug__center { display: grid; justify-items: center; gap: 2px; text-align: center; }
+.lg-scorebug__clock { font-weight: 800; font-size: var(--text-xs); color: var(--text); }
+.lg-scorebug__poss { font-size: 10px; color: var(--text-subtle); text-transform: uppercase; letter-spacing: .04em; white-space: nowrap; }
+
+.lg-final-card {
+  border: 1.5px solid var(--hairline-strong);
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+  margin-bottom: var(--space-3);
+  background: linear-gradient(160deg, rgba(255,255,255,0.05), rgba(255,255,255,0.015));
+  text-align: center;
+}
+.lg-final-card__badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  border: 1px solid var(--hairline-strong);
+  border-radius: var(--radius-pill);
+  padding: 2px 12px;
+  margin-bottom: 8px;
+}
+.lg-final-card__score { display: flex; align-items: center; justify-content: center; gap: 12px; }
+.lg-final-card__team { display: flex; align-items: center; gap: 8px; opacity: 0.66; }
+.lg-final-card__team.is-winner { opacity: 1; }
+.lg-final-card__abbr { font-weight: 800; font-size: var(--text-md); color: var(--text); }
+.lg-final-card__pts { font-weight: 900; font-size: 1.8rem; color: var(--text); font-variant-numeric: tabular-nums; line-height: 1; }
+.lg-final-card__sep { color: var(--text-subtle); font-weight: 700; }
+.lg-final-card__recap { margin-top: 8px; font-size: var(--text-xs); color: var(--text-muted); font-style: italic; }
+.lg-final-card__cta {
+  margin-top: 10px;
+  min-height: var(--mobile-btn-h, 40px);
+  padding: 0 18px;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+  color: #fff;
+  font-weight: 800;
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+.lg-final-card__cta:hover { background: var(--accent-hover); }
+
+.lg-key-moments { margin-bottom: var(--space-3); }
+.lg-key-moments__label { font-size: 10px; font-weight: 800; text-transform: uppercase; letter-spacing: .08em; color: var(--text-subtle); margin-bottom: 5px; }
+.lg-key-moments__list { display: flex; flex-wrap: wrap; gap: 5px; }
+.lg-key-moments__item {
+  font-size: 11px;
+  font-weight: 600;
+  border-radius: var(--radius-pill);
+  padding: 3px 9px;
+  background: var(--surface-strong);
+  border: 1px solid var(--hairline);
+  color: var(--text-muted);
+}
+.lg-key-moments__item--score { border-color: rgba(52,199,89,.4); color: #8fe6ab; }
+
+.lg-play--scoring { color: var(--text); }
+.lg-play--turnover { border-left: 2px solid var(--danger); padding-left: 6px; }
+.lg-play--sack { border-left: 2px solid var(--warning); padding-left: 6px; }
+.lg-play--latest { background: rgba(124,196,255,.07); border-radius: 6px; padding-left: 6px; }
+
+/* ── Activity toast stack (ActivityToastStack.jsx) ──────────────────────────
+   Compact replacement for stacked full-width alert cards on mobile HQ.        */
+.activity-toast-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 4px 12px 6px;
+}
+.activity-toast {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  font-size: var(--m-text-xs, 0.72rem);
+  color: var(--text-muted);
+  background: var(--surface-strong);
+  border: 1px solid var(--hairline);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-sm);
+}
+.activity-toast__dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+.activity-toast__text { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }


### PR DESCRIPTION
Polish the core mobile loop (advance week → week results → live sim →
postgame) without touching any gameplay systems.

Critical bug: the live/week-results panel could show "Week complete",
"Games resolved: 15 / 16" and "No games to display" at the same time —
the header counted all resolved games while the scoreboard only rendered
the user's game. Now completed games are always surfaced, a compact
partial-results warning shows when resolved < scheduled, and the empty
state only renders when no completed game data exists.

Live game (LiveGame.jsx): add sticky MobileScorebug, prominent LiveFinalCard
(FINAL badge, winner emphasis, View Box Score), KeyMomentsStrip, and a
classified play feed (scoring/sack/turnover/latest) instead of a flat log.

Postgame (PostGameScreen.jsx): tighten the top score card and box-score
affordance, compact leader cards, and hide the empty Game Flow card behind
a useful compact empty state.

HQ (FranchiseHQ.jsx): collapse roster/simulation notices into a new reusable
ActivityToastStack compact strip.

Mobile shell: add CSS tokens for card padding, compact button height,
safe-area insets, sticky-footer gap, and a mobile type scale.

Tests: 15 new UI smoke/regression tests across the four touched screens.
Full suite (4834 tests) passes; production build succeeds. No simulation,
awards, trade, free-agency, waiver, draft, playoff, or save-schema changes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012W45FHN6j6zqiW3mWKBzca