### PR TITLE
Mobile Match Review Flow V1: focused Game Book mode, post-sim HQ cleanup, blank-pill fix

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -53,6 +53,7 @@ import EventDecisionModal from './components/EventDecisionModal.jsx';
 import { SettingsProvider, useSettings } from './context/SettingsContext.jsx';
 import { ACTION_LABELS, formatRegularUnitLabel } from './constants/navigationCopy.js';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from './utils/boxScoreAccess.js';
+import { getDisplayableNotifications } from './utils/notificationsDisplay.js';
 import { buildOffseasonActionCenter } from './utils/offseasonActionCenter.js';
 import {
   hasMinimumPlayableLeague,
@@ -1343,9 +1344,12 @@ function AppContent() {
       ) : null}
 
       {/* ── Notifications ──────────────────────────────────────────────── */}
-      {Array.isArray(notifications) && notifications.length > 0 && (
+      {/* Only notifications with real, visible content render a dismissible
+          pill — empty entries would otherwise show as a blank gray block with
+          just an "×" in the post-sim / weekly-results area. */}
+      {getDisplayableNotifications(notifications).length > 0 && (
         <div className="app-notifications">
-          {notifications.map(n => (
+          {getDisplayableNotifications(notifications).map(n => (
             <div
               key={n.id}
               className={`app-notification ${n.level === 'warn' ? 'app-notification-warn' : 'app-notification-info'}`}

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -128,6 +128,9 @@ function loadHQStoredPlan() {
 export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = null, onNavigate, onAdvanceWeek, busy, simulating, actions }) {
   const [lineupToast, setLineupToast] = useState(null);
   const [showGate, setShowGate] = useState(false);
+  // Tracks the week whose post-sim "week complete" status strip the user has
+  // dismissed, so the compact strip stays gone until the next week is played.
+  const [dismissedStripWeek, setDismissedStripWeek] = useState(null);
   const command = useMemo(() => selectFranchiseHQViewModel(league), [league]);
   const hqPrep = useMemo(() => deriveWeeklyPrepState(league), [league]);
   const hqWeeklyContext = useMemo(() => evaluateWeeklyContext(league), [league]);
@@ -272,9 +275,18 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
       label: tied ? 'T' : userWon ? 'W' : 'L',
       tone: tied ? 'info' : userWon ? 'ok' : 'danger',
       text: `${userScore}–${oppScore} vs ${oppAbbr}${weekNum ? ` · Wk${weekNum}` : ''}`,
+      oppAbbr,
+      week: weekNum || null,
       gameId,
     };
   }, [lastGame, league?.userTeamId]);
+
+  // Compact, dismissible post-sim acknowledgement strip. Low visual weight,
+  // single line. Shows once per completed week so the HQ answers "what just
+  // happened?" without auto-expanding full Weekly Results on return.
+  const showPostSimStrip = Boolean(
+    lastResultRow && lastResultRow.week != null && dismissedStripWeek !== lastResultRow.week,
+  );
 
   // Division standings for mini-table (max 4 rows)
   const divisionRows = useMemo(() => {
@@ -493,6 +505,30 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
           <span className="hq-topbar-seg__secondary">{command.seasonLabel}</span>
         </button>
       </header>
+
+      {/* ── POST-SIM STATUS STRIP — compact, dismissible, single line ────── */}
+      {showPostSimStrip && (
+        <div className="hq-postsim-strip" data-testid="hq-postsim-status-strip" data-week={lastResultRow.week}>
+          <button
+            type="button"
+            className="hq-postsim-strip__main"
+            onClick={() => onNavigate?.('Weekly Results')}
+            aria-label={`Week ${lastResultRow.week} complete. Tap to review results.`}
+          >
+            <span className="hq-postsim-strip__dot" aria-hidden="true" />
+            <span className="hq-postsim-strip__text">Week {lastResultRow.week} complete · Tap to review results</span>
+          </button>
+          <button
+            type="button"
+            className="hq-postsim-strip__dismiss"
+            data-testid="hq-postsim-status-strip-dismiss"
+            onClick={() => setDismissedStripWeek(lastResultRow.week)}
+            aria-label="Dismiss week complete notice"
+          >
+            ×
+          </button>
+        </div>
+      )}
 
       {/* ── LAST RESULT ROW — single line, tappable → box score ─────────── */}
       {lastResultRow && (

--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -16,6 +16,61 @@ function findScheduleGame(league, gameId) {
   return null;
 }
 
+// Compact, mobile-first sticky chrome for the Game Book. Keeps the final score,
+// W/L result, week, and a return action above the fold so the user never has to
+// scroll to see the outcome or get back to HQ. Presentational only — it reads
+// from the already-built box-score view model and never recomputes any result.
+function GameBookStickyHeader({ detailVm, userTeamId, week, onBack, backLabel }) {
+  const hasFinal = Boolean(detailVm?.availableData?.finalScore);
+  const home = detailVm?.homeTeam ?? null;
+  const away = detailVm?.awayTeam ?? null;
+  const homeScore = detailVm?.finalScore?.home;
+  const awayScore = detailVm?.finalScore?.away;
+
+  let outcome = null; // { label, tone }
+  if (hasFinal && userTeamId != null && home && away) {
+    const userIsHome = Number(home.id) === Number(userTeamId);
+    const userIsAway = Number(away.id) === Number(userTeamId);
+    if (userIsHome || userIsAway) {
+      const userScore = userIsHome ? homeScore : awayScore;
+      const oppScore = userIsHome ? awayScore : homeScore;
+      if (Number(userScore) === Number(oppScore)) outcome = { label: 'T', tone: 'info' };
+      else if (Number(userScore) > Number(oppScore)) outcome = { label: 'W', tone: 'ok' };
+      else outcome = { label: 'L', tone: 'danger' };
+    }
+  }
+
+  return (
+    <div className="game-book-sticky-header" data-testid="game-book-sticky-header">
+      <button
+        type="button"
+        className="btn btn-sm game-book-sticky-header__back"
+        onClick={onBack}
+        data-testid="game-book-sticky-back"
+      >
+        ← {backLabel ?? 'Return to HQ'}
+      </button>
+      <span className="game-book-sticky-header__week" data-testid="game-book-sticky-week">
+        {week != null ? `Wk ${week}` : 'Game Book'}
+      </span>
+      {hasFinal ? (
+        <span className="game-book-sticky-header__score" data-testid="game-book-sticky-score">
+          {outcome ? (
+            <span className={`game-book-sticky-header__badge tone-${outcome.tone}`} aria-hidden="true">{outcome.label}</span>
+          ) : null}
+          <span className="game-book-sticky-header__teams">
+            {away?.abbr ?? 'AWY'} {awayScore ?? '—'} – {homeScore ?? '—'} {home?.abbr ?? 'HME'}
+          </span>
+        </span>
+      ) : (
+        <span className="game-book-sticky-header__score game-book-sticky-header__score--pending" data-testid="game-book-sticky-score">
+          Final pending
+        </span>
+      )}
+    </div>
+  );
+}
+
 
 export default function GameDetailScreen({ gameId, league, actions, onBack, onPlayerSelect, onTeamSelect, onNavigate, backLabel }) {
   const weekFromId = typeof gameId === 'string' ? gameId.match(/_w(\d+)_/i)?.[1] : null;
@@ -69,6 +124,13 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
 
   return (
     <div className="app-screen-stack" data-testid="game-book">
+      <GameBookStickyHeader
+        detailVm={detailVm}
+        userTeamId={league?.userTeamId}
+        week={detailVm?.week ?? weekFromId ?? null}
+        onBack={onBack}
+        backLabel={backLabel}
+      />
       <ScreenHeader
         eyebrow="Game Book"
         title={screenTitle}

--- a/src/ui/components/GameDetailScreen.test.jsx
+++ b/src/ui/components/GameDetailScreen.test.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderToString } from 'react-dom/server';
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
 import GameDetailScreen from './GameDetailScreen.jsx';
 
 vi.mock('../hooks/useStableRouteRequest.js', () => ({ default: vi.fn(() => ({ data: null, loading: false, error: null })) }));
@@ -135,5 +135,30 @@ describe('GameDetailScreen score source of truth', () => {
     expect(getByTestId('game-book-final-score').textContent).toBe('CLE 10 - 27 PIT');
     expect(container.textContent).not.toContain('CLE 0 - 0 PIT');
     expect(container.textContent).not.toContain('finished tied');
+  });
+
+  it('renders a compact sticky Game Book header with week, teams, score and W/L result', () => {
+    const onBack = vi.fn();
+    const { getByTestId } = render(
+      <GameDetailScreen
+        gameId="2031_w3_1_2"
+        league={league}
+        actions={{ getBoxScore: vi.fn() }}
+        onBack={onBack}
+      />,
+    );
+
+    const header = getByTestId('game-book-sticky-header');
+    expect(getByTestId('game-book-sticky-week').textContent).toContain('Wk 3');
+    const scoreText = getByTestId('game-book-sticky-score').textContent;
+    expect(scoreText).toContain('CLE');
+    expect(scoreText).toContain('PIT');
+    expect(scoreText).toContain('10');
+    expect(scoreText).toContain('27');
+    // User team (PIT, id 1) won 27-10 → W badge from the user's perspective.
+    expect(header.querySelector('.game-book-sticky-header__badge').textContent).toBe('W');
+
+    fireEvent.click(getByTestId('game-book-sticky-back'));
+    expect(onBack).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -813,6 +813,11 @@ export default function LeagueDashboard({
     setActiveTab("Game Detail");
   };
   const activeSection = getShellSectionForDashboardTab(activeTab);
+  // Focused Game Book review mode: when a completed game / Game Book is open
+  // (either the mobile modal overlay or the dedicated Game Detail tab) the
+  // fixed bottom nav and hamburger are collapsed so the result screen is not
+  // boxed in. Returning to any other surface restores the nav automatically.
+  const isGameBookFocus = gameDetailModal.open || activeTab === "Game Detail";
   const WEEKLY_OPERATIONS_TABS = new Set(["Game Plan", "Depth Chart", "Training", "Weekly Prep"]);
   const isWeeklyOperationsTab = WEEKLY_OPERATIONS_TABS.has(activeTab);
   const handleSectionChange = (sectionId) => {
@@ -1613,6 +1618,7 @@ export default function LeagueDashboard({
         advanceLabel={advanceLabel}
         advanceDisabled={advanceDisabled}
         league={league}
+        collapsed={isGameBookFocus}
       />
 
 

--- a/src/ui/components/MobileNav.jsx
+++ b/src/ui/components/MobileNav.jsx
@@ -54,10 +54,16 @@ const BOTTOM_TABS = [
   { id: 'More', label: 'More', icon: MoreIcon, action: 'menu', value: 'more' },
 ];
 
-export default function MobileNav({ activeSection, activeTab, onSectionChange, onDestinationChange, league }) {
+export default function MobileNav({ activeSection, activeTab, onSectionChange, onDestinationChange, league, collapsed = false }) {
   const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => setMenuOpen(false), [activeSection]);
+
+  // When the navigation chrome is collapsed (e.g. focused Game Book review),
+  // close any open More drawer so it cannot linger over the review surface.
+  useEffect(() => {
+    if (collapsed) setMenuOpen(false);
+  }, [collapsed]);
 
   useEffect(() => {
     const handleKey = (e) => e.key === 'Escape' && setMenuOpen(false);
@@ -88,7 +94,7 @@ export default function MobileNav({ activeSection, activeTab, onSectionChange, o
 
   return (
     <>
-      <button className="mobile-nav-hamburger" onClick={() => setMenuOpen(!menuOpen)} aria-label="Open navigation menu" aria-expanded={menuOpen}>
+      <button className={`mobile-nav-hamburger${collapsed ? ' is-collapsed' : ''}`} onClick={() => setMenuOpen(!menuOpen)} aria-label="Open navigation menu" aria-expanded={menuOpen} aria-hidden={collapsed || undefined} tabIndex={collapsed ? -1 : undefined}>
         <span className={`hamburger-line ${menuOpen ? 'open' : ''}`} />
         <span className={`hamburger-line ${menuOpen ? 'open' : ''}`} />
         <span className={`hamburger-line ${menuOpen ? 'open' : ''}`} />
@@ -120,7 +126,11 @@ export default function MobileNav({ activeSection, activeTab, onSectionChange, o
         </div>
       </nav>
 
-      <div className="mobile-bottom-bar premium-bottom-nav">
+      <div
+        className={`mobile-bottom-bar premium-bottom-nav${collapsed ? ' is-collapsed' : ''}`}
+        data-collapsed={collapsed ? 'true' : 'false'}
+        aria-hidden={collapsed || undefined}
+      >
         {BOTTOM_TABS.map((tab) => {
           const Icon = tab.icon;
           const isActive = (tab.action === 'section' && activeSection === tab.value)

--- a/src/ui/components/MobileNav.test.jsx
+++ b/src/ui/components/MobileNav.test.jsx
@@ -38,6 +38,38 @@ describe('MobileNav', () => {
     expect(html).toContain('League');
   });
 
+  it('collapses the bottom nav and hamburger when Game Book focus mode is active', () => {
+    const html = renderToString(
+      <MobileNav
+        activeSection={SHELL_SECTIONS.hq}
+        onSectionChange={vi.fn()}
+        onDestinationChange={vi.fn()}
+        league={{ year: 2026, phase: 'regular' }}
+        collapsed
+      />,
+    );
+
+    // Bottom bar carries the collapsed marker so CSS hides it during review.
+    expect(html).toContain('mobile-bottom-bar premium-bottom-nav is-collapsed');
+    expect(html).toContain('data-collapsed="true"');
+    // Hamburger is collapsed too so it cannot float over the result screen.
+    expect(html).toContain('mobile-nav-hamburger is-collapsed');
+  });
+
+  it('keeps the bottom nav visible (no collapsed class) by default — restored on return to HQ', () => {
+    const html = renderToString(
+      <MobileNav
+        activeSection={SHELL_SECTIONS.hq}
+        onSectionChange={vi.fn()}
+        onDestinationChange={vi.fn()}
+        league={{ year: 2026, phase: 'regular' }}
+      />,
+    );
+
+    expect(html).not.toContain('is-collapsed');
+    expect(html).toContain('data-collapsed="false"');
+  });
+
   it('surfaces the weekly-loop group first with core destinations reachable', () => {
     const html = renderToString(
       <MobileNav

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -327,6 +327,84 @@ describe('FranchiseHQ V4 compact home screen', () => {
   });
 });
 
+describe('LeagueDashboard Game Book focus mode collapses the mobile bottom nav', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('collapses the bottom nav while the Game Book is open and restores it on return to HQ', async () => {
+    window.matchMedia = window.matchMedia ?? (() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }));
+    render(
+      <LeagueDashboard
+        league={baseLeague}
+        actions={{ getDashboardLeaders: vi.fn(() => Promise.resolve({ league: {}, team: {} })) }}
+        busy={false}
+        simulating={false}
+        onAdvanceWeek={() => {}}
+      />,
+    );
+
+    const bottomBar = () => document.querySelector('.mobile-bottom-bar');
+    // Bottom nav visible at HQ.
+    expect(bottomBar()).not.toBeNull();
+    expect(bottomBar().classList.contains('is-collapsed')).toBe(false);
+
+    // Open the Game Book from the HQ Film Room card.
+    const seasonPulse = screen.getByTestId('season-pulse');
+    fireEvent.click(within(seasonPulse).getByRole('button', { name: /open game book/i }));
+    expect(await screen.findByTestId('game-book')).toBeTruthy();
+
+    // Bottom nav collapsed during focused review.
+    expect(bottomBar().classList.contains('is-collapsed')).toBe(true);
+
+    // Return to HQ restores the nav.
+    fireEvent.click(screen.getByTestId('return-to-hq'));
+    expect(await screen.findByTestId('franchise-hq')).toBeTruthy();
+    expect(bottomBar().classList.contains('is-collapsed')).toBe(false);
+  });
+});
+
+describe('FranchiseHQ post-sim compact status strip', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders one compact dismissible status strip with the completed week label', () => {
+    render(
+      <FranchiseHQ league={baseLeague} onNavigate={vi.fn()} onAdvanceWeek={vi.fn()} busy={false} simulating={false} />,
+    );
+    const strip = screen.getByTestId('hq-postsim-status-strip');
+    expect(strip).toBeTruthy();
+    // Last completed user game is week 9 (g-9).
+    expect(strip.textContent).toMatch(/week 9 complete/i);
+    // Dismiss control is present and labelled.
+    expect(within(strip).getByRole('button', { name: /dismiss week complete notice/i })).toBeTruthy();
+  });
+
+  it('routes the status strip tap to Weekly Results without auto-expanding it on HQ', () => {
+    const onNavigate = vi.fn();
+    render(
+      <FranchiseHQ league={baseLeague} onNavigate={onNavigate} onAdvanceWeek={vi.fn()} busy={false} simulating={false} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /week 9 complete\. tap to review results/i }));
+    expect(onNavigate).toHaveBeenCalledWith('Weekly Results');
+    // The HQ itself does not render a full Weekly Results center.
+    expect(screen.queryByTestId('weekly-results')).toBeNull();
+  });
+
+  it('removes the strip after dismiss while keeping Weekly Results reachable elsewhere', () => {
+    const onNavigate = vi.fn();
+    render(
+      <FranchiseHQ league={baseLeague} onNavigate={onNavigate} onAdvanceWeek={vi.fn()} busy={false} simulating={false} />,
+    );
+    fireEvent.click(screen.getByTestId('hq-postsim-status-strip-dismiss'));
+    expect(screen.queryByTestId('hq-postsim-status-strip')).toBeNull();
+    // Weekly Results remains reachable via the league destination nav.
+    fireEvent.click(within(screen.getByTestId('hq-league-destination-links')).getByRole('button', { name: /^standings$/i }));
+    expect(onNavigate).toHaveBeenCalledWith('Standings');
+  });
+});
+
 describe('FranchiseHQ V3 command hierarchy cleanup', () => {
   afterEach(() => {
     cleanup();

--- a/src/ui/components/__tests__/mobileMatchReviewFlow.viewport.test.jsx
+++ b/src/ui/components/__tests__/mobileMatchReviewFlow.viewport.test.jsx
@@ -1,0 +1,104 @@
+/** @vitest-environment jsdom */
+/**
+ * Viewport assertions for the mobile Match Review flow.
+ *
+ * Runs the key structural guarantees at the three target mobile viewports:
+ *   - 390×844 (iPhone 14/15)
+ *   - 375×812 (iPhone X/11 Pro/12 mini)
+ *   - 430×932 (iPhone 14/15 Pro Max)
+ *
+ * jsdom does not compute real layout, so these assert the structural
+ * invariants that keep the result, score, and return action reachable without
+ * scrolling and prevent the bottom nav from overlapping Game Book content:
+ *   - HQ shows the compact post-sim strip, not a full Weekly Results center.
+ *   - The Game Book exposes a sticky header (final score + return action).
+ *   - The mobile bottom nav collapses during Game Book review and restores.
+ */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import LeagueDashboard from '../LeagueDashboard.jsx';
+
+const baseLeague = {
+  year: 2026,
+  week: 10,
+  seasonId: 's10',
+  phase: 'regular',
+  userTeamId: 10,
+  ownerApproval: 58,
+  teams: [
+    { id: 10, city: 'Chicago', name: 'Bears', abbr: 'CHI', conf: 1, div: 0, wins: 6, losses: 3, ties: 0, ovr: 84, capRoom: 7, roster: [{ id: 1 }, { id: 2 }], recentResults: ['W', 'W', 'L', 'W'] },
+    { id: 11, city: 'Detroit', name: 'Lions', abbr: 'DET', conf: 1, div: 0, wins: 5, losses: 4, ties: 0, ovr: 83, capRoom: 11, roster: [] },
+  ],
+  schedule: {
+    weeks: [
+      { week: 9, games: [{ id: 'g-9', home: { id: 11, abbr: 'DET' }, away: { id: 10, abbr: 'CHI' }, homeId: 11, awayId: 10, homeAbbr: 'DET', awayAbbr: 'CHI', homeScore: 20, awayScore: 23, played: true }] },
+      { week: 10, games: [{ id: 'g-10', home: { id: 10, abbr: 'CHI' }, away: { id: 11, abbr: 'DET' }, played: false }] },
+    ],
+  },
+  gameById: { 'g-9': { id: 'g-9', home: 11, away: 10, homeId: 11, awayId: 10, week: 9, played: true, homeScore: 20, awayScore: 23 } },
+  newsItems: [{ id: 'n1', teamId: 10, headline: 'Starter upgraded to probable status.' }],
+};
+
+function setViewport(width, height) {
+  Object.defineProperty(window, 'innerWidth', { value: width, configurable: true, writable: true });
+  Object.defineProperty(window, 'innerHeight', { value: height, configurable: true, writable: true });
+  window.matchMedia = (query) => {
+    const match = /max-width:\s*(\d+)/.exec(query);
+    const matches = match ? width <= Number(match[1]) : false;
+    return { matches, media: query, addEventListener: vi.fn(), removeEventListener: vi.fn(), addListener: vi.fn(), removeListener: vi.fn(), onchange: null, dispatchEvent: vi.fn() };
+  };
+}
+
+const VIEWPORTS = [
+  { label: '390x844', width: 390, height: 844 },
+  { label: '375x812', width: 375, height: 812 },
+  { label: '430x932', width: 430, height: 932 },
+];
+
+describe('mobile Match Review flow — viewport assertions', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it.each(VIEWPORTS)('keeps result, sticky Game Book header, and uncluttered HQ at $label', async ({ width, height }) => {
+    setViewport(width, height);
+    render(
+      <LeagueDashboard
+        league={baseLeague}
+        actions={{ getDashboardLeaders: vi.fn(() => Promise.resolve({ league: {}, team: {} })), getBoxScore: vi.fn() }}
+        busy={false}
+        simulating={false}
+        onAdvanceWeek={() => {}}
+      />,
+    );
+
+    const bottomBar = () => document.querySelector('.mobile-bottom-bar');
+
+    // HQ is not dominated by stacked notices: a single compact post-sim strip,
+    // and no full Weekly Results center embedded on HQ.
+    expect(screen.getByTestId('hq-postsim-status-strip')).toBeTruthy();
+    expect(screen.queryByTestId('weekly-results')).toBeNull();
+    // Bottom nav present and not overlapping (not collapsed) on HQ.
+    expect(bottomBar()).not.toBeNull();
+    expect(bottomBar().classList.contains('is-collapsed')).toBe(false);
+
+    // Open the Game Book from the last result affordance / film room.
+    const seasonPulse = screen.getByTestId('season-pulse');
+    fireEvent.click(within(seasonPulse).getByRole('button', { name: /open game book/i }));
+
+    // Sticky Game Book header carries the final score + a return action above the fold.
+    const stickyHeader = await screen.findByTestId('game-book-sticky-header');
+    expect(stickyHeader).toBeTruthy();
+    expect(screen.getByTestId('game-book-sticky-back')).toBeTruthy();
+    expect(screen.getByTestId('game-book-sticky-score').textContent).toMatch(/\d/);
+
+    // Bottom nav collapses so it cannot overlap Game Book review content.
+    expect(bottomBar().classList.contains('is-collapsed')).toBe(true);
+
+    // Return to HQ is reachable from the sticky header and restores the nav.
+    fireEvent.click(screen.getByTestId('game-book-sticky-back'));
+    expect(await screen.findByTestId('franchise-hq')).toBeTruthy();
+    expect(bottomBar().classList.contains('is-collapsed')).toBe(false);
+  });
+});

--- a/src/ui/styles/app-mobile.css
+++ b/src/ui/styles/app-mobile.css
@@ -840,6 +840,16 @@
   }
 }
 
+/* ── Focused Game Book review: collapse the fixed nav chrome ──────────────────
+   During completed-game / Game Book review the bottom nav and hamburger are
+   collapsed so the result, score, and return action are never boxed in. The
+   surface keeps its own back action, so navigation is not lost. The collapse
+   uses display:none, so no safe-area padding can clip review content. */
+.mobile-bottom-bar.is-collapsed,
+.mobile-nav-hamburger.is-collapsed {
+  display: none !important;
+}
+
 .mobile-bottom-tab {
   display: flex;
   flex-direction: column;
@@ -1560,3 +1570,72 @@
     margin-bottom: 6px;
   }
 }
+
+/* ── Compact sticky Game Book header ──────────────────────────────────────────
+   A thin, sticky chrome row at the top of the Game Book that keeps the return
+   action, week, and final score / W-L result visible above the fold on mobile.
+   It is intentionally low-weight and reuses existing design tokens. */
+.game-book-sticky-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 8px max(10px, env(safe-area-inset-right)) 8px max(10px, env(safe-area-inset-left));
+  background: color-mix(in srgb, var(--surface-strong) 92%, black 8%);
+  border-bottom: 1px solid var(--hairline);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.game-book-sticky-header__back {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.game-book-sticky-header__week {
+  font-size: var(--text-xs);
+  font-weight: 700;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.game-book-sticky-header__score {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  font-size: var(--text-sm);
+  font-weight: 800;
+  color: var(--text);
+}
+
+.game-book-sticky-header__score--pending {
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.game-book-sticky-header__teams {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.game-book-sticky-header__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 5px;
+  border-radius: var(--radius-pill, 999px);
+  font-size: 11px;
+  font-weight: 900;
+  line-height: 1;
+  color: #fff;
+}
+.game-book-sticky-header__badge.tone-ok { background: var(--success, #34C759); }
+.game-book-sticky-header__badge.tone-danger { background: var(--danger, #FF453A); }
+.game-book-sticky-header__badge.tone-info { background: var(--accent, #0A84FF); }

--- a/src/ui/styles/hub.css
+++ b/src/ui/styles/hub.css
@@ -1007,6 +1007,72 @@
   line-height: 1.1;
 }
 
+/* ── Post-sim compact status strip (dismissible) ─────────────────────────── */
+.hq-postsim-strip {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  width: 100%;
+  background: color-mix(in srgb, var(--accent) 7%, var(--surface) 93%);
+  border-bottom: 1px solid var(--hairline);
+}
+
+.hq-postsim-strip__main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-size: 12px;
+  color: var(--text-muted);
+  min-height: 32px;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.hq-postsim-strip__main:hover,
+.hq-postsim-strip__main:focus-visible {
+  color: var(--text);
+}
+
+.hq-postsim-strip__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
+}
+
+.hq-postsim-strip__text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hq-postsim-strip__dismiss {
+  flex-shrink: 0;
+  width: 36px;
+  min-height: 32px;
+  background: none;
+  border: none;
+  border-left: 1px solid var(--hairline);
+  color: var(--text-subtle);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.hq-postsim-strip__dismiss:hover,
+.hq-postsim-strip__dismiss:focus-visible {
+  color: var(--text);
+}
+
 /* ── Single-line status rows (last result / next game) ───────────────────── */
 .hq-status-row {
   display: flex;

--- a/src/ui/utils/notificationsDisplay.js
+++ b/src/ui/utils/notificationsDisplay.js
@@ -1,0 +1,22 @@
+/**
+ * notificationsDisplay.js — guards against empty dismissible notification pills.
+ *
+ * The post-sim / weekly-results area renders each notification as a small
+ * dismissible pill with an "×" control. When a notification arrives with no
+ * message/text (a stale or malformed entry) the pill rendered as a blank gray
+ * block with only an "×" — looking like a broken filter tag or empty chip.
+ *
+ * This helper filters those out so only notifications with real, visible
+ * content render a dismissible control. Pure data helper — no gameplay logic.
+ */
+
+export function getNotificationMessage(notification) {
+  if (!notification || typeof notification !== 'object') return '';
+  const raw = notification.message ?? notification.text ?? '';
+  return typeof raw === 'string' ? raw.trim() : String(raw ?? '').trim();
+}
+
+export function getDisplayableNotifications(notifications) {
+  if (!Array.isArray(notifications)) return [];
+  return notifications.filter((notification) => getNotificationMessage(notification).length > 0);
+}

--- a/src/ui/utils/notificationsDisplay.test.js
+++ b/src/ui/utils/notificationsDisplay.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { getDisplayableNotifications, getNotificationMessage } from './notificationsDisplay.js';
+
+describe('notificationsDisplay', () => {
+  it('keeps notifications that have a real message', () => {
+    const list = [
+      { id: 'a', message: 'Week 3 complete' },
+      { id: 'b', text: 'Injury update' },
+    ];
+    expect(getDisplayableNotifications(list)).toHaveLength(2);
+  });
+
+  it('drops notifications with empty or whitespace-only content (no blank dismissible pill)', () => {
+    const list = [
+      { id: 'a', message: 'Real message' },
+      { id: 'b', message: '' },
+      { id: 'c', message: '   ' },
+      { id: 'd' },
+      { id: 'e', text: null },
+    ];
+    const result = getDisplayableNotifications(list);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('a');
+  });
+
+  it('is safe for non-array input', () => {
+    expect(getDisplayableNotifications(null)).toEqual([]);
+    expect(getDisplayableNotifications(undefined)).toEqual([]);
+  });
+
+  it('normalizes message resolution across message/text fields', () => {
+    expect(getNotificationMessage({ message: 'hi' })).toBe('hi');
+    expect(getNotificationMessage({ text: 'yo' })).toBe('yo');
+    expect(getNotificationMessage({})).toBe('');
+    expect(getNotificationMessage(null)).toBe('');
+  });
+});


### PR DESCRIPTION
Scope A — Focused Game Book mode (mobile):
- Collapse the fixed mobile bottom nav + hamburger during completed-game
  Game Book review via a `collapsed` flag on MobileNav (display:none class),
  restored automatically on return to HQ. Driven from LeagueDashboard
  (gameDetailModal open or the Game Detail tab).
- Add a compact sticky Game Book header (return action, week, team
  abbreviations + final score, user W/L badge) so the result stays above the
  fold at 390x844 without scrolling. Presentational only — reads the existing
  box-score view model, never recomputes any result.

Scope B — Post-sim HQ mobile cleanup:
- Add one compact, dismissible "Week N complete · Tap to review results"
  status strip to Franchise HQ. Low visual weight, single line, per-week
  dismiss. Weekly Results stays reachable; HQ does not auto-expand it.

Scope C — Fix the blank gray dismissible pill:
- Empty/whitespace notifications rendered a blank gray pill with only an "×"
  in the post-sim/weekly-results area. Added getDisplayableNotifications guard
  so only notifications with real content render a dismissible control, with a
  regression test.

Scope D — Spacing guardrails:
- Nav collapse uses display:none (no overlap, no clipping); sticky header
  respects safe-area insets. No new nesting layers or global banners.

Scope E — Tests:
- Unit/component: MobileNav collapse class, sticky Game Book header content,
  post-sim strip render/dismiss/route, empty-notification regression.
- Integration: advance->HQ compact strip; open Game Book -> nav collapsed;
  return to HQ -> nav restored.
- Viewport assertions parameterized at 390x844, 375x812, 430x932.

No simulation, gameplay, standings, contract, trade, FA, draft, or save data
logic was changed. Full unit suite (4946) and production build pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NkCc6abwuJ8H4ERxiA9NoK