### PR TITLE
Trade UI Clarity V1: display-only Trade Breakdown for offer legibility

### DIFF
--- a/src/ui/components/TradeCenter.jsx
+++ b/src/ui/components/TradeCenter.jsx
@@ -31,6 +31,8 @@ import { getPickBaseValueFromMatrix } from "../../core/trades/tradeValuationModi
 import FrontOfficeBadge from "./FrontOfficeBadge.jsx";
 import { getHotSeatStatus } from "../../core/meta/ownerPressureEngine.js";
 import CapImpactSummary from "./common/CapImpactSummary.jsx";
+import TradeValueSummary from "./common/TradeValueSummary.jsx";
+import { deriveTradeContext } from "../selectors/deriveTradeContext.js";
 
 // ── Original helpers (kept exactly as you had) ─────────────────────────────────
 
@@ -502,6 +504,22 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
       capAfter: myCapAfter,
     });
   }, [receiving, offering, theirRosterMap, myRosterMap, myIntel, liveMyTeam?.capRoom, myCapAfter]);
+
+  // Display-only "Trade Breakdown" context. Interprets numbers this screen
+  // already renders (offer values, projected cap room, visible needs) via the
+  // pure deriveTradeContext selector — it feeds nothing back into the engine.
+  const tradeContext = useMemo(() => deriveTradeContext({
+    userGivesPlayers: [...offering].map((id) => myRosterMap.get(toAssetId(id))).filter(Boolean),
+    userGetsPlayers: [...receiving].map((id) => theirRosterMap.get(toAssetId(id))).filter(Boolean),
+    userGivesPicks: myPicks,
+    userGetsPicks: theirPicks,
+    userOfferValue: myOfferValue,
+    otherOfferValue: theirOfferValue,
+    otherTeam: liveTheirTeam,
+    otherTeamNeeds: theirNeedsSummary?.needs ?? [],
+    userCapRoomBefore: liveMyTeam?.capRoom,
+    userCapRoomAfter: myCapAfter,
+  }), [offering, receiving, myRosterMap, theirRosterMap, myPicks, theirPicks, myOfferValue, theirOfferValue, liveTheirTeam, theirNeedsSummary, liveMyTeam?.capRoom, myCapAfter]);
 
   const toggleOffering = (id, checked) => setOffering(prev => { const s = new Set(prev); const normalizedId = toAssetId(id); checked ? s.add(normalizedId) : s.delete(normalizedId); return s; });
   const toggleReceiving = (id, checked) => setReceiving(prev => { const s = new Set(prev); const normalizedId = toAssetId(id); checked ? s.add(normalizedId) : s.delete(normalizedId); return s; });
@@ -1087,6 +1105,8 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
               </div>
             </div>
           )}
+          {/* Trade Breakdown — display-only readability layer (deriveTradeContext). */}
+          <TradeValueSummary context={tradeContext} hasSelection={hasSelection} />
           {hasSelection && (
             <TradeConsequenceStrip
               myTeam={liveMyTeam}

--- a/src/ui/components/__tests__/TradeBreakdownIntegration.test.jsx
+++ b/src/ui/components/__tests__/TradeBreakdownIntegration.test.jsx
@@ -1,0 +1,154 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, fireEvent, waitFor } from '@testing-library/react';
+import TradeCenter from '../TradeCenter.jsx';
+import TradeValueSummary from '../common/TradeValueSummary.jsx';
+import { MOTIVATION_CODES, TRADE_BALANCE } from '../../selectors/deriveTradeContext.js';
+
+function makePlayer(id, name, { pos = 'WR', ovr = 80, age = 26, baseAnnual = 6 } = {}) {
+  return { id, name, pos, ovr, age, contract: { baseAnnual } };
+}
+
+function makeTeam(id, { abbr, capRoom = 20, roster = [], picks = [], frontOffice } = {}) {
+  return { id, name: `Team ${id}`, abbr: abbr ?? `T${id}`, wins: 5, losses: 5, ties: 0, capRoom, picks, roster, frontOffice };
+}
+
+const USER = makeTeam(1, { abbr: 'CHI', capRoom: 20, roster: [makePlayer(101, 'Give Guy', { ovr: 84, age: 24, baseAnnual: 8 })] });
+const AI = makeTeam(2, {
+  abbr: 'DET',
+  capRoom: 30,
+  roster: [makePlayer(201, 'Get Guy', { pos: 'RB', ovr: 80, age: 31, baseAnnual: 5 })],
+  frontOffice: { persona: 'WIN_NOW' },
+});
+
+function makeActions() {
+  return {
+    getRoster: vi.fn(async (tid) => {
+      const team = Number(tid) === 1 ? USER : AI;
+      return { payload: { team, players: team.roster } };
+    }),
+    submitTrade: vi.fn(async () => ({ payload: { accepted: false, reason: 'AI passed.' } })),
+    acceptIncomingTrade: vi.fn(async () => ({ payload: { accepted: false } })),
+    counterIncomingTrade: vi.fn(async () => ({ payload: { accepted: false } })),
+    toggleTradeBlock: vi.fn(async () => ({})),
+    save: vi.fn(),
+  };
+}
+
+function makeLeague() {
+  return {
+    year: 2027,
+    season: 2027,
+    week: 3,
+    phase: 'regular',
+    userTeamId: 1,
+    teams: [USER, AI],
+    incomingTradeOffers: [],
+    inboundTradeOffers: [],
+    settings: { tradeDeadlineWeek: 9 },
+  };
+}
+
+describe('TradeCenter — Trade Breakdown integration', () => {
+  afterEach(cleanup);
+
+  it('renders the Trade Breakdown section on the trade screen', async () => {
+    const { findByText, getByTestId } = render(
+      <TradeCenter league={makeLeague()} actions={makeActions()} />,
+    );
+    expect(await findByText('Trade Breakdown')).toBeTruthy();
+    expect(getByTestId('trade-value-summary')).toBeTruthy();
+  });
+
+  it('shows neutral preview copy for an incomplete trade (no assets selected)', async () => {
+    const { findByText } = render(
+      <TradeCenter league={makeLeague()} actions={makeActions()} />,
+    );
+    expect(await findByText('Add players or picks to preview trade context.')).toBeTruthy();
+  });
+
+  it('keeps CapImpactSummary rendering alongside the breakdown once assets are selected', async () => {
+    const { findByLabelText, getByTestId } = render(
+      <TradeCenter league={makeLeague()} actions={makeActions()} />,
+    );
+    fireEvent.click(await findByLabelText(/Add to Trade Give Guy/i));
+    fireEvent.click(await findByLabelText(/Add to Trade Get Guy/i));
+    await waitFor(() => {
+      expect(getByTestId('cap-impact-summary')).toBeTruthy();
+      expect(getByTestId('trade-value-summary')).toBeTruthy();
+    });
+  });
+
+  it('surfaces motivation copy without ever leaking raw signal codes into the DOM', async () => {
+    const { findByLabelText, container, findByText } = render(
+      <TradeCenter league={makeLeague()} actions={makeActions()} />,
+    );
+    // Give Guy (84 OVR) heading to a WIN_NOW front office → win-now motivation.
+    fireEvent.click(await findByLabelText(/Add to Trade Give Guy/i));
+    fireEvent.click(await findByLabelText(/Add to Trade Get Guy/i));
+    expect(await findByText('Their interest:')).toBeTruthy();
+    expect(await findByText('This fits a win-now roster push.')).toBeTruthy();
+
+    const text = container.textContent;
+    for (const code of Object.values(MOTIVATION_CODES)) {
+      expect(text).not.toContain(code);
+    }
+    expect(text).not.toContain('FAVORABLE');
+    expect(text).not.toContain('UNFAVORABLE');
+  });
+
+  it('renders exactly one Trade Breakdown (no duplicate balance displays)', async () => {
+    const { findByLabelText, queryAllByTestId, getAllByText } = render(
+      <TradeCenter league={makeLeague()} actions={makeActions()} />,
+    );
+    fireEvent.click(await findByLabelText(/Add to Trade Give Guy/i));
+    fireEvent.click(await findByLabelText(/Add to Trade Get Guy/i));
+    await waitFor(() => {
+      expect(queryAllByTestId('trade-value-summary')).toHaveLength(1);
+    });
+    expect(getAllByText('Trade Breakdown')).toHaveLength(1);
+  });
+
+  it('leaves trade submit behavior unchanged (propose still calls submitTrade)', async () => {
+    const actions = makeActions();
+    const { findByLabelText, getAllByText, getByTestId } = render(
+      <TradeCenter league={makeLeague()} actions={actions} />,
+    );
+    fireEvent.click(await findByLabelText(/Add to Trade Give Guy/i));
+    fireEvent.click(await findByLabelText(/Add to Trade Get Guy/i));
+    fireEvent.click(getAllByText('Propose Trade')[0]);
+
+    await waitFor(() => {
+      expect(actions.submitTrade).toHaveBeenCalledTimes(1);
+      expect(getByTestId('trade-status-banner').textContent).toContain('Trade rejected');
+    });
+    expect(actions.submitTrade).toHaveBeenCalledWith(
+      1,
+      2,
+      { playerIds: [101], pickIds: [] },
+      { playerIds: [201], pickIds: [] },
+    );
+  });
+});
+
+describe('TradeValueSummary — unavailable-context state', () => {
+  afterEach(cleanup);
+
+  it('shows "Limited trade context available." when a selection yields no readable context', () => {
+    const context = {
+      userBalance: TRADE_BALANCE.UNKNOWN,
+      userBalanceLabel: 'Not enough selected to read this deal yet.',
+      otherTeamMotivation: [],
+      motivationLabels: [],
+      capNote: null,
+    };
+    const { getByText } = render(<TradeValueSummary context={context} hasSelection />);
+    expect(getByText('Limited trade context available.')).toBeTruthy();
+  });
+
+  it('shows the empty preview copy when nothing is selected', () => {
+    const { getByText } = render(<TradeValueSummary context={undefined} hasSelection={false} />);
+    expect(getByText('Add players or picks to preview trade context.')).toBeTruthy();
+  });
+});

--- a/src/ui/components/common/TradeValueSummary.jsx
+++ b/src/ui/components/common/TradeValueSummary.jsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { TRADE_BALANCE } from '../../selectors/deriveTradeContext.js';
+
+const BALANCE_TONE = Object.freeze({
+  [TRADE_BALANCE.FAVORABLE]: 'var(--success)',
+  [TRADE_BALANCE.UNFAVORABLE]: 'var(--warning)',
+  [TRADE_BALANCE.EVEN]: 'var(--text-muted)',
+  [TRADE_BALANCE.UNKNOWN]: 'var(--text-muted)',
+});
+
+const EMPTY_COPY = 'Add players or picks to preview trade context.';
+const LIMITED_COPY = 'Limited trade context available.';
+
+/**
+ * TradeValueSummary — the "Trade Breakdown" card for the trade builder.
+ *
+ * Purely presentational: it renders a TradeContext produced by the
+ * display-only `deriveTradeContext` selector. It never shows raw signal
+ * codes — only the plain-language labels — and it changes no trade,
+ * valuation, cap, or acceptance behavior.
+ *
+ * @param {object} props
+ * @param {import('../../selectors/deriveTradeContext.js').TradeContext} [props.context]
+ * @param {boolean} [props.hasSelection] Whether any asset is in the package.
+ * @param {string}  [props.testId]
+ */
+export default function TradeValueSummary({
+  context,
+  hasSelection = true,
+  testId = 'trade-value-summary',
+}) {
+  const balance = context?.userBalance ?? TRADE_BALANCE.UNKNOWN;
+  const motivationLabels = Array.isArray(context?.motivationLabels)
+    ? context.motivationLabels.slice(0, 2)
+    : [];
+  const capNote = context?.capNote ?? null;
+  const limited =
+    balance === TRADE_BALANCE.UNKNOWN && motivationLabels.length === 0 && !capNote;
+  const tone = BALANCE_TONE[balance] ?? 'var(--text-muted)';
+
+  return (
+    <div
+      className="card"
+      data-testid={testId}
+      data-balance={balance}
+      style={{
+        padding: 'var(--space-3)',
+        marginBottom: 'var(--space-3)',
+        display: 'grid',
+        gap: 6,
+      }}
+    >
+      <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '.08em', color: 'var(--text-subtle)', fontWeight: 700 }}>
+        Trade Breakdown
+      </div>
+      {!hasSelection ? (
+        <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{EMPTY_COPY}</div>
+      ) : limited ? (
+        <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{LIMITED_COPY}</div>
+      ) : (
+        <>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+            <span
+              style={{
+                display: 'inline-block',
+                fontSize: 10,
+                fontWeight: 700,
+                color: tone,
+                border: `1px solid ${tone}`,
+                background: `${tone}14`,
+                borderRadius: 999,
+                padding: '0 6px',
+                lineHeight: 1.6,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              Value read
+            </span>
+            <span style={{ fontSize: 'var(--text-xs)', fontWeight: 700, color: tone }}>
+              {context?.userBalanceLabel}
+            </span>
+          </div>
+          {motivationLabels.length > 0 ? (
+            <div style={{ display: 'grid', gap: 2 }}>
+              <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-subtle)', fontWeight: 700 }}>
+                Their interest:
+              </span>
+              {motivationLabels.map((label) => (
+                <div key={label} style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+                  {label}
+                </div>
+              ))}
+            </div>
+          ) : null}
+          {capNote ? (
+            <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{capNote}</div>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/ui/selectors/deriveTradeContext.js
+++ b/src/ui/selectors/deriveTradeContext.js
@@ -1,0 +1,316 @@
+/**
+ * deriveTradeContext.js — Display-only trade offer readability (V1)
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ * GUARDRAIL
+ * ──────────────────────────────────────────────────────────────────────────
+ * Display-only selector. Do not import into trade valuation, trade acceptance,
+ * AI trade behavior, cap legality, simulation, or save migration logic.
+ * It may only be imported by UI components and tests.
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ * WHAT THIS IS
+ * ──────────────────────────────────────────────────────────────────────────
+ * A pure, deterministic, *presentational* selector for the trade builder.
+ * Given the current offer as the UI already sees it (players/picks on each
+ * side, the display-only value figures the ValueBar already renders, the
+ * other team's visible needs list, and the user's before/after cap room),
+ * it derives:
+ *
+ *   - a plain-language read on which way the package leans (userBalance),
+ *   - up to two cautious "why they might listen" motivation labels, and
+ *   - an optional user-side cap note.
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ * WHAT THIS IS NOT
+ * ──────────────────────────────────────────────────────────────────────────
+ * This is NOT the trade acceptance brain and must never feed it. It does not
+ * compute valuation — it interprets numbers the screen already displays. It
+ * is deliberately separate from deriveNegotiationContext.js, which covers
+ * contract / FA / re-sign stance only.
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ * SAVE COMPATIBILITY / PURITY
+ * ──────────────────────────────────────────────────────────────────────────
+ * Derived at render time only — no persistence, no migration. Every field
+ * read is defensive: missing or malformed fields cause the relevant signal to
+ * be skipped silently. Inputs are never mutated; same inputs → same output.
+ */
+
+// ── Public constants ──────────────────────────────────────────────────────────
+
+export const TRADE_BALANCE = Object.freeze({
+  FAVORABLE: 'FAVORABLE',
+  EVEN: 'EVEN',
+  UNFAVORABLE: 'UNFAVORABLE',
+  UNKNOWN: 'UNKNOWN',
+});
+
+const BALANCE_LABELS = Object.freeze({
+  [TRADE_BALANCE.FAVORABLE]: 'This package leans in your favor.',
+  [TRADE_BALANCE.EVEN]: 'This package looks close to even.',
+  [TRADE_BALANCE.UNFAVORABLE]: 'You are giving up more than you are getting back.',
+  [TRADE_BALANCE.UNKNOWN]: 'Not enough selected to read this deal yet.',
+});
+
+export const MOTIVATION_CODES = Object.freeze({
+  NEEDS_POSITION: 'NEEDS_POSITION',
+  WIN_NOW_ACQUIRE: 'WIN_NOW_ACQUIRE',
+  REBUILDER_SHED: 'REBUILDER_SHED',
+  SHEDDING_CAP: 'SHEDDING_CAP',
+  PICK_ACCUMULATION: 'PICK_ACCUMULATION',
+  ACQUIRING_YOUTH: 'ACQUIRING_YOUTH',
+});
+
+// Front-office persona keys (mirrors core/ai/frontOfficePersonaEngine.js,
+// read-only — mirrored rather than imported so this file never pulls in
+// engine code).
+const PERSONA = Object.freeze({
+  WIN_NOW: 'WIN_NOW',
+  PATIENT_BUILDER: 'PATIENT_BUILDER',
+  CAP_HOARDER: 'CAP_HOARDER',
+});
+
+// ── Tuning thresholds (display heuristics only) ──────────────────────────────
+
+// Mirrors the ValueBar fairness band: within ±15% of total value reads "even".
+const EVEN_BAND = 0.15;
+// "High-OVR" cut, consistent with the STAR_OVR convention used elsewhere in UI.
+const STAR_OVR = 78;
+// "Veteran" age, consistent with the aging-core cut in teamIntelligence.
+const VETERAN_AGE = 30;
+// Average-age gap (years) before a package reads as a youth acquisition.
+const YOUTH_AGE_GAP = 3;
+// Net salary ($M) the other team must shed before it reads as a cap dump.
+const CAP_SHED_MIN = 5;
+// Projected user cap room ($M) under which a worsening move reads as pressure
+// (mirrors the "tight" threshold in CapImpactSummary).
+const TIGHT_CAP_ROOM = 5;
+// Cap room gain ($M) before a move reads as creating flexibility.
+const CAP_RELIEF_MIN = 3;
+
+const MAX_MOTIVATION_LABELS = 2;
+
+const CAP_NOTES = Object.freeze({
+  PRESSURE: 'This tightens your cap picture.',
+  RELIEF: 'This creates cap flexibility.',
+});
+
+// Priority: lower = more specific / stronger signal, surfaced first.
+const MOTIVATION_PRIORITY = Object.freeze({
+  [MOTIVATION_CODES.NEEDS_POSITION]: 1,
+  [MOTIVATION_CODES.WIN_NOW_ACQUIRE]: 2,
+  [MOTIVATION_CODES.REBUILDER_SHED]: 3,
+  [MOTIVATION_CODES.SHEDDING_CAP]: 4,
+  [MOTIVATION_CODES.PICK_ACCUMULATION]: 5,
+  [MOTIVATION_CODES.ACQUIRING_YOUTH]: 6,
+});
+
+// ── Defensive readers (never throw on partial / old-save shapes) ──────────────
+
+function num(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function arr(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function playerPos(player) {
+  const raw = player?.pos ?? player?.position;
+  return raw ? String(raw).toUpperCase() : null;
+}
+
+function sumSalary(players) {
+  return players.reduce((sum, p) => sum + num(p?.contract?.baseAnnual), 0);
+}
+
+/** Average age across players with a finite age, or null when none have one. */
+function avgAge(players) {
+  const ages = players.map((p) => Number(p?.age)).filter((n) => Number.isFinite(n) && n > 0);
+  if (!ages.length) return null;
+  return ages.reduce((sum, n) => sum + n, 0) / ages.length;
+}
+
+// ── Balance ───────────────────────────────────────────────────────────────────
+
+function resolveBalance({ hasAssets, userOfferValue, otherOfferValue }) {
+  if (!hasAssets) return TRADE_BALANCE.UNKNOWN;
+  const gives = Number(userOfferValue);
+  const gets = Number(otherOfferValue);
+  if (!Number.isFinite(gives) || !Number.isFinite(gets)) return TRADE_BALANCE.UNKNOWN;
+  const total = gives + gets;
+  if (total <= 0) return TRADE_BALANCE.UNKNOWN;
+  const diff = gets - gives;
+  if (Math.abs(diff) < total * EVEN_BAND) return TRADE_BALANCE.EVEN;
+  return diff > 0 ? TRADE_BALANCE.FAVORABLE : TRADE_BALANCE.UNFAVORABLE;
+}
+
+// ── Motivation signals (all SUPPORTED-only, all from visible offer data) ──────
+
+/**
+ * Collects fired motivation codes with their display labels.
+ * "They" is always the other team: they receive what the user gives.
+ */
+function collectMotivations({
+  theyGetPlayers,
+  theySendPlayers,
+  theyGetPicks,
+  otherTeamNeeds,
+  persona,
+}) {
+  const fired = [];
+
+  // NEEDS_POSITION — a player they receive matches a visible roster need.
+  const needsSet = new Set(
+    arr(otherTeamNeeds).map((n) => String(n).toUpperCase()).filter(Boolean),
+  );
+  const neededPos = theyGetPlayers.map(playerPos).find((pos) => pos && needsSet.has(pos));
+  if (neededPos) {
+    fired.push({
+      code: MOTIVATION_CODES.NEEDS_POSITION,
+      label: `They may need help at ${neededPos}.`,
+    });
+  }
+
+  // WIN_NOW_ACQUIRE — win-now front office receiving a high-OVR player.
+  if (persona === PERSONA.WIN_NOW && theyGetPlayers.some((p) => num(p?.ovr) >= STAR_OVR)) {
+    fired.push({
+      code: MOTIVATION_CODES.WIN_NOW_ACQUIRE,
+      label: 'This fits a win-now roster push.',
+    });
+  }
+
+  // REBUILDER_SHED — patient/cap-focused front office sending a high-OVR veteran.
+  if (
+    (persona === PERSONA.PATIENT_BUILDER || persona === PERSONA.CAP_HOARDER) &&
+    theySendPlayers.some((p) => num(p?.ovr) >= STAR_OVR && num(p?.age) >= VETERAN_AGE)
+  ) {
+    fired.push({
+      code: MOTIVATION_CODES.REBUILDER_SHED,
+      label: 'They may be pivoting toward a longer-term build.',
+    });
+  }
+
+  // SHEDDING_CAP — they send meaningfully more salary than they take back.
+  if (sumSalary(theySendPlayers) - sumSalary(theyGetPlayers) >= CAP_SHED_MIN) {
+    fired.push({
+      code: MOTIVATION_CODES.SHEDDING_CAP,
+      label: 'They may be looking to clear cap space.',
+    });
+  }
+
+  // PICK_ACCUMULATION — they move players out and take draft capital back.
+  if (theySendPlayers.length > 0 && theyGetPicks.length > 0) {
+    fired.push({
+      code: MOTIVATION_CODES.PICK_ACCUMULATION,
+      label: 'They are collecting future draft capital.',
+    });
+  }
+
+  // ACQUIRING_YOUTH — the players they receive are meaningfully younger than
+  // the players they send (both sides need known ages).
+  const getAge = avgAge(theyGetPlayers);
+  const sendAge = avgAge(theySendPlayers);
+  if (getAge != null && sendAge != null && sendAge - getAge >= YOUTH_AGE_GAP) {
+    fired.push({
+      code: MOTIVATION_CODES.ACQUIRING_YOUTH,
+      label: 'They appear to be acquiring for the future.',
+    });
+  }
+
+  fired.sort(
+    (a, b) => (MOTIVATION_PRIORITY[a.code] ?? 99) - (MOTIVATION_PRIORITY[b.code] ?? 99),
+  );
+  return fired;
+}
+
+// ── Cap note (user side only) ─────────────────────────────────────────────────
+
+function resolveCapNote({ userCapRoomBefore, userCapRoomAfter }) {
+  const before = Number(userCapRoomBefore);
+  const after = Number(userCapRoomAfter);
+  if (!Number.isFinite(before) || !Number.isFinite(after)) return null;
+  if (after < before && after < TIGHT_CAP_ROOM) return CAP_NOTES.PRESSURE;
+  if (after - before >= CAP_RELIEF_MIN) return CAP_NOTES.RELIEF;
+  return null;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * @typedef {object} TradeContext
+ * @property {'FAVORABLE'|'EVEN'|'UNFAVORABLE'|'UNKNOWN'} userBalance
+ * @property {string}   userBalanceLabel     Always a non-empty string.
+ * @property {string[]} otherTeamMotivation  Raw codes (for tests/tools only).
+ * @property {string[]} motivationLabels     Plain-language labels (max 2).
+ * @property {string|null} capNote           User-side cap note, when relevant.
+ */
+
+/**
+ * Derive display-only readability context for the trade offer currently on
+ * screen. Pure and deterministic; mutates nothing; never throws on partial
+ * input (old/incomplete saves included).
+ *
+ * All value/cap figures are the display numbers the trade screen already
+ * computes and shows — this selector interprets them, it does not price assets.
+ *
+ * @param {object} params
+ * @param {object[]} [params.userGivesPlayers]  Players the user sends (they receive).
+ * @param {object[]} [params.userGetsPlayers]   Players the user receives (they send).
+ * @param {object[]} [params.userGivesPicks]    Picks the user sends (they receive).
+ * @param {object[]} [params.userGetsPicks]     Picks the user receives (they send).
+ * @param {number}   [params.userOfferValue]    Display value of what the user gives.
+ * @param {number}   [params.otherOfferValue]   Display value of what the user gets.
+ * @param {object}   [params.otherTeam]         Partner team (frontOffice persona).
+ * @param {string[]} [params.otherTeamNeeds]    Partner's visible need positions.
+ * @param {number}   [params.userCapRoomBefore] User cap room before the trade ($M).
+ * @param {number}   [params.userCapRoomAfter]  Projected user cap room after ($M).
+ * @returns {TradeContext}
+ */
+export function deriveTradeContext({
+  userGivesPlayers,
+  userGetsPlayers,
+  userGivesPicks,
+  userGetsPicks,
+  userOfferValue,
+  otherOfferValue,
+  otherTeam,
+  otherTeamNeeds,
+  userCapRoomBefore,
+  userCapRoomAfter,
+} = {}) {
+  const theyGetPlayers = arr(userGivesPlayers).filter(Boolean);
+  const theySendPlayers = arr(userGetsPlayers).filter(Boolean);
+  const theyGetPicks = arr(userGivesPicks).filter(Boolean);
+  const theySendPicks = arr(userGetsPicks).filter(Boolean);
+
+  const hasAssets =
+    theyGetPlayers.length > 0 ||
+    theySendPlayers.length > 0 ||
+    theyGetPicks.length > 0 ||
+    theySendPicks.length > 0;
+
+  const userBalance = resolveBalance({ hasAssets, userOfferValue, otherOfferValue });
+
+  const motivations = hasAssets
+    ? collectMotivations({
+        theyGetPlayers,
+        theySendPlayers,
+        theyGetPicks,
+        otherTeamNeeds,
+        persona: otherTeam?.frontOffice?.persona ?? null,
+      })
+    : [];
+
+  return {
+    userBalance,
+    userBalanceLabel: BALANCE_LABELS[userBalance] ?? BALANCE_LABELS[TRADE_BALANCE.UNKNOWN],
+    otherTeamMotivation: motivations.map((m) => m.code),
+    motivationLabels: motivations.slice(0, MAX_MOTIVATION_LABELS).map((m) => m.label),
+    capNote: hasAssets ? resolveCapNote({ userCapRoomBefore, userCapRoomAfter }) : null,
+  };
+}
+
+export default deriveTradeContext;

--- a/src/ui/selectors/deriveTradeContext.test.js
+++ b/src/ui/selectors/deriveTradeContext.test.js
@@ -1,0 +1,370 @@
+import { describe, it, expect } from 'vitest';
+import {
+  deriveTradeContext,
+  TRADE_BALANCE,
+  MOTIVATION_CODES,
+} from './deriveTradeContext.js';
+
+// ── Builders ──────────────────────────────────────────────────────────────────
+
+function makePlayer(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Test Player',
+    pos: 'WR',
+    age: 27,
+    ovr: 74,
+    contract: { baseAnnual: 6 },
+    ...overrides,
+  };
+}
+
+function makeTeam(overrides = {}) {
+  return {
+    id: 10,
+    name: 'Test Team',
+    abbr: 'TT',
+    capRoom: 20,
+    frontOffice: { persona: 'PLAYER_LOYALIST' },
+    ...overrides,
+  };
+}
+
+function makePick(overrides = {}) {
+  return { id: 'pk1', round: 1, season: 2027, ...overrides };
+}
+
+/** A balanced two-player swap with no motivation triggers. */
+function baseInput(overrides = {}) {
+  return {
+    userGivesPlayers: [makePlayer({ id: 1, pos: 'WR', age: 27, ovr: 74, contract: { baseAnnual: 6 } })],
+    userGetsPlayers: [makePlayer({ id: 2, pos: 'RB', age: 27, ovr: 74, contract: { baseAnnual: 6 } })],
+    userGivesPicks: [],
+    userGetsPicks: [],
+    userOfferValue: 1000,
+    otherOfferValue: 1000,
+    otherTeam: makeTeam(),
+    otherTeamNeeds: [],
+    userCapRoomBefore: 20,
+    userCapRoomAfter: 20,
+    ...overrides,
+  };
+}
+
+// ── Determinism ───────────────────────────────────────────────────────────────
+
+describe('deriveTradeContext — determinism', () => {
+  it('returns identical output for identical inputs', () => {
+    const input = baseInput({
+      otherTeamNeeds: ['WR'],
+      otherTeam: makeTeam({ frontOffice: { persona: 'WIN_NOW' } }),
+      userGivesPlayers: [makePlayer({ ovr: 84 })],
+    });
+    const a = deriveTradeContext(input);
+    const b = deriveTradeContext(input);
+    expect(a).toEqual(b);
+  });
+});
+
+// ── Immutability (required guardrail) ─────────────────────────────────────────
+
+describe('deriveTradeContext — immutability', () => {
+  it('does not mutate any input', () => {
+    const input = baseInput({
+      otherTeamNeeds: ['WR', 'QB'],
+      userGivesPicks: [makePick()],
+      userGetsPicks: [makePick({ id: 'pk2', round: 3 })],
+      otherTeam: makeTeam({ frontOffice: { persona: 'CAP_HOARDER' } }),
+    });
+    const before = structuredClone(input);
+    deriveTradeContext(input);
+    expect(input).toEqual(before);
+  });
+});
+
+// ── Empty / unknown states ────────────────────────────────────────────────────
+
+describe('deriveTradeContext — empty and unknown states', () => {
+  it('returns UNKNOWN with no signals for an empty trade', () => {
+    const ctx = deriveTradeContext({});
+    expect(ctx.userBalance).toBe(TRADE_BALANCE.UNKNOWN);
+    expect(ctx.otherTeamMotivation).toEqual([]);
+    expect(ctx.motivationLabels).toEqual([]);
+    expect(ctx.capNote).toBeNull();
+  });
+
+  it('returns UNKNOWN when no arguments are provided at all', () => {
+    const ctx = deriveTradeContext();
+    expect(ctx.userBalance).toBe(TRADE_BALANCE.UNKNOWN);
+    expect(typeof ctx.userBalanceLabel).toBe('string');
+    expect(ctx.userBalanceLabel.length).toBeGreaterThan(0);
+  });
+
+  it('returns UNKNOWN when assets exist but values are missing', () => {
+    const ctx = deriveTradeContext(baseInput({
+      userOfferValue: undefined,
+      otherOfferValue: undefined,
+    }));
+    expect(ctx.userBalance).toBe(TRADE_BALANCE.UNKNOWN);
+  });
+});
+
+// ── Balance classification ────────────────────────────────────────────────────
+
+describe('deriveTradeContext — user balance', () => {
+  it('reads EVEN inside the ±15% band', () => {
+    const ctx = deriveTradeContext(baseInput({ userOfferValue: 1000, otherOfferValue: 1100 }));
+    expect(ctx.userBalance).toBe(TRADE_BALANCE.EVEN);
+  });
+
+  it('reads FAVORABLE when the user gets meaningfully more', () => {
+    const ctx = deriveTradeContext(baseInput({ userOfferValue: 500, otherOfferValue: 1500 }));
+    expect(ctx.userBalance).toBe(TRADE_BALANCE.FAVORABLE);
+  });
+
+  it('reads UNFAVORABLE when the user gives meaningfully more', () => {
+    const ctx = deriveTradeContext(baseInput({ userOfferValue: 1500, otherOfferValue: 500 }));
+    expect(ctx.userBalance).toBe(TRADE_BALANCE.UNFAVORABLE);
+  });
+
+  it('always returns a non-empty userBalanceLabel', () => {
+    const inputs = [
+      deriveTradeContext(),
+      deriveTradeContext(baseInput()),
+      deriveTradeContext(baseInput({ userOfferValue: 0, otherOfferValue: 0 })),
+      deriveTradeContext(baseInput({ userOfferValue: 9999, otherOfferValue: 1 })),
+    ];
+    for (const ctx of inputs) {
+      expect(typeof ctx.userBalanceLabel).toBe('string');
+      expect(ctx.userBalanceLabel.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── Motivation signals: fires / does not fire ─────────────────────────────────
+
+describe('deriveTradeContext — NEEDS_POSITION', () => {
+  it('fires when a player they receive matches a visible need', () => {
+    const ctx = deriveTradeContext(baseInput({ otherTeamNeeds: ['WR'] }));
+    expect(ctx.otherTeamMotivation).toContain(MOTIVATION_CODES.NEEDS_POSITION);
+    expect(ctx.motivationLabels.some((l) => l.includes('help at WR'))).toBe(true);
+  });
+
+  it('does not fire when no received player matches a need', () => {
+    const ctx = deriveTradeContext(baseInput({ otherTeamNeeds: ['QB'] }));
+    expect(ctx.otherTeamMotivation).not.toContain(MOTIVATION_CODES.NEEDS_POSITION);
+  });
+});
+
+describe('deriveTradeContext — WIN_NOW_ACQUIRE', () => {
+  it('fires for a WIN_NOW front office receiving a high-OVR player', () => {
+    const ctx = deriveTradeContext(baseInput({
+      otherTeam: makeTeam({ frontOffice: { persona: 'WIN_NOW' } }),
+      userGivesPlayers: [makePlayer({ ovr: 85 })],
+    }));
+    expect(ctx.otherTeamMotivation).toContain(MOTIVATION_CODES.WIN_NOW_ACQUIRE);
+  });
+
+  it('does not fire for a WIN_NOW team receiving only depth players', () => {
+    const ctx = deriveTradeContext(baseInput({
+      otherTeam: makeTeam({ frontOffice: { persona: 'WIN_NOW' } }),
+      userGivesPlayers: [makePlayer({ ovr: 70 })],
+    }));
+    expect(ctx.otherTeamMotivation).not.toContain(MOTIVATION_CODES.WIN_NOW_ACQUIRE);
+  });
+
+  it('does not fire for a non-WIN_NOW persona receiving a star', () => {
+    const ctx = deriveTradeContext(baseInput({
+      otherTeam: makeTeam({ frontOffice: { persona: 'PATIENT_BUILDER' } }),
+      userGivesPlayers: [makePlayer({ ovr: 90 })],
+    }));
+    expect(ctx.otherTeamMotivation).not.toContain(MOTIVATION_CODES.WIN_NOW_ACQUIRE);
+  });
+});
+
+describe('deriveTradeContext — REBUILDER_SHED', () => {
+  it('fires when a PATIENT_BUILDER sends a high-OVR veteran', () => {
+    const ctx = deriveTradeContext(baseInput({
+      otherTeam: makeTeam({ frontOffice: { persona: 'PATIENT_BUILDER' } }),
+      userGetsPlayers: [makePlayer({ ovr: 84, age: 31 })],
+    }));
+    expect(ctx.otherTeamMotivation).toContain(MOTIVATION_CODES.REBUILDER_SHED);
+  });
+
+  it('fires when a CAP_HOARDER sends a high-OVR veteran', () => {
+    const ctx = deriveTradeContext(baseInput({
+      otherTeam: makeTeam({ frontOffice: { persona: 'CAP_HOARDER' } }),
+      userGetsPlayers: [makePlayer({ ovr: 84, age: 31 })],
+    }));
+    expect(ctx.otherTeamMotivation).toContain(MOTIVATION_CODES.REBUILDER_SHED);
+  });
+
+  it('does not fire when the veteran sent is not star caliber', () => {
+    const ctx = deriveTradeContext(baseInput({
+      otherTeam: makeTeam({ frontOffice: { persona: 'PATIENT_BUILDER' } }),
+      userGetsPlayers: [makePlayer({ ovr: 72, age: 32 })],
+    }));
+    expect(ctx.otherTeamMotivation).not.toContain(MOTIVATION_CODES.REBUILDER_SHED);
+  });
+
+  it('does not fire when the star sent is young', () => {
+    const ctx = deriveTradeContext(baseInput({
+      otherTeam: makeTeam({ frontOffice: { persona: 'PATIENT_BUILDER' } }),
+      userGetsPlayers: [makePlayer({ ovr: 85, age: 24 })],
+    }));
+    expect(ctx.otherTeamMotivation).not.toContain(MOTIVATION_CODES.REBUILDER_SHED);
+  });
+});
+
+describe('deriveTradeContext — SHEDDING_CAP', () => {
+  it('fires when they send meaningfully more salary than they receive', () => {
+    const ctx = deriveTradeContext(baseInput({
+      userGetsPlayers: [makePlayer({ id: 2, contract: { baseAnnual: 14 } })],
+      userGivesPlayers: [makePlayer({ id: 1, contract: { baseAnnual: 4 } })],
+    }));
+    expect(ctx.otherTeamMotivation).toContain(MOTIVATION_CODES.SHEDDING_CAP);
+  });
+
+  it('does not fire on a near-even salary swap', () => {
+    const ctx = deriveTradeContext(baseInput({
+      userGetsPlayers: [makePlayer({ id: 2, contract: { baseAnnual: 7 } })],
+      userGivesPlayers: [makePlayer({ id: 1, contract: { baseAnnual: 6 } })],
+    }));
+    expect(ctx.otherTeamMotivation).not.toContain(MOTIVATION_CODES.SHEDDING_CAP);
+  });
+});
+
+describe('deriveTradeContext — PICK_ACCUMULATION', () => {
+  it('fires when they send players and receive picks', () => {
+    const ctx = deriveTradeContext(baseInput({
+      userGivesPlayers: [],
+      userGivesPicks: [makePick()],
+      userGetsPlayers: [makePlayer({ id: 2 })],
+    }));
+    expect(ctx.otherTeamMotivation).toContain(MOTIVATION_CODES.PICK_ACCUMULATION);
+  });
+
+  it('does not fire when no picks head their way', () => {
+    const ctx = deriveTradeContext(baseInput());
+    expect(ctx.otherTeamMotivation).not.toContain(MOTIVATION_CODES.PICK_ACCUMULATION);
+  });
+});
+
+describe('deriveTradeContext — ACQUIRING_YOUTH', () => {
+  it('fires when the players they receive are meaningfully younger', () => {
+    const ctx = deriveTradeContext(baseInput({
+      userGivesPlayers: [makePlayer({ id: 1, age: 23 })],
+      userGetsPlayers: [makePlayer({ id: 2, age: 31 })],
+    }));
+    expect(ctx.otherTeamMotivation).toContain(MOTIVATION_CODES.ACQUIRING_YOUTH);
+  });
+
+  it('does not fire on a same-age swap', () => {
+    const ctx = deriveTradeContext(baseInput({
+      userGivesPlayers: [makePlayer({ id: 1, age: 27 })],
+      userGetsPlayers: [makePlayer({ id: 2, age: 27 })],
+    }));
+    expect(ctx.otherTeamMotivation).not.toContain(MOTIVATION_CODES.ACQUIRING_YOUTH);
+  });
+
+  it('does not fire when ages are missing (skips silently)', () => {
+    const ctx = deriveTradeContext(baseInput({
+      userGivesPlayers: [makePlayer({ id: 1, age: undefined })],
+      userGetsPlayers: [makePlayer({ id: 2, age: 33 })],
+    }));
+    expect(ctx.otherTeamMotivation).not.toContain(MOTIVATION_CODES.ACQUIRING_YOUTH);
+  });
+});
+
+// ── Cap note ──────────────────────────────────────────────────────────────────
+
+describe('deriveTradeContext — capNote', () => {
+  it('flags cap pressure when the trade worsens an already-tight cap', () => {
+    const ctx = deriveTradeContext(baseInput({ userCapRoomBefore: 6, userCapRoomAfter: 2 }));
+    expect(ctx.capNote).toBe('This tightens your cap picture.');
+  });
+
+  it('flags cap relief when the trade meaningfully improves cap room', () => {
+    const ctx = deriveTradeContext(baseInput({ userCapRoomBefore: 10, userCapRoomAfter: 18 }));
+    expect(ctx.capNote).toBe('This creates cap flexibility.');
+  });
+
+  it('stays null for a small cap change with room to spare', () => {
+    const ctx = deriveTradeContext(baseInput({ userCapRoomBefore: 40, userCapRoomAfter: 39 }));
+    expect(ctx.capNote).toBeNull();
+  });
+
+  it('stays null when cap figures are missing', () => {
+    const ctx = deriveTradeContext(baseInput({
+      userCapRoomBefore: undefined,
+      userCapRoomAfter: undefined,
+    }));
+    expect(ctx.capNote).toBeNull();
+  });
+});
+
+// ── Label cap + label hygiene ─────────────────────────────────────────────────
+
+describe('deriveTradeContext — label constraints', () => {
+  it('caps motivationLabels at 2 even when many signals fire', () => {
+    const ctx = deriveTradeContext(baseInput({
+      otherTeam: makeTeam({ frontOffice: { persona: 'WIN_NOW' } }),
+      otherTeamNeeds: ['WR'],
+      userGivesPlayers: [makePlayer({ id: 1, pos: 'WR', ovr: 85, age: 23, contract: { baseAnnual: 3 } })],
+      userGetsPlayers: [makePlayer({ id: 2, pos: 'RB', ovr: 76, age: 32, contract: { baseAnnual: 15 } })],
+      userGivesPicks: [makePick()],
+    }));
+    expect(ctx.otherTeamMotivation.length).toBeGreaterThan(2);
+    expect(ctx.motivationLabels.length).toBe(2);
+  });
+
+  it('never leaks raw signal codes into user-facing labels', () => {
+    const ctx = deriveTradeContext(baseInput({
+      otherTeam: makeTeam({ frontOffice: { persona: 'WIN_NOW' } }),
+      otherTeamNeeds: ['WR'],
+      userGivesPlayers: [makePlayer({ id: 1, pos: 'WR', ovr: 85, age: 23, contract: { baseAnnual: 3 } })],
+      userGetsPlayers: [makePlayer({ id: 2, pos: 'RB', ovr: 80, age: 32, contract: { baseAnnual: 15 } })],
+      userGivesPicks: [makePick()],
+      userCapRoomBefore: 6,
+      userCapRoomAfter: 2,
+    }));
+    const userFacing = [ctx.userBalanceLabel, ...ctx.motivationLabels, ctx.capNote ?? ''].join(' ');
+    for (const code of Object.values(MOTIVATION_CODES)) {
+      expect(userFacing).not.toContain(code);
+    }
+    for (const code of Object.values(TRADE_BALANCE)) {
+      expect(userFacing).not.toContain(code);
+    }
+  });
+});
+
+// ── Old / incomplete save shapes ──────────────────────────────────────────────
+
+describe('deriveTradeContext — resilience to missing fields', () => {
+  it('does not crash on players with no contract, pos, ovr, or age', () => {
+    const bare = { id: 99, name: 'Bare Player' };
+    expect(() => deriveTradeContext({
+      userGivesPlayers: [bare, null, undefined],
+      userGetsPlayers: [{}],
+      userGivesPicks: [null],
+      userGetsPicks: [{}],
+      otherTeam: {},
+      otherTeamNeeds: null,
+    })).not.toThrow();
+  });
+
+  it('does not crash when otherTeam has no frontOffice', () => {
+    const ctx = deriveTradeContext(baseInput({ otherTeam: { id: 5 } }));
+    expect(ctx.otherTeamMotivation).not.toContain(MOTIVATION_CODES.WIN_NOW_ACQUIRE);
+    expect(ctx.otherTeamMotivation).not.toContain(MOTIVATION_CODES.REBUILDER_SHED);
+  });
+
+  it('does not crash on non-array asset inputs', () => {
+    expect(() => deriveTradeContext({
+      userGivesPlayers: 'nope',
+      userGetsPlayers: 42,
+      userGivesPicks: {},
+      userGetsPicks: null,
+    })).not.toThrow();
+  });
+});


### PR DESCRIPTION
Add a render-time readability layer to the trade builder so users can see
what an offer means without touching any trade behavior:

- deriveTradeContext (src/ui/selectors): pure, deterministic, mutation-free
  selector that interprets numbers the screen already displays into a
  user-balance read (FAVORABLE/EVEN/UNFAVORABLE/UNKNOWN), up to 2 cautious
  other-team motivation labels (needs match, win-now acquire, rebuilder
  shed, cap shed, pick accumulation, youth acquisition), and an optional
  user-side cap note. Guardrail-commented as display-only; separate from
  deriveNegotiationContext, which stays contract/FA/re-sign only.
- TradeValueSummary (components/common): presentational "Trade Breakdown"
  card with neutral empty/limited states; never exposes raw signal codes.
- TradeCenter: derive context in a useMemo and render the card in the
  offer review area, after the existing ValueBar/CapImpactSummary block.
- Tests: 42 new unit + integration tests covering determinism,
  immutability (structuredClone), per-signal fire/no-fire, label cap,
  old-save resilience, no raw codes in DOM, unchanged submit behavior,
  and no duplicate breakdown displays.

No changes to trade valuation, acceptance, AI behavior, cap legality,
simulation, contracts, or save shape.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FUCHuqUTyTofcrJHCoFLzD