### PR TITLE
Add fourth-down and special-teams model to drive engine (V1)

### DIFF
--- a/src/core/__tests__/simulation/driveEngine.test.js
+++ b/src/core/__tests__/simulation/driveEngine.test.js
@@ -46,8 +46,11 @@ describe('driveEngine.buildDriveBasedSummary', () => {
     expect(a.awayScore).toBe(b.awayScore);
     expect(a.seed).toBe(b.seed);
     // Pin the specific seed-42 output so regressions to the PRNG stream are caught.
-    expect(a.homeScore).toBe(57);
-    expect(a.awayScore).toBe(30);
+    // Fourth-down + special-teams V1 added new rng() draws (drive start field
+    // position, FG/punt decisions, 2-pt tries), so the pinned values changed
+    // from the pre-special-teams 57/30 to the new deterministic output.
+    expect(a.homeScore).toBe(43);
+    expect(a.awayScore).toBe(45);
   });
 
   it('keeps possession counts correlated (|homeDrives - awayDrives| ≤ 3) for 100 seeded runs', () => {
@@ -169,8 +172,9 @@ describe('driveEngine.buildDriveBasedSummary with rosters', () => {
       globalSeed: 42,
     });
     // Same pinned seed-42 output as the legacy test — flat callers are untouched.
-    expect(flat.homeScore).toBe(57);
-    expect(flat.awayScore).toBe(30);
+    // (Values updated for fourth-down + special-teams V1; see comment above.)
+    expect(flat.homeScore).toBe(43);
+    expect(flat.awayScore).toBe(45);
   });
 
   it('accepts homeRoster/awayRoster and is deterministic for the same seed', () => {
@@ -188,8 +192,14 @@ describe('driveEngine.buildDriveBasedSummary with rosters', () => {
     ]) {
       expect(summary).toHaveProperty(key);
     }
-    expect(summary.homeScore).toBe(summary.homeTDs * 7 + summary.homeFGs * 3);
-    expect(summary.awayScore).toBe(summary.awayTDs * 7 + summary.awayFGs * 3);
+    // Score identity with PATs modeled explicitly: a TD is 6 + made XP (+1)
+    // or made 2-pt (+2); a failed 2-pt adds nothing.
+    expect(summary.homeScore).toBe(
+      summary.homeTDs * 6 + summary.homeXPs + summary.homeStats.twoPointMade * 2 + summary.homeFGs * 3,
+    );
+    expect(summary.awayScore).toBe(
+      summary.awayTDs * 6 + summary.awayXPs + summary.awayStats.twoPointMade * 2 + summary.awayFGs * 3,
+    );
   });
 
   it('roster-derived ratings drive scoring (strong roster outscores weak over many seeds)', () => {
@@ -205,6 +215,16 @@ describe('driveEngine.buildDriveBasedSummary with rosters', () => {
     expect(strongTotal).toBeGreaterThan(weakTotal);
   });
 
+  it('exposes special-teams counters on homeStats/awayStats', () => {
+    const summary = buildDriveBasedSummary(ROSTER_ARGS);
+    for (const side of [summary.homeStats, summary.awayStats]) {
+      for (const key of ['punts', 'fgAttempts', 'fgMade', 'twoPointAttempts', 'twoPointMade']) {
+        expect(side).toHaveProperty(key);
+        expect(side[key]).toBeGreaterThanOrEqual(0);
+      }
+    }
+  });
+
   it('ignores empty rosters and keeps flat-number behavior', () => {
     const flat = buildDriveBasedSummary({
       season: 2025, week: 3,
@@ -213,7 +233,62 @@ describe('driveEngine.buildDriveBasedSummary with rosters', () => {
       globalSeed: 42,
       homeRoster: [], awayRoster: [],
     });
-    expect(flat.homeScore).toBe(57);
-    expect(flat.awayScore).toBe(30);
+    // Same pinned seed-42 output as above (fourth-down + special-teams V1).
+    expect(flat.homeScore).toBe(43);
+    expect(flat.awayScore).toBe(45);
+  });
+});
+
+// ── Fourth down + special teams V1 ───────────────────────────────────────────
+
+describe('driveEngine.buildDriveBasedSummary fourth-down/special-teams model', () => {
+  const gameForSeed = (seed) => buildDriveBasedSummary({
+    season: 2025, week: 5,
+    home: { id: 3 }, away: { id: 4 },
+    homeOff: 79, awayOff: 77, homeDef: 74, awayDef: 76,
+    globalSeed: seed,
+  });
+
+  it('produces FG makes, punts, and 2-pt attempts in aggregate over 200 seeded games', () => {
+    const baseSeed = 1000;
+    let fgMade = 0;
+    let punts = 0;
+    let twoPointAttempts = 0;
+    let twoPointMade = 0;
+    for (let i = 0; i < 200; i++) {
+      const g = gameForSeed(baseSeed + i);
+      for (const side of [g.homeStats, g.awayStats]) {
+        fgMade += side.fgMade;
+        punts += side.punts;
+        twoPointAttempts += side.twoPointAttempts;
+        twoPointMade += side.twoPointMade;
+        // Per-team sanity: makes can never exceed attempts.
+        expect(side.twoPointMade).toBeLessThanOrEqual(side.twoPointAttempts);
+        expect(side.fgMade).toBeLessThanOrEqual(side.fgAttempts);
+      }
+    }
+    expect(fgMade).toBeGreaterThan(0);
+    expect(punts).toBeGreaterThan(0);
+    expect(twoPointAttempts).toBeGreaterThan(0);
+    expect(twoPointMade).toBeLessThanOrEqual(twoPointAttempts);
+  });
+
+  it('holds the exact score identity for every team in 200 seeded games', () => {
+    // A failed 2-pt try must add 0 PAT points — these identities catch any
+    // accidental "+1 on failed 2-pt" regression cleanly.
+    const baseSeed = 5000;
+    for (let i = 0; i < 200; i++) {
+      const g = gameForSeed(baseSeed + i);
+      // Every TD gets exactly one PAT try: an XP kick or a 2-pt attempt.
+      expect(g.homeXPs + g.homeStats.twoPointAttempts).toBe(g.homeTDs);
+      expect(g.awayXPs + g.awayStats.twoPointAttempts).toBe(g.awayTDs);
+      // Scoreboard reconciles exactly with the scoring-play breakdown.
+      expect(g.homeScore).toBe(
+        g.homeTDs * 6 + g.homeXPs + g.homeStats.twoPointMade * 2 + g.homeFGs * 3,
+      );
+      expect(g.awayScore).toBe(
+        g.awayTDs * 6 + g.awayXPs + g.awayStats.twoPointMade * 2 + g.awayFGs * 3,
+      );
+    }
   });
 });

--- a/src/core/simulation/driveEngine.js
+++ b/src/core/simulation/driveEngine.js
@@ -250,20 +250,94 @@ export function buildDriveBasedSummary({
   const totalDrives = randInt(20, 26);
   const homeDrives = Math.round(totalDrives / 2) + randInt(-1, 1);
   const awayDrives = totalDrives - homeDrives;
-  const homeStats = { passYds: 0, passAtt: 0, comp: 0, passTD: 0, INT: 0, rushYds: 0, rushAtt: 0, sacks: 0, turnovers: 0 };
-  const awayStats = { passYds: 0, passAtt: 0, comp: 0, passTD: 0, INT: 0, rushYds: 0, rushAtt: 0, sacks: 0, turnovers: 0 };
+  const homeStats = { passYds: 0, passAtt: 0, comp: 0, passTD: 0, INT: 0, rushYds: 0, rushAtt: 0, sacks: 0, turnovers: 0, punts: 0, fgAttempts: 0, fgMade: 0, twoPointAttempts: 0, twoPointMade: 0 };
+  const awayStats = { passYds: 0, passAtt: 0, comp: 0, passTD: 0, INT: 0, rushYds: 0, rushAtt: 0, sacks: 0, turnovers: 0, punts: 0, fgAttempts: 0, fgMade: 0, twoPointAttempts: 0, twoPointMade: 0 };
 
   const simTeam = (offOvr, defOvr, drives, teamStats, isHome, netEdge = 0) => {
     let score = 0;
     // Scoring-play breakdown — authoritative source for box-score reconciliation.
-    // Each touchdown here is scored as 7 (6 + a made extra point), so the
-    // identity 7*tds + 3*fgs === score holds exactly.
+    // A touchdown is 6 points plus its PAT (made XP = +1, made 2-pt = +2, failed
+    // 2-pt = +0), so the identity
+    //   score === tds*6 + xps + teamStats.twoPointMade*2 + fgs*3
+    // holds exactly. Every TD gets exactly one PAT try:
+    //   xps + teamStats.twoPointAttempts === tds.
     let tds = 0;
     let fgs = 0;
     let xps = 0;
     const driveSuccessRaw = 0.4 + (offOvr - defOvr) * 0.005 + (isHome ? homeFieldAdv : 0) + netEdge;
     const driveSuccess = U.clamp(driveSuccessRaw, 0.15, 0.72);
+
+    // FG success by kick position — longer kicks (lower yardLine) are harder.
+    const fgSuccessProb = (yardLine) => U.clamp(0.97 - (100 - yardLine) * 0.025, 0.35, 0.97);
+
+    // FG attempt from the current field position. A miss scores nothing —
+    // possession changes either way, so the drive simply ends.
+    const attemptFieldGoal = (yardLine) => {
+      teamStats.fgAttempts += 1;
+      if (chance(fgSuccessProb(yardLine))) {
+        score += 3;
+        fgs += 1;
+        teamStats.fgMade += 1;
+      }
+    };
+
+    // Resolve a drive that reached scoring position (converted drive or a
+    // successful 4th-down go-for-it) into a TD + PAT or a made FG.
+    const resolveScoringDrive = (yardLine) => {
+      if (chance(0.67)) {
+        tds += 1;
+        if (chance(0.58)) teamStats.passTD += 1;
+        if (chance(0.07)) {
+          // 2-point try replaces the XP: success is +2, failure is +0 —
+          // a failed 2-pt attempt adds NO extra point on top of the 6.
+          teamStats.twoPointAttempts += 1;
+          if (chance(0.47)) {
+            teamStats.twoPointMade += 1;
+            score += 8;
+          } else {
+            score += 6;
+          }
+        } else {
+          score += 7;
+          xps += 1;
+        }
+      } else {
+        // Converted drives that stall in close still book a made FG; it
+        // counts as an attempt too so fgAttempts >= fgMade always holds.
+        score += 3;
+        fgs += 1;
+        teamStats.fgAttempts += 1;
+        teamStats.fgMade += 1;
+      }
+    };
+
+    /*
+     * rng() draw order per drive — determinism contract, do NOT reorder.
+     * Conditional draws only happen when their branch is taken:
+     *   1. drive start offset        randInt(-10, 15)   (drive starts at 25 + offset)
+     *   2. passHeavy                 chance(0.56)
+     *   3. passAtt                   randInt
+     *   4. comp                      randInt
+     *   5. passYds                   randInt
+     *   6. rushAtt                   randInt
+     *   7. rushYds                   randInt
+     *   8. sack                      chance
+     *   9. turnover                  chance
+     *  10. [turnover] INT            chance(0.7)
+     *  11. convertedDrive            chance(driveSuccess)
+     *  12. [converted OR go-for-it success] TD-vs-FG   chance(0.67)
+     *  13. [TD] passTD               chance(0.58)
+     *  14. [TD] 2-pt attempt         chance(0.07)
+     *  15. [2-pt attempt] 2-pt make  chance(0.47)
+     *  16. [not converted, estDistance<=2 && yardLine>=60] go-for-it  chance(0.30)
+     *  17. [going for it] conversion chance(0.52) — success re-enters 12
+     *  18. [not converted, not going, yardLine 40–59] FG-vs-punt      chance(0.45)
+     *  19. [FG attempt from 12/18 fail-side or yardLine>=60] FG make  chance(fgSuccessProb)
+     * estDistance is derived from drive yardage (no rng draw).
+     */
     for (let i = 0; i < drives; i++) {
+      // Field position is scoring-model bookkeeping only — local to simTeam.
+      let yardLine = 25 + randInt(-10, 15);
       const passHeavy = chance(0.56);
       const passAtt = randInt(passHeavy ? 3 : 1, passHeavy ? 7 : 4);
       const comp = Math.min(passAtt, randInt(Math.max(0, passAtt - 3), passAtt));
@@ -275,6 +349,7 @@ export function buildDriveBasedSummary({
       teamStats.passYds += passYds;
       teamStats.rushAtt += rushAtt;
       teamStats.rushYds += rushYds;
+      yardLine = U.clamp(yardLine + passYds + rushYds, 1, 99);
       if (chance(U.clamp(0.17 + (defOvr - offOvr) * 0.0025, 0.08, 0.34))) {
         teamStats.sacks += 1;
       }
@@ -284,15 +359,28 @@ export function buildDriveBasedSummary({
       }
       const convertedDrive = chance(driveSuccess);
       if (convertedDrive) {
-        if (chance(0.67)) {
-          score += 7;
-          tds += 1;
-          xps += 1;
-          if (chance(0.58)) teamStats.passTD += 1;
-        } else {
-          score += 3;
-          fgs += 1;
+        resolveScoringDrive(yardLine);
+        continue;
+      }
+      // Drive stalled → fourth-down decision from field position.
+      // Estimated yards-to-go on the stalled 4th down, derived from the
+      // drive's own yardage (deterministic, costs no rng draw): 1..10.
+      const estDistance = 10 - ((passYds + rushYds) % 10);
+      if (estDistance <= 2 && yardLine >= 60 && chance(0.30)) {
+        // Short-yardage go-for-it instead of the FG try.
+        if (chance(0.52)) {
+          resolveScoringDrive(yardLine);
         }
+        // Failure: turnover on downs — no score, possession changes.
+        continue;
+      }
+      if (yardLine >= 60) {
+        attemptFieldGoal(yardLine);
+      } else if (yardLine >= 40) {
+        if (chance(0.45)) attemptFieldGoal(yardLine);
+        else teamStats.punts += 1;
+      } else {
+        teamStats.punts += 1;
       }
     }
     return { score, tds, fgs, xps };

--- a/tests/unit/deterministicSimAudit.test.js
+++ b/tests/unit/deterministicSimAudit.test.js
@@ -212,10 +212,15 @@ describe('Deterministic Sim Reproducibility Audit', () => {
     });
 
     it('different seed + same inputs CAN produce different scores', () => {
+      // The drive engine (seeded from season|week|teamIds ^ league.globalSeed)
+      // is the authoritative score source, so the seed must flow through
+      // league.globalSeed to vary the scoreboard. The Utils seed still feeds
+      // strength noise, but since fourth-down/special-teams V1 that noise is
+      // not guaranteed to cross a scoring threshold for a fixed matchup.
       const seeds = [1001, 2002, 3003, 4004, 5005, 6006, 7007, 8008];
       const scoreSet = new Set(
         seeds.map((seed) => {
-          const league = { teams: [makeTeam(1), makeTeam(2)] };
+          const league = { teams: [makeTeam(1), makeTeam(2)], globalSeed: seed };
           Utils.setSeed(seed);
           const r = simulateMatchup(league.teams[0], league.teams[1], { league });
           return r ? `${r.homeScore}-${r.awayScore}` : 'null';


### PR DESCRIPTION
Replace the binary convertedDrive coin flip in buildDriveBasedSummary()
with a field-position-aware drive-outcome model:

- Track a local yardLine per drive (start 25 + randInt(-10,15), advanced
  by drive yardage) inside simTeam().
- Stalled drives now resolve by field position: FG attempt in range
  (success = clamp(0.97 - (100 - yardLine) * 0.025, 0.35, 0.97)),
  punt-or-FG in the 40-59 band, punt deep in own territory.
- Short-yardage go-for-it: estimated distance <= 2 in FG range has a 30%
  chance to go for it (52% conversion) instead of kicking.
- Two-point conversions: 7% of TDs attempt a 2-pt try (47% success);
  a failed try scores 0 PAT points (TD stays 6).
- New teamStats counters: punts, fgAttempts, fgMade, twoPointAttempts,
  twoPointMade, exposed on homeStats/awayStats. All existing return keys
  are unchanged.
- Document the per-drive rng() draw order as a determinism contract.

Score identity is now score === tds*6 + xps + twoPointMade*2 + fgs*3
with xps + twoPointAttempts === tds. Tests cover the identity per team
across 200 seeded games plus aggregate FG/punt/2-pt distributions.

The pinned seed-42 scores changed (57/30 -> 43/45) because the model
adds new rng() draws to the stream; the deterministic-sim audit's
"different seed CAN change scores" case now varies league.globalSeed,
the seed channel that actually drives the authoritative scoreboard.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RQy13baTqFsj8JH6AopRkh