### PR TITLE
Fix SIM_TO_PHASE draft user-pick auto-advance

### DIFF
--- a/docs/offseason-rollover-performance-profile-v1.md
+++ b/docs/offseason-rollover-performance-profile-v1.md
@@ -135,3 +135,8 @@ Large raw traces are not committed. Generate locally with:
 ```bash
 npm run durability:profile:offseason -- --seed=1684 --phase-timeout-ms=900000 --write-report
 ```
+
+
+## #1688 implementation status
+
+The #1687 recommendation to repair user-owned draft-pick progress in `SIM_TO_PHASE('preseason')` is implemented by #1688. The original measurements above are intentionally preserved as the before profile. The post-fix comparison is documented in `docs/sim-to-phase-draft-user-pick-auto-advance-v1.md` and generated durability/profiler reports.

--- a/docs/sim-to-phase-draft-user-pick-auto-advance-v1.md
+++ b/docs/sim-to-phase-draft-user-pick-auto-advance-v1.md
@@ -1,0 +1,59 @@
+# SIM_TO_PHASE Draft User-Pick Auto-Advance V1
+
+## Root cause
+
+`SIM_TO_PHASE({ targetPhase: 'preseason' })` entered the draft and called the same `handleSimDraftPick()` path used by the interactive Draft UI. That handler intentionally stopped when `pick.teamId === meta.userTeamId`, so the lifecycle re-entered the unchanged user-owned pick until the outer timeout/guard stopped the rollover.
+
+## Live call path audit
+
+- UI/harness dispatches `SIM_TO_PHASE` through the worker protocol.
+- `handleSimToPhase()` loops phases and uses `handleAdvanceWeek`, `handleAdvanceOffseason`, `handleAdvanceFreeAgencyDay`, `handleAdvanceCombineWeek`, then the draft branch.
+- Draft branch calls `handleStartDraft()` to initialize the generated class and pick table, then calls `handleSimDraftPick()` in draft batches.
+- `handleSimDraftPick()` resolves the user team from `meta.userTeamId`, pauses normal interactive simulation at user-owned picks, evaluates AI-to-AI draft trade-up opportunities, selects a prospect with `buildAiTeamStrategy()`, `AiLogic.calculateTeamNeeds()`, `scoreDraftBoardEntry()`, and `getAIDraftBoardAdjustment()`, then commits with `_executeDraftPick()`.
+- `handleMakeDraftPick()` remains the manual user command. It validates that the current pick belongs to the user, validates the selected draft-eligible player, commits through `_executeDraftPick()`, logs the transaction, runs scouting reveal, and transitions after the final pick.
+- `_executeDraftPick()` is the canonical mutation point for draft pick data, player team/status/rookie contract, roster/cap recalculation, draft-pick event emission, current pick advancement, and draft state persistence.
+- Draft completion in `handleSimDraftPick()` and `handleMakeDraftPick()` runs post-draft minicamp, legality validation, and `handleStartNewSeason()` to reach preseason.
+- No worker protocol change was required; the context is internal payload metadata on the existing handler call.
+
+## Behavior contract
+
+Interactive/manual behavior remains default-safe. `SIM_DRAFT_PICK` callers do not pass the internal lifecycle context, so user-owned picks still return a blocked user-pick result and leave `currentPickIndex` unchanged for manual UI control.
+
+Batch lifecycle behavior is explicit. Only the `SIM_TO_PHASE` draft branch passes `{ allowUserAutoPick: targetPhase === 'preseason', source: 'sim_to_phase' }`, allowing the preseason rollover to make a real user-owned pick through the same weighted draft-board selector used for AI picks.
+
+## Selection path and trade-up decision
+
+The prospect-selection scoring previously embedded in `handleSimDraftPick()` is now factored into `selectCanonicalDraftProspectForTeam()`. It preserves the existing inputs: team roster, AI team strategy, team needs, positional priority, scheme/board scoring, upside, combine/interview adjustment, risk tiebreaking, and same-session need-group hoarding penalty.
+
+The batch user auto-pick does **not** add autonomous user trade acceptance. AI-to-AI trade-up behavior is preserved. User-owned batch picks are made at the currently owned slot using the canonical selection helper and `_executeDraftPick()`.
+
+## No-progress contract
+
+`handleSimToPhase()` now captures draft progress state before and after each draft batch. A batch must advance the pick index, change pick identity, complete the draft, change phase, or return an explicit blocked/error result. Otherwise it throws `DRAFT_BATCH_NO_PROGRESS` with season, phase, pick index, pick identity, and team ID.
+
+## Files changed
+
+- `src/worker/worker.js` (draft lifecycle context, no-progress guard, shared selector, and prospect class size alignment with compensatory picks)
+- `src/worker/__tests__/simToPhaseDraftAutoPickRegression.test.js`
+- `docs/offseason-rollover-performance-profile-v1.md`
+- `docs/sim-to-phase-draft-user-pick-auto-advance-v1.md`
+
+## Do-not-touch list honored
+
+No draft scoring weights, prospect generation, hidden development, roster limits, cap rules, free agency, progression, retirement, scheduling, save schema, worker protocol, UI behavior, or persistence optimization were intentionally changed.
+
+## Validation notes
+
+Post-fix validation should compare the preserved #1687 before numbers to the new profiler output: draft-batch calls, completed picks, rollover completion, runtime, flush count, peak memory, and first incomplete stage. The target evidence is not simply speed; it is that user-owned draft picks no longer create an unchanged retry loop.
+
+## Recommended next PR
+
+Choose PR #1689 only from post-fix durability/profiler evidence. If another blocker appears after the draft now progresses, scope that PR to the newly exposed first failure rather than broadening this repair.
+
+## Post-fix validation results (seed 1684)
+
+- Before profile from #1687: 5,550 draft-batch calls, 24 completed picks, 111.7s in draft batch, 5,635 flushes, peak memory 513 MB, timed out before preseason.
+- After profiler attempt: draft-batch calls dropped to 1, the draft consumed 225 picks, the unchanged user-pick retry loop was not reproduced, and the rollover moved past the draft. The run then exposed a separate post-rollover roster/history blocker rather than the old draft stall.
+- One-season durability: reached preseason 2027 in one `SIM_TO_PHASE('preseason')` call after playoffs/offseason, but failed fail-fast invariants at `afterSeasonRollover` with `roster.size-within-legal-range` for team 0 (roster size 11) and a non-fatal archive warning in `processSeasonRecords()` reading missing `passYd`. Save/reload therefore was not claimed green for the full rollover checkpoint.
+- Five-season attempt: attempted 5 seasons, completed 0 full seasons, stopped at the same season-1 post-rollover roster invariant failure.
+- Recommended next PR from new evidence: roster-membership integrity repair for post-rollover roster size, with a side audit of the season archive stat shape that produced the `passYd` warning.

--- a/docs/sim-to-phase-draft-user-pick-auto-advance-v1.md
+++ b/docs/sim-to-phase-draft-user-pick-auto-advance-v1.md
@@ -13,13 +13,13 @@
 - `handleMakeDraftPick()` remains the manual user command. It validates that the current pick belongs to the user, validates the selected draft-eligible player, commits through `_executeDraftPick()`, logs the transaction, runs scouting reveal, and transitions after the final pick.
 - `_executeDraftPick()` is the canonical mutation point for draft pick data, player team/status/rookie contract, roster/cap recalculation, draft-pick event emission, current pick advancement, and draft state persistence.
 - Draft completion in `handleSimDraftPick()` and `handleMakeDraftPick()` runs post-draft minicamp, legality validation, and `handleStartNewSeason()` to reach preseason.
-- No worker protocol change was required; the context is internal payload metadata on the existing handler call.
+- No worker protocol change was required; the context is an internal Symbol-keyed token on the existing handler call, so public worker payloads cannot forge batch auto-pick authority.
 
 ## Behavior contract
 
 Interactive/manual behavior remains default-safe. `SIM_DRAFT_PICK` callers do not pass the internal lifecycle context, so user-owned picks still return a blocked user-pick result and leave `currentPickIndex` unchanged for manual UI control.
 
-Batch lifecycle behavior is explicit. Only the `SIM_TO_PHASE` draft branch passes `{ allowUserAutoPick: targetPhase === 'preseason', source: 'sim_to_phase' }`, allowing the preseason rollover to make a real user-owned pick through the same weighted draft-board selector used for AI picks.
+Batch lifecycle behavior is explicit. Only the `SIM_TO_PHASE` draft branch passes the internal Symbol-keyed context, allowing the preseason rollover to make a real user-owned pick through the same weighted draft-board selector used for AI picks.
 
 ## Selection path and trade-up decision
 
@@ -29,12 +29,13 @@ The batch user auto-pick does **not** add autonomous user trade acceptance. AI-t
 
 ## No-progress contract
 
-`handleSimToPhase()` now captures draft progress state before and after each draft batch. A batch must advance the pick index, change pick identity, complete the draft, change phase, or return an explicit blocked/error result. Otherwise it throws `DRAFT_BATCH_NO_PROGRESS` with season, phase, pick index, pick identity, and team ID.
+`handleSimToPhase()` now captures draft progress state before and after each draft batch. A batch must advance the pick index, change pick identity, complete the draft, or change phase. Blocked/error results are treated as lifecycle stops rather than progress, and unchanged state throws `DRAFT_BATCH_NO_PROGRESS` with season, phase, pick index, pick identity, and team ID.
 
 ## Files changed
 
 - `src/worker/worker.js` (draft lifecycle context, no-progress guard, shared selector, and prospect class size alignment with compensatory picks)
 - `src/worker/__tests__/simToPhaseDraftAutoPickRegression.test.js`
+- `tests/integration/simToPhaseDraftAutoPick.worker.test.js`
 - `docs/offseason-rollover-performance-profile-v1.md`
 - `docs/sim-to-phase-draft-user-pick-auto-advance-v1.md`
 

--- a/src/worker/__tests__/simToPhaseDraftAutoPickRegression.test.js
+++ b/src/worker/__tests__/simToPhaseDraftAutoPickRegression.test.js
@@ -6,13 +6,14 @@ describe('SIM_TO_PHASE draft user-pick auto-advance wiring', () => {
   const workerSource = readFileSync(resolve(process.cwd(), 'src/worker/worker.js'), 'utf8');
 
   it('keeps normal SIM_DRAFT_PICK manual-safe by default', () => {
-    expect(workerSource).toContain("const allowUserAutoPick = payload?.allowUserAutoPick === true && payload?.source === 'sim_to_phase';");
+    expect(workerSource).toContain("const SIM_TO_PHASE_DRAFT_CONTEXT = Symbol('SIM_TO_PHASE_DRAFT_CONTEXT');");
+    expect(workerSource).toContain('const allowUserAutoPick = payload?.[SIM_TO_PHASE_DRAFT_CONTEXT] === true;');
     expect(workerSource).toContain('if (pick.teamId === userTeamId && !allowUserAutoPick)');
     expect(workerSource).toContain("reason: 'user_pick'");
   });
 
   it('opts only SIM_TO_PHASE preseason draft batches into user auto-pick', () => {
-    expect(workerSource).toContain("handleSimDraftPick({ allowUserAutoPick: targetPhase === 'preseason', source: 'sim_to_phase' }, null)");
+    expect(workerSource).toContain("handleSimDraftPick({ [SIM_TO_PHASE_DRAFT_CONTEXT]: targetPhase === 'preseason' }, null)");
     expect(workerSource).toContain("case toWorker.SIM_DRAFT_PICK:     return await handleSimDraftPick(payload, id);");
   });
 
@@ -31,6 +32,7 @@ describe('SIM_TO_PHASE draft user-pick auto-advance wiring', () => {
   it('enforces a no-progress contract around lifecycle draft batch steps', () => {
     expect(workerSource).toContain('captureDraftProgressState(cache.getMeta())');
     expect(workerSource).toContain('draftBatchMadeProgress(beforeDraftStep, afterDraftStep, draftStepResult)');
+    expect(workerSource).toContain('if (result?.blocked || result?.error) return false;');
     expect(workerSource).toContain('throw createDraftNoProgressError(beforeDraftStep, afterDraftStep, draftStepResult)');
     expect(workerSource).toContain("err.code = 'DRAFT_BATCH_NO_PROGRESS'");
   });

--- a/src/worker/__tests__/simToPhaseDraftAutoPickRegression.test.js
+++ b/src/worker/__tests__/simToPhaseDraftAutoPickRegression.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('SIM_TO_PHASE draft user-pick auto-advance wiring', () => {
+  const workerSource = readFileSync(resolve(process.cwd(), 'src/worker/worker.js'), 'utf8');
+
+  it('keeps normal SIM_DRAFT_PICK manual-safe by default', () => {
+    expect(workerSource).toContain("const allowUserAutoPick = payload?.allowUserAutoPick === true && payload?.source === 'sim_to_phase';");
+    expect(workerSource).toContain('if (pick.teamId === userTeamId && !allowUserAutoPick)');
+    expect(workerSource).toContain("reason: 'user_pick'");
+  });
+
+  it('opts only SIM_TO_PHASE preseason draft batches into user auto-pick', () => {
+    expect(workerSource).toContain("handleSimDraftPick({ allowUserAutoPick: targetPhase === 'preseason', source: 'sim_to_phase' }, null)");
+    expect(workerSource).toContain("case toWorker.SIM_DRAFT_PICK:     return await handleSimDraftPick(payload, id);");
+  });
+
+  it('reuses the canonical weighted draft-board selector instead of highest-OVR shortcuting user picks', () => {
+    const helperStart = workerSource.indexOf('function selectCanonicalDraftProspectForTeam');
+    expect(helperStart).toBeGreaterThan(-1);
+    const helperEnd = workerSource.indexOf('// ── Handler: SIM_DRAFT_PICK', helperStart);
+    const helperSource = workerSource.slice(helperStart, helperEnd);
+    expect(helperSource).toContain('scoreDraftBoardEntry');
+    expect(helperSource).toContain('buildAiTeamStrategy');
+    expect(helperSource).toContain('AiLogic.calculateTeamNeeds');
+    expect(helperSource).toContain('getAIDraftBoardAdjustment');
+    expect(helperSource).not.toContain('sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0))[0]');
+  });
+
+  it('enforces a no-progress contract around lifecycle draft batch steps', () => {
+    expect(workerSource).toContain('captureDraftProgressState(cache.getMeta())');
+    expect(workerSource).toContain('draftBatchMadeProgress(beforeDraftStep, afterDraftStep, draftStepResult)');
+    expect(workerSource).toContain('throw createDraftNoProgressError(beforeDraftStep, afterDraftStep, draftStepResult)');
+    expect(workerSource).toContain("err.code = 'DRAFT_BATCH_NO_PROGRESS'");
+  });
+});

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -5331,7 +5331,7 @@ async function handleSimToPhase({ targetPhase }, id) {
             draftDone = true;
           } else {
             const beforeDraftStep = captureDraftProgressState(cache.getMeta());
-            const draftStepResult = await offseasonProfiler.measure('stage.draft.pick-batch', { draftGuard }, () => handleSimDraftPick({ allowUserAutoPick: targetPhase === 'preseason', source: 'sim_to_phase' }, null));
+            const draftStepResult = await offseasonProfiler.measure('stage.draft.pick-batch', { draftGuard }, () => handleSimDraftPick({ [SIM_TO_PHASE_DRAFT_CONTEXT]: targetPhase === 'preseason' }, null));
             const afterDraftStep = captureDraftProgressState(cache.getMeta());
             if (!draftBatchMadeProgress(beforeDraftStep, afterDraftStep, draftStepResult)) {
               throw createDraftNoProgressError(beforeDraftStep, afterDraftStep, draftStepResult);
@@ -10688,6 +10688,8 @@ async function handleMakeDraftPick({ playerId }, id) {
 }
 
 
+const SIM_TO_PHASE_DRAFT_CONTEXT = Symbol('SIM_TO_PHASE_DRAFT_CONTEXT');
+
 function captureDraftProgressState(meta = cache.getMeta()) {
   const draftState = meta?.draftState;
   const pick = draftState?.picks?.[draftState?.currentPickIndex];
@@ -10702,7 +10704,7 @@ function captureDraftProgressState(meta = cache.getMeta()) {
 }
 
 function draftBatchMadeProgress(before, after, result = {}) {
-  if (result?.blocked || result?.error) return true;
+  if (result?.blocked || result?.error) return false;
   if (!before?.draftComplete && after?.draftComplete) return true;
   if (after?.phase !== before?.phase) return true;
   if (Number(after?.currentPickIndex ?? -1) > Number(before?.currentPickIndex ?? -1)) return true;
@@ -10806,7 +10808,7 @@ function selectCanonicalDraftProspectForTeam({ teamId, pick, draftPool, sessionP
  */
 async function handleSimDraftPick(payload = {}, id) {
   return offseasonProfiler.measure('draft.sim-batch', {}, async () => {
-  const allowUserAutoPick = payload?.allowUserAutoPick === true && payload?.source === 'sim_to_phase';
+  const allowUserAutoPick = payload?.[SIM_TO_PHASE_DRAFT_CONTEXT] === true;
   const meta = ensureDynastyMeta(cache.getMeta());
   if (!meta?.draftState) { post(toUI.ERROR, { message: 'No active draft' }, id); return; }
 

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -5330,7 +5330,12 @@ async function handleSimToPhase({ targetPhase }, id) {
           if (!ds || ds.currentPickIndex >= (ds.picks?.length ?? 0)) {
             draftDone = true;
           } else {
-            await offseasonProfiler.measure('stage.draft.pick-batch', { draftGuard }, () => handleSimDraftPick({}, null));
+            const beforeDraftStep = captureDraftProgressState(cache.getMeta());
+            const draftStepResult = await offseasonProfiler.measure('stage.draft.pick-batch', { draftGuard }, () => handleSimDraftPick({ allowUserAutoPick: targetPhase === 'preseason', source: 'sim_to_phase' }, null));
+            const afterDraftStep = captureDraftProgressState(cache.getMeta());
+            if (!draftBatchMadeProgress(beforeDraftStep, afterDraftStep, draftStepResult)) {
+              throw createDraftNoProgressError(beforeDraftStep, afterDraftStep, draftStepResult);
+            }
           }
           draftGuard++;
           await yieldFrame();
@@ -10502,7 +10507,13 @@ async function handleStartDraft(payload, id) {
   const ROUNDS    = Math.max(1, Math.min(12, Number(settings?.draftRounds ?? 7)));
   const teams     = cache.getAllTeams();
   awardCompensatoryPicksForUpcomingDraft(meta);
-  const classSize = ROUNDS * teams.length;
+  const compensatoryPickCount = teams.reduce((count, team) => {
+    const teamCompPicks = (team?.picks ?? []).filter((pk) =>
+      Number(pk?.season) === Number(meta?.year) && !!pk?.isCompensatory && Number(pk?.currentOwner ?? team.id) === Number(team.id)
+    );
+    return count + teamCompPicks.length;
+  }, 0);
+  const classSize = (ROUNDS * teams.length) + compensatoryPickCount;
 
   // Build elite name set from existing players to avoid collisions
   const eliteNames = new Set(cache.getAllPlayers().filter(p => p.ovr > 80).map(p => p.name));
@@ -10676,14 +10687,126 @@ async function handleMakeDraftPick({ playerId }, id) {
   post(toUI.DRAFT_STATE, buildDraftStateView(), id);
 }
 
+
+function captureDraftProgressState(meta = cache.getMeta()) {
+  const draftState = meta?.draftState;
+  const pick = draftState?.picks?.[draftState?.currentPickIndex];
+  return {
+    season: meta?.year ?? meta?.season ?? null,
+    phase: meta?.phase ?? null,
+    currentPickIndex: Number(draftState?.currentPickIndex ?? -1),
+    currentPickId: pick?.id ?? null,
+    currentTeamId: pick?.teamId ?? null,
+    draftComplete: !!draftState && Number(draftState.currentPickIndex ?? 0) >= Number(draftState.picks?.length ?? 0),
+  };
+}
+
+function draftBatchMadeProgress(before, after, result = {}) {
+  if (result?.blocked || result?.error) return true;
+  if (!before?.draftComplete && after?.draftComplete) return true;
+  if (after?.phase !== before?.phase) return true;
+  if (Number(after?.currentPickIndex ?? -1) > Number(before?.currentPickIndex ?? -1)) return true;
+  if ((after?.currentPickId ?? null) !== (before?.currentPickId ?? null)) return true;
+  return false;
+}
+
+function createDraftNoProgressError(before, after, result = {}) {
+  const detail = {
+    season: after?.season ?? before?.season ?? null,
+    phase: after?.phase ?? before?.phase ?? null,
+    pickIndex: before?.currentPickIndex ?? null,
+    pickId: before?.currentPickId ?? null,
+    teamId: before?.currentTeamId ?? null,
+    resultStatus: result?.status ?? null,
+  };
+  const err = new Error(`Draft batch made no progress at pick index ${detail.pickIndex} (pick ${detail.pickId ?? 'unknown'}, team ${detail.teamId ?? 'unknown'}, phase ${detail.phase ?? 'unknown'}, season ${detail.season ?? 'unknown'})`);
+  err.code = 'DRAFT_BATCH_NO_PROGRESS';
+  err.detail = detail;
+  return err;
+}
+
+function selectCanonicalDraftProspectForTeam({ teamId, pick, draftPool, sessionPicksByTeamNeedGroup = new Map(), meta = cache.getMeta() }) {
+  const team = cache.getTeam(teamId);
+  const strategy = offseasonProfiler.measure('draft.ai-strategy', { teamId, pickNumber: Number(pick?.overall ?? 0) }, () => buildAiTeamStrategy({
+    team,
+    roster: cache.getPlayersByTeam(teamId),
+    league: { year: meta?.year, phase: meta?.phase },
+    phase: meta?.phase,
+    year: meta?.year,
+  }));
+  const needs = offseasonProfiler.measure('draft.team-needs', { teamId, pickNumber: Number(pick?.overall ?? 0) }, () => AiLogic.calculateTeamNeeds(teamId));
+  const needPriorityByPos = new Map((strategy?.positionalNeeds ?? []).map((row) => [row.positionGroup, Number(row?.priority ?? 0)]));
+  let bestProspect = null;
+  let bestValue = -1;
+  let bestIdx = -1;
+
+  const __pickProfileToken = offseasonProfiler.start('draft.pick.evaluate-and-select', { teamId, pickNumber: Number(pick?.overall ?? 0), round: Number(pick?.round ?? 0), prospects: draftPool.length });
+  for (let i = 0; i < draftPool.length; i++) {
+    const p = draftPool[i];
+    const boardScore = scoreDraftBoardEntry({
+      ...p,
+      ovr: p?.ovr ?? p?.scoutedOvr ?? 60,
+      potential: p?.potential ?? p?.truePotential ?? p?.ovr ?? 60,
+      combineResults: p?.combineResults,
+      interviewReport: p?.interviewReport,
+      collegeProductionScore: p?.collegeProductionScore ?? 0,
+      schemeFit: p?.schemeFit ?? 65,
+      archetypeTag: p?.archetypeTag ?? p?.pos,
+    }, team, { teamNeeds: needs });
+    const needGroup = mapPlayerPosToNeedGroup(p?.pos) ?? String(p?.pos ?? '');
+    let posPriority = Number(needPriorityByPos.get(needGroup) ?? 0);
+    const qbNeedP = Number(needPriorityByPos.get('QB') ?? 0);
+    if (String(p?.pos) === 'QB' && qbNeedP >= 56) {
+      posPriority = Math.min(100, posPriority + Math.round((qbNeedP - 52) * 0.55));
+    }
+    const talentGapGuard = Math.max(0, Number((p?.ovr ?? 60) - 80));
+    const archetypeNeedFactor = strategy?.archetype === 'contender'
+      ? 0.056
+      : ['rebuild', 'development'].includes(strategy?.archetype)
+        ? 0.086
+        : 0.069;
+    const needBoost = Math.min(6.75, posPriority * archetypeNeedFactor);
+    const eliteProspectReduction = talentGapGuard >= 8 ? 0.22 : talentGapGuard >= 4 ? 0.52 : 1;
+    const sessionKey = `${teamId}|${needGroup}`;
+    const dupDepth = Number(sessionPicksByTeamNeedGroup.get(sessionKey) || 0);
+    const hoardPenalty = dupDepth > 0
+      ? Math.min(3.6, dupDepth * 1.75) * (eliteProspectReduction < 0.95 ? 0.42 : 1)
+      : 0;
+    const combineAdj = getAIDraftBoardAdjustment(p);
+    const combineBonus = combineAdj.slots * 0.1;
+    const val = Number(boardScore?.score ?? 0) + (needBoost * eliteProspectReduction) - hoardPenalty + combineBonus;
+
+    if (val > bestValue) {
+      bestValue = val;
+      bestProspect = p;
+      bestIdx = i;
+    } else if (val === bestValue && bestProspect) {
+      const rBest = Number(bestProspect?.interviewReport?.riskScore ?? 40);
+      const rNew = Number(p?.interviewReport?.riskScore ?? 40);
+      const ovrNew = Number(p?.ovr ?? 0);
+      const ovrBest = Number(bestProspect?.ovr ?? 0);
+      if (ovrNew > ovrBest || (ovrNew === ovrBest && rNew < rBest)) {
+        bestProspect = p;
+        bestIdx = i;
+      }
+    } else if (val === bestValue && !bestProspect) {
+      bestProspect = p;
+      bestIdx = i;
+    }
+  }
+  offseasonProfiler.end(__pickProfileToken, { selectedPlayerId: bestProspect?.id ?? null, prospects: draftPool.length });
+  return { bestProspect, bestIdx };
+}
+
 // ── Handler: SIM_DRAFT_PICK ───────────────────────────────────────────────────
 
 /**
  * Auto-pick for every AI team until we reach the user's next pick (or draft ends).
- * Each AI picks the highest-OVR available prospect.
+ * Each AI pick uses the canonical weighted draft-board selector.
  */
-async function handleSimDraftPick(payload, id) {
+async function handleSimDraftPick(payload = {}, id) {
   return offseasonProfiler.measure('draft.sim-batch', {}, async () => {
+  const allowUserAutoPick = payload?.allowUserAutoPick === true && payload?.source === 'sim_to_phase';
   const meta = ensureDynastyMeta(cache.getMeta());
   if (!meta?.draftState) { post(toUI.ERROR, { message: 'No active draft' }, id); return; }
 
@@ -10699,8 +10822,12 @@ async function handleSimDraftPick(payload, id) {
   while (currentPickIndex < picks.length) {
     const pick = picks[currentPickIndex];
 
-    // Pause at user's pick
-    if (pick.teamId === userTeamId) break;
+    // Pause at user's pick unless the lifecycle batch explicitly opted into auto-picking.
+    if (pick.teamId === userTeamId && !allowUserAutoPick) {
+      await flushDirty();
+      post(toUI.DRAFT_STATE, buildDraftStateView(), id);
+      return { status: 'blocked', blocked: true, reason: 'user_pick', pickIndex: currentPickIndex, pickId: pick?.id ?? null, teamId: pick?.teamId ?? null };
+    }
 
     // ── Draft trade-up: AI-to-AI ─────────────────────────────────────────────
     // Before the AI makes its pick, check whether another AI team wants to trade
@@ -10761,78 +10888,14 @@ async function handleSimDraftPick(payload, id) {
     }
     // ── End draft trade-up ────────────────────────────────────────────────────
 
-    // AI selects by weighted board value (need, scheme fit, upside, combine/interview risk).
-    const team = cache.getTeam(pick.teamId);
-    const strategy = offseasonProfiler.measure('draft.ai-strategy', { teamId: pick.teamId, pickNumber: Number(pick?.overall ?? currentPickIndex + 1) }, () => buildAiTeamStrategy({
-      team,
-      roster: cache.getPlayersByTeam(pick.teamId),
-      league: { year: meta?.year, phase: meta?.phase },
-      phase: meta?.phase,
-      year: meta?.year,
-    }));
-    const needs = offseasonProfiler.measure('draft.team-needs', { teamId: pick.teamId, pickNumber: Number(pick?.overall ?? currentPickIndex + 1) }, () => AiLogic.calculateTeamNeeds(pick.teamId));
-    const needPriorityByPos = new Map((strategy?.positionalNeeds ?? []).map((row) => [row.positionGroup, Number(row?.priority ?? 0)]));
-    let bestProspect = null;
-    let bestValue = -1;
-    let bestIdx = -1;
-
-    const __pickProfileToken = offseasonProfiler.start('draft.pick.evaluate-and-select', { teamId: pick.teamId, pickNumber: Number(pick?.overall ?? currentPickIndex + 1), round: Number(pick?.round ?? 0), prospects: draftPool.length });
-    for (let i = 0; i < draftPool.length; i++) {
-        const p = draftPool[i];
-        const boardScore = scoreDraftBoardEntry({
-          ...p,
-          ovr: p?.ovr ?? p?.scoutedOvr ?? 60,
-          potential: p?.potential ?? p?.truePotential ?? p?.ovr ?? 60,
-          combineResults: p?.combineResults,
-          interviewReport: p?.interviewReport,
-          collegeProductionScore: p?.collegeProductionScore ?? 0,
-          schemeFit: p?.schemeFit ?? 65,
-          archetypeTag: p?.archetypeTag ?? p?.pos,
-        }, team, { teamNeeds: needs });
-        const needGroup = mapPlayerPosToNeedGroup(p?.pos) ?? String(p?.pos ?? '');
-        let posPriority = Number(needPriorityByPos.get(needGroup) ?? 0);
-        const qbNeedP = Number(needPriorityByPos.get('QB') ?? 0);
-        if (String(p?.pos) === 'QB' && qbNeedP >= 56) {
-          posPriority = Math.min(100, posPriority + Math.round((qbNeedP - 52) * 0.55));
-        }
-        const talentGapGuard = Math.max(0, Number((p?.ovr ?? 60) - 80));
-        const archetypeNeedFactor = strategy?.archetype === 'contender'
-          ? 0.056
-          : ['rebuild', 'development'].includes(strategy?.archetype)
-            ? 0.086
-            : 0.069;
-        const needBoost = Math.min(6.75, posPriority * archetypeNeedFactor);
-        // Keep BPA available: suppress need boost on clearly elite prospects.
-        const eliteProspectReduction = talentGapGuard >= 8 ? 0.22 : talentGapGuard >= 4 ? 0.52 : 1;
-        const sessionKey = `${pick.teamId}|${needGroup}`;
-        const dupDepth = Number(sessionPicksByTeamNeedGroup.get(sessionKey) || 0);
-        const hoardPenalty = dupDepth > 0
-          ? Math.min(3.6, dupDepth * 1.75) * (eliteProspectReduction < 0.95 ? 0.42 : 1)
-          : 0;
-        const combineAdj = getAIDraftBoardAdjustment(p);
-        const combineBonus = combineAdj.slots * 0.1;
-        const val = Number(boardScore?.score ?? 0) + (needBoost * eliteProspectReduction) - hoardPenalty + combineBonus;
-
-        if (val > bestValue) {
-            bestValue = val;
-            bestProspect = p;
-            bestIdx = i;
-        } else if (val === bestValue && bestProspect) {
-            const rBest = Number(bestProspect?.interviewReport?.riskScore ?? 40);
-            const rNew = Number(p?.interviewReport?.riskScore ?? 40);
-            const ovrNew = Number(p?.ovr ?? 0);
-            const ovrBest = Number(bestProspect?.ovr ?? 0);
-            if (ovrNew > ovrBest || (ovrNew === ovrBest && rNew < rBest)) {
-              bestProspect = p;
-              bestIdx = i;
-            }
-        } else if (val === bestValue && !bestProspect) {
-            bestProspect = p;
-            bestIdx = i;
-        }
-    }
-
-    offseasonProfiler.end(__pickProfileToken, { selectedPlayerId: bestProspect?.id ?? null, prospects: draftPool.length });
+    // Select by the canonical weighted board value (need, scheme fit, upside, combine/interview risk).
+    const { bestProspect, bestIdx } = selectCanonicalDraftProspectForTeam({
+      teamId: pick.teamId,
+      pick,
+      draftPool,
+      sessionPicksByTeamNeedGroup,
+      meta,
+    });
     if (!bestProspect) break; // pool exhausted
 
     offseasonProfiler.addIteration({ kind: 'draft-pick', pickNumber: Number(pick?.overall ?? currentPickIndex + 1), round: Number(pick?.round ?? 0), teamId: pick.teamId, prospectsRemaining: draftPool.length });

--- a/tests/integration/simToPhaseDraftAutoPick.worker.test.js
+++ b/tests/integration/simToPhaseDraftAutoPick.worker.test.js
@@ -1,0 +1,136 @@
+import 'fake-indexeddb/auto';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { toWorker, toUI } from '../../src/worker/protocol.js';
+import { cache } from '../../src/db/cache.js';
+
+const SLOT_KEY = 'save_slot_1';
+const USER_TEAM_ID = 0;
+const BOOT_TIMEOUT_MS = 180_000;
+const TEST_TIMEOUT_MS = 120_000;
+
+const waiters = new Map();
+let msgSeq = 0;
+
+function installSelfBridge() {
+  globalThis.self = {
+    onmessage: null,
+    postMessage(msg) {
+      if (msg?.id != null && waiters.has(msg.id)) {
+        const resolve = waiters.get(msg.id);
+        waiters.delete(msg.id);
+        resolve(msg);
+      }
+    },
+  };
+}
+
+function payloadOf(msg) {
+  const p = msg?.payload;
+  if (p && typeof p._jsonPayload === 'string') return JSON.parse(p._jsonPayload);
+  return p;
+}
+
+function send(type, payload = {}, { timeoutMs = 60_000 } = {}) {
+  const id = `sim-to-phase-draft-${++msgSeq}`;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      waiters.delete(id);
+      reject(new Error(`Timeout (${timeoutMs}ms) waiting for reply to ${type}`));
+    }, timeoutMs);
+    waiters.set(id, (msg) => {
+      clearTimeout(timer);
+      resolve(msg);
+    });
+    globalThis.self.onmessage({ data: { type, payload, id } });
+  });
+}
+
+function makeProspect(id, patch = {}) {
+  const prospect = {
+    id,
+    name: `Prospect ${id}`,
+    pos: 'QB',
+    ovr: 72,
+    potential: 82,
+    age: 21,
+    teamId: null,
+    status: 'draft_eligible',
+    combineResults: {},
+    interviewReport: { riskScore: 35 },
+    collegeProductionScore: 70,
+    schemeFit: 70,
+    ...patch,
+  };
+  cache.setPlayer(prospect);
+  return prospect;
+}
+
+beforeAll(async () => {
+  installSelfBridge();
+  await import('../../src/worker/worker.js');
+  const ready = await send(toWorker.INIT, {}, { timeoutMs: BOOT_TIMEOUT_MS });
+  expect(ready.type).toBe(toUI.READY);
+  const boot = await send(
+    toWorker.USE_SAFE_STARTER_LEAGUE,
+    { slotKey: SLOT_KEY, options: { rngSeed: 1684, userTeamId: USER_TEAM_ID, name: 'SIM_TO_PHASE Draft Auto Pick Test' } },
+    { timeoutMs: BOOT_TIMEOUT_MS },
+  );
+  expect(boot.type, JSON.stringify(payloadOf(boot))).toBe(toUI.FULL_STATE);
+}, BOOT_TIMEOUT_MS);
+
+afterAll(() => {
+  delete globalThis.self;
+});
+
+describe('SIM_TO_PHASE draft auto-pick worker integration', () => {
+  it('does not let public SIM_DRAFT_PICK payloads forge lifecycle user auto-pick authority', async () => {
+    const meta = cache.getMeta();
+    const prospect = makeProspect('forged-user-autopick');
+    cache.setMeta({
+      phase: 'draft',
+      draftState: {
+        currentPickIndex: 0,
+        picks: [{ id: 'manual-user-pick', overall: 1, round: 1, pickInRound: 1, teamId: USER_TEAM_ID, playerId: null }],
+      },
+    });
+
+    const reply = await send(
+      toWorker.SIM_DRAFT_PICK,
+      { allowUserAutoPick: true, source: 'sim_to_phase' },
+      { timeoutMs: TEST_TIMEOUT_MS },
+    );
+
+    expect(reply.type).toBe(toUI.DRAFT_STATE);
+    expect(cache.getMeta().draftState.currentPickIndex).toBe(0);
+    expect(cache.getMeta().draftState.picks[0].playerId).toBeNull();
+    expect(cache.getPlayer(prospect.id).status).toBe('draft_eligible');
+    expect(cache.getPlayer(prospect.id).teamId).toBeNull();
+    cache.setMeta({ ...meta, draftState: null });
+  }, TEST_TIMEOUT_MS);
+
+  it('generates enough prospects for compensatory draft pick slots', async () => {
+    const meta = cache.getMeta();
+    const year = Number(meta?.year ?? 2026);
+    for (const team of cache.getAllTeams()) {
+      cache.updateTeam(team.id, { picks: [] });
+    }
+    const userTeam = cache.getTeam(USER_TEAM_ID);
+    cache.updateTeam(USER_TEAM_ID, {
+      picks: [{ id: `comp-${year}-7-${USER_TEAM_ID}`, season: year, round: 7, currentOwner: USER_TEAM_ID, isCompensatory: true }],
+    });
+    cache.setMeta({ phase: 'draft', draftState: null });
+
+    const reply = await send(toWorker.START_DRAFT, {}, { timeoutMs: TEST_TIMEOUT_MS });
+    expect(reply.type).toBe(toUI.DRAFT_STATE);
+    const payload = payloadOf(reply);
+    const pickCount = payload?.picks?.length ?? cache.getMeta().draftState.picks.length;
+    const draftEligibleCount = cache.getAllPlayers().filter((p) => p.status === 'draft_eligible').length;
+
+    expect(pickCount).toBe(225);
+    expect(draftEligibleCount).toBeGreaterThanOrEqual(pickCount);
+    expect(cache.getMeta().draftState.picks.some((pick) => pick.isCompensatory)).toBe(true);
+
+    cache.updateTeam(USER_TEAM_ID, { picks: userTeam?.picks ?? [] });
+    cache.setMeta({ ...meta, draftState: null });
+  }, TEST_TIMEOUT_MS);
+});


### PR DESCRIPTION
### Motivation

- Root cause: `SIM_TO_PHASE({ targetPhase: 'preseason' })` reused the interactive `handleSimDraftPick()` path which intentionally stops at `meta.userTeamId` picks, causing the lifecycle to repeatedly re-enter an unchanged draft state and stall the rollover.  
- Goal: allow automated lifecycle advancement to make deterministic, canonical user picks only when invoked from the `SIM_TO_PHASE('preseason')` batch while keeping interactive/manual draft behavior unchanged.  
- Safety: the change must use the existing canonical selection logic and enforce a no-progress contract so the outer lifecycle cannot silently retry unchanged state.

### Description

- Added an explicit batch context and narrow opt-in: `handleSimToPhase()` now calls `handleSimDraftPick({ allowUserAutoPick: targetPhase === 'preseason', source: 'sim_to_phase' }, null)` so only the `SIM_TO_PHASE('preseason')` path enables auto-pick for user-owned slots.  
- Implemented no-progress protection around each draft batch step by capturing before/after draft state (`captureDraftProgressState`) and validating progress with `draftBatchMadeProgress` or throwing a structured `DRAFT_BATCH_NO_PROGRESS` error via `createDraftNoProgressError`.  
- Reused existing canonical selection logic by factoring the prospect-evaluation loop into `selectCanonicalDraftProspectForTeam()` which calls `buildAiTeamStrategy()`, `AiLogic.calculateTeamNeeds()`, `scoreDraftBoardEntry()`, and `getAIDraftBoardAdjustment()` so batch user auto-picks use the same scoring and tiebreakers as AI picks (no highest-OVR shortcut).  
- Ancillary fixes and docs: aligned `handleStartDraft()` prospect `classSize` with compensatory picks, added a focused regression test `src/worker/__tests__/simToPhaseDraftAutoPickRegression.test.js`, updated `docs/offseason-rollover-performance-profile-v1.md`, and added `docs/sim-to-phase-draft-user-pick-auto-advance-v1.md` describing the audit and contract.

### Testing

- Static check: `node --check src/worker/worker.js` passed.  
- Targeted unit regression: `npm run test:unit -- src/worker/__tests__/simToPhaseDraftAutoPickRegression.test.js` — 1 file, 4 tests: all passed.  
- Durability unit harness: `npm run durability:test` — 2 files, 33 tests: all passed.  
- Full unit suite: `npm run test:unit` — 439 files, 5,461 tests: all passed (run time ~242s).  
- Production build: `npm run build` — build succeeded (chunk-size warnings expected).  
- Durability smoke (one-season): `npm run durability:smoke` reached `preseason` (seed 1684) proving the prior user-pick stall is resolved, but exposed downstream invariants at `afterSeasonRollover` (failure: `roster.size-within-legal-range` team 0 roster size 11 and a non-fatal `processSeasonRecords()` `passYd` warning), so full rollover invariants are not yet all green.  
- Five-season attempt: `npm run durability:5` attempted 5 seasons, completed 0 full seasons, and stopped at the same post-rollover roster invariant failure.  

Files changed: `src/worker/worker.js`, `src/worker/__tests__/simToPhaseDraftAutoPickRegression.test.js`, `docs/sim-to-phase-draft-user-pick-auto-advance-v1.md`, and `docs/offseason-rollover-performance-profile-v1.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a529ad107b0832d837fd134fcccbc52)