### PR TITLE
Tension & Drama Verification: Improve High Stakes Narratives

### DIFF
--- a/src/core/simulation/gameSummaryBuilder.js
+++ b/src/core/simulation/gameSummaryBuilder.js
@@ -224,9 +224,21 @@ export function generatePostGameCallbacks(context, stats, homeScore, awayScore) 
 
   if (stakes && stakes > 50) {
     if (won) {
-      callbacks.push(`${stakes >= 90 ? 'A legendary, season-defining' : 'An incredibly clutch'} performance under immense pressure. ${userAbbr} answered the bell and secured a massive ${userScore}-${oppScore} victory!`);
+      if (isBlowout) {
+        callbacks.push(`${stakes >= 90 ? 'A legendary, season-defining' : 'An emphatic'} performance under immense pressure. ${userAbbr} completely dismantled the opponent in a ${userScore}-${oppScore} blowout!`);
+      } else if (isClose) {
+        callbacks.push(`${stakes >= 90 ? 'A legendary, season-defining' : 'An incredibly clutch'} performance under immense pressure. ${userAbbr} survived a thriller and secured a massive ${userScore}-${oppScore} victory!`);
+      } else {
+        callbacks.push(`${stakes >= 90 ? 'A legendary, season-defining' : 'An incredibly clutch'} performance under immense pressure. ${userAbbr} answered the bell and secured a massive ${userScore}-${oppScore} victory!`);
+      }
     } else {
-      callbacks.push(`A devastating, crushing ${scoreDiff}-point defeat when the stakes couldn't have been higher. The locker room is stunned.`);
+      if (isBlowout) {
+        callbacks.push(`A devastating, humiliating ${scoreDiff}-point blowout defeat when the stakes couldn't have been higher. The locker room is completely stunned.`);
+      } else if (isClose) {
+        callbacks.push(`A heart-breaking ${scoreDiff}-point loss in a thriller when the stakes couldn't have been higher. The locker room is stunned.`);
+      } else {
+        callbacks.push(`A devastating, crushing ${scoreDiff}-point defeat when the stakes couldn't have been higher. The locker room is stunned.`);
+      }
     }
   }
 


### PR DESCRIPTION
Completed the daily regression and stability pass. Ran the playability smoke test and verified basic stability (no crashes in testing). Implemented the single requested small improvement by adding emotional nuance to high stakes post-game summaries (differentiating blowouts vs close games).

Daily Summary:
- **What was tested**: Ran unit tests and the `daily_regression.spec.js` Playwright E2E test suite (Playability Smoke Test, Strategy Persistence, Contracts/Cap, Replay Exploit). Tests passed cleanly.
- **What broke**: No blocker regressions were detected during this run.
- **What was fixed**: N/A, no blockers found.
- **One small improvement**: Updated `src/core/simulation/gameSummaryBuilder.js` to branch narrative callbacks for high stakes games (`stakes > 50`) based on `isBlowout` and `isClose`, increasing emotional clarity and tension.

---
*PR created automatically by Jules for task [8897664042627724103](https://jules.google.com/task/8897664042627724103) started by @rbcati*