### PR TITLE
PR #1720 — Game Book Trust & Single Source of Truth V1

### DIFF
--- a/docs/game-book-trust-v1-audit.md
+++ b/docs/game-book-trust-v1-audit.md
@@ -1,0 +1,51 @@
+# Game Book Trust V1 audit
+
+## Scope and data flow
+
+The audit confirmed that `buildBoxScoreViewModel` was already the closest thing
+to a canonical postgame presentation adapter. It reads the normalized archive,
+merges an authoritative stored final with schedule identity, and produces team,
+player, scoring, play, and availability rows without writing league or save
+state. V1 makes that ownership explicit as `buildGameBookPresentation` while
+retaining the old export as a compatibility alias.
+
+| Surface / section | Input before V1 | V1 authority |
+| --- | --- | --- |
+| Game Book header and final | `GameDetailScreen` view model plus a second `BoxScore` view model | One memoized Game Book presentation passed into the embedded box score |
+| Summary / decisive moments | `BoxScore` sliced turning points or scoring rows | `presentation.decisiveMoments` |
+| Key performers | `BoxScore` filtered leader cards | `presentation.keyPerformers` |
+| Team comparison | View-model stat mapping | Unchanged canonical `teamComparisonRows` mapping |
+| Player tables and category tabs | View model built sections, then `BoxScore` rebuilt them | Canonical `playerStatSections` only |
+| Scoring summary, special teams, plays | View-model normalized rows | Unchanged presentation rows and availability flags |
+| Weekly Results featured result | A Game Book view model for score, margin, and performers | Compatibility alias to the same pure presentation builder |
+| Weekly GM Briefing / postgame | Stored strict final and canonical game id; opens Game Book for detail | No football/state change; destination resolves to the same Game Book model |
+
+## Confirmed duplication removed
+
+* The embedded Game Book fetched/parsing the archive twice: once in
+  `GameDetailScreen` and again inside `BoxScore`. The parent now passes its
+  memoized presentation object, disabling the nested request.
+* `BoxScore` rebuilt, filtered, sorted, and mapped player stat sections already
+  present on the view model. It now consumes the prepared sections directly.
+* `BoxScore` independently selected decisive moments and filtered leader cards.
+  Both are now presentation-model fields.
+* Compact leader selection could show the same multi-role player more than
+  once. Candidate ranking remains stable, but each selected player id is now
+  unique and a missing replacement is omitted by `keyPerformers`.
+
+## Intentionally unchanged
+
+The simulation engine, score production, archive schema, IndexedDB writes,
+football statistics, Weekly Briefing decision logic, and visual design are not
+changed. Existing result cards that only need archive access metadata continue
+to use `buildCompletedGamePresentation`; this is routing/availability data, not
+a competing football summary. Legacy archives continue through the existing
+normalizer and are explicitly identified by `legacyData` flags.
+
+## Remaining limitations
+
+Older saves may contain only a final score, or may omit quarter, player, team,
+or play data. The presentation reports those sections unavailable and the UI
+omits their tabs/cards; it does not reconstruct missing football outcomes.
+Canonical event-ledger games without recorded chronological quarter totals keep
+the existing honest quarter-unavailable message.

--- a/src/ui/components/BoxScore.jsx
+++ b/src/ui/components/BoxScore.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { EmptyState } from "./ScreenSystem.jsx";
-import { buildBoxScoreViewModel, buildPlayerStatSections, unwrapBoxScoreResponse } from "../utils/boxScoreViewModel.js";
+import { buildGameBookPresentation, unwrapBoxScoreResponse } from "../utils/boxScoreViewModel.js";
 import useStableRouteRequest from "../hooks/useStableRouteRequest.js";
 import { getPlayerProfileId, hasValidPlayerProfileId, openPlayerProfile } from "../utils/playerProfileNavigation.js";
 import { buildReasoningBullets } from "../../core/gameSummary.js";
@@ -45,6 +45,7 @@ function BoxScore({
   scheduleGame = null,
   isManualSimRun = false,
   backLabel = "Back to flow",
+  presentation = null,
 }) {
   const [activeTab, setActiveTab] = useState('passing');
   const [activeView, setActiveView] = useState('summary');
@@ -57,7 +58,7 @@ function BoxScore({
     setActiveTab('passing');
   }, [gameId]);
 
-  const canLoadArchive = Boolean(gameId && typeof actions?.getBoxScore === "function");
+  const canLoadArchive = Boolean(!presentation && gameId && typeof actions?.getBoxScore === "function");
   const { data: archiveGame } = useStableRouteRequest({
     requestKey: canLoadArchive ? `boxscore:${gameId}` : null,
     enabled: canLoadArchive,
@@ -68,8 +69,8 @@ function BoxScore({
   const fallbackGame = scheduleGame ?? league?.gameById?.[gameId] ?? null;
   const game = unwrapBoxScoreResponse(archiveGame) ?? fallbackGame;
   const vm = useMemo(
-    () => buildBoxScoreViewModel({ league, game, gameId, scheduleGame: fallbackGame, context: { season: league?.seasonId, week: league?.week } }),
-    [league, game, gameId, fallbackGame],
+    () => presentation ?? buildGameBookPresentation({ league, game, gameId, scheduleGame: fallbackGame, context: { season: league?.seasonId, week: league?.week } }),
+    [presentation, league, game, gameId, fallbackGame],
   );
 
   const dismissHandler = onClose ?? onBack;
@@ -94,7 +95,7 @@ function BoxScore({
   const rawFlags = vm.gameReasoningFlags ?? game?.gameReasoningFlags ?? [];
   const reasoningBullets = buildReasoningBullets(rawFlags);
 
-  const tableSections = buildPlayerStatSections(vm.playerTables, {});
+  const tableSections = vm.playerStatSections ?? [];
   const activeSection = tableSections.find((s) => s.key === activeTab) ?? null;
 
   // Score values
@@ -172,12 +173,12 @@ function BoxScore({
 
   // Key leaders — top performers surfaced above dense tables so mobile users
   // answer "who won it" before drilling into full stat sheets.
-  const keyLeaders = (vm.statLeaderCards ?? []).filter((leader) => leader.available);
+  const keyLeaders = vm.keyPerformers ?? [];
 
   // Decisive moments — short, always-visible teaser (turning points, falling
   // back to the first few scoring plays). The exhaustive list lives in the
   // collapsed "Full Scoring Summary" section below.
-  const decisiveMoments = (vm.turningPointRows?.length ? vm.turningPointRows : vm.scoringSummary ?? []).slice(0, 4);
+  const decisiveMoments = vm.decisiveMoments ?? [];
   const scoringSummaryRows = vm.scoringSummary ?? [];
   const teamComparisonRows = vm.teamComparisonRows ?? [];
   const playByPlayRows = vm.playByPlayRows ?? [];

--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -2,7 +2,7 @@ import React, { useMemo, useRef } from 'react';
 import BoxScorePanel from './BoxScorePanel.jsx';
 import { EmptyState, ScreenHeader, SectionCard } from './ScreenSystem.jsx';
 import { buildWeeklyDecisionImpact } from '../utils/weeklyDecisionImpact.js';
-import { buildBoxScoreViewModel, unwrapBoxScoreResponse } from '../utils/boxScoreViewModel.js';
+import { buildGameBookPresentation, unwrapBoxScoreResponse } from '../utils/boxScoreViewModel.js';
 import useStableRouteRequest from '../hooks/useStableRouteRequest.js';
 import { resolveCanonicalCompletedGame } from '../utils/canonicalCompletedGame.js';
 import { getGame as getLocalArchivedGame } from '../../core/archive/gameArchive.ts';
@@ -98,7 +98,7 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
   const userTeam = (league?.teams ?? []).find((team) => Number(team?.id) === Number(league?.userTeamId));
   const prepContext = buildWeeklyDecisionImpact({ league, userTeam, lastGame: scheduleGame });
   const detailVm = useMemo(
-    () => buildBoxScoreViewModel({
+    () => buildGameBookPresentation({
       league,
       game: canonicalGame,
       gameId,
@@ -240,6 +240,7 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
       </div>
       <SectionCard variant="info" title="Game Book Detail" subtitle="Summary → Team stats → Player leaders → Drive/play recap.">
         <BoxScorePanel
+          presentation={detailVm}
           gameId={gameId}
           actions={actions}
           league={league}
@@ -253,4 +254,3 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
     </div>
   );
 }
-

--- a/src/ui/utils/boxScoreViewModel.js
+++ b/src/ui/utils/boxScoreViewModel.js
@@ -220,9 +220,16 @@ const LEADER_SPECS = [
 
 export function buildStatLeaderCards(playerTables = {}) {
   const players = [...(playerTables.away ?? []), ...(playerTables.home ?? [])];
+  const selectedPlayerIds = new Set();
   return LEADER_SPECS.map((spec) => {
     const candidates = players.filter((player) => spec.includeKeys.some((key) => (toNum(player?.stats?.[key]) ?? 0) > 0));
-    const player = sortLeaderCandidates(candidates, spec.primaryKeys, spec.tieKeys)[0] ?? null;
+    // A multi-role player can lead more than one category. The compact key-
+    // performer strip is more useful when every person appears once; choose the
+    // next recorded candidate in deterministic order rather than duplicating a
+    // player or manufacturing a line.
+    const player = sortLeaderCandidates(candidates, spec.primaryKeys, spec.tieKeys)
+      .find((candidate) => !selectedPlayerIds.has(String(candidate?.playerId))) ?? null;
+    if (player?.playerId != null) selectedPlayerIds.add(String(player.playerId));
     return {
       key: spec.key,
       label: spec.label,
@@ -488,7 +495,7 @@ export function unwrapBoxScoreResponse(response) {
   return response;
 }
 
-export function buildBoxScoreViewModel({ league, game, gameId, context = {}, scheduleGame = null } = {}) {
+export function buildGameBookPresentation({ league, game, gameId, context = {}, scheduleGame = null } = {}) {
   const rawGame = unwrapBoxScoreResponse(game);
   const payload = mergeArchivedGameWithScheduleResult(rawGame, scheduleGame) ?? normalizeArchivedGamePayload(rawGame ?? null) ?? rawGame ?? null;
   if (!payload) {
@@ -572,6 +579,10 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
     return 'Game data missing.';
   })();
 
+  const playerStatSections = buildPlayerStatSections(playerTables);
+  const statLeaderCards = buildStatLeaderCards(playerTables);
+  const decisiveMoments = (turningPointRows.length ? turningPointRows : scoringSummary).slice(0, 4);
+
   return {
     gameId: payload?.gameId ?? payload?.id ?? gameId ?? null,
     season: payload?.seasonId ?? context?.season ?? league?.seasonId ?? null,
@@ -584,6 +595,8 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
     finalScoreLine: formatScoreLine(awayTeam, homeTeam, finalScore),
     headlineSummary: buildHeadline({ awayTeam, homeTeam, finalScore, status: payload?.played === false ? 'Scheduled' : 'Final' }),
     winnerSide,
+    winner: winnerSide ? (winnerSide === 'home' ? homeTeam : awayTeam) : null,
+    tie: Boolean(hasScore && homeScore === awayScore),
     margin: hasScore ? Math.abs(homeScore - awayScore) : null,
     quarterScores,
     isCanonicalLedger,
@@ -597,8 +610,10 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
     notablePerformanceRows,
     injuryRows,
     playerTables,
-    playerStatSections: buildPlayerStatSections(playerTables),
-    statLeaderCards: buildStatLeaderCards(playerTables),
+    playerStatSections,
+    statLeaderCards,
+    keyPerformers: statLeaderCards.filter((card) => card.available),
+    decisiveMoments,
     availableData: {
       finalScore: hasScore,
       quarterScores: hasQuarter,
@@ -610,6 +625,11 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
       turningPoints: hasTurningPoints,
       notablePerformances: hasNotablePerformances,
       injuries: hasInjuries,
+      specialTeams: Boolean(specialTeams?.hasData),
+    },
+    legacyData: {
+      archive: !isCanonicalLedger,
+      quarterScores: hasQuarter && !isCanonicalLedger,
     },
     gameFlowSummary: buildGameFlowSummary(payload),
     gameReasoningFlags: Array.isArray(payload?.gameReasoningFlags) ? payload.gameReasoningFlags : [],
@@ -620,3 +640,8 @@ export function buildBoxScoreViewModel({ league, game, gameId, context = {}, sch
     hasDetailedStats: archiveQuality === QUALITY.full || archiveQuality === QUALITY.partial,
   };
 }
+
+// Backward-compatible name for callers outside the Game Book. New postgame
+// presentation surfaces should use buildGameBookPresentation so the ownership
+// boundary is explicit.
+export const buildBoxScoreViewModel = buildGameBookPresentation;

--- a/src/ui/utils/boxScoreViewModel.test.js
+++ b/src/ui/utils/boxScoreViewModel.test.js
@@ -1,8 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { buildBoxScoreViewModel, unwrapBoxScoreResponse } from './boxScoreViewModel.js';
+import { buildBoxScoreViewModel, buildGameBookPresentation, unwrapBoxScoreResponse } from './boxScoreViewModel.js';
 import { buildGameBookStory } from './gameBookStory.js';
 
 describe('buildBoxScoreViewModel', () => {
+  it('keeps the compatibility export on the canonical Game Book presentation builder', () => {
+    expect(buildBoxScoreViewModel).toBe(buildGameBookPresentation);
+  });
+
   it('unwraps BOX_SCORE envelopes with explicit null payload game values', () => {
     expect(unwrapBoxScoreResponse({ type: 'BOX_SCORE', payload: { game: null, error: 'not found' } })).toBeNull();
   });
@@ -161,6 +165,30 @@ describe('buildBoxScoreViewModel', () => {
     expect(vm.statLeaderCards.find((card) => card.key === 'receiving')?.line).toContain('Home WR');
     expect(vm.statLeaderCards.find((card) => card.key === 'defense')?.line).toContain('Away Edge');
     expect(vm.statLeaderCards.find((card) => card.key === 'kicking')?.line).toContain('Home K');
+  });
+
+  it('exposes winner/tie and unique, deterministic key performers', () => {
+    const input = {
+      game: {
+        homeId: 1,
+        awayId: 2,
+        homeScore: 24,
+        awayScore: 24,
+        playerStats: {
+          home: {
+            10: { name: 'Dual Threat', stats: { passAtt: 20, passYd: 210, rushAtt: 8, rushYd: 70 } },
+            11: { name: 'Runner Up', stats: { rushAtt: 12, rushYd: 55 } },
+          },
+          away: {},
+        },
+      },
+    };
+    const first = buildGameBookPresentation(input);
+    const second = buildGameBookPresentation(input);
+    expect(first.tie).toBe(true);
+    expect(first.winner).toBeNull();
+    expect(first.keyPerformers.map((leader) => leader.playerId)).toEqual([10, 11]);
+    expect(second.keyPerformers).toEqual(first.keyPerformers);
   });
 
   it('marks stat leader cards unavailable instead of fabricating missing groups', () => {


### PR DESCRIPTION
### Motivation

- The Game Book presentation was assembled in multiple places (route + embedded box score), producing duplicated mapping, sorting, and leader/turning-point selection that risked stale or conflicting UI output. 
- The goal is a single authoritative presentation model so every UI surface (Game Book, postgame summary, Weekly Results, result cards) shows identical canonical values without changing simulation outcomes. 
- Preserve archive/schema/backwards compatibility and never recompute or mutate recorded football results; this is a presentation-only consolidation.

### Description

- Introduced a single pure presentation adapter `buildGameBookPresentation()` (keeps the old `buildBoxScoreViewModel` export as a backward-compatible alias) and extended the model with explicit `winner`, `tie`, `keyPerformers`, `decisiveMoments`, `specialTeams` availability, and `legacyData` flags. 
- Made compact leader selection deterministic and unique by player id so multi-role players are not duplicated in the top-performers strip. 
- Removed duplicate archive parsing by having `GameDetailScreen` build and memoize the presentation and pass it into the embedded box score; `BoxScore` now consumes prepared `playerStatSections`, `keyPerformers`, and `decisiveMoments` instead of rebuilding them. 
- Files changed: `src/ui/utils/boxScoreViewModel.js`, `src/ui/utils/boxScoreViewModel.test.js`, `src/ui/components/GameDetailScreen.jsx`, `src/ui/components/BoxScore.jsx`, and added `docs/game-book-trust-v1-audit.md` documenting the audit, removed duplication, and known limitations.

### Testing

- Ran `node --check src/ui/utils/boxScoreViewModel.js` and targeted unit tests for Game Book surfaces (Vitest subset of Game Book / Game Detail / Weekly Results tests) which passed (8 files / 113 tests). 
- Ran full unit suite with `npm run test:unit` which completed successfully (463 files / 5,689 tests passed). 
- Ran `npm run check:sim-types` (TS check for sim types) and `npm run build` which both succeeded; the build emitted the expected large chunk-size warning only. 
- Playwright E2E for `tests/e2e/mobile_game_day_trust.spec.js` could not be completed in this environment because Playwright’s Chromium binary is not present and `npx playwright install chromium` failed due to a CDN download (HTTP 403 `Domain forbidden`), so E2E verification was skipped; `npm run check:deploy` was not run because no Netlify/deploy config changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6bc7a8fd2c832dad6fb873149d7e46)