### PR TITLE
Add Roster Decision Board V2 to Roster Hub

### DIFF
--- a/src/ui/components/PlayerDecisionRow.jsx
+++ b/src/ui/components/PlayerDecisionRow.jsx
@@ -1,0 +1,78 @@
+/**
+ * PlayerDecisionRow.jsx — single row of the Roster Decision Board.
+ *
+ * Pure presentation: renders the player's expiring-contract snapshot, the
+ * `_resignMeta` recommendation (data contract from Roster.jsx enrichment —
+ * reads `label` / `negotiationRisk`, never re-derives them), and the four
+ * local pending-decision pills. All state lives in the parent board; this
+ * component never touches league/player/global state.
+ */
+
+import React from "react";
+import { formatContractMoney } from "../utils/contractFormatting.js";
+
+export const DECISION_OPTIONS = [
+  { key: "extend", label: "Extend" },
+  { key: "cut", label: "Cut" },
+  { key: "franchise_tag", label: "Franchise Tag" },
+  { key: "let_walk", label: "Let Walk" },
+];
+
+function DevTraitBadge({ label }) {
+  if (label == null) return null;
+  if (label === "Hidden") {
+    return (
+      <span className="roster-decision-board__dev-badge roster-decision-board__dev-badge--hidden">
+        Dev: Hidden
+      </span>
+    );
+  }
+  return <span className="roster-decision-board__dev-badge">{label}</span>;
+}
+
+export default function PlayerDecisionRow({ row, decision, onDecide, onPlayerSelect }) {
+  const { player, rowKey, yearsRemaining, annualSalary, meta, devTraitLabel } = row;
+  const pos = player?.pos ?? player?.position ?? "—";
+  const name = player?.name ?? "Unknown Player";
+  const canOpenProfile = typeof onPlayerSelect === "function" && player?.id != null;
+
+  return (
+    <tr
+      className={decision ? "roster-decision-board__row--pending" : undefined}
+      data-testid={`decision-row-${rowKey}`}
+      data-pending={decision ? "true" : "false"}
+    >
+      <td>
+        {canOpenProfile ? (
+          <button className="btn-link" onClick={() => onPlayerSelect(player.id)}>{name}</button>
+        ) : (
+          <span>{name}</span>
+        )}
+        <DevTraitBadge label={devTraitLabel} />
+      </td>
+      <td>{pos}</td>
+      <td>{player?.age ?? "—"}</td>
+      <td>{player?.ovr ?? player?.displayOvr ?? "—"}</td>
+      <td className="roster-decision-board__contract-cell">
+        {formatContractMoney(annualSalary)}/yr · {yearsRemaining}y left
+      </td>
+      <td>{meta?.label ?? "—"}</td>
+      <td>{meta?.negotiationRisk ?? "—"}</td>
+      <td>
+        <div className="roster-decision-board__pills" role="group" aria-label={`Pending decision for ${name}`}>
+          {DECISION_OPTIONS.map((option) => (
+            <button
+              key={option.key}
+              type="button"
+              className="roster-decision-board__pill"
+              aria-pressed={decision === option.key}
+              onClick={() => onDecide(rowKey, option.key)}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </td>
+    </tr>
+  );
+}

--- a/src/ui/components/RosterDecisionBoard.jsx
+++ b/src/ui/components/RosterDecisionBoard.jsx
@@ -1,0 +1,266 @@
+/**
+ * RosterDecisionBoard.jsx — contract decision intelligence for the user team.
+ *
+ * Renders a filterable, sortable table of players whose contracts expire
+ * within EXPIRING_WINDOW_SEASONS. Presentation + local pending-decision state
+ * only: decisions live in a useState map keyed by row, and nothing here
+ * mutates league / player / global state.
+ *
+ * Data contracts consumed (never re-derived here):
+ *  - contract years remaining: contract.years with the established
+ *    yearsLeft / yearsRemaining fallbacks (see contractInsights.js). Players
+ *    without a usable contract are excluded from the board.
+ *  - player._resignMeta: recommendation payload written by the Roster
+ *    enrichment site (evaluateResignRecommendation) — reads `label` and
+ *    `negotiationRisk`; missing meta renders "—".
+ *  - hidden dev trait: getHiddenDevTraitLabel (draftVariance.js) decides
+ *    reveal state; hiddenTrueOvr is never read or rendered.
+ *
+ * Props:
+ *  - roster: sanitized player array (RosterHub's null-filtered roster)
+ *  - league: used only for the dev-trait reveal season context
+ *  - onCommitDecisions: optional (decisionsMap) => void; when absent the
+ *    board is preview-only and the commit button stays disabled
+ *  - onPlayerSelect: optional (playerId) => void
+ */
+
+import React, { useMemo, useState } from "react";
+import { EmptyState } from "./ScreenSystem.jsx";
+import { derivePlayerContractFinancials } from "../utils/contractFormatting.js";
+import { getHiddenDevTraitLabel } from "../../core/draft/draftVariance.js";
+import PlayerDecisionRow, { DECISION_OPTIONS } from "./PlayerDecisionRow.jsx";
+
+export const EXPIRING_WINDOW_SEASONS = 2;
+
+const RISK_RANK = { high: 3, medium: 2, low: 1 };
+
+const COLUMNS = [
+  { key: "name", label: "Player Name" },
+  { key: "pos", label: "Pos" },
+  { key: "age", label: "Age" },
+  { key: "ovr", label: "OVR" },
+  { key: "contract", label: "Contract" },
+  { key: "action", label: "Recommended Action" },
+  { key: "risk", label: "Risk" },
+];
+
+function getYearsRemaining(player) {
+  const contract = player?.contract;
+  if (contract == null || typeof contract !== "object") return null;
+  const years = Number(contract.years ?? contract.yearsLeft ?? contract.yearsRemaining);
+  return Number.isFinite(years) ? years : null;
+}
+
+function rowKeyFor(player, index) {
+  const id = player?.id;
+  if (typeof id === "string" || typeof id === "number") return String(id);
+  return `row-${index}`;
+}
+
+function sortValue(row, key) {
+  switch (key) {
+    case "name": return String(row.player?.name ?? "").toLowerCase();
+    case "pos": return String(row.player?.pos ?? row.player?.position ?? "").toLowerCase();
+    case "age": return Number(row.player?.age) || 0;
+    case "ovr": return Number(row.player?.ovr ?? row.player?.displayOvr) || 0;
+    case "contract": return row.annualSalary ?? -1;
+    case "action": return String(row.meta?.label ?? "").toLowerCase();
+    case "risk": return RISK_RANK[String(row.meta?.negotiationRisk ?? "").toLowerCase()] ?? 0;
+    default: return 0;
+  }
+}
+
+export default function RosterDecisionBoard({ roster, league, onCommitDecisions, onPlayerSelect }) {
+  const [decisions, setDecisions] = useState({});
+  const [search, setSearch] = useState("");
+  const [posFilter, setPosFilter] = useState("ALL");
+  const [sortKey, setSortKey] = useState("ovr");
+  const [sortDesc, setSortDesc] = useState(true);
+
+  const revealContext = useMemo(
+    () => ({ currentSeason: league?.year ?? league?.seasonId ?? null }),
+    [league?.year, league?.seasonId],
+  );
+
+  const rows = useMemo(() => {
+    const safe = Array.isArray(roster) ? roster : [];
+    return safe
+      .filter((player) => player && typeof player === "object")
+      .map((player, index) => {
+        const yearsRemaining = getYearsRemaining(player);
+        if (yearsRemaining == null || yearsRemaining > EXPIRING_WINDOW_SEASONS) return null;
+        const meta = player._resignMeta && typeof player._resignMeta === "object" ? player._resignMeta : null;
+        return {
+          player,
+          rowKey: rowKeyFor(player, index),
+          yearsRemaining,
+          annualSalary: derivePlayerContractFinancials(player).annualSalary,
+          meta,
+          devTraitLabel: getHiddenDevTraitLabel(player, revealContext),
+        };
+      })
+      .filter(Boolean);
+  }, [roster, revealContext]);
+
+  const positions = useMemo(() => {
+    const seen = new Set();
+    rows.forEach((row) => {
+      const pos = row.player?.pos ?? row.player?.position;
+      if (pos) seen.add(String(pos));
+    });
+    return ["ALL", ...Array.from(seen).sort()];
+  }, [rows]);
+
+  const visibleRows = useMemo(() => {
+    let next = rows;
+    const q = search.trim().toLowerCase();
+    if (q) {
+      next = next.filter((row) => String(row.player?.name ?? "").toLowerCase().includes(q));
+    }
+    if (posFilter !== "ALL") {
+      next = next.filter((row) => String(row.player?.pos ?? row.player?.position ?? "") === posFilter);
+    }
+    const sorted = [...next].sort((a, b) => {
+      const va = sortValue(a, sortKey);
+      const vb = sortValue(b, sortKey);
+      const cmp = typeof va === "string" ? va.localeCompare(vb) : va - vb;
+      return sortDesc ? -cmp : cmp;
+    });
+    return sorted;
+  }, [rows, search, posFilter, sortKey, sortDesc]);
+
+  const handleSort = (key) => {
+    if (key === sortKey) {
+      setSortDesc((prev) => !prev);
+    } else {
+      setSortKey(key);
+      setSortDesc(key !== "name" && key !== "pos");
+    }
+  };
+
+  const handleDecide = (rowKey, decisionKey) => {
+    setDecisions((prev) => {
+      const next = { ...prev };
+      if (next[rowKey] === decisionKey) {
+        delete next[rowKey];
+      } else {
+        next[rowKey] = decisionKey;
+      }
+      return next;
+    });
+  };
+
+  const pendingCount = Object.keys(decisions).length;
+  const canCommit = typeof onCommitDecisions === "function";
+
+  const handleCommit = () => {
+    if (!canCommit) return;
+    onCommitDecisions({ ...decisions });
+  };
+
+  if (rows.length === 0) {
+    return (
+      <div className="roster-decision-board" data-testid="roster-decision-board">
+        <EmptyState
+          title="No expiring contracts"
+          body={`No players have contracts expiring within ${EXPIRING_WINDOW_SEASONS} seasons.`}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="roster-decision-board" data-testid="roster-decision-board">
+      <div className="roster-decision-board__toolbar">
+        <input
+          type="text"
+          className="settings-input roster-decision-board__search"
+          placeholder="Search expiring players..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          aria-label="Search expiring players"
+        />
+        <div className="division-tabs roster-decision-board__pos-tabs" role="group" aria-label="Filter by position">
+          {positions.map((pos) => (
+            <button
+              key={pos}
+              type="button"
+              className={`division-tab${posFilter === pos ? " active" : ""}`}
+              onClick={() => setPosFilter(pos)}
+            >
+              {pos}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="roster-decision-board__table-wrap">
+        <table className="standings-table roster-decision-board__table">
+          <thead>
+            <tr>
+              {COLUMNS.map((col) => (
+                <th key={col.key} aria-sort={sortKey === col.key ? (sortDesc ? "descending" : "ascending") : "none"}>
+                  <button
+                    type="button"
+                    className="roster-decision-board__sort-button"
+                    onClick={() => handleSort(col.key)}
+                  >
+                    {col.label}
+                    {sortKey === col.key ? (sortDesc ? " ↓" : " ↑") : ""}
+                  </button>
+                </th>
+              ))}
+              <th>Pending Decision</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visibleRows.map((row) => (
+              <PlayerDecisionRow
+                key={row.rowKey}
+                row={row}
+                decision={decisions[row.rowKey] ?? null}
+                onDecide={handleDecide}
+                onPlayerSelect={onPlayerSelect}
+              />
+            ))}
+            {visibleRows.length === 0 && (
+              <tr>
+                <td colSpan={COLUMNS.length + 1} className="roster-decision-board__empty-cell">
+                  No expiring players match the current filters.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="roster-decision-board__footer">
+        <span className="roster-decision-board__meta">
+          {visibleRows.length} of {rows.length} expiring · {pendingCount} pending decision{pendingCount === 1 ? "" : "s"}
+        </span>
+        <div className="roster-decision-board__footer-actions">
+          {pendingCount > 0 && (
+            <button type="button" className="btn-link" onClick={() => setDecisions({})}>
+              Reset
+            </button>
+          )}
+          <button
+            type="button"
+            className="btn"
+            disabled={!canCommit || pendingCount === 0}
+            onClick={handleCommit}
+          >
+            Commit Decisions
+          </button>
+          {!canCommit && (
+            <span className="roster-decision-board__preview-note">
+              Preview only — decisions are not applied yet.
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { DECISION_OPTIONS };

--- a/src/ui/components/RosterHub.jsx
+++ b/src/ui/components/RosterHub.jsx
@@ -17,6 +17,8 @@ import DragAndDropDepthChart from "./DragAndDropDepthChart.jsx";
 import { ScreenHeader, SectionCard, EmptyState, StickySubnav } from "./ScreenSystem.jsx";
 import { applyRangeFilter, inTier, cycleSort } from "../utils/managementList.js";
 import { derivePlayerContractFinancials, formatContractMoney } from "../utils/contractFormatting.js";
+import { evaluateResignRecommendation, classifyTeamDirection } from "../utils/contractInsights.js";
+import RosterDecisionBoard from "./RosterDecisionBoard.jsx";
 
 // ── Position color map (matches stadium-theme.css pos-badge classes) ──
 const POS_COLORS = {
@@ -268,6 +270,7 @@ function ViewToggle({ mode, onChange }) {
     { key: "cards", label: "Cards" },
     { key: "table", label: "Table" },
     { key: "depth", label: "Depth" },
+    { key: "decisions", label: "Decision Board" },
   ];
   return (
     <div style={{
@@ -317,6 +320,20 @@ export default function RosterHub({ league, actions, onPlayerSelect, teamId }) {
   // Filter null/undefined/non-object players so downstream helpers don't throw on bad save data.
   const roster = safeRoster.filter((player) => player && typeof player === "object");
   const isUserTeam = activeTeamId === league?.userTeamId;
+
+  // Decision Board data contract (PR #1655 / resignDecisionFilters.js): rows
+  // carry their recommendation under player._resignMeta, mirroring the
+  // Roster.jsx enrichment site. Read-only copies — source roster objects are
+  // never mutated. Only computed while the Decision Board view is active.
+  const decisionRoster = useMemo(() => {
+    if (viewMode !== "decisions") return [];
+    const direction = classifyTeamDirection(team, league?.week ?? 1);
+    return roster.map((player) => (
+      player?._resignMeta
+        ? player
+        : { ...player, _resignMeta: evaluateResignRecommendation(player, { team, roster, direction }) }
+    ));
+  }, [viewMode, roster, team, league?.week]);
 
   const filtered = useMemo(() => {
     let players = [...roster];
@@ -469,6 +486,19 @@ export default function RosterHub({ league, actions, onPlayerSelect, teamId }) {
             onPlayerSelect={onPlayerSelect}
           />
         </RosterProfileErrorBoundary>
+        </SectionCard>
+      )}
+
+      {/* ── Decision Board view (expiring contracts, preview-only pending decisions) ── */}
+      {viewMode === "decisions" && (
+        <SectionCard title="Decision Board" subtitle="Triage expiring contracts with recommendations and pending decisions.">
+          <RosterProfileErrorBoundary>
+            <RosterDecisionBoard
+              roster={decisionRoster}
+              league={league}
+              onPlayerSelect={onPlayerSelect}
+            />
+          </RosterProfileErrorBoundary>
         </SectionCard>
       )}
 

--- a/src/ui/components/__tests__/RosterDecisionBoard.test.jsx
+++ b/src/ui/components/__tests__/RosterDecisionBoard.test.jsx
@@ -1,0 +1,204 @@
+/** @vitest-environment jsdom */
+/**
+ * RosterDecisionBoard.test.jsx
+ *
+ * Roster Decision Board V2: expiring-contract triage table with local
+ * pending-decision state. Verifies the expiring window filter, safe
+ * `_resignMeta` fallbacks, local-only decision pills, the preview-only
+ * commit path, reuse of the hidden dev-trait reveal helper, and that the
+ * hiddenTrueOvr sentinel never reaches the DOM.
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, within, cleanup } from "@testing-library/react";
+
+afterEach(cleanup);
+
+vi.mock("../../../core/draft/draftVariance.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    getHiddenDevTraitLabel: vi.fn(actual.getHiddenDevTraitLabel),
+  };
+});
+
+import { getHiddenDevTraitLabel } from "../../../core/draft/draftVariance.js";
+import RosterDecisionBoard from "../RosterDecisionBoard.jsx";
+import RosterHub from "../RosterHub.jsx";
+
+// hiddenTrueOvr sentinel value chosen to collide with no other rendered number.
+const SENTINEL_TRUE_OVR = 97;
+
+function makeRoster() {
+  return [
+    {
+      id: 7,
+      name: "Cut Candidate",
+      pos: "QB",
+      age: 29,
+      ovr: 81,
+      hiddenDevTrait: "superstar",
+      hiddenTrueOvr: SENTINEL_TRUE_OVR,
+      ovrHistory: [72, 76, 81], // 3 completed seasons → trait revealed
+      contract: { years: 1, baseAnnual: 8.5 },
+      _resignMeta: {
+        tier: "let_walk",
+        label: "Expendable",
+        tone: "var(--danger)",
+        reason: "Let walk: age and contract demands outpace value",
+        score: 40,
+        urgency: "Low",
+        negotiationRisk: "High",
+        replacementDifficulty: "Low",
+      },
+    },
+    {
+      id: 8,
+      name: "No Meta Man",
+      pos: "WR",
+      age: 22,
+      ovr: 74,
+      hiddenDevTrait: "bust",
+      hiddenTrueOvr: SENTINEL_TRUE_OVR,
+      ovrHistory: [74], // 1 completed season → trait still hidden
+      contract: { years: 2, baseAnnual: 3.2 },
+      // no _resignMeta on purpose
+    },
+    {
+      id: 9,
+      name: "Long Deal Larry",
+      pos: "OL",
+      age: 27,
+      ovr: 79,
+      contract: { years: 3, baseAnnual: 6.4 },
+    },
+    {
+      id: 10,
+      name: "No Contract Nick",
+      pos: "CB",
+      age: 24,
+      ovr: 71,
+      // no contract on purpose
+    },
+    null, // malformed row must be ignored
+  ];
+}
+
+describe("RosterDecisionBoard", () => {
+  beforeEach(() => {
+    vi.mocked(getHiddenDevTraitLabel).mockClear();
+  });
+
+  it("renders with an empty roster and does not crash", () => {
+    expect(() => render(<RosterDecisionBoard roster={[]} league={{}} />)).not.toThrow();
+    expect(screen.getByText("No expiring contracts")).toBeTruthy();
+  });
+
+  it("excludes players without contracts or with more than 2 years remaining", () => {
+    render(<RosterDecisionBoard roster={makeRoster()} league={{}} />);
+    expect(screen.queryByText("Long Deal Larry")).toBeNull();
+    expect(screen.queryByText("No Contract Nick")).toBeNull();
+  });
+
+  it("includes players whose contracts expire within 2 seasons", () => {
+    render(<RosterDecisionBoard roster={makeRoster()} league={{}} />);
+    expect(screen.getByText("Cut Candidate")).toBeTruthy();
+    expect(screen.getByText("No Meta Man")).toBeTruthy();
+    // Real _resignMeta keys surface as Recommended Action / Risk.
+    expect(screen.getByText("Expendable")).toBeTruthy();
+    expect(screen.getByText("High")).toBeTruthy();
+    // Contract column shows salary per year and years left.
+    expect(screen.getByText(/\$8\.5M\/yr · 1y left/)).toBeTruthy();
+  });
+
+  it("renders '—' for missing _resignMeta without crashing", () => {
+    render(<RosterDecisionBoard roster={makeRoster()} league={{}} />);
+    const row = screen.getByTestId("decision-row-8");
+    // Recommended Action and Risk both fall back to the em dash.
+    expect(within(row).getAllByText("—").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("selecting Cut highlights the pill and marks the row pending (local state only)", () => {
+    render(<RosterDecisionBoard roster={makeRoster()} league={{}} />);
+    const row = screen.getByTestId("decision-row-7");
+    expect(row.getAttribute("data-pending")).toBe("false");
+
+    fireEvent.click(within(row).getByRole("button", { name: "Cut" }));
+
+    expect(within(row).getByRole("button", { name: "Cut" }).getAttribute("aria-pressed")).toBe("true");
+    expect(row.getAttribute("data-pending")).toBe("true");
+    expect(row.className).toContain("roster-decision-board__row--pending");
+    // Other rows stay untouched.
+    expect(screen.getByTestId("decision-row-8").getAttribute("data-pending")).toBe("false");
+  });
+
+  it("Commit Decisions calls onCommitDecisions with the local decisions map", () => {
+    const onCommitDecisions = vi.fn();
+    render(<RosterDecisionBoard roster={makeRoster()} league={{}} onCommitDecisions={onCommitDecisions} />);
+
+    fireEvent.click(within(screen.getByTestId("decision-row-7")).getByRole("button", { name: "Cut" }));
+    fireEvent.click(within(screen.getByTestId("decision-row-8")).getByRole("button", { name: "Extend" }));
+    fireEvent.click(screen.getByRole("button", { name: "Commit Decisions" }));
+
+    expect(onCommitDecisions).toHaveBeenCalledTimes(1);
+    expect(onCommitDecisions).toHaveBeenCalledWith({ 7: "cut", 8: "extend" });
+  });
+
+  it("without onCommitDecisions the commit button is disabled, shows preview state, and never mutates players", () => {
+    // Frozen players prove render + interaction never write to player objects.
+    const roster = makeRoster().map((p) => (p ? Object.freeze(p) : p));
+    render(<RosterDecisionBoard roster={roster} league={{}} />);
+
+    const commit = screen.getByRole("button", { name: "Commit Decisions" });
+    expect(commit.disabled).toBe(true);
+    expect(screen.getByText(/Preview only/)).toBeTruthy();
+
+    expect(() => {
+      fireEvent.click(within(screen.getByTestId("decision-row-7")).getByRole("button", { name: "Cut" }));
+      fireEvent.click(commit);
+    }).not.toThrow();
+    expect(roster[0].extensionDecision).toBeUndefined();
+  });
+
+  it("never renders the hiddenTrueOvr sentinel in the DOM", () => {
+    const { container } = render(<RosterDecisionBoard roster={makeRoster()} league={{}} />);
+    expect(container.innerHTML).not.toContain(String(SENTINEL_TRUE_OVR));
+    expect(container.innerHTML).not.toContain("hiddenTrueOvr");
+  });
+
+  it("reuses the shared hiddenDevTrait reveal helper for badges instead of duplicating reveal logic", () => {
+    render(<RosterDecisionBoard roster={makeRoster()} league={{ year: 2027 }} />);
+    // The shared helper is consulted for every board row.
+    expect(vi.mocked(getHiddenDevTraitLabel)).toHaveBeenCalled();
+    // Revealed trait (3 completed seasons) shows the helper's label…
+    expect(screen.getByText("Superstar")).toBeTruthy();
+    // …while an unrevealed trait shows only the subtle hidden badge.
+    expect(screen.getByText("Dev: Hidden")).toBeTruthy();
+  });
+});
+
+describe("RosterHub Decision Board tab", () => {
+  beforeEach(() => {
+    global.IntersectionObserver = vi.fn(function () {
+      return { observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() };
+    });
+  });
+
+  it("exposes a Decision Board tab that renders the board with the sanitized roster", () => {
+    const league = {
+      userTeamId: 1,
+      seasonId: 2026,
+      week: 3,
+      teams: [{ id: 1, name: "Sharks", capRoom: 22, roster: makeRoster(), strategies: {} }],
+    };
+    render(<RosterHub league={league} actions={{}} onPlayerSelect={() => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Decision Board" }));
+
+    expect(screen.getByTestId("roster-decision-board")).toBeTruthy();
+    expect(screen.getByText("Cut Candidate")).toBeTruthy();
+    expect(screen.queryByText("Long Deal Larry")).toBeNull();
+    // RosterHub has no safe batch-commit action yet → preview-only.
+    expect(screen.getByRole("button", { name: "Commit Decisions" }).disabled).toBe(true);
+  });
+});

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -1445,3 +1445,108 @@ details[open] .app-hq-background-section__summary span { transform: rotate(180de
   font-size: var(--text-xs);
   font-weight: 700;
 }
+
+/* ============================================================================
+   ROSTER DECISION BOARD
+   ============================================================================ */
+
+.roster-decision-board {
+  display: grid;
+  gap: var(--space-3);
+}
+.roster-decision-board__toolbar {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+.roster-decision-board__search {
+  flex: 1;
+  min-width: 160px;
+}
+.roster-decision-board__pos-tabs {
+  flex-wrap: wrap;
+}
+.roster-decision-board__table-wrap {
+  overflow-x: auto;
+}
+.roster-decision-board__table {
+  min-width: 760px;
+  width: 100%;
+}
+.roster-decision-board__sort-button {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  padding: 0;
+  white-space: nowrap;
+}
+.roster-decision-board__contract-cell {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.roster-decision-board__row--pending {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+.roster-decision-board__row--pending td:first-child {
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+.roster-decision-board__pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+.roster-decision-board__pill {
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-pill);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: var(--text-xs);
+  font-weight: 700;
+  line-height: 1.6;
+  padding: 0 var(--space-2);
+  white-space: nowrap;
+}
+.roster-decision-board__pill[aria-pressed="true"] {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+.roster-decision-board__dev-badge {
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-pill);
+  color: var(--text);
+  display: inline-block;
+  font-size: var(--text-xs);
+  font-weight: 700;
+  margin-left: var(--space-1);
+  padding: 0 var(--space-2);
+  white-space: nowrap;
+}
+.roster-decision-board__dev-badge--hidden {
+  color: var(--text-subtle);
+  font-weight: 600;
+}
+.roster-decision-board__footer {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  justify-content: space-between;
+}
+.roster-decision-board__footer-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+.roster-decision-board__meta,
+.roster-decision-board__preview-note,
+.roster-decision-board__empty-cell {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}


### PR DESCRIPTION
Adds a "Decision Board" tab to RosterHub with a filterable, sortable
table of players whose contracts expire within 2 seasons. Presentation
and local pending-decision state only — no league/player/global state
is mutated and no contract/cut/tag business logic is implemented.

- RosterDecisionBoard.jsx: expiring-contract table with search,
  position filter, sortable columns, local decisions map, and a
  Commit Decisions button that stays disabled (preview-only) unless
  an onCommitDecisions prop is supplied.
- PlayerDecisionRow.jsx: row presentation with the four decision
  pills (Extend / Cut / Franchise Tag / Let Walk) and safe fallbacks.
- Reads the established data contracts: contract.years (with
  yearsLeft/yearsRemaining fallbacks) for the expiring window,
  player._resignMeta (label/negotiationRisk) for recommendation and
  risk, and getHiddenDevTraitLabel for the dev-trait badge —
  hiddenTrueOvr is never rendered.
- RosterHub enriches the board roster with _resignMeta via
  evaluateResignRecommendation, mirroring the Roster.jsx write site,
  on read-only copies of the sanitized roster.
- Scoped roster-decision-board__* classes in components.css; no
  inline styles in the new components.
- Tests cover empty roster, expiring-window inclusion/exclusion,
  missing _resignMeta fallbacks, pill selection, commit behavior with
  and without the prop, sentinel non-rendering, reveal-helper reuse,
  and the RosterHub tab wiring.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XDw4p1g8SwReEYwMkfk9z5