### PR TITLE
Make postgame surfaces consume one canonical game result

### DIFF
--- a/docs/canonical-game-engine-revival-v1.md
+++ b/docs/canonical-game-engine-revival-v1.md
@@ -1,0 +1,245 @@
+# Canonical Game Engine Revival V1 (#1696)
+
+## 1. Executive summary
+
+One matchup previously produced multiple incompatible versions of the same game.
+The official final score came from the **drive engine** (`buildDriveBasedSummary`),
+but the postgame **Leaders** and **Grades** surfaces were computed from the
+**narrated play-by-play stream** (`simulateFullGame` → `playLogs` / `liveStats`),
+which selects a quarterback at random on every drop-back and counts each log
+reference as a "snap". The result was the screenshot defect: three quarterbacks
+rotating through tiny workloads (~183 combined passing yards) under a
+`NYJ 39 – BAL 23` scoreboard, one-catch receivers stamped "Elite"/"Star", "PFF"
+badges, and mixed-team rows.
+
+This PR makes every factual postgame surface consume **one canonical player box
+score** — the same authority the score is consistent with — and removes the
+external-brand grade styling, the fake snap counts, and the mixed-team rows. It
+also closes a genuine stat-generation gap where the QB's passing line did not
+reconcile with the receivers who caught the passes.
+
+The change is a **stat-authority repair**, not yardage tuning. No score is
+altered after the fact; the drive engine remains the scoring authority.
+
+## 2. Screenshot evidence
+
+Two attached screenshots (mobile + desktop) show the postgame screen for
+`NYJ 39 – BAL 23`, Week 6, with:
+
+- heading "PFF-STYLE PERFORMANCE GRADES" and "PFF" stamped on every badge;
+- three QBs (Parker Taylor 9/10·84, Greg Moore 5/5·51, Logan Mitchell 6/7·48)
+  each with "N snaps";
+- WR/TE rows with `1/1 · 12–22 yds` graded "Star";
+- players from both teams intermixed with no team label.
+
+## 3. Current multi-engine authority map
+
+| Stage | Producer | Authoritative? | Independent RNG? | Consumers (before) |
+|---|---|---|---|---|
+| Narrated full-game loop | `simulateFullGame` (`simulation/index.js`) | No (presentation) | Yes | `playLogs`, `liveStats` |
+| Drive-based summary | `buildDriveBasedSummary` (`driveEngine.js`) | **Yes** — score, TD/FG/XP/2-pt, team drive stats | Yes (seeded) | final score, standings, GAME_EVENT |
+| Player box score | `generateStatsForTeam` → `generate*Stats` | **Yes** — player lines, keyed to drive-engine TD/FG counts | Yes | `res.boxScore`, season/career accumulation |
+| Scoring summary / quarter scores | `buildScoringSummaryFromSimulation` | Derived from **narration** logs | — | Game Book timeline |
+
+The final score (drive engine) and the player box score are the two
+authoritative producers. `liveStats`/`playLogs` are a **narration layer** that
+independently re-rolls players per play and does not agree with either.
+
+## 4. Reproduction seed and mismatch
+
+Deterministic fixture (`src/core/__tests__/simulation/canonicalGameAuthority.test.js`,
+seed `6`, `NYJ` vs `BAL`, near-identical to the screenshot's high-scoring game):
+
+```
+NYJ 41 - BAL 33
+narrated liveStats QBs (6): 11/13·39, 6/9·21, 2/3·6, 9/11·53, 2/2·4, 5/6·61   sum = 184 passing yards
+canonical box score QBs (2): 20/28·251 (NYJ starter), 26/35·302 (BAL starter)  sum = 553 passing yards
+```
+
+The narration shows **six** quarterbacks summing to **184** passing yards
+(matching the screenshot's "~183"); the canonical box score shows **one starter
+per team** with realistic full workloads.
+
+## 5. Narrated score vs official score
+
+The drive engine owns the score; the narration's running score is a separate
+accumulation and is never treated as the result (already enforced by #1692
+strict final-score parsing and #1690 honest placeholders — both preserved).
+
+## 6. Narrated stats vs canonical stats
+
+Narrated `liveStats` is produced by `pickStarterWeighted(...)` **per play**, so a
+healthy backup can take snaps on any drop-back. The canonical box score assigns
+the starter a 100% workload share unless an in-game injury transfers a share to
+the backup (`processPositionGroup(qbs, …, [1.0], …)`). The screenshot's three-QB
+rotation is purely a narration artifact.
+
+## 7. First divergence point
+
+The divergence begins the moment the postgame UI reads `logs`/`liveStats`
+(`AdvancedStats.computeGrades(logs)` and `PostGameScreen.useGameLeaders(logs)`)
+instead of `res.boxScore`. The worker's `handleWatchGame` emitted `PLAY_LOGS`
+with `playLogs` + `liveStats` but **never forwarded the canonical box score**, so
+the UI had no canonical source to consume.
+
+## 8. Chosen canonical game package
+
+The existing committed result already carries a canonical package
+(`commitGameResult` → `resultObj`): `boxScore { home, away }`, `teamStats`,
+`scoringSummary`, `quarterScores`, `driveSummary`, `playLogs`, `recapText`,
+`gameReasoningFlags`, `simSeed`. We **reuse** it — no competing schema was
+introduced. The only transport change is that `res.boxScore` and `res.teamStats`
+are now delivered to the postgame UI alongside the (presentation-only) logs.
+
+## 9. Score reconciliation rules
+
+`reconcileScoreBreakdown` (`gameStatReconciliation.js`) proves:
+
+```
+points = 6·(offTDs + defTDs + stTDs) + xpMade + 2·twoPtMade + 3·FGs + 2·safeties == finalScore
+```
+
+No TD is assumed to be worth 7; missed XPs, two-point tries, safeties, and
+defensive/special-teams scores are counted explicitly.
+
+## 10. Team-stat reconciliation rules
+
+Team offensive totals are the sum of the players' canonical lines
+(`deriveCanonicalTeamSideStats`). Interceptions thrown (passer rows) and
+interceptions made (defender rows) are kept apart so takeaways never cancel
+giveaways.
+
+## 11. Player-stat reconciliation rules
+
+New invariant (was **violated** on `main`): the QB passing line is re-derived
+from actual receiving production after stat generation, so:
+
+```
+sum(all receptions) == sum(QB passComp)
+sum(all recYd)      == sum(QB passYd)
+sum(recTD)          == sum(QB passTD)   (already reconciled via TD distribution)
+```
+
+This closed a ~100-yard hidden gap (e.g. seed 6 NYJ: QB 148 vs receivers 251 →
+now 251 == 251). The re-derivation is deterministic (no new RNG draws) and does
+not change the score. `completionPct`/`passerRating` are recomputed from the
+reconciled line. Gross vs net passing yards: player passing yards are **gross**
+(sacks are tracked separately as `sacked`/`sacksAllowed`); documented, not forced
+to equal net.
+
+## 12. QB participation policy
+
+- The designated starter (`groups.QB[0]`) receives the normal workload share
+  (`[1.0]`).
+- A backup receives meaningful attempts only on an in-game injury
+  (`rollInGameInjury` → `resolveInjurySubstitutionShare`).
+- QB selection does not change per play in the canonical box score.
+- Depth-chart authority is unchanged.
+
+## 13. Grade methodology and sample protection
+
+`gamePerformanceGrades.js` (pure, deterministic, position-aware, bounded
+`[0,100]`):
+
+- raw grade from canonical rate stats per position;
+- **confidence-weighted shrinkage** toward a neutral baseline (60):
+  `overall = baseline + (raw − baseline) · min(1, volume/fullSample)`;
+- `Limited` tier below a per-position minimum sample; `Star`/`Elite` gated behind
+  near-full participation, so one target/carry can never present as Elite;
+- players with no honest production metric (bare OL) are omitted, not fabricated.
+
+## 14. UI terminology changes
+
+- "PFF-Style Performance Grades" → "Game Performance Grades" with the subtitle
+  "In-game estimate from simulated production & participation".
+- "PFF" badge stamp removed (grade number only).
+- "N snaps" removed; rows show an honest participation metric (`att`, `touches`,
+  `tgt`, `inv`) drawn from canonical counts, or nothing when none is honest.
+
+## 15. Team-filter behavior
+
+Every grade row is tagged with its team. A team filter defaults to the user's
+team (starred), with the opponent and an "All" view available; an
+Offense/Defense sub-filter never hides team ownership. Leaders rows also carry a
+team tag.
+
+## 16. Archive changes
+
+`PostGameScreen`'s archive payload now persists the **canonical** `playerStats`
+(never narration-derived totals). When canonical stats are unavailable it stores
+empty sides rather than recounting log references. The season/batch archive path
+already stored `result.boxScore`; both paths now agree.
+
+## 17. Save/reload result
+
+The Game Book (`boxScoreViewModel`) already consumes the archived canonical
+`playerStats`; because the archive now stores the same canonical box score the
+PostGameScreen shows, opening the Game Book no longer swaps to a different set of
+totals. Legacy archives remain readable and fall back to an honest limited-detail
+state.
+
+## 18. Season-stat accumulation result
+
+Unchanged and still committed exactly once: `commitGameResult` accumulates
+`player.stats.game` into season/career via `accumulateStats` with a per-game
+`_processedGameIds` guard. The postgame archive write is presentation persistence
+only and never re-adds to season totals. The QB reconciliation mutates
+`player.stats.game` **before** accumulation, so season totals inherit the
+reconciled (consistent) line.
+
+## 19. Determinism result
+
+No `Math.random`, time seeds, or reroll loops were added. The QB↔receiver
+reconciliation performs zero RNG draws (pure reassignment of already-drawn
+values), so seeded scores and drive outcomes are byte-for-byte unchanged. Only
+the QB's displayed completions/yards change — intentionally, to reconcile.
+
+## 20. Plausibility matrix
+
+Across seeds `[6, 39, 123, 777, 2026, 4242, 8888]` (low/avg/high/blowout/close):
+one starter QB per team, passing reconciles to receiving for both teams, scores
+non-negative and internally consistent. See the regression suite.
+
+## 21. Files changed
+
+- `src/core/simulation/index.js` — QB↔receiver passing reconciliation.
+- `src/core/simulation/gameStatReconciliation.js` — new pure reconciliation invariants.
+- `src/ui/utils/gamePerformanceGrades.js` — new canonical grade module.
+- `src/ui/components/AdvancedStats.jsx` — rewritten to canonical box score + team filter + no PFF/snaps.
+- `src/ui/components/PostGameScreen.jsx` — canonical leaders + canonical archive; log-derivation removed.
+- `src/worker/worker.js` — `PLAY_LOGS` now carries `playerStats`/`teamStats`.
+- `src/worker/workerApi.js`, `src/ui/hooks/useWorker.js`, `src/ui/App.jsx` — plumb canonical stats to the UI.
+
+## 22. Tests added
+
+- `src/ui/utils/gamePerformanceGrades.test.js`
+- `src/ui/components/__tests__/AdvancedStatsCanonical.test.jsx`
+- `src/core/__tests__/simulation/canonicalGameAuthority.test.js`
+- Updated `PostGameScreen.test.jsx`, `PostGameMobilePolish.test.jsx`.
+
+## 23. Explicit untouched systems
+
+Schedule generation, standings rules, playoff qualification, roster
+construction, contracts, free agency, draft, progression, retirement, salary
+cap, award formulas, #1692 strict final-score parsing, and #1690 honest score
+placeholders are all unchanged.
+
+## 24. Remaining canonical play-by-play limitations
+
+The **scoring summary** and **quarter scores** are still derived from the
+narration stream (`buildScoringSummaryFromSimulation`), whose per-quarter
+attribution can lag the authoritative drive-engine total. Postgame does not
+present these as authoritative (it shows the canonical final score and
+presentation-only key moments), and `reconcileQuarterTotals` is provided to flag
+any gap. A fully canonical play-by-play with `scoreAfter` events is deferred.
+
+## 25. Recommended #1697 scope
+
+**#1697 — Canonical Play-by-Play & Score-After Events V1**: have the drive engine
+emit a canonical event ledger (`{ eventId, driveId, sequence, quarter,
+possessionTeamId, eventType, points, scoreAfter{home,away},
+primaryPlayerId, secondaryPlayerId, text }`), derive the scoring summary and
+quarter scores from that ledger (so quarter totals equal the final score by
+construction), let the Live scorebug update only from canonical score-after
+events, and reduce `simulateFullGame` narration to formatting canonical events.
+This retires the last narration-derived factual surface.

--- a/docs/canonical-game-engine-revival-v1.md
+++ b/docs/canonical-game-engine-revival-v1.md
@@ -1,4 +1,8 @@
-# Canonical Game Engine Revival V1 (#1696)
+# Canonical Game Engine Revival V1 (#1698)
+
+> PR numbering note: this work ships as **#1698**. The follow-up for canonical
+> play-by-play / score-after events is **#1699** (#1696 and #1697 are already
+> occupied).
 
 ## 1. Executive summary
 
@@ -84,12 +88,21 @@ the UI had no canonical source to consume.
 
 ## 8. Chosen canonical game package
 
-The existing committed result already carries a canonical package
-(`commitGameResult` → `resultObj`): `boxScore { home, away }`, `teamStats`,
-`scoringSummary`, `quarterScores`, `driveSummary`, `playLogs`, `recapText`,
-`gameReasoningFlags`, `simSeed`. We **reuse** it — no competing schema was
-introduced. The only transport change is that `res.boxScore` and `res.teamStats`
-are now delivered to the postgame UI alongside the (presentation-only) logs.
+The existing committed result already carries the package (`commitGameResult` →
+`resultObj`); we **reuse** it — no competing schema. The **claimed canonical
+(reconciled) surface** of this PR is:
+
+- `finalScore` (drive engine — authority for the score);
+- `boxScore { home, away }` (per-player lines — authority for all player stats);
+- `teamStats { home, away }` (team totals **derived from the player box score**,
+  §10).
+
+Explicitly **NOT** claimed as canonical/reconciled in #1698:
+`scoringSummary`, `quarterScores`, `driveSummary`, and `playLogs` remain
+**narration-derived presentation data**. They are shipped in the package for the
+Game Book story layer but are not asserted to reconcile to the final score
+(§24). The transport change is that `res.boxScore` and `res.teamStats` are now
+delivered to the postgame UI alongside the presentation-only logs.
 
 ## 9. Score reconciliation rules
 
@@ -104,10 +117,21 @@ defensive/special-teams scores are counted explicitly.
 
 ## 10. Team-stat reconciliation rules
 
-Team offensive totals are the sum of the players' canonical lines
-(`deriveCanonicalTeamSideStats`). Interceptions thrown (passer rows) and
-interceptions made (defender rows) are kept apart so takeaways never cancel
-giveaways.
+**One yardage authority: the player box score.** `deriveCanonicalTeamSideStats`
+now derives team pass/rush yards, attempts, completions, and pass/rush TDs from
+the **sum of the players' canonical lines** whenever offensive player rows exist
+— the drive engine's independent yardage estimate is used only as a legacy
+fallback when a record has team stats but no box score. Previously the team
+totals came from the drive engine while player totals came from the box score,
+so `result.teamStats` and `result.boxScore` disagreed by up to ~198 passing
+yards and by whole passing TDs. Per the guardrails we do **not** rescale player
+yards to hit a drive total; instead the team total *is* the player sum, so the
+two agree by construction. Verified by `reconcilePlayerToTeam` against the real
+`result.boxScore` / `result.teamStats` across the seed matrix (§22). Drive-only
+fields the box score can't supply (first downs, third down, red zone, time of
+possession, penalties) still come from the drive engine. Interceptions thrown
+(passer rows) and interceptions made (defender rows) are kept apart so takeaways
+never cancel giveaways.
 
 ## 11. Player-stat reconciliation rules
 
@@ -127,12 +151,21 @@ reconciled line. Gross vs net passing yards: player passing yards are **gross**
 (sacks are tracked separately as `sacked`/`sacksAllowed`); documented, not forced
 to equal net.
 
+**Passing-TD allocation.** A passing TD equals a receiving TD, so the team's
+passing-TD total is `sum(recTD)`. It is now split across the passing QBs by the
+**same reconciled completion share** used for attempts/completions/yards — an
+injury-substituted backup receives a proportional share of passing TDs instead
+of the starter being credited with the backup's touchdowns (regression: forced
+QB injury, §22).
+
 ## 12. QB participation policy
 
 - The designated starter (`groups.QB[0]`) receives the normal workload share
   (`[1.0]`).
 - A backup receives meaningful attempts only on an in-game injury
-  (`rollInGameInjury` → `resolveInjurySubstitutionShare`).
+  (`rollInGameInjury` → `resolveInjurySubstitutionShare`), and the substituted
+  backup's attempts, completions, yards, **and passing TDs** all follow the same
+  workload split (regression covers a forced QB injury end to end, §22).
 - QB selection does not change per play in the canonical box score.
 - Depth-chart authority is unchanged.
 
@@ -202,7 +235,8 @@ non-negative and internally consistent. See the regression suite.
 
 ## 21. Files changed
 
-- `src/core/simulation/index.js` — QB↔receiver passing reconciliation.
+- `src/core/simulation/index.js` — QB↔receiver passing reconciliation + passing-TD workload split.
+- `src/core/simulation/gameSummaryBuilder.js` — team totals derive from the player box score (one yardage authority).
 - `src/core/simulation/gameStatReconciliation.js` — new pure reconciliation invariants.
 - `src/ui/utils/gamePerformanceGrades.js` — new canonical grade module.
 - `src/ui/components/AdvancedStats.jsx` — rewritten to canonical box score + team filter + no PFF/snaps.
@@ -212,9 +246,13 @@ non-negative and internally consistent. See the regression suite.
 
 ## 22. Tests added
 
-- `src/ui/utils/gamePerformanceGrades.test.js`
-- `src/ui/components/__tests__/AdvancedStatsCanonical.test.jsx`
-- `src/core/__tests__/simulation/canonicalGameAuthority.test.js`
+- `src/ui/utils/gamePerformanceGrades.test.js` — deterministic/bounded grades + small-sample protection.
+- `src/ui/components/__tests__/AdvancedStatsCanonical.test.jsx` — no PFF/snaps, team attribution, filters.
+- `src/core/__tests__/simulation/canonicalGameAuthority.test.js` — QB participation; **real result-package
+  `reconcilePlayerToTeam(res.boxScore, res.teamStats)` across the seed matrix**; one-yardage-authority equality;
+  **forced-QB-injury regression** (attempts/completions/yards/passing-TD split reconciles); grade source.
+- `src/ui/components/__tests__/CanonicalPostgameIntegration.test.jsx` — **integration**: `simulateBatch → worker
+  PLAY_LOGS payload → PostGameScreen → archive → Game Book view model` shows the same passing leader and final score.
 - Updated `PostGameScreen.test.jsx`, `PostGameMobilePolish.test.jsx`.
 
 ## 23. Explicit untouched systems
@@ -228,18 +266,21 @@ placeholders are all unchanged.
 
 The **scoring summary** and **quarter scores** are still derived from the
 narration stream (`buildScoringSummaryFromSimulation`), whose per-quarter
-attribution can lag the authoritative drive-engine total. Postgame does not
-present these as authoritative (it shows the canonical final score and
-presentation-only key moments), and `reconcileQuarterTotals` is provided to flag
-any gap. A fully canonical play-by-play with `scoreAfter` events is deferred.
+attribution can lag the authoritative drive-engine total. They are therefore
+**explicitly excluded from #1698's canonical/reconciled scope** (§8): postgame
+shows the canonical final score and presentation-only key moments, and the
+`reconcileQuarterTotals` helper is provided so the gap can be *surfaced* rather
+than silently claimed as reconciled. A fully canonical play-by-play with
+`scoreAfter` events is deferred to the follow-up below.
 
-## 25. Recommended #1697 scope
+## 25. Recommended #1699 scope
 
-**#1697 — Canonical Play-by-Play & Score-After Events V1**: have the drive engine
-emit a canonical event ledger (`{ eventId, driveId, sequence, quarter,
-possessionTeamId, eventType, points, scoreAfter{home,away},
-primaryPlayerId, secondaryPlayerId, text }`), derive the scoring summary and
-quarter scores from that ledger (so quarter totals equal the final score by
-construction), let the Live scorebug update only from canonical score-after
+**#1699 — Canonical Play-by-Play & Score-After Events V1** (numbered #1699
+because #1696 and #1697 are occupied): have the drive engine emit a canonical
+event ledger (`{ eventId, driveId, sequence, quarter, possessionTeamId,
+eventType, points, scoreAfter{home,away}, primaryPlayerId, secondaryPlayerId,
+text }`), derive the scoring summary and quarter scores from that ledger (so
+quarter totals equal the final score by construction — bringing them into
+canonical scope), let the Live scorebug update only from canonical score-after
 events, and reduce `simulateFullGame` narration to formatting canonical events.
 This retires the last narration-derived factual surface.

--- a/src/core/__tests__/simulation/canonicalGameAuthority.test.js
+++ b/src/core/__tests__/simulation/canonicalGameAuthority.test.js
@@ -1,0 +1,186 @@
+/**
+ * Canonical Game Authority — Revival V1 regression suite
+ * ──────────────────────────────────────────────────────
+ * Locks in the fix for the "one matchup, multiple incompatible games" fracture:
+ * the postgame factual surfaces (player stats, leaders, grades) must consume the
+ * CANONICAL player box score, never the narrated liveStats / play-log stream.
+ *
+ * Characterization (before-fix behavior, still true of the narration stream):
+ *   • liveStats rotates the QB every drop-back → many QBs, tiny workloads whose
+ *     passing yards badly undercount the real game.
+ *
+ * Canonical guarantees (after-fix, asserted here):
+ *   • the box score attributes passing to a single starter per team;
+ *   • player totals reconcile internally (pass==rec yards/TDs, comp==rec);
+ *   • the score breakdown sums to the final score;
+ *   • grades derive from canonical stats, not narration references.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Utils as U } from '../../utils.js';
+import { simGameStats } from '../../simulation/index.js';
+import {
+  reconcilePlayerIdentities,
+  reconcileScoreBreakdown,
+  sumBoxScoreSide,
+} from '../../simulation/gameStatReconciliation.js';
+import { gradeTeamBoxScore } from '../../../ui/utils/gamePerformanceGrades.js';
+
+function makePlayer(id, pos, ovr = 75) {
+  const ratings = {
+    QB: { throwPower: 82, throwAccuracy: 84, awareness: 82, speed: 70, agility: 68 },
+    RB: { speed: 88, trucking: 80, juking: 84, awareness: 72 },
+    WR: { speed: 90, awareness: 80, catching: 88 },
+    TE: { speed: 76, awareness: 76, catching: 80 },
+    OL: { passBlock: 80, runBlock: 80 },
+    DL: { passRushPower: 80, passRushSpeed: 78, tackle: 76, strength: 80 },
+    LB: { tackle: 80, awareness: 76, speed: 76, strength: 76 },
+    CB: { speed: 86, awareness: 76, agility: 82 },
+    S: { speed: 82, awareness: 78, tackle: 74 },
+    K: { kickPower: 82, kickAccuracy: 82 },
+    P: { kickPower: 80 },
+  };
+  return { id: `${id}`, pos, ovr, name: `${pos} ${id}`, ratings: ratings[pos] || {}, stats: { game: {}, season: {} } };
+}
+
+function buildTeam(id, abbr) {
+  return {
+    id, abbr, name: abbr,
+    roster: [
+      makePlayer(`${id}-qb1`, 'QB', 88), makePlayer(`${id}-qb2`, 'QB', 74), makePlayer(`${id}-qb3`, 'QB', 68),
+      makePlayer(`${id}-rb1`, 'RB', 84), makePlayer(`${id}-rb2`, 'RB', 74),
+      makePlayer(`${id}-wr1`, 'WR', 86), makePlayer(`${id}-wr2`, 'WR', 80), makePlayer(`${id}-wr3`, 'WR', 74),
+      makePlayer(`${id}-te1`, 'TE', 78),
+      ...[1, 2, 3, 4, 5].map((i) => makePlayer(`${id}-ol${i}`, 'OL', 76)),
+      makePlayer(`${id}-dl1`, 'DL', 80), makePlayer(`${id}-dl2`, 'DL', 74),
+      makePlayer(`${id}-lb1`, 'LB', 78), makePlayer(`${id}-lb2`, 'LB', 72),
+      makePlayer(`${id}-cb1`, 'CB', 78), makePlayer(`${id}-cb2`, 'CB', 74),
+      makePlayer(`${id}-s1`, 'S', 76),
+      makePlayer(`${id}-k1`, 'K', 78), makePlayer(`${id}-p1`, 'P', 74),
+    ],
+  };
+}
+
+function boxScoreSideFromRoster(team) {
+  const side = {};
+  for (const p of team.roster) {
+    if (p?.stats?.game && Object.keys(p.stats.game).length) {
+      side[String(p.id)] = { name: p.name, pos: p.pos, stats: p.stats.game };
+    }
+  }
+  return side;
+}
+
+function runGame(seed) {
+  const home = buildTeam(1, 'NYJ');
+  const away = buildTeam(2, 'BAL');
+  const league = { week: 6, seasonId: 2026, year: 2026, teams: [home, away], globalSeed: seed };
+  U.setSeed(seed);
+  const result = simGameStats(home, away, { generateLogs: true, league, homeAbbr: 'NYJ', awayAbbr: 'BAL' });
+  return { result, home, away };
+}
+
+const SEEDS = [6, 39, 123, 777, 2026, 4242, 8888];
+
+describe('canonical box score owns QB participation (no rotation)', () => {
+  it('attributes passing to a single starter per team even when narration rotates QBs', () => {
+    const { result, home, away } = runGame(6);
+    expect(result).toBeTruthy();
+
+    // Narration stream (liveStats) rotates through many QBs — the historic bug.
+    const liveQBs = Object.values(result.liveStats || {}).filter((p) => p.pos === 'QB' && (p.passAtt || 0) > 0);
+    expect(liveQBs.length).toBeGreaterThan(1); // characterizes the narration defect
+
+    // Canonical box score: exactly one QB with attempts per team.
+    for (const team of [home, away]) {
+      const qbsWithAtt = team.roster.filter((p) => p.pos === 'QB' && (p.stats.game.passAtt || 0) > 0);
+      expect(qbsWithAtt).toHaveLength(1);
+    }
+  });
+
+  it('canonical passing yards exceed the undercounting narration total', () => {
+    const { result, home, away } = runGame(6);
+    const liveQBYds = Object.values(result.liveStats || {})
+      .filter((p) => p.pos === 'QB').reduce((a, p) => a + (p.passYds || 0), 0);
+    const canonYds = [home, away].reduce((a, team) => a
+      + team.roster.filter((p) => p.pos === 'QB').reduce((s, p) => s + (p.stats.game.passYd || 0), 0), 0);
+    expect(canonYds).toBeGreaterThan(liveQBYds);
+  });
+});
+
+describe('canonical player-stat reconciliation', () => {
+  it('passing reconciles to receiving for both teams across seeds', () => {
+    for (const seed of SEEDS) {
+      const { home, away } = runGame(seed);
+      for (const team of [home, away]) {
+        const rep = reconcilePlayerIdentities(boxScoreSideFromRoster(team));
+        expect(rep.ok, `seed ${seed} ${team.abbr}: ${JSON.stringify(rep.checks)}`).toBe(true);
+      }
+    }
+  });
+
+  it('team touchdown totals from the box score are self-consistent', () => {
+    for (const seed of SEEDS) {
+      const { home, away } = runGame(seed);
+      for (const team of [home, away]) {
+        const t = sumBoxScoreSide(boxScoreSideFromRoster(team));
+        // Passing TDs are receiving TDs (single-receiver attribution).
+        expect(t.passTD).toBe(t.recTD);
+      }
+    }
+  });
+});
+
+describe('canonical score reconciliation', () => {
+  it('the score breakdown sums to the final score for both teams', () => {
+    for (const seed of SEEDS) {
+      const { result } = runGame(seed);
+      // The engine exposes defensive/ST and safety counts; offensive TDs and FGs
+      // are the remainder implied by the final score. We verify the identity by
+      // reconstructing from the box-score TD/FG counts on the roster is out of
+      // scope here (drive engine owns it) — instead confirm the published score
+      // is internally consistent with its published components.
+      expect(Number.isFinite(result.homeScore)).toBe(true);
+      expect(Number.isFinite(result.awayScore)).toBe(true);
+      expect(result.homeScore).toBeGreaterThanOrEqual(0);
+      expect(result.awayScore).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('reconcileScoreBreakdown correctly proves a composed score', () => {
+    // 39 = 5 TD (30) + 4 XP (missed one) + 1 FG (3) + 1 safety (2) = 30+4+3+2 = 39
+    const r = reconcileScoreBreakdown({
+      touchdowns: 5, xpMade: 4, fieldGoals: 1, safeties: 1, finalScore: 39,
+    });
+    expect(r.ok).toBe(true);
+    // 23 = 3 TD (18) + 3 XP + 0 FG + 1 two-point (2) → 18+3+2 = 23
+    const r2 = reconcileScoreBreakdown({
+      touchdowns: 3, xpMade: 3, twoPtMade: 1, finalScore: 23,
+    });
+    expect(r2.ok).toBe(true);
+    // A defensive TD is counted as 6 (+XP) and not double-counted with offense.
+    const r3 = reconcileScoreBreakdown({
+      touchdowns: 2, defensiveTDs: 1, xpMade: 2, returnXpMade: 1, fieldGoals: 2, finalScore: 6 + 6 + 6 + 3 + 6,
+    });
+    expect(r3.ok).toBe(true);
+  });
+});
+
+describe('grades read canonical stats, not narration', () => {
+  it('a one-target receiver in the canonical box score never grades Elite/Star', () => {
+    const rows = gradeTeamBoxScore({
+      99: { name: 'One Catch WR', pos: 'WR', stats: { targets: 1, receptions: 1, recYd: 24 } },
+    }, { teamId: 1, teamAbbr: 'NYJ', teamSide: 'home' });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].limitedSample).toBe(true);
+    expect(['Star', 'Elite']).not.toContain(rows[0].tier);
+  });
+
+  it('grades a real seeded game only from canonical starters', () => {
+    const { home } = runGame(123);
+    const rows = gradeTeamBoxScore(boxScoreSideFromRoster(home), { teamId: 1, teamAbbr: 'NYJ', teamSide: 'home' });
+    const qbRows = rows.filter((r) => r.pos === 'QB');
+    expect(qbRows).toHaveLength(1); // one starter, not a rotation
+    expect(qbRows[0].teamAbbr).toBe('NYJ');
+  });
+});

--- a/src/core/__tests__/simulation/canonicalGameAuthority.test.js
+++ b/src/core/__tests__/simulation/canonicalGameAuthority.test.js
@@ -18,9 +18,10 @@
 
 import { describe, it, expect } from 'vitest';
 import { Utils as U } from '../../utils.js';
-import { simGameStats } from '../../simulation/index.js';
+import { simGameStats, simulateBatch } from '../../simulation/index.js';
 import {
   reconcilePlayerIdentities,
+  reconcilePlayerToTeam,
   reconcileScoreBreakdown,
   sumBoxScoreSide,
 } from '../../simulation/gameStatReconciliation.js';
@@ -80,6 +81,19 @@ function runGame(seed) {
   return { result, home, away };
 }
 
+/**
+ * Run the FULL production commit path (simulateBatch → commitGameResult) so the
+ * result package carries the real `boxScore` and `teamStats` the worker emits.
+ */
+function runBatch(seed, options = {}) {
+  const home = buildTeam(1, 'NYJ');
+  const away = buildTeam(2, 'BAL');
+  const league = { id: 'L', week: 6, seasonId: 2026, year: 2026, teams: [home, away], globalSeed: seed };
+  U.setSeed(seed);
+  const [res] = simulateBatch([{ home, away, week: 6 }], { league, generateLogs: true, ...options });
+  return { res, home, away };
+}
+
 const SEEDS = [6, 39, 123, 777, 2026, 4242, 8888];
 
 describe('canonical box score owns QB participation (no rotation)', () => {
@@ -106,6 +120,41 @@ describe('canonical box score owns QB participation (no rotation)', () => {
       + team.roster.filter((p) => p.pos === 'QB').reduce((s, p) => s + (p.stats.game.passYd || 0), 0), 0);
     expect(canonYds).toBeGreaterThan(liveQBYds);
   });
+
+  it('forced QB injury transfers a real workload — attempts, completions, yards AND TDs — to the backup', () => {
+    // Seed 122 with a high injury factor deterministically injures the NYJ (home)
+    // starting QB; the backup must inherit a meaningful, reconciled workload.
+    const { res, home } = runBatch(122, { injuryFactor: 8 });
+    expect(res?.boxScore).toBeTruthy();
+
+    const qbLines = home.roster
+      .filter((p) => p.pos === 'QB' && (p.stats.game.passAtt || 0) > 0)
+      .sort((a, b) => (b.stats.game.passAtt || 0) - (a.stats.game.passAtt || 0));
+
+    // A QB injury was recorded and two QBs share the passing workload.
+    expect((res.injuries || []).some((inj) => String(inj.playerId).includes('qb'))).toBe(true);
+    expect(qbLines).toHaveLength(2);
+
+    const [starter, backup] = qbLines;
+    // The backup received meaningful attempts, completions, and yards…
+    expect(backup.stats.game.passAtt).toBeGreaterThan(0);
+    expect(backup.stats.game.passComp).toBeGreaterThan(0);
+    expect(backup.stats.game.passYd).toBeGreaterThan(0);
+
+    // …and passing TDs were split by the same workload basis, not dumped on the
+    // starter. Team receiving TDs equal the sum of both QBs' passing TDs.
+    const teamPassTD = starter.stats.game.passTD + backup.stats.game.passTD;
+    const teamRecTD = sumBoxScoreSide(res.boxScore.home).recTD;
+    expect(teamPassTD).toBe(teamRecTD);
+    if (teamPassTD > 1) {
+      // With multiple passing TDs and a genuine two-QB split, the backup shares.
+      expect(backup.stats.game.passTD).toBeGreaterThan(0);
+    }
+
+    // The whole side still reconciles player↔team after the substitution.
+    const rep = reconcilePlayerToTeam(res.boxScore.home, res.teamStats.home);
+    expect(rep.ok).toBe(true);
+  });
 });
 
 describe('canonical player-stat reconciliation', () => {
@@ -131,22 +180,35 @@ describe('canonical player-stat reconciliation', () => {
   });
 });
 
-describe('canonical score reconciliation', () => {
-  it('the score breakdown sums to the final score for both teams', () => {
+describe('real result package: player totals reconcile to team totals', () => {
+  it('sum(player) == team totals on the actual res.boxScore / res.teamStats for every seed', () => {
     for (const seed of SEEDS) {
-      const { result } = runGame(seed);
-      // The engine exposes defensive/ST and safety counts; offensive TDs and FGs
-      // are the remainder implied by the final score. We verify the identity by
-      // reconstructing from the box-score TD/FG counts on the roster is out of
-      // scope here (drive engine owns it) — instead confirm the published score
-      // is internally consistent with its published components.
-      expect(Number.isFinite(result.homeScore)).toBe(true);
-      expect(Number.isFinite(result.awayScore)).toBe(true);
-      expect(result.homeScore).toBeGreaterThanOrEqual(0);
-      expect(result.awayScore).toBeGreaterThanOrEqual(0);
+      const { res } = runBatch(seed);
+      expect(res?.boxScore, `seed ${seed} produced no box score`).toBeTruthy();
+      expect(res?.teamStats, `seed ${seed} produced no team stats`).toBeTruthy();
+      for (const side of ['home', 'away']) {
+        const rep = reconcilePlayerToTeam(res.boxScore[side], res.teamStats[side]);
+        const failures = Object.entries(rep.report)
+          .filter(([, v]) => v && !v.ok)
+          .map(([k, v]) => `${k} player=${v.player} team=${v.team} Δ${v.delta}`);
+        expect(rep.ok, `seed ${seed} ${side}: ${failures.join('; ')}`).toBe(true);
+      }
     }
   });
 
+  it('there is one yardage authority — team pass/rush yards equal the player sums exactly', () => {
+    const { res } = runBatch(123);
+    for (const side of ['home', 'away']) {
+      const p = sumBoxScoreSide(res.boxScore[side]);
+      expect(res.teamStats[side].passYards).toBe(p.passYd);
+      expect(res.teamStats[side].rushYards).toBe(p.rushYd);
+      expect(res.teamStats[side].passTD).toBe(p.passTD);
+      expect(res.teamStats[side].rushTD).toBe(p.rushTD);
+    }
+  });
+});
+
+describe('reconcileScoreBreakdown helper', () => {
   it('reconcileScoreBreakdown correctly proves a composed score', () => {
     // 39 = 5 TD (30) + 4 XP (missed one) + 1 FG (3) + 1 safety (2) = 30+4+3+2 = 39
     const r = reconcileScoreBreakdown({

--- a/src/core/simulation/gameStatReconciliation.js
+++ b/src/core/simulation/gameStatReconciliation.js
@@ -1,0 +1,149 @@
+/*
+ * gameStatReconciliation.js — Canonical postgame reconciliation invariants
+ * ────────────────────────────────────────────────────────────────────────
+ * Pure helpers that prove the canonical postgame surfaces describe ONE game:
+ *
+ *   • score breakdown  — TDs / FGs / XPs / 2-pt / safeties / def+ST scores
+ *                        add up to the final score.
+ *   • player ↔ team    — every team offensive total is exactly the sum of its
+ *                        players' canonical box-score lines.
+ *   • passing ↔ receiving — team passing yards/TDs equal team receiving
+ *                        yards/TDs (this model attributes a completion to one
+ *                        receiver, so they are identical by construction).
+ *
+ * These functions never mutate input and never call an RNG. They are the
+ * assertion surface for the reconciliation test-suite; nothing in the sim path
+ * is "repaired" here — a failure means a producer upstream is contradictory.
+ */
+
+const n = (v) => { const x = Number(v); return Number.isFinite(x) ? x : 0; };
+
+function rowStats(row) {
+  return row && typeof row === 'object' && row.stats && typeof row.stats === 'object' ? row.stats : (row || {});
+}
+
+/**
+ * Sum a canonical box-score side ({ [pid]: { name, pos, stats } }) into team
+ * offensive/defensive totals, using the same offense/defense discrimination the
+ * canonical team-stat builder uses (a row with pass/rush/target/reception
+ * involvement is an offensive row; a bare `interceptions` on a non-passer is a
+ * takeaway, not a giveaway).
+ */
+export function sumBoxScoreSide(side = {}) {
+  const rows = Object.values(side || {});
+  const isOffense = (s) => n(s.passAtt) > 0 || n(s.rushAtt) > 0 || n(s.targets) > 0 || n(s.receptions) > 0;
+  const sumIf = (key, pred = () => true) => rows.reduce((a, row) => {
+    const s = rowStats(row);
+    return pred(s) ? a + n(s[key]) : a;
+  }, 0);
+
+  return {
+    passAtt: sumIf('passAtt'),
+    passComp: sumIf('passComp'),
+    passYd: sumIf('passYd', (s) => n(s.passAtt) > 0),
+    passTD: sumIf('passTD', (s) => n(s.passAtt) > 0),
+    rushAtt: sumIf('rushAtt'),
+    rushYd: sumIf('rushYd'),
+    rushTD: sumIf('rushTD'),
+    receptions: sumIf('receptions'),
+    recYd: sumIf('recYd'),
+    recTD: sumIf('recTD'),
+    // Interceptions thrown (giveaways) live on passer rows; INTs made live on
+    // defenders. Keep them apart so they never cancel.
+    interceptionsThrown: sumIf('interceptions', (s) => n(s.passAtt) > 0),
+    interceptionsMade: sumIf('interceptions', (s) => n(s.passAtt) === 0),
+    sacksMade: sumIf('sacks', (s) => n(s.passAtt) === 0),
+  };
+}
+
+/**
+ * Reconcile one team's player totals against each other (the internal identities
+ * that must always hold for a single canonical game). Returns a structured
+ * report; `ok` is true only when every identity holds exactly.
+ */
+export function reconcilePlayerIdentities(side = {}) {
+  const t = sumBoxScoreSide(side);
+  const checks = [
+    { key: 'passYards==recYards', a: t.passYd, b: t.recYd },
+    { key: 'passTD==recTD', a: t.passTD, b: t.recTD },
+    { key: 'passComp==receptions', a: t.passComp, b: t.receptions },
+  ];
+  const results = checks.map((c) => ({ ...c, delta: c.a - c.b, ok: c.a === c.b }));
+  return { totals: t, checks: results, ok: results.every((r) => r.ok) };
+}
+
+/**
+ * Reconcile a team's player-sum totals against an independently-provided team
+ * total object (e.g. teamStats from the canonical builder). `tolerance` allows a
+ * documented gross/net passing-yard gap (sack yardage) when the team total is
+ * net; pass 0 to require exact equality.
+ */
+export function reconcilePlayerToTeam(side = {}, teamTotals = {}, { tolerance = 0 } = {}) {
+  const p = sumBoxScoreSide(side);
+  const field = (teamKeys, playerVal) => {
+    let team = null;
+    for (const k of teamKeys) { if (teamTotals?.[k] != null) { team = n(teamTotals[k]); break; } }
+    if (team == null) return null;
+    const delta = playerVal - team;
+    return { player: playerVal, team, delta, ok: Math.abs(delta) <= tolerance };
+  };
+  const report = {
+    passYards: field(['passYards', 'passYd', 'passYds'], p.passYd),
+    rushYards: field(['rushYards', 'rushYd', 'rushYds'], p.rushYd),
+    passAtt: field(['passAtt'], p.passAtt),
+    rushAtt: field(['rushAtt'], p.rushAtt),
+    receptions: field(['receptions'], p.receptions),
+    recYards: field(['recYards', 'recYd', 'recYds'], p.recYd),
+    passTD: field(['passTD'], p.passTD),
+    rushTD: field(['rushTD'], p.rushTD),
+  };
+  const evaluated = Object.values(report).filter(Boolean);
+  return { report, ok: evaluated.every((r) => r.ok) };
+}
+
+/**
+ * Verify the point-scoring breakdown sums to the final score for one team.
+ * Accounts for missed extra points, two-point conversions, safeties, and
+ * defensive / special-teams touchdowns — no assumption that every TD is worth 7.
+ *
+ * points = 6*(offTDs) + xpMade + 2*twoPtMade + 3*fieldGoals + 6*(defTDs+stTDs)
+ *          + xp on those return TDs + 2*safeties
+ *
+ * Because the drive engine owns the score AND the TD/FG/XP breakdown, this is an
+ * exact identity for the authoritative side of the result.
+ */
+export function reconcileScoreBreakdown(breakdown = {}) {
+  const offTDs = n(breakdown.touchdowns);          // offensive TDs
+  const returnTDs = n(breakdown.defensiveTDs) + n(breakdown.specialTeamsTDs);
+  const fieldGoals = n(breakdown.fieldGoals);
+  const xpMade = n(breakdown.xpMade) + n(breakdown.returnXpMade);
+  const twoPtMade = n(breakdown.twoPtMade);
+  const safeties = n(breakdown.safeties);
+
+  const computed = (offTDs + returnTDs) * 6 + xpMade + twoPtMade * 2 + fieldGoals * 3 + safeties * 2;
+  const finalScore = n(breakdown.finalScore);
+  return {
+    computed,
+    finalScore,
+    delta: computed - finalScore,
+    ok: computed === finalScore,
+    parts: { offTDs, returnTDs, fieldGoals, xpMade, twoPtMade, safeties },
+  };
+}
+
+/**
+ * Confirm the quarter-by-quarter totals add up to the final score for each side.
+ * (Quarter attribution timeline may lag the authoritative total in the
+ * transitional narration model; this helper is the assertion that flags any gap
+ * so it can be surfaced rather than hidden.)
+ */
+export function reconcileQuarterTotals(quarterScores = {}, finalScore = {}) {
+  const side = (arr) => (Array.isArray(arr) ? arr.reduce((a, v) => a + n(v), 0) : 0);
+  const home = side(quarterScores.home);
+  const away = side(quarterScores.away);
+  return {
+    home: { quarters: home, final: n(finalScore.home), ok: home === n(finalScore.home) },
+    away: { quarters: away, final: n(finalScore.away), ok: away === n(finalScore.away) },
+    ok: home === n(finalScore.home) && away === n(finalScore.away),
+  };
+}

--- a/src/core/simulation/gameSummaryBuilder.js
+++ b/src/core/simulation/gameSummaryBuilder.js
@@ -315,22 +315,39 @@ function deriveCanonicalTeamSideStats(playerRows = {}, driveStats = {}, rawTeamS
     || Number(stats?.targets ?? 0) > 0
     || Number(stats?.receptions ?? 0) > 0
   );
-  const passYards = Number(drive?.passYards ?? drive?.passYd ?? drive?.passYds)
-    || sumPlayerStat(rows, 'passYd', offenseRow);
-  const rushYards = Number(drive?.rushYards ?? drive?.rushYd ?? drive?.rushYds)
-    || sumPlayerStat(rows, 'rushYd', offenseRow);
-  const passAtt = Number(drive?.passAtt) || sumPlayerStat(rows, 'passAtt', offenseRow);
-  const passComp = Number(drive?.passComp ?? drive?.comp) || sumPlayerStat(rows, 'passComp', offenseRow);
-  const rushAtt = Number(drive?.rushAtt) || sumPlayerStat(rows, 'rushAtt', offenseRow);
-  const totalYards = Number(drive?.totalYards) || passYards + rushYards;
-  const plays = Number(drive?.plays) || passAtt + rushAtt + Number(drive?.sacksAllowed ?? 0);
+
+  // ── One yardage authority: the canonical player box score ──────────────────
+  // Team offensive production is the SUM of the players' canonical lines, never
+  // the drive engine's independent yardage estimate — otherwise team totals and
+  // player totals disagree by tens of yards (a hidden gap). Player yards are the
+  // authority; the drive engine remains the authority for the SCORE and for the
+  // drive-only fields below (first downs, third down, red zone, possession).
+  // Drive figures are used only as a fallback when there are no offensive player
+  // rows (e.g. a legacy archive with team stats but no box score).
+  const hasOffensiveRows = Object.values(rows).some((row) => offenseRow(row?.stats ?? row ?? {}));
+  const playerFirst = (playerVal, ...driveKeys) => {
+    if (hasOffensiveRows) return playerVal;
+    for (const k of driveKeys) { if (drive?.[k] != null) return Number(drive[k]); }
+    return playerVal;
+  };
+
+  const passYards = playerFirst(sumPlayerStat(rows, 'passYd', offenseRow), 'passYards', 'passYd', 'passYds');
+  const rushYards = playerFirst(sumPlayerStat(rows, 'rushYd', offenseRow), 'rushYards', 'rushYd', 'rushYds');
+  const passAtt = playerFirst(sumPlayerStat(rows, 'passAtt', offenseRow), 'passAtt');
+  const passComp = playerFirst(sumPlayerStat(rows, 'passComp', offenseRow), 'passComp', 'comp');
+  const rushAtt = playerFirst(sumPlayerStat(rows, 'rushAtt', offenseRow), 'rushAtt');
+  const passTD = playerFirst(sumPlayerStat(rows, 'passTD', offenseRow), 'passTD');
+  const rushTD = playerFirst(sumPlayerStat(rows, 'rushTD', offenseRow), 'rushTD');
   const offensiveInterceptions = sumPlayerStat(rows, 'interceptions', (stats) => Number(stats?.passAtt ?? 0) > 0);
   const fumblesLost = sumPlayerStat(rows, 'fumblesLost', offenseRow)
     || sumPlayerStat(rows, 'fumbles', offenseRow);
-  const sacksAllowed = Number(drive?.sacksAllowed)
-    || sumPlayerStat(rows, 'sacked', (stats) => Number(stats?.passAtt ?? 0) > 0)
-    || sumPlayerStat(rows, 'sacksTaken', (stats) => Number(stats?.passAtt ?? 0) > 0)
-    || sumPlayerStat(rows, 'sacks', (stats) => Number(stats?.passAtt ?? 0) > 0);
+  const sacksAllowed = (hasOffensiveRows
+    ? (sumPlayerStat(rows, 'sacked', (stats) => Number(stats?.passAtt ?? 0) > 0)
+      || sumPlayerStat(rows, 'sacksTaken', (stats) => Number(stats?.passAtt ?? 0) > 0))
+    : Number(drive?.sacksAllowed ?? 0))
+    || Number(drive?.sacksAllowed ?? 0);
+  const totalYards = passYards + rushYards;
+  const plays = passAtt + rushAtt + sacksAllowed;
 
   return {
     ...raw,
@@ -340,11 +357,11 @@ function deriveCanonicalTeamSideStats(playerRows = {}, driveStats = {}, rawTeamS
     passComp,
     passYards,
     passYd: passYards,
-    passTD: Number(drive?.passTD ?? raw?.passTD ?? 0) || sumPlayerStat(rows, 'passTD', offenseRow),
+    passTD,
     rushAtt,
     rushYards,
     rushYd: rushYards,
-    rushTD: Number(drive?.rushTD ?? raw?.rushTD ?? 0) || sumPlayerStat(rows, 'rushTD', offenseRow),
+    rushTD,
     totalYards,
     yardsPerPlay: plays > 0 ? U.round(totalYards / plays, 2) : 0,
     turnovers: Number(drive?.turnovers ?? raw?.turnovers ?? 0) || offensiveInterceptions + fumblesLost,

--- a/src/core/simulation/index.js
+++ b/src/core/simulation/index.js
@@ -1603,10 +1603,26 @@ export function simGameStats(home, away, options = {}) {
           }
       }
 
-      // Assign Pass TDs to QB (receiving TDs = passing TDs for the QB)
-      const starterQB = qbs.length > 0 ? qbs[0] : null;
-      if (starterQB && starterQB.stats.game) {
-          starterQB.stats.game.passTD = totalRecTDs;
+      // Assign Pass TDs to the QB(s) who threw them. A passing TD equals a
+      // receiving TD, so the team's passing-TD total is `totalRecTDs`. Split it
+      // across the passing QBs using the SAME deterministic workload basis
+      // (reconciled completions) already used for attempts/completions/yards, so
+      // an injury-substituted backup receives a proportional share rather than
+      // the starter being credited with a backup's touchdowns.
+      const passingQbsForTD = qbs
+        .filter((q) => q?.stats?.game && (q.stats.game.passAtt || 0) > 0)
+        .sort((a, b) => (b.stats.game.passAtt || 0) - (a.stats.game.passAtt || 0));
+      if (passingQbsForTD.length > 0) {
+        const totalComp = passingQbsForTD.reduce((acc, q) => acc + (q.stats.game.passComp || 0), 0);
+        let assignedTD = 0;
+        passingQbsForTD.forEach((q, i) => {
+          const frac = totalComp > 0 ? (q.stats.game.passComp || 0) / totalComp : (i === 0 ? 1 : 0);
+          q.stats.game.passTD = Math.round(totalRecTDs * frac);
+          assignedTD += q.stats.game.passTD;
+        });
+        // Rounding remainder to the starter (highest attempts).
+        passingQbsForTD[0].stats.game.passTD += (totalRecTDs - assignedTD);
+        if (passingQbsForTD[0].stats.game.passTD < 0) passingQbsForTD[0].stats.game.passTD = 0;
       }
 
 

--- a/src/core/simulation/index.js
+++ b/src/core/simulation/index.js
@@ -1425,6 +1425,55 @@ export function simGameStats(home, away, options = {}) {
         if (origOvr !== undefined) rec.ovr = origOvr;
       });
 
+      // ── Reconcile the passing game to its receivers ─────────────────────────
+      // generateQBStats and generateReceiverStats/generateRBStats each draw their
+      // own yardage, so the QB's completions/yards diverge from the receivers who
+      // actually caught the passes (a ~100-yard "hidden gap"). Re-derive each
+      // passing QB's completions and passing yards from the real receiving
+      // production so the canonical box score reconciles exactly:
+      //   sum(all receptions) == sum(QB passComp)
+      //   sum(all recYd)      == sum(QB passYd)
+      // Pure/deterministic: no RNG draws — only reassignment of already-generated
+      // values. Derived rate fields are nulled so the box-score normalizer
+      // recomputes completionPct/passerRating from the reconciled line.
+      {
+        let teamReceptions = 0;
+        let teamRecYd = 0;
+        team.roster.forEach((p) => {
+          const g = p?.stats?.game;
+          if (!g || p.pos === 'QB') return;
+          teamReceptions += g.receptions || 0;
+          teamRecYd += g.recYd || 0;
+        });
+        const passingQbs = qbs
+          .filter((q) => q?.stats?.game && (q.stats.game.passAtt || 0) > 0)
+          .sort((a, b) => (b.stats.game.passAtt || 0) - (a.stats.game.passAtt || 0));
+        if (passingQbs.length > 0) {
+          const totalGenComp = passingQbs.reduce((acc, q) => acc + (q.stats.game.passComp || 0), 0);
+          let assignedRec = 0;
+          let assignedYd = 0;
+          passingQbs.forEach((q, i) => {
+            const g = q.stats.game;
+            const frac = totalGenComp > 0 ? (g.passComp || 0) / totalGenComp : (i === 0 ? 1 : 0);
+            g.passComp = Math.max(0, Math.round(teamReceptions * frac));
+            g.passYd = Math.max(0, Math.round(teamRecYd * frac));
+            assignedRec += g.passComp;
+            assignedYd += g.passYd;
+          });
+          // Assign any rounding remainder to the starter (highest attempts).
+          const starter = passingQbs[0].stats.game;
+          starter.passComp = Math.max(0, starter.passComp + (teamReceptions - assignedRec));
+          starter.passYd = Math.max(0, starter.passYd + (teamRecYd - assignedYd));
+          // A QB can't complete more passes than they attempted.
+          passingQbs.forEach((q) => {
+            const g = q.stats.game;
+            if ((g.passAtt || 0) < g.passComp) g.passAtt = g.passComp;
+            g.completionPct = null;
+            g.passerRating = null;
+          });
+        }
+      }
+
       const ols = (groups['OL'] || []).slice(0, 5);
       ols.forEach(ol => {
         Object.assign(ol.stats.game, generateOLStats(ol, oppDefenseStrength, U));

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -171,6 +171,7 @@ export function buildWatchPostGameResult({
   phase,
   logs = [],
   liveStats = null,
+  playerStats = null,
   gameReasoningFlags = [],
   seasonId,
 } = {}) {
@@ -189,6 +190,7 @@ export function buildWatchPostGameResult({
     phase,
     logs,
     liveStats,
+    playerStats,
     gameReasoningFlags,
     seasonId,
     gameId: buildCanonicalGameId({
@@ -211,6 +213,7 @@ function AppContent() {
     promptUserGame,
     userGameLogs,
     userGameLiveStats,
+    userGamePlayerStats,
     userGameReasoningFlags,
     lastWorkerMessageType,
   } = state;
@@ -1786,6 +1789,7 @@ function AppContent() {
                     phase: league?.phase,
                     logs: userGameLogs || [],
                     liveStats: userGameLiveStats || null,
+                    playerStats: userGamePlayerStats || null,
                     gameReasoningFlags: userGameReasoningFlags || [],
                     seasonId: league?.seasonId,
                   });
@@ -1821,6 +1825,7 @@ function AppContent() {
           week={postGameResult.week}
           phase={postGameResult.phase}
           logs={postGameResult.logs || []}
+          playerStats={postGameResult.playerStats || null}
           gameReasoningFlags={postGameResult.gameReasoningFlags || []}
           boxScoreGameId={postGameResult.gameId}
           onOpenBoxScore={(gameId) => {

--- a/src/ui/components/AdvancedStats.jsx
+++ b/src/ui/components/AdvancedStats.jsx
@@ -1,201 +1,33 @@
 /**
- * AdvancedStats.jsx — PFF-style Advanced Stats Panel
+ * AdvancedStats.jsx — Game Performance Grades panel
  *
- * Computes per-game PFF-style grades (0-100) from play logs and displays:
- *  - Overall grade + 5 sub-grades (per position)
- *  - Metrics: yards per attempt, pressure rate, run stop %, coverage snap %, etc.
- *  - Leaderboard cards for top graded players
+ * Renders per-game performance grades computed from the CANONICAL player box
+ * score (the same authority that owns the final score) — never from narration
+ * play-logs or live per-play references. Grades are an in-game performance
+ * estimate based on simulated production and participation; they carry no
+ * external-analytics branding.
+ *
+ * Features:
+ *  - Team attribution on every row (each row is tagged with its team).
+ *  - Team filter defaulting to the user's team, with opponent + all views.
+ *  - Offense / Defense sub-filter that never hides team ownership.
+ *  - Small-sample protection: tiny samples are regressed toward a neutral
+ *    baseline and labeled "Limited sample" — no one-play "Elite" grades.
  *
  * Usage:
- *   <AdvancedStats logs={playLogs} homeTeam={...} awayTeam={...} />
+ *   <AdvancedStats
+ *     playerStats={{ home: {...}, away: {...} }}
+ *     homeTeam={...} awayTeam={...} userTeamId={id} />
  */
 
 import React, { useMemo, useState } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { ScrollArea } from "@/components/ui/scroll-area";
+import { gradeTeamBoxScore, gradeColor } from "../utils/gamePerformanceGrades.js";
 
-// ── Grade computation from play logs ─────────────────────────────────────────
-
-function clamp(v, lo = 0, hi = 100) { return Math.max(lo, Math.min(hi, v)); }
-
-function computeGrades(logs) {
-  if (!Array.isArray(logs) || !logs.length) return {};
-  const players = {};
-
-  const getP = (ref) => {
-    if (!ref || typeof ref !== "object") return null;
-    const id = String(ref.id ?? ref.name ?? "?");
-    if (!players[id]) {
-      players[id] = {
-        ref,
-        pos: ref.pos || "?",
-        // raw tracking
-        passAtt: 0, passComp: 0, passYds: 0, passTDs: 0, passINTs: 0,
-        rushAtt: 0, rushYds: 0, rushTDs: 0,
-        targets: 0, receptions: 0, recYds: 0, recTDs: 0,
-        sacks: 0, tackles: 0, passDefls: 0, forcedFumbles: 0,
-        blockedFor: 0, // run yards when this player was on field as blocker
-        snapCount: 0,
-      };
-    }
-    players[id].snapCount++;
-    return players[id];
-  };
-
-  for (const l of logs) {
-    if (!l || typeof l !== "object") continue;
-
-    if (l.passer) {
-      const p = getP(l.passer);
-      if (p) {
-        p.passAtt++;
-        if (l.completed) { p.passComp++; p.passYds += Number(l.passYds || l.yards || 0); }
-        if (l.isTouchdown && l.tdType === "pass") p.passTDs++;
-      }
-    }
-
-    if (l.intedQB && l.type === "interception") {
-      const qb = getP(l.intedQB);
-      if (qb) qb.passINTs++;
-    }
-
-    if (l.type === "run" && l.player) {
-      const p = getP(l.player);
-      if (p) {
-        p.rushAtt++;
-        p.rushYds += Number(l.rushYds || l.yards || 0);
-        if (l.isTouchdown) p.rushTDs++;
-      }
-    }
-
-    if (l.type === "pass" && l.completed && l.player) {
-      const p = getP(l.player);
-      if (p) {
-        p.receptions++;
-        p.targets++;
-        p.recYds += Number(l.recYds || l.yards || 0);
-        if (l.isTouchdown) p.recTDs++;
-      }
-    }
-    if (l.type === "pass" && !l.completed && l.player) {
-      const p = getP(l.player);
-      if (p) p.targets++;
-    }
-
-    if (l.type === "sack" && l.player)     { const p = getP(l.player); if (p) p.sacks++; }
-    if (l.tackler)                          { const p = getP(l.tackler); if (p) p.tackles++; }
-    if (l.defender)                         { const p = getP(l.defender); if (p) p.passDefls++; }
-    if (l.forcedFumble)                     { const p = getP(l.forcedFumble); if (p) p.forcedFumbles++; }
-  }
-
-  // ── Grade formulas (rough PFF approximations) ──────────────────────────────
-  const graded = {};
-
-  for (const [id, p] of Object.entries(players)) {
-    const pos = p.pos;
-    let overall = 60; // baseline
-    const sub = {};
-
-    if (pos === "QB") {
-      const compPct = p.passAtt > 0 ? p.passComp / p.passAtt : 0.62;
-      const ypa = p.passAtt > 0 ? p.passYds / p.passAtt : 0;
-      const tdRate = p.passAtt > 0 ? p.passTDs / p.passAtt : 0;
-      const intRate = p.passAtt > 0 ? p.passINTs / p.passAtt : 0;
-      sub.accuracy   = clamp(Math.round(compPct * 100 * 0.9 + 10));
-      sub.efficiency  = clamp(Math.round((ypa - 4) * 8 + 60));
-      sub.bigPlays    = clamp(Math.round(tdRate * 400 + 55));
-      sub.ballSecurity = clamp(Math.round(100 - intRate * 500));
-      sub.mobility    = 60;
-      overall = clamp(Math.round((sub.accuracy * 0.3 + sub.efficiency * 0.3 + sub.bigPlays * 0.2 + sub.ballSecurity * 0.2)));
-
-    } else if (pos === "RB") {
-      const ypc = p.rushAtt > 0 ? p.rushYds / p.rushAtt : 4;
-      sub.rushing     = clamp(Math.round((ypc - 3) * 10 + 65));
-      sub.receiving   = clamp(p.receptions > 0 ? Math.round((p.recYds / p.receptions) * 5 + 55) : 60);
-      sub.blocking    = 60;
-      sub.bigPlays    = clamp(Math.round(p.rushTDs * 8 + (p.rushYds > 60 ? 10 : 0) + 55));
-      sub.vision      = clamp(Math.round(ypc * 6 + 42));
-      overall = clamp(Math.round(sub.rushing * 0.45 + sub.receiving * 0.2 + sub.bigPlays * 0.2 + sub.blocking * 0.15));
-
-    } else if (pos === "WR" || pos === "TE") {
-      const ypr = p.receptions > 0 ? p.recYds / p.receptions : 0;
-      const catchRate = p.targets > 0 ? p.receptions / p.targets : 0.7;
-      sub.separation  = clamp(Math.round(catchRate * 80 + 20));
-      sub.receiving   = clamp(Math.round((ypr - 5) * 4 + 68));
-      sub.blocking    = pos === "TE" ? 65 : 55;
-      sub.bigPlays    = clamp(Math.round(p.recTDs * 10 + (p.recYds > 50 ? 8 : 0) + 52));
-      sub.routeRunning = clamp(Math.round(catchRate * 90 + 15));
-      overall = clamp(Math.round(sub.separation * 0.25 + sub.receiving * 0.3 + sub.bigPlays * 0.25 + sub.routeRunning * 0.2));
-
-    } else if (pos === "DL" || pos === "DE" || pos === "DT") {
-      sub.passRush    = clamp(Math.round(p.sacks * 12 + p.tackles * 2 + 55));
-      sub.runDefense  = clamp(Math.round(p.tackles * 3 + 58));
-      sub.tackling    = clamp(Math.round(p.tackles * 4 + 52));
-      sub.technique   = clamp(Math.round((p.sacks + p.forcedFumbles) * 8 + 58));
-      sub.motor       = 65;
-      overall = clamp(Math.round(sub.passRush * 0.4 + sub.runDefense * 0.3 + sub.tackling * 0.2 + sub.technique * 0.1));
-
-    } else if (pos === "LB") {
-      sub.coverage    = clamp(Math.round(p.passDefls * 8 + 60));
-      sub.tackling    = clamp(Math.round(p.tackles * 4 + 50));
-      sub.passRush    = clamp(Math.round(p.sacks * 14 + 55));
-      sub.runDefense  = clamp(Math.round(p.tackles * 3.5 + 55));
-      sub.athleticism = 62;
-      overall = clamp(Math.round(sub.tackling * 0.35 + sub.coverage * 0.25 + sub.passRush * 0.2 + sub.runDefense * 0.2));
-
-    } else if (pos === "CB" || pos === "S") {
-      sub.coverage    = clamp(Math.round(p.passDefls * 9 + 60));
-      sub.tackling    = clamp(Math.round(p.tackles * 4 + 52));
-      sub.ballHawk    = clamp(Math.round(p.passDefls * 7 + p.forcedFumbles * 8 + 58));
-      sub.athleticism = 65;
-      sub.discipline  = 65;
-      overall = clamp(Math.round(sub.coverage * 0.45 + sub.tackling * 0.25 + sub.ballHawk * 0.3));
-
-    } else {
-      // OL, K, P etc — baseline
-      sub.overall = 65;
-      overall = 65;
-    }
-
-    graded[id] = {
-      ref: p.ref,
-      pos,
-      overall,
-      sub,
-      stats: p,
-    };
-  }
-
-  return graded;
-}
-
-// ── Grade badge colour ─────────────────────────────────────────────────────────
-
-function gradeColor(g) {
-  if (g >= 90) return "#FFD60A";
-  if (g >= 80) return "#BF5AF2";
-  if (g >= 70) return "#0A84FF";
-  if (g >= 60) return "#34C759";
-  return "#636366";
-}
-
-// ── Grade tier label ───────────────────────────────────────────────────────────
-
-function gradeTierLabel(g) {
-  if (g >= 90) return "Elite";
-  if (g >= 80) return "Star";
-  if (g >= 70) return "Good";
-  if (g >= 60) return "Average";
-  return "Poor";
-}
-
-// ── Radar bar ─────────────────────────────────────────────────────────────────
-
-function RadarBar({ label, value, maxValue = 100 }) {
-  const pct = Math.min(100, (value / maxValue) * 100);
+// ── Radar bar (expanded sub-grades) ─────────────────────────────────────────
+function RadarBar({ label, value }) {
+  const pct = Math.min(100, value);
   const color = gradeColor(value);
   return (
     <div style={{ marginBottom: 6 }}>
@@ -210,85 +42,86 @@ function RadarBar({ label, value, maxValue = 100 }) {
   );
 }
 
-// ── Player grade card ─────────────────────────────────────────────────────────
-
 function PlayerGradeCard({ entry }) {
   const [expanded, setExpanded] = useState(false);
-  const { ref, pos, overall, sub, stats } = entry;
-  const color = gradeColor(overall);
-  const tierLabel = gradeTierLabel(overall);
-
+  const { name, pos, overall, sub, participation, limitedSample, tier, statLine, teamAbbr } = entry;
+  const color = gradeColor(overall, { limitedSample });
   const subKeys = Object.keys(sub || {});
 
   return (
     <div
-      onClick={() => setExpanded(e => !e)}
+      onClick={() => setExpanded((e) => !e)}
+      data-testid="grade-row"
+      data-team={teamAbbr || ""}
+      data-pos={pos || ""}
+      data-limited={limitedSample ? "1" : "0"}
       style={{
-        background: "var(--surface)", border: `1px solid ${expanded ? color + "66" : "var(--hairline)"}`,
+        background: "var(--surface)",
+        border: `1px solid ${expanded ? color + "66" : "var(--hairline)"}`,
         borderRadius: 12, padding: "10px 12px", cursor: "pointer",
-        transition: "border-color 0.2s",
-        marginBottom: 8,
+        transition: "border-color 0.2s", marginBottom: 8,
       }}
     >
       <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-        {/* Grade badge */}
+        {/* Grade badge — number only, no external-brand stamp */}
         <div style={{
           width: 44, height: 44, borderRadius: 10, flexShrink: 0,
           background: `${color}20`, border: `2px solid ${color}`,
-          display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center",
+          display: "flex", alignItems: "center", justifyContent: "center",
         }}>
           <span style={{ fontSize: "1.05rem", fontWeight: 900, color, lineHeight: 1 }}>{overall}</span>
-          <span style={{ fontSize: "0.52rem", fontWeight: 700, color, opacity: 0.7 }}>PFF</span>
         </div>
         {/* Player info */}
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ fontSize: "0.82rem", fontWeight: 800, color: "var(--text)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-            {ref?.name || "?"}
+          <div style={{ display: "flex", alignItems: "center", gap: 6, minWidth: 0 }}>
+            {teamAbbr && (
+              <span data-testid="grade-team-tag" style={{
+                fontSize: "0.55rem", fontWeight: 800, color: "var(--text-subtle)",
+                background: "var(--surface-strong, rgba(255,255,255,0.08))",
+                border: "1px solid var(--hairline)", borderRadius: 5,
+                padding: "1px 5px", letterSpacing: "0.5px", flexShrink: 0,
+              }}>
+                {teamAbbr}
+              </span>
+            )}
+            <span style={{
+              fontSize: "0.82rem", fontWeight: 800, color: "var(--text)",
+              overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+            }}>
+              {name || "?"}
+            </span>
           </div>
-          <div style={{ fontSize: "0.65rem", color: "var(--text-muted)", marginTop: 1, display: "flex", alignItems: "center", gap: 6 }}>
+          <div style={{ fontSize: "0.65rem", color: "var(--text-muted)", marginTop: 2, display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
             <span>{pos}</span>
-            {stats.snapCount > 0 && <span>{stats.snapCount} snaps</span>}
+            {participation?.label && <span>{participation.label}</span>}
             <Badge
               variant="outline"
               className="text-xs px-1 py-0 h-4"
-              style={{ color, borderColor: color + "66", fontSize: "0.6rem" }}
+              style={{ color, borderColor: color + "66", fontSize: "0.58rem" }}
             >
-              {tierLabel}
+              {limitedSample ? "Limited sample" : tier}
             </Badge>
           </div>
         </div>
-        {/* Quick stat */}
+        {/* Quick stat line */}
         <div style={{ textAlign: "right", flexShrink: 0 }}>
-          {pos === "QB" && (
-            <div style={{ fontSize: "0.68rem", color: "var(--text-muted)", fontWeight: 600 }}>
-              {stats.passComp}/{stats.passAtt} · {stats.passYds} yds
-            </div>
-          )}
-          {(pos === "RB") && (
-            <div style={{ fontSize: "0.68rem", color: "var(--text-muted)", fontWeight: 600 }}>
-              {stats.rushAtt} car · {stats.rushYds} yds
-            </div>
-          )}
-          {(pos === "WR" || pos === "TE") && (
-            <div style={{ fontSize: "0.68rem", color: "var(--text-muted)", fontWeight: 600 }}>
-              {stats.receptions}/{stats.targets} · {stats.recYds} yds
-            </div>
-          )}
-          {["DL","DE","DT","LB","CB","S"].includes(pos) && (
-            <div style={{ fontSize: "0.68rem", color: "var(--text-muted)", fontWeight: 600 }}>
-              {stats.tackles}tkl{stats.sacks > 0 ? ` · ${stats.sacks}sk` : ""}{stats.passDefls > 0 ? ` · ${stats.passDefls}pd` : ""}
-            </div>
-          )}
+          <div style={{ fontSize: "0.68rem", color: "var(--text-muted)", fontWeight: 600 }}>
+            {statLine}
+          </div>
         </div>
         <div style={{ fontSize: "0.65rem", color: "var(--text-subtle)", marginLeft: 4 }}>
           {expanded ? "▲" : "▼"}
         </div>
       </div>
 
-      {/* Expanded sub-grades */}
       {expanded && subKeys.length > 0 && (
         <div style={{ marginTop: 10, paddingTop: 10, borderTop: "1px solid var(--hairline)" }}>
-          {subKeys.map(k => (
+          {limitedSample && (
+            <div style={{ fontSize: "0.66rem", color: "var(--text-muted)", marginBottom: 8, fontStyle: "italic" }}>
+              Limited sample — grade regressed toward league-average until participation is sufficient.
+            </div>
+          )}
+          {subKeys.map((k) => (
             <RadarBar key={k} label={k.replace(/([A-Z])/g, " $1").trim()} value={sub[k]} />
           ))}
         </div>
@@ -297,89 +130,102 @@ function PlayerGradeCard({ entry }) {
   );
 }
 
-// ── Main component ─────────────────────────────────────────────────────────────
+function FilterButton({ active, onClick, children }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        flex: "0 0 auto",
+        padding: "5px 12px",
+        background: active ? "var(--accent, #0A84FF)" : "transparent",
+        color: active ? "#fff" : "var(--text-muted)",
+        border: `1px solid ${active ? "var(--accent, #0A84FF)" : "var(--hairline)"}`,
+        borderRadius: 8, fontWeight: 700, fontSize: "0.72rem", cursor: "pointer",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </button>
+  );
+}
 
-export default function AdvancedStats({ logs, homeTeam, awayTeam }) {
-  const graded = useMemo(() => computeGrades(logs || []), [logs]);
-  const entries = Object.values(graded);
+export default function AdvancedStats({ playerStats, homeTeam, awayTeam, userTeamId }) {
+  const userIsHome = homeTeam?.id != null && homeTeam.id === userTeamId;
+  const userIsAway = awayTeam?.id != null && awayTeam.id === userTeamId;
 
-  const offPlayers = entries
-    .filter(e => ["QB","RB","WR","TE","OL"].includes(e.pos))
-    .sort((a, b) => b.overall - a.overall);
-  const defPlayers = entries
-    .filter(e => ["DL","DE","DT","LB","CB","S"].includes(e.pos))
-    .sort((a, b) => b.overall - a.overall);
-  const allPlayers = [...entries].sort((a, b) => b.overall - a.overall);
+  // Grade each team's canonical box score with team attribution.
+  const { homeRows, awayRows } = useMemo(() => {
+    const home = gradeTeamBoxScore(playerStats?.home ?? {}, {
+      teamId: homeTeam?.id, teamAbbr: homeTeam?.abbr, teamSide: "home",
+    });
+    const away = gradeTeamBoxScore(playerStats?.away ?? {}, {
+      teamId: awayTeam?.id, teamAbbr: awayTeam?.abbr, teamSide: "away",
+    });
+    return { homeRows: home, awayRows: away };
+  }, [playerStats, homeTeam?.id, homeTeam?.abbr, awayTeam?.id, awayTeam?.abbr]);
 
-  if (!logs?.length) {
+  const hasAny = homeRows.length > 0 || awayRows.length > 0;
+
+  // Default team view: the user's team when identifiable, else home.
+  const defaultTeam = userIsAway ? "away" : "home";
+  const [teamView, setTeamView] = useState(defaultTeam); // "home" | "away" | "all"
+  const [sideView, setSideView] = useState("offense");   // "offense" | "defense"
+
+  const rows = useMemo(() => {
+    let base = teamView === "home" ? homeRows : teamView === "away" ? awayRows : [...homeRows, ...awayRows];
+    base = base.filter((r) => r.side === sideView);
+    return base.sort((a, b) => b.overall - a.overall).slice(0, 16);
+  }, [teamView, sideView, homeRows, awayRows]);
+
+  if (!hasAny) {
     return (
-      <div style={{ padding: "24px 16px", textAlign: "center", color: "var(--text-muted)" }}>
-        No play data available for grade calculations.
+      <div data-testid="grades-unavailable" style={{ padding: "24px 16px", textAlign: "center", color: "var(--text-muted)", fontSize: "0.85rem" }}>
+        Canonical player stats are not available for this game, so performance grades cannot be shown.
       </div>
     );
   }
+
+  const homeLabel = homeTeam?.abbr ?? "HOME";
+  const awayLabel = awayTeam?.abbr ?? "AWAY";
 
   return (
     <Card className="card-premium" style={{ paddingBottom: 16 }}>
       <CardHeader style={{ padding: "12px 16px 8px" }}>
         <CardTitle style={{ fontSize: "0.65rem", fontWeight: 800,
           color: "var(--text-subtle)", textTransform: "uppercase", letterSpacing: "1px" }}>
-          PFF-Style Performance Grades
+          Game Performance Grades
         </CardTitle>
+        <div style={{ fontSize: "0.6rem", color: "var(--text-subtle)", marginTop: 2, fontWeight: 500 }}>
+          In-game estimate from simulated production &amp; participation
+        </div>
       </CardHeader>
-      <CardContent style={{ padding: 0 }}>
-        <Tabs defaultValue="offense">
-          <TabsList style={{ margin: "0 16px 12px", gap: 6 }}>
-            <TabsTrigger value="offense">⚔️ Offense</TabsTrigger>
-            <TabsTrigger value="defense">🛡️ Defense</TabsTrigger>
-            <TabsTrigger value="all">All Players</TabsTrigger>
-          </TabsList>
+      <CardContent style={{ padding: "0 16px" }}>
+        {/* Team attribution filter (defaults to the user's team) */}
+        <div style={{ display: "flex", gap: 6, marginBottom: 8, overflowX: "auto", paddingBottom: 2 }} data-testid="grade-team-filter">
+          <FilterButton active={teamView === "home"} onClick={() => setTeamView("home")}>
+            {homeLabel}{userIsHome ? " ★" : ""}
+          </FilterButton>
+          <FilterButton active={teamView === "away"} onClick={() => setTeamView("away")}>
+            {awayLabel}{userIsAway ? " ★" : ""}
+          </FilterButton>
+          <FilterButton active={teamView === "all"} onClick={() => setTeamView("all")}>All</FilterButton>
+        </div>
+        {/* Offense / Defense sub-filter */}
+        <div style={{ display: "flex", gap: 6, marginBottom: 12 }}>
+          <FilterButton active={sideView === "offense"} onClick={() => setSideView("offense")}>⚔️ Offense</FilterButton>
+          <FilterButton active={sideView === "defense"} onClick={() => setSideView("defense")}>🛡️ Defense</FilterButton>
+        </div>
 
-          <TabsContent value="offense">
-            <ScrollArea className="h-[500px]">
-              <div style={{ padding: "0 16px" }}>
-                {offPlayers.slice(0, 12).map((entry, i) => (
-                  <PlayerGradeCard key={i} entry={entry} />
-                ))}
-                {offPlayers.length === 0 && (
-                  <div style={{ textAlign: "center", padding: 24, color: "var(--text-muted)", fontSize: "0.85rem" }}>
-                    No players in this category.
-                  </div>
-                )}
-              </div>
-            </ScrollArea>
-          </TabsContent>
-
-          <TabsContent value="defense">
-            <ScrollArea className="h-[500px]">
-              <div style={{ padding: "0 16px" }}>
-                {defPlayers.slice(0, 12).map((entry, i) => (
-                  <PlayerGradeCard key={i} entry={entry} />
-                ))}
-                {defPlayers.length === 0 && (
-                  <div style={{ textAlign: "center", padding: 24, color: "var(--text-muted)", fontSize: "0.85rem" }}>
-                    No players in this category.
-                  </div>
-                )}
-              </div>
-            </ScrollArea>
-          </TabsContent>
-
-          <TabsContent value="all">
-            <ScrollArea className="h-[500px]">
-              <div style={{ padding: "0 16px" }}>
-                {allPlayers.slice(0, 12).map((entry, i) => (
-                  <PlayerGradeCard key={i} entry={entry} />
-                ))}
-                {allPlayers.length === 0 && (
-                  <div style={{ textAlign: "center", padding: 24, color: "var(--text-muted)", fontSize: "0.85rem" }}>
-                    No players in this category.
-                  </div>
-                )}
-              </div>
-            </ScrollArea>
-          </TabsContent>
-        </Tabs>
+        <div>
+          {rows.length > 0 ? (
+            rows.map((entry) => <PlayerGradeCard key={`${entry.teamSide}-${entry.playerId}`} entry={entry} />)
+          ) : (
+            <div style={{ textAlign: "center", padding: 20, color: "var(--text-muted)", fontSize: "0.82rem" }}>
+              No graded {sideView} players for this team.
+            </div>
+          )}
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/ui/components/PostGameScreen.jsx
+++ b/src/ui/components/PostGameScreen.jsx
@@ -14,7 +14,7 @@ import React, { useMemo, useState, Component } from "react";
 import PlayerCard from "./PlayerCard.jsx";
 import AdvancedStats from "./AdvancedStats.jsx";
 import { buildGameFlowSummary } from "../../core/sim/gameFlowSummary.js";
-import { buildReasoningBullets } from "../../core/gameSummary.js";
+import { buildReasoningBullets, buildPlayerLeadersFromArchive } from "../../core/gameSummary.js";
 import { readStrictFinalScore } from "../../core/gameArchive.js";
 import ReplayableGameFlowViewer from "./ReplayableGameFlowViewer.jsx";
 
@@ -141,136 +141,60 @@ function Confetti({ colors }) {
   );
 }
 
+
+const asNum = (v) => { const n = Number(v); return Number.isFinite(n) ? n : 0; };
+
 /**
- * Derives structured playerStats ({ home: {[pid]: {name,pos,stats}}, away: {...} })
- * from raw play-by-play logs. Used to populate the archive so the Game Book
- * can display player names when the game is reopened.
+ * Derive game leaders from the CANONICAL player box score (the same authority
+ * that owns the final score) — never from narration play-logs. Returns
+ * team-attributed, pre-formatted leader cards for Passing / Rushing / Receiving
+ * / Defense. When canonical stats are absent, returns no leaders (honest empty
+ * state) rather than recounting narration references.
  */
-function derivePlayerStatsFromLogs(logs, homeId, awayId) {
-  const home = {};
-  const away = {};
-
-  const getSide = (teamId) => {
-    const tid = Number(teamId);
-    if (Number.isFinite(tid)) {
-      if (tid === Number(homeId)) return home;
-      if (tid === Number(awayId)) return away;
-    }
-    return null;
-  };
-
-  const addStats = (player, side, statKey, value = 1) => {
-    if (!player || typeof player !== 'object' || !side) return;
-    const pid = String(player.id ?? player.name ?? '?');
-    if (pid === '?') return;
-    if (!side[pid]) {
-      side[pid] = { name: player.name ?? null, pos: player.pos ?? player.position ?? '—', stats: {} };
-    }
-    if (player.name && !side[pid].name) side[pid].name = player.name;
-    side[pid].stats[statKey] = (side[pid].stats[statKey] ?? 0) + (Number(value) || 0);
-  };
-
-  for (const log of (Array.isArray(logs) ? logs : [])) {
-    if (!log || typeof log !== 'object') continue;
-    const offTeamId = log.teamId ?? log.offenseTeamId ?? log.possessionTeamId ?? null;
-    const offSide = getSide(offTeamId);
-    const defTeamId = offTeamId != null
-      ? (Number(offTeamId) === Number(homeId) ? awayId : homeId)
-      : null;
-    const defSide = getSide(defTeamId);
-
-    if (log.passer) {
-      const pSide = getSide(log.passer.teamId) ?? offSide;
-      addStats(log.passer, pSide, 'passAtt');
-      if (log.completed) {
-        addStats(log.passer, pSide, 'passComp');
-        addStats(log.passer, pSide, 'passYd', log.passYds ?? log.yards ?? 0);
-      }
-      if (log.isTouchdown && log.tdType === 'pass') addStats(log.passer, pSide, 'passTD');
-    }
-
-    if (log.player) {
-      const plSide = getSide(log.player.teamId) ?? offSide;
-      if (log.type === 'run' || log.tdType === 'rush' || (log.rushYds != null && !log.passer)) {
-        addStats(log.player, plSide, 'rushAtt');
-        addStats(log.player, plSide, 'rushYd', log.rushYds ?? log.yards ?? 0);
-        if (log.isTouchdown) addStats(log.player, plSide, 'rushTD');
-      }
-      if (log.completed && log.recYds != null) {
-        addStats(log.player, plSide, 'receptions');
-        addStats(log.player, plSide, 'recYd', log.recYds ?? log.yards ?? 0);
-        if (log.isTouchdown && log.tdType === 'pass') addStats(log.player, plSide, 'recTD');
-      }
-    }
-
-    if (log.tackler) {
-      const tSide = getSide(log.tackler.teamId) ?? defSide;
-      addStats(log.tackler, tSide, 'tackles');
-    }
-    if (log.defender) {
-      const dSide = getSide(log.defender.teamId) ?? defSide;
-      addStats(log.defender, dSide, 'passesDefended');
-    }
-  }
-
-  return { home, away };
-}
-
-// Derive game leaders from play logs (accumulated stats per player)
-function useGameLeaders(logs) {
+function useCanonicalLeaders(playerStats, context) {
   return useMemo(() => {
     const empty = { qb: null, receiver: null, rusher: null, defender: null };
     try {
-      if (!Array.isArray(logs) || !logs.length) return empty;
-      const acc = {};
-      const addP = (p, key, val = 1) => {
-        if (!p || typeof p !== "object") return;
-        const id = String(p.id ?? p.name ?? "?");
-        if (!acc[id]) acc[id] = { ref: p, passAtt: 0, passComp: 0, passYds: 0, passTDs: 0, rushAtt: 0, rushYds: 0, rushTDs: 0, receptions: 0, recYds: 0, recTDs: 0, sacks: 0, ints: 0, tackles: 0, passDefls: 0, forcedFumbles: 0 };
-        acc[id][key] = (acc[id][key] || 0) + (Number(val) || 0);
+      const hasStats = playerStats
+        && (Object.keys(playerStats.home ?? {}).length || Object.keys(playerStats.away ?? {}).length);
+      if (!hasStats) return empty;
+      const { categories } = buildPlayerLeadersFromArchive(playerStats, context);
+      const teamAbbr = (teamId) => (
+        Number(teamId) === Number(context.homeId) ? context.homeAbbr
+          : Number(teamId) === Number(context.awayId) ? context.awayAbbr : null
+      );
+      const format = (row, kind) => {
+        if (!row) return null;
+        const s = row.stats ?? {};
+        let statLine = "";
+        if (kind === "passing") statLine = `${asNum(s.passComp)}/${asNum(s.passAtt)} · ${asNum(s.passYd)} yds${asNum(s.passTD) ? ` · ${asNum(s.passTD)} TD` : ""}`;
+        else if (kind === "receiving") statLine = `${asNum(s.receptions)} rec · ${asNum(s.recYd)} yds${asNum(s.recTD) ? ` · ${asNum(s.recTD)} TD` : ""}`;
+        else if (kind === "rushing") statLine = `${asNum(s.rushAtt)} car · ${asNum(s.rushYd)} yds${asNum(s.rushTD) ? ` · ${asNum(s.rushTD)} TD` : ""}`;
+        else {
+          statLine = [
+            asNum(s.tackles) ? `${asNum(s.tackles)} tkl` : "",
+            asNum(s.sacks) ? `${asNum(s.sacks)} sack${asNum(s.sacks) > 1 ? "s" : ""}` : "",
+            asNum(s.interceptions) ? `${asNum(s.interceptions)} INT` : "",
+            asNum(s.passesDefended) ? `${asNum(s.passesDefended)} PD` : "",
+          ].filter(Boolean).join(" · ");
+        }
+        return { name: row.name, pos: row.pos, teamAbbr: teamAbbr(row.teamId), statLine };
       };
-      for (const l of logs) {
-        if (!l || typeof l !== "object") continue;
-        if (l.passer) {
-          addP(l.passer, "passAtt");
-          if (l.completed) { addP(l.passer, "passComp"); addP(l.passer, "passYds", l.passYds || l.yards || 0); }
-          if (l.isTouchdown && l.tdType === "pass") addP(l.passer, "passTDs");
-        }
-        if (l.rushYds != null && l.player && (l.type === "run" || l.tdType === "rush")) {
-          addP(l.player, "rushAtt");
-          addP(l.player, "rushYds", l.rushYds || l.yards || 0);
-          if (l.isTouchdown) addP(l.player, "rushTDs");
-        }
-        if (l.recYds != null && l.player && l.completed) {
-          addP(l.player, "receptions");
-          addP(l.player, "recYds", l.recYds || l.yards || 0);
-          if (l.isTouchdown && l.tdType === "pass") addP(l.player, "recTDs");
-        }
-        if (l.type === "sack" && l.player) addP(l.player, "sacks");
-        if (l.type === "interception" && l.player) addP(l.player, "ints");
-        if (l.tackler) addP(l.tackler, "tackles");
-        if (l.defender) addP(l.defender, "passDefls");
-        if (l.forcedFumble) addP(l.forcedFumble, "forcedFumbles");
-      }
-      const players = Object.values(acc);
-      const qb = players.filter(p => p.ref?.pos === "QB").sort((a, b) => b.passYds - a.passYds)[0] || null;
-      const receiver = players.filter(p => p.ref?.pos !== "QB" && p.recYds > 0).sort((a, b) => b.recYds - a.recYds)[0] || null;
-      const rusher = players.filter(p => p.ref?.pos !== "QB" && p.rushYds > 0 && p !== receiver).sort((a, b) => b.rushYds - a.rushYds)[0] || null;
-      const defender = players
-        .filter(p => p.sacks > 0 || p.ints > 0 || p.tackles > 0 || p.passDefls > 0 || p.forcedFumbles > 0)
-        .sort((a, b) => (b.sacks * 4 + b.ints * 5 + b.tackles * 1 + b.passDefls * 2 + b.forcedFumbles * 3)
-                      - (a.sacks * 4 + a.ints * 5 + a.tackles * 1 + a.passDefls * 2 + a.forcedFumbles * 3))[0] || null;
-      return { qb, receiver, rusher, defender };
+      return {
+        qb: format(categories.passing, "passing"),
+        receiver: format(categories.receiving, "receiving"),
+        rusher: format(categories.rushing, "rushing"),
+        defender: format(categories.defense, "defense"),
+      };
     } catch (err) {
-      console.error('[useGameLeaders] error:', err);
+      console.error('[useCanonicalLeaders] error:', err);
       return empty;
     }
-  }, [logs]);
+  }, [playerStats, context]);
 }
 
-function LeaderCard({ label, statLine, player, color }) {
-  if (!player) return null;
-  const p = player.ref;
+function LeaderCard({ label, player, color }) {
+  if (!player || !player.statLine) return null;
   return (
     <div style={{
       background: "var(--surface)", border: "1px solid var(--hairline)",
@@ -283,17 +207,25 @@ function LeaderCard({ label, statLine, player, color }) {
         display: "flex", alignItems: "center", justifyContent: "center",
         fontSize: "0.68rem", fontWeight: 900, color,
       }}>
-        {p?.pos || "?"}
+        {player.pos || "?"}
       </div>
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ fontSize: "0.62rem", fontWeight: 700, color: "var(--text-subtle)", textTransform: "uppercase", letterSpacing: "0.8px", marginBottom: 2 }}>
           {label}
         </div>
-        <div style={{ fontSize: "0.85rem", fontWeight: 800, color: "var(--text)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-          {p?.name || "?"}
+        <div style={{ fontSize: "0.85rem", fontWeight: 800, color: "var(--text)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", display: "flex", alignItems: "center", gap: 6 }}>
+          {player.teamAbbr && (
+            <span style={{
+              fontSize: "0.55rem", fontWeight: 800, color: "var(--text-subtle)",
+              background: "var(--surface-strong, rgba(255,255,255,0.08))",
+              border: "1px solid var(--hairline)", borderRadius: 5,
+              padding: "1px 5px", letterSpacing: "0.5px", flexShrink: 0,
+            }}>{player.teamAbbr}</span>
+          )}
+          <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{player.name || "?"}</span>
         </div>
         <div style={{ fontSize: "0.72rem", color, fontWeight: 700, marginTop: 1 }}>
-          {statLine}
+          {player.statLine}
         </div>
       </div>
     </div>
@@ -308,7 +240,8 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
   userTeamId,
   mvpPlayer,          // optional player object (legacy)
   stats = {},         // { totalYards, passYards, rushYards, turnovers }
-  logs = [],          // play-by-play logs for deriving leaders
+  logs = [],          // play-by-play logs (presentation-only: game flow / key moments)
+  playerStats = null, // CANONICAL box score { home: {[pid]:{name,pos,stats}}, away: {...} }
   gameReasoningFlags = [],
   boxScoreGameId,
   onOpenBoxScore,
@@ -344,7 +277,14 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
     return () => clearTimeout(t);
   }, []);
 
-  const { qb, receiver, rusher, defender } = useGameLeaders(logs);
+  const leaderContext = useMemo(() => ({
+    homeId: homeTeam?.id, awayId: awayTeam?.id,
+    homeAbbr: homeTeam?.abbr, awayAbbr: awayTeam?.abbr,
+  }), [homeTeam?.id, awayTeam?.id, homeTeam?.abbr, awayTeam?.abbr]);
+  const { qb, receiver, rusher, defender } = useCanonicalLeaders(playerStats, leaderContext);
+  const hasCanonicalStats = Boolean(
+    playerStats && (Object.keys(playerStats.home ?? {}).length || Object.keys(playerStats.away ?? {}).length),
+  );
   const gfs = useMemo(() => buildGameFlowSummary(rawGameRecord ?? boxScoreGame ?? gameRecord ?? null), [rawGameRecord, boxScoreGame, gameRecord]);
   const [showReplay, setShowReplay] = useState(false);
 
@@ -355,27 +295,7 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
   // Only render the interactive Game Flow card when it has real content.
   const hasGameFlow = Boolean(gfs) || notableMoments.length > 0;
 
-  // Build leader stat lines
-  const qbLine = qb
-    ? `${qb.passComp}/${qb.passAtt} · ${qb.passYds} yds${qb.passTDs > 0 ? ` · ${qb.passTDs} TD` : ""}`
-    : null;
-  const recLine = receiver
-    ? `${receiver.receptions} rec · ${receiver.recYds} yds${receiver.recTDs > 0 ? ` · ${receiver.recTDs} TD` : ""}`
-    : null;
-  const rushLine = rusher
-    ? `${rusher.rushAtt} car · ${rusher.rushYds} yds${rusher.rushTDs > 0 ? ` · ${rusher.rushTDs} TD` : ""}`
-    : null;
-  const defLine = defender
-    ? [
-        defender.tackles > 0 ? `${defender.tackles} tkl` : "",
-        defender.sacks > 0 ? `${defender.sacks} sack${defender.sacks > 1 ? "s" : ""}` : "",
-        defender.ints > 0 ? `${defender.ints} INT` : "",
-        defender.passDefls > 0 ? `${defender.passDefls} PD` : "",
-        defender.forcedFumbles > 0 ? `${defender.forcedFumbles} FF` : "",
-      ].filter(Boolean).join(" · ")
-    : null;
-
-  const showLeaders = qb || receiver || rusher || defender;
+  const showLeaders = Boolean(qb || receiver || rusher || defender);
 
   console.debug('[PostGameScreen] gameReasoningFlags length:', gameReasoningFlags?.length ?? 0);
   const reasoningBullets = useMemo(
@@ -389,7 +309,13 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
     const recapText = notableMoments.length
       ? notableMoments.map((m) => `Q${m.quarter ?? "?"} ${m.clock ?? ""} ${m.text ?? "Momentum swing"}`).join(" ")
       : `${awayTeam?.abbr ?? "AWY"} ${strictFinalScore.away} - ${strictFinalScore.home} ${homeTeam?.abbr ?? "HME"}`;
-    const derivedPlayerStats = derivePlayerStatsFromLogs(logs, homeTeam?.id, awayTeam?.id);
+    // Persist the CANONICAL box score, never narration-derived player totals, so
+    // the Game Book and season accumulation read the same authority the score
+    // came from. Fall back to empty sides when canonical stats are unavailable
+    // rather than recounting play-log references.
+    const canonicalPlayerStats = hasCanonicalStats
+      ? { home: playerStats.home ?? {}, away: playerStats.away ?? {} }
+      : { home: {}, away: {} };
     onArchiveReady({
       gameId: boxScoreGameId,
       season: null,
@@ -402,14 +328,14 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
       awayScore: strictFinalScore.away,
       recapText,
       logs,
-      playerStats: derivedPlayerStats,
+      playerStats: canonicalPlayerStats,
       scoringSummary: notableMoments,
       summary: {
         storyline: recapText,
         simOutputs: null,
       },
     });
-  }, [awayScore, awayTeam?.abbr, awayTeam?.id, boxScoreGameId, homeScore, homeTeam?.abbr, homeTeam?.id, logs, notableMoments, onArchiveReady, strictFinalScore, week]);
+  }, [awayScore, awayTeam?.abbr, awayTeam?.id, boxScoreGameId, hasCanonicalStats, homeScore, homeTeam?.abbr, homeTeam?.id, logs, notableMoments, onArchiveReady, playerStats, strictFinalScore, week]);
 
   const canOpenGameBook = Boolean(boxScoreGameId && hasStrictFinal);
 
@@ -650,7 +576,7 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
           )}
 
           {/* ── Tab switcher (Leaders / Grades) ── */}
-          {(showLeaders || logs.length > 0) && (
+          {(showLeaders || hasCanonicalStats) && (
             <div style={{
               display: "flex", background: "var(--surface)",
               border: "1px solid var(--hairline)", borderRadius: 10,
@@ -674,30 +600,27 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
             </div>
           )}
 
-          {/* ── Game Leaders ── */}
+          {/* ── Game Leaders (canonical box score) ── */}
           {activeTab === "leaders" && showLeaders && (
             <div style={{ marginBottom: 12 }}>
               <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-                {qb && qbLine && (
-                  <LeaderCard label="Passing" statLine={qbLine} player={qb} color="#FF9F0A" />
-                )}
-                {receiver && recLine && (
-                  <LeaderCard label="Receiving" statLine={recLine} player={receiver} color="#0A84FF" />
-                )}
-                {rusher && rushLine && (
-                  <LeaderCard label="Rushing" statLine={rushLine} player={rusher} color="#34C759" />
-                )}
-                {defender && defLine && (
-                  <LeaderCard label="Defense" statLine={defLine} player={defender} color="#FF453A" />
-                )}
+                <LeaderCard label="Passing" player={qb} color="#FF9F0A" />
+                <LeaderCard label="Receiving" player={receiver} color="#0A84FF" />
+                <LeaderCard label="Rushing" player={rusher} color="#34C759" />
+                <LeaderCard label="Defense" player={defender} color="#FF453A" />
               </div>
             </div>
           )}
 
-          {/* ── PFF Grades tab ── */}
-          {activeTab === "grades" && logs.length > 0 && (
+          {/* ── Grades tab (canonical box score) ── */}
+          {activeTab === "grades" && hasCanonicalStats && (
             <div style={{ marginBottom: 16, background: "var(--surface)", borderRadius: 12, overflow: "hidden", border: "1px solid var(--hairline)" }}>
-              <AdvancedStats logs={logs} homeTeam={homeTeam} awayTeam={awayTeam} />
+              <AdvancedStats
+                playerStats={playerStats}
+                homeTeam={homeTeam}
+                awayTeam={awayTeam}
+                userTeamId={userTeamId}
+              />
             </div>
           )}
 

--- a/src/ui/components/PostGameScreen.test.jsx
+++ b/src/ui/components/PostGameScreen.test.jsx
@@ -25,13 +25,21 @@ describe('PostGameScreen resilience', () => {
 describe('PostGameScreen onArchiveReady payload', () => {
   beforeEach(() => { cleanup(); });
 
-  it('includes playerStats derived from logs in the archive payload', async () => {
+  it('persists the canonical playerStats (not narration logs) in the archive payload', async () => {
     const archiveSpy = vi.fn();
+    // Canonical box score is the authority; narration logs must NOT be the
+    // source of archived player totals.
+    const playerStats = {
+      home: {
+        10: { name: 'Home QB', pos: 'QB', stats: { passComp: 24, passAtt: 34, passYd: 288, passTD: 3 } },
+        30: { name: 'Home RB', pos: 'RB', stats: { rushAtt: 18, rushYd: 92, rushTD: 1 } },
+      },
+      away: {
+        20: { name: 'Away QB', pos: 'QB', stats: { passComp: 19, passAtt: 30, passYd: 205 } },
+      },
+    };
     const logs = [
-      { teamId: 1, passer: { id: 10, name: 'Home QB', pos: 'QB' }, passYds: 220, completed: true },
-      { teamId: 1, passer: { id: 10, name: 'Home QB', pos: 'QB' }, passYds: 15, completed: true, isTouchdown: true, tdType: 'pass' },
-      { teamId: 2, passer: { id: 20, name: 'Away QB', pos: 'QB' }, passYds: 180, completed: true },
-      { teamId: 1, player: { id: 30, name: 'Home RB', pos: 'RB' }, rushYds: 55, type: 'run' },
+      { teamId: 1, passer: { id: 99, name: 'Narration Ghost QB', pos: 'QB' }, passYds: 15, completed: true },
     ];
 
     await act(async () => {
@@ -44,6 +52,7 @@ describe('PostGameScreen onArchiveReady payload', () => {
           userTeamId={1}
           boxScoreGameId="test-game-123"
           logs={logs}
+          playerStats={playerStats}
           week={3}
           onArchiveReady={archiveSpy}
           onContinue={() => {}}
@@ -53,17 +62,18 @@ describe('PostGameScreen onArchiveReady payload', () => {
 
     expect(archiveSpy).toHaveBeenCalledOnce();
     const payload = archiveSpy.mock.calls[0][0];
-    expect(payload.playerStats).toBeDefined();
-    expect(payload.playerStats.home).toBeDefined();
-    expect(payload.playerStats.away).toBeDefined();
+    expect(payload.playerStats).toEqual(playerStats);
+    // The narration-only "ghost" passer never leaks into archived player stats.
+    const allNames = [...Object.values(payload.playerStats.home), ...Object.values(payload.playerStats.away)].map((r) => r.name);
+    expect(allNames).not.toContain('Narration Ghost QB');
   });
 
-  it('preserves player names in derived playerStats', async () => {
+  it('preserves player names in canonical playerStats', async () => {
     const archiveSpy = vi.fn();
-    const logs = [
-      { teamId: 1, passer: { id: 10, name: 'Home QB', pos: 'QB' }, passYds: 200, completed: true },
-      { teamId: 2, passer: { id: 20, name: 'Away QB', pos: 'QB' }, passYds: 150, completed: true },
-    ];
+    const playerStats = {
+      home: { 10: { name: 'Home QB', pos: 'QB', stats: { passComp: 18, passAtt: 27, passYd: 210 } } },
+      away: { 20: { name: 'Away QB', pos: 'QB', stats: { passComp: 14, passAtt: 24, passYd: 160 } } },
+    };
 
     await act(async () => {
       render(
@@ -74,7 +84,7 @@ describe('PostGameScreen onArchiveReady payload', () => {
           awayScore={14}
           userTeamId={1}
           boxScoreGameId="test-game-456"
-          logs={logs}
+          playerStats={playerStats}
           week={1}
           onArchiveReady={archiveSpy}
           onContinue={() => {}}
@@ -84,17 +94,15 @@ describe('PostGameScreen onArchiveReady payload', () => {
 
     expect(archiveSpy).toHaveBeenCalledOnce();
     const payload = archiveSpy.mock.calls[0][0];
-    const homeRows = Object.values(payload.playerStats.home);
-    const awayRows = Object.values(payload.playerStats.away);
-    const homeQB = homeRows.find((r) => r.name === 'Home QB');
-    const awayQB = awayRows.find((r) => r.name === 'Away QB');
+    const homeQB = Object.values(payload.playerStats.home).find((r) => r.name === 'Home QB');
+    const awayQB = Object.values(payload.playerStats.away).find((r) => r.name === 'Away QB');
     expect(homeQB).toBeDefined();
     expect(awayQB).toBeDefined();
     expect(homeQB.stats.passAtt).toBeGreaterThanOrEqual(1);
     expect(awayQB.stats.passAtt).toBeGreaterThanOrEqual(1);
   });
 
-  it('does not crash when logs are empty and still calls onArchiveReady with empty playerStats', async () => {
+  it('does not crash when canonical stats are absent and still archives empty playerStats', async () => {
     const archiveSpy = vi.fn();
     await act(async () => {
       render(

--- a/src/ui/components/__tests__/AdvancedStatsCanonical.test.jsx
+++ b/src/ui/components/__tests__/AdvancedStatsCanonical.test.jsx
@@ -1,0 +1,97 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, it, expect } from 'vitest';
+import { cleanup, render, screen, fireEvent, within } from '@testing-library/react';
+import AdvancedStats from '../AdvancedStats.jsx';
+
+const playerStats = {
+  home: {
+    10: { name: 'Home Starter QB', pos: 'QB', stats: { passAtt: 33, passComp: 24, passYd: 288, passTD: 3, interceptions: 1 } },
+    30: { name: 'Home RB', pos: 'RB', stats: { rushAtt: 18, rushYd: 96, rushTD: 1 } },
+    40: { name: 'Home CB', pos: 'CB', stats: { tackles: 6, passesDefended: 2, interceptions: 1 } },
+  },
+  away: {
+    20: { name: 'Away Starter QB', pos: 'QB', stats: { passAtt: 30, passComp: 18, passYd: 205, passTD: 1, interceptions: 2 } },
+    50: { name: 'Away WR One Catch', pos: 'WR', stats: { targets: 1, receptions: 1, recYd: 14 } },
+  },
+};
+
+const homeTeam = { id: 1, abbr: 'NYJ', name: 'Jets' };
+const awayTeam = { id: 2, abbr: 'BAL', name: 'Ravens' };
+
+describe('AdvancedStats — canonical Game Performance Grades', () => {
+  afterEach(() => cleanup());
+
+  it('uses no external-brand language (no "PFF" / "PFF-Style")', () => {
+    const { container } = render(
+      <AdvancedStats playerStats={playerStats} homeTeam={homeTeam} awayTeam={awayTeam} userTeamId={1} />,
+    );
+    expect(container.textContent).not.toMatch(/PFF/i);
+    expect(container.textContent).toMatch(/Game Performance Grades/i);
+  });
+
+  it('never labels a value as "snaps"', () => {
+    const { container } = render(
+      <AdvancedStats playerStats={playerStats} homeTeam={homeTeam} awayTeam={awayTeam} userTeamId={1} />,
+    );
+    expect(container.textContent).not.toMatch(/snap/i);
+  });
+
+  it('defaults to the user team and tags every row with a team', () => {
+    render(
+      <AdvancedStats playerStats={playerStats} homeTeam={homeTeam} awayTeam={awayTeam} userTeamId={2} />,
+    );
+    // User is BAL (away) → default view shows BAL players only.
+    const rows = screen.getAllByTestId('grade-row');
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row.getAttribute('data-team')).toBe('BAL');
+      expect(within(row).getByTestId('grade-team-tag').textContent).toBe('BAL');
+    }
+  });
+
+  it('lets the user switch to the opponent and to All players', () => {
+    render(
+      <AdvancedStats playerStats={playerStats} homeTeam={homeTeam} awayTeam={awayTeam} userTeamId={1} />,
+    );
+    // Default: user is NYJ (home).
+    let rows = screen.getAllByTestId('grade-row');
+    expect(rows.every((r) => r.getAttribute('data-team') === 'NYJ')).toBe(true);
+
+    // Switch to opponent BAL.
+    fireEvent.click(screen.getByText('BAL'));
+    rows = screen.getAllByTestId('grade-row');
+    expect(rows.every((r) => r.getAttribute('data-team') === 'BAL')).toBe(true);
+
+    // Switch to All — both teams appear (offense side).
+    fireEvent.click(screen.getByText('All'));
+    rows = screen.getAllByTestId('grade-row');
+    const teams = new Set(rows.map((r) => r.getAttribute('data-team')));
+    expect(teams.has('NYJ')).toBe(true);
+    expect(teams.has('BAL')).toBe(true);
+  });
+
+  it('marks a one-catch receiver as Limited sample rather than Star/Elite', () => {
+    render(
+      <AdvancedStats playerStats={playerStats} homeTeam={homeTeam} awayTeam={awayTeam} userTeamId={2} />,
+    );
+    const row = screen.getAllByTestId('grade-row').find((r) => r.textContent.includes('Away WR One Catch'));
+    expect(row).toBeTruthy();
+    expect(row.getAttribute('data-limited')).toBe('1');
+    expect(row.textContent).toMatch(/Limited sample/i);
+    expect(row.textContent).not.toMatch(/Elite|Star/);
+  });
+
+  it('shows an honest unavailable state when canonical stats are missing', () => {
+    render(<AdvancedStats playerStats={null} homeTeam={homeTeam} awayTeam={awayTeam} userTeamId={1} />);
+    expect(screen.getByTestId('grades-unavailable')).toBeTruthy();
+  });
+
+  it('shows only one QB per team (no three-QB rotation)', () => {
+    render(
+      <AdvancedStats playerStats={playerStats} homeTeam={homeTeam} awayTeam={awayTeam} userTeamId={1} />,
+    );
+    const qbRows = screen.getAllByTestId('grade-row').filter((r) => r.getAttribute('data-pos') === 'QB');
+    expect(qbRows).toHaveLength(1);
+  });
+});

--- a/src/ui/components/__tests__/CanonicalPostgameIntegration.test.jsx
+++ b/src/ui/components/__tests__/CanonicalPostgameIntegration.test.jsx
@@ -1,0 +1,123 @@
+/** @vitest-environment jsdom */
+/**
+ * End-to-end canonical data-flow integration:
+ *   simulateBatch → worker PLAY_LOGS payload → PostGameScreen → archive → Game Book
+ *
+ * Proves the SAME canonical box score flows unaltered through every stage and
+ * that the passing leader + final score agree on the postgame screen and in the
+ * Game Book view model. No live worker: we reproduce the exact PLAY_LOGS payload
+ * that `handleWatchGame` posts, then drive the real UI + archive + Game Book code.
+ */
+import React from 'react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { Utils as U } from '../../../core/utils.js';
+import { simulateBatch } from '../../../core/simulation/index.js';
+import { buildPlayerLeadersFromArchive } from '../../../core/gameSummary.js';
+import { buildBoxScoreViewModel } from '../../utils/boxScoreViewModel.js';
+import PostGameScreen from '../PostGameScreen.jsx';
+
+function makePlayer(id, pos, ovr = 75) {
+  const ratings = {
+    QB: { throwPower: 82, throwAccuracy: 84, awareness: 82, speed: 70 },
+    RB: { speed: 88, trucking: 80, juking: 84 }, WR: { speed: 90, catching: 88 },
+    TE: { speed: 76, catching: 80 }, OL: { passBlock: 80, runBlock: 80 },
+    DL: { tackle: 76, strength: 80 }, LB: { tackle: 80 }, CB: { speed: 86 },
+    S: { tackle: 74 }, K: { kickAccuracy: 82 }, P: { kickPower: 80 },
+  };
+  return { id: `${id}`, pos, ovr, name: `${pos} ${id}`, ratings: ratings[pos] || {}, stats: { game: {}, season: {} } };
+}
+function buildTeam(id, abbr) {
+  return {
+    id, abbr, name: abbr,
+    roster: [
+      makePlayer(`${id}-qb1`, 'QB', 88), makePlayer(`${id}-qb2`, 'QB', 74),
+      makePlayer(`${id}-rb1`, 'RB', 84), makePlayer(`${id}-rb2`, 'RB', 74),
+      makePlayer(`${id}-wr1`, 'WR', 86), makePlayer(`${id}-wr2`, 'WR', 80), makePlayer(`${id}-wr3`, 'WR', 74),
+      makePlayer(`${id}-te1`, 'TE', 78),
+      ...[1, 2, 3, 4, 5].map((i) => makePlayer(`${id}-ol${i}`, 'OL', 76)),
+      makePlayer(`${id}-dl1`, 'DL', 80), makePlayer(`${id}-lb1`, 'LB', 78),
+      makePlayer(`${id}-cb1`, 'CB', 78), makePlayer(`${id}-s1`, 'S', 76),
+      makePlayer(`${id}-k1`, 'K', 78), makePlayer(`${id}-p1`, 'P', 74),
+    ],
+  };
+}
+
+function simulateUserGame(seed) {
+  const home = buildTeam(1, 'NYJ');
+  const away = buildTeam(2, 'BAL');
+  const league = { id: 'L', week: 6, seasonId: 2026, year: 2026, teams: [home, away], globalSeed: seed };
+  U.setSeed(seed);
+  const [res] = simulateBatch([{ home, away, week: 6 }], { league, generateLogs: true });
+  return { res, home, away, league };
+}
+
+describe('canonical postgame integration: simulateBatch → PLAY_LOGS → PostGameScreen → archive → Game Book', () => {
+  afterEach(() => cleanup());
+
+  it('carries one canonical box score through every surface with matching leaders and score', async () => {
+    const { res, home, away, league } = simulateUserGame(2026);
+    expect(res?.boxScore).toBeTruthy();
+
+    // 1) Exact PLAY_LOGS payload the worker's handleWatchGame posts.
+    const playLogsPayload = {
+      logs: res.playLogs || [],
+      liveStats: res.liveStats || {},
+      playerStats: res.boxScore ? { home: res.boxScore.home ?? {}, away: res.boxScore.away ?? {} } : null,
+      teamStats: res.teamStats ?? null,
+    };
+    expect(playLogsPayload.playerStats).toBeTruthy();
+
+    const homeTeam = { id: home.id, abbr: home.abbr, name: home.name };
+    const awayTeam = { id: away.id, abbr: away.abbr, name: away.name };
+    const finalHome = res.scoreHome ?? res.homeScore;
+    const finalAway = res.scoreAway ?? res.awayScore;
+
+    // 2) Render PostGameScreen with the canonical payload; capture the archive.
+    const archiveSpy = vi.fn();
+    await act(async () => {
+      render(
+        <PostGameScreen
+          homeTeam={homeTeam}
+          awayTeam={awayTeam}
+          homeScore={finalHome}
+          awayScore={finalAway}
+          userTeamId={home.id}
+          boxScoreGameId="integration-game"
+          logs={playLogsPayload.logs}
+          playerStats={playLogsPayload.playerStats}
+          week={6}
+          onArchiveReady={archiveSpy}
+          onContinue={() => {}}
+        />,
+      );
+    });
+
+    // 3) The archive persisted the canonical box score UNCHANGED (not narration).
+    expect(archiveSpy).toHaveBeenCalledOnce();
+    const archive = archiveSpy.mock.calls[0][0];
+    expect(archive.playerStats).toEqual(playLogsPayload.playerStats);
+
+    // 4) The canonical passing leader is the same computed from res.boxScore and
+    //    from the archived playerStats.
+    const ctx = { homeId: home.id, awayId: away.id, homeAbbr: home.abbr, awayAbbr: away.abbr };
+    const resLeader = buildPlayerLeadersFromArchive(res.boxScore, ctx).categories.passing;
+    const archiveLeader = buildPlayerLeadersFromArchive(archive.playerStats, ctx).categories.passing;
+    expect(archiveLeader.name).toBe(resLeader.name);
+    expect(archiveLeader.stats.passYd).toBe(resLeader.stats.passYd);
+
+    // 5) That leader is visible on the rendered PostGameScreen (Leaders tab).
+    expect(screen.getAllByText(resLeader.name).length).toBeGreaterThan(0);
+
+    // 6) The Game Book view model, fed the SAME archive, shows the same final
+    //    score and the same passing leader line — no swap to different totals.
+    const vm = buildBoxScoreViewModel({ league, game: archive, gameId: archive.gameId });
+    expect(vm.finalScore.home).toBe(finalHome);
+    expect(vm.finalScore.away).toBe(finalAway);
+    const gameBookLeaderSide = resLeader.teamId === home.id ? vm.playerTables.home : vm.playerTables.away;
+    const gameBookLeader = gameBookLeaderSide.find((p) => p.name === resLeader.name);
+    expect(gameBookLeader, 'passing leader must appear in the Game Book player tables').toBeTruthy();
+    const gbPassYd = Number(gameBookLeader.stats?.passYd ?? gameBookLeader.passYd);
+    expect(gbPassYd).toBe(resLeader.stats.passYd);
+  });
+});

--- a/src/ui/components/__tests__/PostGameMobilePolish.test.jsx
+++ b/src/ui/components/__tests__/PostGameMobilePolish.test.jsx
@@ -45,16 +45,16 @@ describe('PostGameScreen — compact leaders with partial data', () => {
   afterEach(() => cleanup());
 
   it('renders available leaders compactly and omits missing ones without crashing', async () => {
-    // Only a passing leader is derivable from these logs.
-    const logs = [
-      { teamId: 1, passer: { id: 10, name: 'Home QB', pos: 'QB' }, passYds: 240, completed: true },
-      { teamId: 1, passer: { id: 10, name: 'Home QB', pos: 'QB' }, passYds: 18, completed: true, isTouchdown: true, tdType: 'pass' },
-    ];
+    // Only a passing leader is present in the CANONICAL box score.
+    const playerStats = {
+      home: { 10: { name: 'Home QB', pos: 'QB', stats: { passComp: 22, passAtt: 31, passYd: 258, passTD: 2 } } },
+      away: {},
+    };
 
     let container;
     await act(async () => {
       ({ container } = render(
-        <PostGameScreen {...baseProps} logs={logs} boxScoreGameId="g2" week={5} />,
+        <PostGameScreen {...baseProps} playerStats={playerStats} boxScoreGameId="g2" week={5} />,
       ));
     });
 

--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -72,6 +72,8 @@ export const INITIAL_WORKER_STATE = {
   promptUserGame: false,
   userGameLogs: null,
   userGameLiveStats: null,
+  userGamePlayerStats: null,
+  userGameTeamStats: null,
   userGameReasoningFlags: null,
   lastWorkerMessageType: null,
 };
@@ -147,13 +149,13 @@ export function workerReducer(state, action) {
     case 'PROMPT_USER_GAME':
       return { ...state, busy: false, simulating: false, simProgress: 0, promptUserGame: true, userGameLogs: null };
     case 'PLAY_LOGS':
-      return { ...state, busy: false, simulating: false, promptUserGame: false, userGameLogs: action.logs, userGameLiveStats: action.liveStats || null, userGameReasoningFlags: action.gameReasoningFlags || [] };
+      return { ...state, busy: false, simulating: false, promptUserGame: false, userGameLogs: action.logs, userGameLiveStats: action.liveStats || null, userGamePlayerStats: action.playerStats || null, userGameTeamStats: action.teamStats || null, userGameReasoningFlags: action.gameReasoningFlags || [] };
     case 'CLEAR_USER_GAME':
-      return { ...state, promptUserGame: false, userGameLogs: null, userGameLiveStats: null, userGameReasoningFlags: null };
+      return { ...state, promptUserGame: false, userGameLogs: null, userGameLiveStats: null, userGamePlayerStats: null, userGameTeamStats: null, userGameReasoningFlags: null };
     case 'CLEAR_RESULTS':
       return { ...state, lastResults: [], lastSimWeek: null, gameEvents: [] };
     case 'SIM_START':
-      return { ...state, simulating: true, simProgress: 0, gameEvents: [], promptUserGame: false, userGameLogs: null, userGameReasoningFlags: null };
+      return { ...state, simulating: true, simProgress: 0, gameEvents: [], promptUserGame: false, userGameLogs: null, userGamePlayerStats: null, userGameTeamStats: null, userGameReasoningFlags: null };
     case 'BATCH_SIM_START':
       return { ...state, busy: true, batchSim: { currentWeek: 0, phase: '', targetPhase: action.targetPhase, status: 'running' } };
     case 'BATCH_SIM_PROGRESS':

--- a/src/ui/utils/gamePerformanceGrades.js
+++ b/src/ui/utils/gamePerformanceGrades.js
@@ -1,0 +1,248 @@
+/**
+ * gamePerformanceGrades.js — Game Performance Grades (canonical, in-game)
+ * ─────────────────────────────────────────────────────────────────────
+ * Deterministic, position-aware performance grades derived ONLY from the
+ * canonical player box score (the same authority that owns the final score).
+ * This module never reads narration play-logs or live per-play references.
+ *
+ * These are an in-game performance estimate based on simulated production and
+ * participation. They are NOT affiliated with, licensed by, or equivalent to
+ * any external football-analytics company. Small samples are protected against
+ * one-play grade inflation via confidence-weighted shrinkage toward a neutral
+ * baseline, so a player with a single target/carry cannot post an "Elite" grade.
+ *
+ * Pure functions only — safe to unit-test in isolation.
+ */
+
+const BASELINE = 60; // neutral grade a replacement-level, low-sample player regresses toward
+
+export function clampGrade(v, lo = 0, hi = 100) {
+  return Math.max(lo, Math.min(hi, Math.round(v)));
+}
+
+// ── Field alias resolution (canonical box score already normalizes these, but we
+//    stay defensive so legacy archives without the normalizer still grade) ──────
+function num(stats, ...keys) {
+  for (const k of keys) {
+    const v = stats?.[k];
+    if (v != null && Number.isFinite(Number(v))) return Number(v);
+  }
+  return 0;
+}
+
+const OFFENSE_POS = new Set(['QB', 'RB', 'FB', 'WR', 'TE', 'OL', 'C', 'G', 'T', 'K', 'P']);
+const DEFENSE_POS = new Set(['DL', 'DE', 'DT', 'NT', 'LB', 'OLB', 'ILB', 'MLB', 'EDGE', 'CB', 'S', 'FS', 'SS', 'DB']);
+
+export function sideForPosition(pos) {
+  const p = String(pos || '').toUpperCase();
+  if (DEFENSE_POS.has(p)) return 'defense';
+  if (OFFENSE_POS.has(p)) return 'offense';
+  return 'offense';
+}
+
+/**
+ * Participation volume + thresholds per position. `full` is the volume at which
+ * no shrinkage is applied; `min` is the floor below which the grade is treated
+ * as a "Limited sample" (no Elite/Star tier, overall regressed hard toward
+ * baseline). Participation is drawn from canonical involvement counts — never
+ * from a count of narration references.
+ */
+function participationFor(pos, stats) {
+  const p = String(pos || '').toUpperCase();
+  if (p === 'QB') {
+    return { value: num(stats, 'passAtt'), label: `${num(stats, 'passAtt')} att`, min: 6, full: 18 };
+  }
+  if (p === 'RB' || p === 'FB') {
+    const touches = num(stats, 'rushAtt') + num(stats, 'receptions');
+    return { value: touches, label: `${touches} touch${touches === 1 ? '' : 'es'}`, min: 5, full: 12 };
+  }
+  if (p === 'WR' || p === 'TE') {
+    const tgts = num(stats, 'targets') || num(stats, 'receptions');
+    return { value: tgts, label: `${tgts} tgt`, min: 3, full: 6 };
+  }
+  if (DEFENSE_POS.has(p)) {
+    const involvements = num(stats, 'tackles') + num(stats, 'sacks')
+      + num(stats, 'passesDefended', 'passDefls') + num(stats, 'interceptions')
+      + num(stats, 'tacklesForLoss', 'tfl') + num(stats, 'fumbleRecoveries', 'fumbleRecs');
+    return { value: involvements, label: `${involvements} inv`, min: 2, full: 5 };
+  }
+  if (p === 'K') {
+    const fga = num(stats, 'fieldGoalsAttempted', 'fgAttempts');
+    return { value: fga, label: `${fga} FGA`, min: 1, full: 3 };
+  }
+  // OL / P / unknown — no reliable individual production metric this build.
+  return { value: 0, label: null, min: Infinity, full: Infinity };
+}
+
+/** Raw (pre-shrinkage) grade + sub-grades from canonical rate stats. */
+function rawGradeFor(pos, stats) {
+  const p = String(pos || '').toUpperCase();
+  const sub = {};
+
+  if (p === 'QB') {
+    const att = num(stats, 'passAtt');
+    const compPct = att > 0 ? num(stats, 'passComp') / att : 0.62;
+    const ypa = att > 0 ? num(stats, 'passYd', 'passYds') / att : 0;
+    const tdRate = att > 0 ? num(stats, 'passTD', 'passTDs') / att : 0;
+    const intRate = att > 0 ? num(stats, 'interceptions', 'INT') / att : 0;
+    sub.accuracy = clampGrade(compPct * 100 * 0.9 + 10);
+    sub.efficiency = clampGrade((ypa - 4) * 8 + 60);
+    sub.bigPlays = clampGrade(tdRate * 400 + 55);
+    sub.ballSecurity = clampGrade(100 - intRate * 500);
+    return { overall: sub.accuracy * 0.3 + sub.efficiency * 0.3 + sub.bigPlays * 0.2 + sub.ballSecurity * 0.2, sub };
+  }
+  if (p === 'RB' || p === 'FB') {
+    const ra = num(stats, 'rushAtt');
+    const ypc = ra > 0 ? num(stats, 'rushYd', 'rushYds') / ra : 4;
+    const rec = num(stats, 'receptions');
+    sub.rushing = clampGrade((ypc - 3) * 10 + 65);
+    sub.receiving = clampGrade(rec > 0 ? (num(stats, 'recYd', 'recYds') / rec) * 5 + 55 : 60);
+    sub.bigPlays = clampGrade(num(stats, 'rushTD', 'rushTDs') * 8 + (num(stats, 'rushYd', 'rushYds') > 60 ? 10 : 0) + 55);
+    sub.vision = clampGrade(ypc * 6 + 42);
+    return { overall: sub.rushing * 0.45 + sub.receiving * 0.2 + sub.bigPlays * 0.2 + sub.vision * 0.15, sub };
+  }
+  if (p === 'WR' || p === 'TE') {
+    const rec = num(stats, 'receptions');
+    const tgt = num(stats, 'targets') || rec;
+    const ypr = rec > 0 ? num(stats, 'recYd', 'recYds') / rec : 0;
+    const catchRate = tgt > 0 ? rec / tgt : 0.6;
+    sub.hands = clampGrade(catchRate * 80 + 20);
+    sub.receiving = clampGrade((ypr - 5) * 4 + 68);
+    sub.bigPlays = clampGrade(num(stats, 'recTD', 'recTDs') * 10 + (num(stats, 'recYd', 'recYds') > 50 ? 8 : 0) + 52);
+    sub.routes = clampGrade(catchRate * 90 + 15);
+    return { overall: sub.hands * 0.25 + sub.receiving * 0.3 + sub.bigPlays * 0.25 + sub.routes * 0.2, sub };
+  }
+  if (p === 'DL' || p === 'DE' || p === 'DT' || p === 'NT' || p === 'EDGE') {
+    const sacks = num(stats, 'sacks');
+    const tackles = num(stats, 'tackles');
+    sub.passRush = clampGrade(sacks * 12 + tackles * 2 + 55);
+    sub.runDefense = clampGrade(tackles * 3 + 58);
+    sub.disruption = clampGrade((sacks + num(stats, 'fumbleRecoveries', 'fumbleRecs') + num(stats, 'tacklesForLoss', 'tfl')) * 8 + 55);
+    return { overall: sub.passRush * 0.4 + sub.runDefense * 0.35 + sub.disruption * 0.25, sub };
+  }
+  if (p === 'LB' || p === 'OLB' || p === 'ILB' || p === 'MLB') {
+    const tackles = num(stats, 'tackles');
+    sub.tackling = clampGrade(tackles * 4 + 50);
+    sub.coverage = clampGrade(num(stats, 'passesDefended', 'passDefls') * 8 + num(stats, 'interceptions') * 12 + 58);
+    sub.passRush = clampGrade(num(stats, 'sacks') * 14 + 55);
+    return { overall: sub.tackling * 0.4 + sub.coverage * 0.3 + sub.passRush * 0.3, sub };
+  }
+  if (DEFENSE_POS.has(p)) { // CB / S / DB
+    sub.coverage = clampGrade(num(stats, 'passesDefended', 'passDefls') * 9 + num(stats, 'interceptions') * 13 + 58);
+    sub.tackling = clampGrade(num(stats, 'tackles') * 4 + 52);
+    sub.ballHawk = clampGrade((num(stats, 'passesDefended', 'passDefls') + num(stats, 'interceptions') * 2 + num(stats, 'fumbleRecoveries', 'fumbleRecs')) * 7 + 55);
+    return { overall: sub.coverage * 0.45 + sub.tackling * 0.25 + sub.ballHawk * 0.3, sub };
+  }
+  if (p === 'K') {
+    const fga = num(stats, 'fieldGoalsAttempted', 'fgAttempts');
+    const fgm = num(stats, 'fieldGoalsMade', 'fgMade');
+    const pct = fga > 0 ? fgm / fga : 1;
+    sub.kicking = clampGrade(pct * 45 + 55);
+    return { overall: sub.kicking, sub };
+  }
+  return { overall: BASELINE, sub };
+}
+
+/**
+ * Grade one canonical box-score row. Never inflates a tiny sample: the raw grade
+ * is regressed toward BASELINE by the confidence ratio (volume / fullSample),
+ * and Elite/Star tiers are gated behind sufficient participation.
+ */
+export function computePlayerGameGrade(pos, stats = {}) {
+  const participation = participationFor(pos, stats);
+  const { overall: raw, sub } = rawGradeFor(pos, stats);
+
+  const hasMetric = Number.isFinite(participation.full);
+  const confidence = hasMetric ? Math.max(0, Math.min(1, participation.value / participation.full)) : 0;
+  const limitedSample = hasMetric ? participation.value < participation.min : true;
+
+  // Confidence-weighted shrinkage toward the neutral baseline.
+  const overall = clampGrade(BASELINE + (raw - BASELINE) * confidence);
+
+  return {
+    overall,
+    sub,
+    participation,
+    limitedSample,
+    confidence,
+    hasGrade: hasMetric && participation.value > 0,
+    tier: gradeTier(overall, { limitedSample, confidence }),
+  };
+}
+
+/**
+ * Tier label. Elite/Star require a confident (near-full) sample so a
+ * mathematically perfect one-play rate can never present as authoritative.
+ */
+export function gradeTier(overall, { limitedSample = false, confidence = 1 } = {}) {
+  if (limitedSample) return 'Limited';
+  if (overall >= 90 && confidence >= 0.85) return 'Elite';
+  if (overall >= 80 && confidence >= 0.7) return 'Star';
+  if (overall >= 70) return 'Good';
+  if (overall >= 58) return 'Average';
+  return 'Below Avg';
+}
+
+export function gradeColor(g, { limitedSample = false } = {}) {
+  if (limitedSample) return '#8E8E93';
+  if (g >= 90) return '#FFD60A';
+  if (g >= 80) return '#BF5AF2';
+  if (g >= 70) return '#0A84FF';
+  if (g >= 58) return '#34C759';
+  return '#8E8E93';
+}
+
+/** A short, honest stat line for a graded row, from canonical stats. */
+export function statLineFor(pos, stats = {}) {
+  const p = String(pos || '').toUpperCase();
+  if (p === 'QB') {
+    return `${num(stats, 'passComp')}/${num(stats, 'passAtt')} · ${num(stats, 'passYd', 'passYds')} yds${num(stats, 'passTD', 'passTDs') ? ` · ${num(stats, 'passTD', 'passTDs')} TD` : ''}`;
+  }
+  if (p === 'RB' || p === 'FB') {
+    return `${num(stats, 'rushAtt')} car · ${num(stats, 'rushYd', 'rushYds')} yds${num(stats, 'rushTD', 'rushTDs') ? ` · ${num(stats, 'rushTD', 'rushTDs')} TD` : ''}`;
+  }
+  if (p === 'WR' || p === 'TE') {
+    return `${num(stats, 'receptions')}/${num(stats, 'targets') || num(stats, 'receptions')} · ${num(stats, 'recYd', 'recYds')} yds${num(stats, 'recTD', 'recTDs') ? ` · ${num(stats, 'recTD', 'recTDs')} TD` : ''}`;
+  }
+  if (DEFENSE_POS.has(p)) {
+    const parts = [];
+    if (num(stats, 'tackles')) parts.push(`${num(stats, 'tackles')} tkl`);
+    if (num(stats, 'sacks')) parts.push(`${num(stats, 'sacks')} sk`);
+    if (num(stats, 'interceptions')) parts.push(`${num(stats, 'interceptions')} INT`);
+    if (num(stats, 'passesDefended', 'passDefls')) parts.push(`${num(stats, 'passesDefended', 'passDefls')} PD`);
+    return parts.join(' · ') || '—';
+  }
+  if (p === 'K') {
+    return `${num(stats, 'fieldGoalsMade', 'fgMade')}/${num(stats, 'fieldGoalsAttempted', 'fgAttempts')} FG`;
+  }
+  return '—';
+}
+
+/**
+ * Turn a canonical box score ({ [pid]: { name, pos, stats } }) for one team
+ * into a sorted array of graded rows. Only rows with a real production metric
+ * are graded, so an all-zero OL never shows a fabricated grade.
+ */
+export function gradeTeamBoxScore(teamBoxScore = {}, teamMeta = {}) {
+  const rows = [];
+  for (const [pid, row] of Object.entries(teamBoxScore || {})) {
+    if (!row || typeof row !== 'object') continue;
+    const stats = row.stats && typeof row.stats === 'object' ? row.stats : row;
+    const pos = row.pos ?? row.position ?? '—';
+    const grade = computePlayerGameGrade(pos, stats);
+    if (!grade.hasGrade) continue; // omit players with no honest production metric
+    rows.push({
+      playerId: pid,
+      name: row.name ?? 'Unknown',
+      pos,
+      teamId: teamMeta.teamId ?? null,
+      teamAbbr: teamMeta.teamAbbr ?? null,
+      teamSide: teamMeta.teamSide ?? null,
+      side: sideForPosition(pos),
+      stats,
+      statLine: statLineFor(pos, stats),
+      ...grade,
+    });
+  }
+  return rows.sort((a, b) => b.overall - a.overall);
+}

--- a/src/ui/utils/gamePerformanceGrades.test.js
+++ b/src/ui/utils/gamePerformanceGrades.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computePlayerGameGrade,
+  gradeTeamBoxScore,
+  gradeTier,
+  statLineFor,
+  sideForPosition,
+} from './gamePerformanceGrades.js';
+
+describe('gamePerformanceGrades — small-sample protection', () => {
+  it('does not award an authoritative Elite grade for a single perfect target (WR)', () => {
+    const g = computePlayerGameGrade('WR', { targets: 1, receptions: 1, recYd: 22, recTD: 0 });
+    expect(g.limitedSample).toBe(true);
+    expect(g.tier).toBe('Limited');
+    expect(g.tier).not.toBe('Elite');
+    expect(g.tier).not.toBe('Star');
+    // Regressed toward the neutral baseline rather than a perfect-rate spike.
+    expect(g.overall).toBeLessThan(75);
+  });
+
+  it('does not award an authoritative Elite grade for a single carry (RB)', () => {
+    const g = computePlayerGameGrade('RB', { rushAtt: 1, rushYd: 30, rushTD: 1 });
+    expect(g.limitedSample).toBe(true);
+    expect(['Limited']).toContain(g.tier);
+    expect(g.overall).toBeLessThan(80);
+  });
+
+  it('allows a genuinely high grade when participation is meaningful', () => {
+    const g = computePlayerGameGrade('QB', {
+      passAtt: 34, passComp: 28, passYd: 360, passTD: 4, interceptions: 0,
+    });
+    expect(g.limitedSample).toBe(false);
+    expect(g.overall).toBeGreaterThanOrEqual(80);
+    expect(['Star', 'Elite']).toContain(g.tier);
+  });
+
+  it('is deterministic — identical stats produce identical grades', () => {
+    const stats = { passAtt: 20, passComp: 13, passYd: 190, passTD: 1, interceptions: 1 };
+    const a = computePlayerGameGrade('QB', stats);
+    const b = computePlayerGameGrade('QB', stats);
+    expect(a.overall).toBe(b.overall);
+    expect(a.tier).toBe(b.tier);
+  });
+
+  it('is bounded within [0,100]', () => {
+    const hi = computePlayerGameGrade('QB', { passAtt: 40, passComp: 40, passYd: 800, passTD: 8, interceptions: 0 });
+    const lo = computePlayerGameGrade('QB', { passAtt: 40, passComp: 5, passYd: 20, passTD: 0, interceptions: 8 });
+    expect(hi.overall).toBeLessThanOrEqual(100);
+    expect(lo.overall).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('gamePerformanceGrades — position awareness & honesty', () => {
+  it('classifies offense vs defense by position', () => {
+    expect(sideForPosition('QB')).toBe('offense');
+    expect(sideForPosition('WR')).toBe('offense');
+    expect(sideForPosition('CB')).toBe('defense');
+    expect(sideForPosition('LB')).toBe('defense');
+  });
+
+  it('participation label reports an honest metric — never "snaps"', () => {
+    const qb = computePlayerGameGrade('QB', { passAtt: 30, passComp: 20, passYd: 240 });
+    const rb = computePlayerGameGrade('RB', { rushAtt: 15, rushYd: 70, receptions: 3 });
+    expect(qb.participation.label).toMatch(/att/);
+    expect(rb.participation.label).toMatch(/touch/);
+    expect(qb.participation.label).not.toMatch(/snap/i);
+    expect(rb.participation.label).not.toMatch(/snap/i);
+  });
+
+  it('omits a grade for players with no honest production metric (bare OL)', () => {
+    const rows = gradeTeamBoxScore({
+      1: { name: 'Tackle', pos: 'OL', stats: {} },
+      2: { name: 'Starter QB', pos: 'QB', stats: { passAtt: 30, passComp: 21, passYd: 250, passTD: 2 } },
+    }, { teamId: 7, teamAbbr: 'NYJ', teamSide: 'home' });
+    const names = rows.map((r) => r.name);
+    expect(names).toContain('Starter QB');
+    expect(names).not.toContain('Tackle');
+  });
+
+  it('tags every graded row with its team', () => {
+    const rows = gradeTeamBoxScore({
+      2: { name: 'Starter QB', pos: 'QB', stats: { passAtt: 30, passComp: 21, passYd: 250, passTD: 2 } },
+    }, { teamId: 7, teamAbbr: 'NYJ', teamSide: 'home' });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].teamAbbr).toBe('NYJ');
+    expect(rows[0].teamId).toBe(7);
+  });
+});
+
+describe('gamePerformanceGrades — statLine & tier gating', () => {
+  it('formats a QB line from canonical fields', () => {
+    expect(statLineFor('QB', { passComp: 22, passAtt: 31, passYd: 258, passTD: 2 })).toBe('22/31 · 258 yds · 2 TD');
+  });
+
+  it('gates Elite/Star behind confidence', () => {
+    expect(gradeTier(95, { limitedSample: false, confidence: 1 })).toBe('Elite');
+    expect(gradeTier(95, { limitedSample: false, confidence: 0.4 })).not.toBe('Elite');
+    expect(gradeTier(95, { limitedSample: true })).toBe('Limited');
+  });
+});

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -14524,6 +14524,12 @@ async function handleWatchGame(payload, id) {
     post(toUI.PLAY_LOGS, {
       logs: res.playLogs || [],
       liveStats: res.liveStats || {},
+      // Canonical player box score (the same authority that owns the final
+      // score). The postgame Leaders + Grades consume THIS, never the narrated
+      // liveStats/logs — so a single starter QB's real workload is shown rather
+      // than the play-by-play's randomized QB rotation.
+      playerStats: res.boxScore ? { home: res.boxScore.home ?? {}, away: res.boxScore.away ?? {} } : null,
+      teamStats: res.teamStats ?? null,
       gameReasoningFlags: Array.isArray(res.gameReasoningFlags) ? res.gameReasoningFlags : [],
     }, id);
 

--- a/src/worker/workerApi.js
+++ b/src/worker/workerApi.js
@@ -97,6 +97,8 @@ export function handleWorkerMessage(msg, setState) {
         type: 'PLAY_LOGS',
         logs: payload.logs,
         liveStats: payload.liveStats,
+        playerStats: payload.playerStats,
+        teamStats: payload.teamStats,
         gameReasoningFlags: payload.gameReasoningFlags,
       });
       return true;


### PR DESCRIPTION
The scoreboard came from the drive engine while postgame Leaders and
Grades were computed from the narrated play-by-play stream, which picks a
QB at random per drop-back and counts each log reference as a "snap". That
produced three rotating QBs summing to ~183 passing yards under a 39-23
scoreboard, one-catch receivers graded "Elite", "PFF" badges, and
mixed-team rows.

Route every factual postgame surface through the canonical player box
score (res.boxScore) — the authority the score is consistent with:

- worker PLAY_LOGS now carries canonical playerStats/teamStats; plumbed
  through workerApi -> useWorker -> App -> PostGameScreen.
- PostGameScreen Leaders + archive read the canonical box score
  (buildPlayerLeadersFromArchive); narration logs are presentation-only.
- AdvancedStats rewritten to consume canonical stats: Game Performance
  Grades (no PFF branding/badges), team-attributed rows defaulting to the
  user team with opponent/all + offense/defense filters, honest
  participation metrics (no fake "snaps"), and confidence-weighted
  small-sample protection so one target/carry can't grade Elite.
- new pure gamePerformanceGrades module (deterministic, bounded,
  position-aware) and gameStatReconciliation invariants.

Also close a real stat-generation gap: the QB passing line was drawn
independently from the receivers who caught the passes (~100-yd hidden
gap). Re-derive each passing QB's completions/yards from actual receiving
production so sum(receptions)==passComp and sum(recYd)==passYd. Pure
reassignment, no new RNG draws, so seeded scores are unchanged.

Docs: docs/canonical-game-engine-revival-v1.md. Deferred: canonical
play-by-play / score-after events (scoring summary + quarter scores still
narration-derived) -> #1697.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Hrps9UWqVk28N2XWGh1Gyf