### PR TITLE
Playability & Navigation Integrity V1

### DIFF
--- a/docs/playability-navigation-integrity-v1-audit.md
+++ b/docs/playability-navigation-integrity-v1-audit.md
@@ -1,0 +1,31 @@
+# Playability & Navigation Integrity V1 audit
+
+## Baseline and scope
+
+The inspected branch starts at merge commit `68fe8e6` (#1744), after merge commits `bfa9acc` (#1738) and `147ff4a` (#1737). Fetching `origin/main` confirmed that `68fe8e6` was the live main tip before implementation; draft #1743 was not merged or copied. This is reliability surgery only: no visual redesign, gameplay, simulation, AI, roster, trade valuation, contract, cap, worker ownership, persistence, or save-schema changes are included.
+
+## Navigation ownership model
+
+The shell has three distinct owners:
+
+1. **Shell sections** — `hq`, `team`, `league`, and `news`. `LeagueDashboard` resolves these through `NAV_GROUPS` to the first valid canonical dashboard tab in the section.
+2. **LeagueDashboard destinations** — canonical string tabs rendered by the dashboard content switch. The mobile drawer renders Weekly Results, Schedule, Standings, Stats (labelled League Stats), Roster Hub (labelled Roster / Depth), Game Plan, Staff, Injuries, Contract Center (labelled Contracts), 💰 Cap (labelled Salary Cap), Transactions (labelled Trade), Free Agency, Draft, History Hub (labelled History), Awards & Records, 🤖 GM Advisor, Analytics, and God Mode.
+3. **App actions** — save-slot lifecycle belongs to `App`, which owns `activeSlot` and renders `SaveSlotManager`. Saves is therefore an action (`saves`), not a dashboard destination.
+
+The bottom bar contract is HQ/Team/League as shell sections, News as the canonical `News` dashboard destination, and More as drawer state. Route changes, Escape, backdrop taps, destination taps, section taps, and collapsed Game Book navigation close the drawer.
+
+## Findings and fixes
+
+The reported Saves failure was reproducible by source trace: MobileNav emitted the string `Saves`; LeagueDashboard treated it as a normal tab; and that tab rendered `ModdingHub`, not App's `SaveSlotManager`. The fix marks Saves explicitly as App-owned, passes it through `LeagueDashboard.onOpenSaves`, and invokes the same `setActiveSlot(null)` behavior already used by App's existing **Manage Saves** utility action. Opening it does not call save, delete, reset, create, or worker actions. The obsolete dashboard Saves tab and incorrect ModdingHub rendering were removed.
+
+All other currently rendered drawer IDs resolve to the live dashboard contract. Friendly labels retain their canonical mappings listed above. Contract tests now reject duplicate menu IDs, unknown dashboard routes, invalid shell-section values, and a Saves item that is not App-owned. Interaction tests cover Saves ownership plus drawer closure on action, Escape, and collapsed navigation. A focused 390px Playwright test traverses League Stats, Contracts, Trade, Weekly Results, all primary bottom destinations, and Saves, while checking drawer closure, crash copy, and horizontal overflow.
+
+The audited in-content CTAs in `FranchiseHQ`, `LeagueHub`, `NewsFeed`, `TeamHub`, and `LeagueDashboard` continue to use existing `onNavigate`, entity-select, Game Book, advance, simulation, quick-save, and Manage Saves callbacks. No additional dead callback was proven in the current source, so no speculative rewiring was added.
+
+## Postgame and statistics data boundary
+
+`LeagueStats` receives only `league` and builds its model with `buildLeagueStatsHubModel(league)`. This is intentional: `lastResults` feeds Weekly Results/postgame surfaces and is not a second League Stats authority. The model first uses canonical roster `seasonStats`; only when those are absent does it aggregate detailed player logs from completed schedule games. Team rankings aggregate canonical schedule `teamStats`; score-only games are labelled **Score-only standings data**, partial detail is labelled **Partial data**, and unavailable categories render honest no-data copy. Team columns are filtered by recorded availability, so absent yards/sacks do not produce hollow ranking cells. Existing model tests cover real playerStats, real teamStats, score-only games, input reorder determinism, and non-mutation. No missing propagation or formatter defect requiring a new data path was proven, so the stats pipeline was left unchanged.
+
+## Deferred work
+
+The PFGM-inspired visual redesign, density/polish work, new stat formulas, synthetic stats, new postgame plumbing, new gameplay systems, and broad CTA redesign are intentionally deferred. Sparse or old saves can only display detail actually persisted by their canonical schedule/season-stat data; the truthful limited-data states remain the supported fallback.

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -1594,6 +1594,7 @@ function AppContent() {
               setGameBookBriefingStash(null);
             }
           }}
+          onOpenSaves={() => setActiveSlot(null)}
           advanceLabel={getAdvanceLabel()}
           advanceDisabled={busy || simulating || isCutdownRequired || isBatchSimBlocking || !!promptUserGame}
         />

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -54,7 +54,6 @@ import ContractCenter from "./ContractCenter.jsx";
 import PostseasonHub from "./PostseasonHub.jsx";
 import TrainingCamp from "./TrainingCamp.jsx";
 import StaffManagement from "./StaffManagement.jsx";
-import ModdingHub from "./ModdingHub.jsx";
 import MockDraft from "./MockDraft.jsx";
 import InjuryReport from "./InjuryReport.jsx";
 import GodMode from "./GodMode.jsx";
@@ -218,7 +217,6 @@ const BASE_TABS = [
   "Awards & Records",
   "All-Time Records",
   "Season Recap",
-  "Saves",
   "God Mode",
   "🤖 GM Advisor",
   "Game Detail",
@@ -635,6 +633,7 @@ export default function LeagueDashboard({
   externalDestination,
   onConsumeExternalDestination,
   onGameDetailBack,
+  onOpenSaves,
   advanceLabel = "Advance",
   advanceDisabled = false,
 }) {
@@ -1551,11 +1550,6 @@ export default function LeagueDashboard({
             <StaffManagement league={league} actions={actions} />
           </TabErrorBoundary>
         )}
-        {activeTab === "Saves" && (
-          <TabErrorBoundary label="Saves">
-            <ModdingHub league={league} actions={actions} />
-          </TabErrorBoundary>
-        )}
         {activeTab === "Mock Draft" && (
           <TabErrorBoundary label="Mock Draft">
             <MockDraft
@@ -1627,6 +1621,9 @@ export default function LeagueDashboard({
         activeTab={activeTab}
         onSectionChange={handleSectionChange}
         onDestinationChange={(tab) => setActiveTab(canonicalizeMobileTab(tab))}
+        onAppAction={(action) => {
+          if (action === "saves") onOpenSaves?.();
+        }}
         onAdvance={onAdvanceWeek}
         advanceLabel={advanceLabel}
         advanceDisabled={advanceDisabled}

--- a/src/ui/components/MobileNav.jsx
+++ b/src/ui/components/MobileNav.jsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { SHELL_SECTIONS } from '../utils/shellNavigation.js';
 
-// More-drawer destinations. Ids are canonical dashboard tab ids that match the
-// LeagueDashboard content switch directly, so every entry routes to a real page.
+// More-drawer destinations. Entries are canonical dashboard tab ids unless
+// explicitly marked as an App-owned action (currently Saves).
 // Ordered weekly-loop first so the core game flow is reachable in one tap.
-const MORE_GROUPS = [
+export const MORE_GROUPS = [
   {
     title: 'Weekly Loop',
     items: [
@@ -40,13 +40,13 @@ const MORE_GROUPS = [
     items: [
       { id: '🤖 GM Advisor', label: 'GM Advisor', icon: AdvisorIcon },
       { id: 'Analytics', label: 'Analytics', icon: AnalyticsIcon },
-      { id: 'Saves', label: 'Saves', icon: SaveIcon },
+      { id: 'Saves', label: 'Saves', icon: SaveIcon, action: 'app', value: 'saves' },
       { id: 'God Mode', label: 'God Mode', icon: GodModeIcon },
     ],
   },
 ];
 
-const BOTTOM_TABS = [
+export const BOTTOM_TABS = [
   { id: 'HQ', label: 'HQ', icon: HomeIcon, action: 'section', value: SHELL_SECTIONS.hq },
   { id: 'Team', label: 'Team', icon: RosterIcon, action: 'section', value: SHELL_SECTIONS.team },
   { id: 'League', label: 'League', icon: StandingsIcon, action: 'section', value: SHELL_SECTIONS.league },
@@ -54,7 +54,7 @@ const BOTTOM_TABS = [
   { id: 'More', label: 'More', icon: MoreIcon, action: 'menu', value: 'more' },
 ];
 
-export default function MobileNav({ activeSection, activeTab, onSectionChange, onDestinationChange, league, collapsed = false }) {
+export default function MobileNav({ activeSection, activeTab, onSectionChange, onDestinationChange, onAppAction, league, collapsed = false }) {
   const [menuOpen, setMenuOpen] = useState(false);
 
   // Route-change cleanup: any navigation — section OR tab — closes the More
@@ -92,6 +92,16 @@ export default function MobileNav({ activeSection, activeTab, onSectionChange, o
     window.scrollTo(0, 0);
   };
 
+  const handleMenuItemClick = (item) => {
+    if (item.action === 'app') {
+      onAppAction?.(item.value);
+      setMenuOpen(false);
+      window.scrollTo(0, 0);
+      return;
+    }
+    handleDestinationClick(item.id);
+  };
+
   const hasTeamAlerts = Boolean((league?.incomingTradeOffers ?? []).length) || Boolean((league?.teams ?? []).find((team) => Number(team?.id) === Number(league?.userTeamId))?.roster?.some((player) => Number(player?.injuryWeeksRemaining ?? player?.injuredWeeks ?? player?.injury?.gamesRemaining ?? 0) > 0));
   const hasLeagueAlerts = Boolean((league?.newsItems ?? []).length);
 
@@ -118,7 +128,7 @@ export default function MobileNav({ activeSection, activeTab, onSectionChange, o
               {group.items.map((item) => {
                 const Icon = item.icon;
                 return (
-                  <button key={item.id} className="mobile-nav-item mobile-nav-item-premium" onClick={() => handleDestinationClick(item.id)}>
+                  <button key={item.id} className="mobile-nav-item mobile-nav-item-premium" onClick={() => handleMenuItemClick(item)}>
                     <Icon size={20} />
                     <span>{item.label}</span>
                   </button>

--- a/src/ui/components/MobileNav.test.jsx
+++ b/src/ui/components/MobileNav.test.jsx
@@ -1,10 +1,54 @@
+/** @vitest-environment jsdom */
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderToString } from 'react-dom/server';
-import MobileNav from './MobileNav.jsx';
-import { SHELL_SECTIONS } from '../utils/shellNavigation.js';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import MobileNav, { BOTTOM_TABS, MORE_GROUPS } from './MobileNav.jsx';
+import { isKnownDashboardTab, SHELL_SECTIONS } from '../utils/shellNavigation.js';
 
 describe('MobileNav', () => {
+  beforeEach(() => { window.scrollTo = vi.fn(); });
+  afterEach(() => cleanup());
+
+  it('gives every rendered entry one valid owner without duplicate ids', () => {
+    const items = MORE_GROUPS.flatMap((group) => group.items);
+    expect(new Set(items.map((item) => item.id)).size).toBe(items.length);
+    for (const item of items) {
+      if (item.action === 'app') {
+        expect(item).toMatchObject({ id: 'Saves', value: 'saves' });
+      } else {
+        expect(isKnownDashboardTab(item.id), item.id).toBe(true);
+      }
+    }
+    expect(BOTTOM_TABS.map((tab) => tab.action)).toEqual(['section', 'section', 'section', 'destination', 'menu']);
+    expect(BOTTOM_TABS.filter((tab) => tab.action === 'section').every((tab) => Object.values(SHELL_SECTIONS).includes(tab.value))).toBe(true);
+    expect(isKnownDashboardTab(BOTTOM_TABS.find((tab) => tab.action === 'destination').value)).toBe(true);
+  });
+
+  it('routes Saves to its App owner and closes the drawer', () => {
+    const onAppAction = vi.fn();
+    const onDestinationChange = vi.fn();
+    render(<MobileNav activeSection={SHELL_SECTIONS.hq} onSectionChange={vi.fn()} onDestinationChange={onDestinationChange} onAppAction={onAppAction} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open navigation menu' }));
+    expect(screen.getByRole('button', { name: 'Open navigation menu' }).getAttribute('aria-expanded')).toBe('true');
+    fireEvent.click(screen.getByRole('button', { name: 'Saves' }));
+
+    expect(onAppAction).toHaveBeenCalledWith('saves');
+    expect(onDestinationChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Open navigation menu' }).getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('closes the drawer on Escape and when collapsed', () => {
+    const { container, rerender } = render(<MobileNav activeSection={SHELL_SECTIONS.hq} onSectionChange={vi.fn()} onDestinationChange={vi.fn()} />);
+    const toggle = () => container.querySelector('button[aria-label="Open navigation menu"]');
+    fireEvent.click(toggle());
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(toggle().getAttribute('aria-expanded')).toBe('false');
+    fireEvent.click(toggle());
+    rerender(<MobileNav activeSection={SHELL_SECTIONS.hq} onSectionChange={vi.fn()} onDestinationChange={vi.fn()} collapsed />);
+    expect(toggle().getAttribute('aria-expanded')).toBe('false');
+  });
   it('renders premium bottom nav and marks the active shell tab', () => {
     const html = renderToString(
       <MobileNav

--- a/src/ui/utils/shellNavigation.js
+++ b/src/ui/utils/shellNavigation.js
@@ -64,10 +64,14 @@ const TAB_TO_SECTION = Object.freeze({
   'Hall of Fame': SHELL_SECTIONS.league,
   'Awards & Records': SHELL_SECTIONS.league,
   'Season Recap': SHELL_SECTIONS.league,
-  Saves: SHELL_SECTIONS.league,
   'God Mode': SHELL_SECTIONS.league,
   '🤖 GM Advisor': SHELL_SECTIONS.league,
 });
+
+export function isKnownDashboardTab(tab) {
+  const normalized = normalizeDashboardTab(tab);
+  return Object.prototype.hasOwnProperty.call(TAB_TO_SECTION, normalized);
+}
 
 const LEGACY_MOBILE_ID_TO_SECTION = Object.freeze({
   weekly: SHELL_SECTIONS.hq,

--- a/tests/e2e/mobile_navigation_integrity.spec.js
+++ b/tests/e2e/mobile_navigation_integrity.spec.js
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+import { launchFranchise } from './helpers/franchise.js';
+
+const openMenu = async (page) => {
+  await page.getByRole('button', { name: 'Open navigation menu' }).click();
+  await expect(page.getByRole('navigation', { name: 'More navigation' })).toHaveClass(/open/);
+};
+
+test('mobile primary navigation reaches canonical surfaces and App-owned Saves', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await launchFranchise(page);
+  await expect(page.getByTestId('franchise-hq')).toBeVisible({ timeout: 60_000 });
+
+  for (const route of [
+    { label: 'League Stats', identity: 'League Stats' },
+    { label: 'Contracts', identity: 'Contracts' },
+    { label: 'Trade', identity: 'Trade Center' },
+    { label: 'Weekly Results', identity: 'Weekly Results' },
+  ]) {
+    await openMenu(page);
+    await page.getByRole('button', { name: route.label, exact: true }).click();
+    await expect(page.getByRole('navigation', { name: 'More navigation' })).not.toHaveClass(/open/);
+    await expect(page.getByRole('heading', { name: route.identity, exact: true }).first()).toBeVisible();
+  }
+
+  for (const label of ['HQ', 'Team', 'League', 'News']) {
+    await page.getByRole('button', { name: label, exact: true }).last().click();
+    await expect(page.getByRole('heading', { name: label === 'HQ' ? 'Franchise HQ' : label, exact: true }).first()).toBeVisible();
+  }
+
+  await openMenu(page);
+  await page.getByRole('button', { name: 'Saves', exact: true }).click();
+  await expect(page.getByRole('navigation', { name: 'More navigation' })).toHaveCount(0);
+  await expect(page.getByTestId('app-save-slots')).toBeVisible();
+  await expect(page.getByRole('list', { name: 'Franchise save slots' })).toBeVisible();
+
+  await expect(page.locator('body')).not.toContainText('Something went wrong');
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBe(true);
+});


### PR DESCRIPTION
### Motivation

- Fix mobile playability by ensuring every visible mobile navigation entry either routes to a real dashboard surface or is handled as an explicit App-owned action so users are not shown dead/tappable-but-broken menu items.
- Root cause: `Saves` was treated as a dashboard tab and rendered via `LeagueDashboard` (showing `ModdingHub`) instead of invoking the App-owned `SaveSlotManager`, producing a non-working mobile path and stale drawer state.
- Also harden drawer lifecycle so Escape, collapsed Game Book mode, backdrop taps, and route changes reliably close the More drawer and avoid stale overlays on mobile.

### Description

- MobileNav: exported the drawer/menu config (`MORE_GROUPS`, `BOTTOM_TABS`), classified `Saves` as an App-owned action (`{ action: 'app', value: 'saves' }`), added an `onAppAction` prop and `handleMenuItemClick` to route app actions vs dashboard destinations, and preserved drawer close/scroll behavior (`src/ui/components/MobileNav.jsx`).
- LeagueDashboard & App: removed the dashboard `Saves` tab rendering and ModdingHub path, added an `onOpenSaves` callback prop to `LeagueDashboard`, and wired `onAppAction('saves')` from `MobileNav` through `LeagueDashboard` to `App` which uses the existing `setActiveSlot(null)` semantics to open the real `SaveSlotManager` without touching save/delete/create semantics (`src/ui/components/LeagueDashboard.jsx`, `src/ui/App.jsx`).
- Navigation helpers & tests: added `isKnownDashboardTab` helper to `src/ui/utils/shellNavigation.js`, updated/added unit tests for the mobile nav contract and drawer lifecycle (`src/ui/components/MobileNav.test.jsx`), and added a focused Playwright E2E for mobile navigation integrity at `tests/e2e/mobile_navigation_integrity.spec.js` plus the audit doc `docs/playability-navigation-integrity-v1-audit.md` describing the ownership model and findings.
- Small test & harness fixes: annotated `MobileNav.test.jsx` with `@vitest-environment jsdom`, added a `window.scrollTo` mock for tests, and adjusted assertions to reflect the real behavior that App-owned `Saves` removes/closes the drawer and opens the App save UI.

### Testing

- Ran the targeted unit tests with `npm run test:unit -- --run src/ui/components/MobileNav.test.jsx src/ui/utils/leagueStatsHub.test.js src/ui/components/LeagueStats.test.jsx` and broader suites; targeted suites passed and the full unit run succeeded (full test corpus reported as passing in this environment).
- Type-check and build: `npm run check:sim-types` passed and `npm run build` produced a production build (only the expected chunk-size warnings were reported).
- Netlify parity: `npm run check:deploy` (Netlify parity + rules + offline builds) completed successfully in this environment, with existing dependency audit advisories noted but not changed by this PR.
- Playwright E2E: `tests/e2e/mobile_navigation_integrity.spec.js` was added and verified syntactically with `node --check`, but live Playwright execution was blocked because the Chromium binary could not be installed in this environment (Playwright CDN returned HTTP 403), so full browser E2E could not be run here.
- Notes / limitations: I could not open the remote PR from this environment due to missing GitHub CLI / token authentication, and the Playwright browser download is blocked by CDN permissions — both are environment-level blockers and not changes to repository code or tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a9d65d540832d9ced9220c80256fa)