### PR TITLE
Extend CapImpactSummary into FA inline sign form; dedupe Trade cap display

### DIFF
--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -57,6 +57,7 @@ import { evaluatePendingOfferCapReservation } from "../../core/pendingOfferCapMo
 import { buildShowingLabel, stableSortRows } from "../utils/dataBrowser.js";
 import { resolveFreeAgencyLoadStatus } from "../utils/freeAgencyLoadStatus.js";
 import StatusEmptyState from "./common/StatusEmptyState.jsx";
+import CapImpactSummary from "./common/CapImpactSummary.jsx";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -598,6 +599,9 @@ export function SignInlineForm({ player, capRoom, rosterCount = 53, rosterLimit 
       },
     });
   }, [pendingCapContext, player, annual, years]);
+  // projectedRoom reuses the same post-move figure already shown in this form:
+  // the after-pending reservation when available, otherwise a display estimate of
+  // currentRoom - annual cap hit consistent with the other figures on screen.
   const postMoveCap = proposedReservation?.estimatedCapRoomAfterPending ?? (Number(capRoom) - Number(annual || 0));
   const postMoveRoster = Number(rosterCount) + 1;
   const projectedWarnings = proposedReservation?.warnings ?? [];
@@ -741,6 +745,18 @@ export function SignInlineForm({ player, capRoom, rosterCount = 53, rosterLimit 
             Confirm Bid
           </Button>
         </div>
+      </div>
+
+      {/* Current → this deal → projected room readout at the point of commit. */}
+      <div style={{ marginTop: "var(--space-3)", maxWidth: 360 }}>
+        <CapImpactSummary
+          title={`Sign ${player.name} · cap impact`}
+          currentRoom={capRoom}
+          incoming={Number(annual || 0)}
+          outgoing={0}
+          projectedRoom={postMoveCap}
+          incomingLabel="This contract (annual)"
+        />
       </div>
     </Wrapper>
   );

--- a/src/ui/components/TradeCenter.jsx
+++ b/src/ui/components/TradeCenter.jsx
@@ -125,25 +125,6 @@ function ValueBar({ myValue, theirValue }) {
   );
 }
 
-function CapImpact({ myTeam, theirTeam, myCapAfter, theirCapAfter }) {
-  const myCol = myCapAfter < 0 ? "var(--danger)" : myCapAfter < 10 ? "var(--warning)" : "var(--success)";
-  const theirCol = theirCapAfter < 0 ? "var(--danger)" : theirCapAfter < 10 ? "var(--warning)" : "var(--success)";
-  const fmtCap = (val) => (val < 0 ? `-$${Math.abs(val).toFixed(1)}M` : `$${val.toFixed(1)}M`);
-  return (
-    <div style={{ marginTop: "var(--space-4)", display: "grid", gridTemplateColumns: "1fr auto 1fr", alignItems: "center", gap: "var(--space-3)" }}>
-      <div>
-        <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: "0.5px", marginBottom: 2 }}>{myTeam?.abbr ?? "You"} · Cap After</div>
-        <div style={{ fontSize: "var(--text-xl)", fontWeight: 800, color: myCol }}>{fmtCap(myCapAfter)}</div>
-      </div>
-      <div style={{ textAlign: "center", color: "var(--text-subtle)", fontSize: "var(--text-xs)", lineHeight: 1.3 }}>CAP<br/>SPACE<br/>AFTER</div>
-      <div style={{ textAlign: "right" }}>
-        <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: "0.5px", marginBottom: 2 }}>{theirTeam?.abbr ?? "Them"} · Cap After</div>
-        <div style={{ fontSize: "var(--text-xl)", fontWeight: 800, color: theirCol }}>{fmtCap(theirCapAfter)}</div>
-      </div>
-    </div>
-  );
-}
-
 function pickLabel(pk) {
   const display = buildTradeAssetDisplay(pk, { type: 'pick' });
   return `${display.title}${display.subtitle ? ` · ${display.subtitle}` : ''}`;
@@ -1087,7 +1068,6 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
           {hasSelection && (
             <div className="card" style={{ marginBottom: "var(--space-4)", padding: "var(--space-4) var(--space-5)" }}>
               <ValueBar myValue={myOfferValue} theirValue={theirOfferValue} />
-              <CapImpact myTeam={liveMyTeam} theirTeam={liveTheirTeam} myCapAfter={myCapAfter} theirCapAfter={theirCapAfter} />
               <div style={{ marginTop: "var(--space-3)" }}>
                 <CapImpactSummary
                   title={`${liveMyTeam?.abbr ?? "Your"} cap impact`}

--- a/src/ui/components/__tests__/FreeAgencyInlineSignCapImpact.test.jsx
+++ b/src/ui/components/__tests__/FreeAgencyInlineSignCapImpact.test.jsx
@@ -1,0 +1,46 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import { SignInlineForm } from '../FreeAgency.jsx';
+
+const fmt = (n) => (n < 0 ? `-$${Math.abs(n).toFixed(1)}M` : `$${n.toFixed(1)}M`);
+
+describe('FreeAgency inline sign form — cap impact summary', () => {
+  afterEach(cleanup);
+
+  it('renders the shared cap-impact-summary with current → this contract → projected room', () => {
+    const capRoom = 18;
+    const { getByTestId, container } = render(
+      <SignInlineForm
+        player={{ id: 10, name: 'Inline FA', pos: 'WR', age: 26, ovr: 78, _ask: 6 }}
+        capRoom={capRoom}
+        asDiv
+        onCancel={() => {}}
+        onSubmit={() => {}}
+      />,
+    );
+
+    const summary = getByTestId('cap-impact-summary');
+    expect(summary).toBeTruthy();
+
+    // The annual cap hit is the value the form's salary input already shows.
+    const annualInput = container.querySelector('input[type="number"][step="0.1"]');
+    const annual = parseFloat(annualInput.value);
+    expect(Number.isFinite(annual)).toBe(true);
+
+    // Without a pending-cap context the form's projected figure is currentRoom - annual.
+    const projected = Math.round((capRoom - annual) * 10) / 10;
+
+    // Current room row.
+    expect(summary.textContent).toContain(fmt(capRoom));
+    // "This contract (annual)" deduction row.
+    expect(summary.textContent).toContain('This contract (annual)');
+    expect(summary.textContent).toContain(`-${fmt(annual)}`);
+    // Projected room row matches the form's own post-move figure.
+    expect(summary.textContent).toContain(fmt(projected));
+
+    // Outgoing (freed) row reads $0.0M since signing frees no salary.
+    expect(summary.textContent).toContain('Salary freed');
+  });
+});

--- a/src/ui/components/__tests__/TradeCenterUxCleanup.test.jsx
+++ b/src/ui/components/__tests__/TradeCenterUxCleanup.test.jsx
@@ -86,6 +86,25 @@ describe('TradeCenter — UX cleanup', () => {
     expect(banner.getAttribute('data-tone')).toBe('success');
   });
 
+  it('renders exactly one cap projected-room display (no duplicate legacy block)', async () => {
+    const { findByLabelText, getByTestId, queryAllByTestId, container } = render(
+      <TradeCenter league={makeLeague()} actions={makeActions()} />,
+    );
+
+    fireEvent.click(await findByLabelText(/Add to Trade Give Guy/i));
+    fireEvent.click(await findByLabelText(/Add to Trade Get Guy/i));
+
+    await waitFor(() => {
+      expect(getByTestId('cap-impact-summary')).toBeTruthy();
+    });
+
+    // Only the shared CapImpactSummary should render the projected-room readout.
+    expect(queryAllByTestId('cap-impact-summary')).toHaveLength(1);
+    // The legacy stacked "Cap After" block must be gone.
+    expect(container.textContent).not.toContain('CAPSPACEAFTER');
+    expect(container.textContent).not.toMatch(/CHI · Cap After/);
+  });
+
   it('reports a rejected package clearly after a failed proposal', async () => {
     const { findByLabelText, getByTestId, getAllByText } = render(
       <TradeCenter league={makeLeague()} actions={makeActions()} />,


### PR DESCRIPTION
Display-only consistency pass. No gameplay, valuation, contract,
acceptance, or cap-accounting logic changes — only consumes existing
on-screen values.

Free Agency:
- The inline single-player sign form now renders the shared
  CapImpactSummary (current room → this contract → projected room) at the
  point of commit. currentRoom = userTeam.capRoom (same value the existing
  FA cap panels use), incoming = the offer's annual cap hit, outgoing = 0,
  projectedRoom = the form's existing post-move figure (after-pending
  reservation, else a display estimate of currentRoom - annual).

Trade Center:
- Collapsed the two stacked cap displays into one. Removed the legacy
  CapImpact block so only the shared CapImpactSummary renders the
  authoritative projected cap number. ValueBar and needs/surplus lines
  preserved.

Tests:
- FreeAgency: inline sign form renders the cap-impact-summary testid with
  current room, "this contract (annual)" deduction, and projected room
  matching the figures already shown in the form.
- TradeCenter: asserts exactly one cap projected-room display renders (no
  duplicate legacy block); existing add/propose/rejected assertions intact.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017oCgofP5mgPKszWEiyihp3