### PR TITLE
Add contract decision triage filter tabs to Financials expiring dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.11.0",
         "@playwright/test": "^1.59.1",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.0",
         "@vitejs/plugin-react": "^5.1.4",
         "fake-indexeddb": "^6.2.5",
@@ -2443,7 +2444,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2491,8 +2491,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2713,7 +2712,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2724,7 +2722,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2750,7 +2747,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2949,7 +2945,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2980,8 +2975,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dset": {
       "version": "3.1.4",
@@ -3646,7 +3640,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3828,7 +3821,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3884,8 +3876,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",

--- a/src/ui/components/FinancialsView.jsx
+++ b/src/ui/components/FinancialsView.jsx
@@ -23,6 +23,8 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import FranchiseInvestmentsPanel from "./FranchiseInvestmentsPanel.jsx";
 import { classifyTeamDirection, evaluateResignRecommendation } from "../utils/contractInsights.js";
 import ReSignPriorityBadges from "./resign/ReSignPriorityBadges.jsx";
+import ReSignDecisionTabs from "./resign/ReSignDecisionTabs.jsx";
+import { buildResignDecisionTabs, filterResignDecisionRows, RESIGN_DECISION_DEFAULT_TAB } from "../utils/resignDecisionFilters.js";
 import { CONTRACT_PLAN_LABELS, normalizeManagement } from "../utils/playerManagement.js";
 import InfoTip from "./InfoTip.jsx";
 import { computeRestructureOutcome, isContractRestructureEligible } from "../../core/contracts/restructure.js";
@@ -162,6 +164,7 @@ export default function FinancialsView({ league, actions }) {
   const [notification, setNotification] = useState(null);
   const [contractMarks, setContractMarks] = useState({});
   const [applyingBatch, setApplyingBatch] = useState(false);
+  const [decisionTab, setDecisionTab] = useState(RESIGN_DECISION_DEFAULT_TAB);
 
   const teamId = league?.userTeamId;
   const phase = league?.phase ?? "";
@@ -255,6 +258,15 @@ export default function FinancialsView({ league, actions }) {
     const sortedRows = [...expiring].sort((a, b) => (b.rec?.score ?? 0) - (a.rec?.score ?? 0));
     return { rows: sortedRows, summary };
   }, [enriched, userTeam, league?.week]);
+
+  const decisionTabs = useMemo(
+    () => buildResignDecisionTabs(expiringDashboard.rows, (row) => row.rec),
+    [expiringDashboard.rows],
+  );
+  const filteredExpiringRows = useMemo(
+    () => filterResignDecisionRows(expiringDashboard.rows, (row) => row.rec, decisionTab),
+    [expiringDashboard.rows, decisionTab],
+  );
 
 
   const applyExpiringBatchAction = useCallback(async (flag) => {
@@ -656,8 +668,12 @@ export default function FinancialsView({ league, actions }) {
           <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>
             Recommended focus: {expiringDashboard.summary.expiringStarters >= 3 ? 'address starters now' : 'selective extensions'} · batch mode: {contractMarks.batchAction ? (CONTRACT_PLAN_LABELS[contractMarks.batchAction] ?? contractMarks.batchAction) : 'none'}.
           </div>
+          <ReSignDecisionTabs tabs={decisionTabs} activeTab={decisionTab} onChange={setDecisionTab} />
           <div style={{ maxHeight: 260, overflow: 'auto', border: '1px solid var(--hairline)', borderRadius: 8 }}>
-            {expiringDashboard.rows.map((row) => (
+            {expiringDashboard.rows.length > 0 && filteredExpiringRows.length === 0 && (
+              <div className="resign-decision-empty-state">No expiring players in this bucket.</div>
+            )}
+            {filteredExpiringRows.map((row) => (
               <div key={row.id} style={{ display: 'grid', gridTemplateColumns: '1.3fr repeat(7, minmax(70px, 1fr))', gap: 8, padding: '8px 10px', borderBottom: '1px solid var(--hairline)', fontSize: 12 }}>
                 <div><strong>{row.name}</strong><div style={{ color: 'var(--text-muted)' }}>{row.pos} · age {row.age} · morale {row.morale ?? 70}</div>
                   <ReSignPriorityBadges

--- a/src/ui/components/__tests__/FinancialsExpiringDashboardFilters.test.jsx
+++ b/src/ui/components/__tests__/FinancialsExpiringDashboardFilters.test.jsx
@@ -1,0 +1,189 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, waitFor, fireEvent, within } from '@testing-library/react';
+import FinancialsView from '../FinancialsView.jsx';
+
+function makePlayer(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Player',
+    pos: 'QB',
+    ovr: 70,
+    potential: 70,
+    age: 27,
+    morale: 70,
+    schemeFit: 65,
+    contract: { years: 1, baseAnnual: 6, signingBonus: 0, yearsTotal: 1 },
+    ...overrides,
+  };
+}
+
+// priority_resign: high score (young, high ovr/pot, good morale, thin position).
+const priorityPlayer = makePlayer({
+  id: 201,
+  name: 'Priority Star',
+  pos: 'QB',
+  ovr: 92,
+  potential: 94,
+  age: 24,
+  morale: 85,
+  schemeFit: 75,
+  contract: { years: 1, baseAnnual: 10, signingBonus: 0, yearsTotal: 1 },
+});
+
+// let_walk: old, low morale, low everything.
+const letWalkPlayer = makePlayer({
+  id: 202,
+  name: 'Walk Candidate',
+  pos: 'LB',
+  ovr: 38,
+  potential: 38,
+  age: 39,
+  morale: 28,
+  schemeFit: 45,
+  contract: { years: 1, baseAnnual: 2, signingBonus: 0, yearsTotal: 1 },
+});
+
+// trade_or_tag: elite ovr, big ask, non-contender direction (override fires
+// regardless of replacement difficulty, so deep WR bench below doesn't flip it).
+const tradeOrTagPlayer = makePlayer({
+  id: 203,
+  name: 'Trade Candidate',
+  pos: 'WR',
+  ovr: 88,
+  potential: 88,
+  age: 28,
+  morale: 70,
+  schemeFit: 65,
+  contract: { years: 1, baseAnnual: 30, signingBonus: 0, yearsTotal: 1 },
+  extensionAsk: { baseAnnual: 30 },
+});
+
+// Non-expiring bench depth at WR only, so tradeOrTagPlayer's position is easy
+// to replace while QB/LB (single-occupant positions) stay "high" difficulty —
+// gives the Hard to Replace filter a real positive/negative case to split on.
+const wrBench = [204, 205, 206, 207].map((id) =>
+  makePlayer({ id, name: `WR Depth ${id}`, pos: 'WR', ovr: 65, contract: { years: 3, baseAnnual: 3, signingBonus: 0, yearsTotal: 3 } }),
+);
+
+const rosterPayload = {
+  team: { id: 1, capTotal: 200, capUsed: 150, deadCap: 0, capRoom: 20 },
+  players: [priorityPlayer, letWalkPlayer, tradeOrTagPlayer, ...wrBench],
+};
+
+// Rebuilding direction (low win pct) keeps trade_or_tag classification reachable.
+const baseLeague = {
+  userTeamId: 1,
+  week: 5,
+  year: 2026,
+  phase: 'offseason_resign',
+  teams: [{ id: 1, name: 'Sharks', wins: 2, losses: 14, capRoom: 20 }],
+};
+
+function makeActions(players = rosterPayload.players) {
+  return {
+    getRoster: vi.fn(async () => ({ payload: { ...rosterPayload, players } })),
+  };
+}
+
+async function renderDashboard(players) {
+  const actions = makeActions(players);
+  const utils = render(<FinancialsView league={baseLeague} actions={actions} />);
+  await waitFor(() => expect(actions.getRoster).toHaveBeenCalled());
+  await utils.findAllByTestId('resign-priority-badges');
+  return utils;
+}
+
+describe('FinancialsView — expiring dashboard triage tabs', () => {
+  afterEach(cleanup);
+
+  it('the All tab renders every expiring row', async () => {
+    const { getAllByTestId, getByTestId } = await renderDashboard();
+    expect(getAllByTestId('resign-priority-badges').length).toBe(3);
+    expect(getByTestId('resign-decision-tab-all').textContent).toContain('3');
+  });
+
+  it('the Priority tab only shows priority_resign players', async () => {
+    const { getByTestId, getAllByTestId } = await renderDashboard();
+    fireEvent.click(getByTestId('resign-decision-tab-priority'));
+    const badgeGroups = getAllByTestId('resign-priority-badges');
+    expect(badgeGroups.length).toBe(1);
+    expect(within(badgeGroups[0]).getByTestId('resign-priority-badge-tier').textContent).toBe('Priority Re-sign');
+  });
+
+  it('the Let Walk tab only shows let_walk players', async () => {
+    const { getByTestId, getAllByTestId } = await renderDashboard();
+    fireEvent.click(getByTestId('resign-decision-tab-let_walk'));
+    const badgeGroups = getAllByTestId('resign-priority-badges');
+    expect(badgeGroups.length).toBe(1);
+    expect(within(badgeGroups[0]).getByTestId('resign-priority-badge-tier').textContent).toBe('Let walk');
+  });
+
+  it('the Trade / Tag tab only shows trade_or_tag players', async () => {
+    const { getByTestId, getAllByTestId } = await renderDashboard();
+    fireEvent.click(getByTestId('resign-decision-tab-trade_or_tag'));
+    const badgeGroups = getAllByTestId('resign-priority-badges');
+    expect(badgeGroups.length).toBe(1);
+    expect(within(badgeGroups[0]).getByTestId('resign-priority-badge-tier').textContent).toBe('Trade / Tag');
+  });
+
+  it('the High Risk tab only shows players with high negotiation risk', async () => {
+    const { getByTestId, getAllByTestId } = await renderDashboard();
+    fireEvent.click(getByTestId('resign-decision-tab-high_risk'));
+    const badgeGroups = getAllByTestId('resign-priority-badges');
+    for (const group of badgeGroups) {
+      expect(within(group).getByTestId('resign-priority-badge-risk').textContent).toBe('High risk');
+    }
+    // priorityPlayer has low negotiation risk (high morale, reasonable ask) and is excluded.
+    expect(badgeGroups.length).toBe(2);
+  });
+
+  it('the Hard to Replace tab only shows players with high replacement difficulty', async () => {
+    const { getByTestId, getAllByTestId } = await renderDashboard();
+    fireEvent.click(getByTestId('resign-decision-tab-hard_to_replace'));
+    const badgeGroups = getAllByTestId('resign-priority-badges');
+    for (const group of badgeGroups) {
+      expect(within(group).getByTestId('resign-priority-badge-replacement').textContent).toBe('Hard to replace');
+    }
+    // priorityPlayer (QB) and letWalkPlayer (LB) are the only occupants of their
+    // positions; tradeOrTagPlayer (WR) has a deep bench, so it's excluded here.
+    expect(badgeGroups.length).toBe(2);
+  });
+
+  it('count badges reflect the unfiltered row set regardless of active tab', async () => {
+    const { getByTestId } = await renderDashboard();
+    fireEvent.click(getByTestId('resign-decision-tab-priority'));
+    // Switching tabs must not change any tab's displayed count.
+    expect(getByTestId('resign-decision-tab-all').textContent).toContain('3');
+    expect(getByTestId('resign-decision-tab-let_walk').textContent).toContain('1');
+  });
+
+  it('a zero-count tab remains visible, dimmed, and shows the empty-state message when selected', async () => {
+    // Only a priority_resign player is expiring — every other bucket is empty.
+    const { getByTestId, queryByText } = await renderDashboard([priorityPlayer]);
+
+    const letWalkTab = getByTestId('resign-decision-tab-let_walk');
+    expect(letWalkTab).toBeTruthy();
+    expect(letWalkTab.className).toContain('resign-decision-tab--empty');
+    expect(letWalkTab.textContent).toContain('0');
+
+    fireEvent.click(letWalkTab);
+    expect(queryByText('No expiring players in this bucket.')).toBeTruthy();
+  });
+
+  it('preserves the existing score-descending sort within the filtered result', async () => {
+    // priorityPlayer scores far above tradeOrTagPlayer; both should appear under "All" in that order.
+    const { getByTestId, getAllByTestId } = await renderDashboard();
+    fireEvent.click(getByTestId('resign-decision-tab-all'));
+    const tierBadges = getAllByTestId('resign-priority-badge-tier');
+    expect(tierBadges[0].textContent).toBe('Priority Re-sign');
+  });
+
+  it('does not mutate the source players array when filtering', async () => {
+    const players = [priorityPlayer, letWalkPlayer, tradeOrTagPlayer];
+    const { getByTestId } = await renderDashboard(players);
+    fireEvent.click(getByTestId('resign-decision-tab-let_walk'));
+    expect(players.map((p) => p.id)).toEqual([201, 202, 203]);
+  });
+});

--- a/src/ui/components/resign/ReSignDecisionTabs.jsx
+++ b/src/ui/components/resign/ReSignDecisionTabs.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+/**
+ * ReSignDecisionTabs — presentational triage filter tabs for expiring-contract
+ * list surfaces. Renders precomputed { key, label, count } tabs; never filters
+ * or evaluates recommendations itself.
+ */
+export default function ReSignDecisionTabs({ tabs = [], activeTab, onChange }) {
+  return (
+    <div className="resign-decision-tabs" role="tablist" aria-label="Contract decision filters">
+      {tabs.map((tab) => {
+        const isActive = tab.key === activeTab;
+        const isEmpty = tab.count === 0;
+        return (
+          <button
+            key={tab.key}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            data-testid={`resign-decision-tab-${tab.key}`}
+            className={[
+              'resign-decision-tab',
+              isActive ? 'resign-decision-tab--active' : '',
+              isEmpty ? 'resign-decision-tab--empty' : '',
+            ].filter(Boolean).join(' ')}
+            onClick={() => onChange?.(tab.key)}
+          >
+            <span>{tab.label}</span>
+            <span className="resign-decision-tab-count">{tab.count}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/ui/styles/style.css
+++ b/src/ui/styles/style.css
@@ -3025,6 +3025,62 @@ select:disabled {
   display: none;
 }
 
+/* Contract decision triage tabs (Financials + Roster expiring lists) */
+.resign-decision-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.resign-decision-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--hairline-strong);
+  background: var(--surface-strong);
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  line-height: 1.6;
+  cursor: pointer;
+}
+
+.resign-decision-tab--active {
+  border-color: var(--accent);
+  color: var(--text);
+  background: var(--surface-elevated);
+}
+
+.resign-decision-tab--empty {
+  opacity: 0.5;
+}
+
+.resign-decision-tab-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-pill);
+  background: var(--hairline-strong);
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  font-weight: 600;
+}
+
+.resign-decision-tab--active .resign-decision-tab-count {
+  background: var(--accent);
+  color: #fff;
+}
+
+.resign-decision-empty-state {
+  padding: var(--space-3);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
 /* Coaching Role Styles */
 .coaching-role-interface {
     margin: var(--space-4) 0;

--- a/src/ui/utils/__tests__/resignDecisionFilters.test.js
+++ b/src/ui/utils/__tests__/resignDecisionFilters.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { RESIGN_DECISION_TAB_DEFS, buildResignDecisionTabs, filterResignDecisionRows } from '../resignDecisionFilters.js';
+
+const rows = [
+  { id: 1, rec: { tier: 'priority_resign', negotiationRisk: 'Low', replacementDifficulty: 'High' } },
+  { id: 2, rec: { tier: 'let_walk', negotiationRisk: 'High', replacementDifficulty: 'Low' } },
+  { id: 3, rec: { tier: 'trade_or_tag', negotiationRisk: 'High', replacementDifficulty: 'Medium' } },
+];
+const getDecision = (row) => row.rec;
+
+describe('resignDecisionFilters', () => {
+  it('exposes All, Priority, High Risk, Hard to Replace, Let Walk, Trade / Tag tabs in order', () => {
+    expect(RESIGN_DECISION_TAB_DEFS.map((t) => t.key)).toEqual([
+      'all', 'priority', 'high_risk', 'hard_to_replace', 'let_walk', 'trade_or_tag',
+    ]);
+  });
+
+  it('builds counts from the unfiltered row set', () => {
+    const tabs = buildResignDecisionTabs(rows, getDecision);
+    const byKey = Object.fromEntries(tabs.map((t) => [t.key, t.count]));
+    expect(byKey).toEqual({
+      all: 3, priority: 1, high_risk: 2, hard_to_replace: 1, let_walk: 1, trade_or_tag: 1,
+    });
+  });
+
+  it('filters rows by the active tab without mutating the source array', () => {
+    const original = [...rows];
+    expect(filterResignDecisionRows(rows, getDecision, 'let_walk').map((r) => r.id)).toEqual([2]);
+    expect(filterResignDecisionRows(rows, getDecision, 'trade_or_tag').map((r) => r.id)).toEqual([3]);
+    expect(rows).toEqual(original);
+  });
+
+  it('falls back to the "all" tab for an unknown key', () => {
+    expect(filterResignDecisionRows(rows, getDecision, 'nonsense').length).toBe(3);
+  });
+});

--- a/src/ui/utils/resignDecisionFilters.js
+++ b/src/ui/utils/resignDecisionFilters.js
@@ -1,0 +1,35 @@
+/**
+ * Shared triage-tab config for expiring-contract list surfaces (Financials +
+ * Roster). Filters operate on the already-computed recommendation fields
+ * (tier/negotiationRisk/replacementDifficulty) — never re-derives them.
+ */
+
+function normalizeLevel(value) {
+  return String(value ?? '').trim().toLowerCase();
+}
+
+export const RESIGN_DECISION_TAB_DEFS = [
+  { key: 'all', label: 'All', test: () => true },
+  { key: 'priority', label: 'Priority', test: (d) => d?.tier === 'priority_resign' },
+  { key: 'high_risk', label: 'High Risk', test: (d) => normalizeLevel(d?.negotiationRisk) === 'high' },
+  { key: 'hard_to_replace', label: 'Hard to Replace', test: (d) => normalizeLevel(d?.replacementDifficulty) === 'high' },
+  { key: 'let_walk', label: 'Let Walk', test: (d) => d?.tier === 'let_walk' },
+  { key: 'trade_or_tag', label: 'Trade / Tag', test: (d) => d?.tier === 'trade_or_tag' },
+];
+
+export const RESIGN_DECISION_DEFAULT_TAB = RESIGN_DECISION_TAB_DEFS[0].key;
+
+/** Builds { key, label, count } tabs from an unfiltered row set. */
+export function buildResignDecisionTabs(rows = [], getDecision) {
+  return RESIGN_DECISION_TAB_DEFS.map(({ key, label, test }) => ({
+    key,
+    label,
+    count: rows.filter((row) => test(getDecision(row))).length,
+  }));
+}
+
+/** Returns a new filtered array; never mutates or reorders the source rows. */
+export function filterResignDecisionRows(rows = [], getDecision, activeTabKey) {
+  const def = RESIGN_DECISION_TAB_DEFS.find((t) => t.key === activeTabKey) ?? RESIGN_DECISION_TAB_DEFS[0];
+  return rows.filter((row) => def.test(getDecision(row)));
+}


### PR DESCRIPTION
Adds All/Priority/High Risk/Hard to Replace/Let Walk/Trade-Tag filter
tabs above the Financials expiring contracts list so a GM can triage
re-sign decisions quickly. Tabs read existing rec.tier/negotiationRisk/
replacementDifficulty fields from evaluateResignRecommendation — no
contract/cap/re-sign logic changes. Counts reflect the unfiltered row
set, zero-count tabs stay visible but dimmed, and the existing
score-descending sort and source array are preserved.

Roster's expiring/re-sign surface reuses the same tier/risk/replacement
fields but its "expiring" rows live inside the general roster table's
single-select quick-filter system (posFilter: ALL/EXPIRING/STARTERS/...),
shared across both the table and card-grid renderers. Layering a second
independent filter dimension on top of that safely would require
broader plumbing than this UI-only pass allows, so it's left as a V2
candidate per the task's explicit fallback.

New shared pieces for reuse in that V2 work:
- src/ui/utils/resignDecisionFilters.js — tab defs + count/filter helpers
- src/ui/components/resign/ReSignDecisionTabs.jsx — presentational tabs

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Te4UTLXy3aBvF2V5ZSHEnm