### PR TITLE
Canonical Postgame Integrity Follow-Up V1

### DIFF
--- a/docs/canonical-postgame-integrity-follow-up-v1.md
+++ b/docs/canonical-postgame-integrity-follow-up-v1.md
@@ -1,0 +1,70 @@
+# Canonical Postgame Integrity Follow-Up V1
+
+## Executive summary
+This follow-up completes the narrow correctness cleanup after #1698. It keeps the canonical player box score as the postgame authority while fixing interception semantics, reconciled QB dependent fields, and watched-game team-stat transport.
+
+## #1698 context
+#1698 moved postgame leaders, grades, and archived player statistics off narration-derived logs and onto canonical player box-score rows. This document covers only defects left at that boundary.
+
+## Three confirmed defects
+1. A QB row's `interceptions` value means interceptions thrown, but a defensive row's `interceptions` means takeaways.
+2. Reconciled QB passing yards/completions could leave dependent `dropbacks`, `longestPass`, and rates stale.
+3. The worker reducer stored `userGameTeamStats`, but App did not include it in `buildWatchPostGameResult`, so PostGameScreen archived player stats without the canonical team package.
+
+## Passer-versus-defender interception semantics
+Postgame summary code now treats passing rows (`passAtt > 0` or `pos === QB`) as offensive turnover rows. Defensive interceptions are zero for passing rows and nonnegative only for non-passing rows.
+
+## Defensive leader policy
+Defensive leaders score only defensive production: sacks made, defensive interceptions, tackles, tackles for loss, passes defended, forced fumbles, fumble recoveries, and defensive touchdowns. Interceptions thrown never qualify a passer as the defensive leader.
+
+## Player of Game turnover policy
+Player of Game impact now applies a modest deterministic penalty for interceptions thrown. The policy is intentionally narrow: legitimate passing, rushing, receiving, defensive, and kicking production remain positive, but passer interceptions cannot add positive impact.
+
+## QB dependent-field authority
+After final passing reconciliation, each QB line is clamped to nonnegative attempts, completions, yards, touchdowns, interceptions, and sacks taken. Completion percentage and passer rating are recomputed from the final line.
+
+## Longest-pass policy
+Receiver-to-QB attribution is not available at this seam. The honest repair is deterministic clamping: no completions or no passing yards means `longestPass = 0`; otherwise `longestPass = min(existingLongestPass, passYd)`. No RNG draw is consumed and receiving yards are not redistributed.
+
+## Dropback policy
+Dropbacks are authoritative as `passAtt + sacksTaken`, using the existing generated QB sack-taken field on the QB row. Defensive sacks made remain separate.
+
+## Team-stat transport map
+The fixed path is: worker `PLAY_LOGS.userGameTeamStats` → App state destructuring → `buildWatchPostGameResult.teamStats` → `PostGameScreen teamStats` prop → `onArchiveReady.teamStats` → saved archive → Game Book view model.
+
+## First dropped teamStats boundary
+The first confirmed drop was App: `useWorker` already stored `userGameTeamStats`, but `buildWatchPostGameResult` accepted and returned only `playerStats`.
+
+## Archive behavior
+When canonical team stats are supplied, PostGameScreen includes them unchanged in the archive payload. Archive normalization can still apply established legacy normalization afterward.
+
+## Legacy fallback behavior
+Games without canonical team stats continue through the existing fallback path. Safely derivable totals may be computed from player rows; rich drive-only fields such as first downs, possession, red-zone, and third-down detail are not fabricated by this PR.
+
+## Files changed
+- `src/core/gameSummary.js`
+- `src/core/simulation/index.js`
+- `src/ui/App.jsx`
+- `src/ui/components/PostGameScreen.jsx`
+- Focused unit tests for those seams
+
+## Tests added
+Regression tests cover defensive interception semantics, Player of Game turnover penalty, App team-stat carry, useWorker team-stat transport/clearing, and PostGameScreen archive preservation.
+
+## Determinism confirmation
+The QB reconciliation repair uses no random numbers, does not redistribute receiving yards, and does not alter injury probability or workload generation.
+
+## Unit-test result
+Run result is recorded in the PR and final report.
+
+## Build result
+Run result is recorded in the PR and final report.
+
+## Playwright result
+Run result is recorded in the PR and final report.
+
+## Explicit untouched systems
+Final-score generation, score distributions, play-by-play narration, scoring summary authority, quarter-score authority, schedule generation, standings, playoffs, free agency, draft, contracts, progression, salary cap, and Game Performance Grades are untouched.
+
+## Recommended next PR
+#1700 — E2E Assertion Integrity V1. This should clean up brittle E2E assertion boundaries before any future canonical play-by-play work unless evidence shows that cleanup already landed.

--- a/docs/canonical-postgame-integrity-follow-up-v1.md
+++ b/docs/canonical-postgame-integrity-follow-up-v1.md
@@ -21,7 +21,7 @@ Defensive leaders score only defensive production: sacks made, defensive interce
 Player of Game impact now applies a modest deterministic penalty for interceptions thrown. The policy is intentionally narrow: legitimate passing, rushing, receiving, defensive, and kicking production remain positive, but passer interceptions cannot add positive impact.
 
 ## QB dependent-field authority
-After final passing reconciliation, each QB line is clamped to nonnegative attempts, completions, yards, touchdowns, interceptions, and sacks taken. Completion percentage and passer rating are recomputed from the final line.
+After final passing reconciliation, each QB line is clamped to nonnegative attempts, completions, yards, touchdowns, interceptions, and sacks taken. Completion percentage and passer rating are recomputed from the final line both after yardage/completion reconciliation and again after the final passing-TD allocation.
 
 ## Longest-pass policy
 Receiver-to-QB attribution is not available at this seam. The honest repair is deterministic clamping: no completions or no passing yards means `longestPass = 0`; otherwise `longestPass = min(existingLongestPass, passYd)`. No RNG draw is consumed and receiving yards are not redistributed.
@@ -49,7 +49,7 @@ Games without canonical team stats continue through the existing fallback path. 
 - Focused unit tests for those seams
 
 ## Tests added
-Regression tests cover defensive interception semantics, Player of Game turnover penalty, App team-stat carry, useWorker team-stat transport/clearing, and PostGameScreen archive preservation.
+Regression tests cover defensive interception semantics, Player of Game turnover penalty, exact passer-rating math after final TD allocation, App team-stat carry, useWorker team-stat transport/clearing, PostGameScreen archive preservation, and the canonical postgame integration path into the Game Book team comparison totals.
 
 ## Determinism confirmation
 The QB reconciliation repair uses no random numbers, does not redistribute receiving yards, and does not alter injury probability or workload generation.

--- a/src/core/__tests__/gameSummary.test.js
+++ b/src/core/__tests__/gameSummary.test.js
@@ -110,3 +110,38 @@ describe('archived team stats (post-engine-flip stabilization)', () => {
     expect(fallback.home.turnovers).toBe(3);
   });
 });
+
+describe('postgame leader interception semantics', () => {
+  it('uses passer interceptions as turnovers, never defensive takeaways', async () => {
+    const { buildPlayerLeadersFromArchive } = await import('../gameSummary.js');
+    const boxScore = {
+      home: {
+        qb: { name: 'Turnover QB', pos: 'QB', stats: { passAtt: 35, passComp: 24, passYd: 300, passTD: 3, interceptions: 3 } },
+        cb: { name: 'Takeaway CB', pos: 'CB', stats: { interceptions: 1, tackles: 2 } },
+      },
+      away: {},
+    };
+    const leaders = buildPlayerLeadersFromArchive(boxScore, { homeId: 1, awayId: 2 });
+    expect(leaders.categories.defense?.name).toBe('Takeaway CB');
+    expect(leaders.categories.defense?.stats?.interceptions).toBe(1);
+    expect(leaders.standouts.find((p) => p.name === 'Turnover QB')?.stats?.interceptions).toBe(3);
+  });
+
+  it('does not promote a passer into defense when no defender has production', async () => {
+    const { buildPlayerLeadersFromArchive } = await import('../gameSummary.js');
+    const leaders = buildPlayerLeadersFromArchive({
+      home: { qb: { name: 'Only QB', pos: 'QB', stats: { passAtt: 28, passYd: 220, interceptions: 4 } } },
+      away: {},
+    }, { homeId: 1, awayId: 2 });
+    expect(leaders.categories.defense).toBeNull();
+  });
+
+  it('penalizes otherwise identical passers for interceptions thrown', async () => {
+    const { buildPlayerLeadersFromArchive } = await import('../gameSummary.js');
+    const leaders = buildPlayerLeadersFromArchive({
+      home: { clean: { name: 'Clean QB', pos: 'QB', stats: { passAtt: 30, passComp: 20, passYd: 300, passTD: 3, interceptions: 0 } } },
+      away: { risky: { name: 'Risky QB', pos: 'QB', stats: { passAtt: 30, passComp: 20, passYd: 300, passTD: 3, interceptions: 3 } } },
+    }, { homeId: 1, awayId: 2 });
+    expect(leaders.playerOfGame?.name).toBe('Clean QB');
+  });
+});

--- a/src/core/__tests__/simulation/canonicalGameAuthority.test.js
+++ b/src/core/__tests__/simulation/canonicalGameAuthority.test.js
@@ -18,7 +18,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { Utils as U } from '../../utils.js';
-import { simGameStats, simulateBatch } from '../../simulation/index.js';
+import { calculateCanonicalPasserRating, simGameStats, simulateBatch } from '../../simulation/index.js';
 import {
   reconcilePlayerIdentities,
   reconcilePlayerToTeam,
@@ -179,6 +179,29 @@ describe('canonical player-stat reconciliation', () => {
   });
 
 
+  it('uses the exact canonical passer-rating formula after final passing-TD allocation', () => {
+    const line = { passComp: 24, passAtt: 33, passYd: 288, passTD: 3, interceptions: 1 };
+    const a = Math.max(0, Math.min(2.375, ((line.passComp / line.passAtt) - 0.3) / 0.2));
+    const b = Math.max(0, Math.min(2.375, ((line.passYd / line.passAtt) - 3) / 4));
+    const c = Math.max(0, Math.min(2.375, (line.passTD / line.passAtt) / 0.05));
+    const d = Math.max(0, Math.min(2.375, 2.375 - (line.interceptions / line.passAtt) / 0.04));
+    const expected = Math.round(((a + b + c + d) / 6) * 100 * 10) / 10;
+    expect(calculateCanonicalPasserRating(line)).toBe(expected);
+  });
+
+  it('passer rating and rate fields reflect the final passing-TD split', () => {
+    const { res, home } = runBatch(122, { injuryFactor: 8 });
+    expect(res?.boxScore).toBeTruthy();
+    const qbs = home.roster.filter((p) => p.pos === 'QB' && (p.stats.game.passAtt || 0) > 0);
+    expect(qbs.length).toBeGreaterThan(1);
+    for (const qb of qbs) {
+      const g = qb.stats.game;
+      expect(g.passerRating).toBe(calculateCanonicalPasserRating(g));
+      if ('tdRate' in g) expect(g.tdRate).toBe(Math.round((g.passTD / Math.max(1, g.passAtt)) * 1000) / 10);
+      if ('yardsPerAttempt' in g) expect(g.yardsPerAttempt).toBe(Math.round((g.passYd / Math.max(1, g.passAtt)) * 10) / 10);
+      if ('intRate' in g) expect(g.intRate).toBe(Math.round((g.interceptions / Math.max(1, g.passAtt)) * 1000) / 10);
+    }
+  });
 
   it('reconciled QB dependent fields remain possible across deterministic seeds', () => {
     for (const seed of SEEDS) {

--- a/src/core/__tests__/simulation/canonicalGameAuthority.test.js
+++ b/src/core/__tests__/simulation/canonicalGameAuthority.test.js
@@ -140,6 +140,16 @@ describe('canonical box score owns QB participation (no rotation)', () => {
     expect(backup.stats.game.passAtt).toBeGreaterThan(0);
     expect(backup.stats.game.passComp).toBeGreaterThan(0);
     expect(backup.stats.game.passYd).toBeGreaterThan(0);
+    for (const qb of [starter, backup]) {
+      const g = qb.stats.game;
+      const sacksTaken = Number(g.sacked ?? g.sacksTaken ?? g.sacks ?? 0);
+      expect(g.passComp).toBeLessThanOrEqual(g.passAtt);
+      expect(g.dropbacks).toBe(g.passAtt + sacksTaken);
+      expect(g.longestPass).toBeLessThanOrEqual(g.passYd);
+      if (g.passComp === 0 || g.passYd === 0) expect(g.longestPass).toBe(0);
+      expect(g.completionPct).toBe(Math.round((g.passComp / Math.max(1, g.passAtt)) * 1000) / 10);
+      expect(g.passerRating).not.toBeNull();
+    }
 
     // …and passing TDs were split by the same workload basis, not dumped on the
     // starter. Team receiving TDs equal the sum of both QBs' passing TDs.
@@ -164,6 +174,25 @@ describe('canonical player-stat reconciliation', () => {
       for (const team of [home, away]) {
         const rep = reconcilePlayerIdentities(boxScoreSideFromRoster(team));
         expect(rep.ok, `seed ${seed} ${team.abbr}: ${JSON.stringify(rep.checks)}`).toBe(true);
+      }
+    }
+  });
+
+
+
+  it('reconciled QB dependent fields remain possible across deterministic seeds', () => {
+    for (const seed of SEEDS) {
+      const { home, away } = runGame(seed);
+      for (const team of [home, away]) {
+        const qbs = team.roster.filter((p) => p.pos === 'QB' && (p.stats.game.passAtt || 0) > 0);
+        for (const qb of qbs) {
+          const g = qb.stats.game;
+          const sacksTaken = Number(g.sacked ?? g.sacksTaken ?? g.sacks ?? 0);
+          expect(g.passComp, `seed ${seed} ${team.abbr} ${qb.id} comp`).toBeLessThanOrEqual(g.passAtt);
+          expect(g.dropbacks, `seed ${seed} ${team.abbr} ${qb.id} dropbacks`).toBe(g.passAtt + sacksTaken);
+          expect(g.longestPass, `seed ${seed} ${team.abbr} ${qb.id} long`).toBeLessThanOrEqual(g.passYd);
+          if (g.passComp === 0 || g.passYd === 0) expect(g.longestPass).toBe(0);
+        }
       }
     }
   });

--- a/src/core/gameSummary.js
+++ b/src/core/gameSummary.js
@@ -188,12 +188,34 @@ export function buildTurningPointsFromGameEvents(playLogs = [], context = {}) {
   return points.slice(0, 6);
 }
 
+export function isPassingRow(row) {
+  const pos = String(row?.pos ?? row?.position ?? '').toUpperCase();
+  return asNum(row?.stats?.passAtt) > 0 || pos === 'QB';
+}
+
+export function defensiveInterceptions(row) {
+  return isPassingRow(row) ? 0 : Math.max(0, asNum(row?.stats?.interceptions));
+}
+
+export function interceptionsThrown(row) {
+  return isPassingRow(row) ? Math.max(0, asNum(row?.stats?.interceptions)) : 0;
+}
+
 export function buildPlayerLeadersFromArchive(boxScore = {}, context = {}) {
   const rows = toRows(boxScore, context);
   const pick = (key, min = 1) => rows.filter((r) => asNum(r.stats?.[key]) >= min).sort((a, b) => asNum(b.stats?.[key]) - asNum(a.stats?.[key]))[0] ?? null;
-  const defense = rows
-    .filter((r) => asNum(r.stats?.sacks) + asNum(r.stats?.interceptions) + asNum(r.stats?.tacklesForLoss) + asNum(r.stats?.tackles) > 0)
-    .sort((a, b) => (asNum(b.stats?.sacks) * 2 + asNum(b.stats?.interceptions) * 2 + asNum(b.stats?.tacklesForLoss) + asNum(b.stats?.tackles)) - (asNum(a.stats?.sacks) * 2 + asNum(a.stats?.interceptions) * 2 + asNum(a.stats?.tacklesForLoss) + asNum(a.stats?.tackles)))[0] ?? null;
+  const defenseScore = (r) => asNum(r.stats?.sacks) * 2
+    + defensiveInterceptions(r) * 2
+    + asNum(r.stats?.tacklesForLoss)
+    + asNum(r.stats?.tackles)
+    + asNum(r.stats?.passesDefended)
+    + asNum(r.stats?.forcedFumbles) * 2
+    + asNum(r.stats?.fumbleRecoveries) * 2
+    + asNum(r.stats?.defTD) * 6;
+  const rawDefense = rows
+    .filter((r) => defenseScore(r) > 0)
+    .sort((a, b) => defenseScore(b) - defenseScore(a))[0] ?? null;
+  const defense = rawDefense ? { ...rawDefense, stats: { ...(rawDefense.stats ?? {}), interceptions: defensiveInterceptions(rawDefense) } } : null;
 
   const categories = {
     passing: pick('passYd', 20),
@@ -204,7 +226,7 @@ export function buildPlayerLeadersFromArchive(boxScore = {}, context = {}) {
   };
 
   const scored = rows
-    .map((row) => ({ row, impact: asNum(row.stats?.passYd) / 12 + asNum(row.stats?.passTD) * 5 + asNum(row.stats?.rushYd) / 10 + asNum(row.stats?.rushTD) * 6 + asNum(row.stats?.recYd) / 10 + asNum(row.stats?.recTD) * 6 + asNum(row.stats?.sacks) * 4 + asNum(row.stats?.interceptions) * 5 + asNum(row.stats?.fieldGoalsMade) * 3 }))
+    .map((row) => ({ row, impact: asNum(row.stats?.passYd) / 12 + asNum(row.stats?.passTD) * 5 + asNum(row.stats?.rushYd) / 10 + asNum(row.stats?.rushTD) * 6 + asNum(row.stats?.recYd) / 10 + asNum(row.stats?.recTD) * 6 + asNum(row.stats?.sacks) * 4 + defensiveInterceptions(row) * 5 + asNum(row.stats?.fieldGoalsMade) * 3 - interceptionsThrown(row) * 2 }))
     .sort((a, b) => b.impact - a.impact);
 
   const playerOfGame = scored[0]?.row ?? null;

--- a/src/core/simulation/index.js
+++ b/src/core/simulation/index.js
@@ -29,8 +29,23 @@ import {
 } from '../gameSummary.js';
 
 
+const nQbStat = (v) => { const x = Number(v); return Number.isFinite(x) ? x : 0; };
+
+export function calculateCanonicalPasserRating({ passComp = 0, passAtt = 0, passYd = 0, passTD = 0, interceptions = 0 } = {}) {
+  const att = Math.max(1, nQbStat(passAtt));
+  const comp = Math.max(0, nQbStat(passComp));
+  const yards = Math.max(0, nQbStat(passYd));
+  const tds = Math.max(0, nQbStat(passTD));
+  const ints = Math.max(0, nQbStat(interceptions));
+  const a = Math.max(0, Math.min(2.375, ((comp / att) - 0.3) / 0.2));
+  const b = Math.max(0, Math.min(2.375, ((yards / att) - 3) / 4));
+  const c = Math.max(0, Math.min(2.375, (tds / att) / 0.05));
+  const d = Math.max(0, Math.min(2.375, 2.375 - (ints / att) / 0.04));
+  return Math.round(((a + b + c + d) / 6) * 100 * 10) / 10;
+}
+
 function recomputeReconciledQbDependentStats(g = {}) {
-  const n = (v) => { const x = Number(v); return Number.isFinite(x) ? x : 0; };
+  const n = nQbStat;
   g.passAtt = Math.max(0, Math.round(n(g.passAtt)));
   g.passComp = Math.max(0, Math.min(g.passAtt, Math.round(n(g.passComp))));
   g.passYd = Math.max(0, Math.round(n(g.passYd)));
@@ -41,12 +56,7 @@ function recomputeReconciledQbDependentStats(g = {}) {
   if (g.passComp === 0 || g.passYd === 0) g.longestPass = 0;
   else g.longestPass = Math.max(0, Math.min(Math.round(n(g.longestPass)), g.passYd));
   g.completionPct = Math.round((g.passComp / Math.max(1, g.passAtt)) * 1000) / 10;
-  const att = Math.max(1, g.passAtt);
-  const a = Math.max(0, Math.min(2.375, ((g.passComp / att) - 0.3) / 0.2));
-  const b = Math.max(0, Math.min(2.375, ((g.passYd / att) - 3) / 4));
-  const c = Math.max(0, Math.min(2.375, (g.passTD / att) / 0.05));
-  const d = Math.max(0, Math.min(2.375, 2.375 - (g.interceptions / att) / 0.04));
-  g.passerRating = Math.round(((a + b + c + d) / 6) * 100 * 10) / 10;
+  g.passerRating = calculateCanonicalPasserRating(g);
   if ('yardsPerAttempt' in g) g.yardsPerAttempt = Math.round((g.passYd / Math.max(1, g.passAtt)) * 10) / 10;
   if ('sackPct' in g) g.sackPct = Math.round((sacksTaken / Math.max(1, g.dropbacks)) * 1000) / 10;
   if ('tdRate' in g) g.tdRate = Math.round((g.passTD / Math.max(1, g.passAtt)) * 1000) / 10;
@@ -1648,6 +1658,7 @@ export function simGameStats(home, away, options = {}) {
         // Rounding remainder to the starter (highest attempts).
         passingQbsForTD[0].stats.game.passTD += (totalRecTDs - assignedTD);
         if (passingQbsForTD[0].stats.game.passTD < 0) passingQbsForTD[0].stats.game.passTD = 0;
+        passingQbsForTD.forEach((q) => recomputeReconciledQbDependentStats(q.stats.game));
       }
 
 

--- a/src/core/simulation/index.js
+++ b/src/core/simulation/index.js
@@ -28,6 +28,32 @@ import {
   buildScoringSummaryFromSimulation,
 } from '../gameSummary.js';
 
+
+function recomputeReconciledQbDependentStats(g = {}) {
+  const n = (v) => { const x = Number(v); return Number.isFinite(x) ? x : 0; };
+  g.passAtt = Math.max(0, Math.round(n(g.passAtt)));
+  g.passComp = Math.max(0, Math.min(g.passAtt, Math.round(n(g.passComp))));
+  g.passYd = Math.max(0, Math.round(n(g.passYd)));
+  g.passTD = Math.max(0, Math.round(n(g.passTD)));
+  g.interceptions = Math.max(0, Math.round(n(g.interceptions)));
+  const sacksTaken = Math.max(0, Math.round(n(g.sacked ?? g.sacksTaken ?? g.sacks)));
+  g.dropbacks = g.passAtt + sacksTaken;
+  if (g.passComp === 0 || g.passYd === 0) g.longestPass = 0;
+  else g.longestPass = Math.max(0, Math.min(Math.round(n(g.longestPass)), g.passYd));
+  g.completionPct = Math.round((g.passComp / Math.max(1, g.passAtt)) * 1000) / 10;
+  const att = Math.max(1, g.passAtt);
+  const a = Math.max(0, Math.min(2.375, ((g.passComp / att) - 0.3) / 0.2));
+  const b = Math.max(0, Math.min(2.375, ((g.passYd / att) - 3) / 4));
+  const c = Math.max(0, Math.min(2.375, (g.passTD / att) / 0.05));
+  const d = Math.max(0, Math.min(2.375, 2.375 - (g.interceptions / att) / 0.04));
+  g.passerRating = Math.round(((a + b + c + d) / 6) * 100 * 10) / 10;
+  if ('yardsPerAttempt' in g) g.yardsPerAttempt = Math.round((g.passYd / Math.max(1, g.passAtt)) * 10) / 10;
+  if ('sackPct' in g) g.sackPct = Math.round((sacksTaken / Math.max(1, g.dropbacks)) * 1000) / 10;
+  if ('tdRate' in g) g.tdRate = Math.round((g.passTD / Math.max(1, g.passAtt)) * 1000) / 10;
+  if ('intRate' in g) g.intRate = Math.round((g.interceptions / Math.max(1, g.passAtt)) * 1000) / 10;
+  return g;
+}
+
 // ── Domain modules ──────────────────────────────────────────────────────────
 import {
   getActiveGroups,
@@ -1468,8 +1494,7 @@ export function simGameStats(home, away, options = {}) {
           passingQbs.forEach((q) => {
             const g = q.stats.game;
             if ((g.passAtt || 0) < g.passComp) g.passAtt = g.passComp;
-            g.completionPct = null;
-            g.passerRating = null;
+            recomputeReconciledQbDependentStats(g);
           });
         }
       }

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -172,6 +172,7 @@ export function buildWatchPostGameResult({
   logs = [],
   liveStats = null,
   playerStats = null,
+  teamStats = null,
   gameReasoningFlags = [],
   seasonId,
 } = {}) {
@@ -191,6 +192,7 @@ export function buildWatchPostGameResult({
     logs,
     liveStats,
     playerStats,
+    teamStats,
     gameReasoningFlags,
     seasonId,
     gameId: buildCanonicalGameId({
@@ -214,6 +216,7 @@ function AppContent() {
     userGameLogs,
     userGameLiveStats,
     userGamePlayerStats,
+    userGameTeamStats,
     userGameReasoningFlags,
     lastWorkerMessageType,
   } = state;
@@ -1790,6 +1793,7 @@ function AppContent() {
                     logs: userGameLogs || [],
                     liveStats: userGameLiveStats || null,
                     playerStats: userGamePlayerStats || null,
+                    teamStats: userGameTeamStats || null,
                     gameReasoningFlags: userGameReasoningFlags || [],
                     seasonId: league?.seasonId,
                   });
@@ -1826,6 +1830,7 @@ function AppContent() {
           phase={postGameResult.phase}
           logs={postGameResult.logs || []}
           playerStats={postGameResult.playerStats || null}
+          teamStats={postGameResult.teamStats || null}
           gameReasoningFlags={postGameResult.gameReasoningFlags || []}
           boxScoreGameId={postGameResult.gameId}
           onOpenBoxScore={(gameId) => {

--- a/src/ui/App.test.jsx
+++ b/src/ui/App.test.jsx
@@ -64,4 +64,25 @@ describe('App watch-mode postgame result contract', () => {
     });
     expect(result.homeScore).toBe(result.awayScore);
   });
+
+  it('carries canonical playerStats and teamStats through watch postgame helper', () => {
+    const playerStats = { home: { qb: { stats: { passYd: 250 } } }, away: {} };
+    const teamStats = { home: { passYards: 250, firstDowns: 20 }, away: { passYards: 180, firstDowns: 16 } };
+    const result = buildWatchPostGameResult({
+      canonicalFinal: { home: 24, away: 17 },
+      viewerScores: {},
+      homeTeam,
+      awayTeam,
+      userTeamId: homeTeam.id,
+      week: 4,
+      phase: 'regular',
+      seasonId: '2031',
+      playerStats,
+      teamStats,
+    });
+
+    expect(result.playerStats).toBe(playerStats);
+    expect(result.teamStats).toBe(teamStats);
+  });
+
 });

--- a/src/ui/components/PostGameScreen.jsx
+++ b/src/ui/components/PostGameScreen.jsx
@@ -242,6 +242,7 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
   stats = {},         // { totalYards, passYards, rushYards, turnovers }
   logs = [],          // play-by-play logs (presentation-only: game flow / key moments)
   playerStats = null, // CANONICAL box score { home: {[pid]:{name,pos,stats}}, away: {...} }
+  teamStats = null,
   gameReasoningFlags = [],
   boxScoreGameId,
   onOpenBoxScore,
@@ -329,13 +330,14 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
       recapText,
       logs,
       playerStats: canonicalPlayerStats,
+      ...(teamStats ? { teamStats } : {}),
       scoringSummary: notableMoments,
       summary: {
         storyline: recapText,
         simOutputs: null,
       },
     });
-  }, [awayScore, awayTeam?.abbr, awayTeam?.id, boxScoreGameId, hasCanonicalStats, homeScore, homeTeam?.abbr, homeTeam?.id, logs, notableMoments, onArchiveReady, playerStats, strictFinalScore, week]);
+  }, [awayScore, awayTeam?.abbr, awayTeam?.id, boxScoreGameId, hasCanonicalStats, homeScore, homeTeam?.abbr, homeTeam?.id, logs, notableMoments, onArchiveReady, playerStats, strictFinalScore, teamStats, week]);
 
   const canOpenGameBook = Boolean(boxScoreGameId && hasStrictFinal);
 

--- a/src/ui/components/PostGameScreen.test.jsx
+++ b/src/ui/components/PostGameScreen.test.jsx
@@ -68,6 +68,36 @@ describe('PostGameScreen onArchiveReady payload', () => {
     expect(allNames).not.toContain('Narration Ghost QB');
   });
 
+  it('persists canonical teamStats unchanged when supplied', async () => {
+    const archiveSpy = vi.fn();
+    const playerStats = { home: { 10: { name: 'Home QB', pos: 'QB', stats: { passAtt: 1, passComp: 1, passYd: 12 } } }, away: {} };
+    const teamStats = {
+      home: { passYards: 12, rushYards: 90, totalYards: 102, firstDowns: 11, thirdDownMade: 4, thirdDownAtt: 9, redZoneMade: 1, redZoneAtt: 2, turnovers: 0, plays: 55, yardsPerPlay: 1.85 },
+      away: { passYards: 0, rushYards: 80, totalYards: 80, firstDowns: 8, thirdDownMade: 2, thirdDownAtt: 8, redZoneMade: 0, redZoneAtt: 1, turnovers: 1, plays: 50, yardsPerPlay: 1.6 },
+    };
+
+    await act(async () => {
+      render(
+        <PostGameScreen
+          homeTeam={{ id: 1, abbr: 'HME', name: 'Home' }}
+          awayTeam={{ id: 2, abbr: 'AWY', name: 'Away' }}
+          homeScore={10}
+          awayScore={7}
+          userTeamId={1}
+          boxScoreGameId="team-stats-game"
+          playerStats={playerStats}
+          teamStats={teamStats}
+          week={1}
+          onArchiveReady={archiveSpy}
+          onContinue={() => {}}
+        />,
+      );
+    });
+
+    expect(archiveSpy).toHaveBeenCalledOnce();
+    expect(archiveSpy.mock.calls[0][0].teamStats).toBe(teamStats);
+  });
+
   it('preserves player names in canonical playerStats', async () => {
     const archiveSpy = vi.fn();
     const playerStats = {

--- a/src/ui/components/__tests__/CanonicalPostgameIntegration.test.jsx
+++ b/src/ui/components/__tests__/CanonicalPostgameIntegration.test.jsx
@@ -86,6 +86,7 @@ describe('canonical postgame integration: simulateBatch → PLAY_LOGS → PostGa
           boxScoreGameId="integration-game"
           logs={playLogsPayload.logs}
           playerStats={playLogsPayload.playerStats}
+          teamStats={playLogsPayload.teamStats}
           week={6}
           onArchiveReady={archiveSpy}
           onContinue={() => {}}
@@ -97,6 +98,7 @@ describe('canonical postgame integration: simulateBatch → PLAY_LOGS → PostGa
     expect(archiveSpy).toHaveBeenCalledOnce();
     const archive = archiveSpy.mock.calls[0][0];
     expect(archive.playerStats).toEqual(playLogsPayload.playerStats);
+    expect(archive.teamStats).toEqual(playLogsPayload.teamStats);
 
     // 4) The canonical passing leader is the same computed from res.boxScore and
     //    from the archived playerStats.
@@ -114,6 +116,17 @@ describe('canonical postgame integration: simulateBatch → PLAY_LOGS → PostGa
     const vm = buildBoxScoreViewModel({ league, game: archive, gameId: archive.gameId });
     expect(vm.finalScore.home).toBe(finalHome);
     expect(vm.finalScore.away).toBe(finalAway);
+
+    for (const side of ['home', 'away']) {
+      for (const key of [
+        'passYards', 'rushYards', 'totalYards', 'firstDowns',
+        'thirdDownMade', 'thirdDownAtt', 'redZoneMade', 'redZoneAtt',
+        'turnovers', 'plays', 'yardsPerPlay', 'penalties', 'timePossession',
+      ]) {
+        expect(vm.teamTotals[side]?.[key], `${side}.${key} survives into Game Book`).toBe(playLogsPayload.teamStats[side]?.[key]);
+      }
+    }
+
     const gameBookLeaderSide = resLeader.teamId === home.id ? vm.playerTables.home : vm.playerTables.away;
     const gameBookLeader = gameBookLeaderSide.find((p) => p.name === resLeader.name);
     expect(gameBookLeader, 'passing leader must appear in the Game Book player tables').toBeTruthy();

--- a/src/ui/hooks/useWorker.test.js
+++ b/src/ui/hooks/useWorker.test.js
@@ -33,3 +33,19 @@ describe('workerReducer', () => {
     expect(shouldAcceptBootScopedPayload({ phase: 'regular' }, null, ['boot_1'])).toBe(true);
   });
 });
+
+it('transports and clears watched-game canonical player and team stats together', () => {
+  const playerStats = { home: { qb: { stats: { passYd: 250 } } }, away: {} };
+  const teamStats = { home: { passYards: 250, firstDowns: 20 }, away: { passYards: 180, firstDowns: 15 } };
+  const played = workerReducer(INITIAL_WORKER_STATE, { type: 'PLAY_LOGS', logs: [], playerStats, teamStats });
+  expect(played.userGamePlayerStats).toBe(playerStats);
+  expect(played.userGameTeamStats).toBe(teamStats);
+
+  const cleared = workerReducer(played, { type: 'CLEAR_USER_GAME' });
+  expect(cleared.userGamePlayerStats).toBeNull();
+  expect(cleared.userGameTeamStats).toBeNull();
+
+  const restarted = workerReducer(played, { type: 'SIM_START' });
+  expect(restarted.userGamePlayerStats).toBeNull();
+  expect(restarted.userGameTeamStats).toBeNull();
+});


### PR DESCRIPTION
### Motivation
- Complete the narrow correctness cleanup after the canonical engine change so postgame surfaces consume the canonical box score without leaking passer INTs as defensive production. 
- Fix three confirmed defects: passer interceptions counted as defensive INTs, stale QB-dependent fields after reconciliation, and `teamStats` being dropped before watched-game archive/Game Book. 
- Preserve all #1698 behavior and avoid any engine redesign or unrelated system changes.

### Description
- Added clear semantic helpers `isPassingRow`, `defensiveInterceptions`, and `interceptionsThrown` and updated `buildPlayerLeadersFromArchive` to score defensive leaders only on genuine defensive production and to prevent passer-thrown INTs from appearing as defensive INTs. 
- Apply a modest deterministic penalty for interceptions thrown in the Player-of-Game impact calculation (passer INTs do not increase positive impact). 
- After the QB→receiver reconciliation, recompute dependent QB fields with `recomputeReconciledQbDependentStats` so reconciled lines satisfy invariants: `0 <= passComp <= passAtt`, `dropbacks === passAtt + sacksTaken`, `longestPass <= passYd` and `longestPass == 0` when `passComp === 0 || passYd === 0`, and recompute `completionPct`, `passerRating` and derived rate fields. 
- Restore watched-game team stat plumbing by carrying `userGameTeamStats` through `useWorker` → `buildWatchPostGameResult(teamStats)` → `PostGameScreen.teamStats` → `onArchiveReady.teamStats`, and include supplied canonical `teamStats` unchanged in the archive payload (preserving rich fields such as `firstDowns`, `thirdDownMade`, `thirdDownAtt`, `redZoneMade`, `redZoneAtt`, `timePossession`, `plays`, `yardsPerPlay`, `turnovers`, etc.). 
- Tests and focussed documentation added: `docs/canonical-postgame-integrity-follow-up-v1.md` and regression/unit tests for interception semantics, QB dependent-field invariants, forced-QB-injury reconciliation, `buildWatchPostGameResult` teamStats passthrough, `useWorker` reducer transport, and `PostGameScreen` archive payload.

### Testing
- Unit suites run: `npm run test:unit` — full test run passed (all unit tests; 451 files, 5548 tests reported passing in this environment). 
- Production build: `npm run build` — build succeeded (Vite emitted expected large-chunk warnings only). 
- Durability: `npm run durability:test` — passed. 
- Targeted suites exercised: `src/core/__tests__/gameSummary.test.js`, `src/core/__tests__/simulation/canonicalGameAuthority.test.js`, `src/ui/App.test.jsx`, `src/ui/components/PostGameScreen.test.jsx`, and `src/ui/hooks/useWorker.test.js` — added tests passed. 
- Playwright E2E: `npx playwright test tests/e2e/mobile_game_day_trust.spec.js` blocked by environment/browser install; `npx playwright install --with-deps chromium` attempted but the browser download failed due to a network/CDN policy (HTTP 403 from `cdn.playwright.dev`). This prevented running the E2E mobile game-day trust spec in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c787fc4e0832db44792becdca3b0d)