### PR TITLE
Core Mobile Interaction & Density Cleanup V1 — PlayerProfile portal, Glossary embed, compact Game Book prep, HQ tile density

### DIFF
--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -230,12 +230,20 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
       />
       <div data-testid="game-book-decision-summary">
         <SectionCard variant="compact" title="Preparation Context" subtitle="Pregame context captured before kickoff. This strip does not assign direct causality.">
-          <div className="app-hq-intel-list" role="list" aria-label="Preparation context">
-            {(prepContext?.preparationBullets ?? []).slice(0, 3).map((bullet, idx) => (
-              <p key={`prep-context-${idx}`} role="listitem" className="app-hq-intel-item tone-info">{bullet}</p>
-            ))}
+          <dl className="game-book-prep-context" aria-label="Preparation context">
+            {(prepContext?.preparationBullets ?? []).slice(0, 3).map((bullet, idx) => {
+              const labels = ['Game plan', 'Practice', 'Injury risk'];
+              const unavailable = /^No (saved game-plan snapshot|weekly practice log|pregame injury-risk marker)/i.test(bullet);
+              return (
+                <div key={`prep-context-${idx}`} className="game-book-prep-context__row">
+                  <dt>{labels[idx]}</dt>
+                  <dd title={unavailable ? bullet : undefined}>{unavailable ? 'Not recorded' : bullet}</dd>
+                  {unavailable ? <span className="sr-only">{bullet}</span> : null}
+                </div>
+              );
+            })}
             {!(prepContext?.preparationBullets ?? []).length ? <p className="app-hq-intel-item tone-info">No pregame preparation markers were found for this game.</p> : null}
-          </div>
+          </dl>
         </SectionCard>
       </div>
       <SectionCard variant="info" title="Game Book Detail" subtitle="Summary → Team stats → Player leaders → Drive/play recap.">

--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -17,6 +17,20 @@ function findScheduleGame(league, gameId) {
   return null;
 }
 
+function classifyPreparationBullet(text) {
+  if (typeof text !== 'string' || !text.trim()) return null;
+  if (/^(Game plan was saved before kickoff|No saved game-plan snapshot was found)/i.test(text)) {
+    return { category: 'Game plan', text, unavailable: text.startsWith('No ') };
+  }
+  if (/^(Practice effects were logged this week|A prior practice plan exists|No weekly practice log was matched)/i.test(text)) {
+    return { category: 'Practice', text, unavailable: text.startsWith('No ') };
+  }
+  if (/^(Injury\/availability risk was active entering the week|No pregame injury-risk marker was found)/i.test(text)) {
+    return { category: 'Injury risk', text, unavailable: text.startsWith('No ') };
+  }
+  return null;
+}
+
 // Compact, mobile-first sticky chrome for the Game Book. Keeps the final score,
 // W/L result, week, and a return action above the fold so the user never has to
 // scroll to see the outcome or get back to HQ. Presentational only — it reads
@@ -97,6 +111,9 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
   const canonicalGame = resolveCanonicalCompletedGame({ league, gameId, scheduleGame, archivedGame, localArchivedGame });
   const userTeam = (league?.teams ?? []).find((team) => Number(team?.id) === Number(league?.userTeamId));
   const prepContext = buildWeeklyDecisionImpact({ league, userTeam, lastGame: scheduleGame });
+  const preparationItems = (prepContext?.preparationBullets ?? []).map(classifyPreparationBullet);
+  const categorizedPreparation = preparationItems.filter(Boolean);
+  const genericPreparation = (prepContext?.preparationBullets ?? []).filter((_, index) => !preparationItems[index]);
   const detailVm = useMemo(
     () => buildGameBookPresentation({
       league,
@@ -231,19 +248,18 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
       <div data-testid="game-book-decision-summary">
         <SectionCard variant="compact" title="Preparation Context" subtitle="Pregame context captured before kickoff. This strip does not assign direct causality.">
           <dl className="game-book-prep-context" aria-label="Preparation context">
-            {(prepContext?.preparationBullets ?? []).slice(0, 3).map((bullet, idx) => {
-              const labels = ['Game plan', 'Practice', 'Injury risk'];
-              const unavailable = /^No (saved game-plan snapshot|weekly practice log|pregame injury-risk marker)/i.test(bullet);
-              return (
-                <div key={`prep-context-${idx}`} className="game-book-prep-context__row">
-                  <dt>{labels[idx]}</dt>
-                  <dd title={unavailable ? bullet : undefined}>{unavailable ? 'Not recorded' : bullet}</dd>
-                  {unavailable ? <span className="sr-only">{bullet}</span> : null}
-                </div>
-              );
-            })}
-            {!(prepContext?.preparationBullets ?? []).length ? <p className="app-hq-intel-item tone-info">No pregame preparation markers were found for this game.</p> : null}
+            {categorizedPreparation.map((item) => (
+              <div key={item.category} className="game-book-prep-context__row">
+                <dt>{item.category}</dt>
+                <dd title={item.unavailable ? item.text : undefined}>{item.unavailable ? 'Not recorded' : item.text}</dd>
+                {item.unavailable ? <span className="sr-only">{item.text}</span> : null}
+              </div>
+            ))}
           </dl>
+          {genericPreparation.map((message, index) => (
+            <p key={`prep-context-generic-${index}`} className="game-book-prep-context__fallback" data-testid="game-book-prep-context-fallback">{message}</p>
+          ))}
+          {!(prepContext?.preparationBullets ?? []).length ? <p className="game-book-prep-context__fallback">No pregame preparation markers were found for this game.</p> : null}
         </SectionCard>
       </div>
       <SectionCard variant="info" title="Game Book Detail" subtitle="Summary → Team stats → Player leaders → Drive/play recap.">

--- a/src/ui/components/GameDetailScreen.test.jsx
+++ b/src/ui/components/GameDetailScreen.test.jsx
@@ -103,6 +103,23 @@ describe('GameDetailScreen canonical title and prep context', () => {
     expect(html).toContain('Game plan was saved before kickoff');
   });
 
+  it('compacts distinct unavailable preparation markers without implying zero risk', () => {
+    const html = renderToString(
+      <GameDetailScreen
+        gameId="2031_w3_1_2"
+        league={{ ...league, gameById: { '2031_w3_1_2': archiveGame } }}
+        actions={{}}
+      />,
+    );
+
+    expect(html).toContain('game-book-prep-context__row');
+    expect(html).toContain('Game plan');
+    expect(html).toContain('Practice');
+    expect(html).toContain('Injury risk');
+    expect(html.match(/Not recorded/g)).toHaveLength(3);
+    expect(html).toContain('No pregame injury-risk marker was found');
+  });
+
   it('shows the recovery surface for an unplayed schedule row instead of a fake 0-0 tie', () => {
     // The requested id matches a serialized upcoming game: played=false with
     // Int32Array-default 0-0 scores. This must never render as a final.

--- a/src/ui/components/GameDetailScreen.test.jsx
+++ b/src/ui/components/GameDetailScreen.test.jsx
@@ -100,6 +100,7 @@ describe('GameDetailScreen canonical title and prep context', () => {
 
     expect(html).toContain('Preparation Context');
     expect(html).toContain('does not assign direct causality');
+    expect(html).toMatch(/<dt>Game plan<\/dt><dd>Game plan was saved before kickoff/);
     expect(html).toContain('Game plan was saved before kickoff');
   });
 
@@ -118,6 +119,23 @@ describe('GameDetailScreen canonical title and prep context', () => {
     expect(html).toContain('Injury risk');
     expect(html.match(/Not recorded/g)).toHaveLength(3);
     expect(html).toContain('No pregame injury-risk marker was found');
+  });
+
+  it('renders an uncategorized archive fallback without inventing preparation rows', () => {
+    const archivedOnlyGame = { ...archiveGame, id: '2031_w2_archive', gameId: '2031_w2_archive', week: 2 };
+    const html = renderToString(
+      <GameDetailScreen
+        gameId="2031_w2_archive"
+        league={{ ...league, gameById: { '2031_w2_archive': archivedOnlyGame } }}
+        actions={{}}
+      />,
+    );
+
+    expect(html).toContain('data-testid="game-book-prep-context-fallback"');
+    expect(html).toContain('No completed user game available yet.');
+    expect(html).not.toContain('<dt>Game plan</dt>');
+    expect(html).not.toContain('<dt>Practice</dt>');
+    expect(html).not.toContain('<dt>Injury risk</dt>');
   });
 
   it('shows the recovery surface for an unplayed schedule row instead of a fake 0-0 tie', () => {

--- a/src/ui/components/GlossaryPopover.jsx
+++ b/src/ui/components/GlossaryPopover.jsx
@@ -83,7 +83,7 @@ const categoryColor = (cat) => {
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
-export default function GlossaryPopover() {
+export default function GlossaryPopover({ embedded = false }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [activeCat, setActiveCat] = useState("All");
@@ -125,16 +125,18 @@ export default function GlossaryPopover() {
     <>
       {/* Trigger button */}
       <button
+        type="button"
         onClick={() => setOpen(v => !v)}
         title="Rules & Glossary (? key)"
         aria-label="Open rules glossary"
+        className={embedded ? "mobile-nav-item mobile-nav-item-premium" : undefined}
         style={{
-          position: "fixed",
+          position: embedded ? "static" : "fixed",
           bottom: "calc(env(safe-area-inset-bottom, 0px) + 84px)",
-          right: 12,
+          right: embedded ? "auto" : 12,
           zIndex: 3000,
-          width: 34, height: 34,
-          borderRadius: "50%",
+          width: embedded ? "100%" : 34, height: embedded ? "auto" : 34,
+          borderRadius: embedded ? undefined : "50%",
           background: open ? "var(--accent)" : "color-mix(in srgb, var(--surface-strong) 88%, transparent)",
           border: "1.5px solid var(--hairline)",
           color: open ? "#fff" : "var(--text-muted)",
@@ -147,7 +149,7 @@ export default function GlossaryPopover() {
           opacity: open ? 1 : 0.92,
         }}
       >
-        ?
+        {embedded ? <><span aria-hidden="true">?</span><span>Rules &amp; Glossary</span></> : "?"}
       </button>
 
       {/* Popover panel */}

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -1711,7 +1711,7 @@ export default function LeagueDashboard({
       )}
 
       {/* ── Global utilities (always mounted, visually minimal) ── */}
-      <GlossaryPopover />
+      {!isMobile && <GlossaryPopover />}
       <OnboardingTour league={league} />
 
     </div>

--- a/src/ui/components/MobileNav.jsx
+++ b/src/ui/components/MobileNav.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { SHELL_SECTIONS } from '../utils/shellNavigation.js';
+import GlossaryPopover from './GlossaryPopover.jsx';
 
 // More-drawer destinations. Entries are canonical dashboard tab ids unless
 // explicitly marked as an App-owned action (currently Saves).
@@ -136,6 +137,10 @@ export default function MobileNav({ activeSection, activeTab, onSectionChange, o
               })}
             </section>
           ))}
+          <section className="mobile-nav-group" aria-labelledby="mobile-help-heading">
+            <h3 id="mobile-help-heading" className="mobile-nav-group-title">Help</h3>
+            <GlossaryPopover embedded />
+          </section>
         </div>
       </nav>
 

--- a/src/ui/components/MobileNav.test.jsx
+++ b/src/ui/components/MobileNav.test.jsx
@@ -86,6 +86,17 @@ describe('MobileNav', () => {
     expect(screen.getByRole('button', { name: 'HQ' }).getAttribute('aria-current')).toBe('page');
   });
 
+  it('owns mobile glossary access inside More instead of a floating trigger', () => {
+    render(<MobileNav activeSection={SHELL_SECTIONS.hq} onSectionChange={vi.fn()} onDestinationChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'More' }));
+
+    const glossary = screen.getByRole('button', { name: 'Open rules glossary' });
+    expect(glossary.className).toContain('mobile-nav-item');
+    expect(glossary.style.position).toBe('static');
+    fireEvent.click(glossary);
+    expect(screen.getByText('Rules Glossary')).toBeTruthy();
+  });
+
   it('keeps command menu destinations wired for more drawer entries', () => {
     const html = renderToString(
       <MobileNav

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -4,6 +4,7 @@
  * Modal: accolades/legacy badges + position-aware career stats table.
  */
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import TraitBadge from "./TraitBadge";
 import RadarChart from "./RadarChart";
 import ExtensionNegotiationModal from "./ExtensionNegotiationModal.jsx";
@@ -1118,7 +1119,7 @@ export default function PlayerProfile({
     );
   }
 
-  return (
+  return createPortal(
     <div
       data-testid="player-profile"
       className="player-profile-backdrop"
@@ -2928,7 +2929,8 @@ export default function PlayerProfile({
         .rating-color-avg   { background: var(--warning); }
         .rating-color-bad   { background: var(--danger); }
       `}</style>
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -59,9 +59,11 @@ describe('PlayerProfile', () => {
   });
 
   it('renders with minimum generated player data from league state', async () => {
-    render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={actions} teams={league.teams} league={league} />);
+    const { container } = render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={actions} teams={league.teams} league={league} />);
 
     expect(screen.getByTestId('player-profile')).toBeTruthy();
+    expect(screen.getByTestId('player-profile').parentElement).toBe(document.body);
+    expect(container.childElementCount).toBe(0);
     await waitFor(() => expect(screen.getByTestId('player-profile-summary').textContent).toContain('Avery Fields'));
     expect(screen.getByTestId('player-decision-card').textContent).toContain('Starter');
     expect(screen.getByTestId('player-decision-recommendation').textContent).toMatch(/Build around|Explore extension|Start/);

--- a/src/ui/styles/hub.css
+++ b/src/ui/styles/hub.css
@@ -1409,7 +1409,20 @@
 
 /* Reduce tile min-height on compact layout to save vertical space */
 .hq-compact-layout .app-action-tile {
-  min-height: 96px;
+  min-height: 64px;
+  padding: 8px 10px;
+  gap: 4px;
+}
+
+.hq-compact-layout .app-action-tile__icon {
+  width: 28px;
+  height: 28px;
+  padding: 4px;
+  border-radius: 6px;
+}
+
+.hq-compact-layout .app-action-tile__title-row strong {
+  font-size: 13px;
 }
 
 /* ── Ensure more-drawer trigger is tappable and compact ─────────────────── */

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -510,6 +510,10 @@
 .app-hq-intel-item { margin: 0; border: 1px solid var(--hairline); border-radius: 10px; padding: 8px 10px; font-size: 12px; line-height: 1.35; color: #d9e5f7; background: color-mix(in srgb, var(--surface) 95%, black 5%); }
 .app-hq-intel-item.tone-warning { border-color: rgba(255,159,10,.45); background: rgba(255,159,10,.08); }
 .app-hq-intel-item.tone-ok { border-color: rgba(52,199,89,.45); background: rgba(52,199,89,.08); }
+.game-book-prep-context { display: grid; margin: 0; border-top: 1px solid var(--hairline); }
+.game-book-prep-context__row { display: grid; grid-template-columns: minmax(88px, .35fr) minmax(0, 1fr); gap: 10px; padding: 7px 2px; border-bottom: 1px solid var(--hairline); font-size: var(--text-xs); line-height: 1.35; }
+.game-book-prep-context__row dt { color: var(--text-muted); font-weight: 700; }
+.game-book-prep-context__row dd { min-width: 0; margin: 0; color: var(--text); overflow-wrap: anywhere; }
 .app-hq-impact-list { display: grid; gap: 8px; }
 .app-hq-impact-card { border: 1px solid var(--hairline); border-radius: 10px; padding: 9px 10px; background: color-mix(in srgb, var(--surface) 95%, black 5%); display: grid; gap: 8px; }
 .app-hq-impact-card__head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -514,6 +514,7 @@
 .game-book-prep-context__row { display: grid; grid-template-columns: minmax(88px, .35fr) minmax(0, 1fr); gap: 10px; padding: 7px 2px; border-bottom: 1px solid var(--hairline); font-size: var(--text-xs); line-height: 1.35; }
 .game-book-prep-context__row dt { color: var(--text-muted); font-weight: 700; }
 .game-book-prep-context__row dd { min-width: 0; margin: 0; color: var(--text); overflow-wrap: anywhere; }
+.game-book-prep-context__fallback { margin: 0; color: var(--text-muted); font-size: var(--text-xs); line-height: 1.4; }
 .app-hq-impact-list { display: grid; gap: 8px; }
 .app-hq-impact-card { border: 1px solid var(--hairline); border-radius: 10px; padding: 9px 10px; background: color-mix(in srgb, var(--surface) 95%, black 5%); display: grid; gap: 8px; }
 .app-hq-impact-card__head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }


### PR DESCRIPTION
### Motivation

- Baseline: work built on top of commit `b15864d` (includes merges for #1745, #1747, #1748, #1752, #1753). 
- Root cause: Player Profile opened from nested/anchored weekly surfaces could inherit a constrained containing block (fixed/transformed parent) and collapse to a very narrow column on small mobile viewports. 
- Floating-help obstruction: the visible circular “?” was the app-owned `GlossaryPopover` floating over mobile content rather than the QuickJump FAB. 
- Preparation Context & HQ density: three large “missing-data” cards in Game Book and oversized HQ secondary action tiles consumed excessive vertical space on mobile.

### Description

- Player Profile portal: render the Player Profile modal into `document.body` using a portal so it no longer inherits unexpected containing-block constraints and can use the practical mobile viewport width while preserving the dark shell and existing content. (changed `PlayerProfile.jsx` to use `createPortal`).
- Glossary embedding (help identity + mobile behavior): identified the obstructing control as `GlossaryPopover`, stopped rendering the floating glossary on mobile by gating the global mount (`LeagueDashboard.jsx`) and added an embedded, statically-positioned glossary trigger inside the More drawer (`MobileNav.jsx`) so help remains accessible without floating over content. (`GlossaryPopover.jsx` now accepts `embedded` and adapts position/styles). 
- Compact Preparation Context: replaced three large independent card rows with a compact labelled strip (`dl` rows) showing distinct categories (Game plan / Practice / Injury risk) and rendering `Not recorded` for unavailable entries while preserving the full truthful message for assistive tech via an `sr-only` span. (changes in `GameDetailScreen.jsx` + `screen-system.css`).
- HQ action tile density: reduced vertical footprint of the HQ quick-action tiles by lowering min-height, tightening padding, and reducing action-icon size while preserving labels, badges and behavior. (changes in `hub.css`).

### Testing

- Unit subset: ran `npm run test:unit` against focused UI tests (`GameDetailScreen.test.jsx`, `MobileNav.test.jsx`, `PlayerProfile.test.jsx`, `mobileMatchReviewFlow.viewport.test.jsx`) and the modified tests all passed (53 tests passed for that run). 
- Full unit test run: executed `npm run test:unit` — 5,903/5,904 tests passed and a single unrelated, deterministic ordering test in `src/core/__tests__/eventSystem.test.js` failed (pre-existing ordering sensitivity, not caused by UI changes). 
- Build: ran `npm run build` and the production build succeeded (only the repository-expected large chunk warning was emitted). 
- E2E / Playwright: attempted `npx playwright test` for the mobile e2e smoke, but Playwright Chromium installation failed in this environment (CDN download returned 403), so browser-based E2E could not be completed here. 

Notes and branch status

- Changes committed on branch `feature/pr-1754-core-mobile-interaction-density-cleanup-v1` (commit `85810f7`) and are ready for review; creating a remote PR was not performed because the local environment is not authenticated with GitHub and Playwright browser installation failed here.
- Key files changed: `src/ui/components/PlayerProfile.jsx`, `src/ui/components/GlossaryPopover.jsx`, `src/ui/components/MobileNav.jsx`, `src/ui/components/LeagueDashboard.jsx`, `src/ui/components/GameDetailScreen.jsx`, `src/ui/styles/hub.css`, `src/ui/styles/screen-system.css`, and corresponding unit tests updated/added.

If you want, I can (1) squash/split commits, (2) produce a minimal screenshot checklist for manual mobile verification steps, or (3) attempt to open the PR if GitHub credentials are provided for this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7fa9845664832d94a9291d2113e314)