### PR TITLE
PFGM Core Weekly Screens Visual Conversion V2

### DIFF
--- a/src/ui/components/LeagueLeaders.jsx
+++ b/src/ui/components/LeagueLeaders.jsx
@@ -103,6 +103,17 @@ function normalizeLeaderRows(rawRows = []) {
   }));
 }
 
+function resolveTeamIdentity(row, teams) {
+  const rawTeam = row?.teamAbbr ?? row?.abbr ?? row?.team ?? row?.player?.team;
+  const rawTeamId = row?.teamId ?? row?.tid ?? row?.team?.id ?? row?.player?.teamId;
+  const matchedTeam = teams.find((team) => String(team?.id) === String(rawTeamId));
+  const label = typeof rawTeam === "string" ? rawTeam.trim() : rawTeam?.abbr ?? rawTeam?.name;
+  return {
+    teamId: rawTeamId ?? matchedTeam?.id ?? null,
+    teamLabel: label && label !== "—" ? label : matchedTeam?.abbr ?? matchedTeam?.name ?? null,
+  };
+}
+
 const API_TAB_MAP = Object.freeze({
   Passing: { category: "passing", primaryKey: "passYards", secondaryKey: "passTDs" },
   Rushing: { category: "rushing", primaryKey: "rushYards", secondaryKey: "rushTDs" },
@@ -233,7 +244,7 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
   const [teamFilter, setTeamFilter] = useState("ALL");
   const [sort, setSort] = useState({ key: "primary", dir: "desc" });
   const firstTabRef = useRef(null);
-  const teams = Array.isArray(league?.teams) ? league.teams : [];
+  const teams = useMemo(() => (Array.isArray(league?.teams) ? league.teams : []), [league?.teams]);
 
   useEffect(() => {
     firstTabRef.current?.focus?.();
@@ -270,19 +281,22 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
         normalizeLeaderRows(bucket?.[apiConfig.secondaryKey]).map((row) => [String(row.id), row.value]),
       );
       if (primaryRows.length > 0) {
-        return primaryRows.map((row) => ({
-          player: {
-            ...row.raw,
-            id: row.id,
-            name: row.name,
-            teamName: row.teamAbbr,
-            teamId: row.teamId,
-            pos: row.raw?.pos ?? row.raw?.position ?? row.raw?.player?.pos ?? row.raw?.player?.position ?? "",
-            isUserTeam: Number(row.teamId) === Number(league?.userTeamId),
-          },
-          primary: row.value,
-          secondary: displayNumber(secondaryMap.get(String(row.id))),
-        }));
+        return primaryRows.map((row) => {
+          const identity = resolveTeamIdentity(row.raw, teams);
+          return ({
+            player: {
+              ...row.raw,
+              id: row.id,
+              name: row.name,
+              teamName: identity.teamLabel,
+              teamId: identity.teamId,
+              pos: row.raw?.pos ?? row.raw?.position ?? row.raw?.player?.pos ?? row.raw?.player?.position ?? "",
+              isUserTeam: Number(identity.teamId) === Number(league?.userTeamId),
+            },
+            primary: row.value,
+            secondary: displayNumber(secondaryMap.get(String(row.id))),
+          });
+        });
       }
     }
 
@@ -315,7 +329,7 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
       }))
       .sort((a, b) => (b.primary ?? 0) - (a.primary ?? 0))
       .slice(0, 10);
-  }, [activeTab, league?.userTeamId, model.playerTables, remoteCategories]);
+  }, [activeTab, league?.userTeamId, model.playerTables, remoteCategories, teams]);
 
 
   const positionOptions = useMemo(() => uniqueFilterOptions(rows, (entry) => entry.player?.pos), [rows]);
@@ -346,7 +360,7 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
     : "Showing current regular-season leaders.";
 
   return (
-    <div style={{ display: "grid", gap: "var(--space-3)" }}>
+    <div className="league-leaders-surface pfgm-density-surface" style={{ display: "grid", gap: "var(--space-3)" }}>
       <div className="standings-tabs profile-tab-row" role="tablist" aria-label="League leader categories" style={{ flexWrap: "nowrap", gap: 6, alignItems: "center" }}>
         {TABS.map((tab, index) => (
           <button
@@ -367,7 +381,7 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
       ) : (
         <>
           <div style={{ color: "var(--text-muted)", fontSize: "var(--text-xs)" }}>{sourceLabel}</div>
-          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+          <div className="league-leaders-filters">
             <input aria-label="Search league leaders" value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search player/team" style={{ minHeight: 32, flex: "1 1 180px" }} />
             <select aria-label="Filter leaders by position" value={positionFilter} onChange={(e) => setPositionFilter(e.target.value)} style={{ minHeight: 32 }}>
               <option value="ALL">All positions</option>
@@ -380,8 +394,8 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
             {hasActiveFilters ? <button type="button" onClick={resetFilters} style={{ minHeight: 32 }}>Reset filters</button> : null}
           </div>
           <div style={{ color: "var(--text-muted)", fontSize: "var(--text-xs)" }}>{buildShowingLabel(visibleRows.length, rows.length, "leader")}</div>
-          <div className="table-wrapper" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
-            <table className="standings-table" style={{ width: "100%", minWidth: 680 }}>
+          <div className="table-wrapper league-leaders-table-wrap" style={{ overflowX: "auto", border: "1px solid var(--hairline)", borderRadius: "var(--radius-md)" }}>
+            <table className="standings-table league-leaders-table" style={{ width: "100%", minWidth: 560 }}>
               <thead>
                 <tr>
                   <th style={{ width: 70 }}>Rank</th>
@@ -401,8 +415,8 @@ export default function LeagueLeaders({ league, actions, onPlayerSelect, onNavig
                     <td>{index + 1}</td>
                     <td>
                       <button
-                        className="btn btn-link"
-                        style={{ padding: 0, minHeight: 0 }}
+                        className="app-entity-link league-leaders-player-link"
+                        aria-label={`Open player profile for ${entry.player?.name ?? "player"}`}
                         onClick={() => onPlayerSelect?.(entry.player)}
                       >
                         {entry.player?.name ?? "—"}

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -1121,6 +1121,7 @@ export default function PlayerProfile({
   return (
     <div
       data-testid="player-profile"
+      className="player-profile-backdrop"
       onClick={onClose}
       style={{
         position: "fixed",
@@ -1137,6 +1138,7 @@ export default function PlayerProfile({
       }}
     >
       <div
+        className="player-profile-shell pfgm-density-surface"
         onClick={(e) => e.stopPropagation()}
         style={{
           background: "linear-gradient(180deg, var(--surface-elevated), var(--surface))",

--- a/src/ui/components/PlayerProfileModalBoundary.jsx
+++ b/src/ui/components/PlayerProfileModalBoundary.jsx
@@ -21,7 +21,7 @@ export default class PlayerProfileModalBoundary extends Component {
   render() {
     if (this.state.hasError) {
       return (
-        <div style={{
+        <div className="player-profile-backdrop" style={{
           position: "fixed",
           inset: 0,
           background: "rgba(0,0,0,0.6)",
@@ -31,7 +31,7 @@ export default class PlayerProfileModalBoundary extends Component {
           justifyContent: "center",
           padding: 16,
         }}>
-          <div style={{
+          <div className="player-profile-shell" style={{
             width: "min(560px, 100%)",
             borderRadius: 12,
             border: "1px solid var(--hairline)",

--- a/src/ui/components/__tests__/LeagueLeaders.test.jsx
+++ b/src/ui/components/__tests__/LeagueLeaders.test.jsx
@@ -26,9 +26,10 @@ describe('LeagueLeaders', () => {
   });
 
   it('renders player names as compact entity-style links', () => {
-    renderLeagueLeaders({
+    const { container } = renderLeagueLeaders({
       schedule: { weeks: [{ week: 1, games: [{ played: true, homeId: 1, awayId: 2, playerStats: { home: { 10: { name: 'Row Link QB', pos: 'QB', stats: { passYd: 100 } } }, away: {} } }] }] },
     });
+    expect(container.querySelector('.league-leaders-filters')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Open player profile for Row Link QB' }).classList.contains('league-leaders-player-link')).toBe(true);
   });
 

--- a/src/ui/components/__tests__/LeagueLeaders.test.jsx
+++ b/src/ui/components/__tests__/LeagueLeaders.test.jsx
@@ -5,6 +5,33 @@ import { cleanup, render, screen, fireEvent } from '@testing-library/react';
 import LeagueLeaders from '../LeagueLeaders.jsx';
 
 describe('LeagueLeaders', () => {
+  it('resolves API leader team identity from a real team id and exposes a working team filter', async () => {
+    const actions = {
+      getLeagueLeaders: () => Promise.resolve({
+        payload: {
+          categories: { passing: { passYards: [{ playerId: 42, name: 'Resolved QB', teamId: 2, value: 301 }] } },
+          source: 'current_regular_season',
+        },
+      }),
+    };
+    render(<LeagueLeaders league={{ userTeamId: 1, teams: [{ id: 1, abbr: 'AAA' }, { id: 2, abbr: 'BBB' }] }} actions={actions} onPlayerSelect={() => {}} />);
+
+    expect(await screen.findByText('Resolved QB')).toBeTruthy();
+    expect(screen.getAllByText('BBB')).toHaveLength(2);
+    const teamFilter = screen.getByRole('combobox', { name: 'Filter leaders by team' });
+    expect(screen.getByRole('option', { name: 'BBB' })).toBeTruthy();
+    fireEvent.change(teamFilter, { target: { value: 'BBB' } });
+    expect(screen.getByText('Resolved QB')).toBeTruthy();
+    fireEvent.change(teamFilter, { target: { value: 'ALL' } });
+  });
+
+  it('renders player names as compact entity-style links', () => {
+    renderLeagueLeaders({
+      schedule: { weeks: [{ week: 1, games: [{ played: true, homeId: 1, awayId: 2, playerStats: { home: { 10: { name: 'Row Link QB', pos: 'QB', stats: { passYd: 100 } } }, away: {} } }] }] },
+    });
+    expect(screen.getByRole('button', { name: 'Open player profile for Row Link QB' }).classList.contains('league-leaders-player-link')).toBe(true);
+  });
+
   it('renders non-zero leaders from completed-game stats when API categories are missing', () => {
     const league = {
       userTeamId: 1,
@@ -231,4 +258,3 @@ describe('LeagueLeaders — Advanced tab', () => {
     expect(screen.getByRole('table', { name: /Targets leaders/i })).toBeTruthy();
   });
 });
-

--- a/src/ui/components/__tests__/PlayerProfileModalBoundary.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfileModalBoundary.test.jsx
@@ -13,4 +13,12 @@ describe('PlayerProfileModalBoundary', () => {
 
     expect(html).toContain('Child content');
   });
+
+  it('keeps its fallback in the dark player-profile shell', () => {
+    const boundary = new PlayerProfileModalBoundary({ onClose: vi.fn(), playerId: 'missing' });
+    boundary.state = { hasError: true };
+    const html = renderToString(boundary.render());
+    expect(html).toContain('player-profile-backdrop');
+    expect(html).toContain('player-profile-shell');
+  });
 });

--- a/src/ui/styles/mobile-shell-density.css
+++ b/src/ui/styles/mobile-shell-density.css
@@ -300,7 +300,20 @@
   }
   .league-leaders-filters input { grid-column: 1 / -1; width: 100%; min-width: 0; }
   .league-leaders-filters select { max-width: 130px; min-width: 0; }
+  .league-leaders-surface {
+    --text: #f4f7fb;
+    --text-muted: rgba(244, 247, 251, .76);
+    --text-subtle: rgba(244, 247, 251, .66);
+    --surface: var(--mobile-content-black);
+    --surface-elevated: var(--mobile-row-charcoal-alt);
+    --surface-strong: var(--mobile-row-charcoal);
+    --hairline: var(--mobile-divider);
+    color: var(--text);
+  }
   .league-leaders-table-wrap { max-width: 100%; border-radius: 2px !important; }
+  .league-leaders-table :is(th, td) { color: var(--text); }
+  .league-leaders-table th,
+  .league-leaders-table th button { color: var(--text-muted); }
   .league-leaders-table tbody tr:nth-child(odd) { background: var(--mobile-row-charcoal); }
   .league-leaders-table tbody tr:nth-child(even) { background: var(--mobile-row-charcoal-alt); }
   .league-leaders-player-link {
@@ -322,6 +335,14 @@
 
   .player-profile-backdrop { padding: 0; }
   .player-profile-shell {
+    --text: #f4f7fb;
+    --text-muted: rgba(244, 247, 251, .76);
+    --text-subtle: rgba(244, 247, 251, .66);
+    --surface: var(--mobile-content-black);
+    --surface-elevated: var(--mobile-row-charcoal-alt);
+    --surface-strong: var(--mobile-row-charcoal);
+    --hairline: var(--mobile-divider);
+    --hairline-strong: rgba(255, 255, 255, .24);
     width: 100% !important;
     max-width: 100% !important;
     max-height: 100dvh !important;

--- a/src/ui/styles/mobile-shell-density.css
+++ b/src/ui/styles/mobile-shell-density.css
@@ -282,4 +282,46 @@
     outline: 2px solid var(--mobile-action-green);
     outline-offset: -2px;
   }
+
+  .league-leaders-filters {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    gap: 6px;
+    align-items: center;
+  }
+  .league-leaders-filters input { grid-column: 1 / -1; width: 100%; min-width: 0; }
+  .league-leaders-filters select { max-width: 130px; min-width: 0; }
+  .league-leaders-table-wrap { max-width: 100%; border-radius: 2px !important; }
+  .league-leaders-table tbody tr:nth-child(odd) { background: var(--mobile-row-charcoal); }
+  .league-leaders-table tbody tr:nth-child(even) { background: var(--mobile-row-charcoal-alt); }
+  .league-leaders-player-link {
+    min-height: 44px;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    color: #8fc4ff;
+    font-weight: 800;
+    text-align: left;
+    text-decoration: underline;
+    text-decoration-color: rgba(143, 196, 255, .45);
+    text-underline-offset: 3px;
+  }
+  .league-leaders-player-link:focus-visible { outline: 2px solid var(--mobile-action-green); outline-offset: 2px; }
+
+  .team-hub-mobile-surface .app-hero-summary-grid strong { color: #f4f7fb; }
+
+  .player-profile-backdrop { padding: 0; }
+  .player-profile-shell {
+    width: 100% !important;
+    max-width: 100% !important;
+    max-height: 100dvh !important;
+    border-radius: 0 !important;
+    border-color: var(--mobile-divider) !important;
+    background: var(--mobile-content-black) !important;
+    color: #f4f7fb;
+  }
+  .player-profile-shell [data-testid="player-profile-summary"] { background: var(--mobile-shell-navy) !important; }
+  .player-profile-shell .card-enter,
+  .player-profile-shell .stat-box { background: var(--mobile-row-charcoal-alt); border-color: var(--mobile-divider); }
 }

--- a/src/ui/styles/mobile-shell-density.css
+++ b/src/ui/styles/mobile-shell-density.css
@@ -1,6 +1,15 @@
 /* PFGM-inspired mobile shell and density layer.
- * Intentionally loaded last: this small, mobile-only layer converts the shared
- * screen primitives without changing their component APIs or desktop layouts. */
+ * Intentionally loaded last: the base filter rule preserves the pre-conversion
+ * desktop layout; the media query converts only the mobile screen primitives. */
+.league-leaders-filters {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.league-leaders-filters input { flex: 1 1 180px; min-width: 0; }
+.league-leaders-filters :is(select, button) { min-height: 32px; }
+
 @media (max-width: 767px) {
   :root {
     --mobile-shell-navy: #0d1522;

--- a/src/ui/styles/mobile-shell-density.test.js
+++ b/src/ui/styles/mobile-shell-density.test.js
@@ -30,4 +30,18 @@ describe('mobile shell density scope', () => {
       expect(css.indexOf(selector), selector).toBeGreaterThan(resetIndex);
     }
   });
+
+  it('pins weekly dark surfaces to readable tokens independent of the app theme', () => {
+    const leadersRule = css.match(/\.league-leaders-surface\s*\{([^}]*)\}/)?.[1] ?? '';
+    const profileRule = css.match(/\.player-profile-shell\s*\{([^}]*)\}/)?.[1] ?? '';
+
+    for (const rule of [leadersRule, profileRule]) {
+      expect(rule).toContain('--text: #f4f7fb');
+      expect(rule).toContain('--text-muted: rgba(244, 247, 251, .76)');
+      expect(rule).toContain('--surface: var(--mobile-content-black)');
+      expect(rule).toContain('--surface-elevated: var(--mobile-row-charcoal-alt)');
+      expect(rule).toContain('--hairline: var(--mobile-divider)');
+    }
+    expect(css).toContain('.league-leaders-table :is(th, td) { color: var(--text); }');
+  });
 });


### PR DESCRIPTION
### Motivation

- Address a set of weekly-loop visual and accessibility regressions by converting the weekly-play surfaces to a dense, PFGM-inspired dark mobile shell while preserving all existing data, interactions, and #1752 navigation/overlay fixes. 
- Fix League Leaders team identity, player-link affordance, Player Profile light-card clash, Team Hub last/next contrast, and compact the leaders filter area without broad theme rewrites.

### Description

- Resolve league leader rows from API-provided team ids against `league.teams` and surface a truthful abbreviation/label when resolvable while keeping the limited-data dash when not; player rows are now populated from resolved identities. (file: `src/ui/components/LeagueLeaders.jsx`).
- Convert League Leaders to a denser mobile sports-table: compact filter grid, alternating charcoal row bands, reduced table min-width for mobile, and row-native compact player links with explicit aria labels and visible focus. (files: `src/ui/components/LeagueLeaders.jsx`, `src/ui/styles/mobile-shell-density.css`).
- Convert Player Profile and its error-boundary fallback to opt into a scoped dark mobile shell (`player-profile-shell` / `player-profile-backdrop`) so the drill-down experience in weekly flow no longer shows a light/white elevated card while preserving all profile content and interactions. (files: `src/ui/components/PlayerProfile.jsx`, `src/ui/components/PlayerProfileModalBoundary.jsx`, `src/ui/styles/mobile-shell-density.css`).
- Small, scoped visual/contrast touch-ups: raise Team Hub LAST GAME / NEXT GAME foreground for readability and add focused keyboard-accessible link styling for player names; no global theme rewrite, no simulation/worker/save schema changes. (file: `src/ui/styles/mobile-shell-density.css`).
- Tests added/updated to cover: team identity resolution and functional team filter, row-native player links, and player-profile fallback shell presence. (files: `src/ui/components/__tests__/LeagueLeaders.test.jsx`, `src/ui/components/__tests__/PlayerProfileModalBoundary.test.jsx`).

### Testing

- Ran the focused component test subset: `npx vitest run src/ui/components/__tests__/LeagueLeaders.test.jsx src/ui/components/__tests__/PlayerProfile.test.jsx src/ui/components/__tests__/PlayerProfileModalBoundary.test.jsx src/ui/components/TeamHub.test.jsx src/ui/components/WeeklyResultsCenter.test.jsx src/ui/components/__tests__/FranchiseHQ.test.jsx src/ui/components/__tests__/FranchiseHQMobileShell.test.jsx src/ui/components/__tests__/EntityLink.test.jsx src/ui/components/MobileNav.test.jsx src/ui/components/SaveSlotManager.test.jsx src/ui/components/LeagueStats.test.jsx src/ui/components/__tests__/LeagueStats.test.jsx` — passed (12 files, 134 tests).
- Full unit suite: `npm run test:unit` — passed (475 files, 5,901 tests).
- Sim-type check: `npm run check:sim-types` — passed.
- Production build: `npm run build` — succeeded (emitted known large-chunk warning; build artifacts created).
- Netlify parity: `npm run check:deploy` — succeeded (offline production and deploy-preview checks passed).
- Playwright e2e: `npx playwright test tests/e2e/core_weekly_loop_integrity_pr1752.spec.js` — BLOCKED because the Chromium runtime was not present in the environment; `npx playwright install chromium` failed due to a remote CDN HTTP 403 (`Domain forbidden`), so runtime viewport/hit-test and automated mobile E2E validation could not be executed.

Files changed

- src/ui/components/LeagueLeaders.jsx
- src/ui/components/PlayerProfile.jsx
- src/ui/components/PlayerProfileModalBoundary.jsx
- src/ui/components/__tests__/LeagueLeaders.test.jsx
- src/ui/components/__tests__/PlayerProfileModalBoundary.test.jsx
- src/ui/styles/mobile-shell-density.css

Notes / validations

- Baseline verified: local main at commit `bc32119` (contains the post-#1752 history used for verification); work landed on branch `feature/pr-1753-pfgm-core-weekly-screens-visual-conversion-v2` at commit `39c9d16`.
- Reproduction notes and fixes: LEADERS-01 (team identity) — reproduced and fixed via `resolveTeamIdentity` logic; RESULTS-04 (Player Profile white card) — reproduced and fixed by scoping dark shell classes; HQ-07 (GM Decisions wrap) — not reproducible on current main so not changed; TEAM-01 (LAST/NEXT contrast) — fixed via scoped hero value color; LEADERS-02/03 (pill controls + dead filter) — reproduced and fixed by converting names to row-native entity links and ensuring the team filter is populated from resolved identities; contrast cluster — scoped fixes applied only to touched surfaces.
- Confirmed no regression of #1752 overlay/navigation/postgame consolidation or Game Book ownership as those flows were not modified; existing tests that cover those invariants passed in the unit-run above.
- Accessibility: player links are native buttons with meaningful `aria-label`s, 44px mobile tap targets, and `:focus-visible` outlines; no interactive affordance was changed into a purely visual element.
- Mobile viewport validation (375px / 390px / 430px): source and CSS reviewed for responsive containment and overflow (table-wrapper uses `overflow-x:auto`) but runtime E2E viewport hit-testing is blocked by Playwright/Chromium download failure and thus not executed.

Explicit non-goals

- No changes were made to simulation, worker ownership, save schema, persistence, AI, trade, contracts, cap, draft, free agency, stat formulas, History, Draft, Trade, Free Agency, Setup, News, or broad modal/theme rewrites.

If you want I can (1) attempt to push this branch to a configured remote and open the GitHub PR from here if a remote is available, or (2) provide a short migration/QA checklist for manually validating the affected screens on-device at the three mobile widths now that the Playwright run is blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d6219e714832da5b00078bb20dbe0)