### PR TITLE
Add roster attribute composites to drive engine (V1)

### DIFF
--- a/src/core/__tests__/simulation/driveEngine.test.js
+++ b/src/core/__tests__/simulation/driveEngine.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { advanceDownDistance, buildDriveBasedSummary } from '../../simulation/driveEngine.js';
+import {
+  advanceDownDistance,
+  buildDriveBasedSummary,
+  computeTeamOffensiveRating,
+  computeTeamDefensiveRating,
+} from '../../simulation/driveEngine.js';
 
 describe('driveEngine.advanceDownDistance', () => {
   it('resets to first down when the gain converts the distance', () => {
@@ -55,5 +60,160 @@ describe('driveEngine.buildDriveBasedSummary', () => {
       });
       expect(Math.abs(homeDrives - awayDrives)).toBeLessThanOrEqual(3);
     }
+  });
+});
+
+// ── Team attribute composites ────────────────────────────────────────────────
+
+/** Build a roster of players at the given positions with uniform ratings. */
+function makeRoster(level, ratingKeys) {
+  const positions = [
+    'QB', 'RB',
+    'WR', 'WR', 'WR', 'TE',
+    'OL', 'OL', 'OL', 'OL', 'OL',
+    'DL', 'DL', 'DL', 'DL',
+    'LB', 'LB', 'LB',
+    'CB', 'CB', 'CB',
+    'S', 'S',
+  ];
+  return positions.map((pos, i) => ({
+    id: i,
+    pos,
+    ovr: level,
+    ratings: Object.fromEntries(ratingKeys.map((k) => [k, level])),
+  }));
+}
+
+const ALL_RATING_KEYS = [
+  'throwAccuracy', 'throwPower', 'awareness', 'passBlock', 'runBlock',
+  'strength', 'catching', 'catchInTraffic', 'speed', 'acceleration',
+  'trucking', 'juking', 'passRushPower', 'passRushSpeed', 'tackle',
+  'runStop', 'coverage',
+];
+
+describe('driveEngine.computeTeamOffensiveRating', () => {
+  it('rates a strong offense above a weak one', () => {
+    const strong = computeTeamOffensiveRating(makeRoster(90, ALL_RATING_KEYS));
+    const weak = computeTeamOffensiveRating(makeRoster(60, ALL_RATING_KEYS));
+    expect(strong).toBeGreaterThan(weak);
+    expect(strong).toBeCloseTo(90, 5);
+    expect(weak).toBeCloseTo(60, 5);
+  });
+
+  it('clamps to [55, 95]', () => {
+    expect(computeTeamOffensiveRating(makeRoster(99, ALL_RATING_KEYS))).toBe(95);
+    expect(computeTeamOffensiveRating(makeRoster(30, ALL_RATING_KEYS))).toBe(55);
+  });
+
+  it('falls back to player OVR when granular ratings are missing', () => {
+    const noGranular = makeRoster(85, []); // players have ovr only
+    expect(computeTeamOffensiveRating(noGranular)).toBeCloseTo(85, 5);
+  });
+
+  it('is deterministic and does not mutate the roster', () => {
+    const roster = makeRoster(80, ALL_RATING_KEYS);
+    const snapshot = JSON.stringify(roster);
+    const a = computeTeamOffensiveRating(roster);
+    const b = computeTeamOffensiveRating(roster);
+    expect(a).toBe(b);
+    expect(JSON.stringify(roster)).toBe(snapshot);
+  });
+
+  it('returns a safe default for an empty roster', () => {
+    expect(computeTeamOffensiveRating([])).toBe(70);
+  });
+});
+
+describe('driveEngine.computeTeamDefensiveRating', () => {
+  it('rates a strong defense above a weak one', () => {
+    const strong = computeTeamDefensiveRating(makeRoster(90, ALL_RATING_KEYS));
+    const weak = computeTeamDefensiveRating(makeRoster(60, ALL_RATING_KEYS));
+    expect(strong).toBeGreaterThan(weak);
+    expect(strong).toBeCloseTo(90, 5);
+    expect(weak).toBeCloseTo(60, 5);
+  });
+
+  it('clamps to [55, 95]', () => {
+    expect(computeTeamDefensiveRating(makeRoster(99, ALL_RATING_KEYS))).toBe(95);
+    expect(computeTeamDefensiveRating(makeRoster(30, ALL_RATING_KEYS))).toBe(55);
+  });
+
+  it('falls back to player OVR when granular ratings are missing', () => {
+    const noGranular = makeRoster(85, []);
+    expect(computeTeamDefensiveRating(noGranular)).toBeCloseTo(85, 5);
+  });
+
+  it('handles players with neither granular ratings nor OVR', () => {
+    const roster = [
+      { pos: 'QB' }, { pos: 'DL' }, { pos: 'CB' },
+    ];
+    expect(computeTeamOffensiveRating(roster)).toBe(70);
+    expect(computeTeamDefensiveRating(roster)).toBe(70);
+  });
+});
+
+describe('driveEngine.buildDriveBasedSummary with rosters', () => {
+  const ROSTER_ARGS = {
+    season: 2025, week: 3,
+    home: { id: 1 }, away: { id: 2 },
+    globalSeed: 42,
+    homeRoster: makeRoster(88, ALL_RATING_KEYS),
+    awayRoster: makeRoster(64, ALL_RATING_KEYS),
+  };
+
+  it('stays backward-compatible when only flat ratings are passed', () => {
+    const flat = buildDriveBasedSummary({
+      season: 2025, week: 3,
+      home: { id: 1 }, away: { id: 2 },
+      homeOff: 80, awayOff: 78, homeDef: 76, awayDef: 75,
+      globalSeed: 42,
+    });
+    // Same pinned seed-42 output as the legacy test — flat callers are untouched.
+    expect(flat.homeScore).toBe(57);
+    expect(flat.awayScore).toBe(30);
+  });
+
+  it('accepts homeRoster/awayRoster and is deterministic for the same seed', () => {
+    const a = buildDriveBasedSummary(ROSTER_ARGS);
+    const b = buildDriveBasedSummary(ROSTER_ARGS);
+    expect(a).toEqual(b);
+  });
+
+  it('keeps the same return shape with rosters provided', () => {
+    const summary = buildDriveBasedSummary(ROSTER_ARGS);
+    for (const key of [
+      'seed', 'homeScore', 'awayScore', 'homeDrives', 'awayDrives',
+      'homeTDs', 'awayTDs', 'homeFGs', 'awayFGs', 'homeXPs', 'awayXPs',
+      'homeStats', 'awayStats',
+    ]) {
+      expect(summary).toHaveProperty(key);
+    }
+    expect(summary.homeScore).toBe(summary.homeTDs * 7 + summary.homeFGs * 3);
+    expect(summary.awayScore).toBe(summary.awayTDs * 7 + summary.awayFGs * 3);
+  });
+
+  it('roster-derived ratings drive scoring (strong roster outscores weak over many seeds)', () => {
+    let strongTotal = 0;
+    let weakTotal = 0;
+    for (let seed = 1; seed <= 50; seed++) {
+      const { homeScore, awayScore } = buildDriveBasedSummary({
+        ...ROSTER_ARGS, globalSeed: seed,
+      });
+      strongTotal += homeScore;
+      weakTotal += awayScore;
+    }
+    expect(strongTotal).toBeGreaterThan(weakTotal);
+  });
+
+  it('ignores empty rosters and keeps flat-number behavior', () => {
+    const flat = buildDriveBasedSummary({
+      season: 2025, week: 3,
+      home: { id: 1 }, away: { id: 2 },
+      homeOff: 80, awayOff: 78, homeDef: 76, awayDef: 75,
+      globalSeed: 42,
+      homeRoster: [], awayRoster: [],
+    });
+    expect(flat.homeScore).toBe(57);
+    expect(flat.awayScore).toBe(30);
   });
 });

--- a/src/core/simulation/driveEngine.js
+++ b/src/core/simulation/driveEngine.js
@@ -75,9 +75,143 @@ export function advanceDownDistance(state, gain) {
   return { down, distance, yardLine, firstDown, touchdown, turnoverOnDowns };
 }
 
+/* ── Team attribute composites ─────────────────────────────────────────────
+ * Pure, deterministic roster → team-rating helpers. They never touch the
+ * PRNG stream, so feeding them into buildDriveBasedSummary keeps the same
+ * seed → same result guarantee.
+ */
+
+const RATING_FLOOR = 55;
+const RATING_CEIL = 95;
+const DEFAULT_RATING = 70;
+
+function ratingOrFallback(player, key) {
+  const granular = player?.ratings?.[key];
+  if (Number.isFinite(granular)) return granular;
+  if (Number.isFinite(player?.ovr)) return player.ovr;
+  return DEFAULT_RATING;
+}
+
+/** Weighted blend of a single player's granular ratings (weights sum to 1). */
+function playerComposite(player, weightedKeys) {
+  let total = 0;
+  for (const [key, weight] of weightedKeys) {
+    total += ratingOrFallback(player, key) * weight;
+  }
+  return total;
+}
+
+/** Average playerComposite over the top `count` players (OVR-desc within pos). */
+function unitComposite(players, count, weightedKeys, fallback) {
+  const picked = players.slice(0, count);
+  if (picked.length === 0) return fallback;
+  let sum = 0;
+  for (const p of picked) sum += playerComposite(p, weightedKeys);
+  return sum / picked.length;
+}
+
+/** Group a roster by position, sorted best-first (depthOrder, then OVR desc). */
+function groupRosterByPosition(roster) {
+  const groups = {};
+  for (const player of roster) {
+    const pos = player?.pos || 'UNK';
+    (groups[pos] ||= []).push(player);
+  }
+  for (const pos in groups) {
+    groups[pos].sort((a, b) => {
+      const aOrder = (a.depthOrder != null && a.depthOrder > 0) ? a.depthOrder : 9999;
+      const bOrder = (b.depthOrder != null && b.depthOrder > 0) ? b.depthOrder : 9999;
+      if (aOrder !== bOrder) return aOrder - bOrder;
+      return (b.ovr || 0) - (a.ovr || 0);
+    });
+  }
+  return groups;
+}
+
+/** Average OVR of the whole roster — unit fallback when a position is empty. */
+function rosterAverageOvr(roster) {
+  if (!Array.isArray(roster) || roster.length === 0) return DEFAULT_RATING;
+  let sum = 0;
+  for (const p of roster) sum += Number.isFinite(p?.ovr) ? p.ovr : DEFAULT_RATING;
+  return sum / roster.length;
+}
+
+/**
+ * Offensive team rating from roster attributes. Deterministic and side-effect
+ * free; any missing granular rating falls back to the player's OVR (then 70).
+ *
+ * Unit weights: QB 35%, OL 30%, WR/TE 20%, RB 15%.
+ *
+ * @param {Array<Object>} roster - player objects ({ pos, ovr, ratings, ... })
+ * @param {string} [scheme='balanced'] - reserved for future scheme-aware weights
+ * @returns {number} clamped to [55, 95]
+ */
+export function computeTeamOffensiveRating(roster, scheme = 'balanced') {
+  if (!Array.isArray(roster) || roster.length === 0) return DEFAULT_RATING;
+  const groups = groupRosterByPosition(roster);
+  const fallback = rosterAverageOvr(roster);
+
+  const qb = unitComposite(groups.QB || [], 1, [
+    ['throwAccuracy', 0.45], ['throwPower', 0.25], ['awareness', 0.3],
+  ], fallback);
+  const ol = unitComposite(groups.OL || [], 5, [
+    ['passBlock', 0.4], ['runBlock', 0.4], ['strength', 0.2],
+  ], fallback);
+  // Top receiving options across WR and TE, best-first by OVR.
+  const receivers = [...(groups.WR || []), ...(groups.TE || [])]
+    .sort((a, b) => (b.ovr || 0) - (a.ovr || 0));
+  const rec = unitComposite(receivers, 3, [
+    ['catching', 0.4], ['catchInTraffic', 0.3], ['speed', 0.3],
+  ], fallback);
+  const rb = unitComposite(groups.RB || [], 1, [
+    ['speed', 0.35], ['acceleration', 0.3], ['trucking', 0.175], ['juking', 0.175],
+  ], fallback);
+
+  const composite = qb * 0.35 + ol * 0.3 + rec * 0.2 + rb * 0.15;
+  return U.clamp(composite, RATING_FLOOR, RATING_CEIL);
+}
+
+/**
+ * Defensive team rating from roster attributes. Deterministic and side-effect
+ * free; any missing granular rating falls back to the player's OVR (then 70).
+ *
+ * Unit weights: DL 25%, LB 25%, CB 30%, S 20%.
+ *
+ * @param {Array<Object>} roster - player objects ({ pos, ovr, ratings, ... })
+ * @param {string} [scheme='balanced'] - reserved for future scheme-aware weights
+ * @returns {number} clamped to [55, 95]
+ */
+export function computeTeamDefensiveRating(roster, scheme = 'balanced') {
+  if (!Array.isArray(roster) || roster.length === 0) return DEFAULT_RATING;
+  const groups = groupRosterByPosition(roster);
+  const fallback = rosterAverageOvr(roster);
+
+  const dl = unitComposite(groups.DL || [], 4, [
+    ['passRushPower', 0.4], ['passRushSpeed', 0.35], ['strength', 0.25],
+  ], fallback);
+  const lb = unitComposite(groups.LB || [], 3, [
+    ['tackle', 0.35], ['awareness', 0.3], ['runStop', 0.175], ['coverage', 0.175],
+  ], fallback);
+  const cb = unitComposite(groups.CB || [], 3, [
+    ['coverage', 0.45], ['speed', 0.35], ['awareness', 0.2],
+  ], fallback);
+  const s = unitComposite(groups.S || [], 2, [
+    ['awareness', 0.35], ['coverage', 0.35], ['tackle', 0.3],
+  ], fallback);
+
+  const composite = dl * 0.25 + lb * 0.25 + cb * 0.3 + s * 0.2;
+  return U.clamp(composite, RATING_FLOOR, RATING_CEIL);
+}
+
 /**
  * Deterministic, seeded drive-level game summary. The authoritative source of
  * homeScore / awayScore for a simulated game. Same seed + inputs → same result.
+ *
+ * When a non-empty homeRoster/awayRoster is provided, that side's offensive
+ * and defensive ratings are derived from roster attributes via
+ * computeTeamOffensiveRating / computeTeamDefensiveRating, overriding the
+ * corresponding flat homeOff/homeDef (or awayOff/awayDef) inputs. Without
+ * rosters the flat-number behavior is unchanged.
  */
 export function buildDriveBasedSummary({
   season = 0,
@@ -92,7 +226,18 @@ export function buildDriveBasedSummary({
   homeStrategicEdge = 0,
   awayStrategicEdge = 0,
   globalSeed = 0,
+  homeRoster = null,
+  awayRoster = null,
 }) {
+  if (Array.isArray(homeRoster) && homeRoster.length > 0) {
+    homeOff = computeTeamOffensiveRating(homeRoster);
+    homeDef = computeTeamDefensiveRating(homeRoster);
+  }
+  if (Array.isArray(awayRoster) && awayRoster.length > 0) {
+    awayOff = computeTeamOffensiveRating(awayRoster);
+    awayDef = computeTeamDefensiveRating(awayRoster);
+  }
+
   const baseSeed = hashStringToSeed(`${season}|${week}|${home?.id}|${away?.id}`);
   const seed = (baseSeed ^ (globalSeed >>> 0)) >>> 0;
   const rng = mulberry32(seed);


### PR DESCRIPTION
Add pure, exported computeTeamOffensiveRating/computeTeamDefensiveRating
helpers that derive a team rating in [55, 95] from granular player
ratings (QB 35/OL 30/WR-TE 20/RB 15 on offense; DL 25/LB 25/CB 30/S 20
on defense), falling back to player OVR (then 70) when a rating is
missing. The scheme parameter is accepted but unused for now.

buildDriveBasedSummary now accepts optional homeRoster/awayRoster; when
a non-empty roster is provided it overrides that side's flat off/def
inputs with the composites. Flat-rating callers are byte-for-byte
unchanged (pinned seed-42 output still passes) and the return shape is
untouched. The composites never draw from the PRNG, so determinism for
the same seed and inputs is preserved.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012BGHT7RWQY6UMMgBLfYmGS