### PR TITLE
Strengthen long-save durability authority V2

### DIFF
--- a/docs/long-save-durability-authority-v2.md
+++ b/docs/long-save-durability-authority-v2.md
@@ -1,0 +1,51 @@
+# Long-Save Durability Authority V2
+
+Base SHA: `a4f47f47e46e38db834024248484852aeac63ddf`.
+
+## Why V1 determinism was insufficient
+
+The previous durability report could set `deterministic=true` when two runs had the same lifecycle completion metadata, the same first-failure shape, and the same save/reload booleans. It did not compare durable roster, contract, cap, player, pick, schedule, or history state at corresponding checkpoints. V2 adds a canonical durable-state snapshot and compares checkpoint state directly.
+
+## Snapshot fields
+
+Snapshot schema `2.0.0` includes:
+
+- League: season, year, week, phase, season id, user team id, live salary cap.
+- Teams: canonical team id, record, roster membership, current/deferred dead cap, stable cap fields.
+- Active players: canonical player id/team id, age, OVR/potential, injury availability, contract years/base salary/signing bonus/cap hit.
+- Retired players: canonical player id and retirement year where available.
+- Draft picks: pick id, season, round, original/current owner.
+- Schedule: canonical game id, season/week, home/away, played/final status, final scores only for completed games.
+- League history: season/year, champion, runner up.
+- Pool counts: active, rostered, free agent, retired.
+
+Exclusions remain timestamps, narrative/UI-only text, raw serialization order not guaranteed by production, and volatile completion metadata.
+
+## Stable cap equation
+
+At roster-stable phases, each team is legal when:
+
+`sum(active roster cap hits) + current dead cap + counted pending commitments <= live salary cap`
+
+The live cap is resolved from `meta.economy.currentSalaryCap`/production-visible live cap sources before falling back to team cap totals. Staff payroll is excluded because production cap legality excludes it. Transitional offseason phases skip with a documented reason.
+
+## Current evidence
+
+Commands run on this branch:
+
+- `npm run durability:test` — passed, 5 files / 67 tests.
+- `npm run durability:smoke` — passed one full season, save/reload OK, peak RSS 476 MB.
+- `npm run durability:5 -- --seed=1684 --determinism --collect-all --write-report --summary` — completed both five-season runs but did **not** pass: V2 correctly reported state/lifecycle non-determinism and a first invariant failure.
+
+Latest five-season report:
+
+- Seed: 1684
+- Completed: 5/5 seasons in each determinism leg
+- Run A report runtime: 394.4 seconds, peak RSS 2278 MB
+- First durable divergence: checkpoint `2:afterSeasonRollover`, domain `players`, entity `1590`, field `signingBonus`
+- First invariant failure: `roster.size-within-legal-range` at season 5 `afterSeasonRollover`, team 7 roster size 51
+- Save/reload: OK at seasons 1 and 5
+
+## Remaining unproven areas
+
+Because the strengthened harness uncovered a real state-level divergence and a roster legality failure, this branch must not claim ten-season-safe or state deterministic. The next repair should trace the season-2 offseason/draft/free-agency contract divergence to the first write that changes player 1590's signing bonus between clean runs, then separately assess whether the season-5 team-7 roster size is in the same causal cluster or a later roster-management defect.

--- a/docs/long-save-durability-authority-v2.md
+++ b/docs/long-save-durability-authority-v2.md
@@ -4,59 +4,63 @@ Base SHA: `a4f47f47e46e38db834024248484852aeac63ddf`.
 
 ## Why V1 determinism was insufficient
 
-The previous durability report could set `deterministic=true` when two runs had the same lifecycle completion metadata, the same first-failure shape, and the same save/reload booleans. It did not compare durable roster, contract, cap, player, pick, schedule, or history state at corresponding checkpoints. V2 adds a canonical durable-state snapshot and compares checkpoint state directly.
+The previous durability report could set `deterministic=true` when two runs had the same lifecycle completion metadata, first-failure shape, and save/reload booleans. It did not compare durable roster, contract, cap, player, pick, schedule, or history state at corresponding checkpoints. V2 adds a canonical durable-state snapshot and compares checkpoint state directly.
 
-## Snapshot fields
+## Snapshot fields and normalization
 
-Snapshot schema `2.0.0` includes:
+Snapshot schema `2.0.0` includes league phase/year/week/season id/user team/live salary cap; authoritative DB-backed teams with records, roster membership, dead cap, deferred dead cap, and stable cap fields; active players with canonical ids, team ids, age, ratings, injury availability, canonical normalized contract fields, and active cap hit; retired-player ledger rows; draft picks; schedule identity/results; completed history champion/runner-up references; and pool counts/source.
 
-- League: season, year, week, phase, season id, user team id, live salary cap.
-- Teams: canonical team id, record, roster membership, current/deferred dead cap, stable cap fields from durable team data.
-- Active players: canonical player id/team id, age, OVR/potential, injury availability, canonical contract years remaining/total, base annual, signing bonus, and calculated active cap hit.
-- Retired players: canonical player id and retirement year where available.
-- Draft picks: pick id, season, round, original/current owner.
-- Schedule: canonical game id, season/week, home/away, played/final status, final scores only for completed games.
-- League history: season/year, champion, runner up.
-- Pool counts: active, rostered, free agent, retired.
+Normalization now resolves object-shaped legacy champion and runner-up team references with the canonical team-reference resolver, includes retired ledger evidence from view and DB meta, preserves duplicate entity occurrences during structured comparison, and reports diffs with canonical entity ids rather than array positions.
 
-Exclusions remain timestamps, narrative/UI-only text, raw serialization order not guaranteed by production, and volatile completion metadata.
+Excluded fields remain timestamps, narrative/UI-only text, raw serialization order not guaranteed by production, and volatile completion metadata.
 
 ## Stable cap equation
 
-At stable regular/playoff cap checkpoints, each team is legal when:
+At stable cap checkpoints, each team is legal when:
 
 `sum(active roster cap hits from canonical contracts) + current dead cap + counted pending commitments <= live salary cap`
 
-The live cap is resolved from `view.economy.currentSalaryCap` or `db.meta.economy.currentSalaryCap`. Team dead cap and roster contracts come from authoritative DB team/player records when available. Staff payroll is excluded because production cap legality excludes it. Preseason/offseason transition checkpoints skip cap legality with a documented reason rather than pretending those reconciliation windows are final legal gates.
+The live cap is resolved from `view.economy.currentSalaryCap` or `db.meta.economy.currentSalaryCap`. Team dead cap and roster contracts come from authoritative DB team/player records when available. Staff payroll is excluded because production cap legality excludes it. Transitional offseason windows skip cap legality with a documented reason rather than pretending those reconciliation windows are final legal gates.
+
+## Continuity rules
+
+V2 continuity now checks that completed history grows exactly once at completed rollover checkpoints, schedule game ids are not reused across seasons, active/retired populations do not overlap, full-pool checkpoints do not lose established players without retirement/draft/release/free-agency/removal evidence, and contract years do not increase unless there is transaction evidence or a signing/extension-shaped contract transition.
+
+Roster-only checkpoints explicitly skip player-disappearance proof with a narrow reason because the full free-agent/retired pool is not present in those view-only snapshots.
 
 ## Isolation model
 
 CLI determinism legs and `--seeds` runs execute in clean child processes. This avoids reusing worker module globals, caches, fake IndexedDB state, and seeded RNG state between legs/seeds. In-process harness helpers remain available for unit tests and bounded stubs.
 
+## Production root causes repaired in this iteration
+
+- Retired players were evicted from the hot cache after offseason retirement without durable `meta.retiredPlayers` evidence, so continuity could not distinguish retirement from disappearance after old players left the DB player pool. The repair persists a compact retired-player ledger before eviction.
+- AI stable rollover could enter preseason with an AI roster below the legal minimum after retirements/cuts/free agency. The repair adds a deterministic minimum-roster reconciliation pass that signs from the existing free-agent pool, respects interactive-user isolation, and recalculates all team caps before the preseason save surface.
+- Save/reload could observe stale pre-save cap aggregates because not every final rollover roster mutation recalculated team cap fields before flushing. The repair recalculates every team cap after final rollover roster reconciliation.
+- Several ordering boundaries that affect offers/releases/RNG draw order lacked canonical tie-breaks: AI FA target inputs, equal-score FA offer resolution, offseason roster-cut candidate ties, offseason extension/progression team/player iteration, and staff-carousel team/market ties. These were narrowed to canonical id/name tie-breaks without changing balance formulas.
+
 ## Current evidence
 
-Commands run on this branch:
+Commands run on this branch. The broad unit/build/smoke checks were rerun after the final sort changes; the expensive five-season determinism run below was the latest completed full gate before the final staff/offseason ordering pass and remains the honest long-run blocker until rerun:
 
-- `node --check ...` across changed JS harness files — passed.
-- `npm run durability:test` — passed, 5 files / 75 tests.
-- `npm run durability:smoke` — passed one full season, save/reload OK, peak RSS 470 MB after V2 continuity/cap updates.
-- `npm run durability:smoke -- --determinism` — passed; two isolated one-season child runs were state deterministic.
-- `npm run durability:smoke -- --seeds=1702` — passed and proved `--seeds=1702` runs seed 1702 through the child-process path.
-- `npm run check:sim-types` — passed.
-- `npm run build` — passed with the expected Vite chunk-size warning.
-- `npm run test:unit` — passed, 462 files / 5651 tests.
-- `npm run durability:5 -- --seed=1684 --determinism --collect-all --write-report --summary` — rerun after the first ordering repair still did not pass; first leg had zero invariant failures, second leg surfaced a season-5 roster-size failure, and state determinism remained false.
+- `node --check src/core/freeAgency/aiFaEngine.js src/core/roster/aiRosterCuts.js src/core/ai-logic.js src/worker/worker.js tests/durability/invariants/continuity.js tests/durability/invariants/durableSnapshot.js` — passed in targeted invocations.
+- `npx vitest run tests/unit/aiFaEngine.unit.test.js tests/unit/aiCapManagementExecution.test.js --config vitest.config.ts` — passed, 2 files / 46 tests.
+- `npm run durability:test` — passed, 5 files / 79 tests.
+- `npm run durability:smoke` — passed one full season, save/reload OK, peak RSS 470 MB.
+- `npm run durability:5 -- --seed=1684 --determinism --collect-all --write-report --summary` — completed both isolated five-season legs with zero invariant failures and save/reload OK in both legs, but exited nonzero because state determinism remained false. This run was not repeated after the final staff/offseason iteration-order patch due execution budget.
 
 Latest five-season determinism result:
 
 - Seed: 1684
 - Completed: 5/5 seasons in each isolated child leg
-- First leg runtime/peak RSS: 396.7 seconds / 2236 MB
-- Second leg runtime/peak RSS: 399.8 seconds / 2165 MB
-- First incorrect write cluster identified so far: AI offseason/free-agency offer ordering consumed same-OVR free agents and extension ties without canonical ID tie-breaks, causing different players to receive different generated contracts before the later `activeCapHit` diff.
-- Narrow repair applied: canonical ID tie-breaks for AI extension priority ties and AI free-agent offer pools/team/player iteration.
-- Remaining result: still not green; second leg produced `roster.size-within-legal-range` at season 5 for team 30 (52 players), and the determinism comparator then reported first durable divergence at checkpoint `3:afterSeasonRollover`, domain `players`, entity `it5p5hz6olpp`, field `activeCapHit`.
+- First leg runtime/peak RSS: 587.9 seconds / 2183 MB
+- Second leg runtime/peak RSS: 575.7 seconds / 2248 MB
+- Invariants: 750 pass / 0 fail / 132 skip in both legs
+- Save/reload: OK at season 1 and season 5 in both legs
+- Lifecycle deterministic: true
+- State deterministic: false
+- First remaining durable divergence: checkpoint `4:afterSeasonRollover`, domain `players`, entity `0r6cmohdkrvo`, field `activeCapHit`
 
-## Remaining unproven areas
+## Remaining limitations / not yet proven
 
-The V2 harness no longer has false-green cap behavior and no longer treats lifecycle-only equality as determinism. The first contract-ordering boundary has been narrowed and repaired, but the required five-season seed-1684 determinism proof is still not green: the latest run exposes a later roster-size failure plus a later generated-player active-cap-hit divergence. Because that state-level divergence remains, this branch must not claim five-season deterministic, ten-season-safe, or multi-seed durable authority yet. The next repair must trace the remaining generated-player contract write/RNG/order boundary and the team-30 roster shortfall before running the full requested matrix and ten-season proof.
+This branch must still not claim five-season state determinism, ten-season safety, or multi-seed durable authority. The season-5 roster-size failure is gone and save/reload is stable in the latest five-season run, but a later generated-player contract divergence remains. Because that principal determinism gate is still red, the three-seed five-season matrix, ten-season seed-1684 proof, and optional twenty-season run were not honestly claimable from this head.

--- a/docs/long-save-durability-authority-v2.md
+++ b/docs/long-save-durability-authority-v2.md
@@ -41,26 +41,29 @@ CLI determinism legs and `--seeds` runs execute in clean child processes. This a
 
 ## Current evidence
 
-Commands run on this branch. The broad unit/build/smoke checks were rerun after the final sort changes; the expensive five-season determinism run below was the latest completed full gate before the final staff/offseason ordering pass and remains the honest long-run blocker until rerun:
+Commands run on this branch after the schedule, continuity, minimum-roster, and additional ordering repairs:
 
-- `node --check src/core/freeAgency/aiFaEngine.js src/core/roster/aiRosterCuts.js src/core/ai-logic.js src/worker/worker.js tests/durability/invariants/continuity.js tests/durability/invariants/durableSnapshot.js` — passed in targeted invocations.
-- `npx vitest run tests/unit/aiFaEngine.unit.test.js tests/unit/aiCapManagementExecution.test.js --config vitest.config.ts` — passed, 2 files / 46 tests.
-- `npm run durability:test` — passed, 5 files / 79 tests.
-- `npm run durability:smoke` — passed one full season, save/reload OK, peak RSS 470 MB.
-- `npm run durability:5 -- --seed=1684 --determinism --collect-all --write-report --summary` — completed both isolated five-season legs with zero invariant failures and save/reload OK in both legs, but exited nonzero because state determinism remained false. This run was not repeated after the final staff/offseason iteration-order patch due execution budget.
+- `node --check src/core/ai-logic.js src/core/freeAgency/freeAgencyMarketAnalysis.js src/core/retention/reSigning.js tests/durability/invariants/continuity.js tests/durability/invariants/durableSnapshot.js` — passed.
+- `npx vitest run tests/unit/aiCapManagementExecution.test.js tests/unit/aiFaEngine.unit.test.js tests/unit/aiRetentionLogic.test.js --config vitest.config.ts` — passed, 3 files / 67 tests.
+- `npm run durability:test` — passed, 5 files / 81 tests.
+- `npm run durability:smoke` — passed one full season with save/reload OK.
+- `npm run check:sim-types` — passed.
+- `npm run build` — passed with the expected Vite chunk-size warning.
+- `npm run test:unit` — passed, 462 files / 5659 tests.
+- `npm run durability:5 -- --seed=1684 --determinism --collect-all --write-report --summary` — completed both isolated five-season legs with zero invariant failures and save/reload OK, but exited nonzero because state determinism remains false.
 
 Latest five-season determinism result:
 
 - Seed: 1684
 - Completed: 5/5 seasons in each isolated child leg
-- First leg runtime/peak RSS: 587.9 seconds / 2183 MB
-- Second leg runtime/peak RSS: 575.7 seconds / 2248 MB
+- First leg runtime/peak RSS: 398.0 seconds / 2174 MB
+- Second leg runtime/peak RSS: 401.9 seconds / 2221 MB
 - Invariants: 750 pass / 0 fail / 132 skip in both legs
 - Save/reload: OK at season 1 and season 5 in both legs
 - Lifecycle deterministic: true
 - State deterministic: false
-- First remaining durable divergence: checkpoint `4:afterSeasonRollover`, domain `players`, entity `0r6cmohdkrvo`, field `activeCapHit`
+- First remaining durable divergence: checkpoint `2:afterSeasonRollover`, domain `players`, entity `1005`, field `activeCapHit`
 
 ## Remaining limitations / not yet proven
 
-This branch must still not claim five-season state determinism, ten-season safety, or multi-seed durable authority. The season-5 roster-size failure is gone and save/reload is stable in the latest five-season run, but a later generated-player contract divergence remains. Because that principal determinism gate is still red, the three-seed five-season matrix, ten-season seed-1684 proof, and optional twenty-season run were not honestly claimable from this head.
+This branch must still not claim five-season state determinism, ten-season safety, or multi-seed durable authority. The season-5 roster-size failure is gone, schedule season identity is stronger, continuity no longer accepts substring transaction evidence, and minimum-roster reconciliation now produces valid cap-checked contracts or rolls back. However, the defining state-determinism gate remains red because generated-player/player-1005 contract state still diverges by season 2. Because that principal determinism gate is still red, the three-seed five-season matrix, ten-season seed-1684 proof, and optional twenty-season run were not run as proof artifacts from this head.

--- a/docs/long-save-durability-authority-v2.md
+++ b/docs/long-save-durability-authority-v2.md
@@ -38,25 +38,25 @@ CLI determinism legs and `--seeds` runs execute in clean child processes. This a
 Commands run on this branch:
 
 - `node --check ...` across changed JS harness files — passed.
-- `npm run durability:test` — passed, 5 files / 71 tests.
-- `npm run durability:smoke` — passed one full season, save/reload OK, peak RSS 450 MB after V2 continuity/cap updates.
+- `npm run durability:test` — passed, 5 files / 75 tests.
+- `npm run durability:smoke` — passed one full season, save/reload OK, peak RSS 470 MB after V2 continuity/cap updates.
 - `npm run durability:smoke -- --determinism` — passed; two isolated one-season child runs were state deterministic.
 - `npm run durability:smoke -- --seeds=1702` — passed and proved `--seeds=1702` runs seed 1702 through the child-process path.
 - `npm run check:sim-types` — passed.
 - `npm run build` — passed with the expected Vite chunk-size warning.
-- `npm run test:unit` — passed, 461 files / 5649 tests.
-- `npm run durability:5 -- --seed=1684 --determinism --collect-all --write-report --summary` — completed both five-season child-process legs with zero invariant failures and save/reload OK, but state determinism still failed.
+- `npm run test:unit` — passed, 462 files / 5651 tests.
+- `npm run durability:5 -- --seed=1684 --determinism --collect-all --write-report --summary` — rerun after the first ordering repair still did not pass; first leg had zero invariant failures, second leg surfaced a season-5 roster-size failure, and state determinism remained false.
 
 Latest five-season determinism result:
 
 - Seed: 1684
 - Completed: 5/5 seasons in each isolated child leg
-- First leg runtime/peak RSS: 387.0 seconds / 2236 MB
-- Second leg runtime/peak RSS: 384.6 seconds / 2281 MB
-- Invariants: 0 failures in both legs
-- Save/reload: OK at seasons 1 and 5 in both legs
-- First durable divergence: checkpoint `2:afterSeasonRollover`, domain `players`, entity `kg6rmf9l1dip`, field `activeCapHit`
+- First leg runtime/peak RSS: 396.7 seconds / 2236 MB
+- Second leg runtime/peak RSS: 399.8 seconds / 2165 MB
+- First incorrect write cluster identified so far: AI offseason/free-agency offer ordering consumed same-OVR free agents and extension ties without canonical ID tie-breaks, causing different players to receive different generated contracts before the later `activeCapHit` diff.
+- Narrow repair applied: canonical ID tie-breaks for AI extension priority ties and AI free-agent offer pools/team/player iteration.
+- Remaining result: still not green; second leg produced `roster.size-within-legal-range` at season 5 for team 30 (52 players), and the determinism comparator then reported first durable divergence at checkpoint `3:afterSeasonRollover`, domain `players`, entity `it5p5hz6olpp`, field `activeCapHit`.
 
 ## Remaining unproven areas
 
-The V2 harness no longer has false-green cap behavior and no longer treats lifecycle-only equality as determinism. However, the required five-season seed-1684 determinism proof is still not green: a generated player's calculated active cap hit diverges after the season-2 rollover even in isolated child processes. Because that state-level divergence remains, this branch must not claim five-season deterministic, ten-season-safe, or multi-seed durable authority yet. The next repair must trace that generated player's contract write/RNG boundary and fix it narrowly before running the full requested matrix and ten-season proof.
+The V2 harness no longer has false-green cap behavior and no longer treats lifecycle-only equality as determinism. The first contract-ordering boundary has been narrowed and repaired, but the required five-season seed-1684 determinism proof is still not green: the latest run exposes a later roster-size failure plus a later generated-player active-cap-hit divergence. Because that state-level divergence remains, this branch must not claim five-season deterministic, ten-season-safe, or multi-seed durable authority yet. The next repair must trace the remaining generated-player contract write/RNG/order boundary and the team-30 roster shortfall before running the full requested matrix and ten-season proof.

--- a/docs/long-save-durability-authority-v2.md
+++ b/docs/long-save-durability-authority-v2.md
@@ -11,8 +11,8 @@ The previous durability report could set `deterministic=true` when two runs had 
 Snapshot schema `2.0.0` includes:
 
 - League: season, year, week, phase, season id, user team id, live salary cap.
-- Teams: canonical team id, record, roster membership, current/deferred dead cap, stable cap fields.
-- Active players: canonical player id/team id, age, OVR/potential, injury availability, contract years/base salary/signing bonus/cap hit.
+- Teams: canonical team id, record, roster membership, current/deferred dead cap, stable cap fields from durable team data.
+- Active players: canonical player id/team id, age, OVR/potential, injury availability, canonical contract years remaining/total, base annual, signing bonus, and calculated active cap hit.
 - Retired players: canonical player id and retirement year where available.
 - Draft picks: pick id, season, round, original/current owner.
 - Schedule: canonical game id, season/week, home/away, played/final status, final scores only for completed games.
@@ -23,29 +23,40 @@ Exclusions remain timestamps, narrative/UI-only text, raw serialization order no
 
 ## Stable cap equation
 
-At roster-stable phases, each team is legal when:
+At stable regular/playoff cap checkpoints, each team is legal when:
 
-`sum(active roster cap hits) + current dead cap + counted pending commitments <= live salary cap`
+`sum(active roster cap hits from canonical contracts) + current dead cap + counted pending commitments <= live salary cap`
 
-The live cap is resolved from `meta.economy.currentSalaryCap`/production-visible live cap sources before falling back to team cap totals. Staff payroll is excluded because production cap legality excludes it. Transitional offseason phases skip with a documented reason.
+The live cap is resolved from `view.economy.currentSalaryCap` or `db.meta.economy.currentSalaryCap`. Team dead cap and roster contracts come from authoritative DB team/player records when available. Staff payroll is excluded because production cap legality excludes it. Preseason/offseason transition checkpoints skip cap legality with a documented reason rather than pretending those reconciliation windows are final legal gates.
+
+## Isolation model
+
+CLI determinism legs and `--seeds` runs execute in clean child processes. This avoids reusing worker module globals, caches, fake IndexedDB state, and seeded RNG state between legs/seeds. In-process harness helpers remain available for unit tests and bounded stubs.
 
 ## Current evidence
 
 Commands run on this branch:
 
-- `npm run durability:test` — passed, 5 files / 67 tests.
-- `npm run durability:smoke` — passed one full season, save/reload OK, peak RSS 476 MB.
-- `npm run durability:5 -- --seed=1684 --determinism --collect-all --write-report --summary` — completed both five-season runs but did **not** pass: V2 correctly reported state/lifecycle non-determinism and a first invariant failure.
+- `node --check ...` across changed JS harness files — passed.
+- `npm run durability:test` — passed, 5 files / 71 tests.
+- `npm run durability:smoke` — passed one full season, save/reload OK, peak RSS 450 MB after V2 continuity/cap updates.
+- `npm run durability:smoke -- --determinism` — passed; two isolated one-season child runs were state deterministic.
+- `npm run durability:smoke -- --seeds=1702` — passed and proved `--seeds=1702` runs seed 1702 through the child-process path.
+- `npm run check:sim-types` — passed.
+- `npm run build` — passed with the expected Vite chunk-size warning.
+- `npm run test:unit` — passed, 461 files / 5649 tests.
+- `npm run durability:5 -- --seed=1684 --determinism --collect-all --write-report --summary` — completed both five-season child-process legs with zero invariant failures and save/reload OK, but state determinism still failed.
 
-Latest five-season report:
+Latest five-season determinism result:
 
 - Seed: 1684
-- Completed: 5/5 seasons in each determinism leg
-- Run A report runtime: 394.4 seconds, peak RSS 2278 MB
-- First durable divergence: checkpoint `2:afterSeasonRollover`, domain `players`, entity `1590`, field `signingBonus`
-- First invariant failure: `roster.size-within-legal-range` at season 5 `afterSeasonRollover`, team 7 roster size 51
-- Save/reload: OK at seasons 1 and 5
+- Completed: 5/5 seasons in each isolated child leg
+- First leg runtime/peak RSS: 387.0 seconds / 2236 MB
+- Second leg runtime/peak RSS: 384.6 seconds / 2281 MB
+- Invariants: 0 failures in both legs
+- Save/reload: OK at seasons 1 and 5 in both legs
+- First durable divergence: checkpoint `2:afterSeasonRollover`, domain `players`, entity `kg6rmf9l1dip`, field `activeCapHit`
 
 ## Remaining unproven areas
 
-Because the strengthened harness uncovered a real state-level divergence and a roster legality failure, this branch must not claim ten-season-safe or state deterministic. The next repair should trace the season-2 offseason/draft/free-agency contract divergence to the first write that changes player 1590's signing bonus between clean runs, then separately assess whether the season-5 team-7 roster size is in the same causal cluster or a later roster-management defect.
+The V2 harness no longer has false-green cap behavior and no longer treats lifecycle-only equality as determinism. However, the required five-season seed-1684 determinism proof is still not green: a generated player's calculated active cap hit diverges after the season-2 rollover even in isolated child processes. Because that state-level divergence remains, this branch must not claim five-season deterministic, ten-season-safe, or multi-seed durable authority yet. The next repair must trace that generated player's contract write/RNG boundary and fix it narrowly before running the full requested matrix and ten-season proof.

--- a/scripts/long-save-durability.mjs
+++ b/scripts/long-save-durability.mjs
@@ -37,21 +37,36 @@ async function main() {
     else if (ev.type === 'stopped') console.log(`[durability]   stopped: ${ev.reason}`);
   };
 
-  console.log(`[durability] mode=${raw.mode} seed=${raw.seed} failureMode=${raw.failureMode} stopPhase=${raw.stopPhase} determinism=${raw.determinism}`);
+  console.log(`[durability] mode=${raw.mode} seed=${raw.seeds ? raw.seeds.join(',') : raw.seed} failureMode=${raw.failureMode} stopPhase=${raw.stopPhase} determinism=${raw.determinism}`);
 
   const base = { mode: raw.mode, seed: raw.seed, failureMode: raw.failureMode, perSeasonStopPhase: raw.stopPhase, gitSha, onEvent };
   if (Number.isFinite(raw.phaseTimeoutMs)) base.phaseTimeoutMs = raw.phaseTimeoutMs;
   let report;
-  if (raw.determinism) {
+  if (raw.seeds && raw.seeds.length > 1) {
+    const reports = [];
+    for (const seed of raw.seeds) {
+      console.log(`[durability] === seed ${seed} clean run ===`);
+      reports.push(await runDurabilityHarness({ ...base, seed }));
+    }
+    report = { passed: reports.every((r) => r.passed), toJSON: () => ({ harnessVersion: '2.0.0', mode: raw.mode, seeds: raw.seeds, overallPassed: reports.every((r) => r.passed), reports: reports.map((r) => r.toJSON()) }), toSummaryJSON: () => ({ harnessVersion: '2.0.0', mode: raw.mode, seeds: raw.seeds, overallPassed: reports.every((r) => r.passed), reports: reports.map((r) => r.toSummaryJSON()) }) };
+  } else if (raw.determinism) {
     const det = await runDeterminismCheck(base);
     report = det.reports[0];
-    report.setDeterminism(det.deterministic, det.detail);
+    report.setDeterminism(det.deterministic, det.detail, { lifecycleDeterministic: det.lifecycleDeterministic, stateDeterministic: det.stateDeterministic, firstDivergence: det.firstDivergence });
     console.log(`[durability] deterministic=${det.deterministic} — ${det.detail}`);
   } else {
     report = await runDurabilityHarness(base);
   }
 
-  console.log('\n' + formatConsole(report));
+  if (raw.seeds && raw.seeds.length > 1) {
+    const agg = report.toJSON();
+    console.log(`\n── Long-Save Durability Multi-Seed Report ───────────────────`);
+    console.log(`mode=${agg.mode} seeds=${agg.seeds.join(',')} overallPassed=${agg.overallPassed}`);
+    for (const r of agg.reports) console.log(`seed=${r.seed} passed=${r.summary.failed === 0 && !r.lifecycleException} completed=${r.seasonsCompleted}/${r.requestedSeasons} fail=${r.summary.failed}`);
+    console.log(`─────────────────────────────────────────────────────────────`);
+  } else {
+    console.log('\n' + formatConsole(report));
+  }
 
   if (raw.writeReport) {
     const written = writeReports(report, {

--- a/scripts/long-save-durability.mjs
+++ b/scripts/long-save-durability.mjs
@@ -12,6 +12,10 @@
  *   npm run durability:20 -- --collect-all --seed=1684
  */
 import 'fake-indexeddb/auto';
+import { readFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
 import { parseArgv, USAGE, writeReports, resolveGitSha, defaultReportName } from '../tests/durability/cli.js';
 import { formatConsole } from '../tests/durability/report.js';
 
@@ -25,7 +29,7 @@ async function main() {
     return;
   }
 
-  const { runDurabilityHarness, runDeterminismCheck } = await import('../tests/durability/longSaveHarness.js');
+  const { runDurabilityHarness, runDeterminismCheck, compareReportDeterminism } = await import('../tests/durability/longSaveHarness.js');
   const gitSha = await resolveGitSha();
 
   const onEvent = (ev) => {
@@ -42,23 +46,32 @@ async function main() {
   const base = { mode: raw.mode, seed: raw.seed, failureMode: raw.failureMode, perSeasonStopPhase: raw.stopPhase, gitSha, onEvent };
   if (Number.isFinite(raw.phaseTimeoutMs)) base.phaseTimeoutMs = raw.phaseTimeoutMs;
   let report;
-  if (raw.seeds && raw.seeds.length > 1) {
+  if (process.env.DURABILITY_CHILD_JSON) {
+    report = await runDurabilityHarness(base);
+    await import('node:fs').then((fs) => fs.writeFileSync(process.env.DURABILITY_CHILD_JSON, JSON.stringify(report.toRuntimeJSON())));
+  } else if (raw.seeds) {
     const reports = [];
     for (const seed of raw.seeds) {
-      console.log(`[durability] === seed ${seed} clean run ===`);
-      reports.push(await runDurabilityHarness({ ...base, seed }));
+      console.log(`[durability] === seed ${seed} clean child process ===`);
+      reports.push(runIsolatedChild({ ...raw, seed, seeds: null, determinism: false }));
     }
-    report = { passed: reports.every((r) => r.passed), toJSON: () => ({ harnessVersion: '2.0.0', mode: raw.mode, seeds: raw.seeds, overallPassed: reports.every((r) => r.passed), reports: reports.map((r) => r.toJSON()) }), toSummaryJSON: () => ({ harnessVersion: '2.0.0', mode: raw.mode, seeds: raw.seeds, overallPassed: reports.every((r) => r.passed), reports: reports.map((r) => r.toSummaryJSON()) }) };
+    report = { passed: reports.every((r) => r.summary.failed === 0 && !r.lifecycleException), toJSON: () => ({ harnessVersion: '2.0.0', mode: raw.mode, seeds: raw.seeds, overallPassed: reports.every((r) => r.summary.failed === 0 && !r.lifecycleException), reports: reports.map(stripRuntime) }), toSummaryJSON: () => ({ harnessVersion: '2.0.0', mode: raw.mode, seeds: raw.seeds, overallPassed: reports.every((r) => r.summary.failed === 0 && !r.lifecycleException), reports: reports.map(stripRuntime) }) };
   } else if (raw.determinism) {
-    const det = await runDeterminismCheck(base);
-    report = det.reports[0];
-    report.setDeterminism(det.deterministic, det.detail, { lifecycleDeterministic: det.lifecycleDeterministic, stateDeterministic: det.stateDeterministic, firstDivergence: det.firstDivergence });
+    const childA = runIsolatedChild({ ...raw, determinism: false });
+    const childB = runIsolatedChild({ ...raw, determinism: false });
+    const det = compareReportDeterminism(childA, childB);
+    childA.deterministic = det.deterministic;
+    childA.lifecycleDeterministic = det.lifecycleDeterministic;
+    childA.stateDeterministic = det.stateDeterministic;
+    childA.firstDivergence = det.firstDivergence;
+    childA.determinismDetail = det.detail;
+    report = { passed: childA.summary.failed === 0 && !childA.lifecycleException && det.deterministic, toJSON: () => stripRuntime(childA), toSummaryJSON: () => stripRuntime(childA) };
     console.log(`[durability] deterministic=${det.deterministic} — ${det.detail}`);
   } else {
     report = await runDurabilityHarness(base);
   }
 
-  if (raw.seeds && raw.seeds.length > 1) {
+  if (raw.seeds) {
     const agg = report.toJSON();
     console.log(`\n── Long-Save Durability Multi-Seed Report ───────────────────`);
     console.log(`mode=${agg.mode} seeds=${agg.seeds.join(',')} overallPassed=${agg.overallPassed}`);
@@ -89,3 +102,16 @@ main()
     console.error('[durability] fatal:', e);
     process.exit(1);
   });
+
+function runIsolatedChild(raw) {
+  const out = join(tmpdir(), `durability-child-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+  const args = [process.argv[1], raw.mode, `--seed=${raw.seed}`, `--stop-phase=${raw.stopPhase}`, `--phase-timeout-ms=${raw.phaseTimeoutMs ?? 1800000}`, '--child-run'];
+  if (raw.failureMode === 'collect-all') args.push('--collect-all');
+  const res = spawnSync(join(process.cwd(), 'node_modules/.bin/tsx'), args, { cwd: process.cwd(), env: { ...process.env, DURABILITY_CHILD_JSON: out }, encoding: 'utf8', stdio: ['ignore', 'inherit', 'inherit'] });
+  if (res.status !== 0) process.exitCode = res.status;
+  try { const json = JSON.parse(readFileSync(out, 'utf8')); unlinkSync(out); return json; }
+  catch (err) { throw new Error(`isolated durability child did not produce JSON report: ${err.message}`); }
+}
+function stripRuntime(report) {
+  return { ...report, checkpoints: (report.checkpoints || []).map((c) => ({ ...c, durable: c.durable ? { digest: c.durable.digest, summary: c.durable.summary } : null })) };
+}

--- a/src/core/ai-logic.js
+++ b/src/core/ai-logic.js
@@ -23,7 +23,7 @@ import { buildContractFromMarket, evaluateContractMarket } from './contractModel
 import { evaluatePendingOfferCapReservation } from './pendingOfferCapModel.js';
 import { evaluatePlayerMarketRealism, normalizePositionGroup } from './marketRealismModel.js';
 import { executeAIOffseasonCuts } from './roster/aiRosterCuts.js';
-import { buildTeamCapSnapshot, getActiveCapHit } from './contracts/contractObligations.js';
+import { buildTeamCapSnapshot, getActiveCapHit, normalizeContract } from './contracts/contractObligations.js';
 import { canRestructure, computeRestructure, applyRestructure } from './contracts/restructureEngine.js';
 import { executeAIOffseasonExtensions } from './retention/aiRetentionLogic.js';
 import { calculateTeamDepthDeficiencies, getNeedLevelForPlayer, POSITION_NEED_LEVEL } from './trades/tradePositionalNeeds.js';
@@ -47,6 +47,49 @@ export function buildSortedFreeAgentsMapForOffers(allPlayers = []) {
 function positionRank(pos, order) {
     const idx = order.indexOf(pos);
     return idx >= 0 ? idx : order.length;
+}
+
+function isMinimumRosterSignableFreeAgent(player) {
+    if (!player || player.teamId != null) return false;
+    if (player.deleted || player.isDeleted || player._deleted) return false;
+    const status = String(player.status ?? 'free_agent').trim().toLowerCase();
+    return status === 'free_agent' || status === '';
+}
+
+function buildMinimumRosterContract(player, meta = {}) {
+    const normalized = normalizeContract(player);
+    const currentYearsRemaining = Number(normalized.yearsRemaining ?? 0);
+    const currentYearsTotal = Number(normalized.yearsTotal ?? 0);
+    const currentBaseAnnual = Number(normalized.baseAnnual ?? 0);
+    if (currentYearsRemaining > 0 && currentYearsTotal > 0 && currentBaseAnnual > 0) {
+        return {
+            ...(player.contract || {}),
+            baseAnnual: roundRosterContractMoney(currentBaseAnnual),
+            signingBonus: roundRosterContractMoney(Number(normalized.signingBonus ?? 0)),
+            yearsTotal: Math.max(currentYearsTotal, currentYearsRemaining),
+            yearsRemaining: currentYearsRemaining,
+            years: currentYearsRemaining,
+            startYear: player.contract?.startYear ?? meta?.year ?? null,
+        };
+    }
+
+    const demand = calculateExtensionDemand(player) || {};
+    const years = Math.max(1, Math.min(2, Number(demand.yearsTotal ?? demand.years ?? 1) || 1));
+    const baseAnnual = Math.max(0.8, roundRosterContractMoney(Number(demand.baseAnnual ?? demand.salary ?? 1)));
+    const signingBonus = Math.max(0, roundRosterContractMoney(Number(demand.signingBonus ?? 0)));
+    return {
+        baseAnnual,
+        signingBonus,
+        yearsTotal: years,
+        yearsRemaining: years,
+        years,
+        restructureCount: 0,
+        startYear: meta?.year ?? null,
+    };
+}
+
+function roundRosterContractMoney(value) {
+    return Math.round((Number(value) || 0) * 10) / 10;
 }
 
 class AiLogic {
@@ -262,6 +305,7 @@ class AiLogic {
     static async ensureMinimumRosters({ includeUserTeam = false, minimum = Constants.ROSTER_LIMITS.REGULAR_SEASON } = {}) {
         const meta = cache.getMeta();
         const userTeamId = meta?.userTeamId;
+        const liveSalaryCap = AiLogic._getSalaryCap();
         const allTeams = cache.getAllTeams().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
 
         for (const team of allTeams) {
@@ -279,32 +323,62 @@ class AiLogic {
             while (roster.length < minimum) {
                 const freshTeam = cache.getTeam(team.id);
                 const freeAgents = cache.getAllPlayers()
-                    .filter((p) => isFreeAgent(p))
+                    .filter(isMinimumRosterSignableFreeAgent)
                     .sort((a, b) => {
                         const posDelta = positionRank(a?.pos, positionOrder) - positionRank(b?.pos, positionOrder);
                         if (posDelta !== 0) return posDelta;
                         return (Number(b?.ovr ?? 0) - Number(a?.ovr ?? 0)) || stableIdCompare(a?.id, b?.id);
                     });
-                const capSnapshot = buildTeamCapSnapshot({
-                    team: freshTeam,
-                    roster,
-                    salaryCap: freshTeam?.capTotal ?? meta?.economy?.currentSalaryCap,
-                });
-                const room = Number(capSnapshot?.capRoom ?? freshTeam?.capRoom ?? 0);
-                const candidate = freeAgents.find((p) => Number(getActiveCapHit(p) ?? 0) <= room + 0.01);
-                if (!candidate) break;
 
-                cache.updatePlayer(candidate.id, { teamId: team.id, status: 'active', offers: [] });
-                await Transactions.add({
-                    type: 'SIGN',
-                    seasonId: meta.currentSeasonId,
-                    week: meta.currentWeek,
-                    teamId: team.id,
-                    playerId: candidate.id,
-                    details: { playerId: candidate.id, source: 'minimum_roster_reconciliation' },
-                });
-                AiLogic.updateTeamCap(team.id);
-                roster = cache.getPlayersByTeam(team.id);
+                let signed = false;
+                for (const candidate of freeAgents) {
+                    const contract = buildMinimumRosterContract(candidate, meta);
+                    const projectedPlayer = { ...candidate, teamId: team.id, status: 'active', contract };
+                    if (Number(getActiveCapHit(projectedPlayer) ?? 0) <= 0) continue;
+                    const projectedSnapshot = buildTeamCapSnapshot({
+                        team: { ...freshTeam, capTotal: liveSalaryCap },
+                        roster: [...roster, projectedPlayer],
+                        salaryCap: liveSalaryCap,
+                    });
+                    if (!projectedSnapshot?.isLegallyCompliant) continue;
+
+                    const previousPlayer = { ...(cache.getPlayer(candidate.id) || candidate) };
+                    const previousTeam = { ...(cache.getTeam(team.id) || freshTeam) };
+                    cache.updateTeam(team.id, { capTotal: liveSalaryCap });
+                    cache.updatePlayer(candidate.id, { teamId: team.id, status: 'active', contract, offers: [] });
+                    AiLogic.updateTeamCap(team.id);
+                    const committedTeam = cache.getTeam(team.id);
+                    const committedRoster = cache.getPlayersByTeam(team.id);
+                    const committedSnapshot = buildTeamCapSnapshot({ team: { ...committedTeam, capTotal: liveSalaryCap }, roster: committedRoster, salaryCap: liveSalaryCap });
+                    if (!committedSnapshot?.isLegallyCompliant) {
+                        cache.updatePlayer(candidate.id, {
+                            teamId: previousPlayer.teamId,
+                            status: previousPlayer.status,
+                            contract: previousPlayer.contract,
+                            offers: previousPlayer.offers,
+                        });
+                        cache.updateTeam(team.id, {
+                            capTotal: previousTeam.capTotal,
+                            capUsed: previousTeam.capUsed,
+                            capRoom: previousTeam.capRoom,
+                            deadCap: previousTeam.deadCap,
+                        });
+                        continue;
+                    }
+
+                    await Transactions.add({
+                        type: 'SIGN',
+                        seasonId: meta.currentSeasonId,
+                        week: meta.currentWeek,
+                        teamId: team.id,
+                        playerId: candidate.id,
+                        details: { playerId: candidate.id, source: 'minimum_roster_reconciliation' },
+                    });
+                    roster = committedRoster;
+                    signed = true;
+                    break;
+                }
+                if (!signed) break;
             }
         }
     }
@@ -834,7 +908,7 @@ class AiLogic {
                     (needs[pos] ?? 1.0) >= 1.2
                 );
             })
-            .sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0));
+            .sort((a, b) => ((b.ovr ?? 0) - (a.ovr ?? 0)) || stableIdCompare(a?.id, b?.id));
 
         if (tagCandidates.length > 0) {
             const target      = tagCandidates[0];
@@ -1002,7 +1076,7 @@ class AiLogic {
                 }, {}) || null;
                 if (marketByPos) {
                     for (const pos of Object.keys(marketByPos)) {
-                        marketByPos[pos].sort((a, b) => (b.fitScore ?? 0) - (a.fitScore ?? 0));
+                        marketByPos[pos].sort((a, b) => ((b.fitScore ?? 0) - (a.fitScore ?? 0)) || stableIdCompare(a?._player?.id, b?._player?.id));
                     }
                 }
             }
@@ -1013,7 +1087,7 @@ class AiLogic {
             const allPlayers = cache.getAllPlayers();
             return allPlayers
                 .filter(p => isFreeAgent(p) && p.pos === pos)
-                .sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0));
+                .sort((a, b) => ((b.ovr ?? 0) - (a.ovr ?? 0)) || stableIdCompare(a?.id, b?.id));
         };
 
         const getCandidatesForPos = (pos) => {

--- a/src/core/ai-logic.js
+++ b/src/core/ai-logic.js
@@ -44,6 +44,11 @@ export function buildSortedFreeAgentsMapForOffers(allPlayers = []) {
     return freeAgentsMap;
 }
 
+function positionRank(pos, order) {
+    const idx = order.indexOf(pos);
+    return idx >= 0 ? idx : order.length;
+}
+
 class AiLogic {
     static NEED_GROUP_TO_POS = Object.freeze({
         QB: ['QB'],
@@ -158,7 +163,7 @@ class AiLogic {
     static async executeAICutdowns({ includeUserTeam = false } = {}) {
         const meta = cache.getMeta();
         const userTeamId = meta.userTeamId;
-        const allTeams = cache.getAllTeams();
+        const allTeams = cache.getAllTeams().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
         const limit = Constants.ROSTER_LIMITS.REGULAR_SEASON;
 
         for (const team of allTeams) {
@@ -167,7 +172,7 @@ class AiLogic {
             // user team in via includeUserTeam so the season can still start.
             if (!includeUserTeam && team.id === userTeamId) continue;
 
-            const roster = cache.getPlayersByTeam(team.id);
+            const roster = cache.getPlayersByTeam(team.id).slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
             if (roster.length <= limit) continue;
 
             // Score = OVR * 2 + Potential + (Age < 25 ? 10 : 0)
@@ -245,6 +250,62 @@ class AiLogic {
 
             // Re-calc active cap (roster changed)
             this.updateTeamCap(team.id);
+        }
+    }
+
+    /**
+     * Deterministic minimum-roster reconciliation for AI/headless rollover.
+     * This is a last-mile safety pass after offseason churn: it only fills
+     * under-minimum rosters from the existing free-agent pool and never cuts or
+     * restructures players.
+     */
+    static async ensureMinimumRosters({ includeUserTeam = false, minimum = Constants.ROSTER_LIMITS.REGULAR_SEASON } = {}) {
+        const meta = cache.getMeta();
+        const userTeamId = meta?.userTeamId;
+        const allTeams = cache.getAllTeams().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
+
+        for (const team of allTeams) {
+            if (!includeUserTeam && Number(team.id) === Number(userTeamId)) continue;
+
+            let roster = cache.getPlayersByTeam(team.id);
+            if (roster.length >= minimum) continue;
+
+            const needs = AiLogic.calculateTeamNeeds(team.id);
+            const neededPositions = Object.keys(needs)
+                .filter((pos) => Number(needs[pos] ?? 0) > 1)
+                .sort((a, b) => (Number(needs[b] ?? 0) - Number(needs[a] ?? 0)) || a.localeCompare(b));
+            const positionOrder = [...neededPositions, ...Constants.POSITIONS.filter((pos) => !neededPositions.includes(pos))];
+
+            while (roster.length < minimum) {
+                const freshTeam = cache.getTeam(team.id);
+                const freeAgents = cache.getAllPlayers()
+                    .filter((p) => isFreeAgent(p))
+                    .sort((a, b) => {
+                        const posDelta = positionRank(a?.pos, positionOrder) - positionRank(b?.pos, positionOrder);
+                        if (posDelta !== 0) return posDelta;
+                        return (Number(b?.ovr ?? 0) - Number(a?.ovr ?? 0)) || stableIdCompare(a?.id, b?.id);
+                    });
+                const capSnapshot = buildTeamCapSnapshot({
+                    team: freshTeam,
+                    roster,
+                    salaryCap: freshTeam?.capTotal ?? meta?.economy?.currentSalaryCap,
+                });
+                const room = Number(capSnapshot?.capRoom ?? freshTeam?.capRoom ?? 0);
+                const candidate = freeAgents.find((p) => Number(getActiveCapHit(p) ?? 0) <= room + 0.01);
+                if (!candidate) break;
+
+                cache.updatePlayer(candidate.id, { teamId: team.id, status: 'active', offers: [] });
+                await Transactions.add({
+                    type: 'SIGN',
+                    seasonId: meta.currentSeasonId,
+                    week: meta.currentWeek,
+                    teamId: team.id,
+                    playerId: candidate.id,
+                    details: { playerId: candidate.id, source: 'minimum_roster_reconciliation' },
+                });
+                AiLogic.updateTeamCap(team.id);
+                roster = cache.getPlayersByTeam(team.id);
+            }
         }
     }
 
@@ -585,7 +646,7 @@ class AiLogic {
     static async executeOffseasonRosterCuts() {
         const meta = cache.getMeta();
         const userTeamId = meta?.userTeamId;
-        const allTeams = cache.getAllTeams();
+        const allTeams = cache.getAllTeams().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
         const year = Number(meta?.year ?? 2025);
 
         for (const team of allTeams) {

--- a/src/core/ai-logic.js
+++ b/src/core/ai-logic.js
@@ -1,4 +1,5 @@
 import { cache } from '../db/cache.js';
+import { stableIdCompare } from './referenceIntegrity.js';
 import { Constants } from './constants.js';
 import { Transactions } from '../db/index.js';
 import { calculateExtensionDemand } from './player.js';
@@ -27,6 +28,21 @@ import { canRestructure, computeRestructure, applyRestructure } from './contract
 import { executeAIOffseasonExtensions } from './retention/aiRetentionLogic.js';
 import { calculateTeamDepthDeficiencies, getNeedLevelForPlayer, POSITION_NEED_LEVEL } from './trades/tradePositionalNeeds.js';
 import { buildFranchiseTagContract, buildRFATenderContract, TENDER_CONFIG } from './contracts/tenderLogic.js';
+
+
+export function buildSortedFreeAgentsMapForOffers(allPlayers = []) {
+    const freeAgentsMap = {};
+    for (const p of allPlayers) {
+        if (isFreeAgent(p)) {
+            if (!freeAgentsMap[p.pos]) freeAgentsMap[p.pos] = [];
+            freeAgentsMap[p.pos].push(p);
+        }
+    }
+    for (const pos in freeAgentsMap) {
+        freeAgentsMap[pos].sort((a, b) => ((b.ovr ?? 0) - (a.ovr ?? 0)) || stableIdCompare(a.id, b.id));
+    }
+    return freeAgentsMap;
+}
 
 class AiLogic {
     static NEED_GROUP_TO_POS = Object.freeze({
@@ -658,7 +674,7 @@ class AiLogic {
 
         const roster = cache.getPlayersByTeam(teamId);
         const meta   = cache.getMeta();
-        const allPlayers = cache.getAllPlayers();
+        const allPlayers = cache.getAllPlayers().slice().sort((a, b) => stableIdCompare(a.id, b.id));
         const freeAgents = allPlayers.filter((p) => isFreeAgent(p));
 
         const extensions = executeAIOffseasonExtensions(
@@ -1133,20 +1149,11 @@ class AiLogic {
         const userTeamId = meta.userTeamId;
 
         // OPTIMIZATION: Build freeAgentsMap once for all AI teams
-        const allPlayers = cache.getAllPlayers();
-        const freeAgentsMap = {};
-        for (const p of allPlayers) {
-            if (isFreeAgent(p)) {
-                if (!freeAgentsMap[p.pos]) freeAgentsMap[p.pos] = [];
-                freeAgentsMap[p.pos].push(p);
-            }
-        }
-        for (const pos in freeAgentsMap) {
-            freeAgentsMap[pos].sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0));
-        }
+        const allPlayers = cache.getAllPlayers().slice().sort((a, b) => stableIdCompare(a.id, b.id));
+        const freeAgentsMap = buildSortedFreeAgentsMapForOffers(allPlayers);
 
         // 1. AI Teams Make Offers
-        const allTeams = cache.getAllTeams();
+        const allTeams = cache.getAllTeams().slice().sort((a, b) => stableIdCompare(a.id, b.id));
         for (const team of allTeams) {
             if (team.id !== userTeamId) {
                 await this.makeFreeAgencyOffers(team.id, freeAgentsMap);

--- a/src/core/freeAgency/aiFaEngine.js
+++ b/src/core/freeAgency/aiFaEngine.js
@@ -12,6 +12,7 @@
  *  - Fully deterministic: same inputs → same outputs.
  */
 
+import { stableIdCompare } from '../referenceIntegrity.js';
 import { classifyDeadlinePosture, DEADLINE_POSTURE } from '../trades/tradeDeadlinePressure.js';
 
 // ── Bid factor constants per posture ──────────────────────────────────────────
@@ -234,8 +235,9 @@ export function resolvePlayerChoice(player, offers, context = {}) {
     return { winningOffer: null, reason: 'All offers below market — player re-enters market' };
   }
 
-  // Sort by score descending
-  acceptable.sort((a, b) => b.score - a.score);
+  // Sort by score descending with deterministic tie order so the seeded
+  // tiebreaker indexes the same team set in every process.
+  acceptable.sort((a, b) => (b.score - a.score) || stableIdCompare(a?.teamId, b?.teamId));
 
   // Tiebreaker: seeded hash of playerId + season + week (fully deterministic)
   const topScore = acceptable[0].score;
@@ -274,8 +276,8 @@ export function getAIFaTargets(allTeams, availablePlayers, meta, season = 1, wee
   const userTeamId = Number(meta?.userTeamId ?? -1);
   const result = new Map();
 
-  const safeTeams = Array.isArray(allTeams) ? allTeams : [];
-  const safeFA    = Array.isArray(availablePlayers) ? availablePlayers : [];
+  const safeTeams = (Array.isArray(allTeams) ? allTeams : []).slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
+  const safeFA    = (Array.isArray(availablePlayers) ? availablePlayers : []).slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
 
   for (const team of safeTeams) {
     if (!team?.id || Number(team.id) === userTeamId) continue;
@@ -300,7 +302,7 @@ export function getAIFaTargets(allTeams, availablePlayers, meta, season = 1, wee
       // Rebuilder: skip veterans
       if (posture === DEADLINE_POSTURE.REBUILD && safeNum(player.age, 30) > 27) return false;
       return true;
-    });
+    }).sort((a, b) => (safeNum(b?.ovr, 0) - safeNum(a?.ovr, 0)) || stableIdCompare(a?.id, b?.id));
 
     if (targets.length > 0) {
       result.set(Number(team.id), targets);

--- a/src/core/freeAgency/freeAgencyMarketAnalysis.js
+++ b/src/core/freeAgency/freeAgencyMarketAnalysis.js
@@ -1,3 +1,4 @@
+import { stableIdCompare } from '../referenceIntegrity.js';
 import { buildRosterBuildingAnalysis } from '../rosterBuildingAnalysis.js';
 
 const num = (v, fb = null) => (Number.isFinite(Number(v)) ? Number(v) : fb);
@@ -162,7 +163,7 @@ export function buildFreeAgencyMarketAnalysis({ team = {}, roster = [], freeAgen
       reason,
       _player: p,
     };
-  }).sort((a, b) => b.fitScore - a.fitScore);
+  }).sort((a, b) => (b.fitScore - a.fitScore) || stableIdCompare(a?._player?.id, b?._player?.id));
 
   const topFits = marketRows.slice(0, 5);
   const bargainOptions = marketRows.filter((r) => (r.capFit === 'affordable' || (r.baseAnnual != null && r.baseAnnual <= 3)) && r.recommendation !== 'avoid').slice(0, 5);

--- a/src/core/retention/aiRetentionLogic.js
+++ b/src/core/retention/aiRetentionLogic.js
@@ -9,6 +9,7 @@
  * live in AiLogic.processExtensions() in ai-logic.js.
  */
 
+import { stableIdCompare } from '../referenceIntegrity.js';
 import {
   buildContractProfile,
   buildDemandFromProfile,
@@ -250,7 +251,7 @@ export function executeAIOffseasonExtensions(teamState, roster = [], marketConst
   // Step 2 ── Build Priority Retention Board (highest score first) ──────────
   const board = eligible
     .map((player) => ({ player, priorityScore: computePriorityScore(player, config) }))
-    .sort((a, b) => b.priorityScore - a.priorityScore);
+    .sort((a, b) => (b.priorityScore - a.priorityScore) || stableIdCompare(a.player?.id, b.player?.id));
 
   // Step 3 ── Iterate and offer extensions ──────────────────────────────────
   const extensions = [];

--- a/src/core/retention/reSigning.js
+++ b/src/core/retention/reSigning.js
@@ -1,6 +1,7 @@
 import { buildContractProfile, buildDemandFromProfile, computeMarketHeat, inferTeamDirection } from '../contract-market.js';
 import { evaluateContractOffer } from '../contracts/negotiation.js';
 import { getTeamContextForNegotiation } from '../teamContext/negotiationContext.js';
+import { stableIdCompare } from '../referenceIntegrity.js';
 
 function safeNum(v, d = 0) {
   const n = Number(v);
@@ -217,7 +218,7 @@ export function buildRetentionBoard(team = {}, league = {}) {
     };
   });
 
-  board.sort((a, b) => (b.priority.score - a.priority.score) || ((b.player?.ovr ?? 0) - (a.player?.ovr ?? 0)));
+  board.sort((a, b) => (b.priority.score - a.priority.score) || ((b.player?.ovr ?? 0) - (a.player?.ovr ?? 0)) || stableIdCompare(a.player?.id, b.player?.id));
   const capOutlook = getCapOutlookForRetention(team, board);
 
   return { board, capOutlook };

--- a/src/core/roster/aiRosterCuts.js
+++ b/src/core/roster/aiRosterCuts.js
@@ -13,6 +13,7 @@ import {
   getActiveCapHit,
   calculateReleaseDeadCap,
 } from '../contracts/contractObligations.js';
+import { stableIdCompare } from '../referenceIntegrity.js';
 
 export const ROSTER_CUT_CONFIG = Object.freeze({
   /** Only trigger the cut sweep when projected cap room is below this value ($M). */
@@ -121,7 +122,7 @@ export function executeAIOffseasonCuts(teamState, roster, _currentYear) {
       return { player: p, capSavings: ev.capSavings, reason: ev.reason, priority: ev.priority };
     })
     .filter(Boolean)
-    .sort((a, b) => b.capSavings - a.capSavings); // highest savings first
+    .sort((a, b) => (b.capSavings - a.capSavings) || stableIdCompare(a?.player?.id, b?.player?.id)); // highest savings first
 
   const toRelease = [];
   let simCapRoom = capRoom;

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -178,6 +178,7 @@ import {
   prunePendingOffers,
 } from '../core/freeAgency/pendingOffers.js';
 import { isFreeAgent } from '../core/freeAgency/membership.js';
+import { stableIdCompare } from '../core/referenceIntegrity.js';
 import {
   shouldAITeamPursuePlayer,
   computeAIOffer,
@@ -1593,7 +1594,7 @@ function awardCompensatoryPicksForUpcomingDraft(metaObj = ensureCompMeta(cache.g
   if (!year) return [];
   if ((metaObj?.compPicksGeneratedForSeason ?? []).includes(year)) return [];
 
-  const allTeams = cache.getAllTeams();
+  const allTeams = cache.getAllTeams().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
   const rows = (metaObj?.offseasonFaMovements ?? []).filter((row) =>
     Number(row?.compSeason ?? year) === year && row?.qualifying && row?.externalSigning
   );
@@ -1659,7 +1660,7 @@ function calcAssetBundleValue({ playerIds = [], pickIds = [] } = {}, context = {
 
 function resolvePickById(pickId) {
   if (pickId == null) return null;
-  const allTeams = cache.getAllTeams();
+  const allTeams = cache.getAllTeams().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
   for (const team of allTeams) {
     const picks = Array.isArray(team?.picks) ? team.picks : [];
     const found = picks.find((pk) => String(pk?.id) === String(pickId));
@@ -11558,8 +11559,9 @@ function calculateAwards(stats, teams) {
 
 
 function runAiStaffCarousel(meta, teams) {
-  const market = buildStaffMarket(teams, { year: Number(meta?.year ?? 2025), size: 60 });
-  for (const team of teams) {
+  const sortedTeams = (teams || []).slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
+  const market = buildStaffMarket(sortedTeams, { year: Number(meta?.year ?? 2025), size: 60 });
+  for (const team of sortedTeams) {
     const staff = ensureTeamStaff(team, { year: Number(meta?.year ?? 2025) });
     const winPct = ((team?.wins ?? 0) + 0.5 * (team?.ties ?? 0)) / Math.max(1, (team?.wins ?? 0) + (team?.losses ?? 0) + (team?.ties ?? 0));
     const direction = winPct >= 0.62 ? 'contender' : winPct <= 0.42 ? 'rebuild' : 'balanced';
@@ -11569,7 +11571,7 @@ function runAiStaffCarousel(meta, teams) {
       const currentScore = Number(current?.overall ?? 55);
       const stayBias = direction === 'contender' ? 0.8 : direction === 'rebuild' ? 0.58 : 0.68;
       if (current && currentScore >= 75 && Utils.random() < stayBias) continue;
-      const pool = market.filter((m) => m.roleKey === roleKey).sort((a, b) => Number(b?.overall ?? 0) - Number(a?.overall ?? 0));
+      const pool = market.filter((m) => m.roleKey === roleKey).sort((a, b) => (Number(b?.overall ?? 0) - Number(a?.overall ?? 0)) || String(a?.id ?? a?.name ?? '').localeCompare(String(b?.id ?? b?.name ?? '')));
       if (!pool.length) continue;
       const shortlist = pool.slice(0, 12);
       const candidate = shortlist[Math.floor(Utils.random() * Math.max(2, shortlist.length / 2))] ?? shortlist[0];
@@ -11604,7 +11606,7 @@ async function handleAdvanceOffseason(payload, id) {
   }
 
   // ── Step 1: AI processes contract extensions ──────────────────────────────
-  const allTeams = cache.getAllTeams();
+  const allTeams = cache.getAllTeams().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
   for (const team of allTeams) {
     if (team.id !== meta.userTeamId) {
       await AiLogic.processExtensions(team.id);
@@ -11625,7 +11627,7 @@ async function handleAdvanceOffseason(payload, id) {
     const userConf = userTeamObj?.conf ?? null;
 
     // Pre-compute demand snapshots for all expiring players (same as injectAIFaBids)
-    const allPlayers = cache.getAllPlayers();
+    const allPlayers = cache.getAllPlayers().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
     const expiringPlayers = allPlayers.filter((p) => {
       const yrs = Number(p?.contractYearsLeft ?? p?.contract?.yearsRemaining ?? p?.contract?.years ?? 2);
       return yrs <= 1 && p?.teamId != null && Number(p.teamId) !== userTeamId;
@@ -11764,7 +11766,7 @@ async function handleAdvanceOffseason(payload, id) {
   // ── Step 2: Dynamic progression pass ─────────────────────────────────────
   // processPlayerProgression mutates each player's ratings, ovr, and
   // progressionDelta in place.  We then flush those fields to cache.
-  const allPlayers = cache.getAllPlayers();
+  const allPlayers = cache.getAllPlayers().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
   const focusByTeamId = buildTeamDevelopmentFocusMap(meta);
   const playersById = new Map(allPlayers.map((p) => [String(p?.id), p]));
   const attrPlayers = allPlayers.filter((player) => !!player?.attributesV2);
@@ -11995,6 +11997,27 @@ async function handleAdvanceOffseason(payload, id) {
     }
   }
 
+  if (retired.length > 0) {
+    const latestMeta = ensureDynastyMeta(cache.getMeta());
+    const existingRetired = Array.isArray(latestMeta?.retiredPlayers) ? latestMeta.retiredPlayers : [];
+    const existingIds = new Set(existingRetired.map((row) => String(row?.id ?? row?.playerId ?? '')));
+    const retiredRows = retired
+      .filter((row) => row?.id != null && !existingIds.has(String(row.id)))
+      .map((row) => ({
+        id: row.id,
+        playerId: row.id,
+        name: row.name ?? null,
+        pos: row.pos ?? null,
+        age: row.age ?? null,
+        teamId: row.teamId ?? null,
+        retirementYear: Number(meta?.year ?? 2025),
+        reason: row.reason ?? null,
+      }));
+    if (retiredRows.length > 0) {
+      cache.setMeta({ retiredPlayers: [...existingRetired, ...retiredRows] });
+    }
+  }
+
   if (hofClass.length > 0) {
     const hofMeta = ensureLeagueMemoryMeta(cache.getMeta());
     const updated = addHallOfFameClass(hofMeta, Number(meta?.year ?? 2025), hofClass);
@@ -12125,8 +12148,8 @@ async function injectAIFaBids(day) {
   const season = Number(meta?.season ?? meta?.year ?? 1);
   const week   = Number(meta?.currentWeek ?? 1);
 
-  const allTeams   = cache.getAllTeams();
-  const allPlayers = cache.getAllPlayers();
+  const allTeams   = cache.getAllTeams().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
+  const allPlayers = cache.getAllPlayers().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
   const freeAgents = allPlayers.filter((p) => isFreeAgent(p));
   if (freeAgents.length === 0) return;
 
@@ -13445,6 +13468,11 @@ async function handleStartNewSeason(payload, id) {
       salaryCap: nextEconomy.currentSalaryCap,
     }),
   });
+
+  await AiLogic.ensureMinimumRosters({
+    includeUserTeam: typeof globalThis !== 'undefined' && !!globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__,
+  });
+  for (const team of cache.getAllTeams()) recalculateTeamCap(team.id);
 
   // ── Update franchise all-time leaders once per season rollover ──────────
   try {

--- a/tests/durability/cli.js
+++ b/tests/durability/cli.js
@@ -20,6 +20,7 @@ Modes (default: 1-season):
 Flags:
   --mode=<mode>        Explicit mode (overrides positional)
   --seed=<n>           Deterministic seed (default 1684)
+  --seeds=<a,b,c>      Run multiple clean seeds and aggregate reports
   --stop-phase=<p>     Bound each season to playoffs|offseason|rollover (default rollover).
                        Use offseason to skip the expensive draft/FA rollover.
   --phase-timeout-ms=<n>  Per-SIM_TO_PHASE timeout. On timeout the run records a
@@ -37,7 +38,7 @@ const KNOWN_MODES = ['1-season', '5-season', '10-season', '20-season'];
 
 export function parseArgv(argv) {
   const args = argv.slice(2);
-  const raw = { mode: null, seed: 1684, failureMode: 'fail-fast', determinism: false, writeReport: false, summary: false, out: null, reportName: null, stopPhase: 'rollover', phaseTimeoutMs: null, help: false };
+  const raw = { mode: null, seed: 1684, seeds: null, failureMode: 'fail-fast', determinism: false, writeReport: false, summary: false, out: null, reportName: null, stopPhase: 'rollover', phaseTimeoutMs: null, help: false };
   const errors = [];
   for (const a of args) {
     if (a === '-h' || a === '--help') raw.help = true;
@@ -49,6 +50,7 @@ export function parseArgv(argv) {
     else if (a.startsWith('--stop-phase=')) raw.stopPhase = a.slice(13);
     else if (a.startsWith('--phase-timeout-ms=')) raw.phaseTimeoutMs = Number(a.slice(19));
     else if (a.startsWith('--seed=')) raw.seed = Number(a.slice(7));
+    else if (a.startsWith('--seeds=')) raw.seeds = a.slice(8).split(',').map((v) => Number(v.trim())).filter((v) => Number.isFinite(v));
     else if (a.startsWith('--out=')) { raw.out = a.slice(6); raw.writeReport = true; }
     else if (a.startsWith('--report-name=')) raw.reportName = a.slice(14);
     else if (KNOWN_MODES.includes(a)) raw.mode = a;
@@ -58,6 +60,7 @@ export function parseArgv(argv) {
   if (!KNOWN_MODES.includes(raw.mode)) errors.push(`Unknown mode: ${raw.mode}`);
   if (!['playoffs', 'offseason', 'rollover'].includes(raw.stopPhase)) errors.push(`Unknown --stop-phase: ${raw.stopPhase}`);
   if (!Number.isFinite(raw.seed)) errors.push('Invalid --seed');
+  if (raw.seeds && raw.seeds.length === 0) errors.push('Invalid --seeds');
   return { raw, errors };
 }
 

--- a/tests/durability/cli.js
+++ b/tests/durability/cli.js
@@ -31,6 +31,7 @@ Flags:
   --summary            Also write the compact summary report
   --out=<path>         Explicit output file for the full report
   --report-name=<name> Stable base filename (e.g. long-save-1-season)
+  --child-run          Internal: execute one isolated run for the parent CLI
   -h, --help           Show this help
 `;
 
@@ -38,10 +39,11 @@ const KNOWN_MODES = ['1-season', '5-season', '10-season', '20-season'];
 
 export function parseArgv(argv) {
   const args = argv.slice(2);
-  const raw = { mode: null, seed: 1684, seeds: null, failureMode: 'fail-fast', determinism: false, writeReport: false, summary: false, out: null, reportName: null, stopPhase: 'rollover', phaseTimeoutMs: null, help: false };
+  const raw = { mode: null, seed: 1684, seeds: null, failureMode: 'fail-fast', determinism: false, writeReport: false, summary: false, out: null, reportName: null, stopPhase: 'rollover', phaseTimeoutMs: null, help: false, childRun: false };
   const errors = [];
   for (const a of args) {
     if (a === '-h' || a === '--help') raw.help = true;
+    else if (a === '--child-run') raw.childRun = true;
     else if (a === '--collect-all') raw.failureMode = 'collect-all';
     else if (a === '--determinism') raw.determinism = true;
     else if (a === '--write-report') raw.writeReport = true;
@@ -50,7 +52,7 @@ export function parseArgv(argv) {
     else if (a.startsWith('--stop-phase=')) raw.stopPhase = a.slice(13);
     else if (a.startsWith('--phase-timeout-ms=')) raw.phaseTimeoutMs = Number(a.slice(19));
     else if (a.startsWith('--seed=')) raw.seed = Number(a.slice(7));
-    else if (a.startsWith('--seeds=')) raw.seeds = a.slice(8).split(',').map((v) => Number(v.trim())).filter((v) => Number.isFinite(v));
+    else if (a.startsWith('--seeds=')) raw.seeds = a.slice(8).split(',').map((v) => v.trim());
     else if (a.startsWith('--out=')) { raw.out = a.slice(6); raw.writeReport = true; }
     else if (a.startsWith('--report-name=')) raw.reportName = a.slice(14);
     else if (KNOWN_MODES.includes(a)) raw.mode = a;
@@ -60,7 +62,11 @@ export function parseArgv(argv) {
   if (!KNOWN_MODES.includes(raw.mode)) errors.push(`Unknown mode: ${raw.mode}`);
   if (!['playoffs', 'offseason', 'rollover'].includes(raw.stopPhase)) errors.push(`Unknown --stop-phase: ${raw.stopPhase}`);
   if (!Number.isFinite(raw.seed)) errors.push('Invalid --seed');
-  if (raw.seeds && raw.seeds.length === 0) errors.push('Invalid --seeds');
+  if (raw.seeds) {
+    if (raw.seeds.length === 0 || raw.seeds.some((v) => !/^[-]?\d+$/.test(v))) errors.push('Invalid --seeds');
+    raw.seeds = raw.seeds.map((v) => Number(v));
+  }
+  if (raw.seeds && raw.determinism) errors.push('--seeds cannot be combined with --determinism; run determinism with --seed or run multi-seed without --determinism');
   return { raw, errors };
 }
 

--- a/tests/durability/invariants/cap.js
+++ b/tests/durability/invariants/cap.js
@@ -6,9 +6,11 @@
  * calculator already produces, and structural sanity on contracts. Momentary
  * over-cap states (dead money, pending restructures) are explicitly allowed.
  */
-import { pass, fail, skip, gamePhase, isRosterStablePhase, isUnsafeNumber } from './helpers.js';
+import { pass, fail, skip, gamePhase, PHASE_GROUPS, isUnsafeNumber } from './helpers.js';
 import { CAP } from './bounds.js';
-import { viewTeams, rosteredPlayersFromView } from './derive.js';
+import { playerPool, rosteredPlayersFromView, viewTeams } from './derive.js';
+import { buildTeamCapSnapshot as buildCanonicalTeamCapSnapshot } from '../../../src/core/contracts/contractObligations.js';
+import { canonicalIdKey, sameEntityId } from '../../../src/core/referenceIntegrity.js';
 import { resolveLiveSalaryCap } from './durableSnapshot.js';
 
 export const id = 'cap';
@@ -49,13 +51,13 @@ export function check(ctx) {
   }
 
   // ── stable-phase legal cap equation ─────────────────────────────────────
-  if (!isRosterStablePhase(gamePhase(ctx))) {
+  if (!isCapLegalCheckpoint(ctx)) {
     out.push(skip(ctx, 'cap.stable-phase-legal', `Cap legality skipped in transitional phase ${gamePhase(ctx) ?? 'unknown'}`));
   } else {
-    const snaps = teams.map((team) => buildTeamCapSnapshot(team, ctx));
-    const illegal = snaps.filter((s) => s.totalCommitted > s.liveLimit + 0.0005);
+    const snaps = buildLeagueCapSnapshots(ctx);
+    const illegal = snaps.filter((s) => !s.isLegallyCompliant);
     if (illegal.length) {
-      for (const snap of illegal.slice(0, 12)) out.push(fail(ctx, 'cap.stable-phase-legal', { entityType: 'team', entityId: snap.teamId, message: `Team ${snap.teamId} exceeds live cap by ${snap.overage.toFixed(3)}`, details: snap }));
+      for (const snap of illegal.slice(0, 12)) out.push(fail(ctx, 'cap.stable-phase-legal', { entityType: 'team', entityId: snap.teamId, message: `Team ${snap.teamId} exceeds live cap by ${snap.overageVsLegal.toFixed(2)}`, details: snap }));
     } else {
       out.push(pass(ctx, 'cap.stable-phase-legal', `All ${teams.length} teams legal against live cap`, { snapshots: snaps.slice(0, 2) }));
     }
@@ -104,16 +106,26 @@ export function check(ctx) {
   return out;
 }
 
-export function buildTeamCapSnapshot(team, ctx = {}) {
-  const roster = Array.isArray(team?.roster) ? team.roster : [];
-  const rosterCap = roster.reduce((sum, p) => sum + capHitFor(p), 0);
-  const deadCap = num(team?.deadCap ?? team?.deadMoney ?? team?.currentDeadCap);
-  const pendingCommitments = pendingCountedCommitments(team, ctx);
-  const liveLimit = num(resolveLiveSalaryCap({ view: ctx.view, db: ctx.db })) || num(team?.capTotal);
-  const totalCommitted = round(rosterCap + deadCap + pendingCommitments);
-  return { teamId: team?.id, rosterCap: round(rosterCap), deadCap: round(deadCap), pendingCommitments: round(pendingCommitments), totalCommitted, liveLimit: round(liveLimit), overage: round(totalCommitted - liveLimit) };
+export function buildLeagueCapSnapshots(ctx = {}) {
+  const salaryCap = resolveLiveSalaryCap(ctx);
+  const { players } = playerPool(ctx);
+  return authoritativeTeams(ctx).map((team) => {
+    const roster = players.filter((p) => p && p.teamId != null && sameEntityId(p.teamId, team.id) && p.status !== 'retired' && p.status !== 'free_agent');
+    const snap = buildCanonicalTeamCapSnapshot({
+      team, roster, salaryCap, pendingCommitments: pendingCountedCommitments(team, ctx),
+    });
+    return { ...snap, teamId: canonicalIdKey(team.id), liveLimit: snap.legalLimit };
+  });
 }
-function capHitFor(p) { return num(p?.capHit ?? p?.contract?.capHit ?? p?.contract?.salary ?? p?.salary); }
-function pendingCountedCommitments(team) { return num(team?.pendingCommitments ?? team?.pendingCapCommitments ?? 0); }
-function num(v) { return typeof v === 'number' && Number.isFinite(v) ? v : 0; }
-function round(v) { return Math.round(v * 1000) / 1000; }
+export function buildTeamCapSnapshot(team, ctx = {}) {
+  return buildLeagueCapSnapshots({ ...ctx, db: { ...(ctx.db || {}), teams: [team] } })[0];
+}
+function authoritativeTeams(ctx = {}) {
+  return Array.isArray(ctx?.db?.teams) && ctx.db.teams.length ? ctx.db.teams : viewTeams(ctx);
+}
+function pendingCountedCommitments(team) { return typeof team?.pendingCommitments === 'number' ? team.pendingCommitments : (typeof team?.pendingCapCommitments === 'number' ? team.pendingCapCommitments : 0); }
+
+function isCapLegalCheckpoint(ctx) {
+  const phase = gamePhase(ctx);
+  return PHASE_GROUPS.REGULAR.has(phase) || PHASE_GROUPS.PLAYOFFS.has(phase);
+}

--- a/tests/durability/invariants/cap.js
+++ b/tests/durability/invariants/cap.js
@@ -6,9 +6,10 @@
  * calculator already produces, and structural sanity on contracts. Momentary
  * over-cap states (dead money, pending restructures) are explicitly allowed.
  */
-import { pass, fail, skip, isFiniteNumber, isUnsafeNumber } from './helpers.js';
+import { pass, fail, skip, gamePhase, isRosterStablePhase, isUnsafeNumber } from './helpers.js';
 import { CAP } from './bounds.js';
 import { viewTeams, rosteredPlayersFromView } from './derive.js';
+import { resolveLiveSalaryCap } from './durableSnapshot.js';
 
 export const id = 'cap';
 
@@ -45,6 +46,19 @@ export function check(ctx) {
     }
   } else {
     out.push(pass(ctx, 'cap.aggregates-finite', `All team cap aggregates finite across ${teams.length} teams`));
+  }
+
+  // ── stable-phase legal cap equation ─────────────────────────────────────
+  if (!isRosterStablePhase(gamePhase(ctx))) {
+    out.push(skip(ctx, 'cap.stable-phase-legal', `Cap legality skipped in transitional phase ${gamePhase(ctx) ?? 'unknown'}`));
+  } else {
+    const snaps = teams.map((team) => buildTeamCapSnapshot(team, ctx));
+    const illegal = snaps.filter((s) => s.totalCommitted > s.liveLimit + 0.0005);
+    if (illegal.length) {
+      for (const snap of illegal.slice(0, 12)) out.push(fail(ctx, 'cap.stable-phase-legal', { entityType: 'team', entityId: snap.teamId, message: `Team ${snap.teamId} exceeds live cap by ${snap.overage.toFixed(3)}`, details: snap }));
+    } else {
+      out.push(pass(ctx, 'cap.stable-phase-legal', `All ${teams.length} teams legal against live cap`, { snapshots: snaps.slice(0, 2) }));
+    }
   }
 
   // ── contract numeric safety on rostered players ──────────────────────────
@@ -89,3 +103,17 @@ export function check(ctx) {
 
   return out;
 }
+
+export function buildTeamCapSnapshot(team, ctx = {}) {
+  const roster = Array.isArray(team?.roster) ? team.roster : [];
+  const rosterCap = roster.reduce((sum, p) => sum + capHitFor(p), 0);
+  const deadCap = num(team?.deadCap ?? team?.deadMoney ?? team?.currentDeadCap);
+  const pendingCommitments = pendingCountedCommitments(team, ctx);
+  const liveLimit = num(resolveLiveSalaryCap({ view: ctx.view, db: ctx.db })) || num(team?.capTotal);
+  const totalCommitted = round(rosterCap + deadCap + pendingCommitments);
+  return { teamId: team?.id, rosterCap: round(rosterCap), deadCap: round(deadCap), pendingCommitments: round(pendingCommitments), totalCommitted, liveLimit: round(liveLimit), overage: round(totalCommitted - liveLimit) };
+}
+function capHitFor(p) { return num(p?.capHit ?? p?.contract?.capHit ?? p?.contract?.salary ?? p?.salary); }
+function pendingCountedCommitments(team) { return num(team?.pendingCommitments ?? team?.pendingCapCommitments ?? 0); }
+function num(v) { return typeof v === 'number' && Number.isFinite(v) ? v : 0; }
+function round(v) { return Math.round(v * 1000) / 1000; }

--- a/tests/durability/invariants/continuity.js
+++ b/tests/durability/invariants/continuity.js
@@ -1,3 +1,4 @@
+import { canonicalIdKey } from '../../../src/core/referenceIntegrity.js';
 import { fail, pass, skip } from './helpers.js';
 
 export const id = 'continuity';
@@ -70,33 +71,39 @@ export function check(ctx) {
   return out;
 }
 
+const CONTRACT_TRANSACTION_TYPES = new Set(['SIGN', 'SIGNED', 'SIGNING', 'CONTRACT_SIGNING', 'CONTRACT_EXTENSION', 'EXTENSION', 'RESTRUCTURE', 'CONTRACT_RESTRUCTURE', 'FRANCHISE_TAG', 'RFA_TENDER']);
+const DISPOSITION_TRANSACTION_TYPES = new Set(['RETIRE', 'RETIREMENT', 'RETIRED', 'RELEASE', 'RELEASED', 'PLAYER_RELEASED', 'WAIVE', 'WAIVED', 'FREE_AGENCY', 'FREE_AGENT', 'ROSTER_REMOVAL', 'REMOVED', 'DELETE', 'DELETED', 'DISPOSITION']);
+
 function hasLegitimateDisposition(ctx, player, curRetiredIds) {
   if (!player?.id) return true;
   if (player.status === 'draft_eligible') return true;
   if (curRetiredIds.has(player.id)) return true;
-  return hasPlayerEvent(ctx, player.id, ['retire', 'retirement', 'retired', 'release', 'released', 'waive', 'waived', 'free_agent', 'free agency', 'removed', 'delete', 'disposition']);
+  return hasPlayerEvent(ctx, player.id, DISPOSITION_TRANSACTION_TYPES);
 }
 
 function hasLegitimateContractTransition(ctx, prev, cur) {
-  if (hasPlayerEvent(ctx, prev.id, ['sign', 'signed', 'extension', 'extend', 'extended', 'restructure', 'restructured', 'contract'])) return true;
-  const wasUnsigned = Number(prev.yearsRemaining ?? 0) <= 0 || prev.teamId == null || prev.status === 'free_agent';
-  const isRostered = cur.teamId != null && cur.status !== 'free_agent' && cur.status !== 'retired';
-  if (wasUnsigned && isRostered && Number(cur.yearsRemaining ?? 0) > 0) return true;
-  const totalIncreased = Number(cur.yearsTotal ?? 0) > Number(prev.yearsTotal ?? 0);
-  const economicsChanged = cur.baseAnnual !== prev.baseAnnual || cur.signingBonus !== prev.signingBonus;
-  return totalIncreased && economicsChanged;
+  if (hasPlayerEvent(ctx, prev.id, CONTRACT_TRANSACTION_TYPES)) return true;
+  const wasEstablishedRostered = prev.teamId != null && prev.status !== 'free_agent' && prev.status !== 'draft_eligible' && prev.status !== 'retired' && Number(prev.yearsRemaining ?? 0) > 0;
+  if (wasEstablishedRostered) return false;
+  const becomesRostered = cur.teamId != null && cur.status !== 'free_agent' && cur.status !== 'retired' && cur.status !== 'draft_eligible';
+  return becomesRostered && Number(cur.yearsRemaining ?? 0) > 0;
 }
 
-function hasPlayerEvent(ctx, playerId, words) {
+function hasPlayerEvent(ctx, playerId, allowedTypes) {
   const txs = [
     ...(Array.isArray(ctx?.probes?.transactions) ? ctx.probes.transactions : []),
     ...(Array.isArray(ctx?.transactions) ? ctx.transactions : []),
     ...(Array.isArray(ctx?.durableSnapshot?.transactions) ? ctx.durableSnapshot.transactions : []),
   ];
-  const id = String(playerId);
-  return txs.some((tx) => {
-    const text = JSON.stringify(tx).toLowerCase();
-    if (!text.includes(id.toLowerCase())) return false;
-    return words.some((w) => text.includes(w));
-  });
+  const id = canonicalIdKey(playerId);
+  if (!id) return false;
+  return txs.some((tx) => canonicalIdKey(transactionPlayerId(tx)) === id && allowedTypes.has(normalizeTransactionType(tx)));
+}
+
+function transactionPlayerId(tx) {
+  return tx?.playerId ?? tx?.details?.playerId ?? tx?.details?.player?.id ?? tx?.targetPlayerId ?? tx?.subjectId ?? null;
+}
+
+function normalizeTransactionType(tx) {
+  return String(tx?.type ?? tx?.legacyType ?? tx?.action ?? '').trim().toUpperCase().replace(/[-\s]+/g, '_');
 }

--- a/tests/durability/invariants/continuity.js
+++ b/tests/durability/invariants/continuity.js
@@ -25,13 +25,15 @@ export function check(ctx) {
   const prevHistory = prev.history?.length ?? 0;
   const curHistory = cur.history?.length ?? 0;
   const historyDelta = curHistory - prevHistory;
-  out.push(historyDelta < 0 || historyDelta > 1
-    ? fail(ctx, 'continuity.history-grows-once', { entityType: 'history', entityId: 'league', message: `Completed history changed by ${historyDelta}`, details: { prevHistory, curHistory } })
-    : pass(ctx, 'continuity.history-grows-once', `History growth bounded (${historyDelta})`));
+  const completedRollover = ctx?.phase === 'afterSeasonRollover' && prev.league?.phase && prev.league.phase !== cur.league?.phase;
+  const badHistory = completedRollover ? historyDelta !== 1 : (historyDelta < 0 || historyDelta > 1);
+  out.push(badHistory
+    ? fail(ctx, 'continuity.history-grows-once', { entityType: 'history', entityId: 'league', message: completedRollover ? `Completed rollover history changed by ${historyDelta}; expected exactly 1` : `Completed history changed by ${historyDelta}`, details: { prevHistory, curHistory, completedRollover } })
+    : pass(ctx, 'continuity.history-grows-once', completedRollover ? 'Completed rollover added exactly one history row' : `History growth bounded (${historyDelta})`));
 
   const gameSeason = new Map();
   const reused = [];
-  for (const g of cur.schedule || []) {
+  for (const g of [...(prev.schedule || []), ...(cur.schedule || [])]) {
     if (!g.id || g.season == null) continue;
     if (gameSeason.has(g.id) && gameSeason.get(g.id) !== g.season) reused.push(g.id);
     gameSeason.set(g.id, g.season);
@@ -40,16 +42,30 @@ export function check(ctx) {
     ? fail(ctx, 'continuity.schedule-game-id-season-unique', { entityType: 'game', entityId: reused[0], message: 'Schedule game id reused across seasons', details: { reused: reused.slice(0, 20) } })
     : pass(ctx, 'continuity.schedule-game-id-season-unique', 'Schedule game ids are not reused across seasons in checkpoint'));
 
-  if (prev.league?.phase !== cur.league?.phase) {
-    out.push(skip(ctx, 'continuity.players-do-not-disappear', `Player-disposition continuity skipped across lifecycle phase transition ${prev.league?.phase ?? 'unknown'} -> ${cur.league?.phase ?? 'unknown'}`));
+  const transition = `${prev.league?.phase ?? 'unknown'} -> ${cur.league?.phase ?? 'unknown'}`;
+  if (prev.league?.phase === 'offseason_resign' && cur.league?.phase === 'preseason') {
+    out.push(skip(ctx, 'continuity.players-do-not-disappear', `Player-disposition evidence unavailable during offseason roster/draft/free-agency reconciliation (${transition})`));
   } else {
-    const prevPlayerIds = new Set((prev.players || []).map((p) => p.id));
     const curAllIds = new Set([...(cur.players || []).map((p) => p.id), ...(cur.retiredPlayers || []).map((p) => p.id)]);
-    const disappeared = [...prevPlayerIds].filter((pid) => !curAllIds.has(pid));
+    const disappeared = (prev.players || []).filter((p) => p?.status !== 'draft_eligible' && !curAllIds.has(p.id));
     out.push(disappeared.length
-      ? fail(ctx, 'continuity.players-do-not-disappear', { entityType: 'player', entityId: disappeared[0], message: 'Active player disappeared without retirement record in adjacent same-phase checkpoint', details: { disappeared: disappeared.slice(0, 20) } })
-      : pass(ctx, 'continuity.players-do-not-disappear', 'No active players disappeared without retirement record'));
+      ? fail(ctx, 'continuity.players-do-not-disappear', { entityType: 'player', entityId: disappeared[0].id, message: 'Active/free-agent player disappeared without retirement or disposition evidence', details: { disappeared: disappeared.slice(0, 20).map((p) => p.id), transition } })
+      : pass(ctx, 'continuity.players-do-not-disappear', 'No active/free-agent players disappeared without retirement or disposition evidence'));
   }
+
+  const curById = new Map((cur.players || []).map((p) => [p.id, p]));
+  const yearsIncreased = [];
+  for (const p of prev.players || []) {
+    const next = curById.get(p.id);
+    if (!next) continue;
+    if (Number(next.yearsRemaining ?? 0) > Number(p.yearsRemaining ?? 0)) {
+      const contractChanged = next.yearsTotal !== p.yearsTotal || next.baseAnnual !== p.baseAnnual || next.signingBonus !== p.signingBonus || next.activeCapHit !== p.activeCapHit;
+      if (!contractChanged) yearsIncreased.push({ id: p.id, before: p.yearsRemaining, after: next.yearsRemaining });
+    }
+  }
+  out.push(yearsIncreased.length
+    ? fail(ctx, 'continuity.contract-years-do-not-increase-without-contract-write', { entityType: 'player', entityId: yearsIncreased[0].id, message: 'Contract years increased without a signing/extension/restructure-shaped contract write', details: { yearsIncreased: yearsIncreased.slice(0, 20) } })
+    : pass(ctx, 'continuity.contract-years-do-not-increase-without-contract-write', 'No contract years increased without a contract-write shape'));
 
   return out;
 }

--- a/tests/durability/invariants/continuity.js
+++ b/tests/durability/invariants/continuity.js
@@ -1,0 +1,55 @@
+import { fail, pass, skip } from './helpers.js';
+
+export const id = 'continuity';
+
+export function check(ctx) {
+  const cur = ctx?.durableSnapshot;
+  const prev = ctx?.previousDurableSnapshot;
+  if (!cur || !prev) return [skip(ctx, 'continuity.previous-checkpoint-present', 'No previous durable snapshot for continuity comparison')];
+  const out = [];
+  const prevTeams = new Set((prev.teams || []).map((t) => t.id));
+  const curTeams = new Set((cur.teams || []).map((t) => t.id));
+  const missingTeams = [...prevTeams].filter((id) => !curTeams.has(id));
+  const addedTeams = [...curTeams].filter((id) => !prevTeams.has(id));
+  out.push(missingTeams.length || addedTeams.length
+    ? fail(ctx, 'continuity.team-identity-stable', { entityType: 'league', entityId: 'teams', message: 'Team identity set changed between checkpoints', details: { missingTeams, addedTeams } })
+    : pass(ctx, 'continuity.team-identity-stable', `Team identities stable (${curTeams.size})`));
+
+  const active = new Set((cur.players || []).map((p) => p.id));
+  const retired = new Set((cur.retiredPlayers || []).map((p) => p.id));
+  const overlap = [...active].filter((id) => retired.has(id));
+  out.push(overlap.length
+    ? fail(ctx, 'continuity.active-retired-disjoint', { entityType: 'player', entityId: overlap[0], message: 'Player is both active and retired', details: { overlap: overlap.slice(0, 20) } })
+    : pass(ctx, 'continuity.active-retired-disjoint', 'Active and retired populations are disjoint'));
+
+  const prevHistory = prev.history?.length ?? 0;
+  const curHistory = cur.history?.length ?? 0;
+  const historyDelta = curHistory - prevHistory;
+  out.push(historyDelta < 0 || historyDelta > 1
+    ? fail(ctx, 'continuity.history-grows-once', { entityType: 'history', entityId: 'league', message: `Completed history changed by ${historyDelta}`, details: { prevHistory, curHistory } })
+    : pass(ctx, 'continuity.history-grows-once', `History growth bounded (${historyDelta})`));
+
+  const gameSeason = new Map();
+  const reused = [];
+  for (const g of cur.schedule || []) {
+    if (!g.id || g.season == null) continue;
+    if (gameSeason.has(g.id) && gameSeason.get(g.id) !== g.season) reused.push(g.id);
+    gameSeason.set(g.id, g.season);
+  }
+  out.push(reused.length
+    ? fail(ctx, 'continuity.schedule-game-id-season-unique', { entityType: 'game', entityId: reused[0], message: 'Schedule game id reused across seasons', details: { reused: reused.slice(0, 20) } })
+    : pass(ctx, 'continuity.schedule-game-id-season-unique', 'Schedule game ids are not reused across seasons in checkpoint'));
+
+  if (prev.league?.phase !== cur.league?.phase) {
+    out.push(skip(ctx, 'continuity.players-do-not-disappear', `Player-disposition continuity skipped across lifecycle phase transition ${prev.league?.phase ?? 'unknown'} -> ${cur.league?.phase ?? 'unknown'}`));
+  } else {
+    const prevPlayerIds = new Set((prev.players || []).map((p) => p.id));
+    const curAllIds = new Set([...(cur.players || []).map((p) => p.id), ...(cur.retiredPlayers || []).map((p) => p.id)]);
+    const disappeared = [...prevPlayerIds].filter((pid) => !curAllIds.has(pid));
+    out.push(disappeared.length
+      ? fail(ctx, 'continuity.players-do-not-disappear', { entityType: 'player', entityId: disappeared[0], message: 'Active player disappeared without retirement record in adjacent same-phase checkpoint', details: { disappeared: disappeared.slice(0, 20) } })
+      : pass(ctx, 'continuity.players-do-not-disappear', 'No active players disappeared without retirement record'));
+  }
+
+  return out;
+}

--- a/tests/durability/invariants/continuity.js
+++ b/tests/durability/invariants/continuity.js
@@ -43,14 +43,15 @@ export function check(ctx) {
     : pass(ctx, 'continuity.schedule-game-id-season-unique', 'Schedule game ids are not reused across seasons in checkpoint'));
 
   const transition = `${prev.league?.phase ?? 'unknown'} -> ${cur.league?.phase ?? 'unknown'}`;
-  if (prev.league?.phase === 'offseason_resign' && cur.league?.phase === 'preseason') {
-    out.push(skip(ctx, 'continuity.players-do-not-disappear', `Player-disposition evidence unavailable during offseason roster/draft/free-agency reconciliation (${transition})`));
+  if (cur.pools?.source && cur.pools.source !== 'db') {
+    out.push(skip(ctx, 'continuity.players-do-not-disappear', `Full DB player pool unavailable at current checkpoint; roster-only view cannot prove dispositions (${transition})`, { source: cur.pools.source }));
   } else {
     const curAllIds = new Set([...(cur.players || []).map((p) => p.id), ...(cur.retiredPlayers || []).map((p) => p.id)]);
-    const disappeared = (prev.players || []).filter((p) => p?.status !== 'draft_eligible' && !curAllIds.has(p.id));
+    const curRetiredIds = new Set((cur.retiredPlayers || []).map((p) => p.id));
+    const disappeared = (prev.players || []).filter((p) => !curAllIds.has(p.id) && !hasLegitimateDisposition(ctx, p, curRetiredIds));
     out.push(disappeared.length
-      ? fail(ctx, 'continuity.players-do-not-disappear', { entityType: 'player', entityId: disappeared[0].id, message: 'Active/free-agent player disappeared without retirement or disposition evidence', details: { disappeared: disappeared.slice(0, 20).map((p) => p.id), transition } })
-      : pass(ctx, 'continuity.players-do-not-disappear', 'No active/free-agent players disappeared without retirement or disposition evidence'));
+      ? fail(ctx, 'continuity.players-do-not-disappear', { entityType: 'player', entityId: disappeared[0].id, message: 'Established player disappeared without retirement, draft-pool, free-agency, release, or removal disposition evidence', details: { disappeared: disappeared.slice(0, 20).map((p) => ({ id: p.id, status: p.status })), transition } })
+      : pass(ctx, 'continuity.players-do-not-disappear', 'No established players disappeared without disposition evidence'));
   }
 
   const curById = new Map((cur.players || []).map((p) => [p.id, p]));
@@ -59,8 +60,7 @@ export function check(ctx) {
     const next = curById.get(p.id);
     if (!next) continue;
     if (Number(next.yearsRemaining ?? 0) > Number(p.yearsRemaining ?? 0)) {
-      const contractChanged = next.yearsTotal !== p.yearsTotal || next.baseAnnual !== p.baseAnnual || next.signingBonus !== p.signingBonus || next.activeCapHit !== p.activeCapHit;
-      if (!contractChanged) yearsIncreased.push({ id: p.id, before: p.yearsRemaining, after: next.yearsRemaining });
+      if (!hasLegitimateContractTransition(ctx, p, next)) yearsIncreased.push({ id: p.id, before: p.yearsRemaining, after: next.yearsRemaining, beforeTotal: p.yearsTotal, afterTotal: next.yearsTotal });
     }
   }
   out.push(yearsIncreased.length
@@ -68,4 +68,35 @@ export function check(ctx) {
     : pass(ctx, 'continuity.contract-years-do-not-increase-without-contract-write', 'No contract years increased without a contract-write shape'));
 
   return out;
+}
+
+function hasLegitimateDisposition(ctx, player, curRetiredIds) {
+  if (!player?.id) return true;
+  if (player.status === 'draft_eligible') return true;
+  if (curRetiredIds.has(player.id)) return true;
+  return hasPlayerEvent(ctx, player.id, ['retire', 'retirement', 'retired', 'release', 'released', 'waive', 'waived', 'free_agent', 'free agency', 'removed', 'delete', 'disposition']);
+}
+
+function hasLegitimateContractTransition(ctx, prev, cur) {
+  if (hasPlayerEvent(ctx, prev.id, ['sign', 'signed', 'extension', 'extend', 'extended', 'restructure', 'restructured', 'contract'])) return true;
+  const wasUnsigned = Number(prev.yearsRemaining ?? 0) <= 0 || prev.teamId == null || prev.status === 'free_agent';
+  const isRostered = cur.teamId != null && cur.status !== 'free_agent' && cur.status !== 'retired';
+  if (wasUnsigned && isRostered && Number(cur.yearsRemaining ?? 0) > 0) return true;
+  const totalIncreased = Number(cur.yearsTotal ?? 0) > Number(prev.yearsTotal ?? 0);
+  const economicsChanged = cur.baseAnnual !== prev.baseAnnual || cur.signingBonus !== prev.signingBonus;
+  return totalIncreased && economicsChanged;
+}
+
+function hasPlayerEvent(ctx, playerId, words) {
+  const txs = [
+    ...(Array.isArray(ctx?.probes?.transactions) ? ctx.probes.transactions : []),
+    ...(Array.isArray(ctx?.transactions) ? ctx.transactions : []),
+    ...(Array.isArray(ctx?.durableSnapshot?.transactions) ? ctx.durableSnapshot.transactions : []),
+  ];
+  const id = String(playerId);
+  return txs.some((tx) => {
+    const text = JSON.stringify(tx).toLowerCase();
+    if (!text.includes(id.toLowerCase())) return false;
+    return words.some((w) => text.includes(w));
+  });
 }

--- a/tests/durability/invariants/durableSnapshot.js
+++ b/tests/durability/invariants/durableSnapshot.js
@@ -35,7 +35,7 @@ export function buildDurableSnapshot(state = {}) {
       capUsed: money(t.capUsed), capRoom: money(t.capRoom), capTotal: money(t.capTotal),
     })).sort(byId),
     players: active.map((p) => ({
-      id: idKey(p.id), teamId: p.teamId == null ? null : idKey(p.teamId), age: p.age ?? null,
+      id: idKey(p.id), teamId: p.teamId == null ? null : idKey(p.teamId), status: p.status ?? null, age: p.age ?? null,
       ovr: p.ovr ?? p.overall ?? null, pot: p.pot ?? p.potential ?? null,
       injury: normalizeInjury(p), ...normalizeContractFields(p),
     })).sort(byId),

--- a/tests/durability/invariants/durableSnapshot.js
+++ b/tests/durability/invariants/durableSnapshot.js
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { canonicalIdKey, stableIdCompare } from '../../../src/core/referenceIntegrity.js';
+import { getActiveCapHit, normalizeContract } from '../../../src/core/contracts/contractObligations.js';
 import { activePlayersFromPool, draftPicks, freeAgentsFromPool, leagueHistory, playerPool, viewTeams } from './derive.js';
 
 export const DURABLE_SNAPSHOT_VERSION = '2.0.0';
@@ -10,7 +11,7 @@ const byId = (a, b) => stableIdCompare(a?.id ?? a?.playerId ?? a?.gameId, b?.id 
 export function buildDurableSnapshot(state = {}) {
   const view = state.view ?? {};
   const ctx = { ...state, view };
-  const teams = viewTeams(ctx);
+  const teams = authoritativeTeams(ctx);
   const { players } = playerPool(ctx);
   const retired = players.filter((p) => p?.status === 'retired' || p?.retired === true || p?.retirementYear != null);
   const active = players.filter((p) => p && p.status !== 'retired' && p.retired !== true);
@@ -36,9 +37,7 @@ export function buildDurableSnapshot(state = {}) {
     players: active.map((p) => ({
       id: idKey(p.id), teamId: p.teamId == null ? null : idKey(p.teamId), age: p.age ?? null,
       ovr: p.ovr ?? p.overall ?? null, pot: p.pot ?? p.potential ?? null,
-      injury: normalizeInjury(p), years: p.contract?.years ?? p.years ?? null,
-      baseSalary: money(p.contract?.baseSalary ?? p.contract?.salary ?? p.salary),
-      signingBonus: money(p.contract?.signingBonus ?? p.signingBonus), capHit: money(p.capHit ?? p.contract?.capHit),
+      injury: normalizeInjury(p), ...normalizeContractFields(p),
     })).sort(byId),
     retiredPlayers: retired.map((p) => ({ id: idKey(p.id), retirementYear: p.retirementYear ?? p.retiredYear ?? null })).sort(byId),
     draftPicks: picks.map((pk) => ({ id: idKey(pk.id), season: pk.season ?? pk.year ?? null, round: pk.round ?? null, originalOwner: idKey(pk.originalOwner ?? pk.originalTeamId), currentOwner: idKey(pk.currentOwner ?? pk.teamId ?? pk.owner) })).sort(byId),
@@ -61,19 +60,39 @@ export function compareDurableSnapshots(a, b, limit = 20) {
 function walk(a, b, path, out, limit) {
   if (out.length >= limit) return;
   if (JSON.stringify(a) === JSON.stringify(b)) return;
+  if (Array.isArray(a) && Array.isArray(b) && (a.some(hasStableEntityId) || b.some(hasStableEntityId))) {
+    const keys = [...new Set([...a.map(entityKey), ...b.map(entityKey)])].filter(Boolean).sort(stableIdCompare);
+    const aMap = new Map(a.filter(hasStableEntityId).map((v) => [entityKey(v), v]));
+    const bMap = new Map(b.filter(hasStableEntityId).map((v) => [entityKey(v), v]));
+    for (const key of keys) walk(aMap.get(key), bMap.get(key), `${path}{${key}}`, out, limit);
+    return;
+  }
   if (!a || !b || typeof a !== 'object' || typeof b !== 'object') { out.push(toDiff(path, a, b)); return; }
   const keys = [...new Set([...Object.keys(a), ...Object.keys(b)])].sort();
   for (const k of keys) walk(a[k], b[k], path ? `${path}.${k}` : k, out, limit);
 }
 function toDiff(path, a, b) {
   const parts = path.split('.');
-  return { domain: parts[0] ?? 'state', entityId: entityFromPath(parts), field: parts.at(-1) ?? path, path, runA: a, runB: b };
+  return { domain: parts[0]?.replace(/\{.*$/, '') ?? 'state', entityId: entityFromPath(path), field: parts.at(-1)?.replace(/.*}/, '') ?? path, path, runA: a, runB: b };
 }
-function entityFromPath(parts) { const m = String(parts[1] ?? '').match(/^(\d+)/); return m ? m[1] : null; }
+function hasStableEntityId(v) { return v && typeof v === 'object' && (v.id != null || v.playerId != null || v.gameId != null); }
+function entityKey(v) { return canonicalIdKey(v?.id ?? v?.playerId ?? v?.gameId); }
+function entityFromPath(path) { const m = String(path).match(/\{([^}]+)}/); return m ? m[1] : null; }
 function normalizeInjury(p) { const i = p.injury ?? {}; return { status: p.injuryStatus ?? i.status ?? null, weeks: i.weeks ?? p.injuryWeeks ?? null, available: p.available ?? p.isAvailable ?? null }; }
 function normalizeSchedule(schedule) {
   const games = Array.isArray(schedule?.games) ? schedule.games : (Array.isArray(schedule?.weeks) ? schedule.weeks.flatMap((w) => (w.games || []).map((g) => ({ ...g, week: g.week ?? w.week }))) : []);
   return games.map((g) => ({ id: idKey(g.id ?? g.gameId), season: g.season ?? g.year ?? null, week: g.week ?? null, home: idKey(g.home ?? g.homeTeamId), away: idKey(g.away ?? g.awayTeamId), played: !!(g.played ?? g.final), final: !!(g.final ?? g.completed), homeScore: (g.played || g.final) ? (g.homeScore ?? null) : null, awayScore: (g.played || g.final) ? (g.awayScore ?? null) : null })).sort(byId);
 }
-export function resolveLiveSalaryCap(state = {}) { return state.view?.meta?.economy?.currentSalaryCap ?? state.db?.meta?.economy?.currentSalaryCap ?? state.view?.salaryCap ?? state.db?.meta?.salaryCap ?? state.view?.teams?.[0]?.capTotal ?? null; }
+export function resolveLiveSalaryCap(state = {}) { return state.view?.economy?.currentSalaryCap ?? state.db?.meta?.economy?.currentSalaryCap ?? state.view?.salaryCap ?? state.db?.meta?.salaryCap ?? state.view?.teams?.[0]?.capTotal ?? null; }
 function sortObject(v) { if (Array.isArray(v)) return v.map(sortObject); if (!v || typeof v !== 'object') return v; return Object.fromEntries(Object.keys(v).sort().map((k) => [k, sortObject(v[k])])); }
+
+function normalizeContractFields(p) {
+  const c = normalizeContract(p);
+  return { yearsRemaining: c.yearsRemaining, yearsTotal: c.yearsTotal, baseAnnual: money(c.baseAnnual), signingBonus: money(c.signingBonus), activeCapHit: money(getActiveCapHit(p)) };
+}
+function authoritativeTeams(ctx = {}) {
+  const dbTeams = Array.isArray(ctx?.db?.teams) && ctx.db.teams.length ? ctx.db.teams : null;
+  if (!dbTeams) return viewTeams(ctx);
+  const viewById = new Map(viewTeams(ctx).map((t) => [canonicalIdKey(t.id), t]));
+  return dbTeams.map((team) => ({ ...(viewById.get(canonicalIdKey(team.id)) || {}), ...team }));
+}

--- a/tests/durability/invariants/durableSnapshot.js
+++ b/tests/durability/invariants/durableSnapshot.js
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { canonicalIdKey, stableIdCompare } from '../../../src/core/referenceIntegrity.js';
+import { canonicalIdKey, resolveTeamRefId, stableIdCompare } from '../../../src/core/referenceIntegrity.js';
 import { getActiveCapHit, normalizeContract } from '../../../src/core/contracts/contractObligations.js';
 import { activePlayersFromPool, draftPicks, freeAgentsFromPool, leagueHistory, playerPool, viewTeams } from './derive.js';
 
@@ -12,8 +12,12 @@ export function buildDurableSnapshot(state = {}) {
   const view = state.view ?? {};
   const ctx = { ...state, view };
   const teams = authoritativeTeams(ctx);
-  const { players } = playerPool(ctx);
-  const retired = players.filter((p) => p?.status === 'retired' || p?.retired === true || p?.retirementYear != null);
+  const { players, source: playerSource } = playerPool(ctx);
+  const retired = mergeRetiredPlayers(
+    players.filter((p) => p?.status === 'retired' || p?.retired === true || p?.retirementYear != null),
+    view.retiredPlayers,
+    state.db?.meta?.retiredPlayers,
+  );
   const active = players.filter((p) => p && p.status !== 'retired' && p.retired !== true);
   const picks = draftPicks(ctx).picks;
   const history = leagueHistory(ctx);
@@ -42,8 +46,8 @@ export function buildDurableSnapshot(state = {}) {
     retiredPlayers: retired.map((p) => ({ id: idKey(p.id), retirementYear: p.retirementYear ?? p.retiredYear ?? null })).sort(byId),
     draftPicks: picks.map((pk) => ({ id: idKey(pk.id), season: pk.season ?? pk.year ?? null, round: pk.round ?? null, originalOwner: idKey(pk.originalOwner ?? pk.originalTeamId), currentOwner: idKey(pk.currentOwner ?? pk.teamId ?? pk.owner) })).sort(byId),
     schedule: normalizeSchedule(view.schedule ?? state.db?.schedule),
-    history: history.map((h) => ({ season: h.season ?? h.year ?? null, year: h.year ?? null, champion: idKey(h.championTeamId ?? h.champion), runnerUp: idKey(h.runnerUpTeamId ?? h.runnerUp) })).sort((a,b) => (a.season ?? 0) - (b.season ?? 0)),
-    pools: { active: active.length, rostered: activePlayersFromPool(players).length, freeAgent: freeAgentsFromPool(players).length, retired: retired.length },
+    history: history.map((h) => ({ season: h.season ?? h.year ?? null, year: h.year ?? null, champion: resolveTeamRefId(h.championTeamId ?? h.championId ?? h.champion), runnerUp: resolveTeamRefId(h.runnerUpTeamId ?? h.runnerUpId ?? h.runnerUp) })).sort((a,b) => (a.season ?? 0) - (b.season ?? 0)),
+    pools: { source: playerSource, active: active.length, rostered: activePlayersFromPool(players).length, freeAgent: freeAgentsFromPool(players).length, retired: retired.length },
   });
 }
 
@@ -61,10 +65,15 @@ function walk(a, b, path, out, limit) {
   if (out.length >= limit) return;
   if (JSON.stringify(a) === JSON.stringify(b)) return;
   if (Array.isArray(a) && Array.isArray(b) && (a.some(hasStableEntityId) || b.some(hasStableEntityId))) {
-    const keys = [...new Set([...a.map(entityKey), ...b.map(entityKey)])].filter(Boolean).sort(stableIdCompare);
-    const aMap = new Map(a.filter(hasStableEntityId).map((v) => [entityKey(v), v]));
-    const bMap = new Map(b.filter(hasStableEntityId).map((v) => [entityKey(v), v]));
-    for (const key of keys) walk(aMap.get(key), bMap.get(key), `${path}{${key}}`, out, limit);
+    const aGroups = groupEntityOccurrences(a);
+    const bGroups = groupEntityOccurrences(b);
+    const keys = [...new Set([...aGroups.keys(), ...bGroups.keys()])].sort(stableIdCompare);
+    for (const key of keys) {
+      const left = aGroups.get(key) || [];
+      const right = bGroups.get(key) || [];
+      const count = Math.max(left.length, right.length);
+      for (let i = 0; i < count; i += 1) walk(left[i], right[i], `${path}{${key}}[${i}]`, out, limit);
+    }
     return;
   }
   if (!a || !b || typeof a !== 'object' || typeof b !== 'object') { out.push(toDiff(path, a, b)); return; }
@@ -78,6 +87,18 @@ function toDiff(path, a, b) {
 function hasStableEntityId(v) { return v && typeof v === 'object' && (v.id != null || v.playerId != null || v.gameId != null); }
 function entityKey(v) { return canonicalIdKey(v?.id ?? v?.playerId ?? v?.gameId); }
 function entityFromPath(path) { const m = String(path).match(/\{([^}]+)}/); return m ? m[1] : null; }
+function groupEntityOccurrences(list) {
+  const groups = new Map();
+  for (const v of list || []) {
+    if (!hasStableEntityId(v)) continue;
+    const key = entityKey(v);
+    if (!key) continue;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(v);
+  }
+  for (const values of groups.values()) values.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  return groups;
+}
 function normalizeInjury(p) { const i = p.injury ?? {}; return { status: p.injuryStatus ?? i.status ?? null, weeks: i.weeks ?? p.injuryWeeks ?? null, available: p.available ?? p.isAvailable ?? null }; }
 function normalizeSchedule(schedule) {
   const games = Array.isArray(schedule?.games) ? schedule.games : (Array.isArray(schedule?.weeks) ? schedule.weeks.flatMap((w) => (w.games || []).map((g) => ({ ...g, week: g.week ?? w.week }))) : []);
@@ -95,4 +116,16 @@ function authoritativeTeams(ctx = {}) {
   if (!dbTeams) return viewTeams(ctx);
   const viewById = new Map(viewTeams(ctx).map((t) => [canonicalIdKey(t.id), t]));
   return dbTeams.map((team) => ({ ...(viewById.get(canonicalIdKey(team.id)) || {}), ...team }));
+}
+function mergeRetiredPlayers(...lists) {
+  const byId = new Map();
+  for (const list of lists) {
+    if (!Array.isArray(list)) continue;
+    for (const p of list) {
+      const id = idKey(p?.id ?? p?.playerId);
+      if (!id) continue;
+      if (!byId.has(id)) byId.set(id, { ...p, id });
+    }
+  }
+  return [...byId.values()];
 }

--- a/tests/durability/invariants/durableSnapshot.js
+++ b/tests/durability/invariants/durableSnapshot.js
@@ -1,0 +1,79 @@
+import { createHash } from 'node:crypto';
+import { canonicalIdKey, stableIdCompare } from '../../../src/core/referenceIntegrity.js';
+import { activePlayersFromPool, draftPicks, freeAgentsFromPool, leagueHistory, playerPool, viewTeams } from './derive.js';
+
+export const DURABLE_SNAPSHOT_VERSION = '2.0.0';
+const money = (v) => (typeof v === 'number' && Number.isFinite(v) ? Math.round(v * 1000) / 1000 : v ?? null);
+const idKey = (v) => canonicalIdKey(v) ?? null;
+const byId = (a, b) => stableIdCompare(a?.id ?? a?.playerId ?? a?.gameId, b?.id ?? b?.playerId ?? b?.gameId);
+
+export function buildDurableSnapshot(state = {}) {
+  const view = state.view ?? {};
+  const ctx = { ...state, view };
+  const teams = viewTeams(ctx);
+  const { players } = playerPool(ctx);
+  const retired = players.filter((p) => p?.status === 'retired' || p?.retired === true || p?.retirementYear != null);
+  const active = players.filter((p) => p && p.status !== 'retired' && p.retired !== true);
+  const picks = draftPicks(ctx).picks;
+  const history = leagueHistory(ctx);
+  return sortObject({
+    version: DURABLE_SNAPSHOT_VERSION,
+    league: {
+      season: state.season ?? null,
+      year: view.year ?? state.db?.meta?.year ?? null,
+      week: view.week ?? null,
+      phase: view.phase ?? null,
+      seasonId: view.seasonId ?? state.db?.meta?.seasonId ?? null,
+      userTeamId: idKey(view.userTeamId ?? state.db?.meta?.userTeamId),
+      salaryCap: money(resolveLiveSalaryCap(state)),
+    },
+    teams: teams.map((t) => ({
+      id: idKey(t.id), wins: t.wins ?? 0, losses: t.losses ?? 0, ties: t.ties ?? 0,
+      roster: (Array.isArray(t.roster) ? t.roster.map((p) => idKey(p?.id)) : []).sort(stableIdCompare),
+      deadCap: money(t.deadCap ?? t.deadMoney ?? t.currentDeadCap ?? 0), deferredDeadCap: money(t.deferredDeadCap ?? t.deferredDeadMoney ?? 0),
+      capUsed: money(t.capUsed), capRoom: money(t.capRoom), capTotal: money(t.capTotal),
+    })).sort(byId),
+    players: active.map((p) => ({
+      id: idKey(p.id), teamId: p.teamId == null ? null : idKey(p.teamId), age: p.age ?? null,
+      ovr: p.ovr ?? p.overall ?? null, pot: p.pot ?? p.potential ?? null,
+      injury: normalizeInjury(p), years: p.contract?.years ?? p.years ?? null,
+      baseSalary: money(p.contract?.baseSalary ?? p.contract?.salary ?? p.salary),
+      signingBonus: money(p.contract?.signingBonus ?? p.signingBonus), capHit: money(p.capHit ?? p.contract?.capHit),
+    })).sort(byId),
+    retiredPlayers: retired.map((p) => ({ id: idKey(p.id), retirementYear: p.retirementYear ?? p.retiredYear ?? null })).sort(byId),
+    draftPicks: picks.map((pk) => ({ id: idKey(pk.id), season: pk.season ?? pk.year ?? null, round: pk.round ?? null, originalOwner: idKey(pk.originalOwner ?? pk.originalTeamId), currentOwner: idKey(pk.currentOwner ?? pk.teamId ?? pk.owner) })).sort(byId),
+    schedule: normalizeSchedule(view.schedule ?? state.db?.schedule),
+    history: history.map((h) => ({ season: h.season ?? h.year ?? null, year: h.year ?? null, champion: idKey(h.championTeamId ?? h.champion), runnerUp: idKey(h.runnerUpTeamId ?? h.runnerUp) })).sort((a,b) => (a.season ?? 0) - (b.season ?? 0)),
+    pools: { active: active.length, rostered: activePlayersFromPool(players).length, freeAgent: freeAgentsFromPool(players).length, retired: retired.length },
+  });
+}
+
+export function durableDigest(snapshot) {
+  return createHash('sha256').update(JSON.stringify(snapshot)).digest('hex');
+}
+
+export function compareDurableSnapshots(a, b, limit = 20) {
+  const diffs = [];
+  walk(a, b, '', diffs, limit);
+  return { ok: diffs.length === 0, firstDivergence: diffs[0] ?? null, diffs };
+}
+
+function walk(a, b, path, out, limit) {
+  if (out.length >= limit) return;
+  if (JSON.stringify(a) === JSON.stringify(b)) return;
+  if (!a || !b || typeof a !== 'object' || typeof b !== 'object') { out.push(toDiff(path, a, b)); return; }
+  const keys = [...new Set([...Object.keys(a), ...Object.keys(b)])].sort();
+  for (const k of keys) walk(a[k], b[k], path ? `${path}.${k}` : k, out, limit);
+}
+function toDiff(path, a, b) {
+  const parts = path.split('.');
+  return { domain: parts[0] ?? 'state', entityId: entityFromPath(parts), field: parts.at(-1) ?? path, path, runA: a, runB: b };
+}
+function entityFromPath(parts) { const m = String(parts[1] ?? '').match(/^(\d+)/); return m ? m[1] : null; }
+function normalizeInjury(p) { const i = p.injury ?? {}; return { status: p.injuryStatus ?? i.status ?? null, weeks: i.weeks ?? p.injuryWeeks ?? null, available: p.available ?? p.isAvailable ?? null }; }
+function normalizeSchedule(schedule) {
+  const games = Array.isArray(schedule?.games) ? schedule.games : (Array.isArray(schedule?.weeks) ? schedule.weeks.flatMap((w) => (w.games || []).map((g) => ({ ...g, week: g.week ?? w.week }))) : []);
+  return games.map((g) => ({ id: idKey(g.id ?? g.gameId), season: g.season ?? g.year ?? null, week: g.week ?? null, home: idKey(g.home ?? g.homeTeamId), away: idKey(g.away ?? g.awayTeamId), played: !!(g.played ?? g.final), final: !!(g.final ?? g.completed), homeScore: (g.played || g.final) ? (g.homeScore ?? null) : null, awayScore: (g.played || g.final) ? (g.awayScore ?? null) : null })).sort(byId);
+}
+export function resolveLiveSalaryCap(state = {}) { return state.view?.meta?.economy?.currentSalaryCap ?? state.db?.meta?.economy?.currentSalaryCap ?? state.view?.salaryCap ?? state.db?.meta?.salaryCap ?? state.view?.teams?.[0]?.capTotal ?? null; }
+function sortObject(v) { if (Array.isArray(v)) return v.map(sortObject); if (!v || typeof v !== 'object') return v; return Object.fromEntries(Object.keys(v).sort().map((k) => [k, sortObject(v[k])])); }

--- a/tests/durability/invariants/durableSnapshot.js
+++ b/tests/durability/invariants/durableSnapshot.js
@@ -102,7 +102,7 @@ function groupEntityOccurrences(list) {
 function normalizeInjury(p) { const i = p.injury ?? {}; return { status: p.injuryStatus ?? i.status ?? null, weeks: i.weeks ?? p.injuryWeeks ?? null, available: p.available ?? p.isAvailable ?? null }; }
 function normalizeSchedule(schedule) {
   const games = Array.isArray(schedule?.games) ? schedule.games : (Array.isArray(schedule?.weeks) ? schedule.weeks.flatMap((w) => (w.games || []).map((g) => ({ ...g, week: g.week ?? w.week }))) : []);
-  return games.map((g) => ({ id: idKey(g.id ?? g.gameId), season: g.season ?? g.year ?? null, week: g.week ?? null, home: idKey(g.home ?? g.homeTeamId), away: idKey(g.away ?? g.awayTeamId), played: !!(g.played ?? g.final), final: !!(g.final ?? g.completed), homeScore: (g.played || g.final) ? (g.homeScore ?? null) : null, awayScore: (g.played || g.final) ? (g.awayScore ?? null) : null })).sort(byId);
+  return games.map((g) => ({ id: idKey(g.id ?? g.gameId), season: g.seasonId ?? g.season ?? g.year ?? null, week: g.week ?? null, home: idKey(g.home ?? g.homeTeamId), away: idKey(g.away ?? g.awayTeamId), played: !!(g.played ?? g.final), final: !!(g.final ?? g.completed), homeScore: (g.played || g.final) ? (g.homeScore ?? null) : null, awayScore: (g.played || g.final) ? (g.awayScore ?? null) : null })).sort(byId);
 }
 export function resolveLiveSalaryCap(state = {}) { return state.view?.economy?.currentSalaryCap ?? state.db?.meta?.economy?.currentSalaryCap ?? state.view?.salaryCap ?? state.db?.meta?.salaryCap ?? state.view?.teams?.[0]?.capTotal ?? null; }
 function sortObject(v) { if (Array.isArray(v)) return v.map(sortObject); if (!v || typeof v !== 'object') return v; return Object.fromEntries(Object.keys(v).sort().map((k) => [k, sortObject(v[k])])); }

--- a/tests/durability/invariants/index.js
+++ b/tests/durability/invariants/index.js
@@ -19,6 +19,7 @@ import * as history from './history.js';
 import * as references from './references.js';
 import * as numericSafety from './numericSafety.js';
 import * as saveReload from './saveReload.js';
+import * as continuity from './continuity.js';
 
 export const INVARIANT_MODULES = [
   roster,
@@ -32,6 +33,7 @@ export const INVARIANT_MODULES = [
   references,
   numericSafety,
   saveReload,
+  continuity,
 ];
 
 /**
@@ -70,4 +72,4 @@ export function runInvariants(ctx) {
   return results;
 }
 
-export { roster, cap, draft, freeAgency, schedule, progression, retirement, history, references, numericSafety, saveReload };
+export { roster, cap, draft, freeAgency, schedule, progression, retirement, history, references, numericSafety, saveReload, continuity };

--- a/tests/durability/invariants/saveReload.js
+++ b/tests/durability/invariants/saveReload.js
@@ -18,6 +18,7 @@
  */
 import { pass, fail, skip } from './helpers.js';
 import { canonicalIdKey, stableIdCompare } from '../../../src/core/referenceIntegrity.js';
+import { buildDurableSnapshot, compareDurableSnapshots, durableDigest } from './durableSnapshot.js';
 
 export const id = 'saveReload';
 
@@ -26,6 +27,8 @@ export const id = 'saveReload';
  * ({ view, db }). Pure — safe to call before save and after reload.
  */
 export function canonicalSummary(state) {
+  const durableSnapshot = buildDurableSnapshot(state);
+  const durableSnapshotDigest = durableDigest(durableSnapshot);
   const view = state?.view ?? {};
   const db = state?.db ?? null;
   const teams = Array.isArray(view.teams) ? view.teams : [];
@@ -69,6 +72,9 @@ export function canonicalSummary(state) {
     capFingerprint,
     rosterFingerprint,
     pickOwnership,
+    durableSnapshotVersion: durableSnapshot.version,
+    durableSnapshotDigest,
+    durableSnapshot,
   };
 }
 
@@ -76,6 +82,7 @@ const EXACT_FIELDS = [
   'year', 'week', 'phase', 'teamCount', 'playerPoolSize', 'freeAgentCount',
   'completedSeasonCount', 'championTeamId', 'userTeamId',
   'capFingerprint', 'rosterFingerprint', 'pickOwnership',
+  'durableSnapshotDigest',
 ];
 
 /**
@@ -94,6 +101,10 @@ export function compareCanonical(before, after) {
       const m = { field: f, before: truncate(a), after: truncate(b) };
       if (f === 'rosterFingerprint') {
         m.diagnostic = classifyRosterFingerprintDiff(String(a), String(b));
+      }
+      if (f === 'durableSnapshotDigest') {
+        const diff = compareDurableSnapshots(before?.durableSnapshot, after?.durableSnapshot);
+        m.diagnostic = { classification: 'durable-state', firstDivergence: diff.firstDivergence, diffs: diff.diffs.slice(0, 8) };
       }
       mismatches.push(m);
     }

--- a/tests/durability/lifecycleDriver.js
+++ b/tests/durability/lifecycleDriver.js
@@ -177,6 +177,7 @@ export class LifecycleDriver {
       }
     };
     await tryGet(toWorker.GET_ALL_SEASONS, {}, 'allSeasons', (p) => p);
+    await tryGet(toWorker.GET_TRANSACTIONS, { limit: 5000, mode: 'recent' }, 'transactions', (p) => p?.transactions ?? p);
     await tryGet(toWorker.GET_DRAFT_CLASSES, {}, 'draftClasses', (p) => p);
     await tryGet(toWorker.GET_RECORDS, {}, 'records', (p) => p);
     return probes;

--- a/tests/durability/lifecycleDriver.js
+++ b/tests/durability/lifecycleDriver.js
@@ -22,7 +22,8 @@
  * real DB layer (src/db/index.js) after SAVE_NOW.
  */
 import { toWorker, toUI } from '../../src/worker/protocol.js';
-import { Players, Teams, DraftPicks, Meta, Seasons } from '../../src/db/index.js';
+import { Players, Teams, DraftPicks, Meta, Seasons, clearAllData, deleteLeagueDB } from '../../src/db/index.js';
+import { Utils } from '../../src/core/utils.js';
 import { dispatchWorker as defaultDispatch, loadWorkerModule as defaultLoad } from '../../src/testSupport/dynastySoakRunner.js';
 
 export const DEFAULT_SEED = 1684;
@@ -76,6 +77,8 @@ export class LifecycleDriver {
     globalThis.__DYNASTY_SOAK_PROFILE__ = true;
     globalThis.__DYNASTY_SOAK_AUDIT_CHECKPOINT_ENABLED__ = false;
 
+    await resetDurabilityStorage(SLOT_KEY);
+    Utils.setSeed(this.seed);
     await this.loadWorker();
     const t = Date.now();
     await this.dispatch(toWorker.INIT, {}, { timeoutMs: Math.min(120_000, this.phaseTimeoutMs) });
@@ -217,4 +220,9 @@ export function crashError(checkpoint, message, msg) {
   e.checkpoint = checkpoint;
   e.workerPayload = msg?.payload ?? null;
   return e;
+}
+
+export async function resetDurabilityStorage(slotKey = SLOT_KEY) {
+  try { await clearAllData(); } catch {}
+  try { await deleteLeagueDB(slotKey); } catch {}
 }

--- a/tests/durability/longSaveHarness.js
+++ b/tests/durability/longSaveHarness.js
@@ -15,6 +15,7 @@
 import { LifecycleDriver, CHECKPOINTS, EXPECTED_TEAM_COUNT } from './lifecycleDriver.js';
 import { runInvariants } from './invariants/index.js';
 import { canonicalSummary, compareCanonical } from './invariants/saveReload.js';
+import { compareDurableSnapshots } from './invariants/durableSnapshot.js';
 import { DurabilityReport } from './report.js';
 
 export const MODES = Object.freeze({
@@ -79,8 +80,11 @@ export async function runDurabilityHarness(config = {}) {
 
   const evaluate = (ctx) => {
     sampleMem();
+    const snap = canonicalSummary({ view: ctx.view, db: ctx.db, season: ctx.season });
+    ctx.durableSnapshot = snap.durableSnapshot;
+    ctx.durableSnapshotDigest = snap.durableSnapshotDigest;
     const results = runInvariants(ctx);
-    const counts = report.addCheckpoint({ season: ctx.season, phase: ctx.phase, week: ctx.week, results });
+    const counts = report.addCheckpoint({ season: ctx.season, phase: ctx.phase, week: ctx.week, results, durable: { digest: ctx.durableSnapshotDigest, summary: summarizeSnapshot(ctx.durableSnapshot), snapshot: ctx.durableSnapshot } });
     onEvent({ type: 'checkpoint', season: ctx.season, phase: ctx.phase, counts });
     if (failureMode === 'fail-fast' && counts.fail > 0) {
       throw new StopHarness(`fail-fast: ${counts.fail} invariant failure(s) at season ${ctx.season} ${ctx.phase}`);
@@ -214,13 +218,18 @@ export async function runDeterminismCheck(config = {}) {
   for (const k of Object.keys(na)) {
     if (JSON.stringify(na[k]) !== JSON.stringify(nb[k])) diffs.push({ field: k, a: na[k], b: nb[k] });
   }
-  const deterministic = diffs.length === 0;
+  const state = compareReportSnapshots(a.report, b.report);
+  const lifecycleDeterministic = diffs.length === 0;
+  const stateDeterministic = state.ok;
   return {
-    deterministic,
-    detail: deterministic
-      ? 'Normalized outcome identical across two clean runs'
-      : `Normalized outcome differs in: ${diffs.map((d) => d.field).join(', ')}`,
-    diffs,
+    deterministic: lifecycleDeterministic && stateDeterministic,
+    lifecycleDeterministic,
+    stateDeterministic,
+    firstDivergence: state.firstDivergence,
+    detail: lifecycleDeterministic && stateDeterministic
+      ? 'Lifecycle outcome and canonical durable state identical across two clean runs'
+      : `Lifecycle deterministic=${lifecycleDeterministic}; state deterministic=${stateDeterministic}`,
+    diffs: [...diffs, ...state.diffs],
     reports: [a, b],
   };
 }
@@ -246,4 +255,24 @@ function unexercisedStages(perSeasonStopPhase) {
     return ['draft', 'freeAgency', 'progression', 'retirement', 'historyRollover', 'nextSeasonGeneration'];
   }
   return ['playoffs', 'draft', 'freeAgency', 'progression', 'retirement', 'historyRollover', 'nextSeasonGeneration'];
+}
+
+function summarizeSnapshot(s) {
+  return { league: s?.league, pools: s?.pools, teamCount: s?.teams?.length ?? 0, playerCount: s?.players?.length ?? 0, retiredCount: s?.retiredPlayers?.length ?? 0, pickCount: s?.draftPicks?.length ?? 0, scheduleCount: s?.schedule?.length ?? 0, historyCount: s?.history?.length ?? 0 };
+}
+function compareReportSnapshots(a, b) {
+  const diffs = [];
+  const bByKey = new Map((b.checkpoints || []).map((c) => [`${c.season}:${c.phase}`, c]));
+  for (const ac of a.checkpoints || []) {
+    const key = `${ac.season}:${ac.phase}`;
+    const bc = bByKey.get(key);
+    if (!bc) { diffs.push({ domain: 'checkpoint', entityId: key, field: 'missing', runA: true, runB: false }); break; }
+    if (ac.durable?.digest !== bc.durable?.digest) {
+      const cmp = compareDurableSnapshots(ac.durable?.snapshot, bc.durable?.snapshot);
+      const first = cmp.firstDivergence || { domain: 'checkpoint', entityId: key, field: 'digest', runA: ac.durable?.digest, runB: bc.durable?.digest };
+      first.checkpoint = key;
+      return { ok: false, firstDivergence: first, diffs: cmp.diffs.map((d) => ({ ...d, checkpoint: key })).slice(0, 20) };
+    }
+  }
+  return { ok: diffs.length === 0, firstDivergence: diffs[0] || null, diffs };
 }

--- a/tests/durability/longSaveHarness.js
+++ b/tests/durability/longSaveHarness.js
@@ -78,13 +78,19 @@ export async function runDurabilityHarness(config = {}) {
   let competitiveSeasonsCompleted = 0;
   let completedThrough = CHECKPOINTS.AFTER_INIT;
 
+  let previousDurableSnapshot = null;
+  let lastCheckpointAt = Date.now();
   const evaluate = (ctx) => {
     sampleMem();
     const snap = canonicalSummary({ view: ctx.view, db: ctx.db, season: ctx.season });
     ctx.durableSnapshot = snap.durableSnapshot;
     ctx.durableSnapshotDigest = snap.durableSnapshotDigest;
+    ctx.previousDurableSnapshot = previousDurableSnapshot;
     const results = runInvariants(ctx);
-    const counts = report.addCheckpoint({ season: ctx.season, phase: ctx.phase, week: ctx.week, results, durable: { digest: ctx.durableSnapshotDigest, summary: summarizeSnapshot(ctx.durableSnapshot), snapshot: ctx.durableSnapshot } });
+    const now = Date.now();
+    const counts = report.addCheckpoint({ season: ctx.season, phase: ctx.phase, week: ctx.week, results, durable: { digest: ctx.durableSnapshotDigest, summary: summarizeSnapshot(ctx.durableSnapshot), snapshot: ctx.durableSnapshot }, metrics: { elapsedSincePreviousMs: now - lastCheckpointAt, rssMb: currentRssMb() } });
+    lastCheckpointAt = now;
+    previousDurableSnapshot = ctx.durableSnapshot;
     onEvent({ type: 'checkpoint', season: ctx.season, phase: ctx.phase, counts });
     if (failureMode === 'fail-fast' && counts.fail > 0) {
       throw new StopHarness(`fail-fast: ${counts.fail} invariant failure(s) at season ${ctx.season} ${ctx.phase}`);
@@ -212,27 +218,20 @@ export async function runDurabilityHarness(config = {}) {
 export async function runDeterminismCheck(config = {}) {
   const a = await runDurabilityHarness({ ...config, _determinismRun: 'A' });
   const b = await runDurabilityHarness({ ...config, _determinismRun: 'B' });
-  const na = normalizeOutcome(a.toJSON());
-  const nb = normalizeOutcome(b.toJSON());
+  return { ...compareReportDeterminism(a.report, b.report), reports: [a, b] };
+}
+
+export function compareReportDeterminism(reportA, reportB) {
+  const na = normalizeOutcome(stripSnapshotsForOutcome(reportA));
+  const nb = normalizeOutcome(stripSnapshotsForOutcome(reportB));
   const diffs = [];
-  for (const k of Object.keys(na)) {
-    if (JSON.stringify(na[k]) !== JSON.stringify(nb[k])) diffs.push({ field: k, a: na[k], b: nb[k] });
-  }
-  const state = compareReportSnapshots(a.report, b.report);
+  for (const k of Object.keys(na)) if (JSON.stringify(na[k]) !== JSON.stringify(nb[k])) diffs.push({ field: k, a: na[k], b: nb[k] });
+  const state = compareReportSnapshots(reportA, reportB);
   const lifecycleDeterministic = diffs.length === 0;
   const stateDeterministic = state.ok;
-  return {
-    deterministic: lifecycleDeterministic && stateDeterministic,
-    lifecycleDeterministic,
-    stateDeterministic,
-    firstDivergence: state.firstDivergence,
-    detail: lifecycleDeterministic && stateDeterministic
-      ? 'Lifecycle outcome and canonical durable state identical across two clean runs'
-      : `Lifecycle deterministic=${lifecycleDeterministic}; state deterministic=${stateDeterministic}`,
-    diffs: [...diffs, ...state.diffs],
-    reports: [a, b],
-  };
+  return { deterministic: lifecycleDeterministic && stateDeterministic, lifecycleDeterministic, stateDeterministic, firstDivergence: state.firstDivergence, detail: lifecycleDeterministic && stateDeterministic ? 'Lifecycle outcome and canonical durable state identical across two clean runs' : `Lifecycle deterministic=${lifecycleDeterministic}; state deterministic=${stateDeterministic}`, diffs: [...diffs, ...state.diffs] };
 }
+function stripSnapshotsForOutcome(r) { return { ...r, checkpoints: (r.checkpoints || []).map((c) => ({ ...c, durable: c.durable ? { digest: c.durable.digest } : null })) }; }
 
 function normalizeOutcome(r) {
   return {
@@ -257,6 +256,7 @@ function unexercisedStages(perSeasonStopPhase) {
   return ['playoffs', 'draft', 'freeAgency', 'progression', 'retirement', 'historyRollover', 'nextSeasonGeneration'];
 }
 
+function currentRssMb() { return typeof process !== 'undefined' && process.memoryUsage ? Math.round(process.memoryUsage().rss / (1024 * 1024)) : null; }
 function summarizeSnapshot(s) {
   return { league: s?.league, pools: s?.pools, teamCount: s?.teams?.length ?? 0, playerCount: s?.players?.length ?? 0, retiredCount: s?.retiredPlayers?.length ?? 0, pickCount: s?.draftPicks?.length ?? 0, scheduleCount: s?.schedule?.length ?? 0, historyCount: s?.history?.length ?? 0 };
 }

--- a/tests/durability/longSaveHarness.test.js
+++ b/tests/durability/longSaveHarness.test.js
@@ -190,7 +190,17 @@ describe('continuity invariant V2', () => {
     const cur = { ...baseSnap(), players: [{ ...prev.players[0], yearsRemaining: 2 }] };
     expect(continuity.check(ctxFor(prev, cur, 'afterRegularSeason')).find((r) => r.id === 'continuity.contract-years-do-not-increase-without-contract-write').status).toBe('fail');
     cur.players[0].baseAnnual = 7;
+    expect(continuity.check(ctxFor(prev, cur, 'afterRegularSeason')).find((r) => r.id === 'continuity.contract-years-do-not-increase-without-contract-write').status).toBe('fail');
+    cur.players[0].yearsTotal = 4;
     expect(continuity.check(ctxFor(prev, cur, 'afterRegularSeason')).find((r) => r.id === 'continuity.contract-years-do-not-increase-without-contract-write').status).toBe('pass');
+  });
+
+  it('passes a contract-year increase with production transaction evidence', () => {
+    const prev = baseSnap();
+    const cur = { ...baseSnap(), players: [{ ...prev.players[0], yearsRemaining: 3, yearsTotal: 3 }] };
+    const ctx = ctxFor(prev, cur, 'afterRegularSeason');
+    ctx.probes = { transactions: [{ type: 'CONTRACT_EXTENSION', playerId: 'p10' }] };
+    expect(continuity.check(ctx).find((r) => r.id === 'continuity.contract-years-do-not-increase-without-contract-write').status).toBe('pass');
   });
 
   it('fails disappearing active players but passes recorded retirement and draft-pool disposition', () => {
@@ -202,6 +212,15 @@ describe('continuity invariant V2', () => {
     const draftPrev = { ...baseSnap(), players: [{ id: 'draft1', status: 'draft_eligible' }] };
     cur = { ...baseSnap(), players: [] };
     expect(continuity.check(ctxFor(draftPrev, cur)).find((r) => r.id === 'continuity.players-do-not-disappear').status).toBe('pass');
+  });
+
+  it('does not blanket-skip offseason resign to preseason disappearances and accepts release evidence', () => {
+    const prev = baseSnap();
+    const cur = { ...baseSnap(), league: { phase: 'preseason' }, players: [], retiredPlayers: [] };
+    expect(continuity.check(ctxFor(prev, cur)).find((r) => r.id === 'continuity.players-do-not-disappear').status).toBe('fail');
+    const ctx = ctxFor(prev, cur);
+    ctx.probes = { transactions: [{ type: 'PLAYER_RELEASED', playerId: 'p10' }] };
+    expect(continuity.check(ctx).find((r) => r.id === 'continuity.players-do-not-disappear').status).toBe('pass');
   });
 });
 
@@ -400,6 +419,28 @@ describe('durable snapshot V2', () => {
     b.view.teams[0].roster.push(healthyPlayer(2, '0'));
     b.db.players.push(healthyPlayer(2, '0'));
     expect(compareDurableSnapshots(buildDurableSnapshot(a), buildDurableSnapshot(b)).ok).toBe(false);
+  });
+
+  it('preserves duplicate occurrences when a later same-id entity matches', async () => {
+    const { compareDurableSnapshots } = await import('./invariants/durableSnapshot.js');
+    const a = { players: [{ id: 'p1', ovr: 70 }, { id: 'p1', ovr: 80 }] };
+    const b = { players: [{ id: 'p1', ovr: 75 }, { id: 'p1', ovr: 80 }] };
+    const cmp = compareDurableSnapshots(a, b);
+    expect(cmp.ok).toBe(false);
+    expect(cmp.firstDivergence).toMatchObject({ domain: 'players', entityId: 'p1', field: 'ovr' });
+  });
+
+  it('normalizes legacy object-shaped champion and runner-up team references', async () => {
+    const { buildDurableSnapshot, compareDurableSnapshots } = await import('./invariants/durableSnapshot.js');
+    const base = { season: 1, view: { teams: [healthyTeam(0, []), healthyTeam(1, [])], leagueHistory: [{ season: 2026, champion: { id: 0 }, runnerUp: { teamId: 1 } }] }, db: { teams: [{ id: 0 }, { id: 1 }], players: [], picks: [] } };
+    const alias = structuredClone(base);
+    alias.view.leagueHistory[0] = { season: 2026, championTeamId: '0', runnerUpTeamId: '1' };
+    expect(compareDurableSnapshots(buildDurableSnapshot(base), buildDurableSnapshot(alias)).ok).toBe(true);
+    const changed = structuredClone(base);
+    changed.view.leagueHistory[0].champion = { id: 1 };
+    const cmp = compareDurableSnapshots(buildDurableSnapshot(base), buildDurableSnapshot(changed));
+    expect(cmp.ok).toBe(false);
+    expect(cmp.firstDivergence).toMatchObject({ domain: 'history', field: 'champion' });
   });
 
   it('save/reload detects contract, dead-cap, injury, ratings, schedule, and history mutations', () => {

--- a/tests/durability/longSaveHarness.test.js
+++ b/tests/durability/longSaveHarness.test.js
@@ -164,7 +164,7 @@ describe('continuity invariant V2', () => {
   const baseSnap = () => ({
     league: { phase: 'offseason_resign' },
     teams: [{ id: '0' }],
-    players: [{ id: 'p10', status: 'active', yearsRemaining: 1, yearsTotal: 2, baseAnnual: 5, signingBonus: 0, activeCapHit: 5 }],
+    players: [{ id: 'p10', teamId: '0', status: 'active', yearsRemaining: 1, yearsTotal: 2, baseAnnual: 5, signingBonus: 0, activeCapHit: 5 }],
     retiredPlayers: [],
     history: [{ season: 2026 }],
     schedule: [{ id: 'g1', season: 2026 }],
@@ -179,20 +179,28 @@ describe('continuity invariant V2', () => {
     expect(continuity.check(ctxFor(prev, cur)).find((r) => r.id === 'continuity.history-grows-once').status).toBe('pass');
   });
 
-  it('fails when a game id is reused across prior and current seasons', () => {
+  it('fails when a production-shaped slim schedule game id is reused across prior and current seasons', () => {
     const prev = baseSnap();
-    const cur = { ...baseSnap(), schedule: [{ id: 'g1', season: 2027 }] };
+    const cur = { ...baseSnap(), schedule: [{ id: 'g1', season: 2027, week: 1, home: '0', away: '1' }] };
     expect(continuity.check(ctxFor(prev, cur, 'afterRegularSeason')).find((r) => r.id === 'continuity.schedule-game-id-season-unique').status).toBe('fail');
   });
 
-  it('fails when contract years increase without a contract-write shape and passes with an extension-shaped change', () => {
+  it('fails when contract years increase without exact player transaction evidence, even when economics also change', () => {
     const prev = baseSnap();
-    const cur = { ...baseSnap(), players: [{ ...prev.players[0], yearsRemaining: 2 }] };
-    expect(continuity.check(ctxFor(prev, cur, 'afterRegularSeason')).find((r) => r.id === 'continuity.contract-years-do-not-increase-without-contract-write').status).toBe('fail');
-    cur.players[0].baseAnnual = 7;
-    expect(continuity.check(ctxFor(prev, cur, 'afterRegularSeason')).find((r) => r.id === 'continuity.contract-years-do-not-increase-without-contract-write').status).toBe('fail');
-    cur.players[0].yearsTotal = 4;
-    expect(continuity.check(ctxFor(prev, cur, 'afterRegularSeason')).find((r) => r.id === 'continuity.contract-years-do-not-increase-without-contract-write').status).toBe('pass');
+    const cur = { ...baseSnap(), players: [{ ...prev.players[0], yearsRemaining: 2, yearsTotal: 4, baseAnnual: 7, signingBonus: 3 }] };
+    const result = continuity.check(ctxFor(prev, cur, 'afterRegularSeason')).find((r) => r.id === 'continuity.contract-years-do-not-increase-without-contract-write');
+    expect(result.status).toBe('fail');
+  });
+
+  it('rejects substring or wrong-player transaction matches for contract-year increases', () => {
+    const prev = baseSnap();
+    const cur = { ...baseSnap(), players: [{ ...prev.players[0], yearsRemaining: 2, yearsTotal: 4 }] };
+    const ctx = ctxFor(prev, cur, 'afterRegularSeason');
+    ctx.probes = { transactions: [
+      { type: 'NOTE', details: { playerId: 'p10', text: 'contract extension wording only' } },
+      { type: 'CONTRACT_EXTENSION', playerId: 'xx-p10-xx' },
+    ] };
+    expect(continuity.check(ctx).find((r) => r.id === 'continuity.contract-years-do-not-increase-without-contract-write').status).toBe('fail');
   });
 
   it('passes a contract-year increase with production transaction evidence', () => {
@@ -441,6 +449,17 @@ describe('durable snapshot V2', () => {
     const cmp = compareDurableSnapshots(buildDurableSnapshot(base), buildDurableSnapshot(changed));
     expect(cmp.ok).toBe(false);
     expect(cmp.firstDivergence).toMatchObject({ domain: 'history', field: 'champion' });
+  });
+
+
+  it('uses schedule seasonId before legacy season/year in durable state', async () => {
+    const { buildDurableSnapshot, compareDurableSnapshots } = await import('./invariants/durableSnapshot.js');
+    const a = { season: 1, view: { teams: [healthyTeam(0, []), healthyTeam(1, [])], leagueHistory: [], schedule: { games: [{ id: 'g-season', seasonId: 'season-a', season: 2027, year: 2027, week: 1, homeTeamId: 0, awayTeamId: 1 }] } }, db: { teams: [{ id: 0 }, { id: 1 }], players: [], picks: [] } };
+    const b = structuredClone(a);
+    b.view.schedule.games[0].seasonId = 'season-b';
+    const cmp = compareDurableSnapshots(buildDurableSnapshot(a), buildDurableSnapshot(b));
+    expect(cmp.ok).toBe(false);
+    expect(cmp.firstDivergence).toMatchObject({ domain: 'schedule', entityId: 'g-season', field: 'season' });
   });
 
   it('save/reload detects contract, dead-cap, injury, ratings, schedule, and history mutations', () => {

--- a/tests/durability/longSaveHarness.test.js
+++ b/tests/durability/longSaveHarness.test.js
@@ -26,6 +26,7 @@ import * as references from './invariants/references.js';
 import * as numericSafety from './invariants/numericSafety.js';
 import * as retirement from './invariants/retirement.js';
 import * as history from './invariants/history.js';
+import * as continuity from './invariants/continuity.js';
 import { canonicalSummary, compareCanonical } from './invariants/saveReload.js';
 import { runInvariants } from './invariants/index.js';
 import { scanNumericCorruption, findDuplicateIds } from './invariants/helpers.js';
@@ -154,6 +155,53 @@ describe('invariant checkers — happy path', () => {
     const ctx2 = healthyViewCtx({ phase: 'afterSeasonRollover', season: 3 });
     ctx2.view.leagueHistory = []; // no history despite season 3 → fail
     expect(history.check(ctx2).find((r) => r.id === 'history.season-archive-exists').status).toBe('fail');
+  });
+});
+
+
+
+describe('continuity invariant V2', () => {
+  const baseSnap = () => ({
+    league: { phase: 'offseason_resign' },
+    teams: [{ id: '0' }],
+    players: [{ id: 'p10', status: 'active', yearsRemaining: 1, yearsTotal: 2, baseAnnual: 5, signingBonus: 0, activeCapHit: 5 }],
+    retiredPlayers: [],
+    history: [{ season: 2026 }],
+    schedule: [{ id: 'g1', season: 2026 }],
+  });
+  const ctxFor = (prev, cur, phase = 'afterSeasonRollover') => ({ ...healthyViewCtx({ phase }), durableSnapshot: cur, previousDurableSnapshot: prev });
+
+  it('fails when completed rollover does not add exactly one history row', () => {
+    const prev = baseSnap();
+    const cur = { ...baseSnap(), league: { phase: 'preseason' }, history: prev.history };
+    expect(continuity.check(ctxFor(prev, cur)).find((r) => r.id === 'continuity.history-grows-once').status).toBe('fail');
+    cur.history = [...prev.history, { season: 2027 }];
+    expect(continuity.check(ctxFor(prev, cur)).find((r) => r.id === 'continuity.history-grows-once').status).toBe('pass');
+  });
+
+  it('fails when a game id is reused across prior and current seasons', () => {
+    const prev = baseSnap();
+    const cur = { ...baseSnap(), schedule: [{ id: 'g1', season: 2027 }] };
+    expect(continuity.check(ctxFor(prev, cur, 'afterRegularSeason')).find((r) => r.id === 'continuity.schedule-game-id-season-unique').status).toBe('fail');
+  });
+
+  it('fails when contract years increase without a contract-write shape and passes with an extension-shaped change', () => {
+    const prev = baseSnap();
+    const cur = { ...baseSnap(), players: [{ ...prev.players[0], yearsRemaining: 2 }] };
+    expect(continuity.check(ctxFor(prev, cur, 'afterRegularSeason')).find((r) => r.id === 'continuity.contract-years-do-not-increase-without-contract-write').status).toBe('fail');
+    cur.players[0].baseAnnual = 7;
+    expect(continuity.check(ctxFor(prev, cur, 'afterRegularSeason')).find((r) => r.id === 'continuity.contract-years-do-not-increase-without-contract-write').status).toBe('pass');
+  });
+
+  it('fails disappearing active players but passes recorded retirement and draft-pool disposition', () => {
+    const prev = baseSnap();
+    let cur = { ...baseSnap(), players: [], retiredPlayers: [] };
+    expect(continuity.check(ctxFor(prev, cur)).find((r) => r.id === 'continuity.players-do-not-disappear').status).toBe('fail');
+    cur = { ...baseSnap(), players: [], retiredPlayers: [{ id: 'p10' }] };
+    expect(continuity.check(ctxFor(prev, cur)).find((r) => r.id === 'continuity.players-do-not-disappear').status).toBe('pass');
+    const draftPrev = { ...baseSnap(), players: [{ id: 'draft1', status: 'draft_eligible' }] };
+    cur = { ...baseSnap(), players: [] };
+    expect(continuity.check(ctxFor(draftPrev, cur)).find((r) => r.id === 'continuity.players-do-not-disappear').status).toBe('pass');
   });
 });
 

--- a/tests/durability/longSaveHarness.test.js
+++ b/tests/durability/longSaveHarness.test.js
@@ -365,11 +365,11 @@ describe('durable snapshot V2', () => {
 
   it('stable cap uses live cap, dead cap, team id 0, excludes staff, exact/fractional boundaries, and skips offseason', () => {
     const ctx = healthyViewCtx();
-    ctx.view.meta = { economy: { currentSalaryCap: 200 } };
-    ctx.view.teams = [healthyTeam(0, [{ ...healthyPlayer(1, 0), capHit: 150 }])];
+    ctx.view.economy = { currentSalaryCap: 200 };
+    ctx.view.teams = [healthyTeam(0, [{ ...healthyPlayer(1, 0), contract: { baseAnnual: 150, signingBonus: 0, yearsTotal: 1, yearsRemaining: 1 } }])];
     ctx.view.teams[0].deadCap = 50; ctx.view.teams[0].staffPayroll = 999;
     expect(cap.check(ctx).find((r) => r.id === 'cap.stable-phase-legal').status).toBe('pass');
-    ctx.view.teams[0].deadCap = 50.001;
+    ctx.view.teams[0].deadCap = 50.01;
     expect(cap.check(ctx).find((r) => r.id === 'cap.stable-phase-legal').status).toBe('fail');
     ctx.view.phase = 'offseason';
     expect(cap.check(ctx).find((r) => r.id === 'cap.stable-phase-legal').status).toBe('skip');
@@ -379,4 +379,44 @@ describe('durable snapshot V2', () => {
     const { raw, errors } = parseArgv(['node', 's', '5-season', '--seeds=1684,1702,1703']);
     expect(errors).toEqual([]); expect(raw.seeds).toEqual([1684, 1702, 1703]);
   });
+
+  it('CLI accepts one seed in --seeds, rejects invalid lists, and rejects determinism combination', () => {
+    expect(parseArgv(['node', 's', '5-season', '--seeds=1702']).raw.seeds).toEqual([1702]);
+    expect(parseArgv(['node', 's', '--seeds=1684,nope']).errors).toContain('Invalid --seeds');
+    expect(parseArgv(['node', 's', '--seeds=1684,', '--determinism']).errors.some((e) => e.includes('--seeds cannot be combined'))).toBe(true);
+  });
+  it('production-shaped cap uses DB dead cap and canonical contract fields', () => {
+    const ctx = healthyViewCtx();
+    ctx.view.economy = { currentSalaryCap: 100 };
+    ctx.view.teams = [healthyTeam(0, [])];
+    ctx.db = {
+      meta: { economy: { currentSalaryCap: 100 } },
+      teams: [{ id: 0, deadCap: 21, staffPayroll: 500 }],
+      players: [
+        { id: 'p100', teamId: 0, status: 'active', contract: { baseAnnual: 70, signingBonus: 30, yearsTotal: 3, yearsRemaining: 2 } },
+      ],
+      picks: [],
+    };
+    const res = cap.check(ctx);
+    const legal = res.find((r) => r.id === 'cap.stable-phase-legal');
+    expect(legal.status).toBe('fail');
+    expect(legal.details).toMatchObject({ teamId: '0', rosterCap: 80, deadCap: 21, totalCommitted: 101, salaryCap: 100, overageVsLegal: 1 });
+  });
+
+  it('structured durable diffs report canonical entity id rather than array index', async () => {
+    const { buildDurableSnapshot, compareDurableSnapshots } = await import('./invariants/durableSnapshot.js');
+    const a = { season: 1, view: { teams: [healthyTeam(0, [])], leagueHistory: [] }, db: { teams: [{ id: 0 }], players: [{ ...healthyPlayer(9001, 0), ovr: 70 }], picks: [] } };
+    const b = structuredClone(a);
+    b.db.players[0].ovr = 71;
+    const cmp = compareDurableSnapshots(buildDurableSnapshot(a), buildDurableSnapshot(b));
+    expect(cmp.firstDivergence).toMatchObject({ domain: 'players', entityId: '9001', field: 'ovr' });
+  });
+
+  it('report passed is false when state determinism fails with zero invariant failures', () => {
+    const rep = new DurabilityReport({ seed: 1, mode: '1-season', failureMode: 'collect-all', requestedSeasons: 1 });
+    rep.addCheckpoint({ season: 0, phase: 'afterInit', week: 0, results: [{ id: 'x.ok', status: 'pass', message: 'ok' }] });
+    rep.setDeterminism(false, 'state differs', { lifecycleDeterministic: true, stateDeterministic: false, firstDivergence: { domain: 'players', entityId: '9', field: 'ovr' } });
+    expect(rep.passed).toBe(false);
+  });
+
 });

--- a/tests/durability/longSaveHarness.test.js
+++ b/tests/durability/longSaveHarness.test.js
@@ -38,7 +38,7 @@ function healthyTeam(id, roster = []) {
   return { id, name: `T${id}`, abbr: `T${id}`, wins: 8, losses: 8, ties: 0, ptsFor: 300, ptsAgainst: 300, capUsed: 200, capRoom: 100, capTotal: 301.2, roster, picks: [] };
 }
 function healthyPlayer(id, teamId) {
-  return { id, name: `P${id}`, pos: 'QB', age: 25, ovr: 75, teamId, status: 'active', contract: { years: 3, salary: 10 }, ratings: { throwPower: 80 } };
+  return { id, name: `P${id}`, pos: 'QB', age: 25, ovr: 75, teamId, status: 'active', capHit: 3, contract: { years: 3, salary: 3 }, ratings: { throwPower: 80 } };
 }
 function healthyViewCtx(overrides = {}) {
   const teams = [];
@@ -324,5 +324,59 @@ describe('LifecycleDriver.simToPhase target enforcement', () => {
     const driver = new LifecycleDriver({ loadWorker: async () => {}, dispatch: async () => ({ type: 'OK', payload: { phase: 'regular', year: 2026, dynastySoakSimBatch: { reachedTarget: false } } }) });
     await expect(driver.simToPhase('playoffs', { checkpoint: 'afterRegularSeason', maxCalls: 2 }))
       .rejects.toMatchObject({ isLifecycleCrash: true, checkpoint: 'afterRegularSeason' });
+  });
+});
+
+describe('durable snapshot V2', () => {
+  it('detects identical lifecycle metadata with different roster state as non-deterministic', async () => {
+    const { runDeterminismCheck } = await import('./longSaveHarness.js');
+    let run = 0;
+    const dispatch = async (type) => {
+      if (type === 'INIT') return { type: 'OK', payload: { ok: true } };
+      const v = healthyViewCtx().view;
+      v.teams[0].roster[0] = healthyPlayer(run < 2 ? 1 : 2, 0);
+      if (type === 'USE_SAFE_STARTER_LEAGUE') { run += 1; return { type: 'OK', payload: v }; }
+      return { type: 'OK', payload: { ...v, phase: 'playoffs' } };
+    };
+    const det = await runDeterminismCheck({ mode: '1-season', perSeasonStopPhase: 'playoffs', failureMode: 'collect-all', driverOverrides: { loadWorker: async () => {}, dispatch, readDbPool: async () => { const v = healthyViewCtx().view; v.teams[0].roster[0] = healthyPlayer(run < 2 ? 1 : 2, 0); return { players: v.teams.flatMap((t) => t.roster), teams: v.teams, meta: null, seasons: [], picks: [] }; } } });
+    expect(det.lifecycleDeterministic).toBe(true);
+    expect(det.stateDeterministic).toBe(false);
+    expect(det.firstDivergence).toMatchObject({ domain: expect.any(String), field: expect.any(String) });
+  });
+
+  it('canonicalizes collection ordering and mixed id aliases but preserves duplicates', async () => {
+    const { buildDurableSnapshot, compareDurableSnapshots } = await import('./invariants/durableSnapshot.js');
+    const a = { season: 1, view: { teams: [healthyTeam(0, [healthyPlayer(2, 0), healthyPlayer('1', 0)])], leagueHistory: [] }, db: { players: [healthyPlayer('1', 0), healthyPlayer(2, 0)], picks: [] } };
+    const b = { season: 1, view: { teams: [healthyTeam('0', [healthyPlayer(1, '0'), healthyPlayer('2', '0')])], leagueHistory: [] }, db: { players: [healthyPlayer(2, '0'), healthyPlayer(1, '0')], picks: [] } };
+    expect(compareDurableSnapshots(buildDurableSnapshot(a), buildDurableSnapshot(b)).ok).toBe(true);
+    b.view.teams[0].roster.push(healthyPlayer(2, '0'));
+    b.db.players.push(healthyPlayer(2, '0'));
+    expect(compareDurableSnapshots(buildDurableSnapshot(a), buildDurableSnapshot(b)).ok).toBe(false);
+  });
+
+  it('save/reload detects contract, dead-cap, injury, ratings, schedule, and history mutations', () => {
+    const base = { season: 1, view: { year: 2027, phase: 'preseason', teams: [healthyTeam(0, [{ ...healthyPlayer(1, 0), capHit: 10, injury: { status: 'out' } }])], schedule: { games: [{ id: 'g1', week: 1, home: 0, away: 1, played: true, homeScore: 3, awayScore: 0 }] }, leagueHistory: [{ season: 2026, championTeamId: 0 }] }, db: { players: [{ ...healthyPlayer(1, 0), capHit: 10, injury: { status: 'out' } }], picks: [] } };
+    for (const mutate of [
+      (s) => { s.db.players[0].contract.years = 9; }, (s) => { s.view.teams[0].deadCap = 99; },
+      (s) => { s.db.players[0].injury.status = 'healthy'; }, (s) => { s.db.players[0].ovr = 12; },
+      (s) => { s.view.schedule.games[0].homeScore = 99; }, (s) => { s.view.leagueHistory[0].championTeamId = 1; },
+    ]) { const changed = structuredClone(base); mutate(changed); expect(compareCanonical(canonicalSummary(base), canonicalSummary(changed)).ok).toBe(false); }
+  });
+
+  it('stable cap uses live cap, dead cap, team id 0, excludes staff, exact/fractional boundaries, and skips offseason', () => {
+    const ctx = healthyViewCtx();
+    ctx.view.meta = { economy: { currentSalaryCap: 200 } };
+    ctx.view.teams = [healthyTeam(0, [{ ...healthyPlayer(1, 0), capHit: 150 }])];
+    ctx.view.teams[0].deadCap = 50; ctx.view.teams[0].staffPayroll = 999;
+    expect(cap.check(ctx).find((r) => r.id === 'cap.stable-phase-legal').status).toBe('pass');
+    ctx.view.teams[0].deadCap = 50.001;
+    expect(cap.check(ctx).find((r) => r.id === 'cap.stable-phase-legal').status).toBe('fail');
+    ctx.view.phase = 'offseason';
+    expect(cap.check(ctx).find((r) => r.id === 'cap.stable-phase-legal').status).toBe('skip');
+  });
+
+  it('CLI parses multi-seed runs', () => {
+    const { raw, errors } = parseArgv(['node', 's', '5-season', '--seeds=1684,1702,1703']);
+    expect(errors).toEqual([]); expect(raw.seeds).toEqual([1684, 1702, 1703]);
   });
 });

--- a/tests/durability/report.js
+++ b/tests/durability/report.js
@@ -6,7 +6,7 @@
  * `toSummaryJSON()` returns a compact form safe to commit for long runs (drops
  * per-result pass/skip noise, keeps failures + per-checkpoint counts).
  */
-export const HARNESS_VERSION = '1.0.0';
+export const HARNESS_VERSION = '2.0.0';
 
 export class DurabilityReport {
   constructor({ seed, mode, failureMode, requestedSeasons, gitSha = null, perSeasonStopPhase = 'rollover' }) {
@@ -27,6 +27,9 @@ export class DurabilityReport {
       runtimeMs: 0,
       peakMemoryMb: 0,
       deterministic: null,
+      lifecycleDeterministic: null,
+      stateDeterministic: null,
+      firstDivergence: null,
       determinismDetail: null,
       firstFailure: null,
       lifecycleException: null,
@@ -40,7 +43,7 @@ export class DurabilityReport {
   }
 
   /** Record a completed checkpoint with its structured invariant results. */
-  addCheckpoint({ season, phase, week, results }) {
+  addCheckpoint({ season, phase, week, results, durable = null, metrics = null }) {
     const counts = { pass: 0, fail: 0, skip: 0 };
     for (const r of results) counts[r.status] = (counts[r.status] || 0) + 1;
     this.report.summary.passed += counts.pass;
@@ -58,7 +61,7 @@ export class DurabilityReport {
         message: firstFail.message,
       };
     }
-    this.report.checkpoints.push({ season, phase, week, summary: counts, results });
+    this.report.checkpoints.push({ season, phase, week, summary: counts, results, durable, metrics });
     return counts;
   }
 
@@ -80,8 +83,11 @@ export class DurabilityReport {
     }
   }
 
-  setDeterminism(deterministic, detail) {
+  setDeterminism(deterministic, detail, extra = {}) {
     this.report.deterministic = deterministic;
+    this.report.lifecycleDeterministic = extra.lifecycleDeterministic ?? deterministic;
+    this.report.stateDeterministic = extra.stateDeterministic ?? deterministic;
+    this.report.firstDivergence = extra.firstDivergence ?? null;
     this.report.determinismDetail = detail;
   }
 
@@ -117,7 +123,7 @@ export class DurabilityReport {
     return this.report.summary.failed === 0 && !this.report.lifecycleException;
   }
 
-  toJSON() { return this.report; }
+  toJSON() { return stripRuntimeSnapshots(this.report); }
 
   /** Compact, commit-safe report: strips pass/skip result bodies. */
   toSummaryJSON() {
@@ -128,6 +134,8 @@ export class DurabilityReport {
         phase: c.phase,
         week: c.week,
         summary: c.summary,
+        durable: c.durable ? { digest: c.durable.digest, summary: c.durable.summary } : null,
+        metrics: c.metrics ?? null,
         failures: c.results.filter((r) => r.status === 'fail'),
         skipped: c.results.filter((r) => r.status === 'skip').map((r) => ({ id: r.id, reason: r.message })),
       })),
@@ -173,7 +181,8 @@ export function formatConsole(report) {
   if (r.boundedRun) lines.push(`boundedRun=true completedThrough=${r.completedThrough ?? 'unknown'} unexercised=${(r.unexercisedLifecycleStages || []).join(',')}`);
   lines.push(`runtime=${(r.runtimeMs / 1000).toFixed(1)}s peakMem=${r.peakMemoryMb}MB`);
   lines.push(`invariants: pass=${r.summary.passed} fail=${r.summary.failed} skip=${r.summary.skipped}`);
-  if (r.deterministic != null) lines.push(`deterministic=${r.deterministic} (${r.determinismDetail ?? ''})`);
+  if (r.deterministic != null) lines.push(`deterministic=${r.deterministic} lifecycle=${r.lifecycleDeterministic} state=${r.stateDeterministic} (${r.determinismDetail ?? ''})`);
+  if (r.firstDivergence) lines.push(`FIRST DIVERGENCE: ${r.firstDivergence.checkpoint ?? ''} ${r.firstDivergence.domain}:${r.firstDivergence.entityId}.${r.firstDivergence.field}`);
   if (r.lifecycleException) lines.push(`LIFECYCLE CRASH: ${r.lifecycleException.message} @ ${r.lifecycleException.checkpoint} season ${r.lifecycleException.season}`);
   if (r.firstFailure) {
     lines.push(`FIRST FAILURE: ${r.firstFailure.invariantId} @ season ${r.firstFailure.season} phase ${r.firstFailure.phase}`);
@@ -187,4 +196,14 @@ export function formatConsole(report) {
   if (r.recommendedNextRepairPR) lines.push(`NEXT REPAIR PR: ${r.recommendedNextRepairPR}`);
   lines.push(`─────────────────────────────────────────────────────────────`);
   return lines.join('\n');
+}
+
+function stripRuntimeSnapshots(report) {
+  return {
+    ...report,
+    checkpoints: (report.checkpoints || []).map((c) => ({
+      ...c,
+      durable: c.durable ? { digest: c.durable.digest, summary: c.durable.summary } : null,
+    })),
+  };
 }

--- a/tests/durability/report.js
+++ b/tests/durability/report.js
@@ -120,8 +120,11 @@ export class DurabilityReport {
   }
 
   get passed() {
-    return this.report.summary.failed === 0 && !this.report.lifecycleException;
+    const detOk = this.report.deterministic == null || (this.report.lifecycleDeterministic !== false && this.report.stateDeterministic !== false);
+    return this.report.summary.failed === 0 && !this.report.lifecycleException && detOk;
   }
+
+  toRuntimeJSON() { return this.report; }
 
   toJSON() { return stripRuntimeSnapshots(this.report); }
 

--- a/tests/unit/aiCapManagementExecution.test.js
+++ b/tests/unit/aiCapManagementExecution.test.js
@@ -152,6 +152,32 @@ describe('executeAICapManagement — legality & structure', () => {
   });
 });
 
+describe('ensureMinimumRosters — stable rollover legality', () => {
+  it('fills under-minimum AI rosters from existing free agents without touching interactive user teams', async () => {
+    h.state.store = {
+      meta: { userTeamId: 0, difficulty: 'Normal', economy: { currentSalaryCap: LIVE_CAP }, currentSeasonId: 's5', currentWeek: 1, year: 2030 },
+      teams: new Map([
+        [0, { id: 0, abbr: 'USR', capTotal: LIVE_CAP, deadCap: 0, capRoom: 80 }],
+        [31, { id: 31, abbr: 'AI31', capTotal: LIVE_CAP, deadCap: 0, capRoom: 80 }],
+      ]),
+      players: new Map(),
+    };
+    for (let i = 0; i < 52; i++) {
+      h.state.store.players.set(`ai-${i}`, { id: `ai-${i}`, teamId: 31, pos: 'WR', ovr: 60, age: 24, status: 'active', contract: contract(1, 0, 1, 1) });
+      h.state.store.players.set(`usr-${i}`, { id: `usr-${i}`, teamId: 0, pos: 'WR', ovr: 60, age: 24, status: 'active', contract: contract(1, 0, 1, 1) });
+    }
+    h.state.store.players.set('fa-b', { id: 'fa-b', teamId: null, pos: 'CB', ovr: 65, age: 25, status: 'free_agent', contract: contract(1, 0, 1, 1) });
+    h.state.store.players.set('fa-a', { id: 'fa-a', teamId: null, pos: 'CB', ovr: 66, age: 25, status: 'free_agent', contract: contract(1, 0, 1, 1) });
+
+    await AiLogic.ensureMinimumRosters({ includeUserTeam: false });
+
+    expect(h.mockCache.getPlayersByTeam(31)).toHaveLength(53);
+    expect(h.mockCache.getPlayersByTeam(0)).toHaveLength(52);
+    expect(h.state.store.players.get('fa-a').teamId).toBe(31);
+    expect(h.state.txLog.some((tx) => tx.details?.source === 'minimum_roster_reconciliation')).toBe(true);
+  });
+});
+
 describe('executeAICapManagement — determinism', () => {
   it('produces identical transactions across two identical runs', async () => {
     await AiLogic.executeAICapManagement({ autoManageUserCap: true });

--- a/tests/unit/aiCapManagementExecution.test.js
+++ b/tests/unit/aiCapManagementExecution.test.js
@@ -153,21 +153,25 @@ describe('executeAICapManagement — legality & structure', () => {
 });
 
 describe('ensureMinimumRosters — stable rollover legality', () => {
-  it('fills under-minimum AI rosters from existing free agents without touching interactive user teams', async () => {
+  function buildUnderMinimumStore({ liveCap = LIVE_CAP, staleTeamCap = LIVE_CAP, userRoster = 52, aiRoster = 52, freeAgents = [] } = {}) {
     h.state.store = {
-      meta: { userTeamId: 0, difficulty: 'Normal', economy: { currentSalaryCap: LIVE_CAP }, currentSeasonId: 's5', currentWeek: 1, year: 2030 },
+      meta: { userTeamId: 0, difficulty: 'Normal', economy: { currentSalaryCap: liveCap }, currentSeasonId: 's5', currentWeek: 1, year: 2030 },
       teams: new Map([
-        [0, { id: 0, abbr: 'USR', capTotal: LIVE_CAP, deadCap: 0, capRoom: 80 }],
-        [31, { id: 31, abbr: 'AI31', capTotal: LIVE_CAP, deadCap: 0, capRoom: 80 }],
+        [0, { id: 0, abbr: 'USR', capTotal: staleTeamCap, deadCap: 0, capRoom: liveCap }],
+        [31, { id: 31, abbr: 'AI31', capTotal: staleTeamCap, deadCap: 0, capRoom: liveCap }],
       ]),
       players: new Map(),
     };
-    for (let i = 0; i < 52; i++) {
-      h.state.store.players.set(`ai-${i}`, { id: `ai-${i}`, teamId: 31, pos: 'WR', ovr: 60, age: 24, status: 'active', contract: contract(1, 0, 1, 1) });
-      h.state.store.players.set(`usr-${i}`, { id: `usr-${i}`, teamId: 0, pos: 'WR', ovr: 60, age: 24, status: 'active', contract: contract(1, 0, 1, 1) });
-    }
-    h.state.store.players.set('fa-b', { id: 'fa-b', teamId: null, pos: 'CB', ovr: 65, age: 25, status: 'free_agent', contract: contract(1, 0, 1, 1) });
-    h.state.store.players.set('fa-a', { id: 'fa-a', teamId: null, pos: 'CB', ovr: 66, age: 25, status: 'free_agent', contract: contract(1, 0, 1, 1) });
+    for (let i = 0; i < aiRoster; i++) h.state.store.players.set(`ai-${i}`, { id: `ai-${i}`, teamId: 31, pos: 'WR', ovr: 60, age: 24, status: 'active', contract: contract(1, 0, 1, 1) });
+    for (let i = 0; i < userRoster; i++) h.state.store.players.set(`usr-${i}`, { id: `usr-${i}`, teamId: 0, pos: 'WR', ovr: 60, age: 24, status: 'active', contract: contract(1, 0, 1, 1) });
+    for (const fa of freeAgents) h.state.store.players.set(fa.id, fa);
+  }
+
+  it('fills under-minimum AI rosters from signable free agents without touching interactive user teams', async () => {
+    buildUnderMinimumStore({ freeAgents: [
+      { id: 'fa-b', teamId: null, pos: 'CB', ovr: 65, age: 25, status: 'free_agent', contract: contract(1, 0, 1, 1) },
+      { id: 'fa-a', teamId: null, pos: 'CB', ovr: 66, age: 25, status: 'free_agent', contract: contract(1, 0, 1, 1) },
+    ] });
 
     await AiLogic.ensureMinimumRosters({ includeUserTeam: false });
 
@@ -175,6 +179,60 @@ describe('ensureMinimumRosters — stable rollover legality', () => {
     expect(h.mockCache.getPlayersByTeam(0)).toHaveLength(52);
     expect(h.state.store.players.get('fa-a').teamId).toBe(31);
     expect(h.state.txLog.some((tx) => tx.details?.source === 'minimum_roster_reconciliation')).toBe(true);
+  });
+
+  it('never selects retired, draft-eligible, deleted, or non-signable null-team players', async () => {
+    buildUnderMinimumStore({ freeAgents: [
+      { id: 'retired-fa', teamId: null, pos: 'CB', ovr: 99, age: 35, status: 'retired', contract: contract(1, 0, 1, 1) },
+      { id: 'draft-fa', teamId: null, pos: 'CB', ovr: 98, age: 21, status: 'draft_eligible', contract: contract(1, 0, 1, 1) },
+      { id: 'deleted-fa', teamId: null, pos: 'CB', ovr: 97, age: 25, status: 'free_agent', deleted: true, contract: contract(1, 0, 1, 1) },
+      { id: 'active-null', teamId: null, pos: 'CB', ovr: 96, age: 25, status: 'active', contract: contract(1, 0, 1, 1) },
+      { id: 'signable', teamId: null, pos: 'CB', ovr: 60, age: 25, status: 'free_agent', contract: contract(1, 0, 1, 1) },
+    ] });
+    await AiLogic.ensureMinimumRosters({ includeUserTeam: false });
+    expect(h.state.store.players.get('signable').teamId).toBe(31);
+    expect(h.state.store.players.get('retired-fa').teamId).toBeNull();
+    expect(h.state.store.players.get('draft-fa').teamId).toBeNull();
+    expect(h.state.store.players.get('deleted-fa').teamId).toBeNull();
+    expect(h.state.store.players.get('active-null').teamId).toBeNull();
+  });
+
+  it('gives an expired free agent a valid production-shaped contract', async () => {
+    buildUnderMinimumStore({ freeAgents: [{ id: 'expired-fa', teamId: null, pos: 'CB', ovr: 68, age: 25, status: 'free_agent', contract: contract(0, 0, 0, 0) }] });
+    await AiLogic.ensureMinimumRosters({ includeUserTeam: false });
+    const signed = h.state.store.players.get('expired-fa');
+    expect(signed.teamId).toBe(31);
+    expect(signed.contract).toMatchObject({ yearsRemaining: expect.any(Number), yearsTotal: expect.any(Number), baseAnnual: expect.any(Number), signingBonus: expect.any(Number) });
+    expect(signed.contract.yearsRemaining).toBeGreaterThan(0);
+    expect(signed.contract.baseAnnual).toBeGreaterThan(0);
+  });
+
+  it('uses live economy cap instead of stale team cap for reconciliation legality', async () => {
+    buildUnderMinimumStore({ liveCap: 100, staleTeamCap: 52, freeAgents: [{ id: 'live-cap-fa', teamId: null, pos: 'CB', ovr: 68, age: 25, status: 'free_agent', contract: contract(1, 0, 1, 1) }] });
+    await AiLogic.ensureMinimumRosters({ includeUserTeam: false });
+    expect(h.state.store.players.get('live-cap-fa').teamId).toBe(31);
+    expect(h.state.store.teams.get(31).capTotal).toBe(100);
+  });
+
+  it('rolls back and does not record SIGN when signing would exceed the live cap', async () => {
+    buildUnderMinimumStore({ liveCap: 52.5, staleTeamCap: 52.5, freeAgents: [{ id: 'pricey-fa', teamId: null, pos: 'CB', ovr: 90, age: 25, status: 'free_agent', contract: contract(5, 0, 1, 1) }] });
+    await AiLogic.ensureMinimumRosters({ includeUserTeam: false });
+    expect(h.state.store.players.get('pricey-fa').teamId).toBeNull();
+    expect(h.state.txLog.some((tx) => tx.type === 'SIGN')).toBe(false);
+  });
+
+  it('deterministically selects the same candidate independent of cache insertion order', async () => {
+    const candidates = [
+      { id: 'fa-z', teamId: null, pos: 'CB', ovr: 70, age: 25, status: 'free_agent', contract: contract(1, 0, 1, 1) },
+      { id: 'fa-a', teamId: null, pos: 'CB', ovr: 70, age: 25, status: 'free_agent', contract: contract(1, 0, 1, 1) },
+    ];
+    buildUnderMinimumStore({ freeAgents: structuredClone(candidates) });
+    await AiLogic.ensureMinimumRosters({ includeUserTeam: false });
+    const first = h.state.txLog.find((tx) => tx.type === 'SIGN')?.playerId;
+    h.state.txLog.length = 0;
+    buildUnderMinimumStore({ freeAgents: structuredClone([...candidates].reverse()) });
+    await AiLogic.ensureMinimumRosters({ includeUserTeam: false });
+    expect(h.state.txLog.find((tx) => tx.type === 'SIGN')?.playerId).toBe(first);
   });
 });
 

--- a/tests/unit/aiFaEngine.unit.test.js
+++ b/tests/unit/aiFaEngine.unit.test.js
@@ -331,6 +331,32 @@ describe('getAIFaTargets', () => {
       expect(r1.get(10).map((p) => p.id)).toEqual(r2.get(10).map((p) => p.id));
     }
   });
+
+  it('orders teams and same-tier candidates by canonical id to stabilize offer writes', () => {
+    const meta = { userTeamId: 0 };
+    const teamsA = [makeTeam({ id: 17, wins: 8, losses: 8 }), makeTeam({ id: 2, wins: 8, losses: 8 })];
+    const teamsB = [...teamsA].reverse();
+    const playersA = [makePlayer({ id: 'z', ovr: 71 }), makePlayer({ id: 'a', ovr: 71 }), makePlayer({ id: 9, ovr: 71 })];
+    const playersB = [...playersA].reverse();
+    const r1 = getAIFaTargets(teamsA, playersA, meta, 2028, 1);
+    const r2 = getAIFaTargets(teamsB, playersB, meta, 2028, 1);
+    expect([...r1.keys()]).toEqual([2, 17]);
+    expect([...r2.keys()]).toEqual([2, 17]);
+    expect(r1.get(2).map((p) => p.id)).toEqual([9, 'a', 'z']);
+    expect(r2.get(2).map((p) => p.id)).toEqual([9, 'a', 'z']);
+  });
+
+  it('resolves equal-score offers independently of incoming offer order', () => {
+    const player = makePlayer({ id: 9047 });
+    const offers = [
+      { teamId: 30, amount: 8, years: 1 },
+      { teamId: 9, amount: 8, years: 1 },
+      { teamId: 17, amount: 8, years: 1 },
+    ];
+    const a = resolvePlayerChoice(player, offers, { adjustedDemand: 8, season: 2028, week: 1 });
+    const b = resolvePlayerChoice(player, [...offers].reverse(), { adjustedDemand: 8, season: 2028, week: 1 });
+    expect(b.winningOffer.teamId).toBe(a.winningOffer.teamId);
+  });
 });
 
 // ── AI_POSTURE_BID_FACTORS structure ─────────────────────────────────────────

--- a/tests/unit/aiFreeAgencyOrdering.test.js
+++ b/tests/unit/aiFreeAgencyOrdering.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { buildSortedFreeAgentsMapForOffers } from '../../src/core/ai-logic.js';
+
+function fa(id, pos = 'WR', ovr = 70) {
+  return { id, pos, ovr, teamId: null, status: 'free_agent' };
+}
+
+describe('AI free-agency offer pool ordering', () => {
+  it('orders equal-OVR free agents by canonical id so contract writes are deterministic', () => {
+    const a = buildSortedFreeAgentsMapForOffers([fa('10'), fa('2'), fa('1'), fa('9')]);
+    const b = buildSortedFreeAgentsMapForOffers([fa('9'), fa('1'), fa('2'), fa('10')]);
+    expect(a.WR.map((p) => p.id)).toEqual(['1', '2', '9', '10']);
+    expect(b.WR.map((p) => p.id)).toEqual(a.WR.map((p) => p.id));
+  });
+});

--- a/tests/unit/aiRetentionLogic.test.js
+++ b/tests/unit/aiRetentionLogic.test.js
@@ -223,3 +223,20 @@ describe('AI_RETENTION_CONFIG', () => {
     expect(Object.isFrozen(AI_RETENTION_CONFIG.POSITIONAL_VALUE)).toBe(true);
   });
 });
+
+describe('executeAIOffseasonExtensions — deterministic tie ordering', () => {
+  it('produces identical accepted contract order and terms for tied players regardless of roster order', () => {
+    const makeTied = (id) => makePlayer({ id, pos: 'WR', ovr: 80, potential: 80, age: 26, years: 1, baseAnnual: 2, morale: 70, schemeFit: 65 });
+    const a = makeTied('p-tie-10');
+    const b = makeTied('p-tie-2');
+    const teamA = makeTeam({ capRoom: 40, wins: 8, losses: 9 });
+    const teamB = makeTeam({ capRoom: 40, wins: 8, losses: 9 });
+
+    const first = executeAIOffseasonExtensions(teamA, [a, b], { freeAgents: [] })
+      .map((e) => ({ id: e.player.id, contract: e.contract }));
+    const second = executeAIOffseasonExtensions(teamB, [structuredClone(b), structuredClone(a)], { freeAgents: [] })
+      .map((e) => ({ id: e.player.id, contract: e.contract }));
+
+    expect(second).toEqual(first);
+  });
+});


### PR DESCRIPTION
### Motivation
- Replace a weak lifecycle-only determinism verdict with a durable, checkpoint-level state comparison so the harness can prove a franchise remains structurally correct, cap-legal, persistence-safe, and meaningfully deterministic across runs and seasons; base SHA recorded for this work is `a4f47f47e46e38db834024248484852aeac63ddf`.
- Surface the earliest durable-state divergence (domain/entity/field + checkpoint) and avoid masking real production divergences by lifecycle-only metadata comparisons.
- Add a canonical, versioned durable snapshot that canonicalizes mixed ID types, orders unordered collections deterministically, preserves multiplicity, and normalizes monetary fields to enable robust save/reload and determinism checks.

### Description
- Added `tests/durability/invariants/durableSnapshot.js` which builds a versioned durable snapshot, computes a stable `sha256` digest, and provides `compareDurableSnapshots()` with structured diffs and a `firstDivergence` result (schema v2.0.0). 
- Integrated the durable snapshot into save/reload checks and the harness: `tests/durability/invariants/saveReload.js` now includes the durable digest and detailed diagnostics, and `tests/durability/longSaveHarness.js` records per-checkpoint durable digests and summaries for comparison.
- Replaced the single `deterministic` verdict with distinct `lifecycleDeterministic`, `stateDeterministic`, and `firstDivergence` reporting, and preserved backward-readable summaries while stripping full runtime snapshots from `toJSON()` to avoid multi-megabyte report churn (`tests/durability/report.js`).
- Added stable-phase cap legality checks and snapshot helpers in `tests/durability/invariants/cap.js` using the live salary-cap resolver and a new `buildTeamCapSnapshot()` helper that includes roster cap, dead cap, pending commitments, live limit, and overage.
- Added multi-seed CLI support and aggregate reporting (`tests/durability/cli.js`, `scripts/long-save-durability.mjs`), and hardened the lifecycle driver to reset durability storage and seed the RNG before each real lifecycle boot to ensure clean per-seed isolation (`tests/durability/lifecycleDriver.js`).
- Added focused harness/unit tests that characterize the prior false-green determinism, canonicalize mixed-id ordering while preserving duplicates, assert save/reload detects contract/cap/injury/ratings/schedule/history mutations, validate cap-phase edge cases (including team id `0` and offseason skips), and assert multi-seed parsing and isolation (`tests/durability/longSaveHarness.test.js`).
- Documented the V2 snapshot contract, cap equation, evidence from runs, and remaining next steps in `docs/long-save-durability-authority-v2.md`.

### Testing
- `node --check` validations on the new/modified harness files passed for the changed modules (`durableSnapshot.js`, `saveReload.js`, harness/cli/driver`), and `npm run durability:test` passed the full durability unit-tier (67 tests) on this branch.
- `npm run durability:smoke` (bounded 1-season real-lifecycle) completed successfully with save/reload OK and produced a stable harness checkpoint report (peak RSS reported in output).
- `npm run check:sim-types` and `npm run build` completed successfully (build emitted the expected Vite chunk-size warning), and `npm run test:unit` ran successfully (all unit tests passed in this environment).
- `npm run durability:5 -- --seed=1684 --determinism --collect-all --write-report --summary` executed both five-season legs, and the strengthened harness correctly reported that the runs are not state-deterministic (lifecycle deterministic true/false as reported): it produced a structured first divergence at checkpoint `2:afterSeasonRollover` → `players:1590.signingBonus` and surfaced a first invariant failure `roster.size-within-legal-range` at season 5 `afterSeasonRollover` (team 7 roster size 51), so the branch does not claim ten-season-safe or state-deterministic until that production causal cluster is traced and repaired.
- Skipped/remaining requested long-budget runs (full three-seed 5-season matrix, 10-season seed-1684, and optional 20-season run) were not completed after V2 uncovered a reproducible production divergence and the first invariant failure; per scope these must be repaired and re-proven before claiming broader durability guarantees.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6177cf17cc832dafdd568a37802064)