### PR TITLE
Add hidden draft variance and development traits (V1)

### DIFF
--- a/src/core/draft/__tests__/draftVariance.test.js
+++ b/src/core/draft/__tests__/draftVariance.test.js
@@ -1,0 +1,369 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getDraftVarianceRange,
+  inferProspectRound,
+  rollTrueOvrFromScoutedOvr,
+  rollDevTrait,
+  getDevTraitMultiplier,
+  combineDevModifiers,
+  getTrueOvrGrowthBonus,
+  applyDraftHiddenVariance,
+  HIDDEN_DEV_TRAITS,
+} from '../draftVariance.js';
+import { processPlayerProgression } from '../../progression-logic.js';
+import { generateDraftClass } from '../../player.js';
+import { Utils } from '../../utils.js';
+
+// Local deterministic RNG (mulberry32) so tests never depend on global state.
+function mulberry32(seed) {
+  let s = seed | 0;
+  return function () {
+    s = (s + 0x6D2B79F5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function stdDev(values) {
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  return Math.sqrt(values.reduce((acc, v) => acc + (v - mean) ** 2, 0) / values.length);
+}
+
+// ── getDraftVarianceRange ─────────────────────────────────────────────────────
+
+describe('getDraftVarianceRange', () => {
+  it('returns the round-tiered ranges', () => {
+    expect(getDraftVarianceRange(1)).toEqual({ min: -5, max: 8 });
+    expect(getDraftVarianceRange(2)).toEqual({ min: -8, max: 12 });
+    expect(getDraftVarianceRange(3)).toEqual({ min: -8, max: 12 });
+    for (const r of [4, 5, 6, 7]) {
+      expect(getDraftVarianceRange(r)).toEqual({ min: -10, max: 18 });
+    }
+  });
+
+  it('falls back to round 2-3 variance for unknown rounds', () => {
+    expect(getDraftVarianceRange(undefined)).toEqual({ min: -8, max: 12 });
+    expect(getDraftVarianceRange(99)).toEqual({ min: -8, max: 12 });
+  });
+});
+
+// ── inferProspectRound ────────────────────────────────────────────────────────
+
+describe('inferProspectRound', () => {
+  it('prefers explicit round metadata', () => {
+    expect(inferProspectRound({ round: 2 })).toBe(2);
+    expect(inferProspectRound({ draftRound: 6 })).toBe(6);
+    expect(inferProspectRound({ projectedRound: 4 })).toBe(4);
+    expect(inferProspectRound({ mockRound: 1 })).toBe(1);
+  });
+
+  it('treats a clearly late prospect (visible OVR <= 60) as a late round', () => {
+    const round = inferProspectRound({ scoutedOvr: 55 });
+    expect(round).toBeGreaterThanOrEqual(4);
+    expect(round).toBeLessThanOrEqual(7);
+  });
+
+  it('defaults everything else to round 2-3 variance', () => {
+    expect(inferProspectRound({ ovr: 78 })).toBe(3);
+    expect(inferProspectRound({})).toBe(3);
+  });
+});
+
+// ── getDevTraitMultiplier ─────────────────────────────────────────────────────
+
+describe('getDevTraitMultiplier', () => {
+  it('normal is always 1.0', () => {
+    for (const age of [20, 24, 27, 30, 35]) {
+      expect(getDevTraitMultiplier({ hiddenDevTrait: 'normal' }, age)).toBe(1.0);
+    }
+  });
+
+  it('late_bloomer: 1.0 through 24, 1.3 at 25-27, 1.1 at 28+', () => {
+    const p = { hiddenDevTrait: 'late_bloomer' };
+    expect(getDevTraitMultiplier(p, 22)).toBe(1.0);
+    expect(getDevTraitMultiplier(p, 24)).toBe(1.0);
+    expect(getDevTraitMultiplier(p, 25)).toBe(1.3);
+    expect(getDevTraitMultiplier(p, 27)).toBe(1.3);
+    expect(getDevTraitMultiplier(p, 28)).toBe(1.1);
+    expect(getDevTraitMultiplier(p, 33)).toBe(1.1);
+  });
+
+  it('superstar: 1.2 through 27, 1.5 at 28-30, 0.9 at 31+', () => {
+    const p = { hiddenDevTrait: 'superstar' };
+    expect(getDevTraitMultiplier(p, 21)).toBe(1.2);
+    expect(getDevTraitMultiplier(p, 27)).toBe(1.2);
+    expect(getDevTraitMultiplier(p, 28)).toBe(1.5);
+    expect(getDevTraitMultiplier(p, 30)).toBe(1.5);
+    expect(getDevTraitMultiplier(p, 31)).toBe(0.9);
+  });
+
+  it('bust: 0.9 through 23, 0.7 at 24+', () => {
+    const p = { hiddenDevTrait: 'bust' };
+    expect(getDevTraitMultiplier(p, 21)).toBe(0.9);
+    expect(getDevTraitMultiplier(p, 23)).toBe(0.9);
+    expect(getDevTraitMultiplier(p, 24)).toBe(0.7);
+    expect(getDevTraitMultiplier(p, 30)).toBe(0.7);
+  });
+
+  it('missing or unknown trait is a 1.0 no-op (including legacy devTrait values)', () => {
+    expect(getDevTraitMultiplier({}, 25)).toBe(1.0);
+    expect(getDevTraitMultiplier(null, 25)).toBe(1.0);
+    expect(getDevTraitMultiplier({ hiddenDevTrait: 'X-Factor' }, 25)).toBe(1.0);
+    expect(getDevTraitMultiplier({ devTrait: 'Superstar' }, 25)).toBe(1.0);
+    expect(getDevTraitMultiplier({ hiddenDevTrait: 'superstar' }, undefined)).toBe(1.0);
+  });
+});
+
+// ── rollDevTrait distribution ─────────────────────────────────────────────────
+
+describe('rollDevTrait', () => {
+  it('matches the 60/20/10/10 distribution within ±5% over 1000 rolls', () => {
+    const rng = mulberry32(1337);
+    const counts = { normal: 0, late_bloomer: 0, superstar: 0, bust: 0 };
+    for (let i = 0; i < 1000; i++) counts[rollDevTrait(rng)] += 1;
+
+    expect(counts.normal).toBeGreaterThanOrEqual(550);
+    expect(counts.normal).toBeLessThanOrEqual(650);
+    expect(counts.late_bloomer).toBeGreaterThanOrEqual(150);
+    expect(counts.late_bloomer).toBeLessThanOrEqual(250);
+    expect(counts.superstar).toBeGreaterThanOrEqual(50);
+    expect(counts.superstar).toBeLessThanOrEqual(150);
+    expect(counts.bust).toBeGreaterThanOrEqual(50);
+    expect(counts.bust).toBeLessThanOrEqual(150);
+  });
+
+  it('only ever returns known traits', () => {
+    const rng = mulberry32(7);
+    for (let i = 0; i < 200; i++) {
+      expect(HIDDEN_DEV_TRAITS).toContain(rollDevTrait(rng));
+    }
+  });
+});
+
+// ── rollTrueOvrFromScoutedOvr ─────────────────────────────────────────────────
+
+describe('rollTrueOvrFromScoutedOvr', () => {
+  it('round 4-7 deltas have higher standard deviation than round 1 deltas', () => {
+    const rng1 = mulberry32(2024);
+    const rngLate = mulberry32(2024);
+    const round1Deltas = [];
+    const lateDeltas = [];
+    for (let i = 0; i < 1000; i++) {
+      round1Deltas.push(rollTrueOvrFromScoutedOvr(70, 1, rng1) - 70);
+      lateDeltas.push(rollTrueOvrFromScoutedOvr(70, 6, rngLate) - 70);
+    }
+    expect(stdDev(lateDeltas)).toBeGreaterThan(stdDev(round1Deltas));
+  });
+
+  it('always clamps to [40, 99]', () => {
+    const rng = mulberry32(99);
+    for (let i = 0; i < 1000; i++) {
+      const highEnd = rollTrueOvrFromScoutedOvr(95, 7, rng);
+      const lowEnd = rollTrueOvrFromScoutedOvr(44, 7, rng);
+      expect(highEnd).toBeGreaterThanOrEqual(40);
+      expect(highEnd).toBeLessThanOrEqual(99);
+      expect(lowEnd).toBeGreaterThanOrEqual(40);
+      expect(lowEnd).toBeLessThanOrEqual(99);
+    }
+  });
+
+  it('returns null for non-numeric scoutedOvr', () => {
+    expect(rollTrueOvrFromScoutedOvr(undefined, 3, mulberry32(1))).toBeNull();
+    expect(rollTrueOvrFromScoutedOvr('n/a', 3, mulberry32(1))).toBeNull();
+  });
+});
+
+// ── combineDevModifiers / getTrueOvrGrowthBonus ───────────────────────────────
+
+describe('combineDevModifiers', () => {
+  it('multiplies coach and trait modifiers', () => {
+    expect(combineDevModifiers(1.1, 1.2)).toBeCloseTo(1.32);
+  });
+
+  it('clamps the product to [0.4, 2.5]', () => {
+    expect(combineDevModifiers(0.1, 0.5)).toBe(0.4);
+    expect(combineDevModifiers(2.0, 2.0)).toBe(2.5);
+  });
+
+  it('treats non-finite inputs as 1.0', () => {
+    expect(combineDevModifiers(NaN, undefined)).toBe(1.0);
+    expect(combineDevModifiers(Infinity, 1.2)).toBe(1.2);
+  });
+});
+
+describe('getTrueOvrGrowthBonus', () => {
+  it('grants a small bonus only when below the hidden anchor with positive growth', () => {
+    expect(getTrueOvrGrowthBonus({ ovr: 70, hiddenTrueOvr: 73 }, 2)).toBe(1);
+    expect(getTrueOvrGrowthBonus({ ovr: 70, hiddenTrueOvr: 80 }, 2)).toBe(2);
+  });
+
+  it('never fires on zero/negative growth (no amplified regression)', () => {
+    expect(getTrueOvrGrowthBonus({ ovr: 70, hiddenTrueOvr: 85 }, 0)).toBe(0);
+    expect(getTrueOvrGrowthBonus({ ovr: 70, hiddenTrueOvr: 85 }, -3)).toBe(0);
+  });
+
+  it('never nerfs a player above his anchor', () => {
+    expect(getTrueOvrGrowthBonus({ ovr: 82, hiddenTrueOvr: 70 }, 3)).toBe(0);
+  });
+
+  it('missing hiddenTrueOvr is a no-op', () => {
+    expect(getTrueOvrGrowthBonus({ ovr: 70 }, 3)).toBe(0);
+    expect(getTrueOvrGrowthBonus({}, 3)).toBe(0);
+  });
+});
+
+// ── applyDraftHiddenVariance ──────────────────────────────────────────────────
+
+describe('applyDraftHiddenVariance', () => {
+  it('stamps hidden fields only when missing', () => {
+    const prospect = { ovr: 72, scoutedOvr: 70, projectedRound: 3 };
+    applyDraftHiddenVariance(prospect, mulberry32(5));
+    expect(HIDDEN_DEV_TRAITS).toContain(prospect.hiddenDevTrait);
+    expect(prospect.hiddenTrueOvr).toBeGreaterThanOrEqual(40);
+    expect(prospect.hiddenTrueOvr).toBeLessThanOrEqual(99);
+    expect(prospect.scoutedOvr).toBe(70);
+  });
+
+  it('never overwrites existing hidden fields', () => {
+    const prospect = { ovr: 72, scoutedOvr: 70, hiddenDevTrait: 'superstar', hiddenTrueOvr: 88 };
+    applyDraftHiddenVariance(prospect, mulberry32(5));
+    expect(prospect.hiddenDevTrait).toBe('superstar');
+    expect(prospect.hiddenTrueOvr).toBe(88);
+  });
+
+  it('backfills scoutedOvr from ovr when missing', () => {
+    const prospect = { ovr: 66, projectedRound: 4 };
+    applyDraftHiddenVariance(prospect, mulberry32(5));
+    expect(prospect.scoutedOvr).toBe(66);
+  });
+
+  it('is deterministic: same rng seed and inputs produce the same hidden fields', () => {
+    const base = { ovr: 72, scoutedOvr: 70, projectedRound: 3 };
+    const a = applyDraftHiddenVariance({ ...base }, mulberry32(42));
+    const b = applyDraftHiddenVariance({ ...base }, mulberry32(42));
+    expect(a.hiddenTrueOvr).toBe(b.hiddenTrueOvr);
+    expect(a.hiddenDevTrait).toBe(b.hiddenDevTrait);
+    expect(a.scoutedOvr).toBe(b.scoutedOvr);
+  });
+
+  it('is a safe no-op on players with no usable OVR data', () => {
+    const legacy = { name: 'Old Save Guy' };
+    applyDraftHiddenVariance(legacy, mulberry32(5));
+    expect(legacy.hiddenTrueOvr).toBeUndefined();
+    expect(legacy.scoutedOvr).toBeUndefined();
+  });
+});
+
+// ── generateDraftClass integration ────────────────────────────────────────────
+
+describe('generateDraftClass hidden variance', () => {
+  it('every generated prospect carries hidden variance fields', () => {
+    Utils.setSeed(777);
+    const draftClass = generateDraftClass(2030, { classSize: 40 });
+    for (const rookie of draftClass) {
+      expect(HIDDEN_DEV_TRAITS).toContain(rookie.hiddenDevTrait);
+      expect(rookie.hiddenTrueOvr).toBeGreaterThanOrEqual(40);
+      expect(rookie.hiddenTrueOvr).toBeLessThanOrEqual(99);
+      expect(typeof rookie.scoutedOvr).toBe('number');
+    }
+  });
+
+  it('same seed produces the same scoutedOvr, hiddenTrueOvr, and hiddenDevTrait', () => {
+    Utils.setSeed(4242);
+    const first = generateDraftClass(2030, { classSize: 24 });
+    Utils.setSeed(4242);
+    const second = generateDraftClass(2030, { classSize: 24 });
+    expect(first.map((p) => p.scoutedOvr)).toEqual(second.map((p) => p.scoutedOvr));
+    expect(first.map((p) => p.hiddenTrueOvr)).toEqual(second.map((p) => p.hiddenTrueOvr));
+    expect(first.map((p) => p.hiddenDevTrait)).toEqual(second.map((p) => p.hiddenDevTrait));
+  });
+});
+
+// ── Progression wiring ────────────────────────────────────────────────────────
+
+function buildQb(overrides = {}) {
+  const ratings = {
+    throwPower: 75,
+    throwAccuracy: 75,
+    awareness: 75,
+    intelligence: 75,
+    speed: 75,
+    agility: 75,
+  };
+  return {
+    id: 1,
+    name: 'Variance Test QB',
+    teamId: 1,
+    pos: 'QB',
+    age: 22,
+    ovr: 75,
+    potential: 90,
+    morale: 50,
+    // Neutral profile: zeroes out the personality terms in breakout/bust math.
+    personalityProfile: {
+      workEthic: 55, leadership: 55, diva: 45, riskTaker: 40,
+      discipline: 45, coachability: 60, holdoutRisk: 20, consistency: 65, offFieldRisk: 25,
+    },
+    ratings: { ...ratings },
+    ...overrides,
+  };
+}
+
+// Runs progression for one player under a fixed global seed and returns the
+// resulting OVR delta. Identical player shapes consume the RNG stream
+// identically, so runs with the same seed are directly comparable.
+function progressWithSeed(seed, overrides) {
+  Utils.setSeed(seed);
+  const player = buildQb(overrides);
+  processPlayerProgression([player], {});
+  return player.progressionDelta;
+}
+
+describe('progression wiring for hidden dev traits', () => {
+  it('a superstar gains at least as much as a bust in every context, and more overall', () => {
+    let superstarTotal = 0;
+    let bustTotal = 0;
+    for (let seed = 1; seed <= 200; seed++) {
+      const superstarDelta = progressWithSeed(seed, { hiddenDevTrait: 'superstar' });
+      const bustDelta = progressWithSeed(seed, { hiddenDevTrait: 'bust', age: 24 });
+      superstarTotal += superstarDelta;
+      bustTotal += bustDelta;
+    }
+    expect(superstarTotal).toBeGreaterThan(bustTotal);
+  });
+
+  it('missing hiddenDevTrait behaves exactly like normal', () => {
+    for (const seed of [11, 22, 33, 44, 55]) {
+      const missing = progressWithSeed(seed, {});
+      const normal = progressWithSeed(seed, { hiddenDevTrait: 'normal' });
+      expect(missing).toBe(normal);
+    }
+  });
+
+  it('does not amplify regression: old players decline identically regardless of trait', () => {
+    for (const seed of [3, 13, 23, 33, 43, 53, 63]) {
+      const bust = progressWithSeed(seed, { age: 35, hiddenDevTrait: 'bust' });
+      const normal = progressWithSeed(seed, { age: 35, hiddenDevTrait: 'normal' });
+      expect(bust).toBe(normal);
+    }
+  });
+
+  it('missing hiddenTrueOvr is a no-op relative to an anchor at current ovr', () => {
+    for (const seed of [5, 15, 25, 35, 45]) {
+      const withoutAnchor = progressWithSeed(seed, {});
+      const anchorAtOvr = progressWithSeed(seed, { hiddenTrueOvr: 75 });
+      expect(withoutAnchor).toBe(anchorAtOvr);
+    }
+  });
+
+  it('a player far below his hidden anchor grows at least as fast as one without an anchor', () => {
+    let anchored = 0;
+    let plain = 0;
+    for (let seed = 300; seed < 400; seed++) {
+      anchored += progressWithSeed(seed, { hiddenTrueOvr: 90 });
+      plain += progressWithSeed(seed, {});
+    }
+    expect(anchored).toBeGreaterThan(plain);
+  });
+});

--- a/src/core/draft/draftVariance.js
+++ b/src/core/draft/draftVariance.js
@@ -1,0 +1,191 @@
+/**
+ * draftVariance.js — Hidden draft variance & development traits (V1)
+ *
+ * Makes draft outcomes less linear: a prospect's visible draft-time OVR
+ * (scoutedOvr) and his hidden long-term talent anchor (hiddenTrueOvr) diverge
+ * by a round-dependent amount, and a hidden development trait (hiddenDevTrait)
+ * scales positive progression so gems and busts emerge over seasons.
+ *
+ * Field naming: the codebase already uses `player.trueOvr` to mean "actual
+ * current OVR" (scouting-fog target, revealed in draft-pick news, reset by
+ * minicamp) and `player.devTrait` for the Normal/Star/Superstar/X-Factor
+ * system consumed by the sim and progression engine. The hidden anchor and
+ * trait therefore live in the distinct fields `hiddenTrueOvr` and
+ * `hiddenDevTrait` so neither existing system is disturbed or revealed.
+ *
+ * All helpers are pure. RNG is injected (defaults to the seeded Utils.random
+ * stream used by the rest of draft generation) — never Math.random.
+ *
+ * Hidden data only in this PR: no UI reads these fields.
+ */
+
+import { Utils } from '../utils.js';
+
+const TRUE_OVR_MIN = 40;
+const TRUE_OVR_MAX = 99;
+
+// Bounds for the combined coach × trait development modifier applied to
+// positive growth in progression-logic.js.
+export const DEV_FINAL_MOD_MIN = 0.4;
+export const DEV_FINAL_MOD_MAX = 2.5;
+
+export const HIDDEN_DEV_TRAITS = ['normal', 'late_bloomer', 'superstar', 'bust'];
+
+// Cumulative distribution for rollDevTrait: 60% / 20% / 10% / 10%.
+const DEV_TRAIT_CDF = [
+  [0.60, 'normal'],
+  [0.80, 'late_bloomer'],
+  [0.90, 'superstar'],
+  [1.00, 'bust'],
+];
+
+/** Integer in [min, max] inclusive from an injected rng() → [0, 1). */
+function randIntFrom(rng, min, max) {
+  return Math.floor(rng() * (max - min + 1)) + min;
+}
+
+/**
+ * Round-dependent spread between scouted OVR and the hidden talent anchor.
+ * Early picks are safer bets; late rounds carry both bigger bust risk and
+ * bigger gem upside.
+ *
+ * @param {number} round - draft round (1–7)
+ * @returns {{ min: number, max: number }} inclusive delta range
+ */
+export function getDraftVarianceRange(round) {
+  const r = Number(round);
+  if (r === 1) return { min: -5, max: 8 };
+  if (r >= 4 && r <= 7) return { min: -10, max: 18 };
+  // Rounds 2–3, plus anything unrecognized (defensive default per spec).
+  return { min: -8, max: 12 };
+}
+
+/**
+ * Infer a prospect's draft round from available metadata. Checks explicit
+ * round fields first; with no reliable round, treats a clearly late prospect
+ * (visible OVR ≤ 60) as round 4–7, otherwise as round 2–3.
+ */
+export function inferProspectRound(prospect) {
+  const candidates = [
+    prospect?.round,
+    prospect?.draftRound,
+    prospect?.projectedRound,
+    prospect?.mockRound,
+    prospect?.draft?.round,
+    prospect?.draftPick?.round,
+  ];
+  for (const candidate of candidates) {
+    const n = Number(candidate);
+    if (Number.isFinite(n) && n >= 1 && n <= 7) return Math.round(n);
+  }
+  const visible = Number(prospect?.scoutedOvr ?? prospect?.ovr);
+  if (Number.isFinite(visible) && visible <= 60) return 5;
+  return 3;
+}
+
+/**
+ * Roll the hidden long-term talent anchor from the visible scouted OVR,
+ * clamped to [40, 99].
+ *
+ * @param {number} scoutedOvr - visible OVR at draft time
+ * @param {number} round      - draft round (1–7)
+ * @param {function} rng      - () → [0, 1), seeded
+ * @returns {number|null} anchor OVR, or null if scoutedOvr isn't numeric
+ */
+export function rollTrueOvrFromScoutedOvr(scoutedOvr, round, rng = Utils.random) {
+  const base = Number(scoutedOvr);
+  if (!Number.isFinite(base)) return null;
+  const { min, max } = getDraftVarianceRange(round);
+  const delta = randIntFrom(rng, min, max);
+  return Utils.clamp(Math.round(base + delta), TRUE_OVR_MIN, TRUE_OVR_MAX);
+}
+
+/**
+ * Roll a hidden development trait: normal 60%, late_bloomer 20%,
+ * superstar 10%, bust 10%.
+ */
+export function rollDevTrait(rng = Utils.random) {
+  const r = rng();
+  for (const [threshold, trait] of DEV_TRAIT_CDF) {
+    if (r < threshold) return trait;
+  }
+  return 'normal';
+}
+
+/**
+ * Age-dependent growth multiplier for a player's hidden dev trait.
+ * Missing or unknown trait (including all legacy devTrait values) → 1.0.
+ * Applied to positive growth only — callers must not use it on regression.
+ */
+export function getDevTraitMultiplier(player, age) {
+  const a = Number(age);
+  if (!Number.isFinite(a)) return 1.0;
+  switch (player?.hiddenDevTrait) {
+    case 'late_bloomer':
+      return a <= 24 ? 1.0 : a <= 27 ? 1.3 : 1.1;
+    case 'superstar':
+      return a <= 27 ? 1.2 : a <= 30 ? 1.5 : 0.9;
+    case 'bust':
+      return a <= 23 ? 0.9 : 0.7;
+    default:
+      return 1.0;
+  }
+}
+
+/**
+ * Combine the sanitized coach development modifier with the hidden dev-trait
+ * multiplier, clamped to [0.4, 2.5]. Non-finite inputs are treated as 1.0.
+ */
+export function combineDevModifiers(coachModifier, traitModifier) {
+  const coach = Number.isFinite(Number(coachModifier)) ? Number(coachModifier) : 1.0;
+  const trait = Number.isFinite(Number(traitModifier)) ? Number(traitModifier) : 1.0;
+  return Utils.clamp(coach * trait, DEV_FINAL_MOD_MIN, DEV_FINAL_MOD_MAX);
+}
+
+/**
+ * Small extra positive growth for a player still below his hidden talent
+ * anchor. Returns 0 unless the player has a hiddenTrueOvr, is below it, and
+ * already rolled positive growth — being above the anchor never nerfs him.
+ *
+ * @param {object} player   - player with optional hiddenTrueOvr and ovr
+ * @param {number} ovrDelta - growth delta after coach/trait modifiers
+ * @returns {number} bonus to add to the delta (0, 1, or 2)
+ */
+export function getTrueOvrGrowthBonus(player, ovrDelta) {
+  if (!(ovrDelta > 0)) return 0;
+  const anchor = Number(player?.hiddenTrueOvr);
+  const ovr = Number(player?.ovr);
+  if (!Number.isFinite(anchor) || !Number.isFinite(ovr)) return 0;
+  const gap = anchor - ovr;
+  if (gap >= 6) return 2;
+  if (gap >= 2) return 1;
+  return 0;
+}
+
+/**
+ * Normalization hook: stamp hidden variance fields onto a prospect, each only
+ * if missing. Safe to call on legacy prospects/players — existing fields are
+ * never overwritten, and a prospect with no usable OVR just gets no anchor.
+ * Mutates and returns the prospect.
+ */
+export function applyDraftHiddenVariance(prospect, rng = Utils.random) {
+  if (!prospect || typeof prospect !== 'object') return prospect;
+  if (prospect.scoutedOvr == null) {
+    const visible = Number(prospect.ovr);
+    if (Number.isFinite(visible)) {
+      prospect.scoutedOvr = Utils.clamp(Math.round(visible), TRUE_OVR_MIN, TRUE_OVR_MAX);
+    }
+  }
+  if (prospect.hiddenDevTrait == null) {
+    prospect.hiddenDevTrait = rollDevTrait(rng);
+  }
+  if (prospect.hiddenTrueOvr == null) {
+    const anchor = rollTrueOvrFromScoutedOvr(
+      prospect.scoutedOvr ?? prospect.ovr,
+      inferProspectRound(prospect),
+      rng
+    );
+    if (anchor != null) prospect.hiddenTrueOvr = anchor;
+  }
+  return prospect;
+}

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -8,6 +8,7 @@ import { generateTraits } from './traits.js';
 import { generateFaceConfig } from './face.js';
 import { generatePersonalityProfile, ensurePersonalityProfile, contractPersonalityModifier } from './development/personalitySystem.js';
 import { generateCollegeStats, generateInterviewReport, getScoutingRangeFromProfile, simulateCombineResults } from './draft/draftScouting.js';
+import { applyDraftHiddenVariance } from './draft/draftVariance.js';
 import { generateDeterministicAgentProfile } from './contracts/agentNegotiationEngine.js';
 
 const CONTRACT_DEFAULT = {
@@ -563,6 +564,9 @@ function generateDraftClass(year, options = {}) {
         rookie.scoutingReport = scoutingRange;
         rookie.devTrait = rollDevTrait();
         rookie.projectedRound = U.clamp(Math.ceil((100 - rookie.scoutedOvr) / 10), 1, 7);
+        // Hidden variance: stamps hiddenDevTrait + hiddenTrueOvr (anchor rolled
+        // from scoutedOvr with round-based spread) via the seeded RNG stream.
+        applyDraftHiddenVariance(rookie, U.random);
         rookie.combineResults = simulateCombineResults(rookie.pos, rookie.ratings);
         rookie.collegeStats = generateCollegeStats(rookie.pos, rookie.trueOvr, rookie.potential);
         rookie.interviewReport = generateInterviewReport(rookie);

--- a/src/core/progression-logic.js
+++ b/src/core/progression-logic.js
@@ -26,6 +26,7 @@ import { Constants } from './constants.js';
 import { ensurePersonalityProfile, mentorshipBonusForPlayer } from './development/personalitySystem.js';
 import { getDevelopmentRateModifier } from './coaching-philosophy-effects.js';
 import { getCoachSchemeMultiplier, isPositionMisfitForScheme } from './coaching/coachingEngine.js';
+import { getDevTraitMultiplier, combineDevModifiers, getTrueOvrGrowthBonus } from './draft/draftVariance.js';
 
 // ── Progression probability constants (Task 10) ───────────────────────────────
 // Defined here so they can be tuned without hunting for magic numbers inline.
@@ -393,11 +394,22 @@ export function processPlayerProgression(players, options = {}) {
       ovrDelta += Math.max(1, Math.round(ovrDelta * mentorship.development));
     }
 
-    // ── Coaching philosophy development modifier ───────────────────────────────
+    // ── Coaching philosophy + hidden dev-trait development modifiers ───────────
     // Multiplies positive growth deltas only; never amplifies busts or regressions.
-    // Missing coach/staff or a non-finite modifier → 1.0 (no-op).
+    // Missing coach/staff, a non-finite modifier, or no hiddenDevTrait → 1.0.
+    // Combined modifier is clamped to [0.4, 2.5]; a player still below his
+    // hidden talent anchor (hiddenTrueOvr) gets a small extra growth bonus.
     if (ovrDelta > 0 && !bustEvent) {
-      ovrDelta = applyCoachDevModifier(ovrDelta, player.pos, teamCoaches[player.teamId] ?? null);
+      const teamStaff = teamCoaches[player.teamId] ?? null;
+      const coachModifier = teamStaff
+        ? sanitizeCoachDevModifier(
+            getDevelopmentRateModifier(player.pos, teamStaff.headCoach ?? null, teamStaff)
+          )
+        : 1.0;
+      const traitModifier = getDevTraitMultiplier(player, age);
+      const finalModifier = combineDevModifiers(coachModifier, traitModifier);
+      ovrDelta = Math.round(ovrDelta * finalModifier);
+      ovrDelta += getTrueOvrGrowthBonus(player, ovrDelta);
     }
 
     // ── Apply non-cliff, non-wall deltas via position-specific rating nudges (Task 6)


### PR DESCRIPTION
Draft outcomes are now less linear: each generated prospect gets a hidden
long-term talent anchor (hiddenTrueOvr, rolled from scoutedOvr with a
round-dependent spread) and a hidden development trait (hiddenDevTrait:
normal 60% / late_bloomer 20% / superstar 10% / bust 10%), both rolled
from the existing seeded RNG stream.

New pure helpers in src/core/draft/draftVariance.js:
- getDraftVarianceRange(round), rollTrueOvrFromScoutedOvr(scoutedOvr, round, rng)
- rollDevTrait(rng), getDevTraitMultiplier(player, age)
- combineDevModifiers, getTrueOvrGrowthBonus, inferProspectRound,
  applyDraftHiddenVariance (only-if-missing normalization hook)

Progression wiring: the trait multiplier composes with the sanitized
coaching development modifier (product clamped to [0.4, 2.5]) on positive
growth only, plus a small extra growth bonus while a player sits below his
hidden anchor. Regression and aging decline are never amplified; players
without the new fields behave exactly as before.

The hidden fields use distinct names because trueOvr already means
"actual current OVR" (scouting target, minicamp-reset, reveal news) and
devTrait already drives the Normal/Star/Superstar/X-Factor system. No UI,
draft board sorting, contract, or sim changes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011KUdJpFUZY3XDNCW3JxXy4