### PR TITLE
Navigation/IA Cleanup V1: clearer sections, page orientation, mobile nav

### DIFF
--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -95,6 +95,12 @@ import {
 } from "../utils/shellNavigation.js";
 import { usePhaseRouteHydration } from "../hooks/usePhaseRouteHydration.js";
 import { getPlayerProfileId, hasValidPlayerProfileId } from "../utils/playerProfileNavigation.js";
+import {
+  getPageOrientation,
+  getSectionSubtitle,
+  getTabDisplayLabel,
+} from "../constants/navigationCopy.js";
+import { NAV_GROUPS, HQ_QUICK_TABS } from "../constants/primaryNav.js";
 
 
 // ── TabErrorBoundary ─────────────────────────────────────────────────────────
@@ -222,13 +228,6 @@ const BASE_TABS = [
   "🎙️ Coaches",
 ];
 
-const NAV_GROUPS = [
-  { id: SHELL_SECTIONS.hq, title: "HQ", tabs: ["HQ"] },
-  { id: SHELL_SECTIONS.team, title: "Team Management", tabs: ["Team", "Roster Hub", "Roster", "Depth Chart", "Weekly Prep", "Game Plan", "Training", "Injuries", "Staff", "Financials", "Contract Center", "💰 Cap"] },
-  { id: SHELL_SECTIONS.league, title: "League Office", tabs: ["League", "Weekly Results", "Schedule", "Standings", "Stats", "League Leaders", "Transactions", "Free Agency", "Draft", "History Hub", "Draft History", "History", "Awards & Records", "All-Time Records", "Season Recap"] },
-  { id: SHELL_SECTIONS.news, title: "News", tabs: ["News", "Story", "League Pulse"] },
-];
-
 const NAV_TEST_IDS = {
   [SHELL_SECTIONS.hq]: "nav-hq",
   [SHELL_SECTIONS.team]: "nav-team",
@@ -237,7 +236,6 @@ const NAV_TEST_IDS = {
 };
 
 const TEAM_FACING_TABS = new Set(["Roster", "Depth Chart", "Roster Hub", "Weekly Prep", "Game Plan", "Training", "Injuries", "Staff", "Financials", "Contract Center"]);
-const HQ_QUICK_TABS = ['Roster Hub', 'Schedule', 'Standings', 'Staff'];
 
 const TAB_ALIASES = {
   Trades: "Transactions",
@@ -928,6 +926,14 @@ export default function LeagueDashboard({
             </button>
           ))}
         </div>
+        {getSectionSubtitle(activeSection) ? (
+          <div
+            data-testid="section-subtitle"
+            style={{ fontSize: "11px", color: "var(--text-muted)", paddingLeft: 2, marginTop: -2 }}
+          >
+            {getSectionSubtitle(activeSection)}
+          </div>
+        ) : null}
         <div className="standings-tabs" style={{ flexWrap: "nowrap", overflowX: "auto", gap: 6 }}>
           {(activeSection === SHELL_SECTIONS.hq ? HQ_QUICK_TABS : (NAV_GROUPS.find((group) => group.id === activeSection)?.tabs ?? ['HQ']))
             .filter((tab) => TABS.includes(tab))
@@ -940,11 +946,24 @@ export default function LeagueDashboard({
                 aria-current={activeTab === tab ? "page" : undefined}
                 style={{ flexShrink: 0, fontSize: "11px", padding: "7px 10px" }}
               >
-                {tab}
+                {getTabDisplayLabel(tab)}
               </button>
             ))}
           </div>
       </div>}
+
+      {/* ── Page orientation: a clear "where am I / what is this page for" line.
+            HQ owns its own rich header, so skip it there to avoid duplication. ── */}
+      {!isMobile && activeTab !== "HQ" && getPageOrientation(activeTab) ? (
+        <div data-testid="page-orientation" className="page-orientation" style={{ marginBottom: "var(--space-3)" }}>
+          <div style={{ fontSize: "var(--text-lg)", fontWeight: 800, lineHeight: 1.15 }}>
+            {getPageOrientation(activeTab).title}
+          </div>
+          <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginTop: 2 }}>
+            {getPageOrientation(activeTab).subtitle}
+          </div>
+        </div>
+      ) : null}
 
       {/* ── Tab Content — each tab is independently error-bounded ── */}
       <div className="fade-in" key={activeTab}>

--- a/src/ui/components/MobileNav.jsx
+++ b/src/ui/components/MobileNav.jsx
@@ -1,33 +1,46 @@
 import React, { useState, useEffect } from 'react';
 import { SHELL_SECTIONS } from '../utils/shellNavigation.js';
 
+// More-drawer destinations. Ids are canonical dashboard tab ids that match the
+// LeagueDashboard content switch directly, so every entry routes to a real page.
+// Ordered weekly-loop first so the core game flow is reachable in one tap.
 const MORE_GROUPS = [
   {
-    title: 'Team Management',
+    title: 'Weekly Loop',
     items: [
-      { id: 'Team:Overview', label: 'Team Hub', icon: HomeIcon },
-      { id: 'Team:Roster / Depth', label: 'Roster / Depth', icon: RosterIcon },
-      { id: 'Staff', label: 'Staff', icon: StaffIcon },
-      { id: 'Training', label: 'Training', icon: TrainingIcon },
-      { id: 'Injuries', label: 'Injuries', icon: InjuryIcon },
-      { id: '💰 Cap', label: 'Cap / Financials', icon: FinancesIcon },
-      { id: 'Contract Center', label: 'Contracts', icon: ContractIcon },
+      { id: 'Weekly Results', label: 'Weekly Results', icon: StandingsIcon },
+      { id: 'Schedule', label: 'Schedule', icon: DraftIcon },
+      { id: 'Standings', label: 'Standings', icon: StandingsIcon },
+      { id: 'Stats', label: 'League Stats', icon: AnalyticsIcon },
     ],
   },
   {
-    title: 'League Office',
+    title: 'Team',
     items: [
-      { id: 'League:Overview', label: 'League Hub', icon: StandingsIcon },
-      { id: 'League:Results', label: 'Weekly Results', icon: StandingsIcon },
-      { id: 'Story', label: 'Story', icon: NewsIcon },
-      { id: 'Transactions', label: 'Trades', icon: TradesIcon },
+      { id: 'Roster Hub', label: 'Roster / Depth', icon: RosterIcon },
+      { id: 'Game Plan', label: 'Game Plan', icon: TrainingIcon },
+      { id: 'Staff', label: 'Staff', icon: StaffIcon },
+      { id: 'Injuries', label: 'Injuries', icon: InjuryIcon },
+      { id: 'Contract Center', label: 'Contracts', icon: ContractIcon },
+      { id: '💰 Cap', label: 'Salary Cap', icon: FinancesIcon },
+    ],
+  },
+  {
+    title: 'Front Office',
+    items: [
+      { id: 'Transactions', label: 'Trade', icon: TradesIcon },
       { id: 'Free Agency', label: 'Free Agency', icon: FAIcon },
       { id: 'Draft', label: 'Draft', icon: DraftIcon },
-      { id: 'league-leaders', label: 'League Leaders', icon: StandingsIcon },
       { id: 'History Hub', label: 'History', icon: HomeIcon },
+      { id: 'Awards & Records', label: 'Awards & Records', icon: StandingsIcon },
+    ],
+  },
+  {
+    title: 'Tools',
+    items: [
+      { id: '🤖 GM Advisor', label: 'GM Advisor', icon: AdvisorIcon },
       { id: 'Analytics', label: 'Analytics', icon: AnalyticsIcon },
       { id: 'Saves', label: 'Saves', icon: SaveIcon },
-      { id: '🤖 GM Advisor', label: 'GM Advisor', icon: AdvisorIcon },
       { id: 'God Mode', label: 'God Mode', icon: GodModeIcon },
     ],
   },

--- a/src/ui/components/MobileNav.test.jsx
+++ b/src/ui/components/MobileNav.test.jsx
@@ -33,8 +33,32 @@ describe('MobileNav', () => {
     );
 
     expect(html).toContain('Command Menu');
-    expect(html).toContain('Trades');
+    expect(html).toContain('Trade');
     expect(html).toContain('Free Agency');
     expect(html).toContain('League');
+  });
+
+  it('surfaces the weekly-loop group first with core destinations reachable', () => {
+    const html = renderToString(
+      <MobileNav
+        activeSection={SHELL_SECTIONS.hq}
+        onSectionChange={vi.fn()}
+        onDestinationChange={vi.fn()}
+        league={{ year: 2026, phase: 'regular' }}
+      />,
+    );
+
+    // Weekly Loop group is present and ordered ahead of Front Office.
+    expect(html).toContain('Weekly Loop');
+    expect(html).toContain('Front Office');
+    expect(html.indexOf('Weekly Loop')).toBeLessThan(html.indexOf('Front Office'));
+
+    // Core weekly-loop destinations are reachable from the drawer on mobile.
+    for (const label of ['Weekly Results', 'Schedule', 'Standings', 'League Stats']) {
+      expect(html).toContain(label);
+    }
+    // No vague "office/management" hub headings remain in the drawer.
+    expect(html).not.toContain('League Office');
+    expect(html).not.toContain('Team Management');
   });
 });

--- a/src/ui/constants/navigationCopy.js
+++ b/src/ui/constants/navigationCopy.js
@@ -6,6 +6,77 @@ export const NAV_LABELS = Object.freeze({
   more: 'More',
 });
 
+// Short helper text shown under each primary nav section so a new GM can tell
+// what lives where without clicking through. Keyed by shell section id.
+export const SECTION_SUBTITLES = Object.freeze({
+  hq: 'Your weekly command center',
+  team: 'Roster, depth chart, staff & finances',
+  league: 'Standings, stats, trades, draft & history',
+  news: 'Headlines & franchise storylines',
+});
+
+// Single source of truth for per-page orientation copy: a clear title and a one
+// line "what is this page for" subtitle. Keyed by the canonical dashboard tab
+// id (the same string stored in activeTab / listed in NAV_GROUPS). Display only.
+export const PAGE_ORIENTATION = Object.freeze({
+  HQ: { title: 'Franchise HQ', subtitle: 'Review results, set your plan, then advance the week.' },
+
+  Team: { title: 'Team', subtitle: 'Manage your roster, depth chart, staff, and finances.' },
+  'Roster Hub': { title: 'Roster Hub', subtitle: 'Review your players, ratings, and roster needs.' },
+  Roster: { title: 'Roster', subtitle: 'Your full player roster.' },
+  'Depth Chart': { title: 'Depth Chart', subtitle: 'Set starters and depth before the next game.' },
+  'Game Plan': { title: 'Game Plan', subtitle: 'Tune your offensive and defensive schemes for this week.' },
+  'Weekly Prep': { title: 'Weekly Prep', subtitle: 'Final checklist before you advance the week.' },
+  Training: { title: 'Training', subtitle: 'Set weekly player development focus.' },
+  Injuries: { title: 'Injury Report', subtitle: 'Track injured players and recovery timelines.' },
+  Staff: { title: 'Coaching Staff', subtitle: 'Manage coaches and their philosophies.' },
+  Financials: { title: 'Finances', subtitle: 'Review franchise revenue, expenses, and budget.' },
+  'Contract Center': { title: 'Contracts', subtitle: 'Negotiate extensions and manage player deals.' },
+  '💰 Cap': { title: 'Salary Cap', subtitle: 'Track cap space, commitments, and dead money.' },
+
+  League: { title: 'League', subtitle: 'Standings, stats, transactions, draft, and history across the league.' },
+  Standings: { title: 'Standings', subtitle: 'Division and conference standings and playoff seeding.' },
+  Schedule: { title: 'Schedule', subtitle: 'Your full season schedule and upcoming games.' },
+  'Weekly Results': { title: 'Weekly Results', subtitle: 'Scores and box scores from the latest week.' },
+  Stats: { title: 'League Stats', subtitle: 'Team and player statistical leaders.' },
+  Leaders: { title: 'League Leaders', subtitle: 'Statistical leaders by category.' },
+  'League Leaders': { title: 'League Leaders', subtitle: 'Statistical leaders by category.' },
+  Transactions: { title: 'Trade Center', subtitle: 'Build, evaluate, and propose trades.' },
+  'Free Agency': { title: 'Free Agency', subtitle: 'Browse and sign available free agents.' },
+  Draft: { title: 'Draft', subtitle: 'Scout prospects and make your picks.' },
+  'History Hub': { title: 'History', subtitle: 'Champions, records, awards, and franchise history.' },
+  'Draft History': { title: 'Draft History', subtitle: 'Past draft classes and pick outcomes.' },
+  History: { title: 'History', subtitle: 'Champions, records, awards, and franchise history.' },
+  'Awards & Records': { title: 'Awards & Records', subtitle: 'Season awards and all-time records.' },
+  'All-Time Records': { title: 'All-Time Records', subtitle: 'The league record book.' },
+  'Season Recap': { title: 'Season Recap', subtitle: 'A look back at the season that was.' },
+
+  News: { title: 'News', subtitle: 'League headlines, storylines, and your franchise pulse.' },
+});
+
+// Display-label overrides for sub-nav buttons. The underlying tab id (used for
+// routing and test ids) is unchanged — only the visible button text is clarified
+// so the label matches its destination. Keyed by canonical tab id.
+export const TAB_DISPLAY_LABELS = Object.freeze({
+  Transactions: 'Trade',
+  'History Hub': 'History',
+  '💰 Cap': 'Salary Cap',
+  Financials: 'Finances',
+  'League Leaders': 'Leaders',
+});
+
+export function getPageOrientation(tab) {
+  return PAGE_ORIENTATION[tab] ?? null;
+}
+
+export function getSectionSubtitle(sectionId) {
+  return SECTION_SUBTITLES[sectionId] ?? '';
+}
+
+export function getTabDisplayLabel(tab) {
+  return TAB_DISPLAY_LABELS[tab] ?? tab;
+}
+
 export const ACTION_LABELS = Object.freeze({
   advanceWeek: 'Advance Week',
   advanceFranchise: 'Advance Franchise',

--- a/src/ui/constants/navigationCopy.test.js
+++ b/src/ui/constants/navigationCopy.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PAGE_ORIENTATION,
+  SECTION_SUBTITLES,
+  TAB_DISPLAY_LABELS,
+  getPageOrientation,
+  getSectionSubtitle,
+  getTabDisplayLabel,
+} from './navigationCopy.js';
+
+// Pages that must carry honest "where am I / what is this for" orientation copy.
+const KEY_PAGES = [
+  'HQ',
+  'Schedule',
+  'Weekly Results',
+  'Roster Hub',
+  'Depth Chart',
+  'Transactions',
+  'Free Agency',
+  'Stats',
+  'Standings',
+  'Draft',
+  'History Hub',
+  'Awards & Records',
+];
+
+describe('navigation page orientation copy', () => {
+  it('provides a clear title and subtitle for every key page', () => {
+    for (const tab of KEY_PAGES) {
+      const orientation = getPageOrientation(tab);
+      expect(orientation, `missing orientation for ${tab}`).toBeTruthy();
+      expect(typeof orientation.title).toBe('string');
+      expect(orientation.title.length).toBeGreaterThan(0);
+      expect(typeof orientation.subtitle).toBe('string');
+      expect(orientation.subtitle.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns null for unknown destinations rather than throwing', () => {
+    expect(getPageOrientation('Not A Real Tab')).toBeNull();
+    expect(getPageOrientation(undefined)).toBeNull();
+  });
+
+  it('keeps the orientation map frozen and self-consistent', () => {
+    expect(Object.isFrozen(PAGE_ORIENTATION)).toBe(true);
+    // The Trade Center page is oriented as a trade page, not a vague "transactions" bucket.
+    expect(PAGE_ORIENTATION.Transactions.title.toLowerCase()).toContain('trade');
+  });
+});
+
+describe('section subtitles', () => {
+  it('describes the purpose of each primary nav section', () => {
+    for (const section of ['hq', 'team', 'league', 'news']) {
+      expect(getSectionSubtitle(section).length).toBeGreaterThan(0);
+    }
+    expect(Object.isFrozen(SECTION_SUBTITLES)).toBe(true);
+  });
+
+  it('returns an empty string for unknown sections', () => {
+    expect(getSectionSubtitle('nope')).toBe('');
+  });
+});
+
+describe('tab display labels', () => {
+  it('clarifies vague tab ids so the label matches the destination', () => {
+    expect(getTabDisplayLabel('Transactions')).toBe('Trade');
+    expect(getTabDisplayLabel('History Hub')).toBe('History');
+    expect(getTabDisplayLabel('💰 Cap')).toBe('Salary Cap');
+    expect(Object.isFrozen(TAB_DISPLAY_LABELS)).toBe(true);
+  });
+
+  it('passes through ids that already read clearly', () => {
+    expect(getTabDisplayLabel('Standings')).toBe('Standings');
+    expect(getTabDisplayLabel('Free Agency')).toBe('Free Agency');
+  });
+});

--- a/src/ui/constants/primaryNav.js
+++ b/src/ui/constants/primaryNav.js
@@ -1,0 +1,25 @@
+import { SHELL_SECTIONS } from '../utils/shellNavigation.js';
+
+// Primary nav sections for the desktop shell. Titles are direct labels (no vague
+// "Office"/"Management" hub names); sub-tab order follows the core weekly loop so
+// the most-used destinations come first. Tab ids are unchanged from the legacy
+// nav — only ordering and the visible section label differ — so routing, deep
+// links, and `section-tab-*` test ids stay stable.
+export const NAV_GROUPS = [
+  { id: SHELL_SECTIONS.hq, title: 'HQ', tabs: ['HQ'] },
+  {
+    id: SHELL_SECTIONS.team,
+    title: 'Team',
+    tabs: ['Team', 'Roster Hub', 'Depth Chart', 'Game Plan', 'Weekly Prep', 'Roster', 'Training', 'Injuries', 'Staff', 'Contract Center', 'Financials', '💰 Cap'],
+  },
+  {
+    id: SHELL_SECTIONS.league,
+    title: 'League',
+    tabs: ['League', 'Weekly Results', 'Schedule', 'Standings', 'Stats', 'League Leaders', 'Free Agency', 'Transactions', 'Draft', 'History Hub', 'Awards & Records', 'Draft History', 'History', 'All-Time Records', 'Season Recap'],
+  },
+  { id: SHELL_SECTIONS.news, title: 'News', tabs: ['News', 'Story', 'League Pulse'] },
+];
+
+// Quick links surfaced under HQ — the destinations a GM is most likely to want
+// next in the weekly loop. Each must exist in the dashboard's BASE_TABS.
+export const HQ_QUICK_TABS = ['Weekly Results', 'Schedule', 'Roster Hub', 'Standings', 'Free Agency', 'Transactions'];

--- a/src/ui/constants/primaryNav.test.js
+++ b/src/ui/constants/primaryNav.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { NAV_GROUPS, HQ_QUICK_TABS } from './primaryNav.js';
+import { SHELL_SECTIONS, getShellSectionForDashboardTab } from '../utils/shellNavigation.js';
+
+const flatTabs = NAV_GROUPS.flatMap((group) => group.tabs);
+const tabsFor = (sectionId) => NAV_GROUPS.find((g) => g.id === sectionId)?.tabs ?? [];
+
+describe('primary navigation structure', () => {
+  it('exposes exactly the four shell sections with direct labels', () => {
+    expect(NAV_GROUPS.map((g) => g.id)).toEqual([
+      SHELL_SECTIONS.hq,
+      SHELL_SECTIONS.team,
+      SHELL_SECTIONS.league,
+      SHELL_SECTIONS.news,
+    ]);
+    expect(NAV_GROUPS.map((g) => g.title)).toEqual(['HQ', 'Team', 'League', 'News']);
+  });
+
+  it('drops vague "hub"-style section labels', () => {
+    for (const group of NAV_GROUPS) {
+      expect(group.title).not.toMatch(/office|management/i);
+    }
+  });
+
+  it('keeps every core weekly-loop destination directly discoverable', () => {
+    const core = [
+      'HQ',
+      'Schedule',
+      'Weekly Results',
+      'Roster Hub',
+      'Depth Chart',
+      'Transactions', // Trade Center
+      'Free Agency',
+      'Stats',
+      'Standings',
+      'Draft',
+      'History Hub',
+      'Awards & Records',
+    ];
+    for (const tab of core) {
+      expect(flatTabs, `missing nav destination: ${tab}`).toContain(tab);
+    }
+  });
+
+  it('orders the league section around the weekly loop before deep archives', () => {
+    const league = tabsFor(SHELL_SECTIONS.league);
+    // Core results/standings/stats come before historical archive tabs.
+    expect(league.indexOf('Weekly Results')).toBeLessThan(league.indexOf('Draft History'));
+    expect(league.indexOf('Standings')).toBeLessThan(league.indexOf('Season Recap'));
+    for (const tab of ['Schedule', 'Standings', 'Stats', 'Free Agency', 'Transactions', 'Draft']) {
+      expect(league).toContain(tab);
+    }
+  });
+
+  it('leads the team section with the roster/depth flow', () => {
+    const team = tabsFor(SHELL_SECTIONS.team);
+    expect(team.indexOf('Roster Hub')).toBeLessThan(team.indexOf('Financials'));
+    expect(team.indexOf('Depth Chart')).toBeLessThan(team.indexOf('💰 Cap'));
+  });
+});
+
+describe('nav destinations still route to existing sections', () => {
+  it('maps every team-section tab back to the team shell section', () => {
+    for (const tab of tabsFor(SHELL_SECTIONS.team)) {
+      expect(getShellSectionForDashboardTab(tab)).toBe(SHELL_SECTIONS.team);
+    }
+  });
+
+  it('maps the league weekly-loop tabs back to the league shell section', () => {
+    const loopTabs = [
+      'Weekly Results', 'Schedule', 'Standings', 'Stats', 'League Leaders',
+      'Free Agency', 'Transactions', 'Draft', 'History Hub', 'Awards & Records',
+    ];
+    for (const tab of loopTabs) {
+      expect(getShellSectionForDashboardTab(tab)).toBe(SHELL_SECTIONS.league);
+    }
+  });
+});
+
+describe('HQ quick links', () => {
+  it('surfaces the most likely next actions in the weekly loop', () => {
+    for (const tab of ['Weekly Results', 'Schedule', 'Roster Hub', 'Standings', 'Free Agency', 'Transactions']) {
+      expect(HQ_QUICK_TABS).toContain(tab);
+    }
+  });
+
+  it('routes each quick link to a reachable shell section', () => {
+    for (const tab of HQ_QUICK_TABS) {
+      const section = getShellSectionForDashboardTab(tab);
+      expect([SHELL_SECTIONS.team, SHELL_SECTIONS.league, SHELL_SECTIONS.hq]).toContain(section);
+    }
+  });
+});


### PR DESCRIPTION
UI-only, presentational navigation and orientation pass. No simulation,
gameplay, trade, free-agency, contract, draft, roster, or data changes.

- Rename vague primary-nav hubs ("Team Management" -> "Team",
  "League Office" -> "League") and reorder sub-tabs around the weekly loop.
- Extract the desktop nav model to constants/primaryNav.js so structure and
  routing are unit-testable; tab ids/test ids/deep links unchanged.
- Add navigationCopy: section subtitles, per-page orientation (title +
  "what is this for" subtitle), and display-label overrides so labels match
  destinations (Transactions -> Trade, History Hub -> History, Cap -> Salary Cap).
- Render a section subtitle and a non-HQ page-orientation header in the shell.
- Improve HQ quick links to surface the most likely next actions.
- Rework mobile More drawer: weekly-loop-first grouping, canonical tab ids that
  route directly (fixes latent colon-id mismatches), Schedule/Standings/Stats
  now reachable on mobile.
- Tests: primaryNav structure + route-mapping, navigationCopy orientation/labels,
  expanded MobileNav coverage.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018fs1jJx7uwSXUUXhv1KbDB