### PR TITLE
PFGM‑inspired mobile shell & density (mobile-only)

### DIFF
--- a/docs/pfgm-inspired-mobile-shell-density-v1-audit.md
+++ b/docs/pfgm-inspired-mobile-shell-density-v1-audit.md
@@ -14,6 +14,7 @@
 - Live shared primitives are `ScreenHeader`, `SectionHeader`, and `SectionCard` (`ScreenSystem.jsx`); `.app-screen-stack`, `.app-row-stack`, `.app-compact-list-row`, and game-center rows (`screen-system.css`); `.card` and `.btn`; `.standings-tabs` / `.standings-tab`; and MobileNav's premium bottom-nav classes.
 - The application already provides usable dark, text, divider, state, spacing, and radius variables in `base.css`. It did not provide a restrained green action token or a single late mobile conversion layer, so this PR adds only six mobile-scoped values and a final stylesheet import.
 - Repeated rules across legacy files create soft gradients, large radii, shadows, contained pills, and card-within-card depth. The last-loaded layer is the narrowest safe extension point because changing old global definitions would alter desktop and deferred legacy routes.
+- Review correction: the conversion no longer targets the generic `.card` class. Approved components opt in with `.pfgm-density-surface`; `LeagueDashboard` applies that wrapper only for HQ, Weekly Hub/Home, Team, League, News, and Weekly Results. FranchiseHQ, TeamHub, LeagueHub, NewsFeed, and WeeklyResultsCenter also declare the opt-in at their own roots so focused component renders retain the intended treatment.
 
 ## Repeated visual problems found
 
@@ -38,7 +39,7 @@ These shared primitives are consumed by Franchise HQ, Team/roster-facing workspa
 ## Mobile sizing, overflow, and accessibility
 
 - The conversion is scoped to `max-width: 767px`; desktop remains stable.
-- The shell uses full-width sizing with `max-width: 100%`, contained scrolling for tab/filter strips, `min-width: 0` on screen stacks, and document-level horizontal clipping as a final paint guard. Interactive tab and nav targets remain at least 44px high.
+- There is no document-level `overflow-x` clipping or hiding. The app shell uses border-box `width`/`max-width: 100%`; opted-in screen and row stacks use `min-width: 0` and `max-width: 100%`; compact/game rows are width-constrained; and tab/filter rails own their intentional `overflow-x: auto`. Interactive tab and nav targets remain at least 44px high.
 - The bottom bar reserves content space and includes left/right/bottom safe-area insets. More remains a normal labeled bottom destination and the drawer remains independently scrollable under its existing rules.
 - Selected tabs do not rely on color alone: they use an underline, font weight, and text contrast. Bottom-nav selection adds a top indicator, bold label, and `aria-current`. Focus uses a two-pixel green outline. Heading elements and levels were not changed.
 - Long dynamic names remain governed by existing row wrapping/truncation rules; the new layer does not add nowrap to data rows. Only intentionally contained tab labels stay on one line.
@@ -48,16 +49,18 @@ These shared primitives are consumed by Franchise HQ, Team/roster-facing workspa
 - Draft room, Hall of Fame, modal/dialog internals, destructive confirmations, error states, game simulation views, and legacy routes that do not consume a shared primitive are not individually redesigned.
 - Desktop/tablet layout, player imagery/avatar generation, logos, rating formulas, stat formulas, route strings, and component APIs are deferred/non-goals.
 - Critical decision cards retain semantic separation; this pass does not indiscriminately flatten dialogs or warnings.
+- Generic `.card` consumers—including deferred modal, alert, destructive, error/success, draft, trade, contract, analytics, free-agency, and legacy surfaces—retain their existing styling unless they are a named primitive beneath an approved opt-in root.
 
 ## Validation record
 
 Validation completed:
 
-- Targeted Vitest command covering MobileNav, shell navigation, SaveSlotManager, LeagueHub, TeamHub, NewsFeed, FranchiseHQ/mobile shell, and LeagueDashboard player-profile navigation: 9 files and 82 tests passed.
-- `npm run test:unit`: 472 files and 5,869 tests passed.
+- Targeted Vitest command covering the CSS scope regression, MobileNav, shell navigation, SaveSlotManager, LeagueHub, TeamHub, NewsFeed, FranchiseHQ/mobile shell, and LeagueDashboard player-profile navigation: 10 files and 84 tests passed.
+- `npm run test:unit`: 473 files and 5,871 tests passed.
 - `npm run check:sim-types`: passed.
 - `npm run build`: passed with the repository's documented large-chunk warning.
 - `npm run check:deploy`: production parity, rules, production Netlify CLI build, and deploy-preview Netlify CLI build passed. npm reported the pre-existing package audit count (one low and five high vulnerabilities).
-- `npx playwright test tests/e2e/mobile_navigation_integrity.spec.js`: not executed to an assertion result because the Chromium executable was absent.
+- `npx playwright test tests/e2e/mobile_navigation_integrity.spec.js`: could not execute assertions because Chromium headless shell revision 1217 was absent.
 - `npx playwright install chromium`: failed because the environment returned HTTP 403 `Domain forbidden` for the Playwright CDN. Consequently, screenshots and real-browser 375px/390px/430px measurements were not produced or claimed. The existing mobile E2E source already includes a 390px navigation/Saves flow and document-overflow assertion; it was left intact.
 - `git diff --check`: passed.
+- `npx vitest run src/ui/styles/mobile-shell-density.test.js`: validates that generic `.card` is not flattened and document-level overflow is not masked.

--- a/docs/pfgm-inspired-mobile-shell-density-v1-audit.md
+++ b/docs/pfgm-inspired-mobile-shell-density-v1-audit.md
@@ -1,0 +1,63 @@
+# PFGM-Inspired Mobile Shell & Density V1 Audit
+
+## Baseline and ownership
+
+- Audited baseline commit `94596b5`, the merge commit for PR #1745. The checkout exposed the baseline as branch `work`; this change was created on `feature/pr-1746-pfgm-inspired-mobile-shell-density-v1` without using an unrelated branch.
+- `src/ui/App.jsx` owns the application shell, header actions, route selection, and App-owned Saves / `SaveSlotManager` presentation. No route strings, handlers, or ownership changed.
+- `src/ui/components/MobileNav.jsx` owns the five bottom destinations and More drawer. Its section/destination/App-action callbacks and close-on-route, Escape, and collapse behavior remain intact.
+- `src/ui/components/LeagueDashboard.jsx` owns the dashboard destination switcher and League surface. `FranchiseHQ`, `LeagueHub`, `TeamHub`, `NewsFeed`, and `WeeklyResultsCenter` supply the most visible mobile content inside that shell.
+- Simulation remains in `src/worker`; IndexedDB remains the persistence owner. Neither area is touched.
+
+## Live style-system findings
+
+- CSS enters through `src/ui/main.jsx`. The existing order is `base.css`, legacy/global component rules, layout/hub/mobile layers, `app-mobile.css`, shared `screen-system.css`, then `stadium-theme.css`.
+- Live shared primitives are `ScreenHeader`, `SectionHeader`, and `SectionCard` (`ScreenSystem.jsx`); `.app-screen-stack`, `.app-row-stack`, `.app-compact-list-row`, and game-center rows (`screen-system.css`); `.card` and `.btn`; `.standings-tabs` / `.standings-tab`; and MobileNav's premium bottom-nav classes.
+- The application already provides usable dark, text, divider, state, spacing, and radius variables in `base.css`. It did not provide a restrained green action token or a single late mobile conversion layer, so this PR adds only six mobile-scoped values and a final stylesheet import.
+- Repeated rules across legacy files create soft gradients, large radii, shadows, contained pills, and card-within-card depth. The last-loaded layer is the narrowest safe extension point because changing old global definitions would alter desktop and deferred legacy routes.
+
+## Repeated visual problems found
+
+- Mobile shell padding made the app read as a floating dashboard instead of edge-to-edge game chrome.
+- Page headers and section cards used similar rounded/elevated treatments, weakening hierarchy.
+- Tabs appeared as rounded segmented controls and relied too heavily on their filled active state.
+- Repeated rows were separated by generous gaps and individual borders rather than bands/dividers.
+- Existing primary action styling used the general accent, while active and secondary controls competed for similar emphasis.
+- The floating, rounded bottom navigation read as a web overlay rather than persistent native shell chrome.
+
+## Updated surfaces and primitives
+
+- **Shell/header:** edge-to-edge black content, compact navy App and screen headers, square section bands, stronger uppercase title hierarchy.
+- **Tabs:** shared standings/section/dashboard tabs and News filters are flat, horizontally contained strips with text contrast plus a green active underline.
+- **Rows/cards:** shared screen stacks, row stacks, compact list rows, section cards, team alerts, standings mini rows, News rows, and weekly result cards use tighter gaps, charcoal bands, and visible dividers. Existing content and click semantics remain unchanged.
+- **Actions:** existing `.btn-primary` / `.app-action-primary` classifications receive green high emphasis; secondary buttons remain charcoal and bordered. No buttons were reclassified.
+- **Bottom navigation:** destinations, labels, callbacks, badges, drawer, collapse behavior, and accessible names are unchanged. Chrome is now full-width and flat; active tabs have an icon/color treatment, top indicator, bold label, and `aria-current="page"`.
+- **Identity:** existing team abbreviations, user-team row state, records, scorelines, metadata, ratings, and player/team content gain stronger surrounding contrast. No identity data or imagery was invented.
+
+These shared primitives are consumed by Franchise HQ, Team/roster-facing workspaces, League Hub / League Dashboard, News, and Weekly Results / Game Book entry cards, so those are the exact primary surfaces converted in V1.
+
+## Mobile sizing, overflow, and accessibility
+
+- The conversion is scoped to `max-width: 767px`; desktop remains stable.
+- The shell uses full-width sizing with `max-width: 100%`, contained scrolling for tab/filter strips, `min-width: 0` on screen stacks, and document-level horizontal clipping as a final paint guard. Interactive tab and nav targets remain at least 44px high.
+- The bottom bar reserves content space and includes left/right/bottom safe-area insets. More remains a normal labeled bottom destination and the drawer remains independently scrollable under its existing rules.
+- Selected tabs do not rely on color alone: they use an underline, font weight, and text contrast. Bottom-nav selection adds a top indicator, bold label, and `aria-current`. Focus uses a two-pixel green outline. Heading elements and levels were not changed.
+- Long dynamic names remain governed by existing row wrapping/truncation rules; the new layer does not add nowrap to data rows. Only intentionally contained tab labels stay on one line.
+
+## Intentionally deferred
+
+- Draft room, Hall of Fame, modal/dialog internals, destructive confirmations, error states, game simulation views, and legacy routes that do not consume a shared primitive are not individually redesigned.
+- Desktop/tablet layout, player imagery/avatar generation, logos, rating formulas, stat formulas, route strings, and component APIs are deferred/non-goals.
+- Critical decision cards retain semantic separation; this pass does not indiscriminately flatten dialogs or warnings.
+
+## Validation record
+
+Validation completed:
+
+- Targeted Vitest command covering MobileNav, shell navigation, SaveSlotManager, LeagueHub, TeamHub, NewsFeed, FranchiseHQ/mobile shell, and LeagueDashboard player-profile navigation: 9 files and 82 tests passed.
+- `npm run test:unit`: 472 files and 5,869 tests passed.
+- `npm run check:sim-types`: passed.
+- `npm run build`: passed with the repository's documented large-chunk warning.
+- `npm run check:deploy`: production parity, rules, production Netlify CLI build, and deploy-preview Netlify CLI build passed. npm reported the pre-existing package audit count (one low and five high vulnerabilities).
+- `npx playwright test tests/e2e/mobile_navigation_integrity.spec.js`: not executed to an assertion result because the Chromium executable was absent.
+- `npx playwright install chromium`: failed because the environment returned HTTP 403 `Domain forbidden` for the Playwright CDN. Consequently, screenshots and real-browser 375px/390px/430px measurements were not produced or claimed. The existing mobile E2E source already includes a 390px navigation/Saves flow and document-overflow assertion; it was left intact.
+- `git diff --check`: passed.

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -547,7 +547,7 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
 
   return (
     <div
-      className="app-screen-stack franchise-hq franchise-command-center hq-compact-layout"
+      className="app-screen-stack franchise-hq franchise-command-center hq-compact-layout pfgm-density-surface"
       data-testid="franchise-hq"
       role="main"
       aria-label="Franchise HQ weekly command center"

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -841,8 +841,10 @@ export default function LeagueDashboard({
     setActiveTab(targetTab);
   };
 
+  const usesPfgmDensitySurface = ['HQ', 'Weekly Hub', 'Home', 'Team', 'League', 'News', 'Weekly Results'].includes(activeTab);
+
   return (
-    <div>
+    <div className={usesPfgmDensitySurface ? 'pfgm-density-surface' : undefined}>
       {/* ── Franchise shell status bar ── */}
       <div className="franchise-status-bar">
         <button

--- a/src/ui/components/LeagueHub.jsx
+++ b/src/ui/components/LeagueHub.jsx
@@ -54,7 +54,7 @@ export default function LeagueHub({
   const tradeDeadline = useMemo(() => buildTradeDeadlineContext({ league, team: userTeam, roster: userTeam?.roster }), [league, userTeam]);
 
   return (
-    <div className="app-screen-stack">
+    <div className="app-screen-stack league-hub-mobile-surface pfgm-density-surface">
       <HeroCard
         eyebrow={`${league?.year ?? 'Season'} · Week ${league?.week ?? 1}`}
         title="League Season Pulse"

--- a/src/ui/components/MobileNav.jsx
+++ b/src/ui/components/MobileNav.jsx
@@ -155,7 +155,7 @@ export default function MobileNav({ activeSection, activeTab, onSectionChange, o
             return setMenuOpen((prev) => !prev);
           };
           return (
-            <button key={tab.id} className={`mobile-bottom-tab premium-bottom-tab ${isActive ? 'active' : ''}`} onClick={onClick} aria-label={tab.label}>
+            <button key={tab.id} className={`mobile-bottom-tab premium-bottom-tab ${isActive ? 'active' : ''}`} onClick={onClick} aria-label={tab.label} aria-current={isActive ? 'page' : undefined}>
               <Icon size={20} />
               <span className="mobile-bottom-label">{tab.label}</span>
               {(tab.id === 'Team' && hasTeamAlerts) || (tab.id === 'League' && hasLeagueAlerts) ? <span className="mobile-bottom-tab__badge" aria-hidden /> : null}

--- a/src/ui/components/MobileNav.test.jsx
+++ b/src/ui/components/MobileNav.test.jsx
@@ -61,7 +61,7 @@ describe('MobileNav', () => {
     );
 
     expect(html).toContain('premium-bottom-nav');
-    expect(html).toContain('premium-bottom-tab active" aria-label="Team"');
+    expect(html).toContain('premium-bottom-tab active" aria-label="Team" aria-current="page"');
     expect(html).toContain('Team');
     expect(html).toContain('mobile-bottom-tab__badge');
   });

--- a/src/ui/components/NewsFeed.jsx
+++ b/src/ui/components/NewsFeed.jsx
@@ -230,7 +230,7 @@ export default function NewsFeed({ league, actions, mode = 'full', segment = 'al
   }
 
   return (
-    <div className="app-screen-stack">
+    <div className="app-screen-stack news-feed-mobile-surface pfgm-density-surface">
       {newsError ? (
         <div
           role="alert"

--- a/src/ui/components/TeamHub.jsx
+++ b/src/ui/components/TeamHub.jsx
@@ -110,7 +110,7 @@ export default function TeamHub({ league, actions, onOpenGameDetail, onPlayerSel
     : 'No critical lineup blockers detected';
 
   return (
-    <div className="app-screen-stack">
+    <div className="app-screen-stack team-hub-mobile-surface pfgm-density-surface">
       <HeroCard
         eyebrow={`${league?.year ?? 'Season'} · Week ${league?.week ?? '—'} · ${league?.phase ?? 'regular'}`}
         title="Lineup Check Before Kickoff"

--- a/src/ui/components/WeeklyResultsCenter.jsx
+++ b/src/ui/components/WeeklyResultsCenter.jsx
@@ -315,7 +315,7 @@ export default function WeeklyResultsCenter({ league, initialWeek = null, lastRe
   }
 
   return (
-    <div className="app-screen-stack app-weekly-results-screen" data-testid="weekly-results">
+    <div className="app-screen-stack app-weekly-results-screen pfgm-density-surface" data-testid="weekly-results">
       <HeroCard
         eyebrow="Franchise HQ • Results"
         title="Weekly Results"

--- a/src/ui/main.jsx
+++ b/src/ui/main.jsx
@@ -12,6 +12,7 @@ import './styles/mobile.css';
 import './styles/app-mobile.css';
 import './styles/screen-system.css';
 import './styles/stadium-theme.css';
+import './styles/mobile-shell-density.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/ui/styles/mobile-shell-density.css
+++ b/src/ui/styles/mobile-shell-density.css
@@ -1,0 +1,244 @@
+/* PFGM-inspired mobile shell and density layer.
+ * Intentionally loaded last: this small, mobile-only layer converts the shared
+ * screen primitives without changing their component APIs or desktop layouts. */
+@media (max-width: 767px) {
+  :root {
+    --mobile-shell-navy: #0d1522;
+    --mobile-content-black: #07090d;
+    --mobile-row-charcoal: #171c24;
+    --mobile-row-charcoal-alt: #11161d;
+    --mobile-divider: rgba(255, 255, 255, 0.14);
+    --mobile-action-green: #30b866;
+    --mobile-action-green-hover: #3dcc75;
+  }
+
+  html,
+  body {
+    max-width: 100%;
+    overflow-x: clip;
+    background: var(--mobile-content-black);
+  }
+
+  .app-shell {
+    max-width: 100%;
+    padding: 0 0 calc(76px + env(safe-area-inset-bottom, 0px));
+    background: var(--mobile-content-black);
+  }
+
+  .app-header {
+    position: relative;
+    gap: 8px;
+    margin: 0;
+    padding: calc(10px + env(safe-area-inset-top, 0px)) 12px 10px;
+    border: 0;
+    border-bottom: 1px solid var(--mobile-divider);
+    border-radius: 0;
+    background: var(--mobile-shell-navy);
+    backdrop-filter: none;
+  }
+
+  .app-title {
+    color: var(--text);
+    font-size: 1.05rem;
+    letter-spacing: .045em;
+    text-transform: uppercase;
+    background: none;
+    -webkit-text-fill-color: currentColor;
+  }
+
+  .app-season-info { gap: 6px; }
+  .app-phase-badge {
+    padding: 2px 7px;
+    border: 1px solid var(--mobile-divider);
+    border-radius: 2px;
+    background: var(--mobile-row-charcoal);
+    color: var(--text-muted);
+  }
+
+  .app-header-actions { gap: 6px; }
+  .app-header-actions .btn { min-height: 44px; border-radius: 3px; }
+  .app-action-primary,
+  .btn-primary {
+    border-color: color-mix(in srgb, var(--mobile-action-green) 78%, white 22%);
+    background: var(--mobile-action-green);
+    color: #04130a;
+    box-shadow: none;
+  }
+  .app-action-primary:hover,
+  .btn-primary:hover { background: var(--mobile-action-green-hover); }
+  .app-action-secondary,
+  .btn-secondary {
+    border-color: var(--mobile-divider);
+    background: var(--mobile-row-charcoal);
+    color: var(--text);
+    box-shadow: none;
+  }
+
+  .app-screen-stack { gap: 8px; min-width: 0; }
+  .app-screen-header {
+    gap: 5px;
+    padding: 11px 12px 10px;
+    border: 0;
+    border-bottom: 2px solid var(--mobile-divider);
+    border-radius: 0;
+    background: var(--mobile-shell-navy);
+    box-shadow: none;
+  }
+  .app-screen-header__title {
+    font-size: 1.25rem;
+    font-weight: 900;
+    letter-spacing: .025em;
+    line-height: 1.1;
+    text-transform: uppercase;
+  }
+  .app-screen-header__eyebrow,
+  .app-section-header__eyebrow { color: var(--mobile-action-green); }
+  .app-screen-meta-pill { padding: 3px 8px; border-radius: 2px; }
+
+  .app-section-header {
+    align-items: center;
+    padding: 7px 10px;
+    border-left: 3px solid var(--mobile-action-green);
+    border-bottom: 1px solid var(--mobile-divider);
+    background: var(--mobile-shell-navy);
+  }
+  .app-section-header__title {
+    margin: 0;
+    font-size: .9rem;
+    font-weight: 850;
+    letter-spacing: .055em;
+    text-transform: uppercase;
+  }
+
+  .card,
+  .app-section-card,
+  .app-hero-card,
+  .app-game-center-card,
+  .app-compact-list-row,
+  .app-compact-insight,
+  .team-hub-lineup-frame {
+    border-color: var(--mobile-divider);
+    border-radius: 2px;
+    background: var(--mobile-row-charcoal-alt);
+    box-shadow: none;
+  }
+  .card::before { display: none; }
+  .app-section-card { gap: 7px; padding: 10px 12px; }
+  .app-section-card__header { padding-bottom: 6px; border-bottom: 1px solid var(--mobile-divider); }
+  .app-section-card__title { font-size: .9rem; letter-spacing: .035em; text-transform: uppercase; }
+  .app-row-stack { gap: 1px; }
+  .app-row-stack > :nth-child(odd),
+  .app-news-compact-list > :nth-child(odd),
+  .app-weekly-results-grid > :nth-child(odd) { background-color: var(--mobile-row-charcoal); }
+  .app-compact-list-row { min-height: 48px; padding: 7px 10px; }
+  .app-game-center-card { gap: 6px; padding: 9px 10px; }
+
+  .standings-tabs,
+  .app-section-subnav,
+  .dashboard-main-tabs {
+    gap: 0;
+    padding: 0;
+    border: 0;
+    border-bottom: 1px solid var(--mobile-divider);
+    border-radius: 0;
+    background: #090c11;
+    scrollbar-width: none;
+  }
+  .standings-tab,
+  .app-section-subnav__tab {
+    position: relative;
+    min-height: 44px;
+    padding: 9px 12px 8px;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    color: var(--text-muted);
+    box-shadow: none;
+    white-space: nowrap;
+  }
+  .standings-tab.active,
+  .app-section-subnav__tab.active {
+    border: 0;
+    background: transparent;
+    color: var(--text);
+    box-shadow: inset 0 -3px 0 var(--mobile-action-green);
+    font-weight: 800;
+  }
+
+  .hq-compact-layout { background: var(--mobile-content-black); }
+  .hq-compact-topbar {
+    height: 44px;
+    margin-bottom: 4px;
+    border-bottom: 1px solid var(--mobile-divider);
+    border-radius: 0;
+    background: var(--mobile-shell-navy);
+  }
+  .hq-topbar-seg { min-height: 44px; border-color: var(--mobile-divider); }
+  .hq-standings-mini { border-radius: 2px; }
+  .hq-standings-mini__row:nth-child(odd) { background: var(--mobile-row-charcoal); }
+  .hq-standings-mini__row.is-user {
+    border-left: 3px solid var(--mobile-action-green);
+    background: color-mix(in srgb, var(--mobile-action-green) 12%, var(--mobile-row-charcoal));
+  }
+  .hq-standings-mini__row.is-user .hq-standings-mini__abbr { color: var(--text); }
+  .team-hub-alert-list { gap: 1px; }
+  .team-hub-alert { border-radius: 2px; }
+
+  .app-news-filter-row {
+    gap: 0;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    border-bottom: 1px solid var(--mobile-divider);
+    scrollbar-width: none;
+  }
+  .app-news-filter-row .btn {
+    flex: 0 0 auto;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+  }
+  .app-news-filter-row .btn.is-active {
+    color: var(--text);
+    border: 0;
+    box-shadow: inset 0 -3px 0 var(--mobile-action-green);
+  }
+
+  .premium-bottom-nav {
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    max-width: none;
+    min-height: 64px;
+    margin: 0;
+    padding: 4px max(4px, env(safe-area-inset-right)) calc(4px + env(safe-area-inset-bottom)) max(4px, env(safe-area-inset-left));
+    border: 0;
+    border-top: 1px solid var(--mobile-divider);
+    border-radius: 0;
+    background: #171b21;
+    box-shadow: 0 -8px 24px rgba(0, 0, 0, .42);
+  }
+  .premium-bottom-tab { min-height: 52px; border-radius: 0; color: var(--text-muted); }
+  .premium-bottom-tab.active {
+    background: transparent;
+    color: var(--mobile-action-green);
+    box-shadow: inset 0 3px 0 var(--mobile-action-green);
+  }
+  .premium-bottom-tab.active .mobile-bottom-label { color: var(--text); font-weight: 800; }
+  .mobile-bottom-label { font-size: 10px; letter-spacing: .025em; }
+
+  .mobile-nav-panel-premium {
+    border-color: var(--mobile-divider);
+    background: var(--mobile-shell-navy);
+  }
+  .mobile-nav-item-premium {
+    border-radius: 2px;
+    border-bottom: 1px solid var(--mobile-divider);
+    background: var(--mobile-row-charcoal-alt);
+  }
+
+  :is(.standings-tab, .app-section-subnav__tab, .premium-bottom-tab, .mobile-nav-item-premium):focus-visible {
+    outline: 2px solid var(--mobile-action-green);
+    outline-offset: -2px;
+  }
+}

--- a/src/ui/styles/mobile-shell-density.css
+++ b/src/ui/styles/mobile-shell-density.css
@@ -15,11 +15,12 @@
   html,
   body {
     max-width: 100%;
-    overflow-x: clip;
     background: var(--mobile-content-black);
   }
 
   .app-shell {
+    box-sizing: border-box;
+    width: 100%;
     max-width: 100%;
     padding: 0 0 calc(76px + env(safe-area-inset-bottom, 0px));
     background: var(--mobile-content-black);
@@ -57,25 +58,36 @@
 
   .app-header-actions { gap: 6px; }
   .app-header-actions .btn { min-height: 44px; border-radius: 3px; }
-  .app-action-primary,
-  .btn-primary {
+  .app-header .app-action-primary,
+  .pfgm-density-surface .app-action-primary,
+  .pfgm-density-surface .btn-primary {
     border-color: color-mix(in srgb, var(--mobile-action-green) 78%, white 22%);
     background: var(--mobile-action-green);
     color: #04130a;
     box-shadow: none;
   }
-  .app-action-primary:hover,
-  .btn-primary:hover { background: var(--mobile-action-green-hover); }
-  .app-action-secondary,
-  .btn-secondary {
+  .app-header .app-action-primary:hover,
+  .pfgm-density-surface .app-action-primary:hover,
+  .pfgm-density-surface .btn-primary:hover { background: var(--mobile-action-green-hover); }
+  .pfgm-density-surface .app-action-secondary,
+  .pfgm-density-surface .btn-secondary {
     border-color: var(--mobile-divider);
     background: var(--mobile-row-charcoal);
     color: var(--text);
     box-shadow: none;
   }
 
-  .app-screen-stack { gap: 8px; min-width: 0; }
-  .app-screen-header {
+  .pfgm-density-surface,
+  .pfgm-density-surface .app-screen-stack,
+  .pfgm-density-surface.app-screen-stack {
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+  }
+  .pfgm-density-surface .app-screen-stack,
+  .pfgm-density-surface.app-screen-stack { gap: 8px; }
+  .pfgm-density-surface .app-screen-header {
     gap: 5px;
     padding: 11px 12px 10px;
     border: 0;
@@ -84,25 +96,25 @@
     background: var(--mobile-shell-navy);
     box-shadow: none;
   }
-  .app-screen-header__title {
+  .pfgm-density-surface .app-screen-header__title {
     font-size: 1.25rem;
     font-weight: 900;
     letter-spacing: .025em;
     line-height: 1.1;
     text-transform: uppercase;
   }
-  .app-screen-header__eyebrow,
-  .app-section-header__eyebrow { color: var(--mobile-action-green); }
-  .app-screen-meta-pill { padding: 3px 8px; border-radius: 2px; }
+  .pfgm-density-surface .app-screen-header__eyebrow,
+  .pfgm-density-surface .app-section-header__eyebrow { color: var(--mobile-action-green); }
+  .pfgm-density-surface .app-screen-meta-pill { padding: 3px 8px; border-radius: 2px; }
 
-  .app-section-header {
+  .pfgm-density-surface .app-section-header {
     align-items: center;
     padding: 7px 10px;
     border-left: 3px solid var(--mobile-action-green);
     border-bottom: 1px solid var(--mobile-divider);
     background: var(--mobile-shell-navy);
   }
-  .app-section-header__title {
+  .pfgm-density-surface .app-section-header__title {
     margin: 0;
     font-size: .9rem;
     font-weight: 850;
@@ -110,42 +122,42 @@
     text-transform: uppercase;
   }
 
-  .card,
-  .app-section-card,
-  .app-hero-card,
-  .app-game-center-card,
-  .app-compact-list-row,
-  .app-compact-insight,
-  .team-hub-lineup-frame {
+  .pfgm-density-surface .app-section-card,
+  .pfgm-density-surface .app-hero-card,
+  .pfgm-density-surface .app-game-center-card,
+  .pfgm-density-surface .app-compact-list-row,
+  .pfgm-density-surface .app-compact-insight,
+  .pfgm-density-surface .team-hub-lineup-frame {
     border-color: var(--mobile-divider);
     border-radius: 2px;
     background: var(--mobile-row-charcoal-alt);
     box-shadow: none;
   }
-  .card::before { display: none; }
-  .app-section-card { gap: 7px; padding: 10px 12px; }
-  .app-section-card__header { padding-bottom: 6px; border-bottom: 1px solid var(--mobile-divider); }
-  .app-section-card__title { font-size: .9rem; letter-spacing: .035em; text-transform: uppercase; }
-  .app-row-stack { gap: 1px; }
-  .app-row-stack > :nth-child(odd),
-  .app-news-compact-list > :nth-child(odd),
-  .app-weekly-results-grid > :nth-child(odd) { background-color: var(--mobile-row-charcoal); }
-  .app-compact-list-row { min-height: 48px; padding: 7px 10px; }
-  .app-game-center-card { gap: 6px; padding: 9px 10px; }
+  .pfgm-density-surface .app-section-card { gap: 7px; padding: 10px 12px; }
+  .pfgm-density-surface .app-section-card__header { padding-bottom: 6px; border-bottom: 1px solid var(--mobile-divider); }
+  .pfgm-density-surface .app-section-card__title { font-size: .9rem; letter-spacing: .035em; text-transform: uppercase; }
+  .pfgm-density-surface .app-row-stack { gap: 1px; min-width: 0; max-width: 100%; }
+  .pfgm-density-surface .app-row-stack > :nth-child(odd),
+  .pfgm-density-surface .app-news-compact-list > :nth-child(odd),
+  .pfgm-density-surface .app-weekly-results-grid > :nth-child(odd) { background-color: var(--mobile-row-charcoal); }
+  .pfgm-density-surface .app-compact-list-row { min-width: 0; max-width: 100%; min-height: 48px; padding: 7px 10px; }
+  .pfgm-density-surface .app-game-center-card { min-width: 0; max-width: 100%; gap: 6px; padding: 9px 10px; }
 
-  .standings-tabs,
-  .app-section-subnav,
-  .dashboard-main-tabs {
+  .pfgm-density-surface .standings-tabs,
+  .pfgm-density-surface .app-section-subnav,
+  .pfgm-density-surface .dashboard-main-tabs {
     gap: 0;
     padding: 0;
     border: 0;
     border-bottom: 1px solid var(--mobile-divider);
     border-radius: 0;
     background: #090c11;
+    max-width: 100%;
+    overflow-x: auto;
     scrollbar-width: none;
   }
-  .standings-tab,
-  .app-section-subnav__tab {
+  .pfgm-density-surface .standings-tab,
+  .pfgm-density-surface .app-section-subnav__tab {
     position: relative;
     min-height: 44px;
     padding: 9px 12px 8px;
@@ -156,8 +168,8 @@
     box-shadow: none;
     white-space: nowrap;
   }
-  .standings-tab.active,
-  .app-section-subnav__tab.active {
+  .pfgm-density-surface .standings-tab.active,
+  .pfgm-density-surface .app-section-subnav__tab.active {
     border: 0;
     background: transparent;
     color: var(--text);
@@ -165,39 +177,40 @@
     font-weight: 800;
   }
 
-  .hq-compact-layout { background: var(--mobile-content-black); }
-  .hq-compact-topbar {
+  .pfgm-density-surface.hq-compact-layout,
+  .pfgm-density-surface .hq-compact-layout { background: var(--mobile-content-black); }
+  .pfgm-density-surface .hq-compact-topbar {
     height: 44px;
     margin-bottom: 4px;
     border-bottom: 1px solid var(--mobile-divider);
     border-radius: 0;
     background: var(--mobile-shell-navy);
   }
-  .hq-topbar-seg { min-height: 44px; border-color: var(--mobile-divider); }
-  .hq-standings-mini { border-radius: 2px; }
-  .hq-standings-mini__row:nth-child(odd) { background: var(--mobile-row-charcoal); }
-  .hq-standings-mini__row.is-user {
+  .pfgm-density-surface .hq-topbar-seg { min-height: 44px; border-color: var(--mobile-divider); }
+  .pfgm-density-surface .hq-standings-mini { border-radius: 2px; }
+  .pfgm-density-surface .hq-standings-mini__row:nth-child(odd) { background: var(--mobile-row-charcoal); }
+  .pfgm-density-surface .hq-standings-mini__row.is-user {
     border-left: 3px solid var(--mobile-action-green);
     background: color-mix(in srgb, var(--mobile-action-green) 12%, var(--mobile-row-charcoal));
   }
-  .hq-standings-mini__row.is-user .hq-standings-mini__abbr { color: var(--text); }
-  .team-hub-alert-list { gap: 1px; }
-  .team-hub-alert { border-radius: 2px; }
+  .pfgm-density-surface .hq-standings-mini__row.is-user .hq-standings-mini__abbr { color: var(--text); }
+  .pfgm-density-surface .team-hub-alert-list { gap: 1px; }
+  .pfgm-density-surface .team-hub-alert { border-radius: 2px; }
 
-  .app-news-filter-row {
+  .pfgm-density-surface .app-news-filter-row {
     gap: 0;
     flex-wrap: nowrap;
     overflow-x: auto;
     border-bottom: 1px solid var(--mobile-divider);
     scrollbar-width: none;
   }
-  .app-news-filter-row .btn {
+  .pfgm-density-surface .app-news-filter-row .btn {
     flex: 0 0 auto;
     border: 0;
     border-radius: 0;
     background: transparent;
   }
-  .app-news-filter-row .btn.is-active {
+  .pfgm-density-surface .app-news-filter-row .btn.is-active {
     color: var(--text);
     border: 0;
     box-shadow: inset 0 -3px 0 var(--mobile-action-green);
@@ -237,7 +250,8 @@
     background: var(--mobile-row-charcoal-alt);
   }
 
-  :is(.standings-tab, .app-section-subnav__tab, .premium-bottom-tab, .mobile-nav-item-premium):focus-visible {
+  .pfgm-density-surface :is(.standings-tab, .app-section-subnav__tab):focus-visible,
+  :is(.premium-bottom-tab, .mobile-nav-item-premium):focus-visible {
     outline: 2px solid var(--mobile-action-green);
     outline-offset: -2px;
   }

--- a/src/ui/styles/mobile-shell-density.test.js
+++ b/src/ui/styles/mobile-shell-density.test.js
@@ -1,0 +1,20 @@
+/** @vitest-environment node */
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(new URL('./mobile-shell-density.css', import.meta.url), 'utf8');
+
+describe('mobile shell density scope', () => {
+  it('does not flatten the generic card primitive', () => {
+    expect(css).not.toMatch(/(^|,)\s*\.card\s*(,|\{)/m);
+    expect(css).not.toContain('.card::before');
+    expect(css).toContain('.pfgm-density-surface .app-section-card');
+  });
+
+  it('does not mask document-level horizontal overflow', () => {
+    const documentRule = css.match(/html,\s*\n\s*body\s*\{([^}]*)\}/)?.[1] ?? '';
+    expect(documentRule).not.toMatch(/overflow-x\s*:/);
+    expect(css).toContain('.pfgm-density-surface .standings-tabs');
+    expect(css).toContain('overflow-x: auto');
+  });
+});


### PR DESCRIPTION
### Motivation

- Improve the mobile visual hierarchy and information density to feel more like a compact, dark-native sports‑management shell inspired by Pro Football GM while preserving all existing interaction and navigation contracts. 
- Make a minimal, scoped change that converts shared shell primitives (headers, tabs, rows, cards, bottom nav) on mobile only without touching simulation, persistence, worker, or routing ownership.

### Description

- Added a small, mobile‑scoped stylesheet `src/ui/styles/mobile-shell-density.css` (loaded last in `src/ui/main.jsx`) that applies darker shell chrome, charcoal row bands, flattened section/cards, compact headers/tabs, green primary action, and a full‑width flat bottom nav for `max-width: 767px` only. 
- Preserved component APIs and behaviors; no route strings, save logic, worker code, or simulation logic was changed and no player/team data was invented; the sheet intentionally overrides only visual primitives (cards, rows, tabs, bottom nav) used by HQ, Team/roster surfaces, League Hub/Dashboard, News, and Weekly Results. 
- Accessibility and interaction: added `aria-current="page"` to the active bottom‑nav destination in `src/ui/components/MobileNav.jsx` and updated the server‑rendered MobileNav contract test (`src/ui/components/MobileNav.test.jsx`) to assert it; focus states and minimum target sizes (44px) are preserved. 
- Audit documentation was added at `docs/pfgm-inspired-mobile-shell-density-v1-audit.md` describing ownership, primitives changed, exact surfaces updated, deferred surfaces, and validation notes.

### Testing

- Ran the focused Vitest command covering MobileNav and related shell/navigation contracts: `npx vitest run src/ui/components/MobileNav.test.jsx src/ui/utils/shellNavigation.test.js src/ui/components/SaveSlotManager.test.jsx src/ui/components/LeagueHub.test.jsx src/ui/components/TeamHub.test.jsx src/ui/components/NewsFeed.test.jsx src/ui/components/__tests__/FranchiseHQ.test.jsx src/ui/components/__tests__/FranchiseHQMobileShell.test.jsx src/ui/components/__tests__/LeagueDashboard.playerProfileNavigation.test.jsx` — 9 files, 82 tests passed. 
- Ran the full unit suite: `npm run test:unit` — 472 files, 5,869 tests passed. 
- Infrastructure checks: `npm run check:sim-types` passed, `npm run build` completed (production build succeeded; repository‑documented large‑chunk warning emitted), and `npm run check:deploy` (Netlify parity/rules and offline Netlify CLI builds) completed; npm reported existing audit warnings (1 low, 5 high) but these were preexisting. 
- Mobile E2E could not be completed in this environment: `npx playwright test tests/e2e/mobile_navigation_integrity.spec.js` was blocked because the Chromium executable was not present, and `npx playwright install chromium` failed with HTTP 403 from the Playwright CDN, so no real‑browser 375px/390px/430px measurements or screenshots were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7aa642a138832da87a116650ac1c06)