### PR TITLE
Daily QA Regression Report

### DIFF
--- a/tests/e2e/league_pulse_smoke.spec.js
+++ b/tests/e2e/league_pulse_smoke.spec.js
@@ -13,8 +13,17 @@ test('league pulse appears after one weekly advance and opens full timeline', as
 
   const startWeek = await page.evaluate(() => window?.state?.league?.week ?? 1);
   await page.getByTestId('advance-week-cta').click();
-  await page.getByTestId('gate-advance-anyway-btn').click({ timeout: 2000 }).catch(() => {});
-  await page.getByRole('button', { name: /Simulate \(Skip\)/i }).click({ timeout: 10000 }).catch(() => {});
+
+  const gateAdvanceBtn = page.getByTestId('gate-advance-anyway-btn');
+  if (await gateAdvanceBtn.isVisible().catch(() => false)) {
+    await gateAdvanceBtn.click({ timeout: 2000 });
+  }
+
+  const skipBtn = page.getByRole('button', { name: /Simulate \(Skip\)/i });
+  if (await skipBtn.isVisible().catch(() => false)) {
+    await skipBtn.click({ timeout: 10000 });
+  }
+
   await page.waitForFunction(
     (baseline) => {
       const state = window?.state;

--- a/tests/e2e/mobile_game_day_trust.spec.js
+++ b/tests/e2e/mobile_game_day_trust.spec.js
@@ -33,7 +33,10 @@ async function advanceIntoUserGamePrompt(page) {
   } else {
     await page.evaluate(() => window.handleGlobalAdvance?.());
   }
-  await page.getByRole('button', { name: /Advance anyway/i }).click({ timeout: 1500 }).catch(() => {});
+  const advanceAnywayBtn = page.getByRole('button', { name: /Advance anyway/i });
+  if (await advanceAnywayBtn.isVisible().catch(() => false)) {
+    await advanceAnywayBtn.click({ timeout: 1500 });
+  }
   await page.getByRole('button', { name: /Watch \(Broadcast Pace\)/ }).waitFor({ state: 'visible', timeout: 45000 });
 }
 

--- a/tests/e2e/offseasonFaFlow.spec.js
+++ b/tests/e2e/offseasonFaFlow.spec.js
@@ -215,7 +215,11 @@ test('offseason FA loop: submit → reserve cap → withdraw → strong offer �
         phase: p.phase,
       };
     }, target.id);
-    await page.waitForFunction(() => !window?.state?.busy && !window?.state?.simulating, { timeout: SMOKE_TIMEOUT }).catch(() => {});
+    try {
+      await page.waitForFunction(() => !window?.state?.busy && !window?.state?.simulating, { timeout: SMOKE_TIMEOUT });
+    } catch (e) {
+      console.warn("waitForFunction timed out waiting for state to not be busy/simulating.");
+    }
     if (resolution.status !== 'pending' || resolution.phase !== 'free_agency') break;
   }
 

--- a/tests/e2e/simulateWeek.spec.js
+++ b/tests/e2e/simulateWeek.spec.js
@@ -53,7 +53,10 @@ test('simulate week produces non-zero box score and standings win', async ({ pag
     await closeViewer.click();
   }
   if (!(await page.getByTestId('franchise-hq').isVisible({ timeout: 3000 }).catch(() => false))) {
-    await page.getByRole('button', { name: /^Back to HQ$/i }).click().catch(() => {});
+    const backToHqBtn = page.getByRole('button', { name: /^Back to HQ$/i });
+    if (await backToHqBtn.isVisible().catch(() => false)) {
+      await backToHqBtn.click();
+    }
   }
   await expect(page.getByTestId('franchise-hq')).toBeVisible({ timeout: SMOKE_TIMEOUT });
 


### PR DESCRIPTION
Daily QA regression pass results. The build is stable, but test integrity issues were found where `.catch(() => {})` was used inappropriately to swallow UI assertions in Playwright tests. An implementation prompt to fix this has been provided in the report.

---
*PR created automatically by Jules for task [8763023488421416711](https://jules.google.com/task/8763023488421416711) started by @rbcati*