### PR TITLE
Negotiation Context V1: display-only stance reasons (#1634)

### DIFF
--- a/src/ui/components/ContractCenter.jsx
+++ b/src/ui/components/ContractCenter.jsx
@@ -469,6 +469,8 @@ export default function ContractCenter({ league, actions, compact = false, onNav
         <ExtensionNegotiationModal
           player={extensionPlayer}
           teamId={team?.id}
+          team={team}
+          league={league}
           actions={actions}
           currentSeason={league?.seasonId ?? league?.year ?? null}
           cacheScopeKey={buildLeagueCacheScopeKey(league)}

--- a/src/ui/components/ExtensionNegotiationModal.jsx
+++ b/src/ui/components/ExtensionNegotiationModal.jsx
@@ -5,6 +5,14 @@ import { formatMoneyM, safeRound, toFiniteNumber } from "../utils/numberFormatti
 import { buildRouteRequestKey } from "../utils/requestLoopGuard.js";
 import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 import { getAgentBadgeMeta, hydratePlayerAgent } from "../../core/contracts/agentNegotiationEngine.js";
+import { deriveNegotiationContext, NEGOTIATION_STANCES } from "../selectors/deriveNegotiationContext.js";
+
+const STANCE_TEXT_TONE = {
+  [NEGOTIATION_STANCES.EAGER]: 'var(--success)',
+  [NEGOTIATION_STANCES.RELUCTANT]: 'var(--warning)',
+  [NEGOTIATION_STANCES.NEUTRAL]: 'var(--text)',
+  [NEGOTIATION_STANCES.UNAVAILABLE]: 'var(--text-muted)',
+};
 
 const AGENT_TONE_CLASSES = {
   shark:       'bg-red-100 text-red-800 dark:bg-red-950/40 dark:text-red-400',
@@ -16,6 +24,8 @@ export default function ExtensionNegotiationModal({
   player,
   actions,
   teamId,
+  team = null,
+  league = null,
   currentSeason = null,
   cacheScopeKey = "global",
   onClose,
@@ -51,6 +61,20 @@ export default function ExtensionNegotiationModal({
     () => currentSeason != null &&
           agentHydrated?.negotiationState?.negotiationsFrozenUntilSeason === currentSeason,
     [agentHydrated, currentSeason],
+  );
+
+  // Display-only negotiation stance (no economics; derived at render time).
+  const resolvedTeam = useMemo(
+    () => team ?? league?.teams?.find((t) => t.id === teamId) ?? null,
+    [team, league, teamId],
+  );
+  const resolvedLeague = useMemo(
+    () => league ?? (currentSeason != null ? { seasonId: currentSeason } : null),
+    [league, currentSeason],
+  );
+  const negotiationStance = useMemo(
+    () => deriveNegotiationContext({ player, team: resolvedTeam, league: resolvedLeague }),
+    [player, resolvedTeam, resolvedLeague],
   );
 
   const askYears = toFiniteNumber(ask?.years, null);
@@ -130,6 +154,42 @@ export default function ExtensionNegotiationModal({
           >
             {agentBadge.label}
           </span>
+
+          {/* Negotiation Stance — display only; does not affect terms or acceptance. */}
+          <div
+            data-testid="negotiation-stance-section"
+            data-stance={negotiationStance.stance}
+            style={{
+              border: '1px solid var(--hairline)',
+              borderRadius: 'var(--radius-md)',
+              padding: 'var(--space-3)',
+              margin: 'var(--space-2) 0 var(--space-3)',
+              background: 'var(--surface)',
+              display: 'grid',
+              gap: 4,
+            }}
+          >
+            <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '.08em', color: 'var(--text-subtle)', fontWeight: 700 }}>
+              Negotiation Stance
+            </div>
+            {negotiationStance.stance === NEGOTIATION_STANCES.UNAVAILABLE ? (
+              <div style={{ fontSize: 'var(--text-sm)', color: 'var(--text-muted)' }}>
+                Player is not available to re-sign.
+              </div>
+            ) : (
+              <>
+                <div style={{ fontSize: 'var(--text-sm)', fontWeight: 700, color: STANCE_TEXT_TONE[negotiationStance.stance] ?? 'var(--text)' }}>
+                  {negotiationStance.stanceLabel}
+                </div>
+                {negotiationStance.reasonLabels.slice(0, 2).map((label) => (
+                  <div key={label} style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+                    {label}
+                  </div>
+                ))}
+              </>
+            )}
+          </div>
+
           {isFrozen && (
             <div
               style={{

--- a/src/ui/components/FreeAgency.jsx
+++ b/src/ui/components/FreeAgency.jsx
@@ -58,6 +58,7 @@ import { buildShowingLabel, stableSortRows } from "../utils/dataBrowser.js";
 import { resolveFreeAgencyLoadStatus } from "../utils/freeAgencyLoadStatus.js";
 import StatusEmptyState from "./common/StatusEmptyState.jsx";
 import CapImpactSummary from "./common/CapImpactSummary.jsx";
+import NegotiationStanceBadge from "./common/NegotiationStanceBadge.jsx";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -1857,6 +1858,9 @@ export default function FreeAgency({
                           })()}
                           <div style={{ fontSize: 10, color: "var(--text-subtle)", marginTop: 2 }}>
                             {player?._eval?.archetype?.archetype ?? "Balanced"} · {player?._eval?.roleProjection?.replaceContext ?? "Depth option"}
+                          </div>
+                          <div style={{ marginTop: 3 }}>
+                            <NegotiationStanceBadge player={player} team={userTeam} league={league} maxReasons={2} testId={`fa-stance-${player.id}`} />
                           </div>
                           <ContractOfferInsightBlock player={player} capRoom={capRoom} compact />
                         </TableCell>

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -2855,6 +2855,9 @@ export default function PlayerProfile({
           player={player}
           actions={actions}
           teamId={player.teamId}
+          team={resolvedProfile.team}
+          league={league}
+          currentSeason={league?.seasonId ?? league?.year ?? null}
           cacheScopeKey={cacheScopeKey}
           onClose={() => setExtending(false)}
           onComplete={() => {

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -920,6 +920,9 @@ function RosterTable({
           player={extending}
           actions={actions}
           teamId={teamId}
+          league={league}
+          team={league?.teams?.find((t) => t.id === teamId) ?? null}
+          currentSeason={league?.seasonId ?? league?.year ?? null}
           cacheScopeKey={buildLeagueCacheScopeKey(league)}
           statusNode={<StatusBadge injuryWeeks={extending.injuryWeeksRemaining} />}
           onClose={() => setExtending(null)}

--- a/src/ui/components/__tests__/NegotiationContextDisplay.test.jsx
+++ b/src/ui/components/__tests__/NegotiationContextDisplay.test.jsx
@@ -1,0 +1,150 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import NegotiationStanceBadge from '../common/NegotiationStanceBadge.jsx';
+import ExtensionNegotiationModal from '../ExtensionNegotiationModal.jsx';
+import CapImpactSummary from '../common/CapImpactSummary.jsx';
+
+/**
+ * Negotiation Context V1 — display-only surface integration.
+ *
+ * Verifies the stance badge (Free Agency row surface) and the "Negotiation
+ * Stance" section (re-sign / extension modal) render the derived, display-only
+ * context, and that UNAVAILABLE renders its dedicated copy. No economics,
+ * acceptance, or cap logic is exercised here — these are presentation checks.
+ */
+
+const league = { seasonId: 2026, year: 2026 };
+
+function loyalStar(overrides = {}) {
+  return {
+    id: 42,
+    name: 'Marcus Lane',
+    pos: 'WR',
+    age: 29,
+    ovr: 88,
+    tenureYears: 5,
+    negotiationState: { negotiationsFrozenUntilSeason: null },
+    ...overrides,
+  };
+}
+
+function contenderTeam(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Contenders',
+    wins: 13,
+    losses: 4,
+    ties: 0,
+    frontOffice: { persona: 'WIN_NOW' },
+    ...overrides,
+  };
+}
+
+describe('NegotiationStanceBadge — Free Agency row surface', () => {
+  afterEach(cleanup);
+
+  it('renders a stance badge with plain-language reasons for a player with known context', () => {
+    const { getByTestId, queryByText } = render(
+      <NegotiationStanceBadge player={loyalStar()} team={contenderTeam()} league={league} testId="fa-stance-42" />,
+    );
+    const badge = getByTestId('fa-stance-42');
+    expect(badge.getAttribute('data-stance')).toBe('EAGER');
+    expect(badge.textContent).toMatch(/eager to re-sign/i);
+    // Plain-language reason — never a raw code.
+    expect(badge.textContent).toMatch(/winning now/i);
+    expect(queryByText(/WIN_NOW_URGENCY/)).toBeNull();
+  });
+
+  it('renders the muted UNAVAILABLE stance with no reasons when negotiations are frozen', () => {
+    const player = loyalStar({ negotiationState: { negotiationsFrozenUntilSeason: 2026 } });
+    const { getByTestId } = render(
+      <NegotiationStanceBadge player={player} team={contenderTeam()} league={league} testId="fa-stance-42" />,
+    );
+    const badge = getByTestId('fa-stance-42');
+    expect(badge.getAttribute('data-stance')).toBe('UNAVAILABLE');
+    expect(badge.textContent).toMatch(/not available to re-sign/i);
+  });
+
+  it('renders exactly one stance badge per player (no duplicate displays)', () => {
+    const { getAllByTestId } = render(
+      <NegotiationStanceBadge player={loyalStar()} team={contenderTeam()} league={league} testId="fa-stance-42" />,
+    );
+    expect(getAllByTestId('fa-stance-42')).toHaveLength(1);
+  });
+});
+
+describe('ExtensionNegotiationModal — Negotiation Stance section', () => {
+  afterEach(cleanup);
+
+  // getExtensionAsk never resolves: the stance section renders independently of
+  // the async ask, so the section is present synchronously.
+  const pendingActions = { getExtensionAsk: vi.fn(() => new Promise(() => {})) };
+
+  it('renders a "Negotiation Stance" section with stance + reasons', () => {
+    const { getByTestId, getByText } = render(
+      <ExtensionNegotiationModal
+        player={loyalStar()}
+        actions={pendingActions}
+        teamId={1}
+        team={contenderTeam()}
+        league={league}
+        currentSeason={2026}
+        onClose={() => {}}
+      />,
+    );
+    expect(getByText('Negotiation Stance')).toBeTruthy();
+    const section = getByTestId('negotiation-stance-section');
+    expect(section.getAttribute('data-stance')).toBe('EAGER');
+    expect(section.textContent).toMatch(/winning now/i);
+  });
+
+  it('renders the dedicated UNAVAILABLE copy when the player cannot re-sign', () => {
+    const player = loyalStar({ negotiationState: { negotiationsFrozenUntilSeason: 2026 } });
+    const { getByTestId } = render(
+      <ExtensionNegotiationModal
+        player={player}
+        actions={pendingActions}
+        teamId={1}
+        team={contenderTeam()}
+        league={league}
+        currentSeason={2026}
+        onClose={() => {}}
+      />,
+    );
+    const section = getByTestId('negotiation-stance-section');
+    expect(section.getAttribute('data-stance')).toBe('UNAVAILABLE');
+    expect(section.textContent).toMatch(/player is not available to re-sign/i);
+  });
+
+  it('renders exactly one Negotiation Stance section (no duplicate displays)', () => {
+    const { getAllByTestId } = render(
+      <ExtensionNegotiationModal
+        player={loyalStar()}
+        actions={pendingActions}
+        teamId={1}
+        team={contenderTeam()}
+        league={league}
+        currentSeason={2026}
+        onClose={() => {}}
+      />,
+    );
+    expect(getAllByTestId('negotiation-stance-section')).toHaveLength(1);
+  });
+});
+
+describe('CapImpactSummary — no regression alongside stance display', () => {
+  afterEach(cleanup);
+
+  it('still renders its cap breakdown independently of the new stance surface', () => {
+    const { getByTestId } = render(
+      <div>
+        <NegotiationStanceBadge player={loyalStar()} team={contenderTeam()} league={league} testId="fa-stance-42" />
+        <CapImpactSummary currentRoom={30} incoming={12} outgoing={0} />
+      </div>,
+    );
+    expect(getByTestId('fa-stance-42')).toBeTruthy();
+    expect(getByTestId('cap-impact-summary')).toBeTruthy();
+  });
+});

--- a/src/ui/components/common/NegotiationStanceBadge.jsx
+++ b/src/ui/components/common/NegotiationStanceBadge.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { deriveNegotiationContext, NEGOTIATION_STANCES } from '../../selectors/deriveNegotiationContext.js';
+
+/**
+ * NegotiationStanceBadge — purely presentational display of a player's
+ * derived negotiation stance and plain-language reason labels.
+ *
+ * It calls the pure `deriveNegotiationContext` selector at render time only.
+ * It changes no economics, persists nothing, and never exposes raw reason
+ * codes — only `reasonLabels`. Badge colour maps to existing visual tokens:
+ *   UNAVAILABLE → muted · EAGER → success · RELUCTANT → warning · NEUTRAL → default
+ *
+ * @param {object} props
+ * @param {object} props.player
+ * @param {object} [props.team]
+ * @param {object} [props.league]
+ * @param {number} [props.maxReasons]   How many reason labels to show (default 2).
+ * @param {boolean} [props.showReasons]  Render reason labels beneath the badge (default true).
+ * @param {string} [props.testId]
+ */
+export default function NegotiationStanceBadge({
+  player,
+  team,
+  league,
+  maxReasons = 2,
+  showReasons = true,
+  testId = 'negotiation-stance-badge',
+}) {
+  const ctx = deriveNegotiationContext({ player, team, league });
+
+  const tone = STANCE_TONE[ctx.stance] ?? STANCE_TONE[NEGOTIATION_STANCES.NEUTRAL];
+  const reasonLabels = (ctx.reasonLabels ?? []).slice(0, maxReasons);
+
+  return (
+    <div
+      data-testid={testId}
+      data-stance={ctx.stance}
+      style={{ display: 'grid', gap: 3, justifyItems: 'start' }}
+    >
+      <span
+        aria-label={`Negotiation stance: ${ctx.stanceLabel}`}
+        style={{
+          display: 'inline-block',
+          fontSize: 10,
+          fontWeight: 700,
+          color: tone,
+          border: `1px solid ${tone}`,
+          background: `${tone}14`,
+          borderRadius: 999,
+          padding: '0 6px',
+          lineHeight: 1.6,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {ctx.stanceLabel}
+      </span>
+      {showReasons && reasonLabels.length > 0 ? (
+        <div style={{ display: 'grid', gap: 1 }}>
+          {reasonLabels.map((label) => (
+            <div key={label} style={{ fontSize: 10, color: 'var(--text-subtle)', lineHeight: 1.4 }}>
+              {label}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+const STANCE_TONE = Object.freeze({
+  [NEGOTIATION_STANCES.EAGER]: 'var(--success)',
+  [NEGOTIATION_STANCES.RELUCTANT]: 'var(--warning)',
+  [NEGOTIATION_STANCES.UNAVAILABLE]: 'var(--text-muted)',
+  [NEGOTIATION_STANCES.NEUTRAL]: 'var(--text-muted)',
+});

--- a/src/ui/selectors/deriveNegotiationContext.js
+++ b/src/ui/selectors/deriveNegotiationContext.js
@@ -1,0 +1,275 @@
+/**
+ * deriveNegotiationContext.js — Display-only negotiation stance derivation (V1)
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ * WHAT THIS IS
+ * ──────────────────────────────────────────────────────────────────────────
+ * A pure, deterministic, *presentational* selector. Given a player, the user's
+ * team, and league state, it derives a human-readable "negotiation stance"
+ * (EAGER / NEUTRAL / RELUCTANT / UNAVAILABLE) plus a short list of plain-language
+ * "front-office context" reasons, for display on the Free Agency and re-sign /
+ * extension surfaces.
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ * WHAT THIS IS NOT
+ * ──────────────────────────────────────────────────────────────────────────
+ * It is NOT contract logic. It does not — and must never — influence asking
+ * price, willingness gating, cap-legal checks, acceptance logic, simulation
+ * scoring, trade valuation, owner pressure, or any persisted save data. It lives
+ * under `ui/selectors/` (not `engine/contracts/`) precisely so this intent is
+ * structurally visible: nothing here feeds back into gameplay.
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ * SAVE COMPATIBILITY (Scope D)
+ * ──────────────────────────────────────────────────────────────────────────
+ * This is derived at render time only. There is NO migration and NO new
+ * persistence. Every field read is defensive: missing / undefined fields cause
+ * the relevant reason code to be skipped silently and the stance to fall back to
+ * NEUTRAL. The function must never throw on old save data.
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ * PURITY GUARANTEE
+ * ──────────────────────────────────────────────────────────────────────────
+ * Inputs are never mutated. Same inputs → same output, always (no Math.random,
+ * no Date, no I/O). Only fields that are reliably populated across the codebase
+ * are read (see the A0 field-discovery classification in the PR description).
+ */
+
+// ── Stance constants ──────────────────────────────────────────────────────────
+
+export const NEGOTIATION_STANCES = Object.freeze({
+  EAGER: 'EAGER',
+  NEUTRAL: 'NEUTRAL',
+  RELUCTANT: 'RELUCTANT',
+  UNAVAILABLE: 'UNAVAILABLE',
+});
+
+const STANCE_LABELS = Object.freeze({
+  EAGER: 'Eager to re-sign',
+  NEUTRAL: 'Open to discussions',
+  RELUCTANT: 'Hesitant on a new deal',
+  UNAVAILABLE: 'Not available to re-sign',
+});
+
+// Front-office persona keys (mirrors core/ai/frontOfficePersonaEngine.js, read-only).
+const PERSONA = Object.freeze({
+  WIN_NOW: 'WIN_NOW',
+  PATIENT_BUILDER: 'PATIENT_BUILDER',
+  CAP_HOARDER: 'CAP_HOARDER',
+  PLAYER_LOYALIST: 'PLAYER_LOYALIST',
+});
+
+// "Key contributor" / star caliber threshold. OVR is a reliably populated field;
+// this mirrors the OVR>=78 cut the spec already sanctions for CAP_HOARDER_FRICTION.
+const STAR_OVR = 78;
+
+// A win% "clearly below" a competitive line. Only evaluated once real games exist,
+// so an unplayed 0-0 season never trips this (its win% is treated as undefined).
+const REBUILDER_WIN_PCT = 0.35;
+
+// ── Reason code catalogue (SUPPORTED codes only — V1) ─────────────────────────
+//
+// polarity: 'positive' pulls toward EAGER, 'negative' pulls toward RELUCTANT.
+// label:    plain-language front-office framing. No label asserts a player's
+//           internal emotion or intent — the game tracks no mood value here.
+// priority: lower = stronger signal, surfaced first.
+
+export const REASON_CODES = Object.freeze({
+  WIN_NOW_URGENCY: 'WIN_NOW_URGENCY',
+  LOYALTY_PERSONA: 'LOYALTY_PERSONA',
+  LOYAL_TENURE: 'LOYAL_TENURE',
+  VETERAN_LOYALTY: 'VETERAN_LOYALTY',
+  REBUILDER_FRICTION: 'REBUILDER_FRICTION',
+  CAP_HOARDER_FRICTION: 'CAP_HOARDER_FRICTION',
+});
+
+const REASON_META = Object.freeze({
+  [REASON_CODES.WIN_NOW_URGENCY]: {
+    polarity: 'positive',
+    priority: 1,
+    label: 'The front office is committed to winning now.',
+  },
+  [REASON_CODES.LOYALTY_PERSONA]: {
+    polarity: 'positive',
+    priority: 2,
+    label: 'The front office values player loyalty.',
+  },
+  [REASON_CODES.LOYAL_TENURE]: {
+    polarity: 'positive',
+    priority: 3,
+    label: 'He has history with this franchise.',
+  },
+  [REASON_CODES.VETERAN_LOYALTY]: {
+    polarity: 'positive',
+    priority: 4,
+    label: 'He feels a bond with this team late in his career.',
+  },
+  [REASON_CODES.REBUILDER_FRICTION]: {
+    polarity: 'negative',
+    priority: 5,
+    label: 'He may prefer a more competitive situation.',
+  },
+  [REASON_CODES.CAP_HOARDER_FRICTION]: {
+    polarity: 'negative',
+    priority: 6,
+    label: "He may be uncertain about the front office's commitment.",
+  },
+});
+
+const MAX_REASONS = 3;
+
+// ── Defensive readers (never throw on partial / old-save shapes) ──────────────
+
+function num(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/**
+ * Current-team win fraction, or null when it cannot be reliably determined
+ * (no games played yet → an unplayed record must not read as a rebuild).
+ */
+function resolveWinPct(team) {
+  const wins = num(team?.wins);
+  const losses = num(team?.losses);
+  const ties = num(team?.ties);
+  const games = wins + losses + ties;
+  if (games <= 0) return null;
+  return (wins + ties * 0.5) / games;
+}
+
+/**
+ * UNAVAILABLE flag: agent negotiations frozen for the current season.
+ * `negotiationState.negotiationsFrozenUntilSeason` is initialised on every
+ * player (core/player.js), so this read is safe on new and old saves alike.
+ * When no current season is supplied, we cannot assert unavailability → false.
+ */
+function isUnavailable(player, league) {
+  const frozenUntil = player?.negotiationState?.negotiationsFrozenUntilSeason;
+  if (frozenUntil == null) return false;
+  const currentSeason = league?.seasonId ?? league?.year ?? null;
+  if (currentSeason == null) return false;
+  return frozenUntil === currentSeason;
+}
+
+// ── Reason derivation (SUPPORTED codes only) ──────────────────────────────────
+
+/**
+ * Collects every SUPPORTED reason code whose trigger fires for this
+ * player/team. Pure: reads only, returns a fresh array of code strings.
+ */
+function collectReasonCodes(player, team) {
+  const codes = [];
+
+  const tenure = num(player?.tenureYears);
+  const age = num(player?.age);
+  const ovr = num(player?.ovr);
+  const persona = team?.frontOffice?.persona ?? null;
+  const winPct = resolveWinPct(team);
+
+  // Positive — loyalty / tenure signals
+  if (tenure >= 3) codes.push(REASON_CODES.LOYAL_TENURE);
+  if (age >= 32 && tenure >= 2) codes.push(REASON_CODES.VETERAN_LOYALTY);
+  if (persona === PERSONA.PLAYER_LOYALIST) codes.push(REASON_CODES.LOYALTY_PERSONA);
+
+  // Positive — front office committed to winning now around a key contributor
+  if (persona === PERSONA.WIN_NOW && ovr >= STAR_OVR) {
+    codes.push(REASON_CODES.WIN_NOW_URGENCY);
+  }
+
+  // Negative — friction signals for a quality player
+  if (persona === PERSONA.CAP_HOARDER && ovr >= STAR_OVR) {
+    codes.push(REASON_CODES.CAP_HOARDER_FRICTION);
+  }
+  if (winPct != null && winPct < REBUILDER_WIN_PCT && ovr >= STAR_OVR) {
+    codes.push(REASON_CODES.REBUILDER_FRICTION);
+  }
+
+  return codes;
+}
+
+/**
+ * Resolve the stance from fired reason codes.
+ * Priority order (per spec):
+ *   1. UNAVAILABLE handled before this point.
+ *   2. EAGER     — 2+ positive codes, 0 negative.
+ *   3. RELUCTANT — 1+ negative code (a friction signal outweighs positives).
+ *   4. NEUTRAL   — default.
+ */
+function resolveStance(codes) {
+  let positives = 0;
+  let negatives = 0;
+  for (const code of codes) {
+    const polarity = REASON_META[code]?.polarity;
+    if (polarity === 'positive') positives += 1;
+    else if (polarity === 'negative') negatives += 1;
+  }
+  if (positives >= 2 && negatives === 0) return NEGOTIATION_STANCES.EAGER;
+  if (negatives >= 1) return NEGOTIATION_STANCES.RELUCTANT;
+  return NEGOTIATION_STANCES.NEUTRAL;
+}
+
+/**
+ * Order fired codes so the reasons matching the resolved stance's polarity lead,
+ * then by signal strength (priority). Deterministic; caps at MAX_REASONS.
+ */
+function orderReasonCodes(codes, stance) {
+  const leadPolarity =
+    stance === NEGOTIATION_STANCES.RELUCTANT ? 'negative' : 'positive';
+  return [...codes]
+    .sort((a, b) => {
+      const ma = REASON_META[a];
+      const mb = REASON_META[b];
+      const aLead = ma?.polarity === leadPolarity ? 0 : 1;
+      const bLead = mb?.polarity === leadPolarity ? 0 : 1;
+      if (aLead !== bLead) return aLead - bLead;
+      return (ma?.priority ?? 99) - (mb?.priority ?? 99);
+    })
+    .slice(0, MAX_REASONS);
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {object} NegotiationContext
+ * @property {'EAGER'|'NEUTRAL'|'RELUCTANT'|'UNAVAILABLE'} stance
+ * @property {string}   stanceLabel    Always a non-empty human-readable string.
+ * @property {string[]} reasons        Raw reason codes (0–3). For testing/logic.
+ * @property {string[]} reasonLabels   Plain-language labels (0–3). For display.
+ */
+
+/**
+ * Derive display-only negotiation context for a player relative to a team.
+ *
+ * Pure and deterministic. Mutates nothing. Never throws on partial input.
+ *
+ * @param {object} params
+ * @param {object} [params.player]  Player at FA / re-sign render time.
+ * @param {object} [params.team]    The user's team (record, frontOffice persona).
+ * @param {object} [params.league]  League / season state (for current season).
+ * @returns {NegotiationContext}
+ */
+export function deriveNegotiationContext({ player, team, league } = {}) {
+  // UNAVAILABLE short-circuits everything — no reasons surfaced.
+  if (isUnavailable(player, league)) {
+    return {
+      stance: NEGOTIATION_STANCES.UNAVAILABLE,
+      stanceLabel: STANCE_LABELS.UNAVAILABLE,
+      reasons: [],
+      reasonLabels: [],
+    };
+  }
+
+  const firedCodes = collectReasonCodes(player ?? {}, team ?? {});
+  const stance = resolveStance(firedCodes);
+  const orderedCodes = orderReasonCodes(firedCodes, stance);
+
+  return {
+    stance,
+    stanceLabel: STANCE_LABELS[stance] ?? STANCE_LABELS.NEUTRAL,
+    reasons: orderedCodes,
+    reasonLabels: orderedCodes.map((code) => REASON_META[code]?.label).filter(Boolean),
+  };
+}
+
+export default deriveNegotiationContext;

--- a/src/ui/selectors/deriveNegotiationContext.test.js
+++ b/src/ui/selectors/deriveNegotiationContext.test.js
@@ -1,0 +1,284 @@
+import { describe, it, expect } from 'vitest';
+import {
+  deriveNegotiationContext,
+  NEGOTIATION_STANCES,
+  REASON_CODES,
+} from './deriveNegotiationContext.js';
+
+// ── Builders ──────────────────────────────────────────────────────────────────
+
+function makePlayer(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Test Player',
+    pos: 'WR',
+    age: 27,
+    ovr: 72,
+    tenureYears: 0,
+    negotiationState: { negotiationsFrozenUntilSeason: null },
+    ...overrides,
+  };
+}
+
+function makeTeam(overrides = {}) {
+  return {
+    id: 10,
+    name: 'Test Team',
+    wins: 8,
+    losses: 8,
+    ties: 0,
+    frontOffice: { persona: 'PATIENT_BUILDER' },
+    ...overrides,
+  };
+}
+
+const league = { seasonId: 2026, year: 2026 };
+
+// ── Determinism ───────────────────────────────────────────────────────────────
+
+describe('deriveNegotiationContext — determinism', () => {
+  it('returns identical output for identical inputs', () => {
+    const player = makePlayer({ tenureYears: 4, age: 33, ovr: 85 });
+    const team = makeTeam({ frontOffice: { persona: 'PLAYER_LOYALIST' } });
+    const a = deriveNegotiationContext({ player, team, league });
+    const b = deriveNegotiationContext({ player, team, league });
+    expect(a).toEqual(b);
+  });
+});
+
+// ── Immutability (required guardrail) ─────────────────────────────────────────
+
+describe('deriveNegotiationContext — immutability', () => {
+  it('does not mutate any input', () => {
+    const player = makePlayer({ tenureYears: 4, age: 33, ovr: 90 });
+    const team = makeTeam({ frontOffice: { persona: 'CAP_HOARDER' } });
+    const playerBefore = structuredClone(player);
+    const teamBefore = structuredClone(team);
+    const leagueBefore = structuredClone(league);
+    deriveNegotiationContext({ player, team, league });
+    expect(player).toEqual(playerBefore);
+    expect(team).toEqual(teamBefore);
+    expect(league).toEqual(leagueBefore);
+  });
+});
+
+// ── Individual reason codes fire correctly ────────────────────────────────────
+
+describe('deriveNegotiationContext — reason code triggers', () => {
+  it('LOYAL_TENURE fires at tenureYears >= 3 and not below', () => {
+    const team = makeTeam();
+    expect(
+      deriveNegotiationContext({ player: makePlayer({ tenureYears: 3 }), team, league }).reasons,
+    ).toContain(REASON_CODES.LOYAL_TENURE);
+    expect(
+      deriveNegotiationContext({ player: makePlayer({ tenureYears: 2 }), team, league }).reasons,
+    ).not.toContain(REASON_CODES.LOYAL_TENURE);
+  });
+
+  it('VETERAN_LOYALTY requires age >= 32 AND tenureYears >= 2', () => {
+    const team = makeTeam();
+    expect(
+      deriveNegotiationContext({ player: makePlayer({ age: 32, tenureYears: 2 }), team, league }).reasons,
+    ).toContain(REASON_CODES.VETERAN_LOYALTY);
+    expect(
+      deriveNegotiationContext({ player: makePlayer({ age: 31, tenureYears: 2 }), team, league }).reasons,
+    ).not.toContain(REASON_CODES.VETERAN_LOYALTY);
+    expect(
+      deriveNegotiationContext({ player: makePlayer({ age: 34, tenureYears: 1 }), team, league }).reasons,
+    ).not.toContain(REASON_CODES.VETERAN_LOYALTY);
+  });
+
+  it('LOYALTY_PERSONA fires only for PLAYER_LOYALIST front office', () => {
+    expect(
+      deriveNegotiationContext({
+        player: makePlayer(),
+        team: makeTeam({ frontOffice: { persona: 'PLAYER_LOYALIST' } }),
+        league,
+      }).reasons,
+    ).toContain(REASON_CODES.LOYALTY_PERSONA);
+    expect(
+      deriveNegotiationContext({
+        player: makePlayer(),
+        team: makeTeam({ frontOffice: { persona: 'WIN_NOW' } }),
+        league,
+      }).reasons,
+    ).not.toContain(REASON_CODES.LOYALTY_PERSONA);
+  });
+
+  it('WIN_NOW_URGENCY requires WIN_NOW persona AND star-caliber OVR', () => {
+    const team = makeTeam({ frontOffice: { persona: 'WIN_NOW' } });
+    expect(
+      deriveNegotiationContext({ player: makePlayer({ ovr: 80 }), team, league }).reasons,
+    ).toContain(REASON_CODES.WIN_NOW_URGENCY);
+    expect(
+      deriveNegotiationContext({ player: makePlayer({ ovr: 70 }), team, league }).reasons,
+    ).not.toContain(REASON_CODES.WIN_NOW_URGENCY);
+  });
+
+  it('CAP_HOARDER_FRICTION requires CAP_HOARDER persona AND OVR >= 78', () => {
+    const team = makeTeam({ frontOffice: { persona: 'CAP_HOARDER' } });
+    expect(
+      deriveNegotiationContext({ player: makePlayer({ ovr: 84 }), team, league }).reasons,
+    ).toContain(REASON_CODES.CAP_HOARDER_FRICTION);
+    expect(
+      deriveNegotiationContext({ player: makePlayer({ ovr: 70 }), team, league }).reasons,
+    ).not.toContain(REASON_CODES.CAP_HOARDER_FRICTION);
+  });
+
+  it('REBUILDER_FRICTION fires for a star on a clearly losing team', () => {
+    const team = makeTeam({ wins: 3, losses: 13, ties: 0, frontOffice: { persona: 'PATIENT_BUILDER' } });
+    expect(
+      deriveNegotiationContext({ player: makePlayer({ ovr: 84 }), team, league }).reasons,
+    ).toContain(REASON_CODES.REBUILDER_FRICTION);
+  });
+
+  it('REBUILDER_FRICTION does NOT fire on an unplayed (0-0) record', () => {
+    const team = makeTeam({ wins: 0, losses: 0, ties: 0 });
+    expect(
+      deriveNegotiationContext({ player: makePlayer({ ovr: 90 }), team, league }).reasons,
+    ).not.toContain(REASON_CODES.REBUILDER_FRICTION);
+  });
+
+  it('REBUILDER_FRICTION does NOT fire for a non-star on a losing team', () => {
+    const team = makeTeam({ wins: 2, losses: 14, ties: 0 });
+    expect(
+      deriveNegotiationContext({ player: makePlayer({ ovr: 70 }), team, league }).reasons,
+    ).not.toContain(REASON_CODES.REBUILDER_FRICTION);
+  });
+});
+
+// ── Stance resolution ─────────────────────────────────────────────────────────
+
+describe('deriveNegotiationContext — stance resolution', () => {
+  it('loyal star on a contender → EAGER', () => {
+    const player = makePlayer({ tenureYears: 5, ovr: 88, age: 29 });
+    const team = makeTeam({ wins: 13, losses: 4, frontOffice: { persona: 'WIN_NOW' } });
+    const ctx = deriveNegotiationContext({ player, team, league });
+    expect(ctx.stance).toBe(NEGOTIATION_STANCES.EAGER);
+  });
+
+  it('high-OVR starter on a rebuilder → RELUCTANT', () => {
+    const player = makePlayer({ tenureYears: 0, ovr: 84, age: 27 });
+    const team = makeTeam({ wins: 3, losses: 13, frontOffice: { persona: 'PATIENT_BUILDER' } });
+    const ctx = deriveNegotiationContext({ player, team, league });
+    expect(ctx.stance).toBe(NEGOTIATION_STANCES.RELUCTANT);
+  });
+
+  it('neutral mid-tier player → NEUTRAL', () => {
+    const player = makePlayer({ tenureYears: 1, ovr: 70, age: 26 });
+    const team = makeTeam({ wins: 8, losses: 8, frontOffice: { persona: 'PATIENT_BUILDER' } });
+    const ctx = deriveNegotiationContext({ player, team, league });
+    expect(ctx.stance).toBe(NEGOTIATION_STANCES.NEUTRAL);
+  });
+
+  it('a single positive code is not enough for EAGER (stays NEUTRAL)', () => {
+    const player = makePlayer({ tenureYears: 4, ovr: 70, age: 28 });
+    const team = makeTeam({ frontOffice: { persona: 'PATIENT_BUILDER' } });
+    const ctx = deriveNegotiationContext({ player, team, league });
+    expect(ctx.stance).toBe(NEGOTIATION_STANCES.NEUTRAL);
+  });
+
+  it('any negative code outweighs positives → RELUCTANT', () => {
+    // Loyal tenure (positive) but a cap-hoarder front office (negative).
+    const player = makePlayer({ tenureYears: 5, ovr: 85, age: 30 });
+    const team = makeTeam({ frontOffice: { persona: 'CAP_HOARDER' } });
+    const ctx = deriveNegotiationContext({ player, team, league });
+    expect(ctx.stance).toBe(NEGOTIATION_STANCES.RELUCTANT);
+    // The friction reason leads the displayed labels.
+    expect(ctx.reasons[0]).toBe(REASON_CODES.CAP_HOARDER_FRICTION);
+  });
+});
+
+// ── UNAVAILABLE ───────────────────────────────────────────────────────────────
+
+describe('deriveNegotiationContext — UNAVAILABLE', () => {
+  it('frozen negotiations for the current season → UNAVAILABLE with no reasons', () => {
+    const player = makePlayer({
+      tenureYears: 5,
+      ovr: 90,
+      negotiationState: { negotiationsFrozenUntilSeason: 2026 },
+    });
+    const ctx = deriveNegotiationContext({ player, team: makeTeam(), league });
+    expect(ctx.stance).toBe(NEGOTIATION_STANCES.UNAVAILABLE);
+    expect(ctx.reasons).toEqual([]);
+    expect(ctx.reasonLabels).toEqual([]);
+    expect(ctx.stanceLabel).toBeTruthy();
+  });
+
+  it('a stale freeze from a prior season does NOT mark UNAVAILABLE', () => {
+    const player = makePlayer({
+      negotiationState: { negotiationsFrozenUntilSeason: 2025 },
+    });
+    const ctx = deriveNegotiationContext({ player, team: makeTeam(), league });
+    expect(ctx.stance).not.toBe(NEGOTIATION_STANCES.UNAVAILABLE);
+  });
+
+  it('without a known current season, a freeze cannot assert UNAVAILABLE', () => {
+    const player = makePlayer({
+      negotiationState: { negotiationsFrozenUntilSeason: 2026 },
+    });
+    const ctx = deriveNegotiationContext({ player, team: makeTeam(), league: {} });
+    expect(ctx.stance).not.toBe(NEGOTIATION_STANCES.UNAVAILABLE);
+  });
+});
+
+// ── Output shape / contract guarantees ────────────────────────────────────────
+
+describe('deriveNegotiationContext — output contract', () => {
+  it('reasonLabels has at most 3 entries', () => {
+    // Stack many positives: loyal tenure + veteran loyalty + loyalty persona.
+    const player = makePlayer({ tenureYears: 6, age: 34, ovr: 88 });
+    const team = makeTeam({ frontOffice: { persona: 'PLAYER_LOYALIST' } });
+    const ctx = deriveNegotiationContext({ player, team, league });
+    expect(ctx.reasonLabels.length).toBeLessThanOrEqual(3);
+    expect(ctx.reasons.length).toBeLessThanOrEqual(3);
+  });
+
+  it('stanceLabel is always a non-empty string', () => {
+    for (const player of [makePlayer(), makePlayer({ tenureYears: 5, ovr: 90, age: 35 }), {}]) {
+      const ctx = deriveNegotiationContext({ player, team: makeTeam(), league });
+      expect(typeof ctx.stanceLabel).toBe('string');
+      expect(ctx.stanceLabel.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('reasonLabels never expose raw reason codes', () => {
+    const player = makePlayer({ tenureYears: 5, ovr: 85, age: 33 });
+    const team = makeTeam({ frontOffice: { persona: 'WIN_NOW' } });
+    const ctx = deriveNegotiationContext({ player, team, league });
+    for (const label of ctx.reasonLabels) {
+      expect(label).not.toMatch(/[A-Z]+_[A-Z]+/); // no SCREAMING_SNAKE codes
+    }
+  });
+});
+
+// ── Backward compatibility with old saves ─────────────────────────────────────
+
+describe('deriveNegotiationContext — old save / missing fields', () => {
+  it('missing player and team do not crash and default to NEUTRAL', () => {
+    const ctx = deriveNegotiationContext({});
+    expect(ctx.stance).toBe(NEGOTIATION_STANCES.NEUTRAL);
+    expect(ctx.stanceLabel).toBeTruthy();
+    expect(ctx.reasons).toEqual([]);
+  });
+
+  it('completely empty call does not crash', () => {
+    const ctx = deriveNegotiationContext();
+    expect(ctx.stance).toBe(NEGOTIATION_STANCES.NEUTRAL);
+  });
+
+  it('player without negotiationState (old save) is not UNAVAILABLE', () => {
+    const player = { id: 7, name: 'Legacy', pos: 'QB', age: 28, ovr: 75 };
+    const team = { id: 2, wins: 9, losses: 7 };
+    const ctx = deriveNegotiationContext({ player, team, league });
+    expect(ctx.stance).not.toBe(NEGOTIATION_STANCES.UNAVAILABLE);
+  });
+
+  it('team without frontOffice (old save) skips persona reasons silently', () => {
+    const player = makePlayer({ tenureYears: 4 });
+    const team = { id: 3, wins: 8, losses: 8 };
+    const ctx = deriveNegotiationContext({ player, team, league });
+    expect(ctx.reasons).toContain(REASON_CODES.LOYAL_TENURE);
+    expect(ctx.reasons).not.toContain(REASON_CODES.LOYALTY_PERSONA);
+  });
+});


### PR DESCRIPTION
Surface display-only negotiation context on the Free Agency and re-sign /
extension surfaces. A pure, deterministic selector derives a player's
negotiation stance (EAGER / NEUTRAL / RELUCTANT / UNAVAILABLE) and up to
three plain-language front-office reason labels, computed at render time.

No economics change: asking price, willingness gating, cap-legal checks,
acceptance, simulation, trade valuation, owner pressure, award formulas, and
save data shape are all untouched. No new player/team fields and no new
persistence. The selector mutates no input and never throws on old saves
(missing fields are skipped silently, defaulting to NEUTRAL).

- Add src/ui/selectors/deriveNegotiationContext.js (pure selector) + tests.
- Add NegotiationStanceBadge (FA row surface).
- Add a "Negotiation Stance" section to ExtensionNegotiationModal; pass
  team/league from Roster, ContractCenter, and PlayerProfile call sites.

Only SUPPORTED reason codes are implemented: LOYAL_TENURE, VETERAN_LOYALTY,
LOYALTY_PERSONA, WIN_NOW_URGENCY, CAP_HOARDER_FRICTION, REBUILDER_FRICTION.
PARTIAL/UNSUPPORTED codes (CONTENDER_PULL, ROLE_FRICTION, SHOPPED_FRICTION,
PRESTIGE_APPEAL) are deferred to V2.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A9EdDp9vmPNVHKf5giKC8T