### PR TITLE
chore: complete daily regression pass and improve emotional tension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.11.0",
         "@playwright/test": "^1.59.1",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.0",
         "@vitejs/plugin-react": "^5.1.4",
         "fake-indexeddb": "^6.2.5",
@@ -2443,7 +2444,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2491,8 +2491,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2713,7 +2712,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2724,7 +2722,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2750,7 +2747,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2949,7 +2945,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2980,8 +2975,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dset": {
       "version": "3.1.4",
@@ -3646,7 +3640,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3828,7 +3821,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3884,8 +3876,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",

--- a/src/core/game-runner.js
+++ b/src/core/game-runner.js
@@ -192,6 +192,20 @@ class GameRunner {
             }
         }
 
+        // 5. Emotional Clarity: Winless or Undefeated streaks early-mid season
+        if (stakes === 0 && week >= 3 && week <= 9) {
+            const wins = team.wins || team.record?.w || 0;
+            const losses = team.losses || team.record?.l || 0;
+
+            if (wins === 0 && losses >= 2) {
+                // High tension for a winless team trying to get on the board
+                stakes = 80;
+            } else if (losses === 0 && wins >= 2) {
+                // High tension for an undefeated team trying to keep the streak alive
+                stakes = 80;
+            }
+        }
+
         return stakes;
     }
 

--- a/tests/e2e/helpers/franchise.js
+++ b/tests/e2e/helpers/franchise.js
@@ -131,8 +131,12 @@ export async function goToTab(page, name) {
             const b = anyBtn.nth(i);
             const text = await b.innerText();
             if (text && text.toLowerCase().includes(tab)) {
-                 await b.click({ force: true });
-                 return;
+                 try {
+                     await b.click({ timeout: 1000 });
+                     return;
+                 } catch (e) {
+                     // Ignore elements outside of the viewport
+                 }
             }
         }
   }
@@ -167,8 +171,12 @@ export async function goToTab(page, name) {
             const b = anyBtn.nth(i);
             const text = await b.innerText();
             if (text && text.toLowerCase().includes(tab)) {
-                 await b.click({ force: true });
-                 return;
+                 try {
+                     await b.click({ timeout: 1000 });
+                     return;
+                 } catch (e) {
+                     // Ignore elements outside of the viewport
+                 }
             }
         }
     }


### PR DESCRIPTION
Daily QA and improvement pass:
* Tested playability, strategy persistence, mobile UI scrolling, contracts/cap, and replay exploits via `daily_regression.spec.js`.
* Fixed a bug in `goToTab` test helper where it crashed clicking elements translated off-screen on mobile, improving Playwright test reliability without false negatives.
* Added an emotional improvement in `src/core/game-runner.js` by boosting tension/stakes for early-season winless and undefeated streaks (Weeks 3-9).

---
*PR created automatically by Jules for task [15321779320280244062](https://jules.google.com/task/15321779320280244062) started by @rbcati*