### PR TITLE
PR #1727 — GM Decision Center V1

### DIFF
--- a/docs/gm-decision-center.md
+++ b/docs/gm-decision-center.md
@@ -1,0 +1,7 @@
+# GM Decision Center V1
+
+Availability is the first visible decision category because an unavailable player can immediately compromise the next game's depth chart. It is already supported by recorded roster, injury, role, and replacement context, so the HQ can surface an honest weekly action without inventing a new gameplay mechanic.
+
+The Decision Center remains presentation-only. It reads the existing availability queue in its returned order, shows at most three entries, and sends review actions through existing Franchise HQ navigation. It does not persist, dismiss, re-rank, or modify queue items, roster state, simulation state, or saves.
+
+Future queue expansion may add **Contracts**, **Roster Depth**, **Trade Deadline**, **Opponent Prep**, **Cap Pressure**, and **Development**. The disabled **View All** control reserves a clear affordance for that expansion without creating a destination or navigation workflow in V1.

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -21,6 +21,7 @@ import FranchiseBrandHQ from './FranchiseBrandHQ.jsx';
 import JobSecurityCard from './JobSecurityCard.jsx';
 import ActivityToastStack from './ActivityToastStack.jsx';
 import GameResultSummaryCard from './GameResultSummaryCard.jsx';
+import GMDecisionCenter from './GMDecisionCenter.jsx';
 import { readStrictFinalScore } from '../../core/gameArchive.js';
 
 const BOTTOM_NAV_ITEMS = [
@@ -625,6 +626,8 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
           <span>No blockers — ready to advance</span>
         </div>
       )}
+
+      <GMDecisionCenter league={league} onNavigate={onNavigate} />
 
       {/* ── QUICK ACTION GRID 2×2 ────────────────────────────────────────── */}
       <div

--- a/src/ui/components/GMDecisionCenter.jsx
+++ b/src/ui/components/GMDecisionCenter.jsx
@@ -1,0 +1,80 @@
+import React, { useMemo } from 'react';
+import { buildAvailabilityDecisionQueue } from '../../core/gmDecisionQueue.js';
+
+const SEVERITY_STYLES = {
+  critical: { label: 'Critical', color: 'var(--danger, #FF453A)', background: 'rgba(255,69,58,.12)' },
+  high: { label: 'High', color: 'var(--warning, #FF9F0A)', background: 'rgba(255,159,10,.12)' },
+  medium: { label: 'Medium', color: '#FFD60A', background: 'rgba(255,214,10,.12)' },
+};
+
+function isDepthChartDestination(destination) {
+  return destination?.view === 'Depth Chart';
+}
+
+function routeFor(destination) {
+  return isDepthChartDestination(destination) ? 'Team:Roster / Depth' : 'Team:Injuries';
+}
+
+export default function GMDecisionCenter({ league, onNavigate }) {
+  const team = useMemo(
+    () => (league?.teams ?? []).find((entry) => String(entry?.id) === String(league?.userTeamId)),
+    [league?.teams, league?.userTeamId],
+  );
+  const queue = useMemo(() => buildAvailabilityDecisionQueue({
+    roster: team?.roster,
+    team,
+    league,
+    seasonStatsByPlayerId: league?.seasonStatsByPlayerId,
+  }), [league, team]);
+  const items = queue.items.slice(0, 3);
+
+  if (items.length === 0) return null;
+
+  return (
+    <section
+      aria-labelledby="gm-decisions-heading"
+      data-testid="gm-decision-center"
+      style={{ margin: '4px 12px', border: '1px solid var(--hairline-strong)', borderRadius: 'var(--radius-md)', background: 'var(--surface-strong)', overflow: 'hidden' }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, padding: 'var(--space-3) var(--space-4)', borderBottom: '1px solid var(--hairline)' }}>
+        <h2 id="gm-decisions-heading" style={{ margin: 0, fontSize: 'var(--text-base)', fontWeight: 900 }}>GM Decisions</h2>
+        {/* TODO: Enable when the expanded multi-category decision queue has an existing destination. */}
+        <button type="button" className="btn btn-sm" disabled>View All</button>
+      </div>
+      <div>
+        {items.map((item, index) => {
+          const severity = SEVERITY_STYLES[item.severity] ?? SEVERITY_STYLES.medium;
+          const depthChart = isDepthChartDestination(item.destination);
+          return (
+            <article
+              key={item.id}
+              data-testid="gm-decision-item"
+              style={{ padding: 'var(--space-3) var(--space-4)', borderBottom: index < items.length - 1 ? '1px solid var(--hairline)' : 0 }}
+            >
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10 }}>
+                <div style={{ minWidth: 0 }}>
+                  <span
+                    aria-label={`${severity.label} severity`}
+                    style={{ display: 'inline-flex', padding: '2px 7px', borderRadius: 999, color: severity.color, background: severity.background, fontSize: 'var(--text-xs)', fontWeight: 900 }}
+                  >
+                    {item.severity === 'critical' ? '⚠ ' : ''}{severity.label}
+                  </span>
+                  <div style={{ marginTop: 5, fontSize: 'var(--text-sm)', fontWeight: 800 }}>{item.title}</div>
+                  {item.reasons?.length ? <div style={{ marginTop: 3, color: 'var(--text-muted)', fontSize: 'var(--text-xs)' }}>• {item.reasons[item.reasons.length - 1]}</div> : null}
+                </div>
+                <button
+                  type="button"
+                  className="btn btn-sm"
+                  onClick={() => onNavigate?.(routeFor(item.destination))}
+                  style={{ flex: '0 0 auto' }}
+                >
+                  {depthChart ? 'Review Depth Chart' : 'Review'}
+                </button>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/ui/components/__tests__/GMDecisionCenter.test.jsx
+++ b/src/ui/components/__tests__/GMDecisionCenter.test.jsx
@@ -1,0 +1,101 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import GMDecisionCenter from '../GMDecisionCenter.jsx';
+
+const { buildQueue } = vi.hoisted(() => ({ buildQueue: vi.fn() }));
+
+vi.mock('../../../core/gmDecisionQueue.js', () => ({
+  buildAvailabilityDecisionQueue: buildQueue,
+}));
+
+const league = Object.freeze({
+  userTeamId: 10,
+  teams: Object.freeze([Object.freeze({ id: 10, roster: Object.freeze([]) })]),
+});
+
+function item(id, severity, view = 'Injuries') {
+  return Object.freeze({
+    id,
+    severity,
+    title: `${id} depth requires review`,
+    reasons: Object.freeze([`${severity} reason`]),
+    destination: Object.freeze({ view }),
+  });
+}
+
+describe('GMDecisionCenter', () => {
+  beforeEach(() => {
+    buildQueue.mockReset();
+  });
+
+  afterEach(cleanup);
+
+  it('renders a maximum of three items in stable queue order without mutation', () => {
+    const items = Object.freeze([
+      item('third', 'medium'),
+      item('first', 'critical', 'Depth Chart'),
+      item('second', 'high'),
+      item('hidden', 'critical'),
+    ]);
+    buildQueue.mockReturnValue(Object.freeze({ items, diagnostics: Object.freeze([]) }));
+
+    render(<GMDecisionCenter league={league} onNavigate={vi.fn()} />);
+
+    const rows = screen.getAllByTestId('gm-decision-item');
+    expect(rows).toHaveLength(3);
+    expect(rows.map((row) => within(row).getByText(/depth requires review/).textContent)).toEqual([
+      'third depth requires review',
+      'first depth requires review',
+      'second depth requires review',
+    ]);
+    expect(items).toHaveLength(4);
+    expect(items[0].id).toBe('third');
+  });
+
+  it('renders nothing when the queue is empty', () => {
+    buildQueue.mockReturnValue({ items: [], diagnostics: [] });
+    const { container } = render(<GMDecisionCenter league={league} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('announces critical, high, and medium severities with visible labels', () => {
+    buildQueue.mockReturnValue({
+      items: [item('LT', 'critical'), item('QB', 'high'), item('CB', 'medium')],
+      diagnostics: [],
+    });
+    render(<GMDecisionCenter league={league} />);
+
+    expect(screen.getByLabelText('Critical severity').textContent).toContain('Critical');
+    expect(screen.getByLabelText('High severity').textContent).toContain('High');
+    expect(screen.getByLabelText('Medium severity').textContent).toContain('Medium');
+  });
+
+  it('uses destination-specific labels and fires the existing navigation callback', () => {
+    const onNavigate = vi.fn();
+    buildQueue.mockReturnValue({
+      items: [item('LT', 'critical', 'Depth Chart'), item('CB', 'medium', 'Injuries')],
+      diagnostics: [],
+    });
+    render(<GMDecisionCenter league={league} onNavigate={onNavigate} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Review Depth Chart' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Review' }));
+    expect(onNavigate).toHaveBeenNthCalledWith(1, 'Team:Roster / Depth');
+    expect(onNavigate).toHaveBeenNthCalledWith(2, 'Team:Injuries');
+  });
+
+  it('builds the queue once when rerendered with unchanged inputs', () => {
+    buildQueue.mockReturnValue({ items: [item('QB', 'high')], diagnostics: [] });
+    const { rerender } = render(<GMDecisionCenter league={league} />);
+    rerender(<GMDecisionCenter league={league} />);
+    expect(buildQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps View All disabled until an expanded queue destination exists', () => {
+    buildQueue.mockReturnValue({ items: [item('QB', 'high')], diagnostics: [] });
+    render(<GMDecisionCenter league={league} />);
+    expect(screen.getByRole('button', { name: 'View All' }).disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation

- The availability decision queue was merged but had no visible HQ surface to surface immediate weekly roster risks to the player.  
- Verified dependency `src/core/gmDecisionQueue.js` and `buildAvailabilityDecisionQueue()` exist before implementing the UI integration.  

### Description

- Added a compact presentation component `src/ui/components/GMDecisionCenter.jsx` that consumes `buildAvailabilityDecisionQueue(...)`, memoizes the queue, preserves the queue's returned ordering, and displays at most three items.  
- Integrated `GMDecisionCenter` into `FranchiseHQ.jsx` immediately above the quick-action grid without altering routing, navigation architecture, or any simulation/worker logic.  
- UI behavior: hides completely when the queue is empty, shows a severity badge (Critical/High/Medium) with accessible labels, shows a single `Review` or `Review Depth Chart` button per item that calls the existing `onNavigate` callback, and leaves `View All` disabled with a TODO for future expansion.  
- Tests and documentation: added `src/ui/components/__tests__/GMDecisionCenter.test.jsx` covering rendering limits, empty state, severity labels, ordering, immutability, memoization, destination labels/callbacks, and disabled `View All`, and added `docs/gm-decision-center.md` explaining design rationale and future categories.  

### Testing

- Ran the focused component tests with `npx vitest run src/ui/components/__tests__/GMDecisionCenter.test.jsx src/core/__tests__/gmDecisionQueue.test.js` and they passed.  
- Ran the full unit suite with `npm run test:unit` and all unit tests passed (469 files, 5,765 tests).  
- Ran type checks and build steps with `npm run check:sim-types` and `npm run build`, and `npm run check:deploy` (Netlify parity) and the builds completed; existing chunk-size advisory remained.  
- E2E Playwright smoke could not complete because the Playwright Chromium download failed with HTTP 403 in this environment, so `npx playwright test tests/e2e/fresh_franchise_first_week_smoke.spec.js` was skipped due to unavailable browser binaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ff7c08b38832db6ab6febcbdd06f0)