### PR TITLE
Nav/IA Cleanup V1.1: mobile page orientation, more page copy, HQ action cues

### DIFF
--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -96,11 +96,12 @@ import {
 import { usePhaseRouteHydration } from "../hooks/usePhaseRouteHydration.js";
 import { getPlayerProfileId, hasValidPlayerProfileId } from "../utils/playerProfileNavigation.js";
 import {
-  getPageOrientation,
   getSectionSubtitle,
   getTabDisplayLabel,
+  getNextActionLabel,
 } from "../constants/navigationCopy.js";
 import { NAV_GROUPS, HQ_QUICK_TABS } from "../constants/primaryNav.js";
+import PageOrientationHeader from "./PageOrientationHeader.jsx";
 
 
 // ── TabErrorBoundary ─────────────────────────────────────────────────────────
@@ -946,24 +947,17 @@ export default function LeagueDashboard({
                 aria-current={activeTab === tab ? "page" : undefined}
                 style={{ flexShrink: 0, fontSize: "11px", padding: "7px 10px" }}
               >
-                {getTabDisplayLabel(tab)}
+                {activeSection === SHELL_SECTIONS.hq ? getNextActionLabel(tab) : getTabDisplayLabel(tab)}
               </button>
             ))}
           </div>
       </div>}
 
       {/* ── Page orientation: a clear "where am I / what is this page for" line.
-            HQ owns its own rich header, so skip it there to avoid duplication. ── */}
-      {!isMobile && activeTab !== "HQ" && getPageOrientation(activeTab) ? (
-        <div data-testid="page-orientation" className="page-orientation" style={{ marginBottom: "var(--space-3)" }}>
-          <div style={{ fontSize: "var(--text-lg)", fontWeight: 800, lineHeight: 1.15 }}>
-            {getPageOrientation(activeTab).title}
-          </div>
-          <div style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", marginTop: 2 }}>
-            {getPageOrientation(activeTab).subtitle}
-          </div>
-        </div>
-      ) : null}
+            Rendered on both desktop and mobile so deep pages stay oriented on
+            small screens too. HQ owns its own rich header, so the component
+            skips it to avoid duplication. ── */}
+      <PageOrientationHeader tab={activeTab} />
 
       {/* ── Tab Content — each tab is independently error-bounded ── */}
       <div className="fade-in" key={activeTab}>

--- a/src/ui/components/PageOrientationHeader.jsx
+++ b/src/ui/components/PageOrientationHeader.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { getPageOrientation } from '../constants/navigationCopy.js';
+
+/**
+ * PageOrientationHeader
+ *
+ * Compact "where am I / what is this page for" header rendered above page content
+ * on both desktop and mobile. It is purely presentational — no navigation or data
+ * side effects.
+ *
+ * HQ owns its own rich header, so it is intentionally skipped here to avoid a
+ * duplicate title. Returns null when there is no orientation copy for the active
+ * tab, so unknown destinations render nothing rather than an empty box.
+ */
+export default function PageOrientationHeader({ tab }) {
+  if (tab === 'HQ') return null;
+  const orientation = getPageOrientation(tab);
+  if (!orientation) return null;
+
+  return (
+    <div
+      data-testid="page-orientation"
+      className="page-orientation"
+      style={{ marginBottom: 'var(--space-3)' }}
+    >
+      <div style={{ fontSize: 'var(--text-lg)', fontWeight: 800, lineHeight: 1.15 }}>
+        {orientation.title}
+      </div>
+      <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', marginTop: 2 }}>
+        {orientation.subtitle}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/PageOrientationHeader.test.jsx
+++ b/src/ui/components/PageOrientationHeader.test.jsx
@@ -1,0 +1,34 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import PageOrientationHeader from './PageOrientationHeader.jsx';
+import { getPageOrientation } from '../constants/navigationCopy.js';
+
+describe('PageOrientationHeader', () => {
+  afterEach(() => cleanup());
+
+  it('renders the title and subtitle for a known page', () => {
+    render(<PageOrientationHeader tab="Free Agency" />);
+    const header = screen.getByTestId('page-orientation');
+    const expected = getPageOrientation('Free Agency');
+    expect(header.textContent).toContain(expected.title);
+    expect(header.textContent).toContain(expected.subtitle);
+  });
+
+  it('orients deep mobile-reachable pages like Hall of Fame', () => {
+    render(<PageOrientationHeader tab="Hall of Fame" />);
+    expect(screen.getByTestId('page-orientation').textContent).toMatch(/hall of fame/i);
+  });
+
+  it('renders nothing for HQ, which owns its own header', () => {
+    const { container } = render(<PageOrientationHeader tab="HQ" />);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId('page-orientation')).toBeNull();
+  });
+
+  it('renders nothing for an unknown destination instead of an empty box', () => {
+    const { container } = render(<PageOrientationHeader tab="Not A Real Tab" />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/ui/constants/navigationCopy.js
+++ b/src/ui/constants/navigationCopy.js
@@ -50,8 +50,19 @@ export const PAGE_ORIENTATION = Object.freeze({
   'Awards & Records': { title: 'Awards & Records', subtitle: 'Season awards and all-time records.' },
   'All-Time Records': { title: 'All-Time Records', subtitle: 'The league record book.' },
   'Season Recap': { title: 'Season Recap', subtitle: 'A look back at the season that was.' },
+  'Hall of Fame': { title: 'Hall of Fame', subtitle: 'The all-time greats enshrined across league history.' },
+  'Award Races': { title: 'Award Races', subtitle: 'Who is leading the MVP and other award races right now.' },
+  'Team History': { title: 'Team History', subtitle: 'Season-by-season results and franchise records.' },
+  Almanac: { title: 'League Almanac', subtitle: 'Champions, leaders, and milestones, year by year.' },
+  Postseason: { title: 'Postseason', subtitle: 'Playoff bracket, seeding, and results.' },
+  'Mock Draft': { title: 'Mock Draft', subtitle: 'Simulate how the draft board could fall.' },
+  Offseason: { title: 'Offseason', subtitle: 'Work through the offseason checklist toward the new season.' },
+  Analytics: { title: 'Analytics', subtitle: 'Advanced team and player performance metrics.' },
 
   News: { title: 'News', subtitle: 'League headlines, storylines, and your franchise pulse.' },
+  Story: { title: 'Franchise Story', subtitle: 'Your franchise narrative and major storylines.' },
+  'League Pulse': { title: 'League Pulse', subtitle: 'The mood and momentum shifts across the league.' },
+  '🤖 GM Advisor': { title: 'GM Advisor', subtitle: 'Suggested next moves for your franchise.' },
 });
 
 // Display-label overrides for sub-nav buttons. The underlying tab id (used for
@@ -75,6 +86,25 @@ export function getSectionSubtitle(sectionId) {
 
 export function getTabDisplayLabel(tab) {
   return TAB_DISPLAY_LABELS[tab] ?? tab;
+}
+
+// Action-phrased labels for the HQ next-action quick links. The underlying tab id
+// (used for routing and `section-tab-*` test ids) is unchanged — only the visible
+// chip text becomes a verb-first cue ("Check Roster" vs. a bare "Roster Hub") so a
+// new GM reads HQ as a weekly to-do list. Keyed by canonical tab id. Display only.
+export const HQ_NEXT_ACTIONS = Object.freeze({
+  'Weekly Results': 'Review Results',
+  Schedule: 'View Schedule',
+  'Roster Hub': 'Check Roster',
+  'Depth Chart': 'Set Depth Chart',
+  Standings: 'View Standings',
+  Stats: 'View Stats',
+  'Free Agency': 'Check Free Agents',
+  Transactions: 'Review Trade Market',
+});
+
+export function getNextActionLabel(tab) {
+  return HQ_NEXT_ACTIONS[tab] ?? getTabDisplayLabel(tab);
 }
 
 export const ACTION_LABELS = Object.freeze({

--- a/src/ui/constants/navigationCopy.test.js
+++ b/src/ui/constants/navigationCopy.test.js
@@ -3,9 +3,11 @@ import {
   PAGE_ORIENTATION,
   SECTION_SUBTITLES,
   TAB_DISPLAY_LABELS,
+  HQ_NEXT_ACTIONS,
   getPageOrientation,
   getSectionSubtitle,
   getTabDisplayLabel,
+  getNextActionLabel,
 } from './navigationCopy.js';
 
 // Pages that must carry honest "where am I / what is this for" orientation copy.
@@ -22,6 +24,7 @@ const KEY_PAGES = [
   'Draft',
   'History Hub',
   'Awards & Records',
+  'Hall of Fame',
 ];
 
 describe('navigation page orientation copy', () => {
@@ -72,5 +75,29 @@ describe('tab display labels', () => {
   it('passes through ids that already read clearly', () => {
     expect(getTabDisplayLabel('Standings')).toBe('Standings');
     expect(getTabDisplayLabel('Free Agency')).toBe('Free Agency');
+  });
+});
+
+describe('HQ next-action cues', () => {
+  it('phrases the weekly-loop quick links as verb-first actions', () => {
+    expect(Object.isFrozen(HQ_NEXT_ACTIONS)).toBe(true);
+    expect(getNextActionLabel('Weekly Results')).toMatch(/review/i);
+    expect(getNextActionLabel('Roster Hub')).toMatch(/check roster/i);
+    expect(getNextActionLabel('Depth Chart')).toMatch(/depth chart/i);
+    expect(getNextActionLabel('Free Agency')).toMatch(/free agent/i);
+    expect(getNextActionLabel('Transactions')).toMatch(/trade/i);
+    expect(getNextActionLabel('Standings')).toMatch(/standings/i);
+  });
+
+  it('falls back to the display label for tabs without an action cue', () => {
+    // No action cue defined -> reuse the clarified display label, not a raw id.
+    expect(getNextActionLabel('History Hub')).toBe('History');
+    expect(getNextActionLabel('Draft')).toBe('Draft');
+  });
+
+  it('only references tabs that also carry page orientation copy', () => {
+    for (const tab of Object.keys(HQ_NEXT_ACTIONS)) {
+      expect(getPageOrientation(tab), `missing orientation for HQ action ${tab}`).toBeTruthy();
+    }
   });
 });


### PR DESCRIPTION
Focused presentational follow-up to PR #1630. No simulation, gameplay,
trade, free-agency, contract, draft, roster, or data changes.

- Extract the page-orientation header into a small reusable
  PageOrientationHeader component and render it on mobile as well as
  desktop, so deep pages (Free Agency, Trade, Standings, Hall of Fame,
  etc.) keep a "where am I / what is this for" cue on small screens.
  Previously the header was desktop-only.
- Fill in honest orientation copy for visible pages that fell back to
  nothing: Hall of Fame (a spec-named key page), Award Races, Team
  History, Almanac, Postseason, Mock Draft, Offseason, Analytics, Story,
  League Pulse, GM Advisor.
- Add HQ_NEXT_ACTIONS verb-first labels so HQ quick links read as a
  weekly to-do list ("Check Roster", "Review Trade Market") while keeping
  tab ids / section-tab test ids / routing unchanged.
- Tests: new PageOrientationHeader render coverage (known page, HQ skip,
  unknown destination); extend navigationCopy tests for the new
  orientation entries and HQ action cues.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CEppu6CbN5EmDuyNtQEJPC