### PR TITLE
Trade/FA UX cleanup: shared cap-impact + status states (PR #1627)

### DIFF
--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -44,7 +44,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { computeTeamNeedsSummary, formatNeedsLine, summarizeFreeAgentMarket } from "../utils/marketSignals.js";
 import { buildDirectionGuidance, buildTeamIntelligence, scoreFreeAgentForTeam } from "../utils/teamIntelligence.js";
 import { getBudgetLabel, getMarketPlayerTags, toneToCssColor } from "../utils/transactionMarket.js";
-import { ScreenHeader, EmptyState, StickySubnav } from "./ScreenSystem.jsx";
+import { ScreenHeader, StickySubnav } from "./ScreenSystem.jsx";
 import AdvancedPlayerSearch from "./AdvancedPlayerSearch.jsx";
 import { applyAdvancedPlayerFilters } from "../../core/footballAdvancedFilters";
 import { buildPlayerEvaluation } from "../../core/playerEvaluation.js";
@@ -56,6 +56,7 @@ import { buildContractOfferInsight, toneToContractInsightColor } from "../utils/
 import { evaluatePendingOfferCapReservation } from "../../core/pendingOfferCapModel.js";
 import { buildShowingLabel, stableSortRows } from "../utils/dataBrowser.js";
 import { resolveFreeAgencyLoadStatus } from "../utils/freeAgencyLoadStatus.js";
+import StatusEmptyState from "./common/StatusEmptyState.jsx";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -1558,19 +1559,12 @@ export default function FreeAgency({
       {/* Main Table Card */}
       <Card className="card-premium" style={{ padding: 0, overflow: "hidden" }}>
         {loadStatus.state !== "ready" ? (
-          <div
-            role={loadStatus.state === "error" ? "alert" : "status"}
-            data-testid="fa-load-status"
-            data-state={loadStatus.state}
-            style={{
-              padding: "var(--space-10)",
-              textAlign: "center",
-              color: loadStatus.state === "error" ? "var(--danger)" : "var(--text-muted)",
-            }}
-          >
-            <div style={{ fontWeight: 700, marginBottom: 4 }}>{loadStatus.title}</div>
-            <div style={{ fontSize: "var(--text-sm)" }}>{loadStatus.body}</div>
-          </div>
+          <StatusEmptyState
+            testId="fa-load-status"
+            state={loadStatus.state}
+            title={loadStatus.title}
+            body={loadStatus.body}
+          />
         ) : (
           <div>
             {viewMode === "table" && <div className="desktop-only table-wrapper" style={{ overflowX: "auto" }}>
@@ -1657,13 +1651,16 @@ export default function FreeAgency({
                     <TableRow>
                       <TableCell
                         colSpan={11}
-                        style={{
-                          textAlign: "center",
-                          padding: "var(--space-8)",
-                          color: "var(--text-muted)",
-                        }}
+                        style={{ padding: 0 }}
                       >
-                        No free agents match your filter.
+                        <StatusEmptyState
+                          testId="fa-filtered-empty"
+                          state="filtered"
+                          title="No players match your filters."
+                          body="Adjust your filters, minimum OVR, or search to widen the pool."
+                          actionLabel="Reset filters"
+                          onAction={resetMarketFilters}
+                        />
                       </TableCell>
                     </TableRow>
                   )}
@@ -1926,11 +1923,15 @@ export default function FreeAgency({
             {viewMode === "cards" && (
               <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: "var(--space-3)", padding: "var(--space-3)" }}>
                 {sortedAgents.length === 0 ? (
-                  <EmptyState
-                    title={faState?.phase === "offseason_resign" ? "No re-sign targets in this filter" : "No free agents match"}
+                  <StatusEmptyState
+                    testId="fa-filtered-empty"
+                    state="filtered"
+                    title={faState?.phase === "offseason_resign" ? "No re-sign targets match your filters." : "No players match your filters."}
                     body={faState?.phase === "offseason_resign"
-                      ? "Try broadening position filters or lower minimum OVR to find affordable retention options."
+                      ? "Try broadening position filters or lowering minimum OVR to find affordable retention options."
                       : "Adjust filters or open FA Hub to scout position pressure before returning here."}
+                    actionLabel="Reset filters"
+                    onAction={resetMarketFilters}
                   />
                 ) : null}
                 {sortedAgents.slice(0, 80).map((player, idx) => (
@@ -1962,11 +1963,15 @@ export default function FreeAgency({
             {/* Mobile Card Layout */}
             <div className="mobile-only" style={{ display: "none", flexDirection: "column", gap: "var(--space-3)", padding: "var(--space-3)" }}>
                {sortedAgents.length === 0 && (
-                  <EmptyState
-                    title={faState?.phase === "offseason_resign" ? "No re-sign targets in this filter" : "No free agents match"}
+                  <StatusEmptyState
+                    testId="fa-filtered-empty"
+                    state="filtered"
+                    title={faState?.phase === "offseason_resign" ? "No re-sign targets match your filters." : "No players match your filters."}
                     body={faState?.phase === "offseason_resign"
-                      ? "Try broadening position filters or lower minimum OVR to find affordable retention options."
+                      ? "Try broadening position filters or lowering minimum OVR to find affordable retention options."
                       : "Adjust filters, minimum OVR, or search criteria."}
+                    actionLabel="Reset filters"
+                    onAction={resetMarketFilters}
                   />
                )}
                {sortedAgents.slice(0, 100).map((player, idx) => {

--- a/src/ui/components/TradeCenter.jsx
+++ b/src/ui/components/TradeCenter.jsx
@@ -30,6 +30,7 @@ import { logCompletedTradeAction, persistFranchiseChronicle } from "../utils/fra
 import { getPickBaseValueFromMatrix } from "../../core/trades/tradeValuationModifiers.js";
 import FrontOfficeBadge from "./FrontOfficeBadge.jsx";
 import { getHotSeatStatus } from "../../core/meta/ownerPressureEngine.js";
+import CapImpactSummary from "./common/CapImpactSummary.jsx";
 
 // ── Original helpers (kept exactly as you had) ─────────────────────────────────
 
@@ -71,13 +72,27 @@ function PlayerCheckRow({ player, checked, onChange, onNameClick }) {
   const asset = buildTradeAssetDisplay(player, { type: 'player' });
   return (
     <label className={`trade-asset-row ${checked ? "is-selected" : ""}`}>
-      <input type="checkbox" checked={checked} onChange={(e) => onChange(player.id, e.target.checked)} style={{ accentColor: "var(--accent)", width: 16, height: 16 }} />
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(player.id, e.target.checked)}
+        aria-label={`${checked ? "Remove" : "Add to Trade"} ${asset.title}`}
+        title={checked ? "Remove from trade" : "Add to Trade"}
+        style={{ accentColor: "var(--accent)", width: 18, height: 18 }}
+      />
       <OvrBadge ovr={player.ovr} />
       <span className="trade-asset-row__pos">{player.pos}</span>
-      <span className="trade-asset-row__name" onClick={(e) => { e.preventDefault(); onNameClick?.(player.id); }}>
+      <button
+        type="button"
+        className="trade-asset-row__name"
+        aria-label={`View Player ${asset.title}`}
+        title="View Player"
+        onClick={(e) => { e.preventDefault(); onNameClick?.(player.id); }}
+        style={{ background: "none", border: "none", padding: 0, textAlign: "left", cursor: "pointer", color: "inherit", font: "inherit" }}
+      >
         <strong>{asset.title}</strong>
         <small>{asset.subtitle}</small>
-      </span>
+      </button>
       <span className="trade-asset-row__salary">{asset.meta}</span>
     </label>
   );
@@ -482,6 +497,19 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
     const absorbed = [...offering].reduce((s, id) => s + (myRosterMap.get(toAssetId(id))?.contract?.baseAnnual ?? 0), 0);
     return Math.round((base + freed - absorbed) * 10) / 10;
   }, [offering, receiving, myRosterMap, theirRosterMap, liveTheirTeam]);
+
+  // Salary moving in/out of the user's books — surfaced in the cap breakdown so
+  // the user sees incoming vs outgoing money before proposing. Pure display
+  // figures; they do not feed the acceptance/valuation engine.
+  const myIncomingSalary = useMemo(
+    () => [...receiving].reduce((s, id) => s + (theirRosterMap.get(toAssetId(id))?.contract?.baseAnnual ?? 0), 0),
+    [receiving, theirRosterMap],
+  );
+  const myOutgoingSalary = useMemo(
+    () => [...offering].reduce((s, id) => s + (myRosterMap.get(toAssetId(id))?.contract?.baseAnnual ?? 0), 0),
+    [offering, myRosterMap],
+  );
+
   const tradeImpact = useMemo(() => {
     const incomingPositions = [...receiving].map((id) => theirRosterMap.get(toAssetId(id))?.pos).filter(Boolean);
     const outgoingPositions = [...offering].map((id) => myRosterMap.get(toAssetId(id))?.pos).filter(Boolean);
@@ -569,6 +597,17 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
     if (theirCapAfter < 0) blockers.push("Their team would be over the cap after this package.");
     return blockers;
   }, [targetId, hasSelection, tradeLocked, lockReason, myCapAfter, theirCapAfter]);
+
+  // Single, explicit package status so the user always knows what state the
+  // builder is in. Derived from existing data only — no logic change.
+  const tradeStatus = useMemo(() => {
+    if (tradeResult?.error) return { tone: "danger", label: "Invalid trade", detail: "Missing team or player data — reload the partner and rebuild the package." };
+    if (tradeResult?.accepted) return { tone: "success", label: "Trade accepted", detail: "The deal went through. Build another package or switch partners." };
+    if (tradeResult) return { tone: "danger", label: "Trade rejected", detail: "See the response below, then adjust your package and try again." };
+    if (!hasSelection) return { tone: "muted", label: "No assets selected", detail: "Add at least one player or pick on either side to start a package." };
+    if (tradeBlockers.length) return { tone: "warning", label: "Not ready to propose", detail: "Resolve the issue(s) below before sending this package." };
+    return { tone: "success", label: "Package ready to propose", detail: "Review the cap impact, then Propose Trade." };
+  }, [tradeResult, hasSelection, tradeBlockers.length]);
 
 
   useEffect(() => {
@@ -754,7 +793,7 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
     />
     <StickySubnav title="Package actions">
       {targetId && <Button className="btn btn-primary" onClick={handlePropose} disabled={!hasSelection || submitting || tradeLocked}>{submitting ? "Evaluating…" : counterOfferId ? "Send Counter" : "Propose Trade"}</Button>}
-      <Button className="btn" onClick={() => { setOffering(new Set()); setReceiving(new Set()); setMyPicks([]); setTheirPicks([]); }}>Clear package</Button>
+      <Button className="btn" onClick={() => { setOffering(new Set()); setReceiving(new Set()); setMyPicks([]); setTheirPicks([]); setTradeResult(null); }}>Clear Trade</Button>
     </StickySubnav>
     <Card className="card-premium"><CardContent className="p-4 trade-center-v2">
       <div style={{ marginBottom: 'var(--space-4)' }}>
@@ -1001,6 +1040,29 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
         </div>
       )}
 
+      {/* Explicit package status — always tells the user where they stand. */}
+      {(() => {
+        const toneColor = tradeStatus.tone === "success"
+          ? "var(--success)"
+          : tradeStatus.tone === "danger"
+            ? "var(--danger)"
+            : tradeStatus.tone === "warning"
+              ? "var(--warning)"
+              : "var(--text-muted)";
+        return (
+          <div
+            data-testid="trade-status-banner"
+            data-tone={tradeStatus.tone}
+            role={tradeStatus.tone === "danger" ? "alert" : "status"}
+            className="card"
+            style={{ padding: "var(--space-3)", marginBottom: "var(--space-3)", display: "grid", gap: 2, borderLeft: `3px solid ${toneColor}` }}
+          >
+            <strong style={{ fontSize: "var(--text-sm)", color: toneColor }}>{tradeStatus.label}</strong>
+            <span style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>{tradeStatus.detail}</span>
+          </div>
+        );
+      })()}
+
       {/* Trade result (original) */}
       {tradeResult && <TradeResult result={tradeResult} onDismiss={() => setTradeResult(null)} />}
       {tradeBlockers.length > 0 && (
@@ -1026,6 +1088,17 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
             <div className="card" style={{ marginBottom: "var(--space-4)", padding: "var(--space-4) var(--space-5)" }}>
               <ValueBar myValue={myOfferValue} theirValue={theirOfferValue} />
               <CapImpact myTeam={liveMyTeam} theirTeam={liveTheirTeam} myCapAfter={myCapAfter} theirCapAfter={theirCapAfter} />
+              <div style={{ marginTop: "var(--space-3)" }}>
+                <CapImpactSummary
+                  title={`${liveMyTeam?.abbr ?? "Your"} cap impact`}
+                  currentRoom={liveMyTeam?.capRoom ?? 0}
+                  incoming={myIncomingSalary}
+                  outgoing={myOutgoingSalary}
+                  projectedRoom={myCapAfter}
+                  incomingLabel="Salary coming in"
+                  outgoingLabel="Salary going out"
+                />
+              </div>
               <div style={{ marginTop: 10, display: "grid", gap: 4, fontSize: "var(--text-xs)", color: "var(--text-muted)" }}>
                 <div>{tradeImpact.needHits.length ? `Addresses needs: ${tradeImpact.needHits.join(", ")}` : "Does not directly hit a top need yet."}</div>
                 <div>{tradeImpact.surplusMoved.length ? `Moves surplus from: ${tradeImpact.surplusMoved.join(", ")}` : "Not moving a clear surplus group."}</div>
@@ -1062,7 +1135,7 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
             {/* You Give */}
             <div className="card trade-panel-card" style={{ padding: 0, overflow: "hidden" }}>
               <div className="trade-panel-card__head">
-                <span>You Give</span>
+                <span>Your Assets · You Give</span>
                 <span className={`trade-panel-card__count ${offering.size > 0 || myPicks.length > 0 ? "is-active" : ""}`}>{offering.size + myPicks.length} selected</span>
               </div>
               <div style={{ maxHeight: 360, overflowY: "auto" }}>
@@ -1076,7 +1149,7 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
             {/* You Receive */}
             <div className="card trade-panel-card" style={{ padding: 0, overflow: "hidden" }}>
               <div className="trade-panel-card__head">
-                <span>You Receive</span>
+                <span>Their Assets · You Receive</span>
                 <span className={`trade-panel-card__count ${receiving.size > 0 || theirPicks.length > 0 ? "is-active" : ""}`}>{receiving.size + theirPicks.length} selected</span>
               </div>
               <div style={{ maxHeight: 360, overflowY: "auto" }}>

--- a/src/ui/components/__tests__/FreeAgencyUxStates.test.jsx
+++ b/src/ui/components/__tests__/FreeAgencyUxStates.test.jsx
@@ -1,0 +1,106 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import { resolveFreeAgencyLoadStatus } from '../../utils/freeAgencyLoadStatus.js';
+import StatusEmptyState from '../common/StatusEmptyState.jsx';
+import FreeAgency from '../FreeAgency.jsx';
+
+/**
+ * Free Agency state model regression.
+ *
+ * The page resolves one of: loading / ready / empty(true-empty) /
+ * unavailable(phase) / error via resolveFreeAgencyLoadStatus, and renders the
+ * non-ready states through the shared StatusEmptyState. These tests lock the
+ * resolver → presentation mapping (including filtered-empty) and confirm the
+ * live component renders the loading state before its data arrives.
+ */
+
+function renderStatus(status, extra = {}) {
+  return render(
+    <StatusEmptyState testId="fa-load-status" state={status.state} title={status.title} body={status.body} {...extra} />,
+  );
+}
+
+describe('FreeAgency — state model presentation', () => {
+  afterEach(cleanup);
+
+  it('renders the loading state', () => {
+    const status = resolveFreeAgencyLoadStatus({ loading: true });
+    const { getByTestId } = renderStatus(status);
+    const el = getByTestId('fa-load-status');
+    expect(el.getAttribute('data-state')).toBe('loading');
+    expect(el.textContent).toMatch(/loading free agents/i);
+  });
+
+  it('renders the populated (ready) state with no status block', () => {
+    const status = resolveFreeAgencyLoadStatus({
+      loading: false,
+      faState: { phase: 'free_agency', freeAgents: [{ id: 1 }] },
+      poolCount: 1,
+    });
+    expect(status.state).toBe('ready');
+  });
+
+  it('renders the true-empty state', () => {
+    const status = resolveFreeAgencyLoadStatus({
+      loading: false,
+      faState: { phase: 'free_agency', freeAgents: [] },
+      poolCount: 0,
+    });
+    const { getByRole } = renderStatus(status);
+    expect(getByRole('status').textContent).toMatch(/no free agents available/i);
+  });
+
+  it('renders the phase-unavailable state', () => {
+    const status = resolveFreeAgencyLoadStatus({
+      loading: false,
+      faState: { phase: 'draft', freeAgents: [] },
+      poolCount: 0,
+    });
+    const { getByTestId } = renderStatus(status);
+    expect(getByTestId('fa-load-status').getAttribute('data-state')).toBe('unavailable');
+    expect(getByTestId('fa-load-status').textContent).toMatch(/unavailable during this phase/i);
+  });
+
+  it('renders the error state with role=alert', () => {
+    const status = resolveFreeAgencyLoadStatus({ loading: false, error: 'boom', faState: { freeAgents: [] } });
+    const { getByRole } = renderStatus(status);
+    expect(getByRole('alert').textContent).toMatch(/failed to load free agents/i);
+  });
+
+  it('renders the filtered-empty state with a reset-filters action', () => {
+    const onReset = vi.fn();
+    const { getByTestId, getByText } = render(
+      <StatusEmptyState
+        testId="fa-filtered-empty"
+        state="filtered"
+        title="No players match your filters."
+        body="Adjust your filters."
+        actionLabel="Reset filters"
+        onAction={onReset}
+      />,
+    );
+    expect(getByTestId('fa-filtered-empty').getAttribute('data-state')).toBe('filtered');
+    expect(getByText('Reset filters')).toBeTruthy();
+  });
+});
+
+describe('FreeAgency — live component loading state', () => {
+  afterEach(cleanup);
+
+  it('shows the loading status before free-agent data resolves', () => {
+    // getFreeAgents never resolves during this synchronous render, so the
+    // component stays in its initial loading state.
+    const actions = {
+      getFreeAgents: vi.fn(() => new Promise(() => {})),
+      getRoster: vi.fn(() => new Promise(() => {})),
+    };
+    const league = { userTeamId: 1, week: 1, phase: 'free_agency', teams: [{ id: 1, abbr: 'CHI', capRoom: 30, roster: [] }] };
+    const { getByTestId } = render(
+      <FreeAgency userTeamId={1} league={league} actions={actions} onPlayerSelect={() => {}} onNavigate={() => {}} />,
+    );
+    const el = getByTestId('fa-load-status');
+    expect(el.getAttribute('data-state')).toBe('loading');
+  });
+});

--- a/src/ui/components/__tests__/TradeCenterUxCleanup.test.jsx
+++ b/src/ui/components/__tests__/TradeCenterUxCleanup.test.jsx
@@ -1,0 +1,100 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import { cleanup, render, fireEvent, waitFor } from '@testing-library/react';
+import TradeCenter from '../TradeCenter.jsx';
+
+function makePlayer(id, name, { pos = 'WR', ovr = 80, age = 26, baseAnnual = 6 } = {}) {
+  return { id, name, pos, ovr, age, contract: { baseAnnual } };
+}
+
+function makeTeam(id, { abbr, capRoom = 20, roster = [], picks = [] } = {}) {
+  return { id, name: `Team ${id}`, abbr: abbr ?? `T${id}`, wins: 5, losses: 5, ties: 0, capRoom, picks, roster };
+}
+
+const USER = makeTeam(1, { abbr: 'CHI', capRoom: 20, roster: [makePlayer(101, 'Give Guy', { baseAnnual: 8 })] });
+const AI = makeTeam(2, { abbr: 'DET', capRoom: 30, roster: [makePlayer(201, 'Get Guy', { baseAnnual: 5 })] });
+
+function makeActions() {
+  return {
+    getRoster: vi.fn(async (tid) => {
+      const team = Number(tid) === 1 ? USER : AI;
+      return { payload: { team, players: team.roster } };
+    }),
+    submitTrade: vi.fn(async () => ({ payload: { accepted: false, reason: 'AI passed.' } })),
+    acceptIncomingTrade: vi.fn(async () => ({ payload: { accepted: false } })),
+    counterIncomingTrade: vi.fn(async () => ({ payload: { accepted: false } })),
+    toggleTradeBlock: vi.fn(async () => ({})),
+    save: vi.fn(),
+  };
+}
+
+function makeLeague() {
+  return {
+    year: 2027,
+    season: 2027,
+    week: 3,
+    phase: 'regular',
+    userTeamId: 1,
+    teams: [USER, AI],
+    incomingTradeOffers: [],
+    inboundTradeOffers: [],
+    settings: { tradeDeadlineWeek: 9 },
+  };
+}
+
+describe('TradeCenter — UX cleanup', () => {
+  afterEach(cleanup);
+
+  it('renders without selected assets and shows the "no assets selected" status', () => {
+    const html = renderToString(<TradeCenter league={makeLeague()} actions={makeActions()} />);
+    expect(html).toContain('No assets selected');
+    expect(html).toContain('Clear Trade');
+  });
+
+  it('separates "Your Assets" and "Their Assets" and exposes Add to Trade / View Player affordances', async () => {
+    const { findByText, findByLabelText } = render(
+      <TradeCenter league={makeLeague()} actions={makeActions()} />,
+    );
+    // Rosters load asynchronously via getRoster (driven by mount effects).
+    expect(await findByText('Your Assets · You Give')).toBeTruthy();
+    expect(await findByText('Their Assets · You Receive')).toBeTruthy();
+    expect(await findByLabelText(/Add to Trade Give Guy/i)).toBeTruthy();
+    expect(await findByLabelText(/View Player Give Guy/i)).toBeTruthy();
+  });
+
+  it('shows the cap impact breakdown and "ready to propose" once assets are on both sides', async () => {
+    const { findByLabelText, getByTestId } = render(
+      <TradeCenter league={makeLeague()} actions={makeActions()} />,
+    );
+
+    fireEvent.click(await findByLabelText(/Add to Trade Give Guy/i));
+    fireEvent.click(await findByLabelText(/Add to Trade Get Guy/i));
+
+    await waitFor(() => {
+      const cap = getByTestId('cap-impact-summary');
+      // current 20, freed 8, absorbed 5 → projected 23.0
+      expect(cap.textContent).toContain('$20.0M');
+      expect(cap.textContent).toContain('+$8.0M');
+      expect(cap.textContent).toContain('-$5.0M');
+      expect(cap.textContent).toContain('$23.0M');
+    });
+
+    const banner = getByTestId('trade-status-banner');
+    expect(banner.textContent).toContain('Package ready to propose');
+    expect(banner.getAttribute('data-tone')).toBe('success');
+  });
+
+  it('reports a rejected package clearly after a failed proposal', async () => {
+    const { findByLabelText, getByTestId, getAllByText } = render(
+      <TradeCenter league={makeLeague()} actions={makeActions()} />,
+    );
+    fireEvent.click(await findByLabelText(/Add to Trade Get Guy/i));
+    fireEvent.click(getAllByText('Propose Trade')[0]);
+
+    await waitFor(() => {
+      expect(getByTestId('trade-status-banner').textContent).toContain('Trade rejected');
+    });
+  });
+});

--- a/src/ui/components/common/CapImpactSummary.jsx
+++ b/src/ui/components/common/CapImpactSummary.jsx
@@ -1,0 +1,117 @@
+import React from 'react';
+
+/**
+ * CapImpactSummary — a single, reusable cap-impact breakdown.
+ *
+ * Both Trade Center and Free Agency need to answer the same question before a
+ * user commits to a move: "what does this do to my cap room?". This component
+ * renders that breakdown consistently:
+ *
+ *   current room → outgoing (freed) → incoming (added) → projected room
+ *
+ * It is purely presentational. Callers pass already-computed numbers; this
+ * component does NOT change any valuation, contract, or cap math — it only
+ * formats and, when the projected room is negative, surfaces a clear warning.
+ *
+ * @param {object} props
+ * @param {number} props.currentRoom    Cap room before the move (in $M).
+ * @param {number} [props.incoming]     Salary coming IN / added (in $M).
+ * @param {number} [props.outgoing]     Salary going OUT / freed (in $M).
+ * @param {number} [props.projectedRoom] Cap room after the move. Computed from
+ *                                        currentRoom + outgoing - incoming when omitted.
+ * @param {string} [props.title]        Heading copy.
+ * @param {string} [props.incomingLabel] Override label for the incoming row.
+ * @param {string} [props.outgoingLabel] Override label for the outgoing row.
+ * @param {number} [props.warnThreshold] Projected room at/below this is flagged (default 0).
+ * @param {string} [props.warningText]   Override the default warning copy.
+ */
+export default function CapImpactSummary({
+  currentRoom = 0,
+  incoming = 0,
+  outgoing = 0,
+  projectedRoom,
+  title = 'Cap impact',
+  incomingLabel = 'Salary added',
+  outgoingLabel = 'Salary freed',
+  warnThreshold = 0,
+  warningText,
+}) {
+  const current = Number(currentRoom) || 0;
+  const inc = Number(incoming) || 0;
+  const out = Number(outgoing) || 0;
+  const projected = Number.isFinite(projectedRoom)
+    ? Number(projectedRoom)
+    : Math.round((current + out - inc) * 10) / 10;
+
+  const fmt = (val) => {
+    const n = Number(val) || 0;
+    return n < 0 ? `-$${Math.abs(n).toFixed(1)}M` : `$${n.toFixed(1)}M`;
+  };
+
+  const overCap = projected < warnThreshold;
+  const tight = !overCap && projected < 5;
+  const projectedColor = overCap ? 'var(--danger)' : tight ? 'var(--warning)' : 'var(--success)';
+  const defaultWarning = overCap
+    ? 'This move puts you over the cap. Free up salary or send less money before proposing.'
+    : 'Cap room is tight after this move. Watch your remaining flexibility.';
+
+  const rows = [
+    { key: 'current', label: 'Current cap room', value: fmt(current), color: 'var(--text)' },
+    { key: 'outgoing', label: outgoingLabel, value: out > 0 ? `+${fmt(out)}` : fmt(0), color: out > 0 ? 'var(--success)' : 'var(--text-muted)' },
+    { key: 'incoming', label: incomingLabel, value: inc > 0 ? `-${fmt(inc)}` : fmt(0), color: inc > 0 ? 'var(--warning)' : 'var(--text-muted)' },
+    { key: 'projected', label: 'Projected cap room', value: fmt(projected), color: projectedColor, strong: true },
+  ];
+
+  return (
+    <div
+      className="cap-impact-summary"
+      data-testid="cap-impact-summary"
+      data-over-cap={overCap ? 'true' : 'false'}
+      style={{
+        display: 'grid',
+        gap: 6,
+        border: '1px solid var(--hairline)',
+        borderRadius: 'var(--radius-md)',
+        padding: 'var(--space-3)',
+        background: 'var(--surface)',
+      }}
+    >
+      <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '.08em', color: 'var(--text-subtle)', fontWeight: 700 }}>
+        {title}
+      </div>
+      <div style={{ display: 'grid', gap: 4 }}>
+        {rows.map((row) => (
+          <div
+            key={row.key}
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              gap: 8,
+              fontSize: 'var(--text-xs)',
+              paddingTop: row.strong ? 4 : 0,
+              borderTop: row.strong ? '1px solid var(--hairline)' : 'none',
+            }}
+          >
+            <span style={{ color: 'var(--text-muted)' }}>{row.label}</span>
+            <strong style={{ color: row.color, fontWeight: row.strong ? 800 : 700 }}>{row.value}</strong>
+          </div>
+        ))}
+      </div>
+      {(overCap || tight) && (
+        <div
+          role={overCap ? 'alert' : 'status'}
+          style={{
+            fontSize: 'var(--text-xs)',
+            color: overCap ? 'var(--danger)' : 'var(--warning)',
+            background: overCap ? 'rgba(255,69,58,0.08)' : 'rgba(255,159,10,0.08)',
+            border: `1px solid ${overCap ? 'rgba(255,69,58,0.35)' : 'rgba(255,159,10,0.35)'}`,
+            borderRadius: 'var(--radius-sm)',
+            padding: '6px 8px',
+          }}
+        >
+          {warningText ?? defaultWarning}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/components/common/CapImpactSummary.test.jsx
+++ b/src/ui/components/common/CapImpactSummary.test.jsx
@@ -1,0 +1,57 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import CapImpactSummary from './CapImpactSummary.jsx';
+
+describe('CapImpactSummary', () => {
+  afterEach(cleanup);
+
+  it('renders current room, incoming, outgoing, and projected room', () => {
+    const { getByTestId } = render(
+      <CapImpactSummary currentRoom={20} incoming={5} outgoing={8} projectedRoom={23} />,
+    );
+    const el = getByTestId('cap-impact-summary');
+    expect(el.textContent).toContain('Current cap room');
+    expect(el.textContent).toContain('$20.0M');
+    expect(el.textContent).toContain('Salary added');
+    expect(el.textContent).toContain('-$5.0M');
+    expect(el.textContent).toContain('Salary freed');
+    expect(el.textContent).toContain('+$8.0M');
+    expect(el.textContent).toContain('Projected cap room');
+    expect(el.textContent).toContain('$23.0M');
+  });
+
+  it('computes projected room from current + outgoing - incoming when not provided', () => {
+    const { getByTestId } = render(
+      <CapImpactSummary currentRoom={10} incoming={6} outgoing={2} />,
+    );
+    // 10 + 2 - 6 = 6.0
+    expect(getByTestId('cap-impact-summary').textContent).toContain('$6.0M');
+  });
+
+  it('flags an over-cap projection with an alert and warning copy', () => {
+    const { getByTestId, getByRole } = render(
+      <CapImpactSummary currentRoom={2} incoming={10} outgoing={0} projectedRoom={-8} />,
+    );
+    const el = getByTestId('cap-impact-summary');
+    expect(el.getAttribute('data-over-cap')).toBe('true');
+    expect(getByRole('alert').textContent).toMatch(/over the cap/i);
+    expect(el.textContent).toContain('-$8.0M');
+  });
+
+  it('does not warn when projected room is comfortable', () => {
+    const { getByTestId, queryByRole } = render(
+      <CapImpactSummary currentRoom={40} incoming={5} outgoing={5} projectedRoom={40} />,
+    );
+    expect(getByTestId('cap-impact-summary').getAttribute('data-over-cap')).toBe('false');
+    expect(queryByRole('alert')).toBeNull();
+  });
+
+  it('honours a custom title', () => {
+    const { getByTestId } = render(
+      <CapImpactSummary title="CHI cap impact" currentRoom={10} />,
+    );
+    expect(getByTestId('cap-impact-summary').textContent).toContain('CHI cap impact');
+  });
+});

--- a/src/ui/components/common/StatusEmptyState.jsx
+++ b/src/ui/components/common/StatusEmptyState.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+/**
+ * StatusEmptyState — one consistent presentation for the "nothing to show yet"
+ * states shared across management surfaces (loading, empty, unavailable, error,
+ * filtered-empty).
+ *
+ * It centralises the accessibility + styling decisions that were previously
+ * duplicated inline: error variants announce themselves with role="alert",
+ * everything else uses role="status", and the variant drives colour. An
+ * optional action (e.g. "Reset filters") can be rendered beneath the message.
+ *
+ * Purely presentational — it carries no business logic.
+ *
+ * @param {object} props
+ * @param {"loading"|"empty"|"unavailable"|"error"|"filtered"|string} [props.state]
+ * @param {string} props.title
+ * @param {string} [props.body]
+ * @param {string} [props.testId]      data-testid for targeting in tests.
+ * @param {string} [props.actionLabel] When set with onAction, renders a button.
+ * @param {Function} [props.onAction]
+ */
+export default function StatusEmptyState({
+  state = 'empty',
+  title,
+  body,
+  testId = 'status-empty-state',
+  actionLabel,
+  onAction,
+}) {
+  const isError = state === 'error';
+  return (
+    <div
+      role={isError ? 'alert' : 'status'}
+      data-testid={testId}
+      data-state={state}
+      style={{
+        padding: 'var(--space-8)',
+        textAlign: 'center',
+        color: isError ? 'var(--danger)' : 'var(--text-muted)',
+        display: 'grid',
+        gap: 6,
+        justifyItems: 'center',
+      }}
+    >
+      <div style={{ fontWeight: 700, fontSize: 'var(--text-base)', color: isError ? 'var(--danger)' : 'var(--text)' }}>
+        {title}
+      </div>
+      {body ? <div style={{ fontSize: 'var(--text-sm)', maxWidth: 420 }}>{body}</div> : null}
+      {actionLabel && onAction ? (
+        <button
+          type="button"
+          className="btn"
+          onClick={onAction}
+          style={{ marginTop: 4 }}
+        >
+          {actionLabel}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/ui/components/common/StatusEmptyState.test.jsx
+++ b/src/ui/components/common/StatusEmptyState.test.jsx
@@ -1,0 +1,56 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, fireEvent } from '@testing-library/react';
+import StatusEmptyState from './StatusEmptyState.jsx';
+
+describe('StatusEmptyState', () => {
+  afterEach(cleanup);
+
+  it('uses role="status" for non-error states and exposes the state via data-state', () => {
+    const { getByTestId, getByRole } = render(
+      <StatusEmptyState state="empty" title="No free agents available" body="Check back later." />,
+    );
+    const el = getByTestId('status-empty-state');
+    expect(el.getAttribute('data-state')).toBe('empty');
+    expect(getByRole('status')).toBeTruthy();
+    expect(el.textContent).toContain('No free agents available');
+    expect(el.textContent).toContain('Check back later.');
+  });
+
+  it('uses role="alert" for the error state', () => {
+    const { getByRole } = render(
+      <StatusEmptyState state="error" title="Failed to load free agents" body="Try again." />,
+    );
+    expect(getByRole('alert').textContent).toContain('Failed to load free agents');
+  });
+
+  it('honours a custom testId for targeting', () => {
+    const { getByTestId } = render(
+      <StatusEmptyState testId="fa-load-status" state="loading" title="Loading…" />,
+    );
+    expect(getByTestId('fa-load-status').getAttribute('data-state')).toBe('loading');
+  });
+
+  it('renders an action button only when both actionLabel and onAction are provided', () => {
+    const onAction = vi.fn();
+    const { getByText } = render(
+      <StatusEmptyState
+        state="filtered"
+        title="No players match your filters."
+        actionLabel="Reset filters"
+        onAction={onAction}
+      />,
+    );
+    const btn = getByText('Reset filters');
+    fireEvent.click(btn);
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the action button when no handler is provided', () => {
+    const { queryByText } = render(
+      <StatusEmptyState state="filtered" title="No players match your filters." actionLabel="Reset filters" />,
+    );
+    expect(queryByText('Reset filters')).toBeNull();
+  });
+});


### PR DESCRIPTION
Focused UI/UX clarity pass on the highest-friction management surfaces.
No gameplay, valuation, acceptance, contract, or simulation logic changes.

Shared components (src/ui/components/common):
- CapImpactSummary: reusable cap breakdown (current room → salary out →
  salary in → projected room) with an over-cap warning. Pure display.
- StatusEmptyState: one consistent loading/empty/unavailable/error/filtered
  presentation with correct role (alert vs status) and an optional action.

Trade Center:
- Explicit package status banner (no assets / ready / blocked / rejected /
  accepted / invalid), derived from existing data only.
- Surfaces incoming vs outgoing salary and projected cap room via
  CapImpactSummary before proposing.
- Clearer asset separation ("Your Assets · You Give" / "Their Assets ·
  You Receive"), explicit "Clear Trade" label, and accessible
  Add to Trade / Remove / View Player affordances on asset rows.

Free Agency:
- Routes the load-status block and all filtered-empty states through
  StatusEmptyState for consistent messaging ("No players match your
  filters.") with an obvious Reset filters action; preserves the
  fa-load-status test hook and the freeAgencyLoadStatus foundation.

Tests:
- Unit tests for CapImpactSummary and StatusEmptyState.
- TradeCenter integration: no-asset status, asset separation, cap
  breakdown + ready/rejected status after add/propose.
- FreeAgency state-model presentation across loading/ready/empty/
  unavailable/error/filtered, plus live loading-state mount.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01739eWG8SrFG9S6q4jnZpbf