### PR TITLE
Surface hidden draft dev trait in player profile after ~2 pro seasons

### DIFF
--- a/src/core/draft/__tests__/hiddenDevTraitReveal.test.js
+++ b/src/core/draft/__tests__/hiddenDevTraitReveal.test.js
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  HIDDEN_DEV_TRAIT_REVEAL_SEASONS,
+  getProSeasonsCompleted,
+  shouldRevealHiddenDevTrait,
+  getHiddenDevTraitLabel,
+} from '../draftVariance.js';
+
+const history = (n) =>
+  Array.from({ length: n }, (_, i) => ({ season: 2030 + i, ovr: 70 + i, age: 22 + i }));
+
+// ── getProSeasonsCompleted ────────────────────────────────────────────────────
+
+describe('getProSeasonsCompleted', () => {
+  it('counts ovrHistory entries (one appended per completed pro season)', () => {
+    expect(getProSeasonsCompleted({ ovrHistory: [] })).toBe(0);
+    expect(getProSeasonsCompleted({ ovrHistory: history(1) })).toBe(1);
+    expect(getProSeasonsCompleted({ ovrHistory: history(3) })).toBe(3);
+  });
+
+  it('ovrHistory wins over the draftYear path when both exist', () => {
+    const player = { ovrHistory: history(1), draftYear: 2020 };
+    expect(getProSeasonsCompleted(player, { currentSeason: 2030 })).toBe(1);
+  });
+
+  it('falls back to currentSeason - draftYear when ovrHistory is absent', () => {
+    expect(getProSeasonsCompleted({ draftYear: 2028 }, { currentSeason: 2031 })).toBe(3);
+    expect(getProSeasonsCompleted({ draftYear: 2028 }, { year: 2029 })).toBe(1);
+    expect(getProSeasonsCompleted({ draftYear: 2028 }, { season: 2028 })).toBe(0);
+  });
+
+  it('never returns a negative count from a bad draftYear', () => {
+    expect(getProSeasonsCompleted({ draftYear: 2035 }, { currentSeason: 2030 })).toBe(0);
+  });
+
+  it('returns null when nothing is derivable', () => {
+    expect(getProSeasonsCompleted({}, {})).toBeNull();
+    expect(getProSeasonsCompleted({ draftYear: 2028 }, {})).toBeNull();
+    expect(getProSeasonsCompleted({ draftYear: 2028 }, { currentSeason: 's2031' })).toBeNull();
+    expect(getProSeasonsCompleted({}, { currentSeason: 2031 })).toBeNull();
+    expect(getProSeasonsCompleted(null, null)).toBeNull();
+  });
+});
+
+// ── shouldRevealHiddenDevTrait ────────────────────────────────────────────────
+
+describe('shouldRevealHiddenDevTrait', () => {
+  it('is false without a hiddenDevTrait, regardless of experience', () => {
+    expect(shouldRevealHiddenDevTrait({ ovrHistory: history(5), age: 30 })).toBe(false);
+    expect(shouldRevealHiddenDevTrait({}, {})).toBe(false);
+    expect(shouldRevealHiddenDevTrait(null)).toBe(false);
+  });
+
+  it('is false for draft-eligible prospects even with a trait', () => {
+    const prospect = { hiddenDevTrait: 'superstar', status: 'draft_eligible', age: 30, ovrHistory: history(5) };
+    expect(shouldRevealHiddenDevTrait(prospect)).toBe(false);
+  });
+
+  it('reveals at the seasons threshold via ovrHistory', () => {
+    const base = { hiddenDevTrait: 'normal', age: 22 };
+    expect(shouldRevealHiddenDevTrait({ ...base, ovrHistory: history(0) })).toBe(false);
+    expect(shouldRevealHiddenDevTrait({ ...base, ovrHistory: history(1) })).toBe(false);
+    expect(shouldRevealHiddenDevTrait({ ...base, ovrHistory: history(HIDDEN_DEV_TRAIT_REVEAL_SEASONS) })).toBe(true);
+    expect(shouldRevealHiddenDevTrait({ ...base, ovrHistory: history(6) })).toBe(true);
+  });
+
+  it('an ovrHistory below threshold blocks reveal even for an old player', () => {
+    // The seasons signal is authoritative; the age proxy only applies when
+    // no seasons signal exists at all.
+    expect(shouldRevealHiddenDevTrait({ hiddenDevTrait: 'bust', age: 29, ovrHistory: history(1) })).toBe(false);
+  });
+
+  it('reveals via draftYear + season context when ovrHistory is absent', () => {
+    const player = { hiddenDevTrait: 'late_bloomer', draftYear: 2028, age: 22 };
+    expect(shouldRevealHiddenDevTrait(player, { currentSeason: 2029 })).toBe(false);
+    expect(shouldRevealHiddenDevTrait(player, { currentSeason: 2030 })).toBe(true);
+  });
+
+  it('falls back to age >= 24 when no seasons signal exists', () => {
+    expect(shouldRevealHiddenDevTrait({ hiddenDevTrait: 'normal', age: 23 })).toBe(false);
+    expect(shouldRevealHiddenDevTrait({ hiddenDevTrait: 'normal', age: 24 })).toBe(true);
+    expect(shouldRevealHiddenDevTrait({ hiddenDevTrait: 'normal', age: 31 })).toBe(true);
+  });
+
+  it('defaults to not revealed when age and context are both missing', () => {
+    expect(shouldRevealHiddenDevTrait({ hiddenDevTrait: 'superstar' })).toBe(false);
+    expect(shouldRevealHiddenDevTrait({ hiddenDevTrait: 'superstar' }, {})).toBe(false);
+    expect(shouldRevealHiddenDevTrait({ hiddenDevTrait: 'superstar', age: 'unknown' }, null)).toBe(false);
+  });
+});
+
+// ── getHiddenDevTraitLabel ────────────────────────────────────────────────────
+
+describe('getHiddenDevTraitLabel', () => {
+  const revealed = { ovrHistory: history(2), age: 24 };
+
+  it('returns null when hiddenDevTrait is missing', () => {
+    expect(getHiddenDevTraitLabel({ ...revealed })).toBeNull();
+    expect(getHiddenDevTraitLabel({}, {})).toBeNull();
+    expect(getHiddenDevTraitLabel(null)).toBeNull();
+  });
+
+  it('returns "Hidden" before the reveal threshold', () => {
+    expect(getHiddenDevTraitLabel({ hiddenDevTrait: 'superstar', ovrHistory: history(1), age: 22 })).toBe('Hidden');
+    expect(getHiddenDevTraitLabel({ hiddenDevTrait: 'bust' })).toBe('Hidden');
+  });
+
+  it('maps every known trait to its label once revealed', () => {
+    expect(getHiddenDevTraitLabel({ ...revealed, hiddenDevTrait: 'normal' })).toBe('Normal');
+    expect(getHiddenDevTraitLabel({ ...revealed, hiddenDevTrait: 'late_bloomer' })).toBe('Late Bloomer');
+    expect(getHiddenDevTraitLabel({ ...revealed, hiddenDevTrait: 'superstar' })).toBe('Superstar');
+    expect(getHiddenDevTraitLabel({ ...revealed, hiddenDevTrait: 'bust' })).toBe('Bust');
+  });
+
+  it('returns null for unknown trait values once revealed', () => {
+    expect(getHiddenDevTraitLabel({ ...revealed, hiddenDevTrait: 'x_factor' })).toBeNull();
+    expect(getHiddenDevTraitLabel({ ...revealed, hiddenDevTrait: 'Star' })).toBeNull();
+  });
+});

--- a/src/core/draft/draftVariance.js
+++ b/src/core/draft/draftVariance.js
@@ -16,7 +16,9 @@
  * All helpers are pure. RNG is injected (defaults to the seeded Utils.random
  * stream used by the rest of draft generation) — never Math.random.
  *
- * Hidden data only in this PR: no UI reads these fields.
+ * hiddenTrueOvr stays internal-only and must never be rendered. hiddenDevTrait
+ * may be surfaced through shouldRevealHiddenDevTrait / getHiddenDevTraitLabel
+ * once a player has roughly two completed pro seasons.
  */
 
 import { Utils } from '../utils.js';
@@ -160,6 +162,75 @@ export function getTrueOvrGrowthBonus(player, ovrDelta) {
   if (gap >= 6) return 2;
   if (gap >= 2) return 1;
   return 0;
+}
+
+// ── Hidden dev-trait reveal (UI-facing) ──────────────────────────────────────
+
+// Roughly two completed pro seasons before the hidden trait becomes visible.
+export const HIDDEN_DEV_TRAIT_REVEAL_SEASONS = 2;
+
+// Age proxy used only when no seasons-completed signal exists: drafted players
+// enter at 21–23 (player.js), so age 24 ≈ at least ~2 completed pro seasons.
+const REVEAL_FALLBACK_AGE = 24;
+
+const HIDDEN_DEV_TRAIT_LABELS = {
+  normal: 'Normal',
+  late_bloomer: 'Late Bloomer',
+  superstar: 'Superstar',
+  bust: 'Bust',
+};
+
+/**
+ * Completed pro seasons for a player, derived from existing persisted data —
+ * no new player fields. Paths, most reliable first:
+ *   1. player.ovrHistory — the offseason pipeline appends exactly one entry
+ *      per completed season (draft-eligible/retired players are skipped), so
+ *      its length is a direct seasons-completed count for drafted players.
+ *   2. currentSeason − player.draftYear, when both are known (draftYear is
+ *      read defensively elsewhere, e.g. holdoutEngine, but rarely stamped).
+ *
+ * @param {object} player
+ * @param {object} [context] - league/season context; reads currentSeason,
+ *   year, or season for the current league year
+ * @returns {number|null} completed seasons, or null when underivable
+ */
+export function getProSeasonsCompleted(player, context) {
+  const history = player?.ovrHistory;
+  if (Array.isArray(history)) return history.length;
+  const draftYear = Number(player?.draftYear);
+  const season = Number(context?.currentSeason ?? context?.year ?? context?.season);
+  if (Number.isFinite(draftYear) && Number.isFinite(season)) {
+    return Math.max(0, season - draftYear);
+  }
+  return null;
+}
+
+/**
+ * True once a player's hidden development trait should be visible in the UI:
+ * the player carries a hiddenDevTrait and has ~2 completed pro seasons (see
+ * getProSeasonsCompleted). With no seasons signal, falls back to the age-24
+ * proxy; with no age either — or for draft prospects — stays hidden.
+ */
+export function shouldRevealHiddenDevTrait(player, context) {
+  if (player?.hiddenDevTrait == null) return false;
+  if (player?.status === 'draft_eligible') return false;
+  const seasons = getProSeasonsCompleted(player, context);
+  if (seasons != null) return seasons >= HIDDEN_DEV_TRAIT_REVEAL_SEASONS;
+  const age = Number(player?.age);
+  return Number.isFinite(age) && age >= REVEAL_FALLBACK_AGE;
+}
+
+/**
+ * Display label for a player's hidden development trait.
+ *
+ * @returns {string|null} null when the player has no hiddenDevTrait (render
+ *   nothing), "Hidden" before the reveal threshold, the trait label after it,
+ *   or null for unrecognized trait values.
+ */
+export function getHiddenDevTraitLabel(player, context) {
+  if (player?.hiddenDevTrait == null) return null;
+  if (!shouldRevealHiddenDevTrait(player, context)) return 'Hidden';
+  return HIDDEN_DEV_TRAIT_LABELS[player.hiddenDevTrait] ?? null;
 }
 
 /**

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -41,6 +41,7 @@ import { getPlayerMoraleSummary } from "../../core/mood/playerMoraleEngine.js";
 import { getPlayerAwardSummary, AWARD_LABELS, AWARD_TYPES } from "../../core/awards/awardEngine.js";
 import { getNegotiationContext } from "../../core/contracts/negotiationModifiers.js";
 import { TRACKED_STATS } from "../../core/awards/statLeaderboard.js";
+import { getHiddenDevTraitLabel } from "../../core/draft/draftVariance.js";
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
 
@@ -754,6 +755,10 @@ export default function PlayerProfile({
   const developmentNotes = useMemo(() => buildDevelopmentNotes(player, moraleContext), [player, moraleContext]);
   const ageCurve = useMemo(() => getAgeCurveContext(player), [player]);
   const developmentSnapshot = useMemo(() => getDevelopmentSnapshot(player), [player]);
+  const hiddenDevTraitLabel = useMemo(
+    () => getHiddenDevTraitLabel(player, { currentSeason: league?.year ?? league?.seasonId ?? null }),
+    [player, league?.year, league?.seasonId],
+  );
   const developmentDrivers = useMemo(() => getDevelopmentDrivers(player, moraleContext), [player, moraleContext]);
   const developmentArcModel = useMemo(
     () => buildPlayerDevelopmentModel(effectivePlayer, { developmentContext: effectivePlayer?.developmentContext }),
@@ -1936,6 +1941,17 @@ export default function PlayerProfile({
               <AttrRow label="Potential" value={player?.potential ?? player?.ovr ?? 0} />
               <AttrRow label="Morale" value={player?.morale ?? 0} />
               <AttrRow label="Scheme Fit" value={player?.schemeFit ?? 50} />
+              {hiddenDevTraitLabel != null && (
+                <div
+                  data-testid="player-profile-dev-trait"
+                  style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: 6 }}
+                >
+                  <span style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Development</span>
+                  <span style={{ fontSize: "var(--text-xs)", fontWeight: 700, color: hiddenDevTraitLabel === "Hidden" ? "var(--text-subtle)" : "var(--text)" }}>
+                    {hiddenDevTraitLabel}
+                  </span>
+                </div>
+              )}
             </section>
           )}
 

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -569,6 +569,97 @@ describe('PlayerProfile', () => {
     expect(screen.queryByTestId('player-profile-advanced-ledger')).toBeNull();
   });
 
+  describe('hidden development trait reveal', () => {
+    // useStableRouteRequest keeps a module-level completed-request cache keyed
+    // by league scope + player id, so give each render a unique player id.
+    let nextRevealPlayerId = 9100;
+
+    const buildActions = (revealPlayer) => ({
+      getPlayerCareer: vi.fn(async () => ({
+        payload: {
+          player: revealPlayer,
+          stats: [],
+          teammates: [],
+          meta: { userTeamId: 1, week: 1 },
+        },
+      })),
+      getAllSeasons: vi.fn(async () => ({ payload: { seasons: [] } })),
+      getPlayerDraftContext: vi.fn(async () => ({ payload: { context: { known: false } } })),
+      getRecords: vi.fn(async () => ({ payload: { recordBook: null } })),
+      getTransactions: vi.fn(async () => ({ payload: { transactions: [] } })),
+    });
+
+    const renderProfile = (playerOverrides) => {
+      const id = nextRevealPlayerId++;
+      const revealPlayer = { ...player, ...playerOverrides, id };
+      render(
+        <PlayerProfile
+          playerId={id}
+          onClose={vi.fn()}
+          actions={buildActions(revealPlayer)}
+          teams={league.teams}
+          league={league}
+        />,
+      );
+    };
+
+    it('renders no Development row for players without hiddenDevTrait', async () => {
+      renderProfile({});
+      await waitFor(() => expect(screen.getByTestId('player-profile-summary').textContent).toContain('Avery Fields'));
+      expect(screen.queryByTestId('player-profile-dev-trait')).toBeNull();
+    });
+
+    it('shows "Hidden" below the reveal threshold', async () => {
+      renderProfile({
+        hiddenDevTrait: 'superstar',
+        age: 23,
+        ovrHistory: [{ season: 2030, ovr: 80, age: 22 }],
+      });
+      await waitFor(() => expect(screen.getByTestId('player-profile-dev-trait')).toBeTruthy());
+      const row = screen.getByTestId('player-profile-dev-trait');
+      expect(row.textContent).toContain('Development');
+      expect(row.textContent).toContain('Hidden');
+      expect(row.textContent).not.toContain('Superstar');
+    });
+
+    it.each([
+      ['normal', 'Normal'],
+      ['late_bloomer', 'Late Bloomer'],
+      ['superstar', 'Superstar'],
+      ['bust', 'Bust'],
+    ])('shows the %s label at the reveal threshold', async (trait, label) => {
+      renderProfile({
+        hiddenDevTrait: trait,
+        ovrHistory: [
+          { season: 2030, ovr: 80, age: 22 },
+          { season: 2031, ovr: 82, age: 23 },
+        ],
+      });
+      await waitFor(() => expect(screen.getByTestId('player-profile-dev-trait')).toBeTruthy());
+      expect(screen.getByTestId('player-profile-dev-trait').textContent).toContain(label);
+    });
+
+    it('defaults to "Hidden" when age and season context are both missing', async () => {
+      renderProfile({ hiddenDevTrait: 'bust', age: null, ovrHistory: undefined });
+      await waitFor(() => expect(screen.getByTestId('player-profile-dev-trait')).toBeTruthy());
+      expect(screen.getByTestId('player-profile-dev-trait').textContent).toContain('Hidden');
+    });
+
+    it('never renders hiddenTrueOvr anywhere in the profile tree', async () => {
+      renderProfile({
+        hiddenTrueOvr: 977, // sentinel: impossible OVR so any leak is detectable
+        hiddenDevTrait: 'superstar',
+        ovrHistory: [
+          { season: 2030, ovr: 80, age: 22 },
+          { season: 2031, ovr: 82, age: 23 },
+        ],
+      });
+      await waitFor(() => expect(screen.getByTestId('player-profile-dev-trait')).toBeTruthy());
+      expect(document.body.textContent).not.toContain('977');
+      expect(document.body.innerHTML).not.toContain('hiddenTrueOvr');
+    });
+  });
+
   it('shows legacy watch when career stats and accolades justify legacy scoring', async () => {
     const careerPlayer = {
       id: 22,


### PR DESCRIPTION
Adds a presentation-only reveal for the hiddenDevTrait field introduced
by the draft hidden-variance work, without touching progression, draft
generation, simulation, contracts, or AI logic.

Core (draftVariance.js, pure helpers):
- getProSeasonsCompleted(player, context): derives completed pro seasons
  from existing data only — player.ovrHistory length (the offseason
  pipeline appends exactly one entry per completed season), falling back
  to currentSeason - player.draftYear when both are known.
- shouldRevealHiddenDevTrait(player, context): true once a player with a
  hiddenDevTrait has >= 2 completed seasons; with no seasons signal it
  uses the conservative age >= 24 proxy; draft prospects and players
  with no derivable signal stay hidden.
- getHiddenDevTraitLabel(player, context): null without a trait,
  "Hidden" before reveal, then Normal / Late Bloomer / Superstar / Bust
  (unknown values render nothing).

UI (PlayerProfile.jsx): subtle "Development" row in the Core Attributes
section, rendered only when a label exists. hiddenTrueOvr remains
internal-only and is never rendered.

Tests: new core reveal-helper suite plus PlayerProfile render cases,
including a sentinel check that hiddenTrueOvr never leaks into the DOM.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lsffw2aJmTNRMJKbkFnPr9