### PR TITLE
State Legacy Quarantine V1 — isolate browser-global state behavior in src/core/state.js

### DIFF
--- a/src/core/state.js
+++ b/src/core/state.js
@@ -1,5 +1,13 @@
-// state-save-manager.js - Unified State Management and Persistence
-// ES Module version - migrated from IIFE pattern
+// state.js — legacy state compatibility module (quarantined).
+//
+// The worker (src/worker/worker.js + IndexedDB cache) is the authoritative
+// league state; UI mutations flow through useWorker actions. This module
+// remains only for legacy schema validation/migration and the localStorage
+// save path. It must not install globals at import time:
+//   - window.state access goes through src/state/legacyStateBridge.js
+//   - save slot storage lives in src/state/saveSlotStorage.js
+//   - stat schemas live in src/state/statsSchema.js
+//   - async stringify lives in src/state/stringifyWorkerClient.js
 
 // Import dependencies
 import { Constants } from './constants.js';
@@ -9,12 +17,28 @@ import {
   buildOwnerProfile,
   determineInitialMandate,
 } from './meta/ownerPressureEngine.js';
+import { getZeroStats, getZeroTeamStats } from '../state/statsSchema.js';
+import {
+  normalizeSlot,
+  getActiveSaveSlot,
+  saveKeyFor,
+  SAVE_KEY_BASE,
+} from '../state/saveSlotStorage.js';
+import {
+  getLegacyState,
+  setLegacyState,
+  patchLegacyState,
+  resetLegacyState,
+  getLegacySaveDelegate,
+} from '../state/legacyStateBridge.js';
+import { asyncStringify } from '../state/stringifyWorkerClient.js';
 
+// Legacy mutable export. Stays null until loadState()/State.reset() runs —
+// nothing is installed eagerly at import time anymore.
 export let state = null;
 
 // --- Configuration Variables ---
 const C = Constants;
-const SAVE_KEY_BASE = (C.GAME_CONFIG && C.GAME_CONFIG.SAVE_KEY) || 'nflGM4.state';
 const YEAR_START = (C.GAME_CONFIG && C.GAME_CONFIG.YEAR_START) || 2025;
 
 const DefaultGameState = {
@@ -25,115 +49,13 @@ const DefaultGameState = {
   deadCap: 0
 };
 
-const MAX_SAVE_SLOTS = 5;
-
-function normalizeSlot(slot) {
-  const parsed = parseInt(slot, 10);
-  if (isNaN(parsed) || parsed < 1) return 1;
-  if (parsed > MAX_SAVE_SLOTS) return MAX_SAVE_SLOTS;
-  return parsed;
-}
-
-function getActiveSaveSlot() {
-  if (typeof window === 'undefined') return 1;
-  const stored = window.localStorage.getItem('nflGM4.activeSlot');
-  return normalizeSlot(stored || 1);
-}
-
-function setActiveSaveSlot(slot) {
-  const normalized = normalizeSlot(slot);
-  if (typeof window === 'undefined') return normalized;
-  try {
-    window.localStorage.setItem('nflGM4.activeSlot', normalized);
-    if (window.state) {
-      window.state.saveSlot = normalized;
-    }
-  } catch (err) {
-    console.warn('Unable to persist active save slot', err);
-  }
-  return normalized;
-}
-
-function saveKeyFor(slot) {
-  const normalized = normalizeSlot(slot);
-  return `${SAVE_KEY_BASE}.slot${normalized}`;
-}
-
 // Game Routes (used for UI)
 const routes = [
   'hub', 'roster', 'cap', 'schedule', 'standings', 'trade', 'freeagency',
   'draft', 'playoffs', 'settings', 'hallOfFame', 'scouting'
 ];
 
-// --- Name Data (Fallbacks for Player Generation) ---
-const FIRST_NAMES = (typeof window !== 'undefined' && window.EXPANDED_FIRST_NAMES) || [
-  'James', 'Michael', 'John', 'Robert', 'David', 'William', 'Richard', 'Joseph', 
-  'Thomas', 'Christopher', 'Matthew', 'Anthony', 'Mark', 'Steven', 'Andrew', 'Joshua'
-];
-const LAST_NAMES = (typeof window !== 'undefined' && window.EXPANDED_LAST_NAMES) || [
-  'Smith', 'Johnson', 'Williams', 'Brown', 'Jones', 'Garcia', 'Miller', 'Davis', 
-  'Rodriguez', 'Martinez', 'Hernandez', 'Lopez', 'Gonzalez', 'Wilson', 'Anderson'
-];
-
 // --- State Management System ---
-
-/**
- * Returns an object with common stats initialized to 0.
- * @returns {Object} Zeroed stats object
- */
-// Exported as the single source of truth for the full per-season stat schema.
-// Season archival (worker.archiveSeason) reads these keys so no tracked field is
-// silently dropped from career history. Do not prune fields here.
-export function getZeroStats() {
-  return {
-    // General
-    gamesPlayed: 0,
-
-    // Passing
-    passYd: 0, passTD: 0, interceptions: 0, passAtt: 0, passComp: 0, sacks: 0,
-    dropbacks: 0, longestPass: 0, completionPct: 0, passerRating: 0, sackPct: 0,
-
-    // Rushing
-    rushYd: 0, rushTD: 0, rushAtt: 0, fumbles: 0,
-    longestRun: 0, yardsPerCarry: 0,
-
-    // Receiving
-    recYd: 0, recTD: 0, receptions: 0, targets: 0, drops: 0,
-    yardsAfterCatch: 0, longestCatch: 0, routesRun: 0, targetsWithSeparation: 0,
-    dropRate: 0, separationRate: 0,
-
-    // Defense
-    tackles: 0, forcedFumbles: 0, passesDefended: 0, tacklesForLoss: 0,
-    coverageRating: 0, targetsAllowed: 0, completionsAllowed: 0, yardsAllowed: 0, tdsAllowed: 0,
-    pressureRating: 0, passRushSnaps: 0, pressures: 0, pressureRate: 0,
-
-    // Offensive Line
-    sacksAllowed: 0, tacklesForLossAllowed: 0, protectionGrade: 0,
-
-    // Kicking/Punting
-    fgMade: 0, fgAttempts: 0, xpMade: 0, xpAttempts: 0, punts: 0, puntYards: 0,
-    fgMissed: 0, longestFG: 0, xpMissed: 0, successPct: 0, avgKickYards: 0,
-    avgPuntYards: 0, longestPunt: 0
-  };
-}
-
-/**
- * Returns an object with team stats initialized to 0.
- * @returns {Object} Zeroed team stats object
- */
-function getZeroTeamStats() {
-    return {
-        wins: 0, losses: 0, ties: 0,
-        ptsFor: 0, ptsAgainst: 0,
-        passYds: 0, rushYds: 0,
-        passTD: 0, rushTD: 0,
-        turnovers: 0,
-        sacks: 0,
-        // Game specific
-        thirdDownAttempts: 0, thirdDownConversions: 0,
-        redZoneTrips: 0, redZoneTDs: 0
-    };
-}
 
 /**
  * Centralized utility object for managing the game state schema.
@@ -145,14 +67,14 @@ export const State = {
    */
   init() {
 
-    
+
     const freshState = {
       // Core game data
       league: null,
       season: DefaultGameState.season, // Use DefaultGameState
       week: DefaultGameState.week, // Use DefaultGameState
       year: YEAR_START,
-      
+
       // Financial defaults
       salaryCap: DefaultGameState.salaryCap,
       currentFunds: DefaultGameState.currentFunds,
@@ -165,13 +87,13 @@ export const State = {
         role: 'GM'
       },
       userTeamId: 0,
-      
+
       // Game settings
       namesMode: 'fictional',  // 'fictional' or 'real'
       gameMode: 'gm',         // 'gm' or 'career'
       playerRole: 'GM',       // 'GM', 'OC', 'DC'
       onboarded: false,
-      
+
       // Game systems
       freeAgents: [],
       draftClass: [],
@@ -183,11 +105,11 @@ export const State = {
         version: 1,
         lastEvolutionStamp: null,
       },
-      
+
       // User interface
       currentView: 'hub',
       theme: 'dark',
-      
+
       // Settings
       settings: {
         autoSave: true,
@@ -201,17 +123,17 @@ export const State = {
 
       // Persistence helpers
       saveSlot: getActiveSaveSlot(),
-      
+
       // Version info and persistence
       version: '4.0.0',
       lastSaved: null,
       created: new Date().toISOString()
     };
-    
+
 
     return freshState;
   },
-  
+
   /**
    * ENHANCED: Comprehensive state validation with nested structure checks
    */
@@ -219,30 +141,30 @@ export const State = {
     if (!stateObj || typeof stateObj !== 'object') {
       return { valid: false, errors: ['State is null or undefined'], warnings: [] };
     }
-    
+
     const errors = [];
     const warnings = [];
-    
+
     // Required top-level properties
     const requiredProps = [
       'namesMode', 'onboarded', 'gameMode', 'playerRole', 'userTeamId', 'version'
     ];
-    
+
     requiredProps.forEach(prop => {
       if (stateObj[prop] === undefined) {
         errors.push(`Missing required property: ${prop}`);
       }
     });
-    
+
     // Value validation
     if (stateObj.namesMode && !['fictional', 'real'].includes(stateObj.namesMode)) {
       errors.push('Invalid namesMode');
     }
-    
+
     if (stateObj.userTeamId !== undefined && (typeof stateObj.userTeamId !== 'number' || stateObj.userTeamId < 0)) {
       errors.push('Invalid userTeamId');
     }
-    
+
     // Validate league structure if present
     if (stateObj.league) {
       const leagueErrors = this.validateLeague(stateObj.league);
@@ -250,66 +172,66 @@ export const State = {
     } else {
       warnings.push('No league data present (new game?)');
     }
-    
+
     // Validate nested collections
     if (stateObj.freeAgents && !Array.isArray(stateObj.freeAgents)) {
       errors.push('freeAgents must be an array');
     }
-    
+
     if (stateObj.draftClass && !Array.isArray(stateObj.draftClass)) {
       errors.push('draftClass must be an array');
     }
-    
+
     if (stateObj.pendingOffers && !Array.isArray(stateObj.pendingOffers)) {
       errors.push('pendingOffers must be an array');
     }
-    
+
     // Validate settings structure
     if (stateObj.settings && typeof stateObj.settings !== 'object') {
       errors.push('settings must be an object');
     }
-    
+
     // Check for data integrity issues
     if (stateObj.league && stateObj.league.teams) {
       const teamCount = stateObj.league.teams.length;
       if (teamCount !== 32 && teamCount !== 0) {
         warnings.push(`Unexpected team count: ${teamCount} (expected 32 or 0 for new game)`);
       }
-      
+
       // Validate userTeamId is within bounds
       if (stateObj.userTeamId >= teamCount && teamCount > 0) {
         errors.push(`userTeamId (${stateObj.userTeamId}) out of bounds for ${teamCount} teams`);
       }
     }
-    
-    return { 
-      valid: errors.length === 0, 
-      errors, 
+
+    return {
+      valid: errors.length === 0,
+      errors,
       warnings,
       schemaVersion: stateObj.version || 'unknown'
     };
   },
-  
+
   /**
    * Validate league structure
    */
   validateLeague(league) {
     const errors = [];
-    
+
     if (!league || typeof league !== 'object') {
       errors.push('League must be an object');
       return errors;
     }
-    
+
     // Check required league properties
     if (league.year !== undefined && (typeof league.year !== 'number' || league.year < 2020 || league.year > 2100)) {
       errors.push('Invalid league.year');
     }
-    
+
     if (league.week !== undefined && (typeof league.week !== 'number' || league.week < 1 || league.week > 25)) {
       errors.push('Invalid league.week');
     }
-    
+
     // Validate teams array
     if (league.teams) {
       if (!Array.isArray(league.teams)) {
@@ -320,17 +242,17 @@ export const State = {
             errors.push(`Team at index ${index} is invalid`);
             return;
           }
-          
+
           // Check team has required properties
           if (!team.name && !team.abbr) {
             errors.push(`Team at index ${index} missing name/abbr`);
           }
-          
+
           // Validate roster if present
           if (team.roster && !Array.isArray(team.roster)) {
             errors.push(`Team ${index} roster must be an array`);
           }
-          
+
           // Validate picks if present
           if (team.picks && !Array.isArray(team.picks)) {
             errors.push(`Team ${index} picks must be an array`);
@@ -338,30 +260,30 @@ export const State = {
         });
       }
     }
-    
+
     return errors;
   },
-  
+
   /**
    * ENHANCED: Version-aware migration with schema updates
    */
   migrate(oldState) {
     if (!oldState) return this.init();
-    
+
     const oldVersion = oldState.version || '1.0.0';
 
-    
+
     let migratedState = { ...oldState };
-    
+
     // Version-specific migrations
     if (this.compareVersions(oldVersion, '4.0.0') < 0) {
       // Migrate from pre-4.0.0
       migratedState = this.migrateToV4(migratedState);
     }
-    
+
     // Always ensure current schema structure
     const newState = this.init();
-    
+
     // Safe copy function with type checking
     const safeCopy = (prop, fallback, validator = null) => {
       const value = migratedState[prop];
@@ -376,7 +298,7 @@ export const State = {
         newState[prop] = fallback;
       }
     };
-    
+
     // Copy core properties with validation
     safeCopy('league', null, (v) => typeof v === 'object');
     safeCopy('freeAgents', [], (v) => Array.isArray(v));
@@ -403,52 +325,52 @@ export const State = {
     if (migratedState.settings && typeof migratedState.settings === 'object') {
       newState.settings = { ...newState.settings, ...migratedState.settings };
     }
-    
+
     // Migrate league structure if present
     if (migratedState.league) {
       newState.league = this.migrateLeague(migratedState.league);
     }
-    
+
     // Final updates
     newState.version = this.init().version;
     newState.lastSaved = new Date().toISOString();
-    
+
     // Preserve creation date if exists
     if (migratedState.created) {
       newState.created = migratedState.created;
     }
-    
+
 
     return newState;
   },
-  
+
   /**
    * Migrate league structure
    */
   migrateLeague(league) {
     if (!league || typeof league !== 'object') return null;
-    
+
     const migrated = { ...league };
-    
+
     // Ensure teams array exists and is valid
     if (!Array.isArray(migrated.teams)) {
       migrated.teams = [];
     }
-    
+
     // Migrate each team
     migrated.teams = migrated.teams.map((team, index) => {
       if (!team || typeof team !== 'object') {
         console.warn(`Invalid team at index ${index}, skipping`);
         return null;
       }
-      
+
       const migratedTeam = { ...team };
-      
+
       // Ensure roster is array
       if (!Array.isArray(migratedTeam.roster)) {
         migratedTeam.roster = [];
       }
-      
+
       // Ensure picks is array
       if (!Array.isArray(migratedTeam.picks)) {
         migratedTeam.picks = [];
@@ -486,11 +408,11 @@ export const State = {
       if (!migratedTeam.stats) {
         migratedTeam.stats = { season: getZeroTeamStats(), game: getZeroTeamStats() };
       }
-      
+
       // Migrate player structures if needed
       migratedTeam.roster = migratedTeam.roster.map(player => {
         if (!player || typeof player !== 'object') return null;
-        
+
         // Ensure player has required properties
         const migratedPlayer = { ...player };
         if (!migratedPlayer.id) {
@@ -513,13 +435,13 @@ export const State = {
           if (!migratedPlayer.stats.career) migratedPlayer.stats.career = getZeroStats();
           else if (Object.keys(migratedPlayer.stats.career).length === 0) migratedPlayer.stats.career = getZeroStats();
         }
-        
+
         return ensureFaceConfig(migratedPlayer, 'player');
       }).filter(p => p !== null);
-      
+
       return migratedTeam;
     }).filter(t => t !== null);
-    
+
     migrated.newsItems = migrated?.newsItems ?? [];
     migrated.ownerGoals = migrated?.ownerGoals ?? [];
     migrated.retiredPlayers = migrated?.retiredPlayers ?? [];
@@ -604,7 +526,7 @@ export const State = {
     if (!migrated.records) {
       migrated.records = {};
     }
-    
+
     // Ensure history structure exists
     if (!migrated.history) {
       migrated.history = {
@@ -614,16 +536,16 @@ export const State = {
         coachRankings: []
       };
     }
-    
+
     return migrated;
   },
-  
+
   /**
    * Migrate to version 4.0.0 schema
    */
   migrateToV4(state) {
 
-    
+
     // Add new properties that didn't exist in older versions
     if (!state.settings) {
       state.settings = {
@@ -636,45 +558,39 @@ export const State = {
         allowCoachFiring: true
       };
     }
-    
+
     // Ensure version is set
     state.version = '4.0.0';
-    
+
     return state;
   },
-  
+
   /**
    * Compare version strings (returns -1, 0, or 1)
    */
   compareVersions(v1, v2) {
     const parts1 = v1.split('.').map(Number);
     const parts2 = v2.split('.').map(Number);
-    
+
     for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
       const part1 = parts1[i] || 0;
       const part2 = parts2[i] || 0;
-      
+
       if (part1 < part2) return -1;
       if (part1 > part2) return 1;
     }
-    
+
     return 0;
   },
-  
+
   /**
    * Reset state to initial values.
+   * Legacy consumers hold references to the global state object, so the
+   * bridge clears it in place rather than swapping the object identity.
    */
   reset() {
-
-    const newState = this.init();
-    // Clear all properties on the existing global state object
-    Object.keys(window.state).forEach(key => {
-      delete window.state[key];
-    });
-    // Assign new properties
-    Object.assign(window.state, newState);
-    state = window.state;
-    return window.state;
+    state = resetLegacyState(() => this.init());
+    return state;
   }
 };
 
@@ -687,7 +603,7 @@ export const State = {
 export async function loadState() {
   try {
 
-    
+
     const activeSlot = getActiveSaveSlot();
     const activeKey = saveKeyFor(activeSlot);
     let saved = window.localStorage.getItem(activeKey);
@@ -701,17 +617,17 @@ export async function loadState() {
 
       return null;
     }
-    
+
     const parsed = JSON.parse(saved);
     const validation = State.validate(parsed);
-    
+
     let loadedState;
-    
+
     // Show warnings if any
     if (validation.warnings && validation.warnings.length > 0) {
       console.warn('State validation warnings:', validation.warnings);
     }
-    
+
     // Migrate if invalid, outdated, or has errors
     if (!validation.valid || parsed.version !== State.init().version || validation.errors.length > 0) {
       if (validation.errors.length > 0) {
@@ -720,7 +636,7 @@ export async function loadState() {
 
       }
       loadedState = State.migrate(parsed);
-      
+
       // Re-validate after migration
       const postMigrationValidation = State.validate(loadedState);
       if (!postMigrationValidation.valid) {
@@ -732,11 +648,10 @@ export async function loadState() {
 
       loadedState = parsed;
     }
-    
-    // Overwrite/initialize global state with loaded data
-    window.state = window.state || State.init();
-    Object.assign(window.state, loadedState, { saveSlot: activeSlot });
-    state = window.state;
+
+    // Overwrite/initialize global state with loaded data (bridge-managed)
+    setLegacyState(getLegacyState() || State.init());
+    state = patchLegacyState({ ...loadedState, saveSlot: activeSlot });
 
     if (legacyKeyUsed) {
       // Re-save into the active slot to migrate forward
@@ -744,8 +659,8 @@ export async function loadState() {
       try { window.localStorage.removeItem(SAVE_KEY_BASE); } catch (err) { /* ignore */ }
     }
 
-    return window.state;
-    
+    return state;
+
   } catch (error) {
     console.error('Error loading state:', error);
     return null;
@@ -754,7 +669,7 @@ export async function loadState() {
 
 /**
  * Save the entire game state to localStorage.
- * @param {Object} stateToSave - State to save (optional, uses window.state by default)
+ * @param {Object} stateToSave - State to save (optional, uses legacy global state by default)
  * @returns {boolean} Success status
  */
 function optimizeResultsByWeek(resultsByWeek, keepBoxScoreWeeks = 1) {
@@ -830,70 +745,19 @@ function prepareStateForSave(stateObj, { keepBoxScoreWeeks = 1 } = {}) {
   };
 }
 
-
-// --- Offload JSON.stringify to a worker to prevent blocking main thread ---
-let _stringifyWorker = null;
-let _stringifyCallbacks = {};
-let _stringifyId = 0;
-
-function asyncStringify(obj) {
-  if (typeof window === 'undefined' || !window.Worker || !window.Blob || !window.URL) {
-    return Promise.resolve(JSON.stringify(obj));
-  }
-
-  if (!_stringifyWorker) {
-    const code = `
-      self.onmessage = function(e) {
-        try {
-          const str = JSON.stringify(e.data.obj);
-          self.postMessage({ id: e.data.id, str });
-        } catch (err) {
-          self.postMessage({ id: e.data.id, error: err.message });
-        }
-      };
-    `;
-    try {
-      const blob = new Blob([code], { type: 'application/javascript' });
-      _stringifyWorker = new Worker(URL.createObjectURL(blob));
-      _stringifyWorker.onmessage = function(e) {
-        const { id, str, error } = e.data;
-        if (_stringifyCallbacks[id]) {
-          if (error) _stringifyCallbacks[id].reject(new Error(error));
-          else _stringifyCallbacks[id].resolve(str);
-          delete _stringifyCallbacks[id];
-        }
-      };
-    } catch(err) {
-      console.warn('Failed to create stringify worker, falling back to sync', err);
-      return Promise.resolve(JSON.stringify(obj));
-    }
-  }
-
-  return new Promise((resolve, reject) => {
-    const id = ++_stringifyId;
-    _stringifyCallbacks[id] = { resolve, reject };
-    try {
-      _stringifyWorker.postMessage({ id, obj });
-    } catch(err) {
-      delete _stringifyCallbacks[id];
-      reject(err);
-    }
-  });
-}
-
 export async function saveState(stateToSave = null, options = {}) {
   try {
-    const stateObj = stateToSave || window.state;
+    const stateObj = stateToSave || getLegacyState();
 
-    
+
     if (!stateObj) {
       console.error('No state object available to save');
       return false;
     }
-    
+
     // Update save timestamp
     stateObj.lastSaved = new Date().toISOString();
-    
+
     // Ensure current version is recorded
     if (!stateObj.version) stateObj.version = State.init().version;
 
@@ -901,12 +765,13 @@ export async function saveState(stateToSave = null, options = {}) {
       keepBoxScoreWeeks: options.keepBoxScoreWeeks ?? 1
     });
 
-    // Use Dashboard Save System if available.
-    // This ensures auto-saves via beforeunload go to the same DB as manual saves.
-    // Priority: use worker-based save if available to avoid main-thread serialization blocking.
-    if (typeof window !== 'undefined' && window.saveGame && !options.legacyOnly) {
-        // Pass object directly to window.saveGame - do NOT stringify here
-        await window.saveGame(stateForSave, options);
+    // Use Dashboard Save System if available (read via the legacy bridge).
+    // This ensures auto-saves via beforeunload go to the same DB as manual
+    // saves, and avoids main-thread serialization blocking.
+    const legacySaveDelegate = getLegacySaveDelegate();
+    if (legacySaveDelegate && !options.legacyOnly) {
+        // Pass object directly to the delegate - do NOT stringify here
+        await legacySaveDelegate(stateForSave, options);
         return true;
     }
 
@@ -917,7 +782,7 @@ export async function saveState(stateToSave = null, options = {}) {
     const saveKey = saveKeyFor(activeSlot);
     window.localStorage.setItem(saveKey, serialized);
 
-    
+
 
 
     if (typeof window.setStatus === 'function') {
@@ -930,9 +795,9 @@ export async function saveState(stateToSave = null, options = {}) {
     if (error?.name === 'QuotaExceededError') {
       console.warn('Save failed: storage quota exceeded');
       try {
-        const fallbackState = prepareStateForSave(stateToSave || window.state, { keepBoxScoreWeeks: 0 });
+        const fallbackState = prepareStateForSave(stateToSave || getLegacyState(), { keepBoxScoreWeeks: 0 });
         const fallbackSerialized = await asyncStringify(fallbackState);
-        const activeSlot = (stateToSave || window.state)?.saveSlot || getActiveSaveSlot();
+        const activeSlot = (stateToSave || getLegacyState())?.saveSlot || getActiveSaveSlot();
         const saveKey = saveKeyFor(activeSlot);
         window.localStorage.setItem(saveKey, fallbackSerialized);
         if (typeof window.setStatus === 'function') {
@@ -973,10 +838,13 @@ export function clearSavedState(slot = null) {
 
 /**
  * Set up an automatic save when the user closes the tab/window.
+ * No longer installed at import time — legacy callers must opt in explicitly.
  */
 export function hookAutoSave() {
+  if (typeof window === 'undefined') return;
   // Only hook if setting is enabled, if it exists
-  if (!window.state || window.state.settings?.autoSave !== false) {
+  const legacyState = getLegacyState();
+  if (!legacyState || legacyState.settings?.autoSave !== false) {
     window.addEventListener('beforeunload', function () {
       try {
         // Attempt save, but don't await (browser may kill it if async)
@@ -989,44 +857,17 @@ export function hookAutoSave() {
   }
 }
 
-export function getSaveMetadata(slot) {
-  const normalized = normalizeSlot(slot);
-  const key = saveKeyFor(normalized);
-  const raw = window.localStorage.getItem(key);
-  if (!raw) return null;
-  try {
-    const parsed = JSON.parse(raw);
-    return {
-      slot: normalized,
-      lastSaved: parsed.lastSaved || null,
-      team: parsed.league?.teams?.[parsed.userTeamId || 0]?.name || null,
-      season: parsed.season || 1,
-      mode: parsed.namesMode || 'fictional'
-    };
-  } catch (err) {
-    console.warn('Could not parse save metadata for slot', normalized, err);
-    return null;
-  }
-}
-
-export function listSaveSlots() {
-  const slots = [];
-  for (let i = 1; i <= MAX_SAVE_SLOTS; i++) {
-    slots.push(getSaveMetadata(i));
-  }
-  return slots;
-}
-
 // --- UI/Helper Functions ---
 
 /**
  * Get current team based on user selection
  */
 export function currentTeam() {
-  const L = window.state?.league;
+  const legacyState = getLegacyState();
+  const L = legacyState?.league;
   if (!L || !L.teams) return null;
-  
-  const teamId = window.state.userTeamId || window.state.player?.teamId || 0;
+
+  const teamId = legacyState.userTeamId || legacyState.player?.teamId || 0;
   return L.teams[teamId] || null;
 }
 
@@ -1034,9 +875,9 @@ export function currentTeam() {
  * Get teams by conference
  */
 export function getTeamsByConference(conference) {
-  const L = window.state?.league;
+  const L = getLegacyState()?.league;
   if (!L || !L.teams) return [];
-  
+
   return L.teams.filter(team => team.conf === conference);
 }
 
@@ -1044,70 +885,26 @@ export function getTeamsByConference(conference) {
  * Get teams by division
  */
 export function getTeamsByDivision(conference, division) {
-  const L = window.state?.league;
+  const L = getLegacyState()?.league;
   if (!L || !L.teams) return [];
-  
+
   return L.teams.filter(team => team.conf === conference && team.div === division);
 }
 
-// Export utility functions
-export { getActiveSaveSlot, setActiveSaveSlot, saveKeyFor };
-
+// Legacy compat: coaching.js still calls window.currentTeam(). This installs
+// a plain read helper, not global state — remove once coaching imports it.
 if (typeof window !== 'undefined') {
     window.currentTeam = currentTeam;
 }
 
-// --- Backward Compatibility & Initialization ---
-
-/**
- * Initialize the global state object if it doesn't exist.
- * Attempt to load a saved game first.
- */
-async function initializeGlobalState() {
-  if (!window.state) {
-    // Try to load state first (async)
-    // NOTE: GameController also handles init, so this is a backup/fallback.
-    try {
-        const loaded = await loadState();
-        if (!loaded) {
-
-            window.state = State.init();
-        }
-    } catch (e) {
-        console.warn('Auto-init failed load:', e);
-        window.state = State.init();
-    }
-  } else {
-
-  }
-  state = window.state;
-}
-
-// Initialize state immediately (Basic init only, load is deferred to GameController)
-if (typeof window !== 'undefined') {
-  if (!window.state) {
-      window.state = State.init();
-  }
-  state = window.state;
-
-  // Install autosave hook
-  hookAutoSave();
-}
+// Re-export extracted helpers so legacy imports of this module keep working.
+export { getZeroStats } from '../state/statsSchema.js';
+export {
+  getActiveSaveSlot,
+  setActiveSaveSlot,
+  saveKeyFor,
+  getSaveMetadata,
+  listSaveSlots,
+} from '../state/saveSlotStorage.js';
 
 export const init = State.init;
-
-// Expose name arrays for generation (if they were not globally defined already)
-// Copy-then-Modify pattern: Ensure we have mutable copies on the window object
-// We must handle the case where these are getters (from Constants) by deleting them first
-if (typeof window !== 'undefined') {
-  const currentFirstNames = window.FIRST_NAMES || FIRST_NAMES;
-  const currentLastNames = window.LAST_NAMES || LAST_NAMES;
-
-  try { delete window.FIRST_NAMES; } catch (e) {}
-  try { delete window.LAST_NAMES; } catch (e) {}
-
-  window.FIRST_NAMES = [...currentFirstNames];
-  window.LAST_NAMES = [...currentLastNames];
-
-
-}

--- a/src/state/legacyStateBridge.js
+++ b/src/state/legacyStateBridge.js
@@ -1,0 +1,63 @@
+// legacyStateBridge.js — the ONLY module allowed to touch window.state.
+//
+// The worker (src/worker/worker.js + IndexedDB cache) is the authoritative
+// league state. window.state exists purely for legacy compatibility: old
+// modules and E2E tests still read it. Every remaining write to that global
+// is funneled through this bridge so legacy behavior stays quarantined in
+// one file and can eventually be deleted wholesale.
+//
+// Do not add app logic here. Do not import this from new feature code.
+
+function hasWindow() {
+  return typeof window !== 'undefined';
+}
+
+// Read the legacy global state object, or null when absent / not in a browser.
+export function getLegacyState() {
+  if (!hasWindow()) return null;
+  return window.state || null;
+}
+
+// Replace the legacy global state object outright.
+export function setLegacyState(nextState) {
+  if (!hasWindow()) return nextState;
+  window.state = nextState;
+  return window.state;
+}
+
+// Shallow-merge a patch into the legacy state, only if it already exists.
+// Mirrors the old inline `if (window.state) window.state.foo = …` writes.
+export function patchLegacyState(patch) {
+  const current = getLegacyState();
+  if (!current || !patch || typeof patch !== 'object') return current;
+  Object.assign(current, patch);
+  return current;
+}
+
+// Reset the legacy state to a fresh object produced by `factory`.
+//
+// Legacy modules hold direct references to the state object, so when one
+// already exists its identity must be preserved: clear every key in place,
+// then assign the fresh values (the delete-loop that used to live in
+// src/core/state.js). When no state exists yet, install the fresh object.
+export function resetLegacyState(factory) {
+  const fresh = typeof factory === 'function' ? factory() : {};
+  if (!hasWindow()) return fresh;
+  if (!window.state || typeof window.state !== 'object') {
+    window.state = fresh;
+    return window.state;
+  }
+  Object.keys(window.state).forEach((key) => {
+    delete window.state[key];
+  });
+  Object.assign(window.state, fresh);
+  return window.state;
+}
+
+// Legacy save delegate: the dashboard save system installs window.saveGame.
+// src/core/state.js must not read window.saveGame directly — it asks the
+// bridge, keeping the dual save path visible in exactly one place.
+export function getLegacySaveDelegate() {
+  if (!hasWindow()) return null;
+  return typeof window.saveGame === 'function' ? window.saveGame : null;
+}

--- a/src/state/saveSlotStorage.js
+++ b/src/state/saveSlotStorage.js
@@ -1,0 +1,75 @@
+// saveSlotStorage.js — active save slot selection + slot-keyed localStorage.
+//
+// Extracted from src/core/state.js. Key names and normalization are part of
+// the on-disk save compatibility contract — do not change them:
+//   nflGM4.activeSlot          → active slot number (1..MAX_SAVE_SLOTS)
+//   <SAVE_KEY_BASE>.slot<N>    → serialized state per slot
+//   <SAVE_KEY_BASE>            → legacy single-save key (migrated by loadState)
+
+import { Constants } from '../core/constants.js';
+import { patchLegacyState } from './legacyStateBridge.js';
+
+const C = Constants;
+
+export const SAVE_KEY_BASE = (C.GAME_CONFIG && C.GAME_CONFIG.SAVE_KEY) || 'nflGM4.state';
+export const MAX_SAVE_SLOTS = 5;
+
+const ACTIVE_SLOT_KEY = 'nflGM4.activeSlot';
+
+export function normalizeSlot(slot) {
+  const parsed = parseInt(slot, 10);
+  if (isNaN(parsed) || parsed < 1) return 1;
+  if (parsed > MAX_SAVE_SLOTS) return MAX_SAVE_SLOTS;
+  return parsed;
+}
+
+export function getActiveSaveSlot() {
+  if (typeof window === 'undefined') return 1;
+  const stored = window.localStorage.getItem(ACTIVE_SLOT_KEY);
+  return normalizeSlot(stored || 1);
+}
+
+export function setActiveSaveSlot(slot) {
+  const normalized = normalizeSlot(slot);
+  if (typeof window === 'undefined') return normalized;
+  try {
+    window.localStorage.setItem(ACTIVE_SLOT_KEY, normalized);
+    patchLegacyState({ saveSlot: normalized });
+  } catch (err) {
+    console.warn('Unable to persist active save slot', err);
+  }
+  return normalized;
+}
+
+export function saveKeyFor(slot) {
+  const normalized = normalizeSlot(slot);
+  return `${SAVE_KEY_BASE}.slot${normalized}`;
+}
+
+export function getSaveMetadata(slot) {
+  const normalized = normalizeSlot(slot);
+  const key = saveKeyFor(normalized);
+  const raw = window.localStorage.getItem(key);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return {
+      slot: normalized,
+      lastSaved: parsed.lastSaved || null,
+      team: parsed.league?.teams?.[parsed.userTeamId || 0]?.name || null,
+      season: parsed.season || 1,
+      mode: parsed.namesMode || 'fictional'
+    };
+  } catch (err) {
+    console.warn('Could not parse save metadata for slot', normalized, err);
+    return null;
+  }
+}
+
+export function listSaveSlots() {
+  const slots = [];
+  for (let i = 1; i <= MAX_SAVE_SLOTS; i++) {
+    slots.push(getSaveMetadata(i));
+  }
+  return slots;
+}

--- a/src/state/statsSchema.js
+++ b/src/state/statsSchema.js
@@ -1,0 +1,56 @@
+// statsSchema.js — canonical zeroed stat schemas.
+//
+// Extracted from src/core/state.js so runtime code (worker, sim, tests) can
+// import the stat schema without pulling in the legacy state/persistence
+// module. Pure data — this module must stay free of imports and side effects.
+
+// Single source of truth for the full per-season stat schema.
+// Season archival (worker.archiveSeason) reads these keys so no tracked field
+// is silently dropped from career history. Do not prune fields here.
+export function getZeroStats() {
+  return {
+    // General
+    gamesPlayed: 0,
+
+    // Passing
+    passYd: 0, passTD: 0, interceptions: 0, passAtt: 0, passComp: 0, sacks: 0,
+    dropbacks: 0, longestPass: 0, completionPct: 0, passerRating: 0, sackPct: 0,
+
+    // Rushing
+    rushYd: 0, rushTD: 0, rushAtt: 0, fumbles: 0,
+    longestRun: 0, yardsPerCarry: 0,
+
+    // Receiving
+    recYd: 0, recTD: 0, receptions: 0, targets: 0, drops: 0,
+    yardsAfterCatch: 0, longestCatch: 0, routesRun: 0, targetsWithSeparation: 0,
+    dropRate: 0, separationRate: 0,
+
+    // Defense
+    tackles: 0, forcedFumbles: 0, passesDefended: 0, tacklesForLoss: 0,
+    coverageRating: 0, targetsAllowed: 0, completionsAllowed: 0, yardsAllowed: 0, tdsAllowed: 0,
+    pressureRating: 0, passRushSnaps: 0, pressures: 0, pressureRate: 0,
+
+    // Offensive Line
+    sacksAllowed: 0, tacklesForLossAllowed: 0, protectionGrade: 0,
+
+    // Kicking/Punting
+    fgMade: 0, fgAttempts: 0, xpMade: 0, xpAttempts: 0, punts: 0, puntYards: 0,
+    fgMissed: 0, longestFG: 0, xpMissed: 0, successPct: 0, avgKickYards: 0,
+    avgPuntYards: 0, longestPunt: 0
+  };
+}
+
+// Zeroed team stat schema used when migrating saves that predate team stats.
+export function getZeroTeamStats() {
+  return {
+    wins: 0, losses: 0, ties: 0,
+    ptsFor: 0, ptsAgainst: 0,
+    passYds: 0, rushYds: 0,
+    passTD: 0, rushTD: 0,
+    turnovers: 0,
+    sacks: 0,
+    // Game specific
+    thirdDownAttempts: 0, thirdDownConversions: 0,
+    redZoneTrips: 0, redZoneTDs: 0
+  };
+}

--- a/src/state/stringifyWorkerClient.js
+++ b/src/state/stringifyWorkerClient.js
@@ -1,0 +1,91 @@
+// stringifyWorkerClient.js — off-main-thread JSON.stringify for large saves.
+//
+// Extracted from src/core/state.js. Serialization output is byte-identical
+// to JSON.stringify — the worker exists only to keep the main thread
+// responsive while multi-megabyte league states are serialized.
+//
+// The Blob worker is created lazily on first use and torn down on pagehide;
+// environments without Worker/Blob/URL support fall back to synchronous
+// JSON.stringify.
+
+let _stringifyWorker = null;
+let _stringifyCallbacks = {};
+let _stringifyId = 0;
+let _unloadHookInstalled = false;
+
+const WORKER_CODE = `
+  self.onmessage = function(e) {
+    try {
+      const str = JSON.stringify(e.data.obj);
+      self.postMessage({ id: e.data.id, str });
+    } catch (err) {
+      self.postMessage({ id: e.data.id, error: err.message });
+    }
+  };
+`;
+
+// Terminate the worker and reject anything still in flight. Safe to call
+// repeatedly; the next asyncStringify() lazily recreates the worker.
+export function disposeStringifyWorker(reason = 'stringify worker disposed') {
+  if (_stringifyWorker) {
+    try { _stringifyWorker.terminate(); } catch (err) { /* already gone */ }
+    _stringifyWorker = null;
+  }
+  const pending = _stringifyCallbacks;
+  _stringifyCallbacks = {};
+  Object.values(pending).forEach(({ reject }) => {
+    try { reject(new Error(reason)); } catch (err) { /* listener gone */ }
+  });
+}
+
+function installUnloadHook() {
+  if (_unloadHookInstalled) return;
+  if (typeof window === 'undefined' || typeof window.addEventListener !== 'function') return;
+  // pagehide fires on both navigation and tab close, and unlike beforeunload
+  // it does not interfere with the browser's leave-page prompt.
+  window.addEventListener('pagehide', () => {
+    disposeStringifyWorker('page unloading');
+  });
+  _unloadHookInstalled = true;
+}
+
+function ensureWorker() {
+  if (_stringifyWorker) return _stringifyWorker;
+  const blob = new Blob([WORKER_CODE], { type: 'application/javascript' });
+  _stringifyWorker = new Worker(URL.createObjectURL(blob));
+  _stringifyWorker.onmessage = function (e) {
+    const { id, str, error } = e.data;
+    if (_stringifyCallbacks[id]) {
+      if (error) _stringifyCallbacks[id].reject(new Error(error));
+      else _stringifyCallbacks[id].resolve(str);
+      delete _stringifyCallbacks[id];
+    }
+  };
+  installUnloadHook();
+  return _stringifyWorker;
+}
+
+export function asyncStringify(obj) {
+  if (typeof window === 'undefined' || !window.Worker || !window.Blob || !window.URL) {
+    return Promise.resolve(JSON.stringify(obj));
+  }
+
+  let worker;
+  try {
+    worker = ensureWorker();
+  } catch (err) {
+    console.warn('Failed to create stringify worker, falling back to sync', err);
+    return Promise.resolve(JSON.stringify(obj));
+  }
+
+  return new Promise((resolve, reject) => {
+    const id = ++_stringifyId;
+    _stringifyCallbacks[id] = { resolve, reject };
+    try {
+      worker.postMessage({ id, obj });
+    } catch (err) {
+      delete _stringifyCallbacks[id];
+      reject(err);
+    }
+  });
+}

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -67,6 +67,7 @@ import { getRecentGames, saveGame } from '../core/archive/gameArchive.ts';
 import { applyEventDecision } from './utils/franchiseEvents.js';
 import { logChronicleEvent } from './utils/franchiseChronicle.js';
 import { getBootViewStateValidation, getPlayableLeagueValidation } from '../state/leagueInit.ts';
+import { setLegacyState } from '../state/legacyStateBridge.js';
 
 // Increment this when shipping notable UX/bugfix updates so users
 // see the in-app changelog popup once per version.
@@ -597,7 +598,7 @@ function AppContent() {
 
   // Expose state and actions to window for E2E testing
   useEffect(() => {
-    window.state = state;
+    setLegacyState(state);
     if (actions && typeof handleAdvanceWeek === 'function') {
       window.gameController = {
         ...actions,

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -200,7 +200,7 @@ import { buildAwardHistoryEntry, appendAwardHistory, hydrateAwardHistory } from 
 import { buildAllLeaderboards } from '../core/awards/statLeaderboard.js';
 import { Constants } from '../core/constants.js';
 import { processPlayerProgression } from '../core/progression-logic.js';
-import { getZeroStats as getZeroSeasonStatsSchema } from '../core/state.js';
+import { getZeroStats as getZeroSeasonStatsSchema } from '../state/statsSchema.js';
 import { getDevelopmentRateModifier } from '../core/coaching-philosophy-effects.js';
 import { processOffseasonEvolution, processWeeklyEvolution } from '../core/progression/evolutionEngine.ts';
 import { buildTeamDevelopmentFocusMap as buildCanonicalDevelopmentFocusMap } from './developmentFocus.js';

--- a/tests/unit/saveSlotStorage.test.js
+++ b/tests/unit/saveSlotStorage.test.js
@@ -1,0 +1,120 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  normalizeSlot,
+  getActiveSaveSlot,
+  setActiveSaveSlot,
+  saveKeyFor,
+  getSaveMetadata,
+  listSaveSlots,
+  SAVE_KEY_BASE,
+  MAX_SAVE_SLOTS,
+} from '../../src/state/saveSlotStorage.js';
+import { setLegacyState } from '../../src/state/legacyStateBridge.js';
+
+// These keys are the on-disk save compatibility contract. If one of these
+// assertions fails, existing player saves would be orphaned.
+
+beforeEach(() => {
+  window.localStorage.clear();
+  delete window.state;
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+  delete window.state;
+});
+
+describe('saveSlotStorage — key contract', () => {
+  it('keeps the historical save key names byte-identical', () => {
+    expect(SAVE_KEY_BASE).toBe('nflGM4.league');
+    expect(saveKeyFor(1)).toBe('nflGM4.league.slot1');
+    expect(saveKeyFor(5)).toBe('nflGM4.league.slot5');
+  });
+
+  it('saveKeyFor normalizes out-of-range slots like the legacy code did', () => {
+    expect(saveKeyFor(0)).toBe(`${SAVE_KEY_BASE}.slot1`);
+    expect(saveKeyFor(99)).toBe(`${SAVE_KEY_BASE}.slot${MAX_SAVE_SLOTS}`);
+    expect(saveKeyFor('not-a-slot')).toBe(`${SAVE_KEY_BASE}.slot1`);
+  });
+});
+
+describe('saveSlotStorage — normalizeSlot', () => {
+  it('preserves legacy normalization exactly', () => {
+    expect(normalizeSlot(1)).toBe(1);
+    expect(normalizeSlot('3')).toBe(3);
+    expect(normalizeSlot(MAX_SAVE_SLOTS)).toBe(MAX_SAVE_SLOTS);
+    // clamped / defaulted
+    expect(normalizeSlot(0)).toBe(1);
+    expect(normalizeSlot(-2)).toBe(1);
+    expect(normalizeSlot(MAX_SAVE_SLOTS + 3)).toBe(MAX_SAVE_SLOTS);
+    expect(normalizeSlot(undefined)).toBe(1);
+    expect(normalizeSlot(null)).toBe(1);
+    expect(normalizeSlot('junk')).toBe(1);
+    // parseInt semantics, not Number(): '2abc' parses to 2
+    expect(normalizeSlot('2abc')).toBe(2);
+  });
+});
+
+describe('saveSlotStorage — active slot persistence', () => {
+  it('defaults to slot 1 when nothing is stored', () => {
+    expect(getActiveSaveSlot()).toBe(1);
+  });
+
+  it('round-trips through the legacy localStorage key', () => {
+    expect(setActiveSaveSlot(3)).toBe(3);
+    expect(window.localStorage.getItem('nflGM4.activeSlot')).toBe('3');
+    expect(getActiveSaveSlot()).toBe(3);
+  });
+
+  it('normalizes before persisting', () => {
+    expect(setActiveSaveSlot(42)).toBe(MAX_SAVE_SLOTS);
+    expect(getActiveSaveSlot()).toBe(MAX_SAVE_SLOTS);
+  });
+
+  it('mirrors the slot onto legacy state only when it exists', () => {
+    // No legacy state installed: must not create one
+    setActiveSaveSlot(2);
+    expect(window.state).toBeUndefined();
+
+    // Legacy state installed: saveSlot is patched in place
+    const legacy = setLegacyState({ saveSlot: 1 });
+    setActiveSaveSlot(4);
+    expect(window.state).toBe(legacy);
+    expect(window.state.saveSlot).toBe(4);
+  });
+});
+
+describe('saveSlotStorage — save metadata', () => {
+  it('returns null for empty or corrupt slots', () => {
+    expect(getSaveMetadata(1)).toBeNull();
+    window.localStorage.setItem(saveKeyFor(2), '{not json');
+    expect(getSaveMetadata(2)).toBeNull();
+  });
+
+  it('summarizes a stored save', () => {
+    window.localStorage.setItem(saveKeyFor(2), JSON.stringify({
+      lastSaved: '2026-01-01T00:00:00.000Z',
+      season: 3,
+      namesMode: 'real',
+      userTeamId: 1,
+      league: { teams: [{ name: 'A' }, { name: 'B' }] },
+    }));
+
+    expect(getSaveMetadata(2)).toEqual({
+      slot: 2,
+      lastSaved: '2026-01-01T00:00:00.000Z',
+      team: 'B',
+      season: 3,
+      mode: 'real',
+    });
+  });
+
+  it('lists all slots with nulls for empty ones', () => {
+    window.localStorage.setItem(saveKeyFor(3), JSON.stringify({ season: 7 }));
+    const slots = listSaveSlots();
+    expect(slots).toHaveLength(MAX_SAVE_SLOTS);
+    expect(slots[0]).toBeNull();
+    expect(slots[2]).toMatchObject({ slot: 3, season: 7 });
+  });
+});

--- a/tests/unit/sosTiebreaker.test.js
+++ b/tests/unit/sosTiebreaker.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildDraftOrder, computeStrengthOfSchedule } from '../../src/worker/modding/ruleEngine.js';
-import { getZeroStats } from '../../src/core/state.js';
+import { getZeroStats } from '../../src/state/statsSchema.js';
 
 // Wave 4 Fix 4: draft-order tiebreaker uses Strength of Schedule (not point
 // differential), with a seeded coin-flip fallback.

--- a/tests/unit/stateLegacyBridge.test.js
+++ b/tests/unit/stateLegacyBridge.test.js
@@ -1,0 +1,242 @@
+/** @vitest-environment jsdom */
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  getLegacyState,
+  setLegacyState,
+  patchLegacyState,
+  resetLegacyState,
+  getLegacySaveDelegate,
+} from '../../src/state/legacyStateBridge.js';
+import { saveKeyFor, SAVE_KEY_BASE } from '../../src/state/saveSlotStorage.js';
+
+// src/core/state.js is imported dynamically (not statically) so the spy below
+// can prove that merely importing the module installs nothing on window.
+let stateModule;
+let addEventListenerSpy;
+
+beforeAll(async () => {
+  addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+  stateModule = await import('../../src/core/state.js');
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+  delete window.state;
+  delete window.saveGame;
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+  delete window.state;
+  delete window.saveGame;
+});
+
+describe('importing src/core/state.js is side-effect free for global state', () => {
+  it('does not eagerly install window.state', () => {
+    // beforeEach deletes window.state, but the import in beforeAll ran before
+    // any cleanup — capture proof from the spy-era instead: the module-level
+    // export must still be null and re-importing must not recreate state.
+    expect(stateModule.state).toBeNull();
+    expect(window.state).toBeUndefined();
+  });
+
+  it('does not eagerly install the beforeunload autosave hook', () => {
+    const beforeunloadHooks = addEventListenerSpy.mock.calls.filter(
+      ([eventName]) => eventName === 'beforeunload'
+    );
+    expect(beforeunloadHooks).toHaveLength(0);
+  });
+
+  it('still installs the autosave hook when explicitly requested', () => {
+    stateModule.hookAutoSave();
+    const beforeunloadHooks = addEventListenerSpy.mock.calls.filter(
+      ([eventName]) => eventName === 'beforeunload'
+    );
+    expect(beforeunloadHooks).toHaveLength(1);
+  });
+});
+
+describe('legacyStateBridge primitives', () => {
+  it('getLegacyState returns null until state is installed', () => {
+    expect(getLegacyState()).toBeNull();
+    const installed = setLegacyState({ hello: 'world' });
+    expect(getLegacyState()).toBe(installed);
+    expect(window.state).toBe(installed);
+  });
+
+  it('patchLegacyState merges in place and no-ops without state', () => {
+    expect(patchLegacyState({ a: 1 })).toBeNull();
+    expect(window.state).toBeUndefined();
+
+    const installed = setLegacyState({ a: 1, b: 2 });
+    const patched = patchLegacyState({ b: 3, c: 4 });
+    expect(patched).toBe(installed);
+    expect(window.state).toEqual({ a: 1, b: 3, c: 4 });
+  });
+
+  it('resetLegacyState preserves object identity for legacy references', () => {
+    const original = setLegacyState({ staleKey: true, league: 'old' });
+    const result = resetLegacyState(() => ({ league: null, week: 1 }));
+
+    expect(result).toBe(original); // same object, cleared in place
+    expect(result.staleKey).toBeUndefined();
+    expect(result).toEqual({ league: null, week: 1 });
+  });
+
+  it('resetLegacyState installs fresh state when none exists', () => {
+    const result = resetLegacyState(() => ({ week: 1 }));
+    expect(window.state).toBe(result);
+    expect(result).toEqual({ week: 1 });
+  });
+
+  it('getLegacySaveDelegate only returns installed callable delegates', () => {
+    expect(getLegacySaveDelegate()).toBeNull();
+    window.saveGame = 'not-a-function';
+    expect(getLegacySaveDelegate()).toBeNull();
+    const fn = () => {};
+    window.saveGame = fn;
+    expect(getLegacySaveDelegate()).toBe(fn);
+  });
+});
+
+describe('State.reset preserves legacy behavior via the bridge', () => {
+  it('clears extra keys and repopulates schema on the same object', () => {
+    const legacy = setLegacyState({ zombieKey: 'stale', userTeamId: 7 });
+    const result = stateModule.State.reset();
+
+    expect(result).toBe(legacy); // identity preserved for legacy references
+    expect(result.zombieKey).toBeUndefined();
+    expect(result.userTeamId).toBe(0);
+    expect(result.settings.autoSave).toBe(true);
+    expect(result.version).toBe('4.0.0');
+    // the module-level legacy export tracks the reset
+    expect(stateModule.state).toBe(result);
+  });
+});
+
+describe('saveState routes the dual save path through the bridge', () => {
+  it('delegates to the installed save delegate', async () => {
+    window.saveGame = vi.fn().mockResolvedValue(true);
+    const gameState = { version: '4.0.0', saveSlot: 2, league: null };
+
+    const ok = await stateModule.saveState(gameState, { reason: 'test' });
+
+    expect(ok).toBe(true);
+    expect(window.saveGame).toHaveBeenCalledTimes(1);
+    expect(window.saveGame.mock.calls[0][0]).toMatchObject({ version: '4.0.0', saveSlot: 2 });
+    // nothing written to localStorage when the delegate handles the save
+    expect(window.localStorage.getItem(saveKeyFor(2))).toBeNull();
+  });
+
+  it('falls back to slot-keyed localStorage when no delegate exists', async () => {
+    const gameState = { version: '4.0.0', saveSlot: 2, league: null };
+
+    const ok = await stateModule.saveState(gameState);
+
+    expect(ok).toBe(true);
+    const raw = window.localStorage.getItem(saveKeyFor(2));
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw)).toMatchObject({ version: '4.0.0', saveSlot: 2 });
+  });
+
+  it('honors legacyOnly by skipping the delegate', async () => {
+    window.saveGame = vi.fn();
+    const gameState = { version: '4.0.0', saveSlot: 3, league: null };
+
+    const ok = await stateModule.saveState(gameState, { legacyOnly: true });
+
+    expect(ok).toBe(true);
+    expect(window.saveGame).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(saveKeyFor(3))).not.toBeNull();
+  });
+});
+
+describe('loadState still migrates the legacy single-save key', () => {
+  it('moves an old nflGM4-era save into the active slot', async () => {
+    const oldSave = {
+      version: '3.0.0',
+      namesMode: 'fictional',
+      onboarded: true,
+      gameMode: 'gm',
+      playerRole: 'GM',
+      userTeamId: 0,
+      season: 5,
+    };
+    window.localStorage.setItem(SAVE_KEY_BASE, JSON.stringify(oldSave));
+
+    const loaded = await stateModule.loadState();
+
+    expect(loaded).toBe(window.state);
+    expect(loaded.version).toBe('4.0.0'); // migrated forward
+    expect(loaded.onboarded).toBe(true);
+    expect(loaded.season).toBe(5);
+    expect(loaded.saveSlot).toBe(1);
+
+    // legacy key is retired…
+    expect(window.localStorage.getItem(SAVE_KEY_BASE)).toBeNull();
+    // …and the save lands in the active slot (write is fire-and-forget)
+    await vi.waitFor(() => {
+      expect(window.localStorage.getItem(saveKeyFor(1))).not.toBeNull();
+    });
+    expect(JSON.parse(window.localStorage.getItem(saveKeyFor(1)))).toMatchObject({
+      version: '4.0.0',
+      season: 5,
+    });
+  });
+
+  it('loads a current-format slot save without touching other slots', async () => {
+    const currentSave = {
+      ...stateModule.State.init(),
+      onboarded: true,
+      season: 9,
+    };
+    window.localStorage.setItem(saveKeyFor(1), JSON.stringify(currentSave));
+
+    const loaded = await stateModule.loadState();
+
+    expect(loaded).toBe(window.state);
+    expect(loaded.season).toBe(9);
+    expect(loaded.saveSlot).toBe(1);
+  });
+});
+
+describe('source-level quarantine (grep guards)', () => {
+  // vitest runs from the repo root, so resolve src/ from the working directory
+  const srcRoot = path.resolve(process.cwd(), 'src');
+
+  function walkSourceFiles(dir) {
+    return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) return walkSourceFiles(full);
+      return /\.(js|jsx|ts|tsx)$/.test(entry.name) ? [full] : [];
+    });
+  }
+
+  it('only legacyStateBridge.js assigns window.state', () => {
+    const offenders = walkSourceFiles(srcRoot).filter((file) => {
+      if (file.endsWith(`${path.sep}legacyStateBridge.js`)) return false;
+      return /window\.state\s*=/.test(fs.readFileSync(file, 'utf8'));
+    });
+    expect(offenders).toEqual([]);
+  });
+
+  it('only legacyStateBridge.js reads the legacy save delegate global', () => {
+    const offenders = walkSourceFiles(srcRoot).filter((file) => {
+      if (file.endsWith(`${path.sep}legacyStateBridge.js`)) return false;
+      return /window\.saveGame/.test(fs.readFileSync(file, 'utf8'));
+    });
+    expect(offenders).toEqual([]);
+  });
+
+  it('src/core/state.js no longer delete-loops globals or mutates name globals', () => {
+    const source = fs.readFileSync(path.join(srcRoot, 'core', 'state.js'), 'utf8');
+    expect(source).not.toMatch(/delete window\.state/);
+    expect(source).not.toMatch(/Object\.keys\(window\.state\)/);
+    expect(source).not.toMatch(/delete window\.FIRST_NAMES/);
+    expect(source).not.toMatch(/delete window\.LAST_NAMES/);
+    expect(source).not.toMatch(/window\.FIRST_NAMES\s*=/);
+    expect(source).not.toMatch(/window\.LAST_NAMES\s*=/);
+  });
+});

--- a/tests/unit/statsSchema.test.js
+++ b/tests/unit/statsSchema.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { getZeroStats, getZeroTeamStats } from '../../src/state/statsSchema.js';
+
+// Quarantine guarantee: the stat schema is pure data, importable without a
+// browser environment and without initializing any global state.
+
+describe('statsSchema — getZeroStats', () => {
+  it('is importable in a plain node environment without window/global state', () => {
+    expect(typeof window).toBe('undefined');
+    expect(globalThis.state).toBeUndefined();
+    expect(typeof getZeroStats).toBe('function');
+  });
+
+  it('returns every tracked stat family zeroed', () => {
+    const stats = getZeroStats();
+
+    // One representative key per family — archival relies on these existing.
+    expect(stats).toMatchObject({
+      gamesPlayed: 0,
+      passYd: 0,
+      rushYd: 0,
+      recYd: 0,
+      tackles: 0,
+      sacksAllowed: 0,
+      fgMade: 0,
+    });
+
+    // Every value in the schema starts at exactly 0.
+    for (const [key, value] of Object.entries(stats)) {
+      expect(value, `stat ${key} must start at 0`).toBe(0);
+    }
+  });
+
+  it('returns a fresh object per call (no shared mutable schema)', () => {
+    const a = getZeroStats();
+    const b = getZeroStats();
+    expect(a).not.toBe(b);
+    a.passYd = 300;
+    expect(b.passYd).toBe(0);
+  });
+
+  it('matches the schema re-exported by the legacy state module', async () => {
+    const legacy = await import('../../src/core/state.js');
+    expect(legacy.getZeroStats).toBe(getZeroStats);
+    expect(Object.keys(legacy.getZeroStats())).toEqual(Object.keys(getZeroStats()));
+  });
+});
+
+describe('statsSchema — getZeroTeamStats', () => {
+  it('returns the zeroed team schema', () => {
+    const stats = getZeroTeamStats();
+    expect(stats).toMatchObject({
+      wins: 0, losses: 0, ties: 0,
+      ptsFor: 0, ptsAgainst: 0,
+      thirdDownAttempts: 0, redZoneTrips: 0,
+    });
+    for (const [key, value] of Object.entries(stats)) {
+      expect(value, `team stat ${key} must start at 0`).toBe(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Structural safety PR: quarantines the legacy browser-global behavior of `src/core/state.js` behind small, single-purpose modules under `src/state/`, without changing gameplay, save formats, or the worker protocol. The worker + IndexedDB cache remain the authoritative league state; no new app-wide state store is introduced.

### New modules

| Module | Responsibility |
|---|---|
| `src/state/statsSchema.js` | `getZeroStats()` / `getZeroTeamStats()` as pure, import-side-effect-free data |
| `src/state/saveSlotStorage.js` | `normalizeSlot`, `getActiveSaveSlot`, `setActiveSaveSlot`, `saveKeyFor`, `getSaveMetadata`, `listSaveSlots` — key names (`nflGM4.activeSlot`, `nflGM4.league.slotN`) byte-identical |
| `src/state/legacyStateBridge.js` | The **only** module allowed to write `window.state` (`getLegacyState` / `setLegacyState` / `patchLegacyState` / `resetLegacyState`) and the only reader of the `window.saveGame` dual save delegate (`getLegacySaveDelegate`) |
| `src/state/stringifyWorkerClient.js` | Lazy Blob-worker `asyncStringify` with sync `JSON.stringify` fallback, safe callback tracking, `pagehide` cleanup; serialized output unchanged |

### `src/core/state.js` (now a compatibility module)

- No eager `window.state = State.init()` at import time; the mutable `state` export stays `null` until `loadState()`/`State.reset()` runs.
- No import-time `beforeunload` autosave install — `hookAutoSave()` remains available as an explicit opt-in.
- No deletion/reassignment of `window.FIRST_NAMES` / `window.LAST_NAMES`.
- No direct `window.saveGame` reference; the dual save path goes through `getLegacySaveDelegate()`.
- `State.reset()` clears the legacy state **in place** via the bridge (object identity preserved for legacy references) instead of an inline delete loop.
- Stat schema, save-slot helpers, and async stringify are re-exported/routed from the extracted modules.
- Kept: `window.currentTeam` install (still called by `src/core/coaching.js`) — a read helper, not global state.

### Consumers updated

- `src/worker/worker.js` imports the season stat schema from `src/state/statsSchema.js` (no longer pulls the legacy state module).
- `src/ui/App.jsx` routes its E2E `window.state` exposure through `setLegacyState`.
- `tests/unit/sosTiebreaker.test.js` imports `getZeroStats` from the new schema module.

## Tests

New suites (all in `tests/unit/`): `statsSchema.test.js`, `saveSlotStorage.test.js`, `stateLegacyBridge.test.js`. They verify:

- `getZeroStats()` is importable in plain node with no window/global state, returns fresh zeroed objects, and matches the legacy re-export.
- Save-key contract pinned: `nflGM4.league.slotN`, `nflGM4.activeSlot`, slot normalization semantics unchanged.
- Importing `src/core/state.js` under jsdom installs neither `window.state` nor the `beforeunload` autosave hook.
- `State.reset()` clears extra keys and repopulates on the **same object**.
- Legacy single-save-key (`nflGM4.league`) migration into the active slot still works end-to-end through `loadState()`.
- `saveState()` delegates through the bridge’s save delegate, honors `legacyOnly`, and falls back to slot-keyed localStorage.
- Source-level grep guards: `window.state =` and `window.saveGame` appear nowhere in `src/` outside `legacyStateBridge.js`; `state.js` contains no delete loops or name-global mutation.

## Verification

- `npm run test:unit` — 415 files / 5150 tests passing
- `npm run audit:engine-soak` — all gates PASS
- Acceptance greps return zero hits:
  - `grep -R "window\.state =" src | grep -v legacyStateBridge`
  - `grep -R "delete window.FIRST_NAMES\|delete window.LAST_NAMES" src`
  - `grep -R "window\.saveGame" src/core/state.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRhF9MJV2FjNrTQEyq7Lmj

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRhF9MJV2FjNrTQEyq7Lmj)_