### PR TITLE
Durability V2: deterministic durable snapshots, AI ordering fixes, minimum-roster reconciliation, and harness improvements

### DIFF
--- a/docs/long-save-durability-authority-v2.md
+++ b/docs/long-save-durability-authority-v2.md
@@ -1,0 +1,84 @@
+# Long-Save Durability Authority V2
+
+Base SHA: `a4f47f47e46e38db834024248484852aeac63ddf`.
+
+## Why V1 determinism was insufficient
+
+The previous durability report could set `deterministic=true` when two runs had the same lifecycle completion metadata, first-failure shape, and save/reload booleans. It did not compare durable roster, contract, cap, player, pick, schedule, or history state at corresponding checkpoints. V2 adds a canonical durable-state snapshot and compares checkpoint state directly.
+
+## Snapshot fields and normalization
+
+Snapshot schema `2.0.0` includes league phase/year/week/season id/user team/live salary cap; authoritative DB-backed teams with records, roster membership, dead cap, deferred dead cap, and stable cap fields; active players with canonical ids, team ids, age, ratings, injury availability, canonical normalized contract fields, and active cap hit; retired-player ledger rows; draft picks; schedule identity/results; completed history champion/runner-up references; and pool counts/source.
+
+Normalization now resolves object-shaped legacy champion and runner-up team references with the canonical team-reference resolver, includes retired ledger evidence from view and DB meta, preserves duplicate entity occurrences during structured comparison, and reports diffs with canonical entity ids rather than array positions.
+
+Excluded fields remain timestamps, narrative/UI-only text, raw serialization order not guaranteed by production, and volatile completion metadata.
+
+## Stable cap equation
+
+At stable cap checkpoints, each team is legal when:
+
+`sum(active roster cap hits from canonical contracts) + current dead cap + counted pending commitments <= live salary cap`
+
+The live cap is resolved from `view.economy.currentSalaryCap` or `db.meta.economy.currentSalaryCap`. Team dead cap and roster contracts come from authoritative DB team/player records when available. Staff payroll is excluded because production cap legality excludes it. Transitional offseason windows skip cap legality with a documented reason rather than pretending those reconciliation windows are final legal gates.
+
+## Continuity rules
+
+V2 continuity now checks that completed history grows exactly once at completed rollover checkpoints, schedule game ids are not reused across seasons, active/retired populations do not overlap, full-pool checkpoints do not lose established players without retirement/draft/release/free-agency/removal evidence, and contract years do not increase unless a signing/extension/restructure transaction occurred inside the compared checkpoint window (old retained transaction probes no longer excuse later corruption).
+
+Roster-only checkpoints explicitly skip player-disappearance proof with a narrow reason because the full free-agent/retired pool is not present in those view-only snapshots.
+
+## Isolation model
+
+CLI determinism legs and `--seeds` runs execute in clean child processes. This avoids reusing worker module globals, caches, fake IndexedDB state, and seeded RNG state between legs/seeds. In-process harness helpers remain available for unit tests and bounded stubs.
+
+## Production root causes repaired in this iteration
+
+- Retired players were evicted from the hot cache after offseason retirement without durable `meta.retiredPlayers` evidence, so continuity could not distinguish retirement from disappearance after old players left the DB player pool. The repair persists a compact retired-player ledger before eviction.
+- AI stable rollover could enter preseason with an AI roster below the legal minimum after retirements/cuts/free agency. The repair adds a deterministic minimum-roster reconciliation pass that signs from the existing free-agent pool, respects interactive-user isolation, creates fresh production-shaped contracts instead of inheriting released-player contracts/restructure metadata, validates projected cap legality before commit, and recalculates all team caps before the preseason save surface.
+- Save/reload could observe stale pre-save cap aggregates because not every final rollover roster mutation recalculated team cap fields before flushing. The repair recalculates every team cap after final rollover roster reconciliation.
+- Several ordering boundaries that affect offers/releases/RNG draw order lacked canonical tie-breaks: AI FA target inputs, equal-score FA offer resolution, offseason roster-cut candidate ties, offseason extension/progression team/player iteration, staff-carousel team/market ties, free-agent offer arrays, and FA offer timestamps. These were narrowed to canonical id/name tie-breaks or deterministic phase/week stamps without changing balance formulas.
+- Retention market heat used a falsy team-id predicate, so rostered team `0` players could be counted as free agents. The repair uses `teamId == null` plus non-retired/non-draft status filtering for the market free-agent pool.
+- Minimum-roster reconciliation now uses the canonical signable-free-agent predicate, live economy cap before stale team cap totals, pre-commit cap projection, and post-mutation rollback without emitting a SIGN transaction on failure.
+- Durable schedule normalization now uses production season identity precedence (`seasonId ?? season ?? year ?? null`) so schedule reuse across different production season IDs is detectable.
+
+## Current evidence
+
+Commands run on this branch after the minimum-roster contract, bounded continuity evidence, team-id-0 retention, and FA ordering/timestamp repairs:
+
+- `node --check src/core/ai-logic.js && node --check src/core/retention/reSigning.js && node --check tests/durability/invariants/continuity.js` — passed.
+- `node --check src/worker/worker.js` — passed.
+- `npx vitest run tests/unit/aiCapManagementExecution.test.js --config vitest.config.ts` — passed, 1 file / 16 tests.
+- `npx vitest run src/core/__tests__/retention-board.test.js --config vitest.config.ts` — passed, 1 file / 4 tests.
+- `npm run durability:test` — passed, 5 files / 83 tests.
+- `npm run check:sim-types` — passed.
+- `npm run build` — passed with the existing Vite chunk-size warning.
+- `npm run durability:smoke` — passed one full season with save/reload OK (201 pass / 0 fail / 39 skip, peak RSS 455 MB).
+- `npm run test:unit` — passed, 462 files / 5663 tests.
+- `npm run durability:5 -- --seed=1684 --determinism --collect-all --write-report --summary` — completed both isolated five-season legs with zero invariant failures and save/reload OK in both legs, but exited nonzero because state determinism remained false.
+
+Latest five-season determinism result:
+
+- Seed: 1684
+- Completed: 5/5 seasons in each isolated child leg
+- First leg runtime/peak RSS: 508.5 seconds / 2212 MB
+- Second leg runtime/peak RSS: 516.5 seconds / 2174 MB
+- Invariants: 750 pass / 0 fail / 132 skip in both legs
+- Save/reload: OK at season 1 and season 5 in both legs
+- Lifecycle deterministic: true
+- State deterministic: false
+- First remaining durable divergence: checkpoint `2:afterSeasonRollover`, domain `players`, entity `5013`, field `teamId`
+
+The current first reported divergence is now player `5013.teamId` (`27` vs `28`) at `2:afterSeasonRollover`. This confirms there is still at least one unrepaired FA/offseason ordering boundary upstream of durable team assignment and contract differences, so the PR must remain red for Durability Authority V2.
+
+## Remaining limitations / not yet proven
+
+This branch must still not claim five-season state determinism, ten-season safety, or multi-seed durable authority. The season-5 roster-size failure is gone and save/reload is stable in the latest five-season runs, but the seed-1684 five-season state-determinism gate is still red. Because that principal determinism gate remains red, the three-seed five-season matrix, ten-season seed-1684 proof, and optional twenty-season run were not honestly claimable from this head.
+
+## Focused reconciliation and retired-jersey follow-up
+
+Minimum-roster reconciliation now recalculates the existing positional-need authority after every successful signing. This preserves the existing valuation, cap projection, rollback, and deterministic candidate tie-breaks while preventing a roster that is short at several positions from repeatedly using the priority order computed before its first signing.
+
+Compact retirement ledger rows now persist `jerseyNumber` for new retirements. The retired-jersey resolver remains backward-compatible: when an old compact row has no valid number, it loads the full persisted player row instead of treating the incomplete ledger row as authoritative. It does not restore that full player to the hot cache.
+
+Focused verification on the checked-out head passed (`41` targeted tests), as did the complete unit suite (`462` files / `5667` tests), simulation type check, build, durability unit tier, one-season durability smoke, and local `check:deploy` production/deploy-preview parity builds. Because positional recalculation changes deterministic reconciliation output, the five-season isolated determinism gate was rerun. Both legs completed with zero invariant failures and save/reload OK, but this checkout reported `lifecycleDeterministic=true`, `stateDeterministic=false`, with the first difference at `4:afterSeasonRollover`, player `1046.activeCapHit`. Therefore this evidence does not claim that state determinism is green on the checked-out head.

--- a/scripts/long-save-durability.mjs
+++ b/scripts/long-save-durability.mjs
@@ -12,6 +12,10 @@
  *   npm run durability:20 -- --collect-all --seed=1684
  */
 import 'fake-indexeddb/auto';
+import { readFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
 import { parseArgv, USAGE, writeReports, resolveGitSha, defaultReportName } from '../tests/durability/cli.js';
 import { formatConsole } from '../tests/durability/report.js';
 
@@ -25,7 +29,7 @@ async function main() {
     return;
   }
 
-  const { runDurabilityHarness, runDeterminismCheck } = await import('../tests/durability/longSaveHarness.js');
+  const { runDurabilityHarness, runDeterminismCheck, compareReportDeterminism } = await import('../tests/durability/longSaveHarness.js');
   const gitSha = await resolveGitSha();
 
   const onEvent = (ev) => {
@@ -37,21 +41,45 @@ async function main() {
     else if (ev.type === 'stopped') console.log(`[durability]   stopped: ${ev.reason}`);
   };
 
-  console.log(`[durability] mode=${raw.mode} seed=${raw.seed} failureMode=${raw.failureMode} stopPhase=${raw.stopPhase} determinism=${raw.determinism}`);
+  console.log(`[durability] mode=${raw.mode} seed=${raw.seeds ? raw.seeds.join(',') : raw.seed} failureMode=${raw.failureMode} stopPhase=${raw.stopPhase} determinism=${raw.determinism}`);
 
   const base = { mode: raw.mode, seed: raw.seed, failureMode: raw.failureMode, perSeasonStopPhase: raw.stopPhase, gitSha, onEvent };
   if (Number.isFinite(raw.phaseTimeoutMs)) base.phaseTimeoutMs = raw.phaseTimeoutMs;
   let report;
-  if (raw.determinism) {
-    const det = await runDeterminismCheck(base);
-    report = det.reports[0];
-    report.setDeterminism(det.deterministic, det.detail);
+  if (process.env.DURABILITY_CHILD_JSON) {
+    report = await runDurabilityHarness(base);
+    await import('node:fs').then((fs) => fs.writeFileSync(process.env.DURABILITY_CHILD_JSON, JSON.stringify(report.toRuntimeJSON())));
+  } else if (raw.seeds) {
+    const reports = [];
+    for (const seed of raw.seeds) {
+      console.log(`[durability] === seed ${seed} clean child process ===`);
+      reports.push(runIsolatedChild({ ...raw, seed, seeds: null, determinism: false }));
+    }
+    report = { passed: reports.every((r) => r.summary.failed === 0 && !r.lifecycleException), toJSON: () => ({ harnessVersion: '2.0.0', mode: raw.mode, seeds: raw.seeds, overallPassed: reports.every((r) => r.summary.failed === 0 && !r.lifecycleException), reports: reports.map(stripRuntime) }), toSummaryJSON: () => ({ harnessVersion: '2.0.0', mode: raw.mode, seeds: raw.seeds, overallPassed: reports.every((r) => r.summary.failed === 0 && !r.lifecycleException), reports: reports.map(stripRuntime) }) };
+  } else if (raw.determinism) {
+    const childA = runIsolatedChild({ ...raw, determinism: false });
+    const childB = runIsolatedChild({ ...raw, determinism: false });
+    const det = compareReportDeterminism(childA, childB);
+    childA.deterministic = det.deterministic;
+    childA.lifecycleDeterministic = det.lifecycleDeterministic;
+    childA.stateDeterministic = det.stateDeterministic;
+    childA.firstDivergence = det.firstDivergence;
+    childA.determinismDetail = det.detail;
+    report = { passed: childA.summary.failed === 0 && !childA.lifecycleException && det.deterministic, toJSON: () => stripRuntime(childA), toSummaryJSON: () => stripRuntime(childA) };
     console.log(`[durability] deterministic=${det.deterministic} — ${det.detail}`);
   } else {
     report = await runDurabilityHarness(base);
   }
 
-  console.log('\n' + formatConsole(report));
+  if (raw.seeds) {
+    const agg = report.toJSON();
+    console.log(`\n── Long-Save Durability Multi-Seed Report ───────────────────`);
+    console.log(`mode=${agg.mode} seeds=${agg.seeds.join(',')} overallPassed=${agg.overallPassed}`);
+    for (const r of agg.reports) console.log(`seed=${r.seed} passed=${r.summary.failed === 0 && !r.lifecycleException} completed=${r.seasonsCompleted}/${r.requestedSeasons} fail=${r.summary.failed}`);
+    console.log(`─────────────────────────────────────────────────────────────`);
+  } else {
+    console.log('\n' + formatConsole(report));
+  }
 
   if (raw.writeReport) {
     const written = writeReports(report, {
@@ -74,3 +102,16 @@ main()
     console.error('[durability] fatal:', e);
     process.exit(1);
   });
+
+function runIsolatedChild(raw) {
+  const out = join(tmpdir(), `durability-child-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+  const args = [process.argv[1], raw.mode, `--seed=${raw.seed}`, `--stop-phase=${raw.stopPhase}`, `--phase-timeout-ms=${raw.phaseTimeoutMs ?? 1800000}`, '--child-run'];
+  if (raw.failureMode === 'collect-all') args.push('--collect-all');
+  const res = spawnSync(join(process.cwd(), 'node_modules/.bin/tsx'), args, { cwd: process.cwd(), env: { ...process.env, DURABILITY_CHILD_JSON: out }, encoding: 'utf8', stdio: ['ignore', 'inherit', 'inherit'] });
+  if (res.status !== 0) process.exitCode = res.status;
+  try { const json = JSON.parse(readFileSync(out, 'utf8')); unlinkSync(out); return json; }
+  catch (err) { throw new Error(`isolated durability child did not produce JSON report: ${err.message}`); }
+}
+function stripRuntime(report) {
+  return { ...report, checkpoints: (report.checkpoints || []).map((c) => ({ ...c, durable: c.durable ? { digest: c.durable.digest, summary: c.durable.summary } : null })) };
+}

--- a/src/core/__tests__/retention-board.test.js
+++ b/src/core/__tests__/retention-board.test.js
@@ -32,4 +32,14 @@ describe('retention workflow helpers', () => {
     const state = getExtensionReadiness({ contract: { years: 2 } }, { profile: { moneyPriority: 0.8, loyalty: 0.4, securityPriority: 0.4 }, phase: 'regular' });
     expect(['prefers_to_wait', 'wants_market_reset', 'likely_to_test_free_agency']).toContain(state);
   });
+
+  it('does not count team-id-0 rostered players as free agents when computing market heat', () => {
+    const team = { id: 1, wins: 7, losses: 10, ties: 0, capRoom: 40 };
+    const player = { id: 'target', teamId: 1, status: 'active', pos: 'QB', ovr: 72, potential: 72, age: 27, contract: { years: 1, baseAnnual: 6 } };
+    const teamZeroQb = { id: 'team-zero-qb', teamId: 0, status: 'active', pos: 'QB', ovr: 85, potential: 85, age: 28, contract: { years: 3, baseAnnual: 20 } };
+    const withTeamZero = evaluateReSigningPriority(player, team, { players: [player, teamZeroQb], week: 5 });
+    const withoutTeamZero = evaluateReSigningPriority(player, team, { players: [player], week: 5 });
+    expect(withTeamZero.expectedMarketDifficulty).toBe(withoutTeamZero.expectedMarketDifficulty);
+    expect(withTeamZero.demand).toEqual(withoutTeamZero.demand);
+  });
 });

--- a/src/core/ai-logic.js
+++ b/src/core/ai-logic.js
@@ -1,4 +1,5 @@
 import { cache } from '../db/cache.js';
+import { stableIdCompare } from './referenceIntegrity.js';
 import { Constants } from './constants.js';
 import { Transactions } from '../db/index.js';
 import { calculateExtensionDemand } from './player.js';
@@ -15,7 +16,7 @@ import { buildAiTeamStrategy } from './aiTeamStrategy.js';
 import NewsEngine from './news-engine.js';
 import { getTeamContextForNegotiation } from './teamContext/negotiationContext.js';
 import { evaluateContractOffer } from './contracts/negotiation.js';
-import { isFreeAgent } from './freeAgency/membership.js';
+import { isFreeAgent, isSignableFreeAgent } from './freeAgency/membership.js';
 import { evaluateReSigningPriority } from './retention/reSigning.js';
 import { buildFreeAgencyMarketAnalysis } from './freeAgency/freeAgencyMarketAnalysis.js';
 import { buildContractFromMarket, evaluateContractMarket } from './contractModel.js';
@@ -27,6 +28,104 @@ import { canRestructure, computeRestructure, applyRestructure } from './contract
 import { executeAIOffseasonExtensions } from './retention/aiRetentionLogic.js';
 import { calculateTeamDepthDeficiencies, getNeedLevelForPlayer, POSITION_NEED_LEVEL } from './trades/tradePositionalNeeds.js';
 import { buildFranchiseTagContract, buildRFATenderContract, TENDER_CONFIG } from './contracts/tenderLogic.js';
+
+
+export function buildSortedFreeAgentsMapForOffers(allPlayers = []) {
+    const freeAgentsMap = {};
+    for (const p of allPlayers) {
+        if (isFreeAgent(p)) {
+            if (!freeAgentsMap[p.pos]) freeAgentsMap[p.pos] = [];
+            freeAgentsMap[p.pos].push(p);
+        }
+    }
+    for (const pos in freeAgentsMap) {
+        freeAgentsMap[pos].sort((a, b) => ((b.ovr ?? 0) - (a.ovr ?? 0)) || stableIdCompare(a.id, b.id));
+    }
+    return freeAgentsMap;
+}
+
+function positionRank(pos, order) {
+    const idx = order.indexOf(pos);
+    return idx >= 0 ? idx : order.length;
+}
+
+const round1 = (v) => Math.round(Number(v || 0) * 10) / 10;
+
+export function buildMinimumRosterContract(player = {}, team = {}, context = {}) {
+    const year = Number(context.year ?? context.currentYear ?? context.seasonYear ?? 0);
+    const market = evaluateContractMarket(player, {
+        team,
+        strategy: context.strategy,
+        teamCapRoom: context.capRoom ?? team?.capRoom,
+        capRoom: context.capRoom ?? team?.capRoom,
+        positionalNeed: context.needMultiplier ?? 1,
+    });
+    const years = Math.max(1, Math.round(Number(market?.suggestedYears ?? market?.years ?? 1)));
+    const annual = round1(market?.suggestedAnnual ?? market?.annualSalary ?? Constants.SALARY_CAP.MIN_CONTRACT);
+    const signingBonus = round1(market?.signingBonus ?? 0);
+    return {
+        ...buildContractFromMarket(
+            { ...market, suggestedAnnual: annual, suggestedYears: years, signingBonus },
+            { startYear: year, signedYear: year },
+        ),
+        yearsRemaining: years,
+        restructureCount: 0,
+        restructureHistory: [],
+        restructured: false,
+        restructureSavings: 0,
+        restructureOriginalBase: null,
+        restructureOriginalBonus: null,
+        restructureYear: null,
+        tag: null,
+        tender: null,
+        franchiseTag: null,
+        rfaTender: null,
+    };
+}
+
+function minimumRosterSigningPatch(contract) {
+    return {
+        teamId: undefined,
+        status: 'active',
+        offers: [],
+        contract,
+        contractYearsLeft: contract.yearsRemaining ?? contract.years,
+        tag: null,
+        tender: null,
+        franchiseTag: null,
+        rfaTender: null,
+        restructureCount: 0,
+        restructureHistory: [],
+        restructured: false,
+        restructureSavings: 0,
+        restructureOriginalBase: null,
+        restructureOriginalBonus: null,
+        restructureYear: null,
+    };
+}
+
+const MINIMUM_ROSTER_SIGNING_KEYS = Object.freeze([
+    'teamId', 'status', 'offers', 'contract', 'contractYearsLeft', 'tag',
+    'tender', 'franchiseTag', 'rfaTender', 'restructureCount',
+    'restructureHistory', 'restructured', 'restructureSavings',
+    'restructureOriginalBase', 'restructureOriginalBonus', 'restructureYear',
+]);
+
+function restoreMinimumRosterPlayerPatch(snapshot = {}) {
+    const patch = { ...snapshot };
+    for (const key of MINIMUM_ROSTER_SIGNING_KEYS) {
+        if (!(key in snapshot)) patch[key] = undefined;
+    }
+    return patch;
+}
+
+function resolveLiveCapForMinimumRoster(team = {}, meta = {}) {
+    const economyCap = Number(meta?.economy?.currentSalaryCap);
+    if (Number.isFinite(economyCap) && economyCap > 0) return economyCap;
+    const teamCap = Number(team?.capTotal);
+    if (Number.isFinite(teamCap) && teamCap > 0) return teamCap;
+    return Constants.SALARY_CAP.HARD_CAP;
+}
 
 class AiLogic {
     static NEED_GROUP_TO_POS = Object.freeze({
@@ -142,7 +241,7 @@ class AiLogic {
     static async executeAICutdowns({ includeUserTeam = false } = {}) {
         const meta = cache.getMeta();
         const userTeamId = meta.userTeamId;
-        const allTeams = cache.getAllTeams();
+        const allTeams = cache.getAllTeams().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
         const limit = Constants.ROSTER_LIMITS.REGULAR_SEASON;
 
         for (const team of allTeams) {
@@ -151,7 +250,7 @@ class AiLogic {
             // user team in via includeUserTeam so the season can still start.
             if (!includeUserTeam && team.id === userTeamId) continue;
 
-            const roster = cache.getPlayersByTeam(team.id);
+            const roster = cache.getPlayersByTeam(team.id).slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
             if (roster.length <= limit) continue;
 
             // Score = OVR * 2 + Potential + (Age < 25 ? 10 : 0)
@@ -229,6 +328,101 @@ class AiLogic {
 
             // Re-calc active cap (roster changed)
             this.updateTeamCap(team.id);
+        }
+    }
+
+    /**
+     * Deterministic minimum-roster reconciliation for AI/headless rollover.
+     * This is a last-mile safety pass after offseason churn: it only fills
+     * under-minimum rosters from the existing free-agent pool and never cuts or
+     * restructures players.
+     */
+    static async ensureMinimumRosters({ includeUserTeam = false, minimum = Constants.ROSTER_LIMITS.REGULAR_SEASON } = {}) {
+        const meta = cache.getMeta();
+        const userTeamId = meta?.userTeamId;
+        const allTeams = cache.getAllTeams().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
+
+        for (const team of allTeams) {
+            if (!includeUserTeam && Number(team.id) === Number(userTeamId)) continue;
+
+            let roster = cache.getPlayersByTeam(team.id);
+            if (roster.length >= minimum) continue;
+
+            while (roster.length < minimum) {
+                // Recompute from the just-updated roster after every signing.
+                // Otherwise a multi-player deficit repeatedly uses the first
+                // roster's highest-priority position and can stack one group.
+                const needs = AiLogic.calculateTeamNeeds(team.id);
+                const neededPositions = Object.keys(needs)
+                    .filter((pos) => Number(needs[pos] ?? 0) > 1)
+                    .sort((a, b) => (Number(needs[b] ?? 0) - Number(needs[a] ?? 0)) || a.localeCompare(b));
+                const positionOrder = [...neededPositions, ...Constants.POSITIONS.filter((pos) => !neededPositions.includes(pos))];
+                const freshTeam = cache.getTeam(team.id);
+                const liveSalaryCap = resolveLiveCapForMinimumRoster(freshTeam, meta);
+                const freeAgents = cache.getAllPlayers()
+                    .filter((p) => isSignableFreeAgent(p))
+                    .sort((a, b) => {
+                        const posDelta = positionRank(a?.pos, positionOrder) - positionRank(b?.pos, positionOrder);
+                        if (posDelta !== 0) return posDelta;
+                        return (Number(b?.ovr ?? 0) - Number(a?.ovr ?? 0)) || stableIdCompare(a?.id, b?.id);
+                    });
+                const capSnapshot = buildTeamCapSnapshot({
+                    team: freshTeam,
+                    roster,
+                    salaryCap: liveSalaryCap,
+                });
+                const room = Number(capSnapshot?.capRoom ?? freshTeam?.capRoom ?? 0);
+                let candidate = null;
+                let contract = null;
+                let projectedCap = null;
+                for (const p of freeAgents) {
+                    const strategy = buildAiTeamStrategy({
+                        team: freshTeam,
+                        roster,
+                        league: { year: meta?.year, phase: meta?.phase },
+                        phase: meta?.phase,
+                        year: meta?.year,
+                    });
+                    const proposedContract = buildMinimumRosterContract(p, freshTeam, {
+                        year: meta?.year,
+                        strategy,
+                        capRoom: room,
+                        needMultiplier: needs?.[p?.pos] ?? 1,
+                    });
+                    const projectedPlayer = { ...p, teamId: team.id, status: 'active', contract: proposedContract };
+                    const projection = buildTeamCapSnapshot({
+                        team: freshTeam,
+                        roster: [...roster, projectedPlayer],
+                        salaryCap: liveSalaryCap,
+                    });
+                    if (Number(getActiveCapHit(projectedPlayer) ?? 0) <= room + 0.01 && projection?.isLegallyCompliant !== false) {
+                        candidate = p;
+                        contract = proposedContract;
+                        projectedCap = projection;
+                        break;
+                    }
+                }
+                if (!candidate) break;
+
+                const beforePlayer = JSON.parse(JSON.stringify(candidate));
+                const beforeTeam = JSON.parse(JSON.stringify(freshTeam));
+                cache.updatePlayer(candidate.id, { ...minimumRosterSigningPatch(contract), teamId: team.id });
+                const capResult = AiLogic.updateTeamCap(team.id);
+                if (capResult?.ok === false) {
+                    cache.updatePlayer(candidate.id, restoreMinimumRosterPlayerPatch(beforePlayer));
+                    cache.updateTeam(team.id, beforeTeam);
+                    break;
+                }
+                await Transactions.add({
+                    type: 'SIGN',
+                    seasonId: meta.currentSeasonId,
+                    week: meta.currentWeek,
+                    teamId: team.id,
+                    playerId: candidate.id,
+                    details: { playerId: candidate.id, source: 'minimum_roster_reconciliation', contract, projectedCapRoom: projectedCap?.capRoom },
+                });
+                roster = cache.getPlayersByTeam(team.id);
+            }
         }
     }
 
@@ -569,7 +763,7 @@ class AiLogic {
     static async executeOffseasonRosterCuts() {
         const meta = cache.getMeta();
         const userTeamId = meta?.userTeamId;
-        const allTeams = cache.getAllTeams();
+        const allTeams = cache.getAllTeams().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
         const year = Number(meta?.year ?? 2025);
 
         for (const team of allTeams) {
@@ -658,7 +852,7 @@ class AiLogic {
 
         const roster = cache.getPlayersByTeam(teamId);
         const meta   = cache.getMeta();
-        const allPlayers = cache.getAllPlayers();
+        const allPlayers = cache.getAllPlayers().slice().sort((a, b) => stableIdCompare(a.id, b.id));
         const freeAgents = allPlayers.filter((p) => isFreeAgent(p));
 
         const extensions = executeAIOffseasonExtensions(
@@ -925,7 +1119,7 @@ class AiLogic {
                 }, {}) || null;
                 if (marketByPos) {
                     for (const pos of Object.keys(marketByPos)) {
-                        marketByPos[pos].sort((a, b) => (b.fitScore ?? 0) - (a.fitScore ?? 0));
+                        marketByPos[pos].sort((a, b) => ((b.fitScore ?? 0) - (a.fitScore ?? 0)) || stableIdCompare(a?._player?.id ?? a?.playerId, b?._player?.id ?? b?.playerId));
                     }
                 }
             }
@@ -936,7 +1130,7 @@ class AiLogic {
             const allPlayers = cache.getAllPlayers();
             return allPlayers
                 .filter(p => isFreeAgent(p) && p.pos === pos)
-                .sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0));
+                .sort((a, b) => ((b.ovr ?? 0) - (a.ovr ?? 0)) || stableIdCompare(a?.id, b?.id));
         };
 
         const getCandidatesForPos = (pos) => {
@@ -1105,12 +1299,13 @@ class AiLogic {
                                 flags: realism.flags,
                             },
                         },
-                        timestamp: Date.now()
+                        timestamp: Number(meta?.year ?? 0) * 100000 + Number(meta?.currentWeek ?? 0) * 1000 + Number(teamId ?? 0)
                     };
 
                     // Push to player's offer list (in cache)
                     if (!fa.offers) fa.offers = [];
                     fa.offers.push(offer);
+                    fa.offers.sort((a, b) => stableIdCompare(a?.teamId, b?.teamId));
 
                     // Persist the offer (mark player as dirty)
                     cache.updatePlayer(fa.id, { offers: fa.offers });
@@ -1133,20 +1328,11 @@ class AiLogic {
         const userTeamId = meta.userTeamId;
 
         // OPTIMIZATION: Build freeAgentsMap once for all AI teams
-        const allPlayers = cache.getAllPlayers();
-        const freeAgentsMap = {};
-        for (const p of allPlayers) {
-            if (isFreeAgent(p)) {
-                if (!freeAgentsMap[p.pos]) freeAgentsMap[p.pos] = [];
-                freeAgentsMap[p.pos].push(p);
-            }
-        }
-        for (const pos in freeAgentsMap) {
-            freeAgentsMap[pos].sort((a, b) => (b.ovr ?? 0) - (a.ovr ?? 0));
-        }
+        const allPlayers = cache.getAllPlayers().slice().sort((a, b) => stableIdCompare(a.id, b.id));
+        const freeAgentsMap = buildSortedFreeAgentsMapForOffers(allPlayers);
 
         // 1. AI Teams Make Offers
-        const allTeams = cache.getAllTeams();
+        const allTeams = cache.getAllTeams().slice().sort((a, b) => stableIdCompare(a.id, b.id));
         for (const team of allTeams) {
             if (team.id !== userTeamId) {
                 await this.makeFreeAgencyOffers(team.id, freeAgentsMap);
@@ -1324,7 +1510,7 @@ class AiLogic {
             }, offer, { profile, askTotalValue: askTotal, askAnnual: ask.baseAnnual, askYears: ask.yearsTotal });
             const score = legacyScore * 55 + (offerEval.score / 100) * 45;
 
-            if (score > bestScore) {
+            if (score > bestScore || (score === bestScore && (!bestOffer || stableIdCompare(offer?.teamId, bestOffer?.teamId) < 0))) {
                 bestScore = score;
                 bestOffer = offer;
             }

--- a/src/core/freeAgency/aiFaEngine.js
+++ b/src/core/freeAgency/aiFaEngine.js
@@ -12,6 +12,7 @@
  *  - Fully deterministic: same inputs → same outputs.
  */
 
+import { stableIdCompare } from '../referenceIntegrity.js';
 import { classifyDeadlinePosture, DEADLINE_POSTURE } from '../trades/tradeDeadlinePressure.js';
 
 // ── Bid factor constants per posture ──────────────────────────────────────────
@@ -234,8 +235,9 @@ export function resolvePlayerChoice(player, offers, context = {}) {
     return { winningOffer: null, reason: 'All offers below market — player re-enters market' };
   }
 
-  // Sort by score descending
-  acceptable.sort((a, b) => b.score - a.score);
+  // Sort by score descending with deterministic tie order so the seeded
+  // tiebreaker indexes the same team set in every process.
+  acceptable.sort((a, b) => (b.score - a.score) || stableIdCompare(a?.teamId, b?.teamId));
 
   // Tiebreaker: seeded hash of playerId + season + week (fully deterministic)
   const topScore = acceptable[0].score;
@@ -274,8 +276,8 @@ export function getAIFaTargets(allTeams, availablePlayers, meta, season = 1, wee
   const userTeamId = Number(meta?.userTeamId ?? -1);
   const result = new Map();
 
-  const safeTeams = Array.isArray(allTeams) ? allTeams : [];
-  const safeFA    = Array.isArray(availablePlayers) ? availablePlayers : [];
+  const safeTeams = (Array.isArray(allTeams) ? allTeams : []).slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
+  const safeFA    = (Array.isArray(availablePlayers) ? availablePlayers : []).slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
 
   for (const team of safeTeams) {
     if (!team?.id || Number(team.id) === userTeamId) continue;
@@ -300,7 +302,7 @@ export function getAIFaTargets(allTeams, availablePlayers, meta, season = 1, wee
       // Rebuilder: skip veterans
       if (posture === DEADLINE_POSTURE.REBUILD && safeNum(player.age, 30) > 27) return false;
       return true;
-    });
+    }).sort((a, b) => (safeNum(b?.ovr, 0) - safeNum(a?.ovr, 0)) || stableIdCompare(a?.id, b?.id));
 
     if (targets.length > 0) {
       result.set(Number(team.id), targets);

--- a/src/core/freeAgency/membership.js
+++ b/src/core/freeAgency/membership.js
@@ -21,3 +21,20 @@ export function isFreeAgent(player) {
   const { teamId, status } = player;
   return teamId == null || teamId === 'FA' || status === 'free_agent';
 }
+
+/**
+ * Canonical signability predicate for production free-agent signing paths.
+ *
+ * `isFreeAgent` is intentionally broad because it answers membership and must
+ * tolerate old saves with odd combinations of team/status fields. Signing is a
+ * stricter authority: only explicitly signable free-agent rows with no live
+ * team assignment may be contracted by FA or roster-reconciliation code.
+ */
+export function isSignableFreeAgent(player) {
+  if (!player) return false;
+  const status = String(player?.status ?? '').toLowerCase();
+  if (player?.retired === true) return false;
+  if (['retired', 'draft_eligible', 'draft_pool', 'draft-pool', 'deleted', 'removed'].includes(status)) return false;
+  if (player?.teamId === 'FA') return true;
+  return player?.teamId == null && (status === 'free_agent' || status === 'unsigned' || status === '');
+}

--- a/src/core/history/teamIdentity.integration.test.js
+++ b/src/core/history/teamIdentity.integration.test.js
@@ -5,7 +5,7 @@
  * and the migrateLeague schema from state.js.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   retireJerseyNumber,
   appendChampionshipYear,
@@ -13,6 +13,7 @@ import {
   findAvailableJerseyNumber,
   buildRetiredNumberDisplay,
   createDefaultTeamIdentity,
+  resolveRetiredPlayerForJersey,
 } from './teamIdentityEngine.js';
 import { State } from '../../core/state.js';
 
@@ -164,6 +165,39 @@ describe('retireJerseyNumber — handler semantics', () => {
     const player = makePlayer({ jerseyNumber: undefined });
     expect(() => retireJerseyNumber(team, player)).not.toThrow();
     expect(team.retiredNumbers).toHaveLength(0); // no mutation
+  });
+
+  it('uses a complete compact retired ledger row without loading the full player', async () => {
+    const loadPlayer = vi.fn();
+    const player = await resolveRetiredPlayerForJersey({
+      playerId: 'p1',
+      retiredPlayers: [{ id: 'p1', name: 'Dan Legend', jerseyNumber: 12 }],
+      loadPlayer,
+    });
+    expect(player.jerseyNumber).toBe(12);
+    expect(loadPlayer).not.toHaveBeenCalled();
+  });
+
+  it('falls back to IndexedDB for a legacy compact row without jerseyNumber', async () => {
+    const loadPlayer = vi.fn(async () => makePlayer({ id: 'p1', jerseyNumber: 12 }));
+    const player = await resolveRetiredPlayerForJersey({
+      playerId: 'p1',
+      retiredPlayers: [{ id: 'p1', name: 'Dan Legend' }],
+      loadPlayer,
+    });
+    expect(player.jerseyNumber).toBe(12);
+    expect(loadPlayer).toHaveBeenCalledWith('p1');
+  });
+
+  it('still leaves a genuinely invalid jersey number for handler validation to reject', async () => {
+    const player = await resolveRetiredPlayerForJersey({
+      playerId: 'p1',
+      retiredPlayers: [{ id: 'p1' }],
+      loadPlayer: vi.fn(async () => makePlayer({ jerseyNumber: null })),
+    });
+    expect(Number.isInteger(Number(player.jerseyNumber)) && Number(player.jerseyNumber) >= 1).toBe(false);
+    const team = makeTeam();
+    expect(retireJerseyNumber(team, player)).toBe(team);
   });
 });
 

--- a/src/core/history/teamIdentityEngine.js
+++ b/src/core/history/teamIdentityEngine.js
@@ -44,6 +44,25 @@ export function retireJerseyNumber(team, player) {
 }
 
 /**
+ * Resolve a retired player without treating a compact ledger row as complete.
+ * Old saves may have ledger identity fields but no jersey number, so those rows
+ * must fall through to the persisted player record.
+ */
+export async function resolveRetiredPlayerForJersey({ playerId, cachedPlayer = null, retiredPlayers = [], loadPlayer }) {
+  if (cachedPlayer) return cachedPlayer;
+  const ledgerPlayer = (Array.isArray(retiredPlayers) ? retiredPlayers : [])
+    .find((player) => String(player?.id ?? player?.playerId) === String(playerId)) ?? null;
+  const ledgerJersey = Number(ledgerPlayer?.jerseyNumber);
+  if (ledgerPlayer && Number.isInteger(ledgerJersey) && ledgerJersey >= 1 && ledgerJersey <= 99) return ledgerPlayer;
+  if (typeof loadPlayer !== 'function') return ledgerPlayer;
+  try {
+    return (await loadPlayer(playerId)) ?? ledgerPlayer;
+  } catch {
+    return ledgerPlayer;
+  }
+}
+
+/**
  * Append a championship year to the franchise history.
  * Ignores duplicate years.
  * Sorted ascending (oldest to newest) for stable display.

--- a/src/core/retention/aiRetentionLogic.js
+++ b/src/core/retention/aiRetentionLogic.js
@@ -9,6 +9,7 @@
  * live in AiLogic.processExtensions() in ai-logic.js.
  */
 
+import { stableIdCompare } from '../referenceIntegrity.js';
 import {
   buildContractProfile,
   buildDemandFromProfile,
@@ -250,7 +251,7 @@ export function executeAIOffseasonExtensions(teamState, roster = [], marketConst
   // Step 2 ── Build Priority Retention Board (highest score first) ──────────
   const board = eligible
     .map((player) => ({ player, priorityScore: computePriorityScore(player, config) }))
-    .sort((a, b) => b.priorityScore - a.priorityScore);
+    .sort((a, b) => (b.priorityScore - a.priorityScore) || stableIdCompare(a.player?.id, b.player?.id));
 
   // Step 3 ── Iterate and offer extensions ──────────────────────────────────
   const extensions = [];

--- a/src/core/retention/reSigning.js
+++ b/src/core/retention/reSigning.js
@@ -49,7 +49,7 @@ export function getExtensionReadiness(player = {}, context = {}) {
 
 export function evaluateReSigningPriority(player = {}, team = {}, league = {}) {
   const roster = (league?.players ?? []).filter((p) => Number(p?.teamId) === Number(team?.id));
-  const freeAgents = (league?.players ?? []).filter((p) => !p?.teamId || p?.status === 'free_agent');
+  const freeAgents = (league?.players ?? []).filter((p) => p?.teamId == null && p?.status !== 'retired' && p?.status !== 'draft_eligible');
   const teamDirection = inferTeamDirection(team, Number(league?.week ?? 1));
   const profile = buildContractProfile(player, { tenureYears: safeNum(player?.tenureYears, 0) });
   const marketHeat = computeMarketHeat(player?.pos, freeAgents);

--- a/src/core/roster/aiRosterCuts.js
+++ b/src/core/roster/aiRosterCuts.js
@@ -13,6 +13,7 @@ import {
   getActiveCapHit,
   calculateReleaseDeadCap,
 } from '../contracts/contractObligations.js';
+import { stableIdCompare } from '../referenceIntegrity.js';
 
 export const ROSTER_CUT_CONFIG = Object.freeze({
   /** Only trigger the cut sweep when projected cap room is below this value ($M). */
@@ -121,7 +122,7 @@ export function executeAIOffseasonCuts(teamState, roster, _currentYear) {
       return { player: p, capSavings: ev.capSavings, reason: ev.reason, priority: ev.priority };
     })
     .filter(Boolean)
-    .sort((a, b) => b.capSavings - a.capSavings); // highest savings first
+    .sort((a, b) => (b.capSavings - a.capSavings) || stableIdCompare(a?.player?.id, b?.player?.id)); // highest savings first
 
   const toRelease = [];
   let simCapRoom = capRoom;

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -178,6 +178,7 @@ import {
   prunePendingOffers,
 } from '../core/freeAgency/pendingOffers.js';
 import { isFreeAgent } from '../core/freeAgency/membership.js';
+import { stableIdCompare } from '../core/referenceIntegrity.js';
 import {
   shouldAITeamPursuePlayer,
   computeAIOffer,
@@ -274,6 +275,7 @@ import {
   findAvailableJerseyNumber,
   buildRetiredNumberDisplay,
   derivePreferredJerseyNumber,
+  resolveRetiredPlayerForJersey,
 } from '../core/history/teamIdentityEngine.js';
 import { ensurePersonalityProfile, mentorshipBonusForPlayer, contractPersonalityModifier } from '../core/development/personalitySystem.js';
 import { applyTeamCultureWeek, classifyTeamCulture, buildTeamCultureNarrative, TEAM_CULTURE_DEFAULT } from '../core/teamCulture.js';
@@ -1593,7 +1595,7 @@ function awardCompensatoryPicksForUpcomingDraft(metaObj = ensureCompMeta(cache.g
   if (!year) return [];
   if ((metaObj?.compPicksGeneratedForSeason ?? []).includes(year)) return [];
 
-  const allTeams = cache.getAllTeams();
+  const allTeams = cache.getAllTeams().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
   const rows = (metaObj?.offseasonFaMovements ?? []).filter((row) =>
     Number(row?.compSeason ?? year) === year && row?.qualifying && row?.externalSigning
   );
@@ -1659,7 +1661,7 @@ function calcAssetBundleValue({ playerIds = [], pickIds = [] } = {}, context = {
 
 function resolvePickById(pickId) {
   if (pickId == null) return null;
-  const allTeams = cache.getAllTeams();
+  const allTeams = cache.getAllTeams().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
   for (const team of allTeams) {
     const picks = Array.isArray(team?.picks) ? team.picks : [];
     const found = picks.find((pk) => String(pk?.id) === String(pickId));
@@ -7033,16 +7035,17 @@ async function handleRetireJerseyNumber({ teamId, playerId }, id) {
     return;
   }
 
-  // Find the player in the Ring of Honor or retired pool
-  let player = cache.getPlayer(playerId);
-  if (!player) {
-    // Check retiredPlayers in meta
-    const retired = Array.isArray(meta?.retiredPlayers) ? meta.retiredPlayers : [];
-    player = retired.find((p) => String(p?.id) === String(playerId)) ?? null;
-  }
-  if (!player) {
-    try { player = await Players.load(playerId); } catch (_) { player = null; }
-  }
+  // Compact ledger rows are authoritative for identity, but old rows may not
+  // carry jerseyNumber. In that case continue to the persisted player record.
+  let player = null;
+  try {
+    player = await resolveRetiredPlayerForJersey({
+      playerId,
+      cachedPlayer: cache.getPlayer(playerId),
+      retiredPlayers: meta?.retiredPlayers,
+      loadPlayer: (idToLoad) => Players.load(idToLoad),
+    });
+  } catch (_) { player = null; }
   if (!player) {
     post(toUI.ERROR, { message: 'Player not found for jersey retirement.' }, id);
     return;
@@ -7429,7 +7432,7 @@ function evaluatePlayerOfferDecision(player, offers = [], liveMeta, memory = {})
       askYears: ask.yearsTotal,
     });
     const score = legacyScore * 55 + (evalResult.score / 100) * 45;
-    if (score > bestScore) {
+    if (score > bestScore || (score === bestScore && (!bestOffer || stableIdCompare(offer?.teamId, bestOffer?.teamId) < 0))) {
       bestScore = score;
       bestOffer = { ...offer, _evaluation: evalResult, _teamContext: teamContext };
     }
@@ -7564,7 +7567,7 @@ async function resolvePendingFreeAgencyOffers({ resolutionDay = 7, onlyPlayerId 
   const freeAgentsWithOffers = cache.getAllPlayers().filter((p) => {
     if (targetPlayerId != null && Number(p?.id) !== targetPlayerId) return false;
     return (isFreeAgent(p)) && Array.isArray(p.offers) && p.offers.length > 0;
-  });
+  }).sort((a, b) => stableIdCompare(a?.id, b?.id));
 
   const results = [];
   const pendingToNotify = [];
@@ -11558,8 +11561,9 @@ function calculateAwards(stats, teams) {
 
 
 function runAiStaffCarousel(meta, teams) {
-  const market = buildStaffMarket(teams, { year: Number(meta?.year ?? 2025), size: 60 });
-  for (const team of teams) {
+  const sortedTeams = (teams || []).slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
+  const market = buildStaffMarket(sortedTeams, { year: Number(meta?.year ?? 2025), size: 60 });
+  for (const team of sortedTeams) {
     const staff = ensureTeamStaff(team, { year: Number(meta?.year ?? 2025) });
     const winPct = ((team?.wins ?? 0) + 0.5 * (team?.ties ?? 0)) / Math.max(1, (team?.wins ?? 0) + (team?.losses ?? 0) + (team?.ties ?? 0));
     const direction = winPct >= 0.62 ? 'contender' : winPct <= 0.42 ? 'rebuild' : 'balanced';
@@ -11569,7 +11573,7 @@ function runAiStaffCarousel(meta, teams) {
       const currentScore = Number(current?.overall ?? 55);
       const stayBias = direction === 'contender' ? 0.8 : direction === 'rebuild' ? 0.58 : 0.68;
       if (current && currentScore >= 75 && Utils.random() < stayBias) continue;
-      const pool = market.filter((m) => m.roleKey === roleKey).sort((a, b) => Number(b?.overall ?? 0) - Number(a?.overall ?? 0));
+      const pool = market.filter((m) => m.roleKey === roleKey).sort((a, b) => (Number(b?.overall ?? 0) - Number(a?.overall ?? 0)) || String(a?.id ?? a?.name ?? '').localeCompare(String(b?.id ?? b?.name ?? '')));
       if (!pool.length) continue;
       const shortlist = pool.slice(0, 12);
       const candidate = shortlist[Math.floor(Utils.random() * Math.max(2, shortlist.length / 2))] ?? shortlist[0];
@@ -11604,7 +11608,7 @@ async function handleAdvanceOffseason(payload, id) {
   }
 
   // ── Step 1: AI processes contract extensions ──────────────────────────────
-  const allTeams = cache.getAllTeams();
+  const allTeams = cache.getAllTeams().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
   for (const team of allTeams) {
     if (team.id !== meta.userTeamId) {
       await AiLogic.processExtensions(team.id);
@@ -11625,7 +11629,7 @@ async function handleAdvanceOffseason(payload, id) {
     const userConf = userTeamObj?.conf ?? null;
 
     // Pre-compute demand snapshots for all expiring players (same as injectAIFaBids)
-    const allPlayers = cache.getAllPlayers();
+    const allPlayers = cache.getAllPlayers().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
     const expiringPlayers = allPlayers.filter((p) => {
       const yrs = Number(p?.contractYearsLeft ?? p?.contract?.yearsRemaining ?? p?.contract?.years ?? 2);
       return yrs <= 1 && p?.teamId != null && Number(p.teamId) !== userTeamId;
@@ -11764,7 +11768,7 @@ async function handleAdvanceOffseason(payload, id) {
   // ── Step 2: Dynamic progression pass ─────────────────────────────────────
   // processPlayerProgression mutates each player's ratings, ovr, and
   // progressionDelta in place.  We then flush those fields to cache.
-  const allPlayers = cache.getAllPlayers();
+  const allPlayers = cache.getAllPlayers().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
   const focusByTeamId = buildTeamDevelopmentFocusMap(meta);
   const playersById = new Map(allPlayers.map((p) => [String(p?.id), p]));
   const attrPlayers = allPlayers.filter((player) => !!player?.attributesV2);
@@ -11995,6 +11999,28 @@ async function handleAdvanceOffseason(payload, id) {
     }
   }
 
+  if (retired.length > 0) {
+    const latestMeta = ensureDynastyMeta(cache.getMeta());
+    const existingRetired = Array.isArray(latestMeta?.retiredPlayers) ? latestMeta.retiredPlayers : [];
+    const existingIds = new Set(existingRetired.map((row) => String(row?.id ?? row?.playerId ?? '')));
+    const retiredRows = retired
+      .filter((row) => row?.id != null && !existingIds.has(String(row.id)))
+      .map((row) => ({
+        id: row.id,
+        playerId: row.id,
+        name: row.name ?? null,
+        pos: row.pos ?? null,
+        age: row.age ?? null,
+        teamId: row.teamId ?? null,
+        jerseyNumber: row.jerseyNumber ?? cache.getPlayer(row.id)?.jerseyNumber ?? null,
+        retirementYear: Number(meta?.year ?? 2025),
+        reason: row.reason ?? null,
+      }));
+    if (retiredRows.length > 0) {
+      cache.setMeta({ retiredPlayers: [...existingRetired, ...retiredRows] });
+    }
+  }
+
   if (hofClass.length > 0) {
     const hofMeta = ensureLeagueMemoryMeta(cache.getMeta());
     const updated = addHallOfFameClass(hofMeta, Number(meta?.year ?? 2025), hofClass);
@@ -12125,8 +12151,8 @@ async function injectAIFaBids(day) {
   const season = Number(meta?.season ?? meta?.year ?? 1);
   const week   = Number(meta?.currentWeek ?? 1);
 
-  const allTeams   = cache.getAllTeams();
-  const allPlayers = cache.getAllPlayers();
+  const allTeams   = cache.getAllTeams().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
+  const allPlayers = cache.getAllPlayers().slice().sort((a, b) => stableIdCompare(a?.id, b?.id));
   const freeAgents = allPlayers.filter((p) => isFreeAgent(p));
   if (freeAgents.length === 0) return;
 
@@ -12204,8 +12230,10 @@ async function injectAIFaBids(day) {
       if (!freshPlayer) continue;
       const existingOffers = Array.isArray(freshPlayer.offers) ? freshPlayer.offers : [];
       const withoutThisTeam = existingOffers.filter((o) => Number(o?.teamId) !== Number(teamId));
+      const deterministicTimestamp = Number(season ?? 0) * 100000 + Number(week ?? 0) * 1000 + Number(teamId ?? 0);
       cache.updatePlayer(player.id, {
-        offers: [...withoutThisTeam, { teamId, teamName: team.name, contract, timestamp: Date.now() }],
+        offers: [...withoutThisTeam, { teamId, teamName: team.name, contract, timestamp: deterministicTimestamp }]
+          .sort((a, b) => stableIdCompare(a?.teamId, b?.teamId)),
       });
     }
   }
@@ -13445,6 +13473,11 @@ async function handleStartNewSeason(payload, id) {
       salaryCap: nextEconomy.currentSalaryCap,
     }),
   });
+
+  await AiLogic.ensureMinimumRosters({
+    includeUserTeam: typeof globalThis !== 'undefined' && !!globalThis.__FOOTBALL_GM_LITE_BATCH_SIM__,
+  });
+  for (const team of cache.getAllTeams()) recalculateTeamCap(team.id);
 
   // ── Update franchise all-time leaders once per season rollover ──────────
   try {

--- a/tests/durability/cli.js
+++ b/tests/durability/cli.js
@@ -20,6 +20,7 @@ Modes (default: 1-season):
 Flags:
   --mode=<mode>        Explicit mode (overrides positional)
   --seed=<n>           Deterministic seed (default 1684)
+  --seeds=<a,b,c>      Run multiple clean seeds and aggregate reports
   --stop-phase=<p>     Bound each season to playoffs|offseason|rollover (default rollover).
                        Use offseason to skip the expensive draft/FA rollover.
   --phase-timeout-ms=<n>  Per-SIM_TO_PHASE timeout. On timeout the run records a
@@ -30,6 +31,7 @@ Flags:
   --summary            Also write the compact summary report
   --out=<path>         Explicit output file for the full report
   --report-name=<name> Stable base filename (e.g. long-save-1-season)
+  --child-run          Internal: execute one isolated run for the parent CLI
   -h, --help           Show this help
 `;
 
@@ -37,10 +39,11 @@ const KNOWN_MODES = ['1-season', '5-season', '10-season', '20-season'];
 
 export function parseArgv(argv) {
   const args = argv.slice(2);
-  const raw = { mode: null, seed: 1684, failureMode: 'fail-fast', determinism: false, writeReport: false, summary: false, out: null, reportName: null, stopPhase: 'rollover', phaseTimeoutMs: null, help: false };
+  const raw = { mode: null, seed: 1684, seeds: null, failureMode: 'fail-fast', determinism: false, writeReport: false, summary: false, out: null, reportName: null, stopPhase: 'rollover', phaseTimeoutMs: null, help: false, childRun: false };
   const errors = [];
   for (const a of args) {
     if (a === '-h' || a === '--help') raw.help = true;
+    else if (a === '--child-run') raw.childRun = true;
     else if (a === '--collect-all') raw.failureMode = 'collect-all';
     else if (a === '--determinism') raw.determinism = true;
     else if (a === '--write-report') raw.writeReport = true;
@@ -49,6 +52,7 @@ export function parseArgv(argv) {
     else if (a.startsWith('--stop-phase=')) raw.stopPhase = a.slice(13);
     else if (a.startsWith('--phase-timeout-ms=')) raw.phaseTimeoutMs = Number(a.slice(19));
     else if (a.startsWith('--seed=')) raw.seed = Number(a.slice(7));
+    else if (a.startsWith('--seeds=')) raw.seeds = a.slice(8).split(',').map((v) => v.trim());
     else if (a.startsWith('--out=')) { raw.out = a.slice(6); raw.writeReport = true; }
     else if (a.startsWith('--report-name=')) raw.reportName = a.slice(14);
     else if (KNOWN_MODES.includes(a)) raw.mode = a;
@@ -58,6 +62,11 @@ export function parseArgv(argv) {
   if (!KNOWN_MODES.includes(raw.mode)) errors.push(`Unknown mode: ${raw.mode}`);
   if (!['playoffs', 'offseason', 'rollover'].includes(raw.stopPhase)) errors.push(`Unknown --stop-phase: ${raw.stopPhase}`);
   if (!Number.isFinite(raw.seed)) errors.push('Invalid --seed');
+  if (raw.seeds) {
+    if (raw.seeds.length === 0 || raw.seeds.some((v) => !/^[-]?\d+$/.test(v))) errors.push('Invalid --seeds');
+    raw.seeds = raw.seeds.map((v) => Number(v));
+  }
+  if (raw.seeds && raw.determinism) errors.push('--seeds cannot be combined with --determinism; run determinism with --seed or run multi-seed without --determinism');
   return { raw, errors };
 }
 

--- a/tests/durability/invariants/cap.js
+++ b/tests/durability/invariants/cap.js
@@ -6,9 +6,12 @@
  * calculator already produces, and structural sanity on contracts. Momentary
  * over-cap states (dead money, pending restructures) are explicitly allowed.
  */
-import { pass, fail, skip, isFiniteNumber, isUnsafeNumber } from './helpers.js';
+import { pass, fail, skip, gamePhase, PHASE_GROUPS, isUnsafeNumber } from './helpers.js';
 import { CAP } from './bounds.js';
-import { viewTeams, rosteredPlayersFromView } from './derive.js';
+import { playerPool, rosteredPlayersFromView, viewTeams } from './derive.js';
+import { buildTeamCapSnapshot as buildCanonicalTeamCapSnapshot } from '../../../src/core/contracts/contractObligations.js';
+import { canonicalIdKey, sameEntityId } from '../../../src/core/referenceIntegrity.js';
+import { resolveLiveSalaryCap } from './durableSnapshot.js';
 
 export const id = 'cap';
 
@@ -45,6 +48,19 @@ export function check(ctx) {
     }
   } else {
     out.push(pass(ctx, 'cap.aggregates-finite', `All team cap aggregates finite across ${teams.length} teams`));
+  }
+
+  // ── stable-phase legal cap equation ─────────────────────────────────────
+  if (!isCapLegalCheckpoint(ctx)) {
+    out.push(skip(ctx, 'cap.stable-phase-legal', `Cap legality skipped in transitional phase ${gamePhase(ctx) ?? 'unknown'}`));
+  } else {
+    const snaps = buildLeagueCapSnapshots(ctx);
+    const illegal = snaps.filter((s) => !s.isLegallyCompliant);
+    if (illegal.length) {
+      for (const snap of illegal.slice(0, 12)) out.push(fail(ctx, 'cap.stable-phase-legal', { entityType: 'team', entityId: snap.teamId, message: `Team ${snap.teamId} exceeds live cap by ${snap.overageVsLegal.toFixed(2)}`, details: snap }));
+    } else {
+      out.push(pass(ctx, 'cap.stable-phase-legal', `All ${teams.length} teams legal against live cap`, { snapshots: snaps.slice(0, 2) }));
+    }
   }
 
   // ── contract numeric safety on rostered players ──────────────────────────
@@ -88,4 +104,28 @@ export function check(ctx) {
   }
 
   return out;
+}
+
+export function buildLeagueCapSnapshots(ctx = {}) {
+  const salaryCap = resolveLiveSalaryCap(ctx);
+  const { players } = playerPool(ctx);
+  return authoritativeTeams(ctx).map((team) => {
+    const roster = players.filter((p) => p && p.teamId != null && sameEntityId(p.teamId, team.id) && p.status !== 'retired' && p.status !== 'free_agent');
+    const snap = buildCanonicalTeamCapSnapshot({
+      team, roster, salaryCap, pendingCommitments: pendingCountedCommitments(team, ctx),
+    });
+    return { ...snap, teamId: canonicalIdKey(team.id), liveLimit: snap.legalLimit };
+  });
+}
+export function buildTeamCapSnapshot(team, ctx = {}) {
+  return buildLeagueCapSnapshots({ ...ctx, db: { ...(ctx.db || {}), teams: [team] } })[0];
+}
+function authoritativeTeams(ctx = {}) {
+  return Array.isArray(ctx?.db?.teams) && ctx.db.teams.length ? ctx.db.teams : viewTeams(ctx);
+}
+function pendingCountedCommitments(team) { return typeof team?.pendingCommitments === 'number' ? team.pendingCommitments : (typeof team?.pendingCapCommitments === 'number' ? team.pendingCapCommitments : 0); }
+
+function isCapLegalCheckpoint(ctx) {
+  const phase = gamePhase(ctx);
+  return PHASE_GROUPS.REGULAR.has(phase) || PHASE_GROUPS.PLAYOFFS.has(phase);
 }

--- a/tests/durability/invariants/continuity.js
+++ b/tests/durability/invariants/continuity.js
@@ -1,0 +1,140 @@
+import { fail, pass, skip } from './helpers.js';
+
+export const id = 'continuity';
+
+export function check(ctx) {
+  const cur = ctx?.durableSnapshot;
+  const prev = ctx?.previousDurableSnapshot;
+  if (!cur || !prev) return [skip(ctx, 'continuity.previous-checkpoint-present', 'No previous durable snapshot for continuity comparison')];
+  const out = [];
+  const prevTeams = new Set((prev.teams || []).map((t) => t.id));
+  const curTeams = new Set((cur.teams || []).map((t) => t.id));
+  const missingTeams = [...prevTeams].filter((id) => !curTeams.has(id));
+  const addedTeams = [...curTeams].filter((id) => !prevTeams.has(id));
+  out.push(missingTeams.length || addedTeams.length
+    ? fail(ctx, 'continuity.team-identity-stable', { entityType: 'league', entityId: 'teams', message: 'Team identity set changed between checkpoints', details: { missingTeams, addedTeams } })
+    : pass(ctx, 'continuity.team-identity-stable', `Team identities stable (${curTeams.size})`));
+
+  const active = new Set((cur.players || []).map((p) => p.id));
+  const retired = new Set((cur.retiredPlayers || []).map((p) => p.id));
+  const overlap = [...active].filter((id) => retired.has(id));
+  out.push(overlap.length
+    ? fail(ctx, 'continuity.active-retired-disjoint', { entityType: 'player', entityId: overlap[0], message: 'Player is both active and retired', details: { overlap: overlap.slice(0, 20) } })
+    : pass(ctx, 'continuity.active-retired-disjoint', 'Active and retired populations are disjoint'));
+
+  const prevHistory = prev.history?.length ?? 0;
+  const curHistory = cur.history?.length ?? 0;
+  const historyDelta = curHistory - prevHistory;
+  const completedRollover = ctx?.phase === 'afterSeasonRollover' && prev.league?.phase && prev.league.phase !== cur.league?.phase;
+  const badHistory = completedRollover ? historyDelta !== 1 : (historyDelta < 0 || historyDelta > 1);
+  out.push(badHistory
+    ? fail(ctx, 'continuity.history-grows-once', { entityType: 'history', entityId: 'league', message: completedRollover ? `Completed rollover history changed by ${historyDelta}; expected exactly 1` : `Completed history changed by ${historyDelta}`, details: { prevHistory, curHistory, completedRollover } })
+    : pass(ctx, 'continuity.history-grows-once', completedRollover ? 'Completed rollover added exactly one history row' : `History growth bounded (${historyDelta})`));
+
+  const gameSeason = new Map();
+  const reused = [];
+  for (const g of [...(prev.schedule || []), ...(cur.schedule || [])]) {
+    if (!g.id || g.season == null) continue;
+    if (gameSeason.has(g.id) && gameSeason.get(g.id) !== g.season) reused.push(g.id);
+    gameSeason.set(g.id, g.season);
+  }
+  out.push(reused.length
+    ? fail(ctx, 'continuity.schedule-game-id-season-unique', { entityType: 'game', entityId: reused[0], message: 'Schedule game id reused across seasons', details: { reused: reused.slice(0, 20) } })
+    : pass(ctx, 'continuity.schedule-game-id-season-unique', 'Schedule game ids are not reused across seasons in checkpoint'));
+
+  const transition = `${prev.league?.phase ?? 'unknown'} -> ${cur.league?.phase ?? 'unknown'}`;
+  if (cur.pools?.source && cur.pools.source !== 'db') {
+    out.push(skip(ctx, 'continuity.players-do-not-disappear', `Full DB player pool unavailable at current checkpoint; roster-only view cannot prove dispositions (${transition})`, { source: cur.pools.source }));
+  } else {
+    const curAllIds = new Set([...(cur.players || []).map((p) => p.id), ...(cur.retiredPlayers || []).map((p) => p.id)]);
+    const curRetiredIds = new Set((cur.retiredPlayers || []).map((p) => p.id));
+    const disappeared = (prev.players || []).filter((p) => !curAllIds.has(p.id) && !hasLegitimateDisposition(ctx, p, curRetiredIds));
+    out.push(disappeared.length
+      ? fail(ctx, 'continuity.players-do-not-disappear', { entityType: 'player', entityId: disappeared[0].id, message: 'Established player disappeared without retirement, draft-pool, free-agency, release, or removal disposition evidence', details: { disappeared: disappeared.slice(0, 20).map((p) => ({ id: p.id, status: p.status })), transition } })
+      : pass(ctx, 'continuity.players-do-not-disappear', 'No established players disappeared without disposition evidence'));
+  }
+
+  const curById = new Map((cur.players || []).map((p) => [p.id, p]));
+  const yearsIncreased = [];
+  for (const p of prev.players || []) {
+    const next = curById.get(p.id);
+    if (!next) continue;
+    if (Number(next.yearsRemaining ?? 0) > Number(p.yearsRemaining ?? 0)) {
+      if (!hasLegitimateContractTransition(ctx, p, next)) yearsIncreased.push({ id: p.id, before: p.yearsRemaining, after: next.yearsRemaining, beforeTotal: p.yearsTotal, afterTotal: next.yearsTotal });
+    }
+  }
+  out.push(yearsIncreased.length
+    ? fail(ctx, 'continuity.contract-years-do-not-increase-without-contract-write', { entityType: 'player', entityId: yearsIncreased[0].id, message: 'Contract years increased without a signing/extension/restructure-shaped contract write', details: { yearsIncreased: yearsIncreased.slice(0, 20) } })
+    : pass(ctx, 'continuity.contract-years-do-not-increase-without-contract-write', 'No contract years increased without a contract-write shape'));
+
+  return out;
+}
+
+function hasLegitimateDisposition(ctx, player, curRetiredIds) {
+  if (!player?.id) return true;
+  if (player.status === 'draft_eligible') return true;
+  if (curRetiredIds.has(player.id)) return true;
+  return hasPlayerEvent(ctx, player.id, ['retire', 'retirement', 'retired', 'release', 'released', 'waive', 'waived', 'free_agent', 'free agency', 'removed', 'delete', 'disposition']);
+}
+
+function hasLegitimateContractTransition(ctx, prev, cur) {
+  if (hasPlayerEvent(ctx, prev.id, ['sign', 'signed', 'extension', 'extend', 'extended', 'restructure', 'restructured', 'contract'])) return true;
+  const wasUnsigned = Number(prev.yearsRemaining ?? 0) <= 0 || prev.teamId == null || prev.status === 'free_agent';
+  const isRostered = cur.teamId != null && cur.status !== 'free_agent' && cur.status !== 'retired';
+  if (wasUnsigned && isRostered && Number(cur.yearsRemaining ?? 0) > 0) return true;
+  return false;
+}
+
+function hasPlayerEvent(ctx, playerId, words) {
+  const txs = transitionTransactions(ctx);
+  const id = String(playerId);
+  return txs.some((tx) => {
+    if (!transactionReferencesPlayer(tx, id)) return false;
+    const text = JSON.stringify(tx).toLowerCase();
+    return words.some((w) => text.includes(w));
+  });
+}
+
+function currentTransactions(ctx) {
+  return [
+    ...(Array.isArray(ctx?.probes?.transactions) ? ctx.probes.transactions : []),
+    ...(Array.isArray(ctx?.transactions) ? ctx.transactions : []),
+    ...(Array.isArray(ctx?.durableSnapshot?.transactions) ? ctx.durableSnapshot.transactions : []),
+  ];
+}
+
+function priorTransactions(ctx) {
+  return [
+    ...(Array.isArray(ctx?.previousTransactions) ? ctx.previousTransactions : []),
+    ...(Array.isArray(ctx?.previousDurableSnapshot?.transactions) ? ctx.previousDurableSnapshot.transactions : []),
+  ];
+}
+
+function txIdentity(tx = {}) {
+  if (tx?.id != null) return `id:${tx.id}`;
+  return JSON.stringify({
+    type: tx?.type,
+    seasonId: tx?.seasonId,
+    season: tx?.season,
+    week: tx?.week,
+    teamId: tx?.teamId,
+    playerId: tx?.playerId ?? tx?.details?.playerId,
+    source: tx?.details?.source,
+  });
+}
+
+function transitionTransactions(ctx) {
+  const prior = new Set(priorTransactions(ctx).map(txIdentity));
+  return currentTransactions(ctx).filter((tx) => !prior.has(txIdentity(tx)));
+}
+
+function transactionReferencesPlayer(tx = {}, playerId) {
+  const ids = [
+    tx?.playerId,
+    tx?.player_id,
+    tx?.details?.playerId,
+    tx?.details?.player_id,
+    tx?.details?.player?.id,
+  ].filter((v) => v != null).map(String);
+  return ids.includes(String(playerId));
+}

--- a/tests/durability/invariants/durableSnapshot.js
+++ b/tests/durability/invariants/durableSnapshot.js
@@ -1,0 +1,131 @@
+import { createHash } from 'node:crypto';
+import { canonicalIdKey, resolveTeamRefId, stableIdCompare } from '../../../src/core/referenceIntegrity.js';
+import { getActiveCapHit, normalizeContract } from '../../../src/core/contracts/contractObligations.js';
+import { activePlayersFromPool, draftPicks, freeAgentsFromPool, leagueHistory, playerPool, viewTeams } from './derive.js';
+
+export const DURABLE_SNAPSHOT_VERSION = '2.0.0';
+const money = (v) => (typeof v === 'number' && Number.isFinite(v) ? Math.round(v * 1000) / 1000 : v ?? null);
+const idKey = (v) => canonicalIdKey(v) ?? null;
+const byId = (a, b) => stableIdCompare(a?.id ?? a?.playerId ?? a?.gameId, b?.id ?? b?.playerId ?? b?.gameId);
+
+export function buildDurableSnapshot(state = {}) {
+  const view = state.view ?? {};
+  const ctx = { ...state, view };
+  const teams = authoritativeTeams(ctx);
+  const { players, source: playerSource } = playerPool(ctx);
+  const retired = mergeRetiredPlayers(
+    players.filter((p) => p?.status === 'retired' || p?.retired === true || p?.retirementYear != null),
+    view.retiredPlayers,
+    state.db?.meta?.retiredPlayers,
+  );
+  const active = players.filter((p) => p && p.status !== 'retired' && p.retired !== true);
+  const picks = draftPicks(ctx).picks;
+  const history = leagueHistory(ctx);
+  return sortObject({
+    version: DURABLE_SNAPSHOT_VERSION,
+    league: {
+      season: state.season ?? null,
+      year: view.year ?? state.db?.meta?.year ?? null,
+      week: view.week ?? null,
+      phase: view.phase ?? null,
+      seasonId: view.seasonId ?? state.db?.meta?.seasonId ?? null,
+      userTeamId: idKey(view.userTeamId ?? state.db?.meta?.userTeamId),
+      salaryCap: money(resolveLiveSalaryCap(state)),
+    },
+    teams: teams.map((t) => ({
+      id: idKey(t.id), wins: t.wins ?? 0, losses: t.losses ?? 0, ties: t.ties ?? 0,
+      roster: (Array.isArray(t.roster) ? t.roster.map((p) => idKey(p?.id)) : []).sort(stableIdCompare),
+      deadCap: money(t.deadCap ?? t.deadMoney ?? t.currentDeadCap ?? 0), deferredDeadCap: money(t.deferredDeadCap ?? t.deferredDeadMoney ?? 0),
+      capUsed: money(t.capUsed), capRoom: money(t.capRoom), capTotal: money(t.capTotal),
+    })).sort(byId),
+    players: active.map((p) => ({
+      id: idKey(p.id), teamId: p.teamId == null ? null : idKey(p.teamId), status: p.status ?? null, age: p.age ?? null,
+      ovr: p.ovr ?? p.overall ?? null, pot: p.pot ?? p.potential ?? null,
+      injury: normalizeInjury(p), ...normalizeContractFields(p),
+    })).sort(byId),
+    retiredPlayers: retired.map((p) => ({ id: idKey(p.id), retirementYear: p.retirementYear ?? p.retiredYear ?? null })).sort(byId),
+    draftPicks: picks.map((pk) => ({ id: idKey(pk.id), season: pk.season ?? pk.year ?? null, round: pk.round ?? null, originalOwner: idKey(pk.originalOwner ?? pk.originalTeamId), currentOwner: idKey(pk.currentOwner ?? pk.teamId ?? pk.owner) })).sort(byId),
+    schedule: normalizeSchedule(view.schedule ?? state.db?.schedule),
+    history: history.map((h) => ({ season: h.season ?? h.year ?? null, year: h.year ?? null, champion: resolveTeamRefId(h.championTeamId ?? h.championId ?? h.champion), runnerUp: resolveTeamRefId(h.runnerUpTeamId ?? h.runnerUpId ?? h.runnerUp) })).sort((a,b) => (a.season ?? 0) - (b.season ?? 0)),
+    pools: { source: playerSource, active: active.length, rostered: activePlayersFromPool(players).length, freeAgent: freeAgentsFromPool(players).length, retired: retired.length },
+  });
+}
+
+export function durableDigest(snapshot) {
+  return createHash('sha256').update(JSON.stringify(snapshot)).digest('hex');
+}
+
+export function compareDurableSnapshots(a, b, limit = 20) {
+  const diffs = [];
+  walk(a, b, '', diffs, limit);
+  return { ok: diffs.length === 0, firstDivergence: diffs[0] ?? null, diffs };
+}
+
+function walk(a, b, path, out, limit) {
+  if (out.length >= limit) return;
+  if (JSON.stringify(a) === JSON.stringify(b)) return;
+  if (Array.isArray(a) && Array.isArray(b) && (a.some(hasStableEntityId) || b.some(hasStableEntityId))) {
+    const aGroups = groupEntityOccurrences(a);
+    const bGroups = groupEntityOccurrences(b);
+    const keys = [...new Set([...aGroups.keys(), ...bGroups.keys()])].sort(stableIdCompare);
+    for (const key of keys) {
+      const left = aGroups.get(key) || [];
+      const right = bGroups.get(key) || [];
+      const count = Math.max(left.length, right.length);
+      for (let i = 0; i < count; i += 1) walk(left[i], right[i], `${path}{${key}}[${i}]`, out, limit);
+    }
+    return;
+  }
+  if (!a || !b || typeof a !== 'object' || typeof b !== 'object') { out.push(toDiff(path, a, b)); return; }
+  const keys = [...new Set([...Object.keys(a), ...Object.keys(b)])].sort();
+  for (const k of keys) walk(a[k], b[k], path ? `${path}.${k}` : k, out, limit);
+}
+function toDiff(path, a, b) {
+  const parts = path.split('.');
+  return { domain: parts[0]?.replace(/\{.*$/, '') ?? 'state', entityId: entityFromPath(path), field: parts.at(-1)?.replace(/.*}/, '') ?? path, path, runA: a, runB: b };
+}
+function hasStableEntityId(v) { return v && typeof v === 'object' && (v.id != null || v.playerId != null || v.gameId != null); }
+function entityKey(v) { return canonicalIdKey(v?.id ?? v?.playerId ?? v?.gameId); }
+function entityFromPath(path) { const m = String(path).match(/\{([^}]+)}/); return m ? m[1] : null; }
+function groupEntityOccurrences(list) {
+  const groups = new Map();
+  for (const v of list || []) {
+    if (!hasStableEntityId(v)) continue;
+    const key = entityKey(v);
+    if (!key) continue;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(v);
+  }
+  for (const values of groups.values()) values.sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+  return groups;
+}
+function normalizeInjury(p) { const i = p.injury ?? {}; return { status: p.injuryStatus ?? i.status ?? null, weeks: i.weeks ?? p.injuryWeeks ?? null, available: p.available ?? p.isAvailable ?? null }; }
+function normalizeSchedule(schedule) {
+  const games = Array.isArray(schedule?.games) ? schedule.games : (Array.isArray(schedule?.weeks) ? schedule.weeks.flatMap((w) => (w.games || []).map((g) => ({ ...g, week: g.week ?? w.week }))) : []);
+  return games.map((g) => ({ id: idKey(g.id ?? g.gameId), season: g.seasonId ?? g.season ?? g.year ?? null, week: g.week ?? null, home: idKey(g.home ?? g.homeTeamId), away: idKey(g.away ?? g.awayTeamId), played: !!(g.played ?? g.final), final: !!(g.final ?? g.completed), homeScore: (g.played || g.final) ? (g.homeScore ?? null) : null, awayScore: (g.played || g.final) ? (g.awayScore ?? null) : null })).sort(byId);
+}
+export function resolveLiveSalaryCap(state = {}) { return state.view?.economy?.currentSalaryCap ?? state.db?.meta?.economy?.currentSalaryCap ?? state.view?.salaryCap ?? state.db?.meta?.salaryCap ?? state.view?.teams?.[0]?.capTotal ?? null; }
+function sortObject(v) { if (Array.isArray(v)) return v.map(sortObject); if (!v || typeof v !== 'object') return v; return Object.fromEntries(Object.keys(v).sort().map((k) => [k, sortObject(v[k])])); }
+
+function normalizeContractFields(p) {
+  const c = normalizeContract(p);
+  return { yearsRemaining: c.yearsRemaining, yearsTotal: c.yearsTotal, baseAnnual: money(c.baseAnnual), signingBonus: money(c.signingBonus), activeCapHit: money(getActiveCapHit(p)) };
+}
+function authoritativeTeams(ctx = {}) {
+  const dbTeams = Array.isArray(ctx?.db?.teams) && ctx.db.teams.length ? ctx.db.teams : null;
+  if (!dbTeams) return viewTeams(ctx);
+  const viewById = new Map(viewTeams(ctx).map((t) => [canonicalIdKey(t.id), t]));
+  return dbTeams.map((team) => ({ ...(viewById.get(canonicalIdKey(team.id)) || {}), ...team }));
+}
+function mergeRetiredPlayers(...lists) {
+  const byId = new Map();
+  for (const list of lists) {
+    if (!Array.isArray(list)) continue;
+    for (const p of list) {
+      const id = idKey(p?.id ?? p?.playerId);
+      if (!id) continue;
+      if (!byId.has(id)) byId.set(id, { ...p, id });
+    }
+  }
+  return [...byId.values()];
+}

--- a/tests/durability/invariants/index.js
+++ b/tests/durability/invariants/index.js
@@ -19,6 +19,7 @@ import * as history from './history.js';
 import * as references from './references.js';
 import * as numericSafety from './numericSafety.js';
 import * as saveReload from './saveReload.js';
+import * as continuity from './continuity.js';
 
 export const INVARIANT_MODULES = [
   roster,
@@ -32,6 +33,7 @@ export const INVARIANT_MODULES = [
   references,
   numericSafety,
   saveReload,
+  continuity,
 ];
 
 /**
@@ -70,4 +72,4 @@ export function runInvariants(ctx) {
   return results;
 }
 
-export { roster, cap, draft, freeAgency, schedule, progression, retirement, history, references, numericSafety, saveReload };
+export { roster, cap, draft, freeAgency, schedule, progression, retirement, history, references, numericSafety, saveReload, continuity };

--- a/tests/durability/invariants/saveReload.js
+++ b/tests/durability/invariants/saveReload.js
@@ -18,6 +18,7 @@
  */
 import { pass, fail, skip } from './helpers.js';
 import { canonicalIdKey, stableIdCompare } from '../../../src/core/referenceIntegrity.js';
+import { buildDurableSnapshot, compareDurableSnapshots, durableDigest } from './durableSnapshot.js';
 
 export const id = 'saveReload';
 
@@ -26,6 +27,8 @@ export const id = 'saveReload';
  * ({ view, db }). Pure — safe to call before save and after reload.
  */
 export function canonicalSummary(state) {
+  const durableSnapshot = buildDurableSnapshot(state);
+  const durableSnapshotDigest = durableDigest(durableSnapshot);
   const view = state?.view ?? {};
   const db = state?.db ?? null;
   const teams = Array.isArray(view.teams) ? view.teams : [];
@@ -69,6 +72,9 @@ export function canonicalSummary(state) {
     capFingerprint,
     rosterFingerprint,
     pickOwnership,
+    durableSnapshotVersion: durableSnapshot.version,
+    durableSnapshotDigest,
+    durableSnapshot,
   };
 }
 
@@ -76,6 +82,7 @@ const EXACT_FIELDS = [
   'year', 'week', 'phase', 'teamCount', 'playerPoolSize', 'freeAgentCount',
   'completedSeasonCount', 'championTeamId', 'userTeamId',
   'capFingerprint', 'rosterFingerprint', 'pickOwnership',
+  'durableSnapshotDigest',
 ];
 
 /**
@@ -94,6 +101,10 @@ export function compareCanonical(before, after) {
       const m = { field: f, before: truncate(a), after: truncate(b) };
       if (f === 'rosterFingerprint') {
         m.diagnostic = classifyRosterFingerprintDiff(String(a), String(b));
+      }
+      if (f === 'durableSnapshotDigest') {
+        const diff = compareDurableSnapshots(before?.durableSnapshot, after?.durableSnapshot);
+        m.diagnostic = { classification: 'durable-state', firstDivergence: diff.firstDivergence, diffs: diff.diffs.slice(0, 8) };
       }
       mismatches.push(m);
     }

--- a/tests/durability/lifecycleDriver.js
+++ b/tests/durability/lifecycleDriver.js
@@ -22,7 +22,8 @@
  * real DB layer (src/db/index.js) after SAVE_NOW.
  */
 import { toWorker, toUI } from '../../src/worker/protocol.js';
-import { Players, Teams, DraftPicks, Meta, Seasons } from '../../src/db/index.js';
+import { Players, Teams, DraftPicks, Meta, Seasons, clearAllData, deleteLeagueDB } from '../../src/db/index.js';
+import { Utils } from '../../src/core/utils.js';
 import { dispatchWorker as defaultDispatch, loadWorkerModule as defaultLoad } from '../../src/testSupport/dynastySoakRunner.js';
 
 export const DEFAULT_SEED = 1684;
@@ -76,6 +77,8 @@ export class LifecycleDriver {
     globalThis.__DYNASTY_SOAK_PROFILE__ = true;
     globalThis.__DYNASTY_SOAK_AUDIT_CHECKPOINT_ENABLED__ = false;
 
+    await resetDurabilityStorage(SLOT_KEY);
+    Utils.setSeed(this.seed);
     await this.loadWorker();
     const t = Date.now();
     await this.dispatch(toWorker.INIT, {}, { timeoutMs: Math.min(120_000, this.phaseTimeoutMs) });
@@ -174,6 +177,7 @@ export class LifecycleDriver {
       }
     };
     await tryGet(toWorker.GET_ALL_SEASONS, {}, 'allSeasons', (p) => p);
+    await tryGet(toWorker.GET_TRANSACTIONS, { limit: 5000, mode: 'recent' }, 'transactions', (p) => p?.transactions ?? p);
     await tryGet(toWorker.GET_DRAFT_CLASSES, {}, 'draftClasses', (p) => p);
     await tryGet(toWorker.GET_RECORDS, {}, 'records', (p) => p);
     return probes;
@@ -217,4 +221,9 @@ export function crashError(checkpoint, message, msg) {
   e.checkpoint = checkpoint;
   e.workerPayload = msg?.payload ?? null;
   return e;
+}
+
+export async function resetDurabilityStorage(slotKey = SLOT_KEY) {
+  try { await clearAllData(); } catch {}
+  try { await deleteLeagueDB(slotKey); } catch {}
 }

--- a/tests/durability/longSaveHarness.js
+++ b/tests/durability/longSaveHarness.js
@@ -15,6 +15,7 @@
 import { LifecycleDriver, CHECKPOINTS, EXPECTED_TEAM_COUNT } from './lifecycleDriver.js';
 import { runInvariants } from './invariants/index.js';
 import { canonicalSummary, compareCanonical } from './invariants/saveReload.js';
+import { compareDurableSnapshots } from './invariants/durableSnapshot.js';
 import { DurabilityReport } from './report.js';
 
 export const MODES = Object.freeze({
@@ -77,10 +78,22 @@ export async function runDurabilityHarness(config = {}) {
   let competitiveSeasonsCompleted = 0;
   let completedThrough = CHECKPOINTS.AFTER_INIT;
 
+  let previousDurableSnapshot = null;
+  let previousTransactions = [];
+  let lastCheckpointAt = Date.now();
   const evaluate = (ctx) => {
     sampleMem();
+    const snap = canonicalSummary({ view: ctx.view, db: ctx.db, season: ctx.season });
+    ctx.durableSnapshot = snap.durableSnapshot;
+    ctx.durableSnapshotDigest = snap.durableSnapshotDigest;
+    ctx.previousDurableSnapshot = previousDurableSnapshot;
+    ctx.previousTransactions = previousTransactions;
     const results = runInvariants(ctx);
-    const counts = report.addCheckpoint({ season: ctx.season, phase: ctx.phase, week: ctx.week, results });
+    const now = Date.now();
+    const counts = report.addCheckpoint({ season: ctx.season, phase: ctx.phase, week: ctx.week, results, durable: { digest: ctx.durableSnapshotDigest, summary: summarizeSnapshot(ctx.durableSnapshot), snapshot: ctx.durableSnapshot }, metrics: { elapsedSincePreviousMs: now - lastCheckpointAt, rssMb: currentRssMb() } });
+    lastCheckpointAt = now;
+    previousDurableSnapshot = ctx.durableSnapshot;
+    if (Array.isArray(ctx?.probes?.transactions)) previousTransactions = ctx.probes.transactions;
     onEvent({ type: 'checkpoint', season: ctx.season, phase: ctx.phase, counts });
     if (failureMode === 'fail-fast' && counts.fail > 0) {
       throw new StopHarness(`fail-fast: ${counts.fail} invariant failure(s) at season ${ctx.season} ${ctx.phase}`);
@@ -208,22 +221,20 @@ export async function runDurabilityHarness(config = {}) {
 export async function runDeterminismCheck(config = {}) {
   const a = await runDurabilityHarness({ ...config, _determinismRun: 'A' });
   const b = await runDurabilityHarness({ ...config, _determinismRun: 'B' });
-  const na = normalizeOutcome(a.toJSON());
-  const nb = normalizeOutcome(b.toJSON());
-  const diffs = [];
-  for (const k of Object.keys(na)) {
-    if (JSON.stringify(na[k]) !== JSON.stringify(nb[k])) diffs.push({ field: k, a: na[k], b: nb[k] });
-  }
-  const deterministic = diffs.length === 0;
-  return {
-    deterministic,
-    detail: deterministic
-      ? 'Normalized outcome identical across two clean runs'
-      : `Normalized outcome differs in: ${diffs.map((d) => d.field).join(', ')}`,
-    diffs,
-    reports: [a, b],
-  };
+  return { ...compareReportDeterminism(a.report, b.report), reports: [a, b] };
 }
+
+export function compareReportDeterminism(reportA, reportB) {
+  const na = normalizeOutcome(stripSnapshotsForOutcome(reportA));
+  const nb = normalizeOutcome(stripSnapshotsForOutcome(reportB));
+  const diffs = [];
+  for (const k of Object.keys(na)) if (JSON.stringify(na[k]) !== JSON.stringify(nb[k])) diffs.push({ field: k, a: na[k], b: nb[k] });
+  const state = compareReportSnapshots(reportA, reportB);
+  const lifecycleDeterministic = diffs.length === 0;
+  const stateDeterministic = state.ok;
+  return { deterministic: lifecycleDeterministic && stateDeterministic, lifecycleDeterministic, stateDeterministic, firstDivergence: state.firstDivergence, detail: lifecycleDeterministic && stateDeterministic ? 'Lifecycle outcome and canonical durable state identical across two clean runs' : `Lifecycle deterministic=${lifecycleDeterministic}; state deterministic=${stateDeterministic}`, diffs: [...diffs, ...state.diffs] };
+}
+function stripSnapshotsForOutcome(r) { return { ...r, checkpoints: (r.checkpoints || []).map((c) => ({ ...c, durable: c.durable ? { digest: c.durable.digest } : null })) }; }
 
 function normalizeOutcome(r) {
   return {
@@ -246,4 +257,25 @@ function unexercisedStages(perSeasonStopPhase) {
     return ['draft', 'freeAgency', 'progression', 'retirement', 'historyRollover', 'nextSeasonGeneration'];
   }
   return ['playoffs', 'draft', 'freeAgency', 'progression', 'retirement', 'historyRollover', 'nextSeasonGeneration'];
+}
+
+function currentRssMb() { return typeof process !== 'undefined' && process.memoryUsage ? Math.round(process.memoryUsage().rss / (1024 * 1024)) : null; }
+function summarizeSnapshot(s) {
+  return { league: s?.league, pools: s?.pools, teamCount: s?.teams?.length ?? 0, playerCount: s?.players?.length ?? 0, retiredCount: s?.retiredPlayers?.length ?? 0, pickCount: s?.draftPicks?.length ?? 0, scheduleCount: s?.schedule?.length ?? 0, historyCount: s?.history?.length ?? 0 };
+}
+function compareReportSnapshots(a, b) {
+  const diffs = [];
+  const bByKey = new Map((b.checkpoints || []).map((c) => [`${c.season}:${c.phase}`, c]));
+  for (const ac of a.checkpoints || []) {
+    const key = `${ac.season}:${ac.phase}`;
+    const bc = bByKey.get(key);
+    if (!bc) { diffs.push({ domain: 'checkpoint', entityId: key, field: 'missing', runA: true, runB: false }); break; }
+    if (ac.durable?.digest !== bc.durable?.digest) {
+      const cmp = compareDurableSnapshots(ac.durable?.snapshot, bc.durable?.snapshot);
+      const first = cmp.firstDivergence || { domain: 'checkpoint', entityId: key, field: 'digest', runA: ac.durable?.digest, runB: bc.durable?.digest };
+      first.checkpoint = key;
+      return { ok: false, firstDivergence: first, diffs: cmp.diffs.map((d) => ({ ...d, checkpoint: key })).slice(0, 20) };
+    }
+  }
+  return { ok: diffs.length === 0, firstDivergence: diffs[0] || null, diffs };
 }

--- a/tests/durability/longSaveHarness.test.js
+++ b/tests/durability/longSaveHarness.test.js
@@ -26,6 +26,7 @@ import * as references from './invariants/references.js';
 import * as numericSafety from './invariants/numericSafety.js';
 import * as retirement from './invariants/retirement.js';
 import * as history from './invariants/history.js';
+import * as continuity from './invariants/continuity.js';
 import { canonicalSummary, compareCanonical } from './invariants/saveReload.js';
 import { runInvariants } from './invariants/index.js';
 import { scanNumericCorruption, findDuplicateIds } from './invariants/helpers.js';
@@ -38,7 +39,7 @@ function healthyTeam(id, roster = []) {
   return { id, name: `T${id}`, abbr: `T${id}`, wins: 8, losses: 8, ties: 0, ptsFor: 300, ptsAgainst: 300, capUsed: 200, capRoom: 100, capTotal: 301.2, roster, picks: [] };
 }
 function healthyPlayer(id, teamId) {
-  return { id, name: `P${id}`, pos: 'QB', age: 25, ovr: 75, teamId, status: 'active', contract: { years: 3, salary: 10 }, ratings: { throwPower: 80 } };
+  return { id, name: `P${id}`, pos: 'QB', age: 25, ovr: 75, teamId, status: 'active', capHit: 3, contract: { years: 3, salary: 3 }, ratings: { throwPower: 80 } };
 }
 function healthyViewCtx(overrides = {}) {
   const teams = [];
@@ -154,6 +155,102 @@ describe('invariant checkers — happy path', () => {
     const ctx2 = healthyViewCtx({ phase: 'afterSeasonRollover', season: 3 });
     ctx2.view.leagueHistory = []; // no history despite season 3 → fail
     expect(history.check(ctx2).find((r) => r.id === 'history.season-archive-exists').status).toBe('fail');
+  });
+});
+
+
+
+describe('continuity invariant V2', () => {
+  const baseSnap = () => ({
+    league: { phase: 'offseason_resign' },
+    teams: [{ id: '0' }],
+    players: [{ id: 'p10', status: 'active', yearsRemaining: 1, yearsTotal: 2, baseAnnual: 5, signingBonus: 0, activeCapHit: 5 }],
+    retiredPlayers: [],
+    history: [{ season: 2026 }],
+    schedule: [{ id: 'g1', season: 2026 }],
+  });
+  const ctxFor = (prev, cur, phase = 'afterSeasonRollover') => ({ ...healthyViewCtx({ phase }), durableSnapshot: cur, previousDurableSnapshot: prev });
+
+  it('fails when completed rollover does not add exactly one history row', () => {
+    const prev = baseSnap();
+    const cur = { ...baseSnap(), league: { phase: 'preseason' }, history: prev.history };
+    expect(continuity.check(ctxFor(prev, cur)).find((r) => r.id === 'continuity.history-grows-once').status).toBe('fail');
+    cur.history = [...prev.history, { season: 2027 }];
+    expect(continuity.check(ctxFor(prev, cur)).find((r) => r.id === 'continuity.history-grows-once').status).toBe('pass');
+  });
+
+  it('fails when a game id is reused across prior and current seasons', () => {
+    const prev = baseSnap();
+    const cur = { ...baseSnap(), schedule: [{ id: 'g1', season: 2027 }] };
+    expect(continuity.check(ctxFor(prev, cur, 'afterRegularSeason')).find((r) => r.id === 'continuity.schedule-game-id-season-unique').status).toBe('fail');
+  });
+
+  it('fails when a production game id is reused across different seasonId values', () => {
+    const prev = canonicalSummary({ view: { ...healthyViewCtx().view, schedule: { weeks: [{ week: 1, games: [{ gameId: 'same-game', seasonId: 's1', week: 1, home: 0, away: 1 }] }] } } }).durableSnapshot;
+    const cur = canonicalSummary({ view: { ...healthyViewCtx().view, schedule: { weeks: [{ week: 1, games: [{ gameId: 'same-game', seasonId: 's2', week: 1, home: 0, away: 1 }] }] } } }).durableSnapshot;
+    expect(continuity.check(ctxFor(prev, cur, 'afterRegularSeason')).find((r) => r.id === 'continuity.schedule-game-id-season-unique').status).toBe('fail');
+  });
+
+  it('fails when contract years increase without in-window contract-write evidence even if salary also changes', () => {
+    const prev = baseSnap();
+    const cur = { ...baseSnap(), players: [{ ...prev.players[0], yearsRemaining: 2 }] };
+    expect(continuity.check(ctxFor(prev, cur, 'afterRegularSeason')).find((r) => r.id === 'continuity.contract-years-do-not-increase-without-contract-write').status).toBe('fail');
+    cur.players[0].baseAnnual = 7;
+    expect(continuity.check(ctxFor(prev, cur, 'afterRegularSeason')).find((r) => r.id === 'continuity.contract-years-do-not-increase-without-contract-write').status).toBe('fail');
+    cur.players[0].yearsTotal = 4;
+    expect(continuity.check(ctxFor(prev, cur, 'afterRegularSeason')).find((r) => r.id === 'continuity.contract-years-do-not-increase-without-contract-write').status).toBe('fail');
+  });
+
+  it('passes a contract-year increase with production transaction evidence', () => {
+    const prev = baseSnap();
+    const cur = { ...baseSnap(), players: [{ ...prev.players[0], yearsRemaining: 3, yearsTotal: 3 }] };
+    const ctx = ctxFor(prev, cur, 'afterRegularSeason');
+    ctx.probes = { transactions: [{ type: 'CONTRACT_EXTENSION', playerId: 'p10' }] };
+    expect(continuity.check(ctx).find((r) => r.id === 'continuity.contract-years-do-not-increase-without-contract-write').status).toBe('pass');
+  });
+
+  it('bounds contract-write evidence to the compared checkpoint window', () => {
+    const prev = baseSnap();
+    const cur = { ...baseSnap(), players: [{ ...prev.players[0], yearsRemaining: 3, yearsTotal: 3, baseAnnual: 8 }] };
+    const oldExtension = { id: 'old-extension', type: 'CONTRACT_EXTENSION', playerId: 'p10', season: 2026, week: 2 };
+    const ctx = ctxFor(prev, cur, 'afterRegularSeason');
+    ctx.previousTransactions = [oldExtension];
+    ctx.probes = { transactions: [oldExtension] };
+    expect(continuity.check(ctx).find((r) => r.id === 'continuity.contract-years-do-not-increase-without-contract-write').status).toBe('fail');
+    ctx.probes.transactions = [oldExtension, { id: 'new-extension', type: 'CONTRACT_EXTENSION', playerId: 'p10', season: 2027, week: 1 }];
+    expect(continuity.check(ctx).find((r) => r.id === 'continuity.contract-years-do-not-increase-without-contract-write').status).toBe('pass');
+  });
+
+  it('fails disappearing active players but passes recorded retirement and draft-pool disposition', () => {
+    const prev = baseSnap();
+    let cur = { ...baseSnap(), players: [], retiredPlayers: [] };
+    expect(continuity.check(ctxFor(prev, cur)).find((r) => r.id === 'continuity.players-do-not-disappear').status).toBe('fail');
+    cur = { ...baseSnap(), players: [], retiredPlayers: [{ id: 'p10' }] };
+    expect(continuity.check(ctxFor(prev, cur)).find((r) => r.id === 'continuity.players-do-not-disappear').status).toBe('pass');
+    const draftPrev = { ...baseSnap(), players: [{ id: 'draft1', status: 'draft_eligible' }] };
+    cur = { ...baseSnap(), players: [] };
+    expect(continuity.check(ctxFor(draftPrev, cur)).find((r) => r.id === 'continuity.players-do-not-disappear').status).toBe('pass');
+  });
+
+  it('does not blanket-skip offseason resign to preseason disappearances and accepts release evidence', () => {
+    const prev = baseSnap();
+    const cur = { ...baseSnap(), league: { phase: 'preseason' }, players: [], retiredPlayers: [] };
+    expect(continuity.check(ctxFor(prev, cur)).find((r) => r.id === 'continuity.players-do-not-disappear').status).toBe('fail');
+    const ctx = ctxFor(prev, cur);
+    ctx.probes = { transactions: [{ type: 'PLAYER_RELEASED', playerId: 'p10' }] };
+    expect(continuity.check(ctx).find((r) => r.id === 'continuity.players-do-not-disappear').status).toBe('pass');
+  });
+
+  it('does not let a prior release excuse a later unexplained disappearance', () => {
+    const prev = baseSnap();
+    const cur = { ...baseSnap(), league: { phase: 'preseason' }, players: [], retiredPlayers: [] };
+    const oldRelease = { id: 'old-release', type: 'PLAYER_RELEASED', playerId: 'p10', season: 2026, week: 3 };
+    const ctx = ctxFor(prev, cur);
+    ctx.previousTransactions = [oldRelease];
+    ctx.probes = { transactions: [oldRelease] };
+    expect(continuity.check(ctx).find((r) => r.id === 'continuity.players-do-not-disappear').status).toBe('fail');
+    ctx.probes.transactions = [oldRelease, { id: 'new-release', type: 'PLAYER_RELEASED', playerId: 'p10', season: 2027, week: 1 }];
+    expect(continuity.check(ctx).find((r) => r.id === 'continuity.players-do-not-disappear').status).toBe('pass');
   });
 });
 
@@ -325,4 +422,130 @@ describe('LifecycleDriver.simToPhase target enforcement', () => {
     await expect(driver.simToPhase('playoffs', { checkpoint: 'afterRegularSeason', maxCalls: 2 }))
       .rejects.toMatchObject({ isLifecycleCrash: true, checkpoint: 'afterRegularSeason' });
   });
+});
+
+describe('durable snapshot V2', () => {
+  it('detects identical lifecycle metadata with different roster state as non-deterministic', async () => {
+    const { runDeterminismCheck } = await import('./longSaveHarness.js');
+    let run = 0;
+    const dispatch = async (type) => {
+      if (type === 'INIT') return { type: 'OK', payload: { ok: true } };
+      const v = healthyViewCtx().view;
+      v.teams[0].roster[0] = healthyPlayer(run < 2 ? 1 : 2, 0);
+      if (type === 'USE_SAFE_STARTER_LEAGUE') { run += 1; return { type: 'OK', payload: v }; }
+      return { type: 'OK', payload: { ...v, phase: 'playoffs' } };
+    };
+    const det = await runDeterminismCheck({ mode: '1-season', perSeasonStopPhase: 'playoffs', failureMode: 'collect-all', driverOverrides: { loadWorker: async () => {}, dispatch, readDbPool: async () => { const v = healthyViewCtx().view; v.teams[0].roster[0] = healthyPlayer(run < 2 ? 1 : 2, 0); return { players: v.teams.flatMap((t) => t.roster), teams: v.teams, meta: null, seasons: [], picks: [] }; } } });
+    expect(det.lifecycleDeterministic).toBe(true);
+    expect(det.stateDeterministic).toBe(false);
+    expect(det.firstDivergence).toMatchObject({ domain: expect.any(String), field: expect.any(String) });
+  });
+
+  it('canonicalizes collection ordering and mixed id aliases but preserves duplicates', async () => {
+    const { buildDurableSnapshot, compareDurableSnapshots } = await import('./invariants/durableSnapshot.js');
+    const a = { season: 1, view: { teams: [healthyTeam(0, [healthyPlayer(2, 0), healthyPlayer('1', 0)])], leagueHistory: [] }, db: { players: [healthyPlayer('1', 0), healthyPlayer(2, 0)], picks: [] } };
+    const b = { season: 1, view: { teams: [healthyTeam('0', [healthyPlayer(1, '0'), healthyPlayer('2', '0')])], leagueHistory: [] }, db: { players: [healthyPlayer(2, '0'), healthyPlayer(1, '0')], picks: [] } };
+    expect(compareDurableSnapshots(buildDurableSnapshot(a), buildDurableSnapshot(b)).ok).toBe(true);
+    b.view.teams[0].roster.push(healthyPlayer(2, '0'));
+    b.db.players.push(healthyPlayer(2, '0'));
+    expect(compareDurableSnapshots(buildDurableSnapshot(a), buildDurableSnapshot(b)).ok).toBe(false);
+  });
+
+  it('preserves duplicate occurrences when a later same-id entity matches', async () => {
+    const { compareDurableSnapshots } = await import('./invariants/durableSnapshot.js');
+    const a = { players: [{ id: 'p1', ovr: 70 }, { id: 'p1', ovr: 80 }] };
+    const b = { players: [{ id: 'p1', ovr: 75 }, { id: 'p1', ovr: 80 }] };
+    const cmp = compareDurableSnapshots(a, b);
+    expect(cmp.ok).toBe(false);
+    expect(cmp.firstDivergence).toMatchObject({ domain: 'players', entityId: 'p1', field: 'ovr' });
+  });
+
+  it('normalizes legacy object-shaped champion and runner-up team references', async () => {
+    const { buildDurableSnapshot, compareDurableSnapshots } = await import('./invariants/durableSnapshot.js');
+    const base = { season: 1, view: { teams: [healthyTeam(0, []), healthyTeam(1, [])], leagueHistory: [{ season: 2026, champion: { id: 0 }, runnerUp: { teamId: 1 } }] }, db: { teams: [{ id: 0 }, { id: 1 }], players: [], picks: [] } };
+    const alias = structuredClone(base);
+    alias.view.leagueHistory[0] = { season: 2026, championTeamId: '0', runnerUpTeamId: '1' };
+    expect(compareDurableSnapshots(buildDurableSnapshot(base), buildDurableSnapshot(alias)).ok).toBe(true);
+    const changed = structuredClone(base);
+    changed.view.leagueHistory[0].champion = { id: 1 };
+    const cmp = compareDurableSnapshots(buildDurableSnapshot(base), buildDurableSnapshot(changed));
+    expect(cmp.ok).toBe(false);
+    expect(cmp.firstDivergence).toMatchObject({ domain: 'history', field: 'champion' });
+  });
+
+  it('save/reload detects contract, dead-cap, injury, ratings, schedule, and history mutations', () => {
+    const base = { season: 1, view: { year: 2027, phase: 'preseason', teams: [healthyTeam(0, [{ ...healthyPlayer(1, 0), capHit: 10, injury: { status: 'out' } }])], schedule: { games: [{ id: 'g1', week: 1, home: 0, away: 1, played: true, homeScore: 3, awayScore: 0 }] }, leagueHistory: [{ season: 2026, championTeamId: 0 }] }, db: { players: [{ ...healthyPlayer(1, 0), capHit: 10, injury: { status: 'out' } }], picks: [] } };
+    for (const mutate of [
+      (s) => { s.db.players[0].contract.years = 9; }, (s) => { s.view.teams[0].deadCap = 99; },
+      (s) => { s.db.players[0].injury.status = 'healthy'; }, (s) => { s.db.players[0].ovr = 12; },
+      (s) => { s.view.schedule.games[0].homeScore = 99; }, (s) => { s.view.leagueHistory[0].championTeamId = 1; },
+    ]) { const changed = structuredClone(base); mutate(changed); expect(compareCanonical(canonicalSummary(base), canonicalSummary(changed)).ok).toBe(false); }
+  });
+
+  it('normalizes production schedule seasonId and preserves legacy season/year fallbacks', () => {
+    const withSeasonId = canonicalSummary({ view: { ...healthyViewCtx().view, schedule: { weeks: [{ week: 1, games: [{ gameId: 'g-prod', seasonId: 's-2031', week: 1, home: 0, away: 1 }] }] } } });
+    const changedSeasonId = canonicalSummary({ view: { ...healthyViewCtx().view, schedule: { weeks: [{ week: 1, games: [{ gameId: 'g-prod', seasonId: 's-2032', week: 1, home: 0, away: 1 }] }] } } });
+    expect(compareCanonical(withSeasonId, changedSeasonId).ok).toBe(false);
+
+    const legacySeason = canonicalSummary({ view: { ...healthyViewCtx().view, schedule: { weeks: [{ week: 1, games: [{ gameId: 'g-legacy', season: 2031, week: 1, home: 0, away: 1 }] }] } } });
+    const legacyYear = canonicalSummary({ view: { ...healthyViewCtx().view, schedule: { weeks: [{ week: 1, games: [{ gameId: 'g-legacy', year: 2031, week: 1, home: 0, away: 1 }] }] } } });
+    expect(compareCanonical(legacySeason, legacyYear).ok).toBe(true);
+  });
+
+  it('stable cap uses live cap, dead cap, team id 0, excludes staff, exact/fractional boundaries, and skips offseason', () => {
+    const ctx = healthyViewCtx();
+    ctx.view.economy = { currentSalaryCap: 200 };
+    ctx.view.teams = [healthyTeam(0, [{ ...healthyPlayer(1, 0), contract: { baseAnnual: 150, signingBonus: 0, yearsTotal: 1, yearsRemaining: 1 } }])];
+    ctx.view.teams[0].deadCap = 50; ctx.view.teams[0].staffPayroll = 999;
+    expect(cap.check(ctx).find((r) => r.id === 'cap.stable-phase-legal').status).toBe('pass');
+    ctx.view.teams[0].deadCap = 50.01;
+    expect(cap.check(ctx).find((r) => r.id === 'cap.stable-phase-legal').status).toBe('fail');
+    ctx.view.phase = 'offseason';
+    expect(cap.check(ctx).find((r) => r.id === 'cap.stable-phase-legal').status).toBe('skip');
+  });
+
+  it('CLI parses multi-seed runs', () => {
+    const { raw, errors } = parseArgv(['node', 's', '5-season', '--seeds=1684,1702,1703']);
+    expect(errors).toEqual([]); expect(raw.seeds).toEqual([1684, 1702, 1703]);
+  });
+
+  it('CLI accepts one seed in --seeds, rejects invalid lists, and rejects determinism combination', () => {
+    expect(parseArgv(['node', 's', '5-season', '--seeds=1702']).raw.seeds).toEqual([1702]);
+    expect(parseArgv(['node', 's', '--seeds=1684,nope']).errors).toContain('Invalid --seeds');
+    expect(parseArgv(['node', 's', '--seeds=1684,', '--determinism']).errors.some((e) => e.includes('--seeds cannot be combined'))).toBe(true);
+  });
+  it('production-shaped cap uses DB dead cap and canonical contract fields', () => {
+    const ctx = healthyViewCtx();
+    ctx.view.economy = { currentSalaryCap: 100 };
+    ctx.view.teams = [healthyTeam(0, [])];
+    ctx.db = {
+      meta: { economy: { currentSalaryCap: 100 } },
+      teams: [{ id: 0, deadCap: 21, staffPayroll: 500 }],
+      players: [
+        { id: 'p100', teamId: 0, status: 'active', contract: { baseAnnual: 70, signingBonus: 30, yearsTotal: 3, yearsRemaining: 2 } },
+      ],
+      picks: [],
+    };
+    const res = cap.check(ctx);
+    const legal = res.find((r) => r.id === 'cap.stable-phase-legal');
+    expect(legal.status).toBe('fail');
+    expect(legal.details).toMatchObject({ teamId: '0', rosterCap: 80, deadCap: 21, totalCommitted: 101, salaryCap: 100, overageVsLegal: 1 });
+  });
+
+  it('structured durable diffs report canonical entity id rather than array index', async () => {
+    const { buildDurableSnapshot, compareDurableSnapshots } = await import('./invariants/durableSnapshot.js');
+    const a = { season: 1, view: { teams: [healthyTeam(0, [])], leagueHistory: [] }, db: { teams: [{ id: 0 }], players: [{ ...healthyPlayer(9001, 0), ovr: 70 }], picks: [] } };
+    const b = structuredClone(a);
+    b.db.players[0].ovr = 71;
+    const cmp = compareDurableSnapshots(buildDurableSnapshot(a), buildDurableSnapshot(b));
+    expect(cmp.firstDivergence).toMatchObject({ domain: 'players', entityId: '9001', field: 'ovr' });
+  });
+
+  it('report passed is false when state determinism fails with zero invariant failures', () => {
+    const rep = new DurabilityReport({ seed: 1, mode: '1-season', failureMode: 'collect-all', requestedSeasons: 1 });
+    rep.addCheckpoint({ season: 0, phase: 'afterInit', week: 0, results: [{ id: 'x.ok', status: 'pass', message: 'ok' }] });
+    rep.setDeterminism(false, 'state differs', { lifecycleDeterministic: true, stateDeterministic: false, firstDivergence: { domain: 'players', entityId: '9', field: 'ovr' } });
+    expect(rep.passed).toBe(false);
+  });
+
 });

--- a/tests/durability/report.js
+++ b/tests/durability/report.js
@@ -6,7 +6,7 @@
  * `toSummaryJSON()` returns a compact form safe to commit for long runs (drops
  * per-result pass/skip noise, keeps failures + per-checkpoint counts).
  */
-export const HARNESS_VERSION = '1.0.0';
+export const HARNESS_VERSION = '2.0.0';
 
 export class DurabilityReport {
   constructor({ seed, mode, failureMode, requestedSeasons, gitSha = null, perSeasonStopPhase = 'rollover' }) {
@@ -27,6 +27,9 @@ export class DurabilityReport {
       runtimeMs: 0,
       peakMemoryMb: 0,
       deterministic: null,
+      lifecycleDeterministic: null,
+      stateDeterministic: null,
+      firstDivergence: null,
       determinismDetail: null,
       firstFailure: null,
       lifecycleException: null,
@@ -40,7 +43,7 @@ export class DurabilityReport {
   }
 
   /** Record a completed checkpoint with its structured invariant results. */
-  addCheckpoint({ season, phase, week, results }) {
+  addCheckpoint({ season, phase, week, results, durable = null, metrics = null }) {
     const counts = { pass: 0, fail: 0, skip: 0 };
     for (const r of results) counts[r.status] = (counts[r.status] || 0) + 1;
     this.report.summary.passed += counts.pass;
@@ -58,7 +61,7 @@ export class DurabilityReport {
         message: firstFail.message,
       };
     }
-    this.report.checkpoints.push({ season, phase, week, summary: counts, results });
+    this.report.checkpoints.push({ season, phase, week, summary: counts, results, durable, metrics });
     return counts;
   }
 
@@ -80,8 +83,11 @@ export class DurabilityReport {
     }
   }
 
-  setDeterminism(deterministic, detail) {
+  setDeterminism(deterministic, detail, extra = {}) {
     this.report.deterministic = deterministic;
+    this.report.lifecycleDeterministic = extra.lifecycleDeterministic ?? deterministic;
+    this.report.stateDeterministic = extra.stateDeterministic ?? deterministic;
+    this.report.firstDivergence = extra.firstDivergence ?? null;
     this.report.determinismDetail = detail;
   }
 
@@ -114,10 +120,13 @@ export class DurabilityReport {
   }
 
   get passed() {
-    return this.report.summary.failed === 0 && !this.report.lifecycleException;
+    const detOk = this.report.deterministic == null || (this.report.lifecycleDeterministic !== false && this.report.stateDeterministic !== false);
+    return this.report.summary.failed === 0 && !this.report.lifecycleException && detOk;
   }
 
-  toJSON() { return this.report; }
+  toRuntimeJSON() { return this.report; }
+
+  toJSON() { return stripRuntimeSnapshots(this.report); }
 
   /** Compact, commit-safe report: strips pass/skip result bodies. */
   toSummaryJSON() {
@@ -128,6 +137,8 @@ export class DurabilityReport {
         phase: c.phase,
         week: c.week,
         summary: c.summary,
+        durable: c.durable ? { digest: c.durable.digest, summary: c.durable.summary } : null,
+        metrics: c.metrics ?? null,
         failures: c.results.filter((r) => r.status === 'fail'),
         skipped: c.results.filter((r) => r.status === 'skip').map((r) => ({ id: r.id, reason: r.message })),
       })),
@@ -173,7 +184,8 @@ export function formatConsole(report) {
   if (r.boundedRun) lines.push(`boundedRun=true completedThrough=${r.completedThrough ?? 'unknown'} unexercised=${(r.unexercisedLifecycleStages || []).join(',')}`);
   lines.push(`runtime=${(r.runtimeMs / 1000).toFixed(1)}s peakMem=${r.peakMemoryMb}MB`);
   lines.push(`invariants: pass=${r.summary.passed} fail=${r.summary.failed} skip=${r.summary.skipped}`);
-  if (r.deterministic != null) lines.push(`deterministic=${r.deterministic} (${r.determinismDetail ?? ''})`);
+  if (r.deterministic != null) lines.push(`deterministic=${r.deterministic} lifecycle=${r.lifecycleDeterministic} state=${r.stateDeterministic} (${r.determinismDetail ?? ''})`);
+  if (r.firstDivergence) lines.push(`FIRST DIVERGENCE: ${r.firstDivergence.checkpoint ?? ''} ${r.firstDivergence.domain}:${r.firstDivergence.entityId}.${r.firstDivergence.field}`);
   if (r.lifecycleException) lines.push(`LIFECYCLE CRASH: ${r.lifecycleException.message} @ ${r.lifecycleException.checkpoint} season ${r.lifecycleException.season}`);
   if (r.firstFailure) {
     lines.push(`FIRST FAILURE: ${r.firstFailure.invariantId} @ season ${r.firstFailure.season} phase ${r.firstFailure.phase}`);
@@ -187,4 +199,14 @@ export function formatConsole(report) {
   if (r.recommendedNextRepairPR) lines.push(`NEXT REPAIR PR: ${r.recommendedNextRepairPR}`);
   lines.push(`─────────────────────────────────────────────────────────────`);
   return lines.join('\n');
+}
+
+function stripRuntimeSnapshots(report) {
+  return {
+    ...report,
+    checkpoints: (report.checkpoints || []).map((c) => ({
+      ...c,
+      durable: c.durable ? { digest: c.durable.digest, summary: c.durable.summary } : null,
+    })),
+  };
 }

--- a/tests/unit/aiCapManagementExecution.test.js
+++ b/tests/unit/aiCapManagementExecution.test.js
@@ -152,6 +152,236 @@ describe('executeAICapManagement — legality & structure', () => {
   });
 });
 
+describe('ensureMinimumRosters — stable rollover legality', () => {
+  it('fills under-minimum AI rosters from existing free agents without touching interactive user teams', async () => {
+    h.state.store = {
+      meta: { userTeamId: 0, difficulty: 'Normal', economy: { currentSalaryCap: LIVE_CAP }, currentSeasonId: 's5', currentWeek: 1, year: 2030 },
+      teams: new Map([
+        [0, { id: 0, abbr: 'USR', capTotal: LIVE_CAP, deadCap: 0, capRoom: 80 }],
+        [31, { id: 31, abbr: 'AI31', capTotal: LIVE_CAP, deadCap: 0, capRoom: 80 }],
+      ]),
+      players: new Map(),
+    };
+    for (let i = 0; i < 52; i++) {
+      h.state.store.players.set(`ai-${i}`, { id: `ai-${i}`, teamId: 31, pos: 'WR', ovr: 60, age: 24, status: 'active', contract: contract(1, 0, 1, 1) });
+      h.state.store.players.set(`usr-${i}`, { id: `usr-${i}`, teamId: 0, pos: 'WR', ovr: 60, age: 24, status: 'active', contract: contract(1, 0, 1, 1) });
+    }
+    h.state.store.players.set('fa-b', { id: 'fa-b', teamId: null, pos: 'CB', ovr: 65, age: 25, status: 'free_agent', contract: contract(1, 0, 1, 1) });
+    h.state.store.players.set('fa-a', { id: 'fa-a', teamId: null, pos: 'CB', ovr: 66, age: 25, status: 'free_agent', contract: contract(1, 0, 1, 1) });
+
+    await AiLogic.ensureMinimumRosters({ includeUserTeam: false });
+
+    expect(h.mockCache.getPlayersByTeam(31)).toHaveLength(53);
+    expect(h.mockCache.getPlayersByTeam(0)).toHaveLength(52);
+    expect(h.state.store.players.get('fa-a').teamId).toBe(31);
+    expect(h.state.txLog.some((tx) => tx.details?.source === 'minimum_roster_reconciliation')).toBe(true);
+  });
+
+  it('recomputes positional needs after each signing and preserves deterministic signing order', async () => {
+    const makeStore = () => ({
+      meta: { userTeamId: 0, economy: { currentSalaryCap: LIVE_CAP }, currentSeasonId: 's5', currentWeek: 1, year: 2030 },
+      teams: new Map([[31, { id: 31, abbr: 'AI31', capTotal: LIVE_CAP, deadCap: 0, capRoom: 90 }]]),
+      players: new Map([
+        ['roster-rb', { id: 'roster-rb', teamId: 31, pos: 'RB', ovr: 60, age: 24, status: 'active', contract: contract(1) }],
+        ['fa-qb-a', { id: 'fa-qb-a', teamId: null, pos: 'QB', ovr: 70, age: 25, status: 'free_agent', contract: contract(1) }],
+        ['fa-qb-b', { id: 'fa-qb-b', teamId: null, pos: 'QB', ovr: 69, age: 25, status: 'free_agent', contract: contract(1) }],
+        ['fa-cb', { id: 'fa-cb', teamId: null, pos: 'CB', ovr: 68, age: 25, status: 'free_agent', contract: contract(1) }],
+      ]),
+    });
+    const needsSpy = vi.spyOn(AiLogic, 'calculateTeamNeeds').mockImplementation((teamId) => {
+      const roster = h.mockCache.getPlayersByTeam(teamId);
+      return {
+        QB: roster.some((player) => player.pos === 'QB') ? 1 : 2.2,
+        CB: roster.some((player) => player.pos === 'CB') ? 1 : 2.1,
+      };
+    });
+    const run = async () => {
+      h.state.store = makeStore();
+      h.state.txLog.length = 0;
+      await AiLogic.ensureMinimumRosters({ includeUserTeam: true, minimum: 3 });
+      return h.state.txLog.map((tx) => tx.playerId ?? tx.details?.playerId);
+    };
+
+    const first = await run();
+    const second = await run();
+
+    expect(first).toEqual(['fa-qb-a', 'fa-cb']);
+    expect(second).toEqual(first);
+    expect(h.mockCache.getPlayersByTeam(31).map((player) => player.pos).sort()).toEqual(['CB', 'QB', 'RB']);
+    needsSpy.mockRestore();
+  });
+
+  it('creates a fresh contract for a released free agent instead of inheriting former-club money or restructure metadata', async () => {
+    h.state.store = {
+      meta: { userTeamId: 0, difficulty: 'Normal', economy: { currentSalaryCap: LIVE_CAP }, currentSeasonId: 's5', currentWeek: 1, year: 2030, phase: 'preseason' },
+      teams: new Map([[31, { id: 31, abbr: 'AI31', capTotal: LIVE_CAP, deadCap: 0, capRoom: 80 }]]),
+      players: new Map(),
+    };
+    for (let i = 0; i < 52; i++) h.state.store.players.set(`ai-${i}`, { id: `ai-${i}`, teamId: 31, pos: 'WR', ovr: 60, age: 24, status: 'active', contract: contract(1, 0, 1, 1) });
+    h.state.store.players.set('released', {
+      id: 'released', teamId: null, pos: 'CB', ovr: 70, potential: 70, age: 26, status: 'free_agent',
+      contract: { ...contract(22, 18, 5, 3), restructureCount: 2, restructureHistory: [{ year: 2029, savings: 5 }], tag: 'franchise' },
+      restructureCount: 2, restructureHistory: [{ year: 2029, savings: 5 }], franchiseTag: true,
+    });
+
+    await AiLogic.ensureMinimumRosters({ includeUserTeam: true });
+
+    const signed = h.state.store.players.get('released');
+    expect(signed.teamId).toBe(31);
+    expect(signed.contract.startYear).toBe(2030);
+    expect(signed.contract.signingBonus).not.toBe(18);
+    expect(signed.contract.baseAnnual).not.toBe(22);
+    expect(signed.contract.yearsRemaining).toBeGreaterThan(0);
+    expect(signed.contract.restructureCount).toBe(0);
+    expect(signed.contract.restructureHistory).toEqual([]);
+    expect(signed.restructureCount).toBe(0);
+    expect(signed.restructureHistory).toEqual([]);
+    expect(signed.franchiseTag).toBeNull();
+  });
+
+  it('gives an expired free agent a valid production-shaped minimum-roster contract', async () => {
+    h.state.store = {
+      meta: { userTeamId: 0, difficulty: 'Normal', economy: { currentSalaryCap: LIVE_CAP }, currentSeasonId: 's5', currentWeek: 1, year: 2030, phase: 'preseason' },
+      teams: new Map([[31, { id: 31, abbr: 'AI31', capTotal: LIVE_CAP, deadCap: 0, capRoom: 80 }]]),
+      players: new Map(),
+    };
+    for (let i = 0; i < 52; i++) h.state.store.players.set(`ai-${i}`, { id: `ai-${i}`, teamId: 31, pos: 'WR', ovr: 60, age: 24, status: 'active', contract: contract(1, 0, 1, 1) });
+    h.state.store.players.set('expired', { id: 'expired', teamId: null, pos: 'S', ovr: 62, potential: 62, age: 29, status: 'free_agent', contract: contract(0, 0, 1, 0) });
+
+    await AiLogic.ensureMinimumRosters({ includeUserTeam: true });
+
+    const signed = h.state.store.players.get('expired');
+    expect(signed.contract.yearsRemaining).toBeGreaterThan(0);
+    expect(signed.contract.yearsTotal).toBeGreaterThan(0);
+    expect(signed.contract.baseAnnual).toBeGreaterThan(0);
+    expect(signed.contract.startYear).toBe(2030);
+  });
+
+  it('never signs invalid null-team categories even when they are the highest-rated players', async () => {
+    h.state.store = {
+      meta: { userTeamId: 0, difficulty: 'Normal', economy: { currentSalaryCap: LIVE_CAP }, currentSeasonId: 's5', currentWeek: 1, year: 2030, phase: 'preseason' },
+      teams: new Map([[31, { id: 31, abbr: 'AI31', capTotal: LIVE_CAP, deadCap: 0, capRoom: 80 }]]),
+      players: new Map(),
+    };
+    for (let i = 0; i < 52; i++) h.state.store.players.set(`ai-${i}`, { id: `ai-${i}`, teamId: 31, pos: 'WR', ovr: 60, age: 24, status: 'active', contract: contract(1, 0, 1, 1) });
+    const prohibited = [
+      { id: 'retired-status', teamId: null, pos: 'CB', ovr: 99, age: 35, status: 'retired', contract: contract(1, 0, 1, 1) },
+      { id: 'retired-flag', teamId: null, pos: 'CB', ovr: 98, age: 35, status: 'free_agent', retired: true, contract: contract(1, 0, 1, 1) },
+      { id: 'draft-eligible', teamId: null, pos: 'CB', ovr: 97, age: 22, status: 'draft_eligible', contract: contract(1, 0, 1, 1) },
+      { id: 'draft-pool', teamId: null, pos: 'CB', ovr: 96, age: 22, status: 'draft_pool', contract: contract(1, 0, 1, 1) },
+      { id: 'deleted', teamId: null, pos: 'CB', ovr: 95, age: 26, status: 'deleted', contract: contract(1, 0, 1, 1) },
+      { id: 'removed', teamId: null, pos: 'CB', ovr: 94, age: 26, status: 'removed', contract: contract(1, 0, 1, 1) },
+      { id: 'inconsistent-active', teamId: null, pos: 'CB', ovr: 93, age: 26, status: 'active', contract: contract(1, 0, 1, 1) },
+    ];
+    for (const p of prohibited) h.state.store.players.set(p.id, p);
+    h.state.store.players.set('valid-fa', { id: 'valid-fa', teamId: null, pos: 'CB', ovr: 65, potential: 65, age: 25, status: 'free_agent', contract: contract(1, 0, 1, 1) });
+
+    await AiLogic.ensureMinimumRosters({ includeUserTeam: true });
+
+    expect(h.state.store.players.get('valid-fa').teamId).toBe(31);
+    for (const p of prohibited) expect(h.state.store.players.get(p.id).teamId).toBeNull();
+  });
+
+  it('leaves player and team state unchanged when projected signing cannot fit under the live cap', async () => {
+    h.state.store = {
+      meta: { userTeamId: 0, difficulty: 'Normal', economy: { currentSalaryCap: 53 }, currentSeasonId: 's5', currentWeek: 1, year: 2030, phase: 'preseason' },
+      teams: new Map([[31, { id: 31, abbr: 'AI31', capTotal: 53, deadCap: 0, capRoom: 1 }]]),
+      players: new Map(),
+    };
+    for (let i = 0; i < 52; i++) h.state.store.players.set(`ai-${i}`, { id: `ai-${i}`, teamId: 31, pos: 'WR', ovr: 60, age: 24, status: 'active', contract: contract(1, 0, 1, 1) });
+    h.state.store.players.set('fa-costly', { id: 'fa-costly', teamId: null, pos: 'QB', ovr: 90, potential: 90, age: 27, status: 'free_agent', contract: contract(30, 10, 4, 4) });
+    const before = JSON.stringify([...h.state.store.teams, ...h.state.store.players]);
+
+    await AiLogic.ensureMinimumRosters({ includeUserTeam: true });
+
+    expect(JSON.stringify([...h.state.store.teams, ...h.state.store.players])).toBe(before);
+    expect(h.state.txLog).toHaveLength(0);
+  });
+
+  it('uses the live economy cap before stale team capTotal when validating projected minimum-roster signings', async () => {
+    h.state.store = {
+      meta: { userTeamId: 0, difficulty: 'Normal', economy: { currentSalaryCap: 53 }, currentSeasonId: 's5', currentWeek: 1, year: 2030, phase: 'preseason' },
+      teams: new Map([[31, { id: 31, abbr: 'AI31', capTotal: 100, deadCap: 0, capRoom: 48 }]]),
+      players: new Map(),
+    };
+    for (let i = 0; i < 52; i++) h.state.store.players.set(`ai-${i}`, { id: `ai-${i}`, teamId: 31, pos: 'WR', ovr: 60, age: 24, status: 'active', contract: contract(1, 0, 1, 1) });
+    h.state.store.players.set('fits-stale-cap', { id: 'fits-stale-cap', teamId: null, pos: 'QB', ovr: 90, potential: 90, age: 27, status: 'free_agent', contract: contract(1, 0, 1, 0) });
+    const before = JSON.stringify([...h.state.store.teams, ...h.state.store.players]);
+
+    await AiLogic.ensureMinimumRosters({ includeUserTeam: true });
+
+    expect(JSON.stringify([...h.state.store.teams, ...h.state.store.players])).toBe(before);
+    expect(h.state.txLog).toHaveLength(0);
+  });
+
+  it('does not record a SIGN and rolls back all durable state when final cap validation fails after mutation', async () => {
+    h.state.store = {
+      meta: { userTeamId: 0, difficulty: 'Normal', economy: { currentSalaryCap: LIVE_CAP }, currentSeasonId: 's5', currentWeek: 1, year: 2030, phase: 'preseason' },
+      teams: new Map([[31, { id: 31, abbr: 'AI31', capTotal: LIVE_CAP, deadCap: 0, capRoom: 80, capUsed: 52 }]]),
+      players: new Map(),
+    };
+    for (let i = 0; i < 52; i++) h.state.store.players.set(`ai-${i}`, { id: `ai-${i}`, teamId: 31, pos: 'WR', ovr: 60, age: 24, status: 'active', contract: contract(1, 0, 1, 1) });
+    h.state.store.players.set('fa-rollback', { id: 'fa-rollback', teamId: null, pos: 'CB', ovr: 65, potential: 65, age: 25, status: 'free_agent', contract: contract(1, 0, 1, 1) });
+    const before = JSON.stringify([...h.state.store.teams, ...h.state.store.players]);
+    const spy = vi.spyOn(AiLogic, 'updateTeamCap').mockReturnValueOnce({ ok: false, error: 'forced failure' });
+
+    await AiLogic.ensureMinimumRosters({ includeUserTeam: true });
+
+    expect(JSON.stringify([...h.state.store.teams, ...h.state.store.players])).toBe(before);
+    expect(h.state.txLog).toHaveLength(0);
+    spy.mockRestore();
+  });
+
+  it('chooses the same minimum-roster signing and contract from differently ordered cache input', async () => {
+    const make = (reverse = false) => {
+      const players = new Map();
+      for (let i = 0; i < 52; i++) players.set(`ai-${i}`, { id: `ai-${i}`, teamId: 31, pos: 'WR', ovr: 60, age: 24, status: 'active', contract: contract(1, 0, 1, 1) });
+      const fas = [
+        ['fa-b', { id: 'fa-b', teamId: null, pos: 'CB', ovr: 66, potential: 66, age: 25, status: 'free_agent', contract: contract(5, 2, 2, 2) }],
+        ['fa-a', { id: 'fa-a', teamId: null, pos: 'CB', ovr: 66, potential: 66, age: 25, status: 'free_agent', contract: contract(20, 9, 3, 3) }],
+      ];
+      for (const [id, p] of (reverse ? fas.reverse() : fas)) players.set(id, p);
+      return {
+        meta: { userTeamId: 0, difficulty: 'Normal', economy: { currentSalaryCap: LIVE_CAP }, currentSeasonId: 's5', currentWeek: 1, year: 2030, phase: 'preseason' },
+        teams: new Map([[31, { id: 31, abbr: 'AI31', capTotal: LIVE_CAP, deadCap: 0, capRoom: 80 }]]),
+        players,
+      };
+    };
+    h.state.store = make(false);
+    await AiLogic.ensureMinimumRosters({ includeUserTeam: true });
+    const first = { tx: h.state.txLog[0], contract: h.state.store.players.get(h.state.txLog[0].playerId).contract };
+    h.state.txLog.length = 0;
+    h.state.store = make(true);
+    await AiLogic.ensureMinimumRosters({ includeUserTeam: true });
+    const second = { tx: h.state.txLog[0], contract: h.state.store.players.get(h.state.txLog[0].playerId).contract };
+    expect(second).toEqual(first);
+  });
+});
+
+describe('free-agency offer evaluation — deterministic ties', () => {
+  it('uses canonical team id as the tie-break when offer scores are equal', () => {
+    h.state.store = {
+      meta: { userTeamId: 0, difficulty: 'Normal', economy: { currentSalaryCap: LIVE_CAP }, currentSeasonId: 's5', currentWeek: 1, year: 2030, phase: 'free_agency' },
+      teams: new Map([
+        [27, { id: 27, abbr: 'T27', wins: 8, losses: 9, capRoom: 50 }],
+        [28, { id: 28, abbr: 'T28', wins: 8, losses: 9, capRoom: 50 }],
+      ]),
+      players: new Map([
+        ['fa', {
+          id: 'fa', teamId: null, pos: 'CB', ovr: 74, potential: 74, age: 26, morale: 68, status: 'free_agent',
+          contract: contract(2, 0, 1, 0),
+          offers: [
+            { teamId: 28, contract: contract(5, 0, 1, 1) },
+            { teamId: 27, contract: contract(5, 0, 1, 1) },
+          ],
+        }],
+      ]),
+    };
+    const decision = AiLogic.evaluateOffers(h.state.store.players.get('fa'), 3);
+    expect(decision.offer.teamId).toBe(27);
+  });
+});
+
 describe('executeAICapManagement — determinism', () => {
   it('produces identical transactions across two identical runs', async () => {
     await AiLogic.executeAICapManagement({ autoManageUserCap: true });

--- a/tests/unit/aiFaEngine.unit.test.js
+++ b/tests/unit/aiFaEngine.unit.test.js
@@ -331,6 +331,32 @@ describe('getAIFaTargets', () => {
       expect(r1.get(10).map((p) => p.id)).toEqual(r2.get(10).map((p) => p.id));
     }
   });
+
+  it('orders teams and same-tier candidates by canonical id to stabilize offer writes', () => {
+    const meta = { userTeamId: 0 };
+    const teamsA = [makeTeam({ id: 17, wins: 8, losses: 8 }), makeTeam({ id: 2, wins: 8, losses: 8 })];
+    const teamsB = [...teamsA].reverse();
+    const playersA = [makePlayer({ id: 'z', ovr: 71 }), makePlayer({ id: 'a', ovr: 71 }), makePlayer({ id: 9, ovr: 71 })];
+    const playersB = [...playersA].reverse();
+    const r1 = getAIFaTargets(teamsA, playersA, meta, 2028, 1);
+    const r2 = getAIFaTargets(teamsB, playersB, meta, 2028, 1);
+    expect([...r1.keys()]).toEqual([2, 17]);
+    expect([...r2.keys()]).toEqual([2, 17]);
+    expect(r1.get(2).map((p) => p.id)).toEqual([9, 'a', 'z']);
+    expect(r2.get(2).map((p) => p.id)).toEqual([9, 'a', 'z']);
+  });
+
+  it('resolves equal-score offers independently of incoming offer order', () => {
+    const player = makePlayer({ id: 9047 });
+    const offers = [
+      { teamId: 30, amount: 8, years: 1 },
+      { teamId: 9, amount: 8, years: 1 },
+      { teamId: 17, amount: 8, years: 1 },
+    ];
+    const a = resolvePlayerChoice(player, offers, { adjustedDemand: 8, season: 2028, week: 1 });
+    const b = resolvePlayerChoice(player, [...offers].reverse(), { adjustedDemand: 8, season: 2028, week: 1 });
+    expect(b.winningOffer.teamId).toBe(a.winningOffer.teamId);
+  });
 });
 
 // ── AI_POSTURE_BID_FACTORS structure ─────────────────────────────────────────

--- a/tests/unit/aiFreeAgencyOrdering.test.js
+++ b/tests/unit/aiFreeAgencyOrdering.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { buildSortedFreeAgentsMapForOffers } from '../../src/core/ai-logic.js';
+
+function fa(id, pos = 'WR', ovr = 70) {
+  return { id, pos, ovr, teamId: null, status: 'free_agent' };
+}
+
+describe('AI free-agency offer pool ordering', () => {
+  it('orders equal-OVR free agents by canonical id so contract writes are deterministic', () => {
+    const a = buildSortedFreeAgentsMapForOffers([fa('10'), fa('2'), fa('1'), fa('9')]);
+    const b = buildSortedFreeAgentsMapForOffers([fa('9'), fa('1'), fa('2'), fa('10')]);
+    expect(a.WR.map((p) => p.id)).toEqual(['1', '2', '9', '10']);
+    expect(b.WR.map((p) => p.id)).toEqual(a.WR.map((p) => p.id));
+  });
+});

--- a/tests/unit/aiRetentionLogic.test.js
+++ b/tests/unit/aiRetentionLogic.test.js
@@ -223,3 +223,20 @@ describe('AI_RETENTION_CONFIG', () => {
     expect(Object.isFrozen(AI_RETENTION_CONFIG.POSITIONAL_VALUE)).toBe(true);
   });
 });
+
+describe('executeAIOffseasonExtensions — deterministic tie ordering', () => {
+  it('produces identical accepted contract order and terms for tied players regardless of roster order', () => {
+    const makeTied = (id) => makePlayer({ id, pos: 'WR', ovr: 80, potential: 80, age: 26, years: 1, baseAnnual: 2, morale: 70, schemeFit: 65 });
+    const a = makeTied('p-tie-10');
+    const b = makeTied('p-tie-2');
+    const teamA = makeTeam({ capRoom: 40, wins: 8, losses: 9 });
+    const teamB = makeTeam({ capRoom: 40, wins: 8, losses: 9 });
+
+    const first = executeAIOffseasonExtensions(teamA, [a, b], { freeAgents: [] })
+      .map((e) => ({ id: e.player.id, contract: e.contract }));
+    const second = executeAIOffseasonExtensions(teamB, [structuredClone(b), structuredClone(a)], { freeAgents: [] })
+      .map((e) => ({ id: e.player.id, contract: e.contract }));
+
+    expect(second).toEqual(first);
+  });
+});


### PR DESCRIPTION
### Motivation

- Improve save/reload determinism by comparing a canonical durable-state snapshot rather than coarse lifecycle metadata. 
- Repair several production race/ordering root causes that caused spurious free-agent signings, retired-player eviction, and stale cap aggregates. 
- Make AI free-agent bidding, retention, roster cuts, and minimum-roster reconciliation deterministic with canonical tie-breaks and production-shaped contract generation. 
- Harden the long-save harness for isolated determinism checks, multi-seed aggregation, and richer durable-state diagnostics.

### Description

- Add a canonical durable snapshot schema (`DURABLE_SNAPSHOT_VERSION = "2.0.0"`) with `buildDurableSnapshot`, `durableDigest`, and `compareDurableSnapshots` plus normalized contract/roster/schedule/history fields and structured diffing that reports canonical entity ids. 
- Introduce continuity and durable-cap invariants (`tests/durability/invariants/continuity.js`, `cap.js` enhancements) that validate schedule id reuse, history growth, active/retired disjointness, and stable-phase cap legality using a production live cap resolver. 
- Make AI and retention logic deterministic by adding `stableIdCompare` tie-breaks across `ai-logic.js`, `aiFaEngine.js`, `aiRosterCuts.js`, `aiRetentionLogic.js`, and by building `buildSortedFreeAgentsMapForOffers`, `buildMinimumRosterContract`, `ensureMinimumRosters`, plus `isSignableFreeAgent` in `membership.js`. 
- Repair retired-player ledger handling and jersey retirement resolution via `resolveRetiredPlayerForJersey` and persist a compact retired-player ledger on retirement inside `worker.js` rollover handling. 
- Ensure minimum-roster reconciliation signs from an explicitly signable pool, recalculates positional needs after every signing, uses live economy cap for projections, creates fresh production-shaped contracts (no inherited restructure metadata), validates pre-commit cap compliance, and rolls back on final-cap failure. 
- Stabilize many ordering/timestamp boundaries: deterministic FA offer timestamps and offer sorting, free-agent/market sorts, staff-carousel tie-breaks, pick/team iteration ordering, and pending-offer ordering to avoid non-deterministic writes. 
- Harden the harness and CLI: `scripts/long-save-durability.mjs` can spawn isolated child runs (via `--seeds`) and capture child JSON reports, the CLI accepts `--seeds` and `--child-run`, determinism comparison is centralized in `longSaveHarness.js` (`compareReportDeterminism`), and the `DurabilityReport` schema now carries lifecycle/state determinism detail. 
- Extensive test additions and updates to reflect the new behaviors and invariants, including unit tests for FA ordering, retention determinism, minimum-roster reconciliation, durable snapshot normalization, and integration tests for jersey resolution.

### Testing

- Ran type/check commands: `node --check src/core/ai-logic.js`, `node --check src/core/retention/reSigning.js`, `node --check tests/durability/invariants/continuity.js`, and `node --check src/worker/worker.js` which all passed. 
- Ran unit and targeted suites: `npx vitest run tests/unit/aiCapManagementExecution.test.js` (1 file / 16 tests) passed, `npx vitest run src/core/__tests__/retention-board.test.js` (1 file / 4 tests) passed, and full unit suite `npm run test:unit` passed (462 files / 5663 tests). 
- Ran durability and build flows: `npm run durability:test` passed (5 files / 83 tests), `npm run build` passed (with existing Vite chunk-size warning), `npm run durability:smoke` completed one full season with save/reload OK, and `npm run durability:5 -- --seed=1684 --determinism --collect-all --write-report --summary` completed both isolated legs with zero invariant failures and save/reload OK but exited nonzero because state determinism remained false. 
- Determinism evidence: five-season determinism run (seed 1684) reported `lifecycleDeterministic=true` and `stateDeterministic=false` with the first durable divergence at checkpoint `2:afterSeasonRollover` in domain `players` entity `5013` field `teamId`, confirming at least one remaining FA/offseason ordering divergence; all harness checks and smoke runs otherwise passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6177cf17cc832dafdd568a37802064)