### PR TITLE
Polish re-sign priority badge details

### DIFF
--- a/src/ui/components/FinancialsView.jsx
+++ b/src/ui/components/FinancialsView.jsx
@@ -665,6 +665,7 @@ export default function FinancialsView({ league, actions }) {
                     urgency={row.rec.urgency}
                     risk={row.rec.negotiationRisk}
                     replacementDifficulty={row.rec.replacementDifficulty}
+                    shortReason={row.rec.reason}
                   />
                   <div style={{ color: 'var(--text-subtle)' }}>Plan: {row.management.contractPlan[0] ? (CONTRACT_PLAN_LABELS[row.management.contractPlan[0]] ?? row.management.contractPlan[0]) : 'None'} · Trade status: {row.management.tradeStatus}</div></div>
                 <div>{row.ovr}/{row.potential ?? row.ovr}</div>

--- a/src/ui/components/__tests__/FinancialsExpiringDashboard.integration.test.jsx
+++ b/src/ui/components/__tests__/FinancialsExpiringDashboard.integration.test.jsx
@@ -1,7 +1,7 @@
 /** @vitest-environment jsdom */
 import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, waitFor, act } from '@testing-library/react';
+import { cleanup, render, waitFor, within } from '@testing-library/react';
 import FinancialsView from '../FinancialsView.jsx';
 
 function makePlayer(overrides = {}) {
@@ -74,6 +74,15 @@ describe('FinancialsView — expiring contracts dashboard', () => {
 
     const badgeGroups = await findAllByTestId('resign-priority-badges');
     expect(badgeGroups.length).toBe(2);
+  });
+
+  it('renders the recommendation reason inside the priority badge group', async () => {
+    const actions = makeActions();
+    const { findAllByTestId } = render(<FinancialsView league={baseLeague} actions={actions} />);
+    await waitFor(() => expect(actions.getRoster).toHaveBeenCalled());
+
+    const badgeGroups = await findAllByTestId('resign-priority-badges');
+    expect(within(badgeGroups[0]).getByText('Priority Re-sign: productive starter at a thin position')).toBeTruthy();
   });
 
   it('sorts expiring rows by recommendation score descending (highest priority first)', async () => {

--- a/src/ui/styles/style.css
+++ b/src/ui/styles/style.css
@@ -3014,7 +3014,7 @@ select:disabled {
 }
 
 .resign-priority-badges--compact .resign-priority-badge-row {
-  gap: 2px;
+  gap: var(--space-1);
 }
 
 .resign-priority-badges--compact .resign-priority-badge {


### PR DESCRIPTION
### Motivation
- Financials expiring dashboard wired the re-sign metadata but omitted the existing recommendation `reason` from the badge group and used a raw `2px` gap in compact mode instead of the design spacing token.

### Description
- Files changed: `src/ui/components/FinancialsView.jsx`, `src/ui/components/__tests__/FinancialsExpiringDashboard.integration.test.jsx`, `src/ui/styles/style.css`.
- Passed `row.rec.reason` into `ReSignPriorityBadges` in `FinancialsView` via `shortReason={row.rec.reason}` so list-level badge explanations match Roster behavior.
- Replaced `.resign-priority-badges--compact .resign-priority-badge-row { gap: 2px; }` with `gap: var(--space-1);` and left compact badge padding unchanged.
- Roster inspection: `classifyExpiringDecision` maps `key: rec.tier`, so `expiringDecision.key` is already the recommendation tier string and the Roster call (`tier={expiringDecision.key}`) was left unchanged.

### Testing
- Updated and ran the relevant tests: `ReSignPriorityBadges` unit tests, `FinancialsExpiringDashboard.integration.test.jsx`, and `RosterResignPriorityBadges.integration.test.jsx` with Vitest; all targeted tests passed (3 files, 26 tests) when executed locally.
- Confirmed `shortReason` now renders inside the Financials badge group by the added assertion in the Financials integration test.
- Confirmed compact badge row gap uses `var(--space-1)` by changing `style.css` and verifying the file diff.
- No gameplay, economy, simulation, or core logic files under `src/core/` were modified, so there are no changes to simulation or save shape.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a473e529740832da13623d770b971da)