### PR TITLE
feat: improve early season stakes and narrative context

### DIFF
--- a/src/core/game-runner.js
+++ b/src/core/game-runner.js
@@ -167,6 +167,20 @@ class GameRunner {
             }
         }
 
+        // Undefeated / Winless early season
+        if (stakes === 0 && week >= 3 && week <= 5) {
+            const wins = team.wins || team.record?.w || 0;
+            const losses = team.losses || team.record?.l || 0;
+
+            if (wins === 0 && losses >= 2) {
+                // Pressure of 0-2, 0-3...
+                stakes = 80 + (losses * 2);
+            } else if (losses === 0 && wins >= 2) {
+                // Hype of 2-0, 3-0...
+                stakes = 75 + (wins * 2);
+            }
+        }
+
         // 2. Playoff Bubble
         if (stakes === 0 && week >= 13) {
             const confTeams = league.teams.filter(t => t.conf === team.conf).sort((a, b) => ((b.wins || b.record?.w || 0) - (a.wins || a.record?.w || 0)));

--- a/src/core/simulation/gameSummaryBuilder.js
+++ b/src/core/simulation/gameSummaryBuilder.js
@@ -233,11 +233,11 @@ export function generatePostGameCallbacks(context, stats, homeScore, awayScore) 
       }
     } else {
       if (isBlowout) {
-        callbacks.push(`A devastating, humiliating ${scoreDiff}-point blowout defeat when the stakes couldn't have been higher. The locker room is completely stunned, and the owner will demand answers.`);
+        callbacks.push(`A devastating, humiliating ${scoreDiff}-point blowout defeat in a massive game. The locker room is completely stunned, and the owner will demand answers.`);
       } else if (isClose) {
-        callbacks.push(`An agonizing, heart-breaking ${scoreDiff}-point loss in a thriller with their backs against the wall. The locker room is dead silent.`);
+        callbacks.push(`An agonizing, heart-breaking ${scoreDiff}-point loss in a thriller in a high stakes matchup. The locker room is dead silent.`);
       } else {
-        callbacks.push(`A devastating, crushing ${scoreDiff}-point defeat when the stakes couldn't have been higher. A massive missed opportunity for ${userAbbr}.`);
+        callbacks.push(`A devastating, crushing ${scoreDiff}-point defeat in a massive game. A massive missed opportunity for ${userAbbr}.`);
       }
     }
   }


### PR DESCRIPTION
feat: improve early season stakes and narrative context

- Add tension recognition for winless/undefeated early streaks in game-runner
- Improve repetitive high-stakes phrasing in game summary builder

---
*PR created automatically by Jules for task [10615066345777681655](https://jules.google.com/task/10615066345777681655) started by @rbcati*