### PR TITLE
Universal entity drill‑down V1 — truthful player/team/game links (League Hub)

### DIFF
--- a/docs/universal-clickability-entity-drilldown-v1-audit.md
+++ b/docs/universal-clickability-entity-drilldown-v1-audit.md
@@ -1,0 +1,40 @@
+# Universal Clickability & Entity Drill-Down V1 audit
+
+## Baseline
+
+The implementation started from `1d1fe78`, the merge commit for PR #1747. Its history also contains `94596b5`, the merge commit for PR #1745. No open or superseded branch was used.
+
+## Routing ownership
+
+- **Players:** `playerProfileNavigation.js` validates profile identity and invokes the callback owned by `LeagueDashboard`, which opens the existing `PlayerProfileModalBoundary`/`PlayerProfile` flow.
+- **Teams:** `LeagueDashboard` owns `handleTeamSelect` and the existing `TeamProfile` surface. Entity controls only call that callback; they do not introduce route state.
+- **Games:** `boxScoreAccess.js` owns canonical game identity, archive-quality presentation, and dispatch to the existing Game Book. A final score with only compact/legacy score data is now factual text rather than evidence of a drill-down archive.
+- **Management:** `managementScreenRouting.js` and `shellNavigation.js` remain the destination contract. The Trade Deadline CTA continues to use the existing Trade Center callback.
+
+The requested `src/ui/utils/tradeDeadlineContext.js` does not exist on live main. The live equivalent is `src/core/tradeDeadlineContext.js`, already consumed by `LeagueHub`.
+
+## Existing and inconsistent surfaces
+
+Player drill-down already existed in News, Weekly Results performers, League Leaders, roster/contract surfaces, and several activity views. Team drill-down already existed in standings, stats, schedules, and dashboard-owned profile routes. Weekly Results and League Hub already used the Game Book resolver, although score-only records were still treated as openable.
+
+The League Hub overview was the clearest weekly inconsistency: trending teams, Award Watch players, injury players, and next-week teams were rendered as dead text while adjacent content supported drill-down. Spotlight games also rendered an unconditional button even when resolver evidence was insufficient.
+
+## Updated surfaces
+
+- Added shared player, team, and game entity controls with honest plain-text fallback.
+- Connected League Hub Trending Teams, Award Watch, League Health, and Next Week entities to existing profile callbacks.
+- Routed Spotlight Games through the same Game Book availability gate used elsewhere.
+- Tightened Game Book availability so imported/legacy score-only records do not advertise detail that is not present.
+- Added minimal hover, keyboard-focus, and cursor affordances without changing shell density or semantic tones.
+
+## Deferred deliberately
+
+Franchise HQ, News, Weekly Results, Team Hub, League Stats/Leaders, standings, and schedule already contain substantial working entity/profile or Game Book pathways. Converting every legacy row in one change would increase nested-interactive and regression risk. A later increment can migrate those existing one-off controls onto the shared component after their surface-specific row semantics are audited.
+
+## Accessibility and mobile
+
+Actionable entities use native buttons, inherit row typography, expose optional labels for ambiguous visible text, retain visible `:focus-visible` outlines, and avoid wrapping existing row controls. Non-actionable entities are spans and never enter the tab order. Text itself is the tap target; no tiny icon-only control was added.
+
+## Validation
+
+Focused entity-link and Game Book resolver tests cover valid and invalid player/team identity, detailed versus score-only games, callback dispatch, and accessible naming. The focused tests (18 tests), full unit suite (474 files / 5,882 tests), sim type check, production build, and deploy parity passed locally. The existing mobile League Hub Playwright source was invoked, but browser execution was blocked because Chromium was absent; installation retries were rejected by the download host with HTTP 403.

--- a/docs/universal-clickability-entity-drilldown-v1-audit.md
+++ b/docs/universal-clickability-entity-drilldown-v1-audit.md
@@ -21,15 +21,15 @@ The League Hub overview was the clearest weekly inconsistency: trending teams, A
 
 ## Updated surfaces
 
-- Added shared player, team, and game entity controls with honest plain-text fallback.
-- Connected League Hub Trending Teams, Award Watch, League Health, and Next Week entities to existing profile callbacks.
+- Added shared player, team, and game entity controls with honest plain-text fallback. The reusable primitive is intentionally rolled out only in League Hub for this PR.
+- Connected League Hub Trending Teams, Award Watch, League Health, and Next Week entities to existing profile callbacks. Team links now only activate for finite numeric IDs or numeric-string IDs supported by existing team identity lookups; booleans, arrays, objects, `NaN`, blank strings, and sentinel strings remain inert.
 - Routed Spotlight Games through the same Game Book availability gate used elsewhere.
 - Tightened Game Book availability so imported/legacy score-only records do not advertise detail that is not present.
-- Added minimal hover, keyboard-focus, and cursor affordances without changing shell density or semantic tones.
+- Added minimal hover, keyboard-focus, and cursor affordances without changing shell density or semantic tones. Inline reset styling is scoped away from `.btn` variants so the League Hub `Open Game` CTA keeps its small-button border, padding, background, color, and font styling.
 
 ## Deferred deliberately
 
-Franchise HQ, News, Weekly Results, Team Hub, League Stats/Leaders, standings, and schedule already contain substantial working entity/profile or Game Book pathways. Converting every legacy row in one change would increase nested-interactive and regression risk. A later increment can migrate those existing one-off controls onto the shared component after their surface-specific row semantics are audited.
+Franchise HQ, News, Weekly Results, Team Hub, League Stats/Leaders, Award Races, standings, and schedule remain deferred. Several already contain substantial working entity/profile or Game Book pathways, but this PR intentionally keeps the first rollout League-Hub-only. Converting every legacy row in one change would increase nested-interactive and regression risk. A later increment can migrate those existing one-off controls onto the shared component after their surface-specific row semantics are audited.
 
 ## Accessibility and mobile
 
@@ -37,4 +37,4 @@ Actionable entities use native buttons, inherit row typography, expose optional 
 
 ## Validation
 
-Focused entity-link and Game Book resolver tests cover valid and invalid player/team identity, detailed versus score-only games, callback dispatch, and accessible naming. The focused tests (18 tests), full unit suite (474 files / 5,882 tests), sim type check, production build, and deploy parity passed locally. The existing mobile League Hub Playwright source was invoked, but browser execution was blocked because Chromium was absent; installation retries were rejected by the download host with HTTP 403.
+Focused entity-link, CSS-scope, and Game Book resolver tests cover valid and invalid player/team identity, detailed versus score-only games, callback dispatch, accessible naming, and preservation of explicit `.btn` styling. The focused tests (28 tests across EntityLink, LeagueHub, and CSS-scope coverage), full unit suite (475 files / 5,896 tests), sim type check, production build, and deploy parity passed locally. The existing mobile League Hub Playwright source was invoked, but browser execution was blocked because Chromium was absent; installation retries were rejected by the download host with HTTP 403.

--- a/src/ui/components/EntityLink.jsx
+++ b/src/ui/components/EntityLink.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { buildCompletedGamePresentation, openResolvedBoxScore } from '../utils/boxScoreAccess.js';
+import { hasValidPlayerProfileId, openPlayerProfile } from '../utils/playerProfileNavigation.js';
+
+function hasValidEntityId(value) {
+  if (value == null) return false;
+  const normalized = String(value).trim();
+  return normalized !== '' && normalized !== 'NaN' && normalized !== 'undefined'
+    && normalized !== '__missing_player__' && normalized !== '__missing_team__';
+}
+
+function EntityButton({ actionable, children, ariaLabel, onClick, className = '' }) {
+  if (!actionable) return <span className={className}>{children}</span>;
+  return (
+    <button
+      type="button"
+      className={`app-entity-link ${className}`.trim()}
+      aria-label={ariaLabel}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function PlayerEntityLink({ playerId, children, onPlayerSelect, context = {}, ariaLabel, className }) {
+  const actionable = hasValidPlayerProfileId(playerId) && typeof onPlayerSelect === 'function';
+  return <EntityButton actionable={actionable} ariaLabel={ariaLabel} className={className} onClick={() => openPlayerProfile(playerId, onPlayerSelect, context)}>{children}</EntityButton>;
+}
+
+export function TeamEntityLink({ teamId, children, onTeamSelect, ariaLabel, className }) {
+  const actionable = hasValidEntityId(teamId) && typeof onTeamSelect === 'function';
+  return <EntityButton actionable={actionable} ariaLabel={ariaLabel} className={className} onClick={() => onTeamSelect(teamId)}>{children}</EntityButton>;
+}
+
+export function GameEntityLink({ game, context = {}, children, unavailableChildren = children, onGameSelect, ariaLabel, className }) {
+  const presentation = buildCompletedGamePresentation(game, context);
+  const actionable = presentation.canOpen && presentation.archiveQuality !== 'score'
+    && presentation.archiveQuality !== 'missing' && typeof onGameSelect === 'function';
+  if (!actionable) return <span>{unavailableChildren}</span>;
+  return <EntityButton actionable ariaLabel={ariaLabel} className={className} onClick={() => openResolvedBoxScore(game, context, onGameSelect)}>{children}</EntityButton>;
+}

--- a/src/ui/components/EntityLink.jsx
+++ b/src/ui/components/EntityLink.jsx
@@ -2,11 +2,19 @@ import React from 'react';
 import { buildCompletedGamePresentation, openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 import { hasValidPlayerProfileId, openPlayerProfile } from '../utils/playerProfileNavigation.js';
 
-function hasValidEntityId(value) {
-  if (value == null) return false;
-  const normalized = String(value).trim();
-  return normalized !== '' && normalized !== 'NaN' && normalized !== 'undefined'
-    && normalized !== '__missing_player__' && normalized !== '__missing_team__';
+export function hasValidTeamId(value) {
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value !== 'string') return false;
+  const normalized = value.trim();
+  if (normalized === '') return false;
+  if ([
+    'NaN',
+    'undefined',
+    'null',
+    '__missing_player__',
+    '__missing_team__',
+  ].includes(normalized)) return false;
+  return /^\d+$/.test(normalized);
 }
 
 function EntityButton({ actionable, children, ariaLabel, onClick, className = '' }) {
@@ -29,7 +37,7 @@ export function PlayerEntityLink({ playerId, children, onPlayerSelect, context =
 }
 
 export function TeamEntityLink({ teamId, children, onTeamSelect, ariaLabel, className }) {
-  const actionable = hasValidEntityId(teamId) && typeof onTeamSelect === 'function';
+  const actionable = hasValidTeamId(teamId) && typeof onTeamSelect === 'function';
   return <EntityButton actionable={actionable} ariaLabel={ariaLabel} className={className} onClick={() => onTeamSelect(teamId)}>{children}</EntityButton>;
 }
 

--- a/src/ui/components/LeagueHub.jsx
+++ b/src/ui/components/LeagueHub.jsx
@@ -6,8 +6,8 @@ import { buildNewsDeskModel } from '../utils/newsDesk.js';
 import { buildLeagueSeasonPulse } from '../utils/leagueSeasonPulse.js';
 import { buildWeeklyLeagueRecap } from '../utils/weeklyLeagueRecap.js';
 import { CompactListRow, StatusChip, HeroCard, SectionCard, StatStrip, CompactInsightCard } from './ScreenSystem.jsx';
-import { openResolvedBoxScore } from '../utils/boxScoreAccess.js';
 import { buildTradeDeadlineContext } from '../../core/tradeDeadlineContext.js';
+import { GameEntityLink, PlayerEntityLink, TeamEntityLink } from './EntityLink.jsx';
 
 const LEAGUE_SECTIONS = ['Overview', 'Results', 'Standings', 'News', 'Leaders', 'Coaching'];
 
@@ -22,6 +22,7 @@ export default function LeagueHub({
   initialSection = 'Overview',
   onOpenGameDetail,
   onPlayerSelect,
+  onTeamSelect,
   renderStandings,
   renderResults,
   onNavigateTrade,
@@ -83,15 +84,15 @@ export default function LeagueHub({
           </SectionCard>}
 
           {seasonPulse.availableData.trends && <SectionCard title="Trending Teams" subtitle="Only established multi-game runs are shown." variant="compact">
-            <div className="app-row-stack">{seasonPulse.trendingTeams.map((trend) => <CompactListRow key={`${trend.label}-${trend.teamId}`} title={trend.reason} subtitle={trend.label} meta={<StatusChip label={trend.value} tone={trend.label === 'Losing streak' ? 'warning' : 'ok'} />} />)}</div>
+            <div className="app-row-stack">{seasonPulse.trendingTeams.map((trend) => <CompactListRow key={`${trend.label}-${trend.teamId}`} title={<TeamEntityLink teamId={trend.teamId} onTeamSelect={onTeamSelect} ariaLabel={`Open team profile: ${trend.reason}`}>{trend.reason}</TeamEntityLink>} subtitle={trend.label} meta={<StatusChip label={trend.value} tone={trend.label === 'Losing streak' ? 'warning' : 'ok'} />} />)}</div>
           </SectionCard>}
 
           {seasonPulse.availableData.awards && <SectionCard title="Award Watch" subtitle="Leaders from the league's recorded award boards." variant="compact">
-            <div className="app-row-stack">{seasonPulse.awardWatch.map((award) => <CompactListRow key={award.award} title={award.playerName} subtitle={[award.position, award.team].filter(Boolean).join(' · ')} meta={<StatusChip label={award.award} tone="league" />} />)}</div>
+            <div className="app-row-stack">{seasonPulse.awardWatch.map((award) => <CompactListRow key={award.award} title={<PlayerEntityLink playerId={award.playerId} onPlayerSelect={onPlayerSelect} context={{ source: 'league_award_watch' }}>{award.playerName}</PlayerEntityLink>} subtitle={[award.position, award.team].filter(Boolean).join(' · ')} meta={<StatusChip label={award.award} tone="league" />} />)}</div>
           </SectionCard>}
 
           {seasonPulse.availableData.injuries && <SectionCard title="League Health" subtitle="Longest active recorded absences." variant="compact">
-            <div className="app-row-stack">{seasonPulse.majorInjuries.map((injury) => <CompactListRow key={injury.playerId} title={injury.playerName} subtitle={[injury.position, injury.injury].filter(Boolean).join(' · ')} meta={<StatusChip label={`${injury.weeksRemaining} wk${injury.weeksRemaining === 1 ? '' : 's'}`} tone="warning" />} />)}</div>
+            <div className="app-row-stack">{seasonPulse.majorInjuries.map((injury) => <CompactListRow key={injury.playerId} title={<PlayerEntityLink playerId={injury.playerId} onPlayerSelect={onPlayerSelect} context={{ source: 'league_health' }}>{injury.playerName}</PlayerEntityLink>} subtitle={[injury.position, injury.injury].filter(Boolean).join(' · ')} meta={<StatusChip label={`${injury.weeksRemaining} wk${injury.weeksRemaining === 1 ? '' : 's'}`} tone="warning" />} />)}</div>
           </SectionCard>}
 
           {seasonPulse.availableData.standings && <SectionCard title="Standings Context" subtitle={seasonPulse.omittedReasons.standingsMovement ?? 'Recorded movement this week.'} variant="compact">
@@ -99,7 +100,7 @@ export default function LeagueHub({
           </SectionCard>}
 
           {seasonPulse.nextWeekHighlight && <SectionCard title="Next Week" subtitle="One matchup selected by stable, factual rules." variant="compact">
-            <CompactListRow title={`${seasonPulse.nextWeekHighlight.awayTeam} at ${seasonPulse.nextWeekHighlight.homeTeam}`} subtitle={seasonPulse.nextWeekHighlight.reason} meta={<StatusChip label={`Week ${seasonPulse.nextWeekHighlight.week}`} tone="info" />} />
+            <CompactListRow title={<><TeamEntityLink teamId={seasonPulse.nextWeekHighlight.awayTeamId} onTeamSelect={onTeamSelect}>{seasonPulse.nextWeekHighlight.awayTeam}</TeamEntityLink>{' at '}<TeamEntityLink teamId={seasonPulse.nextWeekHighlight.homeTeamId} onTeamSelect={onTeamSelect}>{seasonPulse.nextWeekHighlight.homeTeam}</TeamEntityLink></>} subtitle={seasonPulse.nextWeekHighlight.reason} meta={<StatusChip label={`Week ${seasonPulse.nextWeekHighlight.week}`} tone="info" />} />
           </SectionCard>}
 
           {spotlightRows.length > 0 && <SectionCard title="Spotlight Games" subtitle="Open a recorded weekly result in Game Book." variant="compact">
@@ -109,13 +110,9 @@ export default function LeagueHub({
               subtitle={spotlight.reason ?? 'Weekly spotlight game'}
               meta={<StatusChip label={`Week ${spotlight.week ?? seasonPulse.week ?? week}`} tone="league" />}
             >
-              <button
-                type="button"
-                className="btn btn-sm"
-                onClick={() => openResolvedBoxScore(spotlight.game, { seasonId: league?.seasonId, week: spotlight.week ?? seasonPulse.week ?? week, source: 'league_overview_spotlight' }, onOpenGameDetail)}
-              >
+              <GameEntityLink className="btn btn-sm" unavailableChildren="Game Book unavailable" game={spotlight.game} context={{ seasonId: league?.seasonId, week: spotlight.week ?? seasonPulse.week ?? week, source: 'league_overview_spotlight' }} onGameSelect={onOpenGameDetail} ariaLabel={`Open Game Book: ${spotlight.score ?? 'spotlight game'}`}>
                 Open Game
-              </button>
+              </GameEntityLink>
             </CompactListRow>)}</div>
           </SectionCard>}
 

--- a/src/ui/components/LeagueHub.test.jsx
+++ b/src/ui/components/LeagueHub.test.jsx
@@ -18,7 +18,7 @@ const league = {
       {
         week: 4,
         games: [
-          { id: 'g1', home: 1, away: 2, played: true, homeScore: 24, awayScore: 21 },
+          { id: 'g1', home: 1, away: 2, played: true, homeScore: 24, awayScore: 21, driveSummary: [{ teamId: 1, result: 'TD', points: 7 }] },
         ],
       },
     ],
@@ -101,8 +101,19 @@ describe('LeagueHub', () => {
     const onOpenGameDetail = vi.fn();
     render(<LeagueHub league={league} onOpenGameDetail={onOpenGameDetail} />);
     const spotlights = screen.getByText('Spotlight Games').closest('section');
-    fireEvent.click(within(spotlights).getByRole('button', { name: 'Open Game' }));
+    fireEvent.click(within(spotlights).getByRole('button', { name: /Open Game Book:/ }));
     expect(onOpenGameDetail).toHaveBeenCalledWith('g1');
+  });
+
+  it('does not advertise Game Book for a score-only spotlight', () => {
+    const scoreOnlyLeague = {
+      ...league,
+      schedule: { weeks: [{ week: 4, games: [{ id: 'legacy-score', home: 1, away: 2, played: true, homeScore: 24, awayScore: 21 }] }] },
+    };
+    render(<LeagueHub league={scoreOnlyLeague} onOpenGameDetail={vi.fn()} />);
+    const spotlights = screen.getByText('Spotlight Games').closest('section');
+    expect(within(spotlights).queryByRole('button', { name: 'Open Game' })).toBeNull();
+    expect(within(spotlights).getByText('Game Book unavailable').tagName).toBe('SPAN');
   });
 
   it('renders factual deadline candidates and opens the existing Trade Center destination', () => {

--- a/src/ui/components/__tests__/EntityLink.test.jsx
+++ b/src/ui/components/__tests__/EntityLink.test.jsx
@@ -19,13 +19,38 @@ describe('entity drill-down links', () => {
     expect(screen.getByText('Unknown player')).toBeTruthy();
   });
 
-  it('opens a valid team and leaves invalid team identity inert', () => {
+  it('opens a valid numeric team id', () => {
     const onTeamSelect = vi.fn();
-    const { rerender } = render(<TeamEntityLink teamId="7" onTeamSelect={onTeamSelect}>SEA</TeamEntityLink>);
-    fireEvent.click(screen.getByRole('button', { name: 'SEA' }));
+    render(<TeamEntityLink teamId={7} onTeamSelect={onTeamSelect}>PIT</TeamEntityLink>);
+    fireEvent.click(screen.getByRole('button', { name: 'PIT' }));
+    expect(onTeamSelect).toHaveBeenCalledWith(7);
+  });
+
+  it('opens a valid numeric-string team id supported by team identity lookups', () => {
+    const onTeamSelect = vi.fn();
+    render(<TeamEntityLink teamId="7" onTeamSelect={onTeamSelect}>PIT</TeamEntityLink>);
+    fireEvent.click(screen.getByRole('button', { name: 'PIT' }));
     expect(onTeamSelect).toHaveBeenCalledWith('7');
-    rerender(<TeamEntityLink teamId="__missing_team__" onTeamSelect={onTeamSelect}>TBD</TeamEntityLink>);
+  });
+
+  it.each([
+    ['false boolean', false],
+    ['true boolean', true],
+    ['plain object', {}],
+    ['array', []],
+    ['NaN number', Number.NaN],
+    ['blank string', '   '],
+    ['NaN string', 'NaN'],
+    ['undefined string', 'undefined'],
+    ['null string', 'null'],
+    ['missing team sentinel', '__missing_team__'],
+    ['missing player sentinel', '__missing_player__'],
+  ])('renders %s team identity as inert text', (_label, teamId) => {
+    const onTeamSelect = vi.fn();
+    render(<TeamEntityLink teamId={teamId} onTeamSelect={onTeamSelect}>TBD</TeamEntityLink>);
     expect(screen.queryByRole('button')).toBeNull();
+    fireEvent.click(screen.getByText('TBD'));
+    expect(onTeamSelect).not.toHaveBeenCalled();
   });
 
   it('opens a resolvable detailed game but not a score-only archive', () => {

--- a/src/ui/components/__tests__/EntityLink.test.jsx
+++ b/src/ui/components/__tests__/EntityLink.test.jsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GameEntityLink, PlayerEntityLink, TeamEntityLink } from '../EntityLink.jsx';
+
+describe('entity drill-down links', () => {
+  afterEach(cleanup);
+  it('opens a valid player through the canonical callback and labels ambiguous text', () => {
+    const onPlayerSelect = vi.fn();
+    render(<PlayerEntityLink playerId={12} onPlayerSelect={onPlayerSelect} ariaLabel="Open player profile: QB1">QB1</PlayerEntityLink>);
+    fireEvent.click(screen.getByRole('button', { name: 'Open player profile: QB1' }));
+    expect(onPlayerSelect).toHaveBeenCalledWith(12, expect.objectContaining({ source: 'unknown' }));
+  });
+
+  it('renders missing player identity as plain text', () => {
+    render(<PlayerEntityLink playerId={null} onPlayerSelect={vi.fn()}>Unknown player</PlayerEntityLink>);
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.getByText('Unknown player')).toBeTruthy();
+  });
+
+  it('opens a valid team and leaves invalid team identity inert', () => {
+    const onTeamSelect = vi.fn();
+    const { rerender } = render(<TeamEntityLink teamId="7" onTeamSelect={onTeamSelect}>SEA</TeamEntityLink>);
+    fireEvent.click(screen.getByRole('button', { name: 'SEA' }));
+    expect(onTeamSelect).toHaveBeenCalledWith('7');
+    rerender(<TeamEntityLink teamId="__missing_team__" onTeamSelect={onTeamSelect}>TBD</TeamEntityLink>);
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('opens a resolvable detailed game but not a score-only archive', () => {
+    const onGameSelect = vi.fn();
+    const detailed = { gameId: '2026_w2_1_2', homeId: 1, awayId: 2, homeScore: 24, awayScore: 17, driveSummary: [{ result: 'TD' }] };
+    const { rerender } = render(<GameEntityLink game={detailed} context={{ seasonId: '2026', week: 2 }} onGameSelect={onGameSelect}>24–17</GameEntityLink>);
+    fireEvent.click(screen.getByRole('button', { name: '24–17' }));
+    expect(onGameSelect).toHaveBeenCalledWith('2026_w2_1_2');
+    rerender(<GameEntityLink game={{ ...detailed, driveSummary: undefined }} context={{ seasonId: '2026', week: 2 }} onGameSelect={onGameSelect}>24–17</GameEntityLink>);
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+});

--- a/src/ui/styles/entity-link-style.test.js
+++ b/src/ui/styles/entity-link-style.test.js
@@ -1,0 +1,19 @@
+/** @vitest-environment node */
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(new URL('./style.css', import.meta.url), 'utf8');
+
+describe('entity link style scope', () => {
+  it('keeps the inline reset off explicit button variants', () => {
+    expect(css).toContain('.app-entity-link:not(.btn)');
+    expect(css).not.toMatch(/\.app-entity-link\s*\{[^}]*\bborder\s*:\s*0/s);
+    expect(css).not.toMatch(/\.app-entity-link\s*\{[^}]*\bpadding\s*:\s*0/s);
+    expect(css).not.toMatch(/\.app-entity-link\s*\{[^}]*\bbackground\s*:\s*transparent/s);
+  });
+
+  it('preserves focus-visible affordance for inline and button entity links', () => {
+    expect(css).toContain('.app-entity-link:focus-visible');
+    expect(css).toMatch(/\.app-entity-link:focus-visible\s*\{[^}]*outline\s*:/s);
+  });
+});

--- a/src/ui/styles/style.css
+++ b/src/ui/styles/style.css
@@ -8503,3 +8503,25 @@ details[open] .nav-summary::after {
   letter-spacing: 0.04em;
   color: var(--text-subtle, #666);
 }
+.app-entity-link {
+  appearance: none;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-weight: inherit;
+  text-align: inherit;
+  cursor: pointer;
+}
+
+.app-entity-link:hover,
+.app-entity-link:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+
+.app-entity-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}

--- a/src/ui/styles/style.css
+++ b/src/ui/styles/style.css
@@ -8504,6 +8504,10 @@ details[open] .nav-summary::after {
   color: var(--text-subtle, #666);
 }
 .app-entity-link {
+  cursor: pointer;
+}
+
+.app-entity-link:not(.btn) {
   appearance: none;
   border: 0;
   padding: 0;
@@ -8512,7 +8516,6 @@ details[open] .nav-summary::after {
   font: inherit;
   font-weight: inherit;
   text-align: inherit;
-  cursor: pointer;
 }
 
 .app-entity-link:hover,


### PR DESCRIPTION
### Motivation
- Improve discoverability by making visible football entities reliably drill into existing detail surfaces while avoiding fake links or extra UI clutter.
- Provide a small, reusable entity-link primitive so surfaces can offer consistent, accessible player/team/game tap targets without invasive layout or routing changes.
- Patch the most visible weekly surface (League Hub Season Pulse) first to demonstrate the pattern and remove misleading Game Book affordances for score-only archives.

### Description
- Add a lightweight shared component `src/ui/components/EntityLink.jsx` that exposes `PlayerEntityLink`, `TeamEntityLink`, and `GameEntityLink` and uses existing helpers (`openPlayerProfile`, `openResolvedBoxScore`, `buildCompletedGamePresentation`) to decide actionability and call the canonical navigation callbacks.
- Wire the new entity links into `src/ui/components/LeagueHub.jsx` for Trending Teams, Award Watch, League Health (injuries), Next Week matchups, and Spotlight Games, using a truthful plain-text fallback for unavailable entities and a `Game Book unavailable` label for score-only archives.
- Add minimal affordance styling in `src/ui/styles/style.css` to preserve row-native typography while exposing pointer, hover/focus underline, and clear `:focus-visible` outlines for keyboard users.
- Add focused tests `src/ui/components/__tests__/EntityLink.test.jsx` and update `src/ui/components/LeagueHub.test.jsx` to assert valid/invalid player/team identity, accessible naming, callback dispatch, resolvable vs score-only Game Book behavior, and the Spotlight gating; add an audit doc `docs/universal-clickability-entity-drilldown-v1-audit.md` documenting routing ownership and decisions.

### Testing
- Ran focused unit tests: `npx vitest run src/ui/components/__tests__/EntityLink.test.jsx src/ui/utils/boxScoreAccess.test.js src/ui/components/LeagueHub.test.jsx` which passed (focused tests for entity behavior and boxscore resolver succeeded).
- Ran full unit suite: `npm run test:unit` which completed successfully (local run: 474 files / 5,882 tests passed).
- Built production bundle: `npm run build` which succeeded; Vite emitted the repository’s documented chunk-size warning only.
- Performed Netlify parity checks: `npm run check:deploy` which completed successfully (build + rules + offline netlify-cli checks passed).
- Playwright/E2E: attempted `npx playwright test tests/e2e/league_hub_season_pulse_mobile.spec.js` but browser execution was blocked because Chromium was not installed in the environment; `npx playwright install chromium` failed with CDN download errors (HTTP 403 `Domain forbidden`), so no browser E2E run was produced.
- Repository/CI notes: attempted to push the feature branch to GitHub but remote authentication is not available in this environment, so the branch and PR were prepared locally and committed but could not be pushed; the local branch exists for a normal authenticated developer push.

Files changed
- Added: `src/ui/components/EntityLink.jsx`, `src/ui/components/__tests__/EntityLink.test.jsx`, `docs/universal-clickability-entity-drilldown-v1-audit.md`.
- Modified: `src/ui/components/LeagueHub.jsx`, `src/ui/components/LeagueHub.test.jsx`, `src/ui/styles/style.css`.

Exact behavior and safety guarantees
- Player links call the existing `openPlayerProfile` pathway and are rendered only when `playerId` is validated by `playerProfileNavigation.js`.
- Team links call the existing `onTeamSelect` callback only when a valid team id is present, otherwise they render as plain text.
- Game links use the existing `buildCompletedGamePresentation` / `openResolvedBoxScore` logic to determine availability and only render a clickable Game Book button when the resolver indicates a resolvable, non-score-only archive; score-only or missing-detail games show honest inert text (`Game Book unavailable`).
- No new destination pages, no navigation state machines, and no changes to simulation, worker ownership, save schema, persistence, AI, trade, contract, cap, draft, or stat formula logic were introduced.

Explicit non‑goals and deferred work
- This PR does not migrate every legacy surface to the shared `EntityLink` (Franchise HQ, News, Weekly Results, Team Hub, and broader league screens are deferred to follow-ups after surface‑specific audits). 
- No gameplay, worker, persistence, or calculation logic was changed.

Baseline verified
- Implementation started from the live main that includes the recent merges for PR #1747 and #1745 (baseline checked in the repository before changes).

If you want I can (once provided with GitHub credentials or pushed via CI): open the PR on origin/remote, add a short mobile E2E run once Playwright browsers are available, or migrate additional surfaces to the shared `EntityLink` in a follow-up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b4213dd60832d869346950be261e3)