### PR TITLE
Portals for modals/glossary, semantic game prep context, mobile glossary embedding and UI tweaks

### DIFF
--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -17,6 +17,19 @@ function findScheduleGame(league, gameId) {
   return null;
 }
 
+export function classifyPreparationBullet(bullet) {
+  if (typeof bullet !== 'string' || !bullet.trim()) return null;
+  const text = bullet.trim();
+  const knownShapes = [
+    { key: 'game-plan', label: 'Game plan', pattern: /^(Game plan was saved before kickoff|No saved game-plan snapshot was found)/i },
+    { key: 'practice', label: 'Practice', pattern: /^(Practice effects were logged|A prior practice plan exists|No weekly practice log was matched)/i },
+    { key: 'injury-risk', label: 'Injury risk', pattern: /^(Injury\/availability risk was active|No pregame injury-risk marker was found)/i },
+  ];
+  const match = knownShapes.find(({ pattern }) => pattern.test(text));
+  if (!match) return null;
+  return { ...match, text, unavailable: text.startsWith('No ') };
+}
+
 // Compact, mobile-first sticky chrome for the Game Book. Keeps the final score,
 // W/L result, week, and a return action above the fold so the user never has to
 // scroll to see the outcome or get back to HQ. Presentational only — it reads
@@ -97,6 +110,9 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
   const canonicalGame = resolveCanonicalCompletedGame({ league, gameId, scheduleGame, archivedGame, localArchivedGame });
   const userTeam = (league?.teams ?? []).find((team) => Number(team?.id) === Number(league?.userTeamId));
   const prepContext = buildWeeklyDecisionImpact({ league, userTeam, lastGame: scheduleGame });
+  const preparationBullets = (prepContext?.preparationBullets ?? []).filter((bullet) => typeof bullet === 'string' && bullet.trim());
+  const categorizedPreparation = preparationBullets.map(classifyPreparationBullet).filter(Boolean);
+  const genericPreparation = preparationBullets.filter((bullet) => !classifyPreparationBullet(bullet));
   const detailVm = useMemo(
     () => buildGameBookPresentation({
       league,
@@ -231,19 +247,18 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
       <div data-testid="game-book-decision-summary">
         <SectionCard variant="compact" title="Preparation Context" subtitle="Pregame context captured before kickoff. This strip does not assign direct causality.">
           <dl className="game-book-prep-context" aria-label="Preparation context">
-            {(prepContext?.preparationBullets ?? []).slice(0, 3).map((bullet, idx) => {
-              const labels = ['Game plan', 'Practice', 'Injury risk'];
-              const unavailable = /^No (saved game-plan snapshot|weekly practice log|pregame injury-risk marker)/i.test(bullet);
-              return (
-                <div key={`prep-context-${idx}`} className="game-book-prep-context__row">
-                  <dt>{labels[idx]}</dt>
-                  <dd title={unavailable ? bullet : undefined}>{unavailable ? 'Not recorded' : bullet}</dd>
-                  {unavailable ? <span className="sr-only">{bullet}</span> : null}
-                </div>
-              );
-            })}
-            {!(prepContext?.preparationBullets ?? []).length ? <p className="app-hq-intel-item tone-info">No pregame preparation markers were found for this game.</p> : null}
+            {categorizedPreparation.map((item) => (
+              <div key={item.key} className="game-book-prep-context__row">
+                <dt>{item.label}</dt>
+                <dd title={item.unavailable ? item.text : undefined}>{item.unavailable ? 'Not recorded' : item.text}</dd>
+                {item.unavailable ? <span className="sr-only">{item.text}</span> : null}
+              </div>
+            ))}
           </dl>
+          {genericPreparation.map((bullet, idx) => (
+            <p key={`prep-context-generic-${idx}`} data-testid="game-book-prep-context-generic" className="app-hq-intel-item tone-info">{bullet}</p>
+          ))}
+          {!preparationBullets.length ? <p className="app-hq-intel-item tone-info">No pregame preparation markers were found for this game.</p> : null}
         </SectionCard>
       </div>
       <SectionCard variant="info" title="Game Book Detail" subtitle="Summary → Team stats → Player leaders → Drive/play recap.">

--- a/src/ui/components/GameDetailScreen.jsx
+++ b/src/ui/components/GameDetailScreen.jsx
@@ -230,12 +230,20 @@ export default function GameDetailScreen({ gameId, league, actions, onBack, onPl
       />
       <div data-testid="game-book-decision-summary">
         <SectionCard variant="compact" title="Preparation Context" subtitle="Pregame context captured before kickoff. This strip does not assign direct causality.">
-          <div className="app-hq-intel-list" role="list" aria-label="Preparation context">
-            {(prepContext?.preparationBullets ?? []).slice(0, 3).map((bullet, idx) => (
-              <p key={`prep-context-${idx}`} role="listitem" className="app-hq-intel-item tone-info">{bullet}</p>
-            ))}
+          <dl className="game-book-prep-context" aria-label="Preparation context">
+            {(prepContext?.preparationBullets ?? []).slice(0, 3).map((bullet, idx) => {
+              const labels = ['Game plan', 'Practice', 'Injury risk'];
+              const unavailable = /^No (saved game-plan snapshot|weekly practice log|pregame injury-risk marker)/i.test(bullet);
+              return (
+                <div key={`prep-context-${idx}`} className="game-book-prep-context__row">
+                  <dt>{labels[idx]}</dt>
+                  <dd title={unavailable ? bullet : undefined}>{unavailable ? 'Not recorded' : bullet}</dd>
+                  {unavailable ? <span className="sr-only">{bullet}</span> : null}
+                </div>
+              );
+            })}
             {!(prepContext?.preparationBullets ?? []).length ? <p className="app-hq-intel-item tone-info">No pregame preparation markers were found for this game.</p> : null}
-          </div>
+          </dl>
         </SectionCard>
       </div>
       <SectionCard variant="info" title="Game Book Detail" subtitle="Summary → Team stats → Player leaders → Drive/play recap.">

--- a/src/ui/components/GameDetailScreen.test.jsx
+++ b/src/ui/components/GameDetailScreen.test.jsx
@@ -103,6 +103,23 @@ describe('GameDetailScreen canonical title and prep context', () => {
     expect(html).toContain('Game plan was saved before kickoff');
   });
 
+  it('compacts distinct unavailable preparation markers without implying zero risk', () => {
+    const html = renderToString(
+      <GameDetailScreen
+        gameId="2031_w3_1_2"
+        league={{ ...league, gameById: { '2031_w3_1_2': archiveGame } }}
+        actions={{}}
+      />,
+    );
+
+    expect(html).toContain('game-book-prep-context__row');
+    expect(html).toContain('Game plan');
+    expect(html).toContain('Practice');
+    expect(html).toContain('Injury risk');
+    expect(html.match(/Not recorded/g)).toHaveLength(3);
+    expect(html).toContain('No pregame injury-risk marker was found');
+  });
+
   it('shows the recovery surface for an unplayed schedule row instead of a fake 0-0 tie', () => {
     // The requested id matches a serialized upcoming game: played=false with
     // Int32Array-default 0-0 scores. This must never render as a final.

--- a/src/ui/components/GameDetailScreen.test.jsx
+++ b/src/ui/components/GameDetailScreen.test.jsx
@@ -120,6 +120,22 @@ describe('GameDetailScreen canonical title and prep context', () => {
     expect(html).toContain('No pregame injury-risk marker was found');
   });
 
+  it('renders an archive-only generic fallback without inventing preparation categories', () => {
+    const html = renderToString(
+      <GameDetailScreen
+        gameId="2031_w3_1_2"
+        league={{ ...league, schedule: { weeks: [] }, gameById: { '2031_w3_1_2': archiveGame } }}
+        actions={{}}
+      />,
+    );
+
+    expect(html).toContain('game-book-prep-context-generic');
+    expect(html).toContain('No completed user game available yet.');
+    expect(html).not.toContain('<dt>Game plan</dt>');
+    expect(html).not.toContain('<dt>Practice</dt>');
+    expect(html).not.toContain('<dt>Injury risk</dt>');
+  });
+
   it('shows the recovery surface for an unplayed schedule row instead of a fake 0-0 tie', () => {
     // The requested id matches a serialized upcoming game: played=false with
     // Int32Array-default 0-0 scores. This must never render as a final.

--- a/src/ui/components/GlossaryPopover.jsx
+++ b/src/ui/components/GlossaryPopover.jsx
@@ -7,6 +7,7 @@
  */
 
 import React, { useState, useMemo, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
 
 // ── Glossary data ─────────────────────────────────────────────────────────────
 
@@ -83,12 +84,18 @@ const categoryColor = (cat) => {
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
-export default function GlossaryPopover() {
+export default function GlossaryPopover({ embedded = false }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [activeCat, setActiveCat] = useState("All");
   const inputRef = useRef(null);
   const panelRef = useRef(null);
+  const triggerRef = useRef(null);
+
+  const closeGlossary = () => {
+    setOpen(false);
+    if (embedded) requestAnimationFrame(() => triggerRef.current?.focus());
+  };
 
   // Focus search on open
   useEffect(() => {
@@ -97,7 +104,7 @@ export default function GlossaryPopover() {
 
   // Close on Escape
   useEffect(() => {
-    const onKey = (e) => { if (e.key === "Escape") setOpen(false); };
+    const onKey = (e) => { if (e.key === "Escape") closeGlossary(); };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, []);
@@ -106,7 +113,7 @@ export default function GlossaryPopover() {
   useEffect(() => {
     if (!open) return;
     const onClick = (e) => {
-      if (panelRef.current && !panelRef.current.contains(e.target)) setOpen(false);
+      if (panelRef.current && !panelRef.current.contains(e.target) && !triggerRef.current?.contains(e.target)) closeGlossary();
     };
     document.addEventListener("mousedown", onClick);
     return () => document.removeEventListener("mousedown", onClick);
@@ -125,16 +132,21 @@ export default function GlossaryPopover() {
     <>
       {/* Trigger button */}
       <button
+        ref={triggerRef}
+        type="button"
         onClick={() => setOpen(v => !v)}
         title="Rules & Glossary (? key)"
         aria-label="Open rules glossary"
+        aria-controls={open ? "rules-glossary-panel" : undefined}
+        aria-expanded={open}
+        className={embedded ? "mobile-nav-item mobile-nav-item-premium" : undefined}
         style={{
-          position: "fixed",
+          position: embedded ? "static" : "fixed",
           bottom: "calc(env(safe-area-inset-bottom, 0px) + 84px)",
-          right: 12,
+          right: embedded ? "auto" : 12,
           zIndex: 3000,
-          width: 34, height: 34,
-          borderRadius: "50%",
+          width: embedded ? "100%" : 34, height: embedded ? "auto" : 34,
+          borderRadius: embedded ? undefined : "50%",
           background: open ? "var(--accent)" : "color-mix(in srgb, var(--surface-strong) 88%, transparent)",
           border: "1.5px solid var(--hairline)",
           color: open ? "#fff" : "var(--text-muted)",
@@ -147,13 +159,16 @@ export default function GlossaryPopover() {
           opacity: open ? 1 : 0.92,
         }}
       >
-        ?
+        {embedded ? <><span aria-hidden="true">?</span><span>Rules &amp; Glossary</span></> : "?"}
       </button>
 
       {/* Popover panel */}
-      {open && (
+      {open && createPortal((
         <div
+          id="rules-glossary-panel"
           ref={panelRef}
+          role="dialog"
+          aria-label="Rules Glossary"
           style={{
             position: "fixed",
             bottom: "calc(env(safe-area-inset-bottom, 0px) + 130px)",
@@ -179,7 +194,7 @@ export default function GlossaryPopover() {
             <span style={{ fontSize: "1rem" }}>📖</span>
             <span style={{ fontWeight: 900, fontSize: "0.9rem", flex: 1 }}>Rules Glossary</span>
             <button
-              onClick={() => setOpen(false)}
+              onClick={closeGlossary}
               style={{ background: "none", border: "none", color: "var(--text-muted)", cursor: "pointer", fontSize: "1rem", lineHeight: 1 }}
               aria-label="Close glossary"
             >
@@ -268,7 +283,7 @@ export default function GlossaryPopover() {
             {filtered.length} term{filtered.length !== 1 ? "s" : ""} · Press <kbd style={{ background: "var(--surface)", border: "1px solid var(--hairline)", borderRadius: 3, padding: "0 4px" }}>Esc</kbd> to close
           </div>
         </div>
-      )}
+      ), document.body)}
     </>
   );
 }

--- a/src/ui/components/LeagueDashboard.jsx
+++ b/src/ui/components/LeagueDashboard.jsx
@@ -1711,7 +1711,7 @@ export default function LeagueDashboard({
       )}
 
       {/* ── Global utilities (always mounted, visually minimal) ── */}
-      <GlossaryPopover />
+      {!isMobile && <GlossaryPopover />}
       <OnboardingTour league={league} />
 
     </div>

--- a/src/ui/components/MobileNav.jsx
+++ b/src/ui/components/MobileNav.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { SHELL_SECTIONS } from '../utils/shellNavigation.js';
+import GlossaryPopover from './GlossaryPopover.jsx';
 
 // More-drawer destinations. Entries are canonical dashboard tab ids unless
 // explicitly marked as an App-owned action (currently Saves).
@@ -136,6 +137,10 @@ export default function MobileNav({ activeSection, activeTab, onSectionChange, o
               })}
             </section>
           ))}
+          <section className="mobile-nav-group" aria-labelledby="mobile-help-heading">
+            <h3 id="mobile-help-heading" className="mobile-nav-group-title">Help</h3>
+            <GlossaryPopover embedded />
+          </section>
         </div>
       </nav>
 

--- a/src/ui/components/MobileNav.test.jsx
+++ b/src/ui/components/MobileNav.test.jsx
@@ -86,6 +86,25 @@ describe('MobileNav', () => {
     expect(screen.getByRole('button', { name: 'HQ' }).getAttribute('aria-current')).toBe('page');
   });
 
+  it('owns mobile glossary access inside More instead of a floating trigger', () => {
+    render(<MobileNav activeSection={SHELL_SECTIONS.hq} onSectionChange={vi.fn()} onDestinationChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'More' }));
+
+    const glossary = screen.getByRole('button', { name: 'Open rules glossary' });
+    expect(glossary.className).toContain('mobile-nav-item');
+    expect(glossary.style.position).toBe('static');
+    fireEvent.click(glossary);
+    const panel = screen.getByRole('dialog', { name: 'Rules Glossary' });
+    expect(panel.closest('.mobile-nav-panel')).toBeNull();
+    expect(panel.parentElement).toBe(document.body);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close glossary' }));
+    expect(screen.queryByRole('dialog', { name: 'Rules Glossary' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'More' }).getAttribute('aria-expanded')).toBe('true');
+    fireEvent.click(screen.getByRole('button', { name: 'Standings' }));
+    expect(screen.getByRole('button', { name: 'More' }).getAttribute('aria-expanded')).toBe('false');
+  });
+
   it('keeps command menu destinations wired for more drawer entries', () => {
     const html = renderToString(
       <MobileNav

--- a/src/ui/components/PlayerProfile.jsx
+++ b/src/ui/components/PlayerProfile.jsx
@@ -4,6 +4,7 @@
  * Modal: accolades/legacy badges + position-aware career stats table.
  */
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import TraitBadge from "./TraitBadge";
 import RadarChart from "./RadarChart";
 import ExtensionNegotiationModal from "./ExtensionNegotiationModal.jsx";
@@ -1118,7 +1119,7 @@ export default function PlayerProfile({
     );
   }
 
-  return (
+  return createPortal(
     <div
       data-testid="player-profile"
       className="player-profile-backdrop"
@@ -2928,7 +2929,8 @@ export default function PlayerProfile({
         .rating-color-avg   { background: var(--warning); }
         .rating-color-bad   { background: var(--danger); }
       `}</style>
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/src/ui/components/__tests__/PlayerProfile.test.jsx
+++ b/src/ui/components/__tests__/PlayerProfile.test.jsx
@@ -59,9 +59,11 @@ describe('PlayerProfile', () => {
   });
 
   it('renders with minimum generated player data from league state', async () => {
-    render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={actions} teams={league.teams} league={league} />);
+    const { container } = render(<PlayerProfile playerId={11} onClose={vi.fn()} actions={actions} teams={league.teams} league={league} />);
 
     expect(screen.getByTestId('player-profile')).toBeTruthy();
+    expect(screen.getByTestId('player-profile').parentElement).toBe(document.body);
+    expect(container.childElementCount).toBe(0);
     await waitFor(() => expect(screen.getByTestId('player-profile-summary').textContent).toContain('Avery Fields'));
     expect(screen.getByTestId('player-decision-card').textContent).toContain('Starter');
     expect(screen.getByTestId('player-decision-recommendation').textContent).toMatch(/Build around|Explore extension|Start/);

--- a/src/ui/styles/hub.css
+++ b/src/ui/styles/hub.css
@@ -1409,7 +1409,20 @@
 
 /* Reduce tile min-height on compact layout to save vertical space */
 .hq-compact-layout .app-action-tile {
-  min-height: 96px;
+  min-height: 64px;
+  padding: 8px 10px;
+  gap: 4px;
+}
+
+.hq-compact-layout .app-action-tile__icon {
+  width: 28px;
+  height: 28px;
+  padding: 4px;
+  border-radius: 6px;
+}
+
+.hq-compact-layout .app-action-tile__title-row strong {
+  font-size: 13px;
 }
 
 /* ── Ensure more-drawer trigger is tappable and compact ─────────────────── */

--- a/src/ui/styles/screen-system.css
+++ b/src/ui/styles/screen-system.css
@@ -510,6 +510,10 @@
 .app-hq-intel-item { margin: 0; border: 1px solid var(--hairline); border-radius: 10px; padding: 8px 10px; font-size: 12px; line-height: 1.35; color: #d9e5f7; background: color-mix(in srgb, var(--surface) 95%, black 5%); }
 .app-hq-intel-item.tone-warning { border-color: rgba(255,159,10,.45); background: rgba(255,159,10,.08); }
 .app-hq-intel-item.tone-ok { border-color: rgba(52,199,89,.45); background: rgba(52,199,89,.08); }
+.game-book-prep-context { display: grid; margin: 0; border-top: 1px solid var(--hairline); }
+.game-book-prep-context__row { display: grid; grid-template-columns: minmax(88px, .35fr) minmax(0, 1fr); gap: 10px; padding: 7px 2px; border-bottom: 1px solid var(--hairline); font-size: var(--text-xs); line-height: 1.35; }
+.game-book-prep-context__row dt { color: var(--text-muted); font-weight: 700; }
+.game-book-prep-context__row dd { min-width: 0; margin: 0; color: var(--text); overflow-wrap: anywhere; }
 .app-hq-impact-list { display: grid; gap: 8px; }
 .app-hq-impact-card { border: 1px solid var(--hairline); border-radius: 10px; padding: 9px 10px; background: color-mix(in srgb, var(--surface) 95%, black 5%); display: grid; gap: 8px; }
 .app-hq-impact-card__head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }


### PR DESCRIPTION
### Motivation
- Improve accessibility and mobile UX by rendering large overlays into `document.body` and returning focus when they close.
- Make the Game Book preparation context more semantic and explicit about unavailable markers so the UI does not imply zero risk.
- Surface the glossary inside the mobile "More" drawer instead of a floating trigger on small screens.
- Reduce vertical density for compact layouts to improve information density on smaller screens.

### Description
- Reworked the preparation context in `GameDetailScreen.jsx` from a loose list to a semantic `<dl>` with labeled rows and explicit handling for unavailable bullets (shows `Not recorded` and preserves original text to screen readers).
- Converted `PlayerProfile.jsx` and `GlossaryPopover.jsx` to render via `createPortal` into `document.body`, added focus/close handling, and ensured modals/popovers announce as dialogs for a11y.
- Added an `embedded` prop to `GlossaryPopover.jsx` to support an inline mobile variant with altered styling and keyboard/aria improvements, and updated `LeagueDashboard.jsx` to only mount the floating glossary on non-mobile (`!isMobile`).
- Embedded the glossary trigger inside the mobile `More` drawer by importing `GlossaryPopover` into `MobileNav.jsx` and wiring an `embedded` instance into the Help section.
- Adjusted CSS in `hub.css` and `screen-system.css` for compact layout density and added styles for `.game-book-prep-context` rows and compact action-tile sizing.
- Added/updated unit tests in `GameDetailScreen.test.jsx`, `MobileNav.test.jsx`, and `__tests__/PlayerProfile.test.jsx` to cover the new prep-context behavior, embedded glossary flow, and portal rendering of the player profile.

### Testing
- Ran component unit tests including `GameDetailScreen.test.jsx`, `MobileNav.test.jsx`, and `__tests__/PlayerProfile.test.jsx` which exercise the new prep-context rendering, mobile glossary embedding, and portal behavior, and all assertions passed.
- Executed the full frontend test suite (Vitest) after changes and it completed successfully with no regressions in the modified components.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7fa9845664832d94a9291d2113e314)