### PR TITLE
Whole-Codebase Stabilization Audit + Safe Fixes V1

### DIFF
--- a/docs/stabilization-audit-v1-2026-07.md
+++ b/docs/stabilization-audit-v1-2026-07.md
@@ -1,0 +1,77 @@
+# Whole-Codebase Stabilization Audit + Safe Fixes V1 — July 2026
+
+Scope: stabilization and risk-reduction pass across app stability, worker/action
+architecture, simulation safety, UI/UX integrity, and test gaps. Only localized,
+low-risk, testable P0/P1 fixes were implemented; everything else is recorded
+here as the handoff roadmap.
+
+Baseline before changes: 428 unit test files / 5346 tests, all passing.
+
+---
+
+## A. Audit summary
+
+| # | Area | Issue | Severity | Why it matters | Status |
+|---|------|-------|----------|----------------|--------|
+| 1 | Worker actions — release/cut | `handleReleasePlayer` ignored the `releasePlayerWithValidation` outcome. A failed release (player not found / not on the selected roster — stale UI, double-click, wrong team) posted a normal `STATE_UPDATE` and no `ERROR`, so the UI (Roster, Decision Board "dispatched" copy) treated the failure as success. | **P1** | Fire-and-forget action overstated success; user believes a cut happened when it did not. | **Fixed** |
+| 2 | Worker actions — bulk release | `toUI.SUCCESS` was posted by `handleBulkReleasePlayers` but never defined in `protocol.js` → messages went out with `type: undefined`. Separately, `STATE_UPDATE` was posted with the request id *before* `SUCCESS`, so the caller's promise (which resolves on the first message carrying the id) resolved with the view-state payload — no `ok`/`released`. | **P1** | Combined with #3, every successful bulk release was reported to the user as a failure. | **Fixed** |
+| 3 | UI — Roster bulk release | `confirmBulkRelease` read `result?.ok` from a `{ type, payload }` envelope (always `undefined`) → success showed the "Bulk release stopped after 0 release(s): Unknown error" alert. A rejected promise (worker ERROR on partial stop) escaped the handler → unhandled rejection, preview modal stuck open, selections not cleared. | **P1** | Incorrect user-facing outcome reporting on a destructive action; stuck modal on partial failure. | **Fixed** |
+| 4 | Hidden data leak | `buildViewState()` serialized raw cache player objects into `league.teams[].roster`, including `hiddenTrueOvr` — the hidden draft-variance anchor documented as "internal-only and must never be rendered" (`draftVariance.js`). Not rendered by any component (sentinel tests cover that), but fully inspectable from the UI thread via devtools/console. | **P1** | Defeats the hidden draft-variance system for savvy users; contradicts the documented data contract. | **Fixed** (field stripped worker-side) |
+| 5 | Hidden data leak | `hiddenDevTrait` is serialized to the UI pre-reveal (the reveal helpers need to know it exists to render the "Hidden" chip). The *value* is devtools-inspectable before the ~2-season reveal. | P2 | Softer leak than #4; masking it requires a worker-side reveal computation and a UI contract change (e.g. `hasHiddenDevTrait` boolean + value only after reveal). | Deferred |
+| 6 | Data-path inconsistency | `GET_ROSTER` (rosterHandlers.js) whitelists player fields and does **not** include `hiddenDevTrait`/`ovrHistory`, while `league.teams[].roster` (buildViewState) does. Screens fed by `getRoster` can never show the dev-trait row; screens fed by league state can. | P2 | Feature appears/disappears depending on which data path fed the screen. | Deferred |
+| 7 | Advance Week flow | `WEEK_COMPLETE` reducer replaces `league.teams` with slim standings rows (no roster/cap fields) until the follow-up `STATE_UPDATE` restores full teams. One-message window of empty roster/cap data; RosterHub's guards render empty states rather than crash. | P2 | Transient flash only, self-heals within the same message batch; a reducer merge (instead of replace) would remove it. | Deferred |
+| 8 | UI feedback | `handleTag` / `handleRestructure` in Roster.jsx `await` request-based actions with no try/catch → worker ERROR causes an unhandled rejection. The global error banner still appears (the hook's message switch dispatches `ERROR` even after rejecting the pending promise), so user feedback exists; the rejection is console noise. | P3 | Console noise; feedback path already works via the banner. | Deferred |
+| 9 | Dead code | `handleApplyFranchiseTag` computes an unused `baseline` variable. | P3 | Cosmetic. | Deferred |
+| 10 | Free agency | `handleGetFreeAgents` top-bid loop reads `o.contract.baseAnnual` without a null guard on `o.contract`. All current offer-creation paths attach a contract, so no observed crash path. | P3 | Would only bite if a malformed offer ever persisted. | Deferred (report-only) |
+| 11 | Save/migration | `migrateSaveMetaToCurrent` chain reviewed (v0 → 5.7): monotonic version bumps, no gaps, future-versioned saves pass through untouched. `migrateV56ToV57` uses `String(Math.random())` only as a last-resort offer-id fallback. | OK | — | No action |
+| 12 | Draft | `buildDraftStateView` prospects are whitelisted; `trueOvr` explicitly not exposed. `truePotential` **is** exposed alongside fogged `potential` — appears intentional (existing UI consumes it), flagging for owner review. | P2/report | If unintended, scouting fog on potential is defeated. Do not change without product intent. | Deferred (needs owner decision) |
+| 13 | Decision Board execution | `rosterDecisionCommitPlan` / `rosterDecisionCommitExecution` / `RosterDecisionBoard` reviewed: stale-plan guard, re-entrancy ref, dispatched-vs-applied copy, and id-only payloads are all correct. Release entries reported as "dispatched" are accurate — and with fix #1, a failed dispatch now surfaces through the error banner instead of silently passing. | OK | — | No action |
+| 14 | useWorker hook | Epoch/boot-scope stale-packet guards, request timeout handling, duplicate-id guard, and localStorage manifest mirroring reviewed — sound. `send()`-based actions clear `busy` via `STATE_UPDATE`/`ERROR` in all paths after fix #1. | OK | — | No action |
+| 15 | Franchise tag / player management | `handleApplyFranchiseTag` (team/player/phase validation) and `handleUpdatePlayerManagement` (whitelisted enums, no-op rejection) reviewed — sound. | OK | — | No action |
+
+## B. Fix summary
+
+### Fix 1 — Failed single release silently succeeded
+- **Files:** `src/worker/worker.js` (`handleReleasePlayer`)
+- **Before:** validation outcome discarded; failed release posted a success-shaped `STATE_UPDATE`.
+- **After:** failure posts `ERROR` ("Release failed: …") with the request id and returns; the reducer surfaces it in the error banner and clears `busy`. Success path unchanged. `releasePlayerWithValidation` is mutation-free on failure, so no flush/refresh is needed on that branch.
+- **Tests:** `src/worker/__tests__/releaseHandlerGuards.test.js` (source-sentinel suite, matching the repo's `loadPipelineRegression.test.js` idiom for the worker monolith).
+
+### Fix 2 — Bulk release protocol + ordering
+- **Files:** `src/worker/protocol.js`, `src/worker/worker.js` (`handleBulkReleasePlayers`)
+- **Before:** `toUI.SUCCESS` undefined (`type: undefined` on the wire); `STATE_UPDATE` carried the request id and resolved the caller's promise before `SUCCESS` was posted.
+- **After:** `SUCCESS` defined in the protocol; posted with the request id *before* the refresh `STATE_UPDATE` (which no longer carries the id). Failure path ERROR now includes the released-so-far count and still refreshes state.
+- **Tests:** `releaseHandlerGuards.test.js` — protocol contract (`toUI.SUCCESS` defined; no undefined `toUI.*` member used anywhere in worker.js), ordering assertions, id-free refresh posts.
+
+### Fix 3 — Roster bulk release confirm flow
+- **Files:** `src/ui/components/Roster.jsx` (`confirmBulkRelease`)
+- **Before:** read `result?.ok` (always undefined) → false failure alert on every success; rejection escaped → stuck modal + unhandled rejection.
+- **After:** reads `result?.payload?.ok`; try/catch surfaces the worker's rejection message via the existing alert; `finally` always closes the modal, clears selection, refetches.
+- **Tests:** `src/ui/components/__tests__/RosterBulkRelease.test.jsx` — full UI drive (bulk mode → select visible → preview → confirm) for both the success path (no alert, modal closes, correct payload `(teamId, [ids])`) and the rejected path (worker message alerted, modal closes).
+
+### Fix 4 — `hiddenTrueOvr` stripped from UI payloads
+- **Files:** `src/worker/viewStateStats.js` (new `sanitizeRosterForClient`), `src/worker/worker.js` (`buildViewState` wraps each team roster)
+- **Before:** every `FULL_STATE`/`STATE_UPDATE` carried `hiddenTrueOvr` for every rostered player.
+- **After:** the field is deleted from shallow copies before posting; players without the field pass through uncopied; canonical cache objects never mutated; `hiddenDevTrait` intentionally preserved (reveal helpers depend on it). No UI code read `hiddenTrueOvr` (verified by grep + existing DOM sentinel tests), so this is not a behavior change for any component.
+- **Tests:** `src/worker/__tests__/viewStateStats.test.js` (4 new cases), plus sentinel assertions in `releaseHandlerGuards.test.js` that `buildViewState` routes rosters through the sanitizer.
+
+## C. Deferred roadmap (next safest PRs, in order)
+
+1. **Pre-reveal masking of `hiddenDevTrait` (from #5) + GET_ROSTER parity (#6).**
+   Scope: compute reveal worker-side (`shouldRevealHiddenDevTrait` is pure and already importable), serialize `hiddenDevTrait` only when revealed plus a `hasHiddenDevTrait` boolean; update `getHiddenDevTraitLabel` call sites to use the boolean for the "Hidden" chip; add `hiddenDevTrait`(masked)/`ovrHistory`-derived reveal fields to the `GET_ROSTER` whitelist so both data paths agree.
+   Files: `viewStateStats.js`, `worker.js`, `rosterHandlers.js`, `draftVariance.js`, `PlayerProfile.jsx`, `RosterDecisionBoard.jsx` + tests.
+   Tests required: reveal-boundary unit tests both sides of the 2-season threshold; DOM sentinel that the raw trait string is absent pre-reveal.
+   Risks: UI contract change — coordinate the boolean flag and label helper in one PR. Do NOT change the reveal threshold or trait distribution (simulation balance).
+2. **`WEEK_COMPLETE` reducer merge (#7).** Merge standings fields into existing team objects instead of replacing `league.teams`. Files: `useWorker.js` (reducer only) + `workerReducer` unit tests. Risk: verify no consumer depends on the slim shape between the two messages (StandingsCenter reads `league.standings`, not `teams`).
+3. **Roster action feedback consistency (#8).** try/catch around `handleTag`/`handleRestructure` mirroring `handleManagementUpdate`'s `setActionError` pattern. Files: `Roster.jsx` + component test. Risk: minimal.
+4. **`truePotential` exposure decision (#12).** Needs a product decision before any code change — if it is a leak, fix is a one-line removal in `buildDraftStateView` + sentinel test; if intentional, document it in the field comment.
+5. **Dead code / guards (#9, #10).** Remove unused `baseline`; add `o?.contract` guard in the FA top-bid loop. Trivial, bundle with any worker PR.
+
+**What NOT to touch** (re-confirmed during this audit): StateStore/legacyStateBridge (single sanctioned `window.state` writer), simulation math and dev-trait distributions, contract business rules, save schema (no migration bugs found), the epoch/boot-scope guards in `useWorker` (subtle and correct).
+
+## D. Tests run
+
+- Targeted: 21 new/updated tests across `viewStateStats.test.js`, `releaseHandlerGuards.test.js` (new), `RosterBulkRelease.test.jsx` (new) — all pass.
+- Related suites: Roster integration, BulkReleasePreviewModal, ReleasePreviewModal, RosterDecisionBoard, workerApi, loadPipelineRegression, rosterDecisionCommitExecution — 59 tests, all pass.
+- Full unit suite: `npm run test:unit` — 430 files / 5361 tests, all pass (baseline was 428 / 5346).
+- Production build: `npm run build` — succeeds (expected >500KB chunk warning only).

--- a/src/ui/components/Roster.jsx
+++ b/src/ui/components/Roster.jsx
@@ -889,13 +889,22 @@ function RosterTable({
   const confirmBulkRelease = async (dedupedPlayers) => {
     const ids = [...new Set((dedupedPlayers ?? []).map((p) => p?.id).filter(Boolean))];
     if (!ids.length || !actions?.bulkReleasePlayers) return;
-    const result = await actions.bulkReleasePlayers(teamId, ids);
-    if (!result?.ok) {
-      window.alert(`Bulk release stopped after ${result?.released?.length ?? 0} release(s): ${result?.error ?? "Unknown error"}`);
+    try {
+      // Resolves with { type: 'SUCCESS', payload: { ok, released } }; a worker
+      // ERROR (partial stop) rejects with the worker's message. The cleanup in
+      // `finally` must run on both paths — a rejection used to leave the
+      // preview modal stuck open.
+      const result = await actions.bulkReleasePlayers(teamId, ids);
+      if (!result?.payload?.ok) {
+        window.alert(`Bulk release did not complete: ${result?.payload?.error ?? "Unknown error"}`);
+      }
+    } catch (err) {
+      window.alert(err?.message ?? "Bulk release failed.");
+    } finally {
+      setBulkPreviewOpen(false);
+      setBulkSelectedIds([]);
+      onRefetch?.();
     }
-    setBulkPreviewOpen(false);
-    setBulkSelectedIds([]);
-    onRefetch?.();
   };
 
   const handleTradeBlockToggle = async (playerId) => {

--- a/src/ui/components/__tests__/RosterBulkRelease.test.jsx
+++ b/src/ui/components/__tests__/RosterBulkRelease.test.jsx
@@ -1,0 +1,110 @@
+/** @vitest-environment jsdom */
+/**
+ * RosterBulkRelease.test.jsx — bulk release confirm flow.
+ *
+ * Regression: actions.bulkReleasePlayers resolves with { type, payload } from
+ * the worker request bridge, but confirmBulkRelease read `result.ok` (always
+ * undefined), so every SUCCESSFUL bulk release showed the "stopped after 0
+ * release(s)" failure alert. A rejected promise (worker ERROR on a partial
+ * stop) escaped the handler entirely and left the preview modal stuck open.
+ */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import Roster from '../Roster.jsx';
+
+function makePlayer(id, overrides = {}) {
+  return {
+    id,
+    name: `Player ${id}`,
+    pos: 'WR',
+    ovr: 74,
+    potential: 78,
+    age: 26,
+    morale: 70,
+    schemeFit: 65,
+    teamId: 1,
+    contract: { years: 2, yearsLeft: 2, baseAnnual: 4, salary: 4_000_000 },
+    depthChart: { rowKey: 'WR', order: id },
+    ...overrides,
+  };
+}
+
+const players = [makePlayer(1), makePlayer(2)];
+
+const rosterPayload = {
+  team: { id: 1, name: 'Sharks', capRoom: 30_000_000, capTotal: 200_000_000 },
+  players,
+};
+
+const baseLeague = {
+  week: 3,
+  year: 2026,
+  phase: 'regular',
+  userTeamId: 1,
+  salaryCap: 200_000_000,
+  teams: [{ id: 1, name: 'Sharks', abbr: 'SHK', wins: 8, losses: 8, capRoom: 30, roster: players, picks: [], strategies: {} }],
+};
+
+async function driveToConfirm(actions) {
+  render(
+    <Roster
+      league={baseLeague}
+      actions={actions}
+      onPlayerSelect={() => {}}
+      initialState={{ view: 'table', filter: 'ALL' }}
+      initialViewMode="table"
+    />,
+  );
+  await waitFor(() => expect(actions.getRoster).toHaveBeenCalled());
+
+  fireEvent.click(await screen.findByRole('button', { name: /bulk cut mode off/i }));
+  fireEvent.click(await screen.findByRole('button', { name: /select visible/i }));
+  fireEvent.click(await screen.findByRole('button', { name: /preview bulk release/i }));
+
+  const dialog = await screen.findByRole('dialog', { name: /bulk release preview/i });
+  fireEvent.click(screen.getByRole('button', { name: /confirm bulk release/i }));
+  return dialog;
+}
+
+describe('Roster — bulk release confirm flow', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('treats a resolved SUCCESS payload as success: no failure alert, modal closes', async () => {
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    const actions = {
+      getRoster: vi.fn(async () => ({ payload: rosterPayload })),
+      bulkReleasePlayers: vi.fn(async () => ({ type: 'SUCCESS', payload: { ok: true, released: [1, 2] } })),
+    };
+
+    await driveToConfirm(actions);
+
+    await waitFor(() => expect(actions.bulkReleasePlayers).toHaveBeenCalledTimes(1));
+    expect(actions.bulkReleasePlayers).toHaveBeenCalledWith(1, [1, 2]);
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: /bulk release preview/i })).toBeNull(),
+    );
+    expect(alertSpy).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a rejected bulk release (worker ERROR) and still closes the modal', async () => {
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    const workerMessage = 'Bulk release stopped after 1 release(s): Player is not on selected roster';
+    const actions = {
+      getRoster: vi.fn(async () => ({ payload: rosterPayload })),
+      bulkReleasePlayers: vi.fn(async () => {
+        throw new Error(workerMessage);
+      }),
+    };
+
+    await driveToConfirm(actions);
+
+    await waitFor(() => expect(alertSpy).toHaveBeenCalledWith(workerMessage));
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog', { name: /bulk release preview/i })).toBeNull(),
+    );
+  });
+});

--- a/src/worker/__tests__/releaseHandlerGuards.test.js
+++ b/src/worker/__tests__/releaseHandlerGuards.test.js
@@ -1,0 +1,98 @@
+/**
+ * releaseHandlerGuards.test.js — regression guards for the release / bulk
+ * release worker handlers and the view-state hidden-field sanitizer.
+ *
+ * worker.js is a monolith whose handlers are not exported, so these follow the
+ * repo's source-sentinel pattern (see loadPipelineRegression.test.js): read the
+ * source and assert the load-bearing lines exist in the required order.
+ *
+ * Bugs these lock down:
+ *  1. handleReleasePlayer ignored the releasePlayerWithValidation outcome — a
+ *     failed release (stale roster view, wrong team, double release) posted a
+ *     normal STATE_UPDATE and looked like a success to the UI.
+ *  2. handleBulkReleasePlayers posted STATE_UPDATE with the request id BEFORE
+ *     the SUCCESS message. The useWorker pending-promise map resolves on the
+ *     FIRST message carrying the id, so callers resolved with the view-state
+ *     payload (no `ok`), and Roster.jsx reported every successful bulk release
+ *     as a failure.
+ *  3. `toUI.SUCCESS` was posted by worker.js without being defined in
+ *     protocol.js, so those messages went out with `type: undefined`.
+ *  4. buildViewState serialized raw cache players (including the internal-only
+ *     hiddenTrueOvr draft-variance anchor) into league.teams[].roster.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { toUI } from '../protocol.js';
+
+const workerSource = readFileSync(resolve(process.cwd(), 'src/worker/worker.js'), 'utf8');
+
+function extractFunction(source, name) {
+  const start = source.indexOf(`async function ${name}(`);
+  expect(start, `${name} must exist in worker.js`).toBeGreaterThan(-1);
+  // Slice to the next top-level function declaration — good enough for sentinels.
+  const rest = source.slice(start);
+  const next = rest.slice(1).search(/\n(async )?function \w+\(/);
+  return next === -1 ? rest : rest.slice(0, next + 1);
+}
+
+describe('protocol contract', () => {
+  it('defines toUI.SUCCESS so bulk mutation results are not posted with type undefined', () => {
+    expect(toUI.SUCCESS).toBe('SUCCESS');
+  });
+
+  it('worker.js never posts an undefined toUI member', () => {
+    const used = [...workerSource.matchAll(/toUI\.(\w+)/g)].map((m) => m[1]);
+    const undefinedMembers = [...new Set(used)].filter((name) => toUI[name] === undefined);
+    expect(undefinedMembers).toEqual([]);
+  });
+});
+
+describe('handleReleasePlayer outcome guard', () => {
+  const fn = extractFunction(workerSource, 'handleReleasePlayer');
+
+  it('checks the releasePlayerWithValidation outcome instead of discarding it', () => {
+    expect(fn.includes('const outcome = await releasePlayerWithValidation')).toBe(true);
+    expect(fn.includes('if (!outcome.ok)')).toBe(true);
+  });
+
+  it('posts an ERROR (and no STATE_UPDATE success signal) when validation fails', () => {
+    const failBranch = fn.slice(fn.indexOf('if (!outcome.ok)'), fn.indexOf('recalcSchemeFitForTeams'));
+    expect(failBranch.includes('post(toUI.ERROR')).toBe(true);
+    expect(failBranch.includes('STATE_UPDATE')).toBe(false);
+    expect(failBranch.includes('return;')).toBe(true);
+  });
+});
+
+describe('handleBulkReleasePlayers message ordering', () => {
+  const fn = extractFunction(workerSource, 'handleBulkReleasePlayers');
+
+  it('posts SUCCESS with the request id BEFORE the follow-up STATE_UPDATE', () => {
+    const successIdx = fn.indexOf("post(toUI.SUCCESS, { ok: true, released }, id)");
+    const stateUpdateIdx = fn.lastIndexOf('post(toUI.STATE_UPDATE');
+    expect(successIdx).toBeGreaterThan(-1);
+    expect(stateUpdateIdx).toBeGreaterThan(successIdx);
+  });
+
+  it('does not attach the request id to the refresh STATE_UPDATE posts', () => {
+    const statePosts = [...fn.matchAll(/post\(toUI\.STATE_UPDATE[^;]+;/g)].map((m) => m[0]);
+    expect(statePosts.length).toBeGreaterThan(0);
+    for (const call of statePosts) {
+      expect(call.includes(', id)')).toBe(false);
+    }
+  });
+
+  it('rejects the caller with the released-count context on a partial stop', () => {
+    expect(fn.includes('Bulk release stopped after ${released.length} release(s)')).toBe(true);
+  });
+});
+
+describe('buildViewState hidden-field sanitizer', () => {
+  it('routes every team roster through sanitizeRosterForClient', () => {
+    expect(workerSource.includes('sanitizeRosterForClient(attachSeasonStatsToRoster(')).toBe(true);
+  });
+
+  it('imports the sanitizer from viewStateStats', () => {
+    expect(workerSource.includes("import { attachSeasonStatsToRoster, sanitizeRosterForClient } from './viewStateStats.js'")).toBe(true);
+  });
+});

--- a/src/worker/__tests__/viewStateStats.test.js
+++ b/src/worker/__tests__/viewStateStats.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { attachSeasonStatsToRoster } from "../viewStateStats.js";
+import { attachSeasonStatsToRoster, sanitizeRosterForClient } from "../viewStateStats.js";
 
 // Mirrors the cache season-stat shape: totals are keyed by player id.
 function lookupFrom(map) {
@@ -54,5 +54,40 @@ describe("attachSeasonStatsToRoster", () => {
     expect(attachSeasonStatsToRoster(null, lookupFrom({}))).toEqual([]);
     const roster = [{ id: 1 }];
     expect(attachSeasonStatsToRoster(roster, undefined)).toBe(roster);
+  });
+});
+
+describe("sanitizeRosterForClient", () => {
+  it("strips hiddenTrueOvr from players bound for the UI", () => {
+    const roster = [
+      { id: 1, name: "QB", ovr: 80, hiddenTrueOvr: 91, hiddenDevTrait: "superstar" },
+      { id: 2, name: "RB", ovr: 74 },
+    ];
+    const out = sanitizeRosterForClient(roster);
+    expect("hiddenTrueOvr" in out[0]).toBe(false);
+    expect(out[0].ovr).toBe(80);
+    // hiddenDevTrait intentionally survives — the UI reveal helpers need it.
+    expect(out[0].hiddenDevTrait).toBe("superstar");
+  });
+
+  it("does not mutate the canonical cache player objects", () => {
+    const player = { id: 1, hiddenTrueOvr: 88 };
+    const out = sanitizeRosterForClient([player]);
+    expect(player.hiddenTrueOvr).toBe(88);
+    expect(out[0]).not.toBe(player);
+  });
+
+  it("passes players without worker-only fields through unchanged (no copy)", () => {
+    const player = { id: 2, name: "RB", ovr: 74 };
+    const out = sanitizeRosterForClient([player]);
+    expect(out[0]).toBe(player);
+  });
+
+  it("tolerates malformed rows and non-array input", () => {
+    expect(sanitizeRosterForClient(null)).toEqual([]);
+    const out = sanitizeRosterForClient([null, undefined, 42, { id: 1, hiddenTrueOvr: 90 }]);
+    expect(out[0]).toBeNull();
+    expect(out[2]).toBe(42);
+    expect("hiddenTrueOvr" in out[3]).toBe(false);
   });
 });

--- a/src/worker/protocol.js
+++ b/src/worker/protocol.js
@@ -294,6 +294,16 @@ export const toUI = Object.freeze({
   /** Save completed */
   SAVED:              'SAVED',
 
+  /**
+   * Generic mutation outcome for request-based bulk actions.
+   * Posted with the request id BEFORE any follow-up STATE_UPDATE so the
+   * caller's promise resolves with this payload (the pending-promise map in
+   * useWorker resolves on the FIRST message carrying the request id).
+   * Previously worker.js posted `toUI.SUCCESS` without this key existing,
+   * which serialized messages with `type: undefined`.
+   */
+  SUCCESS:            'SUCCESS',              // { ok, ... }
+
   /** Fatal worker error */
   ERROR:              'ERROR',               // { message, stack? }
   SAVE_EXPORT:        'SAVE_EXPORT',          // { data }

--- a/src/worker/viewStateStats.js
+++ b/src/worker/viewStateStats.js
@@ -43,3 +43,37 @@ export function attachSeasonStatsToRoster(roster, getSeasonStatTotals) {
     return { ...player, seasonStats: totals };
   });
 }
+
+/**
+ * Player fields that exist only for the worker-side simulation and must never
+ * cross the postMessage boundary into UI state.
+ *
+ * `hiddenTrueOvr` is the hidden draft-variance talent anchor
+ * (draftVariance.js: "stays internal-only and must never be rendered") — but
+ * buildViewState() serialized raw cache players into `league.teams[].roster`,
+ * so the anchor was inspectable from the UI thread (React devtools / console)
+ * even though no component rendered it. `hiddenDevTrait` intentionally stays:
+ * the reveal helpers (getHiddenDevTraitLabel) need it to decide Hidden/label
+ * state in PlayerProfile and the Roster Decision Board.
+ */
+const WORKER_ONLY_PLAYER_FIELDS = Object.freeze(["hiddenTrueOvr"]);
+
+/**
+ * Strip worker-only fields from roster players before they are posted to the
+ * UI. Returns shallow copies — canonical cache player objects are never
+ * mutated. Players without any worker-only field pass through unchanged (no
+ * copy), so the common case stays cheap.
+ *
+ * @param {Array<object>} roster Player objects bound for a UI payload.
+ * @returns {Array<object>} Roster safe to serialize to the UI thread.
+ */
+export function sanitizeRosterForClient(roster) {
+  if (!Array.isArray(roster)) return [];
+  return roster.map((player) => {
+    if (!player || typeof player !== "object") return player;
+    if (!WORKER_ONLY_PLAYER_FIELDS.some((field) => field in player)) return player;
+    const copy = { ...player };
+    for (const field of WORKER_ONLY_PLAYER_FIELDS) delete copy[field];
+    return copy;
+  });
+}

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -217,7 +217,7 @@ import {
 import { processSeasonRecords, createEmptyRecords, getMostPlayedTeam } from '../core/records.js';
 import { ensureLeagueMemoryMeta, buildSeasonArchiveSummary, updateFranchiseHistory, updateRecordBook, evaluateHallOfFameCandidate, addHallOfFameClass, buildSeasonStorylineSnapshot, buildHallOfFameInducteeRow, syncHallOfFameAfterRecordBook } from '../core/league-memory.js';
 import { buildPlayerSeasonStatsArchiveRows } from '../core/playerSeasonStatsArchive.js';
-import { attachSeasonStatsToRoster } from './viewStateStats.js';
+import { attachSeasonStatsToRoster, sanitizeRosterForClient } from './viewStateStats.js';
 import {
   TRANSACTION_TIMELINE_SCHEMA_VERSION,
   compactRowsForArchive,
@@ -1047,10 +1047,12 @@ function buildViewState() {
   const teams = cache.getAllTeams().map(t => {
     // Attach recorded season totals so the League Stats hub (which reads
     // player.seasonStats) shows real leaders instead of all-zero placeholders.
-    const roster = attachSeasonStatsToRoster(
+    // sanitizeRosterForClient strips worker-only fields (hiddenTrueOvr) so the
+    // hidden draft-variance anchor never crosses into UI state.
+    const roster = sanitizeRosterForClient(attachSeasonStatsToRoster(
       cache.getPlayersByTeam(t.id),
       (pid) => cache.getSeasonStat(pid)?.totals,
-    );
+    ));
     return ({
     id:        t.id,
     name:      t.name,
@@ -7599,10 +7601,16 @@ function recalcSchemeFitForTeams(...teamIds) {
 }
 
 async function handleReleasePlayer({ playerId, teamId }, id) {
-  let player = cache.getPlayer(playerId);
-  if (!player) { post(toUI.ERROR, { message: 'Player not found' }, id); return; }
-
-  await releasePlayerWithValidation({ playerId, teamId });
+  // releasePlayerWithValidation is mutation-free on failure (player missing /
+  // not on the selected roster), so a failed outcome only needs the ERROR post
+  // — previously the result was ignored and the UI saw a normal STATE_UPDATE,
+  // making a failed release (stale roster view, double-click after the player
+  // already left the team) look like it succeeded.
+  const outcome = await releasePlayerWithValidation({ playerId, teamId });
+  if (!outcome.ok) {
+    post(toUI.ERROR, { message: `Release failed: ${outcome.error}` }, id);
+    return;
+  }
   recalcSchemeFitForTeams(teamId);
   await flushDirty();
   post(toUI.STATE_UPDATE, { roster: buildRosterView(teamId), ...buildViewState() }, id);
@@ -7615,16 +7623,27 @@ async function handleBulkReleasePlayers({ teamId, playerIds }, id) {
     const outcome = await releasePlayerWithValidation({ playerId, teamId });
     if (!outcome.ok) {
       await flushDirty();
-      post(toUI.ERROR, { message: `Bulk release stopped: ${outcome.error}` }, id);
-      post(toUI.STATE_UPDATE, { roster: buildRosterView(teamId), ...buildViewState() }, id);
-      return post(toUI.SUCCESS, { ok: false, released, failedPlayerId: playerId, error: outcome.error }, id);
+      // ERROR carries the request id so the caller's promise rejects with this
+      // message; the follow-up STATE_UPDATE (no id) refreshes the roster view
+      // to reflect the releases that DID complete before the stop.
+      post(toUI.ERROR, {
+        message: `Bulk release stopped after ${released.length} release(s): ${outcome.error}`,
+        released,
+        failedPlayerId: playerId,
+      }, id);
+      post(toUI.STATE_UPDATE, { roster: buildRosterView(teamId), ...buildViewState() });
+      return;
     }
     released.push(playerId);
   }
   recalcSchemeFitForTeams(teamId);
   await flushDirty();
-  post(toUI.STATE_UPDATE, { roster: buildRosterView(teamId), ...buildViewState() }, id);
+  // SUCCESS must be posted with the request id BEFORE the STATE_UPDATE:
+  // the useWorker pending-promise map resolves on the first message carrying
+  // the id, so posting STATE_UPDATE(id) first made callers resolve with the
+  // view-state payload (no `ok`/`released`) and treat every success as failure.
   post(toUI.SUCCESS, { ok: true, released }, id);
+  post(toUI.STATE_UPDATE, { roster: buildRosterView(teamId), ...buildViewState() });
 }
 
 // ── Handler: SUBMIT_WAIVER_CLAIM ──────────────────────────────────────────────


### PR DESCRIPTION
Stabilization and risk-reduction pass across app stability, worker/action architecture, simulation safety, UI/UX integrity, and test gaps. Only localized, low-risk, testable P0/P1 fixes are implemented; everything else is recorded in the handoff report at **`docs/stabilization-audit-v1-2026-07.md`** (full audit table, deferred roadmap, and do-not-touch list).

## Fixes (all P1, all localized)

### 1. Failed single release silently succeeded — `src/worker/worker.js`
`handleReleasePlayer` discarded the `releasePlayerWithValidation` outcome. A failed release (stale roster view, double-click after the player already left, wrong team) posted a normal `STATE_UPDATE` and no `ERROR`, so the UI — including the new Decision Board "dispatched" flow — treated the failure as success. Now a failed outcome posts `ERROR` ("Release failed: …") and returns; the validation path is mutation-free on failure so no flush is needed. Success path unchanged.

### 2. Bulk release protocol repair — `src/worker/protocol.js`, `src/worker/worker.js`
- `toUI.SUCCESS` was posted by `handleBulkReleasePlayers` but never defined in the frozen protocol object, so those messages went out with `type: undefined`.
- `STATE_UPDATE` was posted with the request id *before* `SUCCESS`. The `useWorker` pending-promise map resolves on the **first** message carrying the id, so callers resolved with the view-state payload (no `ok`/`released`).
- Now: `SUCCESS` is a defined protocol member, posted with the request id before the refresh `STATE_UPDATE` (which no longer carries the id). The partial-stop `ERROR` message includes the released-so-far count.

### 3. Bulk release confirm flow — `src/ui/components/Roster.jsx`
`confirmBulkRelease` read `result?.ok` from the `{ type, payload }` envelope (always `undefined`), so **every successful bulk release showed the "Bulk release stopped after 0 release(s): Unknown error" alert**. A rejected promise (worker ERROR on partial stop) escaped the handler entirely — unhandled rejection and a stuck preview modal. Now it reads `result?.payload?.ok`, catches rejections and alerts the worker's message, and always closes the modal / clears selection / refetches in `finally`.

### 4. `hiddenTrueOvr` stripped from UI payloads — `src/worker/viewStateStats.js`, `src/worker/worker.js`
`buildViewState()` serialized raw cache player objects into `league.teams[].roster`, including `hiddenTrueOvr` — the hidden draft-variance anchor documented in `draftVariance.js` as "internal-only and must never be rendered". No component rendered it (existing DOM sentinel tests cover that), but it was fully inspectable from the UI thread via devtools. New `sanitizeRosterForClient` strips the field from shallow copies before posting; `hiddenDevTrait` is intentionally preserved because the reveal helpers need it; canonical cache objects are never mutated; no UI code read the field (verified by grep + sentinel tests), so no component behavior changes.

## Tests
- **+15 tests** (full suite: 430 files / 5361 tests, all green; baseline was 428 / 5346):
  - `src/worker/__tests__/viewStateStats.test.js` — 4 new sanitizer cases (strip, no-mutation, pass-through, malformed input).
  - `src/worker/__tests__/releaseHandlerGuards.test.js` (new) — source-sentinel guards in the repo's `loadPipelineRegression` idiom: protocol contract (`toUI.SUCCESS` defined; no undefined `toUI.*` member used anywhere in worker.js), release outcome guard, bulk message ordering, sanitizer wiring.
  - `src/ui/components/__tests__/RosterBulkRelease.test.jsx` (new) — drives the real UI (bulk mode → select visible → preview → confirm) for both the success path (no alert, modal closes, correct `(teamId, [ids])` payload) and the rejected path (worker message alerted, modal closes).
- Related suites re-run green: Roster integration, BulkReleasePreviewModal, ReleasePreviewModal, RosterDecisionBoard, workerApi, loadPipelineRegression, rosterDecisionCommitExecution.
- `npm run build` succeeds (expected >500KB chunk warning only).

## Deferred (see `docs/stabilization-audit-v1-2026-07.md` for the full roadmap)
- P2: pre-reveal masking of `hiddenDevTrait` (needs a worker-side reveal computation + UI contract change), `GET_ROSTER` vs league-state field parity for the dev-trait row, `WEEK_COMPLETE` reducer replacing full teams with slim standings rows (transient, self-heals on the follow-up `STATE_UPDATE`), `truePotential` exposure in the draft view (needs a product decision).
- P3: try/catch polish for `handleTag`/`handleRestructure` (error banner already works), unused `baseline` var in the tag handler, null guard in the FA top-bid loop.

Constraints honored: no architecture rewrite, no StateStore/save-schema/simulation-math changes, no business-rule changes, no UI-side roster mutations, no new global state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jwj9DhJcSKXmCmCo1A2wST

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jwj9DhJcSKXmCmCo1A2wST)_