### PR TITLE
Roster Decision Board commit dry-run V1: validated plan preview, no mutations

### DIFF
--- a/src/ui/components/RosterDecisionBoard.jsx
+++ b/src/ui/components/RosterDecisionBoard.jsx
@@ -8,7 +8,7 @@
  *
  * Decision identity: rows without a usable player.id still render, but their
  * decision pills are disabled and they can never appear in the decisions map
- * or the onCommitDecisions payload. The payload is therefore always
+ * or the dry-run commit plan. The payload is therefore always
  * { [String(playerId)]: decisionKey } with stable player-id keys only.
  *
  * Data contracts consumed (never re-derived here):
@@ -21,17 +21,24 @@
  *  - hidden dev trait: getHiddenDevTraitLabel (draftVariance.js) decides
  *    reveal state; hiddenTrueOvr is never read or rendered.
  *
+ * Commit dry-run (V1): "Review Decisions" builds a local, validated commit
+ * plan via buildRosterDecisionCommitPlan and renders it below the board. This
+ * is a preview step only — no contract / cut / tag / extension mutation is
+ * ever called from here.
+ *
  * Props:
  *  - roster: sanitized player array (RosterHub's null-filtered roster)
- *  - league: used only for the dev-trait reveal season context
- *  - onCommitDecisions: optional (decisionsMap) => void; when absent the
- *    board is preview-only and the commit button stays disabled
+ *  - league: dev-trait reveal season context + commit-plan metadata
+ *    (userTeamId / seasonId / phase); read-only
+ *  - onCommitDecisions: optional; reserved for future real-commit wiring (V4).
+ *    Unused by the dry-run flow — Review works with or without it.
  *  - onPlayerSelect: optional (playerId) => void
  */
 
 import React, { useMemo, useState } from "react";
 import { EmptyState } from "./ScreenSystem.jsx";
-import { derivePlayerContractFinancials } from "../utils/contractFormatting.js";
+import { derivePlayerContractFinancials, formatContractMoney } from "../utils/contractFormatting.js";
+import { buildRosterDecisionCommitPlan } from "../utils/rosterDecisionCommitPlan.js";
 import { getHiddenDevTraitLabel } from "../../core/draft/draftVariance.js";
 import PlayerDecisionRow, { DECISION_OPTIONS } from "./PlayerDecisionRow.jsx";
 
@@ -75,8 +82,88 @@ function sortValue(row, key) {
   }
 }
 
+const DECISION_LABELS = Object.fromEntries(DECISION_OPTIONS.map((o) => [o.key, o.label]));
+
+function CommitPlanEntry({ entry }) {
+  const contractBits = [];
+  if (entry.contract.annualSalary != null) contractBits.push(`${formatContractMoney(entry.contract.annualSalary)}/yr`);
+  if (entry.contract.yearsRemaining != null) contractBits.push(`${entry.contract.yearsRemaining}y left`);
+  if (entry.contract.deadCap != null && entry.contract.deadCap > 0) {
+    contractBits.push(`${formatContractMoney(entry.contract.deadCap)} dead cap`);
+  }
+  return (
+    <li className="roster-decision-board__plan-entry" data-testid={`plan-valid-${entry.playerId}`}>
+      <span>
+        <strong>{entry.playerName}</strong>
+        {entry.pos ? ` (${entry.pos})` : ""} — {DECISION_LABELS[entry.decision] ?? entry.decision}
+        {contractBits.length > 0 ? ` · ${contractBits.join(" · ")}` : ""}
+      </span>
+      {entry.blockingErrors.map((message) => (
+        <span key={message} className="roster-decision-board__plan-blocking">{message}</span>
+      ))}
+      {entry.warnings.map((message) => (
+        <span key={message} className="roster-decision-board__plan-warning">{message}</span>
+      ))}
+    </li>
+  );
+}
+
+function CommitPlanSummary({ plan }) {
+  return (
+    <section
+      className="roster-decision-board__dry-run"
+      data-testid="decision-dry-run-summary"
+      aria-label="Commit plan preview"
+    >
+      <div className="roster-decision-board__dry-run-header">
+        <strong>Commit plan preview</strong>
+        <span className="roster-decision-board__dry-run-note">
+          Dry run only — nothing has been applied to your roster yet.
+        </span>
+      </div>
+
+      <div data-testid="dry-run-valid">
+        <h4 className="roster-decision-board__dry-run-heading">
+          Valid decisions ({plan.valid.length})
+        </h4>
+        {plan.valid.length === 0 ? (
+          <p className="roster-decision-board__dry-run-empty">No valid decisions in this plan.</p>
+        ) : (
+          <ul className="roster-decision-board__plan-list">
+            {plan.valid.map((entry) => (
+              <CommitPlanEntry key={entry.playerId} entry={entry} />
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {plan.invalid.length > 0 && (
+        <div data-testid="dry-run-invalid">
+          <h4 className="roster-decision-board__dry-run-heading">
+            Invalid decisions ({plan.invalid.length})
+          </h4>
+          <ul className="roster-decision-board__plan-list">
+            {plan.invalid.map((entry) => (
+              <li
+                key={entry.playerId}
+                className="roster-decision-board__plan-entry roster-decision-board__plan-entry--invalid"
+                data-testid={`plan-invalid-${entry.playerId}`}
+              >
+                Player {entry.playerId} — {DECISION_LABELS[entry.decision] ?? String(entry.decision)}: {entry.reason}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}
+
+// onCommitDecisions is accepted but intentionally unused: reserved for future
+// real-commit wiring (V4). The dry-run review flow never depends on it.
 export default function RosterDecisionBoard({ roster, league, onCommitDecisions, onPlayerSelect }) {
   const [decisions, setDecisions] = useState({});
+  const [commitPlan, setCommitPlan] = useState(null);
   const [search, setSearch] = useState("");
   const [posFilter, setPosFilter] = useState("ALL");
   const [sortKey, setSortKey] = useState("ovr");
@@ -147,6 +234,7 @@ export default function RosterDecisionBoard({ roster, league, onCommitDecisions,
 
   const handleDecide = (playerKey, decisionKey) => {
     if (playerKey == null) return;
+    setCommitPlan(null); // any pending-decision change invalidates the previewed plan
     setDecisions((prev) => {
       const next = { ...prev };
       if (next[playerKey] === decisionKey) {
@@ -159,11 +247,16 @@ export default function RosterDecisionBoard({ roster, league, onCommitDecisions,
   };
 
   const pendingCount = Object.keys(decisions).length;
-  const canCommit = typeof onCommitDecisions === "function";
 
-  const handleCommit = () => {
-    if (!canCommit) return;
-    onCommitDecisions({ ...decisions });
+  const handleReset = () => {
+    setDecisions({});
+    setCommitPlan(null);
+  };
+
+  // Dry run only: builds a local validated plan; never calls mutation handlers.
+  const handleReview = () => {
+    if (pendingCount === 0) return;
+    setCommitPlan(buildRosterDecisionCommitPlan({ decisions: { ...decisions }, roster, league }));
   };
 
   if (rows.length === 0) {
@@ -248,25 +341,25 @@ export default function RosterDecisionBoard({ roster, league, onCommitDecisions,
         </span>
         <div className="roster-decision-board__footer-actions">
           {pendingCount > 0 && (
-            <button type="button" className="btn-link" onClick={() => setDecisions({})}>
+            <button type="button" className="btn-link" onClick={handleReset}>
               Reset
             </button>
           )}
           <button
             type="button"
             className="btn"
-            disabled={!canCommit || pendingCount === 0}
-            onClick={handleCommit}
+            disabled={pendingCount === 0}
+            onClick={handleReview}
           >
-            Commit Decisions
+            Review Decisions
           </button>
-          {!canCommit && (
-            <span className="roster-decision-board__preview-note">
-              Preview only — decisions are not applied yet.
-            </span>
-          )}
+          <span className="roster-decision-board__preview-note">
+            Preview only — reviewing builds a dry-run plan; decisions are not applied yet.
+          </span>
         </div>
       </div>
+
+      {commitPlan != null && <CommitPlanSummary plan={commitPlan} />}
     </div>
   );
 }

--- a/src/ui/components/__tests__/RosterDecisionBoard.test.jsx
+++ b/src/ui/components/__tests__/RosterDecisionBoard.test.jsx
@@ -2,15 +2,16 @@
 /**
  * RosterDecisionBoard.test.jsx
  *
- * Roster Decision Board V2: expiring-contract triage table with local
- * pending-decision state. Verifies the expiring window filter, safe
- * `_resignMeta` fallbacks, local-only decision pills, the preview-only
- * commit path, reuse of the hidden dev-trait reveal helper, and that the
- * hiddenTrueOvr sentinel never reaches the DOM.
+ * Roster Decision Board V2 + commit dry-run V1: expiring-contract triage
+ * table with local pending-decision state. Verifies the expiring window
+ * filter, safe `_resignMeta` fallbacks, local-only decision pills, the
+ * dry-run "Review Decisions" flow (local commit plan, valid/invalid sections,
+ * no mutation handlers called), reuse of the hidden dev-trait reveal helper,
+ * and that the hiddenTrueOvr sentinel never reaches the DOM.
  *
  * Decision identity: decisions are keyed by String(player.id) only. Rows
  * without a usable id render read-only (disabled pills, muted note) and
- * never appear in the onCommitDecisions payload.
+ * never appear in the dry-run commit plan.
  */
 import fs from "node:fs";
 import path from "node:path";
@@ -146,16 +147,87 @@ describe("RosterDecisionBoard", () => {
     expect(screen.getByTestId("decision-row-8").getAttribute("data-pending")).toBe("false");
   });
 
-  it("Commit Decisions calls onCommitDecisions with the local decisions map", () => {
+  it("Review Decisions builds a local dry-run summary and never calls onCommitDecisions", () => {
     const onCommitDecisions = vi.fn();
-    render(<RosterDecisionBoard roster={makeRoster()} league={{}} onCommitDecisions={onCommitDecisions} />);
+    render(
+      <RosterDecisionBoard
+        roster={makeRoster()}
+        league={{ userTeamId: 1, seasonId: 2026 }}
+        onCommitDecisions={onCommitDecisions}
+      />,
+    );
+
+    // No summary before review, and the button enables as soon as decisions are pending.
+    expect(screen.queryByTestId("decision-dry-run-summary")).toBeNull();
+    const review = screen.getByRole("button", { name: "Review Decisions" });
+    expect(review.disabled).toBe(true);
+    fireEvent.click(within(screen.getByTestId("decision-row-7")).getByRole("button", { name: "Cut" }));
+    fireEvent.click(within(screen.getByTestId("decision-row-8")).getByRole("button", { name: "Extend" }));
+    expect(review.disabled).toBe(false);
+
+    fireEvent.click(review);
+
+    // Dry run only: the future real-commit prop is never invoked.
+    expect(onCommitDecisions).not.toHaveBeenCalled();
+    const summary = screen.getByTestId("decision-dry-run-summary");
+    expect(within(summary).getByText(/Dry run only — nothing has been applied/)).toBeTruthy();
+    expect(within(summary).getByText("Valid decisions (2)")).toBeTruthy();
+    expect(within(summary).getByTestId("plan-valid-7").textContent).toContain("Cut Candidate");
+    expect(within(summary).getByTestId("plan-valid-8").textContent).toContain("No Meta Man");
+    // Both decisions were structurally valid → no invalid section rendered.
+    expect(within(summary).queryByTestId("dry-run-invalid")).toBeNull();
+  });
+
+  it("dry-run summary shows valid and invalid decisions separately", () => {
+    const roster = makeRoster();
+    const { rerender } = render(<RosterDecisionBoard roster={roster} league={{}} />);
 
     fireEvent.click(within(screen.getByTestId("decision-row-7")).getByRole("button", { name: "Cut" }));
     fireEvent.click(within(screen.getByTestId("decision-row-8")).getByRole("button", { name: "Extend" }));
-    fireEvent.click(screen.getByRole("button", { name: "Commit Decisions" }));
 
-    expect(onCommitDecisions).toHaveBeenCalledTimes(1);
-    expect(onCommitDecisions).toHaveBeenCalledWith({ 7: "cut", 8: "extend" });
+    // Player 7 leaves the roster while their pending decision survives in
+    // local state — reviewing must now split the plan into valid + invalid.
+    rerender(<RosterDecisionBoard roster={roster.filter((p) => p?.id !== 7)} league={{}} />);
+    fireEvent.click(screen.getByRole("button", { name: "Review Decisions" }));
+
+    const summary = screen.getByTestId("decision-dry-run-summary");
+    expect(within(summary).getByText("Valid decisions (1)")).toBeTruthy();
+    expect(within(summary).getByTestId("plan-valid-8").textContent).toContain("No Meta Man");
+    expect(within(summary).getByText("Invalid decisions (1)")).toBeTruthy();
+    expect(within(summary).getByTestId("plan-invalid-7").textContent).toContain("No roster player matches this ID.");
+  });
+
+  it("cut and franchise-tag entries surface warnings in the dry-run summary", () => {
+    const roster = makeRoster();
+    // Give the cut candidate a signing bonus so releasing them carries dead cap.
+    roster[0] = { ...roster[0], contract: { ...roster[0].contract, yearsTotal: 4, signingBonus: 6 } };
+    render(<RosterDecisionBoard roster={roster} league={{ phase: "regular" }} />);
+
+    fireEvent.click(within(screen.getByTestId("decision-row-7")).getByRole("button", { name: "Cut" }));
+    fireEvent.click(within(screen.getByTestId("decision-row-8")).getByRole("button", { name: "Franchise Tag" }));
+    fireEvent.click(screen.getByRole("button", { name: "Review Decisions" }));
+
+    const summary = screen.getByTestId("decision-dry-run-summary");
+    expect(within(summary).getByTestId("plan-valid-7").textContent).toMatch(/dead cap/i);
+    // No Meta Man has 2 years left → tag is blocked as not expiring now.
+    expect(within(summary).getByTestId("plan-valid-8").textContent).toMatch(/not expiring/i);
+  });
+
+  it("changing or resetting decisions clears a stale dry-run summary", () => {
+    render(<RosterDecisionBoard roster={makeRoster()} league={{}} />);
+    const row = screen.getByTestId("decision-row-7");
+
+    fireEvent.click(within(row).getByRole("button", { name: "Cut" }));
+    fireEvent.click(screen.getByRole("button", { name: "Review Decisions" }));
+    expect(screen.getByTestId("decision-dry-run-summary")).toBeTruthy();
+
+    fireEvent.click(within(row).getByRole("button", { name: "Extend" }));
+    expect(screen.queryByTestId("decision-dry-run-summary")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Review Decisions" }));
+    expect(screen.getByTestId("decision-dry-run-summary")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Reset" }));
+    expect(screen.queryByTestId("decision-dry-run-summary")).toBeNull();
   });
 
   it("renders a missing-id row safely with a muted unavailable note", () => {
@@ -181,20 +253,20 @@ describe("RosterDecisionBoard", () => {
     expect(within(screen.getByTestId("decision-row-7")).getByRole("button", { name: "Cut" }).disabled).toBe(false);
   });
 
-  it("never includes missing-id rows in the onCommitDecisions payload", () => {
-    const onCommitDecisions = vi.fn();
-    render(<RosterDecisionBoard roster={makeRoster()} league={{}} onCommitDecisions={onCommitDecisions} />);
+  it("never includes missing-id rows in the dry-run commit plan", () => {
+    render(<RosterDecisionBoard roster={makeRoster()} league={{}} />);
 
     const nedRow = screen.getByText("No ID Ned").closest("tr");
     fireEvent.click(within(nedRow).getByRole("button", { name: "Cut" }));
     fireEvent.click(within(screen.getByTestId("decision-row-7")).getByRole("button", { name: "Cut" }));
-    fireEvent.click(screen.getByRole("button", { name: "Commit Decisions" }));
+    fireEvent.click(screen.getByRole("button", { name: "Review Decisions" }));
 
-    expect(onCommitDecisions).toHaveBeenCalledTimes(1);
-    const payload = onCommitDecisions.mock.calls[0][0];
-    expect(payload).toEqual({ 7: "cut" });
-    // Stable player-id keys only — no row-index fallbacks of any shape.
-    expect(Object.keys(payload).some((key) => /row|index|missing/i.test(key))).toBe(false);
+    const summary = screen.getByTestId("decision-dry-run-summary");
+    // Only the stable-id decision made it into the plan.
+    expect(within(summary).getByText("Valid decisions (1)")).toBeTruthy();
+    expect(within(summary).getByTestId("plan-valid-7")).toBeTruthy();
+    expect(within(summary).queryByTestId("dry-run-invalid")).toBeNull();
+    expect(summary.textContent).not.toContain("No ID Ned");
   });
 
   it("pending rows keep the background shift but the inset side-border style is gone", () => {
@@ -206,20 +278,25 @@ describe("RosterDecisionBoard", () => {
     expect(css).not.toContain("roster-decision-board__row--pending td:first-child");
   });
 
-  it("without onCommitDecisions the commit button is disabled, shows preview state, and never mutates players", () => {
-    // Frozen players prove render + interaction never write to player objects.
+  it("works preview-only without onCommitDecisions and never mutates players or the league", () => {
+    // Frozen players prove render + review never write to player objects.
     const roster = makeRoster().map((p) => (p ? Object.freeze(p) : p));
-    render(<RosterDecisionBoard roster={roster} league={{}} />);
+    const league = Object.freeze({ userTeamId: 1, seasonId: 2026 });
+    render(<RosterDecisionBoard roster={roster} league={league} />);
 
-    const commit = screen.getByRole("button", { name: "Commit Decisions" });
-    expect(commit.disabled).toBe(true);
     expect(screen.getByText(/Preview only/)).toBeTruthy();
+    const review = screen.getByRole("button", { name: "Review Decisions" });
+    expect(review.disabled).toBe(true);
 
     expect(() => {
       fireEvent.click(within(screen.getByTestId("decision-row-7")).getByRole("button", { name: "Cut" }));
-      fireEvent.click(commit);
+      fireEvent.click(review);
     }).not.toThrow();
+
+    // Reviewing rendered the dry-run summary without touching any state.
+    expect(screen.getByTestId("decision-dry-run-summary")).toBeTruthy();
     expect(roster[0].extensionDecision).toBeUndefined();
+    expect(roster[0].contract).toEqual({ years: 1, baseAnnual: 8.5 });
   });
 
   it("never renders the hiddenTrueOvr sentinel in the DOM", () => {
@@ -260,7 +337,7 @@ describe("RosterHub Decision Board tab", () => {
     expect(screen.getByTestId("roster-decision-board")).toBeTruthy();
     expect(screen.getByText("Cut Candidate")).toBeTruthy();
     expect(screen.queryByText("Long Deal Larry")).toBeNull();
-    // RosterHub has no safe batch-commit action yet → preview-only.
-    expect(screen.getByRole("button", { name: "Commit Decisions" }).disabled).toBe(true);
+    // Review stays disabled until a decision is pending; no commit wiring needed.
+    expect(screen.getByRole("button", { name: "Review Decisions" }).disabled).toBe(true);
   });
 });

--- a/src/ui/styles/components.css
+++ b/src/ui/styles/components.css
@@ -1561,3 +1561,52 @@ details[open] .app-hq-background-section__summary span { transform: rotate(180de
   color: var(--text-muted);
   font-size: var(--text-xs);
 }
+.roster-decision-board__dry-run {
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+  padding: var(--space-2);
+}
+.roster-decision-board__dry-run-header {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+.roster-decision-board__dry-run-note,
+.roster-decision-board__dry-run-empty {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+.roster-decision-board__dry-run-heading {
+  font-size: var(--text-sm);
+  margin: 0 0 var(--space-1);
+}
+.roster-decision-board__plan-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.roster-decision-board__plan-entry {
+  display: flex;
+  flex-direction: column;
+  font-size: var(--text-sm);
+  gap: 2px;
+}
+.roster-decision-board__plan-entry--invalid {
+  color: var(--danger);
+}
+.roster-decision-board__plan-warning {
+  color: var(--warning);
+  font-size: var(--text-xs);
+}
+.roster-decision-board__plan-blocking {
+  color: var(--danger);
+  font-size: var(--text-xs);
+}

--- a/src/ui/utils/rosterDecisionCommitPlan.js
+++ b/src/ui/utils/rosterDecisionCommitPlan.js
@@ -1,0 +1,171 @@
+/**
+ * rosterDecisionCommitPlan.js — dry-run validation for Roster Decision Board commits.
+ *
+ * Converts the board's pending-decision payload ({ [playerId]: decisionKey },
+ * stable player-id keys only — see PR #1667) into a validated commit plan that
+ * can be reviewed before any real roster mutation is wired up. Pure function:
+ * no cache access, no worker calls, no league/player/global writes.
+ *
+ * Mutation-handler audit (V1, read-only — nothing here calls these):
+ *  - extend        → actions.extendContract (useWorker.js → toWorker.EXTEND_CONTRACT)
+ *  - cut           → actions.releasePlayer / bulkReleasePlayers (toWorker.RELEASE_PLAYER;
+ *                    worker splits dead cap by phase — this plan uses the conservative
+ *                    pre-June-1 preview from calculateReleaseDeadCap)
+ *  - franchise_tag → actions.applyFranchiseTag (toWorker.APPLY_FRANCHISE_TAG; the worker
+ *                    requires the player on the team and league phase 'offseason_resign')
+ *  - let_walk      → no roster mutation exists; ContractCenter only records intent via
+ *                    actions.updatePlayerManagement({ extensionDecision: 'let_walk' })
+ */
+
+import { derivePlayerContractFinancials, formatContractMoney } from "./contractFormatting.js";
+import { calculateReleaseDeadCap } from "../../core/contracts/contractObligations.js";
+
+export const ROSTER_DECISION_KEYS = Object.freeze(["extend", "cut", "franchise_tag", "let_walk"]);
+
+/**
+ * Results of the handler audit above. `false` means the decision has no real
+ * roster-mutation handler today and can only ever be a planning note; the plan
+ * surfaces that as a warning on the entry.
+ */
+const DECISION_HANDLER_EXISTS = Object.freeze({
+  extend: true,
+  cut: true,
+  franchise_tag: true,
+  let_walk: false,
+});
+
+/** Phase the worker's APPLY_FRANCHISE_TAG handler requires. */
+const FRANCHISE_TAG_PHASE = "offseason_resign";
+
+/**
+ * Contract years remaining with the board's exact fallback chain
+ * (contract.years → yearsLeft → yearsRemaining). Returns null when the value
+ * cannot be determined — callers must not guess.
+ */
+function getYearsRemaining(player) {
+  const contract = player?.contract;
+  if (contract == null || typeof contract !== "object") return null;
+  const years = Number(contract.years ?? contract.yearsLeft ?? contract.yearsRemaining);
+  return Number.isFinite(years) ? years : null;
+}
+
+function buildValidEntry({ playerId, decision, player, league }) {
+  const yearsRemaining = getYearsRemaining(player);
+  const { annualSalary } = derivePlayerContractFinancials(player);
+  const deadCapTotal = calculateReleaseDeadCap(player).total;
+  const deadCap = Number.isFinite(deadCapTotal) ? deadCapTotal : null;
+  const warnings = [];
+  const blockingErrors = [];
+
+  switch (decision) {
+    case "extend":
+      if (!DECISION_HANDLER_EXISTS.extend) {
+        warnings.push("No extension action/handler is available yet — this stays a planning note.");
+      }
+      break;
+    case "cut":
+      if (deadCap != null && deadCap > 0) {
+        warnings.push(`Releasing this player would incur ${formatContractMoney(deadCap)} in dead cap.`);
+      }
+      break;
+    case "franchise_tag": {
+      if (yearsRemaining == null) {
+        warnings.push("Tag availability could not be determined: contract expiration is unknown.");
+      } else if (yearsRemaining > 1) {
+        blockingErrors.push(
+          `Franchise tag unavailable: contract has ${yearsRemaining} years remaining and is not expiring now.`,
+        );
+      } else {
+        const phase = league?.phase != null ? String(league.phase) : null;
+        if (phase == null) {
+          warnings.push("Tag window could not be verified: league phase is unknown.");
+        } else if (phase !== FRANCHISE_TAG_PHASE) {
+          warnings.push(
+            `Franchise tags are applied during the re-signing phase; current phase is "${phase}".`,
+          );
+        }
+      }
+      break;
+    }
+    case "let_walk":
+      warnings.push(
+        "Planning note only — letting a player walk is not an immediate roster change; the contract expires on its own.",
+      );
+      break;
+    default:
+      break;
+  }
+
+  return {
+    playerId,
+    decision,
+    playerName: player?.name ?? "Unknown Player",
+    pos: player?.pos ?? player?.position ?? null,
+    contract: {
+      yearsRemaining,
+      annualSalary: annualSalary ?? null,
+      deadCap,
+    },
+    warnings,
+    blockingErrors,
+  };
+}
+
+/**
+ * Build a dry-run commit plan from pending board decisions.
+ *
+ * @param {object} args
+ * @param {object} args.decisions - { [playerId]: decisionKey } payload from the board
+ * @param {object[]} args.roster  - sanitized roster array the board rendered from
+ * @param {object} args.league    - league snapshot (userTeamId / seasonId / year / phase)
+ * @returns {{
+ *   source: 'roster_decision_board', version: 1,
+ *   teamId: *, season: *,
+ *   valid: Array<{playerId, decision, playerName, pos, contract, warnings, blockingErrors}>,
+ *   invalid: Array<{playerId, decision, reason}>,
+ * }}
+ */
+export function buildRosterDecisionCommitPlan({ decisions, roster, league } = {}) {
+  const plan = {
+    source: "roster_decision_board",
+    version: 1,
+    teamId: league?.userTeamId ?? null,
+    season: league?.seasonId ?? league?.year ?? null,
+    valid: [],
+    invalid: [],
+  };
+
+  if (decisions == null || typeof decisions !== "object" || Array.isArray(decisions)) {
+    return plan;
+  }
+
+  const rosterAvailable = Array.isArray(roster);
+  const rosterById = new Map();
+  if (rosterAvailable) {
+    for (const player of roster) {
+      const id = player?.id;
+      if (typeof id === "string" || typeof id === "number") {
+        rosterById.set(String(id), player);
+      }
+    }
+  }
+
+  for (const [playerId, decision] of Object.entries(decisions)) {
+    if (!ROSTER_DECISION_KEYS.includes(decision)) {
+      plan.invalid.push({ playerId, decision, reason: `Unsupported decision "${String(decision)}".` });
+      continue;
+    }
+    if (!rosterAvailable) {
+      plan.invalid.push({ playerId, decision, reason: "Roster data unavailable — cannot match player." });
+      continue;
+    }
+    const player = rosterById.get(String(playerId));
+    if (player == null) {
+      plan.invalid.push({ playerId, decision, reason: "No roster player matches this ID." });
+      continue;
+    }
+    plan.valid.push(buildValidEntry({ playerId, decision, player, league }));
+  }
+
+  return plan;
+}

--- a/src/ui/utils/rosterDecisionCommitPlan.test.js
+++ b/src/ui/utils/rosterDecisionCommitPlan.test.js
@@ -1,0 +1,212 @@
+/**
+ * rosterDecisionCommitPlan.test.js
+ *
+ * Dry-run commit plan builder for the Roster Decision Board. Pure-function
+ * contract: valid entries carry contract context + warnings/blockingErrors,
+ * structural failures (missing player, unsupported decision, missing roster)
+ * land in `invalid`, malformed input degrades to an empty plan, and no input
+ * object is ever mutated.
+ */
+import { describe, it, expect } from "vitest";
+import { buildRosterDecisionCommitPlan, ROSTER_DECISION_KEYS } from "./rosterDecisionCommitPlan.js";
+
+const LEAGUE = { userTeamId: 3, seasonId: 2027, phase: "offseason_resign" };
+
+function makeRoster() {
+  return [
+    {
+      id: 7,
+      name: "Cut Candidate",
+      pos: "QB",
+      contract: { years: 1, yearsTotal: 4, baseAnnual: 8.5, signingBonus: 6 },
+    },
+    {
+      id: 8,
+      name: "Clean Cut",
+      pos: "WR",
+      contract: { years: 1, baseAnnual: 3.2 },
+    },
+    {
+      id: 9,
+      name: "Long Deal Larry",
+      pos: "OL",
+      contract: { years: 2, baseAnnual: 6.4 },
+    },
+    {
+      id: 10,
+      name: "No Contract Nick",
+      pos: "CB",
+    },
+  ];
+}
+
+describe("buildRosterDecisionCommitPlan", () => {
+  it("produces a valid commit plan with the documented shape for a valid payload", () => {
+    const plan = buildRosterDecisionCommitPlan({
+      decisions: { 7: "extend", 8: "cut" },
+      roster: makeRoster(),
+      league: LEAGUE,
+    });
+
+    expect(plan.source).toBe("roster_decision_board");
+    expect(plan.version).toBe(1);
+    expect(plan.teamId).toBe(3);
+    expect(plan.season).toBe(2027);
+    expect(plan.invalid).toEqual([]);
+    expect(plan.valid).toHaveLength(2);
+
+    const extend = plan.valid.find((e) => e.decision === "extend");
+    expect(extend).toMatchObject({
+      playerId: "7",
+      playerName: "Cut Candidate",
+      pos: "QB",
+      contract: { yearsRemaining: 1, annualSalary: 8.5 },
+      blockingErrors: [],
+    });
+    // extendContract handler exists (audit) → no missing-handler warning.
+    expect(extend.warnings).toEqual([]);
+  });
+
+  it("falls back to league.year for season and null team/season when league is missing", () => {
+    expect(buildRosterDecisionCommitPlan({ decisions: {}, roster: [], league: { year: 2031 } }).season).toBe(2031);
+    const plan = buildRosterDecisionCommitPlan({ decisions: { 7: "cut" }, roster: makeRoster() });
+    expect(plan.teamId).toBeNull();
+    expect(plan.season).toBeNull();
+    expect(plan.valid).toHaveLength(1); // missing league never throws or invalidates
+  });
+
+  it("marks a player ID that matches no roster player as invalid", () => {
+    const plan = buildRosterDecisionCommitPlan({
+      decisions: { 999: "cut", 7: "cut" },
+      roster: makeRoster(),
+      league: LEAGUE,
+    });
+    expect(plan.valid.map((e) => e.playerId)).toEqual(["7"]);
+    expect(plan.invalid).toEqual([
+      { playerId: "999", decision: "cut", reason: "No roster player matches this ID." },
+    ]);
+  });
+
+  it("marks unsupported decisions as invalid", () => {
+    const plan = buildRosterDecisionCommitPlan({
+      decisions: { 7: "trade", 8: null, 9: 42 },
+      roster: makeRoster(),
+      league: LEAGUE,
+    });
+    expect(plan.valid).toEqual([]);
+    expect(plan.invalid).toHaveLength(3);
+    expect(plan.invalid[0]).toEqual({ playerId: "7", decision: "trade", reason: 'Unsupported decision "trade".' });
+  });
+
+  it("returns an empty plan for a missing or malformed decisions map", () => {
+    for (const decisions of [undefined, null, "cut", 42, ["cut"]]) {
+      const plan = buildRosterDecisionCommitPlan({ decisions, roster: makeRoster(), league: LEAGUE });
+      expect(plan.valid).toEqual([]);
+      expect(plan.invalid).toEqual([]);
+    }
+  });
+
+  it("returns invalid entries for every supplied decision when the roster is missing", () => {
+    const plan = buildRosterDecisionCommitPlan({
+      decisions: { 7: "extend", 8: "cut" },
+      roster: undefined,
+      league: LEAGUE,
+    });
+    expect(plan.valid).toEqual([]);
+    expect(plan.invalid).toEqual([
+      { playerId: "7", decision: "extend", reason: "Roster data unavailable — cannot match player." },
+      { playerId: "8", decision: "cut", reason: "Roster data unavailable — cannot match player." },
+    ]);
+  });
+
+  it("cut warns when dead-cap data exists and is non-zero, stays quiet otherwise", () => {
+    const plan = buildRosterDecisionCommitPlan({
+      decisions: { 7: "cut", 8: "cut" },
+      roster: makeRoster(),
+      league: LEAGUE,
+    });
+    const withBonus = plan.valid.find((e) => e.playerId === "7");
+    const withoutBonus = plan.valid.find((e) => e.playerId === "8");
+    // 6M bonus / 4 yearsTotal × 1 year remaining = 1.5M dead cap.
+    expect(withBonus.contract.deadCap).toBe(1.5);
+    expect(withBonus.warnings.some((w) => /dead cap/i.test(w))).toBe(true);
+    expect(withBonus.blockingErrors).toEqual([]);
+    expect(withoutBonus.contract.deadCap).toBe(0);
+    expect(withoutBonus.warnings).toEqual([]);
+  });
+
+  it("franchise_tag blocks a player who is not expiring now", () => {
+    const plan = buildRosterDecisionCommitPlan({
+      decisions: { 9: "franchise_tag" },
+      roster: makeRoster(),
+      league: LEAGUE,
+    });
+    const entry = plan.valid[0];
+    expect(entry.blockingErrors).toHaveLength(1);
+    expect(entry.blockingErrors[0]).toMatch(/not expiring/i);
+  });
+
+  it("franchise_tag on an expiring player is valid during the re-signing phase, warns outside it", () => {
+    const expiring = buildRosterDecisionCommitPlan({
+      decisions: { 7: "franchise_tag" },
+      roster: makeRoster(),
+      league: LEAGUE,
+    }).valid[0];
+    expect(expiring.blockingErrors).toEqual([]);
+    expect(expiring.warnings).toEqual([]);
+
+    const wrongPhase = buildRosterDecisionCommitPlan({
+      decisions: { 7: "franchise_tag" },
+      roster: makeRoster(),
+      league: { ...LEAGUE, phase: "regular" },
+    }).valid[0];
+    expect(wrongPhase.blockingErrors).toEqual([]);
+    expect(wrongPhase.warnings.some((w) => /re-signing phase/i.test(w))).toBe(true);
+  });
+
+  it("franchise_tag warns instead of guessing when availability cannot be determined", () => {
+    // No contract → expiration unknown.
+    const noContract = buildRosterDecisionCommitPlan({
+      decisions: { 10: "franchise_tag" },
+      roster: makeRoster(),
+      league: LEAGUE,
+    }).valid[0];
+    expect(noContract.blockingErrors).toEqual([]);
+    expect(noContract.warnings.some((w) => /could not be determined/i.test(w))).toBe(true);
+
+    // Expiring player but league phase unknown.
+    const noPhase = buildRosterDecisionCommitPlan({
+      decisions: { 7: "franchise_tag" },
+      roster: makeRoster(),
+      league: { userTeamId: 3, seasonId: 2027 },
+    }).valid[0];
+    expect(noPhase.blockingErrors).toEqual([]);
+    expect(noPhase.warnings.some((w) => /could not be verified/i.test(w))).toBe(true);
+  });
+
+  it("let_walk is valid but flagged as a planning-only note", () => {
+    const plan = buildRosterDecisionCommitPlan({
+      decisions: { 7: "let_walk" },
+      roster: makeRoster(),
+      league: LEAGUE,
+    });
+    const entry = plan.valid[0];
+    expect(entry.blockingErrors).toEqual([]);
+    expect(entry.warnings.some((w) => /planning note only/i.test(w))).toBe(true);
+  });
+
+  it("never mutates decisions, roster, players, or league", () => {
+    const roster = makeRoster().map((p) => Object.freeze({ ...p, contract: p.contract ? Object.freeze({ ...p.contract }) : undefined }));
+    Object.freeze(roster);
+    const decisions = Object.freeze({ 7: "cut", 8: "franchise_tag", 9: "extend", 999: "let_walk", 10: "bogus" });
+    const league = Object.freeze({ ...LEAGUE });
+
+    const before = JSON.stringify({ roster, decisions, league });
+    expect(() => buildRosterDecisionCommitPlan({ decisions, roster, league })).not.toThrow();
+    expect(JSON.stringify({ roster, decisions, league })).toBe(before);
+  });
+
+  it("exposes exactly the four supported decision keys", () => {
+    expect([...ROSTER_DECISION_KEYS]).toEqual(["extend", "cut", "franchise_tag", "let_walk"]);
+  });
+});


### PR DESCRIPTION
Add buildRosterDecisionCommitPlan (src/ui/utils/rosterDecisionCommitPlan.js),
a pure helper that converts the board's stable player-id decision payload
into a { source, version, teamId, season, valid, invalid } commit plan:

- extend / cut / franchise_tag / let_walk validated per decision rules
- cut warns on non-zero dead cap (calculateReleaseDeadCap preview)
- franchise_tag blocks non-expiring players, warns when expiration or the
  re-signing phase window cannot be determined instead of guessing
- let_walk is flagged as a planning-only note (no roster mutation exists)
- missing players / unsupported decisions land in invalid; malformed
  decisions or missing roster/league degrade safely without throwing

The board's primary button becomes "Review Decisions": enabled whenever
decisions are pending, builds the local dry-run plan, and renders a
valid/invalid summary below the table. onCommitDecisions is preserved but
unused (reserved for future real-commit wiring); no contract, cut, tag, or
extension handlers are ever called and no league/player state is written.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SbNqHMKSa7RY2nLU6S4VGH