### PR TITLE
Fix trade breakdown styling guardrails

### DIFF
--- a/src/ui/components/__tests__/TradeBreakdownIntegration.test.jsx
+++ b/src/ui/components/__tests__/TradeBreakdownIntegration.test.jsx
@@ -132,6 +132,27 @@ describe('TradeCenter — Trade Breakdown integration', () => {
   });
 });
 
+describe('TradeValueSummary — class-based styling', () => {
+  afterEach(cleanup);
+
+  it('renders with Trade Breakdown classes instead of inline raw style values', () => {
+    const context = {
+      userBalance: TRADE_BALANCE.FAVORABLE,
+      userBalanceLabel: 'This package leans in your favor.',
+      motivationLabels: ['This fits a win-now roster push.'],
+      capNote: 'Your cap room tightens after this deal.',
+    };
+    const { getByTestId, getByText } = render(<TradeValueSummary context={context} hasSelection />);
+    const card = getByTestId('trade-value-summary');
+
+    expect(card.classList.contains('trade-value-summary')).toBe(true);
+    expect(card.querySelector('.trade-value-summary__eyebrow')).toBeTruthy();
+    expect(card.querySelector('.trade-value-summary__value-row--favorable')).toBeTruthy();
+    expect(getByText('Value read').classList.contains('trade-value-summary__pill')).toBe(true);
+    expect(card.querySelectorAll('[style]')).toHaveLength(0);
+  });
+});
+
 describe('TradeValueSummary — unavailable-context state', () => {
   afterEach(cleanup);
 

--- a/src/ui/components/common/TradeValueSummary.jsx
+++ b/src/ui/components/common/TradeValueSummary.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { TRADE_BALANCE } from '../../selectors/deriveTradeContext.js';
 
-const BALANCE_TONE = Object.freeze({
-  [TRADE_BALANCE.FAVORABLE]: 'var(--success)',
-  [TRADE_BALANCE.UNFAVORABLE]: 'var(--warning)',
-  [TRADE_BALANCE.EVEN]: 'var(--text-muted)',
-  [TRADE_BALANCE.UNKNOWN]: 'var(--text-muted)',
+const BALANCE_TONE_CLASS = Object.freeze({
+  [TRADE_BALANCE.FAVORABLE]: 'trade-value-summary__value-row--favorable',
+  [TRADE_BALANCE.UNFAVORABLE]: 'trade-value-summary__value-row--unfavorable',
+  [TRADE_BALANCE.EVEN]: 'trade-value-summary__value-row--even',
+  [TRADE_BALANCE.UNKNOWN]: 'trade-value-summary__value-row--unknown',
 });
 
 const EMPTY_COPY = 'Add players or picks to preview trade context.';
@@ -36,64 +36,41 @@ export default function TradeValueSummary({
   const capNote = context?.capNote ?? null;
   const limited =
     balance === TRADE_BALANCE.UNKNOWN && motivationLabels.length === 0 && !capNote;
-  const tone = BALANCE_TONE[balance] ?? 'var(--text-muted)';
+  const toneClass = BALANCE_TONE_CLASS[balance] ?? BALANCE_TONE_CLASS[TRADE_BALANCE.UNKNOWN];
 
   return (
     <div
-      className="card"
+      className="card trade-value-summary"
       data-testid={testId}
       data-balance={balance}
-      style={{
-        padding: 'var(--space-3)',
-        marginBottom: 'var(--space-3)',
-        display: 'grid',
-        gap: 6,
-      }}
     >
-      <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '.08em', color: 'var(--text-subtle)', fontWeight: 700 }}>
-        Trade Breakdown
-      </div>
+      <div className="trade-value-summary__eyebrow">Trade Breakdown</div>
       {!hasSelection ? (
-        <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{EMPTY_COPY}</div>
+        <div className="trade-value-summary__copy">{EMPTY_COPY}</div>
       ) : limited ? (
-        <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{LIMITED_COPY}</div>
+        <div className="trade-value-summary__copy">{LIMITED_COPY}</div>
       ) : (
         <>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-            <span
-              style={{
-                display: 'inline-block',
-                fontSize: 10,
-                fontWeight: 700,
-                color: tone,
-                border: `1px solid ${tone}`,
-                background: `${tone}14`,
-                borderRadius: 999,
-                padding: '0 6px',
-                lineHeight: 1.6,
-                whiteSpace: 'nowrap',
-              }}
-            >
-              Value read
-            </span>
-            <span style={{ fontSize: 'var(--text-xs)', fontWeight: 700, color: tone }}>
+          <div className={`trade-value-summary__value-row ${toneClass}`}>
+            <span className="trade-value-summary__pill">Value read</span>
+            <span className="trade-value-summary__balance-label">
               {context?.userBalanceLabel}
             </span>
           </div>
           {motivationLabels.length > 0 ? (
-            <div style={{ display: 'grid', gap: 2 }}>
-              <span style={{ fontSize: 'var(--text-xs)', color: 'var(--text-subtle)', fontWeight: 700 }}>
+            <div className="trade-value-summary__interest">
+              <span className="trade-value-summary__interest-label">
                 Their interest:
               </span>
               {motivationLabels.map((label) => (
-                <div key={label} style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>
+                <div key={label} className="trade-value-summary__copy">
                   {label}
                 </div>
               ))}
             </div>
           ) : null}
           {capNote ? (
-            <div style={{ fontSize: 'var(--text-xs)', color: 'var(--text-muted)' }}>{capNote}</div>
+            <div className="trade-value-summary__copy">{capNote}</div>
           ) : null}
         </>
       )}

--- a/src/ui/selectors/deriveTradeContext.js
+++ b/src/ui/selectors/deriveTradeContext.js
@@ -65,7 +65,7 @@ export const MOTIVATION_CODES = Object.freeze({
 // Front-office persona keys (mirrors core/ai/frontOfficePersonaEngine.js,
 // read-only — mirrored rather than imported so this file never pulls in
 // engine code).
-const PERSONA = Object.freeze({
+export const TRADE_CONTEXT_PERSONAS = Object.freeze({
   WIN_NOW: 'WIN_NOW',
   PATIENT_BUILDER: 'PATIENT_BUILDER',
   CAP_HOARDER: 'CAP_HOARDER',
@@ -175,7 +175,7 @@ function collectMotivations({
   }
 
   // WIN_NOW_ACQUIRE — win-now front office receiving a high-OVR player.
-  if (persona === PERSONA.WIN_NOW && theyGetPlayers.some((p) => num(p?.ovr) >= STAR_OVR)) {
+  if (persona === TRADE_CONTEXT_PERSONAS.WIN_NOW && theyGetPlayers.some((p) => num(p?.ovr) >= STAR_OVR)) {
     fired.push({
       code: MOTIVATION_CODES.WIN_NOW_ACQUIRE,
       label: 'This fits a win-now roster push.',
@@ -184,7 +184,7 @@ function collectMotivations({
 
   // REBUILDER_SHED — patient/cap-focused front office sending a high-OVR veteran.
   if (
-    (persona === PERSONA.PATIENT_BUILDER || persona === PERSONA.CAP_HOARDER) &&
+    (persona === TRADE_CONTEXT_PERSONAS.PATIENT_BUILDER || persona === TRADE_CONTEXT_PERSONAS.CAP_HOARDER) &&
     theySendPlayers.some((p) => num(p?.ovr) >= STAR_OVR && num(p?.age) >= VETERAN_AGE)
   ) {
     fired.push({

--- a/src/ui/selectors/deriveTradeContext.test.js
+++ b/src/ui/selectors/deriveTradeContext.test.js
@@ -1,9 +1,20 @@
 import { describe, it, expect } from 'vitest';
+import { FRONT_OFFICE_PERSONAS } from '../../core/ai/frontOfficePersonaEngine.js';
 import {
   deriveTradeContext,
   TRADE_BALANCE,
   MOTIVATION_CODES,
+  TRADE_CONTEXT_PERSONAS,
 } from './deriveTradeContext.js';
+
+
+describe('deriveTradeContext — front-office persona mirror', () => {
+  it('trade context persona mirror matches known front office personas', () => {
+    for (const key of Object.values(TRADE_CONTEXT_PERSONAS)) {
+      expect(Object.values(FRONT_OFFICE_PERSONAS)).toContain(key);
+    }
+  });
+});
 
 // ── Builders ──────────────────────────────────────────────────────────────────
 

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -1383,3 +1383,65 @@ details[open] .app-hq-background-section__summary span { transform: rotate(180de
   color: var(--text-muted);
   margin-top: var(--space-1);
 }
+
+/* Trade Breakdown card — class-based styling mirrors PageOrientationHeader pattern. */
+.trade-value-summary {
+  display: grid;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+  padding: var(--space-3);
+}
+.trade-value-summary__eyebrow {
+  color: var(--text-subtle);
+  font-size: var(--text-xs);
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+.trade-value-summary__copy {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+.trade-value-summary__value-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  --trade-value-summary-tone: var(--text-muted);
+}
+.trade-value-summary__value-row--favorable {
+  --trade-value-summary-tone: var(--success);
+}
+.trade-value-summary__value-row--unfavorable {
+  --trade-value-summary-tone: var(--warning);
+}
+.trade-value-summary__value-row--even,
+.trade-value-summary__value-row--unknown {
+  --trade-value-summary-tone: var(--text-muted);
+}
+.trade-value-summary__pill {
+  background: color-mix(in srgb, var(--trade-value-summary-tone) 8%, transparent);
+  border: 1px solid var(--trade-value-summary-tone);
+  border-radius: var(--radius-pill);
+  color: var(--trade-value-summary-tone);
+  display: inline-block;
+  font-size: var(--text-xs);
+  font-weight: 700;
+  line-height: 1.6;
+  padding: 0 var(--space-2);
+  white-space: nowrap;
+}
+.trade-value-summary__balance-label {
+  color: var(--trade-value-summary-tone);
+  font-size: var(--text-xs);
+  font-weight: 700;
+}
+.trade-value-summary__interest {
+  display: grid;
+  gap: var(--space-1);
+}
+.trade-value-summary__interest-label {
+  color: var(--text-subtle);
+  font-size: var(--text-xs);
+  font-weight: 700;
+}


### PR DESCRIPTION
### Motivation
- Remove invalid/fragile inline style usage and invalid token guessing in the Trade Breakdown card to match the project design-system and the class-based pattern used elsewhere (e.g., PageOrientationHeader). 
- Enforce a testable guard so the local persona mirror in `deriveTradeContext` cannot silently drift from the canonical engine constants. 
- Keep this as a focused cleanup: no change to trade valuation, acceptance, AI, cap math, simulation, save shape, or contract/negotiation logic. 

### Description
- Reworked `src/ui/components/common/TradeValueSummary.jsx` to remove inline/raw numeric style values and CSS variable strings and render with a class-based structure (`trade-value-summary` and related BEM classes) that uses existing tokens. 
- Added class rules to `src/ui/styles/components.css` for `.trade-value-summary*` using verified tokens such as `--text-xs`, `--text-muted`, `--text-subtle`, `--success`, `--warning`, `--space-*`, and `--radius-pill` instead of inline `gap`, `fontSize`, or `padding` numbers. 
- Replaced balance-to-color inline token mapping with a balance-to-class mapping (`BALANCE_TONE_CLASS`) so color usage happens in CSS (e.g., `.trade-value-summary__value-row--favorable` sets `--trade-value-summary-tone: var(--success)`). 
- Exported the mirrored persona map from `src/ui/selectors/deriveTradeContext.js` as `TRADE_CONTEXT_PERSONAS` (no change to selector semantics), and added a unit test that imports the canonical `FRONT_OFFICE_PERSONAS` and asserts the mirrored values remain present. 
- Added a component test that asserts the Trade Breakdown renders class-based markup and contains no inline `style` attributes. 

### Testing
- Ran the targeted unit tests for the selector and component: `npx vitest run src/ui/selectors/deriveTradeContext.test.js src/ui/components/__tests__/TradeBreakdownIntegration.test.jsx`, and they passed. 
- Ran the full unit test suite: `npm run test:unit`, and the run completed successfully (all tests passed). 
- Built a production bundle with `npm run build`, and the build completed successfully (warnings about chunk size unchanged and expected). 
- Note: a direct `node --check` on `.jsx` files is not supported in this environment (JSX extension check skipped), but `node --check` was used on modified `.js` support files where applicable and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45dbf98d30832dba5f1a8959d92dbc)