### PR TITLE
Harden coaching dev-rate modifier wiring in offseason progression

### DIFF
--- a/src/core/__tests__/coaching-dev-modifier-wiring.test.js
+++ b/src/core/__tests__/coaching-dev-modifier-wiring.test.js
@@ -1,0 +1,248 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  processPlayerProgression,
+  sanitizeCoachDevModifier,
+  applyCoachDevModifier,
+} from '../progression-logic.js';
+import { getDevelopmentRateModifier } from '../coaching-philosophy-effects.js';
+import { Utils } from '../utils.js';
+
+// Wrap getDevelopmentRateModifier in a vi.fn that defaults to the real
+// implementation so most tests exercise the true helper, while individual
+// tests can inject pathological returns (NaN, Infinity, huge values) with
+// mockReturnValueOnce to prove the wiring's safety rails.
+vi.mock('../coaching-philosophy-effects.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getDevelopmentRateModifier: vi.fn(actual.getDevelopmentRateModifier),
+  };
+});
+
+// Real modifier for a QB: 1 + 0.05 (DEVELOPMENTAL) + 0.04 (HC SPREAD) + 0.02 (OC SPREAD × 0.5) = 1.11
+const HIGH_DEV_STAFF = {
+  headCoach: { traits: ['DEVELOPMENTAL'], offensivePhilosophy: 'SPREAD' },
+  offCoordinator: { offensivePhilosophy: 'SPREAD' },
+};
+
+// Real modifier for a QB: 1.0 (no trait, BALANCED philosophy, no dev bonus)
+const LOW_DEV_STAFF = {
+  headCoach: { traits: [], offensivePhilosophy: 'BALANCED' },
+};
+
+function buildProfile() {
+  // workEthic 55 / diva 45 / discipline 45 zero out the personality terms in
+  // the breakout/bust probability math, keeping the growth roll predictable.
+  return {
+    workEthic: 55, leadership: 55, diva: 45, riskTaker: 40,
+    discipline: 45, coachability: 60, holdoutRisk: 20, consistency: 65, offFieldRisk: 25,
+  };
+}
+
+function buildPlayer(overrides = {}) {
+  return {
+    id: 1,
+    name: 'Wiring Test QB',
+    teamId: 1,
+    pos: 'QB',
+    age: 23,
+    ovr: 75,
+    potential: 85,
+    devTrait: 'Superstar',
+    morale: 50,
+    personalityProfile: buildProfile(),
+    ratings: {
+      throwPower: 75,
+      throwAccuracy: 75,
+      accuracyShort: 75,
+      accuracyMedium: 75,
+      accuracyDeep: 75,
+      awareness: 75,
+      intelligence: 75,
+      speed: 75,
+      agility: 75,
+      acceleration: 75,
+    },
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.mocked(getDevelopmentRateModifier).mockClear();
+});
+
+// ── sanitizeCoachDevModifier ──────────────────────────────────────────────────
+
+describe('sanitizeCoachDevModifier', () => {
+  it('defaults non-finite values to 1.0', () => {
+    expect(sanitizeCoachDevModifier(undefined)).toBe(1.0);
+    expect(sanitizeCoachDevModifier(null)).toBe(1.0);
+    expect(sanitizeCoachDevModifier(NaN)).toBe(1.0);
+    expect(sanitizeCoachDevModifier(Infinity)).toBe(1.0);
+    expect(sanitizeCoachDevModifier(-Infinity)).toBe(1.0);
+    expect(sanitizeCoachDevModifier('not a number')).toBe(1.0);
+  });
+
+  it('clamps finite values to [0.5, 2.0]', () => {
+    expect(sanitizeCoachDevModifier(10)).toBe(2.0);
+    expect(sanitizeCoachDevModifier(0.01)).toBe(0.5);
+    expect(sanitizeCoachDevModifier(-3)).toBe(0.5);
+  });
+
+  it('passes through values inside the rails', () => {
+    expect(sanitizeCoachDevModifier(1.11)).toBe(1.11);
+    expect(sanitizeCoachDevModifier(0.85)).toBe(0.85);
+    expect(sanitizeCoachDevModifier(1.0)).toBe(1.0);
+  });
+});
+
+// ── applyCoachDevModifier ─────────────────────────────────────────────────────
+
+describe('applyCoachDevModifier', () => {
+  it('high-development staff boosts a positive delta more than low-development staff', () => {
+    const high = applyCoachDevModifier(5, 'QB', HIGH_DEV_STAFF); // round(5 × 1.11) = 6
+    const low  = applyCoachDevModifier(5, 'QB', LOW_DEV_STAFF);  // round(5 × 1.00) = 5
+    expect(high).toBe(6);
+    expect(low).toBe(5);
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('never touches negative or zero deltas (regression is coach-independent)', () => {
+    expect(applyCoachDevModifier(-3, 'QB', HIGH_DEV_STAFF)).toBe(-3);
+    expect(applyCoachDevModifier(0, 'QB', HIGH_DEV_STAFF)).toBe(0);
+    // Modifier helper is never even consulted for non-positive deltas
+    expect(vi.mocked(getDevelopmentRateModifier)).not.toHaveBeenCalled();
+  });
+
+  it('missing staff is a no-op', () => {
+    expect(applyCoachDevModifier(4, 'QB', null)).toBe(4);
+    expect(applyCoachDevModifier(4, 'QB', undefined)).toBe(4);
+    expect(vi.mocked(getDevelopmentRateModifier)).not.toHaveBeenCalled();
+  });
+
+  it('non-finite modifier returns default to 1.0 (no-op)', () => {
+    vi.mocked(getDevelopmentRateModifier).mockReturnValueOnce(NaN);
+    expect(applyCoachDevModifier(4, 'QB', HIGH_DEV_STAFF)).toBe(4);
+
+    vi.mocked(getDevelopmentRateModifier).mockReturnValueOnce(undefined);
+    expect(applyCoachDevModifier(4, 'QB', HIGH_DEV_STAFF)).toBe(4);
+
+    vi.mocked(getDevelopmentRateModifier).mockReturnValueOnce(Infinity);
+    expect(applyCoachDevModifier(4, 'QB', HIGH_DEV_STAFF)).toBe(4);
+  });
+
+  it('out-of-range modifier returns are clamped to [0.5, 2.0]', () => {
+    vi.mocked(getDevelopmentRateModifier).mockReturnValueOnce(10);
+    expect(applyCoachDevModifier(3, 'QB', HIGH_DEV_STAFF)).toBe(6); // 3 × 2.0
+
+    vi.mocked(getDevelopmentRateModifier).mockReturnValueOnce(0.01);
+    expect(applyCoachDevModifier(4, 'QB', HIGH_DEV_STAFF)).toBe(2); // 4 × 0.5
+  });
+});
+
+// ── processPlayerProgression wiring ───────────────────────────────────────────
+
+describe('processPlayerProgression coaching dev modifier wiring', () => {
+  it('high-development staff produces more positive growth than low-development staff', () => {
+    // random 0.5 avoids breakout (0.20) and bust (0.18) rolls → normal growth.
+    // rand → max: rawDelta 3 × Superstar 1.5 → round(4.5) = 5 base delta.
+    // High staff: round(5 × 1.11) = 6; low staff: 5.
+    // Shared scheme-fit team with a 45-rated coach (×0.88) keeps the final
+    // delta under the ±5 clamp: high round(6 × 0.88) = 5, low round(5 × 0.88) = 4.
+    vi.spyOn(Utils, 'random').mockReturnValue(0.5);
+    vi.spyOn(Utils, 'rand').mockImplementation((min, max) => max);
+
+    const highPlayer = buildPlayer({ id: 10, teamId: 10 });
+    const lowPlayer  = buildPlayer({ id: 11, teamId: 11 });
+    const schemeTeam = { coach: { headCoach: { scheme: 'SPREAD', overallRating: 45 } } };
+
+    processPlayerProgression([highPlayer, lowPlayer], {
+      teamCoaches: { 10: HIGH_DEV_STAFF, 11: LOW_DEV_STAFF },
+      teams: { 10: schemeTeam, 11: schemeTeam },
+    });
+
+    expect(highPlayer.ratings.throwPower).toBe(80); // 75 + 5
+    expect(lowPlayer.ratings.throwPower).toBe(79);  // 75 + 4
+    expect(highPlayer.ovr).toBeGreaterThan(lowPlayer.ovr);
+  });
+
+  it('does not amplify aging decline — regression is identical regardless of staff', () => {
+    // Age 33 QB (decline starts at 31): random 0.5 avoids wall (0.30) and
+    // cliff (0.15) → normal decline of -3 × Superstar 0.75 → -2 for both.
+    vi.spyOn(Utils, 'random').mockReturnValue(0.5);
+    vi.spyOn(Utils, 'rand').mockImplementation((min, max) => max);
+
+    const highVet = buildPlayer({ id: 20, teamId: 20, age: 33 });
+    const lowVet  = buildPlayer({ id: 21, teamId: 21, age: 33 });
+
+    processPlayerProgression([highVet, lowVet], {
+      teamCoaches: { 20: HIGH_DEV_STAFF, 21: LOW_DEV_STAFF },
+    });
+
+    expect(highVet.ratings).toEqual(lowVet.ratings);
+    expect(highVet.ovr).toBe(lowVet.ovr);
+    // Decline path never consults the coaching dev modifier at all
+    expect(vi.mocked(getDevelopmentRateModifier)).not.toHaveBeenCalled();
+  });
+
+  it('missing coach/staff data defaults to a 1.0 multiplier (no-op)', () => {
+    vi.spyOn(Utils, 'random').mockReturnValue(0.5);
+    vi.spyOn(Utils, 'rand').mockImplementation((min, max) => max);
+
+    const noEntry   = buildPlayer({ id: 30, teamId: 30 }); // teamId absent from teamCoaches
+    const nullStaff = buildPlayer({ id: 31, teamId: 31 }); // explicit null staff
+    const neutral   = buildPlayer({ id: 32, teamId: 32 }); // staff with zero dev bonus
+    const noOptions = buildPlayer({ id: 33, teamId: 33 }); // no options at all
+
+    processPlayerProgression([noEntry, nullStaff, neutral], {
+      teamCoaches: { 31: null, 32: LOW_DEV_STAFF },
+    });
+    processPlayerProgression([noOptions]);
+
+    expect(noEntry.ratings).toEqual(nullStaff.ratings);
+    expect(noEntry.ratings).toEqual(neutral.ratings);
+    expect(noEntry.ratings).toEqual(noOptions.ratings);
+    expect(noEntry.ovr).toBe(noOptions.ovr);
+  });
+
+  it('progression is deterministic for the same seed and inputs', () => {
+    function makeLCG(seed) {
+      let s = seed >>> 0 || 1;
+      return () => {
+        s = ((1664525 * s + 1013904223) | 0) >>> 0;
+        return s / 0x100000000;
+      };
+    }
+
+    function runOnce() {
+      const next = makeLCG(1337);
+      vi.spyOn(Utils, 'random').mockImplementation(next);
+      vi.spyOn(Utils, 'rand').mockImplementation(
+        (min, max) => Math.floor(next() * (max - min + 1)) + min
+      );
+
+      const players = [
+        buildPlayer({ id: 1, teamId: 1 }),
+        buildPlayer({ id: 2, teamId: 2, age: 27, devTrait: 'Normal' }),
+        buildPlayer({ id: 3, teamId: 3, age: 33 }),
+      ];
+      const result = processPlayerProgression(players, {
+        season: 2030,
+        teamCoaches: { 1: HIGH_DEV_STAFF, 2: HIGH_DEV_STAFF, 3: LOW_DEV_STAFF },
+      });
+      vi.restoreAllMocks();
+      return { players, result };
+    }
+
+    const first  = runOnce();
+    const second = runOnce();
+
+    expect(second.players.map((p) => p.ratings)).toEqual(first.players.map((p) => p.ratings));
+    expect(second.players.map((p) => p.ovr)).toEqual(first.players.map((p) => p.ovr));
+    expect(second.players.map((p) => p.progressionDelta))
+      .toEqual(first.players.map((p) => p.progressionDelta));
+    expect(second.result.gainers).toEqual(first.result.gainers);
+    expect(second.result.regressors).toEqual(first.result.regressors);
+  });
+});

--- a/src/core/progression-logic.js
+++ b/src/core/progression-logic.js
@@ -115,6 +115,43 @@ export function resolveSchemeMultiplier(player, team) {
   return getCoachSchemeMultiplier(hc.overallRating);
 }
 
+// ── Coaching development-rate modifier safety rails ───────────────────────────
+// getDevelopmentRateModifier clamps its own output to [0.85, 1.15]; these wider
+// bounds are a defensive rail so a future helper change can never zero out or
+// explode development, and a non-finite return can never poison ratings with NaN.
+const COACH_DEV_MOD_MIN = 0.5;
+const COACH_DEV_MOD_MAX = 2.0;
+
+/**
+ * Sanitize a raw coaching development-rate modifier for use as a multiplier.
+ * undefined / null / NaN / non-finite → 1.0 (no-op); finite values are clamped
+ * to [0.5, 2.0].
+ */
+export function sanitizeCoachDevModifier(rawModifier) {
+  if (rawModifier == null) return 1.0; // null coerces to 0, so guard before Number()
+  const mod = Number(rawModifier);
+  if (!Number.isFinite(mod)) return 1.0;
+  return Math.max(COACH_DEV_MOD_MIN, Math.min(COACH_DEV_MOD_MAX, mod));
+}
+
+/**
+ * Apply the coaching philosophy development-rate modifier to a progression delta.
+ * Positive growth only — regression, aging decline, and zero deltas pass through
+ * untouched, as do players on teams with no staff data (multiplier is 1.0).
+ *
+ * @param {number} ovrDelta  - base OVR delta from the age-curve roll
+ * @param {string} position  - player position, e.g. 'QB'
+ * @param {object} teamStaff - team.staff object (or null/undefined)
+ * @returns {number} adjusted delta (rounded when a multiplier was applied)
+ */
+export function applyCoachDevModifier(ovrDelta, position, teamStaff) {
+  if (!(ovrDelta > 0) || !teamStaff) return ovrDelta;
+  const mod = sanitizeCoachDevModifier(
+    getDevelopmentRateModifier(position, teamStaff.headCoach ?? null, teamStaff)
+  );
+  return Math.round(ovrDelta * mod);
+}
+
 /**
  * Apply scheme multiplier and morale bonus to a base OVR delta, clamped to [-5, +5].
  *
@@ -358,13 +395,9 @@ export function processPlayerProgression(players, options = {}) {
 
     // ── Coaching philosophy development modifier ───────────────────────────────
     // Multiplies positive growth deltas only; never amplifies busts or regressions.
-    // Missing coach/staff → getDevelopmentRateModifier returns 1.0 (no-op).
+    // Missing coach/staff or a non-finite modifier → 1.0 (no-op).
     if (ovrDelta > 0 && !bustEvent) {
-      const teamStaff = teamCoaches[player.teamId] ?? null;
-      if (teamStaff) {
-        const coachDevMod = getDevelopmentRateModifier(player.pos, teamStaff.headCoach ?? null, teamStaff);
-        ovrDelta = Math.round(ovrDelta * coachDevMod);
-      }
+      ovrDelta = applyCoachDevModifier(ovrDelta, player.pos, teamCoaches[player.teamId] ?? null);
     }
 
     // ── Apply non-cliff, non-wall deltas via position-specific rating nudges (Task 6)


### PR DESCRIPTION
Extract the getDevelopmentRateModifier application in
processPlayerProgression into exported helpers with safety rails:

- sanitizeCoachDevModifier: null/undefined/NaN/non-finite returns
  default to 1.0; finite values clamp to [0.5, 2.0] as a wider rail
  on top of the helper's own [0.85, 1.15] clamp.
- applyCoachDevModifier: multiplies positive growth deltas only;
  regression/decline and zero deltas pass through untouched, missing
  staff is a no-op.

Behavior is unchanged for every value the helper can currently return.
Adds wiring-level tests: high- vs low-development staff growth,
decline unaffected by staff, missing-staff no-op, non-finite/clamp
rails, and same-seed determinism.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DrNhTbKXMDPCWmjacKE8PA