### PR TITLE
Stabilize Roster Decision Board keys to player-id-only

### DIFF
--- a/src/ui/components/PlayerDecisionRow.jsx
+++ b/src/ui/components/PlayerDecisionRow.jsx
@@ -6,6 +6,11 @@
  * reads `label` / `negotiationRisk`, never re-derives them), and the four
  * local pending-decision pills. All state lives in the parent board; this
  * component never touches league/player/global state.
+ *
+ * Decisions are identified by row.decisionKey (String(player.id), or null
+ * when the player has no usable id). A null decisionKey renders the row
+ * read-only: pills are disabled, onDecide is never called, and a muted
+ * "Decision unavailable" note explains why.
  */
 
 import React from "react";
@@ -31,15 +36,16 @@ function DevTraitBadge({ label }) {
 }
 
 export default function PlayerDecisionRow({ row, decision, onDecide, onPlayerSelect }) {
-  const { player, rowKey, yearsRemaining, annualSalary, meta, devTraitLabel } = row;
+  const { player, decisionKey, renderKey, yearsRemaining, annualSalary, meta, devTraitLabel } = row;
   const pos = player?.pos ?? player?.position ?? "—";
   const name = player?.name ?? "Unknown Player";
   const canOpenProfile = typeof onPlayerSelect === "function" && player?.id != null;
+  const canDecide = decisionKey != null;
 
   return (
     <tr
       className={decision ? "roster-decision-board__row--pending" : undefined}
-      data-testid={`decision-row-${rowKey}`}
+      data-testid={`decision-row-${renderKey}`}
       data-pending={decision ? "true" : "false"}
     >
       <td>
@@ -66,12 +72,18 @@ export default function PlayerDecisionRow({ row, decision, onDecide, onPlayerSel
               type="button"
               className="roster-decision-board__pill"
               aria-pressed={decision === option.key}
-              onClick={() => onDecide(rowKey, option.key)}
+              disabled={!canDecide}
+              onClick={canDecide ? () => onDecide(decisionKey, option.key) : undefined}
             >
               {option.label}
             </button>
           ))}
         </div>
+        {!canDecide && (
+          <span className="roster-decision-board__missing-id-note">
+            Decision unavailable: missing player ID.
+          </span>
+        )}
       </td>
     </tr>
   );

--- a/src/ui/components/RosterDecisionBoard.jsx
+++ b/src/ui/components/RosterDecisionBoard.jsx
@@ -3,8 +3,13 @@
  *
  * Renders a filterable, sortable table of players whose contracts expire
  * within EXPIRING_WINDOW_SEASONS. Presentation + local pending-decision state
- * only: decisions live in a useState map keyed by row, and nothing here
- * mutates league / player / global state.
+ * only: decisions live in a useState map keyed by String(player.id), and
+ * nothing here mutates league / player / global state.
+ *
+ * Decision identity: rows without a usable player.id still render, but their
+ * decision pills are disabled and they can never appear in the decisions map
+ * or the onCommitDecisions payload. The payload is therefore always
+ * { [String(playerId)]: decisionKey } with stable player-id keys only.
  *
  * Data contracts consumed (never re-derived here):
  *  - contract years remaining: contract.years with the established
@@ -51,10 +56,10 @@ function getYearsRemaining(player) {
   return Number.isFinite(years) ? years : null;
 }
 
-function rowKeyFor(player, index) {
+function decisionKeyFor(player) {
   const id = player?.id;
   if (typeof id === "string" || typeof id === "number") return String(id);
-  return `row-${index}`;
+  return null;
 }
 
 function sortValue(row, key) {
@@ -90,9 +95,11 @@ export default function RosterDecisionBoard({ roster, league, onCommitDecisions,
         const yearsRemaining = getYearsRemaining(player);
         if (yearsRemaining == null || yearsRemaining > EXPIRING_WINDOW_SEASONS) return null;
         const meta = player._resignMeta && typeof player._resignMeta === "object" ? player._resignMeta : null;
+        const decisionKey = decisionKeyFor(player);
         return {
           player,
-          rowKey: rowKeyFor(player, index),
+          decisionKey,
+          renderKey: decisionKey ?? `missing-id-${index}`,
           yearsRemaining,
           annualSalary: derivePlayerContractFinancials(player).annualSalary,
           meta,
@@ -138,13 +145,14 @@ export default function RosterDecisionBoard({ roster, league, onCommitDecisions,
     }
   };
 
-  const handleDecide = (rowKey, decisionKey) => {
+  const handleDecide = (playerKey, decisionKey) => {
+    if (playerKey == null) return;
     setDecisions((prev) => {
       const next = { ...prev };
-      if (next[rowKey] === decisionKey) {
-        delete next[rowKey];
+      if (next[playerKey] === decisionKey) {
+        delete next[playerKey];
       } else {
-        next[rowKey] = decisionKey;
+        next[playerKey] = decisionKey;
       }
       return next;
     });
@@ -216,9 +224,9 @@ export default function RosterDecisionBoard({ roster, league, onCommitDecisions,
           <tbody>
             {visibleRows.map((row) => (
               <PlayerDecisionRow
-                key={row.rowKey}
+                key={row.renderKey}
                 row={row}
-                decision={decisions[row.rowKey] ?? null}
+                decision={row.decisionKey != null ? decisions[row.decisionKey] ?? null : null}
                 onDecide={handleDecide}
                 onPlayerSelect={onPlayerSelect}
               />

--- a/src/ui/components/__tests__/RosterDecisionBoard.test.jsx
+++ b/src/ui/components/__tests__/RosterDecisionBoard.test.jsx
@@ -7,7 +7,13 @@
  * `_resignMeta` fallbacks, local-only decision pills, the preview-only
  * commit path, reuse of the hidden dev-trait reveal helper, and that the
  * hiddenTrueOvr sentinel never reaches the DOM.
+ *
+ * Decision identity: decisions are keyed by String(player.id) only. Rows
+ * without a usable id render read-only (disabled pills, muted note) and
+ * never appear in the onCommitDecisions payload.
  */
+import fs from "node:fs";
+import path from "node:path";
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, within, cleanup } from "@testing-library/react";
@@ -80,6 +86,14 @@ function makeRoster() {
       ovr: 71,
       // no contract on purpose
     },
+    {
+      // no id on purpose: renders read-only, never enters the decisions map
+      name: "No ID Ned",
+      pos: "RB",
+      age: 25,
+      ovr: 70,
+      contract: { years: 1, baseAnnual: 2.0 },
+    },
     null, // malformed row must be ignored
   ];
 }
@@ -142,6 +156,54 @@ describe("RosterDecisionBoard", () => {
 
     expect(onCommitDecisions).toHaveBeenCalledTimes(1);
     expect(onCommitDecisions).toHaveBeenCalledWith({ 7: "cut", 8: "extend" });
+  });
+
+  it("renders a missing-id row safely with a muted unavailable note", () => {
+    render(<RosterDecisionBoard roster={makeRoster()} league={{}} />);
+    const row = screen.getByText("No ID Ned").closest("tr");
+    expect(row).toBeTruthy();
+    expect(within(row).getByText("Decision unavailable: missing player ID.")).toBeTruthy();
+  });
+
+  it("disables decision pills for a missing-id row and clicking never marks it pending", () => {
+    render(<RosterDecisionBoard roster={makeRoster()} league={{}} />);
+    const row = screen.getByText("No ID Ned").closest("tr");
+
+    for (const label of ["Extend", "Cut", "Franchise Tag", "Let Walk"]) {
+      const pill = within(row).getByRole("button", { name: label });
+      expect(pill.disabled).toBe(true);
+      fireEvent.click(pill);
+    }
+
+    expect(row.getAttribute("data-pending")).toBe("false");
+    expect(within(row).queryAllByRole("button", { pressed: true })).toHaveLength(0);
+    // Rows with ids stay interactive.
+    expect(within(screen.getByTestId("decision-row-7")).getByRole("button", { name: "Cut" }).disabled).toBe(false);
+  });
+
+  it("never includes missing-id rows in the onCommitDecisions payload", () => {
+    const onCommitDecisions = vi.fn();
+    render(<RosterDecisionBoard roster={makeRoster()} league={{}} onCommitDecisions={onCommitDecisions} />);
+
+    const nedRow = screen.getByText("No ID Ned").closest("tr");
+    fireEvent.click(within(nedRow).getByRole("button", { name: "Cut" }));
+    fireEvent.click(within(screen.getByTestId("decision-row-7")).getByRole("button", { name: "Cut" }));
+    fireEvent.click(screen.getByRole("button", { name: "Commit Decisions" }));
+
+    expect(onCommitDecisions).toHaveBeenCalledTimes(1);
+    const payload = onCommitDecisions.mock.calls[0][0];
+    expect(payload).toEqual({ 7: "cut" });
+    // Stable player-id keys only — no row-index fallbacks of any shape.
+    expect(Object.keys(payload).some((key) => /row|index|missing/i.test(key))).toBe(false);
+  });
+
+  it("pending rows keep the background shift but the inset side-border style is gone", () => {
+    const css = fs.readFileSync(path.resolve(process.cwd(), "src/ui/styles/components.css"), "utf8");
+    const pendingRule = css.match(/\.roster-decision-board__row--pending\s*\{[^}]*\}/);
+    expect(pendingRule).toBeTruthy();
+    expect(pendingRule[0]).toContain("background");
+    expect(pendingRule[0]).not.toContain("box-shadow");
+    expect(css).not.toContain("roster-decision-board__row--pending td:first-child");
   });
 
   it("without onCommitDecisions the commit button is disabled, shows preview state, and never mutates players", () => {

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -1494,9 +1494,6 @@ details[open] .app-hq-background-section__summary span { transform: rotate(180de
 .roster-decision-board__row--pending {
   background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
-.roster-decision-board__row--pending td:first-child {
-  box-shadow: inset 3px 0 0 var(--accent);
-}
 .roster-decision-board__pills {
   display: flex;
   flex-wrap: wrap;
@@ -1518,6 +1515,17 @@ details[open] .app-hq-background-section__summary span { transform: rotate(180de
   background: var(--accent);
   border-color: var(--accent);
   color: #fff;
+}
+.roster-decision-board__pill:disabled {
+  color: var(--text-subtle);
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+.roster-decision-board__missing-id-note {
+  color: var(--text-subtle);
+  display: block;
+  font-size: var(--text-xs);
+  margin-top: var(--space-1);
 }
 .roster-decision-board__dev-badge {
   border: 1px solid var(--hairline);


### PR DESCRIPTION
Prepare the board for future commit actions by removing the fragile
row-${index} fallback decision key:

- Decisions are keyed by String(player.id) only; rows without a usable
  player.id still render but with disabled decision pills, no onDecide
  wiring, and no decisions-map entry, plus a muted
  "Decision unavailable: missing player ID." note.
- React row rendering uses a separate renderKey (id when present,
  missing-id-${index} fallback) so keys stay stable without leaking
  index-based keys into the commit payload.
- onCommitDecisions payload therefore only ever contains stable
  player-id keys ({ [playerId]: decisionKey }).
- Removed the pending-row inset left-border box-shadow; the pending
  background shift remains. Added disabled-pill and missing-id-note
  styles.
- Tests: missing-id row renders safely, pills disabled, excluded from
  commit payload, and pending CSS keeps background without box-shadow.

Board remains presentation-only; no contract/mutation logic touched.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RZpn1vykQkpP3dcVS2poZB