### PR TITLE
PR #1728 — GM Decision Queue V2: Contract Decisions

### DIFF
--- a/docs/gm-decision-center.md
+++ b/docs/gm-decision-center.md
@@ -1,7 +1,7 @@
-# GM Decision Center V1
+# GM Decision Center V2
 
 Availability is the first visible decision category because an unavailable player can immediately compromise the next game's depth chart. It is already supported by recorded roster, injury, role, and replacement context, so the HQ can surface an honest weekly action without inventing a new gameplay mechanic.
 
-The Decision Center remains presentation-only. It reads the existing availability queue in its returned order, shows at most three entries, and sends review actions through existing Franchise HQ navigation. It does not persist, dismiss, re-rank, or modify queue items, roster state, simulation state, or saves.
+The Decision Center remains presentation-only. It now reads the combined availability and contract queue in its returned order, shows at most three total entries, and sends review actions through existing Franchise HQ navigation. Availability reviews retain their Depth Chart/Injuries behavior; contract reviews open the existing Contract Center. It does not persist, dismiss, re-rank, or modify queue items, roster state, simulation state, or saves.
 
-Future queue expansion may add **Contracts**, **Roster Depth**, **Trade Deadline**, **Opponent Prep**, **Cap Pressure**, and **Development**. The disabled **View All** control reserves a clear affordance for that expansion without creating a destination or navigation workflow in V1.
+Future queue expansion may add **Roster Depth**, **Trade Deadline**, **Opponent Prep**, **Cap Pressure**, and **Development**. The disabled **View All** control reserves a clear affordance for that expansion without creating a destination or navigation workflow in V2.

--- a/docs/gm-decision-queue-contracts-v2-audit.md
+++ b/docs/gm-decision-queue-contracts-v2-audit.md
@@ -1,0 +1,41 @@
+# GM Decision Queue V2 — contract decisions audit
+
+## Dependency and scope confirmation
+
+The branch contains the merged #1725–#1727 dependencies: `playerDecisionPresentation.js` and `buildPlayerDecisionPresentation()`, `gmDecisionQueue.js` and `buildAvailabilityDecisionQueue()`, `GMDecisionCenter.jsx`, the availability V1 audit, and the Decision Center documentation. V2 extends those boundaries rather than recreating them. Contract items retain the availability queue contract unchanged and add the shared `primaryReason` field to both categories.
+
+This is presentation-only work. It changes no contract economics, salary-cap calculation, player rating/progression, trade, injury, simulation, AI roster, worker, transaction, persistence, or save-schema behavior.
+
+## Live authority audit
+
+`evaluateReSigningPriority()` in `src/core/retention/reSigning.js` is the authoritative shared retention recommendation. Its exact recommendation values are `cornerstone_priority`, `strong_keep`, `extension_candidate`, `keep_if_price_is_right`, `franchise_tag_candidate`, `replaceable_depth`, `likely_to_walk`, and `move_on`. It also supplies exact lowercase role importance (`core_starter`, `starter`, `rotation`, `depth`), replacement difficulty (`high`, `medium`, `low`), extension readiness, and the expiring decision. `summarizeContractRisk()` supplies exact lowercase negotiation risk bands (`high`, `medium`, `low`).
+
+The older UI-only `evaluateResignRecommendation()` remains live in Contract Center/roster views and emits `priority_resign`, `resign_if_price`, `trade_or_tag`, `let_walk`, and `replaceable_depth`, with title-cased `High`/`Medium`/`Low` risk and replacement labels. It is not used by this core queue because `buildPlayerDecisionPresentation()` already establishes `evaluateReSigningPriority()` as the shared player-decision authority. The presentation adapter exposes that authority's recommendation, role, replacement, risk, readiness, and expiring fields without adding a formula.
+
+Recorded contract terms are `contract.yearsRemaining`, `contract.yearsLeft`, then `contract.years`. Blank, null, missing, and nonnumeric values remain missing. Explicit extension eligibility, tag state, extension decision, or recorded re-sign recommendation can establish a cheap plausible-review signal, but never assigns severity itself. The live Contract Center offers its regular extension hub across normal gameplay phases and a specialized re-signing center in `offseason_resign`; the queue supports the repository's recorded preseason, regular/regular-season, playoffs, offseason/re-signing, free-agency, draft, training-camp, and lifecycle transition names. Unknown phases are omitted with a diagnostic. The exact destination is `Contract Center`; player ID remains metadata because the route does not support player focus.
+
+Unsupported concepts include option decisions without an existing authority, invented tag eligibility, market/cap value judgments, negotiation execution, release/sign/trade actions, and phase-specific legal conclusions beyond the live Contract Center boundary. Legacy Contract Center filtering sometimes defaults missing years to zero; this queue intentionally does not reproduce that limitation.
+
+## Public contracts and eligibility
+
+`buildContractDecisionQueue({ roster, team, league, seasonStatsByPlayerId })` and `buildGMDecisionQueue()` both return `{ items, diagnostics }`. Items use stable IDs, category, explicit severity, player subject, title, one to three reasons, `primaryReason`, specialist destination, `stableSortKey`, and `availableData`.
+
+Eligibility requires supplied-roster membership, matching team ownership, supported active/IR status, a recorded contract, a plausible current review signal, and a supported phase. Free agents, prospects, retirees, foreign-team players, stale references, missing contracts, and safe multi-year contracts without explicit signals are omitted. IR does not exclude a contract review. Candidates are canonically deduplicated before presentation construction.
+
+## Severity and recommendation mapping
+
+Rules run in order. **Critical** is an expiring canonical `cornerstone_priority`. **High** is an expiring core/starter, authoritative High replacement difficulty, authoritative High negotiation risk, or a strong `cornerstone_priority`/`strong_keep`/`extension_candidate`/`franchise_tag_candidate`. **Medium** is another real expiring or authoritative recommendation review. Missing facts never raise severity and candidates without truthful context are diagnosed.
+
+Cornerstone/strong-keep/extension recommendations map to an extension-decision title; franchise-tag candidate maps to tag-or-extension review; replaceable/likely-walk/move-on map to let-walk review; other expiring cases use neutral contract-window copy. No new recommendation scoring is introduced.
+
+## Reasons, ordering, deduplication, and overlap
+
+Contract `primaryReason` selects, in order: current-season expiration, High negotiation risk, High replacement difficulty, canonical recommendation, then role. Availability selects no healthy assigned backup, High replacement difficulty, recorded duration, injury detail, then role. Full deduplicated reasons remain for later detail surfaces; the UI no longer relies on array position.
+
+Contract ordering is severity, canonical recommendation priority, role importance, negotiation risk, replacement difficulty, term urgency, then canonical player ID. The combined queue sorts by severity and each category's stable key. Exact item IDs are deduplicated. Availability and contract items for the same player are genuinely distinct immediate decisions and are both retained; on a severity tie, availability sorts first during the recorded active absence. No information is silently suppressed.
+
+## Legacy, performance, and future categories
+
+Primitive references use a single league-player index. Cheap contract facts filter before presentation construction; each eligible unique candidate is presented once per category. No archive, worker, IndexedDB, market-value, transaction, or persistence path is used, and only final results are sorted. Numeric/string IDs are compared canonically while returned IDs are preserved. Partial team/league/stats and legacy year aliases fail safely; missing never becomes zero.
+
+Future categories remain roster depth, trade deadline, opponent preparation, cap pressure, and development. They are outside this PR.

--- a/src/core/__tests__/gmContractDecisionQueue.test.js
+++ b/src/core/__tests__/gmContractDecisionQueue.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildContractDecisionQueue, buildGMDecisionQueue, createContractDecisionQueueBuilder } from '../gmDecisionQueue.js';
+
+const player = (id, overrides = {}) => ({
+  id, name: `Player ${id}`, pos: 'QB', teamId: 10, status: 'active', age: 26, ovr: 76,
+  potential: 77, morale: 68, schemeFit: 65, contract: { yearsRemaining: 1, baseAnnual: 5 },
+  depthChart: { rowKey: 'QB', order: 1, role: 'starter' }, ...overrides,
+});
+const build = (roster, overrides = {}) => buildContractDecisionQueue({
+  roster, team: { id: 10, roster, capRoom: 80 }, league: { phase: 'regular', week: 8, players: roster.filter((p) => p && typeof p === 'object'), draftClass: [] }, ...overrides,
+});
+
+describe('buildContractDecisionQueue', () => {
+  it('includes expiring starters and backups but excludes unsupported membership/status/data', () => {
+    const starter = player(1);
+    const backup = player(2, { ovr: 68, depthChart: { order: 2, role: 'backup' } });
+    const multi = player(3, { contract: { yearsRemaining: 3 } });
+    const noContract = player(4, { contract: null });
+    const foreign = player(5, { teamId: 11 });
+    const freeAgent = player(6, { status: 'free_agent', teamId: null });
+    const prospect = player(7, { isProspect: true });
+    const retired = player(8, { retired: true });
+    const result = build([starter, backup, multi, noContract, foreign, freeAgent, prospect, retired, 999]);
+    expect(result.items.map((item) => item.subject.playerId)).toEqual(expect.arrayContaining([1, 2]));
+    expect(result.items).toHaveLength(2);
+    expect(result.items.find((item) => item.subject.playerId === 1).severity).toBe('high');
+    expect(result.items.find((item) => item.subject.playerId === 2).severity).toBe('high');
+    expect(result.diagnostics.map((row) => row.reason)).toEqual(expect.arrayContaining(['No current contract decision', 'No contract data', 'Player not owned by supplied team', 'Excluded player status', 'Unresolved player ID']));
+  });
+
+  it('never turns missing or blank terms into expiration and handles unsupported phases honestly', () => {
+    expect(build([player(1, { contract: { yearsRemaining: '' } })]).items).toEqual([]);
+    expect(build([player(1, { contract: { yearsRemaining: null } })]).diagnostics).toContainEqual({ playerId: 1, reason: 'Missing contract term' });
+    expect(build([player(1)], { league: { phase: 'game_day', players: [player(1)] } })).toEqual({ items: [], diagnostics: [{ playerId: null, reason: 'Unsupported contract phase' }] });
+  });
+
+  it('maps canonical recommendations and explicit severity without cap or market copy', () => {
+    const presentations = {
+      1: { identity: { position: 'QB' }, contract: { recommendation: 'cornerstone_priority', roleImportance: 'core_starter', replacementDifficulty: 'high', negotiationRisk: 'high' } },
+      2: { identity: { position: 'WR' }, contract: { recommendation: 'keep_if_price_is_right', roleImportance: 'rotation', replacementDifficulty: 'medium', negotiationRisk: 'medium' } },
+      3: { identity: { position: 'CB' }, contract: { recommendation: 'likely_to_walk', roleImportance: 'depth', replacementDifficulty: 'low', negotiationRisk: 'low' } },
+      4: { identity: { position: 'EDGE' }, contract: { recommendation: 'franchise_tag_candidate', roleImportance: 'starter', replacementDifficulty: 'high', negotiationRisk: 'high' } },
+    };
+    const builder = createContractDecisionQueueBuilder({ buildPresentation: ({ player: p }) => presentations[p.id] });
+    const roster = [player(1), player(2), player(3), player(4)];
+    const result = builder({ roster, team: { id: 10 }, league: { phase: 'regular', players: roster } });
+    expect(result.items.map((item) => item.severity)).toEqual(['critical', 'high', 'medium', 'medium']);
+    expect(result.items.map((item) => item.title)).toEqual(expect.arrayContaining([
+      'Extension decision due for QB', 'WR enters contract decision window', 'Let-walk decision needed for CB', 'Tag or extension review required for EDGE',
+    ]));
+    expect(result.items[0].primaryReason).toBe('Contract expires after this season');
+    expect(JSON.stringify(result)).not.toMatch(/cap claim|market value/i);
+  });
+
+  it('deduplicates, prefilters, orders independently of input order, and remains pure', () => {
+    const calls = vi.fn(({ player: p }) => ({ identity: { position: p.pos }, contract: { recommendation: 'keep_if_price_is_right', roleImportance: p.ovr > 70 ? 'starter' : 'depth', replacementDifficulty: 'low', negotiationRisk: 'low' } }));
+    const builder = createContractDecisionQueueBuilder({ buildPresentation: calls });
+    const eligible = player('2');
+    const later = player('10', { contract: { yearsRemaining: 3 } });
+    const roster = Object.freeze([Object.freeze(eligible), eligible, Object.freeze(later)]);
+    const args = { roster, team: Object.freeze({ id: 10 }), league: Object.freeze({ phase: 'regular', players: roster }) };
+    const first = builder(args);
+    const second = builder({ ...args, roster: [...roster].reverse() });
+    expect(first.items.map((item) => item.subject.playerId)).toEqual(second.items.map((item) => item.subject.playerId));
+    expect(first.diagnostics).toContainEqual({ playerId: '2', reason: 'Duplicate roster reference' });
+    expect(calls).toHaveBeenCalledTimes(2);
+    expect(roster).toHaveLength(3);
+  });
+
+  it('combines categories deterministically and keeps same-player distinct decisions', () => {
+    const injured = player(1, { injury: { type: 'Knee', weeksRemaining: 3 } });
+    const result = buildGMDecisionQueue({ roster: [injured], team: { id: 10, roster: [injured] }, league: { phase: 'regular', players: [injured] } });
+    expect(result.items.map((item) => item.category)).toEqual(['contract', 'availability']);
+    expect(new Set(result.items.map((item) => item.id)).size).toBe(result.items.length);
+  });
+});

--- a/src/core/gmDecisionQueue.js
+++ b/src/core/gmDecisionQueue.js
@@ -3,6 +3,12 @@ import { buildPlayerDecisionPresentation } from './playerDecisionPresentation.js
 const SEVERITY_RANK = { critical: 0, high: 1, medium: 2 };
 const ROLE_RANK = { Starter: 0, Backup: 1, Reserve: 2 };
 const REPLACEMENT_RANK = { High: 0, Medium: 1, Low: 2 };
+const CONTRACT_ROLE_RANK = { core_starter: 0, starter: 0, rotation: 1, depth: 2 };
+const RISK_RANK = { high: 0, medium: 1, low: 2 };
+const RECOMMENDATION_RANK = {
+  cornerstone_priority: 0, strong_keep: 1, franchise_tag_candidate: 2, extension_candidate: 3,
+  keep_if_price_is_right: 4, replaceable_depth: 5, likely_to_walk: 6, move_on: 7,
+};
 const EXCLUDED_STATUSES = new Set(['free_agent', 'draft_eligible', 'retired']);
 
 const canonicalId = (value) => value == null ? null : String(value);
@@ -179,6 +185,13 @@ export function createAvailabilityDecisionQueueBuilder({ buildPresentation = bui
         subject: { type: 'player', playerId: playerId(player), position },
         title: starter ? `Starting ${position} unavailable` : `${position} depth requires review`,
         reasons: [...new Set(reasons)].slice(0, 3),
+        primaryReason: severity === 'critical'
+          ? 'No healthy assigned backup'
+          : replacement === 'High'
+            ? 'High replacement difficulty'
+            : duration != null
+              ? `Recorded absence: ${duration} week${duration === 1 ? '' : 's'}`
+              : (presentation?.availability?.detail ?? (starter ? 'Recorded starter role' : `Recorded ${role.toLowerCase()} role`)),
         destination: { view: starter ? 'Depth Chart' : 'Injuries', playerId: playerId(player) },
         stableSortKey,
         availableData: {
@@ -198,3 +211,140 @@ export function createAvailabilityDecisionQueueBuilder({ buildPresentation = bui
 }
 
 export const buildAvailabilityDecisionQueue = createAvailabilityDecisionQueueBuilder();
+
+const contractYears = (player) => finiteNumber(
+  player?.contract?.yearsRemaining ?? player?.contract?.yearsLeft ?? player?.contract?.years,
+);
+const contractSignal = (player) => player?.extensionEligible === true
+  || player?.contract?.extensionEligible === true
+  || player?.isTagged === true
+  || player?.contract?.tag === true
+  || player?.extensionDecision != null
+  || player?.reSignRecommendation != null;
+const CONTRACT_PHASES = new Set([
+  'preseason', 'regular', 'regular_season', 'playoffs', 'offseason', 'offseason_resign',
+  'free_agency', 'draft', 'training_camp', 'afterRegularSeason', 'afterSeasonRollover',
+]);
+const titleForRecommendation = (recommendation, position, expiring) => {
+  if (recommendation === 'franchise_tag_candidate') return `Tag or extension review required for ${position}`;
+  if (recommendation === 'likely_to_walk' || recommendation === 'move_on' || recommendation === 'replaceable_depth') {
+    return `Let-walk decision needed for ${position}`;
+  }
+  if (recommendation === 'cornerstone_priority' || recommendation === 'strong_keep' || recommendation === 'extension_candidate') {
+    return `Extension decision due for ${position}`;
+  }
+  return expiring ? `${position} enters contract decision window` : `Contract review due for ${position}`;
+};
+
+export function createContractDecisionQueueBuilder({ buildPresentation = buildPlayerDecisionPresentation } = {}) {
+  return function buildContractDecisionQueue({ roster, team, league, seasonStatsByPlayerId = null } = {}) {
+    const items = [];
+    const diagnostics = [];
+    const diagnosticKeys = new Set();
+    const addDiagnostic = (id, reason) => {
+      const key = `${canonicalId(id) ?? 'unresolved'}:${reason}`;
+      if (!diagnosticKeys.has(key)) {
+        diagnosticKeys.add(key);
+        diagnostics.push({ playerId: id ?? null, reason });
+      }
+    };
+    if (!Array.isArray(roster)) {
+      addDiagnostic(null, 'Roster unavailable');
+      return { items, diagnostics };
+    }
+    if (!team || team.id == null) {
+      addDiagnostic(null, 'Supplied team unavailable');
+      return { items, diagnostics };
+    }
+    if (league?.phase != null && !CONTRACT_PHASES.has(String(league.phase))) {
+      addDiagnostic(null, 'Unsupported contract phase');
+      return { items, diagnostics };
+    }
+
+    const leaguePlayers = Array.isArray(league?.players) ? league.players : [];
+    const leagueById = new Map(leaguePlayers.map((entry) => [canonicalId(playerId(entry)), entry]));
+    const seen = new Set();
+    for (const entry of roster) {
+      const player = entry && typeof entry === 'object' ? entry : leagueById.get(canonicalId(entry));
+      const id = playerId(player) ?? (entry && typeof entry !== 'object' ? entry : null);
+      if (!player || playerId(player) == null) { addDiagnostic(id, 'Unresolved player ID'); continue; }
+      const key = canonicalId(playerId(player));
+      if (seen.has(key)) { addDiagnostic(playerId(player), 'Duplicate roster reference'); continue; }
+      seen.add(key);
+      if (!sameId(player.teamId, team.id)) { addDiagnostic(playerId(player), 'Player not owned by supplied team'); continue; }
+      if (excludedPlayer(player, league)) { addDiagnostic(playerId(player), 'Excluded player status'); continue; }
+      if (!player.contract) { addDiagnostic(playerId(player), 'No contract data'); continue; }
+      const years = contractYears(player);
+      const signal = contractSignal(player);
+      if (years == null && !signal) { addDiagnostic(playerId(player), 'Missing contract term'); continue; }
+      if ((years == null || years > 1) && !signal) { addDiagnostic(playerId(player), 'No current contract decision'); continue; }
+
+      const presentation = buildPresentation({ player, team, league: league ?? {}, seasonStats: statsFor(seasonStatsByPlayerId, playerId(player)) });
+      const contract = presentation?.contract;
+      const recommendation = contract?.recommendation ?? null;
+      const role = contract?.roleImportance ?? null;
+      const replacement = contract?.replacementDifficulty ?? null;
+      const risk = contract?.negotiationRisk ?? null;
+      const expiring = years != null && years <= 1;
+      const strongRecommendation = ['cornerstone_priority', 'strong_keep', 'extension_candidate', 'franchise_tag_candidate'].includes(recommendation);
+      let severity = recommendation === 'cornerstone_priority' && expiring
+        ? 'critical'
+        : (['core_starter', 'starter'].includes(role) && expiring) || replacement === 'high' || risk === 'high' || strongRecommendation
+          ? 'high'
+          : (expiring || recommendation ? 'medium' : null);
+      if (!severity) { addDiagnostic(playerId(player), 'Insufficient recommendation context'); continue; }
+
+      const position = presentation?.identity?.position ?? player?.pos ?? player?.position ?? '—';
+      const recommendationReason = recommendation ? `${recommendation.replaceAll('_', ' ')} recommendation` : null;
+      const reasons = [...new Set([
+        expiring ? 'Contract expires after this season' : years === 1 ? 'One year remaining' : null,
+        risk === 'high' ? 'High negotiation risk' : null,
+        replacement === 'high' ? 'High replacement difficulty' : null,
+        recommendationReason,
+        role ? `Recorded ${role.replaceAll('_', ' ')} role` : null,
+      ].filter(Boolean))].slice(0, 3);
+      const primaryReason = expiring ? 'Contract expires after this season'
+        : risk === 'high' ? 'High negotiation risk'
+          : replacement === 'high' ? 'High replacement difficulty'
+            : recommendationReason ?? (role ? `Recorded ${role.replaceAll('_', ' ')} role` : null);
+      if (!primaryReason) { addDiagnostic(playerId(player), 'Insufficient recommendation context'); continue; }
+      const urgencyRank = expiring ? 0 : years === 1 ? 1 : 2;
+      const stableSortKey = [SEVERITY_RANK[severity], RECOMMENDATION_RANK[recommendation] ?? 8,
+        CONTRACT_ROLE_RANK[role] ?? 3, RISK_RANK[risk] ?? 3, RISK_RANK[replacement] ?? 3,
+        urgencyRank, canonicalId(playerId(player))].join(':');
+      items.push({
+        id: `contract:${canonicalId(playerId(player))}`,
+        category: 'contract', severity,
+        subject: { type: 'player', playerId: playerId(player), position },
+        title: titleForRecommendation(recommendation, position, expiring), reasons, primaryReason,
+        destination: { view: 'Contract Center', playerId: playerId(player) }, stableSortKey,
+        availableData: { contractTerm: years != null, recommendation: recommendation != null,
+          negotiationRisk: risk != null, replacementDifficulty: replacement != null, role: role != null },
+      });
+    }
+    items.sort((a, b) => a.stableSortKey.localeCompare(b.stableSortKey, 'en', { numeric: true }) || compareIds(a.subject.playerId, b.subject.playerId));
+    diagnostics.sort((a, b) => compareIds(a.playerId, b.playerId) || a.reason.localeCompare(b.reason));
+    return { items, diagnostics };
+  };
+}
+
+export const buildContractDecisionQueue = createContractDecisionQueueBuilder();
+
+export function buildGMDecisionQueue(args = {}) {
+  const availability = buildAvailabilityDecisionQueue(args);
+  const contracts = buildContractDecisionQueue(args);
+  const itemById = new Map();
+  for (const item of [...availability.items, ...contracts.items]) itemById.set(item.id, item);
+  const items = [...itemById.values()].sort((a, b) => {
+    const severity = (SEVERITY_RANK[a.severity] ?? 3) - (SEVERITY_RANK[b.severity] ?? 3);
+    if (severity) return severity;
+    if (a.subject?.playerId != null && sameId(a.subject.playerId, b.subject?.playerId) && a.category !== b.category) {
+      return a.category === 'availability' ? -1 : 1;
+    }
+    return a.stableSortKey.localeCompare(b.stableSortKey, 'en', { numeric: true }) || a.category.localeCompare(b.category);
+  });
+  const diagnostics = [...availability.diagnostics, ...contracts.diagnostics]
+    .filter((row, index, rows) => rows.findIndex((candidate) => sameId(candidate.playerId, row.playerId) && candidate.reason === row.reason) === index)
+    .sort((a, b) => compareIds(a.playerId, b.playerId) || a.reason.localeCompare(b.reason));
+  return { items, diagnostics };
+}

--- a/src/core/playerDecisionPresentation.js
+++ b/src/core/playerDecisionPresentation.js
@@ -1,5 +1,5 @@
 import { derivePlayerArchetype, getPositionGroup } from './playerEvaluation.js';
-import { evaluateReSigningPriority } from './retention/reSigning.js';
+import { evaluateReSigningPriority, summarizeContractRisk } from './retention/reSigning.js';
 
 const numberOrNull = (value) => {
   if (value == null) return null;
@@ -166,6 +166,7 @@ export function buildPlayerDecisionPresentation({ player, team = null, league = 
   const canEvaluateRetention = Boolean(team && (leaguePlayers || teamRoster) && ['active_roster', 'injured_reserve'].includes(statusKey));
   const retentionLeague = leaguePlayers ? league : { ...league, players: teamRoster };
   const priority = canEvaluateRetention ? evaluateReSigningPriority(player, team, retentionLeague) : null;
+  const contractRisk = priority ? summarizeContractRisk(player, team, retentionLeague, priority) : null;
   const perf = performance(player, normalizePlayerDecisionSeasonStats(seasonStats ?? player?.seasonStats ?? player?.stats ?? null));
   const dev = development(player);
   const contract = contractSummary(player, priority);
@@ -178,7 +179,15 @@ export function buildPlayerDecisionPresentation({ player, team = null, league = 
     availability: health,
     performance: perf,
     development: dev,
-    contract,
+    contract: priority ? {
+      ...contract,
+      recommendation: priority.recommendation,
+      roleImportance: priority.roleImportance,
+      replacementDifficulty: priority.replacementDifficulty,
+      negotiationRisk: contractRisk?.riskBand ?? null,
+      extensionReadiness: priority.extensionReadiness,
+      expiring: priority.expiring,
+    } : contract,
     rosterValue,
     replacement,
     recommendation: recommendation(priority, roleLabel, statusKey, player, health),

--- a/src/ui/components/GMDecisionCenter.jsx
+++ b/src/ui/components/GMDecisionCenter.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { buildAvailabilityDecisionQueue } from '../../core/gmDecisionQueue.js';
+import { buildGMDecisionQueue } from '../../core/gmDecisionQueue.js';
 
 const SEVERITY_STYLES = {
   critical: { label: 'Critical', color: 'var(--danger, #FF453A)', background: 'rgba(255,69,58,.12)' },
@@ -12,6 +12,7 @@ function isDepthChartDestination(destination) {
 }
 
 function routeFor(destination) {
+  if (destination?.view === 'Contract Center') return 'Contract Center';
   return isDepthChartDestination(destination) ? 'Team:Roster / Depth' : 'Team:Injuries';
 }
 
@@ -20,7 +21,7 @@ export default function GMDecisionCenter({ league, onNavigate }) {
     () => (league?.teams ?? []).find((entry) => String(entry?.id) === String(league?.userTeamId)),
     [league?.teams, league?.userTeamId],
   );
-  const queue = useMemo(() => buildAvailabilityDecisionQueue({
+  const queue = useMemo(() => buildGMDecisionQueue({
     roster: team?.roster,
     team,
     league,
@@ -45,13 +46,14 @@ export default function GMDecisionCenter({ league, onNavigate }) {
         {items.map((item, index) => {
           const severity = SEVERITY_STYLES[item.severity] ?? SEVERITY_STYLES.medium;
           const depthChart = isDepthChartDestination(item.destination);
+          const contract = item.category === 'contract';
           return (
             <article
               key={item.id}
               data-testid="gm-decision-item"
               style={{ padding: 'var(--space-3) var(--space-4)', borderBottom: index < items.length - 1 ? '1px solid var(--hairline)' : 0 }}
             >
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10 }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 10 }}>
                 <div style={{ minWidth: 0 }}>
                   <span
                     aria-label={`${severity.label} severity`}
@@ -60,7 +62,7 @@ export default function GMDecisionCenter({ league, onNavigate }) {
                     {item.severity === 'critical' ? '⚠ ' : ''}{severity.label}
                   </span>
                   <div style={{ marginTop: 5, fontSize: 'var(--text-sm)', fontWeight: 800 }}>{item.title}</div>
-                  {item.reasons?.length ? <div style={{ marginTop: 3, color: 'var(--text-muted)', fontSize: 'var(--text-xs)' }}>• {item.reasons[item.reasons.length - 1]}</div> : null}
+                  {item.primaryReason ? <div style={{ marginTop: 3, color: 'var(--text-muted)', fontSize: 'var(--text-xs)' }}>• {item.primaryReason}</div> : null}
                 </div>
                 <button
                   type="button"
@@ -68,7 +70,7 @@ export default function GMDecisionCenter({ league, onNavigate }) {
                   onClick={() => onNavigate?.(routeFor(item.destination))}
                   style={{ flex: '0 0 auto' }}
                 >
-                  {depthChart ? 'Review Depth Chart' : 'Review'}
+                  {contract ? 'Review Contract' : depthChart ? 'Review Depth Chart' : 'Review'}
                 </button>
               </div>
             </article>

--- a/src/ui/components/__tests__/GMDecisionCenter.test.jsx
+++ b/src/ui/components/__tests__/GMDecisionCenter.test.jsx
@@ -7,7 +7,7 @@ import GMDecisionCenter from '../GMDecisionCenter.jsx';
 const { buildQueue } = vi.hoisted(() => ({ buildQueue: vi.fn() }));
 
 vi.mock('../../../core/gmDecisionQueue.js', () => ({
-  buildAvailabilityDecisionQueue: buildQueue,
+  buildGMDecisionQueue: buildQueue,
 }));
 
 const league = Object.freeze({
@@ -21,6 +21,8 @@ function item(id, severity, view = 'Injuries') {
     severity,
     title: `${id} depth requires review`,
     reasons: Object.freeze([`${severity} reason`]),
+    primaryReason: `${severity} primary reason`,
+    category: view === 'Contract Center' ? 'contract' : 'availability',
     destination: Object.freeze({ view }),
   });
 }
@@ -75,15 +77,24 @@ describe('GMDecisionCenter', () => {
   it('uses destination-specific labels and fires the existing navigation callback', () => {
     const onNavigate = vi.fn();
     buildQueue.mockReturnValue({
-      items: [item('LT', 'critical', 'Depth Chart'), item('CB', 'medium', 'Injuries')],
+      items: [item('LT', 'critical', 'Depth Chart'), item('CB', 'medium', 'Injuries'), item('QB', 'high', 'Contract Center')],
       diagnostics: [],
     });
     render(<GMDecisionCenter league={league} onNavigate={onNavigate} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Review Depth Chart' }));
     fireEvent.click(screen.getByRole('button', { name: 'Review' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Review Contract' }));
     expect(onNavigate).toHaveBeenNthCalledWith(1, 'Team:Roster / Depth');
     expect(onNavigate).toHaveBeenNthCalledWith(2, 'Team:Injuries');
+    expect(onNavigate).toHaveBeenNthCalledWith(3, 'Contract Center');
+  });
+
+  it('renders primaryReason rather than relying on the last reason', () => {
+    buildQueue.mockReturnValue({ items: [{ ...item('QB', 'high', 'Contract Center'), reasons: ['first', 'fragile last'], primaryReason: 'Actionable contract reason' }], diagnostics: [] });
+    render(<GMDecisionCenter league={league} />);
+    expect(screen.getByText(/Actionable contract reason/)).toBeTruthy();
+    expect(screen.queryByText(/fragile last/)).toBeNull();
   });
 
   it('builds the queue once when rerendered with unchanged inputs', () => {


### PR DESCRIPTION
### Motivation
- Surface the most important player contract decisions in Franchise HQ so the GM Decision Center remains useful when the roster is healthy.  
- Confirmed required dependencies from merged PRs (#1725–#1727) and audited authoritative helpers before change (notably `buildPlayerDecisionPresentation()`, `evaluateReSigningPriority()`, and `summarizeContractRisk()`).  
- Preserve presentation-only, deterministic behavior and explicitly avoid any changes to contract economics, salary-cap, AI, simulation, worker, persistence, or save-schema behavior.  

### Description
- Added a pure `buildContractDecisionQueue({ roster, team, league, seasonStatsByPlayerId })` and a combined `buildGMDecisionQueue()` that merges availability and contract items into the shared queue shape `{ items, diagnostics }` with deterministic ordering, prefiltering, diagnostics, and one-item-per-player deduplication.  
- Extended `buildPlayerDecisionPresentation()` to expose canonical re-sign recommendation, role importance, replacement difficulty, negotiation-risk band, extension readiness, and expiring context so the queue reuses authoritative contract/retention authorities.  
- Introduced `primaryReason` selection for queue items and updated availability items to include it; contract items get 1–3 deduplicated reasons plus `primaryReason`.  
- Updated `GMDecisionCenter.jsx` to consume `buildGMDecisionQueue()`, render at most three combined items in returned order, show `primaryReason` (not the last reason), use visible severity badges, and route contract items to the existing `Contract Center` with a `Review Contract` button label.  
- Added unit tests and docs: `src/core/__tests__/gmContractDecisionQueue.test.js`, updates to `src/ui/components/__tests__/GMDecisionCenter.test.jsx`, and the audit `docs/gm-decision-queue-contracts-v2-audit.md`, and updated `docs/gm-decision-center.md` to describe combined availability+contracts.  
- Files changed: `src/core/gmDecisionQueue.js`, `src/core/playerDecisionPresentation.js`, `src/ui/components/GMDecisionCenter.jsx`, `src/core/__tests__/gmContractDecisionQueue.test.js`, `src/ui/components/__tests__/GMDecisionCenter.test.jsx`, `docs/gm-decision-queue-contracts-v2-audit.md`, and a small docs update to `docs/gm-decision-center.md`.  

### Testing
- `node --check src/core/gmDecisionQueue.js` and `node --check src/core/playerDecisionPresentation.js` succeeded.  
- Targeted unit tests and component tests: `npx vitest run` for the relevant test suites (targeted run) passed (7 files / 84 tests in the targeted run).  
- Full unit test suite: `npm run test:unit` completed successfully (470 files, 5,771 tests passed).  
- Type checks and production build: `npm run check:sim-types` and `npm run build` completed successfully (build produced expected large-chunk warning only).  
- Netlify parity: `npm run check:deploy` completed successfully.  
- E2E: `npx playwright test tests/e2e/fresh_franchise_first_week_smoke.spec.js` could not run because Chromium was not present; `npx playwright install chromium` was attempted but failed with HTTP 403 (Playwright CDN blocked), so local Playwright E2E verification was not completed.  

If you want, I can split follow-up work to (a) adjust small UX copy, (b) add additional contract reason flavors, or (c) retry E2E once Playwright Chromium is available in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70a653ba34832d8301f1dc6c6d7790)