### PR TITLE
PR #1718 — Weekly GM Briefing & Game Book Flow V1

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -258,6 +258,8 @@ function AppContent() {
   const [postGameResultStash, setPostGameResultStash] = useState(null);
   // Skip-mode summary shown after advanceWeek({ skipUserGame: true }) completes
   const [skipGameSummary, setSkipGameSummary] = useState(null);
+  const [skipGameSummaryStash, setSkipGameSummaryStash] = useState(null);
+  const [externalDashboardDestination, setExternalDashboardDestination] = useState(null);
   const lastShownSkipWeekRef = useRef(null);
   const [initFlow, setInitFlow] = useState(null);
   const [bootRequestId, setBootRequestId] = useState(null);
@@ -1557,11 +1559,17 @@ function AppContent() {
           notifications={notifications}
           onDismissNotification={actions.dismissNotification}
           externalBoxScoreId={externalBoxScoreId}
+          externalDestination={externalDashboardDestination}
+          onConsumeExternalDestination={() => setExternalDashboardDestination(null)}
           onConsumeExternalBoxScore={() => setExternalBoxScoreId(null)}
           onGameDetailBack={() => {
             if (postGameResultStash) {
               setPostGameResult(postGameResultStash);
               setPostGameResultStash(null);
+            }
+            if (skipGameSummaryStash) {
+              setSkipGameSummary(skipGameSummaryStash);
+              setSkipGameSummaryStash(null);
             }
           }}
           advanceLabel={getAdvanceLabel()}
@@ -1948,7 +1956,18 @@ function AppContent() {
           injuries={skipGameSummary.injuries}
           momentumChange={skipGameSummary.momentumChange}
           onClose={() => setSkipGameSummary(null)}
+          nextWeek={{ week: league?.week }}
+          onPreparationAction={(destination) => {
+            setSkipGameSummaryStash(skipGameSummary);
+            setSkipGameSummary(null);
+            setExternalDashboardDestination(destination);
+          }}
+          onContinue={() => {
+            setSkipGameSummary(null);
+            setExternalDashboardDestination('HQ');
+          }}
           onViewGameBook={skipGameSummary.gameId ? () => {
+            setSkipGameSummaryStash(skipGameSummary);
             setSkipGameSummary(null);
             setExternalBoxScoreId(skipGameSummary.gameId);
           } : undefined}

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -258,8 +258,26 @@ function AppContent() {
   const [postGameResultStash, setPostGameResultStash] = useState(null);
   // Skip-mode summary shown after advanceWeek({ skipUserGame: true }) completes
   const [skipGameSummary, setSkipGameSummary] = useState(null);
-  const [skipGameSummaryStash, setSkipGameSummaryStash] = useState(null);
+  // Only Game Book navigation may retain a briefing. Preparation actions route
+  // honestly to their existing screens and must never leave restorable state.
+  const [gameBookBriefingStash, setGameBookBriefingStash] = useState(null);
   const [externalDashboardDestination, setExternalDashboardDestination] = useState(null);
+  const nextWeekBriefingContext = useMemo(() => {
+    const week = league?.week;
+    const userTeamId = league?.userTeamId;
+    const weekRow = (league?.schedule?.weeks ?? []).find((row) => Number(row?.week) === Number(week));
+    const matchup = (weekRow?.games ?? []).find((game) => {
+      const homeId = game?.home?.id ?? game?.homeId ?? game?.home;
+      const awayId = game?.away?.id ?? game?.awayId ?? game?.away;
+      return Number(homeId) === Number(userTeamId) || Number(awayId) === Number(userTeamId);
+    });
+    if (!matchup) return { week };
+    const homeId = matchup?.home?.id ?? matchup?.homeId ?? matchup?.home;
+    const awayId = matchup?.away?.id ?? matchup?.awayId ?? matchup?.away;
+    const opponentId = Number(homeId) === Number(userTeamId) ? awayId : homeId;
+    const opponent = (league?.teams ?? []).find((team) => Number(team?.id) === Number(opponentId));
+    return { week, opponentAbbr: opponent?.abbr ?? null };
+  }, [league?.schedule?.weeks, league?.teams, league?.userTeamId, league?.week]);
   const lastShownSkipWeekRef = useRef(null);
   const [initFlow, setInitFlow] = useState(null);
   const [bootRequestId, setBootRequestId] = useState(null);
@@ -1567,9 +1585,9 @@ function AppContent() {
               setPostGameResult(postGameResultStash);
               setPostGameResultStash(null);
             }
-            if (skipGameSummaryStash) {
-              setSkipGameSummary(skipGameSummaryStash);
-              setSkipGameSummaryStash(null);
+            if (gameBookBriefingStash) {
+              setSkipGameSummary(gameBookBriefingStash);
+              setGameBookBriefingStash(null);
             }
           }}
           advanceLabel={getAdvanceLabel()}
@@ -1956,18 +1974,19 @@ function AppContent() {
           injuries={skipGameSummary.injuries}
           momentumChange={skipGameSummary.momentumChange}
           onClose={() => setSkipGameSummary(null)}
-          nextWeek={{ week: league?.week }}
+          nextWeek={nextWeekBriefingContext}
           onPreparationAction={(destination) => {
-            setSkipGameSummaryStash(skipGameSummary);
+            setGameBookBriefingStash(null);
             setSkipGameSummary(null);
             setExternalDashboardDestination(destination);
           }}
           onContinue={() => {
+            setGameBookBriefingStash(null);
             setSkipGameSummary(null);
             setExternalDashboardDestination('HQ');
           }}
           onViewGameBook={skipGameSummary.gameId ? () => {
-            setSkipGameSummaryStash(skipGameSummary);
+            setGameBookBriefingStash(skipGameSummary);
             setSkipGameSummary(null);
             setExternalBoxScoreId(skipGameSummary.gameId);
           } : undefined}

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -30,7 +30,7 @@ export function PlayerButton({ player, onSelect, context }) {
   );
 }
 
-const TAB_KEYS = ['passing', 'rushing', 'defense'];
+const TAB_KEYS = ['passing', 'rushing', 'receiving', 'defense', 'kicking', 'returns'];
 const MAX_STAT_ROWS = 6;
 
 function BoxScore({
@@ -47,6 +47,7 @@ function BoxScore({
   backLabel = "Back to flow",
 }) {
   const [activeTab, setActiveTab] = useState('passing');
+  const [activeView, setActiveView] = useState('summary');
 
   const canLoadArchive = Boolean(gameId && typeof actions?.getBoxScore === "function");
   const { data: archiveGame } = useStableRouteRequest({
@@ -214,8 +215,21 @@ function BoxScore({
         <div className="bs-sheet-meta">Week {vm.week ?? mdash} · Season {vm.season ?? mdash}</div>
       </div>
 
+      <div className="bs-sheet-view-tabs" role="tablist" aria-label="Game Book sections">
+        {[
+          ['summary', 'Summary'],
+          ...(teamComparisonRows.length ? [['team-stats', 'Team Stats']] : []),
+          ...(tableSections.length ? [['players', 'Players']] : []),
+          ...(playByPlayRows.length ? [['plays', 'Plays']] : []),
+        ].map(([key, label]) => (
+          <button key={key} type="button" role="tab" aria-selected={activeView === key} className={`bs-sheet-view-tab${activeView === key ? ' is-active' : ''}`} onClick={() => setActiveView(key)}>{label}</button>
+        ))}
+      </div>
+
+      <div role="tabpanel" data-testid={`game-book-view-${activeView}`}>
+
       {/* ── KEY LEADERS — priority 2: top performers above dense tables ─── */}
-      {keyLeaders.length > 0 && (
+      {activeView === 'summary' && keyLeaders.length > 0 && (
         <div className="bs-sheet-leaders" data-testid="game-book-leaders">
           <div className="bs-sheet-section-title">Key Leaders</div>
           {keyLeaders.map((leader) => (
@@ -228,13 +242,13 @@ function BoxScore({
       )}
 
       {/* ── EXECUTIVE SUMMARY — inline bullets or hidden debug div ──────── */}
-      {reasoningBullets.length > 0 ? (
+      {activeView === 'summary' && reasoningBullets.length > 0 ? (
         <div className="bs-sheet-exec" data-testid="game-book-executive-summary">
           {reasoningBullets.slice(0, 3).map((bullet) => (
             <span key={bullet} className="bs-sheet-exec-bullet">• {bullet}</span>
           ))}
         </div>
-      ) : (
+      ) : activeView === 'summary' ? (
         /* Debug div: hidden from UI but inspectable during development to verify
            that the gameReasoningFlags array is arriving correctly. The data-flags-count
            attribute surfaces the raw array length so you can confirm the prop plumbing
@@ -245,10 +259,10 @@ function BoxScore({
           data-testid="game-book-exec-debug"
           data-flags-count={String(rawFlags.length)}
         />
-      )}
+      ) : null}
 
       {/* ── DECISIVE MOMENTS — priority 3: short teaser, always visible ─── */}
-      {decisiveMoments.length > 0 && (
+      {activeView === 'summary' && decisiveMoments.length > 0 && (
         <div className="bs-sheet-moments" data-testid="game-book-moments">
           <div className="bs-sheet-section-title">Decisive Moments</div>
           {decisiveMoments.map((m, i) => (
@@ -267,14 +281,14 @@ function BoxScore({
           table is shown; a compact honest note appears instead. Legacy archives
           with genuine stored quarter data still render their linescore. The
           final score + scoring summary below remain fully canonical either way. */}
-      {vm.isCanonicalLedger && !vm.availableData?.quarterScores && (
+      {activeView === 'summary' && vm.isCanonicalLedger && !vm.availableData?.quarterScores && (
         <div className="bs-sheet-quarter-unavailable" data-testid="game-book-quarter-unavailable">
           Quarter breakdown unavailable for this game.
         </div>
       )}
 
       {/* ── FULL SCORING SUMMARY — collapsed, exhaustive list ────────────── */}
-      {scoringSummaryRows.length > 0 && (
+      {activeView === 'summary' && scoringSummaryRows.length > 0 && (
         <details className="bs-sheet-details" data-testid="game-book-scoring-summary">
           <summary>Full Scoring Summary ({scoringSummaryRows.length})</summary>
           <div className="bs-sheet-details-body">
@@ -291,9 +305,9 @@ function BoxScore({
       )}
 
       {/* ── TEAM STAT COMPARISON — priority 4, collapsed ─────────────────── */}
-      {teamComparisonRows.length > 0 && (
-        <details className="bs-sheet-details" data-testid="game-book-team-stats">
-          <summary>Team Stat Comparison</summary>
+      {activeView === 'team-stats' && teamComparisonRows.length > 0 && (
+        <section className="bs-sheet-details" data-testid="game-book-team-stats" aria-label="Team Stat Comparison">
+          <h3 className="bs-sheet-view-heading">Team Stat Comparison</h3>
           <div className="bs-sheet-details-body">
             <div className="bs-sheet-compare-head">
               <span>{awayAbbr}</span>
@@ -308,11 +322,11 @@ function BoxScore({
               </div>
             ))}
           </div>
-        </details>
+        </section>
       )}
 
       {/* ── SPECIAL TEAMS — compact kicking & field-position summary ─────── */}
-      {specialTeams?.hasData && (
+      {activeView === 'summary' && specialTeams?.hasData && (
         <div className="bs-sheet-leaders" data-testid="game-book-special-teams">
           <div className="bs-sheet-section-title">Special Teams</div>
           <div className="bs-sheet-compare-head">
@@ -338,11 +352,11 @@ function BoxScore({
       )}
 
       {/* ── FULL PLAYER STATS — priority 5, collapsed dense tables ───────── */}
-      <details className="bs-sheet-details" data-testid="game-book-player-stats">
-        <summary>Full Player Stats</summary>
+      {activeView === 'players' && <section className="bs-sheet-details" data-testid="game-book-player-stats" aria-label="Player Stats">
+        <h3 className="bs-sheet-view-heading">Player Stats</h3>
         <div className="bs-sheet-details-body">
           <div className="bs-sheet-tab-row" data-testid="game-book-stat-tabs" role="tablist" aria-label="Stat category">
-            {TAB_KEYS.map((tab) => (
+            {TAB_KEYS.filter((tab) => tableSections.some((section) => section.key === tab)).map((tab) => (
               <button
                 key={tab}
                 type="button"
@@ -360,12 +374,12 @@ function BoxScore({
             {renderStatRows(activeSection)}
           </div>
         </div>
-      </details>
+      </section>}
 
       {/* ── FULL PLAY-BY-PLAY — priority 6, collapsed drive/play log ─────── */}
-      {playByPlayRows.length > 0 && (
-        <details className="bs-sheet-details" data-testid="game-book-play-by-play">
-          <summary>Full Play-by-Play ({playByPlayRows.length})</summary>
+      {activeView === 'plays' && playByPlayRows.length > 0 && (
+        <section className="bs-sheet-details" data-testid="game-book-play-by-play" aria-label="Play-by-Play">
+          <h3 className="bs-sheet-view-heading">Play-by-Play ({playByPlayRows.length})</h3>
           <div className="bs-sheet-details-body">
             {playByPlayRows.map((row) => (
               <div key={row.id} className={`bs-sheet-row${row.isKey ? " bs-sheet-row--key" : ""}`}>
@@ -376,8 +390,9 @@ function BoxScore({
               </div>
             ))}
           </div>
-        </details>
+        </section>
       )}
+      </div>
     </div>
   );
 }

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { EmptyState } from "./ScreenSystem.jsx";
 import { buildBoxScoreViewModel, buildPlayerStatSections, unwrapBoxScoreResponse } from "../utils/boxScoreViewModel.js";
 import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
@@ -48,6 +48,14 @@ function BoxScore({
 }) {
   const [activeTab, setActiveTab] = useState('passing');
   const [activeView, setActiveView] = useState('summary');
+
+  // A route can reuse this component instance for another game. Reset local
+  // disclosure only when game identity changes so no previous game's tab or
+  // player category appears while the new canonical record is selected.
+  useEffect(() => {
+    setActiveView('summary');
+    setActiveTab('passing');
+  }, [gameId]);
 
   const canLoadArchive = Boolean(gameId && typeof actions?.getBoxScore === "function");
   const { data: archiveGame } = useStableRouteRequest({

--- a/src/ui/components/BoxScore.test.jsx
+++ b/src/ui/components/BoxScore.test.jsx
@@ -8,6 +8,12 @@ import BoxScore, { PlayerButton } from './BoxScore.jsx';
 vi.mock('../hooks/useStableRouteRequest.js', () => ({ default: vi.fn(() => ({ data: null })) }));
 import useStableRouteRequest from '../hooks/useStableRouteRequest.js';
 
+function openGameBookTab(label) {
+  const tab = [...document.querySelectorAll('[role="tab"]')].find((node) => node.textContent === label);
+  expect(tab, `${label} tab should be available`).toBeTruthy();
+  fireEvent.click(tab);
+}
+
 describe('BoxScore compact sheet — core rendering', () => {
   const baseLeague = { seasonId: 2031, week: 2, teams: [{ id: 1, abbr: 'KC' }, { id: 2, abbr: 'BUF' }] };
 
@@ -66,10 +72,11 @@ describe('BoxScore compact sheet — core rendering', () => {
       <BoxScore gameId="g3" league={{ ...baseLeague, gameById: { g3: game } }} embedded />,
     );
     expect(getByTestId('game-book-score-hero')).toBeTruthy();
+    expect(getByTestId('game-book-view-summary')).toBeTruthy();
+    expect(document.querySelector('[role="tab"][aria-selected="true"]')?.textContent).toBe('Summary');
+    openGameBookTab('Players');
     expect(getByTestId('game-book-stat-tabs')).toBeTruthy();
     expect(getByTestId('game-book-tab-passing')).toBeTruthy();
-    expect(getByTestId('game-book-tab-rushing')).toBeTruthy();
-    expect(getByTestId('game-book-tab-defense')).toBeTruthy();
   });
 
   it('score-only game: renders score hero but no stat table rows', () => {
@@ -79,6 +86,20 @@ describe('BoxScore compact sheet — core rendering', () => {
     expect(getByTestId('game-book-score-hero')).toBeTruthy();
     // No player rows since no playerStats
     expect(queryAllByTestId('game-book-player-link')).toHaveLength(0);
+  });
+
+  it('resets to Summary when a different selected game replaces the current game', () => {
+    const detailed = { homeId: 1, awayId: 2, homeScore: 31, awayScore: 20, teamStats: { home: { passYards: 300 }, away: { passYards: 210 } } };
+    const next = { homeId: 1, awayId: 2, homeScore: 10, awayScore: 7 };
+    const league = { ...baseLeague, gameById: { detailed, next } };
+    const { getByTestId, queryByTestId, rerender } = render(<BoxScore gameId="detailed" league={league} embedded />);
+    openGameBookTab('Team Stats');
+    expect(getByTestId('game-book-team-stats').textContent).toContain('300');
+    rerender(<BoxScore gameId="next" league={league} embedded />);
+    expect(getByTestId('game-book-view-summary')).toBeTruthy();
+    expect(getByTestId('game-book-final-score').textContent).toContain('10');
+    expect(queryByTestId('game-book-team-stats')).toBeNull();
+    expect(document.body.textContent).not.toContain('300');
   });
 
   it('renders passing stat table by default when playerStats exist', () => {
@@ -96,7 +117,9 @@ describe('BoxScore compact sheet — core rendering', () => {
     const { getByTestId } = render(
       <BoxScore gameId="g-pass" league={{ ...baseLeague, gameById: { 'g-pass': game } }} embedded />,
     );
-    // Passing tab active by default
+    expect(document.querySelector('[data-testid="game-book-player-stats"]')).toBeNull();
+    openGameBookTab('Players');
+    // Passing category is active when Players first opens.
     expect(getByTestId('game-book-tab-passing').getAttribute('aria-selected')).toBe('true');
     expect(getByTestId('game-book-table-passing')).toBeTruthy();
     expect(getByTestId('game-book-table-passing').textContent).toContain('Home QB');
@@ -117,6 +140,7 @@ describe('BoxScore compact sheet — core rendering', () => {
     const { getByTestId } = render(
       <BoxScore gameId="g-def" league={{ ...baseLeague, gameById: { 'g-def': game } }} embedded />,
     );
+    openGameBookTab('Players');
     fireEvent.click(getByTestId('game-book-tab-defense'));
     expect(getByTestId('game-book-tab-defense').getAttribute('aria-selected')).toBe('true');
     expect(getByTestId('game-book-table-defense')).toBeTruthy();
@@ -141,6 +165,7 @@ describe('BoxScore compact sheet — core rendering', () => {
     const { getByTestId, queryByTestId } = render(
       <BoxScore gameId="g-tabs" league={{ ...baseLeague, gameById: { 'g-tabs': game } }} embedded />,
     );
+    openGameBookTab('Players');
     // Default: passing tab active, shows QB
     expect(getByTestId('game-book-table-passing').textContent).toContain('QB One');
     // Switch to rushing
@@ -166,6 +191,7 @@ describe('BoxScore compact sheet — core rendering', () => {
     const { getByTestId } = render(
       <BoxScore gameId="g-maxrows" league={{ ...baseLeague, gameById: { 'g-maxrows': game } }} embedded />,
     );
+    openGameBookTab('Players');
     const rows = getByTestId('game-book-table-passing').querySelectorAll('tbody tr');
     expect(rows.length).toBeLessThanOrEqual(6);
   });
@@ -318,6 +344,7 @@ describe('BoxScore player name resolution', () => {
       },
     };
     const { container } = render(<BoxScore gameId="g-named" league={{ ...baseLeague, gameById: { 'g-named': game } }} embedded />);
+    openGameBookTab('Players');
     expect(container.textContent).toContain('Named QB');
     expect(container.textContent).not.toContain('Unknown');
   });
@@ -332,6 +359,7 @@ describe('BoxScore player name resolution', () => {
       },
     };
     const { container } = render(<BoxScore gameId="g-fallback" league={{ ...baseLeague, gameById: { 'g-fallback': game } }} embedded />);
+    openGameBookTab('Players');
     expect(container.textContent).toContain('Player #77');
     expect(container.textContent).not.toContain('Unknown');
   });
@@ -353,6 +381,7 @@ describe('BoxScore player name resolution', () => {
       },
     };
     const { container } = render(<BoxScore gameId="g-roster" league={{ ...leagueWithRoster, gameById: { 'g-roster': game } }} embedded />);
+    openGameBookTab('Players');
     expect(container.textContent).toContain('Roster QB Name');
     expect(container.textContent).not.toContain('Unknown');
   });
@@ -373,6 +402,7 @@ describe('BoxScore player name resolution', () => {
     const { container, getByTestId } = render(
       <BoxScore gameId="g-noblank" league={{ ...baseLeague, gameById: { 'g-noblank': game } }} embedded />,
     );
+    openGameBookTab('Players');
     const passingTable = container.querySelector('[data-testid="game-book-table-passing"]');
     if (passingTable) {
       const cells = passingTable.querySelectorAll('td');
@@ -396,6 +426,7 @@ describe('BoxScore player name resolution', () => {
     const { container, getByTestId } = render(
       <BoxScore gameId="g-names" league={{ ...baseLeague, gameById: { 'g-names': game } }} embedded />,
     );
+    openGameBookTab('Players');
     expect(container.textContent).toContain('Home QB');
     // Switch to rushing to see away RB
     fireEvent.click(getByTestId('game-book-tab-rushing'));
@@ -428,6 +459,7 @@ describe('BoxScore player name resolution', () => {
     const { container } = render(
       <BoxScore gameId="g-mobile" league={{ ...baseLeague, gameById: { 'g-mobile': game } }} embedded />,
     );
+    openGameBookTab('Players');
     const table = container.querySelector('[data-testid="game-book-table-passing"]');
     expect(table).toBeTruthy();
     expect(table.className).toContain('bs-sheet-table');
@@ -472,6 +504,7 @@ describe('BoxScore player button interactions', () => {
     const { getAllByTestId } = render(
       <BoxScore gameId="g4" league={{ ...baseLeague, gameById: { g4: game } }} onPlayerSelect={onSelect} embedded />,
     );
+    openGameBookTab('Players');
     fireEvent.click(getAllByTestId('game-book-player-link')[0]);
     expect(onSelect.mock.calls[0][0]).toBe(11);
     expect(onSelect.mock.calls[0][1]).toMatchObject({

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -632,6 +632,8 @@ export default function LeagueDashboard({
   onDismissNotification,
   externalBoxScoreId,
   onConsumeExternalBoxScore,
+  externalDestination,
+  onConsumeExternalDestination,
   onGameDetailBack,
   advanceLabel = "Advance",
   advanceDisabled = false,
@@ -747,6 +749,12 @@ export default function LeagueDashboard({
     setGameDetailModal({ open: true, gameId: externalBoxScoreId, source: "postgame" });
     onConsumeExternalBoxScore?.();
   }, [externalBoxScoreId, onConsumeExternalBoxScore, activeTab]);
+
+  useEffect(() => {
+    if (!externalDestination) return;
+    setActiveTab(externalDestination);
+    onConsumeExternalDestination?.();
+  }, [externalDestination, onConsumeExternalDestination]);
 
   if (!league) {
     return (
@@ -1639,7 +1647,7 @@ export default function LeagueDashboard({
               onNavigate={setActiveTab}
               onPlayerSelect={handlePlayerSelect}
               onTeamSelect={handleTeamSelect}
-              backLabel={gameDetailModal.source === 'weekly-results' ? 'Back to Weekly Results' : 'Return to HQ'}
+              backLabel={gameDetailModal.source === 'weekly-results' ? 'Back to Weekly Results' : gameDetailModal.source === 'postgame' ? 'Back to Weekly Briefing' : 'Return to HQ'}
             />
           </div>
         </div>

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -1632,7 +1632,10 @@ export default function LeagueDashboard({
           <button
             type="button"
             className="player-profile-modal-backdrop"
-            onClick={() => setGameDetailModal({ open: false, gameId: null, source: null })}
+            onClick={() => {
+              onGameDetailBack?.();
+              setGameDetailModal({ open: false, gameId: null, source: null });
+            }}
             aria-label="Close Game Book"
           />
           <div className="player-profile-modal-content" style={{ maxWidth: 'min(1200px, 100vw)', width: '100%', height: '100%', maxHeight: '100dvh' }}>

--- a/src/ui/components/PostGameSummary.jsx
+++ b/src/ui/components/PostGameSummary.jsx
@@ -9,6 +9,7 @@
 import React, { useEffect, useRef, useMemo } from 'react';
 import { buildPostgameEmotionalFrame } from '../utils/postgameEmotionalFrame.js';
 import GameResultSummaryCard from './GameResultSummaryCard.jsx';
+import { buildPostgameBriefing } from '../utils/postgameBriefing.js';
 
 function safeNum(value, fallback = 0) {
   const n = Number(value);
@@ -65,6 +66,9 @@ export default function PostGameSummary({
   recentResults,
   onClose,
   onViewGameBook,
+  onPreparationAction,
+  onContinue,
+  nextWeek,
 }) {
   const overlayRef = useRef(null);
   const closeButtonRef = useRef(null);
@@ -111,6 +115,8 @@ export default function PostGameSummary({
 
   if (!gameResult) return null;
 
+  const briefing = buildPostgameBriefing({ gameResult, leaders, injuries, nextWeek });
+
   const { homeScore = 0, awayScore = 0, homeTeam, awayTeam, userTeamId, week, phase } = gameResult;
   const homeId = safeNum(homeTeam?.id ?? gameResult.homeId);
   const awayId = safeNum(awayTeam?.id ?? gameResult.awayId);
@@ -130,13 +136,13 @@ export default function PostGameSummary({
   const homeAbbr = homeTeam?.abbr ?? gameResult.homeAbbr ?? 'HOME';
   const awayAbbr = awayTeam?.abbr ?? gameResult.awayAbbr ?? 'AWAY';
 
-  const injuryList = Array.isArray(injuries) ? injuries.filter(Boolean) : [];
+  const injuryList = briefing.injuries;
 
   return (
     <div
       role="dialog"
       aria-modal="true"
-      aria-label="Post-game summary"
+      aria-label="Weekly GM briefing"
       data-testid="post-game-summary"
       ref={overlayRef}
       style={{
@@ -146,7 +152,7 @@ export default function PostGameSummary({
         overflowY: 'auto',
         WebkitOverflowScrolling: 'touch',
         display: 'flex', alignItems: 'flex-start', justifyContent: 'center',
-        padding: '24px 16px 80px',
+        padding: 'max(24px, env(safe-area-inset-top)) 16px max(80px, env(safe-area-inset-bottom))',
       }}
       onClick={(e) => { if (e.target === e.currentTarget) onClose?.(); }}
     >
@@ -162,14 +168,14 @@ export default function PostGameSummary({
           </div>
           {week != null && (
             <div style={{ fontSize: '0.72rem', color: 'var(--text-subtle)', fontWeight: 600, marginBottom: 8 }}>
-              Week {week} · {phase === 'playoffs' ? 'Playoffs' : 'Regular Season'}
+              Weekly GM Briefing · Week {week} · {phase === 'playoffs' ? 'Playoffs' : 'Regular Season'}
             </div>
           )}
           <MomentumBadge change={momentumChange} />
         </div>
 
         {/* Canonical final-score card (shared with Franchise HQ) */}
-        <GameResultSummaryCard
+          <GameResultSummaryCard
           variant="full"
           testId="post-game-summary-result-card"
           awayAbbr={awayAbbr}
@@ -179,9 +185,12 @@ export default function PostGameSummary({
           homeName={homeTeam?.name ?? homeAbbr}
           homeScore={homeScore}
         />
+        <p style={{ margin: '-4px 0 14px', textAlign: 'center', color: 'var(--text-muted)', fontSize: '0.78rem' }}>
+          {briefing.userIsHome ? 'Home' : 'Away'} · {briefing.headline}
+        </p>
 
         {/* Game leaders */}
-        {Array.isArray(leaders) && leaders.length > 0 && (
+        {briefing.leaders.length > 0 && (
           <div style={{
             background: 'var(--surface)',
             border: '1px solid var(--hairline)',
@@ -193,7 +202,7 @@ export default function PostGameSummary({
               Game Leaders
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-              {leaders.map((leader, i) => (
+              {briefing.leaders.map((leader, i) => (
                 <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                   <span style={{
                     width: 36, height: 36, borderRadius: '50%', flexShrink: 0,
@@ -289,6 +298,20 @@ export default function PostGameSummary({
           </div>
         )}
 
+        {nextWeek && onPreparationAction ? (
+          <div data-testid="weekly-briefing-preparation" style={{ margin: '12px 0', padding: '12px 14px', background: 'var(--surface)', border: '1px solid var(--hairline)', borderRadius: 12 }}>
+            <div style={{ fontSize: '0.65rem', fontWeight: 800, color: 'var(--text-subtle)', textTransform: 'uppercase', letterSpacing: '0.8px', marginBottom: 4 }}>Next-week preparation</div>
+            <div style={{ fontWeight: 800, marginBottom: 10 }}>Week {nextWeek.week}{nextWeek.opponentAbbr ? ` · vs ${nextWeek.opponentAbbr}` : ''}</div>
+            <div className="weekly-briefing-actions">
+              {[
+                ['Game Plan', 'Game Plan'], ['Set Lineup', 'Depth Chart'], ['Training', 'Training'], ['Scout Opponent', 'Weekly Prep'],
+              ].map(([label, destination]) => (
+                <button key={label} type="button" className="btn btn-sm" onClick={() => onPreparationAction(destination)}>{label}</button>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
         {/* Actions */}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 8 }}>
           {onViewGameBook && (
@@ -312,7 +335,7 @@ export default function PostGameSummary({
             type="button"
             ref={closeButtonRef}
             data-testid="post-game-summary-close"
-            onClick={onClose}
+            onClick={onContinue ?? onClose}
             style={{
               width: '100%', padding: '14px',
               background: resultColor,
@@ -323,7 +346,7 @@ export default function PostGameSummary({
               boxShadow: `0 4px 18px ${resultColor}40`,
             }}
           >
-            Return to Franchise HQ
+            {nextWeek?.week ? `Continue to Week ${nextWeek.week}` : 'Return to Franchise HQ'}
           </button>
         </div>
       </div>

--- a/src/ui/components/__tests__/BoxScoreAutoOpen.test.jsx
+++ b/src/ui/components/__tests__/BoxScoreAutoOpen.test.jsx
@@ -83,8 +83,7 @@ describe('BoxScore – opt-in auto-open replay gate', () => {
         embedded
       />,
     );
-    // Replay toggle and skip button have been removed; stat tabs are the navigation mechanism
-    expect(getByTestId('game-book-stat-tabs')).toBeTruthy();
+    expect(getByTestId('game-book-view-summary')).toBeTruthy();
     expect(queryByTestId('game-book-replay-toggle')).toBeNull();
     expect(queryByTestId('game-book-skip-to-box-score')).toBeNull();
   });
@@ -98,10 +97,7 @@ describe('BoxScore – opt-in auto-open replay gate', () => {
         embedded
       />,
     );
-    // Viewer initialMode prop no longer exists; stat tabs are shown instead
-    expect(getByTestId('game-book-tab-passing')).toBeTruthy();
-    expect(getByTestId('game-book-tab-rushing')).toBeTruthy();
-    expect(getByTestId('game-book-tab-defense')).toBeTruthy();
+    expect(getByTestId('game-book-view-summary')).toBeTruthy();
     expect(queryByTestId('rgfv-progress')).toBeNull();
   });
 
@@ -151,8 +147,7 @@ describe('BoxScore – opt-in auto-open replay gate', () => {
         embedded
       />,
     );
-    // Replay toggle and viewer removed; stat tabs present instead
-    expect(getByTestId('game-book-stat-tabs')).toBeTruthy();
+    expect(getByTestId('game-book-view-summary')).toBeTruthy();
     expect(queryByTestId('game-book-replay-toggle')).toBeNull();
   });
 

--- a/src/ui/components/__tests__/gameBookMobileDensity.test.jsx
+++ b/src/ui/components/__tests__/gameBookMobileDensity.test.jsx
@@ -10,7 +10,7 @@ import { readFileSync, globSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
 import BoxScore from '../BoxScore.jsx';
 import GameDetailScreen from '../GameDetailScreen.jsx';
 
@@ -106,9 +106,18 @@ describe('Game Book mobile density — section hierarchy', () => {
     return Boolean(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
   }
 
+  function openTab(label) {
+    const tab = [...document.querySelectorAll('[role="tab"]')].find((node) => node.textContent === label);
+    expect(tab, `${label} tab should be available`).toBeTruthy();
+    fireEvent.click(tab);
+  }
+
   it('renders the final score before any dense stat table', () => {
-    const { getByTestId } = renderRichBoxScore();
+    const { getByTestId, queryByTestId } = renderRichBoxScore();
     const hero = getByTestId('game-book-score-hero');
+    expect(getByTestId('game-book-view-summary')).toBeTruthy();
+    expect(queryByTestId('game-book-player-stats')).toBeNull();
+    openTab('Players');
     const playerStats = getByTestId('game-book-player-stats');
     expect(isBefore(hero, playerStats)).toBe(true);
   });
@@ -150,48 +159,51 @@ describe('Game Book mobile density — section hierarchy', () => {
   });
 
   it('renders key leaders above the full player stat tables', () => {
-    const { getByTestId } = renderRichBoxScore();
+    const { getByTestId, queryByTestId } = renderRichBoxScore();
     const leaders = getByTestId('game-book-leaders');
+    expect(queryByTestId('game-book-player-stats')).toBeNull();
+    openTab('Players');
     const playerStats = getByTestId('game-book-player-stats');
-    expect(isBefore(leaders, playerStats)).toBe(true);
+    expect(playerStats).toBeTruthy();
     // Sanity: leaders actually surface top performers, not just a label.
     expect(leaders.textContent).toMatch(/Home QB|Home RB|Home WR|Away QB/);
   });
 
   it('renders decisive moments above the full player stat tables and full play-by-play', () => {
-    const { getByTestId } = renderRichBoxScore();
+    const { getByTestId, queryByTestId } = renderRichBoxScore();
     const moments = getByTestId('game-book-moments');
-    const playerStats = getByTestId('game-book-player-stats');
-    const playByPlay = getByTestId('game-book-play-by-play');
-    expect(isBefore(moments, playerStats)).toBe(true);
-    expect(isBefore(moments, playByPlay)).toBe(true);
+    expect(moments).toBeTruthy();
+    expect(queryByTestId('game-book-play-by-play')).toBeNull();
+    openTab('Plays');
+    expect(getByTestId('game-book-play-by-play')).toBeTruthy();
+    expect(queryByTestId('game-book-moments')).toBeNull();
   });
 
   it('renders team stat comparison above the full player stat tables', () => {
-    const { getByTestId } = renderRichBoxScore();
-    const teamStats = getByTestId('game-book-team-stats');
-    const playerStats = getByTestId('game-book-player-stats');
-    expect(isBefore(teamStats, playerStats)).toBe(true);
+    const { getByTestId, queryByTestId } = renderRichBoxScore();
+    expect(queryByTestId('game-book-team-stats')).toBeNull();
+    openTab('Team Stats');
+    expect(getByTestId('game-book-team-stats')).toBeTruthy();
+    expect(queryByTestId('game-book-player-stats')).toBeNull();
   });
 
-  it('collapses dense sections behind native <details> closed by default', () => {
-    const { getByTestId } = renderRichBoxScore();
-    for (const testId of ['game-book-scoring-summary', 'game-book-team-stats', 'game-book-player-stats', 'game-book-play-by-play']) {
-      const el = getByTestId(testId);
-      expect(el.tagName).toBe('DETAILS');
-      expect(el.hasAttribute('open')).toBe(false);
-      // A summary teaser must still be visible without expansion.
-      expect(el.querySelector('summary')).toBeTruthy();
-    }
+  it('does not render inactive dense sections', () => {
+    const { getByTestId, queryByTestId } = renderRichBoxScore();
+    expect(getByTestId('game-book-scoring-summary').tagName).toBe('DETAILS');
+    expect(queryByTestId('game-book-team-stats')).toBeNull();
+    expect(queryByTestId('game-book-player-stats')).toBeNull();
+    expect(queryByTestId('game-book-play-by-play')).toBeNull();
   });
 
   it('places the full play-by-play log lower in DOM order than the score hero and leaders', () => {
     const { getByTestId } = renderRichBoxScore();
     const hero = getByTestId('game-book-score-hero');
     const leaders = getByTestId('game-book-leaders');
+    openTab('Plays');
     const playByPlay = getByTestId('game-book-play-by-play');
-    expect(isBefore(hero, playByPlay)).toBe(true);
-    expect(isBefore(leaders, playByPlay)).toBe(true);
+    expect(hero).toBeTruthy();
+    expect(playByPlay).toBeTruthy();
+    expect(leaders.isConnected).toBe(false);
   });
 
   it('does not mutate the game/archive data it renders', () => {
@@ -211,7 +223,8 @@ describe('Game Book mobile density — section hierarchy', () => {
   it('still renders when stat leader source data is missing', () => {
     const { getByTestId, queryByTestId } = renderSparseBoxScore({ playerStats: undefined });
     expect(getByTestId('game-book-score-hero')).toBeTruthy();
-    expect(getByTestId('game-book-player-stats')).toBeTruthy();
+    expect(queryByTestId('game-book-player-stats')).toBeNull();
+    expect([...document.querySelectorAll('[role="tab"]')].some((node) => node.textContent === 'Players')).toBe(false);
     expect(queryByTestId('game-book-leaders')).toBeNull();
   });
 

--- a/src/ui/components/__tests__/postGamePersistence.test.jsx
+++ b/src/ui/components/__tests__/postGamePersistence.test.jsx
@@ -13,6 +13,7 @@ function PostGamePersistenceHarness({ initialResult = null }) {
   const [postGameResult, setPostGameResult] = useState(initialResult);
   const [postGameResultStash, setPostGameResultStash] = useState(null);
   const [externalBoxScoreOpen, setExternalBoxScoreOpen] = useState(false);
+  const [destination, setDestination] = useState(null);
 
   const openBoxScore = (gameId) => {
     if (!gameId) return;
@@ -34,6 +35,14 @@ function PostGamePersistenceHarness({ initialResult = null }) {
     setPostGameResultStash(null);
   };
 
+  const openPreparation = () => {
+    setPostGameResultStash(null);
+    setPostGameResult(null);
+    setDestination('Game Plan');
+  };
+
+  const openUnrelatedGameBook = () => setExternalBoxScoreOpen(true);
+
   return (
     <div>
       {postGameResult && !externalBoxScoreOpen && (
@@ -45,6 +54,7 @@ function PostGamePersistenceHarness({ initialResult = null }) {
           <button data-testid="dismiss-result" onClick={dismissResult}>
             Back to Hub
           </button>
+          <button data-testid="open-preparation" onClick={openPreparation}>Game Plan</button>
         </div>
       )}
       {externalBoxScoreOpen && (
@@ -56,7 +66,7 @@ function PostGamePersistenceHarness({ initialResult = null }) {
         </div>
       )}
       {!postGameResult && !externalBoxScoreOpen && (
-        <div data-testid="hq-view">Franchise HQ</div>
+        <div data-testid="hq-view">{destination ?? 'Franchise HQ'}<button data-testid="open-unrelated-game-book" onClick={openUnrelatedGameBook}>Unrelated Game Book</button></div>
       )}
     </div>
   );
@@ -119,5 +129,24 @@ describe('Postgame persistence stash/restore', () => {
     // Context is restored
     expect(queryByTestId('postgame-modal')).not.toBeNull();
     expect(getByTestId('result-label').textContent).toBe('VICTORY');
+  });
+
+  it('preparation navigation leaves no briefing stash for an unrelated Game Book close', () => {
+    const { getByTestId, queryByTestId } = render(<PostGamePersistenceHarness initialResult={{ label: 'VICTORY', gameId: 'g5' }} />);
+    fireEvent.click(getByTestId('open-preparation'));
+    expect(getByTestId('hq-view').textContent).toContain('Game Plan');
+    fireEvent.click(getByTestId('open-unrelated-game-book'));
+    fireEvent.click(getByTestId('game-detail-back'));
+    expect(queryByTestId('postgame-modal')).toBeNull();
+  });
+
+  it('repeated Game Book cycles consume the retained result and never restore obsolete data', () => {
+    const { getByTestId, queryByTestId } = render(<PostGamePersistenceHarness initialResult={{ label: 'VICTORY', gameId: 'g6' }} />);
+    fireEvent.click(getByTestId('view-box-score'));
+    fireEvent.click(getByTestId('game-detail-back'));
+    fireEvent.click(getByTestId('dismiss-result'));
+    fireEvent.click(getByTestId('open-unrelated-game-book'));
+    fireEvent.click(getByTestId('game-detail-back'));
+    expect(queryByTestId('postgame-modal')).toBeNull();
   });
 });

--- a/src/ui/styles/style.css
+++ b/src/ui/styles/style.css
@@ -8049,6 +8049,12 @@ details[open] .nav-summary::after {
   border: 1px solid var(--hairline, #333);
   box-shadow: none;
 }
+.bs-sheet-view-tabs { position: sticky; top: 0; z-index: 3; display: flex; gap: 4px; padding: 8px; overflow-x: auto; background: var(--surface); border-bottom: 1px solid var(--hairline); }
+.bs-sheet-view-tab { min-height: 44px; flex: 1 0 auto; padding: 8px 12px; border: 0; border-radius: 8px; background: transparent; color: var(--text-muted); font-weight: 800; }
+.bs-sheet-view-tab.is-active { background: var(--accent-muted); color: var(--accent); }
+.bs-sheet-view-heading { margin: 0; padding: 12px 14px 4px; font-size: var(--text-sm); }
+.weekly-briefing-actions { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+.weekly-briefing-actions .btn { min-height: 44px; white-space: normal; }
 
 /* ── Single ✕ dismiss — top-right ──────────────────────────────────────── */
 .bs-sheet-dismiss {

--- a/src/ui/utils/postgameBriefing.js
+++ b/src/ui/utils/postgameBriefing.js
@@ -1,0 +1,43 @@
+const finiteScore = (value) => {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+};
+
+/**
+ * Builds the shared, read-only presentation model used by the weekly briefing.
+ * Scores are copied from the completed game record; no scoring events are
+ * summed and sparse legacy records remain honest.
+ */
+export function buildPostgameBriefing({ gameResult, leaders = [], injuries = [], nextWeek = null } = {}) {
+  if (!gameResult) return null;
+  const homeScore = finiteScore(gameResult.homeScore ?? gameResult.scoreHome);
+  const awayScore = finiteScore(gameResult.awayScore ?? gameResult.scoreAway);
+  const homeId = gameResult.homeTeam?.id ?? gameResult.homeId;
+  const awayId = gameResult.awayTeam?.id ?? gameResult.awayId;
+  const userId = gameResult.userTeamId;
+  const userIsHome = String(homeId) === String(userId);
+  const userIsAway = String(awayId) === String(userId);
+  const hasFinal = homeScore != null && awayScore != null;
+  const userScore = userIsHome ? homeScore : userIsAway ? awayScore : null;
+  const opponentScore = userIsHome ? awayScore : userIsAway ? homeScore : null;
+  const outcome = !hasFinal || userScore == null
+    ? 'Final'
+    : userScore === opponentScore ? 'Tie' : userScore > opponentScore ? 'Win' : 'Loss';
+  const opponent = userIsHome ? gameResult.awayTeam : gameResult.homeTeam;
+  const cleanLeaders = (Array.isArray(leaders) ? leaders : []).filter(
+    (leader) => leader && String(leader.name ?? '').trim() && String(leader.statLine ?? '').trim(),
+  );
+
+  return {
+    hasFinal,
+    homeScore,
+    awayScore,
+    userIsHome,
+    opponent,
+    outcome,
+    headline: outcome === 'Win' ? 'A winning week is in the books.' : outcome === 'Loss' ? 'Review the tape, then reset for next week.' : outcome === 'Tie' ? 'Even after four quarters.' : 'The official result is recorded.',
+    leaders: cleanLeaders.slice(0, 3),
+    injuries: (Array.isArray(injuries) ? injuries : []).filter(Boolean).slice(0, 4),
+    nextWeek,
+  };
+}

--- a/src/ui/utils/postgameBriefing.test.js
+++ b/src/ui/utils/postgameBriefing.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { buildPostgameBriefing } from './postgameBriefing.js';
+
+const final = {
+  homeScore: 24,
+  awayScore: 17,
+  homeTeam: { id: 1, abbr: 'HME' },
+  awayTeam: { id: 2, abbr: 'AWY' },
+  userTeamId: 1,
+};
+
+describe('buildPostgameBriefing', () => {
+  it('uses authoritative final scores for home wins, away losses, and ties', () => {
+    expect(buildPostgameBriefing({ gameResult: final })).toMatchObject({ homeScore: 24, awayScore: 17, outcome: 'Win', userIsHome: true });
+    expect(buildPostgameBriefing({ gameResult: { ...final, userTeamId: 2 } }).outcome).toBe('Loss');
+    expect(buildPostgameBriefing({ gameResult: { ...final, homeScore: 10, awayScore: 10 } }).outcome).toBe('Tie');
+  });
+
+  it('handles an away user team and sparse legacy scores honestly', () => {
+    expect(buildPostgameBriefing({ gameResult: { ...final, homeScore: 14, awayScore: 21, userTeamId: 2 } })).toMatchObject({ outcome: 'Win', userIsHome: false });
+    expect(buildPostgameBriefing({ gameResult: { ...final, homeScore: null, awayScore: '' } })).toMatchObject({ hasFinal: false, outcome: 'Final' });
+  });
+
+  it('omits blank performer metrics and keeps available consequences', () => {
+    const injury = { id: 9, name: 'A. Player' };
+    const briefing = buildPostgameBriefing({
+      gameResult: final,
+      leaders: [{ name: 'Q. Back', statLine: '20/27, 250 yards' }, { name: 'Empty', statLine: '' }, { statLine: '2 sacks' }],
+      injuries: [injury],
+    });
+    expect(briefing.leaders).toEqual([{ name: 'Q. Back', statLine: '20/27, 250 yards' }]);
+    expect(briefing.injuries).toEqual([injury]);
+  });
+});

--- a/tests/unit/PostGameSummary.spec.tsx
+++ b/tests/unit/PostGameSummary.spec.tsx
@@ -155,6 +155,21 @@ describe('PostGameSummary', () => {
     expect(screen.getByText('OUT')).toBeTruthy();
   });
 
+  it('opens existing preparation workflows and continues to the next week', () => {
+    const onPreparationAction = vi.fn();
+    const onContinue = vi.fn();
+    render(<PostGameSummary gameResult={BASE_RESULT} nextWeek={{ week: 4, opponentAbbr: 'LV' }} onPreparationAction={onPreparationAction} onContinue={onContinue} onClose={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Game Plan' }));
+    expect(onPreparationAction).toHaveBeenCalledWith('Game Plan');
+    fireEvent.click(screen.getByRole('button', { name: 'Continue to Week 4' }));
+    expect(onContinue).toHaveBeenCalledOnce();
+  });
+
+  it('does not render a performer with an empty metric', () => {
+    render(<PostGameSummary gameResult={BASE_RESULT} leaders={[{ name: 'Blank Metric', statLine: '' }]} onClose={() => {}} />);
+    expect(screen.queryByText('Blank Metric')).toBeNull();
+  });
+
   it('shows positive momentum label', () => {
     render(
       <PostGameSummary


### PR DESCRIPTION
### Motivation
- The existing postgame experience scattered the completed-week result across multiple surfaces causing duplicated information, extra navigation, and friction on mobile; the goal is a single coherent postgame→next-week flow. 
- The Game Book was vertically dense and required excessive scrolling to answer common questions; Summary-first progressive disclosure is needed to reduce friction. 
- Preserve authoritative game data and existing worker/archive plumbing while improving presentation and navigation for mobile-first players. 

### Description
- Adds a deterministic, read-only presentation helper `buildPostgameBriefing` (`src/ui/utils/postgameBriefing.js`) that consumes authoritative saved game fields (final scores, home/away ids) and filters empty performer metrics without reconstructing or mutating simulation data. 
- Evolves the postgame overlay into a mobile-first Weekly GM Briefing in `PostGameSummary.jsx`, surfacing the canonical result hero, headline, cleaned key performers, data-grounded takeaways, injury consequences, existing preparation actions (`Game Plan`, `Set Lineup`, `Training`, `Scout Opponent`), and one context-aware continue action (`Continue to Week N`). 
- Restructures the Game Book (`BoxScore.jsx`) into a tab/segmented view with a default `Summary` tab and data-dependent `Team Stats`, `Players`, and `Plays` tabs, lazy-rendering dense play rows only when `Plays` is active, and exposing `aria-selected` on tabs for accessibility. 
- Adds small navigation plumbing so returning from a postgame Game Book restores the briefing context (`App.jsx` and `LeagueDashboard.jsx`), and updates the modal back label to indicate returning to the briefing when opened from postgame. 
- Styling: compact tab and briefing action styles were added in `src/ui/styles/style.css`. 
- Tests & helpers: new unit tests `src/ui/utils/postgameBriefing.test.js` and focused additions to `tests/unit/PostGameSummary.spec.tsx` validate authoritative-score usage, home/away outcomes, omitted empty metrics, injuries, preparation routing, and continue behavior. 
- Files changed: `src/ui/utils/postgameBriefing.js`, `src/ui/components/PostGameSummary.jsx`, `src/ui/components/BoxScore.jsx`, `src/ui/App.jsx`, `src/ui/components/LeagueDashboard.jsx`, `src/ui/styles/style.css`, plus focused test updates. 

### Testing
- Ran targeted unit tests with Vitest: `npx vitest run src/ui/utils/postgameBriefing.test.js tests/unit/PostGameSummary.spec.tsx src/ui/components/__tests__/postGamePersistence.test.jsx` and all targeted tests passed. 
- Typecheck: `npm run check:sim-types` passed. 
- Production build: `npm run build` succeeded (repository-expected large-chunk warnings only). 
- Netlify parity checks and rules validation were executed and the parity build completed and publish artifacts were validated. 
- Notes and remaining work: legacy Game Book density tests that assert an always-present `<details>` structure needed migration to the new tabbed flow (those legacy assertions were adjusted where required during this rollout but a small set of legacy test assertions remain as follow-up to convert to tab-driven expectations). 

Simulation and scoring logic were not changed; all presentation helpers consume authoritative existing data and do not mutate worker or saved game state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b7702bba0832d9b8fa99918aa2b4b)