### PR TITLE
Worker Handler Registry V1 — command registry + first handler batch carved out of worker.js

### DIFF
--- a/src/worker/commandRegistry.js
+++ b/src/worker/commandRegistry.js
@@ -1,0 +1,63 @@
+/**
+ * commandRegistry.js — minimal message-type → handler dispatch for the worker.
+ *
+ * worker.js remains the owner of self.onmessage and its sequential message
+ * queue. It consults the registry first and falls back to its legacy switch
+ * for commands that have not been migrated yet.
+ *
+ * Handler contract (matches the existing worker handler shape):
+ *   async handler(payload, id, ctx)
+ * Handlers post their own replies via ctx.post, echoing the inbound `id`
+ * exactly as the monolith handlers did — the registry never touches
+ * requestIds or response shapes. Handler errors are NOT swallowed here; they
+ * propagate to the caller so worker.js's existing catch → toUI.ERROR path
+ * stays authoritative.
+ */
+
+export function createCommandRegistry() {
+  const handlers = new Map();
+
+  /** Register one handler for a message type. Duplicate registration throws. */
+  function register(type, handler) {
+    if (typeof type !== 'string' || type.length === 0) {
+      throw new TypeError('commandRegistry.register: type must be a non-empty string');
+    }
+    if (typeof handler !== 'function') {
+      throw new TypeError(`commandRegistry.register: handler for "${type}" must be a function`);
+    }
+    if (handlers.has(type)) {
+      throw new Error(`commandRegistry.register: duplicate handler for "${type}"`);
+    }
+    handlers.set(type, handler);
+  }
+
+  /** Register a { [messageType]: handler } map in one call. */
+  function registerAll(handlerMap = {}) {
+    for (const [type, handler] of Object.entries(handlerMap)) register(type, handler);
+  }
+
+  function has(type) {
+    return handlers.has(type);
+  }
+
+  /** Registered message types, for diagnostics and tests. */
+  function registeredTypes() {
+    return [...handlers.keys()];
+  }
+
+  /**
+   * Dispatch one inbound worker message. Resolves to { handled: true } after
+   * the handler completes, or { handled: false } when no handler is
+   * registered so the caller can fall through to its own routing (the
+   * "unhandled command" result — dispatch itself never throws on unknown
+   * types).
+   */
+  async function dispatch(type, payload = {}, id = null, ctx = undefined) {
+    const handler = handlers.get(type);
+    if (!handler) return { handled: false, type };
+    await handler(payload, id, ctx);
+    return { handled: true, type };
+  }
+
+  return { register, registerAll, has, registeredTypes, dispatch };
+}

--- a/src/worker/commandRegistry.js
+++ b/src/worker/commandRegistry.js
@@ -54,7 +54,10 @@ export function createCommandRegistry() {
    */
   async function dispatch(type, payload = {}, id = null, ctx = undefined) {
     const handler = handlers.get(type);
-    if (!handler) return { handled: false, type };
+    // Function-type guard on the looked-up value: `type` arrives from inbound
+    // worker messages, so never invoke anything the register() path did not
+    // store (CodeQL js/unvalidated-dynamic-method-call).
+    if (typeof handler !== 'function') return { handled: false, type };
     await handler(payload, id, ctx);
     return { handled: true, type };
   }

--- a/src/worker/handlers/draftHandlers.js
+++ b/src/worker/handlers/draftHandlers.js
@@ -1,0 +1,24 @@
+/**
+ * draftHandlers.js — GET_DRAFT_STATE.
+ *
+ * Extracted from worker.js (Worker Handler Registry V1); behavior unchanged.
+ * Draft execution (START_DRAFT, MAKE_DRAFT_PICK, sim picks, trades) stays in
+ * worker.js — this handler only reads the draft view, lazily initializing the
+ * draft through ctx.startDraft when the phase requires it.
+ */
+import { toUI } from '../protocol.js';
+import { ensureDynastyMeta } from '../../core/dynasty-story.js';
+
+// ── Handler: GET_DRAFT_STATE ──────────────────────────────────────────────────
+
+export async function handleGetDraftState(payload, id, ctx) {
+  try {
+    const meta = ensureDynastyMeta(ctx.cache.getMeta());
+    if (meta?.phase === 'draft' && !meta?.draftState) {
+      await ctx.startDraft({}, null);
+    }
+    ctx.post(toUI.DRAFT_STATE, ctx.buildDraftStateView(), id);
+  } catch (error) {
+    ctx.post(toUI.ERROR, { message: `Draft state unavailable. Retry or cancel sim. (${error?.message ?? 'unknown error'})` }, id);
+  }
+}

--- a/src/worker/handlers/freeAgencyHandlers.js
+++ b/src/worker/handlers/freeAgencyHandlers.js
@@ -1,0 +1,459 @@
+/**
+ * freeAgencyHandlers.js — GET_FREE_AGENTS, SUBMIT_OFFER, WITHDRAW_OFFER.
+ *
+ * Extracted from worker.js (Worker Handler Registry V1); behavior unchanged.
+ *
+ * The pending-offer ledger helpers (getPendingOffersLedger,
+ * savePendingOffersLedger, syncPendingOfferLedger, buildDemandSnapshotForOffer)
+ * and the offer-resolution pipeline (resolvePendingFreeAgencyOffers) remain in
+ * worker.js because the unmigrated offseason/FA-day systems also use them;
+ * these handlers reach them through ctx.
+ */
+import { toUI } from '../protocol.js';
+import { ensureDynastyMeta } from '../../core/dynasty-story.js';
+import { getSalaryInflationMultiplier, inflateContract } from '../../core/economy.js';
+import {
+  inferTeamDirection,
+  buildContractProfile,
+  buildDemandFromProfile,
+  evaluateReSignPriority,
+  computeMarketHeat,
+  buildDecisionTiming,
+  marketHeatLabel,
+} from '../../core/contract-market.js';
+import { getTeamContextForNegotiation } from '../../core/teamContext/negotiationContext.js';
+import { evaluateContractOffer, summarizeNegotiationStance } from '../../core/contracts/negotiation.js';
+import { summarizePlayerMood } from '../../core/mood/playerMood.js';
+import { getPlayerMoraleSummary } from '../../core/mood/playerMoraleEngine.js';
+import { getPlayerAwardSummary } from '../../core/awards/awardEngine.js';
+import {
+  computePlayerLeverage,
+  computeFranchiseReputation,
+  applyNegotiationModifiers,
+  getNegotiationContext,
+} from '../../core/contracts/negotiationModifiers.js';
+import { getCoachingInstabilityPenalty } from '../../core/coaching/coachingEngine.js';
+import { getFreeAgencyDecisionState } from '../../core/freeAgency/decisionState.js';
+import {
+  PENDING_OFFER_STATUS,
+  ensurePendingOffersList,
+  computeReservedPendingCap,
+  validateOfferAgainstReservedCap,
+  buildOfferFeedback,
+  createPendingOffer,
+  upsertPendingOffer,
+  markOfferResolved,
+} from '../../core/freeAgency/pendingOffers.js';
+import { buildScoutingSnapshot } from '../../core/staff-system.js';
+import AiLogic from '../../core/ai-logic.js';
+
+// ── Handler: GET_FREE_AGENTS ──────────────────────────────────────────────────
+
+export async function handleGetFreeAgents(payload, id, ctx) {
+  const { cache, post } = ctx;
+  const meta = ensureDynastyMeta(cache.getMeta());
+  const inflationMult = getSalaryInflationMultiplier(meta?.economy ?? {});
+  const userTeamId = meta.userTeamId;
+  // teamId 0 is a valid franchise (the default user team) — only a null/undefined
+  // teamId means unsigned, so accepted players never linger in the FA pool.
+  const allFreeAgents = cache.getAllPlayers().filter((p) => p.teamId == null || p.status === 'free_agent');
+  const userTeam = cache.getTeam(userTeamId);
+  const userDirection = inferTeamDirection(userTeam, Number(meta?.currentWeek ?? 1));
+  const userWinPct = Math.max(0, Math.min(1, (() => {
+    const wins = Number(userTeam?.wins ?? 0);
+    const losses = Number(userTeam?.losses ?? 0);
+    const ties = Number(userTeam?.ties ?? 0);
+    const games = wins + losses + ties;
+    return games > 0 ? (wins + ties * 0.5) / games : 0.5;
+  })()));
+
+  const freeAgents = allFreeAgents
+    .map(p => {
+        const continuity = ctx.getOffseasonReturnSnapshot(p.id, userTeamId, meta);
+        const playbookKnowledgeScore = Math.max(0, Math.min(100, continuity ? Number(continuity?.schemeFit ?? p?.schemeFit ?? 50) : Number(p?.schemeFit ?? 50)));
+        const playbookKnowledgeLabel = playbookKnowledgeScore >= 80
+          ? 'High'
+          : playbookKnowledgeScore >= 60
+            ? 'Moderate'
+            : playbookKnowledgeScore >= 35
+              ? 'Low'
+              : 'None';
+        const scoutingView = buildScoutingSnapshot(p, userTeam, { fogStrength: Number(ctx.getLeagueSetting('scoutingFogStrength', 50)), commissionerMode: !!meta?.commissionerMode });
+        // Summarize offers for UI — bidding war edition
+        const offers = p.offers || [];
+        const userOffer = offers.find(o => o.teamId === userTeamId);
+        const profile = buildContractProfile(p);
+        const heat = computeMarketHeat(p.pos, allFreeAgents);
+        const baseAsk = inflateContract(buildDemandFromProfile(p, profile, {
+          marketHeat: heat,
+          morale: p.morale ?? 68,
+          fit: Number(p?.schemeFit ?? 65),
+          teamSuccess: userWinPct,
+        }), inflationMult);
+        // V2: apply negotiation modifiers (morale, awards, franchise reputation)
+        const pMoraleSummary = getPlayerMoraleSummary(p);
+        const pAwardSummary = getPlayerAwardSummary(p);
+        const faCurrentSeason = Number(meta?.season ?? 0);
+        const pLeverage = computePlayerLeverage(p, { moraleSummary: pMoraleSummary, awardSummary: pAwardSummary, currentSeason: faCurrentSeason });
+        const faUserTeam = cache.getTeam(Number(userTeamId ?? 0));
+        const faInstability = getCoachingInstabilityPenalty(faUserTeam?.coachHistory ?? [], 3);
+        const fReputation = computeFranchiseReputation(meta, { userTeamId: Number(userTeamId ?? 0), currentSeason: faCurrentSeason, coachingInstabilityPenalty: faInstability });
+        const ask = applyNegotiationModifiers(baseAsk, pLeverage, fReputation);
+        const pNegCtx = getNegotiationContext(p, meta, { moraleSummary: pMoraleSummary, awardSummary: pAwardSummary, currentSeason: faCurrentSeason, userTeamId: Number(userTeamId ?? 0) });
+        const reSignInsight = evaluateReSignPriority(p, {
+          marketHeat: heat,
+          teamDirection: userDirection,
+          capRoom: userTeam?.capRoom ?? 0,
+          teamSuccess: userWinPct,
+          profile,
+          demand: ask,
+        });
+
+        // Find the top bid (highest total contract value)
+        let topBid = null;
+        let topOfferValue = 0;
+        let userTrailReason = null;
+        for (const o of offers) {
+            const c = o.contract;
+            const val = (c.baseAnnual * c.yearsTotal) + (c.signingBonus || 0);
+            if (val > topOfferValue) {
+                topOfferValue = val;
+                topBid = o;
+            }
+        }
+
+        const annualCapHitForOffer = (offer) => {
+            const c = offer?.contract ?? {};
+            const years = Math.max(1, Number(c.yearsTotal ?? c.years ?? 1));
+            const baseAnnual = Number(c.baseAnnual ?? c.annualSalary ?? c.annual ?? 0);
+            const signingBonus = Number(c.signingBonus ?? 0);
+            return Math.round((baseAnnual + (signingBonus / years)) * 10) / 10;
+        };
+
+        // Calculate user's bid value if they have one
+        let userBidValue = 0;
+        if (userOffer) {
+            const uc = userOffer.contract;
+            userBidValue = (uc.baseAnnual * uc.yearsTotal) + (uc.signingBonus || 0);
+            if (topBid && topBid.teamId !== userTeamId) {
+              const moneyGap = Math.round((topOfferValue - userBidValue) * 10) / 10;
+              userTrailReason = moneyGap > 0.4 ? `Trailing on value by $${moneyGap}M` : 'Another team offers better fit';
+            }
+        }
+
+        const mem = meta?.contractMarketMemory?.[String(p.id)] ?? {};
+        const topGapRatio = topOfferValue > 0
+          ? Math.max(0, ((ask.baseAnnual * ask.yearsTotal + (ask.signingBonus || 0)) - topOfferValue) / Math.max(1, (ask.baseAnnual * ask.yearsTotal + (ask.signingBonus || 0))))
+          : 0;
+        const decisionTiming = buildDecisionTiming(p, heat, offers.length, meta.phase, {
+          waitCycles: Number(mem?.waitCycles ?? 0),
+          moneyGapRatio: topGapRatio,
+        });
+        const detailTone = userOffer
+          ? userOffer.teamId === topBid?.teamId
+            ? (offers.length >= 3 ? "You're leading, but another team is close" : 'Your bid leads')
+            : (userTrailReason || 'Another team currently leads')
+          : (offers.length >= 2 ? 'Warm market' : 'Open market');
+        const knownMarket = offers.length > 0 || !!userOffer || !!topBid;
+        const riskLabelByRisk = {
+          high: 'High risk of movement',
+          medium: 'Moderate risk',
+          low: 'Low immediate risk',
+        };
+        const patienceLabel = decisionTiming.patienceWeeks <= 1
+          ? 'Ready to decide now'
+          : decisionTiming.patienceWeeks <= 2
+            ? 'Likely to decide soon'
+            : `Decision window: ${decisionTiming.patienceWeeks} cycle${decisionTiming.patienceWeeks > 1 ? 's' : ''}`;
+        const topPreferences = [
+          ['money', profile.moneyPriority],
+          ['contender', profile.contenderPriority],
+          ['role', profile.rolePriority],
+          ['security', profile.securityPriority],
+          ['loyalty', profile.loyaltyPriority],
+        ]
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 3)
+          .map(([tag]) => tag);
+
+        const teamNegotiationContext = getTeamContextForNegotiation(p, userTeam, null, {
+          teamDirection: userDirection,
+          needsAtPosition: AiLogic.calculateTeamNeeds(userTeamId)?.[p.pos] ?? 1,
+          rosterAtPosition: cache.getPlayersByTeam(userTeamId).filter((rp) => rp?.pos === p?.pos),
+        });
+        const userOfferEval = evaluateContractOffer(p, {
+          ...teamNegotiationContext,
+          schemeFitScore: Number(p?.schemeFit ?? 65),
+          franchiseDirectionScore: userDirection === 'contender' ? 78 : userDirection === 'rebuilding' ? 44 : 58,
+        }, userOffer ?? { contract: ask }, {
+          profile,
+          askTotalValue: (ask.baseAnnual * ask.yearsTotal) + (ask.signingBonus || 0),
+          askAnnual: ask.baseAnnual,
+          askYears: ask.yearsTotal,
+        });
+        const moodSummary = summarizePlayerMood(profile, teamNegotiationContext);
+        const decisionState = getFreeAgencyDecisionState({
+          negotiationStance: userOfferEval.negotiationStance,
+          bidderCount: offers.length,
+          urgency: decisionTiming.risk,
+          valueGap: userOfferEval.valueGap,
+        });
+
+        return {
+          id:        p.id,
+          name:      p.name,
+          pos:       p.pos,
+          age:       p.age,
+          ovr:       p.ovr,
+          hofStatus: p.hofStatus ?? 'none',
+          scoutOvr: scoutingView?.estimatedOvr ?? p.ovr,
+          scoutUncertaintyBand: scoutingView?.uncertainty ?? 0,
+          scoutConfidenceLabel: scoutingView?.confidenceLabel ?? 'Medium confidence',
+          potential: p.potential ?? null,
+          contract:  p.contract ?? null,
+          traits:    p.traits ?? [],
+          market: {
+            heat: Math.round(heat * 100) / 100,
+            heatLabel: marketHeatLabel(heat),
+            bidderCount: offers.length,
+            decision: decisionState.summary,
+            decisionReason: `${decisionTiming.reason}. ${summarizeNegotiationStance(userOfferEval)}`,
+            urgency: decisionTiming.risk,
+            urgencyLabel: decisionTiming.risk === 'high'
+              ? 'Decision expected soon'
+              : decisionTiming.risk === 'medium'
+                ? 'Decision window open'
+                : 'No immediate deadline signal',
+            timingState: decisionState.state,
+            attention: detailTone,
+            patienceWeeks: decisionTiming.patienceWeeks,
+            patienceLabel,
+            riskLabel: riskLabelByRisk[decisionTiming.risk] ?? 'Risk unknown',
+            knownMarket,
+            stateChips: decisionState.chips,
+            motivationSummary: moodSummary.summary,
+            fitScore: userOfferEval.score,
+          },
+          demandProfile: {
+            headline: moodSummary.summary,
+            willingness: ask.willingness,
+            askAnnual: ask.baseAnnual,
+            askYears: ask.yearsTotal,
+            priorities: topPreferences,
+            archetype: profile.archetype,
+            contractOutlook: moodSummary.contractOutlook,
+            negotiationStance: userOfferEval.negotiationStance,
+            fitScore: userOfferEval.score,
+            explanationSummary: userOfferEval.explanationSummary,
+            // V2 negotiation modifier context
+            leverageLabel: pNegCtx.leverageLabel,
+            reputationLabel: pNegCtx.reputationLabel,
+            feedbackLine: pNegCtx.feedbackLine,
+            negotiationShift: ask._negotiationShift ?? 0,
+          },
+          playbookKnowledge: {
+            score: Math.round(playbookKnowledgeScore),
+            label: playbookKnowledgeLabel,
+          },
+          reSign: reSignInsight,
+          offers: {
+              count: offers.length,
+              userOffered: !!userOffer,
+              userIsTopBidder: !!userOffer && topBid && topBid.teamId === userTeamId,
+              topOfferValue: Math.round(topOfferValue * 10) / 10,
+              topBidTeam: topBid ? topBid.teamName : null,
+              topBidAnnual: topBid ? Math.round(topBid.contract.baseAnnual * 10) / 10 : 0,
+              topBidAnnualCapHit: topBid ? annualCapHitForOffer(topBid) : 0,
+              topBidYears: topBid ? topBid.contract.yearsTotal : 0,
+              topOfferContractModel: topBid?.contractModel ?? null,
+              userBidAnnual: userOffer ? Math.round(userOffer.contract.baseAnnual * 10) / 10 : 0,
+              userBidAnnualCapHit: userOffer ? annualCapHitForOffer(userOffer) : 0,
+              userBidYears: userOffer ? userOffer.contract.yearsTotal : 0,
+              userOfferContractModel: userOffer?.contractModel ?? null,
+              userBidValue: Math.round(userBidValue * 10) / 10,
+              userTrailReason,
+          }
+        };
+    });
+
+  // Include FA day state for UI
+  const faDay = meta.freeAgencyState?.day ?? 1;
+  const faMaxDays = meta.freeAgencyState?.maxDays ?? 5;
+
+  // Market V2: the user team's pending offer ledger + cap reservation summary.
+  const offerLedger = ensurePendingOffersList(meta.pendingOffers);
+  const pendingOffers = offerLedger
+    .filter((row) => Number(row.teamId) === Number(userTeamId))
+    .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
+  const reservedPendingCap = computeReservedPendingCap(offerLedger, userTeamId);
+  const userCapRoom = Math.round(Number(userTeam?.capRoom ?? 0) * 10) / 10;
+  const capSummary = {
+    capRoom: userCapRoom,
+    reservedPendingCap,
+    effectiveCapRoom: Math.round((userCapRoom - reservedPendingCap) * 10) / 10,
+  };
+
+  // aiFaEngine V1: count of non-user pending AI offers per player (badge data for UI).
+  // AI bids live on player.offers (not in the pending ledger), so count there.
+  // Amounts are NOT included — the UI only shows the count before resolution.
+  const aiOfferCountByPlayerId = {};
+  for (const p of cache.getAllPlayers()) {
+    if (p.teamId != null && p.status !== 'free_agent') continue;
+    if (!Array.isArray(p.offers) || p.offers.length === 0) continue;
+    const aiCount = p.offers.filter((o) => Number(o?.teamId) !== Number(userTeamId)).length;
+    if (aiCount > 0) aiOfferCountByPlayerId[String(p.id)] = aiCount;
+  }
+
+  post(toUI.FREE_AGENT_DATA, { freeAgents, faDay, faMaxDays, phase: meta.phase, pendingOffers, capSummary, aiOfferCountByPlayerId }, id);
+}
+
+// ── Handler: SUBMIT_OFFER ─────────────────────────────────────────────────────
+
+export async function handleSubmitOffer({ playerId, teamId, contract }, id, ctx) {
+  const { cache, post } = ctx;
+  const teamCtx = ctx.resolveTeamContext(teamId);
+  if (!teamCtx.ok) { post(toUI.ERROR, { message: teamCtx.message }, id); return; }
+  const { teamId: resolvedTeamId, team } = teamCtx;
+
+  const player = cache.getPlayer(playerId);
+  if (!player) { post(toUI.ERROR, { message: 'Player not found' }, id); return; }
+
+  // Cap check: the offer must fit inside cap room net of what other pending
+  // offers from this team already reserve.
+  const capHit = contract.baseAnnual + (contract.signingBonus / contract.yearsTotal);
+  const ledger = ctx.getPendingOffersLedger();
+  const capCheck = validateOfferAgainstReservedCap({
+    capRoom: team.capRoom ?? 0,
+    annualCapHit: capHit,
+    pendingOffers: ledger,
+    teamId: resolvedTeamId,
+    playerId: player.id,
+  });
+  if (!capCheck.ok) {
+    post(toUI.ERROR, { message: capCheck.message }, id);
+    return;
+  }
+
+  // Add/Update offer
+  if (!player.offers) player.offers = [];
+
+  // Remove existing offer from this team if any
+  const existingIdx = player.offers.findIndex(o => o.teamId === resolvedTeamId);
+  if (existingIdx > -1) player.offers.splice(existingIdx, 1);
+
+  player.offers.push({
+      teamId: resolvedTeamId,
+      teamName: team.name,
+      contract,
+      timestamp: Date.now()
+  });
+
+  // We strictly don't save "offers" to DB in this simplified model unless we updated schema.
+  // But cache.updatePlayer marks it dirty.
+  // IMPORTANT: Player object schema in DB needs to support 'offers'.
+  // IndexedDB 'put' will handle extra fields fine.
+  cache.updatePlayer(playerId, { offers: player.offers });
+
+  const liveMeta = ensureDynastyMeta(cache.getMeta());
+
+  // Record the bid in the league-level pending offer ledger (replaces any
+  // previous pending offer from this team on this player).
+  const faDay = Number(liveMeta?.freeAgencyState?.day ?? 1);
+  const demandSnapshot = ctx.buildDemandSnapshotForOffer(player, team);
+  const competingTeamIds = player.offers
+    .map((o) => Number(o?.teamId))
+    .filter((tid) => Number.isFinite(tid) && tid !== Number(resolvedTeamId));
+  const quality = buildOfferFeedback({
+    contract,
+    demand: demandSnapshot,
+    playerAge: player.age,
+    competingOfferCount: competingTeamIds.length,
+    capRoomAfter: capCheck.roomAfter,
+  });
+  const offerRecord = createPendingOffer({
+    playerId: player.id,
+    playerName: player.name,
+    pos: player.pos,
+    ovr: player.ovr,
+    teamId: resolvedTeamId,
+    teamName: team.name,
+    contract,
+    day: faDay,
+    demandSnapshot,
+    competingTeamIds,
+    feedback: quality.feedback,
+    score: quality.score,
+  });
+  ctx.savePendingOffersLedger(upsertPendingOffer(ledger, offerRecord).list, { day: faDay });
+  const allFreeAgents = cache.getAllPlayers().filter((p) => !p.teamId || p.status === 'free_agent');
+  const heat = computeMarketHeat(player.pos, allFreeAgents);
+  const marketMemory = liveMeta?.contractMarketMemory?.[String(playerId)] ?? {};
+  const decisionTiming = buildDecisionTiming(player, heat, player.offers.length, liveMeta.phase, {
+    waitCycles: Number(marketMemory?.waitCycles ?? 0),
+  });
+  let immediateOutcome = null;
+  if (liveMeta.phase !== 'free_agency' || decisionTiming.resolveNow) {
+    immediateOutcome = await ctx.resolvePendingFreeAgencyOffers({
+      resolutionDay: 7,
+      onlyPlayerId: playerId,
+      emitNotifications: false,
+    });
+    // Mirror any immediate resolution into the ledger so the offer's status
+    // reads accepted/rejected instead of dangling as pending.
+    ctx.syncPendingOfferLedger({ day: faDay });
+  }
+
+  await ctx.flushDirty();
+
+  // Return updated FA data view so UI reflects the offer immediately
+  // Also state update
+  await handleGetFreeAgents({}, null, ctx); // Broadcast FA update if needed, but easier to just reply success
+  const submittedOffer = ctx.getPendingOffersLedger().find((row) => row.id === offerRecord.id) ?? offerRecord;
+  post(toUI.STATE_UPDATE, { ...ctx.buildViewState(), submittedOffer }, id);
+
+  if (immediateOutcome?.signedCount > 0) {
+    const resolved = immediateOutcome.results?.[0];
+    if (resolved?.signedTeamId === resolvedTeamId) {
+      post(toUI.NOTIFICATION, { level: 'info', message: `${resolved.playerName} accepted your offer immediately.` });
+    } else if (resolved?.signedTeamName) {
+      post(toUI.NOTIFICATION, { level: 'warn', message: `${resolved.playerName} signed with ${resolved.signedTeamName}.` });
+    }
+  } else if (immediateOutcome?.results?.[0]?.status === 'pending') {
+    const pending = immediateOutcome?.results?.[0];
+    if (pending?.changed || pending?.urgency === 'high') {
+      post(toUI.NOTIFICATION, { level: pending?.urgency === 'high' ? 'warn' : 'info', message: `${player.name}: ${pending?.reason ?? decisionTiming.reason}.` });
+    }
+  } else if (!immediateOutcome) {
+    post(toUI.NOTIFICATION, { level: 'info', message: `${player.name} logged your bid. ${decisionTiming.reason}.` });
+  }
+}
+
+// ── Handler: WITHDRAW_OFFER ───────────────────────────────────────────────────
+
+export async function handleWithdrawOffer({ playerId, teamId }, id, ctx) {
+  const { cache, post } = ctx;
+  const teamCtx = ctx.resolveTeamContext(teamId);
+  if (!teamCtx.ok) { post(toUI.ERROR, { message: teamCtx.message }, id); return; }
+  const { teamId: resolvedTeamId } = teamCtx;
+
+  const player = cache.getPlayer(playerId);
+  if (player && Array.isArray(player.offers)) {
+    const nextOffers = player.offers.filter((o) => Number(o?.teamId) !== Number(resolvedTeamId));
+    if (nextOffers.length !== player.offers.length) {
+      cache.updatePlayer(player.id, { offers: nextOffers });
+    }
+  }
+
+  const faDay = Number(cache.getMeta()?.freeAgencyState?.day ?? 1);
+  ctx.savePendingOffersLedger(markOfferResolved(ctx.getPendingOffersLedger(), {
+    playerId,
+    teamId: resolvedTeamId,
+    status: PENDING_OFFER_STATUS.WITHDRAWN,
+    feedback: 'Offer withdrawn — cap reservation released.',
+    day: faDay,
+  }), { day: faDay });
+
+  await ctx.flushDirty();
+  await handleGetFreeAgents({}, null, ctx);
+  post(toUI.STATE_UPDATE, ctx.buildViewState(), id);
+}

--- a/src/worker/handlers/rosterHandlers.js
+++ b/src/worker/handlers/rosterHandlers.js
@@ -1,0 +1,88 @@
+/**
+ * rosterHandlers.js — GET_ROSTER.
+ *
+ * Extracted from worker.js (Worker Handler Registry V1); behavior unchanged.
+ * Produces the ROSTER_DATA view-model slice for one team.
+ */
+import { toUI } from '../protocol.js';
+import { Constants } from '../../core/constants.js';
+import { calculateMorale } from '../../core/player.js';
+import {
+  calculateOffensiveSchemeFit,
+  calculateDefensiveSchemeFit,
+} from '../../core/scheme-core.js';
+import { buildRosterBuildingAnalysis } from '../../core/rosterBuildingAnalysis.js';
+
+// ── Handler: GET_ROSTER ───────────────────────────────────────────────────────
+
+export async function handleGetRoster({ teamId }, id, ctx) {
+  const { cache, post } = ctx;
+  const numId = Number(teamId);
+  const team  = cache.getTeam(numId);
+  if (!team) { post(toUI.ERROR, { message: `Team ${teamId} not found` }, id); return; }
+
+  const players = cache.getPlayersByTeam(numId).map(p => {
+      let fit = 50;
+      if (team && team.staff && team.staff.headCoach) {
+          const hc = team.staff.headCoach;
+          const isOff = ['QB','RB','WR','TE','OL','K'].includes(p.pos);
+          const isDef = ['DL','LB','CB','S','P'].includes(p.pos);
+
+          if (isOff) fit = calculateOffensiveSchemeFit(p, hc.offScheme || 'Balanced');
+          else if (isDef) fit = calculateDefensiveSchemeFit(p, hc.defScheme || '4-3');
+      }
+
+      // Normalise contract: handle both nested p.contract and legacy flat fields.
+      const contract = p.contract ?? (
+        p.baseAnnual != null ? {
+          years:         p.years        ?? 1,
+          yearsTotal:    p.yearsTotal   ?? p.years ?? 1,
+          yearsRemaining:p.years        ?? 1,
+          baseAnnual:    p.baseAnnual,
+          signingBonus:  p.signingBonus ?? 0,
+          guaranteedPct: p.guaranteedPct ?? 0.5,
+        } : null
+      );
+
+      return {
+        id:               p.id,
+        name:             p.name,
+        pos:              p.pos,
+        age:              p.age,
+        ovr:              p.ovr,
+        progressionDelta: p.progressionDelta ?? null,
+        potential:        p.potential ?? null,
+        status:           p.status ?? 'active',
+        onTradeBlock:     p?.onTradeBlock ?? false,
+        contract,
+        traits:           p.traits ?? [],
+        schemeFit:        fit,
+        morale:           calculateMorale(p, team, true)
+      };
+  });
+
+  const analysis = buildRosterBuildingAnalysis({
+    team,
+    roster: players,
+    cap: { capRoom: team?.capRoom, capUsed: team?.capUsed, deadCap: team?.deadCap },
+    freeAgents: cache.getAllPlayers().filter((p) => !p?.teamId || p?.status === 'free_agent'),
+    draftPicks: Array.isArray(team?.picks) ? team.picks : [],
+  });
+
+  post(toUI.ROSTER_DATA, {
+    teamId: numId,
+    team: {
+      id:                team.id,
+      name:              team.name,
+      abbr:              team.abbr,
+      capUsed:           team.capUsed           ?? 0,
+      capRoom:           team.capRoom           ?? 0,
+      capTotal:          team.capTotal          ?? Constants.SALARY_CAP.HARD_CAP,
+      deadCap:           team.deadCap           ?? 0,
+      deadMoneyNextYear: team.deadMoneyNextYear  ?? 0,
+      staff:             team.staff,
+    },
+    players,
+    analysis,
+  }, id);
+}

--- a/src/worker/handlers/saveHandlers.js
+++ b/src/worker/handlers/saveHandlers.js
@@ -1,0 +1,24 @@
+/**
+ * saveHandlers.js — SAVE_NOW.
+ *
+ * Extracted from worker.js (Worker Handler Registry V1); behavior unchanged.
+ * Dirty-flush accumulator internals stay in the worker — this handler only
+ * asks the context to flush and reports the outcome.
+ */
+import { toUI } from '../protocol.js';
+
+// ── Handler: SAVE_NOW ─────────────────────────────────────────────────────────
+
+export async function handleSaveNow(payload, id, ctx) {
+  // Verify the DB connection is still alive before attempting a flush.
+  // On iOS/Safari, the connection can be silently killed after backgrounding.
+  // openDB() re-opens if needed; if it rejects, the catch below surfaces the error.
+  try {
+    if (ctx.getActiveLeagueId()) await ctx.openDB();
+    await ctx.flushDirty();
+    ctx.post(toUI.SAVED, {}, id);
+  } catch (err) {
+    console.error('[Worker] SAVE_NOW failed:', err.message);
+    ctx.post(toUI.ERROR, { message: `Save failed: ${err.message}` }, id);
+  }
+}

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -53,6 +53,12 @@
  */
 
 import { toWorker, toUI } from './protocol.js';
+import { createCommandRegistry } from './commandRegistry.js';
+import { createWorkerContext } from './workerContext.js';
+import { handleGetRoster } from './handlers/rosterHandlers.js';
+import { handleGetFreeAgents, handleSubmitOffer, handleWithdrawOffer } from './handlers/freeAgencyHandlers.js';
+import { handleSaveNow } from './handlers/saveHandlers.js';
+import { handleGetDraftState } from './handlers/draftHandlers.js';
 import {
   createEmptyDirtySnapshot,
   hasDirtySnapshot,
@@ -96,7 +102,7 @@ import {
   marketHeatLabel,
 } from '../core/contract-market.js';
 import { getTeamContextForNegotiation } from '../core/teamContext/negotiationContext.js';
-import { evaluateContractOffer, summarizeNegotiationStance } from '../core/contracts/negotiation.js';
+import { evaluateContractOffer } from '../core/contracts/negotiation.js';
 import {
   hydratePlayerAgent,
   evaluateAgentNegotiation,
@@ -163,17 +169,9 @@ import {
   getNegotiationContext,
 } from '../core/contracts/negotiationModifiers.js';
 import { classifyDeadlinePosture, DEADLINE_POSTURE } from '../core/trades/tradeDeadlinePressure.js';
-import { getFreeAgencyDecisionState } from '../core/freeAgency/decisionState.js';
 import {
-  PENDING_OFFER_STATUS,
   ensurePendingOffersList,
-  createPendingOffer,
-  upsertPendingOffer,
-  computeReservedPendingCap,
-  validateOfferAgainstReservedCap,
-  buildOfferFeedback,
   agePendingOffers,
-  markOfferResolved,
   reconcilePendingOffers,
   expireAllPendingOffers,
   prunePendingOffers,
@@ -331,7 +329,6 @@ import {
 import { deriveFeatsFromRichGame } from '../core/sim/featDerivation.js';
 import { deriveGamePlanMultipliers } from '../core/sim/gamePlanMultipliers.ts';
 import { buildGamePlanNarrative } from '../core/narrative.js';
-import { buildRosterBuildingAnalysis } from '../core/rosterBuildingAnalysis.js';
 import { buildAiTeamStrategy, mapPlayerPosToNeedGroup } from '../core/aiTeamStrategy.js';
 import {
   TEAM_STRATEGIC_POSTURE,
@@ -6803,21 +6800,7 @@ async function handleImportSave({ data, saveName }, id) {
   }
 }
 
-// ── Handler: SAVE_NOW ─────────────────────────────────────────────────────────
-
-async function handleSaveNow(payload, id) {
-  // Verify the DB connection is still alive before attempting a flush.
-  // On iOS/Safari, the connection can be silently killed after backgrounding.
-  // openDB() re-opens if needed; if it rejects, the catch below surfaces the error.
-  try {
-    if (getActiveLeagueId()) await openDB();
-    await flushDirty();
-    post(toUI.SAVED, {}, id);
-  } catch (err) {
-    console.error('[Worker] SAVE_NOW failed:', err.message);
-    post(toUI.ERROR, { message: `Save failed: ${err.message}` }, id);
-  }
-}
+// SAVE_NOW is handled by src/worker/handlers/saveHandlers.js via the command registry.
 
 // ── Handler: RESET_LEAGUE ─────────────────────────────────────────────────────
 
@@ -7079,7 +7062,10 @@ async function handleSignPlayer({ playerId, teamId, contract }, id) {
   post(toUI.STATE_UPDATE, { roster: buildRosterView(resolvedTeamId), ...buildViewState(), freeAgentSigning: completedSigning }, id);
 }
 
-// ── Handler: SUBMIT_OFFER ─────────────────────────────────────────────────────
+// SUBMIT_OFFER / WITHDRAW_OFFER are handled by src/worker/handlers/freeAgencyHandlers.js
+// via the command registry. The pending-offer ledger helpers below stay here
+// because the unmigrated offseason/FA-day systems also use them; the handlers
+// reach them through the worker context.
 
 // ── Pending offer ledger (Free Agency Market V2) ─────────────────────────────
 // League-level record of submitted offers, persisted on meta.pendingOffers.
@@ -7183,153 +7169,6 @@ function syncPendingOfferLedger({ day = null, emitNotifications = false } = {}) 
   }
 
   return { accepted, rejected, expired };
-}
-
-async function handleSubmitOffer({ playerId, teamId, contract }, id) {
-  const teamCtx = resolveTeamContext(teamId);
-  if (!teamCtx.ok) { post(toUI.ERROR, { message: teamCtx.message }, id); return; }
-  const { teamId: resolvedTeamId, team } = teamCtx;
-
-  const player = cache.getPlayer(playerId);
-  if (!player) { post(toUI.ERROR, { message: 'Player not found' }, id); return; }
-
-  // Cap check: the offer must fit inside cap room net of what other pending
-  // offers from this team already reserve.
-  const capHit = contract.baseAnnual + (contract.signingBonus / contract.yearsTotal);
-  const ledger = getPendingOffersLedger();
-  const capCheck = validateOfferAgainstReservedCap({
-    capRoom: team.capRoom ?? 0,
-    annualCapHit: capHit,
-    pendingOffers: ledger,
-    teamId: resolvedTeamId,
-    playerId: player.id,
-  });
-  if (!capCheck.ok) {
-    post(toUI.ERROR, { message: capCheck.message }, id);
-    return;
-  }
-
-  // Add/Update offer
-  if (!player.offers) player.offers = [];
-
-  // Remove existing offer from this team if any
-  const existingIdx = player.offers.findIndex(o => o.teamId === resolvedTeamId);
-  if (existingIdx > -1) player.offers.splice(existingIdx, 1);
-
-  player.offers.push({
-      teamId: resolvedTeamId,
-      teamName: team.name,
-      contract,
-      timestamp: Date.now()
-  });
-
-  // We strictly don't save "offers" to DB in this simplified model unless we updated schema.
-  // But cache.updatePlayer marks it dirty.
-  // IMPORTANT: Player object schema in DB needs to support 'offers'.
-  // IndexedDB 'put' will handle extra fields fine.
-  cache.updatePlayer(playerId, { offers: player.offers });
-
-  const liveMeta = ensureDynastyMeta(cache.getMeta());
-
-  // Record the bid in the league-level pending offer ledger (replaces any
-  // previous pending offer from this team on this player).
-  const faDay = Number(liveMeta?.freeAgencyState?.day ?? 1);
-  const demandSnapshot = buildDemandSnapshotForOffer(player, team);
-  const competingTeamIds = player.offers
-    .map((o) => Number(o?.teamId))
-    .filter((tid) => Number.isFinite(tid) && tid !== Number(resolvedTeamId));
-  const quality = buildOfferFeedback({
-    contract,
-    demand: demandSnapshot,
-    playerAge: player.age,
-    competingOfferCount: competingTeamIds.length,
-    capRoomAfter: capCheck.roomAfter,
-  });
-  const offerRecord = createPendingOffer({
-    playerId: player.id,
-    playerName: player.name,
-    pos: player.pos,
-    ovr: player.ovr,
-    teamId: resolvedTeamId,
-    teamName: team.name,
-    contract,
-    day: faDay,
-    demandSnapshot,
-    competingTeamIds,
-    feedback: quality.feedback,
-    score: quality.score,
-  });
-  savePendingOffersLedger(upsertPendingOffer(ledger, offerRecord).list, { day: faDay });
-  const allFreeAgents = cache.getAllPlayers().filter((p) => !p.teamId || p.status === 'free_agent');
-  const heat = computeMarketHeat(player.pos, allFreeAgents);
-  const marketMemory = liveMeta?.contractMarketMemory?.[String(playerId)] ?? {};
-  const decisionTiming = buildDecisionTiming(player, heat, player.offers.length, liveMeta.phase, {
-    waitCycles: Number(marketMemory?.waitCycles ?? 0),
-  });
-  let immediateOutcome = null;
-  if (liveMeta.phase !== 'free_agency' || decisionTiming.resolveNow) {
-    immediateOutcome = await resolvePendingFreeAgencyOffers({
-      resolutionDay: 7,
-      onlyPlayerId: playerId,
-      emitNotifications: false,
-    });
-    // Mirror any immediate resolution into the ledger so the offer's status
-    // reads accepted/rejected instead of dangling as pending.
-    syncPendingOfferLedger({ day: faDay });
-  }
-
-  await flushDirty();
-
-  // Return updated FA data view so UI reflects the offer immediately
-  // Also state update
-  await handleGetFreeAgents({}, null); // Broadcast FA update if needed, but easier to just reply success
-  const submittedOffer = getPendingOffersLedger().find((row) => row.id === offerRecord.id) ?? offerRecord;
-  post(toUI.STATE_UPDATE, { ...buildViewState(), submittedOffer }, id);
-
-  if (immediateOutcome?.signedCount > 0) {
-    const resolved = immediateOutcome.results?.[0];
-    if (resolved?.signedTeamId === resolvedTeamId) {
-      post(toUI.NOTIFICATION, { level: 'info', message: `${resolved.playerName} accepted your offer immediately.` });
-    } else if (resolved?.signedTeamName) {
-      post(toUI.NOTIFICATION, { level: 'warn', message: `${resolved.playerName} signed with ${resolved.signedTeamName}.` });
-    }
-  } else if (immediateOutcome?.results?.[0]?.status === 'pending') {
-    const pending = immediateOutcome?.results?.[0];
-    if (pending?.changed || pending?.urgency === 'high') {
-      post(toUI.NOTIFICATION, { level: pending?.urgency === 'high' ? 'warn' : 'info', message: `${player.name}: ${pending?.reason ?? decisionTiming.reason}.` });
-    }
-  } else if (!immediateOutcome) {
-    post(toUI.NOTIFICATION, { level: 'info', message: `${player.name} logged your bid. ${decisionTiming.reason}.` });
-  }
-}
-
-// ── Handler: WITHDRAW_OFFER ───────────────────────────────────────────────────
-
-async function handleWithdrawOffer({ playerId, teamId }, id) {
-  const teamCtx = resolveTeamContext(teamId);
-  if (!teamCtx.ok) { post(toUI.ERROR, { message: teamCtx.message }, id); return; }
-  const { teamId: resolvedTeamId } = teamCtx;
-
-  const player = cache.getPlayer(playerId);
-  if (player && Array.isArray(player.offers)) {
-    const nextOffers = player.offers.filter((o) => Number(o?.teamId) !== Number(resolvedTeamId));
-    if (nextOffers.length !== player.offers.length) {
-      cache.updatePlayer(player.id, { offers: nextOffers });
-    }
-  }
-
-  const faDay = Number(cache.getMeta()?.freeAgencyState?.day ?? 1);
-  savePendingOffersLedger(markOfferResolved(getPendingOffersLedger(), {
-    playerId,
-    teamId: resolvedTeamId,
-    status: PENDING_OFFER_STATUS.WITHDRAWN,
-    feedback: 'Offer withdrawn — cap reservation released.',
-    day: faDay,
-  }), { day: faDay });
-
-  await flushDirty();
-  await handleGetFreeAgents({}, null);
-  post(toUI.STATE_UPDATE, buildViewState(), id);
 }
 
 async function finalizeFreeAgencySigning(player, offer, liveMeta) {
@@ -7835,7 +7674,7 @@ async function handleCancelWaiverClaim({ playerId }, id) {
   post(toUI.STATE_UPDATE, buildViewState(), id);
 }
 
-// ── Handler: GET_ROSTER ───────────────────────────────────────────────────────
+// ── Handler: GET_NEWS ─────────────────────────────────────────────────────────
 
 async function handleGetNews({ limit } = {}, id) {
   // The worker is the single source of truth for news. The UI reads news through
@@ -7851,335 +7690,8 @@ async function handleGetNews({ limit } = {}, id) {
   }
 }
 
-async function handleGetRoster({ teamId }, id) {
-  const numId = Number(teamId);
-  const team  = cache.getTeam(numId);
-  if (!team) { post(toUI.ERROR, { message: `Team ${teamId} not found` }, id); return; }
-
-  const players = cache.getPlayersByTeam(numId).map(p => {
-      let fit = 50;
-      if (team && team.staff && team.staff.headCoach) {
-          const hc = team.staff.headCoach;
-          const isOff = ['QB','RB','WR','TE','OL','K'].includes(p.pos);
-          const isDef = ['DL','LB','CB','S','P'].includes(p.pos);
-
-          if (isOff) fit = calculateOffensiveSchemeFit(p, hc.offScheme || 'Balanced');
-          else if (isDef) fit = calculateDefensiveSchemeFit(p, hc.defScheme || '4-3');
-      }
-
-      // Normalise contract: handle both nested p.contract and legacy flat fields.
-      const contract = p.contract ?? (
-        p.baseAnnual != null ? {
-          years:         p.years        ?? 1,
-          yearsTotal:    p.yearsTotal   ?? p.years ?? 1,
-          yearsRemaining:p.years        ?? 1,
-          baseAnnual:    p.baseAnnual,
-          signingBonus:  p.signingBonus ?? 0,
-          guaranteedPct: p.guaranteedPct ?? 0.5,
-        } : null
-      );
-
-      return {
-        id:               p.id,
-        name:             p.name,
-        pos:              p.pos,
-        age:              p.age,
-        ovr:              p.ovr,
-        progressionDelta: p.progressionDelta ?? null,
-        potential:        p.potential ?? null,
-        status:           p.status ?? 'active',
-        onTradeBlock:     p?.onTradeBlock ?? false,
-        contract,
-        traits:           p.traits ?? [],
-        schemeFit:        fit,
-        morale:           calculateMorale(p, team, true)
-      };
-  });
-
-  const analysis = buildRosterBuildingAnalysis({
-    team,
-    roster: players,
-    cap: { capRoom: team?.capRoom, capUsed: team?.capUsed, deadCap: team?.deadCap },
-    freeAgents: cache.getAllPlayers().filter((p) => !p?.teamId || p?.status === 'free_agent'),
-    draftPicks: Array.isArray(team?.picks) ? team.picks : [],
-  });
-
-  post(toUI.ROSTER_DATA, {
-    teamId: numId,
-    team: {
-      id:                team.id,
-      name:              team.name,
-      abbr:              team.abbr,
-      capUsed:           team.capUsed           ?? 0,
-      capRoom:           team.capRoom           ?? 0,
-      capTotal:          team.capTotal          ?? Constants.SALARY_CAP.HARD_CAP,
-      deadCap:           team.deadCap           ?? 0,
-      deadMoneyNextYear: team.deadMoneyNextYear  ?? 0,
-      staff:             team.staff,
-    },
-    players,
-    analysis,
-  }, id);
-}
-
-// ── Handler: GET_FREE_AGENTS ──────────────────────────────────────────────────
-
-async function handleGetFreeAgents(payload, id) {
-  const meta = ensureDynastyMeta(cache.getMeta());
-  const inflationMult = getSalaryInflationMultiplier(meta?.economy ?? {});
-  const userTeamId = meta.userTeamId;
-  // teamId 0 is a valid franchise (the default user team) — only a null/undefined
-  // teamId means unsigned, so accepted players never linger in the FA pool.
-  const allFreeAgents = cache.getAllPlayers().filter((p) => p.teamId == null || p.status === 'free_agent');
-  const userTeam = cache.getTeam(userTeamId);
-  const userDirection = inferTeamDirection(userTeam, Number(meta?.currentWeek ?? 1));
-  const userWinPct = Math.max(0, Math.min(1, (() => {
-    const wins = Number(userTeam?.wins ?? 0);
-    const losses = Number(userTeam?.losses ?? 0);
-    const ties = Number(userTeam?.ties ?? 0);
-    const games = wins + losses + ties;
-    return games > 0 ? (wins + ties * 0.5) / games : 0.5;
-  })()));
-
-  const freeAgents = allFreeAgents
-    .map(p => {
-        const continuity = getOffseasonReturnSnapshot(p.id, userTeamId, meta);
-        const playbookKnowledgeScore = Math.max(0, Math.min(100, continuity ? Number(continuity?.schemeFit ?? p?.schemeFit ?? 50) : Number(p?.schemeFit ?? 50)));
-        const playbookKnowledgeLabel = playbookKnowledgeScore >= 80
-          ? 'High'
-          : playbookKnowledgeScore >= 60
-            ? 'Moderate'
-            : playbookKnowledgeScore >= 35
-              ? 'Low'
-              : 'None';
-        const scoutingView = buildScoutingSnapshot(p, userTeam, { fogStrength: Number(getLeagueSetting('scoutingFogStrength', 50)), commissionerMode: !!meta?.commissionerMode });
-        // Summarize offers for UI — bidding war edition
-        const offers = p.offers || [];
-        const userOffer = offers.find(o => o.teamId === userTeamId);
-        const profile = buildContractProfile(p);
-        const heat = computeMarketHeat(p.pos, allFreeAgents);
-        const baseAsk = inflateContract(buildDemandFromProfile(p, profile, {
-          marketHeat: heat,
-          morale: p.morale ?? 68,
-          fit: Number(p?.schemeFit ?? 65),
-          teamSuccess: userWinPct,
-        }), inflationMult);
-        // V2: apply negotiation modifiers (morale, awards, franchise reputation)
-        const pMoraleSummary = getPlayerMoraleSummary(p);
-        const pAwardSummary = getPlayerAwardSummary(p);
-        const faCurrentSeason = Number(meta?.season ?? 0);
-        const pLeverage = computePlayerLeverage(p, { moraleSummary: pMoraleSummary, awardSummary: pAwardSummary, currentSeason: faCurrentSeason });
-        const faUserTeam = cache.getTeam(Number(userTeamId ?? 0));
-        const faInstability = getCoachingInstabilityPenalty(faUserTeam?.coachHistory ?? [], 3);
-        const fReputation = computeFranchiseReputation(meta, { userTeamId: Number(userTeamId ?? 0), currentSeason: faCurrentSeason, coachingInstabilityPenalty: faInstability });
-        const ask = applyNegotiationModifiers(baseAsk, pLeverage, fReputation);
-        const pNegCtx = getNegotiationContext(p, meta, { moraleSummary: pMoraleSummary, awardSummary: pAwardSummary, currentSeason: faCurrentSeason, userTeamId: Number(userTeamId ?? 0) });
-        const reSignInsight = evaluateReSignPriority(p, {
-          marketHeat: heat,
-          teamDirection: userDirection,
-          capRoom: userTeam?.capRoom ?? 0,
-          teamSuccess: userWinPct,
-          profile,
-          demand: ask,
-        });
-
-        // Find the top bid (highest total contract value)
-        let topBid = null;
-        let topOfferValue = 0;
-        let userTrailReason = null;
-        for (const o of offers) {
-            const c = o.contract;
-            const val = (c.baseAnnual * c.yearsTotal) + (c.signingBonus || 0);
-            if (val > topOfferValue) {
-                topOfferValue = val;
-                topBid = o;
-            }
-        }
-
-        const annualCapHitForOffer = (offer) => {
-            const c = offer?.contract ?? {};
-            const years = Math.max(1, Number(c.yearsTotal ?? c.years ?? 1));
-            const baseAnnual = Number(c.baseAnnual ?? c.annualSalary ?? c.annual ?? 0);
-            const signingBonus = Number(c.signingBonus ?? 0);
-            return Math.round((baseAnnual + (signingBonus / years)) * 10) / 10;
-        };
-
-        // Calculate user's bid value if they have one
-        let userBidValue = 0;
-        if (userOffer) {
-            const uc = userOffer.contract;
-            userBidValue = (uc.baseAnnual * uc.yearsTotal) + (uc.signingBonus || 0);
-            if (topBid && topBid.teamId !== userTeamId) {
-              const moneyGap = Math.round((topOfferValue - userBidValue) * 10) / 10;
-              userTrailReason = moneyGap > 0.4 ? `Trailing on value by $${moneyGap}M` : 'Another team offers better fit';
-            }
-        }
-
-        const mem = meta?.contractMarketMemory?.[String(p.id)] ?? {};
-        const topGapRatio = topOfferValue > 0
-          ? Math.max(0, ((ask.baseAnnual * ask.yearsTotal + (ask.signingBonus || 0)) - topOfferValue) / Math.max(1, (ask.baseAnnual * ask.yearsTotal + (ask.signingBonus || 0))))
-          : 0;
-        const decisionTiming = buildDecisionTiming(p, heat, offers.length, meta.phase, {
-          waitCycles: Number(mem?.waitCycles ?? 0),
-          moneyGapRatio: topGapRatio,
-        });
-        const detailTone = userOffer
-          ? userOffer.teamId === topBid?.teamId
-            ? (offers.length >= 3 ? "You're leading, but another team is close" : 'Your bid leads')
-            : (userTrailReason || 'Another team currently leads')
-          : (offers.length >= 2 ? 'Warm market' : 'Open market');
-        const knownMarket = offers.length > 0 || !!userOffer || !!topBid;
-        const riskLabelByRisk = {
-          high: 'High risk of movement',
-          medium: 'Moderate risk',
-          low: 'Low immediate risk',
-        };
-        const patienceLabel = decisionTiming.patienceWeeks <= 1
-          ? 'Ready to decide now'
-          : decisionTiming.patienceWeeks <= 2
-            ? 'Likely to decide soon'
-            : `Decision window: ${decisionTiming.patienceWeeks} cycle${decisionTiming.patienceWeeks > 1 ? 's' : ''}`;
-        const topPreferences = [
-          ['money', profile.moneyPriority],
-          ['contender', profile.contenderPriority],
-          ['role', profile.rolePriority],
-          ['security', profile.securityPriority],
-          ['loyalty', profile.loyaltyPriority],
-        ]
-          .sort((a, b) => b[1] - a[1])
-          .slice(0, 3)
-          .map(([tag]) => tag);
-
-        const teamNegotiationContext = getTeamContextForNegotiation(p, userTeam, null, {
-          teamDirection: userDirection,
-          needsAtPosition: AiLogic.calculateTeamNeeds(userTeamId)?.[p.pos] ?? 1,
-          rosterAtPosition: cache.getPlayersByTeam(userTeamId).filter((rp) => rp?.pos === p?.pos),
-        });
-        const userOfferEval = evaluateContractOffer(p, {
-          ...teamNegotiationContext,
-          schemeFitScore: Number(p?.schemeFit ?? 65),
-          franchiseDirectionScore: userDirection === 'contender' ? 78 : userDirection === 'rebuilding' ? 44 : 58,
-        }, userOffer ?? { contract: ask }, {
-          profile,
-          askTotalValue: (ask.baseAnnual * ask.yearsTotal) + (ask.signingBonus || 0),
-          askAnnual: ask.baseAnnual,
-          askYears: ask.yearsTotal,
-        });
-        const moodSummary = summarizePlayerMood(profile, teamNegotiationContext);
-        const decisionState = getFreeAgencyDecisionState({
-          negotiationStance: userOfferEval.negotiationStance,
-          bidderCount: offers.length,
-          urgency: decisionTiming.risk,
-          valueGap: userOfferEval.valueGap,
-        });
-
-        return {
-          id:        p.id,
-          name:      p.name,
-          pos:       p.pos,
-          age:       p.age,
-          ovr:       p.ovr,
-          hofStatus: p.hofStatus ?? 'none',
-          scoutOvr: scoutingView?.estimatedOvr ?? p.ovr,
-          scoutUncertaintyBand: scoutingView?.uncertainty ?? 0,
-          scoutConfidenceLabel: scoutingView?.confidenceLabel ?? 'Medium confidence',
-          potential: p.potential ?? null,
-          contract:  p.contract ?? null,
-          traits:    p.traits ?? [],
-          market: {
-            heat: Math.round(heat * 100) / 100,
-            heatLabel: marketHeatLabel(heat),
-            bidderCount: offers.length,
-            decision: decisionState.summary,
-            decisionReason: `${decisionTiming.reason}. ${summarizeNegotiationStance(userOfferEval)}`,
-            urgency: decisionTiming.risk,
-            urgencyLabel: decisionTiming.risk === 'high'
-              ? 'Decision expected soon'
-              : decisionTiming.risk === 'medium'
-                ? 'Decision window open'
-                : 'No immediate deadline signal',
-            timingState: decisionState.state,
-            attention: detailTone,
-            patienceWeeks: decisionTiming.patienceWeeks,
-            patienceLabel,
-            riskLabel: riskLabelByRisk[decisionTiming.risk] ?? 'Risk unknown',
-            knownMarket,
-            stateChips: decisionState.chips,
-            motivationSummary: moodSummary.summary,
-            fitScore: userOfferEval.score,
-          },
-          demandProfile: {
-            headline: moodSummary.summary,
-            willingness: ask.willingness,
-            askAnnual: ask.baseAnnual,
-            askYears: ask.yearsTotal,
-            priorities: topPreferences,
-            archetype: profile.archetype,
-            contractOutlook: moodSummary.contractOutlook,
-            negotiationStance: userOfferEval.negotiationStance,
-            fitScore: userOfferEval.score,
-            explanationSummary: userOfferEval.explanationSummary,
-            // V2 negotiation modifier context
-            leverageLabel: pNegCtx.leverageLabel,
-            reputationLabel: pNegCtx.reputationLabel,
-            feedbackLine: pNegCtx.feedbackLine,
-            negotiationShift: ask._negotiationShift ?? 0,
-          },
-          playbookKnowledge: {
-            score: Math.round(playbookKnowledgeScore),
-            label: playbookKnowledgeLabel,
-          },
-          reSign: reSignInsight,
-          offers: {
-              count: offers.length,
-              userOffered: !!userOffer,
-              userIsTopBidder: !!userOffer && topBid && topBid.teamId === userTeamId,
-              topOfferValue: Math.round(topOfferValue * 10) / 10,
-              topBidTeam: topBid ? topBid.teamName : null,
-              topBidAnnual: topBid ? Math.round(topBid.contract.baseAnnual * 10) / 10 : 0,
-              topBidAnnualCapHit: topBid ? annualCapHitForOffer(topBid) : 0,
-              topBidYears: topBid ? topBid.contract.yearsTotal : 0,
-              topOfferContractModel: topBid?.contractModel ?? null,
-              userBidAnnual: userOffer ? Math.round(userOffer.contract.baseAnnual * 10) / 10 : 0,
-              userBidAnnualCapHit: userOffer ? annualCapHitForOffer(userOffer) : 0,
-              userBidYears: userOffer ? userOffer.contract.yearsTotal : 0,
-              userOfferContractModel: userOffer?.contractModel ?? null,
-              userBidValue: Math.round(userBidValue * 10) / 10,
-              userTrailReason,
-          }
-        };
-    });
-
-  // Include FA day state for UI
-  const faDay = meta.freeAgencyState?.day ?? 1;
-  const faMaxDays = meta.freeAgencyState?.maxDays ?? 5;
-
-  // Market V2: the user team's pending offer ledger + cap reservation summary.
-  const offerLedger = ensurePendingOffersList(meta.pendingOffers);
-  const pendingOffers = offerLedger
-    .filter((row) => Number(row.teamId) === Number(userTeamId))
-    .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0));
-  const reservedPendingCap = computeReservedPendingCap(offerLedger, userTeamId);
-  const userCapRoom = Math.round(Number(userTeam?.capRoom ?? 0) * 10) / 10;
-  const capSummary = {
-    capRoom: userCapRoom,
-    reservedPendingCap,
-    effectiveCapRoom: Math.round((userCapRoom - reservedPendingCap) * 10) / 10,
-  };
-
-  // aiFaEngine V1: count of non-user pending AI offers per player (badge data for UI).
-  // AI bids live on player.offers (not in the pending ledger), so count there.
-  // Amounts are NOT included — the UI only shows the count before resolution.
-  const aiOfferCountByPlayerId = {};
-  for (const p of cache.getAllPlayers()) {
-    if (p.teamId != null && p.status !== 'free_agent') continue;
-    if (!Array.isArray(p.offers) || p.offers.length === 0) continue;
-    const aiCount = p.offers.filter((o) => Number(o?.teamId) !== Number(userTeamId)).length;
-    if (aiCount > 0) aiOfferCountByPlayerId[String(p.id)] = aiCount;
-  }
-
-  post(toUI.FREE_AGENT_DATA, { freeAgents, faDay, faMaxDays, phase: meta.phase, pendingOffers, capSummary, aiOfferCountByPlayerId }, id);
-}
+// GET_ROSTER and GET_FREE_AGENTS are handled by src/worker/handlers/
+// (rosterHandlers.js / freeAgencyHandlers.js) via the command registry.
 
 // ── Handler: COACHING ACTIONS ────────────────────────────────────────────────
 
@@ -8343,7 +7855,7 @@ async function handleFireCoach({ teamId, role }, id) {
   await flushDirty();
   const refreshed = cache.getTeam(Number(teamId));
   postCoachingState(refreshed ?? team, cache.getMeta(), id);
-  await handleGetRoster({ teamId }, id);
+  await handleGetRoster({ teamId }, id, workerContext);
 }
 
 // ── Handler: HIRE_COACH (V1) ──────────────────────────────────────────────────
@@ -8446,7 +7958,7 @@ async function handleHireCoach({ teamId, coachId, coach: legacyCoach, role }, id
   await flushDirty();
   const refreshed = cache.getTeam(Number(teamId));
   postCoachingState(refreshed ?? team, cache.getMeta(), id);
-  await handleGetRoster({ teamId }, id);
+  await handleGetRoster({ teamId }, id, workerContext);
 }
 
 // ── Handler: CONTRACT_EXTENSION_COACH ────────────────────────────────────────
@@ -8700,7 +8212,7 @@ async function handleConductDrill({ teamId, intensity, drillType, positionGroups
     if (dirtyPlayers.length) await flushDirty();
 
     // Return updated roster so UI can reflect new boost values
-    await handleGetRoster({ teamId: numId }, id);
+    await handleGetRoster({ teamId: numId }, id, workerContext);
 }
 
 // ── Handler: UPDATE_MEDICAL_STAFF ──────────────────────────────────────────
@@ -10439,20 +9951,8 @@ async function handleConductPrivateWorkout({ playerId }, id) {
   }
 }
 
-// ── Handler: GET_DRAFT_STATE ──────────────────────────────────────────────────
-
-
-async function handleGetDraftState(payload, id) {
-  try {
-    const meta = ensureDynastyMeta(cache.getMeta());
-    if (meta?.phase === 'draft' && !meta?.draftState) {
-      await handleStartDraft({}, null);
-    }
-    post(toUI.DRAFT_STATE, buildDraftStateView(), id);
-  } catch (error) {
-    post(toUI.ERROR, { message: `Draft state unavailable. Retry or cancel sim. (${error?.message ?? 'unknown error'})` }, id);
-  }
-}
+// GET_DRAFT_STATE is handled by src/worker/handlers/draftHandlers.js via the
+// command registry (draft execution stays in this file).
 
 
 async function handleUpdateDepthChart({ updates, positions }, id) {
@@ -12722,7 +12222,7 @@ async function handleAdvanceFreeAgencyDay(payload, id) {
     // Refresh views
     post(toUI.STATE_UPDATE, buildViewState());
     // Also trigger FA list refresh
-    await handleGetFreeAgents({}, null);
+    await handleGetFreeAgents({}, null, workerContext);
 }
 
 function _initCombineWeek() {
@@ -14431,6 +13931,42 @@ async function handleGetAwardRaces(_payload, id) {
   }, id);
 }
 
+// ── Command registry (Worker Handler Registry V1) ────────────────────────────
+// Migrated commands live in src/worker/handlers/ and are dispatched through
+// the registry with a context object exposing existing worker capabilities.
+// worker.js still owns self.onmessage, the sequential message queue, the
+// state epoch, outbound serialization, and dirty-flush timing.
+
+const workerContext = createWorkerContext({
+  cache,
+  post,
+  flushDirty,
+  buildViewState,
+  getSafeMeta,
+  getLeagueSetting,
+  resolveTeamContext,
+  getOffseasonReturnSnapshot,
+  getPendingOffersLedger,
+  savePendingOffersLedger,
+  syncPendingOfferLedger,
+  buildDemandSnapshotForOffer,
+  resolvePendingFreeAgencyOffers,
+  buildDraftStateView,
+  startDraft: (payload, id) => handleStartDraft(payload, id),
+  getActiveLeagueId,
+  openDB,
+});
+
+const commandRegistry = createCommandRegistry();
+commandRegistry.registerAll({
+  [toWorker.GET_ROSTER]:      handleGetRoster,
+  [toWorker.GET_FREE_AGENTS]: handleGetFreeAgents,
+  [toWorker.SUBMIT_OFFER]:    handleSubmitOffer,
+  [toWorker.WITHDRAW_OFFER]:  handleWithdrawOffer,
+  [toWorker.SAVE_NOW]:        handleSaveNow,
+  [toWorker.GET_DRAFT_STATE]: handleGetDraftState,
+});
+
 // ── Main message router ───────────────────────────────────────────────────────
 
 /**
@@ -14515,6 +14051,12 @@ async function handleMessage(event) {
     // Keep module-scope fallback metadata in sync per message tick.
     meta = getSafeMeta();
 
+    // Migrated commands dispatch through the registry; everything else falls
+    // through to the legacy switch below. Handler errors propagate to the
+    // catch below, so requestId echo and toUI.ERROR behavior are unchanged.
+    const dispatched = await commandRegistry.dispatch(type, payload, id, workerContext);
+    if (dispatched.handled) return;
+
     switch (type) {
       case toWorker.INIT:               return await handleInit(payload, id);
       case toWorker.GET_ALL_SAVES:      return await handleGetAllSaves(payload, id);
@@ -14533,7 +14075,6 @@ async function handleMessage(event) {
       case toWorker.GET_SEASON_HISTORY: return await handleGetSeasonHistory(payload, id);
       case toWorker.GET_ALL_SEASONS:    return await handleGetAllSeasons(payload, id);
       case toWorker.GET_PLAYER_CAREER:  return await handleGetPlayerCareer(payload, id);
-      case toWorker.SAVE_NOW:           return await handleSaveNow(payload, id);
       case toWorker.LOAD_SLOT:          return await handleLoadSlot(payload, id);
       case toWorker.SAVE_SLOT:          return await handleSaveSlot(payload, id);
       case toWorker.DELETE_SLOT:        return await handleDeleteSlot(payload, id);
@@ -14549,8 +14090,6 @@ async function handleMessage(event) {
       case toWorker.IMPORT_DRAFT_CLASS: return await handleImportDraftClass(payload, id);
       case toWorker.SET_USER_TEAM:      return await handleSetUserTeam(payload, id);
       case toWorker.SIGN_PLAYER:        return await handleSignPlayer(payload, id);
-      case toWorker.SUBMIT_OFFER:       return await handleSubmitOffer(payload, id);
-      case toWorker.WITHDRAW_OFFER:     return await handleWithdrawOffer(payload, id);
       case toWorker.RELEASE_PLAYER:     return await handleReleasePlayer(payload, id);
       case toWorker.BULK_RELEASE_PLAYERS: return await handleBulkReleasePlayers(payload, id);
       case toWorker.SUBMIT_WAIVER_CLAIM: return await handleSubmitWaiverClaim(payload, id);
@@ -14559,8 +14098,6 @@ async function handleMessage(event) {
       case toWorker.TOGGLE_COMMISSIONER_MODE: return await handleToggleCommissionerMode(payload, id);
       case toWorker.APPLY_COMMISSIONER_ACTIONS: return await handleApplyCommissionerActions(payload, id);
       case toWorker.GET_NEWS:           return await handleGetNews(payload, id);
-      case toWorker.GET_ROSTER:         return await handleGetRoster(payload, id);
-      case toWorker.GET_FREE_AGENTS:    return await handleGetFreeAgents(payload, id);
       case toWorker.GET_AVAILABLE_COACHES: return await handleGetAvailableCoaches(payload, id);
       case toWorker.GET_STAFF_STATE:    return await handleGetStaffState(payload, id);
       case toWorker.HIRE_STAFF_MEMBER:  return await handleHireStaffMember(payload, id);
@@ -14602,7 +14139,6 @@ async function handleMessage(event) {
       case toWorker.UPDATE_STRATEGY:    return await handleUpdateStrategy(payload, id);
 
       // ── Draft & Offseason ──────────────────────────────────────────────────
-      case toWorker.GET_DRAFT_STATE:    return await handleGetDraftState(payload, id);
       case toWorker.START_DRAFT:        return await handleStartDraft(payload, id);
       case toWorker.MAKE_DRAFT_PICK:    return await handleMakeDraftPick(payload, id);
       case toWorker.CONDUCT_PRIVATE_WORKOUT: return await handleConductPrivateWorkout(payload, id);

--- a/src/worker/workerContext.js
+++ b/src/worker/workerContext.js
@@ -1,0 +1,69 @@
+/**
+ * workerContext.js — capability surface handed to extracted command handlers.
+ *
+ * The worker monolith (worker.js) still owns the runtime: self.onmessage, the
+ * sequential message queue, boot/hydration, state epoch, outbound
+ * serialization, and dirty-flush timing. Handlers extracted into
+ * src/worker/handlers/ receive this context object instead of reaching into
+ * worker.js module scope, which keeps them free of circular imports and
+ * unit-testable with stub capabilities.
+ *
+ * This is intentionally NOT a new state model or store. Every capability is
+ * an existing worker function (or the shared cache singleton) passed through
+ * unchanged. Do not add new state here; add capabilities only when a migrated
+ * handler already used the equivalent worker-scope function.
+ */
+
+/**
+ * Capabilities every extracted handler can rely on:
+ *  - cache: shared in-memory league cache (db/cache.js singleton)
+ *  - post: post(type, payload, id) — outbound message; serialization,
+ *    delta/epoch handling, and Transferables stay owned by worker.js
+ *  - flushDirty: persist dirty cache entries (accumulator internals stay in
+ *    worker.js — handlers only ask for a flush)
+ *  - buildViewState: current UI view-model snapshot (for STATE_UPDATE posts)
+ *  - getSafeMeta: normalized league meta accessor
+ *  - getLeagueSetting: (key, fallback) league settings accessor
+ *  - resolveTeamContext: resolve payload teamId → { ok, meta, teamId, team }
+ *  - getOffseasonReturnSnapshot: chemistry-continuity snapshot lookup
+ *  - getPendingOffersLedger / savePendingOffersLedger / syncPendingOfferLedger
+ *    / buildDemandSnapshotForOffer: pending-offer ledger helpers (shared with
+ *    unmigrated offseason systems, so they remain worker-owned)
+ *  - resolvePendingFreeAgencyOffers: immediate FA offer resolution pipeline
+ *  - buildDraftStateView: draft state view-model builder
+ *  - startDraft: idempotent draft initialization (draft execution stays in
+ *    worker.js)
+ *  - getActiveLeagueId / openDB: DB connection liveness helpers for SAVE_NOW
+ */
+export const WORKER_CONTEXT_CAPABILITIES = Object.freeze([
+  'cache',
+  'post',
+  'flushDirty',
+  'buildViewState',
+  'getSafeMeta',
+  'getLeagueSetting',
+  'resolveTeamContext',
+  'getOffseasonReturnSnapshot',
+  'getPendingOffersLedger',
+  'savePendingOffersLedger',
+  'syncPendingOfferLedger',
+  'buildDemandSnapshotForOffer',
+  'resolvePendingFreeAgencyOffers',
+  'buildDraftStateView',
+  'startDraft',
+  'getActiveLeagueId',
+  'openDB',
+]);
+
+/**
+ * Build the frozen context object passed to registered command handlers.
+ * Validates that every documented capability is present so a wiring mistake
+ * fails loudly at worker boot instead of deep inside a handler.
+ */
+export function createWorkerContext(capabilities = {}) {
+  const missing = WORKER_CONTEXT_CAPABILITIES.filter((name) => capabilities[name] == null);
+  if (missing.length > 0) {
+    throw new Error(`createWorkerContext: missing capabilities: ${missing.join(', ')}`);
+  }
+  return Object.freeze({ ...capabilities });
+}

--- a/tests/unit/freeAgencyMarketV2Wiring.test.js
+++ b/tests/unit/freeAgencyMarketV2Wiring.test.js
@@ -23,10 +23,11 @@ describe('WITHDRAW_OFFER wiring', () => {
     expect(src).toMatch(/withdrawOffer:\s*\(playerId,\s*teamId\)\s*=>\s*\n?\s*request\(toWorker\.WITHDRAW_OFFER/);
   });
 
-  it('is routed to handleWithdrawOffer in the worker', () => {
-    const src = read('src/worker/worker.js');
-    expect(src).toContain('case toWorker.WITHDRAW_OFFER:     return await handleWithdrawOffer(payload, id);');
-    expect(src).toContain('async function handleWithdrawOffer(');
+  it('is routed to handleWithdrawOffer through the command registry', () => {
+    const workerSrc = read('src/worker/worker.js');
+    expect(workerSrc).toMatch(/\[toWorker\.WITHDRAW_OFFER\]:\s*handleWithdrawOffer,/);
+    const handlerSrc = read('src/worker/handlers/freeAgencyHandlers.js');
+    expect(handlerSrc).toContain('export async function handleWithdrawOffer(');
   });
 
   it('is wired from the FreeAgency pending-offers panel to actions.withdrawOffer', () => {
@@ -59,7 +60,7 @@ describe('ADVANCE_FREE_AGENCY_DAY sequencing', () => {
   });
 
   it('the FA pool filters treat team id 0 as a signed team, not a free agent', () => {
-    const workerSrc = read('src/worker/worker.js');
+    const workerSrc = read('src/worker/handlers/freeAgencyHandlers.js');
     const getFreeAgentsStart = workerSrc.indexOf('async function handleGetFreeAgents(');
     const getFreeAgentsBody = workerSrc.slice(getFreeAgentsStart, getFreeAgentsStart + 2000);
     // Regression: `!p.teamId` treated the default user team (id 0) as unsigned,

--- a/tests/unit/worker/commandRegistry.test.js
+++ b/tests/unit/worker/commandRegistry.test.js
@@ -1,0 +1,90 @@
+/**
+ * Command registry dispatch — Worker Handler Registry V1.
+ *
+ * Proves the registry contract worker.js relies on:
+ *  - registered handlers receive (payload, id, ctx) untouched
+ *  - unknown commands resolve { handled: false } without throwing, so the
+ *    worker can fall through to its legacy switch (and its existing
+ *    unknown-command ERROR post) instead of crashing
+ *  - handler errors propagate to the caller (worker.js owns the catch that
+ *    posts toUI.ERROR with the original requestId)
+ *  - duplicate/invalid registrations fail loudly at wiring time
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { createCommandRegistry } from '../../../src/worker/commandRegistry.js';
+
+describe('createCommandRegistry', () => {
+  it('dispatches to the registered handler with payload, id, and ctx untouched', async () => {
+    const registry = createCommandRegistry();
+    const handler = vi.fn(async () => {});
+    registry.register('GET_ROSTER', handler);
+
+    const payload = { teamId: 4 };
+    const ctx = { cache: {}, post: () => {} };
+    const result = await registry.dispatch('GET_ROSTER', payload, 'msg_42', ctx);
+
+    expect(result).toEqual({ handled: true, type: 'GET_ROSTER' });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(payload, 'msg_42', ctx);
+    // Same object references — the registry must not clone or rewrap.
+    expect(handler.mock.calls[0][0]).toBe(payload);
+    expect(handler.mock.calls[0][2]).toBe(ctx);
+  });
+
+  it('resolves { handled: false } for unknown commands without throwing', async () => {
+    const registry = createCommandRegistry();
+    registry.register('KNOWN', vi.fn());
+
+    await expect(registry.dispatch('TOTALLY_UNKNOWN', {}, 'msg_1', {})).resolves.toEqual({
+      handled: false,
+      type: 'TOTALLY_UNKNOWN',
+    });
+  });
+
+  it('propagates handler errors to the caller instead of swallowing them', async () => {
+    const registry = createCommandRegistry();
+    registry.register('EXPLODES', async () => {
+      throw new Error('boom');
+    });
+
+    await expect(registry.dispatch('EXPLODES', {}, 'msg_9', {})).rejects.toThrow('boom');
+  });
+
+  it('supports synchronous handlers (awaited transparently)', async () => {
+    const registry = createCommandRegistry();
+    let seen = null;
+    registry.register('SYNC', (payload, id) => { seen = { payload, id }; });
+
+    const result = await registry.dispatch('SYNC', { a: 1 }, 'msg_3');
+    expect(result.handled).toBe(true);
+    expect(seen).toEqual({ payload: { a: 1 }, id: 'msg_3' });
+  });
+
+  it('registerAll registers a message-type → handler map', async () => {
+    const registry = createCommandRegistry();
+    const a = vi.fn();
+    const b = vi.fn();
+    registry.registerAll({ A: a, B: b });
+
+    expect(registry.has('A')).toBe(true);
+    expect(registry.has('B')).toBe(true);
+    expect(registry.registeredTypes().sort()).toEqual(['A', 'B']);
+
+    await registry.dispatch('B', {}, null);
+    expect(b).toHaveBeenCalledTimes(1);
+    expect(a).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate registrations for the same message type', () => {
+    const registry = createCommandRegistry();
+    registry.register('DUP', () => {});
+    expect(() => registry.register('DUP', () => {})).toThrow(/duplicate handler/);
+  });
+
+  it('rejects invalid types and non-function handlers at registration time', () => {
+    const registry = createCommandRegistry();
+    expect(() => registry.register('', () => {})).toThrow(TypeError);
+    expect(() => registry.register(42, () => {})).toThrow(TypeError);
+    expect(() => registry.register('X', null)).toThrow(TypeError);
+  });
+});

--- a/tests/unit/worker/handlers/draftHandlers.test.js
+++ b/tests/unit/worker/handlers/draftHandlers.test.js
@@ -1,0 +1,59 @@
+/**
+ * GET_DRAFT_STATE handler — extracted behavior parity.
+ *
+ * Pins the lazy draft initialization (startDraft only when phase is 'draft'
+ * with no draftState yet), the DRAFT_STATE reply with requestId echo, and the
+ * handler-local error path (this handler catches its own errors and posts the
+ * specific "Draft state unavailable" message instead of the generic one).
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { toUI } from '../../../../src/worker/protocol.js';
+import { handleGetDraftState } from '../../../../src/worker/handlers/draftHandlers.js';
+import { makeFakeCache, makeCtx, makeFaMeta } from './testContext.js';
+
+describe('handleGetDraftState', () => {
+  it('posts DRAFT_STATE from ctx.buildDraftStateView with the requestId echoed', async () => {
+    const cache = makeFakeCache({ meta: makeFaMeta({ phase: 'regular' }) });
+    const ctx = makeCtx(cache);
+    await handleGetDraftState({}, 'msg_draft_1', ctx);
+
+    expect(ctx.startDraft).not.toHaveBeenCalled();
+    expect(ctx.posts).toEqual([
+      { type: toUI.DRAFT_STATE, payload: { draftState: 'stub' }, id: 'msg_draft_1' },
+    ]);
+  });
+
+  it('lazily starts the draft when phase is draft and no draftState exists', async () => {
+    const cache = makeFakeCache({ meta: makeFaMeta({ phase: 'draft', draftState: undefined }) });
+    const ctx = makeCtx(cache);
+    await handleGetDraftState({}, 'msg_draft_2', ctx);
+
+    expect(ctx.startDraft).toHaveBeenCalledTimes(1);
+    expect(ctx.startDraft).toHaveBeenCalledWith({}, null);
+    expect(ctx.posts.at(-1).type).toBe(toUI.DRAFT_STATE);
+  });
+
+  it('does not re-start the draft when draftState already exists', async () => {
+    const cache = makeFakeCache({ meta: makeFaMeta({ phase: 'draft', draftState: { round: 2 } }) });
+    const ctx = makeCtx(cache);
+    await handleGetDraftState({}, 'msg_draft_3', ctx);
+
+    expect(ctx.startDraft).not.toHaveBeenCalled();
+  });
+
+  it('posts the specific draft-unavailable ERROR when the view build throws', async () => {
+    const cache = makeFakeCache({ meta: makeFaMeta({ phase: 'regular' }) });
+    const ctx = makeCtx(cache, {
+      buildDraftStateView: vi.fn(() => { throw new Error('view exploded'); }),
+    });
+    await handleGetDraftState({}, 'msg_draft_4', ctx);
+
+    expect(ctx.posts).toEqual([
+      {
+        type: toUI.ERROR,
+        payload: { message: 'Draft state unavailable. Retry or cancel sim. (view exploded)' },
+        id: 'msg_draft_4',
+      },
+    ]);
+  });
+});

--- a/tests/unit/worker/handlers/freeAgencyHandlers.test.js
+++ b/tests/unit/worker/handlers/freeAgencyHandlers.test.js
@@ -1,0 +1,213 @@
+/**
+ * GET_FREE_AGENTS / SUBMIT_OFFER / WITHDRAW_OFFER handlers — extracted
+ * behavior parity.
+ *
+ * Proves the migrated FA mutation path still maintains the pending-offer
+ * ledger and cap reservations exactly like the monolith:
+ *  - SUBMIT_OFFER records a pending ledger row + the player bid, reserves
+ *    cap, replaces re-submitted offers, and rejects offers that exceed the
+ *    effective cap room
+ *  - WITHDRAW_OFFER resolves the row to withdrawn (releasing the
+ *    reservation) and strips the bid from player.offers
+ *  - GET_FREE_AGENTS returns the FREE_AGENT_DATA slice (pendingOffers,
+ *    capSummary, aiOfferCountByPlayerId) with the requestId echoed
+ *
+ * Deeper end-to-end coverage (real league, real resolution pipeline) lives in
+ * tests/integration/freeAgencyMarketV2.worker.test.js, which drives these
+ * same handlers through the worker's real self.onmessage path.
+ */
+import { describe, expect, it } from 'vitest';
+import { toUI } from '../../../../src/worker/protocol.js';
+import {
+  PENDING_OFFER_STATUS,
+  computeReservedPendingCap,
+} from '../../../../src/core/freeAgency/pendingOffers.js';
+import {
+  handleGetFreeAgents,
+  handleSubmitOffer,
+  handleWithdrawOffer,
+} from '../../../../src/worker/handlers/freeAgencyHandlers.js';
+import { makeFakeCache, makeCtx, makeFaMeta, makeUserTeam, makeFreeAgent } from './testContext.js';
+
+const USER_TEAM_ID = 0;
+
+function setup({ capRoom = 60, playerOverrides = {} } = {}) {
+  const cache = makeFakeCache({
+    meta: makeFaMeta({ userTeamId: USER_TEAM_ID }),
+    teams: [makeUserTeam({ id: USER_TEAM_ID, capRoom })],
+    players: [makeFreeAgent(playerOverrides)],
+  });
+  return { cache, ctx: makeCtx(cache) };
+}
+
+const CONTRACT = { baseAnnual: 10, yearsTotal: 3, signingBonus: 3 };
+// Annual cap hit the monolith computed: baseAnnual + signingBonus / yearsTotal.
+const CONTRACT_CAP_HIT = CONTRACT.baseAnnual + CONTRACT.signingBonus / CONTRACT.yearsTotal;
+
+function postsOfType(ctx, type) {
+  return ctx.posts.filter((p) => p.type === type);
+}
+
+describe('handleSubmitOffer', () => {
+  it('records a pending ledger row, the player bid, and the cap reservation', async () => {
+    const { cache, ctx } = setup();
+
+    await handleSubmitOffer({ playerId: 101, teamId: USER_TEAM_ID, contract: CONTRACT }, 'msg_offer_1', ctx);
+
+    // Ledger: exactly one pending row for this bid, reserving the cap hit.
+    const ledger = ctx.getPendingOffersLedger();
+    expect(ledger).toHaveLength(1);
+    expect(ledger[0].status).toBe(PENDING_OFFER_STATUS.PENDING);
+    expect(Number(ledger[0].playerId)).toBe(101);
+    expect(Number(ledger[0].teamId)).toBe(USER_TEAM_ID);
+    expect(computeReservedPendingCap(ledger, USER_TEAM_ID)).toBeCloseTo(CONTRACT_CAP_HIT, 1);
+
+    // The operational bid lives on the player for the decision pipeline.
+    const offers = cache.getPlayer(101).offers ?? [];
+    expect(offers).toHaveLength(1);
+    expect(Number(offers[0].teamId)).toBe(USER_TEAM_ID);
+    expect(offers[0].contract).toEqual(CONTRACT);
+
+    // Response contract: an FA broadcast (no id) then STATE_UPDATE echoing the
+    // requestId with the submitted ledger row attached.
+    const faPosts = postsOfType(ctx, toUI.FREE_AGENT_DATA);
+    expect(faPosts).toHaveLength(1);
+    expect(faPosts[0].id).toBeNull();
+    const stateUpdates = postsOfType(ctx, toUI.STATE_UPDATE);
+    expect(stateUpdates).toHaveLength(1);
+    expect(stateUpdates[0].id).toBe('msg_offer_1');
+    expect(stateUpdates[0].payload.submittedOffer.id).toBe(ledger[0].id);
+    expect(ctx.flushDirty).toHaveBeenCalled();
+  });
+
+  it('replaces a re-submitted offer for the same player instead of double-reserving', async () => {
+    const { cache, ctx } = setup();
+    await handleSubmitOffer({ playerId: 101, teamId: USER_TEAM_ID, contract: CONTRACT }, 'msg_offer_2', ctx);
+
+    const replacement = { baseAnnual: 12, yearsTotal: 3, signingBonus: 3 };
+    await handleSubmitOffer({ playerId: 101, teamId: USER_TEAM_ID, contract: replacement }, 'msg_offer_3', ctx);
+
+    const pendingRows = ctx.getPendingOffersLedger().filter((r) => r.status === PENDING_OFFER_STATUS.PENDING);
+    expect(pendingRows).toHaveLength(1);
+    expect(computeReservedPendingCap(ctx.getPendingOffersLedger(), USER_TEAM_ID))
+      .toBeCloseTo(replacement.baseAnnual + replacement.signingBonus / replacement.yearsTotal, 1);
+
+    const userBids = (cache.getPlayer(101).offers ?? []).filter((o) => Number(o.teamId) === USER_TEAM_ID);
+    expect(userBids).toHaveLength(1);
+    expect(userBids[0].contract).toEqual(replacement);
+  });
+
+  it('rejects an offer that exceeds effective cap room with ERROR and no ledger change', async () => {
+    const { cache, ctx } = setup({ capRoom: 5 });
+
+    await handleSubmitOffer({ playerId: 101, teamId: USER_TEAM_ID, contract: CONTRACT }, 'msg_offer_4', ctx);
+
+    expect(ctx.posts).toHaveLength(1);
+    expect(ctx.posts[0].type).toBe(toUI.ERROR);
+    expect(ctx.posts[0].id).toBe('msg_offer_4');
+    expect(ctx.posts[0].payload.message).toBeTruthy();
+    expect(ctx.getPendingOffersLedger()).toHaveLength(0);
+    expect(cache.getPlayer(101).offers ?? []).toHaveLength(0);
+  });
+
+  it('posts ERROR when the player does not exist', async () => {
+    const { ctx } = setup();
+    await handleSubmitOffer({ playerId: 999, teamId: USER_TEAM_ID, contract: CONTRACT }, 'msg_offer_5', ctx);
+
+    expect(ctx.posts).toEqual([
+      { type: toUI.ERROR, payload: { message: 'Player not found' }, id: 'msg_offer_5' },
+    ]);
+  });
+
+  it('posts ERROR when no team context can be resolved', async () => {
+    const cache = makeFakeCache({
+      meta: makeFaMeta({ userTeamId: null }),
+      teams: [],
+      players: [makeFreeAgent()],
+    });
+    const ctx = makeCtx(cache);
+    await handleSubmitOffer({ playerId: 101, contract: CONTRACT }, 'msg_offer_6', ctx);
+
+    expect(ctx.posts).toHaveLength(1);
+    expect(ctx.posts[0].type).toBe(toUI.ERROR);
+    expect(ctx.posts[0].id).toBe('msg_offer_6');
+  });
+});
+
+describe('handleWithdrawOffer', () => {
+  it('marks the row withdrawn, releases the cap reservation, and strips the bid', async () => {
+    const { cache, ctx } = setup();
+    await handleSubmitOffer({ playerId: 101, teamId: USER_TEAM_ID, contract: CONTRACT }, 'msg_w_1', ctx);
+    expect(computeReservedPendingCap(ctx.getPendingOffersLedger(), USER_TEAM_ID)).toBeGreaterThan(0);
+
+    await handleWithdrawOffer({ playerId: 101, teamId: USER_TEAM_ID }, 'msg_w_2', ctx);
+
+    const ledger = ctx.getPendingOffersLedger();
+    const row = ledger.find((r) => Number(r.playerId) === 101 && Number(r.teamId) === USER_TEAM_ID);
+    expect(row.status).toBe(PENDING_OFFER_STATUS.WITHDRAWN);
+    expect(computeReservedPendingCap(ledger, USER_TEAM_ID)).toBe(0);
+    expect((cache.getPlayer(101).offers ?? []).some((o) => Number(o.teamId) === USER_TEAM_ID)).toBe(false);
+
+    // Reply: STATE_UPDATE echoing the withdraw requestId.
+    const stateUpdates = postsOfType(ctx, toUI.STATE_UPDATE);
+    expect(stateUpdates.at(-1).id).toBe('msg_w_2');
+  });
+
+  it('leaves AI bids from other teams on the player untouched', async () => {
+    const aiOffer = { teamId: 7, teamName: 'Rival', contract: { baseAnnual: 9, yearsTotal: 2, signingBonus: 1 }, timestamp: 1 };
+    const { cache, ctx } = setup({ playerOverrides: { offers: [aiOffer] } });
+    await handleSubmitOffer({ playerId: 101, teamId: USER_TEAM_ID, contract: CONTRACT }, 'msg_w_3', ctx);
+    await handleWithdrawOffer({ playerId: 101, teamId: USER_TEAM_ID }, 'msg_w_4', ctx);
+
+    const offers = cache.getPlayer(101).offers ?? [];
+    expect(offers).toHaveLength(1);
+    expect(Number(offers[0].teamId)).toBe(7);
+  });
+});
+
+describe('handleGetFreeAgents', () => {
+  it('posts FREE_AGENT_DATA with the FA slice and the requestId echoed', async () => {
+    const { ctx } = setup();
+    await handleGetFreeAgents({}, 'msg_fa_1', ctx);
+
+    expect(ctx.posts).toHaveLength(1);
+    const { type, payload, id } = ctx.posts[0];
+    expect(type).toBe(toUI.FREE_AGENT_DATA);
+    expect(id).toBe('msg_fa_1');
+    expect(payload.faDay).toBe(1);
+    expect(payload.faMaxDays).toBe(5);
+    expect(payload.phase).toBe('free_agency');
+    expect(payload.pendingOffers).toEqual([]);
+    expect(payload.capSummary).toEqual({ capRoom: 60, reservedPendingCap: 0, effectiveCapRoom: 60 });
+
+    expect(payload.freeAgents).toHaveLength(1);
+    const fa = payload.freeAgents[0];
+    expect(fa.id).toBe(101);
+    // Response-shape parity with the monolith's FA row.
+    for (const key of ['market', 'demandProfile', 'playbookKnowledge', 'reSign', 'offers']) {
+      expect(fa[key], `freeAgents[0].${key}`).toBeTruthy();
+    }
+    expect(fa.offers.count).toBe(0);
+    expect(fa.offers.userOffered).toBe(false);
+  });
+
+  it('reports pending offers, reserved cap, and AI bid counts after a submit', async () => {
+    const aiOffer = { teamId: 7, teamName: 'Rival', contract: { baseAnnual: 9, yearsTotal: 2, signingBonus: 1 }, timestamp: 1 };
+    const { ctx } = setup({ playerOverrides: { offers: [aiOffer] } });
+    await handleSubmitOffer({ playerId: 101, teamId: USER_TEAM_ID, contract: CONTRACT }, 'msg_fa_2', ctx);
+    ctx.posts.length = 0;
+
+    await handleGetFreeAgents({}, 'msg_fa_3', ctx);
+    const { payload, id } = ctx.posts[0];
+    expect(id).toBe('msg_fa_3');
+    expect(payload.pendingOffers).toHaveLength(1);
+    expect(payload.pendingOffers[0].status).toBe(PENDING_OFFER_STATUS.PENDING);
+    expect(payload.capSummary.reservedPendingCap).toBeCloseTo(CONTRACT_CAP_HIT, 1);
+    expect(payload.capSummary.effectiveCapRoom).toBeCloseTo(60 - CONTRACT_CAP_HIT, 1);
+    // Only the AI bid counts toward the badge; the user bid is excluded.
+    expect(payload.aiOfferCountByPlayerId).toEqual({ 101: 1 });
+    const fa = payload.freeAgents[0];
+    expect(fa.offers.userOffered).toBe(true);
+    expect(fa.offers.count).toBe(2);
+  });
+});

--- a/tests/unit/worker/handlers/rosterHandlers.test.js
+++ b/tests/unit/worker/handlers/rosterHandlers.test.js
@@ -1,0 +1,128 @@
+/**
+ * GET_ROSTER handler — extracted behavior parity.
+ *
+ * Pins the ROSTER_DATA response shape the UI depends on: team cap slice,
+ * per-player view-model fields (including legacy flat-contract
+ * normalization), the roster-building analysis, and requestId echo. Also
+ * pins the team-not-found ERROR path.
+ */
+import { describe, expect, it } from 'vitest';
+import { toUI } from '../../../../src/worker/protocol.js';
+import { handleGetRoster } from '../../../../src/worker/handlers/rosterHandlers.js';
+import { makeFakeCache, makeCtx, makeFaMeta, makeUserTeam } from './testContext.js';
+
+function makeRosterPlayer(overrides = {}) {
+  return {
+    id: 11,
+    name: 'Roster Ricky',
+    pos: 'QB',
+    age: 26,
+    ovr: 84,
+    potential: 88,
+    status: 'active',
+    teamId: 3,
+    morale: 70,
+    traits: ['leader'],
+    contract: { years: 2, yearsTotal: 4, yearsRemaining: 2, baseAnnual: 12, signingBonus: 6, guaranteedPct: 0.6 },
+    ...overrides,
+  };
+}
+
+function setup({ players } = {}) {
+  const team = makeUserTeam({
+    id: 3,
+    name: 'Testville Turbines',
+    abbr: 'TVT',
+    capUsed: 141.5,
+    capRoom: 58.5,
+    capTotal: 200,
+    deadCap: 2.5,
+    deadMoneyNextYear: 1,
+    staff: { headCoach: { offScheme: 'West Coast', defScheme: '4-3' } },
+  });
+  const cache = makeFakeCache({
+    meta: makeFaMeta({ userTeamId: 3 }),
+    teams: [team],
+    players: players ?? [
+      makeRosterPlayer(),
+      // Legacy flat-contract player: no nested contract object.
+      makeRosterPlayer({
+        id: 12,
+        name: 'Legacy Larry',
+        pos: 'LB',
+        contract: undefined,
+        years: 3,
+        yearsTotal: 3,
+        baseAnnual: 4.5,
+        signingBonus: 1.5,
+        guaranteedPct: 0.4,
+      }),
+    ],
+  });
+  return { cache, ctx: makeCtx(cache) };
+}
+
+describe('handleGetRoster', () => {
+  it('posts ROSTER_DATA with the team cap slice and the requestId echoed', async () => {
+    const { ctx } = setup();
+    await handleGetRoster({ teamId: 3 }, 'msg_roster_1', ctx);
+
+    expect(ctx.posts).toHaveLength(1);
+    const { type, payload, id } = ctx.posts[0];
+    expect(type).toBe(toUI.ROSTER_DATA);
+    expect(id).toBe('msg_roster_1');
+    expect(payload.teamId).toBe(3);
+    expect(payload.team).toEqual({
+      id: 3,
+      name: 'Testville Turbines',
+      abbr: 'TVT',
+      capUsed: 141.5,
+      capRoom: 58.5,
+      capTotal: 200,
+      deadCap: 2.5,
+      deadMoneyNextYear: 1,
+      staff: { headCoach: { offScheme: 'West Coast', defScheme: '4-3' } },
+    });
+    expect(payload.analysis).toBeTruthy();
+  });
+
+  it('maps players into the roster view-model shape (same keys as the monolith)', async () => {
+    const { ctx } = setup();
+    await handleGetRoster({ teamId: 3 }, 'msg_roster_2', ctx);
+
+    const { players } = ctx.posts[0].payload;
+    expect(players).toHaveLength(2);
+    const ricky = players.find((p) => p.id === 11);
+    expect(Object.keys(ricky).sort()).toEqual([
+      'age', 'contract', 'id', 'morale', 'name', 'onTradeBlock', 'ovr',
+      'pos', 'potential', 'progressionDelta', 'schemeFit', 'status', 'traits',
+    ].sort());
+    expect(ricky.contract).toEqual({ years: 2, yearsTotal: 4, yearsRemaining: 2, baseAnnual: 12, signingBonus: 6, guaranteedPct: 0.6 });
+    expect(typeof ricky.schemeFit).toBe('number');
+    expect(typeof ricky.morale).toBe('number');
+  });
+
+  it('normalizes legacy flat contract fields into a nested contract', async () => {
+    const { ctx } = setup();
+    await handleGetRoster({ teamId: 3 }, 'msg_roster_3', ctx);
+
+    const larry = ctx.posts[0].payload.players.find((p) => p.id === 12);
+    expect(larry.contract).toEqual({
+      years: 3,
+      yearsTotal: 3,
+      yearsRemaining: 3,
+      baseAnnual: 4.5,
+      signingBonus: 1.5,
+      guaranteedPct: 0.4,
+    });
+  });
+
+  it('posts ERROR with the requestId when the team does not exist', async () => {
+    const { ctx } = setup();
+    await handleGetRoster({ teamId: 99 }, 'msg_roster_4', ctx);
+
+    expect(ctx.posts).toEqual([
+      { type: toUI.ERROR, payload: { message: 'Team 99 not found' }, id: 'msg_roster_4' },
+    ]);
+  });
+});

--- a/tests/unit/worker/handlers/saveHandlers.test.js
+++ b/tests/unit/worker/handlers/saveHandlers.test.js
@@ -1,0 +1,59 @@
+/**
+ * SAVE_NOW handler — extracted behavior parity.
+ *
+ * The monolith handler: (1) re-opens the DB when a league is active (iOS
+ * connection liveness), (2) flushes dirty state, (3) posts SAVED echoing the
+ * requestId — or posts ERROR with the `Save failed: …` prefix and the same
+ * requestId when anything rejects.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { toUI } from '../../../../src/worker/protocol.js';
+import { handleSaveNow } from '../../../../src/worker/handlers/saveHandlers.js';
+import { makeFakeCache, makeCtx } from './testContext.js';
+
+describe('handleSaveNow', () => {
+  it('re-opens the DB, flushes, and posts SAVED with the requestId', async () => {
+    const ctx = makeCtx(makeFakeCache());
+    await handleSaveNow({}, 'msg_save_1', ctx);
+
+    expect(ctx.openDB).toHaveBeenCalledTimes(1);
+    expect(ctx.flushDirty).toHaveBeenCalledTimes(1);
+    expect(ctx.posts).toEqual([{ type: toUI.SAVED, payload: {}, id: 'msg_save_1' }]);
+  });
+
+  it('skips the DB liveness check when no league is active', async () => {
+    const ctx = makeCtx(makeFakeCache(), { getActiveLeagueId: () => null });
+    await handleSaveNow({}, 'msg_save_2', ctx);
+
+    expect(ctx.openDB).not.toHaveBeenCalled();
+    expect(ctx.flushDirty).toHaveBeenCalledTimes(1);
+    expect(ctx.posts).toEqual([{ type: toUI.SAVED, payload: {}, id: 'msg_save_2' }]);
+  });
+
+  it('posts ERROR with the original requestId when the flush rejects', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const ctx = makeCtx(makeFakeCache(), {
+      flushDirty: vi.fn(async () => { throw new Error('disk unhappy'); }),
+    });
+    await handleSaveNow({}, 'msg_save_3', ctx);
+
+    expect(ctx.posts).toEqual([
+      { type: toUI.ERROR, payload: { message: 'Save failed: disk unhappy' }, id: 'msg_save_3' },
+    ]);
+    consoleError.mockRestore();
+  });
+
+  it('posts ERROR when re-opening the DB rejects (connection killed)', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const ctx = makeCtx(makeFakeCache(), {
+      openDB: vi.fn(async () => { throw new Error('connection is closing'); }),
+    });
+    await handleSaveNow({}, 'msg_save_4', ctx);
+
+    expect(ctx.flushDirty).not.toHaveBeenCalled();
+    expect(ctx.posts).toEqual([
+      { type: toUI.ERROR, payload: { message: 'Save failed: connection is closing' }, id: 'msg_save_4' },
+    ]);
+    consoleError.mockRestore();
+  });
+});

--- a/tests/unit/worker/handlers/testContext.js
+++ b/tests/unit/worker/handlers/testContext.js
@@ -1,0 +1,150 @@
+/**
+ * Shared test doubles for extracted worker handler tests.
+ *
+ * makeFakeCache mirrors the db/cache.js read/update surface the migrated
+ * handlers use; makeCtx mirrors the capability object worker.js builds with
+ * createWorkerContext, with the ledger helpers implemented exactly like their
+ * worker.js counterparts (backed by the fake cache's meta).
+ */
+import { vi } from 'vitest';
+import {
+  ensurePendingOffersList,
+  prunePendingOffers,
+} from '../../../../src/core/freeAgency/pendingOffers.js';
+
+export function makeFakeCache({ meta = {}, teams = [], players = [] } = {}) {
+  const state = { meta: { ...meta } };
+  const teamMap = new Map(teams.map((t) => [Number(t.id), t]));
+  const playerMap = new Map(players.map((p) => [String(p.id), p]));
+  return {
+    getMeta: () => state.meta,
+    setMeta: (patch) => { state.meta = { ...state.meta, ...patch }; },
+    getTeam: (id) => teamMap.get(Number(id)) ?? null,
+    getAllTeams: () => [...teamMap.values()],
+    getPlayer: (id) => (id != null ? (playerMap.get(String(id)) ?? null) : null),
+    getAllPlayers: () => [...playerMap.values()],
+    getPlayersByTeam: (teamId) =>
+      [...playerMap.values()].filter((p) => p?.teamId != null && Number(p.teamId) === Number(teamId)),
+    updatePlayer: (id, patch) => {
+      const p = playerMap.get(String(id));
+      if (p) Object.assign(p, patch);
+    },
+    updateTeam: (id, patch) => {
+      const t = teamMap.get(Number(id));
+      if (t) Object.assign(t, patch);
+    },
+  };
+}
+
+export function makeCtx(cache, overrides = {}) {
+  const posts = [];
+  return {
+    cache,
+    /** Recorded { type, payload, id } posts, in order. */
+    posts,
+    post: (type, payload = {}, id = null) => { posts.push({ type, payload, id }); },
+    flushDirty: vi.fn(async () => {}),
+    buildViewState: () => ({ viewState: 'stub' }),
+    getSafeMeta: () => cache.getMeta() ?? {},
+    getLeagueSetting: (key, fallback = null) => cache.getMeta()?.settings?.[key] ?? fallback,
+    // Mirrors worker.js resolveTeamContext (payload teamId → meta.userTeamId fallback).
+    resolveTeamContext: (explicitTeamId) => {
+      const meta = cache.getMeta() ?? {};
+      const teamId = explicitTeamId ?? meta.userTeamId ?? null;
+      if (teamId == null) {
+        return { ok: false, message: 'Active team context is missing. Please select your franchise and try again.' };
+      }
+      const team = cache.getTeam(teamId);
+      if (!team) {
+        return { ok: false, message: 'Active franchise team could not be resolved. Please reload and try again.' };
+      }
+      return { ok: true, meta, teamId, team };
+    },
+    getOffseasonReturnSnapshot: () => null,
+    // Ledger helpers mirror the worker.js implementations exactly.
+    getPendingOffersLedger: () => ensurePendingOffersList(cache.getMeta()?.pendingOffers),
+    savePendingOffersLedger: (list, { day = null } = {}) => {
+      const faDay = day ?? Number(cache.getMeta()?.freeAgencyState?.day ?? 1);
+      cache.setMeta({ pendingOffers: prunePendingOffers(list, { day: faDay }) });
+    },
+    syncPendingOfferLedger: vi.fn(() => ({ accepted: [], rejected: [], expired: [] })),
+    buildDemandSnapshotForOffer: () => ({
+      baseAnnual: 8,
+      yearsTotal: 3,
+      signingBonus: 4,
+      guaranteedPct: 0.5,
+      willingness: 60,
+      marketHeat: 1,
+      leverageLabel: 'Neutral',
+      reputationLabel: 'Neutral',
+      feedbackLine: '',
+      leverageReasons: [],
+      franchiseReasons: [],
+      negotiationShift: 0,
+    }),
+    resolvePendingFreeAgencyOffers: vi.fn(async () => ({ signedCount: 0, results: [] })),
+    buildDraftStateView: () => ({ draftState: 'stub' }),
+    startDraft: vi.fn(async () => {}),
+    getActiveLeagueId: () => 'league_test',
+    openDB: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+/** Meta fixture with the fields the migrated FA handlers read. */
+export function makeFaMeta(overrides = {}) {
+  return {
+    userTeamId: 0,
+    phase: 'free_agency',
+    year: 2027,
+    season: 3,
+    currentWeek: 1,
+    currentSeasonId: 'season_3',
+    freeAgencyState: { day: 1, maxDays: 5, complete: false },
+    pendingOffers: [],
+    contractMarketMemory: {},
+    economy: {},
+    settings: {},
+    ...overrides,
+  };
+}
+
+export function makeUserTeam(overrides = {}) {
+  return {
+    id: 0,
+    name: 'Testville Turbines',
+    abbr: 'TVT',
+    wins: 8,
+    losses: 8,
+    ties: 0,
+    capUsed: 140,
+    capRoom: 60,
+    capTotal: 200,
+    deadCap: 0,
+    coachHistory: [],
+    staff: null,
+    picks: [],
+    ...overrides,
+  };
+}
+
+export function makeFreeAgent(overrides = {}) {
+  return {
+    id: 101,
+    name: 'Free Agent Freddy',
+    pos: 'WR',
+    age: 27,
+    ovr: 82,
+    potential: 86,
+    morale: 70,
+    schemeFit: 65,
+    status: 'free_agent',
+    teamId: null,
+    traits: [],
+    offers: [],
+    contract: null,
+    awards: [],
+    moraleEvents: [],
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

Structural refactor only: introduces a thin command-handler registry for the worker and migrates the first low-risk batch of commands out of the 638KB `src/worker/worker.js` monolith. No protocol, save-format, simulation, or gameplay changes. Follows PR #1653 (State Legacy Quarantine V1).

### New modules

- **`src/worker/commandRegistry.js`** — registers handlers by message type and dispatches inbound messages. Unknown commands resolve `{ handled: false }` so `worker.js` falls through to its legacy switch (and its existing unknown-command ERROR post). Handler errors are not swallowed — they propagate to the worker's existing `catch → toUI.ERROR` path, so requestId echo and error shapes are unchanged.
- **`src/worker/workerContext.js`** — frozen capability object handed to extracted handlers (cache, `post`, `flushDirty`, `buildViewState`, pending-offer ledger helpers, etc.), validated at worker boot. Not a new state model: every capability is an existing worker function passed through unchanged.
- **`src/worker/handlers/`** — first migrated batch, bodies moved verbatim (verified byte-identical modulo the mechanical `ctx.` rewrites):
  - `rosterHandlers.js` — `GET_ROSTER`
  - `freeAgencyHandlers.js` — `GET_FREE_AGENTS`, `SUBMIT_OFFER`, `WITHDRAW_OFFER`
  - `saveHandlers.js` — `SAVE_NOW`
  - `draftHandlers.js` — `GET_DRAFT_STATE`

### What stays in worker.js

`self.onmessage`, the sequential message queue, boot/init/hydration, state epoch, delta serialization, dirty-flush accumulator internals and timing, sim execution, draft execution, playoff generation, and the AI offseason loops. The pending-offer ledger helpers (`getPendingOffersLedger` / `savePendingOffersLedger` / `syncPendingOfferLedger` / `buildDemandSnapshotForOffer`) also stay, since the unmigrated offseason/FA-day systems use them; migrated handlers reach them through the context.

`worker.js` shrinks by ~460 net lines (~21KB) and now establishes the pattern for migrating future handler groups one bounded batch at a time.

## Tests

- `tests/unit/worker/commandRegistry.test.js` — dispatch, payload/id/ctx passthrough, unknown-command fallback, error propagation, duplicate-registration guard.
- `tests/unit/worker/handlers/{roster,freeAgency,save,draft}Handlers.test.js` — response-shape parity, requestId echo, error paths; `SUBMIT_OFFER`/`WITHDRAW_OFFER` pending-offer ledger + cap-reservation behavior (record, replace-not-double-reserve, cap-exceeded rejection, withdraw releases reservation and strips the bid).
- Updated the two source-pinning guards in `tests/unit/freeAgencyMarketV2Wiring.test.js` to point at the new handler module; the behavioral integration suite (`tests/integration/freeAgencyMarketV2.worker.test.js`) still drives these commands through the real `self.onmessage` path unchanged.

## Verification

- `npm run test:unit` — **420 files / 5178 tests passed** (includes the FA Market V2 and offseason FA worker integration suites that boot the real worker).
- Acceptance greps: 0 remaining `case` hits in `worker.js` for all six migrated commands.
- `npm run audit:engine-soak` — **PASS on all gates** (win distribution, stat realism, tie rate, variance, performance, zero crashes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GUtnnxnvmoXCnyrZkRAP97

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUtnnxnvmoXCnyrZkRAP97)_