### PR TITLE
fix: hoist STANCE_TONE above NegotiationStanceBadge and add safe fallback tone

### DIFF
--- a/src/ui/components/__tests__/FreeAgencyStanceBadgeRenderPath.test.jsx
+++ b/src/ui/components/__tests__/FreeAgencyStanceBadgeRenderPath.test.jsx
@@ -1,0 +1,58 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import FreeAgency from '../FreeAgency.jsx';
+
+/**
+ * Guards the actual Free Agency row render path: #1634 shipped a
+ * NegotiationStanceBadge reference-before-declaration bug that unit tests on
+ * the badge alone never caught, because nothing rendered it inside a real FA
+ * player row. This mounts the live FreeAgency screen with one free agent and
+ * asserts the row (and its stance badge) render without throwing.
+ */
+
+function buildLeague() {
+  return {
+    year: 2026,
+    week: 5,
+    phase: 'free_agency',
+    userTeamId: 1,
+    teams: [
+      {
+        id: 1,
+        name: 'Pittsburgh',
+        abbr: 'PIT',
+        capRoom: 35,
+        capUsed: 210,
+        capTotal: 255,
+        frontOffice: { persona: 'WIN_NOW' },
+      },
+    ],
+  };
+}
+
+function buildActions() {
+  return {
+    getFreeAgents: vi.fn().mockResolvedValue({
+      payload: {
+        phase: 'free_agency',
+        faDay: 1,
+        faMaxDays: 5,
+        freeAgents: [{ id: 44, name: 'Max Lane', pos: 'WR', ovr: 82, age: 26, teamId: null, contract: { baseAnnual: 6.5 } }],
+      },
+    }),
+  };
+}
+
+describe('FreeAgency — player row render path', () => {
+  afterEach(cleanup);
+
+  it('renders a free agent row with its negotiation stance badge without throwing', async () => {
+    render(<FreeAgency league={buildLeague()} userTeamId={1} actions={buildActions()} />);
+
+    const badge = await screen.findByTestId('fa-stance-44');
+    expect(badge).toBeTruthy();
+    expect(['EAGER', 'NEUTRAL', 'RELUCTANT', 'UNAVAILABLE']).toContain(badge.getAttribute('data-stance'));
+  });
+});

--- a/src/ui/components/common/NegotiationStanceBadge.jsx
+++ b/src/ui/components/common/NegotiationStanceBadge.jsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import { deriveNegotiationContext, NEGOTIATION_STANCES } from '../../selectors/deriveNegotiationContext.js';
 
+const STANCE_TONE = Object.freeze({
+  [NEGOTIATION_STANCES.EAGER]: 'var(--success)',
+  [NEGOTIATION_STANCES.RELUCTANT]: 'var(--warning)',
+  [NEGOTIATION_STANCES.UNAVAILABLE]: 'var(--text-muted)',
+  [NEGOTIATION_STANCES.NEUTRAL]: 'var(--text-muted)',
+});
+
 /**
  * NegotiationStanceBadge — purely presentational display of a player's
  * derived negotiation stance and plain-language reason labels.
@@ -28,7 +35,7 @@ export default function NegotiationStanceBadge({
 }) {
   const ctx = deriveNegotiationContext({ player, team, league });
 
-  const tone = STANCE_TONE[ctx.stance] ?? STANCE_TONE[NEGOTIATION_STANCES.NEUTRAL];
+  const tone = STANCE_TONE[ctx.stance] ?? 'var(--text-muted)';
   const reasonLabels = (ctx.reasonLabels ?? []).slice(0, maxReasons);
 
   return (
@@ -66,10 +73,3 @@ export default function NegotiationStanceBadge({
     </div>
   );
 }
-
-const STANCE_TONE = Object.freeze({
-  [NEGOTIATION_STANCES.EAGER]: 'var(--success)',
-  [NEGOTIATION_STANCES.RELUCTANT]: 'var(--warning)',
-  [NEGOTIATION_STANCES.UNAVAILABLE]: 'var(--text-muted)',
-  [NEGOTIATION_STANCES.NEUTRAL]: 'var(--text-muted)',
-});

--- a/src/ui/components/common/NegotiationStanceBadge.test.jsx
+++ b/src/ui/components/common/NegotiationStanceBadge.test.jsx
@@ -1,0 +1,93 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import NegotiationStanceBadge from './NegotiationStanceBadge.jsx';
+
+/**
+ * Regression coverage for the STANCE_TONE reference-before-declaration bug:
+ * the badge must render without throwing for every known stance plus any
+ * stance value the selector hasn't been taught yet, falling back to a safe
+ * tone instead of crashing the Free Agency row.
+ */
+
+const league = { seasonId: 2026, year: 2026 };
+
+describe('NegotiationStanceBadge — renders without throwing per stance', () => {
+  afterEach(cleanup);
+
+  it('EAGER — renders visibly', () => {
+    const player = { id: 1, name: 'Eager Star', ovr: 88, tenureYears: 5, age: 27 };
+    const team = { frontOffice: { persona: 'WIN_NOW' } };
+    const { getByTestId } = render(
+      <NegotiationStanceBadge player={player} team={team} league={league} testId="badge-eager" />,
+    );
+    const badge = getByTestId('badge-eager');
+    expect(badge.getAttribute('data-stance')).toBe('EAGER');
+    expect(badge.textContent).toMatch(/eager to re-sign/i);
+  });
+
+  it('NEUTRAL — renders visibly', () => {
+    const player = { id: 2, name: 'Neutral Guy', ovr: 70, tenureYears: 1, age: 24 };
+    const team = {};
+    const { getByTestId } = render(
+      <NegotiationStanceBadge player={player} team={team} league={league} testId="badge-neutral" />,
+    );
+    const badge = getByTestId('badge-neutral');
+    expect(badge.getAttribute('data-stance')).toBe('NEUTRAL');
+    expect(badge.textContent).toMatch(/open to discussions/i);
+  });
+
+  it('RELUCTANT — renders visibly', () => {
+    const player = { id: 3, name: 'Reluctant Vet', ovr: 85, tenureYears: 1, age: 27 };
+    const team = { frontOffice: { persona: 'CAP_HOARDER' } };
+    const { getByTestId } = render(
+      <NegotiationStanceBadge player={player} team={team} league={league} testId="badge-reluctant" />,
+    );
+    const badge = getByTestId('badge-reluctant');
+    expect(badge.getAttribute('data-stance')).toBe('RELUCTANT');
+    expect(badge.textContent).toMatch(/hesitant on a new deal/i);
+  });
+
+  it('UNAVAILABLE — renders "not available to re-sign"', () => {
+    const player = {
+      id: 4,
+      name: 'Frozen Player',
+      negotiationState: { negotiationsFrozenUntilSeason: 2026 },
+    };
+    const team = {};
+    const { getByTestId } = render(
+      <NegotiationStanceBadge player={player} team={team} league={league} testId="badge-unavailable" />,
+    );
+    const badge = getByTestId('badge-unavailable');
+    expect(badge.getAttribute('data-stance')).toBe('UNAVAILABLE');
+    expect(badge.textContent).toMatch(/not available to re-sign/i);
+  });
+
+  it('unknown stance — renders with the fallback tone instead of throwing', async () => {
+    vi.resetModules();
+    vi.doMock('../../selectors/deriveNegotiationContext.js', async () => {
+      const actual = await vi.importActual('../../selectors/deriveNegotiationContext.js');
+      return {
+        ...actual,
+        deriveNegotiationContext: () => ({
+          stance: 'FUTURE_STANCE',
+          stanceLabel: 'Future Stance',
+          reasons: [],
+          reasonLabels: [],
+        }),
+      };
+    });
+
+    const { default: BadgeWithMockedSelector } = await import('./NegotiationStanceBadge.jsx');
+    const { getByTestId } = render(
+      <BadgeWithMockedSelector player={{ id: 5 }} team={{}} league={league} testId="badge-unknown" />,
+    );
+    const badge = getByTestId('badge-unknown');
+    expect(badge.getAttribute('data-stance')).toBe('FUTURE_STANCE');
+    expect(badge.querySelector('span').style.color).toBe('var(--text-muted)');
+
+    vi.doUnmock('../../selectors/deriveNegotiationContext.js');
+    vi.resetModules();
+  });
+});


### PR DESCRIPTION
STANCE_TONE was declared as a const at the bottom of the file while the
component referenced it in its body above the declaration, an unsafe
ordering that only worked by accident. Move the declaration above the
component, fall back to a literal muted tone for unknown/missing stance
values, and add render tests covering all four known stances, an
unknown stance, and the live Free Agency row render path that #1634's
tests never exercised.