### PR TITLE
Refactor PlayerProfile Development row to use AttrRow text variant

### DIFF
--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -350,10 +350,20 @@ function getPlayerSummaryChips(player, ringCount, nonRing) {
 }
 
 
-function AttrRow({ label, value }) {
+function AttrRow({ label, value, text = null, muted = false, testId = null }) {
+  // Text variant: renders a label/value pair without the 0-100 track,
+  // e.g. the Development trait label ("Hidden", "Superstar", ...).
+  if (text != null) {
+    return (
+      <div className="attr-row attr-row--text" data-testid={testId ?? undefined}>
+        <span className="attr-label">{label}</span>
+        <span className={`attr-value attr-value--text${muted ? " attr-value--muted" : ""}`}>{text}</span>
+      </div>
+    );
+  }
   const safeValue = Math.max(0, Math.min(100, Number(value ?? 0)));
   return (
-    <div className="attr-row">
+    <div className="attr-row" data-testid={testId ?? undefined}>
       <span className="attr-label">{label}</span>
       <div className="attr-track">
         <div
@@ -1942,15 +1952,12 @@ export default function PlayerProfile({
               <AttrRow label="Morale" value={player?.morale ?? 0} />
               <AttrRow label="Scheme Fit" value={player?.schemeFit ?? 50} />
               {hiddenDevTraitLabel != null && (
-                <div
-                  data-testid="player-profile-dev-trait"
-                  style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: 6 }}
-                >
-                  <span style={{ fontSize: "var(--text-xs)", color: "var(--text-muted)", fontWeight: 700 }}>Development</span>
-                  <span style={{ fontSize: "var(--text-xs)", fontWeight: 700, color: hiddenDevTraitLabel === "Hidden" ? "var(--text-subtle)" : "var(--text)" }}>
-                    {hiddenDevTraitLabel}
-                  </span>
-                </div>
+                <AttrRow
+                  label="Development"
+                  text={hiddenDevTraitLabel}
+                  muted={hiddenDevTraitLabel === "Hidden"}
+                  testId="player-profile-dev-trait"
+                />
               )}
             </section>
           )}

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -1206,6 +1206,9 @@ details[open] .app-hq-background-section__summary span { transform: rotate(180de
 .attr-track { flex: 1; height: 6px; background: var(--surface-overlay); border-radius: var(--radius-pill); overflow: hidden; }
 .attr-fill { height: 100%; border-radius: var(--radius-pill); transition: width var(--duration-slow) var(--ease-out); }
 .attr-value { font-size: var(--text-xs); font-weight: 700; width: 24px; text-align: right; color: var(--text); }
+.attr-row--text { justify-content: space-between; }
+.attr-value--text { width: auto; }
+.attr-value--muted { color: var(--text-subtle); }
 
 .team-hub-lineup-frame {
   display: flex;


### PR DESCRIPTION
Replace the inline-styled hidden dev trait row from #1662 with a small
text variant on AttrRow (label + text value, no 0-100 track), styled by
new attr-row--text / attr-value--text / attr-value--muted classes so the
row shares the Core Attributes section's presentation. Reveal logic,
labels, and the hiddenTrueOvr guard are unchanged.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018AUg19M27NkceTj6MUYube