### PR TITLE
test(e2e): remove silent catch in simulateSingleWeek helper and smoke test

### DIFF
--- a/tests/e2e/fresh_franchise_first_week_smoke.spec.js
+++ b/tests/e2e/fresh_franchise_first_week_smoke.spec.js
@@ -129,7 +129,7 @@ test('fresh franchise first week smoke', async ({ page, context }) => {
     await gateAdvanceBtn.click();
   }
   const skipPrompt = page.getByRole('button', { name: /Simulate \(Skip\)/i });
-  await skipPrompt.click({ timeout: 10000 }).catch(() => {});
+  await skipPrompt.click();
   await page.waitForFunction(
     (baseline) => {
       const state = window?.state;

--- a/tests/e2e/helpers/franchise.js
+++ b/tests/e2e/helpers/franchise.js
@@ -217,7 +217,7 @@ export async function simulateSingleWeek(page, options = {}) {
     // Wait for the button to become enabled if it's rendered
     const advanceCta = page.getByTestId('advance-week-cta');
     if (await advanceCta.isVisible().catch(() => false)) {
-      await expect(advanceCta).toBeEnabled({ timeout: 5000 }).catch(() => {});
+      await expect(advanceCta).toBeEnabled({ timeout: 5000 });
     }
   }
 
@@ -232,9 +232,9 @@ export async function simulateSingleWeek(page, options = {}) {
     });
   }
   if (advanceAnyway) {
-    await page.getByRole('button', { name: /Advance anyway/i }).click({ timeout: 1000 }).catch(() => {});
+    await page.getByRole('button', { name: /Advance anyway/i }).click();
   }
-  await page.getByRole('button', { name: /Simulate \(Skip\)/i }).click({ timeout: 10000 }).catch(() => {});
+  await page.getByRole('button', { name: /Simulate \(Skip\)/i }).click();
   await page.waitForFunction(
     (baseline) => {
       const week = window?.state?.league?.week ?? baseline;


### PR DESCRIPTION
Fixes a test integrity issue where Playwright was silently swallowing errors if the "Advance anyway" or "Simulate (Skip)" buttons failed to appear. E2E tests will now correctly surface UI failures.

---
*PR created automatically by Jules for task [70856071031010306](https://jules.google.com/task/70856071031010306) started by @rbcati*