### PR TITLE
TradeCenter Accept Error Handling V1

### DIFF
--- a/src/ui/components/TradeCenter.jsx
+++ b/src/ui/components/TradeCenter.jsx
@@ -414,6 +414,7 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
   const [submitting, setSubmitting] = useState(false);
   const [isAccepting, setIsAccepting] = useState(false);
   const [tradeResult, setTradeResult] = useState(null);
+  const [postCommitWarning, setPostCommitWarning] = useState(null);
   const [counterOfferId, setCounterOfferId] = useState(null);
   const [previewPlayer, setPreviewPlayer] = useState(null);
   const [showSavedToast, setShowSavedToast] = useState(false);
@@ -600,7 +601,7 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
   // Single, explicit package status so the user always knows what state the
   // builder is in. Derived from existing data only — no logic change.
   const tradeStatus = useMemo(() => {
-    if (tradeResult?.error) return { tone: "danger", label: "Invalid trade", detail: "Missing team or player data — reload the partner and rebuild the package." };
+    if (tradeResult?.error) return { tone: "danger", label: "Trade action failed", detail: "The request did not complete. Review the message below and try again." };
     if (tradeResult?.accepted) return { tone: "success", label: "Trade accepted", detail: "The deal went through. Build another package or switch partners." };
     if (tradeResult) return { tone: "danger", label: "Trade rejected", detail: "See the response below, then adjust your package and try again." };
     if (!hasSelection) return { tone: "muted", label: "No assets selected", detail: "Add at least one player or pick on either side to start a package." };
@@ -688,15 +689,30 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
     if (isAccepting) return;
     setIsAccepting(true);
     setTradeResult(null);
+    setPostCommitWarning(null);
     try {
-      const resp = await actions.acceptIncomingTrade(offer.id);
-      // Worker resolved without a usable payload — treat like a failure so the
-      // user always gets feedback instead of a silent no-op.
-      if (!resp?.payload) {
+      let resp;
+      try {
+        resp = await actions.acceptIncomingTrade(offer.id);
+      } catch (e) {
+        console.error(e);
         setTradeResult({ accepted: false, error: 'Trade could not be completed. No roster changes were made. Please try again.' });
         return;
       }
-      if (resp.payload.accepted) {
+      // A usable result must carry a boolean `accepted` flag. Anything else —
+      // missing payload, `{}` payload, etc. — is a malformed transport/contract
+      // result, not a legitimate trade rejection.
+      if (typeof resp?.payload?.accepted !== 'boolean') {
+        setTradeResult({ accepted: false, error: 'Trade could not be completed. No roster changes were made. Please try again.' });
+        return;
+      }
+      // The trade request itself has settled with a real answer — commit it to
+      // the UI now. Everything below is post-commit follow-up, so a failure
+      // there must never relabel an already-completed trade as failed.
+      setTradeResult(resp.payload);
+      if (!resp.payload.accepted) return;
+
+      try {
         const partnerTeam = league?.teams?.find((team) => Number(team?.id) === Number(offer.offeringTeamId)) ?? { id: offer.offeringTeamId, abbr: offer.offeringTeamAbbr };
         const incomingPlayerIds = offer?.offering?.playerIds ?? [offer?.offeringPlayerId].filter(Boolean);
         const outgoingPlayerIds = offer?.receiving?.playerIds ?? [offer?.receivingPlayerId].filter(Boolean);
@@ -715,11 +731,12 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
         await persistFranchiseChronicle(actions, league);
         await fetchRosters(Number(offer.offeringTeamId));
         setShowSavedToast(true);
+      } catch (e) {
+        // The trade already committed on the worker side. Do not re-run it and
+        // do not report it as failed — just flag that the screen may be stale.
+        console.warn('Post-commit trade follow-up failed:', e);
+        setPostCommitWarning('Trade completed, but some screen data could not refresh. Reload to verify the latest roster.');
       }
-      setTradeResult(resp.payload);
-    } catch (e) {
-      console.error(e);
-      setTradeResult({ accepted: false, error: 'Trade could not be completed. No roster changes were made. Please try again.' });
     } finally {
       setIsAccepting(false);
     }
@@ -1071,6 +1088,15 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
 
       {/* Trade result (original) */}
       {tradeResult && <TradeResult result={tradeResult} onDismiss={() => setTradeResult(null)} />}
+      {postCommitWarning && (
+        <div
+          role="status"
+          style={{ marginTop: "var(--space-2)", borderRadius: "var(--radius-md)", border: "1px solid #FF9F0A44", background: "rgba(255,159,10,0.08)", padding: "10px 14px", display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 10, fontSize: "var(--text-xs)", color: "var(--text-muted)" }}
+        >
+          <span>{postCommitWarning}</span>
+          <Button size="sm" variant="outline" onClick={() => setPostCommitWarning(null)}>Dismiss</Button>
+        </div>
+      )}
       {tradeBlockers.length > 0 && (
         <div className="card" style={{ padding: "var(--space-3)", borderColor: "rgba(255,159,10,.45)", background: "rgba(255,159,10,.08)", display: "grid", gap: 4 }}>
           <strong style={{ fontSize: "var(--text-xs)" }}>Before you submit</strong>

--- a/src/ui/components/TradeCenter.jsx
+++ b/src/ui/components/TradeCenter.jsx
@@ -696,14 +696,14 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
         resp = await actions.acceptIncomingTrade(offer.id);
       } catch (e) {
         console.error(e);
-        setTradeResult({ accepted: false, error: 'Trade could not be completed. No roster changes were made. Please try again.' });
+        setTradeResult({ accepted: false, error: 'Trade outcome could not be confirmed. Reload before retrying to verify your roster.' });
         return;
       }
       // A usable result must carry a boolean `accepted` flag. Anything else —
       // missing payload, `{}` payload, etc. — is a malformed transport/contract
       // result, not a legitimate trade rejection.
       if (typeof resp?.payload?.accepted !== 'boolean') {
-        setTradeResult({ accepted: false, error: 'Trade could not be completed. No roster changes were made. Please try again.' });
+        setTradeResult({ accepted: false, error: 'Trade outcome could not be confirmed. Reload before retrying to verify your roster.' });
         return;
       }
       // The trade request itself has settled with a real answer — commit it to

--- a/src/ui/components/TradeCenter.jsx
+++ b/src/ui/components/TradeCenter.jsx
@@ -687,9 +687,16 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
     // Submit-lock prevents a double-fire on rapid taps.
     if (isAccepting) return;
     setIsAccepting(true);
+    setTradeResult(null);
     try {
       const resp = await actions.acceptIncomingTrade(offer.id);
-      if (resp?.payload?.accepted) {
+      // Worker resolved without a usable payload — treat like a failure so the
+      // user always gets feedback instead of a silent no-op.
+      if (!resp?.payload) {
+        setTradeResult({ accepted: false, error: 'Trade could not be completed. No roster changes were made. Please try again.' });
+        return;
+      }
+      if (resp.payload.accepted) {
         const partnerTeam = league?.teams?.find((team) => Number(team?.id) === Number(offer.offeringTeamId)) ?? { id: offer.offeringTeamId, abbr: offer.offeringTeamAbbr };
         const incomingPlayerIds = offer?.offering?.playerIds ?? [offer?.offeringPlayerId].filter(Boolean);
         const outgoingPlayerIds = offer?.receiving?.playerIds ?? [offer?.receivingPlayerId].filter(Boolean);
@@ -709,10 +716,10 @@ export default function TradeCenter({ league, actions, initialTradeContext = nul
         await fetchRosters(Number(offer.offeringTeamId));
         setShowSavedToast(true);
       }
-      if (resp?.payload) setTradeResult(resp.payload);
+      setTradeResult(resp.payload);
     } catch (e) {
       console.error(e);
-      setTradeResult({ accepted: false, error: 'Trade could not be completed. Please try again.' });
+      setTradeResult({ accepted: false, error: 'Trade could not be completed. No roster changes were made. Please try again.' });
     } finally {
       setIsAccepting(false);
     }

--- a/src/ui/components/__tests__/TradeCenterAcceptErrorHandling.test.jsx
+++ b/src/ui/components/__tests__/TradeCenterAcceptErrorHandling.test.jsx
@@ -1,0 +1,159 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, fireEvent, waitFor } from '@testing-library/react';
+import TradeCenter from '../TradeCenter.jsx';
+
+function makePlayer(id, name, { pos = 'WR', ovr = 80, age = 26, baseAnnual = 6 } = {}) {
+  return { id, name, pos, ovr, age, contract: { baseAnnual } };
+}
+
+function makeTeam(id, { abbr, capRoom = 20, roster = [], picks = [] } = {}) {
+  return { id, name: `Team ${id}`, abbr: abbr ?? `T${id}`, wins: 5, losses: 5, ties: 0, capRoom, picks, roster };
+}
+
+const USER = makeTeam(1, { abbr: 'CHI', capRoom: 20, roster: [makePlayer(101, 'User Guy', { baseAnnual: 8 })] });
+const AI = makeTeam(2, { abbr: 'DET', capRoom: 30, roster: [makePlayer(201, 'AI Guy', { baseAnnual: 5 })] });
+
+function makeIncomingOffer(overrides = {}) {
+  return {
+    id: 'offer-1',
+    offeringTeamId: 2,
+    offeringTeamAbbr: 'DET',
+    offering: { playerIds: [201], pickIds: [] },
+    receiving: { playerIds: [101], pickIds: [] },
+    reason: 'DET wants to add a receiver.',
+    offerType: 'market_offer',
+    urgency: 'standard',
+    ...overrides,
+  };
+}
+
+function makeActions(overrides = {}) {
+  return {
+    getRoster: vi.fn(async (tid) => {
+      const team = Number(tid) === 1 ? USER : AI;
+      return { payload: { team, players: team.roster } };
+    }),
+    submitTrade: vi.fn(async () => ({ payload: { accepted: false, reason: 'unused' } })),
+    counterIncomingTrade: vi.fn(async () => ({ payload: { accepted: false } })),
+    rejectIncomingTrade: vi.fn(),
+    toggleTradeBlock: vi.fn(async () => ({})),
+    save: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeLeague(offers = [makeIncomingOffer()]) {
+  return {
+    year: 2027,
+    season: 2027,
+    week: 3,
+    phase: 'regular',
+    userTeamId: 1,
+    teams: [USER, AI],
+    incomingTradeOffers: offers,
+    inboundTradeOffers: [],
+    settings: { tradeDeadlineWeek: 9 },
+  };
+}
+
+describe('TradeCenter — accept incoming trade error handling', () => {
+  afterEach(cleanup);
+
+  it('runs the existing success path on a confirmed accepted response', async () => {
+    const acceptIncomingTrade = vi.fn(async () => ({ payload: { accepted: true, reason: 'DET deal accepted.' } }));
+    const actions = makeActions({ acceptIncomingTrade });
+    const { findByText, getByText } = render(<TradeCenter league={makeLeague()} actions={actions} />);
+
+    await findByText('DET offered a deal');
+    fireEvent.click(getByText('Accept'));
+
+    await waitFor(() => expect(acceptIncomingTrade).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(getByText('Trade Accepted!')).toBeTruthy());
+    await waitFor(() => expect(actions.getRoster).toHaveBeenCalledWith(2));
+  });
+
+  it('shows a visible error and clears the pending state when the request rejects', async () => {
+    const acceptIncomingTrade = vi.fn(async () => { throw new Error('Worker not ready'); });
+    const actions = makeActions({ acceptIncomingTrade });
+    const { findByText, getByText, queryByText } = render(<TradeCenter league={makeLeague()} actions={actions} />);
+
+    await findByText('DET offered a deal');
+    fireEvent.click(getByText('Accept'));
+
+    await waitFor(() => expect(getByText('Trade Failed')).toBeTruthy());
+    expect(queryByText('Trade Accepted!')).toBeNull();
+    expect(getByText('Accept').disabled).toBe(false);
+  });
+
+  it('shows an error when the response resolves without a usable payload', async () => {
+    const acceptIncomingTrade = vi.fn(async () => undefined);
+    const actions = makeActions({ acceptIncomingTrade });
+    const { findByText, getByText, queryByText } = render(<TradeCenter league={makeLeague()} actions={actions} />);
+
+    await findByText('DET offered a deal');
+    fireEvent.click(getByText('Accept'));
+
+    await waitFor(() => expect(getByText('Trade Failed')).toBeTruthy());
+    expect(queryByText('Trade Accepted!')).toBeNull();
+    expect(getByText('Accept').disabled).toBe(false);
+  });
+
+  it('surfaces an explicit unsuccessful result without crashing or claiming success', async () => {
+    const acceptIncomingTrade = vi.fn(async () => ({ payload: { accepted: false, reason: 'Offer expired or no longer available.' } }));
+    const actions = makeActions({ acceptIncomingTrade });
+    const { findByText, getByText, queryByText } = render(<TradeCenter league={makeLeague()} actions={actions} />);
+
+    await findByText('DET offered a deal');
+    fireEvent.click(getByText('Accept'));
+
+    await waitFor(() => expect(getByText('Trade Rejected')).toBeTruthy());
+    expect(queryByText('Trade Accepted!')).toBeNull();
+  });
+
+  it('blocks a second submission while the first request is still pending', async () => {
+    let resolveAccept;
+    const acceptIncomingTrade = vi.fn(() => new Promise((resolve) => { resolveAccept = resolve; }));
+    const actions = makeActions({ acceptIncomingTrade });
+    const { findByText, getByText } = render(<TradeCenter league={makeLeague()} actions={actions} />);
+
+    await findByText('DET offered a deal');
+    fireEvent.click(getByText('Accept'));
+    fireEvent.click(getByText('Accepting…'));
+    fireEvent.click(getByText('Accepting…'));
+
+    expect(acceptIncomingTrade).toHaveBeenCalledTimes(1);
+    resolveAccept({ payload: { accepted: true, reason: 'DET deal accepted.' } });
+    await waitFor(() => expect(getByText('Trade Accepted!')).toBeTruthy());
+  });
+
+  it('does not trigger success cleanup or roster refresh on a failed acceptance', async () => {
+    const acceptIncomingTrade = vi.fn(async () => { throw new Error('Worker timeout'); });
+    const actions = makeActions({ acceptIncomingTrade });
+    const { findByText, getByText } = render(<TradeCenter league={makeLeague()} actions={actions} />);
+
+    await findByText('DET offered a deal');
+    const rosterCallsBefore = actions.getRoster.mock.calls.length;
+    fireEvent.click(getByText('Accept'));
+
+    await waitFor(() => expect(getByText('Trade Failed')).toBeTruthy());
+    expect(actions.getRoster.mock.calls.length).toBe(rosterCallsBefore);
+  });
+
+  it('clears a prior error banner once a retry succeeds', async () => {
+    const acceptIncomingTrade = vi.fn()
+      .mockImplementationOnce(async () => { throw new Error('Worker not ready'); })
+      .mockImplementationOnce(async () => ({ payload: { accepted: true, reason: 'DET deal accepted.' } }));
+    const actions = makeActions({ acceptIncomingTrade });
+    const { findByText, getByText, queryByText } = render(<TradeCenter league={makeLeague()} actions={actions} />);
+
+    await findByText('DET offered a deal');
+    fireEvent.click(getByText('Accept'));
+    await waitFor(() => expect(getByText('Trade Failed')).toBeTruthy());
+
+    fireEvent.click(getByText('Accept'));
+    await waitFor(() => expect(getByText('Trade Accepted!')).toBeTruthy());
+    expect(queryByText('Trade Failed')).toBeNull();
+  });
+});

--- a/src/ui/components/__tests__/TradeCenterAcceptErrorHandling.test.jsx
+++ b/src/ui/components/__tests__/TradeCenterAcceptErrorHandling.test.jsx
@@ -44,7 +44,7 @@ function makeActions(overrides = {}) {
   };
 }
 
-function makeLeague(offers = [makeIncomingOffer()]) {
+function makeLeague(offers = [makeIncomingOffer()], overrides = {}) {
   return {
     year: 2027,
     season: 2027,
@@ -55,6 +55,7 @@ function makeLeague(offers = [makeIncomingOffer()]) {
     incomingTradeOffers: offers,
     inboundTradeOffers: [],
     settings: { tradeDeadlineWeek: 9 },
+    ...overrides,
   };
 }
 
@@ -155,5 +156,65 @@ describe('TradeCenter — accept incoming trade error handling', () => {
     fireEvent.click(getByText('Accept'));
     await waitFor(() => expect(getByText('Trade Accepted!')).toBeTruthy());
     expect(queryByText('Trade Failed')).toBeNull();
+  });
+
+  it('treats an empty payload object as a malformed result, not a legitimate rejection', async () => {
+    const acceptIncomingTrade = vi.fn(async () => ({ payload: {} }));
+    const actions = makeActions({ acceptIncomingTrade });
+    const { findByText, getByText, queryByText } = render(<TradeCenter league={makeLeague()} actions={actions} />);
+
+    await findByText('DET offered a deal');
+    fireEvent.click(getByText('Accept'));
+
+    await waitFor(() => expect(getByText('Trade Failed')).toBeTruthy());
+    expect(queryByText('Trade Rejected')).toBeNull();
+    expect(queryByText('Trade Accepted!')).toBeNull();
+  });
+
+  it('keeps showing "Trade Accepted!" even when post-commit chronicle sync fails', async () => {
+    const acceptIncomingTrade = vi.fn(async () => ({ payload: { accepted: true, reason: 'DET deal accepted.' } }));
+    const updateFranchiseChronicle = vi.fn(async () => { throw new Error('chronicle write failed'); });
+    const actions = makeActions({ acceptIncomingTrade, updateFranchiseChronicle });
+    const league = makeLeague([makeIncomingOffer()], { franchiseChronicle: [] });
+    const { findByText, getByText, queryByText } = render(<TradeCenter league={league} actions={actions} />);
+
+    await findByText('DET offered a deal');
+    fireEvent.click(getByText('Accept'));
+
+    await waitFor(() => expect(getByText('Trade Accepted!')).toBeTruthy());
+    // The trade committed on the worker side — a follow-up sync failure must
+    // never relabel it as failed or claim no roster changes were made.
+    expect(queryByText('Trade Failed')).toBeNull();
+    expect(queryByText(/No roster changes were made/i)).toBeNull();
+    await waitFor(() => expect(getByText(/could not refresh/i)).toBeTruthy());
+  });
+
+  it('never shows "No roster changes were made" for a post-commit follow-up failure', async () => {
+    const acceptIncomingTrade = vi.fn(async () => ({ payload: { accepted: true, reason: 'DET deal accepted.' } }));
+    const updateFranchiseChronicle = vi.fn(async () => { throw new Error('chronicle write failed'); });
+    const actions = makeActions({ acceptIncomingTrade, updateFranchiseChronicle });
+    const league = makeLeague([makeIncomingOffer()], { franchiseChronicle: [] });
+    const { findByText, getByText, queryByText } = render(<TradeCenter league={league} actions={actions} />);
+
+    await findByText('DET offered a deal');
+    fireEvent.click(getByText('Accept'));
+
+    await waitFor(() => expect(getByText('Trade Accepted!')).toBeTruthy());
+    expect(queryByText(/No roster changes were made/i)).toBeNull();
+  });
+
+  it('shows neutral "Trade action failed" status copy for a worker/transport error, not a data-integrity diagnosis', async () => {
+    const acceptIncomingTrade = vi.fn(async () => { throw new Error('Worker timeout'); });
+    const actions = makeActions({ acceptIncomingTrade });
+    const { findByText, getByText, getByTestId, queryByText } = render(<TradeCenter league={makeLeague()} actions={actions} />);
+
+    await findByText('DET offered a deal');
+    fireEvent.click(getByText('Accept'));
+
+    await waitFor(() => expect(getByText('Trade Failed')).toBeTruthy());
+    const banner = getByTestId('trade-status-banner');
+    expect(banner.textContent).toContain('Trade action failed');
+    expect(banner.textContent).not.toContain('Missing team or player data');
+    expect(queryByText('Invalid trade')).toBeNull();
   });
 });

--- a/src/ui/components/__tests__/TradeCenterAcceptErrorHandling.test.jsx
+++ b/src/ui/components/__tests__/TradeCenterAcceptErrorHandling.test.jsx
@@ -75,7 +75,7 @@ describe('TradeCenter — accept incoming trade error handling', () => {
     await waitFor(() => expect(actions.getRoster).toHaveBeenCalledWith(2));
   });
 
-  it('shows a visible error and clears the pending state when the request rejects', async () => {
+  it('shows the outcome-unknown message and clears the pending state when the request rejects', async () => {
     const acceptIncomingTrade = vi.fn(async () => { throw new Error('Worker not ready'); });
     const actions = makeActions({ acceptIncomingTrade });
     const { findByText, getByText, queryByText } = render(<TradeCenter league={makeLeague()} actions={actions} />);
@@ -86,9 +86,16 @@ describe('TradeCenter — accept incoming trade error handling', () => {
     await waitFor(() => expect(getByText('Trade Failed')).toBeTruthy());
     expect(queryByText('Trade Accepted!')).toBeNull();
     expect(getByText('Accept').disabled).toBe(false);
+    // A worker timeout doesn't cancel the in-flight trade — the outcome is
+    // unknown, not confirmed-failed, so the copy must not overclaim either way
+    // and must not tell the user to just retry immediately.
+    expect(getByText(/Trade outcome could not be confirmed/i)).toBeTruthy();
+    expect(getByText(/Reload before retrying/i)).toBeTruthy();
+    expect(queryByText(/Please try again/i)).toBeNull();
+    expect(queryByText(/No roster changes were made/i)).toBeNull();
   });
 
-  it('shows an error when the response resolves without a usable payload', async () => {
+  it('shows the outcome-unknown message when the response resolves without a usable payload', async () => {
     const acceptIncomingTrade = vi.fn(async () => undefined);
     const actions = makeActions({ acceptIncomingTrade });
     const { findByText, getByText, queryByText } = render(<TradeCenter league={makeLeague()} actions={actions} />);
@@ -99,6 +106,9 @@ describe('TradeCenter — accept incoming trade error handling', () => {
     await waitFor(() => expect(getByText('Trade Failed')).toBeTruthy());
     expect(queryByText('Trade Accepted!')).toBeNull();
     expect(getByText('Accept').disabled).toBe(false);
+    expect(getByText(/Trade outcome could not be confirmed/i)).toBeTruthy();
+    expect(queryByText(/Please try again/i)).toBeNull();
+    expect(queryByText(/No roster changes were made/i)).toBeNull();
   });
 
   it('surfaces an explicit unsuccessful result without crashing or claiming success', async () => {
@@ -111,6 +121,10 @@ describe('TradeCenter — accept incoming trade error handling', () => {
 
     await waitFor(() => expect(getByText('Trade Rejected')).toBeTruthy());
     expect(queryByText('Trade Accepted!')).toBeNull();
+    // A confirmed rejection is unaffected by the outcome-unknown copy change —
+    // it still shows the worker-provided reason verbatim.
+    expect(getByText('Offer expired or no longer available.')).toBeTruthy();
+    expect(queryByText(/Trade outcome could not be confirmed/i)).toBeNull();
   });
 
   it('blocks a second submission while the first request is still pending', async () => {
@@ -169,6 +183,8 @@ describe('TradeCenter — accept incoming trade error handling', () => {
     await waitFor(() => expect(getByText('Trade Failed')).toBeTruthy());
     expect(queryByText('Trade Rejected')).toBeNull();
     expect(queryByText('Trade Accepted!')).toBeNull();
+    expect(getByText(/Trade outcome could not be confirmed/i)).toBeTruthy();
+    expect(queryByText(/Please try again/i)).toBeNull();
   });
 
   it('keeps showing "Trade Accepted!" even when post-commit chronicle sync fails', async () => {


### PR DESCRIPTION
Close the failure boundary in handleAcceptIncomingTrade: a resolved
worker response with no usable payload now surfaces a visible error
instead of silently doing nothing, and a fresh accept attempt clears
any stale trade result before running (matching handlePropose). The
double-fire guard, try/catch/finally, and pending-state cleanup were
already in place and are preserved as-is.

Adds regression coverage for success, rejected promise, explicit
unaccepted result, missing/malformed response, duplicate-click
blocking, failure-does-not-refresh-roster, and error-clears-on-retry.