### PR TITLE
Strict final-score parsing & pending-result safety

### DIFF
--- a/src/core/__tests__/gameArchive.test.js
+++ b/src/core/__tests__/gameArchive.test.js
@@ -85,6 +85,28 @@ describe('gameArchive helpers', () => {
     expect(recovered?.homeScore).toBe(14);
   });
 
+  it('requires complete strict final scores for archive normalization and schedule recovery', () => {
+    for (const scoreFields of [
+      { homeScore: null, awayScore: null },
+      { homeScore: '', awayScore: '   ' },
+      { homeScore: 14, awayScore: null },
+      { homeScore: null, awayScore: 10 },
+    ]) {
+      const normalized = normalizeArchivedGamePayload({
+        id: 'pending',
+        homeId: 5,
+        awayId: 6,
+        played: true,
+        ...scoreFields,
+      });
+      expect([normalized.homeScore, normalized.awayScore]).not.toEqual([0, 0]);
+      expect(normalized.archiveQuality).toBe('missing');
+      expect(recoverArchivedGameFromSchedule('2031_w7_5_6', {
+        schedule: { weeks: [{ week: 7, games: [{ home: 5, away: 6, played: true, ...scoreFields }] }] },
+      })).toBeNull();
+    }
+  });
+
   it('flags contradictory full markers on validation summaries', () => {
     const defects = summarizeArchiveDefects({
       id: 'x',

--- a/src/core/gameArchive.js
+++ b/src/core/gameArchive.js
@@ -11,13 +11,30 @@ const asNumberOrNull = (value) => {
   return Number.isFinite(n) ? n : null;
 };
 
+export const parseStrictFinalScore = (value) => {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed === '') return null;
+    const n = Number(trimmed);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+};
+
+export function readStrictFinalScore(game) {
+  if (!game || typeof game !== 'object') return null;
+  if (game?.played === false || game?.played === 0) return null;
+  const home = parseStrictFinalScore(game?.homeScore ?? game?.scoreHome ?? game?.score?.home);
+  const away = parseStrictFinalScore(game?.awayScore ?? game?.scoreAway ?? game?.score?.away);
+  return home == null || away == null ? null : { home, away };
+}
+
 const hasValues = (obj) => Boolean(obj && typeof obj === 'object' && Object.keys(obj).length > 0);
 
 // Rows explicitly marked unplayed carry serialization-default 0-0 scores
 // (schedule buffers can't hold null) — they are never a real final.
-const hasFinalScore = (game) => !(game?.played === false || game?.played === 0)
-  && Number.isFinite(Number(game?.homeScore ?? game?.scoreHome ?? game?.score?.home))
-  && Number.isFinite(Number(game?.awayScore ?? game?.scoreAway ?? game?.score?.away));
+const hasFinalScore = (game) => readStrictFinalScore(game) != null;
 
 function teamLabel(rawGame, side, key) {
   return rawGame?.[`${side}${key}`] ?? rawGame?.[side]?.[key.toLowerCase()] ?? rawGame?.[side]?.[key] ?? null;
@@ -85,7 +102,7 @@ export function deriveTeamStatsFromPlayerRows(playerRows = {}) {
 
 export function classifyArchiveQuality(rawGame) {
   if (!rawGame || typeof rawGame !== 'object') return QUALITY.missing;
-  const hasFinal = Number.isFinite(Number(rawGame?.homeScore)) && Number.isFinite(Number(rawGame?.awayScore));
+  const hasFinal = readStrictFinalScore(rawGame) != null;
   const hasTeamStats = hasValues(rawGame?.teamStats?.home) && hasValues(rawGame?.teamStats?.away);
   const hasPlayerStats = hasValues(rawGame?.playerStats?.home) && hasValues(rawGame?.playerStats?.away);
   const hasSections = (rawGame?.scoringSummary?.length ?? 0) > 0
@@ -104,7 +121,7 @@ export function summarizeArchiveDefects(rawGame) {
   if (!g?.id) defects.push('missing_id');
   if (!Number.isFinite(Number(g?.homeId))) defects.push('missing_home_id');
   if (!Number.isFinite(Number(g?.awayId))) defects.push('missing_away_id');
-  if (!Number.isFinite(Number(g?.homeScore)) || !Number.isFinite(Number(g?.awayScore))) defects.push('missing_final_score');
+  if (readStrictFinalScore(g) == null) defects.push('missing_final_score');
   const classified = classifyArchiveQuality(g);
   if (declaredQuality === QUALITY.full) {
     if (!(hasValues(g?.teamStats?.home) && hasValues(g?.teamStats?.away))) defects.push('full_without_team_stats');
@@ -186,8 +203,8 @@ export function normalizeArchivedGamePayload(rawGame) {
     awayAbbr: teamLabel(rawGame, 'away', 'Abbr'),
     homeName: teamLabel(rawGame, 'home', 'Name'),
     awayName: teamLabel(rawGame, 'away', 'Name'),
-    homeScore: asNumberOrNull(rawGame?.homeScore ?? rawGame?.scoreHome ?? rawGame?.score?.home),
-    awayScore: asNumberOrNull(rawGame?.awayScore ?? rawGame?.scoreAway ?? rawGame?.score?.away),
+    homeScore: parseStrictFinalScore(rawGame?.homeScore ?? rawGame?.scoreHome ?? rawGame?.score?.home),
+    awayScore: parseStrictFinalScore(rawGame?.awayScore ?? rawGame?.scoreAway ?? rawGame?.score?.away),
     quarterScores: normalizeQuarterScores(rawGame?.quarterScores ?? rawGame?.linescore),
     recap: rawGame?.recap ?? null,
     recapText: rawGame?.recapText ?? null,
@@ -357,20 +374,20 @@ export function recoverArchivedGameFromSchedule(gameId, leagueState) {
       const rowHome = toTeamId(row?.homeId ?? row?.home?.id ?? row?.home);
       const rowAway = toTeamId(row?.awayId ?? row?.away?.id ?? row?.away);
       if (rowHome !== Number(homeValue) || rowAway !== Number(awayValue)) continue;
-      if (row?.homeScore == null && row?.awayScore == null) continue;
+      const finalScore = readStrictFinalScore(row);
+      if (!finalScore) continue;
       // The serialized slim schedule packs unplayed games with default 0-0
       // scores (Int32Array slots can't hold null — see worker/serialization.js),
       // so a row explicitly marked unplayed must never be recovered as a
       // "final". Otherwise a pre-game row surfaces as a fake 0-0 tie.
-      if (row?.played === false || row?.played === 0) continue;
       return normalizeArchivedGamePayload({
         id: gameId,
         seasonId: row?.seasonId ?? seasonId,
         week: row?.week ?? weekNumber,
         homeId: rowHome,
         awayId: rowAway,
-        homeScore: row?.homeScore,
-        awayScore: row?.awayScore,
+        homeScore: finalScore.home,
+        awayScore: finalScore.away,
         homeAbbr: row?.homeAbbr ?? row?.home?.abbr ?? null,
         awayAbbr: row?.awayAbbr ?? row?.away?.abbr ?? null,
         homeName: row?.homeName ?? row?.home?.name ?? null,

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -63,6 +63,7 @@ import {
 } from './utils/leagueBootstrap.js';
 import { clearWeeklyPrepForWeek, pruneWeeklyPrepStorage } from './utils/weeklyPrep.js';
 import { buildCanonicalGameId } from '../core/gameIdentity.js';
+import { readStrictFinalScore } from '../core/gameArchive.js';
 import { getRecentGames, saveGame } from '../core/archive/gameArchive.ts';
 import { applyEventDecision } from './utils/franchiseEvents.js';
 import { logChronicleEvent } from './utils/franchiseChronicle.js';
@@ -1706,11 +1707,7 @@ function AppContent() {
         // watch session. The narrated play stream runs on a different engine
         // whose running score can contradict it — never treat viewer-reported
         // scores as the result when the canonical final exists.
-        const canonicalFinal = userEvent
-          && Number.isFinite(Number(userEvent.homeScore))
-          && Number.isFinite(Number(userEvent.awayScore))
-          ? { home: Number(userEvent.homeScore), away: Number(userEvent.awayScore) }
-          : null;
+        const canonicalFinal = readStrictFinalScore(userEvent);
         return (
           <GameSimErrorBoundary onFallback={() => {
             // If GameSimulation crashes, recover directly to advancing the week
@@ -1736,11 +1733,15 @@ function AppContent() {
                   // Belt-and-suspenders save immediately on game completion
                   if (activeSlot) actions.saveSlot(activeSlot);
                   // Capture final scores + logs for PostGameScreen, then clear the viewer
+                  const completedFinal = canonicalFinal ?? readStrictFinalScore({
+                    homeScore: scores?.homeScore,
+                    awayScore: scores?.awayScore,
+                  });
                   setPostGameResult({
                     homeTeam,
                     awayTeam,
-                    homeScore: canonicalFinal?.home ?? scores?.homeScore ?? 0,
-                    awayScore: canonicalFinal?.away ?? scores?.awayScore ?? 0,
+                    homeScore: completedFinal?.home ?? null,
+                    awayScore: completedFinal?.away ?? null,
                     userTeamId: league?.userTeamId,
                     week: league?.week,
                     phase: league?.phase,

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -161,6 +161,45 @@ function safeSkipScore(value, fallback = 0) {
   return Number.isFinite(n) ? n : fallback;
 }
 
+export function buildWatchPostGameResult({
+  canonicalFinal,
+  viewerScores,
+  homeTeam,
+  awayTeam,
+  userTeamId,
+  week,
+  phase,
+  logs = [],
+  liveStats = null,
+  gameReasoningFlags = [],
+  seasonId,
+} = {}) {
+  const completedFinal = readStrictFinalScore({ score: canonicalFinal }) ?? readStrictFinalScore({
+    homeScore: viewerScores?.homeScore,
+    awayScore: viewerScores?.awayScore,
+  });
+  if (!completedFinal) return null;
+  return {
+    homeTeam,
+    awayTeam,
+    homeScore: completedFinal.home,
+    awayScore: completedFinal.away,
+    userTeamId,
+    week,
+    phase,
+    logs,
+    liveStats,
+    gameReasoningFlags,
+    seasonId,
+    gameId: buildCanonicalGameId({
+      seasonId,
+      week,
+      homeId: homeTeam?.id,
+      awayId: awayTeam?.id,
+    }),
+  };
+}
+
 function AppContent() {
   const { state, actions } = useWorker();
   const {
@@ -199,6 +238,7 @@ function AppContent() {
 
   // Post-game result shown after GameSimulation watch mode completes
   const [postGameResult, setPostGameResult] = useState(null);
+  const [postGameRecovery, setPostGameRecovery] = useState(null);
   // Stash preserves postGameResult while the user browses Game Book, so it can be restored on return.
   const [postGameResultStash, setPostGameResultStash] = useState(null);
   // Skip-mode summary shown after advanceWeek({ skipUserGame: true }) completes
@@ -1732,16 +1772,15 @@ function AppContent() {
                 try {
                   // Belt-and-suspenders save immediately on game completion
                   if (activeSlot) actions.saveSlot(activeSlot);
-                  // Capture final scores + logs for PostGameScreen, then clear the viewer
-                  const completedFinal = canonicalFinal ?? readStrictFinalScore({
-                    homeScore: scores?.homeScore,
-                    awayScore: scores?.awayScore,
-                  });
-                  setPostGameResult({
+                  // Capture final scores + logs for PostGameScreen, then clear the viewer.
+                  // If neither the canonical GAME_EVENT nor the viewer callback has a
+                  // strict pair, do not mount the normal result screen: it would have
+                  // no trustworthy W/L/T or archive payload.
+                  const nextPostGameResult = buildWatchPostGameResult({
+                    canonicalFinal,
+                    viewerScores: scores,
                     homeTeam,
                     awayTeam,
-                    homeScore: completedFinal?.home ?? null,
-                    awayScore: completedFinal?.away ?? null,
                     userTeamId: league?.userTeamId,
                     week: league?.week,
                     phase: league?.phase,
@@ -1749,13 +1788,15 @@ function AppContent() {
                     liveStats: userGameLiveStats || null,
                     gameReasoningFlags: userGameReasoningFlags || [],
                     seasonId: league?.seasonId,
-                    gameId: buildCanonicalGameId({
-                      seasonId: league?.seasonId,
-                      week: league?.week,
-                      homeId: homeTeam?.id,
-                      awayId: awayTeam?.id,
-                    }),
                   });
+                  if (nextPostGameResult) {
+                    setPostGameRecovery(null);
+                    setPostGameResult(nextPostGameResult);
+                  } else {
+                    setPostGameResult(null);
+                    setPostGameResultStash(null);
+                    setPostGameRecovery({ week: league?.week, phase: league?.phase, homeTeam, awayTeam });
+                  }
                   setWatchMode('watch');
                   actions.clearUserGame();
                 } catch (err) {
@@ -1815,8 +1856,66 @@ function AppContent() {
         />
       )}
 
+      {postGameRecovery && !postGameResult && (
+        <div
+          data-testid="postgame-missing-final-recovery"
+          role="status"
+          aria-live="polite"
+          style={{
+            position: "fixed", inset: 0, zIndex: 9700,
+            background: "rgba(0,0,0,0.88)",
+            backdropFilter: "blur(16px)",
+            display: "flex", alignItems: "center", justifyContent: "center",
+            padding: "24px 16px",
+          }}
+        >
+          <div style={{
+            width: "100%", maxWidth: 420,
+            background: "var(--surface)",
+            border: "1px solid var(--hairline)",
+            borderRadius: 16,
+            padding: 20,
+            textAlign: "center",
+          }}>
+            <div style={{ fontSize: "1.2rem", fontWeight: 900, marginBottom: 8 }}>
+              Official result pending
+            </div>
+            <p style={{ color: "var(--text-muted)", marginBottom: 16 }}>
+              The league record did not provide a complete score for {postGameRecovery.awayTeam?.abbr ?? "AWY"} at {postGameRecovery.homeTeam?.abbr ?? "HME"}. No Game Book was opened or persisted.
+            </p>
+            <button
+              type="button"
+              data-testid="postgame-missing-final-continue"
+              onClick={() => {
+                setPostGameRecovery(null);
+                setPostGameResultStash(null);
+                setTimeout(() => {
+                  try {
+                    actions.advanceWeek({ skipUserGame: true });
+                  } catch (err) {
+                    console.error('[PostGameRecovery] advanceWeek failed:', err);
+                  }
+                }, 150);
+              }}
+              style={{
+                cursor: "pointer",
+                fontWeight: 800,
+                fontSize: "0.85rem",
+                padding: "10px 20px",
+                borderRadius: 999,
+                border: "1px solid var(--accent)",
+                background: "var(--accent-muted)",
+                color: "var(--accent)",
+              }}
+            >
+              Continue week processing
+            </button>
+          </div>
+        </div>
+      )}
+
       {/* ── Skip-mode Post-Game Summary ────────────────────────────────── */}
-      {skipGameSummary && !postGameResult && (
+      {skipGameSummary && !postGameResult && !postGameRecovery && (
         <PostGameSummary
           gameResult={skipGameSummary}
           injuries={skipGameSummary.injuries}

--- a/src/ui/App.test.jsx
+++ b/src/ui/App.test.jsx
@@ -1,0 +1,67 @@
+/** @vitest-environment jsdom */
+import { describe, expect, it } from 'vitest';
+import { buildWatchPostGameResult } from './App.jsx';
+
+const homeTeam = { id: 1, abbr: 'HME', name: 'Home' };
+const awayTeam = { id: 2, abbr: 'AWY', name: 'Away' };
+
+describe('App watch-mode postgame result contract', () => {
+  it('does not build a normal postgame result when scores are missing or partial', () => {
+    for (const input of [
+      { canonicalFinal: null, viewerScores: {} },
+      { canonicalFinal: { home: null, away: null }, viewerScores: {} },
+      { canonicalFinal: { home: '', away: '   ' }, viewerScores: {} },
+      { canonicalFinal: null, viewerScores: { homeScore: 21, awayScore: null } },
+    ]) {
+      const result = buildWatchPostGameResult({
+        ...input,
+        homeTeam,
+        awayTeam,
+        userTeamId: homeTeam.id,
+        week: 4,
+        phase: 'regular',
+        seasonId: '2031',
+      });
+
+      expect(result).toBeNull();
+    }
+  });
+
+  it('does not create victory, defeat, tie, archive, or Game Book data without a strict final pair', () => {
+    const result = buildWatchPostGameResult({
+      canonicalFinal: null,
+      viewerScores: {},
+      homeTeam,
+      awayTeam,
+      userTeamId: homeTeam.id,
+      week: 4,
+      phase: 'regular',
+      seasonId: '2031',
+    });
+
+    expect(result).toBeNull();
+    expect(result?.homeScore).toBeUndefined();
+    expect(result?.awayScore).toBeUndefined();
+    expect(result?.gameId).toBeUndefined();
+  });
+
+  it('keeps a genuine canonical 0-0 as a trusted tie-capable result', () => {
+    const result = buildWatchPostGameResult({
+      canonicalFinal: { home: 0, away: 0 },
+      viewerScores: {},
+      homeTeam,
+      awayTeam,
+      userTeamId: homeTeam.id,
+      week: 4,
+      phase: 'regular',
+      seasonId: '2031',
+    });
+
+    expect(result).toMatchObject({
+      homeScore: 0,
+      awayScore: 0,
+      gameId: '2031_w4_1_2',
+    });
+    expect(result.homeScore).toBe(result.awayScore);
+  });
+});

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -21,6 +21,7 @@ import FranchiseBrandHQ from './FranchiseBrandHQ.jsx';
 import JobSecurityCard from './JobSecurityCard.jsx';
 import ActivityToastStack from './ActivityToastStack.jsx';
 import GameResultSummaryCard from './GameResultSummaryCard.jsx';
+import { readStrictFinalScore } from '../../core/gameArchive.js';
 
 const BOTTOM_NAV_ITEMS = [
   { label: 'Home', route: 'HQ', icon: 'home', active: true },
@@ -96,9 +97,8 @@ function getLatestUserResultFromRecentResults(lastResults, { league, lastSimWeek
     const homeId = Number(result?.homeId ?? result?.homeTeamId ?? result?.home?.id ?? result?.home);
     const awayId = Number(result?.awayId ?? result?.awayTeamId ?? result?.away?.id ?? result?.away);
     if (homeId !== userTeamId && awayId !== userTeamId) continue;
-    const homeScore = Number(result?.homeScore ?? result?.scoreHome ?? result?.score?.home);
-    const awayScore = Number(result?.awayScore ?? result?.scoreAway ?? result?.score?.away);
-    if (!Number.isFinite(homeId) || !Number.isFinite(awayId) || !Number.isFinite(homeScore) || !Number.isFinite(awayScore)) continue;
+    const finalScore = readStrictFinalScore(result);
+    if (!Number.isFinite(homeId) || !Number.isFinite(awayId) || !finalScore) continue;
     const home = teams.find((team) => Number(team?.id) === homeId) ?? null;
     const away = teams.find((team) => Number(team?.id) === awayId) ?? null;
     return {
@@ -111,9 +111,9 @@ function getLatestUserResultFromRecentResults(lastResults, { league, lastSimWeek
       away,
       homeAbbr: result?.homeAbbr ?? home?.abbr ?? result?.homeName?.slice?.(0, 3) ?? 'HOME',
       awayAbbr: result?.awayAbbr ?? away?.abbr ?? result?.awayName?.slice?.(0, 3) ?? 'AWAY',
-      homeScore,
-      awayScore,
-      score: { home: homeScore, away: awayScore },
+      homeScore: finalScore.home,
+      awayScore: finalScore.away,
+      score: { home: finalScore.home, away: finalScore.away },
       played: true,
       week: safeNum(result?.week, fallbackWeek),
     };

--- a/src/ui/components/LiveGameViewer.jsx
+++ b/src/ui/components/LiveGameViewer.jsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState, useEffect } from 'react';
 import Scorebug from './Scorebug/Scorebug.jsx';
 import GameEventFeed from './GameEventFeed/GameEventFeed.jsx';
 import { mapArchiveEventsToLiveFeed, getNextImportantEvent } from '../../core/liveGame/liveGameEvents.js';
+import { readStrictFinalScore } from '../../core/gameArchive.js';
 import { getCurrentStandoutPlayers, summarizeGameSwing } from '../utils/liveGamePresentation.js';
 
 const SPEED_STEPS = [
@@ -17,19 +18,12 @@ const TENDENCY_CONFIG = {
   CONSERVATIVE: { label: 'Conservative', chipClass: 'conservative' },
 };
 
-function finiteScore(value) {
-  const n = Number(value);
-  return Number.isFinite(n) ? n : null;
-}
-
 export default function LiveGameViewer({ logs = [], homeTeam, awayTeam, onComplete, initialMode = 'watch', onPlaycallOverride, userTendency = 'BALANCED', finalScore = null }) {
   // Canonical final: the league-recorded result (GAME_EVENT payload). The
   // narrated play stream is a separate engine whose running score can
   // contradict it, so this is the only score the viewer will ever display.
   const canonicalFinal = useMemo(() => {
-    const home = finiteScore(finalScore?.home ?? finalScore?.homeScore);
-    const away = finiteScore(finalScore?.away ?? finalScore?.awayScore);
-    return home != null && away != null ? { home, away } : null;
+    return readStrictFinalScore({ score: finalScore });
   }, [finalScore]);
 
   const events = useMemo(() => mapArchiveEventsToLiveFeed(logs, {
@@ -157,14 +151,14 @@ export default function LiveGameViewer({ logs = [], homeTeam, awayTeam, onComple
                 </div>
               ) : (
                 <div className="watch-final-pending" data-testid="watch-final-pending">
-                  Final score is being recorded — open the Game Book for the official result.
+                  Official score is still being recorded. Game Book review unlocks after the league records both scores.
                 </div>
               )}
               <button
                 className="finish"
                 onClick={() => onComplete?.(displayScore ? { homeScore: displayScore.home, awayScore: displayScore.away } : {})}
               >
-                Open Final Game Book
+                {displayScore ? 'Open Final Game Book' : 'Continue to recovery'}
               </button>
             </div>
           ) : null}

--- a/src/ui/components/PostGameScreen.jsx
+++ b/src/ui/components/PostGameScreen.jsx
@@ -319,17 +319,21 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
 }) {
   const hColor = teamColor(homeTeam?.abbr || "HME");
   const aColor = teamColor(awayTeam?.abbr || "AWY");
+  const strictFinalScore = readStrictFinalScore({ homeScore, awayScore });
+  const hasStrictFinal = Boolean(strictFinalScore);
+  const displayHomeScore = strictFinalScore?.home ?? null;
+  const displayAwayScore = strictFinalScore?.away ?? null;
 
-  const homeWon = homeScore > awayScore;
-  const tied = homeScore === awayScore;
+  const homeWon = hasStrictFinal && displayHomeScore > displayAwayScore;
+  const tied = hasStrictFinal && displayHomeScore === displayAwayScore;
   const userIsHome = homeTeam?.id === userTeamId;
   const userIsAway = awayTeam?.id === userTeamId;
-  const userWon = (userIsHome && homeWon) || (userIsAway && !homeWon && !tied);
-  const userLost = (userIsHome && !homeWon && !tied) || (userIsAway && homeWon);
+  const userWon = hasStrictFinal && ((userIsHome && homeWon) || (userIsAway && !homeWon && !tied));
+  const userLost = hasStrictFinal && ((userIsHome && !homeWon && !tied) || (userIsAway && homeWon));
 
-  const resultColor = userWon ? "#34C759" : userLost ? "#FF453A" : "#FFD60A";
+  const resultColor = userWon ? "#34C759" : userLost ? "#FF453A" : tied ? "#FFD60A" : "var(--text-muted)";
   const resultEmoji = userWon ? "🏆" : userLost ? "😔" : tied ? "🤝" : "🏈";
-  const resultLabel = userWon ? "VICTORY!" : userLost ? "DEFEAT" : tied ? "TIE" : "FINAL";
+  const resultLabel = userWon ? "VICTORY!" : userLost ? "DEFEAT" : tied ? "TIE" : "Result pending";
 
   const [activeTab, setActiveTab] = useState("leaders"); // "leaders" | "grades"
   // Show "Game Saved ✓" for 3 seconds on mount to confirm the auto-save happened
@@ -380,13 +384,11 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
   );
   const archiveSavedRef = React.useRef(false);
   React.useEffect(() => {
-    if (archiveSavedRef.current || !boxScoreGameId || typeof onArchiveReady !== "function") return;
-    const finalScore = readStrictFinalScore({ homeScore, awayScore });
-    if (!finalScore) return;
+    if (archiveSavedRef.current || !boxScoreGameId || typeof onArchiveReady !== "function" || !strictFinalScore) return;
     archiveSavedRef.current = true;
     const recapText = notableMoments.length
       ? notableMoments.map((m) => `Q${m.quarter ?? "?"} ${m.clock ?? ""} ${m.text ?? "Momentum swing"}`).join(" ")
-      : `${awayTeam?.abbr ?? "AWY"} ${awayScore} - ${homeScore} ${homeTeam?.abbr ?? "HME"}`;
+      : `${awayTeam?.abbr ?? "AWY"} ${strictFinalScore.away} - ${strictFinalScore.home} ${homeTeam?.abbr ?? "HME"}`;
     const derivedPlayerStats = derivePlayerStatsFromLogs(logs, homeTeam?.id, awayTeam?.id);
     onArchiveReady({
       gameId: boxScoreGameId,
@@ -396,8 +398,8 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
       awayId: awayTeam?.id,
       homeAbbr: homeTeam?.abbr,
       awayAbbr: awayTeam?.abbr,
-      homeScore: finalScore.home,
-      awayScore: finalScore.away,
+      homeScore: strictFinalScore.home,
+      awayScore: strictFinalScore.away,
       recapText,
       logs,
       playerStats: derivedPlayerStats,
@@ -407,7 +409,9 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
         simOutputs: null,
       },
     });
-  }, [awayScore, awayTeam?.abbr, awayTeam?.id, boxScoreGameId, homeScore, homeTeam?.abbr, homeTeam?.id, logs, notableMoments, onArchiveReady, week]);
+  }, [awayScore, awayTeam?.abbr, awayTeam?.id, boxScoreGameId, homeScore, homeTeam?.abbr, homeTeam?.id, logs, notableMoments, onArchiveReady, strictFinalScore, week]);
+
+  const canOpenGameBook = Boolean(boxScoreGameId && hasStrictFinal);
 
   return (
     <>
@@ -458,7 +462,7 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
                   Week {week} · {phase === "playoffs" ? "Playoffs" : "Regular Season"}
                 </span>
               )}
-              {showSaved && (
+              {showSaved && hasStrictFinal && (
                 <span style={{
                   display: "inline-flex", alignItems: "center", gap: 5,
                   padding: "2px 8px",
@@ -503,14 +507,14 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
                   color: !homeWon && !tied ? aColor : "var(--text-muted)",
                   fontVariantNumeric: "tabular-nums", lineHeight: 1,
                 }}>
-                  {awayScore}
+                  {displayAwayScore ?? "—"}
                 </div>
               </div>
 
               <div style={{ textAlign: "center", padding: "0 12px" }}>
                 <div style={{ fontSize: "0.68rem", fontWeight: 800, color: "var(--text-subtle)",
                   letterSpacing: "1px", textTransform: "uppercase" }}>
-                  FINAL
+                  RESULT
                 </div>
               </div>
 
@@ -532,7 +536,7 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
                   color: homeWon ? hColor : "var(--text-muted)",
                   fontVariantNumeric: "tabular-nums", lineHeight: 1,
                 }}>
-                  {homeScore}
+                  {displayHomeScore ?? "—"}
                 </div>
               </div>
             </div>
@@ -540,21 +544,21 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
               <button
                 type="button"
                 data-testid="box-score-trigger"
-                onClick={() => boxScoreGameId && onOpenBoxScore?.(boxScoreGameId)}
-                disabled={!boxScoreGameId}
+                onClick={() => canOpenGameBook && onOpenBoxScore?.(boxScoreGameId)}
+                disabled={!canOpenGameBook}
                 style={{
-                  cursor: boxScoreGameId ? "pointer" : "not-allowed",
+                  cursor: canOpenGameBook ? "pointer" : "not-allowed",
                   fontWeight: 800,
                   fontSize: "0.8rem",
                   padding: "8px 20px",
                   borderRadius: 999,
-                  border: `1px solid ${boxScoreGameId ? "var(--accent)" : "var(--hairline)"}`,
-                  background: boxScoreGameId ? "var(--accent-muted)" : "transparent",
-                  color: boxScoreGameId ? "var(--accent)" : "var(--text-subtle)",
+                  border: `1px solid ${canOpenGameBook ? "var(--accent)" : "var(--hairline)"}`,
+                  background: canOpenGameBook ? "var(--accent-muted)" : "transparent",
+                  color: canOpenGameBook ? "var(--accent)" : "var(--text-subtle)",
                   minHeight: "var(--mobile-btn-h-compact, 38px)",
                 }}
               >
-                {boxScoreGameId ? "View Game Book ›" : "Box score unavailable"}
+                {canOpenGameBook ? "View Game Book ›" : "Official score pending"}
               </button>
             </div>
           </div>
@@ -618,7 +622,7 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
                   gameFlowSummary={gfs}
                   homeTeam={homeTeam}
                   awayTeam={awayTeam}
-                  finalScore={{ home: homeScore, away: awayScore }}
+                  finalScore={{ home: displayHomeScore, away: displayAwayScore }}
                 />
               </div>
             )}

--- a/src/ui/components/PostGameScreen.jsx
+++ b/src/ui/components/PostGameScreen.jsx
@@ -15,6 +15,7 @@ import PlayerCard from "./PlayerCard.jsx";
 import AdvancedStats from "./AdvancedStats.jsx";
 import { buildGameFlowSummary } from "../../core/sim/gameFlowSummary.js";
 import { buildReasoningBullets } from "../../core/gameSummary.js";
+import { readStrictFinalScore } from "../../core/gameArchive.js";
 import ReplayableGameFlowViewer from "./ReplayableGameFlowViewer.jsx";
 
 // ── Error boundary so a crash here never freezes the whole app ────────────────
@@ -380,6 +381,8 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
   const archiveSavedRef = React.useRef(false);
   React.useEffect(() => {
     if (archiveSavedRef.current || !boxScoreGameId || typeof onArchiveReady !== "function") return;
+    const finalScore = readStrictFinalScore({ homeScore, awayScore });
+    if (!finalScore) return;
     archiveSavedRef.current = true;
     const recapText = notableMoments.length
       ? notableMoments.map((m) => `Q${m.quarter ?? "?"} ${m.clock ?? ""} ${m.text ?? "Momentum swing"}`).join(" ")
@@ -393,8 +396,8 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
       awayId: awayTeam?.id,
       homeAbbr: homeTeam?.abbr,
       awayAbbr: awayTeam?.abbr,
-      homeScore,
-      awayScore,
+      homeScore: finalScore.home,
+      awayScore: finalScore.away,
       recapText,
       logs,
       playerStats: derivedPlayerStats,

--- a/src/ui/components/PostGameScreen.test.jsx
+++ b/src/ui/components/PostGameScreen.test.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderToString } from 'react-dom/server';
-import { cleanup, render, act } from '@testing-library/react';
+import { cleanup, fireEvent, render, act, screen } from '@testing-library/react';
 import PostGameScreen from './PostGameScreen.jsx';
 
 describe('PostGameScreen resilience', () => {
@@ -117,5 +117,59 @@ describe('PostGameScreen onArchiveReady payload', () => {
     expect(payload.playerStats).toBeDefined();
     expect(payload.playerStats.home).toEqual({});
     expect(payload.playerStats.away).toEqual({});
+  });
+
+  it('does not persist archives or allow Game Book navigation when the strict final is missing', async () => {
+    const archiveSpy = vi.fn();
+    const openSpy = vi.fn();
+    await act(async () => {
+      render(
+        <PostGameScreen
+          homeTeam={{ id: 1, abbr: 'HME', name: 'Home' }}
+          awayTeam={{ id: 2, abbr: 'AWY', name: 'Away' }}
+          homeScore={null}
+          awayScore={null}
+          userTeamId={1}
+          boxScoreGameId="pending-game"
+          logs={[]}
+          week={2}
+          onArchiveReady={archiveSpy}
+          onOpenBoxScore={openSpy}
+          onContinue={() => {}}
+        />,
+      );
+    });
+
+    expect(document.body.textContent).not.toMatch(/VICTORY|DEFEAT|\\bTIE\\b|Game saved/i);
+    expect(archiveSpy).not.toHaveBeenCalled();
+    const cta = screen.getByTestId('box-score-trigger');
+    expect(cta.disabled).toBe(true);
+    fireEvent.click(cta);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('treats a genuine 0-0 canonical result as a real tie', async () => {
+    const archiveSpy = vi.fn();
+    await act(async () => {
+      render(
+        <PostGameScreen
+          homeTeam={{ id: 1, abbr: 'HME', name: 'Home' }}
+          awayTeam={{ id: 2, abbr: 'AWY', name: 'Away' }}
+          homeScore={0}
+          awayScore={0}
+          userTeamId={1}
+          boxScoreGameId="zero-zero-game"
+          logs={[]}
+          week={2}
+          onArchiveReady={archiveSpy}
+          onContinue={() => {}}
+        />,
+      );
+    });
+
+    expect(screen.getByTestId('postgame-result-banner').textContent).toContain('TIE');
+    expect(screen.getByTestId('box-score-trigger').disabled).toBe(false);
+    expect(archiveSpy).toHaveBeenCalledOnce();
+    expect(archiveSpy.mock.calls[0][0]).toMatchObject({ homeScore: 0, awayScore: 0 });
   });
 });

--- a/src/ui/components/__tests__/LiveGameViewerTrust.test.jsx
+++ b/src/ui/components/__tests__/LiveGameViewerTrust.test.jsx
@@ -66,8 +66,12 @@ describe('LiveGameViewer — score authority', () => {
   });
 
   it('shows an honest pending note instead of a fabricated final when no canonical score exists', () => {
-    renderViewer({ initialMode: 'instant', finalScore: null });
+    const onComplete = vi.fn();
+    renderViewer({ initialMode: 'instant', finalScore: null, onComplete });
     expect(screen.getByTestId('watch-final-pending')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Open Final Game Book/i })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /Continue to recovery/i }));
+    expect(onComplete).toHaveBeenCalledWith({});
     const bug = screen.getByTestId('watch-scorebug');
     expect(bug.textContent).not.toMatch(/26|41|35/);
   });

--- a/src/ui/utils/boxScoreAccess.js
+++ b/src/ui/utils/boxScoreAccess.js
@@ -1,5 +1,5 @@
 import { buildCanonicalGameId, toTeamId } from "../../core/gameIdentity.js";
-import { normalizeArchivedGamePayload, recoverArchivedGameFromSchedule } from "../../core/gameArchive.js";
+import { normalizeArchivedGamePayload, readStrictFinalScore, recoverArchivedGameFromSchedule } from "../../core/gameArchive.js";
 import { buildBoxScoreViewModel } from "./boxScoreViewModel.js";
 
 const ARCHIVE_QUALITY_LABELS = {
@@ -17,14 +17,7 @@ function archiveQualityKey(label) {
 }
 
 function hasFinalScore(game) {
-  // Explicitly-unplayed schedule rows carry serialization-default 0-0 scores
-  // (Int32Array slots can't hold null) — never treat them as completed.
-  if (game?.played === false || game?.played === 0) return false;
-  return Boolean(
-    game?.played
-      || Number.isFinite(Number(game?.homeScore))
-      || Number.isFinite(Number(game?.awayScore)),
-  );
+  return readStrictFinalScore(game) != null;
 }
 
 export function inferCompletedGameIdentity(game, context = {}) {
@@ -46,7 +39,7 @@ export function normalizeCompletedGameRecord(game, context = {}) {
     homeId: toTeamId(game?.homeId ?? game?.home),
     awayId: toTeamId(game?.awayId ?? game?.away),
     seasonId: game?.seasonId ?? context?.seasonId ?? null,
-    week: Number(game?.week ?? context?.week ?? null),
+    week: (game?.week ?? context?.week) == null ? null : Number(game?.week ?? context?.week),
   };
 }
 
@@ -81,9 +74,10 @@ export function getArchiveQualityLabel(archiveQuality) {
 
 export function buildCompletedGamePresentation(game, context = {}) {
   const availability = getBoxScoreAvailability(game, context);
+  const finalScore = readStrictFinalScore(game);
   const away = context?.teamById?.[toTeamId(game?.awayId ?? game?.away)] ?? null;
   const home = context?.teamById?.[toTeamId(game?.homeId ?? game?.home)] ?? null;
-  const displayScoreLine = `${away?.abbr ?? "AWY"} ${game?.awayScore ?? "—"} - ${game?.homeScore ?? "—"} ${home?.abbr ?? "HME"}`;
+  const displayScoreLine = `${away?.abbr ?? "AWY"} ${finalScore?.away ?? "—"} - ${finalScore?.home ?? "—"} ${home?.abbr ?? "HME"}`;
   return {
     ...availability,
     ctaLabel: availability.canOpen

--- a/src/ui/utils/boxScoreAccess.test.js
+++ b/src/ui/utils/boxScoreAccess.test.js
@@ -59,4 +59,22 @@ describe('box score access clickthrough', () => {
     expect(driveOnly.archiveQuality).toBe('partial');
     expect(driveOnly.statusLabel).toBe('Partial detail');
   });
+
+  it('does not open pending or partial score rows via nullable/blank coercion', () => {
+    const onOpen = vi.fn();
+    const pendingRows = [
+      { gameId: '2026_w1_1_2', played: true, homeId: 1, awayId: 2, homeScore: null, awayScore: null },
+      { gameId: '2026_w1_1_2', played: true, homeId: 1, awayId: 2, homeScore: '', awayScore: '   ' },
+      { gameId: '2026_w1_1_2', played: true, homeId: 1, awayId: 2, homeScore: 17, awayScore: null },
+      { gameId: '2026_w1_1_2', played: false, homeId: 1, awayId: 2, homeScore: 0, awayScore: 0 },
+    ];
+
+    for (const game of pendingRows) {
+      const presentation = buildCompletedGamePresentation(game, { seasonId: '2026', week: 1 });
+      expect(presentation.canOpen).toBe(false);
+      expect(presentation.displayScoreLine).toBe('AWY — - — HME');
+      expect(openResolvedBoxScore(game, { seasonId: '2026', week: 1 }, onOpen)).toBe(false);
+    }
+    expect(onOpen).not.toHaveBeenCalled();
+  });
 });

--- a/src/ui/utils/boxScoreViewModel.js
+++ b/src/ui/utils/boxScoreViewModel.js
@@ -1,4 +1,4 @@
-import { mergeArchivedGameWithScheduleResult, normalizeArchivedGamePayload } from '../../core/gameArchive.js';
+import { mergeArchivedGameWithScheduleResult, normalizeArchivedGamePayload, readStrictFinalScore } from '../../core/gameArchive.js';
 import { isScoringLikeLog, normalizePlayLogEntry } from '../../core/gameEvents.js';
 import { buildGameFlowSummary } from '../../core/sim/gameFlowSummary.js';
 import { buildLeaguePlayerMap, resolvePlayerName } from './playerNameResolver.js';
@@ -67,8 +67,8 @@ function formatScoreLine(awayTeam, homeTeam, finalScore) {
 }
 
 function buildHeadline({ awayTeam, homeTeam, finalScore, status }) {
-  const away = toNum(finalScore?.away);
-  const home = toNum(finalScore?.home);
+  const away = finalScore?.away;
+  const home = finalScore?.home;
   if (away == null || home == null) return status === 'Final' ? 'Final score unavailable' : 'Game not final';
   if (away === home) return `${awayTeam?.abbr ?? 'Away'} and ${homeTeam?.abbr ?? 'Home'} finished tied`;
   const winner = away > home ? awayTeam : homeTeam;
@@ -368,8 +368,8 @@ function normalizePlayByPlayRows(payload = {}, teams = {}) {
 }
 
 function applyCloseGameLastPlays(playRows = [], finalScore = {}) {
-  const home = toNum(finalScore.home);
-  const away = toNum(finalScore.away);
+  const home = finalScore.home;
+  const away = finalScore.away;
   if (home == null || away == null || Math.abs(home - away) > 8 || playRows.length <= 5) return playRows;
   const lastFiveIds = new Set(playRows.slice(-5).map((row) => row.id));
   return playRows.map((row) => lastFiveIds.has(row.id)
@@ -427,8 +427,8 @@ function normalizeTurningPointRows({ payload = {}, scoringSummary = [], playByPl
     if (Number(row.quarter) >= 4 && row.tags?.includes('explosive')) add({ id: `turning-${row.id}`, quarter: row.quarter, clock: row.clock, teamAbbr: row.teamAbbr, text: row.text });
   });
 
-  const home = toNum(finalScore.home);
-  const away = toNum(finalScore.away);
+  const home = finalScore.home;
+  const away = finalScore.away;
   if (inferred.length === 0 && home != null && away != null && Math.abs(home - away) <= 8) {
     playByPlayRows.filter((row) => row.isKey).slice(-2).forEach((row) => add({ id: `turning-close-${row.id}`, quarter: row.quarter, clock: row.clock, teamAbbr: row.teamAbbr, text: row.text }));
   }
@@ -500,8 +500,9 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
   }
   const homeId = payload?.homeId ?? payload?.home;
   const awayId = payload?.awayId ?? payload?.away;
-  const homeScore = toNum(payload?.homeScore);
-  const awayScore = toNum(payload?.awayScore);
+  const strictFinalScore = readStrictFinalScore(payload);
+  const homeScore = strictFinalScore?.home ?? null;
+  const awayScore = strictFinalScore?.away ?? null;
   const quarterScores = payload?.quarterScores ?? null;
   const scoringSummary = normalizeScoringSummary(payload?.scoringSummary);
   const teamStats = payload?.teamStats ?? payload?.stats?.team ?? {};

--- a/src/ui/utils/boxScoreViewModel.test.js
+++ b/src/ui/utils/boxScoreViewModel.test.js
@@ -59,6 +59,22 @@ describe('buildBoxScoreViewModel', () => {
     expect(vm.turningPointRows).toEqual([]);
   });
 
+  it('does not coerce null or blank finals into 0-0 Game Book scores', () => {
+    for (const game of [
+      { played: true, homeScore: null, awayScore: null },
+      { played: true, homeScore: '', awayScore: '   ' },
+      { played: true, homeScore: 21, awayScore: null },
+      { played: false, homeScore: 0, awayScore: 0 },
+    ]) {
+      const vm = buildBoxScoreViewModel({ game });
+      expect(vm.archiveQuality).toBe('Missing detail');
+      expect(vm.availableData.finalScore).toBe(false);
+      expect(vm.finalScore).toEqual({ home: null, away: null });
+      expect(vm.finalScoreLine).toBe('AWAY — - — HOME');
+      expect(vm.headlineSummary).toBe(game.played === false ? 'Game not final' : 'Final score unavailable');
+    }
+  });
+
   it('builds factual game story bullets from available data only', () => {
     const vm = buildBoxScoreViewModel({ game: { homeId: 1, awayId: 2, homeScore: 17, awayScore: 20, teamStats: { home: { turnovers: 2, totalYards: 290 }, away: { turnovers: 0, totalYards: 350 } }, playerStats: { away: { 1: { name: 'A QB', stats: { passYd: 294, passTD: 3 } } }, home: {} } } });
     const story = buildGameBookStory(vm).join(' ');

--- a/src/ui/utils/canonicalCompletedGame.js
+++ b/src/ui/utils/canonicalCompletedGame.js
@@ -1,3 +1,5 @@
+import { readStrictFinalScore } from '../../core/gameArchive.js';
+
 /**
  * resolveCanonicalCompletedGame
  *
@@ -16,19 +18,8 @@
  * Returns null only when no game reference is available at all.
  */
 
-function extractScoreFields(game) {
-  const home = Number(game?.homeScore ?? game?.scoreHome ?? game?.score?.home);
-  const away = Number(game?.awayScore ?? game?.scoreAway ?? game?.score?.away);
-  return { home, away };
-}
-
 function hasValidFinalScore(game) {
-  if (!game || typeof game !== 'object') return false;
-  // Rows explicitly marked unplayed carry serialization-default 0-0 scores
-  // (schedule buffers can't hold null) — never treat them as a real final.
-  if (game.played === false || game.played === 0) return false;
-  const { home, away } = extractScoreFields(game);
-  return Number.isFinite(home) && Number.isFinite(away);
+  return readStrictFinalScore(game) != null;
 }
 
 export function resolveCanonicalCompletedGame({ league, gameId, scheduleGame, archivedGame } = {}) {
@@ -42,7 +33,7 @@ export function resolveCanonicalCompletedGame({ league, gameId, scheduleGame, ar
     // Archive has a valid final score — it wins absolutely for score fields.
     // Always normalize homeScore/awayScore so callers get consistent field names
     // regardless of whether the archive used scoreHome, score.home, etc.
-    const { home: archivedHome, away: archivedAway } = extractScoreFields(archived);
+    const { home: archivedHome, away: archivedAway } = readStrictFinalScore(archived);
     const meta = schedule ?? byId;
     if (!meta) {
       // An archive-validated final is by definition a played game.


### PR DESCRIPTION
### Motivation
- Loose `Number(...)` coercion could turn `null`, `''`, or whitespace into numeric `0`, causing pending or partial score rows to be treated as fabricated 0–0 finals. 
- The intent is to establish a single strict final-score contract so only complete, explicit finals are trusted across archive recovery, completed-game resolution, Game Book rendering, HQ surfaces, live-viewer completion, and postgame persistence. 

### Description
- Added a shared strict parser/reader `parseStrictFinalScore` / `readStrictFinalScore` in `src/core/gameArchive.js` that accepts only finite numbers or non-blank numeric strings and requires both sides to exist. 
- Applied the strict-final contract across archive and schedule flows by updating `normalizeArchivedGamePayload`, `classifyArchiveQuality`, `summarizeArchiveDefects`, and `recoverArchivedGameFromSchedule` to use the reader so incomplete scores are treated as missing. 
- Updated UI and view-model surfaces to rely on the strict contract, including `src/ui/utils/boxScoreViewModel.js`, `src/ui/utils/boxScoreAccess.js`, `src/ui/utils/canonicalCompletedGame.js`, `src/ui/App.jsx`, `src/ui/components/PostGameScreen.jsx`, and `src/ui/components/FranchiseHQ.jsx`, so Game Book availability, display score lines, postgame persistence, and HQ last-result rendering do not display fabricated finals. 
- Added regression tests to assert pending/blank/one-sided scores are treated as unavailable in `src/core/__tests__/gameArchive.test.js`, `src/ui/utils/boxScoreAccess.test.js`, and `src/ui/utils/boxScoreViewModel.test.js`. 

### Testing
- Ran targeted static checks and unit tests: `node --check` on updated plain `.js` helpers and `npx vitest run src/core/__tests__/gameArchive.test.js src/ui/utils/boxScoreAccess.test.js src/ui/utils/boxScoreViewModel.test.js`, which all passed. 
- Ran full unit suite with `npm run test:unit` and observed all tests passing (full Vitest run completed successfully). 
- Built production bundle with `npm run build`, which completed successfully (Vite build warnings about large chunks are unchanged and expected). 
- Note: invoking `node --check` on `.jsx` modules produced `ERR_UNKNOWN_FILE_EXTENSION` (JSX files are validated by the test/build tools), so that check was skipped for `.jsx` files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a557dd078dc832daf14985420af1cae)