### PR TITLE
fix: allow advancing week with warnings instead of blocking

### DIFF
--- a/QA_REPORT.md
+++ b/QA_REPORT.md
@@ -1,0 +1,17 @@
+Daily Regression Report
+
+What was tested:
+- 1. Playability Smoke Test (Fresh start, play week, verify no crashes/freezes)
+- 2. Strategy Persistence & High Stakes
+- 2b. Mobile UI Scrolling Check
+- 3. Contracts & Cap Trust
+- 4. Replay Exploit Prevention
+
+What broke:
+- The "Advance Week" button was unexpectedly disabled when simulating tests with unresolved prep items, blocking the playability smoke test and stopping progression in FranchiseHQ.
+
+What was fixed:
+- Adjusted `buildCommandCenterSummary` to accurately distinguish between danger items (blockers) and warning items instead of broadly locking the advance button on any open items (by checking `criticalCount`). Updated `FranchiseHQ.jsx` to disable the advance button based on `hasDanger` instead of `criticalCount`. The CTA title logic was also updated to check `hasDanger`.
+
+One small improvement:
+- Enhanced the "Advance Week" user experience to let users bypass non-blocker prep warnings, reducing friction and restoring the ability to intentionally "advance anyway".

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -1256,15 +1256,15 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
           className="app-command-advance app-command-advance-gold"
           data-testid="advance-week-cta"
           onClick={handleAdvanceOrGate}
-          disabled={busy || simulating || commandSummary.criticalCount > 0}
+          disabled={busy || simulating || commandSummary.hasDanger}
           aria-label={
             busy || simulating
               ? 'Advancing week…'
-              : commandSummary.criticalCount > 0
+              : commandSummary.hasDanger
                 ? `Advance Week — ${commandSummary.criticalCount} item${commandSummary.criticalCount !== 1 ? 's' : ''} must be resolved first`
                 : `Advance Week — move from ${command.weekLabel} to next week`
           }
-          title={commandSummary.criticalCount > 0 ? `Resolve ${commandSummary.criticalCount} open item${commandSummary.criticalCount !== 1 ? 's' : ''} to unlock` : 'Advance Week'}
+          title={commandSummary.hasDanger ? `Resolve blockers to unlock` : 'Advance Week'}
         >
           {busy || simulating ? 'Advancing…' : 'Advance Week'}
           <HQIcon name="arrowRight" size={16} />

--- a/src/ui/utils/weeklyHubLayout.js
+++ b/src/ui/utils/weeklyHubLayout.js
@@ -166,6 +166,8 @@ export function buildCommandCenterSummary({ gate, weeklyContext } = {}) {
     readinessLabel,
     readinessTone,
     criticalCount: primaryActions.length,
+    hasDanger,
+    hasWarning,
     canAdvanceSafely: readinessTone === 'ok',
   };
 }


### PR DESCRIPTION
This PR fixes an issue where the "Advance Week" button was improperly disabled when the user had non-blocking warnings (such as unreviewed game plans). 

**Changes:**
- `buildCommandCenterSummary` was updated to expose `hasDanger` and `hasWarning` flags.
- `FranchiseHQ` was updated to check `hasDanger` instead of `criticalCount` to determine if the `advance-week-cta` button should be disabled, allowing the readiness gate to be accessed for warnings.
- Added a `QA_REPORT.md` file summarizing the daily regression pass results and fix.

---
*PR created automatically by Jules for task [1650508148527869551](https://jules.google.com/task/1650508148527869551) started by @rbcati*