### PR TITLE
Add _resignMeta data contract for Roster expiring decision board

### DIFF
--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -800,6 +800,27 @@ function RosterTable({
     () => buildExpiringDecisionSummary(players, { team, roster: players, direction: teamDirection }),
     [players, team, teamDirection],
   );
+  // Data contract for the re-sign decision tabs (consumed via
+  // resignDecisionFilters.js): expiring rows carry their recommendation under
+  // player._resignMeta so tab filtering reads precomputed metadata instead of
+  // re-running evaluateResignRecommendation per tab. Only computed on the
+  // EXPIRING quick filter; `roster` must be the full team so
+  // replacementDifficulty sees real positional depth. Not rendered yet.
+  // eslint-disable-next-line no-unused-vars
+  const enrichedExpiringRows = useMemo(() => {
+    if (posFilter !== "EXPIRING") return [];
+    return evaluatedDisplayed.map(({ player, eval: playerEval }) => ({
+      player: {
+        ...player,
+        _resignMeta: evaluateResignRecommendation(player, {
+          team,
+          roster: players,
+          direction: teamDirection,
+        }),
+      },
+      eval: playerEval,
+    }));
+  }, [posFilter, evaluatedDisplayed, team, players, teamDirection]);
 
   const activeFilters = isResignPhase ? ["EXPIRING", "STARTERS", "DEPTH", "INJURED", "DEVELOPMENT", ...POSITIONS] : ["STARTERS", "DEPTH", "INJURED", "EXPIRING", "DEVELOPMENT", ...POSITIONS];
   const hasActiveFilters = Boolean(search.trim()) || posFilter !== "ALL" || advancedFilters.length > 0;

--- a/src/ui/utils/resignDecisionFilters.js
+++ b/src/ui/utils/resignDecisionFilters.js
@@ -2,34 +2,61 @@
  * Shared triage-tab config for expiring-contract list surfaces (Financials +
  * Roster). Filters operate on the already-computed recommendation fields
  * (tier/negotiationRisk/replacementDifficulty) — never re-derives them.
+ *
+ * Rows may carry the recommendation inline under `_resignMeta` (Roster
+ * enriched rows; the default) or anywhere reachable through a custom
+ * accessor (Financials passes `(row) => row.rec`).
+ *
+ * Tiers 'resign_if_price' and 'replaceable_depth' intentionally have no
+ * dedicated tab — those rows surface under All only.
  */
 
 function normalizeLevel(value) {
   return String(value ?? '').trim().toLowerCase();
 }
 
+function getMeta(row) {
+  return row?._resignMeta ?? {};
+}
+
 export const RESIGN_DECISION_TAB_DEFS = [
-  { key: 'all', label: 'All', test: () => true },
-  { key: 'priority', label: 'Priority', test: (d) => d?.tier === 'priority_resign' },
-  { key: 'high_risk', label: 'High Risk', test: (d) => normalizeLevel(d?.negotiationRisk) === 'high' },
-  { key: 'hard_to_replace', label: 'Hard to Replace', test: (d) => normalizeLevel(d?.replacementDifficulty) === 'high' },
-  { key: 'let_walk', label: 'Let Walk', test: (d) => d?.tier === 'let_walk' },
-  { key: 'trade_or_tag', label: 'Trade / Tag', test: (d) => d?.tier === 'trade_or_tag' },
+  { id: 'all', key: 'all', label: 'All', test: () => true },
+  { id: 'priority', key: 'priority', label: 'Priority', test: (d) => d?.tier === 'priority_resign' },
+  { id: 'high-risk', key: 'high_risk', label: 'High Risk', test: (d) => normalizeLevel(d?.negotiationRisk) === 'high' },
+  { id: 'hard-to-replace', key: 'hard_to_replace', label: 'Hard to Replace', test: (d) => normalizeLevel(d?.replacementDifficulty) === 'high' },
+  { id: 'let-walk', key: 'let_walk', label: 'Let Walk', test: (d) => d?.tier === 'let_walk' },
+  { id: 'trade-tag', key: 'trade_or_tag', label: 'Trade / Tag', test: (d) => d?.tier === 'trade_or_tag' },
 ];
 
 export const RESIGN_DECISION_DEFAULT_TAB = RESIGN_DECISION_TAB_DEFS[0].key;
 
-/** Builds { key, label, count } tabs from an unfiltered row set. */
-export function buildResignDecisionTabs(rows = [], getDecision) {
-  return RESIGN_DECISION_TAB_DEFS.map(({ key, label, test }) => ({
+/**
+ * Builds { id, key, label, count } tabs. Counts always come from the full
+ * (unfiltered) row set, regardless of which tab is active.
+ */
+export function buildResignDecisionTabs(rows = [], getDecision = getMeta) {
+  return RESIGN_DECISION_TAB_DEFS.map(({ id, key, label, test }) => ({
+    id,
     key,
     label,
     count: rows.filter((row) => test(getDecision(row))).length,
   }));
 }
 
-/** Returns a new filtered array; never mutates or reorders the source rows. */
-export function filterResignDecisionRows(rows = [], getDecision, activeTabKey) {
-  const def = RESIGN_DECISION_TAB_DEFS.find((t) => t.key === activeTabKey) ?? RESIGN_DECISION_TAB_DEFS[0];
+/**
+ * Returns the rows matching the active tab, preserving insertion order and
+ * never mutating the source. The 'all' tab — and any unknown tab id — returns
+ * the original array reference unchanged.
+ *
+ * Callable as (rows, activeTab) for `_resignMeta` rows, or as
+ * (rows, getDecision, activeTab) with a custom accessor. Tabs match by
+ * either `id` ('high-risk') or `key` ('high_risk').
+ */
+export function filterResignDecisionRows(rows = [], getDecisionOrTab, maybeTab) {
+  const usesAccessor = typeof getDecisionOrTab === 'function';
+  const getDecision = usesAccessor ? getDecisionOrTab : getMeta;
+  const activeTab = usesAccessor ? maybeTab : getDecisionOrTab;
+  const def = RESIGN_DECISION_TAB_DEFS.find((t) => t.id === activeTab || t.key === activeTab);
+  if (!def || def.id === 'all') return rows;
   return rows.filter((row) => def.test(getDecision(row)));
 }

--- a/src/ui/utils/tests/resignDecisionFilters.test.js
+++ b/src/ui/utils/tests/resignDecisionFilters.test.js
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import { buildResignDecisionTabs, filterResignDecisionRows } from '../resignDecisionFilters.js';
+
+const mockRow = (id, tier, risk = 'Medium', difficulty = 'Medium') => ({
+  id,
+  _resignMeta: {
+    tier,
+    negotiationRisk: risk,
+    replacementDifficulty: difficulty,
+  },
+});
+
+const buildMixedRows = () => [
+  mockRow(1, 'priority_resign', 'Low', 'High'),
+  mockRow(2, 'resign_if_price', 'High', 'Medium'),
+  mockRow(3, 'let_walk', 'Medium', 'Low'),
+  mockRow(4, 'trade_or_tag', 'High', 'High'),
+  mockRow(5, 'replaceable_depth', 'Low', 'Low'),
+  { id: 6 }, // no _resignMeta
+];
+
+const tabCounts = (rows) =>
+  Object.fromEntries(buildResignDecisionTabs(rows).map((t) => [t.id, t.count]));
+
+describe('buildResignDecisionTabs', () => {
+  it('returns correct counts from a mixed enriched row set', () => {
+    expect(tabCounts(buildMixedRows())).toEqual({
+      all: 6,
+      priority: 1,
+      'high-risk': 2,
+      'hard-to-replace': 2,
+      'let-walk': 1,
+      'trade-tag': 1,
+    });
+  });
+
+  it('counts all rows under All, including rows without _resignMeta', () => {
+    const rows = buildMixedRows();
+    const tabs = buildResignDecisionTabs(rows);
+    expect(tabs.find((t) => t.id === 'all').count).toBe(rows.length);
+  });
+
+  it('exposes the expected tab ids and labels in order', () => {
+    expect(buildResignDecisionTabs([]).map(({ id, label, count }) => ({ id, label, count }))).toEqual([
+      { id: 'all', label: 'All', count: 0 },
+      { id: 'priority', label: 'Priority', count: 0 },
+      { id: 'high-risk', label: 'High Risk', count: 0 },
+      { id: 'hard-to-replace', label: 'Hard to Replace', count: 0 },
+      { id: 'let-walk', label: 'Let Walk', count: 0 },
+      { id: 'trade-tag', label: 'Trade / Tag', count: 0 },
+    ]);
+  });
+});
+
+describe('filterResignDecisionRows', () => {
+  it('returns the exact same array reference for the all tab', () => {
+    const rows = buildMixedRows();
+    expect(filterResignDecisionRows(rows, 'all')).toBe(rows);
+  });
+
+  it('returns the exact same array reference for an unknown tab', () => {
+    const rows = buildMixedRows();
+    expect(filterResignDecisionRows(rows, 'unknown-tab')).toBe(rows);
+  });
+
+  it('priority tab returns only priority_resign rows', () => {
+    const filtered = filterResignDecisionRows(buildMixedRows(), 'priority');
+    expect(filtered.map((r) => r.id)).toEqual([1]);
+    expect(filtered.every((r) => r._resignMeta.tier === 'priority_resign')).toBe(true);
+  });
+
+  it('high-risk tab returns only rows with negotiationRisk High', () => {
+    const filtered = filterResignDecisionRows(buildMixedRows(), 'high-risk');
+    expect(filtered.map((r) => r.id)).toEqual([2, 4]);
+    expect(filtered.every((r) => r._resignMeta.negotiationRisk === 'High')).toBe(true);
+  });
+
+  it('hard-to-replace tab returns only rows with replacementDifficulty High', () => {
+    const filtered = filterResignDecisionRows(buildMixedRows(), 'hard-to-replace');
+    expect(filtered.map((r) => r.id)).toEqual([1, 4]);
+    expect(filtered.every((r) => r._resignMeta.replacementDifficulty === 'High')).toBe(true);
+  });
+
+  it('let-walk tab returns only let_walk rows', () => {
+    expect(filterResignDecisionRows(buildMixedRows(), 'let-walk').map((r) => r.id)).toEqual([3]);
+  });
+
+  it('trade-tag tab returns only trade_or_tag rows', () => {
+    expect(filterResignDecisionRows(buildMixedRows(), 'trade-tag').map((r) => r.id)).toEqual([4]);
+  });
+
+  it('resign_if_price rows appear only under All', () => {
+    const rows = [mockRow(1, 'resign_if_price')];
+    expect(filterResignDecisionRows(rows, 'all')).toBe(rows);
+    for (const tab of ['priority', 'high-risk', 'hard-to-replace', 'let-walk', 'trade-tag']) {
+      expect(filterResignDecisionRows(rows, tab)).toEqual([]);
+    }
+  });
+
+  it('replaceable_depth rows appear only under All', () => {
+    const rows = [mockRow(1, 'replaceable_depth')];
+    expect(filterResignDecisionRows(rows, 'all')).toBe(rows);
+    for (const tab of ['priority', 'high-risk', 'hard-to-replace', 'let-walk', 'trade-tag']) {
+      expect(filterResignDecisionRows(rows, tab)).toEqual([]);
+    }
+  });
+
+  it('rows with no _resignMeta appear only under All and count 0 on specific tabs', () => {
+    const rows = [{ id: 1 }, { id: 2 }];
+    expect(filterResignDecisionRows(rows, 'all')).toBe(rows);
+    const counts = tabCounts(rows);
+    expect(counts).toEqual({
+      all: 2,
+      priority: 0,
+      'high-risk': 0,
+      'hard-to-replace': 0,
+      'let-walk': 0,
+      'trade-tag': 0,
+    });
+    for (const tab of ['priority', 'high-risk', 'hard-to-replace', 'let-walk', 'trade-tag']) {
+      expect(filterResignDecisionRows(rows, tab)).toEqual([]);
+    }
+  });
+
+  it('preserves original insertion order in filtered results', () => {
+    const rows = [
+      mockRow('c', 'trade_or_tag', 'High'),
+      mockRow('a', 'priority_resign', 'High'),
+      mockRow('b', 'let_walk', 'High'),
+    ];
+    expect(filterResignDecisionRows(rows, 'high-risk').map((r) => r.id)).toEqual(['c', 'a', 'b']);
+  });
+
+  it('never mutates the original rows', () => {
+    const rows = buildMixedRows().map((row) => Object.freeze({ ...row }));
+    const snapshot = structuredClone(rows);
+    for (const tab of ['all', 'priority', 'high-risk', 'hard-to-replace', 'let-walk', 'trade-tag', 'unknown-tab']) {
+      filterResignDecisionRows(rows, tab);
+    }
+    expect(rows).toEqual(snapshot);
+  });
+});


### PR DESCRIPTION
- Extend resignDecisionFilters.js to read enriched rows' _resignMeta by
  default while keeping the accessor-based form used by FinancialsView;
  tabs now expose hyphenated ids alongside existing keys, and the 'all'
  or unknown tab returns the original array reference unchanged.
- Enrich Roster EXPIRING rows with evaluateResignRecommendation output
  under player._resignMeta (memoized, EXPIRING filter only, full-roster
  context) without changing rendered behavior.
- Cover tab counts, per-tab filtering, no-tab tiers, meta-less rows,
  order preservation, and immutability in a new test file.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Hec3k4TCf44T5anfenN1Ci