### PR TITLE
fix: stabilize weekly postgame navigation & Game Book ownership

### DIFF
--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -1528,9 +1528,15 @@ function AppContent() {
       )}
 
       {/* ── Last results ticker ────────────────────────────────────────── */}
-      {authoritativeResults.length > 0 && (
+      {authoritativeResults.some((result) => (
+        Number(result?.homeId) !== Number(league.userTeamId)
+        && Number(result?.awayId) !== Number(league.userTeamId)
+      )) && (
         <div className="app-results-ticker">
-          {authoritativeResults.map((r, i) => {
+          {authoritativeResults.filter((result) => (
+            Number(result?.homeId) !== Number(league.userTeamId)
+            && Number(result?.awayId) !== Number(league.userTeamId)
+          )).map((r, i) => {
             const homeWin = r.homeScore > r.awayScore;
             const isUserGame = r.homeId === league.userTeamId || r.awayId === league.userTeamId;
             const gamePresentation = buildCompletedGamePresentation(r, {
@@ -1584,6 +1590,10 @@ function AppContent() {
           externalDestination={externalDashboardDestination}
           onConsumeExternalDestination={() => setExternalDashboardDestination(null)}
           onConsumeExternalBoxScore={() => setExternalBoxScoreId(null)}
+          onDashboardNavigation={() => {
+            setSkipGameSummary(null);
+            setGameBookBriefingStash(null);
+          }}
           onGameDetailBack={() => {
             if (postGameResultStash) {
               setPostGameResult(postGameResultStash);

--- a/src/ui/components/FranchiseHQ.jsx
+++ b/src/ui/components/FranchiseHQ.jsx
@@ -166,9 +166,6 @@ function loadHQStoredPlan() {
 export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = null, onNavigate, onAdvanceWeek, busy, simulating, actions }) {
   const [lineupToast, setLineupToast] = useState(null);
   const [showGate, setShowGate] = useState(false);
-  // Tracks the week whose post-sim "week complete" status strip the user has
-  // dismissed, so the compact strip stays gone until the next week is played.
-  const [dismissedStripWeek, setDismissedStripWeek] = useState(null);
   const command = useMemo(() => selectFranchiseHQViewModel(league), [league]);
   const hqPrep = useMemo(() => deriveWeeklyPrepState(league), [league]);
   const hqWeeklyContext = useMemo(() => evaluateWeeklyContext(league), [league]);
@@ -363,13 +360,6 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
       gameId,
     };
   }, [lastGame, league?.userTeamId]);
-
-  // Compact, dismissible post-sim acknowledgement strip. Low visual weight,
-  // single line. Shows once per completed week so the HQ answers "what just
-  // happened?" without auto-expanding full Weekly Results on return.
-  const showPostSimStrip = Boolean(
-    lastResultRow && lastResultRow.week != null && dismissedStripWeek !== lastResultRow.week,
-  );
 
   // Division standings for mini-table (max 4 rows)
   const divisionRows = useMemo(() => {
@@ -611,30 +601,6 @@ export default function FranchiseHQ({ league, lastResults = [], lastSimWeek = nu
               : undefined
           }
         />
-      )}
-
-      {/* ── POST-SIM STATUS STRIP — compact, dismissible, single line ────── */}
-      {showPostSimStrip && (
-        <div className="hq-postsim-strip" data-testid="hq-postsim-status-strip" data-week={lastResultRow.week}>
-          <button
-            type="button"
-            className="hq-postsim-strip__main"
-            onClick={() => onNavigate?.('Weekly Results')}
-            aria-label={`Week ${lastResultRow.week} complete. Tap to review results.`}
-          >
-            <span className="hq-postsim-strip__dot" aria-hidden="true" />
-            <span className="hq-postsim-strip__text">Week {lastResultRow.week} complete · Tap to review results</span>
-          </button>
-          <button
-            type="button"
-            className="hq-postsim-strip__dismiss"
-            data-testid="hq-postsim-status-strip-dismiss"
-            onClick={() => setDismissedStripWeek(lastResultRow.week)}
-            aria-label="Dismiss week complete notice"
-          >
-            ×
-          </button>
-        </div>
       )}
 
       {/* ── NEXT GAME ROW — single line, tappable → Game Plan ───────────── */}

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -632,6 +632,7 @@ export default function LeagueDashboard({
   onConsumeExternalBoxScore,
   externalDestination,
   onConsumeExternalDestination,
+  onDashboardNavigation,
   onGameDetailBack,
   onOpenSaves,
   advanceLabel = "Advance",
@@ -755,7 +756,7 @@ export default function LeagueDashboard({
     if (!externalBoxScoreId) return;
     setGameDetailModal({ open: true, gameId: externalBoxScoreId, source: "postgame" });
     onConsumeExternalBoxScore?.();
-  }, [externalBoxScoreId, onConsumeExternalBoxScore, activeTab]);
+  }, [externalBoxScoreId, onConsumeExternalBoxScore]);
 
   useEffect(() => {
     if (!externalDestination) return;
@@ -827,17 +828,21 @@ export default function LeagueDashboard({
     setActiveTab("Game Detail");
   };
   const activeSection = getShellSectionForDashboardTab(activeTab);
-  // Focused Game Book review mode: when a completed game / Game Book is open
-  // (either the mobile modal overlay or the dedicated Game Detail tab) the
-  // fixed bottom nav and hamburger are collapsed so the result screen is not
-  // boxed in. Returning to any other surface restores the nav automatically.
-  const isGameBookFocus = gameDetailModal.open || activeTab === "Game Detail";
   const WEEKLY_OPERATIONS_TABS = new Set(["Game Plan", "Depth Chart", "Training", "Weekly Prep"]);
   const isWeeklyOperationsTab = WEEKLY_OPERATIONS_TABS.has(activeTab);
   const handleSectionChange = (sectionId) => {
     const normalizedSection = normalizeShellSectionId(sectionId);
     const group = NAV_GROUPS.find((entry) => entry.id === normalizedSection);
     const targetTab = group?.tabs?.find((tab) => TABS.includes(tab)) ?? "HQ";
+    setGameDetailModal({ open: false, gameId: null, source: null });
+    onDashboardNavigation?.(targetTab);
+    setActiveTab(targetTab);
+  };
+
+  const handleMobileDestinationChange = (tab) => {
+    const targetTab = canonicalizeMobileTab(tab);
+    setGameDetailModal({ open: false, gameId: null, source: null });
+    onDashboardNavigation?.(targetTab);
     setActiveTab(targetTab);
   };
 
@@ -1450,7 +1455,7 @@ export default function LeagueDashboard({
           </TabErrorBoundary>
         )}
 
-        {activeTab === "Game Detail" && (
+        {activeTab === "Game Detail" && !gameDetailModal.open && (
           <TabErrorBoundary label="Game Detail">
             <GameDetailScreen
               gameId={selectedGameId}
@@ -1622,15 +1627,18 @@ export default function LeagueDashboard({
         activeSection={activeSection}
         activeTab={activeTab}
         onSectionChange={handleSectionChange}
-        onDestinationChange={(tab) => setActiveTab(canonicalizeMobileTab(tab))}
+        onDestinationChange={handleMobileDestinationChange}
         onAppAction={(action) => {
-          if (action === "saves") onOpenSaves?.();
+          if (action === "saves") {
+            onDashboardNavigation?.('Saves');
+            onOpenSaves?.();
+          }
         }}
         onAdvance={onAdvanceWeek}
         advanceLabel={advanceLabel}
         advanceDisabled={advanceDisabled}
         league={league}
-        collapsed={isGameBookFocus}
+        collapsed={false}
       />
 
 

--- a/src/ui/components/PostGameSummary.jsx
+++ b/src/ui/components/PostGameSummary.jsx
@@ -155,6 +155,7 @@ export default function PostGameSummary({
       aria-modal="true"
       aria-label="Weekly GM briefing"
       data-testid="post-game-summary"
+      className="post-game-summary-overlay"
       ref={overlayRef}
       style={{
         position: 'fixed', inset: 0, zIndex: 9600,

--- a/src/ui/components/__tests__/FranchiseHQ.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQ.test.jsx
@@ -376,7 +376,7 @@ describe('FranchiseHQ', () => {
     expect(screen.getByTestId('hq-last-result').textContent).toMatch(/W.*23-20.*DET/i);
   });
 
-  it('shows the compact Last Result card before the status strip and any engine/development notices', () => {
+  it('shows one compact Last Result card before engine/development notices', () => {
     // Force an engine/development notice (injury) into the activity stack so we
     // can prove the Last Result card lands ahead of it on the post-advance HQ.
     const leagueWithInjury = {
@@ -389,14 +389,13 @@ describe('FranchiseHQ', () => {
     render(<FranchiseHQ league={leagueWithInjury} onNavigate={() => {}} onAdvanceWeek={() => {}} busy={false} simulating={false} />);
 
     const lastResultCard = screen.getByTestId('hq-last-result-card');
-    const statusStrip = screen.getByTestId('hq-postsim-status-strip');
     const noticeStack = screen.getByTestId('activity-toast-stack');
 
     const FOLLOWING = Node.DOCUMENT_POSITION_FOLLOWING;
-    // Card → strip → notices, in that document order.
-    expect(lastResultCard.compareDocumentPosition(statusStrip) & FOLLOWING).toBeTruthy();
+    // The canonical result is the only postgame presentation before notices.
+    expect(screen.getAllByTestId('hq-last-result-card')).toHaveLength(1);
+    expect(screen.queryByTestId('hq-postsim-status-strip')).toBeNull();
     expect(lastResultCard.compareDocumentPosition(noticeStack) & FOLLOWING).toBeTruthy();
-    expect(statusStrip.compareDocumentPosition(noticeStack) & FOLLOWING).toBeTruthy();
 
     // The canonical review CTA on the HQ surface reads exactly "View Game Book".
     expect(screen.getByTestId('hq-last-result-cta').textContent).toContain('View Game Book');
@@ -547,12 +546,12 @@ describe('FranchiseHQ V4 compact home screen', () => {
   });
 });
 
-describe('LeagueDashboard Game Book focus mode collapses the mobile bottom nav', () => {
+describe('LeagueDashboard Game Book navigation integrity', () => {
   afterEach(() => {
     cleanup();
   });
 
-  it('collapses the bottom nav while the Game Book is open and restores it on return to HQ', async () => {
+  it('keeps the bottom nav visible while the Game Book is open and after return to HQ', async () => {
     window.matchMedia = window.matchMedia ?? (() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }));
     render(
       <LeagueDashboard
@@ -573,51 +572,71 @@ describe('LeagueDashboard Game Book focus mode collapses the mobile bottom nav',
     const seasonPulse = screen.getByTestId('season-pulse');
     fireEvent.click(within(seasonPulse).getByRole('button', { name: /view game book/i }));
     expect(await screen.findByTestId('game-book')).toBeTruthy();
+    expect(screen.getAllByTestId('game-book')).toHaveLength(1);
+    expect(screen.getAllByTestId('return-to-hq')).toHaveLength(1);
 
-    // Bottom nav collapsed during focused review.
-    expect(bottomBar().classList.contains('is-collapsed')).toBe(true);
+    // Navigation stays available so Game Book cannot trap the weekly loop.
+    expect(bottomBar().classList.contains('is-collapsed')).toBe(false);
 
     // Return to HQ restores the nav.
     fireEvent.click(screen.getByTestId('return-to-hq'));
     expect(await screen.findByTestId('franchise-hq')).toBeTruthy();
     expect(bottomBar().classList.contains('is-collapsed')).toBe(false);
   });
+
+  it('closes the Game Book when mobile navigation changes route', async () => {
+    const onDashboardNavigation = vi.fn();
+    window.matchMedia = window.matchMedia ?? (() => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }));
+    render(
+      <LeagueDashboard
+        league={baseLeague}
+        actions={{ getDashboardLeaders: vi.fn(() => Promise.resolve({ league: {}, team: {} })) }}
+        busy={false}
+        simulating={false}
+        onAdvanceWeek={() => {}}
+        onDashboardNavigation={onDashboardNavigation}
+      />,
+    );
+
+    fireEvent.click(within(screen.getByTestId('season-pulse')).getByRole('button', { name: /view game book/i }));
+    expect(await screen.findByTestId('game-book')).toBeTruthy();
+    fireEvent.click(document.querySelector('.mobile-bottom-tab[aria-label="Team"]'));
+
+    expect(screen.queryByTestId('game-book')).toBeNull();
+    expect(screen.getByTestId('nav-team').getAttribute('aria-current')).toBe('page');
+    expect(onDashboardNavigation).toHaveBeenCalledWith('Team');
+    expect(document.querySelector('.mobile-bottom-bar')).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Open navigation menu' })).toBeTruthy();
+  });
 });
 
-describe('FranchiseHQ post-sim compact status strip', () => {
+describe('FranchiseHQ post-sim result consolidation', () => {
   afterEach(() => {
     cleanup();
   });
 
-  it('renders one compact dismissible status strip with the completed week label', () => {
+  it('does not repeat the completed result in a status strip', () => {
     render(
       <FranchiseHQ league={baseLeague} onNavigate={vi.fn()} onAdvanceWeek={vi.fn()} busy={false} simulating={false} />,
     );
-    const strip = screen.getByTestId('hq-postsim-status-strip');
-    expect(strip).toBeTruthy();
-    // Last completed user game is week 9 (g-9).
-    expect(strip.textContent).toMatch(/week 9 complete/i);
-    // Dismiss control is present and labelled.
-    expect(within(strip).getByRole('button', { name: /dismiss week complete notice/i })).toBeTruthy();
+    expect(screen.getAllByTestId('hq-last-result-card')).toHaveLength(1);
+    expect(screen.queryByTestId('hq-postsim-status-strip')).toBeNull();
   });
 
-  it('routes the status strip tap to Weekly Results without auto-expanding it on HQ', () => {
+  it('routes the canonical result to Game Book', () => {
     const onNavigate = vi.fn();
     render(
       <FranchiseHQ league={baseLeague} onNavigate={onNavigate} onAdvanceWeek={vi.fn()} busy={false} simulating={false} />,
     );
-    fireEvent.click(screen.getByRole('button', { name: /week 9 complete\. tap to review results/i }));
-    expect(onNavigate).toHaveBeenCalledWith('Weekly Results');
-    // The HQ itself does not render a full Weekly Results center.
-    expect(screen.queryByTestId('weekly-results')).toBeNull();
+    fireEvent.click(screen.getByTestId('hq-last-result-card'));
+    expect(onNavigate).toHaveBeenCalledWith('Game Book:g-9');
   });
 
-  it('removes the strip after dismiss while keeping Weekly Results reachable elsewhere', () => {
+  it('keeps league navigation reachable without a duplicate post-sim strip', () => {
     const onNavigate = vi.fn();
     render(
       <FranchiseHQ league={baseLeague} onNavigate={onNavigate} onAdvanceWeek={vi.fn()} busy={false} simulating={false} />,
     );
-    fireEvent.click(screen.getByTestId('hq-postsim-status-strip-dismiss'));
     expect(screen.queryByTestId('hq-postsim-status-strip')).toBeNull();
     // Weekly Results remains reachable via the league destination nav.
     fireEvent.click(within(screen.getByTestId('hq-league-destination-links')).getByRole('button', { name: /^standings$/i }));

--- a/src/ui/components/__tests__/FranchiseHQMobileShell.test.jsx
+++ b/src/ui/components/__tests__/FranchiseHQMobileShell.test.jsx
@@ -62,6 +62,23 @@ describe('FranchiseHQ — mobile shell & safe-area layout', () => {
     expect(screen.getAllByRole('button', { name: /advance week/i })).toHaveLength(1);
   });
 
+  it('presents the completed user game once before standings', () => {
+    render(
+      <FranchiseHQ
+        league={baseLeague}
+        lastSimWeek={9}
+        lastResults={[{ gameId: 'g-9', week: 9, homeId: 11, awayId: 10, homeScore: 20, awayScore: 23, homeAbbr: 'DET', awayAbbr: 'CHI' }]}
+        onNavigate={() => {}}
+        onAdvanceWeek={() => {}}
+        busy={false}
+        simulating={false}
+      />,
+    );
+
+    expect(screen.getAllByTestId('hq-last-result-card')).toHaveLength(1);
+    expect(screen.queryByTestId('hq-postsim-status-strip')).toBeNull();
+  });
+
   it('collapses roster/simulation notices into the compact activity strip while simulating', () => {
     render(<FranchiseHQ league={baseLeague} onNavigate={() => {}} onAdvanceWeek={() => {}} busy={false} simulating={true} />);
     const strip = screen.getByTestId('activity-toast-stack');

--- a/src/ui/components/__tests__/mobileMatchReviewFlow.viewport.test.jsx
+++ b/src/ui/components/__tests__/mobileMatchReviewFlow.viewport.test.jsx
@@ -75,9 +75,10 @@ describe('mobile Match Review flow — viewport assertions', () => {
 
     const bottomBar = () => document.querySelector('.mobile-bottom-bar');
 
-    // HQ is not dominated by stacked notices: a single compact post-sim strip,
-    // and no full Weekly Results center embedded on HQ.
-    expect(screen.getByTestId('hq-postsim-status-strip')).toBeTruthy();
+    // HQ is not dominated by stacked notices: one canonical result entry,
+    // no duplicate post-sim strip, and no embedded Weekly Results center.
+    expect(screen.getAllByTestId('hq-last-result-card')).toHaveLength(1);
+    expect(screen.queryByTestId('hq-postsim-status-strip')).toBeNull();
     expect(screen.queryByTestId('weekly-results')).toBeNull();
     // Bottom nav present and not overlapping (not collapsed) on HQ.
     expect(bottomBar()).not.toBeNull();
@@ -93,8 +94,8 @@ describe('mobile Match Review flow — viewport assertions', () => {
     expect(screen.getByTestId('game-book-sticky-back')).toBeTruthy();
     expect(screen.getByTestId('game-book-sticky-score').textContent).toMatch(/\d/);
 
-    // Bottom nav collapses so it cannot overlap Game Book review content.
-    expect(bottomBar().classList.contains('is-collapsed')).toBe(true);
+    // Bottom nav remains available so Game Book cannot trap route navigation.
+    expect(bottomBar().classList.contains('is-collapsed')).toBe(false);
 
     // Return to HQ is reachable from the sticky header and restores the nav.
     fireEvent.click(screen.getByTestId('game-book-sticky-back'));

--- a/src/ui/components/__tests__/mobileMatchReviewFlow.viewport.test.jsx
+++ b/src/ui/components/__tests__/mobileMatchReviewFlow.viewport.test.jsx
@@ -10,9 +10,10 @@
  * jsdom does not compute real layout, so these assert the structural
  * invariants that keep the result, score, and return action reachable without
  * scrolling and prevent the bottom nav from overlapping Game Book content:
- *   - HQ shows the compact post-sim strip, not a full Weekly Results center.
+ *   - HQ shows one canonical result, not a full Weekly Results center.
  *   - The Game Book exposes a sticky header (final score + return action).
- *   - The mobile bottom nav collapses during Game Book review and restores.
+ *   - The mobile bottom nav intentionally remains available during review.
+ *   - The desktop quick-jump FAB is never mounted at mobile widths.
  */
 import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -48,6 +49,7 @@ function setViewport(width, height) {
     const matches = match ? width <= Number(match[1]) : false;
     return { matches, media: query, addEventListener: vi.fn(), removeEventListener: vi.fn(), addListener: vi.fn(), removeListener: vi.fn(), onchange: null, dispatchEvent: vi.fn() };
   };
+  window.scrollTo = vi.fn();
 }
 
 const VIEWPORTS = [
@@ -80,9 +82,11 @@ describe('mobile Match Review flow — viewport assertions', () => {
     expect(screen.getAllByTestId('hq-last-result-card')).toHaveLength(1);
     expect(screen.queryByTestId('hq-postsim-status-strip')).toBeNull();
     expect(screen.queryByTestId('weekly-results')).toBeNull();
+    expect(document.querySelector('.quick-jump-fab')).toBeNull();
     // Bottom nav present and not overlapping (not collapsed) on HQ.
     expect(bottomBar()).not.toBeNull();
     expect(bottomBar().classList.contains('is-collapsed')).toBe(false);
+    expect(document.querySelector('.quick-jump-fab')).toBeNull();
 
     // Open the Game Book from the last result affordance / film room.
     const seasonPulse = screen.getByTestId('season-pulse');
@@ -101,5 +105,14 @@ describe('mobile Match Review flow — viewport assertions', () => {
     fireEvent.click(screen.getByTestId('game-book-sticky-back'));
     expect(await screen.findByTestId('franchise-hq')).toBeTruthy();
     expect(bottomBar().classList.contains('is-collapsed')).toBe(false);
+
+    fireEvent.click(document.querySelector('.mobile-bottom-tab[aria-label="League"]'));
+    expect(document.querySelector('.league-hub-mobile-surface')).toBeTruthy();
+    expect(document.querySelector('.quick-jump-fab')).toBeNull();
+
+    fireEvent.click(document.querySelector('.mobile-bottom-tab[aria-label="More"]'));
+    expect(screen.getByRole('navigation', { name: 'More navigation' }).classList.contains('open')).toBe(true);
+    expect(screen.getByRole('button', { name: 'Saves' })).toBeTruthy();
+    expect(document.querySelector('.quick-jump-fab')).toBeNull();
   });
 });

--- a/src/ui/styles/app-mobile.css
+++ b/src/ui/styles/app-mobile.css
@@ -538,6 +538,15 @@
 
 /* ── Modals ──────────────────────────────────────────────────────────────────── */
 
+/* Weekly briefing is App-owned, but mobile navigation remains the route owner.
+   Keep the navigation chrome above this one transient surface so selecting a
+   destination can synchronously unmount it instead of stranding it cross-route. */
+@media (max-width: 767px) {
+  .post-game-summary-overlay {
+    z-index: 900 !important;
+  }
+}
+
 .app-modal-overlay {
   position: fixed;
   top: 0; left: 0; right: 0; bottom: 0;

--- a/tests/e2e/core_weekly_loop_integrity_pr1752.spec.js
+++ b/tests/e2e/core_weekly_loop_integrity_pr1752.spec.js
@@ -4,10 +4,30 @@ import { launchFranchise } from './helpers/franchise.js';
 test.use({ viewport: { width: 390, height: 844 } });
 test.setTimeout(120000);
 
+const FLOATING_HELP_SELECTOR = '.quick-jump-fab, .quick-jump-fab-btn, [aria-label="Help"], [aria-label*="help" i], [data-testid*="help-fab" i]';
+
+async function expectTargetCenterUnobstructed(target) {
+  await expect(target).toBeVisible();
+  expect(await target.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    const x = Math.min(window.innerWidth - 1, Math.max(0, rect.left + rect.width / 2));
+    const y = Math.min(window.innerHeight - 1, Math.max(0, rect.top + rect.height / 2));
+    const hit = document.elementFromPoint(x, y);
+    return Boolean(hit && (hit === element || element.contains(hit)));
+  })).toBe(true);
+}
+
+async function expectNoFloatingHelp(page) {
+  await expect(page.locator(FLOATING_HELP_SELECTOR)).toHaveCount(0);
+}
+
 test('mobile weekly-result navigation and Game Book remain single-owner', async ({ page }) => {
   await page.goto('/');
   await launchFranchise(page);
   await expect(page.getByTestId('franchise-hq')).toBeVisible({ timeout: 90000 });
+  await expectNoFloatingHelp(page);
+  await expectTargetCenterUnobstructed(page.getByTestId('advance-week-cta'));
+  await expectTargetCenterUnobstructed(page.getByRole('button', { name: 'HQ', exact: true }).last());
 
   const seasonPulse = page.getByTestId('season-pulse');
   const gameBookEntry = seasonPulse.getByRole('button', { name: /view game book/i });
@@ -15,6 +35,9 @@ test('mobile weekly-result navigation and Game Book remain single-owner', async 
     await gameBookEntry.click();
     await expect(page.getByTestId('game-book')).toHaveCount(1);
     await expect(page.getByTestId('return-to-hq')).toHaveCount(1);
+    await expectNoFloatingHelp(page);
+    await expectTargetCenterUnobstructed(page.getByTestId('return-to-hq'));
+    await expectTargetCenterUnobstructed(page.getByRole('button', { name: 'Team', exact: true }).last());
 
     await page.getByRole('button', { name: 'Team', exact: true }).last().click();
     await expect(page.getByTestId('game-book')).toHaveCount(0);
@@ -23,10 +46,14 @@ test('mobile weekly-result navigation and Game Book remain single-owner', async 
 
     await page.getByRole('button', { name: 'League', exact: true }).last().click();
     await expect(page.getByTestId('post-game-summary')).toHaveCount(0);
+    await expectNoFloatingHelp(page);
+    await expectTargetCenterUnobstructed(page.getByRole('button', { name: 'League', exact: true }).last());
   }
 
   await page.getByRole('button', { name: 'More', exact: true }).click();
   await expect(page.getByRole('navigation', { name: 'More navigation' })).toBeVisible();
-  await expect(page.locator('.quick-jump-fab, [aria-label="Help"]')).toHaveCount(0);
+  await expectNoFloatingHelp(page);
+  await expectTargetCenterUnobstructed(page.getByRole('button', { name: 'Saves', exact: true }));
+  await expectTargetCenterUnobstructed(page.getByRole('button', { name: 'More', exact: true }));
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(true);
 });

--- a/tests/e2e/core_weekly_loop_integrity_pr1752.spec.js
+++ b/tests/e2e/core_weekly_loop_integrity_pr1752.spec.js
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+import { launchFranchise } from './helpers/franchise.js';
+
+test.use({ viewport: { width: 390, height: 844 } });
+test.setTimeout(120000);
+
+test('mobile weekly-result navigation and Game Book remain single-owner', async ({ page }) => {
+  await page.goto('/');
+  await launchFranchise(page);
+  await expect(page.getByTestId('franchise-hq')).toBeVisible({ timeout: 90000 });
+
+  const seasonPulse = page.getByTestId('season-pulse');
+  const gameBookEntry = seasonPulse.getByRole('button', { name: /view game book/i });
+  if (await gameBookEntry.isVisible().catch(() => false)) {
+    await gameBookEntry.click();
+    await expect(page.getByTestId('game-book')).toHaveCount(1);
+    await expect(page.getByTestId('return-to-hq')).toHaveCount(1);
+
+    await page.getByRole('button', { name: 'Team', exact: true }).last().click();
+    await expect(page.getByTestId('game-book')).toHaveCount(0);
+    await expect(page.locator('.mobile-bottom-bar')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Open navigation menu' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'League', exact: true }).last().click();
+    await expect(page.getByTestId('post-game-summary')).toHaveCount(0);
+  }
+
+  await page.getByRole('button', { name: 'More', exact: true }).click();
+  await expect(page.getByRole('navigation', { name: 'More navigation' })).toBeVisible();
+  await expect(page.locator('.quick-jump-fab, [aria-label="Help"]')).toHaveCount(0);
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(true);
+});


### PR DESCRIPTION
### Motivation
- Stabilize the mobile weekly loop so postgame briefing/results never become a stuck overlay after navigation (address NAV-01) and avoid duplicate/multiple postgame presentations (RESULTS-01, HQ-05). 
- Remove obstructive/overlapping mobile chrome caused by lingering App-owned briefing / FAB during the weekly loop (HQ-03) and ensure affordances in Final Results are truthful (RESULTS-07). 
- Verified current main baseline at commit `14d617a7` (includes #1745/#1747/#1748) and implemented minimal, targeted fixes without touching simulation, worker, save schema, or broader PFGM visual conversion work.

### Description
- Route/overlay ownership: added an explicit navigation callback (`onDashboardNavigation`) and synchronization so dashboard route changes close App-owned postgame briefings and the Game Book modal via state rather than hiding with CSS, and mobile destination changes unmount the Game Book modal synchronously; key changes in `src/ui/App.jsx` and `src/ui/components/LeagueDashboard.jsx`.
- Duplicate/adjacent postgame surfaces: consolidated HQ to the canonical `GameResultSummaryCard` only and removed the separate week-complete strip that duplicated the same user result, by simplifying HQ ownership of the single postgame surface in `src/ui/components/FranchiseHQ.jsx`.
- Results ticker and fake affordances: filtered `app-results-ticker` to exclude the user’s game so it does not appear adjacent to HQ user-result presentation, and left Final Results chevrons unchanged when non-actionable (no fake Game Book links); changes in `src/ui/App.jsx` and reviewed `src/ui/components/LiveGame.jsx`/`GameResultSummaryCard.jsx` to preserve truthful gating.
- Mobile non-obstruction and small CSS change: made the PostGameSummary overlay coexist with navigation chrome so a route tap can unmount the briefing (small `post-game-summary-overlay` rule in `src/ui/styles/app-mobile.css`); added a focused Playwright E2E `tests/e2e/core_weekly_loop_integrity_pr1752.spec.js` and updated targeted unit/viewport tests to assert single-result presentation and navigation integrity (`src/ui/components/__tests__/*`).

### Testing
- Unit/integration: ran `npm run test:unit` (full suite) and observed success; focused runs and summary: `src/ui/components` focused suites and full repository suite passed (full run: 5,898 tests passed); modifications include added/updated tests under `src/ui/components/__tests__` and viewport tests updated to assert the single-result behavior.
- Build / Netlify parity: ran `npm run build` and `npm run check:deploy` and both completed successfully (production build emitted an expected large-chunk warning only). 
- Type checks: ran `npm run check:sim-types` and it completed OK.
- E2E / Playwright: added `tests/e2e/core_weekly_loop_integrity_pr1752.spec.js` implementing the 390px scenario required by the PR, but running `npx playwright install chromium` in this environment failed with HTTP 403 from the Playwright CDN so I could not execute the Playwright E2E run; therefore E2E is present but not executed here.
- Git / publish: committed locally on branch `feature/pr-1752-core-weekly-loop-overlay-postgame-integrity-v1` (commit `802a659`), but `git push` / PR creation was blocked because the environment has no GitHub credentials (push/auth failure), so I did not open the remote PR; local commit and all diffs are included in this rollout.

Notes and scope
- Reproductions: NAV-01 / RESULTS-01 / HQ-05 were reproducible and fixed via ownership/state changes above; HQ-03 was addressed by making the briefing non-obstructive on mobile; RESULTS-07 (dead chevrons) was not changed because the codebase already gates Game Book affordances via `buildCompletedGamePresentation` / `getBoxScoreAvailability` — no fake links were introduced.
- Files changed (main): `src/ui/App.jsx`, `src/ui/components/LeagueDashboard.jsx`, `src/ui/components/FranchiseHQ.jsx`, `src/ui/components/PostGameSummary.jsx`, `src/ui/styles/app-mobile.css`, plus focused test files and a new E2E test `tests/e2e/core_weekly_loop_integrity_pr1752.spec.js`.
- Accessibility: Escape and explicit close remain handled by `PostGameSummary` focus/keyboard handlers; navigation buttons retain `aria-*` semantics and `MobileNav` continues to close drawers on route change.
- Mobile validation: unit/viewport assertions were run and updated for 375px/390px/430px where jsdom/viewport tests apply; Playwright browser-level checks are included but blocked by environment-level Playwright browser download constraints.
- Deferral: visual conversion and broader PFGM theme work remain deferred to PR #1753 as requested.

If you want, I can (1) produce the exact diff/patch as a review comment, (2) re-run the Playwright E2E once a Chromium binary is available in CI or the environment (or you provide credentials/CI), or (3) open the remote PR if you provide a GitHub token or run the final `git push` + PR creation from a networked environment with auth.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7cd73c2324832d8d671334671ade2b)