### PR TITLE
Mobile Game Book Density V1: surface leaders/moments before dense tables

### DIFF
--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -161,6 +161,18 @@ function BoxScore({
     );
   };
 
+  // Key leaders — top performers surfaced above dense tables so mobile users
+  // answer "who won it" before drilling into full stat sheets.
+  const keyLeaders = (vm.statLeaderCards ?? []).filter((leader) => leader.available);
+
+  // Decisive moments — short, always-visible teaser (turning points, falling
+  // back to the first few scoring plays). The exhaustive list lives in the
+  // collapsed "Full Scoring Summary" section below.
+  const decisiveMoments = (vm.turningPointRows?.length ? vm.turningPointRows : vm.scoringSummary ?? []).slice(0, 4);
+  const scoringSummaryRows = vm.scoringSummary ?? [];
+  const teamComparisonRows = vm.teamComparisonRows ?? [];
+  const playByPlayRows = vm.playByPlayRows ?? [];
+
   return (
     <div
       className={`bs-sheet${embedded ? " bs-sheet--embedded" : ""}`}
@@ -177,7 +189,7 @@ function BoxScore({
         ✕
       </button>
 
-      {/* ── SCORE HERO ~60px ─────────────────────────────────────────────── */}
+      {/* ── SCORE HERO ~60px — priority 1: what happened ───────────────── */}
       <div className="bs-sheet-hero" data-testid="game-book-score-hero">
         <div className="bs-sheet-score-display">
           <span className="bs-sheet-abbr">{awayAbbr}</span>
@@ -195,6 +207,19 @@ function BoxScore({
         <div className="sr-only" data-testid="game-book-final-score">{vm.finalScoreLine}</div>
         <div className="bs-sheet-meta">Week {vm.week ?? mdash} · Season {vm.season ?? mdash}</div>
       </div>
+
+      {/* ── KEY LEADERS — priority 2: top performers above dense tables ─── */}
+      {keyLeaders.length > 0 && (
+        <div className="bs-sheet-leaders" data-testid="game-book-leaders">
+          <div className="bs-sheet-section-title">Key Leaders</div>
+          {keyLeaders.map((leader) => (
+            <div key={leader.key} className="bs-sheet-leader-row" data-testid={`game-book-leader-${leader.key}`}>
+              <span className="bs-sheet-leader-label">{leader.label}</span>
+              <span className="bs-sheet-leader-line">{leader.line}</span>
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* ── EXECUTIVE SUMMARY — inline bullets or hidden debug div ──────── */}
       {reasoningBullets.length > 0 ? (
@@ -216,27 +241,100 @@ function BoxScore({
         />
       )}
 
-      {/* ── STAT TABS — pill row ─────────────────────────────────────────── */}
-      <div className="bs-sheet-tab-row" data-testid="game-book-stat-tabs" role="tablist" aria-label="Stat category">
-        {TAB_KEYS.map((tab) => (
-          <button
-            key={tab}
-            type="button"
-            role="tab"
-            aria-selected={activeTab === tab}
-            className={`bs-sheet-tab${activeTab === tab ? " is-active" : ""}`}
-            data-testid={`game-book-tab-${tab}`}
-            onClick={() => setActiveTab(tab)}
-          >
-            {tab.charAt(0).toUpperCase() + tab.slice(1)}
-          </button>
-        ))}
-      </div>
+      {/* ── DECISIVE MOMENTS — priority 3: short teaser, always visible ─── */}
+      {decisiveMoments.length > 0 && (
+        <div className="bs-sheet-moments" data-testid="game-book-moments">
+          <div className="bs-sheet-section-title">Decisive Moments</div>
+          {decisiveMoments.map((m, i) => (
+            <div key={m.id ?? i} className="bs-sheet-moment-row">
+              <span className="bs-sheet-moment-meta">
+                {m.quarter != null ? `Q${m.quarter}` : ""}{(m.time ?? m.clock) ? ` ${m.time ?? m.clock}` : ""}
+              </span>
+              <span className="bs-sheet-moment-text">{m.text ?? m.description ?? "Momentum swing"}</span>
+            </div>
+          ))}
+        </div>
+      )}
 
-      {/* ── DENSE STAT TABLE — active tab content ───────────────────────── */}
-      <div className="bs-sheet-stat-body" data-testid="game-book-stat-body" role="tabpanel">
-        {renderStatRows(activeSection)}
-      </div>
+      {/* ── FULL SCORING SUMMARY — collapsed, exhaustive list ────────────── */}
+      {scoringSummaryRows.length > 0 && (
+        <details className="bs-sheet-details" data-testid="game-book-scoring-summary">
+          <summary>Full Scoring Summary ({scoringSummaryRows.length})</summary>
+          <div className="bs-sheet-details-body">
+            {scoringSummaryRows.map((row) => (
+              <div key={row.id} className="bs-sheet-row">
+                <span className="bs-sheet-row-meta">
+                  {row.quarter != null ? `Q${row.quarter}` : ""}{row.time ? ` ${row.time}` : ""}
+                </span>
+                <span>{[row.teamAbbr, row.type, row.description].filter(Boolean).join(" — ")}</span>
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
+
+      {/* ── TEAM STAT COMPARISON — priority 4, collapsed ─────────────────── */}
+      {teamComparisonRows.length > 0 && (
+        <details className="bs-sheet-details" data-testid="game-book-team-stats">
+          <summary>Team Stat Comparison</summary>
+          <div className="bs-sheet-details-body">
+            <div className="bs-sheet-compare-head">
+              <span>{awayAbbr}</span>
+              <span />
+              <span>{homeAbbr}</span>
+            </div>
+            {teamComparisonRows.map((row) => (
+              <div key={row.key} className="bs-sheet-compare-row" data-testid={`game-book-compare-${row.key}`}>
+                <span className={`bs-sheet-compare-value${row.winner === "away" ? " is-winner" : ""}`}>{row.away ?? mdash}</span>
+                <span className="bs-sheet-compare-label">{row.label}</span>
+                <span className={`bs-sheet-compare-value${row.winner === "home" ? " is-winner" : ""}`}>{row.home ?? mdash}</span>
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
+
+      {/* ── FULL PLAYER STATS — priority 5, collapsed dense tables ───────── */}
+      <details className="bs-sheet-details" data-testid="game-book-player-stats">
+        <summary>Full Player Stats</summary>
+        <div className="bs-sheet-details-body">
+          <div className="bs-sheet-tab-row" data-testid="game-book-stat-tabs" role="tablist" aria-label="Stat category">
+            {TAB_KEYS.map((tab) => (
+              <button
+                key={tab}
+                type="button"
+                role="tab"
+                aria-selected={activeTab === tab}
+                className={`bs-sheet-tab${activeTab === tab ? " is-active" : ""}`}
+                data-testid={`game-book-tab-${tab}`}
+                onClick={() => setActiveTab(tab)}
+              >
+                {tab.charAt(0).toUpperCase() + tab.slice(1)}
+              </button>
+            ))}
+          </div>
+          <div className="bs-sheet-stat-body" data-testid="game-book-stat-body" role="tabpanel">
+            {renderStatRows(activeSection)}
+          </div>
+        </div>
+      </details>
+
+      {/* ── FULL PLAY-BY-PLAY — priority 6, collapsed drive/play log ─────── */}
+      {playByPlayRows.length > 0 && (
+        <details className="bs-sheet-details" data-testid="game-book-play-by-play">
+          <summary>Full Play-by-Play ({playByPlayRows.length})</summary>
+          <div className="bs-sheet-details-body">
+            {playByPlayRows.map((row) => (
+              <div key={row.id} className={`bs-sheet-row${row.isKey ? " bs-sheet-row--key" : ""}`}>
+                <span className="bs-sheet-row-meta">
+                  {row.quarter != null ? `Q${row.quarter}` : ""}{row.clock ? ` ${row.clock}` : ""}
+                </span>
+                <span>{row.teamAbbr ? `${row.teamAbbr} — ` : ""}{row.text}</span>
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
     </div>
   );
 }

--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -136,7 +136,7 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
         title={screenTitle}
         subtitle={screenSubtitle}
         onBack={onBack}
-        backLabel="Return to HQ"
+        backLabel={backLabel ?? "Return to HQ"}
         primaryAction={(
           <button type="button" className="btn btn-sm" onClick={() => onNavigate?.('Weekly Prep')}>
             Review Next Week

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -1449,9 +1449,7 @@ export default function LeagueDashboard({
               backLabel={
                 gameDetailOpenSource === "weekly-results"
                   ? "Back to Weekly Results"
-                  : gameDetailOpenSource === "postgame"
-                    ? "Back to Result"
-                    : undefined
+                  : undefined
               }
             />
           </TabErrorBoundary>
@@ -1641,7 +1639,7 @@ export default function LeagueDashboard({
               onNavigate={setActiveTab}
               onPlayerSelect={handlePlayerSelect}
               onTeamSelect={handleTeamSelect}
-              backLabel={gameDetailModal.source === 'weekly-results' ? 'Back to Weekly Results' : 'Back to Result'}
+              backLabel={gameDetailModal.source === 'weekly-results' ? 'Back to Weekly Results' : 'Return to HQ'}
             />
           </div>
         </div>

--- a/src/ui/components/LiveGame.jsx
+++ b/src/ui/components/LiveGame.jsx
@@ -431,7 +431,7 @@ function LiveFinalCard({ framing, recapGame, recapText, onOpenBoxScore }) {
           data-testid="live-final-boxscore"
           onClick={() => onOpenBoxScore?.(framing.gameId)}
         >
-          View Box Score ›
+          View Game Book ›
         </button>
       ) : null}
     </div>

--- a/src/ui/components/__tests__/gameBookMobileDensity.test.jsx
+++ b/src/ui/components/__tests__/gameBookMobileDensity.test.jsx
@@ -1,0 +1,198 @@
+/** @vitest-environment jsdom */
+/**
+ * Mobile Game Book density — verifies the review surface answers "what
+ * happened?" (final score, key leaders, decisive moments) before dense
+ * stat tables/play-by-play, and that dense sections are collapsed via
+ * native <details>/<summary> rather than dumped inline.
+ */
+import React from 'react';
+import { readFileSync, globSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import BoxScore from '../BoxScore.jsx';
+import GameDetailScreen from '../GameDetailScreen.jsx';
+
+vi.mock('../../hooks/useStableRouteRequest.js', () => ({ default: vi.fn(() => ({ data: null })) }));
+import useStableRouteRequest from '../../hooks/useStableRouteRequest.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+const league = {
+  seasonId: 2031,
+  week: 6,
+  userTeamId: 1,
+  teams: [{ id: 1, abbr: 'HME' }, { id: 2, abbr: 'AWY' }],
+};
+
+const richGame = {
+  gameId: 'g-density',
+  homeId: 1,
+  awayId: 2,
+  homeScore: 27,
+  awayScore: 20,
+  teamStats: {
+    home: { totalYards: 400, passYards: 250, rushYards: 150, turnovers: 1, sacks: 2 },
+    away: { totalYards: 350, passYards: 220, rushYards: 130, turnovers: 2, sacks: 1 },
+  },
+  playerStats: {
+    home: {
+      11: { name: 'Home QB', stats: { passAtt: 30, passComp: 22, passYd: 250, passTD: 3 } },
+      22: { name: 'Home RB', stats: { rushAtt: 18, rushYd: 110, rushTD: 1 } },
+      33: { name: 'Home WR', stats: { targets: 8, receptions: 6, recYd: 120, recTD: 2 } },
+      44: { name: 'Home LB', stats: { tackles: 9, sacks: 2, interceptions: 1 } },
+    },
+    away: {
+      55: { name: 'Away QB', stats: { passAtt: 28, passComp: 18, passYd: 220, passTD: 1, interceptions: 1 } },
+    },
+  },
+  scoringSummary: [
+    { quarter: 1, time: '10:21', teamAbbr: 'HME', type: 'TD', description: 'Home QB pass to Home WR', scoreAfter: { home: 7, away: 0 } },
+    { quarter: 2, time: '4:02', teamAbbr: 'AWY', type: 'FG', description: '38-yard field goal', scoreAfter: { home: 7, away: 3 } },
+    { quarter: 3, time: '9:14', teamAbbr: 'HME', type: 'TD', description: 'Home RB run', scoreAfter: { home: 14, away: 3 } },
+    { quarter: 4, time: '2:00', teamAbbr: 'AWY', type: 'TD', description: 'Away QB pass', scoreAfter: { home: 27, away: 20 } },
+    { quarter: 4, time: '0:45', teamAbbr: 'HME', type: 'FG', description: 'Clinching field goal', scoreAfter: { home: 27, away: 20 } },
+  ],
+  playLog: [
+    { quarter: 1, clock: '14:55', teamId: 1, text: 'Home QB pass complete for 12 yards', yards: 12 },
+    { quarter: 1, clock: '10:21', teamId: 1, text: 'Home QB touchdown pass to Home WR', isTouchdown: true, yards: 18 },
+    { quarter: 4, clock: '2:00', teamId: 2, text: 'Away QB touchdown pass', isTouchdown: true, yards: 25 },
+  ],
+};
+
+function renderRichBoxScore(overrides = {}) {
+  return render(
+    <BoxScore
+      gameId="g-density"
+      league={{ ...league, gameById: { 'g-density': richGame } }}
+      embedded
+      {...overrides}
+    />,
+  );
+}
+
+describe('Game Book mobile density — section hierarchy', () => {
+  afterEach(() => {
+    cleanup();
+    vi.mocked(useStableRouteRequest).mockReturnValue({ data: null });
+  });
+
+  function isBefore(a, b) {
+    // true if `a` appears before `b` in document order
+    return Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
+  }
+
+  it('renders the final score before any dense stat table', () => {
+    const { getByTestId } = renderRichBoxScore();
+    const hero = getByTestId('game-book-score-hero');
+    const playerStats = getByTestId('game-book-player-stats');
+    expect(isBefore(hero, playerStats)).toBe(true);
+  });
+
+  it('renders key leaders above the full player stat tables', () => {
+    const { getByTestId } = renderRichBoxScore();
+    const leaders = getByTestId('game-book-leaders');
+    const playerStats = getByTestId('game-book-player-stats');
+    expect(isBefore(leaders, playerStats)).toBe(true);
+    // Sanity: leaders actually surface top performers, not just a label.
+    expect(leaders.textContent).toMatch(/Home QB|Home RB|Home WR|Away QB/);
+  });
+
+  it('renders decisive moments above the full player stat tables and full play-by-play', () => {
+    const { getByTestId } = renderRichBoxScore();
+    const moments = getByTestId('game-book-moments');
+    const playerStats = getByTestId('game-book-player-stats');
+    const playByPlay = getByTestId('game-book-play-by-play');
+    expect(isBefore(moments, playerStats)).toBe(true);
+    expect(isBefore(moments, playByPlay)).toBe(true);
+  });
+
+  it('renders team stat comparison above the full player stat tables', () => {
+    const { getByTestId } = renderRichBoxScore();
+    const teamStats = getByTestId('game-book-team-stats');
+    const playerStats = getByTestId('game-book-player-stats');
+    expect(isBefore(teamStats, playerStats)).toBe(true);
+  });
+
+  it('collapses dense sections behind native <details> closed by default', () => {
+    const { getByTestId } = renderRichBoxScore();
+    for (const testId of ['game-book-scoring-summary', 'game-book-team-stats', 'game-book-player-stats', 'game-book-play-by-play']) {
+      const el = getByTestId(testId);
+      expect(el.tagName).toBe('DETAILS');
+      expect(el.hasAttribute('open')).toBe(false);
+      // A summary teaser must still be visible without expansion.
+      expect(el.querySelector('summary')).toBeTruthy();
+    }
+  });
+
+  it('places the full play-by-play log lower in DOM order than the score hero and leaders', () => {
+    const { getByTestId } = renderRichBoxScore();
+    const hero = getByTestId('game-book-score-hero');
+    const leaders = getByTestId('game-book-leaders');
+    const playByPlay = getByTestId('game-book-play-by-play');
+    expect(isBefore(hero, playByPlay)).toBe(true);
+    expect(isBefore(leaders, playByPlay)).toBe(true);
+  });
+
+  it('does not mutate the game/archive data it renders', () => {
+    const frozenClone = JSON.parse(JSON.stringify(richGame));
+    Object.freeze(frozenClone);
+    Object.freeze(frozenClone.teamStats);
+    Object.freeze(frozenClone.playerStats);
+    Object.freeze(frozenClone.scoringSummary);
+    Object.freeze(frozenClone.playLog);
+    const before = JSON.stringify(richGame);
+    render(
+      <BoxScore gameId="g-density" league={{ ...league, gameById: { 'g-density': richGame } }} embedded />,
+    );
+    expect(JSON.stringify(richGame)).toBe(before);
+  });
+});
+
+describe('Game Book navigation copy — consistent return affordances', () => {
+  afterEach(() => {
+    cleanup();
+    vi.mocked(useStableRouteRequest).mockReturnValue({ data: null });
+  });
+
+  it('defaults the sticky header and screen header back label to "Return to HQ"', () => {
+    const { getByTestId } = render(
+      <GameDetailScreen
+        gameId="g-density"
+        league={{ ...league, gameById: { 'g-density': richGame } }}
+        actions={{}}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(getByTestId('game-book-sticky-back').textContent).toContain('Return to HQ');
+    expect(getByTestId('return-to-hq').textContent).toContain('Return to HQ');
+  });
+
+  it('honors an explicit backLabel (e.g. returning to an intermediate results screen) consistently', () => {
+    const { getByTestId } = render(
+      <GameDetailScreen
+        gameId="g-density"
+        league={{ ...league, gameById: { 'g-density': richGame } }}
+        actions={{}}
+        onBack={vi.fn()}
+        backLabel="Back to Weekly Results"
+      />,
+    );
+    expect(getByTestId('game-book-sticky-back').textContent).toContain('Back to Weekly Results');
+  });
+});
+
+describe('Game Book canonical CTA — "View Game Book" only', () => {
+  it('never reintroduces "View Box Score" copy in active src/ui JSX', () => {
+    const files = globSync('src/ui/**/*.jsx', { cwd: REPO_ROOT });
+    const offenders = [];
+    for (const relPath of files) {
+      if (relPath.includes('__tests__') || relPath.endsWith('.test.jsx')) continue;
+      const contents = readFileSync(path.join(REPO_ROOT, relPath), 'utf8');
+      if (contents.includes('View Box Score')) offenders.push(relPath);
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/ui/styles/style.css
+++ b/src/ui/styles/style.css
@@ -7883,7 +7883,8 @@ details[open] .nav-summary::after {
   right: 0;
   width: 100%;
   max-height: 85dvh;
-  overflow: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   display: flex;
   flex-direction: column;
   background: var(--surface, #1e1e2e);
@@ -7891,7 +7892,6 @@ details[open] .nav-summary::after {
   border-radius: 16px 16px 0 0;
   box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.5);
   z-index: 9500;
-  /* No internal scroll — sheet is non-scrolling by design */
 }
 
 /* Embedded variant: rendered inside a parent container, not fixed */
@@ -8165,4 +8165,181 @@ details[open] .nav-summary::after {
   font-size: 13px;
   color: var(--text-muted, #999);
   text-align: center;
+}
+
+/* ── Section title (shared by leaders / decisive moments) ───────────────── */
+.bs-sheet-section-title {
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-subtle, #666);
+  margin-bottom: 2px;
+}
+
+/* ── Key leaders — priority 2, always visible ────────────────────────────── */
+.bs-sheet-leaders {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: var(--space-3, 12px) var(--space-4, 16px);
+  border-bottom: 1px solid var(--hairline, #333);
+  flex-shrink: 0;
+}
+
+.bs-sheet-leader-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2, 8px);
+  font-size: 12px;
+}
+
+.bs-sheet-leader-label {
+  font-weight: 700;
+  color: var(--text-muted, #999);
+  flex-shrink: 0;
+}
+
+.bs-sheet-leader-line {
+  flex: 1;
+  color: var(--text, #fff);
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Decisive moments — priority 3, short always-visible teaser ─────────── */
+.bs-sheet-moments {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1, 4px);
+  padding: var(--space-2, 8px) var(--space-4, 16px);
+  border-bottom: 1px solid var(--hairline, #333);
+  flex-shrink: 0;
+}
+
+.bs-sheet-moment-row {
+  font-size: 11px;
+  color: var(--text-muted, #999);
+  display: flex;
+  gap: 6px;
+}
+
+.bs-sheet-moment-meta {
+  font-weight: 700;
+  color: var(--text, #fff);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.bs-sheet-moment-text {
+  flex: 1;
+}
+
+/* ── Collapsed dense sections (scoring summary, team stats, player stats,
+   play-by-play) — native <details>/<summary>, mirrors the Weekly Prep
+   Matchup Intel pattern so dense content stays out of the first viewport. */
+.bs-sheet-details {
+  border-bottom: 1px solid var(--hairline, #333);
+  flex-shrink: 0;
+}
+
+.bs-sheet-details summary {
+  cursor: pointer;
+  list-style: none;
+  padding: var(--space-3, 12px) var(--space-4, 16px);
+  font-size: 12px;
+  font-weight: 800;
+  color: var(--text, #fff);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.bs-sheet-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.bs-sheet-details summary::after {
+  content: "▾";
+  color: var(--text-subtle, #666);
+  font-size: 10px;
+  margin-left: var(--space-2, 8px);
+}
+
+.bs-sheet-details[open] summary::after {
+  content: "▴";
+}
+
+.bs-sheet-details-body {
+  padding: 0 var(--space-4, 16px) var(--space-3, 12px);
+}
+
+/* Full scoring summary / play-by-play rows */
+.bs-sheet-row {
+  display: flex;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--text-muted, #999);
+  padding: 3px 0;
+}
+
+.bs-sheet-row--key {
+  color: var(--text, #fff);
+  font-weight: 600;
+}
+
+.bs-sheet-row-meta {
+  font-weight: 700;
+  color: var(--text-subtle, #666);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Team stat comparison rows */
+.bs-sheet-compare-head {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-2, 8px);
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-subtle, #666);
+  text-align: center;
+  padding-bottom: var(--space-1, 4px);
+  border-bottom: 1px solid var(--hairline, #333);
+  margin-bottom: var(--space-1, 4px);
+}
+
+.bs-sheet-compare-row {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-2, 8px);
+  align-items: center;
+  padding: var(--space-1, 4px) 0;
+  font-size: 12px;
+}
+
+.bs-sheet-compare-value {
+  text-align: center;
+  color: var(--text-muted, #999);
+  font-variant-numeric: tabular-nums;
+}
+
+.bs-sheet-compare-value.is-winner {
+  color: var(--text, #fff);
+  font-weight: 800;
+}
+
+.bs-sheet-compare-label {
+  text-align: center;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-subtle, #666);
 }


### PR DESCRIPTION
Game Book (BoxScore.jsx, reached via canonical "View Game Book") answered
"what happened?" with only a score hero followed immediately by dense
passing/rushing/defense stat tables. Key leaders, decisive moments, team
stat comparison, full scoring summary, and play-by-play were either
missing from the render entirely (though already computed in
boxScoreViewModel.js) or dumped inline with no collapse.

- Add Key Leaders and Decisive Moments sections, always visible, sourced
  from the existing view-model fields (statLeaderCards, turningPointRows)
  — display-only, no new stat computation.
- Collapse Full Scoring Summary, Team Stat Comparison, Full Player Stats,
  and Full Play-by-Play behind native <details>/<summary>, mirroring the
  Weekly Prep Matchup Intel pattern, closed by default so dense tables no
  longer dominate the first viewport.
- Standardize return navigation copy to "Return to HQ" (was "Back to
  Result" for the postgame-triggered modal); GameDetailScreen's header now
  honors an explicit backLabel instead of always hardcoding "Return to HQ".
- Rename LiveGame's stray "View Box Score" CTA to "View Game Book" to match
  the canonical CTA introduced in prior work.
- New CSS uses existing tokens (--space-*, var(--text)/--hairline/etc.)
  and no inline style objects.

No sim, stat generation, archive shape, standings, save shape, weekly
prep, or trade/contract logic changed.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014YNVrH4ZwzZmuecJs5UiNT