### PR TITLE
Mobile Game-Day Trust & Recovery V1

### DIFF
--- a/docs/mobile-game-day-trust-recovery-v1.md
+++ b/docs/mobile-game-day-trust-recovery-v1.md
@@ -1,0 +1,233 @@
+# Mobile Game-Day Trust & Recovery V1
+
+Scope: the game-day loop — Live Game → Final → Postgame → Game Book → Return to
+Franchise HQ — on phone-sized viewports. Frontend presentation, navigation,
+view-state interpretation, and error recovery only. No simulation, roster,
+offseason, worker-lifecycle, or save-schema changes (PR #1689 territory is
+untouched).
+
+---
+
+## 1. Screenshot evidence matrix
+
+| # | Screenshot issue | Classification | Root cause / disposition |
+|---|---|---|---|
+| 1a | Scorebug reads 0–7 while a TOUCHDOWN card reads 0–0 | **Confirmed live defect (upstream data)** | Play-log score snapshots are written *before* the scoring increment (`src/core/simulation/index.js` — `addLog` at ~L783 runs before `offTeam.score += td.points` at ~L935), **and** the entire narrated running score belongs to a different engine than the recorded final (see §4). UI now omits per-play scores entirely. |
+| 1b | Every event stamped `Q1 15:10` | **Confirmed live defect (upstream data)** | The clock is drive-granular: one string per drive shared by all of its plays, with randomized seconds (`clockStr` built once per drive; seconds via `U.rand(0,5)*10`, which can even exceed `15:00`). UI now shows quarter + event sequence, never a per-play clock. |
+| 1c | Touchdown ordering ambiguous among same-timestamp cards | **Confirmed layout problem** | Feed was already newest-last but nothing said so and identical clocks blurred order. Feed is now `role="log"` "newest play last" with `#sequence` indicators, quarter markers, and drive dividers. |
+| 1d | Controls/filters/Standouts consume most of the screen | **Confirmed layout problem** | Speed/Skip/Playcall columns + open Standouts list measured ~339 px of a 844 px viewport. Now one 53 px sticky tray + collapsible Standouts; live feed area grew from ~310 px to ~537 px at 390×844. |
+| 2 | Postgame: oversized result banner, disconnected Game Flow row, tall leader cards | **Confirmed layout problem** | Banner compacted to one line (emoji + W/L + week + saved chip), score card tightened, Game Flow empty state honest and compact. Leader rows kept (already compact); calculations untouched. |
+| 3 | "Game recap failed / Returning you to the Weekly Hub…" modal over an unrelated Franchise History screen | **Confirmed live defect** | Two stacked causes, see §3. Recovery surface redesigned per §5. |
+| 4a | Partially visible left drawer after returning to HQ | **Unable to reproduce** (drawer verified off-screen at `translateX(300px)` after the loop) | Hardened anyway: drawer now closes on *any* tab change (was: section change only) and a closed drawer is `visibility:hidden` after its slide, so an interrupted transition can never leave a sliver. |
+| 4b | Stacked full-width activity toasts covering week results | **Confirmed live defect** | Worker `NOTIFICATION`s (e.g. "Weekly simulation ran on the AttributesV2 engine.") never auto-dismissed and stacked up to 10 full-width cards. Now: info-level auto-dismisses after 7 s, max 3 visible rows (newest last), older rows collapse into one "+N earlier notices" row, compact styling. Warnings and retryable notices persist. |
+| 4c | Bottom nav covering content | **Confirmed layout problem** | `.app-shell` mobile bottom padding didn't include `env(safe-area-inset-bottom)`; the floating nav (60 px + 10 px inset + home indicator) could cover the last row. Fixed. |
+| 4d | "Games resolved: 15 / 16" warning | **Intentional behavior — preserved** | The honest partial-results warning in `LiveGame.jsx` is untouched. |
+
+Bonus defect found while reproducing (not in the screenshots but underlying
+several of them): an **infinite React update loop** ran on every screen — see §3.
+
+## 2. Confirmed vs unconfirmed
+
+- Confirmed & fixed: 1a–1d, 2, 3, 4b, 4c, plus the update-loop and the
+  narrated-vs-canonical score divergence at the postgame seam.
+- Unable to reproduce: the drawer sliver (4a) — hardened defensively.
+- Intentional & preserved: partial-results warning (4d); `LiveGame.jsx`'s
+  openly synthetic week-sim ticker (documented as deferred, §15).
+
+## 3. Exact live root cause of the Game Book failure
+
+Two independent, verified-in-browser causes:
+
+1. **Infinite update loop starving the archive fetch.**
+   `SettingsContext.updateSetting` was recreated every render and always
+   produced a new `settings` object even for identical values. `ThemeToggle`
+   calls `updateSetting('theme', …)` from an effect with `updateSetting` in its
+   dependency array → unbounded re-render loop ("Maximum update depth
+   exceeded" repeatedly, verified via CDP stack: `ThemeToggle.jsx:36 →
+   SettingsContext.jsx:30`). Under this storm the Game Book's
+   `useStableRouteRequest` box-score fetch never settled, and the max-depth
+   error could surface through `PostGameErrorBoundary` — producing the "Game
+   recap failed" modal over whatever dashboard tab was mounted behind the
+   overlay (e.g. Franchise History). Fix: `updateSetting` is memoized and
+   bails out when the value is unchanged; `ThemeToggle` only persists a real
+   change. Verified: 100+ loop errors per session before → 0 after.
+
+2. **Serialization-default 0–0 masquerading as a final.**
+   The slim schedule is packed into an `Int32Array`
+   (`src/worker/serialization.js` — `Number(g.homeScore ?? 0)`), so every
+   *unplayed* game reaches the UI with `homeScore: 0, awayScore: 0,
+   played: false`. `recoverArchivedGameFromSchedule` only checked
+   `score == null`, so whenever the archive lookup missed, the Game Book
+   rendered a fake **"T · AWAY 0 – 0 HOME"** for a real game (reproduced
+   live). Fix: rows explicitly marked unplayed are never treated as finals
+   (`gameArchive.js`, `boxScoreAccess.js`, `canonicalCompletedGame.js`), and
+   `normalizeArchivedGamePayload` now preserves the `played` flag.
+
+`GameDetailScreen` additionally gained a loading state and an anchored
+recovery surface (see §5) for the genuinely-missing-game case.
+
+## 4. Score and clock authority map
+
+| Value | Canonical source | Notes |
+|---|---|---|
+| Recorded final score | Drive engine — `buildDriveBasedSummary` (`src/core/simulation/index.js` ~L1176) → `GAME_EVENT.homeScore/awayScore`, schedule row, archive | This is what standings, HQ, and the Game Book record. |
+| Narrated play stream (`playLogs`) | Legacy narration loop (`simulateFullGame`) | **A different engine.** Its running score routinely contradicts the recorded final (observed: narrated 3–26 vs recorded 41–35 in one game). Its per-play `homeScore/awayScore` are additionally *pre-play* snapshots. |
+| Per-play clock | None | Drive-granular estimate with randomized seconds (can exceed 15:00). Not trustworthy per play. |
+| Quarter | `playLogs[].quarter` | Trustworthy (derived deterministically from drive index). |
+| Possession / down / distance / field position | `playLogs[]` | Narration-consistent; displayed as drive context, never as score claims. |
+| Standouts | `playLogs[]` accumulations | Same engine as the box-score player stats — internally consistent. |
+
+UI policy implemented (no simulation changes):
+- Feed event cards carry **no score stamps** (`score: null`); only the
+  `game_end` marker is stamped with the canonical final passed from the
+  `GAME_EVENT` payload (`FINAL a–h` chip).
+- The live scorebug shows quarter + `Play N of M` + possession/down/distance,
+  with **“–” score placeholders** until the final whistle, then the canonical
+  final with a FINAL chip. It never renders the narrated running score.
+- `onComplete` → PostGameScreen → archive all use the canonical `GAME_EVENT`
+  final (previously the narrated score leaked into PostGameScreen and
+  *overwrote the UI archive*, producing an HQ "Last Result" card that showed a
+  LOSS for a league-recorded WIN — reproduced live, now impossible).
+- If no canonical final exists, the viewer shows an honest "Final score is
+  being recorded…" note instead of fabricating one.
+
+## 5. Route/recovery flow — before and after
+
+Before: recap crash → translucent modal ("Game recap failed / Returning you to
+the Weekly Hub…" **plus** a button, no actual auto-navigation) over whatever
+screen was behind; missing archive → fake 0–0 tie Game Book.
+
+After:
+- Recap crash → fully opaque `role="alertdialog"` anchored surface; honest
+  copy ("Game recap unavailable — The final result was saved…"); exactly one
+  user-controlled action (**Return to HQ**) guarded to navigate once.
+- Missing game → `GameDetailScreen` anchored recovery (`game-book-recovery`):
+  "Game Book unavailable — The detailed recap for this game could not be
+  loaded. Your league results are unaffected." + single Return-to-HQ action;
+  loading state shown while the archive request is in flight; no placeholder
+  teams or scores, no unrelated screen behind (modal + backdrop unchanged,
+  content honest).
+
+## 6. Mobile drawer root cause
+
+Not reproducible as a live defect (measured `translateX(300px)`, off-screen,
+after the full loop). Two hardening changes shipped: the drawer closes on any
+`activeTab` change (previously only `activeSection`), and
+`.mobile-nav-panel:not(.open)` becomes `visibility:hidden` once its slide
+completes, so a stuck transform can never leave a visible sliver.
+
+## 7. Toast-stack behavior — before / after
+
+Before: up to 10 permanent full-width alert cards; routine post-sim info
+notices persisted until manually dismissed. After: info-level auto-dismisses
+(7 s), warnings/retryable persist, max 3 visible compact rows (newest last),
+older rows collapse into a "+N earlier notices" summary with dismiss-all.
+Content unchanged — nothing diagnostic was removed.
+
+## 8. Postgame hierarchy changes
+
+One-line result header (emoji + VICTORY/DEFEAT/TIE + week + inline "Game
+saved" chip), tightened score card (42 px badges, 2.2 rem scores), honest
+compact Game Flow empty state ("Detailed game flow was not recorded for this
+matchup."), Leaders/Grades tabs and leader math untouched, Game Book CTA and
+Back to Hub unchanged and reachable.
+
+## 9. Controls compacting (live viewer)
+
+Speed/Skip/Playcall moved from a stacked side-rail block into one sticky
+bottom tray above the safe area: pause toggle + 4 speed steps + a `Skip ▾`
+disclosure containing Next Score / Key Play / Sim End (+ playcall overrides
+when available). Standouts became a collapsible `<details>` (open by default,
+two-column on mobile). Jump pills unchanged (already horizontally scrollable).
+No functionality removed. Side rail: ~339 px → ~108 px at 390×844.
+
+## 10. Files changed
+
+- `src/ui/context/SettingsContext.jsx`, `src/ui/components/ThemeToggle.jsx` — update-loop fix.
+- `src/core/liveGame/liveGameEvents.js` — score omission policy, sequence, canonical-final stamping.
+- `src/ui/components/GameEventFeed/GameEventFeed.jsx` — quarter+sequence display, final-only score chip, `role="log"`.
+- `src/ui/components/Scorebug/Scorebug.jsx` — placeholder scores, no fabricated clock, FINAL chip.
+- `src/ui/components/LiveGameViewer.jsx` — canonical `finalScore` prop, sticky control tray, collapsible standouts.
+- `src/ui/App.jsx` — canonical final into viewer/postgame/archive; notification cap + auto-dismiss; `openBoxScore` E2E hook.
+- `src/ui/components/PostGameScreen.jsx` — recovery boundary redesign, compact hierarchy.
+- `src/ui/components/GameDetailScreen.jsx` — loading + anchored recovery states, navigate-once guard.
+- `src/core/gameArchive.js`, `src/ui/utils/boxScoreAccess.js`, `src/ui/utils/canonicalCompletedGame.js` — unplayed-row 0–0 guards, `played` preserved through normalization.
+- `src/ui/components/MobileNav.jsx`, `src/ui/styles/app-mobile.css` — drawer cleanup/hardening, safe-area shell padding, compact notification styles.
+- `src/ui/utils/notificationsDisplay.js` — `capVisibleNotifications`.
+- `playwright.config.ts` — optional `PLAYWRIGHT_CHROMIUM_EXECUTABLE` env (test infra only).
+- Tests: see §13.
+
+## 11. Mobile viewport validation
+
+Swept 390×844, 393×852, 430×932, 360×780, 1440×900 on the built bundle:
+no horizontal overflow anywhere; control tray on-screen above the safe area;
+scorebug visible; drawer fully off-screen/hidden after the loop; bottom nav no
+longer overlaps the last content row (shell padding includes safe-area inset).
+Desktop keeps the two-column watch layout and in-flow controls.
+
+## 12. Accessibility
+
+- Recovery surfaces: `role="alertdialog"`/`role="alert"` with labelled
+  title/description (screen-reader announcement of recap errors).
+- Feed: `role="log"` + "newest play last" label; score/result meaning carried
+  by text labels (FINAL chip, W/L letters), not color alone.
+- Icon-only pause button has an aria-label; speed buttons expose
+  `aria-pressed`; scorebug placeholders have descriptive aria-labels.
+- Control tray buttons ≥44 px; semantic buttons throughout; no new animation
+  (existing transitions only).
+
+## 13. Tests
+
+New:
+- `src/core/liveGame/liveGameEvents.test.js` (7) — score omission, canonical
+  final stamping, sequence, no default clock, jump filters.
+- `src/ui/components/__tests__/LiveGameViewerTrust.test.jsx` (9) — scorebug
+  never shows narrated scores; canonical final at completion; `onComplete`
+  reports canonical; honest pending state; no fabricated clocks; scoring
+  emphasis; explicit ordering; compact controls keep all functionality.
+- `src/ui/components/__tests__/PostGameRecovery.test.jsx` (6) — user-team W/L
+  heading, canonical Game Book id, continuation, anchored recovery dialog,
+  navigate-exactly-once.
+- `src/ui/components/__tests__/HQOverlayCleanup.test.jsx` (7) — drawer closes
+  on tab change and on Game Book focus; notification cap; unplayed 0–0 rows
+  never masquerade as finals.
+- `tests/e2e/mobile_game_day_trust.spec.js` (2, 390×844) — full loop with
+  canonical-score assertions end to end, and the missing-game recovery
+  fixture (`gameController.openBoxScore('s1_w99_998_999')`).
+
+Updated: `GameDetailScreen.test.jsx` (no-data case now asserts the anchored
+recovery surface instead of a placeholder header).
+
+Results: `npm run test:unit` — 444 files / 5492 tests passed (including the 29
+new tests above). `npm run build` — passes. New E2E spec — 2/2 passed against the
+production build. Pre-existing E2E failures on `main` (verified identical on a
+clean `origin/main` worktree, 4 failures): `box_score_clickthrough.spec.js`
+(2) and `franchise_hq_mobile_smoke.spec.js` HQ-essentials (2) — unrelated to
+this PR and not introduced by it.
+
+## 14. Explicitly untouched systems
+
+Simulation engines and scoring math, play-outcome probabilities, clock-manager
+math, game-stat calculations, league resolution semantics (the 15/16 partial
+warning is preserved verbatim), worker lifecycle/protocol (no new message
+types; no payload changes), save schema, roster/offseason/contracts/free
+agency/draft/retirement, durability harness, season rollover, the passYd
+archive warning.
+
+## 15. Deferred upstream issues (recommended follow-ups)
+
+1. **Narrated play stream vs recorded final divergence.** `WATCH_GAME` builds
+   play-by-play with the legacy narration loop while
+   `buildDriveBasedSummary` overrides the final score
+   (`src/core/simulation/index.js` ~L1176). Fields affected:
+   `playLogs[].homeScore/awayScore/scoreHome/scoreAway` (pre-play snapshots of
+   a non-canonical score) and `playLogs[].clock/timeLeft` (drive-granular,
+   randomized seconds). A separate engine PR should either emit per-play
+   canonical `scoreAfter` from the drive engine or align the narration loop
+   with it; the UI can then re-enable live running scores.
+2. **`GAME_EVENT` lacks `quarterScores`** — adding the drive engine's quarter
+   splits to the watched-game payload would allow an honest quarter-grain
+   running scorebug.
+3. **`LiveGame.jsx` week-sim ticker** generates fully synthetic plays/scores
+   ("always plausible" narration). Out of screenshot scope here; recommend
+   the same omission policy in a follow-up UI PR.

--- a/docs/mobile-game-day-trust-recovery-v1.md
+++ b/docs/mobile-game-day-trust-recovery-v1.md
@@ -198,6 +198,17 @@ New:
 Updated: `GameDetailScreen.test.jsx` (no-data case now asserts the anchored
 recovery surface instead of a placeholder header).
 
+Review follow-up (Codex findings, both confirmed and fixed):
+- The Game Book's recovery gate now requires a *valid final* (played +
+  finite scores), not object existence — an unplayed schedule row matched by
+  id can no longer bypass recovery and render a fake 0-0 tie; conversely, an
+  archive-validated final is stamped `played: true` so a stale
+  `played: false` schedule/index row can never veto a real result.
+- `capVisibleNotifications` never collapses warnings or retryable notices
+  into the info summary row; only routine info rows count against the cap.
+Covered by new cases in `GameDetailScreen.test.jsx` and
+`HQOverlayCleanup.test.jsx` (unit totals now 444 files / 5494 tests).
+
 Results: `npm run test:unit` — 444 files / 5492 tests passed (including the 29
 new tests above). `npm run build` — passes. New E2E spec — 2/2 passed against the
 production build. Pre-existing E2E failures on `main` (verified identical on a

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from '@playwright/test';
 
 const chromiumChannel = process.env.PLAYWRIGHT_CHROMIUM_CHANNEL || undefined;
+// Sandboxed CI images often pre-install a full Chromium at a fixed path
+// instead of the per-revision headless shell; point the runner at it without
+// changing default behavior anywhere else.
+const chromiumExecutable = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE || undefined;
 const mobileViewport = process.env.PLAYWRIGHT_VIEWPORT === 'iphone'
   ? { viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true }
   : {};
@@ -16,6 +20,7 @@ export default defineConfig({
     baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:4173',
     trace: 'on-first-retry',
     ...(chromiumChannel ? { channel: chromiumChannel } : {}),
+    ...(chromiumExecutable ? { launchOptions: { executablePath: chromiumExecutable } } : {}),
     ...mobileViewport,
   },
   webServer: {

--- a/src/core/gameArchive.js
+++ b/src/core/gameArchive.js
@@ -13,7 +13,10 @@ const asNumberOrNull = (value) => {
 
 const hasValues = (obj) => Boolean(obj && typeof obj === 'object' && Object.keys(obj).length > 0);
 
-const hasFinalScore = (game) => Number.isFinite(Number(game?.homeScore ?? game?.scoreHome ?? game?.score?.home))
+// Rows explicitly marked unplayed carry serialization-default 0-0 scores
+// (schedule buffers can't hold null) — they are never a real final.
+const hasFinalScore = (game) => !(game?.played === false || game?.played === 0)
+  && Number.isFinite(Number(game?.homeScore ?? game?.scoreHome ?? game?.score?.home))
   && Number.isFinite(Number(game?.awayScore ?? game?.scoreAway ?? game?.score?.away));
 
 function teamLabel(rawGame, side, key) {
@@ -172,6 +175,10 @@ export function normalizeArchivedGamePayload(rawGame) {
     gameId: id,
     seasonId,
     week,
+    // Preserve the explicit played flag so downstream completed-game checks
+    // can distinguish a real 0-0 final from a serialization-default 0-0 on an
+    // unplayed schedule row. Undefined stays undefined (legacy payloads).
+    played: rawGame?.played,
     phase: rawGame?.phase ?? null,
     homeId,
     awayId,
@@ -351,6 +358,11 @@ export function recoverArchivedGameFromSchedule(gameId, leagueState) {
       const rowAway = toTeamId(row?.awayId ?? row?.away?.id ?? row?.away);
       if (rowHome !== Number(homeValue) || rowAway !== Number(awayValue)) continue;
       if (row?.homeScore == null && row?.awayScore == null) continue;
+      // The serialized slim schedule packs unplayed games with default 0-0
+      // scores (Int32Array slots can't hold null — see worker/serialization.js),
+      // so a row explicitly marked unplayed must never be recovered as a
+      // "final". Otherwise a pre-game row surfaces as a fake 0-0 tie.
+      if (row?.played === false || row?.played === 0) continue;
       return normalizeArchivedGamePayload({
         id: gameId,
         seasonId: row?.seasonId ?? seasonId,

--- a/src/core/liveGame/liveGameEvents.js
+++ b/src/core/liveGame/liveGameEvents.js
@@ -28,21 +28,45 @@ function normalizeEventType(log = {}) {
   return 'routine';
 }
 
+function toFiniteScore(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Canonical-data policy for the live feed.
+ *
+ * The play logs emitted by the narration engine carry per-play
+ * `homeScore`/`awayScore` snapshots, but those values are NOT canonical:
+ * the league-recorded final comes from a separate drive engine
+ * (see `src/core/simulation/index.js` — `buildDriveBasedSummary` overrides
+ * `homeScore`/`awayScore` after the narration loop runs), so the narrated
+ * running score routinely contradicts the real result. Rather than stamp a
+ * score on every event card that can contradict the recorded final, events
+ * carry `score: null` and only the appended `game_end` marker is stamped with
+ * the canonical final passed in via `context.finalScore`.
+ *
+ * The per-play `clock` value is likewise drive-granular (every play in a
+ * drive shares one clock string, and the seconds are randomized), so the feed
+ * exposes `sequence` (a real event-order indicator) instead of pretending to
+ * have a trustworthy per-play game clock. The raw log stays on `raw` for
+ * data-level consumers (jump filters), which never display it.
+ */
 export function buildLiveGameEvent(log = {}, index = 0, context = {}) {
   const eventType = normalizeEventType(log);
-  const home = Number(log.homeScore ?? log.scoreHome ?? 0);
-  const away = Number(log.awayScore ?? log.scoreAway ?? 0);
   return {
     id: `${context.gameId || 'game'}-${index}`,
     gameId: context.gameId || 'game',
     quarter: Number(log.quarter || 1),
-    clock: log.clock || log.timeLeft || '15:00',
+    clock: log.clock || log.timeLeft || null,
+    sequence: index + 1,
     offenseTeamId: log.possession === 'home' ? context.homeTeamId : context.awayTeamId,
     defenseTeamId: log.possession === 'home' ? context.awayTeamId : context.homeTeamId,
     eventType,
     headline: String(log.text || log.playText || 'Drive develops').trim(),
     detail: log.description || undefined,
-    score: { home, away },
+    // Untrusted per-play score snapshots are intentionally omitted — see note above.
+    score: null,
     possessionTeamId: log.possession === 'home' ? context.homeTeamId : context.awayTeamId,
     fieldPosition: log.fieldPosition ?? log.yardLine,
     down: log.down,
@@ -73,6 +97,15 @@ export function mapArchiveEventsToLiveFeed(playLogs = [], context = {}) {
     }
   }
 
+  // The final marker is the only event stamped with a score, and only when the
+  // caller supplies the canonical league-recorded final. Never reconstructed
+  // from the narration stream.
+  const finalHome = toFiniteScore(context.finalScore?.home);
+  const finalAway = toFiniteScore(context.finalScore?.away);
+  const canonicalFinal = finalHome != null && finalAway != null
+    ? { home: finalHome, away: finalAway }
+    : null;
+
   const last = withMarkers[withMarkers.length - 1];
   withMarkers.push({
     ...last,
@@ -80,6 +113,7 @@ export function mapArchiveEventsToLiveFeed(playLogs = [], context = {}) {
     eventType: 'game_end',
     headline: 'Final whistle. Game Book is ready.',
     impactTag: 'swing',
+    score: canonicalFinal,
   });
 
   return withMarkers;

--- a/src/core/liveGame/liveGameEvents.test.js
+++ b/src/core/liveGame/liveGameEvents.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { buildLiveGameEvent, mapArchiveEventsToLiveFeed, getNextImportantEvent } from './liveGameEvents.js';
+
+// The narration engine's per-play score snapshots belong to a different
+// scoring engine than the league-recorded final (see the authority note in
+// liveGameEvents.js), so the live feed must never surface them.
+
+const context = { gameId: 'g1', homeTeamId: 1, awayTeamId: 2 };
+
+describe('buildLiveGameEvent — score/clock trust', () => {
+  it('omits the untrusted per-play score even when the log carries one', () => {
+    const event = buildLiveGameEvent(
+      { text: 'TOUCHDOWN! big play', homeScore: 7, awayScore: 0, quarter: 1, clock: '15:10' },
+      0,
+      context,
+    );
+    expect(event.eventType).toBe('touchdown');
+    expect(event.score).toBeNull();
+  });
+
+  it('keeps a real event-sequence indicator instead of fabricating a per-play clock', () => {
+    const event = buildLiveGameEvent({ text: 'run for 4 yds', quarter: 2 }, 4, context);
+    expect(event.sequence).toBe(5);
+    expect(event.quarter).toBe(2);
+  });
+
+  it('carries no default clock when the log has none', () => {
+    const event = buildLiveGameEvent({ text: 'pass complete' }, 0, context);
+    expect(event.clock).toBeNull();
+  });
+});
+
+describe('mapArchiveEventsToLiveFeed — canonical final stamping', () => {
+  const logs = [
+    { text: 'run for 3 yds', quarter: 1, homeScore: 0, awayScore: 0 },
+    { text: 'TOUCHDOWN! deep ball', quarter: 1, homeScore: 0, awayScore: 0 },
+    { text: 'kneel down', quarter: 4, homeScore: 6, awayScore: 0 },
+  ];
+
+  it('stamps the canonical final only on the game_end marker when supplied', () => {
+    const events = mapArchiveEventsToLiveFeed(logs, { ...context, finalScore: { home: 27, away: 24 } });
+    const finalEvent = events[events.length - 1];
+    expect(finalEvent.eventType).toBe('game_end');
+    expect(finalEvent.score).toEqual({ home: 27, away: 24 });
+    // Every non-final event stays score-free.
+    events.slice(0, -1).forEach((e) => expect(e.score).toBeNull());
+  });
+
+  it('leaves the final marker score-free rather than guessing when no canonical final exists', () => {
+    const events = mapArchiveEventsToLiveFeed(logs, context);
+    const finalEvent = events[events.length - 1];
+    expect(finalEvent.eventType).toBe('game_end');
+    expect(finalEvent.score).toBeNull();
+  });
+
+  it('rejects a partial/non-numeric final instead of coercing to 0', () => {
+    const events = mapArchiveEventsToLiveFeed(logs, { ...context, finalScore: { home: 21, away: undefined } });
+    expect(events[events.length - 1].score).toBeNull();
+  });
+});
+
+describe('getNextImportantEvent — jump filters still work on raw data', () => {
+  it('finds the next scoring event', () => {
+    const events = mapArchiveEventsToLiveFeed([
+      { text: 'short gain', quarter: 1 },
+      { text: 'TOUCHDOWN! strike', quarter: 1 },
+      { text: 'punt', quarter: 2 },
+    ], context);
+    const idx = getNextImportantEvent(events, 0, 'score');
+    expect(events[idx].eventType).toBe('touchdown');
+  });
+});

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -53,7 +53,7 @@ import EventDecisionModal from './components/EventDecisionModal.jsx';
 import { SettingsProvider, useSettings } from './context/SettingsContext.jsx';
 import { ACTION_LABELS, formatRegularUnitLabel } from './constants/navigationCopy.js';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from './utils/boxScoreAccess.js';
-import { getDisplayableNotifications } from './utils/notificationsDisplay.js';
+import { capVisibleNotifications, getDisplayableNotifications } from './utils/notificationsDisplay.js';
 import { buildOffseasonActionCenter } from './utils/offseasonActionCenter.js';
 import {
   hasMinimumPlayableLeague,
@@ -567,6 +567,28 @@ function AppContent() {
     }
   }, [simulating, lastResults, lastSimWeek, userGameLogs, postGameResult, league]);
 
+  // ── Auto-dismiss routine info notices ─────────────────────────────────────
+  // Post-sim info notices ("Weekly simulation ran…", "development updated…")
+  // previously piled up as permanent full-width cards over the weekly results.
+  // Info-level, non-retryable notices now dismiss themselves; warnings and
+  // retryable notices persist until the user acts on them.
+  const autoDismissTimersRef = useRef(new Map());
+  useEffect(() => {
+    const timers = autoDismissTimersRef.current;
+    (notifications ?? []).forEach((n) => {
+      if (!n || n.level === 'warn' || n.retryable || timers.has(n.id)) return;
+      timers.set(n.id, setTimeout(() => {
+        timers.delete(n.id);
+        actions.dismissNotification(n.id);
+      }, 7000));
+    });
+    return undefined;
+  }, [notifications, actions]);
+  useEffect(() => () => {
+    autoDismissTimersRef.current.forEach((t) => clearTimeout(t));
+    autoDismissTimersRef.current.clear();
+  }, []);
+
   // ── Keyboard shortcuts (desktop) ──────────────────────────────────────────
   // Space / Enter  → Advance week (when not busy and no modal open)
   // S              → Manual save
@@ -604,6 +626,9 @@ function AppContent() {
         ...actions,
         startNewLeague: () => actions.newLeague(DEFAULT_TEAMS, { userTeamId: 0, name: 'Test League' }),
         advanceWeek: handleAdvanceWeek,
+        // Route straight into the Game Book screen — used by E2E to exercise
+        // both the canonical open path and the missing-game recovery path.
+        openBoxScore: (gameId) => setExternalBoxScoreId(gameId),
       };
       window.handleGlobalAdvance = handleAdvanceWeek;
     }
@@ -1347,37 +1372,59 @@ function AppContent() {
       {/* ── Notifications ──────────────────────────────────────────────── */}
       {/* Only notifications with real, visible content render a dismissible
           pill — empty entries would otherwise show as a blank gray block with
-          just an "×" in the post-sim / weekly-results area. */}
-      {getDisplayableNotifications(notifications).length > 0 && (
-        <div className="app-notifications">
-          {getDisplayableNotifications(notifications).map(n => (
-            <div
-              key={n.id}
-              className={`app-notification ${n.level === 'warn' ? 'app-notification-warn' : 'app-notification-info'}`}
-            >
-              <span>{n.message}</span>
-              {n.retryable && (
+          just an "×" in the post-sim / weekly-results area.
+          Mobile trust pass: at most 3 rows render (newest last) so routine
+          post-sim notices ("Weekly simulation ran…", "development updated…")
+          can't bury the weekly results; older ones collapse into one compact
+          summary row with a Dismiss-all action. Warnings and retryable rows
+          stay until acted on; info rows auto-dismiss (see effect above). */}
+      {(() => {
+        if (getDisplayableNotifications(notifications).length === 0) return null;
+        const { visible, collapsed } = capVisibleNotifications(notifications, 3);
+        return (
+          <div className="app-notifications" data-testid="app-notifications">
+            {collapsed.length > 0 && (
+              <div className="app-notification app-notification-info app-notification-compact" data-testid="app-notification-overflow">
+                <span>{collapsed.length} earlier notice{collapsed.length === 1 ? '' : 's'}</span>
                 <button
-                  onClick={() => {
-                    actions.dismissNotification(n.id);
-                    handleAdvanceWeek();
-                  }}
-                  className="app-notification-retry"
-                  disabled={busy || simulating}
+                  onClick={() => collapsed.forEach((n) => actions.dismissNotification(n.id))}
+                  className="app-notification-dismiss"
+                  aria-label="Dismiss earlier notices"
                 >
-                  Retry
+                  ×
                 </button>
-              )}
-              <button
-                onClick={() => actions.dismissNotification(n.id)}
-                className="app-notification-dismiss"
+              </div>
+            )}
+            {visible.map(n => (
+              <div
+                key={n.id}
+                className={`app-notification app-notification-compact ${n.level === 'warn' ? 'app-notification-warn' : 'app-notification-info'}`}
               >
-                ×
-              </button>
-            </div>
-          ))}
-        </div>
-      )}
+                <span>{n.message}</span>
+                {n.retryable && (
+                  <button
+                    onClick={() => {
+                      actions.dismissNotification(n.id);
+                      handleAdvanceWeek();
+                    }}
+                    className="app-notification-retry"
+                    disabled={busy || simulating}
+                  >
+                    Retry
+                  </button>
+                )}
+                <button
+                  onClick={() => actions.dismissNotification(n.id)}
+                  className="app-notification-dismiss"
+                  aria-label="Dismiss notice"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+        );
+      })()}
 
       {/* ── Live game viewer (visible during simulation + results) ────── */}
       {/* Hide when user game prompt is active to avoid stale empty state behind modal */}
@@ -1654,6 +1701,16 @@ function AppContent() {
         const awayId = userEvent?.awayId ?? (userMatchup ? Number(userMatchup.away) : league?.teams?.find(t => t.id !== league?.userTeamId)?.id);
         const homeTeam = league?.teams?.find(t => t.id === homeId) || { abbr: userEvent?.homeAbbr || 'HOME', id: homeId };
         const awayTeam = league?.teams?.find(t => t.id === awayId) || { abbr: userEvent?.awayAbbr || 'AWAY', id: awayId };
+        // Canonical final: the worker posts GAME_EVENT (the league-recorded
+        // score) before PLAY_LOGS, so the real result is known for the whole
+        // watch session. The narrated play stream runs on a different engine
+        // whose running score can contradict it — never treat viewer-reported
+        // scores as the result when the canonical final exists.
+        const canonicalFinal = userEvent
+          && Number.isFinite(Number(userEvent.homeScore))
+          && Number.isFinite(Number(userEvent.awayScore))
+          ? { home: Number(userEvent.homeScore), away: Number(userEvent.awayScore) }
+          : null;
         return (
           <GameSimErrorBoundary onFallback={() => {
             // If GameSimulation crashes, recover directly to advancing the week
@@ -1666,6 +1723,7 @@ function AppContent() {
               awayTeam={awayTeam}
               initialMode={watchMode}
               userTendency={userTendency}
+              finalScore={canonicalFinal}
               gameSummary={{
                 gameReasoningFlags: userGameReasoningFlags || [],
                 homeId: homeTeam?.id,
@@ -1681,8 +1739,8 @@ function AppContent() {
                   setPostGameResult({
                     homeTeam,
                     awayTeam,
-                    homeScore: scores?.homeScore ?? 0,
-                    awayScore: scores?.awayScore ?? 0,
+                    homeScore: canonicalFinal?.home ?? scores?.homeScore ?? 0,
+                    awayScore: canonicalFinal?.away ?? scores?.awayScore ?? 0,
                     userTeamId: league?.userTeamId,
                     week: league?.week,
                     phase: league?.phase,
@@ -1748,7 +1806,10 @@ function AppContent() {
           }}
           onArchiveReady={(archivePayload) => {
             if (!archivePayload?.gameId) return;
-            saveGame(archivePayload.gameId, archivePayload);
+            saveGame(archivePayload.gameId, {
+              ...archivePayload,
+              season: archivePayload.season ?? postGameResult.seasonId ?? league?.seasonId ?? null,
+            });
           }}
         />
       )}

--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import BoxScorePanel from './BoxScorePanel.jsx';
 import { EmptyState, ScreenHeader, SectionCard } from './ScreenSystem.jsx';
 import { buildWeeklyDecisionImpact } from '../utils/weeklyDecisionImpact.js';
@@ -77,7 +77,7 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
 
   const scheduleGame = findScheduleGame(league, gameId);
   const canLoadArchive = Boolean(gameId && typeof actions?.getBoxScore === 'function');
-  const { data: archiveResponse } = useStableRouteRequest({
+  const { data: archiveResponse, loading: archiveLoading } = useStableRouteRequest({
     requestKey: canLoadArchive ? `boxscore:${gameId}` : null,
     enabled: canLoadArchive,
     cacheScopeKey: league?.id ?? league?.leagueId ?? 'global',
@@ -103,6 +103,15 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
     ? `${detailVm.finalScoreLine} · Game Book sections show only data recorded for this final.`
     : 'Scan the final, review the recap narrative, compare team stats, then drill into player leaders and play detail.';
 
+  // Recovery guard: onBack navigates exactly once even if the recovery action
+  // is tapped repeatedly while the route transition is in flight.
+  const backFiredRef = useRef(false);
+  const handleBackOnce = () => {
+    if (backFiredRef.current) return;
+    backFiredRef.current = true;
+    onBack?.();
+  };
+
   if (!gameId) {
     return (
       <div className="app-screen-stack" data-testid="game-book">
@@ -118,6 +127,56 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
           title="No completed game selected yet."
           body="Open a final score from Schedule, Weekly Results, or recent surfaces to load the full Game Book."
         />
+      </div>
+    );
+  }
+
+  // No canonical record anywhere (archive, schedule, league index): keep the
+  // user anchored on an honest recovery surface with one clear exit instead
+  // of rendering placeholder teams and a fake 0-0 final.
+  if (!canonicalGame && !archiveLoading) {
+    return (
+      <div className="app-screen-stack" data-testid="game-book">
+        <div
+          role="alert"
+          data-testid="game-book-recovery"
+          style={{
+            display: 'flex', flexDirection: 'column', alignItems: 'center',
+            gap: 12, padding: '40px 20px', textAlign: 'center',
+          }}
+        >
+          <div style={{ fontSize: '1.6rem' }} aria-hidden="true">📖</div>
+          <div style={{ fontSize: '1.05rem', fontWeight: 800, color: 'var(--text)' }}>
+            Game Book unavailable
+          </div>
+          <div style={{ fontSize: '0.85rem', color: 'var(--text-muted)', maxWidth: 340, lineHeight: 1.5 }}>
+            The detailed recap for this game could not be loaded. Your league
+            results are unaffected.
+          </div>
+          <button
+            type="button"
+            className="btn btn-primary"
+            data-testid="game-book-recovery-return"
+            onClick={handleBackOnce}
+            style={{ minHeight: 44, padding: '10px 26px' }}
+          >
+            {backLabel ?? 'Return to HQ'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!canonicalGame && archiveLoading) {
+    return (
+      <div className="app-screen-stack" data-testid="game-book">
+        <div
+          role="status"
+          data-testid="game-book-loading"
+          style={{ padding: '40px 20px', textAlign: 'center', color: 'var(--text-muted)', fontSize: '0.85rem' }}
+        >
+          Loading Game Book…
+        </div>
       </div>
     );
   }

--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -131,10 +131,21 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
     );
   }
 
-  // No canonical record anywhere (archive, schedule, league index): keep the
-  // user anchored on an honest recovery surface with one clear exit instead
-  // of rendering placeholder teams and a fake 0-0 final.
-  if (!canonicalGame && !archiveLoading) {
+  // A "usable" record must carry a real final: resolveCanonicalCompletedGame
+  // returns the best available reference even when no valid final exists
+  // (e.g. an unplayed schedule row whose serialized scores default to 0-0),
+  // so gate on played/score validity — never on object existence alone.
+  const canonicalHasFinal = Boolean(
+    canonicalGame
+    && !(canonicalGame.played === false || canonicalGame.played === 0)
+    && Number.isFinite(Number(canonicalGame.homeScore ?? canonicalGame.scoreHome))
+    && Number.isFinite(Number(canonicalGame.awayScore ?? canonicalGame.scoreAway)),
+  );
+
+  // No canonical completed record anywhere (archive, schedule, league index):
+  // keep the user anchored on an honest recovery surface with one clear exit
+  // instead of rendering placeholder teams and a fake 0-0 final.
+  if (!canonicalHasFinal && !archiveLoading) {
     return (
       <div className="app-screen-stack" data-testid="game-book">
         <div
@@ -167,7 +178,7 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
     );
   }
 
-  if (!canonicalGame && archiveLoading) {
+  if (!canonicalHasFinal && archiveLoading) {
     return (
       <div className="app-screen-stack" data-testid="game-book">
         <div

--- a/src/ui/components/GameDetailScreen.test.jsx
+++ b/src/ui/components/GameDetailScreen.test.jsx
@@ -103,6 +103,39 @@ describe('GameDetailScreen canonical title and prep context', () => {
     expect(html).toContain('Game plan was saved before kickoff');
   });
 
+  it('shows the recovery surface for an unplayed schedule row instead of a fake 0-0 tie', () => {
+    // The requested id matches a serialized upcoming game: played=false with
+    // Int32Array-default 0-0 scores. This must never render as a final.
+    const html = renderToString(
+      <GameDetailScreen
+        gameId="2031_w5_1_2"
+        league={{
+          seasonId: '2031',
+          teams: league.teams,
+          schedule: {
+            weeks: [{
+              week: 5,
+              games: [{
+                gameId: '2031_w5_1_2',
+                id: '2031_w5_1_2',
+                homeId: 1,
+                awayId: 2,
+                homeScore: 0,
+                awayScore: 0,
+                played: false,
+              }],
+            }],
+          },
+        }}
+        actions={{ getBoxScore: async () => ({ game: null }) }}
+      />,
+    );
+
+    expect(html).toContain('Game Book unavailable');
+    expect(html).not.toContain('finished tied');
+    expect(html).not.toContain('0 - 0');
+  });
+
   it('renders an explicit empty state when no game is selected', () => {
     const html = renderToString(
       <GameDetailScreen

--- a/src/ui/components/GameDetailScreen.test.jsx
+++ b/src/ui/components/GameDetailScreen.test.jsx
@@ -60,7 +60,7 @@ describe('GameDetailScreen canonical title and prep context', () => {
     vi.mocked(useStableRouteRequest).mockReturnValue({ data: null, loading: false, error: null });
   });
 
-  it('uses a single Game Book destination title', () => {
+  it('shows an anchored recovery surface (not a placeholder final) when no game data resolves', () => {
     const html = renderToString(
       <GameDetailScreen
         gameId="2031_w1_1_2"
@@ -69,8 +69,11 @@ describe('GameDetailScreen canonical title and prep context', () => {
       />,
     );
 
-    expect(html).toContain('Game Book');
-    expect(html).toContain('Week');
+    expect(html).toContain('Game Book unavailable');
+    expect(html).toContain('game-book-recovery-return');
+    // Never renders a fabricated 0-0 / placeholder final for a missing game.
+    expect(html).not.toContain('finished tied');
+    expect(html).not.toContain('AWAY 0');
     expect(html).not.toContain('Completed Game Detail');
   });
 

--- a/src/ui/components/GameEventFeed/GameEventFeed.jsx
+++ b/src/ui/components/GameEventFeed/GameEventFeed.jsx
@@ -11,16 +11,27 @@ const TAG_CLASS = {
   CLUTCH:     'feed-tag-clutch',
 };
 
+function finiteScore(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
 export default function GameEventFeed({ events = [], activeIndex = 0 }) {
   const visible = events.slice(Math.max(0, activeIndex - 20), activeIndex + 1);
   let previousQuarter = null;
   let previousPossession = null;
   return (
-    <div className="live-feed">
+    <div className="live-feed" role="log" aria-label="Play-by-play, newest play last">
       {visible.map((event, idx) => {
         const tags = getEventTags(event);
         const isLatest = idx === visible.length - 1;
-        const scoreText = event.score ? `${event.score.away}–${event.score.home}` : '';
+        // Score chips only render when the event carries a trustworthy score
+        // (today: the game_end marker stamped with the canonical final).
+        // Per-play narration scores are untrusted and arrive as null — see
+        // buildLiveGameEvent for the authority note.
+        const scoreHome = finiteScore(event.score?.home);
+        const scoreAway = finiteScore(event.score?.away);
+        const scoreText = scoreHome != null && scoreAway != null ? `${scoreAway}–${scoreHome}` : '';
         const isMajor = ['touchdown', 'field_goal', 'turnover', 'sack', 'explosive_play', 'game_end', 'turning_point'].includes(event.eventType);
         const showQuarterMarker = previousQuarter !== null && previousQuarter !== event.quarter;
         const showPossessionDivider = !showQuarterMarker
@@ -40,12 +51,18 @@ export default function GameEventFeed({ events = [], activeIndex = 0 }) {
               <div className="feed-possession-divider" aria-hidden="true" />
             ) : null}
             <article className={`feed-row${isLatest ? ' latest' : ''}${isMajor ? ' major' : ' routine'}`}>
-              <div className="feed-time">Q{event.quarter} <span className="feed-clock">{event.clock}</span></div>
+              {/* Quarter + event-sequence indicator. The narration engine only has
+                  drive-level clock estimates (every play in a drive shares one
+                  randomized stamp), so no per-play clock is displayed. */}
+              <div className="feed-time">
+                Q{event.quarter}
+                {event.sequence != null ? <span className="feed-clock">#{event.sequence}</span> : null}
+              </div>
               <div className="feed-body">
                 <div className="feed-headline">{event.headline}</div>
                 {(scoreText || tags.length > 0) ? (
                   <div className="feed-meta">
-                    {scoreText ? <span className="feed-score">{scoreText}</span> : null}
+                    {scoreText ? <span className="feed-score">FINAL {scoreText}</span> : null}
                     {tags.map((tag) => (
                       <span key={tag} className={`feed-tag ${TAG_CLASS[tag] || 'feed-tag-default'}`}>{tag}</span>
                     ))}

--- a/src/ui/components/LiveGameViewer.jsx
+++ b/src/ui/components/LiveGameViewer.jsx
@@ -17,17 +17,31 @@ const TENDENCY_CONFIG = {
   CONSERVATIVE: { label: 'Conservative', chipClass: 'conservative' },
 };
 
-export default function LiveGameViewer({ logs = [], homeTeam, awayTeam, onComplete, initialMode = 'watch', onPlaycallOverride, userTendency = 'BALANCED' }) {
+function finiteScore(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+export default function LiveGameViewer({ logs = [], homeTeam, awayTeam, onComplete, initialMode = 'watch', onPlaycallOverride, userTendency = 'BALANCED', finalScore = null }) {
+  // Canonical final: the league-recorded result (GAME_EVENT payload). The
+  // narrated play stream is a separate engine whose running score can
+  // contradict it, so this is the only score the viewer will ever display.
+  const canonicalFinal = useMemo(() => {
+    const home = finiteScore(finalScore?.home ?? finalScore?.homeScore);
+    const away = finiteScore(finalScore?.away ?? finalScore?.awayScore);
+    return home != null && away != null ? { home, away } : null;
+  }, [finalScore]);
+
   const events = useMemo(() => mapArchiveEventsToLiveFeed(logs, {
     gameId: `${homeTeam?.id || 'h'}-${awayTeam?.id || 'a'}`,
     homeTeamId: homeTeam?.id,
     awayTeamId: awayTeam?.id,
-  }), [logs, homeTeam?.id, awayTeam?.id]);
+    finalScore: canonicalFinal,
+  }), [logs, homeTeam?.id, awayTeam?.id, canonicalFinal]);
 
   const [index, setIndex] = useState(0);
   const [paused, setPaused] = useState(initialMode === 'pause');
   const [speed, setSpeed] = useState(initialMode === 'fast' ? 'fast' : 'normal');
-  const [lastLeadTeamId, setLastLeadTeamId] = useState(null);
   const [momentBanner, setMomentBanner] = useState(null);
 
   useEffect(() => {
@@ -51,28 +65,31 @@ export default function LiveGameViewer({ logs = [], homeTeam, awayTeam, onComple
   const standout = useMemo(() => getCurrentStandoutPlayers(events, index + 1), [events, index]);
   const swing = useMemo(() => summarizeGameSwing(events, index + 1), [events, index]);
 
+  const finished = index >= events.length - 1;
+  // Scores shown only once the canonical final is in play — never the narrated
+  // per-play snapshots, which belong to a different scoring engine.
+  const displayScore = finished && canonicalFinal ? canonicalFinal : null;
+
   const scoreState = {
-    score: currentEvent.score || { home: 0, away: 0 },
+    score: displayScore,
     quarter: currentEvent.quarter || 1,
-    clock: currentEvent.clock || '15:00',
+    // No trustworthy per-play clock exists (drive-granular estimates only) —
+    // the scorebug shows quarter + event progress instead of a fake clock.
+    clock: null,
+    progressLabel: finished ? 'Final' : `Play ${Math.min(index + 1, events.length)} of ${events.length}`,
     downDistance: currentEvent.down ? `${currentEvent.down}${ordinal(currentEvent.down)} & ${currentEvent.distance || 10}` : 'Drive update',
     ballSpot: currentEvent.fieldPosition != null ? `Ball on ${Math.round(Number(currentEvent.fieldPosition) || 50)}` : 'Ball spot --',
     fieldPosition: currentEvent.fieldPosition,
     possessionTeamId: currentEvent.possessionTeamId,
+    isFinal: finished,
   };
-  const leadTeamId = scoreState.score.home === scoreState.score.away
-    ? null
-    : scoreState.score.home > scoreState.score.away ? homeTeam?.id : awayTeam?.id;
-  const isFinalMinutes = Number(scoreState.quarter) >= 4 && /^([0-4]):/.test(String(scoreState.clock || ''));
+  const isLateGame = Number(scoreState.quarter) >= 4 && index >= Math.floor((events.length - 1) * 0.85);
 
-  const finished = index >= events.length - 1;
   const modeLabel = paused ? 'Paused' : `Watch · ${SPEED_STEPS.find((step) => step.key === speed)?.label ?? 'Normal'}`;
 
   useEffect(() => {
     if (!currentEvent?.eventType) return;
-    if (leadTeamId != null && lastLeadTeamId != null && leadTeamId !== lastLeadTeamId) {
-      setMomentBanner({ type: 'lead', text: `Lead Change · ${leadTeamId === homeTeam?.id ? homeTeam?.abbr : awayTeam?.abbr} in front` });
-    } else if (currentEvent.eventType === 'touchdown') {
+    if (currentEvent.eventType === 'touchdown') {
       setMomentBanner({ type: 'score', text: 'Touchdown' });
     } else if (currentEvent.eventType === 'field_goal') {
       setMomentBanner({ type: 'score', text: 'Field Goal' });
@@ -83,8 +100,10 @@ export default function LiveGameViewer({ logs = [], homeTeam, awayTeam, onComple
     } else {
       setMomentBanner(null);
     }
-    setLastLeadTeamId(leadTeamId);
-  }, [currentEvent?.eventType, leadTeamId, lastLeadTeamId, homeTeam?.abbr, homeTeam?.id, awayTeam?.abbr, awayTeam?.id]);
+  }, [currentEvent?.eventType]);
+
+  const finalHomeScore = displayScore?.home ?? null;
+  const finalAwayScore = displayScore?.away ?? null;
 
   return (
     <div className="watch-overlay">
@@ -93,20 +112,20 @@ export default function LiveGameViewer({ logs = [], homeTeam, awayTeam, onComple
         <Scorebug homeTeam={homeTeam} awayTeam={awayTeam} state={scoreState} />
         <div className="watch-state-strip">
           <span className="watch-mode-chip">{modeLabel}</span>
-          {isFinalMinutes ? <span className="watch-mode-chip clutch">Final Minutes</span> : null}
+          {isLateGame && !finished ? <span className="watch-mode-chip clutch">Late Game</span> : null}
           {finished ? <span className="watch-mode-chip final">Complete</span> : null}
           {(() => {
             const tc = TENDENCY_CONFIG[userTendency] || TENDENCY_CONFIG.BALANCED;
             return <span className={`watch-mode-chip tendency-${tc.chipClass}`}>{tc.label}</span>;
           })()}
         </div>
-        {momentBanner ? <div className={`watch-moment-banner ${momentBanner.type}`}>{momentBanner.text}</div> : null}
+        {momentBanner ? <div className={`watch-moment-banner ${momentBanner.type}`} role="status">{momentBanner.text}</div> : null}
       </header>
 
       <main className="watch-main">
         <section className="watch-panel">
           <div className={`momentum ${swing.tone}`}>Momentum: {swing.label}</div>
-          <div className="jump-row">
+          <div className="jump-row" role="group" aria-label="Jump to game moments">
             <JumpBtn label="Scores" onClick={() => setIndex(getNextImportantEvent(events, index, 'score'))} />
             <JumpBtn label="Red Zone" onClick={() => setIndex(getNextImportantEvent(events, index, 'redZone'))} />
             <JumpBtn label="Turnovers" onClick={() => setIndex(getNextImportantEvent(events, index, 'turnover'))} />
@@ -117,54 +136,79 @@ export default function LiveGameViewer({ logs = [], homeTeam, awayTeam, onComple
         </section>
 
         <aside className="watch-side">
-          <h3 className="watch-side-title">Standouts</h3>
-          <ul className="standout-list">
-            <li><span className="standout-pos">QB</span>{formatQb(standout.qb)}</li>
-            <li><span className="standout-pos">Rush</span>{formatRush(standout.rusher)}</li>
-            <li><span className="standout-pos">Rec</span>{formatRec(standout.receiver)}</li>
-            <li><span className="standout-pos">Sacks</span>{standout.sacks ? `${standout.sacks.player} (${standout.sacks.sacks})` : '—'}</li>
-            <li><span className="standout-pos">INT</span>{standout.picks ? `${standout.picks.player} (${standout.picks.picks})` : '—'}</li>
-          </ul>
-
-          <div className="controls">
-            <div className="controls-label">Speed</div>
-            <div className="speed-row">
-              <button className="ctrl-btn pause-btn" onClick={() => setPaused((prev) => !prev)}>{paused ? '▶' : '⏸'}</button>
-              {SPEED_STEPS.map((step) => (
-                <button key={step.key} className={`ctrl-btn${speed === step.key && !paused ? ' active' : ''}`}
-                  onClick={() => { setSpeed(step.key); setPaused(false); }}>{step.label}</button>
-              ))}
-            </div>
-            <div className="controls-label">Skip</div>
-            <div className="skip-row">
-              <button className="ctrl-btn" onClick={() => setIndex(getNextImportantEvent(events, index, 'score'))}>Next Score</button>
-              <button className="ctrl-btn" onClick={() => setIndex(getNextImportantEvent(events, index, 'keyPlay'))}>Key Play</button>
-              <button className="ctrl-btn" onClick={() => setIndex(events.length - 1)}>Sim End</button>
-            </div>
-            {onPlaycallOverride ? (
-              <>
-                <div className="controls-label">Playcall</div>
-                <div className="playcall-row">
-                  <button className="ctrl-btn" title="Lean run on next drive." onClick={() => onPlaycallOverride?.({ type: 'run_heavy' })}>Run Heavy</button>
-                  <button className="ctrl-btn" title="Lean pass on next drive." onClick={() => onPlaycallOverride?.({ type: 'pass_heavy' })}>Pass Heavy</button>
-                  <button className="ctrl-btn" title="Request a timeout." onClick={() => onPlaycallOverride?.({ type: 'timeout' })}>Timeout</button>
-                </div>
-              </>
-            ) : null}
-          </div>
+          <details className="standout-panel" open>
+            <summary className="watch-side-title">Standouts</summary>
+            <ul className="standout-list">
+              <li><span className="standout-pos">QB</span>{formatQb(standout.qb)}</li>
+              <li><span className="standout-pos">Rush</span>{formatRush(standout.rusher)}</li>
+              <li><span className="standout-pos">Rec</span>{formatRec(standout.receiver)}</li>
+              <li><span className="standout-pos">Sacks</span>{standout.sacks ? `${standout.sacks.player} (${standout.sacks.sacks})` : '—'}</li>
+              <li><span className="standout-pos">INT</span>{standout.picks ? `${standout.picks.player} (${standout.picks.picks})` : '—'}</li>
+            </ul>
+          </details>
 
           {finished ? (
             <div className="watch-final-card">
               <div className="watch-final-label">Final</div>
-              <div className="watch-final-score">
-                <span>{awayTeam?.abbr || 'AWY'} {scoreState.score.away}</span>
-                <span>{homeTeam?.abbr || 'HME'} {scoreState.score.home}</span>
-              </div>
-              <button className="finish" onClick={() => onComplete?.({ homeScore: scoreState.score.home, awayScore: scoreState.score.away })}>Open Final Game Book</button>
+              {displayScore ? (
+                <div className="watch-final-score">
+                  <span>{awayTeam?.abbr || 'AWY'} {finalAwayScore}</span>
+                  <span>{homeTeam?.abbr || 'HME'} {finalHomeScore}</span>
+                </div>
+              ) : (
+                <div className="watch-final-pending" data-testid="watch-final-pending">
+                  Final score is being recorded — open the Game Book for the official result.
+                </div>
+              )}
+              <button
+                className="finish"
+                onClick={() => onComplete?.(displayScore ? { homeScore: displayScore.home, awayScore: displayScore.away } : {})}
+              >
+                Open Final Game Book
+              </button>
             </div>
           ) : null}
         </aside>
       </main>
+
+      {/* Compact sticky control tray — one row of playback controls above the
+          safe area so the feed owns the screen on mobile. */}
+      <footer className="watch-controls-tray" aria-label="Playback controls">
+        <button
+          className="ctrl-btn pause-btn"
+          onClick={() => setPaused((prev) => !prev)}
+          aria-label={paused ? 'Resume playback' : 'Pause playback'}
+        >
+          {paused ? '▶' : '⏸'}
+        </button>
+        <div className="speed-row" role="group" aria-label="Playback speed">
+          {SPEED_STEPS.map((step) => (
+            <button
+              key={step.key}
+              className={`ctrl-btn${speed === step.key && !paused ? ' active' : ''}`}
+              onClick={() => { setSpeed(step.key); setPaused(false); }}
+              aria-pressed={speed === step.key && !paused}
+            >
+              {step.label}
+            </button>
+          ))}
+        </div>
+        <details className="skip-menu">
+          <summary className="ctrl-btn skip-trigger" aria-label="Skip options">Skip ▾</summary>
+          <div className="skip-menu-list">
+            <button className="ctrl-btn" onClick={() => setIndex(getNextImportantEvent(events, index, 'score'))}>Next Score</button>
+            <button className="ctrl-btn" onClick={() => setIndex(getNextImportantEvent(events, index, 'keyPlay'))}>Key Play</button>
+            <button className="ctrl-btn" onClick={() => setIndex(events.length - 1)}>Sim End</button>
+            {onPlaycallOverride ? (
+              <>
+                <button className="ctrl-btn" title="Lean run on next drive." onClick={() => onPlaycallOverride?.({ type: 'run_heavy' })}>Run Heavy</button>
+                <button className="ctrl-btn" title="Lean pass on next drive." onClick={() => onPlaycallOverride?.({ type: 'pass_heavy' })}>Pass Heavy</button>
+                <button className="ctrl-btn" title="Request a timeout." onClick={() => onPlaycallOverride?.({ type: 'timeout' })}>Timeout</button>
+              </>
+            ) : null}
+          </div>
+        </details>
+      </footer>
     </div>
   );
 }
@@ -187,11 +231,16 @@ function formatRec(v) { return v ? `${v.player} ${v.rec} rec ${v.yds}y` : '—';
 const styles = `
 /* ── Layout ─────────────────────────────────────────────────────────── */
 .watch-overlay { position:fixed; inset:0; background:#071021; color:#f3f6ff; z-index:7000; display:flex; flex-direction:column; overflow:hidden; }
-.watch-header { position:sticky; top:0; z-index:2; padding:8px 10px; background:#071021; border-bottom:1px solid #253149; }
-.watch-state-strip { display:flex; align-items:center; gap:5px; margin-top:6px; flex-wrap:wrap; }
+.watch-header { position:sticky; top:0; z-index:2; padding:calc(6px + env(safe-area-inset-top, 0px)) 10px 6px; background:#071021; border-bottom:1px solid #253149; }
+.watch-state-strip { display:flex; align-items:center; gap:5px; margin-top:5px; flex-wrap:wrap; }
 .watch-main { display:grid; grid-template-columns:minmax(0,1fr); gap:8px; padding:8px; flex:1; overflow:hidden; min-height:0; }
 @media (min-width:960px) { .watch-main { grid-template-columns:2fr 1fr; } }
 .watch-panel, .watch-side { background:#0f172b; border:1px solid #2d3a55; border-radius:12px; padding:10px; overflow:auto; }
+@media (max-width:959px) {
+  /* Feed first; side rail collapses to a compact strip below it. */
+  .watch-main { grid-template-rows:minmax(0,1fr) auto; }
+  .watch-side { max-height:32vh; }
+}
 
 /* ── Mode chips ──────────────────────────────────────────────────────── */
 .watch-mode-chip { font-size:11px; border-radius:999px; padding:3px 8px; border:1px solid #3d4d6d; background:#12213b; color:#d9e7ff; }
@@ -212,12 +261,14 @@ const styles = `
 .live-scorebug { display:grid; grid-template-columns:1fr auto 1fr; gap:8px; align-items:center; }
 .sb-team { display:flex; justify-content:space-between; align-items:center; background:#111c33; border:1px solid #30405f; padding:7px 10px; border-radius:9px; }
 .sb-team.has-ball { border-color:#fbbf24; box-shadow:inset 0 0 0 1px #fbbf24; }
+.sb-score-pending { color:#7d92ba; font-weight:600; letter-spacing:.08em; }
 .sb-center { text-align:center; font-size:12px; color:#d0dbf5; }
 .sb-flags { display:flex; justify-content:center; gap:4px; margin-top:4px; flex-wrap:wrap; }
 .sb-flag { font-size:9px; font-weight:800; letter-spacing:.05em; border-radius:999px; padding:2px 6px; background:#1c2f4d; border:1px solid #3d5b88; }
 .sb-flag.redzone { border-color:#8a3e3e; background:#3c1d28; color:#ffb9b9; }
 .sb-flag.clutch { border-color:#8f6f2b; background:#3a2f18; color:#ffe4a3; }
 .sb-flag.overtime { border-color:#5377b0; background:#1c335d; color:#c6ddff; }
+.sb-flag.final { border-color:#56b58a; background:#12321f; color:#91f0c3; }
 
 /* ── Momentum / jump row ─────────────────────────────────────────────── */
 .momentum { font-size:11px; margin-bottom:7px; padding:5px 8px; border-radius:7px; font-weight:700; }
@@ -226,7 +277,7 @@ const styles = `
 .momentum.swing { background:#3b2f18; }
 .momentum.neutral { background:#253149; }
 .jump-row { display:flex; gap:5px; overflow-x:auto; padding-bottom:5px; -webkit-overflow-scrolling:touch; }
-.jump-btn { white-space:nowrap; background:#182741; color:#d8e6ff; border:1px solid #37527d; border-radius:999px; padding:5px 10px; font-size:11px; cursor:pointer; flex-shrink:0; }
+.jump-btn { white-space:nowrap; background:#182741; color:#d8e6ff; border:1px solid #37527d; border-radius:999px; padding:6px 12px; font-size:11px; cursor:pointer; flex-shrink:0; min-height:32px; }
 
 /* ── Live feed ───────────────────────────────────────────────────────── */
 .live-feed { display:grid; gap:5px; }
@@ -252,23 +303,44 @@ const styles = `
 .feed-tag-default { background:#1b2f4f; color:#a0aec0; border:1px solid #415d89; }
 
 /* ── Standouts ───────────────────────────────────────────────────────── */
+.standout-panel > summary { cursor:pointer; list-style:none; }
+.standout-panel > summary::-webkit-details-marker { display:none; }
+.standout-panel > summary::after { content:'▾'; margin-left:6px; color:#6a87b8; }
+.standout-panel:not([open]) > summary::after { content:'▸'; }
 .watch-side-title { margin:0 0 8px; font-size:13px; font-weight:700; color:#c8d8f5; }
 .standout-list { margin:0; padding:0; list-style:none; display:grid; gap:4px; }
 .standout-list li { display:flex; align-items:baseline; gap:6px; font-size:12px; line-height:1.4; }
 .standout-pos { font-size:9px; font-weight:800; text-transform:uppercase; letter-spacing:.06em; color:#6a87b8; min-width:32px; flex-shrink:0; }
+@media (max-width:959px) {
+  .standout-list { grid-template-columns:1fr 1fr; }
+}
 
-/* ── Controls ────────────────────────────────────────────────────────── */
-.controls { margin-top:10px; display:grid; gap:4px; }
-.controls-label { font-size:9px; font-weight:700; text-transform:uppercase; letter-spacing:.07em; color:#4d6a96; margin-top:4px; }
-.speed-row, .skip-row, .playcall-row { display:flex; gap:4px; flex-wrap:wrap; }
-.ctrl-btn { background:#1c2e4d; color:#c8d8f5; border:1px solid #456596; border-radius:7px; padding:5px 9px; font-size:11px; cursor:pointer; white-space:nowrap; }
+/* ── Compact sticky control tray ─────────────────────────────────────── */
+.watch-controls-tray {
+  display:flex; align-items:center; gap:6px;
+  padding:6px 10px calc(6px + env(safe-area-inset-bottom, 0px));
+  background:#0c1730; border-top:1px solid #2d3a55;
+  flex-shrink:0;
+}
+.speed-row { display:flex; gap:4px; flex-wrap:nowrap; overflow-x:auto; -webkit-overflow-scrolling:touch; flex:1; min-width:0; }
+.ctrl-btn { background:#1c2e4d; color:#c8d8f5; border:1px solid #456596; border-radius:8px; padding:8px 10px; font-size:11px; cursor:pointer; white-space:nowrap; min-height:44px; min-width:44px; }
 .ctrl-btn.active { border-color:#7cc4ff; color:#b8e0ff; background:#182948; }
 .ctrl-btn:hover { background:#233660; }
-.pause-btn { font-size:13px; padding:5px 8px; }
+.pause-btn { font-size:14px; padding:8px 12px; flex-shrink:0; }
+.skip-menu { position:relative; flex-shrink:0; }
+.skip-menu > summary { list-style:none; display:inline-flex; align-items:center; }
+.skip-menu > summary::-webkit-details-marker { display:none; }
+.skip-menu[open] .skip-menu-list {
+  position:absolute; right:0; bottom:calc(100% + 6px);
+  display:flex; flex-direction:column; gap:4px;
+  background:#0f1c38; border:1px solid #334870; border-radius:10px;
+  padding:6px; min-width:132px; box-shadow:0 -8px 24px rgba(0,0,0,.45); z-index:3;
+}
 
 /* ── Final card ──────────────────────────────────────────────────────── */
 .watch-final-card { border:1px solid #3d5378; border-radius:10px; margin-top:12px; padding:10px; background:#13203a; }
 .watch-final-label { text-transform:uppercase; font-size:10px; letter-spacing:.08em; color:#98b4dd; margin-bottom:4px; }
 .watch-final-score { display:flex; flex-direction:column; gap:4px; font-size:15px; font-weight:800; color:#ecf4ff; }
-.finish { margin-top:10px; width:100%; background:#1d4ed8; color:#fff; font-weight:800; border:none; border-radius:8px; padding:9px; cursor:pointer; font-size:13px; }
+.watch-final-pending { font-size:12px; color:#b9c9e6; line-height:1.4; }
+.finish { margin-top:10px; width:100%; background:#1d4ed8; color:#fff; font-weight:800; border:none; border-radius:8px; padding:11px; cursor:pointer; font-size:13px; min-height:44px; }
 `;

--- a/src/ui/components/MobileNav.jsx
+++ b/src/ui/components/MobileNav.jsx
@@ -57,7 +57,10 @@ const BOTTOM_TABS = [
 export default function MobileNav({ activeSection, activeTab, onSectionChange, onDestinationChange, league, collapsed = false }) {
   const [menuOpen, setMenuOpen] = useState(false);
 
-  useEffect(() => setMenuOpen(false), [activeSection]);
+  // Route-change cleanup: any navigation — section OR tab — closes the More
+  // drawer, so returning from game-day surfaces (postgame, Game Book) can
+  // never land on HQ with a stale drawer still open or mid-transition.
+  useEffect(() => setMenuOpen(false), [activeSection, activeTab]);
 
   // When the navigation chrome is collapsed (e.g. focused Game Book review),
   // close any open More drawer so it cannot linger over the review surface.

--- a/src/ui/components/PostGameScreen.jsx
+++ b/src/ui/components/PostGameScreen.jsx
@@ -18,33 +18,59 @@ import { buildReasoningBullets } from "../../core/gameSummary.js";
 import ReplayableGameFlowViewer from "./ReplayableGameFlowViewer.jsx";
 
 // ── Error boundary so a crash here never freezes the whole app ────────────────
-class PostGameErrorBoundary extends Component {
-  constructor(props) { super(props); this.state = { crashed: false }; }
+// Recovery contract: the fallback is a fully opaque, anchored surface (no
+// unrelated screen bleeding through behind it), the copy is honest (the game
+// result is already saved — only the recap view failed), and navigation is
+// user-controlled and fires exactly once. No automatic redirect races the
+// button.
+export class PostGameErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { crashed: false };
+    this.recoveredRef = { done: false };
+    this.handleRecover = this.handleRecover.bind(this);
+  }
   static getDerivedStateFromError() { return { crashed: true }; }
   componentDidCatch(err) { console.error('[PostGameScreen] render crash:', err); }
+  handleRecover() {
+    if (this.recoveredRef.done) return;
+    this.recoveredRef.done = true;
+    this.props.onContinue?.();
+  }
   render() {
     if (!this.state.crashed) return this.props.children;
     return (
-      <div style={{
-        position: "fixed", inset: 0, zIndex: 9700,
-        background: "rgba(0,0,0,0.92)", display: "flex",
-        alignItems: "center", justifyContent: "center", flexDirection: "column",
-        gap: 16, padding: 24,
-      }}>
-        <div style={{ fontSize: "1.1rem", fontWeight: 800, color: "#FF453A" }}>
-          Game recap failed
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="postgame-recovery-title"
+        aria-describedby="postgame-recovery-detail"
+        data-testid="postgame-recovery"
+        style={{
+          position: "fixed", inset: 0, zIndex: 9700,
+          background: "var(--bg, #0b0b12)", display: "flex",
+          alignItems: "center", justifyContent: "center", flexDirection: "column",
+          gap: 14, padding: 24, textAlign: "center",
+        }}
+      >
+        <div style={{ fontSize: "1.6rem" }} aria-hidden="true">🏈</div>
+        <div id="postgame-recovery-title" style={{ fontSize: "1.1rem", fontWeight: 800, color: "var(--text, #fff)" }}>
+          Game recap unavailable
         </div>
-        <div style={{ fontSize: "0.85rem", color: "var(--text-muted)", textAlign: "center" }}>
-          Returning you to the Weekly Hub…
+        <div id="postgame-recovery-detail" style={{ fontSize: "0.85rem", color: "var(--text-muted, #9aa2b1)", maxWidth: 320, lineHeight: 1.5 }}>
+          The final result was saved, but the recap view could not be shown.
+          You can pick the week back up from Franchise HQ.
         </div>
         <button
-          onClick={this.props.onContinue}
+          onClick={this.handleRecover}
+          data-testid="postgame-recovery-return"
           style={{
             padding: "12px 28px", background: "#0A84FF", color: "#fff",
             border: "none", borderRadius: 10, fontWeight: 800, cursor: "pointer",
+            minHeight: 44,
           }}
         >
-          Back to Hub →
+          Return to HQ
         </button>
       </div>
     );
@@ -395,39 +421,44 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
       }}>
         <div style={{ width: "100%", maxWidth: 420 }}>
 
-          {/* Result banner */}
-          <div style={{
-            textAlign: "center", marginBottom: 16,
-            animation: "fadeSlideIn 0.4s ease-out",
-          }}>
+          {/* Result banner — compact single-line header so postgame content
+              starts above the fold on a phone. Emotionally clear (emoji +
+              tone color + W/L label) without a half-screen of decoration. */}
+          <div
+            data-testid="postgame-result-banner"
+            style={{
+              textAlign: "center", marginBottom: 10,
+              animation: "fadeSlideIn 0.4s ease-out",
+            }}
+          >
             <style>{`
               @keyframes fadeSlideIn {
                 from { opacity: 0; transform: translateY(16px); }
                 to   { opacity: 1; transform: translateY(0); }
               }
             `}</style>
-            <div style={{ fontSize: "2.6rem", lineHeight: 1, marginBottom: 6 }}>{resultEmoji}</div>
-            <div style={{
-              fontSize: "1.7rem", fontWeight: 900, letterSpacing: "2px",
-              color: resultColor, marginBottom: 4,
-            }}>
-              {resultLabel}
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 8 }}>
+              <span style={{ fontSize: "1.5rem", lineHeight: 1 }} aria-hidden="true">{resultEmoji}</span>
+              <span style={{
+                fontSize: "1.35rem", fontWeight: 900, letterSpacing: "1.5px",
+                color: resultColor,
+              }}>
+                {resultLabel}
+              </span>
             </div>
-            {week && (
-              <div style={{ fontSize: "0.72rem", color: "var(--text-subtle)", fontWeight: 600 }}>
-                Week {week} · {phase === "playoffs" ? "Playoffs" : "Regular Season"}
-              </div>
-            )}
-            {/* Auto-save confirmation toast */}
             <div style={{
-              marginTop: 10,
-              height: 22,
-              display: "flex", alignItems: "center", justifyContent: "center",
+              marginTop: 4, display: "flex", alignItems: "center",
+              justifyContent: "center", gap: 8, minHeight: 18,
             }}>
+              {week && (
+                <span style={{ fontSize: "0.72rem", color: "var(--text-subtle)", fontWeight: 600 }}>
+                  Week {week} · {phase === "playoffs" ? "Playoffs" : "Regular Season"}
+                </span>
+              )}
               {showSaved && (
-                <div style={{
+                <span style={{
                   display: "inline-flex", alignItems: "center", gap: 5,
-                  padding: "3px 10px",
+                  padding: "2px 8px",
                   background: "#34C75918",
                   border: "1px solid #34C75940",
                   borderRadius: 20,
@@ -435,7 +466,7 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
                   animation: "fadeSlideIn 0.3s ease-out",
                 }}>
                   ✓ Game saved
-                </div>
+                </span>
               )}
             </div>
           </div>
@@ -445,8 +476,8 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
             background: "var(--surface)",
             border: "1.5px solid var(--hairline)",
             borderRadius: 16,
-            padding: "14px 18px",
-            marginBottom: 12,
+            padding: "10px 14px",
+            marginBottom: 10,
           }}>
             <div style={{
               display: "flex", alignItems: "center", justifyContent: "space-between",
@@ -454,18 +485,18 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
               {/* Away */}
               <div style={{ flex: 1, textAlign: "center" }}>
                 <div style={{
-                  width: 52, height: 52, borderRadius: "50%", margin: "0 auto 8px",
-                  background: `${aColor}20`, border: `2.5px solid ${aColor}`,
+                  width: 42, height: 42, borderRadius: "50%", margin: "0 auto 6px",
+                  background: `${aColor}20`, border: `2px solid ${aColor}`,
                   display: "flex", alignItems: "center", justifyContent: "center",
-                  fontWeight: 900, fontSize: 14, color: aColor,
+                  fontWeight: 900, fontSize: 13, color: aColor,
                 }}>
                   {awayTeam?.abbr?.slice(0, 3) ?? "AWY"}
                 </div>
-                <div style={{ fontSize: "0.75rem", fontWeight: 700, color: "var(--text-muted)", marginBottom: 4 }}>
+                <div style={{ fontSize: "0.72rem", fontWeight: 700, color: "var(--text-muted)", marginBottom: 3 }}>
                   {awayTeam?.name ?? awayTeam?.abbr ?? "Away"}
                 </div>
                 <div style={{
-                  fontSize: "2.8rem", fontWeight: 900,
+                  fontSize: "2.2rem", fontWeight: 900,
                   color: !homeWon && !tied ? aColor : "var(--text-muted)",
                   fontVariantNumeric: "tabular-nums", lineHeight: 1,
                 }}>
@@ -483,18 +514,18 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
               {/* Home */}
               <div style={{ flex: 1, textAlign: "center" }}>
                 <div style={{
-                  width: 52, height: 52, borderRadius: "50%", margin: "0 auto 8px",
-                  background: `${hColor}20`, border: `2.5px solid ${hColor}`,
+                  width: 42, height: 42, borderRadius: "50%", margin: "0 auto 6px",
+                  background: `${hColor}20`, border: `2px solid ${hColor}`,
                   display: "flex", alignItems: "center", justifyContent: "center",
-                  fontWeight: 900, fontSize: 14, color: hColor,
+                  fontWeight: 900, fontSize: 13, color: hColor,
                 }}>
                   {homeTeam?.abbr?.slice(0, 3) ?? "HME"}
                 </div>
-                <div style={{ fontSize: "0.75rem", fontWeight: 700, color: "var(--text-muted)", marginBottom: 4 }}>
+                <div style={{ fontSize: "0.72rem", fontWeight: 700, color: "var(--text-muted)", marginBottom: 3 }}>
                   {homeTeam?.name ?? homeTeam?.abbr ?? "Home"}
                 </div>
                 <div style={{
-                  fontSize: "2.8rem", fontWeight: 900,
+                  fontSize: "2.2rem", fontWeight: 900,
                   color: homeWon ? hColor : "var(--text-muted)",
                   fontVariantNumeric: "tabular-nums", lineHeight: 1,
                 }}>
@@ -559,7 +590,7 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
               }}
             >
               <strong style={{ fontSize: "0.78rem", color: "var(--text)" }}>Game Flow</strong>
-              <span style={{ color: "var(--text-subtle)" }}>· Open the box score for the full drive chart.</span>
+              <span style={{ color: "var(--text-subtle)" }}>· Detailed game flow was not recorded for this matchup.</span>
             </div>
           ) : (
           <div style={{ marginBottom: 12, background: "var(--surface)", border: "1px solid var(--hairline)", borderRadius: 12, padding: 12 }}>

--- a/src/ui/components/Scorebug/Scorebug.jsx
+++ b/src/ui/components/Scorebug/Scorebug.jsx
@@ -1,32 +1,63 @@
 import React from 'react';
 
+function finiteScore(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Broadcast-style score strip for the live viewer.
+ *
+ * Score authority: `state.score` is rendered only when the caller supplies it
+ * (the canonical league-recorded final). While the narrated replay is running
+ * the caller passes `score: null` because the per-play narration snapshots are
+ * not trustworthy — the bug then shows an explicit "–" placeholder instead of
+ * a number that could contradict the recorded result.
+ *
+ * Clock authority: no per-play clock exists (drive-granular estimates only),
+ * so the center shows quarter + an event-progress label instead of a
+ * fabricated ticking clock.
+ */
 export default function Scorebug({ homeTeam, awayTeam, state }) {
   const possession = state?.possessionTeamId;
   const quarter = Number(state?.quarter ?? 1);
-  const clock = String(state?.clock ?? '15:00');
-  const minutesLeft = Number(clock.split(':')[0] ?? 15);
+  const homeScore = finiteScore(state?.score?.home);
+  const awayScore = finiteScore(state?.score?.away);
+  const hasScore = homeScore != null && awayScore != null;
   const fieldPosition = Number(state?.fieldPosition ?? 50);
   const inRedZone = Number.isFinite(fieldPosition) && fieldPosition >= 80;
-  const twoMinute = quarter >= 2 && minutesLeft <= 2;
   const isOvertime = quarter > 4;
+  const isFinal = Boolean(state?.isFinal);
+  const scoreCell = (value, teamLabel) => (
+    hasScore
+      ? <strong>{value}</strong>
+      : (
+        <strong
+          className="sb-score-pending"
+          aria-label={`${teamLabel} score shown at the final whistle`}
+        >
+          –
+        </strong>
+      )
+  );
   return (
-    <div className="live-scorebug">
+    <div className="live-scorebug" data-testid="watch-scorebug">
       <div className={`sb-team ${possession === awayTeam?.id ? 'has-ball' : ''}`}>
         <span>{awayTeam?.abbr || 'AWY'}</span>
-        <strong>{state?.score?.away ?? 0}</strong>
+        {scoreCell(awayScore, awayTeam?.abbr || 'Away')}
       </div>
       <div className="sb-center">
-        <div>Q{state?.quarter ?? 1} · {state?.clock ?? '15:00'}</div>
+        <div>Q{quarter}{state?.progressLabel ? ` · ${state.progressLabel}` : ''}</div>
         <div>{state?.downDistance || '—'} · {state?.ballSpot || 'Ball on --'}</div>
         <div className="sb-flags">
+          {isFinal ? <span className="sb-flag final">FINAL</span> : null}
           {isOvertime ? <span className="sb-flag overtime">OVERTIME</span> : null}
-          {twoMinute ? <span className="sb-flag clutch">2:00 DRILL</span> : null}
-          {inRedZone ? <span className="sb-flag redzone">RED ZONE</span> : null}
+          {inRedZone && !isFinal ? <span className="sb-flag redzone">RED ZONE</span> : null}
         </div>
       </div>
       <div className={`sb-team ${possession === homeTeam?.id ? 'has-ball' : ''}`}>
         <span>{homeTeam?.abbr || 'HME'}</span>
-        <strong>{state?.score?.home ?? 0}</strong>
+        {scoreCell(homeScore, homeTeam?.abbr || 'Home')}
       </div>
     </div>
   );

--- a/src/ui/components/ThemeToggle.jsx
+++ b/src/ui/components/ThemeToggle.jsx
@@ -48,8 +48,10 @@ export default function ThemeToggle({ compact = false }) {
 
   useEffect(() => {
     applyTheme(theme);
-    updateSetting?.("theme", theme);
-  }, [theme, applyTheme, updateSetting]);
+    // Only persist a real change — unconditionally writing on mount re-ran
+    // this effect through the settings context on every render pass.
+    if (theme !== savedTheme) updateSetting?.("theme", theme);
+  }, [theme, savedTheme, applyTheme, updateSetting]);
 
   const cycle = useCallback(() => {
     setTheme(prev => {

--- a/src/ui/components/__tests__/HQOverlayCleanup.test.jsx
+++ b/src/ui/components/__tests__/HQOverlayCleanup.test.jsx
@@ -60,6 +60,23 @@ describe('Activity notifications — visible-item cap', () => {
     expect(visible.map((n) => n.id)).toEqual([1, 3]);
     expect(collapsed).toEqual([]);
   });
+
+  it('never collapses warnings or retryable notices, even when newer info notices exceed the cap', () => {
+    const notifications = [
+      { id: 1, level: 'warn', message: 'Roster invalid' },
+      { id: 2, level: 'info', message: 'Info A', retryable: true },
+      notice(3, 'Info B'),
+      notice(4, 'Info C'),
+      notice(5, 'Info D'),
+      notice(6, 'Info E'),
+    ];
+    const { visible, collapsed } = capVisibleNotifications(notifications, 3);
+    // Actionable rows (warn + retryable) always stay visible; the info budget
+    // (cap minus actionable rows) keeps only the newest routine notice.
+    expect(visible.map((n) => n.id)).toEqual([1, 2, 6]);
+    expect(collapsed.map((n) => n.id)).toEqual([3, 4, 5]);
+    expect(collapsed.every((n) => n.level !== 'warn' && !n.retryable)).toBe(true);
+  });
 });
 
 describe('Schedule 0-0 defaults never masquerade as finals', () => {

--- a/src/ui/components/__tests__/HQOverlayCleanup.test.jsx
+++ b/src/ui/components/__tests__/HQOverlayCleanup.test.jsx
@@ -1,0 +1,96 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import MobileNav from '../MobileNav.jsx';
+import { capVisibleNotifications } from '../../utils/notificationsDisplay.js';
+import { recoverArchivedGameFromSchedule } from '../../../core/gameArchive.js';
+import { getBoxScoreAvailability } from '../../utils/boxScoreAccess.js';
+
+afterEach(() => cleanup());
+
+describe('MobileNav — drawer route-change cleanup', () => {
+  const panel = () => document.body.querySelector('.mobile-nav-panel');
+  function openDrawer() {
+    const moreButton = [...document.body.querySelectorAll('button')]
+      .find((b) => b.textContent.trim() === 'More');
+    fireEvent.click(moreButton);
+  }
+
+  it('closes the More drawer when the active tab changes (postgame → HQ return)', () => {
+    const { rerender } = render(
+      <MobileNav activeSection="hq" activeTab="Game Detail" league={{ year: 2026, phase: 'regular' }} />,
+    );
+    openDrawer();
+    expect(panel().className).toContain('open');
+
+    // Returning to HQ (tab change without a section change) must close it.
+    rerender(
+      <MobileNav activeSection="hq" activeTab="HQ" league={{ year: 2026, phase: 'regular' }} />,
+    );
+    expect(panel().className).not.toContain('open');
+  });
+
+  it('closes the More drawer when the nav collapses for Game Book focus', () => {
+    const { rerender } = render(
+      <MobileNav activeSection="hq" activeTab="HQ" league={{ year: 2026, phase: 'regular' }} />,
+    );
+    openDrawer();
+    expect(panel().className).toContain('open');
+    rerender(
+      <MobileNav activeSection="hq" activeTab="HQ" league={{ year: 2026, phase: 'regular' }} collapsed />,
+    );
+    expect(panel().className).not.toContain('open');
+  });
+});
+
+describe('Activity notifications — visible-item cap', () => {
+  const notice = (id, message) => ({ id, level: 'info', message });
+
+  it('renders at most the cap, newest last, and collapses the rest', () => {
+    const notifications = [1, 2, 3, 4, 5].map((n) => notice(n, `Notice ${n}`));
+    const { visible, collapsed } = capVisibleNotifications(notifications, 3);
+    expect(visible.map((n) => n.id)).toEqual([3, 4, 5]);
+    expect(collapsed.map((n) => n.id)).toEqual([1, 2]);
+  });
+
+  it('keeps everything visible when under the cap and drops blank entries', () => {
+    const notifications = [notice(1, 'Real'), notice(2, '   '), notice(3, 'Also real')];
+    const { visible, collapsed } = capVisibleNotifications(notifications, 3);
+    expect(visible.map((n) => n.id)).toEqual([1, 3]);
+    expect(collapsed).toEqual([]);
+  });
+});
+
+describe('Schedule 0-0 defaults never masquerade as finals', () => {
+  const leagueState = {
+    schedule: {
+      weeks: [{
+        week: 1,
+        games: [
+          { home: 1, away: 0, homeScore: 0, awayScore: 0, played: false },
+        ],
+      }],
+    },
+  };
+
+  it('recoverArchivedGameFromSchedule skips explicitly-unplayed rows with default 0-0 scores', () => {
+    expect(recoverArchivedGameFromSchedule('s1_w1_1_0', leagueState)).toBeNull();
+  });
+
+  it('still recovers a genuinely played 0-0 row (played flag set)', () => {
+    const playedState = {
+      schedule: { weeks: [{ week: 1, games: [{ home: 1, away: 0, homeScore: 14, awayScore: 10, played: true }] }] },
+    };
+    expect(recoverArchivedGameFromSchedule('s1_w1_1_0', playedState)?.homeScore).toBe(14);
+  });
+
+  it('box-score availability treats unplayed 0-0 rows as not completed', () => {
+    const availability = getBoxScoreAvailability(
+      { home: 1, away: 0, homeScore: 0, awayScore: 0, played: false, week: 1, seasonId: 's1' },
+      { seasonId: 's1', week: 1 },
+    );
+    expect(availability.isCompleted).toBe(false);
+    expect(availability.canOpen).toBe(false);
+  });
+});

--- a/src/ui/components/__tests__/LiveGameViewerTrust.test.jsx
+++ b/src/ui/components/__tests__/LiveGameViewerTrust.test.jsx
@@ -1,0 +1,118 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import LiveGameViewer from '../LiveGameViewer.jsx';
+
+const homeTeam = { id: 1, abbr: 'MIA', name: 'Miami' };
+const awayTeam = { id: 0, abbr: 'BUF', name: 'Buffalo' };
+
+// Narrated logs whose running score (26-3) deliberately contradicts the
+// canonical league-recorded final (35-41) — the real production shape, since
+// the narration and scoring engines are separate.
+const contradictoryLogs = [
+  { text: 'C. Harris finds L. Ortiz for 13 yds.', quarter: 1, clock: '15:10', homeScore: 0, awayScore: 0, possession: 'home' },
+  { text: 'TOUCHDOWN! L. Ortiz catches 17-yard TD pass from C. Harris!', quarter: 1, clock: '15:10', homeScore: 0, awayScore: 0, possession: 'home', type: 'touchdown', isTouchdown: true },
+  { text: 'D. Knight connects with M. Jones for 1 yds.', quarter: 1, clock: '13:20', homeScore: 6, awayScore: 0, possession: 'away' },
+  { text: 'MIA punts.', quarter: 4, clock: '5:30', homeScore: 26, awayScore: 3, possession: 'home', type: 'punt' },
+];
+
+const canonicalFinal = { home: 35, away: 41 };
+
+function renderViewer(extraProps = {}) {
+  return render(
+    <LiveGameViewer
+      logs={contradictoryLogs}
+      homeTeam={homeTeam}
+      awayTeam={awayTeam}
+      initialMode="pause"
+      finalScore={canonicalFinal}
+      {...extraProps}
+    />,
+  );
+}
+
+afterEach(() => cleanup());
+
+describe('LiveGameViewer — score authority', () => {
+  it('never renders the narrated running score in the scorebug during playback', () => {
+    renderViewer();
+    const bug = screen.getByTestId('watch-scorebug');
+    // Both score cells are placeholder dashes, not narration snapshots
+    // (0-0 / 6-0 / 26-3).
+    const cells = within(bug).getAllByLabelText(/score shown at the final whistle/i);
+    expect(cells.length).toBe(2);
+    cells.forEach((cell) => expect(cell.textContent.trim()).toBe('–'));
+  });
+
+  it('shows the canonical league-recorded final once the feed completes', () => {
+    renderViewer({ initialMode: 'instant' });
+    const finalCard = document.querySelector('.watch-final-card');
+    expect(finalCard.textContent).toContain('BUF 41');
+    expect(finalCard.textContent).toContain('MIA 35');
+    // The narrated 26-3 never appears anywhere.
+    expect(document.body.textContent).not.toMatch(/26\s*[–-]\s*3|3\s*[–-]\s*26/);
+    const bug = screen.getByTestId('watch-scorebug');
+    expect(bug.textContent).toContain('41');
+    expect(bug.textContent).toContain('35');
+    expect(bug.textContent).toContain('FINAL');
+  });
+
+  it('reports the canonical final (not narration) through onComplete', () => {
+    const onComplete = vi.fn();
+    renderViewer({ initialMode: 'instant', onComplete });
+    fireEvent.click(screen.getByRole('button', { name: /Open Final Game Book/i }));
+    expect(onComplete).toHaveBeenCalledWith({ homeScore: 35, awayScore: 41 });
+  });
+
+  it('shows an honest pending note instead of a fabricated final when no canonical score exists', () => {
+    renderViewer({ initialMode: 'instant', finalScore: null });
+    expect(screen.getByTestId('watch-final-pending')).toBeTruthy();
+    const bug = screen.getByTestId('watch-scorebug');
+    expect(bug.textContent).not.toMatch(/26|41|35/);
+  });
+});
+
+describe('LiveGameViewer — feed clock and scoring emphasis', () => {
+  it('does not repeat the fabricated drive clock on event rows', () => {
+    renderViewer({ initialMode: 'instant' });
+    expect(document.querySelector('.live-feed').textContent).not.toContain('15:10');
+  });
+
+  it('keeps scoring rows visually distinct via the TD tag and major styling', () => {
+    renderViewer({ initialMode: 'instant' });
+    const feed = document.querySelector('.live-feed');
+    const tdTag = feed.querySelector('.feed-tag-td');
+    expect(tdTag).toBeTruthy();
+    expect(feed.querySelector('.feed-row.major')).toBeTruthy();
+  });
+
+  it('labels the feed with explicit newest-last ordering for consistency', () => {
+    renderViewer();
+    expect(screen.getByRole('log', { name: /newest play last/i })).toBeTruthy();
+  });
+});
+
+describe('LiveGameViewer — compact mobile controls', () => {
+  it('keeps pause, all speed steps, and skip options available in the sticky tray', () => {
+    renderViewer();
+    const tray = document.querySelector('.watch-controls-tray');
+    expect(tray).toBeTruthy();
+    expect(within(tray).getByRole('button', { name: /Resume playback/i })).toBeTruthy();
+    for (const label of ['Slow', 'Normal', 'Fast', '2×']) {
+      expect(within(tray).getByRole('button', { name: label })).toBeTruthy();
+    }
+    // Skip actions live behind one explicit disclosure, not a full column.
+    const skipMenu = tray.querySelector('.skip-menu');
+    expect(skipMenu).toBeTruthy();
+    expect(within(skipMenu).getByRole('button', { name: /Sim End/i })).toBeTruthy();
+    expect(within(skipMenu).getByRole('button', { name: /Next Score/i })).toBeTruthy();
+  });
+
+  it('keeps playcall overrides available when the hook is provided', () => {
+    const onPlaycallOverride = vi.fn();
+    renderViewer({ onPlaycallOverride });
+    fireEvent.click(screen.getByRole('button', { name: /Run Heavy/i }));
+    expect(onPlaycallOverride).toHaveBeenCalledWith({ type: 'run_heavy' });
+  });
+});

--- a/src/ui/components/__tests__/PostGameRecovery.test.jsx
+++ b/src/ui/components/__tests__/PostGameRecovery.test.jsx
@@ -1,0 +1,107 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import PostGameScreen, { PostGameErrorBoundary } from '../PostGameScreen.jsx';
+
+const baseProps = {
+  homeTeam: { id: 1, abbr: 'MIA', name: 'Miami' },
+  awayTeam: { id: 0, abbr: 'BUF', name: 'Buffalo' },
+  homeScore: 35,
+  awayScore: 41,
+  userTeamId: 0,
+  week: 1,
+  phase: 'regular',
+};
+
+function Bomb() {
+  throw new Error('recap render exploded');
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('PostGameScreen — result heading is user-team based', () => {
+  it('declares VICTORY when the user (away) team outscores the home team', async () => {
+    await act(async () => {
+      render(<PostGameScreen {...baseProps} onContinue={() => {}} />);
+    });
+    expect(screen.getByTestId('postgame-result-banner').textContent).toContain('VICTORY');
+  });
+
+  it('declares DEFEAT when the user (home) team loses', async () => {
+    await act(async () => {
+      render(<PostGameScreen {...baseProps} userTeamId={1} onContinue={() => {}} />);
+    });
+    expect(screen.getByTestId('postgame-result-banner').textContent).toContain('DEFEAT');
+    // The final score itself is intact.
+    expect(document.body.textContent).toContain('41');
+    expect(document.body.textContent).toContain('35');
+  });
+});
+
+describe('PostGameScreen — Game Book CTA and continuation path', () => {
+  it('routes View Game Book through the canonical completed-game id', async () => {
+    const onOpenBoxScore = vi.fn();
+    await act(async () => {
+      render(
+        <PostGameScreen
+          {...baseProps}
+          boxScoreGameId="s1_w1_1_0"
+          onOpenBoxScore={onOpenBoxScore}
+          onContinue={() => {}}
+        />,
+      );
+    });
+    fireEvent.click(screen.getByTestId('box-score-trigger'));
+    expect(onOpenBoxScore).toHaveBeenCalledWith('s1_w1_1_0');
+  });
+
+  it('keeps the Back to Hub continuation available', async () => {
+    const onContinue = vi.fn();
+    await act(async () => {
+      render(<PostGameScreen {...baseProps} onContinue={onContinue} />);
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Back to Hub/i }));
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('PostGameScreen — crash recovery surface', () => {
+  function renderCrashed(onContinue) {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    return render(
+      <PostGameErrorBoundary onContinue={onContinue}>
+        <Bomb />
+      </PostGameErrorBoundary>,
+    );
+  }
+
+  it('anchors an honest recovery dialog with a single user-controlled exit', () => {
+    const onContinue = vi.fn();
+    renderCrashed(onContinue);
+
+    const dialog = screen.getByTestId('postgame-recovery');
+    // Announced to assistive tech as a blocking alert dialog.
+    expect(dialog.getAttribute('role')).toBe('alertdialog');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+    // Honest copy: result is safe, recap failed — no fake auto-redirect text.
+    expect(dialog.textContent).toContain('Game recap unavailable');
+    expect(dialog.textContent).toContain('final result was saved');
+    expect(dialog.textContent).not.toMatch(/Returning you to/i);
+    // Fully opaque anchor: unrelated screens cannot bleed through behind it.
+    expect(dialog.style.background).not.toMatch(/rgba/);
+  });
+
+  it('navigates exactly once even when the recovery action is tapped repeatedly', () => {
+    const onContinue = vi.fn();
+    renderCrashed(onContinue);
+    const button = screen.getByTestId('postgame-recovery-return');
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/ui/context/SettingsContext.jsx
+++ b/src/ui/context/SettingsContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, useMemo } from 'react';
+import React, { createContext, useContext, useState, useEffect, useMemo, useCallback } from 'react';
 
 const STORAGE_KEY = 'fgmsim_settings_v1';
 
@@ -31,9 +31,14 @@ export function SettingsProvider({ children }) {
     }
   }, [settings]);
 
-  const updateSetting = (key, value) => setSettings((prev) => ({ ...prev, [key]: value }));
+  // Stable identity + no-op bailout: consumers call updateSetting from mount
+  // effects (e.g. ThemeToggle), so an unstable reference or an always-new
+  // settings object re-triggers those effects forever ("Maximum update depth").
+  const updateSetting = useCallback((key, value) => {
+    setSettings((prev) => (prev[key] === value ? prev : { ...prev, [key]: value }));
+  }, []);
 
-  const value = useMemo(() => ({ settings, updateSetting }), [settings]);
+  const value = useMemo(() => ({ settings, updateSetting }), [settings, updateSetting]);
 
   return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
 }

--- a/src/ui/styles/app-mobile.css
+++ b/src/ui/styles/app-mobile.css
@@ -17,7 +17,10 @@
   max-width: 1200px;
   margin: 0 auto;
   padding: var(--space-3);
-  padding-bottom: calc(var(--space-3) + 80px); /* Space for bottom nav on mobile */
+  /* Space for the floating bottom nav on mobile: nav height (~60px) + its
+     10px inset + breathing room, plus the home-indicator safe area so the
+     last interactive row is never covered on notched iPhones. */
+  padding-bottom: calc(var(--space-3) + 84px + env(safe-area-inset-bottom, 0px));
   min-height: 100vh;
   min-height: 100dvh;
 }
@@ -415,6 +418,20 @@
   color: var(--warning-text);
 }
 
+/* Compact activity notices: routine post-sim messages render as tight rows
+   instead of full-width alert cards, so weekly results stay visible. */
+.app-notification-compact {
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--text-xs);
+  border-radius: var(--radius-sm);
+  min-height: 32px;
+}
+.app-notification-compact .app-notification-dismiss {
+  min-width: 32px;
+  min-height: 32px;
+  padding: var(--space-1);
+}
+
 .app-notification-dismiss {
   background: none;
   border: none;
@@ -761,6 +778,16 @@
 
 .mobile-nav-panel.open {
   transform: translateX(0);
+  visibility: visible;
+}
+
+/* Hardening: a closed drawer is fully invisible even if a transform gets stuck
+   mid-transition (e.g. interrupted by a route change while animating) — no
+   partial sliver can remain over HQ content. Visibility flips after the slide
+   finishes so the close animation still plays. */
+.mobile-nav-panel:not(.open) {
+  visibility: hidden;
+  transition: transform var(--dur-slow) var(--ease), visibility 0s linear var(--dur-slow);
 }
 
 .mobile-nav-header {

--- a/src/ui/utils/boxScoreAccess.js
+++ b/src/ui/utils/boxScoreAccess.js
@@ -17,6 +17,9 @@ function archiveQualityKey(label) {
 }
 
 function hasFinalScore(game) {
+  // Explicitly-unplayed schedule rows carry serialization-default 0-0 scores
+  // (Int32Array slots can't hold null) — never treat them as completed.
+  if (game?.played === false || game?.played === 0) return false;
   return Boolean(
     game?.played
       || Number.isFinite(Number(game?.homeScore))

--- a/src/ui/utils/canonicalCompletedGame.js
+++ b/src/ui/utils/canonicalCompletedGame.js
@@ -45,11 +45,15 @@ export function resolveCanonicalCompletedGame({ league, gameId, scheduleGame, ar
     const { home: archivedHome, away: archivedAway } = extractScoreFields(archived);
     const meta = schedule ?? byId;
     if (!meta) {
-      return { ...archived, homeScore: archivedHome, awayScore: archivedAway };
+      // An archive-validated final is by definition a played game.
+      return { ...archived, homeScore: archivedHome, awayScore: archivedAway, played: true };
     }
     return {
       ...meta,
       ...archived,
+      // The stale schedule/index row may still say played:false (the UI league
+      // snapshot is not refreshed mid-week); the archived final wins.
+      played: true,
       homeScore: archivedHome,
       awayScore: archivedAway,
       homeAbbr: archived.homeAbbr ?? meta.homeAbbr,

--- a/src/ui/utils/canonicalCompletedGame.js
+++ b/src/ui/utils/canonicalCompletedGame.js
@@ -24,6 +24,9 @@ function extractScoreFields(game) {
 
 function hasValidFinalScore(game) {
   if (!game || typeof game !== 'object') return false;
+  // Rows explicitly marked unplayed carry serialization-default 0-0 scores
+  // (schedule buffers can't hold null) — never treat them as a real final.
+  if (game.played === false || game.played === 0) return false;
   const { home, away } = extractScoreFields(game);
   return Number.isFinite(home) && Number.isFinite(away);
 }

--- a/src/ui/utils/notificationsDisplay.js
+++ b/src/ui/utils/notificationsDisplay.js
@@ -20,3 +20,18 @@ export function getDisplayableNotifications(notifications) {
   if (!Array.isArray(notifications)) return [];
   return notifications.filter((notification) => getNotificationMessage(notification).length > 0);
 }
+
+/**
+ * Splits displayable notifications into the rows that render individually and
+ * the older ones that collapse into a single "+N earlier notices" summary, so
+ * routine post-sim messages can't stack over the weekly results on mobile.
+ * Newest entries stay visible (the queue appends newest last).
+ */
+export function capVisibleNotifications(notifications, maxVisible = 3) {
+  const displayable = getDisplayableNotifications(notifications);
+  const max = Math.max(1, Number(maxVisible) || 1);
+  return {
+    visible: displayable.slice(-max),
+    collapsed: displayable.slice(0, -max),
+  };
+}

--- a/src/ui/utils/notificationsDisplay.js
+++ b/src/ui/utils/notificationsDisplay.js
@@ -25,13 +25,24 @@ export function getDisplayableNotifications(notifications) {
  * Splits displayable notifications into the rows that render individually and
  * the older ones that collapse into a single "+N earlier notices" summary, so
  * routine post-sim messages can't stack over the weekly results on mobile.
- * Newest entries stay visible (the queue appends newest last).
+ *
+ * Warnings and retryable notices are actionable and never collapse — the
+ * summary row renders as generic info with only a dismiss-all control, which
+ * would silently discard their severity and retry affordance. Only routine
+ * info rows count against the cap; newest entries stay visible (the queue
+ * appends newest last) and original ordering is preserved.
  */
 export function capVisibleNotifications(notifications, maxVisible = 3) {
   const displayable = getDisplayableNotifications(notifications);
   const max = Math.max(1, Number(maxVisible) || 1);
+  const isActionable = (n) => n?.level === 'warn' || n?.retryable === true;
+  const routine = displayable.filter((n) => !isActionable(n));
+  const routineBudget = Math.max(0, max - (displayable.length - routine.length));
+  const collapsedCount = Math.max(0, routine.length - routineBudget);
+  const collapsed = routine.slice(0, collapsedCount);
+  const collapsedSet = new Set(collapsed);
   return {
-    visible: displayable.slice(-max),
-    collapsed: displayable.slice(0, -max),
+    visible: displayable.filter((n) => !collapsedSet.has(n)),
+    collapsed,
   };
 }

--- a/tests/e2e/mobile_game_day_trust.spec.js
+++ b/tests/e2e/mobile_game_day_trust.spec.js
@@ -1,0 +1,152 @@
+import { test, expect } from '@playwright/test';
+import { launchFranchise } from './helpers/franchise.js';
+
+/**
+ * Mobile game-day trust & recovery loop:
+ *   fresh franchise → advance week → watch user game → final → postgame
+ *   → Game Book (canonical id) → return to HQ, plus the missing-game
+ *   recovery fallback.
+ *
+ * Score authority under test: the league-recorded GAME_EVENT final must be
+ * the only score shown at the final whistle, in postgame, and in HQ's last
+ * result — the narrated play stream is a different engine.
+ */
+
+const IPHONE = { width: 390, height: 844 };
+
+async function markWeeklyPrepDone(page) {
+  await page.evaluate(() => {
+    const PREP_KEY = 'footballgm_weekly_prep_v1';
+    const league = window?.state?.league ?? {};
+    const slotKey = `${league?.seasonId ?? 'season'}:${league?.week ?? 1}:${league?.userTeamId ?? 'user'}`;
+    const stored = JSON.parse(window.localStorage.getItem(PREP_KEY) ?? '{}');
+    stored[slotKey] = { lineupChecked: true, injuriesReviewed: true, opponentScouted: true, planReviewed: true };
+    window.localStorage.setItem(PREP_KEY, JSON.stringify(stored));
+  });
+}
+
+async function advanceIntoUserGamePrompt(page) {
+  await markWeeklyPrepDone(page);
+  const advance = page.getByTestId('advance-week-cta');
+  if (await advance.isVisible().catch(() => false)) {
+    await advance.click();
+  } else {
+    await page.evaluate(() => window.handleGlobalAdvance?.());
+  }
+  await page.getByRole('button', { name: /Advance anyway/i }).click({ timeout: 1500 }).catch(() => {});
+  await page.getByRole('button', { name: /Watch \(Broadcast Pace\)/ }).waitFor({ state: 'visible', timeout: 45000 });
+}
+
+test.describe('Mobile game-day trust loop', () => {
+  test('watch → final → postgame → Game Book → HQ uses the canonical result end to end', async ({ page }) => {
+    await page.setViewportSize(IPHONE);
+    await launchFranchise(page);
+    await advanceIntoUserGamePrompt(page);
+
+    await page.getByRole('button', { name: /Watch \(Broadcast Pace\)/ }).click();
+    await expect(page.locator('.watch-overlay')).toBeVisible({ timeout: 30000 });
+
+    // The canonical league-recorded final is available from GAME_EVENT.
+    const canonical = await page.evaluate(() => {
+      const league = window.state.league;
+      const ev = (window.state.gameEvents ?? []).find(
+        (e) => Number(e.homeId) === Number(league.userTeamId) || Number(e.awayId) === Number(league.userTeamId),
+      );
+      return ev ? { home: Number(ev.homeScore), away: Number(ev.awayScore), gameId: ev.gameId } : null;
+    });
+    expect(canonical).not.toBeNull();
+
+    // During playback the scorebug never shows a numeric score that could
+    // contradict the recorded final.
+    const bug = page.getByTestId('watch-scorebug');
+    await expect(bug).toBeVisible();
+    await expect(bug.locator('.sb-score-pending')).toHaveCount(2);
+
+    // No horizontal overflow, and the compact control tray is on-screen.
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+    expect(overflow).toBeLessThanOrEqual(1);
+    await expect(page.locator('.watch-controls-tray')).toBeInViewport();
+
+    // Skip to the end via the compact Skip menu.
+    await page.locator('.skip-menu > summary').click();
+    await page.getByRole('button', { name: /^Sim End$/ }).click();
+    await expect(page.locator('.watch-final-card')).toBeVisible({ timeout: 20000 });
+
+    // Final card shows the canonical score.
+    const finalCard = page.locator('.watch-final-card');
+    await expect(finalCard).toContainText(String(canonical.home));
+    await expect(finalCard).toContainText(String(canonical.away));
+
+    // Postgame screen: same canonical numbers, Game Book CTA enabled.
+    await page.getByRole('button', { name: /Open Final Game Book/i }).click();
+    const boxScoreCta = page.getByTestId('box-score-trigger');
+    await expect(boxScoreCta).toBeVisible({ timeout: 20000 });
+    await expect(boxScoreCta).toBeEnabled();
+    await expect(page.getByTestId('postgame-result-banner')).toBeVisible();
+    const postgameText = await page.evaluate(() => document.body.innerText);
+    expect(postgameText).toContain(String(canonical.home));
+    expect(postgameText).toContain(String(canonical.away));
+
+    // Open the Game Book — it must resolve the just-played canonical game,
+    // never a placeholder 0-0 or an error over an unrelated screen.
+    await boxScoreCta.click();
+    await expect(page.getByTestId('game-book')).toBeVisible({ timeout: 20000 });
+    await expect(page.getByTestId('game-book-recovery')).toHaveCount(0);
+    const sticky = page.getByTestId('game-book-sticky-score');
+    await expect(sticky).toContainText(String(canonical.home));
+    await expect(sticky).toContainText(String(canonical.away));
+
+    // Return to HQ (restores postgame), then continue the weekly loop.
+    await page.getByTestId('game-book-sticky-back').click();
+    await expect(page.getByTestId('box-score-trigger')).toBeVisible({ timeout: 15000 });
+    await page.getByRole('button', { name: /Back to Hub/i }).click();
+
+    // The rest of the week simulates; wait for it to settle.
+    await page.waitForFunction(() => !window?.state?.simulating && !window?.state?.busy, null, { timeout: 90000 });
+
+    // Route cleanup: no stale drawer, no postgame overlay, no game-book modal.
+    await expect(page.locator('.mobile-nav-panel.open')).toHaveCount(0);
+    await expect(page.getByTestId('game-book')).toHaveCount(0);
+    await expect(page.getByTestId('box-score-trigger')).toHaveCount(0);
+    const drawerHidden = await page.evaluate(() => {
+      const panel = document.querySelector('.mobile-nav-panel');
+      if (!panel) return true;
+      const rect = panel.getBoundingClientRect();
+      const style = getComputedStyle(panel);
+      return style.visibility === 'hidden' || rect.left >= window.innerWidth || rect.right <= 0;
+    });
+    expect(drawerHidden).toBeTruthy();
+
+    // Notification stack is capped and compact — never a wall of cards.
+    const noticeCount = await page.locator('[data-testid="app-notifications"] .app-notification').count();
+    expect(noticeCount).toBeLessThanOrEqual(4); // 3 visible + optional overflow summary
+
+    // HQ's last-result surface agrees with the canonical final.
+    const hqText = await page.evaluate(() => document.body.innerText);
+    expect(hqText).toContain(String(canonical.home));
+    expect(hqText).toContain(String(canonical.away));
+
+    await expect(page.locator('body')).not.toContainText('Something went wrong');
+  });
+
+  test('missing Game Book produces an anchored recovery state and one clean return', async ({ page }) => {
+    await page.setViewportSize(IPHONE);
+    await launchFranchise(page);
+
+    // Controlled missing-game fixture: a canonical-looking id that exists in
+    // no archive, schedule, or league index.
+    await page.evaluate(() => window.gameController.openBoxScore('s1_w99_998_999'));
+
+    const recovery = page.getByTestId('game-book-recovery');
+    await expect(recovery).toBeVisible({ timeout: 20000 });
+    await expect(recovery).toContainText('Game Book unavailable');
+    // No fabricated final behind or inside the recovery surface.
+    await expect(page.getByTestId('game-book-sticky-score')).toHaveCount(0);
+    await expect(recovery).not.toContainText('0 - 0');
+
+    await page.getByTestId('game-book-recovery-return').click();
+    await expect(page.getByTestId('game-book')).toHaveCount(0, { timeout: 15000 });
+    await expect(page.getByTestId('franchise-hq')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('body')).not.toContainText('Something went wrong');
+  });
+});


### PR DESCRIPTION
# Mobile Game-Day Trust & Recovery V1

Focused mobile UX + reliability pass on the game-day loop: **Live Game → Final → Postgame → Game Book → Return to HQ**. Frontend presentation, navigation, view-state interpretation, and recovery only — no simulation, roster, offseason, worker-lifecycle, or save-schema changes (no overlap with #1689).

Full report: `docs/mobile-game-day-trust-recovery-v1.md`.

## Screenshot evidence matrix

| Issue | Classification | Disposition |
|---|---|---|
| TD card shows 0–0 while scorebug shows 0–7 | Confirmed live defect (upstream data) | Play-log scores are pre-play snapshots **and** the narrated stream is a different engine than the recorded final. Per-play scores omitted; only the final-whistle marker carries the canonical `GAME_EVENT` score. |
| Every event stamped `Q1 15:10` | Confirmed live defect (upstream data) | Clock is drive-granular with randomized seconds (can exceed 15:00). Feed now shows quarter + `#sequence`; scorebug shows quarter + play progress, no fabricated clock. |
| Ambiguous event ordering | Confirmed layout problem | Feed is `role="log"` "newest play last" with sequence indicators, quarter markers, drive dividers. |
| Controls/Standouts fill the screen | Confirmed layout problem | One 53px sticky control tray (pause + speeds + `Skip ▾` menu + playcalls) and collapsible Standouts; side rail ~339px → ~108px, feed area ~310px → ~537px at 390×844. Nothing removed. |
| Postgame hierarchy (oversized banner, empty Game Flow row, tall cards) | Confirmed layout problem | One-line result header with inline saved-chip, tighter score card, honest compact Game Flow empty state. Leader math untouched. |
| "Game recap failed" modal over Franchise History | Confirmed live defect | Two root causes, below. |
| Left drawer sliver on HQ return | Unable to reproduce | Hardened: drawer closes on any tab change; closed drawer is `visibility:hidden`. |
| Toast pileup over week results | Confirmed live defect | Notices never auto-dismissed (up to 10 cards). Now: info auto-dismisses (7s), max 3 compact rows, older collapse into "+N earlier notices". Warnings/retryable persist. |
| Bottom nav covering content | Confirmed layout problem | Shell padding now includes nav height + `env(safe-area-inset-bottom)`. |
| "Games resolved: 15 / 16" | Intentional — preserved | Honest partial-results warning untouched. |

## Exact Game Book failure root causes (both verified in-browser)

1. **Infinite React update loop** — `SettingsContext.updateSetting` was recreated per render and always produced a new settings object; `ThemeToggle`'s effect (with `updateSetting` in deps) looped forever. The "Maximum update depth exceeded" storm ran on every screen, starved the Game Book's archive fetch, and could surface through `PostGameErrorBoundary` as "Game recap failed" over whatever tab was mounted behind. Fixed with memoization + no-op bailout (CDP-verified: 100+ errors/session → 0).
2. **Serialization-default 0–0 as a fake final** — unplayed schedule rows reach the UI with `homeScore: 0, awayScore: 0, played: false` (Int32Array packing), and the resolvers only checked `== null`, so any archive miss rendered "T · AWAY 0 – 0 HOME" for a real game. Explicitly-unplayed rows are no longer treated as finals; `played` survives normalization.

Also fixed at the seam: the narrated final previously flowed into PostGameScreen and **overwrote the UI archive** — HQ could show a LOSS for a league-recorded WIN (reproduced live: HQ card "L 20–22 vs MIA" beside standings "BUF 1-0"). Postgame/archive/viewer-final now use only the canonical `GAME_EVENT` score.

## Recovery behavior

- Recap crash → opaque `role="alertdialog"`, honest copy ("the final result was saved…"), one user-controlled **Return to HQ** that navigates exactly once. No fake auto-redirect text.
- Missing game → anchored `Game Book unavailable` state with a single return action, plus a loading state while the archive request is in flight. Never a placeholder 0–0.

## Validation

- `npm run test:unit`: **444 files / 5492 tests passed** (includes 29 new tests: `liveGameEvents.test.js`, `LiveGameViewerTrust.test.jsx`, `PostGameRecovery.test.jsx`, `HQOverlayCleanup.test.jsx`).
- `npm run build`: passes.
- New mobile Playwright spec `tests/e2e/mobile_game_day_trust.spec.js` (390×844): full loop with canonical-score assertions end-to-end + missing-game recovery fixture — **2/2 passed** against the production build.
- Viewport sweep on the built bundle (390×844, 393×852, 430×932, 360×780, 1440×900): no horizontal overflow, control tray above the safe area, drawer hidden after the loop, bottom nav no longer overlaps content. Desktop layout unchanged (two-column watch view).
- Pre-existing e2e failures verified identical on a clean `origin/main` worktree (4: `box_score_clickthrough` ×2, `franchise_hq_mobile_smoke` HQ-essentials ×2) — unrelated to this PR.

## Deferred upstream (documented, intentionally not fixed here)

- Narrated play stream vs drive-engine final divergence (`src/core/simulation/index.js` ~L1176) — a separate engine PR should emit canonical per-play `scoreAfter` so the UI can re-enable a live running score.
- `GAME_EVENT` lacks `quarterScores` for a quarter-grain honest scorebug.
- `LiveGame.jsx` week-sim ticker still generates fully synthetic narration (outside this PR's screenshot scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAbJ79VcyH5EpCiA6XaDcZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAbJ79VcyH5EpCiA6XaDcZ)_