### PR TITLE
fix: E2E advance week readiness timeout and stakes UI

### DIFF
--- a/src/ui/utils/advanceReadinessGate.js
+++ b/src/ui/utils/advanceReadinessGate.js
@@ -130,7 +130,15 @@ export function buildAdvanceReadinessGate({ league, prep, weeklyContext } = {}) 
     ? "You can still advance, but this week's setup is not clean."
     : 'No prep blockers detected. Ready to advance.';
 
-  if (!shouldWarn && hasPlayoffStakes) summary += ' Playoff stakes are high—every decision counts.';
+  let advanceAnywayLabel = 'Advance anyway';
+  if (shouldWarn && hasPlayoffStakes) {
+    summary += ' Playoff stakes are high—ignoring these warnings could cost you your season.';
+    advanceAnywayLabel = 'Risk it and advance';
+  } else if (!shouldWarn && hasPlayoffStakes) {
+    summary += ' Playoff stakes are high—every decision counts.';
+  } else if (shouldWarn && (league?.week ?? 0) < 4) {
+    summary += ' Early season games set the tone. Are you sure you want to risk it?';
+  }
 
   // primaryFixDestination: most critical item first
   const primaryItem =
@@ -146,6 +154,6 @@ export function buildAdvanceReadinessGate({ league, prep, weeklyContext } = {}) 
     summary,
     riskItems,
     primaryFixDestination,
-    advanceAnywayLabel: 'Advance anyway',
+    advanceAnywayLabel,
   };
 }

--- a/tests/e2e/helpers/franchise.js
+++ b/tests/e2e/helpers/franchise.js
@@ -223,7 +223,7 @@ export async function simulateSingleWeek(page, options = {}) {
       try {
         await expect(advanceCta).toBeEnabled({ timeout: 500 });
       } catch (err) {
-        if (err.name !== 'TimeoutError') throw err;
+        if (err.name !== 'TimeoutError' && !(err.message && err.message.includes('toBeEnabled'))) throw err;
       }
     } catch (err) {
       if (err.name !== 'TimeoutError') throw err;
@@ -261,7 +261,7 @@ export async function simulateSingleWeek(page, options = {}) {
       await expect(advanceAnywayBtn).toBeEnabled({ timeout: 5000 });
       await advanceAnywayBtn.click();
     } catch (err) {
-      if (err.name !== 'TimeoutError') throw err;
+      if (err.name !== 'TimeoutError' && !(err.message && err.message.includes('toBeEnabled'))) throw err;
     }
   }
   const skipPromptBtn = page.getByRole('button', { name: /Simulate \(Skip\)/i });
@@ -270,7 +270,7 @@ export async function simulateSingleWeek(page, options = {}) {
     await expect(skipPromptBtn).toBeEnabled({ timeout: 5000 });
     await skipPromptBtn.click();
   } catch (err) {
-    if (err.name !== 'TimeoutError') throw err;
+    if (err.name !== 'TimeoutError' && !(err.message && err.message.includes('toBeEnabled'))) throw err;
   }
   await page.waitForFunction(
     (baseline) => {


### PR DESCRIPTION
Fixed the daily regression playability smoke test where `simulateSingleWeek` failed due to Playwright's `toBeEnabled` throwing a standard `Error` instead of a `TimeoutError`. Also added contextual stakes and tension to the `AdvanceReadinessGate` to fulfill the daily prompt requirement.

---
*PR created automatically by Jules for task [11609789145936144836](https://jules.google.com/task/11609789145936144836) started by @rbcati*