### PR TITLE
Canonical drive-level gamecast: one event ledger for scoring & live scorebug (#1700)

### DIFF
--- a/docs/canonical-gamecast-playable-tomorrow-v1.md
+++ b/docs/canonical-gamecast-playable-tomorrow-v1.md
@@ -14,6 +14,20 @@ fabricates play-by-play, a clock, or player attribution.
 
 The canonical player/team-stat authority from #1698/#1699 is untouched.
 
+## 1a. Post-review revisions
+
+**Defect #1 — fabricated quarter authority (FIXED).** The first build assigned
+regulation quarters by evenly dividing interleaved drives into four buckets and
+published a quarter-score table from them. That was deterministic but not
+canonical timing. It is removed: canonical events now carry `quarter: null` +
+an honest `periodLabel` (`"Drive 8"` / `"OT"`), `quarterScores` is `null`, and
+the UI (scorebug + feed) shows `Drive {n} · {ABBR} possession` instead of a
+fabricated `Q{n}`. Overtime is flagged `isOvertime: true` / `periodLabel: "OT"`,
+never `Q5`. See §6, §8, §10, §13.
+
+Review defects #2–#4 from the follow-up request were truncated in transmission
+and are not yet addressed in this revision.
+
 ## 2. Before-fix authority map
 
 | Surface | Producer (before) | Authoritative? |
@@ -67,14 +81,23 @@ Q2 · BAL drive · 8 plays, 71 yards · Touchdown · NYJ 10 — BAL 14
 Produced by `src/core/simulation/canonicalGameEvents.js`:
 
 ```
-{ eventId, gameId, driveId, sequence, quarter, clock: null,
+{ eventId, gameId, driveId, sequence, driveNumber,
+  quarter: null, periodLabel, isOvertime, clock: null,
   possessionTeamId, scoringTeamId, eventType, driveResult, points,
-  scoreAfter: { home, away }, plays, yards, isScore, isOvertime,
+  scoreAfter: { home, away }, plays, yards, isScore,
   primaryPlayerId: null, secondaryPlayerId: null, teamAbbr, text }
 ```
 
 Every score-changing event carries: stable `eventId`, deterministic `sequence`,
-`quarter`, `scoringTeamId`, `eventType`, `points`, and `scoreAfter.{home,away}`.
+`scoringTeamId`, `eventType`, `points`, and `scoreAfter.{home,away}`.
+
+**Honest period, not a fabricated quarter (post-review fix — defect #1).** The
+drive engine generates separate home and away drive logs with no shared clock,
+so there is *no* canonical mapping of a drive to Q1–Q4. Publishing evenly-divided
+"quarters" would be invented authority. Therefore `quarter` is `null` for all
+regulation *and* overtime events; the honest ordering signal is `sequence` +
+`periodLabel` (`"Drive 8"`). Overtime — the one period the sim tracks distinctly
+— carries `isOvertime: true` and `periodLabel: "OT"` (never a fabricated `Q5`).
 
 ## 7. Score reconciliation
 
@@ -85,12 +108,17 @@ per-drive log (which sums to the drive-engine score); OT points are captured fro
 the OT loop and appended, so the total equals the post-OT final. TDs are scored
 as 6/7/8 explicitly (no "every TD is 7" assumption); FGs are 3.
 
-## 8. Quarter-score reconciliation
+## 8. Quarter-score authority (post-review fix — defect #1)
 
-`quarterScores = sum of canonical scoring-event points by quarter`. Regulation
-drives are interleaved (deterministic, seed-driven) and split into four quarters;
-`sum(quarter scores, per side) === final score`. A quarter with no scoring shows
-0; a genuine 0–0 game yields four zero quarters and remains valid.
+There is **no canonical quarter-score table**. The authoritative engine does not
+simulate a chronological regulation timeline, so `canonicalGameEvents` sets
+`quarterScores: null` — the established "unavailable" representation the Game Book
+/ box-score view model already handle (they simply do not render a linescore).
+This replaces the earlier build, which divided interleaved drives evenly into four
+buckets and published them as quarter scores; that was deterministic but was
+**invented quarter timing**, and is removed. The scoring summary and running
+score remain fully canonical (§7, §9) — only the fabricated quarter placement is
+gone.
 
 ## 9. Scoring-summary reconciliation
 
@@ -101,8 +129,9 @@ team, quarter, scoring type, point value, and running score (`scoreAfter`).
 ## 10. Clock policy
 
 No clock is invented. `clock` is always `null`; the scorebug shows
-`Q{n} · Drive {i} of {N}` and the feed shows `Q{n} · #{sequence}`. No fake
-`15:10`-style values anywhere.
+`Drive {n} · {ABBR} possession` (or `OT · …`) and the feed shows the honest
+`periodLabel` (`"Drive 8"` / `"OT"`) with the event `#{sequence}`. No fake
+`15:10`-style values and no fabricated quarter labels anywhere.
 
 ## 11. Player-attribution policy
 
@@ -125,8 +154,10 @@ new RNG is consumed to format the canonical events (pure transform).
 `LiveGameViewer` prefers the canonical ledger: the scorebug reads the current
 canonical event's `scoreAfter` (a real, monotonic running score) and shows the
 league-recorded final at the end. It never parses narration or shows a narrated
-running score. Legacy archives with no ledger fall back to the #1692 honest
-placeholder (final only at the end).
+running score. The period cell shows the honest `Drive {n} · {ABBR} possession`
+(defect #1 fix), never a fabricated quarter. Legacy archives with no ledger fall
+back to the #1692 honest placeholder (final only at the end) and keep their
+numeric quarter labels.
 
 At completion: live scorebug === GAME_EVENT final === PostGameScreen final ===
 schedule result === Game Book final.
@@ -219,9 +250,11 @@ One P0 fix beyond the core change: the `workerApi.js` PLAY_LOGS transport gap
 
 ## 23. Unit-test result
 
-`npm run test:unit` → **454 files, 5582 tests passed** (+32 new). Includes 14
-ledger-invariant tests, 14 full-path integration tests, 3 canonical-viewer tests,
-and 1 canonical-archive test.
+`npm run test:unit` → **454 files, 5584 tests passed**. Includes 14
+ledger-invariant tests (now asserting null quarter authority + honest
+`periodLabel`), 14 full-path integration tests, 4 canonical-viewer tests
+(incl. the `Drive N · ABBR possession` scorebug), 1 canonical-archive test, and
+the PLAY_LOGS transport regression.
 
 ## 24. Build result
 

--- a/docs/canonical-gamecast-playable-tomorrow-v1.md
+++ b/docs/canonical-gamecast-playable-tomorrow-v1.md
@@ -16,17 +16,41 @@ The canonical player/team-stat authority from #1698/#1699 is untouched.
 
 ## 1a. Post-review revisions
 
+All four follow-up review defects are fixed.
+
 **Defect #1 — fabricated quarter authority (FIXED).** The first build assigned
 regulation quarters by evenly dividing interleaved drives into four buckets and
 published a quarter-score table from them. That was deterministic but not
-canonical timing. It is removed: canonical events now carry `quarter: null` +
-an honest `periodLabel` (`"Drive 8"` / `"OT"`), `quarterScores` is `null`, and
-the UI (scorebug + feed) shows `Drive {n} · {ABBR} possession` instead of a
+canonical timing. Removed: canonical events now carry `quarter: null` + an honest
+`periodLabel` (`"Drive 8"` / `"OT"`), `quarterScores` is `null`, and the UI
+(scorebug + feed) shows `Drive {n} of {N} · {ABBR} possession` instead of a
 fabricated `Q{n}`. Overtime is flagged `isOvertime: true` / `periodLabel: "OT"`,
-never `Q5`. See §6, §8, §10, §13.
+never `Q5`. PostGameScreen / Game Book now show an honest **"Quarter breakdown
+unavailable for this game."** note for canonical-ledger games (legacy archives
+with genuine stored quarter data still display it), and `deriveQuarterScores`
+never reconstructs a fabricated quarter table from the narration stream for a
+canonical-ledger game. See §6, §8, §10, §13.
 
-Review defects #2–#4 from the follow-up request were truncated in transmission
-and are not yet addressed in this revision.
+**Defect #2 — fake play-call agency (FIXED).** The Run Heavy / Pass Heavy /
+Timeout buttons claimed strategic effect but the watched game is fully simulated
+before playback, so they could not change the result on any path (and App never
+wired `onPlaycallOverride`). They are **removed** (not merely hidden) on every
+path; canonical playback shows the honest note *"Game strategy was locked when
+simulation began."* `onPlaycallOverride` is never invoked. Pause / speed / next
+score / key moment / sim-to-end controls are preserved. See §14.
+
+**Defect #3 — offensive sacks miscounted as defensive (FIXED).** A passing row's
+`sacks` field means sacks *taken*; a defensive row's means sacks *made*. New
+shared semantic helpers `defensiveSacks(row)` / `sacksTaken(row)` (alongside the
+existing `isPassingRow`) are used by both `buildPlayerLeadersFromArchive` and
+`deriveStandoutsFromBoxScore`, so a QB's sacks-taken can never make it the
+defensive/sack leader, add positive Player-of-Game impact, or become the live
+Sacks standout. Genuine defender sacks are unaffected. See §11.
+
+**Defect #4 — drive progress miscount (FIXED).** The terminal `game_end` marker
+is not a drive. A pure helper `countCanonicalRegulationDrives(events)` excludes it
+(and the OT divider), so the scorebug reads `Drive 24 of 24`, never `of 25`, and
+shows `Final` at the terminal marker. See §13.
 
 ## 2. Before-fix authority map
 
@@ -120,10 +144,17 @@ buckets and published them as quarter scores; that was deterministic but was
 score remain fully canonical (§7, §9) — only the fabricated quarter placement is
 gone.
 
+PostGameScreen and the Game Book render an honest **"Quarter breakdown
+unavailable for this game."** note for canonical-ledger games and drop the
+`Q{n}` prefix from scoring rows in favor of the `periodLabel` (`"Drive 8"`).
+`boxScorePresentation.deriveQuarterScores` refuses to reconstruct a fabricated
+quarter table from the narration stream whenever a canonical ledger is present.
+Legacy archives that carry genuine stored `quarterScores` still display them.
+
 ## 9. Scoring-summary reconciliation
 
 The scoring summary is the `isScore` slice of the ledger. Each row agrees on
-team, quarter, scoring type, point value, and running score (`scoreAfter`).
+team, period label, scoring type, point value, and running score (`scoreAfter`).
 `sum(scoring-summary points, per side) === final score`.
 
 ## 10. Clock policy
@@ -141,6 +172,14 @@ team-level text. Player totals are **never** recounted from event text — the
 canonical box score from #1698/#1699 remains the sole player-stat authority. The
 live "Standouts" panel now derives from that canonical box score
 (`liveGameStandouts.js`), never the narration stream.
+
+**Sack semantics (review defect #3).** `sacks` is overloaded on the canonical
+row: on a passing row it is sacks *taken*; on a defensive row it is sacks *made*.
+Shared helpers `defensiveSacks(row)` / `sacksTaken(row)` (with `isPassingRow`) are
+the single source of truth, used by both `buildPlayerLeadersFromArchive` and
+`deriveStandoutsFromBoxScore`. A QB's sacks-taken never counts as defensive
+production (defensive/sack leader, positive Player-of-Game impact, or the live
+Sacks standout); genuine defender sacks still count.
 
 ## 12. Narration role after the fix
 
@@ -164,13 +203,16 @@ schedule result === Game Book final.
 
 ## 14. User play-call control audit
 
-The viewer's Run Heavy / Pass Heavy / Timeout controls (`onPlaycallOverride`) are
-**presentation-only** in the watched flow — the authoritative drive engine is
-already fully simulated before playback begins, so they cannot change the
-outcome. They remain as viewing preferences; this PR does **not** claim they
-steer the canonical result. Pause / speed / skip / jump controls are preserved
-and fully functional. (Wiring live play-calls into the authoritative engine is
-out of scope; flagged as a future item, not a #1700 deliverable.)
+The authoritative drive engine is fully simulated **before** playback begins, so
+Run Heavy / Pass Heavy / Timeout could not change the outcome on any path — and
+App never wired `onPlaycallOverride` at all. Per review defect #2 these controls
+are **removed** (not hidden, and not rebranded as "viewing preferences"), because
+they claimed a strategic effect they did not have. Canonical playback shows the
+honest note *"Game strategy was locked when simulation began."* and
+`onPlaycallOverride` is never invoked. The controls that do real work — pause,
+speed, next score, key moment, sim-to-end, jump filters — are preserved and
+fully functional. (Wiring live play-calls into the authoritative engine remains
+out of scope; a future item, not a #1700 deliverable.)
 
 ## 15. Archive and save/reload behavior
 
@@ -250,11 +292,13 @@ One P0 fix beyond the core change: the `workerApi.js` PLAY_LOGS transport gap
 
 ## 23. Unit-test result
 
-`npm run test:unit` → **454 files, 5584 tests passed**. Includes 14
-ledger-invariant tests (now asserting null quarter authority + honest
-`periodLabel`), 14 full-path integration tests, 4 canonical-viewer tests
-(incl. the `Drive N · ABBR possession` scorebug), 1 canonical-archive test, and
-the PLAY_LOGS transport regression.
+`npm run test:unit` → **455 files, 5596 tests passed**. Includes: 14
+ledger-invariant tests (null quarter authority + honest `periodLabel`); 14
+full-path integration tests; canonical-viewer tests (drive-progress `Drive N of
+N`, `Final` at the terminal marker, and no play-call controls); sack-semantics
+regressions in `gameSummary.test.js` and `liveGameStandouts.test.js` (the review's
+QB-5-sacks-taken / EDGE-1-sack fixture); Game-Book quarter-unavailable +
+`periodLabel` DOM tests; and the `deriveQuarterScores` canonical-guard test.
 
 ## 24. Build result
 

--- a/docs/canonical-gamecast-playable-tomorrow-v1.md
+++ b/docs/canonical-gamecast-playable-tomorrow-v1.md
@@ -1,0 +1,266 @@
+# Canonical Gamecast & Playable-Tomorrow Release Gate V1 (#1700)
+
+## 1. Executive verdict
+
+**Merge-ready.** The last narration-owned factual surface — the watched-game
+event stream (scoring summary, quarter scores, live scorebug) — now derives from
+**one canonical drive-level event ledger** built from the same drive engine that
+owns the official final score. Every factual surface (live scorebug → final →
+quarter scores → scoring summary → PostGameScreen → Game Book → save/reload)
+describes the same game. The change is **Lane B** (canonical drive-level
+gamecast): the authoritative engine owns drives and drive outcomes, not
+individual plays or a clock, so the ledger is honest at the drive level and never
+fabricates play-by-play, a clock, or player attribution.
+
+The canonical player/team-stat authority from #1698/#1699 is untouched.
+
+## 2. Before-fix authority map
+
+| Surface | Producer (before) | Authoritative? |
+|---|---|---|
+| Official final score | `buildDriveBasedSummary` (drive engine) | **Yes** |
+| TD/FG/XP/2PT breakdown | `buildDriveBasedSummary` | **Yes** |
+| Overtime points | `simGameStats` OT loop (global RNG) | Yes (added after regulation) |
+| Player box score | `generateStatsForTeam` (#1698/#1699) | **Yes** |
+| Team stats | derived from box score (#1698) | **Yes** |
+| **Scoring summary** | `buildScoringSummaryFromSimulation(playLogs)` | ❌ narration-derived |
+| **Quarter scores** | `buildQuarterScoresFromScoring(scoringSummary)` | ❌ narration-derived |
+| **Live scorebug (watch)** | `LiveGame.jsx` synthetic `generatePlay()` ticker / narration | ❌ fabricated |
+| Drive cards | `buildDriveSummaryFromSimulation(playLogs)` | ❌ narration (flavor only) |
+
+The drive engine simulated **all home drives, then all away drives**, accumulating
+only aggregate counters — it retained no ordered, quarter-assigned, `scoreAfter`
+event list. The scoring summary and quarter scores were therefore reconstructed
+from the independent narration `playLogs`, whose per-quarter attribution and
+running score routinely disagreed with the authoritative final.
+
+## 3. Reproduction games and seeds
+
+Reproduced through the real drive engine + ledger across the required seeds
+(`6, 39, 123, 777, 2026, 4242, 8888`) covering low/normal/high/blowout/close and
+a synthetic OT case. For each: official final, canonical scoring-event count,
+quarter totals, and scoring-summary totals all reconcile exactly. See
+`src/core/__tests__/simulation/canonicalGameEvents.test.js` and
+`canonicalEventsIntegration.test.js` (full `simGameStats` / `simulateBatch` path).
+
+## 4. First factual event divergence
+
+The divergence began the moment any factual surface read the narration
+`playLogs`: `buildScoringSummaryFromSimulation(normalizedPlayLogs, …)` in
+`simGameStats`, and the fully synthetic `generatePlay()` ticker in `LiveGame.jsx`
+(fabricated `7`-pt TDs on an ~8-play cadence). Neither consulted the drive
+engine's authoritative scoring breakdown.
+
+## 5. Chosen lane — **Lane B**
+
+The authoritative engine owns drives and drive outcomes but **not** individual
+plays, yardage-by-play, a trustworthy clock, or per-play player pairing. Forcing
+play-level detail would fabricate data that contradicts the box score. Lane B
+presents an honest drive-by-drive gamecast:
+
+```
+Q2 · BAL drive · 8 plays, 71 yards · Touchdown · NYJ 10 — BAL 14
+```
+
+## 6. Canonical event schema
+
+Produced by `src/core/simulation/canonicalGameEvents.js`:
+
+```
+{ eventId, gameId, driveId, sequence, quarter, clock: null,
+  possessionTeamId, scoringTeamId, eventType, driveResult, points,
+  scoreAfter: { home, away }, plays, yards, isScore, isOvertime,
+  primaryPlayerId: null, secondaryPlayerId: null, teamAbbr, text }
+```
+
+Every score-changing event carries: stable `eventId`, deterministic `sequence`,
+`quarter`, `scoringTeamId`, `eventType`, `points`, and `scoreAfter.{home,away}`.
+
+## 7. Score reconciliation
+
+Guaranteed by construction, verified across the seed matrix:
+`sum(scoring-event points, per side) === final score` and
+`last scoreAfter === final score`. Regulation points come from the drive engine's
+per-drive log (which sums to the drive-engine score); OT points are captured from
+the OT loop and appended, so the total equals the post-OT final. TDs are scored
+as 6/7/8 explicitly (no "every TD is 7" assumption); FGs are 3.
+
+## 8. Quarter-score reconciliation
+
+`quarterScores = sum of canonical scoring-event points by quarter`. Regulation
+drives are interleaved (deterministic, seed-driven) and split into four quarters;
+`sum(quarter scores, per side) === final score`. A quarter with no scoring shows
+0; a genuine 0–0 game yields four zero quarters and remains valid.
+
+## 9. Scoring-summary reconciliation
+
+The scoring summary is the `isScore` slice of the ledger. Each row agrees on
+team, quarter, scoring type, point value, and running score (`scoreAfter`).
+`sum(scoring-summary points, per side) === final score`.
+
+## 10. Clock policy
+
+No clock is invented. `clock` is always `null`; the scorebug shows
+`Q{n} · Drive {i} of {N}` and the feed shows `Q{n} · #{sequence}`. No fake
+`15:10`-style values anywhere.
+
+## 11. Player-attribution policy
+
+Drive-level authority cannot prove per-play passer/receiver pairing, so
+`primaryPlayerId`/`secondaryPlayerId` are `null` and scoring rows use honest
+team-level text. Player totals are **never** recounted from event text — the
+canonical box score from #1698/#1699 remains the sole player-stat authority. The
+live "Standouts" panel now derives from that canonical box score
+(`liveGameStandouts.js`), never the narration stream.
+
+## 12. Narration role after the fix
+
+`simulateFullGame`/`playLogs` are demoted to a **non-factual flavor layer**
+(drive-summary cards, momentum text). They no longer own score, scoring events,
+quarter scoring, possession outcomes, player totals, leaders, or the final. No
+new RNG is consumed to format the canonical events (pure transform).
+
+## 13. Live scorebug behavior
+
+`LiveGameViewer` prefers the canonical ledger: the scorebug reads the current
+canonical event's `scoreAfter` (a real, monotonic running score) and shows the
+league-recorded final at the end. It never parses narration or shows a narrated
+running score. Legacy archives with no ledger fall back to the #1692 honest
+placeholder (final only at the end).
+
+At completion: live scorebug === GAME_EVENT final === PostGameScreen final ===
+schedule result === Game Book final.
+
+## 14. User play-call control audit
+
+The viewer's Run Heavy / Pass Heavy / Timeout controls (`onPlaycallOverride`) are
+**presentation-only** in the watched flow — the authoritative drive engine is
+already fully simulated before playback begins, so they cannot change the
+outcome. They remain as viewing preferences; this PR does **not** claim they
+steer the canonical result. Pause / speed / skip / jump controls are preserved
+and fully functional. (Wiring live play-calls into the authoritative engine is
+out of scope; flagged as a future item, not a #1700 deliverable.)
+
+## 15. Archive and save/reload behavior
+
+The canonical `scoringSummary`, `quarterScores`, and `canonicalEvents` are
+persisted by both paths: the worker season/batch archive builder and the watch
+path (`PostGameScreen.onArchiveReady`, which now archives the **canonical**
+scoring summary/quarter scores/ledger, not the narration `notableMoments`).
+Opening the Game Book re-reads the persisted canonical data — it does not
+regenerate events, recount narration, or change the running score. Save/reload
+preserves the event fingerprint (id/sequence/quarter/team/type/points/scoreAfter).
+
+## 16. Legacy-game behavior
+
+Archives without a canonical ledger remain readable: the viewer falls back to the
+narration feed with the #1692 honest final-only scorebug, and the Game Book uses
+its existing limited-detail derivation. No canonical timeline is fabricated for
+old archives.
+
+## 17. Browser release journey
+
+Ran the real production build (`vite build` + `preview`, port 4173) through the
+critical journeys with pre-installed Chromium:
+
+- `fresh_franchise_first_week_smoke.spec.js` — fresh storage → Start New
+  Franchise → onboarding → HQ → advance Week 1 → Simulate (Skip) → PostGame →
+  Game Book → HQ. **PASS.**
+- `mobile_game_day_trust.spec.js` — watch → canonical live scorebug → final →
+  PostGame → Game Book → HQ, all using the canonical result end to end; plus the
+  missing-Game-Book recovery case. **PASS (2/2).**
+
+This journey caught a real transport gap (see §20) that unit tests could not.
+
+## 18. Mobile viewport results
+
+`mobile_game_day_trust.spec.js` runs at 390×844 (iPhone) with a horizontal-overflow
+assertion (`scrollWidth - clientWidth <= 1`) and an in-viewport control-tray
+assertion — both pass. `fresh_franchise_first_week_smoke` exercises the desktop
+build path. No nested-scroll trap; sticky controls remain reachable.
+
+## 19. Console/page-error results
+
+The passing specs complete without an app crash (`not.toContainText('Something
+went wrong')`) and without unhandled navigation errors. (A dedicated
+console-error allowlist collector is recommended as a follow-up hardening item;
+the current specs assert on error boundaries and recovery surfaces.)
+
+## 20. E2E silent-catch removals
+
+- `tests/e2e/helpers/franchise.js`: removed the swallowed
+  `expect(advanceCta).toBeEnabled().catch(() => {})` (now a readiness probe) and
+  the swallowed `Advance anyway` / `Simulate (Skip)` `click().catch(() => {})`.
+  Both are now explicit optional-state branches: probe visibility → assert
+  enabled → click without swallowing; the existing week-advance `waitForFunction`
+  asserts the transition.
+- `tests/e2e/fresh_franchise_first_week_smoke.spec.js`: `Simulate (Skip)` is now a
+  **required** asserted interaction (visible → enabled → click), not a swallowed
+  click.
+- `tests/e2e/mobile_game_day_trust.spec.js`: the scorebug assertion was updated
+  from "shows dashes during playback" to "shows the canonical running score,
+  numeric and never exceeding the recorded final" — the #1700 behavior.
+
+**Transport gap the browser journey caught:** `workerApi.js` did not forward the
+new `PLAY_LOGS` fields, so `canonicalEvents` never reached the viewer in the real
+app (unit tests passed because they injected the prop directly). Fixed — this is
+exactly the class of defect swallowed Playwright failures used to hide.
+
+## 21. Other screens audited
+
+Existing smoke specs cover HQ, Roster, Schedule/Standings, Player Profile, Box
+Score click-through, League Pulse, Free Agency, and phase hydration; they remain
+green in the unit suite. No new dead doors were introduced by this PR.
+
+## 22. Additional P0/P1 fixes
+
+One P0 fix beyond the core change: the `workerApi.js` PLAY_LOGS transport gap
+(§20) — required for the canonical live scorebug to work in the real app.
+
+## 23. Unit-test result
+
+`npm run test:unit` → **454 files, 5582 tests passed** (+32 new). Includes 14
+ledger-invariant tests, 14 full-path integration tests, 3 canonical-viewer tests,
+and 1 canonical-archive test.
+
+## 24. Build result
+
+`npm run build` → **success** (large-chunk advisory only, pre-existing).
+
+## 25. Playwright result
+
+Against the **production build**: `mobile_game_day_trust.spec.js` **2/2 pass**;
+`fresh_franchise_first_week_smoke.spec.js` **1/1 pass**. Chromium was available
+(`/opt/pw-browsers/chromium-1194`); execution was **not** blocked.
+
+## 26. Durability result
+
+`npm run durability:test` → **38 pass**. `npm run durability:smoke` and
+`durability:5` → **stop at season-1 `afterSeasonRollover`** with
+`schedule.games-reference-valid-teams` (8 scheduled games reference an unknown
+team, 3 invariant failures). **Verified pre-existing** (identical `fail=3` on the
+base tree at #1699 via `git stash`), unrelated to the canonical-event change,
+which touches no schedule/rollover code. Reported, not bundled.
+
+## 27. Known remaining defects
+
+- Post-rollover schedule references invalid teams (durability, pre-existing).
+- Live play-call controls are presentation-only in the watched flow (§14).
+- No dedicated console-error allowlist collector yet (§19).
+
+## 28. Exact #1701 recommendation
+
+**#1701 — Post-Rollover Schedule & Archive Reference Integrity V1.** Fix the
+season-rollover schedule generation so no scheduled game references an unknown
+team id (`schedule.games-reference-valid-teams`), plus the related archived-champion
+/ self-game / rosterFingerprint durability invariants. Do not weaken the
+durability invariants; repair the shared references. This is orthogonal to the
+canonical-event work.
+
+## 29. Merge recommendation
+
+**Merge #1700.** The watched game now tells one coherent, truthful story: the live
+scorebug, quarter scores, scoring summary, PostGameScreen, Game Book, and
+save/reload all describe the single game the drive engine simulated. Unit, build,
+and the critical browser journeys pass; the only durability failure is a
+documented, pre-existing, out-of-scope rollover issue deferred to #1701.

--- a/docs/canonical-gamecast-playable-tomorrow-v1.md
+++ b/docs/canonical-gamecast-playable-tomorrow-v1.md
@@ -3,14 +3,17 @@
 ## 1. Executive verdict
 
 **Merge-ready.** The last narration-owned factual surface — the watched-game
-event stream (scoring summary, quarter scores, live scorebug) — now derives from
-**one canonical drive-level event ledger** built from the same drive engine that
-owns the official final score. Every factual surface (live scorebug → final →
-quarter scores → scoring summary → PostGameScreen → Game Book → save/reload)
-describes the same game. The change is **Lane B** (canonical drive-level
-gamecast): the authoritative engine owns drives and drive outcomes, not
-individual plays or a clock, so the ledger is honest at the drive level and never
-fabricates play-by-play, a clock, or player attribution.
+event stream (scoring summary + live scorebug) — now derives from **one canonical
+drive-level event ledger** built from the same drive engine that owns the
+official final score. Every factual surface (live scorebug → final → scoring
+summary → PostGameScreen → Game Book → save/reload) describes the same game. The
+change is **Lane B** (canonical drive-level gamecast): the authoritative engine
+owns drives and drive outcomes, not individual plays, a clock, or a chronological
+timeline, so the ledger is honest at the drive level and never fabricates
+play-by-play, a clock, quarter placement, or player attribution. The mid-game
+possession order and running score are a labeled reconstruction; only the final
+is official. No canonical quarter-score table is published (the engine owns no
+quarter timing).
 
 The canonical player/team-stat authority from #1698/#1699 is untouched.
 
@@ -51,6 +54,36 @@ Sacks standout. Genuine defender sacks are unaffected. See §11.
 is not a drive. A pure helper `countCanonicalRegulationDrives(events)` excludes it
 (and the OT divider), so the scorebug reads `Drive 24 of 24`, never `of 25`, and
 shows `Final` at the terminal marker. See §13.
+
+## 1b. Post-review round 2 (honesty of the reconstruction)
+
+1. **Reconstructed order is no longer called canonical chronology.** The engine
+   simulates each side's drives separately and owns no possession chronology; the
+   interleaved order — and every intermediate `scoreAfter` before the final — is a
+   deterministic *reconstruction*. Module/UI comments now say so; what stays
+   canonical is the final score, the scoring events, their points, and per-side
+   totals (`canonicalGameEvents.js`, `liveGameEvents.js`, `LiveGameViewer.jsx`).
+2. **The intermediate gamecast progression is labeled honestly.** During canonical
+   playback the viewer shows a **"Reconstructed order"** chip (with a tooltip)
+   clarifying the mid-game order/running score are illustrative and only the final
+   is official.
+3. **Final box-score Standouts are hidden until the final whistle.** They are final
+   totals, so showing them mid-game was misleading; the panel now shows *"Game
+   leaders unlock at the final whistle."* until `finished`.
+4. **Stale quarter wording removed** from this document and the PR title.
+5. The two production-build Playwright flows were re-run (see §25).
+
+**Additional P1 fixed while re-running the flows — watch→Game Book recovery race.**
+Re-running `mobile_game_day_trust` surfaced a genuine, pre-existing race
+(reproduced 3/3 on the prior commit): the Game Book resolved the just-watched
+game only from the **async** worker fetch (`getBoxScore`) and never from the
+**synchronous** localStorage postgame archive that `PostGameScreen` writes
+(`saveGame`). When the worker fetch lost the race it landed on the honest
+"recovery" state instead of the game the user just watched. Fix:
+`GameDetailScreen` now also consults `getGame(gameId)` (localStorage) and
+`resolveCanonicalCompletedGame` accepts a `localArchivedGame` source and uses
+whichever archive carries a valid final. The flow is now stable across repeated
+runs. Regression: `src/ui/utils/canonicalCompletedGame.test.js`.
 
 ## 2. Before-fix authority map
 
@@ -191,11 +224,15 @@ new RNG is consumed to format the canonical events (pure transform).
 ## 13. Live scorebug behavior
 
 `LiveGameViewer` prefers the canonical ledger: the scorebug reads the current
-canonical event's `scoreAfter` (a real, monotonic running score) and shows the
-league-recorded final at the end. It never parses narration or shows a narrated
-running score. The period cell shows the honest `Drive {n} · {ABBR} possession`
-(defect #1 fix), never a fabricated quarter. Legacy archives with no ledger fall
-back to the #1692 honest placeholder (final only at the end) and keep their
+canonical event's `scoreAfter` — a monotonic running total over a **reconstructed
+possession order** — and shows the league-recorded final at the end. It never
+parses narration or shows a narrated running score. During playback a
+**"Reconstructed order"** chip makes clear the mid-game order and running score
+are illustrative (only the final is official — post-review point 2), the period
+cell shows the honest `Drive {n} of {N} · {ABBR} possession` (never a fabricated
+quarter), and the box-score **Standouts stay hidden until the final whistle**
+(post-review point 3) since they are final totals. Legacy archives with no ledger
+fall back to the #1692 honest placeholder (final only at the end) and keep their
 numeric quarter labels.
 
 At completion: live scorebug === GAME_EVENT final === PostGameScreen final ===
@@ -287,18 +324,25 @@ green in the unit suite. No new dead doors were introduced by this PR.
 
 ## 22. Additional P0/P1 fixes
 
-One P0 fix beyond the core change: the `workerApi.js` PLAY_LOGS transport gap
-(§20) — required for the canonical live scorebug to work in the real app.
+Two fixes beyond the core change, both surfaced by the real browser journey:
+1. **P0** — the `workerApi.js` PLAY_LOGS transport gap (§20): required for the
+   canonical live scorebug to work in the real app.
+2. **P1** — the watch→Game Book recovery race (§1b): the Game Book resolved the
+   just-watched game only from the async worker fetch and could land on the
+   recovery state; it now also consults the synchronous localStorage postgame
+   archive. Reproduced 3/3 before the fix; stable across repeated runs after.
 
 ## 23. Unit-test result
 
-`npm run test:unit` → **455 files, 5596 tests passed**. Includes: 14
+`npm run test:unit` → **456 files, 5602 tests passed**. Includes: 14
 ledger-invariant tests (null quarter authority + honest `periodLabel`); 14
 full-path integration tests; canonical-viewer tests (drive-progress `Drive N of
-N`, `Final` at the terminal marker, and no play-call controls); sack-semantics
+N`, `Final` at the terminal marker, the "Reconstructed order" chip, hidden
+Standouts until the final whistle, and no play-call controls); sack-semantics
 regressions in `gameSummary.test.js` and `liveGameStandouts.test.js` (the review's
 QB-5-sacks-taken / EDGE-1-sack fixture); Game-Book quarter-unavailable +
-`periodLabel` DOM tests; and the `deriveQuarterScores` canonical-guard test.
+`periodLabel` DOM tests; the `deriveQuarterScores` canonical-guard test; and the
+`resolveCanonicalCompletedGame` local-archive fallback test.
 
 ## 24. Build result
 
@@ -306,7 +350,9 @@ QB-5-sacks-taken / EDGE-1-sack fixture); Game-Book quarter-unavailable +
 
 ## 25. Playwright result
 
-Against the **production build**: `mobile_game_day_trust.spec.js` **2/2 pass**;
+Against the **production build**: `mobile_game_day_trust.spec.js` **2/2 pass**
+(re-run repeatedly — 6 consecutive clean runs after the §22 Game Book race fix;
+it had failed 3/3 before);
 `fresh_franchise_first_week_smoke.spec.js` **1/1 pass**. Chromium was available
 (`/opt/pw-browsers/chromium-1194`); execution was **not** blocked.
 
@@ -337,7 +383,8 @@ canonical-event work.
 ## 29. Merge recommendation
 
 **Merge #1700.** The watched game now tells one coherent, truthful story: the live
-scorebug, quarter scores, scoring summary, PostGameScreen, Game Book, and
-save/reload all describe the single game the drive engine simulated. Unit, build,
+scorebug, scoring summary, PostGameScreen, Game Book, and save/reload all describe
+the single game the drive engine simulated, with the mid-game progression
+honestly labeled as a reconstruction and no fabricated quarter table. Unit, build,
 and the critical browser journeys pass; the only durability failure is a
 documented, pre-existing, out-of-scope rollover issue deferred to #1701.

--- a/src/core/__tests__/gameSummary.test.js
+++ b/src/core/__tests__/gameSummary.test.js
@@ -145,3 +145,39 @@ describe('postgame leader interception semantics', () => {
     expect(leaders.playerOfGame?.name).toBe('Clean QB');
   });
 });
+
+describe('postgame sack semantics — offensive sacks-taken are not defensive production (#1700 review defect #3)', () => {
+  // Fixture from the review: a QB with 5 sacks TAKEN and an EDGE with 1 sack MADE.
+  const boxScore = {
+    home: { qb: { name: 'Sacked QB', pos: 'QB', stats: { passAtt: 32, passComp: 20, passYd: 240, sacks: 5 } } },
+    away: { edge: { name: 'Edge Rusher', pos: 'EDGE', stats: { passAtt: 0, sacks: 1, tackles: 3 } } },
+  };
+
+  it('the EDGE (sacks made) is the defensive leader, never the QB (sacks taken)', async () => {
+    const { buildPlayerLeadersFromArchive } = await import('../gameSummary.js');
+    const leaders = buildPlayerLeadersFromArchive(boxScore, { homeId: 1, awayId: 2 });
+    expect(leaders.categories.defense?.name).toBe('Edge Rusher');
+    expect(leaders.categories.defense?.name).not.toBe('Sacked QB');
+  });
+
+  it("a QB's sacks taken add NO positive Player-of-Game impact", async () => {
+    const { buildPlayerLeadersFromArchive } = await import('../gameSummary.js');
+    // Two QBs identical except: one took 5 sacks, the other took 0 and threw for
+    // one more yard. If sacks-taken added impact the sacked QB would win; it must
+    // not — the extra yard decides it.
+    const leaders = buildPlayerLeadersFromArchive({
+      home: { sacked: { name: 'Sacked QB', pos: 'QB', stats: { passAtt: 32, passComp: 20, passYd: 300, sacks: 5 } } },
+      away: { clean: { name: 'Clean QB', pos: 'QB', stats: { passAtt: 32, passComp: 20, passYd: 301, sacks: 0 } } },
+    }, { homeId: 1, awayId: 2 });
+    expect(leaders.playerOfGame?.name).toBe('Clean QB');
+  });
+
+  it('genuine defender sacks still count as defensive production', async () => {
+    const { buildPlayerLeadersFromArchive } = await import('../gameSummary.js');
+    const leaders = buildPlayerLeadersFromArchive({
+      home: { edge: { name: 'Real Sacker', pos: 'EDGE', stats: { passAtt: 0, sacks: 3 } } },
+      away: {},
+    }, { homeId: 1, awayId: 2 });
+    expect(leaders.categories.defense?.name).toBe('Real Sacker');
+  });
+});

--- a/src/core/__tests__/simulation/canonicalEventsIntegration.test.js
+++ b/src/core/__tests__/simulation/canonicalEventsIntegration.test.js
@@ -72,10 +72,9 @@ describe('simGameStats emits a canonical event ledger that reconciles to the fin
     const finalScore = { home: result.homeScore, away: result.awayScore };
     assertLedgerReconciles(result.canonicalEvents, finalScore);
 
-    // Quarter totals equal the final score.
-    const total = (arr) => (arr || []).reduce((a, b) => a + b, 0);
-    expect(total(result.quarterScores?.home)).toBe(finalScore.home);
-    expect(total(result.quarterScores?.away)).toBe(finalScore.away);
+    // No fabricated quarter authority: the sim owns no chronological regulation
+    // timeline, so no quarter-score table is published.
+    expect(result.quarterScores).toBeNull();
 
     // Scoring summary totals equal the final score.
     const ssHome = (result.scoringSummary || []).filter((r) => r.teamId === 1).reduce((a, r) => a + r.points, 0);

--- a/src/core/__tests__/simulation/canonicalEventsIntegration.test.js
+++ b/src/core/__tests__/simulation/canonicalEventsIntegration.test.js
@@ -1,0 +1,103 @@
+/**
+ * Canonical event ledger — full production-path integration (#1700)
+ * ─────────────────────────────────────────────────────────────────
+ * Proves that the SAME canonical event ledger reconciles to the official final
+ * score when produced through the real simulation path (simGameStats and the
+ * full simulateBatch → commitGameResult commit path), not just from synthetic
+ * drive logs. This is the boundary the worker forwards and the archive persists.
+ */
+import { describe, it, expect } from 'vitest';
+import { Utils as U } from '../../utils.js';
+import { simGameStats, simulateBatch } from '../../simulation/index.js';
+import { reconcileCanonicalEvents } from '../../simulation/canonicalGameEvents.js';
+
+function makePlayer(id, pos, ovr = 75) {
+  const ratings = {
+    QB: { throwPower: 82, throwAccuracy: 84, awareness: 82 },
+    RB: { speed: 88, trucking: 80, juking: 84 },
+    WR: { speed: 90, awareness: 80, catching: 88 },
+    TE: { speed: 76, awareness: 76, catching: 80 },
+    OL: { passBlock: 80, runBlock: 80 },
+    DL: { passRushPower: 80, passRushSpeed: 78, tackle: 76, strength: 80 },
+    LB: { tackle: 80, awareness: 76, speed: 76 },
+    CB: { speed: 86, awareness: 76 },
+    S: { speed: 82, awareness: 78, tackle: 74 },
+    K: { kickPower: 82, kickAccuracy: 82 },
+    P: { kickPower: 80 },
+  };
+  return { id: `${id}`, pos, ovr, name: `${pos} ${id}`, ratings: ratings[pos] || {}, stats: { game: {}, season: {} } };
+}
+
+function buildTeam(id, abbr) {
+  return {
+    id, abbr, name: abbr,
+    roster: [
+      makePlayer(`${id}-qb1`, 'QB', 88), makePlayer(`${id}-qb2`, 'QB', 74),
+      makePlayer(`${id}-rb1`, 'RB', 84), makePlayer(`${id}-rb2`, 'RB', 74),
+      makePlayer(`${id}-wr1`, 'WR', 86), makePlayer(`${id}-wr2`, 'WR', 80), makePlayer(`${id}-wr3`, 'WR', 74),
+      makePlayer(`${id}-te1`, 'TE', 78),
+      ...[1, 2, 3, 4, 5].map((i) => makePlayer(`${id}-ol${i}`, 'OL', 76)),
+      makePlayer(`${id}-dl1`, 'DL', 80), makePlayer(`${id}-dl2`, 'DL', 74),
+      makePlayer(`${id}-lb1`, 'LB', 78), makePlayer(`${id}-lb2`, 'LB', 72),
+      makePlayer(`${id}-cb1`, 'CB', 78), makePlayer(`${id}-cb2`, 'CB', 74),
+      makePlayer(`${id}-s1`, 'S', 76),
+      makePlayer(`${id}-k1`, 'K', 78), makePlayer(`${id}-p1`, 'P', 74),
+    ],
+  };
+}
+
+const SEEDS = [6, 39, 123, 777, 2026, 4242, 8888];
+
+function assertLedgerReconciles(events, finalScore) {
+  expect(Array.isArray(events)).toBe(true);
+  expect(events.length).toBeGreaterThan(0);
+  const rec = reconcileCanonicalEvents(events, finalScore);
+  expect(rec.finalMatchesSum).toBe(true);
+  expect(rec.finalMatchesLast).toBe(true);
+  expect(rec.monotonic).toBe(true);
+  expect(rec.scoreOnlyOnScore).toBe(true);
+  expect(rec.strictlyOrdered).toBe(true);
+  expect(rec.uniqueIds).toBe(true);
+}
+
+describe('simGameStats emits a canonical event ledger that reconciles to the final', () => {
+  it.each(SEEDS)('seed %i: canonicalEvents / quarterScores / scoringSummary all == final', (seed) => {
+    const home = buildTeam(1, 'NYJ');
+    const away = buildTeam(2, 'BAL');
+    const league = { week: 6, seasonId: 2026, year: 2026, teams: [home, away], globalSeed: seed };
+    U.setSeed(seed);
+    const result = simGameStats(home, away, { generateLogs: true, league, homeAbbr: 'NYJ', awayAbbr: 'BAL' });
+    expect(result).toBeTruthy();
+
+    const finalScore = { home: result.homeScore, away: result.awayScore };
+    assertLedgerReconciles(result.canonicalEvents, finalScore);
+
+    // Quarter totals equal the final score.
+    const total = (arr) => (arr || []).reduce((a, b) => a + b, 0);
+    expect(total(result.quarterScores?.home)).toBe(finalScore.home);
+    expect(total(result.quarterScores?.away)).toBe(finalScore.away);
+
+    // Scoring summary totals equal the final score.
+    const ssHome = (result.scoringSummary || []).filter((r) => r.teamId === 1).reduce((a, r) => a + r.points, 0);
+    const ssAway = (result.scoringSummary || []).filter((r) => r.teamId === 2).reduce((a, r) => a + r.points, 0);
+    expect(ssHome).toBe(finalScore.home);
+    expect(ssAway).toBe(finalScore.away);
+  });
+});
+
+describe('full commit path (simulateBatch → commitGameResult) carries the same ledger', () => {
+  it.each(SEEDS)('seed %i: result package canonicalEvents reconcile to scoreHome/scoreAway', (seed) => {
+    const home = buildTeam(1, 'NYJ');
+    const away = buildTeam(2, 'BAL');
+    const league = { id: 'L', week: 6, seasonId: 2026, year: 2026, teams: [home, away], globalSeed: seed };
+    U.setSeed(seed);
+    const [res] = simulateBatch([{ home, away, week: 6 }], { league, generateLogs: true });
+    expect(res).toBeTruthy();
+
+    const finalScore = {
+      home: res.scoreHome ?? res.homeScore,
+      away: res.scoreAway ?? res.awayScore,
+    };
+    assertLedgerReconciles(res.canonicalEvents, finalScore);
+  });
+});

--- a/src/core/__tests__/simulation/canonicalGameEvents.test.js
+++ b/src/core/__tests__/simulation/canonicalGameEvents.test.js
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import { buildDriveBasedSummary } from '../../simulation/driveEngine.js';
+import {
+  buildCanonicalGameEvents,
+  reconcileCanonicalEvents,
+} from '../../simulation/canonicalGameEvents.js';
+
+const SEEDS = [6, 39, 123, 777, 2026, 4242, 8888];
+const HOME = { id: 10, abbr: 'NYJ' };
+const AWAY = { id: 20, abbr: 'BAL' };
+
+function ledgerForSeed(seed, overrides = {}) {
+  const ds = buildDriveBasedSummary({
+    season: 2026, week: 6, home: HOME, away: AWAY,
+    homeOff: 74, awayOff: 76, homeDef: 73, awayDef: 75,
+    globalSeed: seed, ...overrides,
+  });
+  const ledger = buildCanonicalGameEvents({
+    gameId: `g-${seed}`,
+    homeId: HOME.id, awayId: AWAY.id, homeAbbr: HOME.abbr, awayAbbr: AWAY.abbr,
+    homeDriveLog: ds.homeDriveLog, awayDriveLog: ds.awayDriveLog,
+    overtimeEvents: [],
+    seed: ds.seed,
+  });
+  return { ds, ledger, finalScore: { home: ds.homeScore, away: ds.awayScore } };
+}
+
+describe('canonical game event ledger (#1700)', () => {
+  it('1. canonical scoring-event points equal the final score (both sides)', () => {
+    for (const seed of SEEDS) {
+      const { ledger, finalScore } = ledgerForSeed(seed);
+      const sum = (teamId) => ledger.scoringSummary
+        .filter((r) => r.teamId === teamId)
+        .reduce((a, r) => a + r.points, 0);
+      expect(sum(HOME.id)).toBe(finalScore.home);
+      expect(sum(AWAY.id)).toBe(finalScore.away);
+    }
+  });
+
+  it('2. last scoreAfter equals the final score', () => {
+    for (const seed of SEEDS) {
+      const { ledger, finalScore } = ledgerForSeed(seed);
+      const last = ledger.events[ledger.events.length - 1];
+      expect(last.scoreAfter).toEqual(finalScore);
+    }
+  });
+
+  it('3. quarter totals equal the final score', () => {
+    for (const seed of SEEDS) {
+      const { ledger, finalScore } = ledgerForSeed(seed);
+      const total = (arr) => arr.reduce((a, b) => a + b, 0);
+      expect(total(ledger.quarterScores.home)).toBe(finalScore.home);
+      expect(total(ledger.quarterScores.away)).toBe(finalScore.away);
+    }
+  });
+
+  it('4. scoring-summary totals equal the final score', () => {
+    for (const seed of SEEDS) {
+      const { ledger, finalScore } = ledgerForSeed(seed);
+      const rec = reconcileCanonicalEvents(ledger.events, finalScore);
+      expect(rec.finalMatchesSum).toBe(true);
+      expect(rec.finalMatchesLast).toBe(true);
+    }
+  });
+
+  it('5. score progression is monotonic and only changes on scoring events', () => {
+    for (const seed of SEEDS) {
+      const { ledger, finalScore } = ledgerForSeed(seed);
+      const rec = reconcileCanonicalEvents(ledger.events, finalScore);
+      expect(rec.monotonic).toBe(true);
+      expect(rec.scoreOnlyOnScore).toBe(true);
+    }
+  });
+
+  it('6. no duplicate event ids', () => {
+    for (const seed of SEEDS) {
+      const { ledger, finalScore } = ledgerForSeed(seed);
+      const rec = reconcileCanonicalEvents(ledger.events, finalScore);
+      expect(rec.uniqueIds).toBe(true);
+    }
+  });
+
+  it('7. event sequences are strictly ordered', () => {
+    for (const seed of SEEDS) {
+      const { ledger } = ledgerForSeed(seed);
+      let prev = -Infinity;
+      for (const e of ledger.events) {
+        expect(e.sequence).toBeGreaterThan(prev);
+        prev = e.sequence;
+      }
+    }
+  });
+
+  it('8. every scoring event references a real team', () => {
+    for (const seed of SEEDS) {
+      const { ledger } = ledgerForSeed(seed);
+      for (const e of ledger.events.filter((x) => x.isScore)) {
+        expect([HOME.id, AWAY.id]).toContain(e.scoringTeamId);
+        expect(e.scoringTeamId).toBe(e.possessionTeamId);
+      }
+    }
+  });
+
+  it('9. home and away sides are never swapped', () => {
+    // Feed a lopsided game; the home drive log alone must land on the home side.
+    const ledger = buildCanonicalGameEvents({
+      gameId: 'swap', homeId: 1, awayId: 2, homeAbbr: 'H', awayAbbr: 'A',
+      homeDriveLog: [{ result: 'TOUCHDOWN', points: 7, plays: 9, yards: 75 }],
+      awayDriveLog: [{ result: 'PUNT', points: 0, plays: 3, yards: 4 }],
+      seed: 1,
+    });
+    const last = ledger.events[ledger.events.length - 1];
+    expect(last.scoreAfter).toEqual({ home: 7, away: 0 });
+    expect(ledger.scoringSummary[0].teamId).toBe(1);
+  });
+
+  it('10. overtime is represented honestly (Q5 column, not folded into Q4)', () => {
+    const ledger = buildCanonicalGameEvents({
+      gameId: 'ot', homeId: 1, awayId: 2, homeAbbr: 'H', awayAbbr: 'A',
+      homeDriveLog: [{ result: 'FIELD_GOAL', points: 3, plays: 8, yards: 60 }],
+      awayDriveLog: [{ result: 'FIELD_GOAL', points: 3, plays: 7, yards: 55 }],
+      overtimeEvents: [{ side: 'home', points: 3, result: 'FIELD_GOAL' }],
+      seed: 2,
+    });
+    expect(ledger.quarterScores.home).toHaveLength(5);
+    expect(ledger.quarterScores.home[4]).toBe(3); // OT points in the OT column
+    const last = ledger.events[ledger.events.length - 1];
+    expect(last.scoreAfter).toEqual({ home: 6, away: 3 });
+    expect(ledger.events.some((e) => e.isOvertime && e.isScore)).toBe(true);
+  });
+
+  it('11. field goals, TDs, and 2-pt conversions are accounted for accurately', () => {
+    const ledger = buildCanonicalGameEvents({
+      gameId: 'mix', homeId: 1, awayId: 2, homeAbbr: 'H', awayAbbr: 'A',
+      homeDriveLog: [
+        { result: 'TOUCHDOWN', points: 8, plays: 10, yards: 80, twoPointMade: true }, // TD + 2PT
+        { result: 'FIELD_GOAL', points: 3, plays: 6, yards: 40 },
+        { result: 'TOUCHDOWN', points: 6, plays: 5, yards: 55 }, // TD, PAT no good
+      ],
+      awayDriveLog: [{ result: 'TOUCHDOWN', points: 7, plays: 8, yards: 70 }],
+      seed: 3,
+    });
+    const last = ledger.events[ledger.events.length - 1];
+    expect(last.scoreAfter).toEqual({ home: 17, away: 7 });
+    const homeRows = ledger.scoringSummary.filter((r) => r.teamId === 1);
+    expect(homeRows.map((r) => r.points).sort()).toEqual([3, 6, 8]);
+    expect(homeRows.find((r) => r.points === 8).type).toMatch(/2-PT/i);
+  });
+
+  it('12. a genuine 0-0 game remains valid (4 zero quarters, no scoring rows)', () => {
+    const ledger = buildCanonicalGameEvents({
+      gameId: 'zero', homeId: 1, awayId: 2,
+      homeDriveLog: [{ result: 'PUNT', points: 0, plays: 3, yards: 5 }],
+      awayDriveLog: [{ result: 'TURNOVER', points: 0, plays: 4, yards: 8 }],
+      seed: 4,
+    });
+    expect(ledger.scoringSummary).toHaveLength(0);
+    expect(ledger.quarterScores.home).toEqual([0, 0, 0, 0]);
+    expect(ledger.quarterScores.away).toEqual([0, 0, 0, 0]);
+    const last = ledger.events[ledger.events.length - 1];
+    expect(last.scoreAfter).toEqual({ home: 0, away: 0 });
+  });
+
+  it('13. same seed produces identical event fingerprints', () => {
+    const fp = (seed) => ledgerForSeed(seed).ledger.events
+      .map((e) => `${e.sequence}:${e.quarter}:${e.eventType}:${e.points}:${e.scoreAfter.home}-${e.scoreAfter.away}:${e.possessionTeamId}`)
+      .join('|');
+    for (const seed of SEEDS) {
+      expect(fp(seed)).toBe(fp(seed));
+    }
+  });
+
+  it('14. no RNG is consumed building the ledger (drive-engine score unchanged)', () => {
+    // Building the ledger must not disturb the seeded score. Two identical drive
+    // summaries produce identical ledgers and identical scores.
+    const a = buildDriveBasedSummary({ season: 1, week: 1, home: HOME, away: AWAY, globalSeed: 555 });
+    const b = buildDriveBasedSummary({ season: 1, week: 1, home: HOME, away: AWAY, globalSeed: 555 });
+    expect(a.homeScore).toBe(b.homeScore);
+    expect(a.awayScore).toBe(b.awayScore);
+    // The drive logs sum to the score (no phantom points).
+    const homePts = a.homeDriveLog.reduce((s, d) => s + d.points, 0);
+    const awayPts = a.awayDriveLog.reduce((s, d) => s + d.points, 0);
+    expect(homePts).toBe(a.homeScore);
+    expect(awayPts).toBe(a.awayScore);
+  });
+});

--- a/src/core/__tests__/simulation/canonicalGameEvents.test.js
+++ b/src/core/__tests__/simulation/canonicalGameEvents.test.js
@@ -45,12 +45,23 @@ describe('canonical game event ledger (#1700)', () => {
     }
   });
 
-  it('3. quarter totals equal the final score', () => {
+  it('3. NO fabricated quarter authority: quarterScores is null and events carry null quarter + honest periodLabel', () => {
     for (const seed of SEEDS) {
-      const { ledger, finalScore } = ledgerForSeed(seed);
-      const total = (arr) => arr.reduce((a, b) => a + b, 0);
-      expect(total(ledger.quarterScores.home)).toBe(finalScore.home);
-      expect(total(ledger.quarterScores.away)).toBe(finalScore.away);
+      const { ledger } = ledgerForSeed(seed);
+      // The sim owns no chronological regulation quarters — no quarter-score table.
+      expect(ledger.quarterScores).toBeNull();
+      // Every regulation drive event has a null quarter and an honest "Drive N" label.
+      const driveEvents = ledger.events.filter((e) => e.eventType !== 'game_end');
+      driveEvents.forEach((e, i) => {
+        expect(e.quarter).toBeNull();
+        expect(e.periodLabel).toBe(`Drive ${i + 1}`);
+        expect(e.isOvertime).toBe(false);
+      });
+      // Scoring summary rows also drop the fabricated quarter.
+      ledger.scoringSummary.forEach((r) => {
+        expect(r.quarter).toBeNull();
+        expect(typeof r.periodLabel).toBe('string');
+      });
     }
   });
 
@@ -114,7 +125,7 @@ describe('canonical game event ledger (#1700)', () => {
     expect(ledger.scoringSummary[0].teamId).toBe(1);
   });
 
-  it('10. overtime is represented honestly (Q5 column, not folded into Q4)', () => {
+  it('10. overtime is represented honestly (isOvertime + OT label, never a fabricated Q5)', () => {
     const ledger = buildCanonicalGameEvents({
       gameId: 'ot', homeId: 1, awayId: 2, homeAbbr: 'H', awayAbbr: 'A',
       homeDriveLog: [{ result: 'FIELD_GOAL', points: 3, plays: 8, yards: 60 }],
@@ -122,11 +133,17 @@ describe('canonical game event ledger (#1700)', () => {
       overtimeEvents: [{ side: 'home', points: 3, result: 'FIELD_GOAL' }],
       seed: 2,
     });
-    expect(ledger.quarterScores.home).toHaveLength(5);
-    expect(ledger.quarterScores.home[4]).toBe(3); // OT points in the OT column
+    // No fabricated quarter table, even with overtime.
+    expect(ledger.quarterScores).toBeNull();
+    const otEvent = ledger.events.find((e) => e.isOvertime && e.isScore);
+    expect(otEvent).toBeTruthy();
+    expect(otEvent.periodLabel).toBe('OT');
+    expect(otEvent.quarter).toBeNull();
+    // No event is ever labeled Q5.
+    expect(ledger.events.some((e) => e.periodLabel === 'Q5' || e.quarter === 5)).toBe(false);
     const last = ledger.events[ledger.events.length - 1];
     expect(last.scoreAfter).toEqual({ home: 6, away: 3 });
-    expect(ledger.events.some((e) => e.isOvertime && e.isScore)).toBe(true);
+    expect(last.isOvertime).toBe(true);
   });
 
   it('11. field goals, TDs, and 2-pt conversions are accounted for accurately', () => {
@@ -147,7 +164,7 @@ describe('canonical game event ledger (#1700)', () => {
     expect(homeRows.find((r) => r.points === 8).type).toMatch(/2-PT/i);
   });
 
-  it('12. a genuine 0-0 game remains valid (4 zero quarters, no scoring rows)', () => {
+  it('12. a genuine 0-0 game remains valid (no scoring rows, null quarter table)', () => {
     const ledger = buildCanonicalGameEvents({
       gameId: 'zero', homeId: 1, awayId: 2,
       homeDriveLog: [{ result: 'PUNT', points: 0, plays: 3, yards: 5 }],
@@ -155,15 +172,14 @@ describe('canonical game event ledger (#1700)', () => {
       seed: 4,
     });
     expect(ledger.scoringSummary).toHaveLength(0);
-    expect(ledger.quarterScores.home).toEqual([0, 0, 0, 0]);
-    expect(ledger.quarterScores.away).toEqual([0, 0, 0, 0]);
+    expect(ledger.quarterScores).toBeNull();
     const last = ledger.events[ledger.events.length - 1];
     expect(last.scoreAfter).toEqual({ home: 0, away: 0 });
   });
 
   it('13. same seed produces identical event fingerprints', () => {
     const fp = (seed) => ledgerForSeed(seed).ledger.events
-      .map((e) => `${e.sequence}:${e.quarter}:${e.eventType}:${e.points}:${e.scoreAfter.home}-${e.scoreAfter.away}:${e.possessionTeamId}`)
+      .map((e) => `${e.sequence}:${e.periodLabel}:${e.eventType}:${e.points}:${e.scoreAfter.home}-${e.scoreAfter.away}:${e.possessionTeamId}`)
       .join('|');
     for (const seed of SEEDS) {
       expect(fp(seed)).toBe(fp(seed));

--- a/src/core/gameArchive.js
+++ b/src/core/gameArchive.js
@@ -216,6 +216,10 @@ export function normalizeArchivedGamePayload(rawGame) {
     teamStats,
     playerStats,
     scoringSummary,
+    // Canonical drive-level event ledger (#1700) — preserved so the Game Book
+    // knows this is a canonical-ledger game (no fabricated quarter table) and
+    // can replay the same scoreAfter progression.
+    canonicalEvents: Array.isArray(rawGame?.canonicalEvents) ? rawGame.canonicalEvents : [],
     driveSummary: Array.isArray(rawGame?.driveSummary)
       ? rawGame.driveSummary
       : (Array.isArray(rawGame?.drives)
@@ -303,6 +307,9 @@ export function mergeArchivedGameWithScheduleResult(archivedGame, scheduleGame) 
     homeScore: archived.homeScore ?? schedule.homeScore,
     awayScore: archived.awayScore ?? schedule.awayScore,
     quarterScores: archived.quarterScores ?? schedule.quarterScores,
+    canonicalEvents: (Array.isArray(archived.canonicalEvents) && archived.canonicalEvents.length)
+      ? archived.canonicalEvents
+      : (Array.isArray(schedule.canonicalEvents) ? schedule.canonicalEvents : []),
     recap: archived.recap ?? schedule.recap,
     recapText: archived.recapText ?? schedule.recapText,
     summary: archived.summary ?? schedule.summary,

--- a/src/core/gameSummary.js
+++ b/src/core/gameSummary.js
@@ -201,10 +201,25 @@ export function interceptionsThrown(row) {
   return isPassingRow(row) ? Math.max(0, asNum(row?.stats?.interceptions)) : 0;
 }
 
+/**
+ * Sack semantics are overloaded on the canonical player row: on a passing row
+ * `sacks` means sacks TAKEN (offensive attrition); on a defensive row it means
+ * sacks MADE (defensive production). These two helpers are the single source of
+ * truth so the postgame leaders and the live standouts never credit a QB's
+ * sacks-taken as defensive production.
+ */
+export function defensiveSacks(row) {
+  return isPassingRow(row) ? 0 : Math.max(0, asNum(row?.stats?.sacks));
+}
+
+export function sacksTaken(row) {
+  return isPassingRow(row) ? Math.max(0, asNum(row?.stats?.sacks)) : 0;
+}
+
 export function buildPlayerLeadersFromArchive(boxScore = {}, context = {}) {
   const rows = toRows(boxScore, context);
   const pick = (key, min = 1) => rows.filter((r) => asNum(r.stats?.[key]) >= min).sort((a, b) => asNum(b.stats?.[key]) - asNum(a.stats?.[key]))[0] ?? null;
-  const defenseScore = (r) => asNum(r.stats?.sacks) * 2
+  const defenseScore = (r) => defensiveSacks(r) * 2
     + defensiveInterceptions(r) * 2
     + asNum(r.stats?.tacklesForLoss)
     + asNum(r.stats?.tackles)
@@ -226,7 +241,7 @@ export function buildPlayerLeadersFromArchive(boxScore = {}, context = {}) {
   };
 
   const scored = rows
-    .map((row) => ({ row, impact: asNum(row.stats?.passYd) / 12 + asNum(row.stats?.passTD) * 5 + asNum(row.stats?.rushYd) / 10 + asNum(row.stats?.rushTD) * 6 + asNum(row.stats?.recYd) / 10 + asNum(row.stats?.recTD) * 6 + asNum(row.stats?.sacks) * 4 + defensiveInterceptions(row) * 5 + asNum(row.stats?.fieldGoalsMade) * 3 - interceptionsThrown(row) * 2 }))
+    .map((row) => ({ row, impact: asNum(row.stats?.passYd) / 12 + asNum(row.stats?.passTD) * 5 + asNum(row.stats?.rushYd) / 10 + asNum(row.stats?.rushTD) * 6 + asNum(row.stats?.recYd) / 10 + asNum(row.stats?.recTD) * 6 + defensiveSacks(row) * 4 + defensiveInterceptions(row) * 5 + asNum(row.stats?.fieldGoalsMade) * 3 - interceptionsThrown(row) * 2 }))
     .sort((a, b) => b.impact - a.impact);
 
   const playerOfGame = scored[0]?.row ?? null;

--- a/src/core/liveGame/liveGameEvents.js
+++ b/src/core/liveGame/liveGameEvents.js
@@ -124,8 +124,12 @@ export function mapArchiveEventsToLiveFeed(playLogs = [], context = {}) {
  * viewer renders. Unlike the narration path, every canonical event carries a
  * trustworthy `scoreAfter` (the drive engine's running score), so the scorebug
  * and the feed can show a real, monotonic score progression — no narration
- * score is ever consulted. Quarter-change markers are inserted the same way as
- * the narration path so the feed still reads as a game.
+ * score is ever consulted.
+ *
+ * The sim owns no chronological regulation quarters, so the feed does NOT insert
+ * fabricated quarter/halftime markers. Drives are ordered and labeled by their
+ * honest `periodLabel` ("Drive 8"); the one real period boundary — the start of
+ * overtime — is marked explicitly.
  */
 export function mapCanonicalEventsToLiveFeed(canonicalEvents = [], context = {}) {
   const list = Array.isArray(canonicalEvents) ? canonicalEvents : [];
@@ -142,7 +146,11 @@ export function mapCanonicalEventsToLiveFeed(canonicalEvents = [], context = {})
     return {
       id: event.eventId,
       gameId: event.gameId || context.gameId || 'game',
-      quarter: Number(event.quarter || 1),
+      // No fabricated quarter — regulation carries `quarter: null` and the honest
+      // `periodLabel` ("Drive 8"); OT carries isOvertime + periodLabel 'OT'.
+      quarter: null,
+      periodLabel: event.periodLabel ?? (event.isOvertime ? 'OT' : null),
+      driveNumber: event.driveNumber ?? null,
       clock: null,
       sequence: event.sequence,
       eventType,
@@ -170,14 +178,15 @@ export function mapCanonicalEventsToLiveFeed(canonicalEvents = [], context = {})
     const event = list[i];
     feed.push(toFeed(event));
     const next = list[i + 1];
-    if (next && Number(next.quarter) !== Number(event.quarter) && event.eventType !== 'game_end') {
-      const q = Number(event.quarter);
+    // The only honest period boundary is the start of overtime.
+    if (next && next.isOvertime && !event.isOvertime && event.eventType !== 'game_end') {
       feed.push({
         ...toFeed(event),
-        id: `${event.eventId}-q-end`,
-        eventType: q === 2 ? 'halftime' : 'quarter_end',
-        headline: q === 2 ? 'Halftime.' : `End of Q${q}`,
-        impactTag: q === 2 ? 'swing' : 'routine',
+        id: `${event.eventId}-ot-start`,
+        eventType: 'overtime_start',
+        periodLabel: 'OT',
+        headline: 'Overtime',
+        impactTag: 'swing',
         score: null,
         isScore: false,
       });

--- a/src/core/liveGame/liveGameEvents.js
+++ b/src/core/liveGame/liveGameEvents.js
@@ -119,6 +119,73 @@ export function mapArchiveEventsToLiveFeed(playLogs = [], context = {}) {
   return withMarkers;
 }
 
+/**
+ * Map the CANONICAL drive-level event ledger (#1700) to the live-feed shape the
+ * viewer renders. Unlike the narration path, every canonical event carries a
+ * trustworthy `scoreAfter` (the drive engine's running score), so the scorebug
+ * and the feed can show a real, monotonic score progression — no narration
+ * score is ever consulted. Quarter-change markers are inserted the same way as
+ * the narration path so the feed still reads as a game.
+ */
+export function mapCanonicalEventsToLiveFeed(canonicalEvents = [], context = {}) {
+  const list = Array.isArray(canonicalEvents) ? canonicalEvents : [];
+  if (!list.length) return [];
+
+  const toFeed = (event) => {
+    const eventType = event.eventType || 'routine';
+    const isScore = Boolean(event.isScore);
+    const impactTag = EVENT_TYPE_TO_TAG[eventType]
+      || (event.isOvertime ? 'swing' : 'routine');
+    const scoreAfter = event.scoreAfter && Number.isFinite(Number(event.scoreAfter.home))
+      ? { home: Number(event.scoreAfter.home), away: Number(event.scoreAfter.away) }
+      : null;
+    return {
+      id: event.eventId,
+      gameId: event.gameId || context.gameId || 'game',
+      quarter: Number(event.quarter || 1),
+      clock: null,
+      sequence: event.sequence,
+      eventType,
+      headline: String(event.text || 'Drive').trim(),
+      possessionTeamId: event.possessionTeamId ?? null,
+      scoringTeamId: event.scoringTeamId ?? null,
+      // Canonical running score after this event — the ONLY score the scorebug
+      // and feed ever read. On non-scoring events it carries the unchanged
+      // running total so the scorebug can display live progress at any index.
+      scoreAfter,
+      // Score chip renders on scoring events and the final marker.
+      score: (isScore || eventType === 'game_end') ? scoreAfter : null,
+      fieldPosition: null,
+      plays: event.plays ?? 0,
+      yards: event.yards ?? 0,
+      isScore,
+      isOvertime: Boolean(event.isOvertime),
+      impactTag,
+      raw: event,
+    };
+  };
+
+  const feed = [];
+  for (let i = 0; i < list.length; i += 1) {
+    const event = list[i];
+    feed.push(toFeed(event));
+    const next = list[i + 1];
+    if (next && Number(next.quarter) !== Number(event.quarter) && event.eventType !== 'game_end') {
+      const q = Number(event.quarter);
+      feed.push({
+        ...toFeed(event),
+        id: `${event.eventId}-q-end`,
+        eventType: q === 2 ? 'halftime' : 'quarter_end',
+        headline: q === 2 ? 'Halftime.' : `End of Q${q}`,
+        impactTag: q === 2 ? 'swing' : 'routine',
+        score: null,
+        isScore: false,
+      });
+    }
+  }
+  return feed;
+}
+
 export function getNextImportantEvent(events = [], startIndex = 0, filter = 'score') {
   const important = {
     score: (event) => event.eventType === 'touchdown' || event.eventType === 'field_goal',

--- a/src/core/liveGame/liveGameEvents.js
+++ b/src/core/liveGame/liveGameEvents.js
@@ -121,15 +121,17 @@ export function mapArchiveEventsToLiveFeed(playLogs = [], context = {}) {
 
 /**
  * Map the CANONICAL drive-level event ledger (#1700) to the live-feed shape the
- * viewer renders. Unlike the narration path, every canonical event carries a
- * trustworthy `scoreAfter` (the drive engine's running score), so the scorebug
- * and the feed can show a real, monotonic score progression — no narration
- * score is ever consulted.
+ * viewer renders. Every canonical event carries a `scoreAfter` derived from the
+ * drive engine's outcomes, so the scorebug and feed show a monotonic score
+ * progression toward the official final — no narration score is ever consulted.
+ * The possession ORDER (and thus the intermediate running score) is a
+ * deterministic reconstruction, not a recorded chronology; the viewer labels it
+ * "Reconstructed order" and only the final total is official.
  *
- * The sim owns no chronological regulation quarters, so the feed does NOT insert
- * fabricated quarter/halftime markers. Drives are ordered and labeled by their
- * honest `periodLabel` ("Drive 8"); the one real period boundary — the start of
- * overtime — is marked explicitly.
+ * The sim owns no chronological quarters, so the feed does NOT insert fabricated
+ * quarter/halftime markers. Drives are labeled by their `periodLabel`
+ * ("Drive 8"); the one period boundary the sim tracks — the start of overtime —
+ * is marked explicitly.
  */
 export function mapCanonicalEventsToLiveFeed(canonicalEvents = [], context = {}) {
   const list = Array.isArray(canonicalEvents) ? canonicalEvents : [];

--- a/src/core/liveGame/liveGameEvents.js
+++ b/src/core/liveGame/liveGameEvents.js
@@ -195,6 +195,25 @@ export function mapCanonicalEventsToLiveFeed(canonicalEvents = [], context = {})
   return feed;
 }
 
+/**
+ * Count the real regulation DRIVES in a canonical feed/ledger. The terminal
+ * `game_end` marker and the `overtime_start` divider are NOT drives, and OT
+ * possessions are counted separately — so a game with 24 regulation drives plus
+ * a final marker returns 24, never 25 (#1700 review defect #4). Pure; never
+ * mutates the event package.
+ */
+export function countCanonicalRegulationDrives(events = []) {
+  const list = Array.isArray(events) ? events : [];
+  let max = 0;
+  for (const e of list) {
+    if (!e || e.isOvertime) continue;
+    if (e.eventType === 'game_end' || e.eventType === 'overtime_start') continue;
+    const n = Number(e.driveNumber);
+    if (Number.isFinite(n) && n > max) max = n;
+  }
+  return max;
+}
+
 export function getNextImportantEvent(events = [], startIndex = 0, filter = 'score') {
   const important = {
     score: (event) => event.eventType === 'touchdown' || event.eventType === 'field_goal',

--- a/src/core/simulation/canonicalGameEvents.js
+++ b/src/core/simulation/canonicalGameEvents.js
@@ -11,18 +11,27 @@
  *
  * LANE B (canonical drive-level gamecast). The authoritative engine owns drives
  * and drive outcomes but NOT individual plays, a trustworthy clock, per-play
- * player attribution, OR a chronological regulation timeline. Accordingly this
- * ledger:
+ * player attribution, OR a chronological timeline. Accordingly this ledger:
  *   - represents each possession as one drive event (plays + yards + result),
  *   - never invents a game clock (clock is always null),
  *   - never invents player attribution (primary/secondary player ids are null),
  *   - never invents a QUARTER. The engine generates separate home and away
  *     drive logs with no shared clock, so there is no canonical mapping of a
- *     drive to Q1–Q4. Regulation `quarter` is therefore `null`; the honest
- *     ordering signal is `sequence` + `periodLabel` ("Drive 8"). No official
- *     quarter-score table is published for regulation (`quarterScores: null`).
+ *     drive to Q1–Q4. Regulation `quarter` is therefore `null`; drives are
+ *     labeled by `periodLabel` ("Drive 8"). No quarter-score table is published
+ *     for regulation (`quarterScores: null`).
  *   - Overtime is the only period the sim tracks distinctly: OT events carry
  *     `isOvertime: true` and `periodLabel: 'OT'` (never a fabricated Q5).
+ *
+ * WHAT IS CANONICAL vs RECONSTRUCTED. The engine simulates each team's drives
+ * separately and has NO real possession chronology. The interleaved possession
+ * ORDER (and therefore every INTERMEDIATE `scoreAfter` shown before the final)
+ * is a deterministic RECONSTRUCTION for presentation — it is not the recorded
+ * order in which the game happened. What IS canonical and reconciles exactly:
+ * the final score, the set of scoring events, their point values, and each
+ * side's per-event totals. Consumers must present the mid-game progression as a
+ * reconstruction, not as a recorded play-by-play timeline; only the final is
+ * official.
  *
  * DETERMINISM. Everything here is a pure transform of already-drawn values plus
  * the seed. No RNG is consumed, so the same seed yields an identical event
@@ -33,6 +42,8 @@
  *   last scoreAfter                     === final score
  *   scoreAfter is monotonic and changes only on a scoring event
  *   event sequence is strictly ordered and event ids are unique
+ * (Note: monotonicity and the final total are canonical; the specific drive at
+ *  which an intermediate scoreAfter lands is reconstructed, not recorded.)
  */
 
 const SCORING_RESULTS = new Set(['TOUCHDOWN', 'FIELD_GOAL']);
@@ -75,10 +86,13 @@ function abbrFor(side, homeAbbr, awayAbbr) {
 }
 
 /**
- * Interleave the two teams' regulation drive logs into a single plausible
- * possession order. Football alternates possessions, so we alternate starting
- * from a seed-derived first possession; when one team has more drives the extra
- * drives append in order. Deterministic (seed-driven), consumes no RNG.
+ * Interleave the two teams' regulation drive logs into a single presentation
+ * order. This is a RECONSTRUCTION, not the game's recorded chronology: the
+ * engine simulated each side's drives separately and owns no real possession
+ * order. We alternate possessions (as football does) from a seed-derived first
+ * possession and append any surplus drives in order. Deterministic (seed-driven)
+ * and consumes no RNG, but the resulting order — and every intermediate running
+ * score derived from it — is illustrative; only the final total is canonical.
  */
 function interleaveDrives(homeDriveLog, awayDriveLog, homeFirst) {
   const seq = [];

--- a/src/core/simulation/canonicalGameEvents.js
+++ b/src/core/simulation/canonicalGameEvents.js
@@ -6,26 +6,31 @@
  * turns those two drive logs into ONE canonical, deterministic event ledger —
  * the single authority for:
  *   - the scoring summary,
- *   - the quarter scores,
  *   - the live scorebug's running score (scoreAfter), and
  *   - the drive-by-drive gamecast feed.
  *
  * LANE B (canonical drive-level gamecast). The authoritative engine owns drives
- * and drive outcomes but NOT individual plays, a trustworthy clock, or per-play
- * player attribution. Accordingly this ledger:
+ * and drive outcomes but NOT individual plays, a trustworthy clock, per-play
+ * player attribution, OR a chronological regulation timeline. Accordingly this
+ * ledger:
  *   - represents each possession as one drive event (plays + yards + result),
- *   - never invents a game clock (clock is always null; sequence + quarter are
- *     the honest ordering signal),
- *   - never invents player attribution (primary/secondary player ids are null).
+ *   - never invents a game clock (clock is always null),
+ *   - never invents player attribution (primary/secondary player ids are null),
+ *   - never invents a QUARTER. The engine generates separate home and away
+ *     drive logs with no shared clock, so there is no canonical mapping of a
+ *     drive to Q1–Q4. Regulation `quarter` is therefore `null`; the honest
+ *     ordering signal is `sequence` + `periodLabel` ("Drive 8"). No official
+ *     quarter-score table is published for regulation (`quarterScores: null`).
+ *   - Overtime is the only period the sim tracks distinctly: OT events carry
+ *     `isOvertime: true` and `periodLabel: 'OT'` (never a fabricated Q5).
  *
  * DETERMINISM. Everything here is a pure transform of already-drawn values plus
  * the seed. No RNG is consumed, so the same seed yields an identical event
- * fingerprint (id / sequence / quarter / team / type / points / scoreAfter).
+ * fingerprint (id / sequence / periodLabel / team / type / points / scoreAfter).
  *
  * RECONCILIATION (guaranteed by construction, verified by tests):
  *   sum(scoring-event points, per side) === final score
  *   last scoreAfter                     === final score
- *   sum(quarter scores, per side)       === final score
  *   scoreAfter is monotonic and changes only on a scoring event
  *   event sequence is strictly ordered and event ids are unique
  */
@@ -127,35 +132,25 @@ export function buildCanonicalGameEvents({
 
   const homeFirst = (Number(seed) >>> 0) % 2 === 0;
   const seq = interleaveDrives(home, away, homeFirst);
-
-  const totalReg = seq.length;
-  const drivesPerQuarter = Math.max(1, Math.ceil(totalReg / 4));
   const hasOt = ot.length > 0;
-  const numQuarters = 4 + (hasOt ? 1 : 0);
-
-  const quarterHome = Array.from({ length: numQuarters }, () => 0);
-  const quarterAway = Array.from({ length: numQuarters }, () => 0);
 
   const events = [];
   const scoringSummary = [];
   let runHome = 0;
   let runAway = 0;
   let sequence = 0;
+  let driveNumber = 0;
 
   const teamIdFor = (side) => (side === 'home' ? homeId : awayId);
 
-  const pushEvent = ({ side, drive, quarter, isOt = false }) => {
+  const pushEvent = ({ side, drive, isOt = false }) => {
     sequence += 1;
+    driveNumber += 1;
     const result = drive?.result ?? 'PUNT';
     const points = Math.max(0, Number(drive?.points) || 0);
     const isScore = SCORING_RESULTS.has(result) && points > 0;
     if (side === 'home') runHome += points;
     else runAway += points;
-    const qIdx = quarter - 1;
-    if (isScore) {
-      if (side === 'home') quarterHome[qIdx] += points;
-      else quarterAway[qIdx] += points;
-    }
     const eventType = RESULT_TO_EVENT_TYPE[result] || 'punt';
     const label = resultLabel(result, points);
     const teamId = teamIdFor(side);
@@ -164,6 +159,9 @@ export function buildCanonicalGameEvents({
     const plays = Math.max(0, Number(drive?.plays) || 0);
     const yards = Math.max(0, Number(drive?.yards) || 0);
     const driveId = `${gameId}-drv-${sequence}`;
+    // Honest period label: the sim owns no chronological quarter for regulation,
+    // so drives are labeled by their game-order number; overtime is labeled OT.
+    const periodLabel = isOt ? 'OT' : `Drive ${driveNumber}`;
     const text = isScore
       ? `${abbr ?? 'Offense'} ${label} — ${plays} plays, ${yards} yards`
       : `${abbr ?? 'Offense'} drive: ${label} (${plays} plays, ${yards} yards)`;
@@ -172,7 +170,12 @@ export function buildCanonicalGameEvents({
       gameId,
       driveId,
       sequence,
-      quarter,
+      driveNumber,
+      // No fabricated quarter — see module header. `quarter` stays null for
+      // regulation AND overtime; `periodLabel` / `isOvertime` are the honest
+      // presentation signals.
+      quarter: null,
+      periodLabel,
       clock: null,
       possessionTeamId: teamId,
       scoringTeamId: isScore ? teamId : null,
@@ -193,7 +196,9 @@ export function buildCanonicalGameEvents({
     if (isScore) {
       scoringSummary.push({
         id: event.eventId,
-        quarter,
+        quarter: null,
+        periodLabel,
+        isOvertime: isOt,
         clock: null,
         teamId,
         teamAbbr: abbr,
@@ -213,19 +218,19 @@ export function buildCanonicalGameEvents({
     }
   };
 
-  seq.forEach((entry, i) => {
-    const quarter = Math.min(4, Math.floor(i / drivesPerQuarter) + 1);
-    pushEvent({ side: entry.side, drive: entry.drive, quarter });
+  seq.forEach((entry) => {
+    pushEvent({ side: entry.side, drive: entry.drive });
   });
 
-  // Overtime: extend the quarter array (Q5 = OT) rather than folding OT points
-  // into the fourth quarter.
+  // Overtime is the one period the sim tracks distinctly. OT events are honestly
+  // flagged (isOvertime + periodLabel 'OT') — never folded into regulation and
+  // never relabeled as a fabricated Q5.
   ot.forEach((otEvent) => {
     const side = otEvent?.side === 'home' ? 'home' : 'away';
     const points = Math.max(0, Number(otEvent?.points) || 0);
     if (points <= 0) return;
     const result = otEvent?.result === 'FIELD_GOAL' ? 'FIELD_GOAL' : 'TOUCHDOWN';
-    pushEvent({ side, drive: { result, points, plays: 0, yards: 0 }, quarter: 5, isOt: true });
+    pushEvent({ side, drive: { result, points, plays: 0, yards: 0 }, isOt: true });
   });
 
   // Terminal game-end marker carries the final scoreAfter so the last canonical
@@ -236,7 +241,9 @@ export function buildCanonicalGameEvents({
     gameId,
     driveId: null,
     sequence,
-    quarter: hasOt ? 5 : 4,
+    driveNumber,
+    quarter: null,
+    periodLabel: 'Final',
     clock: null,
     possessionTeamId: null,
     scoringTeamId: null,
@@ -257,7 +264,10 @@ export function buildCanonicalGameEvents({
   return {
     events,
     scoringSummary,
-    quarterScores: { home: quarterHome, away: quarterAway },
+    // The sim owns no chronological regulation quarters, so no official
+    // quarter-score table is published. `null` is the established "unavailable"
+    // representation the Game Book / box-score view model already handle.
+    quarterScores: null,
   };
 }
 

--- a/src/core/simulation/canonicalGameEvents.js
+++ b/src/core/simulation/canonicalGameEvents.js
@@ -1,0 +1,318 @@
+/*
+ * Canonical Game Event Ledger (#1700)
+ * ───────────────────────────────────
+ * The drive engine (`buildDriveBasedSummary`) owns the official final score and
+ * now also emits an ordered per-drive outcome log for each team. This module
+ * turns those two drive logs into ONE canonical, deterministic event ledger —
+ * the single authority for:
+ *   - the scoring summary,
+ *   - the quarter scores,
+ *   - the live scorebug's running score (scoreAfter), and
+ *   - the drive-by-drive gamecast feed.
+ *
+ * LANE B (canonical drive-level gamecast). The authoritative engine owns drives
+ * and drive outcomes but NOT individual plays, a trustworthy clock, or per-play
+ * player attribution. Accordingly this ledger:
+ *   - represents each possession as one drive event (plays + yards + result),
+ *   - never invents a game clock (clock is always null; sequence + quarter are
+ *     the honest ordering signal),
+ *   - never invents player attribution (primary/secondary player ids are null).
+ *
+ * DETERMINISM. Everything here is a pure transform of already-drawn values plus
+ * the seed. No RNG is consumed, so the same seed yields an identical event
+ * fingerprint (id / sequence / quarter / team / type / points / scoreAfter).
+ *
+ * RECONCILIATION (guaranteed by construction, verified by tests):
+ *   sum(scoring-event points, per side) === final score
+ *   last scoreAfter                     === final score
+ *   sum(quarter scores, per side)       === final score
+ *   scoreAfter is monotonic and changes only on a scoring event
+ *   event sequence is strictly ordered and event ids are unique
+ */
+
+const SCORING_RESULTS = new Set(['TOUCHDOWN', 'FIELD_GOAL']);
+
+const RESULT_TO_EVENT_TYPE = {
+  TOUCHDOWN: 'touchdown',
+  FIELD_GOAL: 'field_goal',
+  MISSED_FG: 'missed_fg',
+  TURNOVER: 'turnover',
+  PUNT: 'punt',
+  DOWNS: 'downs',
+};
+
+function touchdownLabel(points) {
+  if (points >= 8) return 'Touchdown (2-PT good)';
+  if (points === 6) return 'Touchdown (PAT no good)';
+  return 'Touchdown';
+}
+
+function resultLabel(result, points) {
+  switch (result) {
+    case 'TOUCHDOWN': return touchdownLabel(points);
+    case 'FIELD_GOAL': return 'Field Goal';
+    case 'MISSED_FG': return 'Missed FG';
+    case 'TURNOVER': return 'Turnover';
+    case 'PUNT': return 'Punt';
+    case 'DOWNS': return 'Turnover on downs';
+    default: return 'Drive';
+  }
+}
+
+function scoreTypeFor(result) {
+  if (result === 'TOUCHDOWN') return 'touchdown';
+  if (result === 'FIELD_GOAL') return 'field_goal';
+  return null;
+}
+
+function abbrFor(side, homeAbbr, awayAbbr) {
+  return side === 'home' ? homeAbbr : awayAbbr;
+}
+
+/**
+ * Interleave the two teams' regulation drive logs into a single plausible
+ * possession order. Football alternates possessions, so we alternate starting
+ * from a seed-derived first possession; when one team has more drives the extra
+ * drives append in order. Deterministic (seed-driven), consumes no RNG.
+ */
+function interleaveDrives(homeDriveLog, awayDriveLog, homeFirst) {
+  const seq = [];
+  let hi = 0;
+  let ai = 0;
+  let turn = homeFirst ? 'home' : 'away';
+  while (hi < homeDriveLog.length || ai < awayDriveLog.length) {
+    if (turn === 'home' && hi < homeDriveLog.length) {
+      seq.push({ side: 'home', drive: homeDriveLog[hi++] });
+    } else if (turn === 'away' && ai < awayDriveLog.length) {
+      seq.push({ side: 'away', drive: awayDriveLog[ai++] });
+    } else if (hi < homeDriveLog.length) {
+      seq.push({ side: 'home', drive: homeDriveLog[hi++] });
+    } else if (ai < awayDriveLog.length) {
+      seq.push({ side: 'away', drive: awayDriveLog[ai++] });
+    }
+    turn = turn === 'home' ? 'away' : 'home';
+  }
+  return seq;
+}
+
+/**
+ * Build the canonical event ledger from drive logs.
+ *
+ * @param {Object} params
+ * @param {string} params.gameId
+ * @param {number} params.homeId
+ * @param {number} params.awayId
+ * @param {string} [params.homeAbbr]
+ * @param {string} [params.awayAbbr]
+ * @param {Array}  params.homeDriveLog  ordered regulation drives (home)
+ * @param {Array}  params.awayDriveLog  ordered regulation drives (away)
+ * @param {Array}  [params.overtimeEvents]  [{ side:'home'|'away', points, result, isPassTD }]
+ * @param {number} [params.seed]        drive-engine seed (first-possession + ids)
+ * @returns {{ events:Array, scoringSummary:Array, quarterScores:{home:number[],away:number[]} }}
+ */
+export function buildCanonicalGameEvents({
+  gameId = 'game',
+  homeId = null,
+  awayId = null,
+  homeAbbr = null,
+  awayAbbr = null,
+  homeDriveLog = [],
+  awayDriveLog = [],
+  overtimeEvents = [],
+  seed = 0,
+} = {}) {
+  const home = Array.isArray(homeDriveLog) ? homeDriveLog : [];
+  const away = Array.isArray(awayDriveLog) ? awayDriveLog : [];
+  const ot = Array.isArray(overtimeEvents) ? overtimeEvents : [];
+
+  const homeFirst = (Number(seed) >>> 0) % 2 === 0;
+  const seq = interleaveDrives(home, away, homeFirst);
+
+  const totalReg = seq.length;
+  const drivesPerQuarter = Math.max(1, Math.ceil(totalReg / 4));
+  const hasOt = ot.length > 0;
+  const numQuarters = 4 + (hasOt ? 1 : 0);
+
+  const quarterHome = Array.from({ length: numQuarters }, () => 0);
+  const quarterAway = Array.from({ length: numQuarters }, () => 0);
+
+  const events = [];
+  const scoringSummary = [];
+  let runHome = 0;
+  let runAway = 0;
+  let sequence = 0;
+
+  const teamIdFor = (side) => (side === 'home' ? homeId : awayId);
+
+  const pushEvent = ({ side, drive, quarter, isOt = false }) => {
+    sequence += 1;
+    const result = drive?.result ?? 'PUNT';
+    const points = Math.max(0, Number(drive?.points) || 0);
+    const isScore = SCORING_RESULTS.has(result) && points > 0;
+    if (side === 'home') runHome += points;
+    else runAway += points;
+    const qIdx = quarter - 1;
+    if (isScore) {
+      if (side === 'home') quarterHome[qIdx] += points;
+      else quarterAway[qIdx] += points;
+    }
+    const eventType = RESULT_TO_EVENT_TYPE[result] || 'punt';
+    const label = resultLabel(result, points);
+    const teamId = teamIdFor(side);
+    const abbr = abbrFor(side, homeAbbr, awayAbbr);
+    const scoreAfter = { home: runHome, away: runAway };
+    const plays = Math.max(0, Number(drive?.plays) || 0);
+    const yards = Math.max(0, Number(drive?.yards) || 0);
+    const driveId = `${gameId}-drv-${sequence}`;
+    const text = isScore
+      ? `${abbr ?? 'Offense'} ${label} — ${plays} plays, ${yards} yards`
+      : `${abbr ?? 'Offense'} drive: ${label} (${plays} plays, ${yards} yards)`;
+    const event = {
+      eventId: `${gameId}-evt-${sequence}`,
+      gameId,
+      driveId,
+      sequence,
+      quarter,
+      clock: null,
+      possessionTeamId: teamId,
+      scoringTeamId: isScore ? teamId : null,
+      eventType,
+      driveResult: result,
+      points: isScore ? points : 0,
+      scoreAfter,
+      plays,
+      yards,
+      isScore,
+      isOvertime: isOt,
+      primaryPlayerId: null,
+      secondaryPlayerId: null,
+      teamAbbr: abbr,
+      text,
+    };
+    events.push(event);
+    if (isScore) {
+      scoringSummary.push({
+        id: event.eventId,
+        quarter,
+        clock: null,
+        teamId,
+        teamAbbr: abbr,
+        scoreType: scoreTypeFor(result),
+        type: label,
+        points,
+        text,
+        description: text,
+        scoreAfter: { ...scoreAfter },
+        // Lane B: drive-level ledger cannot prove per-play attribution.
+        passerId: null,
+        rusherId: null,
+        receiverId: null,
+        defenderId: null,
+        kickerId: null,
+      });
+    }
+  };
+
+  seq.forEach((entry, i) => {
+    const quarter = Math.min(4, Math.floor(i / drivesPerQuarter) + 1);
+    pushEvent({ side: entry.side, drive: entry.drive, quarter });
+  });
+
+  // Overtime: extend the quarter array (Q5 = OT) rather than folding OT points
+  // into the fourth quarter.
+  ot.forEach((otEvent) => {
+    const side = otEvent?.side === 'home' ? 'home' : 'away';
+    const points = Math.max(0, Number(otEvent?.points) || 0);
+    if (points <= 0) return;
+    const result = otEvent?.result === 'FIELD_GOAL' ? 'FIELD_GOAL' : 'TOUCHDOWN';
+    pushEvent({ side, drive: { result, points, plays: 0, yards: 0 }, quarter: 5, isOt: true });
+  });
+
+  // Terminal game-end marker carries the final scoreAfter so the last canonical
+  // scoreAfter always equals the official final, even for a 0-0 game.
+  sequence += 1;
+  events.push({
+    eventId: `${gameId}-evt-${sequence}`,
+    gameId,
+    driveId: null,
+    sequence,
+    quarter: hasOt ? 5 : 4,
+    clock: null,
+    possessionTeamId: null,
+    scoringTeamId: null,
+    eventType: 'game_end',
+    driveResult: 'GAME_END',
+    points: 0,
+    scoreAfter: { home: runHome, away: runAway },
+    plays: 0,
+    yards: 0,
+    isScore: false,
+    isOvertime: hasOt,
+    primaryPlayerId: null,
+    secondaryPlayerId: null,
+    teamAbbr: null,
+    text: 'Final whistle.',
+  });
+
+  return {
+    events,
+    scoringSummary,
+    quarterScores: { home: quarterHome, away: quarterAway },
+  };
+}
+
+/**
+ * Pure reconciliation checker used by the regression suite (and available to
+ * runtime asserts). Returns a structured report; never throws.
+ */
+export function reconcileCanonicalEvents(events = [], finalScore = {}) {
+  const list = Array.isArray(events) ? events : [];
+  const scoring = list.filter((e) => e && e.isScore);
+  // Per-side point totals are recomputed from the monotonic scoreAfter steps so
+  // the checker verifies the ledger's own running score rather than trusting the
+  // raw points field.
+  let home = 0;
+  let away = 0;
+  const finalHome = Number(finalScore?.home);
+  const finalAway = Number(finalScore?.away);
+  const last = list[list.length - 1] || null;
+  const lastAfter = last?.scoreAfter ?? null;
+  let prevHome = 0;
+  let prevAway = 0;
+  let monotonic = true;
+  let scoreOnlyOnScore = true;
+  let strictlyOrdered = true;
+  const ids = new Set();
+  let uniqueIds = true;
+  let prevSeq = -Infinity;
+  for (const e of list) {
+    if (!e) continue;
+    if (ids.has(e.eventId)) uniqueIds = false;
+    ids.add(e.eventId);
+    if (!(e.sequence > prevSeq)) strictlyOrdered = false;
+    prevSeq = e.sequence;
+    const after = e.scoreAfter ?? { home: prevHome, away: prevAway };
+    const dHome = Number(after.home) - prevHome;
+    const dAway = Number(after.away) - prevAway;
+    if (dHome < 0 || dAway < 0) monotonic = false;
+    if ((dHome > 0 || dAway > 0) && !e.isScore) scoreOnlyOnScore = false;
+    home += Math.max(0, dHome);
+    away += Math.max(0, dAway);
+    prevHome = Number(after.home);
+    prevAway = Number(after.away);
+  }
+  return {
+    pointsHome: home,
+    pointsAway: away,
+    lastAfter,
+    finalMatchesLast: lastAfter != null
+      && Number(lastAfter.home) === finalHome
+      && Number(lastAfter.away) === finalAway,
+    finalMatchesSum: home === finalHome && away === finalAway,
+    monotonic,
+    scoreOnlyOnScore,
+    strictlyOrdered,
+    uniqueIds,
+    scoringEventCount: scoring.length,
+  };
+}

--- a/src/core/simulation/driveEngine.js
+++ b/src/core/simulation/driveEngine.js
@@ -255,6 +255,11 @@ export function buildDriveBasedSummary({
 
   const simTeam = (offOvr, defOvr, drives, teamStats, isHome, netEdge = 0) => {
     let score = 0;
+    // Ordered per-drive outcome log — the raw material for the canonical event
+    // ledger (#1700). Populated purely by RECORDING values already drawn from
+    // the rng() stream; it consumes NO additional draws, so the seeded score is
+    // byte-for-byte unchanged whether or not this log is built.
+    const driveLog = [];
     // Scoring-play breakdown — authoritative source for box-score reconciliation.
     // A touchdown is 6 points plus its PAT (made XP = +1, made 2-pt = +2, failed
     // 2-pt = +0), so the identity
@@ -336,6 +341,18 @@ export function buildDriveBasedSummary({
      * estDistance is derived from drive yardage (no rng draw).
      */
     for (let i = 0; i < drives; i++) {
+      // Snapshot the mutable scoring counters so the drive's outcome can be
+      // classified purely from deltas after it resolves (no extra rng draw).
+      const scoreBefore = score;
+      const tdsBefore = tds;
+      const fgsBefore = fgs;
+      const passTDBefore = teamStats.passTD;
+      const fgAttBefore = teamStats.fgAttempts;
+      const puntsBefore = teamStats.punts;
+      const twoMadeBefore = teamStats.twoPointMade;
+      const twoAttBefore = teamStats.twoPointAttempts;
+      let sackThisDrive = false;
+      let turnoverThisDrive = false;
       // Field position is scoring-model bookkeeping only — local to simTeam.
       let yardLine = 25 + randInt(-10, 15);
       const passHeavy = chance(0.56);
@@ -352,38 +369,64 @@ export function buildDriveBasedSummary({
       yardLine = U.clamp(yardLine + passYds + rushYds, 1, 99);
       if (chance(U.clamp(0.17 + (defOvr - offOvr) * 0.0025, 0.08, 0.34))) {
         teamStats.sacks += 1;
+        sackThisDrive = true;
       }
       if (chance(U.clamp(0.08 + (defOvr - offOvr) * 0.002, 0.03, 0.2))) {
         teamStats.turnovers += 1;
+        turnoverThisDrive = true;
         if (chance(0.7)) teamStats.INT += 1;
       }
-      const convertedDrive = chance(driveSuccess);
-      if (convertedDrive) {
-        resolveScoringDrive(yardLine);
-        continue;
-      }
-      // Drive stalled → fourth-down decision from field position.
-      // Estimated yards-to-go on the stalled 4th down, derived from the
-      // drive's own yardage (deterministic, costs no rng draw): 1..10.
-      const estDistance = 10 - ((passYds + rushYds) % 10);
-      if (estDistance <= 2 && yardLine >= 60 && chance(0.30)) {
-        // Short-yardage go-for-it instead of the FG try.
-        if (chance(0.52)) {
+      // Resolve the drive to a score / punt / turnover-on-downs. Extracted into
+      // a local closure (returning instead of `continue`) so the rng() draw
+      // order is preserved exactly while the outcome can be recorded once below.
+      const resolveDrive = () => {
+        const convertedDrive = chance(driveSuccess);
+        if (convertedDrive) {
           resolveScoringDrive(yardLine);
+          return;
         }
-        // Failure: turnover on downs — no score, possession changes.
-        continue;
-      }
-      if (yardLine >= 60) {
-        attemptFieldGoal(yardLine);
-      } else if (yardLine >= 40) {
-        if (chance(0.45)) attemptFieldGoal(yardLine);
-        else teamStats.punts += 1;
-      } else {
-        teamStats.punts += 1;
-      }
+        // Drive stalled → fourth-down decision from field position.
+        // Estimated yards-to-go on the stalled 4th down, derived from the
+        // drive's own yardage (deterministic, costs no rng draw): 1..10.
+        const estDistance = 10 - ((passYds + rushYds) % 10);
+        if (estDistance <= 2 && yardLine >= 60 && chance(0.30)) {
+          // Short-yardage go-for-it instead of the FG try.
+          if (chance(0.52)) {
+            resolveScoringDrive(yardLine);
+          }
+          // Failure: turnover on downs — no score, possession changes.
+          return;
+        }
+        if (yardLine >= 60) {
+          attemptFieldGoal(yardLine);
+        } else if (yardLine >= 40) {
+          if (chance(0.45)) attemptFieldGoal(yardLine);
+          else teamStats.punts += 1;
+        } else {
+          teamStats.punts += 1;
+        }
+      };
+      resolveDrive();
+
+      // Classify the drive outcome from the counter deltas.
+      let result;
+      if (tds > tdsBefore) result = 'TOUCHDOWN';
+      else if (fgs > fgsBefore) result = 'FIELD_GOAL';
+      else if (teamStats.fgAttempts > fgAttBefore) result = 'MISSED_FG';
+      else if (turnoverThisDrive) result = 'TURNOVER';
+      else if (teamStats.punts > puntsBefore) result = 'PUNT';
+      else result = 'DOWNS';
+      driveLog.push({
+        plays: passAtt + rushAtt + (sackThisDrive ? 1 : 0),
+        yards: Math.max(0, passYds + rushYds),
+        result,
+        points: score - scoreBefore,
+        isPassTD: result === 'TOUCHDOWN' && teamStats.passTD > passTDBefore,
+        twoPointMade: teamStats.twoPointMade > twoMadeBefore,
+        twoPointAttempt: teamStats.twoPointAttempts > twoAttBefore,
+      });
     }
-    return { score, tds, fgs, xps };
+    return { score, tds, fgs, xps, driveLog };
   };
 
   const homeResult = simTeam(homeOff, awayDef, homeDrives, homeStats, true, homeNetEdge);
@@ -407,6 +450,9 @@ export function buildDriveBasedSummary({
     awayFGs: awayResult.fgs,
     homeXPs: homeResult.xps,
     awayXPs: awayResult.xps,
+    // Ordered per-drive outcome logs (regulation only) — canonical event source.
+    homeDriveLog: homeResult.driveLog,
+    awayDriveLog: awayResult.driveLog,
     homeStats: { ...homeStats, qbRating: homeQbRating, rushYPC: homeYpc },
     awayStats: { ...awayStats, qbRating: awayQbRating, rushYPC: awayYpc },
   };

--- a/src/core/simulation/index.js
+++ b/src/core/simulation/index.js
@@ -27,6 +27,8 @@ import {
   buildQuarterScoresFromScoring,
   buildScoringSummaryFromSimulation,
 } from '../gameSummary.js';
+import { buildCanonicalGameEvents } from './canonicalGameEvents.js';
+import { buildCanonicalGameId } from '../gameIdentity.js';
 
 
 const nQbStat = (v) => { const x = Number(v); return Number.isFinite(x) ? x : 0; };
@@ -1222,6 +1224,11 @@ export function simGameStats(home, away, options = {}) {
     let homeXPs = driveSummary?.homeXPs ?? homeRes.xpMade;
     let awayXPs = driveSummary?.awayXPs ?? awayRes.xpMade;
 
+    // Ordered overtime scoring events, captured for the canonical event ledger
+    // (#1700). Regulation drives come from driveSummary.home/awayDriveLog; OT
+    // points are generated here (a separate loop) so they are recorded here.
+    const overtimeEvents = [];
+
     // --- OVERTIME LOGIC WITH CLUTCH MECHANICS ---
     // If tied at end of regulation, simulate OT
     // Clutch trait on QB gives a scoring boost in OT
@@ -1295,6 +1302,11 @@ export function simGameStats(home, away, options = {}) {
                 } else {
                     awayScore += drivePoints;
                 }
+                overtimeEvents.push({
+                    side: possession,
+                    points: drivePoints,
+                    result: drivePoints >= 6 ? 'TOUCHDOWN' : 'FIELD_GOAL',
+                });
             }
 
             // End-of-game decision (NFL 2024+ / college rules) owned by clockManager.
@@ -1309,8 +1321,8 @@ export function simGameStats(home, away, options = {}) {
             console.warn(`[SIM-DEBUG] OT hit hard iteration cap (${HARD_ITERATION_CAP}). Forcing end.`);
             // Force a winner if still tied after safety cap
             if (homeScore === awayScore) {
-                if (U.random() < 0.5) homeScore += 3;
-                else awayScore += 3;
+                if (U.random() < 0.5) { homeScore += 3; overtimeEvents.push({ side: 'home', points: 3, result: 'FIELD_GOAL' }); }
+                else { awayScore += 3; overtimeEvents.push({ side: 'away', points: 3, result: 'FIELD_GOAL' }); }
             }
         }
 
@@ -1733,9 +1745,35 @@ export function simGameStats(home, away, options = {}) {
       awayAbbr: away?.abbr,
     };
     const normalizedPlayLogs = normalizePlayLogs(fullGameResult.playLogs || [], summaryContext);
-    const scoringSummary = buildScoringSummaryFromSimulation(normalizedPlayLogs, summaryContext);
+    // Drive-level narration cards remain a presentation-only flavor layer.
     const driveSummaryRows = buildDriveSummaryFromSimulation(normalizedPlayLogs, summaryContext);
-    const quarterScores = buildQuarterScoresFromScoring(scoringSummary, summaryContext);
+
+    // ── CANONICAL EVENT LEDGER (#1700) ──────────────────────────────────────
+    // The scoring summary and quarter scores are now derived from the drive
+    // engine's ordered per-drive outcome logs (the same authority that owns the
+    // final score) PLUS any overtime scoring captured above — never from the
+    // narration play stream. This makes quarter totals and the scoring summary
+    // reconcile to the official final by construction.
+    const canonicalGameId = buildCanonicalGameId({
+      seasonId: options?.league?.seasonId ?? options?.league?.year ?? 0,
+      week: options?.league?.week ?? 1,
+      homeId: home?.id,
+      awayId: away?.id,
+    });
+    const canonicalLedger = buildCanonicalGameEvents({
+      gameId: canonicalGameId,
+      homeId: home?.id,
+      awayId: away?.id,
+      homeAbbr: home?.abbr,
+      awayAbbr: away?.abbr,
+      homeDriveLog: driveSummary?.homeDriveLog ?? [],
+      awayDriveLog: driveSummary?.awayDriveLog ?? [],
+      overtimeEvents,
+      seed: driveSummary?.seed ?? 0,
+    });
+    const canonicalEvents = canonicalLedger.events;
+    const scoringSummary = canonicalLedger.scoringSummary;
+    const quarterScores = canonicalLedger.quarterScores;
 
     // --- EXECUTIVE POSTGAME DIAGNOSTICS (gameReasoningFlags) ---
     // Detect whether in-game attrition forced a clearly lower-rated backup into
@@ -1816,6 +1854,7 @@ export function simGameStats(home, away, options = {}) {
       driveSummary: driveSummaryRows,
       scoringSummary,
       quarterScores,
+      canonicalEvents,
       recapText,
       simSeed: driveSummary?.seed ?? null,
     };
@@ -2092,6 +2131,7 @@ export function commitGameResult(league, gameData, options = { persist: true }) 
         driveSummary: gameData.driveSummary || [],
         scoringSummary: gameData.scoringSummary || [],
         quarterScores: gameData.quarterScores || null,
+        canonicalEvents: gameData.canonicalEvents || [],
         recapText: gameData.recapText || null,
         simSeed: gameData.simSeed ?? null,
         gameReasoningFlags: Array.isArray(gameData.gameReasoningFlags) ? gameData.gameReasoningFlags : [],
@@ -2105,6 +2145,7 @@ export function commitGameResult(league, gameData, options = { persist: true }) 
         scheduledGame.boxScore = resultObj.boxScore;
         scheduledGame.scoringSummary = resultObj.scoringSummary;
         scheduledGame.quarterScores = resultObj.quarterScores;
+        scheduledGame.canonicalEvents = resultObj.canonicalEvents;
         scheduledGame.driveSummary = resultObj.driveSummary;
         scheduledGame.playLogs = resultObj.playLogs;
         scheduledGame.playLog = resultObj.playLogs;
@@ -2318,6 +2359,7 @@ export function simulateBatch(games, options = {}) {
                 pair._driveSummary = gameScores.driveSummary || [];
                 pair._scoringSummary = gameScores.scoringSummary || [];
                 pair._quarterScores = gameScores.quarterScores || null;
+                pair._canonicalEvents = gameScores.canonicalEvents || [];
                 pair._recapText = gameScores.recapText || null;
                 pair._simSeed = gameScores.simSeed ?? null;
                 pair._gameReasoningFlags = Array.isArray(gameScores.gameReasoningFlags) ? gameScores.gameReasoningFlags : [];
@@ -2445,6 +2487,7 @@ export function simulateBatch(games, options = {}) {
                 driveSummary: pair._driveSummary || [],
                 scoringSummary: pair._scoringSummary || [],
                 quarterScores: pair._quarterScores || null,
+                canonicalEvents: pair._canonicalEvents || [],
                 recapText: pair._recapText || null,
                 simSeed: pair._simSeed ?? null,
                 gameReasoningFlags: pair._gameReasoningFlags || [],
@@ -2482,6 +2525,7 @@ export function simulateBatch(games, options = {}) {
                     driveSummary: pair._driveSummary || [],
                     scoringSummary: pair._scoringSummary || [],
                     quarterScores: pair._quarterScores || null,
+                    canonicalEvents: pair._canonicalEvents || [],
                     recapText: pair._recapText || null,
                     simSeed: pair._simSeed ?? null,
                     gameReasoningFlags: pair._gameReasoningFlags || [],

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -173,6 +173,9 @@ export function buildWatchPostGameResult({
   liveStats = null,
   playerStats = null,
   teamStats = null,
+  canonicalEvents = null,
+  scoringSummary = null,
+  quarterScores = null,
   gameReasoningFlags = [],
   seasonId,
 } = {}) {
@@ -193,6 +196,9 @@ export function buildWatchPostGameResult({
     liveStats,
     playerStats,
     teamStats,
+    canonicalEvents,
+    scoringSummary,
+    quarterScores,
     gameReasoningFlags,
     seasonId,
     gameId: buildCanonicalGameId({
@@ -217,6 +223,9 @@ function AppContent() {
     userGameLiveStats,
     userGamePlayerStats,
     userGameTeamStats,
+    userGameCanonicalEvents,
+    userGameScoringSummary,
+    userGameQuarterScores,
     userGameReasoningFlags,
     lastWorkerMessageType,
   } = state;
@@ -1762,6 +1771,8 @@ function AppContent() {
           }}>
             <LiveGameView
               logs={userGameLogs}
+              canonicalEvents={userGameCanonicalEvents}
+              playerStats={userGamePlayerStats}
               homeTeam={homeTeam}
               awayTeam={awayTeam}
               initialMode={watchMode}
@@ -1794,6 +1805,9 @@ function AppContent() {
                     liveStats: userGameLiveStats || null,
                     playerStats: userGamePlayerStats || null,
                     teamStats: userGameTeamStats || null,
+                    canonicalEvents: userGameCanonicalEvents || null,
+                    scoringSummary: userGameScoringSummary || null,
+                    quarterScores: userGameQuarterScores || null,
                     gameReasoningFlags: userGameReasoningFlags || [],
                     seasonId: league?.seasonId,
                   });
@@ -1831,6 +1845,9 @@ function AppContent() {
           logs={postGameResult.logs || []}
           playerStats={postGameResult.playerStats || null}
           teamStats={postGameResult.teamStats || null}
+          scoringSummary={postGameResult.scoringSummary || null}
+          quarterScores={postGameResult.quarterScores || null}
+          canonicalEvents={postGameResult.canonicalEvents || null}
           gameReasoningFlags={postGameResult.gameReasoningFlags || []}
           boxScoreGameId={postGameResult.gameId}
           onOpenBoxScore={(gameId) => {

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -254,11 +254,22 @@ function BoxScore({
           {decisiveMoments.map((m, i) => (
             <div key={m.id ?? i} className="bs-sheet-moment-row">
               <span className="bs-sheet-moment-meta">
-                {m.quarter != null ? `Q${m.quarter}` : ""}{(m.time ?? m.clock) ? ` ${m.time ?? m.clock}` : ""}
+                {m.periodLabel ?? (m.quarter != null ? `Q${m.quarter}` : "")}{(m.time ?? m.clock) ? ` ${m.time ?? m.clock}` : ""}
               </span>
               <span className="bs-sheet-moment-text">{m.text ?? m.description ?? "Momentum swing"}</span>
             </div>
           ))}
+        </div>
+      )}
+
+      {/* ── QUARTER BREAKDOWN — honest availability (#1700 review defect #1) ─
+          Canonical-ledger games own no chronological quarters, so no quarter
+          table is shown; a compact honest note appears instead. Legacy archives
+          with genuine stored quarter data still render their linescore. The
+          final score + scoring summary below remain fully canonical either way. */}
+      {vm.isCanonicalLedger && !vm.availableData?.quarterScores && (
+        <div className="bs-sheet-quarter-unavailable" data-testid="game-book-quarter-unavailable">
+          Quarter breakdown unavailable for this game.
         </div>
       )}
 
@@ -270,7 +281,7 @@ function BoxScore({
             {scoringSummaryRows.map((row) => (
               <div key={row.id} className="bs-sheet-row">
                 <span className="bs-sheet-row-meta">
-                  {row.quarter != null ? `Q${row.quarter}` : ""}{row.time ? ` ${row.time}` : ""}
+                  {row.periodLabel ?? (row.quarter != null ? `Q${row.quarter}` : "")}{row.time ? ` ${row.time}` : ""}
                 </span>
                 <span>{[row.teamAbbr, row.type, row.description].filter(Boolean).join(" — ")}</span>
               </div>

--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -5,6 +5,7 @@ import { buildWeeklyDecisionImpact } from '../utils/weeklyDecisionImpact.js';
 import { buildBoxScoreViewModel, unwrapBoxScoreResponse } from '../utils/boxScoreViewModel.js';
 import useStableRouteRequest from '../hooks/useStableRouteRequest.js';
 import { resolveCanonicalCompletedGame } from '../utils/canonicalCompletedGame.js';
+import { getGame as getLocalArchivedGame } from '../../core/archive/gameArchive.ts';
 
 function findScheduleGame(league, gameId) {
   for (const week of league?.schedule?.weeks ?? []) {
@@ -85,7 +86,15 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
     warnLabel: 'GameDetailScreen',
   });
   const archivedGame = unwrapBoxScoreResponse(archiveResponse);
-  const canonicalGame = resolveCanonicalCompletedGame({ league, gameId, scheduleGame, archivedGame });
+  // Synchronous localStorage archive written by PostGameScreen (onArchiveReady →
+  // saveGame). It is available the moment the postgame screen mounts — before the
+  // user can navigate — so consulting it lets the Game Book open the just-watched
+  // game immediately instead of racing (and sometimes losing to) the async
+  // worker fetch, which was landing on the recovery state intermittently.
+  const localArchivedGame = useMemo(() => {
+    try { return getLocalArchivedGame(gameId); } catch { return null; }
+  }, [gameId]);
+  const canonicalGame = resolveCanonicalCompletedGame({ league, gameId, scheduleGame, archivedGame, localArchivedGame });
   const userTeam = (league?.teams ?? []).find((team) => Number(team?.id) === Number(league?.userTeamId));
   const prepContext = buildWeeklyDecisionImpact({ league, userTeam, lastGame: scheduleGame });
   const detailVm = useMemo(

--- a/src/ui/components/GameEventFeed/GameEventFeed.jsx
+++ b/src/ui/components/GameEventFeed/GameEventFeed.jsx
@@ -32,13 +32,19 @@ export default function GameEventFeed({ events = [], activeIndex = 0 }) {
         const scoreHome = finiteScore(event.score?.home);
         const scoreAway = finiteScore(event.score?.away);
         const scoreText = scoreHome != null && scoreAway != null ? `${scoreAway}–${scoreHome}` : '';
-        const isMajor = ['touchdown', 'field_goal', 'turnover', 'sack', 'explosive_play', 'game_end', 'turning_point'].includes(event.eventType);
-        const showQuarterMarker = previousQuarter !== null && previousQuarter !== event.quarter;
+        const isMajor = ['touchdown', 'field_goal', 'turnover', 'sack', 'explosive_play', 'game_end', 'turning_point', 'overtime_start'].includes(event.eventType);
+        // Canonical events carry `periodLabel` ("Drive 8" / "OT") and a null
+        // quarter; legacy narration events carry a numeric quarter. Prefer the
+        // honest period label, falling back to Q{n} only for legacy events.
+        const periodText = event.periodLabel
+          ?? (event.quarter != null ? `Q${event.quarter}` : null);
+        const showQuarterMarker = event.quarter != null
+          && previousQuarter !== null && previousQuarter !== event.quarter;
         const showPossessionDivider = !showQuarterMarker
           && previousPossession !== null
           && event.possessionTeamId != null
           && previousPossession !== event.possessionTeamId
-          && !['halftime', 'quarter_end', 'game_end'].includes(event.eventType);
+          && !['halftime', 'quarter_end', 'game_end', 'overtime_start'].includes(event.eventType);
         previousQuarter = event.quarter;
         previousPossession = event.possessionTeamId ?? previousPossession;
         return (
@@ -51,12 +57,12 @@ export default function GameEventFeed({ events = [], activeIndex = 0 }) {
               <div className="feed-possession-divider" aria-hidden="true" />
             ) : null}
             <article className={`feed-row${isLatest ? ' latest' : ''}${isMajor ? ' major' : ' routine'}`}>
-              {/* Quarter + event-sequence indicator. The narration engine only has
-                  drive-level clock estimates (every play in a drive shares one
-                  randomized stamp), so no per-play clock is displayed. */}
+              {/* Period + event-sequence indicator. No per-play clock exists, and
+                  the sim owns no chronological quarter, so this shows the honest
+                  period label ("Drive 8" / "OT") or a legacy Q{n}. */}
               <div className="feed-time">
-                Q{event.quarter}
-                {event.sequence != null ? <span className="feed-clock">#{event.sequence}</span> : null}
+                {periodText || `#${event.sequence ?? ''}`}
+                {periodText && event.sequence != null ? <span className="feed-clock">#{event.sequence}</span> : null}
               </div>
               <div className="feed-body">
                 <div className="feed-headline">{event.headline}</div>

--- a/src/ui/components/LiveGameViewer.jsx
+++ b/src/ui/components/LiveGameViewer.jsx
@@ -98,24 +98,35 @@ export default function LiveGameViewer({ logs = [], canonicalEvents = null, play
 
   const scoreState = {
     score: displayScore,
-    quarter: currentEvent.quarter || 1,
+    // Canonical events own no chronological quarter — the scorebug shows the
+    // honest period label ("Drive 8" / "OT") instead. Legacy narration keeps its
+    // numeric quarter.
+    quarter: useCanonical ? null : (currentEvent.quarter || 1),
+    periodLabel: useCanonical
+      ? (finished ? 'Final' : (currentEvent.periodLabel ?? (currentEvent.isOvertime ? 'OT' : null)))
+      : undefined,
+    isOvertime: useCanonical ? Boolean(currentEvent.isOvertime) : undefined,
     // No trustworthy per-play clock exists (drive-granular estimates only) —
-    // the scorebug shows quarter + event progress instead of a fake clock.
+    // the scorebug shows the period label + possession instead of a fake clock.
     clock: null,
     progressLabel: finished
       ? 'Final'
       : (useCanonical
-        ? `Drive ${Math.min(index + 1, events.length)} of ${events.length}`
+        ? null
         : `Play ${Math.min(index + 1, events.length)} of ${events.length}`),
     downDistance: useCanonical
       ? (currentEvent.plays != null ? `${currentEvent.plays} plays · ${currentEvent.yards || 0} yds` : 'Drive update')
       : (currentEvent.down ? `${currentEvent.down}${ordinal(currentEvent.down)} & ${currentEvent.distance || 10}` : 'Drive update'),
-    ballSpot: currentEvent.fieldPosition != null ? `Ball on ${Math.round(Number(currentEvent.fieldPosition) || 50)}` : 'Ball spot --',
+    ballSpot: useCanonical
+      ? '—'
+      : (currentEvent.fieldPosition != null ? `Ball on ${Math.round(Number(currentEvent.fieldPosition) || 50)}` : 'Ball spot --'),
     fieldPosition: currentEvent.fieldPosition,
     possessionTeamId: currentEvent.possessionTeamId,
     isFinal: finished,
   };
-  const isLateGame = Number(scoreState.quarter) >= 4 && index >= Math.floor((events.length - 1) * 0.85);
+  const isLateGame = useCanonical
+    ? (Boolean(currentEvent.isOvertime) && !finished)
+    : (Number(scoreState.quarter) >= 4 && index >= Math.floor((events.length - 1) * 0.85));
 
   const modeLabel = paused ? 'Paused' : `Watch · ${SPEED_STEPS.find((step) => step.key === speed)?.label ?? 'Normal'}`;
 

--- a/src/ui/components/LiveGameViewer.jsx
+++ b/src/ui/components/LiveGameViewer.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import Scorebug from './Scorebug/Scorebug.jsx';
 import GameEventFeed from './GameEventFeed/GameEventFeed.jsx';
-import { mapArchiveEventsToLiveFeed, mapCanonicalEventsToLiveFeed, getNextImportantEvent } from '../../core/liveGame/liveGameEvents.js';
+import { mapArchiveEventsToLiveFeed, mapCanonicalEventsToLiveFeed, getNextImportantEvent, countCanonicalRegulationDrives } from '../../core/liveGame/liveGameEvents.js';
 import { readStrictFinalScore } from '../../core/gameArchive.js';
 import { getCurrentStandoutPlayers, summarizeGameSwing } from '../utils/liveGamePresentation.js';
 import { deriveStandoutsFromBoxScore } from '../utils/liveGameStandouts.js';
@@ -96,15 +96,25 @@ export default function LiveGameViewer({ logs = [], canonicalEvents = null, play
     ? (finished && canonicalFinal ? canonicalFinal : runningScore)
     : (finished && canonicalFinal ? canonicalFinal : null);
 
+  // Real regulation drive total — excludes the terminal game_end marker and the
+  // overtime divider (#1700 review defect #4), so the scorebug reads
+  // "Drive N of {drives}", never "of {drives+1}".
+  const regulationDriveTotal = useCanonical ? countCanonicalRegulationDrives(events) : 0;
+  const canonicalPeriodLabel = () => {
+    if (finished) return 'Final';
+    if (currentEvent.isOvertime) return 'OT';
+    if (Number.isFinite(Number(currentEvent.driveNumber)) && regulationDriveTotal > 0) {
+      return `Drive ${currentEvent.driveNumber} of ${regulationDriveTotal}`;
+    }
+    return currentEvent.periodLabel ?? null;
+  };
   const scoreState = {
     score: displayScore,
     // Canonical events own no chronological quarter — the scorebug shows the
-    // honest period label ("Drive 8" / "OT") instead. Legacy narration keeps its
-    // numeric quarter.
+    // honest drive progress ("Drive 8 of 24" / "OT" / "Final") instead. Legacy
+    // narration keeps its numeric quarter.
     quarter: useCanonical ? null : (currentEvent.quarter || 1),
-    periodLabel: useCanonical
-      ? (finished ? 'Final' : (currentEvent.periodLabel ?? (currentEvent.isOvertime ? 'OT' : null)))
-      : undefined,
+    periodLabel: useCanonical ? canonicalPeriodLabel() : undefined,
     isOvertime: useCanonical ? Boolean(currentEvent.isOvertime) : undefined,
     // No trustworthy per-play clock exists (drive-granular estimates only) —
     // the scorebug shows the period label + possession instead of a fake clock.
@@ -242,12 +252,15 @@ export default function LiveGameViewer({ logs = [], canonicalEvents = null, play
             <button className="ctrl-btn" onClick={() => setIndex(getNextImportantEvent(events, index, 'score'))}>Next Score</button>
             <button className="ctrl-btn" onClick={() => setIndex(getNextImportantEvent(events, index, 'keyPlay'))}>Key Play</button>
             <button className="ctrl-btn" onClick={() => setIndex(events.length - 1)}>Sim End</button>
-            {onPlaycallOverride ? (
-              <>
-                <button className="ctrl-btn" title="Lean run on next drive." onClick={() => onPlaycallOverride?.({ type: 'run_heavy' })}>Run Heavy</button>
-                <button className="ctrl-btn" title="Lean pass on next drive." onClick={() => onPlaycallOverride?.({ type: 'pass_heavy' })}>Pass Heavy</button>
-                <button className="ctrl-btn" title="Request a timeout." onClick={() => onPlaycallOverride?.({ type: 'timeout' })}>Timeout</button>
-              </>
+            {/* Run Heavy / Pass Heavy / Timeout removed (#1700 review defect #2):
+                the watched game is fully simulated before playback, so these
+                could not affect the canonical result on any path — displaying
+                them claimed strategic agency that did not exist. onPlaycallOverride
+                is intentionally never invoked during canonical playback. */}
+            {useCanonical ? (
+              <span className="skip-menu-note" data-testid="strategy-locked-note">
+                Game strategy was locked when simulation began.
+              </span>
             ) : null}
           </div>
         </details>
@@ -379,6 +392,7 @@ const styles = `
   background:#0f1c38; border:1px solid #334870; border-radius:10px;
   padding:6px; min-width:132px; box-shadow:0 -8px 24px rgba(0,0,0,.45); z-index:3;
 }
+.skip-menu-note { font-size:10px; color:#93a7c9; line-height:1.35; padding:4px 2px 2px; max-width:160px; }
 
 /* ── Final card ──────────────────────────────────────────────────────── */
 .watch-final-card { border:1px solid #3d5378; border-radius:10px; margin-top:12px; padding:10px; background:#13203a; }

--- a/src/ui/components/LiveGameViewer.jsx
+++ b/src/ui/components/LiveGameViewer.jsx
@@ -1,9 +1,10 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import Scorebug from './Scorebug/Scorebug.jsx';
 import GameEventFeed from './GameEventFeed/GameEventFeed.jsx';
-import { mapArchiveEventsToLiveFeed, getNextImportantEvent } from '../../core/liveGame/liveGameEvents.js';
+import { mapArchiveEventsToLiveFeed, mapCanonicalEventsToLiveFeed, getNextImportantEvent } from '../../core/liveGame/liveGameEvents.js';
 import { readStrictFinalScore } from '../../core/gameArchive.js';
 import { getCurrentStandoutPlayers, summarizeGameSwing } from '../utils/liveGamePresentation.js';
+import { deriveStandoutsFromBoxScore } from '../utils/liveGameStandouts.js';
 
 const SPEED_STEPS = [
   { key: 'slow',     label: 'Slow',      ms: 1400 },
@@ -18,20 +19,31 @@ const TENDENCY_CONFIG = {
   CONSERVATIVE: { label: 'Conservative', chipClass: 'conservative' },
 };
 
-export default function LiveGameViewer({ logs = [], homeTeam, awayTeam, onComplete, initialMode = 'watch', onPlaycallOverride, userTendency = 'BALANCED', finalScore = null }) {
-  // Canonical final: the league-recorded result (GAME_EVENT payload). The
-  // narrated play stream is a separate engine whose running score can
-  // contradict it, so this is the only score the viewer will ever display.
+export default function LiveGameViewer({ logs = [], canonicalEvents = null, playerStats = null, homeTeam, awayTeam, onComplete, initialMode = 'watch', onPlaycallOverride, userTendency = 'BALANCED', finalScore = null }) {
+  // Canonical final: the league-recorded result (GAME_EVENT payload).
   const canonicalFinal = useMemo(() => {
     return readStrictFinalScore({ score: finalScore });
   }, [finalScore]);
 
-  const events = useMemo(() => mapArchiveEventsToLiveFeed(logs, {
-    gameId: `${homeTeam?.id || 'h'}-${awayTeam?.id || 'a'}`,
-    homeTeamId: homeTeam?.id,
-    awayTeamId: awayTeam?.id,
-    finalScore: canonicalFinal,
-  }), [logs, homeTeam?.id, awayTeam?.id, canonicalFinal]);
+  // Prefer the canonical drive-level event ledger (#1700): every event carries a
+  // trustworthy scoreAfter, so the scorebug shows a real live score progression.
+  // Fall back to the legacy narration feed only when no canonical ledger exists
+  // (e.g. a legacy archive) — that path shows the final score only at the end.
+  const useCanonical = Array.isArray(canonicalEvents) && canonicalEvents.length > 0;
+
+  const events = useMemo(() => {
+    if (useCanonical) {
+      return mapCanonicalEventsToLiveFeed(canonicalEvents, {
+        gameId: `${homeTeam?.id || 'h'}-${awayTeam?.id || 'a'}`,
+      });
+    }
+    return mapArchiveEventsToLiveFeed(logs, {
+      gameId: `${homeTeam?.id || 'h'}-${awayTeam?.id || 'a'}`,
+      homeTeamId: homeTeam?.id,
+      awayTeamId: awayTeam?.id,
+      finalScore: canonicalFinal,
+    });
+  }, [useCanonical, canonicalEvents, logs, homeTeam?.id, awayTeam?.id, canonicalFinal]);
 
   const [index, setIndex] = useState(0);
   const [paused, setPaused] = useState(initialMode === 'pause');
@@ -56,13 +68,33 @@ export default function LiveGameViewer({ logs = [], homeTeam, awayTeam, onComple
   }, [paused, speed, index, events.length]);
 
   const currentEvent = events[index] || {};
-  const standout = useMemo(() => getCurrentStandoutPlayers(events, index + 1), [events, index]);
+  // Standouts (a.k.a. live leaders): in canonical mode these come from the
+  // canonical box score — the same authority PostGameScreen Leaders use — never
+  // the narration stream. Legacy mode keeps the narration-derived standouts.
+  const canonicalStandouts = useMemo(
+    () => (useCanonical ? deriveStandoutsFromBoxScore(playerStats) : null),
+    [useCanonical, playerStats],
+  );
+  const narrationStandouts = useMemo(
+    () => (useCanonical ? null : getCurrentStandoutPlayers(events, index + 1)),
+    [useCanonical, events, index],
+  );
+  const standout = canonicalStandouts ?? narrationStandouts ?? {};
   const swing = useMemo(() => summarizeGameSwing(events, index + 1), [events, index]);
 
   const finished = index >= events.length - 1;
-  // Scores shown only once the canonical final is in play — never the narrated
-  // per-play snapshots, which belong to a different scoring engine.
-  const displayScore = finished && canonicalFinal ? canonicalFinal : null;
+  // Score policy:
+  //   Canonical mode — the scorebug reads the CURRENT canonical event's
+  //     scoreAfter (a real, monotonic running score); at the end it equals the
+  //     league-recorded final.
+  //   Legacy mode — no trustworthy running score exists, so the score is shown
+  //     only once the canonical final is in play (#1692 honest placeholder).
+  const runningScore = useCanonical
+    ? (currentEvent.scoreAfter ?? { home: 0, away: 0 })
+    : null;
+  const displayScore = useCanonical
+    ? (finished && canonicalFinal ? canonicalFinal : runningScore)
+    : (finished && canonicalFinal ? canonicalFinal : null);
 
   const scoreState = {
     score: displayScore,
@@ -70,8 +102,14 @@ export default function LiveGameViewer({ logs = [], homeTeam, awayTeam, onComple
     // No trustworthy per-play clock exists (drive-granular estimates only) —
     // the scorebug shows quarter + event progress instead of a fake clock.
     clock: null,
-    progressLabel: finished ? 'Final' : `Play ${Math.min(index + 1, events.length)} of ${events.length}`,
-    downDistance: currentEvent.down ? `${currentEvent.down}${ordinal(currentEvent.down)} & ${currentEvent.distance || 10}` : 'Drive update',
+    progressLabel: finished
+      ? 'Final'
+      : (useCanonical
+        ? `Drive ${Math.min(index + 1, events.length)} of ${events.length}`
+        : `Play ${Math.min(index + 1, events.length)} of ${events.length}`),
+    downDistance: useCanonical
+      ? (currentEvent.plays != null ? `${currentEvent.plays} plays · ${currentEvent.yards || 0} yds` : 'Drive update')
+      : (currentEvent.down ? `${currentEvent.down}${ordinal(currentEvent.down)} & ${currentEvent.distance || 10}` : 'Drive update'),
     ballSpot: currentEvent.fieldPosition != null ? `Ball on ${Math.round(Number(currentEvent.fieldPosition) || 50)}` : 'Ball spot --',
     fieldPosition: currentEvent.fieldPosition,
     possessionTeamId: currentEvent.possessionTeamId,

--- a/src/ui/components/LiveGameViewer.jsx
+++ b/src/ui/components/LiveGameViewer.jsx
@@ -26,9 +26,10 @@ export default function LiveGameViewer({ logs = [], canonicalEvents = null, play
   }, [finalScore]);
 
   // Prefer the canonical drive-level event ledger (#1700): every event carries a
-  // trustworthy scoreAfter, so the scorebug shows a real live score progression.
-  // Fall back to the legacy narration feed only when no canonical ledger exists
-  // (e.g. a legacy archive) — that path shows the final score only at the end.
+  // scoreAfter, so the scorebug shows a reconstructed score progression toward
+  // the official final (labeled "Reconstructed order"; only the final is
+  // official). Fall back to the legacy narration feed only when no canonical
+  // ledger exists (e.g. a legacy archive) — that path shows the final only at the end.
   const useCanonical = Array.isArray(canonicalEvents) && canonicalEvents.length > 0;
 
   const events = useMemo(() => {
@@ -68,25 +69,30 @@ export default function LiveGameViewer({ logs = [], canonicalEvents = null, play
   }, [paused, speed, index, events.length]);
 
   const currentEvent = events[index] || {};
-  // Standouts (a.k.a. live leaders): in canonical mode these come from the
-  // canonical box score — the same authority PostGameScreen Leaders use — never
-  // the narration stream. Legacy mode keeps the narration-derived standouts.
+  const finished = index >= events.length - 1;
+  // Standouts (game leaders): in canonical mode these are the FINAL box-score
+  // totals (the same authority PostGameScreen Leaders use), so they are only
+  // meaningful at the final whistle. Showing final totals mid-game would be
+  // misleading, so they stay hidden until `finished`. Legacy mode keeps the
+  // narration-derived running standouts.
   const canonicalStandouts = useMemo(
-    () => (useCanonical ? deriveStandoutsFromBoxScore(playerStats) : null),
-    [useCanonical, playerStats],
+    () => (useCanonical && finished ? deriveStandoutsFromBoxScore(playerStats) : null),
+    [useCanonical, finished, playerStats],
   );
   const narrationStandouts = useMemo(
     () => (useCanonical ? null : getCurrentStandoutPlayers(events, index + 1)),
     [useCanonical, events, index],
   );
   const standout = canonicalStandouts ?? narrationStandouts ?? {};
+  // Canonical standouts are withheld until the final whistle (see above).
+  const standoutsLocked = useCanonical && !finished;
   const swing = useMemo(() => summarizeGameSwing(events, index + 1), [events, index]);
-
-  const finished = index >= events.length - 1;
   // Score policy:
-  //   Canonical mode — the scorebug reads the CURRENT canonical event's
-  //     scoreAfter (a real, monotonic running score); at the end it equals the
-  //     league-recorded final.
+  //   Canonical mode — the scorebug reads the current canonical event's
+  //     scoreAfter: a monotonic running total over a RECONSTRUCTED possession
+  //     order (see canonicalGameEvents.js). The intermediate value is
+  //     illustrative — labeled "Reconstructed order" in the UI — while the final
+  //     equals the league-recorded official result exactly.
   //   Legacy mode — no trustworthy running score exists, so the score is shown
   //     only once the canonical final is in play (#1692 honest placeholder).
   const runningScore = useCanonical
@@ -165,6 +171,19 @@ export default function LiveGameViewer({ logs = [], canonicalEvents = null, play
         <Scorebug homeTeam={homeTeam} awayTeam={awayTeam} state={scoreState} />
         <div className="watch-state-strip">
           <span className="watch-mode-chip">{modeLabel}</span>
+          {/* Honest framing: the drive-by-drive order and the running score shown
+              before the final are a deterministic RECONSTRUCTION of possessions,
+              not the game's recorded chronology (the engine simulates each side's
+              drives separately and owns no clock). Only the final is official. */}
+          {useCanonical && !finished ? (
+            <span
+              className="watch-mode-chip reconstructed"
+              data-testid="reconstructed-order-chip"
+              title="Drive order and the running score are a reconstructed progression toward the official final — not a recorded play-by-play timeline."
+            >
+              Reconstructed order
+            </span>
+          ) : null}
           {isLateGame && !finished ? <span className="watch-mode-chip clutch">Late Game</span> : null}
           {finished ? <span className="watch-mode-chip final">Complete</span> : null}
           {(() => {
@@ -191,13 +210,19 @@ export default function LiveGameViewer({ logs = [], canonicalEvents = null, play
         <aside className="watch-side">
           <details className="standout-panel" open>
             <summary className="watch-side-title">Standouts</summary>
-            <ul className="standout-list">
-              <li><span className="standout-pos">QB</span>{formatQb(standout.qb)}</li>
-              <li><span className="standout-pos">Rush</span>{formatRush(standout.rusher)}</li>
-              <li><span className="standout-pos">Rec</span>{formatRec(standout.receiver)}</li>
-              <li><span className="standout-pos">Sacks</span>{standout.sacks ? `${standout.sacks.player} (${standout.sacks.sacks})` : '—'}</li>
-              <li><span className="standout-pos">INT</span>{standout.picks ? `${standout.picks.player} (${standout.picks.picks})` : '—'}</li>
-            </ul>
+            {standoutsLocked ? (
+              <p className="standout-locked" data-testid="standouts-locked">
+                Game leaders unlock at the final whistle.
+              </p>
+            ) : (
+              <ul className="standout-list">
+                <li><span className="standout-pos">QB</span>{formatQb(standout.qb)}</li>
+                <li><span className="standout-pos">Rush</span>{formatRush(standout.rusher)}</li>
+                <li><span className="standout-pos">Rec</span>{formatRec(standout.receiver)}</li>
+                <li><span className="standout-pos">Sacks</span>{standout.sacks ? `${standout.sacks.player} (${standout.sacks.sacks})` : '—'}</li>
+                <li><span className="standout-pos">INT</span>{standout.picks ? `${standout.picks.player} (${standout.picks.picks})` : '—'}</li>
+              </ul>
+            )}
           </details>
 
           {finished ? (
@@ -305,6 +330,8 @@ const styles = `
 .watch-mode-chip.tendency-aggressive { border-color:#ff453a; color:#ffb3b0; background:rgba(255,69,58,.15); }
 .watch-mode-chip.tendency-balanced { border-color:#0a84ff; color:#a8d4ff; background:rgba(10,132,255,.12); }
 .watch-mode-chip.tendency-conservative { border-color:#34c759; color:#a3f0b8; background:rgba(52,199,89,.12); }
+.watch-mode-chip.reconstructed { border-color:#7c8db0; color:#c3d2ec; background:rgba(124,141,176,.14); }
+.standout-locked { font-size:12px; color:#93a7c9; margin:0; line-height:1.4; }
 
 /* ── Moment banner ───────────────────────────────────────────────────── */
 .watch-moment-banner { margin-top:6px; font-size:12px; font-weight:800; border-radius:8px; padding:5px 10px; }

--- a/src/ui/components/PostGameScreen.jsx
+++ b/src/ui/components/PostGameScreen.jsx
@@ -243,6 +243,9 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
   logs = [],          // play-by-play logs (presentation-only: game flow / key moments)
   playerStats = null, // CANONICAL box score { home: {[pid]:{name,pos,stats}}, away: {...} }
   teamStats = null,
+  scoringSummary = null,   // CANONICAL scoring summary (drive-level event ledger, #1700)
+  quarterScores = null,    // CANONICAL quarter scores derived from the ledger
+  canonicalEvents = null,  // CANONICAL drive-level event ledger
   gameReasoningFlags = [],
   boxScoreGameId,
   onOpenBoxScore,
@@ -317,6 +320,12 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
     const canonicalPlayerStats = hasCanonicalStats
       ? { home: playerStats.home ?? {}, away: playerStats.away ?? {} }
       : { home: {}, away: {} };
+    // Persist the CANONICAL scoring summary / quarter scores / event ledger
+    // (#1700) so the Game Book replays the exact same scoreAfter progression
+    // the live viewer showed — never the narration-derived `notableMoments`.
+    // Legacy fallback to notableMoments only when no canonical ledger exists.
+    const hasCanonicalLedger = Array.isArray(scoringSummary);
+    const archivedScoringSummary = hasCanonicalLedger ? scoringSummary : notableMoments;
     onArchiveReady({
       gameId: boxScoreGameId,
       season: null,
@@ -331,13 +340,15 @@ function PostGameScreenInner({ rawGameRecord, boxScoreGame, gameRecord,
       logs,
       playerStats: canonicalPlayerStats,
       ...(teamStats ? { teamStats } : {}),
-      scoringSummary: notableMoments,
+      scoringSummary: archivedScoringSummary,
+      ...(quarterScores ? { quarterScores } : {}),
+      ...(Array.isArray(canonicalEvents) && canonicalEvents.length ? { canonicalEvents } : {}),
       summary: {
         storyline: recapText,
         simOutputs: null,
       },
     });
-  }, [awayScore, awayTeam?.abbr, awayTeam?.id, boxScoreGameId, hasCanonicalStats, homeScore, homeTeam?.abbr, homeTeam?.id, logs, notableMoments, onArchiveReady, playerStats, strictFinalScore, teamStats, week]);
+  }, [awayScore, awayTeam?.abbr, awayTeam?.id, boxScoreGameId, canonicalEvents, hasCanonicalStats, homeScore, homeTeam?.abbr, homeTeam?.id, logs, notableMoments, onArchiveReady, playerStats, quarterScores, scoringSummary, strictFinalScore, teamStats, week]);
 
   const canOpenGameBook = Boolean(boxScoreGameId && hasStrictFinal);
 

--- a/src/ui/components/PostGameScreen.test.jsx
+++ b/src/ui/components/PostGameScreen.test.jsx
@@ -186,6 +186,56 @@ describe('PostGameScreen onArchiveReady payload', () => {
     expect(openSpy).not.toHaveBeenCalled();
   });
 
+  it('archives the CANONICAL scoring summary / quarter scores / event ledger, not narration moments (#1700)', async () => {
+    const archiveSpy = vi.fn();
+    // Narration logs that would otherwise seed a narration-derived scoring
+    // summary via notableMoments — these must NOT win over the canonical ledger.
+    const logs = [
+      { text: 'TOUCHDOWN narration', isTouchdown: true, quarter: 1 },
+      { text: 'field goal narration', quarter: 2 },
+    ];
+    const canonicalScoringSummary = [
+      { id: 'g-evt-1', quarter: 1, teamId: 1, scoreType: 'touchdown', type: 'Touchdown', points: 7, scoreAfter: { home: 7, away: 0 } },
+      { id: 'g-evt-2', quarter: 3, teamId: 2, scoreType: 'field_goal', type: 'Field Goal', points: 3, scoreAfter: { home: 7, away: 3 } },
+    ];
+    const canonicalQuarterScores = { home: [7, 0, 0, 0], away: [0, 0, 3, 0] };
+    const canonicalEvents = [
+      { eventId: 'g-evt-1', sequence: 1, quarter: 1, isScore: true, scoringTeamId: 1, points: 7, scoreAfter: { home: 7, away: 0 } },
+      { eventId: 'g-evt-2', sequence: 2, quarter: 3, isScore: true, scoringTeamId: 2, points: 3, scoreAfter: { home: 7, away: 3 } },
+    ];
+
+    await act(async () => {
+      render(
+        <PostGameScreen
+          homeTeam={{ id: 1, abbr: 'HME', name: 'Home' }}
+          awayTeam={{ id: 2, abbr: 'AWY', name: 'Away' }}
+          homeScore={7}
+          awayScore={3}
+          userTeamId={1}
+          boxScoreGameId="canonical-ledger-game"
+          logs={logs}
+          scoringSummary={canonicalScoringSummary}
+          quarterScores={canonicalQuarterScores}
+          canonicalEvents={canonicalEvents}
+          week={4}
+          onArchiveReady={archiveSpy}
+          onContinue={() => {}}
+        />,
+      );
+    });
+
+    expect(archiveSpy).toHaveBeenCalledOnce();
+    const payload = archiveSpy.mock.calls[0][0];
+    // Canonical ledger wins — not the narration notableMoments.
+    expect(payload.scoringSummary).toBe(canonicalScoringSummary);
+    expect(payload.quarterScores).toEqual(canonicalQuarterScores);
+    expect(payload.canonicalEvents).toBe(canonicalEvents);
+    // Quarter totals reconcile to the final score.
+    const total = (a) => a.reduce((x, y) => x + y, 0);
+    expect(total(payload.quarterScores.home)).toBe(7);
+    expect(total(payload.quarterScores.away)).toBe(3);
+  });
+
   it('treats a genuine 0-0 canonical result as a real tie', async () => {
     const archiveSpy = vi.fn();
     await act(async () => {

--- a/src/ui/components/Scorebug/Scorebug.jsx
+++ b/src/ui/components/Scorebug/Scorebug.jsx
@@ -20,14 +20,24 @@ function finiteScore(value) {
  */
 export default function Scorebug({ homeTeam, awayTeam, state }) {
   const possession = state?.possessionTeamId;
-  const quarter = Number(state?.quarter ?? 1);
+  const quarter = state?.quarter != null ? Number(state.quarter) : null;
   const homeScore = finiteScore(state?.score?.home);
   const awayScore = finiteScore(state?.score?.away);
   const hasScore = homeScore != null && awayScore != null;
   const fieldPosition = Number(state?.fieldPosition ?? 50);
   const inRedZone = Number.isFinite(fieldPosition) && fieldPosition >= 80;
-  const isOvertime = quarter > 4;
+  // Overtime is an explicit signal from the canonical ledger; fall back to the
+  // legacy quarter>4 heuristic only when no explicit flag is provided.
+  const isOvertime = state?.isOvertime != null ? Boolean(state.isOvertime) : (quarter != null && quarter > 4);
   const isFinal = Boolean(state?.isFinal);
+  // Honest period label: "Drive 8" / "OT" from the canonical ledger, or Q{n}
+  // for the legacy narration path. The sim owns no chronological quarter, so a
+  // bare "Q1" is never fabricated when a period label is available.
+  const periodLabel = state?.periodLabel
+    ?? (quarter != null ? `Q${quarter}` : '—');
+  const possessionAbbr = possession != null && possession === homeTeam?.id
+    ? (homeTeam?.abbr ?? null)
+    : (possession != null && possession === awayTeam?.id ? (awayTeam?.abbr ?? null) : null);
   const scoreCell = (value, teamLabel) => (
     hasScore
       ? <strong>{value}</strong>
@@ -47,7 +57,7 @@ export default function Scorebug({ homeTeam, awayTeam, state }) {
         {scoreCell(awayScore, awayTeam?.abbr || 'Away')}
       </div>
       <div className="sb-center">
-        <div>Q{quarter}{state?.progressLabel ? ` · ${state.progressLabel}` : ''}</div>
+        <div>{periodLabel}{possessionAbbr ? ` · ${possessionAbbr} possession` : (state?.progressLabel ? ` · ${state.progressLabel}` : '')}</div>
         <div>{state?.downDistance || '—'} · {state?.ballSpot || 'Ball on --'}</div>
         <div className="sb-flags">
           {isFinal ? <span className="sb-flag final">FINAL</span> : null}

--- a/src/ui/components/WeeklyResultsCenter.jsx
+++ b/src/ui/components/WeeklyResultsCenter.jsx
@@ -24,6 +24,10 @@ function normalizeTeam(team) {
 function formatPeriodLabel(game) {
   const quarterCount = Number(game?.quarterScores?.home?.length ?? game?.quarterScores?.away?.length ?? 0);
   if (quarterCount > 4) return `Final/OT${quarterCount - 4 > 1 ? quarterCount - 4 : ''}`;
+  // Canonical-ledger games publish no quarter table (#1700), so detect overtime
+  // from the honest event flag instead of a fabricated quarter count.
+  const events = Array.isArray(game?.canonicalEvents) ? game.canonicalEvents : [];
+  if (events.some((e) => e && e.isOvertime)) return 'Final/OT';
   return 'Final';
 }
 

--- a/src/ui/components/__tests__/LiveGameViewerCanonical.test.jsx
+++ b/src/ui/components/__tests__/LiveGameViewerCanonical.test.jsx
@@ -40,7 +40,7 @@ describe('LiveGameViewer — canonical event ledger', () => {
     expect(within(bug).queryByLabelText(/score shown at the final whistle/i)).toBeNull();
   });
 
-  it('scorebug shows the honest period label + possession ("Drive N · ABBR possession"), never a fabricated quarter', () => {
+  it('scorebug shows honest drive progress + possession, never a fabricated quarter', () => {
     render(
       <LiveGameViewer
         canonicalEvents={canonicalEvents}
@@ -51,10 +51,48 @@ describe('LiveGameViewer — canonical event ledger', () => {
       />,
     );
     const bug = screen.getByTestId('watch-scorebug');
-    // First canonical event is MIA's opening TD drive → "Drive 1 · MIA possession".
-    expect(within(bug).getByText(/Drive 1 · MIA possession/)).toBeTruthy();
+    // First canonical event is MIA's opening TD drive. Two regulation drives in
+    // the fixture, and the game_end marker is NOT counted (defect #4) → "of 2".
+    expect(within(bug).getByText(/Drive 1 of 2 · MIA possession/)).toBeTruthy();
     // No fabricated quarter label anywhere on the scorebug.
     expect(within(bug).queryByText(/^Q\d/)).toBeNull();
+  });
+
+  it('drive progress excludes the terminal game_end marker and shows Final at the end (defect #4)', () => {
+    render(
+      <LiveGameViewer
+        canonicalEvents={canonicalEvents}
+        homeTeam={homeTeam}
+        awayTeam={awayTeam}
+        initialMode="instant"
+        finalScore={canonicalFinal}
+      />,
+    );
+    const bug = screen.getByTestId('watch-scorebug');
+    // At the terminal marker the scorebug reads "Final", never "Drive 3 of 2".
+    expect(within(bug).getByText(/Final/)).toBeTruthy();
+    expect(within(bug).queryByText(/of 3/)).toBeNull();
+  });
+
+  it('canonical playback renders NO Run Heavy / Pass Heavy / Timeout controls (defect #2)', () => {
+    const overrideSpy = () => { throw new Error('onPlaycallOverride must never be called in canonical playback'); };
+    render(
+      <LiveGameViewer
+        canonicalEvents={canonicalEvents}
+        homeTeam={homeTeam}
+        awayTeam={awayTeam}
+        initialMode="pause"
+        finalScore={canonicalFinal}
+        onPlaycallOverride={overrideSpy}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: /Run Heavy/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Pass Heavy/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Timeout/i })).toBeNull();
+    // Preserved controls remain reachable.
+    expect(screen.getByRole('button', { name: /Slow/i })).toBeTruthy();
+    // Honest copy replaces the fake strategic agency.
+    expect(screen.getByTestId('strategy-locked-note').textContent).toMatch(/locked when simulation began/i);
   });
 
   it('shows the canonical final once complete, matching the league-recorded score', () => {

--- a/src/ui/components/__tests__/LiveGameViewerCanonical.test.jsx
+++ b/src/ui/components/__tests__/LiveGameViewerCanonical.test.jsx
@@ -1,0 +1,77 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import LiveGameViewer from '../LiveGameViewer.jsx';
+import { buildCanonicalGameEvents } from '../../../core/simulation/canonicalGameEvents.js';
+import { mapCanonicalEventsToLiveFeed } from '../../../core/liveGame/liveGameEvents.js';
+
+const homeTeam = { id: 1, abbr: 'MIA', name: 'Miami' };
+const awayTeam = { id: 0, abbr: 'BUF', name: 'Buffalo' };
+
+// Canonical ledger: MIA scores a TD (drive 1), then BUF a FG (drive 2).
+const { events: canonicalEvents } = buildCanonicalGameEvents({
+  gameId: 'g', homeId: 1, awayId: 0, homeAbbr: 'MIA', awayAbbr: 'BUF',
+  homeDriveLog: [{ result: 'TOUCHDOWN', points: 7, plays: 9, yards: 75 }],
+  awayDriveLog: [{ result: 'FIELD_GOAL', points: 3, plays: 6, yards: 42 }],
+  seed: 0, // home possesses first
+});
+const canonicalFinal = { home: 7, away: 3 };
+
+afterEach(() => cleanup());
+
+describe('LiveGameViewer — canonical event ledger', () => {
+  it('scorebug shows the canonical running scoreAfter during playback (not dashes)', () => {
+    // Pause on the first event (MIA TD) — the scorebug must read scoreAfter 7-0.
+    render(
+      <LiveGameViewer
+        canonicalEvents={canonicalEvents}
+        homeTeam={homeTeam}
+        awayTeam={awayTeam}
+        initialMode="pause"
+        finalScore={canonicalFinal}
+      />,
+    );
+    const bug = screen.getByTestId('watch-scorebug');
+    // The first canonical event is the MIA touchdown → running score 7 (home), 0 (away).
+    expect(within(bug).getByText('7')).toBeTruthy();
+    expect(within(bug).getByText('0')).toBeTruthy();
+    // No pending-dash placeholders in canonical mode.
+    expect(within(bug).queryByLabelText(/score shown at the final whistle/i)).toBeNull();
+  });
+
+  it('shows the canonical final once complete, matching the league-recorded score', () => {
+    render(
+      <LiveGameViewer
+        canonicalEvents={canonicalEvents}
+        homeTeam={homeTeam}
+        awayTeam={awayTeam}
+        initialMode="instant"
+        finalScore={canonicalFinal}
+      />,
+    );
+    const finalCard = document.querySelector('.watch-final-card');
+    expect(finalCard).toBeTruthy();
+    expect(finalCard.textContent).toContain('MIA 7');
+    expect(finalCard.textContent).toContain('BUF 3');
+  });
+
+  it('mapCanonicalEventsToLiveFeed carries scoreAfter on every event and stamps score chips only on scoring events', () => {
+    const feed = mapCanonicalEventsToLiveFeed(canonicalEvents, { gameId: 'g' });
+    // Every feed event carries a trustworthy running score.
+    feed.forEach((e) => {
+      expect(e.scoreAfter).toBeTruthy();
+      expect(Number.isFinite(e.scoreAfter.home)).toBe(true);
+    });
+    // Score chip present on scoring events + final, absent on the (empty) rest.
+    const chipped = feed.filter((e) => e.score);
+    expect(chipped.length).toBeGreaterThanOrEqual(2); // two scores + game_end
+    // Monotonic running score.
+    let prevHome = 0;
+    feed.forEach((e) => {
+      expect(e.scoreAfter.home).toBeGreaterThanOrEqual(prevHome);
+      prevHome = e.scoreAfter.home;
+    });
+    expect(feed[feed.length - 1].scoreAfter).toEqual(canonicalFinal);
+  });
+});

--- a/src/ui/components/__tests__/LiveGameViewerCanonical.test.jsx
+++ b/src/ui/components/__tests__/LiveGameViewerCanonical.test.jsx
@@ -40,6 +40,23 @@ describe('LiveGameViewer — canonical event ledger', () => {
     expect(within(bug).queryByLabelText(/score shown at the final whistle/i)).toBeNull();
   });
 
+  it('scorebug shows the honest period label + possession ("Drive N · ABBR possession"), never a fabricated quarter', () => {
+    render(
+      <LiveGameViewer
+        canonicalEvents={canonicalEvents}
+        homeTeam={homeTeam}
+        awayTeam={awayTeam}
+        initialMode="pause"
+        finalScore={canonicalFinal}
+      />,
+    );
+    const bug = screen.getByTestId('watch-scorebug');
+    // First canonical event is MIA's opening TD drive → "Drive 1 · MIA possession".
+    expect(within(bug).getByText(/Drive 1 · MIA possession/)).toBeTruthy();
+    // No fabricated quarter label anywhere on the scorebug.
+    expect(within(bug).queryByText(/^Q\d/)).toBeNull();
+  });
+
   it('shows the canonical final once complete, matching the league-recorded score', () => {
     render(
       <LiveGameViewer

--- a/src/ui/components/__tests__/LiveGameViewerCanonical.test.jsx
+++ b/src/ui/components/__tests__/LiveGameViewerCanonical.test.jsx
@@ -74,6 +74,68 @@ describe('LiveGameViewer — canonical event ledger', () => {
     expect(within(bug).queryByText(/of 3/)).toBeNull();
   });
 
+  it('labels the intermediate progression honestly with a "Reconstructed order" chip during playback (post-review point 2)', () => {
+    // Mid-game (paused): the reconstruction is disclosed.
+    const { unmount } = render(
+      <LiveGameViewer
+        canonicalEvents={canonicalEvents}
+        homeTeam={homeTeam}
+        awayTeam={awayTeam}
+        initialMode="pause"
+        finalScore={canonicalFinal}
+      />,
+    );
+    expect(screen.getByTestId('reconstructed-order-chip').textContent).toMatch(/Reconstructed order/i);
+    unmount();
+
+    // At the final whistle the chip disappears (the final IS official).
+    render(
+      <LiveGameViewer
+        canonicalEvents={canonicalEvents}
+        homeTeam={homeTeam}
+        awayTeam={awayTeam}
+        initialMode="instant"
+        finalScore={canonicalFinal}
+      />,
+    );
+    expect(screen.queryByTestId('reconstructed-order-chip')).toBeNull();
+  });
+
+  it('hides final box-score Standouts until the final whistle (post-review point 3)', () => {
+    const playerStats = {
+      home: { qb: { name: 'Home QB', pos: 'QB', stats: { passAtt: 30, passComp: 20, passYd: 260, passTD: 2 } } },
+      away: {},
+    };
+    // Paused mid-game: standouts are locked, the QB's final line is NOT shown.
+    const { unmount } = render(
+      <LiveGameViewer
+        canonicalEvents={canonicalEvents}
+        playerStats={playerStats}
+        homeTeam={homeTeam}
+        awayTeam={awayTeam}
+        initialMode="pause"
+        finalScore={canonicalFinal}
+      />,
+    );
+    expect(screen.getByTestId('standouts-locked').textContent).toMatch(/unlock at the final whistle/i);
+    expect(screen.queryByText(/260y/)).toBeNull();
+    unmount();
+
+    // At the final whistle the standouts appear.
+    render(
+      <LiveGameViewer
+        canonicalEvents={canonicalEvents}
+        playerStats={playerStats}
+        homeTeam={homeTeam}
+        awayTeam={awayTeam}
+        initialMode="instant"
+        finalScore={canonicalFinal}
+      />,
+    );
+    expect(screen.queryByTestId('standouts-locked')).toBeNull();
+    expect(screen.getByText(/260y/)).toBeTruthy();
+  });
+
   it('canonical playback renders NO Run Heavy / Pass Heavy / Timeout controls (defect #2)', () => {
     const overrideSpy = () => { throw new Error('onPlaycallOverride must never be called in canonical playback'); };
     render(

--- a/src/ui/components/__tests__/LiveGameViewerTrust.test.jsx
+++ b/src/ui/components/__tests__/LiveGameViewerTrust.test.jsx
@@ -113,10 +113,15 @@ describe('LiveGameViewer — compact mobile controls', () => {
     expect(within(skipMenu).getByRole('button', { name: /Next Score/i })).toBeTruthy();
   });
 
-  it('keeps playcall overrides available when the hook is provided', () => {
+  it('never renders play-call controls that claim strategic agency (#1700 review defect #2)', () => {
+    // The watched game is fully simulated before playback, so Run Heavy / Pass
+    // Heavy / Timeout could not affect the result on any path. They are removed
+    // (not merely hidden) and onPlaycallOverride is never invoked.
     const onPlaycallOverride = vi.fn();
     renderViewer({ onPlaycallOverride });
-    fireEvent.click(screen.getByRole('button', { name: /Run Heavy/i }));
-    expect(onPlaycallOverride).toHaveBeenCalledWith({ type: 'run_heavy' });
+    expect(screen.queryByRole('button', { name: /Run Heavy/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Pass Heavy/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Timeout/i })).toBeNull();
+    expect(onPlaycallOverride).not.toHaveBeenCalled();
   });
 });

--- a/src/ui/components/__tests__/gameBookMobileDensity.test.jsx
+++ b/src/ui/components/__tests__/gameBookMobileDensity.test.jsx
@@ -113,6 +113,42 @@ describe('Game Book mobile density — section hierarchy', () => {
     expect(isBefore(hero, playerStats)).toBe(true);
   });
 
+  it('for a canonical-ledger game: shows the honest quarter-unavailable note, uses periodLabel, and never a fabricated Q1–Q4 (#1700 review defect #1)', () => {
+    const canonicalGame = {
+      gameId: 'g-canon',
+      homeId: 1,
+      awayId: 2,
+      homeScore: 10,
+      awayScore: 7,
+      // Canonical ledger present, no quarter table, scoring rows carry periodLabel.
+      canonicalEvents: [
+        { eventId: 'g-evt-1', sequence: 1, isScore: true, scoringTeamId: 1, periodLabel: 'Drive 2', quarter: null, scoreAfter: { home: 7, away: 0 } },
+        { eventId: 'g-evt-2', sequence: 2, isScore: true, scoringTeamId: 2, periodLabel: 'Drive 5', quarter: null, scoreAfter: { home: 7, away: 7 } },
+      ],
+      quarterScores: null,
+      scoringSummary: [
+        { id: 'g-evt-1', quarter: null, periodLabel: 'Drive 2', teamAbbr: 'HME', type: 'Touchdown', description: 'HME Touchdown', scoreAfter: { home: 7, away: 0 } },
+        { id: 'g-evt-2', quarter: null, periodLabel: 'Drive 5', teamAbbr: 'AWY', type: 'Touchdown', description: 'AWY Touchdown', scoreAfter: { home: 7, away: 7 } },
+      ],
+    };
+    const { getByTestId } = render(
+      <BoxScore gameId="g-canon" league={{ ...league, gameById: { 'g-canon': canonicalGame } }} embedded />,
+    );
+    // Honest note appears; final score + canonical scoring summary still render.
+    expect(getByTestId('game-book-quarter-unavailable').textContent).toMatch(/Quarter breakdown unavailable/i);
+    const summary = getByTestId('game-book-scoring-summary');
+    expect(summary.textContent).toContain('Drive 2');
+    expect(summary.textContent).toContain('Drive 5');
+    // No fabricated quarter label anywhere in the scoring summary.
+    expect(summary.textContent).not.toMatch(/Q[1-4]\b/);
+  });
+
+  it('legacy game with quarter numbers does NOT show the canonical unavailable note', () => {
+    // richGame has no canonicalEvents → legacy path, note suppressed.
+    const { queryByTestId } = renderRichBoxScore();
+    expect(queryByTestId('game-book-quarter-unavailable')).toBeNull();
+  });
+
   it('renders key leaders above the full player stat tables', () => {
     const { getByTestId } = renderRichBoxScore();
     const leaders = getByTestId('game-book-leaders');

--- a/src/ui/hooks/useWorker.js
+++ b/src/ui/hooks/useWorker.js
@@ -74,6 +74,9 @@ export const INITIAL_WORKER_STATE = {
   userGameLiveStats: null,
   userGamePlayerStats: null,
   userGameTeamStats: null,
+  userGameCanonicalEvents: null,
+  userGameScoringSummary: null,
+  userGameQuarterScores: null,
   userGameReasoningFlags: null,
   lastWorkerMessageType: null,
 };
@@ -149,13 +152,13 @@ export function workerReducer(state, action) {
     case 'PROMPT_USER_GAME':
       return { ...state, busy: false, simulating: false, simProgress: 0, promptUserGame: true, userGameLogs: null };
     case 'PLAY_LOGS':
-      return { ...state, busy: false, simulating: false, promptUserGame: false, userGameLogs: action.logs, userGameLiveStats: action.liveStats || null, userGamePlayerStats: action.playerStats || null, userGameTeamStats: action.teamStats || null, userGameReasoningFlags: action.gameReasoningFlags || [] };
+      return { ...state, busy: false, simulating: false, promptUserGame: false, userGameLogs: action.logs, userGameLiveStats: action.liveStats || null, userGamePlayerStats: action.playerStats || null, userGameTeamStats: action.teamStats || null, userGameCanonicalEvents: Array.isArray(action.canonicalEvents) ? action.canonicalEvents : null, userGameScoringSummary: Array.isArray(action.scoringSummary) ? action.scoringSummary : null, userGameQuarterScores: action.quarterScores || null, userGameReasoningFlags: action.gameReasoningFlags || [] };
     case 'CLEAR_USER_GAME':
-      return { ...state, promptUserGame: false, userGameLogs: null, userGameLiveStats: null, userGamePlayerStats: null, userGameTeamStats: null, userGameReasoningFlags: null };
+      return { ...state, promptUserGame: false, userGameLogs: null, userGameLiveStats: null, userGamePlayerStats: null, userGameTeamStats: null, userGameCanonicalEvents: null, userGameScoringSummary: null, userGameQuarterScores: null, userGameReasoningFlags: null };
     case 'CLEAR_RESULTS':
       return { ...state, lastResults: [], lastSimWeek: null, gameEvents: [] };
     case 'SIM_START':
-      return { ...state, simulating: true, simProgress: 0, gameEvents: [], promptUserGame: false, userGameLogs: null, userGamePlayerStats: null, userGameTeamStats: null, userGameReasoningFlags: null };
+      return { ...state, simulating: true, simProgress: 0, gameEvents: [], promptUserGame: false, userGameLogs: null, userGamePlayerStats: null, userGameTeamStats: null, userGameCanonicalEvents: null, userGameScoringSummary: null, userGameQuarterScores: null, userGameReasoningFlags: null };
     case 'BATCH_SIM_START':
       return { ...state, busy: true, batchSim: { currentWeek: 0, phase: '', targetPhase: action.targetPhase, status: 'running' } };
     case 'BATCH_SIM_PROGRESS':

--- a/src/ui/styles/style.css
+++ b/src/ui/styles/style.css
@@ -8394,6 +8394,13 @@ details[open] .nav-summary::after {
   flex: 1;
 }
 
+.bs-sheet-quarter-unavailable {
+  font-size: 12px;
+  color: var(--text-muted, #98a7c0);
+  padding: 6px 2px;
+  font-style: italic;
+}
+
 /* ── Collapsed dense sections (scoring summary, team stats, player stats,
    play-by-play) — native <details>/<summary>, mirrors the Weekly Prep
    Matchup Intel pattern so dense content stays out of the first viewport. */

--- a/src/ui/utils/__tests__/liveGameStandouts.test.js
+++ b/src/ui/utils/__tests__/liveGameStandouts.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { deriveStandoutsFromBoxScore } from '../liveGameStandouts.js';
+
+describe('deriveStandoutsFromBoxScore — sack semantics (#1700 review defect #3)', () => {
+  // Review fixture: QB with 5 sacks TAKEN, EDGE with 1 sack MADE.
+  const playerStats = {
+    home: { qb: { name: 'Sacked QB', pos: 'QB', stats: { passAtt: 32, passComp: 20, passYd: 240, sacks: 5 } } },
+    away: { edge: { name: 'Edge Rusher', pos: 'EDGE', stats: { passAtt: 0, sacks: 1, tackles: 3 } } },
+  };
+
+  it('shows the EDGE (defensive sacks) under Sacks, never the QB (sacks taken)', () => {
+    const standouts = deriveStandoutsFromBoxScore(playerStats);
+    expect(standouts.sacks).toBeTruthy();
+    expect(standouts.sacks.player).toMatch(/Rusher/);
+    expect(standouts.sacks.sacks).toBe(1);
+  });
+
+  it('does not surface a QB as the Sacks standout even when it has the highest raw sacks field', () => {
+    const qbOnly = {
+      home: { qb: { name: 'Only QB', pos: 'QB', stats: { passAtt: 30, sacks: 7 } } },
+      away: {},
+    };
+    const standouts = deriveStandoutsFromBoxScore(qbOnly);
+    // No genuine defensive sack production → no Sacks standout.
+    expect(standouts.sacks).toBeNull();
+  });
+
+  it('still surfaces genuine defender sacks', () => {
+    const standouts = deriveStandoutsFromBoxScore({
+      home: { dl: { name: 'Real Sacker', pos: 'DL', stats: { passAtt: 0, sacks: 2 } } },
+      away: {},
+    });
+    expect(standouts.sacks?.player).toMatch(/Sacker/);
+    expect(standouts.sacks?.sacks).toBe(2);
+  });
+});

--- a/src/ui/utils/boxScorePresentation.js
+++ b/src/ui/utils/boxScorePresentation.js
@@ -172,6 +172,11 @@ export function deriveQuarterScores(game, logs = []) {
     };
   }
 
+  // #1700 review defect #1: a canonical-ledger game owns no chronological
+  // quarters, so NEVER reconstruct a fabricated quarter table from the narration
+  // stream. Return the honest "unavailable" shape and let the UI say so.
+  if (Array.isArray(game?.canonicalEvents) && game.canonicalEvents.length) return fallback;
+
   if (!logs.length) return fallback;
 
   const maxQuarter = Math.max(4, ...logs.map((log) => Number(log?.quarter ?? 1)));

--- a/src/ui/utils/boxScorePresentation.test.js
+++ b/src/ui/utils/boxScorePresentation.test.js
@@ -23,6 +23,28 @@ describe('box score presentation fallback', () => {
     expect(out.home[3]).toBe(1);
   });
 
+  it('NEVER reconstructs a fabricated quarter table from narration for a canonical-ledger game (#1700 review defect #1)', () => {
+    const game = {
+      homeId: 1, awayId: 2,
+      // Presence of a canonical ledger means the sim owns no chronological
+      // quarters — the narration logs must not be used to fabricate a table.
+      canonicalEvents: [{ eventId: 'g-evt-1', isScore: true, scoreAfter: { home: 7, away: 0 } }],
+    };
+    const logs = [
+      { quarter: 1, teamId: 2, text: 'Field goal', points: 3 },
+      { quarter: 2, teamId: 1, isTouchdown: true, points: 6 },
+    ];
+    const out = deriveQuarterScores(game, logs);
+    expect(out).toEqual({ home: [null, null, null, null], away: [null, null, null, null] });
+  });
+
+  it('still displays genuine stored quarter data for legacy archives', () => {
+    const game = { homeId: 1, awayId: 2, quarterScores: { home: [7, 0, 3, 0], away: [0, 7, 0, 3] } };
+    const out = deriveQuarterScores(game, []);
+    expect(out.home).toEqual([7, 0, 3, 0]);
+    expect(out.away).toEqual([0, 7, 0, 3]);
+  });
+
   it('renders scoring summary entries from partial logs', () => {
     const rows = deriveScoringSummary([{ quarter: 3, clock: '2:11', text: 'Touchdown pass', teamId: 2 }], { 2: { abbr: 'BUF' } });
     expect(rows).toHaveLength(1);

--- a/src/ui/utils/boxScoreViewModel.js
+++ b/src/ui/utils/boxScoreViewModel.js
@@ -242,6 +242,10 @@ function normalizeScoringSummary(rows) {
   return rows.map((row, idx) => ({
     id: row?.id ?? `score-${idx}`,
     quarter: row?.quarter ?? row?.period ?? null,
+    // Honest period label from the canonical ledger ("Drive 8" / "OT"). The sim
+    // owns no chronological quarter, so this — not a fabricated Q{n} — is what
+    // the Game Book shows for canonical games.
+    periodLabel: row?.periodLabel ?? null,
     time: row?.time ?? row?.clock ?? null,
     teamAbbr: row?.teamAbbr ?? row?.team ?? null,
     type: row?.type ?? row?.scoreType ?? null,
@@ -513,6 +517,10 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
 
   const hasScore = homeScore != null && awayScore != null;
   const hasQuarter = Array.isArray(quarterScores?.home) || Array.isArray(quarterScores?.away);
+  // A canonical-ledger game (#1700) owns no chronological quarters, so it never
+  // has a quarter table; the Game Book shows an honest "unavailable" note only
+  // for these games (legacy archives without a ledger keep their old behavior).
+  const isCanonicalLedger = Array.isArray(payload?.canonicalEvents) && payload.canonicalEvents.length > 0;
   const hasTeamTotals = hasValues(teamStats?.home) || hasValues(teamStats?.away);
   const hasPlayerStats = homePlayers.length > 0 || awayPlayers.length > 0;
   const hasScoringSummary = scoringSummary.length > 0;
@@ -578,6 +586,7 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
     winnerSide,
     margin: hasScore ? Math.abs(homeScore - awayScore) : null,
     quarterScores,
+    isCanonicalLedger,
     teamTotals,
     teamComparisonRows: buildTeamComparisonRows(teamTotals),
     specialTeams,

--- a/src/ui/utils/canonicalCompletedGame.js
+++ b/src/ui/utils/canonicalCompletedGame.js
@@ -6,7 +6,12 @@ import { readStrictFinalScore } from '../../core/gameArchive.js';
  * Archive-first canonical resolution for any completed-game display surface.
  *
  * Priority rule:
- *  1. archivedGame with valid final score wins absolutely for homeScore/awayScore.
+ *  1. an archive with a valid final score wins absolutely for homeScore/awayScore.
+ *     Two archive sources are accepted: `archivedGame` (async worker response)
+ *     and `localArchivedGame` (the synchronous localStorage postgame archive
+ *     written by PostGameScreen). Whichever carries a valid final is used; this
+ *     lets the Game Book open the just-watched game immediately, without waiting
+ *     on — or racing — the async worker fetch.
  *  2. scheduleGame fills only missing metadata (abbr, week, ids); never overrides archived scores.
  *  3. league.gameById[gameId] is last resort with the same merge rules.
  *
@@ -22,8 +27,13 @@ function hasValidFinalScore(game) {
   return readStrictFinalScore(game) != null;
 }
 
-export function resolveCanonicalCompletedGame({ league, gameId, scheduleGame, archivedGame } = {}) {
-  const archived = archivedGame ?? null;
+export function resolveCanonicalCompletedGame({ league, gameId, scheduleGame, archivedGame, localArchivedGame } = {}) {
+  // Prefer whichever archive source actually carries a valid final. The async
+  // worker response (`archivedGame`) and the synchronous localStorage archive
+  // (`localArchivedGame`) are interchangeable here; using either eliminates the
+  // watch→Game Book race where the worker fetch had not yet resolved.
+  const archiveCandidates = [archivedGame, localArchivedGame].filter(Boolean);
+  const archived = archiveCandidates.find(hasValidFinalScore) ?? archiveCandidates[0] ?? null;
   const schedule = scheduleGame ?? null;
   const byId = (gameId != null && league?.gameById)
     ? (league.gameById[String(gameId)] ?? null)

--- a/src/ui/utils/canonicalCompletedGame.test.js
+++ b/src/ui/utils/canonicalCompletedGame.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { resolveCanonicalCompletedGame } from './canonicalCompletedGame.js';
+
+const gid = 's2026_w1_1_2';
+
+describe('resolveCanonicalCompletedGame — archive sources', () => {
+  it('resolves from the async worker archive when it carries a valid final', () => {
+    const out = resolveCanonicalCompletedGame({
+      gameId: gid,
+      archivedGame: { gameId: gid, homeId: 1, awayId: 2, score: { home: 24, away: 17 }, homeAbbr: 'HME', awayAbbr: 'AWY' },
+    });
+    expect(out.homeScore).toBe(24);
+    expect(out.awayScore).toBe(17);
+    expect(out.played).toBe(true);
+  });
+
+  it('falls back to the SYNCHRONOUS localStorage archive when the async fetch has no final yet (#1700 watch→Game Book race fix)', () => {
+    // Simulate the race: the async worker response has not resolved a final, but
+    // PostGameScreen already wrote the postgame archive synchronously.
+    const out = resolveCanonicalCompletedGame({
+      gameId: gid,
+      archivedGame: null,
+      localArchivedGame: { gameId: gid, homeId: 1, awayId: 2, score: { home: 31, away: 20 }, homeAbbr: 'HME', awayAbbr: 'AWY' },
+    });
+    expect(out.homeScore).toBe(31);
+    expect(out.awayScore).toBe(20);
+    expect(out.played).toBe(true);
+  });
+
+  it('prefers whichever archive source actually carries a valid final', () => {
+    const out = resolveCanonicalCompletedGame({
+      gameId: gid,
+      // Worker response present but WITHOUT a usable final; local archive has it.
+      archivedGame: { gameId: gid, homeId: 1, awayId: 2 },
+      localArchivedGame: { gameId: gid, homeId: 1, awayId: 2, score: { home: 10, away: 7 } },
+    });
+    expect(out.homeScore).toBe(10);
+    expect(out.awayScore).toBe(7);
+  });
+
+  it('returns null when no source has any reference', () => {
+    expect(resolveCanonicalCompletedGame({ gameId: gid })).toBeNull();
+  });
+});

--- a/src/ui/utils/liveGameStandouts.js
+++ b/src/ui/utils/liveGameStandouts.js
@@ -1,0 +1,88 @@
+/*
+ * Live "Standouts" (game leaders) derived from the CANONICAL box score.
+ *
+ * The watched-game viewer used to derive its live standouts by re-accumulating
+ * the narration play stream. Per #1698/#1699 the canonical player box score is
+ * the single leader authority, and #1700 forbids the narration layer from
+ * owning leaders. So in canonical mode the viewer reads game leaders straight
+ * from the same box score PostGameScreen Leaders use. Drive-level playback has
+ * no per-play progression, so these are the game's real totals (fully accurate
+ * at the final whistle); they are never fabricated.
+ */
+
+function num(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function shortName(row) {
+  const raw = String(row?.name ?? '').trim();
+  if (!raw) {
+    const pos = row?.pos || '';
+    return pos ? `${pos}` : 'Player';
+  }
+  const parts = raw.split(/\s+/);
+  return parts.length >= 2 ? `${parts[0][0]}. ${parts[parts.length - 1]}` : raw;
+}
+
+function rowsOf(side) {
+  if (!side || typeof side !== 'object') return [];
+  return Object.values(side).map((row) => ({
+    name: row?.name,
+    pos: row?.pos,
+    stats: row?.stats ?? row ?? {},
+  }));
+}
+
+function topBy(rows, statKey, minValue = 1) {
+  let best = null;
+  for (const row of rows) {
+    const v = num(row.stats?.[statKey]);
+    if (v < minValue) continue;
+    if (!best || v > num(best.stats?.[statKey])) best = row;
+  }
+  return best;
+}
+
+/**
+ * @param {{home?:Object, away?:Object}} playerStats canonical box score
+ * @returns {{qb, rusher, receiver, sacks, picks}} in the shape the viewer renders
+ */
+export function deriveStandoutsFromBoxScore(playerStats) {
+  const rows = [...rowsOf(playerStats?.home), ...rowsOf(playerStats?.away)];
+  if (!rows.length) return { qb: null, rusher: null, receiver: null, sacks: null, picks: null };
+
+  const qbRow = topBy(rows, 'passYd', 1);
+  const rushRow = topBy(rows, 'rushYd', 1);
+  const recRow = topBy(rows, 'recYd', 1);
+  const sackRow = topBy(rows, 'sacks', 1);
+  // Defensive interceptions only (a passer's `interceptions` are thrown, not
+  // takeaways) — mirror the postgame defensive-leader policy.
+  const pickRow = rows
+    .filter((r) => num(r.stats?.passAtt) === 0 && num(r.stats?.interceptions) >= 1)
+    .sort((a, b) => num(b.stats?.interceptions) - num(a.stats?.interceptions))[0] || null;
+
+  return {
+    qb: qbRow ? {
+      player: shortName(qbRow),
+      yds: num(qbRow.stats?.passYd),
+      td: num(qbRow.stats?.passTD),
+      att: num(qbRow.stats?.passAtt),
+      comp: num(qbRow.stats?.passComp),
+    } : null,
+    rusher: rushRow ? {
+      player: shortName(rushRow),
+      yds: num(rushRow.stats?.rushYd),
+      att: num(rushRow.stats?.rushAtt),
+      td: num(rushRow.stats?.rushTD),
+    } : null,
+    receiver: recRow ? {
+      player: shortName(recRow),
+      yds: num(recRow.stats?.recYd),
+      rec: num(recRow.stats?.receptions ?? recRow.stats?.rec),
+      td: num(recRow.stats?.recTD),
+    } : null,
+    sacks: sackRow ? { player: shortName(sackRow), sacks: num(sackRow.stats?.sacks) } : null,
+    picks: pickRow ? { player: shortName(pickRow), picks: num(pickRow.stats?.interceptions) } : null,
+  };
+}

--- a/src/ui/utils/liveGameStandouts.js
+++ b/src/ui/utils/liveGameStandouts.js
@@ -10,6 +10,8 @@
  * at the final whistle); they are never fabricated.
  */
 
+import { defensiveSacks } from '../../core/gameSummary.js';
+
 function num(value) {
   const n = Number(value);
   return Number.isFinite(n) ? n : 0;
@@ -55,7 +57,11 @@ export function deriveStandoutsFromBoxScore(playerStats) {
   const qbRow = topBy(rows, 'passYd', 1);
   const rushRow = topBy(rows, 'rushYd', 1);
   const recRow = topBy(rows, 'recYd', 1);
-  const sackRow = topBy(rows, 'sacks', 1);
+  // Defensive sacks only — a QB's `sacks` field is sacks TAKEN, never defensive
+  // production. Uses the shared semantic helper so leaders and standouts agree.
+  const sackRow = rows
+    .filter((r) => defensiveSacks(r) >= 1)
+    .sort((a, b) => defensiveSacks(b) - defensiveSacks(a))[0] || null;
   // Defensive interceptions only (a passer's `interceptions` are thrown, not
   // takeaways) — mirror the postgame defensive-leader policy.
   const pickRow = rows
@@ -82,7 +88,7 @@ export function deriveStandoutsFromBoxScore(playerStats) {
       rec: num(recRow.stats?.receptions ?? recRow.stats?.rec),
       td: num(recRow.stats?.recTD),
     } : null,
-    sacks: sackRow ? { player: shortName(sackRow), sacks: num(sackRow.stats?.sacks) } : null,
+    sacks: sackRow ? { player: shortName(sackRow), sacks: defensiveSacks(sackRow) } : null,
     picks: pickRow ? { player: shortName(pickRow), picks: num(pickRow.stats?.interceptions) } : null,
   };
 }

--- a/src/worker/__tests__/workerApi.test.js
+++ b/src/worker/__tests__/workerApi.test.js
@@ -51,6 +51,26 @@ describe('handleWorkerMessage routing', () => {
     expect(setState).toHaveBeenCalledWith(expect.objectContaining({ type: 'WEEK_COMPLETE', week: 4, nextWeek: 5 }));
   });
 
+  it('forwards the canonical event ledger fields on a PLAY_LOGS message (#1700)', () => {
+    // Regression: workerApi previously dropped canonicalEvents/scoringSummary/
+    // quarterScores, so the live scorebug never received the canonical ledger.
+    const setState = vi.fn();
+    const canonicalEvents = [{ eventId: 'g-evt-1', sequence: 1, isScore: true, scoreAfter: { home: 7, away: 0 } }];
+    const scoringSummary = [{ id: 'g-evt-1', quarter: 1, teamId: 1, points: 7 }];
+    const quarterScores = { home: [7, 0, 0, 0], away: [0, 0, 0, 0] };
+    const handled = handleWorkerMessage(
+      { type: toUI.PLAY_LOGS, payload: { logs: [], liveStats: {}, playerStats: {}, teamStats: {}, canonicalEvents, scoringSummary, quarterScores, gameReasoningFlags: [] } },
+      setState,
+    );
+    expect(handled).toBe(true);
+    expect(setState).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'PLAY_LOGS',
+      canonicalEvents,
+      scoringSummary,
+      quarterScores,
+    }));
+  });
+
   it('returns false for stateful messages it intentionally leaves to the hook', () => {
     const setState = vi.fn();
     expect(handleWorkerMessage({ type: toUI.FULL_STATE, payload: {} }, setState)).toBe(false);

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -4974,6 +4974,10 @@ function applyGameResultToCache(result, week, seasonId) {
     drives: result.driveSummary ?? result.drives ?? driveSummary ?? null,
     quarterScores: result.quarterScores ?? result.linescore ?? null,
     scoringSummary,
+    // Canonical drive-level event ledger (#1700). Persisted so the Game Book
+    // replays the same scoreAfter progression the live viewer showed — never
+    // regenerated from narration on reload.
+    canonicalEvents: Array.isArray(result.canonicalEvents) ? result.canonicalEvents : [],
     driveSummary,
     playLog: playLogs,
     summary: {
@@ -14530,6 +14534,12 @@ async function handleWatchGame(payload, id) {
       // than the play-by-play's randomized QB rotation.
       playerStats: res.boxScore ? { home: res.boxScore.home ?? {}, away: res.boxScore.away ?? {} } : null,
       teamStats: res.teamStats ?? null,
+      // Canonical drive-level event ledger (#1700) — the live scorebug steps
+      // through its scoreAfter progression and the feed renders its drive cards.
+      // This is the same ledger the archive/Game Book persists.
+      canonicalEvents: Array.isArray(res.canonicalEvents) ? res.canonicalEvents : [],
+      scoringSummary: Array.isArray(res.scoringSummary) ? res.scoringSummary : [],
+      quarterScores: res.quarterScores ?? null,
       gameReasoningFlags: Array.isArray(res.gameReasoningFlags) ? res.gameReasoningFlags : [],
     }, id);
 

--- a/src/worker/workerApi.js
+++ b/src/worker/workerApi.js
@@ -99,6 +99,11 @@ export function handleWorkerMessage(msg, setState) {
         liveStats: payload.liveStats,
         playerStats: payload.playerStats,
         teamStats: payload.teamStats,
+        // Canonical drive-level event ledger (#1700) + its derived scoring
+        // surfaces — feed the live scorebug/feed and the postgame archive.
+        canonicalEvents: payload.canonicalEvents,
+        scoringSummary: payload.scoringSummary,
+        quarterScores: payload.quarterScores,
         gameReasoningFlags: payload.gameReasoningFlags,
       });
       return true;

--- a/tests/e2e/fresh_franchise_first_week_smoke.spec.js
+++ b/tests/e2e/fresh_franchise_first_week_smoke.spec.js
@@ -128,8 +128,13 @@ test('fresh franchise first week smoke', async ({ page, context }) => {
   if (await gateAdvanceBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
     await gateAdvanceBtn.click();
   }
+  // The Simulate (Skip) prompt is REQUIRED in this flow (fresh franchise, the
+  // user always has a Week 1 game). Assert it appears and is clickable rather
+  // than swallowing a missing button — a vanished prompt is a real defect.
   const skipPrompt = page.getByRole('button', { name: /Simulate \(Skip\)/i });
-  await skipPrompt.click({ timeout: 10000 }).catch(() => {});
+  await expect(skipPrompt).toBeVisible({ timeout: 10000 });
+  await expect(skipPrompt).toBeEnabled();
+  await skipPrompt.click();
   await page.waitForFunction(
     (baseline) => {
       const state = window?.state;

--- a/tests/e2e/helpers/franchise.js
+++ b/tests/e2e/helpers/franchise.js
@@ -214,10 +214,12 @@ export async function simulateSingleWeek(page, options = {}) {
         window.localStorage.setItem(PREP_KEY, JSON.stringify(stored));
       } catch (_e) { /* non-fatal */ }
     });
-    // Wait for the button to become enabled if it's rendered
+    // Let the readiness state settle if the CTA is rendered. This is a probe,
+    // not an assertion: readiness may still be gated (that is exactly what the
+    // "Advance anyway" branch below exists to bypass), so we must not fail here.
     const advanceCta = page.getByTestId('advance-week-cta');
     if (await advanceCta.isVisible().catch(() => false)) {
-      await expect(advanceCta).toBeEnabled({ timeout: 5000 }).catch(() => {});
+      await advanceCta.isEnabled().catch(() => false);
     }
   }
 
@@ -231,10 +233,24 @@ export async function simulateSingleWeek(page, options = {}) {
       else if (window.handleGlobalAdvance) window.handleGlobalAdvance();
     });
   }
+  // The advance flow can present two dialogs in order: an optional readiness
+  // gate ("Advance anyway"), then the user-game prompt ("Simulate (Skip)").
+  // Each is handled with an explicit visibility probe — but once we commit to a
+  // branch, the button's enabled state is asserted and the click is NOT
+  // swallowed. A missing button that WAS visible then fails loudly; the final
+  // week-advance assertion below guarantees the transition actually happened.
   if (advanceAnyway) {
-    await page.getByRole('button', { name: /Advance anyway/i }).click({ timeout: 1000 }).catch(() => {});
+    const advanceAnywayBtn = page.getByRole('button', { name: /Advance anyway/i });
+    if (await advanceAnywayBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await expect(advanceAnywayBtn).toBeEnabled({ timeout: 5000 });
+      await advanceAnywayBtn.click();
+    }
   }
-  await page.getByRole('button', { name: /Simulate \(Skip\)/i }).click({ timeout: 10000 }).catch(() => {});
+  const skipPromptBtn = page.getByRole('button', { name: /Simulate \(Skip\)/i });
+  if (await skipPromptBtn.isVisible({ timeout: 10000 }).catch(() => false)) {
+    await expect(skipPromptBtn).toBeEnabled({ timeout: 5000 });
+    await skipPromptBtn.click();
+  }
   await page.waitForFunction(
     (baseline) => {
       const week = window?.state?.league?.week ?? baseline;

--- a/tests/e2e/mobile_game_day_trust.spec.js
+++ b/tests/e2e/mobile_game_day_trust.spec.js
@@ -59,11 +59,23 @@ test.describe('Mobile game-day trust loop', () => {
     });
     expect(canonical).not.toBeNull();
 
-    // During playback the scorebug never shows a numeric score that could
-    // contradict the recorded final.
+    // During playback the scorebug shows the CANONICAL running score — the
+    // scoreAfter values from the drive-level event ledger (#1700). It must be
+    // numeric (no pending dashes) and must never exceed the league-recorded
+    // final, proving it is derived from canonical scoreAfter and never from a
+    // contradicting narration score.
     const bug = page.getByTestId('watch-scorebug');
     await expect(bug).toBeVisible();
-    await expect(bug.locator('.sb-score-pending')).toHaveCount(2);
+    await expect(bug.locator('.sb-score-pending')).toHaveCount(0);
+    const liveScores = await bug.locator('.sb-team strong').allTextContents();
+    const liveNums = liveScores.map((t) => parseInt(t.trim(), 10)).filter((n) => Number.isFinite(n));
+    expect(liveNums.length).toBe(2);
+    // Scorebug DOM order is away, then home.
+    const [liveAway, liveHome] = liveNums;
+    expect(liveHome).toBeGreaterThanOrEqual(0);
+    expect(liveHome).toBeLessThanOrEqual(canonical.home);
+    expect(liveAway).toBeGreaterThanOrEqual(0);
+    expect(liveAway).toBeLessThanOrEqual(canonical.away);
 
     // No horizontal overflow, and the compact control tray is on-screen.
     const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);


### PR DESCRIPTION
The watched-game event stream was the last narration-owned factual surface:
the official final score came from the drive engine, but the scoring summary and
the live scorebug were derived from an independent narration stream that could
describe a different game.

Build ONE canonical drive-level event ledger (Lane B) from the same drive
engine that owns the final score, and make every factual surface consume it.

## Engine
- `driveEngine.buildDriveBasedSummary` emits an ordered per-drive outcome log
  per team (plays/yards/result/points), recorded from already-drawn values so
  the seeded score is byte-for-byte unchanged (zero extra RNG).
- New `canonicalGameEvents.js` builds the ledger and derives the scoring summary.
  Reconciles by construction: `sum(scoring-event points) == last scoreAfter ==
  final`.

## Canonical vs reconstructed (honest framing)
The engine simulates each side's drives separately and owns **no possession
chronology**. What is canonical: the final score, the scoring events, their point
values, and per-side totals. What is a deterministic **reconstruction** for
presentation: the interleaved possession order and every intermediate
`scoreAfter` shown before the final. The live viewer labels the mid-game
progression **"Reconstructed order"**; only the final is official.

## No fabricated quarter authority
The engine owns no quarter timing, so events carry `quarter: null` + an honest
`periodLabel` (`"Drive 8"` / `"OT"`); `quarterScores` is `null`; overtime is
`isOvertime`/`"OT"`, never `Q5`. PostGameScreen / Game Book show a
**"Quarter breakdown unavailable for this game."** note (legacy archives with
genuine stored quarter data still display it), and `deriveQuarterScores` never
rebuilds a quarter table from narration for a canonical game.

## No fake play-call agency
Run Heavy / Pass Heavy / Timeout are **removed** on every path — the watched game
is fully simulated before playback, so they could not affect the result.
Canonical playback shows *"Game strategy was locked when simulation began."*

## Correct sack semantics
Shared helpers `defensiveSacks(row)` / `sacksTaken(row)` ensure a QB's sacks
*taken* never count as defensive production (leader, Player-of-Game impact, or
the live Sacks standout). Genuine defender sacks preserved.

## Live viewer honesty
- Scorebug reads the current canonical event's `scoreAfter` and shows
  `Drive N of M · ABBR possession` / `OT` / `Final` — drive progress excludes the
  terminal `game_end` marker (never `of N+1`).
- Box-score **Standouts stay hidden until the final whistle** (they are final
  totals).
- Feed shows drive cards; only the final is official.

## Additional P0/P1 fixes surfaced by the real browser journey
- **P0** — `workerApi.js` dropped the new `PLAY_LOGS` fields, so `canonicalEvents`
  never reached the viewer in the real app. Fixed.
- **P1** — the watch→Game Book **recovery race**: the Game Book resolved the
  just-watched game only from the async worker fetch and could land on the
  recovery state; it now also consults the synchronous localStorage postgame
  archive (`getGame` / `resolveCanonicalCompletedGame` `localArchivedGame`).
  Reproduced 3/3 before the fix; 6 consecutive clean runs after.

## Release gate
- `npm run test:unit` → **5602 pass** (456 files).
- `npm run build` → success.
- Production-build Playwright: `mobile_game_day_trust` (2/2, repeatedly),
  `fresh_franchise_first_week_smoke` (1/1).
- `npm run durability:test` → 38 pass. `durability:smoke`/`durability:5` stop at
  the **pre-existing** `schedule.games-reference-valid-teams` rollover failure
  (verified identical on the base tree), deferred to **#1701 — Post-Rollover
  Schedule & Archive Reference Integrity V1**.
- Removed swallowed Playwright `click()`/`expect()` failures; `Simulate (Skip)` is
  a required asserted interaction.

Canonical player/team-stat authority from #1698/#1699 is untouched. Full details
in `docs/canonical-gamecast-playable-tomorrow-v1.md` (§1a/§1b summarize the
review-defect fixes and the honesty pass).

**Merge recommendation: merge-ready.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrQvoHW4F1dT3dYCx1ornw