### PR TITLE
Remove unused coach dev modifier helper

### DIFF
--- a/src/core/__tests__/coaching-dev-modifier-wiring.test.js
+++ b/src/core/__tests__/coaching-dev-modifier-wiring.test.js
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   processPlayerProgression,
   sanitizeCoachDevModifier,
-  applyCoachDevModifier,
 } from '../progression-logic.js';
 import { getDevelopmentRateModifier } from '../coaching-philosophy-effects.js';
 import { Utils } from '../utils.js';
@@ -94,50 +93,6 @@ describe('sanitizeCoachDevModifier', () => {
     expect(sanitizeCoachDevModifier(1.11)).toBe(1.11);
     expect(sanitizeCoachDevModifier(0.85)).toBe(0.85);
     expect(sanitizeCoachDevModifier(1.0)).toBe(1.0);
-  });
-});
-
-// ── applyCoachDevModifier ─────────────────────────────────────────────────────
-
-describe('applyCoachDevModifier', () => {
-  it('high-development staff boosts a positive delta more than low-development staff', () => {
-    const high = applyCoachDevModifier(5, 'QB', HIGH_DEV_STAFF); // round(5 × 1.11) = 6
-    const low  = applyCoachDevModifier(5, 'QB', LOW_DEV_STAFF);  // round(5 × 1.00) = 5
-    expect(high).toBe(6);
-    expect(low).toBe(5);
-    expect(high).toBeGreaterThan(low);
-  });
-
-  it('never touches negative or zero deltas (regression is coach-independent)', () => {
-    expect(applyCoachDevModifier(-3, 'QB', HIGH_DEV_STAFF)).toBe(-3);
-    expect(applyCoachDevModifier(0, 'QB', HIGH_DEV_STAFF)).toBe(0);
-    // Modifier helper is never even consulted for non-positive deltas
-    expect(vi.mocked(getDevelopmentRateModifier)).not.toHaveBeenCalled();
-  });
-
-  it('missing staff is a no-op', () => {
-    expect(applyCoachDevModifier(4, 'QB', null)).toBe(4);
-    expect(applyCoachDevModifier(4, 'QB', undefined)).toBe(4);
-    expect(vi.mocked(getDevelopmentRateModifier)).not.toHaveBeenCalled();
-  });
-
-  it('non-finite modifier returns default to 1.0 (no-op)', () => {
-    vi.mocked(getDevelopmentRateModifier).mockReturnValueOnce(NaN);
-    expect(applyCoachDevModifier(4, 'QB', HIGH_DEV_STAFF)).toBe(4);
-
-    vi.mocked(getDevelopmentRateModifier).mockReturnValueOnce(undefined);
-    expect(applyCoachDevModifier(4, 'QB', HIGH_DEV_STAFF)).toBe(4);
-
-    vi.mocked(getDevelopmentRateModifier).mockReturnValueOnce(Infinity);
-    expect(applyCoachDevModifier(4, 'QB', HIGH_DEV_STAFF)).toBe(4);
-  });
-
-  it('out-of-range modifier returns are clamped to [0.5, 2.0]', () => {
-    vi.mocked(getDevelopmentRateModifier).mockReturnValueOnce(10);
-    expect(applyCoachDevModifier(3, 'QB', HIGH_DEV_STAFF)).toBe(6); // 3 × 2.0
-
-    vi.mocked(getDevelopmentRateModifier).mockReturnValueOnce(0.01);
-    expect(applyCoachDevModifier(4, 'QB', HIGH_DEV_STAFF)).toBe(2); // 4 × 0.5
   });
 });
 

--- a/src/core/progression-logic.js
+++ b/src/core/progression-logic.js
@@ -136,24 +136,6 @@ export function sanitizeCoachDevModifier(rawModifier) {
 }
 
 /**
- * Apply the coaching philosophy development-rate modifier to a progression delta.
- * Positive growth only — regression, aging decline, and zero deltas pass through
- * untouched, as do players on teams with no staff data (multiplier is 1.0).
- *
- * @param {number} ovrDelta  - base OVR delta from the age-curve roll
- * @param {string} position  - player position, e.g. 'QB'
- * @param {object} teamStaff - team.staff object (or null/undefined)
- * @returns {number} adjusted delta (rounded when a multiplier was applied)
- */
-export function applyCoachDevModifier(ovrDelta, position, teamStaff) {
-  if (!(ovrDelta > 0) || !teamStaff) return ovrDelta;
-  const mod = sanitizeCoachDevModifier(
-    getDevelopmentRateModifier(position, teamStaff.headCoach ?? null, teamStaff)
-  );
-  return Math.round(ovrDelta * mod);
-}
-
-/**
  * Apply scheme multiplier and morale bonus to a base OVR delta, clamped to [-5, +5].
  *
  * moraleBonus: +0.5 if morale >= 70, -0.5 if morale <= 30, 0 otherwise.


### PR DESCRIPTION
### Motivation
- `applyCoachDevModifier` was left as a standalone helper after progression wiring switched to the explicit `sanitizeCoachDevModifier(getDevelopmentRateModifier(...)) × getDevTraitMultiplier(...)` path, leaving a dead export and stale tests. 
- The change is cleanup-only to remove unused code while preserving runtime progression behavior and safety rails.

### Description
- Removed the unused `applyCoachDevModifier` export and its implementation from `src/core/progression-logic.js`. 
- Removed the direct helper-only tests and cleaned up the import list in `src/core/__tests__/coaching-dev-modifier-wiring.test.js` while keeping `sanitizeCoachDevModifier` and the `processPlayerProgression` wiring tests intact. 
- Left `sanitizeCoachDevModifier`, the runtime coaching modifier wiring (`getDevelopmentRateModifier(...)` → `sanitizeCoachDevModifier(...)` → `getDevTraitMultiplier(...)` → `combineDevModifiers(...)`), and all progression logic unchanged. 
- Files changed: `src/core/progression-logic.js`, `src/core/__tests__/coaching-dev-modifier-wiring.test.js`.

### Testing
- Searched the repo with `rg -n "applyCoachDevModifier" .` and confirmed it only appeared in the removed export and the dedicated test file. 
- Static check with `node --check src/core/progression-logic.js` succeeded. 
- Ran the targeted test file with `npx vitest run src/core/__tests__/coaching-dev-modifier-wiring.test.js` and it passed (`1 file, 7 tests`). 
- Ran full unit suite with `npm run test:unit` and observed all tests pass (`426 files, 5304 tests passed`). 
- Built the production bundle with `npm run build` and the build completed successfully (with existing chunk-size warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cfebc3d90832da89ba39880ee4fa5)