### PR TITLE
Surface special-teams stats in the Game Book

### DIFF
--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -172,6 +172,12 @@ function BoxScore({
   const scoringSummaryRows = vm.scoringSummary ?? [];
   const teamComparisonRows = vm.teamComparisonRows ?? [];
   const playByPlayRows = vm.playByPlayRows ?? [];
+  const specialTeams = vm.specialTeams ?? null;
+  const specialTeamsNoteText = (note) => {
+    if (note.side === 'home') return `${homeAbbr} — ${note.text}`;
+    if (note.side === 'away') return `${awayAbbr} — ${note.text}`;
+    return note.text;
+  };
 
   return (
     <div
@@ -292,6 +298,32 @@ function BoxScore({
             ))}
           </div>
         </details>
+      )}
+
+      {/* ── SPECIAL TEAMS — compact kicking & field-position summary ─────── */}
+      {specialTeams?.hasData && (
+        <div className="bs-sheet-leaders" data-testid="game-book-special-teams">
+          <div className="bs-sheet-section-title">Special Teams</div>
+          <div className="bs-sheet-compare-head">
+            <span>{awayAbbr}</span>
+            <span />
+            <span>{homeAbbr}</span>
+          </div>
+          {specialTeams.rows.map((row) => (
+            <div key={row.key} className="bs-sheet-compare-row" data-testid={`game-book-special-teams-${row.key}`}>
+              <span className="bs-sheet-compare-value">{row.away}</span>
+              <span className="bs-sheet-compare-label">{row.label}</span>
+              <span className="bs-sheet-compare-value">{row.home}</span>
+            </div>
+          ))}
+          {specialTeams.notes.length > 0 && (
+            <div className="bs-sheet-exec" data-testid="game-book-special-teams-notes">
+              {specialTeams.notes.map((note) => (
+                <span key={note.id} className="bs-sheet-exec-bullet">• {specialTeamsNoteText(note)}</span>
+              ))}
+            </div>
+          )}
+        </div>
       )}
 
       {/* ── FULL PLAYER STATS — priority 5, collapsed dense tables ───────── */}

--- a/src/ui/components/BoxScore.test.jsx
+++ b/src/ui/components/BoxScore.test.jsx
@@ -222,6 +222,84 @@ describe('BoxScore compact sheet — core rendering', () => {
   });
 });
 
+describe('BoxScore special teams section', () => {
+  const baseLeague = { seasonId: 2031, week: 2, teams: [{ id: 1, abbr: 'KC' }, { id: 2, abbr: 'BUF' }] };
+
+  beforeEach(() => {
+    cleanup();
+    vi.mocked(useStableRouteRequest).mockReturnValue({ data: null });
+  });
+
+  it('renders FG, punts, XP and 2PT rows from teamDriveStats special-teams counters', () => {
+    const game = {
+      homeId: 1, awayId: 2, homeScore: 27, awayScore: 13,
+      teamDriveStats: {
+        home: { punts: 4, fgAttempts: 3, fgMade: 2, twoPointAttempts: 1, twoPointMade: 1 },
+        away: { punts: 7, fgAttempts: 2, fgMade: 2, twoPointAttempts: 0, twoPointMade: 0 },
+      },
+      homeXPs: 2,
+      awayXPs: 1,
+    };
+    const { getByTestId } = render(
+      <BoxScore gameId="g-st" league={{ ...baseLeague, gameById: { 'g-st': game } }} embedded />,
+    );
+    expect(getByTestId('game-book-special-teams')).toBeTruthy();
+    // Rows read away-value · label · home-value
+    expect(getByTestId('game-book-special-teams-fg').textContent).toBe('2/2FG Made/Att2/3');
+    expect(getByTestId('game-book-special-teams-punts').textContent).toBe('7Punts4');
+    expect(getByTestId('game-book-special-teams-twoPoint').textContent).toBe('0/02PT Made/Att1/1');
+    expect(getByTestId('game-book-special-teams-xp').textContent).toBe('1XP Made2');
+  });
+
+  it('shows impact notes for 2PT tries, missed FGs, and punt-heavy games', () => {
+    const game = {
+      homeId: 1, awayId: 2, homeScore: 20, awayScore: 16,
+      teamDriveStats: {
+        home: { punts: 7, fgAttempts: 3, fgMade: 1, twoPointAttempts: 1, twoPointMade: 0 },
+        away: { punts: 8, fgAttempts: 1, fgMade: 1, twoPointAttempts: 0, twoPointMade: 0 },
+      },
+    };
+    const { getByTestId } = render(
+      <BoxScore gameId="g-st-notes" league={{ ...baseLeague, gameById: { 'g-st-notes': game } }} embedded />,
+    );
+    const notes = getByTestId('game-book-special-teams-notes').textContent;
+    expect(notes).toContain('KC — 2-point attempt changed the scoring math.');
+    expect(notes).toContain('KC — Missed field goal opportunity.');
+    expect(notes).toContain('Field-position game.');
+  });
+
+  it('missing special-teams fields default safely and do not crash', () => {
+    const game = {
+      homeId: 1, awayId: 2, homeScore: 24, awayScore: 21,
+      teamDriveStats: { home: { turnovers: 1 }, away: { turnovers: 2 } },
+    };
+    const { getByTestId, queryByTestId } = render(
+      <BoxScore gameId="g-st-missing" league={{ ...baseLeague, gameById: { 'g-st-missing': game } }} embedded />,
+    );
+    expect(getByTestId('game-book-special-teams-fg').textContent).toBe('0/0FG Made/Att0/0');
+    expect(getByTestId('game-book-special-teams-punts').textContent).toBe('0Punts0');
+    expect(getByTestId('game-book-special-teams-twoPoint').textContent).toBe('0/02PT Made/Att0/0');
+    expect(queryByTestId('game-book-special-teams-notes')).toBeNull();
+  });
+
+  it('legacy score-only game objects still render without a special-teams section', () => {
+    const { getByTestId, queryByTestId } = render(
+      <BoxScore gameId="g-legacy" league={{ ...baseLeague, gameById: { 'g-legacy': { homeId: 1, awayId: 2, homeScore: 6, awayScore: 3 } } }} embedded />,
+    );
+    expect(getByTestId('game-book-score-hero')).toBeTruthy();
+    expect(queryByTestId('game-book-special-teams')).toBeNull();
+  });
+
+  it('legacy games fall back to homeFGs/awayFGs and homeXPs/awayXPs scalars', () => {
+    const game = { homeId: 1, awayId: 2, homeScore: 13, awayScore: 9, homeFGs: 2, awayFGs: 3, homeXPs: 1, awayXPs: 0 };
+    const { getByTestId } = render(
+      <BoxScore gameId="g-legacy-fg" league={{ ...baseLeague, gameById: { 'g-legacy-fg': game } }} embedded />,
+    );
+    expect(getByTestId('game-book-special-teams-fg').textContent).toBe('3/3FG Made/Att2/2');
+    expect(getByTestId('game-book-special-teams-xp').textContent).toBe('0XP Made1');
+  });
+});
+
 describe('BoxScore player name resolution', () => {
   const baseLeague = { seasonId: 2031, week: 2, teams: [{ id: 1, abbr: 'KC' }, { id: 2, abbr: 'BUF' }] };
 

--- a/src/ui/utils/boxScoreViewModel.js
+++ b/src/ui/utils/boxScoreViewModel.js
@@ -2,6 +2,7 @@ import { mergeArchivedGameWithScheduleResult, normalizeArchivedGamePayload } fro
 import { isScoringLikeLog, normalizePlayLogEntry } from '../../core/gameEvents.js';
 import { buildGameFlowSummary } from '../../core/sim/gameFlowSummary.js';
 import { buildLeaguePlayerMap, resolvePlayerName } from './playerNameResolver.js';
+import { buildSpecialTeamsSummary } from './specialTeamsSummary.js';
 
 const QUALITY = { full: 'Full detail', partial: 'Partial detail', score: 'Score only', missing: 'Missing detail' };
 
@@ -519,6 +520,18 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
   const homeTeam = teamInfo(league, homeId, 'home', payload);
   const finalScore = { home: homeScore, away: awayScore };
   const teamTotals = { home: teamStats?.home ?? {}, away: teamStats?.away ?? {} };
+  // Special-teams rollup — legacy scalar counters (homeFGs/homeXPs) and raw
+  // drive-summary stats only exist on the unnormalized record, so feed both.
+  const specialTeams = buildSpecialTeamsSummary({
+    teamDriveStats: payload?.teamDriveStats ?? rawGame?.teamDriveStats,
+    teamStats: teamTotals,
+    homeStats: rawGame?.homeStats,
+    awayStats: rawGame?.awayStats,
+    homeFGs: rawGame?.homeFGs,
+    awayFGs: rawGame?.awayFGs,
+    homeXPs: rawGame?.homeXPs,
+    awayXPs: rawGame?.awayXPs,
+  });
   const playerTables = { home: homePlayers, away: awayPlayers };
   const winnerSide = hasScore && awayScore !== homeScore ? (awayScore > homeScore ? 'away' : 'home') : null;
   const teamContext = { home: homeTeam, away: awayTeam };
@@ -566,6 +579,7 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
     quarterScores,
     teamTotals,
     teamComparisonRows: buildTeamComparisonRows(teamTotals),
+    specialTeams,
     scoringSummary,
     driveSummaryRows,
     playByPlayRows,

--- a/src/ui/utils/specialTeamsSummary.js
+++ b/src/ui/utils/specialTeamsSummary.js
@@ -1,0 +1,104 @@
+/**
+ * specialTeamsSummary.js — presentation-only special-teams rollup for the
+ * Game Book / post-game summary.
+ *
+ * Reads the special-teams counters added to buildDriveBasedSummary()
+ * (punts, fgAttempts, fgMade, twoPointAttempts, twoPointMade — surfaced to
+ * the UI as teamDriveStats.home/away) with safe fallbacks for legacy game
+ * objects that predate those fields.
+ */
+
+const toNum = (v) => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+};
+
+// Punt totals at or above this read as a field-position battle.
+const PUNT_HEAVY_THRESHOLD = 6;
+
+function sideSources(game = {}, side) {
+  const rawDrive = game?.teamDriveStats?.[side]
+    ?? (side === 'home' ? game?.homeStats : game?.awayStats);
+  const driveStats = (rawDrive && typeof rawDrive === 'object') ? rawDrive : {};
+  const rawTeam = game?.teamStats?.[side];
+  const teamStats = (rawTeam && typeof rawTeam === 'object') ? rawTeam : {};
+  // Legacy scalar counters from the drive summary (FGs made, XPs made).
+  const legacyFGs = toNum(game?.[`${side}FGs`]);
+  const legacyXPs = toNum(game?.[`${side}XPs`]);
+  return { driveStats, teamStats, legacyFGs, legacyXPs };
+}
+
+function buildSide(game, side) {
+  const { driveStats, teamStats, legacyFGs, legacyXPs } = sideSources(game, side);
+
+  const fgMade = toNum(driveStats.fgMade) ?? toNum(teamStats.fieldGoalsMade) ?? legacyFGs ?? 0;
+  // Legacy records only counted made FGs, so attempts fall back to made.
+  const fgAttempts = Math.max(
+    toNum(driveStats.fgAttempts) ?? toNum(teamStats.fieldGoalsAttempted) ?? legacyFGs ?? 0,
+    fgMade,
+  );
+  const punts = toNum(driveStats.punts) ?? toNum(teamStats.punts) ?? 0;
+  const twoPointMade = toNum(driveStats.twoPointMade) ?? 0;
+  const twoPointAttempts = Math.max(toNum(driveStats.twoPointAttempts) ?? 0, twoPointMade);
+  const xpMade = legacyXPs ?? toNum(driveStats.xpMade) ?? toNum(teamStats.extraPointsMade) ?? null;
+
+  // Any drive-level team stats mean a simulated game — show the section with
+  // safe zero defaults even if the record predates the special-teams counters.
+  // Only score-only games (no team stats of any kind) hide the section.
+  const hasData = Object.keys(driveStats).length > 0
+    || toNum(teamStats.fieldGoalsMade) != null
+    || toNum(teamStats.fieldGoalsAttempted) != null
+    || toNum(teamStats.punts) != null
+    || toNum(teamStats.extraPointsMade) != null
+    || legacyFGs != null
+    || legacyXPs != null;
+
+  return { fgMade, fgAttempts, punts, twoPointMade, twoPointAttempts, xpMade, hasData };
+}
+
+function buildNotes(home, away) {
+  const notes = [];
+  const push = (side, text) => notes.push({ id: `${side}-${notes.length}`, side, text });
+
+  for (const [side, stats] of [['away', away], ['home', home]]) {
+    if (stats.twoPointAttempts > 0) push(side, '2-point attempt changed the scoring math.');
+    if (stats.fgAttempts > stats.fgMade) push(side, 'Missed field goal opportunity.');
+  }
+  if (home.punts >= PUNT_HEAVY_THRESHOLD && away.punts >= PUNT_HEAVY_THRESHOLD) {
+    push('game', 'Field-position game.');
+  } else {
+    if (away.punts >= PUNT_HEAVY_THRESHOLD) push('away', 'Field-position game.');
+    if (home.punts >= PUNT_HEAVY_THRESHOLD) push('home', 'Field-position game.');
+  }
+  return notes;
+}
+
+/**
+ * Builds the special-teams section model from any game-shaped payload
+ * (archived, normalized, or raw sim result). Never throws on missing data.
+ *
+ * @returns {{ hasData: boolean,
+ *             home: object, away: object,
+ *             rows: Array<{key, label, home: string, away: string}>,
+ *             notes: Array<{id, side, text}> }}
+ */
+export function buildSpecialTeamsSummary(game) {
+  const safeGame = (game && typeof game === 'object') ? game : {};
+  const home = buildSide(safeGame, 'home');
+  const away = buildSide(safeGame, 'away');
+  const hasData = home.hasData || away.hasData;
+
+  const fmtRatio = (made, att) => `${made}/${att}`;
+  const fmtCount = (value) => (value == null ? '—' : String(value));
+
+  const rows = [
+    { key: 'fg', label: 'FG Made/Att', away: fmtRatio(away.fgMade, away.fgAttempts), home: fmtRatio(home.fgMade, home.fgAttempts) },
+    { key: 'xp', label: 'XP Made', away: fmtCount(away.xpMade), home: fmtCount(home.xpMade) },
+    { key: 'punts', label: 'Punts', away: fmtCount(away.punts), home: fmtCount(home.punts) },
+    { key: 'twoPoint', label: '2PT Made/Att', away: fmtRatio(away.twoPointMade, away.twoPointAttempts), home: fmtRatio(home.twoPointMade, home.twoPointAttempts) },
+  ];
+
+  return { hasData, home, away, rows, notes: hasData ? buildNotes(home, away) : [] };
+}
+
+export default buildSpecialTeamsSummary;

--- a/src/ui/utils/specialTeamsSummary.test.js
+++ b/src/ui/utils/specialTeamsSummary.test.js
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import { buildSpecialTeamsSummary } from './specialTeamsSummary.js';
+
+const row = (summary, key) => summary.rows.find((r) => r.key === key);
+
+describe('buildSpecialTeamsSummary — drive-engine stats (PR #1658 shape)', () => {
+  const game = {
+    teamDriveStats: {
+      home: { punts: 4, fgAttempts: 3, fgMade: 2, twoPointAttempts: 1, twoPointMade: 1 },
+      away: { punts: 7, fgAttempts: 1, fgMade: 1, twoPointAttempts: 0, twoPointMade: 0 },
+    },
+    homeXPs: 3,
+    awayXPs: 2,
+  };
+
+  it('reports FG made/attempted per side', () => {
+    const st = buildSpecialTeamsSummary(game);
+    expect(st.hasData).toBe(true);
+    expect(st.home.fgMade).toBe(2);
+    expect(st.home.fgAttempts).toBe(3);
+    expect(st.away.fgMade).toBe(1);
+    expect(st.away.fgAttempts).toBe(1);
+    expect(row(st, 'fg')).toMatchObject({ home: '2/3', away: '1/1' });
+  });
+
+  it('reports punts per side', () => {
+    const st = buildSpecialTeamsSummary(game);
+    expect(st.home.punts).toBe(4);
+    expect(st.away.punts).toBe(7);
+    expect(row(st, 'punts')).toMatchObject({ home: '4', away: '7' });
+  });
+
+  it('reports 2PT made/attempted per side', () => {
+    const st = buildSpecialTeamsSummary(game);
+    expect(st.home.twoPointMade).toBe(1);
+    expect(st.home.twoPointAttempts).toBe(1);
+    expect(row(st, 'twoPoint')).toMatchObject({ home: '1/1', away: '0/0' });
+  });
+
+  it('reports XP made from homeXPs/awayXPs', () => {
+    const st = buildSpecialTeamsSummary(game);
+    expect(st.home.xpMade).toBe(3);
+    expect(st.away.xpMade).toBe(2);
+    expect(row(st, 'xp')).toMatchObject({ home: '3', away: '2' });
+  });
+
+  it('also accepts raw drive-summary homeStats/awayStats fields', () => {
+    const st = buildSpecialTeamsSummary({
+      homeStats: { punts: 5, fgAttempts: 2, fgMade: 1, twoPointAttempts: 1, twoPointMade: 0 },
+      awayStats: { punts: 3, fgAttempts: 0, fgMade: 0, twoPointAttempts: 0, twoPointMade: 0 },
+    });
+    expect(st.hasData).toBe(true);
+    expect(row(st, 'fg')).toMatchObject({ home: '1/2', away: '0/0' });
+    expect(row(st, 'punts')).toMatchObject({ home: '5', away: '3' });
+    expect(row(st, 'twoPoint')).toMatchObject({ home: '0/1', away: '0/0' });
+  });
+});
+
+describe('buildSpecialTeamsSummary — legacy fallbacks', () => {
+  it('missing special-teams fields default safely to 0', () => {
+    const st = buildSpecialTeamsSummary({ teamDriveStats: { home: { sacks: 2 }, away: { sacks: 1 } } });
+    for (const side of [st.home, st.away]) {
+      expect(side.punts).toBe(0);
+      expect(side.fgMade).toBe(0);
+      expect(side.fgAttempts).toBe(0);
+      expect(side.twoPointMade).toBe(0);
+      expect(side.twoPointAttempts).toBe(0);
+    }
+  });
+
+  it('missing fgMade/fgAttempts fall back to legacy homeFGs/awayFGs', () => {
+    const st = buildSpecialTeamsSummary({ homeFGs: 2, awayFGs: 1, homeXPs: 4, awayXPs: 1 });
+    expect(st.hasData).toBe(true);
+    expect(row(st, 'fg')).toMatchObject({ home: '2/2', away: '1/1' });
+    expect(row(st, 'xp')).toMatchObject({ home: '4', away: '1' });
+  });
+
+  it('falls back to team totals derived from player rows (fieldGoals*, extraPointsMade, punts)', () => {
+    const st = buildSpecialTeamsSummary({
+      teamStats: {
+        home: { fieldGoalsMade: 3, fieldGoalsAttempted: 4, extraPointsMade: 2, punts: 5 },
+        away: { fieldGoalsMade: 0, fieldGoalsAttempted: 1, extraPointsMade: 3, punts: 6 },
+      },
+    });
+    expect(row(st, 'fg')).toMatchObject({ home: '3/4', away: '0/1' });
+    expect(row(st, 'xp')).toMatchObject({ home: '2', away: '3' });
+    expect(row(st, 'punts')).toMatchObject({ home: '5', away: '6' });
+  });
+
+  it('never crashes on null, empty, or score-only legacy games and hides the section', () => {
+    for (const game of [null, undefined, {}, { homeScore: 21, awayScore: 17 }, 'bad-input']) {
+      const st = buildSpecialTeamsSummary(game);
+      expect(st.hasData).toBe(false);
+      expect(st.notes).toEqual([]);
+    }
+  });
+
+  it('shows an em dash for unknown XP counts instead of implying zero', () => {
+    const st = buildSpecialTeamsSummary({ teamDriveStats: { home: { punts: 2 }, away: { punts: 3 } } });
+    expect(row(st, 'xp')).toMatchObject({ home: '—', away: '—' });
+  });
+});
+
+describe('buildSpecialTeamsSummary — impact notes', () => {
+  it('flags a 2-point attempt', () => {
+    const st = buildSpecialTeamsSummary({
+      teamDriveStats: { home: { twoPointAttempts: 1, twoPointMade: 1 }, away: {} },
+    });
+    expect(st.notes).toContainEqual(expect.objectContaining({ side: 'home', text: '2-point attempt changed the scoring math.' }));
+  });
+
+  it('flags missed field goals', () => {
+    const st = buildSpecialTeamsSummary({
+      teamDriveStats: { home: {}, away: { fgAttempts: 3, fgMade: 1 } },
+    });
+    expect(st.notes).toContainEqual(expect.objectContaining({ side: 'away', text: 'Missed field goal opportunity.' }));
+  });
+
+  it('flags a field-position game once when both teams punt heavily', () => {
+    const st = buildSpecialTeamsSummary({
+      teamDriveStats: { home: { punts: 7 }, away: { punts: 6 } },
+    });
+    const fieldPositionNotes = st.notes.filter((n) => n.text === 'Field-position game.');
+    expect(fieldPositionNotes).toEqual([expect.objectContaining({ side: 'game' })]);
+  });
+
+  it('emits no notes for a quiet special-teams game', () => {
+    const st = buildSpecialTeamsSummary({
+      teamDriveStats: {
+        home: { punts: 2, fgAttempts: 1, fgMade: 1, twoPointAttempts: 0, twoPointMade: 0 },
+        away: { punts: 3, fgAttempts: 0, fgMade: 0, twoPointAttempts: 0, twoPointMade: 0 },
+      },
+    });
+    expect(st.notes).toEqual([]);
+  });
+});


### PR DESCRIPTION
Add a compact Special Teams section to the Game Book sheet showing
FG made/attempted, XP made, punts, and 2PT made/attempted per team,
sourced from the drive-engine counters (teamDriveStats) with safe
fallbacks for legacy game records (homeFGs/awayFGs, homeXPs/awayXPs,
player-derived team totals). Short game-impact notes flag 2-point
tries, missed field goals, and punt-heavy field-position games.

Presentation only — no simulation logic touched. New helper
buildSpecialTeamsSummary() carries the extraction/fallback rules and
is unit-tested alongside new BoxScore rendering tests covering the
modern payload, missing-field defaults, and legacy score-only games.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C7xCwxMyL37R7UPwEUkzhU