### PR TITLE
Fix test integrity in `simulateSingleWeek`

### DIFF
--- a/tests/e2e/helpers/franchise.js
+++ b/tests/e2e/helpers/franchise.js
@@ -256,22 +256,14 @@ export async function simulateSingleWeek(page, options = {}) {
   // week-advance assertion below guarantees the transition actually happened.
   if (advanceAnyway) {
     const advanceAnywayBtn = page.getByRole('button', { name: /Advance anyway/i });
-    try {
-      await advanceAnywayBtn.waitFor({ state: 'visible', timeout: 2000 });
-      await expect(advanceAnywayBtn).toBeEnabled({ timeout: 5000 });
-      await advanceAnywayBtn.click();
-    } catch (err) {
-      if (err.name !== 'TimeoutError') throw err;
-    }
+    await advanceAnywayBtn.waitFor({ state: 'visible', timeout: 2000 });
+    await expect(advanceAnywayBtn).toBeEnabled({ timeout: 5000 });
+    await advanceAnywayBtn.click();
   }
   const skipPromptBtn = page.getByRole('button', { name: /Simulate \(Skip\)/i });
-  try {
-    await skipPromptBtn.waitFor({ state: 'visible', timeout: 10000 });
-    await expect(skipPromptBtn).toBeEnabled({ timeout: 5000 });
-    await skipPromptBtn.click();
-  } catch (err) {
-    if (err.name !== 'TimeoutError') throw err;
-  }
+  await skipPromptBtn.waitFor({ state: 'visible', timeout: 10000 });
+  await expect(skipPromptBtn).toBeEnabled({ timeout: 5000 });
+  await skipPromptBtn.click();
   await page.waitForFunction(
     (baseline) => {
       const week = window?.state?.league?.week ?? baseline;


### PR DESCRIPTION
- Fix test integrity by enforcing strict UI playability on weekly simulation bypasses in tests.
- Removed silent `.catch(() => {})` anti-patterns on Playwright locator clicks in the E2E helper `simulateSingleWeek` for "Advance anyway" and "Simulate (Skip)" buttons.
- The test suite handles bypassing the gate explicitly using the `advanceAnyway` flag, otherwise it relies on natural flow.
- Ensure the tests do not silently skip potential missing UI bugs.

---
*PR created automatically by Jules for task [17061853544586100093](https://jules.google.com/task/17061853544586100093) started by @rbcati*