### PR TITLE
Let Walk Durable Intent V1

### DIFF
--- a/src/ui/components/PlayerDecisionRow.jsx
+++ b/src/ui/components/PlayerDecisionRow.jsx
@@ -11,6 +11,11 @@
  * when the player has no usable id). A null decisionKey renders the row
  * read-only: pills are disabled, onDecide is never called, and a muted
  * "Decision unavailable" note explains why.
+ *
+ * decision === "clear_let_walk" (pending clear of a persisted let-walk) is not
+ * a pill: no option renders pressed and a muted note explains the pending
+ * clear. Display only — the clear executes through the board's Review/Apply
+ * flow, never from this row.
  */
 
 import React from "react";
@@ -82,6 +87,11 @@ export default function PlayerDecisionRow({ row, decision, onDecide, onPlayerSel
         {!canDecide && (
           <span className="roster-decision-board__missing-id-note">
             Decision unavailable: missing player ID.
+          </span>
+        )}
+        {decision === "clear_let_walk" && (
+          <span className="roster-decision-board__missing-id-note">
+            Pending: clears the saved Let Walk intent on apply.
           </span>
         )}
       </td>

--- a/src/ui/components/RosterDecisionBoard.jsx
+++ b/src/ui/components/RosterDecisionBoard.jsx
@@ -21,6 +21,17 @@
  *  - hidden dev trait: getHiddenDevTraitLabel (draftVariance.js) decides
  *    reveal state; hiddenTrueOvr is never read or rendered.
  *
+ * Durable let-walk intent (V1): on mount (and on roster syncs before any user
+ * interaction) pending decisions are pre-populated from persisted
+ * player.extensionDecision === "let_walk" — the intent recorded by a previous
+ * apply or by Contract Center. ONLY let_walk pre-populates: no other persisted
+ * value maps unambiguously to a DECISION_OPTIONS key. Once the user touches
+ * the board (decide / reset / review / apply), roster syncs never overwrite
+ * local pending state. Toggling off a persisted let-walk does NOT call the
+ * worker — it becomes a local "clear_let_walk" pending intent that flows
+ * through the same Review Decisions / Apply flow and executes as
+ * updatePlayerManagement({ extensionDecision: null }).
+ *
  * Commit dry-run (V1): "Review Decisions" builds a local, validated commit
  * plan via buildRosterDecisionCommitPlan and renders it below the board. The
  * review step itself never mutates anything.
@@ -48,7 +59,7 @@
  *  - onPlayerSelect: optional (playerId) => void
  */
 
-import React, { useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { EmptyState } from "./ScreenSystem.jsx";
 import { derivePlayerContractFinancials, formatContractMoney } from "../utils/contractFormatting.js";
 import { buildRosterDecisionCommitPlan } from "../utils/rosterDecisionCommitPlan.js";
@@ -86,6 +97,27 @@ function decisionKeyFor(player) {
   return null;
 }
 
+/**
+ * Pending decisions seeded from durable player state. Only
+ * extensionDecision === "let_walk" pre-populates: "pending" / "deferred" /
+ * "extended" / "tagged" have no unambiguous DECISION_OPTIONS pill, so they are
+ * ignored by design. Scope matches the board rows exactly — usable player id
+ * and a contract expiring within the board window.
+ */
+function seedPersistedDecisions(roster) {
+  const seeded = {};
+  for (const player of Array.isArray(roster) ? roster : []) {
+    if (!player || typeof player !== "object") continue;
+    if (player.extensionDecision !== "let_walk") continue;
+    const key = decisionKeyFor(player);
+    if (key == null) continue;
+    const yearsRemaining = getYearsRemaining(player);
+    if (yearsRemaining == null || yearsRemaining > EXPIRING_WINDOW_SEASONS) continue;
+    seeded[key] = "let_walk";
+  }
+  return seeded;
+}
+
 function sortValue(row, key) {
   switch (key) {
     case "name": return String(row.player?.name ?? "").toLowerCase();
@@ -99,7 +131,12 @@ function sortValue(row, key) {
   }
 }
 
-const DECISION_LABELS = Object.fromEntries(DECISION_OPTIONS.map((o) => [o.key, o.label]));
+const DECISION_LABELS = {
+  ...Object.fromEntries(DECISION_OPTIONS.map((o) => [o.key, o.label])),
+  // Not a pill: the pending clear intent created by toggling off a persisted
+  // let-walk. Needs a label wherever plan entries / execution results render.
+  clear_let_walk: "Clear Let Walk",
+};
 
 function CommitPlanEntry({ entry }) {
   const contractBits = [];
@@ -249,17 +286,37 @@ function ExecutionResultSummary({ result, plan }) {
 // onCommitDecisions is accepted but intentionally unused: execution is wired
 // through the `actions` worker handlers instead of a bespoke commit callback.
 export default function RosterDecisionBoard({ roster, league, actions, onCommitDecisions, onPlayerSelect }) {
-  const [decisions, setDecisions] = useState({});
+  const [decisions, setDecisions] = useState(() => seedPersistedDecisions(roster));
   const [commitPlan, setCommitPlan] = useState(null);
   const [executionResult, setExecutionResult] = useState(null);
   const [isExecuting, setIsExecuting] = useState(false);
   // Re-entrancy guard for apply: state updates are async, so two clicks in the
   // same tick would both read isExecuting === false. The ref closes that gap.
   const executingRef = useRef(false);
+  // True once the user decides / resets / reviews / applies this session.
+  // Roster syncs (worker STATE_UPDATE refreshes) may re-seed pending decisions
+  // from persisted intent ONLY while this is false — never over user edits.
+  const userTouchedRef = useRef(false);
   const [search, setSearch] = useState("");
   const [posFilter, setPosFilter] = useState("ALL");
   const [sortKey, setSortKey] = useState("ovr");
   const [sortDesc, setSortDesc] = useState(true);
+
+  // Pre-population sync: a roster that arrives/refreshes before any user
+  // interaction re-seeds pending decisions from persisted let-walk intent.
+  // Returning `prev` when nothing changed avoids a pointless re-render on
+  // parent renders that rebuild the roster array.
+  useEffect(() => {
+    if (userTouchedRef.current) return;
+    const seeded = seedPersistedDecisions(roster);
+    setDecisions((prev) => {
+      const prevKeys = Object.keys(prev);
+      const seededKeys = Object.keys(seeded);
+      const unchanged =
+        prevKeys.length === seededKeys.length && seededKeys.every((key) => prev[key] === seeded[key]);
+      return unchanged ? prev : seeded;
+    });
+  }, [roster]);
 
   const revealContext = useMemo(
     () => ({ currentSeason: league?.year ?? league?.seasonId ?? null }),
@@ -324,14 +381,35 @@ export default function RosterDecisionBoard({ roster, league, actions, onCommitD
     }
   };
 
+  // Decision keys whose CURRENT roster player carries a persisted let-walk
+  // intent — toggling let_walk off for these must become a pending clear
+  // intent instead of silently dropping the pending entry.
+  const persistedLetWalkKeys = useMemo(() => {
+    const keys = new Set();
+    for (const row of rows) {
+      if (row.decisionKey != null && row.player?.extensionDecision === "let_walk") {
+        keys.add(row.decisionKey);
+      }
+    }
+    return keys;
+  }, [rows]);
+
   const handleDecide = (playerKey, decisionKey) => {
     if (playerKey == null) return;
+    userTouchedRef.current = true;
     setCommitPlan(null); // any pending-decision change invalidates the previewed plan
     setExecutionResult(null);
     setDecisions((prev) => {
       const next = { ...prev };
       if (next[playerKey] === decisionKey) {
-        delete next[playerKey];
+        if (decisionKey === "let_walk" && persistedLetWalkKeys.has(playerKey)) {
+          // Local pending clear intent ONLY — no worker call happens here.
+          // The clear executes through Review Decisions / Apply, as
+          // updatePlayerManagement({ extensionDecision: null }).
+          next[playerKey] = "clear_let_walk";
+        } else {
+          delete next[playerKey];
+        }
       } else {
         next[playerKey] = decisionKey;
       }
@@ -341,8 +419,12 @@ export default function RosterDecisionBoard({ roster, league, actions, onCommitD
 
   const pendingCount = Object.keys(decisions).length;
 
+  // Reset returns to the board's INITIAL state — session edits are discarded
+  // but persisted let-walk intents re-seed (clearing a persisted intent is a
+  // reviewed decision, not a side effect of Reset).
   const handleReset = () => {
-    setDecisions({});
+    userTouchedRef.current = true;
+    setDecisions(seedPersistedDecisions(roster));
     setCommitPlan(null);
     setExecutionResult(null);
   };
@@ -350,6 +432,7 @@ export default function RosterDecisionBoard({ roster, league, actions, onCommitD
   // Dry run only: builds a local validated plan; never calls mutation handlers.
   const handleReview = () => {
     if (pendingCount === 0) return;
+    userTouchedRef.current = true;
     setExecutionResult(null);
     setCommitPlan(buildRosterDecisionCommitPlan({ decisions: { ...decisions }, roster, league }));
   };
@@ -367,6 +450,7 @@ export default function RosterDecisionBoard({ roster, league, actions, onCommitD
   // re-applying requires a fresh "Review Decisions" pass.
   const handleApplyExecutable = async () => {
     if (commitPlan == null || executingRef.current || executionResult != null) return;
+    userTouchedRef.current = true;
     executingRef.current = true;
     setIsExecuting(true);
     try {

--- a/src/ui/components/__tests__/RosterDecisionBoard.test.jsx
+++ b/src/ui/components/__tests__/RosterDecisionBoard.test.jsx
@@ -467,6 +467,121 @@ describe("RosterDecisionBoard commit execution", () => {
   });
 });
 
+describe("RosterDecisionBoard durable let-walk intent", () => {
+  const league = { userTeamId: 1, seasonId: 2026 };
+
+  function makeActions(overrides = {}) {
+    return {
+      releasePlayer: vi.fn(() => undefined),
+      applyFranchiseTag: vi.fn(async () => ({ type: "STATE_UPDATE" })),
+      updatePlayerManagement: vi.fn(async () => ({ type: "STATE_UPDATE" })),
+      ...overrides,
+    };
+  }
+
+  // Player 7 (1y left) carries a persisted let-walk intent from a previous
+  // session / Contract Center.
+  function makePersistedRoster() {
+    const roster = makeRoster();
+    roster[0] = { ...roster[0], extensionDecision: "let_walk" };
+    return roster;
+  }
+
+  it("pre-populates let_walk from player.extensionDecision on mount", () => {
+    render(<RosterDecisionBoard roster={makePersistedRoster()} league={league} actions={makeActions()} />);
+
+    const row = screen.getByTestId("decision-row-7");
+    expect(row.getAttribute("data-pending")).toBe("true");
+    expect(within(row).getByRole("button", { name: "Let Walk" }).getAttribute("aria-pressed")).toBe("true");
+    // Players without persisted intent stay untouched.
+    expect(screen.getByTestId("decision-row-8").getAttribute("data-pending")).toBe("false");
+  });
+
+  it("pre-populates ONLY let_walk — other persisted extensionDecision values are ignored", () => {
+    const roster = makeRoster();
+    roster[0] = { ...roster[0], extensionDecision: "deferred" };
+    roster[1] = { ...roster[1], extensionDecision: "tagged" };
+    render(<RosterDecisionBoard roster={roster} league={league} actions={makeActions()} />);
+
+    expect(screen.getByTestId("decision-row-7").getAttribute("data-pending")).toBe("false");
+    expect(screen.getByTestId("decision-row-8").getAttribute("data-pending")).toBe("false");
+  });
+
+  it("a roster sync arriving before any interaction still pre-populates", () => {
+    const { rerender } = render(<RosterDecisionBoard roster={makeRoster()} league={league} actions={makeActions()} />);
+    expect(screen.getByTestId("decision-row-7").getAttribute("data-pending")).toBe("false");
+
+    rerender(<RosterDecisionBoard roster={makePersistedRoster()} league={league} actions={makeActions()} />);
+
+    const row = screen.getByTestId("decision-row-7");
+    expect(row.getAttribute("data-pending")).toBe("true");
+    expect(within(row).getByRole("button", { name: "Let Walk" }).getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("pre-population never overwrites a user edit made this session", () => {
+    const { rerender } = render(<RosterDecisionBoard roster={makeRoster()} league={league} actions={makeActions()} />);
+    fireEvent.click(within(screen.getByTestId("decision-row-7")).getByRole("button", { name: "Cut" }));
+
+    // A fresh roster sync now carries a persisted let-walk for the same player.
+    rerender(<RosterDecisionBoard roster={makePersistedRoster()} league={league} actions={makeActions()} />);
+
+    const row = screen.getByTestId("decision-row-7");
+    expect(within(row).getByRole("button", { name: "Cut" }).getAttribute("aria-pressed")).toBe("true");
+    expect(within(row).getByRole("button", { name: "Let Walk" }).getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("toggling off a pre-populated let_walk becomes a pending clear intent without calling the worker", () => {
+    const actions = makeActions();
+    render(<RosterDecisionBoard roster={makePersistedRoster()} league={league} actions={actions} />);
+
+    const row = screen.getByTestId("decision-row-7");
+    fireEvent.click(within(row).getByRole("button", { name: "Let Walk" }));
+
+    // Still pending — as a clear intent: no pill pressed, muted note shown.
+    expect(row.getAttribute("data-pending")).toBe("true");
+    expect(within(row).queryAllByRole("button", { pressed: true })).toHaveLength(0);
+    expect(within(row).getByText(/clears the saved Let Walk intent/i)).toBeTruthy();
+    // Clear-intent rule: a pill toggle never reaches the worker directly.
+    expect(actions.updatePlayerManagement).not.toHaveBeenCalled();
+    expect(actions.releasePlayer).not.toHaveBeenCalled();
+  });
+
+  it("the pending clear intent flows through Review/Apply and calls updatePlayerManagement with null", async () => {
+    const actions = makeActions();
+    render(<RosterDecisionBoard roster={makePersistedRoster()} league={league} actions={actions} />);
+
+    fireEvent.click(within(screen.getByTestId("decision-row-7")).getByRole("button", { name: "Let Walk" }));
+    fireEvent.click(screen.getByRole("button", { name: "Review Decisions" }));
+
+    const summary = screen.getByTestId("decision-dry-run-summary");
+    expect(within(summary).getByTestId("plan-valid-7").textContent).toContain("Clear Let Walk");
+    expect(actions.updatePlayerManagement).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /Apply Executable Decisions \(1\)/ }));
+    await screen.findByTestId("decision-execution-result");
+
+    expect(actions.updatePlayerManagement).toHaveBeenCalledTimes(1);
+    expect(actions.updatePlayerManagement).toHaveBeenCalledWith("7", 1, { extensionDecision: null });
+  });
+
+  it("a pre-populated let_walk reviews and applies identically to a user-entered one", async () => {
+    const actions = makeActions();
+    render(<RosterDecisionBoard roster={makePersistedRoster()} league={league} actions={actions} />);
+
+    // No pill click at all — straight from pre-population to review/apply.
+    fireEvent.click(screen.getByRole("button", { name: "Review Decisions" }));
+    const summary = screen.getByTestId("decision-dry-run-summary");
+    expect(within(summary).getByTestId("plan-valid-7").textContent).toContain("Let Walk");
+
+    fireEvent.click(screen.getByRole("button", { name: /Apply Executable Decisions \(1\)/ }));
+    await screen.findByTestId("decision-execution-result");
+
+    // Exact same handler + payload as the user-entered let_walk path.
+    expect(actions.updatePlayerManagement).toHaveBeenCalledTimes(1);
+    expect(actions.updatePlayerManagement).toHaveBeenCalledWith("7", 1, { extensionDecision: "let_walk" });
+  });
+});
+
 describe("RosterHub Decision Board tab", () => {
   beforeEach(() => {
     global.IntersectionObserver = vi.fn(function () {

--- a/src/ui/utils/rosterDecisionCommitExecution.js
+++ b/src/ui/utils/rosterDecisionCommitExecution.js
@@ -26,6 +26,10 @@
  *                    { extensionDecision: 'let_walk' }) — the exact
  *                    ContractCenter intent path (toWorker.UPDATE_PLAYER_MANAGEMENT).
  *                    Intent only: the player is not removed from the roster.
+ *  - clear_let_walk→ actions.updatePlayerManagement(playerId, teamId,
+ *                    { extensionDecision: null }) — reviewed clear intent for a
+ *                    PERSISTED let-walk. Same handler, same intent-only
+ *                    semantics; the worker wipes the stored decision to null.
  *  - extend        → never executed from the board. The plan only carries a
  *                    decision key, not negotiated contract terms, so extend is
  *                    always skipped toward the Contract Center flow.
@@ -142,19 +146,23 @@ export async function executeRosterDecisionCommitPlan({ plan, actions } = {}) {
       continue;
     }
 
-    if (decision === "let_walk") {
+    if (decision === "let_walk" || decision === "clear_let_walk") {
       if (typeof actions?.updatePlayerManagement !== "function") {
         skipped.push({ playerId, decision, reason: "Not applied — no player management action handler is available." });
         continue;
       }
       try {
         await Promise.resolve(
-          actions.updatePlayerManagement(playerId, teamId, { extensionDecision: "let_walk" }),
+          actions.updatePlayerManagement(playerId, teamId, {
+            extensionDecision: decision === "let_walk" ? "let_walk" : null,
+          }),
         );
         applied.push({
           playerId,
           decision,
-          message: "Marked as let walk (intent only — the player stays on the roster until the contract expires).",
+          message: decision === "let_walk"
+            ? "Marked as let walk (intent only — the player stays on the roster until the contract expires)."
+            : "Cleared the saved let-walk intent (the player's extension decision is back to undecided).",
         });
       } catch (err) {
         failed.push({ playerId, decision, reason: err?.message ?? "Let-walk intent update failed." });

--- a/src/ui/utils/rosterDecisionCommitPlan.js
+++ b/src/ui/utils/rosterDecisionCommitPlan.js
@@ -15,12 +15,22 @@
  *                    requires the player on the team and league phase 'offseason_resign')
  *  - let_walk      → no roster mutation exists; ContractCenter only records intent via
  *                    actions.updatePlayerManagement({ extensionDecision: 'let_walk' })
+ *  - clear_let_walk→ reviewed clear intent for a persisted let-walk; executed via
+ *                    actions.updatePlayerManagement({ extensionDecision: null }).
+ *                    Not a board pill (never in DECISION_OPTIONS) — it only enters the
+ *                    decisions payload when the board toggles off a persisted let-walk.
  */
 
 import { derivePlayerContractFinancials, formatContractMoney } from "./contractFormatting.js";
 import { calculateReleaseDeadCap } from "../../core/contracts/contractObligations.js";
 
-export const ROSTER_DECISION_KEYS = Object.freeze(["extend", "cut", "franchise_tag", "let_walk"]);
+export const ROSTER_DECISION_KEYS = Object.freeze([
+  "extend",
+  "cut",
+  "franchise_tag",
+  "let_walk",
+  "clear_let_walk",
+]);
 
 /**
  * Results of the handler audit above. `false` means the decision has no
@@ -37,6 +47,7 @@ const DECISION_HAS_ROSTER_MUTATION_HANDLER = Object.freeze({
   cut: true,
   franchise_tag: true,
   let_walk: false, // intent-only via updatePlayerManagement; no roster mutation
+  clear_let_walk: false, // intent-only: wipes a persisted let_walk back to null
 });
 
 /** Phase the worker's APPLY_FRANCHISE_TAG handler requires. */
@@ -95,6 +106,11 @@ function buildValidEntry({ playerId, decision, player, league }) {
     case "let_walk":
       warnings.push(
         "Planning note only — letting a player walk is not an immediate roster change; the contract expires on its own.",
+      );
+      break;
+    case "clear_let_walk":
+      warnings.push(
+        "Clears the saved let-walk intent — no roster change; the player's extension decision returns to undecided.",
       );
       break;
     default:

--- a/src/ui/utils/rosterDecisionCommitPlan.test.js
+++ b/src/ui/utils/rosterDecisionCommitPlan.test.js
@@ -195,6 +195,19 @@ describe("buildRosterDecisionCommitPlan", () => {
     expect(entry.warnings.some((w) => /planning note only/i.test(w))).toBe(true);
   });
 
+  it("clear_let_walk is valid and flagged as clearing the saved intent (no roster change)", () => {
+    const plan = buildRosterDecisionCommitPlan({
+      decisions: { 7: "clear_let_walk" },
+      roster: makeRoster(),
+      league: LEAGUE,
+    });
+    const entry = plan.valid[0];
+    expect(entry).toMatchObject({ playerId: "7", decision: "clear_let_walk" });
+    expect(entry.blockingErrors).toEqual([]);
+    expect(entry.warnings.some((w) => /clears the saved let-walk intent/i.test(w))).toBe(true);
+    expect(entry.warnings.some((w) => /no roster change/i.test(w))).toBe(true);
+  });
+
   it("never mutates decisions, roster, players, or league", () => {
     const roster = makeRoster().map((p) => Object.freeze({ ...p, contract: p.contract ? Object.freeze({ ...p.contract }) : undefined }));
     Object.freeze(roster);
@@ -206,7 +219,13 @@ describe("buildRosterDecisionCommitPlan", () => {
     expect(JSON.stringify({ roster, decisions, league })).toBe(before);
   });
 
-  it("exposes exactly the four supported decision keys", () => {
-    expect([...ROSTER_DECISION_KEYS]).toEqual(["extend", "cut", "franchise_tag", "let_walk"]);
+  it("exposes exactly the five supported decision keys", () => {
+    expect([...ROSTER_DECISION_KEYS]).toEqual([
+      "extend",
+      "cut",
+      "franchise_tag",
+      "let_walk",
+      "clear_let_walk",
+    ]);
   });
 });

--- a/src/worker/__tests__/playerManagementHandler.test.js
+++ b/src/worker/__tests__/playerManagementHandler.test.js
@@ -1,0 +1,79 @@
+/**
+ * playerManagementHandler.test.js — regression guards for
+ * handleUpdatePlayerManagement (toWorker.UPDATE_PLAYER_MANAGEMENT).
+ *
+ * worker.js is a monolith whose handlers are not exported, so these follow the
+ * repo's source-sentinel pattern (see releaseHandlerGuards.test.js): read the
+ * source and assert the load-bearing lines exist.
+ *
+ * Contract locked down (Let Walk durable intent V1):
+ *  1. extensionDecision = 'let_walk' is a valid value and is persisted onto
+ *     the player patch — the Roster Decision Board pre-populates from the
+ *     persisted field on mount, so losing this line silently breaks intent
+ *     durability across navigation.
+ *  2. An explicit `extensionDecision: null` clears the persisted intent (the
+ *     board's reviewed clear-intent flow). Only a literal null clears; an
+ *     absent/undefined field must never touch the stored decision, which the
+ *     string-typeof guard on the set-path already enforces.
+ *  3. The patch persists through cache.updatePlayer + flushDirty and the
+ *     handler replies with a STATE_UPDATE carrying the request id, so the
+ *     client roster reflects the new value on the next view state.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const workerSource = readFileSync(resolve(process.cwd(), 'src/worker/worker.js'), 'utf8');
+
+function extractFunction(source, name) {
+  const start = source.indexOf(`async function ${name}(`);
+  expect(start, `${name} must exist in worker.js`).toBeGreaterThan(-1);
+  // Slice to the next top-level function declaration — good enough for sentinels.
+  const rest = source.slice(start);
+  const next = rest.slice(1).search(/\n(async )?function \w+\(/);
+  return next === -1 ? rest : rest.slice(0, next + 1);
+}
+
+describe('handleUpdatePlayerManagement extensionDecision persistence', () => {
+  const fn = extractFunction(workerSource, 'handleUpdatePlayerManagement');
+
+  it("accepts 'let_walk' as a valid extensionDecision value", () => {
+    const validSet = fn.match(/validExtensionDecisions = new Set\(\[([^\]]*)\]\)/);
+    expect(validSet, 'validExtensionDecisions allowlist must exist').toBeTruthy();
+    expect(validSet[1]).toContain("'let_walk'");
+  });
+
+  it('persists a validated string extensionDecision onto the player patch', () => {
+    expect(fn.includes(
+      "if (typeof updates.extensionDecision === 'string' && validExtensionDecisions.has(updates.extensionDecision))",
+    )).toBe(true);
+    expect(fn.includes('patch.extensionDecision = updates.extensionDecision')).toBe(true);
+  });
+
+  it('clears the persisted intent ONLY for an explicit null, not for undefined', () => {
+    // The clear branch must be the else-if of the string set-path, so an
+    // absent field falls through both branches and never touches the value.
+    const clearBranch = fn.match(/} else if \(updates\.extensionDecision === null\) \{[\s\S]*?patch\.extensionDecision = null;/);
+    expect(clearBranch, 'explicit-null clear branch must exist').toBeTruthy();
+    expect(fn.includes('updates.extensionDecision === undefined')).toBe(false);
+  });
+
+  it('writes the patch through cache.updatePlayer and flushes before replying', () => {
+    const updateIdx = fn.indexOf('cache.updatePlayer(player.id, patch)');
+    const flushIdx = fn.indexOf('await flushDirty()');
+    const replyIdx = fn.indexOf('post(toUI.STATE_UPDATE, buildViewState(), id)');
+    expect(updateIdx).toBeGreaterThan(-1);
+    expect(flushIdx).toBeGreaterThan(updateIdx);
+    expect(replyIdx).toBeGreaterThan(flushIdx);
+  });
+
+  it('rejects a payload with no valid updates instead of writing an empty patch', () => {
+    const emptyGuardIdx = fn.indexOf('if (Object.keys(patch).length === 0)');
+    const updateIdx = fn.indexOf('cache.updatePlayer(player.id, patch)');
+    expect(emptyGuardIdx).toBeGreaterThan(-1);
+    expect(emptyGuardIdx).toBeLessThan(updateIdx);
+    const guardBody = fn.slice(emptyGuardIdx, updateIdx);
+    expect(guardBody.includes('post(toUI.ERROR')).toBe(true);
+    expect(guardBody.includes('return;')).toBe(true);
+  });
+});

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -10081,6 +10081,11 @@ async function handleUpdatePlayerManagement({ playerId, teamId, updates = {} }, 
   }
   if (typeof updates.extensionDecision === 'string' && validExtensionDecisions.has(updates.extensionDecision)) {
     patch.extensionDecision = updates.extensionDecision;
+  } else if (updates.extensionDecision === null) {
+    // Explicit null clears a persisted intent (Roster Decision Board reviewed
+    // clear-intent flow). Only a literal null clears — an absent/undefined
+    // field must never touch the stored decision.
+    patch.extensionDecision = null;
   }
 
   if (Object.keys(patch).length === 0) {


### PR DESCRIPTION
## Summary

The Roster Decision Board's `let_walk` decisions were persisted by the worker (`updatePlayerManagement` → `extensionDecision: 'let_walk'`) but never reflected back on the board — the intent was lost on navigation. This makes the intent durable end-to-end:

- **Worker** (`worker.js`): `handleUpdatePlayerManagement` already validated and persisted `'let_walk'` — the `extensionDecision` field already existed (used by Contract Center, the tag handler, and AI logic), so no schema change. The only addition is an explicit-null clear branch: `{ extensionDecision: null }` wipes a persisted intent; an absent/undefined field still never touches the stored value.
- **Board pre-population** (`RosterDecisionBoard.jsx`): pending decisions seed from persisted `player.extensionDecision === 'let_walk'` on mount, and on later roster syncs via an effect. A `userTouchedRef` (set on decide/reset/review/apply) gates the sync so a roster refresh never clobbers session edits. Only `let_walk` pre-populates — no other persisted value (`pending`/`deferred`/`extended`/`tagged`) maps unambiguously to a `DECISION_OPTIONS` key.
- **Clear intent, no hidden mutation path**: toggling off a persisted let-walk pill becomes a local `clear_let_walk` pending decision — no worker call from the pill. It flows through the same Review Decisions / Apply Executable Decisions flow: the plan builder validates it as an intent-only entry, and the execution adapter applies it as `updatePlayerManagement(playerId, teamId, { extensionDecision: null })`. `PlayerDecisionRow` only renders a muted "Pending: clears the saved Let Walk intent on apply." note (`DECISION_OPTIONS` unchanged).
- **Dry-run parity**: a pre-populated `let_walk` is indistinguishable from a user-entered one in the decisions map, so review and apply treat them identically.

## Tests

- `playerManagementHandler.test.js` (new, repo's source-sentinel pattern): `'let_walk'` in the allowlist and persisted onto the patch; explicit-null clear (and never on undefined); persistence ordering through `cache.updatePlayer` → `flushDirty` → `STATE_UPDATE`.
- `RosterDecisionBoard.test.jsx`: pre-populates on mount; only `let_walk` pre-populates; late roster sync pre-populates while untouched; sync never overwrites a user edit; toggle-off creates a pending clear intent with no worker call; clear applies via Review/Apply as `{ extensionDecision: null }`; pre-populated let_walk reviews/applies identically to user-entered.
- `rosterDecisionCommitPlan.test.js`: `clear_let_walk` is a valid intent-only plan entry; decision-key list updated.

Full suite: 431 files / 5374 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184DzMWGKSBm3j7Ho4XWVEZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0184DzMWGKSBm3j7Ho4XWVEZ)_