### PR TITLE
PR #1726 — GM Decision Queue V1: Availability Foundation

### DIFF
--- a/docs/gm-decision-queue-availability-v1-audit.md
+++ b/docs/gm-decision-queue-availability-v1-audit.md
@@ -1,0 +1,71 @@
+# GM Decision Queue V1 — availability foundation audit
+
+## Scope and dependency
+
+This model-only change depends on merged PR #1725. The target contains `playerDecisionPresentation.js`, its exported `buildPlayerDecisionPresentation()` and `normalizePlayerDecisionSeasonStats()`, the player decision card/profile consumers, and `player-decision-cards-v1-audit.md`. The queue calls the merged presentation builder rather than reproducing player role, availability, retention, recommendation, archetype, contract, roster-value, or replacement evaluation.
+
+No UI is wired in this change. The queue performs no navigation, transaction, persistence, worker, IndexedDB, save-schema, or simulation operation.
+
+## Live-source findings
+
+### Player facts consumed
+
+The queue consumes these exact presentation fields once per plausible, unique candidate:
+
+- `identity.id`, `identity.position`, and `identity.statusKey`;
+- `role.label` (`Starter`, `Backup`, `Reserve`, or `Role unavailable`) and the presentation model's canonical role/depth interpretation;
+- `availability.available` and `availability.detail`;
+- `replacement.label`, whose exact live values are title-cased `High`, `Medium`, and `Low` (the underlying re-signing evaluator emits lowercase values and the presentation adapter establishes this casing);
+- `availableData` indirectly as the authoritative presentation contract, while queue `availableData` reports which queue facts were established.
+
+The cheap prefilter recognizes only recorded facts already supported by the player surface: `injuryWeeksRemaining`, `injury.weeksRemaining`, `injury.gamesRemaining`, a non-healthy `injury.status`, an injury `name`/`type`, `onIR`, and `status: 'injured_reserve'`. A missing injury record is healthy for prefilter purposes; a duration is never invented. IR status is treated as recorded unavailability even where an old save has no injury object.
+
+### Ownership and status
+
+The supplied roster is the membership boundary and `player.teamId` must match `team.id` using legacy-safe string comparison. Primitive roster references resolve only through `league.players`; unresolved references are omitted. Retired players, free agents, and draft prospects (including membership in `league.draftClass`) are excluded. Canonical player IDs are retained in returned metadata rather than numerically coerced.
+
+### Depth-chart authority and replacement existence
+
+`src/core/depthChart.js` defines canonical rows and writes `depthChart.rowKey`, `depthChart.order`, and `depthChart.role`; it also preserves `depthOrder`. The team-level `team.depthChart[rowKey]` assignment array is the strongest source for proving that a starter's row has no later assigned player. Per-player placement can prove a healthy next-depth player exists, but partial per-player data cannot prove absence.
+
+A replacement must be on the same supplied team, have a recorded later assignment in the same canonical row, be currently available, and not be retired, a prospect, or a free agent. Overall rating is never consulted. Existing canonical row grouping is honored through `rowKey`; the queue defines no new position group or replacement-quality formula.
+
+Missing row assignments, missing role, or incomplete depth information cannot establish “no replacement.” An unavailable starter with unsupported depth evidence remains high and receives a diagnostic rather than being raised to critical.
+
+## Queue contract and rules
+
+`buildAvailabilityDecisionQueue({ roster, team, league, seasonStatsByPlayerId })` returns `{ items, diagnostics }`. Each item has a stable availability ID, category and explicit severity, player subject, factual title, one to three deduplicated reasons, specialist destination metadata, debug sort key, and availability-of-data flags.
+
+Eligibility requires supplied-roster membership, supplied-team ownership, a supported roster status, and a recorded current injury/unavailability fact. A candidate passing the cheap prefilter is presented once. It remains eligible when season stats are missing; matching stats are passed through without loading, archive scanning, mutation, or missing-to-zero conversion.
+
+Severity rules are applied in order:
+
+1. **Critical:** an unavailable recorded `Starter` and complete canonical team-row assignments confirm no healthy next assigned player.
+2. **High:** an unavailable recorded `Starter`, or presentation `replacement.label === 'High'`.
+3. **Medium:** another unavailable player with an authoritative `Backup` or `Reserve` role and enough context to review.
+
+Replacement difficulty alone never makes an item critical. Missing role never means starter. Missing replacement data never means High. Unsupported candidates are omitted with diagnostics.
+
+Reasons use recorded role, IR status, duration, injury detail, replacement difficulty, and confirmed backup presence/absence. Missing duration produces no duration copy; recorded zero remains available data but does not itself establish an injury. Titles contain only position and recorded starter/depth context.
+
+## Ordering, deduplication, and diagnostics
+
+Items sort by explicit severity rank (`critical`, `high`, `medium`), authoritative role rank (`Starter`, `Backup`, `Reserve`, unavailable), exact replacement rank (`High`, `Medium`, `Low`, unavailable), then canonical ID. `stableSortKey` exposes those components. Numeric and string IDs are compared without mutating or replacing the returned ID, and roster arrival order is not a tie-breaker.
+
+Canonical string-equivalent IDs deduplicate roster references before presentation construction, yielding at most one item and one presentation call per player. Diagnostics are deduplicated and deterministically sorted. They cover unresolved IDs, duplicates, ownership mismatch, excluded status, healthy prefilter results, missing actionable injury context, insufficient role/context, and unsupported critical-depth evidence. They are debug/test data, never item copy.
+
+## Destinations
+
+The live navigation authority names the lineup workflow `Depth Chart` and the injury workflow `Injuries` (the screen heading is “Injury Report”). Recorded starters go to `Depth Chart`; informational non-starters go to `Injuries`. `playerId` is retained as metadata, but this model neither navigates nor invents a player-focused route.
+
+## Performance and partial-data behavior
+
+The implementation indexes league players once for stale primitive references, prefilters before presentation work, deduplicates before presentation work, computes each presentation once, reuses one resolved roster list for depth checks, and sorts only final items and diagnostics. It performs no archive parsing, league scan per output field, persistence read, or worker call. A dependency-injected builder factory is exported solely as a test seam for call-count assertions; the public production function uses the merged presentation helper.
+
+Legacy numeric/string IDs, `onIR`, `injured_reserve`, legacy injury-week aliases, blank/null duration, `depthOrder`/`depthRank`, missing replacement evaluation, missing stats, duplicate references, empty rosters, and partial team/league values fail safely. Missing values do not become zero and absence of evidence cannot increase severity.
+
+## Intentionally unsupported and future work
+
+This foundation does not decide lineup mutations, IR placement, diagnosis, recovery, transactions, dismissal/snoozing, advance blocking, or replacement quality. It adds no contract, roster-shortage, trade, signing, release, waiver, preparation, or cap decision.
+
+Expected later queue categories are **contract**, **roster depth**, **trade deadline**, **opponent preparation**, **cap pressure**, and **development**. Their future integration should retain the same deterministic presentation-only boundary. This PR changes no simulation outcomes, injury mechanics, salary cap, contracts, trades, ratings, AI roster logic, worker behavior, navigation state, transaction behavior, persistence, or save schema.

--- a/src/core/__tests__/gmDecisionQueue.test.js
+++ b/src/core/__tests__/gmDecisionQueue.test.js
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAvailabilityDecisionQueue, createAvailabilityDecisionQueueBuilder } from '../gmDecisionQueue.js';
+
+const player = (id, overrides = {}) => ({
+  id, name: `Player ${id}`, pos: 'QB', teamId: 10, status: 'active', age: 26, ovr: 76,
+  contract: { yearsRemaining: 2 }, depthChart: { rowKey: 'QB', order: 2, role: 'backup' },
+  injury: { type: 'Knee', weeksRemaining: 2 }, ...overrides,
+});
+const build = (roster, overrides = {}) => buildAvailabilityDecisionQueue({
+  roster, team: { id: 10, depthChart: { QB: roster.filter(Boolean).map((p) => p.id) } },
+  league: { players: roster.filter((p) => p && typeof p === 'object'), draftClass: [] }, ...overrides,
+});
+
+describe('buildAvailabilityDecisionQueue', () => {
+  it('includes unavailable starters/backups and excludes healthy or foreign players', () => {
+    const starter = player(1, { depthChart: { rowKey: 'QB', order: 1, role: 'starter' } });
+    const backup = player(2);
+    const healthy = player(3, { injury: null });
+    const foreign = player(4, { teamId: 11 });
+    const result = build([starter, backup, healthy, foreign]);
+    expect(result.items.map((item) => item.subject.playerId)).toEqual([1, 2]);
+    expect(result.items[0]).toMatchObject({ severity: 'high', destination: { view: 'Depth Chart', playerId: 1 } });
+    expect(result.items[1]).toMatchObject({ destination: { view: 'Injuries', playerId: 2 } });
+    expect(result.diagnostics).toEqual(expect.arrayContaining([
+      { playerId: 3, reason: 'Healthy player' },
+      { playerId: 4, reason: 'Player not owned by supplied team' },
+    ]));
+  });
+
+  it.each([
+    ['free agent', { status: 'free_agent', teamId: null }],
+    ['draft prospect', { status: 'draft_eligible', draftEligible: true }],
+    ['retired player', { status: 'retired', retired: true }],
+  ])('excludes %s', (_label, fields) => {
+    expect(build([player(1, fields)]).items).toEqual([]);
+  });
+
+  it('requires confirmed missing replacement for critical and a healthy backup prevents it', () => {
+    const starter = player(1, { depthChart: { rowKey: 'QB', order: 1, role: 'starter' } });
+    expect(build([starter]).items[0].severity).toBe('critical');
+    expect(build([starter, player(2, { injury: null })]).items[0].severity).toBe('high');
+    const missingDepth = build([starter], { team: { id: 10 }, league: { players: [starter] } });
+    expect(missingDepth.items[0].severity).toBe('high');
+    expect(missingDepth.diagnostics).toContainEqual({ playerId: 1, reason: 'Unsupported depth data for critical classification' });
+  });
+
+  it('does not invent starter status when role data is missing', () => {
+    const incomplete = player(1, { depthChart: null, depthOrder: null, ovr: 1 });
+    const result = build([incomplete]);
+    expect(result.items[0]).toMatchObject({ severity: 'high', destination: { view: 'Injuries' } });
+    expect(result.items[0].reasons).not.toContain('Recorded starter role');
+  });
+
+  it('uses authoritative High replacement difficulty to raise a backup to high', () => {
+    const backup = player(1);
+    const result = build([backup]);
+    expect(result.items[0].severity).toBe('high');
+    expect(result.items[0].reasons).toContain('High replacement difficulty');
+  });
+
+  it('renders recorded duration, omits missing duration, and preserves recorded zero without calling it missing', () => {
+    const duration = build([player(1)]).items[0].reasons;
+    expect(duration).toContain('Recorded absence: 2 weeks');
+    const noDuration = build([player(2, { injury: { type: 'Knee', weeksRemaining: null } })]).items[0].reasons;
+    expect(noDuration.join(' ')).not.toMatch(/0 week/);
+    const zero = build([player(3, { injury: { type: 'Knee', weeksRemaining: 0 } })]).items[0];
+    expect(zero.availableData.injuryDuration).toBe(true);
+    expect(new Set(zero.reasons).size).toBe(zero.reasons.length);
+  });
+
+  it('orders by severity, role, replacement, then stable canonical ID independent of input order', () => {
+    const rows = [player('20'), player(3), player('11')];
+    const first = build(rows).items.map((item) => item.subject.playerId);
+    const second = build([...rows].reverse()).items.map((item) => item.subject.playerId);
+    expect(first).toEqual([3, '11', '20']);
+    expect(second).toEqual(first);
+  });
+
+  it('deduplicates canonical IDs and presentation calls', () => {
+    const presentation = vi.fn(({ player: input }) => ({
+      identity: { statusKey: 'active_roster', position: input.pos }, role: { label: 'Backup' },
+      availability: { available: false, detail: 'Knee' }, replacement: { label: 'Medium' },
+    }));
+    const builder = createAvailabilityDecisionQueueBuilder({ buildPresentation: presentation });
+    const original = player(1);
+    const result = builder({ roster: [original, { ...original }], team: { id: 10 }, league: { players: [original] } });
+    expect(result.items).toHaveLength(1);
+    expect(presentation).toHaveBeenCalledTimes(1);
+    expect(result.diagnostics).toContainEqual({ playerId: 1, reason: 'Duplicate roster reference' });
+  });
+
+  it('prefilters healthy players before presentation construction', () => {
+    const presentation = vi.fn();
+    const builder = createAvailabilityDecisionQueueBuilder({ buildPresentation: presentation });
+    builder({ roster: [player(1, { injury: null })], team: { id: 10 }, league: {} });
+    expect(presentation).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [{ status: 'injured_reserve', injury: null }], [{ onIR: true, injury: null }],
+    [{ injuryWeeksRemaining: 3, injury: null }], [{ injury: { type: 'Knee', weeksRemaining: null } }],
+    [{ injury: { status: 'Out', weeksRemaining: '' } }],
+  ])('handles legacy/partial unavailable shape %j', (fields) => {
+    expect(build([player(1, fields)]).items).toHaveLength(1);
+  });
+
+  it('is pure, deterministic, and safely handles stale/partial inputs', () => {
+    const roster = [player(1)];
+    const team = { id: 10, depthChart: { QB: [1] } };
+    const league = { players: roster };
+    const stats = { 1: { passYd: 0 } };
+    const snapshot = structuredClone({ roster, team, league, stats });
+    const input = { roster, team, league, seasonStatsByPlayerId: stats };
+    expect(buildAvailabilityDecisionQueue(input)).toEqual(buildAvailabilityDecisionQueue(input));
+    expect({ roster, team, league, stats }).toEqual(snapshot);
+    expect(buildAvailabilityDecisionQueue({ roster: [999], team, league })).toMatchObject({ items: [] });
+    expect(buildAvailabilityDecisionQueue({ roster: [], team, league }).items).toEqual([]);
+    expect(buildAvailabilityDecisionQueue({ roster: null, team: null, league: null }).diagnostics).not.toEqual([]);
+  });
+});

--- a/src/core/gmDecisionQueue.js
+++ b/src/core/gmDecisionQueue.js
@@ -1,0 +1,200 @@
+import { buildPlayerDecisionPresentation } from './playerDecisionPresentation.js';
+
+const SEVERITY_RANK = { critical: 0, high: 1, medium: 2 };
+const ROLE_RANK = { Starter: 0, Backup: 1, Reserve: 2 };
+const REPLACEMENT_RANK = { High: 0, Medium: 1, Low: 2 };
+const EXCLUDED_STATUSES = new Set(['free_agent', 'draft_eligible', 'retired']);
+
+const canonicalId = (value) => value == null ? null : String(value);
+const playerId = (player) => player?.id ?? player?.prospectId ?? null;
+const sameId = (left, right) => left != null && right != null && String(left) === String(right);
+const finiteNumber = (value) => {
+  if (value == null || (typeof value === 'string' && value.trim() === '')) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+function recordedUnavailable(player) {
+  const weeks = finiteNumber(player?.injuryWeeksRemaining ?? player?.injury?.weeksRemaining ?? player?.injury?.gamesRemaining);
+  const injuryStatus = String(player?.injury?.status ?? '').trim();
+  const injuryLabel = player?.injury?.name ?? player?.injury?.type ?? null;
+  return (weeks != null && weeks > 0)
+    || Boolean(injuryLabel)
+    || Boolean(injuryStatus && injuryStatus.toLowerCase() !== 'healthy')
+    || player?.onIR === true
+    || player?.status === 'injured_reserve';
+}
+
+function excludedPlayer(player, league) {
+  if (player?.retired || player?.isRetired || EXCLUDED_STATUSES.has(player?.status)) return true;
+  if (player?.isProspect || player?.draftEligible) return true;
+  return Array.isArray(league?.draftClass) && league.draftClass.some((prospect) =>
+    sameId(playerId(prospect), playerId(player)));
+}
+
+function statsFor(stats, id) {
+  if (!stats || id == null) return null;
+  if (stats instanceof Map) return stats.get(id) ?? stats.get(String(id)) ?? null;
+  return stats[id] ?? stats[String(id)] ?? null;
+}
+
+function depthResult(player, roster, team) {
+  const id = playerId(player);
+  const rowKey = player?.depthChart?.rowKey ?? null;
+  if (!rowKey) return { confirmed: false, healthyBackup: false };
+
+  const assignedIds = team?.depthChart?.[rowKey];
+  if (Array.isArray(assignedIds) && assignedIds.some((assignedId) => sameId(assignedId, id))) {
+    const laterIds = assignedIds.slice(assignedIds.findIndex((assignedId) => sameId(assignedId, id)) + 1);
+    const healthyBackup = laterIds.some((assignedId) => {
+      const candidate = roster.find((entry) => sameId(playerId(entry), assignedId));
+      return candidate && sameId(candidate.teamId, team?.id) && !excludedPlayer(candidate, null) && !recordedUnavailable(candidate);
+    });
+    return { confirmed: true, healthyBackup };
+  }
+
+  const assigned = roster.filter((candidate) => candidate?.depthChart?.rowKey === rowKey
+    && finiteNumber(candidate?.depthChart?.order ?? candidate?.depthOrder ?? candidate?.depthRank) != null);
+  if (!assigned.some((candidate) => sameId(playerId(candidate), id))) return { confirmed: false, healthyBackup: false };
+  const healthyBackup = assigned.some((candidate) => !sameId(playerId(candidate), id)
+      && sameId(candidate.teamId, team?.id)
+      && finiteNumber(candidate?.depthChart?.order ?? candidate?.depthOrder ?? candidate?.depthRank) > 1
+      && !excludedPlayer(candidate, null)
+      && !recordedUnavailable(candidate));
+  // Per-player placement can prove a replacement exists, but cannot prove that
+  // an otherwise absent row assignment does not exist elsewhere in partial data.
+  return { confirmed: healthyBackup, healthyBackup };
+}
+
+function compareIds(left, right) {
+  const a = canonicalId(left) ?? '';
+  const b = canonicalId(right) ?? '';
+  const an = finiteNumber(a);
+  const bn = finiteNumber(b);
+  if (an != null && bn != null && an !== bn) return an - bn;
+  return a.localeCompare(b, 'en', { numeric: true });
+}
+
+export function createAvailabilityDecisionQueueBuilder({ buildPresentation = buildPlayerDecisionPresentation } = {}) {
+  return function buildAvailabilityDecisionQueue({ roster, team, league, seasonStatsByPlayerId = null } = {}) {
+    const items = [];
+    const diagnostics = [];
+    const diagnosticKeys = new Set();
+    const addDiagnostic = (id, reason) => {
+      const key = `${canonicalId(id) ?? 'unresolved'}:${reason}`;
+      if (!diagnosticKeys.has(key)) {
+        diagnosticKeys.add(key);
+        diagnostics.push({ playerId: id ?? null, reason });
+      }
+    };
+
+    if (!Array.isArray(roster)) {
+      addDiagnostic(null, 'Roster unavailable');
+      return { items, diagnostics };
+    }
+    if (!team || team.id == null) {
+      addDiagnostic(null, 'Supplied team unavailable');
+      return { items, diagnostics };
+    }
+
+    const leaguePlayers = Array.isArray(league?.players) ? league.players : [];
+    const leagueById = new Map(leaguePlayers.map((player) => [canonicalId(playerId(player)), player]));
+    const resolvedRoster = roster.map((entry) => {
+      if (entry && typeof entry === 'object') return entry;
+      return leagueById.get(canonicalId(entry)) ?? null;
+    }).filter(Boolean);
+    const seen = new Set();
+
+    for (const entry of roster) {
+      const player = entry && typeof entry === 'object' ? entry : leagueById.get(canonicalId(entry));
+      const id = playerId(player) ?? (entry && typeof entry !== 'object' ? entry : null);
+      if (!player || playerId(player) == null) {
+        addDiagnostic(id, 'Unresolved player ID');
+        continue;
+      }
+      const key = canonicalId(playerId(player));
+      if (seen.has(key)) {
+        addDiagnostic(playerId(player), 'Duplicate roster reference');
+        continue;
+      }
+      seen.add(key);
+      if (!sameId(player.teamId, team.id)) {
+        addDiagnostic(playerId(player), 'Player not owned by supplied team');
+        continue;
+      }
+      if (excludedPlayer(player, league)) {
+        addDiagnostic(playerId(player), 'Excluded player status');
+        continue;
+      }
+      if (!recordedUnavailable(player)) {
+        addDiagnostic(playerId(player), 'Healthy player');
+        continue;
+      }
+
+      const presentation = buildPresentation({
+        player,
+        team,
+        league: league ?? {},
+        seasonStats: statsFor(seasonStatsByPlayerId, playerId(player)),
+      });
+      const presentationUnavailable = presentation?.availability?.available === false;
+      const recordedIr = presentation?.identity?.statusKey === 'injured_reserve';
+      if (!presentationUnavailable && !recordedIr) {
+        addDiagnostic(playerId(player), 'Missing actionable injury context');
+        continue;
+      }
+
+      const role = presentation?.role?.label;
+      const starter = role === 'Starter';
+      const supportedRole = starter || role === 'Backup' || role === 'Reserve';
+      const replacement = presentation?.replacement?.label ?? null;
+      const depth = starter ? depthResult(player, resolvedRoster, team) : { confirmed: false, healthyBackup: false };
+      let severity = starter && depth.confirmed && !depth.healthyBackup
+        ? 'critical'
+        : (starter || replacement === 'High' ? 'high' : supportedRole ? 'medium' : null);
+      if (!severity) {
+        addDiagnostic(playerId(player), 'Insufficient role/context for medium severity');
+        continue;
+      }
+      if (starter && !depth.confirmed) addDiagnostic(playerId(player), 'Unsupported depth data for critical classification');
+
+      const duration = finiteNumber(player?.injuryWeeksRemaining ?? player?.injury?.weeksRemaining ?? player?.injury?.gamesRemaining);
+      const reasons = [];
+      if (starter) reasons.push('Recorded starter role');
+      else if (supportedRole) reasons.push(`Recorded ${role.toLowerCase()} role`);
+      if (player?.status === 'injured_reserve' || player?.onIR === true) reasons.push('Injured-reserve status');
+      else if (duration != null) reasons.push(`Recorded absence: ${duration} week${duration === 1 ? '' : 's'}`);
+      else if (presentation?.availability?.detail) reasons.push(String(presentation.availability.detail));
+      if (severity === 'critical') reasons.push('No healthy assigned backup');
+      else if (starter && depth.confirmed && depth.healthyBackup) reasons.push('Healthy assigned backup exists');
+      else if (replacement) reasons.push(`${replacement} replacement difficulty`);
+
+      const position = presentation?.identity?.position ?? player?.pos ?? player?.position ?? '—';
+      const stableSortKey = [SEVERITY_RANK[severity], ROLE_RANK[role] ?? 3,
+        REPLACEMENT_RANK[replacement] ?? 3, canonicalId(playerId(player))].join(':');
+      items.push({
+        id: `availability:${canonicalId(playerId(player))}`,
+        category: 'availability',
+        severity,
+        subject: { type: 'player', playerId: playerId(player), position },
+        title: starter ? `Starting ${position} unavailable` : `${position} depth requires review`,
+        reasons: [...new Set(reasons)].slice(0, 3),
+        destination: { view: starter ? 'Depth Chart' : 'Injuries', playerId: playerId(player) },
+        stableSortKey,
+        availableData: {
+          role: supportedRole,
+          replacementDifficulty: replacement != null,
+          injuryDuration: duration != null,
+          depthChart: depth.confirmed,
+        },
+      });
+    }
+
+    items.sort((a, b) => a.stableSortKey.localeCompare(b.stableSortKey, 'en', { numeric: true })
+      || compareIds(a.subject.playerId, b.subject.playerId));
+    diagnostics.sort((a, b) => compareIds(a.playerId, b.playerId) || a.reason.localeCompare(b.reason));
+    return { items, diagnostics };
+  };
+}
+
+export const buildAvailabilityDecisionQueue = createAvailabilityDecisionQueueBuilder();


### PR DESCRIPTION
### Motivation

- Provide a pure, deterministic team-level presentation model that surfaces the most important player availability decisions for a user roster while reusing the authoritative player presentation from the merged Player Decision Cards V1.
- Confirmed dependency on merged PR #1725 and presence of `src/core/playerDecisionPresentation.js`, `buildPlayerDecisionPresentation()`, `normalizePlayerDecisionSeasonStats()`, and `docs/player-decision-cards-v1-audit.md` before implementing.
- The queue must be presentation-only and must not mutate state, perform transactions, navigate, call workers, or change simulation/persistence/contract logic.

### Description

- Add `src/core/gmDecisionQueue.js` that exports `buildAvailabilityDecisionQueue({ roster, team, league, seasonStatsByPlayerId = null })` and a test seam `createAvailabilityDecisionQueueBuilder()`; the builder reuses `buildPlayerDecisionPresentation()` for authoritative role, availability, and replacement facts.
- Implement cheap factual prefiltering for recorded unavailability (`injuryWeeksRemaining`, `injury.weeksRemaining`, `injury.gamesRemaining`, `injury.name/type`, `onIR`, `status: 'injured_reserve'`) and deterministic eligibility checks (roster membership, team ownership, exclusions for free agents/prospects/retired, and unresolved references produce diagnostics).
- Apply explicit severity rules (in order): Critical = unavailable recorded starter + canonical team-row confirmation of no healthy assigned backup; High = unavailable recorded starter or presentation `replacement.label === 'High'`; Medium = unavailable non-starter with sufficient role context; missing data never raises severity and unsupported critical evidence emits diagnostics.
- Confirm healthy backup only via canonical `depthChart.rowKey` assignments and per-player row-order evidence without inventing replacements or using overall ratings, and map destinations to existing specialist workflows `Depth Chart` and `Injuries` (no navigation performed).
- Produce deterministic, deduplicated output items with `id`, `category`, `severity`, `subject`, `title`, 1–3 factual `reasons`, `destination`, `stableSortKey`, `availableData`, and a `diagnostics` array for omitted candidates; ensure each eligible player presentation is built at most once and inputs are not mutated.
- Add documentation `docs/gm-decision-queue-availability-v1-audit.md` describing audit findings, authoritative fields reused, severity and healthy-backup logic, ordering/deduplication, diagnostics, performance, legacy handling, and explicit confirmation that simulation/persistence/UI/worker systems were not changed.
- Files changed: `src/core/gmDecisionQueue.js`, `src/core/__tests__/gmDecisionQueue.test.js`, `docs/gm-decision-queue-availability-v1-audit.md`.

### Testing

- `node --check src/core/gmDecisionQueue.js` — passed. 
- Ran targeted tests: `npx vitest run src/core/__tests__/gmDecisionQueue.test.js src/core/__tests__/playerDecisionPresentation.test.js src/core/__tests__/depth-chart.test.js src/core/roster/__tests__/depthChartManager.test.ts src/ui/components/__tests__/InjuryReportAvailability.test.jsx` — passed (5 files, 70 tests).
- Full suite: `npm run test:unit` — passed (468 files, 5,759 tests).
- Type check: `npm run check:sim-types` — passed.
- Build: `npm run build` — succeeded (repository-expected large-chunk warning only).
- Deploy parity: `npm run check:deploy` — passed (netlify parity, rules, production offline build, and deploy-preview offline build).
- E2E: not run because this PR is model-only and does not wire the queue into any UI workflow; no placeholder UI was added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6febd86974832da20ed8c50bf7696a)