### PR TITLE
Fix post-rollover user-roster collapse: teamId 0 misclassified as free agent

### DIFF
--- a/docs/post-rollover-roster-membership-integrity-v1.md
+++ b/docs/post-rollover-roster-membership-integrity-v1.md
@@ -1,0 +1,293 @@
+# Post-Rollover Roster Membership Integrity V1 (PR #1689)
+
+## 1. Executive summary
+
+After PR #1688 removed the automated-draft user-pick stall, the production
+lifecycle could reach the next preseason, exposing the first full-rollover
+invariant failure:
+
+```
+roster.size-within-legal-range  teamId: 0  roster size: 11  (expected [53, 120])
+```
+
+**Root cause (proven):** the user team has id **`0`**, and `teamId === 0` is
+**falsy** in JavaScript. The offseason free-agency code classified free agents
+with the shortcut `!player.teamId`, which is `true` for every team-0 player. As a
+result the entire user roster was treated as a pool of free agents, and AI teams
+signed all 53 user players away during the free-agency phase. By the next
+preseason team 0 held only its ~11 drafted rookies. Only team 0 was affected —
+AI team ids 1–31 are truthy.
+
+**Fix (Lane 1 — canonical membership boundary):** introduced one canonical
+predicate `isFreeAgent(player)` (tests `teamId == null`, never falsiness) and
+routed all 12 free-agency classification sites through it. No roster "repair"
+pass, no invariant weakening, no team-0 special-casing.
+
+A second, separate issue — a non-fatal-looking `passYd` warning — was actually a
+hard `TypeError` that aborted `archiveSeason()` on the first rollover. It is a
+tiny record-book schema-compat defect and is fixed here too (with focused tests).
+
+After both fixes the first durability season **completes** (`seasonsCompleted: 1`)
+and the roster/reference/cap/draft invariants pass. The next remaining first
+failure is an unrelated schedule/standings/history reconciliation defect, which
+is recommended as **#1690** (evidence below).
+
+## 2. Reproduction
+
+```
+npm run durability:smoke          # seed 1684, real worker lifecycle
+```
+
+Pre-fix (baseline, collect-all to rollover):
+
+| Checkpoint | pass | fail | notable failures |
+|---|---|---|---|
+| afterSeasonRollover | 31 | 4 | **roster.size team 0 = 11**, schedule.games-reference, schedule.no-self-games, history.season-archive-exists |
+| afterReload | 31 | 4 | roster.size team 0 = 11, schedule.*, saveReload.canonical-summary-stable |
+
+A worker log line accompanied every rollover:
+
+```
+[Worker] Failed to archive season s1: TypeError: Cannot read properties of undefined (reading 'passYd')
+    at processSeasonRecords (src/core/records.js:96)
+    at archiveSeason (src/worker/worker.js:12848)
+    at handleStartNewSeason (src/worker/worker.js:13113)
+```
+
+## 3. Roster-authority map
+
+| Question | Answer |
+|---|---|
+| Canonical membership | `player.teamId` (the single source of truth) |
+| Does `status` gate inclusion | Only for exclusion (`retired` / `free_agent` / `draft_eligible`); a rostered player is `teamId != null` |
+| What is `team.roster` | **View-only.** `buildViewState()` derives it live from `cache.getPlayersByTeam(t.id)` |
+| `cache.getPlayersByTeam(teamId)` | Live `filter` over the player Map; **no index**, so no stale-index class of bug |
+| Can an index go stale | N/A — there is no membership index |
+| Multiple player stores | No — one `_players` Map in `cache.js`; DB is the durable mirror |
+| Worker rebuild vs mutate | Worker mutates `player.teamId`; rosters are always derived, never stored |
+| Persistence scope | All players (including free agents with `teamId: null`) are serialized |
+| FULL_STATE filtering | View exposes rostered players per team; free agents come only from the DB pool |
+| Harness vs gameplay representation | The durability harness reads the same `buildViewState()` the UI reads |
+
+Because `getPlayersByTeam` correctly guards `p?.teamId != null` before comparing,
+the **read path was never wrong**. The defect was purely in the free-agency
+**classification** predicate, which used falsiness instead of null-ness.
+
+## 4. Lifecycle call graph (offseason rollover)
+
+```
+SIM_TO_PHASE('preseason')
+└─ handleSimToPhase (worker.js:5183)
+   ├─ offseason_resign → handleAdvanceOffseason (worker.js:11445)
+   │    AI extensions (skips user) · progression · aging · retirements(+evict) · AI cuts (skip user)
+   │    → phase = free_agency
+   ├─ free_agency → handleAdvanceFreeAgencyDay ×maxDays (worker.js:12138)
+   │    injectAIFaBids → AiLogic.makeFreeAgencyOffers → AiLogic.processFreeAgencyDay  ◀── DEFECT
+   │    → phase = draft_combine → draft
+   ├─ draft → handleStartDraft / handleSimDraftPick → _executeDraftPick (assigns rookies)
+   └─ → handleStartNewSeason (worker.js:13100)
+        archiveSeason → processSeasonRecords  ◀── passYd TypeError (records.js)
+        reset records · roll dead money · makeAccurateSchedule · → phase = preseason
+```
+
+## 5. Phase-by-phase roster ledger (team 0 vs AI sample, seed 1684)
+
+Captured by stepping the real worker (strict membership: `teamId != null && ==0`).
+
+| Boundary | team 0 | team 1 | team 2 | team 3 | free agents | retired(evicted) |
+|---|---|---|---|---|---|---|
+| afterInit / regular | 53 | 53 | 53 | 53 | 0 | 0 |
+| afterRegularSeason | 53 | 53 | 53 | 53 | 0 | 0 |
+| afterPlayoffs (offseason_resign) | 53 | 53 | 53 | 53 | 0 | 0 |
+| afterAdvanceOffseason (retire+resign) | **53** | 52 | 52 | 51 | 0 | 38 |
+| **during free_agency** | **53 → 0** | (healthy) | (healthy) | (healthy) | — | — |
+| afterSeasonRollover (preseason) — **pre-fix** | **11** | 53+ | 53+ | 53+ | — | — |
+| afterSeasonRollover (preseason) — **post-fix** | **60** | 53+ | 53+ | 53+ | — | — |
+
+The user roster is intact through retirement/re-signing (team 0 loses 0 to
+retirement for this seed). The collapse happens **only** in `free_agency`.
+
+## 6. Team-0 player-transition ledger
+
+A per-mutation tracer (wrapping `cache.updatePlayer` / `removePlayer`, strict
+`teamId === 0`) recorded, for the pre-fix run:
+
+```
+total team-0 departures: 53
+by phase:  { free_agency: 53 }
+site:      AiLogic.processFreeAgencyDay (ai-logic.js:970)  ← cache.updatePlayer({ teamId, status:'active', contract })
+sample:    id 1 Jordan Sanders QB → team 26
+           id 2 Sean Allen    QB → team 26
+           id 3 Dillon Knight  QB → team 26
+```
+
+Every departure was a **legitimate-looking AI signing** of a player the FA
+classifier wrongly believed was available. No retirements, releases, trades, or
+deletions removed team-0 players. Post-fix the same tracer records **0**
+team-0 departures.
+
+## 7. User vs AI comparison
+
+* **AI teams (id 1–31):** never misclassified (truthy id). They re-sign their own
+  expiring players (`handleAdvanceOffseason` skips only `userTeamId`), bid in free
+  agency, and run cutdowns — normal offseason behavior.
+* **User team (id 0):** the game intentionally leaves the user's re-signing/FA
+  *decisions* to the interactive UI (batch sim does not auto-GM the user, by
+  design). That is correct and unchanged. The bug was **not** a missing
+  auto-management policy — it was that the user's already-rostered players were
+  being **treated as free agents and taken by AI teams**. The distinction matters:
+  the user losing players it never released is corruption, not a decision window.
+
+## 8. Exact first point of roster decline
+
+`src/core/ai-logic.js` free-agency pool construction and signing
+(`processFreeAgencyDay`, lines 930–950 pre-fix) via the predicate
+`(!p.teamId || p.status === 'free_agent')`. `!p.teamId` is `true` for
+`teamId === 0`, so team-0 players entered `freeAgentsMap`, received AI offers, and
+were signed away.
+
+## 9. Root cause
+
+`teamId === 0` is falsy. Twelve free-agency classification sites used
+`!player.teamId` as "is a free agent", misclassifying the entire user roster.
+This is a membership-classification defect (Lane 1), not stale cache/index, not
+save/reload, not a missing decision policy.
+
+## 10. Chosen lifecycle contract
+
+**Contract A/C hybrid, no new behavior:** `SIM_TO_PHASE('preseason')` legitimately
+reaches preseason with the user roster intact; the user's *optional* offseason
+decisions (extra signings, cuts) remain interactive and are enforced later at the
+preseason cutdown gate (`handleAdvanceWeek`, `meta.phase === 'preseason'`,
+worker.js:3054). No blocked-state contract was needed because a legal roster is
+reachable without any user decision once the corruption is removed. The roster
+invariant at preseason (min 53) is therefore correct and was **kept as-is**.
+
+## 11. Implementation lane
+
+**Lane 1 — membership/canonical-boundary fix.** One shared predicate
+`isFreeAgent(player)` replaces the falsy shortcut at every classification site.
+No final "repair rosters" pass; the canonical seam is the predicate itself.
+
+## 12. Files changed
+
+| File | Change |
+|---|---|
+| `src/core/freeAgency/membership.js` | **new** — canonical `isFreeAgent(player)` (`teamId == null || 'FA' || status==='free_agent'`) |
+| `src/core/ai-logic.js` | 5 FA predicates → `isFreeAgent` (incl. the signing path) |
+| `src/worker/worker.js` | 6 FA predicates → `isFreeAgent` (incl. `injectAIFaBids`, FA-day snapshot) |
+| `src/worker/handlers/freeAgencyHandlers.js` | 1 FA predicate → `isFreeAgent` |
+| `src/core/records.js` | `processSeasonRecords` tolerates the legacy record-book stub (passYd fix) |
+| `src/core/freeAgency/__tests__/membership.test.js` | **new** — predicate unit tests incl. team-0 regression |
+| `src/core/__tests__/processSeasonRecords.legacyShape.test.js` | **new** — record-book legacy-shape tests |
+| `tests/durability/postRolloverRosterIntegrity.test.js` | **new** — real-lifecycle behavior regression |
+
+## 13. Why no broader auto-GM behavior was introduced
+
+The roster loss was corruption (players taken without being released), not an
+unresolved user decision window. Removing the misclassification fully restores a
+legal roster, so no auto-signing/auto-cut/auto-GM policy is warranted or added.
+Interactive user control is unchanged.
+
+## 14. Save/reload comparison
+
+Post-fix, save/reload still reports a `saveReload.canonical-summary-stable`
+divergence on `rosterFingerprint` — but this is **pre-existing** (present in the
+pre-fix baseline too) and lives in the schedule/serialization domain, not roster
+membership. The `rosterFingerprint` comparator sorts ids with
+`Number(a)-Number(b)`, which is unstable for the string ids that rookies carry, so
+before/after orderings differ for identical sets. This belongs to #1690.
+
+## 15. Invariant results (1-season, collect-all, post-fix)
+
+```
+seasons: attempted=1 completed=1 competitive=1
+invariants: pass=159 fail=7 skip=34
+afterSeasonRollover: pass=35 fail=3   → schedule.games-reference-valid-teams,
+                                         schedule.no-self-games, history.champion-refs-valid
+afterReload:         pass=33 fail=4   → the three above + saveReload.canonical-summary-stable
+```
+
+`roster.*`, `references.*`, `cap.*`, `draft.*`, `progression.*`, `retirement.*`,
+`numericSafety.*` all pass. The roster failure is gone.
+
+### Before/after attribution (same seed, same harness)
+
+| Failure | pre-fix | post-fix | attribution |
+|---|---|---|---|
+| `roster.size-within-legal-range` team 0=11 | FAIL | **PASS** | fixed by `isFreeAgent` |
+| passYd crash / `history.season-archive-exists` | crash, 0 archives | **archives, passes** | fixed by records guard |
+| `schedule.games-reference-valid-teams` | FAIL | FAIL | pre-existing → #1690 |
+| `schedule.no-self-games` | FAIL | FAIL | pre-existing → #1690 |
+| `history.champion-refs-valid` | masked by crash | FAIL | latent, exposed once archive runs → #1690 |
+| `saveReload.canonical-summary-stable` | FAIL | FAIL | pre-existing → #1690 |
+
+## 16. One-season result
+
+`seasonsCompleted: 1`, `boundedRun: false`. The first full rollover completes; the
+user team reaches preseason with a legal roster (60). Fail-fast stops at the
+independent schedule defect, so the smoke does not go fully green — this is
+reported honestly, not masked.
+
+## 17. Five-season result
+
+```
+npm run durability:5   (fail-fast)
+seasons: requested=5 attempted=1 completed=0
+stopped: season 1 afterSeasonRollover — schedule.games-reference-valid-teams (8 games)
+runtime=34.1s peakMem=388MB
+```
+
+Five seasons cannot complete **because of the independent schedule defect**, not
+roster integrity. Per scope discipline, #1689 does not broaden to fix it.
+
+## 18. passYd audit
+
+* **Function/caller:** `processSeasonRecords` (`src/core/records.js`) called by
+  `archiveSeason` → `handleStartNewSeason`.
+* **Object:** the record book `existingRecords = meta.records`.
+* **Cause:** a fresh league is bootstrapped (`defaultLeague.ts:258`,
+  `league.js:187`) with a **legacy stub** `{ mostPassingYardsSeason, ... }` that
+  lacks the V1 `singleSeason`/`allTime` buckets. `structuredClone`-ing it and then
+  reading `records.singleSeason['passYd']` throws
+  `Cannot read properties of undefined (reading 'passYd')`.
+* **Canonical field:** the engine uses `singleSeason.passYd` internally and maps to
+  `passingYards` for career totals (`CATEGORY_TO_RECORD_KEY`). The crash is a
+  record-book **shape** mismatch, not a per-player stat-field alias issue.
+* **New or newly reachable:** newly *reachable* — the first rollover only became
+  attainable after #1688; the mismatch itself predates it.
+* **Impact:** it aborted `archiveSeason` after `archiveSeasonStats()` had already
+  cleared the accumulators, so the season silently failed to archive.
+* **Fix:** `processSeasonRecords` now accepts `existingRecords` only when it carries
+  the V1 shape, otherwise starts from `createEmptyRecords()`. Schema-compatible,
+  preserves a real V1 book, tolerates legacy saves. Covered by
+  `processSeasonRecords.legacyShape.test.js`.
+
+## 19. Remaining risks
+
+* **Schedule/standings/history reconciliation (#1690):** 8 preseason games have
+  undefined home/away (self-game + invalid-team-ref); 1 archived season carries an
+  invalid champion ref; save/reload `rosterFingerprint` diverges. All pre-existing
+  and independent of this PR.
+* **Cosmetic team-0 truthiness residue:** `news-engine.js` uses
+  `player.teamId ? cache.getTeam(...) : null` in three spots — a team-0 player's
+  news item would not resolve its team object. Non-roster, cosmetic; noted, not
+  fixed here to keep scope tight.
+* **User FA participation:** batch sim still does not have the user bid on free
+  agents (by design). Not corruption; unchanged.
+
+## 20. Recommended #1690 (evidence-based)
+
+**#1690 — Schedule / Standings / History Reconciliation V1.** The durability
+harness itself now recommends "Schedule/standings reconciliation repair PR" as the
+next first failure. Scope suggested by evidence:
+
+1. `schedule.games-reference-valid-teams` + `schedule.no-self-games`: 8 games with
+   undefined `home`/`away` after `makeAccurateSchedule`/`slimifySchedule` — likely
+   bye/placeholder rows leaking into `schedule.weeks[].games`.
+2. `history.champion-refs-valid`: the archived season's champion reference resolves
+   to an unknown team (now reachable because season archiving works again).
+3. `saveReload.canonical-summary-stable`: `rosterFingerprint` divergence, at least
+   partly a comparator issue (numeric sort over string rookie ids).
+
+Let post-fix durability evidence — not this document — drive the final #1690 scope.

--- a/src/core/__tests__/processSeasonRecords.legacyShape.test.js
+++ b/src/core/__tests__/processSeasonRecords.legacyShape.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { processSeasonRecords, createEmptyRecords } from '../records.js';
+
+/**
+ * Regression coverage for the season-archive passYd crash.
+ *
+ * A freshly bootstrapped league carries a LEGACY record stub
+ * (`{ mostPassingYardsSeason, ... }`) that lacks the V1 singleSeason/allTime
+ * buckets. Before the guard, `records.singleSeason.passYd` threw
+ * "Cannot read properties of undefined (reading 'passYd')" and aborted
+ * archiveSeason() on the first rollover.
+ */
+describe('processSeasonRecords — legacy record-book shape', () => {
+  const seasonStats = [
+    { playerId: 'p1', name: 'Test QB', pos: 'QB', teamId: 1, totals: { passYd: 5000, passTD: 40 } },
+  ];
+  const teamAbbrMap = { 1: 'AAA' };
+
+  it('does not throw when existingRecords uses the legacy stub shape', () => {
+    const legacy = {
+      mostPassingYardsSeason: null,
+      mostRushingYardsSeason: null,
+      mostWinsSeason: null,
+      mostChampionships: null,
+      highestOvrPlayer: null,
+    };
+    expect(() =>
+      processSeasonRecords(legacy, seasonStats, [], 2026, teamAbbrMap, []),
+    ).not.toThrow();
+  });
+
+  it('recovers to a valid V1 record book and records the season leader', () => {
+    const legacy = { mostPassingYardsSeason: null };
+    const { records } = processSeasonRecords(legacy, seasonStats, [], 2026, teamAbbrMap, []);
+    expect(records.singleSeason).toBeDefined();
+    expect(records.allTime).toBeDefined();
+    expect(records.singleSeason.passYd.value).toBe(5000);
+    expect(records.singleSeason.passYd.name).toBe('Test QB');
+  });
+
+  it('still handles a null existingRecords (first-ever season)', () => {
+    expect(() => processSeasonRecords(null, seasonStats, [], 2026, teamAbbrMap, [])).not.toThrow();
+  });
+
+  it('preserves an already-V1 record book instead of resetting it', () => {
+    const v1 = createEmptyRecords();
+    v1.singleSeason.passYd = { playerId: 'old', name: 'Old QB', pos: 'QB', team: 'ZZZ', value: 6000, year: 2020 };
+    const { records } = processSeasonRecords(v1, seasonStats, [], 2026, teamAbbrMap, []);
+    // 5000 < existing 6000, so the prior record must survive.
+    expect(records.singleSeason.passYd.value).toBe(6000);
+    expect(records.singleSeason.passYd.name).toBe('Old QB');
+  });
+});

--- a/src/core/ai-logic.js
+++ b/src/core/ai-logic.js
@@ -15,6 +15,7 @@ import { buildAiTeamStrategy } from './aiTeamStrategy.js';
 import NewsEngine from './news-engine.js';
 import { getTeamContextForNegotiation } from './teamContext/negotiationContext.js';
 import { evaluateContractOffer } from './contracts/negotiation.js';
+import { isFreeAgent } from './freeAgency/membership.js';
 import { evaluateReSigningPriority } from './retention/reSigning.js';
 import { buildFreeAgencyMarketAnalysis } from './freeAgency/freeAgencyMarketAnalysis.js';
 import { buildContractFromMarket, evaluateContractMarket } from './contractModel.js';
@@ -452,7 +453,7 @@ class AiLogic {
         const roster = cache.getPlayersByTeam(teamId);
         const meta   = cache.getMeta();
         const allPlayers = cache.getAllPlayers();
-        const freeAgents = allPlayers.filter((p) => !p.teamId || p.status === 'free_agent');
+        const freeAgents = allPlayers.filter((p) => isFreeAgent(p));
 
         const extensions = executeAIOffseasonExtensions(
             team,
@@ -728,7 +729,7 @@ class AiLogic {
         const legacyGetCandidates = (pos) => {
             const allPlayers = cache.getAllPlayers();
             return allPlayers
-                .filter(p => (!p.teamId || p.status === 'free_agent') && p.pos === pos)
+                .filter(p => isFreeAgent(p) && p.pos === pos)
                 .sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0));
         };
 
@@ -929,7 +930,7 @@ class AiLogic {
         const allPlayers = cache.getAllPlayers();
         const freeAgentsMap = {};
         for (const p of allPlayers) {
-            if (!p.teamId || p.status === 'free_agent') {
+            if (isFreeAgent(p)) {
                 if (!freeAgentsMap[p.pos]) freeAgentsMap[p.pos] = [];
                 freeAgentsMap[p.pos].push(p);
             }
@@ -947,7 +948,7 @@ class AiLogic {
         }
 
         // 2. Players Evaluate Offers
-        const freeAgents = allPlayers.filter(p => (!p.teamId || p.status === 'free_agent') && p.offers && p.offers.length > 0);
+        const freeAgents = allPlayers.filter(p => isFreeAgent(p) && p.offers && p.offers.length > 0);
 
         const txsToCommit = [];
         for (const player of freeAgents) {
@@ -1074,7 +1075,7 @@ class AiLogic {
      */
     static evaluateOffers(player, day = 1) {
         if (!player.offers || player.offers.length === 0) return { signed: false, offer: null };
-        const allFreeAgents = cache.getAllPlayers().filter((p) => (!p.teamId || p.status === 'free_agent') && p.pos === player.pos);
+        const allFreeAgents = cache.getAllPlayers().filter((p) => isFreeAgent(p) && p.pos === player.pos);
         const heat = computeMarketHeat(player.pos, allFreeAgents);
         const profile = buildContractProfile(player);
         const ask = buildDemandFromProfile(player, profile, {

--- a/src/core/freeAgency/__tests__/membership.test.js
+++ b/src/core/freeAgency/__tests__/membership.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { isFreeAgent } from '../membership.js';
+
+describe('isFreeAgent — canonical free-agency membership predicate', () => {
+  it('treats a null/undefined teamId as a free agent', () => {
+    expect(isFreeAgent({ teamId: null })).toBe(true);
+    expect(isFreeAgent({ teamId: undefined })).toBe(true);
+    expect(isFreeAgent({})).toBe(true);
+  });
+
+  it('treats the legacy "FA" sentinel teamId as a free agent', () => {
+    expect(isFreeAgent({ teamId: 'FA' })).toBe(true);
+  });
+
+  it('treats an explicit free_agent status as a free agent even with a stale teamId', () => {
+    expect(isFreeAgent({ teamId: 7, status: 'free_agent' })).toBe(true);
+  });
+
+  it('REGRESSION: team 0 (the user team) is NOT a free agent', () => {
+    // The historical `!player.teamId` shortcut is truthy for teamId 0, which
+    // misclassified the entire user roster as free agents and let AI teams sign
+    // them away during the offseason (post-rollover collapse to ~11 players).
+    expect(isFreeAgent({ teamId: 0, status: 'active' })).toBe(false);
+    expect(isFreeAgent({ teamId: 0 })).toBe(false);
+    expect(isFreeAgent({ teamId: '0', status: 'active' })).toBe(false);
+  });
+
+  it('treats any real numbered team as rostered, not a free agent', () => {
+    for (const teamId of [0, 1, 15, 31]) {
+      expect(isFreeAgent({ teamId, status: 'active' })).toBe(false);
+    }
+  });
+
+  it('is null-safe', () => {
+    expect(isFreeAgent(null)).toBe(false);
+    expect(isFreeAgent(undefined)).toBe(false);
+  });
+});

--- a/src/core/freeAgency/membership.js
+++ b/src/core/freeAgency/membership.js
@@ -1,0 +1,23 @@
+/**
+ * Canonical free-agency membership predicate.
+ *
+ * A player is a FREE AGENT when they hold no team — `teamId` is null/undefined
+ * or the legacy `'FA'` sentinel — or they carry the explicit `'free_agent'`
+ * status. Retired and draft-eligible players are NOT free agents (they are never
+ * signable through the offseason market), so callers that build signable pools
+ * should combine this with a status guard where relevant.
+ *
+ * WHY THIS EXISTS — the user team has id `0`. The historical shortcut
+ * `!player.teamId` evaluates to `true` for `teamId === 0`, so every player on the
+ * user's roster was misclassified as a free agent and signed away by AI teams
+ * during the offseason free-agency phase (post-rollover roster collapse to ~11).
+ * Membership must be tested against `null`, never falsiness.
+ *
+ * @param {{ teamId?: unknown, status?: unknown } | null | undefined} player
+ * @returns {boolean}
+ */
+export function isFreeAgent(player) {
+  if (!player) return false;
+  const { teamId, status } = player;
+  return teamId == null || teamId === 'FA' || status === 'free_agent';
+}

--- a/src/core/records.js
+++ b/src/core/records.js
@@ -76,7 +76,17 @@ export function createEmptyRecords() {
  * @returns {{ records: Object, broken: Object[] }} Updated records and list of newly broken records
  */
 export function processSeasonRecords(existingRecords, seasonStats, allPlayers, year, teamAbbrMap, leagueHistory = []) {
-  const records = existingRecords ? structuredClone(existingRecords) : createEmptyRecords();
+  // A league is bootstrapped (defaultLeague / league.js) with a LEGACY record
+  // stub shaped `{ mostPassingYardsSeason, ... }` that lacks the V1
+  // singleSeason/allTime buckets this engine indexes into. structuredClone-ing
+  // that stub and then reading `records.singleSeason.passYd` throws. Accept an
+  // existing record book only when it carries the current shape; otherwise start
+  // from a fresh empty book (the legacy stub holds no real records to preserve).
+  const hasV1Shape = existingRecords
+    && typeof existingRecords === 'object'
+    && existingRecords.singleSeason
+    && existingRecords.allTime;
+  const records = hasV1Shape ? structuredClone(existingRecords) : createEmptyRecords();
   if (!records.history) records.history = [];
   const broken = [];
 

--- a/src/worker/handlers/freeAgencyHandlers.js
+++ b/src/worker/handlers/freeAgencyHandlers.js
@@ -22,6 +22,7 @@ import {
   marketHeatLabel,
 } from '../../core/contract-market.js';
 import { getTeamContextForNegotiation } from '../../core/teamContext/negotiationContext.js';
+import { isFreeAgent } from '../../core/freeAgency/membership.js';
 import { evaluateContractOffer, summarizeNegotiationStance } from '../../core/contracts/negotiation.js';
 import { summarizePlayerMood } from '../../core/mood/playerMood.js';
 import { getPlayerMoraleSummary } from '../../core/mood/playerMoraleEngine.js';
@@ -385,7 +386,7 @@ export async function handleSubmitOffer({ playerId, teamId, contract }, id, ctx)
     score: quality.score,
   });
   ctx.savePendingOffersLedger(upsertPendingOffer(ledger, offerRecord).list, { day: faDay });
-  const allFreeAgents = cache.getAllPlayers().filter((p) => !p.teamId || p.status === 'free_agent');
+  const allFreeAgents = cache.getAllPlayers().filter((p) => isFreeAgent(p));
   const heat = computeMarketHeat(player.pos, allFreeAgents);
   const marketMemory = liveMeta?.contractMarketMemory?.[String(playerId)] ?? {};
   const decisionTiming = buildDecisionTiming(player, heat, player.offers.length, liveMeta.phase, {

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -177,6 +177,7 @@ import {
   expireAllPendingOffers,
   prunePendingOffers,
 } from '../core/freeAgency/pendingOffers.js';
+import { isFreeAgent } from '../core/freeAgency/membership.js';
 import {
   shouldAITeamPursuePlayer,
   computeAIOffer,
@@ -962,7 +963,7 @@ function buildTeamContractSnapshot(teamId) {
     return years <= 1;
   });
 
-  const allFreeAgents = cache.getAllPlayers().filter((p) => !p.teamId || p.status === 'free_agent');
+  const allFreeAgents = cache.getAllPlayers().filter((p) => isFreeAgent(p));
   const hotPositions = {};
   for (const pos of Object.keys(depth)) {
     hotPositions[pos] = computeMarketHeat(pos, allFreeAgents);
@@ -7235,7 +7236,7 @@ async function finalizeFreeAgencySigning(player, offer, liveMeta) {
 
 function evaluatePlayerOfferDecision(player, offers = [], liveMeta, memory = {}) {
   if (!player || !offers.length) return { status: 'pending', reason: 'No offers yet', bestOffer: null };
-  const freeAgents = cache.getAllPlayers().filter((p) => !p.teamId || p.status === 'free_agent');
+  const freeAgents = cache.getAllPlayers().filter((p) => isFreeAgent(p));
   const heat = computeMarketHeat(player.pos, freeAgents);
   const profile = buildContractProfile(player);
   const ask = buildDemandFromProfile(player, profile, { marketHeat: heat, morale: player.morale ?? 68, fit: 65, teamSuccess: 0.5 });
@@ -7410,7 +7411,7 @@ async function resolvePendingFreeAgencyOffers({ resolutionDay = 7, onlyPlayerId 
   const nextMemory = { ...memory };
   const freeAgentsWithOffers = cache.getAllPlayers().filter((p) => {
     if (targetPlayerId != null && Number(p?.id) !== targetPlayerId) return false;
-    return (!p.teamId || p.status === 'free_agent') && Array.isArray(p.offers) && p.offers.length > 0;
+    return (isFreeAgent(p)) && Array.isArray(p.offers) && p.offers.length > 0;
   });
 
   const results = [];
@@ -8290,7 +8291,7 @@ async function handleGetExtensionAsk({ playerId }, id) {
   if (!player) { post(toUI.ERROR, { message: 'Player not found' }, id); return; }
   const team = cache.getTeam(player.teamId ?? meta.userTeamId);
   const profile = buildContractProfile(player);
-  const marketHeat = computeMarketHeat(player.pos, cache.getAllPlayers().filter((p) => !p.teamId || p.status === 'free_agent'));
+  const marketHeat = computeMarketHeat(player.pos, cache.getAllPlayers().filter((p) => isFreeAgent(p)));
   const demandFromProfile = inflateContract(buildDemandFromProfile(player, profile, {
     marketHeat,
     morale: calculateMorale(player, team, true),
@@ -11974,7 +11975,7 @@ async function injectAIFaBids(day) {
 
   const allTeams   = cache.getAllTeams();
   const allPlayers = cache.getAllPlayers();
-  const freeAgents = allPlayers.filter((p) => !p.teamId || p.status === 'free_agent');
+  const freeAgents = allPlayers.filter((p) => isFreeAgent(p));
   if (freeAgents.length === 0) return;
 
   const userTeam = cache.getTeam(userTeamId);
@@ -12166,7 +12167,7 @@ async function handleAdvanceFreeAgencyDay(payload, id) {
     // Snapshot free-agent player IDs before bids/signings for post-pass events.
     const preBidFaIds = new Set(
       cache.getAllPlayers()
-        .filter((p) => !p.teamId || p.status === 'free_agent')
+        .filter((p) => isFreeAgent(p))
         .map((p) => p.id),
     );
     try {

--- a/tests/durability/postRolloverRosterIntegrity.test.js
+++ b/tests/durability/postRolloverRosterIntegrity.test.js
@@ -1,0 +1,76 @@
+/**
+ * Post-Rollover Roster Membership Integrity (PR #1689) — behavior regression.
+ *
+ * Reproduces the real production lifecycle through the first offseason rollover
+ * and proves the user team (id 0) keeps a legal roster.
+ *
+ * ROOT CAUSE guarded here: the user team has id `0`, and `teamId === 0` is
+ * falsy. The offseason free-agency classifier used `!player.teamId` to mean
+ * "is a free agent", so every player on the user's roster was misclassified as a
+ * free agent and signed away by AI teams — collapsing team 0 to ~11 players by
+ * the next preseason while every AI team stayed healthy.
+ *
+ * This exercises the REAL worker (INIT → USE_SAFE_STARTER_LEAGUE → SIM_TO_PHASE)
+ * so it validates the actual mutation path, not a fixture.
+ */
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { LifecycleDriver } from './lifecycleDriver.js';
+import { ROSTER } from './invariants/bounds.js';
+
+const USER_TEAM_ID = 0;
+
+describe('post-rollover roster membership integrity (PR #1689)', () => {
+  /** @type {LifecycleDriver} */
+  let driver;
+  let preRolloverUserCount = 0;
+  let preseasonView = null;
+
+  beforeAll(async () => {
+    driver = new LifecycleDriver({ seed: 1684 });
+    await driver.initLeague();
+    await driver.simToPhase('playoffs', { checkpoint: 'afterRegularSeason' });
+    await driver.simToPhase('offseason', { checkpoint: 'afterPlayoffs' });
+    const preUser = driver.view.teams.find((t) => Number(t.id) === USER_TEAM_ID);
+    preRolloverUserCount = preUser?.roster?.length ?? 0;
+    await driver.simToPhase('preseason', { checkpoint: 'afterSeasonRollover' });
+    preseasonView = driver.view;
+  }, 200_000);
+
+  it('reaches the next preseason without a lifecycle crash', () => {
+    expect(preseasonView.phase).toBe('preseason');
+  });
+
+  it('user team enters the offseason with a full roster', () => {
+    expect(preRolloverUserCount).toBeGreaterThanOrEqual(ROSTER.REGULAR_SEASON_MIN);
+  });
+
+  it('REGRESSION: user team (id 0) is NOT stripped to ~11 players by AI free agency', () => {
+    const team0 = preseasonView.teams.find((t) => Number(t.id) === USER_TEAM_ID);
+    expect(team0).toBeTruthy();
+    // Pre-fix this collapsed to 11. Post-fix the user keeps its veterans (it does
+    // not actively cut/re-sign in a batch sim) plus drafted rookies.
+    expect(team0.roster.length).toBeGreaterThanOrEqual(ROSTER.REGULAR_SEASON_MIN);
+    expect(team0.roster.length).toBeLessThanOrEqual(ROSTER.ABSOLUTE_MAX);
+  });
+
+  it('every team — user and AI alike — holds a legal preseason roster', () => {
+    const offenders = preseasonView.teams
+      .map((t) => ({ id: t.id, size: Array.isArray(t.roster) ? t.roster.length : 0 }))
+      .filter((t) => t.size < ROSTER.REGULAR_SEASON_MIN || t.size > ROSTER.ABSOLUTE_MAX);
+    expect(offenders).toEqual([]);
+  });
+
+  it('no player is rostered on more than one team after the rollover', () => {
+    const owner = new Map();
+    for (const team of preseasonView.teams) {
+      for (const p of team.roster ?? []) {
+        const key = String(p.id);
+        if (owner.has(key)) owner.set(key, [...owner.get(key), team.id]);
+        else owner.set(key, [team.id]);
+      }
+    }
+    const dupes = [...owner.entries()].filter(([, teams]) => new Set(teams.map(String)).size > 1);
+    expect(dupes).toEqual([]);
+  });
+});


### PR DESCRIPTION
The user team has id 0, and `teamId === 0` is falsy. The offseason free-agency
code classified free agents with the shortcut `!player.teamId`, which is true
for every team-0 player, so the entire user roster was treated as a free-agent
pool and signed away by AI teams during the free-agency phase. By the next
preseason team 0 held only its ~11 drafted rookies, tripping the durability
`roster.size-within-legal-range` invariant (team 0, size 11). Only team 0 was
affected — AI team ids 1-31 are truthy.

Introduce a single canonical predicate `isFreeAgent(player)` that tests
`teamId == null` (never falsiness) and route all 12 free-agency classification
sites through it (ai-logic.js, worker.js, freeAgencyHandlers.js). This is a
canonical membership-boundary fix — no roster-repair pass, no invariant
weakening, no team-0 special-casing. Post-fix the user team retains its roster
through the offseason (53 veterans + drafted rookies = 60 at preseason) and the
roster invariant passes.

Also fix the `passYd` TypeError that aborted archiveSeason() on the first
rollover: a fresh league is bootstrapped with a legacy record-book stub lacking
the V1 singleSeason/allTime buckets, so `records.singleSeason.passYd` threw.
`processSeasonRecords` now accepts an existing book only when it carries the V1
shape, otherwise starts from an empty book. Schema-compatible; legacy saves and
the season archive now work.

Tests: canonical-predicate unit tests (incl. team-0 regression), record-book
legacy-shape tests, and a real-lifecycle durability regression driving the full
first rollover and asserting every team keeps a legal preseason roster. Full
unit suite (5473) and durability suite (38) pass; production build passes.

The remaining durability failures (schedule self-games/invalid-team-refs,
archived-champion ref, save/reload rosterFingerprint) are pre-existing and
independent; see docs/post-rollover-roster-membership-integrity-v1.md for the
before/after attribution and the recommended #1690 scope.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014UzJrfJ6V5o6acuYUws2vE