### PR TITLE
feat: add League Hub Season Pulse V1

### DIFF
--- a/docs/league-hub-season-pulse-v1-audit.md
+++ b/docs/league-hub-season-pulse-v1-audit.md
@@ -11,13 +11,14 @@ The branch was created from live `origin/main` at `2a5c810` (the merge of PR #17
 - **Standings:** `prepareStandingsView()` in `src/views/standingsView.js` is the canonical UI preparation layer. It supplies current division leaders and playoff ordering. Weekly movement remains limited to explicit before/after snapshots accepted by the existing weekly story helper.
 - **Awards:** the only midseason race contract exposed to UI is `league.awardRaces.awards`, already consumed by `SeasonRecap.jsx`. V1 reads the same ordered boards and never calls `determineSeasonAwards()` or creates an award score.
 - **Injuries:** active roster/league injury records use `injuryWeeksRemaining` (with existing legacy aliases). V1 requires a player name and a positive remaining duration, preserves the recorded injury label, and orders by recorded duration.
+- **Injury identity correction:** league-level injury rows resolve player identity from `playerId`, then `id`, then `player.id`; `teamId` is never treated as a player identity. This preserves multiple injured players recorded on the same team while retaining roster-player support.
 - **Streaks:** completed schedule results are authoritative for the active run. V1 requires at least two consecutive wins/losses and does not label a one-game result a trend.
 - **Existing league destination:** `LeagueHub.jsx` is already routed by `LeagueDashboard.jsx` from the canonical `League` navigation destination. Its Overview is the least disruptive integration point.
 - **Owner/hot-seat:** `coachHotSeat` is current team state used by the existing Coaching subsection. No league-wide historical pressure transition is available to Overview.
 
 ## Duplicate presentation logic identified
 
-`weeklyLeagueRecap.js` independently derives league order, streaks, upset-like language from prior record, spotlight scores, and a playoff bubble approximation. The old League Overview rendered a subset of it. Season Pulse removes that Overview usage and delegates factual weekly headlines to `weeklyStoryPresentation.js`; the Results screen remains unchanged. `franchiseCommandCenter.js` also has a UI-only power ranking formula, but V1 intentionally does not use or duplicate it.
+`weeklyLeagueRecap.js` independently derives league order, streaks, upset-like language from prior record, spotlight scores, and a playoff bubble approximation. Season Pulse delegates factual weekly headlines to `weeklyStoryPresentation.js`; `weeklyLeagueRecap.js` remains in the Overview only to preserve its existing recorded-game Spotlight/Game Book drill-down. The Results screen is unchanged. `franchiseCommandCenter.js` also has a UI-only power ranking formula, but V1 intentionally does not use or duplicate it.
 
 ## Implemented truthful categories
 
@@ -27,6 +28,7 @@ The branch was created from live `origin/main` at `2a5c810` (the merge of PR #17
 4. League Health: up to three identified active injuries, ordered by recorded remaining duration.
 5. Standings Context: recorded before/after movement when supplied; otherwise current division leaders from `prepareStandingsView()` with explicit current-state copy.
 6. Next Week: one unplayed scheduled game, prioritized by user involvement, division membership, two above-.500 records, recorded rematch, then week and stable game key.
+7. Spotlight Games: the prior League Overview drill-down remains beneath Season Pulse and continues through `openResolvedBoxScore()` into the existing Game Book callback.
 
 Headline ranking is inherited exactly from `weeklyStoryPresentation.js`: standings lead change (110), playoff seed movement (100 + magnitude), authoritative upset (90 + probability gap), injury (80 + bounded duration), closest finish (75 - margin), largest margin (60 + margin), and highest combined score (50 + points), followed by stable story key. One story per type and subject de-duplication cap the list at five. Input order does not affect output.
 

--- a/docs/league-hub-season-pulse-v1-audit.md
+++ b/docs/league-hub-season-pulse-v1-audit.md
@@ -1,0 +1,48 @@
+# League Hub / Season Pulse V1 audit
+
+## Merged-state inspection
+
+The branch was created from live `origin/main` at `2a5c810` (the merge of PR #1731). The current tree already contains the postgame/Weekly GM Briefing presentation (`postgameBriefing.js`, `WeeklyResultsCenter.jsx`), canonical Game Book view model and presentation helpers, weekly factual stories (`weeklyStoryPresentation.js`), Player Decision Cards, `GMDecisionCenter.jsx`, the Franchise HQ decision surfaces, and the contract decision queue merged by PR #1731. Season Pulse does not replace or alter any of those flows.
+
+## Authoritative sources found
+
+- **Weekly results and stories:** `weeklyStoryPresentation.js` already deterministically presents largest margin, closest finish, highest combined score, an upset only when a saved pregame win probability exists, recorded standings movement, and recorded injuries. Season Pulse reuses it rather than adding another headline engine.
+- **Schedule/results:** `league.schedule.weeks[].games` is already the League screen's schedule contract. A result is accepted only when both scores are numeric. Upcoming games use the same schedule; no archive is loaded on render.
+- **Standings:** `prepareStandingsView()` in `src/views/standingsView.js` is the canonical UI preparation layer. It supplies current division leaders and playoff ordering. Weekly movement remains limited to explicit before/after snapshots accepted by the existing weekly story helper.
+- **Awards:** the only midseason race contract exposed to UI is `league.awardRaces.awards`, already consumed by `SeasonRecap.jsx`. V1 reads the same ordered boards and never calls `determineSeasonAwards()` or creates an award score.
+- **Injuries:** active roster/league injury records use `injuryWeeksRemaining` (with existing legacy aliases). V1 requires a player name and a positive remaining duration, preserves the recorded injury label, and orders by recorded duration.
+- **Streaks:** completed schedule results are authoritative for the active run. V1 requires at least two consecutive wins/losses and does not label a one-game result a trend.
+- **Existing league destination:** `LeagueHub.jsx` is already routed by `LeagueDashboard.jsx` from the canonical `League` navigation destination. Its Overview is the least disruptive integration point.
+- **Owner/hot-seat:** `coachHotSeat` is current team state used by the existing Coaching subsection. No league-wide historical pressure transition is available to Overview.
+
+## Duplicate presentation logic identified
+
+`weeklyLeagueRecap.js` independently derives league order, streaks, upset-like language from prior record, spotlight scores, and a playoff bubble approximation. The old League Overview rendered a subset of it. Season Pulse removes that Overview usage and delegates factual weekly headlines to `weeklyStoryPresentation.js`; the Results screen remains unchanged. `franchiseCommandCenter.js` also has a UI-only power ranking formula, but V1 intentionally does not use or duplicate it.
+
+## Implemented truthful categories
+
+1. Around the League: largest margin, closest finish, highest-scoring game, authoritative-expectation upset, supplied standings movement, and meaningful recorded injury story candidates, ranked by the reused helper.
+2. Trending Teams: longest established winning and losing runs, plus an undefeated team after at least two recorded games.
+3. Award Watch: MVP, OPOY, DPOY, OROY, and DROY only when their existing ordered race board contains an identified leader.
+4. League Health: up to three identified active injuries, ordered by recorded remaining duration.
+5. Standings Context: recorded before/after movement when supplied; otherwise current division leaders from `prepareStandingsView()` with explicit current-state copy.
+6. Next Week: one unplayed scheduled game, prioritized by user involvement, division membership, two above-.500 records, recorded rematch, then week and stable game key.
+
+Headline ranking is inherited exactly from `weeklyStoryPresentation.js`: standings lead change (110), playoff seed movement (100 + magnitude), authoritative upset (90 + probability gap), injury (80 + bounded duration), closest finish (75 - margin), largest margin (60 + margin), and highest combined score (50 + points), followed by stable story key. One story per type and subject de-duplication cap the list at five. Input order does not affect output.
+
+## Unsupported concepts and intentional deferrals
+
+- No comeback story: there is no authoritative comeback flag in the League view contract.
+- No inferred upset from records, power ranking, or point differential.
+- No clinch/elimination or playoff movement without canonical transition evidence.
+- No standings riser/faller without before/after snapshots.
+- No new power ranking or award formula.
+- No award probability, “favorite,” runner-up, or race when `awardRaces` is absent.
+- No injury “impact” score, diagnosis, starter inference, or claim that every injury is major.
+- No league-wide hot-seat movement: only current state exists and the existing Coaching subsection already owns it.
+- No player-performance headline because the compact schedule rows do not reliably carry canonical player stat lines.
+- No separate route or mandatory postgame surface. The existing League Overview is the integration point.
+
+## Legacy and performance notes
+
+Unsupported sections are hidden, and a single honest fallback appears when the entire model is empty. Missing schedules, teams, awards, injuries, weeks, and partial legacy records return bounded empty arrays and omission metadata. The model is pure: it performs no mutation, persistence, worker request, archive read, or randomness. It memoizes once in `LeagueHub`, indexes teams for awards/upcoming games, bounds displayed arrays, and scans the already-present compact schedule once per derived category. No worker payload, persistence behavior, or save schema is changed.

--- a/src/ui/components/LeagueHub.jsx
+++ b/src/ui/components/LeagueHub.jsx
@@ -4,7 +4,9 @@ import SocialFeed from './SocialFeed.jsx';
 import LeagueLeaders from './LeagueLeaders.jsx';
 import { buildNewsDeskModel } from '../utils/newsDesk.js';
 import { buildLeagueSeasonPulse } from '../utils/leagueSeasonPulse.js';
+import { buildWeeklyLeagueRecap } from '../utils/weeklyLeagueRecap.js';
 import { CompactListRow, StatusChip, HeroCard, SectionCard, StatStrip, CompactInsightCard } from './ScreenSystem.jsx';
+import { openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 
 const LEAGUE_SECTIONS = ['Overview', 'Results', 'Standings', 'News', 'Leaders', 'Coaching'];
 
@@ -30,6 +32,7 @@ export default function LeagueHub({
 
   const week = Number(league?.week ?? 1);
   const seasonPulse = useMemo(() => buildLeagueSeasonPulse({ league, week }), [league, week]);
+  const recap = useMemo(() => buildWeeklyLeagueRecap(league, { week }), [league, week]);
   const newsDesk = useMemo(() => buildNewsDeskModel(league, { segment: 'league', limit: 80 }), [league]);
   const transactionRows = useMemo(() => {
     return (newsDesk.transactions ?? []).slice(0, 8).map((item) => {
@@ -44,6 +47,7 @@ export default function LeagueHub({
       return { ...item, _txType: type };
     });
   }, [newsDesk.transactions]);
+  const spotlightRows = recap?.spotlights ?? [];
 
   return (
     <div className="app-screen-stack">
@@ -91,6 +95,23 @@ export default function LeagueHub({
 
           {seasonPulse.nextWeekHighlight && <SectionCard title="Next Week" subtitle="One matchup selected by stable, factual rules." variant="compact">
             <CompactListRow title={`${seasonPulse.nextWeekHighlight.awayTeam} at ${seasonPulse.nextWeekHighlight.homeTeam}`} subtitle={seasonPulse.nextWeekHighlight.reason} meta={<StatusChip label={`Week ${seasonPulse.nextWeekHighlight.week}`} tone="info" />} />
+          </SectionCard>}
+
+          {spotlightRows.length > 0 && <SectionCard title="Spotlight Games" subtitle="Open a recorded weekly result in Game Book." variant="compact">
+            <div className="app-row-stack">{spotlightRows.slice(0, 2).map((spotlight, index) => <CompactListRow
+              key={spotlight.key ?? `spotlight-${index}`}
+              title={spotlight.score ?? 'Spotlight game'}
+              subtitle={spotlight.reason ?? 'Weekly spotlight game'}
+              meta={<StatusChip label={`Week ${spotlight.week ?? seasonPulse.week ?? week}`} tone="league" />}
+            >
+              <button
+                type="button"
+                className="btn btn-sm"
+                onClick={() => openResolvedBoxScore(spotlight.game, { seasonId: league?.seasonId, week: spotlight.week ?? seasonPulse.week ?? week, source: 'league_overview_spotlight' }, onOpenGameDetail)}
+              >
+                Open Game
+              </button>
+            </CompactListRow>)}</div>
           </SectionCard>}
 
           {!Object.values(seasonPulse.availableData).some(Boolean) && <SectionCard title="Season Pulse" variant="compact"><CompactInsightCard title="No league pulse is available yet" subtitle="Complete games to unlock factual weekly context." tone="info" /></SectionCard>}

--- a/src/ui/components/LeagueHub.jsx
+++ b/src/ui/components/LeagueHub.jsx
@@ -3,9 +3,8 @@ import SectionSubnav from './SectionSubnav.jsx';
 import SocialFeed from './SocialFeed.jsx';
 import LeagueLeaders from './LeagueLeaders.jsx';
 import { buildNewsDeskModel } from '../utils/newsDesk.js';
-import { buildWeeklyLeagueRecap } from '../utils/weeklyLeagueRecap.js';
+import { buildLeagueSeasonPulse } from '../utils/leagueSeasonPulse.js';
 import { CompactListRow, StatusChip, HeroCard, SectionCard, StatStrip, CompactInsightCard } from './ScreenSystem.jsx';
-import { openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 
 const LEAGUE_SECTIONS = ['Overview', 'Results', 'Standings', 'News', 'Leaders', 'Coaching'];
 
@@ -30,7 +29,7 @@ export default function LeagueHub({
   }, [initialSection]);
 
   const week = Number(league?.week ?? 1);
-  const recap = useMemo(() => buildWeeklyLeagueRecap(league, { week }), [league, week]);
+  const seasonPulse = useMemo(() => buildLeagueSeasonPulse({ league, week }), [league, week]);
   const newsDesk = useMemo(() => buildNewsDeskModel(league, { segment: 'league', limit: 80 }), [league]);
   const transactionRows = useMemo(() => {
     return (newsDesk.transactions ?? []).slice(0, 8).map((item) => {
@@ -46,18 +45,16 @@ export default function LeagueHub({
     });
   }, [newsDesk.transactions]);
 
-  const spotlightRows = recap?.spotlights ?? [];
-
   return (
     <div className="app-screen-stack">
       <HeroCard
         eyebrow={`${league?.year ?? 'Season'} · Week ${league?.week ?? 1}`}
-        title="League Command Center"
-        subtitle="Results, standings pressure, league activity, and leaders."
+        title="League Season Pulse"
+        subtitle="What matters around the league right now."
         rightMeta={<StatusChip label={section} tone="league" />}
       >
         <StatStrip items={[
-          { label: 'Spotlights', value: `${spotlightRows.length}`, tone: 'league' },
+          { label: 'Stories', value: `${seasonPulse.headlineStories.length}`, tone: 'league' },
           { label: 'Trades', value: `${transactionRows.filter((row) => row?._txType === 'Trade').length}`, tone: 'info' },
           { label: 'Signings', value: `${transactionRows.filter((row) => row?._txType === 'Signing').length}`, tone: 'neutral' },
           { label: 'Releases', value: `${transactionRows.filter((row) => row?._txType === 'Release').length}`, tone: transactionRows.some((row) => row?._txType === 'Release') ? 'warning' : 'neutral' },
@@ -68,61 +65,36 @@ export default function LeagueHub({
 
       {section === 'Overview' && (
         <div className="app-screen-stack">
-          <SectionCard title="League pulse" subtitle="What changed this week." variant="compact">
+          {seasonPulse.availableData.headlines && <SectionCard title="Around the League" subtitle={`The most meaningful recorded results from Week ${seasonPulse.week}.`} variant="compact">
             <div className="app-row-stack">
-              {(recap?.bullets ?? []).slice(0, 3).map((bullet, idx) => (
-                <CompactInsightCard key={`overview-bullet-${idx}`} title={bullet} tone="info" />
+              {seasonPulse.headlineStories.map((story) => (
+                <CompactInsightCard key={story.key} title={story.text} tone="info" />
               ))}
-              {(recap?.bullets ?? []).length === 0 ? <CompactInsightCard title="Pulse unlocks after results" subtitle="Complete games to populate weekly pulse and race context." tone="info" /> : null}
             </div>
-          </SectionCard>
+          </SectionCard>}
 
-          <SectionCard title="Standings pressure" variant="compact">
-            <StatStrip items={[
-              {
-                label: 'Hottest',
-                value: recap?.raceCenter?.hottest?.[0]
-                  ? `${recap.raceCenter.hottest[0].team?.abbr ?? recap.raceCenter.hottest[0].team?.name} (${recap.raceCenter.hottest[0].streak.length}W)`
-                  : '—',
-                tone: 'ok',
-              },
-              {
-                label: 'Coldest',
-                value: recap?.raceCenter?.coldest?.[0]
-                  ? `${recap.raceCenter.coldest[0].team?.abbr ?? recap.raceCenter.coldest[0].team?.name} (${recap.raceCenter.coldest[0].streak.length}L)`
-                  : '—',
-                tone: 'warning',
-              },
-              {
-                label: 'Mover',
-                value: recap?.raceCenter?.biggestMover?.change > 0
-                  ? `${recap.raceCenter.biggestMover.team?.abbr ?? recap.raceCenter.biggestMover.team?.name} (+${recap.raceCenter.biggestMover.change})`
-                  : 'No major move',
-                tone: 'league',
-              },
-            ]} />
-          </SectionCard>
+          {seasonPulse.availableData.trends && <SectionCard title="Trending Teams" subtitle="Only established multi-game runs are shown." variant="compact">
+            <div className="app-row-stack">{seasonPulse.trendingTeams.map((trend) => <CompactListRow key={`${trend.label}-${trend.teamId}`} title={trend.reason} subtitle={trend.label} meta={<StatusChip label={trend.value} tone={trend.label === 'Losing streak' ? 'warning' : 'ok'} />} />)}</div>
+          </SectionCard>}
 
-          {spotlightRows.length > 0 && (
-            <SectionCard title="Spotlight games" variant="compact">
-              {spotlightRows.slice(0, 2).map((spotlight, idx) => (
-                <CompactListRow
-                  key={spotlight.key ?? `spotlight-${idx}`}
-                  title={spotlight.score ?? 'Spotlight game'}
-                  subtitle={spotlight.reason ?? 'Weekly spotlight game'}
-                  meta={<StatusChip label={`Week ${spotlight.week ?? week}`} tone="league" />}
-                >
-                  <button
-                    type="button"
-                    className="btn btn-sm"
-                    onClick={() => openResolvedBoxScore(spotlight.game, { seasonId: league?.seasonId, week: spotlight.week ?? week, source: 'league_overview_spotlight' }, onOpenGameDetail)}
-                  >
-                    Open spotlight
-                  </button>
-                </CompactListRow>
-              ))}
-            </SectionCard>
-          )}
+          {seasonPulse.availableData.awards && <SectionCard title="Award Watch" subtitle="Leaders from the league's recorded award boards." variant="compact">
+            <div className="app-row-stack">{seasonPulse.awardWatch.map((award) => <CompactListRow key={award.award} title={award.playerName} subtitle={[award.position, award.team].filter(Boolean).join(' · ')} meta={<StatusChip label={award.award} tone="league" />} />)}</div>
+          </SectionCard>}
+
+          {seasonPulse.availableData.injuries && <SectionCard title="League Health" subtitle="Longest active recorded absences." variant="compact">
+            <div className="app-row-stack">{seasonPulse.majorInjuries.map((injury) => <CompactListRow key={injury.playerId} title={injury.playerName} subtitle={[injury.position, injury.injury].filter(Boolean).join(' · ')} meta={<StatusChip label={`${injury.weeksRemaining} wk${injury.weeksRemaining === 1 ? '' : 's'}`} tone="warning" />} />)}</div>
+          </SectionCard>}
+
+          {seasonPulse.availableData.standings && <SectionCard title="Standings Context" subtitle={seasonPulse.omittedReasons.standingsMovement ?? 'Recorded movement this week.'} variant="compact">
+            <div className="app-row-stack">{seasonPulse.standingsImpact.slice(0, 4).map((item) => <CompactInsightCard key={item.key ?? `${item.type}-${item.teamId}`} title={item.text} tone="league" />)}</div>
+          </SectionCard>}
+
+          {seasonPulse.nextWeekHighlight && <SectionCard title="Next Week" subtitle="One matchup selected by stable, factual rules." variant="compact">
+            <CompactListRow title={`${seasonPulse.nextWeekHighlight.awayTeam} at ${seasonPulse.nextWeekHighlight.homeTeam}`} subtitle={seasonPulse.nextWeekHighlight.reason} meta={<StatusChip label={`Week ${seasonPulse.nextWeekHighlight.week}`} tone="info" />} />
+          </SectionCard>}
+
+          {!Object.values(seasonPulse.availableData).some(Boolean) && <SectionCard title="Season Pulse" variant="compact"><CompactInsightCard title="No league pulse is available yet" subtitle="Complete games to unlock factual weekly context." tone="info" /></SectionCard>}
+
         </div>
       )}
 

--- a/src/ui/components/LeagueHub.test.jsx
+++ b/src/ui/components/LeagueHub.test.jsx
@@ -39,13 +39,13 @@ describe('LeagueHub', () => {
       />,
     );
 
-    expect(html).toContain('League Command Center');
+    expect(html).toContain('League Season Pulse');
     expect(html).toContain('Overview');
     expect(html).toContain('Results');
     expect(html).toContain('Standings');
     expect(html).toContain('News');
     expect(html).toContain('Leaders');
-    expect(html).toContain('League pulse');
+    expect(html).toContain('Around the League');
     expect(html).not.toContain('Weekly Results Stub');
   });
 
@@ -78,5 +78,19 @@ describe('LeagueHub', () => {
         renderStandings={() => <div>Standings unavailable</div>}
       />,
     )).not.toThrow();
+  });
+
+  it('hides unsupported sections instead of rendering empty containers', () => {
+    const html = renderToString(<LeagueHub league={{ year: 2026, week: 1, seasonId: 'empty' }} />);
+    expect(html).toContain('No league pulse is available yet');
+    expect(html).not.toContain('Award Watch');
+    expect(html).not.toContain('League Health');
+    expect(html).not.toContain('Trending Teams');
+  });
+
+  it('renders long player names in the mobile-safe stacked row layout', () => {
+    const html = renderToString(<LeagueHub league={{ ...league, teams: league.teams.map((team, index) => index ? team : { ...team, roster: [{ id: 'long', name: 'A Very Long Player Name That Must Wrap Cleanly', pos: 'QB', injuryWeeksRemaining: 6 }] }) }} />);
+    expect(html).toContain('A Very Long Player Name That Must Wrap Cleanly');
+    expect(html).toContain('app-row-stack');
   });
 });

--- a/src/ui/components/LeagueHub.test.jsx
+++ b/src/ui/components/LeagueHub.test.jsx
@@ -1,6 +1,8 @@
+/** @vitest-environment jsdom */
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { renderToString } from 'react-dom/server';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import LeagueHub from './LeagueHub.jsx';
 
 const league = {
@@ -27,6 +29,7 @@ const league = {
 };
 
 describe('LeagueHub', () => {
+  afterEach(cleanup);
   it('renders command-center sections with overview as default', () => {
     const html = renderToString(
       <LeagueHub
@@ -92,5 +95,13 @@ describe('LeagueHub', () => {
     const html = renderToString(<LeagueHub league={{ ...league, teams: league.teams.map((team, index) => index ? team : { ...team, roster: [{ id: 'long', name: 'A Very Long Player Name That Must Wrap Cleanly', pos: 'QB', injuryWeeksRemaining: 6 }] }) }} />);
     expect(html).toContain('A Very Long Player Name That Must Wrap Cleanly');
     expect(html).toContain('app-row-stack');
+  });
+
+  it('opens a recorded spotlight through the existing Game Book callback', () => {
+    const onOpenGameDetail = vi.fn();
+    render(<LeagueHub league={league} onOpenGameDetail={onOpenGameDetail} />);
+    const spotlights = screen.getByText('Spotlight Games').closest('section');
+    fireEvent.click(within(spotlights).getByRole('button', { name: 'Open Game' }));
+    expect(onOpenGameDetail).toHaveBeenCalledWith('g1');
   });
 });

--- a/src/ui/utils/leagueSeasonPulse.js
+++ b/src/ui/utils/leagueSeasonPulse.js
@@ -7,6 +7,8 @@ const n = (value) => {
   return Number.isFinite(parsed) ? parsed : null;
 };
 const id = (value) => String(value?.id ?? value?.teamId ?? value ?? '');
+const playerId = (value) => value?.playerId ?? value?.id ?? value?.player?.id ?? null;
+const playerKey = (value) => String(playerId(value) ?? '');
 const teamName = (team) => team?.abbr ?? team?.name ?? 'Team';
 const sideId = (game, side) => id(game?.[`${side}Id`] ?? game?.[side]);
 const gameKey = (game) => String(game?.gameId ?? game?.id ?? `${sideId(game, 'away')}-${sideId(game, 'home')}`);
@@ -85,11 +87,11 @@ function buildInjuries(league, teams) {
   const roster = teams.flatMap((team) => (team?.roster ?? []).map((player) => ({ ...player, teamId: player?.teamId ?? team.id })));
   return [...supplied, ...roster]
     .map((player) => ({ player, weeks: n(player?.injuryWeeksRemaining ?? player?.injury?.gamesRemaining ?? player?.weeksOut) }))
-    .filter(({ player, weeks }) => id(player) && String(player?.name ?? '').trim() && weeks > 0)
-    .sort((a, b) => b.weeks - a.weeks || id(a.player).localeCompare(id(b.player)))
-    .filter((row, index, all) => all.findIndex((other) => id(other.player) === id(row.player)) === index)
+    .filter(({ player, weeks }) => playerKey(player) && String(player?.name ?? '').trim() && weeks > 0)
+    .sort((a, b) => b.weeks - a.weeks || playerKey(a.player).localeCompare(playerKey(b.player)))
+    .filter((row, index, all) => all.findIndex((other) => playerKey(other.player) === playerKey(row.player)) === index)
     .slice(0, 3)
-    .map(({ player, weeks }) => ({ playerId: player.id, playerName: player.name, teamId: player.teamId ?? null, position: player.pos ?? player.position ?? null, injury: player?.injury?.name ?? player?.injuryName ?? null, weeksRemaining: weeks }));
+    .map(({ player, weeks }) => ({ playerId: playerId(player), playerName: player.name, teamId: player.teamId ?? null, position: player.pos ?? player.position ?? null, injury: player?.injury?.name ?? player?.injuryName ?? null, weeksRemaining: weeks }));
 }
 
 function currentStandings(league) {

--- a/src/ui/utils/leagueSeasonPulse.js
+++ b/src/ui/utils/leagueSeasonPulse.js
@@ -1,0 +1,143 @@
+import { prepareStandingsView } from '../../views/standingsView.js';
+import { buildWeeklyStoryPresentation } from './weeklyStoryPresentation.js';
+
+const n = (value) => {
+  if (value == null || value === '') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+const id = (value) => String(value?.id ?? value?.teamId ?? value ?? '');
+const teamName = (team) => team?.abbr ?? team?.name ?? 'Team';
+const sideId = (game, side) => id(game?.[`${side}Id`] ?? game?.[side]);
+const gameKey = (game) => String(game?.gameId ?? game?.id ?? `${sideId(game, 'away')}-${sideId(game, 'home')}`);
+const isPlayed = (game) => n(game?.homeScore ?? game?.scoreHome) != null && n(game?.awayScore ?? game?.scoreAway) != null;
+
+function scheduleRows(schedule) {
+  return (Array.isArray(schedule?.weeks) ? schedule.weeks : [])
+    .map((row) => ({ week: n(row?.week), games: Array.isArray(row?.games) ? row.games : [] }))
+    .filter((row) => row.week != null)
+    .sort((a, b) => a.week - b.week);
+}
+
+function resolveCompletedGames(schedule, requestedWeek, supplied) {
+  if (Array.isArray(supplied)) return { week: n(requestedWeek), games: supplied.filter(isPlayed) };
+  const eligible = scheduleRows(schedule)
+    .filter((row) => requestedWeek == null || row.week <= requestedWeek)
+    .filter((row) => row.games.some(isPlayed));
+  const row = eligible.at(-1);
+  return { week: row?.week ?? n(requestedWeek), games: (row?.games ?? []).filter(isPlayed) };
+}
+
+function resultsForTeam(schedule, teamId, throughWeek) {
+  return scheduleRows(schedule).filter((row) => throughWeek == null || row.week <= throughWeek).flatMap((row) => row.games)
+    .filter(isPlayed)
+    .filter((game) => sideId(game, 'home') === teamId || sideId(game, 'away') === teamId)
+    .map((game) => {
+      const home = sideId(game, 'home') === teamId;
+      const mine = n(home ? game?.homeScore ?? game?.scoreHome : game?.awayScore ?? game?.scoreAway);
+      const theirs = n(home ? game?.awayScore ?? game?.scoreAway : game?.homeScore ?? game?.scoreHome);
+      return mine === theirs ? 'T' : mine > theirs ? 'W' : 'L';
+    });
+}
+
+function buildTrends(teams, schedule, week) {
+  const rows = teams.map((team) => {
+    const teamId = id(team);
+    const results = resultsForTeam(schedule, teamId, week);
+    const last = results.at(-1);
+    let length = 0;
+    if (last === 'W' || last === 'L') for (let i = results.length - 1; i >= 0 && results[i] === last; i -= 1) length += 1;
+    const wins = n(team?.wins) ?? results.filter((r) => r === 'W').length;
+    const losses = n(team?.losses) ?? results.filter((r) => r === 'L').length;
+    const ties = n(team?.ties) ?? results.filter((r) => r === 'T').length;
+    return { team, teamId, results, last, length, wins, losses, ties };
+  });
+  const trends = [];
+  const winners = rows.filter((row) => row.last === 'W' && row.length >= 2).sort((a, b) => b.length - a.length || a.teamId.localeCompare(b.teamId));
+  const losers = rows.filter((row) => row.last === 'L' && row.length >= 2).sort((a, b) => b.length - a.length || a.teamId.localeCompare(b.teamId));
+  const undefeated = rows.filter((row) => row.results.length >= 2 && row.losses === 0).sort((a, b) => b.wins - a.wins || a.teamId.localeCompare(b.teamId));
+  if (winners[0]) trends.push({ teamId: winners[0].team.id, label: 'Winning streak', value: `${winners[0].length} games`, reason: `${teamName(winners[0].team)} has won ${winners[0].length} straight.` });
+  if (losers[0]) trends.push({ teamId: losers[0].team.id, label: 'Losing streak', value: `${losers[0].length} games`, reason: `${teamName(losers[0].team)} has lost ${losers[0].length} straight.` });
+  if (undefeated[0] && !trends.some((row) => id(row.teamId) === undefeated[0].teamId)) trends.push({ teamId: undefeated[0].team.id, label: 'Undefeated', value: `${undefeated[0].wins}-${undefeated[0].losses}${undefeated[0].ties ? `-${undefeated[0].ties}` : ''}`, reason: `${teamName(undefeated[0].team)} remains unbeaten.` });
+  return trends.slice(0, 4);
+}
+
+const AWARDS = [['mvp', 'MVP'], ['opoy', 'OPOY'], ['dpoy', 'DPOY'], ['oroy', 'OROY'], ['droy', 'DROY']];
+function buildAwardWatch(league, teams) {
+  const races = league?.awardRaces?.awards;
+  if (!races || typeof races !== 'object') return [];
+  const teamMap = new Map(teams.map((team) => [id(team), team]));
+  const seen = new Set();
+  return AWARDS.flatMap(([key, award]) => {
+    const board = races?.[key]?.league ?? races?.[key]?.afc ?? races?.[key]?.nfc;
+    const leader = Array.isArray(board) ? board[0] : null;
+    const playerId = id(leader?.playerId ?? leader?.id);
+    const name = String(leader?.playerName ?? leader?.name ?? '').trim();
+    if (!leader || !playerId || !name || seen.has(playerId)) return [];
+    seen.add(playerId);
+    const team = teamMap.get(id(leader?.teamId));
+    return [{ award, playerId: leader?.playerId ?? leader?.id, playerName: name, position: leader?.pos ?? leader?.position ?? null, teamId: leader?.teamId ?? null, team: teamName(team), score: n(leader?.score) }];
+  });
+}
+
+function buildInjuries(league, teams) {
+  const supplied = Array.isArray(league?.injuries) ? league.injuries : [];
+  const roster = teams.flatMap((team) => (team?.roster ?? []).map((player) => ({ ...player, teamId: player?.teamId ?? team.id })));
+  return [...supplied, ...roster]
+    .map((player) => ({ player, weeks: n(player?.injuryWeeksRemaining ?? player?.injury?.gamesRemaining ?? player?.weeksOut) }))
+    .filter(({ player, weeks }) => id(player) && String(player?.name ?? '').trim() && weeks > 0)
+    .sort((a, b) => b.weeks - a.weeks || id(a.player).localeCompare(id(b.player)))
+    .filter((row, index, all) => all.findIndex((other) => id(other.player) === id(row.player)) === index)
+    .slice(0, 3)
+    .map(({ player, weeks }) => ({ playerId: player.id, playerName: player.name, teamId: player.teamId ?? null, position: player.pos ?? player.position ?? null, injury: player?.injury?.name ?? player?.injuryName ?? null, weeksRemaining: weeks }));
+}
+
+function currentStandings(league) {
+  if (!(league?.teams?.length || league?.standings?.length)) return [];
+  return prepareStandingsView(league).divisions.flatMap((division) => {
+    const leader = division.teams[0];
+    return leader ? [{ type: 'division-leader', teamId: leader.id, text: `${teamName(leader)} leads its division at ${leader.wins}-${leader.losses}${leader.ties ? `-${leader.ties}` : ''}.` }] : [];
+  });
+}
+
+function buildNextWeek(schedule, teams, userTeamId, afterWeek) {
+  const teamMap = new Map(teams.map((team) => [id(team), team]));
+  const candidates = scheduleRows(schedule).filter((row) => afterWeek == null || row.week > afterWeek).flatMap((row) => row.games.filter((game) => !isPlayed(game)).map((game) => {
+    const home = teamMap.get(sideId(game, 'home')); const away = teamMap.get(sideId(game, 'away'));
+    if (!home || !away) return null;
+    const userGame = [id(home), id(away)].includes(id(userTeamId));
+    const divisional = home.conf != null && away.conf != null && String(home.conf) === String(away.conf) && String(home.div ?? home.division) === String(away.div ?? away.division);
+    const games = (team) => (n(team.wins) ?? 0) + (n(team.losses) ?? 0) + (n(team.ties) ?? 0);
+    const pct = (team) => games(team) ? ((n(team.wins) ?? 0) + (n(team.ties) ?? 0) * 0.5) / games(team) : 0;
+    const strong = games(home) >= 2 && games(away) >= 2 && pct(home) > 0.5 && pct(away) > 0.5;
+    const prior = scheduleRows(schedule).filter((old) => old.week < row.week).some((old) => old.games.some((game) => [sideId(game, 'home'), sideId(game, 'away')].includes(id(home)) && [sideId(game, 'home'), sideId(game, 'away')].includes(id(away)) && isPlayed(game)));
+    const priority = (userGame ? 100 : 0) + (divisional ? 30 : 0) + (strong ? 20 : 0) + (prior ? 10 : 0) - row.week;
+    const reason = userGame ? `Your Week ${row.week} matchup` : divisional ? 'Divisional matchup' : strong ? 'Two teams above .500' : prior ? 'Rematch' : `Week ${row.week} matchup`;
+    return { week: row.week, gameId: game.gameId ?? game.id ?? null, homeTeamId: home.id, awayTeamId: away.id, homeTeam: teamName(home), awayTeam: teamName(away), reason, priority, key: gameKey(game) };
+  }).filter(Boolean));
+  return candidates.sort((a, b) => b.priority - a.priority || a.week - b.week || a.key.localeCompare(b.key))[0] ?? null;
+}
+
+/** Pure, deterministic Season Pulse assembled only from state already present in the League view. */
+export function buildLeagueSeasonPulse({ league = {}, userTeamId = league?.userTeamId, completedGames, schedule = league?.schedule, standingsBefore = null, standingsAfter = null, week = league?.week } = {}) {
+  const teams = Array.isArray(league?.teams) ? league.teams : [];
+  const completed = resolveCompletedGames(schedule, n(week), completedGames);
+  const injuries = buildInjuries(league, teams);
+  const storyInjuries = injuries.map((row) => ({ id: row.playerId, name: row.playerName, teamId: row.teamId, injuryWeeksRemaining: row.weeksRemaining, injury: row.injury ? { name: row.injury } : null }));
+  const story = buildWeeklyStoryPresentation({ league, week: completed.week, userTeamId, completedGames: completed.games, injuries: storyInjuries, standingsBefore, standingsAfter });
+  const trendingTeams = buildTrends(teams, schedule, completed.week);
+  const awardWatch = buildAwardWatch(league, teams);
+  const standingsImpact = story.standingsImpact.length ? story.standingsImpact : currentStandings(league);
+  const nextWeekHighlight = buildNextWeek(schedule, teams, userTeamId, completed.week);
+  return {
+    week: completed.week,
+    headlineStories: story.leagueHeadlines,
+    trendingTeams,
+    awardWatch,
+    majorInjuries: injuries,
+    standingsImpact,
+    nextWeekHighlight,
+    availableData: { headlines: story.leagueHeadlines.length > 0, trends: trendingTeams.length > 0, awards: awardWatch.length > 0, injuries: injuries.length > 0, standings: standingsImpact.length > 0, nextWeek: Boolean(nextWeekHighlight) },
+    omittedReasons: { headlines: completed.games.length ? null : 'No completed games were recorded', trends: trendingTeams.length ? null : 'No multi-game streak is established', awards: awardWatch.length ? null : 'No authoritative award race board is available', injuries: injuries.length ? null : 'No active recorded injuries', standingsMovement: Array.isArray(standingsBefore) && Array.isArray(standingsAfter) ? null : 'No before/after standings snapshots; current leaders only', nextWeek: nextWeekHighlight ? null : 'No upcoming scheduled game is available', hotSeat: 'League-wide historical pressure changes are not available in this view' },
+  };
+}

--- a/src/ui/utils/leagueSeasonPulse.test.js
+++ b/src/ui/utils/leagueSeasonPulse.test.js
@@ -39,6 +39,18 @@ describe('buildLeagueSeasonPulse', () => {
     expect(new Set(pulse.awardWatch.map((row) => row.playerId)).size).toBe(pulse.awardWatch.length);
   });
 
+  it('keeps distinct league-level playerId injuries on the same team in deterministic order', () => {
+    const pulse = buildLeagueSeasonPulse({ league: { ...league, injuries: [
+      { playerId: 202, teamId: 1, name: 'Second Player', injuryWeeksRemaining: 4 },
+      { playerId: 101, teamId: 1, name: 'First Player', injuryWeeksRemaining: 4 },
+    ] } });
+    expect(pulse.majorInjuries).toEqual([
+      expect.objectContaining({ playerId: 11, playerName: 'Starting Quarterback With A Long Name' }),
+      expect.objectContaining({ playerId: 101, teamId: 1, playerName: 'First Player' }),
+      expect.objectContaining({ playerId: 202, teamId: 1, playerName: 'Second Player' }),
+    ]);
+  });
+
   it('omits unsupported upset, award, movement, and single-game trends', () => {
     const oneWeek = { ...league, teams: teams.map((team) => ({ ...team, wins: 0, losses: 0, roster: [] })), schedule: { weeks: [weeks[0]] } };
     const pulse = buildLeagueSeasonPulse({ league: oneWeek });

--- a/src/ui/utils/leagueSeasonPulse.test.js
+++ b/src/ui/utils/leagueSeasonPulse.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { buildLeagueSeasonPulse } from './leagueSeasonPulse.js';
+
+const teams = [
+  { id: 1, name: 'Buffalo Very Long Team Name', abbr: 'BUF', conf: 0, div: 0, wins: 3, losses: 0, roster: [{ id: 11, name: 'Starting Quarterback With A Long Name', pos: 'QB', injuryWeeksRemaining: 5, injury: { name: 'Shoulder' } }] },
+  { id: 2, name: 'Miami', abbr: 'MIA', conf: 0, div: 0, wins: 1, losses: 2 },
+  { id: 3, name: 'Kansas City', abbr: 'KC', conf: 0, div: 1, wins: 2, losses: 1 },
+  { id: 4, name: 'Las Vegas', abbr: 'LV', conf: 0, div: 1, wins: 0, losses: 3 },
+];
+const weeks = [
+  { week: 1, games: [{ id: 'a', home: 1, away: 2, homeScore: 21, awayScore: 20 }, { id: 'b', home: 3, away: 4, homeScore: 31, awayScore: 10 }] },
+  { week: 2, games: [{ id: 'c', home: 2, away: 1, homeScore: 7, awayScore: 28 }, { id: 'd', home: 4, away: 3, homeScore: 13, awayScore: 17 }] },
+  { week: 3, games: [{ id: 'e', home: 1, away: 3, homeScore: 30, awayScore: 27 }, { id: 'f', home: 2, away: 4, homeScore: 14, awayScore: 10 }] },
+  { week: 4, games: [{ id: 'g', home: 1, away: 2 }, { id: 'h', home: 3, away: 4 }] },
+];
+const league = { seasonId: 2026, week: 3, phase: 'regular', userTeamId: 1, teams, schedule: { weeks } };
+
+describe('buildLeagueSeasonPulse', () => {
+  it('builds factual result stories, trends, injuries, standings, and a next game', () => {
+    const pulse = buildLeagueSeasonPulse({ league });
+    expect(pulse.headlineStories.some((story) => story.type === 'highest-scoring')).toBe(true);
+    expect(pulse.headlineStories.some((story) => story.type === 'largest-margin')).toBe(true);
+    expect(pulse.trendingTeams).toEqual(expect.arrayContaining([expect.objectContaining({ teamId: 1, label: 'Winning streak', value: '3 games' }), expect.objectContaining({ teamId: 4, label: 'Losing streak', value: '3 games' })]));
+    expect(pulse.majorInjuries[0]).toMatchObject({ playerId: 11, injury: 'Shoulder', weeksRemaining: 5 });
+    expect(pulse.standingsImpact.some((row) => row.type === 'division-leader')).toBe(true);
+    expect(pulse.nextWeekHighlight).toMatchObject({ gameId: 'g', reason: 'Your Week 4 matchup' });
+  });
+
+  it('uses only canonical recorded award boards and deduplicates players', () => {
+    const pulse = buildLeagueSeasonPulse({ league: { ...league, awardRaces: { awards: {
+      mvp: { league: [{ playerId: 11, playerName: 'QB One', teamId: 1, pos: 'QB', score: 99 }] },
+      opoy: { league: [{ playerId: 11, playerName: 'QB One', teamId: 1, pos: 'QB', score: 80 }] },
+      dpoy: { league: [{ playerId: 44, playerName: 'Edge Two', teamId: 4, pos: 'EDGE' }] },
+    } } } });
+    expect(pulse.awardWatch).toEqual([
+      expect.objectContaining({ award: 'MVP', playerName: 'QB One', score: 99 }),
+      expect.objectContaining({ award: 'DPOY', playerName: 'Edge Two' }),
+    ]);
+    expect(new Set(pulse.awardWatch.map((row) => row.playerId)).size).toBe(pulse.awardWatch.length);
+  });
+
+  it('omits unsupported upset, award, movement, and single-game trends', () => {
+    const oneWeek = { ...league, teams: teams.map((team) => ({ ...team, wins: 0, losses: 0, roster: [] })), schedule: { weeks: [weeks[0]] } };
+    const pulse = buildLeagueSeasonPulse({ league: oneWeek });
+    expect(pulse.headlineStories.some((story) => story.type === 'upset')).toBe(false);
+    expect(pulse.awardWatch).toEqual([]);
+    expect(pulse.trendingTeams).toEqual([]);
+    expect(pulse.omittedReasons.standingsMovement).toMatch(/No before\/after/);
+  });
+
+  it('accepts authoritative expectation and standings snapshots', () => {
+    const pulse = buildLeagueSeasonPulse({
+      league,
+      week: 3,
+      completedGames: [{ id: 'upset', home: 3, away: 4, homeScore: 10, awayScore: 17, homeWinProbability: 0.8 }],
+      standingsBefore: [{ teamId: 1, divisionLeader: false, seed: 7 }],
+      standingsAfter: [{ teamId: 1, divisionLeader: true, seed: 4 }],
+    });
+    expect(pulse.headlineStories.some((story) => story.type === 'upset')).toBe(true);
+    expect(pulse.standingsImpact[0].text).toContain('took the division lead');
+  });
+
+  it('is pure and invariant to completed-game input order', () => {
+    const completedGames = weeks[0].games;
+    const before = structuredClone(league);
+    const a = buildLeagueSeasonPulse({ league, week: 1, completedGames });
+    const b = buildLeagueSeasonPulse({ league, week: 1, completedGames: [...completedGames].reverse() });
+    expect(b).toEqual(a);
+    expect(league).toEqual(before);
+    expect(buildLeagueSeasonPulse({ league, week: 1, completedGames })).toEqual(a);
+  });
+
+  it.each([
+    ['empty league', {}],
+    ['offseason', { phase: 'offseason', week: null }],
+    ['postseason', { phase: 'playoffs', teams: [], schedule: { weeks: [] } }],
+    ['partial legacy save', { year: 2020, teams: [{ id: 1, name: 'Legacy' }] }],
+  ])('degrades honestly for %s', (_label, partial) => {
+    const pulse = buildLeagueSeasonPulse({ league: partial });
+    expect(pulse.headlineStories).toEqual([]);
+    expect(pulse.awardWatch).toEqual([]);
+    expect(pulse.nextWeekHighlight).toBeNull();
+  });
+});

--- a/tests/e2e/league_hub_season_pulse_mobile.spec.js
+++ b/tests/e2e/league_hub_season_pulse_mobile.spec.js
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+import { goToTab, launchFranchise } from './helpers/franchise.js';
+
+test.use({ viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true });
+
+test('League Hub Season Pulse is readable without horizontal overflow', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await launchFranchise(page);
+  await goToTab(page, 'league');
+
+  await expect(page.getByRole('heading', { name: 'League Season Pulse' })).toBeVisible();
+  await expect(page.getByText('What matters around the league right now.')).toBeVisible();
+  const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(overflow).toBeLessThanOrEqual(1);
+  await page.screenshot({ path: 'test-results/league-hub-season-pulse-mobile.png', fullPage: true });
+});


### PR DESCRIPTION
### Motivation

- Provide a compact, factual weekly briefing so players can see what mattered across the league without inventing narratives or changing simulation state.

### Description

- Added a pure, deterministic presentation model `buildLeagueSeasonPulse()` that assembles headline stories, trending teams, award-watch leaders, meaningful recorded injuries, standings context (or movement when authoritative snapshots supplied), and a single next-week highlight from existing league state and recorded games (`src/ui/utils/leagueSeasonPulse.js`).
- Reused the existing authoritative `buildWeeklyStoryPresentation()` for weekly headlines and `prepareStandingsView()` for standings rather than introducing new award/standings/power-ranking logic.
- Integrated the Season Pulse into the existing League Overview UI by replacing the Overview card contents in `LeagueHub.jsx` and conditionally rendering the sections: Around the League, Trending Teams, Award Watch, League Health, Standings Context, and Next Week.
- Added unit tests for the pure model (`src/ui/utils/leagueSeasonPulse.test.js`) and updated `LeagueHub` tests to assert the new presentation and empty-state behavior; added a Playwright mobile smoke spec to validate mobile layout (`tests/e2e/league_hub_season_pulse_mobile.spec.js`).
- Documented an audit covering authoritative helpers reused, omitted concepts, ranking rules, model shape, UI integration point, and performance/legacy behavior in `docs/league-hub-season-pulse-v1-audit.md`.

Files changed
- Added: `src/ui/utils/leagueSeasonPulse.js`
- Added: `src/ui/utils/leagueSeasonPulse.test.js`
- Updated: `src/ui/components/LeagueHub.jsx`
- Updated: `src/ui/components/LeagueHub.test.jsx`
- Added: `tests/e2e/league_hub_season_pulse_mobile.spec.js`
- Added: `docs/league-hub-season-pulse-v1-audit.md`

No changes were made to worker, persistence, simulation, contracts, cap logic, save schema, or other core systems.

### Testing

- Ran targeted unit tests: `npx vitest run src/ui/utils/leagueSeasonPulse.test.js src/ui/components/LeagueHub.test.jsx src/ui/utils/weeklyStoryPresentation.test.js` — passed (26 tests across those files passed after fixes).
- Ran broader unit/integration subsets referenced in the PR checklist including standings, awards, injury availability, and Franchise HQ tests — passed (81 tests in that sweep passed).
- Full unit suite: `npm run test:unit` — passed (470 files, 5,806 tests) in this environment.
- Type check for sim types: `npm run check:sim-types` — passed.
- Production build: `npm run build` — succeeded (expected chunk-size warnings only).
- Netlify parity checks: `npm run check:deploy` — passed (offline production and preview builds succeeded); audit reported existing dependency warnings (unchanged).
- Playwright E2E: added `tests/e2e/league_hub_season_pulse_mobile.spec.js` but actual browser test execution is blocked in this environment because the Playwright Chromium download failed with HTTP 403 (CDN access blocked), so no E2E screenshot/run was produced here.

Notes and limitations
- Award Watch displays leaders only when `league.awardRaces.awards` is present; no new award scoring was added.
- Standings movement is shown only when authoritative before/after snapshots are supplied; otherwise current division leaders are shown via `prepareStandingsView()`.
- Injury stories use recorded `injuryWeeksRemaining` (and legacy aliases) only; no impact scoring or diagnosis is invented.
- Next-week selection is deterministic and prioritizes the user team, divisional games, two teams above .500, rematches, then deterministic tiebreaking.
- The environment used to run tests could not push the branch or open the remote PR due to missing GitHub credentials (`git push` failed). A local commit is on branch `feature/pr-1737-league-hub-season-pulse-v1`.
- Playwright browser install failed (HTTP 403), so E2E execution and screenshot capture are not available from this run.

All changes are presentation-only and preserve simulation determinism and save compatibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7558469294832d9c4af1146e36734d)