### PR TITLE
Add player decision presentation, UI card, and tests

### DIFF
--- a/docs/player-decision-cards-v1-audit.md
+++ b/docs/player-decision-cards-v1-audit.md
@@ -54,6 +54,10 @@ It is pure, performs no persistence or worker calls, mutates no inputs, uses no 
 
 The model recognizes legacy `depthOrder`, contract `years`/`salary`, injury-week aliases, potential aliases, free agents, prospects, retirees, practice squad, and injured reserve. Missing player records return an unavailable model; missing sections are omitted or explicitly labeled unavailable; missing metrics never become invented zeroes. Legitimate recorded zeroes remain visible when another usage field establishes a real sample. No save migration or persisted schema change is required.
 
+Review hardening keeps a machine-readable `injured_reserve` key separate from its display label, so IR players retain recorded depth roles and roster evaluation. Special-teams totals are normalized once from canonical `fieldGoalsMade` / `fieldGoalsAttempted` names (plus recorded long-kick and punting aliases) before presentation. Archetype derivation now requires meaningful position-specific rating evidence; explicit recorded archetypes remain authoritative, while empty, overall-only, and partial legacy rating objects omit the label.
+
 ## Performance and follow-up
 
 The model is memoized once in Player Profile. It consumes already-resolved player/team/league context and already-assembled season totals, causing no IndexedDB load and no additional render-time league scan beyond the existing retention helper. Dense career and game-log details remain behind existing profile tabs. A future iteration can migrate other player surfaces only after their action handlers and trade/release authorities can be passed without duplicating legality checks.
+
+Player Profile workflow links are routed through the League Dashboard boundary: the selected-player ID and context are cleared before the existing destination tab is activated. This prevents the modal from covering Depth Chart or Contract Center without duplicating either workflow's action rules.

--- a/docs/player-decision-cards-v1-audit.md
+++ b/docs/player-decision-cards-v1-audit.md
@@ -1,0 +1,59 @@
+# Player Decision Cards V1 — implementation audit
+
+## Scope and live surfaces
+
+The live, full player surface is `PlayerProfile.jsx`. It resolves an in-league player, then augments it with worker-provided career rows, archive seasons, transactions, records, game logs, awards, development, morale, negotiation, and contract context. `PlayerDetailModal.jsx` is a smaller career-table modal used by other roster entry points; it is not the authoritative full profile. Roster cards, the depth-chart editor, Contract/Re-Sign Center, Trade Center, release previews, Injury Report, comparison, and history surfaces remain specialized workflows.
+
+V1 integrates only the full `PlayerProfile` overview. It deliberately leaves `PlayerDetailModal`, roster rows/cards, depth chart, contract/re-sign, trade/release, free agency, comparison, injury, awards, and history layouts unchanged. Those screens retain their existing calculations and legal-action guards.
+
+## Fact authority
+
+| Player fact | Live authority used in V1 | Notes |
+| --- | --- | --- |
+| Identity, ratings, status | resolved player record (`resolvePlayerForProfile`) | Missing jersey, experience, potential, and ratings remain absent rather than becoming zero. |
+| Team | resolved profile team / canonical team identity | Free agents, prospects, and retired players do not receive an invented team. |
+| Depth role | `player.depthChart.role`, then `depthChart.order` / legacy `depthOrder` | V1 never promotes the highest-OVR player to starter. Canonical order 1/2 maps to starter/backup; unassigned players say role unavailable. |
+| Injury availability | recorded injury object and legacy injury-week fields | No injury-risk forecast is introduced. |
+| Archetype | recorded `player.archetype`, else existing `derivePlayerArchetype()` when rating inputs exist | Missing rating inputs omit the archetype. The existing evaluation thresholds are unchanged. |
+| Current performance | current-season totals already assembled from canonical player game logs in `PlayerProfile` | Position-aware metrics omit missing fields. Derived efficiency is shown only with a recorded denominator. Recent form is omitted because no cheap canonical multi-game form classifier was found. |
+| Development | recorded overall/rating history; legacy `progressionDelta` fallback | Incompatible/missing checkpoints yield “Insufficient history.” Existing progression mechanics and projections are unchanged. |
+| Contract term/cost | recorded contract fields and legacy aliases | V1 does not recompute dead cap. Guarantee, tag, and richer negotiation details remain in their existing specialist surfaces. |
+| Contract recommendation, role importance, replacement | `evaluateReSigningPriority()` | This is the existing shared retention authority. Its lowercase replacement value is normalized only for display. V1 does not expect a precomputed recommendation on the player. |
+| Morale | recorded player morale and existing profile morale engine | Preserved in the detailed profile; not converted into a new recommendation formula. |
+| Awards/history/career stats | existing award timeline, record book, archive merge, career timeline, and game-log helpers | Existing detail remains available below the decision summary and in the existing tabs. |
+| Trade value, release/dead cap, action legality | Trade Center, release preview/handlers, and their existing helpers | Not copied into V1 because no single profile-safe authoritative value/action model was available. |
+
+## Existing recommendation systems
+
+The repository already contains several contextual evaluators. `evaluateReSigningPriority()` is authoritative for retention recommendation, role importance, replacement difficulty, development outlook, market difficulty, and extension readiness. Player evaluation owns the existing archetype derivation. Contract negotiation owns leverage/risk. Trade valuation owns trade values. Release preview owns release consequences. The decision model reuses retention and archetype evaluation and does not create competing trade, release, cap, negotiation, or football evaluation formulas.
+
+Recommendations appear only when a team roster context can be evaluated. They are deterministic display mappings of existing retention results, with factual role/replacement/expiration reasons. An injured roster player receives “Monitor injury recovery.” Free agents, prospects, retirees, and incomplete team contexts omit the recommendation rather than receiving a speculative instruction.
+
+## Duplication and consolidation
+
+Player presentation is currently duplicated across `PlayerProfile`, `PlayerDetailModal`, `PlayerCard`, roster tables, Contract Center, Trade Center, release previews, and comparison. `buildPlayerProfileAnalysis()` also assembles an older general profile object but includes a separate salary-versus-OVR heuristic; V1 does not reuse that heuristic for contract outlook. V1 introduces `buildPlayerDecisionPresentation()` as the one pure decision-summary boundary and makes the full Player Profile its first consumer. Existing detailed rendering is preserved to avoid broad workflow changes.
+
+The resulting model contains:
+
+`identity`, `role`, `availability`, `performance`, `development`, `contract`, `rosterValue`, `replacement`, `recommendation`, `context`, `availableData`, and `omittedReasons`.
+
+It is pure, performs no persistence or worker calls, mutates no inputs, uses no randomness, and returns the same result for the same inputs.
+
+## Unsupported and intentionally omitted in V1
+
+- Recent form: reliable weekly rows exist in the full profile, but no canonical multi-game form authority exists.
+- Trustworthy dead-cap consequence and release legality: retained in release preview/worker guards.
+- A single profile-safe trade value and trade legality model: retained in Trade Center.
+- Team-friendly/market-aligned contract pricing: the existing profile heuristic estimates salary from OVR, so it is not promoted into the decision card.
+- Guaranteed money: displayed only if directly recorded; old contract shapes generally omit it.
+- Franchise option/tag eligibility and no-trade clauses: no consistent cross-save profile action authority was confirmed.
+- Snap share/current usage role: not consistently recorded across saves.
+- Starter mutation, extension submission, trade submission, release, IR placement, and compare handlers: the full profile does not receive consistent legal handlers for all entry points. V1 links only to existing specialist screens and leaves their guards authoritative.
+
+## Legacy and partial records
+
+The model recognizes legacy `depthOrder`, contract `years`/`salary`, injury-week aliases, potential aliases, free agents, prospects, retirees, practice squad, and injured reserve. Missing player records return an unavailable model; missing sections are omitted or explicitly labeled unavailable; missing metrics never become invented zeroes. Legitimate recorded zeroes remain visible when another usage field establishes a real sample. No save migration or persisted schema change is required.
+
+## Performance and follow-up
+
+The model is memoized once in Player Profile. It consumes already-resolved player/team/league context and already-assembled season totals, causing no IndexedDB load and no additional render-time league scan beyond the existing retention helper. Dense career and game-log details remain behind existing profile tabs. A future iteration can migrate other player surfaces only after their action handlers and trade/release authorities can be passed without duplicating legality checks.

--- a/src/core/__tests__/playerDecisionPresentation.test.js
+++ b/src/core/__tests__/playerDecisionPresentation.test.js
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import { buildPlayerDecisionPresentation } from '../playerDecisionPresentation.js';
+
+const starter = {
+  id: 1, name: 'Jordan Longname', pos: 'QB', age: 25, ovr: 84, potential: 88, teamId: 10,
+  status: 'active', depthChart: { order: 1, role: 'starter' }, progressionDelta: 2,
+  ratings: { awareness: 80, throwAccuracy: 82, throwPower: 80 },
+  contract: { yearsRemaining: 1, baseAnnual: 18 },
+};
+const team = { id: 10, abbr: 'POR', capRoom: 40, wins: 7, losses: 2 };
+const league = { phase: 'regular', week: 10, players: [starter, { id: 2, pos: 'QB', teamId: 10, status: 'active', ovr: 68 }] };
+
+describe('buildPlayerDecisionPresentation', () => {
+  it('builds a deterministic starter decision from canonical role and re-sign evaluation', () => {
+    const input = { player: starter, team, league, seasonStats: { passAtt: 120, passComp: 80, passYd: 1050, passTD: 8, interceptions: 2 } };
+    const first = buildPlayerDecisionPresentation(input);
+    expect(first).toEqual(buildPlayerDecisionPresentation(input));
+    expect(first.role.label).toBe('Starter');
+    expect(first.performance.metrics.map((metric) => metric.value)).toContain(1050);
+    expect(first.development.label).toBe('Rising');
+    expect(first.replacement.label).toBe('High');
+    expect(first.recommendation.reasons.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(first.recommendation.reasons).size).toBe(first.recommendation.reasons.length);
+  });
+
+  it.each([
+    ['backup', { ...starter, depthChart: { order: 2 }, contract: { years: 3 } }, 'Backup'],
+    ['free agent', { ...starter, teamId: null, status: 'free_agent', contract: null }, 'Free agent'],
+    ['draft prospect', { ...starter, teamId: null, status: 'draft_eligible', contract: null }, 'Draft prospect'],
+    ['retired player', { ...starter, status: 'retired', retired: true, contract: null }, 'Retired'],
+    ['legacy role', { ...starter, depthChart: null, depthOrder: 1 }, 'Starter'],
+  ])('handles %s identity/role', (_label, player, expected) => {
+    expect(buildPlayerDecisionPresentation({ player, league }).role.label).toBe(expected);
+  });
+
+  it('reports injury availability and omits an unavailable jersey number', () => {
+    const result = buildPlayerDecisionPresentation({ player: { ...starter, jerseyNumber: undefined, injury: { name: 'Hamstring', weeksRemaining: 3 } }, team, league });
+    expect(result.identity.jerseyNumber).toBeNull();
+    expect(result.availability).toMatchObject({ available: false, label: 'Unavailable · 3w' });
+    expect(result.recommendation.action).toBe('Monitor injury recovery');
+  });
+
+  it.each([
+    ['RB', { rushAtt: 20, rushYd: 100, rushTD: 0, recYd: 12 }, 'Yards / carry'],
+    ['WR', { receptions: 0, recYd: 0, recTD: 0, targets: 1 }, 'Receptions'],
+    ['LB', { tackles: 10, sacks: 0, interceptions: 0 }, 'Tackles'],
+    ['K', { fgMade: 0, fgAttempts: 1, longestFG: 0 }, 'Field goals'],
+  ])('formats %s stats and preserves legitimate zeros', (pos, seasonStats, metric) => {
+    const result = buildPlayerDecisionPresentation({ player: { ...starter, pos }, seasonStats });
+    expect(result.performance.available).toBe(true);
+    expect(result.performance.metrics.some((row) => row.label === metric)).toBe(true);
+  });
+
+  it('distinguishes missing stats from zero values and ignores missing fields', () => {
+    expect(buildPlayerDecisionPresentation({ player: starter }).performance).toMatchObject({ available: false, metrics: [] });
+    const zero = buildPlayerDecisionPresentation({ player: starter, seasonStats: { passAtt: 1, passYd: 0, passTD: 0 } });
+    expect(zero.performance.metrics.find((metric) => metric.label === 'Passing yards').value).toBe(0);
+  });
+
+  it.each([
+    [[{ ovr: 70 }, { ovr: 74 }], 'Rising'],
+    [[{ overall: 70 }, { overall: 70 }], 'Stable'],
+    [[{ ovr: 74 }, { ovr: 70 }], 'Declining'],
+    [[], 'Insufficient history'],
+  ])('classifies recorded development history', (ratingHistory, label) => {
+    expect(buildPlayerDecisionPresentation({ player: { ...starter, progressionDelta: undefined, ratingHistory } }).development.label).toBe(label);
+  });
+
+  it('handles no-contract and legacy contract shapes honestly', () => {
+    expect(buildPlayerDecisionPresentation({ player: { ...starter, contract: null } }).contract.label).toBe('No contract data');
+    const legacy = buildPlayerDecisionPresentation({ player: { ...starter, contract: { years: 2, salary: 6 } } });
+    expect(legacy.contract).toMatchObject({ yearsRemaining: 2, capHit: 6, available: true });
+  });
+
+  it('preserves missing identity numbers instead of coercing them to zero', () => {
+    const result = buildPlayerDecisionPresentation({
+      player: { ...starter, age: null, potential: null, experience: null, pot: null, ratings: { ...starter.ratings, potential: null } },
+    });
+    expect(result.identity).toMatchObject({ age: null, potential: null, experience: null });
+  });
+
+  it.each([null, '', '   ', '\t'])('does not treat missing contract years %j as expiring', (yearsRemaining) => {
+    const result = buildPlayerDecisionPresentation({
+      player: { ...starter, contract: { yearsRemaining, baseAnnual: null, guaranteedMoney: null } },
+    });
+    expect(result.contract).toMatchObject({
+      label: 'Under contract',
+      yearsRemaining: null,
+      capHit: null,
+      guaranteed: null,
+    });
+  });
+
+  it('treats a null progression delta without comparable history as insufficient', () => {
+    const result = buildPlayerDecisionPresentation({
+      player: { ...starter, progressionDelta: null, ratingHistory: [] },
+    });
+    expect(result.development).toMatchObject({ label: 'Insufficient history', available: false });
+  });
+
+  it('preserves meaningful numeric zero and supports trimmed numeric strings', () => {
+    const zero = buildPlayerDecisionPresentation({
+      player: { ...starter, age: 0, potential: 0, experience: 0, depthChart: { order: 0 }, contract: { yearsRemaining: 0, baseAnnual: 0, guaranteedMoney: 0 } },
+    });
+    expect(zero.identity).toMatchObject({ age: 0, potential: 0, experience: 0 });
+    expect(zero.role.depthOrder).toBe(0);
+    expect(zero.contract).toMatchObject({ yearsRemaining: 0, capHit: 0, guaranteed: 0, label: 'Rental / expiring' });
+
+    const numericString = buildPlayerDecisionPresentation({
+      player: { ...starter, age: ' 25 ', potential: ' 88 ', experience: ' 3 ', contract: { yearsRemaining: ' 2 ', baseAnnual: ' 6 ' } },
+    });
+    expect(numericString.identity).toMatchObject({ age: 25, potential: 88, experience: 3 });
+    expect(numericString.contract).toMatchObject({ yearsRemaining: 2, capHit: 6 });
+  });
+
+  it.each([' ', '\n\t', 'not-a-number', NaN, Infinity, -Infinity])('rejects non-finite or blank numeric input %j', (value) => {
+    const result = buildPlayerDecisionPresentation({
+      player: { ...starter, age: value, potential: value, experience: value, depthChart: { order: value }, contract: { yearsRemaining: value, baseAnnual: value, guaranteedMoney: value } },
+    });
+    expect(result.identity).toMatchObject({ age: null, potential: null, experience: null });
+    expect(result.role.depthOrder).toBeNull();
+    expect(result.contract).toMatchObject({ yearsRemaining: null, capHit: null, guaranteed: null });
+  });
+
+  it('does not evaluate replacement or recommend actions without team inputs', () => {
+    const result = buildPlayerDecisionPresentation({ player: starter, league });
+    expect(result.replacement).toBeNull();
+    expect(result.recommendation).toBeNull();
+    expect(result.omittedReasons).toContain('Replacement evaluation unavailable');
+  });
+});

--- a/src/core/__tests__/playerDecisionPresentation.test.js
+++ b/src/core/__tests__/playerDecisionPresentation.test.js
@@ -41,6 +41,29 @@ describe('buildPlayerDecisionPresentation', () => {
   });
 
   it.each([
+    ['recorded IR status', { status: 'injured_reserve' }],
+    ['legacy onIR flag', { status: 'active', onIR: true }],
+  ])('keeps depth and roster evaluation for %s', (_label, irFields) => {
+    const injured = { ...starter, ...irFields, injury: { name: 'Knee', weeksRemaining: 4 } };
+    const irLeague = { ...league, players: [injured, ...league.players.slice(1)] };
+    const result = buildPlayerDecisionPresentation({ player: injured, team, league: irLeague });
+    expect(result.identity).toMatchObject({ statusKey: 'injured_reserve', status: 'Injured reserve' });
+    expect(result.role.label).toBe('Starter');
+    expect(result.availability.available).toBe(false);
+    expect(result.rosterValue).not.toBeNull();
+    expect(result.replacement).not.toBeNull();
+    expect(result.recommendation.action).toBe('Monitor injury recovery');
+  });
+
+  it('uses only recorded or sufficiently evidenced archetypes', () => {
+    expect(buildPlayerDecisionPresentation({ player: { ...starter, archetype: 'Recorded Field General', ratings: {} } }).role.archetype).toBe('Recorded Field General');
+    expect(buildPlayerDecisionPresentation({ player: starter }).role.archetype).toBeTruthy();
+    expect(buildPlayerDecisionPresentation({ player: { ...starter, ratings: {} } }).role.archetype).toBeNull();
+    expect(buildPlayerDecisionPresentation({ player: { ...starter, ratings: { ovr: 84, potential: 88 } } }).role.archetype).toBeNull();
+    expect(buildPlayerDecisionPresentation({ player: { ...starter, ratings: { throwPower: 90 } } }).role.archetype).toBeNull();
+  });
+
+  it.each([
     ['RB', { rushAtt: 20, rushYd: 100, rushTD: 0, recYd: 12 }, 'Yards / carry'],
     ['WR', { receptions: 0, recYd: 0, recTD: 0, targets: 1 }, 'Receptions'],
     ['LB', { tackles: 10, sacks: 0, interceptions: 0 }, 'Tackles'],
@@ -55,6 +78,13 @@ describe('buildPlayerDecisionPresentation', () => {
     expect(buildPlayerDecisionPresentation({ player: starter }).performance).toMatchObject({ available: false, metrics: [] });
     const zero = buildPlayerDecisionPresentation({ player: starter, seasonStats: { passAtt: 1, passYd: 0, passTD: 0 } });
     expect(zero.performance.metrics.find((metric) => metric.label === 'Passing yards').value).toBe(0);
+  });
+
+  it('omits special-teams performance without a recorded attempt sample', () => {
+    expect(buildPlayerDecisionPresentation({ player: { ...starter, pos: 'K' }, seasonStats: { gamesPlayed: 1, fgMade: 0, fgAttempts: 0 } }).performance.available).toBe(false);
+    expect(buildPlayerDecisionPresentation({ player: { ...starter, pos: 'P' }, seasonStats: { gamesPlayed: 1, punts: 0, puntYards: 0 } }).performance.available).toBe(false);
+    const puntsWithoutYards = buildPlayerDecisionPresentation({ player: { ...starter, pos: 'P' }, seasonStats: { punts: 2 } });
+    expect(puntsWithoutYards.performance.metrics.map((metric) => metric.label)).toEqual(['Punts']);
   });
 
   it.each([

--- a/src/core/playerDecisionPresentation.js
+++ b/src/core/playerDecisionPresentation.js
@@ -10,19 +10,24 @@ const numberOrNull = (value) => {
 
 const titleCase = (value) => String(value ?? '').replaceAll('_', ' ').replace(/\b\w/g, (letter) => letter.toUpperCase());
 
+const STATUS_LABELS = {
+  retired: 'Retired', draft_prospect: 'Draft prospect', practice_squad: 'Practice squad',
+  injured_reserve: 'Injured reserve', free_agent: 'Free agent', active_roster: 'Active roster',
+};
+
 function playerStatus(player, league) {
-  if (player?.retired || player?.isRetired || player?.status === 'retired') return 'Retired';
+  if (player?.retired || player?.isRetired || player?.status === 'retired') return 'retired';
   const draftClass = Array.isArray(league?.draftClass) ? league.draftClass : [];
   if (player?.isProspect || player?.draftEligible || player?.status === 'draft_eligible'
-    || draftClass.some((prospect) => String(prospect?.id ?? prospect?.prospectId) === String(player?.id ?? player?.prospectId))) return 'Draft prospect';
-  if (player?.status === 'practice_squad') return 'Practice squad';
-  if (player?.status === 'injured_reserve' || player?.onIR) return 'Injured reserve';
-  if (player?.teamId == null || player?.teamId === 'FA' || player?.status === 'free_agent') return 'Free agent';
-  return titleCase(player?.status === 'active' || !player?.status ? 'active roster' : player.status);
+    || draftClass.some((prospect) => String(prospect?.id ?? prospect?.prospectId) === String(player?.id ?? player?.prospectId))) return 'draft_prospect';
+  if (player?.status === 'practice_squad') return 'practice_squad';
+  if (player?.status === 'injured_reserve' || player?.onIR) return 'injured_reserve';
+  if (player?.teamId == null || player?.teamId === 'FA' || player?.status === 'free_agent') return 'free_agent';
+  return player?.status === 'active' || !player?.status ? 'active_roster' : String(player.status);
 }
 
-function depthRole(player, status) {
-  if (status !== 'Active Roster' && status !== 'Injured Reserve') return status;
+function depthRole(player, statusKey) {
+  if (!['active_roster', 'injured_reserve'].includes(statusKey)) return STATUS_LABELS[statusKey] ?? titleCase(statusKey);
   const canonical = player?.depthChart?.role;
   if (canonical) return titleCase(canonical);
   const order = numberOrNull(player?.depthChart?.order ?? player?.depthOrder ?? player?.depthRank);
@@ -30,6 +35,36 @@ function depthRole(player, status) {
   if (order === 2) return 'Backup';
   if (order != null && order > 2) return 'Reserve';
   return 'Role unavailable';
+}
+
+function hasArchetypeEvidence(player) {
+  const source = { ...(player?.ratings ?? {}), ...(player?.attributesV2 ?? {}) };
+  const has = (...keys) => keys.every((key) => source[key] != null && Number.isFinite(Number(source[key])));
+  switch (getPositionGroup(player)) {
+    case 'QB': return has('awareness', 'throwPower') && (has('throwAccuracy') || has('throwAccuracyShort'));
+    case 'RB': return has('trucking', 'juking');
+    case 'RECEIVER': return has('speed', 'catching', 'catchInTraffic');
+    case 'OL': return has('runBlock', 'passBlock');
+    case 'FRONT7': return has('runStop') && (has('passRush') || has('passRushSpeed'));
+    case 'SECONDARY': return has('coverage', 'speed', 'awareness');
+    default: return false;
+  }
+}
+
+export function normalizePlayerDecisionSeasonStats(stats) {
+  if (!stats) return null;
+  const normalized = { ...stats };
+  const alias = (target, ...sources) => {
+    const value = sources.map((key) => stats?.[key]).find((candidate) => candidate != null);
+    if (value != null) normalized[target] = value;
+  };
+  alias('fgMade', 'fieldGoalsMade', 'fgMade');
+  alias('fgAttempts', 'fieldGoalsAttempted', 'fgAttempts', 'fgAtt');
+  alias('longestFG', 'longestFieldGoal', 'longestFG', 'fieldGoalLong');
+  alias('punts', 'punts');
+  alias('puntYards', 'puntYards', 'puntYd');
+  alias('longestPunt', 'longestPunt', 'puntLong');
+  return normalized;
 }
 
 function availability(player) {
@@ -54,9 +89,9 @@ const METRICS = {
 function metricValue(key, stats) {
   if (key === '_ypc') return Number(stats?.rushAtt) > 0 ? (Number(stats.rushYd ?? 0) / Number(stats.rushAtt)).toFixed(1) : null;
   if (key === '_ypr') return Number(stats?.receptions) > 0 ? (Number(stats.recYd ?? 0) / Number(stats.receptions)).toFixed(1) : null;
-  if (key === '_fg') return stats?.fgMade != null && stats?.fgAttempts != null ? `${stats.fgMade}/${stats.fgAttempts}` : null;
+  if (key === '_fg') return Number(stats?.fgAttempts) > 0 && stats?.fgMade != null ? `${stats.fgMade}/${stats.fgAttempts}` : null;
   if (key === '_fgPct') return Number(stats?.fgAttempts) > 0 ? `${((Number(stats.fgMade ?? 0) / Number(stats.fgAttempts)) * 100).toFixed(1)}%` : null;
-  if (key === '_puntAvg') return Number(stats?.punts) > 0 ? (Number(stats.puntYards ?? 0) / Number(stats.punts)).toFixed(1) : null;
+  if (key === '_puntAvg') return Number(stats?.punts) > 0 && stats?.puntYards != null ? (Number(stats.puntYards) / Number(stats.punts)).toFixed(1) : null;
   return stats?.[key] == null ? null : stats[key];
 }
 
@@ -66,6 +101,8 @@ function performance(player, stats) {
   }
   const pos = String(player?.pos ?? player?.position ?? '').toUpperCase();
   const group = pos === 'K' || pos === 'P' ? pos : getPositionGroup(player);
+  if (group === 'K' && !(Number(stats?.fgAttempts) > 0)) return { label: 'No recorded usage', metrics: [], available: false };
+  if (group === 'P' && !(Number(stats?.punts) > 0)) return { label: 'No recorded usage', metrics: [], available: false };
   const definitions = METRICS[group] ?? [];
   const metrics = definitions.map(([label, key]) => ({ label, value: metricValue(key, stats) })).filter((metric) => metric.value != null);
   return { label: metrics.length ? 'Current season' : 'No position stats recorded', metrics, available: metrics.length > 0 };
@@ -101,8 +138,8 @@ function contractSummary(player, priority) {
   return { label, yearsRemaining, capHit: salary, guaranteed, available: true, tagged: Boolean(contract.tag || player?.isTagged) };
 }
 
-function recommendation(priority, role, status, player, health) {
-  if (!priority || !['Active Roster', 'Injured Reserve'].includes(status)) return null;
+function recommendation(priority, role, statusKey, player, health) {
+  if (!priority || !['active_roster', 'injured_reserve'].includes(statusKey)) return null;
   if (!health.available) return { action: 'Monitor injury recovery', reasons: [health.detail ?? health.label, `${role} role`].filter(Boolean) };
   const map = {
     cornerstone_priority: 'Build around', strong_keep: 'Explore extension', extension_candidate: 'Explore extension',
@@ -120,22 +157,23 @@ function recommendation(priority, role, status, player, health) {
 
 export function buildPlayerDecisionPresentation({ player, team = null, league = {}, seasonStats = null } = {}) {
   if (!player) return { identity: null, availableData: [], omittedReasons: ['Player record unavailable'] };
-  const status = playerStatus(player, league);
-  const roleLabel = depthRole(player, status);
+  const statusKey = playerStatus(player, league);
+  const status = STATUS_LABELS[statusKey] ?? titleCase(statusKey);
+  const roleLabel = depthRole(player, statusKey);
   const health = availability(player);
   const leaguePlayers = Array.isArray(league?.players) ? league.players : null;
   const teamRoster = Array.isArray(team?.roster) ? team.roster : null;
-  const canEvaluateRetention = Boolean(team && (leaguePlayers || teamRoster) && ['Active Roster', 'Injured Reserve'].includes(status));
+  const canEvaluateRetention = Boolean(team && (leaguePlayers || teamRoster) && ['active_roster', 'injured_reserve'].includes(statusKey));
   const retentionLeague = leaguePlayers ? league : { ...league, players: teamRoster };
   const priority = canEvaluateRetention ? evaluateReSigningPriority(player, team, retentionLeague) : null;
-  const perf = performance(player, seasonStats ?? player?.seasonStats ?? player?.stats ?? null);
+  const perf = performance(player, normalizePlayerDecisionSeasonStats(seasonStats ?? player?.seasonStats ?? player?.stats ?? null));
   const dev = development(player);
   const contract = contractSummary(player, priority);
-  const archetype = player?.archetype ?? (player?.attributesV2 || player?.ratings ? derivePlayerArchetype(player).archetype : null);
+  const archetype = player?.archetype ?? (hasArchetypeEvidence(player) ? derivePlayerArchetype(player).archetype : null);
   const replacement = priority ? { label: titleCase(priority.replacementDifficulty), source: 'Re-signing priority' } : null;
   const rosterValue = priority ? { label: ({ core_starter: 'Core', starter: 'High', rotation: 'Moderate', depth: 'Depth' })[priority.roleImportance] ?? 'Moderate', source: 'Re-signing role importance' } : null;
   const result = {
-    identity: { id: player.id ?? player.prospectId ?? null, name: player.name ?? 'Unknown Player', position: player.pos ?? player.position ?? '—', age: numberOrNull(player.age), team: team?.abbr ?? team?.name ?? null, jerseyNumber: player.jerseyNumber ?? player.number ?? null, overall: numberOrNull(player.ovr ?? player.ratings?.ovr), potential: numberOrNull(player.potential ?? player.pot ?? player.ratings?.potential), experience: numberOrNull(player.experience ?? player.yearsPro), status },
+    identity: { id: player.id ?? player.prospectId ?? null, name: player.name ?? 'Unknown Player', position: player.pos ?? player.position ?? '—', age: numberOrNull(player.age), team: team?.abbr ?? team?.name ?? null, jerseyNumber: player.jerseyNumber ?? player.number ?? null, overall: numberOrNull(player.ovr ?? player.ratings?.ovr), potential: numberOrNull(player.potential ?? player.pot ?? player.ratings?.potential), experience: numberOrNull(player.experience ?? player.yearsPro), statusKey, status },
     role: { label: roleLabel, depthOrder: numberOrNull(player?.depthChart?.order ?? player?.depthOrder ?? player?.depthRank), archetype },
     availability: health,
     performance: perf,
@@ -143,7 +181,7 @@ export function buildPlayerDecisionPresentation({ player, team = null, league = 
     contract,
     rosterValue,
     replacement,
-    recommendation: recommendation(priority, roleLabel, status, player, health),
+    recommendation: recommendation(priority, roleLabel, statusKey, player, health),
     context: { morale: player?.morale ?? null, awards: Array.isArray(player?.awards) ? player.awards.length : null },
   };
   result.availableData = Object.entries(result).filter(([, value]) => value != null).map(([key]) => key);

--- a/src/core/playerDecisionPresentation.js
+++ b/src/core/playerDecisionPresentation.js
@@ -1,0 +1,152 @@
+import { derivePlayerArchetype, getPositionGroup } from './playerEvaluation.js';
+import { evaluateReSigningPriority } from './retention/reSigning.js';
+
+const numberOrNull = (value) => {
+  if (value == null) return null;
+  if (typeof value === 'string' && value.trim() === '') return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+};
+
+const titleCase = (value) => String(value ?? '').replaceAll('_', ' ').replace(/\b\w/g, (letter) => letter.toUpperCase());
+
+function playerStatus(player, league) {
+  if (player?.retired || player?.isRetired || player?.status === 'retired') return 'Retired';
+  const draftClass = Array.isArray(league?.draftClass) ? league.draftClass : [];
+  if (player?.isProspect || player?.draftEligible || player?.status === 'draft_eligible'
+    || draftClass.some((prospect) => String(prospect?.id ?? prospect?.prospectId) === String(player?.id ?? player?.prospectId))) return 'Draft prospect';
+  if (player?.status === 'practice_squad') return 'Practice squad';
+  if (player?.status === 'injured_reserve' || player?.onIR) return 'Injured reserve';
+  if (player?.teamId == null || player?.teamId === 'FA' || player?.status === 'free_agent') return 'Free agent';
+  return titleCase(player?.status === 'active' || !player?.status ? 'active roster' : player.status);
+}
+
+function depthRole(player, status) {
+  if (status !== 'Active Roster' && status !== 'Injured Reserve') return status;
+  const canonical = player?.depthChart?.role;
+  if (canonical) return titleCase(canonical);
+  const order = numberOrNull(player?.depthChart?.order ?? player?.depthOrder ?? player?.depthRank);
+  if (order === 1) return 'Starter';
+  if (order === 2) return 'Backup';
+  if (order != null && order > 2) return 'Reserve';
+  return 'Role unavailable';
+}
+
+function availability(player) {
+  const weeks = numberOrNull(player?.injuryWeeksRemaining ?? player?.injury?.weeksRemaining ?? player?.injury?.gamesRemaining);
+  const injuryName = player?.injury?.name ?? player?.injury?.type ?? null;
+  const injured = (weeks != null && weeks > 0) || Boolean(injuryName) || (player?.injury?.status && player.injury.status !== 'Healthy');
+  return injured
+    ? { label: weeks ? `Unavailable · ${weeks}w` : 'Injured', detail: injuryName ?? player?.injury?.status ?? null, available: false }
+    : { label: 'Available', detail: null, available: true };
+}
+
+const METRICS = {
+  QB: [['Passing yards', 'passYd'], ['Passing TD', 'passTD'], ['Interceptions', 'interceptions']],
+  RB: [['Rushing yards', 'rushYd'], ['Yards / carry', '_ypc'], ['Rushing TD', 'rushTD'], ['Receiving yards', 'recYd']],
+  RECEIVER: [['Receptions', 'receptions'], ['Receiving yards', 'recYd'], ['Receiving TD', 'recTD'], ['Yards / catch', '_ypr']],
+  FRONT7: [['Tackles', 'tackles'], ['Sacks', 'sacks'], ['Tackles for loss', 'tacklesForLoss'], ['Forced fumbles', 'forcedFumbles']],
+  SECONDARY: [['Tackles', 'tackles'], ['Interceptions', 'interceptions'], ['Passes defended', 'passesDefended'], ['Forced fumbles', 'forcedFumbles']],
+  K: [['Field goals', '_fg'], ['FG percentage', '_fgPct'], ['Long', 'longestFG']],
+  P: [['Punts', 'punts'], ['Punt average', '_puntAvg'], ['Long', 'longestPunt']],
+};
+
+function metricValue(key, stats) {
+  if (key === '_ypc') return Number(stats?.rushAtt) > 0 ? (Number(stats.rushYd ?? 0) / Number(stats.rushAtt)).toFixed(1) : null;
+  if (key === '_ypr') return Number(stats?.receptions) > 0 ? (Number(stats.recYd ?? 0) / Number(stats.receptions)).toFixed(1) : null;
+  if (key === '_fg') return stats?.fgMade != null && stats?.fgAttempts != null ? `${stats.fgMade}/${stats.fgAttempts}` : null;
+  if (key === '_fgPct') return Number(stats?.fgAttempts) > 0 ? `${((Number(stats.fgMade ?? 0) / Number(stats.fgAttempts)) * 100).toFixed(1)}%` : null;
+  if (key === '_puntAvg') return Number(stats?.punts) > 0 ? (Number(stats.puntYards ?? 0) / Number(stats.punts)).toFixed(1) : null;
+  return stats?.[key] == null ? null : stats[key];
+}
+
+function performance(player, stats) {
+  if (!stats || !Object.values(stats).some((value) => Number.isFinite(Number(value)) && Number(value) !== 0)) {
+    return { label: 'No recorded usage', metrics: [], available: false };
+  }
+  const pos = String(player?.pos ?? player?.position ?? '').toUpperCase();
+  const group = pos === 'K' || pos === 'P' ? pos : getPositionGroup(player);
+  const definitions = METRICS[group] ?? [];
+  const metrics = definitions.map(([label, key]) => ({ label, value: metricValue(key, stats) })).filter((metric) => metric.value != null);
+  return { label: metrics.length ? 'Current season' : 'No position stats recorded', metrics, available: metrics.length > 0 };
+}
+
+function development(player) {
+  const histories = [player?.ovrHistory, player?.ratingHistory, player?.developmentHistory].find((rows) => Array.isArray(rows) && rows.length >= 2) ?? [];
+  const points = histories.map((row) => numberOrNull(typeof row === 'number' ? row : row?.ovr ?? row?.overall)).filter((value) => value != null);
+  let delta = null;
+  let detail = null;
+  if (points.length >= 2) {
+    delta = points.at(-1) - points[0];
+    detail = `Overall moved from ${points[0]} to ${points.at(-1)} across ${points.length} recorded checkpoints.`;
+  } else {
+    delta = numberOrNull(player?.progressionDelta);
+  }
+  if (delta != null && points.length < 2) {
+    detail = `${delta >= 0 ? '+' : ''}${delta} OVR in the latest recorded progression cycle.`;
+  }
+  if (delta == null) return { label: 'Insufficient history', detail: 'No comparable overall checkpoints are recorded.', available: false };
+  return { label: delta >= 2 ? 'Rising' : delta <= -2 ? 'Declining' : 'Stable', detail, available: true };
+}
+
+function contractSummary(player, priority) {
+  const contract = player?.contract;
+  if (!contract) return { label: 'No contract data', available: false };
+  const yearsRemaining = numberOrNull(contract.yearsRemaining ?? contract.yearsLeft ?? contract.years);
+  const salary = numberOrNull(contract.capHit ?? contract.baseAnnual ?? contract.salary ?? contract.annualSalary);
+  const guaranteed = numberOrNull(contract.guaranteedMoney ?? contract.guaranteed);
+  let label = yearsRemaining != null && yearsRemaining <= 1 ? 'Rental / expiring' : 'Under contract';
+  if (priority?.recommendation === 'cornerstone_priority' || priority?.recommendation === 'extension_candidate') label = 'Extension priority';
+  else if (priority?.recommendation === 'replaceable_depth' && salary != null) label = 'Review role and cost';
+  return { label, yearsRemaining, capHit: salary, guaranteed, available: true, tagged: Boolean(contract.tag || player?.isTagged) };
+}
+
+function recommendation(priority, role, status, player, health) {
+  if (!priority || !['Active Roster', 'Injured Reserve'].includes(status)) return null;
+  if (!health.available) return { action: 'Monitor injury recovery', reasons: [health.detail ?? health.label, `${role} role`].filter(Boolean) };
+  const map = {
+    cornerstone_priority: 'Build around', strong_keep: 'Explore extension', extension_candidate: 'Explore extension',
+    keep_if_price_is_right: role === 'Starter' ? 'Start' : 'Keep in rotation', franchise_tag_candidate: 'Explore extension',
+    replaceable_depth: 'Develop', likely_to_walk: 'Let walk', move_on: (() => {
+      const yearsRemaining = numberOrNull(player?.contract?.yearsRemaining ?? player?.contract?.years);
+      return yearsRemaining != null && yearsRemaining <= 1 ? 'Let walk' : 'Replace';
+    })(),
+  };
+  const reasons = [`${role} role`, `${titleCase(priority.replacementDifficulty)} to replace`];
+  if (priority.expiring) reasons.push('Contract expires after this season');
+  else if (priority.developmentOutlook === 'ascending') reasons.push('Existing evaluation marks an ascending outlook');
+  return { action: map[priority.recommendation] ?? 'Monitor', reasons: [...new Set(reasons)].slice(0, 3), source: 'Re-signing priority' };
+}
+
+export function buildPlayerDecisionPresentation({ player, team = null, league = {}, seasonStats = null } = {}) {
+  if (!player) return { identity: null, availableData: [], omittedReasons: ['Player record unavailable'] };
+  const status = playerStatus(player, league);
+  const roleLabel = depthRole(player, status);
+  const health = availability(player);
+  const leaguePlayers = Array.isArray(league?.players) ? league.players : null;
+  const teamRoster = Array.isArray(team?.roster) ? team.roster : null;
+  const canEvaluateRetention = Boolean(team && (leaguePlayers || teamRoster) && ['Active Roster', 'Injured Reserve'].includes(status));
+  const retentionLeague = leaguePlayers ? league : { ...league, players: teamRoster };
+  const priority = canEvaluateRetention ? evaluateReSigningPriority(player, team, retentionLeague) : null;
+  const perf = performance(player, seasonStats ?? player?.seasonStats ?? player?.stats ?? null);
+  const dev = development(player);
+  const contract = contractSummary(player, priority);
+  const archetype = player?.archetype ?? (player?.attributesV2 || player?.ratings ? derivePlayerArchetype(player).archetype : null);
+  const replacement = priority ? { label: titleCase(priority.replacementDifficulty), source: 'Re-signing priority' } : null;
+  const rosterValue = priority ? { label: ({ core_starter: 'Core', starter: 'High', rotation: 'Moderate', depth: 'Depth' })[priority.roleImportance] ?? 'Moderate', source: 'Re-signing role importance' } : null;
+  const result = {
+    identity: { id: player.id ?? player.prospectId ?? null, name: player.name ?? 'Unknown Player', position: player.pos ?? player.position ?? '—', age: numberOrNull(player.age), team: team?.abbr ?? team?.name ?? null, jerseyNumber: player.jerseyNumber ?? player.number ?? null, overall: numberOrNull(player.ovr ?? player.ratings?.ovr), potential: numberOrNull(player.potential ?? player.pot ?? player.ratings?.potential), experience: numberOrNull(player.experience ?? player.yearsPro), status },
+    role: { label: roleLabel, depthOrder: numberOrNull(player?.depthChart?.order ?? player?.depthOrder ?? player?.depthRank), archetype },
+    availability: health,
+    performance: perf,
+    development: dev,
+    contract,
+    rosterValue,
+    replacement,
+    recommendation: recommendation(priority, roleLabel, status, player, health),
+    context: { morale: player?.morale ?? null, awards: Array.isArray(player?.awards) ? player.awards.length : null },
+  };
+  result.availableData = Object.entries(result).filter(([, value]) => value != null).map(([key]) => key);
+  result.omittedReasons = [!archetype && 'Archetype source unavailable', !replacement && 'Replacement evaluation unavailable', !result.recommendation && 'GM recommendation unavailable outside an evaluated team roster'].filter(Boolean);
+  return result;
+}

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -652,6 +652,14 @@ export default function LeagueDashboard({
     setSelectedPlayerId(hasValidPlayerProfileId(playerId) ? playerId : '__missing_player__');
     setSelectedPlayerContext(profileContext ?? { source: 'unknown', missingEntity: true });
   };
+  const closePlayerProfile = React.useCallback(() => {
+    setSelectedPlayerId(null);
+    setSelectedPlayerContext(null);
+  }, []);
+  const handlePlayerProfileNavigate = React.useCallback((destination) => {
+    closePlayerProfile();
+    setActiveTab(destination);
+  }, [closePlayerProfile]);
   const [selectedTeamId, setSelectedTeamId] = useState(null);
   const handleTeamSelect = (teamOrId) => {
     const teamId = typeof teamOrId === 'object' ? teamOrId?.id ?? teamOrId?.teamId : teamOrId;
@@ -1659,14 +1667,14 @@ export default function LeagueDashboard({
       {/* ── Player Profile modal ── */}
       {selectedPlayerId && (
         <TabErrorBoundary label="Player Profile">
-          <PlayerProfileModalBoundary playerId={selectedPlayerId} onClose={() => { setSelectedPlayerId(null); setSelectedPlayerContext(null); }}>
+          <PlayerProfileModalBoundary playerId={selectedPlayerId} onClose={closePlayerProfile}>
             <PlayerProfile
               playerId={selectedPlayerId}
-              onClose={() => { setSelectedPlayerId(null); setSelectedPlayerContext(null); }}
+              onClose={closePlayerProfile}
               actions={actions}
               teams={league.teams}
               league={league}
-              onNavigate={setActiveTab}
+              onNavigate={handlePlayerProfileNavigate}
               profileContext={selectedPlayerContext}
               onOpenBoxScore={(gameId) => openGameDetail(gameId, selectedPlayerContext?.source === 'weekly-results' ? 'Weekly Results' : 'Game Detail')}
               onFocusLeagueHistorySeason={(seasonId) => {

--- a/src/ui/components/PlayerDecisionCard.jsx
+++ b/src/ui/components/PlayerDecisionCard.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+const labelStyle = { color: 'var(--text-subtle)', fontSize: 'var(--text-xs)', fontWeight: 800, letterSpacing: '.06em', textTransform: 'uppercase' };
+
+function money(value) {
+  if (value == null) return null;
+  const amount = Math.abs(Number(value)) >= 1000 ? Number(value) / 1e6 : Number(value);
+  return `$${amount.toFixed(amount % 1 ? 1 : 0)}M`;
+}
+
+export default function PlayerDecisionCard({ presentation, onNavigate }) {
+  if (!presentation?.identity) return null;
+  const { role, availability, performance, development, contract, rosterValue, replacement, recommendation } = presentation;
+  return (
+    <section
+      className="card-enter"
+      data-testid="player-decision-card"
+      aria-labelledby="player-decision-heading"
+      style={{ border: '1px solid var(--hairline-strong)', borderRadius: 'var(--radius-lg)', padding: 'var(--space-4)', background: 'linear-gradient(145deg, rgba(10,132,255,.10), var(--surface-strong))', minWidth: 0 }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 12, flexWrap: 'wrap' }}>
+        <div style={{ minWidth: 0 }}>
+          <div style={labelStyle}>Decision summary</div>
+          <h3 id="player-decision-heading" style={{ margin: '3px 0 0', fontSize: 'var(--text-lg)', overflowWrap: 'anywhere' }}>{role.label}</h3>
+          <div style={{ color: 'var(--text-muted)', fontSize: 'var(--text-sm)', marginTop: 3 }}>
+            {[role.archetype, availability.label].filter(Boolean).join(' · ')}
+          </div>
+        </div>
+        {recommendation ? (
+          <div style={{ minWidth: 'min(100%, 230px)', flex: '1 1 230px', maxWidth: 420 }} data-testid="player-decision-recommendation">
+            <div style={labelStyle}>GM consideration</div>
+            <div style={{ fontSize: 'var(--text-lg)', fontWeight: 900, marginTop: 3 }}>{recommendation.action}</div>
+            <ul style={{ margin: '6px 0 0', paddingLeft: 18, color: 'var(--text-muted)', fontSize: 'var(--text-sm)' }}>
+              {recommendation.reasons.map((reason) => <li key={reason}>{reason}</li>)}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 150px), 1fr))', gap: 12, marginTop: 16 }}>
+        {performance.available && <div data-testid="player-decision-performance"><div style={labelStyle}>Performance</div>{performance.metrics.slice(0, 4).map((metric) => <div key={metric.label} style={{ display: 'flex', justifyContent: 'space-between', gap: 8, fontSize: 'var(--text-sm)', marginTop: 4 }}><span style={{ color: 'var(--text-muted)' }}>{metric.label}</span><strong>{metric.value}</strong></div>)}</div>}
+        <div data-testid="player-decision-development"><div style={labelStyle}>Development</div><strong style={{ display: 'block', marginTop: 4 }}>{development.label}</strong><div style={{ color: 'var(--text-muted)', fontSize: 'var(--text-xs)', marginTop: 3 }}>{development.detail}</div></div>
+        {contract.available && <div data-testid="player-decision-contract"><div style={labelStyle}>Contract outlook</div><strong style={{ display: 'block', marginTop: 4 }}>{contract.label}</strong><div style={{ color: 'var(--text-muted)', fontSize: 'var(--text-xs)', marginTop: 3 }}>{contract.yearsRemaining != null ? `${contract.yearsRemaining} year${contract.yearsRemaining === 1 ? '' : 's'} remaining` : 'Term unavailable'}{money(contract.capHit) ? ` · ${money(contract.capHit)} cap/salary` : ''}</div></div>}
+        {(rosterValue || replacement) && <div data-testid="player-decision-value"><div style={labelStyle}>Team value</div>{rosterValue && <div style={{ marginTop: 4 }}><span style={{ color: 'var(--text-muted)', fontSize: 'var(--text-sm)' }}>Roster value </span><strong>{rosterValue.label}</strong></div>}{replacement && <div style={{ marginTop: 4 }}><span style={{ color: 'var(--text-muted)', fontSize: 'var(--text-sm)' }}>Replacement </span><strong>{replacement.label}</strong></div>}</div>}
+      </div>
+      {onNavigate && (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 16 }} aria-label="Player decision actions">
+          <button className="btn" onClick={() => onNavigate('Depth Chart')}>Open depth chart</button>
+          <button className="btn" onClick={() => onNavigate('Trade Center')}>Trade workspace</button>
+          <button className="btn" onClick={() => onNavigate('Contract Center')}>Contract center</button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/ui/components/PlayerDecisionCard.jsx
+++ b/src/ui/components/PlayerDecisionCard.jsx
@@ -47,7 +47,7 @@ export default function PlayerDecisionCard({ presentation, onNavigate }) {
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 16 }} aria-label="Player decision actions">
           <button className="btn" onClick={() => onNavigate('Depth Chart')}>Open depth chart</button>
           <button className="btn" onClick={() => onNavigate('Trade Center')}>Trade workspace</button>
-          <button className="btn" onClick={() => onNavigate('Contract Center')}>Contract center</button>
+          <button className="btn" onClick={() => onNavigate('Contract Center')}>Open contracts</button>
         </div>
       )}
     </section>

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -22,7 +22,7 @@ import { Line } from 'react-chartjs-2';
 import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend } from 'chart.js';
 import { PERSONALITY_TOOLTIPS } from '../../core/development/personalitySystem.js';
 import { buildPlayerProfileAnalysis } from "../../core/playerProfileAnalysis.js";
-import { buildPlayerDecisionPresentation } from "../../core/playerDecisionPresentation.js";
+import { buildPlayerDecisionPresentation, normalizePlayerDecisionSeasonStats } from "../../core/playerDecisionPresentation.js";
 import PlayerDecisionCard from "./PlayerDecisionCard.jsx";
 import { resolvePlayerForProfile } from "../utils/playerProfileResolver.js";
 import { buildDevelopmentNotes, classifyDevelopmentTrend, getPlayerReadiness, getSchemeFitSignal, getAgeCurveContext, getDevelopmentSnapshot, getDevelopmentDrivers } from '../utils/playerDevelopmentSignals.js';
@@ -1020,6 +1020,12 @@ export default function PlayerProfile({
       recTD: 0,
       tackles: 0,
       sacks: 0,
+      fieldGoalsMade: 0,
+      fieldGoalsAttempted: 0,
+      punts: 0,
+      puntYards: 0,
+      longestFieldGoal: null,
+      longestPunt: null,
     };
     for (const row of playerGameLogs) {
       const gameKey = row.gameId ? String(row.gameId) : `w${row.week}`;
@@ -1041,6 +1047,14 @@ export default function PlayerProfile({
       totals.recTD += Number(s.recTD ?? 0);
       totals.tackles += Number(s.tackles ?? 0);
       totals.sacks += Number(s.sacks ?? 0);
+      totals.fieldGoalsMade += Number(s.fieldGoalsMade ?? 0);
+      totals.fieldGoalsAttempted += Number(s.fieldGoalsAttempted ?? 0);
+      totals.punts += Number(s.punts ?? 0);
+      totals.puntYards += Number(s.puntYards ?? 0);
+      const longestFieldGoal = Number(s.longestFieldGoal);
+      if (Number.isFinite(longestFieldGoal)) totals.longestFieldGoal = Math.max(totals.longestFieldGoal ?? 0, longestFieldGoal);
+      const longestPunt = Number(s.longestPunt);
+      if (Number.isFinite(longestPunt)) totals.longestPunt = Math.max(totals.longestPunt ?? 0, longestPunt);
     }
     return totals;
   }, [league, playerGameLogs]);
@@ -1055,7 +1069,7 @@ export default function PlayerProfile({
     player: effectivePlayer,
     team: resolvedProfile.team,
     league,
-    seasonStats: seasonStatsRecorded ? primarySeasonTotals : null,
+    seasonStats: seasonStatsRecorded ? normalizePlayerDecisionSeasonStats(primarySeasonTotals) : null,
   }), [effectivePlayer, resolvedProfile.team, league, seasonStatsRecorded, primarySeasonTotals]);
   const gmContext = profileAnalysis?.recommendationContext ?? {};
   const hasGmContext = Boolean(

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -22,6 +22,8 @@ import { Line } from 'react-chartjs-2';
 import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend } from 'chart.js';
 import { PERSONALITY_TOOLTIPS } from '../../core/development/personalitySystem.js';
 import { buildPlayerProfileAnalysis } from "../../core/playerProfileAnalysis.js";
+import { buildPlayerDecisionPresentation } from "../../core/playerDecisionPresentation.js";
+import PlayerDecisionCard from "./PlayerDecisionCard.jsx";
 import { resolvePlayerForProfile } from "../utils/playerProfileResolver.js";
 import { buildDevelopmentNotes, classifyDevelopmentTrend, getPlayerReadiness, getSchemeFitSignal, getAgeCurveContext, getDevelopmentSnapshot, getDevelopmentDrivers } from '../utils/playerDevelopmentSignals.js';
 import { ToneChip, DevelopmentSignalRow, DevelopmentStatCard } from './PlayerDevelopmentUI.jsx';
@@ -1049,6 +1051,12 @@ export default function PlayerProfile({
   const quickTags = getQuickTags(player);
   const primarySeasonTotals = (currentSeasonTotals && hasRecordedStats(currentSeasonTotals)) ? currentSeasonTotals : latestTotals;
   const seasonStatsRecorded = hasRecordedStats(primarySeasonTotals);
+  const playerDecisionPresentation = useMemo(() => buildPlayerDecisionPresentation({
+    player: effectivePlayer,
+    team: resolvedProfile.team,
+    league,
+    seasonStats: seasonStatsRecorded ? primarySeasonTotals : null,
+  }), [effectivePlayer, resolvedProfile.team, league, seasonStatsRecorded, primarySeasonTotals]);
   const gmContext = profileAnalysis?.recommendationContext ?? {};
   const hasGmContext = Boolean(
     gmContext?.sourceLabel || gmContext?.reason || gmContext?.comparisonReceipt || gmContext?.recommendation || gmContext?.fitScore != null || gmContext?.capImpactLabel || gmContext?.valueLabel
@@ -1796,6 +1804,9 @@ export default function PlayerProfile({
           </div>
           {activeProfileTab === "Overview" && (
             <>
+          {!loading && playerView && (
+            <PlayerDecisionCard presentation={playerDecisionPresentation} onNavigate={onNavigate} />
+          )}
           {hasThisWeekContext && (
             <section className="card-enter" data-testid="player-profile-game-impact">
               <h3 style={sectionLabelStyle}>This Week / Game Impact</h3>

--- a/src/ui/components/__tests__/LeagueDashboard.playerProfileNavigation.test.jsx
+++ b/src/ui/components/__tests__/LeagueDashboard.playerProfileNavigation.test.jsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+vi.mock('../TeamHub.jsx', () => ({
+  default: ({ onPlayerSelect }) => <button onClick={() => onPlayerSelect(91)}>Open test player</button>,
+}));
+vi.mock('../DragAndDropDepthChart.jsx', () => ({ default: () => <h2>Depth Chart</h2> }));
+vi.mock('../ContractCenter.jsx', () => ({ default: () => <h2>Contracts</h2> }));
+import LeagueDashboard from '../LeagueDashboard.jsx';
+
+const rosterPlayer = {
+  id: 91, name: 'Navigation Quarterback', pos: 'QB', age: 26, ovr: 82, potential: 84,
+  teamId: 1, status: 'active', depthChart: { rowKey: 'QB', order: 1, role: 'starter' },
+  contract: { yearsRemaining: 1, baseAnnual: 12 }, ratings: { awareness: 80, throwPower: 82, throwAccuracy: 80 },
+};
+
+const team = { id: 1, name: 'Portland Pioneers', abbr: 'POR', roster: [rosterPlayer], capRoom: 30, wins: 0, losses: 0 };
+const league = {
+  year: 2026, seasonId: 's1', week: 1, phase: 'preseason', userTeamId: 1,
+  teams: [team], players: [rosterPlayer], schedule: { weeks: [] }, incomingTradeOffers: [],
+};
+const actions = {
+  getRoster: vi.fn(async () => ({ payload: { team, players: [rosterPlayer] } })),
+  getPlayerCareer: vi.fn(async () => null),
+  getAllSeasons: vi.fn(async () => ({ payload: { seasons: [] } })),
+  getPlayerDraftContext: vi.fn(async () => ({ payload: { context: { known: false } } })),
+  getRecords: vi.fn(async () => ({ payload: { recordBook: null } })),
+  getTransactions: vi.fn(async () => ({ payload: { transactions: [] } })),
+};
+
+describe('LeagueDashboard Player Profile workflow navigation', () => {
+  beforeEach(() => {
+    window.matchMedia = vi.fn(() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }));
+    global.IntersectionObserver = vi.fn(function () { return { observe: vi.fn(), unobserve: vi.fn(), disconnect: vi.fn() }; });
+  });
+  afterEach(() => cleanup());
+
+  it.each([
+    ['Open depth chart', 'Depth Chart'],
+    ['Open contracts', 'Contracts'],
+  ])('closes the profile before opening %s', async (actionLabel, destinationHeading) => {
+    render(<LeagueDashboard league={league} actions={actions} busy={false} simulating={false} onAdvanceWeek={vi.fn()} />);
+    fireEvent.click(screen.getByTestId('nav-team'));
+    fireEvent.click(screen.getByTestId('section-tab-team'));
+    fireEvent.click(screen.getByRole('button', { name: 'Open test player' }));
+    const profile = await screen.findByTestId('player-profile');
+    const decisionCard = await within(profile).findByTestId('player-decision-card');
+    fireEvent.click(within(decisionCard).getByRole('button', { name: actionLabel }));
+    await waitFor(() => expect(screen.queryByTestId('player-profile')).toBeNull());
+    expect(screen.getAllByText(destinationHeading).length).toBeGreaterThan(0);
+  });
+});

--- a/src/ui/components/__tests__/PlayerDecisionCard.test.jsx
+++ b/src/ui/components/__tests__/PlayerDecisionCard.test.jsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import PlayerDecisionCard from '../PlayerDecisionCard.jsx';
+
+const presentation = {
+  identity: { name: 'A Very Long Player Name That Must Wrap' },
+  role: { label: 'Starter', archetype: 'Field General' },
+  availability: { label: 'Available' },
+  performance: { available: true, metrics: [{ label: 'Passing yards', value: 1234 }] },
+  development: { label: 'Rising', detail: 'Overall moved from 74 to 78.' },
+  contract: { available: true, label: 'Rental / expiring', yearsRemaining: 1, capHit: 12 },
+  rosterValue: { label: 'Core' },
+  replacement: { label: 'Hard' },
+  recommendation: { action: 'Explore extension', reasons: ['Starter role', 'Hard to replace'] },
+};
+
+describe('PlayerDecisionCard', () => {
+  afterEach(() => cleanup());
+  it('renders the decisive summary and routes only through existing workflow destinations', () => {
+    const onNavigate = vi.fn();
+    render(<div style={{ width: 375 }}><PlayerDecisionCard presentation={presentation} onNavigate={onNavigate} /></div>);
+    expect(screen.getByTestId('player-decision-card').textContent).toContain('Explore extension');
+    expect(screen.getByTestId('player-decision-performance').textContent).toContain('1,234'.replace(',', ''));
+    fireEvent.click(screen.getByRole('button', { name: 'Open depth chart' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Trade workspace' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Contract center' }));
+    expect(onNavigate.mock.calls).toEqual([['Depth Chart'], ['Trade Center'], ['Contract Center']]);
+  });
+
+  it('omits unavailable optional sections', () => {
+    render(<PlayerDecisionCard presentation={{ ...presentation, performance: { available: false, metrics: [] }, contract: { available: false }, rosterValue: null, replacement: null, recommendation: null }} />);
+    expect(screen.queryByTestId('player-decision-performance')).toBeNull();
+    expect(screen.queryByTestId('player-decision-contract')).toBeNull();
+    expect(screen.queryByTestId('player-decision-recommendation')).toBeNull();
+  });
+});

--- a/src/ui/components/__tests__/PlayerDecisionCard.test.jsx
+++ b/src/ui/components/__tests__/PlayerDecisionCard.test.jsx
@@ -25,7 +25,7 @@ describe('PlayerDecisionCard', () => {
     expect(screen.getByTestId('player-decision-performance').textContent).toContain('1,234'.replace(',', ''));
     fireEvent.click(screen.getByRole('button', { name: 'Open depth chart' }));
     fireEvent.click(screen.getByRole('button', { name: 'Trade workspace' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Contract center' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Open contracts' }));
     expect(onNavigate.mock.calls).toEqual([['Depth Chart'], ['Trade Center'], ['Contract Center']]);
   });
 

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -14,6 +14,7 @@ const player = {
   potential: 90,
   teamId: 1,
   status: 'active',
+  depthChart: { rowKey: 'QB', order: 1, role: 'starter' },
   contract: { years: 2, baseAnnual: 12 },
   traits: [],
   accolades: [],
@@ -62,6 +63,8 @@ describe('PlayerProfile', () => {
 
     expect(screen.getByTestId('player-profile')).toBeTruthy();
     await waitFor(() => expect(screen.getByTestId('player-profile-summary').textContent).toContain('Avery Fields'));
+    expect(screen.getByTestId('player-decision-card').textContent).toContain('Starter');
+    expect(screen.getByTestId('player-decision-recommendation').textContent).toMatch(/Build around|Explore extension|Start/);
     expect(screen.getByTestId('player-profile-season-stats').textContent).toContain('Season stats will appear after this player records tracked stats.');
     expect(screen.getByTestId('player-profile-career-timeline').textContent).toContain('No career timeline recorded yet.');
     await waitFor(() => expect(screen.getByText('Contract Read')).toBeTruthy());

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -212,6 +212,34 @@ describe('PlayerProfile', () => {
     expect(screen.getByTestId('player-profile-game-logs').textContent).toContain('NYG');
   });
 
+  it.each([
+    ['kicker', { ...player, id: 21, name: 'Casey Kick', pos: 'K' }, { fieldGoalsMade: 0, fieldGoalsAttempted: 1 }, ['Field goals', '0/1', '0.0%']],
+    ['punter', { ...player, id: 22, name: 'Pat Punt', pos: 'P' }, { punts: 2, puntYards: 92, longestPunt: 51 }, ['Punts', '2', '46.0', '51']],
+  ])('shows current-season %s production from canonical profile game-log totals', async (_label, specialist, specialistStats, expected) => {
+    const specialistLeague = {
+      ...league,
+      teams: [{ ...league.teams[0], roster: [specialist] }],
+      schedule: {
+        weeks: [{
+          week: 1,
+          games: [{
+            id: `special-${specialist.id}`,
+            played: true,
+            home: 1,
+            away: 2,
+            homeScore: 10,
+            awayScore: 7,
+            playerStats: { home: { [specialist.id]: { stats: specialistStats } }, away: {} },
+          }],
+        }],
+      },
+      teamById: { 1: { id: 1, abbr: 'DAL' }, 2: { id: 2, abbr: 'NYG' } },
+    };
+    render(<PlayerProfile playerId={specialist.id} onClose={vi.fn()} actions={actions} teams={specialistLeague.teams} league={specialistLeague} />);
+    const performance = await screen.findByTestId('player-decision-performance');
+    for (const value of expected) expect(performance.textContent).toContain(value);
+  });
+
   it('return buttons navigate to Game Book and HQ', () => {
     const onClose = vi.fn();
     const onOpenBoxScore = vi.fn();

--- a/src/ui/utils/playerGameLogs.js
+++ b/src/ui/utils/playerGameLogs.js
@@ -62,7 +62,8 @@ export function getPlayerGameLogs(league, player) {
           rushAtt: stats.rushAtt, rushYd: stats.rushYd, rushTD: stats.rushTD, receptions: stats.receptions, targets: stats.targets, recYd: stats.recYd, recTD: stats.recTD,
           tackles: stats.tackles, sacks: stats.sacks, passDeflections: stats.passDeflections, forcedFumbles: stats.forcedFumbles,
           fieldGoalsMade: stats.fieldGoalsMade, fieldGoalsAttempted: stats.fieldGoalsAttempted, extraPointsMade: stats.extraPointsMade, extraPointsAttempted: stats.extraPointsAttempted,
-          punts: stats.punts, puntYards: stats.puntYards,
+          longestFieldGoal: stats.longestFieldGoal ?? stats.longestFG ?? stats.fieldGoalLong,
+          punts: stats.punts, puntYards: stats.puntYards, longestPunt: stats.longestPunt ?? stats.puntLong,
         },
       });
     }


### PR DESCRIPTION
### Motivation

- Introduce a single, pure decision-summary model to surface concise GM-facing recommendations on the full `PlayerProfile` without duplicating or mutating existing evaluation/legality logic.

### Description

- Add a pure builder `buildPlayerDecisionPresentation` in `src/core/playerDecisionPresentation.js` that consolidates identity, role, availability, performance, development, contract, roster value, replacement difficulty, and deterministic recommendation using existing authorities like `evaluateReSigningPriority` and `derivePlayerArchetype`.
- Add a presentational React component `PlayerDecisionCard` in `src/ui/components/PlayerDecisionCard.jsx` and integrate it into `PlayerProfile.jsx` via `useMemo` to render the decision summary alongside existing overview content.
- Include an audit document `docs/player-decision-cards-v1-audit.md` describing scope, authoritative facts, omissions, and performance considerations for V1 of the decision cards.
- Add unit tests for the presentation model and UI and update profile tests: `src/core/__tests__/playerDecisionPresentation.test.js`, `src/ui/components/__tests__/PlayerDecisionCard.test.jsx`, and adjustments in `src/ui/components/__tests__/PlayerProfile.test.jsx` to assert the new decision card behavior.

### Testing

- Ran unit tests for the new presentation model with `playerDecisionPresentation.test.js` and UI tests with `PlayerDecisionCard.test.jsx` as part of the Vitest suite, and they passed.
- Updated `PlayerProfile` tests (`PlayerProfile.test.jsx`) to exercise embedding the card in the overview and those tests passed as well.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cdb6b5760832d8fe781d9b27433c2)