### PR TITLE
fix(stability): Roster Hub crash + League Stats zeros, with regression tests

### DIFF
--- a/src/db/__tests__/cacheHydrateSeasonStats.test.js
+++ b/src/db/__tests__/cacheHydrateSeasonStats.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { cache } from '../cache.js';
+
+/**
+ * Regression for the persisted save/load League-Stats path (PR #1626 review).
+ *
+ * hydrate() clears _seasonStats and only restores meta/teams/players/draftPicks.
+ * cache.hydrateSeasonStats() backfills the persisted current-season rows so
+ * view-model consumers see real totals after a reload instead of zero leaders.
+ */
+describe('cache.hydrateSeasonStats', () => {
+  beforeEach(() => {
+    cache.reset();
+    cache.hydrate({
+      meta: { id: 'L1', currentSeasonId: 2026 },
+      teams: [{ id: 1, wins: 1 }],
+      players: [{ id: 'qb1', teamId: 1 }],
+      draftPicks: [],
+    });
+  });
+
+  it('starts empty after hydrate (the bug precondition)', () => {
+    expect(cache.getSeasonStat('qb1')).toBeNull();
+    expect(cache.getAllSeasonStats()).toHaveLength(0);
+  });
+
+  it('restores persisted DB rows so totals are readable again', () => {
+    cache.hydrateSeasonStats([
+      { playerId: 'qb1', teamId: 1, seasonId: 2026, totals: { passYd: 305, passTD: 3, gamesPlayed: 1 } },
+    ]);
+    const entry = cache.getSeasonStat('qb1');
+    expect(entry).toBeTruthy();
+    expect(entry.totals.passYd).toBe(305);
+    expect(entry.teamId).toBe(1);
+  });
+
+  it('looks up restored rows by string OR numeric id', () => {
+    cache.hydrateSeasonStats([{ playerId: 7, totals: { rushYd: 88 } }]);
+    expect(cache.getSeasonStat(7).totals.rushYd).toBe(88);
+    expect(cache.getSeasonStat('7').totals.rushYd).toBe(88);
+  });
+
+  it('does not clobber a fresher in-memory entry', () => {
+    cache.updateSeasonStat('qb1', 1, { passYd: 400 }); // live, freshest
+    cache.hydrateSeasonStats([{ playerId: 'qb1', totals: { passYd: 1 } }]);
+    expect(cache.getSeasonStat('qb1').totals.passYd).toBe(400);
+  });
+
+  it('does not mark restored rows dirty (data came from the DB)', () => {
+    cache.hydrateSeasonStats([{ playerId: 'qb1', totals: { passYd: 100 } }]);
+    expect(cache.isDirty()).toBe(false);
+  });
+
+  it('tolerates malformed input without throwing', () => {
+    expect(() => cache.hydrateSeasonStats(null)).not.toThrow();
+    expect(() => cache.hydrateSeasonStats([null, undefined, {}, 42])).not.toThrow();
+    expect(cache.getAllSeasonStats()).toHaveLength(0);
+  });
+});

--- a/src/db/cache.js
+++ b/src/db/cache.js
@@ -213,6 +213,30 @@ export const cache = {
     }
     _dirty.seasonStats.add(playerId);
   },
+  /**
+   * Restore persisted current-season stat rows from the DB on load.
+   *
+   * hydrate() clears _seasonStats, and the load pipeline only restores
+   * meta/teams/players/draftPicks — so after a reload the accumulators are
+   * empty until something backfills them. Without this, any consumer that reads
+   * live totals (e.g. the League Stats view model) shows zero leaders for a
+   * save that already has recorded games. Does NOT mark anything dirty (the
+   * data came straight from the DB) and never clobbers a fresher live entry.
+   */
+  hydrateSeasonStats: (rows = []) => {
+    if (!Array.isArray(rows)) return;
+    for (const row of rows) {
+      if (!row || row.playerId == null) continue;
+      const key = String(row.playerId);
+      if (_seasonStats.has(key)) continue; // prefer in-memory (freshest)
+      _seasonStats.set(key, {
+        seasonId: row.seasonId ?? _meta?.currentSeasonId,
+        playerId: key,
+        teamId: row.teamId,
+        totals: (row.totals && typeof row.totals === 'object') ? row.totals : {},
+      });
+    }
+  },
 
   // --- Draft picks ---
 

--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -55,6 +55,7 @@ import { buildFreeAgencyProfileContext } from "../utils/playerProfileContext.js"
 import { buildContractOfferInsight, toneToContractInsightColor } from "../utils/contractOfferInsights.js";
 import { evaluatePendingOfferCapReservation } from "../../core/pendingOfferCapModel.js";
 import { buildShowingLabel, stableSortRows } from "../utils/dataBrowser.js";
+import { resolveFreeAgencyLoadStatus } from "../utils/freeAgencyLoadStatus.js";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -871,6 +872,7 @@ export default function FreeAgency({
 }) {
   const [faState, setFaState] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(null);
 
   // Filters
   const [posFilter, setPosFilter] = useState("ALL");
@@ -909,16 +911,25 @@ export default function FreeAgency({
     if (loadCountRef.current === 0) setLoading(true);
     loadCountRef.current += 1;
 
-    actions
-      .getFreeAgents()
+    setLoadError(null);
+
+    Promise.resolve(actions?.getFreeAgents?.())
       .then((res) => {
         if (!active) return;
-        setFaState(res.payload);
+        // Treat a missing/empty response shape as an honest load failure rather
+        // than silently rendering a misleading "no players match" empty state.
+        if (!res || typeof res !== "object" || res.payload == null) {
+          setFaState({ freeAgents: [] });
+          setLoadError("Free agent data was unavailable.");
+        } else {
+          setFaState(res.payload);
+        }
         setLoading(false);
       })
       .catch((err) => {
         if (!active) return;
         console.error("FA load error:", err);
+        setLoadError(err?.message || "Failed to load free agents.");
         setLoading(false);
       });
 
@@ -1021,6 +1032,23 @@ export default function FreeAgency({
   const archetypeOptions = useMemo(
     () => Array.from(new Set(evaluatedFaPool.map((p) => p?._eval?.archetype?.archetype).filter(Boolean))).slice(0, 24),
     [evaluatedFaPool],
+  );
+
+  // Honest load/empty status for the main table card. Distinguishes:
+  //  - loading        → fetch in flight
+  //  - error          → fetch failed / response unavailable
+  //  - unavailable    → no FA window this phase (loaded but pool is empty here)
+  //  - empty          → FA pool genuinely has no players
+  //  - ready          → players exist (filtered-empty handled inline in the table)
+  // resolveFreeAgencyLoadStatus is exported for unit testing each state.
+  const loadStatus = useMemo(
+    () => resolveFreeAgencyLoadStatus({
+      loading,
+      error: loadError,
+      faState,
+      poolCount: evaluatedFaPool.length,
+    }),
+    [loading, loadError, faState, evaluatedFaPool.length],
   );
 
 
@@ -1529,15 +1557,19 @@ export default function FreeAgency({
 
       {/* Main Table Card */}
       <Card className="card-premium" style={{ padding: 0, overflow: "hidden" }}>
-        {loading ? (
+        {loadStatus.state !== "ready" ? (
           <div
+            role={loadStatus.state === "error" ? "alert" : "status"}
+            data-testid="fa-load-status"
+            data-state={loadStatus.state}
             style={{
               padding: "var(--space-10)",
               textAlign: "center",
-              color: "var(--text-muted)",
+              color: loadStatus.state === "error" ? "var(--danger)" : "var(--text-muted)",
             }}
           >
-            Loading Free Agents...
+            <div style={{ fontWeight: 700, marginBottom: 4 }}>{loadStatus.title}</div>
+            <div style={{ fontSize: "var(--text-sm)" }}>{loadStatus.body}</div>
           </div>
         ) : (
           <div>

--- a/src/ui/components/PlayerCardGrid.jsx
+++ b/src/ui/components/PlayerCardGrid.jsx
@@ -15,6 +15,7 @@
 
 import React, { useState, useMemo } from "react";
 import { derivePlayerContractFinancials, formatContractMoney } from "../utils/contractFormatting.js";
+import { toPlayerId, toEntityKey } from "../utils/entityId.js";
 import FaceAvatar from "./FaceAvatar.jsx";
 
 // ── Colour maps ────────────────────────────────────────────────────────────────
@@ -52,7 +53,9 @@ function getAttrValue(player, key) {
   if (src[key] != null) return Math.round(src[key]);
   // Deterministic fallback using OVR + key seed so cards look consistent
   const ovr  = player.ovr ?? 70;
-  const base = (player.id ?? "x").split("").reduce((h, c) => h * 31 + c.charCodeAt(0), 0) & 0xffff;
+  // toPlayerId guarantees a string — player.id may be numeric/missing/object,
+  // and calling .split() on a raw numeric id throws "split is not a function".
+  const base = toPlayerId(player, "x").split("").reduce((h, c) => h * 31 + c.charCodeAt(0), 0) & 0xffff;
   const seed = (base + key.charCodeAt(0) * 17) & 0xffff;
   const norm = ((seed * 1664525 + 1013904223) & 0xffff) / 0xffff;
   return Math.round(Math.min(99, Math.max(40, ovr + (norm - 0.5) * 20)));
@@ -257,8 +260,16 @@ export default function PlayerCardGrid({ roster = [], onPlayerSelect }) {
   const [sortKey,   setSortKey]   = useState("ovr");
   const [sortDesc,  setSortDesc]  = useState(true);
 
+  // Normalize once: drop null/non-object rows so neither the filter-pill counts
+  // nor the grid render ever throw on malformed save data. Malformed rows are
+  // skipped (not crashed on); the rest render with fallback labels.
+  const safeRoster = useMemo(
+    () => (Array.isArray(roster) ? roster : []).filter((p) => p && typeof p === "object"),
+    [roster],
+  );
+
   const filtered = useMemo(() => {
-    let players = [...roster];
+    let players = [...safeRoster];
 
     // Position filter
     const group = POSITION_GROUPS.find(g => g.label === posFilter);
@@ -293,7 +304,7 @@ export default function PlayerCardGrid({ roster = [], onPlayerSelect }) {
     });
 
     return players;
-  }, [roster, posFilter, sortKey, sortDesc]);
+  }, [safeRoster, posFilter, sortKey, sortDesc]);
 
   function toggleSort(key) {
     if (sortKey === key) {
@@ -318,8 +329,8 @@ export default function PlayerCardGrid({ roster = [], onPlayerSelect }) {
           const isActive  = posFilter === g.label;
           const posClr    = POS_COLORS[g.label];
           const count     = g.positions
-            ? roster.filter(p => g.positions.includes(p.pos ?? p.position)).length
-            : roster.length;
+            ? safeRoster.filter(p => g.positions.includes(p.pos ?? p.position)).length
+            : safeRoster.length;
 
           return (
             <button
@@ -399,7 +410,7 @@ export default function PlayerCardGrid({ roster = [], onPlayerSelect }) {
         }}>
           {filtered.map((player, i) => (
             <div
-              key={player.id}
+              key={toEntityKey(player.id ?? player.pid, i, "player")}
               className={`stagger-${Math.min(i + 1, 8)}`}
               style={{ animationDelay: `${Math.min(i, 7) * 30}ms` }}
             >

--- a/src/ui/components/__tests__/playerCardGridIdSafety.test.jsx
+++ b/src/ui/components/__tests__/playerCardGridIdSafety.test.jsx
@@ -1,0 +1,78 @@
+/** @vitest-environment jsdom */
+/**
+ * playerCardGridIdSafety.test.jsx
+ *
+ * Regression for the Roster Hub crash:
+ *   "(e.id ?? \"x\").split is not a function"
+ *
+ * Root cause: PlayerCardGrid.getAttrValue() called .split() directly on a raw
+ * player id, which throws when the id is numeric / missing / an object — a
+ * shape that occurs in seeded fixtures and legacy saves. The grid (and the
+ * Roster Hub card view that renders it) must never crash on malformed ids; bad
+ * rows should be skipped and the rest should render with fallback labels.
+ */
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import PlayerCardGrid from "../PlayerCardGrid.jsx";
+
+// facesjs (rendered via FaceAvatar) touches IntersectionObserver, which jsdom
+// does not implement. Stub it so the grid mounts in the test environment.
+beforeEach(() => {
+  global.IntersectionObserver = vi.fn(function () {
+    return { observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() };
+  });
+});
+
+// No `ratings`/`attrs` so getAttrValue() takes the id-seeded fallback branch —
+// the exact code path that crashed.
+function barePlayer(id, name, pos = "QB") {
+  return { id, name, pos, ovr: 80, age: 25 };
+}
+
+describe("PlayerCardGrid id safety (split crash regression)", () => {
+  it("renders a numeric id without throwing", () => {
+    const roster = [barePlayer(7, "Numeric Id")];
+    expect(() => render(<PlayerCardGrid roster={roster} />)).not.toThrow();
+    expect(screen.getByText("Numeric Id")).toBeTruthy();
+  });
+
+  it("renders missing / null / object ids without throwing", () => {
+    const roster = [
+      barePlayer(undefined, "No Id"),
+      barePlayer(null, "Null Id"),
+      barePlayer({ nested: true }, "Object Id"),
+      barePlayer("base36str", "String Id"),
+      barePlayer(0, "Zero Id"),
+    ];
+    expect(() => render(<PlayerCardGrid roster={roster} />)).not.toThrow();
+    // Every well-formed row still renders (fallback labels for bad ids).
+    for (const name of ["No Id", "Null Id", "Object Id", "String Id", "Zero Id"]) {
+      expect(screen.getByText(name)).toBeTruthy();
+    }
+  });
+
+  it("skips malformed (null / non-object) rows instead of crashing", () => {
+    const roster = [barePlayer(1, "Good One"), null, undefined, 42, barePlayer(2, "Good Two")];
+    expect(() => render(<PlayerCardGrid roster={roster} />)).not.toThrow();
+    expect(screen.getByText("Good One")).toBeTruthy();
+    expect(screen.getByText("Good Two")).toBeTruthy();
+  });
+
+  it("gives missing-id rows distinct React keys (no duplicate-key warning)", () => {
+    const errors = [];
+    const original = console.error;
+    console.error = (...args) => { errors.push(args.join(" ")); };
+    try {
+      const roster = [
+        barePlayer(undefined, "No Id A"),
+        barePlayer(undefined, "No Id B"),
+        barePlayer(null, "Null Id C"),
+      ];
+      render(<PlayerCardGrid roster={roster} />);
+    } finally {
+      console.error = original;
+    }
+    expect(errors.join(" ")).not.toMatch(/same key|duplicate key/i);
+  });
+});

--- a/src/ui/components/__tests__/rosterHubIdSafety.test.jsx
+++ b/src/ui/components/__tests__/rosterHubIdSafety.test.jsx
@@ -1,0 +1,56 @@
+/** @vitest-environment jsdom */
+/**
+ * rosterHubIdSafety.test.jsx
+ *
+ * Integration regression for the Roster Hub crash
+ *   "(e.id ?? \"x\").split is not a function"
+ *
+ * Opens the real RosterHub (default "cards" view → PlayerCardGrid) with a team
+ * whose roster carries numeric / missing / object ids and a null row. The hub
+ * must render without throwing and surface the well-formed players.
+ */
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import RosterHub from "../RosterHub.jsx";
+
+beforeEach(() => {
+  global.IntersectionObserver = vi.fn(function () {
+    return { observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() };
+  });
+});
+
+function makeLeague(roster) {
+  return {
+    userTeamId: 1,
+    seasonId: 2026,
+    week: 3,
+    teams: [{ id: 1, name: "Sharks", abbr: "SHK", capRoom: 22, roster, strategies: {} }],
+  };
+}
+
+describe("RosterHub id safety (split crash regression, integration)", () => {
+  it("renders the cards view without crashing on malformed roster ids", () => {
+    const roster = [
+      { id: 7, name: "Numeric Id", pos: "QB", ovr: 82, age: 26 },
+      { id: undefined, name: "Missing Id", pos: "WR", ovr: 78, age: 24 },
+      { id: { weird: true }, name: "Object Id", pos: "RB", ovr: 80, age: 25 },
+      null, // malformed row
+      { id: "good-str", name: "String Id", pos: "TE", ovr: 75, age: 28 },
+    ];
+    expect(() =>
+      render(<RosterHub league={makeLeague(roster)} actions={{}} onPlayerSelect={() => {}} />),
+    ).not.toThrow();
+
+    expect(screen.getByText("Numeric Id")).toBeTruthy();
+    expect(screen.getByText("Missing Id")).toBeTruthy();
+    expect(screen.getByText("Object Id")).toBeTruthy();
+    expect(screen.getByText("String Id")).toBeTruthy();
+  });
+
+  it("renders an empty roster without crashing", () => {
+    expect(() =>
+      render(<RosterHub league={makeLeague([])} actions={{}} onPlayerSelect={() => {}} />),
+    ).not.toThrow();
+  });
+});

--- a/src/ui/hooks/useWorkerNavigationStability.test.js
+++ b/src/ui/hooks/useWorkerNavigationStability.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { INITIAL_WORKER_STATE, workerReducer } from "./useWorker.js";
+
+/**
+ * Navigation stability smoke test (Priority 5).
+ *
+ * "Starting game engine…" renders whenever `workerReady` is false, and the
+ * worker is spawned exactly once (useEffect with [] deps). So the engine can
+ * only "remount" if `workerReady` flips back to false. Normal navigation
+ * between HQ / Roster / Schedule / Standings / Stats only fires read requests
+ * (BUSY → STATE_UPDATE → IDLE) and busy toggles — none of which may reset
+ * `workerReady` or drop the loaded `league`.
+ *
+ * These tests pin that invariant at the reducer level (the single source of
+ * truth for the boot screen), without standing up the heavy dashboard tree.
+ */
+
+const league = {
+  activeLeagueId: "save_slot_1",
+  seasonId: 2026,
+  year: 2026,
+  week: 4,
+  phase: "regular",
+  userTeamId: 7,
+  teams: [{ id: 7, abbr: "BOS", name: "Bostons", roster: [{ id: "p1", name: "QB" }] }],
+  schedule: { weeks: [{ week: 1, games: [{ home: 7, away: 8, played: true, homeScore: 21, awayScore: 14 }] }] },
+};
+
+function readyState() {
+  return { ...INITIAL_WORKER_STATE, workerReady: true, hasSave: true, league };
+}
+
+// Simulate the dispatch sequence a single tab switch produces: a (silent) read
+// request sets BUSY, the worker replies with STATE_UPDATE, then IDLE/CLEAR_BUSY.
+function navigateOnce(state, patch = {}) {
+  let s = workerReducer(state, { type: "BUSY" });
+  s = workerReducer(s, { type: "STATE_UPDATE", payload: { ...league, ...patch }, messageType: "STATE_UPDATE" });
+  s = workerReducer(s, { type: "IDLE" });
+  return workerReducer(s, { type: "CLEAR_BUSY" });
+}
+
+describe("worker navigation stability (no engine remount / no state loss)", () => {
+  it("keeps workerReady true across a navigation request cycle", () => {
+    const next = navigateOnce(readyState());
+    expect(next.workerReady).toBe(true); // → never shows "Starting game engine…"
+    expect(next.busy).toBe(false);
+  });
+
+  it("preserves league across HQ → Roster → Schedule → Standings → Stats → Roster", () => {
+    let state = readyState();
+    for (const _tab of ["Roster", "Schedule", "Standings", "Stats", "Roster"]) {
+      state = navigateOnce(state);
+      expect(state.workerReady).toBe(true);
+      expect(state.league).toBeTruthy();
+      expect(state.league.userTeamId).toBe(7);
+      expect(state.league.teams[0].abbr).toBe("BOS");
+      expect(state.league.week).toBe(4);
+    }
+  });
+
+  it("STATE_UPDATE merges into league instead of replacing it (partial payloads keep prior fields)", () => {
+    // A read action that returns only a slice must not wipe unrelated league data.
+    const state = readyState();
+    const next = workerReducer(state, {
+      type: "STATE_UPDATE",
+      payload: { week: 5 },
+      messageType: "STATE_UPDATE",
+    });
+    expect(next.week).toBeUndefined; // sanity: week lives under league
+    expect(next.league.week).toBe(5);
+    expect(next.league.teams[0].abbr).toBe("BOS"); // preserved
+    expect(next.league.schedule.weeks[0].games[0].homeScore).toBe(21); // preserved
+    expect(next.workerReady).toBe(true);
+  });
+
+  it("busy toggles during navigation never touch workerReady or league", () => {
+    const state = readyState();
+    expect(workerReducer(state, { type: "BUSY" }).workerReady).toBe(true);
+    expect(workerReducer(state, { type: "BUSY" }).league).toBe(league);
+    expect(workerReducer(state, { type: "IDLE" }).workerReady).toBe(true);
+    expect(workerReducer(state, { type: "CLEAR_BUSY" }).league).toBe(league);
+  });
+});

--- a/src/ui/utils/entityId.js
+++ b/src/ui/utils/entityId.js
@@ -1,0 +1,79 @@
+/**
+ * entityId.js — Type-safe normalization for roster / player / team entity IDs.
+ *
+ * Background
+ * ----------
+ * Entity IDs in saved leagues are inconsistent: the live engine generates
+ * base-36 string IDs via U.id(), but seeded fixtures, legacy saves, and some
+ * worker code paths use plain numbers. UI helpers that call string methods
+ * directly on an ID (e.g. `(player.id ?? "x").split("")`) crash with
+ * "split is not a function" the moment a numeric or object ID flows through.
+ *
+ * This module is the single, defensive choke point: it coerces any ID-ish
+ * value into a safe, non-empty string before the UI touches it, and never
+ * throws on malformed/missing input.
+ */
+
+/**
+ * Coerce an arbitrary ID-ish value into a safe string.
+ *
+ * Handles: strings (trimmed), finite numbers, bigints, and objects exposing an
+ * `id`/`pid`/`tid` field. Anything else (null, undefined, NaN, empty string,
+ * functions, plain objects without an id) falls back to `fallback`.
+ *
+ * @param {unknown} value
+ * @param {string} [fallback=""]
+ * @returns {string}
+ */
+export function toEntityId(value, fallback = "") {
+  // Unwrap common nested-id object shapes ({ id }, { pid }, { tid }).
+  if (value && typeof value === "object") {
+    const nested = value.id ?? value.pid ?? value.tid;
+    if (nested != null && nested !== value) {
+      return toEntityId(nested, fallback);
+    }
+    return fallback;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : fallback;
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(value) : fallback;
+  }
+
+  if (typeof value === "bigint") {
+    return String(value);
+  }
+
+  return fallback;
+}
+
+/**
+ * Resolve a player's stable ID, checking the common id/pid aliases.
+ *
+ * @param {{ id?: unknown, pid?: unknown }} player
+ * @param {string} [fallback=""]
+ * @returns {string}
+ */
+export function toPlayerId(player, fallback = "") {
+  if (!player || typeof player !== "object") return fallback;
+  return toEntityId(player.id ?? player.pid, fallback);
+}
+
+/**
+ * Build a guaranteed-unique, safe React key for a list of entities, even when
+ * IDs are missing or duplicated. Falls back to the row index so React never
+ * receives an empty/duplicate key.
+ *
+ * @param {unknown} value   Raw id-ish value.
+ * @param {number} index    Position in the list (uniqueness backstop).
+ * @param {string} [prefix="row"]
+ * @returns {string}
+ */
+export function toEntityKey(value, index, prefix = "row") {
+  const id = toEntityId(value);
+  return id !== "" ? id : `${prefix}-${index}`;
+}

--- a/src/ui/utils/entityId.test.js
+++ b/src/ui/utils/entityId.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { toEntityId, toPlayerId, toEntityKey } from "./entityId.js";
+
+describe("toEntityId", () => {
+  it("returns trimmed non-empty strings unchanged", () => {
+    expect(toEntityId("abc")).toBe("abc");
+    expect(toEntityId("  abc  ")).toBe("abc");
+  });
+
+  it("coerces finite numbers (the .split crash vector) to strings", () => {
+    expect(toEntityId(7)).toBe("7");
+    expect(toEntityId(0)).toBe("0");
+    expect(toEntityId(-12)).toBe("-12");
+  });
+
+  it("coerces bigints to strings", () => {
+    expect(toEntityId(42n)).toBe("42");
+  });
+
+  it("falls back for missing / malformed values", () => {
+    expect(toEntityId(undefined)).toBe("");
+    expect(toEntityId(null)).toBe("");
+    expect(toEntityId("")).toBe("");
+    expect(toEntityId("   ")).toBe("");
+    expect(toEntityId(NaN)).toBe("");
+    expect(toEntityId(Infinity)).toBe("");
+    expect(toEntityId(() => {})).toBe("");
+  });
+
+  it("honors the provided fallback", () => {
+    expect(toEntityId(null, "x")).toBe("x");
+    expect(toEntityId({}, "fallback")).toBe("fallback");
+  });
+
+  it("unwraps nested id-bearing objects", () => {
+    expect(toEntityId({ id: 9 })).toBe("9");
+    expect(toEntityId({ pid: "qb1" })).toBe("qb1");
+    expect(toEntityId({ tid: 3 })).toBe("3");
+    expect(toEntityId({ name: "no id" })).toBe("");
+  });
+
+  it("always returns a string that exposes .split (regression guard)", () => {
+    for (const v of [7, 0, "abc", null, undefined, {}, NaN, 42n, { id: 5 }]) {
+      const id = toEntityId(v, "x");
+      expect(typeof id).toBe("string");
+      expect(() => id.split("")).not.toThrow();
+    }
+  });
+});
+
+describe("toPlayerId", () => {
+  it("resolves id then pid aliases", () => {
+    expect(toPlayerId({ id: 5 })).toBe("5");
+    expect(toPlayerId({ pid: "p9" })).toBe("p9");
+    expect(toPlayerId({ id: null, pid: 3 })).toBe("3");
+  });
+
+  it("falls back for malformed players", () => {
+    expect(toPlayerId(null, "x")).toBe("x");
+    expect(toPlayerId(undefined, "x")).toBe("x");
+    expect(toPlayerId({}, "x")).toBe("x");
+  });
+});
+
+describe("toEntityKey", () => {
+  it("uses the id when present", () => {
+    expect(toEntityKey(7, 0)).toBe("7");
+    expect(toEntityKey("abc", 3)).toBe("abc");
+  });
+
+  it("falls back to a unique index-based key when the id is missing", () => {
+    expect(toEntityKey(null, 4, "player")).toBe("player-4");
+    expect(toEntityKey(undefined, 2)).toBe("row-2");
+    expect(toEntityKey("", 1, "player")).toBe("player-1");
+  });
+});

--- a/src/ui/utils/freeAgencyLoadStatus.js
+++ b/src/ui/utils/freeAgencyLoadStatus.js
@@ -1,0 +1,78 @@
+/**
+ * freeAgencyLoadStatus.js — honest load/empty status for Free Agency screens.
+ *
+ * The Free Agency page must never show filters over a blank list with no
+ * explanation. This resolver classifies the current load into one explicit
+ * state so the UI can render an accurate, actionable message:
+ *
+ *   loading      → fetch in flight
+ *   error        → fetch failed or returned an unusable payload
+ *   unavailable  → loaded, but free agency is not open in this phase
+ *   empty        → free agency is open but the pool genuinely has no players
+ *   ready        → players exist (filter-level emptiness handled by the table)
+ */
+
+// Phases in which a free-agent pool is expected to be browseable.
+const FA_ACTIVE_PHASES = new Set([
+  "free_agency",
+  "offseason_resign",
+  "open",
+  "regular", // in-season street free agents
+  "regular_season",
+  "preseason",
+]);
+
+/**
+ * @param {object} args
+ * @param {boolean} args.loading       Fetch in flight.
+ * @param {string|null} [args.error]   Error message, if the load failed.
+ * @param {object|null} [args.faState] Worker payload ({ freeAgents, phase, ... }).
+ * @param {number} [args.poolCount]    Size of the evaluated (unfiltered) pool.
+ * @returns {{ state: "loading"|"error"|"unavailable"|"empty"|"ready", title: string, body: string }}
+ */
+export function resolveFreeAgencyLoadStatus({ loading, error, faState, poolCount } = {}) {
+  if (loading) {
+    return { state: "loading", title: "Loading free agents…", body: "Fetching the current market snapshot." };
+  }
+
+  if (error) {
+    return {
+      state: "error",
+      title: "Failed to load free agents",
+      body: typeof error === "string" && error.trim() ? error : "Something went wrong fetching the market. Try again.",
+    };
+  }
+
+  // No payload at all (and not loading / not an explicit error) — treat as error
+  // so the user gets an honest message rather than a silent blank list.
+  if (!faState || typeof faState !== "object") {
+    return {
+      state: "error",
+      title: "Failed to load free agents",
+      body: "Free agent data was unavailable.",
+    };
+  }
+
+  const count = Number.isFinite(poolCount)
+    ? poolCount
+    : (Array.isArray(faState.freeAgents) ? faState.freeAgents.length : 0);
+
+  if (count > 0) {
+    return { state: "ready", title: "", body: "" };
+  }
+
+  const phase = typeof faState.phase === "string" ? faState.phase : null;
+  if (phase && !FA_ACTIVE_PHASES.has(phase)) {
+    return {
+      state: "unavailable",
+      title: "Free agency unavailable during this phase",
+      body: `Free agents become available later in the season cycle (current phase: ${phase.replace(/_/g, " ")}).`,
+    };
+  }
+
+  return {
+    state: "empty",
+    title: phase === "offseason_resign" ? "No re-sign targets available" : "No free agents available",
+    body: "There are no available players in the pool right now. Check back after roster cuts or as contracts expire.",
+  };
+}

--- a/src/ui/utils/freeAgencyLoadStatus.test.js
+++ b/src/ui/utils/freeAgencyLoadStatus.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { resolveFreeAgencyLoadStatus } from "./freeAgencyLoadStatus.js";
+
+/**
+ * Free Agency load/empty state regression (Priority 4).
+ * Each branch maps to an honest, distinct message so the page never shows
+ * filters over an unexplained blank list.
+ */
+describe("resolveFreeAgencyLoadStatus", () => {
+  it("reports loading while the fetch is in flight", () => {
+    const s = resolveFreeAgencyLoadStatus({ loading: true });
+    expect(s.state).toBe("loading");
+  });
+
+  it("reports error when the load failed", () => {
+    const s = resolveFreeAgencyLoadStatus({ loading: false, error: "boom", faState: { freeAgents: [] } });
+    expect(s.state).toBe("error");
+    expect(s.title).toMatch(/failed to load/i);
+    expect(s.body).toBe("boom");
+  });
+
+  it("reports error when no payload arrived (silent failure)", () => {
+    const s = resolveFreeAgencyLoadStatus({ loading: false, error: null, faState: null });
+    expect(s.state).toBe("error");
+  });
+
+  it("reports ready (populated) when the pool has players", () => {
+    const s = resolveFreeAgencyLoadStatus({
+      loading: false,
+      faState: { phase: "free_agency", freeAgents: [{ id: 1 }] },
+      poolCount: 1,
+    });
+    expect(s.state).toBe("ready");
+  });
+
+  it("stays ready when the pool has players but filters hid them (filtered-empty handled by the table)", () => {
+    // poolCount reflects the UNFILTERED pool; a filtered-empty view is still "ready".
+    const s = resolveFreeAgencyLoadStatus({
+      loading: false,
+      faState: { phase: "free_agency", freeAgents: [{ id: 1 }, { id: 2 }] },
+      poolCount: 2,
+    });
+    expect(s.state).toBe("ready");
+  });
+
+  it("reports true-empty when free agency is open but the pool is empty", () => {
+    const s = resolveFreeAgencyLoadStatus({
+      loading: false,
+      faState: { phase: "free_agency", freeAgents: [] },
+      poolCount: 0,
+    });
+    expect(s.state).toBe("empty");
+    expect(s.title).toMatch(/no free agents/i);
+  });
+
+  it("reports phase-unavailable when the pool is empty during a non-FA phase", () => {
+    const s = resolveFreeAgencyLoadStatus({
+      loading: false,
+      faState: { phase: "draft", freeAgents: [] },
+      poolCount: 0,
+    });
+    expect(s.state).toBe("unavailable");
+    expect(s.title).toMatch(/unavailable during this phase/i);
+  });
+
+  it("uses a re-sign specific message during the resign phase", () => {
+    const s = resolveFreeAgencyLoadStatus({
+      loading: false,
+      faState: { phase: "offseason_resign", freeAgents: [] },
+      poolCount: 0,
+    });
+    expect(s.state).toBe("empty");
+    expect(s.title).toMatch(/re-sign/i);
+  });
+});

--- a/src/ui/utils/leagueStatsPipeline.test.js
+++ b/src/ui/utils/leagueStatsPipeline.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { buildLeagueStatsHubModel } from "./leagueStatsHub.js";
+import { attachSeasonStatsToRoster } from "../../worker/viewStateStats.js";
+
+/**
+ * Stats pipeline regression (Priority 2).
+ *
+ * Proves the full contract that was broken: recorded per-game totals (in the
+ * cache's singular-key shape produced by statAccumulator + updateSeasonStat)
+ * surface as NON-ZERO leaders in the League Stats hub once they are attached to
+ * the view-model roster via attachSeasonStatsToRoster — exactly what
+ * buildViewState now does.
+ */
+
+// One completed game's worth of recorded season totals, keyed by player id,
+// using the SAME singular keys the worker writes (passYd, rushYd, recYd, ...).
+const recordedTotals = {
+  "qb1": { passYd: 305, passTD: 3, passComp: 24, passAtt: 33, interceptions: 1, gamesPlayed: 1 },
+  "rb1": { rushYd: 128, rushTD: 2, rushAtt: 21, gamesPlayed: 1 },
+  "wr1": { recYd: 142, recTD: 1, receptions: 8, targets: 11, gamesPlayed: 1 },
+  "lb1": { tackles: 12, sacks: 1.5, tacklesForLoss: 2, gamesPlayed: 1 },
+};
+
+function buildLeagueWithRecordedGame() {
+  const rawRoster = [
+    { id: "qb1", name: "Test QB", pos: "QB", teamId: 1 },
+    { id: "rb1", name: "Test RB", pos: "RB", teamId: 1 },
+    { id: "wr1", name: "Test WR", pos: "WR", teamId: 1 },
+    { id: "lb1", name: "Test LB", pos: "LB", teamId: 1 },
+  ];
+  const roster = attachSeasonStatsToRoster(rawRoster, (pid) => recordedTotals[String(pid)] ?? null);
+
+  return {
+    seasonId: 2026,
+    week: 2,
+    userTeamId: 1,
+    teams: [
+      { id: 1, abbr: "AAA", name: "Alphas", roster },
+      { id: 2, abbr: "BBB", name: "Betas", roster: [] },
+    ],
+    // Slim schedule: one completed game with scores (no box score / teamStats,
+    // matching what the worker writes into the slim schedule).
+    schedule: {
+      weeks: [
+        { week: 1, games: [{ id: "g1", week: 1, home: 1, away: 2, played: true, homeScore: 24, awayScore: 17 }] },
+      ],
+    },
+  };
+}
+
+describe("League Stats pipeline after one completed game", () => {
+  const model = buildLeagueStatsHubModel(buildLeagueWithRecordedGame());
+
+  it("sources player stats from season totals (not the empty fallback)", () => {
+    expect(model.statSources.playerStats).toBe("seasonStats");
+  });
+
+  it("shows the correct NON-ZERO passing leader", () => {
+    const top = model.playerLeaders.passing[0];
+    expect(top.name).toBe("Test QB");
+    expect(top.passYds).toBe(305);
+    expect(top.passTd).toBe(3);
+  });
+
+  it("shows the correct NON-ZERO rushing leader", () => {
+    const top = model.playerLeaders.rushing[0];
+    expect(top.name).toBe("Test RB");
+    expect(top.rushYds).toBe(128);
+    expect(top.rushTd).toBe(2);
+  });
+
+  it("shows the correct NON-ZERO receiving leader", () => {
+    const top = model.playerLeaders.receiving[0];
+    expect(top.name).toBe("Test WR");
+    expect(top.recYds).toBe(142);
+  });
+
+  it("shows the correct NON-ZERO defensive leader", () => {
+    const top = model.playerLeaders.defense[0];
+    expect(top.name).toBe("Test LB");
+    expect(top.tkl).toBe(12);
+    expect(top.sack).toBe(1.5);
+  });
+
+  it("derives team scoring from the completed game (score-only at minimum)", () => {
+    expect(["scoreOnly", "gameTeamStats", "partial"]).toContain(model.statSources.teamStats);
+    const alphas = model.teamRankings.offense.find((r) => r.team === "AAA");
+    expect(alphas.pf).toBe(24);
+    expect(alphas.pa).toBe(17);
+    // Team rankings are NOT flagged unavailable when a completed game exists.
+    expect(model.warnings.join(" ")).not.toMatch(/did not record team stats or scores/i);
+  });
+
+  it("renders all-zero placeholders ONLY when nothing has been recorded", () => {
+    const empty = buildLeagueStatsHubModel({
+      seasonId: 2026,
+      teams: [{ id: 1, abbr: "AAA", roster: [{ id: "x", name: "Nobody", pos: "QB" }] }],
+      schedule: { weeks: [{ week: 1, games: [{ home: 1, away: 2, played: false }] }] },
+    });
+    expect(empty.playerLeaders.passing.every((r) => r.passYds === 0)).toBe(true);
+    expect(empty.statSources.teamStats).toBe("unavailable");
+  });
+});

--- a/src/ui/utils/weeklyResultsDerivation.test.js
+++ b/src/ui/utils/weeklyResultsDerivation.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  getGameLifecycleBucket,
+  selectWeekGames,
+  resolveDefaultResultsWeek,
+} from "./gameCenterResults.js";
+
+/**
+ * Weekly Results derivation regression (Priority 3).
+ *
+ * Weekly Results, standings, and the schedule all read from ONE canonical
+ * store: the slim schedule on the league view-model. After the user plays a
+ * game, the worker writes `played: true` + scores into that slim schedule game.
+ * These tests pin the contract so Weekly Results can never drift from standings
+ * (e.g. standings 1-0 while Weekly Results shows 0 completed games).
+ */
+
+// A week-1 slim schedule where the user (team 1) game has been played and the
+// rest of the week is still upcoming — exactly the post-user-game state.
+function scheduleAfterUserGame() {
+  return {
+    weeks: [
+      {
+        week: 1,
+        games: [
+          { id: "g1", week: 1, home: 1, away: 2, played: true, homeScore: 27, awayScore: 20 },
+          { id: "g2", week: 1, home: 3, away: 4, played: false },
+          { id: "g3", week: 1, home: 5, away: 6, played: false },
+        ],
+      },
+    ],
+  };
+}
+
+describe("Weekly Results derivation after one user game", () => {
+  const schedule = scheduleAfterUserGame();
+  const games = selectWeekGames(schedule, 1);
+  const buckets = games.map(getGameLifecycleBucket);
+
+  it("buckets the played user game as completed and the rest as upcoming", () => {
+    expect(buckets).toEqual(["completed", "upcoming", "upcoming"]);
+  });
+
+  it("reports exactly 1 completed game (matches a 1-0/0-1 standings change)", () => {
+    const completed = buckets.filter((b) => b === "completed").length;
+    expect(completed).toBe(1);
+  });
+
+  it("decrements the upcoming count for the week", () => {
+    const upcoming = buckets.filter((b) => b === "upcoming").length;
+    expect(upcoming).toBe(games.length - 1);
+    expect(upcoming).toBe(2);
+  });
+
+  it("exposes the SAME final score that standings derive their W/L from", () => {
+    const userGame = games.find((g) => Number(g.home) === 1);
+    expect(userGame.homeScore).toBe(27);
+    expect(userGame.awayScore).toBe(20);
+    // Standings derive the home win from the identical score fields.
+    const homeWon = Number(userGame.homeScore) > Number(userGame.awayScore);
+    expect(homeWon).toBe(true);
+  });
+
+  it("defaults the Weekly Results view to the week that has the completed game", () => {
+    // currentWeek is still 1 (week not fully advanced); the completed game lives there.
+    expect(resolveDefaultResultsWeek(schedule, { currentWeek: 1 })).toBe(1);
+  });
+
+  it("treats an unplayed game with no scores as upcoming (no false completion)", () => {
+    expect(getGameLifecycleBucket({ home: 1, away: 2, played: false })).toBe("upcoming");
+    expect(getGameLifecycleBucket({ home: 1, away: 2 })).toBe("upcoming");
+  });
+});

--- a/src/worker/__tests__/viewStateStats.test.js
+++ b/src/worker/__tests__/viewStateStats.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { attachSeasonStatsToRoster } from "../viewStateStats.js";
+
+// Mirrors the cache season-stat shape: totals are keyed by player id.
+function lookupFrom(map) {
+  return (pid) => map[String(pid)] ?? null;
+}
+
+describe("attachSeasonStatsToRoster", () => {
+  it("copies recorded totals onto each player as seasonStats", () => {
+    const totalsById = {
+      "1": { passYd: 320, passTD: 3, gamesPlayed: 1 },
+      "2": { rushYd: 110, rushTD: 1, gamesPlayed: 1 },
+    };
+    const roster = [
+      { id: 1, name: "QB" },
+      { id: 2, name: "RB" },
+    ];
+
+    const out = attachSeasonStatsToRoster(roster, lookupFrom(totalsById));
+
+    expect(out[0].seasonStats).toEqual(totalsById["1"]);
+    expect(out[1].seasonStats).toEqual(totalsById["2"]);
+  });
+
+  it("does not mutate the original cache player objects", () => {
+    const roster = [{ id: 1, name: "QB" }];
+    const out = attachSeasonStatsToRoster(roster, lookupFrom({ "1": { passYd: 100 } }));
+    expect(roster[0].seasonStats).toBeUndefined();
+    expect(out[0]).not.toBe(roster[0]);
+  });
+
+  it("leaves players without recorded totals unchanged", () => {
+    const roster = [{ id: 9, name: "Benchwarmer" }];
+    const out = attachSeasonStatsToRoster(roster, lookupFrom({}));
+    expect(out[0].seasonStats).toBeUndefined();
+  });
+
+  it("respects an already-present seasonStats object", () => {
+    const existing = { passYd: 999 };
+    const roster = [{ id: 1, name: "QB", seasonStats: existing }];
+    const out = attachSeasonStatsToRoster(roster, lookupFrom({ "1": { passYd: 1 } }));
+    expect(out[0].seasonStats).toBe(existing);
+  });
+
+  it("passes malformed rows through without throwing", () => {
+    const roster = [null, undefined, 42, { id: 1, name: "QB" }];
+    const out = attachSeasonStatsToRoster(roster, lookupFrom({ "1": { passYd: 50 } }));
+    expect(out[0]).toBeNull();
+    expect(out[3].seasonStats).toEqual({ passYd: 50 });
+  });
+
+  it("returns [] for non-array input and tolerates a missing lookup", () => {
+    expect(attachSeasonStatsToRoster(null, lookupFrom({}))).toEqual([]);
+    const roster = [{ id: 1 }];
+    expect(attachSeasonStatsToRoster(roster, undefined)).toBe(roster);
+  });
+});

--- a/src/worker/viewStateStats.js
+++ b/src/worker/viewStateStats.js
@@ -1,0 +1,45 @@
+/**
+ * viewStateStats.js — expose recorded season stats on roster players.
+ *
+ * Background
+ * ----------
+ * Per-player season totals are accumulated in a dedicated cache map
+ * (cache._seasonStats), keyed by player id, NOT on the player objects
+ * themselves. The League Stats hub (buildLeagueStatsHubModel) reads each
+ * player's totals from `player.seasonStats` on the view-model roster. Because
+ * the view-model never copied those totals onto roster players, League Stats
+ * fell back to game-log aggregation — and since the slim schedule carries no
+ * box scores either, it rendered all-zero leaders even when games had been
+ * recorded and standings updated.
+ *
+ * This helper bridges the gap: it copies the recorded season totals onto a
+ * shallow copy of each roster player so the UI sees real numbers, without
+ * mutating the canonical cache player objects.
+ */
+
+/**
+ * Attach recorded season-stat totals onto roster players.
+ *
+ * @param {Array<object>} roster                   Player objects from the cache.
+ * @param {(playerId: unknown) => (object|null|undefined)} getSeasonStatTotals
+ *        Lookup returning the recorded `totals` object for a player id (or
+ *        null/undefined when none exist yet).
+ * @returns {Array<object>} New roster array with `seasonStats` populated where
+ *        totals exist. Malformed rows and players without totals pass through
+ *        unchanged.
+ */
+export function attachSeasonStatsToRoster(roster, getSeasonStatTotals) {
+  if (!Array.isArray(roster)) return [];
+  if (typeof getSeasonStatTotals !== "function") return roster;
+
+  return roster.map((player) => {
+    if (!player || typeof player !== "object") return player;
+    // Respect an already-present seasonStats object (some code paths attach it).
+    if (player.seasonStats && typeof player.seasonStats === "object") return player;
+
+    const totals = getSeasonStatTotals(player.id);
+    if (!totals || typeof totals !== "object") return player;
+
+    return { ...player, seasonStats: totals };
+  });
+}

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -2144,6 +2144,14 @@ async function loadSave() {
   ]);
 
   cache.hydrate({ meta, teams, players, draftPicks });
+  // Backfill persisted current-season stats. hydrate() clears _seasonStats and
+  // only restores meta/teams/players/draftPicks, so without this the League
+  // Stats view model rebuilds from roster players with no seasonStats and shows
+  // zero leaders after a reload — even when games were already recorded.
+  if (meta?.currentSeasonId != null) {
+    const seasonStatRows = await PlayerStats.bySeason(meta.currentSeasonId).catch(() => []);
+    cache.hydrateSeasonStats(seasonStatRows);
+  }
   hydrateAllPlayersForDevelopment();
   return true;
 }

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -219,6 +219,7 @@ import {
 import { processSeasonRecords, createEmptyRecords, getMostPlayedTeam } from '../core/records.js';
 import { ensureLeagueMemoryMeta, buildSeasonArchiveSummary, updateFranchiseHistory, updateRecordBook, evaluateHallOfFameCandidate, addHallOfFameClass, buildSeasonStorylineSnapshot, buildHallOfFameInducteeRow, syncHallOfFameAfterRecordBook } from '../core/league-memory.js';
 import { buildPlayerSeasonStatsArchiveRows } from '../core/playerSeasonStatsArchive.js';
+import { attachSeasonStatsToRoster } from './viewStateStats.js';
 import {
   TRANSACTION_TIMELINE_SCHEMA_VERSION,
   compactRowsForArchive,
@@ -1047,7 +1048,12 @@ function buildViewState() {
   const standingsRows = resolveStandingsRows(meta, standingsContext);
   const tradeDeadline = getTradeDeadlineSnapshot(meta);
   const teams = cache.getAllTeams().map(t => {
-    const roster = cache.getPlayersByTeam(t.id);
+    // Attach recorded season totals so the League Stats hub (which reads
+    // player.seasonStats) shows real leaders instead of all-zero placeholders.
+    const roster = attachSeasonStatsToRoster(
+      cache.getPlayersByTeam(t.id),
+      (pid) => cache.getSeasonStat(pid)?.totals,
+    );
     return ({
     id:        t.id,
     name:      t.name,


### PR DESCRIPTION
Core data-stability pass for the league loop and stats pipeline. Scoped to the highest-value **confirmed** issues — no router, sim-engine, Awards/HOF, or Draft rewrites.

## Reproduction summary

| Priority | Finding | Status |
|---|---|---|
| **P1** | Roster Hub crash `(e.id ?? "x").split is not a function` | ✅ **CONFIRMED** (reproduced with a failing test, then fixed) |
| **P2** | League Stats / player stats show all zeros after simming | ✅ **CONFIRMED** (root cause traced, fixed) |
| **P3** | Weekly Results 0 completed while standings updated | ⚪ **NOT REPRODUCED** in data layer — both derive from the same canonical slim-schedule store; contract pinned with a regression test |
| **P4** | Free Agency shows filters but no players / no honest empty state | 🟡 **PARTIAL** — load-error path silently showed a misleading "no match"; improved with honest states |
| **P5** | Navigation triggers "Starting game engine…" remount | ⚪ **NOT REPRODUCED** for normal navigation — worker spawns once (`useEffect([])`); tab switches are local state; remount only via intentional `window.location.reload()` recovery paths |

## Root causes & fixes

**P1 — Roster Hub crash (fixed)**
`PlayerCardGrid.getAttrValue()` called `.split()` directly on a raw `player.id`, throwing when the id was numeric / missing / an object (seeded fixtures, legacy saves). `PlayerCard.jsx` already guarded with `String()`; this site didn't.
- Adds `src/ui/utils/entityId.js` (`toEntityId`/`toPlayerId`/`toEntityKey`) — type-safe, never-throw id normalization. Used at the crash site and for grid keys.
- Roster is normalized once so null/non-object rows are skipped (not crashed on) by both the filter-pill counts and the render.

**P2 — League Stats all-zero leaders (fixed)**
Season totals live in `cache._seasonStats`, but `buildViewState` never copied them onto roster players. The League Stats hub reads `player.seasonStats`, so it fell back to game-log aggregation — and the slim schedule carries no box scores — yielding all-zero leaders even after games were recorded and standings updated. (Stat **keys** were verified consistent end-to-end: `statAccumulator` → `updateSeasonStat` → reader all use singular `passYd`/`rushYd`/`tackles`.)
- Adds `src/worker/viewStateStats.js` `attachSeasonStatsToRoster()`, wired into `buildViewState`, exposing recorded totals without mutating cache player objects.

**P4 — Free Agency empty state (improved)**
`getFreeAgents` failures silently left a misleading "no players match" list.
- Adds `src/ui/utils/freeAgencyLoadStatus.js` to classify **loading / error / phase-unavailable / true-empty / ready** and render honest, distinct messages. Filtered-empty stays handled inline by the table.

**P3 / P5 — verified, contract pinned with regression tests**
Weekly Results and standings both read from the same slim-schedule store; the worker spawns once and tab navigation is local state, so normal navigation cannot remount the engine or lose league state.

## Tests (48 new; full suite green: 385 files / 4928 tests; build passes)
- `entityId`, `attachSeasonStatsToRoster`, `freeAgencyLoadStatus` unit tests
- PlayerCardGrid + RosterHub id-safety render regressions
- League Stats pipeline integration (non-zero leaders after a recorded game)
- Weekly Results derivation + worker navigation-stability smoke tests

## Parallel simulation design note (not implemented, per scope)
- **Parallelizable later:** AI-vs-AI games within a week — `simulateBatch` games are pure functions of `(teams snapshot, seed, settings)` and could run in Web Workers returning plain `gameResult` objects.
- **Must stay sequential:** the user's interactive/live-play game, and all league-state commits in order: collect → validate all → apply completed games → standings → stats → injuries/transactions → write Weekly Results → persist.
- **Shared state to protect:** `cache` (`updateTeam`/`updateSeasonStat`/`addGame`), the slim `meta.schedule`, and the dirty-flush buffer. Workers receive immutable snapshots and **return** results only — never mutate canonical league state directly.

## Remaining risks / follow-ups
- **P2 payload:** `buildViewState` now shallow-copies roster players with `seasonStats` (bounded, additive); consider lazy attachment on very large dynasties.
- **P3/P5:** Couldn't drive the live worker+UI in this environment; the QA mismatches are likely a stale view before the next `STATE_UPDATE` (timing) rather than data divergence. Follow-up: ensure `WATCH_GAME` posts a `STATE_UPDATE` so Weekly Results refreshes immediately after the user game.
- **P4:** `FreeAgencyHub.jsx` ("FA Hub") still lacks the same honest empty states (low priority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNpqw3NSQLu4hRFLcgvUAr)_