### PR TITLE
Game Result Integrity Audit Closure V1

### DIFF
--- a/docs/AUDIT_REPORT.md
+++ b/docs/AUDIT_REPORT.md
@@ -12,6 +12,13 @@
 
 **Verdict: Structurally broken at the core. The game simulates each match twice with two unreconciled engines and stitches the score from one onto the stat lines of the other.**
 
+> **Game Result Integrity Audit Closure — 2026-07-09.** Re-verified every finding in this section against current `index.js`/`driveEngine.js`. Status:
+> - **Return-TD precedence bug — fixed in a prior commit.** `checkReturnTD` already uses the bounded expression `Math.min(0.15, Math.max(0.01, 0.04 + (str - 70) * 0.001))` for both sides. Extracted to a tested pure helper, `calculateReturnTDChance` (`scoreKeeper.js`), with regression coverage in `src/core/__tests__/simulation/gameResultIntegrity.test.js`. No behavior change.
+> - **Overtime gating on the wrong score — fixed in a prior commit.** The `if (homeScore === awayScore)` OT check already runs on `homeScore`/`awayScore` *after* they are assigned from `driveSummary` (the canonical source), not a stale engine-A value. Regression test added (playoff games never commit a tied result).
+> - **Ties recorded as home wins — fixed in a prior commit.** `winnerIsHome`/`homeWin`/`awayWin`/`tie` are all derived via strict three-way comparison (`homeScore > awayScore` / `awayScore > homeScore` / `===`) everywhere in `index.js`. Consolidated into a tested pure helper, `buildGameOutcomeState` (`scoreKeeper.js`), used by `commitGameResult` and the `simulateBatch` fallback path so a tie can never surface as `homeWin: true`.
+> - **Dual-engine score/stat fracture — partially fixed in a prior commit, one residual mismatch fixed in this PR.** `driveSummary` (the drive engine) is already the authoritative source for the final score *and* for TD/FG/XP counts fed into the box score (`homeTDs`/`homeFGs`/`homeXPs` all read `driveSummary?.… ?? homeRes.…`). The one remaining leak: 2-point-conversion attribution (`homeTwoPts`/`awayTwoPts`) still read `homeRes.twoPtMade`/`awayRes.twoPtMade` — engine A's independently-seeded count — instead of `driveSummary`'s. Patched to prefer `driveSummary?.homeStats?.twoPointMade` (falling back to engine A only if the drive summary is unavailable), matching the pattern already used for TDs/FGs/XPs. Regression test added: box-score point totals (`TDs·6 + 2-pt·2 + FG·3 + XP`) now sum exactly to `homeScore`/`awayScore` across 30 seeded games.
+> - **Known gap, intentionally deferred (not in original scope, out of surgical-fix budget):** the play-by-play-derived scoring narrative (`scoringSummary`/`quarterScores`, built from `fullGameResult.playLogs`, i.e. engine A) is **not** reconciled with the canonical `driveSummary`-based final score — the two can diverge substantially (observed: canonical 54–34 vs. quarter-by-quarter narrative summing to 17–7 for the same seed). Fixing this requires either making engine A authoritative again (regressing the box-score fix above) or teaching the drive engine to emit play-by-play events, both of which are simulation-architecture changes beyond this audit-closure pass. Flagged for a follow-up architectural decision, not patched here.
+
 ### Are game outcome calculations mathematically sound?
 **No — the architecture is the problem, not the individual formulas.** Each individual engine produces plausible NFL ranges (`buildDriveBasedSummary`, `driveEngine.js:111-144`: 20–26 drives, `driveSuccess` clamped 0.15–0.72, 67% TD / 33% FG split → ~20–26 pts/team). But two engines run per game:
 
@@ -49,8 +56,11 @@ There is no constraint that `7·TDs + 3·FGs + XPs == homeScore`. **A user can s
   const returnTDChance = 0.04 + (team === result.home ? homeStr : awayStr - 70) * 0.001;
   ```
   Operator precedence parses this as `home ? homeStr : (awayStr-70)*0.001`, so when home, `returnTDChance ≈ 0.04 + 75 = 75.04` → **always fires**; when away, it's near-zero. The added points land on the discarded engine's score anyway.
+  **[FIXED — prior commit, re-verified 2026-07-09]** Live code already reads `Math.min(0.15, Math.max(0.01, 0.04 + (str - 70) * 0.001))` for both sides.
 - **Overtime gates on the wrong score (Critical).** `if (homeScore === awayScore)` (`index.js:1128`) runs *after* `homeScore`/`awayScore` were reassigned from engine B, so OT triggers on a value unrelated to the play-by-play the user watched.
+  **[FIXED — prior commit, re-verified 2026-07-09]** The live OT check already runs on the post-reassignment (canonical) `homeScore`/`awayScore`.
 - **Ties recorded as home wins (High).** `winnerIsHome = homeScore >= awayScore` (`index.js:1543`) contradicts `homeWin: homeScore > awayScore` (`index.js:1864`); a true tie is shown as a home win in the recap.
+  **[FIXED — prior commit, re-verified 2026-07-09]** All winner/tie fields now use strict three-way comparison; see closure note above.
 
 ---
 
@@ -168,11 +178,11 @@ For completeness, the sections still crammed in the dead monolith (already extra
 
 | # | Issue Title | Severity | Category | What the User Experiences | Root Cause (file + function) | Fix Summary |
 |---|---|---|---|---|---|---|
-| 1 | Dual-engine score/stat fracture | Critical | Simulation | Box-score TDs don't match the final score; QB has 3 TDs in a 13-9 game | `index.js:1116-1123` `simulateMatchup` (score from `buildDriveBasedSummary`, TDs from `simulateFullGame`) | Pick one authoritative engine for both score and TD/FG counts |
-| 2 | Overtime gates on the wrong score | Critical | Simulation | OT fails to trigger on real ties / appends points to non-tied games | `index.js:1128` (uses reassigned engine-B score) | Run OT off the single reconciled score source |
+| 1 | Dual-engine score/stat fracture | Critical | Simulation | Box-score TDs don't match the final score; QB has 3 TDs in a 13-9 game | `index.js:1116-1123` `simulateMatchup` (score from `buildDriveBasedSummary`, TDs from `simulateFullGame`) | **[MOSTLY FIXED 2026-07-09]** TD/FG/XP already reconciled to `driveSummary` in a prior commit; the 2-pt-conversion leak fixed in this PR. Residual gap: `scoringSummary`/`quarterScores` narrative still derives from engine A playLogs — deferred, see Section 1 closure note. |
+| 2 | Overtime gates on the wrong score | Critical | Simulation | OT fails to trigger on real ties / appends points to non-tied games | `index.js:1128` (uses reassigned engine-B score) | **[FIXED — prior commit, verified 2026-07-09]** OT already gates on the canonical post-reassignment score. |
 | 3 | Two disagreeing injury-availability predicates | Critical | Simulation | Injured player appears in one sim path's lineup but not the other | `injury-core.js:94-108` `canPlayerPlay` vs `playExecution.js` `!p.injured` | Single availability predicate; `injured===true` ⇒ excluded |
-| 4 | Return-TD probability precedence bug | High | Simulation | Special-teams return TDs at ~75% when home, ~0% away | `index.js:1079` `checkReturnTD` | `0.04 + ((home?homeStr:awayStr)-70)*0.001`, clamp |
-| 5 | Ties recorded as home wins | High | Simulation | A tied regular-season game shows the home team winning | `index.js:1543` vs `:1864` | Three-way compare; only `>` is a win |
+| 4 | Return-TD probability precedence bug | High | Simulation | Special-teams return TDs at ~75% when home, ~0% away | `index.js:1079` `checkReturnTD` | **[FIXED — prior commit, verified 2026-07-09]** Bounded expression already in place; extracted to a tested helper in this PR. |
+| 5 | Ties recorded as home wins | High | Simulation | A tied regular-season game shows the home team winning | `index.js:1543` vs `:1864` | **[FIXED — prior commit, verified 2026-07-09]** Strict three-way comparison already in place everywhere; consolidated into a tested helper in this PR. |
 | 6 | In-game injuries mutate shared rosters during 0-0 retry | High | Data Integrity | Rare games stack/duplicate injuries on the live roster | `index.js:1240-1254`, retry `:2085-2090` | Apply injuries once at commit, or snapshot/rollback |
 | 7 | Depth chart never repaired after a cut | High | AI | Released starter remains a ghost in the lineup until an unrelated rebuild | `worker.js:6142-6230` (no `ensureTeamDepthChart`) | Strip released ID + repair on release |
 | 8 | Salary cap effectively soft (capRoom goes negative) | High | AI | Teams silently sit over the "hard" cap; AI loses budgeted targets | `ai-logic.js:79-82` `updateTeamCap` | Reject/clamp any transaction leaving `capRoom < 0` |
@@ -201,15 +211,15 @@ For completeness, the sections still crammed in the dead monolith (already extra
 ## SECTION 7 — TOP 10 PRIORITY REPAIR LIST
 
 ```
-1.  [Critical] Dual-engine score/stat fracture → index.js:1116-1123 simulateMatchup → derive TDs/FGs and score from ONE engine (make buildDriveBasedSummary authoritative for both).
-2.  [Critical] Overtime gates on the wrong (engine-B) score → index.js:1128 → run OT off the single reconciled score after #1.
+1.  [Critical] Dual-engine score/stat fracture → index.js:1116-1123 simulateMatchup → derive TDs/FGs and score from ONE engine (make buildDriveBasedSummary authoritative for both). [MOSTLY FIXED 2026-07-09 — see Section 1 closure note; scoringSummary/quarterScores narrative split deferred]
+2.  [Critical] Overtime gates on the wrong (engine-B) score → index.js:1128 → run OT off the single reconciled score after #1. [FIXED — prior commit, verified 2026-07-09]
 3.  [Critical] Two disagreeing injury-availability predicates → injury-core.js:94-108 canPlayerPlay vs playExecution.js → make injured===true a hard exclude in both paths.
-4.  [High] Return-TD ~75% precedence bug → index.js:1079 checkReturnTD → fix parenthesization and clamp.
+4.  [High] Return-TD ~75% precedence bug → index.js:1079 checkReturnTD → fix parenthesization and clamp. [FIXED — prior commit, verified 2026-07-09]
 5.  [High] Depth chart never repaired after a cut → worker.js:6142-6230 → call ensureTeamDepthChart on release.
 6.  [High] Salary cap effectively soft → ai-logic.js:79-82 updateTeamCap → reject any transaction leaving capRoom < 0.
 7.  [High] TradeCenter accept has no error handling → TradeCenter.jsx:554 → wrap in try/catch + surface failure.
 8.  [High] Record holder uses recyclable numeric id → recordBookV1.js:664/675; legacyScore.js:228 → match on immutable GUID.
-9.  [High] Ties recorded as home wins → index.js:1543 → three-way comparison.
+9.  [High] Ties recorded as home wins → index.js:1543 → three-way comparison. [FIXED — prior commit, verified 2026-07-09]
 10. [High] Trade valuation inconsistent/exploitable → trade-logic.js:96-125,453 + worker.js:6968-7010 → single shared getAssetValue(); penalize by live cap.
 ```
 

--- a/src/core/__tests__/simulation/gameResultIntegrity.test.js
+++ b/src/core/__tests__/simulation/gameResultIntegrity.test.js
@@ -1,0 +1,223 @@
+/**
+ * Game Result Integrity Audit Closure — Regression Suite (V1)
+ *
+ * Locks in the audit-closure findings from docs/AUDIT_REPORT.md Section 1:
+ *  1. Return-TD probability stays bounded [0.01, 0.15] for any team strength.
+ *  2. The final score and its TD/FG/XP/2-pt scoring breakdown come from the
+ *     same authoritative source (the drive engine), so the box score always
+ *     sums to the scoreboard.
+ *  3. Overtime gates on the canonical (post-drive-engine) score, never a
+ *     stale intermediate value.
+ *  4. Winner/tie state uses strict three-way comparison — a true tie is
+ *     never represented as a home win.
+ *  5. Identical seed + input always reproduces an identical result.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Utils as U } from '../../utils.js';
+import { simGameStats } from '../../simulation/index.js';
+import { calculateReturnTDChance, buildGameOutcomeState } from '../../simulation/scoreKeeper.js';
+
+// ── Minimal roster factory (mirrors the engine's expected player shape) ─────
+function makePlayer(id, pos, ovr = 75) {
+  const ratings = {
+    QB: { throwPower: 75, throwAccuracy: 75, awareness: 75, speed: 65, agility: 65 },
+    RB: { speed: 78, trucking: 72, juking: 70, awareness: 65 },
+    WR: { speed: 85, awareness: 72, catching: 80 },
+    TE: { speed: 72, awareness: 70, catching: 74 },
+    OL: { passBlock: 73, runBlock: 74 },
+    DL: { passRushPower: 73, passRushSpeed: 71, tackle: 72, strength: 74 },
+    LB: { tackle: 75, awareness: 72, speed: 72, strength: 70 },
+    CB: { speed: 82, awareness: 72, agility: 78 },
+    S: { speed: 78, awareness: 75, tackle: 70 },
+    K: { kickPower: 78, kickAccuracy: 76 },
+    P: { kickPower: 76 },
+  };
+  return {
+    id: `${id}`, pos, ovr, name: `${pos} ${id}`, ratings: ratings[pos] || {},
+    stats: { game: {}, season: {} },
+  };
+}
+
+function buildTeam(id) {
+  return {
+    id,
+    abbr: `T${id}`,
+    name: `Team ${id}`,
+    roster: [
+      makePlayer(`${id}-qb1`, 'QB', 80),
+      makePlayer(`${id}-rb1`, 'RB', 76),
+      makePlayer(`${id}-rb2`, 'RB', 70),
+      makePlayer(`${id}-wr1`, 'WR', 79),
+      makePlayer(`${id}-wr2`, 'WR', 74),
+      makePlayer(`${id}-wr3`, 'WR', 70),
+      makePlayer(`${id}-te1`, 'TE', 74),
+      makePlayer(`${id}-ol1`, 'OL', 74),
+      makePlayer(`${id}-ol2`, 'OL', 72),
+      makePlayer(`${id}-ol3`, 'OL', 71),
+      makePlayer(`${id}-ol4`, 'OL', 70),
+      makePlayer(`${id}-ol5`, 'OL', 70),
+      makePlayer(`${id}-dl1`, 'DL', 76),
+      makePlayer(`${id}-dl2`, 'DL', 72),
+      makePlayer(`${id}-lb1`, 'LB', 74),
+      makePlayer(`${id}-lb2`, 'LB', 71),
+      makePlayer(`${id}-cb1`, 'CB', 75),
+      makePlayer(`${id}-cb2`, 'CB', 72),
+      makePlayer(`${id}-s1`, 'S', 73),
+      makePlayer(`${id}-k1`, 'K', 70),
+      makePlayer(`${id}-p1`, 'P', 70),
+    ],
+  };
+}
+
+function runGame(seed, options = {}) {
+  const home = buildTeam(1);
+  const away = buildTeam(2);
+  const league = {
+    week: 1, seasonId: 2030, year: 2030,
+    teams: [home, away],
+    globalSeed: seed,
+  };
+  U.setSeed(seed);
+  const result = simGameStats(home, away, {
+    generateLogs: true,
+    league,
+    homeAbbr: home.abbr,
+    awayAbbr: away.abbr,
+    ...options,
+  });
+  return { result, home, away };
+}
+
+// ── 1. Return-TD probability bounded [0.01, 0.15] ───────────────────────────
+describe('calculateReturnTDChance — bounded probability', () => {
+  it('stays within [0.01, 0.15] for representative strength values', () => {
+    for (const str of [40, 70, 100]) {
+      const chance = calculateReturnTDChance(str);
+      expect(chance).toBeGreaterThanOrEqual(0.01);
+      expect(chance).toBeLessThanOrEqual(0.15);
+    }
+  });
+
+  it('clamps to the floor/ceiling for extreme strength values (regression for the old precedence bug)', () => {
+    // The old bug parsed `home ? homeStr : (awayStr - 70) * 0.001`, which for a
+    // home team produced `0.04 + homeStr` (~75+ for any realistic strength).
+    // A correctly-bounded expression must never exceed 0.15 regardless of how
+    // large `str` is.
+    expect(calculateReturnTDChance(999)).toBe(0.15);
+    expect(calculateReturnTDChance(-999)).toBe(0.01);
+    expect(calculateReturnTDChance(0)).toBeGreaterThanOrEqual(0.01);
+  });
+
+  it('is symmetric — home and away use the identical formula (no side-dependent branching)', () => {
+    // The historical bug made home ≈0.75+ and away ≈0 for the same strength.
+    // The fixed formula must produce identical output for identical input
+    // regardless of which side it's computed for.
+    const homeChance = calculateReturnTDChance(85);
+    const awayChance = calculateReturnTDChance(85);
+    expect(homeChance).toBe(awayChance);
+  });
+});
+
+// ── 2. buildGameOutcomeState — three-way winner/tie classification ─────────
+describe('buildGameOutcomeState — winner/tie/margin classification', () => {
+  it('reports a home win with strict comparison fields', () => {
+    const state = buildGameOutcomeState({ homeScore: 24, awayScore: 17 });
+    expect(state.homeWin).toBe(true);
+    expect(state.awayWin).toBe(false);
+    expect(state.tie).toBe(false);
+    expect(state.winner).toBe('home');
+    expect(state.winnerIsHome).toBe(true);
+    expect(state.margin).toBe(7);
+  });
+
+  it('reports an away win with strict comparison fields', () => {
+    const state = buildGameOutcomeState({ homeScore: 14, awayScore: 20 });
+    expect(state.homeWin).toBe(false);
+    expect(state.awayWin).toBe(true);
+    expect(state.tie).toBe(false);
+    expect(state.winner).toBe('away');
+    expect(state.winnerIsHome).toBe(false);
+    expect(state.margin).toBe(6);
+  });
+
+  it('reports a tie and never represents it as a home win', () => {
+    const state = buildGameOutcomeState({ homeScore: 20, awayScore: 20 });
+    expect(state.tie).toBe(true);
+    expect(state.homeWin).toBe(false);
+    expect(state.awayWin).toBe(false);
+    expect(state.winner).toBeNull();
+    expect(state.margin).toBe(0);
+    // winnerIsHome only exists for a decisive result, never for a tie.
+    expect(state).not.toHaveProperty('winnerIsHome');
+  });
+
+  it('carries the overtimePlayed flag through unchanged', () => {
+    expect(buildGameOutcomeState({ homeScore: 23, awayScore: 20, overtimePlayed: true }).overtimePlayed).toBe(true);
+    expect(buildGameOutcomeState({ homeScore: 23, awayScore: 20 }).overtimePlayed).toBe(false);
+  });
+});
+
+// ── 3. Final score / TD / FG / XP / 2-pt box-score reconciliation ──────────
+describe('simGameStats — box score reconciles with the final score', () => {
+  function sumBoxScorePoints(roster) {
+    let offensiveTDs = 0;
+    let twoPtMade = 0;
+    let fgMade = 0;
+    let xpMade = 0;
+    for (const p of roster) {
+      const g = p.stats?.game || {};
+      offensiveTDs += (g.rushTD || 0) + (g.recTD || 0);
+      twoPtMade += g.twoPtMade || 0;
+      fgMade += g.fgMade || 0;
+      xpMade += g.xpMade || 0;
+    }
+    return {
+      points: offensiveTDs * 6 + twoPtMade * 2 + fgMade * 3 + xpMade,
+      offensiveTDs, twoPtMade, fgMade, xpMade,
+    };
+  }
+
+  it('home and away box-score point totals sum exactly to the final score across many seeds', () => {
+    for (let seed = 1; seed <= 30; seed++) {
+      const { result, home, away } = runGame(seed);
+      expect(result).toBeTruthy();
+
+      const homeBox = sumBoxScorePoints(home.roster);
+      const awayBox = sumBoxScorePoints(away.roster);
+
+      expect(homeBox.points, `seed ${seed} home mismatch`).toBe(result.homeScore);
+      expect(awayBox.points, `seed ${seed} away mismatch`).toBe(result.awayScore);
+    }
+  });
+});
+
+// ── 4. Overtime gates on the canonical score ────────────────────────────────
+describe('simGameStats — overtime uses the canonical final score', () => {
+  it('never commits a tied result for a playoff game (OT always resolves to a winner)', () => {
+    // Playoff games disallow ties (allowTies=false), so if OT correctly gates
+    // on the same canonical homeScore/awayScore used for the final result,
+    // every playoff game must end decisively. If OT instead gated on a stale
+    // intermediate score, a canonical tie could slip through uncorrected and
+    // surface here as a tied "playoff" result.
+    for (let seed = 1; seed <= 40; seed++) {
+      const { result } = runGame(seed, { isPlayoff: true });
+      expect(result.homeScore, `seed ${seed} produced a tie in a playoff game`).not.toBe(result.awayScore);
+    }
+  });
+});
+
+// ── 5. Determinism ───────────────────────────────────────────────────────────
+describe('simGameStats — deterministic for identical seed/input', () => {
+  it('produces an identical score and outcome for the same seed', () => {
+    const run1 = runGame(2468);
+    const run2 = runGame(2468);
+    expect(run1.result.homeScore).toBe(run2.result.homeScore);
+    expect(run1.result.awayScore).toBe(run2.result.awayScore);
+    expect(run1.result.teamDriveStats).toEqual(run2.result.teamDriveStats);
+
+    const outcome1 = buildGameOutcomeState({ homeScore: run1.result.homeScore, awayScore: run1.result.awayScore });
+    const outcome2 = buildGameOutcomeState({ homeScore: run2.result.homeScore, awayScore: run2.result.awayScore });
+    expect(outcome1).toEqual(outcome2);
+  });
+});

--- a/src/core/simulation/index.js
+++ b/src/core/simulation/index.js
@@ -54,6 +54,8 @@ import {
   resolveFieldGoalScore,
   resolveDefensiveTouchdownScore,
   resolveSafetyScore,
+  calculateReturnTDChance,
+  buildGameOutcomeState,
 } from './scoreKeeper.js';
 import { buildDriveBasedSummary, advanceDownDistance } from './driveEngine.js';
 import {
@@ -1134,7 +1136,7 @@ export function simGameStats(home, away, options = {}) {
         // NFL average: ~2-3 return TDs per team per season (~0.15/game)
         const checkReturnTD = (team, oppDefStr) => {
             const str = team === result.home ? homeStr : awayStr;
-            const returnTDChance = Math.min(0.15, Math.max(0.01, 0.04 + (str - 70) * 0.001));
+            const returnTDChance = calculateReturnTDChance(str);
             if (U.random() < returnTDChance) {
                 team.score += 7;
                 team.touchdowns++;
@@ -1562,10 +1564,14 @@ export function simGameStats(home, away, options = {}) {
 // In-game injuries handled within position groups
     };
 
-    // Pass the mods to the team generation
-    // Pass actualTwoPts (homeRes.twoPtMade / awayRes.twoPtMade)
-    const homeTwoPts = homeRes.twoPtMade || 0;
-    const awayTwoPts = awayRes.twoPtMade || 0;
+    // Pass the mods to the team generation.
+    // The drive engine is authoritative for the score AND its scoring-play
+    // breakdown (see homeTDs/homeFGs/homeXPs above), so 2-pt conversions
+    // must come from the same driveSummary source. Fall back to engine A
+    // only when the drive summary is unavailable, mirroring the TD/FG/XP
+    // fallback pattern above.
+    const homeTwoPts = driveSummary?.homeStats?.twoPointMade ?? (homeRes.twoPtMade || 0);
+    const awayTwoPts = driveSummary?.awayStats?.twoPointMade ?? (awayRes.twoPtMade || 0);
 
     // Collect all injuries for this game
     const gameInjuries = [];
@@ -1604,8 +1610,7 @@ export function simGameStats(home, away, options = {}) {
     const awaySacks = awayOut?.sacks ?? 0;
     // Three-way result: only a strictly higher score is a win. A tie is neither
     // a home win nor an away win.
-    const isTie = homeScore === awayScore;
-    const winnerIsHome = homeScore > awayScore;
+    const { tie: isTie, winnerIsHome = false } = buildGameOutcomeState({ homeScore, awayScore });
     const winnerAbbr = winnerIsHome ? home.abbr : away.abbr;
     const loserAbbr = winnerIsHome ? away.abbr : home.abbr;
     const winnerScore = winnerIsHome ? homeScore : awayScore;
@@ -1933,6 +1938,7 @@ export function commitGameResult(league, gameData, options = { persist: true }) 
         },
     });
 
+    const gameOutcome = buildGameOutcomeState({ homeScore, awayScore });
     const resultObj = {
         id: `g_final_${Date.now()}_${U.id()}`,
         gameId: gameData.gameId ?? null,
@@ -1944,9 +1950,9 @@ export function commitGameResult(league, gameData, options = { persist: true }) 
         scoreAway: awayScore,
         homeScore,
         awayScore,
-        homeWin: homeScore > awayScore,
-        awayWin: awayScore > homeScore,
-        tie: homeScore === awayScore,
+        homeWin: gameOutcome.homeWin,
+        awayWin: gameOutcome.awayWin,
+        tie: gameOutcome.tie,
         homeTeamName: home.name,
         awayTeamName: away.name,
         homeTeamAbbr: home.abbr,
@@ -2349,15 +2355,16 @@ export function simulateBatch(games, options = {}) {
             } catch (commitErr) {
                 console.error(`[SIM] commitGameResult threw for ${home?.abbr} vs ${away?.abbr}:`, commitErr?.message);
                 // Fallback: create a minimal result object so the game isn't lost
+                const fallbackOutcome = buildGameOutcomeState({ homeScore: sH, awayScore: sA });
                 resultObj = {
                     id: `g_fallback_${Date.now()}_${index}`,
                     home: home.id,
                     away: away.id,
                     scoreHome: sH,
                     scoreAway: sA,
-                    homeWin: sH > sA,
-                    awayWin: sA > sH,
-                    tie: sH === sA,
+                    homeWin: fallbackOutcome.homeWin,
+                    awayWin: fallbackOutcome.awayWin,
+                    tie: fallbackOutcome.tie,
                     homeTeamName: home.name,
                     awayTeamName: away.name,
                     homeTeamAbbr: home.abbr,

--- a/src/core/simulation/scoreKeeper.js
+++ b/src/core/simulation/scoreKeeper.js
@@ -61,6 +61,40 @@ export function resolveSafetyScore() {
 }
 
 /**
+ * Kick/punt return-TD probability from a team's overall strength rating.
+ * Bounded to [0.01, 0.15] (NFL average ~2-3 return TDs/team/season, ~0.15/game)
+ * regardless of how extreme `str` is.
+ * @param {number} str - team overall strength rating
+ * @returns {number}
+ */
+export function calculateReturnTDChance(str) {
+  return Math.min(0.15, Math.max(0.01, 0.04 + (str - 70) * 0.001));
+}
+
+/**
+ * Pure three-way outcome classification for a game's canonical final score.
+ * A true tie is never represented as a home win — only a strictly higher
+ * score is a win, and `winnerIsHome` is omitted entirely for ties.
+ * @param {{homeScore: number, awayScore: number, overtimePlayed?: boolean}} args
+ * @returns {{homeWin: boolean, awayWin: boolean, tie: boolean, winner: ('home'|'away'|null), winnerIsHome?: boolean, margin: number, overtimePlayed: boolean}}
+ */
+export function buildGameOutcomeState({ homeScore, awayScore, overtimePlayed = false }) {
+  const homeWin = homeScore > awayScore;
+  const awayWin = awayScore > homeScore;
+  const tie = homeScore === awayScore;
+  const state = {
+    homeWin,
+    awayWin,
+    tie,
+    winner: homeWin ? 'home' : (awayWin ? 'away' : null),
+    margin: Math.abs(homeScore - awayScore),
+    overtimePlayed: !!overtimePlayed,
+  };
+  if (!tie) state.winnerIsHome = homeWin;
+  return state;
+}
+
+/**
  * Helper to build/refresh the league's id→team map (cached on the league).
  */
 export function ensureTeamsMap(league) {


### PR DESCRIPTION
Audit-closure pass over docs/AUDIT_REPORT.md's simulation-integrity findings.
The return-TD precedence bug, overtime score gating, and tie/winner
comparisons were already fixed in prior commits — verified against live
code and left unchanged, with regression tests added so they can't regress.

One residual leak in the dual-engine score/stat fracture: 2-point-conversion
attribution still read engine A's independently-seeded twoPtMade count
instead of the canonical driveSummary count used for the score and
TD/FG/XP breakdown. Patched to source from driveSummary, matching the
existing TD/FG/XP fallback pattern.

Extracted calculateReturnTDChance and buildGameOutcomeState as small pure,
tested helpers in scoreKeeper.js to remove duplicated winner/tie logic
across commitGameResult and simulateBatch's fallback path.

Documents a deferred, out-of-scope finding: the play-by-play-derived
scoringSummary/quarterScores narrative still comes from engine A and can
diverge from the canonical driveSummary-based final score. Reconciling
that needs a deeper simulation-architecture decision, not a surgical patch.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RW8vRHdpZ8EZvf3GEqxU7Q