### PR TITLE
Surface contract-market intelligence in re-sign modal via Scouting Intel panel

### DIFF
--- a/src/ui/components/ExtensionNegotiationModal.jsx
+++ b/src/ui/components/ExtensionNegotiationModal.jsx
@@ -6,6 +6,8 @@ import { buildRouteRequestKey } from "../utils/requestLoopGuard.js";
 import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 import { getAgentBadgeMeta, hydratePlayerAgent } from "../../core/contracts/agentNegotiationEngine.js";
 import { deriveNegotiationContext, NEGOTIATION_STANCES } from "../selectors/deriveNegotiationContext.js";
+import { evaluateReSignPriority, inferTeamDirection } from "../../core/contract-market.js";
+import NegotiationContextPanel from "./contracts/NegotiationContextPanel.jsx";
 
 const STANCE_TEXT_TONE = {
   [NEGOTIATION_STANCES.EAGER]: 'var(--success)',
@@ -76,6 +78,24 @@ export default function ExtensionNegotiationModal({
     () => deriveNegotiationContext({ player, team: resolvedTeam, league: resolvedLeague }),
     [player, resolvedTeam, resolvedLeague],
   );
+
+  // Display-only scouting intel (existing contract-market intelligence; no
+  // economics computed here). Uses the worker-provided ask as the demand so
+  // the recommendation matches the numbers on screen. Decision timing inputs
+  // (offerCount, phase, waitCycles) are not available at this surface — the
+  // Decision row is a V2 follow-up.
+  const priorityContext = useMemo(() => {
+    if (!player || ask == null) return null;
+    try {
+      return evaluateReSignPriority(player, {
+        teamDirection: inferTeamDirection(resolvedTeam ?? {}, toFiniteNumber(resolvedLeague?.week, 1)),
+        marketHeat: toFiniteNumber(ask?.marketHeat, 1),
+        demand: ask,
+      });
+    } catch {
+      return null;
+    }
+  }, [player, ask, resolvedTeam, resolvedLeague]);
 
   const askYears = toFiniteNumber(ask?.years, null);
   const askBaseAnnual = toFiniteNumber(ask?.baseAnnual, null);
@@ -189,6 +209,9 @@ export default function ExtensionNegotiationModal({
               </>
             )}
           </div>
+
+          {/* Scouting Intel — display-only contract-market intelligence. */}
+          <NegotiationContextPanel priorityContext={priorityContext} />
 
           {isFrozen && (
             <div

--- a/src/ui/components/__tests__/NegotiationContextPanel.integration.test.jsx
+++ b/src/ui/components/__tests__/NegotiationContextPanel.integration.test.jsx
@@ -1,0 +1,150 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import ExtensionNegotiationModal from '../ExtensionNegotiationModal.jsx';
+import CapImpactSummary from '../common/CapImpactSummary.jsx';
+import { __resetStableRouteRequestCache } from '../../hooks/useStableRouteRequest.js';
+
+/**
+ * Scouting Intel integration — the re-sign / extension modal surfaces the
+ * display-only NegotiationContextPanel above the offer area, without
+ * duplicating the existing Negotiation Stance section (PR #1634) and without
+ * changing offer submission behavior.
+ */
+
+const league = { seasonId: 2026, year: 2026, week: 8 };
+
+function expiringStar(overrides = {}) {
+  return {
+    id: 42,
+    name: 'Marcus Lane',
+    pos: 'WR',
+    age: 29,
+    ovr: 88,
+    potential: 90,
+    morale: 72,
+    schemeFit: 78,
+    tenureYears: 5,
+    contract: { baseAnnual: 18, years: 1, yearsTotal: 4 },
+    negotiationState: { negotiationsFrozenUntilSeason: null },
+    ...overrides,
+  };
+}
+
+function contenderTeam(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Contenders',
+    wins: 13,
+    losses: 4,
+    ties: 0,
+    frontOffice: { persona: 'WIN_NOW' },
+    ...overrides,
+  };
+}
+
+const resolvedAsk = {
+  years: 3,
+  yearsTotal: 3,
+  baseAnnual: 24.5,
+  signingBonus: 10,
+  guaranteedPct: 0.6,
+  willingness: 0.55,
+  profileHeadline: 'Money-focused',
+  marketHeat: 1.3,
+  marketHeatLabel: 'Warm',
+};
+
+function makeActions(overrides = {}) {
+  return {
+    getExtensionAsk: vi.fn(async () => ({ payload: { ask: resolvedAsk } })),
+    extendContract: vi.fn(async () => ({ payload: { status: 'accepted' } })),
+    ...overrides,
+  };
+}
+
+function renderModal({ actions = makeActions(), player = expiringStar(), onComplete = () => {}, onClose = () => {} } = {}) {
+  return render(
+    <ExtensionNegotiationModal
+      player={player}
+      actions={actions}
+      teamId={1}
+      team={contenderTeam()}
+      league={league}
+      currentSeason={2026}
+      onClose={onClose}
+      onComplete={onComplete}
+    />,
+  );
+}
+
+describe('ExtensionNegotiationModal — Scouting Intel panel wiring', () => {
+  beforeEach(() => __resetStableRouteRequestCache());
+  afterEach(cleanup);
+
+  it('renders the NegotiationContextPanel once the ask resolves', async () => {
+    const { getByTestId, getByText } = renderModal();
+    await waitFor(() => expect(getByTestId('negotiation-context-panel')).toBeTruthy());
+    expect(getByText('Scouting Intel')).toBeTruthy();
+    expect(getByTestId('negotiation-context-urgency')).toBeTruthy();
+  });
+
+  it('places the panel above the offer fields and submit actions', async () => {
+    const { getByTestId, getByText } = renderModal();
+    await waitFor(() => expect(getByTestId('negotiation-context-panel')).toBeTruthy());
+    const panel = getByTestId('negotiation-context-panel');
+    const offerArea = getByText('Agent demand');
+    const submit = getByText('Submit Offer');
+    expect(panel.compareDocumentPosition(offerArea) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(panel.compareDocumentPosition(submit) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // The stance section (PR #1634) stays above the new panel.
+    const stance = getByTestId('negotiation-stance-section');
+    expect(stance.compareDocumentPosition(panel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('leaves offer submission behavior unchanged', async () => {
+    const actions = makeActions();
+    const onComplete = vi.fn();
+    const { getByText } = renderModal({ actions, onComplete });
+    await waitFor(() => expect(getByText('Submit Offer')).toBeTruthy());
+    fireEvent.click(getByText('Submit Offer'));
+    await waitFor(() => expect(actions.extendContract).toHaveBeenCalledTimes(1));
+    expect(actions.extendContract).toHaveBeenCalledWith(42, 1, resolvedAsk);
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not regress CapImpactSummary rendering alongside the panel', async () => {
+    const { getByTestId } = render(
+      <div>
+        <ExtensionNegotiationModal
+          player={expiringStar()}
+          actions={makeActions()}
+          teamId={1}
+          team={contenderTeam()}
+          league={league}
+          currentSeason={2026}
+          onClose={() => {}}
+        />
+        <CapImpactSummary currentRoom={30} incoming={12} outgoing={0} />
+      </div>,
+    );
+    await waitFor(() => expect(getByTestId('negotiation-context-panel')).toBeTruthy());
+    expect(getByTestId('cap-impact-summary')).toBeTruthy();
+  });
+
+  it('never exposes raw recommendation enum values in the DOM', async () => {
+    const { container, getByTestId } = renderModal();
+    await waitFor(() => expect(getByTestId('negotiation-context-panel')).toBeTruthy());
+    expect(container.textContent).not.toMatch(
+      /priority_resign|resign_if_price|trade_or_tag|let_walk|replaceable_depth/,
+    );
+  });
+
+  it('shows exactly one negotiation/scouting context cluster — no duplicate stance or intel blocks', async () => {
+    const { getAllByTestId, getByTestId } = renderModal();
+    await waitFor(() => expect(getByTestId('negotiation-context-panel')).toBeTruthy());
+    expect(getAllByTestId('negotiation-stance-section')).toHaveLength(1);
+    expect(getAllByTestId('negotiation-context-panel')).toHaveLength(1);
+  });
+});

--- a/src/ui/components/__tests__/NegotiationContextPanel.test.jsx
+++ b/src/ui/components/__tests__/NegotiationContextPanel.test.jsx
@@ -1,0 +1,150 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import NegotiationContextPanel from '../contracts/NegotiationContextPanel.jsx';
+
+/**
+ * NegotiationContextPanel — display-only Scouting Intel panel.
+ *
+ * Presentational checks only: labels, tone classes, null-safety. No contract
+ * economics, acceptance, or cap logic is exercised here.
+ */
+
+function fullPriorityContext(overrides = {}) {
+  return {
+    recommendationTier: 'priority_resign',
+    shortReason: 'Priority Re-sign: productive starter at a thin position',
+    urgencyLevel: 'high',
+    negotiationRisk: 'medium',
+    likelyReplacementDifficulty: 'high',
+    profileHeadline: 'Money-focused',
+    ...overrides,
+  };
+}
+
+describe('NegotiationContextPanel — rendering', () => {
+  afterEach(cleanup);
+
+  it('renders the panel when a valid priorityContext is provided', () => {
+    const { getByTestId, getByText } = render(
+      <NegotiationContextPanel priorityContext={fullPriorityContext()} />,
+    );
+    expect(getByTestId('negotiation-context-panel')).toBeTruthy();
+    expect(getByText('Scouting Intel')).toBeTruthy();
+    expect(getByText('Money-focused')).toBeTruthy();
+    expect(getByText('Priority Re-sign: productive starter at a thin position')).toBeTruthy();
+  });
+
+  it('returns null when both props are null', () => {
+    const { container } = render(
+      <NegotiationContextPanel priorityContext={null} decisionTiming={null} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders readable labels — raw enum values never appear in the DOM', () => {
+    const tiers = ['priority_resign', 'resign_if_price', 'trade_or_tag', 'let_walk', 'replaceable_depth'];
+    const expected = {
+      priority_resign: 'Priority Re-sign',
+      resign_if_price: 'Re-sign if price is right',
+      trade_or_tag: 'Trade or tag candidate',
+      let_walk: 'Let walk candidate',
+      replaceable_depth: 'Replaceable depth',
+    };
+    for (const tier of tiers) {
+      const { container, getByText, unmount } = render(
+        <NegotiationContextPanel priorityContext={fullPriorityContext({ recommendationTier: tier, shortReason: '' })} />,
+      );
+      expect(getByText(expected[tier])).toBeTruthy();
+      expect(container.textContent).not.toMatch(/priority_resign|resign_if_price|trade_or_tag|let_walk|replaceable_depth/);
+      unmount();
+    }
+  });
+});
+
+describe('NegotiationContextPanel — urgency tone classes', () => {
+  afterEach(cleanup);
+
+  it('applies the high tone class when urgency is high', () => {
+    const { getByTestId } = render(
+      <NegotiationContextPanel priorityContext={fullPriorityContext({ urgencyLevel: 'high' })} />,
+    );
+    expect(getByTestId('negotiation-context-urgency').className).toContain('neg-context-value--high');
+  });
+
+  it('applies the low tone class when urgency is low', () => {
+    const { getByTestId } = render(
+      <NegotiationContextPanel priorityContext={fullPriorityContext({ urgencyLevel: 'low' })} />,
+    );
+    expect(getByTestId('negotiation-context-urgency').className).toContain('neg-context-value--low');
+  });
+});
+
+describe('NegotiationContextPanel — decision timing row', () => {
+  afterEach(cleanup);
+
+  it('shows "Decision imminent" when patienceWeeks is 0', () => {
+    const { getByTestId } = render(
+      <NegotiationContextPanel decisionTiming={{ patienceWeeks: 0 }} />,
+    );
+    const decision = getByTestId('negotiation-context-decision');
+    expect(decision.textContent).toBe('Decision imminent');
+    expect(decision.className).toContain('neg-context-value--high');
+  });
+
+  it('shows "1 week left" when patienceWeeks is 1', () => {
+    const { getByTestId } = render(
+      <NegotiationContextPanel decisionTiming={{ patienceWeeks: 1 }} />,
+    );
+    const decision = getByTestId('negotiation-context-decision');
+    expect(decision.textContent).toBe('1 week left');
+    expect(decision.className).toContain('neg-context-value--medium');
+  });
+
+  it('shows "${n} weeks" when patienceWeeks is 2 or more', () => {
+    const { getByTestId } = render(
+      <NegotiationContextPanel decisionTiming={{ patienceWeeks: 3 }} />,
+    );
+    const decision = getByTestId('negotiation-context-decision');
+    expect(decision.textContent).toBe('3 weeks');
+    expect(decision.className).toContain('neg-context-value--low');
+  });
+
+  it('omits the decision row when patienceWeeks is missing', () => {
+    const { queryByTestId } = render(
+      <NegotiationContextPanel priorityContext={fullPriorityContext()} decisionTiming={{}} />,
+    );
+    expect(queryByTestId('negotiation-context-decision')).toBeNull();
+  });
+});
+
+describe('NegotiationContextPanel — resilience', () => {
+  afterEach(cleanup);
+
+  it('does not crash when optional fields are missing', () => {
+    const { getByTestId } = render(
+      <NegotiationContextPanel priorityContext={{ urgencyLevel: 'medium' }} />,
+    );
+    const panel = getByTestId('negotiation-context-panel');
+    expect(panel).toBeTruthy();
+    expect(getByTestId('negotiation-context-urgency').textContent).toBe('Medium');
+  });
+
+  it('tolerates unknown enum values without exposing them as tier labels', () => {
+    const { getByTestId, queryByText } = render(
+      <NegotiationContextPanel
+        priorityContext={fullPriorityContext({ recommendationTier: 'mystery_tier', urgencyLevel: 'weird' })}
+      />,
+    );
+    expect(getByTestId('negotiation-context-panel')).toBeTruthy();
+    expect(queryByText('mystery_tier')).toBeNull();
+  });
+
+  it('has no inline styles on the panel root', () => {
+    const { getByTestId } = render(
+      <NegotiationContextPanel priorityContext={fullPriorityContext()} />,
+    );
+    expect(getByTestId('negotiation-context-panel').getAttribute('style')).toBeNull();
+  });
+});

--- a/src/ui/components/contracts/NegotiationContextPanel.jsx
+++ b/src/ui/components/contracts/NegotiationContextPanel.jsx
@@ -1,0 +1,123 @@
+import React from 'react';
+
+/**
+ * NegotiationContextPanel — display-only "Scouting Intel" for re-sign /
+ * extension negotiations. Surfaces existing contract-market intelligence;
+ * it never computes economics and never affects offers or acceptance.
+ *
+ * Props (both optional; renders null when neither is provided):
+ *
+ * @param {object|null} priorityContext — result of `evaluateReSignPriority`:
+ *   {
+ *     recommendationTier: 'priority_resign'|'resign_if_price'|'trade_or_tag'|'let_walk'|'replaceable_depth',
+ *     shortReason: string,
+ *     urgencyLevel: 'high'|'medium'|'low',
+ *     negotiationRisk: 'high'|'medium'|'low',
+ *     likelyReplacementDifficulty: 'high'|'medium'|'low',
+ *     profileHeadline: string,
+ *   }
+ * @param {object|null} decisionTiming — result of `buildDecisionTiming`:
+ *   { patienceWeeks: number, ... } — only `patienceWeeks` is displayed.
+ */
+
+const TIER_LABEL = {
+  priority_resign: 'Priority Re-sign',
+  resign_if_price: 'Re-sign if price is right',
+  trade_or_tag: 'Trade or tag candidate',
+  let_walk: 'Let walk candidate',
+  replaceable_depth: 'Replaceable depth',
+};
+
+const TIER_TONE = {
+  priority_resign: 'high',
+  resign_if_price: 'medium',
+  trade_or_tag: 'medium',
+  let_walk: 'muted',
+  replaceable_depth: 'muted',
+};
+
+const REPLACEMENT_LABEL = {
+  high: 'Hard to replace',
+  medium: 'Moderate to replace',
+  low: 'Easy to replace',
+};
+
+const RISK_LABEL = {
+  high: 'High negotiation risk',
+  medium: 'Medium negotiation risk',
+  low: 'Low negotiation risk',
+};
+
+const LEVEL_LABEL = { high: 'High', medium: 'Medium', low: 'Low' };
+
+function toneClass(tone) {
+  if (tone === 'high') return 'neg-context-value--high';
+  if (tone === 'medium') return 'neg-context-value--medium';
+  if (tone === 'low') return 'neg-context-value--low';
+  return 'neg-context-value--muted';
+}
+
+function decisionLabel(patienceWeeks) {
+  if (patienceWeeks === 0) return 'Decision imminent';
+  if (patienceWeeks === 1) return '1 week left';
+  return `${patienceWeeks} weeks`;
+}
+
+function decisionTone(patienceWeeks) {
+  if (patienceWeeks === 0) return 'high';
+  if (patienceWeeks === 1) return 'medium';
+  return 'low';
+}
+
+function Row({ label, value, tone, testId }) {
+  return (
+    <div className="neg-context-row">
+      <span className="neg-context-label">{label}</span>
+      <span className={`neg-context-value ${toneClass(tone)}`} data-testid={testId}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+export default function NegotiationContextPanel({ priorityContext = null, decisionTiming = null }) {
+  if (priorityContext == null && decisionTiming == null) return null;
+
+  const tier = priorityContext?.recommendationTier;
+  const tierLabel = TIER_LABEL[tier] ?? null;
+  const urgency = priorityContext?.urgencyLevel;
+  const urgencyText = LEVEL_LABEL[urgency] ?? null;
+  const replacementText = REPLACEMENT_LABEL[priorityContext?.likelyReplacementDifficulty] ?? null;
+  const riskLabel = RISK_LABEL[priorityContext?.negotiationRisk] ?? null;
+  const headline = priorityContext?.profileHeadline || null;
+  const shortReason = priorityContext?.shortReason || null;
+  const patienceWeeks = Number.isFinite(decisionTiming?.patienceWeeks)
+    ? Math.max(0, Math.round(decisionTiming.patienceWeeks))
+    : null;
+
+  return (
+    <div className="neg-context-panel" data-testid="negotiation-context-panel">
+      <div className="neg-context-header">Scouting Intel</div>
+      {headline && <Row label="Motivation" value={headline} tone="muted" />}
+      {tierLabel && <Row label="Priority" value={tierLabel} tone={TIER_TONE[tier]} />}
+      {urgencyText && (
+        <Row
+          label="Urgency"
+          value={replacementText ? `${urgencyText} · ${replacementText}` : urgencyText}
+          tone={urgency}
+          testId="negotiation-context-urgency"
+        />
+      )}
+      {patienceWeeks != null && (
+        <Row
+          label="Decision"
+          value={decisionLabel(patienceWeeks)}
+          tone={decisionTone(patienceWeeks)}
+          testId="negotiation-context-decision"
+        />
+      )}
+      {riskLabel && <Row label="Risk" value={riskLabel} tone={priorityContext?.negotiationRisk} />}
+      {shortReason && <div className="neg-context-note">{shortReason}</div>}
+    </div>
+  );
+}

--- a/src/ui/styles/style.css
+++ b/src/ui/styles/style.css
@@ -2925,6 +2925,55 @@ select:disabled {
   background: #545b62;
 }
 
+/* Negotiation context panel (Scouting Intel — re-sign / extension modal) */
+.neg-context-panel {
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  padding: var(--space-3);
+  margin: 0 0 var(--space-3);
+  display: grid;
+  gap: var(--space-1);
+}
+
+.neg-context-header {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-subtle);
+  font-weight: 700;
+  margin-bottom: var(--space-1);
+}
+
+.neg-context-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.neg-context-label {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.neg-context-value {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  text-align: right;
+}
+
+.neg-context-value--high { color: var(--danger); }
+.neg-context-value--medium { color: var(--warning); }
+.neg-context-value--low { color: var(--success); }
+.neg-context-value--muted { color: var(--text-muted); }
+
+.neg-context-note {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  margin-top: var(--space-1);
+}
+
 /* Coaching Role Styles */
 .coaching-role-interface {
     margin: var(--space-4) 0;


### PR DESCRIPTION
Add a display-only NegotiationContextPanel that surfaces existing
re-sign intelligence (evaluateReSignPriority: motivation headline,
recommendation tier, urgency + replacement difficulty, negotiation
risk, short reason) in the extension/re-sign modal, below the PR #1634
Negotiation Stance section and above the offer area.

- Panel is presentational only; renders null with no data and maps all
  tiers to readable labels (no raw enums in the DOM)
- Priority context is computed at the render site from props already
  available (player, team, league.week) plus the worker-provided ask
  (marketHeat, demand), wrapped so a failure never blocks the offer flow
- Decision timing row is supported by the component but not wired:
  buildDecisionTiming inputs (offerCount, phase, waitCycles) are not
  available at this surface (V2 follow-up)
- Tone styling via new .neg-context-* classes using existing tokens
- Component + integration tests, including single-context-cluster and
  unchanged offer submission assertions

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017yJpgH7yEVhyiWyy34HUxp