### PR TITLE
Weekly Prep: use spacing tokens and avoid duplicate Scout Summary fallback

### DIFF
--- a/src/ui/components/WeeklyPrepScreen.jsx
+++ b/src/ui/components/WeeklyPrepScreen.jsx
@@ -15,6 +15,18 @@ import { evaluateWeeklyContext } from '../utils/weeklyContext.js';
 import { buildWeeklyPrepActions } from '../utils/weeklyPrepActions.js';
 import { TeamIdentityBadge } from './HQVisuals.jsx';
 
+export function buildScoutSummaryItems({ prep, model, primaryAction } = {}) {
+  return [
+    { label: 'Opponent', value: `${prep?.nextGame?.isHome ? 'vs' : '@'} ${prep?.opponent?.name ?? model?.opponentAbbr ?? 'TBD'}` },
+    { label: 'Matchup context', value: model?.matchupHeadline ?? 'No opponent locked yet' },
+    {
+      label: 'Primary action',
+      value: primaryAction ? `${primaryAction.title}: ${primaryAction.reason}` : '—',
+    },
+    { label: 'Game-plan key', value: prep?.keyMatchupNote ?? model?.keyRiskLabel ?? 'No major matchup risk flagged yet.' },
+  ];
+}
+
 function TonePill({ tone = 'info', label }) {
   const palette = {
     success: { border: 'var(--success)', bg: 'color-mix(in srgb, var(--success) 12%, var(--surface))' },
@@ -302,12 +314,7 @@ export default function WeeklyPrepScreen({ league, onNavigate, onOpenBoxScore })
   const effectiveRemaining = Object.values(effectiveCompletion).filter((done) => !done).length;
   const effectiveScore = Math.round(((4 - effectiveRemaining) / 4) * 100);
   const primaryAction = model.priorityActions?.[0];
-  const scoutSummaryItems = [
-    { label: 'Opponent', value: `${prep?.nextGame?.isHome ? 'vs' : '@'} ${prep?.opponent?.name ?? model.opponentAbbr}` },
-    { label: 'Matchup context', value: model.matchupHeadline },
-    { label: 'Primary action', value: primaryAction ? `${primaryAction.title}: ${primaryAction.reason}` : model.keyRiskLabel },
-    { label: 'Game-plan key', value: prep?.keyMatchupNote ?? model.keyRiskLabel },
-  ];
+  const scoutSummaryItems = buildScoutSummaryItems({ prep, model, primaryAction });
 
   // Readiness tone/status derive from liveSummary so they update on every plan change.
   const liveReadinessTone = liveSummary.severity === 'major_risk' ? 'danger' : liveSummary.severity === 'minor_risk' ? 'warning' : 'success';

--- a/src/ui/components/__tests__/WeeklyPrepScreen.test.jsx
+++ b/src/ui/components/__tests__/WeeklyPrepScreen.test.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
-import WeeklyPrepScreen from '../WeeklyPrepScreen.jsx';
+import WeeklyPrepScreen, { buildScoutSummaryItems } from '../WeeklyPrepScreen.jsx';
 import * as weeklyPrepActionsModule from '../../utils/weeklyPrepActions.js';
 import { getWeeklyPrepProgress } from '../../utils/weeklyPrep.js';
 
@@ -88,6 +88,29 @@ describe('WeeklyPrepScreen', () => {
     expect(text.indexOf('Scout Report Summary')).toBeLessThan(text.indexOf('Priority Actions'));
     expect(text.indexOf('Priority Actions')).toBeLessThan(text.indexOf('Readiness Command'));
     expect(text.indexOf('Scout Report Summary')).toBeLessThan(text.indexOf('Matchup Intel Details'));
+  });
+
+  it('does not duplicate non-empty scout summary fallback values when action and matchup note are missing', () => {
+    const items = buildScoutSummaryItems({
+      prep: {
+        nextGame: { isHome: true },
+        opponent: { name: 'Lions' },
+      },
+      model: {
+        opponentAbbr: 'DET',
+        matchupHeadline: 'Home matchup vs DET',
+        keyRiskLabel: 'Defensive front must limit explosive passing downs.',
+      },
+      primaryAction: null,
+    });
+
+    const nonEmptyValues = items
+      .map((item) => item.value)
+      .filter((value) => value && value !== '—');
+
+    expect(items.find((item) => item.label === 'Primary action')?.value).toBe('—');
+    expect(items.find((item) => item.label === 'Game-plan key')?.value).toBe('Defensive front must limit explosive passing downs.');
+    expect(new Set(nonEmptyValues).size).toBe(nonEmptyValues.length);
   });
 
   it('does not mutate league gameplay data while rendering the denser prep view', () => {

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -720,8 +720,8 @@
 .weekly-prep-mini-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(180px, 100%), 1fr)); gap: 8px; font-size: var(--text-xs); }
 .weekly-prep-command-row { display: flex; gap: 8px; flex-wrap: wrap; }
 .weekly-prep-caption { margin: 0; font-size: var(--text-sm); color: var(--text-muted); }
-.weekly-prep-scout-summary { display: grid; gap: 6px; }
-.weekly-prep-compact-row { display: grid; grid-template-columns: minmax(96px, .45fr) 1fr; gap: 8px; align-items: start; border: 1px solid var(--hairline); border-radius: var(--radius-md); padding: 8px; font-size: var(--text-sm); background: color-mix(in srgb, var(--surface) 94%, black 6%); }
+.weekly-prep-scout-summary { display: grid; gap: var(--space-1); }
+.weekly-prep-compact-row { display: grid; grid-template-columns: minmax(96px, .45fr) 1fr; gap: var(--space-2); align-items: start; border: 1px solid var(--hairline); border-radius: var(--radius-md); padding: var(--space-2); font-size: var(--text-sm); background: color-mix(in srgb, var(--surface) 94%, black 6%); }
 .weekly-prep-compact-row span { color: var(--text-muted); font-size: var(--text-xs); text-transform: uppercase; letter-spacing: .04em; }
 .weekly-prep-compact-row strong { font-size: var(--text-sm); line-height: 1.35; }
 .weekly-prep-action-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(220px, 100%), 1fr)); gap: 8px; }
@@ -739,7 +739,7 @@
 .weekly-prep-details[open] summary { margin-bottom: var(--space-2); }
 
 @media (max-width: 480px) {
-  .weekly-prep-compact-row { grid-template-columns: 1fr; gap: 2px; }
+  .weekly-prep-compact-row { grid-template-columns: 1fr; gap: var(--space-1); }
   .weekly-prep-action-card .btn,
   .weekly-prep-nav-row .btn {
     min-height: 40px;


### PR DESCRIPTION
### Motivation
- Recent Weekly Prep UI changes introduced hard-coded pixel spacing and a fallback edge where both Scout Summary rows could show the same `model.keyRiskLabel` when `primaryAction` and `prep.keyMatchupNote` were missing, causing visual inconsistency and duplicate content.

### Description
- Replaced raw pixel spacing in `src/ui/styles/screen-system.css` for the Weekly Prep classes with existing tokens: `gap: var(--space-1)` for `.weekly-prep-scout-summary`, `gap: var(--space-2)` and `padding: var(--space-2)` for `.weekly-prep-compact-row`, and mobile `gap: var(--space-1)` under `@media (max-width: 480px)`; token names were verified in `src/ui/styles/base.css` before use.
- Prevented duplicate Scout Summary values by extracting row construction into `buildScoutSummaryItems` in `src/ui/components/WeeklyPrepScreen.jsx` and changing the Primary action missing fallback to an em dash (`'—'`) while leaving Game-plan key to fallback to `prep?.keyMatchupNote ?? model?.keyRiskLabel`.
- Added a regression unit test `does not duplicate non-empty scout summary fallback values when action and matchup note are missing` to `src/ui/components/__tests__/WeeklyPrepScreen.test.jsx` that asserts the Primary action shows `—`, the Game-plan key shows the risk note, and that no non-empty values are duplicated.

### Testing
- Ran the updated Weekly Prep unit test file with `npm run test:unit -- src/ui/components/__tests__/WeeklyPrepScreen.test.jsx` and the test file passed (29 tests in that file passed).
- Executed related utility tests with `npm run test:unit -- src/ui/utils/weeklyPrep.test.js src/ui/utils/weeklyPrepScreenModel.test.js src/ui/utils/weeklyPrepActions.test.js` and they all passed (41 tests across those files passed), and then ran the full unit suite `npm run test:unit` which completed successfully (all tests passed in the environment: 5044 tests passing reported).
- Built the app with `npm run build` to ensure CSS/token usage compiles and the build succeeded; attempting `node --check src/ui/components/WeeklyPrepScreen.jsx` was skipped effectively because Node reported `ERR_UNKNOWN_FILE_EXTENSION` for `.jsx` in this environment.

No gameplay, simulation, weekly-prep effects, scout formulas, ratings, injuries, game-plan logic, or save-shape changes were made; edits are UI-only (CSS + presentation fallback) and include one regression test. Files changed: `src/ui/styles/screen-system.css`, `src/ui/components/WeeklyPrepScreen.jsx`, `src/ui/components/__tests__/WeeklyPrepScreen.test.jsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45e3864728832d8fa76dd5b342588e)