### PR TITLE
Depth Chart Repair After Player Release V1

### DIFF
--- a/src/core/roster/__tests__/depthChartManager.test.ts
+++ b/src/core/roster/__tests__/depthChartManager.test.ts
@@ -168,4 +168,80 @@ describe('depthChartManager', () => {
     const fallback = Manager.findEmergencyPositionFallback('CB', team.roster as any, {});
     expect(fallback?.id).toBe('10');
   });
+
+  // ── Depth chart repair after a player is permanently removed from roster ──
+  // (release / cut / waive). The roster no longer contains the player, but
+  // depthChart still holds their id until repairDepthChart runs — this is the
+  // "ghost reference" scenario ensureTeamDepthChart must clean up.
+  describe('repair after a player is removed from the roster (release/cut)', () => {
+    it('strips the released starter id from the depth chart and promotes the next eligible player', () => {
+      // QB1 ('1') released: no longer in roster, but still the QB1 slot.
+      const team = makeTeam({
+        roster: makeTeam().roster.filter((p) => p.id !== '1').concat([
+          { id: '11', name: 'QB2', pos: 'QB', ovr: 74, teamId: 1, injuryWeeksRemaining: 0 },
+        ]),
+        depthChart: { QB: ['1', '11'], RB: ['2', '3'], WR: ['4', '5'], OL: ['7', '8'], CB: ['9'], S: ['10'] },
+      });
+
+      const result = Manager.repairDepthChart(team as any, { phase: 'regular' });
+
+      expect(result.modified).toBe(true);
+      expect(result.repairedAssignments.QB).not.toContain('1');
+      expect(result.repairedAssignments.QB[0]).toBe('11');
+    });
+
+    it('leaves the slot empty (no throw) when the released player was the only one at that position', () => {
+      // CB1 ('9') released and there is no other CB/DB-eligible player on roster.
+      const team = makeTeam({
+        roster: makeTeam().roster.filter((p) => p.id !== '9'),
+        depthChart: { QB: ['1'], RB: ['2', '3'], WR: ['4', '5'], OL: ['7', '8'], CB: ['9'], S: ['10'] },
+      });
+
+      expect(() => Manager.repairDepthChart(team as any, { phase: 'regular' })).not.toThrow();
+      const result = Manager.repairDepthChart(team as any, { phase: 'regular' });
+
+      expect(result.repairedAssignments.CB).not.toContain('9');
+      // Safety can fill CB in an emergency, but if unavailable the row is left
+      // empty with an unresolved issue rather than throwing.
+      if (result.repairedAssignments.CB.length === 0) {
+        expect(result.unresolvedIssues.some((i) => i.rowKey === 'CB')).toBe(true);
+      }
+    });
+
+    it('releasing a backup does not reorder or otherwise touch unrelated rows', () => {
+      // RB2 ('3') is a backup, not the starter. Releasing them should only
+      // touch the RB row; every other row must stay byte-for-byte identical.
+      const base = makeTeam();
+      const team = makeTeam({
+        roster: base.roster.filter((p) => p.id !== '3'),
+        depthChart: { ...base.depthChart },
+      });
+
+      const result = Manager.repairDepthChart(team as any, { phase: 'regular' });
+
+      expect(result.repairedAssignments.RB).not.toContain('3');
+      expect(result.repairedAssignments.RB[0]).toBe('2'); // starter untouched
+      expect(result.repairedAssignments.QB).toEqual(base.depthChart.QB);
+      expect(result.repairedAssignments.WR).toEqual(base.depthChart.WR);
+      expect(result.repairedAssignments.OL).toEqual(base.depthChart.OL);
+      expect(result.repairedAssignments.CB).toEqual(base.depthChart.CB);
+      expect(result.repairedAssignments.S).toEqual(base.depthChart.S);
+    });
+
+    it('does not leave a ghost reference when the depth chart stores the legacy numeric id but the roster uses string ids', () => {
+      // Legacy saves may have numeric ids in depthChart while the roster (and
+      // every other id) has since been normalized to strings. The released
+      // player (numeric 2) must still be stripped regardless of type.
+      const base = makeTeam();
+      const team = makeTeam({
+        roster: base.roster.filter((p) => p.id !== '2'), // RB starter released
+        depthChart: { ...base.depthChart, RB: [2, '3'] as any }, // mixed legacy types
+      });
+
+      const result = Manager.repairDepthChart(team as any, { phase: 'regular' });
+
+      expect(result.repairedAssignments.RB.map(String)).not.toContain('2');
+      expect(result.repairedAssignments.RB[0]).toBe('3');
+    });
+  });
 });

--- a/src/worker/__tests__/depthChartRepairAfterRelease.test.js
+++ b/src/worker/__tests__/depthChartRepairAfterRelease.test.js
@@ -1,0 +1,117 @@
+/**
+ * depthChartRepairAfterRelease.test.js — regression guards for Depth Chart
+ * Repair After Player Release V1.
+ *
+ * worker.js is a monolith whose handlers are not exported, so these follow the
+ * repo's source-sentinel pattern (see releaseHandlerGuards.test.js): read the
+ * source and assert the load-bearing lines exist, and in the required order.
+ *
+ * Confirmed-live bug this locks down: three AI-driven roster-removal paths
+ * (preseason cutdowns, AI cap-management cuts, AI offseason roster cuts) set
+ * a released player's `teamId` to null directly without ever repairing
+ * `team.depthChart`, so the cut player's id lingered as a dangling
+ * starter/backup reference until an unrelated later rebuild (the next
+ * `validateAndRepairAllTeamDepthCharts('pre-sim')` pass) happened to run.
+ *
+ * The single/bulk player-release commands (handleReleasePlayer /
+ * handleBulkReleasePlayers, via releasePlayerWithValidation) already called
+ * ensureTeamDepthChart immediately after every mutation — those assertions
+ * here are regression locks, not new behavior.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve, dirname } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const workerSource = readFileSync(resolve(__dirname, '../worker.js'), 'utf8');
+
+function extractFunction(source, name) {
+  const start = source.indexOf(`async function ${name}(`);
+  expect(start, `${name} must exist in worker.js`).toBeGreaterThan(-1);
+  const rest = source.slice(start);
+  const next = rest.slice(1).search(/\n(async )?function \w+\(/);
+  return next === -1 ? rest : rest.slice(0, next + 1);
+}
+
+describe('releasePlayerWithValidation — depth chart repair (already-fixed primary release path)', () => {
+  const fn = extractFunction(workerSource, 'releasePlayerWithValidation');
+
+  it('repairs the depth chart on the waivers branch', () => {
+    const waiverBranch = fn.slice(fn.indexOf("isWaiverWindowOpen"), fn.indexOf('return { ok: true, playerId: player.id };'));
+    expect(waiverBranch.includes('ensureTeamDepthChart(teamId')).toBe(true);
+  });
+
+  it('repairs the depth chart on the immediate free-agent branch', () => {
+    const immediateBranch = fn.slice(fn.lastIndexOf("cache.updatePlayer(player.id, { teamId: null, status: 'free_agent'"));
+    expect(immediateBranch.includes('ensureTeamDepthChart(teamId')).toBe(true);
+  });
+
+  it('repairs the depth chart after the roster mutation, not before', () => {
+    const mutationIdx = fn.lastIndexOf("cache.updatePlayer(player.id, { teamId: null, status: 'free_agent'");
+    const repairIdx = fn.indexOf('ensureTeamDepthChart(teamId', mutationIdx);
+    expect(mutationIdx).toBeGreaterThan(-1);
+    expect(repairIdx).toBeGreaterThan(mutationIdx);
+  });
+});
+
+describe('AI preseason cutdowns / cap management — depth chart repair', () => {
+  const fn = extractFunction(workerSource, 'handleAdvanceWeek');
+
+  it('calls the canonical depth-chart repair after AI cutdowns and cap management', () => {
+    const cutdownIdx = fn.indexOf('AiLogic.executeAICutdowns()');
+    const capMgmtIdx = fn.indexOf('AiLogic.executeAICapManagement()');
+    const repairIdx = fn.indexOf("validateAndRepairAllTeamDepthCharts('post-ai-cutdown')");
+
+    expect(cutdownIdx).toBeGreaterThan(-1);
+    expect(capMgmtIdx).toBeGreaterThan(cutdownIdx);
+    expect(repairIdx).toBeGreaterThan(capMgmtIdx);
+  });
+
+  it('repairs depth charts before the phase-transition flush so the cleanup persists', () => {
+    const repairIdx = fn.indexOf("validateAndRepairAllTeamDepthCharts('post-ai-cutdown')");
+    const flushIdx = fn.indexOf('await flushDirty()', repairIdx);
+    expect(repairIdx).toBeGreaterThan(-1);
+    expect(flushIdx).toBeGreaterThan(repairIdx);
+  });
+
+  it('does not introduce a new post() call (response shape for this phase transition is unchanged)', () => {
+    const repairIdx = fn.indexOf("validateAndRepairAllTeamDepthCharts('post-ai-cutdown')");
+    const nextLineEnd = fn.indexOf('\n', repairIdx);
+    const line = fn.slice(repairIdx, nextLineEnd);
+    expect(line.includes('post(')).toBe(false);
+  });
+});
+
+describe('AI offseason roster cuts — depth chart repair', () => {
+  const fn = extractFunction(workerSource, 'handleAdvanceOffseason');
+
+  it('calls the canonical depth-chart repair immediately after AI offseason cuts', () => {
+    const cutsIdx = fn.indexOf('AiLogic.executeOffseasonRosterCuts()');
+    const repairIdx = fn.indexOf("validateAndRepairAllTeamDepthCharts('post-ai-offseason-cuts')");
+    expect(cutsIdx).toBeGreaterThan(-1);
+    expect(repairIdx).toBeGreaterThan(cutsIdx);
+  });
+
+  it('repairs depth charts before the free_agency phase transition is flushed', () => {
+    const repairIdx = fn.indexOf("validateAndRepairAllTeamDepthCharts('post-ai-offseason-cuts')");
+    const setMetaIdx = fn.indexOf("phase: 'free_agency'", repairIdx);
+    const flushIdx = fn.indexOf('await flushDirty()', repairIdx);
+    expect(repairIdx).toBeGreaterThan(-1);
+    expect(setMetaIdx).toBeGreaterThan(repairIdx);
+    expect(flushIdx).toBeGreaterThan(setMetaIdx);
+  });
+});
+
+describe('ensureTeamDepthChart / validateAndRepairAllTeamDepthCharts — single canonical implementation', () => {
+  it('there is exactly one repairDepthChart-backed batch entry point (no second implementation introduced)', () => {
+    const matches = [...workerSource.matchAll(/function validateAndRepairAllTeamDepthCharts\(/g)];
+    expect(matches.length).toBe(1);
+  });
+
+  it('the batch repair delegates to ensureTeamDepthChart (same per-team utility used by manual release)', () => {
+    const start = workerSource.indexOf('function validateAndRepairAllTeamDepthCharts(');
+    const body = workerSource.slice(start, workerSource.indexOf('\nfunction ', start + 1));
+    expect(body.includes('ensureTeamDepthChart(team.id')).toBe(true);
+  });
+});

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -3098,6 +3098,12 @@ async function handleAdvanceWeek(payload, id) {
     // veterans so all AI teams are under the $301.2M hard cap at season start.
     await AiLogic.executeAICapManagement();
 
+    // Both cutdown passes above release players directly (teamId -> null)
+    // without touching team.depthChart, so cut players would otherwise linger
+    // as dangling starter/backup references until the next pre-sim rebuild.
+    // Repair immediately using the same canonical utility as a manual release.
+    validateAndRepairAllTeamDepthCharts('post-ai-cutdown');
+
     // Priority 4: Initialize zeroed-out season stat entries for EVERY active player
     // on EVERY team before the first game is simulated. This guarantees that:
     //   (a) Players who never appear in a box score still show gamesPlayed: 0
@@ -11864,6 +11870,11 @@ async function handleAdvanceOffseason(payload, id) {
   // whose dead-cap penalty is less than their active cap hit.  Only runs for
   // AI-controlled teams; human roster is never touched.
   await AiLogic.executeOffseasonRosterCuts();
+
+  // These cuts mutate rosters directly without touching team.depthChart —
+  // repair immediately so a cut veteran doesn't stay a dangling depth-chart
+  // reference through free agency and the draft.
+  validateAndRepairAllTeamDepthCharts('post-ai-offseason-cuts');
 
   // ── Step 5: Phase transition → free_agency ────────────────────────────────
   // All DB writes happen here atomically before the UI is notified.


### PR DESCRIPTION
Re-audited the release/cut/waive paths on top of PR #1678: the
user-facing single/bulk release commands (releasePlayerWithValidation)
already repaired team.depthChart via ensureTeamDepthChart immediately
after every mutation, so docs/AUDIT_REPORT.md's issue #7 no longer
applies there.

Three AI-driven roster-removal paths were still live-broken, though:
preseason cutdowns and cap-management cuts (AiLogic.executeAICutdowns /
executeAICapManagement, called from handleAdvanceWeek) and AI offseason
roster cuts (AiLogic.executeOffseasonRosterCuts, called from
handleAdvanceOffseason) all set a released player's teamId to null
directly without ever repairing team.depthChart. The cut player's id
lingered as a dangling depth-chart reference until the next unrelated
validateAndRepairAllTeamDepthCharts('pre-sim') rebuild.

Fix: call the existing validateAndRepairAllTeamDepthCharts utility
right after each of those three cut passes, before the phase-transition
flush — reusing the same canonical per-team repair (ensureTeamDepthChart
-> repairDepthChart) the manual release path already relies on, with no
second implementation.

Tests: pure unit coverage in depthChartManager.test.ts for the
"player removed from roster" repair scenario (ghost reference
stripped, next-man promoted, numeric/string legacy id variants,
backup release leaves unrelated rows untouched, empty position slot
doesn't throw), plus worker-source-sentinel regression tests locking
down call order/placement for all three release paths and the
already-fixed manual release path.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F14zTr42q2WLDNwJ7PtYZP