### PR TITLE
test(e2e): Fix test integrity by removing .catch(() => false)

### DIFF
--- a/tests/e2e/fresh_franchise_first_week_smoke.spec.js
+++ b/tests/e2e/fresh_franchise_first_week_smoke.spec.js
@@ -125,8 +125,11 @@ test('fresh franchise first week smoke', async ({ page, context }) => {
   await advanceBtn.click();
   // In case a soft readiness gate dialog still shows, dismiss it.
   const gateAdvanceBtn = page.getByTestId('gate-advance-anyway-btn');
-  if (await gateAdvanceBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+  try {
+    await gateAdvanceBtn.waitFor({ state: 'visible', timeout: 2000 });
     await gateAdvanceBtn.click();
+  } catch (e) {
+    if (e.name !== 'TimeoutError') throw e;
   }
   // The Simulate (Skip) prompt is REQUIRED in this flow (fresh franchise, the
   // user always has a Week 1 game). Assert it appears and is clickable rather

--- a/tests/e2e/helpers/franchise.js
+++ b/tests/e2e/helpers/franchise.js
@@ -241,15 +241,21 @@ export async function simulateSingleWeek(page, options = {}) {
   // week-advance assertion below guarantees the transition actually happened.
   if (advanceAnyway) {
     const advanceAnywayBtn = page.getByRole('button', { name: /Advance anyway/i });
-    if (await advanceAnywayBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+    try {
+      await advanceAnywayBtn.waitFor({ state: 'visible', timeout: 2000 });
       await expect(advanceAnywayBtn).toBeEnabled({ timeout: 5000 });
       await advanceAnywayBtn.click();
+    } catch (e) {
+      if (e.name !== 'TimeoutError') throw e;
     }
   }
   const skipPromptBtn = page.getByRole('button', { name: /Simulate \(Skip\)/i });
-  if (await skipPromptBtn.isVisible({ timeout: 10000 }).catch(() => false)) {
+  try {
+    await skipPromptBtn.waitFor({ state: 'visible', timeout: 10000 });
     await expect(skipPromptBtn).toBeEnabled({ timeout: 5000 });
     await skipPromptBtn.click();
+  } catch (e) {
+    if (e.name !== 'TimeoutError') throw e;
   }
   await page.waitForFunction(
     (baseline) => {


### PR DESCRIPTION
Replaced silent `catch(() => false)` wrappers that swallowed valid errors in UI test assertions with stricter try/catch statements targeting `TimeoutError` in E2E franchise simulation helpers and smoke tests, enforcing better test integrity.

---
*PR created automatically by Jules for task [9202111540672668339](https://jules.google.com/task/9202111540672668339) started by @rbcati*