### PR TITLE
Fix E2E button text matching & enhance HQ stakes messaging

### DIFF
--- a/src/ui/utils/hqHelpers.js
+++ b/src/ui/utils/hqHelpers.js
@@ -59,19 +59,19 @@ export function getTeamStatusLine(team, league, weekly) {
   const { rank: divisionRank, teams: divisionTeams } = getDivisionPosition(team, league);
   const gamesBackDivision = divisionTeams.length > 1 ? getWinPct(divisionTeams[0]) - winPct : 0;
 
-  if (pressure === 'urgent' && week >= 8) return 'Owner pressure: results needed now';
+  if (pressure === 'urgent' && week >= 8) return 'Owner pressure is critical: results needed immediately to save your job';
 
   const lateSeason = week >= 13;
   const inPlayoffPosition = seed != null ? seed <= 7 : winPct >= 0.58;
   const bubbleRecord = winPct >= 0.45 && winPct < 0.58;
 
-  if (lateSeason && !inPlayoffPosition && bubbleRecord) return 'Must-win stretch to stay alive';
-  if (inPlayoffPosition && (divisionRank === 1 || winPct >= 0.64)) return 'Contender track: protect playoff seed';
-  if (divisionRank != null && divisionRank <= 2 && gamesBackDivision <= 0.08 && week >= 6) return 'Division race tightening';
-  if (bubbleRecord && week >= 7) return 'Playoff bubble: every week swings odds';
-  if (ovr >= 84 && winPct < 0.45 && week >= 5) return 'Underachieving relative to roster talent';
+  if (lateSeason && !inPlayoffPosition && bubbleRecord) return 'Must-win stretch to stay alive in the playoff hunt';
+  if (inPlayoffPosition && (divisionRank === 1 || winPct >= 0.64)) return 'Contender track: protect playoff seed at all costs';
+  if (divisionRank != null && divisionRank <= 2 && gamesBackDivision <= 0.08 && week >= 6) return 'Division race tightening - every game matters';
+  if (bubbleRecord && week >= 7) return 'Playoff bubble: every week swings odds drastically';
+  if (ovr >= 84 && winPct < 0.45 && week >= 5) return 'Underachieving relative to roster talent - fans are restless';
   if ((weekly?.direction === 'rebuilding' || ovr < 77) && week >= 5) return 'Rebuild lane: prioritize long-term value';
-  if (pressure === 'warning') return 'Owner expectations rising';
+  if (pressure === 'warning') return 'Owner expectations rising - your seat is getting warm';
 
   return 'Weekly prep window is open';
 }

--- a/tests/e2e/daily_regression.spec.js
+++ b/tests/e2e/daily_regression.spec.js
@@ -168,7 +168,7 @@ test.describe('Daily Regression Pass', () => {
         const hasCutButton = await page.evaluate(async () => {
             const rows = document.querySelectorAll('.standings-table tbody tr, table tbody tr');
             for(let row of rows) {
-                const cutBtn = Array.from(row.querySelectorAll('button')).find(b => b.innerText === 'Cut' || b.innerText === 'Release');
+                const cutBtn = Array.from(row.querySelectorAll('button')).find(b => b.innerText && (b.innerText.toLowerCase().includes('cut') || b.innerText.toLowerCase().includes('release')));
                 if (cutBtn) { cutBtn.click(); return true; }
             }
             return false;
@@ -181,7 +181,7 @@ test.describe('Daily Regression Pass', () => {
             page.on('dialog', d => d.accept());
 
             await page.evaluate(() => {
-                const confirmBtn = Array.from(document.querySelectorAll('button')).find(b => b.innerText === 'Confirm Release');
+                const confirmBtn = Array.from(document.querySelectorAll('button')).find(b => b.innerText && b.innerText.toLowerCase().includes('confirm release'));
                 if (confirmBtn) { confirmBtn.click(); }
             });
 
@@ -220,7 +220,7 @@ test.describe('Daily Regression Pass', () => {
         const playerInfo = await page.evaluate(() => {
             const rows = Array.from(document.querySelectorAll('.standings-table tbody tr, table tbody tr'));
             for (let i = 0; i < rows.length; i++) {
-                const btn = Array.from(rows[i].querySelectorAll('button')).find(b => b.innerText === 'Offer' || b.innerText === 'Update' || b.innerText === 'Sign');
+                const btn = Array.from(rows[i].querySelectorAll('button')).find(b => b.innerText && (b.innerText.toLowerCase().includes('offer') || b.innerText.toLowerCase().includes('update') || b.innerText.toLowerCase().includes('sign')));
                 if (btn && !btn.disabled) {
                     return { index: i, text: btn.innerText };
                 }
@@ -232,7 +232,7 @@ test.describe('Daily Regression Pass', () => {
             // Click "Offer" button
             await page.evaluate((idx) => {
                 const rows = Array.from(document.querySelectorAll('.standings-table tbody tr, table tbody tr'));
-                const btn = Array.from(rows[idx].querySelectorAll('button')).find(b => b.innerText === 'Offer' || b.innerText === 'Update' || b.innerText === 'Sign');
+                const btn = Array.from(rows[idx].querySelectorAll('button')).find(b => b.innerText && (b.innerText.toLowerCase().includes('offer') || b.innerText.toLowerCase().includes('update') || b.innerText.toLowerCase().includes('sign')));
                 if(btn) btn.click();
             }, playerInfo.index);
             await page.waitForTimeout(500);
@@ -240,7 +240,7 @@ test.describe('Daily Regression Pass', () => {
             // Now click "Confirm" in the sign form (which is likely in the next row or same context)
             // The sign form row has "Confirm" button.
             await page.evaluate(() => {
-                 const btn = Array.from(document.querySelectorAll('button')).find(b => b.innerText === 'Confirm');
+                 const btn = Array.from(document.querySelectorAll('button')).find(b => b.innerText && b.innerText.toLowerCase().includes('confirm'));
                  if(btn) btn.click();
             });
             await page.waitForTimeout(2000);
@@ -251,7 +251,7 @@ test.describe('Daily Regression Pass', () => {
             const offerStatus = await page.evaluate(() => {
                 const rows = Array.from(document.querySelectorAll('.standings-table tbody tr, table tbody tr'));
                 for(let row of rows) {
-                    const btn = Array.from(row.querySelectorAll('button')).find(b => b.innerText === 'Update' || b.innerText === 'Revoke' || b.innerText === 'Release');
+                    const btn = Array.from(row.querySelectorAll('button')).find(b => b.innerText && (b.innerText.toLowerCase().includes('update') || b.innerText.toLowerCase().includes('revoke') || b.innerText.toLowerCase().includes('release')));
                     if (btn) return true;
                 }
                 return false;


### PR DESCRIPTION
This commit fixes flakiness in the Playwright end-to-end (E2E) daily regression tests by making the text matching for various action buttons (e.g., "Cut", "Release", "Offer") case-insensitive. This prevents tests from failing when CSS `text-transform` (like uppercase) alters the `.innerText` read by the browser.

Additionally, to satisfy the daily regression requirement of improving tension and emotional clarity (without altering mechanics), the Franchise HQ messaging logic (`src/ui/utils/hqHelpers.js`) has been updated to provide stronger, higher-stakes text for situations such as urgent owner pressure, late-season playoff bubble battles, and division races.

---
*PR created automatically by Jules for task [10176285111551435758](https://jules.google.com/task/10176285111551435758) started by @rbcati*