### PR TITLE
AI Post-Rollover Salary-Cap Compliance V1

### DIFF
--- a/docs/ai-post-rollover-salary-cap-compliance-v1.md
+++ b/docs/ai-post-rollover-salary-cap-compliance-v1.md
@@ -1,0 +1,286 @@
+# AI Post-Rollover Salary-Cap Compliance V1
+
+## 1. Executive verdict
+
+Multiple AI teams were unable to enter the Season 4 regular season legally under
+the salary cap, deadlocking the five-season durability run during Season 4
+preseason. The root cause is **two coupled defects**:
+
+1. **Ordering** — the pre-advance legality gate in `handleAdvanceWeek` evaluated
+   every team's cap on its *pre-cutdown* 67–74-man offseason roster, and it ran
+   *before* the preseason cutdown + AI cap-management pass that produces the
+   legal 53-man roster. By Season 4 the grown cap and inflated contracts made
+   several teams' full offseason payroll exceed the cap, so the gate blocked the
+   advance before the cutdown/cap-manager could ever run.
+2. **The AI cap manager itself** (`AiLogic.executeAICapManagement`) planned
+   against a stale constant cap (`Constants.SALARY_CAP.HARD_CAP = 301.2`, vs. the
+   live Season-4 cap of `333.94`), decided whether action was needed from
+   `capUsed` **excluding dead cap**, used a restructure formula that produced ~0
+   current-year relief, and ranked cuts by cap-hit inefficiency rather than
+   realizable net relief.
+
+Both are fixed. AI cap management now runs **before** the legality gate during
+preseason, and the manager plans against one canonical, live-cap equation that
+includes dead cap. The five-season durability run completes all five seasons and
+is deterministic across identical seeds.
+
+This PR does **not** weaken the legality gate, change the configured cap amount,
+erase dead cap, or auto-manage interactive user rosters.
+
+## 2. Latest-main SHA
+
+`c6b04863f11482f2b76d0f156a605ce19738cb63` (merge of PR #1702).
+
+## 3. Seed and first failing checkpoint
+
+- Seed: **1684**, five-season harness (`npm run durability:5`).
+- First failure: **Season 4 (year 2029), phase = preseason**, at the
+  `ADVANCE_WEEK` pre-advance legality gate (`runLegalityValidation('pre-advance')`).
+
+## 4. Failing-team cap ledger (pre-fix, reproduced)
+
+Live salary cap at Season 4 = **$333.94M** (base 301.2 grown at 3.5%/yr for 3
+rollovers). The manager's stale constant target was **$301.2M**. Teams reported
+over cap at the gate (pre-cutdown, ~67–74-man rosters):
+
+| Team    | rosterCap | deadCap | committed | legal cap | overage | roster |
+|---------|-----------|---------|-----------|-----------|---------|--------|
+| CIN (5) | 333.18    | 1.49    | 334.67    | 333.94    | +0.73   | 67     |
+| CLE (6) | 333.83    | 3.56    | 337.39    | 333.94    | +3.45   | 67     |
+| KC (13) | 338.59    | 0.49    | 339.08    | 333.94    | +5.14   | 69     |
+| WAS (19)| 334.41    | 1.73    | 336.14    | 333.94    | +2.20   | 74     |
+
+The mission brief named "Indianapolis" as the failing team; on the actual pinned
+main the failing teams are CIN/CLE/KC/WAS. The defect is **systemic**, not
+team-specific — no team was special-cased.
+
+## 5. First overcommit checkpoint
+
+The **"before preseason cutdown"** checkpoint. Teams accumulate a full offseason
+roster (re-signings + free agency + draft + rookies) whose aggregate cap hit,
+after three seasons of 2.5% contract inflation against a 3.5% cap, exceeds the
+cap while the roster is still ~70 players. This is expected and would be resolved
+by the 53-man cutdown — the defect is that the cutdown/cap-manager never ran
+(gate blocked first), and that the manager, had it run on a 53-man roster still
+over cap, used the wrong ceiling and ignored dead cap.
+
+## 6. Canonical cap-authority map
+
+| Authority | Location | Role |
+|-----------|----------|------|
+| `meta.economy.currentSalaryCap` | `core/economy.js` | live legal cap, grows 3.5%/yr |
+| `settings.salaryCap` | synced to `currentSalaryCap` | what the legality gate reads |
+| `validateLeagueTeamLegality` | `core/teamValidation.js` | legal gate: `Σ capHit + deadCap ≤ cap` |
+| `calculateContractCapHit` | `core/contracts/realisticContracts.js` | `base + signingBonus/yearsTotal + likely incentives` |
+| `getActiveCapHit` / `calculateTeamCapObligations` | `core/contracts/contractObligations.js` | canonical pure cap helpers |
+| **`buildTeamCapSnapshot`** (new) | `core/contracts/contractObligations.js` | single legal-compliance snapshot shared by planner + gate |
+| `AiLogic._getSalaryCap` | `core/ai-logic.js` | reads live economy cap |
+| `AiLogic.updateTeamCap` | `core/ai-logic.js` | writes team.capUsed/capRoom (capRoom already dead-cap aware) |
+| `recalculateTeamCap` | `worker/worker.js` | worker cap fields (includes staff + dead cap in capUsed) |
+
+## 7. Conflicting formulas found
+
+- The legality gate counts `Σ activeCapHit + team.deadCap` against the **live**
+  cap and **excludes** staff payroll.
+- `AiLogic.executeAICapManagement` (pre-fix) compared `team.capUsed` (roster cap
+  hits **only**, no dead cap) against a **static** `301.2` constant.
+- `recalculateTeamCap` defines `capUsed` as `playerPayroll + staffPayroll +
+  deadCap` — a third definition.
+
+The new `buildTeamCapSnapshot` gives the planner exactly the gate's equation
+(roster cap hits + dead cap vs. the live cap, staff excluded), so planner and
+gate can no longer disagree.
+
+## 8. capUsed-vs-capRoom result
+
+**Confirmed defect.** The manager's action trigger and stop condition were
+`team.capUsed <= hardCap`, which ignored `team.deadCap`. A team at
+`capUsed = 295, deadCap = 18` was treated as safe even when `295 + 18 = 313`
+exceeded the applicable cap. The manager now plans on `totalCommitted =
+rosterCap + deadCap`, identical to the gate.
+
+## 9. Live-cap-vs-constant result
+
+**Confirmed defect.** `executeAICapManagement` used
+`Constants.SALARY_CAP.HARD_CAP` (301.2) for the ceiling and the difficulty
+buffer, while the live Season-4 cap was 333.94 and the legality gate used the
+live value. The manager now uses `AiLogic._getSalaryCap()` (live economy cap) as
+the legal ceiling; the difficulty buffer is applied to that live cap.
+
+## 10. Restructure math before and after
+
+**Before** (inline in the manager): `convert = base × 0.5`; added to signing
+bonus as `convert × yearsRemaining`; the cap calculator then re-prorates the
+signing bonus over `yearsTotal`. Net current-year relief =
+`convert × (1 − yearsRemaining/yearsTotal)`, which is **0** for a contract in its
+first year (`yearsRemaining == yearsTotal`) — the common case. It shifted money
+into the future without lowering the current cap hit.
+
+**After**: the manager now delegates to the canonical restructure engine
+(`computeRestructure` / `applyRestructure`, used by the interactive
+`RESTRUCTURE_CONTRACT` handler). It converts `0.40 × currentCapHit` from base to
+bonus (`newBase = base − c`, `newBonus = bonus + c`), giving verified positive
+relief `c × (yearsTotal − 1)/yearsTotal`. Example (base 20, SB 0, 4 yrs): before
+cap hit = 20, convert = 8 → newBase 12, newBonus 8, after cap hit = 12 + 8/4 =
+14, **relief = 6**. Every restructure the planner keeps is re-measured and
+discarded if relief ≤ 0.
+
+## 11. Release net-relief policy
+
+A preseason (post-June-1) release charges `currentYearDead = signingBonus /
+yearsTotal` now and defers the rest to `deadMoneyNextYear`. **Net current-year
+relief = activeCapHit − currentYearDead** (= base + likely incentives). The
+planner:
+
+- filters out any candidate with `netRelief ≤ 0` (never worsens the current cap);
+- ranks by net relief descending (a high-cap-hit, all-bonus player with tiny net
+  relief is correctly deprioritised below a lower-cap-hit, all-base player);
+- never cuts a position below its floor (`AiLogic.POSITION_FLOOR`).
+
+## 12. Dead-money rollover result
+
+Verified correct and **not duplicated**. At `startNewSeason` each team rolls
+`deadMoneyNextYear → deadCap` exactly once, clears `deadMoneyNextYear`, and sets
+`capTotal = nextEconomy.currentSalaryCap`. Save/reload preserves the scalar
+`deadCap`/`deadMoneyNextYear` and does not re-apply the roll.
+
+## 13. Upstream transaction prevention
+
+Free-agency and re-signing commit points already gate on `team.capRoom`
+(dead-cap-aware, live-cap-based via `team.capTotal`) and the pending-offer cap
+reservation (`evaluatePendingOfferCapReservation`). These were **not** the first
+causal defect and are left intact; the preseason manager remains the safety net.
+No upstream transaction boundary was loosened.
+
+## 14. Compliance planning stages
+
+`buildAiCapCompliancePlan` (pure, deterministic, side-effect-free) discovers a
+plan on clones, then `executeAICapManagement` commits it:
+
+1. Recalculate canonical cap state (`buildTeamCapSnapshot`).
+2. Restructures (non-destructive) toward the **planning target**
+   (`legalCap − difficulty buffer`); only positive-relief actions kept; no player
+   restructured twice in a season.
+3. Releases (destructive) **only while still over the legal cap** — never to
+   chase the buffer — ranked by net relief, respecting position floors.
+4. Commit through cache + `Transactions`, recalc, and re-verify the **live**
+   committed result (not the projection).
+5. If no legal plan exists, return a structured failure with the exact remaining
+   overage and protected positions — no infinite loop, no fabricated money.
+
+## 15. Position and roster safeguards
+
+Releases never drop a position below `AiLogic.POSITION_FLOOR`
+(QB 2, RB 2, WR 3, TE 1, OL 5, DL 4, LB 3, CB 2, S 2, K 1, P 1). Depth charts are
+repaired (`validateAndRepairAllTeamDepthCharts('post-ai-cutdown')`) after the
+cutdown/cap-manager pass and before the legality gate, so no dangling
+starter/backup references reach the gate. Released players get `teamId = null`,
+`status = 'free_agent'`, and one `RELEASE` transaction each.
+
+## 16. User-team isolation
+
+The interactive user team is **never** auto-managed:
+`executeAICapManagement({ autoManageUserCap })` skips `userTeamId` unless
+`autoManageUserCap` is true. An interactive user over the cap still receives the
+existing actionable legality-gate error at Start Season with roster and contracts
+unchanged.
+
+## 17. Headless lifecycle policy
+
+Headless/durability lifecycles opt the user team in via
+`autoManageUserCap: true`, gated by the **explicit** batch-sim capability
+`globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__` (set only by the durability lifecycle
+driver). `skipUserGame` is **not** used as blanket front-office consent for cap
+management.
+
+## 18. Save/reload result
+
+Save/reload preserves the cap snapshot: `deadCap`, `deadMoneyNextYear`,
+`capTotal`, and contract fingerprints round-trip unchanged; the dead-money roll
+is not re-applied on load. Covered by the durability harness save/reload
+checkpoints (see §20).
+
+## 19. Season 4 reproduction result
+
+- **Before fix:** durability:5 stops in Season 4 preseason — CIN/CLE/KC/WAS over
+  cap at the pre-advance gate.
+- **After fix:** the Season 4 preseason→regular transition passes for all teams;
+  cap management runs before the gate and every AI team is legal.
+
+## 20. Five-season result
+
+`npm run durability:5` (seed 1684) completes **all five seasons**; every
+preseason→regular checkpoint reports all AI teams legally cap compliant, all cap
+aggregates finite, no invalid contracts, no duplicate releases, no broken depth
+charts. (See PR body / CI for the exact console verdict.)
+
+## 21. Determinism result
+
+Two identical five-season runs (and the unit-level determinism test) produce
+identical cap snapshots, restructure/release actions, and transaction
+fingerprints.
+
+## 22. Browser result
+
+Production build passes (`npm run build`). Playwright browser coverage: see PR
+body — reported honestly (only claimed if Playwright actually executed in CI).
+
+## 23. Files changed
+
+- `src/core/contracts/contractObligations.js` — new `buildTeamCapSnapshot`.
+- `src/core/ai-logic.js` — rewrote `executeAICapManagement` as plan-then-commit;
+  added `buildAiCapCompliancePlan`, `_capPlanningBuffer`, `_releaseDeadCapSplit`;
+  new imports.
+- `src/worker/worker.js` — run preseason AI cutdown + cap management + depth
+  repair before the pre-advance legality gate; pass `autoManageUserCap` from the
+  explicit batch-sim capability.
+- `src/worker/__tests__/depthChartRepairAfterRelease.test.js` — updated the
+  call-ordering sentinel for the new method signature.
+
+## 24. Tests added
+
+- `tests/unit/aiCapCompliancePlan.test.js` — snapshot equation, dead-cap
+  compliance, live cap, restructure relief, no-repeat restructure, net-relief
+  cuts, zero-relief skip, position floor, structured failure, determinism.
+- `tests/unit/aiCapManagementExecution.test.js` — user-team isolation
+  (interactive vs. headless), team-id-0 validity, live-cap legality, one
+  transaction per action, determinism.
+
+## 25. Unit-test result
+
+`npm run test:unit` — **5640 passed / 460 files**.
+
+## 26. Build result
+
+`npm run build` — **passed**.
+
+## 27. Durability result
+
+- `npm run durability:test` — **62 passed / 5 files**.
+- `npm run durability:smoke` — passed (1-season).
+- `npm run durability:5` — five seasons complete; determinism stable.
+
+## 28. Explicit untouched systems
+
+Schedule generator and history-reference contract; scoring / gamecast;
+standings / playoff rules; progression / retirement; team numbering (team id 0
+remains valid, `teamId == null` still means free agent); the configured cap
+amount; the legality gate's rule; interactive user roster control; contract
+market value / demand model.
+
+## 29. Remaining first failure, if any
+
+None within the salary-cap causal cluster through five seasons at seed 1684. Any
+future failure surfaced by longer runs should be triaged as its own defect.
+
+## 30. Recommended next PR
+
+Extend the deterministic cap-compliance harness to 10/20-season runs and multiple
+seeds to confirm the cap manager holds under deeper contract inflation, and add
+an explicit durability invariant `cap.ai-teams-legal-at-regular-season-start`.
+
+## 31. Merge recommendation
+
+**Merge.** The first causal cap defect is fixed with one canonical equation
+shared by planning and the legality gate, no gameplay systems outside the cap
+cluster changed, unit + durability suites green, and behaviour is deterministic.

--- a/src/core/ai-logic.js
+++ b/src/core/ai-logic.js
@@ -22,6 +22,8 @@ import { buildContractFromMarket, evaluateContractMarket } from './contractModel
 import { evaluatePendingOfferCapReservation } from './pendingOfferCapModel.js';
 import { evaluatePlayerMarketRealism, normalizePositionGroup } from './marketRealismModel.js';
 import { executeAIOffseasonCuts } from './roster/aiRosterCuts.js';
+import { buildTeamCapSnapshot, getActiveCapHit } from './contracts/contractObligations.js';
+import { canRestructure, computeRestructure, applyRestructure } from './contracts/restructureEngine.js';
 import { executeAIOffseasonExtensions } from './retention/aiRetentionLogic.js';
 import { calculateTeamDepthDeficiencies, getNeedLevelForPlayer, POSITION_NEED_LEVEL } from './trades/tradePositionalNeeds.js';
 import { buildFranchiseTagContract, buildRFATenderContract, TENDER_CONFIG } from './contracts/tenderLogic.js';
@@ -231,120 +233,248 @@ class AiLogic {
     }
 
     /**
-     * Execute AI Cap Management for the start of the regular season.
-     *
-     * If a team is over the $301.2M hard cap after cutdowns, the AI will:
-     *   1. First try to restructure the highest-paid star players (OVR ≥ 80)
-     *      by converting 50% of their base salary to prorated bonus.
-     *   2. If still over cap, cut the most "cap-inefficient" veterans:
-     *      players with the worst (cap hit / OVR) ratio, skipping essential
-     *      starters (OVR ≥ 85) if possible.
-     *
-     * This runs for all AI teams; the user's team must manage its own cap.
+     * Difficulty-based PLANNING buffer ($M below the legal cap). This is a
+     * planning target only — it never changes the legal ceiling and must never
+     * drive destructive cuts once a team is already legally under the cap.
      */
-    static async executeAICapManagement() {
+    static _capPlanningBuffer(difficulty) {
+        if (difficulty === 'Hard') return 10;
+        if (difficulty === 'Legendary') return 25;
+        return 0;
+    }
+
+    /**
+     * Post-June-1 dead-cap split for a release. Preseason cap management runs in
+     * a POST_JUNE1 phase, so only the current year's bonus proration hits the
+     * current cap; the remainder defers to deadMoneyNextYear. Mirrors the split
+     * used by executeAICutdowns so the two paths agree.
+     */
+    static _releaseDeadCapSplit(player) {
+        const c = player?.contract ?? {};
+        const yearsTotal = Math.max(1, Number(c.yearsTotal ?? c.years ?? 1));
+        const yearsRemaining = Math.max(0, Number(c.years ?? c.yearsRemaining ?? 1));
+        const annualBonus = Math.max(0, Number(c.signingBonus ?? 0)) / yearsTotal;
+        const currentYearDead = Math.round(annualBonus * 100) / 100;
+        const futureYearsDead = Math.round(annualBonus * Math.max(0, yearsRemaining - 1) * 100) / 100;
+        return { currentYearDead, futureYearsDead };
+    }
+
+    /**
+     * Build a deterministic, side-effect-free cap-compliance plan for one team.
+     *
+     * The plan is discovered against clones so nothing is mutated while we are
+     * still deciding whether a legal plan exists. Compliance uses the SAME
+     * canonical equation as the pre-advance legality gate:
+     *
+     *   totalCommitted = Σ activeCapHit(roster) + team.deadCap
+     *   legal          ⇔ totalCommitted ≤ liveSalaryCap
+     *
+     * Least-destructive ordering:
+     *   1. Restructures (non-destructive) toward the PLANNING TARGET
+     *      (legalCap − difficulty buffer). Only actions with proven positive
+     *      current-year relief are kept; no player is restructured twice in the
+     *      same season.
+     *   2. Releases (destructive) ONLY while still over the LEGAL cap — never to
+     *      chase the buffer. Ranked by realizable NET current-year relief
+     *      (capHit − new current-year dead cap); zero/negative-relief players are
+     *      never chosen, and no position is cut below its floor.
+     *
+     * @returns {{ actions: object[], projected: object, failure: object|null }}
+     */
+    static buildAiCapCompliancePlan(team, roster, { legalCap, targetBuffer = 0, season = 0 } = {}) {
+        const actions = [];
+        let workRoster = roster.map((p) => ({ ...p, contract: { ...(p?.contract ?? {}) } }));
+        let deadCap = Math.max(0, Number(team?.deadCap ?? 0));
+        const snap = () => buildTeamCapSnapshot({ team: { deadCap }, roster: workRoster, salaryCap: legalCap, targetBuffer });
+
+        // ── Phase 1: restructures toward the planning target ──────────────────
+        const touched = new Set();
+        let guard = 0;
+        while (snap().totalCommitted > snap().targetCommitted && guard++ < 500) {
+            const s = snap();
+            const candidates = workRoster
+                .filter((p) => !touched.has(p.id))
+                .filter((p) => Number(p?.contract?.lastRestructuredSeason) !== Number(season))
+                .filter((p) => canRestructure(p, { capRoom: s.capRoom, deadCapItems: [] }).eligible)
+                .map((p) => ({ p, hit: getActiveCapHit(p) }))
+                .sort((a, b) => (b.hit - a.hit) || String(a.p.id).localeCompare(String(b.p.id)));
+            if (!candidates.length) break;
+
+            let applied = false;
+            for (const { p, hit } of candidates) {
+                const yearsLeft = Number(p.contract?.yearsRemaining ?? p.contract?.years ?? 1);
+                const preview = computeRestructure(p, hit, yearsLeft, season);
+                // Never convert more base than exists — a restructure must not
+                // drive base salary negative.
+                if (!(preview.conversionAmount > 0) || preview.conversionAmount > Number(p.contract?.baseAnnual ?? 0)) {
+                    touched.add(p.id);
+                    continue;
+                }
+                const { updatedPlayer, updatedTeam } = applyRestructure(p, team ?? {}, preview, season);
+                const relief = Math.round((getActiveCapHit(p) - getActiveCapHit(updatedPlayer)) * 100) / 100;
+                touched.add(p.id);
+                if (relief <= 0) continue; // no genuine current-year relief → skip
+                const idx = workRoster.findIndex((r) => r.id === p.id);
+                workRoster[idx] = { ...updatedPlayer, contract: { ...updatedPlayer.contract, lastRestructuredSeason: Number(season) } };
+                const newDeadCapItem = Array.isArray(updatedTeam?.deadCapItems)
+                    ? updatedTeam.deadCapItems[updatedTeam.deadCapItems.length - 1]
+                    : null;
+                actions.push({
+                    type: 'RESTRUCTURE',
+                    playerId: p.id,
+                    conversionAmount: preview.conversionAmount,
+                    relief,
+                    newContract: workRoster[idx].contract,
+                    deadCapItem: newDeadCapItem,
+                });
+                applied = true;
+                break;
+            }
+            if (!applied) break;
+        }
+
+        // ── Phase 2: releases — only while still over the LEGAL cap ────────────
+        const posCount = {};
+        for (const p of workRoster) posCount[p.pos] = (posCount[p.pos] ?? 0) + 1;
+
+        guard = 0;
+        while (snap().totalCommitted > legalCap && guard++ < 500) {
+            const candidates = workRoster
+                .map((p) => {
+                    const { currentYearDead, futureYearsDead } = AiLogic._releaseDeadCapSplit(p);
+                    const netRelief = Math.round((getActiveCapHit(p) - currentYearDead) * 100) / 100;
+                    return { p, netRelief, currentYearDead, futureYearsDead };
+                })
+                .filter((c) => c.netRelief > 0)
+                .filter((c) => (posCount[c.p.pos] ?? 0) > (AiLogic.POSITION_FLOOR[c.p.pos] ?? 1))
+                .sort((a, b) => (b.netRelief - a.netRelief)
+                    || ((a.p.ovr ?? 0) - (b.p.ovr ?? 0))
+                    || String(a.p.id).localeCompare(String(b.p.id)));
+            if (!candidates.length) break;
+
+            const choice = candidates[0];
+            workRoster = workRoster.filter((r) => r.id !== choice.p.id);
+            posCount[choice.p.pos] = (posCount[choice.p.pos] ?? 1) - 1;
+            deadCap = Math.round((deadCap + choice.currentYearDead) * 100) / 100;
+            actions.push({
+                type: 'RELEASE',
+                playerId: choice.p.id,
+                currentYearDead: choice.currentYearDead,
+                futureYearsDead: choice.futureYearsDead,
+                netRelief: choice.netRelief,
+            });
+        }
+
+        const projected = snap();
+        const failure = projected.isLegallyCompliant ? null : {
+            teamId: team?.id,
+            abbr: team?.abbr,
+            reason: 'no_legal_plan',
+            remainingOverage: projected.overageVsLegal,
+            rosterCap: projected.rosterCap,
+            deadCap: projected.deadCap,
+            totalCommitted: projected.totalCommitted,
+            legalCap,
+            protectedPositions: Object.keys(AiLogic.POSITION_FLOOR).filter((pos) => (posCount[pos] ?? 0) <= (AiLogic.POSITION_FLOOR[pos] ?? 1)),
+        };
+
+        return { actions, projected, failure };
+    }
+
+    /**
+     * Execute AI Cap Management before the start of the regular season.
+     *
+     * Every AI team is brought to a legally cap-compliant state against the LIVE
+     * salary cap using the least-destructive plan (restructures first, then
+     * net-positive releases). Restructures and releases are committed through the
+     * canonical contract helpers so cap state, dead money and transaction records
+     * all stay consistent.
+     *
+     * The interactive user team is NEVER auto-managed. Headless/durability
+     * lifecycles pass `autoManageUserCap: true` (gated on the explicit batch-sim
+     * capability by the caller) so the franchise can start a season without an
+     * interactive front office.
+     *
+     * @param {{autoManageUserCap?: boolean}} [opts]
+     * @returns {Promise<{failures: object[], teamsManaged: number}>}
+     */
+    static async executeAICapManagement({ autoManageUserCap = false } = {}) {
         const txsToCommit = [];
         const meta        = cache.getMeta();
         const userTeamId  = meta.userTeamId;
-        let targetCap = Constants.SALARY_CAP.HARD_CAP;
-        // On higher difficulties, AI targets a lower cap utilization to preserve space for free agency
-        if (meta.difficulty === 'Hard') targetCap = Constants.SALARY_CAP.HARD_CAP - 10; // Target $10M buffer
-        if (meta.difficulty === 'Legendary') targetCap = Constants.SALARY_CAP.HARD_CAP - 25; // Target $25M buffer
-        const hardCap = targetCap;
+        const seasonId    = meta.currentSeasonId;
+        const week        = meta.currentWeek;
+        const season      = Number(meta?.year ?? 0);
+        const legalCap    = AiLogic._getSalaryCap();
+        const targetBuffer = AiLogic._capPlanningBuffer(meta.difficulty);
         const allTeams    = cache.getAllTeams();
+        const failures    = [];
+        let teamsManaged  = 0;
 
         for (const team of allTeams) {
-            if (team.id === userTeamId) continue;
+            if (team.id === userTeamId && !autoManageUserCap) continue;
 
             this.updateTeamCap(team.id);
-            let freshTeam = cache.getTeam(team.id);
-            if ((freshTeam.capUsed ?? 0) <= hardCap) continue;
-
+            const freshTeam = cache.getTeam(team.id);
             const roster = cache.getPlayersByTeam(team.id);
+            const snapshot = buildTeamCapSnapshot({ team: freshTeam, roster, salaryCap: legalCap, targetBuffer });
+            if (snapshot.isWithinPlanningTarget) continue;
 
-            // ── Step 1: Restructure star players (OVR ≥ 80, ≥ 2 yrs remaining) ──
-            const restructureCandidates = roster
-                .filter(p => (p.ovr ?? 0) >= 80 && (p.contract?.years ?? 1) >= 2)
-                .sort((a, b) => {
-                    const hitA = (a.contract?.baseAnnual ?? 0) + ((a.contract?.signingBonus ?? 0) / (a.contract?.yearsTotal || 1));
-                    const hitB = (b.contract?.baseAnnual ?? 0) + ((b.contract?.signingBonus ?? 0) / (b.contract?.yearsTotal || 1));
-                    return hitB - hitA; // highest cap hit first
-                });
+            const plan = AiLogic.buildAiCapCompliancePlan(freshTeam, roster, { legalCap, targetBuffer, season });
+            if (plan.actions.length === 0 && snapshot.isLegallyCompliant) continue;
+            teamsManaged += 1;
 
-            for (const p of restructureCandidates) {
-                freshTeam = cache.getTeam(team.id);
-                if ((freshTeam.capUsed ?? 0) <= hardCap) break;
+            for (const action of plan.actions) {
+                const player = cache.getPlayer(action.playerId);
+                if (!player) continue;
 
-                const c = p.contract;
-                if (!c) continue;
-                const yearsRemaining  = Math.max(c.years ?? 1, 2);
-                const base            = c.baseAnnual ?? 0;
-                const convertAmount   = Math.round(base * Constants.SALARY_CAP.RESTRUCTURE_MAX_CONVERT_PCT * 100) / 100;
-                if (convertAmount <= 0) continue;
-
-                const newBase         = Math.round((base - convertAmount) * 100) / 100;
-                const addedBonusTotal = convertAmount * yearsRemaining;
-                const newSigningBonus = Math.round(((c.signingBonus ?? 0) + addedBonusTotal) * 100) / 100;
-
-                cache.updatePlayer(p.id, {
-                    contract: { ...c, baseAnnual: newBase, signingBonus: newSigningBonus },
-                });
-                this.updateTeamCap(team.id);
-
-                txsToCommit.push({
-                    type: 'RESTRUCTURE', seasonId: meta.currentSeasonId,
-                    week: meta.currentWeek, teamId: team.id,
-                    details: { playerId: p.id, convertAmount, aiInitiated: true },
-                });
+                if (action.type === 'RESTRUCTURE') {
+                    cache.updatePlayer(player.id, {
+                        contract: { ...action.newContract, lastRestructuredSeason: season },
+                    });
+                    if (action.deadCapItem) {
+                        const t = cache.getTeam(team.id);
+                        const existing = Array.isArray(t?.deadCapItems) ? t.deadCapItems : [];
+                        cache.updateTeam(team.id, { deadCapItems: [...existing, action.deadCapItem] });
+                    }
+                    this.updateTeamCap(team.id);
+                    txsToCommit.push({
+                        type: 'RESTRUCTURE', seasonId, week, teamId: team.id,
+                        details: { playerId: player.id, convertAmount: action.conversionAmount, relief: action.relief, aiInitiated: true },
+                    });
+                } else if (action.type === 'RELEASE') {
+                    cache.updatePlayer(player.id, { teamId: null, status: 'free_agent' });
+                    const t = cache.getTeam(team.id);
+                    if (action.currentYearDead > 0) {
+                        cache.updateTeam(team.id, { deadCap: Math.round(((t.deadCap ?? 0) + action.currentYearDead) * 100) / 100 });
+                    }
+                    const t2 = cache.getTeam(team.id);
+                    if (action.futureYearsDead > 0) {
+                        cache.updateTeam(team.id, { deadMoneyNextYear: Math.round(((t2.deadMoneyNextYear ?? 0) + action.futureYearsDead) * 100) / 100 });
+                    }
+                    this.updateTeamCap(team.id);
+                    txsToCommit.push({
+                        type: 'RELEASE', seasonId, week, teamId: team.id,
+                        details: { playerId: player.id, deadCap: action.currentYearDead, aiCapCut: true },
+                    });
+                }
             }
 
-            // ── Step 2: Cut cap-inefficient veterans if still over cap ──────────
-            freshTeam = cache.getTeam(team.id);
-            if ((freshTeam.capUsed ?? 0) <= hardCap) continue;
-
-            // Score by inefficiency = cap hit / OVR  (higher = more inefficient)
-            const cutCandidates = roster
-                .filter(p => {
-                    // Don't cut essential starters or rookies
-                    const ovr = p.ovr ?? 0;
-                    const age = p.age ?? 28;
-                    return ovr < 85 && age >= 27;
-                })
-                .map(p => {
-                    const base  = p.contract?.baseAnnual  ?? p.baseAnnual  ?? 0;
-                    const bonus = p.contract?.signingBonus ?? p.signingBonus ?? 0;
-                    const yrs   = p.contract?.yearsTotal   ?? p.yearsTotal   ?? 1;
-                    const capHit = base + bonus / (yrs || 1);
-                    const ovr   = p.ovr ?? 50;
-                    return { ...p, _capHit: capHit, _inefficiency: ovr > 0 ? capHit / ovr : capHit };
-                })
-                .sort((a, b) => b._inefficiency - a._inefficiency); // most inefficient first
-
-            for (const p of cutCandidates) {
-                freshTeam = cache.getTeam(team.id);
-                if ((freshTeam.capUsed ?? 0) <= hardCap) break;
-
-                // Calculate dead cap (Preseason is Post-June 1)
-                const c           = p.contract;
-                const annualBonus = (c?.signingBonus ?? 0) / (c?.yearsTotal || 1);
-                const yearsRemaining = c?.years || 1;
-                const currentYearDead = annualBonus;
-                const futureYearsDead = annualBonus * Math.max(0, yearsRemaining - 1);
-
-                cache.updatePlayer(p.id, { teamId: null, status: 'free_agent' });
-                const t = cache.getTeam(team.id);
-                if (currentYearDead > 0) {
-                    cache.updateTeam(team.id, { deadCap: (t.deadCap ?? 0) + currentYearDead });
-                }
-                if (futureYearsDead > 0) {
-                    cache.updateTeam(team.id, { deadMoneyNextYear: (t.deadMoneyNextYear ?? 0) + futureYearsDead });
-                }
-                this.updateTeamCap(team.id);
-
-                txsToCommit.push({
-                    type: 'RELEASE', seasonId: meta.currentSeasonId,
-                    week: meta.currentWeek, teamId: team.id,
-                    details: { playerId: p.id, deadCap: currentYearDead, aiCapCut: true },
+            // Confirm the live committed result rather than trusting projections.
+            this.updateTeamCap(team.id);
+            const liveTeam = cache.getTeam(team.id);
+            const liveRoster = cache.getPlayersByTeam(team.id);
+            const liveSnap = buildTeamCapSnapshot({ team: liveTeam, roster: liveRoster, salaryCap: legalCap });
+            if (!liveSnap.isLegallyCompliant) {
+                failures.push({
+                    teamId: team.id,
+                    abbr: team.abbr,
+                    remainingOverage: liveSnap.overageVsLegal,
+                    rosterCap: liveSnap.rosterCap,
+                    deadCap: liveSnap.deadCap,
+                    totalCommitted: liveSnap.totalCommitted,
+                    legalCap,
+                    ...(plan.failure ?? {}),
                 });
             }
         }
@@ -352,6 +482,13 @@ class AiLogic {
         if (txsToCommit.length > 0) {
             await Promise.all(txsToCommit.map(tx => Transactions.add(tx)));
         }
+
+        if (failures.length > 0) {
+            console.warn(`[AiLogic] executeAICapManagement: ${failures.length} team(s) could not reach a legal cap plan:`,
+                failures.map((f) => `${f.abbr}(${f.teamId}) over by $${f.remainingOverage}M`).join(', '));
+        }
+
+        return { failures, teamsManaged };
     }
 
     /**

--- a/src/core/ai-logic.js
+++ b/src/core/ai-logic.js
@@ -285,6 +285,9 @@ class AiLogic {
         const actions = [];
         let workRoster = roster.map((p) => ({ ...p, contract: { ...(p?.contract ?? {}) } }));
         let deadCap = Math.max(0, Number(team?.deadCap ?? 0));
+        // Original (pre-restructure) contracts, kept so a restructure can be rolled
+        // back if the player later turns out to be the only cap-legal release.
+        const originalContracts = new Map();
         const snap = () => buildTeamCapSnapshot({ team: { deadCap }, roster: workRoster, salaryCap: legalCap, targetBuffer });
 
         // ── Phase 1: restructures toward the planning target ──────────────────
@@ -315,6 +318,7 @@ class AiLogic {
                 touched.add(p.id);
                 if (relief <= 0) continue; // no genuine current-year relief → skip
                 const idx = workRoster.findIndex((r) => r.id === p.id);
+                if (!originalContracts.has(p.id)) originalContracts.set(p.id, { ...workRoster[idx].contract });
                 workRoster[idx] = { ...updatedPlayer, contract: { ...updatedPlayer.contract, lastRestructuredSeason: Number(season) } };
                 const newDeadCapItem = Array.isArray(updatedTeam?.deadCapItems)
                     ? updatedTeam.deadCapItems[updatedTeam.deadCapItems.length - 1]
@@ -333,13 +337,12 @@ class AiLogic {
             if (!applied) break;
         }
 
-        // ── Phase 2: releases — only while still over the LEGAL cap ────────────
-        // Exclude players already restructured in phase 1 from the release pool.
-        // Restructuring converts base to prorated bonus, so a just-restructured
-        // player has HIGHER dead cap and LOWER net release relief than he did
-        // originally — restructuring and then releasing the same player is
-        // strictly worse than a direct release would have been. Keep the players
-        // we chose to restructure; cut from the rest.
+        // ── Phase 2a: releases from the NON-restructured pool ──────────────────
+        // Prefer cutting players we did NOT restructure. Restructuring converts
+        // base to prorated bonus, so a just-restructured player has HIGHER dead
+        // cap and LOWER net release relief — restructuring then releasing the same
+        // player is wasteful. Keep the players we chose to restructure and cut the
+        // rest first.
         const restructuredIds = new Set(
             actions.filter((a) => a.type === 'RESTRUCTURE').map((a) => a.playerId),
         );
@@ -372,6 +375,49 @@ class AiLogic {
                 currentYearDead: choice.currentYearDead,
                 futureYearsDead: choice.futureYearsDead,
                 netRelief: choice.netRelief,
+            });
+        }
+
+        // ── Phase 2b: rollback releases — LAST resort, only if still over legal ──
+        // If cutting the non-restructured pool cannot reach the legal cap, a
+        // restructured player may be the only remaining cap-legal release. Rather
+        // than restructure AND release him (wasteful) or falsely report no legal
+        // plan, ROLL BACK his restructure and release him from his ORIGINAL
+        // contract — this both removes the now-pointless restructure and realizes
+        // the full original release relief.
+        guard = 0;
+        while (snap().totalCommitted > legalCap && guard++ < 500) {
+            const candidates = workRoster
+                .filter((p) => restructuredIds.has(p.id) && originalContracts.has(p.id))
+                .map((p) => {
+                    const origPlayer = { ...p, contract: originalContracts.get(p.id) };
+                    const { currentYearDead, futureYearsDead } = AiLogic._releaseDeadCapSplit(origPlayer);
+                    const netRelief = Math.round((getActiveCapHit(origPlayer) - currentYearDead) * 100) / 100;
+                    return { p, netRelief, currentYearDead, futureYearsDead };
+                })
+                .filter((c) => c.netRelief > 0)
+                .filter((c) => (posCount[c.p.pos] ?? 0) > (AiLogic.POSITION_FLOOR[c.p.pos] ?? 1))
+                .sort((a, b) => (b.netRelief - a.netRelief)
+                    || ((a.p.ovr ?? 0) - (b.p.ovr ?? 0))
+                    || String(a.p.id).localeCompare(String(b.p.id)));
+            if (!candidates.length) break;
+
+            const choice = candidates[0];
+            // Roll back the restructure: drop its action (and its void-year dead
+            // money) so the committed contract stays original, then release.
+            const rIdx = actions.findIndex((a) => a.type === 'RESTRUCTURE' && a.playerId === choice.p.id);
+            if (rIdx >= 0) actions.splice(rIdx, 1);
+            restructuredIds.delete(choice.p.id);
+            workRoster = workRoster.filter((r) => r.id !== choice.p.id);
+            posCount[choice.p.pos] = (posCount[choice.p.pos] ?? 1) - 1;
+            deadCap = Math.round((deadCap + choice.currentYearDead) * 100) / 100;
+            actions.push({
+                type: 'RELEASE',
+                playerId: choice.p.id,
+                currentYearDead: choice.currentYearDead,
+                futureYearsDead: choice.futureYearsDead,
+                netRelief: choice.netRelief,
+                rolledBackRestructure: true,
             });
         }
 

--- a/src/core/ai-logic.js
+++ b/src/core/ai-logic.js
@@ -334,12 +334,22 @@ class AiLogic {
         }
 
         // ── Phase 2: releases — only while still over the LEGAL cap ────────────
+        // Exclude players already restructured in phase 1 from the release pool.
+        // Restructuring converts base to prorated bonus, so a just-restructured
+        // player has HIGHER dead cap and LOWER net release relief than he did
+        // originally — restructuring and then releasing the same player is
+        // strictly worse than a direct release would have been. Keep the players
+        // we chose to restructure; cut from the rest.
+        const restructuredIds = new Set(
+            actions.filter((a) => a.type === 'RESTRUCTURE').map((a) => a.playerId),
+        );
         const posCount = {};
         for (const p of workRoster) posCount[p.pos] = (posCount[p.pos] ?? 0) + 1;
 
         guard = 0;
         while (snap().totalCommitted > legalCap && guard++ < 500) {
             const candidates = workRoster
+                .filter((p) => !restructuredIds.has(p.id))
                 .map((p) => {
                     const { currentYearDead, futureYearsDead } = AiLogic._releaseDeadCapSplit(p);
                     const netRelief = Math.round((getActiveCapHit(p) - currentYearDead) * 100) / 100;

--- a/src/core/ai-logic.js
+++ b/src/core/ai-logic.js
@@ -421,7 +421,18 @@ class AiLogic {
             if (snapshot.isWithinPlanningTarget) continue;
 
             const plan = AiLogic.buildAiCapCompliancePlan(freshTeam, roster, { legalCap, targetBuffer, season });
-            if (plan.actions.length === 0 && snapshot.isLegallyCompliant) continue;
+
+            // If no legal plan exists, do NOT commit partial destructive actions.
+            // Committing releases/restructures that cannot eliminate the overage
+            // would strip players/contracts for no compliance benefit and leave
+            // retries operating on a needlessly mutated roster. Record the
+            // structured failure and leave the roster intact instead.
+            if (plan.failure) {
+                failures.push({ ...plan.failure, legalCap });
+                continue;
+            }
+
+            if (plan.actions.length === 0) continue;
             teamsManaged += 1;
 
             for (const action of plan.actions) {

--- a/src/core/contracts/contractObligations.js
+++ b/src/core/contracts/contractObligations.js
@@ -161,6 +161,77 @@ export function calculateTeamCapObligations(team = {}, players = [], leagueSetti
 }
 
 /**
+ * Canonical salary-cap snapshot for legal-compliance decisions.
+ *
+ * This is the SINGLE source of truth shared by AI cap planning and the
+ * pre-advance legality gate. It intentionally mirrors the legality gate's
+ * equation exactly (see teamValidation.validateLeagueTeamLegality):
+ *
+ *   rosterCap      = Σ getActiveCapHit(rosterPlayer)     (active contracts only)
+ *   deadCap        = team.deadCap                          (current-year dead money)
+ *   totalCommitted = rosterCap + deadCap + pendingCommitments
+ *   capRoom        = salaryCap - totalCommitted
+ *
+ * Staff payroll is deliberately EXCLUDED — the legality gate does not count it
+ * toward cap compliance, so neither may the planner (otherwise the AI would
+ * over-cut chasing a stricter ceiling than the gate enforces).
+ *
+ * The legal ceiling is the live economy cap; the planning target subtracts an
+ * optional difficulty buffer. The buffer is advisory only — it must never be
+ * used as the legal ceiling.
+ *
+ * @param {object}  args
+ * @param {object}  args.team               team record (reads team.deadCap)
+ * @param {Array}   args.roster             active roster players
+ * @param {number}  args.salaryCap          live legal salary cap ($M)
+ * @param {number} [args.targetBuffer=0]    planning buffer below the legal cap
+ * @param {number} [args.pendingCommitments=0] cap that legally counts now but is
+ *                                          not yet on the roster (e.g. reserved
+ *                                          offers). Included in totalCommitted.
+ * @returns {{
+ *   salaryCap:number, rosterCap:number, deadCap:number, pendingCommitments:number,
+ *   totalCommitted:number, capRoom:number, legalLimit:number, targetBuffer:number,
+ *   targetCommitted:number, targetRoom:number,
+ *   isLegallyCompliant:boolean, isWithinPlanningTarget:boolean,
+ *   overageVsLegal:number, overageVsTarget:number
+ * }}
+ */
+export function buildTeamCapSnapshot({
+  team = {},
+  roster = [],
+  salaryCap,
+  targetBuffer = 0,
+  pendingCommitments = 0,
+} = {}) {
+  const legalLimit = n(salaryCap, 301.2);
+  const rosterCap = round2((roster ?? []).reduce((sum, p) => sum + getActiveCapHit(p), 0));
+  const deadCap = Math.max(0, n(team?.deadCap, 0));
+  const pending = Math.max(0, n(pendingCommitments, 0));
+  const totalCommitted = round2(rosterCap + deadCap + pending);
+  const capRoom = round2(legalLimit - totalCommitted);
+  const buffer = Math.max(0, n(targetBuffer, 0));
+  const targetCommitted = round2(legalLimit - buffer);
+  const targetRoom = round2(targetCommitted - totalCommitted);
+
+  return {
+    salaryCap: legalLimit,
+    rosterCap,
+    deadCap,
+    pendingCommitments: pending,
+    totalCommitted,
+    capRoom,
+    legalLimit,
+    targetBuffer: buffer,
+    targetCommitted,
+    targetRoom,
+    isLegallyCompliant: totalCommitted <= legalLimit,
+    isWithinPlanningTarget: totalCommitted <= targetCommitted,
+    overageVsLegal: round2(Math.max(0, totalCommitted - legalLimit)),
+    overageVsTarget: round2(Math.max(0, totalCommitted - targetCommitted)),
+  };
+}
+
+/**
  * Pure cap-affordability check for a proposed new contract.
  * Does NOT mutate state.
  *

--- a/src/worker/__tests__/depthChartRepairAfterRelease.test.js
+++ b/src/worker/__tests__/depthChartRepairAfterRelease.test.js
@@ -59,13 +59,34 @@ describe('AI preseason cutdowns / cap management — depth chart repair', () => 
   const fn = extractFunction(workerSource, 'handleAdvanceWeek');
 
   it('calls the canonical depth-chart repair after AI cutdowns and cap management', () => {
-    const cutdownIdx = fn.indexOf('AiLogic.executeAICutdowns()');
+    const cutdownIdx = fn.indexOf('AiLogic.executeAICutdowns({ includeUserTeam: batchSim })');
     const capMgmtIdx = fn.indexOf('AiLogic.executeAICapManagement(');
     const repairIdx = fn.indexOf("validateAndRepairAllTeamDepthCharts('post-ai-cutdown')");
 
     expect(cutdownIdx).toBeGreaterThan(-1);
     expect(capMgmtIdx).toBeGreaterThan(cutdownIdx);
     expect(repairIdx).toBeGreaterThan(capMgmtIdx);
+  });
+
+  it('gates interactive skipUserGame/SIM_TO_PHASE before any preseason AI mutation', () => {
+    const batchGuardIdx = fn.indexOf('if (!batchSim) {');
+    const rosterCheckIdx = fn.indexOf('userRoster.length > rosterLimit', batchGuardIdx);
+    const capCheckIdx = fn.indexOf("runLegalityValidation({ stage: 'pre-advance', teamIds: [meta.userTeamId] })", rosterCheckIdx);
+    const cutdownIdx = fn.indexOf('AiLogic.executeAICutdowns({ includeUserTeam: batchSim })');
+    const capMgmtIdx = fn.indexOf('AiLogic.executeAICapManagement({ autoManageUserCap: batchSim })');
+
+    expect(batchGuardIdx).toBeGreaterThan(-1);
+    expect(rosterCheckIdx).toBeGreaterThan(batchGuardIdx);
+    expect(capCheckIdx).toBeGreaterThan(rosterCheckIdx);
+    expect(cutdownIdx).toBeGreaterThan(capCheckIdx);
+    expect(capMgmtIdx).toBeGreaterThan(cutdownIdx);
+  });
+
+  it('treats explicit durability batch mode as the only user auto-management capability', () => {
+    expect(fn.includes('if (payload?.skipUserGame)')).toBe(false);
+    expect(fn.includes('AiLogic.executeAICutdowns({ includeUserTeam: true })')).toBe(false);
+    expect(fn.includes('AiLogic.executeAICutdowns({ includeUserTeam: batchSim })')).toBe(true);
+    expect(fn.includes('AiLogic.executeAICapManagement({ autoManageUserCap: batchSim })')).toBe(true);
   });
 
   it('repairs depth charts before the phase-transition flush so the cleanup persists', () => {

--- a/src/worker/__tests__/depthChartRepairAfterRelease.test.js
+++ b/src/worker/__tests__/depthChartRepairAfterRelease.test.js
@@ -60,7 +60,7 @@ describe('AI preseason cutdowns / cap management — depth chart repair', () => 
 
   it('calls the canonical depth-chart repair after AI cutdowns and cap management', () => {
     const cutdownIdx = fn.indexOf('AiLogic.executeAICutdowns()');
-    const capMgmtIdx = fn.indexOf('AiLogic.executeAICapManagement()');
+    const capMgmtIdx = fn.indexOf('AiLogic.executeAICapManagement(');
     const repairIdx = fn.indexOf("validateAndRepairAllTeamDepthCharts('post-ai-cutdown')");
 
     expect(cutdownIdx).toBeGreaterThan(-1);

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -3145,6 +3145,39 @@ async function handleAdvanceWeek(payload, id) {
       post(toUI.ERROR, { message: `Cannot advance week in phase "${meta.phase}". Use the correct action.` }, id);
       return;
   }
+
+  // ── Preseason AI cutdown + cap management MUST precede the legality gate ────
+  // The pre-advance legality gate below evaluates every team's cap against the
+  // live salary cap. During preseason a team still carries its full offseason
+  // roster (well over 53), so its aggregate cap hit is meaningless until the
+  // cutdown + AI cap-management pass has produced the legal 53-man roster.
+  // Running that pass here — before the gate — is what lets AI teams (and, in an
+  // explicit headless lifecycle, the auto-managed user team) enter the regular
+  // season legally instead of deadlocking the franchise at the first AI team
+  // whose pre-cutdown payroll happens to exceed that season's grown cap.
+  if (meta.phase === 'preseason') {
+    const batchSim = typeof globalThis !== 'undefined' && !!globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__;
+
+    // Headless/batch lifecycle: no interactive user to make the 53-man cutdown,
+    // so the user team is cut with the same logic as every AI team.
+    if (payload?.skipUserGame) {
+      await AiLogic.executeAICutdowns({ includeUserTeam: true });
+    }
+
+    // AI roster cutdowns (53-man limit) for all AI teams.
+    await AiLogic.executeAICutdowns();
+
+    // AI cap management: bring every AI team legally under the LIVE cap using the
+    // least-destructive plan. The interactive user team is NEVER auto-managed;
+    // only an explicit headless lifecycle (durability batch-sim) opts it in.
+    await AiLogic.executeAICapManagement({ autoManageUserCap: batchSim });
+
+    // Cutdowns/releases above release players directly (teamId -> null) without
+    // touching team.depthChart, leaving dangling starter/backup references.
+    // Repair them before the legality gate validates depth-chart integrity.
+    validateAndRepairAllTeamDepthCharts('post-ai-cutdown');
+  }
+
   const legality = runLegalityValidation({ stage: 'pre-advance' }).issues.filter((issue) => issue.severity === 'error');
   if (legality.length > 0) {
     post(toUI.ERROR, { message: legality[0].message }, id);
@@ -3165,34 +3198,15 @@ async function handleAdvanceWeek(payload, id) {
   if (meta.phase === 'preseason') {
     const limit = Constants.ROSTER_LIMITS.REGULAR_SEASON;
 
-    // Headless/batch simulation (skipUserGame) has no interactive user to make
-    // the preseason 53-man cutdown, so the user team is cut down by the same AI
-    // logic as every other team — otherwise the new season can never start and
-    // the franchise cannot survive into subsequent years. Interactive play is
-    // unchanged: skipUserGame is only set by the batch orchestrator, so the
-    // manual-cutdown gate below still applies to real players.
-    if (payload?.skipUserGame) {
-      await AiLogic.executeAICutdowns({ includeUserTeam: true });
-    }
-
+    // AI cutdowns + AI cap management + depth repair already ran above (before
+    // the legality gate). For an INTERACTIVE user the roster is cut manually, so
+    // block the season start until the user is at the 53-man limit. In a headless
+    // lifecycle the user team was already cut above via includeUserTeam.
     const userRoster = cache.getPlayersByTeam(meta.userTeamId);
     if (userRoster.length > limit) {
       post(toUI.ERROR, { message: `Roster limit exceeded! You have ${userRoster.length} players. Cut down to ${limit} to advance.` }, id);
       return;
     }
-
-    // Execute AI Cutdowns (53-man roster limit)
-    await AiLogic.executeAICutdowns();
-
-    // Execute AI Cap Management — restructure stars or cut cap-inefficient
-    // veterans so all AI teams are under the $301.2M hard cap at season start.
-    await AiLogic.executeAICapManagement();
-
-    // Both cutdown passes above release players directly (teamId -> null)
-    // without touching team.depthChart, so cut players would otherwise linger
-    // as dangling starter/backup references until the next pre-sim rebuild.
-    // Repair immediately using the same canonical utility as a manual release.
-    validateAndRepairAllTeamDepthCharts('post-ai-cutdown');
 
     // Priority 4: Initialize zeroed-out season stat entries for EVERY active player
     // on EVERY team before the first game is simulated. This guarantees that:

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -3157,11 +3157,21 @@ async function handleAdvanceWeek(payload, id) {
   // whose pre-cutdown payroll happens to exceed that season's grown cap.
   if (meta.phase === 'preseason') {
     const batchSim = typeof globalThis !== 'undefined' && !!globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__;
+    const rosterLimit = Constants.ROSTER_LIMITS.REGULAR_SEASON;
 
-    // Headless/batch lifecycle: no interactive user to make the 53-man cutdown,
-    // so the user team is cut with the same logic as every AI team.
+    // INTERACTIVE user cuts down manually. Block a doomed Start Season BEFORE any
+    // AI mutation runs, so a failed attempt never releases/restructures AI players
+    // or writes transactions while the season does not advance. HEADLESS/batch
+    // lifecycles have no interactive user, so the user team is cut with the AI
+    // teams below (includeUserTeam) instead.
     if (payload?.skipUserGame) {
       await AiLogic.executeAICutdowns({ includeUserTeam: true });
+    } else {
+      const userRoster = cache.getPlayersByTeam(meta.userTeamId);
+      if (userRoster.length > rosterLimit) {
+        post(toUI.ERROR, { message: `Roster limit exceeded! You have ${userRoster.length} players. Cut down to ${rosterLimit} to advance.` }, id);
+        return;
+      }
     }
 
     // AI roster cutdowns (53-man limit) for all AI teams.
@@ -3194,19 +3204,11 @@ async function handleAdvanceWeek(payload, id) {
     }
   }
 
-  // ── Preseason Cutdown Check ──────────────────────────────────────────────
+  // ── Preseason → Regular transition ────────────────────────────────────────
   if (meta.phase === 'preseason') {
-    const limit = Constants.ROSTER_LIMITS.REGULAR_SEASON;
-
-    // AI cutdowns + AI cap management + depth repair already ran above (before
-    // the legality gate). For an INTERACTIVE user the roster is cut manually, so
-    // block the season start until the user is at the 53-man limit. In a headless
-    // lifecycle the user team was already cut above via includeUserTeam.
-    const userRoster = cache.getPlayersByTeam(meta.userTeamId);
-    if (userRoster.length > limit) {
-      post(toUI.ERROR, { message: `Roster limit exceeded! You have ${userRoster.length} players. Cut down to ${limit} to advance.` }, id);
-      return;
-    }
+    // Roster cutdowns, AI cap management, depth repair, and the interactive-user
+    // 53-man gate all ran above (before the legality gate). Nothing to block on
+    // here — proceed to season-stat initialization and the phase transition.
 
     // Priority 4: Initialize zeroed-out season stat entries for EVERY active player
     // on EVERY team before the first game is simulated. This guarantees that:

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -3172,6 +3172,18 @@ async function handleAdvanceWeek(payload, id) {
         post(toUI.ERROR, { message: `Roster limit exceeded! You have ${userRoster.length} players. Cut down to ${rosterLimit} to advance.` }, id);
         return;
       }
+      // Also confirm the user team is cap-legal BEFORE mutating AI teams, so a
+      // doomed Start Season (user at 53 but over the cap) never releases or
+      // restructures AI players or writes transactions. The full gate below
+      // re-checks every team once the AI teams have been made legal. Scope to
+      // cap only — depth-chart issues are auto-repaired by the pass below and
+      // must not falsely block here.
+      const userCapIssues = runLegalityValidation({ stage: 'pre-advance', teamIds: [meta.userTeamId] })
+        .issues.filter((issue) => issue.severity === 'error' && issue.code === 'cap_limit');
+      if (userCapIssues.length > 0) {
+        post(toUI.ERROR, { message: userCapIssues[0].message }, id);
+        return;
+      }
     }
 
     // AI roster cutdowns (53-man limit) for all AI teams.

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -3166,6 +3166,21 @@ async function handleAdvanceWeek(payload, id) {
     // teams below (includeUserTeam) instead.
     if (payload?.skipUserGame) {
       await AiLogic.executeAICutdowns({ includeUserTeam: true });
+      // "Sim to phase" is an INTERACTIVE feature that also advances with
+      // skipUserGame (batchSim is false there — only an explicit headless
+      // durability lifecycle sets it). If the auto-cut user team is still over
+      // the cap, block before AI CAP MANAGEMENT restructures/releases AI players
+      // — the interactive user must resolve their own cap first. An explicit
+      // headless lifecycle (batchSim) auto-manages the user team instead and
+      // never blocks here.
+      if (!batchSim) {
+        const userCapIssues = runLegalityValidation({ stage: 'pre-advance', teamIds: [meta.userTeamId] })
+          .issues.filter((issue) => issue.severity === 'error' && issue.code === 'cap_limit');
+        if (userCapIssues.length > 0) {
+          post(toUI.ERROR, { message: userCapIssues[0].message }, id);
+          return;
+        }
+      }
     } else {
       const userRoster = cache.getPlayersByTeam(meta.userTeamId);
       if (userRoster.length > rosterLimit) {

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -3161,38 +3161,22 @@ async function handleAdvanceWeek(payload, id) {
 
     // INTERACTIVE user cuts down manually. Block a doomed Start Season BEFORE any
     // AI mutation runs, so a failed attempt never releases/restructures AI players
-    // or writes transactions while the season does not advance. HEADLESS/batch
-    // lifecycles have no interactive user, so the user team is cut with the AI
-    // teams below (includeUserTeam) instead.
-    if (payload?.skipUserGame) {
-      await AiLogic.executeAICutdowns({ includeUserTeam: true });
-      // "Sim to phase" is an INTERACTIVE feature that also advances with
-      // skipUserGame (batchSim is false there — only an explicit headless
-      // durability lifecycle sets it). If the auto-cut user team is still over
-      // the cap, block before AI CAP MANAGEMENT restructures/releases AI players
-      // — the interactive user must resolve their own cap first. An explicit
-      // headless lifecycle (batchSim) auto-manages the user team instead and
-      // never blocks here.
-      if (!batchSim) {
-        const userCapIssues = runLegalityValidation({ stage: 'pre-advance', teamIds: [meta.userTeamId] })
-          .issues.filter((issue) => issue.severity === 'error' && issue.code === 'cap_limit');
-        if (userCapIssues.length > 0) {
-          post(toUI.ERROR, { message: userCapIssues[0].message }, id);
-          return;
-        }
-      }
-    } else {
+    // or writes transactions while the season does not advance. `skipUserGame` is
+    // only a prompt/game-simulation skip used by UI flows such as SIM_TO_PHASE; it
+    // is not a headless roster-management capability. Only the explicit durability
+    // batch flag opts the user team into automated cutdowns/cap management.
+    if (!batchSim) {
       const userRoster = cache.getPlayersByTeam(meta.userTeamId);
       if (userRoster.length > rosterLimit) {
         post(toUI.ERROR, { message: `Roster limit exceeded! You have ${userRoster.length} players. Cut down to ${rosterLimit} to advance.` }, id);
         return;
       }
-      // Also confirm the user team is cap-legal BEFORE mutating AI teams, so a
-      // doomed Start Season (user at 53 but over the cap) never releases or
-      // restructures AI players or writes transactions. The full gate below
-      // re-checks every team once the AI teams have been made legal. Scope to
-      // cap only — depth-chart issues are auto-repaired by the pass below and
-      // must not falsely block here.
+      // Confirm the user team is cap-legal BEFORE mutating AI teams, so a doomed
+      // interactive Start Season/SIM_TO_PHASE/skipUserGame advance never releases
+      // or restructures AI players or writes transactions. The full gate below
+      // re-checks every team once the AI teams have been made legal. Scope to cap
+      // only — depth-chart issues are auto-repaired by the pass below and must
+      // not falsely block here.
       const userCapIssues = runLegalityValidation({ stage: 'pre-advance', teamIds: [meta.userTeamId] })
         .issues.filter((issue) => issue.severity === 'error' && issue.code === 'cap_limit');
       if (userCapIssues.length > 0) {
@@ -3201,8 +3185,10 @@ async function handleAdvanceWeek(payload, id) {
       }
     }
 
-    // AI roster cutdowns (53-man limit) for all AI teams.
-    await AiLogic.executeAICutdowns();
+    // AI roster cutdowns (53-man limit) for all AI teams. Explicit headless
+    // durability/batch mode also opts the user team into the same deterministic
+    // cutdown pass; interactive skipUserGame/SIM_TO_PHASE does not.
+    await AiLogic.executeAICutdowns({ includeUserTeam: batchSim });
 
     // AI cap management: bring every AI team legally under the LIVE cap using the
     // least-destructive plan. The interactive user team is NEVER auto-managed;

--- a/tests/integration/preseasonAdvanceUserGate.worker.test.js
+++ b/tests/integration/preseasonAdvanceUserGate.worker.test.js
@@ -1,0 +1,256 @@
+import 'fake-indexeddb/auto';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { toWorker, toUI } from '../../src/worker/protocol.js';
+import { cache } from '../../src/db/cache.js';
+import { Transactions } from '../../src/db/index.js';
+
+const SLOT_KEY = 'save_slot_1';
+const USER_TEAM_ID = 0;
+const BOOT_TIMEOUT_MS = 180_000;
+const TEST_TIMEOUT_MS = 180_000;
+
+const waiters = new Map();
+let msgSeq = 0;
+let syntheticSeq = 0;
+
+function installSelfBridge() {
+  globalThis.self = {
+    onmessage: null,
+    postMessage(msg) {
+      if (msg?.id != null && waiters.has(msg.id)) {
+        const resolve = waiters.get(msg.id);
+        waiters.delete(msg.id);
+        resolve(msg);
+      }
+    },
+  };
+}
+
+function payloadOf(msg) {
+  const p = msg?.payload;
+  if (p && typeof p._jsonPayload === 'string') return JSON.parse(p._jsonPayload);
+  return p;
+}
+
+function send(type, payload = {}, { timeoutMs = 60_000 } = {}) {
+  const id = `preseason-user-gate-${++msgSeq}`;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      waiters.delete(id);
+      reject(new Error(`Timeout (${timeoutMs}ms) waiting for reply to ${type}`));
+    }, timeoutMs);
+    waiters.set(id, (msg) => {
+      clearTimeout(timer);
+      resolve(msg);
+    });
+    globalThis.self.onmessage({ data: { type, payload, id } });
+  });
+}
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function sortedRoster(teamId) {
+  return cache.getPlayersByTeam(teamId).slice().sort((a, b) => String(a.id).localeCompare(String(b.id)));
+}
+
+function rosterIds(teamId) {
+  return sortedRoster(teamId).map((p) => String(p.id));
+}
+
+function rosterContracts(teamId) {
+  return sortedRoster(teamId).map((p) => [String(p.id), cloneJson(p.contract ?? null)]);
+}
+
+function allAiRosterContracts() {
+  return cache.getAllTeams()
+    .filter((team) => Number(team.id) !== USER_TEAM_ID)
+    .map((team) => [Number(team.id), rosterContracts(team.id)]);
+}
+
+function teamMoney(teamId) {
+  const team = cache.getTeam(teamId);
+  return {
+    deadCap: Number(team?.deadCap ?? 0),
+    deadMoneyNextYear: Number(team?.deadMoneyNextYear ?? 0),
+  };
+}
+
+function userDepthSnapshot() {
+  const team = cache.getTeam(USER_TEAM_ID);
+  return cloneJson({
+    teamDepthChart: team?.depthChart ?? null,
+    playerDepth: sortedRoster(USER_TEAM_ID).map((p) => [String(p.id), cloneJson(p.depthChart ?? null)]),
+  });
+}
+
+async function transactionCountByTypes(types, teamId = null) {
+  const txs = await Transactions.loadRecent(4000).catch(() => []);
+  return txs.filter((tx) =>
+    types.includes(tx?.type) &&
+    (teamId == null || Number(tx?.teamId) === Number(teamId))
+  ).length;
+}
+
+function enterPreseason() {
+  const meta = cache.getMeta();
+  cache.setMeta({
+    ...meta,
+    phase: 'preseason',
+    currentWeek: 1,
+    currentSeasonId: meta?.currentSeasonId ?? `season-${meta?.year ?? 2026}`,
+    economy: {
+      ...(meta?.economy ?? {}),
+      currentSalaryCap: Number(meta?.economy?.currentSalaryCap ?? 300),
+    },
+  });
+}
+
+function normalizeUserRosterTo(count) {
+  const roster = sortedRoster(USER_TEAM_ID);
+  for (const player of roster.slice(count)) {
+    cache.updatePlayer(player.id, { teamId: null, status: 'free_agent' });
+  }
+  const kept = sortedRoster(USER_TEAM_ID);
+  if (kept.length >= count) return;
+  const template = kept[0] ?? cache.getAllPlayers()[0];
+  for (let i = kept.length; i < count; i += 1) {
+    const id = `synthetic-user-${Date.now()}-${++syntheticSeq}`;
+    cache.setPlayer({
+      ...cloneJson(template),
+      id,
+      name: `Synthetic User ${syntheticSeq}`,
+      teamId: USER_TEAM_ID,
+      status: 'active',
+      ovr: 35,
+      potential: 35,
+      contract: {
+        years: 1,
+        yearsTotal: 1,
+        baseAnnual: 1,
+        signingBonus: 0,
+        guaranteedPct: 0,
+      },
+      depthChart: null,
+    });
+  }
+}
+
+function makeUserOverCap() {
+  const meta = cache.getMeta();
+  const hardCap = Number(meta?.settings?.salaryCap ?? 300);
+  const [player] = sortedRoster(USER_TEAM_ID);
+  cache.updatePlayer(player.id, {
+    contract: {
+      ...(player.contract ?? {}),
+      years: 1,
+      yearsTotal: 1,
+      baseAnnual: hardCap + 100,
+      signingBonus: 0,
+      guaranteedPct: 1,
+    },
+  });
+}
+
+async function bootFreshLeague(name) {
+  const boot = await send(
+    toWorker.USE_SAFE_STARTER_LEAGUE,
+    { slotKey: SLOT_KEY, options: { rngSeed: 1684, userTeamId: USER_TEAM_ID, name } },
+    { timeoutMs: BOOT_TIMEOUT_MS },
+  );
+  expect(boot.type, JSON.stringify(payloadOf(boot))).toBe(toUI.FULL_STATE);
+  enterPreseason();
+  delete globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__;
+}
+
+beforeAll(async () => {
+  installSelfBridge();
+  await import('../../src/worker/worker.js');
+  const ready = await send(toWorker.INIT, {}, { timeoutMs: BOOT_TIMEOUT_MS });
+  expect(ready.type).toBe(toUI.READY);
+}, BOOT_TIMEOUT_MS);
+
+beforeEach(async () => {
+  await bootFreshLeague(`Preseason User Gate ${Date.now()}`);
+}, BOOT_TIMEOUT_MS);
+
+afterAll(() => {
+  delete globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__;
+  delete globalThis.self;
+});
+
+describe('ADVANCE_WEEK preseason user gating', () => {
+  it('blocks interactive SIM_TO_PHASE skip when the user roster is over 53 without mutating user or AI state', async () => {
+    normalizeUserRosterTo(54);
+    const userRosterBefore = rosterIds(USER_TEAM_ID);
+    const userContractsBefore = rosterContracts(USER_TEAM_ID);
+    const userDepthBefore = userDepthSnapshot();
+    const userMoneyBefore = teamMoney(USER_TEAM_ID);
+    const aiBefore = allAiRosterContracts();
+    const userTxBefore = await transactionCountByTypes(['RELEASE', 'RESTRUCTURE'], USER_TEAM_ID);
+
+    const reply = await send(toWorker.ADVANCE_WEEK, { skipUserGame: true }, { timeoutMs: TEST_TIMEOUT_MS });
+
+    expect(reply.type).toBe(toUI.ERROR);
+    expect(payloadOf(reply)?.message).toMatch(/Roster limit exceeded|Cut down to 53|has 54\/53 players/i);
+    expect(rosterIds(USER_TEAM_ID)).toEqual(userRosterBefore);
+    expect(rosterContracts(USER_TEAM_ID)).toEqual(userContractsBefore);
+    expect(userDepthSnapshot()).toEqual(userDepthBefore);
+    expect(teamMoney(USER_TEAM_ID)).toEqual(userMoneyBefore);
+    expect(await transactionCountByTypes(['RELEASE', 'RESTRUCTURE'], USER_TEAM_ID)).toBe(userTxBefore);
+    expect(allAiRosterContracts()).toEqual(aiBefore);
+    expect(cache.getMeta()?.phase).toBe('preseason');
+  }, TEST_TIMEOUT_MS);
+
+  it('blocks interactive SIM_TO_PHASE skip when the user is over cap without mutating any team or committing transactions', async () => {
+    normalizeUserRosterTo(53);
+    makeUserOverCap();
+    const userRosterBefore = rosterIds(USER_TEAM_ID);
+    const userContractsBefore = rosterContracts(USER_TEAM_ID);
+    const userMoneyBefore = teamMoney(USER_TEAM_ID);
+    const aiBefore = allAiRosterContracts();
+    const txBefore = await transactionCountByTypes(['RELEASE', 'RESTRUCTURE']);
+
+    const reply = await send(toWorker.ADVANCE_WEEK, { skipUserGame: true }, { timeoutMs: TEST_TIMEOUT_MS });
+
+    expect(reply.type).toBe(toUI.ERROR);
+    expect(payloadOf(reply)?.message).toMatch(/over cap/i);
+    expect(rosterIds(USER_TEAM_ID)).toEqual(userRosterBefore);
+    expect(rosterContracts(USER_TEAM_ID)).toEqual(userContractsBefore);
+    expect(teamMoney(USER_TEAM_ID)).toEqual(userMoneyBefore);
+    expect(allAiRosterContracts()).toEqual(aiBefore);
+    expect(await transactionCountByTypes(['RELEASE', 'RESTRUCTURE'])).toBe(txBefore);
+    expect(cache.getMeta()?.phase).toBe('preseason');
+  }, TEST_TIMEOUT_MS);
+
+  it('allows explicit headless batch mode to cut down the user team and complete preseason transition', async () => {
+    normalizeUserRosterTo(54);
+    const userRosterBefore = rosterIds(USER_TEAM_ID);
+    globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__ = true;
+
+    const reply = await send(toWorker.ADVANCE_WEEK, { skipUserGame: true }, { timeoutMs: TEST_TIMEOUT_MS });
+
+    expect(reply.type).not.toBe(toUI.ERROR);
+    expect(cache.getMeta()?.phase).toBe('regular');
+    expect(rosterIds(USER_TEAM_ID).length).toBeLessThanOrEqual(53);
+    expect(rosterIds(USER_TEAM_ID)).not.toEqual(userRosterBefore);
+    expect(cache.getAllTeams().every((team) => cache.getPlayersByTeam(team.id).length <= 53)).toBe(true);
+  }, TEST_TIMEOUT_MS);
+
+  it('blocks normal interactive Start Season before AI mutations when the user roster is over 53', async () => {
+    normalizeUserRosterTo(54);
+    const userRosterBefore = rosterIds(USER_TEAM_ID);
+    const userContractsBefore = rosterContracts(USER_TEAM_ID);
+    const aiBefore = allAiRosterContracts();
+
+    const reply = await send(toWorker.ADVANCE_WEEK, {}, { timeoutMs: TEST_TIMEOUT_MS });
+
+    expect(reply.type).toBe(toUI.ERROR);
+    expect(payloadOf(reply)?.message).toMatch(/Roster limit exceeded|Cut down to 53|has 54\/53 players/i);
+    expect(rosterIds(USER_TEAM_ID)).toEqual(userRosterBefore);
+    expect(rosterContracts(USER_TEAM_ID)).toEqual(userContractsBefore);
+    expect(allAiRosterContracts()).toEqual(aiBefore);
+    expect(cache.getMeta()?.phase).toBe('preseason');
+  }, TEST_TIMEOUT_MS);
+});

--- a/tests/unit/aiCapCompliancePlan.test.js
+++ b/tests/unit/aiCapCompliancePlan.test.js
@@ -139,6 +139,23 @@ describe('AiLogic.buildAiCapCompliancePlan — releases by net relief', () => {
     for (const r of releases) expect(r.netRelief).toBeGreaterThan(0);
   });
 
+  it('never releases a player it just restructured (excludes restructured IDs from the cut pool)', () => {
+    // Star is restructured in phase 1 but the team is still over the legal cap,
+    // forcing phase-2 cuts. A restructured player has inflated dead cap / reduced
+    // net relief, so he must NOT be the release target — cheaper depth is cut.
+    const star = player({ id: 'STAR', pos: 'QB', ovr: 95, age: 28, base: 50, sb: 0, yearsTotal: 4, years: 4 });
+    const roster = [star, ...depthFiller(52, 5)]; // rosterCap = 50 + 260 = 310
+    const team = { id: 5, abbr: 'CIN', deadCap: 0 };
+    const plan = AiLogic.buildAiCapCompliancePlan(team, roster, { legalCap: 285, targetBuffer: 0, season: 2029 });
+
+    const restructuredStar = plan.actions.find((a) => a.type === 'RESTRUCTURE' && a.playerId === 'STAR');
+    const releasedStar = plan.actions.find((a) => a.type === 'RELEASE' && a.playerId === 'STAR');
+    expect(restructuredStar).toBeDefined();
+    expect(releasedStar).toBeUndefined();
+    expect(plan.actions.some((a) => a.type === 'RELEASE')).toBe(true); // reached legal via depth cuts
+    expect(plan.projected.isLegallyCompliant).toBe(true);
+  });
+
   it('never chooses a zero/negative-net-relief release for cap compliance', () => {
     // Player with all-bonus contract → net relief 0.
     const zero = player({ id: 'Z', pos: 'WR', ovr: 70, age: 30, base: 0, sb: 20, yearsTotal: 4, years: 4 }); // hit 5, dead 5, net 0

--- a/tests/unit/aiCapCompliancePlan.test.js
+++ b/tests/unit/aiCapCompliancePlan.test.js
@@ -1,0 +1,201 @@
+/**
+ * aiCapCompliancePlan.test.js
+ *
+ * Unit coverage for the canonical AI cap-compliance planner and cap snapshot
+ * introduced by "AI Post-Rollover Salary-Cap Compliance V1".
+ *
+ * These exercise the PURE decision layer (no cache, no IndexedDB):
+ *   - buildTeamCapSnapshot  (contractObligations.js) — the single legal-cap
+ *     equation shared with the pre-advance legality gate.
+ *   - AiLogic.buildAiCapCompliancePlan — deterministic plan-then-commit planner.
+ *   - AiLogic._releaseDeadCapSplit — post-June-1 dead-cap split.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the heavy cache / persistence deps so importing AiLogic is side-effect
+// free. The planner functions under test never touch these mocks.
+vi.mock('../../src/db/cache.js', () => ({ cache: {} }));
+vi.mock('../../src/db/index.js', () => ({ Transactions: { add: vi.fn() } }));
+vi.mock('../../src/core/news-engine.js', () => ({ default: { logTransaction: vi.fn(), logNews: vi.fn() } }));
+
+import { buildTeamCapSnapshot } from '../../src/core/contracts/contractObligations.js';
+import AiLogic from '../../src/core/ai-logic.js';
+
+let uid = 0;
+function player({ pos = 'WR', ovr = 70, age = 27, base = 1, sb = 0, yearsTotal = 1, years = yearsTotal, id, restructureCount = 0, lastRestructuredSeason } = {}) {
+  return {
+    id: id ?? `p${++uid}`,
+    pos, ovr, age,
+    contract: { baseAnnual: base, signingBonus: sb, yearsTotal, years, yearsRemaining: years, restructureCount, ...(lastRestructuredSeason != null ? { lastRestructuredSeason } : {}) },
+  };
+}
+
+/** Roster of cheap depth so position floors are always satisfied. */
+function depthFiller(n, base = 0.75) {
+  const positions = ['QB', 'RB', 'WR', 'TE', 'OL', 'DL', 'LB', 'CB', 'S', 'K', 'P'];
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    out.push(player({ pos: positions[i % positions.length], ovr: 60, age: 25, base }));
+  }
+  return out;
+}
+
+describe('buildTeamCapSnapshot — canonical legal equation (matches legality gate)', () => {
+  it('counts current-year dead cap toward legal compliance', () => {
+    // rosterCap 295 + deadCap 18 = 313 committed vs cap 301 → over by 12.
+    const roster = [player({ base: 295, yearsTotal: 1 })];
+    const snap = buildTeamCapSnapshot({ team: { deadCap: 18 }, roster, salaryCap: 301 });
+    expect(snap.rosterCap).toBe(295);
+    expect(snap.deadCap).toBe(18);
+    expect(snap.totalCommitted).toBe(313);
+    expect(snap.isLegallyCompliant).toBe(false);
+    expect(snap.overageVsLegal).toBe(12);
+  });
+
+  it('does not treat roster cap alone below the cap as compliant when dead cap pushes it over', () => {
+    const roster = [player({ base: 295, yearsTotal: 1 })];
+    const snap = buildTeamCapSnapshot({ team: { deadCap: 18 }, roster, salaryCap: 301 });
+    // capUsed(295) <= cap(301) would be the OLD buggy check — snapshot rejects it.
+    expect(snap.rosterCap).toBeLessThanOrEqual(301);
+    expect(snap.isLegallyCompliant).toBe(false);
+  });
+
+  it('uses the live salary cap passed in, not a hard-coded constant', () => {
+    const roster = [player({ base: 295, yearsTotal: 1 })];
+    const overSnap = buildTeamCapSnapshot({ team: { deadCap: 18 }, roster, salaryCap: 301 });
+    const liveSnap = buildTeamCapSnapshot({ team: { deadCap: 18 }, roster, salaryCap: 350 });
+    expect(overSnap.isLegallyCompliant).toBe(false);
+    expect(liveSnap.isLegallyCompliant).toBe(true);
+    expect(liveSnap.capRoom).toBe(37);
+  });
+
+  it('separates the planning buffer from the legal ceiling', () => {
+    const roster = [player({ base: 290, yearsTotal: 1 })];
+    const snap = buildTeamCapSnapshot({ team: { deadCap: 0 }, roster, salaryCap: 301, targetBuffer: 25 });
+    expect(snap.legalLimit).toBe(301);
+    expect(snap.isLegallyCompliant).toBe(true);       // 290 <= 301
+    expect(snap.targetCommitted).toBe(276);           // 301 - 25
+    expect(snap.isWithinPlanningTarget).toBe(false);  // 290 > 276
+  });
+});
+
+describe('AiLogic._releaseDeadCapSplit — post-June-1 dead cap', () => {
+  it('charges only the current year proration now and defers the rest', () => {
+    const p = player({ base: 4, sb: 12, yearsTotal: 4, years: 4 });
+    const { currentYearDead, futureYearsDead } = AiLogic._releaseDeadCapSplit(p);
+    expect(currentYearDead).toBe(3);   // 12 / 4
+    expect(futureYearsDead).toBe(9);   // 3 * (4 - 1)
+  });
+});
+
+describe('AiLogic.buildAiCapCompliancePlan — restructures', () => {
+  it('produces a restructure with proven positive current-year relief and reaches legal', () => {
+    const star = player({ pos: 'QB', ovr: 90, base: 50, sb: 0, yearsTotal: 4, years: 4 });
+    const roster = [star, ...depthFiller(52, 1.15)]; // rosterCap ≈ 50 + 59.8 = 109.8
+    const team = { id: 5, abbr: 'CIN', deadCap: 0 };
+    const plan = AiLogic.buildAiCapCompliancePlan(team, roster, { legalCap: 100, targetBuffer: 0, season: 2029 });
+
+    const restructures = plan.actions.filter((a) => a.type === 'RESTRUCTURE');
+    expect(restructures.length).toBeGreaterThan(0);
+    for (const r of restructures) expect(r.relief).toBeGreaterThan(0);
+    expect(plan.projected.isLegallyCompliant).toBe(true);
+    expect(plan.failure).toBeNull();
+  });
+
+  it('skips restructuring a player already restructured this season (no repeat)', () => {
+    const star = player({ pos: 'QB', ovr: 90, base: 50, sb: 0, yearsTotal: 4, years: 4, lastRestructuredSeason: 2029 });
+    const roster = [star, ...depthFiller(52, 1.15)];
+    const team = { id: 5, abbr: 'CIN', deadCap: 0 };
+    const plan = AiLogic.buildAiCapCompliancePlan(team, roster, { legalCap: 100, targetBuffer: 0, season: 2029 });
+    const restructuredStar = plan.actions.find((a) => a.type === 'RESTRUCTURE' && a.playerId === star.id);
+    expect(restructuredStar).toBeUndefined();
+  });
+
+  it('does not restructure the same player twice within a single plan', () => {
+    const star = player({ pos: 'QB', ovr: 95, base: 80, sb: 0, yearsTotal: 5, years: 5 });
+    const roster = [star, ...depthFiller(52, 2)];
+    const team = { id: 5, abbr: 'CIN', deadCap: 0 };
+    const plan = AiLogic.buildAiCapCompliancePlan(team, roster, { legalCap: 100, targetBuffer: 0, season: 2029 });
+    const ids = plan.actions.filter((a) => a.type === 'RESTRUCTURE').map((a) => a.playerId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('AiLogic.buildAiCapCompliancePlan — releases by net relief', () => {
+  it('prefers realizable net relief over raw cap hit', () => {
+    // A: high cap hit but almost all dead money → tiny net relief.
+    const A = player({ id: 'A', pos: 'WR', ovr: 70, age: 30, base: 2, sb: 40, yearsTotal: 4, years: 4 }); // hit 12, dead 10, net 2
+    // B: lower cap hit, all base → large net relief.
+    const B = player({ id: 'B', pos: 'WR', ovr: 70, age: 30, base: 9, sb: 0, yearsTotal: 1, years: 1 });   // hit 9, dead 0, net 9
+    const roster = [A, B, ...depthFiller(51, 1)];
+    const team = { id: 6, abbr: 'CLE', deadCap: 0 };
+    // Over the legal cap by ~ a few M so exactly one net-relief cut is needed.
+    const legalCap = buildTeamCapSnapshot({ team, roster, salaryCap: 9999 }).rosterCap - 5;
+    const plan = AiLogic.buildAiCapCompliancePlan(team, roster, { legalCap, targetBuffer: 0, season: 2029 });
+    const releases = plan.actions.filter((a) => a.type === 'RELEASE');
+    expect(releases.length).toBeGreaterThan(0);
+    // The first release must be B (net 9), never A (net 2).
+    expect(releases[0].playerId).toBe('B');
+    for (const r of releases) expect(r.netRelief).toBeGreaterThan(0);
+  });
+
+  it('never chooses a zero/negative-net-relief release for cap compliance', () => {
+    // Player with all-bonus contract → net relief 0.
+    const zero = player({ id: 'Z', pos: 'WR', ovr: 70, age: 30, base: 0, sb: 20, yearsTotal: 4, years: 4 }); // hit 5, dead 5, net 0
+    const real = player({ id: 'R', pos: 'WR', ovr: 68, age: 31, base: 12, sb: 0, yearsTotal: 1, years: 1 }); // net 12
+    const roster = [zero, real, ...depthFiller(51, 1)];
+    const team = { id: 6, abbr: 'CLE', deadCap: 0 };
+    const legalCap = buildTeamCapSnapshot({ team, roster, salaryCap: 9999 }).rosterCap - 6;
+    const plan = AiLogic.buildAiCapCompliancePlan(team, roster, { legalCap, targetBuffer: 0, season: 2029 });
+    const releasedZero = plan.actions.find((a) => a.type === 'RELEASE' && a.playerId === 'Z');
+    expect(releasedZero).toBeUndefined();
+  });
+});
+
+describe('AiLogic.buildAiCapCompliancePlan — safeguards', () => {
+  it('does not cut a position below its floor even when it is the only cap relief', () => {
+    // Roster sits at EXACTLY the position floor for every group, so cutting any
+    // player would drop that position below its floor. The two QBs are expensive
+    // and un-restructurable (1 yr left) — the only theoretical relief.
+    const floors = { QB: 2, RB: 2, WR: 3, TE: 1, OL: 5, DL: 4, LB: 3, CB: 2, S: 2, K: 1, P: 1 };
+    const roster = [];
+    for (const [pos, count] of Object.entries(floors)) {
+      for (let i = 0; i < count; i++) {
+        const expensiveQb = pos === 'QB';
+        roster.push(player({
+          id: `${pos}${i}`, pos, ovr: 78, age: 30,
+          base: expensiveQb ? 30 : 0.75, sb: 0, yearsTotal: 1, years: 1,
+        }));
+      }
+    }
+    const team = { id: 9, abbr: 'IND', deadCap: 0 };
+    const legalCap = buildTeamCapSnapshot({ team, roster, salaryCap: 9999 }).rosterCap - 10;
+    const plan = AiLogic.buildAiCapCompliancePlan(team, roster, { legalCap, targetBuffer: 0, season: 2029 });
+    const cutQb = plan.actions.find((a) => a.type === 'RELEASE' && String(a.playerId).startsWith('QB'));
+    expect(cutQb).toBeUndefined();
+    // No legal plan exists without violating a floor → structured failure, not silent success.
+    expect(plan.failure).not.toBeNull();
+    expect(plan.failure.remainingOverage).toBeGreaterThan(0);
+  });
+
+  it('returns a structured failure (not an infinite loop) when no legal plan exists', () => {
+    const roster = depthFiller(53, 0.75).map((p) => ({ ...p, contract: { ...p.contract, baseAnnual: 0, signingBonus: 20, yearsTotal: 4, years: 4 } }));
+    const team = { id: 13, abbr: 'KC', deadCap: 0 };
+    const plan = AiLogic.buildAiCapCompliancePlan(team, roster, { legalCap: 10, targetBuffer: 0, season: 2029 });
+    expect(plan.failure).not.toBeNull();
+    expect(plan.failure.reason).toBe('no_legal_plan');
+  });
+
+  it('is deterministic for identical input', () => {
+    const build = () => {
+      uid = 1000; // stable ids across both builds
+      const star = player({ pos: 'QB', ovr: 90, base: 40, sb: 0, yearsTotal: 4, years: 4, id: 'STAR' });
+      const roster = [star, ...depthFiller(52, 2)];
+      const team = { id: 5, abbr: 'CIN', deadCap: 4 };
+      return AiLogic.buildAiCapCompliancePlan(team, roster, { legalCap: 100, targetBuffer: 0, season: 2029 });
+    };
+    const a = build();
+    const b = build();
+    expect(JSON.stringify(a.actions)).toBe(JSON.stringify(b.actions));
+  });
+});

--- a/tests/unit/aiCapCompliancePlan.test.js
+++ b/tests/unit/aiCapCompliancePlan.test.js
@@ -156,6 +156,31 @@ describe('AiLogic.buildAiCapCompliancePlan — releases by net relief', () => {
     expect(plan.projected.isLegallyCompliant).toBe(true);
   });
 
+  it('rolls back a restructure and releases the player when he is the only cap-legal relief', () => {
+    // Star is restructured in phase 1 but the team is still over the legal cap,
+    // and every other player has zero net release relief (all-bonus contracts),
+    // so phase 2a cannot help. Phase 2b must roll back the star's restructure and
+    // release him from his ORIGINAL contract rather than falsely report no plan.
+    const star = player({ id: 'STAR', pos: 'QB', ovr: 95, age: 28, base: 50, sb: 0, yearsTotal: 4, years: 4 });
+    const fillers = [];
+    // Two extra QBs so releasing the star stays at/above the QB floor (2).
+    for (let i = 0; i < 2; i++) fillers.push(player({ id: `QBf${i}`, pos: 'QB', base: 0, sb: 6, yearsTotal: 4, years: 4 }));
+    for (const pos of ['RB', 'WR', 'TE', 'OL', 'DL', 'LB', 'CB', 'S', 'K', 'P']) {
+      for (let i = 0; i < 4; i++) fillers.push(player({ id: `${pos}${i}`, pos, base: 0, sb: 6, yearsTotal: 4, years: 4 }));
+    }
+    const roster = [star, ...fillers]; // all-bonus fillers → net release relief 0
+    const team = { id: 9, abbr: 'IND', deadCap: 0 };
+    const plan = AiLogic.buildAiCapCompliancePlan(team, roster, { legalCap: 90, targetBuffer: 0, season: 2029 });
+
+    const starRelease = plan.actions.find((a) => a.type === 'RELEASE' && a.playerId === 'STAR');
+    const starRestructure = plan.actions.find((a) => a.type === 'RESTRUCTURE' && a.playerId === 'STAR');
+    expect(starRelease).toBeDefined();
+    expect(starRelease.rolledBackRestructure).toBe(true);
+    expect(starRestructure).toBeUndefined();          // restructure rolled back / removed
+    expect(plan.projected.isLegallyCompliant).toBe(true);
+    expect(plan.failure).toBeNull();
+  });
+
   it('never chooses a zero/negative-net-relief release for cap compliance', () => {
     // Player with all-bonus contract → net relief 0.
     const zero = player({ id: 'Z', pos: 'WR', ovr: 70, age: 30, base: 0, sb: 20, yearsTotal: 4, years: 4 }); // hit 5, dead 5, net 0

--- a/tests/unit/aiCapManagementExecution.test.js
+++ b/tests/unit/aiCapManagementExecution.test.js
@@ -1,0 +1,139 @@
+/**
+ * aiCapManagementExecution.test.js
+ *
+ * Integration coverage for AiLogic.executeAICapManagement against an in-memory
+ * cache. Verifies the live commit path: user-team isolation (interactive vs
+ * explicit headless), team-id-0 validity, live-cap legality, and determinism.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => {
+  const state = { store: null, txLog: [] };
+  const mockCache = {
+    getMeta: () => state.store.meta,
+    setMeta: (p) => Object.assign(state.store.meta, p),
+    getAllTeams: () => [...state.store.teams.values()],
+    getTeam: (id) => state.store.teams.get(id),
+    getPlayer: (id) => state.store.players.get(id),
+    getPlayersByTeam: (id) => [...state.store.players.values()].filter((p) => p.teamId === id && p.status !== 'free_agent'),
+    getAllPlayers: () => [...state.store.players.values()],
+    updatePlayer: (id, patch) => { const p = state.store.players.get(id); if (p) Object.assign(p, patch); },
+    updateTeam: (id, patch) => { const t = state.store.teams.get(id); if (t) Object.assign(t, patch); },
+  };
+  return { state, mockCache };
+});
+
+vi.mock('../../src/db/cache.js', () => ({ cache: h.mockCache }));
+vi.mock('../../src/db/index.js', () => ({ Transactions: { add: (tx) => { h.state.txLog.push(tx); return Promise.resolve(); } } }));
+vi.mock('../../src/core/news-engine.js', () => ({ default: { logTransaction: () => {}, logNews: () => {} } }));
+
+import AiLogic from '../../src/core/ai-logic.js';
+import { buildTeamCapSnapshot } from '../../src/core/contracts/contractObligations.js';
+
+const LIVE_CAP = 100;
+
+function contract(base, sb = 0, yearsTotal = 1, years = yearsTotal) {
+  return { baseAnnual: base, signingBonus: sb, yearsTotal, years, yearsRemaining: years, restructureCount: 0 };
+}
+
+function makeRoster(teamId, { starBase = 40 } = {}) {
+  const players = [];
+  // Restructurable star (4 yrs) — one restructure should restore legality.
+  players.push({ id: `${teamId}-STAR`, teamId, pos: 'QB', ovr: 92, age: 28, status: 'active', contract: contract(starBase, 0, 4, 4) });
+  // 52 cheap depth players across positions so floors are satisfied.
+  const positions = ['QB', 'RB', 'WR', 'TE', 'OL', 'DL', 'LB', 'CB', 'S', 'K', 'P'];
+  for (let i = 0; i < 52; i++) {
+    players.push({ id: `${teamId}-d${i}`, teamId, pos: positions[i % positions.length], ovr: 62, age: 25, status: 'active', contract: contract(1.3, 0, 1, 1) });
+  }
+  return players;
+}
+
+function buildStore({ difficulty = 'Normal' } = {}) {
+  const teams = new Map([
+    [0, { id: 0, abbr: 'USR', capTotal: LIVE_CAP, deadCap: 0 }],
+    [1, { id: 1, abbr: 'AI1', capTotal: LIVE_CAP, deadCap: 0 }],
+    [2, { id: 2, abbr: 'AI2', capTotal: LIVE_CAP, deadCap: 0 }],
+  ]);
+  const players = new Map();
+  // Team 0 (user) and Team 1 (AI) both over cap; Team 2 under cap.
+  for (const p of makeRoster(0)) players.set(p.id, p);
+  for (const p of makeRoster(1)) players.set(p.id, p);
+  for (const p of [...makeRoster(2, { starBase: 5 })]) players.set(p.id, p); // cheap → legal
+  return {
+    meta: { userTeamId: 0, difficulty, economy: { currentSalaryCap: LIVE_CAP }, currentSeasonId: 's4', currentWeek: 1, year: 2029 },
+    teams, players,
+  };
+}
+
+function committed(teamId) {
+  const team = h.state.store.teams.get(teamId);
+  const roster = [...h.state.store.players.values()].filter((p) => p.teamId === teamId && p.status !== 'free_agent');
+  return buildTeamCapSnapshot({ team, roster, salaryCap: LIVE_CAP });
+}
+
+beforeEach(() => {
+  h.state.txLog.length = 0;
+  h.state.store = buildStore();
+});
+
+describe('executeAICapManagement — user-team isolation', () => {
+  it('does NOT auto-manage the interactive user team but DOES make AI teams legal', async () => {
+    const userBefore = JSON.stringify([...h.state.store.players.values()].filter((p) => p.teamId === 0).map((p) => [p.id, p.contract, p.status]));
+    expect(committed(0).isLegallyCompliant).toBe(false); // user starts over cap
+
+    await AiLogic.executeAICapManagement({ autoManageUserCap: false });
+
+    // User roster + contracts are untouched.
+    const userAfter = JSON.stringify([...h.state.store.players.values()].filter((p) => p.teamId === 0).map((p) => [p.id, p.contract, p.status]));
+    expect(userAfter).toBe(userBefore);
+    expect(committed(0).isLegallyCompliant).toBe(false);
+
+    // AI team is legal.
+    expect(committed(1).isLegallyCompliant).toBe(true);
+  });
+
+  it('auto-manages the user team ONLY under the explicit headless capability', async () => {
+    expect(committed(0).isLegallyCompliant).toBe(false);
+    const res = await AiLogic.executeAICapManagement({ autoManageUserCap: true });
+    expect(committed(0).isLegallyCompliant).toBe(true);
+    expect(res.failures.length).toBe(0);
+  });
+});
+
+describe('executeAICapManagement — legality & structure', () => {
+  it('brings every AI team legally under the LIVE cap', async () => {
+    await AiLogic.executeAICapManagement({ autoManageUserCap: false });
+    expect(committed(1).isLegallyCompliant).toBe(true);
+    expect(committed(2).isLegallyCompliant).toBe(true); // already legal, untouched
+  });
+
+  it('treats team id 0 as a valid team (not absent) when headless', async () => {
+    // team 0 must be found and managed — not skipped as a falsy id.
+    await AiLogic.executeAICapManagement({ autoManageUserCap: true });
+    expect(h.state.store.teams.get(0)).toBeDefined();
+    expect(committed(0).isLegallyCompliant).toBe(true);
+  });
+
+  it('emits one transaction per committed action', async () => {
+    await AiLogic.executeAICapManagement({ autoManageUserCap: false });
+    // Only AI teams (1) acted; team 2 legal. Every tx is RESTRUCTURE or RELEASE.
+    expect(h.state.txLog.length).toBeGreaterThan(0);
+    for (const tx of h.state.txLog) expect(['RESTRUCTURE', 'RELEASE']).toContain(tx.type);
+    const playerIds = h.state.txLog.map((t) => t.details.playerId);
+    expect(new Set(playerIds).size).toBe(playerIds.length); // no duplicate action on one player
+  });
+});
+
+describe('executeAICapManagement — determinism', () => {
+  it('produces identical transactions across two identical runs', async () => {
+    await AiLogic.executeAICapManagement({ autoManageUserCap: true });
+    const first = JSON.stringify(h.state.txLog);
+
+    h.state.txLog.length = 0;
+    h.state.store = buildStore();
+    await AiLogic.executeAICapManagement({ autoManageUserCap: true });
+    const second = JSON.stringify(h.state.txLog);
+
+    expect(second).toBe(first);
+  });
+});

--- a/tests/unit/aiCapManagementExecution.test.js
+++ b/tests/unit/aiCapManagementExecution.test.js
@@ -114,6 +114,34 @@ describe('executeAICapManagement — legality & structure', () => {
     expect(committed(0).isLegallyCompliant).toBe(true);
   });
 
+  it('commits NOTHING and reports a structured failure when no legal plan exists', async () => {
+    // Team at exact position floors, expensive, un-restructurable (1 yr left),
+    // and massively over a tiny live cap — no legal plan is possible.
+    const floors = { QB: 2, RB: 2, WR: 3, TE: 1, OL: 5, DL: 4, LB: 3, CB: 2, S: 2, K: 1, P: 1 };
+    const players = new Map();
+    for (const [pos, count] of Object.entries(floors)) {
+      for (let k = 0; k < count; k++) {
+        const id = `imp-${pos}-${k}`;
+        players.set(id, { id, teamId: 7, pos, ovr: 80, age: 30, status: 'active', contract: contract(20, 0, 1, 1) });
+      }
+    }
+    h.state.store = {
+      meta: { userTeamId: 0, difficulty: 'Normal', economy: { currentSalaryCap: 50 }, currentSeasonId: 's4', currentWeek: 1, year: 2029 },
+      teams: new Map([[7, { id: 7, abbr: 'IMP', capTotal: 50, deadCap: 0 }]]),
+      players,
+    };
+    const before = JSON.stringify([...h.state.store.players.values()].map((p) => [p.id, p.teamId, p.contract]));
+
+    const res = await AiLogic.executeAICapManagement({ autoManageUserCap: false });
+
+    const after = JSON.stringify([...h.state.store.players.values()].map((p) => [p.id, p.teamId, p.contract]));
+    expect(h.state.txLog.length).toBe(0);       // no destructive actions committed
+    expect(after).toBe(before);                 // roster + contracts intact
+    expect(res.failures.length).toBe(1);
+    expect(res.failures[0].teamId).toBe(7);
+    expect(res.failures[0].remainingOverage).toBeGreaterThan(0);
+  });
+
   it('emits one transaction per committed action', async () => {
     await AiLogic.executeAICapManagement({ autoManageUserCap: false });
     // Only AI teams (1) acted; team 2 legal. Every tx is RESTRUCTURE or RELEASE.


### PR DESCRIPTION
## Summary

Makes FootballGMSim's AI teams remain legally salary-cap compliant across
repeated offseason rollovers. On latest `main`
(`c6b04863f11482f2b76d0f156a605ce19738cb63`, incl. #1702) the five-season
durability run (seed 1684) stopped in **Season 4 preseason** when several
AI teams failed the pre-advance legality gate over the cap.

## Pre-fix failing team & checkpoint

- **Season 4 (year 2029), phase = preseason**, at the `ADVANCE_WEEK`
  pre-advance legality gate.
- Failing teams on the pinned main: **CIN(5), CLE(6), KC(13), WAS(19)** —
  *not* "Indianapolis". The defect is **systemic**; no team was special-cased.
- Live cap = **$333.94M**; the AI manager's stale constant target = **$301.2M**.

| Team | rosterCap | deadCap | committed | legal cap | overage |
|------|-----------|---------|-----------|-----------|---------|
| CIN  | 333.18 | 1.49 | 334.67 | 333.94 | +0.73 |
| CLE  | 333.83 | 3.56 | 337.39 | 333.94 | +3.45 |
| KC   | 338.59 | 0.49 | 339.08 | 333.94 | +5.14 |
| WAS  | 334.41 | 1.73 | 336.14 | 333.94 | +2.20 |

## First overcommit checkpoint

**Before preseason cutdown.** Teams carry a full ~70-man offseason roster whose
aggregate cap hit, after three seasons of 2.5% contract inflation vs. a 3.5% cap,
exceeds the cap while still un-cut. This is normally resolved by the 53-man
cutdown — but the cutdown/cap-manager ran **after** the gate that blocked on it,
so it never executed in Season 4.

## Root cause (two coupled defects)

1. **Ordering** — the pre-advance legality gate evaluated cap on the pre-cutdown
   roster and ran *before* the preseason cutdown + AI cap-management pass.
2. **The AI cap manager** used a stale constant cap (301.2 vs. live 333.94),
   triggered on `capUsed` **excluding dead cap**, restructured with a formula
   that produced ~0 relief, and ranked cuts by inefficiency not net relief.

## Canonical salary-cap equation

```
totalCommitted = Σ activeCapHit(rosterPlayer) + team.deadCap   (staff excluded)
legal          ⇔ totalCommitted ≤ liveSalaryCap (meta.economy.currentSalaryCap)
```

New `buildTeamCapSnapshot` (contractObligations.js) is the single source of
truth shared by the AI planner and identical to the legality gate.

## Answers to the required questions

- **Dead cap omitted from AI planning?** Yes (pre-fix). Now included via
  `totalCommitted = rosterCap + deadCap`.
- **Stale constant cap used?** Yes (pre-fix, 301.2). Now uses the live economy
  cap; the difficulty buffer is applied to the live cap and is planning-only.
- **Restructure math produced genuine relief?** No (pre-fix ~0). Now delegates to
  the canonical restructure engine — verified positive current-year relief; no
  negative base; no repeat in a season.
- **Net release relief** = `activeCapHit − currentYearDead`
  (currentYearDead = signingBonus/yearsTotal, post-June-1). Zero/negative-relief
  players are never cut; candidates ranked by net relief; position floors held.
- **Upstream transaction boundaries changed?** None loosened. FA / re-signing
  already gate on dead-cap-aware `capRoom` + pending-offer reservation; the
  preseason manager remains the safety net.
- **User-team behavior:** interactive users are never auto-managed; an over-cap
  user still gets the existing actionable Start-Season error, roster unchanged.
- **Headless behavior:** the user team is auto-managed only under the explicit
  `__FOOTBALL_GM_LITE_BATCH_SIM__` capability (not `skipUserGame`).

## Results

- `npm run test:unit` — **5640 passed / 460 files**.
- `npm run build` — **passed**.
- `npm run durability:test` — **62 passed / 5 files**.
- `npm run durability:smoke` (1-season) — passed, `FIRST FAILURE: none`.
- `npm run durability:5` — **all five seasons complete**, every
  `afterSeasonRollover` checkpoint pass=40 fail=0, `FIRST FAILURE: none`.
- Determinism (5-season ×2, seed 1684): **`deterministic=true`** — normalized
  outcome identical across two clean runs, both completing all five seasons.
- Browser: production build passes; no Playwright browser flow was executed in
  this environment, so no browser assertion is claimed.

## Explicit non-goals (unchanged)

Schedule generation, scoring/gamecast, standings/playoff rules,
progression/retirement, team numbering (team id 0 stays valid), the configured
cap amount, the legality gate's rule, contract market value/demand, and
interactive user roster control are all untouched.

## Remaining failures

None within the salary-cap causal cluster through five seasons at seed 1684.

See `docs/ai-post-rollover-salary-cap-compliance-v1.md` for the full audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012aRg63TEuQBqYe9NaeRzSv

---
_Generated by [Claude Code](https://claude.ai/code/session_012aRg63TEuQBqYe9NaeRzSv)_