### PR TITLE
Mobile Match Review V1: canonical result card + #1631 guardrail fixes

### DIFF
--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -20,6 +20,7 @@ import FranchiseLegacyView from './FranchiseLegacyView.jsx';
 import FranchiseBrandHQ from './FranchiseBrandHQ.jsx';
 import JobSecurityCard from './JobSecurityCard.jsx';
 import ActivityToastStack from './ActivityToastStack.jsx';
+import GameResultSummaryCard from './GameResultSummaryCard.jsx';
 
 const BOTTOM_NAV_ITEMS = [
   { label: 'Home', route: 'HQ', icon: 'home', active: true },
@@ -269,6 +270,8 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
     const oppAbbr = userIsHome
       ? (lastGame.awayAbbr ?? lastGame.away?.abbr ?? 'OPP')
       : (lastGame.homeAbbr ?? lastGame.home?.abbr ?? 'OPP');
+    const homeAbbr = lastGame.homeAbbr ?? lastGame.home?.abbr ?? 'HOME';
+    const awayAbbr = lastGame.awayAbbr ?? lastGame.away?.abbr ?? 'AWAY';
     const gameId = lastGame.gameId ?? lastGame.id ?? null;
     const weekNum = safeNum(lastGame.week);
     return {
@@ -276,6 +279,11 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
       tone: tied ? 'info' : userWon ? 'ok' : 'danger',
       text: `${userScore}–${oppScore} vs ${oppAbbr}${weekNum ? ` · Wk${weekNum}` : ''}`,
       oppAbbr,
+      homeAbbr,
+      awayAbbr,
+      homeScore,
+      awayScore,
+      userIsHome,
       week: weekNum || null,
       gameId,
     };
@@ -383,7 +391,7 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
       filmLabel: lastGame ? lastGameDisplay.heroLine : 'Kickoff ahead',
       filmDetail: lastGame ? 'Open the latest final before changing next week.' : 'Scout the opponent and lock a plan before kickoff.',
       filmRoute: gameId ? buildGameBookDestination(gameId) : 'Weekly Prep',
-      filmCta: gameId ? 'Open Game Book' : 'Open Weekly Prep',
+      filmCta: gameId ? 'View Game Book' : 'Open Weekly Prep',
       rosterNeed: hqTeamBuilder.biggestNeed ?? 'No urgent need',
       rosterDetail: hqTeamBuilder.nextAction ?? 'Review team builder for leverage.',
       capLabel,
@@ -506,6 +514,30 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
         </button>
       </header>
 
+      {/* ── LAST RESULT CARD — canonical compact result, before any notices ─
+            Priority #2 on the post-advance mobile HQ: the score lands above the
+            dismissible status strip and any engine/development notices. Shares
+            GameResultSummaryCard with the postgame overlay; tapping opens the
+            Game Book. ── */}
+      {lastResultRow && (
+        <GameResultSummaryCard
+          variant="compact"
+          testId="hq-last-result-card"
+          ctaTestId="hq-last-result-cta"
+          homeAbbr={lastResultRow.homeAbbr}
+          awayAbbr={lastResultRow.awayAbbr}
+          homeScore={lastResultRow.homeScore}
+          awayScore={lastResultRow.awayScore}
+          userIsHome={lastResultRow.userIsHome}
+          week={lastResultRow.week}
+          onViewGameBook={
+            lastResultRow.gameId
+              ? () => onNavigate?.(buildGameBookDestination(lastResultRow.gameId))
+              : undefined
+          }
+        />
+      )}
+
       {/* ── POST-SIM STATUS STRIP — compact, dismissible, single line ────── */}
       {showPostSimStrip && (
         <div className="hq-postsim-strip" data-testid="hq-postsim-status-strip" data-week={lastResultRow.week}>
@@ -528,21 +560,6 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
             ×
           </button>
         </div>
-      )}
-
-      {/* ── LAST RESULT ROW — single line, tappable → box score ─────────── */}
-      {lastResultRow && (
-        <button
-          type="button"
-          className={`hq-status-row hq-status-row--result`}
-          data-tone={lastResultRow.tone}
-          aria-label={`Last result: ${lastResultRow.text}. Tap to view box score.`}
-          onClick={() => lastResultRow.gameId && onNavigate?.(buildGameBookDestination(lastResultRow.gameId))}
-        >
-          <span className={`hq-wl-badge hq-wl-badge--${lastResultRow.tone}`}>{lastResultRow.label}</span>
-          <span className="hq-status-row__text">{lastResultRow.text}</span>
-          <span className="hq-status-row__chevron" aria-hidden="true">›</span>
-        </button>
       )}
 
       {/* ── NEXT GAME ROW — single line, tappable → Game Plan ───────────── */}

--- a/src/ui/components/GameResultSummaryCard.jsx
+++ b/src/ui/components/GameResultSummaryCard.jsx
@@ -1,0 +1,175 @@
+/**
+ * GameResultSummaryCard.jsx — Canonical final-result summary card
+ *
+ * Single shared presentation of a completed game's final score, used in exactly
+ * two surfaces of the weekly mobile loop:
+ *   - variant="full"    → the postgame result overlay (PostGameSummary)
+ *   - variant="compact" → the Franchise HQ "last result" entry point
+ *
+ * Purely presentational. It renders an already-resolved score and never
+ * recomputes a game outcome, standings, or any save data. Callers pass the raw
+ * home/away scores + which side is the user; the card only derives display
+ * framing (who won, which score to dim, the W/L/T badge).
+ *
+ * The review call-to-action is standardized to a single label — "View Game
+ * Book" — so postgame and HQ surfaces stay consistent.
+ */
+import React from 'react';
+
+export const VIEW_GAME_BOOK_LABEL = 'View Game Book';
+
+function safeNum(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+// Deterministic team accent used for the full-variant crests/scores. Mirrors the
+// palette the postgame overlay used before extraction so the look is unchanged.
+function teamColor(abbr = '') {
+  const palette = [
+    '#0A84FF', '#34C759', '#FF9F0A', '#FF453A', '#5E5CE6',
+    '#64D2FF', '#FFD60A', '#30D158', '#FF6961', '#AEC6CF',
+    '#FF6B35', '#B4A0E5',
+  ];
+  let h = 0;
+  for (let i = 0; i < abbr.length; i++) h = abbr.charCodeAt(i) + ((h << 5) - h);
+  return palette[Math.abs(h) % palette.length];
+}
+
+/**
+ * Derive the display framing for a final result from raw scores. Pure: returns
+ * only presentation hints, never mutates inputs or touches game/save state.
+ */
+export function resolveResultFraming({ homeScore, awayScore, userIsHome }) {
+  const home = safeNum(homeScore);
+  const away = safeNum(awayScore);
+  const tied = home === away;
+  const homeWon = home > away;
+  const userWon = !tied && (userIsHome ? homeWon : !homeWon);
+  const userLost = !tied && !userWon;
+  return {
+    tied,
+    homeWon,
+    userWon,
+    userLost,
+    userScore: userIsHome ? home : away,
+    oppScore: userIsHome ? away : home,
+    badge: tied ? 'T' : userWon ? 'W' : 'L',
+    tone: tied ? 'info' : userWon ? 'ok' : 'danger',
+  };
+}
+
+function FullVariant({ homeAbbr, awayAbbr, homeName, awayName, homeScore, awayScore, testId }) {
+  const home = safeNum(homeScore);
+  const away = safeNum(awayScore);
+  const homeWon = home > away;
+  const tied = home === away;
+  const hColor = teamColor(homeAbbr);
+  const aColor = teamColor(awayAbbr);
+
+  return (
+    <div
+      data-testid={testId}
+      data-variant="full"
+      style={{
+        background: 'var(--surface)',
+        border: '1.5px solid var(--hairline)',
+        borderRadius: 16,
+        padding: '20px 24px',
+        marginBottom: 14,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        {/* Away */}
+        <div style={{ flex: 1, textAlign: 'center' }}>
+          <div style={{
+            width: 48, height: 48, borderRadius: '50%', margin: '0 auto 8px',
+            background: `${aColor}20`, border: `2.5px solid ${aColor}`,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontWeight: 900, fontSize: 13, color: aColor,
+          }}>
+            {String(awayAbbr ?? 'AWY').slice(0, 3)}
+          </div>
+          <div style={{ fontSize: '0.72rem', fontWeight: 700, color: 'var(--text-muted)', marginBottom: 3 }}>
+            {awayName ?? awayAbbr}
+          </div>
+          <div style={{
+            fontSize: '2.6rem', fontWeight: 900,
+            color: !homeWon && !tied ? aColor : 'var(--text-muted)',
+            fontVariantNumeric: 'tabular-nums', lineHeight: 1,
+          }}>
+            {away}
+          </div>
+        </div>
+
+        <div style={{ textAlign: 'center', padding: '0 10px' }}>
+          <div style={{ fontSize: '0.65rem', fontWeight: 800, color: 'var(--text-subtle)', letterSpacing: '1px', textTransform: 'uppercase' }}>
+            FINAL
+          </div>
+        </div>
+
+        {/* Home */}
+        <div style={{ flex: 1, textAlign: 'center' }}>
+          <div style={{
+            width: 48, height: 48, borderRadius: '50%', margin: '0 auto 8px',
+            background: `${hColor}20`, border: `2.5px solid ${hColor}`,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontWeight: 900, fontSize: 13, color: hColor,
+          }}>
+            {String(homeAbbr ?? 'HOM').slice(0, 3)}
+          </div>
+          <div style={{ fontSize: '0.72rem', fontWeight: 700, color: 'var(--text-muted)', marginBottom: 3 }}>
+            {homeName ?? homeAbbr}
+          </div>
+          <div style={{
+            fontSize: '2.6rem', fontWeight: 900,
+            color: homeWon ? hColor : 'var(--text-muted)',
+            fontVariantNumeric: 'tabular-nums', lineHeight: 1,
+          }}>
+            {home}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CompactVariant({
+  homeAbbr, awayAbbr, homeScore, awayScore, userIsHome, week,
+  onViewGameBook, gameBookLabel, testId, ctaTestId,
+}) {
+  const framing = resolveResultFraming({ homeScore, awayScore, userIsHome });
+  const oppAbbr = userIsHome ? (awayAbbr ?? 'OPP') : (homeAbbr ?? 'OPP');
+  const weekNum = safeNum(week, 0);
+  const text = `${framing.userScore}–${framing.oppScore} vs ${oppAbbr}${weekNum ? ` · Wk${weekNum}` : ''}`;
+  const interactive = typeof onViewGameBook === 'function';
+  const label = gameBookLabel ?? VIEW_GAME_BOOK_LABEL;
+
+  return (
+    <button
+      type="button"
+      className="hq-status-row hq-status-row--result"
+      data-testid={testId}
+      data-tone={framing.tone}
+      data-variant="compact"
+      disabled={!interactive}
+      aria-label={`Last result: ${text}. ${label}.`}
+      onClick={interactive ? onViewGameBook : undefined}
+    >
+      <span className={`hq-wl-badge hq-wl-badge--${framing.tone}`}>{framing.badge}</span>
+      <span className="hq-status-row__text">{text}</span>
+      <span className="hq-status-row__cta" data-testid={ctaTestId}>{label} ›</span>
+    </button>
+  );
+}
+
+export default function GameResultSummaryCard({
+  variant = 'compact',
+  gameBookLabel = VIEW_GAME_BOOK_LABEL,
+  ...props
+}) {
+  if (variant === 'full') {
+    return <FullVariant {...props} />;
+  }
+  return <CompactVariant gameBookLabel={gameBookLabel} {...props} />;
+}

--- a/src/ui/components/GameResultSummaryCard.test.jsx
+++ b/src/ui/components/GameResultSummaryCard.test.jsx
@@ -1,0 +1,90 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import GameResultSummaryCard, {
+  VIEW_GAME_BOOK_LABEL,
+  resolveResultFraming,
+} from './GameResultSummaryCard.jsx';
+
+describe('GameResultSummaryCard', () => {
+  afterEach(() => cleanup());
+
+  describe('resolveResultFraming', () => {
+    it('frames a user win', () => {
+      const f = resolveResultFraming({ homeScore: 27, awayScore: 20, userIsHome: true });
+      expect(f).toMatchObject({ userWon: true, userLost: false, tied: false, badge: 'W', tone: 'ok', userScore: 27, oppScore: 20 });
+    });
+    it('frames a user loss', () => {
+      const f = resolveResultFraming({ homeScore: 27, awayScore: 20, userIsHome: false });
+      expect(f).toMatchObject({ userWon: false, userLost: true, badge: 'L', tone: 'danger', userScore: 20, oppScore: 27 });
+    });
+    it('frames a tie', () => {
+      const f = resolveResultFraming({ homeScore: 14, awayScore: 14, userIsHome: true });
+      expect(f).toMatchObject({ tied: true, userWon: false, userLost: false, badge: 'T', tone: 'info' });
+    });
+  });
+
+  describe('full variant', () => {
+    it('renders both final scores', () => {
+      render(
+        <GameResultSummaryCard
+          variant="full"
+          testId="result-card"
+          awayAbbr="BUF"
+          awayName="Buffalo"
+          awayScore={20}
+          homeAbbr="KC"
+          homeName="Kansas City"
+          homeScore={27}
+        />,
+      );
+      const card = screen.getByTestId('result-card');
+      expect(card.getAttribute('data-variant')).toBe('full');
+      expect(screen.getByText('27')).toBeTruthy();
+      expect(screen.getByText('20')).toBeTruthy();
+    });
+  });
+
+  describe('compact variant', () => {
+    it('uses the canonical "View Game Book" CTA label', () => {
+      const onViewGameBook = vi.fn();
+      render(
+        <GameResultSummaryCard
+          variant="compact"
+          testId="compact-card"
+          ctaTestId="compact-cta"
+          homeAbbr="DET"
+          awayAbbr="CHI"
+          homeScore={20}
+          awayScore={23}
+          userIsHome={false}
+          week={9}
+          onViewGameBook={onViewGameBook}
+        />,
+      );
+      expect(VIEW_GAME_BOOK_LABEL).toBe('View Game Book');
+      expect(screen.getByTestId('compact-cta').textContent).toContain('View Game Book');
+      // Score framed from the user's perspective (user is away): 23–20 vs DET.
+      expect(screen.getByTestId('compact-card').textContent).toContain('23–20 vs DET');
+      fireEvent.click(screen.getByTestId('compact-card'));
+      expect(onViewGameBook).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables the row when there is no game to open', () => {
+      render(
+        <GameResultSummaryCard
+          variant="compact"
+          testId="compact-card"
+          homeAbbr="DET"
+          awayAbbr="CHI"
+          homeScore={20}
+          awayScore={23}
+          userIsHome={false}
+          week={9}
+        />,
+      );
+      expect(screen.getByTestId('compact-card').disabled).toBe(true);
+    });
+  });
+});

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -97,8 +97,7 @@ import { usePhaseRouteHydration } from "../hooks/usePhaseRouteHydration.js";
 import { getPlayerProfileId, hasValidPlayerProfileId } from "../utils/playerProfileNavigation.js";
 import {
   getSectionSubtitle,
-  getTabDisplayLabel,
-  getNextActionLabel,
+  getTabLabel,
 } from "../constants/navigationCopy.js";
 import { NAV_GROUPS, HQ_QUICK_TABS } from "../constants/primaryNav.js";
 import PageOrientationHeader from "./PageOrientationHeader.jsx";
@@ -952,7 +951,7 @@ export default function LeagueDashboard({
                 aria-current={activeTab === tab ? "page" : undefined}
                 style={{ flexShrink: 0, fontSize: "11px", padding: "7px 10px" }}
               >
-                {activeSection === SHELL_SECTIONS.hq ? getNextActionLabel(tab) : getTabDisplayLabel(tab)}
+                {getTabLabel(tab, { section: activeSection })}
               </button>
             ))}
           </div>

--- a/src/ui/components/PageOrientationHeader.jsx
+++ b/src/ui/components/PageOrientationHeader.jsx
@@ -18,17 +18,9 @@ export default function PageOrientationHeader({ tab }) {
   if (!orientation) return null;
 
   return (
-    <div
-      data-testid="page-orientation"
-      className="page-orientation"
-      style={{ marginBottom: 'var(--space-3)' }}
-    >
-      <div style={{ fontSize: 'var(--text-lg)', fontWeight: 800, lineHeight: 1.15 }}>
-        {orientation.title}
-      </div>
-      <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)', marginTop: 2 }}>
-        {orientation.subtitle}
-      </div>
+    <div data-testid="page-orientation" className="page-orientation">
+      <div className="page-orientation__title">{orientation.title}</div>
+      <div className="page-orientation__subtitle">{orientation.subtitle}</div>
     </div>
   );
 }

--- a/src/ui/components/PageOrientationHeader.test.jsx
+++ b/src/ui/components/PageOrientationHeader.test.jsx
@@ -31,4 +31,17 @@ describe('PageOrientationHeader', () => {
     const { container } = render(<PageOrientationHeader tab="Not A Real Tab" />);
     expect(container.firstChild).toBeNull();
   });
+
+  it('styles itself with classes only — no inline style attributes', () => {
+    render(<PageOrientationHeader tab="Free Agency" />);
+    const header = screen.getByTestId('page-orientation');
+    expect(header.getAttribute('style')).toBeNull();
+    expect(header.classList.contains('page-orientation')).toBe(true);
+    // Title + subtitle carry semantic class hooks, not inline styles.
+    for (const el of header.querySelectorAll('div')) {
+      expect(el.getAttribute('style')).toBeNull();
+    }
+    expect(header.querySelector('.page-orientation__title')).toBeTruthy();
+    expect(header.querySelector('.page-orientation__subtitle')).toBeTruthy();
+  });
 });

--- a/src/ui/components/PostGameScreen.jsx
+++ b/src/ui/components/PostGameScreen.jsx
@@ -520,7 +520,7 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
                   minHeight: "var(--mobile-btn-h-compact, 38px)",
                 }}
               >
-                {boxScoreGameId ? "View Box Score ›" : "Box score unavailable"}
+                {boxScoreGameId ? "View Game Book ›" : "Box score unavailable"}
               </button>
             </div>
           </div>

--- a/src/ui/components/PostGameSummary.jsx
+++ b/src/ui/components/PostGameSummary.jsx
@@ -8,21 +8,11 @@
 
 import React, { useEffect, useRef, useMemo } from 'react';
 import { buildPostgameEmotionalFrame } from '../utils/postgameEmotionalFrame.js';
+import GameResultSummaryCard from './GameResultSummaryCard.jsx';
 
 function safeNum(value, fallback = 0) {
   const n = Number(value);
   return Number.isFinite(n) ? n : fallback;
-}
-
-function teamColor(abbr = '') {
-  const palette = [
-    '#0A84FF', '#34C759', '#FF9F0A', '#FF453A', '#5E5CE6',
-    '#64D2FF', '#FFD60A', '#30D158', '#FF6961', '#AEC6CF',
-    '#FF6B35', '#B4A0E5',
-  ];
-  let h = 0;
-  for (let i = 0; i < abbr.length; i++) h = abbr.charCodeAt(i) + ((h << 5) - h);
-  return palette[Math.abs(h) % palette.length];
 }
 
 function MomentumBadge({ change }) {
@@ -139,8 +129,6 @@ export default function PostGameSummary({
 
   const homeAbbr = homeTeam?.abbr ?? gameResult.homeAbbr ?? 'HOME';
   const awayAbbr = awayTeam?.abbr ?? gameResult.awayAbbr ?? 'AWAY';
-  const hColor = teamColor(homeAbbr);
-  const aColor = teamColor(awayAbbr);
 
   const injuryList = Array.isArray(injuries) ? injuries.filter(Boolean) : [];
 
@@ -180,66 +168,17 @@ export default function PostGameSummary({
           <MomentumBadge change={momentumChange} />
         </div>
 
-        {/* Score card */}
-        <div style={{
-          background: 'var(--surface)',
-          border: '1.5px solid var(--hairline)',
-          borderRadius: 16,
-          padding: '20px 24px',
-          marginBottom: 14,
-        }}>
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            {/* Away */}
-            <div style={{ flex: 1, textAlign: 'center' }}>
-              <div style={{
-                width: 48, height: 48, borderRadius: '50%', margin: '0 auto 8px',
-                background: `${aColor}20`, border: `2.5px solid ${aColor}`,
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
-                fontWeight: 900, fontSize: 13, color: aColor,
-              }}>
-                {awayAbbr.slice(0, 3)}
-              </div>
-              <div style={{ fontSize: '0.72rem', fontWeight: 700, color: 'var(--text-muted)', marginBottom: 3 }}>
-                {awayTeam?.name ?? awayAbbr}
-              </div>
-              <div style={{
-                fontSize: '2.6rem', fontWeight: 900,
-                color: !homeWon && !tied ? aColor : 'var(--text-muted)',
-                fontVariantNumeric: 'tabular-nums', lineHeight: 1,
-              }}>
-                {awayScore}
-              </div>
-            </div>
-
-            <div style={{ textAlign: 'center', padding: '0 10px' }}>
-              <div style={{ fontSize: '0.65rem', fontWeight: 800, color: 'var(--text-subtle)', letterSpacing: '1px', textTransform: 'uppercase' }}>
-                FINAL
-              </div>
-            </div>
-
-            {/* Home */}
-            <div style={{ flex: 1, textAlign: 'center' }}>
-              <div style={{
-                width: 48, height: 48, borderRadius: '50%', margin: '0 auto 8px',
-                background: `${hColor}20`, border: `2.5px solid ${hColor}`,
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
-                fontWeight: 900, fontSize: 13, color: hColor,
-              }}>
-                {homeAbbr.slice(0, 3)}
-              </div>
-              <div style={{ fontSize: '0.72rem', fontWeight: 700, color: 'var(--text-muted)', marginBottom: 3 }}>
-                {homeTeam?.name ?? homeAbbr}
-              </div>
-              <div style={{
-                fontSize: '2.6rem', fontWeight: 900,
-                color: homeWon ? hColor : 'var(--text-muted)',
-                fontVariantNumeric: 'tabular-nums', lineHeight: 1,
-              }}>
-                {homeScore}
-              </div>
-            </div>
-          </div>
-        </div>
+        {/* Canonical final-score card (shared with Franchise HQ) */}
+        <GameResultSummaryCard
+          variant="full"
+          testId="post-game-summary-result-card"
+          awayAbbr={awayAbbr}
+          awayName={awayTeam?.name ?? awayAbbr}
+          awayScore={awayScore}
+          homeAbbr={homeAbbr}
+          homeName={homeTeam?.name ?? homeAbbr}
+          homeScore={homeScore}
+        />
 
         {/* Game leaders */}
         {Array.isArray(leaders) && leaders.length > 0 && (

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -146,7 +146,7 @@ describe('FranchiseHQ', () => {
 
     // "Next Action" panel removed — Game Book access is now via the Film Room card in Season Pulse
     const seasonPulse = screen.getByTestId('season-pulse');
-    const filmRoomBtn = within(seasonPulse).getByRole('button', { name: /open game book/i });
+    const filmRoomBtn = within(seasonPulse).getByRole('button', { name: /view game book/i });
     expect(filmRoomBtn).toBeTruthy();
     fireEvent.click(filmRoomBtn);
 
@@ -182,6 +182,32 @@ describe('FranchiseHQ', () => {
     expect(screen.getByTestId('hq-last-result').textContent).toMatch(/W.*23-20.*DET/i);
   });
 
+  it('shows the compact Last Result card before the status strip and any engine/development notices', () => {
+    // Force an engine/development notice (injury) into the activity stack so we
+    // can prove the Last Result card lands ahead of it on the post-advance HQ.
+    const leagueWithInjury = {
+      ...baseLeague,
+      teams: [
+        { ...baseLeague.teams[0], roster: [{ id: 1, injuryWeeksRemaining: 3 }, { id: 2 }] },
+        baseLeague.teams[1],
+      ],
+    };
+    render(<FranchiseHQ league={leagueWithInjury} onNavigate={() => {}} onAdvanceWeek={() => {}} busy={false} simulating={false} />);
+
+    const lastResultCard = screen.getByTestId('hq-last-result-card');
+    const statusStrip = screen.getByTestId('hq-postsim-status-strip');
+    const noticeStack = screen.getByTestId('activity-toast-stack');
+
+    const FOLLOWING = Node.DOCUMENT_POSITION_FOLLOWING;
+    // Card → strip → notices, in that document order.
+    expect(lastResultCard.compareDocumentPosition(statusStrip) & FOLLOWING).toBeTruthy();
+    expect(lastResultCard.compareDocumentPosition(noticeStack) & FOLLOWING).toBeTruthy();
+    expect(statusStrip.compareDocumentPosition(noticeStack) & FOLLOWING).toBeTruthy();
+
+    // The canonical review CTA on the HQ surface reads exactly "View Game Book".
+    expect(screen.getByTestId('hq-last-result-cta').textContent).toContain('View Game Book');
+  });
+
   it('parses Game Book route intents before tab normalization can reject them', () => {
     expect(parseGameBookDestination('Game Book:g-9')).toEqual({ type: 'gameBook', gameId: 'g-9' });
     expect(parseGameBookDestination({ type: 'gameBook', gameId: 'g-9' })).toEqual({ type: 'gameBook', gameId: 'g-9' });
@@ -194,7 +220,7 @@ describe('FranchiseHQ', () => {
 
     // "Next Action" panel removed — Game Book access is now via the Film Room card in Season Pulse
     const seasonPulse = screen.getByTestId('season-pulse');
-    fireEvent.click(within(seasonPulse).getByRole('button', { name: /open game book/i }));
+    fireEvent.click(within(seasonPulse).getByRole('button', { name: /view game book/i }));
 
     expect(await screen.findByTestId('game-book')).toBeTruthy();
     expect(screen.getByTestId('game-book-final-score').textContent).toContain('CHI 23 - 20 DET');
@@ -351,7 +377,7 @@ describe('LeagueDashboard Game Book focus mode collapses the mobile bottom nav',
 
     // Open the Game Book from the HQ Film Room card.
     const seasonPulse = screen.getByTestId('season-pulse');
-    fireEvent.click(within(seasonPulse).getByRole('button', { name: /open game book/i }));
+    fireEvent.click(within(seasonPulse).getByRole('button', { name: /view game book/i }));
     expect(await screen.findByTestId('game-book')).toBeTruthy();
 
     // Bottom nav collapsed during focused review.

--- a/src/ui/components/__tests__/mobileMatchReviewFlow.viewport.test.jsx
+++ b/src/ui/components/__tests__/mobileMatchReviewFlow.viewport.test.jsx
@@ -85,7 +85,7 @@ describe('mobile Match Review flow — viewport assertions', () => {
 
     // Open the Game Book from the last result affordance / film room.
     const seasonPulse = screen.getByTestId('season-pulse');
-    fireEvent.click(within(seasonPulse).getByRole('button', { name: /open game book/i }));
+    fireEvent.click(within(seasonPulse).getByRole('button', { name: /view game book/i }));
 
     // Sticky Game Book header carries the final score + a return action above the fold.
     const stickyHeader = await screen.findByTestId('game-book-sticky-header');

--- a/src/ui/constants/navigationCopy.js
+++ b/src/ui/constants/navigationCopy.js
@@ -107,6 +107,19 @@ export function getNextActionLabel(tab) {
   return HQ_NEXT_ACTIONS[tab] ?? getTabDisplayLabel(tab);
 }
 
+// Single source of truth for the visible label of a quick/sub-nav tab button.
+// `context` selects the framing without callers branching on it themselves:
+//   - in the HQ section, tabs read as verb-first next actions ("Check Roster")
+//   - everywhere else they use the standard display label ("Trade", "Finances")
+// `context` may be the section id string ('hq') or an object ({ section } /
+// { isHQ }). The underlying tab id (routing + `section-tab-*` test ids) is
+// unchanged — this only resolves display text.
+export function getTabLabel(tab, context = {}) {
+  const ctx = typeof context === 'string' ? { section: context } : (context ?? {});
+  const isHQ = ctx.isHQ === true || ctx.section === 'hq' || ctx.section === 'HQ';
+  return isHQ ? getNextActionLabel(tab) : getTabDisplayLabel(tab);
+}
+
 export const ACTION_LABELS = Object.freeze({
   advanceWeek: 'Advance Week',
   advanceFranchise: 'Advance Franchise',

--- a/src/ui/constants/navigationCopy.test.js
+++ b/src/ui/constants/navigationCopy.test.js
@@ -8,6 +8,7 @@ import {
   getSectionSubtitle,
   getTabDisplayLabel,
   getNextActionLabel,
+  getTabLabel,
 } from './navigationCopy.js';
 
 // Pages that must carry honest "where am I / what is this for" orientation copy.
@@ -98,6 +99,35 @@ describe('HQ next-action cues', () => {
   it('only references tabs that also carry page orientation copy', () => {
     for (const tab of Object.keys(HQ_NEXT_ACTIONS)) {
       expect(getPageOrientation(tab), `missing orientation for HQ action ${tab}`).toBeTruthy();
+    }
+  });
+});
+
+describe('getTabLabel (centralized quick/sub-nav label resolver)', () => {
+  it('uses verb-first next-action labels inside the HQ section', () => {
+    expect(getTabLabel('Roster Hub', { section: 'hq' })).toBe(getNextActionLabel('Roster Hub'));
+    expect(getTabLabel('Weekly Results', { section: 'hq' })).toMatch(/review/i);
+    // Also accepts an explicit isHQ flag and a bare section-id string.
+    expect(getTabLabel('Depth Chart', { isHQ: true })).toBe(getNextActionLabel('Depth Chart'));
+    expect(getTabLabel('Free Agency', 'hq')).toBe(getNextActionLabel('Free Agency'));
+  });
+
+  it('uses the standard display label outside the HQ section', () => {
+    expect(getTabLabel('Transactions', { section: 'league' })).toBe('Trade');
+    expect(getTabLabel('History Hub', { section: 'league' })).toBe('History');
+    expect(getTabLabel('Standings', { section: 'league' })).toBe('Standings');
+  });
+
+  it('defaults to the display label when no context is given', () => {
+    expect(getTabLabel('Transactions')).toBe(getTabDisplayLabel('Transactions'));
+    expect(getTabLabel('Roster Hub')).toBe(getTabDisplayLabel('Roster Hub'));
+  });
+
+  it('matches the branching it replaced in LeagueDashboard for both sections', () => {
+    const tabs = ['Weekly Results', 'Schedule', 'Roster Hub', 'Depth Chart', 'Standings', 'Stats', 'Free Agency', 'Transactions'];
+    for (const tab of tabs) {
+      expect(getTabLabel(tab, { section: 'hq' })).toBe(getNextActionLabel(tab));
+      expect(getTabLabel(tab, { section: 'team' })).toBe(getTabDisplayLabel(tab));
     }
   });
 });

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -1367,3 +1367,19 @@ details[open] .app-hq-background-section__summary span { transform: rotate(180de
 }
 .activity-toast__dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
 .activity-toast__text { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* Page orientation header — compact "where am I / what is this page for" cue.
+   Class-based so it carries no inline styles; uses spacing + muted text tokens. */
+.page-orientation {
+  margin-bottom: var(--space-3);
+}
+.page-orientation__title {
+  font-size: var(--text-lg);
+  font-weight: 800;
+  line-height: 1.15;
+}
+.page-orientation__subtitle {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  margin-top: var(--space-1);
+}

--- a/src/ui/styles/hub.css
+++ b/src/ui/styles/hub.css
@@ -1165,6 +1165,19 @@
   flex-shrink: 0;
 }
 
+.hq-status-row__cta {
+  font-size: 11px;
+  font-weight: 800;
+  color: var(--accent);
+  flex-shrink: 0;
+  letter-spacing: 0.01em;
+}
+
+.hq-status-row:disabled {
+  cursor: default;
+  opacity: 0.85;
+}
+
 .hq-status-row__chevron {
   font-size: 13px;
   color: var(--text-subtle);


### PR DESCRIPTION
Scope A — Canonical result card:
- Extract a shared GameResultSummaryCard used in exactly two surfaces:
  the postgame overlay (variant="full") and the Franchise HQ last-result
  entry point (variant="compact"). The full variant ports the existing
  postgame score card verbatim (token-based styles, no visual change); the
  compact variant reuses the hq-status-row chrome.
- Standardize the review CTA to exactly "View Game Book" across postgame/HQ
  surfaces (postgame overlay, HQ last-result card, HQ Season Pulse film card,
  and the watch-mode PostGameScreen trigger). Presentational only.

Scope B — Post-advance HQ density:
- Reorder the post-advance mobile HQ so the compact Last Result card lands
  before the dismissible status strip and before any engine/development
  notices (ActivityToastStack), matching the documented priority order.

Scope E — Required #1631 review guardrail fixes:
- PageOrientationHeader now styles itself with classes only (no inline
  styles) via .page-orientation/.page-orientation__title/__subtitle using
  valid spacing + muted-text design tokens.
- Centralize the HQ quick-tab vs. standard label branching into
  getTabLabel(tab, context); LeagueDashboard no longer duplicates the
  inline section check. User-facing labels and routing are unchanged.

Tests:
- New GameResultSummaryCard unit tests (full/compact, framing, CTA label).
- FranchiseHQ ordering test: Last Result card precedes the status strip and
  engine/development notices; HQ review CTA reads "View Game Book".
- PageOrientationHeader test asserts class-based styling with no inline
  style attributes.
- navigationCopy getTabLabel coverage for HQ and non-HQ sections, including
  parity with the branching it replaced.
- Updated existing assertions from "Open Game Book" to "View Game Book".

No simulation, standings, contract, trade, free-agency, draft, or save-data
logic changed. Full unit suite (4961) and production build pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018H3aJzXDCTTtbgDheAVBSz