### PR TITLE
Improve weekly prep scout report density

### DIFF
--- a/src/ui/components/WeeklyPrepScreen.jsx
+++ b/src/ui/components/WeeklyPrepScreen.jsx
@@ -301,6 +301,13 @@ export default function WeeklyPrepScreen({ league, onNavigate, onOpenBoxScore })
 
   const effectiveRemaining = Object.values(effectiveCompletion).filter((done) => !done).length;
   const effectiveScore = Math.round(((4 - effectiveRemaining) / 4) * 100);
+  const primaryAction = model.priorityActions?.[0];
+  const scoutSummaryItems = [
+    { label: 'Opponent', value: `${prep?.nextGame?.isHome ? 'vs' : '@'} ${prep?.opponent?.name ?? model.opponentAbbr}` },
+    { label: 'Matchup context', value: model.matchupHeadline },
+    { label: 'Primary action', value: primaryAction ? `${primaryAction.title}: ${primaryAction.reason}` : model.keyRiskLabel },
+    { label: 'Game-plan key', value: prep?.keyMatchupNote ?? model.keyRiskLabel },
+  ];
 
   // Readiness tone/status derive from liveSummary so they update on every plan change.
   const liveReadinessTone = liveSummary.severity === 'major_risk' ? 'danger' : liveSummary.severity === 'minor_risk' ? 'warning' : 'success';
@@ -363,24 +370,16 @@ export default function WeeklyPrepScreen({ league, onNavigate, onOpenBoxScore })
         </div>
       </SectionCard>
 
-      <SectionCard title="Readiness Command" subtitle="Confirm prep quality before returning to HQ.">
-        <div className="weekly-prep-command-row">
-          <TonePill tone={liveReadinessTone} label={`${effectiveScore}% ready`} />
-          <TonePill tone={effectiveRemaining === 0 ? 'success' : 'warning'} label={`${4 - effectiveRemaining}/4 complete`} />
-          <TonePill tone={effectiveRemaining === 0 ? 'success' : 'warning'} label={effectiveRemaining === 0 ? 'Ready to Advance' : 'Needs Attention'} />
+      <SectionCard title="Scout Report Summary" actions={<TonePill tone="info" label="Top read" />}>
+        <div className="weekly-prep-scout-summary" data-testid="weekly-prep-scout-summary">
+          {scoutSummaryItems.map((item) => (
+            <div key={item.label} className="weekly-prep-compact-row">
+              <span>{item.label}</span>
+              <strong>{item.value}</strong>
+            </div>
+          ))}
         </div>
-        <p className="weekly-prep-caption">{model.keyRiskLabel}</p>
       </SectionCard>
-
-      <GamePlanControlCenter
-        key={`${league?.seasonId}:${league?.week}`}
-        prep={prep}
-        league={league}
-        plan={plan}
-        liveSummary={liveSummary}
-        onPlanChange={handlePlanChange}
-        onPlanReviewed={() => setLocalPlanReviewed(true)}
-      />
 
       <SectionCard title="Priority Actions" subtitle="Complete these before sim day.">
         <div className="weekly-prep-action-grid">
@@ -400,27 +399,49 @@ export default function WeeklyPrepScreen({ league, onNavigate, onOpenBoxScore })
         </div>
       </SectionCard>
 
-      <SectionCard title="Matchup Intel" subtitle="Strengths, weaknesses, and pressure points.">
-        <div className="weekly-prep-intel-grid">
-          <div>
-            <div className="weekly-prep-intel-head">Strengths</div>
-            <ul>
-              {(prep.opponentStrengths.length ? prep.opponentStrengths : ['No clear dominant opponent edge identified yet.']).map((item) => <li key={item}>{item}</li>)}
-            </ul>
-          </div>
-          <div>
-            <div className="weekly-prep-intel-head">Exploitable weaknesses</div>
-            <ul>
-              {(prep.opponentWeaknesses.length ? prep.opponentWeaknesses : ['No obvious weakness — execution will decide this one.']).map((item) => <li key={item}>{item}</li>)}
-            </ul>
-          </div>
-          <div>
-            <div className="weekly-prep-intel-head">Pressure points</div>
-            <ul>
-              {(prep.pressurePoints.length ? prep.pressurePoints : ['No major pressure point flagged.']).map((item) => <li key={item}>{item}</li>)}
-            </ul>
-          </div>
+      <SectionCard title="Readiness Command" subtitle="Confirm prep quality before returning to HQ.">
+        <div className="weekly-prep-command-row">
+          <TonePill tone={liveReadinessTone} label={`${effectiveScore}% ready`} />
+          <TonePill tone={effectiveRemaining === 0 ? 'success' : 'warning'} label={`${4 - effectiveRemaining}/4 complete`} />
+          <TonePill tone={effectiveRemaining === 0 ? 'success' : 'warning'} label={effectiveRemaining === 0 ? 'Ready to Advance' : 'Needs Attention'} />
         </div>
+        <p className="weekly-prep-caption">{model.keyRiskLabel}</p>
+      </SectionCard>
+
+      <GamePlanControlCenter
+        key={`${league?.seasonId}:${league?.week}`}
+        prep={prep}
+        league={league}
+        plan={plan}
+        liveSummary={liveSummary}
+        onPlanChange={handlePlanChange}
+        onPlanReviewed={() => setLocalPlanReviewed(true)}
+      />
+
+      <SectionCard title="Matchup Intel Details" subtitle="Strengths, weaknesses, and pressure points.">
+        <details className="weekly-prep-details" data-testid="weekly-prep-matchup-details">
+          <summary>Open detailed scout report</summary>
+          <div className="weekly-prep-intel-grid">
+            <div>
+              <div className="weekly-prep-intel-head">Strengths</div>
+              <ul>
+                {(prep.opponentStrengths.length ? prep.opponentStrengths : ['No clear dominant opponent edge identified yet.']).map((item) => <li key={item}>{item}</li>)}
+              </ul>
+            </div>
+            <div>
+              <div className="weekly-prep-intel-head">Exploitable weaknesses</div>
+              <ul>
+                {(prep.opponentWeaknesses.length ? prep.opponentWeaknesses : ['No obvious weakness — execution will decide this one.']).map((item) => <li key={item}>{item}</li>)}
+              </ul>
+            </div>
+            <div>
+              <div className="weekly-prep-intel-head">Pressure points</div>
+              <ul>
+                {(prep.pressurePoints.length ? prep.pressurePoints : ['No major pressure point flagged.']).map((item) => <li key={item}>{item}</li>)}
+              </ul>
+            </div>
+          </div>
+        </details>
       </SectionCard>
 
       <SectionCard title="Active Effects" subtitle="Live plan impact for this week.">

--- a/src/ui/components/__tests__/WeeklyPrepScreen.test.jsx
+++ b/src/ui/components/__tests__/WeeklyPrepScreen.test.jsx
@@ -51,7 +51,8 @@ describe('WeeklyPrepScreen', () => {
     expect(screen.getByText(/Weekly Prep War Room/i)).toBeTruthy();
     expect(screen.getByText(/Readiness Command/i)).toBeTruthy();
     expect(screen.getByText(/Priority Actions/i)).toBeTruthy();
-    expect(screen.getByRole('heading', { name: /Matchup Intel/i })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /Scout Report Summary/i })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: /Matchup Intel Details/i })).toBeTruthy();
     expect(screen.getByText(/Prep Checklist/i)).toBeTruthy();
     expect(screen.getByText(/Opponent (scouted|pending)/i)).toBeTruthy();
   });
@@ -75,6 +76,27 @@ describe('WeeklyPrepScreen', () => {
       />,
     );
     expect(screen.getByText(/Weekly prep unavailable/i)).toBeTruthy();
+  });
+
+  it('puts mobile-critical scout report copy before detailed breakdowns', () => {
+    const { container } = render(<WeeklyPrepScreen league={league} onNavigate={vi.fn()} />);
+    const text = container.textContent;
+
+    expect(screen.getByTestId('weekly-prep-scout-summary').textContent).toMatch(/Opponent.*Lions|Opponent.*DET/i);
+    expect(screen.getByTestId('weekly-prep-scout-summary').textContent).toMatch(/Primary action/i);
+    expect(screen.getByText(/Open detailed scout report/i)).toBeTruthy();
+    expect(text.indexOf('Scout Report Summary')).toBeLessThan(text.indexOf('Priority Actions'));
+    expect(text.indexOf('Priority Actions')).toBeLessThan(text.indexOf('Readiness Command'));
+    expect(text.indexOf('Scout Report Summary')).toBeLessThan(text.indexOf('Matchup Intel Details'));
+  });
+
+  it('does not mutate league gameplay data while rendering the denser prep view', () => {
+    const immutableLeague = structuredClone(league);
+    const before = JSON.stringify(immutableLeague);
+
+    render(<WeeklyPrepScreen league={immutableLeague} onNavigate={vi.fn()} />);
+
+    expect(JSON.stringify(immutableLeague)).toBe(before);
   });
 });
 

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -720,6 +720,10 @@
 .weekly-prep-mini-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(180px, 100%), 1fr)); gap: 8px; font-size: var(--text-xs); }
 .weekly-prep-command-row { display: flex; gap: 8px; flex-wrap: wrap; }
 .weekly-prep-caption { margin: 0; font-size: var(--text-sm); color: var(--text-muted); }
+.weekly-prep-scout-summary { display: grid; gap: 6px; }
+.weekly-prep-compact-row { display: grid; grid-template-columns: minmax(96px, .45fr) 1fr; gap: 8px; align-items: start; border: 1px solid var(--hairline); border-radius: var(--radius-md); padding: 8px; font-size: var(--text-sm); background: color-mix(in srgb, var(--surface) 94%, black 6%); }
+.weekly-prep-compact-row span { color: var(--text-muted); font-size: var(--text-xs); text-transform: uppercase; letter-spacing: .04em; }
+.weekly-prep-compact-row strong { font-size: var(--text-sm); line-height: 1.35; }
 .weekly-prep-action-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(220px, 100%), 1fr)); gap: 8px; }
 .weekly-prep-action-card { border: 1px solid var(--hairline); border-radius: var(--radius-md); padding: 10px; display: grid; gap: 8px; background: color-mix(in srgb, var(--surface) 94%, black 6%); }
 .weekly-prep-action-head { display: flex; gap: 8px; justify-content: space-between; align-items: flex-start; }
@@ -731,8 +735,11 @@
 .weekly-prep-intel-grid li { font-size: var(--text-sm); }
 .weekly-prep-effects-grid { display: grid; gap: 6px; }
 .weekly-prep-effect-row { font-size: var(--text-sm); border: 1px solid var(--hairline); border-radius: var(--radius-md); padding: 8px; }
+.weekly-prep-details summary { cursor: pointer; font-size: var(--text-sm); font-weight: 700; color: var(--text); }
+.weekly-prep-details[open] summary { margin-bottom: var(--space-2); }
 
 @media (max-width: 480px) {
+  .weekly-prep-compact-row { grid-template-columns: 1fr; gap: 2px; }
   .weekly-prep-action-card .btn,
   .weekly-prep-nav-row .btn {
     min-height: 40px;


### PR DESCRIPTION
### Motivation
- Mobile users had to scroll past readiness controls and verbose matchup details to see the next opponent, matchup context, and the primary recommended action.
- The intent is to surface highest-priority pregame information early while preserving full scout detail and keeping all simulation/gameplay logic unchanged.

### Description
- Added a compact `Scout Report Summary` section near the top of `WeeklyPrepScreen` that shows Opponent, Matchup context, Primary action, and Game-plan key using existing design tokens and class-based CSS. (changes: `src/ui/components/WeeklyPrepScreen.jsx`, `src/ui/styles/screen-system.css`)
- Reordered content so `Priority Actions` appears earlier in the flow and moved verbose strengths/weaknesses/pressure-points into an expandable `Matchup Intel Details` `<details>` block to collapse secondary copy.
- Introduced CSS classes for `.weekly-prep-scout-summary`, `.weekly-prep-compact-row`, and `.weekly-prep-details` to implement the denser, mobile-friendly layout without introducing inline styles or new tokens.
- Added regression tests that assert mobile ordering, summary visibility, presence of the expandable detailed report, and that rendering does not mutate league gameplay data. (changes: `src/ui/components/__tests__/WeeklyPrepScreen.test.jsx`)

### Testing
- Ran the targeted unit test: `npm run test:unit -- WeeklyPrepScreen.test.jsx` and the test file passed (all tests in that file succeeded).
- Built the production bundle with `npm run build` and the build completed successfully (standard chunk-size warnings only).
- Ran the full unit suite: `npm run test:unit` and the full Vitest run passed (no failing tests).
- E2E/Playwright smoke tests were not run for this targeted UI density change and were intentionally skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45e00002ec832da292217fbddcf2be)