### PR TITLE
Add re-sign priority badges to expiring-contract list views

### DIFF
--- a/src/ui/components/FinancialsView.jsx
+++ b/src/ui/components/FinancialsView.jsx
@@ -22,6 +22,7 @@ import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import FranchiseInvestmentsPanel from "./FranchiseInvestmentsPanel.jsx";
 import { classifyTeamDirection, evaluateResignRecommendation } from "../utils/contractInsights.js";
+import ReSignPriorityBadges from "./resign/ReSignPriorityBadges.jsx";
 import { CONTRACT_PLAN_LABELS, normalizeManagement } from "../utils/playerManagement.js";
 import InfoTip from "./InfoTip.jsx";
 import { computeRestructureOutcome, isContractRestructureEligible } from "../../core/contracts/restructure.js";
@@ -250,7 +251,9 @@ export default function FinancialsView({ league, actions }) {
       estimatedExtensionCost: expiring.reduce((sum, p) => sum + p.estimatedDemand, 0),
       capRiskNextYear: expiring.filter((p) => (p.age ?? 0) >= 30 && p.estimatedDemand >= 12).length,
     };
-    return { rows: expiring, summary };
+    // Sort a copy so the underlying player/enriched arrays are never reordered.
+    const sortedRows = [...expiring].sort((a, b) => (b.rec?.score ?? 0) - (a.rec?.score ?? 0));
+    return { rows: sortedRows, summary };
   }, [enriched, userTeam, league?.week]);
 
 
@@ -656,7 +659,14 @@ export default function FinancialsView({ league, actions }) {
           <div style={{ maxHeight: 260, overflow: 'auto', border: '1px solid var(--hairline)', borderRadius: 8 }}>
             {expiringDashboard.rows.map((row) => (
               <div key={row.id} style={{ display: 'grid', gridTemplateColumns: '1.3fr repeat(7, minmax(70px, 1fr))', gap: 8, padding: '8px 10px', borderBottom: '1px solid var(--hairline)', fontSize: 12 }}>
-                <div><strong>{row.name}</strong><div style={{ color: 'var(--text-muted)' }}>{row.pos} · age {row.age} · morale {row.morale ?? 70}</div><div style={{ color: row.rec.tone }}>{row.rec.label}</div><div style={{ color: 'var(--text-subtle)' }}>Plan: {row.management.contractPlan[0] ? (CONTRACT_PLAN_LABELS[row.management.contractPlan[0]] ?? row.management.contractPlan[0]) : 'None'} · Trade status: {row.management.tradeStatus}</div></div>
+                <div><strong>{row.name}</strong><div style={{ color: 'var(--text-muted)' }}>{row.pos} · age {row.age} · morale {row.morale ?? 70}</div>
+                  <ReSignPriorityBadges
+                    tier={row.rec.tier}
+                    urgency={row.rec.urgency}
+                    risk={row.rec.negotiationRisk}
+                    replacementDifficulty={row.rec.replacementDifficulty}
+                  />
+                  <div style={{ color: 'var(--text-subtle)' }}>Plan: {row.management.contractPlan[0] ? (CONTRACT_PLAN_LABELS[row.management.contractPlan[0]] ?? row.management.contractPlan[0]) : 'None'} · Trade status: {row.management.tradeStatus}</div></div>
                 <div>{row.ovr}/{row.potential ?? row.ovr}</div>
                 <div>{fmt(row.capHit)}</div>
                 <div>{fmt(row.estimatedDemand)}</div>

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -52,6 +52,7 @@ import {
   summarizeExpiring,
 } from "../utils/contractInsights.js";
 import { buildDirectionGuidance, buildTeamIntelligence } from "../utils/teamIntelligence.js";
+import ReSignPriorityBadges from "./resign/ReSignPriorityBadges.jsx";
 import { normalizeManagement, TRADE_STATUSES, TRADE_STATUS_LABELS, CONTRACT_PLAN_LABELS, toggleContractPlan } from "../utils/playerManagement.js";
 import { deriveTeamCapSnapshot, formatMoneyM, toFiniteNumber } from "../utils/numberFormatting.js";
 import { derivePlayerContractFinancials } from "../utils/contractFormatting.js";
@@ -1339,26 +1340,14 @@ function RosterTable({
                         </span>
                       )}
                       {expiringDecision && (
-                        <span
-                          style={{
-                            marginLeft: 6,
-                            padding: "1px 5px",
-                            borderRadius: "var(--radius-pill)",
-                            background: `${expiringDecision.tone}22`,
-                            color: expiringDecision.tone,
-                            fontSize: 9,
-                            fontWeight: 800,
-                            letterSpacing: "0.3px",
-                            verticalAlign: "middle",
-                          }}
-                        >
-                          {expiringDecision.label}
-                        </span>
-                      )}
-                      {expiringDecision && (
-                        <div style={{ fontSize: 10, color: "var(--text-muted)", marginTop: 2 }}>
-                          {expiringDecision.reason} · {expiringDecision.urgency} urgency · {expiringDecision.negotiationRisk} risk
-                        </div>
+                        <ReSignPriorityBadges
+                          tier={expiringDecision.key}
+                          urgency={expiringDecision.urgency}
+                          risk={expiringDecision.negotiationRisk}
+                          replacementDifficulty={expiringDecision.replacementDifficulty}
+                          shortReason={expiringDecision.reason}
+                          compact={showMobileView}
+                        />
                       )}
                     </TableCell>
                     {/* OVR */}
@@ -2266,15 +2255,6 @@ function PlayerCard({ player, onSelect, showDecisionContext = false, decisionCon
               EXPIRING
             </span>
           )}
-          {showDecisionContext && expiringDecision && (
-            <span style={{
-              fontSize: 9, fontWeight: 700, color: expiringDecision.tone,
-              background: `${expiringDecision.tone}22`, padding: "1px 5px",
-              borderRadius: 4, border: `1px solid ${expiringDecision.tone}66`,
-            }}>
-              {expiringDecision.label}
-            </span>
-          )}
           {potential >= 90 && (
             <span style={{
               fontSize: 9, fontWeight: 700, color: "#FFD700",
@@ -2285,6 +2265,16 @@ function PlayerCard({ player, onSelect, showDecisionContext = false, decisionCon
             </span>
           )}
         </div>
+      )}
+      {showDecisionContext && expiringDecision && (
+        <ReSignPriorityBadges
+          tier={expiringDecision.key}
+          urgency={expiringDecision.urgency}
+          risk={expiringDecision.negotiationRisk}
+          replacementDifficulty={expiringDecision.replacementDifficulty}
+          shortReason={expiringDecision.reason}
+          compact
+        />
       )}
     </div>
   );

--- a/src/ui/components/__tests__/FinancialsExpiringDashboard.integration.test.jsx
+++ b/src/ui/components/__tests__/FinancialsExpiringDashboard.integration.test.jsx
@@ -1,0 +1,110 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, waitFor, act } from '@testing-library/react';
+import FinancialsView from '../FinancialsView.jsx';
+
+function makePlayer(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Player',
+    pos: 'QB',
+    ovr: 70,
+    potential: 70,
+    age: 27,
+    morale: 70,
+    schemeFit: 65,
+    contract: { years: 1, baseAnnual: 6, signingBonus: 0, yearsTotal: 1 },
+    ...overrides,
+  };
+}
+
+// High-value, young, well-liked starter → should score highest → priority_resign.
+const starPlayer = makePlayer({
+  id: 101,
+  name: 'Star Quarterback',
+  pos: 'QB',
+  ovr: 90,
+  potential: 92,
+  age: 25,
+  morale: 80,
+  schemeFit: 70,
+  contract: { years: 1, baseAnnual: 10, signingBonus: 0, yearsTotal: 1 },
+});
+
+// Old, declining, low-morale depth piece → should score lowest → let_walk.
+const walkPlayer = makePlayer({
+  id: 102,
+  name: 'Aging Linebacker',
+  pos: 'LB',
+  ovr: 40,
+  potential: 40,
+  age: 38,
+  morale: 30,
+  schemeFit: 50,
+  contract: { years: 1, baseAnnual: 3, signingBonus: 0, yearsTotal: 1 },
+});
+
+const rosterPayload = {
+  team: { id: 1, capTotal: 200, capUsed: 150, deadCap: 0, capRoom: 30 },
+  players: [starPlayer, walkPlayer],
+};
+
+const baseLeague = {
+  userTeamId: 1,
+  week: 5,
+  year: 2026,
+  phase: 'offseason_resign',
+  teams: [{ id: 1, name: 'Sharks', wins: 8, losses: 8, capRoom: 30 }],
+};
+
+function makeActions(players = rosterPayload.players) {
+  return {
+    getRoster: vi.fn(async () => ({ payload: { ...rosterPayload, players } })),
+  };
+}
+
+describe('FinancialsView — expiring contracts dashboard', () => {
+  afterEach(cleanup);
+
+  it('renders priority badges for expiring players', async () => {
+    const actions = makeActions();
+    const { findAllByTestId } = render(<FinancialsView league={baseLeague} actions={actions} />);
+    await waitFor(() => expect(actions.getRoster).toHaveBeenCalled());
+
+    const badgeGroups = await findAllByTestId('resign-priority-badges');
+    expect(badgeGroups.length).toBe(2);
+  });
+
+  it('sorts expiring rows by recommendation score descending (highest priority first)', async () => {
+    const actions = makeActions();
+    const { findAllByTestId } = render(<FinancialsView league={baseLeague} actions={actions} />);
+    await waitFor(() => expect(actions.getRoster).toHaveBeenCalled());
+
+    const tierBadges = await findAllByTestId('resign-priority-badge-tier');
+    // Star quarterback (high score) must render before the aging linebacker (low score).
+    expect(tierBadges[0].textContent).toBe('Priority Re-sign');
+    expect(tierBadges[1].textContent).toBe('Let walk');
+  });
+
+  it('does not mutate the source players array when sorting the dashboard rows', async () => {
+    const players = [starPlayer, walkPlayer];
+    const actions = makeActions(players);
+    const { findAllByTestId } = render(<FinancialsView league={baseLeague} actions={actions} />);
+    await waitFor(() => expect(actions.getRoster).toHaveBeenCalled());
+    await findAllByTestId('resign-priority-badges');
+
+    // The original fixture array order must be untouched by the dashboard's internal sort.
+    expect(players[0].id).toBe(starPlayer.id);
+    expect(players[1].id).toBe(walkPlayer.id);
+  });
+
+  it('does not render raw enum values such as priority_resign or trade_or_tag in the list', async () => {
+    const actions = makeActions();
+    const { findAllByTestId, container } = render(<FinancialsView league={baseLeague} actions={actions} />);
+    await waitFor(() => expect(actions.getRoster).toHaveBeenCalled());
+    await findAllByTestId('resign-priority-badges');
+
+    expect(container.textContent).not.toMatch(/priority_resign|resign_if_price|trade_or_tag|replaceable_depth/);
+  });
+});

--- a/src/ui/components/__tests__/ReSignPriorityBadges.test.jsx
+++ b/src/ui/components/__tests__/ReSignPriorityBadges.test.jsx
@@ -1,0 +1,159 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import ReSignPriorityBadges from '../resign/ReSignPriorityBadges.jsx';
+
+describe('ReSignPriorityBadges — tier labels', () => {
+  afterEach(cleanup);
+
+  const tiers = {
+    priority_resign: 'Priority Re-sign',
+    resign_if_price: 'Re-sign if price holds',
+    trade_or_tag: 'Trade / Tag',
+    let_walk: 'Let walk',
+    replaceable_depth: 'Replaceable depth',
+  };
+
+  for (const [tier, label] of Object.entries(tiers)) {
+    it(`renders a readable label for tier "${tier}"`, () => {
+      const { getByTestId } = render(<ReSignPriorityBadges tier={tier} />);
+      expect(getByTestId('resign-priority-badge-tier').textContent).toBe(label);
+    });
+  }
+});
+
+describe('ReSignPriorityBadges — urgency labels and tone classes', () => {
+  afterEach(cleanup);
+
+  it('maps high urgency to a readable label and high tone class', () => {
+    const { getByTestId } = render(<ReSignPriorityBadges urgency="High" />);
+    const el = getByTestId('resign-priority-badge-urgency');
+    expect(el.textContent).toBe('High urgency');
+    expect(el.className).toContain('resign-priority-badge--high');
+  });
+
+  it('maps medium urgency to a readable label and medium tone class', () => {
+    const { getByTestId } = render(<ReSignPriorityBadges urgency="medium" />);
+    const el = getByTestId('resign-priority-badge-urgency');
+    expect(el.textContent).toBe('Mid urgency');
+    expect(el.className).toContain('resign-priority-badge--medium');
+  });
+
+  it('maps low urgency to a readable label and low tone class', () => {
+    const { getByTestId } = render(<ReSignPriorityBadges urgency="Low" />);
+    const el = getByTestId('resign-priority-badge-urgency');
+    expect(el.textContent).toBe('Low urgency');
+    expect(el.className).toContain('resign-priority-badge--low');
+  });
+});
+
+describe('ReSignPriorityBadges — risk labels and tone classes', () => {
+  afterEach(cleanup);
+
+  it('maps high risk to a readable label and high tone class', () => {
+    const { getByTestId } = render(<ReSignPriorityBadges risk="High" />);
+    const el = getByTestId('resign-priority-badge-risk');
+    expect(el.textContent).toBe('High risk');
+    expect(el.className).toContain('resign-priority-badge--high');
+  });
+
+  it('maps medium risk to a readable label and medium tone class', () => {
+    const { getByTestId } = render(<ReSignPriorityBadges risk="Medium" />);
+    const el = getByTestId('resign-priority-badge-risk');
+    expect(el.textContent).toBe('Med risk');
+    expect(el.className).toContain('resign-priority-badge--medium');
+  });
+
+  it('maps low risk to a readable label and low tone class', () => {
+    const { getByTestId } = render(<ReSignPriorityBadges risk="Low" />);
+    const el = getByTestId('resign-priority-badge-risk');
+    expect(el.textContent).toBe('Low risk');
+    expect(el.className).toContain('resign-priority-badge--low');
+  });
+});
+
+describe('ReSignPriorityBadges — replacement difficulty labels', () => {
+  afterEach(cleanup);
+
+  it('maps high difficulty to "Hard to replace"', () => {
+    const { getByTestId } = render(<ReSignPriorityBadges replacementDifficulty="High" />);
+    expect(getByTestId('resign-priority-badge-replacement').textContent).toBe('Hard to replace');
+  });
+
+  it('maps medium difficulty to "Replaceable"', () => {
+    const { getByTestId } = render(<ReSignPriorityBadges replacementDifficulty="Medium" />);
+    expect(getByTestId('resign-priority-badge-replacement').textContent).toBe('Replaceable');
+  });
+
+  it('maps low difficulty to "Easy to replace"', () => {
+    const { getByTestId } = render(<ReSignPriorityBadges replacementDifficulty="Low" />);
+    expect(getByTestId('resign-priority-badge-replacement').textContent).toBe('Easy to replace');
+  });
+});
+
+describe('ReSignPriorityBadges — fallback safety', () => {
+  afterEach(cleanup);
+
+  it('falls back safely when all props are missing', () => {
+    const { getByTestId, container } = render(<ReSignPriorityBadges />);
+    expect(getByTestId('resign-priority-badges')).toBeTruthy();
+    expect(getByTestId('resign-priority-badge-tier').textContent).toBe('Unrated');
+    expect(getByTestId('resign-priority-badge-urgency').className).toContain('resign-priority-badge--muted');
+    expect(container.textContent).not.toMatch(/undefined|null/);
+  });
+
+  it('falls back safely for an unrecognized tier/level without exposing raw values', () => {
+    const { getByTestId, container } = render(
+      <ReSignPriorityBadges tier="mystery_tier" urgency="weird" risk="weird" replacementDifficulty="weird" />,
+    );
+    expect(getByTestId('resign-priority-badge-tier').textContent).toBe('Unrated');
+    expect(container.textContent).not.toMatch(/mystery_tier|weird/);
+  });
+
+  it('never renders raw enum values in the DOM for any known tier', () => {
+    const tiers = ['priority_resign', 'resign_if_price', 'trade_or_tag', 'let_walk', 'replaceable_depth'];
+    for (const tier of tiers) {
+      const { container, unmount } = render(<ReSignPriorityBadges tier={tier} urgency="high" risk="medium" replacementDifficulty="low" />);
+      expect(container.textContent).not.toMatch(/priority_resign|resign_if_price|trade_or_tag|let_walk|replaceable_depth/);
+      unmount();
+    }
+  });
+});
+
+describe('ReSignPriorityBadges — compact mode', () => {
+  afterEach(cleanup);
+
+  it('applies the compact modifier class and still renders all badge chips', () => {
+    const { getByTestId } = render(
+      <ReSignPriorityBadges tier="priority_resign" urgency="high" risk="low" replacementDifficulty="medium" compact />,
+    );
+    const root = getByTestId('resign-priority-badges');
+    expect(root.className).toContain('resign-priority-badges--compact');
+    expect(getByTestId('resign-priority-badge-tier')).toBeTruthy();
+    expect(getByTestId('resign-priority-badge-urgency')).toBeTruthy();
+    expect(getByTestId('resign-priority-badge-risk')).toBeTruthy();
+    expect(getByTestId('resign-priority-badge-replacement')).toBeTruthy();
+  });
+});
+
+describe('ReSignPriorityBadges — no inline styles', () => {
+  afterEach(cleanup);
+
+  it('has no inline style attributes on the root or any badge element', () => {
+    const { getByTestId } = render(
+      <ReSignPriorityBadges
+        tier="priority_resign"
+        urgency="high"
+        risk="medium"
+        replacementDifficulty="low"
+        shortReason="Priority Re-sign: core player worth protecting"
+      />,
+    );
+    const root = getByTestId('resign-priority-badges');
+    expect(root.getAttribute('style')).toBeNull();
+    for (const el of root.querySelectorAll('*')) {
+      expect(el.getAttribute('style')).toBeNull();
+    }
+  });
+});

--- a/src/ui/components/__tests__/RosterResignPriorityBadges.integration.test.jsx
+++ b/src/ui/components/__tests__/RosterResignPriorityBadges.integration.test.jsx
@@ -1,0 +1,82 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import Roster from '../Roster.jsx';
+
+function makePlayer(id, overrides = {}) {
+  return {
+    id,
+    name: `Player ${id}`,
+    pos: 'QB',
+    ovr: 80,
+    potential: 82,
+    age: 27,
+    morale: 70,
+    schemeFit: 65,
+    teamId: 1,
+    contract: { years: 1, yearsLeft: 1, baseAnnual: 8, salary: 8_000_000 },
+    depthChart: { rowKey: 'QB', order: id },
+    ...overrides,
+  };
+}
+
+const rosterPayload = {
+  team: { id: 1, name: 'Sharks', capRoom: 30_000_000, capTotal: 200_000_000 },
+  players: [
+    makePlayer(1, { pos: 'QB' }),
+    makePlayer(2, { pos: 'WR', contract: { years: 3, yearsLeft: 3, baseAnnual: 5 } }),
+  ],
+};
+
+const baseLeague = {
+  week: 3,
+  year: 2026,
+  phase: 'offseason_resign',
+  userTeamId: 1,
+  salaryCap: 200_000_000,
+  teams: [{ id: 1, name: 'Sharks', abbr: 'SHK', wins: 8, losses: 8, capRoom: 30, roster: rosterPayload.players, picks: [], strategies: {} }],
+};
+
+describe('Roster — expiring/re-sign tab priority badges', () => {
+  afterEach(cleanup);
+
+  it('renders priority badges for expiring players in the resign-phase table', async () => {
+    const actions = { getRoster: vi.fn(async () => ({ payload: rosterPayload })) };
+
+    const { findAllByTestId } = render(
+      <Roster
+        league={baseLeague}
+        actions={actions}
+        onPlayerSelect={() => {}}
+        initialState={{ view: 'table', filter: 'ALL' }}
+        initialViewMode="table"
+      />,
+    );
+
+    await waitFor(() => expect(actions.getRoster).toHaveBeenCalledTimes(1));
+
+    // Only Player 1 has a 1-year-or-less contract, so only one badge group should render.
+    const badgeGroups = await findAllByTestId('resign-priority-badges');
+    expect(badgeGroups.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not render raw enum values in the roster list', async () => {
+    const actions = { getRoster: vi.fn(async () => ({ payload: rosterPayload })) };
+
+    const { container, findAllByTestId } = render(
+      <Roster
+        league={baseLeague}
+        actions={actions}
+        onPlayerSelect={() => {}}
+        initialState={{ view: 'table', filter: 'ALL' }}
+        initialViewMode="table"
+      />,
+    );
+
+    await waitFor(() => expect(actions.getRoster).toHaveBeenCalledTimes(1));
+    await findAllByTestId('resign-priority-badges');
+
+    expect(container.textContent).not.toMatch(/priority_resign|resign_if_price|trade_or_tag|replaceable_depth/);
+  });
+});

--- a/src/ui/components/resign/ReSignPriorityBadges.jsx
+++ b/src/ui/components/resign/ReSignPriorityBadges.jsx
@@ -1,0 +1,89 @@
+import React from 'react';
+
+/**
+ * ReSignPriorityBadges — presentational-only priority/risk/urgency/replacement
+ * chips for expiring-contract list rows (Financials + Roster). Renders already
+ * computed recommendation data; never evaluates contract economics itself.
+ *
+ * Accepts capitalized ('High') or lowercase ('high') level strings since
+ * different surfaces normalize case differently upstream.
+ */
+
+const TIER_LABEL = {
+  priority_resign: 'Priority Re-sign',
+  resign_if_price: 'Re-sign if price holds',
+  trade_or_tag: 'Trade / Tag',
+  let_walk: 'Let walk',
+  replaceable_depth: 'Replaceable depth',
+};
+
+const TIER_TONE = {
+  priority_resign: 'high',
+  resign_if_price: 'medium',
+  trade_or_tag: 'medium',
+  let_walk: 'muted',
+  replaceable_depth: 'muted',
+};
+
+const URGENCY_LABEL = { high: 'High urgency', medium: 'Mid urgency', low: 'Low urgency' };
+const RISK_LABEL = { high: 'High risk', medium: 'Med risk', low: 'Low risk' };
+const REPLACEMENT_LABEL = { high: 'Hard to replace', medium: 'Replaceable', low: 'Easy to replace' };
+
+function normalizeLevel(value) {
+  const s = String(value ?? '').trim().toLowerCase();
+  return s === 'high' || s === 'medium' || s === 'low' ? s : null;
+}
+
+function toneClass(tone) {
+  if (tone === 'high') return 'resign-priority-badge--high';
+  if (tone === 'medium') return 'resign-priority-badge--medium';
+  if (tone === 'low') return 'resign-priority-badge--low';
+  return 'resign-priority-badge--muted';
+}
+
+function Badge({ label, tone, extraClass = '', testId }) {
+  return (
+    <span
+      className={`resign-priority-badge ${toneClass(tone)} ${extraClass}`.trim()}
+      data-testid={testId}
+    >
+      {label}
+    </span>
+  );
+}
+
+export default function ReSignPriorityBadges({
+  tier = null,
+  urgency = null,
+  risk = null,
+  replacementDifficulty = null,
+  shortReason = null,
+  compact = false,
+}) {
+  const tierLabel = TIER_LABEL[tier] ?? 'Unrated';
+  const tierTone = TIER_TONE[tier] ?? 'muted';
+
+  const urgencyLevel = normalizeLevel(urgency);
+  const urgencyLabel = urgencyLevel ? URGENCY_LABEL[urgencyLevel] : 'Urgency unknown';
+
+  const riskLevel = normalizeLevel(risk);
+  const riskLabel = riskLevel ? RISK_LABEL[riskLevel] : 'Risk unknown';
+
+  const replacementLevel = normalizeLevel(replacementDifficulty);
+  const replacementLabel = replacementLevel ? REPLACEMENT_LABEL[replacementLevel] : 'Replacement unknown';
+
+  return (
+    <div
+      className={`resign-priority-badges${compact ? ' resign-priority-badges--compact' : ''}`}
+      data-testid="resign-priority-badges"
+    >
+      <div className="resign-priority-badge-row">
+        <Badge label={tierLabel} tone={tierTone} extraClass="resign-priority-badge--tier" testId="resign-priority-badge-tier" />
+        <Badge label={urgencyLabel} tone={urgencyLevel} testId="resign-priority-badge-urgency" />
+        <Badge label={riskLabel} tone={riskLevel} testId="resign-priority-badge-risk" />
+        <Badge label={replacementLabel} tone={replacementLevel} testId="resign-priority-badge-replacement" />
+      </div>
+      {shortReason && <div className="resign-priority-reason">{shortReason}</div>}
+    </div>
+  );
+}

--- a/src/ui/styles/style.css
+++ b/src/ui/styles/style.css
@@ -2974,6 +2974,57 @@ select:disabled {
   margin-top: var(--space-1);
 }
 
+/* Re-sign priority badges (expiring-contract list rows — Financials + Roster) */
+.resign-priority-badges {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.resign-priority-badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.resign-priority-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--hairline-strong);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  line-height: 1.6;
+  white-space: nowrap;
+}
+
+.resign-priority-badge--tier {
+  font-weight: 700;
+}
+
+.resign-priority-badge--high { color: var(--danger); border-color: var(--danger); }
+.resign-priority-badge--medium { color: var(--warning); border-color: var(--warning); }
+.resign-priority-badge--low { color: var(--success); border-color: var(--success); }
+.resign-priority-badge--muted { color: var(--text-muted); border-color: var(--hairline-strong); }
+
+.resign-priority-reason {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.resign-priority-badges--compact .resign-priority-badge-row {
+  gap: 2px;
+}
+
+.resign-priority-badges--compact .resign-priority-badge {
+  padding: 0 var(--space-1);
+}
+
+.resign-priority-badges--compact .resign-priority-reason {
+  display: none;
+}
+
 /* Coaching Role Styles */
 .coaching-role-interface {
     margin: var(--space-4) 0;

--- a/src/ui/utils/contractInsights.js
+++ b/src/ui/utils/contractInsights.js
@@ -89,6 +89,7 @@ export function evaluateResignRecommendation(player, context = {}) {
     label: toLabel(tier),
     tone: toTone(tier),
     reason,
+    score,
     urgency,
     negotiationRisk: risk,
     replacementDifficulty: depthDiff[0].toUpperCase() + depthDiff.slice(1),


### PR DESCRIPTION
Surfaces the existing contract-market recommendation (tier, urgency,
risk, replacement difficulty) as compact badges at the list level in
FinancialsView's expiring dashboard and Roster's offseason re-sign
table/card views, so GMs can triage before opening each player.

- New presentational ReSignPriorityBadges component (no core imports)
- FinancialsView expiring dashboard now sorts rows by recommendation
  score descending, without mutating the source player array
- contractInsights.js exposes the already-computed `score` field so
  the sort has real data to work with
- New CSS classes reuse existing design tokens (--success/--warning/
  --danger/--text-muted, --space-*, --radius-pill)