### PR TITLE
Fix Playwright expect timeout handling in E2E conditional checks

### DIFF
--- a/tests/e2e/helpers/franchise.js
+++ b/tests/e2e/helpers/franchise.js
@@ -223,7 +223,7 @@ export async function simulateSingleWeek(page, options = {}) {
       try {
         await expect(advanceCta).toBeEnabled({ timeout: 500 });
       } catch (err) {
-        if (err.name !== 'TimeoutError') throw err;
+        if (err.name !== 'TimeoutError' && !(err.name === 'Error' && err.message.includes('toBeEnabled'))) throw err;
       }
     } catch (err) {
       if (err.name !== 'TimeoutError') throw err;
@@ -261,7 +261,7 @@ export async function simulateSingleWeek(page, options = {}) {
       await expect(advanceAnywayBtn).toBeEnabled({ timeout: 5000 });
       await advanceAnywayBtn.click();
     } catch (err) {
-      if (err.name !== 'TimeoutError') throw err;
+      if (err.name !== 'TimeoutError' && !(err.name === 'Error' && err.message.includes('toBeEnabled'))) throw err;
     }
   }
   const skipPromptBtn = page.getByRole('button', { name: /Simulate \(Skip\)/i });
@@ -270,7 +270,7 @@ export async function simulateSingleWeek(page, options = {}) {
     await expect(skipPromptBtn).toBeEnabled({ timeout: 5000 });
     await skipPromptBtn.click();
   } catch (err) {
-    if (err.name !== 'TimeoutError') throw err;
+    if (err.name !== 'TimeoutError' && !(err.name === 'Error' && err.message.includes('toBeEnabled'))) throw err;
   }
   await page.waitForFunction(
     (baseline) => {


### PR DESCRIPTION
Fixes a flaky E2E test issue in Playwright where conditional probes checking button state incorrectly threw errors. Playwright's expect().toBeEnabled timeout throws a standard `Error` containing `toBeEnabled` instead of a `TimeoutError`, so the error filtering was adjusted to prevent aborting tests during conditional readiness checks.

---
*PR created automatically by Jules for task [7394989535220725728](https://jules.google.com/task/7394989535220725728) started by @rbcati*